### PR TITLE
Add an option in OpenVINOProviderOptions to support the queue-based overload for creating ClContext

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -623,7 +623,8 @@ typedef struct OrtOpenVINOProviderOptions {
                                  cache_dir{},
                                  context{},
                                  enable_opencl_throttling{},
-                                 enable_dynamic_shapes{} {}
+                                 enable_dynamic_shapes{},
+                                 queue{} {}
 #endif
   /** \brief Device type string
    *
@@ -637,6 +638,7 @@ typedef struct OrtOpenVINOProviderOptions {
   void* context;
   unsigned char enable_opencl_throttling;  ///< 0 = disabled, nonzero = enabled
   unsigned char enable_dynamic_shapes;     ///< 0 = disabled, nonzero = enabled
+  void* queue;
 } OrtOpenVINOProviderOptions;
 
 struct OrtApi;

--- a/onnxruntime/core/providers/openvino/contexts.h
+++ b/onnxruntime/core/providers/openvino/contexts.h
@@ -31,6 +31,7 @@ struct GlobalContext {
   int onnx_opset_version;
   void* context = 0;
   bool use_api_2;
+  void* queue = 0;
 };
 
 // Holds context specific to subgraph.

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
@@ -25,6 +25,7 @@ OpenVINOExecutionProvider::OpenVINOExecutionProvider(const OpenVINOExecutionProv
   global_context_->enable_opencl_throttling = info.enable_opencl_throttling_;
   global_context_->disable_dynamic_shapes = info.disable_dynamic_shapes_;
   global_context_->num_of_threads = info.num_of_threads_;
+  global_context_->queue = info.queue_;
 
   // to check if target device is available
   // using ie_core capability GetAvailableDevices to fetch list of devices plugged in

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.h
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.h
@@ -70,11 +70,12 @@ struct OpenVINOExecutionProviderInfo {
   void* context_;
   bool enable_opencl_throttling_;
   bool disable_dynamic_shapes_;
+  void* queue_;
 
   explicit OpenVINOExecutionProviderInfo(std::string dev_type, bool enable_npu_fast_compile, std::string dev_id,
                                          size_t num_of_threads, std::string cache_dir, int num_streams,
                                          void* context, bool enable_opencl_throttling,
-                                         bool disable_dynamic_shapes)
+                                         bool disable_dynamic_shapes, void* queue)
       : enable_npu_fast_compile_(enable_npu_fast_compile),
         device_id_(dev_id),
         num_of_threads_(num_of_threads),
@@ -82,7 +83,8 @@ struct OpenVINOExecutionProviderInfo {
         num_streams_(num_streams),
         context_(context),
         enable_opencl_throttling_(enable_opencl_throttling),
-        disable_dynamic_shapes_(disable_dynamic_shapes) {
+        disable_dynamic_shapes_(disable_dynamic_shapes),
+        queue_(queue) {
     if (dev_type == "") {
       LOGS_DEFAULT(INFO) << "[OpenVINO-EP]"
                          << "No runtime device selection option provided.";
@@ -166,7 +168,7 @@ struct OpenVINOExecutionProviderInfo {
                        << "Choosing Device: " << device_type_ << " , Precision: " << precision_;
   }
   OpenVINOExecutionProviderInfo() {
-    OpenVINOExecutionProviderInfo("", false, "", 0, "", 1, NULL, false, false);
+    OpenVINOExecutionProviderInfo("", false, "", 0, "", 1, NULL, false, false, 0);
   }
 };
 

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -1713,6 +1713,13 @@ ProviderOptions OrtOpenVINOProviderOptionsToOrtOpenVINOProviderOptionsV2(const O
 
   // Add new provider option below
   ov_options_converted_map["num_streams"] = "1";
+
+  if (legacy_ov_options->queue != nullptr) {
+    std::stringstream queue_string;
+    queue_string << legacy_ov_options->queue;
+    ov_options_converted_map["queue"] = queue_string.str();
+  }
+
   return ov_options_converted_map;
 }
 


### PR DESCRIPTION
### Description
Currently, the OpenVINO EP only provides a way to share an OpenCL context (for IO Buffering) through a context pointer, given in its provider options (either the struct or string-map based API).

This is problematic when wanting to use a specific OpenCL queue instead, as there is no way to do so through the current API, even though OpenVINO itself provides an overload for it.

This PR addresses this issue by adding an option to the OpenVINO EP provider options that enables the use of that second overload. This makes it possible to explicitly share OpenCL command queues when using OpenVINO EP.

### Motivation and Context
As described in issue https://github.com/microsoft/onnxruntime/issues/19697.


