### PR TITLE
Fix DEBUG_GENERATION build

### DIFF
--- a/onnxruntime/contrib_ops/cpu/transformers/logits_processor.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/logits_processor.cc
@@ -28,10 +28,6 @@ void MinLengthLogitsProcessor<T>::Process(const ISequences* sequences,
   if (sequences->GetSequenceLength() < min_length_) {
     next_token_scores.SetScore(eos_token_id_, std::numeric_limits<T>::lowest());
   }
-
-#ifdef DEBUG_GENERATION
-  DumpScores("MinLengthLogitsProcessor", next_token_scores);
-#endif
 }
 
 template <typename T>
@@ -60,10 +56,6 @@ void RepetitionPenaltyLogitsProcessor<T>::Process(const ISequences* sequences,
       beam_token_scores[word_id] = (score < 0 ? score * penalty_ : score / penalty_);
     }
   }
-
-#ifdef DEBUG_GENERATION
-  DumpScores("RepetitionPenaltyLogitsProcessor", next_token_scores);
-#endif
 }
 
 template <typename T>
@@ -101,10 +93,6 @@ void NoRepeatNGramLogitsProcessor<T>::Process(const ISequences* sequences,
       beam_token_scores[word_id] = std::numeric_limits<T>::lowest();
     }
   }
-
-#ifdef DEBUG_GENERATION
-  DumpScores("NoRepeatNGramLogitsProcessor", next_token_scores);
-#endif
 }
 
 template <typename T>
@@ -128,10 +116,6 @@ void VocabMaskLogitsProcessor<T>::Process(const ISequences* /*sequences*/,
       }
     }
   }
-
-#ifdef DEBUG_GENERATION
-  DumpScores("VocabMaskLogitsProcessor", next_token_scores);
-#endif
 }
 
 template <typename T>
@@ -163,10 +147,6 @@ void PrefixVocabMaskLogitsProcessor<T>::Process(const ISequences* /*sequences*/,
       }
     }
   }
-
-#ifdef DEBUG_GENERATION
-  DumpScores("PrefixVocabMaskLogitsProcessor", next_token_scores);
-#endif
 }
 
 template <typename T>
@@ -185,10 +165,6 @@ void TemperatureLogitsProcessor<T>::Process(const ISequences* /*sequences*/,
     *p /= temperature_;
     ++p;
   }
-
-#ifdef DEBUG_GENERATION
-  DumpScores("TemperatureLogitsProcessor", next_token_scores);
-#endif
 }
 
 template <typename T>
@@ -210,10 +186,6 @@ void PresencePenaltyLogitsProcessor<T>::Process(const ISequences*,
   for (size_t i = 0; i < next_token_scores.scores.size(); i++) {
     *p -= presence_mask_[i] * presence_penalty_;
   }
-
-#ifdef DEBUG_GENERATION
-  DumpScores("PresencePenaltyLogitsProcessor", next_token_scores);
-#endif
 }
 
 void LogitsProcessorList::Init(const BeamSearchParameters& parameters) {

--- a/onnxruntime/contrib_ops/cpu/transformers/logits_processor.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/logits_processor.cc
@@ -17,14 +17,6 @@ namespace onnxruntime {
 namespace contrib {
 namespace transformers {
 
-#ifdef DEBUG_GENERATION
-template <typename T>
-void DumpScores(const char* name, const NextTokenScores<T>& next_token_scores) {
-  std::cout << name << std::endl;
-  ORT_UNUSED_PARAMETER(next_token_scores);
-}
-#endif
-
 // Interface for all scorers for beam search or beam sample.
 template <typename T>
 MinLengthLogitsProcessor<T>::MinLengthLogitsProcessor(int min_length, int eos_token_id)

--- a/onnxruntime/contrib_ops/cpu/transformers/logits_processor.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/logits_processor.h
@@ -34,6 +34,14 @@ struct NextTokenScores {
   }
 };
 
+#ifdef DEBUG_GENERATION
+template <typename T>
+void DumpScores(const char* name, const NextTokenScores<T>& next_token_scores) {
+  std::cout << name << std::endl;
+  ORT_UNUSED_PARAMETER(next_token_scores);
+}
+#endif
+
 // Interface for all scorers for beam search or beam sample.
 template <typename T>
 class ILogitsProcessor {

--- a/onnxruntime/contrib_ops/cpu/transformers/logits_processor.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/logits_processor.h
@@ -34,14 +34,6 @@ struct NextTokenScores {
   }
 };
 
-#ifdef DEBUG_GENERATION
-template <typename T>
-void DumpScores(const char* name, const NextTokenScores<T>& next_token_scores) {
-  std::cout << name << std::endl;
-  ORT_UNUSED_PARAMETER(next_token_scores);
-}
-#endif
-
 // Interface for all scorers for beam search or beam sample.
 template <typename T>
 class ILogitsProcessor {
@@ -273,10 +265,6 @@ class TimestampLogitsProcessor : public ILogitsProcessor<T> {
         }
       }
     }
-
-#ifdef DEBUG_GENERATION
-    DumpScores("TimestampLogitsProcessor", next_token_scores);
-#endif
   }
 
  private:


### PR DESCRIPTION
### Description
Currently, ORT will fail a build when the flag DEBUG_GENERATION is set to 1 (used to debug BeamSearch and GreedySearch) in [console_dumper.h](https://github.com/microsoft/onnxruntime/blob/3b63d85c253c50099c70ba0db6c141b842bc7cda/onnxruntime/contrib_ops/cpu/utils/console_dumper.h#L12) with the following error:

`onnxruntime/onnxruntime/contrib_ops/cpu/transformers/logits_processor.h:270:15: error: ‘DumpScores’ was not declared in this scope`

This is because it is defined in `logits_processor.cc`, and a debugging artifact was passed in an earlier PR where this function is called from `logits_processor.h` before it is defined [[link](https://github.com/microsoft/onnxruntime/blob/3a2ab1963a195fe8df59e6220d3f191e5dfe80ee/onnxruntime/contrib_ops/cpu/transformers/logits_processor.h#L270)]. Builds with the flag have been broken since that PR was merged.

This PR moves DumpScores() definition from `logits_processor.cc` to `logits_processor.h` so that all debug statements can be used correctly in `logits_processor.cc` and `logits_processor.h` and build succeeds with this debug flag.


