### PR TITLE
Update training api python documentation

### DIFF
--- a/docs/python/on_device_training/training_api.rst
+++ b/docs/python/on_device_training/training_api.rst
@@ -42,12 +42,32 @@ Sample usage:
     CheckpointState.save_checkpoint(state, path_to_the_checkpoint_artifact)
 
 
+.. autoclass:: onnxruntime.training.api.checkpoint_state.Parameter
+    :members:
+    :show-inheritance:
+    :member-order: bysource
+    :inherited-members:
+    :special-members: __repr__
+
+.. autoclass:: onnxruntime.training.api.checkpoint_state.Parameters
+    :members:
+    :show-inheritance:
+    :member-order: bysource
+    :inherited-members:
+    :special-members: __getitem__, __setitem__, __contains__, __iter__, __repr__, __len__
+
+.. autoclass:: onnxruntime.training.api.checkpoint_state.Properties
+    :members:
+    :show-inheritance:
+    :member-order: bysource
+    :inherited-members:
+    :special-members: __getitem__, __setitem__, __contains__, __iter__, __repr__, __len__
+
 .. autoclass:: onnxruntime.training.api.CheckpointState
     :members:
     :show-inheritance:
     :member-order: bysource
     :inherited-members:
-    :special-members: __getitem__, __setitem__, __contains__
 
 .. autoclass:: onnxruntime.training.api.Module
     :members:


### PR DESCRIPTION
In a recent PR (https://github.com/microsoft/onnxruntime/pull/17364), the training api for checkpoint state was updated.

This PR updates the documentation to reflect the changes.

Preview: https://baijumeswani.github.io/onnxruntime/docs/api/python/on_device_training/training_api.html
