### PR TITLE
Unified OV compile_model API in OVEP

### DIFF
--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -90,8 +90,7 @@ BasicBackend::BasicBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
                                                            device_config,
                                                            subgraph_context_.subgraph_name);
         ie_cnn_network_ = exe_network_.Get().get_runtime_model();
-      } else if (!subgraph_context_.has_dynamic_input_shape &&
-                 !global_context_.cache_dir.empty()) {
+      } else if (!subgraph_context_.has_dynamic_input_shape) {
         // Inputs with static dimenstions
         std::string prec_str = (global_context_.precision_str != "ACCURACY") ? global_context_.precision_str : global_context_.model_precision;
         const std::string model = model_proto.SerializeAsString();

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -91,10 +91,11 @@ BasicBackend::BasicBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
                                                            subgraph_context_.subgraph_name);
         ie_cnn_network_ = exe_network_.Get().get_runtime_model();
       } else if (!subgraph_context_.has_dynamic_input_shape &&
-                 global_context_.onnx_model_path_name.find(".onnx") != std::string ::npos) {
+                 !global_context_.cache_dir.empty()) {
         // Inputs with static dimenstions
         std::string prec_str = (global_context_.precision_str != "ACCURACY") ? global_context_.precision_str : global_context_.model_precision;
-        exe_network_ = global_context_.ie_core.CompileModel(global_context_.onnx_model_path_name,
+        const std::string model = model_proto.SerializeAsString();
+        exe_network_ = global_context_.ie_core.CompileModel(model,
                                                             hw_target,
                                                             prec_str,
                                                             global_context_.cache_dir,

--- a/onnxruntime/core/providers/openvino/ov_interface.cc
+++ b/onnxruntime/core/providers/openvino/ov_interface.cc
@@ -88,7 +88,7 @@ OVExeNetwork OVCore::CompileModel(std::shared_ptr<const OVNetwork>& ie_cnn_netwo
   }
 }
 
-OVExeNetwork OVCore::CompileModel(const std::string onnx_model_path,
+OVExeNetwork OVCore::CompileModel(const std::string& onnx_model,
                                   std::string& hw_target,
                                   std::string precision,
                                   std::string cache_dir,
@@ -97,13 +97,13 @@ OVExeNetwork OVCore::CompileModel(const std::string onnx_model_path,
   ov::CompiledModel obj;
   try {
     if (hw_target == "AUTO:GPU,CPU") {
-      obj = oe.compile_model(onnx_model_path,
+      obj = oe.compile_model(onnx_model, ov::Tensor(),
                              "AUTO",
                              ov::device::priorities("GPU", "CPU"),
                              ov::device::properties("GPU", {ov::cache_dir(cache_dir),
                                                             ov::hint::inference_precision(precision)}));
     } else {
-      obj = oe.compile_model(onnx_model_path, hw_target, device_config);
+      obj = oe.compile_model(onnx_model, ov::Tensor(), hw_target, device_config);
     }
 #ifndef NDEBUG
     printDebugInfo(obj);

--- a/onnxruntime/core/providers/openvino/ov_interface.h
+++ b/onnxruntime/core/providers/openvino/ov_interface.h
@@ -44,7 +44,7 @@ class OVCore {
                             std::string& hw_target,
                             ov::AnyMap& device_config,
                             std::string name);
-  OVExeNetwork CompileModel(const std::string onnx_model_path,
+  OVExeNetwork CompileModel(const std::string& onnx_model,
                             std::string& hw_target,
                             std::string precision,
                             std::string cache_dir,


### PR DESCRIPTION
### Description
Have a unified API in OVEP that pass the ONNX graph proto from ORT to OV for compilation


### Motivation and Context
The earlier implementation used two different flows when onnx model path is present vs model laoded from memory.
The former directly passed the onnx model path to OV when the graph is fully supported by EP. While the latter pass the ORT model proto to OV. 

This cause a difference in results when ORT optimizations are enabled. This PR address this issue.


