### PR TITLE
Fix a backend test by using local backend

### DIFF
--- a/orttraining/orttraining/test/python/orttraining_test_dort.py
+++ b/orttraining/orttraining/test/python/orttraining_test_dort.py
@@ -48,7 +48,13 @@ class TestTorchDynamoOrt(unittest.TestCase):
                 tensor_q = tensor_p.sigmoid()
                 return tensor_q
 
-            optimized_elementwise_model = torch.compile(elementwise_model, backend="onnxrt", dynamic=True)
+            # TODO: in order to decompose torch function calls to aten ops,
+            # we need to set user_aot_autograd=True because there is no
+            # decomposition in DORT anymore. A long-term fix will be brining
+            # decomposition pass back into DORT.
+            # optimized_elementwise_model = torch.compile(elementwise_model, backend="onnxrt", dynamic=True)
+            local_backend = make_local_backend(dynamic=True, use_aot_autograd=True)
+            optimized_elementwise_model = torch.compile(elementwise_model, backend=local_backend, dynamic=True)
 
             def run(fun, list_x):
                 tensor_x = torch.tensor(list_x, dtype=torch.float32).requires_grad_()

--- a/orttraining/orttraining/test/python/orttraining_test_dort.py
+++ b/orttraining/orttraining/test/python/orttraining_test_dort.py
@@ -216,7 +216,12 @@ class TestTorchDynamoOrt(unittest.TestCase):
             tensor_q = tensor_p.relu()
             return tensor_q
 
-        local_backend = make_local_backend(dynamic=True, use_aot_autograd=False)
+        # TODO: Set use_aot_autograd=False. In order to decompose torch
+        # function calls to aten ops, we need to set
+        # user_aot_autograd=True because there is no decomposition in DORT
+        # anymore. A long-term fix will be brining # decomposition pass back
+        # into DORT.
+        local_backend = make_local_backend(dynamic=True, use_aot_autograd=True)
         optimized_elementwise_model = torch.compile(elementwise_model, backend=local_backend, dynamic=True)
 
         def run(fun, list_x):

--- a/orttraining/orttraining/test/python/orttraining_test_dort.py
+++ b/orttraining/orttraining/test/python/orttraining_test_dort.py
@@ -48,13 +48,7 @@ class TestTorchDynamoOrt(unittest.TestCase):
                 tensor_q = tensor_p.sigmoid()
                 return tensor_q
 
-            # TODO: in order to decompose torch function calls to aten ops,
-            # we need to set user_aot_autograd=True because there is no
-            # decomposition in DORT anymore. A long-term fix will be brining
-            # decomposition pass back into DORT.
-            # optimized_elementwise_model = torch.compile(elementwise_model, backend="onnxrt", dynamic=True)
-            local_backend = make_local_backend(dynamic=True, use_aot_autograd=True)
-            optimized_elementwise_model = torch.compile(elementwise_model, backend=local_backend, dynamic=True)
+            optimized_elementwise_model = torch.compile(elementwise_model, backend="onnxrt", dynamic=True)
 
             def run(fun, list_x):
                 tensor_x = torch.tensor(list_x, dtype=torch.float32).requires_grad_()


### PR DESCRIPTION
The decomposition pass (e.g., converting torch.add to aten.add) in DORT no longer exists. Therefore, we have to use `use_aot_autograd=True` to enable Dynamo's built-in operator decomposition. I think we need to add the decomposition pass back to DORT or remove `use_aot_autograd` (remove because it will always be `true`).

