### PR TITLE
[js/web/training] lazyResetGrad implementation

### DIFF
--- a/js/common/lib/backend.ts
+++ b/js/common/lib/backend.ts
@@ -48,6 +48,7 @@ export interface TrainingSessionHandler extends SessionHandler {
   readonly evalInputNames: readonly string[];
   readonly evalOutputNames: readonly string[];
 
+  lazyResetGrad(): Promise<void>;
   runTrainStep(
       feeds: SessionHandler.FeedsType, fetches: SessionHandler.FetchesType,
       options: InferenceSession.RunOptions): Promise<SessionHandler.ReturnType>;

--- a/js/common/lib/training-session-impl.ts
+++ b/js/common/lib/training-session-impl.ts
@@ -192,6 +192,10 @@ export class TrainingSession implements TrainingSessionInterface {
     return returnValue;
   }
 
+  async lazyResetGrad(): Promise<void> {
+    await this.handler.lazyResetGrad();
+  }
+
   runTrainStep(feeds: FeedsType, options?: RunOptions): Promise<ReturnType>;
   runTrainStep(feeds: FeedsType, fetches: FetchesType, options?: RunOptions): Promise<ReturnType>;
   async runTrainStep(feeds: FeedsType, arg1?: FetchesType|RunOptions, arg2?: RunOptions): Promise<ReturnType> {

--- a/js/common/lib/training-session.ts
+++ b/js/common/lib/training-session.ts
@@ -23,8 +23,8 @@ export interface TrainingSession {
   // #region run()
 
   /**
-   * Lazily resets the gradients of all trainable parameters to zero. Should happen after the invocation of runOptimizerStep. 
-   * runTrainStep().
+   * Lazily resets the gradients of all trainable parameters to zero. Should happen after the invocation of
+   * runOptimizerStep.
    */
   lazyResetGrad(): Promise<void>;
 

--- a/js/common/lib/training-session.ts
+++ b/js/common/lib/training-session.ts
@@ -23,7 +23,7 @@ export interface TrainingSession {
   // #region run()
 
   /**
-   * Lazily resets the gradients of all trainable parameters to zero. Should happen before the invocation of the next
+   * Lazily resets the gradients of all trainable parameters to zero. Should happen after the invocation of runOptimizerStep. 
    * runTrainStep().
    */
   lazyResetGrad(): Promise<void>;

--- a/js/common/lib/training-session.ts
+++ b/js/common/lib/training-session.ts
@@ -23,6 +23,12 @@ export interface TrainingSession {
   // #region run()
 
   /**
+   * Lazily resets the gradients of all trainable parameters to zero. Should happen before the invocation of the next
+   * runTrainStep().
+   */
+  lazyResetGrad(): Promise<void>;
+
+  /**
    * Run TrainStep asynchronously with the given feeds and options.
    *
    * @param feeds - Representation of the model input. See type description of `InferenceSession.InputType` for

--- a/js/web/lib/wasm/session-handler-training.ts
+++ b/js/web/lib/wasm/session-handler-training.ts
@@ -6,7 +6,7 @@ import {env, InferenceSession, OnnxValue, SessionHandler, Tensor, TrainingSessio
 import {SerializableModeldata, TensorMetadata} from './proxy-messages';
 import {decodeTensorMetadata, encodeTensorMetadata} from './session-handler-inference';
 import {createSessionAllocate, initRuntime, isOrtEnvInitialized} from './wasm-core-impl';
-import {createCheckpointHandle, createTrainingSessionHandle, getContiguousParameters, getModelInputOutputNames, getParametersSize, loadParametersBuffer, releaseTrainingSessionAndCheckpoint, runEvalStep, runOptimizerStep, runTrainStep} from './wasm-training-core-impl';
+import {createCheckpointHandle, createTrainingSessionHandle, getContiguousParameters, getModelInputOutputNames, getParametersSize, lazyResetGrad, loadParametersBuffer, releaseTrainingSessionAndCheckpoint, runEvalStep, runOptimizerStep, runTrainStep} from './wasm-training-core-impl';
 
 export class OnnxruntimeWebAssemblyTrainingSessionHandler implements TrainingSessionHandler {
   private sessionId: number;
@@ -103,6 +103,10 @@ export class OnnxruntimeWebAssemblyTrainingSessionHandler implements TrainingSes
       resultMap[this.outputNames[outputIndices[i]]] = outputArray[i] ?? decodeTensorMetadata(results[i]);
     }
     return resultMap;
+  }
+
+  async lazyResetGrad(): Promise<void> {
+    await lazyResetGrad(this.sessionId);
   }
 
   async runTrainStep(

--- a/js/web/lib/wasm/wasm-training-core-impl.ts
+++ b/js/web/lib/wasm/wasm-training-core-impl.ts
@@ -263,7 +263,7 @@ export const lazyResetGrad = async(trainingSessionId: number):
       } else {
         throw new Error(NO_TRAIN_FUNCS_MSG);
       }
-    }
+    };
 
 export const runTrainStep = async(
     trainingSessionId: number, inputIndices: number[], inputTensors: TensorMetadata[], outputIndices: number[],

--- a/js/web/lib/wasm/wasm-training-core-impl.ts
+++ b/js/web/lib/wasm/wasm-training-core-impl.ts
@@ -253,6 +253,18 @@ const moveOutputToTensorMetadataArr =
       return output;
     };
 
+export const lazyResetGrad = async(trainingSessionId: number):
+    Promise<void> => {
+      const wasm = getInstance();
+
+      if (wasm._OrtTrainingLazyResetGrad) {
+        const errorCode = wasm._OrtTrainingLazyResetGrad(trainingSessionId);
+        ifErrCodeCheckLastError(errorCode, 'Can\'t call lazyResetGrad.');
+      } else {
+        throw new Error(NO_TRAIN_FUNCS_MSG);
+      }
+    }
+
 export const runTrainStep = async(
     trainingSessionId: number, inputIndices: number[], inputTensors: TensorMetadata[], outputIndices: number[],
     outputTensors: Array<TensorMetadata|null>, options: InferenceSession.RunOptions): Promise<TensorMetadata[]> => {

--- a/js/web/lib/wasm/wasm-training-core-impl.ts
+++ b/js/web/lib/wasm/wasm-training-core-impl.ts
@@ -253,17 +253,16 @@ const moveOutputToTensorMetadataArr =
       return output;
     };
 
-export const lazyResetGrad = async(trainingSessionId: number):
-    Promise<void> => {
-      const wasm = getInstance();
+export const lazyResetGrad = async(trainingSessionId: number): Promise<void> => {
+  const wasm = getInstance();
 
-      if (wasm._OrtTrainingLazyResetGrad) {
-        const errorCode = wasm._OrtTrainingLazyResetGrad(trainingSessionId);
-        ifErrCodeCheckLastError(errorCode, 'Can\'t call lazyResetGrad.');
-      } else {
-        throw new Error(NO_TRAIN_FUNCS_MSG);
-      }
-    };
+  if (wasm._OrtTrainingLazyResetGrad) {
+    const errorCode = wasm._OrtTrainingLazyResetGrad(trainingSessionId);
+    ifErrCodeCheckLastError(errorCode, 'Can\'t call lazyResetGrad.');
+  } else {
+    throw new Error(NO_TRAIN_FUNCS_MSG);
+  }
+};
 
 export const runTrainStep = async(
     trainingSessionId: number, inputIndices: number[], inputTensors: TensorMetadata[], outputIndices: number[],


### PR DESCRIPTION
### Description
* implemented lazyResetGrad function

### Motivation and Context
* we are in the process of adding language bindings to enable training on web
* lazyresetgrad ensures that the gradients are calculated correctly after the first runTrainStep call


