### PR TITLE
[js/web] add "browser" field to support parcel v2

### DIFF
--- a/js/web/package.json
+++ b/js/web/package.json
@@ -64,7 +64,8 @@
     "numpy-parser": "^1.2.3",
     "strip-json-comments": "^5.0.0"
   },
-  "main": "dist/ort-web.node.js",
+  "main": "dist/ort.node.min.js",
+  "browser": "dist/ort.min.js",
   "exports": {
     ".": {
       "node": "./dist/ort.node.min.js",


### PR DESCRIPTION
### Description

As described in latest discussion in #19915, parcel v2 without using the [new resolver](https://parceljs.org/blog/v2-9-0/#new-resolver) will not work correctly with onnxruntime-web. There are still users who uses parcel with default resolver, so add this deprecated field "browser" back for backward compatibility. This PR also corrects the "main" field, which is for old resolver for Node.js.