### PR TITLE
Add SD-Turbo and refine diffusion demo

### DIFF
--- a/onnxruntime/python/tools/transformers/models/stable_diffusion/README.md
+++ b/onnxruntime/python/tools/transformers/models/stable_diffusion/README.md
@@ -76,35 +76,43 @@ For example:
 `--work-dir WORK_DIR` can be used to load or save models under the given directory. You can download the [optimized ONNX models of Stable Diffusion XL 1.0](https://huggingface.co/tlwu/stable-diffusion-xl-1.0-onnxruntime#usage-example) to save time in running the XL demo.
 
 #### Generate an image guided by a text prompt
-```python3 demo_txt2img.py "astronaut riding a horse on mars"```
+```
+python3 demo_txt2img.py "astronaut riding a horse on mars"
+```
 
 #### Generate an image with Stable Diffusion XL guided by a text prompt
-```python3 demo_txt2img_xl.py "starry night over Golden Gate Bridge by van gogh"```
+```
+python3 demo_txt2img_xl.py "starry night over Golden Gate Bridge by van gogh"
+python3 demo_txt2img_xl.py --enable-refiner "starry night over Golden Gate Bridge by van gogh"
+```
 
 If you do not provide prompt, the script will generate different image sizes for a list of prompts for demonstration.
 
 ### Generate an image guided by a text prompt using LCM LoRA
 ```
-python3 demo_txt2img_xl.py "Self-portrait oil painting, a beautiful cyborg with golden hair, 8k" --scheduler LCM --lora-weights latent-consistency/lcm-lora-sdxl --denoising-steps 4 --disable-refiner
+python3 demo_txt2img_xl.py --scheduler LCM --lora-weights latent-consistency/lcm-lora-sdxl --denoising-steps 4 "Self-portrait oil painting, a beautiful cyborg with golden hair, 8k"
 ```
+
 #### Generate an image with SDXL LCM model guided by a text prompt
 ```
-python3 demo_txt2img_xl.py --lcm --disable-refiner "an astronaut riding a rainbow unicorn, cinematic, dramatic"
+python3 demo_txt2img_xl.py --lcm "an astronaut riding a rainbow unicorn, cinematic, dramatic"
 ```
 
 #### Generate an image with SDXL Turbo model guided by a text prompt
-It is recommended to use LCM or EuerA scheduler to run SDXL Turbo model.
+It is recommended to use LCM or EulerA scheduler to run SDXL Turbo model.
 ```
-python3 demo_txt2img_xl.py --version xl-turbo --height 512 --width 512 --denoising-steps 4 --scheduler LCM "little cute gremlin wearing a jacket, cinematic, vivid colors, intricate masterpiece, golden ratio, highly detailed"
+python3 demo_txt2img_xl.py --version xl-turbo "little cute gremlin wearing a jacket, cinematic, vivid colors, intricate masterpiece, golden ratio, highly detailed"
 ```
 
 #### Generate an image with a text prompt using a control net
 Control Net is supported for 1.5, SD XL and Turbo models in this demo.
 
 ```
-python3 demo_txt2img.py "Stormtrooper's lecture in beautiful lecture hall" --controlnet-type depth --controlnet-scale 1.0
+wget https://huggingface.co/lllyasviel/sd-controlnet-depth/resolve/main/images/stormtrooper.png
+python3 demo_txt2img_xl.py --controlnet-image stormtrooper.png --controlnet-type depth --controlnet-scale 0.5 --version xl-turbo "Stormtrooper's lecture in beautiful lecture hall"
 
-python3 demo_txt2img_xl.py --controlnet-type canny --controlnet-scale 0.5 --version xl-turbo --denoising-steps 2 --scheduler LCM --height 768 --width 768 "portrait of young Mona Lisa with mountain, river and forest in the background"
+wget https://hf.co/datasets/huggingface/documentation-images/resolve/main/diffusers/input_image_vermeer.png
+python3 demo_txt2img_xl.py --controlnet-type canny --controlnet-scale 0.5 --controlnet-image input_image_vermeer.png --version xl-turbo --height 1024 --width 1024 "portrait of young Mona Lisa with mountain, river and forest in the background"
 ```
 
 ## Optimize Stable Diffusion ONNX models for Hugging Face Diffusers or Optimum

--- a/onnxruntime/python/tools/transformers/models/stable_diffusion/README.md
+++ b/onnxruntime/python/tools/transformers/models/stable_diffusion/README.md
@@ -44,7 +44,7 @@ After launching the docker, you can build and install onnxruntime-gpu wheel like
 ```
 export CUDACXX=/usr/local/cuda-12.2/bin/nvcc
 git config --global --add safe.directory '*'
-sh build.sh --config Release  --build_shared_lib --parallel 4 --nvcc_threads 1 --use_cuda --cuda_version 12.2 \
+sh build.sh --config Release  --build_shared_lib --parallel --use_cuda --cuda_version 12.2 \
             --cuda_home /usr/local/cuda-12.2 --cudnn_home /usr/lib/x86_64-linux-gnu/ --build_wheel --skip_tests \
             --use_tensorrt --tensorrt_home /usr/src/tensorrt \
             --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF \
@@ -54,7 +54,8 @@ python3 -m pip install --upgrade pip
 python3 -m pip install build/Linux/Release/dist/onnxruntime_gpu-1.17.0-cp310-cp310-linux_x86_64.whl --force-reinstall
 ```
 
-If the GPU is not A100, change `CMAKE_CUDA_ARCHITECTURES=80` in the command line according to the GPU compute capacity.
+If the GPU is not A100, change `CMAKE_CUDA_ARCHITECTURES=80` in the command line according to the GPU compute capacity (like 89 for RTX 4090, or 86 for RTX 3090).
+If your machine has less than 64GB memory, replace `--parallel` by `--parallel 4 --nvcc_threads 1 ` to avoid out of memory.
 
 #### Install required packages
 ```

--- a/onnxruntime/python/tools/transformers/models/stable_diffusion/README.md
+++ b/onnxruntime/python/tools/transformers/models/stable_diffusion/README.md
@@ -44,7 +44,7 @@ After launching the docker, you can build and install onnxruntime-gpu wheel like
 ```
 export CUDACXX=/usr/local/cuda-12.2/bin/nvcc
 git config --global --add safe.directory '*'
-sh build.sh --config Release  --build_shared_lib --parallel --use_cuda --cuda_version 12.2 \
+sh build.sh --config Release  --build_shared_lib --parallel 4 --nvcc_threads 1 --use_cuda --cuda_version 12.2 \
             --cuda_home /usr/local/cuda-12.2 --cudnn_home /usr/lib/x86_64-linux-gnu/ --build_wheel --skip_tests \
             --use_tensorrt --tensorrt_home /usr/src/tensorrt \
             --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF \
@@ -83,6 +83,7 @@ python3 demo_txt2img.py "astronaut riding a horse on mars"
 #### Generate an image with Stable Diffusion XL guided by a text prompt
 ```
 python3 demo_txt2img_xl.py "starry night over Golden Gate Bridge by van gogh"
+
 python3 demo_txt2img_xl.py --enable-refiner "starry night over Golden Gate Bridge by van gogh"
 ```
 
@@ -98,14 +99,16 @@ python3 demo_txt2img_xl.py --scheduler LCM --lora-weights latent-consistency/lcm
 python3 demo_txt2img_xl.py --lcm "an astronaut riding a rainbow unicorn, cinematic, dramatic"
 ```
 
-#### Generate an image with SDXL Turbo model guided by a text prompt
-It is recommended to use LCM or EulerA scheduler to run SDXL Turbo model.
+#### Generate an image with SD-Turbo or SDXL-Turbo model guided by a text prompt
+It is recommended to use LCM or EulerA scheduler to run SD-Turbo or SDXL-Turbo model.
 ```
+python3 demo_txt2img.py --version sd-turbo "little cute gremlin wearing a jacket, cinematic, vivid colors, intricate masterpiece, golden ratio, highly detailed"
+
 python3 demo_txt2img_xl.py --version xl-turbo "little cute gremlin wearing a jacket, cinematic, vivid colors, intricate masterpiece, golden ratio, highly detailed"
 ```
 
 #### Generate an image with a text prompt using a control net
-Control Net is supported for 1.5, SD XL and Turbo models in this demo.
+Control Net is supported for 1.5, SDXL base and SDXL-Turbo models in this demo.
 
 ```
 wget https://huggingface.co/lllyasviel/sd-controlnet-depth/resolve/main/images/stormtrooper.png

--- a/onnxruntime/python/tools/transformers/models/stable_diffusion/demo_txt2img_xl.py
+++ b/onnxruntime/python/tools/transformers/models/stable_diffusion/demo_txt2img_xl.py
@@ -119,8 +119,8 @@ def load_pipelines(args, batch_size):
 
     if engine_type == EngineType.ORT_CUDA:
         enable_vae_slicing = args.enable_vae_slicing
-        if batch_size > 4 and not enable_vae_slicing:
-            print("Updating enable_vae_slicing to be True to avoid cuDNN error for batch size > 4.")
+        if batch_size > 4 and not enable_vae_slicing and (args.height >= 1024 and args.width >= 1024):
+            print("Updating enable_vae_slicing to be True to avoid cuDNN error for batch size > 4 and resolution >= 1024.")
             enable_vae_slicing = True
         if enable_vae_slicing:
             (refiner or base).backend.enable_vae_slicing()

--- a/onnxruntime/python/tools/transformers/models/stable_diffusion/demo_txt2img_xl.py
+++ b/onnxruntime/python/tools/transformers/models/stable_diffusion/demo_txt2img_xl.py
@@ -120,7 +120,9 @@ def load_pipelines(args, batch_size):
     if engine_type == EngineType.ORT_CUDA:
         enable_vae_slicing = args.enable_vae_slicing
         if batch_size > 4 and not enable_vae_slicing and (args.height >= 1024 and args.width >= 1024):
-            print("Updating enable_vae_slicing to be True to avoid cuDNN error for batch size > 4 and resolution >= 1024.")
+            print(
+                "Updating enable_vae_slicing to be True to avoid cuDNN error for batch size > 4 and resolution >= 1024."
+            )
             enable_vae_slicing = True
         if enable_vae_slicing:
             (refiner or base).backend.enable_vae_slicing()

--- a/onnxruntime/python/tools/transformers/models/stable_diffusion/demo_utils.py
+++ b/onnxruntime/python/tools/transformers/models/stable_diffusion/demo_utils.py
@@ -52,13 +52,13 @@ def set_default_arguments(args):
     if args.width is None:
         args.width = PipelineInfo.default_resolution(args.version)
 
-    is_lcm = args.lcm or "lcm" in args.lora_weights
-    is_turbo = args.version == "xl-turbo"
+    is_lcm = (args.version == "xl-1.0" and args.lcm) or "lcm" in args.lora_weights
+    is_turbo = args.version in ["sd-turbo", "xl-turbo"]
     if args.denoising_steps is None:
         args.denoising_steps = 4 if is_turbo else 8 if is_lcm else (30 if args.version == "xl-1.0" else 50)
 
     if args.scheduler is None:
-        args.scheduler = "LCM" if (is_lcm or is_turbo) else "EulerA"
+        args.scheduler = "LCM" if (is_lcm or is_turbo) else ("EulerA" if args.version == "xl-1.0" else "DDIM")
 
     if args.guidance is None:
         args.guidance = 0.0 if (is_lcm or is_turbo) else (5.0 if args.version == "xl-1.0" else 7.5)
@@ -103,7 +103,7 @@ def parse_arguments(is_xl: bool, parser):
         "-s",
         "--scheduler",
         type=str,
-        default=None if is_xl else "DDIM",
+        default=None,
         choices=["DDIM", "EulerA", "UniPC", "LCM"],
         help="Scheduler for diffusion process" + " of base" if is_xl else "",
     )

