### PR TITLE
Fix GQA shape inference

### DIFF
--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -259,7 +259,6 @@ void GroupQueryAttentionTypeAndShapeInference(ONNX_NAMESPACE::InferenceContext& 
       *output_shape.add_dim() = query_dims[1];
       *output_shape.add_dim() = query_dims[2];
       updateOutputShape(ctx, 0, output_shape);
-      return;
     } else {
       fail_shape_inference("Missing input 2 (value)");
     }


### PR DESCRIPTION
The shape inference is always returning before getting the chance to infer the key/value outputs.