### PR TITLE
Update docker file in devcontainers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -31,7 +31,5 @@ RUN apt-get update \
 
 # Install newer CMake version
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends aria2 aria2 && aria2c -q -d /tmp -o cmake-3.21.0-linux-x86_64.tar.gz https://github.com/Kitware/CMake/releases/download/v3.21.0/cmake-3.21.0-linux-x86_64.tar.gz && tar -zxf /tmp/cmake-3.21.0-linux-x86_64.tar.gz --strip=1 -C /usr \
+    && apt-get install -y --no-install-recommends aria2 aria2 && aria2c -q -d /tmp -o cmake-3.27.3-linux-x86_64.tar.gz https://github.com/Kitware/CMake/releases/download/v3.27.3/cmake-3.27.3-linux-x86_64.tar.gz && tar -zxf /tmp/cmake-3.27.3-linux-x86_64.tar.gz --strip=1 -C /usr \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
-
-

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -42,8 +42,8 @@
 	"remoteUser": "vscode",
 
 	"features": {
-		"git": "os-provided",
-		"python": "os-provided",
-		"powershell": "7.1"
+		"ghcr.io/devcontainers/features/git:1": {"version": "os-provided"},
+		"ghcr.io/devcontainers/features/python:1": {"version": "os-provided"},
+		"ghcr.io/devcontainers/features/powershell:1": {"version": "7.1"}
 	}
 }


### PR DESCRIPTION
### Description
Update the cmake version in the Dockerfile in devcontainers, and rewrite the features in devcontainer.json.


### Motivation and Context
The CMakeLists.txt file now requires cmake version 3.26, but the one shipped in the devcontainer is 3.21. As most of the Dockerfiles in ci-build is using 3.27.3, I changed that to 3.27.3.

The features are reported as deprecated when the devcontainers is build. I found the current way of writing the features following the deprecation message.