### PR TITLE
Follow up build failure fix for PR #20365 for arm-based device.

### DIFF
--- a/onnxruntime/core/common/cpuid_info.h
+++ b/onnxruntime/core/common/cpuid_info.h
@@ -122,8 +122,16 @@ class CPUIDInfo {
 
   void X86Init();
 #elif defined(CPUIDINFO_ARCH_ARM)
-  // Now the following var is only used in ARM build, but later one we may expand the usage.
+// Now the following var is only used in ARM build, but later one we may expand the usage.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+#endif
   [[maybe_unused]] bool pytorch_cpuinfo_init_{false};
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
 #endif
 
 #ifdef __linux__


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Previous change can bring build failures like this :

/onnxruntime/onnxruntime/core/common/cpuid_info.h:126:52: error: ‘maybe_unused’ attribute ignored [-Werror=attributes]
 126 |  [[maybe_unused]] bool pytorch_cpuinfo_init_{false};
     |                                                   ^
cc1plus: all warnings being treated as errors (happened on Nvidia Jetson build + an arm-based device)

Follow up PR to get around this.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

#20365 

thanks @yf711 for reporting this.