### PR TITLE
[WebNN EP] Infer the layout via ONNX domain for Resize

### DIFF
--- a/onnxruntime/core/optimizer/layout_transformation/layout_transformation.cc
+++ b/onnxruntime/core/optimizer/layout_transformation/layout_transformation.cc
@@ -162,8 +162,7 @@ Status TransformLayoutForEP(Graph& graph, bool& modified, const IExecutionProvid
       // Except for resize and convolution ops, all the other layout sensitive ops only require layout transformation
       // for 0th input and output. For resize, add the other relevant inputs which need conversion. For Conv - layout
       // transformer only converts layout for 0th input, weights should be handled by every EP.
-      // For resize in WebNN EP, we don't want to convert all the inputs except the 0th input.
-      if (node->OpType() == "Resize" && node->GetExecutionProviderType() != kWebNNExecutionProvider) {
+      if (node->OpType() == "Resize") {
         // Older versions of resize have a bug where ROI and Scales cannot be made empty inputs. To handle this case,
         // we need to jump a few extra hoops to make sure its inputs are correctly handled.
         //


### PR DESCRIPTION
Previously we added EP specific logic into generic core code to restrict Resize for WebNN EP at https://github.com/microsoft/onnxruntime/pull/18687 which does not scale and make sense.

This PR reverts the change in https://github.com/microsoft/onnxruntime/pull/18687 and uses ONNX domain infomation to infer the layout infomation during layout transformation.