### PR TITLE
[mlas] Speed up tanhf activation function

### DIFF
--- a/onnxruntime/core/mlas/lib/amd64/TanhKernelFma3.asm
+++ b/onnxruntime/core/mlas/lib/amd64/TanhKernelFma3.asm
@@ -64,39 +64,33 @@ INCLUDE TransKernelCommon.inc
         END_PROLOGUE
 
         lea     rax,MlasTanhConstants
-        vbroadcastss ymm4,TanhConstants.LowerRange[rax]
-        vbroadcastss ymm5,TanhConstants.UpperRange[rax]
-        vbroadcastss ymm6,TanhConstants.alpha_13[rax]
-        vbroadcastss ymm7,TanhConstants.alpha_11[rax]
-        vbroadcastss ymm8,TanhConstants.alpha_9[rax]
-        vbroadcastss ymm9,TanhConstants.alpha_7[rax]
-        vbroadcastss ymm10,TanhConstants.alpha_5[rax]
-        vbroadcastss ymm11,TanhConstants.alpha_3[rax]
-        vbroadcastss ymm12,TanhConstants.alpha_1[rax]
-        vbroadcastss ymm13,TanhConstants.beta_6[rax]
-        vbroadcastss ymm14,TanhConstants.beta_2[rax]
-        vbroadcastss ymm15,TanhConstants.beta_0[rax]
+        vbroadcastss ymm5,  DWORD PTR [rax + 0]   ; nc2
+        vbroadcastss ymm6,  DWORD PTR [rax + 4]   ; nc1
+        vbroadcastss ymm4,  DWORD PTR [rax + 8]   ; nc0
+        vbroadcastss ymm7,  DWORD PTR [rax + 12]  ; dc2
+        vbroadcastss ymm8,  DWORD PTR [rax + 16]  ; dc1
+        vbroadcastss ymm9,  DWORD PTR [rax + 20]  ; dc0
+        vbroadcastss ymm10, DWORD PTR [rax + 24]  ; absmask
+        vbroadcastss ymm11, DWORD PTR [rax + 28]  ; bound
 
         sub     r8,8
         jb      ProcessRemainingCount
 
 ComputeTanhBy8Loop:
-        vmaxps  ymm0,ymm4,YMMWORD PTR [rcx]     ; clamp lower bound
-        vmovaps ymm2,ymm7
-        vminps  ymm0,ymm5,ymm0                  ; clamp upper bound
-        vmulps  ymm1,ymm0,ymm0                  ; x2
-        vbroadcastss ymm3,TanhConstants.beta_4[rax]
-        vfmadd231ps ymm2,ymm1,ymm6              ; p = x2 * alpha_13 + alpha_11
-        vfmadd213ps ymm2,ymm1,ymm8              ; p = x2 * p + alpha_9
-        vfmadd213ps ymm2,ymm1,ymm9              ; p = x2 * p + alpha_7
-        vfmadd213ps ymm2,ymm1,ymm10             ; p = x2 * p + alpha_5
-        vfmadd213ps ymm2,ymm1,ymm11             ; p = x2 * p + alpha_3
-        vfmadd213ps ymm2,ymm1,ymm12             ; p = x2 * p + alpha_1
-        vfmadd231ps ymm3,ymm1,ymm13             ; q = x2 * beta_6 + beta_4
-        vfmadd213ps ymm3,ymm1,ymm14             ; q = x2 * q + beta_2
-        vfmadd213ps ymm3,ymm1,ymm15             ; q = x2 * q + beta_0
-        vmulps  ymm2,ymm0,ymm2                  ; p = x * p
-        vdivps  ymm0,ymm2,ymm3                  ; tanh = p / q
+        vandps      ymm0,ymm10,YMMWORD PTR [rcx]
+	vmovaps	    ymm3, ymm5
+	vmovaps	    ymm13, ymm7
+	vxorps	    ymm1, ymm0, YMMWORD PTR [rcx]
+	vmulps	    ymm2, ymm0, ymm0
+	vcmpps	    ymm12, ymm0, ymm11, 29
+	vfmadd132ps ymm3, ymm6, ymm2
+	vfmadd132ps ymm13, ymm8, ymm2
+	vfmadd132ps ymm3, ymm4, ymm2
+	vfmadd132ps ymm2, ymm9, ymm13
+	vfmadd132ps ymm0, ymm0, ymm2
+	vdivps      ymm0, ymm0, ymm3
+	vblendvps   ymm0, ymm0, ymm4, ymm12
+	vxorps      ymm0, ymm0, ymm1
         add     rcx,8*4                         ; advance input by 8 elements
         vmovups YMMWORD PTR [rdx],ymm0
         add     rdx,8*4                         ; advance output by 8 elements
