### PR TITLE
Recognize NaN operands in Min and Max ops

### DIFF
--- a/onnxruntime/core/providers/cuda/cu_inc/common.cuh
+++ b/onnxruntime/core/providers/cuda/cu_inc/common.cuh
@@ -344,12 +344,6 @@ __device__ __inline__ double _Pow(double a, double b) { return pow(a, b); }
 template <>
 __device__ __inline__ half _Pow(half a, half b) { return half(powf((float)a, (float)b)); }
 
-#define ISNAN_HALF(v__) static_cast<uint16_t>(*reinterpret_cast<const uint16_t*>(&v__) & ~MLFloat16::kSignMask) \
-                        > MLFloat16::kPositiveInfinityBits
-
-#define ISNAN_BFLOAT16(v__) static_cast<uint16_t>(*reinterpret_cast<const uint16_t*>(&v__) & ~BFloat16::kSignMask) \
-                        > BFloat16::kPositiveInfinityBits
-
 template <typename T>
 __device__ __inline__ T _Min(T a, T b) { return a < b ? a : b; }
 
@@ -361,16 +355,6 @@ __device__ __inline__ float _Min(float a, float b) {
 template <>
 __device__ __inline__ double _Min(double a, double b) {
   return (isnan(a) || isnan(b)) ? std::numeric_limits<double>::quiet_NaN() : ( a < b ? a : b );
-}
-
-template <>
-__device__ __inline__ half _Min(half a, half b) {
-  return ISNAN_HALF(a) ? a : ( ISNAN_HALF(b) ? b : ( a < b ? a : b ) );
-}
-
-template <>
-__device__ __inline__ BFloat16 _Min(BFloat16 a, BFloat16 b) {
-  return ISNAN_BFLOAT16(a) ? a : ( ISNAN_BFLOAT16(b) ? b : ( a < b ? a : b ) );
 }
 
 template <typename T>
@@ -385,19 +369,6 @@ template <>
 __device__ __inline__ double _Max(double a, double b) {
   return (isnan(a) || isnan(b)) ? std::numeric_limits<double>::quiet_NaN() : ( a > b ? a : b );
 }
-
-template <>
-__device__ __inline__ half _Max(half a, half b) {
-  return ISNAN_HALF(a) ? a : ( ISNAN_HALF(b) ? b : ( a > b ? a : b ) );
-}
-
-template <>
-__device__ __inline__ BFloat16 _Max(BFloat16 a, BFloat16 b) {
-  return ISNAN_BFLOAT16(a) ? a : ( ISNAN_BFLOAT16(b) ? b : ( a > b ? a : b ) );
-}
-
-#undef ISNAN_HALF
-#undef ISNAN_BFLOAT16
 
 template <typename T>
 __device__ __inline__ T _Abs(T a) { return a > (T)0 ? a : -a; }

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -1546,19 +1546,19 @@ TEST(MathOpTest, Min_12_Double) {
 TEST(MathOpTest, Min_12_Double_Nan) {
   OpTester test("Min", 12);
   test.AddInput<double>("data_2", {3, 3},
-                       {std::numeric_limits<double>::quiet_NaN(),
-                        std::numeric_limits<double>::quiet_NaN(),
-                        std::numeric_limits<double>::quiet_NaN(),
-                        -0.5, 0.0, -2.0,
-                        0.5, 0.0, 2.0});
-  test.AddInput<double>("data_1", {3, 1},
-                       {0.0, -1.0, 1.0});
-  test.AddOutput<double>("min", {3, 3},
                         {std::numeric_limits<double>::quiet_NaN(),
                          std::numeric_limits<double>::quiet_NaN(),
                          std::numeric_limits<double>::quiet_NaN(),
-                         -1.0, -1.0, -2.0,
-                         0.5, 0.0, 1.0});
+                         -0.5, 0.0, -2.0,
+                         0.5, 0.0, 2.0});
+  test.AddInput<double>("data_1", {3, 1},
+                        {0.0, -1.0, 1.0});
+  test.AddOutput<double>("min", {3, 3},
+                         {std::numeric_limits<double>::quiet_NaN(),
+                          std::numeric_limits<double>::quiet_NaN(),
+                          std::numeric_limits<double>::quiet_NaN(),
+                          -1.0, -1.0, -2.0,
+                          0.5, 0.0, 1.0});
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});  // TensorRT: Input batch size is inconsistent
 }
 
