### PR TITLE
pin controlnet_aux version to 0.0.7 to fix Big Models Stable Diffusion pipeline failure

### DIFF
--- a/onnxruntime/python/tools/transformers/models/stable_diffusion/requirements.txt
+++ b/onnxruntime/python/tools/transformers/models/stable_diffusion/requirements.txt
@@ -9,7 +9,7 @@ packaging
 protobuf==3.20.3
 psutil
 sympy
-controlnet_aux
+controlnet_aux==0.0.7
 # The following are for SDXL
 optimum==1.14.1
 safetensors


### PR DESCRIPTION
conflict in cv2 causes
"    LayerId = cv2.dnn.DictValue
AttributeError: module 'cv2.dnn' has no attribute 'DictValue'
"
controlnet_aux 0.0.8 pulls in a conflicting version of opencv-python 
pin to 0.0.7

failing pipeline passes with this change:
https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=1348876&view=results