@@ -108,24 +102,23 @@ ProcessRemainingCount:
         jz      ExitKernel
         neg     r8
         lea     r10,MlasMaskMoveTableAvx+8*4
-        vmovups ymm2,YMMWORD PTR [r10+r8*4]
-        vmaskmovps ymm0,ymm2,YMMWORD PTR [rcx]
-        vmaxps  ymm0,ymm4,ymm0                  ; clamp lower bound
-        vminps  ymm0,ymm5,ymm0                  ; clamp upper bound
-        vmulps  ymm1,ymm0,ymm0                  ; x2
-        vbroadcastss ymm3,TanhConstants.beta_4[rax]
-        vfmadd231ps ymm7,ymm1,ymm6              ; p = x2 * alpha_13 + alpha_11
-        vfmadd213ps ymm7,ymm1,ymm8              ; p = x2 * p + alpha_9
-        vfmadd213ps ymm7,ymm1,ymm9              ; p = x2 * p + alpha_7
-        vfmadd213ps ymm7,ymm1,ymm10             ; p = x2 * p + alpha_5
-        vfmadd213ps ymm7,ymm1,ymm11             ; p = x2 * p + alpha_3
-        vfmadd213ps ymm7,ymm1,ymm12             ; p = x2 * p + alpha_1
-        vfmadd231ps ymm3,ymm1,ymm13             ; q = x2 * beta_6 + beta_4
-        vfmadd213ps ymm3,ymm1,ymm14             ; q = x2 * q + beta_2
-        vfmadd213ps ymm3,ymm1,ymm15             ; q = x2 * q + beta_0
-        vmulps  ymm7,ymm0,ymm7                  ; p = x * p
-        vdivps  ymm0,ymm7,ymm3                  ; tanh = p / q
-        vmaskmovps YMMWORD PTR [rdx],ymm2,ymm0
+        vmovups     ymm15,YMMWORD PTR [r10+r8*4]
+        vmaskmovps  ymm0,ymm15,YMMWORD PTR [rcx]
+        vandps      ymm0,ymm10,ymm0
+	vmovaps	    ymm3, ymm5
+	vmovaps	    ymm13, ymm7
+	vxorps	    ymm1, ymm0, YMMWORD PTR [rcx]
+	vmulps	    ymm2, ymm0, ymm0
+	vcmpps	    ymm12, ymm0, ymm11, 29
+	vfmadd132ps ymm3, ymm6, ymm2
+	vfmadd132ps ymm13, ymm8, ymm2
+	vfmadd132ps ymm3, ymm4, ymm2
+	vfmadd132ps ymm2, ymm9, ymm13
+	vfmadd132ps ymm0, ymm0, ymm2
+	vdivps      ymm0, ymm0, ymm3
+	vblendvps   ymm0, ymm0, ymm4, ymm12
+	vxorps      ymm0, ymm0, ymm1
+        vmaskmovps  YMMWORD PTR [rdx],ymm15,ymm0
 
 ExitKernel:
         vzeroupper

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -1735,6 +1735,17 @@ MlasLoadFloat32x4(const float* Buffer)
 }
 
 MLAS_FORCEINLINE
