### PR TITLE
Change binet to bin

### DIFF
--- a/tools/ci_build/github/linux/docker/Dockerfile.manylinux2_28_cuda
+++ b/tools/ci_build/github/linux/docker/Dockerfile.manylinux2_28_cuda
@@ -7,7 +7,7 @@ ARG PLATFORM=x86_64
 ARG BASEIMAGE=nvidia/cuda:11.8.0-cudnn8-devel-ubi8
 ARG DEVTOOLSET_ROOTPATH=/usr
 ARG LD_LIBRARY_PATH_ARG=/usr/local/lib64
-ARG PREPEND_PATH=/usr/local/cuda/binet
+ARG PREPEND_PATH=/usr/local/cuda/bin
 ARG TRT_VERSION=8.6.1.6-1.cuda11.8
 
 #Build manylinux docker image begin


### PR DESCRIPTION
### Description
This pull request includes a small change to the `Dockerfile.manylinux2_28_cuda` file in the `tools/ci_build/github/linux/docker` directory. The change corrects the `PREPEND_PATH` argument from `/usr/local/cuda/binet` to `/usr/local/cuda/bin`, ensuring the correct path to CUDA binaries is set.





