### PR TITLE
[WebNN EP] Update chromium flag

### DIFF
--- a/js/web/README.md
+++ b/js/web/README.md
@@ -49,7 +49,7 @@ Refer to the following links for development information:
 - \[2]: WebGPU requires Chromium v113 or later on Windows. Float16 support requires Chrome v121 or later, and Edge v122 or later.
 - \[3]: WebGPU requires Chromium v121 or later on Windows.
 - \[4]: WebGL support is in maintenance mode. It is recommended to use WebGPU for better performance.
-- \[5]: Requires to launch browser with commandline flag `--enable-experimental-web-platform-features`.
+- \[5]: Requires to launch browser with commandline flag `--enable-features=WebMachineLearningNeuralNetwork`.
 
 ### Operators
 

--- a/js/web/script/test-runner-cli.ts
+++ b/js/web/script/test-runner-cli.ts
@@ -569,7 +569,7 @@ async function main() {
         chromiumFlags.push('--enable-dawn-features=allow_unsafe_apis,use_dxc');
       }
       if (webnn) {
-        chromiumFlags.push('--enable-experimental-web-platform-features');
+        chromiumFlags.push('--enable-features=WebMachineLearningNeuralNetwork');
       }
       if (process.argv.includes('--karma-debug')) {
         karmaArgs.push('--log-level debug');


### PR DESCRIPTION
WebNN is currently enabled behind "Enables WebNN API" flag.

