### PR TITLE
Install ONNX by buildling source code in Windows DML stage

### DIFF
--- a/onnxruntime/test/python/requirements.txt
+++ b/onnxruntime/test/python/requirements.txt
@@ -1,2 +1,2 @@
-onnx
+onnx=1.15.0
 pytest

--- a/onnxruntime/test/python/requirements.txt
+++ b/onnxruntime/test/python/requirements.txt
@@ -1,2 +1,2 @@
-onnx=1.15.0
+onnx==1.15.0
 pytest

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -2087,7 +2087,7 @@ def run_onnxruntime_tests(args, source_dir, ctest_path, build_dir, configs):
                     run_subprocess(
                         [sys.executable, "-m", "pip", "uninstall", "--yes", "onnx"], cwd=cwd, dll_path=dll_path
                     )
-                    run_subprocess([sys.executable, "-m", "pip", "install", "-q", "onnx"], cwd=cwd, dll_path=dll_path)
+                    run_subprocess([sys.executable, "-m", "pip", "install", "-q", "onnx==1.15.0"], cwd=cwd, dll_path=dll_path)
                 run_subprocess([sys.executable, "onnxruntime_test_python_iobinding.py"], cwd=cwd, dll_path=dll_path)
 
             if args.use_cuda:

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -2083,13 +2083,6 @@ def run_onnxruntime_tests(args, source_dir, ctest_path, build_dir, configs):
             # For CUDA or DML enabled builds test IOBinding feature
             if args.use_cuda or args.use_dml:
                 log.info("Testing IOBinding feature")
-                if args.use_dml:
-                    run_subprocess(
-                        [sys.executable, "-m", "pip", "uninstall", "--yes", "onnx"], cwd=cwd, dll_path=dll_path
-                    )
-                    run_subprocess(
-                        [sys.executable, "-m", "pip", "install", "-q", "onnx==1.15.0"], cwd=cwd, dll_path=dll_path
-                    )
                 run_subprocess([sys.executable, "onnxruntime_test_python_iobinding.py"], cwd=cwd, dll_path=dll_path)
 
             if args.use_cuda:

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -2087,7 +2087,9 @@ def run_onnxruntime_tests(args, source_dir, ctest_path, build_dir, configs):
                     run_subprocess(
                         [sys.executable, "-m", "pip", "uninstall", "--yes", "onnx"], cwd=cwd, dll_path=dll_path
                     )
-                    run_subprocess([sys.executable, "-m", "pip", "install", "-q", "onnx==1.15.0"], cwd=cwd, dll_path=dll_path)
+                    run_subprocess(
+                        [sys.executable, "-m", "pip", "install", "-q", "onnx==1.15.0"], cwd=cwd, dll_path=dll_path
+                    )
                 run_subprocess([sys.executable, "onnxruntime_test_python_iobinding.py"], cwd=cwd, dll_path=dll_path)
 
             if args.use_cuda:

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-prebuild-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-prebuild-steps.yml
@@ -110,7 +110,7 @@ steps:
 
     displayName: Install ccache and update PATH to use linked versions of gcc, cc, etc
 
