### PR TITLE
[ROCm] fix build failure when nccl is enabled

### DIFF
--- a/cmake/onnxruntime_rocm_hipify.cmake
+++ b/cmake/onnxruntime_rocm_hipify.cmake
@@ -114,6 +114,10 @@ if (NOT onnxruntime_USE_NCCL)
   list(APPEND contrib_ops_excluded_files "collective/distributed_reduce.cc")
   list(APPEND contrib_ops_excluded_files "collective/distributed_unsqueeze.cc")
   list(APPEND contrib_ops_excluded_files "collective/distributed_squeeze.cc")
+else()
+  # moe not supported for ROCm EP
+  list(APPEND contrib_ops_excluded_files "collective/sharded_moe.h")
+  list(APPEND contrib_ops_excluded_files "collective/sharded_moe.cc")
 endif()
 
 set(provider_excluded_files


### PR DESCRIPTION
### Description
Building onnxruntime ROCm EP with --enable_nccl --use_mpi fails due to inclusion of MOE source files but MOE is not supported.  The error observed is

`error: contrib_ops/rocm/moe/ft_moe/moe_kernel.h: No such file or directory`

The fix is to exclude collective/sharded_moe.* files when nccl is requested.

CC @tianleiwu 