@@ -1672,21 +1672,19 @@ TEST(MathOpTest, Min_12_MLFLoat16_Scalar1) {
 TEST(MathOpTest, Min_12_MLFloat16_Nan) {
   OpTester test("Min", 12);
   test.AddInput<MLFloat16>("data_0", {3, 3},
-                       MakeMLFloat16({
-                        std::numeric_limits<float>::quiet_NaN(),
-                        std::numeric_limits<float>::quiet_NaN(),
-                        std::numeric_limits<float>::quiet_NaN(),
-                        -0.5f, 0.0f, -2.0f,
-                        0.5f, 0.0f, 2.0f}));
+                           MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(),
+                                          std::numeric_limits<float>::quiet_NaN(),
+                                          std::numeric_limits<float>::quiet_NaN(),
+                                          -0.5f, 0.0f, -2.0f,
+                                          0.5f, 0.0f, 2.0f}));
   test.AddInput<MLFloat16>("data_1", {3, 1},
-                       MakeMLFloat16({0.0f, -1.0f, 1.0f}));
+                           MakeMLFloat16({0.0f, -1.0f, 1.0f}));
   test.AddOutput<MLFloat16>("min", {3, 3},
-                        MakeMLFloat16({
-                         std::numeric_limits<float>::quiet_NaN(),
-                         std::numeric_limits<float>::quiet_NaN(),
-                         std::numeric_limits<float>::quiet_NaN(),
-                         -1.0f, -1.0f, -2.0f,
-                         0.5f, 0.0f, 1.0f}));
+                            MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(),
+                                           std::numeric_limits<float>::quiet_NaN(),
+                                           std::numeric_limits<float>::quiet_NaN(),
+                                           -1.0f, -1.0f, -2.0f,
+                                           0.5f, 0.0f, 1.0f}));
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});  // TensorRT: Input batch size is inconsistent
 }
 
@@ -1817,19 +1815,19 @@ TEST(MathOpTest, Max_12_Double) {
 TEST(MathOpTest, Max_12_Double_Nan) {
   OpTester test("Max", 12);
   test.AddInput<double>("data_2", {3, 3},
-                       {std::numeric_limits<double>::quiet_NaN(),
-                        std::numeric_limits<double>::quiet_NaN(),
-                        std::numeric_limits<double>::quiet_NaN(),
-                        -0.5, 0.0, -2.0,
-                        0.5, 0.0, 2.0});
-  test.AddInput<double>("data_1", {3, 1},
-                       {0.0, -1.0, 1.0});
-  test.AddOutput<double>("max", {3, 3},
                         {std::numeric_limits<double>::quiet_NaN(),
                          std::numeric_limits<double>::quiet_NaN(),
                          std::numeric_limits<double>::quiet_NaN(),
-                         -0.5, 0.0, -1.0,
-                         1.0, 1.0, 2.0});
+                         -0.5, 0.0, -2.0,
+                         0.5, 0.0, 2.0});
+  test.AddInput<double>("data_1", {3, 1},
+                        {0.0, -1.0, 1.0});
+  test.AddOutput<double>("max", {3, 3},
+                         {std::numeric_limits<double>::quiet_NaN(),
+                          std::numeric_limits<double>::quiet_NaN(),
+                          std::numeric_limits<double>::quiet_NaN(),
+                          -0.5, 0.0, -1.0,
+                          1.0, 1.0, 2.0});
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});  // TensorRT: Input batch size is inconsistent
 }
 
