### PR TITLE
[TensorRT EP] Add one stage to test TRTEP multiGPU with cuda12/cudnn9/latestTRT 

### DIFF
--- a/tools/ci_build/github/azure-pipelines/post-merge-jobs.yml
+++ b/tools/ci_build/github/azure-pipelines/post-merge-jobs.yml
@@ -281,6 +281,26 @@ stages:
         MachinePool: onnxruntime-Win2022-GPU-MultiA10
         OnnxruntimeTestGpuDeviceId: 1
 
+- ${{ if or(startsWith(variables['System.CollectionUri'], 'https://dev.azure.com/aiinfra/'),startsWith(variables['System.CollectionUri'], 'https://aiinfra.visualstudio.com/')) }}:
+  # The settings below is the same as Windows GPU CI pipeline's CUDA job except here we set OnnxruntimeTestGpuDeviceId to 1
+  - stage: trt_multi_gpu_trt_10_cuda12_cudnn9
+    dependsOn: []
+    jobs:
+    - template: templates/jobs/win-ci-vs-2022-job.yml
+      parameters:
+        BuildConfig: 'RelWithDebInfo'
+        EnvSetupScript: setup_env_trt_10_cuda12_cudnn9.bat
+        buildArch: x64
+        additionalBuildFlags: --enable_pybind --build_java --build_nodejs --use_cuda --cuda_home="$(Agent.TempDirectory)\v12.2" --cudnn_home="C:\local\cudnn-windows-x86_64-9.0.0.312_cuda12-archive\lib" --enable_cuda_profiling --use_tensorrt --tensorrt_home="C:\local\TensorRT-10.0.0.2.Windows10.win10.cuda-12.4\TensorRT-10.0.0.2\lib" --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=86
+        msbuildPlatform: x64
+        isX86: false
+        job_name_suffix: x64_RelWithDebInfo
+        RunOnnxRuntimeTests: true
+        ORT_EP_NAME: TRT
+        WITH_CACHE: true
+        MachinePool: onnxruntime-Win2022-GPU-MultiA10
+        OnnxruntimeTestGpuDeviceId: 1
+
 - stage: Mimalloc
   dependsOn: [ ]
   jobs:

--- a/tools/ci_build/github/windows/setup_env_trt_10_cuda12_cudnn9.bat
+++ b/tools/ci_build/github/windows/setup_env_trt_10_cuda12_cudnn9.bat
@@ -1,0 +1,12 @@
+REM Copyright (c) Microsoft Corporation. All rights reserved.
+REM Licensed under the MIT License.
+
+if exist PATH=%AGENT_TEMPDIRECTORY%\v12.2\ (
+    set PATH=%PATH%;%AGENT_TEMPDIRECTORY%\v12.2\bin;%AGENT_TEMPDIRECTORY%\v12.2\extras\CUPTI\lib64
+) else (
+    set PATH=%PATH%;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2\bin;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2\extras\CUPTI\lib64
+)
+
+set PATH=C:\local\TensorRT-10.0.0.2.Windows10.win10.cuda-12.4\TensorRT-10.0.0.2\lib;C:\local\cudnn-windows-x86_64-9.0.0.312_cuda12-archive\lib;%PATH%
+set GRADLE_OPTS=-Dorg.gradle.daemon=false
+set CUDA_MODULE_LOADING=LAZY


### PR DESCRIPTION
(Blocker: CI Image need to be re-build, 
however, [onnxruntime windows 2022 image](https://aiinfra.visualstudio.com/AI%20Infra%20Management/_build?definitionId=1140&_a=summary) is deprecated and this need to be migrated to 1ES managed image)

### Description
<!-- Describe your changes. -->
Add one stage to test TRTEP windows multiGPU CI with cuda12/cudnn9/latestTRT.



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


