### PR TITLE
Reduce downloads to NodeJS to mitigate random connection exception.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -58,6 +58,8 @@ variables:
     value: nvidia/cuda:11.8.0-cudnn8-devel-ubi8
   - name: linux_trt_version
     value: 8.6.1.6-1.cuda11.8
+  - name: Repository
+    value: 'onnxruntimecuda11manylinuxbuild'
 
 stages:
 - stage: Build_Onnxruntime_Cuda
@@ -79,6 +81,7 @@ stages:
       clean: true
       submodules: none
 
+    # same as linux-gpu-ci-pipeline.yml
     - template: templates/get-docker-image-steps.yml
       parameters:
         Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2_28_cuda
@@ -89,7 +92,7 @@ stages:
         --build-arg TRT_VERSION=$(linux_trt_version)
         --build-arg BUILD_UID=$( id -u )
         "
-        Repository: onnxruntimecuda11build
+        Repository: $(Repository)
 
     - task: Cache@2
       inputs:
@@ -121,7 +124,7 @@ stages:
             -e NIGHTLY_BUILD \
             -e BUILD_BUILDNUMBER \
             -e CCACHE_DIR=/cache \
-            onnxruntimecuda11build \
+            $(Repository) \
             /bin/bash -c "
               set -ex; \
               env; \

--- a/tools/ci_build/github/azure-pipelines/linux-gpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-ci-pipeline.yml
@@ -68,9 +68,9 @@ variables:
 
   - name: Repository
     ${{ if eq(parameters.CudaVersion, '11.8') }}:
-      value: 'onnxruntimecuda11build'
+      value: 'onnxruntimecuda11manylinuxbuild'
     ${{ if eq(parameters.CudaVersion, '12.2') }}:
-      value: 'onnxruntimecuda12build'
+      value: 'onnxruntimecuda12manylinuxbuild'
 
 stages:
 - stage: Linux_Build


### PR DESCRIPTION
### Description
There was connection exception in docker build in package pipeline
```
48.26 + curl https://nodejs.org/dist/v18.17.1/node-v18.17.1-linux-x64.tar.gz -sSL --retry 5 --retry-delay 30 --create-dirs -o /tmp/src/node-v18.17.1-linux-x64.tar.gz --fail
456.0 curl: (92) HTTP/2 stream 0 was not closed cleanly: INTERNAL_ERROR (err 2)
```
https://dev.azure.com/aiinfra/Lotus/_build/results?buildId=453140&view=logs&j=f9f5b320-fa10-56c4-debe-61ea69c74793&t=1656e225-defa-5b12-8935-2a0a93e76a67&s=3c85d903-a183-5028-775e-d63999fcc9ae

In fact, docker image shouldn't be rebuilt this time.

Checked the code, The docker image tag in Linux_C_API_Packaging_GPU_x64 of onnxruntimecuda${{ variables.CUDA_VERSION_MAJOR }}build was same as the image tag of Linux-gpu-ci-pipeline, but their docker files are different.

So changing the Linux GPU pipeline's image tag to avoid packaging pipeline docker image overridden unexpectedly.



