### PR TITLE
Zhijxu/cleanup cached tensors when oom

### DIFF
--- a/onnxruntime/core/framework/execution_frame.cc
+++ b/onnxruntime/core/framework/execution_frame.cc
@@ -205,7 +205,7 @@ AllocatorPtr IExecutionFrame::GetAllocator(const OrtDevice& info) const {
 Status IExecutionFrame::ReleaseMLValue(int ort_value_idx) { return ReleaseMLValueImpl(ort_value_idx); }
 
 #ifdef ENABLE_TRAINING
-Status IExecutionFrame::ReleaseAllMLValues(){
+Status IExecutionFrame::ReleaseAllMLValues() {
   for (size_t ort_value_idx = 0; ort_value_idx < all_values_.size(); ort_value_idx++) {
     all_values_[ort_value_idx] = OrtValue();
   }
@@ -848,8 +848,8 @@ Status ExecutionFrame::CreateNodeOutputMLValueImpl(OrtValue& ort_value, int ort_
     return status;
   } catch (const std::exception& e) {
     LOGS(session_state_.Logger(), WARNING)
-      << "Exception caught when allocating memory for ort_value with index: " << ort_value_idx
-      << "so clean up all_values_";
+        << "Exception caught when allocating memory for ort_value with index: " << ort_value_idx
+        << "so clean up all_values_";
     static_cast<void>(ReleaseAllMLValues());
     return Status(ONNXRUNTIME, FAIL, e.what());
   }

--- a/onnxruntime/core/framework/execution_frame.cc
+++ b/onnxruntime/core/framework/execution_frame.cc
@@ -206,7 +206,7 @@ Status IExecutionFrame::ReleaseMLValue(int ort_value_idx) { return ReleaseMLValu
 
 #ifdef ENABLE_TRAINING
 Status IExecutionFrame::ReleaseAllMLValues(){
-  for (uint ort_value_idx = 0; ort_value_idx < all_values_.size(); ort_value_idx++) {
+  for (size_t ort_value_idx = 0; ort_value_idx < all_values_.size(); ort_value_idx++) {
     all_values_[ort_value_idx] = OrtValue();
   }
   return Status::OK();

--- a/onnxruntime/core/framework/execution_frame.h
+++ b/onnxruntime/core/framework/execution_frame.h
@@ -68,7 +68,7 @@ class IExecutionFrame {
                      const std::unordered_map<int, OrtValue>& initializers);
   Status GetOutputs(gsl::span<const int> fetch_mlvalue_idxs, std::vector<OrtValue>& fetches);
   // if OOM happens, then release all values, so session can run next batch.
-  Status ReleaseAllMLValues();
+  void ReleaseAllMLValues();
 #endif
 
   // TO DO: make it thread safe

--- a/onnxruntime/core/framework/execution_frame.h
+++ b/onnxruntime/core/framework/execution_frame.h
@@ -67,6 +67,8 @@ class IExecutionFrame {
 
                      const std::unordered_map<int, OrtValue>& initializers);
   Status GetOutputs(gsl::span<const int> fetch_mlvalue_idxs, std::vector<OrtValue>& fetches);
+  // if OOM happens, then release all values, so session can run next batch.
+  Status ReleaseAllMLValues();
 #endif
 
   // TO DO: make it thread safe

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -196,18 +196,21 @@ class TrainingManager(GraphExecutionManager):
 
                 # Run and get results
                 backward_outputs = C.OrtValueVector()
-                self._execution_agent.run_backward(backward_inputs, backward_outputs, ctx.run_info.state)
-                # Destroy the state immediately (as opposed to be at the mercy of garbage collector) so it does not
-                # affect peak memory usage in a subsequent graph run.
-                del ctx.run_info.state
+                try:
+                    self._execution_agent.run_backward(backward_inputs, backward_outputs, ctx.run_info.state)
+                    # Destroy the state immediately (as opposed to be at the mercy of garbage collector) so it does not
+                    # affect peak memory usage in a subsequent graph run.
 
-                # Fast version: all backward_outputs are converted first.
-                # This version only works if backward_outputs is an OrtValueVector.
-                transferred_backward_outputs = _utils._ortvalues_to_torch_tensor(backward_outputs, self._device)
+                    # Fast version: all backward_outputs are converted first.
+                    # This version only works if backward_outputs is an OrtValueVector.
+                    transferred_backward_outputs = _utils._ortvalues_to_torch_tensor(backward_outputs, self._device)
 
-                self._runtime_inspector.memory_ob.inspect_memory(Phase.POST_BACKWARD)
+                    self._runtime_inspector.memory_ob.inspect_memory(Phase.POST_BACKWARD)
+                    res = tuple(transferred_backward_outputs[idx] if idx != -1 else None for idx in self._gradient_map)
+                    return res
+                finally:
+                    del ctx.run_info.state
 
-                return tuple(transferred_backward_outputs[idx] if idx != -1 else None for idx in self._gradient_map)
 
         return _ORTModuleFunction
 

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -211,7 +211,6 @@ class TrainingManager(GraphExecutionManager):
                 finally:
                     del ctx.run_info.state
 
-
         return _ORTModuleFunction
 
     def forward(self, *inputs, **kwargs):


### PR DESCRIPTION
in pytorch, when oom happens at bp, user could decrease the batch size and rerun it without restarting the process.

while in ORT, the intermediate tensors are kept even OOM, so decrease batch size still fail.


this is torch run, we can see after oom failure, torch will release tensor before next step
![image](https://github.com/microsoft/onnxruntime/assets/43435212/92b8a2e3-454b-448a-a223-17cb91d463c2)

this is from ort, we can see ort not release its tensors after OOM failure.
![image](https://github.com/microsoft/onnxruntime/assets/43435212/bb6a3882-8e14-4f37-8079-e7f70fc2546b)

ort with the PR, we can see memory is released, **the 4GB memory is not own by ort, and will be released by torch at the end**.
![image](https://github.com/microsoft/onnxruntime/assets/43435212/7f39d711-4e36-47d5-aecf-3805433a6d01)