-- $${{ if eq(parameters.InstallONNX, true}}:
+- ${{ if eq(parameters.InstallONNX, true) }}:
   - ${{ if eq(parameters.WITHCACHE, true) }}:
     - task: Cache@2
       # machinepool is used to ensure the compiler is same

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-prebuild-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-prebuild-steps.yml
@@ -106,34 +106,34 @@ steps:
 
     displayName: Install ccache and update PATH to use linked versions of gcc, cc, etc
 
-  - ${{ if eq(parameters.WITHCACHE, true) }}:
-    - task: Cache@2
-      # machinepool is used to ensure the compiler is same
-      inputs:
-        key: '"$(TODAY)" | ${{ parameters.buildArch }} | ${{ parameters.BuildConfig }} | ${{ parameters.MachinePool }} | $(Build.SourcesDirectory)/cmake/deps.txt, $(Build.SourcesDirectory)/tools/ci_build/github/windows/install_third_party_deps.ps1, $(Build.SourcesDirectory)/tools/ci_build/github/windows/helpers.ps1'
-        path: $(Agent.TempDirectory)/deps_ccache
-        restoreKeys: |
-          "$(TODAY)" | ${{ parameters.buildArch }} | ${{ parameters.BuildConfig }} | ${{ parameters.MachinePool }}
-      displayName: Cache Task
-
-  - task: PowerShell@2
-    displayName: 'Install ONNX'
+- ${{ if eq(parameters.WITHCACHE, true) }}:
+  - task: Cache@2
+    # machinepool is used to ensure the compiler is same
     inputs:
-      filePath: '$(Build.SourcesDirectory)/tools/ci_build/github/windows/install_third_party_deps.ps1'
-      workingDirectory: '$(Build.BinariesDirectory)'
-      ${{ if eq(parameters.WITHCACHE, true) }}:
-        arguments: -cpu_arch ${{ parameters.buildArch }} -install_prefix $(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\installed -build_config ${{ parameters.BuildConfig }} -use_cache
-      ${{ else }}:
-        arguments: -cpu_arch ${{ parameters.buildArch }} -install_prefix $(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\installed -build_config ${{ parameters.BuildConfig }}
-    ${{ if eq(parameters.WITHCACHE, true) }}:
-      env:
-        CCACHE_DIR: $(Agent.TempDirectory)/deps_ccache
-        CCACHE_COMPILERCHECK: content
+      key: '"$(TODAY)" | ${{ parameters.buildArch }} | ${{ parameters.BuildConfig }} | ${{ parameters.MachinePool }} | $(Build.SourcesDirectory)/cmake/deps.txt, $(Build.SourcesDirectory)/tools/ci_build/github/windows/install_third_party_deps.ps1, $(Build.SourcesDirectory)/tools/ci_build/github/windows/helpers.ps1'
+      path: $(Agent.TempDirectory)/deps_ccache
+      restoreKeys: |
+        "$(TODAY)" | ${{ parameters.buildArch }} | ${{ parameters.BuildConfig }} | ${{ parameters.MachinePool }}
+    displayName: Cache Task
 
-  - ${{ if eq(parameters.WITHCACHE, true) }}:
-    - powershell: |
-        ccache -sv
-        ccache -z
-      displayName: cache stat
-      env:
-        CCACHE_DIR: $(Agent.TempDirectory)/deps_ccache
+- task: PowerShell@2
+  displayName: 'Install ONNX'
+  inputs:
+    filePath: '$(Build.SourcesDirectory)/tools/ci_build/github/windows/install_third_party_deps.ps1'
+    workingDirectory: '$(Build.BinariesDirectory)'
+    ${{ if eq(parameters.WITHCACHE, true) }}:
+      arguments: -cpu_arch ${{ parameters.buildArch }} -install_prefix $(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\installed -build_config ${{ parameters.BuildConfig }} -use_cache
+    ${{ else }}:
+      arguments: -cpu_arch ${{ parameters.buildArch }} -install_prefix $(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\installed -build_config ${{ parameters.BuildConfig }}
+  ${{ if eq(parameters.WITHCACHE, true) }}:
+    env:
+      CCACHE_DIR: $(Agent.TempDirectory)/deps_ccache
+      CCACHE_COMPILERCHECK: content
+
+- ${{ if eq(parameters.WITHCACHE, true) }}:
+  - powershell: |
+      ccache -sv
+      ccache -z
+    displayName: cache stat
+    env:
+      CCACHE_DIR: $(Agent.TempDirectory)/deps_ccache

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-prebuild-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-prebuild-steps.yml
@@ -13,6 +13,10 @@ parameters:
   type: boolean
   default: false
 
+- name: InstallONNX
+  type: boolean
+  default: true
+
 - name: WITHCACHE
   type: boolean
   default: false
@@ -106,34 +110,35 @@ steps:
 
     displayName: Install ccache and update PATH to use linked versions of gcc, cc, etc
 
-- ${{ if eq(parameters.WITHCACHE, true) }}:
-  - task: Cache@2
-    # machinepool is used to ensure the compiler is same
+- $${{ if eq(parameters.InstallONNX, true}}:
+  - ${{ if eq(parameters.WITHCACHE, true) }}:
+    - task: Cache@2
+      # machinepool is used to ensure the compiler is same
+      inputs:
+        key: '"$(TODAY)" | ${{ parameters.buildArch }} | ${{ parameters.BuildConfig }} | ${{ parameters.MachinePool }} | $(Build.SourcesDirectory)/cmake/deps.txt, $(Build.SourcesDirectory)/tools/ci_build/github/windows/install_third_party_deps.ps1, $(Build.SourcesDirectory)/tools/ci_build/github/windows/helpers.ps1'
+        path: $(Agent.TempDirectory)/deps_ccache
+        restoreKeys: |
+          "$(TODAY)" | ${{ parameters.buildArch }} | ${{ parameters.BuildConfig }} | ${{ parameters.MachinePool }}
+      displayName: Cache Task
+
+  - task: PowerShell@2
+    displayName: 'Install ONNX'
     inputs:
-      key: '"$(TODAY)" | ${{ parameters.buildArch }} | ${{ parameters.BuildConfig }} | ${{ parameters.MachinePool }} | $(Build.SourcesDirectory)/cmake/deps.txt, $(Build.SourcesDirectory)/tools/ci_build/github/windows/install_third_party_deps.ps1, $(Build.SourcesDirectory)/tools/ci_build/github/windows/helpers.ps1'
-      path: $(Agent.TempDirectory)/deps_ccache
-      restoreKeys: |
-        "$(TODAY)" | ${{ parameters.buildArch }} | ${{ parameters.BuildConfig }} | ${{ parameters.MachinePool }}
-    displayName: Cache Task
-
-- task: PowerShell@2
-  displayName: 'Install ONNX'
-  inputs:
-    filePath: '$(Build.SourcesDirectory)/tools/ci_build/github/windows/install_third_party_deps.ps1'
-    workingDirectory: '$(Build.BinariesDirectory)'
+      filePath: '$(Build.SourcesDirectory)/tools/ci_build/github/windows/install_third_party_deps.ps1'
+      workingDirectory: '$(Build.BinariesDirectory)'
+      ${{ if eq(parameters.WITHCACHE, true) }}:
+        arguments: -cpu_arch ${{ parameters.buildArch }} -install_prefix $(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\installed -build_config ${{ parameters.BuildConfig }} -use_cache
+      ${{ else }}:
+        arguments: -cpu_arch ${{ parameters.buildArch }} -install_prefix $(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\installed -build_config ${{ parameters.BuildConfig }}
     ${{ if eq(parameters.WITHCACHE, true) }}:
-      arguments: -cpu_arch ${{ parameters.buildArch }} -install_prefix $(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\installed -build_config ${{ parameters.BuildConfig }} -use_cache
-    ${{ else }}:
-      arguments: -cpu_arch ${{ parameters.buildArch }} -install_prefix $(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\installed -build_config ${{ parameters.BuildConfig }}
-  ${{ if eq(parameters.WITHCACHE, true) }}:
-    env:
-      CCACHE_DIR: $(Agent.TempDirectory)/deps_ccache
-      CCACHE_COMPILERCHECK: content
+      env:
+        CCACHE_DIR: $(Agent.TempDirectory)/deps_ccache
+        CCACHE_COMPILERCHECK: content
 
-- ${{ if eq(parameters.WITHCACHE, true) }}:
-  - powershell: |
-      ccache -sv
-      ccache -z
-    displayName: cache stat
-    env:
-      CCACHE_DIR: $(Agent.TempDirectory)/deps_ccache
+  - ${{ if eq(parameters.WITHCACHE, true) }}:
+    - powershell: |
+        ccache -sv
+        ccache -z
+      displayName: cache stat
+      env:
+        CCACHE_DIR: $(Agent.TempDirectory)/deps_ccache

--- a/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
@@ -68,6 +68,7 @@ stages:
           BuildConfig: Debug
           MachinePool: 'onnxruntime-Win-CPU-2022'
           WithCache: false
+          InstallONNX: false
           Today: $(TODAY)
 
       - task: PythonScript@0
@@ -155,7 +156,7 @@ stages:
         GenerateDocumentation: false
         WITH_CACHE: false
         MachinePool: 'onnxruntime-Win-CPU-2022'
-        
+
 - stage: x86_release
   dependsOn: []
   jobs:
@@ -256,5 +257,3 @@ stages:
         GenerateDocumentation: false
         WITH_CACHE: false
         MachinePool: 'onnxruntime-Win-CPU-2022'
-
-


### PR DESCRIPTION
### Description
In #20073, I use pin onnx version to unblock the whole PR CI.
In fact, we could use the onnx that installed by building source code, that the onnx version is controlled by deps.txt.
For some history reason, DML stage installed onnx from pypi. Now, the onnx can be installed as other stages.

add an option to skip installing onnx in win-ci-prebuild-step