--- a/onnxruntime/python/tools/transformers/models/stable_diffusion/demo_utils.py
+++ b/onnxruntime/python/tools/transformers/models/stable_diffusion/demo_utils.py
@@ -23,15 +23,12 @@ import argparse
 import os
 import sys
 from importlib.metadata import PackageNotFoundError, version
-from io import BytesIO
 from typing import Any, Dict, List
 
 import controlnet_aux
 import cv2
 import numpy as np
-import requests
 import torch
-from diffusers.utils import load_image
 from diffusion_models import PipelineInfo
 from engine_builder import EngineType, get_engine_paths
 from PIL import Image
@@ -42,13 +39,37 @@ class RawTextArgumentDefaultsHelpFormatter(argparse.ArgumentDefaultsHelpFormatte
 
 
 def arg_parser(description: str):
-    return argparse.ArgumentParser(description=description, formatter_class=RawTextArgumentDefaultsHelpFormatter)
+    return argparse.ArgumentParser(
+        description=description, formatter_class=RawTextArgumentDefaultsHelpFormatter, add_help=False
+    )
+
+
+def set_default_arguments(args):
+    # set default value for some arguments if not provided
+    if args.height is None:
+        args.height = PipelineInfo.default_resolution(args.version)
+
+    if args.width is None:
+        args.width = PipelineInfo.default_resolution(args.version)
+
+    is_lcm = args.lcm or "lcm" in args.lora_weights
+    is_turbo = args.version == "xl-turbo"
+    if args.denoising_steps is None:
+        args.denoising_steps = 4 if is_turbo else 8 if is_lcm else (30 if args.version == "xl-1.0" else 50)
+
+    if args.scheduler is None:
+        args.scheduler = "LCM" if (is_lcm or is_turbo) else "EulerA"
+
+    if args.guidance is None:
+        args.guidance = 0.0 if (is_lcm or is_turbo) else (5.0 if args.version == "xl-1.0" else 7.5)
 
 
 def parse_arguments(is_xl: bool, parser):
     engines = ["ORT_CUDA", "ORT_TRT", "TRT"]
+    parser.add_argument("--help", action="store_true", help="show this help message and exit")
 
     parser.add_argument(
+        "-e",
         "--engine",
         type=str,
         default=engines[0],
@@ -59,6 +80,7 @@ def parse_arguments(is_xl: bool, parser):
 
     supported_versions = PipelineInfo.supported_versions(is_xl)
     parser.add_argument(
+        "-v",
         "--version",
         type=str,
         default="xl-1.0" if is_xl else "1.5",
@@ -67,24 +89,27 @@ def parse_arguments(is_xl: bool, parser):
     )
 
     parser.add_argument(
+        "-h",
         "--height",
         type=int,
-        default=1024 if is_xl else 512,
+        default=None,
         help="Height of image to generate (must be multiple of 8).",
     )
     parser.add_argument(
-        "--width", type=int, default=1024 if is_xl else 512, help="Height of image to generate (must be multiple of 8)."
+        "-w", "--width", type=int, default=None, help="Height of image to generate (must be multiple of 8)."
     )
 
     parser.add_argument(
+        "-s",
         "--scheduler",
         type=str,
-        default="EulerA" if is_xl else "DDIM",
+        default=None if is_xl else "DDIM",
         choices=["DDIM", "EulerA", "UniPC", "LCM"],
         help="Scheduler for diffusion process" + " of base" if is_xl else "",
     )
 
     parser.add_argument(
+        "-wd",
         "--work-dir",
         default=".",
         help="Root Directory to store torch or ONNX models, built engines and output images etc.",
@@ -93,9 +118,14 @@ def parse_arguments(is_xl: bool, parser):
     parser.add_argument("prompt", nargs="*", default=[""], help="Text prompt(s) to guide image generation.")
 
     parser.add_argument(
-        "--negative-prompt", nargs="*", default=[""], help="Optional negative prompt(s) to guide the image generation."
+        "-n",
+        "--negative-prompt",
+        nargs="*",
+        default=[""],
+        help="Optional negative prompt(s) to guide the image generation.",
     )
     parser.add_argument(
+        "-b",
         "--batch-size",
         type=int,
         default=1,
@@ -104,23 +134,25 @@ def parse_arguments(is_xl: bool, parser):
     )
 
     parser.add_argument(
+        "-d",
         "--denoising-steps",
         type=int,
-        default=30 if is_xl else 50,
+        default=None,
         help="Number of denoising steps" + (" in base." if is_xl else "."),
     )
 
     parser.add_argument(
+        "-g",
         "--guidance",
         type=float,
-        default=5.0 if is_xl else 7.5,
+        default=None,
         help="Higher guidance scale encourages to generate images that are closely linked to the text prompt.",
     )
 
     parser.add_argument(
-        "--lora-scale", type=float, default=1, help="Scale of LoRA weights, default 1 (must between 0 and 1)"
+        "-ls", "--lora-scale", type=float, default=1, help="Scale of LoRA weights, default 1 (must between 0 and 1)"
     )
-    parser.add_argument("--lora-weights", type=str, default="", help="LoRA weights to apply in the base model")
+    parser.add_argument("-lw", "--lora-weights", type=str, default="", help="LoRA weights to apply in the base model")
 
     if is_xl:
         parser.add_argument(
@@ -130,6 +162,7 @@ def parse_arguments(is_xl: bool, parser):
         )
 
         parser.add_argument(
+            "-rs",
             "--refiner-scheduler",
             type=str,
             default="EulerA",
@@ -138,6 +171,7 @@ def parse_arguments(is_xl: bool, parser):
         )
 
         parser.add_argument(
+            "-rg",
             "--refiner-guidance",
             type=float,
             default=5.0,
@@ -145,10 +179,11 @@ def parse_arguments(is_xl: bool, parser):
         )
 
         parser.add_argument(
-            "--refiner-steps",
+            "-rd",
+            "--refiner-denoising-steps",
             type=int,
             default=30,
-            help="Number of denoising steps in refiner. Note that actual refiner steps is refiner_steps * strength.",
+            help="Number of denoising steps in refiner. Note that actual steps is refiner_denoising_steps * strength.",
         )
 
         parser.add_argument(
@@ -159,7 +194,10 @@ def parse_arguments(is_xl: bool, parser):
         )
 
         parser.add_argument(
-            "--disable-refiner", action="store_true", help="Disable refiner and only run base for XL pipeline."
+            "-r",
+            "--enable-refiner",
+            action="store_true",
+            help="Enable SDXL refiner to refine image from base pipeline.",
         )
 
     # ONNX export
@@ -188,19 +226,25 @@ def parse_arguments(is_xl: bool, parser):
     # Engine build options.
     parser.add_argument("--force-engine-build", action="store_true", help="Force rebuilding the TensorRT engine.")
     parser.add_argument(
-        "--build-dynamic-batch", action="store_true", help="Build TensorRT engines to support dynamic batch size."
+        "-db",
+        "--build-dynamic-batch",
+        action="store_true",
+        help="Build TensorRT engines to support dynamic batch size.",
     )
     parser.add_argument(
-        "--build-dynamic-shape", action="store_true", help="Build TensorRT engines to support dynamic image sizes."
+        "-ds",
+        "--build-dynamic-shape",
+        action="store_true",
+        help="Build TensorRT engines to support dynamic image sizes.",
     )
 
     # Inference related options
     parser.add_argument(
-        "--num-warmup-runs", type=int, default=5, help="Number of warmup runs before benchmarking performance."
+        "-nw", "--num-warmup-runs", type=int, default=5, help="Number of warmup runs before benchmarking performance."
     )
     parser.add_argument("--nvtx-profile", action="store_true", help="Enable NVTX markers for performance profiling.")
     parser.add_argument("--seed", type=int, default=None, help="Seed for random generator to get consistent results.")
-    parser.add_argument("--disable-cuda-graph", action="store_true", help="Disable cuda graph.")
+    parser.add_argument("-dc", "--disable-cuda-graph", action="store_true", help="Disable cuda graph.")
 
     group = parser.add_argument_group("Options for ORT_CUDA engine only")
     group.add_argument("--enable-vae-slicing", action="store_true", help="True will feed only one image to VAE once.")
@@ -219,6 +263,11 @@ def parse_arguments(is_xl: bool, parser):
     )
 
     args = parser.parse_args()
+    if args.help:
+        parser.print_help()
+        sys.exit()
+
+    set_default_arguments(args)
 
     if (
         args.engine in ["ORT_CUDA", "ORT_TRT"]
@@ -245,33 +294,20 @@ def parse_arguments(is_xl: bool, parser):
 
     if is_xl:
         if args.version == "xl-turbo":
-            if args.guidance > 1.0:
-                print("[I] Use --guidance=0.0 for sdxl-turbo.")
-                args.guidance = 0.0
             if args.lcm:
                 print("[I] sdxl-turbo cannot use with LCM.")
                 args.lcm = False
-            if args.denoising_steps > 8:
-                print("[I] Use --denoising_steps=4 (no more than 8) for sdxl-turbo.")
-                args.denoising_steps = 4
-            if not args.disable_refiner:
-                print("[I] Disable SDXL refiner to run sdxl-turbo.")
-                args.disable_refiner = True
-
-        if args.lcm and args.scheduler != "LCM":
-            print("[I] Use --scheduler=LCM for base since LCM is used.")
-            args.scheduler = "LCM"
 
         assert args.strength > 0.0 and args.strength < 1.0
 
         assert not (args.lcm and args.lora_weights), "it is not supported to use both lcm unet and Lora together"
 
     if args.scheduler == "LCM":
-        if args.guidance > 1.0:
-            print("[I] Use --guidance=0.0 for base since LCM is used.")
+        if args.guidance > 2.0:
+            print("[I] Use --guidance=0.0 (no more than 2.0) when LCM scheduler is used.")
             args.guidance = 0.0
         if args.denoising_steps > 16:
-            print("[I] Use --denoising_steps=8 (no more than 16) for base since LCM is used.")
+            print("[I] Use --denoising_steps=8 (no more than 16) when LCM scheduler is used.")
             args.denoising_steps = 8
 
     print(args)
@@ -309,13 +345,13 @@ def get_metadata(args, is_xl: bool = False) -> Dict[str, Any]:
         metadata["controlnet_type"] = args.controlnet_type
         metadata["controlnet_scale"] = args.controlnet_scale
 
-    if is_xl and not args.disable_refiner:
+    if is_xl and args.enable_refiner:
         metadata["base.scheduler"] = args.scheduler
         metadata["base.denoising_steps"] = args.denoising_steps
         metadata["base.guidance"] = args.guidance
         metadata["refiner.strength"] = args.strength
         metadata["refiner.scheduler"] = args.refiner_scheduler
-        metadata["refiner.denoising_steps"] = args.refiner_steps
+        metadata["refiner.denoising_steps"] = args.refiner_denoising_steps
         metadata["refiner.guidance"] = args.refiner_guidance
     else:
         metadata["scheduler"] = args.scheduler
@@ -450,6 +486,8 @@ def get_depth_image(image):
     with torch.no_grad(), torch.autocast("cuda"):
         depth_map = depth_estimator(image).predicted_depth
 
+    # The depth map is 384x384 by default, here we interpolate to the default output size.
+    # Note that it will be resized to output image size later. May change the size here to avoid interpolate twice.
     depth_map = torch.nn.functional.interpolate(
         depth_map.unsqueeze(1),
         size=(1024, 1024),
@@ -482,19 +520,8 @@ def process_controlnet_images_xl(args) -> List[Image.Image]:
     """
     Process control image for SDXL control net.
     """
-    image = None
-    if args.controlnet_image:
-        image = Image.open(args.controlnet_image[0])
-    else:
-        # If no image is provided, download an image for demo purpose.
-        if args.controlnet_type[0] == "canny":
-            image = load_image(
-                "https://hf.co/datasets/huggingface/documentation-images/resolve/main/diffusers/input_image_vermeer.png"
-            )
-        elif args.controlnet_type[0] == "depth":
-            image = load_image(
-                "https://huggingface.co/lllyasviel/sd-controlnet-depth/resolve/main/images/stormtrooper.png"
-            )
+    assert len(args.controlnet_image) == 1
+    image = Image.open(args.controlnet_image[0]).convert("RGB")
 
     controlnet_images = []
     if args.controlnet_type[0] == "canny":
@@ -502,7 +529,7 @@ def process_controlnet_images_xl(args) -> List[Image.Image]:
     elif args.controlnet_type[0] == "depth":
         controlnet_images.append(get_depth_image(image))
     else:
-        raise ValueError(f"The controlnet is not supported for SDXL: {args.controlnet_type}")
+        raise ValueError(f"This controlnet type is not supported for SDXL or Turbo: {args.controlnet_type}.")
 
     return controlnet_images
 
@@ -514,6 +541,7 @@ def add_controlnet_arguments(parser, is_xl: bool = False):
     group = parser.add_argument_group("Options for ControlNet (only supports SD 1.5 or XL).")
 
     group.add_argument(
+        "-ci",
         "--controlnet-image",
         nargs="*",
         type=str,
@@ -521,6 +549,7 @@ def add_controlnet_arguments(parser, is_xl: bool = False):
         help="Path to the input regular RGB image/images for controlnet",
     )
     group.add_argument(
+        "-ct",
         "--controlnet-type",
         nargs="*",
         type=str,
@@ -529,75 +558,13 @@ def add_controlnet_arguments(parser, is_xl: bool = False):
         help="A list of controlnet type",
     )
     group.add_argument(
+        "-cs",
         "--controlnet-scale",
         nargs="*",
         type=float,
         default=[],
         help="The outputs of the controlnet are multiplied by `controlnet_scale` before they are added to the residual in the original unet. Default is 0.5 for SDXL, or 1.0 for SD 1.5",
     )
-
-
-def download_image(url) -> Image.Image:
-    response = requests.get(url)
-    return Image.open(BytesIO(response.content)).convert("RGB")
-
-
-def controlnet_demo_images(controlnet_list: List[str], height, width) -> List[Image.Image]:
-    """
-    Return demo images of control net v1.1 for Stable Diffusion 1.5.
-    """
-    control_images = []
-    shape = (height, width)
-    for controlnet in controlnet_list:
-        if controlnet == "canny":
-            canny_image = download_image(
-                "https://hf.co/datasets/huggingface/documentation-images/resolve/main/diffusers/input_image_vermeer.png"
-            )
-            canny_image = controlnet_aux.CannyDetector()(canny_image)
-            control_images.append(canny_image.resize(shape))
-        elif controlnet == "normalbae":
-            normal_image = download_image(
-                "https://huggingface.co/lllyasviel/sd-controlnet-normal/resolve/main/images/toy.png"
-            )
-            normal_image = controlnet_aux.NormalBaeDetector.from_pretrained("lllyasviel/Annotators")(normal_image)
-            control_images.append(normal_image.resize(shape))
-        elif controlnet == "depth":
-            depth_image = download_image(
-                "https://huggingface.co/lllyasviel/sd-controlnet-depth/resolve/main/images/stormtrooper.png"
-            )
-            depth_image = controlnet_aux.LeresDetector.from_pretrained("lllyasviel/Annotators")(depth_image)
-            control_images.append(depth_image.resize(shape))
-        elif controlnet == "mlsd":
-            mlsd_image = download_image(
-                "https://huggingface.co/lllyasviel/sd-controlnet-mlsd/resolve/main/images/room.png"
-            )
-            mlsd_image = controlnet_aux.MLSDdetector.from_pretrained("lllyasviel/Annotators")(mlsd_image)
-            control_images.append(mlsd_image.resize(shape))
-        elif controlnet == "openpose":
-            openpose_image = download_image(
-                "https://huggingface.co/lllyasviel/sd-controlnet-openpose/resolve/main/images/pose.png"
-            )
-            openpose_image = controlnet_aux.OpenposeDetector.from_pretrained("lllyasviel/Annotators")(openpose_image)
-            control_images.append(openpose_image.resize(shape))
-        elif controlnet == "scribble":
-            scribble_image = download_image(
-                "https://huggingface.co/lllyasviel/sd-controlnet-scribble/resolve/main/images/bag.png"
-            )
-            scribble_image = controlnet_aux.HEDdetector.from_pretrained("lllyasviel/Annotators")(
-                scribble_image, scribble=True
-            )
-            control_images.append(scribble_image.resize(shape))
-        elif controlnet == "seg":
-            seg_image = download_image(
-                "https://huggingface.co/lllyasviel/sd-controlnet-seg/resolve/main/images/house.png"
-            )
-            seg_image = controlnet_aux.SamDetector.from_pretrained(
-                "ybelkada/segment-anything", subfolder="checkpoints"
-            )(seg_image)
-            control_images.append(seg_image.resize(shape))
-        else:
-            raise ValueError(f"There is no demo image of this controlnet: {controlnet}")
-    return control_images
 
 
 def process_controlnet_image(controlnet_type: str, image: Image.Image, height, width):
@@ -642,6 +609,15 @@ def process_controlnet_arguments(args):
     assert isinstance(args.controlnet_type, list)
     assert isinstance(args.controlnet_scale, list)
     assert isinstance(args.controlnet_image, list)
+
+    if len(args.controlnet_image) != len(args.controlnet_type):
+        raise ValueError(
+            f"Numbers of controlnet_image {len(args.controlnet_image)} should be equal to number of controlnet_type {len(args.controlnet_type)}."
+        )
+
+    if len(args.controlnet_type) == 0:
+        return None, None
+
     if args.version not in ["1.5", "xl-1.0", "xl-turbo"]:
         raise ValueError("This demo only supports ControlNet in Stable Diffusion 1.5, XL or Turbo.")
 
@@ -649,19 +625,11 @@ def process_controlnet_arguments(args):
     if is_xl and len(args.controlnet_type) > 1:
         raise ValueError("This demo only support one ControlNet for Stable Diffusion XL or Turbo.")
 
-    if len(args.controlnet_image) != 0 and len(args.controlnet_image) != len(args.controlnet_scale):
-        raise ValueError(
-            f"Numbers of ControlNets {len(args.controlnet_image)} should be equal to number of ControlNet scales {len(args.controlnet_scale)}."
-        )
-
-    if len(args.controlnet_type) == 0:
-        return None, None
-
     if len(args.controlnet_scale) == 0:
         args.controlnet_scale = [0.5 if is_xl else 1.0] * len(args.controlnet_type)
     elif len(args.controlnet_type) != len(args.controlnet_scale):
         raise ValueError(
-            f"Numbers of ControlNets {len(args.controlnet_type)} should be equal to number of ControlNet scales {len(args.controlnet_scale)}."
+            f"Numbers of controlnet_type {len(args.controlnet_type)} should be equal to number of controlnet_scale {len(args.controlnet_scale)}."
         )
 
     # Convert controlnet scales to tensor
@@ -671,12 +639,7 @@ def process_controlnet_arguments(args):
         images = process_controlnet_images_xl(args)
     else:
         images = []
-        if len(args.controlnet_image) > 0:
-            for i, image in enumerate(args.controlnet_image):
-                images.append(
-                    process_controlnet_image(args.controlnet_type[i], Image.open(image), args.height, args.width)
-                )
-        else:
-            images = controlnet_demo_images(args.controlnet_type, args.height, args.width)
+        for i, image in enumerate(args.controlnet_image):
+            images.append(process_controlnet_image(args.controlnet_type[i], Image.open(image), args.height, args.width))
 
     return images, controlnet_scale

--- a/onnxruntime/python/tools/transformers/models/stable_diffusion/diffusion_models.py
+++ b/onnxruntime/python/tools/transformers/models/stable_diffusion/diffusion_models.py
@@ -234,12 +234,16 @@ class PipelineInfo:
     def max_image_size(self):
         return self._max_image_size
 
-    def default_image_size(self):
-        if self.version == "xl-1.0":
+    @staticmethod
+    def default_resolution(version: str) -> int:
+        if version == "xl-1.0":
             return 1024
-        if self.version in ("2.0", "2.1"):
+        if version in ("2.0", "2.1"):
             return 768
         return 512
+
+    def default_image_size(self) -> int:
+        return PipelineInfo.default_resolution(self.version)
 
     @staticmethod
     def supported_controlnet(version="1.5"):

--- a/onnxruntime/python/tools/transformers/models/stable_diffusion/engine_builder.py
+++ b/onnxruntime/python/tools/transformers/models/stable_diffusion/engine_builder.py
@@ -118,6 +118,7 @@ class EngineBuilder:
 
     def get_model_dir(self, model_name, root_dir, opt=True, suffix="", create=True):
         engine_name = self.engine_type.name.lower()
+        # TODO: Need not add engine name for ORT_CUDA
         directory_name = self.get_cached_model_name(model_name) + (f".{engine_name}" if opt else "") + suffix
         onnx_model_dir = os.path.join(root_dir, directory_name)
         if create:
@@ -261,6 +262,9 @@ def get_engine_paths(work_dir: str, pipeline_info: PipelineInfo, engine_type: En
     output_dir = os.path.join(root_dir, engine_type.name, short_name, "output")
 
     timing_cache = os.path.join(root_dir, engine_type.name, "timing_cache")
-    framework_model_dir = os.path.join(root_dir, engine_type.name, "torch_model")
+
+    # Shared among ORT_CUDA, ORT_TRT and TRT engines, and need use load_model(..., always_download_fp16=True)
+    # So that the shared model is always fp16.
+    framework_model_dir = os.path.join(root_dir, "torch_model")
 
     return onnx_dir, engine_dir, output_dir, framework_model_dir, timing_cache

--- a/onnxruntime/python/tools/transformers/models/stable_diffusion/ort_optimizer.py
+++ b/onnxruntime/python/tools/transformers/models/stable_diffusion/ort_optimizer.py
@@ -7,6 +7,7 @@
 ONNX Model Optimizer for Stable Diffusion
 """
 
+import gc
 import logging
 import os
 import shutil
@@ -40,6 +41,10 @@ class OrtStableDiffusionOptimizer:
         logger.info("Saving a temporary model to run OnnxRuntime graph optimizations...")
         tmp_model_path = Path(tmp_dir) / "model.onnx"
         onnx_model.save_model_to_file(str(tmp_model_path), use_external_data_format=use_external_data_format)
+
+        del onnx_model
+        gc.collect()
+
         ort_optimized_model_path = Path(tmp_dir) / "optimized.onnx"
         optimize_by_onnxruntime(
             str(tmp_model_path),

--- a/onnxruntime/python/tools/transformers/models/stable_diffusion/pipeline_stable_diffusion.py
+++ b/onnxruntime/python/tools/transformers/models/stable_diffusion/pipeline_stable_diffusion.py
@@ -264,23 +264,25 @@ class StableDiffusionPipeline:
 
         if not self.pipeline_info.is_xl():
             images = [
-                (np.array(i.convert("RGB")).astype(np.float32) / 255.0)[..., None]
-                .transpose(3, 2, 0, 1)
-                .repeat(batch_size, axis=0)
-                for i in images
+                torch.from_numpy(
+                    (np.array(image.convert("RGB")).astype(np.float32) / 255.0)[..., None].transpose(3, 2, 0, 1)
+                )
+                .to(device=self.device, dtype=torch.float16)
+                .repeat_interleave(batch_size, dim=0)
+                for image in images
             ]
-            if do_classifier_free_guidance:
-                images = [torch.cat([torch.from_numpy(i).to(self.device).float()] * 2) for i in images]
-            else:
-                images = [torch.from_numpy(i).to(self.device).float() for i in images]
-            images = torch.cat([image[None, ...] for image in images], dim=0)
-            images = images.to(dtype=torch.float16)
         else:
-            images = self.control_image_processor.preprocess(images, height=height, width=width).to(dtype=torch.float32)
-            images = images.repeat_interleave(batch_size, dim=0)
-            images = images.to(device=self.device, dtype=torch.float16)
-            if do_classifier_free_guidance:
-                images = torch.cat([images] * 2)
+            images = [
+                self.control_image_processor.preprocess(image, height=height, width=width)
+                .to(device=self.device, dtype=torch.float16)
+                .repeat_interleave(batch_size, dim=0)
+                for image in images
+            ]
+
+        if do_classifier_free_guidance:
+            images = [torch.cat([i] * 2) for i in images]
+        images = torch.cat([image[None, ...] for image in images], dim=0)
+
         self.stop_profile("preprocess")
         return images
 

--- a/onnxruntime/python/tools/transformers/models/stable_diffusion/pipeline_stable_diffusion.py
+++ b/onnxruntime/python/tools/transformers/models/stable_diffusion/pipeline_stable_diffusion.py
@@ -349,22 +349,22 @@ class StableDiffusionPipeline:
                     uncond_hidden_states = outputs["hidden_states"]
 
             # Concatenate the unconditional and text embeddings into a single batch to avoid doing two forward passes for classifier free guidance
-            text_embeddings = torch.cat([uncond_embeddings, text_embeddings]).to(dtype=torch.float16)
+            text_embeddings = torch.cat([uncond_embeddings, text_embeddings])
 
         if pooled_outputs:
             pooled_output = text_embeddings
 
         if output_hidden_states:
             if do_classifier_free_guidance:
-                text_embeddings = torch.cat([uncond_hidden_states, hidden_states]).to(dtype=torch.float16)
+                text_embeddings = torch.cat([uncond_hidden_states, hidden_states])
             else:
-                text_embeddings = hidden_states.to(dtype=torch.float16)
+                text_embeddings = hidden_states
 
         self.stop_profile("clip")
 
         if pooled_outputs:
-            return text_embeddings, pooled_output
-        return text_embeddings
+            return text_embeddings.to(dtype=torch.float16), pooled_output.to(dtype=torch.float16)
+        return text_embeddings.to(dtype=torch.float16)
 
     def denoise_latent(
         self,


### PR DESCRIPTION
### Description

[SD-Turbo](https://huggingface.co/stabilityai/sd-turbo) is a fast generative text-to-image model that distilled from [Stable Diffusion 2.1](https://huggingface.co/stabilityai/stable-diffusion-2-1). It is targeted for 512x512 resolution.

1. Support sd-turbo model.
1. Refiner ControlNet in demo
    +  Cache the ControlNet model so that it is downloaded only once.
    +  Do not download default images in script. Instead update document to use wget to download example image.
    +  Fix an issue of control image processing that causes shape mismatch in inference.
1. Refine arguments:
   + Change argument --disable-refiner to --enable-refiner since refiner is not used in most cases
   + Rename --refiner-steps to --refiner_denoising_steps
   + Add abbreviations for most used arguments.
   + Add logic to set default arguments for different models.
1. Refine torch model cache:
   + Share cached torch model among different engines to save disk space.
   + Only download fp16 model (previously, ORT_CUDA downloads fp32 model).
1. Do not use vae slicing when image size is small.
1. For LCM scheduler, allow guidance scale 1.0~2.0.
2. Allow sdxl-turbo to use refiner

###  Performance Test Results

Average latency in ms for SD-Turbo (FP16, EulerA, 512x512) on A100-SXM4-80GB.

Batch | Steps | TRT 8.6 static | ORT_TRT static | ORT_CUDA static | TRT 8.6 dynamic | ORT_TRT dynamic | ORT_CUDA dynamic
-- | -- | -- | -- | -- | -- | -- | --
1 | 1 | 32.07 | 30.55 | 32.89 | 36.41 | 38.30 | 34.83
4 | 1 | 125.36 | 97.40 | 97.49 | 118.24 | 114.95 | 99.10
1 | 4 | 62.29 | 60.24 | 62.50 | 72.49 | 77.82 | 67.66
4 | 4 | 203.51 | 173.11 | 168.32 | 217.14 | 215.71 | 172.53

* Dynamic engine is built for batch size 1 to 8, image size 512x512 to 768x768, optimized for batch size 1 and 512x512