### PR TITLE
Disable CPU EP's allocator's arena when address sanitizer is enabled

### DIFF
--- a/onnxruntime/core/providers/cpu/cpu_execution_provider.cc
+++ b/onnxruntime/core/providers/cpu/cpu_execution_provider.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "core/providers/cpu/cpu_execution_provider.h"
+#include <absl/base/config.h>
 #include "core/framework/op_kernel.h"
 #include "core/framework/kernel_registry.h"
 #include "core/mlas/inc/mlas.h"
@@ -29,7 +30,7 @@ CPUExecutionProvider::CPUExecutionProvider(const CPUExecutionProviderInfo& info)
 
 std::vector<AllocatorPtr> CPUExecutionProvider::CreatePreferredAllocators() {
   bool create_arena = info_.create_arena;
-#if defined(USE_JEMALLOC) || defined(USE_MIMALLOC)
+#if defined(USE_JEMALLOC) || defined(USE_MIMALLOC) || defined(ABSL_HAVE_ADDRESS_SANITIZER)
   // JEMalloc/mimalloc already have memory pool, so just use device allocator.
   create_arena = false;
 #elif !(defined(__amd64__) || defined(_M_AMD64) || defined(__aarch64__) || defined(_M_ARM64))

--- a/onnxruntime/test/providers/cpu/model_tests.cc
+++ b/onnxruntime/test/providers/cpu/model_tests.cc
@@ -308,7 +308,6 @@ TEST_P(ModelTest, Run) {
           if (ort_st != nullptr) {
             OrtErrorCode error_code = OrtApis::GetErrorCode(ort_st);
             if (error_code == ORT_NOT_IMPLEMENTED) {
-              OrtApis::ReleaseStatus(ort_st);
               for (char* p : output_names) {
                 default_allocator->Free(p);
               }
@@ -317,6 +316,7 @@ TEST_P(ModelTest, Run) {
               }
             }
             FAIL() << OrtApis::GetErrorMessage(ort_st);
+            OrtApis::ReleaseStatus(ort_st);
           }
         }
 

--- a/onnxruntime/test/quantization/quantization_test.cc
+++ b/onnxruntime/test/quantization/quantization_test.cc
@@ -99,9 +99,8 @@ void EnsureQuantizedTensorParam(const float scale, const T zero_point) {
 
   // First, create the scale tensor:
   auto alloc = TestCPUExecutionProvider()->CreatePreferredAllocators()[0];
-  auto num_bytes = shape.Size() * sizeof(float);
-  void* data = alloc->Alloc(num_bytes);
-  float* float_data = static_cast<float*>(data);
+  IAllocatorUniquePtr<float> buffer = IAllocator::MakeUniquePtr<float>(alloc, shape.Size());
+  float* float_data = buffer.get();
   float_data[0] = scale;
   Tensor scale_tensor(DataTypeImpl::GetType<float>(),
                       shape,
@@ -110,9 +109,8 @@ void EnsureQuantizedTensorParam(const float scale, const T zero_point) {
                       /*offset=*/0);
 
   // Next, create the zero_point tensor:
-  auto T_num_bytes = shape.Size() * sizeof(T);
-  void* T_data = alloc->Alloc(T_num_bytes);
-  T* typed_data = static_cast<T*>(T_data);
+  IAllocatorUniquePtr<T> buffer2 = IAllocator::MakeUniquePtr<T>(alloc, shape.Size());
+  T* typed_data = buffer2.get();
   typed_data[0] = zero_point;
   Tensor zero_point_tensor(DataTypeImpl::GetType<T>(),
                            shape,

--- a/onnxruntime/test/quantization/quantization_test.cc
+++ b/onnxruntime/test/quantization/quantization_test.cc
@@ -104,7 +104,7 @@ void EnsureQuantizedTensorParam(const float scale, const T zero_point) {
   float_data[0] = scale;
   Tensor scale_tensor(DataTypeImpl::GetType<float>(),
                       shape,
-                      data,
+                      float_data,
                       alloc->Info(),
                       /*offset=*/0);
 
@@ -114,7 +114,7 @@ void EnsureQuantizedTensorParam(const float scale, const T zero_point) {
   typed_data[0] = zero_point;
   Tensor zero_point_tensor(DataTypeImpl::GetType<T>(),
                            shape,
-                           T_data,
+                           typed_data,
                            alloc->Info(),
                            /*offset=*/0);
 


### PR DESCRIPTION
### Description
Disable CPU EP's allocator's arena when address sanitizer is enabled, because it masks problems.  For example, the code in onnxruntime/test/quantization/quantization_test.cc has a memory leak problem: it allocated a buffer but didn't free it, but most memory leak check tool cannot detect that because the buffer was from an arena and the arena was finally freed. 

### Motivation and Context
Provider better memory leak check coverage. 


