### PR TITLE
Fix ordering of value info in GraphProto creation

### DIFF
--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -4062,7 +4062,11 @@ void Graph::ToGraphProtoInternal(ONNX_NAMESPACE::GraphProto& graph_proto) const 
     *(graph_proto.mutable_output()->Add()) = output_arg->ToProto();
   }
 
-  for (const auto* value_info : value_info_) {
+  auto sort_predicate = [](const NodeArg* v1, const NodeArg* v2) {return v1->Name() < v2->Name();};
+  std::vector<const NodeArg*> value_info_set{value_info_.begin(), value_info_.end()};
+  std::sort(value_info_set.begin(), value_info_set.end(), sort_predicate);
+
+  for (const auto* value_info : value_info_set) {
     *(graph_proto.mutable_value_info()->Add()) = value_info->ToProto();
   }
 


### PR DESCRIPTION
### Description
Graph member value_info_ (unordered_set) is ordered before its values are added to the graph proto. 


### Motivation and Context

- Without this ordering, the model proto used by the OpenVINO EP is not deterministic and varies across runs.
- Since the model proto varies, it affects caching attempts by OpenVINO.

Q: If creating a vector to have ordered elements is costly, should we make value_info_ a std::set that is sorted according to NodeArg names?


