### PR TITLE
Fix build errors from date/date.h C++20 compatibility

### DIFF
--- a/cmake/onnxruntime_common.cmake
+++ b/cmake/onnxruntime_common.cmake
@@ -129,7 +129,7 @@ target_include_directories(onnxruntime_common
         ${OPTIONAL_LITE_INCLUDE_DIR})
 
 
-target_link_libraries(onnxruntime_common PUBLIC safeint_interface ${GSL_TARGET} ${ABSEIL_LIBS})
+target_link_libraries(onnxruntime_common PUBLIC safeint_interface ${GSL_TARGET} ${ABSEIL_LIBS} date::date)
 
 add_dependencies(onnxruntime_common ${onnxruntime_EXTERNAL_DEPENDENCIES})
 

--- a/include/onnxruntime/core/common/logging/logging.h
+++ b/include/onnxruntime/core/common/logging/logging.h
@@ -58,9 +58,9 @@ namespace logging {
 
 using Timestamp = std::chrono::time_point<std::chrono::system_clock>;
 
-// TODO When other compilers support std::chrono::operator<<, update this.
-// TODO Check support for other compilers' version before enable C++20 for other compilers 
-// Xcode added support for C++20's std::chrono::operator<< in version 14.4.
+// TODO: When other compilers support std::chrono::operator<<, update this.
+// TODO: Check support for other compilers' version before enable C++20 for other compilers.
+// Xcode added support for C++20's std::chrono::operator<< in SDK version 14.4.
 #if __cplusplus >= 202002L && __MAC_OS_X_VERSION_MAX_ALLOWED >= 140400L
 namespace timestamp_ns = std::chrono;
 #else

--- a/include/onnxruntime/core/common/logging/logging.h
+++ b/include/onnxruntime/core/common/logging/logging.h
@@ -58,7 +58,8 @@ namespace logging {
 
 using Timestamp = std::chrono::time_point<std::chrono::system_clock>;
 
-#if __cplusplus >= 202002L
+// NOTE When other compilers support std::chrono::operator<<, update this.
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 140400L
 namespace timestamp_ns = std::chrono;
 #else
 namespace timestamp_ns = ::date;

--- a/include/onnxruntime/core/common/logging/logging.h
+++ b/include/onnxruntime/core/common/logging/logging.h
@@ -58,8 +58,10 @@ namespace logging {
 
 using Timestamp = std::chrono::time_point<std::chrono::system_clock>;
 
-// NOTE When other compilers support std::chrono::operator<<, update this.
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 140400L
+// TODO When other compilers support std::chrono::operator<<, update this.
+// TODO Check support for other compilers' version before enable C++20 for other compilers 
+// Xcode added support for C++20's std::chrono::operator<< in version 14.4.
+#if __cplusplus >= 202002L && __MAC_OS_X_VERSION_MAX_ALLOWED >= 140400L
 namespace timestamp_ns = std::chrono;
 #else
 namespace timestamp_ns = ::date;

--- a/include/onnxruntime/core/common/logging/logging.h
+++ b/include/onnxruntime/core/common/logging/logging.h
@@ -18,6 +18,8 @@
 
 #include "core/common/logging/macros.h"
 
+#include "date/date.h"
+
 /*
 
   Logging overview and expected usage:
@@ -55,6 +57,12 @@ namespace onnxruntime {
 namespace logging {
 
 using Timestamp = std::chrono::time_point<std::chrono::system_clock>;
+
+#if __cplusplus >= 202002L
+namespace timestamp_ns = std::chrono;
+#else
+namespace timestamp_ns = ::date;
+#endif
 
 #ifndef NDEBUG
 ORT_ATTRIBUTE_UNUSED static bool vlog_enabled = true;  // Set directly based on your needs.

--- a/onnxruntime/core/common/logging/sinks/ostream_sink.cc
+++ b/onnxruntime/core/common/logging/sinks/ostream_sink.cc
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #include "core/common/logging/sinks/ostream_sink.h"
-#include "date/date.h"
 
 namespace onnxruntime {
 namespace logging {
@@ -24,7 +23,7 @@ struct Color {
 
 void OStreamSink::SendImpl(const Timestamp& timestamp, const std::string& logger_id, const Capture& message) {
   // operator for formatting of timestamp in ISO8601 format including microseconds
-  using date::operator<<;
+  using timestamp_ns::operator<<;
 
   // Two options as there may be multiple calls attempting to write to the same sink at once:
   // 1) Use mutex to synchronize access to the stream.

--- a/onnxruntime/core/platform/apple/logging/apple_log_sink.mm
+++ b/onnxruntime/core/platform/apple/logging/apple_log_sink.mm
@@ -13,7 +13,7 @@ namespace onnxruntime {
 namespace logging {
 
 void AppleLogSink::SendImpl(const Timestamp& timestamp, const std::string& logger_id, const Capture& message) {
-  using date::operator<<;
+  using timestamp_ns::operator<<;
   std::ostringstream msg;
   msg << timestamp << " [" << message.SeverityPrefix() << ":" << message.Category() << ":" << logger_id << ", "
       << message.Location().ToString() << "] " << message.Message();

--- a/onnxruntime/test/common/logging/helpers.h
+++ b/onnxruntime/test/common/logging/helpers.h
@@ -5,7 +5,6 @@
 
 #include <sstream>
 
-#include "date/date.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -30,7 +29,7 @@ class MockSink : public ::onnxruntime::logging::ISink {
 #endif
 
 ACTION(PrintArgs) {
-  using date::operator<<;
+  using onnxruntime::logging::timestamp_ns::operator<<;
 
   // const Timestamp &timestamp, const std::string &logger_id, const Message &message
   //                  arg0                          arg1                        arg2

--- a/onnxruntime/test/util/include/test/capturing_sink.h
+++ b/onnxruntime/test/util/include/test/capturing_sink.h
@@ -6,8 +6,6 @@
 #include "core/common/logging/logging.h"
 #include "core/common/logging/isink.h"
 
-#include "date/date.h"
-
 namespace onnxruntime {
 namespace test {
 
@@ -17,7 +15,7 @@ class CapturingSink : public logging::ISink {
  public:
   void SendImpl(const Timestamp& timestamp, const std::string& logger_id, const Capture& message) override {
     // operator for formatting of timestamp in ISO8601 format including microseconds
-    using date::operator<<;
+    using timestamp_ns::operator<<;
     std::ostringstream msg;
 
     msg << timestamp << " [" << message.SeverityPrefix() << ":" << message.Category() << ":" << logger_id << ", "


### PR DESCRIPTION
### Description
For C++ standards >= 20, use `std::chrono::operator<<` in place of `date::operator<<` to fix ambiguous operator compile error. 

### Motivation and Context
The external dependency HowardHinnant/date has a conflict with std::chrono for >=C++20.
Solves #20137 

