### PR TITLE
Remove cuda gencode 90 to reduce onnxruntime-training package size

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-cuda.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-cuda.yml
@@ -15,7 +15,7 @@ stages:
     torch_version: '2.0.0'
     opset_version: '15'
     cuda_version: '11.8'
-    cmake_cuda_architectures: 60;61;70;75;80;86;90
+    cmake_cuda_architectures: 60;61;70;75;80;86
     docker_file: Dockerfile.manylinux2_28_training_cuda11_8
     agent_pool: Onnxruntime-Linux-GPU
     upload_wheel: 'yes'


### PR DESCRIPTION
onnxruntime-training CUDA 11.8 package size is > 300 MB and as a result publishing to PyPI fails.
gencode 90 requires CUDA > 12.

This change brings the package size < 300 MB.