### PR TITLE
Remove usage of 'required reason' iOS API from protobuf

### DIFF
--- a/cmake/patches/protobuf/protobuf_cmake.patch
+++ b/cmake/patches/protobuf/protobuf_cmake.patch
@@ -29,3 +29,27 @@ index 04cb3303a..4025805cf 100644
    # When building with "make", "lib" prefix will be added automatically by
    # the build tool.
    set(LIB_PREFIX)
+diff --git a/src/google/protobuf/map.h b/src/google/protobuf/map.h
+index 008c19225..cbab108c2 100644
+--- a/src/google/protobuf/map.h
++++ b/src/google/protobuf/map.h
+@@ -52,7 +52,8 @@
+ #endif  // defined(__cpp_lib_string_view)
+ 
+ #if !defined(GOOGLE_PROTOBUF_NO_RDTSC) && defined(__APPLE__)
+-#include <mach/mach_time.h>
++// apply update from https://github.com/protocolbuffers/protobuf/pull/15662/
++#include <time.h>
+ #endif
+ 
+ #include <google/protobuf/stubs/common.h>
+@@ -1154,7 +1155,8 @@ class Map {
+ #if defined(__APPLE__)
+       // Use a commpage-based fast time function on Apple environments (MacOS,
+       // iOS, tvOS, watchOS, etc).
+-      s += mach_absolute_time();
++      // apply update from https://github.com/protocolbuffers/protobuf/pull/15662/
++      s += clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
+ #elif defined(__x86_64__) && defined(__GNUC__)
+       uint32_t hi, lo;
+       asm volatile("rdtsc" : "=a"(lo), "=d"(hi));

--- a/tools/ci_build/github/apple/build_host_protoc.sh
+++ b/tools/ci_build/github/apple/build_host_protoc.sh
@@ -22,9 +22,11 @@ pushd .
 mkdir -p "$PROTOC_BUILD_PATH"
 cd "$PROTOC_BUILD_PATH"
 DEP_FILE_PATH="$ORT_REPO_ROOT/cmake/deps.txt"
+PATCH_FILE_PATH="$ORT_REPO_ROOT/cmake/patches/protobuf/protobuf_cmake.patch"
 protobuf_url=$(grep '^protobuf' "$DEP_FILE_PATH" | cut -d ';' -f 2 | sed 's/\.zip$/\.tar.gz/')
 curl -sSL --retry 5 --retry-delay 10 --create-dirs --fail -L -o protobuf_src.tar.gz "$protobuf_url"
 tar -zxf protobuf_src.tar.gz --strip=1
+patch --binary --ignore-whitespace -p1 < "$PATCH_FILE_PATH"
 # The second 'cmake' is a folder name
 cmake cmake \
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON \


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Using certain APIs is about to require a [privacy manifest](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api) to be added to a package. 

Our version of protobuf uses `mach_absolute_time`. Patch as per https://github.com/protocolbuffers/protobuf/pull/15662/ to remove usage. 

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Usage of API will require a privacy manifest for an iOS app to be accepted as of 5/1/2024
#20519 
