### PR TITLE
Fix citation author name issue

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,7 @@ title: ONNX Runtime
 message: "Please use this information to cite ONNX Runtime in
   research or other publications."
 authors:
-  - affiliation: Microsoft Corporation
-    name: ONNX Runtime developers
+  - name: ONNX Runtime developers
 date-released: 2018-11-29
 url: "https://onnxruntime.ai"
 repository-code: "https://github.com/microsoft/onnxruntime"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ message: "Please use this information to cite ONNX Runtime in
   research or other publications."
 authors:
   - affiliation: Microsoft Corporation
-    given-names: ONNX Runtime developers
+    name: ONNX Runtime developers
 date-released: 2018-11-29
 url: "https://onnxruntime.ai"
 repository-code: "https://github.com/microsoft/onnxruntime"


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Use `name` rather than `given-names` to set author name.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

The old CITATION.cff uses `given-names` to set author names, which won't be rendered properly with some bibtex style of LaTeX:

<img width="680" alt="image" src="https://github.com/microsoft/onnxruntime/assets/22856433/c509400e-5b16-4400-8950-550b05186369">

The problem is that **the `"ONNX Runtime developers"` is regarded as a human name**.

How to fix: by using `name` to set author name, the generated Bibtex entry will use `{}` to enclose the `"ONNX Runtime developers"`. Then it is displayed literally:

<img width="742" alt="image" src="https://github.com/microsoft/onnxruntime/assets/22856433/94083c9f-0daa-4c51-92e1-c966b88d09d2">

