### PR TITLE
[TensorRT EP] Use protobuf with debug build on Windows

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1243,11 +1243,16 @@ def generate_build_tree(
             "-Donnxruntime_USE_OPENVINO_AUTO=" + ("ON" if args.use_openvino.startswith("AUTO") else "OFF"),
         ]
 
-    # VitisAI and OpenVINO providers currently only support
-    # full_protobuf option. TensorRT provider only requires it if built with oss_parser
+    # VitisAI and OpenVINO providers currently only support full_protobuf option.
+    # TensorRT provider only requires it if built with oss_parser, and
+    # it implicitly uses oss_parser with debug build on Windows.
+    #
+    # Note: oss_parser will support protobuf-lite in TRT 10 GA, so TRT EP will fully
+    # support protobuf-lite then.
     if (
         args.use_full_protobuf
         or (args.use_tensorrt and args.use_tensorrt_oss_parser)
+        or (args.use_tensorrt and is_windows() and "Debug" in args.config)
         or args.use_openvino
         or args.use_vitisai
         or args.gen_doc


### PR DESCRIPTION
TRT EP implicitly uses oss_parser with debug build on Windows, therefore it should use protobuf rather than protobuf-lite.


