### PR TITLE
Fully dynamic ETW controlled logging for ORT and QNN logs

### DIFF
--- a/include/onnxruntime/core/common/logging/isink.h
+++ b/include/onnxruntime/core/common/logging/isink.h
@@ -6,17 +6,15 @@
 #include <string>
 
 #include "core/common/logging/logging.h"
+#include "core/common/logging/sink_types.h"
 
 namespace onnxruntime {
 namespace logging {
 class ISink {
  public:
-  ISink() = default;
+  explicit ISink(SinkType type = SinkType::BaseSink) : type_(type) {}
 
-  enum SinkType { BaseSink,
-                  CompositeSink,
-                  EtwSink };
-  virtual SinkType GetType() const { return BaseSink; }
+  SinkType GetType() const { return type_; }
 
   /**
      Sends the message to the sink.
@@ -37,6 +35,8 @@ class ISink {
   virtual ~ISink() = default;
 
  private:
+  SinkType type_;
+
   // Make Code Analysis happy by disabling all for now. Enable as needed.
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(ISink);
 

--- a/include/onnxruntime/core/common/logging/isink.h
+++ b/include/onnxruntime/core/common/logging/isink.h
@@ -13,6 +13,11 @@ class ISink {
  public:
   ISink() = default;
 
+  enum SinkType { BaseSink,
+                  CompositeSink,
+                  EtwSink };
+  virtual SinkType GetType() const { return BaseSink; }
+
   /**
      Sends the message to the sink.
      @param timestamp The timestamp.

--- a/include/onnxruntime/core/common/logging/logging.h
+++ b/include/onnxruntime/core/common/logging/logging.h
@@ -16,6 +16,7 @@
 #include "core/common/logging/capture.h"
 #include "core/common/logging/macros.h"
 #include "core/common/logging/severity.h"
+#include "core/common/logging/sink_types.h"
 #include "core/platform/ort_mutex.h"
 #include "date/date.h"
 
@@ -171,18 +172,16 @@ class LoggingManager final {
   */
   static LoggingManager* GetDefaultInstance();
 
-#ifdef _WIN32
   /**
-     Removes the ETW Sink if one is present
+     Removes a Sink if one is present
   */
-  void RemoveEtwSink();
+  void RemoveSink(SinkType sinkType);
 
   /**
-     Adds an ETW Sink to the current sink creating a CompositeSink if necessary
-     @param etwSeverity The severity level for the ETW Sink
+     Adds a Sink to the current sink creating a CompositeSink if necessary
+     @param severity The severity level for the new Sink
   */
-  void AddEtwSink(logging::Severity etwSeverity);
-#endif
+  void AddSink(SinkType sinkType, std::function<std::unique_ptr<ISink>()> sinkFactory, logging::Severity severity);
 
   /**
      Change the minimum severity level for log messages to be output by the default logger.

--- a/include/onnxruntime/core/common/logging/logging.h
+++ b/include/onnxruntime/core/common/logging/logging.h
@@ -173,16 +173,6 @@ class LoggingManager final {
 
 #ifdef _WIN32
   /**
-    Returns the current sink
-  */
-  // std::shared_ptr<ISink> GetCurrentSink() const;
-
-  /**
-    Replace the current sink with a new one
-  */
-  void UpdateSink(std::unique_ptr<ISink> new_sink);
-
-  /**
      Removes the ETW Sink if one is present
   */
   void RemoveEtwSink();
@@ -393,7 +383,7 @@ unsigned int GetProcessId();
    If the ONNXRuntimeTraceLoggingProvider ETW Provider is enabled, then adds to the existing logger.
 */
 std::unique_ptr<ISink> EnhanceSinkWithEtw(std::unique_ptr<ISink> existingSink, logging::Severity originalSeverity,
-                                            logging::Severity etwSeverity);
+                                          logging::Severity etwSeverity);
 
 /**
   If the ONNXRuntimeTraceLoggingProvider ETW Provider is enabled, then can override the logging level.

--- a/include/onnxruntime/core/common/logging/logging.h
+++ b/include/onnxruntime/core/common/logging/logging.h
@@ -179,9 +179,10 @@ class LoggingManager final {
 
   /**
      Adds a Sink to the current sink creating a CompositeSink if necessary
+     Sinks types must be unique
      @param severity The severity level for the new Sink
   */
-  void AddSink(SinkType sinkType, std::function<std::unique_ptr<ISink>()> sinkFactory, logging::Severity severity);
+  bool AddSinkOfType(SinkType sinkType, std::function<std::unique_ptr<ISink>()> sinkFactory, logging::Severity severity);
 
   /**
      Change the minimum severity level for log messages to be output by the default logger.

--- a/include/onnxruntime/core/common/logging/sink_types.h
+++ b/include/onnxruntime/core/common/logging/sink_types.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace onnxruntime {
+namespace logging {
+enum class SinkType {
+  BaseSink,
+  CompositeSink,
+  EtwSink
+};
+}  // namespace logging
+}  // namespace onnxruntime

--- a/onnxruntime/core/common/logging/logging.cc
+++ b/onnxruntime/core/common/logging/logging.cc
@@ -266,7 +266,7 @@ std::unique_ptr<ISink> EnhanceSinkWithEtw(std::unique_ptr<ISink> existingSink, l
   // On non-Windows platforms, just return the existing logger
   (void)originalSeverity;
   (void)etwSeverity;
-  return existingLogger;
+  return existingSink;
 #endif  // _WIN32
 }
 

--- a/onnxruntime/core/common/logging/logging.cc
+++ b/onnxruntime/core/common/logging/logging.cc
@@ -9,11 +9,11 @@
 #include "core/common/exceptions.h"
 #include "core/common/logging/isink.h"
 #include "core/common/logging/logging.h"
+#include "core/common/logging/sinks/composite_sink.h"
 
 #ifdef _WIN32
 #include <Windows.h>
 #include "core/platform/windows/logging/etw_sink.h"
-#include "core/common/logging/sinks/composite_sink.h"
 #else
 #include <unistd.h>
 #if defined(__MACH__) || defined(__wasm__) || defined(_AIX)

--- a/onnxruntime/core/common/logging/logging.cc
+++ b/onnxruntime/core/common/logging/logging.cc
@@ -22,10 +22,10 @@
 #include <sys/syscall.h>
 #endif
 #endif
-#include "core/platform/ort_mutex.h"
 
 #if __FreeBSD__
 #include <sys/thr.h>  // Use thr_self() syscall under FreeBSD to get thread id
+#include "logging.h"
 #endif
 
 namespace onnxruntime {
@@ -52,6 +52,10 @@ static std::atomic<void*>& DefaultLoggerManagerInstance() noexcept {
   return default_instance;
 }
 
+LoggingManager* LoggingManager::GetDefaultInstance() {
+  return static_cast<LoggingManager*>(DefaultLoggerManagerInstance().load());
+}
+
 // GSL_SUPRESS(i.22) is broken. Ignore the warnings for the static local variables that are trivial
 // and should not have any destruction order issues via pragmas instead.
 // https://developercommunity.visualstudio.com/content/problem/249706/gslsuppress-does-not-work-for-i22-c-core-guideline.html
@@ -66,6 +70,7 @@ static OrtMutex& DefaultLoggerMutex() noexcept {
 }
 
 Logger* LoggingManager::s_default_logger_ = nullptr;
+OrtMutex sink_mutex_;
 
 #ifdef _MSC_VER
 #pragma warning(pop)
@@ -155,11 +160,33 @@ std::unique_ptr<Logger> LoggingManager::CreateLogger(const std::string& logger_i
   return logger;
 }
 
+#ifdef _WIN32
+// std::shared_ptr<ISink> LoggingManager::GetCurrentSink() const {
+//     std::lock_guard<OrtMutex> guard(sink_mutex_);
+//     return sink_;
+// }
+
+void LoggingManager::UpdateSink(std::unique_ptr<ISink> new_sink) {
+    if (!new_sink) {
+        throw std::invalid_argument("new_sink must not be nullptr.");
+    }
+
+    std::lock_guard<OrtMutex> guard(sink_mutex_);
+    sink_ = std::move(new_sink);
+}
+#endif
+
 void LoggingManager::Log(const std::string& logger_id, const Capture& message) const {
+// #ifdef _WIN32
+//   std::lock_guard<OrtMutex> guard(sink_mutex_);
+// #endif
   sink_->Send(GetTimestamp(), logger_id, message);
 }
 
 void LoggingManager::SendProfileEvent(profiling::EventRecord& eventRecord) const {
+// #ifdef _WIN32
+//   std::lock_guard<OrtMutex> guard(sink_mutex_);
+// #endif
   sink_->SendProfileEvent(eventRecord);
 }
 
@@ -245,17 +272,17 @@ unsigned int GetProcessId() {
 #endif
 }
 
-std::unique_ptr<ISink> EnhanceLoggerWithEtw(std::unique_ptr<ISink> existingLogger, logging::Severity originalSeverity,
+std::unique_ptr<ISink> EnhanceSinkWithEtw(std::unique_ptr<ISink> existingSink, logging::Severity originalSeverity,
                                             logging::Severity etwSeverity) {
 #ifdef _WIN32
   auto& manager = EtwRegistrationManager::Instance();
   if (manager.IsEnabled()) {
     auto compositeSink = std::make_unique<CompositeSink>();
-    compositeSink->AddSink(std::move(existingLogger), originalSeverity);
+    compositeSink->AddSink(std::move(existingSink), originalSeverity);
     compositeSink->AddSink(std::make_unique<EtwSink>(), etwSeverity);
     return compositeSink;
   } else {
-    return existingLogger;
+    return existingSink;
   }
 #else
   // On non-Windows platforms, just return the existing logger
@@ -275,6 +302,82 @@ Severity OverrideLevelWithEtw(Severity originalSeverity) {
 #endif  // _WIN32
   return originalSeverity;
 }
+
+#ifdef _WIN32
+void LoggingManager::AddEtwSink(logging::Severity etwSeverity) {
+    std::lock_guard<OrtMutex> guard(sink_mutex_);
+
+    // Check if the EtwRegistrationManager is enabled
+    auto& manager = EtwRegistrationManager::Instance();
+    if (!manager.IsEnabled()) {
+        return; // ETW not enabled, no operation needed
+    }
+
+    CompositeSink* current_composite = dynamic_cast<CompositeSink*>(sink_.get());
+    if (!current_composite) {
+        // Current sink is not a composite, create a new composite sink and add the current sink to it
+        auto new_composite = std::make_unique<CompositeSink>();
+        new_composite->AddSink(std::move(sink_), default_min_severity_);  // Move the current sink into the new composite
+        sink_ = std::move(new_composite); // Now sink_ is pointing to the new composite
+        current_composite = static_cast<CompositeSink*>(sink_.get()); // Update pointer to the new composite sink
+    }
+
+    // Adjust the default minimum severity level to accommodate ETW logging needs
+    default_min_severity_ = std::min(default_min_severity_, etwSeverity);
+    if (s_default_logger_ != nullptr) {
+        s_default_logger_->SetSeverity(default_min_severity_);
+    }
+
+    // Check if an EtwSink already exists in the current composite
+    const auto& sinks = current_composite->GetSinks();
+    if (std::any_of(sinks.begin(), sinks.end(), [](const auto& pair) {
+        return dynamic_cast<EtwSink*>(pair.first.get()) != nullptr;
+    })) {
+        return; // EtwSink already exists, do not add another
+    }
+
+    // Add a new EtwSink
+    current_composite->AddSink(std::make_unique<EtwSink>(), etwSeverity);
+
+}
+
+void LoggingManager::RemoveEtwSink() {
+    std::lock_guard<OrtMutex> guard(sink_mutex_);
+    auto composite_sink = dynamic_cast<CompositeSink*>(sink_.get());
+
+    if (composite_sink) {
+        const auto& sinks_with_severity = composite_sink->GetSinks();
+        std::unique_ptr<ISink> remaining_sink;
+
+        Severity newSeverity = Severity::kFATAL;
+
+        for (const auto& sink_pair : sinks_with_severity) {
+          if (dynamic_cast<EtwSink*>(sink_pair.first.get()) == nullptr) {
+            if (remaining_sink) {
+              // If more than one non-EtwSink is found, we leave the CompositeSink intact
+              return;
+            }
+            newSeverity = std::min(newSeverity, sink_pair.second);
+            remaining_sink = std::move(const_cast<std::unique_ptr<ISink>&>(sink_pair.first));
+          }
+        }
+
+        // If only one non-EtwSink remains, replace the CompositeSink with this sink
+        if (remaining_sink) {
+            sink_ = std::move(remaining_sink);
+
+        } else {
+            // Handle the case where all sinks were EtwSinks
+            // sink_ = std::make_unique<NullSink>(); // Assuming NullSink is a basic ISink that does nothing
+        }
+
+        default_min_severity_ = newSeverity;
+        if (s_default_logger_ != nullptr) {
+            s_default_logger_->SetSeverity(default_min_severity_);
+        }
+    }
+}
+#endif
 
 }  // namespace logging
 }  // namespace onnxruntime

--- a/onnxruntime/core/common/logging/sinks/composite_sink.h
+++ b/onnxruntime/core/common/logging/sinks/composite_sink.h
@@ -25,6 +25,8 @@ class CompositeSink : public ISink {
   /// </summary>
   CompositeSink() {}
 
+  SinkType GetType() const override { return ISink::CompositeSink; }
+
   /// <summary>
   /// Adds a sink. Takes ownership of the sink (so pass unique_ptr by value).
   /// </summary>

--- a/onnxruntime/core/common/logging/sinks/composite_sink.h
+++ b/onnxruntime/core/common/logging/sinks/composite_sink.h
@@ -23,9 +23,7 @@ class CompositeSink : public ISink {
   /// Initializes a new instance of the <see cref="CompositeSink"/> class.
   /// Use AddSink to add sinks.
   /// </summary>
-  CompositeSink() {}
-
-  SinkType GetType() const override { return ISink::CompositeSink; }
+  CompositeSink() : ISink(SinkType::CompositeSink) {}
 
   /// <summary>
   /// Adds a sink. Takes ownership of the sink (so pass unique_ptr by value).

--- a/onnxruntime/core/common/logging/sinks/composite_sink.h
+++ b/onnxruntime/core/common/logging/sinks/composite_sink.h
@@ -26,6 +26,16 @@ class CompositeSink : public ISink {
   CompositeSink() : ISink(SinkType::CompositeSink) {}
 
   /// <summary>
+  /// Check if the composite sink contains a sink of the specified type.
+  /// </summary>
+  bool HasType(SinkType sink_type) const {
+    return std::any_of(sinks_with_severity_.begin(), sinks_with_severity_.end(),
+                       [&](const auto& sink_pair) {
+                         return sink_pair.first->GetType() == sink_type;
+                       });
+  }
+
+  /// <summary>
   /// Adds a sink. Takes ownership of the sink (so pass unique_ptr by value).
   /// </summary>
   /// <param name="sink">The sink.</param>
@@ -37,11 +47,48 @@ class CompositeSink : public ISink {
   }
 
   /// <summary>
-  /// Gets a const reference to the collection of sinks and min severity for that sink
+  /// Remove a sink of the specified type.
   /// </summary>
-  /// <returns>A const reference to the vector pair of unique_ptr to ISink and severity.</returns>
-  const std::vector<std::pair<std::unique_ptr<ISink>, logging::Severity>>& GetSinks() const {
-    return sinks_with_severity_;
+  /// <param name="sink_type">Sink type to remove</param>
+  /// <returns>Minimum severity of the remaining sinks</returns>
+  logging::Severity RemoveSink(SinkType sink_type) {
+    logging::Severity severity = Severity::kFATAL;  // default if we end up with no sinks
+
+    // find entries to remove and the minimum severity of the remaining sinks
+    auto entries_to_remove = std::remove_if(sinks_with_severity_.begin(), sinks_with_severity_.end(),
+                                            [&](const auto& entry) {
+                                              if (entry.first->GetType() == sink_type) {
+                                                return true;
+                                              } else {
+                                                severity = std::min(severity, entry.second);
+                                                return false;
+                                              }
+                                            });
+
+    sinks_with_severity_.erase(entries_to_remove, sinks_with_severity_.end());
+
+    return severity;
+  }
+
+  /// <summary>
+  /// Check if there's only one sink left
+  /// </summary>
+  /// <returns> True if only 1 sink remaining </returns>
+  bool HasOnlyOneSink() const {
+    return sinks_with_severity_.size() == 1;
+  }
+
+  /// <summary>
+  /// If one sink is remaining then returns it and empties the composite sink
+  /// </summary>
+  /// <returns> If one sink remains then returns the sink, otherwise nullptr </returns>
+  std::unique_ptr<ISink> GetRemoveSingleSink() {
+    if (HasOnlyOneSink()) {
+      auto single_sink = std::move(sinks_with_severity_.begin()->first);
+      sinks_with_severity_.clear();
+      return single_sink;
+    }
+    return nullptr;
   }
 
  private:

--- a/onnxruntime/core/platform/telemetry.cc
+++ b/onnxruntime/core/platform/telemetry.cc
@@ -55,7 +55,7 @@ void Telemetry::LogSessionCreation(uint32_t session_id, int64_t ir_version, cons
                                    const std::string& model_graph_name,
                                    const std::unordered_map<std::string, std::string>& model_metadata,
                                    const std::string& loadedFrom, const std::vector<std::string>& execution_provider_ids,
-                                   bool use_fp16) const {
+                                   bool use_fp16, bool captureState) const {
   ORT_UNUSED_PARAMETER(session_id);
   ORT_UNUSED_PARAMETER(ir_version);
   ORT_UNUSED_PARAMETER(model_producer_name);
@@ -67,6 +67,7 @@ void Telemetry::LogSessionCreation(uint32_t session_id, int64_t ir_version, cons
   ORT_UNUSED_PARAMETER(loadedFrom);
   ORT_UNUSED_PARAMETER(execution_provider_ids);
   ORT_UNUSED_PARAMETER(use_fp16);
+  ORT_UNUSED_PARAMETER(captureState);
 }
 
 void Telemetry::LogRuntimeError(uint32_t session_id, const common::Status& status, const char* file,

--- a/onnxruntime/core/platform/telemetry.h
+++ b/onnxruntime/core/platform/telemetry.h
@@ -60,7 +60,7 @@ class Telemetry {
                                   const std::string& model_graph_name,
                                   const std::unordered_map<std::string, std::string>& model_metadata,
                                   const std::string& loadedFrom, const std::vector<std::string>& execution_provider_ids,
-                                  bool use_fp16) const;
+                                  bool use_fp16, bool captureState) const;
 
   virtual void LogRuntimeError(uint32_t session_id, const common::Status& status, const char* file,
                                const char* function, uint32_t line) const;

--- a/onnxruntime/core/platform/windows/logging/etw_sink.h
+++ b/onnxruntime/core/platform/windows/logging/etw_sink.h
@@ -31,10 +31,8 @@ namespace logging {
 
 class EtwSink : public ISink {
  public:
-  EtwSink() = default;
+  EtwSink() : ISink(SinkType::EtwSink) {}
   ~EtwSink() = default;
-
-  SinkType GetType() const override { return ISink::EtwSink; }
 
   constexpr static const char* kEventName = "ONNXRuntimeLogEvent";
 

--- a/onnxruntime/core/platform/windows/logging/etw_sink.h
+++ b/onnxruntime/core/platform/windows/logging/etw_sink.h
@@ -34,6 +34,8 @@ class EtwSink : public ISink {
   EtwSink() = default;
   ~EtwSink() = default;
 
+  SinkType GetType() const override { return ISink::EtwSink; }
+
   constexpr static const char* kEventName = "ONNXRuntimeLogEvent";
 
  private:

--- a/onnxruntime/core/platform/windows/telemetry.cc
+++ b/onnxruntime/core/platform/windows/telemetry.cc
@@ -216,17 +216,17 @@ void WindowsTelemetry::LogSessionCreation(uint32_t session_id, int64_t ir_versio
 
   // build the strings we need
 
-  std::string domain_to_verison_string;
+  std::string domain_to_version_string;
   bool first = true;
   for (auto& i : domain_to_version_map) {
     if (first) {
       first = false;
     } else {
-      domain_to_verison_string += ',';
+      domain_to_version_string += ',';
     }
-    domain_to_verison_string += i.first;
-    domain_to_verison_string += '=';
-    domain_to_verison_string += std::to_string(i.second);
+    domain_to_version_string += i.first;
+    domain_to_version_string += '=';
+    domain_to_version_string += std::to_string(i.second);
   }
 
   std::string model_metadata_string;
@@ -271,7 +271,7 @@ void WindowsTelemetry::LogSessionCreation(uint32_t session_id, int64_t ir_versio
                       TraceLoggingString(model_producer_version.c_str(), "modelProducerVersion"),
                       TraceLoggingString(model_domain.c_str(), "modelDomain"),
                       TraceLoggingBool(use_fp16, "usefp16"),
-                      TraceLoggingString(domain_to_verison_string.c_str(), "domainToVersionMap"),
+                      TraceLoggingString(domain_to_version_string.c_str(), "domainToVersionMap"),
                       TraceLoggingString(model_graph_name.c_str(), "modelGraphName"),
                       TraceLoggingString(model_metadata_string.c_str(), "modelMetaData"),
                       TraceLoggingString(loaded_from.c_str(), "loadedFrom"),
@@ -293,7 +293,7 @@ void WindowsTelemetry::LogSessionCreation(uint32_t session_id, int64_t ir_versio
                       TraceLoggingString(model_producer_version.c_str(), "modelProducerVersion"),
                       TraceLoggingString(model_domain.c_str(), "modelDomain"),
                       TraceLoggingBool(use_fp16, "usefp16"),
-                      TraceLoggingString(domain_to_verison_string.c_str(), "domainToVersionMap"),
+                      TraceLoggingString(domain_to_version_string.c_str(), "domainToVersionMap"),
                       TraceLoggingString(model_graph_name.c_str(), "modelGraphName"),
                       TraceLoggingString(model_metadata_string.c_str(), "modelMetaData"),
                       TraceLoggingString(loaded_from.c_str(), "loadedFrom"),

--- a/onnxruntime/core/platform/windows/telemetry.cc
+++ b/onnxruntime/core/platform/windows/telemetry.cc
@@ -210,7 +210,7 @@ void WindowsTelemetry::LogSessionCreation(uint32_t session_id, int64_t ir_versio
                                           const std::string& model_graph_name,
                                           const std::unordered_map<std::string, std::string>& model_metadata,
                                           const std::string& loaded_from, const std::vector<std::string>& execution_provider_ids,
-                                          bool use_fp16) const {
+                                          bool use_fp16, bool captureState) const {
   if (global_register_count_ == 0 || enabled_ == false)
     return;
 
@@ -253,27 +253,52 @@ void WindowsTelemetry::LogSessionCreation(uint32_t session_id, int64_t ir_versio
     execution_provider_string += i;
   }
 
-  TraceLoggingWrite(telemetry_provider_handle,
-                    "SessionCreation",
-                    TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
-                    TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
-                    TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
-                    TraceLoggingKeyword(static_cast<uint64_t>(onnxruntime::logging::ORTTraceLoggingKeyword::Session)),
-                    TraceLoggingLevel(WINEVENT_LEVEL_INFO),
-                    // Telemetry info
-                    TraceLoggingUInt8(0, "schemaVersion"),
-                    TraceLoggingUInt32(session_id, "sessionId"),
-                    TraceLoggingInt64(ir_version, "irVersion"),
-                    TraceLoggingUInt32(projection_, "OrtProgrammingProjection"),
-                    TraceLoggingString(model_producer_name.c_str(), "modelProducerName"),
-                    TraceLoggingString(model_producer_version.c_str(), "modelProducerVersion"),
-                    TraceLoggingString(model_domain.c_str(), "modelDomain"),
-                    TraceLoggingBool(use_fp16, "usefp16"),
-                    TraceLoggingString(domain_to_verison_string.c_str(), "domainToVersionMap"),
-                    TraceLoggingString(model_graph_name.c_str(), "modelGraphName"),
-                    TraceLoggingString(model_metadata_string.c_str(), "modelMetaData"),
-                    TraceLoggingString(loaded_from.c_str(), "loadedFrom"),
-                    TraceLoggingString(execution_provider_string.c_str(), "executionProviderIds"));
+  // Difference is MeasureEvent & isCaptureState, but keep in sync otherwise
+  if (!captureState) {
+    TraceLoggingWrite(telemetry_provider_handle,
+                      "SessionCreation",
+                      TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
+                      TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+                      TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+                      TraceLoggingKeyword(static_cast<uint64_t>(onnxruntime::logging::ORTTraceLoggingKeyword::Session)),
+                      TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+                      // Telemetry info
+                      TraceLoggingUInt8(0, "schemaVersion"),
+                      TraceLoggingUInt32(session_id, "sessionId"),
+                      TraceLoggingInt64(ir_version, "irVersion"),
+                      TraceLoggingUInt32(projection_, "OrtProgrammingProjection"),
+                      TraceLoggingString(model_producer_name.c_str(), "modelProducerName"),
+                      TraceLoggingString(model_producer_version.c_str(), "modelProducerVersion"),
+                      TraceLoggingString(model_domain.c_str(), "modelDomain"),
+                      TraceLoggingBool(use_fp16, "usefp16"),
+                      TraceLoggingString(domain_to_verison_string.c_str(), "domainToVersionMap"),
+                      TraceLoggingString(model_graph_name.c_str(), "modelGraphName"),
+                      TraceLoggingString(model_metadata_string.c_str(), "modelMetaData"),
+                      TraceLoggingString(loaded_from.c_str(), "loadedFrom"),
+                      TraceLoggingString(execution_provider_string.c_str(), "executionProviderIds"));
+  } else {
+    TraceLoggingWrite(telemetry_provider_handle,
+                      "SessionCreation_CaptureState",
+                      TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
+                      TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+                      // Not a measure event
+                      TraceLoggingKeyword(static_cast<uint64_t>(onnxruntime::logging::ORTTraceLoggingKeyword::Session)),
+                      TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+                      // Telemetry info
+                      TraceLoggingUInt8(0, "schemaVersion"),
+                      TraceLoggingUInt32(session_id, "sessionId"),
+                      TraceLoggingInt64(ir_version, "irVersion"),
+                      TraceLoggingUInt32(projection_, "OrtProgrammingProjection"),
+                      TraceLoggingString(model_producer_name.c_str(), "modelProducerName"),
+                      TraceLoggingString(model_producer_version.c_str(), "modelProducerVersion"),
+                      TraceLoggingString(model_domain.c_str(), "modelDomain"),
+                      TraceLoggingBool(use_fp16, "usefp16"),
+                      TraceLoggingString(domain_to_verison_string.c_str(), "domainToVersionMap"),
+                      TraceLoggingString(model_graph_name.c_str(), "modelGraphName"),
+                      TraceLoggingString(model_metadata_string.c_str(), "modelMetaData"),
+                      TraceLoggingString(loaded_from.c_str(), "loadedFrom"),
+                      TraceLoggingString(execution_provider_string.c_str(), "executionProviderIds"));
+  }
 }
 
 void WindowsTelemetry::LogRuntimeError(uint32_t session_id, const common::Status& status, const char* file,

--- a/onnxruntime/core/platform/windows/telemetry.h
+++ b/onnxruntime/core/platform/windows/telemetry.h
@@ -51,7 +51,7 @@ class WindowsTelemetry : public Telemetry {
                           const std::string& model_graph_name,
                           const std::unordered_map<std::string, std::string>& model_metadata,
                           const std::string& loadedFrom, const std::vector<std::string>& execution_provider_ids,
-                          bool use_fp16) const override;
+                          bool use_fp16, bool captureState) const override;
 
   void LogRuntimeError(uint32_t session_id, const common::Status& status, const char* file,
                        const char* function, uint32_t line) const override;

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -234,28 +234,12 @@ void QnnLogging(const char* format,
                 QnnLog_Level_t level,
                 uint64_t timestamp,
                 va_list argument_parameter) {
+  ORT_UNUSED_PARAMETER(level);
   ORT_UNUSED_PARAMETER(timestamp);
 
   const auto& logger = ::onnxruntime::logging::LoggingManager::DefaultLogger();
+  const auto severity = ::onnxruntime::logging::Severity::kVERBOSE;
   const auto data_type = ::onnxruntime::logging::DataType::SYSTEM;
-
-  ::onnxruntime::logging::Severity severity;
-  switch (level) {
-    case QNN_LOG_LEVEL_ERROR:
-      severity = ::onnxruntime::logging::Severity::kERROR;
-      break;
-    case QNN_LOG_LEVEL_WARN:
-      severity = ::onnxruntime::logging::Severity::kWARNING;
-      break;
-    case QNN_LOG_LEVEL_INFO:
-      severity = ::onnxruntime::logging::Severity::kINFO;
-      break;
-    case QNN_LOG_LEVEL_VERBOSE:
-    case QNN_LOG_LEVEL_DEBUG:  // Treat DEBUG as VERBOSE in ORT
-    default:
-      severity = ::onnxruntime::logging::Severity::kVERBOSE;
-      break;
-  }
 
   if (logger.OutputIsEnabled(severity, data_type)) {
     ::onnxruntime::logging::Capture(logger,

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -317,7 +317,7 @@ QnnLog_Level_t QnnBackendManager::MapOrtSeverityToQNNLogLevel(logging::Severity 
 
 Status QnnBackendManager::ResetQnnLogLevel() {
   auto ort_log_level = logger_->GetSeverity();
-  LOGS(*logger_, INFO) << "Reset Qnn log level to ORT Logger level: " << (UINT)ort_log_level;
+  LOGS(*logger_, INFO) << "Reset Qnn log level to ORT Logger level: " << (unsigned int)ort_log_level;
   return UpdateQnnLogLevel(ort_log_level);
 }
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -236,26 +236,25 @@ void QnnLogging(const char* format,
                 va_list argument_parameter) {
   ORT_UNUSED_PARAMETER(timestamp);
 
-  // Always output Qnn log as Ort verbose log
   const auto& logger = ::onnxruntime::logging::LoggingManager::DefaultLogger();
   const auto data_type = ::onnxruntime::logging::DataType::SYSTEM;
 
   ::onnxruntime::logging::Severity severity;
   switch (level) {
-      case QNN_LOG_LEVEL_ERROR:
-          severity = ::onnxruntime::logging::Severity::kERROR;
-          break;
-      case QNN_LOG_LEVEL_WARN:
-          severity = ::onnxruntime::logging::Severity::kWARNING;
-          break;
-      case QNN_LOG_LEVEL_INFO:
-          severity = ::onnxruntime::logging::Severity::kINFO;
-          break;
-      case QNN_LOG_LEVEL_VERBOSE:
-      case QNN_LOG_LEVEL_DEBUG:  // Treat DEBUG as VERBOSE in ORT
-      default:
-          severity = ::onnxruntime::logging::Severity::kVERBOSE;
-          break;
+    case QNN_LOG_LEVEL_ERROR:
+      severity = ::onnxruntime::logging::Severity::kERROR;
+      break;
+    case QNN_LOG_LEVEL_WARN:
+      severity = ::onnxruntime::logging::Severity::kWARNING;
+      break;
+    case QNN_LOG_LEVEL_INFO:
+      severity = ::onnxruntime::logging::Severity::kINFO;
+      break;
+    case QNN_LOG_LEVEL_VERBOSE:
+    case QNN_LOG_LEVEL_DEBUG:  // Treat DEBUG as VERBOSE in ORT
+    default:
+      severity = ::onnxruntime::logging::Severity::kVERBOSE;
+      break;
   }
 
   if (logger.OutputIsEnabled(severity, data_type)) {
@@ -270,87 +269,75 @@ void QnnLogging(const char* format,
 
 void QnnBackendManager::InitializeQnnLog() {
   // Set Qnn log level align with Ort log level
-  QnnLog_Level_t qnn_log_level = QNN_LOG_LEVEL_WARN;
   auto ort_log_level = logger_->GetSeverity();
-  switch (ort_log_level) {
-    case logging::Severity::kVERBOSE:
-      qnn_log_level = QNN_LOG_LEVEL_DEBUG;
-      break;
-    case logging::Severity::kINFO:
-      qnn_log_level = QNN_LOG_LEVEL_INFO;
-      break;
-    case logging::Severity::kWARNING:
-      qnn_log_level = QNN_LOG_LEVEL_WARN;
-      break;
-    case logging::Severity::kERROR:
-      qnn_log_level = QNN_LOG_LEVEL_ERROR;
-      break;
-    default:
-      break;
-  }
+  QnnLog_Level_t qnn_log_level = MapOrtSeverityToQNNLogLevel(ort_log_level);
   LOGS(*logger_, VERBOSE) << "Set Qnn log level: " << qnn_log_level;
 
   Qnn_ErrorHandle_t result = qnn_interface_.logCreate(QnnLogging, qnn_log_level, &log_handle_);
 
   if (result != QNN_SUCCESS) {
-      switch (result) {
-          case QNN_COMMON_ERROR_NOT_SUPPORTED:
-              LOGS(*logger_, ERROR) << "Logging not supported in the QNN backend.";
-              break;
-          case QNN_LOG_ERROR_INVALID_ARGUMENT:
-              LOGS(*logger_, ERROR) << "Invalid argument provided to QnnLog_create.";
-              break;
-          case QNN_LOG_ERROR_MEM_ALLOC:
-              LOGS(*logger_, ERROR) << "Memory allocation error during QNN logging initialization.";
-              break;
-          case QNN_LOG_ERROR_INITIALIZATION:
-              LOGS(*logger_, ERROR) << "Initialization of logging failed in the QNN backend.";
-              break;
-          default:
-              LOGS(*logger_, WARNING) << "Unknown error occurred while initializing logging in the QNN backend.";
-              break;
-      }
+    switch (result) {
+      case QNN_COMMON_ERROR_NOT_SUPPORTED:
+        LOGS(*logger_, ERROR) << "Logging not supported in the QNN backend.";
+        break;
+      case QNN_LOG_ERROR_INVALID_ARGUMENT:
+        LOGS(*logger_, ERROR) << "Invalid argument provided to QnnLog_create.";
+        break;
+      case QNN_LOG_ERROR_MEM_ALLOC:
+        LOGS(*logger_, ERROR) << "Memory allocation error during QNN logging initialization.";
+        break;
+      case QNN_LOG_ERROR_INITIALIZATION:
+        LOGS(*logger_, ERROR) << "Initialization of logging failed in the QNN backend.";
+        break;
+      default:
+        LOGS(*logger_, WARNING) << "Unknown error occurred while initializing logging in the QNN backend.";
+        break;
+    }
   }
 }
 
-void QnnBackendManager::UpdateQnnLogLevel(logging::Severity ort_log_level) {
+QnnLog_Level_t QnnBackendManager::MapOrtSeverityToQNNLogLevel(logging::Severity ort_log_level) {
+  // Map ORT log severity to Qnn log level
+  switch (ort_log_level) {
+    case logging::Severity::kVERBOSE:
+      return QNN_LOG_LEVEL_DEBUG;
+    case logging::Severity::kINFO:
+      return QNN_LOG_LEVEL_INFO;
+    case logging::Severity::kWARNING:
+      return QNN_LOG_LEVEL_WARN;
+    case logging::Severity::kERROR:
+    case logging::Severity::kFATAL:
+    default:
+      return QNN_LOG_LEVEL_ERROR;
+  }
+}
 
+void QnnBackendManager::ResetQnnLogLevel() {
+  auto ort_log_level = logger_->GetSeverity();
+  LOGS(*logger_, INFO) << "Reset Qnn log level to ORT Logger level: " << (UINT) ort_log_level;
+  UpdateQnnLogLevel(ort_log_level);
+}
+
+void QnnBackendManager::UpdateQnnLogLevel(logging::Severity ort_log_level) {
   if (nullptr == log_handle_) {
     LOGS(*logger_, ERROR) << "Unable to update QNN Log Level. Invalid QNN log handle.";
     return;
   }
+  QnnLog_Level_t qnn_log_level = MapOrtSeverityToQNNLogLevel(ort_log_level);
 
-  QnnLog_Level_t qnn_log_level = QNN_LOG_LEVEL_ERROR;
-    // Map ORT log severity to Qnn log level
-    switch (ort_log_level) {
-        case logging::Severity::kVERBOSE:
-            qnn_log_level = QNN_LOG_LEVEL_DEBUG;
-            break;
-        case logging::Severity::kINFO:
-            qnn_log_level = QNN_LOG_LEVEL_INFO;
-            break;
-        case logging::Severity::kWARNING:
-            qnn_log_level = QNN_LOG_LEVEL_WARN;
-            break;
-        case logging::Severity::kERROR:
-        case logging::Severity::kFATAL:
-        default:
-            break;
+  LOGS(*logger_, INFO) << "Updating Qnn log level to: " << qnn_log_level;
+
+  // Use the QnnLog_setLogLevel API to set the new log level
+  Qnn_ErrorHandle_t result = qnn_interface_.logSetLogLevel(log_handle_, qnn_log_level);
+  if (QNN_SUCCESS != result) {
+    if (result == QNN_LOG_ERROR_INVALID_ARGUMENT) {
+      LOGS(*logger_, ERROR) << "Invalid log level argument provided to QnnLog_setLogLevel.";
+    } else if (result == QNN_LOG_ERROR_INVALID_HANDLE) {
+      LOGS(*logger_, ERROR) << "Invalid log handle provided to QnnLog_setLogLevel.";
+    } else {
+      LOGS(*logger_, ERROR) << "Failed to set log level in Qnn backend.";
     }
-
-    LOGS(*logger_, INFO) << "Updating Qnn log level to: " << qnn_log_level;
-
-    // Use the QnnLog_setLogLevel API to set the new log level
-    Qnn_ErrorHandle_t result = qnn_interface_.logSetLogLevel(log_handle_, qnn_log_level);
-    if (QNN_SUCCESS != result) {
-        if (result == QNN_LOG_ERROR_INVALID_ARGUMENT) {
-            LOGS(*logger_, ERROR) << "Invalid log level argument provided to QnnLog_setLogLevel.";
-        } else if (result == QNN_LOG_ERROR_INVALID_HANDLE) {
-            LOGS(*logger_, ERROR) << "Invalid log handle provided to QnnLog_setLogLevel.";
-        } else {
-            LOGS(*logger_, ERROR) << "Failed to set log level in Qnn backend.";
-        }
-    }
+  }
 }
 
 Status QnnBackendManager::InitializeBackend() {

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -314,7 +314,7 @@ QnnLog_Level_t QnnBackendManager::MapOrtSeverityToQNNLogLevel(logging::Severity 
 
 void QnnBackendManager::ResetQnnLogLevel() {
   auto ort_log_level = logger_->GetSeverity();
-  LOGS(*logger_, INFO) << "Reset Qnn log level to ORT Logger level: " << (UINT) ort_log_level;
+  LOGS(*logger_, INFO) << "Reset Qnn log level to ORT Logger level: " << (UINT)ort_log_level;
   UpdateQnnLogLevel(ort_log_level);
 }
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -111,15 +111,15 @@ class QnnBackendManager {
   void SetLogger(const logging::Logger* logger) {
     if (logger_ == nullptr) {
       logger_ = logger;
-      InitializeQnnLog();
+      (void)InitializeQnnLog();
     }
   }
 
-  void InitializeQnnLog();
+  Status InitializeQnnLog();
 
-  void UpdateQnnLogLevel(logging::Severity ort_log_level);
+  Status UpdateQnnLogLevel(logging::Severity ort_log_level);
 
-  void ResetQnnLogLevel();
+  Status ResetQnnLogLevel();
 
   // Terminate logging in the backend
   Status TerminateQnnLog() {
@@ -145,6 +145,8 @@ class QnnBackendManager {
   Status ExtractProfilingEvent(QnnProfile_EventId_t profile_event_id, const std::string& eventLevel,
                                std::ofstream& outfile, bool backendSupportsExtendedEventData,
                                bool tracelogging_provider_ep_enabled);
+
+  Status SetProfilingLevelETW(ProfilingLevel profiling_level_etw_param);
 
   void SetQnnBackendType(uint32_t backend_id);
   QnnBackendType GetQnnBackendType() { return qnn_backend_type_; }

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -119,6 +119,8 @@ class QnnBackendManager {
 
   void UpdateQnnLogLevel(logging::Severity ort_log_level);
 
+  void ResetQnnLogLevel();
+
   // Terminate logging in the backend
   Status TerminateQnnLog() {
     if (logger_ == nullptr) {
@@ -208,6 +210,7 @@ class QnnBackendManager {
   static const std::string GetEventTypeString(QnnProfile_EventType_t eventType);
   static const std::string ExtractQnnScalarValue(const Qnn_Scalar_t& scalar);
   const char* QnnProfileErrorToString(QnnProfile_Error_t error);
+  QnnLog_Level_t MapOrtSeverityToQNNLogLevel(logging::Severity ort_log_level);
 #ifdef _WIN32
   void LogQnnProfileEventAsTraceLogging(
       uint64_t timestamp,

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -117,6 +117,8 @@ class QnnBackendManager {
 
   void InitializeQnnLog();
 
+  void UpdateQnnLogLevel(logging::Severity ort_log_level);
+
   // Terminate logging in the backend
   Status TerminateQnnLog() {
     if (logger_ == nullptr) {

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -244,10 +244,11 @@ QNNExecutionProvider::QNNExecutionProvider(const ProviderOptions& provider_optio
         (void)FilterData;
         (void)CallbackContext;
 
-        if (((MatchAnyKeyword & static_cast<ULONGLONG>(onnxruntime::logging::ORTTraceLoggingKeyword::Logs)) != 0) &&
-            IsEnabled == EVENT_CONTROL_CODE_ENABLE_PROVIDER) {
-          auto ortETWSeverity = etwRegistrationManager.MapLevelToSeverity();
-          qnn_backend_manager_->UpdateQnnLogLevel(ortETWSeverity);
+        if (IsEnabled == EVENT_CONTROL_CODE_ENABLE_PROVIDER) {
+          if ((MatchAnyKeyword & static_cast<ULONGLONG>(onnxruntime::logging::ORTTraceLoggingKeyword::Logs)) != 0) {
+            auto ortETWSeverity = etwRegistrationManager.MapLevelToSeverity();
+            qnn_backend_manager_->UpdateQnnLogLevel(ortETWSeverity);
+          }
         }
 
         if (IsEnabled == EVENT_CONTROL_CODE_DISABLE_PROVIDER) {

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -23,6 +23,11 @@
 #include "core/providers/qnn/builder/onnx_ctx_model_helper.h"
 #include "core/framework/run_options.h"
 
+#ifdef _WIN32
+#include <Windows.h>
+#include "core/platform/windows/logging/etw_sink.h"
+#endif
+
 namespace onnxruntime {
 
 constexpr const char* QNN = "QNN";
@@ -219,6 +224,37 @@ QNNExecutionProvider::QNNExecutionProvider(const ProviderOptions& provider_optio
       }
     }
   }
+
+#ifdef _WIN32
+    auto& etwRegistrationManager = logging::EtwRegistrationManager::Instance();
+    // Register callback for ETW capture state (rundown)
+    etwRegistrationManager.RegisterInternalCallback(
+        [&etwRegistrationManager, this](
+            LPCGUID SourceId,
+            ULONG IsEnabled,
+            UCHAR Level,
+            ULONGLONG MatchAnyKeyword,
+            ULONGLONG MatchAllKeyword,
+            PEVENT_FILTER_DESCRIPTOR FilterData,
+            PVOID CallbackContext) {
+          (void)SourceId;
+          (void)Level;
+          (void)MatchAnyKeyword;
+          (void)MatchAllKeyword;
+          (void)FilterData;
+          (void)CallbackContext;
+
+          // Check if this callback is for enabling
+          if (((MatchAnyKeyword & static_cast<ULONGLONG>(onnxruntime::logging::ORTTraceLoggingKeyword::Logs)) != 0) &&
+              IsEnabled == EVENT_CONTROL_CODE_ENABLE_PROVIDER) {
+            auto ortETWSeverity = etwRegistrationManager.MapLevelToSeverity();
+            qnn_backend_manager_->UpdateQnnLogLevel(ortETWSeverity);
+          }
+
+          // We can't just set to whatever when ETW is disabled. TODO - We need to remember/restore the original value
+          // (IsEnabled == EVENT_CONTROL_CODE_DISABLE_PROVIDER)
+        });
+#endif
 
   // In case ETW gets disabled later
   auto profiling_level_pos = provider_options_map.find(PROFILING_LEVEL);

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -70,6 +70,8 @@ class QNNExecutionProvider : public IExecutionProvider {
 
   void InitQnnGraphConfigs(qnn::QnnConfigsBuilder<QnnGraph_Config_t, QnnHtpGraph_CustomConfig_t>& configs_builder) const;
 
+  qnn::ProfilingLevel GetProfilingLevelFromETWLevel(unsigned char level);
+
  private:
   qnn::HtpGraphFinalizationOptimizationMode htp_graph_finalization_opt_mode_ = qnn::HtpGraphFinalizationOptimizationMode::kDefault;
   std::unique_ptr<qnn::QnnBackendManager> qnn_backend_manager_;

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -567,7 +567,7 @@ void InferenceSession::ConstructorCommon(const SessionOptions& session_options,
 }
 
 void InferenceSession::TraceSessionOptions(const SessionOptions& session_options, bool captureState) {
-  ORT_UNUSED_PARAMETER(captureState); // Otherwise Linux build error
+  ORT_UNUSED_PARAMETER(captureState);  // Otherwise Linux build error
 
   LOGS(*session_logger_, INFO) << session_options;
 

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -422,11 +422,11 @@ void InferenceSession::ConstructorCommon(const SessionOptions& session_options,
           if ((MatchAnyKeyword & static_cast<ULONGLONG>(onnxruntime::logging::ORTTraceLoggingKeyword::Logs)) != 0 &&
               IsEnabled == EVENT_CONTROL_CODE_ENABLE_PROVIDER) {
             LOGS(*session_logger_, VERBOSE) << "Adding ETW Sink to logger with severity level: " << (ULONG)ortETWSeverity;
-            logging_manager_->AddSink(
+            logging_manager_->AddSinkOfType(
                 onnxruntime::logging::SinkType::EtwSink,
                 []() -> std::unique_ptr<onnxruntime::logging::ISink> { return std::make_unique<onnxruntime::logging::EtwSink>(); },
                 ortETWSeverity);
-            onnxruntime::logging::LoggingManager::GetDefaultInstance()->AddSink(
+            onnxruntime::logging::LoggingManager::GetDefaultInstance()->AddSinkOfType(
                 onnxruntime::logging::SinkType::EtwSink,
                 []() -> std::unique_ptr<onnxruntime::logging::ISink> { return std::make_unique<onnxruntime::logging::EtwSink>(); },
                 ortETWSeverity);

--- a/onnxruntime/core/session/ort_env.cc
+++ b/onnxruntime/core/session/ort_env.cc
@@ -48,7 +48,7 @@ OrtEnv* OrtEnv::GetInstance(const OrtEnv::LoggingManagerConstructionInfo& lm_inf
       sink = MakePlatformDefaultLogSink();
     }
     auto etwOverrideSeverity = logging::OverrideLevelWithEtw(static_cast<Severity>(lm_info.default_warning_level));
-    sink = EnhanceLoggerWithEtw(std::move(sink), static_cast<Severity>(lm_info.default_warning_level),
+    sink = EnhanceSinkWithEtw(std::move(sink), static_cast<Severity>(lm_info.default_warning_level),
                                 etwOverrideSeverity);
     lmgr = std::make_unique<LoggingManager>(std::move(sink),
                                             std::min(static_cast<Severity>(lm_info.default_warning_level), etwOverrideSeverity),

--- a/onnxruntime/core/session/ort_env.cc
+++ b/onnxruntime/core/session/ort_env.cc
@@ -49,7 +49,7 @@ OrtEnv* OrtEnv::GetInstance(const OrtEnv::LoggingManagerConstructionInfo& lm_inf
     }
     auto etwOverrideSeverity = logging::OverrideLevelWithEtw(static_cast<Severity>(lm_info.default_warning_level));
     sink = EnhanceSinkWithEtw(std::move(sink), static_cast<Severity>(lm_info.default_warning_level),
-                                etwOverrideSeverity);
+                              etwOverrideSeverity);
     lmgr = std::make_unique<LoggingManager>(std::move(sink),
                                             std::min(static_cast<Severity>(lm_info.default_warning_level), etwOverrideSeverity),
                                             false,

--- a/onnxruntime/test/common/logging/helpers.h
+++ b/onnxruntime/test/common/logging/helpers.h
@@ -18,6 +18,16 @@ class MockSink : public ::onnxruntime::logging::ISink {
                               const ::onnxruntime::logging::Capture& message));
 };
 
+class MockEtwSink : public ::onnxruntime::logging::ISink {
+ public:
+  MockEtwSink() : ISink(onnxruntime::logging::SinkType::EtwSink) {}
+  ~MockEtwSink() = default;
+
+  MOCK_METHOD3(SendImpl, void(const ::onnxruntime::logging::Timestamp& timestamp,
+                              const std::string& logger_id,
+                              const ::onnxruntime::logging::Capture& message));
+};
+
 // The ACTION*() macros trigger warning C4100 (unreferenced formal
 // parameter) in MSVC with -W4.  Unfortunately they cannot be fixed in
 // the macro definition, as the warnings are generated when the macro

--- a/onnxruntime/test/common/logging/sinks_test.cc
+++ b/onnxruntime/test/common/logging/sinks_test.cc
@@ -179,7 +179,7 @@ TEST(LoggingTests, TestRemoveSink) {
 
   // Remove the sink and check severity update
   auto new_severity = sink.RemoveSink(SinkType::EtwSink);
-  EXPECT_EQ(new_severity, Severity::kERROR);  // assuming mock_sink1 had SpecificType and was removed
+  EXPECT_EQ(new_severity, Severity::kWARNING);  // assuming mock_sink2 had SpecificType and was removed
 
   // Verify that sink2 is still in the composite
   EXPECT_TRUE(sink.HasType(SinkType::BaseSink));

--- a/onnxruntime/test/common/logging/sinks_test.cc
+++ b/onnxruntime/test/common/logging/sinks_test.cc
@@ -144,8 +144,8 @@ TEST(LoggingTests, TestFileSink) {
 /// <summary>
 /// Tests that a composite_sink works correctly.
 /// </summary>
-TEST(LoggingTests, TestCompositeSink) {
-  const std::string logid{"TestCompositeSink"};
+TEST(LoggingTests, TestCompositeSinkBasic) {
+  const std::string logid{"TestCompositeSinkBasic"};
   const Severity min_log_level = Severity::kWARNING;
 
   MockSink* sink_ptr1 = new MockSink();
@@ -162,4 +162,59 @@ TEST(LoggingTests, TestCompositeSink) {
   auto logger = manager.CreateLogger(logid);
 
   LOGS_CATEGORY(*logger, WARNING, "ArbitraryCategory") << "Warning";
+}
+
+/// <summary>
+/// Tests that removing a sink of a specific type correctly updates the composite sink.
+/// </summary>
+TEST(LoggingTests, TestRemoveSink) {
+  CompositeSink sink;
+  MockSink* mock_sink1 = new MockSink();
+  MockEtwSink* mock_sink2 = new MockEtwSink();
+  sink.AddSink(std::unique_ptr<ISink>(mock_sink1), Severity::kWARNING);
+  sink.AddSink(std::unique_ptr<ISink>(mock_sink2), Severity::kERROR);
+
+  // Set expectations that no SendImpl will be called on the removed sink
+  EXPECT_CALL(*mock_sink1, SendImpl(testing::_, testing::_, testing::_)).Times(0);
+
+  // Remove the sink and check severity update
+  auto new_severity = sink.RemoveSink(SinkType::EtwSink);
+  EXPECT_EQ(new_severity, Severity::kERROR);  // assuming mock_sink1 had SpecificType and was removed
+
+  // Verify that sink2 is still in the composite
+  EXPECT_TRUE(sink.HasType(SinkType::BaseSink));
+}
+
+/// <summary>
+/// Tests the HasOnlyOneSink method to ensure it correctly identifies when one sink is left.
+/// </summary>
+TEST(LoggingTests, TestHasOnlyOneSink) {
+  CompositeSink sink;
+  sink.AddSink(std::unique_ptr<ISink>(new MockEtwSink()), Severity::kWARNING);
+  sink.AddSink(std::unique_ptr<ISink>(new MockSink()), Severity::kERROR);
+
+  EXPECT_FALSE(sink.HasOnlyOneSink());
+
+  sink.RemoveSink(SinkType::EtwSink);
+  EXPECT_TRUE(sink.HasOnlyOneSink());
+
+  sink.RemoveSink(SinkType::BaseSink);  // Remove the last one
+  EXPECT_FALSE(sink.HasOnlyOneSink());
+}
+
+/// <summary>
+/// Tests the GetRemoveSingleSink method to ensure it returns the last sink and empties the composite sink.
+/// </summary>
+TEST(LoggingTests, TestGetRemoveSingleSink) {
+  CompositeSink sink;
+  auto* single_mock_sink = new MockSink();
+  sink.AddSink(std::unique_ptr<ISink>(single_mock_sink), Severity::kWARNING);
+
+  // Check we have one sink
+  EXPECT_TRUE(sink.HasOnlyOneSink());
+
+  // Get and remove the single sink
+  auto removed_sink = sink.GetRemoveSingleSink();
+  EXPECT_EQ(removed_sink.get(), single_mock_sink);  // Check it's the same sink
+  EXPECT_FALSE(sink.HasOnlyOneSink());              // Should be empty now
 }

--- a/ort.wprp
+++ b/ort.wprp
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- TODO: 
+<!-- TODO:
 1. Find and replace "OrtTraceLoggingProvider" with your component name.
 2. See TODO below to update GUID for your event provider
 -->
@@ -12,8 +12,11 @@
       <Buffers Value="10" PercentageOfTotalMemory="true"/>
     </EventCollector>
 
-    <EventProvider Id="EventProvider_OrtTraceLoggingProvider"
-      Name="3a26b1ff-7484-7484-7484-15261f42614d" Level="5" />
+    <EventProvider Id="EventProvider_OrtTraceLoggingProvider" Name="3a26b1ff-7484-7484-7484-15261f42614d" Level="5" >
+      <CaptureStateOnSave>
+        <Keyword Value="0x1"/> <!-- Session rundown -->
+      </CaptureStateOnSave>
+    </EventProvider>
     <Profile Id="OrtTraceLoggingProvider.Verbose.File"
       Name="OrtTraceLoggingProvider" Description="OrtTraceLoggingProvider"
       LoggingMode="File" DetailLevel="Verbose">


### PR DESCRIPTION
### Description
Windows - Fully dynamic ETW controlled logging for ORT and QNN logs

The logging support is documented here 
- https://onnxruntime.ai/docs/performance/tune-performance/logging_tracing.html#tracing---windows
- https://onnxruntime.ai/docs/performance/tune-performance/profiling-tools.html#tracelogging-etw-windows-profiling

Also add support for logging ORT SessionCreation on ETW CaptureState

### Motivation and Context
The previous ETW support only worked if you enabled ETW before the session started. There can commonly be long-lived AI inference processes that need to be traced & debugged. This enables logging fully on the fly.

Without this support a dev would have to end up killing a process or stopping a service in order to get tracing. We had to do this for a recent issue with QNN, and it was a bit painful to get the logs and it ruined the repro.

### Testing
I tested with the following cases
- Leaving default ORT run
- Enabling ETW prior to start and leaving running for entire session + inferences, then stopping
- Starting ORT session + inf, then enabling and stopping ETW
  - Start ORT session /w long running Inferences 
  - wpr -start [ort.wprp](https://github.com/microsoft/onnxruntime/blob/e6228575e4d5866bdb831e76cc93e6c35af4de8b/ort.wprp#L4) -start [etw_provider.wprp](https://github.com/microsoft/onnxruntime/blob/e6228575e4d5866bdb831e76cc93e6c35af4de8b/onnxruntime/test/platform/windows/logging/etw_provider.wprp)
  - Wait a few seconds
  - wpr -stop ort.etl
  - Inferences are still running
  - Verify ONNXRuntimeLogEvent provider events are present and new SessionCreation_CaptureState event under Microsoft.ML.ONNXRuntime provider

Related:
#18882
#19428

