### PR TITLE
Memory tool chain improvement

### DIFF
--- a/orttraining/orttraining/core/optimizer/memory_optimizer/memory_insight.cc
+++ b/orttraining/orttraining/core/optimizer/memory_optimizer/memory_insight.cc
@@ -491,14 +491,9 @@ void ListAllCombinations(const InlinedVector<InlinedVector<InlinedVector<std::sh
   for (size_t i = 0; i < plan_combination_list_at_cur_index.size(); ++i) {
     const auto& plan_combination = plan_combination_list_at_cur_index[i];
     InlinedVector<std::shared_ptr<NodeOptimizationPlanBase>> new_combination = current_combination;
-    // Append the chosen complete plan and continue explore the next reused buffer by index + 1.
+    // Append the chosen complete plan and continue exploring the next reused buffer by index + 1.
     new_combination.insert(new_combination.end(), plan_combination.begin(), plan_combination.end());
-
-    // for (const auto& plan : plan_combination) {
-    //   InlinedVector<std::shared_ptr<NodeOptimizationPlanBase>> new_combination = current_combination;
-    //   new_combination.push_back(plan);
     ListAllCombinations(all_possible_node_optimization_plans, index + 1, new_combination, logger, all_combinations);
-    // }
   }
 
   MO_LOG_DEBUG_INFO(logger, "Exit ListAllCombinations");

--- a/orttraining/orttraining/core/optimizer/memory_optimizer/optimization_planner.cc
+++ b/orttraining/orttraining/core/optimizer/memory_optimizer/optimization_planner.cc
@@ -15,35 +15,6 @@
 
 namespace onnxruntime::optimizer::memory_optimizer {
 
-std::string NodeOptimizationPlanBase::GetMemorySavingSymbolicString() const {
-  std::string saving_str;
-  for (auto output_index : activation_output_indices_) {
-    // If the output is reusing other node's buffer, then no memory saving.
-    if (reuse_buffers.find(output_index) != reuse_buffers.end()) {
-      continue;
-    }
-
-    const auto& output_def = node->OutputDefs()[output_index];
-    MLDataType ml_data_type = DataTypeImpl::TypeFromProto(*output_def->TypeAsProto());
-    ORT_ENFORCE(ml_data_type->IsTensorType(), "ml_type must be a tensor type, but it is ",
-                DataTypeImpl::ToString(ml_data_type));
-    const TensorTypeBase* tensor_type_base = ml_data_type->AsTensorType();
-    ORT_ENFORCE(nullptr != tensor_type_base);
-    MLDataType elt_type = tensor_type_base->GetElementType();
-    const auto byte_count_per_element = elt_type->Size();
-    if (!saving_str.empty()) {
-      saving_str += " + ";
-    }
-    saving_str = "(" + GetActivationOutputDimParamString(output_index) + " * " +
-                 std::to_string(byte_count_per_element) + " * " +
-                 std::to_string(GetSaveRatio()) + ")";
-  }
-  if (saving_str.empty()) {
-    return saving_str;
-  }
-  return "(" + saving_str + ")";
-}
-
 Status MemoryOptimizationPlanner::UpdateNodePlansFromExecutionPlan(const GraphViewer& graph_viewer,
                                                                    const OrtValueNameIdxMap& ortvalue_name_to_idx_map,
                                                                    const SequentialExecutionPlan& p_seq_exec_plan) {

--- a/orttraining/orttraining/core/optimizer/memory_optimizer/optimization_planner.h
+++ b/orttraining/orttraining/core/optimizer/memory_optimizer/optimization_planner.h
@@ -83,7 +83,7 @@ class NodeOptimizationPlanBase {
   /**
    * Get a symbolic string to represent the memory saving for this optimization plan.
    */
-  std::string GetMemorySavingSymbolicString() const;
+  virtual std::string GetMemorySavingSymbolicString() const = 0;
 
   std::string GetActivationOutputDimParamString(size_t index) const {
     ORT_ENFORCE(activation_output_dim_params_.find(index) != activation_output_dim_params_.end(),

--- a/orttraining/orttraining/core/optimizer/memory_optimizer/recompute_analysis.cc
+++ b/orttraining/orttraining/core/optimizer/memory_optimizer/recompute_analysis.cc
@@ -72,11 +72,13 @@ const InlinedHashMap<std::string, AllowedRecomputeNodeConfig>& GetAllowedRecompu
         {"Add", AllowedRecomputeNodeConfig{{0, 1}}},
         {"BiasGelu", AllowedRecomputeNodeConfig{{0, 1}}},
         {"Div", AllowedRecomputeNodeConfig{{0, 1}}},
+        {"Equal", AllowedRecomputeNodeConfig{{0, 1}}},
         {"Mul", AllowedRecomputeNodeConfig{{0, 1}}},
         {"Sub", AllowedRecomputeNodeConfig{{0, 1}}},
 
         // Data layout
         /// The shape input is trivial whether it exists or not in backward.
+        {"Shape", AllowedRecomputeNodeConfig{{0}}},
         {"Reshape", AllowedRecomputeNodeConfig{{0}}},
         {"Squeeze", AllowedRecomputeNodeConfig{{0}}},
         {"Transpose", AllowedRecomputeNodeConfig{{0}}},

--- a/orttraining/orttraining/core/optimizer/memory_optimizer/recompute_analysis.cc
+++ b/orttraining/orttraining/core/optimizer/memory_optimizer/recompute_analysis.cc
@@ -94,6 +94,7 @@ const InlinedHashMap<std::string, AllowedRecomputeNodeConfig>& GetAllowedRecompu
         {"Expand", AllowedRecomputeNodeConfig{{0}}},
         {"FastGelu", AllowedRecomputeNodeConfig{{0}}},
         {"Gelu", AllowedRecomputeNodeConfig{{0}}},
+        {"QuickGelu", AllowedRecomputeNodeConfig{{0}}},
 
         // Ternary elementwise
         {"Where", AllowedRecomputeNodeConfig{{0, 1, 2}}},

--- a/orttraining/orttraining/core/optimizer/memory_optimizer/recompute_analysis.h
+++ b/orttraining/orttraining/core/optimizer/memory_optimizer/recompute_analysis.h
@@ -127,9 +127,7 @@ class NodeRecomputePlan : public NodeOptimizationPlanBase {
       saving_str = "(" + cur_output_saving_str + ")";
     }
 
-    if (saving_str.empty()) {
-      return saving_str;
-    }
+    ORT_ENFORCE(!saving_str.empty(), "saving_str should not be empty for node: ", node->OpType(), " ", node->Name());
     return "(" + saving_str + ")";
   }
 

--- a/orttraining/orttraining/python/training/ortmodule/_runtime_inspector.py
+++ b/orttraining/orttraining/python/training/ortmodule/_runtime_inspector.py
@@ -509,6 +509,8 @@ class MemoryObserver:
 
         self._is_first_inspect = True
 
+        self._m = m
+
     def is_enabled(self) -> bool:
         """Check if memory inspector is enabled."""
         return self._is_enabled
@@ -621,10 +623,12 @@ class MemoryObserver:
         need_print = self._current_step < 10 or (self._current_step & (self._current_step - 1) == 0)
 
         if need_print:
-            self._logger.info(
-                log_memory_usage(
-                    _convert_phase_to_string(cur_phase), rank_0_only=True, step_info=f"step {self._current_step}"
-                )
+            log_memory_usage(
+                _convert_phase_to_string(cur_phase),
+                rank_0_only=True,
+                step_info=f"step {self._current_step}",
+                logger=self._logger,
+                module=self._m,
             )
 
         if cur_phase == self._last_phase:

--- a/orttraining/orttraining/python/training/ortmodule/_runtime_inspector.py
+++ b/orttraining/orttraining/python/training/ortmodule/_runtime_inspector.py
@@ -14,7 +14,7 @@ from onnx import onnx_pb as onnx_proto
 from sympy import Symbol, simplify
 from sympy.parsing.sympy_parser import parse_expr
 
-from onnxruntime.training.utils import PTable
+from onnxruntime.training.utils import PTable, log_memory_usage
 
 from ._execution_agent import TrainingAgent
 from .options import _MemoryOptimizationLevel, _RuntimeOptions
@@ -621,29 +621,11 @@ class MemoryObserver:
         need_print = self._current_step < 10 or (self._current_step & (self._current_step - 1) == 0)
 
         if need_print:
-            cur_mem_allocated = self._normalize(torch.cuda.memory_allocated())
-            max_mem_allocated = self._normalize(torch.cuda.max_memory_allocated())
-            cur_mem_cached = self._normalize(torch.cuda.memory_reserved())
-            max_mem_cached = self._normalize(torch.cuda.max_memory_reserved())
-            torch_mem_stat = torch.cuda.memory_stats()
-            cur_mem_inactive = self._normalize(torch_mem_stat.get("inactive_split_bytes.all.current", 0))
-            max_mem_inactive = self._normalize(torch_mem_stat.get("inactive_split_bytes.all.peak", 0))
-
-            mem_stats = [
-                ["phase", _convert_phase_to_string(cur_phase)],
-                ["allocated", cur_mem_allocated],  # current memory allocated for tensors
-                ["max allocated", max_mem_allocated],  # peak memory allocated for tensors
-                ["cached", cur_mem_cached],  # current memory cached for the caching allocator
-                ["max cached", max_mem_cached],  # peak memory cached for caching allocator.
-                ["inactive", cur_mem_inactive],  # amount of inactive, non-releasable memory
-                ["max inactive", max_mem_inactive],  # peak of inactive, non-releasable memory
-            ]
-
-            summ = f"{self._rank_info} step {self._current_step} memory ({MemoryObserver.NORMALIZER_UNIT})"
-            for stat in mem_stats:
-                summ += f" | {stat[0]}: {stat[1]}"
-
-            self._logger.info(summ)
+            self._logger.info(
+                log_memory_usage(
+                    _convert_phase_to_string(cur_phase), rank_0_only=True, step_info=f"step {self._current_step}"
+                )
+            )
 
         if cur_phase == self._last_phase:
             self._increase_step()
@@ -654,9 +636,6 @@ class MemoryObserver:
 
     def _increase_step(self):
         self._current_step += 1
-
-    def _normalize(self, mem_size_in_bytes: Union[float, int]) -> str:
-        return f"{float(mem_size_in_bytes) / MemoryObserver.NORMALIZER_FACTOR:.0f}"
 
     def display_memory_optimization_plans(self, memory_optimizer_config, details=False) -> Tuple[List[str], PTable]:
         mem_plan_count = len(self.cluster_id_combination_to_saving_symbolics_map)

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -237,7 +237,7 @@ class TrainingManager(GraphExecutionManager):
                 # Only change this after the firs time a warning is issued.
                 self._first_skip_check_warning = False
                 self._logger.info(
-                    "Fast path enabled - skipping checks.Rebuild graph: %s, Execution agent: %s, Device check: %s",
+                    "Fast path enabled - skipping checks. Rebuild graph: %s, Execution agent: %s, Device check: %s",
                     self._runtime_options.skip_check.is_set(_SkipCheck.SKIP_CHECK_BUILD_GRADIENT),
                     self._runtime_options.skip_check.is_set(_SkipCheck.SKIP_CHECK_EXECUTION_AGENT),
                     self._runtime_options.skip_check.is_set(_SkipCheck.SKIP_CHECK_DEVICE),

--- a/orttraining/orttraining/python/training/ortmodule/_zero_stage3_compatibility.py
+++ b/orttraining/orttraining/python/training/ortmodule/_zero_stage3_compatibility.py
@@ -179,8 +179,6 @@ def post_processing_enable_zero_stage3_compat(
     exported_model.graph.node.insert(0, weight_pull_node)
 
     # Update safe_run_mode attribute for PythonOp.
-    from onnxruntime.training.utils.hooks._subscriber_manager import _IncrementStep
-
     _allowed_unsafe_run_python_op_names = [
         get_fully_qualified_class_name(ORTZeROOffloadPreForwardFunction),
         get_fully_qualified_class_name(ORTZeROOffloadPostForwardFunction),
@@ -188,7 +186,6 @@ def post_processing_enable_zero_stage3_compat(
         DEEPSPEED_PRE_BACKWARD_FUNCTION_NAME,
         DEEPSPEED_POST_BACKWARD_FUNCTION_NAME,
         DEEPSPEED_LINEAR_FUNCTION_NAME,
-        get_fully_qualified_class_name(_IncrementStep),
     ]
 
     for node in exported_model.graph.node:

--- a/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cpu/torch_interop_utils/custom_function_fw.cc
+++ b/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cpu/torch_interop_utils/custom_function_fw.cc
@@ -181,7 +181,6 @@ py::object finalize_training_mode_forward(
   }
 
   if (kernel_info.is_first_run) {
-    std::cout << "666666666666666666666666.  py_fn->materialize_grads:" << py_fn->materialize_grads << std::endl;
     get_materialize_grads_once(forward_output_tensors, py_fn->materialize_grads, kernel_info);
 
     if (kernel_info.safe_run_enabled) {

--- a/orttraining/orttraining/python/training/utils/__init__.py
+++ b/orttraining/orttraining/python/training/utils/__init__.py
@@ -12,6 +12,7 @@ from onnxruntime.training.utils.torch_io_helper import (
     unflatten_data_using_schema,
 )
 from onnxruntime.training.utils.torch_profile_utils import (
+    log_memory_usage,
     nvtx_function_decorator,
     torch_nvtx_range_pop,
     torch_nvtx_range_push,
@@ -31,6 +32,7 @@ __all__ = [
     "torch_nvtx_range_push",
     "torch_nvtx_range_pop",
     "nvtx_function_decorator",
+    "log_memory_usage",
     "pytorch_type_to_onnx_dtype",
     "onnx_dtype_to_pytorch_dtype",
     "pytorch_scalar_type_to_pytorch_dtype",

--- a/orttraining/orttraining/python/training/utils/hooks/__init__.py
+++ b/orttraining/orttraining/python/training/utils/hooks/__init__.py
@@ -8,12 +8,14 @@ import torch
 
 __all__ = [
     "StatisticsSubscriber",
+    "MemoryStatisticsSubscriber",
     "GlobalSubscriberManager",
     "inspect_activation",
     "ZeROOffloadSubscriber",
     "configure_ort_compatible_zero_stage3",
 ]
 
+from ._mem_statistics_subscriber import MemoryStatisticsSubscriber
 from ._statistics_subscriber import StatisticsSubscriber, _InspectActivation
 from ._subscriber_manager import SubscriberManager
 from ._zero_offload_subscriber import ZeROOffloadSubscriber, configure_ort_compatible_zero_stage3

--- a/orttraining/orttraining/python/training/utils/hooks/_mem_statistics_subscriber.py
+++ b/orttraining/orttraining/python/training/utils/hooks/_mem_statistics_subscriber.py
@@ -1,0 +1,134 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+
+from typing import List, Optional, Tuple, Union
+
+import onnx
+import torch
+
+from onnxruntime.training.utils import log_memory_usage, extract_data_and_schema, unflatten_data_using_schema, ORTModelInputOutputType
+
+
+from ._subscriber_base import RuntimeStates, SubscriberBase
+
+
+_PRE_FW_PASS_PHASE = "pre-fw-pass"
+_POST_FW_PASS_PHASE = "post-fw-pass"
+_PRE_BW_PASS_PHASE = "pre-bw-pass"
+_POST_BW_PASS_PHASE = "post-bw-pass"
+
+class _InspectMemoryUsage(torch.autograd.Function):
+    """This class is used to print the memory statistics in the forward and backward passes."""
+
+    @staticmethod
+    def forward(ctx, phase: str, run_ctx: RuntimeStates, module: torch.nn.Module,
+                *input_tensor_list: Tuple[torch.Tensor, ...]) -> Tuple[torch.Tensor, ...]:
+        """Make sure there is the same number of `tensor` inputs and outputs.
+        """
+        ctx.current_step = run_ctx.global_states.execution_step
+        ctx.phase = phase
+        ctx.module = module
+
+        assert ctx.phase in [_PRE_FW_PASS_PHASE, _POST_FW_PASS_PHASE], f"Invalid phase {ctx.phase}"
+
+        # The step is not always consistent with the step in users' training loops.
+        # It is a counter of how many times the forward+backward pass is called.
+        log_memory_usage(f"{ctx.phase}", rank_0_only=True, step_info=f"step {ctx.current_step}", module=ctx.module)
+
+        return tuple(t.detach().requires_grad_(t.requires_grad) for t in input_tensor_list)
+
+    @staticmethod
+    def backward(ctx, *grad_output: Tuple[Optional[torch.Tensor], ...]) -> Tuple[Optional[torch.Tensor], ...]:
+        phase = ctx.phase
+        if ctx.phase == _PRE_FW_PASS_PHASE:
+            phase = _POST_BW_PASS_PHASE
+        elif ctx.phase == _POST_FW_PASS_PHASE:
+            phase = _PRE_BW_PASS_PHASE
+        log_memory_usage(f"{phase}", rank_0_only=True, step_info=f"step {ctx.current_step}", module=ctx.module)
+        return (None, None, None, *tuple(g for g in grad_output))
+
+    @staticmethod
+    def infer_shape(
+        node: onnx.NodeProto,
+        tensor_input_shapes: List[Optional[List[Union[int, str]]]],
+        tensor_input_dtypes: List[torch.onnx.TensorProtoDataType],
+    ) -> Tuple[List[Optional[List[Union[int, str]]]], List[torch.onnx.TensorProtoDataType]]:
+        return tensor_input_shapes, tensor_input_dtypes
+
+    @staticmethod
+    def alias_input(node_proto_str: str):
+        node = onnx.NodeProto()
+        node.ParseFromString(node_proto_str)
+        non_tensor_fw_input_count = 3
+        fw_output_count = len(node.output) - 1  # exclude the first output appended in ONNX
+        fw_alias_map = [-1] * fw_output_count
+        bw_alias_map = [-1] * (non_tensor_fw_input_count + len(node.input))
+
+        for i in range(fw_output_count):
+            fw_alias_map[i] = i + non_tensor_fw_input_count
+
+        tensor_input_index = 0
+        for i in range(len(bw_alias_map)):
+            if i < non_tensor_fw_input_count:
+                continue
+            bw_alias_map[i] = tensor_input_index
+            tensor_input_index += 1
+        return fw_alias_map, bw_alias_map
+
+
+
+class MemoryStatisticsSubscriber(SubscriberBase):
+    """
+    This subscriber is used to print the memory statistics in the forward and backward passes.
+    """
+
+    def __init__(
+        self,
+        start_step: Union[None, int] = None,
+        end_step: Union[None, int] = None,
+    ):
+        """
+        Steps in [start_step, end_step) will run subscriber actions.
+
+        Args:
+            start_step: the first step that runs subscriber actions.
+            end_step: the end step (exclusively) that runs subscriber actions.
+        """
+        super().__init__(start_step=start_step, end_step=end_step)
+
+    def pre_forward_outmost_module_apply_impl(
+        self,
+        run_ctx: RuntimeStates,
+        module: torch.nn.Module,
+        args: ORTModelInputOutputType,
+        kwargs: ORTModelInputOutputType,
+    ) -> Tuple[ORTModelInputOutputType, ORTModelInputOutputType]:
+
+        flatten_args_tensor_list, args_schema = extract_data_and_schema(args)
+        flatten_kwargs_tensor_list, kwargs_schema = extract_data_and_schema(kwargs)
+        flatten_out = _InspectMemoryUsage.apply(_PRE_FW_PASS_PHASE, run_ctx, module,
+                                                 *(flatten_args_tensor_list + flatten_kwargs_tensor_list))
+        args_tensors = flatten_out[:len(flatten_args_tensor_list)]
+        kwargs_tensors = flatten_out[len(flatten_args_tensor_list):]
+        restored_args = unflatten_data_using_schema(args_tensors, args_schema)
+        restored_kwargs = unflatten_data_using_schema(kwargs_tensors, kwargs_schema)
+
+        return restored_args, restored_kwargs
+
+
+    def post_forward_outmost_module_apply_impl(
+        self,
+        run_ctx: RuntimeStates,
+        module: torch.nn.Module,
+        args: ORTModelInputOutputType,
+        outputs: ORTModelInputOutputType,
+    ) -> Tuple[ORTModelInputOutputType, ORTModelInputOutputType]:
+
+        flatten_output_tensor_list, output_schema = extract_data_and_schema(outputs)
+        output_tensors = _InspectMemoryUsage.apply(_POST_FW_PASS_PHASE, run_ctx, module, *flatten_output_tensor_list)
+        restored_outputs = unflatten_data_using_schema(output_tensors, output_schema)
+
+        return args, restored_outputs

--- a/orttraining/orttraining/python/training/utils/hooks/_statistics_subscriber.py
+++ b/orttraining/orttraining/python/training/utils/hooks/_statistics_subscriber.py
@@ -13,6 +13,8 @@ from typing import List, Optional, Tuple, Union
 import onnx
 import torch
 
+from onnxruntime.training.utils import log_memory_usage
+
 from ._subscriber_base import RuntimeStates, SubscriberBase
 
 
@@ -201,82 +203,86 @@ def _summarize_tensor(
     run_on_cpu: bool = False,
     bucket_size: int = 1024 * 1024 * 1024 // 2,
 ):
-    # This is to try the best effort to align the count of numbers per line for easier comparison in diff views,
-    # though it does not always guarantee to do this way.
-    torch.set_printoptions(precision=6, linewidth=128)
+    # # This is to try the best effort to align the count of numbers per line for easier comparison in diff views,
+    # # though it does not always guarantee to do this way.
+    # torch.set_printoptions(precision=6, linewidth=128)
 
-    tensor_shape = tensor.shape
-    tensor_dtype = tensor.dtype
-    flatten_array = tensor.flatten().view(-1)
+    # tensor_shape = tensor.shape
+    # tensor_dtype = tensor.dtype
+    # flatten_array = tensor.flatten().view(-1)
 
-    if run_on_cpu:
-        flatten_array = flatten_array.to("cpu")
+    # if run_on_cpu:
+    #     flatten_array = flatten_array.to("cpu")
 
-    if run_on_cpu:
-        num_nan = torch.isnan(flatten_array).sum()
-        num_inf = torch.isinf(flatten_array).sum()
-        num_neg = (flatten_array < 0).sum()
-        num_pos = (flatten_array > 0).sum()
-        num_zero = (flatten_array == 0).sum()
-        min_value = flatten_array.min()
-        max_value = flatten_array.max()
-        mean_value = flatten_array.mean()
-        std_value = flatten_array.std()
-    else:
-        # Split the calculation for each bucket, then do another round of calculation on the bucket results.
-        # This can at the best effort reduce the peak memory impact.
-        element_count = flatten_array.numel()
-        ceil_bucket_count = (element_count + bucket_size - 1) // (bucket_size)
-        nan_buckets = torch.zeros(ceil_bucket_count, dtype=torch.int64, device=flatten_array.device)
-        inf_buckets = torch.zeros(ceil_bucket_count, dtype=torch.int64, device=flatten_array.device)
-        neg_buckets = torch.zeros(ceil_bucket_count, dtype=torch.int64, device=flatten_array.device)
-        pos_buckets = torch.zeros(ceil_bucket_count, dtype=torch.int64, device=flatten_array.device)
-        zero_buckets = torch.zeros(ceil_bucket_count, dtype=torch.int64, device=flatten_array.device)
-        min_buckets = torch.zeros(ceil_bucket_count, dtype=flatten_array.dtype, device=flatten_array.device)
-        max_buckets = torch.zeros(ceil_bucket_count, dtype=flatten_array.dtype, device=flatten_array.device)
-        mean_buckets = torch.zeros(ceil_bucket_count, dtype=flatten_array.dtype, device=flatten_array.device)
-        std_buckets = torch.zeros(ceil_bucket_count, dtype=flatten_array.dtype, device=flatten_array.device)
+    # if run_on_cpu:
+    #     num_nan = torch.isnan(flatten_array).sum()
+    #     num_inf = torch.isinf(flatten_array).sum()
+    #     num_neg = (flatten_array < 0).sum()
+    #     num_pos = (flatten_array > 0).sum()
+    #     num_zero = (flatten_array == 0).sum()
+    #     min_value = flatten_array.min()
+    #     max_value = flatten_array.max()
+    #     mean_value = flatten_array.mean()
+    #     std_value = flatten_array.std()
+    # else:
+    #     # Split the calculation for each bucket, then do another round of calculation on the bucket results.
+    #     # This can at the best effort reduce the peak memory impact.
+    #     element_count = flatten_array.numel()
+    #     ceil_bucket_count = (element_count + bucket_size - 1) // (bucket_size)
+    #     nan_buckets = torch.zeros(ceil_bucket_count, dtype=torch.int64, device=flatten_array.device)
+    #     inf_buckets = torch.zeros(ceil_bucket_count, dtype=torch.int64, device=flatten_array.device)
+    #     neg_buckets = torch.zeros(ceil_bucket_count, dtype=torch.int64, device=flatten_array.device)
+    #     pos_buckets = torch.zeros(ceil_bucket_count, dtype=torch.int64, device=flatten_array.device)
+    #     zero_buckets = torch.zeros(ceil_bucket_count, dtype=torch.int64, device=flatten_array.device)
+    #     min_buckets = torch.zeros(ceil_bucket_count, dtype=flatten_array.dtype, device=flatten_array.device)
+    #     max_buckets = torch.zeros(ceil_bucket_count, dtype=flatten_array.dtype, device=flatten_array.device)
+    #     mean_buckets = torch.zeros(ceil_bucket_count, dtype=flatten_array.dtype, device=flatten_array.device)
+    #     std_buckets = torch.zeros(ceil_bucket_count, dtype=flatten_array.dtype, device=flatten_array.device)
 
-        # Summary for each bucket
-        element_count_per_bucket = torch.zeros(ceil_bucket_count, dtype=torch.int64, device=flatten_array.device)
-        for i in range(ceil_bucket_count):
-            end = min((i + 1) * bucket_size, element_count)
-            bucket = flatten_array[i * bucket_size : end]
-            element_count_per_bucket[i] = bucket.numel()
+    #     # Summary for each bucket
+    #     element_count_per_bucket = torch.zeros(ceil_bucket_count, dtype=torch.int64, device=flatten_array.device)
+    #     for i in range(ceil_bucket_count):
+    #         end = min((i + 1) * bucket_size, element_count)
+    #         bucket = flatten_array[i * bucket_size : end]
+    #         element_count_per_bucket[i] = bucket.numel()
 
-            nan_buckets[i] = torch.isnan(bucket).sum()
-            inf_buckets[i] = torch.isinf(bucket).sum()
-            neg_buckets[i] = (bucket < 0).sum()
-            pos_buckets[i] = (bucket > 0).sum()
-            zero_buckets[i] = (bucket == 0).sum()
-            min_buckets[i] = bucket.min()
-            max_buckets[i] = bucket.max()
-            mean_buckets[i] = bucket.sum()
-            std_buckets[i] = bucket.std()
+    #         nan_buckets[i] = torch.isnan(bucket).sum()
+    #         inf_buckets[i] = torch.isinf(bucket).sum()
+    #         neg_buckets[i] = (bucket < 0).sum()
+    #         pos_buckets[i] = (bucket > 0).sum()
+    #         zero_buckets[i] = (bucket == 0).sum()
+    #         min_buckets[i] = bucket.min()
+    #         max_buckets[i] = bucket.max()
+    #         mean_buckets[i] = bucket.sum()
+    #         std_buckets[i] = bucket.std()
 
-        # Reduction across all buckets
-        num_nan = nan_buckets.sum()
-        num_inf = inf_buckets.sum()
-        num_neg = neg_buckets.sum()
-        num_pos = pos_buckets.sum()
-        num_zero = zero_buckets.sum()
-        min_value = min_buckets.min()
-        max_value = max_buckets.max()
-        mean_value = float(mean_buckets.sum()) / float(element_count)
-        # Here we refer to
-        # https://math.stackexchange.com/questions/2971315/how-do-i-combine-standard-deviations-of-two-groups
-        # to calculate the combined standard deviation of all buckets.
-        s = (element_count_per_bucket - 1) * (std_buckets**2) + element_count_per_bucket * (
-            (mean_buckets - mean_value) ** 2
-        )
-        std_value = torch.sqrt(s.sum() / (element_count - 1))
+    #     # Reduction across all buckets
+    #     num_nan = nan_buckets.sum()
+    #     num_inf = inf_buckets.sum()
+    #     num_neg = neg_buckets.sum()
+    #     num_pos = pos_buckets.sum()
+    #     num_zero = zero_buckets.sum()
+    #     min_value = min_buckets.min()
+    #     max_value = max_buckets.max()
+    #     mean_value = float(mean_buckets.sum()) / float(element_count)
+    #     # Here we refer to
+    #     # https://math.stackexchange.com/questions/2971315/how-do-i-combine-standard-deviations-of-two-groups
+    #     # to calculate the combined standard deviation of all buckets.
+    #     s = (element_count_per_bucket - 1) * (std_buckets**2) + element_count_per_bucket * (
+    #         (mean_buckets - mean_value) ** 2
+    #     )
+    #     std_value = torch.sqrt(s.sum() / (element_count - 1))
 
-    f.write(
-        f"{'>'*max(0, depth) + display_name} shape: {tensor_shape} dtype: {tensor_dtype} size: {flatten_array.size()} \n"
-        f"min: {min_value} max: {max_value}, mean: {mean_value}, "
-        f"std: {std_value} \n"
-        f"nan: {num_nan}, inf: {num_inf}\n"
-    )
-    f.write(f"samples(top 128): {flatten_array[:128]}\n")
-    f.write(f"neg: {num_neg}, pos: {num_pos}, zero: {num_zero},\n")
-    f.write(f"{'='*16}\n")
+    # f.write(
+    #     f"{'>'*max(0, depth) + display_name} shape: {tensor_shape} dtype: {tensor_dtype} size: {flatten_array.size()} \n"
+    #     f"min: {min_value} max: {max_value}, mean: {mean_value}, "
+    #     f"std: {std_value} \n"
+    #     f"nan: {num_nan}, inf: {num_inf}\n"
+    # )
+    # f.write(f"samples(top 128): {flatten_array[:128]}\n")
+    # f.write(f"neg: {num_neg}, pos: {num_pos}, zero: {num_zero},\n")
+    # f.write(f"{'='*16}\n")
+
+    # f.write(f"{display_name} shape: {tensor.shape} dtype: {tensor.dtype} size: {tensor.size()}, \n")
+    f.write(f"{log_memory_usage(display_name, rank_0_only=True, step_info='')}\n")
+    # f.write(f"{'='*16}\n")

--- a/orttraining/orttraining/python/training/utils/hooks/_statistics_subscriber.py
+++ b/orttraining/orttraining/python/training/utils/hooks/_statistics_subscriber.py
@@ -156,12 +156,12 @@ class StatisticsSubscriber(SubscriberBase):
                 )
 
     def post_forward_tensor_apply_impl(
-        self, run_rtx: RuntimeStates, module: torch.nn.Module, tensor_index: int, tensor: torch.Tensor
+        self, run_ctx: RuntimeStates, module: torch.nn.Module, tensor_index: int, tensor: torch.Tensor
     ) -> torch.Tensor:
-        module_index = run_rtx.global_states.module_to_module_index[module]
+        module_index = run_ctx.global_states.module_to_module_index[module]
         name = f"{module.__class__.__name__}_{module_index}_{tensor_index}th_output"
         return _InspectActivation.apply(
-            name, module_index, run_rtx, tensor, self.module_post_forward_impl, self.module_pre_backward_impl
+            name, module_index, run_ctx, tensor, self.module_post_forward_impl, self.module_pre_backward_impl
         )
 
     def module_post_forward_impl(self, activation: torch.Tensor, depth: int, name: str, step: int):

--- a/orttraining/orttraining/python/training/utils/hooks/_zero_offload_subscriber.py
+++ b/orttraining/orttraining/python/training/utils/hooks/_zero_offload_subscriber.py
@@ -5,7 +5,6 @@
 
 import ctypes
 import inspect
-import warnings
 from collections import OrderedDict
 from datetime import timedelta
 from types import CodeType, FunctionType
@@ -169,7 +168,8 @@ try:
         if torch.nn.functional.linear is zero3_linear_wrap:
             torch.nn.functional.linear = _zero3_linear_wrap_ort_compatible
 
-except ImportError as e:
+except ImportError:
+
     def configure_ort_compatible_zero_stage3(debug=False, stats_output_dir=None, stats_overwrite=False):
         raise RuntimeError("DeepSpeed is not installed, cannot configure ORT compatible ZeRO stage3.")
 

--- a/orttraining/orttraining/python/training/utils/hooks/_zero_offload_subscriber.py
+++ b/orttraining/orttraining/python/training/utils/hooks/_zero_offload_subscriber.py
@@ -170,8 +170,6 @@ try:
             torch.nn.functional.linear = _zero3_linear_wrap_ort_compatible
 
 except ImportError as e:
-    warnings.warn(f"DeepSpeed import error {e}")
-
     def configure_ort_compatible_zero_stage3(debug=False, stats_output_dir=None, stats_overwrite=False):
         raise RuntimeError("DeepSpeed is not installed, cannot configure ORT compatible ZeRO stage3.")
 
@@ -476,7 +474,7 @@ class ZeROOffloadSubscriber(SubscriberBase):
     @nvtx_function_decorator
     def pre_forward_module_apply_impl(
         self,
-        run_rtx: RuntimeStates,
+        run_ctx: RuntimeStates,
         module: torch.nn.Module,
         args: ORTModelInputOutputType,
         kwargs: ORTModelInputOutputType,
@@ -552,7 +550,7 @@ class ZeROOffloadSubscriber(SubscriberBase):
     @nvtx_function_decorator
     def post_forward_module_apply_impl(
         self,
-        run_rtx: RuntimeStates,
+        run_ctx: RuntimeStates,
         module: torch.nn.Module,
         args: ORTModelInputOutputType,
         outputs: ORTModelInputOutputType,
@@ -611,7 +609,7 @@ class ZeROOffloadSubscriber(SubscriberBase):
     @nvtx_function_decorator
     def post_forward_outmost_module_apply_impl(
         self,
-        run_rtx: RuntimeStates,
+        run_ctx: RuntimeStates,
         module: torch.nn.Module,
         args: ORTModelInputOutputType,
         outputs: ORTModelInputOutputType,

--- a/orttraining/orttraining/python/training/utils/torch_profile_utils.py
+++ b/orttraining/orttraining/python/training/utils/torch_profile_utils.py
@@ -32,13 +32,21 @@ def nvtx_function_decorator(func):
     return wrapped_fn
 
 
-def log_memory_usage(cur_phase: str, rank_0_only=True, step_info="") -> str:
+def log_memory_usage(cur_phase: str, rank_0_only=True, step_info="", logger=None, module=None):
+    """Log memory usage for the current phase.
+    Args:
+        cur_phase (str): The current phase.
+        rank_0_only (bool, optional): Only log the memory usage for rank 0. Defaults to True.
+        step_info (str, optional): The step information. Defaults to "".
+        logger (logging.Logger, optional): The logger to log the memory usage. Defaults to None, which means print to stdout.
+        module (torch.nn.Module, optional): The module to get parameter, buffer and grad sizes. Defaults to None.
+    """
     rank = 0
     if rank_0_only is True:
         if torch.distributed.is_initialized():
             rank = torch.distributed.get_rank()
         if rank != 0:
-            return ""
+            return
 
     _normalizer_factor = float(1024 * 1024)
     _normalizer_unit = "MiB"
@@ -62,21 +70,48 @@ def log_memory_usage(cur_phase: str, rank_0_only=True, step_info="") -> str:
         memory_use_info = output_to_list(sp.check_output(nvm_cmd.split(), stderr=sp.STDOUT))[1:]
     except sp.CalledProcessError as e:
         raise RuntimeError(f"command '{e.cmd}' return with error (code {e.returncode}): {e.output}") from None
-    memory_use_values = [str(x.split()[0]) for i, x in enumerate(memory_use_info)]
+    memory_use_value = [int(x.split()[0]) for i, x in enumerate(memory_use_info)][rank]
 
     mem_stats = [
         ["phase", cur_phase],
+        ["nvm smi", memory_use_value],
         ["allocated", cur_mem_allocated],  # current memory allocated for tensors
         ["max allocated", max_mem_allocated],  # peak memory allocated for tensors
         ["cached", cur_mem_cached],  # current memory cached for the caching allocator
         ["max cached", max_mem_cached],  # peak memory cached for caching allocator.
         ["inactive", cur_mem_inactive],  # amount of inactive, non-releasable memory
         ["max inactive", max_mem_inactive],  # peak of inactive, non-releasable memory
-        ["nvm smi", ",".join(memory_use_values)],
     ]
 
-    summ = f"{rank} {step_info} memory ({_normalizer_unit})"
+    # Calculate the total size of parameters and gradients in the model
+    if module:
+        param_total_size = 0
+        grad_total_size = 0
+        for p in module.parameters():
+            if p.is_cuda:
+                param_total_size += p.numel() * p.element_size()
+            if p.grad is not None and p.grad.is_cuda:
+                grad_total_size += p.grad.numel() * p.grad.element_size()
+
+        # Calculate the total size of buffers in the model
+        buffer_total_size = 0
+        for b in module.buffers():
+            if b.is_cuda:
+                buffer_total_size += b.numel() * b.element_size()
+
+        mem_stats.extend(
+            [
+                ["param size", _normalize(param_total_size)],
+                ["grad size", _normalize(grad_total_size)],
+                ["buffer size", _normalize(buffer_total_size)],
+            ]
+        )
+
+    summ = f"rank-{rank} {step_info} memory ({_normalizer_unit})"
     for stat in mem_stats:
         summ += f" | {stat[0]}: {stat[1]}"
 
-    return summ
+    if logger is None:
+        print(summ)
+    else:
+        logger.info(summ)

--- a/orttraining/orttraining/python/training/utils/torch_profile_utils.py
+++ b/orttraining/orttraining/python/training/utils/torch_profile_utils.py
@@ -3,6 +3,10 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
+from __future__ import annotations
+
+import subprocess as sp
+
 import torch
 
 
@@ -26,3 +30,53 @@ def nvtx_function_decorator(func):
         return ret_val
 
     return wrapped_fn
+
+
+def log_memory_usage(cur_phase: str, rank_0_only=True, step_info="") -> str:
+    rank = 0
+    if rank_0_only is True:
+        if torch.distributed.is_initialized():
+            rank = torch.distributed.get_rank()
+        if rank != 0:
+            return ""
+
+    _normalizer_factor = float(1024 * 1024)
+    _normalizer_unit = "MiB"
+
+    def _normalize(mem_size_in_bytes: float | int) -> str:
+        return f"{float(mem_size_in_bytes) / _normalizer_factor:.0f}"
+
+    cur_mem_allocated = _normalize(torch.cuda.memory_allocated())
+    max_mem_allocated = _normalize(torch.cuda.max_memory_allocated())
+    cur_mem_cached = _normalize(torch.cuda.memory_reserved())
+    max_mem_cached = _normalize(torch.cuda.max_memory_reserved())
+    torch_mem_stat = torch.cuda.memory_stats()
+    cur_mem_inactive = _normalize(torch_mem_stat.get("inactive_split_bytes.all.current", 0))
+    max_mem_inactive = _normalize(torch_mem_stat.get("inactive_split_bytes.all.peak", 0))
+
+    def output_to_list(x):
+        return x.decode("ascii").split("\n")[:-1]
+
+    nvm_cmd = "nvidia-smi --query-gpu=memory.used --format=csv"
+    try:
+        memory_use_info = output_to_list(sp.check_output(nvm_cmd.split(), stderr=sp.STDOUT))[1:]
+    except sp.CalledProcessError as e:
+        raise RuntimeError(f"command '{e.cmd}' return with error (code {e.returncode}): {e.output}") from None
+    memory_use_values = [str(x.split()[0]) for i, x in enumerate(memory_use_info)]
+
+    mem_stats = [
+        ["phase", cur_phase],
+        ["allocated", cur_mem_allocated],  # current memory allocated for tensors
+        ["max allocated", max_mem_allocated],  # peak memory allocated for tensors
+        ["cached", cur_mem_cached],  # current memory cached for the caching allocator
+        ["max cached", max_mem_cached],  # peak memory cached for caching allocator.
+        ["inactive", cur_mem_inactive],  # amount of inactive, non-releasable memory
+        ["max inactive", max_mem_inactive],  # peak of inactive, non-releasable memory
+        ["nvm smi", ",".join(memory_use_values)],
+    ]
+
+    summ = f"{rank} {step_info} memory ({_normalizer_unit})"
+    for stat in mem_stats:
+        summ += f" | {stat[0]}: {stat[1]}"
+
+    return summ


### PR DESCRIPTION
### 

Display recomputable graph reusing buffers - For some subgraph whose ending node is reusing other buffers, currently it is not displayed in the recomputation plans, this PR fix this bug. 

Extract memory logging into torch_profile_utils.py, which can be used in any other places we want to inspect memory during training.


Add `MemoryStatisticsSubscriber` to print memory stats, used to compare PyTorch and ORT memory peak. 




