### PR TITLE
Whisper Beam search word level timings fix

### DIFF
--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_base.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_base.h
@@ -91,7 +91,6 @@ struct BeamSearchCpuState : IBeamSearchCpuState {
       : parameters_{parameters} {
     sequence_lengths = AllocateBuffer<int32_t>(allocator, sequence_lengths_buffer_, batch_beam_size_, stream);
 
-    // Allocate the sequence & indices buffers back to back
     size_t sequences_bytes = SafeInt<size_t>(2) * batch_beam_size_ * parameters.max_length;
     sequences_space = AllocateBuffer<int32_t>(allocator, sequences_space_buffer_, sequences_bytes, stream, true /* fill */);
     indices_space = AllocateBuffer<int32_t>(allocator, indices_space_buffer_, sequences_bytes / 2, stream, false /* fill */);

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_base.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_base.h
@@ -91,9 +91,11 @@ struct BeamSearchCpuState : IBeamSearchCpuState {
       : parameters_{parameters} {
     sequence_lengths = AllocateBuffer<int32_t>(allocator, sequence_lengths_buffer_, batch_beam_size_, stream);
 
+    // Allocate the sequence & indices buffers back to back
     size_t sequences_bytes = SafeInt<size_t>(2) * batch_beam_size_ * parameters.max_length;
     sequences_space = AllocateBuffer<int32_t>(allocator, sequences_space_buffer_, sequences_bytes, stream, true /* fill */);
-    sequences.Init(sequences_space, batch_beam_size_, parameters.sequence_length, parameters.max_length);
+    indices_space = AllocateBuffer<int32_t>(allocator, indices_space_buffer_, sequences_bytes / 2, stream, false /* fill */);
+    sequences.Init(sequences_space, indices_space, batch_beam_size_, parameters.sequence_length, parameters.max_length);
 
     if (is_cuda) {
       // buffers used by CUDA operator but not by CPU operator.
@@ -137,6 +139,7 @@ struct BeamSearchCpuState : IBeamSearchCpuState {
   IAllocatorUniquePtr<void> topk_tokens_buffer_;
   IAllocatorUniquePtr<void> topk_indices_buffer_;
   IAllocatorUniquePtr<void> sequences_space_buffer_;
+  IAllocatorUniquePtr<void> indices_space_buffer_;
   IAllocatorUniquePtr<void> next_token_scores_buffer_;
 };
 

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_base.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_base.h
@@ -93,7 +93,7 @@ struct BeamSearchCpuState : IBeamSearchCpuState {
 
     size_t sequences_bytes = SafeInt<size_t>(2) * batch_beam_size_ * parameters.max_length;
     sequences_space = AllocateBuffer<int32_t>(allocator, sequences_space_buffer_, sequences_bytes, stream, true /* fill */);
-    indices_space = AllocateBuffer<int32_t>(allocator, indices_space_buffer_, sequences_bytes / 2, stream, false /* fill */);
+    indices_space = AllocateBuffer<int32_t>(allocator, indices_space_buffer_, sequences_bytes / 2, stream, true /* fill */);
     sequences.Init(sequences_space, indices_space, batch_beam_size_, parameters.sequence_length, parameters.max_length);
 
     if (is_cuda) {

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_gpt.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_gpt.h
@@ -380,6 +380,7 @@ Status BeamSearchGpt<T>::Execute(const FeedsFetchesManager* init_run_feeds_fetch
   this->beam_scorer_->Finalize(cpu_state.sequences,
                                final_beam_scores,
                                output_sequences,
+                               nullptr,
                                output_sequences_scores);
 
   // Output per token scores

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_t5.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_t5.h
@@ -379,6 +379,7 @@ Status BeamSearchT5<T>::Execute(const FeedsFetchesManager& encoder_feeds_fetches
   this->beam_scorer_->Finalize(cpu_state.sequences,
                                final_beam_scores,
                                output_sequences,
+                               nullptr,
                                output_sequences_scores);
 
   // Output per token scores

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_whisper.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_whisper.h
@@ -477,7 +477,7 @@ Status BeamSearchWhisper<T>::Execute(const FeedsFetchesManager& encoder_feeds_fe
     assert(this->IsCuda());
     ORT_RETURN_IF_ERROR(this->device_copy_int32_func_(gsl::span<int32_t>{cache_indir_data_device, cache_indir_data_size},
                                                       gsl::span<const int32_t>{cache_indir_data, cache_indir_data_size},
-                                                      nullptr,
+                                                      this->ort_stream_,
                                                       DeviceCopyDirection::hostToDevice));
 
     ORT_RETURN_IF_ERROR(this->finalize_decoder_cross_qk_func_(

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_whisper.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_whisper.h
@@ -480,7 +480,6 @@ Status BeamSearchWhisper<T>::Execute(const FeedsFetchesManager& encoder_feeds_fe
                                                       nullptr,
                                                       DeviceCopyDirection::hostToDevice));
 
-    size_t cache_indir_input_offset = static_cast<size_t>(decoder_subgraph_.GetFirstPastInputIndex()) + 4 * static_cast<size_t>(decoder_subgraph_.num_layers) + 2;
     ORT_RETURN_IF_ERROR(this->finalize_decoder_cross_qk_func_(
         this->ort_stream_,
         iteration_counter,
@@ -494,7 +493,7 @@ Status BeamSearchWhisper<T>::Execute(const FeedsFetchesManager& encoder_feeds_fe
         cross_qk_buffer_data,
         cross_qk_output->MutableData<float>(),
         parameters->num_return_sequences,
-        cache_indir_data_device, // cache_indir_data,
+        cache_indir_data_device,
         ReinterpretAsSpan<const int32_t>(beam_state.chosen_indices)));
   }
 

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_whisper.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_whisper.h
@@ -219,13 +219,13 @@ Status BeamSearchWhisper<T>::Execute(const FeedsFetchesManager& encoder_feeds_fe
 
   // for decoder subgraph output cross qk
   int64_t frames_of_k = 0LL;
-  Tensor* cross_qk_output = nullptr;  // output tensor
+  Tensor* cross_qk_output  = nullptr; // output tensor
   int64_t cross_qk_layer_head_pair_count = 0LL;
   OrtValue cross_qk_buffer_value;
   float* cross_qk_buffer_data = nullptr;
   std::vector<int32_t> cross_qk_all_layer_heads;
   const int32_t* cross_qk_layer_head_pairs = nullptr;
-  IAllocatorUniquePtr<float*> qk_layer_pointers;  // if needed, device array hold the cross qk data pointers, shape of [num_layers]
+  IAllocatorUniquePtr<float*> qk_layer_pointers; // if needed, device array hold the cross qk data pointers, shape of [num_layers]
 
   std::vector<OrtValue> decoder_fetches;
 
@@ -278,17 +278,17 @@ Status BeamSearchWhisper<T>::Execute(const FeedsFetchesManager& encoder_feeds_fe
       const auto* input_tensor_cross_qk_layer_head = this->context_.template Input<Tensor>(12);
       ORT_ENFORCE(input_tensor_cross_qk_layer_head != nullptr, "Must specify input cross_qk_layer_head");
       cross_qk_layer_head_pair_count = input_tensor_cross_qk_layer_head->Shape()[0];
-      cross_qk_layer_head_pairs = input_tensor_cross_qk_layer_head->template Data<int32_t>();  // it is on GPU
+      cross_qk_layer_head_pairs = input_tensor_cross_qk_layer_head->template Data<int32_t>(); // it is on GPU
 
       size_t decoder_input_first_cross_key = static_cast<size_t>(decoder_subgraph_.GetFirstPastInputIndex()) + (2 * decoder_subgraph_.num_layers);
       auto first_cross_attention_key = decoder_feeds[decoder_input_first_cross_key].GetMutable<Tensor>();
       frames_of_k = first_cross_attention_key->Shape()[2];
 
       TensorShape layer_cross_qk_shape{
-          static_cast<int64_t>(parameters->BatchBeamSize()),
-          static_cast<int64_t>(parameters->num_heads),
-          1LL,
-          static_cast<int64_t>(frames_of_k)};
+        static_cast<int64_t>(parameters->BatchBeamSize()),
+        static_cast<int64_t>(parameters->num_heads),
+        1LL,
+        static_cast<int64_t>(frames_of_k)};
       for (int layer = 0; layer < decoder_subgraph_.num_layers; layer++) {
         OrtValue cross_qk_value;
         Tensor::InitOrtValue(DataTypeImpl::GetType<float>(), layer_cross_qk_shape, this->temp_space_allocator_, cross_qk_value);
@@ -357,16 +357,16 @@ Status BeamSearchWhisper<T>::Execute(const FeedsFetchesManager& encoder_feeds_fe
     if (decoder_subgraph_.output_cross_qk_) {
       int decoder_output_first_cross_qk = decoder_subgraph_.GetFirstPresentOutputIndex() + (2 * decoder_subgraph_.num_layers);
       ORT_RETURN_IF_ERROR(this->update_decoder_cross_qk_func_(
-          iteration_counter,
-          this->ort_stream_,
-          &decoder_fetches[decoder_output_first_cross_qk],
-          qk_layer_pointers,
-          parameters->num_layers,
-          static_cast<int>(cross_qk_layer_head_pair_count),
-          cross_qk_layer_head_pairs,
-          cross_qk_buffer_data,
-          parameters->max_length,
-          this->temp_space_allocator_));
+        iteration_counter,
+        this->ort_stream_,
+        &decoder_fetches[decoder_output_first_cross_qk],
+        qk_layer_pointers,
+        parameters->num_layers,
+        static_cast<int>(cross_qk_layer_head_pair_count),
+        cross_qk_layer_head_pairs,
+        cross_qk_buffer_data,
+        parameters->max_length,
+        this->temp_space_allocator_));
     }
 
 #ifdef DEBUG_GENERATION
@@ -386,7 +386,7 @@ Status BeamSearchWhisper<T>::Execute(const FeedsFetchesManager& encoder_feeds_fe
 
     // When all batches are finished, stop earlier to avoid wasting computation.
     if (this->beam_scorer_->IsDone()) {
-      break;
+        break;
     }
 
     // Increase sequence length after a new token is generated.
@@ -444,7 +444,7 @@ Status BeamSearchWhisper<T>::Execute(const FeedsFetchesManager& encoder_feeds_fe
       static_cast<int64_t>(parameters->max_length)};
 
   OrtValue output_sequence_indices_value;
-  Tensor* output_sequence_indices{};
+  Tensor *output_sequence_indices{};
 
   if (decoder_subgraph_.output_cross_qk_) {
     Tensor::InitOrtValue(DataTypeImpl::GetType<int32_t>(), output_sequence_indices_shape, this->cpu_allocator_, output_sequence_indices_value);
@@ -494,9 +494,10 @@ Status BeamSearchWhisper<T>::Execute(const FeedsFetchesManager& encoder_feeds_fe
         cross_qk_buffer_data,
         cross_qk_output->MutableData<float>(),
         parameters->num_return_sequences,
-        cache_indir_data_device,  // cache_indir_data,
+        cache_indir_data_device, // cache_indir_data,
         ReinterpretAsSpan<const int32_t>(beam_state.chosen_indices)));
   }
+
 
   /*
   if (output_sequences_scores == nullptr || output_sequences_scores->IsDataType<float>()) {

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_scorer.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_scorer.cc
@@ -62,7 +62,7 @@ template <typename T>
 void BeamHypotheses::Output(
     int top_k,
     int max_length,
-    gsl::span<int32_t>& sequences,  // buffer filled with pad token ID, shape (num_return_sequences, max_length)
+    gsl::span<int32_t>& sequences,       // buffer filled with pad token ID, shape (num_return_sequences, max_length)
     gsl::span<int32_t>& indices,
     gsl::span<T>& sequences_scores)  // buffer of shape (num_return_sequences) or empty
 {
@@ -206,15 +206,15 @@ void BeamSearchScorer::Process(ISequences& sequences,
 
 template <typename T>
 void BeamSearchScorer::OutputSequenceScores(ISequences& sequences,
-                                            gsl::span<const float>& final_beam_scores,
-                                            Tensor* output_sequences,
-                                            Tensor* output_sequence_scores,
-                                            gsl::span<int32_t> output,
-                                            gsl::span<int32_t> output_indices) {
+                                gsl::span<const float>& final_beam_scores,
+                                Tensor* output_sequences,
+                                Tensor* output_sequence_scores, 
+                                gsl::span<int32_t> output,
+                                gsl::span<int32_t> output_indices){
   ORT_ENFORCE(output_sequences != nullptr);
 
   // Score of each sequence, with shape (batch_size * num_return_sequences).
-  // gsl::span<T> sequence_scores;
+  //gsl::span<T> sequence_scores;
   gsl::span<T> sequence_scores = output_sequence_scores->MutableDataAsSpan<T>();
   gsl::span<T> batch_sequence_score;
 

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_scorer.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_scorer.h
@@ -38,9 +38,9 @@ struct BeamHypotheses {
 
   // Output results
   template <typename T>
-  void Output(int top_k,                      // number of sequences to return
-              int max_length,                 // max sequence length
-              gsl::span<int32_t>& sequences,  // buffer with pad token, shape (num_return_sequences, max_length)
+  void Output(int top_k,                            // number of sequences to return
+              int max_length,                       // max sequence length
+              gsl::span<int32_t>& sequences,        // buffer with pad token, shape (num_return_sequences, max_length)
               gsl::span<int32_t>& indices,
               gsl::span<T>& sequences_scores);  // buffer for sequence scores, with shape (num_return_sequences)
 

--- a/onnxruntime/contrib_ops/cpu/transformers/generation_shared.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/generation_shared.h
@@ -48,6 +48,7 @@ struct IBeamSearchState {
 struct IBeamSearchCpuState {
   gsl::span<int32_t> sequence_lengths;  // shape (batch_size, num_beams), initial sequence length
   gsl::span<int32_t> sequences_space;   // shape (2, batch_size, num_beams, max_seq_length)
+  gsl::span<int32_t> indices_space;     // shape (2, batch_size, num_beams, max_seq_length) (same as sequences
 
   // The following are used only by CUDA operator for data copied from device.
   gsl::span<float> topk_scores;        // shape (batch_size, 2*num_beams), scores of topk candidates (K=2*num_beams).
@@ -97,6 +98,7 @@ struct ISamplingState {
 struct ISequences {
   virtual ~ISequences() {}
   virtual gsl::span<const int32_t> GetSequence(int beam_index) const = 0;
+  virtual gsl::span<const int32_t> GetSequenceIndices(int beam_index) const = 0;
   virtual int GetSequenceLength() const = 0;
 };
 
@@ -117,6 +119,7 @@ struct IBeamScorer {
   virtual void Finalize(ISequences& sequences,
                         gsl::span<const float>& final_beam_scores,
                         Tensor* output_sequences,
+                        Tensor* output_sequence_indices,
                         Tensor* output_sequence_scores) = 0;
 
   virtual gsl::span<int32_t>& GetNextIndices() = 0;

--- a/onnxruntime/contrib_ops/cpu/transformers/greedy_search_impl_base.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/greedy_search_impl_base.h
@@ -90,7 +90,7 @@ struct GreedySearchState : public IGreedySearchState<T> {
                                                     sequences_space_buffer_,
                                                     SafeInt<size_t>(2) * batch_size * max_length, stream);
     memset(this->sequences_space.data(), 0, this->sequences_space.size_bytes());
-    this->sequences.Init(this->sequences_space, static_cast<int>(batch_size), sequence_length, max_length);
+    this->sequences.Init(this->sequences_space, {}, static_cast<int>(batch_size), sequence_length, max_length);
 
     this->sequence_lengths = AllocateBuffer<int32_t>(cpu_allocator, sequence_lengths_buffer_, batch_size, stream);
     this->eos_meet = AllocateBuffer<bool>(cpu_allocator, eos_meet_buffer_, batch_size, stream);

--- a/onnxruntime/contrib_ops/cpu/transformers/sequences.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/sequences.cc
@@ -8,12 +8,14 @@ namespace onnxruntime {
 namespace contrib {
 namespace transformers {
 
-void Sequences::Init(gsl::span<int32_t> buffer, int batch_beam_size, int sequence_length, int max_length) {
+void Sequences::Init(gsl::span<int32_t> buffer, gsl::span<int32_t> indices_buffer, int batch_beam_size, int sequence_length, int max_length) {
   size_t sequences_size = SafeInt<size_t>(batch_beam_size) * max_length;
   assert(buffer.size() == sequences_size + sequences_size);
 
   sequences[0] = buffer.subspan(0, sequences_size);
   sequences[1] = buffer.subspan(sequences_size);
+
+  indices = indices_buffer;
 
   current_sequences_buffer = 0;
 
@@ -25,6 +27,10 @@ void Sequences::Init(gsl::span<int32_t> buffer, int batch_beam_size, int sequenc
 gsl::span<const int32_t> Sequences::GetSequence(int beam_index) const {
   gsl::span<const int32_t> buffer = sequences[current_sequences_buffer];
   return buffer.subspan(SafeInt<size_t>(beam_index) * max_length_, static_cast<gsl::index>(current_length_));
+}
+
+gsl::span<const int32_t> Sequences::GetSequenceIndices(int beam_index) const {
+  return indices.subspan(SafeInt<size_t>(beam_index) * max_length_, static_cast<gsl::index>(current_length_));
 }
 
 int Sequences::GetSequenceLength() const {

--- a/onnxruntime/contrib_ops/cpu/transformers/sequences.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/sequences.cc
@@ -30,6 +30,8 @@ gsl::span<const int32_t> Sequences::GetSequence(int beam_index) const {
 }
 
 gsl::span<const int32_t> Sequences::GetSequenceIndices(int beam_index) const {
+  if (indices.empty())
+    return {};
   return indices.subspan(SafeInt<size_t>(beam_index) * max_length_, static_cast<gsl::index>(current_length_));
 }
 

--- a/onnxruntime/contrib_ops/cpu/transformers/sequences.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/sequences.h
@@ -14,10 +14,11 @@ namespace transformers {
 class Sequences : public ISequences {
  public:
   // Initialize the sequence.
-  void Init(gsl::span<int32_t> buffer, int batch_beam_size, int sequence_length, int max_length);
+  void Init(gsl::span<int32_t> buffer, gsl::span<int32_t> indices_buffer, int batch_beam_size, int sequence_length, int max_length);
 
   // Returns a sequence of word IDs for a given beam index ( beam_index < batch_beam_size).
   gsl::span<const int32_t> GetSequence(int beam_index) const override;
+  gsl::span<const int32_t> GetSequenceIndices(int beam_index) const override;
 
   // Returns current sequence length.
   int GetSequenceLength() const override;
@@ -31,6 +32,7 @@ class Sequences : public ISequences {
   void AppendNextTokenToSequences(
       gsl::span<int32_t>& beam_indices,
       gsl::span<int32_t>& beam_next_tokens);
+  gsl::span<int32_t> GetIndexHistoryCPU() { return indices; }
 
   void AppendNextTokenToSequences(
       gsl::span<int32_t>& next_tokens);
@@ -40,6 +42,8 @@ class Sequences : public ISequences {
   // At each time, there is only one buffer is active. The other one will be active in next token.
   // Each AppendNextTokenToSequences call will trigger a rotation of active buffer.
   gsl::span<int32_t> sequences[2];
+
+  gsl::span<int32_t> indices;  // Past beam indices history (used for models like whisper for cross_qk_cache output history)
 
   // Index (either 0 or 1) of two buffers that is currently is active.
   int current_sequences_buffer;

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.cc
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.cc
@@ -448,7 +448,9 @@ Status ProcessLogits(const OrtValue& logits,                                 // 
 
   // NOTE: currently we treat extra decoding ids are same
   int extra_decoding_len = static_cast<int>(parameters->extra_decoding_ids.size() / parameters->batch_size);
-  const bool need_handle_extra_decoding_ids = is_whisper_model && (!parameters->extra_decoding_ids.empty()) && (extra_decoding_len >= step);
+  const bool need_handle_extra_decoding_ids = is_whisper_model
+                                               && (!parameters->extra_decoding_ids.empty())
+                                               && (extra_decoding_len >= step);
 
   cuda::LaunchLogitsProcessKernel<float>(
       next_token_scores.data(),
@@ -495,14 +497,14 @@ Status ProcessLogits(const OrtValue& logits,                                 // 
 
   if (need_handle_extra_decoding_ids && !parameters->extra_decoding_ids.empty()) {
     cuda::LaunchForceDecodingIds(
-        next_token_scores.data(),
-        parameters->batch_size,
-        parameters->num_beams,
-        parameters->vocab_size,
-        parameters->extra_decoding_ids.data(),
-        parameters->extra_decoding_ids.size() / parameters->batch_size,
-        step - 1,
-        cuda_stream);
+      next_token_scores.data(),
+      parameters->batch_size,
+      parameters->num_beams,
+      parameters->vocab_size,
+      parameters->extra_decoding_ids.data(),
+      parameters->extra_decoding_ids.size() / parameters->batch_size,
+      step - 1,
+      cuda_stream);
   }
 
 #ifdef DEBUG_GENERATION
@@ -1542,20 +1544,20 @@ Status FinalizeDecoderCrossQK(
   cudaStream_t cuda_stream = stream ? static_cast<cudaStream_t>(stream->GetHandle()) : nullptr;
 
   cuda::LaunchFinalizeCrossQK(
-      cuda_stream,
-      iteration_number,
-      context_decoding_len,
-      batch_size,
-      num_beams,
-      max_length,
-      cross_qk_layer_head_pair_count,
-      cross_qk_layer_head_pairs,
-      frames_of_k,
-      cross_qk_buffer_data,
-      cross_qk_output,
-      num_return_sequences,
-      cache_indir_data,
-      beam_indices_gpu.data());
+    cuda_stream,
+    iteration_number,
+    context_decoding_len,
+    batch_size,
+    num_beams,
+    max_length,
+    cross_qk_layer_head_pair_count,
+    cross_qk_layer_head_pairs,
+    frames_of_k,
+    cross_qk_buffer_data,
+    cross_qk_output,
+    num_return_sequences,
+    cache_indir_data,
+    beam_indices_gpu.data());
 
   CUDA_RETURN_IF_ERROR(cudaGetLastError());
 

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.cc
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.cc
@@ -1173,7 +1173,7 @@ Status UpdateDecoderFeeds(
                                                                   current_length,
                                                                   cuda_stream);
 
-      CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(sequences.GetIndexHistoryCPU().data(), cache_indirection.GetMutable<Tensor>()->MutableData<int32_t>(), sizeof(int32_t) * num_beams * max_sequence_length, cudaMemcpyDeviceToHost, cuda_stream));
+      CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(sequences.GetIndexHistoryCPU().data(), cache_indirection.GetMutable<Tensor>()->MutableData<int32_t>(), sizeof(int32_t) * batch_beam_size * max_sequence_length, cudaMemcpyDeviceToHost, cuda_stream));
 
       // Update cache indirection for next decoding run
       next_inputs[past_sequence_length_idx + 2] = cache_indirection;


### PR DESCRIPTION
### Description
With beam search, the jump_times output values were wrong. The cause was because the internal cross_qk_cache values used for it were being copied from the wrong indices.

With beam search, the winning sequences are pulled from the top of the "beam hypothesis" list, not the current batch of sequences. The issue was the cross_qk_cache indices were being pulled from the current batch of sequences.

The fix is to store the beam index ancestry with each beam hypothesis. Then to use that ancestry to generate the cross_qk_cache values.