@@ -1943,21 +1941,19 @@ TEST(MathOpTest, Max_12_MLFLoat16_Scalar1) {
 TEST(MathOpTest, Max_12_MLFloat16_Nan) {
   OpTester test("Max", 12);
   test.AddInput<MLFloat16>("data_0", {3, 3},
-                       MakeMLFloat16({
-                        std::numeric_limits<float>::quiet_NaN(),
-                        std::numeric_limits<float>::quiet_NaN(),
-                        std::numeric_limits<float>::quiet_NaN(),
-                        -0.5f, 0.0f, -2.0f,
-                        0.5f, 0.0f, 2.0f}));
+                           MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(),
+                                          std::numeric_limits<float>::quiet_NaN(),
+                                          std::numeric_limits<float>::quiet_NaN(),
+                                          -0.5f, 0.0f, -2.0f,
+                                          0.5f, 0.0f, 2.0f}));
   test.AddInput<MLFloat16>("data_1", {3, 1},
-                       MakeMLFloat16({0.0f, -1.0f, 1.0f}));
+                           MakeMLFloat16({0.0f, -1.0f, 1.0f}));
   test.AddOutput<MLFloat16>("max", {3, 3},
-                       MakeMLFloat16({
-                        std::numeric_limits<float>::quiet_NaN(),
-                        std::numeric_limits<float>::quiet_NaN(),
-                        std::numeric_limits<float>::quiet_NaN(),
-                        -0.5f, 0.0f, -1.0f,
-                        1.0f, 1.0f, 2.0f}));
+                            MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(),
+                                           std::numeric_limits<float>::quiet_NaN(),
+                                           std::numeric_limits<float>::quiet_NaN(),
+                                           -0.5f, 0.0f, -1.0f,
+                                           1.0f, 1.0f, 2.0f}));
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});  // TensorRT: Input batch size is inconsistent
 }
 

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -8,6 +8,7 @@
 #include "test/common/cuda_op_test_utils.h"
 #include "core/util/math.h"
 #include <algorithm>
+#include <limits>
 #include <math.h>
 
 namespace onnxruntime {
@@ -1506,6 +1507,25 @@ TEST(MathOpTest, Min_12_Float_2_Input) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});  // TensorRT: Input batch size is inconsistent
 }
 
+TEST(MathOpTest, Min_12_Float_Nan) {
+  OpTester test("Min", 12);
+  test.AddInput<float>("data_2", {3, 3},
+                       {std::numeric_limits<float>::quiet_NaN(),
+                        std::numeric_limits<float>::quiet_NaN(),
+                        std::numeric_limits<float>::quiet_NaN(),
+                        -0.5f, 0.0f, -2.0f,
+                        0.5f, 0.0f, 2.0f});
+  test.AddInput<float>("data_1", {3, 1},
+                       {0.0f, -1.0f, 1.0f});
+  test.AddOutput<float>("min", {3, 3},
+                        {std::numeric_limits<float>::quiet_NaN(),
+                         std::numeric_limits<float>::quiet_NaN(),
+                         std::numeric_limits<float>::quiet_NaN(),
+                         -1.0f, -1.0f, -2.0f,
+                         0.5f, 0.0f, 1.0f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});  // TensorRT: Input batch size is inconsistent
+}
+
 TEST(MathOpTest, Min_12_Double) {
   OpTester test("Min", 12);
   test.AddInput<double>("data_0", {1, 3},
@@ -1521,6 +1541,25 @@ TEST(MathOpTest, Min_12_Double) {
                           1.0f, 2.0f, 3.0f,
                           -70.0f, -80.0f, -90.0f});
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  // TensorRT: Input batch size is inconsistent
+}
+
+TEST(MathOpTest, Min_12_Double_Nan) {
+  OpTester test("Min", 12);
+  test.AddInput<double>("data_2", {3, 3},
+                       {std::numeric_limits<double>::quiet_NaN(),
+                        std::numeric_limits<double>::quiet_NaN(),
+                        std::numeric_limits<double>::quiet_NaN(),
+                        -0.5, 0.0, -2.0,
+                        0.5, 0.0, 2.0});
+  test.AddInput<double>("data_1", {3, 1},
+                       {0.0, -1.0, 1.0});
+  test.AddOutput<double>("min", {3, 3},
+                        {std::numeric_limits<double>::quiet_NaN(),
+                         std::numeric_limits<double>::quiet_NaN(),
+                         std::numeric_limits<double>::quiet_NaN(),
+                         -1.0, -1.0, -2.0,
+                         0.5, 0.0, 1.0});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});  // TensorRT: Input batch size is inconsistent
 }
 
 TEST(MathOpTest, Min_12_Int32) {
@@ -1629,6 +1668,28 @@ TEST(MathOpTest, Min_12_MLFLoat16_Scalar1) {
                             MakeMLFloat16({-10.f, -10.f, -10.f}));
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  // TensorRT: Input batch size is inconsistent
 }
