### PR TITLE
Set pythonInterpreter in set-python-manylinux-variables-step.yml

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/set-python-manylinux-variables-step.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/set-python-manylinux-variables-step.yml
@@ -4,6 +4,7 @@
 steps:
 - task: PythonScript@0
   displayName: 'Set Python manylinux variables'
+  pythonInterpreter: /usr/bin/python3
   inputs:
     scriptSource: inline
     script: |

--- a/tools/ci_build/github/azure-pipelines/templates/set-python-manylinux-variables-step.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/set-python-manylinux-variables-step.yml
@@ -4,8 +4,8 @@
 steps:
 - task: PythonScript@0
   displayName: 'Set Python manylinux variables'
-  pythonInterpreter: /usr/bin/python3
   inputs:
+    pythonInterpreter: /usr/bin/python3
     scriptSource: inline
     script: |
       version = "$(PythonVersion)"


### PR DESCRIPTION
### Description
Set pythonInterpreter in set-python-manylinux-variables-step.yml. To fix a build error:

```
Starting: Set Python manylinux variables
==============================================================================
Task         : Python script
Description  : Run a Python file or inline script
Version      : 0.231.1
Author       : Microsoft Corporation
Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/python-script
==============================================================================
##[error]Parameter 'toolPath' cannot be null or empty.
Finishing: Set Python manylinux variables
```
The error was because today I deleted a bunch of software from the VM image.  The task might fail if no Python versions are found in $(Agent.ToolsDirectory).  I haven't populate the folder yet.  I need to run https://github.com/actions/runner-images/blob/main/images/ubuntu/scripts/build/Install-Toolset.ps1  when building the images.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


