### PR TITLE
Fix Objective-C static analysis warnings.

### DIFF
--- a/cmake/onnxruntime_providers_coreml.cmake
+++ b/cmake/onnxruntime_providers_coreml.cmake
@@ -126,10 +126,12 @@ endif()
 if (APPLE)
   file(GLOB
     onnxruntime_providers_coreml_objcc_srcs CONFIGURE_DEPENDS
-    "${ONNXRUNTIME_ROOT}/core/providers/coreml/model/model.h"
-    "${ONNXRUNTIME_ROOT}/core/providers/coreml/model/model.mm"
     "${ONNXRUNTIME_ROOT}/core/providers/coreml/model/host_utils.h"
     "${ONNXRUNTIME_ROOT}/core/providers/coreml/model/host_utils.mm"
+    "${ONNXRUNTIME_ROOT}/core/providers/coreml/model/model.h"
+    "${ONNXRUNTIME_ROOT}/core/providers/coreml/model/model.mm"
+    "${ONNXRUNTIME_ROOT}/core/providers/coreml/model/objc_str_utils.h"
+    "${ONNXRUNTIME_ROOT}/core/providers/coreml/model/objc_str_utils.mm"
   )
 else()
   # add the Model implementation that uses the protobuf types but excludes any actual CoreML dependencies

--- a/objectivec/ort_checkpoint.mm
+++ b/objectivec/ort_checkpoint.mm
@@ -8,6 +8,7 @@
 #include <variant>
 #import "cxx_api.h"
 
+#import "cxx_utils.h"
 #import "error_utils.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -73,7 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
   try {
     Ort::Property value = [self CXXAPIOrtCheckpoint].GetProperty(name.UTF8String);
     if (std::string* str = std::get_if<std::string>(&value)) {
-      return [NSString stringWithUTF8String:str->c_str()];
+      return utils::toNSString(str->c_str());
     }
     ORT_CXX_API_THROW("Property is not a string.", ORT_INVALID_ARGUMENT);
   }

--- a/objectivec/ort_session.mm
+++ b/objectivec/ort_session.mm
@@ -7,6 +7,7 @@
 #include <vector>
 
 #import "cxx_api.h"
+#import "cxx_utils.h"
 #import "error_utils.h"
 #import "ort_enums_internal.h"
 #import "ort_env_internal.h"
@@ -198,8 +199,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     for (size_t i = 0; i < nameCount; ++i) {
       auto name = getName(i, allocator);
-      NSString* nameNsstr = [NSString stringWithUTF8String:name.get()];
-      NSAssert(nameNsstr != nil, @"nameNsstr must not be nil");
+      NSString* nameNsstr = utils::toNSString(name.get());
       [result addObject:nameNsstr];
     }
 

--- a/onnxruntime/core/providers/coreml/model/host_utils.mm
+++ b/onnxruntime/core/providers/coreml/model/host_utils.mm
@@ -3,6 +3,7 @@
 
 #include "core/platform/env.h"
 #include "core/providers/coreml/model/host_utils.h"
+#include "core/providers/coreml/model/objc_str_utils.h"
 
 #import <Foundation/Foundation.h>
 
@@ -36,7 +37,7 @@ std::string GetTemporaryFilePath() {
 #if !defined(NDEBUG)
   std::string path_override = Env::Default().GetEnvironmentVar(kOverrideModelOutputDirectoryEnvVar);
   if (!path_override.empty()) {
-    NSString* ns_path_override = [NSString stringWithUTF8String:path_override.c_str()];
+    NSString* ns_path_override = Utf8StringToNSString(path_override.c_str());
     temporary_directory_url = [NSURL fileURLWithPath:ns_path_override isDirectory:YES];
   }
 #endif

--- a/onnxruntime/core/providers/coreml/model/objc_str_utils.h
+++ b/onnxruntime/core/providers/coreml/model/objc_str_utils.h
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+namespace onnxruntime::coreml::util {
+
+// Converts a UTF8 const char* to an NSString. Throws on failure.
+// Prefer this to directly calling [NSString stringWithUTF8String:] as that may return nil.
+NSString* _Nonnull Utf8StringToNSString(const char* _Nonnull utf8_str);
+
+}  // onnxruntime::coreml::util

--- a/onnxruntime/core/providers/coreml/model/objc_str_utils.h
+++ b/onnxruntime/core/providers/coreml/model/objc_str_utils.h
@@ -11,4 +11,4 @@ namespace onnxruntime::coreml::util {
 // Prefer this to directly calling [NSString stringWithUTF8String:] as that may return nil.
 NSString* _Nonnull Utf8StringToNSString(const char* _Nonnull utf8_str);
 
-}  // onnxruntime::coreml::util
+}  // namespace onnxruntime::coreml::util

--- a/onnxruntime/core/providers/coreml/model/objc_str_utils.mm
+++ b/onnxruntime/core/providers/coreml/model/objc_str_utils.mm
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/coreml/model/objc_str_utils.h"
+
+#include "core/common/common.h"
+
+namespace onnxruntime::coreml::util {
+
+NSString* _Nonnull Utf8StringToNSString(const char* _Nonnull utf8_str) {
+  NSString* result = [NSString stringWithUTF8String:utf8_str];
+  ORT_ENFORCE(result != nil, "NSString conversion failed.");
+  return result;
+}
+
+}  // namespace onnxruntime::coreml::util


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Replace most usages of [NSString stringWithUTF8String:] with checked helper function. The issue is that the former can return nil.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix Objective-C static analysis build.
https://dev.azure.com/onnxruntime/onnxruntime/_build?definitionId=178&_a=summary