### PR TITLE
improve the partition logic

### DIFF
--- a/onnxruntime/core/providers/partitioning_utils.cc
+++ b/onnxruntime/core/providers/partitioning_utils.cc
@@ -159,7 +159,7 @@ std::vector<std::vector<const Node*>> CreateSupportedPartitionNodeGroups(
       auto node = initial_nodes_to_process.begin();
       while (node != initial_nodes_to_process.end()) {
         bool node_is_counsumed = false;
-        
+
         for (auto output = (*node)->OutputNodesBegin(); output != (*node)->OutputNodesEnd(); ++output) {
           if (std::find(supported_group.begin(), supported_group.end(), &(*output)) != supported_group.end()) {
             node_is_counsumed = true;

--- a/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
@@ -123,6 +123,8 @@ void QnnContextBinaryMultiPartitionTestBody(bool single_ep_node = true) {
   for (auto& node : ctx_graph.Nodes()) {
     if (node.OpType() == "EPContext") {
       ++ep_context_node_count;
+      // validate the fix for the partition issue
+      ASSERT_EQ(node.InputDefs().size(), 1);
     } else {
       ++non_ep_context_node_count;
     }

--- a/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
@@ -79,7 +79,7 @@ static GetTestModelFn BuildGraphWithQAndNonQ(bool single_ep_node = true) {
 
 // This test doesn't run the model through optimization, the ini->Q->DQ on the 2nd Add is placed to the 1st partition
 // Still need to be improved.
-TEST(GraphPartitionTest, DISABLED_Partition2EachHas6Nodes) {
+TEST(GraphPartitionTest, DISABLED_2PartitionWithEqualNodes) {
   const std::unordered_map<std::string, int> domain_to_version = {{"", 13}, {kMSDomain, 1}};
 
   auto& logging_manager = DefaultLoggingManager();


### PR DESCRIPTION
### Description
![image](https://github.com/microsoft/onnxruntime/assets/29932710/025c61a5-a75c-4304-b3c9-02619c343cf1)
A DQ node with initializer input could be put into wrong partition which not sit together with it's QDQ groups any more.
Improved the utils::CreateSupportedPartitions to check whether the input node is consumed by any nodes in the currently partition to decide whether to keep it or not.



