### PR TITLE
[TensorRT EP] Fix bug for DDS output handling for empty tensor

### DIFF
--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -36,8 +36,8 @@ mimalloc;https://github.com/microsoft/mimalloc/archive/refs/tags/v2.1.1.zip;d5ee
 mp11;https://github.com/boostorg/mp11/archive/refs/tags/boost-1.82.0.zip;9bc9e01dffb64d9e0773b2e44d2f22c51aace063
 neural_speed;https://github.com/intel/neural-speed/archive/refs/tags/bestlav0.1.1.zip;65b0f7a0d04f72f0d5a8d48af70f0366f2ab3939
 onnx;https://github.com/onnx/onnx/archive/refs/tags/v1.15.0.zip;54c3f960a0541c5d8d3e60c2933e11f5d3688a11
-#use the commit of supporting all the plugins and TRT 8.6-GA (https://github.com/onnx/onnx-tensorrt/commit/0462dc31ae78f48744b6141ae376df1f96d3f459)
-onnx_tensorrt;https://github.com/onnx/onnx-tensorrt/archive/a43ce67187bab219520fd80f21af8bbd4354bc8c.zip;572535aefef477050f86744dfab1fef840198035
+#use the commit of Final DDS removal. DDS output is now supported by ORT TRT.
+onnx_tensorrt;https://github.com/onnx/onnx-tensorrt/archive/bacfaaa951653cd4e72efe727a543567cb38f7de.zip;26434329612e804164ab7baa6ae629ada56c1b26
 protobuf;https://github.com/protocolbuffers/protobuf/archive/refs/tags/v21.12.zip;7cf2733949036c7d52fda017badcab093fe73bfa
 protoc_win64;https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-win64.zip;b4521f7ada5b260380f94c4bd7f1b7684c76969a
 protoc_win32;https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-win32.zip;3688010318192c46ce73213cdfb6b3e5656da874

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -3873,8 +3873,6 @@ Status TensorrtExecutionProvider::CreateNodeComputeInfoFromPrecompiledEngine(con
       CUDA_RETURN_IF_ERROR(cudaStreamSynchronize(stream));
     }
 
-    bool sync_stream_after_dds_output_copy = false;
-
     // Assign TRT output back to ORT output
     // (1) Bind TRT DDS output to ORT kernel context output. (It needs to wait until enqueueV3 is finished)
     // (2) Cast TRT INT32 output to ORT INT64 output or TRT double output to float output

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -1132,7 +1132,7 @@ Status BindKernelOutput(Ort::KernelContext& ctx,
       SafeInt<int> output_dim_size(1);
       for (size_t i = 0; i < shape.size(); ++i) {
         if (shape[i] == 0) {
-          output_dim_size = 1;
+          output_dim_size = 0;
           break;
         } else {
           output_dim_size *= shape[i];
@@ -1150,7 +1150,7 @@ Status BindKernelOutput(Ort::KernelContext& ctx,
       SafeInt<int> output_dim_size(1);
       for (size_t i = 0; i < shape.size(); ++i) {
         if (shape[i] == 0) {
-          output_dim_size = 1;
+          output_dim_size = 0;
           break;
         } else {
           output_dim_size *= shape[i];

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -861,12 +861,8 @@ Status BindContextInput(Ort::KernelContext& ctx,
       CASE_GET_INPUT_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, int8_t)
       CASE_GET_INPUT_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, uint8_t)
       CASE_GET_INPUT_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32, int32_t)
-#if NV_TENSORRT_MAJOR >= 10
-      CASE_GET_INPUT_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, int64_t)
-#else
-      // Cast int64 input to int32 input because TensorRT < 10 doesn't support int64
+      // Cast int64 input to int32 input because TensorRT doesn't support int64
       CASE_GET_CAST_INPUT_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, int64_t, int32_t)
-#endif
       // Cast double input to float because TensorRT doesn't support double
       CASE_GET_CAST_INPUT_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE, double, float)
       default: {
@@ -953,12 +949,8 @@ Status BindContextOutput(Ort::KernelContext& ctx,
       CASE_GET_OUTPUT_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, int8_t)
       CASE_GET_OUTPUT_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, uint8_t)
       CASE_GET_OUTPUT_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32, int32_t)
-#if NV_TENSORRT_MAJOR >= 10
-      CASE_GET_OUTPUT_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, int64_t)
-#else
-      // Allocate int32 CUDA memory for int64 output type because TensorRT < 10 doesn't support int64
+      // Allocate int32 CUDA memory for int64 output type because TensorRT doesn't support int64
       CASE_GET_CAST_OUTPUT_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, int64_t, int32_t)
