### PR TITLE
Use xcode parallel build flags to speed up iOS CI that is timing out

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1669,8 +1669,6 @@ def build_targets(args, cmake_path, build_dir, configs, num_parallel_jobs, targe
                     f"/p:CL_MPCount={num_parallel_jobs}",
                 ]
             elif args.cmake_generator == "Xcode":
-                # CMake will generate correct build tool args for Xcode
-                # cmd_args += ["--parallel", str(num_parallel_jobs)]
                 build_tool_args += [
                     "-parallelizeTargets",
                     "-jobs",

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1671,7 +1671,11 @@ def build_targets(args, cmake_path, build_dir, configs, num_parallel_jobs, targe
             elif args.cmake_generator == "Xcode":
                 # CMake will generate correct build tool args for Xcode
                 # cmd_args += ["--parallel", str(num_parallel_jobs)]
-                build_tool_args += ["-parallelizeTargets", f"-jobs {num_parallel_jobs}"]
+                build_tool_args += [
+                    "-parallelizeTargets",
+                    "-jobs",
+                    str(num_parallel_jobs),
+                ]
             else:
                 build_tool_args += [f"-j{num_parallel_jobs}"]
 

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1631,9 +1631,11 @@ def generate_build_tree(
             [
                 *temp_cmake_args,
                 f"-DCMAKE_BUILD_TYPE={config}",
-                f"-DCMAKE_PREFIX_PATH={build_dir}/{config}/installed"
-                if preinstalled_dir.exists() and not (args.arm64 or args.arm64ec or args.arm)
-                else "",
+                (
+                    f"-DCMAKE_PREFIX_PATH={build_dir}/{config}/installed"
+                    if preinstalled_dir.exists() and not (args.arm64 or args.arm64ec or args.arm)
+                    else ""
+                ),
             ],
             cwd=config_build_dir,
             cuda_home=cuda_home,
@@ -1668,7 +1670,8 @@ def build_targets(args, cmake_path, build_dir, configs, num_parallel_jobs, targe
                 ]
             elif args.cmake_generator == "Xcode":
                 # CMake will generate correct build tool args for Xcode
-                cmd_args += ["--parallel", str(num_parallel_jobs)]
+                # cmd_args += ["--parallel", str(num_parallel_jobs)]
+                build_tool_args += ["-parallelizeTargets", f"-jobs {num_parallel_jobs}"]
             else:
                 build_tool_args += [f"-j{num_parallel_jobs}"]
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Provide specific xcodebuild flags instead of depending on cmake to do the right thing.

This built in just over an hour with a ccache miss. Previous CIs with a ccache miss were timing out after 150 minutes.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


