### PR TITLE
[WIP]   shape optimizer

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -2829,7 +2829,98 @@ class SymbolicShapeInference:
         if not all_shapes_inferred:
             onnx.save_model(symbolic_shape_inference.out_mp_, "sym_shape_infer_temp.onnx", save_as_external_data=True)
             raise Exception("Incomplete symbolic shape inference")
+
+        SymbolicShapeInference.optimize_graph(symbolic_shape_inference)
         return symbolic_shape_inference.out_mp_
+
+    @staticmethod
+    def optimize_graph(symbolic_shape_inference):
+        graph = symbolic_shape_inference.out_mp_.graph
+        value_info_dict = {vi.name: vi.type for vi in graph.value_info}
+        # store node which has only one output
+        output_name_to_node = {node.output[0]: node for node in graph.node if len(node.output) == 1}
+        node_to_add, node_to_remove = [], []
+
+        def shape_output_to_name():
+            # key is the output value, value is the name of the node output
+            from collections import defaultdict
+
+            res = defaultdict(list)
+            for name, shape in symbolic_shape_inference.sympy_data_.items():
+                node = output_name_to_node[name]
+                if node.op_type != "Shape":
+                    continue
+                if isinstance(shape, list):
+                    res[tuple(shape)].append(name)
+                elif isinstance(shape, int):
+                    res[(shape,)].append(name)
+            return res
+
+        def sym_data_can_be_const(sym_data):
+            if isinstance(sym_data, int):
+                return True
+            elif isinstance(sym_data, list):
+                return all(isinstance(i, int) for i in sym_data)
+            else:
+                return False
+
+        def find_node_by_output_name(graph, output_name):
+            for node in graph.node:
+                if [output_name] == node.output:
+                    return node
+            return None
+
+        def replace_node_by_output_name(node_output, value):
+            old_node = find_node_by_output_name(graph, node_output)
+            if old_node is None:
+                return
+            dtype = value_info_dict[node_output].tensor_type.elem_type
+            dims = [1] if isinstance(value, list) else []
+            value = value if isinstance(value, list) else [value]
+            new_node = helper.make_node(
+                "Constant",
+                inputs=[],
+                outputs=[node_output],
+                value=helper.make_tensor(name=f"sym_data_opt_{node_output}", data_type=dtype, dims=dims, vals=value),
+            )
+            node_to_add.append(new_node)
+            node_to_remove.append(old_node)
+            return
+
+        def modify_graph():
+            nodes = [node for node in graph.node if node not in node_to_remove]
+            nodes.extend(node_to_add)
+            graph.ClearField("node")
+            graph.node.extend(nodes)
+            node_to_add.clear()
+            node_to_remove.clear()
+
+        def node_to_const_if_possible():
+            # from sym_data_, we can know node's output value is const or not
+            # if it is const, then we can replace the node by a Constant node
+            for output_name, value in symbolic_shape_inference.sympy_data_.items():
+                if sym_data_can_be_const(value):
+                    replace_node_by_output_name(output_name, value)
+            modify_graph()
+
+        def share_shape_ops_if_possible():
+            # if shape output is same, then actually we only need the first shape node in topo order
+            group_shape_output_by_output_value_dict = shape_output_to_name()
+            for _, output_names in group_shape_output_by_output_value_dict.items():
+                if len(output_names) <= 1:
+                    continue
+                output_name_to_keep = output_names[0]
+                for output_name in output_names[1:]:
+                    for node in graph.node:
+                        if output_name in node.input:
+                            for ind, name in enumerate(node.input):
+                                if name == output_name:
+                                    node.input[ind] = output_name_to_keep
+                    node_to_remove.append(output_name_to_node[output_name])
+            modify_graph()
+
+        node_to_const_if_possible()
+        share_shape_ops_if_possible()
 
 
 def parse_arguments():

--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -402,8 +402,8 @@ class GraphExecutionManager(GraphExecutionInterface):
                     "training": self._export_mode,
                     "dynamic_axes": self._input_info.dynamic_axes,
                     "verbose": torch_exporter_verbose_log,
-                    "export_params": False,
-                    "keep_initializers_as_inputs": True,
+                    "export_params": True if self._export_mode == torch.onnx.TrainingMode.EVAL else False,
+                    "keep_initializers_as_inputs": False if self._export_mode == torch.onnx.TrainingMode.EVAL else True,
                 }
 
                 if check_function_has_param(torch.onnx.export, "autograd_inlining"):


### PR DESCRIPTION
after symbolic shape inference, we know shape nodes' output value e.g ["x", 256, "y"], then we actually do two optimization:
1. constant folding, e.g. shape > gather the 2nd elem, then it is a const with value 256
2. share shape ops, if multiple shape nodes have some value, then we can only keep 1 shape, this will also help the CSE optimizer, e.g. the subgraphes to generate decoder attention's mask actually only need one subgraph instead of each attention layer has its own subgraph.


