### PR TITLE
[js/web] remove "browser" field in package.json

### DIFF
--- a/js/web/package.json
+++ b/js/web/package.json
@@ -1,6 +1,5 @@
 {
   "license": "MIT",
-  "browser": "dist/ort-web.min.js",
   "unpkg": "dist/ort.min.js",
   "name": "onnxruntime-web",
   "repository": {


### PR DESCRIPTION
### Description

Field "browser" is deprecated in favor of "exports". Removes the unused field.

Some bundler may read from "browser" and generate errors. Removing this field should let bundler to look up "exports". Fixes #19915