### PR TITLE
Fix bug related to export failure for DynamicQuantizeLSTM [issue 15465]

### DIFF
--- a/onnxruntime/python/tools/quantization/operators/lstm.py
+++ b/onnxruntime/python/tools/quantization/operators/lstm.py
@@ -103,6 +103,8 @@ class LSTMQuant(QuantOperatorBase):
 
         kwargs = {}
         for attribute in node.attribute:
+            if attribute.name == "layout":
+                continue
             kwargs.update(attribute_to_kwarg(attribute))
         kwargs["domain"] = ms_domain
 


### PR DESCRIPTION
### Description

See issue 15465: https://github.com/microsoft/onnxruntime/issues/15465

This PR just applies the workaround suggested in the thread that I and numerous others on the thread have validated to work for them and allows them to successfully export a PyTorch model with LSTM layers that are dynamically quantized by ONNX.



### Motivation and Context

It is not possible to successfully export a dynamically quantized LSTM model that I have trained for use in the onnx runtime without this change. 

Currently, this workaround lives as a local change in my python package directory, and makes it basically impossible for anyone else at the place I work at to successfully export the quantized model that I am exporting.


See issue 15465: https://github.com/microsoft/onnxruntime/issues/15465 
