### PR TITLE
[VitisAI] Add Version Check. Requsted by Microsoft

### DIFF
--- a/onnxruntime/core/providers/vitisai/include/vaip/vaip_ort_api.h
+++ b/onnxruntime/core/providers/vitisai/include/vaip/vaip_ort_api.h
@@ -13,6 +13,14 @@ struct OrtApi;
 namespace vaip_core {
 
 struct OrtApiForVaip {
+  uint32_t magic;  // 'VAIP' or something else to make sure the following field
+                   // are not garbage.
+  uint32_t major;  // bump this field changes that are not backward compatible or
+                   // that represent a change in direction for the project
+  uint32_t minor;  // bump this field for adding new features without breaking
+                   // existing behavior
+  uint32_t patch;  // bump this field for fixing some bugs but not introducing
+                   // new functionality
   onnxruntime::ProviderHost* host_;
   const OrtApi* ort_api_;
   // model


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Add version for onnxruntime_providers_vitisai.dll. So, the onnxruntime_vitisai_ep.dll can check if the version is compatible.
To make sure the old onnxruntime_vitisai_ep.dll still work, we would offset the api struct by version field.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
This is the direct request from Microsoft. The following is the problem we try to solve:

How would you describe the dependency between (a) onnxruntime_vitisai_ep.dll and (b) onnxruntime_providers_vitisai.dll? E.g. for each version of (a) there is a minimum required version of (b), or for each version of (b) there is minimum required version of (a).

Please note that in practice we won't be able to use the exact version of ORT/EP that you tested against (because we might need to update ORT for other reasons), but we might be able to accommodate some version constraints that you specify. As we approach shipping, we'll lock the version of ORT/EP to allow for stabilization and more detailed testing (and work with you if it needs to be updated).