### PR TITLE
Add Big models pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -17,8 +17,6 @@ resources:
     name: pypa/manylinux
     ref: 5eda9aded5462201e6310105728d33016e637ea7
 
-resources:
-  repositories:
   - repository: LLaMa2Onnx
     type: Github
     endpoint: Microsoft

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -223,7 +223,13 @@ stages:
         downloadPath: $(Build.BinariesDirectory)/llama2_onnx_ft16
 
     - script: |
+        ls -l $(Build.BinariesDirectory)/llama2_onnx_ft16/7B_FT_float16/ONNX/
+        ls -l
+      displayName: Check files
+      workingDirectory: $(Build.SourcesDirectory)
+
+    - script: |
         python MinimumExample/Example_ONNX_LlamaV2.py --onnx_file $(Agent.TempDirectory)/llama2_onnx_ft16/7B_FT_float16/ONNX/LlamaV2_7B_FT_float16.onnx
           --embedding_file $(Agent.TempDirectory)/llama2_onnx_ft16/7B_FT_float16/embeddings.pth --tokenizer_path tokenizer.model --prompt "What is the lightest element?"
       displayName: 'Run llama2 model'
-      workingDirectory: $(Build.SourcesDirectory)/LLaMa2Onnx
+      workingDirectory: $(Build.SourcesDirectory)

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -1,7 +1,7 @@
 stages:
-- stage: Stale diffusion
+- stage: Stale_Diffusion
   jobs:
-  - job: Stale diffusion
+  - job: Stale_Diffusion
     variables:
       skipComponentGovernanceDetection: true
     workspace:

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -191,7 +191,7 @@ stages:
       skipComponentGovernanceDetection: true
     workspace:
       clean: all
-    pool: onnxruntime-Linux-GPU-A10-12G
+    pool: onnxruntime-Linux-GPU-T4
     steps:
     - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
       displayName: 'Clean Agent Directories'

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -123,8 +123,9 @@ stages:
           find -executable -type f > $(Build.BinariesDirectory)/Release/perms.txt
 
     - script: |
