### PR TITLE
Add implementation for ScatterND

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -1121,7 +1121,7 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain,
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, double, LRN);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, MLFloat16, LRN);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, 13, Identity);
-class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, ScatterND);
+class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, 15, ScatterND);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, 17, float, Pad);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, 17, double, Pad);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, 17, MLFloat16, Pad);
@@ -1256,6 +1256,7 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain,
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 16, double, LessOrEqual);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 16, MLFloat16, LessOrEqual);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 16, 17, ScatterElements);
+class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 16, 17, ScatterND);
 
 // Opset 17
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 17, float, LayerNormalization);
@@ -1272,6 +1273,7 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain,
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 18, int32_t, ReduceMax);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 18, int64_t, ReduceMax);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 18, ScatterElements);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 18, ScatterND);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 18, float, Pad);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 18, double, Pad);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 18, MLFloat16, Pad);
@@ -2015,7 +2017,7 @@ static Status RegisterCudaKernels(KernelRegistry& kernel_registry) {
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, double, LRN)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, MLFloat16, LRN)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, 13, Identity)>,
-    BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, ScatterND)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, 15, ScatterND)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, 17, float, Pad)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, 17, double, Pad)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, 17, MLFloat16, Pad)>,
@@ -2143,6 +2145,7 @@ static Status RegisterCudaKernels(KernelRegistry& kernel_registry) {
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 16, double, LessOrEqual)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 16, MLFloat16, LessOrEqual)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 16, 17, ScatterElements)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 16, 17, ScatterND)>,
 
     // Opset 17
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 17, float, LayerNormalization)>,
@@ -2165,6 +2168,7 @@ static Status RegisterCudaKernels(KernelRegistry& kernel_registry) {
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 18, int32_t, ReduceMax)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 18, int64_t, ReduceMax)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 18, ScatterElements)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 18, ScatterND)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 18, float, Pad)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 18, double, Pad)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 18, MLFloat16, Pad)>,

--- a/onnxruntime/core/providers/cuda/tensor/scatter_elements.cc
+++ b/onnxruntime/core/providers/cuda/tensor/scatter_elements.cc
@@ -133,7 +133,7 @@ Status ScatterElements::ComputeInternal(OpKernelContext* context) const {
   } else if (reduction_ == "max") {
     args.operation = GatherScatterElementsArgs::Operation::MAX;
   } else {
-    ORT_THROW("Unsupported reduction type");
+    ORT_THROW("Unsupported reduction type for ScatterElements.");
   }
 
   // Use element size instead of concrete types so we can specialize less template functions to reduce binary size.

--- a/onnxruntime/core/providers/cuda/tensor/scatter_nd.cc
+++ b/onnxruntime/core/providers/cuda/tensor/scatter_nd.cc
@@ -18,9 +18,27 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(ScatterND,
                                       .MayInplace(0, 0),
                                   ScatterND);
 
+ONNX_OPERATOR_VERSIONED_KERNEL_EX(ScatterND,
+                                  kOnnxDomain,
+                                  13, 15,
+                                  kCudaExecutionProvider,
+                                  (*KernelDefBuilder::Create())
+                                      .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes())
+                                      .MayInplace(0, 0),
+                                  ScatterND);
+
+ONNX_OPERATOR_VERSIONED_KERNEL_EX(ScatterND,
+                                  kOnnxDomain,
+                                  16, 17,
+                                  kCudaExecutionProvider,
+                                  (*KernelDefBuilder::Create())
+                                      .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes())
+                                      .MayInplace(0, 0),
+                                  ScatterND);
+
 ONNX_OPERATOR_KERNEL_EX(ScatterND,
                         kOnnxDomain,
-                        13,
+                        18,
                         kCudaExecutionProvider,
                         (*KernelDefBuilder::Create())
                             .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes())
