### PR TITLE
QAttention test updates

### DIFF
--- a/build/Windows/Debug/Debug/testdata/qattention.py
+++ b/build/Windows/Debug/Debug/testdata/qattention.py
@@ -1,0 +1,71 @@
+from enum import Enum  # noqa: F401
+
+import onnx
+from onnx import TensorProto, helper
+
+
+def GenerateModel(model_name, sign_i, sign_w, output_type_fp16, has_zp=True):  # noqa: N802
+    nodes = [  # subgraph
+        helper.make_node(
+            "QAttention",
+            ["input", "weight", "bias", "input_scale", "weight_scale", "input_zero_point", "weight_zero_point", "past"],# if has_zp else ["A", "B"],
+            ["present", "output"],
+            "QAttention",
+            unidirectional=1
+        )
+    ]
+
+    inputs = [  # inputs
+        helper.make_tensor_value_info("input", TensorProto.INT8 if sign_i else TensorProto.UINT8, ["batch_size", "sequence_length", "hidden_size"]),
+        helper.make_tensor_value_info("weight", TensorProto.INT8 if sign_w else TensorProto.UINT8, ["hidden_size", "3 * hidden_size"]),
+        helper.make_tensor_value_info("bias", TensorProto.FLOAT16 if output_type_fp16 else TensorProto.FLOAT, ["3 * hidden_size"]),
+        helper.make_tensor_value_info("input_scale", TensorProto.FLOAT16 if output_type_fp16 else TensorProto.FLOAT, [1]),
+        helper.make_tensor_value_info("weight_scale", TensorProto.FLOAT16 if output_type_fp16 else TensorProto.FLOAT, [1]),# per column: ["C"]),
+        helper.make_tensor_value_info("input_zero_point", TensorProto.INT8 if sign_i else TensorProto.UINT8, ["1"]),
+        helper.make_tensor_value_info("weight_zero_point", TensorProto.INT8 if sign_w else TensorProto.UINT8, ["1"]),
+        helper.make_tensor_value_info("past", TensorProto.FLOAT16 if output_type_fp16 else TensorProto.FLOAT, [2, "batch_size", "number_of_heads", "past_sequence_length", "head_size"]),
+    ]
+
+    #if has_zp:
+    #    inputs.extend(
+    #        [
+    #            helper.make_tensor_value_info(
+    #                "a_zero_point",
+    #                TensorProto.INT8 if sign_i else TensorProto.UINT8,
+    #                [1],
+    #            ),
+    #            helper.make_tensor_value_info(
+    #                "b_zero_point",
+    #                TensorProto.INT8 if sign_w else TensorProto.UINT8,
+    #                ["C"],
+    #            ),
+    #        ]
+    #    )
+
+    #if bias:
+    #    nodes.extend([helper.make_node("Add", ["mul_bottom_output", "bias"], ["Y"], "add")])
+    #
+    #    inputs.extend([helper.make_tensor_value_info("bias", TensorProto.FLOAT16 if output_type_fp16 else TensorProto.FLOAT, ["N"])])
+
+    graph = helper.make_graph(
+        nodes,
+        "QAttention",  # name
+        inputs,
+        [  # outputs
+            helper.make_tensor_value_info("present", TensorProto.FLOAT16 if output_type_fp16 else TensorProto.FLOAT, [2, "batch_size", "number_of_heads", "past_sequence_length + sequence_length", "head_size"]),
+            helper.make_tensor_value_info("output", TensorProto.FLOAT16 if output_type_fp16 else TensorProto.FLOAT, ["batch_size", "sequence_length", "hidden_size"]),
+        ],
+    )
+
+    model = helper.make_model(graph)
+    onnx.save(model, model_name)
+
+
+if __name__ == "__main__":
+    GenerateModel("qattentionfp16_int8.onnx", sign_i=False, sign_w=True, output_type_fp16=True)
+    GenerateModel("qattentionfp16_uint8.onnx", sign_i=False, sign_w=False, output_type_fp16=True)
+    GenerateModel("qattentionfp16_int8_int8.onnx", sign_i=True, sign_w=True, output_type_fp16=True)
+
+    GenerateModel("qattention_int8.onnx", sign_i=False, sign_w=True, output_type_fp16=False)
+    GenerateModel("qattention_uint8.onnx", sign_i=False, sign_w=False, output_type_fp16=False)
+    GenerateModel("qattention_int8_int8.onnx", sign_i=True, sign_w=True, output_type_fp16=False)

