### PR TITLE
[Android] Increase JVM memory limit to 16G for custom Android Build

### DIFF
--- a/tools/android_custom_build/build_custom_android_package.py
+++ b/tools/android_custom_build/build_custom_android_package.py
@@ -168,6 +168,8 @@ def main():
         container_ops_config_file,
         container_build_settings_file,
         "/workspace/shared/output",
+        "-e",
+        'JAVA_OPTS="-Xms16G -Xmx16G"',
     ]
 
     run(docker_container_build_cmd)


### PR DESCRIPTION
### Description
Increase JVM memory limit to 16G to avoid crashes when custom building Android .aar packages.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/microsoft/onnxruntime/issues/19584.

