### PR TITLE
OneDNN/dnnl: Fix filepath after dnnl move

### DIFF
--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -484,7 +484,7 @@ def generate_files(line_list, args):
         files_list.append(
             "<file src="
             + '"'
-            + os.path.join(args.sources_path, "include\\onnxruntime\\core\\providers\\dnnl\\dnnl_provider_factory.h")
+            + os.path.join(args.sources_path, "onnxruntime\\core\\providers\\dnnl\\dnnl_provider_factory.h")
             + '" target="build\\native\\include" />'
         )
 

--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -484,7 +484,7 @@ def generate_files(line_list, args):
         files_list.append(
             "<file src="
             + '"'
-            + os.path.join(args.sources_path, "onnxruntime\\core\\providers\\dnnl\\dnnl_provider_factory.h")
+            + os.path.join(args.sources_path, "include\\onnxruntime\\core\\providers\\dnnl\\dnnl_provider_options.h")
             + '" target="build\\native\\include" />'
         )
 


### PR DESCRIPTION
### Description
This adjusts the path used in the nuget script for dnnl to the new location of the file.

There isn't a CI pipeline for this as far as I can tell, and I can't easily confirm this change works on master, so please check.

### Motivation and Context
It is currently not possible to build onednn nuget packages. It's possible that the correct action would be to move the file not fix this path, but I'm not familiar enough with the repository layout.


