### PR TITLE
Update labeler.yml to change permissions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,6 +3,9 @@ on:
   issues:
     types: [opened, edited]
 
+permissions:
+  issues: write
+
 jobs:
   triage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description
Updated github/issue-labeler permissions to give write access for issues. Tried to submit the same PR last week, but the checks kept failing, so I couldn't merge.



### Motivation and Context
Enables issue labeling again, which has been broken since GitHub Actions permissions were changed a couple weeks ago.


