### PR TITLE
Fix GroupQueryAttention input size range error

### DIFF
--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -1062,11 +1062,13 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
         .Input(5,
                "seqlens_k",
                "1d Tensor of shape (batch_size). Indicates past sequence lengths for token generation case.",
-               "M")
+               "M",
+               OpSchema::Optional)
         .Input(6,
                "total_sequence_length",
                "Scalar tensor of total sequence length (past + new).",
-               "M")
+               "M",
+               OpSchema::Optional)
         .Input(7,
                "cos_cache",
                "2D tensor with shape (max_sequence_length, head_size / 2).",
@@ -1086,13 +1088,13 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
                 "present state key with support for format BNSH. When past_key uses same tensor as present_key"
                 "(k-v buffer), it is of length max_sequence_length... otherwise of length past_sequence_length +"
                 "kv_sequence_length.",
-                "T")
+                "T", OpSchema::Optional)
         .Output(2,
                 "present_value",
                 "present state value with support for format BNSH. When past_value uses same tensor as present_value"
                 "(k-v buffer), it is of length max_sequence_length... otherwise of length past_sequence_length +"
                 "kv_sequence_length.",
-                "T")
+                "T", OpSchema::Optional)
         .TypeConstraint("T", {"tensor(float16)", "tensor(bfloat16)"}, "Constrain input and output to float tensors.")
         .TypeConstraint("M", {"tensor(int32)"}, "Constrain mask to int tensor.")
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {


### PR DESCRIPTION
onnxruntime.capi.onnxruntime_pybind11_state.InvalidGraph: [ONNXRuntimeError] : 10 : INVALID_GRAPH : This is an invalid model. In Node, ("GroupQueryAttention_0", GroupQueryAttention, "com.microsoft", -1) : ("query": tensor(float16),"key": tensor(float16),"value": tensor(float16),"past_key": tensor(float16),"past_value": tensor(float16),"",) -> ("output": tensor(float16),"present_key": tensor(float16),"present_value": tensor(float16),) , Error Node (GroupQueryAttention_0) has input size 6 not in range [min=7, max=9].

### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


