### PR TITLE
[Quant tool] Do not default to contrib Q/DQ ops for 16-bit

### DIFF
--- a/onnxruntime/python/tools/quantization/execution_providers/qnn/quant_config.py
+++ b/onnxruntime/python/tools/quantization/execution_providers/qnn/quant_config.py
@@ -168,7 +168,7 @@ def get_qnn_qdq_config(
     # ONNX opset < 21 does not support 16-bit quantization, so must use 'com.microsoft' domain
     # on Q/DQ operators if using 16-bit quantization.
     onnx_opset = next(x for x in model.opset_import if x.domain == "" or x.domain == "ai.onnx")
-    if onnx_opset < 21:
+    if onnx_opset.version < 21:
         overrides_have_int16 = any(t in Q16_TYPES for t in overrides_helper.get_quant_types())
         if activation_type in Q16_TYPES or weight_type in Q16_TYPES or overrides_have_int16:
             extra_options["UseQDQContribOps"] = True

--- a/onnxruntime/python/tools/quantization/execution_providers/qnn/quant_config.py
+++ b/onnxruntime/python/tools/quantization/execution_providers/qnn/quant_config.py
@@ -165,10 +165,13 @@ def get_qnn_qdq_config(
         "WeightSymmetric": weight_symmetric,
     }
 
-    # TODO: Remove this extra option once ORT uses an ONNX version that supports 16-bit Q/DQ ops.
-    overrides_have_int16 = any(t in Q16_TYPES for t in overrides_helper.get_quant_types())
-    if activation_type in Q16_TYPES or weight_type in Q16_TYPES or overrides_have_int16:
-        extra_options["UseQDQContribOps"] = True
+    # ONNX opset < 21 does not support 16-bit quantization, so must use 'com.microsoft' domain
+    # on Q/DQ operators if using 16-bit quantization.
+    onnx_opset = next(x for x in model.opset_import if x.domain == "" or x.domain == "ai.onnx")
+    if onnx_opset < 21:
+        overrides_have_int16 = any(t in Q16_TYPES for t in overrides_helper.get_quant_types())
+        if activation_type in Q16_TYPES or weight_type in Q16_TYPES or overrides_have_int16:
+            extra_options["UseQDQContribOps"] = True
 
     return StaticQuantConfig(
         calibration_data_reader,

--- a/onnxruntime/python/tools/quantization/qdq_quantizer.py
+++ b/onnxruntime/python/tools/quantization/qdq_quantizer.py
@@ -187,20 +187,22 @@ class QDQQuantizer(BaseQuantizer):
 
         self.qdq_op_domain = ms_domain if extra_options.get("UseQDQContribOps", False) else None
 
-        # The ONNX spec does not yet support 16-bit Q/DQ ops. So, must override the Q/DQ op domain to 'com.microsoft'
-        # if the activation or weight types are 16-bit integers.
-        # TODO: Remove this override (and use only the 'UseQDQContribOps' option) if/when ONNX adds 16-bit support.
-        int16_types = (TensorProto.UINT16, TensorProto.INT16)
-        overrides_have_int16 = any(t.tensor_type in int16_types for t in self.tensor_quant_override_qtypes)
-        if not self.qdq_op_domain and (
-            self.activation_qType in int16_types or self.weight_qType in int16_types or overrides_have_int16
-        ):
-            logging.warning(
-                "ONNX QuantizeLinear and DequantizeLinear operators do not support 16-bit integer quantization types. "
-                f"The domain of QuantizeLinear and DequantizeLinear operators will be set to '{ms_domain}' to "
-                "enable support."
-            )
-            self.qdq_op_domain = ms_domain
+        # The ONNX spec did not support 16-bit Q/DQ ops before opset 21.
+        # So, may have to override the Q/DQ op domain to 'com.microsoft' if the activation or weight types
+        # are 16-bit integers.
+        if self.opset_version < 21:
+            int16_types = (TensorProto.UINT16, TensorProto.INT16)
+            overrides_have_int16 = any(t.tensor_type in int16_types for t in self.tensor_quant_override_qtypes)
+            if not self.qdq_op_domain and (
+                self.activation_qType in int16_types or self.weight_qType in int16_types or overrides_have_int16
+            ):
+                logging.warning(
+                    "ONNX QuantizeLinear and DequantizeLinear operators do not support "
+                    "16-bit integer quantization types prior to opset 21. "
+                    f"The domain of QuantizeLinear and DequantizeLinear operators will be set to '{ms_domain}' to "
+                    "enable support."
+                )
+                self.qdq_op_domain = ms_domain
 
         self.quantization_params = self.calc_graph_quant_params()
 


### PR DESCRIPTION
### Description
Updates the QDQ quantizer to use ONNX Q/DQ ops for 16-bit quantization if opset >= 21.

### Motivation and Context
The QDQ quantizer previously set the 'com.microsoft' domain on inserted Q/DQ ops when the model needed 16-bit support. ONNX 1.16.0 added int16/uint16 support to the QuantizeLinear and DequantizeLinear operators, so we can change the default behavior.