+
+TEST(MathOpTest, Min_12_MLFloat16_Nan) {
+  OpTester test("Min", 12);
+  test.AddInput<MLFloat16>("data_0", {3, 3},
+                       MakeMLFloat16({
+                        std::numeric_limits<float>::quiet_NaN(),
+                        std::numeric_limits<float>::quiet_NaN(),
+                        std::numeric_limits<float>::quiet_NaN(),
+                        -0.5f, 0.0f, -2.0f,
+                        0.5f, 0.0f, 2.0f}));
+  test.AddInput<MLFloat16>("data_1", {3, 1},
+                       MakeMLFloat16({0.0f, -1.0f, 1.0f}));
+  test.AddOutput<MLFloat16>("min", {3, 3},
+                        MakeMLFloat16({
+                         std::numeric_limits<float>::quiet_NaN(),
+                         std::numeric_limits<float>::quiet_NaN(),
+                         std::numeric_limits<float>::quiet_NaN(),
+                         -1.0f, -1.0f, -2.0f,
+                         0.5f, 0.0f, 1.0f}));
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});  // TensorRT: Input batch size is inconsistent
+}
+
 TEST(MathOpTest, Max_6) {
   OpTester test("Max", 6);
   std::vector<int64_t> dims{3, 3};
@@ -1717,6 +1778,25 @@ TEST(MathOpTest, Max_12_Float) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});  // TensorRT: Input batch size is inconsistent
 }
 
