### PR TITLE
Make embed sparsity optimizer work with skipped layer norm fusion

### DIFF
--- a/include/onnxruntime/core/optimizer/graph_transformer_utils.h
+++ b/include/onnxruntime/core/optimizer/graph_transformer_utils.h
@@ -35,7 +35,7 @@ InlinedVector<std::unique_ptr<RewriteRule>> GenerateRewriteRules(
     const InlinedHashSet<std::string>& rules_to_disable = {});
 
 /** Given a TransformerLevel, this method generates a name for the rule-based graph transformer of that level. */
-std::string GenerateRuleBasedTransformerName(TransformerLevel level);
+std::string GenerateRuleBasedTransformerName(TransformerLevel level, const std::string& prefix = "");
 
 /** Generates all rule-based transformers for this level. */
 std::unique_ptr<RuleBasedGraphTransformer> GenerateRuleBasedGraphTransformer(

--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -103,8 +103,8 @@ static void FilterTransformers(InlinedVector<std::unique_ptr<GraphTransformer>>&
 
 #if !defined(ORT_MINIMAL_BUILD)
 
-std::string GenerateRuleBasedTransformerName(TransformerLevel level) {
-  return "Level" + std::to_string(static_cast<uint32_t>(level)) + "_RuleBasedTransformer";
+std::string GenerateRuleBasedTransformerName(TransformerLevel level, const std::string& prefix) {
+  return "Level" + std::to_string(static_cast<uint32_t>(level)) + "_" + prefix + "RuleBasedTransformer";
 }
 
 InlinedVector<std::unique_ptr<RewriteRule>> GenerateRewriteRules(

--- a/orttraining/orttraining/core/optimizer/memory_optimizer/recompute_analysis.cc
+++ b/orttraining/orttraining/core/optimizer/memory_optimizer/recompute_analysis.cc
@@ -206,6 +206,12 @@ const InlinedHashMap<std::string, OpsetToIgnorableIndicesMap>& GetAllowedRecompu
             },
         },
         {
+            utils::GetFullQualifiedOpName("FlattenAndUnpad", kMSDomain),
+            {
+                {1, {1}},  // ignore the indices
+            },
+        },
+        {
             utils::GetFullQualifiedOpName("Gather", kOnnxDomain),
             {
                 {1, {1}},  // ignore the indices
@@ -242,6 +248,12 @@ const InlinedHashMap<std::string, OpsetToIgnorableIndicesMap>& GetAllowedRecompu
                 {7, {}},
                 {13, {}},
                 {14, {}},
+            },
+        },
+        {
+            utils::GetFullQualifiedOpName("PadAndUnflatten", kMSDomain),
+            {
+                {1, {1, 2}},  // ignore the indices and unflatten_dims
             },
         },
         {


### PR DESCRIPTION
### Make embed sparsity optimizer work with skipped layer norm fusion

Without enabling padding elimination optimization:
1. In the first level-1 pass, skipped layer norm fail to fuse this graph into skippedlayernborm node:

![image](https://github.com/microsoft/onnxruntime/assets/10530022/c262aff4-4f8f-49ac-bf5a-39d69a327eb6)

The check https://github.com/microsoft/onnxruntime/blob/6579f74af0c160f2d6090fbf12d1366a2cc305ef/onnxruntime/core/optimizer/layer_norm_fusion.cc#L602 failed, because Div's input is not same with Pow's input. 

2. Then `DivMulFusion`, modify the graph, making the Div and Pow share the same input. 
3. In the second level-1 pass, the fusion succeed.

With enabling padding elimination optimization, the bug repros with following flow:
1. In the first pass, skipped layer norm fail to fuse this graph into skippedlayernborm node. (Same with above 1)

2. Then, PaddingElimination optimizer applies, so it insert `PadAndUnflatten` and `FlattenAndUnpad` for the selected subgraph. 

![image](https://github.com/microsoft/onnxruntime/assets/10530022/991f3e09-4331-4cdf-afc7-ab8428569ba2)

4. Then the second pass or later, the layer norm subgraph pattern did not match any more, so it will not be fused. 


The Fix:

Move DivMulFusion to run before PaddingElimination, by separating rule based optimizers into 1). primitive graph optimizers in a begginning of the finalized transformer list, 2). coarse-grained optimizers in the end of the finalized transformer list. 

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


