### PR TITLE
Disable algo caching in ROCM EP

### DIFF
--- a/onnxruntime/core/providers/rocm/nn/conv.h
+++ b/onnxruntime/core/providers/rocm/nn/conv.h
@@ -108,9 +108,6 @@ class lru_unordered_map {
   list_type lru_list_;
 };
 
-// cached miopen descriptors
-constexpr size_t MAX_CACHED_ALGO_PERF_RESULTS = 10000;
-
 template <typename AlgoPerfType>
 struct MiopenConvState {
   // if x/w dims changed, update algo and miopenTensors
@@ -147,9 +144,6 @@ struct MiopenConvState {
     decltype(AlgoPerfType().bwd_data_algo) bwd_data_algo;
     decltype(AlgoPerfType().memory) memory;
   };
-
-  lru_unordered_map<TensorShapeVector, PerfFwdResultParams, vector_hash> cached_benchmark_fwd_results{MAX_CACHED_ALGO_PERF_RESULTS};
-  lru_unordered_map<TensorShapeVector, PerfBwdResultParams, vector_hash> cached_benchmark_bwd_results{MAX_CACHED_ALGO_PERF_RESULTS};
 
   // Some properties needed to support asymmetric padded Conv nodes
   bool post_slicing_required;


### PR DESCRIPTION
### Description
Similar to the work done by Liangxijun-1001 in
https://github.com/apache/tvm/pull/16178 the ROCM spec mandates calling miopenFindConvolution*Algorithm() before using any Convolution API

This is the link to the porting guide describing this requirement https://rocmdocs.amd.com/projects/MIOpen/en/latest/MIOpen_Porting_Guide.html

Thus, this change disables the algo cache and enforces the official API semantics

### Motivation and Context
Without this change onnxruntime would fail subsequent calls to convolution APIs with errors like
'MIOpen Error: No invoker was registered for convolution forward.' It was reproduced, for example,
while porting immich to use ROCM acceleration



