### PR TITLE
Optimize onnxruntime::InferenceSession::Initialize with focus on GrapViewer. For large models the speedup of this function can be up to 3x.

### DIFF
--- a/include/onnxruntime/core/graph/constants.h
+++ b/include/onnxruntime/core/graph/constants.h
@@ -55,7 +55,4 @@ constexpr const char* kAzureExecutionProvider = "AzureExecutionProvider";
 constexpr const char* kExecutionProviderSharedLibraryPath = "shared_lib_path";
 constexpr const char* kExecutionProviderSharedLibraryEntry = "provider_factory_entry_point";
 
-// For Priority based graph topology sorting.
-constexpr const char* kBackwardNodeAttributeName = "__backwardpass";
-
 }  // namespace onnxruntime

--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -398,11 +398,11 @@ class Node {
   /** Gets the Node's attributes. */
   const NodeAttributes& GetAttributes() const noexcept { return attributes_; }
 
-  /** @returns true if the Node is a forward node, false otherwise. **/
-  bool isForwardNode() const noexcept { return is_forward_node_; }
+  /** @returns true if the Node is a forward node (inference), false (training backward pass) otherwise. **/
+  bool IsForwardNode() const noexcept { return is_forward_node_; }
 
   /* Sets the forward node status  */
-  void setForwardNode(bool is_forward_node) noexcept { is_forward_node_ = is_forward_node; }
+  void SetForwardNode(bool is_forward_node) noexcept { is_forward_node_ = is_forward_node; }
 
 #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
   /** Remove the specified attribute from this Node */
@@ -637,7 +637,7 @@ class Node {
   int priority_ = 0;
 
   // This node is a forward node if value, otherwise it is a backward node.
-  bool is_forward_node_;
+  bool is_forward_node_ = true;
 
   // set from op_->SinceVersion() or via deserialization when OpSchema is not available
   int since_version_ = -1;

--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -294,17 +294,21 @@ class Node {
   Class to provide const access to Node instances iterated via an EdgeConstIterator. */
   class NodeConstIterator {
    public:
-    NodeConstIterator(EdgeConstIterator p_iter);
+    NodeConstIterator(EdgeConstIterator p_iter) { m_iter = p_iter; }
 
-    bool operator==(const NodeConstIterator& p_other) const;
+    bool operator==(const NodeConstIterator& p_other) const {
+      return m_iter == p_other.m_iter;
+    }
 
-    bool operator!=(const NodeConstIterator& p_other) const;
+    bool operator!=(const NodeConstIterator& p_other) const {
+      return m_iter != p_other.m_iter;
+    }
 
-    void operator++();
-    void operator--();
+    void operator++() { ++m_iter; }
+    void operator--() { --m_iter; }
 
-    const Node& operator*() const;
-    const Node* operator->() const;
+    const Node& operator*() const { return (*m_iter).GetNode(); }
+    const Node* operator->() const { return &(operator*()); };
 
    private:
     EdgeConstIterator m_iter;
@@ -394,6 +398,9 @@ class Node {
   /** Gets the Node's attributes. */
   const NodeAttributes& GetAttributes() const noexcept { return attributes_; }
 
+  /** @returns true if the Node is a forward node, false otherwise. **/
+  bool isForwardNode() const noexcept { return isForwardNode_; }
+
 #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
   /** Remove the specified attribute from this Node */
   bool ClearAttribute(const std::string& attr_name);
@@ -457,7 +464,7 @@ class Node {
   std::unordered_map<std::string, gsl::not_null<const Graph*>> GetAttributeNameToSubgraphMap() const;
 
   /** Gets the execution ProviderType that this node will be executed by. */
-  ProviderType GetExecutionProviderType() const noexcept { return execution_provider_type_; }
+  ProviderType const& GetExecutionProviderType() const noexcept { return execution_provider_type_; }
 
   /** Sets the execution ProviderType that this Node will be executed by. */
   void SetExecutionProviderType(ProviderType execution_provider_type) {
@@ -625,6 +632,10 @@ class Node {
 
   // Execution priority, lower value for higher priority
   int priority_ = 0;
+
+  // True is Node is a forwardNode and thus doesn't contain a attribute
+  // named kBackwardNodeAttributeName. False otherwise.
+  bool isForwardNode_;
 
   // set from op_->SinceVersion() or via deserialization when OpSchema is not available
   int since_version_ = -1;

--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -399,7 +399,10 @@ class Node {
   const NodeAttributes& GetAttributes() const noexcept { return attributes_; }
 
   /** @returns true if the Node is a forward node, false otherwise. **/
-  bool isForwardNode() const noexcept { return isForwardNode_; }
+  bool isForwardNode() const noexcept { return is_forward_node_; }
+
+  /* Sets the forward node status  */
+  void setForwardNode(bool is_forward_node) noexcept { is_forward_node_ = is_forward_node; }
 
 #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
   /** Remove the specified attribute from this Node */
@@ -464,7 +467,7 @@ class Node {
   std::unordered_map<std::string, gsl::not_null<const Graph*>> GetAttributeNameToSubgraphMap() const;
 
   /** Gets the execution ProviderType that this node will be executed by. */
-  ProviderType const& GetExecutionProviderType() const noexcept { return execution_provider_type_; }
+  ProviderType GetExecutionProviderType() const noexcept { return execution_provider_type_; }
 
   /** Sets the execution ProviderType that this Node will be executed by. */
   void SetExecutionProviderType(ProviderType execution_provider_type) {
@@ -633,9 +636,8 @@ class Node {
   // Execution priority, lower value for higher priority
   int priority_ = 0;
 
-  // True is Node is a forwardNode and thus doesn't contain a attribute
-  // named kBackwardNodeAttributeName. False otherwise.
-  bool isForwardNode_;
+  // This node is a forward node if value, otherwise it is a backward node.
+  bool is_forward_node_;
 
   // set from op_->SinceVersion() or via deserialization when OpSchema is not available
   int since_version_ = -1;

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -528,34 +528,6 @@ Node::EdgeEnd::EdgeEnd(const Node& node) noexcept
     : EdgeEnd(node, INT_MAX, INT_MAX) {
 }
 
-Node::NodeConstIterator::NodeConstIterator(EdgeConstIterator p_iter) {
-  m_iter = p_iter;
-}
-
-bool Node::NodeConstIterator::operator==(const NodeConstIterator& p_other) const {
-  return m_iter == p_other.m_iter;
-}
-
-bool Node::NodeConstIterator::operator!=(const NodeConstIterator& p_other) const {
-  return m_iter != p_other.m_iter;
-}
-
-void Node::NodeConstIterator::operator++() {
-  ++m_iter;
-}
-
-void Node::NodeConstIterator::operator--() {
-  --m_iter;
-}
-
-const Node& Node::NodeConstIterator::operator*() const {
-  return (*m_iter).GetNode();
-}
-
-const Node* Node::NodeConstIterator::operator->() const {
-  return &(operator*());
-}
-
 void Node::SetPriority(int priority) noexcept {
   priority_ = priority;
 }
@@ -878,6 +850,7 @@ void Node::Init(std::string_view name,
                 gsl::span<NodeArg* const> output_args,
                 const NodeAttributes* attributes,
                 std::string_view domain) {
+  isForwardNode_ = true;
   name_ = name;
   op_type_ = op_type;
   description_ = description;
@@ -898,7 +871,12 @@ void Node::Init(std::string_view name,
   if (attributes) {
     attributes_ = *attributes;
 
+    isForwardNode_ = true;
     for (auto& name_to_attr : attributes_) {
+      if (!isForwardNode_ && name_to_attr.first == kBackwardNodeAttributeName) {
+        isForwardNode_ = false;
+      }
+
       if (utils::HasGraph(name_to_attr.second)) {
 #if !defined(ORT_MINIMAL_BUILD)
         CreateSubgraph(name_to_attr.first);
@@ -942,6 +920,9 @@ void Node::CreateSubgraph(const std::string& attr_name) {
 #endif  // !defined(ORT_MINIMAL_BUILD)
 
 void Node::AddAttributeProto(AttributeProto value) {
+  if (value.name() == kBackwardNodeAttributeName) {
+    isForwardNode_ = false;
+  }
   utils::SetNodeAttribute(std::move(value), attributes_);
   if (graph_) {
     graph_->SetGraphResolveNeeded();
@@ -978,6 +959,7 @@ ADD_ATTR_IMPLS(TypeProto)
 #undef ADD_ATTR_LIST_IMPL
 #undef ADD_ATTR_IMPLS
 
+// TODO why isn't attr_name a const&?
 void Node::AddAttribute(std::string attr_name, GraphProto value) {
   // Do not move attr_name as it is needed below
   AttributeProto a = utils::MakeAttribute(attr_name, std::move(value));
@@ -993,7 +975,11 @@ void Node::AddAttribute(std::string attr_name, GraphProto value) {
 bool Node::ClearAttribute(const std::string& attr_name) {
   graph_->SetGraphResolveNeeded();
   graph_->SetGraphProtoSyncNeeded();
-  return attributes_.erase(attr_name) > 0;
+  size_t erased = attributes_.erase(attr_name);
+  if (erased && attr_name == kBackwardNodeAttributeName) {
+    isForwardNode_ = true;
+  }
+  return erased > 0;
 }
 
 #endif  // !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
@@ -1003,7 +989,11 @@ int Node::PruneRemovableAttributes(gsl::span<const std::string> removable_attrib
   graph_->SetGraphProtoSyncNeeded();
   int n_removed = 0;
   for (const auto& name : removable_attributes) {
-    n_removed += static_cast<int>(attributes_.erase(name));
+    bool erased = attributes_.erase(name);
+    if (erased && name == kBackwardNodeAttributeName) {
+      isForwardNode_ = true;
+    }
+    n_removed += static_cast<int>(erased);
   }
   can_be_saved_ = can_be_saved_ && n_removed == 0;
   return n_removed;
@@ -1821,13 +1811,13 @@ void Graph::ReverseDFSFrom(gsl::span<const Node* const> from,
 #if !defined(ORT_MINIMAL_BUILD)
 void Graph::KahnsTopologicalSort(const std::function<void(const Node*)>& enter,
                                  const std::function<bool(const Node*, const Node*)>& comp) const {
-  std::unordered_map<NodeIndex, size_t> in_degree;
+  std::vector<size_t> in_degree(MaxNodeIndex(), 0);
   std::priority_queue<const Node*, std::vector<const Node*>, decltype(comp)> to_visit(comp);
   std::vector<NodeIndex> topo_order;
 
   for (auto& node : Nodes()) {
     size_t input_edge_count = node.GetInputEdgesCount();
-    in_degree.insert({node.Index(), input_edge_count});
+    in_degree[node.Index()] = input_edge_count;
     if (input_edge_count == 0) {
       to_visit.push(&node);
     }
@@ -2044,7 +2034,7 @@ class InferenceContextImpl : public ONNX_NAMESPACE::InferenceContext {
     }
   }
 
-  std::vector<TypeProto> InferredOutputTypes() const { return node_output_types_; }
+  std::vector<TypeProto> const& InferredOutputTypes() const { return node_output_types_; }
 
   const AttributeProto* getAttribute(const std::string& name) const override {
     auto& attribute_value_map = node_.GetAttributes();
@@ -2240,7 +2230,7 @@ Status Graph::InferAndVerifyTypeMatch(Node& node, const OpSchema& op, const Reso
     // Number of inputs corresponding to the i-th argument.
     const int arg_count = node.InputArgCount()[i];
     // The i-th formal parameter definition.
-    auto op_formal_parameter = op.inputs()[i];
+    auto const &op_formal_parameter = op.inputs()[i];
 
     // Check all <arg_count> actual parameters (corresponding to the k-th input)
     // match the formal parameter definition (i-th argument).
@@ -2345,7 +2335,7 @@ Status Graph::InferAndVerifyTypeMatch(Node& node, const OpSchema& op, const Reso
 
     const int num_formal_params = gsl::narrow_cast<int>(op.outputs().size());
     auto operand_index = std::min(i, num_formal_params - 1);
-    auto op_formal_parameter = op.outputs().at(operand_index);
+    auto const &op_formal_parameter = op.outputs().at(operand_index);
 
     const TypeProto& onnx_inferred_type = onnx_inferred_types[i];
     DataType existing_type = output_def->Type();

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -2214,7 +2214,7 @@ Status Graph::InferAndVerifyTypeMatch(Node& node, const OpSchema& op, const Reso
     // Number of inputs corresponding to the i-th argument.
     const int arg_count = node.InputArgCount()[i];
     // The i-th formal parameter definition.
-    auto const &op_formal_parameter = op.inputs()[i];
+    const auto& op_formal_parameter = op.inputs()[i];
 
     // Check all <arg_count> actual parameters (corresponding to the k-th input)
     // match the formal parameter definition (i-th argument).

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -2018,7 +2018,7 @@ class InferenceContextImpl : public ONNX_NAMESPACE::InferenceContext {
     }
   }
 
-  std::vector<TypeProto> const& InferredOutputTypes() const noexcept { return node_output_types_; }
+  const std::vector<TypeProto>& InferredOutputTypes() const noexcept { return node_output_types_; }
 
   const AttributeProto* getAttribute(const std::string& name) const override {
     auto& attribute_value_map = node_.GetAttributes();
@@ -2319,7 +2319,7 @@ Status Graph::InferAndVerifyTypeMatch(Node& node, const OpSchema& op, const Reso
 
     const int num_formal_params = gsl::narrow_cast<int>(op.outputs().size());
     auto operand_index = std::min(i, num_formal_params - 1);
-    auto const &op_formal_parameter = op.outputs().at(operand_index);
+    const auto& op_formal_parameter = op.outputs().at(operand_index);
 
     const TypeProto& onnx_inferred_type = onnx_inferred_types[i];
     DataType existing_type = output_def->Type();

--- a/onnxruntime/core/graph/graph_viewer.cc
+++ b/onnxruntime/core/graph/graph_viewer.cc
@@ -14,8 +14,8 @@ bool NodeCompare::operator()(const Node* n1, const Node* n2) const {
 struct PriorityNodeCompare {
   inline bool IsHighPri(const Node* n) const {
     // local statics so we can compare std::strings in the checks
-    static const std::string shape_op("Shape");
-    static const std::string size_op("Size");
+    static constexpr std::string_view shape_op("Shape");
+    static constexpr std::string_view size_op("Size");
 
     const auto& op_type = n->OpType();
     return op_type == shape_op || op_type == size_op;
@@ -36,11 +36,11 @@ struct PriorityNodeCompare {
     }
 
     // nodes of forward pass will be output first
-    auto n1_attrs = n1->GetAttributes();
-    auto n2_attrs = n2->GetAttributes();
-    int64_t n1_is_forward = static_cast<int64_t>(n1_attrs.find(kBackwardNodeAttributeName) == n1_attrs.cend()) ||
+    auto const& n1_attrs = n1->GetAttributes();
+    auto const& n2_attrs = n2->GetAttributes();
+    int64_t n1_is_forward = static_cast<int64_t>(n1->isForwardNode()) ||
                             (n1_attrs.at(kBackwardNodeAttributeName).i() + 1) % 2;
-    int64_t n2_is_forward = static_cast<int64_t>(n2_attrs.find(kBackwardNodeAttributeName) == n2_attrs.cend()) ||
+    int64_t n2_is_forward = static_cast<int64_t>(n2->isForwardNode()) ||
                             (n2_attrs.at(kBackwardNodeAttributeName).i() + 1) % 2;
     if (n1_is_forward != n2_is_forward) {
       return n2_is_forward > n1_is_forward;

--- a/onnxruntime/core/graph/graph_viewer.cc
+++ b/onnxruntime/core/graph/graph_viewer.cc
@@ -36,8 +36,8 @@ struct PriorityNodeCompare {
     }
 
     // nodes of forward pass will be output first
-    int64_t n1_is_forward = n1->isForwardNode();
-    int64_t n2_is_forward = n2->isForwardNode();
+    int64_t n1_is_forward = n1->IsForwardNode();
+    int64_t n2_is_forward = n2->IsForwardNode();
     if (n1_is_forward != n2_is_forward) {
       return n2_is_forward > n1_is_forward;
     }

--- a/onnxruntime/core/graph/graph_viewer.cc
+++ b/onnxruntime/core/graph/graph_viewer.cc
@@ -36,12 +36,8 @@ struct PriorityNodeCompare {
     }
 
     // nodes of forward pass will be output first
-    auto const& n1_attrs = n1->GetAttributes();
-    auto const& n2_attrs = n2->GetAttributes();
-    int64_t n1_is_forward = static_cast<int64_t>(n1->isForwardNode()) ||
-                            (n1_attrs.at(kBackwardNodeAttributeName).i() + 1) % 2;
-    int64_t n2_is_forward = static_cast<int64_t>(n2->isForwardNode()) ||
-                            (n2_attrs.at(kBackwardNodeAttributeName).i() + 1) % 2;
+    int64_t n1_is_forward = n1->isForwardNode();
+    int64_t n2_is_forward = n2->isForwardNode();
     if (n1_is_forward != n2_is_forward) {
       return n2_is_forward > n1_is_forward;
     }

--- a/onnxruntime/core/optimizer/matmul_scale_fusion.cc
+++ b/onnxruntime/core/optimizer/matmul_scale_fusion.cc
@@ -255,11 +255,7 @@ Status ProcessNode(
 
   matmul_scale_node.SetExecutionProviderType(node.GetExecutionProviderType());
 #ifdef USE_ROCM
-  // forward the __backwardpass, if present
-  auto& attrs = node.GetAttributes();
-  if (attrs.count("__backwardpass")) {
-    matmul_scale_node.AddAttribute("__backwardpass", static_cast<int64_t>(attrs.at("__backwardpass").i()));
-  }
+  matmul_scale_node.setForwardNode(node.GetForwardNode());
 #endif
 
   {

--- a/onnxruntime/core/optimizer/matmul_scale_fusion.cc
+++ b/onnxruntime/core/optimizer/matmul_scale_fusion.cc
@@ -255,7 +255,7 @@ Status ProcessNode(
 
   matmul_scale_node.SetExecutionProviderType(node.GetExecutionProviderType());
 #ifdef USE_ROCM
-  matmul_scale_node.setForwardNode(node.GetForwardNode());
+  matmul_scale_node.SetForwardNode(node.GetForwardNode());
 #endif
 
   {

--- a/onnxruntime/core/optimizer/matmul_transpose_fusion.cc
+++ b/onnxruntime/core/optimizer/matmul_transpose_fusion.cc
@@ -407,7 +407,7 @@ Status MatmulTransposeFusion::ApplyImpl(Graph& graph, bool& modified, int graph_
     matmul_node.SetExecutionProviderType(node.GetExecutionProviderType());
 #ifdef USE_ROCM
     // forward the __backwardpass, if present
-    malmul_node.setForwardPass(node.getForwardPass());
+    malmul_node.SetForwardPass(node.getForwardPass());
 #endif
 
     graph_utils::FinalizeNodeFusion(graph, matmul_node, node);

--- a/onnxruntime/core/optimizer/matmul_transpose_fusion.cc
+++ b/onnxruntime/core/optimizer/matmul_transpose_fusion.cc
@@ -407,10 +407,7 @@ Status MatmulTransposeFusion::ApplyImpl(Graph& graph, bool& modified, int graph_
     matmul_node.SetExecutionProviderType(node.GetExecutionProviderType());
 #ifdef USE_ROCM
     // forward the __backwardpass, if present
-    auto& attrs = node.GetAttributes();
-    if (attrs.count("__backwardpass")) {
-      matmul_node.AddAttribute("__backwardpass", static_cast<int64_t>(attrs.at("__backwardpass").i()));
-    }
+    malmul_node.setForwardPass(node.getForwardPass());
 #endif
 
     graph_utils::FinalizeNodeFusion(graph, matmul_node, node);

--- a/onnxruntime/core/optimizer/rocm_blas_alt_impl.cc
+++ b/onnxruntime/core/optimizer/rocm_blas_alt_impl.cc
@@ -26,7 +26,7 @@ Status RocmBlasAltImpl::ApplyImpl(Graph& graph, bool& modified, int graph_level,
     ORT_RETURN_IF_ERROR(Recurse(node, modified, graph_level, logger));
 
     if (is_backward_pass) {
-      node.setForwardNode(false);
+      node.SetForwardNode(false);
       modified = true;
     }
   }

--- a/onnxruntime/core/optimizer/rocm_blas_alt_impl.cc
+++ b/onnxruntime/core/optimizer/rocm_blas_alt_impl.cc
@@ -26,7 +26,7 @@ Status RocmBlasAltImpl::ApplyImpl(Graph& graph, bool& modified, int graph_level,
     ORT_RETURN_IF_ERROR(Recurse(node, modified, graph_level, logger));
 
     if (is_backward_pass) {
-      node.AddAttribute(std::string("__backwardpass"), static_cast<int64_t>(1));
+      node.setForwardNode(false);
       modified = true;
     }
   }

--- a/onnxruntime/core/providers/rocm/rocm_kernel.h
+++ b/onnxruntime/core/providers/rocm/rocm_kernel.h
@@ -25,7 +25,7 @@ class RocmKernel : public OpKernel {
 
   Status Compute(OpKernelContext* p_op_kernel_context) const override {
     Status s;
-    auto is_backward_pass = !Node().isForwardNode();
+    auto is_backward_pass = !Node().IsForwardNode();
     if (is_backward_pass) {
       BackwardPassGuard guard;
       s = ComputeInternal(p_op_kernel_context);

--- a/onnxruntime/core/providers/rocm/rocm_kernel.h
+++ b/onnxruntime/core/providers/rocm/rocm_kernel.h
@@ -25,7 +25,7 @@ class RocmKernel : public OpKernel {
 
   Status Compute(OpKernelContext* p_op_kernel_context) const override {
     Status s;
-    auto is_backward_pass = Info().GetAttrOrDefault<int64_t>("__backwardpass", 0);
+    auto is_backward_pass = !Node().isForwardNode();
     if (is_backward_pass) {
       BackwardPassGuard guard;
       s = ComputeInternal(p_op_kernel_context);

--- a/orttraining/orttraining/core/optimizer/memory_optimizer/memory_insight.cc
+++ b/orttraining/orttraining/core/optimizer/memory_optimizer/memory_insight.cc
@@ -197,13 +197,13 @@ Status ResetNodeBackwardPassAttribute(Graph& graph, bool& modified) {
   // Set the attribute to true for all backward nodes.
   for (auto& node : graph.Nodes()) {
     if (std::find(fw_nodes.begin(), fw_nodes.end(), &node) == fw_nodes.end()) {
-      if (node.isForwardNode()) {
-        node.setForwardNode(false);
+      if (node.IsForwardNode()) {
+        node.SetForwardNode(false);
         modified = true;
       }
     } else {
-      if (!node.isForwardNode()) {
-        node.setForwardNode(true);
+      if (!node.IsForwardNode()) {
+        node.SetForwardNode(true);
         modified = true;
       }
     }

--- a/orttraining/orttraining/core/optimizer/memory_optimizer/memory_insight.cc
+++ b/orttraining/orttraining/core/optimizer/memory_optimizer/memory_insight.cc
@@ -197,16 +197,13 @@ Status ResetNodeBackwardPassAttribute(Graph& graph, bool& modified) {
   // Set the attribute to true for all backward nodes.
   for (auto& node : graph.Nodes()) {
     if (std::find(fw_nodes.begin(), fw_nodes.end(), &node) == fw_nodes.end()) {
-      auto& attrs = node.GetAttributes();
-      if (attrs.count(kBackwardNodeAttributeName)) {
-        continue;
+      if (node.isForwardNode()) {
+        node.setForwardNode(false);
+        modified = true;
       }
-      node.AddAttribute(kBackwardNodeAttributeName, static_cast<int64_t>(1));
-      modified = true;
     } else {
-      auto& attrs = node.GetAttributes();
-      if (attrs.count(kBackwardNodeAttributeName)) {
-        node.ClearAttribute(kBackwardNodeAttributeName);
+      if (!node.isForwardNode()) {
+        node.setForwardNode(true);
         modified = true;
       }
     }


### PR DESCRIPTION

### Description
<!-- Describe your changes. -->
- In multiple locations which are in the hot loop copies of unordered_maps and other types were made where references would have been possible
- In multiple locations return by value is being used where return by const& would have been appropriate
- Replaced std::unordered_map by std::vector for in_degree in KahnsTopologicalSort
- Added Node::isForwardNode() function to cache the existence of kBackwardNodeAttributeName.
- Inlined functions of NodeConstIterator 


### Motivation and Context
Load time of the huggingface 7b llama files can be quite long (>45s). 50% of this time is IO while the other 50% of the time was TransformGraph. To decrease loading time and thus startup time it'd be good to optimize the non-IO part as much as possible.


