### PR TITLE
Two improvements in pipelines

### DIFF
--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -224,10 +224,12 @@ stages:
       workingDirectory: $(Build.SourcesDirectory)
 
     # For verification we will check the generated image looks .
+    # Because the artifact isn't used by other jobs, we set the artifact name to a random value.
+    # So the job can be rerun without the exception that artifact has been published.
     - task: PublishPipelineArtifact@0
-      displayName: 'Publish code coverage report'
+      displayName: 'Publish Generated Image Artifact'
       inputs:
-          artifactName: "Generated-Image"
+          artifactName: 'Generated-Image-$(Get-Date -format yyyyMMdd-Hmmss)'
           targetPath: '$(GenerateImage_DIR)'
 
     - task: Cache@2

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -224,7 +224,7 @@ stages:
       workingDirectory: $(Build.SourcesDirectory)
 
     # For verification we will check the generated image looks .
-    # Because the artifact isn't used by other jobs, we set the artifact name to a random value.
+    # Because the artifact isn't used by other jobs, we set the artifact name to a varabile value.
     # So the job can be rerun without the exception that artifact has been published.
     - task: PublishPipelineArtifact@0
       displayName: 'Publish Generated Image Artifact'

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -229,7 +229,7 @@ stages:
     - task: PublishPipelineArtifact@0
       displayName: 'Publish Generated Image Artifact'
       inputs:
-          artifactName: 'Generated-Image-$(Get-Date -format yyyyMMdd-Hmmss)'
+          artifactName: Generated-Image-$(System.JobAttempt)
           targetPath: '$(GenerateImage_DIR)'
 
     - task: Cache@2

--- a/tools/ci_build/github/azure-pipelines/stages/nuget-linux-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nuget-linux-cuda-packaging-stage.yml
@@ -88,7 +88,12 @@ stages:
       workspace:
         clean: all
       pool: 'Onnxruntime-Linux-GPU'
-
+      variables:
+        - name: CUDA_VERSION_MAJOR
+          ${{ if eq(parameters.CudaVersion, '11.8') }}:
+            value: '11'
+          ${{ if eq(parameters.CudaVersion, '12.2') }}:
+            value: '12'
       steps:
         - checkout: self                           # due to checkout multiple repos, the root directory is $(Build.SourcesDirectory)/onnxruntime
           submodules: false


### PR DESCRIPTION
### Description
1. Update the image name to avoid docker image wouldn't be overwrite.
      there was an mistake that variables.CUDA_VERSION_MAJOR is always empty
      https://github.com/microsoft/onnxruntime/blob/14fcf0a52d61e6015f288cf70025ad62dec7ac85/tools/ci_build/github/azure-pipelines/stages/nuget-linux-cuda-packaging-stage.yml#L120
3. set one artifact name as variable to make the job rerunnable



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


