### PR TITLE
Change "#ifdef WIN32" to "#ifdef _WIN32"

### DIFF
--- a/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
+++ b/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
@@ -318,7 +318,7 @@ JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_closeC
 
   // Iterate the handles, calling the appropriate close function
   for (jint i = 0; i < numHandles; i++) {
-#ifdef WIN32
+#ifdef _WIN32
     FreeLibrary((void*)handles[i]);
 #else
     dlclose((void*)handles[i]);

--- a/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
+++ b/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
@@ -8,7 +8,7 @@
 #include "onnxruntime/core/session/onnxruntime_c_api.h"
 #include "OrtJniUtil.h"
 #include "ai_onnxruntime_OrtSession_SessionOptions.h"
-#ifdef WIN32
+#ifdef _WIN32
 #include <Windows.h>
 #else
 #include <dlfcn.h>

--- a/onnxruntime/core/mlas/lib/amx_common.h
+++ b/onnxruntime/core/mlas/lib/amx_common.h
@@ -18,7 +18,7 @@ Abstract:
 
 #include "mlasi.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define tile_dpbssd(dst, src1, src2) _tile_dpbssd(dst, src1, src2)
 
 #define tile_dpbsud(dst, src1, src2) _tile_dpbsud(dst, src1, src2)


### PR DESCRIPTION
### Description
`_WIN32` is a standard macro listed at https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170 . But `WIN32` is not.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


