### PR TITLE
Fix shape conv fuse opt

### DIFF
--- a/onnxruntime/core/optimizer/conv_activation_fusion.cc
+++ b/onnxruntime/core/optimizer/conv_activation_fusion.cc
@@ -28,16 +28,14 @@ const Node* GetLoneConsumerNode(const GraphViewer& graph_viewer, const Node& nod
   const size_t input_edges_total = next_node->GetInputEdgesCount();
   int non_const_edges = 0;
   for (size_t edge_idx = 0; edge_idx < input_edges_total; ++edge_idx) {
-      if(!graph_utils::NodeArgIsConstant(graph_viewer.GetGraph(), *next_node->InputDefs()[edge_idx]))
-      {
-          ++non_const_edges;
-      }
+    if (!graph_utils::NodeArgIsConstant(graph_viewer.GetGraph(), *next_node->InputDefs()[edge_idx])) {
+      ++non_const_edges;
+    }
   }
-  if (non_const_edges > 1)
-  {
-      return nullptr;
+  if (non_const_edges > 1) {
+    return nullptr;
   } else {
-      return next_node;
+    return next_node;
   }
 }
 
@@ -153,10 +151,6 @@ class ConvAddRelu : public NodeSelector {
     // only for CUDA EP
     if (node_ep != kCudaExecutionProvider) {
       return std::nullopt;
-    }
-    if (node.Name() == "Conv_3009")
-    {
-        [[maybe_unused]] int x = 0;
     }
 
     if (!ConvFusionDataTypeCheck(node)) {

--- a/onnxruntime/core/optimizer/conv_activation_fusion.cc
+++ b/onnxruntime/core/optimizer/conv_activation_fusion.cc
@@ -25,9 +25,9 @@ const Node* GetLoneConsumerNode(const GraphViewer& graph_viewer, const Node& nod
   }
   const Node* next_node = &*node.OutputNodesBegin();
   // ensure that the target node also has only one input that is not an initializer
-  const int input_edges_total = next_node->GetInputEdgesCount();
+  const size_t input_edges_total = next_node->GetInputEdgesCount();
   int non_const_edges = 0;
-  for (int edge_idx = 0; edge_idx < input_edges_total; ++edge_idx) {
+  for (size_t edge_idx = 0; edge_idx < input_edges_total; ++edge_idx) {
       if(!graph_utils::NodeArgIsConstant(graph_viewer.GetGraph(), *next_node->InputDefs()[edge_idx]))
       {
           ++non_const_edges;

--- a/onnxruntime/core/optimizer/shape_input_merge.cc
+++ b/onnxruntime/core/optimizer/shape_input_merge.cc
@@ -58,13 +58,13 @@ Status ShapeInputMerge::ApplyImpl(Graph& graph, bool& modified, int graph_level,
     for (size_t i = 1; i < kv.second.size(); ++i) {
       Node* p_node = kv.second[i];
       const NodeArg* input_arg = p_node->InputDefs()[0];
-      if (input_arg->Name() == first_input_arg->Name() || !p_node->GetInputEdgesCount()) continue;
-      if (!graph.IsInputsIncludingInitializers(input_arg)) {
+      if (input_arg->Name() == first_input_arg->Name()) continue;
+      if (!graph.IsInputsIncludingInitializers(input_arg) && p_node->GetInputEdgesCount()) {
         const Node::EdgeEnd& input_edge = *p_node->InputEdgesBegin();
         graph.RemoveEdge(input_edge.GetNode().Index(), p_node->Index(), input_edge.GetSrcArgIndex(), 0);
       }
       graph_utils::ReplaceNodeInput(*p_node, 0, *first_input_arg);
-      if (!is_first_input_arg_graph_input) {
+      if (!is_first_input_arg_graph_input && kv.second[0]->GetInputEdgesCount()) {
         const Node::EdgeEnd& first_input_edge = *kv.second[0]->InputEdgesBegin();
         graph.AddEdge(first_input_edge.GetNode().Index(), p_node->Index(), first_input_edge.GetSrcArgIndex(), 0);
       }

--- a/onnxruntime/core/optimizer/shape_input_merge.cc
+++ b/onnxruntime/core/optimizer/shape_input_merge.cc
@@ -58,7 +58,7 @@ Status ShapeInputMerge::ApplyImpl(Graph& graph, bool& modified, int graph_level,
     for (size_t i = 1; i < kv.second.size(); ++i) {
       Node* p_node = kv.second[i];
       const NodeArg* input_arg = p_node->InputDefs()[0];
-      if (p_node->InputDefs()[0]->Name() == first_input_arg->Name()) continue;
+      if (input_arg->Name() == first_input_arg->Name() || !p_node->GetInputEdgesCount()) continue;
       if (!graph.IsInputsIncludingInitializers(input_arg)) {
         const Node::EdgeEnd& input_edge = *p_node->InputEdgesBegin();
         graph.RemoveEdge(input_edge.GetNode().Index(), p_node->Index(), input_edge.GetSrcArgIndex(), 0);


### PR DESCRIPTION
### Description

FIx:
- Multiples Convs into an Add+Relu will fuse the op although intermediates are needed @tianleiwu for viz
   ![image](https://github.com/microsoft/onnxruntime/assets/44298237/0c85a30c-5f41-4e62-ae2e-f41eada6c2c3)
- Also fixes an issue with Shape Initializers Merge as input, that occurs when the input initializer is the same across multiple nodes but not all nodes are Shape nodes. @er3x3 for viz

