### PR TITLE
[WebNN EP] Disable ConvTranspose for WebNN CPU

### DIFF
--- a/js/web/docs/webnn-operators.md
+++ b/js/web/docs/webnn-operators.md
@@ -22,7 +22,7 @@ operators and the supported opset domain/versions in **WebNN EP** by ONNX Runtim
 | Clip | ai.onnx(7-10, 11, 12, 13+) | clamp | ✓ | ✓ | |
 | Concat | ai.onnx(7-10, 11-12, 13+) | concat | ✓ | ✓ | |
 | Conv | ai.onnx(7-10, 11+) | conv2d | ✓ | ✓ | Only supports 3-D or 4-D input and 'W' (weight). WebNN CPU requires the 'W' (weight) input to be a constant |
-| ConvTranspose | ai.onnx(7-10, 11+) | convTranspose2d | ✓ | ✓ | Only supports 3-D or 4-D input and 'W' (weight). WebNN CPU requires the 'W' (weight) input to be a constant |
+| ConvTranspose | ai.onnx(7-10, 11+) | convTranspose2d | ✓ | ✗ | Only supports 3-D or 4-D input and 'W' (weight). |
 | Cos | ai.onnx(7+) | cos | ✗ | ✓ | |
 | Div | ai.onnx(7-12, 13, 14+) | div | ✓ | ✓ | |
 | Elu | ai.onnx(7+) | elu | ✓ | ✓ | |

--- a/onnxruntime/core/providers/webnn/builders/helper.h
+++ b/onnxruntime/core/providers/webnn/builders/helper.h
@@ -167,7 +167,7 @@ static const InlinedHashMap<std::string, WebnnOpInfo> op_map = {
     {"Concat", {"concat", true}},
     {"Conv", {"conv2d", true}},
     {"ConvInteger", {"conv2dInteger", false}},
-    {"ConvTranspose", {"convTranspose2d", true}},
+    {"ConvTranspose", {"convTranspose2d", false}},
     {"Cos", {"cos", false}},
     {"Div", {"div", true}},
     {"DequantizeLinear", {"dequantizeLinear", false}},


### PR DESCRIPTION
WebNN CPU backend implementation has been migrated from XNNPack to TFLite, currently TFLite has not supported WebNN's convTranspose2d yet, just disable it for now.