### PR TITLE
[Fix] Random connection exceptions in MacOS_C_API_Packaging_CPU stage

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/download-deps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/download-deps.yml
@@ -12,7 +12,7 @@ steps:
       feed: '/7424c8e4-5c62-490e-95c4-79446f31017c'
       definition: '517c4f6f-5437-4392-a70d-4f15ec5be2f0'
       version: 1.0.150
-      downloadPath: $(Build.BinariesDirectory)/deps
+      downloadPath: $(Build.BinariesDirectory)/_deps
 
 # The private ADO project
 - ${{ if eq(variables['System.CollectionId'], 'bc038106-a83b-4dab-9dd3-5a41bc58f34c') }}:
@@ -23,6 +23,6 @@ steps:
       feed: '/4c7631f5-24c0-4307-8822-1aa8f180c325'
       definition: 'fd9dd5ad-b73e-4678-890e-edcf680dbc1a'
       version: 1.0.150
-      downloadPath: $(Build.BinariesDirectory)/deps
+      downloadPath: $(Build.BinariesDirectory)/_deps
 
 # You can add more ADO accounts at here.

--- a/tools/ci_build/github/azure-pipelines/templates/download-deps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/download-deps.yml
@@ -12,7 +12,7 @@ steps:
       feed: '/7424c8e4-5c62-490e-95c4-79446f31017c'
       definition: '517c4f6f-5437-4392-a70d-4f15ec5be2f0'
       version: 1.0.150
-      downloadPath: $(Build.BinariesDirectory)/_deps
+      downloadPath: $(Build.BinariesDirectory)/deps
 
 # The private ADO project
 - ${{ if eq(variables['System.CollectionId'], 'bc038106-a83b-4dab-9dd3-5a41bc58f34c') }}:
@@ -23,6 +23,6 @@ steps:
       feed: '/4c7631f5-24c0-4307-8822-1aa8f180c325'
       definition: 'fd9dd5ad-b73e-4678-890e-edcf680dbc1a'
       version: 1.0.150
-      downloadPath: $(Build.BinariesDirectory)/_deps
+      downloadPath: $(Build.BinariesDirectory)/deps
 
 # You can add more ADO accounts at here.

--- a/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packing-jobs.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packing-jobs.yml
@@ -66,6 +66,13 @@ jobs:
 
   - template: download-deps.yml
 
+  - task: PythonScript@0
+    displayName: 'Update deps.txt'
+    inputs:
+      scriptPath: $(Build.SourcesDirectory)/tools/ci_build/replace_urls_in_deps.py
+      arguments: --new_dir $(Build.BinariesDirectory)/deps
+      workingDirectory: $(Build.BinariesDirectory)
+
   - template: mac-build-step-with-cache.yml
     parameters:
       WithCache: ${{ parameters.WithCache }}

--- a/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packing-jobs.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packing-jobs.yml
@@ -64,7 +64,7 @@ jobs:
     parameters:
       xcodeVersion: 14.2
 
-  - template: templates/download-deps.yml
+  - template: download-deps.yml
 
   - template: mac-build-step-with-cache.yml
     parameters:

--- a/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packing-jobs.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packing-jobs.yml
@@ -64,6 +64,8 @@ jobs:
     parameters:
       xcodeVersion: 14.2
 
+  - template: templates/download-deps.yml
+
   - template: mac-build-step-with-cache.yml
     parameters:
       WithCache: ${{ parameters.WithCache }}


### PR DESCRIPTION
### Description
Add download_deps to reduce downloading from 3rd party websites.


### Motivation and Context
Fix frequent random exception like
```
CMake Error at abseil_cpp-subbuild/abseil_cpp-populate-prefix/src/abseil_cpp-populate-stamp/download-abseil_cpp-populate.cmake:162 (message):
  Each download failed!

    error: downloading 'https://github.com/abseil/abseil-cpp/archive/refs/tags/20240116.0.zip' failed
          status_code: 35
          status_string: "SSL connect error"
          log:
          --- LOG BEGIN ---
            Trying 20.29.134.23:443...

  Connected to github.com (20.29.134.23) port 443

  ALPN: curl offers h2,http/1.1

  (304) (OUT), TLS handshake, Client hello (1):

  [315 bytes data]

   CAfile: /etc/ssl/cert.pem
   CApath: none

  Recv failure: Operation timed out

  LibreSSL/3.3.6: error:02FFF03C:system library:func(4095):Operation timed
  out

  Closing connection
```
https://dev.azure.com/aiinfra/Lotus/_build/results?buildId=443278&view=logs&j=006a7a04-d43b-5fe1-df02-ecafb79c4d6e&t=110edd38-9f3b-50cf-b328-8ed0f915e5c1

