### PR TITLE
[WebNN EP] Don't covert all inputs except the 0th input for Resize

### DIFF
--- a/onnxruntime/core/optimizer/layout_transformation/layout_transformation.cc
+++ b/onnxruntime/core/optimizer/layout_transformation/layout_transformation.cc
@@ -162,7 +162,8 @@ Status TransformLayoutForEP(Graph& graph, bool& modified, const IExecutionProvid
       // Except for resize and convolution ops, all the other layout sensitive ops only require layout transformation
       // for 0th input and output. For resize, add the other relevant inputs which need conversion. For Conv - layout
       // transformer only converts layout for 0th input, weights should be handled by every EP.
-      if (node->OpType() == "Resize") {
+      // For resize in WebNN EP, we don't want to convert all the inputs except the 0th input.
+      if (node->OpType() == "Resize" && node->GetExecutionProviderType() != kWebNNExecutionProvider) {
         // Older versions of resize have a bug where ROI and Scales cannot be made empty inputs. To handle this case,
         // we need to jump a few extra hoops to make sure its inputs are correctly handled.
         //

--- a/onnxruntime/core/providers/webnn/builders/impl/resize_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/resize_op_builder.cc
@@ -123,11 +123,7 @@ Status ResizeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
   const bool isNhwc = model_builder.GetPreferredLayout() == DataLayout::NHWC;
   if (input_defs.size() == 3) {  // Use scales.
     ORT_RETURN_IF_NOT(GetResizeScales(initializers, node, scales, logger), "Error getting resize scales");
-    if (isNhwc) {
-      scales_hw = {scales[1], scales[2]};
-    } else {
-      scales_hw = {scales[2], scales[3]};
-    }
+    scales_hw = {scales[2], scales[3]};
     options.set("scales", emscripten::val::array(scales_hw));
   } else {  // We already checked number of inputs in IsOpSupportedImpl.
     std::vector<int64_t> output_sizes;
@@ -136,11 +132,7 @@ Status ResizeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
     std::transform(output_sizes.cbegin(), output_sizes.cend(),
                    std::back_inserter(sizes),
                    [](int64_t dim) -> int32_t { return SafeInt<int32_t>(dim); });
-    if (isNhwc) {
-      sizes_hw = {sizes[1], sizes[2]};
-    } else {
-      sizes_hw = {sizes[2], sizes[3]};
-    }
+    sizes_hw = {sizes[2], sizes[3]};
     options.set("sizes", emscripten::val::array(sizes_hw));
   }
 


### PR DESCRIPTION
Currently all the inputs of Resize node will be converted to NHWC if the preferred layout is NHWC, and the ORT will call `IsOpSupportedImpl` twice, first time the inputs are NCHW, and the second time the inputs have been converted to NHWC. This would make the validation for scales input complicated and difficult to identify the height and width values.

