### PR TITLE
Use compute queues by default in DML EP

### DIFF
--- a/onnxruntime/core/providers/dml/dml_provider_factory.cc
+++ b/onnxruntime/core/providers/dml/dml_provider_factory.cc
@@ -542,7 +542,11 @@ static D3D12_COMMAND_LIST_TYPE CalculateCommandListType(ID3D12Device* d3d12_devi
       sizeof(feature_levels)
       ));
 
-  auto use_compute_command_list = (feature_levels.MaxSupportedFeatureLevel <= D3D_FEATURE_LEVEL_1_0_CORE);
+  // Use compute queue whenever possible on supported hardware to avoid TDR and maintain UI QoS
+  // Core and generic devices only have compute queues, DX11 has "immediate" submission, DX12 has both
+  auto use_compute_command_list = (feature_levels.MaxSupportedFeatureLevel <= D3D_FEATURE_LEVEL_1_0_CORE) ||
+                                  (feature_levels.MaxSupportedFeatureLevel >= D3D_FEATURE_LEVEL_12_0);
+
   if (use_compute_command_list)
   {
     return D3D12_COMMAND_LIST_TYPE_COMPUTE;


### PR DESCRIPTION
### Description
We originally only use compute queues for compute-only devices; this change sets the default for DX12 devices to use compute queues as well.



### Motivation and Context
There have been issues with TDRs occurring when using the current default queues, which doesn't happen on compute queues. 


