### PR TITLE
Add onnxblock large models support & allow loss block to accept extra inputs.

### DIFF
--- a/orttraining/orttraining/python/training/artifacts.py
+++ b/orttraining/orttraining/python/training/artifacts.py
@@ -141,7 +141,7 @@ def generate_artifacts(
 
             return self._loss(*inputs_to_loss)
 
-    training_block = _TrainingBlock(loss_block)
+    training_block = _TrainingBlock(loss_block, loss_input_names)
 
     if requires_grad is not None and frozen_params is not None and set(requires_grad).intersection(set(frozen_params)):
         raise RuntimeError(

--- a/orttraining/orttraining/python/training/artifacts.py
+++ b/orttraining/orttraining/python/training/artifacts.py
@@ -48,6 +48,7 @@ def generate_artifacts(
     custom_op_library: Optional[Union[str, bytes, os.PathLike]] = None,
     additional_output_names: Optional[List[str]] = None,
     nominal_checkpoint: bool = False,
+    loss_input_names: Optional[List[str]] = None,
 ) -> None:
     """Generates artifacts required for training with ORT training api.
 
@@ -77,7 +78,9 @@ def generate_artifacts(
             Default is False. Nominal checkpoint is a checkpoint that contains nominal information about the model
             parameters. It can be used on the device to reduce overhead while constructing the training model
             as well as to reduce the size of the checkpoint packaged with the on-device application.
-
+        loss_input_names: Specifies a list of input names to be used specifically for the loss computation. When provided,
+            only these inputs will be passed to the loss function. If `None`, all graph outputs are passed to
+            the loss function.
     Raises:
         RuntimeError: If the loss provided is neither one of the supported losses nor an instance of `onnxblock.Block`
         RuntimeError: If the optimizer provided is not one of the supported optimizers.
@@ -111,11 +114,17 @@ def generate_artifacts(
         logging.info("Custom loss block provided: %s", loss.__class__.__name__)
 
     class _TrainingBlock(onnxblock.TrainingBlock):
-        def __init__(self, _loss):
+        def __init__(self, _loss, _loss_input_names=None):
             super().__init__()
             self._loss = _loss
+            self._loss_input_names = _loss_input_names
 
         def build(self, *inputs_to_loss):
+
+            # If loss_input_names is passed, only pass the specified input names to the loss function.
+            if self._loss_input_names:
+                inputs_to_loss = self._loss_input_names
+
             if additional_output_names:
                 # If additional output names is not a list, raise an error
                 if not isinstance(additional_output_names, list):
@@ -157,9 +166,11 @@ def generate_artifacts(
         logging.info("Custom op library provided: %s", custom_op_library)
         custom_op_library_path = pathlib.Path(custom_op_library)
 
-    with onnxblock.base(model), onnxblock.custom_op_library(
-        custom_op_library_path
-    ) if custom_op_library is not None else contextlib.nullcontext():
+    with onnxblock.base(model), (
+        onnxblock.custom_op_library(custom_op_library_path)
+        if custom_op_library is not None
+        else contextlib.nullcontext()
+    ):
         _ = training_block(*[output.name for output in model.graph.output])
         training_model, eval_model = training_block.to_model_proto()
         model_params = training_block.parameters()

--- a/orttraining/orttraining/python/training/onnxblock/blocks.py
+++ b/orttraining/orttraining/python/training/onnxblock/blocks.py
@@ -53,7 +53,6 @@ class Block(ABC):
             # Check if the error is specifically due to exceeding the maximum protobuf size.
             if "exceeds maximum protobuf size of 2GB" in str(e):
                 logging.info("Handling large model that exceeds the maximum protobuf size of 2GB.")
-                pass
             else:
                 # If the error is for any other reason, re-raise it to not silently ignore important issues.
                 raise

--- a/orttraining/orttraining/python/training/onnxblock/blocks.py
+++ b/orttraining/orttraining/python/training/onnxblock/blocks.py
@@ -47,7 +47,16 @@ class Block(ABC):
 
         output = self.build(*args, **kwargs)
 
-        onnx.checker.check_model(self.base, True)
+        try:
+            onnx.checker.check_model(self.base, True)
+        except ValueError as e:
+            # Check if the error is specifically due to exceeding the maximum protobuf size.
+            if "exceeds maximum protobuf size of 2GB" in str(e):
+                logging.info("Handling large model that exceeds the maximum protobuf size of 2GB.")
+                pass
+            else:
+                # If the error is for any other reason, re-raise it to not silently ignore important issues.
+                raise
 
         return output
 

--- a/orttraining/orttraining/python/training/onnxblock/loss/loss.py
+++ b/orttraining/orttraining/python/training/onnxblock/loss/loss.py
@@ -33,7 +33,7 @@ class MSELoss(blocks.Block):
         self._sub = blocks.Sub()
         self._square = blocks.Pow(2.0)
 
-    def build(self, loss_input_name: str, target_name: str = "target"):
+    def build(self, loss_input_name: str, target_name: str = "target", *args):
         """Adds an MSELoss subgraph on top of the base_model.
 
         Args:
@@ -72,7 +72,7 @@ class CrossEntropyLoss(blocks.Block):
         self._reduction = reduction
         self._ignore_index = ignore_index
 
-    def build(self, scores_input_name: str, labels_name: str = "labels"):
+    def build(self, scores_input_name: str, labels_name: str = "labels", *args):
         """Adds a CrossEntropyLoss subgraph on top of an onnx model.
 
         Args:
@@ -149,7 +149,7 @@ class BCEWithLogitsLoss(blocks.Block):
         self._mul = blocks.Mul()
         self._neg = blocks.Neg()
 
-    def build(self, loss_input_name: str, target_name: str = "target"):
+    def build(self, loss_input_name: str, target_name: str = "target", *args):
         """Adds a BCEWithLogitsLoss subgraph on top of an onnx model.
 
         Creates a block that measures the binary cross entropy with logits between
@@ -229,7 +229,7 @@ class L1Loss(blocks.Block):
         self._abs = blocks.Abs()
         self._sub = blocks.Sub()
 
-    def build(self, loss_input_name: str, target_name: Optional[str] = "target"):
+    def build(self, loss_input_name: str, target_name: Optional[str] = "target", *args):
         """Adds an L1 loss subgraph on top of the base_model.
 
         Args:

--- a/orttraining/orttraining/python/training/onnxblock/loss/loss.py
+++ b/orttraining/orttraining/python/training/onnxblock/loss/loss.py
@@ -33,7 +33,7 @@ class MSELoss(blocks.Block):
         self._sub = blocks.Sub()
         self._square = blocks.Pow(2.0)
 
-    def build(self, loss_input_name: str, target_name: str = "target", *args):
+    def build(self, loss_input_name: str, target_name: str = "target"):
         """Adds an MSELoss subgraph on top of the base_model.
 
         Args:
@@ -72,7 +72,7 @@ class CrossEntropyLoss(blocks.Block):
         self._reduction = reduction
         self._ignore_index = ignore_index
 
-    def build(self, scores_input_name: str, labels_name: str = "labels", *args):
+    def build(self, scores_input_name: str, labels_name: str = "labels"):
         """Adds a CrossEntropyLoss subgraph on top of an onnx model.
 
         Args:
@@ -149,7 +149,7 @@ class BCEWithLogitsLoss(blocks.Block):
         self._mul = blocks.Mul()
         self._neg = blocks.Neg()
 
-    def build(self, loss_input_name: str, target_name: str = "target", *args):
+    def build(self, loss_input_name: str, target_name: str = "target"):
         """Adds a BCEWithLogitsLoss subgraph on top of an onnx model.
 
         Creates a block that measures the binary cross entropy with logits between
@@ -229,7 +229,7 @@ class L1Loss(blocks.Block):
         self._abs = blocks.Abs()
         self._sub = blocks.Sub()
 
-    def build(self, loss_input_name: str, target_name: Optional[str] = "target", *args):
+    def build(self, loss_input_name: str, target_name: Optional[str] = "target"):
         """Adds an L1 loss subgraph on top of the base_model.
 
         Args:

--- a/orttraining/orttraining/python/training/onnxblock/onnxblock.py
+++ b/orttraining/orttraining/python/training/onnxblock/onnxblock.py
@@ -192,7 +192,7 @@ class TrainingBlock(blocks.Block):
         size_check = False
         # Check If the protobuf is larger than 2GB
         try:
-            protobuf_string = model.SerializeToString()
+            model.SerializeToString()
         except ValueError as e:  # Catching ValueError exceptions
             # Now, e is an instance of ValueError, and you can check its message
             if "exceeds maximum protobuf size of 2GB" in str(e):

--- a/orttraining/orttraining/python/training/onnxblock/onnxblock.py
+++ b/orttraining/orttraining/python/training/onnxblock/onnxblock.py
@@ -188,7 +188,7 @@ class TrainingBlock(blocks.Block):
         output = self.build(*args, **kwargs)
 
         model = accessor._GLOBAL_ACCESSOR.model
-        
+
         size_check = False
         # Check If the protobuf is larger than 2GB
         try:
@@ -202,14 +202,14 @@ class TrainingBlock(blocks.Block):
             initializers_backup = model.graph.initializer[:]
 
             # Remove initializers from the model
-            model.graph.ClearField('initializer')
+            model.graph.ClearField("initializer")
 
             # Perform shape inference on the model without initializers
             model = onnx.shape_inference.infer_shapes(accessor._GLOBAL_ACCESSOR.model)
 
             # Restore initializers to the model
             model.graph.initializer.extend(initializers_backup)
-        else:  
+        else:
             model = onnx.shape_inference.infer_shapes(accessor._GLOBAL_ACCESSOR.model)
 
         _graph_utils.register_graph_outputs(model, output)


### PR DESCRIPTION
# onnxblock large models support.
This PR makes it possible for onnxblock to handle large models more effectively. 
Currently, onnxblock encounters problems when dealing with models larger than 2GB due to protobuf message max size. 
To address this issue, we temporarily remove initializers from the model during shape inference, and once shape inference is complete, the initializers are added back to the model. 

This change ensures that onnxblock can handle models larger than 2GB without issues.

# loss function extra inputs.

Currently, the loss functions in onnxblock expect exactly two inputs in their build method. 
Occasionally, models may pass additional inputs, causing the build function to fail. 
To solve this issue, we can temporarily resolve it by adding *args to the build method, allowing it to ignore any additional inputs beyond the expected two.


