### PR TITLE
fix the build issue for Win Arm64 Release build

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -876,6 +876,11 @@ if (MSVC)
                 "$<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:/wd26451>")
   target_compile_options(onnxruntime_test_all PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--compiler-options /wd4244>"
                 "$<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:/wd4244>")
+  # Avoid the error for Win arm64 Release build. error C1128: number of sections exceeded object file format limit: compile with /bigobj
+  string(TOLOWER ${onnxruntime_target_platform} GEN_PLATFORM)
+  if (${GEN_PLATFORM} STREQUAL "arm64" AND "${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+    target_compile_options(onnxruntime_test_all PRIVATE "/bigobj")
+  endif()
 else()
   target_compile_options(onnxruntime_test_all PRIVATE "-Wno-parentheses")
 endif()


### PR DESCRIPTION
### Description
Fix the build error for Win ARM64 Release build.
graph_transform_test.cc(1,1): error C1128: number of sections exceeded
object file format limit: compile with /bigobj [D:\build\Windows\Release\onnxruntime_test_all.vcxproj]


### Motivation and Context
Fix issue: https://github.com/microsoft/onnxruntime/issues/20406


