### PR TITLE
[WebNN] Ignore empty optional input tensor

### DIFF
--- a/onnxruntime/core/providers/webnn/builders/helper.h
+++ b/onnxruntime/core/providers/webnn/builders/helper.h
@@ -54,6 +54,10 @@ std::string GetShapeString(std::vector<T>& shape) {
   return shape_info.str();
 }
 
+inline std::string GetTensorName(const ConstPointerContainer<std::vector<NodeArg *>>& input_defs, const size_t index) {
+  return (input_defs.size() > index) ? std::string(input_defs[index]->Name()) : "";
+}
+
 inline std::vector<uint32_t> GetVecUint32FromVecInt64(const std::vector<int64_t>& int64_vec) {
   std::vector<uint32_t> uint32_vec;
   uint32_vec.reserve(int64_vec.size());

--- a/onnxruntime/core/providers/webnn/builders/helper.h
+++ b/onnxruntime/core/providers/webnn/builders/helper.h
@@ -54,7 +54,7 @@ std::string GetShapeString(std::vector<T>& shape) {
   return shape_info.str();
 }
 
-inline std::string GetTensorName(const ConstPointerContainer<std::vector<NodeArg *>>& input_defs, const size_t index) {
+inline std::string GetTensorName(const ConstPointerContainer<std::vector<NodeArg*>>& input_defs, const size_t index) {
   return (input_defs.size() > index) ? std::string(input_defs[index]->Name()) : "";
 }
 

--- a/onnxruntime/core/providers/webnn/builders/impl/pad_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/pad_op_builder.cc
@@ -179,11 +179,9 @@ bool PadOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
     }
     for (size_t i = 1; i < input_defs.size(); i++) {
       // Optional tensors (constant_value, axes) can be indicated by an empty name, just ignore it.
-      if (i > 1 && input_defs[i]->Name().empty()) {
-        continue;
-      }
-      if (!Contains(initializers, input_defs[i]->Name())) {
-        LOGS(logger, VERBOSE) << "Input [" << input_defs[i]->Name() << "] must be known as initializer";
+      const std::string input_name = GetTensorName(input_defs, i);
+      if (!input_name.empty() && !Contains(initializers, input_name)) {
+        LOGS(logger, VERBOSE) << "Input [" << input_name << "] must be known as initializer";
         return false;
       }
     }

--- a/onnxruntime/core/providers/webnn/builders/impl/pad_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/pad_op_builder.cc
@@ -178,6 +178,10 @@ bool PadOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
       return false;
     }
     for (size_t i = 1; i < input_defs.size(); i++) {
+      // Optional tensors (constant_value, axes) can be indicated by an empty name, just ignore it.
+      if (i > 1 && input_defs[i]->Name().empty()) {
+        continue;
+      }
       if (!Contains(initializers, input_defs[i]->Name())) {
         LOGS(logger, VERBOSE) << "Input [" << input_defs[i]->Name() << "] must be known as initializer";
         return false;

--- a/onnxruntime/core/providers/webnn/builders/impl/reduction_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/reduction_op_builder.cc
@@ -134,8 +134,9 @@ bool ReductionOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializ
     return false;
 
   const auto& op_type = node.OpType();
+  const auto& axes_name = input_defs[1]->Name();
   // If the optional input 'axes' is provided, it must be an initializer.
-  if (input_defs.size() > 1 && !Contains(initializers, input_defs[1]->Name())) {
+  if (input_defs.size() > 1 && !axes_name.empty() && !Contains(initializers, axes_name)) {
     LOGS(logger, VERBOSE) << "Input axes of " << op_type << " must be a constant";
     return false;
   }

--- a/onnxruntime/core/providers/webnn/builders/impl/reduction_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/reduction_op_builder.cc
@@ -134,9 +134,9 @@ bool ReductionOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializ
     return false;
 
   const auto& op_type = node.OpType();
-  const auto& axes_name = input_defs[1]->Name();
+  const std::string axes_name = GetTensorName(input_defs, 1);
   // If the optional input 'axes' is provided, it must be an initializer.
-  if (input_defs.size() > 1 && !axes_name.empty() && !Contains(initializers, axes_name)) {
+  if (!axes_name.empty() && !Contains(initializers, axes_name)) {
     LOGS(logger, VERBOSE) << "Input axes of " << op_type << " must be a constant";
     return false;
   }

--- a/onnxruntime/core/providers/webnn/builders/impl/slice_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/slice_op_builder.cc
@@ -124,11 +124,9 @@ bool SliceOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
   // Inputs: starts, ends, axes, and steps must be constant initializers if present.
   for (size_t i = 1; i < input_defs.size(); i++) {
     // Optional tensors (axes, steps) can be indicated by an empty name, just ignore it.
-    if (i > 3 && input_defs[i]->Name().empty()) {
-      continue;
-    }
-    if (!Contains(initializers, input_defs[i]->Name())) {
-      LOGS(logger, VERBOSE) << "Input [" << input_defs[i]->Name() << "] of " << op_type
+    const std::string input_name = GetTensorName(input_defs, i);
+    if (!input_name.empty() && !Contains(initializers, input_name)) {
+      LOGS(logger, VERBOSE) << "Input [" << input_name << "] of " << op_type
                             << " [" << name << "] must be known as initializer";
       return false;
     }

--- a/onnxruntime/core/providers/webnn/builders/impl/slice_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/slice_op_builder.cc
@@ -123,6 +123,10 @@ bool SliceOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
 
   // Inputs: starts, ends, axes, and steps must be constant initializers if present.
   for (size_t i = 1; i < input_defs.size(); i++) {
+    // Optional tensors (axes, steps) can be indicated by an empty name, just ignore it.
+    if (i > 3 && input_defs[i]->Name().empty()) {
+      continue;
+    }
     if (!Contains(initializers, input_defs[i]->Name())) {
       LOGS(logger, VERBOSE) << "Input [" << input_defs[i]->Name() << "] of " << op_type
                             << " [" << name << "] must be known as initializer";

--- a/onnxruntime/core/providers/webnn/builders/impl/split_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/split_op_builder.cc
@@ -137,9 +137,9 @@ bool SplitOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
   axis = SafeInt<int32_t>(HandleNegativeAxis(axis, rank));
 
   if (input_defs.size() == 2) {
-    // Inputs contains optional 'split' input
+    // Inputs contain optional 'split' input.
     const auto& split_name = input_defs[1]->Name();
-    if (!Contains(initializers, split_name)) {
+    if (!split_name.empty() && !Contains(initializers, split_name)) {
       LOGS(logger, VERBOSE) << "The split must be a constant initializer.";
       return false;
     }

--- a/onnxruntime/core/providers/webnn/builders/impl/split_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/split_op_builder.cc
@@ -136,10 +136,10 @@ bool SplitOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
   int32_t axis = helper.Get("axis", 0);
   axis = SafeInt<int32_t>(HandleNegativeAxis(axis, rank));
 
-  if (input_defs.size() == 2) {
-    // Inputs contain optional 'split' input.
-    const auto& split_name = input_defs[1]->Name();
-    if (!split_name.empty() && !Contains(initializers, split_name)) {
+  const std::string split_name = GetTensorName(input_defs, 1);
+  // Inputs contain optional 'split' input.
+  if (!split_name.empty()) {
+    if (!Contains(initializers, split_name)) {
       LOGS(logger, VERBOSE) << "The split must be a constant initializer.";
       return false;
     }
@@ -166,7 +166,7 @@ bool SplitOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
       LOGS(logger, VERBOSE) << "Sum of the split's values must be equal to the dim value at 'axis' specified.";
       return false;
     }
-  } else if (input_defs.size() == 1) {
+  } else {
     if (helper.HasAttr("num_outputs")) {
       // Split has 'num_outputs' attribute when opset is 18.
       const int32_t num_outputs = helper.Get("num_outputs", 1);

--- a/onnxruntime/core/providers/webnn/builders/impl/squeeze_unsqueeze_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/squeeze_unsqueeze_op_builder.cc
@@ -140,7 +140,7 @@ bool SqueezeUnsqueezeOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& in
   if (node.SinceVersion() >= 13) {
     if (input_defs.size() > 1) {
       const auto& axes_name = input_defs[1]->Name();
-      if (!Contains(initializers, axes_name)) {
+      if (!axes_name.empty() && !Contains(initializers, axes_name)) {
         LOGS(logger, ERROR) << "Input axes of " << op_type << " is not present and constant";
         return false;
       }

--- a/onnxruntime/core/providers/webnn/builders/impl/squeeze_unsqueeze_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/squeeze_unsqueeze_op_builder.cc
@@ -138,9 +138,9 @@ bool SqueezeUnsqueezeOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& in
 
   // Squeeze/Unsqueeze opset 13 uses input 1 as axes, it needs to be an initializer.
   if (node.SinceVersion() >= 13) {
-    if (input_defs.size() > 1) {
-      const auto& axes_name = input_defs[1]->Name();
-      if (!axes_name.empty() && !Contains(initializers, axes_name)) {
+    const std::string axes_name = GetTensorName(input_defs, 1);
+    if (!axes_name.empty()) {
+      if (!Contains(initializers, axes_name)) {
         LOGS(logger, ERROR) << "Input axes of " << op_type << " is not present and constant";
         return false;
       }


### PR DESCRIPTION
Empty optional input tensors are indicated by an empty name, which are allowed and we should just ignore them.