### PR TITLE
Use build.py to build in py-win-gpu.yml so parallelization parameters are set

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/py-win-gpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-win-gpu.yml
@@ -120,7 +120,7 @@ jobs:
             $(TelemetryOption) ${{ parameters.BUILD_PY_PARAMETERS }} ${{ parameters.EP_BUILD_FLAGS }}
           workingDirectory: '$(Build.BinariesDirectory)'
 
-      # test building with build.py so the parallelization parameters are added to the msbuild command
+      # building with build.py so the parallelization parameters are added to the msbuild command
       - task: PythonScript@0
         displayName: 'Build'
         inputs:
@@ -131,18 +131,6 @@ jobs:
             --parallel --build
             $(TelemetryOption) ${{ parameters.BUILD_PY_PARAMETERS }} ${{ parameters.EP_BUILD_FLAGS }}
           workingDirectory: '$(Build.BinariesDirectory)'
-
-      # - task: VSBuild@1
-      #   displayName: 'Build'
-      #   inputs:
-      #     solution: '$(Build.BinariesDirectory)\RelWithDebInfo\onnxruntime.sln'
-      #     platform: x64
-      #     configuration: RelWithDebInfo
-      #     msbuildArchitecture: $(buildArch)
-      #     maximumCpuCount: true
-      #     logProjectEvents: true
-      #     workingFolder: '$(Build.BinariesDirectory)\RelWithDebInfo'
-      #     createLogFile: true
 
       # Esrp signing
       - template: win-esrp-dll.yml

--- a/tools/ci_build/github/azure-pipelines/templates/py-win-gpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-win-gpu.yml
@@ -120,17 +120,29 @@ jobs:
             $(TelemetryOption) ${{ parameters.BUILD_PY_PARAMETERS }} ${{ parameters.EP_BUILD_FLAGS }}
           workingDirectory: '$(Build.BinariesDirectory)'
 
-      - task: VSBuild@1
+      # test building with build.py so the parallelization parameters are added to the msbuild command
+      - task: PythonScript@0
         displayName: 'Build'
         inputs:
-          solution: '$(Build.BinariesDirectory)\RelWithDebInfo\onnxruntime.sln'
-          platform: x64
-          configuration: RelWithDebInfo
-          msbuildArchitecture: $(buildArch)
-          maximumCpuCount: true
-          logProjectEvents: true
-          workingFolder: '$(Build.BinariesDirectory)\RelWithDebInfo'
-          createLogFile: true
+          scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
+          arguments: >
+            --config RelWithDebInfo
+            --build_dir $(Build.BinariesDirectory)
+            --parallel --build
+            $(TelemetryOption) ${{ parameters.BUILD_PY_PARAMETERS }} ${{ parameters.EP_BUILD_FLAGS }}
+          workingDirectory: '$(Build.BinariesDirectory)'
+
+      # - task: VSBuild@1
+      #   displayName: 'Build'
+      #   inputs:
+      #     solution: '$(Build.BinariesDirectory)\RelWithDebInfo\onnxruntime.sln'
+      #     platform: x64
+      #     configuration: RelWithDebInfo
+      #     msbuildArchitecture: $(buildArch)
+      #     maximumCpuCount: true
+      #     logProjectEvents: true
+      #     workingFolder: '$(Build.BinariesDirectory)\RelWithDebInfo'
+      #     createLogFile: true
 
       # Esrp signing
       - template: win-esrp-dll.yml
@@ -188,7 +200,7 @@ jobs:
         condition: and (succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
         inputs:
           GdnPublishTsaOnboard: false
-          GdnPublishTsaConfigFile: '$(Build.sourcesDirectory)\.gdn\.gdntsa' 
+          GdnPublishTsaConfigFile: '$(Build.sourcesDirectory)\.gdn\.gdntsa'
 
       - template: component-governance-component-detection-steps.yml
         parameters:


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
build.py sets a few parallelization parameters when building. Using msbuild directly lacks those.

https://github.com/microsoft/onnxruntime/blob/7a5860e4909387448cb51351d3af50933238ba10/tools/ci_build/build.py#L1665-L1669

Changed to use build.py. If there's a concern with that we _could_ set the parameters in the yaml, but that will be uglier due to duplicating logic in multiple places.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


