### PR TITLE
Add Windows ARM build jobs to post merge pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/post-merge-jobs.yml
+++ b/tools/ci_build/github/azure-pipelines/post-merge-jobs.yml
@@ -10,9 +10,13 @@ stages:
       UseWebPoolName: true
       WebCpuPoolName: 'Onnxruntime-Win-CPU-2022'
 
-# This stage is to test if the combined build works on
+# The follow section has 12 different build jobs that can be divided into 3 groups:
+# 1. Default CPU build with normal win32 linking, without ORT extension
+# 2. Default CPU build with wcos linking(use apiset), without ORT extension
+# 3. Default CPU build with normal win32 linking with ORT extension
+# Each group has 4 jobs that cover:
 # o Windows ARM64
-# o Windows ARM64EC
+# o Windows ARM
 # o Windows x64
 # o Windows x86
 # Now we don't have coverage for ARM64EC yet. Will add it.
@@ -24,7 +28,7 @@ stages:
     buildArch: x86
     msbuildPlatform: Win32
     packageName: x86
-    buildparameter: --use_extensions --enable_onnx_tests
+    buildparameter: --enable_onnx_tests
     runTests: true
     buildJava: false
     buildNodejs: false
@@ -34,7 +38,140 @@ stages:
   parameters:
     DoCompliance: false
     DoEsrp: false
+    stage_name_suffix: CPU_arm_default
+    buildArch: x64
+    msbuildPlatform: arm
+    packageName: arm
+    buildparameter: --arm  --enable_onnx_tests --path_to_protoc_exe $(Build.BinariesDirectory)\RelWithDebInfo\installed\bin\protoc.exe
+    runTests: false
+    buildJava: false
+    buildNodejs: false
+    ort_build_pool_name: 'onnxruntime-Win-CPU-2022'
+
+- template: templates/win-ci.yml
+  parameters:
+    DoCompliance: false
+    DoEsrp: false
     stage_name_suffix: CPU_arm64_default
+    buildArch: x64
+    msbuildPlatform: arm64
+    packageName: arm64
+    buildparameter: --build_nodejs --arm64  --enable_onnx_tests --path_to_protoc_exe $(Build.BinariesDirectory)\RelWithDebInfo\installed\bin\protoc.exe
+    runTests: false
+    buildJava: false
+    buildNodejs: true
+    ort_build_pool_name: 'onnxruntime-Win-CPU-2022'
+
+- template: templates/win-ci.yml
+  parameters:
+    DoCompliance: false
+    DoEsrp: false
+    stage_name_suffix: CPU_x64_default
+    buildArch: x64
+    msbuildPlatform: x64
+    packageName: x64
+    buildparameter: --build_java --build_nodejs  --enable_onnx_tests
+    runTests: true
+    buildJava: true
+    buildNodejs: true
+    ort_build_pool_name: 'onnxruntime-Win-CPU-2022'
+
+- template: templates/win-ci.yml
+  parameters:
+    DoCompliance: false
+    DoEsrp: false
+    stage_name_suffix: CPU_x86_wcos
+    artifact_name_suffix: '-wcos'
+    buildArch: x86
+    msbuildPlatform: Win32
+    packageName: x86
+    buildparameter: --enable_onnx_tests --enable_wcos
+    runTests: true
+    buildJava: false
+    buildNodejs: false
+    ort_build_pool_name: 'onnxruntime-Win-CPU-2022'
+
+- template: templates/win-ci.yml
+  parameters:
+    DoCompliance: false
+    DoEsrp: false
+    stage_name_suffix: CPU_arm_wcos
+    artifact_name_suffix: '-wcos'
+    buildArch: x64
+    msbuildPlatform: arm
+    packageName: arm
+    buildparameter: --arm  --enable_onnx_tests --enable_wcos --path_to_protoc_exe $(Build.BinariesDirectory)\RelWithDebInfo\installed\bin\protoc.exe
+    runTests: false
+    buildJava: false
+    buildNodejs: false
+    ort_build_pool_name: 'onnxruntime-Win-CPU-2022'
+
+- template: templates/win-ci.yml
+  parameters:
+    DoCompliance: false
+    DoEsrp: false
+    stage_name_suffix: CPU_arm64_wcos
+    artifact_name_suffix: '-wcos'
+    buildArch: x64
+    msbuildPlatform: arm64
+    packageName: arm64
+    buildparameter: --build_nodejs --enable_wcos --arm64  --enable_onnx_tests --path_to_protoc_exe $(Build.BinariesDirectory)\RelWithDebInfo\installed\bin\protoc.exe
+    runTests: false
+    buildJava: false
+    buildNodejs: true
+    ort_build_pool_name: 'onnxruntime-Win-CPU-2022'
+
+- template: templates/win-ci.yml
+  parameters:
+    DoCompliance: false
+    DoEsrp: false
+    stage_name_suffix: CPU_x64_wcos
+    artifact_name_suffix: '-wcos'
+    buildArch: x64
+    msbuildPlatform: x64
+    packageName: x64
+    buildparameter: --build_java --build_nodejs --enable_onnx_tests  --enable_wcos
+    runTests: true
+    buildJava: true
+    buildNodejs: true
+    ort_build_pool_name: 'onnxruntime-Win-CPU-2022'
+
+- template: templates/win-ci.yml
+  parameters:
+    DoCompliance: false
+    DoEsrp: false
+    stage_name_suffix: CPU_x86_extension
+    artifact_name_suffix: '-extension'
+    buildArch: x86
+    msbuildPlatform: Win32
+    packageName: x86
+    buildparameter: --enable_onnx_tests
+    runTests: true
+    buildJava: false
+    buildNodejs: false
+    ort_build_pool_name: 'onnxruntime-Win-CPU-2022'
+
+- template: templates/win-ci.yml
+  parameters:
+    DoCompliance: false
+    DoEsrp: false
+    stage_name_suffix: CPU_arm_extension
+    artifact_name_suffix: '-extension'
+    buildArch: x64
+    msbuildPlatform: arm
+    packageName: arm
+    buildparameter: --arm --use_extensions  --enable_onnx_tests --path_to_protoc_exe $(Build.BinariesDirectory)\RelWithDebInfo\installed\bin\protoc.exe
+    runTests: false
+    buildJava: false
+    buildNodejs: false
+    ort_build_pool_name: 'onnxruntime-Win-CPU-2022'
+
+- template: templates/win-ci.yml
+  parameters:
+    DoCompliance: false
+    DoEsrp: false
+    stage_name_suffix: CPU_arm64_extension
+    artifact_name_suffix: '-extension'
     buildArch: x64
     msbuildPlatform: arm64
     packageName: arm64
