### PR TITLE
[Quant] Fix accuracy_level config option for MatMul 4bits quantizer

### DIFF
--- a/onnxruntime/python/tools/quantization/matmul_4bits_quantizer.py
+++ b/onnxruntime/python/tools/quantization/matmul_4bits_quantizer.py
@@ -440,7 +440,7 @@ class DefaultWeightOnlyQuantizer:
         kwargs["bits"] = 4
         kwargs["block_size"] = self.config.block_size
         if self.config.accuracy_level is not None:
-            kwargs["accuracy_level"] = self.accuracy_level
+            kwargs["accuracy_level"] = self.config.accuracy_level
 
         matmul_q4_node = onnx.helper.make_node(
             "MatMulNBits",


### PR DESCRIPTION
### Description
Fixes code that extracts the accuracy level when creating a MatMulNBits node.


### Motivation and Context
Error from line 443: `AttributeError: 'DefaultWeightOnlyQuantizer' object has no attribute 'accuracy_level'`. The solution is to access `self.config.accuracy_level` instead of `self.accuracy_level`.

Relevant commit: https://github.com/microsoft/onnxruntime/pull/19106


