### PR TITLE
Address custom op output type inference in old release

### DIFF
--- a/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
+++ b/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
@@ -634,12 +634,16 @@ class RunQueue {
   // position, these conditions would be indistinguishable); (2) obtain
   // consistent snapshot of front_/back_ for Size operation using the
   // modification counters.
+#ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable: 4324)
+#pragma warning(disable : 4324)
+#endif
   ORT_ALIGN_TO_AVOID_FALSE_SHARING std::atomic<unsigned> front_;
   ORT_ALIGN_TO_AVOID_FALSE_SHARING std::atomic<unsigned> back_;
   ORT_ALIGN_TO_AVOID_FALSE_SHARING Elem array_[kSize];
+#ifdef _MSC_VER
 #pragma warning(pop)
+#endif
 
   // SizeOrNotEmpty returns current queue size; if NeedSizeEstimate is false,
   // only whether the size is 0 is guaranteed to be correct.

--- a/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
+++ b/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
@@ -634,9 +634,12 @@ class RunQueue {
   // position, these conditions would be indistinguishable); (2) obtain
   // consistent snapshot of front_/back_ for Size operation using the
   // modification counters.
+#pragma warning(push)
+#pragma warning(disable: 4324)
   ORT_ALIGN_TO_AVOID_FALSE_SHARING std::atomic<unsigned> front_;
   ORT_ALIGN_TO_AVOID_FALSE_SHARING std::atomic<unsigned> back_;
   ORT_ALIGN_TO_AVOID_FALSE_SHARING Elem array_[kSize];
+#pragma warning(pop)
 
   // SizeOrNotEmpty returns current queue size; if NeedSizeEstimate is false,
   // only whether the size is 0 is guaranteed to be correct.

--- a/onnxruntime/core/session/custom_ops.cc
+++ b/onnxruntime/core/session/custom_ops.cc
@@ -768,7 +768,10 @@ common::Status CreateCustomRegistry(gsl::span<OrtCustomOpDomain* const> op_domai
     }
 
     std::vector<ONNX_NAMESPACE::OpSchema> schemas;
-    for (const auto& [name, schema] : schema_map) {
+    schemas.reserve(schema_map.size());
+    for (const auto& ent : schema_map) {
+      const auto& name = ent.first;
+      const auto& schema = ent.second;
       schemas.push_back(schema);
       ONNX_NAMESPACE::InferenceFunction infer_fn = [schema, kernel_defs = std::move(kernel_def_map[name])](
                                                        ONNX_NAMESPACE::InferenceContext& infer_ctx) {


### PR DESCRIPTION
### Description
Pass schema to InferOutputTypes.
This helps detect optional input/outputs.
Quit inference on variadic inputs/outputs.

### Motivation and Context
Currently the optional arguments are choked on, and the inference quits when optional output is encountered resulting in incomplete inference.

