### PR TITLE
Add cuda visible devices for Mistral benchmark

### DIFF
--- a/onnxruntime/python/tools/transformers/models/llama/README.md
+++ b/onnxruntime/python/tools/transformers/models/llama/README.md
@@ -412,7 +412,7 @@ python -m models.llama.convert_to_onnx -i /path/to/model/directory -o /path/to/o
 The benchmarking scripts in the LLaMA directory support Mistral benchmarking. To benchmark the ORT version, you can run: 
 
 ```
-python -m models.llama.benchmark \
+CUDA_VISIBLE_DEVICES=0 python -m models.llama.benchmark \
     -bt ort-convert-to-onnx \
     -p fp16 \
     -m mistralai/Mistral-7B-v0.1 \
@@ -422,7 +422,7 @@ python -m models.llama.benchmark \
 To benchmark the Hugging Face implementation without `torch.compile`:
 
 ```
-python -m models.llama.benchmark \
+CUDA_VISIBLE_DEVICES=0 python -m models.llama.benchmark \
     -bt hf-pt-eager \
     -p fp16 \
     -m mistralai/Mistral-7B-v0.1
@@ -431,7 +431,7 @@ python -m models.llama.benchmark \
 And to benchmark the Hugging Face implementation with `torch.compile`:
 
 ```
-python -m models.llama.benchmark \
+CUDA_VISIBLE_DEVICES=0 python -m models.llama.benchmark \
     -bt hf-pt-compile \
     -p fp16 \
     -m mistralai/Mistral-7B-v0.1

--- a/onnxruntime/python/tools/transformers/models/llama/benchmark.py
+++ b/onnxruntime/python/tools/transformers/models/llama/benchmark.py
@@ -374,12 +374,7 @@ def measure_fn(args, fn, inputs):
     # Measure memory usage
     gc.collect()
     torch.cuda.empty_cache()
-    # measure memory fn is not working with pytorch so adding a try catch block
-    try:
-        measure_memory(is_gpu=(args.device != "cpu"), func=lambda: fn(inputs))
-    except RuntimeError as e:
-        logger.exception(e)
-        print("Memasure memory function is not working correctly, continuing")
+    measure_memory(is_gpu=(args.device != "cpu"), func=lambda: fn(inputs))
 
     # Flush output so memory usage is printed
     sys.stdout.flush()

--- a/onnxruntime/python/tools/transformers/models/llama/benchmark.py
+++ b/onnxruntime/python/tools/transformers/models/llama/benchmark.py
@@ -11,7 +11,7 @@ import numpy as np
 import onnx
 import psutil
 import torch
-from benchmark_helper import setup_logger
+from benchmark_helper import measure_memory, setup_logger
 from dist_settings import get_rank, get_size
 from llama_inputs import (
     add_io_bindings,
@@ -374,9 +374,13 @@ def measure_fn(args, fn, inputs):
     # Measure memory usage
     gc.collect()
     torch.cuda.empty_cache()
-    # Disable measure memory fn as it is not working with pytorch
-    # from benchmark_helper import measure_memory
-    # measure_memory(is_gpu=(args.device != "cpu"), func=lambda: fn(inputs))
+    # measure memory fn is not working with pytorch so adding a try catch block
+    try:
+        measure_memory(is_gpu=(args.device != "cpu"), func=lambda: fn(inputs))
+    except RuntimeError as e:
+        logger.exception(e)
+        print("Memasure memory function is not working correctly, continuing")
+        continue
 
     # Flush output so memory usage is printed
     sys.stdout.flush()

--- a/onnxruntime/python/tools/transformers/models/llama/benchmark.py
+++ b/onnxruntime/python/tools/transformers/models/llama/benchmark.py
@@ -11,7 +11,7 @@ import numpy as np
 import onnx
 import psutil
 import torch
-from benchmark_helper import measure_memory, setup_logger
+from benchmark_helper import setup_logger
 from dist_settings import get_rank, get_size
 from llama_inputs import (
     add_io_bindings,
@@ -375,6 +375,7 @@ def measure_fn(args, fn, inputs):
     gc.collect()
     torch.cuda.empty_cache()
     # Disable measure memory fn as it is not working with pytorch
+    # from benchmark_helper import measure_memory
     # measure_memory(is_gpu=(args.device != "cpu"), func=lambda: fn(inputs))
 
     # Flush output so memory usage is printed

--- a/onnxruntime/python/tools/transformers/models/llama/benchmark.py
+++ b/onnxruntime/python/tools/transformers/models/llama/benchmark.py
@@ -374,7 +374,8 @@ def measure_fn(args, fn, inputs):
     # Measure memory usage
     gc.collect()
     torch.cuda.empty_cache()
-    measure_memory(is_gpu=(args.device != "cpu"), func=lambda: fn(inputs))
+    # Disable measure memory fn as it is not working with pytorch
+    # measure_memory(is_gpu=(args.device != "cpu"), func=lambda: fn(inputs))
 
     # Flush output so memory usage is printed
     sys.stdout.flush()

--- a/onnxruntime/python/tools/transformers/models/llama/benchmark.py
+++ b/onnxruntime/python/tools/transformers/models/llama/benchmark.py
@@ -380,7 +380,6 @@ def measure_fn(args, fn, inputs):
     except RuntimeError as e:
         logger.exception(e)
         print("Memasure memory function is not working correctly, continuing")
-        continue
 
     # Flush output so memory usage is printed
     sys.stdout.flush()


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Add cuda visible devices for Mistral benchmark as it is not working for Torch compile and throwing an error.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Error: 
  File "/opt/conda/envs/ptca/lib/python3.8/site-packages/torch/_inductor/triton_heuristics.py", line 556, in run
    return launcher(
  File "<string>", line 8, in launcher
RuntimeError: Triton Error [CUDA]: invalid device context

