### PR TITLE
Update QNN python packages to use QNN SDK version 2.19.2

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -475,9 +475,9 @@ stages:
       - template: py-win-arm64-qnn.yml
         parameters:
           MACHINE_POOL: 'onnxruntime-qnn-windows-vs-2022-arm64'
-          QNN_SDK: 'qnn-v2.18.0.240101_win'
+          QNN_SDK: 'qnn-v2.19.2.240210_win'
           PYTHON_VERSION: '3.11'
-          NUMPY_VERSION: '1.25.2'
+          NUMPY_VERSION: '1.26.4'
 
   - ${{ if eq(parameters.enable_windows_x64_qnn, true) }}:
     - stage: Python_Packaging_Windows_x64_QNN
@@ -486,4 +486,4 @@ stages:
         - template: py-win-x64-qnn.yml
           parameters:
             MACHINE_POOL: 'Onnxruntime-QNNEP-Windows-2022-CPU'
-            QNN_SDK: 'qnn-v2.18.0.240101_win'
+            QNN_SDK: 'qnn-v2.19.2.240210_win'

--- a/tools/ci_build/github/azure-pipelines/templates/py-win-arm64-qnn.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-win-arm64-qnn.yml
@@ -7,7 +7,7 @@ parameters:
 - name: QNN_SDK
   displayName: QNN Windows SDK path
   type: string
-  default: qnn-v2.18.0.240101_win
+  default: qnn-v2.19.2.240210_win
 
 - name: PYTHON_VERSION
   type: string
@@ -15,7 +15,7 @@ parameters:
 
 - name: NUMPY_VERSION
   type: string
-  default: '1.25.2'
+  default: '1.26.4'
 
 - name: ENV_SETUP_SCRIPT
   type: string

--- a/tools/ci_build/github/azure-pipelines/templates/py-win-x64-qnn.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-win-x64-qnn.yml
@@ -7,7 +7,7 @@ parameters:
 - name: QNN_SDK
   displayName: QNN Windows SDK path
   type: string
-  default: qnn-v2.18.0.240101_win
+  default: qnn-v2.19.2.240210_win
 
 - name: ENV_SETUP_SCRIPT
   type: string


### PR DESCRIPTION
### Description
Update QNN python packages to use QNN SDK version 2.19.2.



### Motivation and Context
Our CI builds already use QNN SDK version 2.19.2. We should make sure the ort-nightly-qnn python packages are also built with the same QNN SDK version.


