### PR TITLE
Change nuget pipeline's "Final_Jar_Testing_Windows_GPU" job to download TRT binaries in every build

### DIFF
--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -394,12 +394,11 @@ stages:
     steps:
     - template: templates/set-version-number-variables-step.yml
 
-    - task: BatchScript@1
-      displayName: 'setup env'
-      inputs:
-        filename: '$(Build.SourcesDirectory)\tools\ci_build\github\windows\setup_env_cuda.bat'
-        modifyEnvironment: true
-        workingFolder: '$(Build.BinariesDirectory)'
+    - template: jobs/download_win_gpu_library.yml
+      parameters:
+        CudaVersion: ${{ parameters.CudaVersion }}
+        DownloadCUDA: true
+        DownloadTRT: true
 
     - template: templates\flex-downloadPipelineArtifact.yml
       parameters:

--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -394,7 +394,7 @@ stages:
     steps:
     - template: templates/set-version-number-variables-step.yml
 
-    - template: jobs/download_win_gpu_library.yml
+    - template: templates/jobs/download_win_gpu_library.yml
       parameters:
         CudaVersion: ${{ parameters.CudaVersion }}
         DownloadCUDA: true


### PR DESCRIPTION
### Description
Change nuget pipeline's "Final_Jar_Testing_Windows_GPU" job to download TRT binaries in every build.  Now all the other build jobs are already doing this. This is the only one left. 


### Motivation and Context

As a follow up of #19118