-        set -ex; \
-        cp $(Build.BinariesDirectory)/Release/dist/*.whl $(Agent.TempDirectory)/ort
+        set -ex
+        mkdir -p $(Agent.TempDirectory)/ort
+        cp $(Build.BinariesDirectory)/Release/dist/*.whl $(Agent.TempDirectory)/ort/
       displayName: 'Copy Wheels'
 
     - task: PublishPipelineArtifact@0
@@ -226,7 +227,7 @@ stages:
         python -m pip install --upgrade pip;
         python -m pip install $(Build.BinariesDirectory)/ort-artifact/*.whl;
         ls -l
-        ls -l $(Build.SourcesDirectory)/llama2_onnx_ft16/7B_FT_float16/ONNX/
+        ls -l $(Build.SourcesDirectory)/7B_FT_float16/ONNX/
       displayName: Install Onnxruntime
       workingDirectory: $(Build.SourcesDirectory)
 

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -113,13 +113,6 @@ stages:
                   ccache -z"
         workingDirectory: $(Build.SourcesDirectory)
 
-    - task: PythonScript@0
-      displayName: 'Build wheel'
-      inputs:
-        scriptPath: '$(Build.SourcesDirectory)\setup.py'
-        arguments: 'bdist_wheel'
-        workingDirectory: '$(Build.BinariesDirectory)\Release'
-
     - task: CmdLine@2
       inputs:
         script: |

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -165,7 +165,7 @@ stages:
             set -ex; \
             python3 --version; \
             python3 -m pip install --upgrade pip; \
-            python3 -m pip install /Release/dist/*.whl; \
+            python3 -m pip install /Release/*.whl; \
             pushd /workspace/onnxruntime/python/tools/transformers/models/stable_diffusion; \
             python3 -m pip install -r requirements-cuda11.txt; \
             python3 -m pip install --upgrade polygraphy onnx-graphsurgeon --extra-index-url https://pypi.ngc.nvidia.com; \
@@ -223,9 +223,11 @@ stages:
         downloadPath: $(Build.BinariesDirectory)/llama2_onnx_ft16
 
     - script: |
-        ls -l $(Build.BinariesDirectory)/llama2_onnx_ft16/7B_FT_float16/ONNX/
+        python -m pip install --upgrade pip;
+        python -m pip install $(Build.BinariesDirectory)/ort-artifact/*.whl;
         ls -l
-      displayName: Check files
+        ls -l $(Build.SourcesDirectory)/llama2_onnx_ft16/7B_FT_float16/ONNX/
+      displayName: Install Onnxruntime
       workingDirectory: $(Build.SourcesDirectory)
 
     - script: |

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -213,6 +213,7 @@ stages:
       inputs:
         packageType: upack
         feed: '/7424c8e4-5c62-490e-95c4-79446f31017c'
+        version: 1.0.0
         definition: '772ebce3-7e06-46d5-b3cc-82040ec4b2ce'
         downloadPath: $(Build.BinariesDirectory)/llama2_onnx_ft16
 

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -232,19 +232,20 @@ stages:
         UpdateDepsTxt: false
 
     - script: |
-        docker run --rm --gpus all -v $PWD:/workspace -v $(Build.SourcesDirectory)/Llama-2-Onnx:/workspace \
+        docker run --rm --gpus all -v $(Build.SourcesDirectory)/Llama-2-Onnx:/workspace \
            -v $(Build.BinariesDirectory)/ort-artifact/:/ort-artifact \
-           -v $(Agent.TempDirectory)/llama2_onnx_ft16:/models onnxruntimeubi8packagestest \
-          bash -c "
-            set -ex; \
-            python3 -m pip install --upgrade pip ; \
-            python3 -m pip install /ort-artifact/*.whl ; \
-            python3 -m pip install torch --index-url https://download.pytorch.org/whl/cu118 ; \
-            python3 -m pip install sentencepiece ; \
-            pushd /workspace ; \
-            python3 python MinimumExample/Example_ONNX_LlamaV2.py --onnx_file /models/ONNX/LlamaV2_7B_FT_float16.onnx \
-              --embedding_file /models/embeddings.pth --tokenizer_path tokenizer.model --prompt "What is the lightest element?" ; \
-            popd ; \
-          "
+           -v $(Agent.TempDirectory)/llama2_onnx_ft16:/models \
+           onnxruntimeubi8packagestest \
+            bash -c "
+              set -ex; \
+              python3 -m pip install --upgrade pip ; \
+              python3 -m pip install /ort-artifact/*.whl ; \
+              python3 -m pip install torch --index-url https://download.pytorch.org/whl/cu118 ; \
+              python3 -m pip install sentencepiece ; \
+              pushd /workspace ; \
+              python3 python MinimumExample/Example_ONNX_LlamaV2.py --onnx_file /models/ONNX/LlamaV2_7B_FT_float16.onnx \
+                --embedding_file /models/embeddings.pth --tokenizer_path tokenizer.model --prompt "What is the lightest element?" ; \
+              popd ; \
+            "
       displayName: 'Run Llama2 demo'
       workingDirectory: $(Build.SourcesDirectory)

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -113,13 +113,12 @@ stages:
                   ccache -z"
         workingDirectory: $(Build.SourcesDirectory)
 
-    - ${{ if eq(parameters.EnablePython, true) }}:
-        - task: PythonScript@0
-          displayName: 'Build wheel'
-          inputs:
-            scriptPath: '$(Build.SourcesDirectory)\setup.py'
-            arguments: 'bdist_wheel'
-            workingDirectory: '$(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\${{ parameters.BuildConfig }}'
+    - task: PythonScript@0
+      displayName: 'Build wheel'
+      inputs:
+        scriptPath: '$(Build.SourcesDirectory)\setup.py'
+        arguments: 'bdist_wheel'
+        workingDirectory: '$(Build.BinariesDirectory)\Release'
 
     - task: CmdLine@2
       inputs:

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -108,9 +108,9 @@ stages:
                 --enable_cuda_profiling --enable_cuda_nhwc_ops \
                 --enable_pybind --build_java \
                 --use_cache \
-                --cmake_extra_defines  CMAKE_CUDA_ARCHITECTURES=75;86; \
-                  ccache -sv; \
-                  ccache -z"
+                --cmake_extra_defines  'CMAKE_CUDA_ARCHITECTURES=75;86' ; \
+                ccache -sv; \
+                ccache -z"
         workingDirectory: $(Build.SourcesDirectory)
 
     - task: CmdLine@2

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -126,7 +126,7 @@ stages:
 
 - stage: Stale_Diffusion
   dependsOn:
-  - Linux_Build
+  - Build_Onnxruntime_Cuda
   jobs:
   - job: Stale_Diffusion
     variables:
@@ -170,11 +170,12 @@ stages:
       workingDirectory: $(Build.SourcesDirectory)
 
 - stage: Llama2_ONNX_FP16
+  dependsOn:
+  - Build_Onnxruntime_Cuda
   jobs:
   - job: Llama2_ONNX_FP16
     variables:
       skipComponentGovernanceDetection: true
-      CCACHE_DIR: $(Pipeline.Workspace)/ccache
     workspace:
       clean: all
     pool: onnxruntime-Linux-GPU-A10-12G

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -227,6 +227,7 @@ stages:
         python -m pip install --upgrade pip;
         python -m pip install $(Build.BinariesDirectory)/ort-artifact/*.whl;
         ls -l
+        ls -l $(Agent.TempDirectory)/llama2_onnx_ft16
         ls -l $(Agent.TempDirectory)/llama2_onnx_ft16/7B_FT_float16/ONNX/
       displayName: Install Onnxruntime
       workingDirectory: $(Build.SourcesDirectory)

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -202,8 +202,8 @@ stages:
       condition: always()
 
     - task: UsePythonVersion@0:
-        inputs:
-          VersionSpec: '3.10'
+      inputs:
+        VersionSpec: '3.10'
       displayName: 'Use Python 3.10'
 
     - template: templates/flex-downloadPipelineArtifact.yml

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -125,6 +125,8 @@ stages:
     - template: templates/explicitly-defined-final-tasks.yml
 
 - stage: Stale_Diffusion
+  dependsOn:
+  - Linux_Build
   jobs:
   - job: Stale_Diffusion
     variables:
@@ -133,16 +135,7 @@ stages:
     workspace:
       clean: all
     pool: onnxruntime-Linux-GPU-A10-12G
-    dependsOn:
-    - Linux_Build
     steps:
-    - task: tem@2
-      displayName: 'Download Pipeline Artifact'
-      inputs:
-        buildType: 'current'
-        artifactName: 'drop-linux'
-        targetPath: '$(Build.BinariesDirectory)/Release'
-
     - checkout: self
       clean: true
       submodules: none

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -8,7 +8,7 @@ stages:
       CCACHE_DIR: $(Pipeline.Workspace)/ccache
     workspace:
       clean: all
-    pool: onnxruntime-Linux-GPU-A10-16G
+    pool: onnxruntime-Linux-GPU-A10-12G
     steps:
     - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
       displayName: 'Clean Agent Directories'

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -228,12 +228,12 @@ stages:
         python -m pip install $(Build.BinariesDirectory)/ort-artifact/*.whl;
         ls -l
         ls -l $(Agent.TempDirectory)/llama2_onnx_ft16
-        ls -l $(Agent.TempDirectory)/llama2_onnx_ft16/7B_FT_float16/ONNX/
+        ls -l $(Agent.TempDirectory)/llama2_onnx_ft16/ONNX/
       displayName: Install Onnxruntime
       workingDirectory: $(Build.SourcesDirectory)
 
     - script: |
-        python MinimumExample/Example_ONNX_LlamaV2.py --onnx_file $(Agent.TempDirectory)/llama2_onnx_ft16/7B_FT_float16/ONNX/LlamaV2_7B_FT_float16.onnx
-          --embedding_file $(Agent.TempDirectory)/llama2_onnx_ft16/7B_FT_float16/embeddings.pth --tokenizer_path tokenizer.model --prompt "What is the lightest element?"
+        python MinimumExample/Example_ONNX_LlamaV2.py --onnx_file $(Agent.TempDirectory)/llama2_onnx_ft16/ONNX/LlamaV2_7B_FT_float16.onnx
+          --embedding_file $(Agent.TempDirectory)/llama2_onnx_ft16/embeddings.pth --tokenizer_path tokenizer.model --prompt "What is the lightest element?"
       displayName: 'Run llama2 model'
       workingDirectory: $(Build.SourcesDirectory)

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -116,11 +116,17 @@ stages:
           cd $(Build.BinariesDirectory)/Release
           find -executable -type f > $(Build.BinariesDirectory)/Release/perms.txt
 
+    - script: |
+        set -ex; \
+        cp $(Build.BinariesDirectory)/Release/dist/*.whl $(Agent.TempDirectory)/
+      displayName: 'Copy Wheels'
+
+
     - task: PublishPipelineArtifact@0
       displayName: 'Publish Pipeline Artifact'
       inputs:
         artifactName: 'drop-ort-linux-gpu'
-        targetPath: '$(Build.BinariesDirectory)/Release'
+        targetPath: '$(Agent.TempDirectory)/'
 
     - template: templates/explicitly-defined-final-tasks.yml
 
@@ -144,7 +150,7 @@ stages:
       parameters:
         StepName: 'Download Onnxruntime Artifact'
         ArtifactName: 'drop-ort-linux-gpu'
-        TargetPath: '$(Build.BinariesDirectory)\ort-artifact\'
+        TargetPath: '$(Build.BinariesDirectory)/ort-artifact/'
         SpecificArtifact: ${{ parameters.specificArtifact }}
         BuildId: ${{ parameters.BuildId }}
 
@@ -152,6 +158,7 @@ stages:
         docker run --rm --gpus all -v $PWD:/workspace -v $(Build.BinariesDirectory)/ort-artifact:/Release nvcr.io/nvidia/pytorch:23.10-py3 \
           bash -c "
             set -ex; \
+            python3 --version; \
             python3 -m pip install --upgrade pip; \
             python3 -m pip install /Release/dist/*.whl; \
             pushd /workspace/onnxruntime/python/tools/transformers/models/stable_diffusion; \

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -227,8 +227,8 @@ stages:
         python -m pip install --upgrade pip
         python -m pip install $(Build.BinariesDirectory)/ort-artifact/*.whl
         python -m pip install torch --index-url https://download.pytorch.org/whl/cu118
-        ls -l
-        ls -l $(Agent.TempDirectory)/llama2_onnx_ft16/ONNX/
+        python -m pip install sentencepiece
+        ls -l $(Agent.TempDirectory)/llama2_onnx_ft16/
       displayName: Install Onnxruntime
       workingDirectory: $(Build.SourcesDirectory)
 

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -225,28 +225,24 @@ stages:
 
     - template: templates/get-docker-image-steps.yml
       parameters:
-        Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2_28_cuda
-        Context: tools/ci_build/github/linux/docker
-        DockerBuildArgs: "
-        --network=host
-        --build-arg BASEIMAGE=$(docker_base_image)
-        --build-arg TRT_VERSION=$(linux_trt_version)
-        --build-arg BUILD_UID=$( id -u )
-        "
-        Repository: onnxruntimecuda11build
+        Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.package_ubi8_cuda11_8_tensorrt8_6
+        Context: tools/ci_build/github/linux/docker/
+        DockerBuildArgs: "--build-arg BUILD_UID=$( id -u )"
+        Repository: onnxruntimeubi8packagestest
+        UpdateDepsTxt: false
 
     - script: |
         docker run --rm --gpus all -v $PWD:/workspace -v $(Build.SourcesDirectory):/workspace \
            -v $(Build.BinariesDirectory)/ort-artifact/:/ort-artifact \
-           -v $(Agent.TempDirectory)/llama2_onnx_ft16:/models onnxruntimecuda11build \
+           -v $(Agent.TempDirectory)/llama2_onnx_ft16:/models onnxruntimeubi8packagestest \
           bash -c "
             set -ex; \
-            /opt/python/cp38-cp38/bin/python3 -m pip install --upgrade pip ; \
-            /opt/python/cp38-cp38/bin/python3 -m pip install /ort-artifact/*.whl ; \
-            /opt/python/cp38-cp38/bin/python3 -m pip install torch --index-url https://download.pytorch.org/whl/cu118 ; \
-            /opt/python/cp38-cp38/bin/python3 -m pip install sentencepiece ; \
-            pushd /workspace ;\
-            /opt/python/cp38-cp38/bin/python3 python MinimumExample/Example_ONNX_LlamaV2.py --onnx_file /models/ONNX/LlamaV2_7B_FT_float16.onnx \
+            python3 -m pip install --upgrade pip ; \
+            python3 -m pip install /ort-artifact/*.whl ; \
+            python3 -m pip install torch --index-url https://download.pytorch.org/whl/cu118 ; \
+            python3 -m pip install sentencepiece ; \
+            pushd /workspace ; \
+            python3 python MinimumExample/Example_ONNX_LlamaV2.py --onnx_file /models/ONNX/LlamaV2_7B_FT_float16.onnx \
               --embedding_file /models/embeddings.pth --tokenizer_path tokenizer.model --prompt "What is the lightest element?" ; \
             popd ; \
           "

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -91,7 +91,7 @@ stages:
               set -ex; \
               env; \
               ccache -s; \
-              /opt/python/cp38-cp38/bin/python3 /onnxruntime_src/tools/ci_build/build.py \
+              /opt/python/cp310-cp310/bin/python3 /onnxruntime_src/tools/ci_build/build.py \
                 --build_dir /build --cmake_generator Ninja \
                 --config Release --update --build \
                 --skip_submodule_sync \
@@ -102,7 +102,7 @@ stages:
                 --enable_cuda_profiling --enable_cuda_nhwc_ops \
                 --enable_pybind --build_java \
                 --use_cache \
-                --cmake_extra_defines  CMAKE_CUDA_ARCHITECTURES=75; \
+                --cmake_extra_defines  CMAKE_CUDA_ARCHITECTURES=86; \
                   ccache -sv; \
                   ccache -z"
         workingDirectory: $(Build.SourcesDirectory)

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -2,41 +2,41 @@ stages:
 - stage: Stale diffusion
   jobs:
   - job: Stale diffusion
-  variables:
-    skipComponentGovernanceDetection: true
-  workspace:
-    clean: all
-  pool: onnxruntime-Linux-GPU-A10-16G
-  steps:
-  - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
-    displayName: 'Clean Agent Directories'
-    condition: always()
+    variables:
+      skipComponentGovernanceDetection: true
+    workspace:
+      clean: all
+    pool: onnxruntime-Linux-GPU-A10-16G
+    steps:
+    - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
+      displayName: 'Clean Agent Directories'
+      condition: always()
 
-  - checkout: self
-    clean: true
-    submodules: none
+    - checkout: self
+      clean: true
+      submodules: none
 
-  - script: |
-      docker run --rm --gpus all -v $PWD:/workspace nvcr.io/nvidia/pytorch:23.10-py3 \
-        bash -c "
-          set -ex; \
-          export CUDACXX=/usr/local/cuda-12.2/bin/nvcc; \
-          git config --global --add safe.directory '*'; \
-          sh build.sh --config Release  --build_shared_lib --parallel --use_cuda --cuda_version 12.2 \
-                      --cuda_home /usr/local/cuda-12.2 --cudnn_home /usr/lib/x86_64-linux-gnu/ --build_wheel --skip_tests \
-                      --use_tensorrt --tensorrt_home /usr/src/tensorrt \
-                      --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF \
-                      --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=86 \
-                      --allow_running_as_root; \
-          python3 -m pip install --upgrade pip; \
-          python3 -m pip install build/Linux/Release/dist/onnxruntime_gpu-1.17.0-cp310-cp310-linux_x86_64.whl --force-reinstall; \
-          pushd /workspace/onnxruntime/python/tools/transformers/models/stable_diffusion; \
-          python3 -m pip install -r requirements-cuda12.txt; \
-          python3 -m pip install --upgrade polygraphy onnx-graphsurgeon --extra-index-url https://pypi.ngc.nvidia.com; \
-          echo "Generate an image guided by a text prompt"
-          python3 demo_txt2img.py "astronaut riding a horse on mars";\
-          python3 demo_txt2img_xl.py "starry night over Golden Gate Bridge by van gogh"; \
-          popd; \
-        "
-    displayName: 'Hello world'
-    workingDirectory: $(Build.SourcesDirectory)
+    - script: |
+        docker run --rm --gpus all -v $PWD:/workspace nvcr.io/nvidia/pytorch:23.10-py3 \
+          bash -c "
+            set -ex; \
+            export CUDACXX=/usr/local/cuda-12.2/bin/nvcc; \
+            git config --global --add safe.directory '*'; \
+            sh build.sh --config Release  --build_shared_lib --parallel --use_cuda --cuda_version 12.2 \
+                        --cuda_home /usr/local/cuda-12.2 --cudnn_home /usr/lib/x86_64-linux-gnu/ --build_wheel --skip_tests \
+                        --use_tensorrt --tensorrt_home /usr/src/tensorrt \
+                        --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF \
+                        --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=86 \
+                        --allow_running_as_root; \
+            python3 -m pip install --upgrade pip; \
+            python3 -m pip install build/Linux/Release/dist/onnxruntime_gpu-1.17.0-cp310-cp310-linux_x86_64.whl --force-reinstall; \
+            pushd /workspace/onnxruntime/python/tools/transformers/models/stable_diffusion; \
+            python3 -m pip install -r requirements-cuda12.txt; \
+            python3 -m pip install --upgrade polygraphy onnx-graphsurgeon --extra-index-url https://pypi.ngc.nvidia.com; \
+            echo "Generate an image guided by a text prompt"; \
+            python3 demo_txt2img.py "astronaut riding a horse on mars"; \
+            python3 demo_txt2img_xl.py "starry night over Golden Gate Bridge by van gogh"; \
+            popd; \
+          "
+      displayName: 'Hello world'
+      workingDirectory: $(Build.SourcesDirectory)

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -244,7 +244,7 @@ stages:
               python3 -m pip install sentencepiece ; \
               pushd /workspace ; \
               python3 MinimumExample/Example_ONNX_LlamaV2.py --onnx_file /models/ONNX/LlamaV2_7B_FT_float16.onnx \
-                --embedding_file /models/embeddings.pth --tokenizer_path tokenizer.model --prompt "What is the lightest element?" ; \
+                --embedding_file /models/embeddings.pth --tokenizer_path tokenizer.model --prompt 'What is the lightest element?' ; \
               popd ; \
             "
       displayName: 'Run Llama2 demo'

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -46,7 +46,6 @@ stages:
                         --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF \
                         --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=86 \
                         --allow_running_as_root; \
-                        --use_cache; \
           "
       displayName: 'Build Onnxruntime'
       workingDirectory: $(Build.SourcesDirectory)

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -133,7 +133,7 @@ stages:
       displayName: 'Publish Pipeline Artifact'
       inputs:
         artifactName: 'drop-ort-linux-gpu'
-        targetPath: '$(Agent.TempDirectory)/ort'
+        targetPath: '$(Build.BinariesDirectory)/Release'
 
     - template: templates/explicitly-defined-final-tasks.yml
 
@@ -157,7 +157,7 @@ stages:
       parameters:
         StepName: 'Download Onnxruntime Artifact'
         ArtifactName: 'drop-ort-linux-gpu'
-        TargetPath: '$(Build.BinariesDirectory)/ort-artifact/'
+        TargetPath: '$(Build.BinariesDirectory)/Release'
         SpecificArtifact: ${{ parameters.specificArtifact }}
         BuildId: ${{ parameters.BuildId }}
 
@@ -165,12 +165,12 @@ stages:
         ls -l $(Build.BinariesDirectory)/ort-artifact
 
     - script: |
-        docker run --rm --gpus all -v $PWD:/workspace -v $(Build.BinariesDirectory)/ort-artifact:/Release nvcr.io/nvidia/pytorch:23.10-py3 \
+        docker run --rm --gpus all -v $PWD:/workspace -v $(Build.BinariesDirectory)/Release:/Release nvcr.io/nvidia/pytorch:23.10-py3 \
           bash -c "
             set -ex; \
             python3 --version; \
             python3 -m pip install --upgrade pip; \
-            python3 -m pip install /Release/*.whl; \
+            python3 -m pip install /Release/dist/*.whl; \
             pushd /workspace/onnxruntime/python/tools/transformers/models/stable_diffusion; \
             python3 -m pip install -r requirements-cuda11.txt; \
             python3 -m pip install --upgrade polygraphy onnx-graphsurgeon --extra-index-url https://pypi.ngc.nvidia.com; \
@@ -219,7 +219,7 @@ stages:
       submodules: none
 
     - script: |
-        az artifacts universal download --organization https://dev.azure.com/onnxruntime --feed onnxruntime --name llama2_onnx_ft16 --version '*' --path $(Agent.TempDirectory)/llama2_onnx_ft16 --skip-download-errors
+        az artifacts universal download --organization https://dev.azure.com/onnxruntime --feed onnxruntime --name llama2_onnx_ft16 --version '*' --path $(Agent.TempDirectory)/llama2_onnx_ft16
       displayName: 'Download llama2 model'
 
     - script: |

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -201,6 +201,11 @@ stages:
       displayName: 'Clean Agent Directories'
       condition: always()
 
+    - task: UsePythonVersion@0:
+        inputs:
+          VersionSpec: '3.10'
+      displayName: 'Use Python 3.10'
+
     - template: templates/flex-downloadPipelineArtifact.yml
       parameters:
         StepName: 'Download Onnxruntime Artifact'

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -108,7 +108,7 @@ stages:
                 --enable_cuda_profiling --enable_cuda_nhwc_ops \
                 --enable_pybind --build_java \
                 --use_cache \
-                --cmake_extra_defines  CMAKE_CUDA_ARCHITECTURES=86; \
+                --cmake_extra_defines  CMAKE_CUDA_ARCHITECTURES=75;86; \
                   ccache -sv; \
                   ccache -z"
         workingDirectory: $(Build.SourcesDirectory)
@@ -122,11 +122,16 @@ stages:
           cd $(Build.BinariesDirectory)/Release
           find -executable -type f > $(Build.BinariesDirectory)/Release/perms.txt
 
+    - script: |
+        set -ex; \
+        cp $(Build.BinariesDirectory)/Release/dist/*.whl $(Agent.TempDirectory)/ort
+      displayName: 'Copy Wheels'
+
     - task: PublishPipelineArtifact@0
       displayName: 'Publish Pipeline Artifact'
       inputs:
         artifactName: 'drop-ort-linux-gpu'
-        targetPath: '$(Build.BinariesDirectory)/Release'
+        targetPath: '$(Agent.TempDirectory)/ort'
 
     - template: templates/explicitly-defined-final-tasks.yml
 
@@ -209,7 +214,7 @@ stages:
       submodules: none
 
     - task: DownloadPackage@1
-      displayName: 'Download ONNX Runtime Build Time Deps'
+      displayName: 'Download Llama2 model'
       inputs:
         packageType: upack
         feed: '/7424c8e4-5c62-490e-95c4-79446f31017c'

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -212,8 +212,8 @@ stages:
       displayName: 'Download ONNX Runtime Build Time Deps'
       inputs:
         packageType: upack
-        feed: '/4c7631f5-24c0-4307-8822-1aa8f180c325'
-        definition: 'fd9dd5ad-b73e-4678-890e-edcf680dbc1a'
+        feed: '/7424c8e4-5c62-490e-95c4-79446f31017c'
+        definition: '772ebce3-7e06-46d5-b3cc-82040ec4b2ce'
         downloadPath: $(Build.BinariesDirectory)/llama2_onnx_ft16
 
     - script: |

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -1,0 +1,42 @@
+stages:
+- stage: Stale diffusion
+  jobs:
+  - job: Stale diffusion
+  variables:
+    skipComponentGovernanceDetection: true
+  workspace:
+    clean: all
+  pool: onnxruntime-Linux-GPU-A10-16G
+  steps:
+  - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
+    displayName: 'Clean Agent Directories'
+    condition: always()
+
+  - checkout: self
+    clean: true
+    submodules: none
+
+  - script: |
+      docker run --rm --gpus all -v $PWD:/workspace nvcr.io/nvidia/pytorch:23.10-py3 \
+        bash -c "
+          set -ex; \
+          export CUDACXX=/usr/local/cuda-12.2/bin/nvcc; \
+          git config --global --add safe.directory '*'; \
+          sh build.sh --config Release  --build_shared_lib --parallel --use_cuda --cuda_version 12.2 \
+                      --cuda_home /usr/local/cuda-12.2 --cudnn_home /usr/lib/x86_64-linux-gnu/ --build_wheel --skip_tests \
+                      --use_tensorrt --tensorrt_home /usr/src/tensorrt \
+                      --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF \
+                      --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=86 \
+                      --allow_running_as_root; \
+          python3 -m pip install --upgrade pip; \
+          python3 -m pip install build/Linux/Release/dist/onnxruntime_gpu-1.17.0-cp310-cp310-linux_x86_64.whl --force-reinstall; \
+          pushd /workspace/onnxruntime/python/tools/transformers/models/stable_diffusion; \
+          python3 -m pip install -r requirements-cuda12.txt; \
+          python3 -m pip install --upgrade polygraphy onnx-graphsurgeon --extra-index-url https://pypi.ngc.nvidia.com; \
+          echo "Generate an image guided by a text prompt"
+          python3 demo_txt2img.py "astronaut riding a horse on mars";\
+          python3 demo_txt2img_xl.py "starry night over Golden Gate Bridge by van gogh"; \
+          popd; \
+        "
+    displayName: 'Hello world'
+    workingDirectory: $(Build.SourcesDirectory)

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -124,6 +124,7 @@ stages:
 
     - script: |
         set -ex; \
+        mkdir -p $(Agent.TempDirectory)/ort
         cp $(Build.BinariesDirectory)/Release/dist/*.whl $(Agent.TempDirectory)/ort
       displayName: 'Copy Wheels'
 

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -197,10 +197,13 @@ stages:
       displayName: 'Clean Agent Directories'
       condition: always()
 
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.8'
-      displayName: 'Use Python 3.8'
+    - checkout: self
+      clean: true
+      submodules: none
+
+    - checkout: LLaMa2Onnx
+      clean: true
+      submodules: none
 
     - template: templates/flex-downloadPipelineArtifact.yml
       parameters:
@@ -209,10 +212,6 @@ stages:
         TargetPath: '$(Build.BinariesDirectory)/ort-artifact/'
         SpecificArtifact: ${{ parameters.specificArtifact }}
         BuildId: ${{ parameters.BuildId }}
-
-    - checkout: LLaMa2Onnx
-      clean: true
-      submodules: none
 
     - task: DownloadPackage@1
       displayName: 'Download Llama2 model'
@@ -225,14 +224,14 @@ stages:
 
     - template: templates/get-docker-image-steps.yml
       parameters:
-        Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.package_ubi8_cuda11_8_tensorrt8_6
+        Dockerfile: onnxruntime/tools/ci_build/github/linux/docker/Dockerfile.package_ubi8_cuda11_8_tensorrt8_6
         Context: tools/ci_build/github/linux/docker/
         DockerBuildArgs: "--build-arg BUILD_UID=$( id -u )"
         Repository: onnxruntimeubi8packagestest
         UpdateDepsTxt: false
 
     - script: |
-        docker run --rm --gpus all -v $PWD:/workspace -v $(Build.SourcesDirectory):/workspace \
+        docker run --rm --gpus all -v $PWD:/workspace -v $(Build.SourcesDirectory)/Llama-2-Onnx:/workspace \
            -v $(Build.BinariesDirectory)/ort-artifact/:/ort-artifact \
            -v $(Agent.TempDirectory)/llama2_onnx_ft16:/models onnxruntimeubi8packagestest \
           bash -c "

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -243,7 +243,7 @@ stages:
               python3 -m pip install torch --index-url https://download.pytorch.org/whl/cu118 ; \
               python3 -m pip install sentencepiece ; \
               pushd /workspace ; \
-              python3 python MinimumExample/Example_ONNX_LlamaV2.py --onnx_file /models/ONNX/LlamaV2_7B_FT_float16.onnx \
+              python3 MinimumExample/Example_ONNX_LlamaV2.py --onnx_file /models/ONNX/LlamaV2_7B_FT_float16.onnx \
                 --embedding_file /models/embeddings.pth --tokenizer_path tokenizer.model --prompt "What is the lightest element?" ; \
               popd ; \
             "

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -201,7 +201,7 @@ stages:
       displayName: 'Clean Agent Directories'
       condition: always()
 
-    - task: UsePythonVersion@0:
+    - task: UsePythonVersion@0
       inputs:
         versionSpec: '3.10'
       displayName: 'Use Python 3.10'

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -149,7 +149,7 @@ stages:
         BuildId: ${{ parameters.BuildId }}
 
     - script: |
-        docker run --rm --gpus all -v $PWD:/workspace $(Build.BinariesDirectory)/ort-artifact:/Release nvcr.io/nvidia/pytorch:23.10-py3 \
+        docker run --rm --gpus all -v $PWD:/workspace -v $(Build.BinariesDirectory)/ort-artifact:/Release nvcr.io/nvidia/pytorch:23.10-py3 \
           bash -c "
             set -ex; \
             python3 -m pip install --upgrade pip; \

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -61,7 +61,7 @@ stages:
             python3 -m pip install --upgrade polygraphy onnx-graphsurgeon --extra-index-url https://pypi.ngc.nvidia.com; \
             echo "Generate an image guided by a text prompt"; \
             python3 demo_txt2img.py "astronaut riding a horse on mars"; \
-            echo "Generate an image with Stable Diffusion XL guided by a text prompt"
+            echo "Generate an image with Stable Diffusion XL guided by a text prompt"; \
             python3 demo_txt2img_xl.py "starry night over Golden Gate Bridge by van gogh"; \
             python3 demo_txt2img_xl.py --enable-refiner "starry night over Golden Gate Bridge by van gogh"; \
             echo "Generate an image guided by a text prompt using LCM LoRA"; \

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -113,6 +113,14 @@ stages:
                   ccache -z"
         workingDirectory: $(Build.SourcesDirectory)
 
+    - ${{ if eq(parameters.EnablePython, true) }}:
+        - task: PythonScript@0
+          displayName: 'Build wheel'
+          inputs:
+            scriptPath: '$(Build.SourcesDirectory)\setup.py'
+            arguments: 'bdist_wheel'
+            workingDirectory: '$(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\${{ parameters.BuildConfig }}'
+
     - task: CmdLine@2
       inputs:
         script: |

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -221,13 +221,13 @@ stages:
         feed: '/7424c8e4-5c62-490e-95c4-79446f31017c'
         version: 1.0.0
         definition: '772ebce3-7e06-46d5-b3cc-82040ec4b2ce'
-        downloadPath: $(Build.BinariesDirectory)/llama2_onnx_ft16
+        downloadPath: $(Agent.TempDirectory)/llama2_onnx_ft16
 
     - script: |
         python -m pip install --upgrade pip;
         python -m pip install $(Build.BinariesDirectory)/ort-artifact/*.whl;
         ls -l
-        ls -l $(Build.SourcesDirectory)/7B_FT_float16/ONNX/
+        ls -l $(Agent.TempDirectory)/llama2_onnx_ft16/7B_FT_float16/ONNX/
       displayName: Install Onnxruntime
       workingDirectory: $(Build.SourcesDirectory)
 

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -191,7 +191,7 @@ stages:
       skipComponentGovernanceDetection: true
     workspace:
       clean: all
-    pool: onnxruntime-Linux-GPU-T4
+    pool: onnxruntime-Linux-GPU-A10-12G
     steps:
     - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
       displayName: 'Clean Agent Directories'

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -34,8 +34,8 @@ stages:
       displayName: Create Cache Dir
 
     - script: |
-        docker run --rm --gpus all -v $PWD:/workspace nvcr.io/nvidia/pytorch:23.10-py3 \
-          -e CCACHE_DIR=/cache \
+        docker run --rm --gpus all -v $PWD:/workspace -e CCACHE_DIR=/cache \
+          nvcr.io/nvidia/pytorch:23.10-py3 \
           bash -c "
             set -ex; \
             export CUDACXX=/usr/local/cuda-12.2/bin/nvcc; \
@@ -52,7 +52,6 @@ stages:
 
     - script: |
         docker run --rm --gpus all -v $PWD:/workspace nvcr.io/nvidia/pytorch:23.10-py3 \
-          -e CCACHE_DIR=/cache \
           bash -c "
             set -ex; \
             python3 -m pip install --upgrade pip; \

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -97,7 +97,7 @@ stages:
               set -ex; \
               env; \
               ccache -s; \
-              /opt/python/cp310-cp310/bin/python3 /onnxruntime_src/tools/ci_build/build.py \
+              /opt/python/cp38-cp38/bin/python3 /onnxruntime_src/tools/ci_build/build.py \
                 --build_dir /build --cmake_generator Ninja \
                 --config Release --update --build \
                 --skip_submodule_sync \
@@ -155,7 +155,7 @@ stages:
         BuildId: ${{ parameters.BuildId }}
 
     - script: |
-        docker run --rm --gpus all -v $PWD:/workspace -v $(Build.BinariesDirectory)/Release:/Release nvcr.io/nvidia/pytorch:23.10-py3 \
+        docker run --rm --gpus all -v $PWD:/workspace -v $(Build.BinariesDirectory)/Release:/Release nvcr.io/nvidia/pytorch:22.11-py3 \
           bash -c "
             set -ex; \
             python3 --version; \
@@ -208,9 +208,13 @@ stages:
       clean: true
       submodules: none
 
-    - script: |
-        az artifacts universal download --organization https://dev.azure.com/onnxruntime --feed onnxruntime --name llama2_onnx_ft16 --version '*' --path $(Agent.TempDirectory)/llama2_onnx_ft16
-      displayName: 'Download llama2 model'
+    - task: DownloadPackage@1
+      displayName: 'Download ONNX Runtime Build Time Deps'
+      inputs:
+        packageType: upack
+        feed: '/4c7631f5-24c0-4307-8822-1aa8f180c325'
+        definition: 'fd9dd5ad-b73e-4678-890e-edcf680dbc1a'
+        downloadPath: $(Build.BinariesDirectory)/llama2_onnx_ft16
 
     - script: |
         python MinimumExample/Example_ONNX_LlamaV2.py --onnx_file $(Agent.TempDirectory)/llama2_onnx_ft16/7B_FT_float16/ONNX/LlamaV2_7B_FT_float16.onnx

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -1,14 +1,25 @@
 # reference: https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/python/tools/transformers/models/stable_diffusion/README.md
+parameters:
+- name: specificArtifact
+  displayName: Use Specific Artifact
+  type: boolean
+  default: false
+- name: BuildId
+  displayName: Specific Artifact's RunId
+  type: number
+  default: 0
+
 stages:
-- stage: Stale_Diffusion
+- stage: Build_Onnxruntime_Cuda
   jobs:
-  - job: Stale_Diffusion
+  - job: Linux_Build
+    timeoutInMinutes: 120
     variables:
       skipComponentGovernanceDetection: true
       CCACHE_DIR: $(Pipeline.Workspace)/ccache
     workspace:
       clean: all
-    pool: onnxruntime-Linux-GPU-A10-12G
+    pool: onnxruntime-Ubuntu2204-AMD-CPU
     steps:
     - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
       displayName: 'Clean Agent Directories'
@@ -17,6 +28,18 @@ stages:
     - checkout: self
       clean: true
       submodules: none
+
+    - template: templates/get-docker-image-steps.yml
+      parameters:
+        Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2_28_cuda
+        Context: tools/ci_build/github/linux/docker
+        DockerBuildArgs: "
+        --network=host
+        --build-arg BASEIMAGE=$(docker_base_image)
+        --build-arg TRT_VERSION=$(linux_trt_version)
+        --build-arg BUILD_UID=$( id -u )
+        "
+        Repository: onnxruntimecuda11build
 
     - task: Cache@2
       inputs:
@@ -33,31 +56,98 @@ stages:
       condition: ne(variables.CACHE_RESTORED, 'true')
       displayName: Create Cache Dir
 
-    - script: |
-        docker run --rm --gpus all -v $PWD:/workspace -e CCACHE_DIR=/cache \
-          nvcr.io/nvidia/pytorch:23.10-py3 \
-          bash -c "
-            set -ex; \
-            export CUDACXX=/usr/local/cuda-12.2/bin/nvcc; \
-            git config --global --add safe.directory '*'; \
-            sh build.sh --config Release  --build_shared_lib --parallel --use_cuda --cuda_version 12.2 \
-                        --cuda_home /usr/local/cuda-12.2 --cudnn_home /usr/lib/x86_64-linux-gnu/ --build_wheel --skip_tests \
-                        --use_tensorrt --tensorrt_home /usr/src/tensorrt \
-                        --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF \
-                        --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=86 \
-                        --allow_running_as_root; \
-          "
-      displayName: 'Build Onnxruntime'
-      workingDirectory: $(Build.SourcesDirectory)
+    - task: CmdLine@2
+      inputs:
+        script: |
+          mkdir -p $HOME/.onnx
+          docker run -e CFLAGS="-Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -fstack-clash-protection -fcf-protection -O3 -Wl,--strip-all" -e CXXFLAGS="-Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -fstack-clash-protection -fcf-protection -O3 -Wl,--strip-all" --rm \
+            --volume /data/onnx:/data/onnx:ro \
+            --volume $(Build.SourcesDirectory):/onnxruntime_src \
+            --volume $(Build.BinariesDirectory):/build \
+            --volume /data/models:/build/models:ro \
+            --volume $HOME/.onnx:/home/onnxruntimedev/.onnx \
+            --volume $(Pipeline.Workspace)/ccache:/cache \
+            -e ALLOW_RELEASED_ONNX_OPSET_ONLY=0 \
+            -e NIGHTLY_BUILD \
+            -e BUILD_BUILDNUMBER \
+            -e CCACHE_DIR=/cache \
+            onnxruntimecuda11build \
+            /bin/bash -c "
+              set -ex; \
+              env; \
+              ccache -s; \
+              /opt/python/cp38-cp38/bin/python3 /onnxruntime_src/tools/ci_build/build.py \
+                --build_dir /build --cmake_generator Ninja \
+                --config Release --update --build \
+                --skip_submodule_sync \
+                --build_shared_lib \
+                --parallel \
+                --build_wheel \
+                --enable_onnx_tests --use_cuda --cuda_version=${{variables.common_cuda_version}} --cuda_home=/usr/local/cuda-${{variables.common_cuda_version}} --cudnn_home=/usr/local/cuda-${{variables.common_cuda_version}} \
+                --enable_cuda_profiling --enable_cuda_nhwc_ops \
+                --enable_pybind --build_java \
+                --use_cache \
+                --cmake_extra_defines  CMAKE_CUDA_ARCHITECTURES=75; \
+                  ccache -sv; \
+                  ccache -z"
+        workingDirectory: $(Build.SourcesDirectory)
+
+    - task: CmdLine@2
+      inputs:
+        script: |
+          rm -rf $(Build.BinariesDirectory)/Release/onnxruntime $(Build.BinariesDirectory)/Release/pybind11
+          rm -f $(Build.BinariesDirectory)/Release/models
+          find $(Build.BinariesDirectory)/Release/_deps -mindepth 1 ! -regex '^$(Build.BinariesDirectory)/Release/_deps/onnx-src\(/.*\)?' -delete
+          cd $(Build.BinariesDirectory)/Release
+          find -executable -type f > $(Build.BinariesDirectory)/Release/perms.txt
+
+    - task: PublishPipelineArtifact@0
+      displayName: 'Publish Pipeline Artifact'
+      inputs:
+        artifactName: 'drop-ort-linux-gpu'
+        targetPath: '$(Build.BinariesDirectory)/Release'
+
+    - template: templates/explicitly-defined-final-tasks.yml
+
+- stage: Stale_Diffusion
+  jobs:
+  - job: Stale_Diffusion
+    variables:
+      skipComponentGovernanceDetection: true
+      CCACHE_DIR: $(Pipeline.Workspace)/ccache
+    workspace:
+      clean: all
+    pool: onnxruntime-Linux-GPU-A10-12G
+    dependsOn:
+    - Linux_Build
+    steps:
+    - task: tem@2
+      displayName: 'Download Pipeline Artifact'
+      inputs:
+        buildType: 'current'
+        artifactName: 'drop-linux'
+        targetPath: '$(Build.BinariesDirectory)/Release'
+
+    - checkout: self
+      clean: true
+      submodules: none
+
+    - template: templates/flex-downloadPipelineArtifact.yml
+      parameters:
+        StepName: 'Download Onnxruntime Artifact'
+        ArtifactName: 'drop-ort-linux-gpu'
+        TargetPath: '$(Build.BinariesDirectory)\ort-artifact\'
+        SpecificArtifact: ${{ parameters.specificArtifact }}
+        BuildId: ${{ parameters.BuildId }}
 
     - script: |
-        docker run --rm --gpus all -v $PWD:/workspace nvcr.io/nvidia/pytorch:23.10-py3 \
+        docker run --rm --gpus all -v $PWD:/workspace $(Build.BinariesDirectory)/ort-artifact:/Release nvcr.io/nvidia/pytorch:23.10-py3 \
           bash -c "
             set -ex; \
             python3 -m pip install --upgrade pip; \
-            python3 -m pip install build/Linux/Release/dist/*.whl; \
+            python3 -m pip install /Release/dist/*.whl; \
             pushd /workspace/onnxruntime/python/tools/transformers/models/stable_diffusion; \
-            python3 -m pip install -r requirements-cuda12.txt; \
+            python3 -m pip install -r requirements-cuda11.txt; \
             python3 -m pip install --upgrade polygraphy onnx-graphsurgeon --extra-index-url https://pypi.ngc.nvidia.com; \
             echo Generate an image guided by a text prompt; \
             python3 demo_txt2img.py "astronaut riding a horse on mars"; \
@@ -70,3 +160,17 @@ stages:
           "
       displayName: 'Run stable diffusion demo'
       workingDirectory: $(Build.SourcesDirectory)
+
+- stage: Llama2_ONNX_FP16
+  jobs:
+  - job: Llama2_ONNX_FP16
+    variables:
+      skipComponentGovernanceDetection: true
+      CCACHE_DIR: $(Pipeline.Workspace)/ccache
+    workspace:
+      clean: all
+    pool: onnxruntime-Linux-GPU-A10-12G
+    steps:
+    - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
+      displayName: 'Clean Agent Directories'
+      condition: always()

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -199,8 +199,8 @@ stages:
 
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '3.10'
-      displayName: 'Use Python 3.10'
+        versionSpec: '3.8'
+      displayName: 'Use Python 3.8'
 
     - template: templates/flex-downloadPipelineArtifact.yml
       parameters:

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -224,16 +224,16 @@ stages:
         downloadPath: $(Agent.TempDirectory)/llama2_onnx_ft16
 
     - script: |
-        python -m pip install --upgrade pip;
-        python -m pip install $(Build.BinariesDirectory)/ort-artifact/*.whl;
+        python -m pip install --upgrade pip
+        python -m pip install $(Build.BinariesDirectory)/ort-artifact/*.whl
+        python -m pip install --index-url https://download.pytorch.org/whl/cu118
         ls -l
-        ls -l $(Agent.TempDirectory)/llama2_onnx_ft16
         ls -l $(Agent.TempDirectory)/llama2_onnx_ft16/ONNX/
       displayName: Install Onnxruntime
       workingDirectory: $(Build.SourcesDirectory)
 
     - script: |
-        python MinimumExample/Example_ONNX_LlamaV2.py --onnx_file $(Agent.TempDirectory)/llama2_onnx_ft16/ONNX/LlamaV2_7B_FT_float16.onnx
+        python MinimumExample/Example_ONNX_LlamaV2.py --onnx_file $(Agent.TempDirectory)/llama2_onnx_ft16/ONNX/LlamaV2_7B_FT_float16.onnx \
           --embedding_file $(Agent.TempDirectory)/llama2_onnx_ft16/embeddings.pth --tokenizer_path tokenizer.model --prompt "What is the lightest element?"
       displayName: 'Run llama2 model'
       workingDirectory: $(Build.SourcesDirectory)

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -122,13 +122,6 @@ stages:
           cd $(Build.BinariesDirectory)/Release
           find -executable -type f > $(Build.BinariesDirectory)/Release/perms.txt
 
-    - script: |
-        set -ex; \
-        mkdir -p $(Agent.TempDirectory)/ort
-        cp $(Build.BinariesDirectory)/Release/dist/*.whl $(Agent.TempDirectory)/ort
-      displayName: 'Copy Wheels'
-
-
     - task: PublishPipelineArtifact@0
       displayName: 'Publish Pipeline Artifact'
       inputs:
@@ -160,9 +153,6 @@ stages:
         TargetPath: '$(Build.BinariesDirectory)/Release'
         SpecificArtifact: ${{ parameters.specificArtifact }}
         BuildId: ${{ parameters.BuildId }}
-
-    - script: |
-        ls -l $(Build.BinariesDirectory)/ort-artifact
 
     - script: |
         docker run --rm --gpus all -v $PWD:/workspace -v $(Build.BinariesDirectory)/Release:/Release nvcr.io/nvidia/pytorch:23.10-py3 \

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -46,6 +46,7 @@ stages:
                         --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF \
                         --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=86 \
                         --allow_running_as_root; \
+                        --use_cache; \
           "
       displayName: 'Build Onnxruntime'
       workingDirectory: $(Build.SourcesDirectory)
@@ -59,12 +60,12 @@ stages:
             pushd /workspace/onnxruntime/python/tools/transformers/models/stable_diffusion; \
             python3 -m pip install -r requirements-cuda12.txt; \
             python3 -m pip install --upgrade polygraphy onnx-graphsurgeon --extra-index-url https://pypi.ngc.nvidia.com; \
-            echo "Generate an image guided by a text prompt"; \
+            echo Generate an image guided by a text prompt; \
             python3 demo_txt2img.py "astronaut riding a horse on mars"; \
-            echo "Generate an image with Stable Diffusion XL guided by a text prompt"; \
-            python3 demo_txt2img_xl.py "starry night over Golden Gate Bridge by van gogh"; \
-            python3 demo_txt2img_xl.py --enable-refiner "starry night over Golden Gate Bridge by van gogh"; \
-            echo "Generate an image guided by a text prompt using LCM LoRA"; \
+            echo Generate an image with Stable Diffusion XL guided by a text prompt; \
+            python3 demo_txt2img_xl.py 'starry night over Golden Gate Bridge by van gogh'; \
+            python3 demo_txt2img_xl.py --enable-refiner 'starry night over Golden Gate Bridge by van gogh'; \
+            echo Generate an image guided by a text prompt using LCM LoRA; \
             python3 demo_txt2img_xl.py --scheduler LCM --lora-weights latent-consistency/lcm-lora-sdxl --denoising-steps 4 "Self-portrait oil painting, a beautiful cyborg with golden hair, 8k"; \
             popd; \
           "

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -203,7 +203,7 @@ stages:
 
     - task: UsePythonVersion@0:
       inputs:
-        VersionSpec: '3.10'
+        versionSpec: '3.10'
       displayName: 'Use Python 3.10'
 
     - template: templates/flex-downloadPipelineArtifact.yml

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -244,8 +244,16 @@ stages:
               python3 -m pip install sentencepiece ; \
               pushd /workspace ; \
               python3 MinimumExample/Example_ONNX_LlamaV2.py --onnx_file /models/ONNX/LlamaV2_7B_FT_float16.onnx \
-                --embedding_file /models/embeddings.pth --tokenizer_path tokenizer.model --prompt 'What is the lightest element?' ; \
+                --embedding_file /models/embeddings.pth --tokenizer_path tokenizer.model --prompt 'What is the lightest element?' > /workspace/answer.txt ; \
               popd ; \
             "
       displayName: 'Run Llama2 demo'
       workingDirectory: $(Build.SourcesDirectory)
+
+    - script: |
+        set -ex
+        real=$(cat $(Build.SourcesDirectory)/Llama-2-Onnx/answer.txt)
+        trim_actual=$(tr -dc '[[:print:]]' <<< "$real")
+        expected="The lightest element is hydrogen. Hydrogen is the lightest element on the periodic table, with an atomic mass of 1.00794 u (unified atomic mass units)."
+        [ "$expected" == "$trim_actual" ] && exit 0 || exit 1
+      displayName: 'Check result'

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -226,7 +226,7 @@ stages:
     - script: |
         python -m pip install --upgrade pip
         python -m pip install $(Build.BinariesDirectory)/ort-artifact/*.whl
-        python -m pip install --index-url https://download.pytorch.org/whl/cu118
+        python -m pip install torch --index-url https://download.pytorch.org/whl/cu118
         ls -l
         ls -l $(Agent.TempDirectory)/llama2_onnx_ft16/ONNX/
       displayName: Install Onnxruntime

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -1,9 +1,11 @@
+# reference: https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/python/tools/transformers/models/stable_diffusion/README.md
 stages:
 - stage: Stale_Diffusion
   jobs:
   - job: Stale_Diffusion
     variables:
       skipComponentGovernanceDetection: true
+      CCACHE_DIR: $(Pipeline.Workspace)/ccache
     workspace:
       clean: all
     pool: onnxruntime-Linux-GPU-A10-16G
@@ -16,8 +18,24 @@ stages:
       clean: true
       submodules: none
 
+    - task: Cache@2
+      inputs:
+        key: '"ccache" | "$(Build.SourceBranch)" | "$(Build.SourceVersion)"'
+        path: $(CCACHE_DIR)
+        restoreKeys: |
+          "ccache" | "$(Build.SourceBranch)"
+          "ccache"
+        cacheHitVar: CACHE_RESTORED
+      displayName: Cach Task
+
+    - script: |
+        sudo mkdir -p $(Pipeline.Workspace)/ccache
+      condition: ne(variables.CACHE_RESTORED, 'true')
+      displayName: Create Cache Dir
+
     - script: |
         docker run --rm --gpus all -v $PWD:/workspace nvcr.io/nvidia/pytorch:23.10-py3 \
+          -e CCACHE_DIR=/cache \
           bash -c "
             set -ex; \
             export CUDACXX=/usr/local/cuda-12.2/bin/nvcc; \
@@ -28,15 +46,28 @@ stages:
                         --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF \
                         --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=86 \
                         --allow_running_as_root; \
+          "
+      displayName: 'Build Onnxruntime'
+      workingDirectory: $(Build.SourcesDirectory)
+
+    - script: |
+        docker run --rm --gpus all -v $PWD:/workspace nvcr.io/nvidia/pytorch:23.10-py3 \
+          -e CCACHE_DIR=/cache \
+          bash -c "
+            set -ex; \
             python3 -m pip install --upgrade pip; \
-            python3 -m pip install build/Linux/Release/dist/onnxruntime_gpu-1.17.0-cp310-cp310-linux_x86_64.whl --force-reinstall; \
+            python3 -m pip install build/Linux/Release/dist/*.whl; \
             pushd /workspace/onnxruntime/python/tools/transformers/models/stable_diffusion; \
             python3 -m pip install -r requirements-cuda12.txt; \
             python3 -m pip install --upgrade polygraphy onnx-graphsurgeon --extra-index-url https://pypi.ngc.nvidia.com; \
             echo "Generate an image guided by a text prompt"; \
             python3 demo_txt2img.py "astronaut riding a horse on mars"; \
+            echo "Generate an image with Stable Diffusion XL guided by a text prompt"
             python3 demo_txt2img_xl.py "starry night over Golden Gate Bridge by van gogh"; \
+            python3 demo_txt2img_xl.py --enable-refiner "starry night over Golden Gate Bridge by van gogh"; \
+            echo "Generate an image guided by a text prompt using LCM LoRA"; \
+            python3 demo_txt2img_xl.py --scheduler LCM --lora-weights latent-consistency/lcm-lora-sdxl --denoising-steps 4 "Self-portrait oil painting, a beautiful cyborg with golden hair, 8k"; \
             popd; \
           "
-      displayName: 'Build Onnxruntime and run stable diffusion demo'
+      displayName: 'Run stable diffusion demo'
       workingDirectory: $(Build.SourcesDirectory)

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -9,6 +9,21 @@ parameters:
   type: number
   default: 0
 
+resources:
+  repositories:
+  - repository: manylinux
+    type: Github
+    endpoint: Microsoft
+    name: pypa/manylinux
+    ref: 5eda9aded5462201e6310105728d33016e637ea7
+
+variables:
+  - template: templates/common-variables.yml
+  - name: docker_base_image
+    value: nvidia/cuda:11.8.0-cudnn8-devel-ubi8
+  - name: linux_trt_version
+    value: 8.6.1.6-1.cuda11.8
+
 stages:
 - stage: Build_Onnxruntime_Cuda
   jobs:

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -223,17 +223,32 @@ stages:
         definition: '772ebce3-7e06-46d5-b3cc-82040ec4b2ce'
         downloadPath: $(Agent.TempDirectory)/llama2_onnx_ft16
 
-    - script: |
-        python -m pip install --upgrade pip
-        python -m pip install $(Build.BinariesDirectory)/ort-artifact/*.whl
-        python -m pip install torch --index-url https://download.pytorch.org/whl/cu118
-        python -m pip install sentencepiece
-        ls -l $(Agent.TempDirectory)/llama2_onnx_ft16/
-      displayName: Install Onnxruntime
-      workingDirectory: $(Build.SourcesDirectory)
+    - template: templates/get-docker-image-steps.yml
+      parameters:
+        Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2_28_cuda
+        Context: tools/ci_build/github/linux/docker
+        DockerBuildArgs: "
+        --network=host
+        --build-arg BASEIMAGE=$(docker_base_image)
+        --build-arg TRT_VERSION=$(linux_trt_version)
+        --build-arg BUILD_UID=$( id -u )
+        "
+        Repository: onnxruntimecuda11build
 
     - script: |
-        python MinimumExample/Example_ONNX_LlamaV2.py --onnx_file $(Agent.TempDirectory)/llama2_onnx_ft16/ONNX/LlamaV2_7B_FT_float16.onnx \
-          --embedding_file $(Agent.TempDirectory)/llama2_onnx_ft16/embeddings.pth --tokenizer_path tokenizer.model --prompt "What is the lightest element?"
-      displayName: 'Run llama2 model'
+        docker run --rm --gpus all -v $PWD:/workspace -v $(Build.SourcesDirectory):/workspace \
+           -v $(Build.BinariesDirectory)/ort-artifact/:/ort-artifact \
+           -v $(Agent.TempDirectory)/llama2_onnx_ft16:/models onnxruntimecuda11build \
+          bash -c "
+            set -ex; \
+            /opt/python/cp38-cp38/bin/python3 -m pip install --upgrade pip ; \
+            /opt/python/cp38-cp38/bin/python3 -m pip install /ort-artifact/*.whl ; \
+            /opt/python/cp38-cp38/bin/python3 -m pip install torch --index-url https://download.pytorch.org/whl/cu118 ; \
+            /opt/python/cp38-cp38/bin/python3 -m pip install sentencepiece ; \
+            pushd /workspace ;\
+            /opt/python/cp38-cp38/bin/python3 python MinimumExample/Example_ONNX_LlamaV2.py --onnx_file /models/ONNX/LlamaV2_7B_FT_float16.onnx \
+              --embedding_file /models/embeddings.pth --tokenizer_path tokenizer.model --prompt "What is the lightest element?" ; \
+            popd ; \
+          "
+      displayName: 'Run Llama2 demo'
       workingDirectory: $(Build.SourcesDirectory)

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -17,6 +17,14 @@ resources:
     name: pypa/manylinux
     ref: 5eda9aded5462201e6310105728d33016e637ea7
 
+resources:
+  repositories:
+  - repository: LLaMa2Onnx
+    type: Github
+    endpoint: Microsoft
+    name: Microsoft/Llama-2-Onnx
+    ref: main
+
 variables:
   - template: templates/common-variables.yml
   - name: docker_base_image
@@ -118,7 +126,7 @@ stages:
 
     - script: |
         set -ex; \
-        cp $(Build.BinariesDirectory)/Release/dist/*.whl $(Agent.TempDirectory)/
+        cp $(Build.BinariesDirectory)/Release/dist/*.whl $(Agent.TempDirectory)/ort
       displayName: 'Copy Wheels'
 
 
@@ -126,7 +134,7 @@ stages:
       displayName: 'Publish Pipeline Artifact'
       inputs:
         artifactName: 'drop-ort-linux-gpu'
-        targetPath: '$(Agent.TempDirectory)/'
+        targetPath: '$(Agent.TempDirectory)/ort'
 
     - template: templates/explicitly-defined-final-tasks.yml
 
@@ -155,12 +163,15 @@ stages:
         BuildId: ${{ parameters.BuildId }}
 
     - script: |
+        ls -l $(Build.BinariesDirectory)/ort-artifact
+
+    - script: |
         docker run --rm --gpus all -v $PWD:/workspace -v $(Build.BinariesDirectory)/ort-artifact:/Release nvcr.io/nvidia/pytorch:23.10-py3 \
           bash -c "
             set -ex; \
             python3 --version; \
             python3 -m pip install --upgrade pip; \
-            python3 -m pip install /Release/dist/*.whl; \
+            python3 -m pip install /Release/*.whl; \
             pushd /workspace/onnxruntime/python/tools/transformers/models/stable_diffusion; \
             python3 -m pip install -r requirements-cuda11.txt; \
             python3 -m pip install --upgrade polygraphy onnx-graphsurgeon --extra-index-url https://pypi.ngc.nvidia.com; \
@@ -185,8 +196,30 @@ stages:
       skipComponentGovernanceDetection: true
     workspace:
       clean: all
-    pool: onnxruntime-Linux-GPU-A10-12G
+    pool: onnxruntime-Linux-GPU-T4
     steps:
     - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
       displayName: 'Clean Agent Directories'
       condition: always()
+
+    - template: templates/flex-downloadPipelineArtifact.yml
+      parameters:
+        StepName: 'Download Onnxruntime Artifact'
+        ArtifactName: 'drop-ort-linux-gpu'
+        TargetPath: '$(Build.BinariesDirectory)/ort-artifact/'
+        SpecificArtifact: ${{ parameters.specificArtifact }}
+        BuildId: ${{ parameters.BuildId }}
+
+    - checkout: LLaMa2Onnx
+      clean: true
+      submodules: none
+
+    - script: |
+        az artifacts universal download --organization https://dev.azure.com/onnxruntime --feed onnxruntime --name llama2_onnx_ft16 --version '*' --path $(Agent.TempDirectory)/llama2_onnx_ft16 --skip-download-errors
+      displayName: 'Download llama2 model'
+
+    - script: |
+        python MinimumExample/Example_ONNX_LlamaV2.py --onnx_file $(Agent.TempDirectory)/llama2_onnx_ft16/7B_FT_float16/ONNX/LlamaV2_7B_FT_float16.onnx
+          --embedding_file $(Agent.TempDirectory)/llama2_onnx_ft16/7B_FT_float16/embeddings.pth --tokenizer_path tokenizer.model --prompt "What is the lightest element?"
+      displayName: 'Run llama2 model'
+      workingDirectory: $(Build.SourcesDirectory)/LLaMa2Onnx

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -225,7 +225,8 @@ stages:
     - template: templates/get-docker-image-steps.yml
       parameters:
         Dockerfile: onnxruntime/tools/ci_build/github/linux/docker/Dockerfile.package_ubi8_cuda11_8_tensorrt8_6
-        Context: tools/ci_build/github/linux/docker/
+        Context: onnxruntime/tools/ci_build/github/linux/docker/
+        ScriptName: onnxruntime/tools/ci_build/get_docker_image.py
         DockerBuildArgs: "--build-arg BUILD_UID=$( id -u )"
         Repository: onnxruntimeubi8packagestest
         UpdateDepsTxt: false

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -38,5 +38,5 @@ stages:
             python3 demo_txt2img_xl.py "starry night over Golden Gate Bridge by van gogh"; \
             popd; \
           "
-      displayName: 'Hello world'
+      displayName: 'Build Onnxruntime and run stable diffusion demo'
       workingDirectory: $(Build.SourcesDirectory)

--- a/tools/ci_build/github/azure-pipelines/linux-gpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-ci-pipeline.yml
@@ -78,9 +78,9 @@ jobs:
       Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2_28_cuda
       Context: tools/ci_build/github/linux/docker
       DockerBuildArgs: "
-      --network=host 
+      --network=host
       --build-arg BASEIMAGE=$(docker_base_image)
-      --build-arg TRT_VERSION=$(linux_trt_version) 
+      --build-arg TRT_VERSION=$(linux_trt_version)
       --build-arg BUILD_UID=$( id -u )
       "
       Repository: onnxruntimecuda11build
@@ -179,7 +179,7 @@ jobs:
       Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2_28_cuda
       Context: tools/ci_build/github/linux/docker
       DockerBuildArgs: "
-      --network=host 
+      --network=host
       --build-arg BASEIMAGE=$(docker_base_image)
       --build-arg TRT_VERSION=$(linux_trt_version)
       --build-arg BUILD_UID=$( id -u )


### PR DESCRIPTION
### Description
2 models are added in CI.
Stabe diffusion Model stage is based on  https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/python/tools/transformers/models/stable_diffusion/README.md

LLama2 FP16 is based on https://github.com/microsoft/Llama-2-Onnx.
12G GPU memory is not useful, so I choose T4 to run it.

### Motivation and Context
Add regular E2E test for big models. 
It will be triggered in main build, that is, it runs after one PR is merged.

More models will be added later.


