### PR TITLE
[js/webgpu] Provide a vectorized algorithm for GroupedConv

### DIFF
--- a/js/web/lib/wasm/jsep/webgpu/ops/conv-grouped.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/conv-grouped.ts
@@ -3,9 +3,9 @@
 
 import {TensorView} from '../../tensor-view';
 import {ShapeUtil} from '../../util';
-import {ProgramInfo} from '../types';
+import {ProgramInfo, ProgramUniform} from '../types';
 
-import {getMaxComponents, inputVariable, outputVariable, ShaderHelper} from './common';
+import {createTensorShapeVariables, getMaxComponents, inputVariable, outputVariable, ShaderHelper} from './common';
 import {calculateOutputShape, ConvAttributes} from './conv';
 import {getActivationSnippet} from './fuse-utils';
 
@@ -104,77 +104,86 @@ export const createGroupedConvVectorizeProgramInfo =
       const outputSize = ShapeUtil.size(outputShape) / components / outputNumber;
       const xShape = [inputs[0].dims[0], inputs[0].dims[1], inputs[0].dims[2], inputs[0].dims[3] / components];
       const wShape = [inputs[1].dims[0], inputs[1].dims[1], inputs[1].dims[2], inputs[1].dims[3] / components];
+      const outputShapeInShader = [outputShape[0], outputShape[1], outputShape[2], outputShape[3] / components];
 
+      const programUniforms: ProgramUniform[] = [
+        {type: 'uint32', data: outputSize}, ...createTensorShapeVariables(xShape),
+        ...createTensorShapeVariables(wShape), ...createTensorShapeVariables(outputShapeInShader)
+      ];
+      const xNumber = (outputNumber - 1) * attributes.strides[1] + wShape[1];
       const getShaderSource = (shaderHelper: ShaderHelper) => {
-        const output = outputVariable(
-            'output', inputs[0].dataType, [outputShape[0], outputShape[1], outputShape[2], outputShape[3] / components],
-            components);
+        const output = outputVariable('output', inputs[0].dataType, outputShapeInShader.length, components);
         const {activationFunction, applyActivation} = getActivationSnippet(attributes, output.type.value);
-        const x = inputVariable('x', inputs[0].dataType, xShape, components);
-        const w = inputVariable('w', inputs[1].dataType, wShape, components);
+        const x = inputVariable('x', inputs[0].dataType, xShape.length, components);
+        const w = inputVariable('w', inputs[1].dataType, wShape.length, components);
         const inputVars = [x, w];
         if (hasBias) {
           inputVars.push(inputVariable('b', inputs[2].dataType, inputs[2].dims, components));
         }
         const processBias = hasBias ? 'value += b[output_channel];' : '';
-        const xNumber = (outputNumber - 1) * attributes.strides[1] + wShape[1];
 
         return `
   const strides: vec2<i32> = vec2(${attributes.strides[0]}, ${attributes.strides[1]});
   const pads: vec2<i32> = vec2(${attributes.pads[0]}, ${attributes.pads[1]});
-  ${shaderHelper.declareVariables(...inputVars, output)}
+  ${shaderHelper.registerUniform('output_size', 'u32').declareVariables(...inputVars, output)}
   ${activationFunction}
   ${shaderHelper.mainStart()}
-    ${shaderHelper.guardAgainstOutOfBoundsWorkgroupSizes(outputSize)}
-    let width0 = ${outputShape[3]}u / ${components}u;
+    ${shaderHelper.guardAgainstOutOfBoundsWorkgroupSizes('uniforms.output_size')}
+    let width0 = uniforms.output_shape[3];
     let output_channel = global_idx % width0;
     var index1 = global_idx / width0;
-    let width1 = ${outputShape[2]}u / ${outputNumber}u;
+    let width1 = uniforms.output_shape[2] / ${outputNumber}u;
     let col = (index1 % width1) * ${outputNumber}u;
     index1 = index1 / width1;
-    let row = index1 % ${outputShape[1]}u;
-    let batch = index1 / ${outputShape[1]}u;
+    let row = index1 % uniforms.output_shape[1];
+    let batch = index1 / uniforms.output_shape[1];
 
     let xRCCorner = vec2<i32>(i32(row), i32(col)) * strides - pads;
 
     var xVals: array<${x.type.value}, ${xNumber}>;
     var values: array<${output.type.value}, ${outputNumber}>;
     let input_channel = output_channel;
-      for (var wHeight: u32 = 0u; wHeight < ${wShape[0]}u; wHeight++) {
-        let xHeight = xRCCorner.x + i32(wHeight);
-        if (xHeight >= 0 || xHeight < ${xShape[1]}) {
-          for (var i = 0; i < ${xNumber}; i++) {
-            let xWidth = xRCCorner.y + i;
-            if (xWidth >= 0 && xWidth < ${xShape[2]}) {
-              xVals[i] = ${x.get('batch', 'u32(xHeight)', 'u32(xWidth)', 'input_channel')};
-            } else {
-              xVals[i] = ${x.type.value}(0);
-            }
+    // Use constant instead of uniform can give better performance for w's height/width.
+    for (var wHeight: u32 = 0u; wHeight < ${wShape[0]}; wHeight++) {
+      let xHeight = xRCCorner.x + i32(wHeight);
+      if (xHeight >= 0 || u32(xHeight) < uniforms.x_shape[1]) {
+        for (var i = 0; i < ${xNumber}; i++) {
+          let xWidth = xRCCorner.y + i;
+          if (xWidth >= 0 && u32(xWidth) < uniforms.x_shape[2]) {
+            xVals[i] = ${x.get('batch', 'u32(xHeight)', 'u32(xWidth)', 'input_channel')};
+          } else {
+            xVals[i] = ${x.type.value}(0);
           }
-          for (var wWidth: u32 = 0u; wWidth < ${wShape[1]}u; wWidth++) {
-            let wVal = ${w.get('wHeight', 'wWidth', '0', 'output_channel')};
-            for (var i = 0u; i < ${outputNumber}u; i++) {
-              values[i] = fma(xVals[i * ${attributes.strides[1]}u + wWidth], wVal, values[i]);
-            }
+        }
+        for (var wWidth: u32 = 0u; wWidth < ${wShape[1]}; wWidth++) {
+          let wVal = ${w.get('wHeight', 'wWidth', '0', 'output_channel')};
+          for (var i = 0u; i < ${outputNumber}u; i++) {
+            values[i] = fma(xVals[i * ${attributes.strides[1]}u + wWidth], wVal, values[i]);
           }
         }
       }
+    }
 
     for (var i = 0u; i < ${outputNumber}u; i++) {
-        var value = values[i];
-        ${processBias}
-        ${applyActivation}
-        ${output.set('batch', 'row', 'col + i', 'output_channel', 'value')};
+      var value = values[i];
+      ${processBias}
+      ${applyActivation}
+      ${output.set('batch', 'row', 'col + i', 'output_channel', 'value')};
     }
   }`;
       };
 
       return {
         name: 'GroupedConv-Vectorize',
-        shaderCache: {hint: attributes.cacheKey},
+        shaderCache: {
+          hint: `${attributes.activationCacheKey};${attributes.strides};${attributes.pads};${components};${
+              outputNumber};${xNumber};${wShape[0]};${wShape[1]}`,
+          inputDependencies: hasBias ? ['rank', 'rank', 'type'] : ['rank', 'rank']
+        },
         getRunData: () => ({
           outputs: [{dims: outputShape, dataType: inputs[0].dataType}],
           dispatchGroup: {x: Math.ceil(outputSize / 64 /* workgroup size */)},
+          programUniforms
         }),
         getShaderSource,
       };