--- a/build/Windows/Debug/Debug/testdata/qattention_int8.onnx
+++ b/build/Windows/Debug/Debug/testdata/qattention_int8.onnx
@@ -1,0 +1,63 @@
+	:Ç
+›
+input
+weight
+bias
+input_scale
+weight_scale
+input_zero_point
+weight_zero_point
+pastpresentoutput
+QAttention"
+QAttention*
+unidirectional 
+QAttentionZ?
+input6
+40
+
+batch_size
+sequence_length
+hidden_sizeZ2
+weight(
+&"
+hidden_size
+3 * hidden_sizeZ!
+bias
+
+3 * hidden_sizeZ
+input_scale
+
+
+Z
+weight_scale
+
+
+Z
+input_zero_point
+	
+1Z 
+weight_zero_point
+	
+1ZX
+pastP
+NJ
+
+
+batch_size
+number_of_heads
+past_sequence_length
+	head_sizebm
+presentb
+`\
+
+
+batch_size
+number_of_heads
+(&past_sequence_length + sequence_length
+	head_sizeb@
+output6
+40
+
+batch_size
+sequence_length
+hidden_sizeB

--- a/build/Windows/Debug/Debug/testdata/qattention_int8_int8.onnx
+++ b/build/Windows/Debug/Debug/testdata/qattention_int8_int8.onnx
@@ -1,0 +1,63 @@
+	:Ç
+›
+input
+weight
+bias
+input_scale
+weight_scale
+input_zero_point
+weight_zero_point
+pastpresentoutput
+QAttention"
+QAttention*
+unidirectional 
+QAttentionZ?
+input6
+40
+
+batch_size
+sequence_length
+hidden_sizeZ2
+weight(
+&"
+hidden_size
+3 * hidden_sizeZ!
+bias
+
+3 * hidden_sizeZ
+input_scale
+
+
+Z
+weight_scale
+
+
+Z
+input_zero_point
+	
+1Z 
+weight_zero_point
+	
+1ZX
+pastP
+NJ
+
+
+batch_size
+number_of_heads
+past_sequence_length
+	head_sizebm
+presentb
+`\
+
+
+batch_size
+number_of_heads
+(&past_sequence_length + sequence_length
+	head_sizeb@
+output6
+40
+
+batch_size
+sequence_length
+hidden_sizeB

--- a/build/Windows/Debug/Debug/testdata/qattention_uint8.onnx
+++ b/build/Windows/Debug/Debug/testdata/qattention_uint8.onnx
@@ -1,0 +1,63 @@
+	:Ç
+›
+input
+weight
+bias
+input_scale
+weight_scale
+input_zero_point
+weight_zero_point
+pastpresentoutput
+QAttention"
+QAttention*
+unidirectional 
+QAttentionZ?
+input6
+40
+
+batch_size
+sequence_length
+hidden_sizeZ2
+weight(
+&"
+hidden_size
+3 * hidden_sizeZ!
+bias
+
+3 * hidden_sizeZ
+input_scale
+
+
+Z
+weight_scale
+
+
+Z
+input_zero_point
+	
+1Z 
+weight_zero_point
+	
+1ZX
+pastP
+NJ
+
+
+batch_size
+number_of_heads
+past_sequence_length
+	head_sizebm
+presentb
+`\
+
+
+batch_size
+number_of_heads
+(&past_sequence_length + sequence_length
+	head_sizeb@
+output6
+40
+
+batch_size
+sequence_length
+hidden_sizeB

--- a/build/Windows/Debug/Debug/testdata/qattentionfp16_int8.onnx
+++ b/build/Windows/Debug/Debug/testdata/qattentionfp16_int8.onnx
@@ -1,0 +1,69 @@
+	:Ç
+›
+input
+weight
+bias
+input_scale
+weight_scale
+input_zero_point
+weight_zero_point
+pastpresentoutput
+QAttention"
+QAttention*
+unidirectional 
+QAttentionZ?
+input6
+40
+
+batch_size
+sequence_length
+hidden_sizeZ2
+weight(
+&"
+hidden_size
+3 * hidden_sizeZ!
+bias
+
+
+3 * hidden_sizeZ
+input_scale
+
+
+
+Z
+weight_scale
+
+
+
+Z
+input_zero_point
+	
+1Z 
+weight_zero_point
+	
+1ZX
+pastP
+N
+J
+
+
+batch_size
+number_of_heads
+past_sequence_length
+	head_sizebm
+presentb
+`
+\
+
+
+batch_size
+number_of_heads
+(&past_sequence_length + sequence_length
+	head_sizeb@
+output6
+4
+0
+
+batch_size
+sequence_length
+hidden_sizeB

--- a/build/Windows/Debug/Debug/testdata/qattentionfp16_int8_int8.onnx
+++ b/build/Windows/Debug/Debug/testdata/qattentionfp16_int8_int8.onnx
@@ -1,0 +1,69 @@
+	:Ç
+›
+input
+weight
+bias
+input_scale
+weight_scale
+input_zero_point
+weight_zero_point
+pastpresentoutput
+QAttention"
+QAttention*
+unidirectional 
+QAttentionZ?
+input6
+40
+
+batch_size
+sequence_length
+hidden_sizeZ2
+weight(
+&"
+hidden_size
+3 * hidden_sizeZ!
+bias
+
+
+3 * hidden_sizeZ
+input_scale
+
+
+
+Z
+weight_scale
+
+
+
+Z
+input_zero_point
+	
+1Z 
+weight_zero_point
+	
+1ZX
+pastP
+N
+J
+
+
+batch_size
+number_of_heads
+past_sequence_length
+	head_sizebm
+presentb
+`
+\
+
+
+batch_size
+number_of_heads
+(&past_sequence_length + sequence_length
+	head_sizeb@
+output6
+4
+0
+
+batch_size
+sequence_length
+hidden_sizeB

--- a/build/Windows/Debug/Debug/testdata/qattentionfp16_uint8.onnx
+++ b/build/Windows/Debug/Debug/testdata/qattentionfp16_uint8.onnx
@@ -1,0 +1,69 @@
+	:Ç
+›
+input
+weight
+bias
+input_scale
+weight_scale
+input_zero_point
+weight_zero_point
+pastpresentoutput
+QAttention"
+QAttention*
+unidirectional 
+QAttentionZ?
+input6
+40
+
+batch_size
+sequence_length
+hidden_sizeZ2
+weight(
+&"
+hidden_size
+3 * hidden_sizeZ!
+bias
+
+
+3 * hidden_sizeZ
+input_scale
+
+
+
+Z
+weight_scale
+
+
+
+Z
+input_zero_point
+	
+1Z 
+weight_zero_point
+	
+1ZX
+pastP
+N
+J
+
+
+batch_size
+number_of_heads
+past_sequence_length
+	head_sizebm
+presentb
+`
+\
+
+
+batch_size
+number_of_heads
+(&past_sequence_length + sequence_length
+	head_sizeb@
+output6
+4
+0
+
+batch_size
+sequence_length
+hidden_sizeB

--- a/onnxruntime/test/common/random_generator.h
+++ b/onnxruntime/test/common/random_generator.h
@@ -151,6 +151,16 @@ class RandomValueGenerator {
     return val;
   }
 
+  // Gaussian distribution for Integer and Clamp to [value]
+  template <typename TInt>
+  inline std::vector<TInt> fill(const std::vector<int64_t>& dims, TInt value) {
+    std::vector<TInt> val(detail::SizeFromDims(dims));
+    for (size_t i = 0; i < val.size(); ++i) {
+      val[i] = value;
+    }
+    return val;
+  }
+
   template <class T>
   inline std::vector<T> OneHot(const std::vector<int64_t>& dims, int64_t stride) {
     std::vector<T> val(detail::SizeFromDims(dims), T(0));


### PR DESCRIPTION
### Description

- Added `QAttentionPastState_DML_u8u8` test case
- Updated `QAttentionPastState_u8u8` to use model with direct `QAttention` node



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


