### PR TITLE
Optimize MlasComputeSoftmax with prefetch

### DIFF
--- a/onnxruntime/core/mlas/lib/compute.cpp
+++ b/onnxruntime/core/mlas/lib/compute.cpp
@@ -855,6 +855,7 @@ Return Value:
 
     while (CountN > 0) {
 
+#if defined(MLAS_SSE2_INTRINSICS)
         //
         // Prefetch the next row of the input buffer.
         //
@@ -862,6 +863,7 @@ Return Value:
         for (size_t i = 0; i * ElementsPerCacheLine < D; i++) {
             _mm_prefetch((char*)(Input + D) + i * CacheLineSize, _MM_HINT_T0);
         }
+#endif
 
         //
         // Find the maximum value for the row.

--- a/onnxruntime/core/mlas/lib/compute.cpp
+++ b/onnxruntime/core/mlas/lib/compute.cpp
@@ -850,8 +850,10 @@ Return Value:
     const float* Input = WorkBlock->Input + n * D;
     float* Output = WorkBlock->Output + n * D;
 
-    constexpr size_t CacheLineSize = 64;
+#if defined(MLAS_SSE2_INTRINSICS)
+    constexpr size_t CacheLineSize = std::hardware_constructive_interference_size;
     constexpr size_t ElementsPerCacheLine = CacheLineSize / sizeof(float);
+#endif
 
     while (CountN > 0) {
 

--- a/onnxruntime/core/mlas/lib/compute.cpp
+++ b/onnxruntime/core/mlas/lib/compute.cpp
@@ -862,9 +862,6 @@ Return Value:
         for (size_t i = 0; i * ElementsPerCacheLine < D; i++) {
             _mm_prefetch((char*)(Input + D) + i * CacheLineSize, _MM_HINT_T0);
         }
-        //for (size_t i = 0; i < D; i += ElementsPerCacheLine) {
-        //    _mm_prefetch(reinterpret_cast<char const*>(Input + D) + i * sizeof(float), _MM_HINT_T0);
-        //}
 
         //
         // Find the maximum value for the row.

--- a/onnxruntime/core/mlas/lib/compute.cpp
+++ b/onnxruntime/core/mlas/lib/compute.cpp
@@ -851,7 +851,8 @@ Return Value:
     float* Output = WorkBlock->Output + n * D;
 
 #if defined(MLAS_SSE2_INTRINSICS)
-    constexpr size_t CacheLineSize = std::hardware_constructive_interference_size;
+    // TODO: Use std::hardware_constructive_interference_size
+    constexpr size_t CacheLineSize = 64;
     constexpr size_t ElementsPerCacheLine = CacheLineSize / sizeof(float);
 #endif
 

--- a/onnxruntime/core/mlas/lib/compute.cpp
+++ b/onnxruntime/core/mlas/lib/compute.cpp
@@ -850,7 +850,21 @@ Return Value:
     const float* Input = WorkBlock->Input + n * D;
     float* Output = WorkBlock->Output + n * D;
 
+    constexpr size_t CacheLineSize = 64;
+    constexpr size_t ElementsPerCacheLine = CacheLineSize / sizeof(float);
+
     while (CountN > 0) {
+
+        //
+        // Prefetch the next row of the input buffer.
+        //
+
+        for (size_t i = 0; i * ElementsPerCacheLine < D; i++) {
+            _mm_prefetch((char*)(Input + D) + i * CacheLineSize, _MM_HINT_T0);
+        }
+        //for (size_t i = 0; i < D; i += ElementsPerCacheLine) {
+        //    _mm_prefetch(reinterpret_cast<char const*>(Input + D) + i * sizeof(float), _MM_HINT_T0);
+        //}
 
         //
         // Find the maximum value for the row.


### PR DESCRIPTION
The prefetching instructions (_mm_prefetch) is used to anticipate memory accesses by prefetching the next row of the input buffer. This optimization is designed to reduce the impact of memory latency, thereby enhancing the performance of the MlasComputeSoftmax function. As a result, the worst-case performance of the OCR model has improved by approximately 50ms, which equates to a 3% improvement.


