### PR TITLE
[REACT NATIVE] Bugfix -> casing Podfile

### DIFF
--- a/js/react_native/app.plugin.js
+++ b/js/react_native/app.plugin.js
@@ -29,7 +29,7 @@ const withOrt = (config) => {
   config = configPlugin.withDangerousMod(config, [
     'ios',
     (config) => {
-      const podFilePath = path.join(config.modRequest.platformProjectRoot, 'PodFile');
+      const podFilePath = path.join(config.modRequest.platformProjectRoot, 'Podfile');
       const contents = fs.readFileSync(podFilePath, {encoding: 'utf-8'});
       const updatedContents =
           generateCode


### PR DESCRIPTION
### Description
The casing of Podfile is incorrect in the plugin. This causes issues when building iOS on case-sensitive systems such as Linux.

### Motivation and Context
because cannot build ios on case sensitive systems


