### PR TITLE
[js/webgpu] Fix shader compilation errors in Resize

### DIFF
--- a/js/web/lib/wasm/jsep/webgpu/ops/resize.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/resize.ts
@@ -342,7 +342,7 @@ const bilinearInterpolation =
       var col:${dType} = originalIndices[${widthIdx}];
       ${
           useExtrapolation ?
-              `if (row < 0 || row > (${inputShape[heightIdx]} - 1) || col < 0 || col > (${inputShape[widthIdx]} - 1))) {
+              `if (row < 0 || row > (${inputShape[heightIdx]} - 1) || col < 0 || col > (${inputShape[widthIdx]} - 1)) {
         return ${extrapolationValue};
       }` :
               ''};


### PR DESCRIPTION
### Description
An extra right parenthesis was added by accidentally, which results some resize cases fail. This PR fixes it. 


