### PR TITLE
Unconditionally re-enable /W4 on Windows and fix warnings which showed up

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1259,11 +1259,7 @@ endif()
 #Dependencies end. In the next we'll enable "treat warning as error"
 
 #Adjust warning flags
-if (onnxruntime_USE_CUDA)
-  set_msvc_c_cpp_compiler_warning_level(3)
-else()
-  set_msvc_c_cpp_compiler_warning_level(4)
-endif()
+set_msvc_c_cpp_compiler_warning_level(4)
 
 set(onnxruntime_DELAYLOAD_FLAGS "")
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1259,8 +1259,11 @@ endif()
 #Dependencies end. In the next we'll enable "treat warning as error"
 
 #Adjust warning flags
-set_msvc_c_cpp_compiler_warning_level(4)
-
+if (onnxruntime_USE_TENSORRT)
+  set_msvc_c_cpp_compiler_warning_level(3)
+else()
+  set_msvc_c_cpp_compiler_warning_level(4)
+endif()
 set(onnxruntime_DELAYLOAD_FLAGS "")
 
 include_directories(

--- a/onnxruntime/contrib_ops/cuda/bert/rotary_embedding.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/rotary_embedding.cc
@@ -82,8 +82,6 @@ Status RotaryEmbedding<T>::ComputeInternal(OpKernelContext* context) const {
       interleaved,
       device_prop.maxThreadsPerBlock,
       parameters.transposed);
-
-  return Status::OK();
 }
 
 }  // namespace cuda

--- a/onnxruntime/core/framework/sequential_executor.cc
+++ b/onnxruntime/core/framework/sequential_executor.cc
@@ -305,8 +305,8 @@ class KernelScope {
     session_scope_.series_.write_flag(kernel_.Node().Name().c_str());
 #endif
 
-#ifdef ENABLE_NVTX_PROFILE
     auto& node = kernel_.Node();
+#ifdef ENABLE_NVTX_PROFILE
     profile::NvtxRangeCreator& forward_range = session_scope_.forward_range_;
     profile::NvtxRangeCreator& backward_range = session_scope_.backward_range_;
     if (node.Description() != "Backward pass" && !forward_range.IsBeginCalled()) {
@@ -335,7 +335,6 @@ class KernelScope {
 #endif
 
     if (session_state_.Profiler().IsEnabled()) {
-      auto& node = kernel.Node();
       node_name_ = node.Name().empty() ? MakeString(node.OpType(), "_", node.Index()) : node.Name();
       auto& profiler = session_state_.Profiler();
       auto sync_time_begin = profiler.Start();

--- a/onnxruntime/core/providers/cuda/cudnn_common.cc
+++ b/onnxruntime/core/providers/cuda/cudnn_common.cc
@@ -160,7 +160,6 @@ cudnnDataType_t CudnnTensor::GetDataType<half>() {
 template <>
 cudnnDataType_t CudnnTensor::GetDataType<BFloat16>() {
   ORT_THROW("cuDNN doesn't support BFloat16.");
-  return CUDNN_DATA_FLOAT;
 }
 
 template <>

--- a/onnxruntime/test/contrib_ops/decoder_masked_multihead_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/decoder_masked_multihead_attention_op_test.cc
@@ -469,6 +469,8 @@ std::vector<T> Softmax_QK_Transpose(T* qk_transpose_matrix,
 template <>
 std::vector<float> Softmax_QK_Transpose(float* qk_transpose_matrix,
                                         int batch_size, int num_heads, int sequence_length, int total_sequence_length, int head_size) {
+  ORT_UNUSED_PARAMETER(head_size);
+
   if (sequence_length != 1) {
     throw std::runtime_error("Not supported");
   }
@@ -508,6 +510,8 @@ std::vector<float> Softmax_QK_Transpose(float* qk_transpose_matrix,
 template <>
 std::vector<MLFloat16> Softmax_QK_Transpose(MLFloat16* qk_transpose_matrix,
                                             int batch_size, int num_heads, int sequence_length, int total_sequence_length, int head_size) {
+  ORT_UNUSED_PARAMETER(head_size);
+
   if (sequence_length != 1) {
     throw std::runtime_error("Not supported");
   }

--- a/onnxruntime/test/providers/cpu/generator/random_test.cc
+++ b/onnxruntime/test/providers/cpu/generator/random_test.cc
@@ -381,6 +381,8 @@ void RunRandomNormalGpuTest(const std::vector<int64_t> dims, const float mean, c
   }
 
   auto output_verifier = [&](const std::vector<OrtValue>& fetches, const std::string& provider_type) {
+    ORT_UNUSED_PARAMETER(provider_type);
+
     // Only one output, and mean of output values are near attribute mean.
     ASSERT_EQ(fetches.size(), 1u);
     const auto& output_tensor = fetches[0].Get<Tensor>();
@@ -473,6 +475,8 @@ void RunRandomUniformGpuTest(const std::vector<int64_t> dims, const float low, c
   }
 
   auto output_verifier = [&](const std::vector<OrtValue>& fetches, const std::string& provider_type) {
+    ORT_UNUSED_PARAMETER(provider_type);
+
     // Only one output. Each value in output tensoer is between low and high.
     // Mean of output values are near attribute mean of low and high.
     ASSERT_EQ(fetches.size(), 1u);

--- a/orttraining/orttraining/test/training_ops/cuda/cross_entropy_test.cc
+++ b/orttraining/orttraining/test/training_ops/cuda/cross_entropy_test.cc
@@ -324,6 +324,7 @@ static std::vector<OrtValue> RunSCELossWithEP(const char* op,
                                               std::vector<T>& X_data,
                                               std::vector<int64_t>& index_data,
                                               std::vector<T>& weight_data) {
+  ORT_UNUSED_PARAMETER(error_tolerance);
   /**
    * OpTester's atol/rtol check is too strict for our testing cases. Imagine expected value is 4.7683704451628728e-07,
    * real value is 0, even we set rtol=1e-1, atol = 1e-4. The check still fail.

--- a/orttraining/orttraining/training_ops/cuda/nn/conv_transpose_grad.cc
+++ b/orttraining/orttraining/training_ops/cuda/nn/conv_transpose_grad.cc
@@ -53,7 +53,6 @@ Status ConvTransposeGrad<T>::ComputeInputGradient(onnxruntime::Stream* stream, c
             algo_perf.algo, workspace.get(), algo_perf.memory, &zero, args.y_tensor, args.y_data));
         return Status::OK();
       });
-  return Status::OK();
 }
 
 template <typename T>
@@ -71,7 +70,6 @@ Status ConvTransposeGrad<T>::ComputeWeightGradient(onnxruntime::Stream* stream, 
             algo_perf.algo, workspace.get(), algo_perf.memory, &zero, args.w_desc, args.dw_data));
         return Status::OK();
       });
-  return Status::OK();
 }
 
 template <typename T>


### PR DESCRIPTION
### Description
I've set the compiler warning level for msvc back to /W4 for the CUDA backend to ensure better pre-commit testing and fixed the warnings in the core onnxruntime & CUDA EP which showed up after this change.


### Motivation and Context
The warning level on gcc/clang is higher than the one on MSVC when enabling the CUDA backend resulting in CI potential failures when filing a PR developed on Windows. Increase the warning level to have more overlap in warnings between MSVC and gcc/clang.

fix issue #19565


