### PR TITLE
Fix binary size check build publish step.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/android-binary-size-check-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/android-binary-size-check-stage.yml
@@ -112,7 +112,7 @@ stages:
             echo "File not found: ${BINARY_SIZE_DATA_FILE}"
             exit 1
           fi
-          /usr/bin/python3 -m pip install -r $(Build.SourcesDirectory)/tools/ci_build/github/windows/post_to_dashboard/requirements.txt && \
+          /usr/bin/python3 -m pip install --user -r $(Build.SourcesDirectory)/tools/ci_build/github/windows/post_to_dashboard/requirements.txt && \
           /usr/bin/python3 $(Build.SourcesDirectory)/tools/ci_build/github/windows/post_binary_sizes_to_dashboard.py \
             --commit_hash=$(Build.SourceVersion) \
             --size_data_file="${BINARY_SIZE_DATA_FILE}" \


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Add `--user` option to pip install command.

Error:
```
ERROR: Could not install packages due to an OSError: [Errno 13] Permission denied: '/usr/local/bin/f2py'
Consider using the `--user` option or check the permissions.
```

See #19877.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix publishing of binary size data.