### PR TITLE
[qnn ep] sign onnxruntime.dll/pyd for qnn packages

### DIFF
--- a/tools/ci_build/github/azure-pipelines/qnn-ep-nuget-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/qnn-ep-nuget-packaging-pipeline.yml
@@ -73,6 +73,7 @@ jobs:
           FolderPath: '$(Build.BinariesDirectory)\Windows\${{ parameters.build_config }}\${{ parameters.build_config }}'
           DisplayName: 'ESRP - Sign dlls'
           DoEsrp: ${{ parameters.DoEsrp }}
+          Pattern: 'onnxruntime.dll'
 
       - task: CmdLine@2
         displayName: 'Generating nuspec for the native Nuget package x64'
@@ -178,6 +179,7 @@ jobs:
           FolderPath: '$(Build.BinariesDirectory)\Win_arm64\${{ parameters.build_config }}\${{ parameters.build_config }}'
           DisplayName: 'ESRP - Sign dlls'
           DoEsrp: ${{ parameters.DoEsrp }}
+          Pattern: 'onnxruntime.dll'
 
       - task: CmdLine@2
         displayName: 'Generating nuspec for the native Nuget package arm64'

--- a/tools/ci_build/github/azure-pipelines/templates/py-win-arm64-qnn.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-win-arm64-qnn.yml
@@ -115,7 +115,7 @@ jobs:
           FolderPath: '$(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\onnxruntime\capi'
           DisplayName: 'ESRP - Sign Native dlls'
           DoEsrp: true
-          Pattern: '*.pyd,*.dll'
+          Pattern: '*.pyd'
 
       - task: PythonScript@0
         displayName: 'Build wheel'

--- a/tools/ci_build/github/azure-pipelines/templates/py-win-x64-qnn.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-win-x64-qnn.yml
@@ -127,7 +127,7 @@ jobs:
           FolderPath: '$(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\onnxruntime\capi'
           DisplayName: 'ESRP - Sign Native dlls'
           DoEsrp: true
-          Pattern: '*.pyd,*.dll'
+          Pattern: '*.pyd'
 
       - task: PythonScript@0
         displayName: 'Build wheel'


### PR DESCRIPTION
sign only onnxruntime.dll and onnxruntime_pybind11_state.pyd in packages.
