### PR TITLE
Fix CI error:  The workflow is not valid. .github/workflows/rust-ci.yml (Line: 27, Col: 7): Unexpected value 'ORT_RUST_STRATEGY=download'

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -24,7 +24,7 @@ jobs:
     name: Download prebuilt ONNX Runtime archive from build.rs
     runs-on: ubuntu-latest
     env:
-      ORT_RUST_STRATEGY=download
+      ORT_RUST_STRATEGY: download
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/rust-toolchain-setup


### PR DESCRIPTION
Use colon for Env variable instead of =

### Description
Workflow file is not valid. See docs [here](https://docs.github.com/en/actions/learn-github-actions/variables).



### Motivation and Context
Fix Github Action


