### PR TITLE
[WIP][js/common] first step to support better tensor preprocess

### DIFF
--- a/js/common/lib/backend-impl.ts
+++ b/js/common/lib/backend-impl.ts
@@ -63,18 +63,18 @@ export const registerBackend = (name: string, backend: Backend, priority: number
  * Resolve backend by specified hints.
  *
  * @param backendHints - a list of execution provider names to lookup. If omitted use registered backends as list.
- * @returns a promise that resolves to the backend.
+ * @returns a promise that resolves to the name and the backend.
  *
  * @ignore
  */
-export const resolveBackend = async(backendHints: readonly string[]): Promise<Backend> => {
+export const resolveBackend = async(backendHints: readonly string[]): Promise<[name: string, backend: Backend]> => {
   const backendNames = backendHints.length === 0 ? backendsSortedByPriority : backendHints;
   const errors = [];
   for (const backendName of backendNames) {
     const backendInfo = backends.get(backendName);
     if (backendInfo) {
       if (backendInfo.initialized) {
-        return backendInfo.backend;
+        return [backendName, backendInfo.backend];
       } else if (backendInfo.aborted) {
         continue;  // current backend is unavailable; try next
       }
@@ -86,7 +86,7 @@ export const resolveBackend = async(backendHints: readonly string[]): Promise<Ba
         }
         await backendInfo.initPromise;
         backendInfo.initialized = true;
-        return backendInfo.backend;
+        return [backendName, backendInfo.backend];
       } catch (e) {
         if (!isInitializing) {
           errors.push({name: backendName, err: e});

--- a/js/common/lib/preprocess-impl.ts
+++ b/js/common/lib/preprocess-impl.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import {Preprocessor} from './preprocess.js';
+
+const registeredPreprocessors: Map<string, Map<string, () => Promise<Preprocessor>>> = new Map();
+
+/**
+ * Register a preprocessor.
+ *
+ * A preprocessor can process a certain type of raw data into a data type that can be directly used as feeds by the
+ * backend for inference.
+ *
+ * @param backendName - the backend name.
+ * @param input - the input type. usually a raw data type.
+ * @param output - the output data type.
+ * @param getPreprocessor - a function that returns a promise of a preprocessor.
+ *
+ * @ignore
+ */
+export const registerPreprocessor =
+    (backendName: string, input: string, output: string, getPreprocessor: () => Promise<Preprocessor>): void => {
+      let preprocessors = registeredPreprocessors.get(backendName);
+      if (preprocessors === undefined) {
+        preprocessors = new Map();
+        registeredPreprocessors.set(backendName, preprocessors);
+      }
+      preprocessors.set(`${input}:${output}`, getPreprocessor);
+    };
+
+/**
+ * Resolve a preprocessor.
+ *
+ * @param backendName - the backend name.
+ * @param input - the input type. usually a raw data type.
+ * @param output - the output data type.
+ *
+ * @ignore
+ */
+export const resolvePreprocessor =
+    async(backendName: string, input: string, output: string): Promise<Preprocessor|undefined> => {
+  const preprocessors = registeredPreprocessors.get(backendName);
+  if (preprocessors === undefined) {
+    return undefined;
+  }
+  const getPreprocessor = preprocessors.get(`${input}:${output}`);
+  if (getPreprocessor === undefined) {
+    return undefined;
+  }
+  return getPreprocessor();
+};

--- a/js/common/lib/preprocess.ts
+++ b/js/common/lib/preprocess.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import {Tensor} from './tensor.js';
+
+/* eslint-disable @typescript-eslint/naming-convention */
+export interface PreprocessorDataInputTypeMapping {
+  'image-data': ImageData;
+  'image-bitmap': ImageBitmap;
+  'image-url': string;
+  'image-element': HTMLImageElement;
+}
+
+interface PreprocessorDataOutputForGpuBuffer {
+  readonly gpuBuffer: Tensor['gpuBuffer'];
+  readonly dispose?: Tensor['dispose'];
+}
+
+
+export interface PreprocessorDataOutputTypeMapping {
+  'cpu': Tensor['data'];
+  'gpu-buffer': PreprocessorDataOutputForGpuBuffer;
+}
+/* eslint-enable @typescript-eslint/naming-convention */
+
+/**
+ * A preprocess plan describes how to preprocess a certain type of raw data into an inference-ready data.
+ */
+export interface PreprocessPlan<
+    Input extends keyof PreprocessorDataInputTypeMapping = keyof PreprocessorDataInputTypeMapping,
+                  Output extends keyof PreprocessorDataOutputTypeMapping = keyof PreprocessorDataOutputTypeMapping> {
+  data: PreprocessorDataInputTypeMapping[Input];
+  input: Input;
+  output: Output;
+  options?: unknown;
+}
+
+export interface Preprocessor<
+    Input extends keyof PreprocessorDataInputTypeMapping = keyof PreprocessorDataInputTypeMapping,
+                  Output extends keyof PreprocessorDataOutputTypeMapping = keyof PreprocessorDataOutputTypeMapping> {
+  process(data: PreprocessorDataInputTypeMapping[Input], options?: unknown):
+      Promise<PreprocessorDataOutputTypeMapping[Output]>;
+}
+
+export {registerPreprocessor} from './preprocess-impl.js';

--- a/js/common/lib/tensor-factory-impl.ts
+++ b/js/common/lib/tensor-factory-impl.ts
@@ -1,98 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import {OptionsDimensions, OptionsFormat, OptionsNormalizationParameters, OptionsTensorFormat, OptionsTensorLayout, TensorFromGpuBufferOptions, TensorFromImageBitmapOptions, TensorFromImageDataOptions, TensorFromImageElementOptions, TensorFromTextureOptions, TensorFromUrlOptions} from './tensor-factory.js';
+import {TensorFromGpuBufferOptions, TensorFromImageBitmapOptions, TensorFromImageDataOptions, TensorFromImageElementOptions, TensorFromTextureOptions, TensorFromUrlOptions} from './tensor-factory.js';
 import {Tensor} from './tensor-impl.js';
 import {Tensor as TensorInterface} from './tensor.js';
-
-interface BufferToTensorOptions extends OptionsDimensions, OptionsTensorLayout, OptionsNormalizationParameters,
-                                        OptionsFormat, OptionsTensorFormat {}
-
-/**
- * Create a new tensor object from image object
- *
- * @param buffer - Extracted image buffer data - assuming RGBA format
- * @param imageFormat - input image configuration - required configurations height, width, format
- * @param tensorFormat - output tensor configuration - Default is RGB format
- */
-export const bufferToTensor = (buffer: Uint8ClampedArray|undefined, options: BufferToTensorOptions): Tensor => {
-  if (buffer === undefined) {
-    throw new Error('Image buffer must be defined');
-  }
-  if (options.height === undefined || options.width === undefined) {
-    throw new Error('Image height and width must be defined');
-  }
-  if (options.tensorLayout === 'NHWC') {
-    throw new Error('NHWC Tensor layout is not supported yet');
-  }
-
-  const {height, width} = options;
-
-  const norm = options.norm ?? {mean: 255, bias: 0};
-  let normMean: [number, number, number, number];
-  let normBias: [number, number, number, number];
-
-  if (typeof (norm.mean) === 'number') {
-    normMean = [norm.mean, norm.mean, norm.mean, norm.mean];
-  } else {
-    normMean = [norm.mean![0], norm.mean![1], norm.mean![2], norm.mean![3] ?? 255];
-  }
-
-  if (typeof (norm.bias) === 'number') {
-    normBias = [norm.bias, norm.bias, norm.bias, norm.bias];
-  } else {
-    normBias = [norm.bias![0], norm.bias![1], norm.bias![2], norm.bias![3] ?? 0];
-  }
-
-  const inputformat = options.format !== undefined ? options.format : 'RGBA';
-  // default value is RGBA since imagedata and HTMLImageElement uses it
-
-  const outputformat =
-      options.tensorFormat !== undefined ? (options.tensorFormat !== undefined ? options.tensorFormat : 'RGB') : 'RGB';
-  const stride = height * width;
-  const float32Data = outputformat === 'RGBA' ? new Float32Array(stride * 4) : new Float32Array(stride * 3);
-
-  // Default pointer assignments
-  let step = 4, rImagePointer = 0, gImagePointer = 1, bImagePointer = 2, aImagePointer = 3;
-  let rTensorPointer = 0, gTensorPointer = stride, bTensorPointer = stride * 2, aTensorPointer = -1;
-
-  // Updating the pointer assignments based on the input image format
-  if (inputformat === 'RGB') {
-    step = 3;
-    rImagePointer = 0;
-    gImagePointer = 1;
-    bImagePointer = 2;
-    aImagePointer = -1;
-  }
-
-  // Updating the pointer assignments based on the output tensor format
-  if (outputformat === 'RGBA') {
-    aTensorPointer = stride * 3;
-  } else if (outputformat === 'RBG') {
-    rTensorPointer = 0;
-    bTensorPointer = stride;
-    gTensorPointer = stride * 2;
-  } else if (outputformat === 'BGR') {
-    bTensorPointer = 0;
-    gTensorPointer = stride;
-    rTensorPointer = stride * 2;
-  }
-
-  for (let i = 0; i < stride;
-       i++, rImagePointer += step, bImagePointer += step, gImagePointer += step, aImagePointer += step) {
-    float32Data[rTensorPointer++] = (buffer[rImagePointer] + normBias[0]) / normMean[0];
-    float32Data[gTensorPointer++] = (buffer[gImagePointer] + normBias[1]) / normMean[1];
-    float32Data[bTensorPointer++] = (buffer[bImagePointer] + normBias[2]) / normMean[2];
-    if (aTensorPointer !== -1 && aImagePointer !== -1) {
-      float32Data[aTensorPointer++] = (buffer[aImagePointer] + normBias[3]) / normMean[3];
-    }
-  }
-
-  // Float32Array -> ort.Tensor
-  const outputTensor = outputformat === 'RGBA' ? new Tensor('float32', float32Data, [1, 4, height, width]) :
-                                                 new Tensor('float32', float32Data, [1, 3, height, width]);
-  return outputTensor;
-};
 
 /**
  * implementation of Tensor.fromImage().
@@ -102,135 +13,34 @@ export const tensorFromImage = async(
     options?: TensorFromImageDataOptions|TensorFromImageElementOptions|TensorFromImageBitmapOptions|
     TensorFromUrlOptions): Promise<Tensor> => {
   // checking the type of image object
-  const isHTMLImageEle = typeof (HTMLImageElement) !== 'undefined' && image instanceof HTMLImageElement;
-  const isImageDataEle = typeof (ImageData) !== 'undefined' && image instanceof ImageData;
-  const isImageBitmap = typeof (ImageBitmap) !== 'undefined' && image instanceof ImageBitmap;
+  const isImageElement = typeof HTMLImageElement !== 'undefined' && image instanceof HTMLImageElement;
+  const isImageData = typeof ImageData !== 'undefined' && image instanceof ImageData;
+  const isImageBitmap = typeof ImageBitmap !== 'undefined' && image instanceof ImageBitmap;
   const isString = typeof image === 'string';
 
-  let data: Uint8ClampedArray|undefined;
-  let bufferToTensorOptions: BufferToTensorOptions = options ?? {};
-
-  // filling and checking image configuration options
-  if (isHTMLImageEle) {
-    // HTMLImageElement - image object - format is RGBA by default
-    const canvas = document.createElement('canvas');
-    canvas.width = image.width;
-    canvas.height = image.height;
-    const pixels2DContext = canvas.getContext('2d');
-
-    if (pixels2DContext != null) {
-      let height = image.height;
-      let width = image.width;
-      if (options !== undefined && options.resizedHeight !== undefined && options.resizedWidth !== undefined) {
-        height = options.resizedHeight;
-        width = options.resizedWidth;
-      }
-
-      if (options !== undefined) {
-        bufferToTensorOptions = options;
-        if (options.tensorFormat !== undefined) {
-          throw new Error('Image input config format must be RGBA for HTMLImageElement');
-        } else {
-          bufferToTensorOptions.tensorFormat = 'RGBA';
-        }
-        bufferToTensorOptions.height = height;
-        bufferToTensorOptions.width = width;
-      } else {
-        bufferToTensorOptions.tensorFormat = 'RGBA';
-        bufferToTensorOptions.height = height;
-        bufferToTensorOptions.width = width;
-      }
-
-      pixels2DContext.drawImage(image, 0, 0);
-      data = pixels2DContext.getImageData(0, 0, width, height).data;
-    } else {
-      throw new Error('Can not access image data');
-    }
-  } else if (isImageDataEle) {
-    let height: number;
-    let width: number;
-
-    if (options !== undefined && options.resizedWidth !== undefined && options.resizedHeight !== undefined) {
-      height = options.resizedHeight;
-      width = options.resizedWidth;
-    } else {
-      height = image.height;
-      width = image.width;
-    }
-
-    if (options !== undefined) {
-      bufferToTensorOptions = options;
-    }
-    bufferToTensorOptions.format = 'RGBA';
-    bufferToTensorOptions.height = height;
-    bufferToTensorOptions.width = width;
-
-    if (options !== undefined) {
-      const tempCanvas = document.createElement('canvas');
-
-      tempCanvas.width = width;
-      tempCanvas.height = height;
-
-      const pixels2DContext = tempCanvas.getContext('2d');
-
-      if (pixels2DContext != null) {
-        pixels2DContext.putImageData(image, 0, 0);
-        data = pixels2DContext.getImageData(0, 0, width, height).data;
-      } else {
-        throw new Error('Can not access image data');
-      }
-    } else {
-      data = image.data;
-    }
+  const channels = options?.tensorFormat?.length ?? 3;
+  const type = options?.dataType ?? 'float32';
+  if (isImageElement) {
+    const width = options?.resizedWidth ?? image.width ?? image.naturalWidth;
+    const height = options?.resizedHeight ?? image.height ?? image.naturalHeight;
+    const dims = options?.tensorLayout === 'NCHW' ? [1, channels, height, width] : [1, height, width, channels];
+    return new Tensor(
+        {location: 'pending', input: 'image-element', output: options?.location ?? 'cpu', data: image, dims, type});
+  } else if (isImageData) {
+    const width = options?.resizedWidth ?? image.width;
+    const height = options?.resizedHeight ?? image.height;
+    const channels = options?.tensorFormat?.length ?? 3;
+    const dims = options?.tensorLayout === 'NCHW' ? [1, channels, height, width] : [1, height, width, channels];
+    return new Tensor({location: 'pending', input: 'image-data', output: 'cpu', data: image, dims, type});
   } else if (isImageBitmap) {
-    // ImageBitmap - image object - format must be provided by user
-    if (options === undefined) {
-      throw new Error('Please provide image config with format for Imagebitmap');
-    }
-
-    const canvas = document.createElement('canvas');
-    canvas.width = image.width;
-    canvas.height = image.height;
-    const pixels2DContext = canvas.getContext('2d');
-
-    if (pixels2DContext != null) {
-      const height = image.height;
-      const width = image.width;
-      pixels2DContext.drawImage(image, 0, 0, width, height);
-      data = pixels2DContext.getImageData(0, 0, width, height).data;
-      bufferToTensorOptions.height = height;
-      bufferToTensorOptions.width = width;
-      return bufferToTensor(data, bufferToTensorOptions);
-    } else {
-      throw new Error('Can not access image data');
-    }
+    const width = options?.resizedWidth ?? image.width;
+    const height = options?.resizedHeight ?? image.height;
+    const channels = options?.tensorFormat?.length ?? 3;
+    const dims = options?.tensorLayout === 'NCHW' ? [1, channels, height, width] : [1, height, width, channels];
+    return new Tensor({location: 'pending', input: 'image-bitmap', output: 'gpu-buffer', data: image, dims, type});
   } else if (isString) {
-    return new Promise((resolve, reject) => {
-      const canvas = document.createElement('canvas');
-      const context = canvas.getContext('2d');
-      if (!image || !context) {
-        return reject();
-      }
-      const newImage = new Image();
-      newImage.crossOrigin = 'Anonymous';
-      newImage.src = image;
-      newImage.onload = () => {
-        canvas.width = newImage.width;
-        canvas.height = newImage.height;
-        context.drawImage(newImage, 0, 0, canvas.width, canvas.height);
-        const img = context.getImageData(0, 0, canvas.width, canvas.height);
-
-        bufferToTensorOptions.height = canvas.height;
-        bufferToTensorOptions.width = canvas.width;
-        resolve(bufferToTensor(img.data, bufferToTensorOptions));
-      };
-    });
-  } else {
-    throw new Error('Input data provided is not supported - aborted tensor creation');
-  }
-
-  if (data !== undefined) {
-    return bufferToTensor(data, bufferToTensorOptions);
+    // TODO: better support or deprecate for URL
+    throw new Error('Not implemented');
   } else {
     throw new Error('Input data provided is not supported - aborted tensor creation');
   }

--- a/js/common/lib/tensor-factory.ts
+++ b/js/common/lib/tensor-factory.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import {PreprocessPlan} from './preprocess.js';
 import {Tensor, TypedTensor} from './tensor.js';
 
 export type ImageFormat = 'RGB'|'RGBA'|'BGR'|'RBG';
@@ -84,6 +85,17 @@ export interface GpuBufferConstructorParameters<T extends Tensor.GpuBufferDataTy
   readonly gpuBuffer: Tensor.GpuBufferType;
 }
 
+/**
+ * represent the parameter for constructing a tensor from a preprocess setep.
+ */
+export interface PreProcessConstructorParameters<T extends Tensor.Type = Tensor.Type> extends
+    PreprocessPlan, CommonConstructorParameters<T> {
+  /**
+   * Specify the location of the data to be 'pending'.
+   */
+  readonly location: 'pending';
+}
+
 // #endregion
 
 // the following region contains type definitions of each individual options.
@@ -113,6 +125,13 @@ export interface OptionsTensorDataType {
    * Describes the data type of the tensor.
    */
   dataType?: 'float32'|'uint8';
+}
+
+export interface OptionsTensorTargetLocation {
+  /**
+   * Describes the target location of the tensor.
+   */
+  location?: 'gpu-buffer'|'cpu';
 }
 
 export interface OptionsTensorLayout {
@@ -175,18 +194,20 @@ export interface OptionsNormalizationParameters {
 // #region Options composition
 
 export interface TensorFromImageDataOptions extends OptionResizedDimensions, OptionsTensorFormat, OptionsTensorLayout,
-                                                    OptionsTensorDataType, OptionsNormalizationParameters {}
+                                                    OptionsTensorDataType, OptionsTensorTargetLocation,
+                                                    OptionsNormalizationParameters {}
 
 export interface TensorFromImageElementOptions extends OptionResizedDimensions, OptionsTensorFormat,
                                                        OptionsTensorLayout, OptionsTensorDataType,
-                                                       OptionsNormalizationParameters {}
+                                                       OptionsTensorTargetLocation, OptionsNormalizationParameters {}
 
 export interface TensorFromUrlOptions extends OptionsDimensions, OptionResizedDimensions, OptionsTensorFormat,
-                                              OptionsTensorLayout, OptionsTensorDataType,
+                                              OptionsTensorLayout, OptionsTensorDataType, OptionsTensorTargetLocation,
                                               OptionsNormalizationParameters {}
 
 export interface TensorFromImageBitmapOptions extends OptionResizedDimensions, OptionsTensorFormat, OptionsTensorLayout,
-                                                      OptionsTensorDataType, OptionsNormalizationParameters {}
+                                                      OptionsTensorDataType, OptionsTensorTargetLocation,
+                                                      OptionsNormalizationParameters {}
 
 export interface TensorFromTextureOptions<T extends Tensor.TextureDataTypes> extends
     Required<OptionsDimensions>, OptionsFormat, GpuResourceConstructorParameters<T>/* TODO: add more */ {}

--- a/js/common/lib/tensor.ts
+++ b/js/common/lib/tensor.ts
@@ -140,7 +140,32 @@ export declare namespace Tensor {
   /**
    * represent where the tensor data is stored
    */
-  export type DataLocation = 'none'|'cpu'|'cpu-pinned'|'texture'|'gpu-buffer';
+  export type DataLocation =|
+      /**
+       * the data is disposed and became unavailable.
+       */
+      'none'|
+      /**
+       * the data is stored in CPU, as either a string array (for 'string' tensor type) or a TypedArray (for numeric
+       * tensor type).
+       */
+      'cpu'|
+      /**
+       * the numeric tensor data is stored in CPU as TypedArray with pinned buffer.
+       */
+      'cpu-pinned'|
+      /**
+       * the numeric tensor data is stored as WebGL texture.
+       */
+      'texture'|
+      /**
+       * the numeric tensor data is stored as WebGPU buffer.
+       */
+      'gpu-buffer'|
+      /**
+       * the data is pending on one or more pre-processing step(s) before it became available.
+       */
+      'pending';
 
   /**
    * represent the data type of a tensor

--- a/js/common/lib/training-session-impl.ts
+++ b/js/common/lib/training-session-impl.ts
@@ -58,7 +58,7 @@ export class TrainingSession implements TrainingSessionInterface {
     // get backend hints
     const eps = options.executionProviders || [];
     const backendHints = eps.map(i => typeof i === 'string' ? i : i.name);
-    const backend = await resolveBackend(backendHints);
+    const [, backend] = await resolveBackend(backendHints);
     if (backend.createTrainingSessionHandler) {
       const handler = await backend.createTrainingSessionHandler(
           trainingOptions.checkpointState, trainingOptions.trainModel, evalModel, optimizerModel, options);


### PR DESCRIPTION
### Description

The current tensor preprocessing is not in good shape and does not support GPU. The existing CPU implementation is not efficient. This PR makes a few fundamental changes to onnxruntime-common to support tensor preprocessing in a new way:
- onnxruntime-common does not include any pre-processing implementation any more. Instead, it introduces a set of API for users (including onnxruntime-web) to register preprocessors to deal with the actual requirements.
- A preprocessor is defined with a [backend, inputType, outputType] tuple, for example, ['webgpu', 'image-bitmap', 'gpu-buffer'] means a preprocessor works on webgpu backend to process ImageBitmap input to a GpuBuffer output.
- A new location 'pending' is added and corresponding changes to `Tensor` and `InferenceSession` implementation is done.

onnxruntime-web should add a few code to implement major preprocessors for image and register them. This part is WIP.