### PR TITLE
Update DmlOperatorElementwiseQLinear to accept 1d tensors

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorElementWise.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorElementWise.cpp
@@ -554,7 +554,9 @@ public:
             // If the input tensor is a 1D vector, then extra massaging is needed to project their
             // 1D vectors back to the full shape for broadcasting along the given axis.
             // The 1D vector should have a length equal to the output tensor's dimension on that axis.
-            if (inputTensorShape.size() == 1 && inputTensorShape != outputShape)
+            if ((inputTensorShape.size() == 1 ) && 
+                (outputShape.size() > 1) &&
+                (inputTensorShape != outputShape))
             {
                 ML_CHECK_VALID_ARGUMENT(axis < outputShapeDimCount);
                 uint32_t broadcastAxisLength = outputShape[axis];

--- a/onnxruntime/test/contrib_ops/quantize_ops_test.cc
+++ b/onnxruntime/test/contrib_ops/quantize_ops_test.cc
@@ -76,6 +76,16 @@ TEST(DequantizeLinearOpTest, DequantizeLinear_per_tensor_float_int32_cpu) {
   test.Run();
 }
 
+TEST(DequantizeLinearOpTest, DequantizeLinearOpTest_1D) {
+  OpTester test("DequantizeLinear", 1, onnxruntime::kMSDomain);
+
+  test.AddInput<int32_t>("x", {4}, {-30, -3, 100, 127});
+  test.AddInput<float>("x_scale", {1}, {2.0f}, true);
+  test.AddInput<int32_t>("zero_point", {1}, {0}, true);
+  test.AddOutput<float>("y", {4}, {-60.f, -6.f, 200.f, 254.f});
+  test.Run();
+}
+
 #ifdef USE_CUDA
 TEST(DequantizeLinearOpTest, DequantizeLinear_per_tensor_half_uint8) {
   OpTester test("DequantizeLinear", 1, onnxruntime::kMSDomain);

--- a/onnxruntime/test/providers/cpu/tensor/quantize_linear_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/quantize_linear_test.cc
@@ -47,6 +47,16 @@ TEST(DequantizeLinearOpTest, Int32) {
   test.Run();
 }
 
+TEST(DequantizeLinearOpTest_1D, Int32) {
+  OpTester test("DequantizeLinear", 13);
+  std::vector<int64_t> dims{4};
+  test.AddInput<int32_t>("x", dims, {-30, -3, 100, 127});
+  test.AddInput<float>("x_scale", {1}, {2.0f});
+  test.AddInput<int32_t>("zero_point", {1}, {0});
+  test.AddOutput<float>("y", dims, {-60.f, -6.f, 200.f, 254.f});
+  test.Run();
+}
+
 // 2d inputs
 TEST(DequantizeLinearOpTest, 2D) {
   OpTester test("DequantizeLinear", 10);


### PR DESCRIPTION
DmlOperatorElementwiseQLinear would fail if dimensions was specified for ZeroPoint or scale and tensor output was 1d if the dimensions did not match.   

### Description
Updated DmlOperatorElementwiseQLinear to only project shape on multidimensional tensors.



### Motivation and Context
Some QDQ models were failing with ElementWiseQlinear and 1D buffers.


