### PR TITLE
Add CUDA v12 support for Java onnxruntime_gpu build

### DIFF
--- a/dockerfiles/Dockerfile.java-cuda
+++ b/dockerfiles/Dockerfile.java-cuda
@@ -1,0 +1,27 @@
+FROM nvidia/cuda:12.1.1-cudnn8-devel-ubi8
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN yum install -y zlib-devel python39-devel python39-numpy python39-setuptools python39-wheel python39-pip git unzip wget java-1.8.0-devel patch && \
+    wget https://github.com/Kitware/CMake/releases/download/v3.27.3/cmake-3.27.3-linux-x86_64.tar.gz && \
+    tar -zxf cmake-3.27.3-linux-x86_64.tar.gz --strip=1 -C /usr && rm -f cmake-3.27.3-linux-x86_64.tar.gz && \
+    wget https://services.gradle.org/distributions/gradle-8.6-bin.zip && unzip gradle-8.6-bin.zip -d /opt/ && rm -f gradle-8.6-bin.zip
+
+ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.402.b06-2.el8.x86_64
+
+RUN ln -s /usr/lib64 /usr/lib/x86_64-linux-gnu && /bin/bash -c 'for f in $(find $JAVA_HOME -name "*.h"); do ln -s $f /usr/include/$(basename $f); done' && \
+    git clone https://github.com/protocolbuffers/protobuf.git && cd protobuf && git checkout v21.12 && git submodule update --init --recursive && mkdir build_source && cd build_source && \
+    cmake ../cmake  -DCMAKE_INSTALL_LIBDIR=lib64 -Dprotobuf_BUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_SYSCONFDIR=/etc -DCMAKE_POSITION_INDEPENDENT_CODE=ON -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release && \
+    make -j$(nproc) && make install
+
+ENV GRADLE_HOME=/opt/gradle-8.6
+ENV PATH=${GRADLE_HOME}/bin:${PATH}
+
+COPY ./onnxruntime /onnxruntime
+WORKDIR /onnxruntime
+
+RUN python3 -m pip install -r tools/ci_build/github/linux/docker/inference/x64/python/cpu/scripts/requirements.txt && \
+    ./build.sh --allow_running_as_root --compile_no_warning_as_error --skip_tests \
+               --use_cuda --cuda_home /usr/local/cuda --cudnn_home /usr/lib64/ --config Release --build_java --update --build --parallel --cmake_extra_defines \
+               ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) CMAKE_CUDA_ARCHITECTURES="52;60;61;70;75;86" CMAKE_CXX_STANDARD=17 CMAKE_CXX_STANDARD_REQUIRED=ON \
+               ONNX_USE_PROTOBUF_SHARED_LIBS=OFF onnxruntime_BUILD_UNIT_TESTS=OFF

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -12,8 +12,23 @@ allprojects {
 	}
 }
 
-project.group = "com.microsoft.onnxruntime"
-version = rootProject.file('../VERSION_NUMBER').text.trim()
+def getCUDAVersion = {
+	def nvccStdout = new ByteArrayOutputStream()
+	exec {
+		commandLine 'nvcc', '--version'
+		standardOutput = nvccStdout
+	}
+
+	for (line in nvccStdout.toString().trim().split("\n")) {
+		if (line.contains("release")) {
+			def fromIndex = line.indexOf("release") + 7
+			def toIndex = line.indexOf(".", fromIndex)
+			return Integer.parseInt(line.substring(fromIndex, toIndex).trim())
+		}
+	}
+
+	throw new IllegalArgumentException("Unexpected output of \"nvcc --version\" command");
+}
 
 // cmake runs will inform us of the build directory of the current run
 def cmakeBuildDir = System.properties['cmakeBuildDir']
@@ -36,6 +51,14 @@ def defaultDescription = 'ONNX Runtime is a performance-focused inference engine
 def trainingDescription = 'ONNX Runtime Training is a training and inference package for ONNX ' +
 	'(Open Neural Network Exchange) models. This package is targeted for Learning on The Edge aka On-Device Training ' +
 	'See https://github.com/microsoft/onnxruntime-training-examples/tree/master/on_device_training for more details.'
+
+project.group = "com.microsoft.onnxruntime"
+version = rootProject.file('../VERSION_NUMBER').text.trim()
+if (useCUDA != null) {
+        version += "-cu" + getCUDAVersion()
+} else if (useROCM != null) {
+        version += "-rocm"
+}
 
 java {
 	sourceCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
### Description
348e3c709dff30b6d7490c6084a912f048687bbb Add Dockerfile for Java release build with CUDA
c9974effd1936e690b68cd298bd743225025d447 Add CUDA version to Java artifact version


### Motivation and Context
Java build for the latest `onnxruntime v1.17.1` is not (yet) available. Moreover existing Maven artifacts are not compatible with CUDA 12. This PR aims to fix this by providing two updates to onnxruntime:
1. An update to `java/build.gradle` to automatically postfix the build tag to the version number (`-cuXX` for CUDA and `-rocm` for ROCM).
2. A new Dockerfile that will compile `onnxruntime` with the `--build_java` option from scratch using the `*-ubi8` base image for maximum compatibility

This PR fixes issue #19960 "Add CUDA12 support for Java's onnxruntime_gpu dependency"