+MLAS_FLOAT32X4
+MlasPartialLoadFloat32x4(const float* Buffer, const int N)
+{
+    float temp[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+    for (int ii = 0; ii < N; ++ii) {
+        temp[ii] = Buffer[ii];
+    }
+    return MlasLoadFloat32x4(temp);
+}
+
+MLAS_FORCEINLINE
 void
 MlasStoreFloat32x4(float* Buffer, MLAS_FLOAT32X4 Vector)
 {
@@ -1751,6 +1762,17 @@ MlasStoreFloat32x4(float* Buffer, MLAS_FLOAT32X4 Vector)
 #else
     *((MLAS_FLOAT32X4*)Buffer) = Vector;
 #endif
+}
+
+MLAS_FORCEINLINE
+void
+MlasPartialStoreFloat32x4(float* Buffer, MLAS_FLOAT32X4 Vector, const int N)
+{
+    float temp[4];
+    MlasStoreFloat32x4(temp, Vector);
+    for (int ii = 0; ii < N; ++ii) {
+        Buffer[ii] = temp[ii];
+    }
 }
 
 MLAS_FORCEINLINE
@@ -2044,6 +2066,25 @@ MlasDivideFloat32x4(MLAS_FLOAT32X4 Vector1, MLAS_FLOAT32X4 Vector2)
     return __lsx_vfdiv_s(Vector1, Vector2);
 #else
     return Vector1 / Vector2;
+#endif
+}
+
+MLAS_FORCEINLINE
+MLAS_FLOAT32X4
+MlasGreaterThanEqualFloat32x4(MLAS_FLOAT32X4 Vector1, MLAS_FLOAT32X4 Vector2)
+{
+#if defined(MLAS_NEON_INTRINSICS)
+    return vreinterpretq_f32_u32(vcgeq_f32(Vector1, Vector2));
+#elif defined(MLAS_SSE2_INTRINSICS)
+    return _mm_cmpge_ps(Vector1, Vector2);
+#elif defined(MLAS_WASM_SIMD_INTRINSICS)
+    return wasm_f32x4_ge(Vector1, Vector2);
+#elif defined(MLAS_VSX_INTRINSICS)
+    return MLAS_FLOAT32X4(vec_cmpge(Vector1, Vector2));
+#elif defined(MLAS_LSX_INTRINSICS)
+    return (MLAS_FLOAT32X4)__lsx_vfcmp_cle_s(Vector2, Vector1);
+#else
+    return Vector1 >= Vector2;
 #endif
 }
 

--- a/onnxruntime/core/mlas/lib/tanh.cpp
+++ b/onnxruntime/core/mlas/lib/tanh.cpp
@@ -27,33 +27,23 @@ Abstract:
 //
 
 MLAS_INTERNAL_DATA const struct {
-    float LowerRange;
-    float UpperRange;
-    float alpha_13;
-    float alpha_11;
-    float alpha_9;
-    float alpha_7;
-    float alpha_5;
-    float alpha_3;
-    float alpha_1;
-    float beta_6;
-    float beta_4;
-    float beta_2;
-    float beta_0;
+    uint32_t _nc2;
+    uint32_t _nc1;
+    uint32_t _nc0;
+    uint32_t _dc2;
+    uint32_t _dc1;
+    uint32_t _dc0;
+    uint32_t _absmask;
+    uint32_t _ubound;
 } MlasTanhConstants = {
-    -9.0f,
-    9.0f,
-    -2.76076847742355e-16f,
-    2.00018790482477e-13f,
-    -8.60467152213735e-11f,
-    5.12229709037114e-08f,
-    1.48572235717979e-05f,
-    6.37261928875436e-04f,
-    4.89352455891786e-03f,
-    1.19825839466702e-06f,
-    1.18534705686654e-04f,
-    2.26843463243900e-03f,
-    4.89352518554385e-03f,
+    0x3c520a84,  /* _nc2  */
+    0x3edef102,  /* _nc1  */
+    0x3f800000,  /* _nc0  */
+    0x3a2fc8e6,  /* _dc2  */
+    0x3dd1c060,  /* _dc1  */
+    0xb859e195,  /* _dc0  */
+    0x7fffffff,  /* _absmask  */
+    0x40a00000,  /* _ubound = +5.0f */
 };
 
 void