+TEST(MathOpTest, Max_12_Float_Nan) {
+  OpTester test("Max", 12);
+  test.AddInput<float>("data_2", {3, 3},
+                       {std::numeric_limits<float>::quiet_NaN(),
+                        std::numeric_limits<float>::quiet_NaN(),
+                        std::numeric_limits<float>::quiet_NaN(),
+                        -0.5f, 0.0f, -2.0f,
+                        0.5f, 0.0f, 2.0f});
+  test.AddInput<float>("data_1", {3, 1},
+                       {0.0f, -1.0f, 1.0f});
+  test.AddOutput<float>("max", {3, 3},
+                        {std::numeric_limits<float>::quiet_NaN(),
+                         std::numeric_limits<float>::quiet_NaN(),
+                         std::numeric_limits<float>::quiet_NaN(),
+                         -0.5f, 0.0f, -1.0f,
+                         1.0f, 1.0f, 2.0f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});  // TensorRT: Input batch size is inconsistent
+}
+
 TEST(MathOpTest, Max_12_Double) {
   OpTester test("Max", 12);
   test.AddInput<double>("data_0", {1, 3},
@@ -1732,6 +1812,25 @@ TEST(MathOpTest, Max_12_Double) {
                           40.0, 50.0, 60.0,
                           300.0, 300.0, 300.0});
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  // TensorRT: Input batch size is inconsistent
+}
+
+TEST(MathOpTest, Max_12_Double_Nan) {
+  OpTester test("Max", 12);
+  test.AddInput<double>("data_2", {3, 3},
+                       {std::numeric_limits<double>::quiet_NaN(),
+                        std::numeric_limits<double>::quiet_NaN(),
+                        std::numeric_limits<double>::quiet_NaN(),
+                        -0.5, 0.0, -2.0,
+                        0.5, 0.0, 2.0});
+  test.AddInput<double>("data_1", {3, 1},
+                       {0.0, -1.0, 1.0});
+  test.AddOutput<double>("max", {3, 3},
+                        {std::numeric_limits<double>::quiet_NaN(),
+                         std::numeric_limits<double>::quiet_NaN(),
+                         std::numeric_limits<double>::quiet_NaN(),
+                         -0.5, 0.0, -1.0,
+                         1.0, 1.0, 2.0});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});  // TensorRT: Input batch size is inconsistent
 }
 
 TEST(MathOpTest, Max_12_Int32) {
@@ -1839,6 +1938,27 @@ TEST(MathOpTest, Max_12_MLFLoat16_Scalar1) {
   test.AddOutput<MLFloat16>("max", {1, 3},
                             MakeMLFloat16({2.f, 2.f, 2.f}));
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  // TensorRT: Input batch size is inconsistent
+}
+
+TEST(MathOpTest, Max_12_MLFloat16_Nan) {
+  OpTester test("Max", 12);
+  test.AddInput<MLFloat16>("data_0", {3, 3},
+                       MakeMLFloat16({
+                        std::numeric_limits<float>::quiet_NaN(),
+                        std::numeric_limits<float>::quiet_NaN(),
+                        std::numeric_limits<float>::quiet_NaN(),
+                        -0.5f, 0.0f, -2.0f,
+                        0.5f, 0.0f, 2.0f}));
+  test.AddInput<MLFloat16>("data_1", {3, 1},
+                       MakeMLFloat16({0.0f, -1.0f, 1.0f}));
+  test.AddOutput<MLFloat16>("max", {3, 3},
+                       MakeMLFloat16({
+                        std::numeric_limits<float>::quiet_NaN(),
+                        std::numeric_limits<float>::quiet_NaN(),
+                        std::numeric_limits<float>::quiet_NaN(),
+                        -0.5f, 0.0f, -1.0f,
+                        1.0f, 1.0f, 2.0f}));
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});  // TensorRT: Input batch size is inconsistent
 }
 
 TEST(MathOpTest, Not) {

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -1523,7 +1523,7 @@ TEST(MathOpTest, Min_12_Float_Nan) {
                          std::numeric_limits<float>::quiet_NaN(),
                          -1.0f, -1.0f, -2.0f,
                          0.5f, 0.0f, 1.0f});
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});  // TensorRT: Input batch size is inconsistent
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider, kQnnExecutionProvider});
 }
 
 TEST(MathOpTest, Min_12_Double) {
@@ -1559,7 +1559,7 @@ TEST(MathOpTest, Min_12_Double_Nan) {
                           std::numeric_limits<double>::quiet_NaN(),
                           -1.0, -1.0, -2.0,
                           0.5, 0.0, 1.0});
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});  // TensorRT: Input batch size is inconsistent
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
 TEST(MathOpTest, Min_12_Int32) {
@@ -1685,7 +1685,7 @@ TEST(MathOpTest, Min_12_MLFloat16_Nan) {
                                            std::numeric_limits<float>::quiet_NaN(),
                                            -1.0f, -1.0f, -2.0f,
                                            0.5f, 0.0f, 1.0f}));
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});  // TensorRT: Input batch size is inconsistent
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
 TEST(MathOpTest, Max_6) {
@@ -1792,7 +1792,7 @@ TEST(MathOpTest, Max_12_Float_Nan) {
                          std::numeric_limits<float>::quiet_NaN(),
                          -0.5f, 0.0f, -1.0f,
                          1.0f, 1.0f, 2.0f});
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});  // TensorRT: Input batch size is inconsistent
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider, kQnnExecutionProvider});
 }
 
 TEST(MathOpTest, Max_12_Double) {
@@ -1828,7 +1828,7 @@ TEST(MathOpTest, Max_12_Double_Nan) {
                           std::numeric_limits<double>::quiet_NaN(),
                           -0.5, 0.0, -1.0,
                           1.0, 1.0, 2.0});
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});  // TensorRT: Input batch size is inconsistent
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
 TEST(MathOpTest, Max_12_Int32) {
@@ -1954,7 +1954,7 @@ TEST(MathOpTest, Max_12_MLFloat16_Nan) {
                                            std::numeric_limits<float>::quiet_NaN(),
                                            -0.5f, 0.0f, -1.0f,
                                            1.0f, 1.0f, 2.0f}));
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});  // TensorRT: Input batch size is inconsistent
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
 TEST(MathOpTest, Not) {

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -1523,7 +1523,16 @@ TEST(MathOpTest, Min_12_Float_Nan) {
                          std::numeric_limits<float>::quiet_NaN(),
                          -1.0f, -1.0f, -2.0f,
                          0.5f, 0.0f, 1.0f});
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider, kQnnExecutionProvider});
+  if (nullptr != DefaultCpuExecutionProvider().get()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCpuExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+  if (nullptr != DefaultCudaExecutionProvider().get()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCudaExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
 }
 
 TEST(MathOpTest, Min_12_Double) {
@@ -1559,7 +1568,16 @@ TEST(MathOpTest, Min_12_Double_Nan) {
                           std::numeric_limits<double>::quiet_NaN(),
                           -1.0, -1.0, -2.0,
                           0.5, 0.0, 1.0});
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+  if (nullptr != DefaultCpuExecutionProvider().get()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCpuExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+  if (nullptr != DefaultCudaExecutionProvider().get()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCudaExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
 }
 
 TEST(MathOpTest, Min_12_Int32) {
@@ -1685,7 +1703,16 @@ TEST(MathOpTest, Min_12_MLFloat16_Nan) {
                                            std::numeric_limits<float>::quiet_NaN(),
                                            -1.0f, -1.0f, -2.0f,
                                            0.5f, 0.0f, 1.0f}));
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+  if (nullptr != DefaultCpuExecutionProvider().get()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCpuExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+  if (nullptr != DefaultCudaExecutionProvider().get()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCudaExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
 }
 
 TEST(MathOpTest, Max_6) {
@@ -1792,7 +1819,16 @@ TEST(MathOpTest, Max_12_Float_Nan) {
                          std::numeric_limits<float>::quiet_NaN(),
                          -0.5f, 0.0f, -1.0f,
                          1.0f, 1.0f, 2.0f});
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider, kQnnExecutionProvider});
+  if (nullptr != DefaultCpuExecutionProvider().get()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCpuExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+  if (nullptr != DefaultCudaExecutionProvider().get()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCudaExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
 }
 
 TEST(MathOpTest, Max_12_Double) {
@@ -1828,7 +1864,16 @@ TEST(MathOpTest, Max_12_Double_Nan) {
                           std::numeric_limits<double>::quiet_NaN(),
                           -0.5, 0.0, -1.0,
                           1.0, 1.0, 2.0});
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+  if (nullptr != DefaultCpuExecutionProvider().get()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCpuExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+  if (nullptr != DefaultCudaExecutionProvider().get()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCudaExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
 }
 
 TEST(MathOpTest, Max_12_Int32) {
@@ -1954,7 +1999,16 @@ TEST(MathOpTest, Max_12_MLFloat16_Nan) {
                                            std::numeric_limits<float>::quiet_NaN(),
                                            -0.5f, 0.0f, -1.0f,
                                            1.0f, 1.0f, 2.0f}));
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+  if (nullptr != DefaultCpuExecutionProvider().get()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCpuExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+  if (nullptr != DefaultCudaExecutionProvider().get()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCudaExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
 }
 
 TEST(MathOpTest, Not) {

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -1687,34 +1687,6 @@ TEST(MathOpTest, Min_12_MLFLoat16_Scalar1) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  // TensorRT: Input batch size is inconsistent
 }
 
-TEST(MathOpTest, Min_12_MLFloat16_Nan) {
-  OpTester test("Min", 12);
-  test.AddInput<MLFloat16>("data_0", {3, 3},
-                           MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(),
-                                          std::numeric_limits<float>::quiet_NaN(),
-                                          std::numeric_limits<float>::quiet_NaN(),
-                                          -0.5f, 0.0f, -2.0f,
-                                          0.5f, 0.0f, 2.0f}));
-  test.AddInput<MLFloat16>("data_1", {3, 1},
-                           MakeMLFloat16({0.0f, -1.0f, 1.0f}));
-  test.AddOutput<MLFloat16>("min", {3, 3},
-                            MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(),
-                                           std::numeric_limits<float>::quiet_NaN(),
-                                           std::numeric_limits<float>::quiet_NaN(),
-                                           -1.0f, -1.0f, -2.0f,
-                                           0.5f, 0.0f, 1.0f}));
-  if (nullptr != DefaultCpuExecutionProvider().get()) {
-    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
-    execution_providers.push_back(DefaultCpuExecutionProvider());
-    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
-  }
-  if (nullptr != DefaultCudaExecutionProvider().get()) {
-    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
-    execution_providers.push_back(DefaultCudaExecutionProvider());
-    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
-  }
-}
-
 TEST(MathOpTest, Max_6) {
   OpTester test("Max", 6);
   std::vector<int64_t> dims{3, 3};
@@ -1981,34 +1953,6 @@ TEST(MathOpTest, Max_12_MLFLoat16_Scalar1) {
   test.AddOutput<MLFloat16>("max", {1, 3},
                             MakeMLFloat16({2.f, 2.f, 2.f}));
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  // TensorRT: Input batch size is inconsistent
-}
-
-TEST(MathOpTest, Max_12_MLFloat16_Nan) {
-  OpTester test("Max", 12);
-  test.AddInput<MLFloat16>("data_0", {3, 3},
-                           MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(),
-                                          std::numeric_limits<float>::quiet_NaN(),
-                                          std::numeric_limits<float>::quiet_NaN(),
-                                          -0.5f, 0.0f, -2.0f,
-                                          0.5f, 0.0f, 2.0f}));
-  test.AddInput<MLFloat16>("data_1", {3, 1},
-                           MakeMLFloat16({0.0f, -1.0f, 1.0f}));
-  test.AddOutput<MLFloat16>("max", {3, 3},
-                            MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(),
-                                           std::numeric_limits<float>::quiet_NaN(),
-                                           std::numeric_limits<float>::quiet_NaN(),
-                                           -0.5f, 0.0f, -1.0f,
-                                           1.0f, 1.0f, 2.0f}));
-  if (nullptr != DefaultCpuExecutionProvider().get()) {
-    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
-    execution_providers.push_back(DefaultCpuExecutionProvider());
-    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
-  }
-  if (nullptr != DefaultCudaExecutionProvider().get()) {
-    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
-    execution_providers.push_back(DefaultCudaExecutionProvider());
-    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
-  }
 }
 
 TEST(MathOpTest, Not) {


### PR DESCRIPTION
### Description
Update the Min and Max CUDA math operations on float/double types to propagate NaNs: if either operand is NaN, the result should be NaN.

TODO: float16/bfloat16 need similar change.

### Motivation
Currently, results differ between the CPU and CUDA implementations of the floating point Min and Max operators: the CPU operators correctly return NaN results if either operand is NaN.  This PR updates the CUDA implementations to conform with this correct behavior.

See the the issue and comments raised [here](https://github.com/onnx/onnx/issues/6003).

### Context
Same behavior in numpy, torch and Java:
```
>>> numpy.min([numpy.NAN, 1])
nan
>>> numpy.max([numpy.NAN, 1])
nan

>>> torch.min(torch.tensor([1, float('nan')]))
tensor(nan)
>>> torch.max(torch.tensor([1, float('nan')]))
tensor(nan)
```

C languguage [fmin](https://en.cppreference.com/w/c/numeric/math/fmin) and [fmax](https://en.cppreference.com/w/c/numeric/math/fmax) has different behavior:
```
fmax(NaN,1) = 1
fmin(NaN,1) = 1
```

https://grouper.ieee.org/groups/msc/ANSI_IEEE-Std-754-2019/background/minNum_maxNum_Removal_Demotion_v3.pdf
![image](https://github.com/microsoft/onnxruntime/assets/30328909/62446cf1-f252-4ddc-8118-5ce605252331)

https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2273.pdf