### PR TITLE
Remove usage of TRT deprecated APIs

### DIFF
--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -3171,13 +3171,13 @@ common::Status TensorrtExecutionProvider::Compile(const std::vector<FusedNodeAnd
           trt_config->setFlag(nvinfer1::BuilderFlag::kSPARSE_WEIGHTS);
           LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Sparse weights are allowed";
         }
-
+#if NV_TENSORRT_MAJOR == 8 && NV_TENSORRT_MINOR == 5
         // enable builder heuristics
         if (trt_state->build_heuristics_enable) {
           trt_config->setFlag(nvinfer1::BuilderFlag::kENABLE_TACTIC_HEURISTIC);
           LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Builder heuristics are enabled";
         }
-#if NV_TENSORRT_MAJOR == 8 && NV_TENSORRT_MINOR > 5 || NV_TENSORRT_MAJOR > 8
+#elif NV_TENSORRT_MAJOR == 8 && NV_TENSORRT_MINOR > 5 || NV_TENSORRT_MAJOR > 8
         // switch optimizaion level
         if (trt_state->builder_optimization_level != 3) {
           trt_config->setBuilderOptimizationLevel(trt_state->builder_optimization_level);

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
@@ -88,7 +88,7 @@ struct TensorrtInferDeleter {
   template <typename T>
   void operator()(T* obj) const {
     if (obj) {
-      obj->destroy();
+      delete obj;
     }
   }
 };


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

- Wrap usage of kENABLE_TACTIC_HEURISTIC around version checking macros
- Use delete instead of deprecated destroy() functions on TRT objects.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- Removes usages of deprecated TRT APIs.


