### PR TITLE
Add API to create a session from model memory buffer with external data path

### DIFF
--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -680,7 +680,7 @@ class Graph {  // NOLINT(clang-analyzer-optin.performance.Padding): preserve exi
   const Path& ModelPath() const;
 
   /** Gets the path of the external initializer data, if any. */
-  const Path& ExternalIniPath() const;
+  const Path& ExternalDataPath() const;
 
   /** Returns true if this is a subgraph or false if it is a high-level graph. */
   bool IsSubgraph() const { return parent_graph_ != nullptr; }

--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -679,6 +679,9 @@ class Graph {  // NOLINT(clang-analyzer-optin.performance.Padding): preserve exi
   /** Gets the path of the owning model, if any. */
   const Path& ModelPath() const;
 
+  /** Gets the path of the external initializer data, if any. */
+  const Path& ExternalIniPath() const;
+
   /** Returns true if this is a subgraph or false if it is a high-level graph. */
   bool IsSubgraph() const { return parent_graph_ != nullptr; }
 

--- a/include/onnxruntime/core/graph/graph_viewer.h
+++ b/include/onnxruntime/core/graph/graph_viewer.h
@@ -45,6 +45,9 @@ class GraphViewer {
   /** Gets the path of the owning model if any **/
   const Path& ModelPath() const noexcept { return graph_->ModelPath(); }
 
+  /** Gets the folder path of the external data if any **/
+  const Path& ExternalDataPath() const noexcept { return graph_->ExternalDataPath(); }
+
   /**
   Gets a tensor created from an initializer.
   @param tensor_name The tensor name

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -4515,6 +4515,23 @@ struct OrtApi {
    * \since Version 1.17.
    */
   ORT_API2_STATUS(ReadOpAttr, _In_ const OrtOpAttr* op_attr, _In_ OrtOpAttrType type, _Inout_ void* data, _In_ size_t len, _Out_ size_t* out);
+
+  /** \brief Create session from memory with external initializer data
+   *
+   * Same functionality offered by OrtApi::CreateSessionFromArray except that it provides folder path to the external initializers.
+   *
+   * \param[in] env
+   * \param[in] model_data Array of bytes holding the model
+   * \param[in] model_data_length Number of bytes in `model_data_model`
+   * \param[in] external_data_path external initializer data folder path
+   * \param[in] options
+   * \param[out] out Newly created ::OrtSession. Must be freed with OrtApi::ReleaseSession
+   *
+   * \since Version 1.17.
+   */
+  ORT_API2_STATUS(CreateSessionFromArrayWithExternalData, _In_ const OrtEnv* env,
+                  _In_ const void* model_data, size_t model_data_length, _In_ const ORTCHAR_T* external_data_path,
+                  _In_ const OrtSessionOptions* options, _Outptr_ OrtSession** out);
 };
 
 /*

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -1114,6 +1114,8 @@ struct Session : detail::SessionImpl<OrtSession> {
   Session(const Env& env, const void* model_data, size_t model_data_length, const SessionOptions& options);  ///< Wraps OrtApi::CreateSessionFromArray
   Session(const Env& env, const void* model_data, size_t model_data_length, const SessionOptions& options,
           OrtPrepackedWeightsContainer* prepacked_weights_container);  ///< Wraps OrtApi::CreateSessionFromArrayWithPrepackedWeightsContainer
+  Session(const Env& env, const void* model_data, size_t model_data_length, const ORTCHAR_T* external_data_path,
+          const SessionOptions& options);  ///< Wraps OrtApi::CreateSessionFromArrayWithExternalData
 
   ConstSession GetConst() const { return ConstSession{this->p_}; }
   UnownedSession GetUnowned() const { return UnownedSession{this->p_}; }

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -1044,6 +1044,11 @@ inline Session::Session(const Env& env, const void* model_data, size_t model_dat
                                                                             prepacked_weights_container, &this->p_));
 }
 
+inline Session::Session(const Env& env, const void* model_data, size_t model_data_length, const ORTCHAR_T* external_data_path,
+                        const SessionOptions& options) {
+  ThrowOnError(GetApi().CreateSessionFromArrayWithExternalData(env, model_data, model_data_length, external_data_path, options, &this->p_));
+}
+
 inline AllocatedStringPtr ModelMetadata::GetProducerNameAllocated(OrtAllocator* allocator) const {
   char* out;
   ThrowOnError(GetApi().ModelMetadataGetProducerName(p_, allocator, &out));

--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -1172,7 +1172,7 @@ static Status VerifyEachNodeIsAssignedToAnEp(const Graph& graph, const logging::
   return Status::OK();
 }
 
-Status SessionState::FinalizeSessionState(const std::basic_string<PATH_CHAR_TYPE>& external_ini_path,
+Status SessionState::FinalizeSessionState(const std::basic_string<PATH_CHAR_TYPE>& external_data_path,
                                           const KernelRegistryManager& kernel_registry_manager,
                                           bool remove_initializers,
                                           bool saving_ort_format) {
@@ -1186,7 +1186,7 @@ Status SessionState::FinalizeSessionState(const std::basic_string<PATH_CHAR_TYPE
 
   InlinedHashMap<std::string, size_t> constant_initializers_use_count;
   ComputeConstantInitializerUseCount(graph_, constant_initializers_use_count);
-  return FinalizeSessionStateImpl(external_ini_path, kernel_registry_manager, nullptr, sess_options_,
+  return FinalizeSessionStateImpl(external_data_path, kernel_registry_manager, nullptr, sess_options_,
                                   remove_initializers, constant_initializers_use_count);
 }
 
@@ -1315,7 +1315,7 @@ static void AccumulateAllNestedSubgraphsInfo(
   }
 }
 
-Status SessionState::FinalizeSessionStateImpl(const std::basic_string<PATH_CHAR_TYPE>& external_ini_path,
+Status SessionState::FinalizeSessionStateImpl(const std::basic_string<PATH_CHAR_TYPE>& external_data_path,
                                               const KernelRegistryManager& kernel_registry_manager,
                                               _In_opt_ const Node* parent_node,
                                               const SessionOptions& session_options,
@@ -1475,7 +1475,7 @@ Status SessionState::FinalizeSessionStateImpl(const std::basic_string<PATH_CHAR_
 
   ORT_RETURN_IF_ERROR(
       session_state_utils::SaveInitializedTensors(
-          Env::Default(), external_ini_path, *graph_viewer_,
+          Env::Default(), external_data_path, *graph_viewer_,
           GetAllocator(OrtDevice()),
           ort_value_name_idx_map_, initializer_allocation_order, *tensor_allocator,
           [this, remove_initializers](const std::string& name, int idx, const OrtValue& value, const OrtCallback& d,
@@ -1542,7 +1542,7 @@ Status SessionState::FinalizeSessionStateImpl(const std::basic_string<PATH_CHAR_
                                                                subgraph_session_state.GetGraphViewer(),
                                                                subgraph_outer_scope_node_arg_to_location_map));
       ORT_RETURN_IF_ERROR(subgraph_session_state.FinalizeSessionStateImpl(
-          external_ini_path, kernel_registry_manager, &node, subgraph_session_options, remove_initializers,
+          external_data_path, kernel_registry_manager, &node, subgraph_session_options, remove_initializers,
           constant_initializers_use_count, subgraph_outer_scope_node_arg_to_location_map, true));
 
       // setup all the info for handling the feeds and fetches used in subgraph execution

--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -1172,7 +1172,7 @@ static Status VerifyEachNodeIsAssignedToAnEp(const Graph& graph, const logging::
   return Status::OK();
 }
 
-Status SessionState::FinalizeSessionState(const std::basic_string<PATH_CHAR_TYPE>& graph_location,
+Status SessionState::FinalizeSessionState(const std::basic_string<PATH_CHAR_TYPE>& external_ini_path,
                                           const KernelRegistryManager& kernel_registry_manager,
                                           bool remove_initializers,
                                           bool saving_ort_format) {
@@ -1186,7 +1186,7 @@ Status SessionState::FinalizeSessionState(const std::basic_string<PATH_CHAR_TYPE
 
   InlinedHashMap<std::string, size_t> constant_initializers_use_count;
   ComputeConstantInitializerUseCount(graph_, constant_initializers_use_count);
-  return FinalizeSessionStateImpl(graph_location, kernel_registry_manager, nullptr, sess_options_,
+  return FinalizeSessionStateImpl(external_ini_path, kernel_registry_manager, nullptr, sess_options_,
                                   remove_initializers, constant_initializers_use_count);
 }
 
@@ -1315,7 +1315,7 @@ static void AccumulateAllNestedSubgraphsInfo(
   }
 }
 
-Status SessionState::FinalizeSessionStateImpl(const std::basic_string<PATH_CHAR_TYPE>& graph_location,
+Status SessionState::FinalizeSessionStateImpl(const std::basic_string<PATH_CHAR_TYPE>& external_ini_path,
                                               const KernelRegistryManager& kernel_registry_manager,
                                               _In_opt_ const Node* parent_node,
                                               const SessionOptions& session_options,
@@ -1475,7 +1475,7 @@ Status SessionState::FinalizeSessionStateImpl(const std::basic_string<PATH_CHAR_
 
   ORT_RETURN_IF_ERROR(
       session_state_utils::SaveInitializedTensors(
-          Env::Default(), graph_location, *graph_viewer_,
+          Env::Default(), external_ini_path, *graph_viewer_,
           GetAllocator(OrtDevice()),
           ort_value_name_idx_map_, initializer_allocation_order, *tensor_allocator,
           [this, remove_initializers](const std::string& name, int idx, const OrtValue& value, const OrtCallback& d,
@@ -1542,7 +1542,7 @@ Status SessionState::FinalizeSessionStateImpl(const std::basic_string<PATH_CHAR_
                                                                subgraph_session_state.GetGraphViewer(),
                                                                subgraph_outer_scope_node_arg_to_location_map));
       ORT_RETURN_IF_ERROR(subgraph_session_state.FinalizeSessionStateImpl(
-          graph_location, kernel_registry_manager, &node, subgraph_session_options, remove_initializers,
+          external_ini_path, kernel_registry_manager, &node, subgraph_session_options, remove_initializers,
           constant_initializers_use_count, subgraph_outer_scope_node_arg_to_location_map, true));
 
       // setup all the info for handling the feeds and fetches used in subgraph execution

--- a/onnxruntime/core/framework/session_state.h
+++ b/onnxruntime/core/framework/session_state.h
@@ -302,7 +302,7 @@ class SessionState {
   const InlinedHashSet<NodeIndex>* GetToBeExecutedRange(gsl::span<int const> fetch_mlvalue_idxs) const;
 #endif
 
-  Status FinalizeSessionState(const std::basic_string<PATH_CHAR_TYPE>& external_ini_path,
+  Status FinalizeSessionState(const std::basic_string<PATH_CHAR_TYPE>& external_data_path,
                               const KernelRegistryManager& kernel_registry_manager,
                               bool remove_initializers = true,
                               bool saving_ort_format = false);
@@ -384,7 +384,7 @@ class SessionState {
   Status PopulateKernelCreateInfo(const KernelRegistryManager& kernel_registry_manager,
                                   bool saving_ort_format);
 
-  Status FinalizeSessionStateImpl(const std::basic_string<PATH_CHAR_TYPE>& external_ini_path,
+  Status FinalizeSessionStateImpl(const std::basic_string<PATH_CHAR_TYPE>& external_data_path,
                                   const KernelRegistryManager& kernel_registry_manager,
                                   _In_opt_ const Node* parent_node,
                                   const SessionOptions& session_options,

--- a/onnxruntime/core/framework/session_state.h
+++ b/onnxruntime/core/framework/session_state.h
@@ -302,7 +302,7 @@ class SessionState {
   const InlinedHashSet<NodeIndex>* GetToBeExecutedRange(gsl::span<int const> fetch_mlvalue_idxs) const;
 #endif
 
-  Status FinalizeSessionState(const std::basic_string<PATH_CHAR_TYPE>& graph_loc,
+  Status FinalizeSessionState(const std::basic_string<PATH_CHAR_TYPE>& external_ini_path,
                               const KernelRegistryManager& kernel_registry_manager,
                               bool remove_initializers = true,
                               bool saving_ort_format = false);
@@ -384,7 +384,7 @@ class SessionState {
   Status PopulateKernelCreateInfo(const KernelRegistryManager& kernel_registry_manager,
                                   bool saving_ort_format);
 
-  Status FinalizeSessionStateImpl(const std::basic_string<PATH_CHAR_TYPE>& graph_loc,
+  Status FinalizeSessionStateImpl(const std::basic_string<PATH_CHAR_TYPE>& external_ini_path,
                                   const KernelRegistryManager& kernel_registry_manager,
                                   _In_opt_ const Node* parent_node,
                                   const SessionOptions& session_options,

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -188,7 +188,7 @@ static common::Status DeserializeTensorProto(const Env& env, const std::basic_st
 }
 
 common::Status SaveInitializedTensors(
-    const Env& env, const std::basic_string<PATH_CHAR_TYPE>& graph_loc,
+    const Env& env, const std::basic_string<PATH_CHAR_TYPE>& external_ini_path,
     const GraphViewer& graph, const AllocatorPtr& default_cpu_alloc,
     const OrtValueNameIdxMap& ort_value_name_idx_map,
     const std::vector<OrtValueIndex>& initializer_allocation_order,
@@ -317,7 +317,7 @@ common::Status SaveInitializedTensors(
       bool use_device_allocator_for_initializers =
           session_options.config_options.GetConfigOrDefault(kOrtSessionOptionsUseDeviceAllocatorForInitializers, "0") == "1";
 
-      Status st = DeserializeTensorProto(env, graph_loc, tensor_proto, (m.has_value()) ? &*m : nullptr, alloc,
+      Status st = DeserializeTensorProto(env, external_ini_path, tensor_proto, (m.has_value()) ? &*m : nullptr, alloc,
                                          default_cpu_alloc, ort_value, data_transfer_mgr,
                                          use_device_allocator_for_initializers);
       if (!st.IsOK()) {

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -188,7 +188,7 @@ static common::Status DeserializeTensorProto(const Env& env, const std::basic_st
 }
 
 common::Status SaveInitializedTensors(
-    const Env& env, const std::basic_string<PATH_CHAR_TYPE>& external_ini_path,
+    const Env& env, const std::basic_string<PATH_CHAR_TYPE>& external_data_path,
     const GraphViewer& graph, const AllocatorPtr& default_cpu_alloc,
     const OrtValueNameIdxMap& ort_value_name_idx_map,
     const std::vector<OrtValueIndex>& initializer_allocation_order,
@@ -317,7 +317,7 @@ common::Status SaveInitializedTensors(
       bool use_device_allocator_for_initializers =
           session_options.config_options.GetConfigOrDefault(kOrtSessionOptionsUseDeviceAllocatorForInitializers, "0") == "1";
 
-      Status st = DeserializeTensorProto(env, external_ini_path, tensor_proto, (m.has_value()) ? &*m : nullptr, alloc,
+      Status st = DeserializeTensorProto(env, external_data_path, tensor_proto, (m.has_value()) ? &*m : nullptr, alloc,
                                          default_cpu_alloc, ort_value, data_transfer_mgr,
                                          use_device_allocator_for_initializers);
       if (!st.IsOK()) {

--- a/onnxruntime/core/framework/session_state_utils.h
+++ b/onnxruntime/core/framework/session_state_utils.h
@@ -35,7 +35,7 @@ using SaveTensorFunction = std::function<Status(const std::string& name, int idx
 using MemoryProfileFunction = std::function<void(ITensorAllocator& planner)>;
 
 common::Status SaveInitializedTensors(
-    const Env& env, const std::basic_string<PATH_CHAR_TYPE>& graph_loc,
+    const Env& env, const std::basic_string<PATH_CHAR_TYPE>& external_ini_path,
     const GraphViewer& graph, const AllocatorPtr& default_cpu_memory_info,
     const OrtValueNameIdxMap& ort_value_name_idx_map, const std::vector<OrtValueIndex>& initializer_allocation_order,
     ITensorAllocator& planner,

--- a/onnxruntime/core/framework/session_state_utils.h
+++ b/onnxruntime/core/framework/session_state_utils.h
@@ -35,7 +35,7 @@ using SaveTensorFunction = std::function<Status(const std::string& name, int idx
 using MemoryProfileFunction = std::function<void(ITensorAllocator& planner)>;
 
 common::Status SaveInitializedTensors(
-    const Env& env, const std::basic_string<PATH_CHAR_TYPE>& external_ini_path,
+    const Env& env, const std::basic_string<PATH_CHAR_TYPE>& external_data_path,
     const GraphViewer& graph, const AllocatorPtr& default_cpu_memory_info,
     const OrtValueNameIdxMap& ort_value_name_idx_map, const std::vector<OrtValueIndex>& initializer_allocation_order,
     ITensorAllocator& planner,

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -803,9 +803,11 @@ Status GetExtDataFromTensorProto(const Env& env, const ORTCHAR_T* external_data_
                                  void*& ext_data_buf, SafeInt<size_t>& ext_data_len, OrtCallback& ext_data_deleter) {
   ORT_ENFORCE(utils::HasExternalData(tensor_proto));
   std::basic_string<ORTCHAR_T> external_data_file_path;
+  std::basic_string<ORTCHAR_T> tensor_proto_dir(external_data_path);
+  const ORTCHAR_T* t_prot_dir_s = tensor_proto_dir.size() == 0 ? nullptr : tensor_proto_dir.c_str();
   FileOffsetType file_offset;
   SafeInt<size_t> raw_data_safe_len = 0;
-  ORT_RETURN_IF_ERROR(GetExternalDataInfo(tensor_proto, external_data_path, external_data_file_path, file_offset,
+  ORT_RETURN_IF_ERROR(GetExternalDataInfo(tensor_proto, t_prot_dir_s, external_data_file_path, file_offset,
                                           raw_data_safe_len));
 
   if (external_data_file_path == onnxruntime::utils::kTensorProtoMemoryAddressTag) {

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -1407,7 +1407,7 @@ static void SparsifyGeneric(const void* dense_raw_data, size_t n_dense_elements,
 }
 
 common::Status DenseTensorToSparseTensorProto(const ONNX_NAMESPACE::TensorProto& dense_proto,
-                                              const Path& model_path,
+                                              const Path& external_ini_path,
                                               ONNX_NAMESPACE::SparseTensorProto& result) {
   ORT_ENFORCE(HasDataType(dense_proto), "Must have a valid data type");
 
@@ -1433,7 +1433,7 @@ common::Status DenseTensorToSparseTensorProto(const ONNX_NAMESPACE::TensorProto&
   size_t element_size = ml_data->Size();
 
   std::vector<uint8_t> dense_raw_data;
-  ORT_RETURN_IF_ERROR(UnpackInitializerData(dense_proto, model_path, dense_raw_data));
+  ORT_RETURN_IF_ERROR(UnpackInitializerData(dense_proto, external_ini_path, dense_raw_data));
 
   size_t nnz = 0;
   void* dense_data = dense_raw_data.data();
@@ -1501,7 +1501,7 @@ template common::Status GetSizeInBytesFromTensorProto<0>(const ONNX_NAMESPACE::T
   }
 
 Status UnpackInitializerData(const onnx::TensorProto& initializer,
-                             const Path& model_path,
+                             const Path& external_ini_folder_path,
                              std::vector<uint8_t>& unpacked_tensor) {
   // TODO, if std::vector does not use a custom allocator, the default std::allocator will
   // allocation the memory aligned to std::max_align_t, need look into allocating
@@ -1509,7 +1509,7 @@ Status UnpackInitializerData(const onnx::TensorProto& initializer,
   if (initializer.data_location() == TensorProto_DataLocation_EXTERNAL) {
     ORT_RETURN_IF_ERROR(ReadExternalDataForTensor(
         initializer,
-        (model_path.IsEmpty() || model_path.ParentPath().IsEmpty()) ? nullptr : model_path.ParentPath().ToPathString().c_str(),
+        external_ini_folder_path.IsEmpty() ? nullptr : external_ini_folder_path.ToPathString().c_str(),
         unpacked_tensor));
     return Status::OK();
   }

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -1071,7 +1071,7 @@ common::Status ConstantNodeProtoToTensorProto(const ONNX_NAMESPACE::NodeProto& n
       break;
     }
 #else
-      ORT_UNUSED_PARAMETER(model_path);
+      ORT_UNUSED_PARAMETER(external_data_path);
 #endif
     default:
       ORT_THROW("Unsupported attribute value type of ", constant_attribute.type(),

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -946,16 +946,16 @@ Status TensorProtoToTensor(const Env& env, const ORTCHAR_T* external_data_path,
   return Status::OK();
 }
 
-Status TensorProtoToOrtValue(const Env& env, const ORTCHAR_T* model_path,
+Status TensorProtoToOrtValue(const Env& env, const ORTCHAR_T* external_data_path,
                              const ONNX_NAMESPACE::TensorProto& tensor_proto,
                              const MemBuffer& m, OrtValue& value) {
-  return TensorProtoToOrtValueImpl(env, model_path, tensor_proto, &m, nullptr, value);
+  return TensorProtoToOrtValueImpl(env, external_data_path, tensor_proto, &m, nullptr, value);
 }
 
-Status TensorProtoToOrtValue(const Env& env, const ORTCHAR_T* model_path,
+Status TensorProtoToOrtValue(const Env& env, const ORTCHAR_T* external_data_path,
                              const ONNX_NAMESPACE::TensorProto& tensor_proto,
                              AllocatorPtr alloc, OrtValue& value) {
-  return TensorProtoToOrtValueImpl(env, model_path, tensor_proto, nullptr, alloc, value);
+  return TensorProtoToOrtValueImpl(env, external_data_path, tensor_proto, nullptr, alloc, value);
 }
 
 #define CASE_TYPE(X)                             \

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -802,12 +802,10 @@ Status GetExtDataFromTensorProto(const Env& env, const ORTCHAR_T* external_data_
                                  const ONNX_NAMESPACE::TensorProto& tensor_proto,
                                  void*& ext_data_buf, SafeInt<size_t>& ext_data_len, OrtCallback& ext_data_deleter) {
   ORT_ENFORCE(utils::HasExternalData(tensor_proto));
-  std::basic_string<ORTCHAR_T> tensor_proto_dir(external_data_path);
-  const ORTCHAR_T* t_prot_dir_s = tensor_proto_dir.empty() ? nullptr : tensor_proto_dir.c_str();
   std::basic_string<ORTCHAR_T> external_data_file_path;
   FileOffsetType file_offset;
   SafeInt<size_t> raw_data_safe_len = 0;
-  ORT_RETURN_IF_ERROR(GetExternalDataInfo(tensor_proto, t_prot_dir_s, external_data_file_path, file_offset,
+  ORT_RETURN_IF_ERROR(GetExternalDataInfo(tensor_proto, external_data_path, external_data_file_path, file_offset,
                                           raw_data_safe_len));
 
   if (external_data_file_path == onnxruntime::utils::kTensorProtoMemoryAddressTag) {

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -798,15 +798,12 @@ static Status GetFileContent(
   return Status::OK();
 }
 
-Status GetExtDataFromTensorProto(const Env& env, const ORTCHAR_T* model_path,
+Status GetExtDataFromTensorProto(const Env& env, const ORTCHAR_T* external_ini_path,
                                  const ONNX_NAMESPACE::TensorProto& tensor_proto,
                                  void*& ext_data_buf, SafeInt<size_t>& ext_data_len, OrtCallback& ext_data_deleter) {
   ORT_ENFORCE(utils::HasExternalData(tensor_proto));
-  std::basic_string<ORTCHAR_T> tensor_proto_dir;
-  if (model_path != nullptr) {
-    ORT_RETURN_IF_ERROR(GetDirNameFromFilePath(model_path, tensor_proto_dir));
-  }
-  const ORTCHAR_T* t_prot_dir_s = tensor_proto_dir.size() == 0 ? nullptr : tensor_proto_dir.c_str();
+  std::basic_string<ORTCHAR_T> tensor_proto_dir(external_ini_path);
+  const ORTCHAR_T* t_prot_dir_s = tensor_proto_dir.empty() ? nullptr : tensor_proto_dir.c_str();
   std::basic_string<ORTCHAR_T> external_data_file_path;
   FileOffsetType file_offset;
   SafeInt<size_t> raw_data_safe_len = 0;

--- a/onnxruntime/core/framework/tensorprotoutils.h
+++ b/onnxruntime/core/framework/tensorprotoutils.h
@@ -110,23 +110,23 @@ common::Status GetExtDataFromTensorProto(const Env& env, const ORTCHAR_T* model_
 // the data location is external. i.e. it does not load the external data.
 // However if AttributeProto contains SparseTensorProto then it converts the data into dense tensor proto
 // (including loading external data when applicable).
-// model_path is used for contructing full path for external_data
+// external_ini_path is used for contructing full path for external_data
 // tensor_name specifies the name for the new TensorProto TensorProto
 common::Status ConstantNodeProtoToTensorProto(const ONNX_NAMESPACE::NodeProto& node,
-                                              const Path& model_path,
+                                              const Path& external_ini_path,
                                               ONNX_NAMESPACE::TensorProto& tensor, const std::string& tensor_name);
 
 common::Status ConstantNodeProtoToTensorProto(const ONNX_NAMESPACE::NodeProto& node,
-                                              const Path& model_path,
+                                              const Path& external_ini_path,
                                               ONNX_NAMESPACE::TensorProto& tensor);
 
 #if !defined(DISABLE_SPARSE_TENSORS)
 // Convert a SparseTensorProto to a dense TensorProto
 // If the SparseTensorProto contains external data then it loads the data and converts to dense tensor proto
 // The resulting TensorProto will contain the data as raw data.
-// model_path is used for constructing full path for external_data
+// external_ini_path is used for constructing full path for external_data
 common::Status SparseTensorProtoToDenseTensorProto(const ONNX_NAMESPACE::SparseTensorProto& sparse,
-                                                   const Path& model_path,
+                                                   const Path& external_ini_path,
                                                    ONNX_NAMESPACE::TensorProto& dense);
 
 #if !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/core/framework/tensorprotoutils.h
+++ b/onnxruntime/core/framework/tensorprotoutils.h
@@ -124,7 +124,7 @@ common::Status ConstantNodeProtoToTensorProto(const ONNX_NAMESPACE::NodeProto& n
 // Convert a SparseTensorProto to a dense TensorProto
 // If the SparseTensorProto contains external data then it loads the data and converts to dense tensor proto
 // The resulting TensorProto will contain the data as raw data.
-// model_path is used for contructing full path for external_data
+// model_path is used for constructing full path for external_data
 common::Status SparseTensorProtoToDenseTensorProto(const ONNX_NAMESPACE::SparseTensorProto& sparse,
                                                    const Path& model_path,
                                                    ONNX_NAMESPACE::TensorProto& dense);
@@ -133,9 +133,9 @@ common::Status SparseTensorProtoToDenseTensorProto(const ONNX_NAMESPACE::SparseT
 // Convert a TensorProto to a SparseTensorProto
 // If the tensorproto contains external data then it loads the data and converts to sparse tensor
 // The resulting SparseTensorProto will contain the data as raw data
-// model_path is used for contructing full path for external_data
+// external_ini_path is used for constructing full path for external_data
 common::Status DenseTensorToSparseTensorProto(const ONNX_NAMESPACE::TensorProto& dense,
-                                              const Path& model_path,
+                                              const Path& external_ini_path,
                                               ONNX_NAMESPACE::SparseTensorProto& sparse);
 #endif  // !ORT_MINIMAL_BUILD
 #endif  // !defined(DISABLE_SPARSE_TENSORS)
@@ -452,13 +452,13 @@ Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const Path& model
 /**
  * Unpack the data from an initializer tensor
  * Please note, this function does not unpack string_data of an initializer tensor
- * @param initializer       given initializer tensor
- * @param model_path        model_path to construct external data dir path. When this is empty, current dir is used.
- * @param unpacked_tensor   the vector holds data from the initializer in byte form
- * @returns                 Status::OK() if data is unpacked successfully
+ * @param initializer               given initializer tensor
+ * @param external_ini_folder_path  external data dir path. When this is empty, current dir is used.
+ * @param unpacked_tensor           the vector holds data from the initializer in byte form
+ * @returns                         Status::OK() if data is unpacked successfully
  */
 common::Status UnpackInitializerData(const ONNX_NAMESPACE::TensorProto& initializer,
-                                     const Path& model_path,
+                                     const Path& external_ini_folder_path,
                                      std::vector<uint8_t>& unpacked_tensor);
 
 /**

--- a/onnxruntime/core/framework/tensorprotoutils.h
+++ b/onnxruntime/core/framework/tensorprotoutils.h
@@ -100,7 +100,7 @@ constexpr const ORTCHAR_T* kTensorProtoMemoryAddressTag = ORT_TSTR("*/_ORT_MEM_A
 
 // Given a tensor proto with external data obtain a pointer to the data and its length.
 // The ext_data_deleter argument is updated with a callback that owns/releases the data.
-common::Status GetExtDataFromTensorProto(const Env& env, const ORTCHAR_T* model_path,
+common::Status GetExtDataFromTensorProto(const Env& env, const ORTCHAR_T* external_ini_path,
                                          const ONNX_NAMESPACE::TensorProto& tensor_proto,
                                          void*& ext_data_buf, SafeInt<size_t>& ext_data_len,
                                          OrtCallback& ext_data_deleter);

--- a/onnxruntime/core/framework/tensorprotoutils.h
+++ b/onnxruntime/core/framework/tensorprotoutils.h
@@ -40,7 +40,7 @@ TensorShape GetTensorShapeFromTensorProto(const ONNX_NAMESPACE::TensorProto& ten
 
 /**
  * deserialize a TensorProto into a preallocated memory buffer on CPU.
- * \param tensor_proto_path A local file path of where the 'input' was loaded from.
+ * \param tensor_proto_path A local folder path of where the 'input' was loaded from.
  *                          Can be NULL if the tensor proto doesn't have external data or it was loaded from
  *                          the current working dir. This path could be either a relative path or an absolute path.
  * \return Status::OK on success with 'value' containing the Tensor in CPU based memory.
@@ -51,7 +51,7 @@ common::Status TensorProtoToOrtValue(const Env& env, const ORTCHAR_T* tensor_pro
 
 /**
  * deserialize a TensorProto into a buffer on CPU allocated using 'alloc'.
- * \param tensor_proto_path A local file path of where the 'input' was loaded from.
+ * \param tensor_proto_path A local folder path of where the 'input' was loaded from.
  *                          Can be NULL if the tensor proto doesn't have external data or it was loaded from
  *                          the current working dir. This path could be either a relative path or an absolute path.
  * \param alloc             Allocator to use for allocating the buffer. Must allocate CPU based memory.

--- a/onnxruntime/core/framework/tensorprotoutils.h
+++ b/onnxruntime/core/framework/tensorprotoutils.h
@@ -64,12 +64,12 @@ common::Status TensorProtoToOrtValue(const Env& env, const ORTCHAR_T* tensor_pro
 /**
  * @brief Deserialize a TensorProto into a preallocated empty Tensor
  * @param env
- * @param model_path
+ * @param external_data_path
  * @param tensor_proto  source data
  * @param tensorp       destination empty tensor
  * @return
  */
-common::Status TensorProtoToTensor(const Env& env, const ORTCHAR_T* model_path,
+common::Status TensorProtoToTensor(const Env& env, const ORTCHAR_T* external_data_path,
                                    const ONNX_NAMESPACE::TensorProto& tensor_proto,
                                    Tensor& tensor);
 

--- a/onnxruntime/core/framework/tensorprotoutils.h
+++ b/onnxruntime/core/framework/tensorprotoutils.h
@@ -100,7 +100,7 @@ constexpr const ORTCHAR_T* kTensorProtoMemoryAddressTag = ORT_TSTR("*/_ORT_MEM_A
 
 // Given a tensor proto with external data obtain a pointer to the data and its length.
 // The ext_data_deleter argument is updated with a callback that owns/releases the data.
-common::Status GetExtDataFromTensorProto(const Env& env, const ORTCHAR_T* external_ini_path,
+common::Status GetExtDataFromTensorProto(const Env& env, const ORTCHAR_T* external_data_path,
                                          const ONNX_NAMESPACE::TensorProto& tensor_proto,
                                          void*& ext_data_buf, SafeInt<size_t>& ext_data_len,
                                          OrtCallback& ext_data_deleter);
@@ -110,32 +110,32 @@ common::Status GetExtDataFromTensorProto(const Env& env, const ORTCHAR_T* extern
 // the data location is external. i.e. it does not load the external data.
 // However if AttributeProto contains SparseTensorProto then it converts the data into dense tensor proto
 // (including loading external data when applicable).
-// external_ini_path is used for contructing full path for external_data
+// external_data_path is used for constructing full path for external_data
 // tensor_name specifies the name for the new TensorProto TensorProto
 common::Status ConstantNodeProtoToTensorProto(const ONNX_NAMESPACE::NodeProto& node,
-                                              const Path& external_ini_path,
+                                              const Path& external_data_path,
                                               ONNX_NAMESPACE::TensorProto& tensor, const std::string& tensor_name);
 
 common::Status ConstantNodeProtoToTensorProto(const ONNX_NAMESPACE::NodeProto& node,
-                                              const Path& external_ini_path,
+                                              const Path& external_data_path,
                                               ONNX_NAMESPACE::TensorProto& tensor);
 
 #if !defined(DISABLE_SPARSE_TENSORS)
 // Convert a SparseTensorProto to a dense TensorProto
 // If the SparseTensorProto contains external data then it loads the data and converts to dense tensor proto
 // The resulting TensorProto will contain the data as raw data.
-// external_ini_path is used for constructing full path for external_data
+// external_data_path is used for constructing full path for external_data
 common::Status SparseTensorProtoToDenseTensorProto(const ONNX_NAMESPACE::SparseTensorProto& sparse,
-                                                   const Path& external_ini_path,
+                                                   const Path& external_data_path,
                                                    ONNX_NAMESPACE::TensorProto& dense);
 
 #if !defined(ORT_MINIMAL_BUILD)
 // Convert a TensorProto to a SparseTensorProto
 // If the tensorproto contains external data then it loads the data and converts to sparse tensor
 // The resulting SparseTensorProto will contain the data as raw data
-// external_ini_path is used for constructing full path for external_data
+// external_data_path is used for constructing full path for external_data
 common::Status DenseTensorToSparseTensorProto(const ONNX_NAMESPACE::TensorProto& dense,
-                                              const Path& external_ini_path,
+                                              const Path& external_data_path,
                                               ONNX_NAMESPACE::SparseTensorProto& sparse);
 #endif  // !ORT_MINIMAL_BUILD
 #endif  // !defined(DISABLE_SPARSE_TENSORS)
@@ -453,12 +453,12 @@ Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const Path& model
  * Unpack the data from an initializer tensor
  * Please note, this function does not unpack string_data of an initializer tensor
  * @param initializer               given initializer tensor
- * @param external_ini_folder_path  external data dir path. When this is empty, current dir is used.
+ * @param external_data_folder_path  external data dir path. When this is empty, current dir is used.
  * @param unpacked_tensor           the vector holds data from the initializer in byte form
  * @returns                         Status::OK() if data is unpacked successfully
  */
 common::Status UnpackInitializerData(const ONNX_NAMESPACE::TensorProto& initializer,
-                                     const Path& external_ini_folder_path,
+                                     const Path& external_data_folder_path,
                                      std::vector<uint8_t>& unpacked_tensor);
 
 /**

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -2861,6 +2861,10 @@ const Path& Graph::ModelPath() const {
   return owning_model_.ModelPath();
 }
 
+const Path& Graph::ExternalIniPath() const {
+  return owning_model_.ExternalIniPath();
+}
+
 template <typename T, typename TIter>
 static void RemoveRepeatedFieldEntry(T& repeated_field, const TIter& entry_to_remove) {
   auto num_entries = repeated_field.size();
@@ -3411,7 +3415,7 @@ ONNX_NAMESPACE::GraphProto Graph::ToGraphProtoWithExternalInitializers(const std
   int64_t external_offset = 0;
 
   // Add the initializers to the result graph.
-  const auto& model_path = ModelPath();
+  const auto& external_ini_path = ExternalIniPath();
 #if !defined(DISABLE_SPARSE_TENSORS)
   const auto sparse_end = sparse_tensor_names_.end();
 #endif
@@ -3421,7 +3425,7 @@ ONNX_NAMESPACE::GraphProto Graph::ToGraphProtoWithExternalInitializers(const std
     if (sparse_end != sparse_tensor_names_.find(initializer.name())) {
       // Sparse tensors are added to the ONNX file.
       auto& sparse_initializer = *result.add_sparse_initializer();
-      auto status = utils::DenseTensorToSparseTensorProto(initializer, model_path, sparse_initializer);
+      auto status = utils::DenseTensorToSparseTensorProto(initializer, external_ini_path, sparse_initializer);
       ORT_ENFORCE(status.IsOK(), "Failed to convert dense initializer to sparse");
     } else {
 #endif
@@ -3429,7 +3433,7 @@ ONNX_NAMESPACE::GraphProto Graph::ToGraphProtoWithExternalInitializers(const std
       TensorProto* output_proto = result.add_initializer();
 
       std::vector<uint8_t> raw_data;
-      ORT_THROW_IF_ERROR(utils::UnpackInitializerData(initializer, model_path, raw_data));
+      ORT_THROW_IF_ERROR(utils::UnpackInitializerData(initializer, external_ini_path, raw_data));
       size_t tensor_bytes_size = raw_data.size();
       if (tensor_bytes_size < initializer_size_threshold) {
         *output_proto = initializer;

--- a/onnxruntime/core/graph/graph_flatbuffers_utils.cc
+++ b/onnxruntime/core/graph/graph_flatbuffers_utils.cc
@@ -28,7 +28,7 @@ SaveDims(flatbuffers::FlatBufferBuilder& builder, const DimsFieldType& dims) {
 
 Status SaveInitializerOrtFormat(flatbuffers::FlatBufferBuilder& builder,
                                 const TensorProto& initializer,
-                                const Path& external_ini_path,
+                                const Path& external_data_path,
                                 flatbuffers::Offset<fbs::Tensor>& fbs_tensor) {
   auto name = SaveStringToOrtFormat(builder, initializer.has_name(), initializer.name());
   auto doc_string = SaveStringToOrtFormat(builder, initializer.has_doc_string(), initializer.doc_string());
@@ -46,7 +46,7 @@ Status SaveInitializerOrtFormat(flatbuffers::FlatBufferBuilder& builder,
   } else {
     std::vector<uint8_t> unpacked_tensor;
     ORT_RETURN_IF_ERROR(
-        onnxruntime::utils::UnpackInitializerData(initializer, external_ini_path, unpacked_tensor));
+        onnxruntime::utils::UnpackInitializerData(initializer, external_data_path, unpacked_tensor));
     raw_data = builder.CreateVector(unpacked_tensor.data(), unpacked_tensor.size());
   }
 
@@ -66,17 +66,17 @@ Status SaveInitializerOrtFormat(flatbuffers::FlatBufferBuilder& builder,
 #if !defined(DISABLE_SPARSE_TENSORS)
 Status SaveSparseInitializerOrtFormat(flatbuffers::FlatBufferBuilder& builder,
                                       const ONNX_NAMESPACE::SparseTensorProto& initializer,
-                                      const Path& external_ini_path,
+                                      const Path& external_data_path,
                                       flatbuffers::Offset<fbs::SparseTensor>& fbs_sparse_tensor) {
   // values
   const auto& values = initializer.values();
   flatbuffers::Offset<fbs::Tensor> values_off;
-  ORT_RETURN_IF_ERROR(SaveInitializerOrtFormat(builder, values, external_ini_path, values_off));
+  ORT_RETURN_IF_ERROR(SaveInitializerOrtFormat(builder, values, external_data_path, values_off));
 
   // Indicies
   const auto& indicies = initializer.indices();
   flatbuffers::Offset<fbs::Tensor> indicies_off;
-  ORT_RETURN_IF_ERROR(SaveInitializerOrtFormat(builder, indicies, external_ini_path, indicies_off));
+  ORT_RETURN_IF_ERROR(SaveInitializerOrtFormat(builder, indicies, external_data_path, indicies_off));
 
   // Shape
   auto shape = SaveDims(builder, initializer.dims());
@@ -107,7 +107,7 @@ Status SaveSparseInitializerOrtFormat(flatbuffers::FlatBufferBuilder& builder,
 Status SaveAttributeOrtFormat(flatbuffers::FlatBufferBuilder& builder,
                               const AttributeProto& attr_proto,
                               flatbuffers::Offset<fbs::Attribute>& fbs_attr,
-                              const Path& external_ini_path,
+                              const Path& external_data_path,
                               const onnxruntime::Graph* subgraph) {
   auto name = SaveStringToOrtFormat(builder, attr_proto.has_name(), attr_proto.name());
   auto doc_string = SaveStringToOrtFormat(builder, attr_proto.has_doc_string(), attr_proto.doc_string());
@@ -126,7 +126,7 @@ Status SaveAttributeOrtFormat(flatbuffers::FlatBufferBuilder& builder,
     case fbs::AttributeType::TENSOR: {
       flatbuffers::Offset<fbs::Tensor> fbs_tensor;
       ORT_RETURN_IF_ERROR(
-          SaveInitializerOrtFormat(builder, attr_proto.t(), external_ini_path, fbs_tensor));
+          SaveInitializerOrtFormat(builder, attr_proto.t(), external_data_path, fbs_tensor));
       GET_FBS_ATTR(builder, type, t, fbs_tensor);
     } break;
     case fbs::AttributeType::GRAPH: {
@@ -156,7 +156,7 @@ Status SaveAttributeOrtFormat(flatbuffers::FlatBufferBuilder& builder,
       for (const auto& tensor : attr_proto.tensors()) {
         flatbuffers::Offset<fbs::Tensor> fbs_tensor;
         ORT_RETURN_IF_ERROR(
-            SaveInitializerOrtFormat(builder, tensor, external_ini_path, fbs_tensor));
+            SaveInitializerOrtFormat(builder, tensor, external_data_path, fbs_tensor));
         fbs_tensors_vec.push_back(fbs_tensor);
       }
       auto tensors = builder.CreateVector(fbs_tensors_vec);

--- a/onnxruntime/core/graph/graph_flatbuffers_utils.h
+++ b/onnxruntime/core/graph/graph_flatbuffers_utils.h
@@ -42,12 +42,12 @@ namespace utils {
 
 Status SaveInitializerOrtFormat(
     flatbuffers::FlatBufferBuilder& builder, const ONNX_NAMESPACE::TensorProto& initializer,
-    const Path& external_ini_path, flatbuffers::Offset<fbs::Tensor>& fbs_tensor);
+    const Path& external_data_path, flatbuffers::Offset<fbs::Tensor>& fbs_tensor);
 
 #if !defined(DISABLE_SPARSE_TENSORS)
 Status SaveSparseInitializerOrtFormat(
     flatbuffers::FlatBufferBuilder& builder, const ONNX_NAMESPACE::SparseTensorProto& initializer,
-    const Path& external_ini_path, flatbuffers::Offset<fbs::SparseTensor>& fbs_sparse_tensor);
+    const Path& external_data_path, flatbuffers::Offset<fbs::SparseTensor>& fbs_sparse_tensor);
 #endif  // !defined(DISABLE_SPARSE_TENSORS)
 
 // Convert a given AttributeProto into fbs::Attribute
@@ -56,7 +56,7 @@ Status SaveSparseInitializerOrtFormat(
 //       instead of the GraphProto in attr_proto
 Status SaveAttributeOrtFormat(
     flatbuffers::FlatBufferBuilder& builder, const ONNX_NAMESPACE::AttributeProto& attr_proto,
-    flatbuffers::Offset<fbs::Attribute>& fbs_attr, const Path& external_ini_path,
+    flatbuffers::Offset<fbs::Attribute>& fbs_attr, const Path& external_data_path,
     const onnxruntime::Graph* subgraph);
 
 /// <summary>

--- a/onnxruntime/core/graph/graph_flatbuffers_utils.h
+++ b/onnxruntime/core/graph/graph_flatbuffers_utils.h
@@ -42,12 +42,12 @@ namespace utils {
 
 Status SaveInitializerOrtFormat(
     flatbuffers::FlatBufferBuilder& builder, const ONNX_NAMESPACE::TensorProto& initializer,
-    const Path& model_path, flatbuffers::Offset<fbs::Tensor>& fbs_tensor);
+    const Path& external_ini_path, flatbuffers::Offset<fbs::Tensor>& fbs_tensor);
 
 #if !defined(DISABLE_SPARSE_TENSORS)
 Status SaveSparseInitializerOrtFormat(
     flatbuffers::FlatBufferBuilder& builder, const ONNX_NAMESPACE::SparseTensorProto& initializer,
-    const Path& model_path, flatbuffers::Offset<fbs::SparseTensor>& fbs_sparse_tensor);
+    const Path& external_ini_path, flatbuffers::Offset<fbs::SparseTensor>& fbs_sparse_tensor);
 #endif  // !defined(DISABLE_SPARSE_TENSORS)
 
 // Convert a given AttributeProto into fbs::Attribute
@@ -56,7 +56,7 @@ Status SaveSparseInitializerOrtFormat(
 //       instead of the GraphProto in attr_proto
 Status SaveAttributeOrtFormat(
     flatbuffers::FlatBufferBuilder& builder, const ONNX_NAMESPACE::AttributeProto& attr_proto,
-    flatbuffers::Offset<fbs::Attribute>& fbs_attr, const Path& model_path,
+    flatbuffers::Offset<fbs::Attribute>& fbs_attr, const Path& external_ini_path,
     const onnxruntime::Graph* subgraph);
 
 /// <summary>

--- a/onnxruntime/core/graph/model.cc
+++ b/onnxruntime/core/graph/model.cc
@@ -82,6 +82,7 @@ Model::Model(const std::string& graph_name,
              const logging::Logger& logger,
              const ModelOptions& options)
     : model_path_(Path::Parse(model_path)) {
+  external_ini_path_ = model_path_.ParentPath();
   model_proto_.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
   model_proto_.mutable_graph()->set_name(graph_name);
   model_metadata_ = model_metadata;
@@ -160,6 +161,7 @@ Model::Model(ModelProto&& model_proto, const PathString& model_path,
              const IOnnxRuntimeOpSchemaRegistryList* local_registries,
              const logging::Logger& logger, const ModelOptions& options)
     : model_path_(Path::Parse(model_path)) {
+  external_ini_path_ = model_path_.ParentPath();
   if (!utils::HasGraph(model_proto)) {
     ORT_THROW("ModelProto does not have a graph.");
   }

--- a/onnxruntime/core/graph/model.cc
+++ b/onnxruntime/core/graph/model.cc
@@ -81,8 +81,7 @@ Model::Model(const std::string& graph_name,
              const std::vector<ONNX_NAMESPACE::FunctionProto>& model_local_functions,
              const logging::Logger& logger,
              const ModelOptions& options)
-    : model_path_(std::move(Path::Parse(model_path)))
-    , external_data_path_(std::move(model_path_.ParentPath())) {
+    : model_path_(std::move(Path::Parse(model_path))), external_data_path_(std::move(model_path_.ParentPath())) {
   model_proto_.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
   model_proto_.mutable_graph()->set_name(graph_name);
   model_metadata_ = model_metadata;
@@ -160,8 +159,7 @@ Model::Model(const ModelProto& model_proto, const PathString& model_path,
 Model::Model(ModelProto&& model_proto, const PathString& model_path,
              const IOnnxRuntimeOpSchemaRegistryList* local_registries,
              const logging::Logger& logger, const ModelOptions& options)
-    : model_path_(std::move(Path::Parse(model_path)))
-    , external_data_path_(std::move(model_path_.ParentPath())) {
+    : model_path_(std::move(Path::Parse(model_path))), external_data_path_(std::move(model_path_.ParentPath())) {
   if (!utils::HasGraph(model_proto)) {
     ORT_THROW("ModelProto does not have a graph.");
   }

--- a/onnxruntime/core/graph/model.cc
+++ b/onnxruntime/core/graph/model.cc
@@ -82,7 +82,7 @@ Model::Model(const std::string& graph_name,
              const logging::Logger& logger,
              const ModelOptions& options)
     : model_path_(Path::Parse(model_path)) {
-  external_ini_path_ = model_path_.ParentPath();
+  external_data_path_ = model_path_.ParentPath();
   model_proto_.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
   model_proto_.mutable_graph()->set_name(graph_name);
   model_metadata_ = model_metadata;
@@ -161,7 +161,7 @@ Model::Model(ModelProto&& model_proto, const PathString& model_path,
              const IOnnxRuntimeOpSchemaRegistryList* local_registries,
              const logging::Logger& logger, const ModelOptions& options)
     : model_path_(Path::Parse(model_path)) {
-  external_ini_path_ = model_path_.ParentPath();
+  external_data_path_ = model_path_.ParentPath();
   if (!utils::HasGraph(model_proto)) {
     ORT_THROW("ModelProto does not have a graph.");
   }

--- a/onnxruntime/core/graph/model.cc
+++ b/onnxruntime/core/graph/model.cc
@@ -81,8 +81,8 @@ Model::Model(const std::string& graph_name,
              const std::vector<ONNX_NAMESPACE::FunctionProto>& model_local_functions,
              const logging::Logger& logger,
              const ModelOptions& options)
-    : model_path_(Path::Parse(model_path)) {
-  external_data_path_ = model_path_.ParentPath();
+    : model_path_(std::move(Path::Parse(model_path)))
+    , external_data_path_(std::move(model_path_.ParentPath())) {
   model_proto_.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
   model_proto_.mutable_graph()->set_name(graph_name);
   model_metadata_ = model_metadata;
@@ -160,8 +160,8 @@ Model::Model(const ModelProto& model_proto, const PathString& model_path,
 Model::Model(ModelProto&& model_proto, const PathString& model_path,
              const IOnnxRuntimeOpSchemaRegistryList* local_registries,
              const logging::Logger& logger, const ModelOptions& options)
-    : model_path_(Path::Parse(model_path)) {
-  external_data_path_ = model_path_.ParentPath();
+    : model_path_(std::move(Path::Parse(model_path)))
+    , external_data_path_(std::move(model_path_.ParentPath())) {
   if (!utils::HasGraph(model_proto)) {
     ORT_THROW("ModelProto does not have a graph.");
   }

--- a/onnxruntime/core/graph/model.cc
+++ b/onnxruntime/core/graph/model.cc
@@ -81,7 +81,7 @@ Model::Model(const std::string& graph_name,
              const std::vector<ONNX_NAMESPACE::FunctionProto>& model_local_functions,
              const logging::Logger& logger,
              const ModelOptions& options)
-    : model_path_(std::move(Path::Parse(model_path))), external_data_path_(std::move(model_path_.ParentPath())) {
+    : model_path_(Path::Parse(model_path)), external_data_path_(model_path_.ParentPath()) {
   model_proto_.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
   model_proto_.mutable_graph()->set_name(graph_name);
   model_metadata_ = model_metadata;
@@ -159,7 +159,7 @@ Model::Model(const ModelProto& model_proto, const PathString& model_path,
 Model::Model(ModelProto&& model_proto, const PathString& model_path,
              const IOnnxRuntimeOpSchemaRegistryList* local_registries,
              const logging::Logger& logger, const ModelOptions& options)
-    : model_path_(std::move(Path::Parse(model_path))), external_data_path_(std::move(model_path_.ParentPath())) {
+    : model_path_(Path::Parse(model_path)), external_data_path_(model_path_.ParentPath()) {
   if (!utils::HasGraph(model_proto)) {
     ORT_THROW("ModelProto does not have a graph.");
   }

--- a/onnxruntime/core/graph/model.h
+++ b/onnxruntime/core/graph/model.h
@@ -177,10 +177,10 @@ class Model {
   const Path& ModelPath() const noexcept { return model_path_; }
 
   // Gets the folder path for the external initializer data
-  const Path& ExternalIniPath() const noexcept { return external_ini_path_; }
+  const Path& ExternalDataPath() const noexcept { return external_data_path_; }
 
-  void SetExternalIniPath(const PathString& external_ini_path) {
-    external_ini_path_ = Path::Parse(external_ini_path);
+  void SetExternalDataPath(const PathString& external_data_path) {
+    external_data_path_ = Path::Parse(external_data_path);
   }
 
   // Get model's main graph.
@@ -354,6 +354,6 @@ class Model {
   std::unique_ptr<Graph> graph_;
 
   // Path to external initializer data folder. May be empty
-  Path external_ini_path_;
+  Path external_data_path_;
 };
 }  // namespace onnxruntime

--- a/onnxruntime/core/graph/model.h
+++ b/onnxruntime/core/graph/model.h
@@ -176,6 +176,13 @@ class Model {
   // Gets the path from which the model was loaded, if any.
   const Path& ModelPath() const noexcept { return model_path_; }
 
+  // Gets the folder path for the external initializer data
+  const Path& ExternalIniPath() const noexcept { return external_ini_path_; }
+
+  void SetExternalIniPath(const PathString& external_ini_path) {
+    external_ini_path_ = Path::Parse(external_ini_path);
+  }
+
   // Get model's main graph.
   Graph& MainGraph() noexcept;
   const Graph& MainGraph() const noexcept;
@@ -345,5 +352,8 @@ class Model {
 
   // Main graph of the model.
   std::unique_ptr<Graph> graph_;
+
+  // Path to external initializer data folder. May be empty
+  Path external_ini_path_;
 };
 }  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/initializer.cc
+++ b/onnxruntime/core/optimizer/initializer.cc
@@ -25,11 +25,11 @@ Initializer::Initializer(ONNX_NAMESPACE::TensorProto_DataType data_type,
   }
 }
 
-Initializer::Initializer(const ONNX_NAMESPACE::TensorProto& tensor_proto, const Path& model_path) {
+Initializer::Initializer(const ONNX_NAMESPACE::TensorProto& tensor_proto, const Path& external_data_path) {
   ORT_ENFORCE(utils::HasDataType(tensor_proto), "Initializer must have a datatype");
   if (utils::HasExternalData(tensor_proto)) {
-    ORT_ENFORCE(!model_path.IsEmpty(),
-                "model_path must not be empty. Ensure that a path is provided when the model is created or loaded.");
+    ORT_ENFORCE(!external_data_path.IsEmpty(),
+                "external_data_path must not be empty. Ensure that a path is provided when the model is created or loaded.");
   }
 
   auto proto_data_type = tensor_proto.data_type();
@@ -42,7 +42,7 @@ Initializer::Initializer(const ONNX_NAMESPACE::TensorProto& tensor_proto, const 
   // This must be pre-allocated
   Tensor w(DataTypeImpl::TensorTypeFromONNXEnum(proto_data_type)->GetElementType(), proto_shape,
            std::make_shared<CPUAllocator>());
-  ORT_THROW_IF_ERROR(utils::TensorProtoToTensor(Env::Default(), model_path.ToPathString().c_str(), tensor_proto, w));
+  ORT_THROW_IF_ERROR(utils::TensorProtoToTensor(Env::Default(), external_data_path.ToPathString().c_str(), tensor_proto, w));
   data_ = std::move(w);
 }
 

--- a/onnxruntime/core/optimizer/initializer.h
+++ b/onnxruntime/core/optimizer/initializer.h
@@ -28,7 +28,7 @@ class Initializer final {
               gsl::span<const int64_t> dims);
 
   Initializer(const ONNX_NAMESPACE::TensorProto& tensor_proto,
-              const Path& model_path = {});
+              const Path& external_data_path = {});
 
   ~Initializer() = default;
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionHelper.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionHelper.cpp
@@ -115,7 +115,7 @@ namespace DmlGraphFusionHelper
         // The tensor may be stored as raw data or in typed fields.
         if (initializer->data_location() == onnx::TensorProto_DataLocation_EXTERNAL)
         {
-            THROW_IF_NOT_OK(onnxruntime::utils::UnpackInitializerData(*initializer, graph.ExternalIniPath(), unpackedExternalTensor));
+            THROW_IF_NOT_OK(onnxruntime::utils::UnpackInitializerData(*initializer, graph.ExternalDataPath(), unpackedExternalTensor));
             tensorPtr = reinterpret_cast<std::byte*>(unpackedExternalTensor.data());
             tensorByteSize = unpackedExternalTensor.size();
         }

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionHelper.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionHelper.cpp
@@ -115,7 +115,7 @@ namespace DmlGraphFusionHelper
         // The tensor may be stored as raw data or in typed fields.
         if (initializer->data_location() == onnx::TensorProto_DataLocation_EXTERNAL)
         {
-            THROW_IF_NOT_OK(onnxruntime::utils::UnpackInitializerData(*initializer, graph.ModelPath(), unpackedExternalTensor));
+            THROW_IF_NOT_OK(onnxruntime::utils::UnpackInitializerData(*initializer, graph.ExternalIniPath(), unpackedExternalTensor));
             tensorPtr = reinterpret_cast<std::byte*>(unpackedExternalTensor.data());
             tensorByteSize = unpackedExternalTensor.size();
         }

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/slice_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/slice_op_builder.cc
@@ -92,9 +92,8 @@ static Status GetInitializerInputData(const NodeUnitIODef& input, const QnnModel
   Tensor tensor(dtype, shape, std::make_shared<CPUAllocator>());
 
   // Deserialize initializer into Tensor.
-  onnxruntime::PathString model_path = qnn_model_wrapper.GetGraphViewer().ModelPath().ToPathString();
-  const ORTCHAR_T* model_path_str = model_path.empty() ? nullptr : model_path.c_str();
-  ORT_RETURN_IF_ERROR(onnxruntime::utils::TensorProtoToTensor(onnxruntime::Env::Default(), model_path_str,
+  ORT_RETURN_IF_ERROR(onnxruntime::utils::TensorProtoToTensor(onnxruntime::Env::Default(),
+                                                              qnn_model_wrapper.GetGraphViewer().ExternalDataPath().ToPathString().c_str(),
                                                               *initializer_proto, tensor));
 
   Status status;

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
@@ -506,7 +506,7 @@ void QnnModelWrapper::GetGraphInputOutputTensorWrapper(const std::vector<std::st
 Status QnnModelWrapper::UnpackInitializerData(const ONNX_NAMESPACE::TensorProto& initializer,
                                               std::vector<uint8_t>& unpacked_tensor) const {
   if (initializer.data_location() == onnx::TensorProto_DataLocation_EXTERNAL) {
-    return onnxruntime::utils::UnpackInitializerData(initializer, graph_viewer_.ModelPath(), unpacked_tensor);
+    return onnxruntime::utils::UnpackInitializerData(initializer, graph_viewer_.ExternalDataPath(), unpacked_tensor);
   }
 
   return onnxruntime::utils::UnpackInitializerData(initializer, unpacked_tensor);

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1843,8 +1843,9 @@ common::Status InferenceSession::Initialize() {
 #endif  // !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
     }
 
+    auto graph_location = external_ini_path_.empty() ? model_location_ : external_ini_path_ + PathString(L"/model.onnx");
     ORT_RETURN_IF_ERROR_SESSIONID_(
-        session_state_->FinalizeSessionState(model_location_, kernel_registry_manager_,
+        session_state_->FinalizeSessionState(graph_location, kernel_registry_manager_,
                                              // need to keep the initializers if saving the optimized model
                                              !saving_model,
                                              saving_ort_format));
@@ -3017,6 +3018,11 @@ common::Status InferenceSession::WaitForNotification(Notification* p_executor_do
   p_executor_done->Wait();
 
   return Status::OK();
+}
+
+void InferenceSession::SetExternalIniPath(const PathString& external_ini_path) {
+  model_->SetExternalIniPath(external_ini_path);
+  external_ini_path_ = external_ini_path;
 }
 
 SessionIOBinding::SessionIOBinding(InferenceSession* session) : sess_(session) {

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1843,11 +1843,11 @@ common::Status InferenceSession::Initialize() {
 #endif  // !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
     }
 
-    if (external_ini_path_.empty() && !model_location_.empty()) {
-      external_ini_path_ = Path::Parse(model_location_).ParentPath().ToPathString();
+    if (external_data_path_.empty() && !model_location_.empty()) {
+      external_data_path_ = Path::Parse(model_location_).ParentPath().ToPathString();
     }
     ORT_RETURN_IF_ERROR_SESSIONID_(
-        session_state_->FinalizeSessionState(external_ini_path_, kernel_registry_manager_,
+        session_state_->FinalizeSessionState(external_data_path_, kernel_registry_manager_,
                                              // need to keep the initializers if saving the optimized model
                                              !saving_model,
                                              saving_ort_format));
@@ -3022,9 +3022,9 @@ common::Status InferenceSession::WaitForNotification(Notification* p_executor_do
   return Status::OK();
 }
 
-void InferenceSession::SetExternalIniPath(const PathString& external_ini_path) {
-  model_->SetExternalIniPath(external_ini_path);
-  external_ini_path_ = external_ini_path;
+void InferenceSession::SetExternalDataPath(const PathString& external_data_path) {
+  model_->SetExternalDataPath(external_data_path);
+  external_data_path_ = external_data_path;
 }
 
 SessionIOBinding::SessionIOBinding(InferenceSession* session) : sess_(session) {

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1843,9 +1843,11 @@ common::Status InferenceSession::Initialize() {
 #endif  // !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
     }
 
-    auto graph_location = external_ini_path_.empty() ? model_location_ : external_ini_path_ + PathString(L"/model.onnx");
+    if (external_ini_path_.empty() && !model_location_.empty()) {
+      external_ini_path_ = Path::Parse(model_location_).ParentPath().ToPathString();
+    }
     ORT_RETURN_IF_ERROR_SESSIONID_(
-        session_state_->FinalizeSessionState(graph_location, kernel_registry_manager_,
+        session_state_->FinalizeSessionState(external_ini_path_, kernel_registry_manager_,
                                              // need to keep the initializers if saving the optimized model
                                              !saving_model,
                                              saving_ort_format));

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -524,6 +524,8 @@ class InferenceSession {
    */
   Status AddPrePackedWeightsContainer(PrepackedWeightsContainer* prepacked_weights_container);
 
+  void SetExternalIniPath(const PathString& external_ini_path);
+
  protected:
 #if !defined(ORT_MINIMAL_BUILD)
 
@@ -589,6 +591,9 @@ class InferenceSession {
 
   // The file path of where the model was loaded. e.g. /tmp/test_squeezenet/model.onnx
   PathString model_location_;
+
+  // The folder path of the external initializers
+  PathString external_ini_path_;
 
   // The list of execution providers.
   ExecutionProviders execution_providers_;

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -524,7 +524,7 @@ class InferenceSession {
    */
   Status AddPrePackedWeightsContainer(PrepackedWeightsContainer* prepacked_weights_container);
 
-  void SetExternalIniPath(const PathString& external_ini_path);
+  void SetExternalDataPath(const PathString& external_data_path);
 
  protected:
 #if !defined(ORT_MINIMAL_BUILD)
@@ -593,7 +593,7 @@ class InferenceSession {
   PathString model_location_;
 
   // The folder path of the external initializers
-  PathString external_ini_path_;
+  PathString external_data_path_;
 
   // The list of execution providers.
   ExecutionProviders execution_providers_;

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -683,7 +683,7 @@ static ORT_STATUS_PTR CreateSessionAndLoadModel(_In_ const OrtSessionOptions* op
                                                 _In_opt_z_ const ORTCHAR_T* model_path,
                                                 _In_opt_ const void* model_data,
                                                 size_t model_data_length,
-                                                _In_opt_z_ const ORTCHAR_T* external_ini_path,
+                                                _In_opt_z_ const ORTCHAR_T* external_data_path,
                                                 std::unique_ptr<onnxruntime::InferenceSession>& sess) {
   // quick check here to decide load path. InferenceSession will provide error message for invalid values.
   // TODO: Could move to a helper
@@ -733,8 +733,8 @@ static ORT_STATUS_PTR CreateSessionAndLoadModel(_In_ const OrtSessionOptions* op
     }
   }
 
-  if (external_ini_path != nullptr) {
-    sess->SetExternalIniPath(external_ini_path);
+  if (external_data_path != nullptr) {
+    sess->SetExternalDataPath(external_data_path);
   }
 
   return nullptr;

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -683,7 +683,7 @@ static ORT_STATUS_PTR CreateSessionAndLoadModel(_In_ const OrtSessionOptions* op
                                                 _In_opt_z_ const ORTCHAR_T* model_path,
                                                 _In_opt_ const void* model_data,
                                                 size_t model_data_length,
-
+                                                _In_opt_z_ const ORTCHAR_T* external_ini_path,
                                                 std::unique_ptr<onnxruntime::InferenceSession>& sess) {
   // quick check here to decide load path. InferenceSession will provide error message for invalid values.
   // TODO: Could move to a helper
@@ -733,6 +733,10 @@ static ORT_STATUS_PTR CreateSessionAndLoadModel(_In_ const OrtSessionOptions* op
     }
   }
 
+  if (external_ini_path != nullptr) {
+    sess->SetExternalIniPath(external_ini_path);
+  }
+
   return nullptr;
 }
 
@@ -776,7 +780,7 @@ ORT_API_STATUS_IMPL(OrtApis::CreateSession, _In_ const OrtEnv* env, _In_ const O
   *out = nullptr;
 
   ORT_TRY {
-    ORT_API_RETURN_IF_ERROR(CreateSessionAndLoadModel(options, env, model_path, nullptr, 0, sess));
+    ORT_API_RETURN_IF_ERROR(CreateSessionAndLoadModel(options, env, model_path, nullptr, 0, nullptr, sess));
     ORT_API_RETURN_IF_ERROR(InitializeSession(options, sess));
 
     *out = reinterpret_cast<OrtSession*>(sess.release());
@@ -799,7 +803,7 @@ ORT_API_STATUS_IMPL(OrtApis::CreateSessionFromArray, _In_ const OrtEnv* env, _In
   *out = nullptr;
 
   ORT_TRY {
-    ORT_API_RETURN_IF_ERROR(CreateSessionAndLoadModel(options, env, nullptr, model_data, model_data_length, sess));
+    ORT_API_RETURN_IF_ERROR(CreateSessionAndLoadModel(options, env, nullptr, model_data, model_data_length, nullptr, sess));
     ORT_API_RETURN_IF_ERROR(InitializeSession(options, sess));
 
     *out = reinterpret_cast<OrtSession*>(sess.release());
@@ -2269,7 +2273,7 @@ ORT_API_STATUS_IMPL(OrtApis::CreateSessionWithPrepackedWeightsContainer, _In_ co
   *out = nullptr;
 
   ORT_TRY {
-    ORT_API_RETURN_IF_ERROR(CreateSessionAndLoadModel(options, env, model_path, nullptr, 0, sess));
+    ORT_API_RETURN_IF_ERROR(CreateSessionAndLoadModel(options, env, model_path, nullptr, 0, nullptr, sess));
     ORT_API_RETURN_IF_ERROR(InitializeSession(options, sess, prepacked_weights_container));
 
     *out = reinterpret_cast<OrtSession*>(sess.release());
@@ -2295,7 +2299,7 @@ ORT_API_STATUS_IMPL(OrtApis::CreateSessionFromArrayWithPrepackedWeightsContainer
 
   ORT_TRY {
     ORT_API_RETURN_IF_ERROR(CreateSessionAndLoadModel(options, env, nullptr, model_data,
-                                                      model_data_length, sess));
+                                                      model_data_length, nullptr, sess));
     ORT_API_RETURN_IF_ERROR(InitializeSession(options, sess, prepacked_weights_container));
 
     *out = reinterpret_cast<OrtSession*>(sess.release());
@@ -2352,6 +2356,30 @@ ORT_API(const OrtTrainingApi*, OrtApis::GetTrainingApi, uint32_t version) {
 
   return nullptr;
 #endif
+}
+
+ORT_API_STATUS_IMPL(OrtApis::CreateSessionFromArrayWithExternalData, _In_ const OrtEnv* env, _In_ const void* model_data,
+                    size_t model_data_length, _In_ const ORTCHAR_T* external_data_path,
+                    _In_ const OrtSessionOptions* options, _Outptr_ OrtSession** out) {
+  API_IMPL_BEGIN
+  std::unique_ptr<onnxruntime::InferenceSession> sess;
+  OrtStatus* status = nullptr;
+  *out = nullptr;
+
+  ORT_TRY {
+    ORT_API_RETURN_IF_ERROR(CreateSessionAndLoadModel(options, env, nullptr, model_data, model_data_length, external_data_path, sess));
+    ORT_API_RETURN_IF_ERROR(InitializeSession(options, sess));
+
+    *out = reinterpret_cast<OrtSession*>(sess.release());
+  }
+  ORT_CATCH(const std::exception& e) {
+    ORT_HANDLE_EXCEPTION([&]() {
+      status = OrtApis::CreateStatus(ORT_FAIL, e.what());
+    });
+  }
+
+  return status;
+  API_IMPL_END
 }
 
 static constexpr OrtApiBase ort_api_base = {
@@ -2721,6 +2749,7 @@ static constexpr OrtApi ort_api_1_to_17 = {
     &OrtApis::ShapeInferContext_SetOutputTypeShape,
     &OrtApis::SetSymbolicDimensions,
     &OrtApis::ReadOpAttr,
+    &OrtApis::CreateSessionFromArrayWithExternalData,
 };
 
 // OrtApiBase can never change as there is no way to know what version of OrtApiBase is returned by OrtGetApiBase.

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -281,6 +281,9 @@ ORT_API_STATUS_IMPL(CreateSessionFromArrayWithPrepackedWeightsContainer, _In_ co
                     _In_ const void* model_data, size_t model_data_length,
                     _In_ const OrtSessionOptions* options, _Inout_ OrtPrepackedWeightsContainer* prepacked_weights_container,
                     _Outptr_ OrtSession** out);
+ORT_API_STATUS_IMPL(CreateSessionFromArrayWithExternalData, _In_ const OrtEnv* env,
+                    _In_ const void* model_data, size_t model_data_length, _In_ const ORTCHAR_T* external_data_path,
+                    _In_ const OrtSessionOptions* options, _Outptr_ OrtSession** out);
 ORT_API_STATUS_IMPL(SessionOptionsAppendExecutionProvider_TensorRT_V2,
                     _In_ OrtSessionOptions* options, _In_ const OrtTensorRTProviderOptionsV2* tensorrt_options);
 ORT_API_STATUS_IMPL(CreateTensorRTProviderOptions, _Outptr_ OrtTensorRTProviderOptionsV2** out);

--- a/onnxruntime/test/framework/save_model_with_external_initializers.cc
+++ b/onnxruntime/test/framework/save_model_with_external_initializers.cc
@@ -44,6 +44,7 @@ void LoadSaveAndCompareModel(const std::string& input_onnx,
   // Compare the initializers of the two versions.
   Path model_path{};
   Path external_data_path{};
+  Path external_data_folder_path{};
   for (auto i : initializers) {
     const std::string kInitName = i.first;
     const ONNX_NAMESPACE::TensorProto* tensor_proto = i.second;
@@ -51,15 +52,16 @@ void LoadSaveAndCompareModel(const std::string& input_onnx,
 
     std::vector<uint8_t> tensor_proto_data;
     model_path = Path::Parse(ToPathString(input_onnx));
-    external_data_path = model_path.ParentPath();
+    external_data_folder_path = model_path.ParentPath();
     // the file name of the external initializer data is tracked inside the tensor protocol
-    ORT_THROW_IF_ERROR(utils::UnpackInitializerData(*tensor_proto, external_data_path, tensor_proto_data));
+    ORT_THROW_IF_ERROR(utils::UnpackInitializerData(*tensor_proto, external_data_folder_path, tensor_proto_data));
     size_t tensor_proto_size = tensor_proto_data.size();
 
     std::vector<uint8_t> from_external_tensor_proto_data;
     model_path = Path::Parse(ToPathString(output_onnx));
-    external_data_path = model_path.ParentPath();
-    ORT_THROW_IF_ERROR(utils::UnpackInitializerData(*from_external_tensor_proto, external_data_path, from_external_tensor_proto_data));
+    external_data_folder_path = model_path.ParentPath();
+    external_data_path = model_path.ParentPath().Append(Path::Parse(ToPathString(output_external_init_file)));
+    ORT_THROW_IF_ERROR(utils::UnpackInitializerData(*from_external_tensor_proto, external_data_folder_path, from_external_tensor_proto_data));
     size_t from_external_tensor_proto_size = from_external_tensor_proto_data.size();
 
     if (from_external_tensor_proto_size < initializer_size_threshold) {

--- a/onnxruntime/test/shared_lib/test_model_loading.cc
+++ b/onnxruntime/test/shared_lib/test_model_loading.cc
@@ -105,6 +105,26 @@ TEST(CApiTest, TestExternalInitializersInjection) {
   EXPECT_NO_THROW(Ort::Session(*ort_env, model_path, so));
 }
 
+TEST(CApiTest, TestLoadModelFromArrayWithExternalInitiliazers) {
+  constexpr auto model_path = ORT_TSTR("testdata/model_with_external_initializers.onnx");
+  std::vector<char> buffer;
+  {
+    std::ifstream file(model_path, std::ios::binary | std::ios::ate);
+    if (!file)
+      ORT_THROW("Error reading model");
+    buffer.resize(narrow<size_t>(file.tellg()));
+    file.seekg(0, std::ios::beg);
+    if (!file.read(buffer.data(), buffer.size()))
+      ORT_THROW("Error reading model");
+  }
+
+  Ort::SessionOptions so;
+  const ORTCHAR_T* ort_model_path = ORT_TSTR("testdata/model_with_external_initializers_opt.onnx");
+  so.SetOptimizedModelFilePath(ort_model_path);
+  constexpr auto external_ini_path = ORT_TSTR("testdata");
+  Ort::Session session(*ort_env.get(), buffer.data(), buffer.size(), external_ini_path, so);
+}
+
 #endif
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/shared_lib/test_model_loading.cc
+++ b/onnxruntime/test/shared_lib/test_model_loading.cc
@@ -121,8 +121,8 @@ TEST(CApiTest, TestLoadModelFromArrayWithExternalInitiliazers) {
   Ort::SessionOptions so;
   const ORTCHAR_T* ort_model_path = ORT_TSTR("testdata/model_with_external_initializers_opt.onnx");
   so.SetOptimizedModelFilePath(ort_model_path);
-  constexpr auto external_ini_path = ORT_TSTR("testdata");
-  Ort::Session session(*ort_env.get(), buffer.data(), buffer.size(), external_ini_path, so);
+  constexpr auto external_data_path = ORT_TSTR("testdata");
+  Ort::Session session(*ort_env.get(), buffer.data(), buffer.size(), external_data_path, so);
 }
 
 #endif

--- a/onnxruntime/test/util/test_utils.cc
+++ b/onnxruntime/test/util/test_utils.cc
@@ -233,7 +233,7 @@ void CheckShapeEquality(const ONNX_NAMESPACE::TensorShapeProto* shape1,
 #if !defined(DISABLE_SPARSE_TENSORS)
 void SparseIndicesChecker(const ONNX_NAMESPACE::TensorProto& indices_proto, gsl::span<const int64_t> expected_indicies) {
   using namespace ONNX_NAMESPACE;
-  Path model_path;
+  Path external_data_path;
   std::vector<uint8_t> unpack_buffer;
   gsl::span<const int64_t> ind_span;
   std::vector<int64_t> converted_indices;
@@ -245,7 +245,7 @@ void SparseIndicesChecker(const ONNX_NAMESPACE::TensorProto& indices_proto, gsl:
       if (has_raw_data) {
         const auto& rd = indices_proto.raw_data();
         ASSERT_EQ(rd.size(), elements * sizeof(int64_t));
-        ASSERT_STATUS_OK(utils::UnpackInitializerData(indices_proto, model_path, unpack_buffer));
+        ASSERT_STATUS_OK(utils::UnpackInitializerData(indices_proto, external_data_path, unpack_buffer));
         ind_span = ReinterpretAsSpan<const int64_t>(gsl::make_span(unpack_buffer));
       } else {
         ind_span = gsl::make_span(indices_proto.int64_data().data(), indices_proto.int64_data_size());
@@ -256,7 +256,7 @@ void SparseIndicesChecker(const ONNX_NAMESPACE::TensorProto& indices_proto, gsl:
       if (has_raw_data) {
         const auto& rd = indices_proto.raw_data();
         ASSERT_EQ(rd.size(), elements * sizeof(int32_t));
-        ASSERT_STATUS_OK(utils::UnpackInitializerData(indices_proto, model_path, unpack_buffer));
+        ASSERT_STATUS_OK(utils::UnpackInitializerData(indices_proto, external_data_path, unpack_buffer));
         auto int32_span = ReinterpretAsSpan<const int32_t>(gsl::make_span(unpack_buffer));
         converted_indices.insert(converted_indices.cend(), int32_span.begin(), int32_span.end());
       } else {
@@ -269,7 +269,7 @@ void SparseIndicesChecker(const ONNX_NAMESPACE::TensorProto& indices_proto, gsl:
       ASSERT_TRUE(has_raw_data);
       const auto& rd = indices_proto.raw_data();
       ASSERT_EQ(rd.size(), elements * sizeof(int16_t));
-      ASSERT_STATUS_OK(utils::UnpackInitializerData(indices_proto, model_path, unpack_buffer));
+      ASSERT_STATUS_OK(utils::UnpackInitializerData(indices_proto, external_data_path, unpack_buffer));
       auto int16_span = ReinterpretAsSpan<const int16_t>(gsl::make_span(unpack_buffer));
       converted_indices.insert(converted_indices.cend(), int16_span.begin(), int16_span.end());
       ind_span = gsl::make_span(converted_indices);
@@ -279,7 +279,7 @@ void SparseIndicesChecker(const ONNX_NAMESPACE::TensorProto& indices_proto, gsl:
       ASSERT_TRUE(has_raw_data);
       const auto& rd = indices_proto.raw_data();
       ASSERT_EQ(rd.size(), elements);
-      ASSERT_STATUS_OK(utils::UnpackInitializerData(indices_proto, model_path, unpack_buffer));
+      ASSERT_STATUS_OK(utils::UnpackInitializerData(indices_proto, external_data_path, unpack_buffer));
       auto int8_span = ReinterpretAsSpan<const int8_t>(gsl::make_span(unpack_buffer));
       converted_indices.insert(converted_indices.cend(), int8_span.begin(), int8_span.end());
       ind_span = gsl::make_span(converted_indices);

--- a/orttraining/orttraining/core/session/training_session.h
+++ b/orttraining/orttraining/core/session/training_session.h
@@ -369,6 +369,9 @@ class TrainingSession : public InferenceSession {
   /** Gets the model location. */
   const PathString& GetModelLocation() const { return model_location_; }
 
+  /** Gets the folder path of the external initializers. */
+  const PathString& GetExternalDataPath() const { return external_data_path_; }
+
   /**
    * Checks to be see if given graph output is produced by an fp32-only node.
    * @param The name of the output.

--- a/orttraining/orttraining/models/runner/training_runner.cc
+++ b/orttraining/orttraining/models/runner/training_runner.cc
@@ -1274,7 +1274,7 @@ Status TrainingRunner::LoadCheckpoint(const PathString& checkpoint_path) {
       checkpointed_tensors, checkpointed_properties));
 
   ORT_RETURN_IF_ERROR(WithOrtValuesFromTensorProtos(
-      session_.GetModelLocation(), checkpointed_tensors,
+      session_.GetExternalDataPath(), checkpointed_tensors,
       [this](const NameMLValMap& name_to_ort_value) -> Status {
         ORT_RETURN_IF_ERROR(session_.SetStateTensors(name_to_ort_value, true));
         return Status::OK();

--- a/orttraining/orttraining/test/framework/checkpointing_test.cc
+++ b/orttraining/orttraining/test/framework/checkpointing_test.cc
@@ -46,7 +46,7 @@ class OrtValueTensorData {
 };
 
 void CompareOrtValuesToTensorProtoValues(
-    const PathString& model_path,
+    const PathString& external_data_path,
     const NameMLValMap& name_to_ort_value,
     const std::unordered_map<std::string, ONNX_NAMESPACE::TensorProto>& name_to_tensor_proto) {
   ASSERT_EQ(name_to_ort_value.size(), name_to_tensor_proto.size());
@@ -60,7 +60,7 @@ void CompareOrtValuesToTensorProtoValues(
     TensorShape shape{tensor_proto.dims().data(), static_cast<size_t>(tensor_proto.dims().size())};
     ASSERT_EQ(tensor_proto.data_type(), ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
     OrtValue ort_value;
-    ASSERT_STATUS_OK(utils::TensorProtoToOrtValue(Env::Default(), model_path.c_str(), tensor_proto,
+    ASSERT_STATUS_OK(utils::TensorProtoToOrtValue(Env::Default(), external_data_path.c_str(), tensor_proto,
                                                   tmp_allocator, ort_value));
 
     name_to_ort_value_from_tensor_proto.emplace(name, ort_value);
@@ -100,7 +100,8 @@ TEST(CheckpointingTest, SaveAndLoad) {
       {"three", "3"},
   };
 
-  TemporaryDirectory tmp_dir{ORT_TSTR("checkpointing_test_dir")};
+  PathString model_folder(ORT_TSTR("checkpointing_test_dir"));
+  TemporaryDirectory tmp_dir{model_folder};
 
   PathString checkpoint_path{
       ConcatPathComponent(tmp_dir.Path(), ORT_TSTR("test_checkpoint"))};
@@ -131,7 +132,7 @@ TEST(CheckpointingTest, SaveAndLoad) {
       });
 
   CompareOrtValuesToTensorProtoValues(
-      model_path, name_to_ort_value, name_to_loaded_tensor_proto);
+      model_folder, name_to_ort_value, name_to_loaded_tensor_proto);
 }
 
 }  // namespace test


### PR DESCRIPTION
Add new API to create a session from model memory buffer with external data path

### Description
Given a model with external weights. There's no way to load the external weight if create the session using API CreateSessionFromArray. Because it lost track of the model path.
User want to create the session from model memory buffer, and at the mean time provide the path to the external data.
New API required to meet the requirement.


