### PR TITLE
Add ARM64EC build jobs

### DIFF
--- a/tools/ci_build/github/azure-pipelines/post-merge-jobs.yml
+++ b/tools/ci_build/github/azure-pipelines/post-merge-jobs.yml
@@ -10,11 +10,12 @@ stages:
       UseWebPoolName: true
       WebCpuPoolName: 'Onnxruntime-Win-CPU-2022'
 
-# The follow section has 12 different build jobs that can be divided into 3 groups:
+# The follow section has 15 different build jobs that can be divided into 3 groups:
 # 1. Default CPU build with normal win32 linking, without ORT extension
 # 2. Default CPU build with wcos linking(use apiset), without ORT extension
 # 3. Default CPU build with normal win32 linking with ORT extension
 # Each group has 4 jobs that cover:
+# o Windows ARM64EC
 # o Windows ARM64
 # o Windows ARM
 # o Windows x64
@@ -60,6 +61,20 @@ stages:
     runTests: false
     buildJava: false
     buildNodejs: true
+    ort_build_pool_name: 'onnxruntime-Win-CPU-2022'
+
+- template: templates/win-ci.yml
+  parameters:
+    DoCompliance: false
+    DoEsrp: false
+    stage_name_suffix: CPU_arm64ec_default
+    buildArch: x64
+    msbuildPlatform: ARM64EC
+    packageName: arm64ec
+    buildparameter: --arm64ec  --enable_onnx_tests --path_to_protoc_exe $(Build.BinariesDirectory)\RelWithDebInfo\installed\bin\protoc.exe
+    runTests: false
+    buildJava: false
+    buildNodejs: false
     ort_build_pool_name: 'onnxruntime-Win-CPU-2022'
 
 - template: templates/win-ci.yml
@@ -125,6 +140,21 @@ stages:
   parameters:
     DoCompliance: false
     DoEsrp: false
+    stage_name_suffix: CPU_arm64ec_wcos
+    artifact_name_suffix: '-wcos'
+    buildArch: x64
+    msbuildPlatform: ARM64EC
+    packageName: arm64ec
+    buildparameter: --enable_wcos --arm64ec  --enable_onnx_tests --path_to_protoc_exe $(Build.BinariesDirectory)\RelWithDebInfo\installed\bin\protoc.exe
+    runTests: false
+    buildJava: false
+    buildNodejs: false
+    ort_build_pool_name: 'onnxruntime-Win-CPU-2022'
+
+- template: templates/win-ci.yml
+  parameters:
+    DoCompliance: false
+    DoEsrp: false
     stage_name_suffix: CPU_x64_wcos
     artifact_name_suffix: '-wcos'
     buildArch: x64
@@ -180,6 +210,21 @@ stages:
     buildJava: false
     buildNodejs: true
     ort_build_pool_name: 'onnxruntime-Win-CPU-2022'
+
+#- template: templates/win-ci.yml
+#  parameters:
+#    DoCompliance: false
+#    DoEsrp: false
+#    stage_name_suffix: CPU_arm64ec_extension
+#    artifact_name_suffix: '-extension'
+#    buildArch: x64
+#    msbuildPlatform: ARM64EC
+#    packageName: arm64ec
+#    buildparameter: --arm64ec --use_extensions --enable_onnx_tests --path_to_protoc_exe $(Build.BinariesDirectory)\RelWithDebInfo\installed\bin\protoc.exe
+#    runTests: false
+#    buildJava: false
+#    buildNodejs: false
+#    ort_build_pool_name: 'onnxruntime-Win-CPU-2022'
 
 - template: templates/win-ci.yml
   parameters:


### PR DESCRIPTION
### Description
Add ARM64EC build jobs in post merge pipeline to validate if our code is compatible with Windows ARM64EC.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