--- a/js/web/lib/wasm/jsep/webgpu/ops/conv-grouped.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/conv-grouped.ts
@@ -141,27 +141,27 @@ export const createGroupedConvVectorizeProgramInfo =
     let row = index1 % uniforms.output_shape[1];
     let batch = index1 / uniforms.output_shape[1];
 
-    let xRCCorner = vec2<i32>(i32(row), i32(col)) * uniforms.strides - uniforms.pads;
+    let x_corner = vec2<i32>(i32(row), i32(col)) * uniforms.strides - uniforms.pads;
 
-    var xVals: array<${x.type.value}, ${xNumber}>;
+    var x_vals: array<${x.type.value}, ${xNumber}>;
     var values: array<${output.type.value}, ${outputNumber}>;
     let input_channel = output_channel;
     // Use constant instead of uniform can give better performance for w's height/width.
-    for (var wHeight: u32 = 0u; wHeight < ${wShape[0]}; wHeight++) {
-      let xHeight = xRCCorner.x + i32(wHeight);
-      if (xHeight >= 0 || u32(xHeight) < uniforms.x_shape[1]) {
+    for (var w_height: u32 = 0u; w_height < ${wShape[0]}; w_height++) {
+      let x_height = x_corner.x + i32(w_height);
+      if (x_height >= 0 || u32(x_height) < uniforms.x_shape[1]) {
         for (var i = 0; i < ${xNumber}; i++) {
-          let xWidth = xRCCorner.y + i;
-          if (xWidth >= 0 && u32(xWidth) < uniforms.x_shape[2]) {
-            xVals[i] = ${x.get('batch', 'u32(xHeight)', 'u32(xWidth)', 'input_channel')};
+          let x_width = x_corner.y + i;
+          if (x_width >= 0 && u32(x_width) < uniforms.x_shape[2]) {
+            x_vals[i] = ${x.get('batch', 'u32(x_height)', 'u32(x_width)', 'input_channel')};
           } else {
-            xVals[i] = ${x.type.value}(0);
+            x_vals[i] = ${x.type.value}(0);
           }
         }
-        for (var wWidth: u32 = 0u; wWidth < ${wShape[1]}; wWidth++) {
-          let wVal = ${w.get('wHeight', 'wWidth', '0', 'output_channel')};
+        for (var w_width: u32 = 0u; w_width < ${wShape[1]}; w_width++) {
+          let w_val = ${w.get('w_height', 'w_width', '0', 'output_channel')};
           for (var i = 0u; i < ${outputNumber}u; i++) {
-            values[i] = fma(xVals[i * ${attributes.strides[1]}u + wWidth], wVal, values[i]);
+            values[i] = fma(x_vals[i * ${attributes.strides[1]}u + w_width], w_val, values[i]);
           }
         }
       }

--- a/js/web/test/data/ops/conv.jsonc
+++ b/js/web/test/data/ops/conv.jsonc
@@ -298,7 +298,157 @@
       }
     ]
   },
-
+  {
+    "name": "conv - vectorize group - A",
+    "operator": "Conv",
+    "inputShapeDefinitions": "rankOnly",
+    "opset": { "domain": "", "version": 17 },
+    "attributes": [
+      { "name": "kernel_shape", "data": [1, 1], "type": "ints" },
+      { "name": "group", "data": 2, "type": "int" }
+    ],
+    "cases": [
+      {
+        "name": "T[0]",
+        "inputs": [
+          {
+            "data": [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0],
+            "dims": [1, 2, 3, 3],
+            "type": "float32"
+          },
+          {
+            "data": [1.0, 2.0],
+            "dims": [2, 1, 1, 1],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 18.0, 20.0, 22.0, 24.0, 26.0, 28.0, 30.0, 32.0, 34.0],
+            "dims": [1, 2, 3, 3],
+            "type": "float32"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "conv - vectorize group - B",
+    "operator": "Conv",
+    "inputShapeDefinitions": "rankOnly",
+    "opset": { "domain": "", "version": 17 },
+    "attributes": [
+      { "name": "kernel_shape", "data": [2, 2], "type": "ints" },
+      { "name": "group", "data": 3, "type": "int" }
+    ],
+    "cases": [
+      {
+        "name": "T[0]",
+        "inputs": [
+          {
+            "data": [
+              0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0,
+              19.0, 20.0, 21.0, 22.0, 23.0, 0, 0, 0
+            ],
+            "dims": [1, 3, 3, 3],
+            "type": "float32"
+          },
+          {
+            "data": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0],
+            "dims": [3, 1, 2, 2],
+            "type": "float32"
+          },
+          {
+            "data": [0.1, 0.2, 0.3],
+            "dims": [3],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [27.1, 37.1, 57.1, 67.1, 293.2, 319.2, 371.2, 397.2, 847.3, 889.3, 409.3, 428.3],
+            "dims": [1, 3, 2, 2],
+            "type": "float32"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "conv - vectorize group - C",
+    "operator": "Conv",
+    "inputShapeDefinitions": "rankOnly",
+    "opset": { "domain": "", "version": 17 },
+    "attributes": [
+      { "name": "kernel_shape", "data": [2, 2], "type": "ints" },
+      { "name": "group", "data": 3, "type": "int" }
+    ],
+    "cases": [
+      {
+        "name": "T[0]",
+        "inputs": [
+          {
+            "data": [
+              0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0,
+              19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0, 31.0, 32.0, 33.0, 34.0, 35.0
+            ],
+            "dims": [1, 3, 3, 4],
+            "type": "float32"
+          },
+          {
+            "data": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0],
+            "dims": [3, 1, 2, 2],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [34, 44, 54, 74, 84, 94, 386, 412, 438, 490, 516, 542, 1122, 1164, 1206, 1290, 1332, 1374],
+            "dims": [1, 3, 2, 3],
+            "type": "float32"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "conv - vectorize group - D",
+    "operator": "Conv",
+    "inputShapeDefinitions": "rankOnly",
+    "opset": { "domain": "", "version": 17 },
+    "attributes": [
+      { "name": "kernel_shape", "data": [2, 2], "type": "ints" },
+      { "name": "group", "data": 3, "type": "int" },
+      { "name": "strides", "data": [2, 2], "type": "ints" }
+    ],
+    "cases": [
+      {
+        "name": "T[0] strides = [2, 2]",
+        "inputs": [
+          {
+            "data": [
+              0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0,
+              19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0, 31.0, 32.0, 33.0, 34.0, 35.0
+            ],
+            "dims": [1, 3, 3, 4],
+            "type": "float32"
+          },
+          {
+            "data": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0],
+            "dims": [3, 1, 2, 2],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [34, 54, 386, 438, 1122, 1206],
+            "dims": [1, 3, 1, 2],
+            "type": "float32"
+          }
+        ]
+      }
+    ]
+  },
   {
     "name": "conv - pointwise",
     "operator": "Conv",


### PR DESCRIPTION
### Description
This PR provides a vectorized algorithm for NHWC GroupedConv to improve performance.

The aggregate time of GroupedConv in mobilenetv2-12 becomes ~1ms from ~4ms on Intel Alder Lake machine. About 20% improvement for the whole model.
