### PR TITLE
Re-enable Sign op int64 test for QNN CPU test

### DIFF
--- a/onnxruntime/test/providers/cpu/math/sign_test.cc
+++ b/onnxruntime/test/providers/cpu/math/sign_test.cc
@@ -140,8 +140,7 @@ TEST(MathOpTest, Sign_int64) {
   std::vector<int64_t> output;
   TestImpl<int64_t>(input.cbegin(), input.cend(), std::back_inserter(output));
   test.AddOutput<int64_t>("output", input_dims, output);
-  // TODO: QNN execute error, need further investigation
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kOpenVINOExecutionProvider, kQnnExecutionProvider});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kOpenVINOExecutionProvider});
 }
 
 TEST(MathOpTest, Sign_float) {

--- a/onnxruntime/test/providers/cpu/nn/conv_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/conv_op_test.cc
@@ -63,14 +63,6 @@ void TestConvOp(const ConvOpAndTestAttributes& attributes,
   // QNN SDK 2.10.0 has a bug that breaks support for dynamic bias inputs.
   excluded_providers.insert(kQnnExecutionProvider);
 
-  // TODO: Enable QNN EP when bug with QNN SDK 2.10.0 is fixed:
-  /*
-  // QNN have issue with dynamic weight, auto pad with SAME_UPPER, SAME_LOWER
-  if (!weight_is_initializer || attributes.auto_pad == "SAME_UPPER" || attributes.auto_pad == "SAME_LOWER") {
-    excluded_providers.insert(kQnnExecutionProvider);
-  }
-  */
-
   test.Run(expect_result, err_str, excluded_providers);
 }
 


### PR DESCRIPTION
### Description
Re-enable Sign op int64 test for QNN CPU test

