### PR TITLE
Set seed for DynamicQuantizeMatMul tests

### DIFF
--- a/onnxruntime/test/contrib_ops/dynamic_quantize_matmul_test.cc
+++ b/onnxruntime/test/contrib_ops/dynamic_quantize_matmul_test.cc
@@ -89,7 +89,7 @@ void TestDynamicQuantizeMatMul(bool is_matrix_b_constant,
                                bool has_bias = false,
                                bool empty_input = false) {
   // create rand inputs
-  RandomValueGenerator random{};
+  RandomValueGenerator random{1668426375};
 
   int64_t M = empty_input ? 1 : 4;
   int64_t N = 128;


### PR DESCRIPTION
### Description
Fix seed for DynamicQuantizeMatMul tests to avoid pipeline failures with marginal mismatches. 



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


