### PR TITLE
Changed command line argpasrse to process '--symmetric [True|False]'.

### DIFF
--- a/onnxruntime/python/tools/quantization/matmul_4bits_quantizer.py
+++ b/onnxruntime/python/tools/quantization/matmul_4bits_quantizer.py
@@ -371,6 +371,7 @@ set of 4b integers with a scaling factor and an optional offset.
         const=True,
         nargs='?',
         type=ort_convert_str_to_bool,
+        choices=[True, False],
         help="Indicate whether to quantize the model symmetrically",
     )
     parser.add_argument(

--- a/onnxruntime/python/tools/quantization/matmul_4bits_quantizer.py
+++ b/onnxruntime/python/tools/quantization/matmul_4bits_quantizer.py
@@ -348,6 +348,8 @@ class MatMul4BitsQuantizer:
 
             self.int4_quant_algo()
 
+def ort_convert_str_to_bool(value):
+    return value.lower() in ("true", "1")
 
 def parse_args():
     parser = argparse.ArgumentParser(
@@ -366,7 +368,9 @@ set of 4b integers with a scaling factor and an optional offset.
         "--symmetric",
         required=False,
         default=True,
-        type=bool,
+        const=False,
+        nargs='?',
+        type=ort_convert_str_to_bool,
         help="Indicate whether to quantize the model symmetrically",
     )
     parser.add_argument(

--- a/onnxruntime/python/tools/quantization/matmul_4bits_quantizer.py
+++ b/onnxruntime/python/tools/quantization/matmul_4bits_quantizer.py
@@ -368,7 +368,7 @@ set of 4b integers with a scaling factor and an optional offset.
         "--symmetric",
         required=False,
         default=True,
-        const=False,
+        const=True,
         nargs='?',
         type=ort_convert_str_to_bool,
         help="Indicate whether to quantize the model symmetrically",

--- a/onnxruntime/python/tools/quantization/matmul_4bits_quantizer.py
+++ b/onnxruntime/python/tools/quantization/matmul_4bits_quantizer.py
@@ -348,8 +348,10 @@ class MatMul4BitsQuantizer:
 
             self.int4_quant_algo()
 
+
 def ort_convert_str_to_bool(value):
     return value.lower() in ("true", "1")
+
 
 def parse_args():
     parser = argparse.ArgumentParser(
@@ -369,7 +371,7 @@ set of 4b integers with a scaling factor and an optional offset.
         required=False,
         default=True,
         const=True,
-        nargs='?',
+        nargs="?",
         type=ort_convert_str_to_bool,
         choices=[True, False],
         help="Indicate whether to quantize the model symmetrically",


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Accept the command line option --symmetric and its optional value correctly. If the optional value matches uncased to 'True' then set symmetric to True else set symmetric to False. Asymmetric quantization will generate zero_point input.
```
usage: matmul_4bits_quantizer.py [-h] --input_model INPUT_MODEL --output_model OUTPUT_MODEL [--block_size BLOCK_SIZE] [--symmetric [{True,False}]] [--accuracy_level ACCURACY_LEVEL] [-v]
                                 [--nodes_to_exclude NODES_TO_EXCLUDE [NODES_TO_EXCLUDE ...]]
```
### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


