### PR TITLE
[java] Adding back support for getValue returning fp16 values as float[]

### DIFF
--- a/java/src/main/java/ai/onnxruntime/TensorInfo.java
+++ b/java/src/main/java/ai/onnxruntime/TensorInfo.java
@@ -276,6 +276,9 @@ public class TensorInfo implements ValueInfo {
    * all elements as that's the expected format of the native code. It can be reshaped to the
    * correct shape using {@link OrtUtil#reshape(String[],long[])}.
    *
+   * <p>For fp16 and bf16 tensors the output carrier type is float, and so this method produces
+   * multidimensional float arrays.
+   *
    * @return A multidimensional array of the appropriate primitive type (or String).
    * @throws OrtException If the shape isn't representable in Java (i.e. if one of its indices is
    *     greater than an int).
@@ -288,6 +291,8 @@ public class TensorInfo implements ValueInfo {
               + Arrays.toString(shape));
     }
     switch (type) {
+      case BFLOAT16:
+      case FLOAT16:
       case FLOAT:
         return OrtUtil.newFloatArray(shape);
       case DOUBLE:


### PR DESCRIPTION
### Description
In #16703 we added support for returning the bit values of fp16 and bfloat16 values via the `getShortBuffer` method, along with a bunch of conversions to get them back out as floats. This unintentionally broke the old behaviour which allowed fp16 values to be returned by `OnnxTensor.getValue` as float arrays, upcasting them to fp32. This PR re-enables the old behaviour (now with better fp16 support, so it doesn't junk denormals, infinities and NaNs like it used to), and also allows bfloat16 values to be returned in the same way.

Plus there's a test for the behaviour in both fp16 and bfloat16 so I don't break it accidentally again.

### Motivation and Context
Fixes #18926. 


