### PR TITLE
[js/webgpu] Fix the undefined push error

### DIFF
--- a/js/web/lib/wasm/jsep/backend-webgpu.ts
+++ b/js/web/lib/wasm/jsep/backend-webgpu.ts
@@ -530,8 +530,10 @@ export class WebGpuBackend {
       };
       this.pendingKernels.push(pendingKernelInfo);
 
-      const sessionPendingKernels = this.capturedPendingKernels.get(this.currentSessionId!);
-      sessionPendingKernels!.push(pendingKernelInfo);
+      if (this.sessionStatus === 'capturing') {
+        const sessionPendingKernels = this.capturedPendingKernels.get(this.currentSessionId!);
+        sessionPendingKernels!.push(pendingKernelInfo);
+      }
     }
 
     this.programManager.run(artifact, inputDatas, outputDatas, normalizedDispatchGroup, uniformBufferBinding);


### PR DESCRIPTION
### Description
This PR fixes below errors when enable webgpu profiling: 
```
TypeError: Cannot read properties of undefined (reading 'push')
```
