### PR TITLE
Reduce Heap contention in StringNormalizer

### DIFF
--- a/onnxruntime/core/providers/cpu/text/string_normalizer.cc
+++ b/onnxruntime/core/providers/cpu/text/string_normalizer.cc
@@ -57,7 +57,7 @@ class Utf8ConverterGeneric {
     std::codecvt_base::result ret_code = std::codecvt_base::ok;
 
     // Continue while we exhaust the sequence
-    while (true) {
+    while (converted < wstr.length()) {
       ret_code = converter_.out(state,
                                 wchar_next,
                                 src_end,
@@ -67,10 +67,6 @@ class Utf8ConverterGeneric {
                                 char_next);
       result += (char_next - dummy_dest);
       converted = (wchar_next - src);
-
-      if (converted == wstr.length()) {
-        break;
-      }
 
       if (ret_code != std::codecvt_base::partial &&
           ret_code != std::codecvt_base::ok) {
@@ -137,14 +133,14 @@ class Utf8ConverterGeneric {
     const char* src = str.data();
     const char* src_end = src + str.length();
 
-    wchar_t dummy_dest[256] = {0};
+    wchar_t dummy_dest[128] = {0};
     const char* char_next = src;
     wchar_t* wchar_next = dummy_dest;
 
     size_t converted = 0;
 
     std::codecvt_base::result ret_code = std::codecvt_base::ok;
-    while (true) {
+    while (converted < str.length()) {
       ret_code = converter_.in(state,
                                char_next,
                                src_end,
@@ -154,9 +150,6 @@ class Utf8ConverterGeneric {
                                wchar_next);
       result += (wchar_next - dummy_dest);
       converted = (char_next - src);
-      if (converted == str.length()) {
-        break;
-      }
 
       if (ret_code != std::codecvt_base::partial &&
           ret_code != std::codecvt_base::ok) {

--- a/onnxruntime/core/providers/cpu/text/string_normalizer.cc
+++ b/onnxruntime/core/providers/cpu/text/string_normalizer.cc
@@ -4,6 +4,8 @@
 #include "string_normalizer.h"
 #include "core/common/common.h"
 #include "core/framework/tensor.h"
+// Used below HAS_DEPRECATED_DECLARATIONS
+#include "onnxruntime_config.h"
 
 #ifdef _MSC_VER
 #include <locale.h>

--- a/onnxruntime/core/providers/cpu/text/string_normalizer.cc
+++ b/onnxruntime/core/providers/cpu/text/string_normalizer.cc
@@ -468,7 +468,8 @@ StringNormalizer::StringNormalizer(const OpKernelInfo& info) : OpKernel(info),
     ORT_ENFORCE(false, "attribute case_change_action has invalid value");
   }
 
-  compare_caseaction_ = (case_change_action_ == UPPER) ? UPPER : LOWER;
+  // Set this to lower because some characters do not have capital case.
+  compare_caseaction_ = LOWER;
   locale_name_ = info.GetAttrOrDefault("locale", default_locale);
 
   std::vector<std::string> stop_words = info.GetAttrsOrDefault<std::string>("stopwords");

--- a/onnxruntime/core/providers/cpu/text/string_normalizer.cc
+++ b/onnxruntime/core/providers/cpu/text/string_normalizer.cc
@@ -539,7 +539,7 @@ Status StringNormalizer::Compute(OpKernelContext* ctx) const {
   size_t max_wide_buffer_len = 0;
   auto input_span = X->DataAsSpan<std::string>();
   for (const auto& s : input_span) {
-    size_t wchars;
+    size_t wchars = 0;
     // Checks for invalid UTF-8 characters on Windows
     ORT_RETURN_IF_ERROR(converter.ComputeRequiredSizeToWideChar(s, wchars));
     max_wide_buffer_len = std::max(max_wide_buffer_len, wchars);
@@ -600,7 +600,7 @@ Status StringNormalizer::Compute(OpKernelContext* ctx) const {
     } else {
       // we need to filter
       InlinedVector<size_t> filtered_strings_indecies;
-      filtered_strings_indecies.reserve(C);
+      filtered_strings_indecies.reserve(narrow<size_t>(C));
 
       for (size_t i = 0, lim = narrow<size_t>(C); i < lim; ++i) {
         const std::string& s = input_span[i];
@@ -623,7 +623,7 @@ Status StringNormalizer::Compute(OpKernelContext* ctx) const {
       // to the same case. For that we convert to wchar_t UNICODE.
       // Otherwise, we need to pull ICU library on all platforms
       InlinedVector<size_t> filtered_strings_indecies;
-      filtered_strings_indecies.reserve(C);
+      filtered_strings_indecies.reserve(narrow<size_t>(C));
       for (size_t i = 0, lim = narrow<size_t>(C); i < lim; ++i) {
         const std::string& s = input_span[i];
         wchar_buffer.resize(max_wide_buffer_len);

--- a/onnxruntime/core/providers/cpu/text/string_normalizer.h
+++ b/onnxruntime/core/providers/cpu/text/string_normalizer.h
@@ -27,7 +27,9 @@ class StringNormalizer : public OpKernel {
  private:
   bool is_case_sensitive_;
   CaseAction case_change_action_;
-  CaseAction compare_caseaction_;  // used for case-insensitive compare
+  // Set this to lower because some characters do not have capital case.
+  // used for case-insensitive compare
+  CaseAction compare_caseaction_{LOWER};
   std::string locale_name_;
   // Either if these are populated but not both
   InlinedHashSet<std::string> stopwords_;

--- a/onnxruntime/core/providers/cpu/text/string_normalizer.h
+++ b/onnxruntime/core/providers/cpu/text/string_normalizer.h
@@ -25,8 +25,8 @@ class StringNormalizer : public OpKernel {
   Status Compute(OpKernelContext* ctx) const override;
 
  private:
-  bool is_case_sensitive_;
-  CaseAction case_change_action_;
+  bool is_case_sensitive_{true};
+  CaseAction case_change_action_{NONE};
   // Set this to lower because some characters do not have capital case.
   // used for case-insensitive compare
   CaseAction compare_caseaction_{LOWER};

--- a/onnxruntime/test/providers/cpu/text/string_normalizer_test.cc
+++ b/onnxruntime/test/providers/cpu/text/string_normalizer_test.cc
@@ -111,29 +111,29 @@ TEST(ContribOpTest, StringNormalizerSensitiveFilterOutUpperWithLocale) {
   // - UPPER should produce the same output as they are all lower.
 
   OpTester test("StringNormalizer", opset_ver, domain);
-  InitTestAttr(test, "UPPER", true, {u8"monday"}, test_locale);
+  InitTestAttr(test, "UPPER", true, {"monday"}, test_locale);
   std::vector<int64_t> dims{7};
-  std::vector<std::string> input = {std::string(u8"monday"),
-                                    std::string(u8"tuesday"),
-                                    std::string(u8"Besançon"),
-                                    std::string(u8"École élémentaire"),
-                                    std::string(u8"Понедельник"),
-                                    std::string(u8"mit freundlichen grüßen"),
-                                    std::string(u8"中文")};
+  std::vector<std::string> input = {"monday",
+                                    "tuesday",
+                                    "Besançon",
+                                    "École élémentaire",
+                                    "Понедельник",
+                                    "mit freundlichen grüßen",
+                                    "中文"};
   test.AddInput<std::string>("T", dims, input);
 
   // en_US results (default)
-  std::vector<std::string> output = {std::string(u8"TUESDAY"),
+  std::vector<std::string> output = {"TUESDAY",
                                      // It does upper case cecedille, accented E
                                      // and german umlaut but fails
                                      // with german eszett
-                                     std::string(u8"BESANÇON"),
-                                     std::string(u8"ÉCOLE ÉLÉMENTAIRE"),
+                                     "BESANÇON",
+                                     "ÉCOLE ÉLÉMENTAIRE",
                                      // No issues with Cyrllic
-                                     std::string(u8"ПОНЕДЕЛЬНИК"),
-                                     std::string(u8"MIT FREUNDLICHEN GRÜßEN"),
+                                     "ПОНЕДЕЛЬНИК",
+                                     "MIT FREUNDLICHEN GRÜßEN",
                                      // Chinese do not have cases
-                                     std::string(u8"中文")};
+                                     "中文"};
   test.AddOutput<std::string>("Y", {6}, output);
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
@@ -146,29 +146,29 @@ TEST(ContribOpTest, StringNormalizerInsensitiveFilterOutUpperWithLocale) {
   // - UPPER should produce the same output as they are all lower.
 
   OpTester test("StringNormalizer", opset_ver, domain);
-  InitTestAttr(test, "UPPER", false, {u8"monday"}, test_locale);
+  InitTestAttr(test, "UPPER", false, {"monday"}, test_locale);
   std::vector<int64_t> dims{7};
-  std::vector<std::string> input = {std::string(u8"monday"),
-                                    std::string(u8"tuesday"),
-                                    std::string(u8"Besançon"),
-                                    std::string(u8"École élémentaire"),
-                                    std::string(u8"Понедельник"),
-                                    std::string(u8"mit freundlichen grüßen"),
-                                    std::string(u8"中文")};
+  std::vector<std::string> input = {"monday",
+                                    "tuesday",
+                                    "Besançon",
+                                    "École élémentaire",
+                                    "Понедельник",
+                                    "mit freundlichen grüßen",
+                                    "中文"};
   test.AddInput<std::string>("T", dims, input);
 
   // en_US results (default)
-  std::vector<std::string> output = {std::string(u8"TUESDAY"),
+  std::vector<std::string> output = {"TUESDAY",
                                      // It does upper case cecedille, accented E
                                      // and german umlaut but fails
                                      // with german eszett
-                                     std::string(u8"BESANÇON"),
-                                     std::string(u8"ÉCOLE ÉLÉMENTAIRE"),
+                                     "BESANÇON",
+                                     "ÉCOLE ÉLÉMENTAIRE",
                                      // No issues with Cyrllic
-                                     std::string(u8"ПОНЕДЕЛЬНИК"),
-                                     std::string(u8"MIT FREUNDLICHEN GRÜßEN"),
+                                     "ПОНЕДЕЛЬНИК",
+                                     "MIT FREUNDLICHEN GRÜßEN",
                                      // Chinese do not have cases
-                                     std::string(u8"中文")};
+                                     "中文"};
   test.AddOutput<std::string>("Y", {6}, output);
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
@@ -182,8 +182,7 @@ TEST(ContribOpTest, StringNormalizerSensitiveFilterOutUpperEmptyCase) {
   OpTester test("StringNormalizer", opset_ver, domain);
   InitTestAttr(test, "UPPER", true, {"monday"}, test_locale);
   std::vector<int64_t> dims{2};
-  std::vector<std::string> input = {std::string("monday"),
-                                    std::string("monday")};
+  std::vector<std::string> input = {"monday", "monday"};
   test.AddInput<std::string>("T", dims, input);
 
   std::vector<std::string> output{""};  // One empty string

--- a/onnxruntime/test/providers/cpu/text/string_normalizer_test.cc
+++ b/onnxruntime/test/providers/cpu/text/string_normalizer_test.cc
@@ -4,6 +4,13 @@
 #include "gtest/gtest.h"
 #include "test/providers/provider_test_utils.h"
 
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#if TARGET_OS_IOS
+#define ORT_IOS
+#endif
+#endif
+
 namespace onnxruntime {
 namespace test {
 
@@ -206,7 +213,7 @@ TEST(ContribOpTest, StringNormalizerSensitiveFilterOutUpperEmptyCase) {
 
 // Fails on iOS because necessary locales are not installed
 // MacOS runs fine.
-#ifndef __APPLE__
+#ifndef ORT_IOS
 TEST(ContribOpTest, StringNormalizerSensitiveFilterOutUpperSameOutput) {
   // Empty output case
   // - casesensitive approach

--- a/onnxruntime/test/providers/cpu/text/string_normalizer_test.cc
+++ b/onnxruntime/test/providers/cpu/text/string_normalizer_test.cc
@@ -35,7 +35,7 @@ static void InitTestAttr(OpTester& test, const std::string& case_change_action,
 
 using namespace str_normalizer_test;
 
-TEST(ContribOpTest, StringNormalizerSensetiveNoCase) {
+TEST(ContribOpTest, StringNormalizerSensitiveNoCase) {
   // - casesensitive approach
   // - no stopwords.
   // - No change case action, expecting default to take over
@@ -50,7 +50,7 @@ TEST(ContribOpTest, StringNormalizerSensetiveNoCase) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, StringNormalizerSensetiveFilterOutNoCase) {
+TEST(ContribOpTest, StringNormalizerSensitiveFilterOutNoCase) {
   // - casesensitive approach
   // - filter out monday
   // - No change case action
@@ -68,7 +68,7 @@ TEST(ContribOpTest, StringNormalizerSensetiveFilterOutNoCase) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, StringNormalizerSensetiveFilterOutLower) {
+TEST(ContribOpTest, StringNormalizerSensitiveFilterOutLower) {
   // - casesensitive approach
   // - filter out monday
   // - LOWER should produce the same output as they are all lower.
@@ -85,7 +85,7 @@ TEST(ContribOpTest, StringNormalizerSensetiveFilterOutLower) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, StringNormalizerSensetiveFilterOutUpper) {
+TEST(ContribOpTest, StringNormalizerSensitiveFilterOutUpper) {
   // - casesensitive approach
   // - filter out monday
   // - UPPER should produce the same output as they are all lower.
@@ -103,8 +103,8 @@ TEST(ContribOpTest, StringNormalizerSensetiveFilterOutUpper) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, StringNormalizerSensetiveFilterOutUpperWithLocale) {
-  // - case-SENSETIVE approach en_US locale
+TEST(ContribOpTest, StringNormalizerSensitiveFilterOutUpperWithLocale) {
+  // - case-SENSITIVE approach en_US locale
   // - we test the behavior of a mix of english, french, german, russian and chinese
   //   with en_US locale
   // - filter out monday
@@ -138,8 +138,8 @@ TEST(ContribOpTest, StringNormalizerSensetiveFilterOutUpperWithLocale) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, StringNormalizerInsensetiveFilterOutUpperWithLocale) {
-  // - case-INSENSETIVE approach en_US locale
+TEST(ContribOpTest, StringNormalizerInsensitiveFilterOutUpperWithLocale) {
+  // - case-INSENSITIVE approach en_US locale
   // - we test the behavior of a mix of english, french, german, russian and chinese
   //   with en_US locale
   // - filter out monday
@@ -173,7 +173,7 @@ TEST(ContribOpTest, StringNormalizerInsensetiveFilterOutUpperWithLocale) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, StringNormalizerSensetiveFilterOutUpperEmptyCase) {
+TEST(ContribOpTest, StringNormalizerSensitiveFilterOutUpperEmptyCase) {
   // Empty output case
   // - casesensitive approach
   // - filter out monday
@@ -191,7 +191,7 @@ TEST(ContribOpTest, StringNormalizerSensetiveFilterOutUpperEmptyCase) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, StringNormalizerSensetiveFilterOutUpperSameOutput) {
+TEST(ContribOpTest, StringNormalizerSensitiveFilterOutUpperSameOutput) {
   // Empty output case
   // - casesensitive approach
   // - filter out monday

--- a/onnxruntime/test/providers/cpu/text/string_normalizer_test.cc
+++ b/onnxruntime/test/providers/cpu/text/string_normalizer_test.cc
@@ -206,8 +206,7 @@ TEST(ContribOpTest, StringNormalizerSensitiveFilterOutUpperEmptyCase) {
 
 // Fails on iOS because necessary locales are not installed
 // MacOS runs fine.
-
-#if defined(TARGET_IPHONE_SIMULATOR) || defined(TARGET_OS_IPHONE)
+#ifdef __APPLE__
 TEST(ContribOpTest, StringNormalizerSensitiveFilterOutUpperSameOutput) {
   // Empty output case
   // - casesensitive approach

--- a/onnxruntime/test/providers/cpu/text/string_normalizer_test.cc
+++ b/onnxruntime/test/providers/cpu/text/string_normalizer_test.cc
@@ -1,8 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#if ((__cplusplus >= 201703L) || (defined(_MSVC_LANG) && (_MSVC_LANG >= 201703L)))
-// TODO: handle the u8string.
-#else
 #include "gtest/gtest.h"
 #include "test/providers/provider_test_utils.h"
 
@@ -19,10 +16,10 @@ const std::string test_locale("en-US");
 const std::string test_locale("en_US.UTF-8");
 #endif
 
-void InitTestAttr(OpTester& test, const std::string& case_change_action,
-                  bool is_case_sensitive,
-                  const std::vector<std::string>& stopwords,
-                  const std::string& locale) {
+static void InitTestAttr(OpTester& test, const std::string& case_change_action,
+                         bool is_case_sensitive,
+                         const std::vector<std::string>& stopwords,
+                         const std::string& locale) {
   if (!case_change_action.empty()) {
     test.AddAttribute("case_change_action", case_change_action);
   }
@@ -38,170 +35,178 @@ void InitTestAttr(OpTester& test, const std::string& case_change_action,
 
 using namespace str_normalizer_test;
 
-TEST(ContribOpTest, StringNormalizerTest) {
+TEST(ContribOpTest, StringNormalizerSensetiveNoCase) {
   // - casesensitive approach
   // - no stopwords.
   // - No change case action, expecting default to take over
-  {
-    OpTester test("StringNormalizer", opset_ver, domain);
-    InitTestAttr(test, "", true, {}, test_locale);
-    std::vector<int64_t> dims{4};
-    std::vector<std::string> input = {std::string("monday"), std::string("tuesday"),
-                                      std::string("wednesday"), std::string("thursday")};
-    test.AddInput<std::string>("T", dims, input);
-    std::vector<std::string> output(input);  // do the same for now
-    test.AddOutput<std::string>("Y", dims, output);
-    test.Run(OpTester::ExpectResult::kExpectSuccess);
-  }
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "", true, {}, test_locale);
+  std::vector<int64_t> dims{4};
+  std::vector<std::string> input = {std::string("monday"), std::string("tuesday"),
+                                    std::string("wednesday"), std::string("thursday")};
+  test.AddInput<std::string>("T", dims, input);
+  std::vector<std::string> output(input);  // do the same for now
+  test.AddOutput<std::string>("Y", dims, output);
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, StringNormalizerSensetiveFilterOutNoCase) {
   // - casesensitive approach
   // - filter out monday
   // - No change case action
-  {
-    OpTester test("StringNormalizer", opset_ver, domain);
-    InitTestAttr(test, "NONE", true, {"monday"}, test_locale);
-    std::vector<int64_t> dims{4};
-    std::vector<std::string> input = {std::string("monday"), std::string("tuesday"),
-                                      std::string("wednesday"), std::string("thursday")};
-    test.AddInput<std::string>("T", dims, input);
 
-    std::vector<std::string> output = {std::string("tuesday"),
-                                       std::string("wednesday"), std::string("thursday")};
-    test.AddOutput<std::string>("Y", {3}, output);
-    test.Run(OpTester::ExpectResult::kExpectSuccess);
-  }
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "NONE", true, {"monday"}, test_locale);
+  std::vector<int64_t> dims{4};
+  std::vector<std::string> input = {std::string("monday"), std::string("tuesday"),
+                                    std::string("wednesday"), std::string("thursday")};
+  test.AddInput<std::string>("T", dims, input);
+
+  std::vector<std::string> output = {std::string("tuesday"),
+                                     std::string("wednesday"), std::string("thursday")};
+  test.AddOutput<std::string>("Y", {3}, output);
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, StringNormalizerSensetiveFilterOutLower) {
   // - casesensitive approach
   // - filter out monday
   // - LOWER should produce the same output as they are all lower.
-  {
-    OpTester test("StringNormalizer", opset_ver, domain);
-    InitTestAttr(test, "LOWER", true, {"monday"}, test_locale);
-    std::vector<int64_t> dims{4};
-    std::vector<std::string> input = {std::string("monday"), std::string("tuesday"),
-                                      std::string("wednesday"), std::string("thursday")};
-    test.AddInput<std::string>("T", dims, input);
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "LOWER", true, {"monday"}, test_locale);
+  std::vector<int64_t> dims{4};
+  std::vector<std::string> input = {std::string("monday"), std::string("tuesday"),
+                                    std::string("wednesday"), std::string("thursday")};
+  test.AddInput<std::string>("T", dims, input);
 
-    std::vector<std::string> output = {std::string("tuesday"),
-                                       std::string("wednesday"), std::string("thursday")};
-    test.AddOutput<std::string>("Y", {3}, output);
-    test.Run(OpTester::ExpectResult::kExpectSuccess);
-  }
+  std::vector<std::string> output = {std::string("tuesday"),
+                                     std::string("wednesday"), std::string("thursday")};
+  test.AddOutput<std::string>("Y", {3}, output);
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, StringNormalizerSensetiveFilterOutUpper) {
   // - casesensitive approach
   // - filter out monday
   // - UPPER should produce the same output as they are all lower.
-  {
-    OpTester test("StringNormalizer", opset_ver, domain);
-    InitTestAttr(test, "UPPER", true, {"monday"}, test_locale);
-    std::vector<int64_t> dims{4};
-    std::vector<std::string> input = {std::string("monday"), std::string("tuesday"),
-                                      std::string("wednesday"), std::string("thursday")};
-    test.AddInput<std::string>("T", dims, input);
 
-    std::vector<std::string> output = {std::string("TUESDAY"),
-                                       std::string("WEDNESDAY"), std::string("THURSDAY")};
-    test.AddOutput<std::string>("Y", {3}, output);
-    test.Run(OpTester::ExpectResult::kExpectSuccess);
-  }
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "UPPER", true, {"monday"}, test_locale);
+  std::vector<int64_t> dims{4};
+  std::vector<std::string> input = {std::string("monday"), std::string("tuesday"),
+                                    std::string("wednesday"), std::string("thursday")};
+  test.AddInput<std::string>("T", dims, input);
+
+  std::vector<std::string> output = {std::string("TUESDAY"),
+                                     std::string("WEDNESDAY"), std::string("THURSDAY")};
+  test.AddOutput<std::string>("Y", {3}, output);
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, StringNormalizerSensetiveFilterOutUpperWithLocale) {
   // - case-SENSETIVE approach en_US locale
   // - we test the behavior of a mix of english, french, german, russian and chinese
   //   with en_US locale
   // - filter out monday
   // - UPPER should produce the same output as they are all lower.
-  {
-    OpTester test("StringNormalizer", opset_ver, domain);
-    InitTestAttr(test, "UPPER", true, {u8"monday"}, test_locale);
-    std::vector<int64_t> dims{7};
-    std::vector<std::string> input = {std::string(u8"monday"),
-                                      std::string(u8"tuesday"),
-                                      std::string(u8"Besançon"),
-                                      std::string(u8"École élémentaire"),
-                                      std::string(u8"Понедельник"),
-                                      std::string(u8"mit freundlichen grüßen"),
-                                      std::string(u8"中文")};
-    test.AddInput<std::string>("T", dims, input);
 
-    // en_US results (default)
-    std::vector<std::string> output = {std::string(u8"TUESDAY"),
-                                       // It does upper case cecedille, accented E
-                                       // and german umlaut but fails
-                                       // with german eszett
-                                       std::string(u8"BESANÇON"),
-                                       std::string(u8"ÉCOLE ÉLÉMENTAIRE"),
-                                       // No issues with Cyrllic
-                                       std::string(u8"ПОНЕДЕЛЬНИК"),
-                                       std::string(u8"MIT FREUNDLICHEN GRÜßEN"),
-                                       // Chinese do not have cases
-                                       std::string(u8"中文")};
-    test.AddOutput<std::string>("Y", {6}, output);
-    test.Run(OpTester::ExpectResult::kExpectSuccess);
-  }
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "UPPER", true, {u8"monday"}, test_locale);
+  std::vector<int64_t> dims{7};
+  std::vector<std::string> input = {std::string(u8"monday"),
+                                    std::string(u8"tuesday"),
+                                    std::string(u8"Besançon"),
+                                    std::string(u8"École élémentaire"),
+                                    std::string(u8"Понедельник"),
+                                    std::string(u8"mit freundlichen grüßen"),
+                                    std::string(u8"中文")};
+  test.AddInput<std::string>("T", dims, input);
+
+  // en_US results (default)
+  std::vector<std::string> output = {std::string(u8"TUESDAY"),
+                                     // It does upper case cecedille, accented E
+                                     // and german umlaut but fails
+                                     // with german eszett
+                                     std::string(u8"BESANÇON"),
+                                     std::string(u8"ÉCOLE ÉLÉMENTAIRE"),
+                                     // No issues with Cyrllic
+                                     std::string(u8"ПОНЕДЕЛЬНИК"),
+                                     std::string(u8"MIT FREUNDLICHEN GRÜßEN"),
+                                     // Chinese do not have cases
+                                     std::string(u8"中文")};
+  test.AddOutput<std::string>("Y", {6}, output);
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, StringNormalizerInsensetiveFilterOutUpperWithLocale) {
   // - case-INSENSETIVE approach en_US locale
   // - we test the behavior of a mix of english, french, german, russian and chinese
   //   with en_US locale
   // - filter out monday
   // - UPPER should produce the same output as they are all lower.
-  {
-    OpTester test("StringNormalizer", opset_ver, domain);
-    InitTestAttr(test, "UPPER", false, {u8"monday"}, test_locale);
-    std::vector<int64_t> dims{7};
-    std::vector<std::string> input = {std::string(u8"monday"),
-                                      std::string(u8"tuesday"),
-                                      std::string(u8"Besançon"),
-                                      std::string(u8"École élémentaire"),
-                                      std::string(u8"Понедельник"),
-                                      std::string(u8"mit freundlichen grüßen"),
-                                      std::string(u8"中文")};
-    test.AddInput<std::string>("T", dims, input);
 
-    // en_US results (default)
-    std::vector<std::string> output = {std::string(u8"TUESDAY"),
-                                       // It does upper case cecedille, accented E
-                                       // and german umlaut but fails
-                                       // with german eszett
-                                       std::string(u8"BESANÇON"),
-                                       std::string(u8"ÉCOLE ÉLÉMENTAIRE"),
-                                       // No issues with Cyrllic
-                                       std::string(u8"ПОНЕДЕЛЬНИК"),
-                                       std::string(u8"MIT FREUNDLICHEN GRÜßEN"),
-                                       // Chinese do not have cases
-                                       std::string(u8"中文")};
-    test.AddOutput<std::string>("Y", {6}, output);
-    test.Run(OpTester::ExpectResult::kExpectSuccess);
-  }
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "UPPER", false, {u8"monday"}, test_locale);
+  std::vector<int64_t> dims{7};
+  std::vector<std::string> input = {std::string(u8"monday"),
+                                    std::string(u8"tuesday"),
+                                    std::string(u8"Besançon"),
+                                    std::string(u8"École élémentaire"),
+                                    std::string(u8"Понедельник"),
+                                    std::string(u8"mit freundlichen grüßen"),
+                                    std::string(u8"中文")};
+  test.AddInput<std::string>("T", dims, input);
 
+  // en_US results (default)
+  std::vector<std::string> output = {std::string(u8"TUESDAY"),
+                                     // It does upper case cecedille, accented E
+                                     // and german umlaut but fails
+                                     // with german eszett
+                                     std::string(u8"BESANÇON"),
+                                     std::string(u8"ÉCOLE ÉLÉMENTAIRE"),
+                                     // No issues with Cyrllic
+                                     std::string(u8"ПОНЕДЕЛЬНИК"),
+                                     std::string(u8"MIT FREUNDLICHEN GRÜßEN"),
+                                     // Chinese do not have cases
+                                     std::string(u8"中文")};
+  test.AddOutput<std::string>("Y", {6}, output);
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, StringNormalizerSensetiveFilterOutUpperEmptyCase) {
   // Empty output case
   // - casesensitive approach
   // - filter out monday
   // - UPPER should produce the same output as they are all lower.
-  {
-    OpTester test("StringNormalizer", opset_ver, domain);
-    InitTestAttr(test, "UPPER", true, {"monday"}, test_locale);
-    std::vector<int64_t> dims{2};
-    std::vector<std::string> input = {std::string("monday"),
-                                      std::string("monday")};
-    test.AddInput<std::string>("T", dims, input);
 
-    std::vector<std::string> output{""};  // One empty string
-    test.AddOutput<std::string>("Y", {1}, output);
-    test.Run(OpTester::ExpectResult::kExpectSuccess);
-  }
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "UPPER", true, {"monday"}, test_locale);
+  std::vector<int64_t> dims{2};
+  std::vector<std::string> input = {std::string("monday"),
+                                    std::string("monday")};
+  test.AddInput<std::string>("T", dims, input);
+
+  std::vector<std::string> output{""};  // One empty string
+  test.AddOutput<std::string>("Y", {1}, output);
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, StringNormalizerSensetiveFilterOutUpperSameOutput) {
   // Empty output case
   // - casesensitive approach
   // - filter out monday
   // - UPPER should produce the same output as they are all lower.
-  {
-    OpTester test("StringNormalizer", opset_ver, domain);
-    InitTestAttr(test, "UPPER", true, {"monday"}, "");
-    std::vector<int64_t> dims{1, 2};
-    std::vector<std::string> input = {std::string("monday"),
-                                      std::string("monday")};
-    test.AddInput<std::string>("T", dims, input);
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "UPPER", true, {"monday"}, "");
+  std::vector<int64_t> dims{1, 2};
+  std::vector<std::string> input = {std::string("monday"),
+                                    std::string("monday")};
+  test.AddInput<std::string>("T", dims, input);
 
-    std::vector<std::string> output{""};  // One empty string
-    test.AddOutput<std::string>("Y", {1, 1}, output);
-    test.Run(OpTester::ExpectResult::kExpectSuccess);
-  }
+  std::vector<std::string> output{""};  // One empty string
+  test.AddOutput<std::string>("Y", {1, 1}, output);
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
 }  // namespace test
 }  // namespace onnxruntime
-#endif

--- a/onnxruntime/test/providers/cpu/text/string_normalizer_test.cc
+++ b/onnxruntime/test/providers/cpu/text/string_normalizer_test.cc
@@ -206,7 +206,7 @@ TEST(ContribOpTest, StringNormalizerSensitiveFilterOutUpperEmptyCase) {
 
 // Fails on iOS because necessary locales are not installed
 // MacOS runs fine.
-#ifdef __APPLE__
+#ifndef __APPLE__
 TEST(ContribOpTest, StringNormalizerSensitiveFilterOutUpperSameOutput) {
   // Empty output case
   // - casesensitive approach


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Re-use pre-computed and pre-allocated buffers for UNICODE conversions.
Make sure we do not introduce unnecessary intermediate `std::string` instances.
Create a Utf8Generic converter for use with non-Windows platforms.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
This reduces heap contention in P1 customer.

![image](https://github.com/microsoft/onnxruntime/assets/11303988/fd39fb01-7361-47d2-8f83-69dbc3bbc65c)


