### PR TITLE
Dynamically load ort-wasm*.js according to the EP name

### DIFF
--- a/js/web/lib/backend-wasm.ts
+++ b/js/web/lib/backend-wasm.ts
@@ -50,7 +50,7 @@ export class OnnxruntimeWebAssemblyBackend implements Backend {
     initializeFlags();
 
     // init wasm
-    await initializeWebAssemblyAndOrtRuntime();
+    await initializeWebAssemblyAndOrtRuntime(backendName);
 
     // performe EP specific initialization
     await initializeOrtEp(backendName);

--- a/js/web/lib/wasm/proxy-messages.ts
+++ b/js/web/lib/wasm/proxy-messages.ts
@@ -44,7 +44,7 @@ interface MessageError {
 
 interface MessageInitWasm extends MessageError {
   type: 'init-wasm';
-  in ?: Env;
+  in ?: {env: Env; epName: string};
   out?: never;
 }
 

--- a/js/web/lib/wasm/proxy-worker/main.ts
+++ b/js/web/lib/wasm/proxy-worker/main.ts
@@ -43,11 +43,12 @@ self.onmessage = (ev: MessageEvent<OrtWasmMessage>): void => {
   const {type, in : message} = ev.data;
   try {
     switch (type) {
-      case 'init-wasm':
-        initializeWebAssembly(message!.wasm)
+      case 'init-wasm': {
+        const {env, epName} = message!;
+        initializeWebAssembly(env!.wasm, epName)
             .then(
                 () => {
-                  initRuntime(message!).then(
+                  initRuntime(env!).then(
                       () => {
                         postMessage({type});
                       },
@@ -59,6 +60,7 @@ self.onmessage = (ev: MessageEvent<OrtWasmMessage>): void => {
                   postMessage({type, err});
                 });
         break;
+      }
       case 'init-ep': {
         const {epName, env} = message!;
         initEp(env, epName)

--- a/js/web/lib/wasm/proxy-wrapper.ts
+++ b/js/web/lib/wasm/proxy-wrapper.ts
@@ -64,7 +64,7 @@ const onProxyWorkerMessage = (ev: MessageEvent<OrtWasmMessage>): void => {
 
 const scriptSrc = typeof document !== 'undefined' ? (document?.currentScript as HTMLScriptElement)?.src : undefined;
 
-export const initializeWebAssemblyAndOrtRuntime = async(): Promise<void> => {
+export const initializeWebAssemblyAndOrtRuntime = async(epName: string): Promise<void> => {
   if (initialized) {
     return;
   }
@@ -100,13 +100,13 @@ export const initializeWebAssemblyAndOrtRuntime = async(): Promise<void> => {
       proxyWorker.onmessage = onProxyWorkerMessage;
       URL.revokeObjectURL(workerUrl);
       initWasmCallbacks = [resolve, reject];
-      const message: OrtWasmMessage = {type: 'init-wasm', in : env};
+      const message: OrtWasmMessage = {type: 'init-wasm', in : {env, epName}};
       proxyWorker.postMessage(message);
     });
 
   } else {
     try {
-      await initializeWebAssembly(env.wasm);
+      await initializeWebAssembly(env.wasm, epName);
       await core.initRuntime(env);
       initialized = true;
     } catch (e) {

--- a/js/web/lib/wasm/wasm-factory.ts
+++ b/js/web/lib/wasm/wasm-factory.ts
@@ -113,10 +113,11 @@ export const initializeWebAssembly = async(flags: Env.WebAssemblyFlags, epName: 
   // this would cause other ep (e.g. webnn ep) fail in npm test if it is not compiled in the ort-wasm*.jsep.js.
   // Overrides ortWasmFactory and ortWasmFactoryThreaded to dynamically load ort-wasm*.js according to the epName.
   if (BUILD_DEFS.DISABLE_TRAINING && epName != 'webgpu') {
-    ortWasmFactory = require('./binding/ort-wasm.js');
+    ortWasmFactory = useSimd ? require('./binding/ort-wasm-simd.js') : require('./binding/ort-wasm.js');
   }
   if (!BUILD_DEFS.DISABLE_WASM_THREAD && useThreads && epName != 'webgpu') {
-    ortWasmFactoryThreaded = require('./binding/ort-wasm-threaded.js');
+    ortWasmFactoryThreaded = useSimd ? require('./binding/ort-wasm-simd-threaded.js') :
+                                       require('./binding/ort-wasm-threaded.js');
   }
 
   const wasmPaths = flags.wasmPaths;


### PR DESCRIPTION
In wasm-factory.ts file, if the BUILD_DEFS.DISABLE_WEBGPU is false, it will load the ort-wasm*.jsep.js by default, which would cause other ep (e.g. webnn ep) fail in npm test if it is not compiled in the ort-wasm*.jsep.js. This PR is intent to dynamically load the ort-wasm*.js according to the ep name.