-#endif
       // Allocate float CUDA memory for double output type because TensorRT doesn't support double
       CASE_GET_CAST_OUTPUT_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE, double, float)
       default: {
@@ -1022,12 +1014,8 @@ Status BindKernelOutput(Ort::KernelContext& ctx,
     CASE_COPY_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, int8_t)
     CASE_COPY_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, uint8_t)
     CASE_COPY_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32, int32_t)
-#if NV_TENSORRT_MAJOR >= 10
-    CASE_COPY_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, int64_t)
-#else
-    // The allocation buffer holds the int32 output data since TRT < 10 doesn't support int64. So, we need to cast the data (int32 -> int64) for ORT kernel output.
+    // The allocation buffer holds the int32 output data since TRT doesn't support int64. So, we need to cast the data (int32 -> int64) for ORT kernel output.
     CASE_CAST_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, int32_t, int64_t)
-#endif
     // The allocation buffer holds the float output data since TRT doesn't support double. So, we need to cast the data (float -> double) for ORT kernel output.
     CASE_CAST_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE, float, double)
     default: {
@@ -3466,15 +3454,12 @@ Status TensorrtExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphView
         }
       } else {
         auto& output_tensor = output_tensors[i];
-#if NV_TENSORRT_MAJOR < 10
         if (output_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64) {
           auto output_tensor_ptr = output_tensor.GetTensorMutableData<int64_t>();
           if (output_tensor_ptr != nullptr) {
             cuda::Impl_Cast<int32_t, int64_t>(stream, reinterpret_cast<int32_t*>(buffers[output_name]), output_tensor_ptr, output_dim_sizes[i]);
           }
-        }
-#endif
-        if (output_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE) {
+        } else if (output_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE) {
           auto output_tensor_ptr = output_tensor.GetTensorMutableData<double>();
           if (output_tensor_ptr != nullptr) {
             cuda::Impl_Cast<float, double>(stream, reinterpret_cast<float*>(buffers[output_name]), output_tensor_ptr, output_dim_sizes[i]);
@@ -3738,7 +3723,7 @@ Status TensorrtExecutionProvider::CreateNodeComputeInfoFromPrecompiledEngine(con
     }
 
     // Assign TRT output back to ORT output
-    // (1) Bind TRT DDS output to ORT kernel context output.
+    // (1) Bind TRT DDS output to ORT kernel context output. (It needs to wait until enqueueV3 is finished)
     // (2) Cast TRT INT32 output to ORT INT64 output or TRT double output to float output
     for (size_t i = 0, end = output_binding_names.size(); i < end; ++i) {
       char const* output_name = output_binding_names[i];
@@ -3761,15 +3746,12 @@ Status TensorrtExecutionProvider::CreateNodeComputeInfoFromPrecompiledEngine(con
         }
       } else {
         auto& output_tensor = output_tensors[i];
-#if NV_TENSORRT_MAJOR < 10
         if (output_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64) {
           auto output_tensor_ptr = output_tensor.GetTensorMutableData<int64_t>();
           if (output_tensor_ptr != nullptr) {
             cuda::Impl_Cast<int32_t, int64_t>(stream, reinterpret_cast<int32_t*>(buffers[output_name]), output_tensor_ptr, output_dim_sizes[i]);
           }
-        }
-#endif
-        if (output_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE) {
+        } else if (output_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE) {
           auto output_tensor_ptr = output_tensor.GetTensorMutableData<double>();
           if (output_tensor_ptr != nullptr) {
             cuda::Impl_Cast<float, double>(stream, reinterpret_cast<float*>(buffers[output_name]), output_tensor_ptr, output_dim_sizes[i]);

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -717,57 +717,57 @@ Status ApplyProfileShapesFromInputTensorValue(std::vector<nvinfer1::IOptimizatio
   return Status::OK();
 }
 
-#define CASE_GET_INPUT_TENSOR(DATA_TYPE, SrcT)                                                                                                     \
-  case DATA_TYPE: {                                                                                                                                \
-    auto input_tensor_ptr = input_tensor.GetTensorData<SrcT>();                                                                                    \
-    if (input_tensor_ptr != nullptr && elem_cnt > 0) {                                                                                                             \
-      data = const_cast<SrcT*>(input_tensor_ptr);                                                                                                  \
-    } else {                                                                                                                                       \
-      scratch_buffers.push_back(IAllocator::MakeUniquePtrFromOrtAllocator<void>(alloc, sizeof(SrcT)));                                             \
-      data = scratch_buffers.back().get();                                                                                                         \
-    }                                                                                                                                              \
-    break;                                                                                                                                         \
+#define CASE_GET_INPUT_TENSOR(DATA_TYPE, SrcT)                                                         \
+  case DATA_TYPE: {                                                                                    \
+    auto input_tensor_ptr = input_tensor.GetTensorData<SrcT>();                                        \
+    if (input_tensor_ptr != nullptr && elem_cnt > 0) {                                                 \
+      data = const_cast<SrcT*>(input_tensor_ptr);                                                      \
+    } else {                                                                                           \
+      scratch_buffers.push_back(IAllocator::MakeUniquePtrFromOrtAllocator<void>(alloc, sizeof(SrcT))); \
+      data = scratch_buffers.back().get();                                                             \
+    }                                                                                                  \
+    break;                                                                                             \
   }
 
-#define CASE_GET_CAST_INPUT_TENSOR(DATA_TYPE, SrcT, DstT)                                                                                          \
-  case DATA_TYPE: {                                                                                                                                \
-    auto input_tensor_ptr = input_tensor.GetTensorData<SrcT>();                                                                                    \
-    if (input_tensor_ptr != nullptr && elem_cnt > 0) {                                                                                             \
-      scratch_buffers.push_back(IAllocator::MakeUniquePtrFromOrtAllocator<void>(alloc, elem_cnt * sizeof(DstT)));                                  \
-      data = scratch_buffers.back().get();                                                                                                         \
-      cuda::Impl_Cast<SrcT, DstT>(stream, input_tensor_ptr, reinterpret_cast<DstT*>(data), elem_cnt);                                              \
-    } else {                                                                                                                                       \
-      scratch_buffers.push_back(IAllocator::MakeUniquePtrFromOrtAllocator<void>(alloc, sizeof(DstT)));                                             \
-      data = scratch_buffers.back().get();                                                                                                         \
-    }                                                                                                                                              \
-  break;                                                                                                                                           \
+#define CASE_GET_CAST_INPUT_TENSOR(DATA_TYPE, SrcT, DstT)                                                         \
+  case DATA_TYPE: {                                                                                               \
+    auto input_tensor_ptr = input_tensor.GetTensorData<SrcT>();                                                   \
+    if (input_tensor_ptr != nullptr && elem_cnt > 0) {                                                            \
+      scratch_buffers.push_back(IAllocator::MakeUniquePtrFromOrtAllocator<void>(alloc, elem_cnt * sizeof(DstT))); \
+      data = scratch_buffers.back().get();                                                                        \
+      cuda::Impl_Cast<SrcT, DstT>(stream, input_tensor_ptr, reinterpret_cast<DstT*>(data), elem_cnt);             \
+    } else {                                                                                                      \
+      scratch_buffers.push_back(IAllocator::MakeUniquePtrFromOrtAllocator<void>(alloc, sizeof(DstT)));            \
+      data = scratch_buffers.back().get();                                                                        \
+    }                                                                                                             \
+    break;                                                                                                        \
   }
 
-#define CASE_GET_OUTPUT_TENSOR(DATA_TYPE, SrcT)                                                                                                    \
-  case DATA_TYPE: {                                                                                                                                \
-    auto output_tensor_ptr = output_tensor.GetTensorMutableData<SrcT>();                                                                           \
-    if (output_tensor_ptr != nullptr && elem_cnt > 0) {                                                                                            \
-      buffers[output_name] = output_tensor_ptr;                                                                                                    \
-    } else {                                                                                                                                       \
-      scratch_buffers.push_back(IAllocator::MakeUniquePtrFromOrtAllocator<void>(alloc, sizeof(SrcT)));                                             \
-      buffers[output_name] = scratch_buffers.back().get();                                                                                         \
-    }                                                                                                                                              \
-    break;                                                                                                                                         \
+#define CASE_GET_OUTPUT_TENSOR(DATA_TYPE, SrcT)                                                        \
+  case DATA_TYPE: {                                                                                    \
+    auto output_tensor_ptr = output_tensor.GetTensorMutableData<SrcT>();                               \
+    if (output_tensor_ptr != nullptr && elem_cnt > 0) {                                                \
+      buffers[output_name] = output_tensor_ptr;                                                        \
+    } else {                                                                                           \
+      scratch_buffers.push_back(IAllocator::MakeUniquePtrFromOrtAllocator<void>(alloc, sizeof(SrcT))); \
+      buffers[output_name] = scratch_buffers.back().get();                                             \
+    }                                                                                                  \
+    break;                                                                                             \
   }
 
-#define CASE_GET_CAST_OUTPUT_TENSOR(DATA_TYPE, SrcT, DstT)                                                                                         \
-  case DATA_TYPE: {                                                                                                                                \
-    auto output_tensor_ptr = output_tensor.GetTensorMutableData<SrcT>();                                                                           \
-    if (output_tensor_ptr != nullptr && elem_cnt > 0) {                                                                                            \
-      scratch_buffers.push_back(IAllocator::MakeUniquePtrFromOrtAllocator<void>(alloc, elem_cnt * sizeof(DstT)));                                  \
-      buffers[output_name] = scratch_buffers.back().get();                                                                                         \
-      output_dim_sizes[i] = static_cast<int>(elem_cnt);                                                                                            \
-    } else {                                                                                                                                       \
-      scratch_buffers.push_back(IAllocator::MakeUniquePtrFromOrtAllocator<void>(alloc, sizeof(DstT)));                                             \
-      buffers[output_name] = scratch_buffers.back().get();                                                                                         \
-      output_dim_sizes[i] = 1;                                                                                                                     \
-    }                                                                                                                                              \
-    break;                                                                                                                                         \
+#define CASE_GET_CAST_OUTPUT_TENSOR(DATA_TYPE, SrcT, DstT)                                                        \
+  case DATA_TYPE: {                                                                                               \
+    auto output_tensor_ptr = output_tensor.GetTensorMutableData<SrcT>();                                          \
+    if (output_tensor_ptr != nullptr && elem_cnt > 0) {                                                           \
+      scratch_buffers.push_back(IAllocator::MakeUniquePtrFromOrtAllocator<void>(alloc, elem_cnt * sizeof(DstT))); \
+      buffers[output_name] = scratch_buffers.back().get();                                                        \
+      output_dim_sizes[i] = static_cast<int>(elem_cnt);                                                           \
+    } else {                                                                                                      \
+      scratch_buffers.push_back(IAllocator::MakeUniquePtrFromOrtAllocator<void>(alloc, sizeof(DstT)));            \
+      buffers[output_name] = scratch_buffers.back().get();                                                        \
+      output_dim_sizes[i] = 1;                                                                                    \
+    }                                                                                                             \
+    break;                                                                                                        \
   }
 
 #define CASE_COPY_TENSOR(DATA_TYPE, DstT)                                                                                                          \
@@ -969,7 +969,7 @@ Status BindContextOutput(Ort::KernelContext& ctx,
  *
  * In the case of DDS (data-dependent shape) output, TRT requires a provided allocator to allocate memory during runtime.
  * Once the output has been put in the allocation buffer, ORT calls this function to bind the allocation to ORT kernel context output.
- * 
+ *
  * Note: Current approach of setting the ORT kernel context output is copying the output data from allocation buffer to ORT context output address which is not optimal,
  * we are waiting for ORT core to support "assign" memory address to ORT context output. Some works need to be done in ORT memory planner to be aware of this memory support.
  */
@@ -984,7 +984,7 @@ Status BindKernelOutput(Ort::KernelContext& ctx,
   auto& shape = allocator->getOutputShape();
   auto output_tensor = ctx.GetOutput(output_index, shape);
 
-  /* 
+  /*
    * Return the number of elements specified by the tensor shape (all dimensions multiplied by each other).
    * For 0 dimensions, 1 is returned. If any dimension is less than 0, the result is always -1.
    *
@@ -999,7 +999,7 @@ Status BindKernelOutput(Ort::KernelContext& ctx,
   /*
    * Copy output data from allocation buffer to ORT kernel context output location or
    * cast (int32 or float) -> (int64 or double) to ORT kernel context output location.
-   * 
+   *
    * Note:
    * 1. If the output tensor is empty tensor (i.e. any of the dimension is 0) which means element count is 0,
    *    TRT EP does not perform cuda memory copy nor cuda cast to prevent overwriting other location that might belong to other tensors.
@@ -1007,8 +1007,8 @@ Status BindKernelOutput(Ort::KernelContext& ctx,
    *    don't need to explicitly call cudaStreamSynchronize() after those APIs due to CUDA EP and TRT EP uses same stream,
    *    and within the same stream, operations are guaranteed to be executed in order.
    */
-  switch (output_type) {                                           
-    CASE_COPY_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, float) 
+  switch (output_type) {
+    CASE_COPY_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, float)
     CASE_COPY_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16, uint16_t)
     CASE_COPY_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL, bool)
     CASE_COPY_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, int8_t)


### PR DESCRIPTION
When the DDS output is empty tensor (i.e. any of the dimension is 0), TRT EP won't perform either cudaMemcpyAsync() nor cuda::Impl_Cast(), to prevent accidentally overwriting other location that might belong to other tensors. 

This PR also refactors the code to only allocate single bytes for all empty tensors.

#TODO: add unit tests to cover the DDS code paths or doing more testing with concurrent,sequential, threaded  faster-rcnn using onnx_test_runner and verifying outputs
