### PR TITLE
Put x64 specific benchmark code into ifdefs.

### DIFF
--- a/onnxruntime/test/mlas/bench/bench_computesoftmax.cpp
+++ b/onnxruntime/test/mlas/bench/bench_computesoftmax.cpp
@@ -67,6 +67,8 @@ void COMPUTESOFTMAXINPLACE(benchmark::State& state) {
   free(ptr.underlying_buffer);
 }
 
+#if defined(MLAS_TARGET_AMD64)
+
 void REDUCEMAXIMUMF32KERNELAVX(benchmark::State& state) {
   const auto byte_aligned = narrow<int>(state.range(0));
   const auto D = narrow<int>(state.range(1));
@@ -174,6 +176,8 @@ void COMPUTESOFTMAXOUTPUTF32KERNELAVX(benchmark::State& state) {
   free(ptr.underlying_buffer);
 }
 
+#endif  // defined(MLAS_TARGET_AMD64)
+
 static void ComputeSoftmaxInplaceArgs(benchmark::internal::Benchmark* b) {
   b->ArgNames({"ByteAligned", "N", "D", "Threads"});
   for (int threads : {1, 8}) {
@@ -199,6 +203,8 @@ static void ComputeSoftmaxInplaceArgs(benchmark::internal::Benchmark* b) {
 }
 
 BENCHMARK(COMPUTESOFTMAXINPLACE)->Apply(ComputeSoftmaxInplaceArgs)->UseRealTime();
+
+#if defined(MLAS_TARGET_AMD64)
 
 BENCHMARK(REDUCEMAXIMUMF32KERNELAVX)
     ->ArgNames({"ByteAligned", "D"})
@@ -231,3 +237,5 @@ BENCHMARK(COMPUTESOFTMAXOUTPUTF32KERNELAVX)
         {3, 4, 5, 7, 9, 11, 13, 15, 16, 500, 2000},  // D
     })
     ->UseRealTime();
+
+#endif  // defined(MLAS_TARGET_AMD64)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Put x64 specific benchmark code into ifdefs.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix build on non-x64 platforms.