### PR TITLE
Fix the doxygen error

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -4641,7 +4641,7 @@ struct OrtApi {
    * will occur before any of the optimizations take place. The data will be copied into the graph
    * since TensorProto can't refer to the user provided buffers.
    *
-   * \param[in] session options
+   * \param[in] options
    * \param[in] external_initializer_file_names Array of null terminated UTF-8 encoded strings of the file names
    *            which holds the external initializers.
    * \param[in] external_initializer_file_buffer_array Array of pointers to the buffer of the file content.


### PR DESCRIPTION
Fix onnxruntime/include/onnxruntime/core/session/onnxruntime_c_api.h:4637: error: argument 'session' of command @param is not found in the argument list of

OrtApi::AddExternalInitializersFromFilesInMemory(
    OrtSessionOptions *options,
    const char *const *external_initializer_file_names,
    char *const *external_initializer_file_buffer_array,
    const size_t *external_initializer_file_lengths,
    size_t num_external_initializer_files)