### PR TITLE
[VitisAI] Resolving compilation errors when using USE_VITISAI

### DIFF
--- a/onnxruntime/core/providers/provider_factory_creators.h
+++ b/onnxruntime/core/providers/provider_factory_creators.h
@@ -78,6 +78,10 @@
 #include "core/providers/tvm/tvm_provider_factory_creator.h"
 #endif
 
+#if defined(USE_VITISAI)
+#include "core/providers/vitisai/vitisai_provider_factory_creator.h"
+#endif
+
 #if defined(USE_XNNPACK)
 #include "core/providers/xnnpack/xnnpack_provider_factory_creator.h"
 #endif

--- a/onnxruntime/core/providers/vitisai/vitisai_provider_factory.cc
+++ b/onnxruntime/core/providers/vitisai/vitisai_provider_factory.cc
@@ -10,8 +10,6 @@
 #include "./vitisai_execution_provider.h"
 #include "core/framework/execution_provider.h"
 
-#include "core/session/abi_session_options_impl.h"
-
 using namespace onnxruntime;
 namespace onnxruntime {
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Resolving compilation errors when using USE_VITISAI


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
There will be compilation errors when USE_VITISAI is enabled
This is in addition to the #19058 

