### PR TITLE
Some Shape Related Fusions

### DIFF
--- a/onnxruntime/core/optimizer/common_subexpression_elimination.cc
+++ b/onnxruntime/core/optimizer/common_subexpression_elimination.cc
@@ -4,6 +4,7 @@
 #include "common_subexpression_elimination.h"
 #include "core/optimizer/utils.h"
 #include "core/graph/graph_utils.h"
+#include "core/framework/tensorprotoutils.h"
 
 #include <memory>
 #include <type_traits>
@@ -170,6 +171,31 @@ bool AreRangesEqual(const Range& lhs, const Range& rhs) {
          std::equal(lhs.begin(), lhs.end(), rhs.begin());
 }
 
+// Check if two tensor attributes are equal scalar tensors, mainly to support ConstantOfShape Op.
+bool AreScalarTensorAttributeEqual(const ONNX_NAMESPACE::TensorProto& lhs_t, const ONNX_NAMESPACE::TensorProto& rhs_t) {
+  if (!(utils::HasDataType(lhs_t) && utils::HasDataType(rhs_t) && lhs_t.data_type() == rhs_t.data_type() &&
+        (lhs_t.data_type() == onnx::TensorProto_DataType_FLOAT ||
+         lhs_t.data_type() == onnx::TensorProto_DataType_FLOAT16 ||
+         lhs_t.data_type() == onnx::TensorProto_DataType_INT64) &&
+        lhs_t.dims_size() == 1 && rhs_t.dims_size() == 1 && lhs_t.dims()[0] == 1 && rhs_t.dims()[0] == 1 &&
+        utils::HasRawData(lhs_t) && utils::HasRawData(rhs_t))) {
+    return false;
+  }
+  const void* lhs_value = lhs_t.raw_data().data();
+  const void* rhs_value = rhs_t.raw_data().data();
+  switch (lhs_t.data_type()) {
+    case onnx::TensorProto_DataType_FLOAT:
+      return *reinterpret_cast<const float*>(lhs_value) == *reinterpret_cast<const float*>(rhs_value);
+    case onnx::TensorProto_DataType_FLOAT16:
+      return *reinterpret_cast<const MLFloat16*>(lhs_value) == *reinterpret_cast<const MLFloat16*>(rhs_value);
+    case onnx::TensorProto_DataType_INT64:
+      return *reinterpret_cast<const int64_t*>(lhs_value) == *reinterpret_cast<const int64_t*>(rhs_value);
+    default:
+      break;
+  }
+  return false;
+}
+
 bool AreEqual(const ONNX_NAMESPACE::AttributeProto& lhs, const ONNX_NAMESPACE::AttributeProto& rhs) {
   if (&lhs == &rhs) {
     return true;
@@ -193,6 +219,7 @@ bool AreEqual(const ONNX_NAMESPACE::AttributeProto& lhs, const ONNX_NAMESPACE::A
     case onnx::AttributeProto_AttributeType_STRINGS:
       return AreRangesEqual(lhs.strings(), rhs.strings());
     case onnx::AttributeProto_AttributeType_TENSOR:
+      return AreScalarTensorAttributeEqual(lhs.t(), rhs.t());
     case onnx::AttributeProto_AttributeType_GRAPH:
     case onnx::AttributeProto_AttributeType_SPARSE_TENSOR:
     case onnx::AttributeProto_AttributeType_TYPE_PROTO:
@@ -205,6 +232,31 @@ bool AreEqual(const ONNX_NAMESPACE::AttributeProto& lhs, const ONNX_NAMESPACE::A
   }
 
   return false;
+}
+
+// Support scalar tensor attribute only for now.
+std::size_t GetTensorAttributeHash(const ONNX_NAMESPACE::TensorProto& attr_t) {
+  std::size_t hash = 0;
+  if (utils::HasDataType(attr_t) && attr_t.dims_size() == 1 && attr_t.dims()[0] == 1 && utils::HasRawData(attr_t)) {
+    int data_type = attr_t.data_type();
+    switch (data_type) {
+      case onnx::TensorProto_DataType_FLOAT:
+        UpdateHash(data_type, hash);
+        UpdateHash(*reinterpret_cast<const float*>(attr_t.raw_data().data()), hash);
+        break;
+      case onnx::TensorProto_DataType_FLOAT16:
+        UpdateHash(data_type, hash);
+        UpdateHash(static_cast<float>(*reinterpret_cast<const MLFloat16*>(attr_t.raw_data().data())), hash);
+        break;
+      case onnx::TensorProto_DataType_INT64:
+        UpdateHash(data_type, hash);
+        UpdateHash(*reinterpret_cast<const int64_t*>(attr_t.raw_data().data()), hash);
+        break;
+      default:
+        break;
+    }
+  }
+  return hash;
 }
 
 std::size_t GetAttributeHash(const ONNX_NAMESPACE::AttributeProto& attr) {
@@ -233,6 +285,8 @@ std::size_t GetAttributeHash(const ONNX_NAMESPACE::AttributeProto& attr) {
       UpdateHashWithContainer(attr.strings(), hash);
       break;
     case onnx::AttributeProto_AttributeType_TENSOR:
+      UpdateHash(attr.t(), &GetTensorAttributeHash, hash);
+      break;
     case onnx::AttributeProto_AttributeType_GRAPH:
     case onnx::AttributeProto_AttributeType_SPARSE_TENSOR:
     case onnx::AttributeProto_AttributeType_TYPE_PROTO:

--- a/onnxruntime/core/optimizer/common_subexpression_elimination.cc
+++ b/onnxruntime/core/optimizer/common_subexpression_elimination.cc
@@ -172,6 +172,7 @@ bool AreRangesEqual(const Range& lhs, const Range& rhs) {
 }
 
 // Check if two tensor attributes are equal scalar tensors, mainly to support ConstantOfShape Op.
+// Currently support float, float16 and int64 data types, and requires the data are raw data in TensorProto.
 bool AreScalarTensorAttributeEqual(const ONNX_NAMESPACE::TensorProto& lhs_t, const ONNX_NAMESPACE::TensorProto& rhs_t) {
   if (!(utils::HasDataType(lhs_t) && utils::HasDataType(rhs_t) && lhs_t.data_type() == rhs_t.data_type() &&
         (lhs_t.data_type() == onnx::TensorProto_DataType_FLOAT ||
@@ -234,7 +235,7 @@ bool AreEqual(const ONNX_NAMESPACE::AttributeProto& lhs, const ONNX_NAMESPACE::A
   return false;
 }
 
-// Support scalar tensor attribute only for now.
+// Support scalar float/int64/fp16 tensor attribute only for now, and requires data is raw data in TensorProto.
 std::size_t GetTensorAttributeHash(const ONNX_NAMESPACE::TensorProto& attr_t) {
   std::size_t hash = 0;
   if (utils::HasDataType(attr_t) && attr_t.dims_size() == 1 && attr_t.dims()[0] == 1 && utils::HasRawData(attr_t)) {

--- a/onnxruntime/core/optimizer/constant_folding.cc
+++ b/onnxruntime/core/optimizer/constant_folding.cc
@@ -100,7 +100,8 @@ static bool ConstantFoldGatherNode(Graph& graph, Node& node) {
       tensor_proto->data_type() != ONNX_NAMESPACE::TensorProto::INT64 || tensor_proto->dims_size() >= 2) {
     return false;
   }
-  size_t output_element_count = tensor_proto->dims_size() == 0 ? 1 : tensor_proto->dims()[0];
+  size_t output_element_count = 1;
+  if (tensor_proto->dims_size() > 0) output_element_count = static_cast<size_t>(tensor_proto->dims()[0]);
   if (output_element_count == 0) return false;
   InlinedVector<int64_t> output_values;
   Initializer init_const{*tensor_proto, graph.ModelPath()};
@@ -109,8 +110,8 @@ static bool ConstantFoldGatherNode(Graph& graph, Node& node) {
   for (size_t i = 0; i < output_element_count; ++i) {
     int64_t index = indices_data[i];
     if (index < 0) index += sliced_rank;
-    if (index < 0 || index >= sliced_rank || dim_values[index + start] == -1) return false;
-    output_values.push_back(dim_values[index + start]);
+    if (index < 0 || index >= sliced_rank || dim_values[static_cast<size_t>(index + start)] == -1) return false;
+    output_values.push_back(dim_values[static_cast<size_t>(index + start)]);
   }
 
   ONNX_NAMESPACE::TensorProto gather_output_constant;

--- a/onnxruntime/core/optimizer/constant_folding.cc
+++ b/onnxruntime/core/optimizer/constant_folding.cc
@@ -82,6 +82,8 @@ static bool ConstantFoldShapeNode(Graph& graph, Node& node) {
 }
 
 // Handle Gather from a Shape node, and the indices are all selecting dimensions which have concrete values.
+// This is a pattern from some transformer models, when folding these nodes, the concrete value can be fused further to
+// MatMul nodes as alpha, which will save one Mul/Div node and Memcpy node between device and host.
 static bool ConstantFoldGatherNode(Graph& graph, Node& node) {
   if (node.GetInputEdgesCount() == 0) return false;
   Node& pre_node = *graph.GetNode(node.InputNodesBegin()->Index());
@@ -115,11 +117,14 @@ static bool ConstantFoldGatherNode(Graph& graph, Node& node) {
   auto* gather_output_arg = node.MutableOutputDefs()[0];
   gather_output_constant.set_name(gather_output_arg->Name());
   gather_output_constant.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_INT64);
-  if (tensor_proto->dims_size() == 1) gather_output_constant.add_dims(static_cast<int64_t>(output_element_count));
+  if (tensor_proto->dims_size() == 1) {
+    gather_output_constant.add_dims(static_cast<int64_t>(output_element_count));
+  }
   gather_output_constant.set_raw_data(output_values.data(), output_element_count * sizeof(int64_t));
   ONNX_NAMESPACE::TensorShapeProto gather_output_shape;
-  if (tensor_proto->dims_size() == 1)
+  if (tensor_proto->dims_size() == 1) {
     gather_output_shape.add_dim()->set_dim_value(static_cast<int64_t>(output_element_count));
+  }
   gather_output_arg->SetShape(gather_output_shape);
   graph.AddInitializedTensor(gather_output_constant);
   return true;
@@ -207,150 +212,155 @@ Status ConstantFolding::ApplyImpl(Graph& graph, bool& modified, int graph_level,
       }
     } else if (node->OpType().compare("Shape") == 0) {
       converted_to_constant = ConstantFoldShapeNode(graph, *node);
-    } else if (node->OpType().compare("Gather") == 0) {
-      converted_to_constant = ConstantFoldGatherNode(graph, *node);
     } else {
-      InitializedTensorSet constant_inputs;
-
-      // Check if constant folding can be applied on this node.
-      const auto can_constant_fold_node = [&](const Node& n, bool skip_inputs_constant_check = false) {
-        return graph_utils::IsSupportedProvider(n, GetCompatibleExecutionProviders()) &&
-               optimizer_utils::IsOperationDeterministic(n.Domain(), n.OpType()) &&
-               // constant folding does not support executing a node that includes subgraphs (control flow operators,
-               // such as If/Loop/Scan, fall into this category). individual nodes in the subgraph will be processed
-               // by the Recurse call above
-               !n.ContainsSubgraph() &&
-               (skip_inputs_constant_check ||
-                graph_utils::AllNodeInputsAreConstant(graph, n, constant_inputs, excluded_initializers_));
-      };
-
-      if (!can_constant_fold_node(*node)) {
-        continue;
+      if (node->OpType().compare("Gather") == 0) {
+        converted_to_constant = ConstantFoldGatherNode(graph, *node);
       }
+      // If Gather is not folded, still need to go over below logic.
+      if (!converted_to_constant) {
+        InitializedTensorSet constant_inputs;
 
-      // if skip_dequantize_linear is true we want to maintain QDQ node units so avoid constant folding
-      // DequantizeLinear unless we can fold the whole QDQ node unit
-      if (skip_dequantize_linear_ && node->OpType() == "DequantizeLinear") {
-        bool can_constant_fold_qdq_node_unit = false;
+        // Check if constant folding can be applied on this node.
+        const auto can_constant_fold_node = [&](const Node& n, bool skip_inputs_constant_check = false) {
+          return graph_utils::IsSupportedProvider(n, GetCompatibleExecutionProviders()) &&
+                 optimizer_utils::IsOperationDeterministic(n.Domain(), n.OpType()) &&
+                 // constant folding does not support executing a node that includes subgraphs (control flow operators,
+                 // such as If/Loop/Scan, fall into this category). individual nodes in the subgraph will be processed
+                 // by the Recurse call above
+                 !n.ContainsSubgraph() &&
+                 (skip_inputs_constant_check ||
+                  graph_utils::AllNodeInputsAreConstant(graph, n, constant_inputs, excluded_initializers_));
+        };
 
-        // Simplest scenario where the whole QDQ node unit of (DQ -> X -> Q) can be constant folded is if:
-        //   - the DQ node does not produce a graph output, and its output is only consumed by X
-        //   - X is a deterministic node with a single input and single output
-        //   - the output from X is not a graph output and is only consumed by a Q node
-        if (optimizer_utils::CheckOutputEdges(graph, *node, 1)) {  // DQ does not produce graph output, single consumer
-          const Node& node_x = *node->OutputNodesBegin();
-          if (node_x.InputDefs().size() == 1 &&
-              node_x.OutputDefs().size() == 1 &&
-              optimizer_utils::CheckOutputEdges(graph, node_x, 1)) {
-            const Node& probably_q = *node_x.OutputNodesBegin();
+        if (!can_constant_fold_node(*node)) {
+          continue;
+        }
 
-            if (probably_q.OpType() == "QuantizeLinear") {
-              // the inputs to these nodes are not const yet, but will be if we constant fold,
-              // so set skip_const_check to simulate that having happened
-              constexpr bool skip_const_check = true;
-              can_constant_fold_qdq_node_unit = can_constant_fold_node(node_x, skip_const_check) &&
-                                                can_constant_fold_node(probably_q, skip_const_check);
+        // if skip_dequantize_linear is true we want to maintain QDQ node units so avoid constant folding
+        // DequantizeLinear unless we can fold the whole QDQ node unit
+        if (skip_dequantize_linear_ && node->OpType() == "DequantizeLinear") {
+          bool can_constant_fold_qdq_node_unit = false;
+
+          // Simplest scenario where the whole QDQ node unit of (DQ -> X -> Q) can be constant folded is if:
+          //   - the DQ node does not produce a graph output, and its output is only consumed by X
+          //   - X is a deterministic node with a single input and single output
+          //   - the output from X is not a graph output and is only consumed by a Q node
+          if (optimizer_utils::CheckOutputEdges(graph, *node,
+                                                1)) {  // DQ does not produce graph output, single consumer
+            const Node& node_x = *node->OutputNodesBegin();
+            if (node_x.InputDefs().size() == 1 && node_x.OutputDefs().size() == 1 &&
+                optimizer_utils::CheckOutputEdges(graph, node_x, 1)) {
+              const Node& probably_q = *node_x.OutputNodesBegin();
+
+              if (probably_q.OpType() == "QuantizeLinear") {
+                // the inputs to these nodes are not const yet, but will be if we constant fold,
+                // so set skip_const_check to simulate that having happened
+                constexpr bool skip_const_check = true;
+                can_constant_fold_qdq_node_unit = can_constant_fold_node(node_x, skip_const_check) &&
+                                                  can_constant_fold_node(probably_q, skip_const_check);
+              }
             }
+          }
+
+          if (!can_constant_fold_qdq_node_unit) {
+            continue;
           }
         }
 
-        if (!can_constant_fold_qdq_node_unit) {
-          continue;
-        }
-      }
-
 #if !defined(DISABLE_SPARSE_TENSORS)
-      // Create execution frame for executing constant nodes.
-      OptimizerExecutionFrame::Info info({node}, constant_inputs, graph.ModelPath(), execution_provider_,
-                                         is_sparse_initializer_check);
+        // Create execution frame for executing constant nodes.
+        OptimizerExecutionFrame::Info info({node}, constant_inputs, graph.ModelPath(), execution_provider_,
+                                           is_sparse_initializer_check);
 #else
-      // Create execution frame for executing constant nodes.
-      OptimizerExecutionFrame::Info info({node}, constant_inputs, graph.ModelPath(), execution_provider_,
-                                         [](std::string const&) { return false; });
+        // Create execution frame for executing constant nodes.
+        OptimizerExecutionFrame::Info info({node}, constant_inputs, graph.ModelPath(), execution_provider_,
+                                           [](std::string const&) { return false; });
 #endif
 
-      std::vector<int> fetch_mlvalue_idxs;
-      for (const auto* node_out : node->OutputDefs()) {
-        fetch_mlvalue_idxs.push_back(info.GetMLValueIndex(node_out->Name()));
-      }
+        std::vector<int> fetch_mlvalue_idxs;
+        for (const auto* node_out : node->OutputDefs()) {
+          fetch_mlvalue_idxs.push_back(info.GetMLValueIndex(node_out->Name()));
+        }
 
-      const bool node_on_cpu_ep = node->GetExecutionProviderType() == kCpuExecutionProvider;
+        const bool node_on_cpu_ep = node->GetExecutionProviderType() == kCpuExecutionProvider;
 
-      std::unique_ptr<const OpKernel> kernel;
+        std::unique_ptr<const OpKernel> kernel;
 
-      if (!node_on_cpu_ep) {
-        // We need to copy the string here instead of taking a reference to it since node->SetExecutionProviderType
-        // will change the value of the reference
-        auto ep_type = node->GetExecutionProviderType();
+        if (!node_on_cpu_ep) {
+          // We need to copy the string here instead of taking a reference to it since node->SetExecutionProviderType
+          // will change the value of the reference
+          auto ep_type = node->GetExecutionProviderType();
 
-        // override the EP assigned to the node so that it will use the CPU kernel for Compute.
-        node->SetExecutionProviderType(kCpuExecutionProvider);
+          // override the EP assigned to the node so that it will use the CPU kernel for Compute.
+          node->SetExecutionProviderType(kCpuExecutionProvider);
 
-        kernel = info.CreateKernel(node, config_options_);
+          kernel = info.CreateKernel(node, config_options_);
 
-        // undo the EP change to the value that was assigned at graph partitioning time
-        node->SetExecutionProviderType(ep_type);
-      } else {
-        kernel = info.CreateKernel(node, config_options_);
-      }
+          // undo the EP change to the value that was assigned at graph partitioning time
+          node->SetExecutionProviderType(ep_type);
+        } else {
+          kernel = info.CreateKernel(node, config_options_);
+        }
 
-      // We currently constant fold using the CPU EP only.
-      // If we can't find a CPU kernel for this node, then we can't proceed with constant folding.
-      //
-      // TODO(adrianlizarraga): Support constant folding with other execution providers. For example, we may be able
-      // to use a CUDA kernel to constant fold operators with data types not supported by the CPU EP kernel.
-      if (kernel == nullptr) {
-        LOGS(logger, WARNING) << "Could not find a CPU kernel and hence "
-                              << "can't constant fold " << node->OpType() << " node '" << node->Name() << "'";
+        // We currently constant fold using the CPU EP only.
+        // If we can't find a CPU kernel for this node, then we can't proceed with constant folding.
+        //
+        // TODO(adrianlizarraga): Support constant folding with other execution providers. For example, we may be able
+        // to use a CUDA kernel to constant fold operators with data types not supported by the CPU EP kernel.
+        if (kernel == nullptr) {
+          LOGS(logger, WARNING) << "Could not find a CPU kernel and hence "
+                                << "can't constant fold " << node->OpType() << " node '" << node->Name() << "'";
 
-        // Move on to the next candidate node
-        continue;
-      }
+          // Move on to the next candidate node
+          continue;
+        }
 
-      OptimizerExecutionFrame frame(info, fetch_mlvalue_idxs);
+        OptimizerExecutionFrame frame(info, fetch_mlvalue_idxs);
 #ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable : 6387)
 #endif
-      OpKernelContext op_kernel_context(&frame, kernel.get(), /*stream*/ nullptr, nullptr, logger);
-      ORT_RETURN_IF_ERROR(kernel->Compute(&op_kernel_context));
+        OpKernelContext op_kernel_context(&frame, kernel.get(), /*stream*/ nullptr, nullptr, logger);
+        ORT_RETURN_IF_ERROR(kernel->Compute(&op_kernel_context));
 #ifdef _WIN32
 #pragma warning(pop)
 #endif
 
-      std::vector<OrtValue> fetches;
-      ORT_RETURN_IF_ERROR(frame.GetOutputs(fetches));
+        std::vector<OrtValue> fetches;
+        ORT_RETURN_IF_ERROR(frame.GetOutputs(fetches));
 
-      // Go over all output node args and substitute them with the newly computed tensors, which will be
-      // added to the graph as initializers.
-      ORT_ENFORCE(fetches.size() == node->OutputDefs().size());
-      converted_to_constant = true;
-      for (size_t fetch_idx = 0; fetch_idx < fetches.size(); ++fetch_idx) {
-        const auto& constant_arg_out = *node->OutputDefs()[fetch_idx];
-        // XXX: Add support for SparseTensors outputs when we have sparse outputs
-        if (!utils::HasTensorType(*constant_arg_out.TypeAsProto())) {
-          LOGS(logger, INFO) << "Unsupported output type of " << constant_arg_out.Type()
-                             << ". Can't constant fold " << node->OpType() << " node '" << node->Name() << "'";
-          converted_to_constant = false;
-          break;
-        }
-      }
-
-      if (converted_to_constant) {
+        // Go over all output node args and substitute them with the newly computed tensors, which will be
+        // added to the graph as initializers.
+        ORT_ENFORCE(fetches.size() == node->OutputDefs().size());
+        converted_to_constant = true;
         for (size_t fetch_idx = 0; fetch_idx < fetches.size(); ++fetch_idx) {
-          OrtValue& ort_value = fetches[fetch_idx];
-          // Build the TensorProto that corresponds to the computed OrtValue and add it as initializer to the graph.
-          auto* constant_arg_out = node->MutableOutputDefs()[fetch_idx];
-          const Tensor& out_tensor = ort_value.Get<Tensor>();
-          ONNX_NAMESPACE::TensorProto out_tensorproto = utils::TensorToTensorProto(out_tensor, constant_arg_out->Name());
-
-          ONNX_NAMESPACE::TensorShapeProto result_shape;
-          for (auto& dim : out_tensor.Shape().GetDims()) {
-            result_shape.add_dim()->set_dim_value(dim);
+          const auto& constant_arg_out = *node->OutputDefs()[fetch_idx];
+          // XXX: Add support for SparseTensors outputs when we have sparse outputs
+          if (!utils::HasTensorType(*constant_arg_out.TypeAsProto())) {
+            LOGS(logger, INFO) << "Unsupported output type of " << constant_arg_out.Type() << ". Can't constant fold "
+                               << node->OpType() << " node '" << node->Name() << "'";
+            converted_to_constant = false;
+            break;
           }
+        }
 
-          constant_arg_out->SetShape(result_shape);
-          graph.AddInitializedTensor(out_tensorproto);
+        if (converted_to_constant) {
+          for (size_t fetch_idx = 0; fetch_idx < fetches.size(); ++fetch_idx) {
+            OrtValue& ort_value = fetches[fetch_idx];
+            // Build the TensorProto that corresponds to the computed OrtValue and add it as initializer to the graph.
+            auto* constant_arg_out = node->MutableOutputDefs()[fetch_idx];
+            const Tensor& out_tensor = ort_value.Get<Tensor>();
+            ONNX_NAMESPACE::TensorProto out_tensorproto =
+                utils::TensorToTensorProto(out_tensor, constant_arg_out->Name());
+
+            ONNX_NAMESPACE::TensorShapeProto result_shape;
+            for (auto& dim : out_tensor.Shape().GetDims()) {
+              result_shape.add_dim()->set_dim_value(dim);
+            }
+
+            constant_arg_out->SetShape(result_shape);
+            graph.AddInitializedTensor(out_tensorproto);
+          }
         }
       }
     }

--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -213,9 +213,8 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
       }
 
       // Put ConstantSharing and ShapeInputMerge before CommonSubexpressionElimination by intention as it can create
-      // more opportunities for CSE. For example, if A and B nodes both do Add operation with a same value but different
-      // initializers, by default, CSE will not merge them, because the different initializers are represented by
-      // different NodeArg.
+      // more opportunities for CSE. For example, if A and B nodes consume same different args but produce same output
+      // or consume different initializers with same value, by default, CSE will not merge them.
       InlinedHashSet<std::string> excluded_initializers;
       excluded_initializers.reserve(session_options.initializers_to_share_map.size());
       for (const auto& p : session_options.initializers_to_share_map) {

--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -69,6 +69,7 @@
 #include "core/optimizer/reshape_fusion.h"
 #include "core/optimizer/rocm_blas_alt_impl.h"
 #include "core/optimizer/rule_based_graph_transformer.h"
+#include "core/optimizer/shape_input_merge.h"
 #include "core/optimizer/skip_layer_norm_fusion.h"
 #include "core/optimizer/slice_elimination.h"
 #include "core/optimizer/transpose_optimizer.h"
@@ -211,9 +212,10 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
         transformers.emplace_back(std::make_unique<DoubleQDQPairsRemover>());
       }
 
-      // Put ConstantSharing before CommonSubexpressionElimination by intention as it can create more opportunities for
-      // CSE. For example, if A and B nodes both do Add operation with a same value but different initializers, by
-      // default, CSE will not merge them, because the different initializers are represented by different NodeArg.
+      // Put ConstantSharing and ShapeInputMerge before CommonSubexpressionElimination by intention as it can create
+      // more opportunities for CSE. For example, if A and B nodes both do Add operation with a same value but different
+      // initializers, by default, CSE will not merge them, because the different initializers are represented by
+      // different NodeArg.
       InlinedHashSet<std::string> excluded_initializers;
       excluded_initializers.reserve(session_options.initializers_to_share_map.size());
       for (const auto& p : session_options.initializers_to_share_map) {
@@ -221,7 +223,7 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
       }
       const InlinedHashSet<std::string_view> no_limit_empty_ep_list = {};
       transformers.emplace_back(std::make_unique<ConstantSharing>(no_limit_empty_ep_list, excluded_initializers));
-
+      transformers.emplace_back(std::make_unique<ShapeInputMerge>());
       transformers.emplace_back(std::make_unique<CommonSubexpressionElimination>());
       transformers.emplace_back(std::make_unique<ConstantFolding>(cpu_execution_provider, !disable_quant_qdq,
                                                                   session_options.config_options));

--- a/onnxruntime/core/optimizer/shape_input_merge.cc
+++ b/onnxruntime/core/optimizer/shape_input_merge.cc
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/optimizer/shape_input_merge.h"
+
+#include "core/graph/graph_utils.h"
+
+namespace onnxruntime {
+
+namespace {
+std::string GetShapeString(const NodeArg* input_arg) {
+  auto shape = input_arg->Shape();
+  if (!shape) return "";
+  std::string shape_str = "[";
+  for (int i = 0; i < shape->dim_size(); ++i) {
+    if (i != 0) shape_str += ",";
+    auto dim = shape->dim(i);
+    if (dim.has_dim_value()) {
+      shape_str += std::to_string(dim.dim_value());
+    } else {
+      shape_str += ("'" + dim.dim_param() + "'");
+    }
+  }
+  shape_str += "]";
+  return shape_str;
+}
+}  // namespace
+
+Status ShapeInputMerge::ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const {
+  GraphViewer graph_viewer(graph);
+  const auto& node_topology_list = graph_viewer.GetNodesInTopologicalOrder();
+  InlinedHashMap<std::string, InlinedVector<Node*>> input_hash_to_nodes;
+  for (auto node_index : node_topology_list) {
+    auto* p_node = graph.GetNode(node_index);
+    if (!p_node) continue;  // we removed the node as part of an earlier fusion
+    ORT_RETURN_IF_ERROR(Recurse(*p_node, modified, graph_level, logger));
+    if (!graph_utils::IsSupportedOptypeVersionAndDomain(*p_node, "Shape", {1, 13, 15, 19, 21}) ||
+        !graph_utils::IsSupportedProvider(*p_node, GetCompatibleExecutionProviders())) {
+      continue;
+    }
+    std::string shape_str = GetShapeString(p_node->InputDefs()[0]);
+    if (shape_str.empty()) continue;
+    if (input_hash_to_nodes.find(shape_str) == input_hash_to_nodes.end()) {
+      input_hash_to_nodes[shape_str] = InlinedVector<Node*>();
+    }
+    input_hash_to_nodes[shape_str].emplace_back(p_node);
+  }
+
+  for (auto& kv : input_hash_to_nodes) {
+    if (kv.second.size() < 2) continue;
+    NodeArg* first_input_arg = kv.second[0]->MutableInputDefs()[0];
+    bool is_first_input_arg_graph_input = graph.IsInputsIncludingInitializers(first_input_arg);
+    for (size_t i = 1; i < kv.second.size(); ++i) {
+      Node* p_node = kv.second[i];
+      const NodeArg* input_arg = p_node->InputDefs()[0];
+      if (p_node->InputDefs()[0]->Name() == first_input_arg->Name()) continue;
+      if (!graph.IsInputsIncludingInitializers(input_arg)) {
+        const Node::EdgeEnd& input_edge = *p_node->InputEdgesBegin();
+        graph.RemoveEdge(input_edge.GetNode().Index(), p_node->Index(), input_edge.GetSrcArgIndex(), 0);
+      }
+      if (is_first_input_arg_graph_input) {
+        graph_utils::ReplaceNodeInput(*p_node, 0, *first_input_arg);
+      } else {
+        const Node::EdgeEnd& first_input_edge = *kv.second[0]->InputEdgesBegin();
+        graph.AddEdge(first_input_edge.GetNode().Index(), p_node->Index(), first_input_edge.GetSrcArgIndex(), 0);
+      }
+      modified = true;
+    }
+  }
+
+  return Status::OK();
+}
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/shape_input_merge.cc
+++ b/onnxruntime/core/optimizer/shape_input_merge.cc
@@ -11,21 +11,23 @@ namespace {
 std::string GetShapeString(const NodeArg* input_arg) {
   auto shape = input_arg->Shape();
   if (!shape) return "";
-  std::string shape_str = "[";
+  std::stringstream ss;
+  ss << "[";
   for (int i = 0; i < shape->dim_size(); ++i) {
-    if (i != 0) shape_str += ",";
+    if (i != 0) ss << ",";
     auto dim = shape->dim(i);
     if (dim.has_dim_value()) {
-      shape_str += std::to_string(dim.dim_value());
+      ss << std::to_string(dim.dim_value());
     } else if (dim.has_dim_param()) {
-      shape_str += ("'" + dim.dim_param() + "'");
+      ss << "'" << dim.dim_param() << "'";
     } else {
       return "";
     }
   }
-  shape_str += "]";
-  return shape_str;
+  ss << "]";
+  return ss.str();
 }
+
 }  // namespace
 
 Status ShapeInputMerge::ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const {

--- a/onnxruntime/core/optimizer/shape_input_merge.h
+++ b/onnxruntime/core/optimizer/shape_input_merge.h
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/optimizer/graph_transformer.h"
+
+namespace onnxruntime {
+
+/**
+@Class ShapeInputMerge
+Merge all shape inputs having same shape value to a single shape input.
+*/
+class ShapeInputMerge : public GraphTransformer {
+ public:
+  ShapeInputMerge(const InlinedHashSet<std::string_view>& compatible_execution_providers = {}) noexcept
+      : GraphTransformer("ShapeInputMerge", compatible_execution_providers) {}
+
+  Status ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const override;
+};
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/shape_input_merge.h
+++ b/onnxruntime/core/optimizer/shape_input_merge.h
@@ -10,6 +10,7 @@ namespace onnxruntime {
 /**
 @Class ShapeInputMerge
 Merge all shape inputs having same shape value to a single shape input.
+This change will not affect the performance, but it open chances for CSE fusion to merge nodes.
 */
 class ShapeInputMerge : public GraphTransformer {
  public:

--- a/onnxruntime/core/optimizer/utils.cc
+++ b/onnxruntime/core/optimizer/utils.cc
@@ -272,7 +272,7 @@ int32_t IndexOfNodeOutput(const Node& node, const NodeArg& node_arg) {
 // We could also allow other known domains (kMSDomain, kMSNchwcDomain, kMSFeaturizersDomain),
 // as long as we verify which of their operations are non-deterministic and add them in the map below.
 constexpr std::array kOnnxDomainNonDeterministicOps{"RandomUniform", "RandomNormal", "RandomUniformLike",
-                                                    "RandomNormalLike", "Multinomial"};
+                                                    "RandomNormalLike", "Multinomial", "Dropout"};
 
 // List of deterministic MS domain operators. Currently used for constant folding and common subexpression elimination.
 //
@@ -280,7 +280,8 @@ constexpr std::array kOnnxDomainNonDeterministicOps{"RandomUniform", "RandomNorm
 // with the above ONNX list. With the current approach, only MS domain Q/DQ operators
 // (plus ShrunkenGather for training) are considered deterministic.
 #ifdef ENABLE_TRAINING_OPS
-constexpr std::array kMSDomainDeterministicOps{"ShrunkenGather", "QuantizeLinear", "DequantizeLinear"};
+constexpr std::array kMSDomainDeterministicOps{"ShrunkenGather", "QuantizeLinear", "DequantizeLinear",
+                                               "ConcatTraining"};
 #else
 constexpr std::array kMSDomainDeterministicOps{"QuantizeLinear", "DequantizeLinear"};
 #endif

--- a/orttraining/orttraining/core/optimizer/graph_transformer_utils.cc
+++ b/orttraining/orttraining/core/optimizer/graph_transformer_utils.cc
@@ -117,9 +117,8 @@ std::vector<std::unique_ptr<GraphTransformer>> GeneratePreTrainingTransformers(
 #endif
 
       // Put ConstantSharing and ShapeInputMerge before CommonSubexpressionElimination by intention as it can create
-      // more opportunities for CSE. For example, if A and B nodes both do Add operation with a same value but different
-      // initializers, by default, CSE will not merge them, because the different initializers are represented by
-      // different NodeArg.
+      // more opportunities for CSE. For example, if A and B nodes consume same different args but produce same output
+      // or consume different initializers with same value, by default, CSE will not merge them.
       transformers.emplace_back(std::make_unique<ConstantSharing>(compatible_eps));
       transformers.emplace_back(std::make_unique<ShapeInputMerge>(compatible_eps));
       // LayerNormFusion must be applied before CommonSubexpressionElimination as the latter will break the pattern when 2 LayerNormFusion share the same input.

--- a/orttraining/orttraining/core/optimizer/graph_transformer_utils.cc
+++ b/orttraining/orttraining/core/optimizer/graph_transformer_utils.cc
@@ -44,6 +44,7 @@
 #include "core/optimizer/relu_clip_fusion.h"
 #include "core/optimizer/reshape_fusion.h"
 #include "core/optimizer/rule_based_graph_transformer.h"
+#include "core/optimizer/shape_input_merge.h"
 #include "core/optimizer/skip_layer_norm_fusion.h"
 #include "core/optimizer/slice_elimination.h"
 #include "core/optimizer/unsqueeze_elimination.h"
@@ -115,10 +116,12 @@ std::vector<std::unique_ptr<GraphTransformer>> GeneratePreTrainingTransformers(
       ORT_THROW_IF_ERROR(rule_transformer->Register(std::make_unique<PythonOpRewriter>()));
 #endif
 
-      // Put ConstantSharing before CommonSubexpressionElimination by intention as it can create more opportunities for
-      // CSE. For example, if A and B nodes both do Add operation with a same value but different initializers, by
-      // default, CSE will not merge them, because the different initializers are represented by different NodeArg.
+      // Put ConstantSharing and ShapeInputMerge before CommonSubexpressionElimination by intention as it can create
+      // more opportunities for CSE. For example, if A and B nodes both do Add operation with a same value but different
+      // initializers, by default, CSE will not merge them, because the different initializers are represented by
+      // different NodeArg.
       transformers.emplace_back(std::make_unique<ConstantSharing>(compatible_eps));
+      transformers.emplace_back(std::make_unique<ShapeInputMerge>(compatible_eps));
       // LayerNormFusion must be applied before CommonSubexpressionElimination as the latter will break the pattern when 2 LayerNormFusion share the same input.
       transformers.emplace_back(std::make_unique<LayerNormFusion>(compatible_eps));
       // Remove duplicate nodes. Must be applied before any recompute transformations.


### PR DESCRIPTION
This PR adds below shape related fusions, which is helpful for some transformer models:
- ShapeInputMerge is to merge all Shape nodes' input NodeArg to a single one (the 1st one on topo order) if they have the same shape value. This helps CSE fusion to merge more nodes.
- CSE fusion to support scalar tensor as attribute value. This is mainly to support ConstantOfShape node.
