### PR TITLE
Fix Onnxruntime-TVM CI

### DIFF
--- a/onnxruntime/core/graph/graph_proto_serializer.cc
+++ b/onnxruntime/core/graph/graph_proto_serializer.cc
@@ -9,7 +9,7 @@ void GraphViewerToProto(const GraphViewer& graph_view,
                         ONNX_NAMESPACE::GraphProto& graph_proto,
                         bool include_initializer,
                         bool include_outer_scope_args,
-                        ExecutionOrder order = ExecutionOrder::DEFAULT) {
+                        ExecutionOrder order) {
   graph_proto.set_name(graph_view.Name());
   graph_proto.set_doc_string(graph_view.Description());
 

--- a/onnxruntime/core/graph/graph_proto_serializer.h
+++ b/onnxruntime/core/graph/graph_proto_serializer.h
@@ -11,5 +11,5 @@ void GraphViewerToProto(const GraphViewer& graph_view,
                         ONNX_NAMESPACE::GraphProto& graph_proto,
                         bool include_initializer,
                         bool include_outer_scope_args,
-                        ExecutionOrder order);
+                        ExecutionOrder order = ExecutionOrder::DEFAULT);
 }  // namespace onnxruntime


### PR DESCRIPTION
### Description

```
  tvm_execution_provider.cc
  denormal.cc
D:\a\onnxruntime\onnxruntime\onnxruntime\core\providers\tvm\tvm_execution_provider.cc(122,5): error C2660: 'onnxruntime::GraphViewerToProto': function does not take 4 arguments [D:\a\onnxruntime\onnxruntime\build\Release\onnxruntime_providers_tvm.vcxproj]
  D:\a\onnxruntime\onnxruntime\onnxruntime\core\graph\graph_proto_serializer.h(10,6):
  see declaration of 'onnxruntime::GraphViewerToProto'
  D:\a\onnxruntime\onnxruntime\onnxruntime\core\providers\tvm\tvm_execution_provider.cc(122,5):
  while trying to match the argument list '(const onnxruntime::GraphViewer, onnx::GraphProto, bool, bool)'
  
  cpuid_uarch.cc
  get_execution_providers.cc
  abi_session_options.cc
  bias_dropout_fusion.cc
  if.cc
```


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


