### PR TITLE
[Nuget] Add netstandard* to buildTransitive folders (microsoft#17010)

### DIFF
--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -945,7 +945,14 @@ def generate_files(line_list, args):
         files_list.append("<file src=" + '"' + target_targets + '" target="' + build_dir + '\\native"  />')
         if not is_snpe_package and not is_qnn_package:
             files_list.append("<file src=" + '"' + target_targets + '" target="' + build_dir + '\\netstandard2.0" />')
+            files_list.append(
+                "<file src=" + '"' + target_targets + '" target="buildTransitive\\netstandard2.0" />'
+            )
+
             files_list.append("<file src=" + '"' + target_targets + '" target="' + build_dir + '\\netstandard2.1"  />')
+            files_list.append(
+                "<file src=" + '"' + target_targets + '" target="buildTransitive\\netstandard2.1" />'
+            )
 
         # Process xamarin targets files
         if args.package_name == "Microsoft.ML.OnnxRuntime":


### PR DESCRIPTION
The netstandard2.0 folder was added to the build folder, but not the buildTransitive folder. This means that packages like Microsoft.ML.OnnxRuntime aren't being included as transitive build dependencies.

For example, if I have a nuget of my MyLibrary which has a dependency on Microsoft.ML.OnnxRuntime and someone adds MyLibrary to their application their application would not pull in the Microsoft.ML.OnnxRuntime nuget. This manifests when the application is run and there is a onnxruntime not found error.


NOTE: I was NOT able to build packages so I couldn't test this out. Any feedback would be much appreciated.

fixes #17010