### PR TITLE
Fix a bug in build.py

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -2592,7 +2592,7 @@ def main():
         raise BuildError("Using --get-api-doc requires a single build config")
 
     # Disabling unit tests for GPU on nuget creation
-    if args.use_openvino != "CPU_FP32" and args.build_nuget:
+    if args.use_openvino and args.use_openvino != "CPU_FP32" and args.build_nuget:
         args.test = False
 
     # GDK builds don't support testing


### PR DESCRIPTION
### Description
Fix a bug in build.py that accidentally disabled C# tests for most builds when "--build_nuget" is specified. 


### Motivation and Context
It was added in PR #8892 .