@@ -83,69 +73,51 @@ Return Value:
 
 --*/
 {
-    while (N >= 4) {
+    const MLAS_FLOAT32X4 nc0 = MlasBroadcastFloat32x4((float*)&MlasTanhConstants._nc0);
+    const MLAS_FLOAT32X4 nc1 = MlasBroadcastFloat32x4((float*)&MlasTanhConstants._nc1);
+    const MLAS_FLOAT32X4 nc2 = MlasBroadcastFloat32x4((float*)&MlasTanhConstants._nc2);
+    const MLAS_FLOAT32X4 dc0 = MlasBroadcastFloat32x4((float*)&MlasTanhConstants._dc0);
+    const MLAS_FLOAT32X4 dc1 = MlasBroadcastFloat32x4((float*)&MlasTanhConstants._dc1);
+    const MLAS_FLOAT32X4 dc2 = MlasBroadcastFloat32x4((float*)&MlasTanhConstants._dc2);
+    const MLAS_FLOAT32X4 ub  = MlasBroadcastFloat32x4((float*)&MlasTanhConstants._ubound);
+    const MLAS_FLOAT32X4 absmask = MlasBroadcastFloat32x4((float*)&MlasTanhConstants._absmask);
+    MLAS_FLOAT32X4 Val;
 
-        MLAS_FLOAT32X4 Value = MlasLoadFloat32x4(Input);
+    size_t count = 0;
+    while (count < N) {
 
-        Value = MlasMaximumFloat32x4(MlasBroadcastFloat32x4(MlasTanhConstants.LowerRange), Value);
-        Value = MlasMinimumFloat32x4(MlasBroadcastFloat32x4(MlasTanhConstants.UpperRange), Value);
+        if (N - count >= 4) {
+            Val = MlasLoadFloat32x4(Input);
+        }
+        else {
+            Val = MlasPartialLoadFloat32x4(Input, N - count);
+        }
+        MLAS_FLOAT32X4 ValAbs       = MlasAndFloat32x4(Val, absmask);
+        MLAS_FLOAT32X4 boundmask    = MlasGreaterThanEqualFloat32x4(ValAbs, ub);
+        MLAS_FLOAT32X4 signVal      = MlasXorFloat32x4(ValAbs, Val);
+        MLAS_FLOAT32X4 ValSq        = MlasMultiplyFloat32x4(ValAbs, ValAbs);
 
-        MLAS_FLOAT32X4 ValueSquared = MlasMultiplyFloat32x4(Value, Value);
+        MLAS_FLOAT32X4 npoly = MlasMultiplyAddFloat32x4(nc2, ValSq, nc1);
+        npoly = MlasMultiplyAddFloat32x4(npoly, ValSq, nc0);
 
-        MLAS_FLOAT32X4 p;
-        p = MlasMultiplyAddFloat32x4(ValueSquared, MlasBroadcastFloat32x4(MlasTanhConstants.alpha_13),
-            MlasBroadcastFloat32x4(MlasTanhConstants.alpha_11));
-        p = MlasMultiplyAddFloat32x4(p, ValueSquared, MlasBroadcastFloat32x4(MlasTanhConstants.alpha_9));
-        p = MlasMultiplyAddFloat32x4(p, ValueSquared, MlasBroadcastFloat32x4(MlasTanhConstants.alpha_7));
-        p = MlasMultiplyAddFloat32x4(p, ValueSquared, MlasBroadcastFloat32x4(MlasTanhConstants.alpha_5));
-        p = MlasMultiplyAddFloat32x4(p, ValueSquared, MlasBroadcastFloat32x4(MlasTanhConstants.alpha_3));
-        p = MlasMultiplyAddFloat32x4(p, ValueSquared, MlasBroadcastFloat32x4(MlasTanhConstants.alpha_1));
-        p = MlasMultiplyFloat32x4(p, Value);
+        MLAS_FLOAT32X4 dpoly = MlasMultiplyAddFloat32x4(dc2, ValSq, dc1);
+        dpoly = MlasMultiplyAddFloat32x4(dpoly, ValSq, dc0);
+        dpoly = MlasMultiplyAddFloat32x4(dpoly, ValAbs, ValAbs);
 
-        MLAS_FLOAT32X4 q;
-        q = MlasMultiplyAddFloat32x4(ValueSquared, MlasBroadcastFloat32x4(MlasTanhConstants.beta_6),
-            MlasBroadcastFloat32x4(MlasTanhConstants.beta_4));
-        q = MlasMultiplyAddFloat32x4(q, ValueSquared, MlasBroadcastFloat32x4(MlasTanhConstants.beta_2));
-        q = MlasMultiplyAddFloat32x4(q, ValueSquared, MlasBroadcastFloat32x4(MlasTanhConstants.beta_0));
+        MLAS_FLOAT32X4 out = MlasDivideFloat32x4(dpoly, npoly);
+        out = MlasBlendFloat32x4(out, nc0, boundmask);
+        out = MlasXorFloat32x4(out, signVal);
 
-        MlasStoreFloat32x4(Output, MlasDivideFloat32x4(p, q));
+        if (N - count >= 4) {
+            MlasStoreFloat32x4(Output, out);
+        }
+        else {
+            MlasPartialStoreFloat32x4(Output, out, N - count);
+        }
 
         Input += 4;
         Output += 4;
-        N -= 4;
-    }
-
-    while (N > 0) {
-
-        float Value = *Input++;
-
-        // This odd two-step process exists to ensure an input value of NaN carries through 
-        // without modification because "std::min" and "std::max" return unreliable results 
-        // when NaNs are involved, and it's clear from the test's reference outputs that 
-        // they want a NaN on output whenever the input is a NaN.
-        float v_tmp;
-        v_tmp = (Value < MlasTanhConstants.LowerRange) ? MlasTanhConstants.LowerRange : Value;
-        Value = (v_tmp > MlasTanhConstants.UpperRange) ? MlasTanhConstants.UpperRange : v_tmp;
-
-        float ValueSquared = Value * Value;
-
-        float p;
-        p = ValueSquared * MlasTanhConstants.alpha_13 + MlasTanhConstants.alpha_11;
-        p = p * ValueSquared + MlasTanhConstants.alpha_9;
-        p = p * ValueSquared + MlasTanhConstants.alpha_7;
-        p = p * ValueSquared + MlasTanhConstants.alpha_5;
-        p = p * ValueSquared + MlasTanhConstants.alpha_3;
-        p = p * ValueSquared + MlasTanhConstants.alpha_1;
-        p = p * Value;
-
-        float q;
-        q = ValueSquared * MlasTanhConstants.beta_6 + MlasTanhConstants.beta_4;
-        q = q * ValueSquared + MlasTanhConstants.beta_2;
-        q = q * ValueSquared + MlasTanhConstants.beta_0;
-
-        *Output++ = (p / q);
-
-        N -= 1;
+        count += 4;
     }
 }
 

--- a/onnxruntime/core/mlas/lib/x86_64/TanhKernelFma3.S
+++ b/onnxruntime/core/mlas/lib/x86_64/TanhKernelFma3.S
@@ -20,6 +20,7 @@ Abstract:
 #include "asmmacro.h"
 #include "TransKernelCommon.h"
 
+
         .intel_syntax noprefix
 
         .text
@@ -48,71 +49,61 @@ Return Value:
         FUNCTION_ENTRY MlasComputeTanhF32KernelFma3
 
         lea     rax,C_UNDERSCORE(MlasTanhConstants)[rip]
-        vbroadcastss ymm4,.LTanhConstants_LowerRange[rax]
-        vbroadcastss ymm5,.LTanhConstants_UpperRange[rax]
-        vbroadcastss ymm6,.LTanhConstants_alpha_13[rax]
-        vbroadcastss ymm7,.LTanhConstants_alpha_11[rax]
-        vbroadcastss ymm8,.LTanhConstants_alpha_9[rax]
-        vbroadcastss ymm9,.LTanhConstants_alpha_7[rax]
-        vbroadcastss ymm10,.LTanhConstants_alpha_5[rax]
-        vbroadcastss ymm11,.LTanhConstants_alpha_3[rax]
-        vbroadcastss ymm12,.LTanhConstants_alpha_1[rax]
-        vbroadcastss ymm13,.LTanhConstants_beta_6[rax]
-        vbroadcastss ymm14,.LTanhConstants_beta_2[rax]
-        vbroadcastss ymm15,.LTanhConstants_beta_0[rax]
-
+        vbroadcastss ymm5,  0x00[rax]  // nc2
+        vbroadcastss ymm6,  0x04[rax]  // nc1
+        vbroadcastss ymm4,  0x08[rax]  // nc0
+        vbroadcastss ymm7,  0x0c[rax]  // dc2
+        vbroadcastss ymm8,  0x10[rax]  // dc1
+        vbroadcastss ymm9,  0x14[rax]  // dc0
+        vbroadcastss ymm10, 0x18[rax]  // absmask
+        vbroadcastss ymm11, 0x1c[rax]  // bound
         sub     rdx,8
         jb      .LProcessRemainingCount
 
 .LComputeTanhBy8Loop:
-        vmaxps  ymm0,ymm4,YMMWORD PTR [rdi]     # clamp lower bound
-        vmovaps ymm2,ymm7
-        vminps  ymm0,ymm5,ymm0                  # clamp upper bound
-        vmulps  ymm1,ymm0,ymm0                  # x2
-        vbroadcastss ymm3,.LTanhConstants_beta_4[rax]
-        vfmadd231ps ymm2,ymm1,ymm6              # p = x2 * alpha_13 + alpha_11
-        vfmadd213ps ymm2,ymm1,ymm8              # p = x2 * p + alpha_9
-        vfmadd213ps ymm2,ymm1,ymm9              # p = x2 * p + alpha_7
-        vfmadd213ps ymm2,ymm1,ymm10             # p = x2 * p + alpha_5
-        vfmadd213ps ymm2,ymm1,ymm11             # p = x2 * p + alpha_3
-        vfmadd213ps ymm2,ymm1,ymm12             # p = x2 * p + alpha_1
-        vfmadd231ps ymm3,ymm1,ymm13             # q = x2 * beta_6 + beta_4
-        vfmadd213ps ymm3,ymm1,ymm14             # q = x2 * q + beta_2
-        vfmadd213ps ymm3,ymm1,ymm15             # q = x2 * q + beta_0
-        vmulps  ymm2,ymm0,ymm2                  # p = x * p
-        vdivps  ymm0,ymm2,ymm3                  # tanh = p / q
-        add     rdi,8*4                         # advance input by 8 elements
-        vmovups YMMWORD PTR [rsi],ymm0
-        add     rsi,8*4                         # advance output by 8 elements
-        sub     rdx,8
+        vandps      ymm0,ymm10,YMMWORD PTR [rdi]
+	vmovaps	    ymm3, ymm5
+	vmovaps	    ymm13, ymm7
+	vxorps	    ymm1, ymm0, YMMWORD PTR [rdi]
+	vmulps	    ymm2, ymm0, ymm0
+	vcmpps	    ymm12, ymm0, ymm11, 29
+	vfmadd132ps ymm3, ymm6, ymm2
+	vfmadd132ps ymm13, ymm8, ymm2
+	vfmadd132ps ymm3, ymm4, ymm2
+	vfmadd132ps ymm2, ymm9, ymm13
+	vfmadd132ps ymm0, ymm0, ymm2
+	vdivps      ymm0, ymm0, ymm3
+	vblendvps   ymm0, ymm0, ymm4, ymm12
+	vxorps      ymm0, ymm0, ymm1
+        add         rdi,8*4                         # advance input by 8 elements
+        vmovups     YMMWORD PTR [rsi],ymm0
+        add         rsi,8*4                         # advance output by 8 elements
+        sub         rdx,8
         jae     .LComputeTanhBy8Loop
 
 .LProcessRemainingCount:
-        add     rdx,8                           # correct for over-subtract above
-        jz      .LExitKernel
-        neg     rdx
-        lea     r10,C_UNDERSCORE(MlasMaskMoveTableAvx)[rip+8*4]
-        vmovups ymm2,YMMWORD PTR [r10+rdx*4]
-        vmaskmovps ymm0,ymm2,YMMWORD PTR [rdi]
-        vmaxps  ymm0,ymm4,ymm0                  # clamp lower bound
-        vminps  ymm0,ymm5,ymm0                  # clamp upper bound
-        vmulps  ymm1,ymm0,ymm0                  # x2
-        vbroadcastss ymm3,.LTanhConstants_beta_4[rax]
-        vfmadd231ps ymm7,ymm1,ymm6              # p = x2 * alpha_13 + alpha_11
-        vfmadd213ps ymm7,ymm1,ymm8              # p = x2 * p + alpha_9
-        vfmadd213ps ymm7,ymm1,ymm9              # p = x2 * p + alpha_7
-        vfmadd213ps ymm7,ymm1,ymm10             # p = x2 * p + alpha_5
-        vfmadd213ps ymm7,ymm1,ymm11             # p = x2 * p + alpha_3
-        vfmadd213ps ymm7,ymm1,ymm12             # p = x2 * p + alpha_1
-        vfmadd231ps ymm3,ymm1,ymm13             # q = x2 * beta_6 + beta_4
-        vfmadd213ps ymm3,ymm1,ymm14             # q = x2 * q + beta_2
-        vfmadd213ps ymm3,ymm1,ymm15             # q = x2 * q + beta_0
-        vmulps  ymm7,ymm0,ymm7                  # p = x * p
-        vdivps  ymm0,ymm7,ymm3                  # tanh = p / q
-        vmaskmovps YMMWORD PTR [rsi],ymm2,ymm0
+        add         rdx,8                           # correct for over-subtract above
+        jz          .LExitKernel
+        neg         rdx
+        lea         r10,C_UNDERSCORE(MlasMaskMoveTableAvx)[rip+8*4]
+        vmovups     ymm15,YMMWORD PTR [r10+rdx*4]
+        vmaskmovps  ymm0,ymm15,YMMWORD PTR [rdi]
+        vandps      ymm0,ymm10,ymm0
+	vmovaps	    ymm3, ymm5
+	vmovaps	    ymm13, ymm7
+	vxorps	    ymm1, ymm0, YMMWORD PTR [rdi]
+	vmulps	    ymm2, ymm0, ymm0
+	vcmpps	    ymm12, ymm0, ymm11, 29
+	vfmadd132ps ymm3, ymm6, ymm2
+	vfmadd132ps ymm13, ymm8, ymm2
+	vfmadd132ps ymm3, ymm4, ymm2
+	vfmadd132ps ymm2, ymm9, ymm13
+	vfmadd132ps ymm0, ymm0, ymm2
+	vdivps      ymm0, ymm0, ymm3
+	vblendvps   ymm0, ymm0, ymm4, ymm12
+	vxorps      ymm0, ymm0, ymm1
+        vmaskmovps  YMMWORD PTR [rsi],ymm15,ymm0
 
 .LExitKernel:
         vzeroupper
         ret
-
-        .end

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -1851,11 +1851,11 @@ TEST(InferenceSessionTests, TestTruncatedSequence) {
                           0.56804454f, 0.92559665f, 0.07103606f};
 
   std::vector<int64_t> Y_dims = {5, 1, 2};
-  std::vector<float> Y_data = {-1.1730184e-04f, -3.1204990e-04f,
-                               -2.9978977e-04f, -1.0602647e-03f,
-                               -3.8115133e-04f, -2.0684483e-03f,
-                               -2.5120965e-04f, -2.9920202e-03f,
-                               3.0980256e-05f, -3.5933927e-03f};
+  std::vector<float> Y_data = {-1.1725388e-04f, -3.1192770e-04f,
+                               -2.9967332e-04f, -1.0598592e-03f,
+                               -3.8101958e-04f, -2.0676597e-03f,
+                               -2.5116475e-04f, -2.9908563e-03f,
+                               3.0859868e-05f, -3.5919433e-03f};
 
   OrtValue ml_value;
   CreateMLValue<float>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0], X_dims, X, &ml_value);


