### PR TITLE
fix(build): add missing include

### DIFF
--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -6,6 +6,7 @@
 #include <functional>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <string>
 #include <type_traits>
 #include <unordered_map>


### PR DESCRIPTION
### Description
Add missing `#include <optional>` in `include/onnxruntime/core/graph/graph.h`

### Motivation and Context
The current status is that it relies on 3rd party includes to provide this include file.
`std::optional` is used directly in the file so this include should be present. https://github.com/microsoft/onnxruntime/blob/a36692066da2b9b4d1d6a91f45630af5c62d3288/include/onnxruntime/core/graph/graph.h#L1472-L1477

Version 1.17.3 fails to build in ConanCenter without this patch (most likely because abseil is built as c++14 on Windows).
c.f. https://github.com/conan-io/conan-center-index/pull/23409#issuecomment-2094207580 

