### PR TITLE
Remove non-existing function call

### DIFF
--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -368,7 +368,6 @@ class MinMaxCalibrater(CalibraterBase):
                 self.max_intermediate_outputs is not None
                 and len(self.intermediate_outputs) == self.max_intermediate_outputs
             ):
-                self.compute_range()
                 self.clear_collected_data()
 
         if len(self.intermediate_outputs) == 0 and self.calibrate_tensors_range is None:


### PR DESCRIPTION
This function call is confusing, since it is a function call without definition of the function. It  was correctly repalced from compute_data to compute_range, but function call was reintroudced in a later PR.

### Description
Problem as described in [this issue](https://github.com/microsoft/onnxruntime/issues/18893 )

In the examples, different calls of compute_range() from calibrate.py can be found, also in the calibrate.py itself. 

The problem is that it was [replaced here] (https://github.com/microsoft/onnxruntime/pull/16550/files#diff-75e84436a983e17527f8b5bc585087e7ad75b3b515c2101c2a82dcaecca490de ) from `compute_range()` to `cpmute_data() -> TensorsData` and then falsely [added as call here](https://github.com/microsoft/onnxruntime/pull/17029/files#diff-75e84436a983e17527f8b5bc585087e7ad75b3b515c2101c2a82dcaecca490de ).

### Motivation and Context
I suggest in this PR to remove this confusing call `self.calibrate_range()` in calibrate.py. Once it is removed and packaged, somehow the examples from the onnx-runtime-examples repository must be adapted, since they are already not working. Examples of `compute_range()` in the examples are linked in [this issue](https://github.com/microsoft/onnxruntime/issues/18893 ).


