### PR TITLE
[JS/Web] Bug with sesion initialization

### DIFF
--- a/js/web/.gitignore
+++ b/js/web/.gitignore
@@ -9,6 +9,7 @@ tsconfig.tsbuildinfo
 !lib/build-def.d.ts
 
 lib/**/*.js
+!lib/wasm/binding/*.js
 lib/**/*.js.map
 test/**/*.js
 test/**/*.js.map

--- a/js/web/lib/wasm/binding/ort-wasm-simd-threaded.js
+++ b/js/web/lib/wasm/binding/ort-wasm-simd-threaded.js
@@ -1,0 +1,1247 @@
+var ortWasmThreaded = (() => {
+  var _scriptDir = typeof document !== "undefined" && document.currentScript ? document.currentScript.src : undefined;
+  if (typeof __filename !== "undefined") _scriptDir = _scriptDir || __filename;
+  return function (moduleArg = {}) {
+    function aa() {
+      d.buffer != l.buffer && m();
+      return l;
+    }
+    function n() {
+      d.buffer != l.buffer && m();
+      return ba;
+    }
+    function p() {
+      d.buffer != l.buffer && m();
+      return ca;
+    }
+    function r() {
+      d.buffer != l.buffer && m();
+      return da;
+    }
+    function ea() {
+      d.buffer != l.buffer && m();
+      return fa;
+    }
+    var w = moduleArg,
+      ha,
+      x;
+    w.ready = new Promise((a, b) => {
+      ha = a;
+      x = b;
+    });
+    var ia = Object.assign({}, w),
+      ja = "./this.program",
+      z = (a, b) => {
+        throw b;
+      },
+      ka = "object" == typeof window,
+      A = "function" == typeof importScripts,
+      B = "object" == typeof process && "object" == typeof process.versions && "string" == typeof process.versions.node,
+      D = w.ENVIRONMENT_IS_PTHREAD || !1,
+      E = "";
+    function la(a) {
+      return w.locateFile ? w.locateFile(a, E) : E + a;
+    }
+    var ma, F, H;
+    if (B) {
+      var fs = require("fs"),
+        na = require("path");
+      E = A ? na.dirname(E) + "/" : __dirname + "/";
+      ma = (b, c) => {
+        b = b.startsWith("file://") ? new URL(b) : na.normalize(b);
+        return fs.readFileSync(b, c ? void 0 : "utf8");
+      };
+      H = (b) => {
+        b = ma(b, !0);
+        b.buffer || (b = new Uint8Array(b));
+        return b;
+      };
+      F = (b, c, e, h = !0) => {
+        b = b.startsWith("file://") ? new URL(b) : na.normalize(b);
+        fs.readFile(b, h ? void 0 : "utf8", (g, k) => {
+          g ? e(g) : c(h ? k.buffer : k);
+        });
+      };
+      !w.thisProgram && 1 < process.argv.length && (ja = process.argv[1].replace(/\\/g, "/"));
+      process.argv.slice(2);
+      z = (b, c) => {
+        process.exitCode = b;
+        throw c;
+      };
+      w.inspect = () => "[Emscripten Module object]";
+      let a;
+      try {
+        a = require("worker_threads");
+      } catch (b) {
+        throw (
+          (console.error(
+            'The "worker_threads" module is not supported in this node.js build - perhaps a newer version is needed?',
+          ),
+          b)
+        );
+      }
+      global.Worker = a.Worker;
+    } else if (ka || A)
+      A
+        ? (E = self.location.href)
+        : "undefined" != typeof document && document.currentScript && (E = document.currentScript.src),
+        _scriptDir && (E = _scriptDir),
+        0 !== E.indexOf("blob:") ? (E = E.substr(0, E.replace(/[?#].*/, "").lastIndexOf("/") + 1)) : (E = ""),
+        B ||
+          ((ma = (a) => {
+            var b = new XMLHttpRequest();
+            b.open("GET", a, !1);
+            b.send(null);
+            return b.responseText;
+          }),
+          A &&
+            (H = (a) => {
+              var b = new XMLHttpRequest();
+              b.open("GET", a, !1);
+              b.responseType = "arraybuffer";
+              b.send(null);
+              return new Uint8Array(b.response);
+            }),
+          (F = (a, b, c) => {
+            var e = new XMLHttpRequest();
+            e.open("GET", a, !0);
+            e.responseType = "arraybuffer";
+            e.onload = () => {
+              200 == e.status || (0 == e.status && e.response) ? b(e.response) : c();
+            };
+            e.onerror = c;
+            e.send(null);
+          }));
+    B && "undefined" == typeof performance && (global.performance = require("perf_hooks").performance);
+    var oa = console.log.bind(console),
+      pa = console.error.bind(console);
+    B && ((oa = (...a) => fs.writeSync(1, a.join(" ") + "\n")), (pa = (...a) => fs.writeSync(2, a.join(" ") + "\n")));
+    var qa = w.print || oa,
+      I = w.printErr || pa;
+    Object.assign(w, ia);
+    ia = null;
+    w.thisProgram && (ja = w.thisProgram);
+    w.quit && (z = w.quit);
+    var J;
+    w.wasmBinary && (J = w.wasmBinary);
+    var noExitRuntime = w.noExitRuntime || !0;
+    "object" != typeof WebAssembly && K("no native wasm support detected");
+    var d,
+      L,
+      ra,
+      M = !1,
+      N,
+      l,
+      ba,
+      ca,
+      da,
+      fa;
+    function m() {
+      var a = d.buffer;
+      w.HEAP8 = l = new Int8Array(a);
+      w.HEAP16 = new Int16Array(a);
+      w.HEAP32 = ca = new Int32Array(a);
+      w.HEAPU8 = ba = new Uint8Array(a);
+      w.HEAPU16 = new Uint16Array(a);
+      w.HEAPU32 = da = new Uint32Array(a);
+      w.HEAPF32 = new Float32Array(a);
+      w.HEAPF64 = fa = new Float64Array(a);
+    }
+    var O = w.INITIAL_MEMORY || 16777216;
+    5242880 <= O || K("INITIAL_MEMORY should be larger than STACK_SIZE, was " + O + "! (STACK_SIZE=5242880)");
+    if (D) d = w.wasmMemory;
+    else if (w.wasmMemory) d = w.wasmMemory;
+    else if (
+      ((d = new WebAssembly.Memory({ initial: O / 65536, maximum: 65536, shared: !0 })),
+      !(d.buffer instanceof SharedArrayBuffer))
+    )
+      throw (
+        (I(
+          "requested a shared WebAssembly.Memory but the returned buffer is not a SharedArrayBuffer, indicating that while the browser has SharedArrayBuffer it does not have WebAssembly threads support - you may need to set a flag",
+        ),
+        B &&
+          I(
+            "(on node you may need: --experimental-wasm-threads --experimental-wasm-bulk-memory and/or recent version)",
+          ),
+        Error("bad memory"))
+      );
+    m();
+    O = d.buffer.byteLength;
+    var sa,
+      ta = [],
+      ua = [],
+      va = [],
+      wa = 0;
+    function P() {
+      return noExitRuntime || 0 < wa;
+    }
+    var Q = 0,
+      xa = null,
+      R = null;
+    function ya() {
+      Q++;
+      w.monitorRunDependencies && w.monitorRunDependencies(Q);
+    }
+    function za() {
+      Q--;
+      w.monitorRunDependencies && w.monitorRunDependencies(Q);
+      if (0 == Q && (null !== xa && (clearInterval(xa), (xa = null)), R)) {
+        var a = R;
+        R = null;
+        a();
+      }
+    }
+    function K(a) {
+      if (w.onAbort) w.onAbort(a);
+      a = "Aborted(" + a + ")";
+      I(a);
+      M = !0;
+      N = 1;
+      a = new WebAssembly.RuntimeError(a + ". Build with -sASSERTIONS for more info.");
+      x(a);
+      throw a;
+    }
+    function Aa(a) {
+      return a.startsWith("data:application/octet-stream;base64,");
+    }
+    var S;
+    S = "ort-wasm-simd-threaded.wasm";
+    Aa(S) || (S = la(S));
+    function Ba(a) {
+      if (a == S && J) return new Uint8Array(J);
+      if (H) return H(a);
+      throw "both async and sync fetching of the wasm failed";
+    }
+    function Ca(a) {
+      if (!J && (ka || A)) {
+        if ("function" == typeof fetch && !a.startsWith("file://"))
+          return fetch(a, { credentials: "same-origin" })
+            .then((b) => {
+              if (!b.ok) throw "failed to load wasm binary file at '" + a + "'";
+              return b.arrayBuffer();
+            })
+            .catch(() => Ba(a));
+        if (F)
+          return new Promise((b, c) => {
+            F(a, (e) => b(new Uint8Array(e)), c);
+          });
+      }
+      return Promise.resolve().then(() => Ba(a));
+    }
+    function Da(a, b, c) {
+      return Ca(a)
+        .then((e) => WebAssembly.instantiate(e, b))
+        .then((e) => e)
+        .then(c, (e) => {
+          I("failed to asynchronously prepare wasm: " + e);
+          K(e);
+        });
+    }
+    function Ea(a, b) {
+      var c = S;
+      return J ||
+        "function" != typeof WebAssembly.instantiateStreaming ||
+        Aa(c) ||
+        c.startsWith("file://") ||
+        B ||
+        "function" != typeof fetch
+        ? Da(c, a, b)
+        : fetch(c, { credentials: "same-origin" }).then((e) =>
+            WebAssembly.instantiateStreaming(e, a).then(b, function (h) {
+              I("wasm streaming compile failed: " + h);
+              I("falling back to ArrayBuffer instantiation");
+              return Da(c, a, b);
+            }),
+          );
+    }
+    var T;
+    function U(a) {
+      this.name = "ExitStatus";
+      this.message = `Program terminated with exit(${a})`;
+      this.status = a;
+    }
+    function Fa(a) {
+      a.terminate();
+      a.onmessage = () => {};
+    }
+    function Ga(a) {
+      (a = V.Fa[a]) || K();
+      V.fb(a);
+    }
+    function Ha(a) {
+      var b = V.Za();
+      if (!b) return 6;
+      V.Ia.push(b);
+      V.Fa[a.Ha] = b;
+      b.Ha = a.Ha;
+      var c = { cmd: "run", start_routine: a.gb, arg: a.Ya, pthread_ptr: a.Ha };
+      B && b.unref();
+      b.postMessage(c, a.mb);
+      return 0;
+    }
+    var Ia = "undefined" != typeof TextDecoder ? new TextDecoder("utf8") : void 0,
+      Ja = (a, b, c) => {
+        b >>>= 0;
+        var e = b + c;
+        for (c = b; a[c] && !(c >= e); ) ++c;
+        if (16 < c - b && a.buffer && Ia)
+          return Ia.decode(a.buffer instanceof SharedArrayBuffer ? a.slice(b, c) : a.subarray(b, c));
+        for (e = ""; b < c; ) {
+          var h = a[b++];
+          if (h & 128) {
+            var g = a[b++] & 63;
+            if (192 == (h & 224)) e += String.fromCharCode(((h & 31) << 6) | g);
+            else {
+              var k = a[b++] & 63;
+              h =
+                224 == (h & 240)
+                  ? ((h & 15) << 12) | (g << 6) | k
+                  : ((h & 7) << 18) | (g << 12) | (k << 6) | (a[b++] & 63);
+              65536 > h
+                ? (e += String.fromCharCode(h))
+                : ((h -= 65536), (e += String.fromCharCode(55296 | (h >> 10), 56320 | (h & 1023))));
+            }
+          } else e += String.fromCharCode(h);
+        }
+        return e;
+      },
+      Ka = (a, b) => ((a >>>= 0) ? Ja(n(), a, b) : "");
+    function La(a) {
+      if (D) return W(1, 1, a);
+      N = a;
+      if (!P()) {
+        V.hb();
+        if (w.onExit) w.onExit(a);
+        M = !0;
+      }
+      z(a, new U(a));
+    }
+    var Na = (a) => {
+        N = a;
+        if (D) throw (Ma(a), "unwind");
+        La(a);
+      },
+      V = {
+        La: [],
+        Ia: [],
+        Ta: [],
+        Fa: {},
+        Pa: function () {
+          D ? V.ab() : V.$a();
+        },
+        $a: function () {
+          ta.unshift(() => {
+            ya();
+            V.bb(() => za());
+          });
+        },
+        ab: function () {
+          V.receiveObjectTransfer = V.eb;
+          V.threadInitTLS = V.Sa;
+          V.setExitStatus = V.Ra;
+          noExitRuntime = !1;
+        },
+        Ra: function (a) {
+          N = a;
+        },
+        rb: ["$terminateWorker"],
+        hb: function () {
+          for (var a of V.Ia) Fa(a);
+          for (a of V.La) Fa(a);
+          V.La = [];
+          V.Ia = [];
+          V.Fa = [];
+        },
+        fb: function (a) {
+          var b = a.Ha;
+          delete V.Fa[b];
+          V.La.push(a);
+          V.Ia.splice(V.Ia.indexOf(a), 1);
+          a.Ha = 0;
+          Oa(b);
+        },
+        eb: function () {},
+        Sa: function () {
+          V.Ta.forEach((a) => a());
+        },
+        cb: (a) =>
+          new Promise((b) => {
+            a.onmessage = (g) => {
+              g = g.data;
+              var k = g.cmd;
+              if (g.targetThread && g.targetThread != X()) {
+                var t = V.Fa[g.qb];
+                t
+                  ? t.postMessage(g, g.transferList)
+                  : I(
+                      'Internal error! Worker sent a message "' +
+                        k +
+                        '" to target pthread ' +
+                        g.targetThread +
+                        ", but that thread no longer exists!",
+                    );
+              } else if ("checkMailbox" === k) Y();
+              else if ("spawnThread" === k) Ha(g);
+              else if ("cleanupThread" === k) Ga(g.thread);
+              else if ("killThread" === k)
+                (g = g.thread),
+                  (k = V.Fa[g]),
+                  delete V.Fa[g],
+                  Fa(k),
+                  Oa(g),
+                  V.Ia.splice(V.Ia.indexOf(k), 1),
+                  (k.Ha = 0);
+              else if ("cancelThread" === k) V.Fa[g.thread].postMessage({ cmd: "cancel" });
+              else if ("loaded" === k) (a.loaded = !0), b(a);
+              else if ("alert" === k) alert("Thread " + g.threadId + ": " + g.text);
+              else if ("setimmediate" === g.target) a.postMessage(g);
+              else if ("callHandler" === k) w[g.handler](...g.args);
+              else k && I("worker sent an unknown command " + k);
+            };
+            a.onerror = (g) => {
+              I("worker sent an error! " + g.filename + ":" + g.lineno + ": " + g.message);
+              throw g;
+            };
+            B &&
+              (a.on("message", function (g) {
+                a.onmessage({ data: g });
+              }),
+              a.on("error", function (g) {
+                a.onerror(g);
+              }));
+            var c = [],
+              e = ["onExit", "onAbort", "print", "printErr"],
+              h;
+            for (h of e) w.hasOwnProperty(h) && c.push(h);
+            a.postMessage({
+              cmd: "load",
+              handlers: c,
+              urlOrBlob: w.mainScriptUrlOrBlob || _scriptDir,
+              wasmMemory: d,
+              wasmModule: ra,
+            });
+          }),
+        bb: function (a) {
+          a();
+        },
+        Xa: function () {
+          var a = la("ort-wasm-simd-threaded.worker.js");
+          a = new Worker(a);
+          V.La.push(a);
+        },
+        Za: function () {
+          0 == V.La.length && (V.Xa(), V.cb(V.La[0]));
+          return V.La.pop();
+        },
+      };
+    w.PThread = V;
+    var Pa = (a) => {
+      for (; 0 < a.length; ) a.shift()(w);
+    };
+    w.establishStackSpace = function () {
+      var a = X(),
+        b = p()[((a + 52) >> 2) >>> 0];
+      a = p()[((a + 56) >> 2) >>> 0];
+      Qa(b, b - a);
+      Ra(b);
+    };
+    function Ma(a) {
+      if (D) return W(2, 0, a);
+      Na(a);
+    }
+    var Sa = [];
+    w.invokeEntryPoint = function (a, b) {
+      var c = Sa[a];
+      c || (a >= Sa.length && (Sa.length = a + 1), (Sa[a] = c = sa.get(a)));
+      a = c(b);
+      P() ? V.Ra(a) : Ta(a);
+    };
+    function Ua(a) {
+      this.Oa = a - 24;
+      this.Wa = function (b) {
+        r()[((this.Oa + 4) >> 2) >>> 0] = b;
+      };
+      this.Va = function (b) {
+        r()[((this.Oa + 8) >> 2) >>> 0] = b;
+      };
+      this.Pa = function (b, c) {
+        this.Ua();
+        this.Wa(b);
+        this.Va(c);
+      };
+      this.Ua = function () {
+        r()[((this.Oa + 16) >> 2) >>> 0] = 0;
+      };
+    }
+    var Va = 0,
+      Wa = 0;
+    function Xa(a, b, c, e) {
+      return D ? W(3, 1, a, b, c, e) : Ya(a, b, c, e);
+    }
+    function Ya(a, b, c, e) {
+      a >>>= 0;
+      b >>>= 0;
+      c >>>= 0;
+      e >>>= 0;
+      if ("undefined" == typeof SharedArrayBuffer)
+        return I("Current environment does not support SharedArrayBuffer, pthreads are not available!"), 6;
+      var h = [];
+      if (D && 0 === h.length) return Xa(a, b, c, e);
+      a = { gb: c, Ha: a, Ya: e, mb: h };
+      return D ? ((a.ob = "spawnThread"), postMessage(a, h), 0) : Ha(a);
+    }
+    function Za(a, b, c) {
+      return D ? W(4, 1, a, b, c) : 0;
+    }
+    function $a(a, b) {
+      if (D) return W(5, 1, a, b);
+    }
+    var ab = (a) => {
+        for (var b = 0, c = 0; c < a.length; ++c) {
+          var e = a.charCodeAt(c);
+          127 >= e ? b++ : 2047 >= e ? (b += 2) : 55296 <= e && 57343 >= e ? ((b += 4), ++c) : (b += 3);
+        }
+        return b;
+      },
+      bb = (a, b, c, e) => {
+        c >>>= 0;
+        if (!(0 < e)) return 0;
+        var h = c;
+        e = c + e - 1;
+        for (var g = 0; g < a.length; ++g) {
+          var k = a.charCodeAt(g);
+          if (55296 <= k && 57343 >= k) {
+            var t = a.charCodeAt(++g);
+            k = (65536 + ((k & 1023) << 10)) | (t & 1023);
+          }
+          if (127 >= k) {
+            if (c >= e) break;
+            b[c++ >>> 0] = k;
+          } else {
+            if (2047 >= k) {
+              if (c + 1 >= e) break;
+              b[c++ >>> 0] = 192 | (k >> 6);
+            } else {
+              if (65535 >= k) {
+                if (c + 2 >= e) break;
+                b[c++ >>> 0] = 224 | (k >> 12);
+              } else {
+                if (c + 3 >= e) break;
+                b[c++ >>> 0] = 240 | (k >> 18);
+                b[c++ >>> 0] = 128 | ((k >> 12) & 63);
+              }
+              b[c++ >>> 0] = 128 | ((k >> 6) & 63);
+            }
+            b[c++ >>> 0] = 128 | (k & 63);
+          }
+        }
+        b[c >>> 0] = 0;
+        return c - h;
+      },
+      cb = (a, b, c) => bb(a, n(), b, c);
+    function db(a, b) {
+      if (D) return W(6, 1, a, b);
+    }
+    function eb(a, b, c) {
+      if (D) return W(7, 1, a, b, c);
+    }
+    function fb(a, b, c) {
+      return D ? W(8, 1, a, b, c) : 0;
+    }
+    function gb(a, b) {
+      if (D) return W(9, 1, a, b);
+    }
+    function hb(a, b, c) {
+      if (D) return W(10, 1, a, b, c);
+    }
+    function ib(a, b, c, e) {
+      if (D) return W(11, 1, a, b, c, e);
+    }
+    function jb(a, b, c, e) {
+      if (D) return W(12, 1, a, b, c, e);
+    }
+    function kb(a, b, c, e) {
+      if (D) return W(13, 1, a, b, c, e);
+    }
+    function lb(a) {
+      if (D) return W(14, 1, a);
+    }
+    function mb(a, b) {
+      if (D) return W(15, 1, a, b);
+    }
+    function nb(a, b, c) {
+      if (D) return W(16, 1, a, b, c);
+    }
+    var ob = (a) => {
+      if (!M)
+        try {
+          if ((a(), !P()))
+            try {
+              D ? Ta(N) : Na(N);
+            } catch (b) {
+              b instanceof U || "unwind" == b || z(1, b);
+            }
+        } catch (b) {
+          b instanceof U || "unwind" == b || z(1, b);
+        }
+    };
+    function pb(a) {
+      a >>>= 0;
+      "function" === typeof Atomics.nb &&
+        (Atomics.nb(p(), a >> 2, a).value.then(Y), (a += 128), Atomics.store(p(), a >> 2, 1));
+    }
+    w.__emscripten_thread_mailbox_await = pb;
+    function Y() {
+      var a = X();
+      a && (pb(a), ob(() => qb()));
+    }
+    w.checkMailbox = Y;
+    var Z = (a) => 0 === a % 4 && (0 !== a % 100 || 0 === a % 400),
+      rb = [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335],
+      sb = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334];
+    function tb(a, b, c, e, h, g, k, t) {
+      return D ? W(17, 1, a, b, c, e, h, g, k, t) : -52;
+    }
+    function ub(a, b, c, e, h, g, k) {
+      if (D) return W(18, 1, a, b, c, e, h, g, k);
+    }
+    var wb = (a) => {
+        var b = ab(a) + 1,
+          c = vb(b);
+        c && cb(a, c, b);
+        return c;
+      },
+      yb = (a) => {
+        var b = xb();
+        a = a();
+        Ra(b);
+        return a;
+      };
+    function W(a, b) {
+      var c = arguments.length - 2,
+        e = arguments;
+      return yb(() => {
+        for (var h = zb(8 * c), g = h >> 3, k = 0; k < c; k++) {
+          var t = e[2 + k];
+          ea()[(g + k) >>> 0] = t;
+        }
+        return Ab(a, c, h, b);
+      });
+    }
+    var Bb = [],
+      Cb = {},
+      Eb = () => {
+        if (!Db) {
+          var a = {
+              USER: "web_user",
+              LOGNAME: "web_user",
+              PATH: "/",
+              PWD: "/",
+              HOME: "/home/web_user",
+              LANG:
+                (("object" == typeof navigator && navigator.languages && navigator.languages[0]) || "C").replace(
+                  "-",
+                  "_",
+                ) + ".UTF-8",
+              _: ja || "./this.program",
+            },
+            b;
+          for (b in Cb) void 0 === Cb[b] ? delete a[b] : (a[b] = Cb[b]);
+          var c = [];
+          for (b in a) c.push(`${b}=${a[b]}`);
+          Db = c;
+        }
+        return Db;
+      },
+      Db;
+    function Fb(a, b) {
+      if (D) return W(19, 1, a, b);
+      a >>>= 0;
+      b >>>= 0;
+      var c = 0;
+      Eb().forEach(function (e, h) {
+        var g = b + c;
+        h = r()[((a + 4 * h) >> 2) >>> 0] = g;
+        for (g = 0; g < e.length; ++g) aa()[(h++ >> 0) >>> 0] = e.charCodeAt(g);
+        aa()[(h >> 0) >>> 0] = 0;
+        c += e.length + 1;
+      });
+      return 0;
+    }
+    function Gb(a, b) {
+      if (D) return W(20, 1, a, b);
+      a >>>= 0;
+      b >>>= 0;
+      var c = Eb();
+      r()[(a >> 2) >>> 0] = c.length;
+      var e = 0;
+      c.forEach(function (h) {
+        e += h.length + 1;
+      });
+      r()[(b >> 2) >>> 0] = e;
+      return 0;
+    }
+    function Hb(a) {
+      return D ? W(21, 1, a) : 52;
+    }
+    function Ib(a, b, c, e) {
+      return D ? W(22, 1, a, b, c, e) : 52;
+    }
+    function Mb(a, b, c, e, h) {
+      return D ? W(23, 1, a, b, c, e, h) : 70;
+    }
+    var Nb = [null, [], []];
+    function Ob(a, b, c, e) {
+      if (D) return W(24, 1, a, b, c, e);
+      b >>>= 0;
+      c >>>= 0;
+      e >>>= 0;
+      for (var h = 0, g = 0; g < c; g++) {
+        var k = r()[(b >> 2) >>> 0],
+          t = r()[((b + 4) >> 2) >>> 0];
+        b += 8;
+        for (var C = 0; C < t; C++) {
+          var v = n()[(k + C) >>> 0],
+            y = Nb[a];
+          0 === v || 10 === v ? ((1 === a ? qa : I)(Ja(y, 0)), (y.length = 0)) : y.push(v);
+        }
+        h += t;
+      }
+      r()[(e >> 2) >>> 0] = h;
+      return 0;
+    }
+    var Pb = () => {
+        if ("object" == typeof crypto && "function" == typeof crypto.getRandomValues)
+          return (c) => (c.set(crypto.getRandomValues(new Uint8Array(c.byteLength))), c);
+        if (B)
+          try {
+            var a = require("crypto");
+            if (a.randomFillSync) return (c) => a.randomFillSync(c);
+            var b = a.randomBytes;
+            return (c) => (c.set(b(c.byteLength)), c);
+          } catch (c) {}
+        K("initRandomDevice");
+      },
+      Qb = (a) => (Qb = Pb())(a),
+      Rb = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+      Sb = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    function Tb(a) {
+      var b = Array(ab(a) + 1);
+      bb(a, b, 0, b.length);
+      return b;
+    }
+    var Ub = (a, b) => {
+      aa().set(a, b >>> 0);
+    };
+    function Vb(a, b, c, e) {
+      function h(f, q, u) {
+        for (f = "number" == typeof f ? f.toString() : f || ""; f.length < q; ) f = u[0] + f;
+        return f;
+      }
+      function g(f, q) {
+        return h(f, q, "0");
+      }
+      function k(f, q) {
+        function u(Jb) {
+          return 0 > Jb ? -1 : 0 < Jb ? 1 : 0;
+        }
+        var G;
+        0 === (G = u(f.getFullYear() - q.getFullYear())) &&
+          0 === (G = u(f.getMonth() - q.getMonth())) &&
+          (G = u(f.getDate() - q.getDate()));
+        return G;
+      }
+      function t(f) {
+        switch (f.getDay()) {
+          case 0:
+            return new Date(f.getFullYear() - 1, 11, 29);
+          case 1:
+            return f;
+          case 2:
+            return new Date(f.getFullYear(), 0, 3);
+          case 3:
+            return new Date(f.getFullYear(), 0, 2);
+          case 4:
+            return new Date(f.getFullYear(), 0, 1);
+          case 5:
+            return new Date(f.getFullYear() - 1, 11, 31);
+          case 6:
+            return new Date(f.getFullYear() - 1, 11, 30);
+        }
+      }
+      function C(f) {
+        var q = f.Ja;
+        for (f = new Date(new Date(f.Ka + 1900, 0, 1).getTime()); 0 < q; ) {
+          var u = f.getMonth(),
+            G = (Z(f.getFullYear()) ? Rb : Sb)[u];
+          if (q > G - f.getDate())
+            (q -= G - f.getDate() + 1),
+              f.setDate(1),
+              11 > u ? f.setMonth(u + 1) : (f.setMonth(0), f.setFullYear(f.getFullYear() + 1));
+          else {
+            f.setDate(f.getDate() + q);
+            break;
+          }
+        }
+        u = new Date(f.getFullYear() + 1, 0, 4);
+        q = t(new Date(f.getFullYear(), 0, 4));
+        u = t(u);
+        return 0 >= k(q, f) ? (0 >= k(u, f) ? f.getFullYear() + 1 : f.getFullYear()) : f.getFullYear() - 1;
+      }
+      a >>>= 0;
+      b >>>= 0;
+      c >>>= 0;
+      e >>>= 0;
+      var v = p()[((e + 40) >> 2) >>> 0];
+      e = {
+        kb: p()[(e >> 2) >>> 0],
+        jb: p()[((e + 4) >> 2) >>> 0],
+        Ma: p()[((e + 8) >> 2) >>> 0],
+        Qa: p()[((e + 12) >> 2) >>> 0],
+        Na: p()[((e + 16) >> 2) >>> 0],
+        Ka: p()[((e + 20) >> 2) >>> 0],
+        Ga: p()[((e + 24) >> 2) >>> 0],
+        Ja: p()[((e + 28) >> 2) >>> 0],
+        sb: p()[((e + 32) >> 2) >>> 0],
+        ib: p()[((e + 36) >> 2) >>> 0],
+        lb: v ? Ka(v) : "",
+      };
+      c = Ka(c);
+      v = {
+        "%c": "%a %b %d %H:%M:%S %Y",
+        "%D": "%m/%d/%y",
+        "%F": "%Y-%m-%d",
+        "%h": "%b",
+        "%r": "%I:%M:%S %p",
+        "%R": "%H:%M",
+        "%T": "%H:%M:%S",
+        "%x": "%m/%d/%y",
+        "%X": "%H:%M:%S",
+        "%Ec": "%c",
+        "%EC": "%C",
+        "%Ex": "%m/%d/%y",
+        "%EX": "%H:%M:%S",
+        "%Ey": "%y",
+        "%EY": "%Y",
+        "%Od": "%d",
+        "%Oe": "%e",
+        "%OH": "%H",
+        "%OI": "%I",
+        "%Om": "%m",
+        "%OM": "%M",
+        "%OS": "%S",
+        "%Ou": "%u",
+        "%OU": "%U",
+        "%OV": "%V",
+        "%Ow": "%w",
+        "%OW": "%W",
+        "%Oy": "%y",
+      };
+      for (var y in v) c = c.replace(new RegExp(y, "g"), v[y]);
+      var Kb = "Sunday Monday Tuesday Wednesday Thursday Friday Saturday".split(" "),
+        Lb = "January February March April May June July August September October November December".split(" ");
+      v = {
+        "%a": (f) => Kb[f.Ga].substring(0, 3),
+        "%A": (f) => Kb[f.Ga],
+        "%b": (f) => Lb[f.Na].substring(0, 3),
+        "%B": (f) => Lb[f.Na],
+        "%C": (f) => g(((f.Ka + 1900) / 100) | 0, 2),
+        "%d": (f) => g(f.Qa, 2),
+        "%e": (f) => h(f.Qa, 2, " "),
+        "%g": (f) => C(f).toString().substring(2),
+        "%G": (f) => C(f),
+        "%H": (f) => g(f.Ma, 2),
+        "%I": (f) => {
+          f = f.Ma;
+          0 == f ? (f = 12) : 12 < f && (f -= 12);
+          return g(f, 2);
+        },
+        "%j": (f) => {
+          for (var q = 0, u = 0; u <= f.Na - 1; q += (Z(f.Ka + 1900) ? Rb : Sb)[u++]);
+          return g(f.Qa + q, 3);
+        },
+        "%m": (f) => g(f.Na + 1, 2),
+        "%M": (f) => g(f.jb, 2),
+        "%n": () => "\n",
+        "%p": (f) => (0 <= f.Ma && 12 > f.Ma ? "AM" : "PM"),
+        "%S": (f) => g(f.kb, 2),
+        "%t": () => "\t",
+        "%u": (f) => f.Ga || 7,
+        "%U": (f) => g(Math.floor((f.Ja + 7 - f.Ga) / 7), 2),
+        "%V": (f) => {
+          var q = Math.floor((f.Ja + 7 - ((f.Ga + 6) % 7)) / 7);
+          2 >= (f.Ga + 371 - f.Ja - 2) % 7 && q++;
+          if (q) 53 == q && ((u = (f.Ga + 371 - f.Ja) % 7), 4 == u || (3 == u && Z(f.Ka)) || (q = 1));
+          else {
+            q = 52;
+            var u = (f.Ga + 7 - f.Ja - 1) % 7;
+            (4 == u || (5 == u && Z((f.Ka % 400) - 1))) && q++;
+          }
+          return g(q, 2);
+        },
+        "%w": (f) => f.Ga,
+        "%W": (f) => g(Math.floor((f.Ja + 7 - ((f.Ga + 6) % 7)) / 7), 2),
+        "%y": (f) => (f.Ka + 1900).toString().substring(2),
+        "%Y": (f) => f.Ka + 1900,
+        "%z": (f) => {
+          f = f.ib;
+          var q = 0 <= f;
+          f = Math.abs(f) / 60;
+          return (q ? "+" : "-") + String("0000" + ((f / 60) * 100 + (f % 60))).slice(-4);
+        },
+        "%Z": (f) => f.lb,
+        "%%": () => "%",
+      };
+      c = c.replace(/%%/g, "\x00\x00");
+      for (y in v) c.includes(y) && (c = c.replace(new RegExp(y, "g"), v[y](e)));
+      c = c.replace(/\0\0/g, "%");
+      y = Tb(c);
+      if (y.length > b) return 0;
+      Ub(y, a);
+      return y.length - 1;
+    }
+    V.Pa();
+    var Wb = [null, La, Ma, Xa, Za, $a, db, eb, fb, gb, hb, ib, jb, kb, lb, mb, nb, tb, ub, Fb, Gb, Hb, Ib, Mb, Ob],
+      Zb = {
+        b: function (a, b, c) {
+          a >>>= 0;
+          new Ua(a).Pa(b >>> 0, c >>> 0);
+          Va = a;
+          Wa++;
+          throw Va;
+        },
+        N: function (a) {
+          Xb(a >>> 0, !A, 1, !ka, 131072, !1);
+          V.Sa();
+        },
+        k: function (a) {
+          a >>>= 0;
+          D ? postMessage({ cmd: "cleanupThread", thread: a }) : Ga(a);
+        },
+        I: Ya,
+        h: Za,
+        T: $a,
+        E: db,
+        G: eb,
+        U: fb,
+        R: gb,
+        J: hb,
+        Q: ib,
+        o: jb,
+        F: kb,
+        C: lb,
+        S: mb,
+        D: nb,
+        q: () => !0,
+        A: function (a, b) {
+          a >>>= 0;
+          a == b >>> 0
+            ? setTimeout(() => Y())
+            : D
+            ? postMessage({ targetThread: a, cmd: "checkMailbox" })
+            : (a = V.Fa[a]) && a.postMessage({ cmd: "checkMailbox" });
+        },
+        L: function () {
+          return -1;
+        },
+        M: pb,
+        p: function (a) {
+          B && V.Fa[a >>> 0].ref();
+        },
+        t: function (a, b, c) {
+          a = (b + 2097152) >>> 0 < 4194305 - !!a ? (a >>> 0) + 4294967296 * b : NaN;
+          c >>>= 0;
+          a = new Date(1e3 * a);
+          p()[(c >> 2) >>> 0] = a.getUTCSeconds();
+          p()[((c + 4) >> 2) >>> 0] = a.getUTCMinutes();
+          p()[((c + 8) >> 2) >>> 0] = a.getUTCHours();
+          p()[((c + 12) >> 2) >>> 0] = a.getUTCDate();
+          p()[((c + 16) >> 2) >>> 0] = a.getUTCMonth();
+          p()[((c + 20) >> 2) >>> 0] = a.getUTCFullYear() - 1900;
+          p()[((c + 24) >> 2) >>> 0] = a.getUTCDay();
+          a = ((a.getTime() - Date.UTC(a.getUTCFullYear(), 0, 1, 0, 0, 0, 0)) / 864e5) | 0;
+          p()[((c + 28) >> 2) >>> 0] = a;
+        },
+        u: function (a, b, c) {
+          a = (b + 2097152) >>> 0 < 4194305 - !!a ? (a >>> 0) + 4294967296 * b : NaN;
+          c >>>= 0;
+          a = new Date(1e3 * a);
+          p()[(c >> 2) >>> 0] = a.getSeconds();
+          p()[((c + 4) >> 2) >>> 0] = a.getMinutes();
+          p()[((c + 8) >> 2) >>> 0] = a.getHours();
+          p()[((c + 12) >> 2) >>> 0] = a.getDate();
+          p()[((c + 16) >> 2) >>> 0] = a.getMonth();
+          p()[((c + 20) >> 2) >>> 0] = a.getFullYear() - 1900;
+          p()[((c + 24) >> 2) >>> 0] = a.getDay();
+          b = ((Z(a.getFullYear()) ? rb : sb)[a.getMonth()] + a.getDate() - 1) | 0;
+          p()[((c + 28) >> 2) >>> 0] = b;
+          p()[((c + 36) >> 2) >>> 0] = -(60 * a.getTimezoneOffset());
+          b = new Date(a.getFullYear(), 6, 1).getTimezoneOffset();
+          var e = new Date(a.getFullYear(), 0, 1).getTimezoneOffset();
+          a = (b != e && a.getTimezoneOffset() == Math.min(e, b)) | 0;
+          p()[((c + 32) >> 2) >>> 0] = a;
+        },
+        v: function (a) {
+          a >>>= 0;
+          var b = new Date(
+              p()[((a + 20) >> 2) >>> 0] + 1900,
+              p()[((a + 16) >> 2) >>> 0],
+              p()[((a + 12) >> 2) >>> 0],
+              p()[((a + 8) >> 2) >>> 0],
+              p()[((a + 4) >> 2) >>> 0],
+              p()[(a >> 2) >>> 0],
+              0,
+            ),
+            c = p()[((a + 32) >> 2) >>> 0],
+            e = b.getTimezoneOffset(),
+            h = new Date(b.getFullYear(), 6, 1).getTimezoneOffset(),
+            g = new Date(b.getFullYear(), 0, 1).getTimezoneOffset(),
+            k = Math.min(g, h);
+          0 > c
+            ? (p()[((a + 32) >> 2) >>> 0] = Number(h != g && k == e))
+            : 0 < c != (k == e) && ((h = Math.max(g, h)), b.setTime(b.getTime() + 6e4 * ((0 < c ? k : h) - e)));
+          p()[((a + 24) >> 2) >>> 0] = b.getDay();
+          c = ((Z(b.getFullYear()) ? rb : sb)[b.getMonth()] + b.getDate() - 1) | 0;
+          p()[((a + 28) >> 2) >>> 0] = c;
+          p()[(a >> 2) >>> 0] = b.getSeconds();
+          p()[((a + 4) >> 2) >>> 0] = b.getMinutes();
+          p()[((a + 8) >> 2) >>> 0] = b.getHours();
+          p()[((a + 12) >> 2) >>> 0] = b.getDate();
+          p()[((a + 16) >> 2) >>> 0] = b.getMonth();
+          p()[((a + 20) >> 2) >>> 0] = b.getYear();
+          a = b.getTime() / 1e3;
+          return (
+            Yb(
+              ((T = a),
+              1 <= +Math.abs(T)
+                ? 0 < T
+                  ? +Math.floor(T / 4294967296) >>> 0
+                  : ~~+Math.ceil((T - +(~~T >>> 0)) / 4294967296) >>> 0
+                : 0),
+            ),
+            a >>> 0
+          );
+        },
+        r: tb,
+        s: ub,
+        z: function (a, b, c) {
+          function e(v) {
+            return (v = v.toTimeString().match(/\(([A-Za-z ]+)\)$/)) ? v[1] : "GMT";
+          }
+          a >>>= 0;
+          b >>>= 0;
+          c >>>= 0;
+          var h = new Date().getFullYear(),
+            g = new Date(h, 0, 1),
+            k = new Date(h, 6, 1);
+          h = g.getTimezoneOffset();
+          var t = k.getTimezoneOffset(),
+            C = Math.max(h, t);
+          r()[(a >> 2) >>> 0] = 60 * C;
+          p()[(b >> 2) >>> 0] = Number(h != t);
+          a = e(g);
+          b = e(k);
+          a = wb(a);
+          b = wb(b);
+          t < h
+            ? ((r()[(c >> 2) >>> 0] = a), (r()[((c + 4) >> 2) >>> 0] = b))
+            : ((r()[(c >> 2) >>> 0] = b), (r()[((c + 4) >> 2) >>> 0] = a));
+        },
+        c: () => {
+          K("");
+        },
+        l: function () {},
+        i: function () {
+          return Date.now();
+        },
+        V: () => {
+          wa += 1;
+          throw "unwind";
+        },
+        B: function () {
+          return 4294901760;
+        },
+        e: () => performance.timeOrigin + performance.now(),
+        f: function () {
+          return B ? require("os").cpus().length : navigator.hardwareConcurrency;
+        },
+        K: function (a, b, c, e) {
+          V.pb = b >>> 0;
+          Bb.length = c;
+          b = (e >>> 0) >> 3;
+          for (e = 0; e < c; e++) Bb[e] = ea()[(b + e) >>> 0];
+          return Wb[a].apply(null, Bb);
+        },
+        y: function (a) {
+          a >>>= 0;
+          var b = n().length;
+          if (a <= b || 4294901760 < a) return !1;
+          for (var c = 1; 4 >= c; c *= 2) {
+            var e = b * (1 + 0.2 / c);
+            e = Math.min(e, a + 100663296);
+            var h = Math;
+            e = Math.max(a, e);
+            a: {
+              h = (h.min.call(h, 4294901760, e + ((65536 - (e % 65536)) % 65536)) - d.buffer.byteLength + 65535) >>> 16;
+              try {
+                d.grow(h);
+                m();
+                var g = 1;
+                break a;
+              } catch (k) {}
+              g = void 0;
+            }
+            if (g) return !0;
+          }
+          return !1;
+        },
+        O: Fb,
+        P: Gb,
+        j: Na,
+        g: Hb,
+        n: Ib,
+        w: Mb,
+        m: Ob,
+        x: function (a, b) {
+          a >>>= 0;
+          b >>>= 0;
+          Qb(n().subarray(a >>> 0, (a + b) >>> 0));
+          return 0;
+        },
+        a: d || w.wasmMemory,
+        H: Vb,
+        d: function (a, b, c, e) {
+          return Vb(a >>> 0, b >>> 0, c >>> 0, e >>> 0);
+        },
+      };
+    (function () {
+      function a(c, e) {
+        c = c.exports;
+        L = c = $b(c);
+        V.Ta.push(L.sa);
+        sa = L.ta;
+        ua.unshift(L.W);
+        ra = e;
+        za();
+        return c;
+      }
+      var b = { a: Zb };
+      ya();
+      if (w.instantiateWasm)
+        try {
+          return w.instantiateWasm(b, a);
+        } catch (c) {
+          I("Module.instantiateWasm callback failed with error: " + c), x(c);
+        }
+      Ea(b, function (c) {
+        a(c.instance, c.module);
+      }).catch(x);
+      return {};
+    })();
+    w._OrtInit = (a, b) => (w._OrtInit = L.X)(a, b);
+    w._OrtGetLastError = (a, b) => (w._OrtGetLastError = L.Y)(a, b);
+    w._OrtCreateSessionOptions = (a, b, c, e, h, g, k, t, C, v) =>
+      (w._OrtCreateSessionOptions = L.Z)(a, b, c, e, h, g, k, t, C, v);
+    w._OrtAppendExecutionProvider = (a, b) => (w._OrtAppendExecutionProvider = L._)(a, b);
+    w._OrtAddSessionConfigEntry = (a, b, c) => (w._OrtAddSessionConfigEntry = L.$)(a, b, c);
+    w._OrtReleaseSessionOptions = (a) => (w._OrtReleaseSessionOptions = L.aa)(a);
+    w._OrtCreateSession = (a, b, c) => (w._OrtCreateSession = L.ba)(a, b, c);
+    w._OrtReleaseSession = (a) => (w._OrtReleaseSession = L.ca)(a);
+    w._OrtGetInputOutputCount = (a, b, c) => (w._OrtGetInputOutputCount = L.da)(a, b, c);
+    w._OrtGetInputName = (a, b) => (w._OrtGetInputName = L.ea)(a, b);
+    w._OrtGetOutputName = (a, b) => (w._OrtGetOutputName = L.fa)(a, b);
+    w._OrtFree = (a) => (w._OrtFree = L.ga)(a);
+    w._OrtCreateTensor = (a, b, c, e, h) => (w._OrtCreateTensor = L.ha)(a, b, c, e, h);
+    w._OrtGetTensorData = (a, b, c, e, h) => (w._OrtGetTensorData = L.ia)(a, b, c, e, h);
+    w._OrtReleaseTensor = (a) => (w._OrtReleaseTensor = L.ja)(a);
+    w._OrtCreateRunOptions = (a, b, c, e) => (w._OrtCreateRunOptions = L.ka)(a, b, c, e);
+    w._OrtAddRunConfigEntry = (a, b, c) => (w._OrtAddRunConfigEntry = L.la)(a, b, c);
+    w._OrtReleaseRunOptions = (a) => (w._OrtReleaseRunOptions = L.ma)(a);
+    w._OrtRun = (a, b, c, e, h, g, k, t) => (w._OrtRun = L.na)(a, b, c, e, h, g, k, t);
+    w._OrtEndProfiling = (a) => (w._OrtEndProfiling = L.oa)(a);
+    var X = (w._pthread_self = () => (X = w._pthread_self = L.pa)()),
+      vb = (w._malloc = (a) => (vb = w._malloc = L.qa)(a));
+    w._free = (a) => (w._free = L.ra)(a);
+    w.__emscripten_tls_init = () => (w.__emscripten_tls_init = L.sa)();
+    var Xb = (w.__emscripten_thread_init = (a, b, c, e, h, g) =>
+      (Xb = w.__emscripten_thread_init = L.ua)(a, b, c, e, h, g));
+    w.__emscripten_thread_crashed = () => (w.__emscripten_thread_crashed = L.va)();
+    var Ab = (a, b, c, e) => (Ab = L.wa)(a, b, c, e),
+      Oa = (a) => (Oa = L.xa)(a),
+      Ta = (w.__emscripten_thread_exit = (a) => (Ta = w.__emscripten_thread_exit = L.ya)(a)),
+      qb = (w.__emscripten_check_mailbox = () => (qb = w.__emscripten_check_mailbox = L.za)()),
+      Yb = (a) => (Yb = L.Aa)(a),
+      Qa = (a, b) => (Qa = L.Ba)(a, b),
+      xb = () => (xb = L.Ca)(),
+      Ra = (a) => (Ra = L.Da)(a),
+      zb = (a) => (zb = L.Ea)(a);
+    function $b(a) {
+      a = Object.assign({}, a);
+      var b = (e) => () => e() >>> 0,
+        c = (e) => (h) => e(h) >>> 0;
+      a.__errno_location = b(a.__errno_location);
+      a.pthread_self = b(a.pthread_self);
+      a.malloc = c(a.malloc);
+      a.stackSave = b(a.stackSave);
+      a.stackAlloc = c(a.stackAlloc);
+      return a;
+    }
+    w.keepRuntimeAlive = P;
+    w.wasmMemory = d;
+    w.stackAlloc = zb;
+    w.stackSave = xb;
+    w.stackRestore = Ra;
+    w.UTF8ToString = Ka;
+    w.stringToUTF8 = cb;
+    w.lengthBytesUTF8 = ab;
+    w.ExitStatus = U;
+    w.PThread = V;
+    var ac;
+    R = function bc() {
+      ac || cc();
+      ac || (R = bc);
+    };
+    function cc() {
+      function a() {
+        if (!ac && ((ac = !0), (w.calledRun = !0), !M)) {
+          D || Pa(ua);
+          ha(w);
+          if (w.onRuntimeInitialized) w.onRuntimeInitialized();
+          if (!D) {
+            if (w.postRun)
+              for ("function" == typeof w.postRun && (w.postRun = [w.postRun]); w.postRun.length; ) {
+                var b = w.postRun.shift();
+                va.unshift(b);
+              }
+            Pa(va);
+          }
+        }
+      }
+      if (!(0 < Q))
+        if (D) ha(w), D || Pa(ua), startWorker(w);
+        else {
+          if (w.preRun)
+            for ("function" == typeof w.preRun && (w.preRun = [w.preRun]); w.preRun.length; )
+              ta.unshift(w.preRun.shift());
+          Pa(ta);
+          0 < Q ||
+            (w.setStatus
+              ? (w.setStatus("Running..."),
+                setTimeout(function () {
+                  setTimeout(function () {
+                    w.setStatus("");
+                  }, 1);
+                  a();
+                }, 1))
+              : a());
+        }
+    }
+    if (w.preInit)
+      for ("function" == typeof w.preInit && (w.preInit = [w.preInit]); 0 < w.preInit.length; ) w.preInit.pop()();
+    cc();
+
+    return moduleArg.ready;
+  };
+})();
+if (typeof exports === "object" && typeof module === "object") module.exports = ortWasmThreaded;
+else if (typeof define === "function" && define["amd"]) define([], () => ortWasmThreaded);

--- a/js/web/lib/wasm/binding/ort-wasm-simd-threaded.jsep.js
+++ b/js/web/lib/wasm/binding/ort-wasm-simd-threaded.jsep.js
@@ -1,0 +1,1817 @@
+var ortWasmThreaded = (() => {
+  var _scriptDir = typeof document !== "undefined" && document.currentScript ? document.currentScript.src : undefined;
+  if (typeof __filename !== "undefined") _scriptDir = _scriptDir || __filename;
+  return function (moduleArg = {}) {
+    function d() {
+      l.buffer != p.buffer && q();
+      return p;
+    }
+    function u() {
+      l.buffer != p.buffer && q();
+      return aa;
+    }
+    function z() {
+      l.buffer != p.buffer && q();
+      return ba;
+    }
+    function A() {
+      l.buffer != p.buffer && q();
+      return ca;
+    }
+    function da() {
+      l.buffer != p.buffer && q();
+      return ea;
+    }
+    var B = moduleArg,
+      fa,
+      C;
+    B.ready = new Promise((a, b) => {
+      fa = a;
+      C = b;
+    });
+    ("use strict");
+    B.jsepInit = function (a, b, c, e, f, h, k, m) {
+      B.Ib = a;
+      B.ob = b;
+      B.qb = c;
+      B.ab = e;
+      B.pb = f;
+      B.xa = h;
+      B.rb = k;
+      B.sb = m;
+    };
+    var ha = Object.assign({}, B),
+      ia = "./this.program",
+      D = (a, b) => {
+        throw b;
+      },
+      ja = "object" == typeof window,
+      E = "function" == typeof importScripts,
+      F = "object" == typeof process && "object" == typeof process.versions && "string" == typeof process.versions.node,
+      G = B.ENVIRONMENT_IS_PTHREAD || !1,
+      H = "";
+    function ka(a) {
+      return B.locateFile ? B.locateFile(a, H) : H + a;
+    }
+    var la, I, ma;
+    if (F) {
+      var fs = require("fs"),
+        na = require("path");
+      H = E ? na.dirname(H) + "/" : __dirname + "/";
+      la = (b, c) => {
+        b = b.startsWith("file://") ? new URL(b) : na.normalize(b);
+        return fs.readFileSync(b, c ? void 0 : "utf8");
+      };
+      ma = (b) => {
+        b = la(b, !0);
+        b.buffer || (b = new Uint8Array(b));
+        return b;
+      };
+      I = (b, c, e, f = !0) => {
+        b = b.startsWith("file://") ? new URL(b) : na.normalize(b);
+        fs.readFile(b, f ? void 0 : "utf8", (h, k) => {
+          h ? e(h) : c(f ? k.buffer : k);
+        });
+      };
+      !B.thisProgram && 1 < process.argv.length && (ia = process.argv[1].replace(/\\/g, "/"));
+      process.argv.slice(2);
+      D = (b, c) => {
+        process.exitCode = b;
+        throw c;
+      };
+      B.inspect = () => "[Emscripten Module object]";
+      let a;
+      try {
+        a = require("worker_threads");
+      } catch (b) {
+        throw (
+          (console.error(
+            'The "worker_threads" module is not supported in this node.js build - perhaps a newer version is needed?',
+          ),
+          b)
+        );
+      }
+      global.Worker = a.Worker;
+    } else if (ja || E)
+      E
+        ? (H = self.location.href)
+        : "undefined" != typeof document && document.currentScript && (H = document.currentScript.src),
+        _scriptDir && (H = _scriptDir),
+        0 !== H.indexOf("blob:") ? (H = H.substr(0, H.replace(/[?#].*/, "").lastIndexOf("/") + 1)) : (H = ""),
+        F ||
+          ((la = (a) => {
+            var b = new XMLHttpRequest();
+            b.open("GET", a, !1);
+            b.send(null);
+            return b.responseText;
+          }),
+          E &&
+            (ma = (a) => {
+              var b = new XMLHttpRequest();
+              b.open("GET", a, !1);
+              b.responseType = "arraybuffer";
+              b.send(null);
+              return new Uint8Array(b.response);
+            }),
+          (I = (a, b, c) => {
+            var e = new XMLHttpRequest();
+            e.open("GET", a, !0);
+            e.responseType = "arraybuffer";
+            e.onload = () => {
+              200 == e.status || (0 == e.status && e.response) ? b(e.response) : c();
+            };
+            e.onerror = c;
+            e.send(null);
+          }));
+    F && "undefined" == typeof performance && (global.performance = require("perf_hooks").performance);
+    var oa = console.log.bind(console),
+      pa = console.error.bind(console);
+    F && ((oa = (...a) => fs.writeSync(1, a.join(" ") + "\n")), (pa = (...a) => fs.writeSync(2, a.join(" ") + "\n")));
+    var qa = B.print || oa,
+      J = B.printErr || pa;
+    Object.assign(B, ha);
+    ha = null;
+    B.thisProgram && (ia = B.thisProgram);
+    B.quit && (D = B.quit);
+    var K;
+    B.wasmBinary && (K = B.wasmBinary);
+    var noExitRuntime = B.noExitRuntime || !0;
+    "object" != typeof WebAssembly && L("no native wasm support detected");
+    var l,
+      M,
+      ra,
+      N = !1,
+      P,
+      p,
+      aa,
+      ba,
+      ca,
+      ea;
+    function q() {
+      var a = l.buffer;
+      B.HEAP8 = p = new Int8Array(a);
+      B.HEAP16 = new Int16Array(a);
+      B.HEAP32 = ba = new Int32Array(a);
+      B.HEAPU8 = aa = new Uint8Array(a);
+      B.HEAPU16 = new Uint16Array(a);
+      B.HEAPU32 = ca = new Uint32Array(a);
+      B.HEAPF32 = new Float32Array(a);
+      B.HEAPF64 = ea = new Float64Array(a);
+    }
+    var sa = B.INITIAL_MEMORY || 16777216;
+    5242880 <= sa || L("INITIAL_MEMORY should be larger than STACK_SIZE, was " + sa + "! (STACK_SIZE=5242880)");
+    if (G) l = B.wasmMemory;
+    else if (B.wasmMemory) l = B.wasmMemory;
+    else if (
+      ((l = new WebAssembly.Memory({ initial: sa / 65536, maximum: 65536, shared: !0 })),
+      !(l.buffer instanceof SharedArrayBuffer))
+    )
+      throw (
+        (J(
+          "requested a shared WebAssembly.Memory but the returned buffer is not a SharedArrayBuffer, indicating that while the browser has SharedArrayBuffer it does not have WebAssembly threads support - you may need to set a flag",
+        ),
+        F &&
+          J(
+            "(on node you may need: --experimental-wasm-threads --experimental-wasm-bulk-memory and/or recent version)",
+          ),
+        Error("bad memory"))
+      );
+    q();
+    sa = l.buffer.byteLength;
+    var ta = [],
+      ua = [],
+      va = [],
+      wa = 0;
+    function xa() {
+      return noExitRuntime || 0 < wa;
+    }
+    var Q = 0,
+      ya = null,
+      R = null;
+    function za() {
+      Q++;
+      B.monitorRunDependencies && B.monitorRunDependencies(Q);
+    }
+    function Aa() {
+      Q--;
+      B.monitorRunDependencies && B.monitorRunDependencies(Q);
+      if (0 == Q && (null !== ya && (clearInterval(ya), (ya = null)), R)) {
+        var a = R;
+        R = null;
+        a();
+      }
+    }
+    function L(a) {
+      if (B.onAbort) B.onAbort(a);
+      a = "Aborted(" + a + ")";
+      J(a);
+      N = !0;
+      P = 1;
+      a = new WebAssembly.RuntimeError(a + ". Build with -sASSERTIONS for more info.");
+      C(a);
+      throw a;
+    }
+    function Ba(a) {
+      return a.startsWith("data:application/octet-stream;base64,");
+    }
+    var S;
+    S = "ort-wasm-simd-threaded.wasm";
+    Ba(S) || (S = ka(S));
+    function Ca(a) {
+      if (a == S && K) return new Uint8Array(K);
+      if (ma) return ma(a);
+      throw "both async and sync fetching of the wasm failed";
+    }
+    function Da(a) {
+      if (!K && (ja || E)) {
+        if ("function" == typeof fetch && !a.startsWith("file://"))
+          return fetch(a, { credentials: "same-origin" })
+            .then((b) => {
+              if (!b.ok) throw "failed to load wasm binary file at '" + a + "'";
+              return b.arrayBuffer();
+            })
+            .catch(() => Ca(a));
+        if (I)
+          return new Promise((b, c) => {
+            I(a, (e) => b(new Uint8Array(e)), c);
+          });
+      }
+      return Promise.resolve().then(() => Ca(a));
+    }
+    function Ea(a, b, c) {
+      return Da(a)
+        .then((e) => WebAssembly.instantiate(e, b))
+        .then((e) => e)
+        .then(c, (e) => {
+          J("failed to asynchronously prepare wasm: " + e);
+          L(e);
+        });
+    }
+    function Fa(a, b) {
+      var c = S;
+      return K ||
+        "function" != typeof WebAssembly.instantiateStreaming ||
+        Ba(c) ||
+        c.startsWith("file://") ||
+        F ||
+        "function" != typeof fetch
+        ? Ea(c, a, b)
+        : fetch(c, { credentials: "same-origin" }).then((e) =>
+            WebAssembly.instantiateStreaming(e, a).then(b, function (f) {
+              J("wasm streaming compile failed: " + f);
+              J("falling back to ArrayBuffer instantiation");
+              return Ea(c, a, b);
+            }),
+          );
+    }
+    var T,
+      Ga = {
+        898348: () => {
+          B.jsepRunPromise = new Promise(function (a) {
+            B.tb = a;
+          });
+        },
+        898443: (a) => {
+          B.tb(a);
+        },
+        898481: (a) => B.ob(a),
+        898514: (a) => B.qb(a),
+        898546: (a, b, c) => {
+          B.ab(a, b, c, !0);
+        },
+        898585: (a, b, c) => {
+          B.ab(a, b, c);
+        },
+        898618: (a) => {
+          B.xa("Abs", a, void 0);
+        },
+        898669: (a) => {
+          B.xa("Neg", a, void 0);
+        },
+        898720: (a) => {
+          B.xa("Floor", a, void 0);
+        },
+        898773: (a) => {
+          B.xa("Ceil", a, void 0);
+        },
+        898825: (a) => {
+          B.xa("Reciprocal", a, void 0);
+        },
+        898883: (a) => {
+          B.xa("Sqrt", a, void 0);
+        },
+        898935: (a) => {
+          B.xa("Exp", a, void 0);
+        },
+        898986: (a) => {
+          B.xa("Erf", a, void 0);
+        },
+        899037: (a) => {
+          B.xa("Sigmoid", a, void 0);
+        },
+        899092: (a) => {
+          B.xa("Log", a, void 0);
+        },
+        899143: (a) => {
+          B.xa("Sin", a, void 0);
+        },
+        899194: (a) => {
+          B.xa("Cos", a, void 0);
+        },
+        899245: (a) => {
+          B.xa("Tan", a, void 0);
+        },
+        899296: (a) => {
+          B.xa("Asin", a, void 0);
+        },
+        899348: (a) => {
+          B.xa("Acos", a, void 0);
+        },
+        899400: (a) => {
+          B.xa("Atan", a, void 0);
+        },
+        899452: (a) => {
+          B.xa("Sinh", a, void 0);
+        },
+        899504: (a) => {
+          B.xa("Cosh", a, void 0);
+        },
+        899556: (a) => {
+          B.xa("Asinh", a, void 0);
+        },
+        899609: (a) => {
+          B.xa("Acosh", a, void 0);
+        },
+        899662: (a) => {
+          B.xa("Atanh", a, void 0);
+        },
+        899715: (a) => {
+          B.xa("Tanh", a, void 0);
+        },
+        899767: (a, b, c) => {
+          B.xa("ClipV10", a, { min: b, max: c });
+        },
+        899839: (a) => {
+          B.xa("Clip", a, void 0);
+        },
+        899891: (a, b) => {
+          B.xa("Elu", a, { alpha: b });
+        },
+        899949: (a) => {
+          B.xa("Relu", a, void 0);
+        },
+        900001: (a, b) => {
+          B.xa("LeakyRelu", a, { alpha: b });
+        },
+        900065: (a, b) => {
+          B.xa("ThresholdedRelu", a, { alpha: b });
+        },
+        900135: (a, b) => {
+          B.xa("Cast", a, { to: b });
+        },
+        900193: (a) => {
+          B.xa("Add", a, void 0);
+        },
+        900244: (a) => {
+          B.xa("Sub", a, void 0);
+        },
+        900295: (a) => {
+          B.xa("Mul", a, void 0);
+        },
+        900346: (a) => {
+          B.xa("Div", a, void 0);
+        },
+        900397: (a) => {
+          B.xa("Pow", a, void 0);
+        },
+        900448: (a, b, c, e, f) => {
+          B.xa("ReduceMean", a, {
+            keepDims: !!b,
+            noopWithEmptyAxes: !!c,
+            axes: e ? Array.from(z().subarray(f >>> 0, (f + e) >>> 0)) : [],
+          });
+        },
+        900612: (a, b, c, e, f) => {
+          B.xa("ReduceMax", a, {
+            keepDims: !!b,
+            noopWithEmptyAxes: !!c,
+            axes: e ? Array.from(z().subarray(f >>> 0, (f + e) >>> 0)) : [],
+          });
+        },
+        900775: (a, b, c, e, f) => {
+          B.xa("ReduceMin", a, {
+            keepDims: !!b,
+            noopWithEmptyAxes: !!c,
+            axes: e ? Array.from(z().subarray(f >>> 0, (f + e) >>> 0)) : [],
+          });
+        },
+        900938: (a, b, c, e, f) => {
+          B.xa("ReduceProd", a, {
+            keepDims: !!b,
+            noopWithEmptyAxes: !!c,
+            axes: e ? Array.from(z().subarray(f >>> 0, (f + e) >>> 0)) : [],
+          });
+        },
+        901102: (a, b, c, e, f) => {
+          B.xa("ReduceSum", a, {
+            keepDims: !!b,
+            noopWithEmptyAxes: !!c,
+            axes: e ? Array.from(z().subarray(f >>> 0, (f + e) >>> 0)) : [],
+          });
+        },
+        901265: (a, b, c, e, f) => {
+          B.xa("ReduceL1", a, {
+            keepDims: !!b,
+            noopWithEmptyAxes: !!c,
+            axes: e ? Array.from(z().subarray(f >>> 0, (f + e) >>> 0)) : [],
+          });
+        },
+        901427: (a, b, c, e, f) => {
+          B.xa("ReduceL2", a, {
+            keepDims: !!b,
+            noopWithEmptyAxes: !!c,
+            axes: e ? Array.from(z().subarray(f >>> 0, (f + e) >>> 0)) : [],
+          });
+        },
+        901589: (a, b, c, e, f) => {
+          B.xa("ReduceLogSum", a, {
+            keepDims: !!b,
+            noopWithEmptyAxes: !!c,
+            axes: e ? Array.from(z().subarray(f >>> 0, (f + e) >>> 0)) : [],
+          });
+        },
+        901755: (a, b, c, e, f) => {
+          B.xa("ReduceSumSquare", a, {
+            keepDims: !!b,
+            noopWithEmptyAxes: !!c,
+            axes: e ? Array.from(z().subarray(f >>> 0, (f + e) >>> 0)) : [],
+          });
+        },
+        901924: (a, b, c, e, f) => {
+          B.xa("ReduceLogSumExp", a, {
+            keepDims: !!b,
+            noopWithEmptyAxes: !!c,
+            axes: e ? Array.from(z().subarray(f >>> 0, (f + e) >>> 0)) : [],
+          });
+        },
+        902093: (a, b, c) => {
+          B.xa("Transpose", a, { perm: b ? Array.from(z().subarray(c >>> 0, (c + b) >>> 0)) : [] });
+        },
+        902206: (a, b, c, e, f, h, k, m, v, n) => {
+          B.xa("Conv", a, {
+            format: v ? "NHWC" : "NCHW",
+            auto_pad: b,
+            dilations: [c],
+            group: e,
+            kernel_shape: [f],
+            pads: [h, k],
+            strides: [m],
+            w_is_const: () => !!d()[n >>> 0],
+          });
+        },
+        902434: (a, b, c, e, f, h, k, m, v, n, r, x, y, g, t) => {
+          B.xa("Conv", a, {
+            format: g ? "NHWC" : "NCHW",
+            auto_pad: b,
+            dilations: [c, e],
+            group: f,
+            kernel_shape: [h, k],
+            pads: [m, v, n, r],
+            strides: [x, y],
+            w_is_const: () => !!d()[t >>> 0],
+          });
+        },
+        902693: (a, b, c, e, f, h, k, m, v, n) => {
+          B.xa("Conv", a, {
+            format: v ? "NHWC" : "NCHW",
+            auto_pad: b,
+            dilations: [c],
+            group: e,
+            kernel_shape: [f],
+            pads: [h, k],
+            strides: [m],
+            w_is_const: () => !!d()[n >>> 0],
+          });
+        },
+        902921: (a, b, c, e, f, h, k, m, v, n, r, x, y, g, t) => {
+          B.xa("Conv", a, {
+            format: g ? "NHWC" : "NCHW",
+            auto_pad: b,
+            dilations: [c, e],
+            group: f,
+            kernel_shape: [h, k],
+            pads: [m, v, n, r],
+            strides: [x, y],
+            w_is_const: () => !!d()[t >>> 0],
+          });
+        },
+        903180: (a, b, c, e, f, h, k, m, v, n, r, x, y, g) => {
+          B.xa("ConvTranspose", a, {
+            format: v ? "NHWC" : "NCHW",
+            autoPad: b,
+            dilations: [c],
+            group: e,
+            kernel_shape: [f],
+            pads: [h, k],
+            strides: [m],
+            wIsConst: () => !!d()[n >>> 0],
+            outputPadding: r ? Array.from(z().subarray(x >>> 0, (x + r) >>> 0)) : [],
+            outputShape: y ? Array.from(z().subarray(g >>> 0, (g + y) >>> 0)) : [],
+          });
+        },
+        903560: (a, b, c, e, f, h, k, m, v, n, r, x, y) => {
+          B.xa("ConvTranspose", a, {
+            format: m ? "NHWC" : "NCHW",
+            autoPad: b,
+            dilations: Array.from(z().subarray(c >>> 0, (c + 2) >>> 0)),
+            group: e,
+            kernelShape: Array.from(z().subarray(f >>> 0, (f + 2) >>> 0)),
+            pads: Array.from(z().subarray(h >>> 0, (h + 4) >>> 0)),
+            strides: Array.from(z().subarray(k >>> 0, (k + 2) >>> 0)),
+            wIsConst: () => !!d()[v >>> 0],
+            outputPadding: 0 < n ? Array.from(z().subarray(r >>> 0, (r + n) >>> 0)) : [],
+            outputShape: 0 < x ? Array.from(z().subarray(y >>> 0, (y + x) >>> 0)) : [],
+          });
+        },
+        904083: (a, b, c, e, f, h, k, m, v, n, r, x, y, g) => {
+          B.xa("ConvTranspose", a, {
+            format: v ? "NHWC" : "NCHW",
+            autoPad: b,
+            dilations: [c],
+            group: e,
+            kernel_shape: [f],
+            pads: [h, k],
+            strides: [m],
+            wIsConst: () => !!d()[n >>> 0],
+            outputPadding: r ? Array.from(z().subarray(x >>> 0, (x + r) >>> 0)) : [],
+            outputShape: y ? Array.from(z().subarray(g >>> 0, (g + y) >>> 0)) : [],
+          });
+        },
+        904463: (a, b, c, e, f, h, k, m, v, n, r, x, y) => {
+          B.xa("ConvTranspose", a, {
+            format: m ? "NHWC" : "NCHW",
+            autoPad: b,
+            dilations: Array.from(z().subarray(c >>> 0, (c + 2) >>> 0)),
+            group: e,
+            kernelShape: Array.from(z().subarray(f >>> 0, (f + 2) >>> 0)),
+            pads: Array.from(z().subarray(h >>> 0, (h + 4) >>> 0)),
+            strides: Array.from(z().subarray(k >>> 0, (k + 2) >>> 0)),
+            wIsConst: () => !!d()[v >>> 0],
+            outputPadding: 0 < n ? Array.from(z().subarray(r >>> 0, (r + n) >>> 0)) : [],
+            outputShape: 0 < x ? Array.from(z().subarray(y >>> 0, (y + x) >>> 0)) : [],
+          });
+        },
+        904986: (a, b) => {
+          B.xa("GlobalAveragePool", a, { format: b ? "NHWC" : "NCHW" });
+        },
+        905077: (a, b, c, e, f, h, k, m, v, n, r, x, y, g, t, w) => {
+          B.xa("AveragePool", a, {
+            format: w ? "NHWC" : "NCHW",
+            auto_pad: b,
+            ceil_mode: c,
+            count_include_pad: e,
+            storage_order: f,
+            dilations: [h, k],
+            kernel_shape: [m, v],
+            pads: [n, r, x, y],
+            strides: [g, t],
+          });
+        },
+        905361: (a, b) => {
+          B.xa("GlobalAveragePool", a, { format: b ? "NHWC" : "NCHW" });
+        },
+        905452: (a, b, c, e, f, h, k, m, v, n, r, x, y, g, t, w) => {
+          B.xa("AveragePool", a, {
+            format: w ? "NHWC" : "NCHW",
+            auto_pad: b,
+            ceil_mode: c,
+            count_include_pad: e,
+            storage_order: f,
+            dilations: [h, k],
+            kernel_shape: [m, v],
+            pads: [n, r, x, y],
+            strides: [g, t],
+          });
+        },
+        905736: (a, b) => {
+          B.xa("GlobalMaxPool", a, { format: b ? "NHWC" : "NCHW" });
+        },
+        905823: (a, b, c, e, f, h, k, m, v, n, r, x, y, g, t, w) => {
+          B.xa("MaxPool", a, {
+            format: w ? "NHWC" : "NCHW",
+            auto_pad: b,
+            ceil_mode: c,
+            count_include_pad: e,
+            storage_order: f,
+            dilations: [h, k],
+            kernel_shape: [m, v],
+            pads: [n, r, x, y],
+            strides: [g, t],
+          });
+        },
+        906103: (a, b) => {
+          B.xa("GlobalMaxPool", a, { format: b ? "NHWC" : "NCHW" });
+        },
+        906190: (a, b, c, e, f, h, k, m, v, n, r, x, y, g, t, w) => {
+          B.xa("MaxPool", a, {
+            format: w ? "NHWC" : "NCHW",
+            auto_pad: b,
+            ceil_mode: c,
+            count_include_pad: e,
+            storage_order: f,
+            dilations: [h, k],
+            kernel_shape: [m, v],
+            pads: [n, r, x, y],
+            strides: [g, t],
+          });
+        },
+        906470: (a, b, c, e, f) => {
+          B.xa("Gemm", a, { alpha: b, beta: c, transA: e, transB: f });
+        },
+        906574: (a) => {
+          B.xa("MatMul", a, void 0);
+        },
+        906628: (a, b, c, e) => {
+          B.xa("ArgMax", a, { keepDims: !!b, selectLastIndex: !!c, axis: e });
+        },
+        906736: (a, b, c, e) => {
+          B.xa("ArgMin", a, { keepDims: !!b, selectLastIndex: !!c, axis: e });
+        },
+        906844: (a, b) => {
+          B.xa("Softmax", a, { axis: b });
+        },
+        906907: (a, b) => {
+          B.xa("Concat", a, { axis: b });
+        },
+        906967: (a, b, c, e, f) => {
+          B.xa("Split", a, {
+            axis: b,
+            numOutputs: c,
+            splitSizes: e ? Array.from(z().subarray(f >>> 0, (f + e) >>> 0)) : [],
+          });
+        },
+        907112: (a) => {
+          B.xa("Expand", a, void 0);
+        },
+        907166: (a, b) => {
+          B.xa("Gather", a, { axis: Number(b) });
+        },
+        907237: (a, b, c, e, f, h, k, m, v, n, r) => {
+          B.xa("Resize", a, {
+            antialias: b,
+            axes: c ? Array.from(z().subarray(e >>> 0, (e + c) >>> 0)) : [],
+            coordinateTransformMode: U(f),
+            cubicCoeffA: h,
+            excludeOutside: k,
+            extrapolationValue: m,
+            keepAspectRatioPolicy: U(v),
+            mode: U(n),
+            nearestMode: U(r),
+          });
+        },
+        907588: (a, b, c, e, f, h, k) => {
+          B.xa("Slice", a, {
+            starts: b ? Array.from(z().subarray(c >>> 0, (c + b) >>> 0)) : [],
+            ends: e ? Array.from(z().subarray(f >>> 0, (f + e) >>> 0)) : [],
+            axes: h ? Array.from(z().subarray(k >>> 0, (k + h) >>> 0)) : [],
+          });
+        },
+        907819: (a) => {
+          B.xa("Tile", a, void 0);
+        },
+        907871: (a, b, c) => {
+          B.xa("LayerNormalization", a, { axis: Number(b), epsilon: Number(c) });
+        },
+        907978: (a, b, c) => {
+          B.xa("InstanceNormalization", a, { epsilon: b, format: c ? "NHWC" : "NCHW" });
+        },
+        908092: (a, b, c) => {
+          B.xa("InstanceNormalization", a, { epsilon: b, format: c ? "NHWC" : "NCHW" });
+        },
+        908206: (a) => {
+          B.xa("Gelu", a, void 0);
+        },
+        908258: (a, b) => {
+          B.xa("SkipLayerNormalization", a, { epsilon: b });
+        },
+        908339: (a) => {
+          B.rb(a);
+        },
+        908373: (a, b) => B.sb(a, b),
+      };
+    function Ha(a) {
+      this.name = "ExitStatus";
+      this.message = `Program terminated with exit(${a})`;
+      this.status = a;
+    }
+    function Ia(a) {
+      a.terminate();
+      a.onmessage = () => {};
+    }
+    function Ja(a) {
+      (a = V.Ja[a]) || L();
+      V.xb(a);
+    }
+    function Ka(a) {
+      var b = V.lb();
+      if (!b) return 6;
+      V.Ra.push(b);
+      V.Ja[a.Qa] = b;
+      b.Qa = a.Qa;
+      var c = { cmd: "run", start_routine: a.yb, arg: a.jb, pthread_ptr: a.Qa };
+      F && b.unref();
+      b.postMessage(c, a.Eb);
+      return 0;
+    }
+    var La = "undefined" != typeof TextDecoder ? new TextDecoder("utf8") : void 0,
+      Ma = (a, b, c) => {
+        b >>>= 0;
+        var e = b + c;
+        for (c = b; a[c] && !(c >= e); ) ++c;
+        if (16 < c - b && a.buffer && La)
+          return La.decode(a.buffer instanceof SharedArrayBuffer ? a.slice(b, c) : a.subarray(b, c));
+        for (e = ""; b < c; ) {
+          var f = a[b++];
+          if (f & 128) {
+            var h = a[b++] & 63;
+            if (192 == (f & 224)) e += String.fromCharCode(((f & 31) << 6) | h);
+            else {
+              var k = a[b++] & 63;
+              f =
+                224 == (f & 240)
+                  ? ((f & 15) << 12) | (h << 6) | k
+                  : ((f & 7) << 18) | (h << 12) | (k << 6) | (a[b++] & 63);
+              65536 > f
+                ? (e += String.fromCharCode(f))
+                : ((f -= 65536), (e += String.fromCharCode(55296 | (f >> 10), 56320 | (f & 1023))));
+            }
+          } else e += String.fromCharCode(f);
+        }
+        return e;
+      },
+      U = (a, b) => ((a >>>= 0) ? Ma(u(), a, b) : "");
+    function Na(a) {
+      if (G) return W(1, 1, a);
+      P = a;
+      if (!xa()) {
+        V.zb();
+        if (B.onExit) B.onExit(a);
+        N = !0;
+      }
+      D(a, new Ha(a));
+    }
+    var Pa = (a) => {
+        P = a;
+        if (G) throw (Oa(a), "unwind");
+        Na(a);
+      },
+      V = {
+        Ua: [],
+        Ra: [],
+        eb: [],
+        Ja: {},
+        Xa: function () {
+          G ? V.nb() : V.mb();
+        },
+        mb: function () {
+          ta.unshift(() => {
+            za();
+            V.ub(() => Aa());
+          });
+        },
+        nb: function () {
+          V.receiveObjectTransfer = V.wb;
+          V.threadInitTLS = V.cb;
+          V.setExitStatus = V.bb;
+          noExitRuntime = !1;
+        },
+        bb: function (a) {
+          P = a;
+        },
+        Kb: ["$terminateWorker"],
+        zb: function () {
+          for (var a of V.Ra) Ia(a);
+          for (a of V.Ua) Ia(a);
+          V.Ua = [];
+          V.Ra = [];
+          V.Ja = [];
+        },
+        xb: function (a) {
+          var b = a.Qa;
+          delete V.Ja[b];
+          V.Ua.push(a);
+          V.Ra.splice(V.Ra.indexOf(a), 1);
+          a.Qa = 0;
+          Qa(b);
+        },
+        wb: function () {},
+        cb: function () {
+          V.eb.forEach((a) => a());
+        },
+        vb: (a) =>
+          new Promise((b) => {
+            a.onmessage = (h) => {
+              h = h.data;
+              var k = h.cmd;
+              if (h.targetThread && h.targetThread != Ra()) {
+                var m = V.Ja[h.Jb];
+                m
+                  ? m.postMessage(h, h.transferList)
+                  : J(
+                      'Internal error! Worker sent a message "' +
+                        k +
+                        '" to target pthread ' +
+                        h.targetThread +
+                        ", but that thread no longer exists!",
+                    );
+              } else if ("checkMailbox" === k) Sa();
+              else if ("spawnThread" === k) Ka(h);
+              else if ("cleanupThread" === k) Ja(h.thread);
+              else if ("killThread" === k)
+                (h = h.thread),
+                  (k = V.Ja[h]),
+                  delete V.Ja[h],
+                  Ia(k),
+                  Qa(h),
+                  V.Ra.splice(V.Ra.indexOf(k), 1),
+                  (k.Qa = 0);
+              else if ("cancelThread" === k) V.Ja[h.thread].postMessage({ cmd: "cancel" });
+              else if ("loaded" === k) (a.loaded = !0), b(a);
+              else if ("alert" === k) alert("Thread " + h.threadId + ": " + h.text);
+              else if ("setimmediate" === h.target) a.postMessage(h);
+              else if ("callHandler" === k) B[h.handler](...h.args);
+              else k && J("worker sent an unknown command " + k);
+            };
+            a.onerror = (h) => {
+              J("worker sent an error! " + h.filename + ":" + h.lineno + ": " + h.message);
+              throw h;
+            };
+            F &&
+              (a.on("message", function (h) {
+                a.onmessage({ data: h });
+              }),
+              a.on("error", function (h) {
+                a.onerror(h);
+              }));
+            var c = [],
+              e = ["onExit", "onAbort", "print", "printErr"],
+              f;
+            for (f of e) B.hasOwnProperty(f) && c.push(f);
+            a.postMessage({
+              cmd: "load",
+              handlers: c,
+              urlOrBlob: B.mainScriptUrlOrBlob || _scriptDir,
+              wasmMemory: l,
+              wasmModule: ra,
+            });
+          }),
+        ub: function (a) {
+          a();
+        },
+        ib: function () {
+          var a = ka("ort-wasm-simd-threaded.worker.js");
+          a = new Worker(a);
+          V.Ua.push(a);
+        },
+        lb: function () {
+          0 == V.Ua.length && (V.ib(), V.vb(V.Ua[0]));
+          return V.Ua.pop();
+        },
+      };
+    B.PThread = V;
+    var Ta = (a) => {
+      for (; 0 < a.length; ) a.shift()(B);
+    };
+    B.establishStackSpace = function () {
+      var a = Ra(),
+        b = z()[((a + 52) >> 2) >>> 0];
+      a = z()[((a + 56) >> 2) >>> 0];
+      Ua(b, b - a);
+      Va(b);
+    };
+    function Oa(a) {
+      if (G) return W(2, 0, a);
+      Pa(a);
+    }
+    B.invokeEntryPoint = function (a, b) {
+      a = Wa.apply(null, [a, b]);
+      xa() ? V.bb(a) : Xa(a);
+    };
+    function Ya(a) {
+      this.$a = a - 24;
+      this.hb = function (b) {
+        A()[((this.$a + 4) >> 2) >>> 0] = b;
+      };
+      this.gb = function (b) {
+        A()[((this.$a + 8) >> 2) >>> 0] = b;
+      };
+      this.Xa = function (b, c) {
+        this.fb();
+        this.hb(b);
+        this.gb(c);
+      };
+      this.fb = function () {
+        A()[((this.$a + 16) >> 2) >>> 0] = 0;
+      };
+    }
+    var Za = 0,
+      $a = 0;
+    function ab(a, b, c, e) {
+      return G ? W(3, 1, a, b, c, e) : bb(a, b, c, e);
+    }
+    function bb(a, b, c, e) {
+      a >>>= 0;
+      b >>>= 0;
+      c >>>= 0;
+      e >>>= 0;
+      if ("undefined" == typeof SharedArrayBuffer)
+        return J("Current environment does not support SharedArrayBuffer, pthreads are not available!"), 6;
+      var f = [];
+      if (G && 0 === f.length) return ab(a, b, c, e);
+      a = { yb: c, Qa: a, jb: e, Eb: f };
+      return G ? ((a.Gb = "spawnThread"), postMessage(a, f), 0) : Ka(a);
+    }
+    function cb(a, b, c) {
+      return G ? W(4, 1, a, b, c) : 0;
+    }
+    function db(a, b) {
+      if (G) return W(5, 1, a, b);
+    }
+    var eb = (a) => {
+        for (var b = 0, c = 0; c < a.length; ++c) {
+          var e = a.charCodeAt(c);
+          127 >= e ? b++ : 2047 >= e ? (b += 2) : 55296 <= e && 57343 >= e ? ((b += 4), ++c) : (b += 3);
+        }
+        return b;
+      },
+      fb = (a, b, c, e) => {
+        c >>>= 0;
+        if (!(0 < e)) return 0;
+        var f = c;
+        e = c + e - 1;
+        for (var h = 0; h < a.length; ++h) {
+          var k = a.charCodeAt(h);
+          if (55296 <= k && 57343 >= k) {
+            var m = a.charCodeAt(++h);
+            k = (65536 + ((k & 1023) << 10)) | (m & 1023);
+          }
+          if (127 >= k) {
+            if (c >= e) break;
+            b[c++ >>> 0] = k;
+          } else {
+            if (2047 >= k) {
+              if (c + 1 >= e) break;
+              b[c++ >>> 0] = 192 | (k >> 6);
+            } else {
+              if (65535 >= k) {
+                if (c + 2 >= e) break;
+                b[c++ >>> 0] = 224 | (k >> 12);
+              } else {
+                if (c + 3 >= e) break;
+                b[c++ >>> 0] = 240 | (k >> 18);
+                b[c++ >>> 0] = 128 | ((k >> 12) & 63);
+              }
+              b[c++ >>> 0] = 128 | ((k >> 6) & 63);
+            }
+            b[c++ >>> 0] = 128 | (k & 63);
+          }
+        }
+        b[c >>> 0] = 0;
+        return c - f;
+      },
+      gb = (a, b, c) => fb(a, u(), b, c);
+    function hb(a, b) {
+      if (G) return W(6, 1, a, b);
+    }
+    function ib(a, b, c) {
+      if (G) return W(7, 1, a, b, c);
+    }
+    function jb(a, b, c) {
+      return G ? W(8, 1, a, b, c) : 0;
+    }
+    function kb(a, b) {
+      if (G) return W(9, 1, a, b);
+    }
+    function lb(a, b, c) {
+      if (G) return W(10, 1, a, b, c);
+    }
+    function mb(a, b, c, e) {
+      if (G) return W(11, 1, a, b, c, e);
+    }
+    function nb(a, b, c, e) {
+      if (G) return W(12, 1, a, b, c, e);
+    }
+    function ob(a, b, c, e) {
+      if (G) return W(13, 1, a, b, c, e);
+    }
+    function pb(a) {
+      if (G) return W(14, 1, a);
+    }
+    function qb(a, b) {
+      if (G) return W(15, 1, a, b);
+    }
+    function rb(a, b, c) {
+      if (G) return W(16, 1, a, b, c);
+    }
+    var sb = (a) => {
+      if (!N)
+        try {
+          if ((a(), !xa()))
+            try {
+              G ? Xa(P) : Pa(P);
+            } catch (b) {
+              b instanceof Ha || "unwind" == b || D(1, b);
+            }
+        } catch (b) {
+          b instanceof Ha || "unwind" == b || D(1, b);
+        }
+    };
+    function tb(a) {
+      a >>>= 0;
+      "function" === typeof Atomics.Fb &&
+        (Atomics.Fb(z(), a >> 2, a).value.then(Sa), (a += 128), Atomics.store(z(), a >> 2, 1));
+    }
+    B.__emscripten_thread_mailbox_await = tb;
+    function Sa() {
+      var a = Ra();
+      a && (tb(a), sb(() => ub()));
+    }
+    B.checkMailbox = Sa;
+    var X = (a) => 0 === a % 4 && (0 !== a % 100 || 0 === a % 400),
+      vb = [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335],
+      wb = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334];
+    function xb(a, b, c, e, f, h, k, m) {
+      return G ? W(17, 1, a, b, c, e, f, h, k, m) : -52;
+    }
+    function yb(a, b, c, e, f, h, k) {
+      if (G) return W(18, 1, a, b, c, e, f, h, k);
+    }
+    var Ab = (a) => {
+        var b = eb(a) + 1,
+          c = zb(b);
+        c && gb(a, c, b);
+        return c;
+      },
+      Bb = [],
+      Cb = (a, b) => {
+        Bb.length = 0;
+        var c;
+        for (b >>= 2; (c = u()[a++ >>> 0]); )
+          (b += (105 != c) & b), Bb.push(105 == c ? z()[b >>> 0] : da()[b++ >>> 1]), ++b;
+        return Bb;
+      },
+      Eb = (a) => {
+        var b = Db();
+        a = a();
+        Va(b);
+        return a;
+      };
+    function W(a, b) {
+      var c = arguments.length - 2,
+        e = arguments;
+      return Eb(() => {
+        for (var f = Fb(8 * c), h = f >> 3, k = 0; k < c; k++) {
+          var m = e[2 + k];
+          da()[(h + k) >>> 0] = m;
+        }
+        return Gb(a, c, f, b);
+      });
+    }
+    var Hb = [],
+      Ib = {},
+      Kb = () => {
+        if (!Jb) {
+          var a = {
+              USER: "web_user",
+              LOGNAME: "web_user",
+              PATH: "/",
+              PWD: "/",
+              HOME: "/home/web_user",
+              LANG:
+                (("object" == typeof navigator && navigator.languages && navigator.languages[0]) || "C").replace(
+                  "-",
+                  "_",
+                ) + ".UTF-8",
+              _: ia || "./this.program",
+            },
+            b;
+          for (b in Ib) void 0 === Ib[b] ? delete a[b] : (a[b] = Ib[b]);
+          var c = [];
+          for (b in a) c.push(`${b}=${a[b]}`);
+          Jb = c;
+        }
+        return Jb;
+      },
+      Jb;
+    function Lb(a, b) {
+      if (G) return W(19, 1, a, b);
+      a >>>= 0;
+      b >>>= 0;
+      var c = 0;
+      Kb().forEach(function (e, f) {
+        var h = b + c;
+        f = A()[((a + 4 * f) >> 2) >>> 0] = h;
+        for (h = 0; h < e.length; ++h) d()[(f++ >> 0) >>> 0] = e.charCodeAt(h);
+        d()[(f >> 0) >>> 0] = 0;
+        c += e.length + 1;
+      });
+      return 0;
+    }
+    function Mb(a, b) {
+      if (G) return W(20, 1, a, b);
+      a >>>= 0;
+      b >>>= 0;
+      var c = Kb();
+      A()[(a >> 2) >>> 0] = c.length;
+      var e = 0;
+      c.forEach(function (f) {
+        e += f.length + 1;
+      });
+      A()[(b >> 2) >>> 0] = e;
+      return 0;
+    }
+    function Nb(a) {
+      return G ? W(21, 1, a) : 52;
+    }
+    function Ob(a, b, c, e) {
+      return G ? W(22, 1, a, b, c, e) : 52;
+    }
+    function Pb(a, b, c, e, f) {
+      return G ? W(23, 1, a, b, c, e, f) : 70;
+    }
+    var Qb = [null, [], []];
+    function Rb(a, b, c, e) {
+      if (G) return W(24, 1, a, b, c, e);
+      b >>>= 0;
+      c >>>= 0;
+      e >>>= 0;
+      for (var f = 0, h = 0; h < c; h++) {
+        var k = A()[(b >> 2) >>> 0],
+          m = A()[((b + 4) >> 2) >>> 0];
+        b += 8;
+        for (var v = 0; v < m; v++) {
+          var n = u()[(k + v) >>> 0],
+            r = Qb[a];
+          0 === n || 10 === n ? ((1 === a ? qa : J)(Ma(r, 0)), (r.length = 0)) : r.push(n);
+        }
+        f += m;
+      }
+      A()[(e >> 2) >>> 0] = f;
+      return 0;
+    }
+    var Tb = () => {
+        if ("object" == typeof crypto && "function" == typeof crypto.getRandomValues)
+          return (c) => (c.set(crypto.getRandomValues(new Uint8Array(c.byteLength))), c);
+        if (F)
+          try {
+            var a = require("crypto");
+            if (a.randomFillSync) return (c) => a.randomFillSync(c);
+            var b = a.randomBytes;
+            return (c) => (c.set(b(c.byteLength)), c);
+          } catch (c) {}
+        L("initRandomDevice");
+      },
+      Ub = (a) => (Ub = Tb())(a),
+      Vb = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+      Wb = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    function Xb(a) {
+      var b = Array(eb(a) + 1);
+      fb(a, b, 0, b.length);
+      return b;
+    }
+    var Yb = (a, b) => {
+      d().set(a, b >>> 0);
+    };
+    function Zb(a, b, c, e) {
+      function f(g, t, w) {
+        for (g = "number" == typeof g ? g.toString() : g || ""; g.length < t; ) g = w[0] + g;
+        return g;
+      }
+      function h(g, t) {
+        return f(g, t, "0");
+      }
+      function k(g, t) {
+        function w(Sb) {
+          return 0 > Sb ? -1 : 0 < Sb ? 1 : 0;
+        }
+        var O;
+        0 === (O = w(g.getFullYear() - t.getFullYear())) &&
+          0 === (O = w(g.getMonth() - t.getMonth())) &&
+          (O = w(g.getDate() - t.getDate()));
+        return O;
+      }
+      function m(g) {
+        switch (g.getDay()) {
+          case 0:
+            return new Date(g.getFullYear() - 1, 11, 29);
+          case 1:
+            return g;
+          case 2:
+            return new Date(g.getFullYear(), 0, 3);
+          case 3:
+            return new Date(g.getFullYear(), 0, 2);
+          case 4:
+            return new Date(g.getFullYear(), 0, 1);
+          case 5:
+            return new Date(g.getFullYear() - 1, 11, 31);
+          case 6:
+            return new Date(g.getFullYear() - 1, 11, 30);
+        }
+      }
+      function v(g) {
+        var t = g.Sa;
+        for (g = new Date(new Date(g.Ta + 1900, 0, 1).getTime()); 0 < t; ) {
+          var w = g.getMonth(),
+            O = (X(g.getFullYear()) ? Vb : Wb)[w];
+          if (t > O - g.getDate())
+            (t -= O - g.getDate() + 1),
+              g.setDate(1),
+              11 > w ? g.setMonth(w + 1) : (g.setMonth(0), g.setFullYear(g.getFullYear() + 1));
+          else {
+            g.setDate(g.getDate() + t);
+            break;
+          }
+        }
+        w = new Date(g.getFullYear() + 1, 0, 4);
+        t = m(new Date(g.getFullYear(), 0, 4));
+        w = m(w);
+        return 0 >= k(t, g) ? (0 >= k(w, g) ? g.getFullYear() + 1 : g.getFullYear()) : g.getFullYear() - 1;
+      }
+      a >>>= 0;
+      b >>>= 0;
+      c >>>= 0;
+      e >>>= 0;
+      var n = z()[((e + 40) >> 2) >>> 0];
+      e = {
+        Cb: z()[(e >> 2) >>> 0],
+        Bb: z()[((e + 4) >> 2) >>> 0],
+        Va: z()[((e + 8) >> 2) >>> 0],
+        Za: z()[((e + 12) >> 2) >>> 0],
+        Wa: z()[((e + 16) >> 2) >>> 0],
+        Ta: z()[((e + 20) >> 2) >>> 0],
+        Pa: z()[((e + 24) >> 2) >>> 0],
+        Sa: z()[((e + 28) >> 2) >>> 0],
+        Lb: z()[((e + 32) >> 2) >>> 0],
+        Ab: z()[((e + 36) >> 2) >>> 0],
+        Db: n ? U(n) : "",
+      };
+      c = U(c);
+      n = {
+        "%c": "%a %b %d %H:%M:%S %Y",
+        "%D": "%m/%d/%y",
+        "%F": "%Y-%m-%d",
+        "%h": "%b",
+        "%r": "%I:%M:%S %p",
+        "%R": "%H:%M",
+        "%T": "%H:%M:%S",
+        "%x": "%m/%d/%y",
+        "%X": "%H:%M:%S",
+        "%Ec": "%c",
+        "%EC": "%C",
+        "%Ex": "%m/%d/%y",
+        "%EX": "%H:%M:%S",
+        "%Ey": "%y",
+        "%EY": "%Y",
+        "%Od": "%d",
+        "%Oe": "%e",
+        "%OH": "%H",
+        "%OI": "%I",
+        "%Om": "%m",
+        "%OM": "%M",
+        "%OS": "%S",
+        "%Ou": "%u",
+        "%OU": "%U",
+        "%OV": "%V",
+        "%Ow": "%w",
+        "%OW": "%W",
+        "%Oy": "%y",
+      };
+      for (var r in n) c = c.replace(new RegExp(r, "g"), n[r]);
+      var x = "Sunday Monday Tuesday Wednesday Thursday Friday Saturday".split(" "),
+        y = "January February March April May June July August September October November December".split(" ");
+      n = {
+        "%a": (g) => x[g.Pa].substring(0, 3),
+        "%A": (g) => x[g.Pa],
+        "%b": (g) => y[g.Wa].substring(0, 3),
+        "%B": (g) => y[g.Wa],
+        "%C": (g) => h(((g.Ta + 1900) / 100) | 0, 2),
+        "%d": (g) => h(g.Za, 2),
+        "%e": (g) => f(g.Za, 2, " "),
+        "%g": (g) => v(g).toString().substring(2),
+        "%G": (g) => v(g),
+        "%H": (g) => h(g.Va, 2),
+        "%I": (g) => {
+          g = g.Va;
+          0 == g ? (g = 12) : 12 < g && (g -= 12);
+          return h(g, 2);
+        },
+        "%j": (g) => {
+          for (var t = 0, w = 0; w <= g.Wa - 1; t += (X(g.Ta + 1900) ? Vb : Wb)[w++]);
+          return h(g.Za + t, 3);
+        },
+        "%m": (g) => h(g.Wa + 1, 2),
+        "%M": (g) => h(g.Bb, 2),
+        "%n": () => "\n",
+        "%p": (g) => (0 <= g.Va && 12 > g.Va ? "AM" : "PM"),
+        "%S": (g) => h(g.Cb, 2),
+        "%t": () => "\t",
+        "%u": (g) => g.Pa || 7,
+        "%U": (g) => h(Math.floor((g.Sa + 7 - g.Pa) / 7), 2),
+        "%V": (g) => {
+          var t = Math.floor((g.Sa + 7 - ((g.Pa + 6) % 7)) / 7);
+          2 >= (g.Pa + 371 - g.Sa - 2) % 7 && t++;
+          if (t) 53 == t && ((w = (g.Pa + 371 - g.Sa) % 7), 4 == w || (3 == w && X(g.Ta)) || (t = 1));
+          else {
+            t = 52;
+            var w = (g.Pa + 7 - g.Sa - 1) % 7;
+            (4 == w || (5 == w && X((g.Ta % 400) - 1))) && t++;
+          }
+          return h(t, 2);
+        },
+        "%w": (g) => g.Pa,
+        "%W": (g) => h(Math.floor((g.Sa + 7 - ((g.Pa + 6) % 7)) / 7), 2),
+        "%y": (g) => (g.Ta + 1900).toString().substring(2),
+        "%Y": (g) => g.Ta + 1900,
+        "%z": (g) => {
+          g = g.Ab;
+          var t = 0 <= g;
+          g = Math.abs(g) / 60;
+          return (t ? "+" : "-") + String("0000" + ((g / 60) * 100 + (g % 60))).slice(-4);
+        },
+        "%Z": (g) => g.Db,
+        "%%": () => "%",
+      };
+      c = c.replace(/%%/g, "\x00\x00");
+      for (r in n) c.includes(r) && (c = c.replace(new RegExp(r, "g"), n[r](e)));
+      c = c.replace(/\0\0/g, "%");
+      r = Xb(c);
+      if (r.length > b) return 0;
+      Yb(r, a);
+      return r.length - 1;
+    }
+    function $b(a) {
+      try {
+        a();
+      } catch (b) {
+        L(b);
+      }
+    }
+    function ac(a) {
+      var b = {},
+        c;
+      for (c in a)
+        (function (e) {
+          var f = a[e];
+          b[e] =
+            "function" == typeof f
+              ? function () {
+                  bc.push(e);
+                  try {
+                    return f.apply(null, arguments);
+                  } finally {
+                    N ||
+                      (bc.pop() === e || L(),
+                      Y &&
+                        1 === Z &&
+                        0 === bc.length &&
+                        ((Z = 0), (wa += 1), $b(cc), "undefined" != typeof Fibers && Fibers.Mb()));
+                  }
+                }
+              : f;
+        })(c);
+      return b;
+    }
+    var Z = 0,
+      Y = null,
+      dc = 0,
+      bc = [],
+      ec = {},
+      fc = {},
+      gc = 0,
+      hc = null,
+      ic = [];
+    function jc() {
+      var a = zb(65548),
+        b = a + 12;
+      A()[(a >> 2) >>> 0] = b;
+      A()[((a + 4) >> 2) >>> 0] = b + 65536;
+      b = bc[0];
+      var c = ec[b];
+      void 0 === c && ((c = gc++), (ec[b] = c), (fc[c] = b));
+      b = c;
+      z()[((a + 8) >> 2) >>> 0] = b;
+      return a;
+    }
+    function kc() {
+      var a = z()[((Y + 8) >> 2) >>> 0];
+      a = M[fc[a]];
+      --wa;
+      return a();
+    }
+    function lc(a) {
+      if (!N) {
+        if (0 === Z) {
+          var b = !1,
+            c = !1;
+          a((e = 0) => {
+            if (!N && ((dc = e), (b = !0), c)) {
+              Z = 2;
+              $b(() => mc(Y));
+              "undefined" != typeof Browser && Browser.Ya.kb && Browser.Ya.resume();
+              e = !1;
+              try {
+                var f = kc();
+              } catch (m) {
+                (f = m), (e = !0);
+              }
+              var h = !1;
+              if (!Y) {
+                var k = hc;
+                k && ((hc = null), (e ? k.reject : k.resolve)(f), (h = !0));
+              }
+              if (e && !h) throw f;
+            }
+          });
+          c = !0;
+          b ||
+            ((Z = 1),
+            (Y = jc()),
+            "undefined" != typeof Browser && Browser.Ya.kb && Browser.Ya.pause(),
+            $b(() => nc(Y)));
+        } else 2 === Z ? ((Z = 0), $b(oc), pc(Y), (Y = null), ic.forEach((e) => sb(e))) : L(`invalid state: ${Z}`);
+        return dc;
+      }
+    }
+    function qc(a) {
+      return lc((b) => {
+        a().then(b);
+      });
+    }
+    V.Xa();
+    var rc = [null, Na, Oa, ab, cb, db, hb, ib, jb, kb, lb, mb, nb, ob, pb, qb, rb, xb, yb, Lb, Mb, Nb, Ob, Pb, Rb],
+      uc = {
+        r: function (a, b, c) {
+          return qc(async () => {
+            await B.pb(a, b, c);
+          });
+        },
+        b: function (a, b, c) {
+          a >>>= 0;
+          new Ya(a).Xa(b >>> 0, c >>> 0);
+          Za = a;
+          $a++;
+          throw Za;
+        },
+        O: function (a) {
+          sc(a >>> 0, !E, 1, !ja, 131072, !1);
+          V.cb();
+        },
+        m: function (a) {
+          a >>>= 0;
+          G ? postMessage({ cmd: "cleanupThread", thread: a }) : Ja(a);
+        },
+        J: bb,
+        i: cb,
+        U: db,
+        G: hb,
+        I: ib,
+        V: jb,
+        S: kb,
+        K: lb,
+        R: mb,
+        q: nb,
+        H: ob,
+        E: pb,
+        T: qb,
+        F: rb,
+        Y: () => !0,
+        C: function (a, b) {
+          a >>>= 0;
+          a == b >>> 0
+            ? setTimeout(() => Sa())
+            : G
+            ? postMessage({ targetThread: a, cmd: "checkMailbox" })
+            : (a = V.Ja[a]) && a.postMessage({ cmd: "checkMailbox" });
+        },
+        M: function () {
+          return -1;
+        },
+        N: tb,
+        X: function (a) {
+          F && V.Ja[a >>> 0].ref();
+        },
+        u: function (a, b, c) {
+          a = (b + 2097152) >>> 0 < 4194305 - !!a ? (a >>> 0) + 4294967296 * b : NaN;
+          c >>>= 0;
+          a = new Date(1e3 * a);
+          z()[(c >> 2) >>> 0] = a.getUTCSeconds();
+          z()[((c + 4) >> 2) >>> 0] = a.getUTCMinutes();
+          z()[((c + 8) >> 2) >>> 0] = a.getUTCHours();
+          z()[((c + 12) >> 2) >>> 0] = a.getUTCDate();
+          z()[((c + 16) >> 2) >>> 0] = a.getUTCMonth();
+          z()[((c + 20) >> 2) >>> 0] = a.getUTCFullYear() - 1900;
+          z()[((c + 24) >> 2) >>> 0] = a.getUTCDay();
+          a = ((a.getTime() - Date.UTC(a.getUTCFullYear(), 0, 1, 0, 0, 0, 0)) / 864e5) | 0;
+          z()[((c + 28) >> 2) >>> 0] = a;
+        },
+        v: function (a, b, c) {
+          a = (b + 2097152) >>> 0 < 4194305 - !!a ? (a >>> 0) + 4294967296 * b : NaN;
+          c >>>= 0;
+          a = new Date(1e3 * a);
+          z()[(c >> 2) >>> 0] = a.getSeconds();
+          z()[((c + 4) >> 2) >>> 0] = a.getMinutes();
+          z()[((c + 8) >> 2) >>> 0] = a.getHours();
+          z()[((c + 12) >> 2) >>> 0] = a.getDate();
+          z()[((c + 16) >> 2) >>> 0] = a.getMonth();
+          z()[((c + 20) >> 2) >>> 0] = a.getFullYear() - 1900;
+          z()[((c + 24) >> 2) >>> 0] = a.getDay();
+          b = ((X(a.getFullYear()) ? vb : wb)[a.getMonth()] + a.getDate() - 1) | 0;
+          z()[((c + 28) >> 2) >>> 0] = b;
+          z()[((c + 36) >> 2) >>> 0] = -(60 * a.getTimezoneOffset());
+          b = new Date(a.getFullYear(), 6, 1).getTimezoneOffset();
+          var e = new Date(a.getFullYear(), 0, 1).getTimezoneOffset();
+          a = (b != e && a.getTimezoneOffset() == Math.min(e, b)) | 0;
+          z()[((c + 32) >> 2) >>> 0] = a;
+        },
+        w: function (a) {
+          a >>>= 0;
+          var b = new Date(
+              z()[((a + 20) >> 2) >>> 0] + 1900,
+              z()[((a + 16) >> 2) >>> 0],
+              z()[((a + 12) >> 2) >>> 0],
+              z()[((a + 8) >> 2) >>> 0],
+              z()[((a + 4) >> 2) >>> 0],
+              z()[(a >> 2) >>> 0],
+              0,
+            ),
+            c = z()[((a + 32) >> 2) >>> 0],
+            e = b.getTimezoneOffset(),
+            f = new Date(b.getFullYear(), 6, 1).getTimezoneOffset(),
+            h = new Date(b.getFullYear(), 0, 1).getTimezoneOffset(),
+            k = Math.min(h, f);
+          0 > c
+            ? (z()[((a + 32) >> 2) >>> 0] = Number(f != h && k == e))
+            : 0 < c != (k == e) && ((f = Math.max(h, f)), b.setTime(b.getTime() + 6e4 * ((0 < c ? k : f) - e)));
+          z()[((a + 24) >> 2) >>> 0] = b.getDay();
+          c = ((X(b.getFullYear()) ? vb : wb)[b.getMonth()] + b.getDate() - 1) | 0;
+          z()[((a + 28) >> 2) >>> 0] = c;
+          z()[(a >> 2) >>> 0] = b.getSeconds();
+          z()[((a + 4) >> 2) >>> 0] = b.getMinutes();
+          z()[((a + 8) >> 2) >>> 0] = b.getHours();
+          z()[((a + 12) >> 2) >>> 0] = b.getDate();
+          z()[((a + 16) >> 2) >>> 0] = b.getMonth();
+          z()[((a + 20) >> 2) >>> 0] = b.getYear();
+          a = b.getTime() / 1e3;
+          return (
+            tc(
+              ((T = a),
+              1 <= +Math.abs(T)
+                ? 0 < T
+                  ? +Math.floor(T / 4294967296) >>> 0
+                  : ~~+Math.ceil((T - +(~~T >>> 0)) / 4294967296) >>> 0
+                : 0),
+            ),
+            a >>> 0
+          );
+        },
+        s: xb,
+        t: yb,
+        A: function (a, b, c) {
+          function e(n) {
+            return (n = n.toTimeString().match(/\(([A-Za-z ]+)\)$/)) ? n[1] : "GMT";
+          }
+          a >>>= 0;
+          b >>>= 0;
+          c >>>= 0;
+          var f = new Date().getFullYear(),
+            h = new Date(f, 0, 1),
+            k = new Date(f, 6, 1);
+          f = h.getTimezoneOffset();
+          var m = k.getTimezoneOffset(),
+            v = Math.max(f, m);
+          A()[(a >> 2) >>> 0] = 60 * v;
+          z()[(b >> 2) >>> 0] = Number(f != m);
+          a = e(h);
+          b = e(k);
+          a = Ab(a);
+          b = Ab(b);
+          m < f
+            ? ((A()[(c >> 2) >>> 0] = a), (A()[((c + 4) >> 2) >>> 0] = b))
+            : ((A()[(c >> 2) >>> 0] = b), (A()[((c + 4) >> 2) >>> 0] = a));
+        },
+        d: () => {
+          L("");
+        },
+        c: function (a, b, c) {
+          a >>>= 0;
+          b = Cb(b >>> 0, c >>> 0);
+          return Ga[a].apply(null, b);
+        },
+        l: function (a, b, c) {
+          a >>>= 0;
+          b = Cb(b >>> 0, c >>> 0);
+          return Ga[a].apply(null, b);
+        },
+        n: function () {},
+        j: function () {
+          return Date.now();
+        },
+        W: () => {
+          wa += 1;
+          throw "unwind";
+        },
+        D: function () {
+          return 4294901760;
+        },
+        f: () => performance.timeOrigin + performance.now(),
+        g: function () {
+          return F ? require("os").cpus().length : navigator.hardwareConcurrency;
+        },
+        L: function (a, b, c, e) {
+          V.Hb = b >>> 0;
+          Hb.length = c;
+          b = (e >>> 0) >> 3;
+          for (e = 0; e < c; e++) Hb[e] = da()[(b + e) >>> 0];
+          return (0 > a ? Ga[-a - 1] : rc[a]).apply(null, Hb);
+        },
+        z: function (a) {
+          a >>>= 0;
+          var b = u().length;
+          if (a <= b || 4294901760 < a) return !1;
+          for (var c = 1; 4 >= c; c *= 2) {
+            var e = b * (1 + 0.2 / c);
+            e = Math.min(e, a + 100663296);
+            var f = Math;
+            e = Math.max(a, e);
+            a: {
+              f = (f.min.call(f, 4294901760, e + ((65536 - (e % 65536)) % 65536)) - l.buffer.byteLength + 65535) >>> 16;
+              try {
+                l.grow(f);
+                q();
+                var h = 1;
+                break a;
+              } catch (k) {}
+              h = void 0;
+            }
+            if (h) return !0;
+          }
+          return !1;
+        },
+        P: Lb,
+        Q: Mb,
+        k: Pa,
+        h: Nb,
+        p: Ob,
+        x: Pb,
+        o: Rb,
+        y: function (a, b) {
+          a >>>= 0;
+          b >>>= 0;
+          Ub(u().subarray(a >>> 0, (a + b) >>> 0));
+          return 0;
+        },
+        a: l || B.wasmMemory,
+        B: Zb,
+        e: function (a, b, c, e) {
+          return Zb(a >>> 0, b >>> 0, c >>> 0, e >>> 0);
+        },
+      };
+    (function () {
+      function a(c, e) {
+        c = c.exports;
+        c = ac(c);
+        M = c = vc(c);
+        V.eb.push(M.wa);
+        ua.unshift(M.Z);
+        ra = e;
+        Aa();
+        return c;
+      }
+      var b = { a: uc };
+      za();
+      if (B.instantiateWasm)
+        try {
+          return B.instantiateWasm(b, a);
+        } catch (c) {
+          J("Module.instantiateWasm callback failed with error: " + c), C(c);
+        }
+      Fa(b, function (c) {
+        a(c.instance, c.module);
+      }).catch(C);
+      return {};
+    })();
+    B._OrtInit = (a, b) => (B._OrtInit = M._)(a, b);
+    B._OrtGetLastError = (a, b) => (B._OrtGetLastError = M.$)(a, b);
+    B._OrtCreateSessionOptions = (a, b, c, e, f, h, k, m, v, n) =>
+      (B._OrtCreateSessionOptions = M.aa)(a, b, c, e, f, h, k, m, v, n);
+    B._OrtAppendExecutionProvider = (a, b) => (B._OrtAppendExecutionProvider = M.ba)(a, b);
+    B._OrtAddSessionConfigEntry = (a, b, c) => (B._OrtAddSessionConfigEntry = M.ca)(a, b, c);
+    B._OrtReleaseSessionOptions = (a) => (B._OrtReleaseSessionOptions = M.da)(a);
+    B._OrtCreateSession = (a, b, c) => (B._OrtCreateSession = M.ea)(a, b, c);
+    B._OrtReleaseSession = (a) => (B._OrtReleaseSession = M.fa)(a);
+    B._OrtGetInputOutputCount = (a, b, c) => (B._OrtGetInputOutputCount = M.ga)(a, b, c);
+    B._OrtGetInputName = (a, b) => (B._OrtGetInputName = M.ha)(a, b);
+    B._OrtGetOutputName = (a, b) => (B._OrtGetOutputName = M.ia)(a, b);
+    B._OrtFree = (a) => (B._OrtFree = M.ja)(a);
+    B._OrtCreateTensor = (a, b, c, e, f) => (B._OrtCreateTensor = M.ka)(a, b, c, e, f);
+    B._OrtGetTensorData = (a, b, c, e, f) => (B._OrtGetTensorData = M.la)(a, b, c, e, f);
+    B._OrtReleaseTensor = (a) => (B._OrtReleaseTensor = M.ma)(a);
+    B._OrtCreateRunOptions = (a, b, c, e) => (B._OrtCreateRunOptions = M.na)(a, b, c, e);
+    B._OrtAddRunConfigEntry = (a, b, c) => (B._OrtAddRunConfigEntry = M.oa)(a, b, c);
+    B._OrtReleaseRunOptions = (a) => (B._OrtReleaseRunOptions = M.pa)(a);
+    B._OrtRun = (a, b, c, e, f, h, k, m) => (B._OrtRun = M.qa)(a, b, c, e, f, h, k, m);
+    B._OrtEndProfiling = (a) => (B._OrtEndProfiling = M.ra)(a);
+    B._JsepOutput = (a, b, c) => (B._JsepOutput = M.sa)(a, b, c);
+    var Ra = (B._pthread_self = () => (Ra = B._pthread_self = M.ta)()),
+      zb = (B._malloc = (a) => (zb = B._malloc = M.ua)(a)),
+      pc = (B._free = (a) => (pc = B._free = M.va)(a));
+    B.__emscripten_tls_init = () => (B.__emscripten_tls_init = M.wa)();
+    var sc = (B.__emscripten_thread_init = (a, b, c, e, f, h) =>
+      (sc = B.__emscripten_thread_init = M.ya)(a, b, c, e, f, h));
+    B.__emscripten_thread_crashed = () => (B.__emscripten_thread_crashed = M.za)();
+    var Gb = (a, b, c, e) => (Gb = M.Aa)(a, b, c, e),
+      Qa = (a) => (Qa = M.Ba)(a),
+      Xa = (B.__emscripten_thread_exit = (a) => (Xa = B.__emscripten_thread_exit = M.Ca)(a)),
+      ub = (B.__emscripten_check_mailbox = () => (ub = B.__emscripten_check_mailbox = M.Da)()),
+      tc = (a) => (tc = M.Ea)(a),
+      Ua = (a, b) => (Ua = M.Fa)(a, b),
+      Db = () => (Db = M.Ga)(),
+      Va = (a) => (Va = M.Ha)(a),
+      Fb = (a) => (Fb = M.Ia)(a),
+      Wa = (B.dynCall_ii = (a, b) => (Wa = B.dynCall_ii = M.Ka)(a, b)),
+      nc = (a) => (nc = M.La)(a),
+      cc = () => (cc = M.Ma)(),
+      mc = (a) => (mc = M.Na)(a),
+      oc = () => (oc = M.Oa)();
+    B.___start_em_js = 908408;
+    B.___stop_em_js = 908569;
+    function vc(a) {
+      a = Object.assign({}, a);
+      var b = (e) => () => e() >>> 0,
+        c = (e) => (f) => e(f) >>> 0;
+      a.__errno_location = b(a.__errno_location);
+      a.pthread_self = b(a.pthread_self);
+      a.malloc = c(a.malloc);
+      a.stackSave = b(a.stackSave);
+      a.stackAlloc = c(a.stackAlloc);
+      return a;
+    }
+    B.keepRuntimeAlive = xa;
+    B.wasmMemory = l;
+    B.stackAlloc = Fb;
+    B.stackSave = Db;
+    B.stackRestore = Va;
+    B.UTF8ToString = U;
+    B.stringToUTF8 = gb;
+    B.lengthBytesUTF8 = eb;
+    B.ExitStatus = Ha;
+    B.PThread = V;
+    var wc;
+    R = function xc() {
+      wc || yc();
+      wc || (R = xc);
+    };
+    function yc() {
+      function a() {
+        if (!wc && ((wc = !0), (B.calledRun = !0), !N)) {
+          G || Ta(ua);
+          fa(B);
+          if (B.onRuntimeInitialized) B.onRuntimeInitialized();
+          if (!G) {
+            if (B.postRun)
+              for ("function" == typeof B.postRun && (B.postRun = [B.postRun]); B.postRun.length; ) {
+                var b = B.postRun.shift();
+                va.unshift(b);
+              }
+            Ta(va);
+          }
+        }
+      }
+      if (!(0 < Q))
+        if (G) fa(B), G || Ta(ua), startWorker(B);
+        else {
+          if (B.preRun)
+            for ("function" == typeof B.preRun && (B.preRun = [B.preRun]); B.preRun.length; )
+              ta.unshift(B.preRun.shift());
+          Ta(ta);
+          0 < Q ||
+            (B.setStatus
+              ? (B.setStatus("Running..."),
+                setTimeout(function () {
+                  setTimeout(function () {
+                    B.setStatus("");
+                  }, 1);
+                  a();
+                }, 1))
+              : a());
+        }
+    }
+    if (B.preInit)
+      for ("function" == typeof B.preInit && (B.preInit = [B.preInit]); 0 < B.preInit.length; ) B.preInit.pop()();
+    yc();
+
+    return moduleArg.ready;
+  };
+})();
+if (typeof exports === "object" && typeof module === "object") module.exports = ortWasmThreaded;
+else if (typeof define === "function" && define["amd"]) define([], () => ortWasmThreaded);

--- a/js/web/lib/wasm/binding/ort-wasm-simd-threaded.jsep.worker.js
+++ b/js/web/lib/wasm/binding/ort-wasm-simd-threaded.jsep.worker.js
@@ -1,0 +1,116 @@
+"use strict";
+var Module = {};
+var ENVIRONMENT_IS_NODE =
+  typeof process == "object" && typeof process.versions == "object" && typeof process.versions.node == "string";
+if (ENVIRONMENT_IS_NODE) {
+  var nodeWorkerThreads = require("worker_threads");
+  var parentPort = nodeWorkerThreads.parentPort;
+  parentPort.on("message", (data) => onmessage({ data: data }));
+  var fs = require("fs");
+  Object.assign(global, {
+    self: global,
+    require: require,
+    Module: Module,
+    location: { href: __filename },
+    Worker: nodeWorkerThreads.Worker,
+    importScripts: (f) => (0, eval)(fs.readFileSync(f, "utf8") + "//# sourceURL=" + f),
+    postMessage: (msg) => parentPort.postMessage(msg),
+    performance: global.performance || { now: Date.now },
+  });
+}
+var initializedJS = false;
+function threadPrintErr() {
+  var text = Array.prototype.slice.call(arguments).join(" ");
+  if (ENVIRONMENT_IS_NODE) {
+    fs.writeSync(2, text + "\n");
+    return;
+  }
+  console.error(text);
+}
+function threadAlert() {
+  var text = Array.prototype.slice.call(arguments).join(" ");
+  postMessage({ cmd: "alert", text: text, threadId: Module["_pthread_self"]() });
+}
+var err = threadPrintErr;
+self.alert = threadAlert;
+Module["instantiateWasm"] = (info, receiveInstance) => {
+  var module = Module["wasmModule"];
+  Module["wasmModule"] = null;
+  var instance = new WebAssembly.Instance(module, info);
+  return receiveInstance(instance);
+};
+self.onunhandledrejection = (e) => {
+  throw e.reason ?? e;
+};
+function handleMessage(e) {
+  try {
+    if (e.data.cmd === "load") {
+      let messageQueue = [];
+      self.onmessage = (e) => messageQueue.push(e);
+      self.startWorker = (instance) => {
+        Module = instance;
+        postMessage({ cmd: "loaded" });
+        for (let msg of messageQueue) {
+          handleMessage(msg);
+        }
+        self.onmessage = handleMessage;
+      };
+      Module["wasmModule"] = e.data.wasmModule;
+      for (const handler of e.data.handlers) {
+        Module[handler] = (...args) => {
+          postMessage({ cmd: "callHandler", handler: handler, args: args });
+        };
+      }
+      Module["wasmMemory"] = e.data.wasmMemory;
+      Module["buffer"] = Module["wasmMemory"].buffer;
+      Module["ENVIRONMENT_IS_PTHREAD"] = true;
+      if (typeof e.data.urlOrBlob == "string") {
+        importScripts(e.data.urlOrBlob);
+      } else {
+        var objectUrl = URL.createObjectURL(e.data.urlOrBlob);
+        importScripts(objectUrl);
+        URL.revokeObjectURL(objectUrl);
+      }
+      ortWasmThreaded(Module);
+    } else if (e.data.cmd === "run") {
+      Module["__emscripten_thread_init"](
+        e.data.pthread_ptr,
+        /*isMainBrowserThread=*/ 0,
+        /*isMainRuntimeThread=*/ 0,
+        /*canBlock=*/ 1,
+      );
+      Module["__emscripten_thread_mailbox_await"](e.data.pthread_ptr);
+      Module["establishStackSpace"]();
+      Module["PThread"].receiveObjectTransfer(e.data);
+      Module["PThread"].threadInitTLS();
+      if (!initializedJS) {
+        initializedJS = true;
+      }
+      try {
+        Module["invokeEntryPoint"](e.data.start_routine, e.data.arg);
+      } catch (ex) {
+        if (ex != "unwind") {
+          throw ex;
+        }
+      }
+    } else if (e.data.cmd === "cancel") {
+      if (Module["_pthread_self"]()) {
+        Module["__emscripten_thread_exit"](-1);
+      }
+    } else if (e.data.target === "setimmediate") {
+    } else if (e.data.cmd === "checkMailbox") {
+      if (initializedJS) {
+        Module["checkMailbox"]();
+      }
+    } else if (e.data.cmd) {
+      err("worker.js received unknown command " + e.data.cmd);
+      err(e.data);
+    }
+  } catch (ex) {
+    if (Module["__emscripten_thread_crashed"]) {
+      Module["__emscripten_thread_crashed"]();
+    }
+    throw ex;
+  }
+}
+self.onmessage = handleMessage;

--- a/js/web/lib/wasm/binding/ort-wasm-simd-threaded.worker.js
+++ b/js/web/lib/wasm/binding/ort-wasm-simd-threaded.worker.js
@@ -1,0 +1,116 @@
+"use strict";
+var Module = {};
+var ENVIRONMENT_IS_NODE =
+  typeof process == "object" && typeof process.versions == "object" && typeof process.versions.node == "string";
+if (ENVIRONMENT_IS_NODE) {
+  var nodeWorkerThreads = require("worker_threads");
+  var parentPort = nodeWorkerThreads.parentPort;
+  parentPort.on("message", (data) => onmessage({ data: data }));
+  var fs = require("fs");
+  Object.assign(global, {
+    self: global,
+    require: require,
+    Module: Module,
+    location: { href: __filename },
+    Worker: nodeWorkerThreads.Worker,
+    importScripts: (f) => (0, eval)(fs.readFileSync(f, "utf8") + "//# sourceURL=" + f),
+    postMessage: (msg) => parentPort.postMessage(msg),
+    performance: global.performance || { now: Date.now },
+  });
+}
+var initializedJS = false;
+function threadPrintErr() {
+  var text = Array.prototype.slice.call(arguments).join(" ");
+  if (ENVIRONMENT_IS_NODE) {
+    fs.writeSync(2, text + "\n");
+    return;
+  }
+  console.error(text);
+}
+function threadAlert() {
+  var text = Array.prototype.slice.call(arguments).join(" ");
+  postMessage({ cmd: "alert", text: text, threadId: Module["_pthread_self"]() });
+}
+var err = threadPrintErr;
+self.alert = threadAlert;
+Module["instantiateWasm"] = (info, receiveInstance) => {
+  var module = Module["wasmModule"];
+  Module["wasmModule"] = null;
+  var instance = new WebAssembly.Instance(module, info);
+  return receiveInstance(instance);
+};
+self.onunhandledrejection = (e) => {
+  throw e.reason ?? e;
+};
+function handleMessage(e) {
+  try {
+    if (e.data.cmd === "load") {
+      let messageQueue = [];
+      self.onmessage = (e) => messageQueue.push(e);
+      self.startWorker = (instance) => {
+        Module = instance;
+        postMessage({ cmd: "loaded" });
+        for (let msg of messageQueue) {
+          handleMessage(msg);
+        }
+        self.onmessage = handleMessage;
+      };
+      Module["wasmModule"] = e.data.wasmModule;
+      for (const handler of e.data.handlers) {
+        Module[handler] = (...args) => {
+          postMessage({ cmd: "callHandler", handler: handler, args: args });
+        };
+      }
+      Module["wasmMemory"] = e.data.wasmMemory;
+      Module["buffer"] = Module["wasmMemory"].buffer;
+      Module["ENVIRONMENT_IS_PTHREAD"] = true;
+      if (typeof e.data.urlOrBlob == "string") {
+        importScripts(e.data.urlOrBlob);
+      } else {
+        var objectUrl = URL.createObjectURL(e.data.urlOrBlob);
+        importScripts(objectUrl);
+        URL.revokeObjectURL(objectUrl);
+      }
+      ortWasmThreaded(Module);
+    } else if (e.data.cmd === "run") {
+      Module["__emscripten_thread_init"](
+        e.data.pthread_ptr,
+        /*isMainBrowserThread=*/ 0,
+        /*isMainRuntimeThread=*/ 0,
+        /*canBlock=*/ 1,
+      );
+      Module["__emscripten_thread_mailbox_await"](e.data.pthread_ptr);
+      Module["establishStackSpace"]();
+      Module["PThread"].receiveObjectTransfer(e.data);
+      Module["PThread"].threadInitTLS();
+      if (!initializedJS) {
+        initializedJS = true;
+      }
+      try {
+        Module["invokeEntryPoint"](e.data.start_routine, e.data.arg);
+      } catch (ex) {
+        if (ex != "unwind") {
+          throw ex;
+        }
+      }
+    } else if (e.data.cmd === "cancel") {
+      if (Module["_pthread_self"]()) {
+        Module["__emscripten_thread_exit"](-1);
+      }
+    } else if (e.data.target === "setimmediate") {
+    } else if (e.data.cmd === "checkMailbox") {
+      if (initializedJS) {
+        Module["checkMailbox"]();
+      }
+    } else if (e.data.cmd) {
+      err("worker.js received unknown command " + e.data.cmd);
+      err(e.data);
+    }
+  } catch (ex) {
+    if (Module["__emscripten_thread_crashed"]) {
+      Module["__emscripten_thread_crashed"]();
+    }
+    throw ex;
+  }
+}
+self.onmessage = handleMessage;

--- a/js/web/lib/wasm/binding/ort-wasm-simd.js
+++ b/js/web/lib/wasm/binding/ort-wasm-simd.js
@@ -1,0 +1,840 @@
+var ortWasm = (() => {
+  var _scriptDir = typeof document !== "undefined" && document.currentScript ? document.currentScript.src : undefined;
+  if (typeof __filename !== "undefined") _scriptDir = _scriptDir || __filename;
+  return function (moduleArg = {}) {
+    var e = moduleArg,
+      aa,
+      h;
+    e.ready = new Promise((a, b) => {
+      aa = a;
+      h = b;
+    });
+    var ba = Object.assign({}, e),
+      m = "./this.program",
+      q = (a, b) => {
+        throw b;
+      },
+      ca = "object" == typeof window,
+      v = "function" == typeof importScripts,
+      x = "object" == typeof process && "object" == typeof process.versions && "string" == typeof process.versions.node,
+      y = "",
+      A,
+      B,
+      C;
+    if (x) {
+      var fs = require("fs"),
+        D = require("path");
+      y = v ? D.dirname(y) + "/" : __dirname + "/";
+      A = (a, b) => {
+        a = a.startsWith("file://") ? new URL(a) : D.normalize(a);
+        return fs.readFileSync(a, b ? void 0 : "utf8");
+      };
+      C = (a) => {
+        a = A(a, !0);
+        a.buffer || (a = new Uint8Array(a));
+        return a;
+      };
+      B = (a, b, c, f = !0) => {
+        a = a.startsWith("file://") ? new URL(a) : D.normalize(a);
+        fs.readFile(a, f ? void 0 : "utf8", (g, k) => {
+          g ? c(g) : b(f ? k.buffer : k);
+        });
+      };
+      !e.thisProgram && 1 < process.argv.length && (m = process.argv[1].replace(/\\/g, "/"));
+      process.argv.slice(2);
+      q = (a, b) => {
+        process.exitCode = a;
+        throw b;
+      };
+      e.inspect = () => "[Emscripten Module object]";
+    } else if (ca || v)
+      v
+        ? (y = self.location.href)
+        : "undefined" != typeof document && document.currentScript && (y = document.currentScript.src),
+        _scriptDir && (y = _scriptDir),
+        0 !== y.indexOf("blob:") ? (y = y.substr(0, y.replace(/[?#].*/, "").lastIndexOf("/") + 1)) : (y = ""),
+        (A = (a) => {
+          var b = new XMLHttpRequest();
+          b.open("GET", a, !1);
+          b.send(null);
+          return b.responseText;
+        }),
+        v &&
+          (C = (a) => {
+            var b = new XMLHttpRequest();
+            b.open("GET", a, !1);
+            b.responseType = "arraybuffer";
+            b.send(null);
+            return new Uint8Array(b.response);
+          }),
+        (B = (a, b, c) => {
+          var f = new XMLHttpRequest();
+          f.open("GET", a, !0);
+          f.responseType = "arraybuffer";
+          f.onload = () => {
+            200 == f.status || (0 == f.status && f.response) ? b(f.response) : c();
+          };
+          f.onerror = c;
+          f.send(null);
+        });
+    var da = e.print || console.log.bind(console),
+      E = e.printErr || console.error.bind(console);
+    Object.assign(e, ba);
+    ba = null;
+    e.thisProgram && (m = e.thisProgram);
+    e.quit && (q = e.quit);
+    var F;
+    e.wasmBinary && (F = e.wasmBinary);
+    var noExitRuntime = e.noExitRuntime || !0;
+    "object" != typeof WebAssembly && G("no native wasm support detected");
+    var H,
+      I,
+      J = !1,
+      K,
+      L,
+      M,
+      N;
+    function ea() {
+      var a = H.buffer;
+      e.HEAP8 = K = new Int8Array(a);
+      e.HEAP16 = new Int16Array(a);
+      e.HEAP32 = M = new Int32Array(a);
+      e.HEAPU8 = L = new Uint8Array(a);
+      e.HEAPU16 = new Uint16Array(a);
+      e.HEAPU32 = N = new Uint32Array(a);
+      e.HEAPF32 = new Float32Array(a);
+      e.HEAPF64 = new Float64Array(a);
+    }
+    var fa = [],
+      ha = [],
+      ia = [];
+    function ja() {
+      var a = e.preRun.shift();
+      fa.unshift(a);
+    }
+    var O = 0,
+      P = null,
+      Q = null;
+    function G(a) {
+      if (e.onAbort) e.onAbort(a);
+      a = "Aborted(" + a + ")";
+      E(a);
+      J = !0;
+      a = new WebAssembly.RuntimeError(a + ". Build with -sASSERTIONS for more info.");
+      h(a);
+      throw a;
+    }
+    function ka(a) {
+      return a.startsWith("data:application/octet-stream;base64,");
+    }
+    var R;
+    R = "ort-wasm-simd.wasm";
+    if (!ka(R)) {
+      var la = R;
+      R = e.locateFile ? e.locateFile(la, y) : y + la;
+    }
+    function ma(a) {
+      if (a == R && F) return new Uint8Array(F);
+      if (C) return C(a);
+      throw "both async and sync fetching of the wasm failed";
+    }
+    function na(a) {
+      if (!F && (ca || v)) {
+        if ("function" == typeof fetch && !a.startsWith("file://"))
+          return fetch(a, { credentials: "same-origin" })
+            .then((b) => {
+              if (!b.ok) throw "failed to load wasm binary file at '" + a + "'";
+              return b.arrayBuffer();
+            })
+            .catch(() => ma(a));
+        if (B)
+          return new Promise((b, c) => {
+            B(a, (f) => b(new Uint8Array(f)), c);
+          });
+      }
+      return Promise.resolve().then(() => ma(a));
+    }
+    function oa(a, b, c) {
+      return na(a)
+        .then((f) => WebAssembly.instantiate(f, b))
+        .then((f) => f)
+        .then(c, (f) => {
+          E("failed to asynchronously prepare wasm: " + f);
+          G(f);
+        });
+    }
+    function pa(a, b) {
+      var c = R;
+      return F ||
+        "function" != typeof WebAssembly.instantiateStreaming ||
+        ka(c) ||
+        c.startsWith("file://") ||
+        x ||
+        "function" != typeof fetch
+        ? oa(c, a, b)
+        : fetch(c, { credentials: "same-origin" }).then((f) =>
+            WebAssembly.instantiateStreaming(f, a).then(b, function (g) {
+              E("wasm streaming compile failed: " + g);
+              E("falling back to ArrayBuffer instantiation");
+              return oa(c, a, b);
+            }),
+          );
+    }
+    var S;
+    function qa(a) {
+      this.name = "ExitStatus";
+      this.message = `Program terminated with exit(${a})`;
+      this.status = a;
+    }
+    var T = (a) => {
+      for (; 0 < a.length; ) a.shift()(e);
+    };
+    function ra(a) {
+      this.qa = a - 24;
+      this.va = function (b) {
+        N[((this.qa + 4) >> 2) >>> 0] = b;
+      };
+      this.ua = function (b) {
+        N[((this.qa + 8) >> 2) >>> 0] = b;
+      };
+      this.sa = function (b, c) {
+        this.ta();
+        this.va(b);
+        this.ua(c);
+      };
+      this.ta = function () {
+        N[((this.qa + 16) >> 2) >>> 0] = 0;
+      };
+    }
+    var sa = 0,
+      ta = 0,
+      ua = "undefined" != typeof TextDecoder ? new TextDecoder("utf8") : void 0,
+      va = (a, b, c) => {
+        b >>>= 0;
+        var f = b + c;
+        for (c = b; a[c] && !(c >= f); ) ++c;
+        if (16 < c - b && a.buffer && ua) return ua.decode(a.subarray(b, c));
+        for (f = ""; b < c; ) {
+          var g = a[b++];
+          if (g & 128) {
+            var k = a[b++] & 63;
+            if (192 == (g & 224)) f += String.fromCharCode(((g & 31) << 6) | k);
+            else {
+              var l = a[b++] & 63;
+              g =
+                224 == (g & 240)
+                  ? ((g & 15) << 12) | (k << 6) | l
+                  : ((g & 7) << 18) | (k << 12) | (l << 6) | (a[b++] & 63);
+              65536 > g
+                ? (f += String.fromCharCode(g))
+                : ((g -= 65536), (f += String.fromCharCode(55296 | (g >> 10), 56320 | (g & 1023))));
+            }
+          } else f += String.fromCharCode(g);
+        }
+        return f;
+      },
+      U = (a, b) => ((a >>>= 0) ? va(L, a, b) : ""),
+      V = (a) => {
+        for (var b = 0, c = 0; c < a.length; ++c) {
+          var f = a.charCodeAt(c);
+          127 >= f ? b++ : 2047 >= f ? (b += 2) : 55296 <= f && 57343 >= f ? ((b += 4), ++c) : (b += 3);
+        }
+        return b;
+      },
+      W = (a, b, c, f) => {
+        c >>>= 0;
+        if (!(0 < f)) return 0;
+        var g = c;
+        f = c + f - 1;
+        for (var k = 0; k < a.length; ++k) {
+          var l = a.charCodeAt(k);
+          if (55296 <= l && 57343 >= l) {
+            var r = a.charCodeAt(++k);
+            l = (65536 + ((l & 1023) << 10)) | (r & 1023);
+          }
+          if (127 >= l) {
+            if (c >= f) break;
+            b[c++ >>> 0] = l;
+          } else {
+            if (2047 >= l) {
+              if (c + 1 >= f) break;
+              b[c++ >>> 0] = 192 | (l >> 6);
+            } else {
+              if (65535 >= l) {
+                if (c + 2 >= f) break;
+                b[c++ >>> 0] = 224 | (l >> 12);
+              } else {
+                if (c + 3 >= f) break;
+                b[c++ >>> 0] = 240 | (l >> 18);
+                b[c++ >>> 0] = 128 | ((l >> 12) & 63);
+              }
+              b[c++ >>> 0] = 128 | ((l >> 6) & 63);
+            }
+            b[c++ >>> 0] = 128 | (l & 63);
+          }
+        }
+        b[c >>> 0] = 0;
+        return c - g;
+      },
+      X = (a) => 0 === a % 4 && (0 !== a % 100 || 0 === a % 400),
+      wa = [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335],
+      xa = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334],
+      Ca = (a) => {
+        var b = V(a) + 1,
+          c = ya(b);
+        c && W(a, L, c, b);
+        return c;
+      },
+      Y = {},
+      Ea = () => {
+        if (!Da) {
+          var a = {
+              USER: "web_user",
+              LOGNAME: "web_user",
+              PATH: "/",
+              PWD: "/",
+              HOME: "/home/web_user",
+              LANG:
+                (("object" == typeof navigator && navigator.languages && navigator.languages[0]) || "C").replace(
+                  "-",
+                  "_",
+                ) + ".UTF-8",
+              _: m || "./this.program",
+            },
+            b;
+          for (b in Y) void 0 === Y[b] ? delete a[b] : (a[b] = Y[b]);
+          var c = [];
+          for (b in a) c.push(`${b}=${a[b]}`);
+          Da = c;
+        }
+        return Da;
+      },
+      Da,
+      Fa = [null, [], []],
+      Ga = () => {
+        if ("object" == typeof crypto && "function" == typeof crypto.getRandomValues)
+          return (c) => crypto.getRandomValues(c);
+        if (x)
+          try {
+            var a = require("crypto");
+            if (a.randomFillSync) return (c) => a.randomFillSync(c);
+            var b = a.randomBytes;
+            return (c) => (c.set(b(c.byteLength)), c);
+          } catch (c) {}
+        G("initRandomDevice");
+      },
+      Ha = (a) => (Ha = Ga())(a),
+      Ia = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+      Ja = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    function Ka(a) {
+      var b = Array(V(a) + 1);
+      W(a, b, 0, b.length);
+      return b;
+    }
+    function La(a, b, c, f) {
+      function g(d, n, p) {
+        for (d = "number" == typeof d ? d.toString() : d || ""; d.length < n; ) d = p[0] + d;
+        return d;
+      }
+      function k(d, n) {
+        return g(d, n, "0");
+      }
+      function l(d, n) {
+        function p(za) {
+          return 0 > za ? -1 : 0 < za ? 1 : 0;
+        }
+        var z;
+        0 === (z = p(d.getFullYear() - n.getFullYear())) &&
+          0 === (z = p(d.getMonth() - n.getMonth())) &&
+          (z = p(d.getDate() - n.getDate()));
+        return z;
+      }
+      function r(d) {
+        switch (d.getDay()) {
+          case 0:
+            return new Date(d.getFullYear() - 1, 11, 29);
+          case 1:
+            return d;
+          case 2:
+            return new Date(d.getFullYear(), 0, 3);
+          case 3:
+            return new Date(d.getFullYear(), 0, 2);
+          case 4:
+            return new Date(d.getFullYear(), 0, 1);
+          case 5:
+            return new Date(d.getFullYear() - 1, 11, 31);
+          case 6:
+            return new Date(d.getFullYear() - 1, 11, 30);
+        }
+      }
+      function w(d) {
+        var n = d.ma;
+        for (d = new Date(new Date(d.na + 1900, 0, 1).getTime()); 0 < n; ) {
+          var p = d.getMonth(),
+            z = (X(d.getFullYear()) ? Ia : Ja)[p];
+          if (n > z - d.getDate())
+            (n -= z - d.getDate() + 1),
+              d.setDate(1),
+              11 > p ? d.setMonth(p + 1) : (d.setMonth(0), d.setFullYear(d.getFullYear() + 1));
+          else {
+            d.setDate(d.getDate() + n);
+            break;
+          }
+        }
+        p = new Date(d.getFullYear() + 1, 0, 4);
+        n = r(new Date(d.getFullYear(), 0, 4));
+        p = r(p);
+        return 0 >= l(n, d) ? (0 >= l(p, d) ? d.getFullYear() + 1 : d.getFullYear()) : d.getFullYear() - 1;
+      }
+      a >>>= 0;
+      b >>>= 0;
+      c >>>= 0;
+      f >>>= 0;
+      var t = M[((f + 40) >> 2) >>> 0];
+      f = {
+        ya: M[(f >> 2) >>> 0],
+        xa: M[((f + 4) >> 2) >>> 0],
+        oa: M[((f + 8) >> 2) >>> 0],
+        ra: M[((f + 12) >> 2) >>> 0],
+        pa: M[((f + 16) >> 2) >>> 0],
+        na: M[((f + 20) >> 2) >>> 0],
+        ha: M[((f + 24) >> 2) >>> 0],
+        ma: M[((f + 28) >> 2) >>> 0],
+        Aa: M[((f + 32) >> 2) >>> 0],
+        wa: M[((f + 36) >> 2) >>> 0],
+        za: t ? U(t) : "",
+      };
+      c = U(c);
+      t = {
+        "%c": "%a %b %d %H:%M:%S %Y",
+        "%D": "%m/%d/%y",
+        "%F": "%Y-%m-%d",
+        "%h": "%b",
+        "%r": "%I:%M:%S %p",
+        "%R": "%H:%M",
+        "%T": "%H:%M:%S",
+        "%x": "%m/%d/%y",
+        "%X": "%H:%M:%S",
+        "%Ec": "%c",
+        "%EC": "%C",
+        "%Ex": "%m/%d/%y",
+        "%EX": "%H:%M:%S",
+        "%Ey": "%y",
+        "%EY": "%Y",
+        "%Od": "%d",
+        "%Oe": "%e",
+        "%OH": "%H",
+        "%OI": "%I",
+        "%Om": "%m",
+        "%OM": "%M",
+        "%OS": "%S",
+        "%Ou": "%u",
+        "%OU": "%U",
+        "%OV": "%V",
+        "%Ow": "%w",
+        "%OW": "%W",
+        "%Oy": "%y",
+      };
+      for (var u in t) c = c.replace(new RegExp(u, "g"), t[u]);
+      var Aa = "Sunday Monday Tuesday Wednesday Thursday Friday Saturday".split(" "),
+        Ba = "January February March April May June July August September October November December".split(" ");
+      t = {
+        "%a": (d) => Aa[d.ha].substring(0, 3),
+        "%A": (d) => Aa[d.ha],
+        "%b": (d) => Ba[d.pa].substring(0, 3),
+        "%B": (d) => Ba[d.pa],
+        "%C": (d) => k(((d.na + 1900) / 100) | 0, 2),
+        "%d": (d) => k(d.ra, 2),
+        "%e": (d) => g(d.ra, 2, " "),
+        "%g": (d) => w(d).toString().substring(2),
+        "%G": (d) => w(d),
+        "%H": (d) => k(d.oa, 2),
+        "%I": (d) => {
+          d = d.oa;
+          0 == d ? (d = 12) : 12 < d && (d -= 12);
+          return k(d, 2);
+        },
+        "%j": (d) => {
+          for (var n = 0, p = 0; p <= d.pa - 1; n += (X(d.na + 1900) ? Ia : Ja)[p++]);
+          return k(d.ra + n, 3);
+        },
+        "%m": (d) => k(d.pa + 1, 2),
+        "%M": (d) => k(d.xa, 2),
+        "%n": () => "\n",
+        "%p": (d) => (0 <= d.oa && 12 > d.oa ? "AM" : "PM"),
+        "%S": (d) => k(d.ya, 2),
+        "%t": () => "\t",
+        "%u": (d) => d.ha || 7,
+        "%U": (d) => k(Math.floor((d.ma + 7 - d.ha) / 7), 2),
+        "%V": (d) => {
+          var n = Math.floor((d.ma + 7 - ((d.ha + 6) % 7)) / 7);
+          2 >= (d.ha + 371 - d.ma - 2) % 7 && n++;
+          if (n) 53 == n && ((p = (d.ha + 371 - d.ma) % 7), 4 == p || (3 == p && X(d.na)) || (n = 1));
+          else {
+            n = 52;
+            var p = (d.ha + 7 - d.ma - 1) % 7;
+            (4 == p || (5 == p && X((d.na % 400) - 1))) && n++;
+          }
+          return k(n, 2);
+        },
+        "%w": (d) => d.ha,
+        "%W": (d) => k(Math.floor((d.ma + 7 - ((d.ha + 6) % 7)) / 7), 2),
+        "%y": (d) => (d.na + 1900).toString().substring(2),
+        "%Y": (d) => d.na + 1900,
+        "%z": (d) => {
+          d = d.wa;
+          var n = 0 <= d;
+          d = Math.abs(d) / 60;
+          return (n ? "+" : "-") + String("0000" + ((d / 60) * 100 + (d % 60))).slice(-4);
+        },
+        "%Z": (d) => d.za,
+        "%%": () => "%",
+      };
+      c = c.replace(/%%/g, "\x00\x00");
+      for (u in t) c.includes(u) && (c = c.replace(new RegExp(u, "g"), t[u](f)));
+      c = c.replace(/\0\0/g, "%");
+      u = Ka(c);
+      if (u.length > b) return 0;
+      K.set(u, a >>> 0);
+      return u.length - 1;
+    }
+    var Na = {
+      a: function (a, b, c) {
+        a >>>= 0;
+        new ra(a).sa(b >>> 0, c >>> 0);
+        sa = a;
+        ta++;
+        throw sa;
+      },
+      e: function () {
+        return 0;
+      },
+      I: function () {},
+      y: function () {},
+      A: function () {},
+      K: function () {
+        return 0;
+      },
+      G: function () {},
+      B: function () {},
+      F: function () {},
+      g: function () {},
+      z: function () {},
+      w: function () {},
+      H: function () {},
+      x: function () {},
+      k: () => !0,
+      n: function (a, b, c) {
+        a = (b + 2097152) >>> 0 < 4194305 - !!a ? (a >>> 0) + 4294967296 * b : NaN;
+        c >>>= 0;
+        a = new Date(1e3 * a);
+        M[(c >> 2) >>> 0] = a.getUTCSeconds();
+        M[((c + 4) >> 2) >>> 0] = a.getUTCMinutes();
+        M[((c + 8) >> 2) >>> 0] = a.getUTCHours();
+        M[((c + 12) >> 2) >>> 0] = a.getUTCDate();
+        M[((c + 16) >> 2) >>> 0] = a.getUTCMonth();
+        M[((c + 20) >> 2) >>> 0] = a.getUTCFullYear() - 1900;
+        M[((c + 24) >> 2) >>> 0] = a.getUTCDay();
+        M[((c + 28) >> 2) >>> 0] = ((a.getTime() - Date.UTC(a.getUTCFullYear(), 0, 1, 0, 0, 0, 0)) / 864e5) | 0;
+      },
+      o: function (a, b, c) {
+        a = (b + 2097152) >>> 0 < 4194305 - !!a ? (a >>> 0) + 4294967296 * b : NaN;
+        c >>>= 0;
+        a = new Date(1e3 * a);
+        M[(c >> 2) >>> 0] = a.getSeconds();
+        M[((c + 4) >> 2) >>> 0] = a.getMinutes();
+        M[((c + 8) >> 2) >>> 0] = a.getHours();
+        M[((c + 12) >> 2) >>> 0] = a.getDate();
+        M[((c + 16) >> 2) >>> 0] = a.getMonth();
+        M[((c + 20) >> 2) >>> 0] = a.getFullYear() - 1900;
+        M[((c + 24) >> 2) >>> 0] = a.getDay();
+        M[((c + 28) >> 2) >>> 0] = ((X(a.getFullYear()) ? wa : xa)[a.getMonth()] + a.getDate() - 1) | 0;
+        M[((c + 36) >> 2) >>> 0] = -(60 * a.getTimezoneOffset());
+        b = new Date(a.getFullYear(), 6, 1).getTimezoneOffset();
+        var f = new Date(a.getFullYear(), 0, 1).getTimezoneOffset();
+        M[((c + 32) >> 2) >>> 0] = (b != f && a.getTimezoneOffset() == Math.min(f, b)) | 0;
+      },
+      p: function (a) {
+        a >>>= 0;
+        var b = new Date(
+            M[((a + 20) >> 2) >>> 0] + 1900,
+            M[((a + 16) >> 2) >>> 0],
+            M[((a + 12) >> 2) >>> 0],
+            M[((a + 8) >> 2) >>> 0],
+            M[((a + 4) >> 2) >>> 0],
+            M[(a >> 2) >>> 0],
+            0,
+          ),
+          c = M[((a + 32) >> 2) >>> 0],
+          f = b.getTimezoneOffset(),
+          g = new Date(b.getFullYear(), 6, 1).getTimezoneOffset(),
+          k = new Date(b.getFullYear(), 0, 1).getTimezoneOffset(),
+          l = Math.min(k, g);
+        0 > c
+          ? (M[((a + 32) >> 2) >>> 0] = Number(g != k && l == f))
+          : 0 < c != (l == f) && ((g = Math.max(k, g)), b.setTime(b.getTime() + 6e4 * ((0 < c ? l : g) - f)));
+        M[((a + 24) >> 2) >>> 0] = b.getDay();
+        M[((a + 28) >> 2) >>> 0] = ((X(b.getFullYear()) ? wa : xa)[b.getMonth()] + b.getDate() - 1) | 0;
+        M[(a >> 2) >>> 0] = b.getSeconds();
+        M[((a + 4) >> 2) >>> 0] = b.getMinutes();
+        M[((a + 8) >> 2) >>> 0] = b.getHours();
+        M[((a + 12) >> 2) >>> 0] = b.getDate();
+        M[((a + 16) >> 2) >>> 0] = b.getMonth();
+        M[((a + 20) >> 2) >>> 0] = b.getYear();
+        a = b.getTime() / 1e3;
+        return (
+          Ma(
+            ((S = a),
+            1 <= +Math.abs(S)
+              ? 0 < S
+                ? +Math.floor(S / 4294967296) >>> 0
+                : ~~+Math.ceil((S - +(~~S >>> 0)) / 4294967296) >>> 0
+              : 0),
+          ),
+          a >>> 0
+        );
+      },
+      l: function () {
+        return -52;
+      },
+      m: function () {},
+      u: function (a, b, c) {
+        function f(w) {
+          return (w = w.toTimeString().match(/\(([A-Za-z ]+)\)$/)) ? w[1] : "GMT";
+        }
+        c >>>= 0;
+        var g = new Date().getFullYear(),
+          k = new Date(g, 0, 1),
+          l = new Date(g, 6, 1);
+        g = k.getTimezoneOffset();
+        var r = l.getTimezoneOffset();
+        N[((a >>> 0) >> 2) >>> 0] = 60 * Math.max(g, r);
+        M[((b >>> 0) >> 2) >>> 0] = Number(g != r);
+        a = f(k);
+        b = f(l);
+        a = Ca(a);
+        b = Ca(b);
+        r < g
+          ? ((N[(c >> 2) >>> 0] = a), (N[((c + 4) >> 2) >>> 0] = b))
+          : ((N[(c >> 2) >>> 0] = b), (N[((c + 4) >> 2) >>> 0] = a));
+      },
+      d: () => {
+        G("");
+      },
+      h: function () {
+        return Date.now();
+      },
+      v: function () {
+        return 4294901760;
+      },
+      b: () => performance.now(),
+      J: function (a, b, c) {
+        b >>>= 0;
+        return L.copyWithin((a >>> 0) >>> 0, b >>> 0, (b + (c >>> 0)) >>> 0);
+      },
+      t: function (a) {
+        a >>>= 0;
+        var b = L.length;
+        if (4294901760 < a) return !1;
+        for (var c = 1; 4 >= c; c *= 2) {
+          var f = b * (1 + 0.2 / c);
+          f = Math.min(f, a + 100663296);
+          var g = Math;
+          f = Math.max(a, f);
+          a: {
+            g = (g.min.call(g, 4294901760, f + ((65536 - (f % 65536)) % 65536)) - H.buffer.byteLength + 65535) >>> 16;
+            try {
+              H.grow(g);
+              ea();
+              var k = 1;
+              break a;
+            } catch (l) {}
+            k = void 0;
+          }
+          if (k) return !0;
+        }
+        return !1;
+      },
+      D: function (a, b) {
+        a >>>= 0;
+        b >>>= 0;
+        var c = 0;
+        Ea().forEach(function (f, g) {
+          var k = b + c;
+          g = N[((a + 4 * g) >> 2) >>> 0] = k;
+          for (k = 0; k < f.length; ++k) K[(g++ >> 0) >>> 0] = f.charCodeAt(k);
+          K[(g >> 0) >>> 0] = 0;
+          c += f.length + 1;
+        });
+        return 0;
+      },
+      E: function (a, b) {
+        a >>>= 0;
+        b >>>= 0;
+        var c = Ea();
+        N[(a >> 2) >>> 0] = c.length;
+        var f = 0;
+        c.forEach(function (g) {
+          f += g.length + 1;
+        });
+        N[(b >> 2) >>> 0] = f;
+        return 0;
+      },
+      s: (a) => {
+        if (!noExitRuntime) {
+          if (e.onExit) e.onExit(a);
+          J = !0;
+        }
+        q(a, new qa(a));
+      },
+      f: () => 52,
+      j: function () {
+        return 52;
+      },
+      q: function () {
+        return 70;
+      },
+      i: function (a, b, c, f) {
+        b >>>= 0;
+        c >>>= 0;
+        f >>>= 0;
+        for (var g = 0, k = 0; k < c; k++) {
+          var l = N[(b >> 2) >>> 0],
+            r = N[((b + 4) >> 2) >>> 0];
+          b += 8;
+          for (var w = 0; w < r; w++) {
+            var t = L[(l + w) >>> 0],
+              u = Fa[a];
+            0 === t || 10 === t ? ((1 === a ? da : E)(va(u, 0)), (u.length = 0)) : u.push(t);
+          }
+          g += r;
+        }
+        N[(f >> 2) >>> 0] = g;
+        return 0;
+      },
+      r: function (a, b) {
+        a >>>= 0;
+        Ha(L.subarray(a >>> 0, (a + (b >>> 0)) >>> 0));
+        return 0;
+      },
+      C: La,
+      c: function (a, b, c, f) {
+        return La(a >>> 0, b >>> 0, c >>> 0, f >>> 0);
+      },
+    };
+    (function () {
+      function a(c) {
+        c = c.exports;
+        I = c = Oa(c);
+        H = I.L;
+        ea();
+        ha.unshift(I.M);
+        O--;
+        e.monitorRunDependencies && e.monitorRunDependencies(O);
+        if (0 == O && (null !== P && (clearInterval(P), (P = null)), Q)) {
+          var f = Q;
+          Q = null;
+          f();
+        }
+        return c;
+      }
+      var b = { a: Na };
+      O++;
+      e.monitorRunDependencies && e.monitorRunDependencies(O);
+      if (e.instantiateWasm)
+        try {
+          return e.instantiateWasm(b, a);
+        } catch (c) {
+          E("Module.instantiateWasm callback failed with error: " + c), h(c);
+        }
+      pa(b, function (c) {
+        a(c.instance);
+      }).catch(h);
+      return {};
+    })();
+    e._OrtInit = (a, b) => (e._OrtInit = I.N)(a, b);
+    e._OrtGetLastError = (a, b) => (e._OrtGetLastError = I.O)(a, b);
+    e._OrtCreateSessionOptions = (a, b, c, f, g, k, l, r, w, t) =>
+      (e._OrtCreateSessionOptions = I.P)(a, b, c, f, g, k, l, r, w, t);
+    e._OrtAppendExecutionProvider = (a, b) => (e._OrtAppendExecutionProvider = I.Q)(a, b);
+    e._OrtAddSessionConfigEntry = (a, b, c) => (e._OrtAddSessionConfigEntry = I.R)(a, b, c);
+    e._OrtReleaseSessionOptions = (a) => (e._OrtReleaseSessionOptions = I.S)(a);
+    e._OrtCreateSession = (a, b, c) => (e._OrtCreateSession = I.T)(a, b, c);
+    e._OrtReleaseSession = (a) => (e._OrtReleaseSession = I.U)(a);
+    e._OrtGetInputOutputCount = (a, b, c) => (e._OrtGetInputOutputCount = I.V)(a, b, c);
+    e._OrtGetInputName = (a, b) => (e._OrtGetInputName = I.W)(a, b);
+    e._OrtGetOutputName = (a, b) => (e._OrtGetOutputName = I.X)(a, b);
+    e._OrtFree = (a) => (e._OrtFree = I.Y)(a);
+    e._OrtCreateTensor = (a, b, c, f, g) => (e._OrtCreateTensor = I.Z)(a, b, c, f, g);
+    e._OrtGetTensorData = (a, b, c, f, g) => (e._OrtGetTensorData = I._)(a, b, c, f, g);
+    e._OrtReleaseTensor = (a) => (e._OrtReleaseTensor = I.$)(a);
+    e._OrtCreateRunOptions = (a, b, c, f) => (e._OrtCreateRunOptions = I.aa)(a, b, c, f);
+    e._OrtAddRunConfigEntry = (a, b, c) => (e._OrtAddRunConfigEntry = I.ba)(a, b, c);
+    e._OrtReleaseRunOptions = (a) => (e._OrtReleaseRunOptions = I.ca)(a);
+    e._OrtRun = (a, b, c, f, g, k, l, r) => (e._OrtRun = I.da)(a, b, c, f, g, k, l, r);
+    e._OrtEndProfiling = (a) => (e._OrtEndProfiling = I.ea)(a);
+    var ya = (e._malloc = (a) => (ya = e._malloc = I.fa)(a));
+    e._free = (a) => (e._free = I.ga)(a);
+    var Ma = (a) => (Ma = I.ia)(a),
+      Pa = () => (Pa = I.ja)(),
+      Qa = (a) => (Qa = I.ka)(a),
+      Ra = (a) => (Ra = I.la)(a);
+    function Oa(a) {
+      a = Object.assign({}, a);
+      var b = (f) => () => f() >>> 0,
+        c = (f) => (g) => f(g) >>> 0;
+      a.__errno_location = b(a.__errno_location);
+      a.malloc = c(a.malloc);
+      a.stackSave = b(a.stackSave);
+      a.stackAlloc = c(a.stackAlloc);
+      return a;
+    }
+    e.stackAlloc = Ra;
+    e.stackSave = Pa;
+    e.stackRestore = Qa;
+    e.UTF8ToString = U;
+    e.stringToUTF8 = (a, b, c) => W(a, L, b, c);
+    e.lengthBytesUTF8 = V;
+    var Z;
+    Q = function Sa() {
+      Z || Ta();
+      Z || (Q = Sa);
+    };
+    function Ta() {
+      function a() {
+        if (!Z && ((Z = !0), (e.calledRun = !0), !J)) {
+          T(ha);
+          aa(e);
+          if (e.onRuntimeInitialized) e.onRuntimeInitialized();
+          if (e.postRun)
+            for ("function" == typeof e.postRun && (e.postRun = [e.postRun]); e.postRun.length; ) {
+              var b = e.postRun.shift();
+              ia.unshift(b);
+            }
+          T(ia);
+        }
+      }
+      if (!(0 < O)) {
+        if (e.preRun) for ("function" == typeof e.preRun && (e.preRun = [e.preRun]); e.preRun.length; ) ja();
+        T(fa);
+        0 < O ||
+          (e.setStatus
+            ? (e.setStatus("Running..."),
+              setTimeout(function () {
+                setTimeout(function () {
+                  e.setStatus("");
+                }, 1);
+                a();
+              }, 1))
+            : a());
+      }
+    }
+    if (e.preInit)
+      for ("function" == typeof e.preInit && (e.preInit = [e.preInit]); 0 < e.preInit.length; ) e.preInit.pop()();
+    Ta();
+
+    return moduleArg.ready;
+  };
+})();
+if (typeof exports === "object" && typeof module === "object") module.exports = ortWasm;
+else if (typeof define === "function" && define["amd"]) define([], () => ortWasm);

--- a/js/web/lib/wasm/binding/ort-wasm-simd.jsep.js
+++ b/js/web/lib/wasm/binding/ort-wasm-simd.jsep.js
@@ -1,0 +1,1427 @@
+var ortWasm = (() => {
+  var _scriptDir = typeof document !== "undefined" && document.currentScript ? document.currentScript.src : undefined;
+  if (typeof __filename !== "undefined") _scriptDir = _scriptDir || __filename;
+  return function (moduleArg = {}) {
+    var d = moduleArg,
+      aa,
+      k;
+    d.ready = new Promise((a, b) => {
+      aa = a;
+      k = b;
+    });
+    ("use strict");
+    d.jsepInit = function (a, b, c, e, f, h, l, m) {
+      d.Sa = a;
+      d.Ea = b;
+      d.Ga = c;
+      d.Ca = e;
+      d.Fa = f;
+      d.la = h;
+      d.Ha = l;
+      d.Ia = m;
+    };
+    var ba = Object.assign({}, d),
+      t = "./this.program",
+      x = (a, b) => {
+        throw b;
+      },
+      ca = "object" == typeof window,
+      y = "function" == typeof importScripts,
+      z = "object" == typeof process && "object" == typeof process.versions && "string" == typeof process.versions.node,
+      A = "",
+      da,
+      B,
+      C;
+    if (z) {
+      var fs = require("fs"),
+        ea = require("path");
+      A = y ? ea.dirname(A) + "/" : __dirname + "/";
+      da = (a, b) => {
+        a = a.startsWith("file://") ? new URL(a) : ea.normalize(a);
+        return fs.readFileSync(a, b ? void 0 : "utf8");
+      };
+      C = (a) => {
+        a = da(a, !0);
+        a.buffer || (a = new Uint8Array(a));
+        return a;
+      };
+      B = (a, b, c, e = !0) => {
+        a = a.startsWith("file://") ? new URL(a) : ea.normalize(a);
+        fs.readFile(a, e ? void 0 : "utf8", (f, h) => {
+          f ? c(f) : b(e ? h.buffer : h);
+        });
+      };
+      !d.thisProgram && 1 < process.argv.length && (t = process.argv[1].replace(/\\/g, "/"));
+      process.argv.slice(2);
+      x = (a, b) => {
+        process.exitCode = a;
+        throw b;
+      };
+      d.inspect = () => "[Emscripten Module object]";
+    } else if (ca || y)
+      y
+        ? (A = self.location.href)
+        : "undefined" != typeof document && document.currentScript && (A = document.currentScript.src),
+        _scriptDir && (A = _scriptDir),
+        0 !== A.indexOf("blob:") ? (A = A.substr(0, A.replace(/[?#].*/, "").lastIndexOf("/") + 1)) : (A = ""),
+        (da = (a) => {
+          var b = new XMLHttpRequest();
+          b.open("GET", a, !1);
+          b.send(null);
+          return b.responseText;
+        }),
+        y &&
+          (C = (a) => {
+            var b = new XMLHttpRequest();
+            b.open("GET", a, !1);
+            b.responseType = "arraybuffer";
+            b.send(null);
+            return new Uint8Array(b.response);
+          }),
+        (B = (a, b, c) => {
+          var e = new XMLHttpRequest();
+          e.open("GET", a, !0);
+          e.responseType = "arraybuffer";
+          e.onload = () => {
+            200 == e.status || (0 == e.status && e.response) ? b(e.response) : c();
+          };
+          e.onerror = c;
+          e.send(null);
+        });
+    var fa = d.print || console.log.bind(console),
+      D = d.printErr || console.error.bind(console);
+    Object.assign(d, ba);
+    ba = null;
+    d.thisProgram && (t = d.thisProgram);
+    d.quit && (x = d.quit);
+    var E;
+    d.wasmBinary && (E = d.wasmBinary);
+    var noExitRuntime = d.noExitRuntime || !0;
+    "object" != typeof WebAssembly && F("no native wasm support detected");
+    var G,
+      I,
+      J = !1,
+      K,
+      L,
+      M,
+      N,
+      O,
+      ha;
+    function ia() {
+      var a = G.buffer;
+      d.HEAP8 = L = new Int8Array(a);
+      d.HEAP16 = new Int16Array(a);
+      d.HEAP32 = N = new Int32Array(a);
+      d.HEAPU8 = M = new Uint8Array(a);
+      d.HEAPU16 = new Uint16Array(a);
+      d.HEAPU32 = O = new Uint32Array(a);
+      d.HEAPF32 = new Float32Array(a);
+      d.HEAPF64 = ha = new Float64Array(a);
+    }
+    var ja = [],
+      ka = [],
+      la = [];
+    function ma() {
+      var a = d.preRun.shift();
+      ja.unshift(a);
+    }
+    var P = 0,
+      na = null,
+      Q = null;
+    function F(a) {
+      if (d.onAbort) d.onAbort(a);
+      a = "Aborted(" + a + ")";
+      D(a);
+      J = !0;
+      K = 1;
+      a = new WebAssembly.RuntimeError(a + ". Build with -sASSERTIONS for more info.");
+      k(a);
+      throw a;
+    }
+    function oa(a) {
+      return a.startsWith("data:application/octet-stream;base64,");
+    }
+    var R;
+    R = "ort-wasm-simd.wasm";
+    if (!oa(R)) {
+      var pa = R;
+      R = d.locateFile ? d.locateFile(pa, A) : A + pa;
+    }
+    function qa(a) {
+      if (a == R && E) return new Uint8Array(E);
+      if (C) return C(a);
+      throw "both async and sync fetching of the wasm failed";
+    }
+    function ra(a) {
+      if (!E && (ca || y)) {
+        if ("function" == typeof fetch && !a.startsWith("file://"))
+          return fetch(a, { credentials: "same-origin" })
+            .then((b) => {
+              if (!b.ok) throw "failed to load wasm binary file at '" + a + "'";
+              return b.arrayBuffer();
+            })
+            .catch(() => qa(a));
+        if (B)
+          return new Promise((b, c) => {
+            B(a, (e) => b(new Uint8Array(e)), c);
+          });
+      }
+      return Promise.resolve().then(() => qa(a));
+    }
+    function sa(a, b, c) {
+      return ra(a)
+        .then((e) => WebAssembly.instantiate(e, b))
+        .then((e) => e)
+        .then(c, (e) => {
+          D("failed to asynchronously prepare wasm: " + e);
+          F(e);
+        });
+    }
+    function ta(a, b) {
+      var c = R;
+      return E ||
+        "function" != typeof WebAssembly.instantiateStreaming ||
+        oa(c) ||
+        c.startsWith("file://") ||
+        z ||
+        "function" != typeof fetch
+        ? sa(c, a, b)
+        : fetch(c, { credentials: "same-origin" }).then((e) =>
+            WebAssembly.instantiateStreaming(e, a).then(b, function (f) {
+              D("wasm streaming compile failed: " + f);
+              D("falling back to ArrayBuffer instantiation");
+              return sa(c, a, b);
+            }),
+          );
+    }
+    var S,
+      ua = {
+        894528: () => {
+          d.jsepRunPromise = new Promise(function (a) {
+            d.Ja = a;
+          });
+        },
+        894623: (a) => {
+          d.Ja(a);
+        },
+        894661: (a) => d.Ea(a),
+        894694: (a) => d.Ga(a),
+        894726: (a, b, c) => {
+          d.Ca(a, b, c, !0);
+        },
+        894765: (a, b, c) => {
+          d.Ca(a, b, c);
+        },
+        894798: (a) => {
+          d.la("Abs", a, void 0);
+        },
+        894849: (a) => {
+          d.la("Neg", a, void 0);
+        },
+        894900: (a) => {
+          d.la("Floor", a, void 0);
+        },
+        894953: (a) => {
+          d.la("Ceil", a, void 0);
+        },
+        895005: (a) => {
+          d.la("Reciprocal", a, void 0);
+        },
+        895063: (a) => {
+          d.la("Sqrt", a, void 0);
+        },
+        895115: (a) => {
+          d.la("Exp", a, void 0);
+        },
+        895166: (a) => {
+          d.la("Erf", a, void 0);
+        },
+        895217: (a) => {
+          d.la("Sigmoid", a, void 0);
+        },
+        895272: (a) => {
+          d.la("Log", a, void 0);
+        },
+        895323: (a) => {
+          d.la("Sin", a, void 0);
+        },
+        895374: (a) => {
+          d.la("Cos", a, void 0);
+        },
+        895425: (a) => {
+          d.la("Tan", a, void 0);
+        },
+        895476: (a) => {
+          d.la("Asin", a, void 0);
+        },
+        895528: (a) => {
+          d.la("Acos", a, void 0);
+        },
+        895580: (a) => {
+          d.la("Atan", a, void 0);
+        },
+        895632: (a) => {
+          d.la("Sinh", a, void 0);
+        },
+        895684: (a) => {
+          d.la("Cosh", a, void 0);
+        },
+        895736: (a) => {
+          d.la("Asinh", a, void 0);
+        },
+        895789: (a) => {
+          d.la("Acosh", a, void 0);
+        },
+        895842: (a) => {
+          d.la("Atanh", a, void 0);
+        },
+        895895: (a) => {
+          d.la("Tanh", a, void 0);
+        },
+        895947: (a, b, c) => {
+          d.la("ClipV10", a, { min: b, max: c });
+        },
+        896019: (a) => {
+          d.la("Clip", a, void 0);
+        },
+        896071: (a, b) => {
+          d.la("Elu", a, { alpha: b });
+        },
+        896129: (a) => {
+          d.la("Relu", a, void 0);
+        },
+        896181: (a, b) => {
+          d.la("LeakyRelu", a, { alpha: b });
+        },
+        896245: (a, b) => {
+          d.la("ThresholdedRelu", a, { alpha: b });
+        },
+        896315: (a, b) => {
+          d.la("Cast", a, { to: b });
+        },
+        896373: (a) => {
+          d.la("Add", a, void 0);
+        },
+        896424: (a) => {
+          d.la("Sub", a, void 0);
+        },
+        896475: (a) => {
+          d.la("Mul", a, void 0);
+        },
+        896526: (a) => {
+          d.la("Div", a, void 0);
+        },
+        896577: (a) => {
+          d.la("Pow", a, void 0);
+        },
+        896628: (a, b, c, e, f) => {
+          d.la("ReduceMean", a, {
+            keepDims: !!b,
+            noopWithEmptyAxes: !!c,
+            axes: e ? Array.from(N.subarray(f >>> 0, (f + e) >>> 0)) : [],
+          });
+        },
+        896792: (a, b, c, e, f) => {
+          d.la("ReduceMax", a, {
+            keepDims: !!b,
+            noopWithEmptyAxes: !!c,
+            axes: e ? Array.from(N.subarray(f >>> 0, (f + e) >>> 0)) : [],
+          });
+        },
+        896955: (a, b, c, e, f) => {
+          d.la("ReduceMin", a, {
+            keepDims: !!b,
+            noopWithEmptyAxes: !!c,
+            axes: e ? Array.from(N.subarray(f >>> 0, (f + e) >>> 0)) : [],
+          });
+        },
+        897118: (a, b, c, e, f) => {
+          d.la("ReduceProd", a, {
+            keepDims: !!b,
+            noopWithEmptyAxes: !!c,
+            axes: e ? Array.from(N.subarray(f >>> 0, (f + e) >>> 0)) : [],
+          });
+        },
+        897282: (a, b, c, e, f) => {
+          d.la("ReduceSum", a, {
+            keepDims: !!b,
+            noopWithEmptyAxes: !!c,
+            axes: e ? Array.from(N.subarray(f >>> 0, (f + e) >>> 0)) : [],
+          });
+        },
+        897445: (a, b, c, e, f) => {
+          d.la("ReduceL1", a, {
+            keepDims: !!b,
+            noopWithEmptyAxes: !!c,
+            axes: e ? Array.from(N.subarray(f >>> 0, (f + e) >>> 0)) : [],
+          });
+        },
+        897607: (a, b, c, e, f) => {
+          d.la("ReduceL2", a, {
+            keepDims: !!b,
+            noopWithEmptyAxes: !!c,
+            axes: e ? Array.from(N.subarray(f >>> 0, (f + e) >>> 0)) : [],
+          });
+        },
+        897769: (a, b, c, e, f) => {
+          d.la("ReduceLogSum", a, {
+            keepDims: !!b,
+            noopWithEmptyAxes: !!c,
+            axes: e ? Array.from(N.subarray(f >>> 0, (f + e) >>> 0)) : [],
+          });
+        },
+        897935: (a, b, c, e, f) => {
+          d.la("ReduceSumSquare", a, {
+            keepDims: !!b,
+            noopWithEmptyAxes: !!c,
+            axes: e ? Array.from(N.subarray(f >>> 0, (f + e) >>> 0)) : [],
+          });
+        },
+        898104: (a, b, c, e, f) => {
+          d.la("ReduceLogSumExp", a, {
+            keepDims: !!b,
+            noopWithEmptyAxes: !!c,
+            axes: e ? Array.from(N.subarray(f >>> 0, (f + e) >>> 0)) : [],
+          });
+        },
+        898273: (a, b, c) => {
+          d.la("Transpose", a, { perm: b ? Array.from(N.subarray(c >>> 0, (c + b) >>> 0)) : [] });
+        },
+        898386: (a, b, c, e, f, h, l, m, r, n) => {
+          d.la("Conv", a, {
+            format: r ? "NHWC" : "NCHW",
+            auto_pad: b,
+            dilations: [c],
+            group: e,
+            kernel_shape: [f],
+            pads: [h, l],
+            strides: [m],
+            w_is_const: () => !!L[n >>> 0],
+          });
+        },
+        898614: (a, b, c, e, f, h, l, m, r, n, p, v, w, g, q) => {
+          d.la("Conv", a, {
+            format: g ? "NHWC" : "NCHW",
+            auto_pad: b,
+            dilations: [c, e],
+            group: f,
+            kernel_shape: [h, l],
+            pads: [m, r, n, p],
+            strides: [v, w],
+            w_is_const: () => !!L[q >>> 0],
+          });
+        },
+        898873: (a, b, c, e, f, h, l, m, r, n) => {
+          d.la("Conv", a, {
+            format: r ? "NHWC" : "NCHW",
+            auto_pad: b,
+            dilations: [c],
+            group: e,
+            kernel_shape: [f],
+            pads: [h, l],
+            strides: [m],
+            w_is_const: () => !!L[n >>> 0],
+          });
+        },
+        899101: (a, b, c, e, f, h, l, m, r, n, p, v, w, g, q) => {
+          d.la("Conv", a, {
+            format: g ? "NHWC" : "NCHW",
+            auto_pad: b,
+            dilations: [c, e],
+            group: f,
+            kernel_shape: [h, l],
+            pads: [m, r, n, p],
+            strides: [v, w],
+            w_is_const: () => !!L[q >>> 0],
+          });
+        },
+        899360: (a, b, c, e, f, h, l, m, r, n, p, v, w, g) => {
+          d.la("ConvTranspose", a, {
+            format: r ? "NHWC" : "NCHW",
+            autoPad: b,
+            dilations: [c],
+            group: e,
+            kernel_shape: [f],
+            pads: [h, l],
+            strides: [m],
+            wIsConst: () => !!L[n >>> 0],
+            outputPadding: p ? Array.from(N.subarray(v >>> 0, (v + p) >>> 0)) : [],
+            outputShape: w ? Array.from(N.subarray(g >>> 0, (g + w) >>> 0)) : [],
+          });
+        },
+        899740: (a, b, c, e, f, h, l, m, r, n, p, v, w) => {
+          d.la("ConvTranspose", a, {
+            format: m ? "NHWC" : "NCHW",
+            autoPad: b,
+            dilations: Array.from(N.subarray(c >>> 0, (c + 2) >>> 0)),
+            group: e,
+            kernelShape: Array.from(N.subarray(f >>> 0, (f + 2) >>> 0)),
+            pads: Array.from(N.subarray(h >>> 0, (h + 4) >>> 0)),
+            strides: Array.from(N.subarray(l >>> 0, (l + 2) >>> 0)),
+            wIsConst: () => !!L[r >>> 0],
+            outputPadding: 0 < n ? Array.from(N.subarray(p >>> 0, (p + n) >>> 0)) : [],
+            outputShape: 0 < v ? Array.from(N.subarray(w >>> 0, (w + v) >>> 0)) : [],
+          });
+        },
+        900263: (a, b, c, e, f, h, l, m, r, n, p, v, w, g) => {
+          d.la("ConvTranspose", a, {
+            format: r ? "NHWC" : "NCHW",
+            autoPad: b,
+            dilations: [c],
+            group: e,
+            kernel_shape: [f],
+            pads: [h, l],
+            strides: [m],
+            wIsConst: () => !!L[n >>> 0],
+            outputPadding: p ? Array.from(N.subarray(v >>> 0, (v + p) >>> 0)) : [],
+            outputShape: w ? Array.from(N.subarray(g >>> 0, (g + w) >>> 0)) : [],
+          });
+        },
+        900643: (a, b, c, e, f, h, l, m, r, n, p, v, w) => {
+          d.la("ConvTranspose", a, {
+            format: m ? "NHWC" : "NCHW",
+            autoPad: b,
+            dilations: Array.from(N.subarray(c >>> 0, (c + 2) >>> 0)),
+            group: e,
+            kernelShape: Array.from(N.subarray(f >>> 0, (f + 2) >>> 0)),
+            pads: Array.from(N.subarray(h >>> 0, (h + 4) >>> 0)),
+            strides: Array.from(N.subarray(l >>> 0, (l + 2) >>> 0)),
+            wIsConst: () => !!L[r >>> 0],
+            outputPadding: 0 < n ? Array.from(N.subarray(p >>> 0, (p + n) >>> 0)) : [],
+            outputShape: 0 < v ? Array.from(N.subarray(w >>> 0, (w + v) >>> 0)) : [],
+          });
+        },
+        901166: (a, b) => {
+          d.la("GlobalAveragePool", a, { format: b ? "NHWC" : "NCHW" });
+        },
+        901257: (a, b, c, e, f, h, l, m, r, n, p, v, w, g, q, u) => {
+          d.la("AveragePool", a, {
+            format: u ? "NHWC" : "NCHW",
+            auto_pad: b,
+            ceil_mode: c,
+            count_include_pad: e,
+            storage_order: f,
+            dilations: [h, l],
+            kernel_shape: [m, r],
+            pads: [n, p, v, w],
+            strides: [g, q],
+          });
+        },
+        901541: (a, b) => {
+          d.la("GlobalAveragePool", a, { format: b ? "NHWC" : "NCHW" });
+        },
+        901632: (a, b, c, e, f, h, l, m, r, n, p, v, w, g, q, u) => {
+          d.la("AveragePool", a, {
+            format: u ? "NHWC" : "NCHW",
+            auto_pad: b,
+            ceil_mode: c,
+            count_include_pad: e,
+            storage_order: f,
+            dilations: [h, l],
+            kernel_shape: [m, r],
+            pads: [n, p, v, w],
+            strides: [g, q],
+          });
+        },
+        901916: (a, b) => {
+          d.la("GlobalMaxPool", a, { format: b ? "NHWC" : "NCHW" });
+        },
+        902003: (a, b, c, e, f, h, l, m, r, n, p, v, w, g, q, u) => {
+          d.la("MaxPool", a, {
+            format: u ? "NHWC" : "NCHW",
+            auto_pad: b,
+            ceil_mode: c,
+            count_include_pad: e,
+            storage_order: f,
+            dilations: [h, l],
+            kernel_shape: [m, r],
+            pads: [n, p, v, w],
+            strides: [g, q],
+          });
+        },
+        902283: (a, b) => {
+          d.la("GlobalMaxPool", a, { format: b ? "NHWC" : "NCHW" });
+        },
+        902370: (a, b, c, e, f, h, l, m, r, n, p, v, w, g, q, u) => {
+          d.la("MaxPool", a, {
+            format: u ? "NHWC" : "NCHW",
+            auto_pad: b,
+            ceil_mode: c,
+            count_include_pad: e,
+            storage_order: f,
+            dilations: [h, l],
+            kernel_shape: [m, r],
+            pads: [n, p, v, w],
+            strides: [g, q],
+          });
+        },
+        902650: (a, b, c, e, f) => {
+          d.la("Gemm", a, { alpha: b, beta: c, transA: e, transB: f });
+        },
+        902754: (a) => {
+          d.la("MatMul", a, void 0);
+        },
+        902808: (a, b, c, e) => {
+          d.la("ArgMax", a, { keepDims: !!b, selectLastIndex: !!c, axis: e });
+        },
+        902916: (a, b, c, e) => {
+          d.la("ArgMin", a, { keepDims: !!b, selectLastIndex: !!c, axis: e });
+        },
+        903024: (a, b) => {
+          d.la("Softmax", a, { axis: b });
+        },
+        903087: (a, b) => {
+          d.la("Concat", a, { axis: b });
+        },
+        903147: (a, b, c, e, f) => {
+          d.la("Split", a, {
+            axis: b,
+            numOutputs: c,
+            splitSizes: e ? Array.from(N.subarray(f >>> 0, (f + e) >>> 0)) : [],
+          });
+        },
+        903292: (a) => {
+          d.la("Expand", a, void 0);
+        },
+        903346: (a, b) => {
+          d.la("Gather", a, { axis: Number(b) });
+        },
+        903417: (a, b, c, e, f, h, l, m, r, n, p) => {
+          d.la("Resize", a, {
+            antialias: b,
+            axes: c ? Array.from(N.subarray(e >>> 0, (e + c) >>> 0)) : [],
+            coordinateTransformMode: T(f),
+            cubicCoeffA: h,
+            excludeOutside: l,
+            extrapolationValue: m,
+            keepAspectRatioPolicy: T(r),
+            mode: T(n),
+            nearestMode: T(p),
+          });
+        },
+        903768: (a, b, c, e, f, h, l) => {
+          d.la("Slice", a, {
+            starts: b ? Array.from(N.subarray(c >>> 0, (c + b) >>> 0)) : [],
+            ends: e ? Array.from(N.subarray(f >>> 0, (f + e) >>> 0)) : [],
+            axes: h ? Array.from(N.subarray(l >>> 0, (l + h) >>> 0)) : [],
+          });
+        },
+        903999: (a) => {
+          d.la("Tile", a, void 0);
+        },
+        904051: (a, b, c) => {
+          d.la("LayerNormalization", a, { axis: Number(b), epsilon: Number(c) });
+        },
+        904158: (a, b, c) => {
+          d.la("InstanceNormalization", a, { epsilon: b, format: c ? "NHWC" : "NCHW" });
+        },
+        904272: (a, b, c) => {
+          d.la("InstanceNormalization", a, { epsilon: b, format: c ? "NHWC" : "NCHW" });
+        },
+        904386: (a) => {
+          d.la("Gelu", a, void 0);
+        },
+        904438: (a, b) => {
+          d.la("SkipLayerNormalization", a, { epsilon: b });
+        },
+        904519: (a) => {
+          d.Ha(a);
+        },
+        904553: (a, b) => d.Ia(a, b),
+      };
+    function va(a) {
+      this.name = "ExitStatus";
+      this.message = `Program terminated with exit(${a})`;
+      this.status = a;
+    }
+    var wa = (a) => {
+      for (; 0 < a.length; ) a.shift()(d);
+    };
+    function xa(a) {
+      this.za = a - 24;
+      this.Ra = function (b) {
+        O[((this.za + 4) >> 2) >>> 0] = b;
+      };
+      this.Qa = function (b) {
+        O[((this.za + 8) >> 2) >>> 0] = b;
+      };
+      this.Ka = function (b, c) {
+        this.Pa();
+        this.Ra(b);
+        this.Qa(c);
+      };
+      this.Pa = function () {
+        O[((this.za + 16) >> 2) >>> 0] = 0;
+      };
+    }
+    var ya = 0,
+      za = 0,
+      Aa = "undefined" != typeof TextDecoder ? new TextDecoder("utf8") : void 0,
+      Ba = (a, b, c) => {
+        b >>>= 0;
+        var e = b + c;
+        for (c = b; a[c] && !(c >= e); ) ++c;
+        if (16 < c - b && a.buffer && Aa) return Aa.decode(a.subarray(b, c));
+        for (e = ""; b < c; ) {
+          var f = a[b++];
+          if (f & 128) {
+            var h = a[b++] & 63;
+            if (192 == (f & 224)) e += String.fromCharCode(((f & 31) << 6) | h);
+            else {
+              var l = a[b++] & 63;
+              f =
+                224 == (f & 240)
+                  ? ((f & 15) << 12) | (h << 6) | l
+                  : ((f & 7) << 18) | (h << 12) | (l << 6) | (a[b++] & 63);
+              65536 > f
+                ? (e += String.fromCharCode(f))
+                : ((f -= 65536), (e += String.fromCharCode(55296 | (f >> 10), 56320 | (f & 1023))));
+            }
+          } else e += String.fromCharCode(f);
+        }
+        return e;
+      },
+      T = (a, b) => ((a >>>= 0) ? Ba(M, a, b) : ""),
+      Ca = (a) => {
+        for (var b = 0, c = 0; c < a.length; ++c) {
+          var e = a.charCodeAt(c);
+          127 >= e ? b++ : 2047 >= e ? (b += 2) : 55296 <= e && 57343 >= e ? ((b += 4), ++c) : (b += 3);
+        }
+        return b;
+      },
+      Da = (a, b, c, e) => {
+        c >>>= 0;
+        if (!(0 < e)) return 0;
+        var f = c;
+        e = c + e - 1;
+        for (var h = 0; h < a.length; ++h) {
+          var l = a.charCodeAt(h);
+          if (55296 <= l && 57343 >= l) {
+            var m = a.charCodeAt(++h);
+            l = (65536 + ((l & 1023) << 10)) | (m & 1023);
+          }
+          if (127 >= l) {
+            if (c >= e) break;
+            b[c++ >>> 0] = l;
+          } else {
+            if (2047 >= l) {
+              if (c + 1 >= e) break;
+              b[c++ >>> 0] = 192 | (l >> 6);
+            } else {
+              if (65535 >= l) {
+                if (c + 2 >= e) break;
+                b[c++ >>> 0] = 224 | (l >> 12);
+              } else {
+                if (c + 3 >= e) break;
+                b[c++ >>> 0] = 240 | (l >> 18);
+                b[c++ >>> 0] = 128 | ((l >> 12) & 63);
+              }
+              b[c++ >>> 0] = 128 | ((l >> 6) & 63);
+            }
+            b[c++ >>> 0] = 128 | (l & 63);
+          }
+        }
+        b[c >>> 0] = 0;
+        return c - f;
+      },
+      U = (a) => 0 === a % 4 && (0 !== a % 100 || 0 === a % 400),
+      Ea = [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335],
+      Fa = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334],
+      Ha = (a) => {
+        var b = Ca(a) + 1,
+          c = Ga(b);
+        c && Da(a, M, c, b);
+        return c;
+      },
+      Ia = [],
+      Ja = (a, b) => {
+        Ia.length = 0;
+        var c;
+        for (b >>= 2; (c = M[a++ >>> 0]); ) (b += (105 != c) & b), Ia.push(105 == c ? N[b >>> 0] : ha[b++ >>> 1]), ++b;
+        return Ia;
+      },
+      Ka = {},
+      Na = () => {
+        if (!La) {
+          var a = {
+              USER: "web_user",
+              LOGNAME: "web_user",
+              PATH: "/",
+              PWD: "/",
+              HOME: "/home/web_user",
+              LANG:
+                (("object" == typeof navigator && navigator.languages && navigator.languages[0]) || "C").replace(
+                  "-",
+                  "_",
+                ) + ".UTF-8",
+              _: t || "./this.program",
+            },
+            b;
+          for (b in Ka) void 0 === Ka[b] ? delete a[b] : (a[b] = Ka[b]);
+          var c = [];
+          for (b in a) c.push(`${b}=${a[b]}`);
+          La = c;
+        }
+        return La;
+      },
+      La,
+      Oa = (a) => {
+        K = a;
+        if (!noExitRuntime) {
+          if (d.onExit) d.onExit(a);
+          J = !0;
+        }
+        x(a, new va(a));
+      },
+      Pa = [null, [], []],
+      Qa = () => {
+        if ("object" == typeof crypto && "function" == typeof crypto.getRandomValues)
+          return (c) => crypto.getRandomValues(c);
+        if (z)
+          try {
+            var a = require("crypto");
+            if (a.randomFillSync) return (c) => a.randomFillSync(c);
+            var b = a.randomBytes;
+            return (c) => (c.set(b(c.byteLength)), c);
+          } catch (c) {}
+        F("initRandomDevice");
+      },
+      Ra = (a) => (Ra = Qa())(a),
+      Sa = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+      Ta = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    function Ua(a) {
+      var b = Array(Ca(a) + 1);
+      Da(a, b, 0, b.length);
+      return b;
+    }
+    function Va(a, b, c, e) {
+      function f(g, q, u) {
+        for (g = "number" == typeof g ? g.toString() : g || ""; g.length < q; ) g = u[0] + g;
+        return g;
+      }
+      function h(g, q) {
+        return f(g, q, "0");
+      }
+      function l(g, q) {
+        function u(Ma) {
+          return 0 > Ma ? -1 : 0 < Ma ? 1 : 0;
+        }
+        var H;
+        0 === (H = u(g.getFullYear() - q.getFullYear())) &&
+          0 === (H = u(g.getMonth() - q.getMonth())) &&
+          (H = u(g.getDate() - q.getDate()));
+        return H;
+      }
+      function m(g) {
+        switch (g.getDay()) {
+          case 0:
+            return new Date(g.getFullYear() - 1, 11, 29);
+          case 1:
+            return g;
+          case 2:
+            return new Date(g.getFullYear(), 0, 3);
+          case 3:
+            return new Date(g.getFullYear(), 0, 2);
+          case 4:
+            return new Date(g.getFullYear(), 0, 1);
+          case 5:
+            return new Date(g.getFullYear() - 1, 11, 31);
+          case 6:
+            return new Date(g.getFullYear() - 1, 11, 30);
+        }
+      }
+      function r(g) {
+        var q = g.va;
+        for (g = new Date(new Date(g.wa + 1900, 0, 1).getTime()); 0 < q; ) {
+          var u = g.getMonth(),
+            H = (U(g.getFullYear()) ? Sa : Ta)[u];
+          if (q > H - g.getDate())
+            (q -= H - g.getDate() + 1),
+              g.setDate(1),
+              11 > u ? g.setMonth(u + 1) : (g.setMonth(0), g.setFullYear(g.getFullYear() + 1));
+          else {
+            g.setDate(g.getDate() + q);
+            break;
+          }
+        }
+        u = new Date(g.getFullYear() + 1, 0, 4);
+        q = m(new Date(g.getFullYear(), 0, 4));
+        u = m(u);
+        return 0 >= l(q, g) ? (0 >= l(u, g) ? g.getFullYear() + 1 : g.getFullYear()) : g.getFullYear() - 1;
+      }
+      a >>>= 0;
+      b >>>= 0;
+      c >>>= 0;
+      e >>>= 0;
+      var n = N[((e + 40) >> 2) >>> 0];
+      e = {
+        Na: N[(e >> 2) >>> 0],
+        Ma: N[((e + 4) >> 2) >>> 0],
+        xa: N[((e + 8) >> 2) >>> 0],
+        Ba: N[((e + 12) >> 2) >>> 0],
+        ya: N[((e + 16) >> 2) >>> 0],
+        wa: N[((e + 20) >> 2) >>> 0],
+        qa: N[((e + 24) >> 2) >>> 0],
+        va: N[((e + 28) >> 2) >>> 0],
+        Ta: N[((e + 32) >> 2) >>> 0],
+        La: N[((e + 36) >> 2) >>> 0],
+        Oa: n ? T(n) : "",
+      };
+      c = T(c);
+      n = {
+        "%c": "%a %b %d %H:%M:%S %Y",
+        "%D": "%m/%d/%y",
+        "%F": "%Y-%m-%d",
+        "%h": "%b",
+        "%r": "%I:%M:%S %p",
+        "%R": "%H:%M",
+        "%T": "%H:%M:%S",
+        "%x": "%m/%d/%y",
+        "%X": "%H:%M:%S",
+        "%Ec": "%c",
+        "%EC": "%C",
+        "%Ex": "%m/%d/%y",
+        "%EX": "%H:%M:%S",
+        "%Ey": "%y",
+        "%EY": "%Y",
+        "%Od": "%d",
+        "%Oe": "%e",
+        "%OH": "%H",
+        "%OI": "%I",
+        "%Om": "%m",
+        "%OM": "%M",
+        "%OS": "%S",
+        "%Ou": "%u",
+        "%OU": "%U",
+        "%OV": "%V",
+        "%Ow": "%w",
+        "%OW": "%W",
+        "%Oy": "%y",
+      };
+      for (var p in n) c = c.replace(new RegExp(p, "g"), n[p]);
+      var v = "Sunday Monday Tuesday Wednesday Thursday Friday Saturday".split(" "),
+        w = "January February March April May June July August September October November December".split(" ");
+      n = {
+        "%a": (g) => v[g.qa].substring(0, 3),
+        "%A": (g) => v[g.qa],
+        "%b": (g) => w[g.ya].substring(0, 3),
+        "%B": (g) => w[g.ya],
+        "%C": (g) => h(((g.wa + 1900) / 100) | 0, 2),
+        "%d": (g) => h(g.Ba, 2),
+        "%e": (g) => f(g.Ba, 2, " "),
+        "%g": (g) => r(g).toString().substring(2),
+        "%G": (g) => r(g),
+        "%H": (g) => h(g.xa, 2),
+        "%I": (g) => {
+          g = g.xa;
+          0 == g ? (g = 12) : 12 < g && (g -= 12);
+          return h(g, 2);
+        },
+        "%j": (g) => {
+          for (var q = 0, u = 0; u <= g.ya - 1; q += (U(g.wa + 1900) ? Sa : Ta)[u++]);
+          return h(g.Ba + q, 3);
+        },
+        "%m": (g) => h(g.ya + 1, 2),
+        "%M": (g) => h(g.Ma, 2),
+        "%n": () => "\n",
+        "%p": (g) => (0 <= g.xa && 12 > g.xa ? "AM" : "PM"),
+        "%S": (g) => h(g.Na, 2),
+        "%t": () => "\t",
+        "%u": (g) => g.qa || 7,
+        "%U": (g) => h(Math.floor((g.va + 7 - g.qa) / 7), 2),
+        "%V": (g) => {
+          var q = Math.floor((g.va + 7 - ((g.qa + 6) % 7)) / 7);
+          2 >= (g.qa + 371 - g.va - 2) % 7 && q++;
+          if (q) 53 == q && ((u = (g.qa + 371 - g.va) % 7), 4 == u || (3 == u && U(g.wa)) || (q = 1));
+          else {
+            q = 52;
+            var u = (g.qa + 7 - g.va - 1) % 7;
+            (4 == u || (5 == u && U((g.wa % 400) - 1))) && q++;
+          }
+          return h(q, 2);
+        },
+        "%w": (g) => g.qa,
+        "%W": (g) => h(Math.floor((g.va + 7 - ((g.qa + 6) % 7)) / 7), 2),
+        "%y": (g) => (g.wa + 1900).toString().substring(2),
+        "%Y": (g) => g.wa + 1900,
+        "%z": (g) => {
+          g = g.La;
+          var q = 0 <= g;
+          g = Math.abs(g) / 60;
+          return (q ? "+" : "-") + String("0000" + ((g / 60) * 100 + (g % 60))).slice(-4);
+        },
+        "%Z": (g) => g.Oa,
+        "%%": () => "%",
+      };
+      c = c.replace(/%%/g, "\x00\x00");
+      for (p in n) c.includes(p) && (c = c.replace(new RegExp(p, "g"), n[p](e)));
+      c = c.replace(/\0\0/g, "%");
+      p = Ua(c);
+      if (p.length > b) return 0;
+      L.set(p, a >>> 0);
+      return p.length - 1;
+    }
+    function V(a) {
+      try {
+        a();
+      } catch (b) {
+        F(b);
+      }
+    }
+    function Wa(a) {
+      var b = {},
+        c;
+      for (c in a)
+        (function (e) {
+          var f = a[e];
+          b[e] =
+            "function" == typeof f
+              ? function () {
+                  W.push(e);
+                  try {
+                    return f.apply(null, arguments);
+                  } finally {
+                    J ||
+                      (W.pop() === e || F(),
+                      X && 1 === Y && 0 === W.length && ((Y = 0), V(Xa), "undefined" != typeof Fibers && Fibers.Ua()));
+                  }
+                }
+              : f;
+        })(c);
+      return b;
+    }
+    var Y = 0,
+      X = null,
+      Ya = 0,
+      W = [],
+      Za = {},
+      $a = {},
+      ab = 0,
+      bb = null,
+      cb = [];
+    function db() {
+      var a = Ga(65548),
+        b = a + 12;
+      O[(a >> 2) >>> 0] = b;
+      O[((a + 4) >> 2) >>> 0] = b + 65536;
+      b = W[0];
+      var c = Za[b];
+      void 0 === c && ((c = ab++), (Za[b] = c), ($a[c] = b));
+      N[((a + 8) >> 2) >>> 0] = c;
+      return a;
+    }
+    function eb(a) {
+      if (!J) {
+        if (0 === Y) {
+          var b = !1,
+            c = !1;
+          a((e = 0) => {
+            if (!J && ((Ya = e), (b = !0), c)) {
+              Y = 2;
+              V(() => fb(X));
+              "undefined" != typeof Browser && Browser.Aa.Da && Browser.Aa.resume();
+              e = !1;
+              try {
+                var f = (0, I[$a[N[((X + 8) >> 2) >>> 0]]])();
+              } catch (m) {
+                (f = m), (e = !0);
+              }
+              var h = !1;
+              if (!X) {
+                var l = bb;
+                l && ((bb = null), (e ? l.reject : l.resolve)(f), (h = !0));
+              }
+              if (e && !h) throw f;
+            }
+          });
+          c = !0;
+          b ||
+            ((Y = 1), (X = db()), "undefined" != typeof Browser && Browser.Aa.Da && Browser.Aa.pause(), V(() => gb(X)));
+        } else
+          2 === Y
+            ? ((Y = 0),
+              V(hb),
+              ib(X),
+              (X = null),
+              cb.forEach((e) => {
+                if (!J)
+                  try {
+                    if ((e(), !noExitRuntime))
+                      try {
+                        (K = e = K), Oa(e);
+                      } catch (f) {
+                        f instanceof va || "unwind" == f || x(1, f);
+                      }
+                  } catch (f) {
+                    f instanceof va || "unwind" == f || x(1, f);
+                  }
+              }))
+            : F(`invalid state: ${Y}`);
+        return Ya;
+      }
+    }
+    function jb(a) {
+      return eb((b) => {
+        a().then(b);
+      });
+    }
+    var lb = {
+      o: function (a, b, c) {
+        return jb(async () => {
+          await d.Fa(a, b, c);
+        });
+      },
+      a: function (a, b, c) {
+        a >>>= 0;
+        new xa(a).Ka(b >>> 0, c >>> 0);
+        ya = a;
+        za++;
+        throw ya;
+      },
+      g: function () {
+        return 0;
+      },
+      L: function () {},
+      C: function () {},
+      E: function () {},
+      N: function () {
+        return 0;
+      },
+      J: function () {},
+      F: function () {},
+      I: function () {},
+      l: function () {},
+      D: function () {},
+      A: function () {},
+      K: function () {},
+      B: function () {},
+      m: () => !0,
+      r: function (a, b, c) {
+        a = (b + 2097152) >>> 0 < 4194305 - !!a ? (a >>> 0) + 4294967296 * b : NaN;
+        c >>>= 0;
+        a = new Date(1e3 * a);
+        N[(c >> 2) >>> 0] = a.getUTCSeconds();
+        N[((c + 4) >> 2) >>> 0] = a.getUTCMinutes();
+        N[((c + 8) >> 2) >>> 0] = a.getUTCHours();
+        N[((c + 12) >> 2) >>> 0] = a.getUTCDate();
+        N[((c + 16) >> 2) >>> 0] = a.getUTCMonth();
+        N[((c + 20) >> 2) >>> 0] = a.getUTCFullYear() - 1900;
+        N[((c + 24) >> 2) >>> 0] = a.getUTCDay();
+        N[((c + 28) >> 2) >>> 0] = ((a.getTime() - Date.UTC(a.getUTCFullYear(), 0, 1, 0, 0, 0, 0)) / 864e5) | 0;
+      },
+      s: function (a, b, c) {
+        a = (b + 2097152) >>> 0 < 4194305 - !!a ? (a >>> 0) + 4294967296 * b : NaN;
+        c >>>= 0;
+        a = new Date(1e3 * a);
+        N[(c >> 2) >>> 0] = a.getSeconds();
+        N[((c + 4) >> 2) >>> 0] = a.getMinutes();
+        N[((c + 8) >> 2) >>> 0] = a.getHours();
+        N[((c + 12) >> 2) >>> 0] = a.getDate();
+        N[((c + 16) >> 2) >>> 0] = a.getMonth();
+        N[((c + 20) >> 2) >>> 0] = a.getFullYear() - 1900;
+        N[((c + 24) >> 2) >>> 0] = a.getDay();
+        N[((c + 28) >> 2) >>> 0] = ((U(a.getFullYear()) ? Ea : Fa)[a.getMonth()] + a.getDate() - 1) | 0;
+        N[((c + 36) >> 2) >>> 0] = -(60 * a.getTimezoneOffset());
+        b = new Date(a.getFullYear(), 6, 1).getTimezoneOffset();
+        var e = new Date(a.getFullYear(), 0, 1).getTimezoneOffset();
+        N[((c + 32) >> 2) >>> 0] = (b != e && a.getTimezoneOffset() == Math.min(e, b)) | 0;
+      },
+      t: function (a) {
+        a >>>= 0;
+        var b = new Date(
+            N[((a + 20) >> 2) >>> 0] + 1900,
+            N[((a + 16) >> 2) >>> 0],
+            N[((a + 12) >> 2) >>> 0],
+            N[((a + 8) >> 2) >>> 0],
+            N[((a + 4) >> 2) >>> 0],
+            N[(a >> 2) >>> 0],
+            0,
+          ),
+          c = N[((a + 32) >> 2) >>> 0],
+          e = b.getTimezoneOffset(),
+          f = new Date(b.getFullYear(), 6, 1).getTimezoneOffset(),
+          h = new Date(b.getFullYear(), 0, 1).getTimezoneOffset(),
+          l = Math.min(h, f);
+        0 > c
+          ? (N[((a + 32) >> 2) >>> 0] = Number(f != h && l == e))
+          : 0 < c != (l == e) && ((f = Math.max(h, f)), b.setTime(b.getTime() + 6e4 * ((0 < c ? l : f) - e)));
+        N[((a + 24) >> 2) >>> 0] = b.getDay();
+        N[((a + 28) >> 2) >>> 0] = ((U(b.getFullYear()) ? Ea : Fa)[b.getMonth()] + b.getDate() - 1) | 0;
+        N[(a >> 2) >>> 0] = b.getSeconds();
+        N[((a + 4) >> 2) >>> 0] = b.getMinutes();
+        N[((a + 8) >> 2) >>> 0] = b.getHours();
+        N[((a + 12) >> 2) >>> 0] = b.getDate();
+        N[((a + 16) >> 2) >>> 0] = b.getMonth();
+        N[((a + 20) >> 2) >>> 0] = b.getYear();
+        a = b.getTime() / 1e3;
+        return (
+          kb(
+            ((S = a),
+            1 <= +Math.abs(S)
+              ? 0 < S
+                ? +Math.floor(S / 4294967296) >>> 0
+                : ~~+Math.ceil((S - +(~~S >>> 0)) / 4294967296) >>> 0
+              : 0),
+          ),
+          a >>> 0
+        );
+      },
+      p: function () {
+        return -52;
+      },
+      q: function () {},
+      x: function (a, b, c) {
+        function e(r) {
+          return (r = r.toTimeString().match(/\(([A-Za-z ]+)\)$/)) ? r[1] : "GMT";
+        }
+        c >>>= 0;
+        var f = new Date().getFullYear(),
+          h = new Date(f, 0, 1),
+          l = new Date(f, 6, 1);
+        f = h.getTimezoneOffset();
+        var m = l.getTimezoneOffset();
+        O[((a >>> 0) >> 2) >>> 0] = 60 * Math.max(f, m);
+        N[((b >>> 0) >> 2) >>> 0] = Number(f != m);
+        a = e(h);
+        b = e(l);
+        a = Ha(a);
+        b = Ha(b);
+        m < f
+          ? ((O[(c >> 2) >>> 0] = a), (O[((c + 4) >> 2) >>> 0] = b))
+          : ((O[(c >> 2) >>> 0] = b), (O[((c + 4) >> 2) >>> 0] = a));
+      },
+      e: () => {
+        F("");
+      },
+      b: function (a, b, c) {
+        a >>>= 0;
+        b = Ja(b >>> 0, c >>> 0);
+        return ua[a].apply(null, b);
+      },
+      i: function (a, b, c) {
+        a >>>= 0;
+        b = Ja(b >>> 0, c >>> 0);
+        return ua[a].apply(null, b);
+      },
+      h: function () {
+        return Date.now();
+      },
+      z: function () {
+        return 4294901760;
+      },
+      d: () => performance.now(),
+      M: function (a, b, c) {
+        b >>>= 0;
+        return M.copyWithin((a >>> 0) >>> 0, b >>> 0, (b + (c >>> 0)) >>> 0);
+      },
+      w: function (a) {
+        a >>>= 0;
+        var b = M.length;
+        if (4294901760 < a) return !1;
+        for (var c = 1; 4 >= c; c *= 2) {
+          var e = b * (1 + 0.2 / c);
+          e = Math.min(e, a + 100663296);
+          var f = Math;
+          e = Math.max(a, e);
+          a: {
+            f = (f.min.call(f, 4294901760, e + ((65536 - (e % 65536)) % 65536)) - G.buffer.byteLength + 65535) >>> 16;
+            try {
+              G.grow(f);
+              ia();
+              var h = 1;
+              break a;
+            } catch (l) {}
+            h = void 0;
+          }
+          if (h) return !0;
+        }
+        return !1;
+      },
+      G: function (a, b) {
+        a >>>= 0;
+        b >>>= 0;
+        var c = 0;
+        Na().forEach(function (e, f) {
+          var h = b + c;
+          f = O[((a + 4 * f) >> 2) >>> 0] = h;
+          for (h = 0; h < e.length; ++h) L[(f++ >> 0) >>> 0] = e.charCodeAt(h);
+          L[(f >> 0) >>> 0] = 0;
+          c += e.length + 1;
+        });
+        return 0;
+      },
+      H: function (a, b) {
+        a >>>= 0;
+        b >>>= 0;
+        var c = Na();
+        O[(a >> 2) >>> 0] = c.length;
+        var e = 0;
+        c.forEach(function (f) {
+          e += f.length + 1;
+        });
+        O[(b >> 2) >>> 0] = e;
+        return 0;
+      },
+      n: (a) => {
+        K = a;
+        Oa(a);
+      },
+      f: () => 52,
+      k: function () {
+        return 52;
+      },
+      u: function () {
+        return 70;
+      },
+      j: function (a, b, c, e) {
+        b >>>= 0;
+        c >>>= 0;
+        e >>>= 0;
+        for (var f = 0, h = 0; h < c; h++) {
+          var l = O[(b >> 2) >>> 0],
+            m = O[((b + 4) >> 2) >>> 0];
+          b += 8;
+          for (var r = 0; r < m; r++) {
+            var n = M[(l + r) >>> 0],
+              p = Pa[a];
+            0 === n || 10 === n ? ((1 === a ? fa : D)(Ba(p, 0)), (p.length = 0)) : p.push(n);
+          }
+          f += m;
+        }
+        O[(e >> 2) >>> 0] = f;
+        return 0;
+      },
+      v: function (a, b) {
+        a >>>= 0;
+        Ra(M.subarray(a >>> 0, (a + (b >>> 0)) >>> 0));
+        return 0;
+      },
+      y: Va,
+      c: function (a, b, c, e) {
+        return Va(a >>> 0, b >>> 0, c >>> 0, e >>> 0);
+      },
+    };
+    (function () {
+      function a(c) {
+        c = c.exports;
+        c = Wa(c);
+        I = c = mb(c);
+        G = I.O;
+        ia();
+        ka.unshift(I.P);
+        P--;
+        d.monitorRunDependencies && d.monitorRunDependencies(P);
+        if (0 == P && (null !== na && (clearInterval(na), (na = null)), Q)) {
+          var e = Q;
+          Q = null;
+          e();
+        }
+        return c;
+      }
+      var b = { a: lb };
+      P++;
+      d.monitorRunDependencies && d.monitorRunDependencies(P);
+      if (d.instantiateWasm)
+        try {
+          return d.instantiateWasm(b, a);
+        } catch (c) {
+          D("Module.instantiateWasm callback failed with error: " + c), k(c);
+        }
+      ta(b, function (c) {
+        a(c.instance);
+      }).catch(k);
+      return {};
+    })();
+    d._OrtInit = (a, b) => (d._OrtInit = I.Q)(a, b);
+    d._OrtGetLastError = (a, b) => (d._OrtGetLastError = I.R)(a, b);
+    d._OrtCreateSessionOptions = (a, b, c, e, f, h, l, m, r, n) =>
+      (d._OrtCreateSessionOptions = I.S)(a, b, c, e, f, h, l, m, r, n);
+    d._OrtAppendExecutionProvider = (a, b) => (d._OrtAppendExecutionProvider = I.T)(a, b);
+    d._OrtAddSessionConfigEntry = (a, b, c) => (d._OrtAddSessionConfigEntry = I.U)(a, b, c);
+    d._OrtReleaseSessionOptions = (a) => (d._OrtReleaseSessionOptions = I.V)(a);
+    d._OrtCreateSession = (a, b, c) => (d._OrtCreateSession = I.W)(a, b, c);
+    d._OrtReleaseSession = (a) => (d._OrtReleaseSession = I.X)(a);
+    d._OrtGetInputOutputCount = (a, b, c) => (d._OrtGetInputOutputCount = I.Y)(a, b, c);
+    d._OrtGetInputName = (a, b) => (d._OrtGetInputName = I.Z)(a, b);
+    d._OrtGetOutputName = (a, b) => (d._OrtGetOutputName = I._)(a, b);
+    d._OrtFree = (a) => (d._OrtFree = I.$)(a);
+    d._OrtCreateTensor = (a, b, c, e, f) => (d._OrtCreateTensor = I.aa)(a, b, c, e, f);
+    d._OrtGetTensorData = (a, b, c, e, f) => (d._OrtGetTensorData = I.ba)(a, b, c, e, f);
+    d._OrtReleaseTensor = (a) => (d._OrtReleaseTensor = I.ca)(a);
+    d._OrtCreateRunOptions = (a, b, c, e) => (d._OrtCreateRunOptions = I.da)(a, b, c, e);
+    d._OrtAddRunConfigEntry = (a, b, c) => (d._OrtAddRunConfigEntry = I.ea)(a, b, c);
+    d._OrtReleaseRunOptions = (a) => (d._OrtReleaseRunOptions = I.fa)(a);
+    d._OrtRun = (a, b, c, e, f, h, l, m) => (d._OrtRun = I.ga)(a, b, c, e, f, h, l, m);
+    d._OrtEndProfiling = (a) => (d._OrtEndProfiling = I.ha)(a);
+    d._JsepOutput = (a, b, c) => (d._JsepOutput = I.ia)(a, b, c);
+    var Ga = (d._malloc = (a) => (Ga = d._malloc = I.ja)(a)),
+      ib = (d._free = (a) => (ib = d._free = I.ka)(a)),
+      kb = (a) => (kb = I.ma)(a),
+      nb = () => (nb = I.na)(),
+      ob = (a) => (ob = I.oa)(a),
+      pb = (a) => (pb = I.pa)(a),
+      gb = (a) => (gb = I.ra)(a),
+      Xa = () => (Xa = I.sa)(),
+      fb = (a) => (fb = I.ta)(a),
+      hb = () => (hb = I.ua)();
+    d.___start_em_js = 904588;
+    d.___stop_em_js = 904749;
+    function mb(a) {
+      a = Object.assign({}, a);
+      var b = (e) => () => e() >>> 0,
+        c = (e) => (f) => e(f) >>> 0;
+      a.__errno_location = b(a.__errno_location);
+      a.malloc = c(a.malloc);
+      a.stackSave = b(a.stackSave);
+      a.stackAlloc = c(a.stackAlloc);
+      return a;
+    }
+    d.stackAlloc = pb;
+    d.stackSave = nb;
+    d.stackRestore = ob;
+    d.UTF8ToString = T;
+    d.stringToUTF8 = (a, b, c) => Da(a, M, b, c);
+    d.lengthBytesUTF8 = Ca;
+    var Z;
+    Q = function qb() {
+      Z || rb();
+      Z || (Q = qb);
+    };
+    function rb() {
+      function a() {
+        if (!Z && ((Z = !0), (d.calledRun = !0), !J)) {
+          wa(ka);
+          aa(d);
+          if (d.onRuntimeInitialized) d.onRuntimeInitialized();
+          if (d.postRun)
+            for ("function" == typeof d.postRun && (d.postRun = [d.postRun]); d.postRun.length; ) {
+              var b = d.postRun.shift();
+              la.unshift(b);
+            }
+          wa(la);
+        }
+      }
+      if (!(0 < P)) {
+        if (d.preRun) for ("function" == typeof d.preRun && (d.preRun = [d.preRun]); d.preRun.length; ) ma();
+        wa(ja);
+        0 < P ||
+          (d.setStatus
+            ? (d.setStatus("Running..."),
+              setTimeout(function () {
+                setTimeout(function () {
+                  d.setStatus("");
+                }, 1);
+                a();
+              }, 1))
+            : a());
+      }
+    }
+    if (d.preInit)
+      for ("function" == typeof d.preInit && (d.preInit = [d.preInit]); 0 < d.preInit.length; ) d.preInit.pop()();
+    rb();
+
+    return moduleArg.ready;
+  };
+})();
+if (typeof exports === "object" && typeof module === "object") module.exports = ortWasm;
+else if (typeof define === "function" && define["amd"]) define([], () => ortWasm);

--- a/js/web/lib/wasm/binding/ort-wasm-threaded.js
+++ b/js/web/lib/wasm/binding/ort-wasm-threaded.js
@@ -1,0 +1,1247 @@
+var ortWasmThreaded = (() => {
+  var _scriptDir = typeof document !== "undefined" && document.currentScript ? document.currentScript.src : undefined;
+  if (typeof __filename !== "undefined") _scriptDir = _scriptDir || __filename;
+  return function (moduleArg = {}) {
+    function aa() {
+      d.buffer != l.buffer && m();
+      return l;
+    }
+    function n() {
+      d.buffer != l.buffer && m();
+      return ba;
+    }
+    function p() {
+      d.buffer != l.buffer && m();
+      return ca;
+    }
+    function r() {
+      d.buffer != l.buffer && m();
+      return da;
+    }
+    function ea() {
+      d.buffer != l.buffer && m();
+      return fa;
+    }
+    var w = moduleArg,
+      ha,
+      x;
+    w.ready = new Promise((a, b) => {
+      ha = a;
+      x = b;
+    });
+    var ia = Object.assign({}, w),
+      ja = "./this.program",
+      z = (a, b) => {
+        throw b;
+      },
+      ka = "object" == typeof window,
+      A = "function" == typeof importScripts,
+      B = "object" == typeof process && "object" == typeof process.versions && "string" == typeof process.versions.node,
+      D = w.ENVIRONMENT_IS_PTHREAD || !1,
+      E = "";
+    function la(a) {
+      return w.locateFile ? w.locateFile(a, E) : E + a;
+    }
+    var ma, F, H;
+    if (B) {
+      var fs = require("fs"),
+        na = require("path");
+      E = A ? na.dirname(E) + "/" : __dirname + "/";
+      ma = (b, c) => {
+        b = b.startsWith("file://") ? new URL(b) : na.normalize(b);
+        return fs.readFileSync(b, c ? void 0 : "utf8");
+      };
+      H = (b) => {
+        b = ma(b, !0);
+        b.buffer || (b = new Uint8Array(b));
+        return b;
+      };
+      F = (b, c, e, h = !0) => {
+        b = b.startsWith("file://") ? new URL(b) : na.normalize(b);
+        fs.readFile(b, h ? void 0 : "utf8", (g, k) => {
+          g ? e(g) : c(h ? k.buffer : k);
+        });
+      };
+      !w.thisProgram && 1 < process.argv.length && (ja = process.argv[1].replace(/\\/g, "/"));
+      process.argv.slice(2);
+      z = (b, c) => {
+        process.exitCode = b;
+        throw c;
+      };
+      w.inspect = () => "[Emscripten Module object]";
+      let a;
+      try {
+        a = require("worker_threads");
+      } catch (b) {
+        throw (
+          (console.error(
+            'The "worker_threads" module is not supported in this node.js build - perhaps a newer version is needed?',
+          ),
+          b)
+        );
+      }
+      global.Worker = a.Worker;
+    } else if (ka || A)
+      A
+        ? (E = self.location.href)
+        : "undefined" != typeof document && document.currentScript && (E = document.currentScript.src),
+        _scriptDir && (E = _scriptDir),
+        0 !== E.indexOf("blob:") ? (E = E.substr(0, E.replace(/[?#].*/, "").lastIndexOf("/") + 1)) : (E = ""),
+        B ||
+          ((ma = (a) => {
+            var b = new XMLHttpRequest();
+            b.open("GET", a, !1);
+            b.send(null);
+            return b.responseText;
+          }),
+          A &&
+            (H = (a) => {
+              var b = new XMLHttpRequest();
+              b.open("GET", a, !1);
+              b.responseType = "arraybuffer";
+              b.send(null);
+              return new Uint8Array(b.response);
+            }),
+          (F = (a, b, c) => {
+            var e = new XMLHttpRequest();
+            e.open("GET", a, !0);
+            e.responseType = "arraybuffer";
+            e.onload = () => {
+              200 == e.status || (0 == e.status && e.response) ? b(e.response) : c();
+            };
+            e.onerror = c;
+            e.send(null);
+          }));
+    B && "undefined" == typeof performance && (global.performance = require("perf_hooks").performance);
+    var oa = console.log.bind(console),
+      pa = console.error.bind(console);
+    B && ((oa = (...a) => fs.writeSync(1, a.join(" ") + "\n")), (pa = (...a) => fs.writeSync(2, a.join(" ") + "\n")));
+    var qa = w.print || oa,
+      I = w.printErr || pa;
+    Object.assign(w, ia);
+    ia = null;
+    w.thisProgram && (ja = w.thisProgram);
+    w.quit && (z = w.quit);
+    var J;
+    w.wasmBinary && (J = w.wasmBinary);
+    var noExitRuntime = w.noExitRuntime || !0;
+    "object" != typeof WebAssembly && K("no native wasm support detected");
+    var d,
+      L,
+      ra,
+      M = !1,
+      N,
+      l,
+      ba,
+      ca,
+      da,
+      fa;
+    function m() {
+      var a = d.buffer;
+      w.HEAP8 = l = new Int8Array(a);
+      w.HEAP16 = new Int16Array(a);
+      w.HEAP32 = ca = new Int32Array(a);
+      w.HEAPU8 = ba = new Uint8Array(a);
+      w.HEAPU16 = new Uint16Array(a);
+      w.HEAPU32 = da = new Uint32Array(a);
+      w.HEAPF32 = new Float32Array(a);
+      w.HEAPF64 = fa = new Float64Array(a);
+    }
+    var O = w.INITIAL_MEMORY || 16777216;
+    5242880 <= O || K("INITIAL_MEMORY should be larger than STACK_SIZE, was " + O + "! (STACK_SIZE=5242880)");
+    if (D) d = w.wasmMemory;
+    else if (w.wasmMemory) d = w.wasmMemory;
+    else if (
+      ((d = new WebAssembly.Memory({ initial: O / 65536, maximum: 65536, shared: !0 })),
+      !(d.buffer instanceof SharedArrayBuffer))
+    )
+      throw (
+        (I(
+          "requested a shared WebAssembly.Memory but the returned buffer is not a SharedArrayBuffer, indicating that while the browser has SharedArrayBuffer it does not have WebAssembly threads support - you may need to set a flag",
+        ),
+        B &&
+          I(
+            "(on node you may need: --experimental-wasm-threads --experimental-wasm-bulk-memory and/or recent version)",
+          ),
+        Error("bad memory"))
+      );
+    m();
+    O = d.buffer.byteLength;
+    var sa,
+      ta = [],
+      ua = [],
+      va = [],
+      wa = 0;
+    function P() {
+      return noExitRuntime || 0 < wa;
+    }
+    var Q = 0,
+      xa = null,
+      R = null;
+    function ya() {
+      Q++;
+      w.monitorRunDependencies && w.monitorRunDependencies(Q);
+    }
+    function za() {
+      Q--;
+      w.monitorRunDependencies && w.monitorRunDependencies(Q);
+      if (0 == Q && (null !== xa && (clearInterval(xa), (xa = null)), R)) {
+        var a = R;
+        R = null;
+        a();
+      }
+    }
+    function K(a) {
+      if (w.onAbort) w.onAbort(a);
+      a = "Aborted(" + a + ")";
+      I(a);
+      M = !0;
+      N = 1;
+      a = new WebAssembly.RuntimeError(a + ". Build with -sASSERTIONS for more info.");
+      x(a);
+      throw a;
+    }
+    function Aa(a) {
+      return a.startsWith("data:application/octet-stream;base64,");
+    }
+    var S;
+    S = "ort-wasm-threaded.wasm";
+    Aa(S) || (S = la(S));
+    function Ba(a) {
+      if (a == S && J) return new Uint8Array(J);
+      if (H) return H(a);
+      throw "both async and sync fetching of the wasm failed";
+    }
+    function Ca(a) {
+      if (!J && (ka || A)) {
+        if ("function" == typeof fetch && !a.startsWith("file://"))
+          return fetch(a, { credentials: "same-origin" })
+            .then((b) => {
+              if (!b.ok) throw "failed to load wasm binary file at '" + a + "'";
+              return b.arrayBuffer();
+            })
+            .catch(() => Ba(a));
+        if (F)
+          return new Promise((b, c) => {
+            F(a, (e) => b(new Uint8Array(e)), c);
+          });
+      }
+      return Promise.resolve().then(() => Ba(a));
+    }
+    function Da(a, b, c) {
+      return Ca(a)
+        .then((e) => WebAssembly.instantiate(e, b))
+        .then((e) => e)
+        .then(c, (e) => {
+          I("failed to asynchronously prepare wasm: " + e);
+          K(e);
+        });
+    }
+    function Ea(a, b) {
+      var c = S;
+      return J ||
+        "function" != typeof WebAssembly.instantiateStreaming ||
+        Aa(c) ||
+        c.startsWith("file://") ||
+        B ||
+        "function" != typeof fetch
+        ? Da(c, a, b)
+        : fetch(c, { credentials: "same-origin" }).then((e) =>
+            WebAssembly.instantiateStreaming(e, a).then(b, function (h) {
+              I("wasm streaming compile failed: " + h);
+              I("falling back to ArrayBuffer instantiation");
+              return Da(c, a, b);
+            }),
+          );
+    }
+    var T;
+    function U(a) {
+      this.name = "ExitStatus";
+      this.message = `Program terminated with exit(${a})`;
+      this.status = a;
+    }
+    function Fa(a) {
+      a.terminate();
+      a.onmessage = () => {};
+    }
+    function Ga(a) {
+      (a = V.Fa[a]) || K();
+      V.fb(a);
+    }
+    function Ha(a) {
+      var b = V.Za();
+      if (!b) return 6;
+      V.Ia.push(b);
+      V.Fa[a.Ha] = b;
+      b.Ha = a.Ha;
+      var c = { cmd: "run", start_routine: a.gb, arg: a.Ya, pthread_ptr: a.Ha };
+      B && b.unref();
+      b.postMessage(c, a.mb);
+      return 0;
+    }
+    var Ia = "undefined" != typeof TextDecoder ? new TextDecoder("utf8") : void 0,
+      Ja = (a, b, c) => {
+        b >>>= 0;
+        var e = b + c;
+        for (c = b; a[c] && !(c >= e); ) ++c;
+        if (16 < c - b && a.buffer && Ia)
+          return Ia.decode(a.buffer instanceof SharedArrayBuffer ? a.slice(b, c) : a.subarray(b, c));
+        for (e = ""; b < c; ) {
+          var h = a[b++];
+          if (h & 128) {
+            var g = a[b++] & 63;
+            if (192 == (h & 224)) e += String.fromCharCode(((h & 31) << 6) | g);
+            else {
+              var k = a[b++] & 63;
+              h =
+                224 == (h & 240)
+                  ? ((h & 15) << 12) | (g << 6) | k
+                  : ((h & 7) << 18) | (g << 12) | (k << 6) | (a[b++] & 63);
+              65536 > h
+                ? (e += String.fromCharCode(h))
+                : ((h -= 65536), (e += String.fromCharCode(55296 | (h >> 10), 56320 | (h & 1023))));
+            }
+          } else e += String.fromCharCode(h);
+        }
+        return e;
+      },
+      Ka = (a, b) => ((a >>>= 0) ? Ja(n(), a, b) : "");
+    function La(a) {
+      if (D) return W(1, 1, a);
+      N = a;
+      if (!P()) {
+        V.hb();
+        if (w.onExit) w.onExit(a);
+        M = !0;
+      }
+      z(a, new U(a));
+    }
+    var Na = (a) => {
+        N = a;
+        if (D) throw (Ma(a), "unwind");
+        La(a);
+      },
+      V = {
+        La: [],
+        Ia: [],
+        Ta: [],
+        Fa: {},
+        Pa: function () {
+          D ? V.ab() : V.$a();
+        },
+        $a: function () {
+          ta.unshift(() => {
+            ya();
+            V.bb(() => za());
+          });
+        },
+        ab: function () {
+          V.receiveObjectTransfer = V.eb;
+          V.threadInitTLS = V.Sa;
+          V.setExitStatus = V.Ra;
+          noExitRuntime = !1;
+        },
+        Ra: function (a) {
+          N = a;
+        },
+        rb: ["$terminateWorker"],
+        hb: function () {
+          for (var a of V.Ia) Fa(a);
+          for (a of V.La) Fa(a);
+          V.La = [];
+          V.Ia = [];
+          V.Fa = [];
+        },
+        fb: function (a) {
+          var b = a.Ha;
+          delete V.Fa[b];
+          V.La.push(a);
+          V.Ia.splice(V.Ia.indexOf(a), 1);
+          a.Ha = 0;
+          Oa(b);
+        },
+        eb: function () {},
+        Sa: function () {
+          V.Ta.forEach((a) => a());
+        },
+        cb: (a) =>
+          new Promise((b) => {
+            a.onmessage = (g) => {
+              g = g.data;
+              var k = g.cmd;
+              if (g.targetThread && g.targetThread != X()) {
+                var t = V.Fa[g.qb];
+                t
+                  ? t.postMessage(g, g.transferList)
+                  : I(
+                      'Internal error! Worker sent a message "' +
+                        k +
+                        '" to target pthread ' +
+                        g.targetThread +
+                        ", but that thread no longer exists!",
+                    );
+              } else if ("checkMailbox" === k) Y();
+              else if ("spawnThread" === k) Ha(g);
+              else if ("cleanupThread" === k) Ga(g.thread);
+              else if ("killThread" === k)
+                (g = g.thread),
+                  (k = V.Fa[g]),
+                  delete V.Fa[g],
+                  Fa(k),
+                  Oa(g),
+                  V.Ia.splice(V.Ia.indexOf(k), 1),
+                  (k.Ha = 0);
+              else if ("cancelThread" === k) V.Fa[g.thread].postMessage({ cmd: "cancel" });
+              else if ("loaded" === k) (a.loaded = !0), b(a);
+              else if ("alert" === k) alert("Thread " + g.threadId + ": " + g.text);
+              else if ("setimmediate" === g.target) a.postMessage(g);
+              else if ("callHandler" === k) w[g.handler](...g.args);
+              else k && I("worker sent an unknown command " + k);
+            };
+            a.onerror = (g) => {
+              I("worker sent an error! " + g.filename + ":" + g.lineno + ": " + g.message);
+              throw g;
+            };
+            B &&
+              (a.on("message", function (g) {
+                a.onmessage({ data: g });
+              }),
+              a.on("error", function (g) {
+                a.onerror(g);
+              }));
+            var c = [],
+              e = ["onExit", "onAbort", "print", "printErr"],
+              h;
+            for (h of e) w.hasOwnProperty(h) && c.push(h);
+            a.postMessage({
+              cmd: "load",
+              handlers: c,
+              urlOrBlob: w.mainScriptUrlOrBlob || _scriptDir,
+              wasmMemory: d,
+              wasmModule: ra,
+            });
+          }),
+        bb: function (a) {
+          a();
+        },
+        Xa: function () {
+          var a = la("ort-wasm-threaded.worker.js");
+          a = new Worker(a);
+          V.La.push(a);
+        },
+        Za: function () {
+          0 == V.La.length && (V.Xa(), V.cb(V.La[0]));
+          return V.La.pop();
+        },
+      };
+    w.PThread = V;
+    var Pa = (a) => {
+      for (; 0 < a.length; ) a.shift()(w);
+    };
+    w.establishStackSpace = function () {
+      var a = X(),
+        b = p()[((a + 52) >> 2) >>> 0];
+      a = p()[((a + 56) >> 2) >>> 0];
+      Qa(b, b - a);
+      Ra(b);
+    };
+    function Ma(a) {
+      if (D) return W(2, 0, a);
+      Na(a);
+    }
+    var Sa = [];
+    w.invokeEntryPoint = function (a, b) {
+      var c = Sa[a];
+      c || (a >= Sa.length && (Sa.length = a + 1), (Sa[a] = c = sa.get(a)));
+      a = c(b);
+      P() ? V.Ra(a) : Ta(a);
+    };
+    function Ua(a) {
+      this.Oa = a - 24;
+      this.Wa = function (b) {
+        r()[((this.Oa + 4) >> 2) >>> 0] = b;
+      };
+      this.Va = function (b) {
+        r()[((this.Oa + 8) >> 2) >>> 0] = b;
+      };
+      this.Pa = function (b, c) {
+        this.Ua();
+        this.Wa(b);
+        this.Va(c);
+      };
+      this.Ua = function () {
+        r()[((this.Oa + 16) >> 2) >>> 0] = 0;
+      };
+    }
+    var Va = 0,
+      Wa = 0;
+    function Xa(a, b, c, e) {
+      return D ? W(3, 1, a, b, c, e) : Ya(a, b, c, e);
+    }
+    function Ya(a, b, c, e) {
+      a >>>= 0;
+      b >>>= 0;
+      c >>>= 0;
+      e >>>= 0;
+      if ("undefined" == typeof SharedArrayBuffer)
+        return I("Current environment does not support SharedArrayBuffer, pthreads are not available!"), 6;
+      var h = [];
+      if (D && 0 === h.length) return Xa(a, b, c, e);
+      a = { gb: c, Ha: a, Ya: e, mb: h };
+      return D ? ((a.ob = "spawnThread"), postMessage(a, h), 0) : Ha(a);
+    }
+    function Za(a, b, c) {
+      return D ? W(4, 1, a, b, c) : 0;
+    }
+    function $a(a, b) {
+      if (D) return W(5, 1, a, b);
+    }
+    var ab = (a) => {
+        for (var b = 0, c = 0; c < a.length; ++c) {
+          var e = a.charCodeAt(c);
+          127 >= e ? b++ : 2047 >= e ? (b += 2) : 55296 <= e && 57343 >= e ? ((b += 4), ++c) : (b += 3);
+        }
+        return b;
+      },
+      bb = (a, b, c, e) => {
+        c >>>= 0;
+        if (!(0 < e)) return 0;
+        var h = c;
+        e = c + e - 1;
+        for (var g = 0; g < a.length; ++g) {
+          var k = a.charCodeAt(g);
+          if (55296 <= k && 57343 >= k) {
+            var t = a.charCodeAt(++g);
+            k = (65536 + ((k & 1023) << 10)) | (t & 1023);
+          }
+          if (127 >= k) {
+            if (c >= e) break;
+            b[c++ >>> 0] = k;
+          } else {
+            if (2047 >= k) {
+              if (c + 1 >= e) break;
+              b[c++ >>> 0] = 192 | (k >> 6);
+            } else {
+              if (65535 >= k) {
+                if (c + 2 >= e) break;
+                b[c++ >>> 0] = 224 | (k >> 12);
+              } else {
+                if (c + 3 >= e) break;
+                b[c++ >>> 0] = 240 | (k >> 18);
+                b[c++ >>> 0] = 128 | ((k >> 12) & 63);
+              }
+              b[c++ >>> 0] = 128 | ((k >> 6) & 63);
+            }
+            b[c++ >>> 0] = 128 | (k & 63);
+          }
+        }
+        b[c >>> 0] = 0;
+        return c - h;
+      },
+      cb = (a, b, c) => bb(a, n(), b, c);
+    function db(a, b) {
+      if (D) return W(6, 1, a, b);
+    }
+    function eb(a, b, c) {
+      if (D) return W(7, 1, a, b, c);
+    }
+    function fb(a, b, c) {
+      return D ? W(8, 1, a, b, c) : 0;
+    }
+    function gb(a, b) {
+      if (D) return W(9, 1, a, b);
+    }
+    function hb(a, b, c) {
+      if (D) return W(10, 1, a, b, c);
+    }
+    function ib(a, b, c, e) {
+      if (D) return W(11, 1, a, b, c, e);
+    }
+    function jb(a, b, c, e) {
+      if (D) return W(12, 1, a, b, c, e);
+    }
+    function kb(a, b, c, e) {
+      if (D) return W(13, 1, a, b, c, e);
+    }
+    function lb(a) {
+      if (D) return W(14, 1, a);
+    }
+    function mb(a, b) {
+      if (D) return W(15, 1, a, b);
+    }
+    function nb(a, b, c) {
+      if (D) return W(16, 1, a, b, c);
+    }
+    var ob = (a) => {
+      if (!M)
+        try {
+          if ((a(), !P()))
+            try {
+              D ? Ta(N) : Na(N);
+            } catch (b) {
+              b instanceof U || "unwind" == b || z(1, b);
+            }
+        } catch (b) {
+          b instanceof U || "unwind" == b || z(1, b);
+        }
+    };
+    function pb(a) {
+      a >>>= 0;
+      "function" === typeof Atomics.nb &&
+        (Atomics.nb(p(), a >> 2, a).value.then(Y), (a += 128), Atomics.store(p(), a >> 2, 1));
+    }
+    w.__emscripten_thread_mailbox_await = pb;
+    function Y() {
+      var a = X();
+      a && (pb(a), ob(() => qb()));
+    }
+    w.checkMailbox = Y;
+    var Z = (a) => 0 === a % 4 && (0 !== a % 100 || 0 === a % 400),
+      rb = [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335],
+      sb = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334];
+    function tb(a, b, c, e, h, g, k, t) {
+      return D ? W(17, 1, a, b, c, e, h, g, k, t) : -52;
+    }
+    function ub(a, b, c, e, h, g, k) {
+      if (D) return W(18, 1, a, b, c, e, h, g, k);
+    }
+    var wb = (a) => {
+        var b = ab(a) + 1,
+          c = vb(b);
+        c && cb(a, c, b);
+        return c;
+      },
+      yb = (a) => {
+        var b = xb();
+        a = a();
+        Ra(b);
+        return a;
+      };
+    function W(a, b) {
+      var c = arguments.length - 2,
+        e = arguments;
+      return yb(() => {
+        for (var h = zb(8 * c), g = h >> 3, k = 0; k < c; k++) {
+          var t = e[2 + k];
+          ea()[(g + k) >>> 0] = t;
+        }
+        return Ab(a, c, h, b);
+      });
+    }
+    var Bb = [],
+      Cb = {},
+      Eb = () => {
+        if (!Db) {
+          var a = {
+              USER: "web_user",
+              LOGNAME: "web_user",
+              PATH: "/",
+              PWD: "/",
+              HOME: "/home/web_user",
+              LANG:
+                (("object" == typeof navigator && navigator.languages && navigator.languages[0]) || "C").replace(
+                  "-",
+                  "_",
+                ) + ".UTF-8",
+              _: ja || "./this.program",
+            },
+            b;
+          for (b in Cb) void 0 === Cb[b] ? delete a[b] : (a[b] = Cb[b]);
+          var c = [];
+          for (b in a) c.push(`${b}=${a[b]}`);
+          Db = c;
+        }
+        return Db;
+      },
+      Db;
+    function Fb(a, b) {
+      if (D) return W(19, 1, a, b);
+      a >>>= 0;
+      b >>>= 0;
+      var c = 0;
+      Eb().forEach(function (e, h) {
+        var g = b + c;
+        h = r()[((a + 4 * h) >> 2) >>> 0] = g;
+        for (g = 0; g < e.length; ++g) aa()[(h++ >> 0) >>> 0] = e.charCodeAt(g);
+        aa()[(h >> 0) >>> 0] = 0;
+        c += e.length + 1;
+      });
+      return 0;
+    }
+    function Gb(a, b) {
+      if (D) return W(20, 1, a, b);
+      a >>>= 0;
+      b >>>= 0;
+      var c = Eb();
+      r()[(a >> 2) >>> 0] = c.length;
+      var e = 0;
+      c.forEach(function (h) {
+        e += h.length + 1;
+      });
+      r()[(b >> 2) >>> 0] = e;
+      return 0;
+    }
+    function Hb(a) {
+      return D ? W(21, 1, a) : 52;
+    }
+    function Ib(a, b, c, e) {
+      return D ? W(22, 1, a, b, c, e) : 52;
+    }
+    function Mb(a, b, c, e, h) {
+      return D ? W(23, 1, a, b, c, e, h) : 70;
+    }
+    var Nb = [null, [], []];
+    function Ob(a, b, c, e) {
+      if (D) return W(24, 1, a, b, c, e);
+      b >>>= 0;
+      c >>>= 0;
+      e >>>= 0;
+      for (var h = 0, g = 0; g < c; g++) {
+        var k = r()[(b >> 2) >>> 0],
+          t = r()[((b + 4) >> 2) >>> 0];
+        b += 8;
+        for (var C = 0; C < t; C++) {
+          var v = n()[(k + C) >>> 0],
+            y = Nb[a];
+          0 === v || 10 === v ? ((1 === a ? qa : I)(Ja(y, 0)), (y.length = 0)) : y.push(v);
+        }
+        h += t;
+      }
+      r()[(e >> 2) >>> 0] = h;
+      return 0;
+    }
+    var Pb = () => {
+        if ("object" == typeof crypto && "function" == typeof crypto.getRandomValues)
+          return (c) => (c.set(crypto.getRandomValues(new Uint8Array(c.byteLength))), c);
+        if (B)
+          try {
+            var a = require("crypto");
+            if (a.randomFillSync) return (c) => a.randomFillSync(c);
+            var b = a.randomBytes;
+            return (c) => (c.set(b(c.byteLength)), c);
+          } catch (c) {}
+        K("initRandomDevice");
+      },
+      Qb = (a) => (Qb = Pb())(a),
+      Rb = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+      Sb = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    function Tb(a) {
+      var b = Array(ab(a) + 1);
+      bb(a, b, 0, b.length);
+      return b;
+    }
+    var Ub = (a, b) => {
+      aa().set(a, b >>> 0);
+    };
+    function Vb(a, b, c, e) {
+      function h(f, q, u) {
+        for (f = "number" == typeof f ? f.toString() : f || ""; f.length < q; ) f = u[0] + f;
+        return f;
+      }
+      function g(f, q) {
+        return h(f, q, "0");
+      }
+      function k(f, q) {
+        function u(Jb) {
+          return 0 > Jb ? -1 : 0 < Jb ? 1 : 0;
+        }
+        var G;
+        0 === (G = u(f.getFullYear() - q.getFullYear())) &&
+          0 === (G = u(f.getMonth() - q.getMonth())) &&
+          (G = u(f.getDate() - q.getDate()));
+        return G;
+      }
+      function t(f) {
+        switch (f.getDay()) {
+          case 0:
+            return new Date(f.getFullYear() - 1, 11, 29);
+          case 1:
+            return f;
+          case 2:
+            return new Date(f.getFullYear(), 0, 3);
+          case 3:
+            return new Date(f.getFullYear(), 0, 2);
+          case 4:
+            return new Date(f.getFullYear(), 0, 1);
+          case 5:
+            return new Date(f.getFullYear() - 1, 11, 31);
+          case 6:
+            return new Date(f.getFullYear() - 1, 11, 30);
+        }
+      }
+      function C(f) {
+        var q = f.Ja;
+        for (f = new Date(new Date(f.Ka + 1900, 0, 1).getTime()); 0 < q; ) {
+          var u = f.getMonth(),
+            G = (Z(f.getFullYear()) ? Rb : Sb)[u];
+          if (q > G - f.getDate())
+            (q -= G - f.getDate() + 1),
+              f.setDate(1),
+              11 > u ? f.setMonth(u + 1) : (f.setMonth(0), f.setFullYear(f.getFullYear() + 1));
+          else {
+            f.setDate(f.getDate() + q);
+            break;
+          }
+        }
+        u = new Date(f.getFullYear() + 1, 0, 4);
+        q = t(new Date(f.getFullYear(), 0, 4));
+        u = t(u);
+        return 0 >= k(q, f) ? (0 >= k(u, f) ? f.getFullYear() + 1 : f.getFullYear()) : f.getFullYear() - 1;
+      }
+      a >>>= 0;
+      b >>>= 0;
+      c >>>= 0;
+      e >>>= 0;
+      var v = p()[((e + 40) >> 2) >>> 0];
+      e = {
+        kb: p()[(e >> 2) >>> 0],
+        jb: p()[((e + 4) >> 2) >>> 0],
+        Ma: p()[((e + 8) >> 2) >>> 0],
+        Qa: p()[((e + 12) >> 2) >>> 0],
+        Na: p()[((e + 16) >> 2) >>> 0],
+        Ka: p()[((e + 20) >> 2) >>> 0],
+        Ga: p()[((e + 24) >> 2) >>> 0],
+        Ja: p()[((e + 28) >> 2) >>> 0],
+        sb: p()[((e + 32) >> 2) >>> 0],
+        ib: p()[((e + 36) >> 2) >>> 0],
+        lb: v ? Ka(v) : "",
+      };
+      c = Ka(c);
+      v = {
+        "%c": "%a %b %d %H:%M:%S %Y",
+        "%D": "%m/%d/%y",
+        "%F": "%Y-%m-%d",
+        "%h": "%b",
+        "%r": "%I:%M:%S %p",
+        "%R": "%H:%M",
+        "%T": "%H:%M:%S",
+        "%x": "%m/%d/%y",
+        "%X": "%H:%M:%S",
+        "%Ec": "%c",
+        "%EC": "%C",
+        "%Ex": "%m/%d/%y",
+        "%EX": "%H:%M:%S",
+        "%Ey": "%y",
+        "%EY": "%Y",
+        "%Od": "%d",
+        "%Oe": "%e",
+        "%OH": "%H",
+        "%OI": "%I",
+        "%Om": "%m",
+        "%OM": "%M",
+        "%OS": "%S",
+        "%Ou": "%u",
+        "%OU": "%U",
+        "%OV": "%V",
+        "%Ow": "%w",
+        "%OW": "%W",
+        "%Oy": "%y",
+      };
+      for (var y in v) c = c.replace(new RegExp(y, "g"), v[y]);
+      var Kb = "Sunday Monday Tuesday Wednesday Thursday Friday Saturday".split(" "),
+        Lb = "January February March April May June July August September October November December".split(" ");
+      v = {
+        "%a": (f) => Kb[f.Ga].substring(0, 3),
+        "%A": (f) => Kb[f.Ga],
+        "%b": (f) => Lb[f.Na].substring(0, 3),
+        "%B": (f) => Lb[f.Na],
+        "%C": (f) => g(((f.Ka + 1900) / 100) | 0, 2),
+        "%d": (f) => g(f.Qa, 2),
+        "%e": (f) => h(f.Qa, 2, " "),
+        "%g": (f) => C(f).toString().substring(2),
+        "%G": (f) => C(f),
+        "%H": (f) => g(f.Ma, 2),
+        "%I": (f) => {
+          f = f.Ma;
+          0 == f ? (f = 12) : 12 < f && (f -= 12);
+          return g(f, 2);
+        },
+        "%j": (f) => {
+          for (var q = 0, u = 0; u <= f.Na - 1; q += (Z(f.Ka + 1900) ? Rb : Sb)[u++]);
+          return g(f.Qa + q, 3);
+        },
+        "%m": (f) => g(f.Na + 1, 2),
+        "%M": (f) => g(f.jb, 2),
+        "%n": () => "\n",
+        "%p": (f) => (0 <= f.Ma && 12 > f.Ma ? "AM" : "PM"),
+        "%S": (f) => g(f.kb, 2),
+        "%t": () => "\t",
+        "%u": (f) => f.Ga || 7,
+        "%U": (f) => g(Math.floor((f.Ja + 7 - f.Ga) / 7), 2),
+        "%V": (f) => {
+          var q = Math.floor((f.Ja + 7 - ((f.Ga + 6) % 7)) / 7);
+          2 >= (f.Ga + 371 - f.Ja - 2) % 7 && q++;
+          if (q) 53 == q && ((u = (f.Ga + 371 - f.Ja) % 7), 4 == u || (3 == u && Z(f.Ka)) || (q = 1));
+          else {
+            q = 52;
+            var u = (f.Ga + 7 - f.Ja - 1) % 7;
+            (4 == u || (5 == u && Z((f.Ka % 400) - 1))) && q++;
+          }
+          return g(q, 2);
+        },
+        "%w": (f) => f.Ga,
+        "%W": (f) => g(Math.floor((f.Ja + 7 - ((f.Ga + 6) % 7)) / 7), 2),
+        "%y": (f) => (f.Ka + 1900).toString().substring(2),
+        "%Y": (f) => f.Ka + 1900,
+        "%z": (f) => {
+          f = f.ib;
+          var q = 0 <= f;
+          f = Math.abs(f) / 60;
+          return (q ? "+" : "-") + String("0000" + ((f / 60) * 100 + (f % 60))).slice(-4);
+        },
+        "%Z": (f) => f.lb,
+        "%%": () => "%",
+      };
+      c = c.replace(/%%/g, "\x00\x00");
+      for (y in v) c.includes(y) && (c = c.replace(new RegExp(y, "g"), v[y](e)));
+      c = c.replace(/\0\0/g, "%");
+      y = Tb(c);
+      if (y.length > b) return 0;
+      Ub(y, a);
+      return y.length - 1;
+    }
+    V.Pa();
+    var Wb = [null, La, Ma, Xa, Za, $a, db, eb, fb, gb, hb, ib, jb, kb, lb, mb, nb, tb, ub, Fb, Gb, Hb, Ib, Mb, Ob],
+      Zb = {
+        b: function (a, b, c) {
+          a >>>= 0;
+          new Ua(a).Pa(b >>> 0, c >>> 0);
+          Va = a;
+          Wa++;
+          throw Va;
+        },
+        N: function (a) {
+          Xb(a >>> 0, !A, 1, !ka, 131072, !1);
+          V.Sa();
+        },
+        k: function (a) {
+          a >>>= 0;
+          D ? postMessage({ cmd: "cleanupThread", thread: a }) : Ga(a);
+        },
+        I: Ya,
+        h: Za,
+        T: $a,
+        E: db,
+        G: eb,
+        U: fb,
+        R: gb,
+        J: hb,
+        Q: ib,
+        o: jb,
+        F: kb,
+        C: lb,
+        S: mb,
+        D: nb,
+        q: () => !0,
+        A: function (a, b) {
+          a >>>= 0;
+          a == b >>> 0
+            ? setTimeout(() => Y())
+            : D
+            ? postMessage({ targetThread: a, cmd: "checkMailbox" })
+            : (a = V.Fa[a]) && a.postMessage({ cmd: "checkMailbox" });
+        },
+        L: function () {
+          return -1;
+        },
+        M: pb,
+        p: function (a) {
+          B && V.Fa[a >>> 0].ref();
+        },
+        t: function (a, b, c) {
+          a = (b + 2097152) >>> 0 < 4194305 - !!a ? (a >>> 0) + 4294967296 * b : NaN;
+          c >>>= 0;
+          a = new Date(1e3 * a);
+          p()[(c >> 2) >>> 0] = a.getUTCSeconds();
+          p()[((c + 4) >> 2) >>> 0] = a.getUTCMinutes();
+          p()[((c + 8) >> 2) >>> 0] = a.getUTCHours();
+          p()[((c + 12) >> 2) >>> 0] = a.getUTCDate();
+          p()[((c + 16) >> 2) >>> 0] = a.getUTCMonth();
+          p()[((c + 20) >> 2) >>> 0] = a.getUTCFullYear() - 1900;
+          p()[((c + 24) >> 2) >>> 0] = a.getUTCDay();
+          a = ((a.getTime() - Date.UTC(a.getUTCFullYear(), 0, 1, 0, 0, 0, 0)) / 864e5) | 0;
+          p()[((c + 28) >> 2) >>> 0] = a;
+        },
+        u: function (a, b, c) {
+          a = (b + 2097152) >>> 0 < 4194305 - !!a ? (a >>> 0) + 4294967296 * b : NaN;
+          c >>>= 0;
+          a = new Date(1e3 * a);
+          p()[(c >> 2) >>> 0] = a.getSeconds();
+          p()[((c + 4) >> 2) >>> 0] = a.getMinutes();
+          p()[((c + 8) >> 2) >>> 0] = a.getHours();
+          p()[((c + 12) >> 2) >>> 0] = a.getDate();
+          p()[((c + 16) >> 2) >>> 0] = a.getMonth();
+          p()[((c + 20) >> 2) >>> 0] = a.getFullYear() - 1900;
+          p()[((c + 24) >> 2) >>> 0] = a.getDay();
+          b = ((Z(a.getFullYear()) ? rb : sb)[a.getMonth()] + a.getDate() - 1) | 0;
+          p()[((c + 28) >> 2) >>> 0] = b;
+          p()[((c + 36) >> 2) >>> 0] = -(60 * a.getTimezoneOffset());
+          b = new Date(a.getFullYear(), 6, 1).getTimezoneOffset();
+          var e = new Date(a.getFullYear(), 0, 1).getTimezoneOffset();
+          a = (b != e && a.getTimezoneOffset() == Math.min(e, b)) | 0;
+          p()[((c + 32) >> 2) >>> 0] = a;
+        },
+        v: function (a) {
+          a >>>= 0;
+          var b = new Date(
+              p()[((a + 20) >> 2) >>> 0] + 1900,
+              p()[((a + 16) >> 2) >>> 0],
+              p()[((a + 12) >> 2) >>> 0],
+              p()[((a + 8) >> 2) >>> 0],
+              p()[((a + 4) >> 2) >>> 0],
+              p()[(a >> 2) >>> 0],
+              0,
+            ),
+            c = p()[((a + 32) >> 2) >>> 0],
+            e = b.getTimezoneOffset(),
+            h = new Date(b.getFullYear(), 6, 1).getTimezoneOffset(),
+            g = new Date(b.getFullYear(), 0, 1).getTimezoneOffset(),
+            k = Math.min(g, h);
+          0 > c
+            ? (p()[((a + 32) >> 2) >>> 0] = Number(h != g && k == e))
+            : 0 < c != (k == e) && ((h = Math.max(g, h)), b.setTime(b.getTime() + 6e4 * ((0 < c ? k : h) - e)));
+          p()[((a + 24) >> 2) >>> 0] = b.getDay();
+          c = ((Z(b.getFullYear()) ? rb : sb)[b.getMonth()] + b.getDate() - 1) | 0;
+          p()[((a + 28) >> 2) >>> 0] = c;
+          p()[(a >> 2) >>> 0] = b.getSeconds();
+          p()[((a + 4) >> 2) >>> 0] = b.getMinutes();
+          p()[((a + 8) >> 2) >>> 0] = b.getHours();
+          p()[((a + 12) >> 2) >>> 0] = b.getDate();
+          p()[((a + 16) >> 2) >>> 0] = b.getMonth();
+          p()[((a + 20) >> 2) >>> 0] = b.getYear();
+          a = b.getTime() / 1e3;
+          return (
+            Yb(
+              ((T = a),
+              1 <= +Math.abs(T)
+                ? 0 < T
+                  ? +Math.floor(T / 4294967296) >>> 0
+                  : ~~+Math.ceil((T - +(~~T >>> 0)) / 4294967296) >>> 0
+                : 0),
+            ),
+            a >>> 0
+          );
+        },
+        r: tb,
+        s: ub,
+        z: function (a, b, c) {
+          function e(v) {
+            return (v = v.toTimeString().match(/\(([A-Za-z ]+)\)$/)) ? v[1] : "GMT";
+          }
+          a >>>= 0;
+          b >>>= 0;
+          c >>>= 0;
+          var h = new Date().getFullYear(),
+            g = new Date(h, 0, 1),
+            k = new Date(h, 6, 1);
+          h = g.getTimezoneOffset();
+          var t = k.getTimezoneOffset(),
+            C = Math.max(h, t);
+          r()[(a >> 2) >>> 0] = 60 * C;
+          p()[(b >> 2) >>> 0] = Number(h != t);
+          a = e(g);
+          b = e(k);
+          a = wb(a);
+          b = wb(b);
+          t < h
+            ? ((r()[(c >> 2) >>> 0] = a), (r()[((c + 4) >> 2) >>> 0] = b))
+            : ((r()[(c >> 2) >>> 0] = b), (r()[((c + 4) >> 2) >>> 0] = a));
+        },
+        c: () => {
+          K("");
+        },
+        l: function () {},
+        i: function () {
+          return Date.now();
+        },
+        V: () => {
+          wa += 1;
+          throw "unwind";
+        },
+        B: function () {
+          return 4294901760;
+        },
+        e: () => performance.timeOrigin + performance.now(),
+        f: function () {
+          return B ? require("os").cpus().length : navigator.hardwareConcurrency;
+        },
+        K: function (a, b, c, e) {
+          V.pb = b >>> 0;
+          Bb.length = c;
+          b = (e >>> 0) >> 3;
+          for (e = 0; e < c; e++) Bb[e] = ea()[(b + e) >>> 0];
+          return Wb[a].apply(null, Bb);
+        },
+        y: function (a) {
+          a >>>= 0;
+          var b = n().length;
+          if (a <= b || 4294901760 < a) return !1;
+          for (var c = 1; 4 >= c; c *= 2) {
+            var e = b * (1 + 0.2 / c);
+            e = Math.min(e, a + 100663296);
+            var h = Math;
+            e = Math.max(a, e);
+            a: {
+              h = (h.min.call(h, 4294901760, e + ((65536 - (e % 65536)) % 65536)) - d.buffer.byteLength + 65535) >>> 16;
+              try {
+                d.grow(h);
+                m();
+                var g = 1;
+                break a;
+              } catch (k) {}
+              g = void 0;
+            }
+            if (g) return !0;
+          }
+          return !1;
+        },
+        O: Fb,
+        P: Gb,
+        j: Na,
+        g: Hb,
+        n: Ib,
+        w: Mb,
+        m: Ob,
+        x: function (a, b) {
+          a >>>= 0;
+          b >>>= 0;
+          Qb(n().subarray(a >>> 0, (a + b) >>> 0));
+          return 0;
+        },
+        a: d || w.wasmMemory,
+        H: Vb,
+        d: function (a, b, c, e) {
+          return Vb(a >>> 0, b >>> 0, c >>> 0, e >>> 0);
+        },
+      };
+    (function () {
+      function a(c, e) {
+        c = c.exports;
+        L = c = $b(c);
+        V.Ta.push(L.sa);
+        sa = L.ta;
+        ua.unshift(L.W);
+        ra = e;
+        za();
+        return c;
+      }
+      var b = { a: Zb };
+      ya();
+      if (w.instantiateWasm)
+        try {
+          return w.instantiateWasm(b, a);
+        } catch (c) {
+          I("Module.instantiateWasm callback failed with error: " + c), x(c);
+        }
+      Ea(b, function (c) {
+        a(c.instance, c.module);
+      }).catch(x);
+      return {};
+    })();
+    w._OrtInit = (a, b) => (w._OrtInit = L.X)(a, b);
+    w._OrtGetLastError = (a, b) => (w._OrtGetLastError = L.Y)(a, b);
+    w._OrtCreateSessionOptions = (a, b, c, e, h, g, k, t, C, v) =>
+      (w._OrtCreateSessionOptions = L.Z)(a, b, c, e, h, g, k, t, C, v);
+    w._OrtAppendExecutionProvider = (a, b) => (w._OrtAppendExecutionProvider = L._)(a, b);
+    w._OrtAddSessionConfigEntry = (a, b, c) => (w._OrtAddSessionConfigEntry = L.$)(a, b, c);
+    w._OrtReleaseSessionOptions = (a) => (w._OrtReleaseSessionOptions = L.aa)(a);
+    w._OrtCreateSession = (a, b, c) => (w._OrtCreateSession = L.ba)(a, b, c);
+    w._OrtReleaseSession = (a) => (w._OrtReleaseSession = L.ca)(a);
+    w._OrtGetInputOutputCount = (a, b, c) => (w._OrtGetInputOutputCount = L.da)(a, b, c);
+    w._OrtGetInputName = (a, b) => (w._OrtGetInputName = L.ea)(a, b);
+    w._OrtGetOutputName = (a, b) => (w._OrtGetOutputName = L.fa)(a, b);
+    w._OrtFree = (a) => (w._OrtFree = L.ga)(a);
+    w._OrtCreateTensor = (a, b, c, e, h) => (w._OrtCreateTensor = L.ha)(a, b, c, e, h);
+    w._OrtGetTensorData = (a, b, c, e, h) => (w._OrtGetTensorData = L.ia)(a, b, c, e, h);
+    w._OrtReleaseTensor = (a) => (w._OrtReleaseTensor = L.ja)(a);
+    w._OrtCreateRunOptions = (a, b, c, e) => (w._OrtCreateRunOptions = L.ka)(a, b, c, e);
+    w._OrtAddRunConfigEntry = (a, b, c) => (w._OrtAddRunConfigEntry = L.la)(a, b, c);
+    w._OrtReleaseRunOptions = (a) => (w._OrtReleaseRunOptions = L.ma)(a);
+    w._OrtRun = (a, b, c, e, h, g, k, t) => (w._OrtRun = L.na)(a, b, c, e, h, g, k, t);
+    w._OrtEndProfiling = (a) => (w._OrtEndProfiling = L.oa)(a);
+    var X = (w._pthread_self = () => (X = w._pthread_self = L.pa)()),
+      vb = (w._malloc = (a) => (vb = w._malloc = L.qa)(a));
+    w._free = (a) => (w._free = L.ra)(a);
+    w.__emscripten_tls_init = () => (w.__emscripten_tls_init = L.sa)();
+    var Xb = (w.__emscripten_thread_init = (a, b, c, e, h, g) =>
+      (Xb = w.__emscripten_thread_init = L.ua)(a, b, c, e, h, g));
+    w.__emscripten_thread_crashed = () => (w.__emscripten_thread_crashed = L.va)();
+    var Ab = (a, b, c, e) => (Ab = L.wa)(a, b, c, e),
+      Oa = (a) => (Oa = L.xa)(a),
+      Ta = (w.__emscripten_thread_exit = (a) => (Ta = w.__emscripten_thread_exit = L.ya)(a)),
+      qb = (w.__emscripten_check_mailbox = () => (qb = w.__emscripten_check_mailbox = L.za)()),
+      Yb = (a) => (Yb = L.Aa)(a),
+      Qa = (a, b) => (Qa = L.Ba)(a, b),
+      xb = () => (xb = L.Ca)(),
+      Ra = (a) => (Ra = L.Da)(a),
+      zb = (a) => (zb = L.Ea)(a);
+    function $b(a) {
+      a = Object.assign({}, a);
+      var b = (e) => () => e() >>> 0,
+        c = (e) => (h) => e(h) >>> 0;
+      a.__errno_location = b(a.__errno_location);
+      a.pthread_self = b(a.pthread_self);
+      a.malloc = c(a.malloc);
+      a.stackSave = b(a.stackSave);
+      a.stackAlloc = c(a.stackAlloc);
+      return a;
+    }
+    w.keepRuntimeAlive = P;
+    w.wasmMemory = d;
+    w.stackAlloc = zb;
+    w.stackSave = xb;
+    w.stackRestore = Ra;
+    w.UTF8ToString = Ka;
+    w.stringToUTF8 = cb;
+    w.lengthBytesUTF8 = ab;
+    w.ExitStatus = U;
+    w.PThread = V;
+    var ac;
+    R = function bc() {
+      ac || cc();
+      ac || (R = bc);
+    };
+    function cc() {
+      function a() {
+        if (!ac && ((ac = !0), (w.calledRun = !0), !M)) {
+          D || Pa(ua);
+          ha(w);
+          if (w.onRuntimeInitialized) w.onRuntimeInitialized();
+          if (!D) {
+            if (w.postRun)
+              for ("function" == typeof w.postRun && (w.postRun = [w.postRun]); w.postRun.length; ) {
+                var b = w.postRun.shift();
+                va.unshift(b);
+              }
+            Pa(va);
+          }
+        }
+      }
+      if (!(0 < Q))
+        if (D) ha(w), D || Pa(ua), startWorker(w);
+        else {
+          if (w.preRun)
+            for ("function" == typeof w.preRun && (w.preRun = [w.preRun]); w.preRun.length; )
+              ta.unshift(w.preRun.shift());
+          Pa(ta);
+          0 < Q ||
+            (w.setStatus
+              ? (w.setStatus("Running..."),
+                setTimeout(function () {
+                  setTimeout(function () {
+                    w.setStatus("");
+                  }, 1);
+                  a();
+                }, 1))
+              : a());
+        }
+    }
+    if (w.preInit)
+      for ("function" == typeof w.preInit && (w.preInit = [w.preInit]); 0 < w.preInit.length; ) w.preInit.pop()();
+    cc();
+
+    return moduleArg.ready;
+  };
+})();
+if (typeof exports === "object" && typeof module === "object") module.exports = ortWasmThreaded;
+else if (typeof define === "function" && define["amd"]) define([], () => ortWasmThreaded);

--- a/js/web/lib/wasm/binding/ort-wasm-threaded.worker.js
+++ b/js/web/lib/wasm/binding/ort-wasm-threaded.worker.js
@@ -1,0 +1,116 @@
+"use strict";
+var Module = {};
+var ENVIRONMENT_IS_NODE =
+  typeof process == "object" && typeof process.versions == "object" && typeof process.versions.node == "string";
+if (ENVIRONMENT_IS_NODE) {
+  var nodeWorkerThreads = require("worker_threads");
+  var parentPort = nodeWorkerThreads.parentPort;
+  parentPort.on("message", (data) => onmessage({ data: data }));
+  var fs = require("fs");
+  Object.assign(global, {
+    self: global,
+    require: require,
+    Module: Module,
+    location: { href: __filename },
+    Worker: nodeWorkerThreads.Worker,
+    importScripts: (f) => (0, eval)(fs.readFileSync(f, "utf8") + "//# sourceURL=" + f),
+    postMessage: (msg) => parentPort.postMessage(msg),
+    performance: global.performance || { now: Date.now },
+  });
+}
+var initializedJS = false;
+function threadPrintErr() {
+  var text = Array.prototype.slice.call(arguments).join(" ");
+  if (ENVIRONMENT_IS_NODE) {
+    fs.writeSync(2, text + "\n");
+    return;
+  }
+  console.error(text);
+}
+function threadAlert() {
+  var text = Array.prototype.slice.call(arguments).join(" ");
+  postMessage({ cmd: "alert", text: text, threadId: Module["_pthread_self"]() });
+}
+var err = threadPrintErr;
+self.alert = threadAlert;
+Module["instantiateWasm"] = (info, receiveInstance) => {
+  var module = Module["wasmModule"];
+  Module["wasmModule"] = null;
+  var instance = new WebAssembly.Instance(module, info);
+  return receiveInstance(instance);
+};
+self.onunhandledrejection = (e) => {
+  throw e.reason ?? e;
+};
+function handleMessage(e) {
+  try {
+    if (e.data.cmd === "load") {
+      let messageQueue = [];
+      self.onmessage = (e) => messageQueue.push(e);
+      self.startWorker = (instance) => {
+        Module = instance;
+        postMessage({ cmd: "loaded" });
+        for (let msg of messageQueue) {
+          handleMessage(msg);
+        }
+        self.onmessage = handleMessage;
+      };
+      Module["wasmModule"] = e.data.wasmModule;
+      for (const handler of e.data.handlers) {
+        Module[handler] = (...args) => {
+          postMessage({ cmd: "callHandler", handler: handler, args: args });
+        };
+      }
+      Module["wasmMemory"] = e.data.wasmMemory;
+      Module["buffer"] = Module["wasmMemory"].buffer;
+      Module["ENVIRONMENT_IS_PTHREAD"] = true;
+      if (typeof e.data.urlOrBlob == "string") {
+        importScripts(e.data.urlOrBlob);
+      } else {
+        var objectUrl = URL.createObjectURL(e.data.urlOrBlob);
+        importScripts(objectUrl);
+        URL.revokeObjectURL(objectUrl);
+      }
+      ortWasmThreaded(Module);
+    } else if (e.data.cmd === "run") {
+      Module["__emscripten_thread_init"](
+        e.data.pthread_ptr,
+        /*isMainBrowserThread=*/ 0,
+        /*isMainRuntimeThread=*/ 0,
+        /*canBlock=*/ 1,
+      );
+      Module["__emscripten_thread_mailbox_await"](e.data.pthread_ptr);
+      Module["establishStackSpace"]();
+      Module["PThread"].receiveObjectTransfer(e.data);
+      Module["PThread"].threadInitTLS();
+      if (!initializedJS) {
+        initializedJS = true;
+      }
+      try {
+        Module["invokeEntryPoint"](e.data.start_routine, e.data.arg);
+      } catch (ex) {
+        if (ex != "unwind") {
+          throw ex;
+        }
+      }
+    } else if (e.data.cmd === "cancel") {
+      if (Module["_pthread_self"]()) {
+        Module["__emscripten_thread_exit"](-1);
+      }
+    } else if (e.data.target === "setimmediate") {
+    } else if (e.data.cmd === "checkMailbox") {
+      if (initializedJS) {
+        Module["checkMailbox"]();
+      }
+    } else if (e.data.cmd) {
+      err("worker.js received unknown command " + e.data.cmd);
+      err(e.data);
+    }
+  } catch (ex) {
+    if (Module["__emscripten_thread_crashed"]) {
+      Module["__emscripten_thread_crashed"]();
+    }
+    throw ex;
+  }
+}
+self.onmessage = handleMessage;

--- a/js/web/lib/wasm/binding/ort-wasm.d.ts
+++ b/js/web/lib/wasm/binding/ort-wasm.d.ts
@@ -24,7 +24,7 @@ export interface OrtWasmModule extends EmscriptenModule {
   // #endregion
 
   // #region ORT APIs
-  _OrtInit(numThreads: number, loggingLevel: number): number;
+  _OrtInit(numThreads: number, loggingLevel: number): Promise<number>;
 
   _OrtGetLastError(errorCodeOffset: number, errorMessageOffset: number): void;
 

--- a/js/web/lib/wasm/binding/ort-wasm.js
+++ b/js/web/lib/wasm/binding/ort-wasm.js
@@ -1,0 +1,840 @@
+var ortWasm = (() => {
+  var _scriptDir = typeof document !== "undefined" && document.currentScript ? document.currentScript.src : undefined;
+  if (typeof __filename !== "undefined") _scriptDir = _scriptDir || __filename;
+  return function (moduleArg = {}) {
+    var e = moduleArg,
+      aa,
+      h;
+    e.ready = new Promise((a, b) => {
+      aa = a;
+      h = b;
+    });
+    var ba = Object.assign({}, e),
+      m = "./this.program",
+      q = (a, b) => {
+        throw b;
+      },
+      ca = "object" == typeof window,
+      v = "function" == typeof importScripts,
+      x = "object" == typeof process && "object" == typeof process.versions && "string" == typeof process.versions.node,
+      y = "",
+      A,
+      B,
+      C;
+    if (x) {
+      var fs = require("fs"),
+        D = require("path");
+      y = v ? D.dirname(y) + "/" : __dirname + "/";
+      A = (a, b) => {
+        a = a.startsWith("file://") ? new URL(a) : D.normalize(a);
+        return fs.readFileSync(a, b ? void 0 : "utf8");
+      };
+      C = (a) => {
+        a = A(a, !0);
+        a.buffer || (a = new Uint8Array(a));
+        return a;
+      };
+      B = (a, b, c, f = !0) => {
+        a = a.startsWith("file://") ? new URL(a) : D.normalize(a);
+        fs.readFile(a, f ? void 0 : "utf8", (g, k) => {
+          g ? c(g) : b(f ? k.buffer : k);
+        });
+      };
+      !e.thisProgram && 1 < process.argv.length && (m = process.argv[1].replace(/\\/g, "/"));
+      process.argv.slice(2);
+      q = (a, b) => {
+        process.exitCode = a;
+        throw b;
+      };
+      e.inspect = () => "[Emscripten Module object]";
+    } else if (ca || v)
+      v
+        ? (y = self.location.href)
+        : "undefined" != typeof document && document.currentScript && (y = document.currentScript.src),
+        _scriptDir && (y = _scriptDir),
+        0 !== y.indexOf("blob:") ? (y = y.substr(0, y.replace(/[?#].*/, "").lastIndexOf("/") + 1)) : (y = ""),
+        (A = (a) => {
+          var b = new XMLHttpRequest();
+          b.open("GET", a, !1);
+          b.send(null);
+          return b.responseText;
+        }),
+        v &&
+          (C = (a) => {
+            var b = new XMLHttpRequest();
+            b.open("GET", a, !1);
+            b.responseType = "arraybuffer";
+            b.send(null);
+            return new Uint8Array(b.response);
+          }),
+        (B = (a, b, c) => {
+          var f = new XMLHttpRequest();
+          f.open("GET", a, !0);
+          f.responseType = "arraybuffer";
+          f.onload = () => {
+            200 == f.status || (0 == f.status && f.response) ? b(f.response) : c();
+          };
+          f.onerror = c;
+          f.send(null);
+        });
+    var da = e.print || console.log.bind(console),
+      E = e.printErr || console.error.bind(console);
+    Object.assign(e, ba);
+    ba = null;
+    e.thisProgram && (m = e.thisProgram);
+    e.quit && (q = e.quit);
+    var F;
+    e.wasmBinary && (F = e.wasmBinary);
+    var noExitRuntime = e.noExitRuntime || !0;
+    "object" != typeof WebAssembly && G("no native wasm support detected");
+    var H,
+      I,
+      J = !1,
+      K,
+      L,
+      M,
+      N;
+    function ea() {
+      var a = H.buffer;
+      e.HEAP8 = K = new Int8Array(a);
+      e.HEAP16 = new Int16Array(a);
+      e.HEAP32 = M = new Int32Array(a);
+      e.HEAPU8 = L = new Uint8Array(a);
+      e.HEAPU16 = new Uint16Array(a);
+      e.HEAPU32 = N = new Uint32Array(a);
+      e.HEAPF32 = new Float32Array(a);
+      e.HEAPF64 = new Float64Array(a);
+    }
+    var fa = [],
+      ha = [],
+      ia = [];
+    function ja() {
+      var a = e.preRun.shift();
+      fa.unshift(a);
+    }
+    var O = 0,
+      P = null,
+      Q = null;
+    function G(a) {
+      if (e.onAbort) e.onAbort(a);
+      a = "Aborted(" + a + ")";
+      E(a);
+      J = !0;
+      a = new WebAssembly.RuntimeError(a + ". Build with -sASSERTIONS for more info.");
+      h(a);
+      throw a;
+    }
+    function ka(a) {
+      return a.startsWith("data:application/octet-stream;base64,");
+    }
+    var R;
+    R = "ort-wasm.wasm";
+    if (!ka(R)) {
+      var la = R;
+      R = e.locateFile ? e.locateFile(la, y) : y + la;
+    }
+    function ma(a) {
+      if (a == R && F) return new Uint8Array(F);
+      if (C) return C(a);
+      throw "both async and sync fetching of the wasm failed";
+    }
+    function na(a) {
+      if (!F && (ca || v)) {
+        if ("function" == typeof fetch && !a.startsWith("file://"))
+          return fetch(a, { credentials: "same-origin" })
+            .then((b) => {
+              if (!b.ok) throw "failed to load wasm binary file at '" + a + "'";
+              return b.arrayBuffer();
+            })
+            .catch(() => ma(a));
+        if (B)
+          return new Promise((b, c) => {
+            B(a, (f) => b(new Uint8Array(f)), c);
+          });
+      }
+      return Promise.resolve().then(() => ma(a));
+    }
+    function oa(a, b, c) {
+      return na(a)
+        .then((f) => WebAssembly.instantiate(f, b))
+        .then((f) => f)
+        .then(c, (f) => {
+          E("failed to asynchronously prepare wasm: " + f);
+          G(f);
+        });
+    }
+    function pa(a, b) {
+      var c = R;
+      return F ||
+        "function" != typeof WebAssembly.instantiateStreaming ||
+        ka(c) ||
+        c.startsWith("file://") ||
+        x ||
+        "function" != typeof fetch
+        ? oa(c, a, b)
+        : fetch(c, { credentials: "same-origin" }).then((f) =>
+            WebAssembly.instantiateStreaming(f, a).then(b, function (g) {
+              E("wasm streaming compile failed: " + g);
+              E("falling back to ArrayBuffer instantiation");
+              return oa(c, a, b);
+            }),
+          );
+    }
+    var S;
+    function qa(a) {
+      this.name = "ExitStatus";
+      this.message = `Program terminated with exit(${a})`;
+      this.status = a;
+    }
+    var T = (a) => {
+      for (; 0 < a.length; ) a.shift()(e);
+    };
+    function ra(a) {
+      this.qa = a - 24;
+      this.va = function (b) {
+        N[((this.qa + 4) >> 2) >>> 0] = b;
+      };
+      this.ua = function (b) {
+        N[((this.qa + 8) >> 2) >>> 0] = b;
+      };
+      this.sa = function (b, c) {
+        this.ta();
+        this.va(b);
+        this.ua(c);
+      };
+      this.ta = function () {
+        N[((this.qa + 16) >> 2) >>> 0] = 0;
+      };
+    }
+    var sa = 0,
+      ta = 0,
+      ua = "undefined" != typeof TextDecoder ? new TextDecoder("utf8") : void 0,
+      va = (a, b, c) => {
+        b >>>= 0;
+        var f = b + c;
+        for (c = b; a[c] && !(c >= f); ) ++c;
+        if (16 < c - b && a.buffer && ua) return ua.decode(a.subarray(b, c));
+        for (f = ""; b < c; ) {
+          var g = a[b++];
+          if (g & 128) {
+            var k = a[b++] & 63;
+            if (192 == (g & 224)) f += String.fromCharCode(((g & 31) << 6) | k);
+            else {
+              var l = a[b++] & 63;
+              g =
+                224 == (g & 240)
+                  ? ((g & 15) << 12) | (k << 6) | l
+                  : ((g & 7) << 18) | (k << 12) | (l << 6) | (a[b++] & 63);
+              65536 > g
+                ? (f += String.fromCharCode(g))
+                : ((g -= 65536), (f += String.fromCharCode(55296 | (g >> 10), 56320 | (g & 1023))));
+            }
+          } else f += String.fromCharCode(g);
+        }
+        return f;
+      },
+      U = (a, b) => ((a >>>= 0) ? va(L, a, b) : ""),
+      V = (a) => {
+        for (var b = 0, c = 0; c < a.length; ++c) {
+          var f = a.charCodeAt(c);
+          127 >= f ? b++ : 2047 >= f ? (b += 2) : 55296 <= f && 57343 >= f ? ((b += 4), ++c) : (b += 3);
+        }
+        return b;
+      },
+      W = (a, b, c, f) => {
+        c >>>= 0;
+        if (!(0 < f)) return 0;
+        var g = c;
+        f = c + f - 1;
+        for (var k = 0; k < a.length; ++k) {
+          var l = a.charCodeAt(k);
+          if (55296 <= l && 57343 >= l) {
+            var r = a.charCodeAt(++k);
+            l = (65536 + ((l & 1023) << 10)) | (r & 1023);
+          }
+          if (127 >= l) {
+            if (c >= f) break;
+            b[c++ >>> 0] = l;
+          } else {
+            if (2047 >= l) {
+              if (c + 1 >= f) break;
+              b[c++ >>> 0] = 192 | (l >> 6);
+            } else {
+              if (65535 >= l) {
+                if (c + 2 >= f) break;
+                b[c++ >>> 0] = 224 | (l >> 12);
+              } else {
+                if (c + 3 >= f) break;
+                b[c++ >>> 0] = 240 | (l >> 18);
+                b[c++ >>> 0] = 128 | ((l >> 12) & 63);
+              }
+              b[c++ >>> 0] = 128 | ((l >> 6) & 63);
+            }
+            b[c++ >>> 0] = 128 | (l & 63);
+          }
+        }
+        b[c >>> 0] = 0;
+        return c - g;
+      },
+      X = (a) => 0 === a % 4 && (0 !== a % 100 || 0 === a % 400),
+      wa = [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335],
+      xa = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334],
+      Ca = (a) => {
+        var b = V(a) + 1,
+          c = ya(b);
+        c && W(a, L, c, b);
+        return c;
+      },
+      Y = {},
+      Ea = () => {
+        if (!Da) {
+          var a = {
+              USER: "web_user",
+              LOGNAME: "web_user",
+              PATH: "/",
+              PWD: "/",
+              HOME: "/home/web_user",
+              LANG:
+                (("object" == typeof navigator && navigator.languages && navigator.languages[0]) || "C").replace(
+                  "-",
+                  "_",
+                ) + ".UTF-8",
+              _: m || "./this.program",
+            },
+            b;
+          for (b in Y) void 0 === Y[b] ? delete a[b] : (a[b] = Y[b]);
+          var c = [];
+          for (b in a) c.push(`${b}=${a[b]}`);
+          Da = c;
+        }
+        return Da;
+      },
+      Da,
+      Fa = [null, [], []],
+      Ga = () => {
+        if ("object" == typeof crypto && "function" == typeof crypto.getRandomValues)
+          return (c) => crypto.getRandomValues(c);
+        if (x)
+          try {
+            var a = require("crypto");
+            if (a.randomFillSync) return (c) => a.randomFillSync(c);
+            var b = a.randomBytes;
+            return (c) => (c.set(b(c.byteLength)), c);
+          } catch (c) {}
+        G("initRandomDevice");
+      },
+      Ha = (a) => (Ha = Ga())(a),
+      Ia = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+      Ja = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    function Ka(a) {
+      var b = Array(V(a) + 1);
+      W(a, b, 0, b.length);
+      return b;
+    }
+    function La(a, b, c, f) {
+      function g(d, n, p) {
+        for (d = "number" == typeof d ? d.toString() : d || ""; d.length < n; ) d = p[0] + d;
+        return d;
+      }
+      function k(d, n) {
+        return g(d, n, "0");
+      }
+      function l(d, n) {
+        function p(za) {
+          return 0 > za ? -1 : 0 < za ? 1 : 0;
+        }
+        var z;
+        0 === (z = p(d.getFullYear() - n.getFullYear())) &&
+          0 === (z = p(d.getMonth() - n.getMonth())) &&
+          (z = p(d.getDate() - n.getDate()));
+        return z;
+      }
+      function r(d) {
+        switch (d.getDay()) {
+          case 0:
+            return new Date(d.getFullYear() - 1, 11, 29);
+          case 1:
+            return d;
+          case 2:
+            return new Date(d.getFullYear(), 0, 3);
+          case 3:
+            return new Date(d.getFullYear(), 0, 2);
+          case 4:
+            return new Date(d.getFullYear(), 0, 1);
+          case 5:
+            return new Date(d.getFullYear() - 1, 11, 31);
+          case 6:
+            return new Date(d.getFullYear() - 1, 11, 30);
+        }
+      }
+      function w(d) {
+        var n = d.ma;
+        for (d = new Date(new Date(d.na + 1900, 0, 1).getTime()); 0 < n; ) {
+          var p = d.getMonth(),
+            z = (X(d.getFullYear()) ? Ia : Ja)[p];
+          if (n > z - d.getDate())
+            (n -= z - d.getDate() + 1),
+              d.setDate(1),
+              11 > p ? d.setMonth(p + 1) : (d.setMonth(0), d.setFullYear(d.getFullYear() + 1));
+          else {
+            d.setDate(d.getDate() + n);
+            break;
+          }
+        }
+        p = new Date(d.getFullYear() + 1, 0, 4);
+        n = r(new Date(d.getFullYear(), 0, 4));
+        p = r(p);
+        return 0 >= l(n, d) ? (0 >= l(p, d) ? d.getFullYear() + 1 : d.getFullYear()) : d.getFullYear() - 1;
+      }
+      a >>>= 0;
+      b >>>= 0;
+      c >>>= 0;
+      f >>>= 0;
+      var t = M[((f + 40) >> 2) >>> 0];
+      f = {
+        ya: M[(f >> 2) >>> 0],
+        xa: M[((f + 4) >> 2) >>> 0],
+        oa: M[((f + 8) >> 2) >>> 0],
+        ra: M[((f + 12) >> 2) >>> 0],
+        pa: M[((f + 16) >> 2) >>> 0],
+        na: M[((f + 20) >> 2) >>> 0],
+        ha: M[((f + 24) >> 2) >>> 0],
+        ma: M[((f + 28) >> 2) >>> 0],
+        Aa: M[((f + 32) >> 2) >>> 0],
+        wa: M[((f + 36) >> 2) >>> 0],
+        za: t ? U(t) : "",
+      };
+      c = U(c);
+      t = {
+        "%c": "%a %b %d %H:%M:%S %Y",
+        "%D": "%m/%d/%y",
+        "%F": "%Y-%m-%d",
+        "%h": "%b",
+        "%r": "%I:%M:%S %p",
+        "%R": "%H:%M",
+        "%T": "%H:%M:%S",
+        "%x": "%m/%d/%y",
+        "%X": "%H:%M:%S",
+        "%Ec": "%c",
+        "%EC": "%C",
+        "%Ex": "%m/%d/%y",
+        "%EX": "%H:%M:%S",
+        "%Ey": "%y",
+        "%EY": "%Y",
+        "%Od": "%d",
+        "%Oe": "%e",
+        "%OH": "%H",
+        "%OI": "%I",
+        "%Om": "%m",
+        "%OM": "%M",
+        "%OS": "%S",
+        "%Ou": "%u",
+        "%OU": "%U",
+        "%OV": "%V",
+        "%Ow": "%w",
+        "%OW": "%W",
+        "%Oy": "%y",
+      };
+      for (var u in t) c = c.replace(new RegExp(u, "g"), t[u]);
+      var Aa = "Sunday Monday Tuesday Wednesday Thursday Friday Saturday".split(" "),
+        Ba = "January February March April May June July August September October November December".split(" ");
+      t = {
+        "%a": (d) => Aa[d.ha].substring(0, 3),
+        "%A": (d) => Aa[d.ha],
+        "%b": (d) => Ba[d.pa].substring(0, 3),
+        "%B": (d) => Ba[d.pa],
+        "%C": (d) => k(((d.na + 1900) / 100) | 0, 2),
+        "%d": (d) => k(d.ra, 2),
+        "%e": (d) => g(d.ra, 2, " "),
+        "%g": (d) => w(d).toString().substring(2),
+        "%G": (d) => w(d),
+        "%H": (d) => k(d.oa, 2),
+        "%I": (d) => {
+          d = d.oa;
+          0 == d ? (d = 12) : 12 < d && (d -= 12);
+          return k(d, 2);
+        },
+        "%j": (d) => {
+          for (var n = 0, p = 0; p <= d.pa - 1; n += (X(d.na + 1900) ? Ia : Ja)[p++]);
+          return k(d.ra + n, 3);
+        },
+        "%m": (d) => k(d.pa + 1, 2),
+        "%M": (d) => k(d.xa, 2),
+        "%n": () => "\n",
+        "%p": (d) => (0 <= d.oa && 12 > d.oa ? "AM" : "PM"),
+        "%S": (d) => k(d.ya, 2),
+        "%t": () => "\t",
+        "%u": (d) => d.ha || 7,
+        "%U": (d) => k(Math.floor((d.ma + 7 - d.ha) / 7), 2),
+        "%V": (d) => {
+          var n = Math.floor((d.ma + 7 - ((d.ha + 6) % 7)) / 7);
+          2 >= (d.ha + 371 - d.ma - 2) % 7 && n++;
+          if (n) 53 == n && ((p = (d.ha + 371 - d.ma) % 7), 4 == p || (3 == p && X(d.na)) || (n = 1));
+          else {
+            n = 52;
+            var p = (d.ha + 7 - d.ma - 1) % 7;
+            (4 == p || (5 == p && X((d.na % 400) - 1))) && n++;
+          }
+          return k(n, 2);
+        },
+        "%w": (d) => d.ha,
+        "%W": (d) => k(Math.floor((d.ma + 7 - ((d.ha + 6) % 7)) / 7), 2),
+        "%y": (d) => (d.na + 1900).toString().substring(2),
+        "%Y": (d) => d.na + 1900,
+        "%z": (d) => {
+          d = d.wa;
+          var n = 0 <= d;
+          d = Math.abs(d) / 60;
+          return (n ? "+" : "-") + String("0000" + ((d / 60) * 100 + (d % 60))).slice(-4);
+        },
+        "%Z": (d) => d.za,
+        "%%": () => "%",
+      };
+      c = c.replace(/%%/g, "\x00\x00");
+      for (u in t) c.includes(u) && (c = c.replace(new RegExp(u, "g"), t[u](f)));
+      c = c.replace(/\0\0/g, "%");
+      u = Ka(c);
+      if (u.length > b) return 0;
+      K.set(u, a >>> 0);
+      return u.length - 1;
+    }
+    var Na = {
+      a: function (a, b, c) {
+        a >>>= 0;
+        new ra(a).sa(b >>> 0, c >>> 0);
+        sa = a;
+        ta++;
+        throw sa;
+      },
+      e: function () {
+        return 0;
+      },
+      I: function () {},
+      y: function () {},
+      A: function () {},
+      K: function () {
+        return 0;
+      },
+      G: function () {},
+      B: function () {},
+      F: function () {},
+      g: function () {},
+      z: function () {},
+      w: function () {},
+      H: function () {},
+      x: function () {},
+      k: () => !0,
+      n: function (a, b, c) {
+        a = (b + 2097152) >>> 0 < 4194305 - !!a ? (a >>> 0) + 4294967296 * b : NaN;
+        c >>>= 0;
+        a = new Date(1e3 * a);
+        M[(c >> 2) >>> 0] = a.getUTCSeconds();
+        M[((c + 4) >> 2) >>> 0] = a.getUTCMinutes();
+        M[((c + 8) >> 2) >>> 0] = a.getUTCHours();
+        M[((c + 12) >> 2) >>> 0] = a.getUTCDate();
+        M[((c + 16) >> 2) >>> 0] = a.getUTCMonth();
+        M[((c + 20) >> 2) >>> 0] = a.getUTCFullYear() - 1900;
+        M[((c + 24) >> 2) >>> 0] = a.getUTCDay();
+        M[((c + 28) >> 2) >>> 0] = ((a.getTime() - Date.UTC(a.getUTCFullYear(), 0, 1, 0, 0, 0, 0)) / 864e5) | 0;
+      },
+      o: function (a, b, c) {
+        a = (b + 2097152) >>> 0 < 4194305 - !!a ? (a >>> 0) + 4294967296 * b : NaN;
+        c >>>= 0;
+        a = new Date(1e3 * a);
+        M[(c >> 2) >>> 0] = a.getSeconds();
+        M[((c + 4) >> 2) >>> 0] = a.getMinutes();
+        M[((c + 8) >> 2) >>> 0] = a.getHours();
+        M[((c + 12) >> 2) >>> 0] = a.getDate();
+        M[((c + 16) >> 2) >>> 0] = a.getMonth();
+        M[((c + 20) >> 2) >>> 0] = a.getFullYear() - 1900;
+        M[((c + 24) >> 2) >>> 0] = a.getDay();
+        M[((c + 28) >> 2) >>> 0] = ((X(a.getFullYear()) ? wa : xa)[a.getMonth()] + a.getDate() - 1) | 0;
+        M[((c + 36) >> 2) >>> 0] = -(60 * a.getTimezoneOffset());
+        b = new Date(a.getFullYear(), 6, 1).getTimezoneOffset();
+        var f = new Date(a.getFullYear(), 0, 1).getTimezoneOffset();
+        M[((c + 32) >> 2) >>> 0] = (b != f && a.getTimezoneOffset() == Math.min(f, b)) | 0;
+      },
+      p: function (a) {
+        a >>>= 0;
+        var b = new Date(
+            M[((a + 20) >> 2) >>> 0] + 1900,
+            M[((a + 16) >> 2) >>> 0],
+            M[((a + 12) >> 2) >>> 0],
+            M[((a + 8) >> 2) >>> 0],
+            M[((a + 4) >> 2) >>> 0],
+            M[(a >> 2) >>> 0],
+            0,
+          ),
+          c = M[((a + 32) >> 2) >>> 0],
+          f = b.getTimezoneOffset(),
+          g = new Date(b.getFullYear(), 6, 1).getTimezoneOffset(),
+          k = new Date(b.getFullYear(), 0, 1).getTimezoneOffset(),
+          l = Math.min(k, g);
+        0 > c
+          ? (M[((a + 32) >> 2) >>> 0] = Number(g != k && l == f))
+          : 0 < c != (l == f) && ((g = Math.max(k, g)), b.setTime(b.getTime() + 6e4 * ((0 < c ? l : g) - f)));
+        M[((a + 24) >> 2) >>> 0] = b.getDay();
+        M[((a + 28) >> 2) >>> 0] = ((X(b.getFullYear()) ? wa : xa)[b.getMonth()] + b.getDate() - 1) | 0;
+        M[(a >> 2) >>> 0] = b.getSeconds();
+        M[((a + 4) >> 2) >>> 0] = b.getMinutes();
+        M[((a + 8) >> 2) >>> 0] = b.getHours();
+        M[((a + 12) >> 2) >>> 0] = b.getDate();
+        M[((a + 16) >> 2) >>> 0] = b.getMonth();
+        M[((a + 20) >> 2) >>> 0] = b.getYear();
+        a = b.getTime() / 1e3;
+        return (
+          Ma(
+            ((S = a),
+            1 <= +Math.abs(S)
+              ? 0 < S
+                ? +Math.floor(S / 4294967296) >>> 0
+                : ~~+Math.ceil((S - +(~~S >>> 0)) / 4294967296) >>> 0
+              : 0),
+          ),
+          a >>> 0
+        );
+      },
+      l: function () {
+        return -52;
+      },
+      m: function () {},
+      u: function (a, b, c) {
+        function f(w) {
+          return (w = w.toTimeString().match(/\(([A-Za-z ]+)\)$/)) ? w[1] : "GMT";
+        }
+        c >>>= 0;
+        var g = new Date().getFullYear(),
+          k = new Date(g, 0, 1),
+          l = new Date(g, 6, 1);
+        g = k.getTimezoneOffset();
+        var r = l.getTimezoneOffset();
+        N[((a >>> 0) >> 2) >>> 0] = 60 * Math.max(g, r);
+        M[((b >>> 0) >> 2) >>> 0] = Number(g != r);
+        a = f(k);
+        b = f(l);
+        a = Ca(a);
+        b = Ca(b);
+        r < g
+          ? ((N[(c >> 2) >>> 0] = a), (N[((c + 4) >> 2) >>> 0] = b))
+          : ((N[(c >> 2) >>> 0] = b), (N[((c + 4) >> 2) >>> 0] = a));
+      },
+      d: () => {
+        G("");
+      },
+      h: function () {
+        return Date.now();
+      },
+      v: function () {
+        return 4294901760;
+      },
+      b: () => performance.now(),
+      J: function (a, b, c) {
+        b >>>= 0;
+        return L.copyWithin((a >>> 0) >>> 0, b >>> 0, (b + (c >>> 0)) >>> 0);
+      },
+      t: function (a) {
+        a >>>= 0;
+        var b = L.length;
+        if (4294901760 < a) return !1;
+        for (var c = 1; 4 >= c; c *= 2) {
+          var f = b * (1 + 0.2 / c);
+          f = Math.min(f, a + 100663296);
+          var g = Math;
+          f = Math.max(a, f);
+          a: {
+            g = (g.min.call(g, 4294901760, f + ((65536 - (f % 65536)) % 65536)) - H.buffer.byteLength + 65535) >>> 16;
+            try {
+              H.grow(g);
+              ea();
+              var k = 1;
+              break a;
+            } catch (l) {}
+            k = void 0;
+          }
+          if (k) return !0;
+        }
+        return !1;
+      },
+      D: function (a, b) {
+        a >>>= 0;
+        b >>>= 0;
+        var c = 0;
+        Ea().forEach(function (f, g) {
+          var k = b + c;
+          g = N[((a + 4 * g) >> 2) >>> 0] = k;
+          for (k = 0; k < f.length; ++k) K[(g++ >> 0) >>> 0] = f.charCodeAt(k);
+          K[(g >> 0) >>> 0] = 0;
+          c += f.length + 1;
+        });
+        return 0;
+      },
+      E: function (a, b) {
+        a >>>= 0;
+        b >>>= 0;
+        var c = Ea();
+        N[(a >> 2) >>> 0] = c.length;
+        var f = 0;
+        c.forEach(function (g) {
+          f += g.length + 1;
+        });
+        N[(b >> 2) >>> 0] = f;
+        return 0;
+      },
+      s: (a) => {
+        if (!noExitRuntime) {
+          if (e.onExit) e.onExit(a);
+          J = !0;
+        }
+        q(a, new qa(a));
+      },
+      f: () => 52,
+      j: function () {
+        return 52;
+      },
+      q: function () {
+        return 70;
+      },
+      i: function (a, b, c, f) {
+        b >>>= 0;
+        c >>>= 0;
+        f >>>= 0;
+        for (var g = 0, k = 0; k < c; k++) {
+          var l = N[(b >> 2) >>> 0],
+            r = N[((b + 4) >> 2) >>> 0];
+          b += 8;
+          for (var w = 0; w < r; w++) {
+            var t = L[(l + w) >>> 0],
+              u = Fa[a];
+            0 === t || 10 === t ? ((1 === a ? da : E)(va(u, 0)), (u.length = 0)) : u.push(t);
+          }
+          g += r;
+        }
+        N[(f >> 2) >>> 0] = g;
+        return 0;
+      },
+      r: function (a, b) {
+        a >>>= 0;
+        Ha(L.subarray(a >>> 0, (a + (b >>> 0)) >>> 0));
+        return 0;
+      },
+      C: La,
+      c: function (a, b, c, f) {
+        return La(a >>> 0, b >>> 0, c >>> 0, f >>> 0);
+      },
+    };
+    (function () {
+      function a(c) {
+        c = c.exports;
+        I = c = Oa(c);
+        H = I.L;
+        ea();
+        ha.unshift(I.M);
+        O--;
+        e.monitorRunDependencies && e.monitorRunDependencies(O);
+        if (0 == O && (null !== P && (clearInterval(P), (P = null)), Q)) {
+          var f = Q;
+          Q = null;
+          f();
+        }
+        return c;
+      }
+      var b = { a: Na };
+      O++;
+      e.monitorRunDependencies && e.monitorRunDependencies(O);
+      if (e.instantiateWasm)
+        try {
+          return e.instantiateWasm(b, a);
+        } catch (c) {
+          E("Module.instantiateWasm callback failed with error: " + c), h(c);
+        }
+      pa(b, function (c) {
+        a(c.instance);
+      }).catch(h);
+      return {};
+    })();
+    e._OrtInit = (a, b) => (e._OrtInit = I.N)(a, b);
+    e._OrtGetLastError = (a, b) => (e._OrtGetLastError = I.O)(a, b);
+    e._OrtCreateSessionOptions = (a, b, c, f, g, k, l, r, w, t) =>
+      (e._OrtCreateSessionOptions = I.P)(a, b, c, f, g, k, l, r, w, t);
+    e._OrtAppendExecutionProvider = (a, b) => (e._OrtAppendExecutionProvider = I.Q)(a, b);
+    e._OrtAddSessionConfigEntry = (a, b, c) => (e._OrtAddSessionConfigEntry = I.R)(a, b, c);
+    e._OrtReleaseSessionOptions = (a) => (e._OrtReleaseSessionOptions = I.S)(a);
+    e._OrtCreateSession = (a, b, c) => (e._OrtCreateSession = I.T)(a, b, c);
+    e._OrtReleaseSession = (a) => (e._OrtReleaseSession = I.U)(a);
+    e._OrtGetInputOutputCount = (a, b, c) => (e._OrtGetInputOutputCount = I.V)(a, b, c);
+    e._OrtGetInputName = (a, b) => (e._OrtGetInputName = I.W)(a, b);
+    e._OrtGetOutputName = (a, b) => (e._OrtGetOutputName = I.X)(a, b);
+    e._OrtFree = (a) => (e._OrtFree = I.Y)(a);
+    e._OrtCreateTensor = (a, b, c, f, g) => (e._OrtCreateTensor = I.Z)(a, b, c, f, g);
+    e._OrtGetTensorData = (a, b, c, f, g) => (e._OrtGetTensorData = I._)(a, b, c, f, g);
+    e._OrtReleaseTensor = (a) => (e._OrtReleaseTensor = I.$)(a);
+    e._OrtCreateRunOptions = (a, b, c, f) => (e._OrtCreateRunOptions = I.aa)(a, b, c, f);
+    e._OrtAddRunConfigEntry = (a, b, c) => (e._OrtAddRunConfigEntry = I.ba)(a, b, c);
+    e._OrtReleaseRunOptions = (a) => (e._OrtReleaseRunOptions = I.ca)(a);
+    e._OrtRun = (a, b, c, f, g, k, l, r) => (e._OrtRun = I.da)(a, b, c, f, g, k, l, r);
+    e._OrtEndProfiling = (a) => (e._OrtEndProfiling = I.ea)(a);
+    var ya = (e._malloc = (a) => (ya = e._malloc = I.fa)(a));
+    e._free = (a) => (e._free = I.ga)(a);
+    var Ma = (a) => (Ma = I.ia)(a),
+      Pa = () => (Pa = I.ja)(),
+      Qa = (a) => (Qa = I.ka)(a),
+      Ra = (a) => (Ra = I.la)(a);
+    function Oa(a) {
+      a = Object.assign({}, a);
+      var b = (f) => () => f() >>> 0,
+        c = (f) => (g) => f(g) >>> 0;
+      a.__errno_location = b(a.__errno_location);
+      a.malloc = c(a.malloc);
+      a.stackSave = b(a.stackSave);
+      a.stackAlloc = c(a.stackAlloc);
+      return a;
+    }
+    e.stackAlloc = Ra;
+    e.stackSave = Pa;
+    e.stackRestore = Qa;
+    e.UTF8ToString = U;
+    e.stringToUTF8 = (a, b, c) => W(a, L, b, c);
+    e.lengthBytesUTF8 = V;
+    var Z;
+    Q = function Sa() {
+      Z || Ta();
+      Z || (Q = Sa);
+    };
+    function Ta() {
+      function a() {
+        if (!Z && ((Z = !0), (e.calledRun = !0), !J)) {
+          T(ha);
+          aa(e);
+          if (e.onRuntimeInitialized) e.onRuntimeInitialized();
+          if (e.postRun)
+            for ("function" == typeof e.postRun && (e.postRun = [e.postRun]); e.postRun.length; ) {
+              var b = e.postRun.shift();
+              ia.unshift(b);
+            }
+          T(ia);
+        }
+      }
+      if (!(0 < O)) {
+        if (e.preRun) for ("function" == typeof e.preRun && (e.preRun = [e.preRun]); e.preRun.length; ) ja();
+        T(fa);
+        0 < O ||
+          (e.setStatus
+            ? (e.setStatus("Running..."),
+              setTimeout(function () {
+                setTimeout(function () {
+                  e.setStatus("");
+                }, 1);
+                a();
+              }, 1))
+            : a());
+      }
+    }
+    if (e.preInit)
+      for ("function" == typeof e.preInit && (e.preInit = [e.preInit]); 0 < e.preInit.length; ) e.preInit.pop()();
+    Ta();
+
+    return moduleArg.ready;
+  };
+})();
+if (typeof exports === "object" && typeof module === "object") module.exports = ortWasm;
+else if (typeof define === "function" && define["amd"]) define([], () => ortWasm);

--- a/js/web/lib/wasm/proxy-worker/main.ts
+++ b/js/web/lib/wasm/proxy-worker/main.ts
@@ -25,7 +25,7 @@ self.onmessage = (ev: MessageEvent<OrtWasmMessage>): void => {
                                                                                                 type: 'init-ort',
                                                                                                 err
                                                                                               } as OrtWasmMessage));
-        postMessage({type: 'init-ort'} as OrtWasmMessage);
+        // postMessage({type: 'init-ort'} as OrtWasmMessage);
       } catch (err) {
         postMessage({type: 'init-ort', err} as OrtWasmMessage);
       }

--- a/js/web/lib/wasm/proxy-wrapper.ts
+++ b/js/web/lib/wasm/proxy-wrapper.ts
@@ -44,6 +44,7 @@ const onProxyWorkerMessage = (ev: MessageEvent<OrtWasmMessage>): void => {
       }
       break;
     case 'init-ort':
+      console.log('message init-ort received');
       if (ev.data.err) {
         initOrtCallbacks[1](ev.data.err);
       } else {
@@ -65,6 +66,7 @@ const onProxyWorkerMessage = (ev: MessageEvent<OrtWasmMessage>): void => {
       }
       break;
     case 'create':
+      console.log('message create received');
       if (ev.data.err) {
         createSessionCallbacks.shift()![1](ev.data.err);
       } else {
@@ -139,6 +141,7 @@ export const initializeRuntime = async(env: Env): Promise<void> => {
     ensureWorker();
     return new Promise<void>((resolve, reject) => {
       initOrtCallbacks = [resolve, reject];
+      console.log('message init-ort send');
       const message: OrtWasmMessage = {type: 'init-ort', in : env};
       proxyWorker!.postMessage(message);
     });
@@ -180,6 +183,7 @@ export const createSession =
     ensureWorker();
     return new Promise<SerializableSessionMetadata>((resolve, reject) => {
       createSessionCallbacks.push([resolve, reject]);
+      console.log('message create send');
       const message: OrtWasmMessage = {type: 'create', in : {model, options}};
       proxyWorker!.postMessage(message, [model.buffer]);
     });

--- a/js/web/lib/wasm/wasm-core-impl.ts
+++ b/js/web/lib/wasm/wasm-core-impl.ts
@@ -35,8 +35,8 @@ const getSessionInputOutputCount = (sessionHandle: number): [number, number] => 
  * @param numThreads SetGlobalIntraOpNumThreads(numThreads)
  * @param loggingLevel CreateEnv(static_cast<OrtLoggingLevel>(logging_level))
  */
-const initOrt = (numThreads: number, loggingLevel: number): void => {
-  const errorCode = getInstance()._OrtInit(numThreads, loggingLevel);
+const initOrt = async (numThreads: number, loggingLevel: number): Promise<void> => {
+  const errorCode = await getInstance()._OrtInit(numThreads, loggingLevel);
   if (errorCode !== 0) {
     checkLastError('Can\'t initialize onnxruntime.');
   }
@@ -48,7 +48,7 @@ const initOrt = (numThreads: number, loggingLevel: number): void => {
  */
 export const initRuntime = async(env: Env): Promise<void> => {
   // init ORT
-  initOrt(env.wasm.numThreads!, logLevelStringToEnum(env.logLevel));
+  await initOrt(env.wasm.numThreads!, logLevelStringToEnum(env.logLevel));
 
   if (!BUILD_DEFS.DISABLE_WEBGPU) {
     // init JSEP if available


### PR DESCRIPTION
### Description
Fix initializeRuntime (init-ort) duration. It's more workers' code fix, but I haven't found repo for workers, so contributing here.


### Motivation and Context
Lib version: 1.16.3

### Reproduction
I had logical 8 processors and code like this

```typescript
import * as ort from 'onnxruntime-web'

async function runOnnxSession(model: ArrayBufferLike) {
  const ort_config: ort.InferenceSession.SessionOptions = {
    executionProviders: ['wasm'],
    graphOptimizationLevel: 'all',
    executionMode: 'parallel',
    enableCpuMemArena: true,
  }
  
  const session = (await ort.InferenceSession.create(model, ort_config)) as ort.InferenceSession
  
  const feeds = {
    input: new ort.Tensor('float32', new Float32Array(input.data), input.shape),
  }
  
  const outputData = await session.run(feeds, {})
  
  return outputData['output']
}
```

And when I ran this code, the model ran in ~17 seconds, which is the same amount of time as if I were running this on a single thread. But when I ran this code second time after a few seconds, I've got a session duration of ~4.5 seconds, which is expected duration.

When I added some console.log's, I noticed that at the first time model inference session the workers had not yet sent a message with `data.cmd === 'loaded'`:
![Frame 6](https://github.com/microsoft/onnxruntime/assets/56451791/c49a8100-a8fa-4257-ad9f-17780322975b)

But at the second time workers were already loaded, so inference session runned on multiple threads:
![Frame 7](https://github.com/microsoft/onnxruntime/assets/56451791/0f9d8843-d74d-48c0-9b1c-d31da2c9f91e)

I've tested this with multiple consecutive runs, and all the runs before workers loading had the same duration as they had with one thread.

As I said before, I haven't found repo for workers code, and also I was unable to successfully launch the library on the latest versions of artifacts from CI. Also debug CI artefacts for 1.16.3 were deleted after 10 days of pipeline run, so commit with fixes is written for npm's dist workers version (I'm sorry). But below I will describe what the fix would look like for the current version of the artifacts.

### Fix

To fix this behavior, I've replaced this `ort-wasm-simd-threaded.js` code:

```javascript
var _OrtInit = (Module["_OrtInit"] = createExportWrapper("OrtInit"));
```

By this:

```javascript
var resolveOrtInitCallback;
var ortInitThreadsLoadedCount = 0;
var ortInitExpectedThreadsCount = 0;
var ortInitReturnCode; 

// Count initialized threads and resolve our promise, when all the thread are initialized
var handleWasmThreadLoad = () => {
  ortInitThreadsLoadedCount++;
  if (typeof resolveOrtInitCallback === "function" && ortInitThreadsLoadedCount === ortInitExpectedThreadsCount) {
    resolveOrtInitCallback(ortInitReturnCode);
  }
};

var _OrtInit = (Module["_OrtInit"] = (numThreads, loggingLevel) => {
  ortInitExpectedThreadsCount = numThreads - 1; // One is used by main thread
  return new Promise((resolve) => {
    ortInitReturnCode = createExportWrapper("OrtInit")(numThreads, loggingLevel);
    resolveOrtInitCallback = resolve;
  });
});
```

And called `handleWasmThreadLoad` in `PThread.loadWasmModuleToWorker`:
```diff
} else if (cmd === "loaded") {
+ handleWasmThreadLoad();
  worker.loaded = true;
  onFinishedLoading(worker);
} else if (cmd === "alert") {
```

Fixed `_OrtInit` function signature in [lib/wasm/binding/ort-wasm.d.ts](https://github.com/microsoft/onnxruntime/commit/34db233948557124daa1e0bea44641bef4c16379#diff-1211811c4fe87181d3db79c0ea8f021cf8dae85df13c54416a5978bd0b0fd221):

```diff
- _OrtInit(numThreads: number, loggingLevel: number): number;
+ _OrtInit(numThreads: number, loggingLevel: number): Promise<number>;
```

Removed sync `postMessage({ type: "init-ort" })` call:

```diff
case "init-ort":
  try {
    initRuntime(ev.data.in).then(
      () => postMessage({ type: "init-ort" } as OrtWasmMessage),
      (err) =>
        postMessage({
          type: "init-ort",
          err,
        } as OrtWasmMessage),
    );
-   postMessage({ type: "init-ort" } as OrtWasmMessage);
```

Added `await`s in  in [lib/wasm/wasm-core-impl.ts](https://github.com/microsoft/onnxruntime/commit/34db233948557124daa1e0bea44641bef4c16379#diff-d3f7d7b2ba7b5644ee5e29b09d15ebf104126b028bf01a53e61ca4597977b8c2ts) file:

```diff
-const initOrt = (numThreads: number, loggingLevel: number): void => {
-  const errorCode = getInstance()._OrtInit(numThreads, loggingLevel);
+const initOrt = async (numThreads: number, loggingLevel: number): Promise<void> => {
+  const errorCode = await getInstance()._OrtInit(numThreads, loggingLevel);
```

```diff
- initOrt(env.wasm.numThreads!, logLevelStringToEnum(env.logLevel));
+ await initOrt(env.wasm.numThreads!, logLevelStringToEnum(env.logLevel));
```

After this edits, I've got workers initialization before my model first run:

<img width="1125" alt="Screenshot 2023-12-03 at 07 44 36" src="https://github.com/microsoft/onnxruntime/assets/56451791/f39651ea-3752-42b6-8685-f9c076b75c17">

Commit with all the edits and console.logs on production build of WASM and JS: https://github.com/microsoft/onnxruntime/commit/34db233948557124daa1e0bea44641bef4c16379

So... it looks like fix, and the fix may be the same for all the simd/jsep combinations, but... how I can bring it into your code?