### PR TITLE
Update MatMulIntegerToFloat test data for DML

### DIFF
--- a/onnxruntime/test/contrib_ops/matmul_integer_to_float_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_integer_to_float_test.cc
@@ -36,16 +36,24 @@ void TestMatMulIntegerToFloat(const std::vector<int64_t>& A_dims,
 
   std::vector<IType> A_data;
   std::vector<int> tmp_A_data = random.Uniform<int32_t>(A_dims,
-                                                        std::numeric_limits<WType>::lowest(),
-                                                        std::numeric_limits<WType>::max());
-  std::transform(tmp_A_data.begin(), tmp_A_data.end(), std::back_inserter(A_data), [](int32_t v) -> WType {
+                                                        std::numeric_limits<IType>::lowest(),
+                                                        std::numeric_limits<IType>::max());
+  std::transform(tmp_A_data.begin(), tmp_A_data.end(), std::back_inserter(A_data), [](int32_t v) -> IType {
     return static_cast<IType>(v);
   });
 
   std::vector<WType> B_data;
+
+#if defined(USE_DML)
+  std::vector<int> tmp_B_data = random.Uniform<int32_t>(B_dims,
+                                                        (constexpr(std::is_same_v<WType, int8_t>) ? -2 : 1),
+                                                        5);
+#else
   std::vector<int> tmp_B_data = random.Uniform<int32_t>(B_dims,
                                                         std::numeric_limits<WType>::lowest(),
                                                         std::numeric_limits<WType>::max());
+#endif
+
   std::transform(tmp_B_data.begin(), tmp_B_data.end(), std::back_inserter(B_data), [](int32_t v) -> WType {
     return static_cast<WType>(v);
   });
@@ -77,7 +85,7 @@ void TestMatMulIntegerToFloat(const std::vector<int64_t>& A_dims,
     test.AddInput<IType>("a_zero_point", {1}, A_zero_point);
     test.AddInput<WType>("b_zero_point", {b_scale_zp_size}, B_zero_point);
   } else {
-    test.AddOptionalInputEdge<WType>();
+    test.AddOptionalInputEdge<IType>();
     test.AddOptionalInputEdge<WType>();
   }
 


### PR DESCRIPTION
### Description

Updating Test values od B Matrix for **DMLEP** tests and correcting template data type for A Matrix.

Occasional failures for random seeds, are still noticed ~ 1/5 runs, but for only 2-5 elements. This is mostly when the actual reference values are small. Currently FP16 has relative tolerance, which ORT uses it as `*(params.relative_error) * std::abs(static_cast<float>(cur_expected[i]))`.

Example ORT test random seed: 3081517116
```
The difference between f_expected[i] and f_actual[i] is 0.0962677001953125, which exceeds *(params.relative_error) * std::abs(static_cast<float>(cur_expected[i])), where
f_expected[i] evaluates to -0.0259552001953125,
f_actual[i] evaluates to 0.0703125, and
*(params.relative_error) * std::abs(static_cast<float>(cur_expected[i])) evaluates to 0.051910400390625.
i:217

The difference between f_expected[i] and f_actual[i] is 0.00566864013671875, which exceeds *(params.relative_error) * std::abs(static_cast<float>(cur_expected[i])), where
f_expected[i] evaluates to -0.00244903564453125,
f_actual[i] evaluates to -0.00811767578125, and
*(params.relative_error) * std::abs(static_cast<float>(cur_expected[i])) evaluates to 0.0048980712890625.
i:184

The difference between f_expected[i] and f_actual[i] is 0.0962677001953125, which exceeds *(params.relative_error) * std::abs(static_cast<float>(cur_expected[i])), where
f_expected[i] evaluates to -0.0259552001953125,
f_actual[i] evaluates to 0.0703125, and
*(params.relative_error) * std::abs(static_cast<float>(cur_expected[i])) evaluates to 0.051910400390625.
i:217
``` 


```
Note: Google Test filter = *MatMulIntegerToFloat*
[==========] Running 13 tests from 4 test suites.
[----------] Global test environment set-up.
[----------] 1 test from CPU_U8S8_Precision_Tests
[ RUN      ] CPU_U8S8_Precision_Tests.MatMulIntegerToFloat
[       OK ] CPU_U8S8_Precision_Tests.MatMulIntegerToFloat (244 ms)
[----------] 1 test from CPU_U8S8_Precision_Tests (244 ms total)

[----------] 2 tests from GraphTransformationTests
[ RUN      ] GraphTransformationTests.MatMulIntegerToFloatTest
[       OK ] GraphTransformationTests.MatMulIntegerToFloatTest (17 ms)
[ RUN      ] GraphTransformationTests.MatMulIntegerToFloat16Test
[       OK ] GraphTransformationTests.MatMulIntegerToFloat16Test (6 ms)
[----------] 2 tests from GraphTransformationTests (24 ms total)

[----------] 1 test from QDQTransformerTests
[ RUN      ] QDQTransformerTests.MatMulIntegerToFloat
[       OK ] QDQTransformerTests.MatMulIntegerToFloat (1065 ms)
[----------] 1 test from QDQTransformerTests (1065 ms total)

[----------] 9 tests from MatMulIntegerToFloat
[ RUN      ] MatMulIntegerToFloat.HasZeroPoint_NoBias_test_U8X8_FP16
[       OK ] MatMulIntegerToFloat.HasZeroPoint_NoBias_test_U8X8_FP16 (2506 ms)
[ RUN      ] MatMulIntegerToFloat.NoZeroPoint_HasBias_test_U8X8_FP16
[       OK ] MatMulIntegerToFloat.NoZeroPoint_HasBias_test_U8X8_FP16 (1873 ms)
[ RUN      ] MatMulIntegerToFloat.HasZeroPoint_NoBias_test_S8S8_FP16
[       OK ] MatMulIntegerToFloat.HasZeroPoint_NoBias_test_S8S8_FP16 (906 ms)
[ RUN      ] MatMulIntegerToFloat.NoZeroPoint_HasBias_test_S8S8_FP16
[       OK ] MatMulIntegerToFloat.NoZeroPoint_HasBias_test_S8S8_FP16 (944 ms)
[ RUN      ] MatMulIntegerToFloat.HasZeroPoint_NoBias_test_U8X8
[       OK ] MatMulIntegerToFloat.HasZeroPoint_NoBias_test_U8X8 (1804 ms)
[ RUN      ] MatMulIntegerToFloat.NoZeroPoint_HasBias_test_U8X8
[       OK ] MatMulIntegerToFloat.NoZeroPoint_HasBias_test_U8X8 (1838 ms)
[ RUN      ] MatMulIntegerToFloat.HasZeroPoint_NoBias_test_S8S8
[       OK ] MatMulIntegerToFloat.HasZeroPoint_NoBias_test_S8S8 (943 ms)
[ RUN      ] MatMulIntegerToFloat.NoZeroPoint_HasBias_test_S8S8
[       OK ] MatMulIntegerToFloat.NoZeroPoint_HasBias_test_S8S8 (961 ms)
[ RUN      ] MatMulIntegerToFloat.MatMulInteger_With_ZeroPoint
[       OK ] MatMulIntegerToFloat.MatMulInteger_With_ZeroPoint (284 ms)
[----------] 9 tests from MatMulIntegerToFloat (12065 ms total)

[----------] Global test environment tear-down
[==========] 13 tests from 4 test suites ran. (13403 ms total)
[  PASSED  ] 13 tests.
memleakdbg: 
----- No memory leaks detected -----
```

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


