### PR TITLE
[CUDA] Sparse Attention support 128k sequence length

### DIFF
--- a/onnxruntime/contrib_ops/cuda/sparse/block_mask.cu
+++ b/onnxruntime/contrib_ops/cuda/sparse/block_mask.cu
@@ -28,26 +28,27 @@ __global__ void MaskToCSR(const int* mask, int* csr_row_indices, int* csr_col_in
   }
 
   extern __shared__ int non_zero_counts[];
-  non_zero_counts[threadIdx.x] = count;
+  non_zero_counts[row + 1] = count;
   __syncthreads();
 
   // The first thread will calculate the accumulated partial sum of non-zero counts.
+  // The result is csr_row_indices stored in shared memory.
   if (row == 0) {
+    non_zero_counts[0] = 0;
     for (int i = 1; i < num_rows; i++) {
-      non_zero_counts[i] += non_zero_counts[i - 1];
+      non_zero_counts[i + 1] += non_zero_counts[i];
     }
+
+    // The first thread output the last element.
+    csr_row_indices[num_rows] = non_zero_counts[num_rows];
   }
   __syncthreads();
 
-  // The starting index of current row in csr_col_indices
-  int offset = (row == 0) ? 0 : non_zero_counts[row - 1];
+    // The starting index of current row in csr_col_indices
+  int offset = non_zero_counts[row];
 
   // Output row indices.
   csr_row_indices[row] = offset;
-  if (row == 0) {
-    // The first thread output the last element.
-    csr_row_indices[num_rows] = non_zero_counts[num_rows - 1];
-  }
 
   for (int col = 0; col < num_cols; col++) {
     if (mask[row * num_cols + col] == 1) {
@@ -60,6 +61,59 @@ __global__ void MaskToCSR(const int* mask, int* csr_row_indices, int* csr_col_in
   // The last element of csr_row_indices is the total number of non-zero elements.
 }
 
+__global__ void MaskToCSR_Large(const int* mask,
+                                int* csr_row_indices,
+                                int* csr_col_indices,
+                                int num_rows,
+                                int num_cols,
+                                int rows_per_thread  // Each thread handle mutliple rows
+) {
+  extern __shared__ int non_zero_counts[];
+
+  // Update input and output data pointers to the start of current head
+  int head = blockIdx.x;
+  mask += head * num_rows * num_cols;
+  csr_row_indices += head * (num_rows + 1);
+  csr_col_indices += head * num_rows * num_cols;
+
+  int tid = threadIdx.x;
+  for (int row = tid * rows_per_thread; row < num_rows && row < (tid + 1) * rows_per_thread; row++) {
+    int count = 0;
+    for (int col = 0; col < num_cols; col++) {
+      if (mask[row * num_cols + col] == 1) {
+        count++;
+      }
+    }
+    non_zero_counts[row + 1] = count;
+  }
+
+  __syncthreads();
+
+  // The first thread will calculate the accumulated partial sum of non-zero counts.
+  if (tid == 0) {
+    non_zero_counts[0] = 0;
+    for (int i = 1; i < num_rows; i++) {
+      non_zero_counts[i + 1] += non_zero_counts[i];
+    }
+
+    csr_row_indices[num_rows] = non_zero_counts[num_rows];
+  }
+
+  __syncthreads();
+
+  for (int row = tid * rows_per_thread; row < num_rows && row < (tid + 1) * rows_per_thread; row++) {
+    int offset = non_zero_counts[row];
+    csr_row_indices[row] = offset;
+
+    for (int col = 0; col < num_cols; col++) {
+      if (mask[row * num_cols + col] == 1) {
+        csr_col_indices[offset] = col;
+        offset++;
+      }
+    }
+  }
+}
+
 void ConvertMaskToCSR(cudaStream_t stream,
                       const int* mask,       // input mask with shape (num_layout, num_rows, num_cols)
                       int num_layout,        // number of layouts
@@ -68,15 +122,17 @@ void ConvertMaskToCSR(cudaStream_t stream,
                       int* csr_row_indices,  // output CSR row indices
                       int* csr_col_indices,  // output CSR column indices
                       int max_threads_per_block) {
-  int threads_per_block = (num_rows + 31) / 32 * 32;
-
-  // Each thread handle one row. The kernel assumes that all rows of one head can be handled in one block.
-  if (threads_per_block > max_threads_per_block) {
-    ORT_THROW("num_rows is too large: num_rows=", num_rows, ", max_threads_per_block=", max_threads_per_block);
+  if (num_rows <= max_threads_per_block) {
+    // Each thread handle one row.
+    MaskToCSR<<<num_layout, num_rows, (num_rows + 1) * sizeof(int), stream>>>(
+        mask, csr_row_indices, csr_col_indices, num_rows, num_cols);
+  } else {
+    // Each thread will handle multiple rows when number of rows > max_threads_per_block.
+    // For example 128K length with sparse block size 64 will have 2048 rows. Each thread will handle 2 rows.
+    int rows_per_thread = (num_rows + max_threads_per_block - 1) / max_threads_per_block;
+    MaskToCSR_Large<<<num_layout, max_threads_per_block, (num_rows + 1) * sizeof(int), stream>>>(
+        mask, csr_row_indices, csr_col_indices, num_rows, num_cols, rows_per_thread);
   }
-
-  MaskToCSR<<<num_layout, threads_per_block, threads_per_block * sizeof(int), stream>>>(
-      mask, csr_row_indices, csr_col_indices, num_rows, num_cols);
 }
 
 }  // namespace cuda


### PR DESCRIPTION
### Description
When sequence length is 128K, block_mask has 2048 rows, that is not supported by previous kernel.
(1) Add a new kernel to handle more than 1024 rows, and each thread need handle two rows.
(2) Add a test for sequence length 128k.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


