### PR TITLE
Use Remove-Item to replace DeleteFiles to speed up

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/component-governance-component-detection-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/component-governance-component-detection-steps.yml
@@ -6,11 +6,16 @@ parameters:
 
 steps:
 - ${{ if eq(variables['System.TeamProject'], 'Lotus') }}:
-  - task: DeleteFiles@1
+  {% comment %} - task: DeleteFiles@1
     inputs:
       SourceFolder: '$(Build.BinariesDirectory)'
       contents: |
         **/*
+    displayName: 'Clean up build directory' {% endcomment %}
+
+  - powershell: |
+      Remove-Item '$(Build.BinariesDirectory)' -Force -Recurse
+    workingDirectory: '$(Build.SourcesDirectory)
     displayName: 'Clean up build directory'
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0

--- a/tools/ci_build/github/azure-pipelines/templates/component-governance-component-detection-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/component-governance-component-detection-steps.yml
@@ -6,13 +6,6 @@ parameters:
 
 steps:
 - ${{ if eq(variables['System.TeamProject'], 'Lotus') }}:
-  {% comment %} - task: DeleteFiles@1
-    inputs:
-      SourceFolder: '$(Build.BinariesDirectory)'
-      contents: |
-        **/*
-    displayName: 'Clean up build directory' {% endcomment %}
-
   - powershell: |
       Remove-Item '$(Build.BinariesDirectory)' -Force -Recurse
     workingDirectory: '$(Build.SourcesDirectory)

--- a/tools/ci_build/github/azure-pipelines/templates/component-governance-component-detection-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/component-governance-component-detection-steps.yml
@@ -8,7 +8,7 @@ steps:
 - ${{ if eq(variables['System.TeamProject'], 'Lotus') }}:
   - powershell: |
       Remove-Item '$(Build.BinariesDirectory)' -Force -Recurse
-    workingDirectory: '$(Build.SourcesDirectory)
+    workingDirectory: '$(Build.SourcesDirectory)'
     displayName: 'Clean up build directory'
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0

--- a/tools/ci_build/github/azure-pipelines/templates/component-governance-component-detection-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/component-governance-component-detection-steps.yml
@@ -7,7 +7,9 @@ parameters:
 steps:
 - ${{ if eq(variables['System.TeamProject'], 'Lotus') }}:
   - powershell: |
-      Remove-Item '$(Build.BinariesDirectory)' -Force -Recurse
+      if (Test-Path $(Build.BinariesDirectory)) {
+        Remove-Item '$(Build.BinariesDirectory)' -Force -Recurse
+      }
     workingDirectory: '$(Build.SourcesDirectory)'
     displayName: 'Clean up build directory'
 


### PR DESCRIPTION

DeleteFiles@1 takes long time in Nuget-CUDA-Packaging-Pipeline and encounter problem. This PR use Remove-Item to speed up.

Use DeleteFiles@1:
![image](https://github.com/microsoft/onnxruntime/assets/94887879/420ab596-8a1f-466f-b5b4-7ee2e29098b1)
https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=415102&view=logs&j=7e009e83-d906-5d2f-987c-4cab9f4f25f8&t=a9a3231e-bcf1-5765-c413-edbd7c62c236

Use Remove-Item:
![image](https://github.com/microsoft/onnxruntime/assets/94887879/827d2445-b994-4d3c-a98b-04239011bab8)
https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=415747&view=logs&j=92389838-2d01-5cb5-3e19-6f88093eb7cf&t=5153fb64-f58c-5e8d-5f6f-7a163bdcc405


