### PR TITLE
Add web documentation + installation instructions

### DIFF
--- a/docs/build/training.md
+++ b/docs/build/training.md
@@ -49,6 +49,10 @@ redirect_from: /docs/how-to/build/training
 
     Refer to the [iOS build instructions](./ios.md) and add the ```--enable_training_apis``` build flag.
 
+   f. For web
+
+    Refer to the [web build instructions](./web.md).
+
 > **Note**
 >
 > - To build the C# bindings, add the ```--build_nuget``` flag to the build command above.

--- a/docs/get-started/with-web.md
+++ b/docs/get-started/with-web.md
@@ -18,3 +18,4 @@ ORT Web can be used in your web applications for model inferencing.
 * [Build from source](./../build/web.md)
 * [Tutorials: Deploy on web](./../tutorials/web/index.md)
   * [Guide: Build a web application with ONNX Runtime](./../tutorials/web/build-web-app)
+* [Training on web demo](https://github.com/microsoft/onnxruntime-training-examples/tree/master/on_device_training/web)

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -307,6 +307,19 @@ pod 'onnxruntime-training-objc'
       </ul>
     </td>
   </tr>
+  <tr>
+    <td>Web</td>
+    <td> JavaScript, TypeScript</td>
+     <td><b></b>onnxruntime-web</td>
+     <td>
+     <pre>npm install onnxruntime-web</pre>
+       <ul>
+        <li>
+            Use either <code>import * as ort from 'onnxruntime-web/training';</code> or <code>const ort = require('onnxruntime-web/training');</code>
+        </li>
+      </ul>
+    </td>
+  </tr>
 </table>
 
 ## Large Model Training

--- a/docs/tutorials/on-device-training/index.md
+++ b/docs/tutorials/on-device-training/index.md
@@ -7,4 +7,6 @@ nav_order: 11
 
 # On-Device Training
 
+{:toc }
+
 * [Training on web demo](https://github.com/microsoft/onnxruntime-training-examples/tree/master/on_device_training/web)

--- a/docs/tutorials/on-device-training/index.md
+++ b/docs/tutorials/on-device-training/index.md
@@ -7,7 +7,4 @@ nav_order: 11
 
 # On-Device Training
 
-* Placeholder (this text will be scrapped)
-{:toc}
-
 * [Training on web demo](https://github.com/microsoft/onnxruntime-training-examples/tree/master/on_device_training/web)

--- a/docs/tutorials/on-device-training/index.md
+++ b/docs/tutorials/on-device-training/index.md
@@ -6,3 +6,5 @@ nav_order: 11
 ---
 
 # On-Device Training
+
+* [Training on web demo](https://github.com/microsoft/onnxruntime-training-examples/tree/master/on_device_training/web)

--- a/docs/tutorials/on-device-training/index.md
+++ b/docs/tutorials/on-device-training/index.md
@@ -7,6 +7,7 @@ nav_order: 11
 
 # On-Device Training
 
-{:toc }
+* Placeholder (this text will be scrapped)
+{:toc}
 
 * [Training on web demo](https://github.com/microsoft/onnxruntime-training-examples/tree/master/on_device_training/web)

--- a/src/routes/getting-started/table.svelte
+++ b/src/routes/getting-started/table.svelte
@@ -54,7 +54,7 @@
 	const TrainingScenarioIds = ['ot_large_model', 'ot_on_device'];
 	const TrainingPlatforms = ['Linux', 'Windows', 'Mac', 'Android', 'iOS', 'Web browser'];
 	const TrainingPlatformIds = ['ot_linux', 'ot_windows', 'ot_mac', 'ot_android', 'ot_ios', 'ot_web'];
-	const TrainingAPIs = ['Python', 'C', 'C++', 'C#', 'Java', 'Obj-C', 'JavaScript/TypeScript'];
+	const TrainingAPIs = ['Python', 'C', 'C++', 'C#', 'Java', 'Obj-C', 'JavaScript'];
 	const TrainingAPIIds = ['ot_python', 'ot_c', 'ot_cplusplus', 'ot_csharp', 'ot_java', 'ot_objc', 'ot_js'];
 	const TrainingVersions = ['CUDA 11.8', 'ROCm', 'CPU'];
 	const TrainingVersionIds = ['ot_CUDA118', 'ot_ROCm', 'ot_CPU'];

--- a/src/routes/getting-started/table.svelte
+++ b/src/routes/getting-started/table.svelte
@@ -52,12 +52,21 @@
 	// Training
 	const TrainingScenarios = ['Large Model Training', 'On-Device Training'];
 	const TrainingScenarioIds = ['ot_large_model', 'ot_on_device'];
+<<<<<<< Updated upstream
 	const TrainingPlatforms = ['Linux', 'Windows', 'Mac', 'Android', 'iOS'];
 	const TrainingPlatformIds = ['ot_linux', 'ot_windows', 'ot_mac', 'ot_android', 'ot_ios'];
 	const TrainingAPIs = ['Python', 'C', 'C++', 'C#', 'Java', 'Obj-C'];
 	const TrainingAPIIds = ['ot_python', 'ot_c', 'ot_cplusplus', 'ot_csharp', 'ot_java', 'ot_objc'];
 	const TrainingVersions = ['CUDA 11.8', 'CUDA 12.2', 'ROCm', 'CPU'];
 	const TrainingVersionIds = ['ot_CUDA118', 'ot_CUDA122', 'ot_ROCm', 'ot_CPU'];
+=======
+	const TrainingPlatforms = ['Linux', 'Windows', 'Mac', 'Android', 'iOS', 'Web'];
+	const TrainingPlatformIds = ['ot_linux', 'ot_windows', 'ot_mac', 'ot_android', 'ot_ios', 'ot_web'];
+	const TrainingAPIs = ['Python', 'C', 'C++', 'C#', 'Java', 'Obj-C', 'JavaScript/TypeScript'];
+	const TrainingAPIIds = ['ot_python', 'ot_c', 'ot_cplusplus', 'ot_csharp', 'ot_java', 'ot_objc', 'ot_js'];
+	const TrainingVersions = ['CUDA 11.8', 'ROCm', 'CPU'];
+	const TrainingVersionIds = ['ot_CUDA118', 'ot_ROCm', 'ot_CPU'];
+>>>>>>> Stashed changes
 	const TrainingBuilds = ['Stable', 'Preview (Nightly)'];
 	const TrainingBuildIds = ['ot_stable', 'ot_nightly'];
 	const validCombos = {
@@ -812,7 +821,14 @@
 			"Follow build instructions from&nbsp;<a class='text-blue-500' href='https://onnxruntime.ai/docs/build/ios.html' target='_blank'>here</a>",
 
 		'ot_ios,ot_on_device,ot_cplusplus,ot_X64,ot_CPU,ot_nightly':
-			"Follow build instructions from&nbsp;<a class='text-blue-500' href='https://onnxruntime.ai/docs/build/ios.html' target='_blank'>here</a>"
+			"Follow build instructions from&nbsp;<a class='text-blue-500' href='https://onnxruntime.ai/docs/build/ios.html' target='_blank'>here</a>",
+
+		'ot_web,ot_on_device,ot_js,ot_X64,ot_CPU,ot_stable':
+			"npm install onnxruntime-web",
+
+		'ot_web,ot_on_device,ot_js,ot_X64,ot_CPU,ot_nightly':
+			"npm install onnxruntime-web@dev",
+
 	};
 	onMount(() => {
 		var supportedOperatingSystemsNew = [

--- a/src/routes/getting-started/table.svelte
+++ b/src/routes/getting-started/table.svelte
@@ -1985,7 +1985,7 @@
 			</div>
 			<div class="col-span-1 bg-success r-heading rounded p-2 text-xl">
 				<h3 id="ot_selectOS">Platform</h3>
-				<p id="ot_decriptionOS" class="sr-only">Platform list contains five items</p>
+				<p id="ot_decriptionOS" class="sr-only">Platform list contains six items</p>
 			</div>
 			<div
 				class="col-span-4 w-full r-content"
@@ -1994,7 +1994,7 @@
 				aria-labelledby="ot_selectOS"
 				aria-describedby="ot_decriptionOS"
 			>
-				<div class="grid grid-cols-5 gap-4 ot_os">
+				<div class="grid grid-cols-6 gap-4 ot_os">
 					{#each TrainingPlatforms as trainingplatform, i}
 						<a
 							class="r-option version join-item btn rounded"
@@ -2009,7 +2009,7 @@
 
 			<div class="col-span-1 bg-success r-heading rounded p-2 text-xl">
 				<h3 id="ot_selectLanguage">API</h3>
-				<p id="ot_decriptionLanguage" class="sr-only">API list contains six items</p>
+				<p id="ot_decriptionLanguage" class="sr-only">API list contains seven items</p>
 			</div>
 			<div
 				class="col-span-4 w-full r-content"
@@ -2018,7 +2018,7 @@
 				aria-labelledby="ot_selectLanguage"
 				aria-describedby="ot_decriptionLanguage"
 			>
-				<div class="grid grid-cols-6 gap-4 ot_language">
+				<div class="grid grid-cols-7 gap-4 ot_language">
 					{#each TrainingAPIs as trainingapi, i}
 						<a
 							class="r-option version join-item btn rounded"

--- a/src/routes/getting-started/table.svelte
+++ b/src/routes/getting-started/table.svelte
@@ -52,21 +52,12 @@
 	// Training
 	const TrainingScenarios = ['Large Model Training', 'On-Device Training'];
 	const TrainingScenarioIds = ['ot_large_model', 'ot_on_device'];
-<<<<<<< Updated upstream
-	const TrainingPlatforms = ['Linux', 'Windows', 'Mac', 'Android', 'iOS'];
-	const TrainingPlatformIds = ['ot_linux', 'ot_windows', 'ot_mac', 'ot_android', 'ot_ios'];
-	const TrainingAPIs = ['Python', 'C', 'C++', 'C#', 'Java', 'Obj-C'];
-	const TrainingAPIIds = ['ot_python', 'ot_c', 'ot_cplusplus', 'ot_csharp', 'ot_java', 'ot_objc'];
-	const TrainingVersions = ['CUDA 11.8', 'CUDA 12.2', 'ROCm', 'CPU'];
-	const TrainingVersionIds = ['ot_CUDA118', 'ot_CUDA122', 'ot_ROCm', 'ot_CPU'];
-=======
-	const TrainingPlatforms = ['Linux', 'Windows', 'Mac', 'Android', 'iOS', 'Web'];
+	const TrainingPlatforms = ['Linux', 'Windows', 'Mac', 'Android', 'iOS', 'Web browser'];
 	const TrainingPlatformIds = ['ot_linux', 'ot_windows', 'ot_mac', 'ot_android', 'ot_ios', 'ot_web'];
 	const TrainingAPIs = ['Python', 'C', 'C++', 'C#', 'Java', 'Obj-C', 'JavaScript/TypeScript'];
 	const TrainingAPIIds = ['ot_python', 'ot_c', 'ot_cplusplus', 'ot_csharp', 'ot_java', 'ot_objc', 'ot_js'];
 	const TrainingVersions = ['CUDA 11.8', 'ROCm', 'CPU'];
 	const TrainingVersionIds = ['ot_CUDA118', 'ot_ROCm', 'ot_CPU'];
->>>>>>> Stashed changes
 	const TrainingBuilds = ['Stable', 'Preview (Nightly)'];
 	const TrainingBuildIds = ['ot_stable', 'ot_nightly'];
 	const validCombos = {


### PR DESCRIPTION
### Description
Updated docs section with information on installation and building. 

Live previews of modified pages:
* [Installation table](https://carzh.github.io/onnxruntime/getting-started) -- under the Optimize Training tab
* [Build for training](https://carzh.github.io/onnxruntime/docs/build/training.html)
* [Getting started with web](https://carzh.github.io/onnxruntime/docs/get-started/with-web.html) -- added link to E2E demo code
* [Install for on-device training](https://carzh.github.io/onnxruntime/docs/install/#install-for-on-device-training)
* [Tutorials page for On-device training](https://carzh.github.io/onnxruntime/docs/tutorials/on-device-training/) -- this page looks a little odd with just the link to the E2E demo. potential alternative of creating a separate page that links to the demo + mentions that a tutorial will be coming soon?


### Motivation and Context
- Updating docs with information about ORT Training for Web for 1.17 release


