### PR TITLE
[ROCm] do not use failed miopen fusion compile

### DIFF
--- a/onnxruntime/contrib_ops/rocm/fused_conv.cc
+++ b/onnxruntime/contrib_ops/rocm/fused_conv.cc
@@ -319,8 +319,7 @@ class FusedConv : public onnxruntime::rocm::Conv<T, false> {
       auto ret = miopenCompileFusionPlan(handle, fusion->plan);
       if (miopenStatusSuccess == ret) {
         fusion->compiled_on.insert(handle);
-      }
-      else {
+      } else {
         return ret;
       }
       return miopenStatusSuccess;


### PR DESCRIPTION
The FusedConv operator for the ROCm EP could fail to compile the fused operation, in which case it should not attempt to use the failed fusion plan.  In addition, the hash for the miopenConvolutionDescriptor_t for newer ROCm versions was failing to use all components of the descriptor.