### PR TITLE
[WebNN EP] Change axis to axes for argMax/argMin

### DIFF
--- a/onnxruntime/core/providers/webnn/builders/impl/argmax_min_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/argmax_min_op_builder.cc
@@ -41,9 +41,11 @@ Status ArgMaxMinOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
   const auto select_last_index = helper.Get("select_last_index", 0);
 
   axis = HandleNegativeAxis(axis, input_rank);
+  emscripten::val axes = emscripten::val::array();
+  axes.call<void>("push", static_cast<uint32_t>(axis));
 
   emscripten::val options = emscripten::val::object();
-  options.set("axis", static_cast<int32_t>(axis));
+  options.set("axes", axes);
   options.set("keepDimensions", keep_dims == 1);
   options.set("selectLastIndex", select_last_index == 1);
   emscripten::val output = emscripten::val::object();


### PR DESCRIPTION
In the latest spec, the axes option of WebNN's argMax and argMin requires the use of a sequence long type. Replace axis option (long type) with axes (sequence long type) for argMax and argMin.