@@ -48,7 +185,8 @@ stages:
   parameters:
     DoCompliance: false
     DoEsrp: false
-    stage_name_suffix: CPU_x64_default
+    stage_name_suffix: CPU_x64_extension
+    artifact_name_suffix: '-extension'
     buildArch: x64
     msbuildPlatform: x64
     packageName: x64

--- a/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
@@ -259,7 +259,7 @@ stages:
         condition: and(succeeded(), eq('${{ parameters.buildJava}}', true))
         displayName: 'Publish Java temp binaries'
         inputs:
-          pathtoPublish: '$(Build.BinariesDirectory)\onnxruntime-java-win-${{ parameters.msbuildPlatform }}'
+          pathtoPublish: '$(Build.BinariesDirectory)\onnxruntime-java-win-${{ parameters.msbuildPlatform }}${{parameters.artifact_name_suffix}}'
           artifactName: 'drop-onnxruntime-java-win-${{ parameters.packageName }}'
 
       - ${{ if eq(parameters['DoCompliance'], 'true') }}:

--- a/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
@@ -193,7 +193,7 @@ stages:
         - template: nodejs-artifacts-package-and-publish-steps-windows.yml
           parameters:
             arch: ${{ parameters.packageName }}
-            artifactName: 'drop-onnxruntime-nodejs-win-${{ parameters.packageName }}'
+            artifactName: 'drop-onnxruntime-nodejs-win-${{ parameters.packageName }}${{ parameters.artifact_name_suffix }}'
             DoEsrp: ${{ parameters.DoEsrp }}
 
       #Upload protoc.exe, which will be used in nuget build for generating C# files

--- a/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
@@ -259,8 +259,8 @@ stages:
         condition: and(succeeded(), eq('${{ parameters.buildJava}}', true))
         displayName: 'Publish Java temp binaries'
         inputs:
-          pathtoPublish: '$(Build.BinariesDirectory)\onnxruntime-java-win-${{ parameters.msbuildPlatform }}${{parameters.artifact_name_suffix}}'
-          artifactName: 'drop-onnxruntime-java-win-${{ parameters.packageName }}'
+          pathtoPublish: '$(Build.BinariesDirectory)\onnxruntime-java-win-${{ parameters.msbuildPlatform }}'
+          artifactName: 'drop-onnxruntime-java-win-${{ parameters.packageName }}${{parameters.artifact_name_suffix}}'
 
       - ${{ if eq(parameters['DoCompliance'], 'true') }}:
         - task: CredScan@3


### PR DESCRIPTION
### Description
Add Windows ARM build jobs to post merge pipeline to valid our code is still compatible with these build settings.


### Motivation and Context