@@ -80,7 +98,8 @@ Status ScatterND::ComputeInternal(OpKernelContext* context) const {
       last_index_dimension,
       element_counts_and_input_dims_gpu.GpuPtr(),
       updates_tensor->DataRaw(),
-      input_shape.SizeFromDimension(last_index_dimension)));
+      input_shape.SizeFromDimension(last_index_dimension),
+      static_cast<int>(reduction_)));
 
   return Status::OK();
 }

--- a/onnxruntime/core/providers/cuda/tensor/scatter_nd.h
+++ b/onnxruntime/core/providers/cuda/tensor/scatter_nd.h
@@ -11,9 +11,36 @@ namespace onnxruntime {
 namespace cuda {
 
 class ScatterND final : public CudaKernel {
+  // TODO: this is common to cpu/cuda providers, where should it be placed?
+  enum class Reduction : int {
+    None = 0,
+    Add = 1,
+    Mul = 2,
+    Min = 3,
+    Max = 4,
+  };  
  public:
-  explicit ScatterND(const OpKernelInfo& info) : CudaKernel(info) {}
+  explicit ScatterND(const OpKernelInfo& info) : CudaKernel(info) {
+    std::string reduction = info.GetAttrOrDefault<std::string>("reduction", "none");
+
+    if (info.GetAttr<std::string>("reduction", &reduction).IsOK()) {
+      if (reduction == "add")
+        reduction_ = Reduction::Add;
+      else if (reduction == "mul")
+        reduction_ = Reduction::Mul;
+      else if (reduction == "min")
+        reduction_ = Reduction::Min;
+      else if (reduction == "max")
+        reduction_ = Reduction::Max;
+    }
+  }
   Status ComputeInternal(OpKernelContext* context) const override;
+  
+ private:
+  // "reduction" attribute has been defined since opset 13 but
+  // we never implemented it. Let's try to support them starting
+  // with opset 18.
+  Reduction reduction_{Reduction::None};
 };
 
 }  // namespace cuda

--- a/onnxruntime/core/providers/cuda/tensor/scatter_nd_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/scatter_nd_impl.cu
@@ -8,6 +8,16 @@
 namespace onnxruntime {
 namespace cuda {
 
+/*
+enum class Reduction : int {
+  None = 0,
+  Add = 1,
+  Mul = 2,
+  Min = 3,
+  Max = 4,
+};  
+*/
+
 template <typename T>
 __global__ void _ScatterNDKernel(
     T* output_data,
@@ -68,7 +78,9 @@ Status ScatterNDImpl(
     const int64_t last_index_dimension,
     const int64_t* element_counts_and_input_dims,
     const void* updates_data,
-    const size_t num_updates_elements) {
+    const size_t num_updates_elements,
+    const int operation) {
+  ORT_THROW(operation == 0, "unexpected reduction for ScatterND");
   if (num_indices == 0)
     return Status::OK();
 

--- a/onnxruntime/core/providers/cuda/tensor/scatter_nd_impl.h
+++ b/onnxruntime/core/providers/cuda/tensor/scatter_nd_impl.h
@@ -17,7 +17,8 @@ Status ScatterNDImpl(
     const int64_t last_index_dimension,
     const int64_t* element_counts_and_input_dims,
     const void* updates_data,
-    const size_t num_updates_elements);
+    const size_t num_updates_elements,
+    const int operation);
 
 }  // namespace cuda
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/tensor/scatter_nd_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/scatter_nd_op_test.cc
@@ -180,5 +180,16 @@ TEST(ScatterNDOpTest, ScatterND_batched_3tensor_int64) {
   test3.Run();
 }
 
+TEST(ScatterNDOpTest, ScatterND_18_add) {
+  OpTester test1("ScatterND", 18);
+  test1.AddAttribute("reduction", "add");
+  test1.AddInput<float>("data", {4, 4, 4}, {1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1, 1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1, 8, 7, 6, 5, 4, 3, 2, 1, 1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1, 1, 2, 3, 4, 5, 6, 7, 8});
+  test1.AddInput<int64_t>("indices", {2, 1}, {0, 0});
+  test1.AddInput<float>("updates", {2, 4, 4}, {5, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7, 8, 8, 8, 8, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4});
+  test1.AddOutput<float>("output", {4, 4, 4}, {7, 8, 9, 10, 13, 14, 15, 16, 18, 17, 16, 15, 16, 15, 14, 13, 1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 8, 7, 6, 5, 4, 3, 2, 1, 1, 2, 3, 4, 5, 6, 7, 8});
+  test1.Run();
+}
+
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/tensor/scatter_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/scatter_op_test.cc
@@ -315,6 +315,19 @@ TEST(ScatterElements, AddReduction) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
+TEST(ScatterElements, AddReduction_MLFloat16) {
+  OpTester test("ScatterElements", 18);
+  test.AddAttribute<int64_t>("axis", 0);
+  test.AddAttribute<std::string>("reduction", "add");
+
+  test.AddInput<MLFloat16>("data", {2, 3}, ToFloat16(std::vector<float>({-9.f, -4.f, -1.f, -7.f, -3.f, -6.f})));
+  test.AddInput<int64_t>("indices", {4, 3}, {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
+  test.AddInput<MLFloat16>("updates", {4, 3}, ToFloat16(std::vector<float>({1.f, 1.f, 1.f, 2.f, 2.f, 2.f, 3.f, 3.f, 3.f, 4.f, 4.f, 4.f})));
+  test.AddOutput<MLFloat16>("y", {2, 3}, ToFloat16(std::vector<float>({-9.f, -4.f, -1.f, -7.f + (1.f + 2.f + 3.f + 4.f), -3.f + (1.f + 2.f + 3.f + 4.f), -6.f + (1.f + 2.f + 3.f + 4.f)})));
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+}
+
 TEST(ScatterElements, AddReductionAxis1) {
   OpTester test("ScatterElements", 18);
   test.AddAttribute<int64_t>("axis", 1);

--- a/onnxruntime/test/python/onnxruntime_scatternd_test.py
+++ b/onnxruntime/test/python/onnxruntime_scatternd_test.py
@@ -1,0 +1,245 @@
+import itertools
+import json
+import os
+import unittest
+import numpy as np
+import onnxruntime  # noqa: F401
+import onnx.helper as oh
+from onnx import TensorProto, load
+from onnx.numpy_helper import from_array
+from experimental_experiment.ext_test_case import ExtTestCase, ignore_warnings
+
+
+def has_cuda():
+    available_providers = [provider for provider in onnxruntime.get_available_providers()]
+    return "CUDAExecutionProvider" in available_providers
+
+
+class TestScatterPerProvider(ExtTestCase):
+    def common_scatter(self, opset, providers, dtype, reduction, expected_names):
+        from onnxruntime import InferenceSession, SessionOptions
+
+        op_type = (
+            "ScatterElements" if "ScatterElements" in expected_names else "ScatterND"
+        )
+        ndim = 2 if op_type == "ScatterElements" else 3
+
+        assert dtype in (np.float16, np.float32)
+        itype = TensorProto.FLOAT if dtype == np.float32 else TensorProto.FLOAT16
+        model = oh.make_model(
+            oh.make_graph(
+                [
+                    oh.make_node("CastLike", ["X", "I"], ["data"]),
+                    oh.make_node(
+                        op_type,
+                        inputs=["data", "indices", "updates"],
+                        outputs=["sy"],
+                        # axis=0,
+                        reduction=reduction,
+                    ),
+                    oh.make_node("Sub", ["sy", "I"], ["Y"]),
+                ],
+                "name",
+                [
+                    oh.make_tensor_value_info("X", TensorProto.FLOAT, [None] * ndim),
+                    oh.make_tensor_value_info(
+                        "indices", TensorProto.INT64, [None, None]
+                    ),
+                    oh.make_tensor_value_info("updates", itype, [None] * ndim),
+                ],
+                [oh.make_tensor_value_info("Y", itype, [None] * ndim)],
+                [from_array(np.array([1], dtype=dtype), name="I")],
+            ),
+            opset_imports=[oh.make_opsetid("", opset)],
+            ir_version=8 if opset <= 18 else 9,
+        )
+
+        if not os.path.exists("temp_dump"):
+            os.mkdir("temp_dump")
+        for name in os.listdir("temp_dump"):
+            os.remove(os.path.join("temp_dump", name))
+
+        filename = f"temp_dump/{op_type}_{providers[0]}_{itype}.onnx"
+        opts = SessionOptions()
+        opts.optimized_model_filepath = filename
+        sess = InferenceSession(model.SerializeToString(), opts, providers=providers)
+        self.assertTrue(sess is not None)
+        self.assertExists(filename)
+        onx = load(filename)
+        names = [n.op_type for n in onx.graph.node]
+        self.assertEqual(expected_names, names)
+
+        sonx = str(onx).replace(" ", "").replace("\n", "|")
+        sexp = 'op_type:"Cast"|attribute{|name:"to"|type:INT|i:%d|}' % itype
+        sexp2 = 'op_type:"Cast"|attribute{|name:"to"|i:%d|type:INT|}' % itype
+        assert sexp in sonx or sexp2 in sonx, f"Unable to find a substring in {sonx!r}"
+        if providers == ["CPUExecutionProvider"]:
+            return
+
+        if op_type == "ScatterElements":
+            data = np.zeros((3, 3), dtype=np.float32)
+            indices = np.array([[1, 0, 2], [0, 2, 1]], dtype=np.int64)
+            updates = np.array([[1.0, 1.1, 1.2], [2.0, 2.1, 2.2]], dtype=dtype)
+        else:
+            data = np.array(
+                [
+                    [[1, 2, 3, 4], [5, 6, 7, 8], [8, 7, 6, 5], [4, 3, 2, 1]],
+                    [[1, 2, 3, 4], [5, 6, 7, 8], [8, 7, 6, 5], [4, 3, 2, 1]],
+                    [[8, 7, 6, 5], [4, 3, 2, 1], [1, 2, 3, 4], [5, 6, 7, 8]],
+                    [[8, 7, 6, 5], [4, 3, 2, 1], [1, 2, 3, 4], [5, 6, 7, 8]],
+                ],
+                dtype=np.float32,
+            )
+            indices = np.array([[0], [2]], dtype=np.int64)
+            updates = np.array(
+                [
+                    [[5, 5, 5, 5], [6, 6, 6, 6], [7, 7, 7, 7], [8, 8, 8, 8]],
+                    [[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3], [4, 4, 4, 4]],
+                ],
+                dtype=dtype,
+            )
+        opts = SessionOptions()
+        opts.enable_profiling = True
+        opts.optimized_model_filepath = filename
+        sess = InferenceSession(model.SerializeToString(), opts, providers=providers)
+        sess.run(None, {"X": data, "indices": indices, "updates": updates})
+        prof = sess.end_profiling()
+
+        with open(prof, "r") as f:
+            content = f.read()
+        js = json.loads(content)
+
+        exe_providers = []
+        suffixes = ["_kernel_time", "_fence_before", "_fence_after"]
+        rows = []
+        for row in js:
+            if "args" in row and isinstance(row["args"], dict):
+                for k, v in row["args"].items():
+                    row[f"args_{k}"] = v
+                del row["args"]
+            name = row["name"]
+            for suf in suffixes:
+                if name.endswith(suf):
+                    changed = name[: -len(suf)]
+                    row["op_name"] = changed
+                    break
+            rows.append(row)
+            exe_providers.append(
+                (row.get("args_provider", None), row.get("args_op_name", None))
+            )
+        short_list = [
+            (a, b) for a, b in exe_providers if a is not None and b is not None
+        ]
+        self.assertEqual(
+            short_list, [("CUDAExecutionProvider", o) for o in expected_names]
+        )
+
+    @unittest.skipIf(not has_cuda(), reason="cuda not available")
+    @ignore_warnings(DeprecationWarning)
+    def test_scatterels_cuda(self):
+        default_value = [
+            "Cast",
+            # "MemcpyToHost",
+            "ScatterElements",
+            # "MemcpyFromHost",
+            "Sub",
+        ]
+        expected = {
+            (np.float32, "none"): default_value,
+            (np.float16, "none"): default_value,
+            (np.float32, "add"): default_value,
+            (np.float16, "add"): default_value,
+        }
+        for opset, dtype, reduction in itertools.product(
+            [16, 18], [np.float32, np.float16], ["none", "add"]
+        ):
+            with self.subTest(dtype=dtype, reduction=reduction, opset=opset):
+                self.common_scatter(
+                    opset,
+                    ["CUDAExecutionProvider"],
+                    np.float32,
+                    reduction,
+                    expected[dtype, reduction],
+                )
+
+    @unittest.skipIf(not has_cuda(), reason="cuda not available")
+    @ignore_warnings(DeprecationWarning)
+    def test_scatternd_cuda(self):
+        default_value = [
+            "Cast",
+            # "MemcpyToHost",
+            "ScatterND",
+            # "MemcpyFromHost",
+            "Sub",
+        ]
+        expected = {
+            (np.float32, "none"): default_value,
+            (np.float16, "none"): default_value,
+            (np.float32, "add"): default_value,
+            (np.float16, "add"): default_value,
+        }
+        for opset, dtype, reduction in itertools.product(
+            [16, 18], [np.float32, np.float16], ["none", "add"]
+        ):
+            with self.subTest(dtype=dtype, reduction=reduction, opset=opset):
+                self.common_scatter(
+                    opset,
+                    ["CUDAExecutionProvider"],
+                    np.float32,
+                    reduction,
+                    expected[dtype, reduction],
+                )
+
+    @ignore_warnings(DeprecationWarning)
+    def test_scatterels_cpu(self):
+        default_value = [
+            "Cast",
+            "ScatterElements",
+            "Sub",
+        ]
+        expected = {
+            (np.float32, "none"): default_value,
+            (np.float16, "none"): default_value,
+            (np.float32, "add"): default_value,
+            (np.float16, "add"): default_value,
+        }
+        for opset, dtype, reduction in itertools.product(
+            [16, 18], [np.float32, np.float16], ["none", "add"]
+        ):
+            with self.subTest(dtype=dtype, reduction=reduction, opset=opset):
+                self.common_scatter(
+                    opset,
+                    ["CPUExecutionProvider"],
+                    np.float32,
+                    reduction,
+                    expected[dtype, reduction],
+                )
+
+    @ignore_warnings(DeprecationWarning)
+    def test_scatternd_cpu(self):
+        default_value = [
+            "Cast",
+            "ScatterElements",
+            "Sub",
+        ]
+        expected = {
+            (np.float32, "none"): default_value,
+            (np.float16, "none"): default_value,
+            (np.float32, "add"): default_value,
+            (np.float16, "add"): default_value,
+        }
+        for opset, dtype, reduction in itertools.product(
+            [16, 18], [np.float32, np.float16], ["none", "add"]
+        ):
+            with self.subTest(dtype=dtype, reduction=reduction, opset=opset):
+                self.common_scatter(
+                    opset,
+                    ["CPUExecutionProvider"],
+                    np.float32,
+                    reduction,
+                    expected[dtype, reduction],
+                )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
### Description
onnxruntime switches to CPU for ScatterND after opset 13. This extends the implementation of higher opsets.



