### PR TITLE
[js] Make error friendly when isOrtFormat is undefined

### DIFF
--- a/js/node/test/unittests/lib/inference-session.ts
+++ b/js/node/test/unittests/lib/inference-session.ts
@@ -68,6 +68,11 @@ describe('UnitTests - InferenceSession.create()', () => {
       await InferenceSession.create(new Uint8Array(0));
     }, {name: 'Error', message: /No graph was found in the protobuf/});
   });
+  it('EXPECTED FAILURE - invalid buffer', async () => {
+    await assert.rejects(async () => {
+      await InferenceSession.create(new Uint8Array(Array.from({length: 100}, () => 42)));
+    }, {name: 'Error', message: /as ONNX.+as ORT/m});
+  });
   // #endregion
 
   it('metadata: inputNames', async () => {

--- a/js/node/test/unittests/lib/inference-session.ts
+++ b/js/node/test/unittests/lib/inference-session.ts
@@ -68,11 +68,6 @@ describe('UnitTests - InferenceSession.create()', () => {
       await InferenceSession.create(new Uint8Array(0));
     }, {name: 'Error', message: /No graph was found in the protobuf/});
   });
-  it('EXPECTED FAILURE - invalid buffer', async () => {
-    await assert.rejects(async () => {
-      await InferenceSession.create(new Uint8Array(Array.from({length: 100}, () => 42)));
-    }, {name: 'Error', message: /as ONNX.+as ORT/m});
-  });
   // #endregion
 
   it('metadata: inputNames', async () => {

--- a/js/web/lib/onnxjs/model.ts
+++ b/js/web/lib/onnxjs/model.ts
@@ -32,7 +32,6 @@ export class Model {
 
     try {
       this.loadFromOrtFormat(buf, graphInitializer);
-      return;
     } catch (e) {
       if (isOrtFormat !== undefined) {
         throw e;

--- a/js/web/lib/onnxjs/model.ts
+++ b/js/web/lib/onnxjs/model.ts
@@ -16,6 +16,7 @@ export class Model {
   constructor() {}
 
   load(buf: Uint8Array, graphInitializer?: Graph.Initializer, isOrtFormat?: boolean): void {
+    let onnxError: Error|undefined;
     if (!isOrtFormat) {
       // isOrtFormat === false || isOrtFormat === undefined
       try {
@@ -25,10 +26,20 @@ export class Model {
         if (isOrtFormat !== undefined) {
           throw e;
         }
+        onnxError = e;
       }
     }
 
-    this.loadFromOrtFormat(buf, graphInitializer);
+    try {
+      this.loadFromOrtFormat(buf, graphInitializer);
+      return;
+    } catch (e) {
+      if (isOrtFormat !== undefined) {
+        throw e;
+      }
+      // Tried both formats and failed (when isOrtFormat === undefined)
+      throw new Error(`Failed to load model as ONNX format: ${onnxError}\nas ORT format: ${e}`);
+    }
   }
 
   private loadFromOnnxFormat(buf: Uint8Array, graphInitializer?: Graph.Initializer): void {

--- a/js/web/test/e2e/browser-test-webgl.js
+++ b/js/web/test/e2e/browser-test-webgl.js
@@ -6,3 +6,18 @@
 it('Browser E2E testing - WebGL backend', async function() {
   await testFunction(ort, {executionProviders: ['webgl']});
 });
+
+it('Browser E2E testing - invalid buffer', async () => {
+  try {
+    await ort.InferenceSession.create(
+      new Uint8Array(Array.from({length: 100}, () => 42)),
+      {executionProviders: ['webgl']}
+    );
+
+    // Should not reach here.
+    assert(false);
+  } catch (e) {
+    assert(e.message.includes("as ONNX format"));
+    assert(e.message.includes("as ORT format"));
+  }
+});

--- a/js/web/test/e2e/browser-test-webgl.js
+++ b/js/web/test/e2e/browser-test-webgl.js
@@ -10,14 +10,12 @@ it('Browser E2E testing - WebGL backend', async function() {
 it('Browser E2E testing - invalid buffer', async () => {
   try {
     await ort.InferenceSession.create(
-      new Uint8Array(Array.from({length: 100}, () => 42)),
-      {executionProviders: ['webgl']}
-    );
+        new Uint8Array(Array.from({length: 100}, () => 42)), {executionProviders: ['webgl']});
 
     // Should not reach here.
     assert(false);
   } catch (e) {
-    assert(e.message.includes("as ONNX format"));
-    assert(e.message.includes("as ORT format"));
+    assert(e.message.includes('as ONNX format'));
+    assert(e.message.includes('as ORT format'));
   }
 });


### PR DESCRIPTION
### Description
Make error friendly when isOrtFormat is undefined (`onnxruntime.InferenceSession.create` is called with ArrayBuffer or Uint8Array).

### Motivation and Context
I was trying to run my onnx model in WebGL EP, but it gave me the error "Cannot read properties of null (reading 'irVersion')".
I used debugger to find that actual error is `int64 is not supported`, but the error was invisible for me.
So I made it to show both error when isOrtFormat is undefined.
<s>I haven't written unit test yet, so I'm making it draft. (I have no idea about how do I test this though...)</s> [d62d942](https://github.com/microsoft/onnxruntime/pull/19958/commits/d62d9425ba7b9e5ff0d0a2ae6998dd53817d5db9)