### PR TITLE
[TensorRT EP] Obey precision given in ONNX file

### DIFF
--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
@@ -152,6 +152,7 @@ struct TensorrtFuncState {
   OrtMutex* tensorrt_mu_ptr = nullptr;
   bool fp16_enable = false;
   bool int8_enable = false;
+  bool strong_typing_enable = true;
   bool int8_calibration_cache_available = false;
   bool dla_enable = false;
   int dla_core = 0;
@@ -261,6 +262,7 @@ class TensorrtExecutionProvider : public IExecutionProvider {
   size_t max_workspace_size_ = 1 << 30;  // 1GB
   bool fp16_enable_ = false;
   bool int8_enable_ = false;
+  bool strong_typing_enable_ = false;
   bool dla_enable_ = false;
   int dla_core_ = 0;
   bool force_sequential_engine_build_ = false;


### PR DESCRIPTION
### Description

This will allow to obey the precision constraints defined in an ONNX file with any TRT release after 9.2.
Sample usage in TRT exec: https://github.com/NVIDIA/TensorRT/blob/release/9.2/samples/common/sampleEngines.cpp#L1240-L1242

This should finally enable a fair runtime comparison between other execution providers by obeying the given datatype. It is still possible to overwrite this using the `fp16_enable` flag for example.

This is based on #18008.

