### PR TITLE
fix type annotation for sess_options

### DIFF
--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -358,7 +358,7 @@ class InferenceSession(Session):
     def __init__(
         self,
         path_or_bytes: str | bytes | os.PathLike,
-        sess_options: Sequence[onnxruntime.SessionOptions] | None = None,
+        sess_options: onnxruntime.SessionOptions | None = None,
         providers: Sequence[str | tuple[str, dict[Any, Any]]] | None = None,
         provider_options: Sequence[dict[Any, Any]] | None = None,
         **kwargs,


### PR DESCRIPTION
### Description
Changed the type annotation of sess_options in InferenceSession's `__init__` method


### Motivation and Context
sess_options is one `SessionOptions`, not a sequence of it.

It is passed directly into `C.InferenceSession`, and from the definition of [`C.InferenceSession`](https://github.com/microsoft/onnxruntime/blob/efc17e79de8c1a62eb419d19576ccb90b371b0d0/onnxruntime/python/onnxruntime_pybind_state.cc#L1790), we can see that it is not a sequence:

```cpp
  py::class_<PyInferenceSession>(m, "InferenceSession", R"pbdoc(This is the main class used to run a model.)pbdoc")
      // In Python3, a Python bytes object will be passed to C++ functions that accept std::string or char*
      // without any conversion. So this init method can be used for model file path (string) and model content (bytes)
      .def(py::init([](const PySessionOptions& so, const std::string arg, bool is_arg_file_name,
                       bool load_config_from_model = false) {
```

