### PR TITLE
Objective-C API updates

### DIFF
--- a/objectivec/include/ort_training_session.h
+++ b/objectivec/include/ort_training_session.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
  * session which will be moved to the device specified in the session option if needed.
  *
  * @param env The `ORTEnv` instance to use for the training session.
- * @param sessionOptions The `ORTSessionOptions` to use for the training session.
+ * @param sessionOptions The optional `ORTSessionOptions` to use for the training session.
  * @param checkpoint Training states that are used as a starting point for training.
  * @param trainModelPath The path to the training onnx model.
  * @param evalModelPath The path to the evaluation onnx model.
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
  * keeps a strong (owning) pointer to the checkpoint state.
  */
 - (nullable instancetype)initWithEnv:(ORTEnv*)env
-                      sessionOptions:(ORTSessionOptions*)sessionOptions
+                      sessionOptions:(nullable ORTSessionOptions*)sessionOptions
                           checkpoint:(ORTCheckpoint*)checkpoint
                       trainModelPath:(NSString*)trainModelPath
                        evalModelPath:(nullable NSString*)evalModelPath

--- a/objectivec/ort_session.mm
+++ b/objectivec/ort_session.mm
@@ -24,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation ORTSession {
   std::optional<Ort::Session> _session;
+  ORTEnv* _env;  // keep a strong reference so the ORTEnv doesn't get destroyed before this does
 }
 
 #pragma mark - Public
@@ -47,6 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
     _session = Ort::Session{[env CXXAPIOrtEnv],
                             path.UTF8String,
                             [sessionOptions CXXAPIOrtSessionOptions]};
+    _env = env;
 
     return self;
   }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

- Add ORTSession and ORTTrainingSession strong references to ORTEnv.
- Make ORTTrainingSession session options parameter optional.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

API improvements.
Ensure ORTEnv doesn't get destroyed while a session is still using it.