### PR TITLE
[TensorRT EP] to support 10-GA oss parser

### DIFF
--- a/cmake/onnxruntime_providers_tensorrt.cmake
+++ b/cmake/onnxruntime_providers_tensorrt.cmake
@@ -85,8 +85,12 @@
     endif()
   endif()
 
-  if (onnxruntime_USE_TENSORRT_BUILTIN_PARSER)
-    # Add TensorRT library
+  # Add TensorRT library
+  if (onnxruntime_USE_TENSORRT_BUILTIN_PARSER OR
+      (NV_TENSORRT_MAJOR_INT GREATER 10) OR
+      (NV_TENSORRT_MAJOR_INT EQUAL 10 AND NV_TENSORRT_MINOR_INT GREATER 0) OR
+      (NV_TENSORRT_MAJOR_INT EQUAL 10 AND NV_TENSORRT_PATCH_INT GREATER 0))
+
     MESSAGE(STATUS "Search for ${NVINFER_LIB}, ${NVINFER_PLUGIN_LIB} and ${PARSER_LIB}")
 
     find_library(TENSORRT_LIBRARY_INFER ${NVINFER_LIB}
@@ -105,6 +109,7 @@
       MESSAGE(STATUS "Can't find ${NVINFER_PLUGIN_LIB}")
     endif()
 
+  if (onnxruntime_USE_TENSORRT_BUILTIN_PARSER)
     find_library(TENSORRT_LIBRARY_NVONNXPARSER ${PARSER_LIB}
       HINTS  ${TENSORRT_ROOT}
       PATH_SUFFIXES lib lib64 lib/x64)
@@ -114,7 +119,6 @@
     endif()
 
     set(TENSORRT_LIBRARY ${TENSORRT_LIBRARY_INFER} ${TENSORRT_LIBRARY_INFER_PLUGIN} ${TENSORRT_LIBRARY_NVONNXPARSER})
-    MESSAGE(STATUS "Find TensorRT libs at ${TENSORRT_LIBRARY}")
   else()
     FetchContent_Declare(
       onnx_tensorrt
@@ -148,10 +152,12 @@
     if ((NV_TENSORRT_MAJOR_INT GREATER 10) OR
         (NV_TENSORRT_MAJOR_INT EQUAL 10 AND NV_TENSORRT_MINOR_INT GREATER 0) OR
         (NV_TENSORRT_MAJOR_INT EQUAL 10 AND NV_TENSORRT_PATCH_INT GREATER 0))
+      set(TENSORRT_LIBRARY ${TENSORRT_LIBRARY_INFER} ${TENSORRT_LIBRARY_INFER_PLUGIN})
       set(onnxparser_link_libs nvonnxparser_static ${TENSORRT_LIBRARY})
     else()
       set(onnxparser_link_libs nvonnxparser_static)
     endif()
+    MESSAGE(STATUS "Find TensorRT libs at ${TENSORRT_LIBRARY}")
   endif()
 
   include_directories(${TENSORRT_INCLUDE_DIR})

--- a/cmake/onnxruntime_providers_tensorrt.cmake
+++ b/cmake/onnxruntime_providers_tensorrt.cmake
@@ -82,6 +82,7 @@
       set(PARSER_LIB "nvonnxparser_${NV_TENSORRT_MAJOR}")
     else()
       set(PARSER_LIB "nvonnxparser")
+    endif()
   endif()
 
   if (onnxruntime_USE_TENSORRT_BUILTIN_PARSER)

--- a/cmake/onnxruntime_providers_tensorrt.cmake
+++ b/cmake/onnxruntime_providers_tensorrt.cmake
@@ -77,7 +77,11 @@
   endif()
 
   if (NOT PARSER_LIB)
-     set(PARSER_LIB "nvonnxparser")
+    # See https://github.com/onnx/onnx-tensorrt/blame/d609f4ad6275ad39bfac8060a3ed6a5cba5d7a81/CMakeLists.txt#L108-L112
+    if (NOT onnxruntime_USE_TENSORRT_BUILTIN_PARSER AND MSVC)
+      set(PARSER_LIB "nvonnxparser_${NV_TENSORRT_MAJOR}")
+    else()
+      set(PARSER_LIB "nvonnxparser")
   endif()
 
   if (onnxruntime_USE_TENSORRT_BUILTIN_PARSER)

--- a/cmake/onnxruntime_providers_tensorrt.cmake
+++ b/cmake/onnxruntime_providers_tensorrt.cmake
@@ -108,7 +108,8 @@
     if (NOT TENSORRT_LIBRARY_INFER_PLUGIN)
       MESSAGE(STATUS "Can't find ${NVINFER_PLUGIN_LIB}")
     endif()
-
+  endif()
+  
   if (onnxruntime_USE_TENSORRT_BUILTIN_PARSER)
     find_library(TENSORRT_LIBRARY_NVONNXPARSER ${PARSER_LIB}
       HINTS  ${TENSORRT_ROOT}


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
This change is required as onnx-tensorrt 10-GA branch is no longer linked against tensorrt libraries.
See https://github.com/onnx/onnx-tensorrt/blame/d609f4ad6275ad39bfac8060a3ed6a5cba5d7a81/CMakeLists.txt#L134 for more detail.




### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Under current cmake setting, error happens when building ORT: 
```cmake
/usr/bin/ld: CMakeFiles/onnxruntime_test_all.dir/workspace/yifanl/onnxruntime/onnxruntime/test/unittest_main/test_main.cc.o: in function `_GLOBAL__sub_I_ort_env':
test_main.cc:(.text.startup._GLOBAL__sub_I_ort_env+0x86): undefined reference to `createInferBuilder_INTERNAL'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/onnxruntime_test_all.dir/build.make:5164: onnxruntime_test_all] Error 1
make[1]: *** [CMakeFiles/Makefile2:2643: CMakeFiles/onnxruntime_test_all.dir/all] Error 2
make: *** [Makefile:166: all] Error 2
```



