### PR TITLE
[js/web] fix test runner with optional input/output

### DIFF
--- a/js/web/test/data/ops/simplified-layer-norm.jsonc
+++ b/js/web/test/data/ops/simplified-layer-norm.jsonc
@@ -36,11 +36,11 @@
             ],
             "dims": [1, 2, 8],
             "type": "float32"
-          },
-          {
-            "data": null,
-            "type": "float32"
           }
+          // {
+          //   "data": null,
+          //   "type": "float32"
+          // }
         ]
       }
     ]

--- a/js/web/test/data/ops/skip-layer-norm.jsonc
+++ b/js/web/test/data/ops/skip-layer-norm.jsonc
@@ -1,6 +1,6 @@
 [
   {
-    "name": "SkipLayerNormalization",
+    "name": "SkipLayerNormalization - no output[3]",
     "operator": "SkipLayerNormalization",
     "opset": { "domain": "com.microsoft", "version": 1 },
     "attributes": [
@@ -49,21 +49,36 @@
             ],
             "dims": [1, 2, 4],
             "type": "float32"
-          },
-          {
-            "data": null,
-            "type": "float32"
-          },
-          {
-            "data": null,
-            "type": "float32"
-          },
-          {
-            "data": null,
-            "type": "float32"
           }
+          // {
+          //   "data": null,
+          //   "type": "float32"
+          // },
+          // {
+          //   "data": null,
+          //   "type": "float32"
+          // },
+          // {
+          //   "data": null,
+          //   "type": "float32"
+          // }
         ]
-      },
+      }
+    ]
+  },
+  {
+    "name": "SkipLayerNormalization - has output[3]",
+    "operator": "SkipLayerNormalization",
+    "opset": { "domain": "com.microsoft", "version": 1 },
+    "attributes": [
+      {
+        "name": "epsilon",
+        "data": 1e-5,
+        "type": "float"
+      }
+    ],
+    "inputShapeDefinitions": [[1, 2, 4], [1, 2, 4], [4], [4], [4]],
+    "cases": [
       {
         "name": "default",
         "inputs": [

--- a/js/web/test/data/ops/skip-simplified-layer-norm.jsonc
+++ b/js/web/test/data/ops/skip-simplified-layer-norm.jsonc
@@ -41,11 +41,11 @@
             ],
             "dims": [1, 2, 8],
             "type": "float32"
-          },
-          {
-            "data": null,
-            "type": "float32"
           }
+          // {
+          //   "data": null,
+          //   "type": "float32"
+          // }
         ]
       }
     ]


### PR DESCRIPTION
### Description
fix test runner with optional input/output.

This change fixes the OP test runner (.jsonc format test) with optional input(s) and/or output(s).

this fix reveals a problem of dealing with optional outputs:

> Take SkipSimplifiedLayerNorm as example: 
>
> if in the ONNX model, the node's outputs are: [ 'output_0', '' ] instead of [ 'output_0' ], the current implementation will fail. The difference is, in the first case, context.outputCount == 2, and then the typescript implementation will try to create a tensor for output[1]. It will eventually call to C++ function (OpKernelContext::Output), and the output.DataRaw() will be nullptr. WebGPU backend will fail because it cannot deal with a TensorView with data == 0.
>

This problem may need to be fixed or workaround in separated PR. This PR does not fix this problem. Failed test cases are modified to work - please note this PR does not break those test cases as they never work.