### PR DESCRIPTION
### Description
New faster algorithm for `tanhf `activation function using Intel SVML. 

### Motivation and Context
Improves performance of `tanhf` by nearly 40%. The newer algorithm also fixes a bug in the current `tanhf` algorithm which goes out of bounds [-1, 1]. Example: for `x = +0x1.06417ep+003`, `tanhf= +0x1.000002p+000`. 

```
Benchmark                                                 Time             CPU      Time Old      Time New       CPU Old       CPU New
--------------------------------------------------------------------------------------------------------------------------------------
[BM_Tanh vs. BM_Tanh]/40000/real_time                  -0.3822         -0.3825         15059          9304         15035          9283
[BM_Tanh vs. BM_Tanh]/80000/real_time                  -0.3845         -0.3844         30055         18499         29998         18467
[BM_Tanh vs. BM_Tanh]/160000/real_time                 -0.3146         -0.3144         17803         12203         17762         12178
[BM_Tanh vs. BM_Tanh]/320000/real_time                 -0.3495         -0.3491         32840         21362         32724         21300
[BM_Tanh vs. BM_Tanh]/640000/real_time                 -0.3563         -0.3568         62902         40487         62754         40361
[BM_Tanh vs. BM_Tanh]/1280000/real_time                -0.3326         -0.3333        128536         85780        128102         85408
OVERALL_GEOMEAN                                        -0.3538         -0.3539             0             0             0             0

```