### PR TITLE
Set NDK version in Linux CPU Minimal Build E2E CI Pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
@@ -74,6 +74,8 @@ jobs:
     clean: true
     submodules: none
 
+  - template: "templates/use-android-ndk.yml"
+
   - template: templates/get-docker-image-steps.yml
     parameters:
       Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2_28_cpu


### PR DESCRIPTION
### Description
To upgrade the clang version in preparation for PR #17031 .


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


