### PR TITLE
Jump Times Fix

### DIFF
--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_whisper.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_whisper.h
@@ -503,41 +503,37 @@ Status BeamSearchWhisper<T>::Execute(const FeedsFetchesManager& encoder_feeds_fe
   if (decoder_subgraph_.output_cross_qk_) {
       // Trim output of Cross_QK to match real sequence size
     int real_decoded_length = 0;
-    for (int i = 0; i < output_sequences->Shape()[2]; i++) {
-      std::cout << "Token sequence: " << output_sequences->MutableDataAsSpan<int32_t>().data()[i] << " EOS Token: " << parameters->eos_token_id << std::endl;
+    for (int i = 0; i < output_sequences->Shape()[2]; i++) { // Assumes num_return_sequences and batch size == 1, need to change for bsz
       if (output_sequences->MutableDataAsSpan<int32_t>().data()[i] != parameters->eos_token_id)
         real_decoded_length++;
     }
 
-    std::cout<< "Real decoded length: " << real_decoded_length << std::endl;
-    real_decoded_length = 29;
-      TensorShape cross_qk_shape{
-          static_cast<int64_t>(parameters->batch_size),
-          static_cast<int64_t>(parameters->num_return_sequences),
-          cross_qk_layer_head_pair_count,
-          static_cast<int64_t>(real_decoded_length-1),
-          frames_of_k};
-      cross_qk_output = this->context_.Output(3, cross_qk_shape);
+    TensorShape cross_qk_shape{
+        static_cast<int64_t>(parameters->batch_size),
+        static_cast<int64_t>(parameters->num_return_sequences),
+        cross_qk_layer_head_pair_count,
+        static_cast<int64_t>(real_decoded_length-1),
+        frames_of_k};
+    cross_qk_output = this->context_.Output(3, cross_qk_shape);
 
-      size_t cache_indir_input_offset = static_cast<size_t>(decoder_subgraph_.GetFirstPastInputIndex()) + 4 * static_cast<size_t>(decoder_subgraph_.num_layers) + 2;
-      const int* cache_indir_data = decoder_feeds[cache_indir_input_offset].GetMutable<Tensor>()->Data<int32_t>();
-      ORT_RETURN_IF_ERROR(this->finalize_decoder_cross_qk_func_(
-        this->ort_stream_,
-        iteration_counter,
-        current_length,
-        parameters->batch_size,
-        parameters->num_beams,
-        parameters->max_length,
-        static_cast<int>(cross_qk_layer_head_pair_count),
-        cross_qk_layer_head_pairs,
-        static_cast<int>(frames_of_k),
-        cross_qk_buffer_data,
-        cross_qk_output->MutableData<float>(),
-        parameters->num_return_sequences,
-        cache_indir_data,
-        ReinterpretAsSpan<const int32_t>(beam_state.chosen_indices),
-        this->GetConsoleDumper(),
-        real_decoded_length));
+    size_t cache_indir_input_offset = static_cast<size_t>(decoder_subgraph_.GetFirstPastInputIndex()) + 4 * static_cast<size_t>(decoder_subgraph_.num_layers) + 2;
+    const int* cache_indir_data = decoder_feeds[cache_indir_input_offset].GetMutable<Tensor>()->Data<int32_t>();
+    ORT_RETURN_IF_ERROR(this->finalize_decoder_cross_qk_func_(
+      this->ort_stream_,
+      iteration_counter,
+      current_length,
+      parameters->batch_size,
+      parameters->num_beams,
+      parameters->max_length,
+      static_cast<int>(cross_qk_layer_head_pair_count),
+      cross_qk_layer_head_pairs,
+      static_cast<int>(frames_of_k),
+      cross_qk_buffer_data,
+      cross_qk_output->MutableData<float>(),
+      parameters->num_return_sequences,
+      cache_indir_data,
+      ReinterpretAsSpan<const int32_t>(beam_state.chosen_indices),
+      real_decoded_length));
     }
 
 

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_whisper.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_whisper.h
@@ -431,38 +431,7 @@ Status BeamSearchWhisper<T>::Execute(const FeedsFetchesManager& encoder_feeds_fe
       decoder_fetches.clear();
     }
   }
- /*
-  if (decoder_subgraph_.output_cross_qk_) {
 
-    TensorShape cross_qk_shape{
-        static_cast<int64_t>(parameters->batch_size),
-        static_cast<int64_t>(parameters->num_return_sequences),
-        cross_qk_layer_head_pair_count,
-        static_cast<int64_t>(iteration_counter - 1),
-        frames_of_k};
-    cross_qk_output = this->context_.Output(3, cross_qk_shape);
-
-    size_t cache_indir_input_offset = static_cast<size_t>(decoder_subgraph_.GetFirstPastInputIndex()) + 4 * static_cast<size_t>(decoder_subgraph_.num_layers) + 2;
-    const int* cache_indir_data = decoder_feeds[cache_indir_input_offset].GetMutable<Tensor>()->Data<int32_t>();
-    ORT_RETURN_IF_ERROR(this->finalize_decoder_cross_qk_func_(
-      this->ort_stream_,
-      iteration_counter,
-      current_length,
-      parameters->batch_size,
-      parameters->num_beams,
-      parameters->max_length,
-      static_cast<int>(cross_qk_layer_head_pair_count),
-      cross_qk_layer_head_pairs,
-      static_cast<int>(frames_of_k),
-      cross_qk_buffer_data,
-      cross_qk_output->MutableData<float>(),
-      parameters->num_return_sequences,
-      cache_indir_data,
-      ReinterpretAsSpan<const int32_t>(beam_state.chosen_indices),
-      this->GetConsoleDumper(),
-      real_decoded_length));
-  }
-*/
   gsl::span<const float> final_beam_scores = beam_state.beam_scores;
   if (this->IsCuda()) {
     ORT_RETURN_IF_ERROR(this->device_copy_func_(cpu_state.final_beam_scores,

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_whisper.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_whisper.h
@@ -432,6 +432,35 @@ Status BeamSearchWhisper<T>::Execute(const FeedsFetchesManager& encoder_feeds_fe
     }
   }
 
+  if (decoder_subgraph_.output_cross_qk_) {
+      // Copy Cross_QK values to match real sequence size for each batch 
+    TensorShape cross_qk_shape{
+        static_cast<int64_t>(parameters->batch_size),
+        static_cast<int64_t>(parameters->num_return_sequences),
+        cross_qk_layer_head_pair_count,
+        static_cast<int64_t>(iteration_counter-1),
+        frames_of_k};
+    cross_qk_output = this->context_.Output(3, cross_qk_shape);
+
+    size_t cache_indir_input_offset = static_cast<size_t>(decoder_subgraph_.GetFirstPastInputIndex()) + 4 * static_cast<size_t>(decoder_subgraph_.num_layers) + 2;
+    const int* cache_indir_data = decoder_feeds[cache_indir_input_offset].GetMutable<Tensor>()->Data<int32_t>();
+    ORT_RETURN_IF_ERROR(this->finalize_decoder_cross_qk_func_(
+      this->ort_stream_,
+      iteration_counter,
+      current_length,
+      parameters->batch_size,
+      parameters->num_beams,
+      parameters->max_length,
+      static_cast<int>(cross_qk_layer_head_pair_count),
+      cross_qk_layer_head_pairs,
+      static_cast<int>(frames_of_k),
+      cross_qk_buffer_data,
+      cross_qk_output->MutableData<float>(),
+      parameters->num_return_sequences,
+      cache_indir_data,
+      ReinterpretAsSpan<const int32_t>(beam_state.chosen_indices)));
+  }
+
   gsl::span<const float> final_beam_scores = beam_state.beam_scores;
   if (this->IsCuda()) {
     ORT_RETURN_IF_ERROR(this->device_copy_func_(cpu_state.final_beam_scores,
@@ -468,34 +497,6 @@ Status BeamSearchWhisper<T>::Execute(const FeedsFetchesManager& encoder_feeds_fe
     ORT_RETURN_IF_ERROR(this->device_copy_func_(target, source, nullptr, DeviceCopyDirection::deviceToDevice));
   }
 
-  if (decoder_subgraph_.output_cross_qk_) {
-      // Copy Cross_QK values to match real sequence size for each batch 
-    TensorShape cross_qk_shape{
-        static_cast<int64_t>(parameters->batch_size),
-        static_cast<int64_t>(parameters->num_return_sequences),
-        cross_qk_layer_head_pair_count,
-        static_cast<int64_t>(iteration_counter-1),
-        frames_of_k};
-    cross_qk_output = this->context_.Output(3, cross_qk_shape);
-
-    size_t cache_indir_input_offset = static_cast<size_t>(decoder_subgraph_.GetFirstPastInputIndex()) + 4 * static_cast<size_t>(decoder_subgraph_.num_layers) + 2;
-    const int* cache_indir_data = decoder_feeds[cache_indir_input_offset].GetMutable<Tensor>()->Data<int32_t>();
-    ORT_RETURN_IF_ERROR(this->finalize_decoder_cross_qk_func_(
-      this->ort_stream_,
-      iteration_counter,
-      current_length,
-      parameters->batch_size,
-      parameters->num_beams,
-      parameters->max_length,
-      static_cast<int>(cross_qk_layer_head_pair_count),
-      cross_qk_layer_head_pairs,
-      static_cast<int>(frames_of_k),
-      cross_qk_buffer_data,
-      cross_qk_output->MutableData<float>(),
-      parameters->num_return_sequences,
-      cache_indir_data,
-      ReinterpretAsSpan<const int32_t>(beam_state.chosen_indices)));
-  }
   return status;
 }
 

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_whisper.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_whisper.h
@@ -383,7 +383,8 @@ Status BeamSearchWhisper<T>::Execute(const FeedsFetchesManager& encoder_feeds_fe
         parameters->max_length,
         this->temp_space_allocator_,
         ReinterpretAsSpan<const int32_t>(beam_indices),
-        cross_qk_buffer_value));
+        cross_qk_buffer_value,
+        parameters->num_beams));
     }
 
     // When all batches are finished, stop earlier to avoid wasting computation.

--- a/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.cc
@@ -581,6 +581,7 @@ void PickGptPastState(const std::vector<OrtValue>& last_outputs,
     gsl::span<T> past_span = gsl::make_span<T>(past.GetMutable<Tensor>()->MutableData<T>(), onnxruntime::narrow<size_t>(past_shape.Size()));
     gsl::span<const T> present_span = gsl::make_span<const T>(present.Get<Tensor>().Data<T>(), onnxruntime::narrow<size_t>(past_shape.Size()));
     for (size_t j = 0; j < beam_indices.size(); j++) {
+      // Copying from j to beam_index[j]
       int32_t beam_index = beam_indices[j];
       gsl::span<const T> present_key = present_span.subspan(beam_index * SafeInt<size_t>(block_size_per_beam), onnxruntime::narrow<size_t>(block_size_per_beam));
       gsl::span<const T> present_value = present_span.subspan(past_key_size + beam_index * SafeInt<size_t>(block_size_per_beam),
@@ -1096,7 +1097,9 @@ Status UpdateDecoderCrossQK(
     [[maybe_unused]] const int* cross_qk_layer_head_pairs,
     [[maybe_unused]] float* cross_qk_buffer_data,
     [[maybe_unused]] int max_length,
-    [[maybe_unused]] AllocatorPtr allocator
+    [[maybe_unused]] AllocatorPtr allocator,
+    [[maybe_unused]] gsl::span<const int32_t> beam_indices_gpu,
+    [[maybe_unused]] OrtValue cross_qk_buffer_value
 ) {
   throw std::runtime_error("CPU beam search current not support output cross QK.");
   return Status::OK();

--- a/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.cc
@@ -1100,8 +1100,7 @@ Status UpdateDecoderCrossQK(
     [[maybe_unused]] AllocatorPtr allocator,
     [[maybe_unused]] gsl::span<const int32_t> beam_indices_gpu,
     [[maybe_unused]] OrtValue cross_qk_buffer_value,
-    [[maybe_unused]] int num_beams,
-    [[maybe_unused]] const transformers::IConsoleDumper* dumper
+    [[maybe_unused]] int num_beams
 ) {
   throw std::runtime_error("CPU beam search current not support output cross QK.");
   return Status::OK();
@@ -1121,8 +1120,7 @@ Status FinalizeDecoderCrossQK(
     [[maybe_unused]] float* cross_qk_output,
     [[maybe_unused]] int num_return_sequences,
     [[maybe_unused]] const int* cache_indir_data,
-    [[maybe_unused]] gsl::span<const int32_t> beam_indices,
-    [[maybe_unused]] int real_decoded_length
+    [[maybe_unused]] gsl::span<const int32_t> beam_indices
 ) {
   throw std::runtime_error("CPU beam search current not support output cross QK.");
   return Status::OK();

--- a/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.cc
@@ -1122,7 +1122,6 @@ Status FinalizeDecoderCrossQK(
     [[maybe_unused]] int num_return_sequences,
     [[maybe_unused]] const int* cache_indir_data,
     [[maybe_unused]] gsl::span<const int32_t> beam_indices,
-    [[maybe_unused]] const transformers::IConsoleDumper* dumper,
     [[maybe_unused]] int real_decoded_length
 ) {
   throw std::runtime_error("CPU beam search current not support output cross QK.");

--- a/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.cc
@@ -1100,7 +1100,8 @@ Status UpdateDecoderCrossQK(
     [[maybe_unused]] AllocatorPtr allocator,
     [[maybe_unused]] gsl::span<const int32_t> beam_indices_gpu,
     [[maybe_unused]] OrtValue cross_qk_buffer_value,
-    [[maybe_unused]] int num_beams
+    [[maybe_unused]] int num_beams,
+    [[maybe_unused]] const transformers::IConsoleDumper* dumper
 ) {
   throw std::runtime_error("CPU beam search current not support output cross QK.");
   return Status::OK();
@@ -1120,7 +1121,9 @@ Status FinalizeDecoderCrossQK(
     [[maybe_unused]] float* cross_qk_output,
     [[maybe_unused]] int num_return_sequences,
     [[maybe_unused]] const int* cache_indir_data,
-    [[maybe_unused]] gsl::span<const int32_t> beam_indices
+    [[maybe_unused]] gsl::span<const int32_t> beam_indices,
+    [[maybe_unused]] const transformers::IConsoleDumper* dumper,
+    [[maybe_unused]] int real_decoded_length
 ) {
   throw std::runtime_error("CPU beam search current not support output cross QK.");
   return Status::OK();

--- a/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.cc
@@ -1099,7 +1099,7 @@ Status UpdateDecoderCrossQK(
     [[maybe_unused]] int max_length,
     [[maybe_unused]] AllocatorPtr allocator,
     [[maybe_unused]] gsl::span<const int32_t> beam_indices_gpu,
-    [[maybe_unused]] OrtValue cross_qk_buffer_value,
+    [[maybe_unused]] OrtValue& cross_qk_buffer_value,
     [[maybe_unused]] int num_beams
 ) {
   throw std::runtime_error("CPU beam search current not support output cross QK.");

--- a/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.cc
@@ -1099,7 +1099,8 @@ Status UpdateDecoderCrossQK(
     [[maybe_unused]] int max_length,
     [[maybe_unused]] AllocatorPtr allocator,
     [[maybe_unused]] gsl::span<const int32_t> beam_indices_gpu,
-    [[maybe_unused]] OrtValue cross_qk_buffer_value
+    [[maybe_unused]] OrtValue cross_qk_buffer_value,
+    [[maybe_unused]] int num_beams
 ) {
   throw std::runtime_error("CPU beam search current not support output cross QK.");
   return Status::OK();

--- a/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.h
@@ -208,7 +208,8 @@ using UpdateDecoderCrossQKFunc = std::function<Status(
     int max_length,
     AllocatorPtr allocator,
     gsl::span<const int32_t> beam_indices_gpu,
-    OrtValue cross_qk_buffer_value )>;
+    OrtValue cross_qk_buffer_value,
+    int num_beams)>;
 
 
 using FinalizeDecoderCrossQKFunc = std::function<Status(
@@ -402,7 +403,8 @@ Status UpdateDecoderCrossQK(
     int max_length,
     AllocatorPtr allocator,
     gsl::span<const int32_t> beam_indices_gpu,
-    OrtValue cross_qk_buffer_value
+    OrtValue cross_qk_buffer_value,
+    int num_beams
 );
 
 Status FinalizeDecoderCrossQK(

--- a/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.h
@@ -208,7 +208,7 @@ using UpdateDecoderCrossQKFunc = std::function<Status(
     int max_length,
     AllocatorPtr allocator,
     gsl::span<const int32_t> beam_indices_gpu,
-    OrtValue cross_qk_buffer_value,
+    OrtValue& cross_qk_buffer_value,
     int num_beams)>;
 
 
@@ -403,7 +403,7 @@ Status UpdateDecoderCrossQK(
     int max_length,
     AllocatorPtr allocator,
     gsl::span<const int32_t> beam_indices_gpu,
-    OrtValue cross_qk_buffer_value,
+    OrtValue& cross_qk_buffer_value,
     int num_beams
 );
 

--- a/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.h
@@ -206,7 +206,9 @@ using UpdateDecoderCrossQKFunc = std::function<Status(
     const int* cross_qk_layer_head_pairs,
     float* cross_qk_buffer_data,
     int max_length,
-    AllocatorPtr allocator)>;
+    AllocatorPtr allocator,
+    gsl::span<const int32_t> beam_indices_gpu,
+    OrtValue cross_qk_buffer_value )>;
 
 
 using FinalizeDecoderCrossQKFunc = std::function<Status(
@@ -398,7 +400,9 @@ Status UpdateDecoderCrossQK(
     const int* cross_qk_layer_head_pairs,
     float* cross_qk_buffer_data,
     int max_length,
-    AllocatorPtr allocator
+    AllocatorPtr allocator,
+    gsl::span<const int32_t> beam_indices_gpu,
+    OrtValue cross_qk_buffer_value
 );
 
 Status FinalizeDecoderCrossQK(

--- a/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.h
@@ -209,7 +209,8 @@ using UpdateDecoderCrossQKFunc = std::function<Status(
     AllocatorPtr allocator,
     gsl::span<const int32_t> beam_indices_gpu,
     OrtValue cross_qk_buffer_value,
-    int num_beams)>;
+    int num_beams,
+    const transformers::IConsoleDumper* dumper)>;
 
 
 using FinalizeDecoderCrossQKFunc = std::function<Status(
@@ -226,7 +227,9 @@ using FinalizeDecoderCrossQKFunc = std::function<Status(
     float* cross_qk_output,
     int num_return_sequences,
     const int* cache_indir_data,
-    gsl::span<const int32_t> beam_indices)>;
+    gsl::span<const int32_t> beam_indices,
+    const transformers::IConsoleDumper* dumper,
+    int real_decoded_length)>;
 
 }  // namespace GenerationDeviceHelper
 
@@ -404,7 +407,8 @@ Status UpdateDecoderCrossQK(
     AllocatorPtr allocator,
     gsl::span<const int32_t> beam_indices_gpu,
     OrtValue cross_qk_buffer_value,
-    int num_beams
+    int num_beams,
+    const transformers::IConsoleDumper* dumper
 );
 
 Status FinalizeDecoderCrossQK(
@@ -421,7 +425,9 @@ Status FinalizeDecoderCrossQK(
     float* cross_qk_output,
     int num_return_sequences,
     const int* cache_indir_data,
-    gsl::span<const int32_t> beam_indices
+    gsl::span<const int32_t> beam_indices,
+    const transformers::IConsoleDumper* dumper,
+    int real_decoded_length
 );
 
 }  // namespace GenerationCpuDeviceHelper

--- a/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.h
@@ -209,8 +209,7 @@ using UpdateDecoderCrossQKFunc = std::function<Status(
     AllocatorPtr allocator,
     gsl::span<const int32_t> beam_indices_gpu,
     OrtValue cross_qk_buffer_value,
-    int num_beams,
-    const transformers::IConsoleDumper* dumper)>;
+    int num_beams)>;
 
 
 using FinalizeDecoderCrossQKFunc = std::function<Status(
@@ -227,8 +226,7 @@ using FinalizeDecoderCrossQKFunc = std::function<Status(
     float* cross_qk_output,
     int num_return_sequences,
     const int* cache_indir_data,
-    gsl::span<const int32_t> beam_indices,
-    int real_decoded_length)>;
+    gsl::span<const int32_t> beam_indices)>;
 
 }  // namespace GenerationDeviceHelper
 
@@ -406,8 +404,7 @@ Status UpdateDecoderCrossQK(
     AllocatorPtr allocator,
     gsl::span<const int32_t> beam_indices_gpu,
     OrtValue cross_qk_buffer_value,
-    int num_beams,
-    const transformers::IConsoleDumper* dumper
+    int num_beams
 );
 
 Status FinalizeDecoderCrossQK(
@@ -424,8 +421,7 @@ Status FinalizeDecoderCrossQK(
     float* cross_qk_output,
     int num_return_sequences,
     const int* cache_indir_data,
-    gsl::span<const int32_t> beam_indices,
-    int real_decoded_length
+    gsl::span<const int32_t> beam_indices
 );
 
 }  // namespace GenerationCpuDeviceHelper

--- a/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.h
@@ -228,7 +228,6 @@ using FinalizeDecoderCrossQKFunc = std::function<Status(
     int num_return_sequences,
     const int* cache_indir_data,
     gsl::span<const int32_t> beam_indices,
-    const transformers::IConsoleDumper* dumper,
     int real_decoded_length)>;
 
 }  // namespace GenerationDeviceHelper
@@ -426,7 +425,6 @@ Status FinalizeDecoderCrossQK(
     int num_return_sequences,
     const int* cache_indir_data,
     gsl::span<const int32_t> beam_indices,
-    const transformers::IConsoleDumper* dumper,
     int real_decoded_length
 );
 

--- a/onnxruntime/contrib_ops/cpu/utils/console_dumper.h
+++ b/onnxruntime/contrib_ops/cpu/utils/console_dumper.h
@@ -9,7 +9,7 @@ namespace onnxruntime {
 namespace contrib {
 namespace transformers {
 
-// #define DEBUG_GENERATION 1  // uncomment it for debugging generation (like beam search etc)
+#define DEBUG_GENERATION 1  // uncomment it for debugging generation (like beam search etc)
 #ifdef DEBUG_GENERATION
 #define DUMP_TENSOR_LEVEL 2
 #else

--- a/onnxruntime/contrib_ops/cpu/utils/console_dumper.h
+++ b/onnxruntime/contrib_ops/cpu/utils/console_dumper.h
@@ -9,7 +9,7 @@ namespace onnxruntime {
 namespace contrib {
 namespace transformers {
 
-#define DEBUG_GENERATION 1  // uncomment it for debugging generation (like beam search etc)
+// #define DEBUG_GENERATION 1  // uncomment it for debugging generation (like beam search etc)
 #ifdef DEBUG_GENERATION
 #define DUMP_TENSOR_LEVEL 2
 #else

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_cuda_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_cuda_impl.cu
@@ -1082,8 +1082,8 @@ __global__ void CopyDecoderCrossQKAllStepsKernel(
   const int batch = br / num_return_sequences;
   const int ret_seq_id = br % num_return_sequences;
 
-  // get the real beam index, as the cache_indir_data did not updated in last token
-  const int src_beam = beam_indices[batch * num_beams + ret_seq_id] % num_beams;
+  // We shuffled around indices in UpdateDecoderCrossQK, so the desired beam will always be index 0
+  const int src_beam = 0;//beam_indices[batch * num_beams + ret_seq_id] % num_beams;
 
   const int64_t offset_in_cache = ((int64_t)batch * num_beams + src_beam) * max_length + token_decoding_index + context_decoding_len;
   int bm_mapped = ((num_beams <= 1) ? 0: ((token_decoding_index == total_decoding_length - 1) ?  ret_seq_id : cache_indir_data[offset_in_cache]));

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_cuda_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_cuda_impl.cu
@@ -1082,7 +1082,6 @@ __global__ void CopyDecoderCrossQKAllStepsKernel(
   const int batch = br / num_return_sequences;
   const int ret_seq_id = br % num_return_sequences;
 
-  // We shuffled around indices in UpdateDecoderCrossQK, so the desired beam will always be index 0
   const int src_beam = beam_indices[batch * num_beams + ret_seq_id] % num_beams;
 
   const int64_t offset_in_cache = ((int64_t)batch * num_beams + src_beam) * max_length + token_decoding_index + context_decoding_len;
@@ -1093,8 +1092,8 @@ __global__ void CopyDecoderCrossQKAllStepsKernel(
   const T* src = cross_qk_buffer_data +
           ((int64_t)bi_src * layer_head_pair_count * max_length + (int64_t)pair * max_length + token_decoding_index) * frames_of_k;
   for (int tid = threadIdx.x; tid < frames_of_k; tid += blockDim.x) {
-      target[tid] = src[tid]; // use vectorized read write in future if needed
-    }
+    target[tid] = src[tid]; // use vectorized read write in future if needed
+  }
 }
 
 void LaunchFinalizeCrossQK(

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_cuda_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_cuda_impl.cu
@@ -1100,7 +1100,7 @@ __global__ void CopyDecoderCrossQKAllStepsKernel(
 
 void LaunchFinalizeCrossQK(
     cudaStream_t stream,
-    int iteration_number,
+    int real_decoding_len,
     int context_decoding_len,
     int batch_size,
     int num_beams,
@@ -1116,7 +1116,7 @@ void LaunchFinalizeCrossQK(
 ) {
   int64_t br = (int64_t)batch_size * num_return_sequences;
   ORT_ENFORCE(br < 65536L && cross_qk_layer_head_pair_count < 65536);
-  const int total_decoding_length = 28;
+  const int total_decoding_length = real_decoding_len - 1;
   dim3 block(512);
   dim3 grid(total_decoding_length, cross_qk_layer_head_pair_count, (unsigned)br);
   typedef typename ToCudaType<float>::MappedType CudaT;

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_cuda_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_cuda_impl.cu
@@ -1116,7 +1116,7 @@ void LaunchFinalizeCrossQK(
 ) {
   int64_t br = (int64_t)batch_size * num_return_sequences;
   ORT_ENFORCE(br < 65536L && cross_qk_layer_head_pair_count < 65536);
-  const int total_decoding_length = iteration_number - 1;
+  const int total_decoding_length = 28;
   dim3 block(512);
   dim3 grid(total_decoding_length, cross_qk_layer_head_pair_count, (unsigned)br);
   typedef typename ToCudaType<float>::MappedType CudaT;

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.cc
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.cc
@@ -1486,7 +1486,9 @@ Status UpdateDecoderCrossQK(
     const int* cross_qk_layer_head_pairs,
     float* cross_qk_buffer_data,
     int max_length,
-    AllocatorPtr allocator) {
+    AllocatorPtr allocator,
+    gsl::span<const int32_t> beam_indices_gpu,
+    OrtValue cross_qk_buffer_value) {
   cudaStream_t cuda_stream = stream ? static_cast<cudaStream_t>(stream->GetHandle()) : nullptr;
 
   if (qk_layer_pointers.get() == nullptr) {
@@ -1521,6 +1523,34 @@ Status UpdateDecoderCrossQK(
 
   CUDA_RETURN_IF_ERROR(cudaGetLastError());
 
+  // Shuffle according to new beam_indices
+  cudaStreamSynchronize(cuda_stream);
+
+  const TensorShape& cross_qk_shape = cross_qk_buffer_value.Get<Tensor>().Shape();
+  // Create a tensor with same shape to copy shuffled data to.
+  OrtValue shuffled_cross_qk;
+  auto cross_qk_type = cross_qk_buffer_value.Get<Tensor>().DataType();
+  Tensor::InitOrtValue(cross_qk_type, cross_qk_shape, allocator, shuffled_cross_qk);
+
+  // TODO: Replace this value
+  auto block_size_per_beam = cross_qk_shape[0];
+
+  gsl::span<float> old_cross_qk_span = gsl::make_span<float>(cross_qk_buffer_value.GetMutable<Tensor>()->MutableData<float>(), onnxruntime::narrow<size_t>(cross_qk_shape.Size()));
+  gsl::span<float> new_cross_qk_span = gsl::make_span<float>(shuffled_cross_qk.GetMutable<Tensor>()->MutableData<float>(), onnxruntime::narrow<size_t>(cross_qk_shape.Size()));
+
+  for (size_t j = 0; j < beam_indices_gpu.size(); j++) {
+    // Copying from j to beam_index[j]
+    int32_t beam_index = beam_indices_gpu[j];
+    // TODO: Do pointer arithmatic right here to index old and new data by beam_indexs
+    gsl::span<float> new_cross_qk = new_cross_qk_span.subspan(beam_index * SafeInt<size_t>(block_size_per_beam), onnxruntime::narrow<size_t>(block_size_per_beam));
+    gsl::span<float> old_cross_qk = old_cross_qk_span.subspan(j * SafeInt<size_t>(block_size_per_beam), onnxruntime::narrow<size_t>(block_size_per_beam));
+    // Make this memcpy work with proper pointer data
+    CUDA_RETURN_IF_ERROR(cudaMemcpyAsync((void*)new_cross_qk.get(), old_cross_qk, sizeof(float) * num_layers,
+                                         cudaMemcpyDeviceToDevice, cuda_stream));
+  }
+
+  cross_qk_buffer_data = shuffled_cross_qk.data();
+
   return Status::OK();
 }
 
@@ -1534,7 +1564,7 @@ Status FinalizeDecoderCrossQK(
     int cross_qk_layer_head_pair_count,
     const int* cross_qk_layer_head_pairs,
     int frames_of_k,
-    const float* cross_qk_buffer_data,
+    float* cross_qk_buffer_data,
     float* cross_qk_output,
     int num_return_sequences,
     const int* cache_indir_data,

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.cc
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.cc
@@ -1489,8 +1489,7 @@ Status UpdateDecoderCrossQK(
     AllocatorPtr allocator,
     gsl::span<const int32_t> beam_indices_gpu,
     OrtValue cross_qk_buffer_value,
-    int num_beams,
-    const transformers::IConsoleDumper* dumper) {
+    int num_beams) {
   cudaStream_t cuda_stream = stream ? static_cast<cudaStream_t>(stream->GetHandle()) : nullptr;
 
   if (qk_layer_pointers.get() == nullptr) {
@@ -1525,6 +1524,7 @@ Status UpdateDecoderCrossQK(
 
   CUDA_RETURN_IF_ERROR(cudaGetLastError());
 
+  
   // Shuffle according to new beam_indices
   cudaStreamSynchronize(cuda_stream);
 
@@ -1556,9 +1556,6 @@ Status UpdateDecoderCrossQK(
   }
 
   cross_qk_buffer_data = new_cross_qk_span.data();
-
-  //dumper->Print("Cross_QK_Scores update:", cross_qk_buffer_data, batchxbeam, max_length, frames); //batchxbeam, layer_head_pair_count, max_length, frame
-
   return Status::OK();
 }
 
@@ -1576,14 +1573,13 @@ Status FinalizeDecoderCrossQK(
     float* cross_qk_output,
     int num_return_sequences,
     const int* cache_indir_data,
-    gsl::span<const int32_t> beam_indices_gpu,
-    int real_decoded_length) {
+    gsl::span<const int32_t> beam_indices_gpu) {
   cudaStream_t cuda_stream = stream ? static_cast<cudaStream_t>(stream->GetHandle()) : nullptr;
 
   
   cuda::LaunchFinalizeCrossQK(
     cuda_stream,
-    real_decoded_length,
+    iteration_number,
     context_decoding_len,
     batch_size,
     num_beams,

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.cc
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.cc
@@ -1488,7 +1488,7 @@ Status UpdateDecoderCrossQK(
     int max_length,
     AllocatorPtr allocator,
     gsl::span<const int32_t> beam_indices_gpu,
-    OrtValue cross_qk_buffer_value,
+    OrtValue& cross_qk_buffer_value,
     int num_beams) {
   cudaStream_t cuda_stream = stream ? static_cast<cudaStream_t>(stream->GetHandle()) : nullptr;
 
@@ -1524,6 +1524,9 @@ Status UpdateDecoderCrossQK(
 
   CUDA_RETURN_IF_ERROR(cudaGetLastError());
 
+  cudaDeviceSynchronize();
+  /*
+
   
   // Shuffle according to new beam_indices
 
@@ -1554,7 +1557,9 @@ Status UpdateDecoderCrossQK(
                                         cudaMemcpyDeviceToDevice, cuda_stream));
   }
 
-  cross_qk_buffer_data = new_cross_qk_span.data();
+  cross_qk_buffer_value = std::move(shuffled_cross_qk);
+  cudaStreamSynchronize(cuda_stream);
+  */
   return Status::OK();
 }
 

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.cc
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.cc
@@ -1526,7 +1526,6 @@ Status UpdateDecoderCrossQK(
 
   
   // Shuffle according to new beam_indices
-  cudaStreamSynchronize(cuda_stream);
 
   const TensorShape& cross_qk_shape = cross_qk_buffer_value.Get<Tensor>().Shape(); // shape [batchxbeam, layer_head_pair_count, max_length, frame]
                                                                                    

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.cc
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.cc
@@ -1577,16 +1577,13 @@ Status FinalizeDecoderCrossQK(
     int num_return_sequences,
     const int* cache_indir_data,
     gsl::span<const int32_t> beam_indices_gpu,
-    const transformers::IConsoleDumper* dumper,
     int real_decoded_length) {
   cudaStream_t cuda_stream = stream ? static_cast<cudaStream_t>(stream->GetHandle()) : nullptr;
 
-  // Print output here:
-  //dumper->Print("Cross_QK_Scores Finalize:", cross_qk_buffer_data, batch_size * num_beams, *cross_qk_layer_head_pairs, max_length, frames_of_k); //batchxbeam, layer_head_pair_count, max_length, frame
-
+  
   cuda::LaunchFinalizeCrossQK(
     cuda_stream,
-    iteration_number,
+    real_decoded_length,
     context_decoding_len,
     batch_size,
     num_beams,
@@ -1599,11 +1596,6 @@ Status FinalizeDecoderCrossQK(
     num_return_sequences,
     cache_indir_data,
     beam_indices_gpu.data());
-
-  // Print output here:
-  std::cout << "Iteration_number: " << iteration_number << std::endl;
-  std::cout << "Context decoding number: " << context_decoding_len << std::endl;
-  //dumper->Print("Cross_QK_Output:", cross_qk_output, batch_size, cross_qk_layer_head_pair_count, iteration_number - 1, frames_of_k); //batchxbeam, layer_head_pair_count, max_length, frame
 
   CUDA_RETURN_IF_ERROR(cudaGetLastError());
 

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.h
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.h
@@ -159,7 +159,8 @@ Status UpdateDecoderCrossQK(
     int max_length,
     AllocatorPtr allocator,
     gsl::span<const int32_t> beam_indices_gpu,
-    OrtValue cross_qk_buffer_value);
+    OrtValue cross_qk_buffer_value,
+    int num_beams);
 
 Status FinalizeDecoderCrossQK(
     Stream* stream,

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.h
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.h
@@ -160,7 +160,9 @@ Status UpdateDecoderCrossQK(
     AllocatorPtr allocator,
     gsl::span<const int32_t> beam_indices_gpu,
     OrtValue cross_qk_buffer_value,
-    int num_beams);
+    int num_beams,
+    const transformers::IConsoleDumper* dumper
+    );
 
 Status FinalizeDecoderCrossQK(
     Stream* stream,
@@ -176,7 +178,9 @@ Status FinalizeDecoderCrossQK(
     float* cross_qk_output,
     int num_return_sequences,
     const int* cache_indir_data,
-    gsl::span<const int32_t> beam_indices);
+    gsl::span<const int32_t> beam_indices,
+    const transformers::IConsoleDumper* dumper,
+    int real_decoded_length);
 
 }  // namespace GenerationCudaDeviceHelper
 }  // namespace contrib

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.h
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.h
@@ -160,8 +160,7 @@ Status UpdateDecoderCrossQK(
     AllocatorPtr allocator,
     gsl::span<const int32_t> beam_indices_gpu,
     OrtValue cross_qk_buffer_value,
-    int num_beams,
-    const transformers::IConsoleDumper* dumper
+    int num_beams
     );
 
 Status FinalizeDecoderCrossQK(
@@ -178,8 +177,7 @@ Status FinalizeDecoderCrossQK(
     float* cross_qk_output,
     int num_return_sequences,
     const int* cache_indir_data,
-    gsl::span<const int32_t> beam_indices,
-    int real_decoded_length);
+    gsl::span<const int32_t> beam_indices);
 
 }  // namespace GenerationCudaDeviceHelper
 }  // namespace contrib

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.h
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.h
@@ -157,7 +157,9 @@ Status UpdateDecoderCrossQK(
     const int* cross_qk_layer_head_pairs,
     float* cross_qk_buffer_data,
     int max_length,
-    AllocatorPtr allocator);
+    AllocatorPtr allocator,
+    gsl::span<const int32_t> beam_indices_gpu,
+    OrtValue cross_qk_buffer_value);
 
 Status FinalizeDecoderCrossQK(
     Stream* stream,

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.h
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.h
@@ -179,7 +179,6 @@ Status FinalizeDecoderCrossQK(
     int num_return_sequences,
     const int* cache_indir_data,
     gsl::span<const int32_t> beam_indices,
-    const transformers::IConsoleDumper* dumper,
     int real_decoded_length);
 
 }  // namespace GenerationCudaDeviceHelper

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.h
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.h
@@ -159,7 +159,7 @@ Status UpdateDecoderCrossQK(
     int max_length,
     AllocatorPtr allocator,
     gsl::span<const int32_t> beam_indices_gpu,
-    OrtValue cross_qk_buffer_value,
+    OrtValue& cross_qk_buffer_value,
     int num_beams
     );
 


### PR DESCRIPTION
### Description
Currently, there is a bug in whisper-main where cross_qk outputs (outputs used to generate timestamps) don't function correctly when num_beams > 1. For example - showing `jump_times` output in current `whisper-main` with one data point:

Beam == 1: `[[ 0.    2.34  2.44  2.52  2.74  2.84  3.1   3.36  3.64  3.96  4.04  4.1
   4.36  4.58  4.76  5.36  6.72  7.24 12.36 13.42 15.5  19.28 19.74 20.2
  20.66]]`
  
Beam == 4: `[[ 0.    1.96  1.98  2.36  2.44  2.52  2.74  2.84  3.1   3.36  3.6   3.96
   4.    4.1   4.36  4.58  4.76  5.36  6.72  7.24  7.88 11.7  11.88 12.32
  13.36 14.36 14.92 15.56 19.28 19.74 20.2 ]]`
  
  
This is a result of two different causes:

1. When conducting Beam Search, ORT should be moving around data (ex. KV cache) between beam locations in memory. For example, in a single iteration of Beam Search, if one beam suddenly becomes the most likely sequence, we copy the data for that beam to the pointer we keep for the highest likelihood beam. Currently, cross_qk outputs aren't shuffled around in the same way, and so the ultimate cross_qk output will be comprised of a random mix of beams instead of one cohesive beam over time.

2. A bug in the way the beam index is handled when copying data from the cross_qk_data (holds data for all batches, all beams) to the cross_qk_output (all batches, top beam) - this is the replacement of `parameters->sequence_length` with `current_length`. 

  
After the change in this PR:

Beam == 1: `[[ 0.    2.34  2.44  2.52  2.74  2.84  3.1   3.36  3.64  3.96  4.04  4.1
   4.36  4.58  4.76  5.36  6.72  7.24 12.36 13.42 15.5  19.28 19.74 20.2
  20.66]]`
  
Beam == 4: `[[ 0.    2.34  2.44  2.52  2.74  2.84  3.1   3.36  3.64  3.96  4.04  4.1
   4.36  4.58  4.76  5.36  6.72  7.24 12.36 13.42 16.78 19.28 19.76 20.2
  20.66 21.8  29.98 29.98 29.98 29.98 29.98]]`
  
  
The extra tokens at the end of the last sequence is a known limitation that will be handled outside the Whisper model.


