### PR TITLE
Set default flags nvcc and do not set default compile flags for ROCM EP

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1485,6 +1485,7 @@ def generate_build_tree(
             and not args.ios
             and not args.android
             and not args.build_wasm
+            and not args.use_rocm
             and not (is_linux() and platform.machine() != "aarch64" and platform.machine() != "x86_64")
         ):
             if is_windows():
@@ -1528,7 +1529,7 @@ def generate_build_tree(
                     if len(cuda_compile_flags_str) != 0:
                         cudaflags.append('-Xcompiler="%s"' % cuda_compile_flags_str)
             elif is_linux() or is_macOS():
-                if is_linux() and not args.use_rocm:
+                if is_linux():
                     ldflags = ["-Wl,-Bsymbolic-functions", "-Wl,-z,relro", "-Wl,-z,now"]
                 else:
                     ldflags = []

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1530,7 +1530,7 @@ def generate_build_tree(
                         cudaflags.append('-Xcompiler="%s"' % cuda_compile_flags_str)
             elif is_linux() or is_macOS():
                 if is_linux():
-                    ldflags = ["-Wl,-Bsymbolic-functions", "-Wl,-z,relro", "-Wl,-z,now"]
+                    ldflags = ["-Wl,-Bsymbolic-functions", "-Wl,-z,relro", "-Wl,-z,now", "-Wl,-z,noexecstack"]
                 else:
                     ldflags = []
                 if config == "Release":

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1524,11 +1524,11 @@ def generate_build_tree(
                         if compile_flag.startswith("/D"):
                             cudaflags.append(compile_flag)
                         else:
-                            cuda_compile_flags_str =cuda_compile_flags_str + " " +  compile_flag
-                    if len(cuda_compile_flags_str) !=0:
-                        cudaflags.append("-Xcompiler=\"%s\"" %  cuda_compile_flags_str)
+                            cuda_compile_flags_str = cuda_compile_flags_str + " " + compile_flag
+                    if len(cuda_compile_flags_str) != 0:
+                        cudaflags.append('-Xcompiler="%s"' % cuda_compile_flags_str)
             elif is_linux() or is_macOS():
-                if is_linux():
+                if is_linux() and not args.use_rocm:
                     ldflags = ["-Wl,-Bsymbolic-functions", "-Wl,-z,relro", "-Wl,-z,now"]
                 else:
                     ldflags = []


### PR DESCRIPTION
### Description
Set default flags nvcc and do not set the flags for ROCM EP. 


### Motivation and Context
1. To meet a BinSkim requirement for CUDA EP.
https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2024EnableSpectreMitigations

2. The ROCM EP's pipeline is broken since PR #19073 . Unit tests failed to load the EP with the following error message:

Failed to load library libonnxruntime_providers_rocm.so with error: /build/Release/libonnxruntime_providers_rocm.so: undefined symbol: vtable for onnxruntime::InsertMaxPoolOutput . 

This PR is a hot fix to bring the pipeline back. So far I don't know why the error happened.  The symbol "InsertMaxPoolOutput" is in onnxruntime_optimizers. I don't see any EP code references it directly. 
