### PR TITLE
Fix build error for CoreML Split op

### DIFF
--- a/onnxruntime/core/providers/coreml/builders/impl/split_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/split_op_builder.cc
@@ -139,8 +139,8 @@ bool SplitOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputPar
     }
     const auto& splits_tensor = *initializers.at(input_defs[1]->Name());
     Initializer unpacked_tensor(splits_tensor);
-    auto splits_span = unpacked_tensor.DataAsSpan<uint64_t>();
-    int sum_of_splits = std::accumulate(splits_span.begin(), splits_span.end(), 0);
+    auto splits_span = unpacked_tensor.DataAsSpan<int64_t>();
+    int64_t sum_of_splits = std::accumulate(splits_span.begin(), splits_span.end(), uint64_t(0));
     if (sum_of_splits != split_dims_at_axis) {
       LOGS(logger, VERBOSE) << "Mismatch between the sum of 'split'. Expected: "
                             << split_dims_at_axis

--- a/onnxruntime/core/providers/coreml/builders/impl/split_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/split_op_builder.cc
@@ -140,7 +140,7 @@ bool SplitOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputPar
     const auto& splits_tensor = *initializers.at(input_defs[1]->Name());
     Initializer unpacked_tensor(splits_tensor);
     auto splits_span = unpacked_tensor.DataAsSpan<int64_t>();
-    int64_t sum_of_splits = std::accumulate(splits_span.begin(), splits_span.end(), uint64_t(0));
+    int64_t sum_of_splits = std::accumulate(splits_span.begin(), splits_span.end(), int64_t{0});
     if (sum_of_splits != split_dims_at_axis) {
       LOGS(logger, VERBOSE) << "Mismatch between the sum of 'split'. Expected: "
                             << split_dims_at_axis


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
The `split` input of the Split op is int64_t. Fixing that resolves a type mismatch build error on Windows when CoreML is enabled (for debugging the partitioning code).

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Fix build error

