### PR TITLE
Follow up fix for #20472

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
@@ -380,7 +380,7 @@ stages:
 
     - task: PublishPipelineArtifact@1
       inputs:
-        artifact: e2e_test_logs_$(Build.BuildId)_$(Date:yyyyMMddHHmmss)
+        artifact: e2e_test_logs_$(Build.BuildId)_$(Build.BuildNumber)
         targetPath: '$(Build.SourcesDirectory)/js/react_native/e2e/artifacts'
       condition: succeededOrFailed()
       displayName: Publish React Native Detox E2E test logs

--- a/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
@@ -380,7 +380,7 @@ stages:
 
     - task: PublishPipelineArtifact@1
       inputs:
-        artifact: e2e_test_logs_$(Build.BuildId)_$(Build.BuildNumber)
+        artifact: e2e_test_logs_$(Build.BuildId)_$(Build.BuildNumber)_$(System.JobAttempt)
         targetPath: '$(Build.SourcesDirectory)/js/react_native/e2e/artifacts'
       condition: succeededOrFailed()
       displayName: Publish React Native Detox E2E test logs


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Error: 

**Artifact name input: e2e_test_logs_1364625_$(Date:yyyyMMddHHmmss)
##[error]Artifact name is not valid: e2e_test_logs_1364625_$(Date:yyyyMMddHHmmss). It cannot contain '\', /', "', ':', '<', '>', '|', '*', and '?'**

Date not correctly showing up in the artifact name. Use predefined pipeline variable BuildNumber instead which also serves similarly as a timestamp.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

RN CI failure
