### PR TITLE
add hipify-clang requirement to rocm ep eps.md

### DIFF
--- a/docs/build/eps.md
+++ b/docs/build/eps.md
@@ -603,6 +603,8 @@ See more information on the ROCm Execution Provider [here](../execution-provider
 
 * Install [ROCm](https://rocm.docs.amd.com/projects/install-on-linux/en/docs-6.0.0/)
   * The ROCm execution provider for ONNX Runtime is built and tested with ROCm6.0.0
+* Install [hipify-clang](https://rocm.docs.amd.com/projects/HIPIFY/en/latest/hipify-clang.html)
+  * This is required for the build target: generate_hipified_files
 
 ### Build Instructions
 {: .no_toc }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Added hipify-clang as a requirement for building the ROCm Execution Provider version of onnxruntime


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
was really confused for like 5 minutes when HIPIFY-PERL wasn't found