### PR TITLE
Update build directory clean up stage for python package pipeline

### DIFF
--- a/cmake/patches/composable_kernel/Fix_Clang_Build.patch
+++ b/cmake/patches/composable_kernel/Fix_Clang_Build.patch
@@ -71,6 +71,19 @@ index 04674124c..12e8b8b00 100644
 -    LDCONFIG
 -    HEADER_ONLY
 -)
+diff --git a/docs/sphinx/requirements.txt b/docs/sphinx/requirements.txt
+index 8041b8198..4b5c13c54 100644
+--- a/docs/sphinx/requirements.txt
++++ b/docs/sphinx/requirements.txt
+@@ -84,7 +84,7 @@ pydata-sphinx-theme==0.13.3
+     #   sphinx-book-theme
+ pygithub==1.58.2
+     # via rocm-docs-core
+-pygments==2.14.0
++pygments==2.15.0
+     # via
+     #   accessible-pygments
+     #   pydata-sphinx-theme
 diff --git a/library/src/tensor_operation_instance/gpu/CMakeLists.txt b/library/src/tensor_operation_instance/gpu/CMakeLists.txt
 index 9cb5d0e9a..141a46f3d 100644
 --- a/library/src/tensor_operation_instance/gpu/CMakeLists.txt

--- a/cmake/patches/composable_kernel/Fix_Clang_Build.patch
+++ b/cmake/patches/composable_kernel/Fix_Clang_Build.patch
@@ -71,19 +71,6 @@ index 04674124c..12e8b8b00 100644
 -    LDCONFIG
 -    HEADER_ONLY
 -)
-diff --git a/docs/sphinx/requirements.txt b/docs/sphinx/requirements.txt
-index 8041b8198..4b5c13c54 100644
---- a/docs/sphinx/requirements.txt
-+++ b/docs/sphinx/requirements.txt
-@@ -84,7 +84,7 @@ pydata-sphinx-theme==0.13.3
-     #   sphinx-book-theme
- pygithub==1.58.2
-     # via rocm-docs-core
--pygments==2.14.0
-+pygments==2.15.0
-     # via
-     #   accessible-pygments
-     #   pydata-sphinx-theme
 diff --git a/library/src/tensor_operation_instance/gpu/CMakeLists.txt b/library/src/tensor_operation_instance/gpu/CMakeLists.txt
 index 9cb5d0e9a..141a46f3d 100644
 --- a/library/src/tensor_operation_instance/gpu/CMakeLists.txt

--- a/tools/ci_build/github/azure-pipelines/templates/component-governance-component-detection-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/component-governance-component-detection-steps.yml
@@ -5,10 +5,12 @@ parameters:
   default: 'succeeded' # could be 'ci_only', 'always', 'succeeded'
 
 steps:
-- ${{ if eq(variables['System.TeamProject'], 'Lotus') }}: 
+- ${{ if eq(variables['System.TeamProject'], 'Lotus') }}:
   - task: DeleteFiles@1
     inputs:
-      contents: $(Build.BinariesDirectory)/*
+      SourceFolder: '$(Build.BinariesDirectory)'
+      contents: |
+        **/*
     displayName: 'Clean up build directory'
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0


### PR DESCRIPTION
Fix to make clean up stage take effect.

If the `SourceFolder ` is empty, the task deletes files from the root folder of the repository as though [$(Build.SourcesDirectory)](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables) was specified.

