### PR TITLE
[js/webgpu] Enable GroupedConvVectorize path

### DIFF
--- a/js/web/lib/wasm/jsep/backend-webgpu.ts
+++ b/js/web/lib/wasm/jsep/backend-webgpu.ts
@@ -106,16 +106,10 @@ class AdapterInfoImpl implements AdapterInfo {
   }
 
   isArchitecture(architecture: GpuArchitecture): boolean {
-    if (typeof this.architecture === 'undefined') {
-      return false;
-    }
     return this.architecture === architecture;
   }
 
   isVendor(vendor: GpuVendor): boolean {
-    if (typeof this.vendor === 'undefined') {
-      return false;
-    }
     return this.vendor === vendor;
   }
 }

--- a/js/web/lib/wasm/jsep/backend-webgpu.ts
+++ b/js/web/lib/wasm/jsep/backend-webgpu.ts
@@ -95,8 +95,8 @@ const getProgramInfoUniqueKey =
     };
 
 class AdapterInfoImpl implements AdapterInfo {
-  readonly architecture: string;
-  readonly vendor: string;
+  readonly architecture?: string;
+  readonly vendor?: string;
 
   constructor(adapterInfo: GPUAdapterInfo) {
     if (adapterInfo) {

--- a/js/web/lib/wasm/jsep/backend-webgpu.ts
+++ b/js/web/lib/wasm/jsep/backend-webgpu.ts
@@ -94,11 +94,27 @@ const getProgramInfoUniqueKey =
       return key;
     };
 
+export class AdapterInfo {
+  private vendor: string;
+
+  constructor(adapterInfo: GPUAdapterInfo) {
+    if (adapterInfo) {
+      this.vendor = adapterInfo.vendor;
+    }
+  }
+
+  // vendor could be intel, nvidia, amd, etc.
+  isVendor(vendor: string): boolean {
+    return this.vendor === vendor;
+  }
+}
+
 /**
  * this class is designed to store status and being used as a singleton for JSEP. It will be passed to jsepInit() as
  * the first parameter so that it is stored for future use.
  */
 export class WebGpuBackend {
+  adapterInfo: AdapterInfo;
   device: GPUDevice;
   /**
    * an instance of GpuDataManager to manage a GpuDataId -> GpuBuffer mapping
@@ -212,6 +228,8 @@ export class WebGpuBackend {
     }
 
     this.device = await adapter.requestDevice(deviceDescriptor);
+    const adapterInfo = await adapter.requestAdapterInfo();
+    this.adapterInfo = new AdapterInfo(adapterInfo);
     this.gpuDataManager = createGpuDataManager(this);
     this.programManager = new ProgramManager(this);
     this.kernels = new Map();

--- a/js/web/lib/wasm/jsep/backend-webgpu.ts
+++ b/js/web/lib/wasm/jsep/backend-webgpu.ts
@@ -94,17 +94,34 @@ const getProgramInfoUniqueKey =
       return key;
     };
 
+
+/**
+ * this class is designed for info and related helper functions of the GPU adapter in use
+ */
 export class AdapterInfo {
+  private architecture: string;
   private vendor: string;
 
   constructor(adapterInfo: GPUAdapterInfo) {
     if (adapterInfo) {
+      this.architecture = adapterInfo.architecture;
       this.vendor = adapterInfo.vendor;
     }
   }
 
-  // vendor could be intel, nvidia, amd, etc.
+  // architecture could be ampere, gen12-lp, etc.
+  isArchitecture(architecture: string): boolean {
+    if (typeof this.architecture === 'undefined') {
+      return false;
+    }
+    return this.architecture === architecture;
+  }
+
+  // vendor could be amd, intel, nvidia, etc.
   isVendor(vendor: string): boolean {
+    if (typeof this.vendor === 'undefined') {
+      return false;
+    }
     return this.vendor === vendor;
   }
 }

--- a/js/web/lib/wasm/jsep/init.ts
+++ b/js/web/lib/wasm/jsep/init.ts
@@ -6,11 +6,11 @@ import {Env} from 'onnxruntime-common';
 import {OrtWasmModule} from '../binding/ort-wasm';
 import {DataType, getTensorElementSize} from '../wasm-common';
 
-import {AdapterInfo, WebGpuBackend} from './backend-webgpu';
+import {WebGpuBackend} from './backend-webgpu';
 import {LOG_DEBUG} from './log';
 import {TensorView} from './tensor-view';
 import {ShapeUtil} from './util';
-import {ComputeContext, ComputeContextInputsOutputsMapping, ProgramInfo} from './webgpu/types';
+import {AdapterInfo, ComputeContext, ComputeContextInputsOutputsMapping, ProgramInfo} from './webgpu/types';
 
 /* eslint-disable no-bitwise */
 

--- a/js/web/lib/wasm/jsep/init.ts
+++ b/js/web/lib/wasm/jsep/init.ts
@@ -6,7 +6,7 @@ import {Env} from 'onnxruntime-common';
 import {OrtWasmModule} from '../binding/ort-wasm';
 import {DataType, getTensorElementSize} from '../wasm-common';
 
-import {WebGpuBackend} from './backend-webgpu';
+import {AdapterInfo, WebGpuBackend} from './backend-webgpu';
 import {LOG_DEBUG} from './log';
 import {TensorView} from './tensor-view';
 import {ShapeUtil} from './util';
@@ -54,6 +54,7 @@ class TensorViewImpl implements TensorView {
 }
 
 class ComputeContextImpl implements ComputeContext {
+  readonly adapterInfo: AdapterInfo;
   readonly opKernelContext: number;
   readonly inputs: readonly TensorView[];
   readonly outputCount: number;
@@ -66,6 +67,7 @@ class ComputeContextImpl implements ComputeContext {
   private customDataOffset = 0;
   private customDataSize = 0;
   constructor(private module: OrtWasmModule, private backend: WebGpuBackend, contextDataOffset: number) {
+    this.adapterInfo = backend.adapterInfo;
     const heapU32 = module.HEAPU32;
 
     // extract context data

--- a/js/web/lib/wasm/jsep/webgpu/ops/conv.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/conv.ts
@@ -148,11 +148,12 @@ const conv2d = (context: ComputeContext, inputs: readonly TensorView[], attribut
   // const hasPreluActivationWeights = false; /* TODO: add support for prelu activation weights */
   const isChannelsLast = attributes.format === 'NHWC';
   if (attributes.group !== 1) {
-    // Temporarily disable createGroupedConvVectorizeProgramInfo path due to bots failures with below two cases:
+    // One CI bot with NVIDIA GPU fails with below 2 cases, but we couldn't repro them with any other GPUs, including NVIDIA ones.
     // [webgpu]Conv - conv - vectorize group - B
     // [webgpu]Conv - conv - vectorize group - D
-    const disableGroupedConvVectorize = true;
-    if (!disableGroupedConvVectorize && isChannelsLast && inputs[1].dims[0] === attributes.group &&
+    // Disable vectorize on NVIDIA to make bots happy. BTW, no obvious perf gain with vectorize is seen on NVIDIA GPUs.
+    const enableGroupedConvVectorize = context.adapterInfo.isVendor('nvidia') ? false : true;
+    if (enableGroupedConvVectorize && isChannelsLast && inputs[1].dims[0] === attributes.group &&
         inputs[1].dims[1] === 1 && attributes.dilations[0] === 1 && attributes.dilations[1] === 1) {
       const outputShape = calculateOutputShape(
           inputs[0].dims, inputs[1].dims, attributes.dilations, adjustedAttributes.pads, attributes.strides,

--- a/js/web/lib/wasm/jsep/webgpu/ops/conv.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/conv.ts
@@ -148,7 +148,7 @@ const conv2d = (context: ComputeContext, inputs: readonly TensorView[], attribut
   // const hasPreluActivationWeights = false; /* TODO: add support for prelu activation weights */
   const isChannelsLast = attributes.format === 'NHWC';
   if (attributes.group !== 1) {
-    // NVIDIA GPU with ampere architecutre fails with below 2 cases, but we couldn't repro them with any other
+    // NVIDIA GPU with ampere architecture fails with below 2 cases, but we couldn't repro them with any other
     // GPUs. So just disable vectorize on NVIDIA ampere to ensure always correct outputs.
     // [webgpu]Conv - conv - vectorize group - B
     // [webgpu]Conv - conv - vectorize group - D

--- a/js/web/lib/wasm/jsep/webgpu/ops/conv.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/conv.ts
@@ -148,11 +148,11 @@ const conv2d = (context: ComputeContext, inputs: readonly TensorView[], attribut
   // const hasPreluActivationWeights = false; /* TODO: add support for prelu activation weights */
   const isChannelsLast = attributes.format === 'NHWC';
   if (attributes.group !== 1) {
-    // One CI bot with NVIDIA GPU fails with below 2 cases, but we couldn't repro them with any other GPUs, including NVIDIA ones.
+    // One CI with NVIDIA GPU (ampere architecutre) fails with below 2 cases, but we couldn't repro them with any other GPUs, including NVIDIA ones.
     // [webgpu]Conv - conv - vectorize group - B
     // [webgpu]Conv - conv - vectorize group - D
-    // Disable vectorize on NVIDIA to make bots happy. BTW, no obvious perf gain with vectorize is seen on NVIDIA GPUs.
-    const enableGroupedConvVectorize = context.adapterInfo.isVendor('nvidia') ? false : true;
+    // Disable vectorize on NVIDIA ampere to make bots happy. BTW, no obvious perf gain with vectorize is seen on NVIDIA GPUs.
+    const enableGroupedConvVectorize = context.adapterInfo.isArchitecture('ampere') ? false : true;
     if (enableGroupedConvVectorize && isChannelsLast && inputs[1].dims[0] === attributes.group &&
         inputs[1].dims[1] === 1 && attributes.dilations[0] === 1 && attributes.dilations[1] === 1) {
       const outputShape = calculateOutputShape(

--- a/js/web/lib/wasm/jsep/webgpu/ops/conv.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/conv.ts
@@ -148,8 +148,8 @@ const conv2d = (context: ComputeContext, inputs: readonly TensorView[], attribut
   // const hasPreluActivationWeights = false; /* TODO: add support for prelu activation weights */
   const isChannelsLast = attributes.format === 'NHWC';
   if (attributes.group !== 1) {
-    // One CI with NVIDIA GPU (ampere architecutre) fails with below 2 cases, but we couldn't repro them with any other
-    // GPUs, including NVIDIA ones. So just disable vectorize on NVIDIA ampere to ensure always correct outputs.
+    // NVIDIA GPU with ampere architecutre fails with below 2 cases, but we couldn't repro them with any other
+    // GPUs. So just disable vectorize on NVIDIA ampere to ensure always correct outputs.
     // [webgpu]Conv - conv - vectorize group - B
     // [webgpu]Conv - conv - vectorize group - D
     const enableGroupedConvVectorize = !context.adapterInfo.isArchitecture('ampere');

--- a/js/web/lib/wasm/jsep/webgpu/ops/conv.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/conv.ts
@@ -148,10 +148,11 @@ const conv2d = (context: ComputeContext, inputs: readonly TensorView[], attribut
   // const hasPreluActivationWeights = false; /* TODO: add support for prelu activation weights */
   const isChannelsLast = attributes.format === 'NHWC';
   if (attributes.group !== 1) {
-    // One CI with NVIDIA GPU (ampere architecutre) fails with below 2 cases, but we couldn't repro them with any other GPUs, including NVIDIA ones.
+    // One CI with NVIDIA GPU (ampere architecutre) fails with below 2 cases, but we couldn't repro them with any other
+    // GPUs, including NVIDIA ones.
     // [webgpu]Conv - conv - vectorize group - B
     // [webgpu]Conv - conv - vectorize group - D
-    // Disable vectorize on NVIDIA ampere to make bots happy. BTW, no obvious perf gain with vectorize is seen on NVIDIA GPUs.
+    // Disable vectorize on NVIDIA ampere to make bots happy.
     const enableGroupedConvVectorize = context.adapterInfo.isArchitecture('ampere') ? false : true;
     if (enableGroupedConvVectorize && isChannelsLast && inputs[1].dims[0] === attributes.group &&
         inputs[1].dims[1] === 1 && attributes.dilations[0] === 1 && attributes.dilations[1] === 1) {

--- a/js/web/lib/wasm/jsep/webgpu/ops/conv.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/conv.ts
@@ -149,11 +149,10 @@ const conv2d = (context: ComputeContext, inputs: readonly TensorView[], attribut
   const isChannelsLast = attributes.format === 'NHWC';
   if (attributes.group !== 1) {
     // One CI with NVIDIA GPU (ampere architecutre) fails with below 2 cases, but we couldn't repro them with any other
-    // GPUs, including NVIDIA ones.
+    // GPUs, including NVIDIA ones. So just disable vectorize on NVIDIA ampere to ensure always correct outputs.
     // [webgpu]Conv - conv - vectorize group - B
     // [webgpu]Conv - conv - vectorize group - D
-    // Disable vectorize on NVIDIA ampere to make bots happy.
-    const enableGroupedConvVectorize = context.adapterInfo.isArchitecture('ampere') ? false : true;
+    const enableGroupedConvVectorize = !context.adapterInfo.isArchitecture('ampere');
     if (enableGroupedConvVectorize && isChannelsLast && inputs[1].dims[0] === attributes.group &&
         inputs[1].dims[1] === 1 && attributes.dilations[0] === 1 && attributes.dilations[1] === 1) {
       const outputShape = calculateOutputShape(

--- a/js/web/lib/wasm/jsep/webgpu/types.ts
+++ b/js/web/lib/wasm/jsep/webgpu/types.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import {DataType} from '../../wasm-common';
-import {AdapterInfo} from '../backend-webgpu'
 import {TensorView} from '../tensor-view';
 
 import {ShaderHelper} from './ops/common';
@@ -15,6 +14,16 @@ export enum GpuDataType {
   profile = 2
 }
 export type GpuDataId = number;
+
+export type GpuArchitecture = 'ampere';
+export type GpuVendor = 'amd'|'intel'|'nvidia';
+export interface AdapterInfo {
+  readonly architecture: string;
+  readonly vendor: string;
+
+  isArchitecture: (architecture: GpuArchitecture) => boolean;
+  isVendor: (vendor: GpuVendor) => boolean;
+}
 
 export interface GpuData {
   type: GpuDataType;

--- a/js/web/lib/wasm/jsep/webgpu/types.ts
+++ b/js/web/lib/wasm/jsep/webgpu/types.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import {DataType} from '../../wasm-common';
+import {AdapterInfo} from '../backend-webgpu'
 import {TensorView} from '../tensor-view';
 
 import {ShaderHelper} from './ops/common';
@@ -146,6 +147,11 @@ export interface ComputeContextInputsOutputsMapping {
  * A ComputeContext instance carries the states that representing the current running of a kernel.
  */
 export interface ComputeContext {
+  /**
+   * gpu adapter info
+   */
+  readonly adapterInfo: AdapterInfo;
+
   /**
    * stores the pointer to OpKernelContext
    */

--- a/js/web/lib/wasm/jsep/webgpu/types.ts
+++ b/js/web/lib/wasm/jsep/webgpu/types.ts
@@ -18,9 +18,6 @@ export type GpuDataId = number;
 export type GpuArchitecture = 'ampere';
 export type GpuVendor = 'amd'|'intel'|'nvidia';
 export interface AdapterInfo {
-  readonly architecture: string;
-  readonly vendor: string;
-
   isArchitecture: (architecture: GpuArchitecture) => boolean;
   isVendor: (vendor: GpuVendor) => boolean;
 }


### PR DESCRIPTION
Vectorize met 2 failed cases in a CI bot with NVIDIA GPU, but we couldn't repro with all the GPUs at hand, including NVIDIA GPUs. This PR introduces GPUAdapterInfo and enables this opt on non-NVIDIA GPUs to make the bots happy.
No obivous perf gain can be seen if we enable vectorize on NVIDIA. However, it shows big perf improvement on Intel. On my Gen12 Intel GPU, mobilenetv2-12 perf was improved from 11.14ms to 7.1ms.