### PR TITLE
[Build] Change `onnxruntime_NVCC_THREADS` from option to cache entry

### DIFF
--- a/cmake/onnxruntime_providers_cuda.cmake
+++ b/cmake/onnxruntime_providers_cuda.cmake
@@ -153,7 +153,7 @@
     # CUDA 11.3+ supports parallel compilation
     # https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#options-for-guiding-compiler-driver-threads
     if (CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.3)
-      option(onnxruntime_NVCC_THREADS "Number of threads that NVCC can use for compilation." 1)
+      set(onnxruntime_NVCC_THREADS "1" CACHE STRING "Number of threads that NVCC can use for compilation.")
       target_compile_options(${target} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--threads \"${onnxruntime_NVCC_THREADS}\">")
     endif()
 


### PR DESCRIPTION
### Description
Changes the `onnxruntime_NVCC_THREADS` CMake variable from an [`option`](https://cmake.org/cmake/help/latest/command/option.html) to a [cache entry](https://cmake.org/cmake/help/latest/command/set.html#set-cache-entry).

### Motivation and Context
Fixes #19833.

`option` in CMake (confusingly, IMHO) always defines a *boolean* option. The original definition of `onnxruntime_NVCC_THREADS` specified a default of `1`, which I presume is coerced to `ON`. Thus, if the option is not overridden with a value of another type, NVCC will receive a malformed option `--threads ON` (rather than the expected `--threads 1`), which causes the error reported in #19833.

This error only occurred if compiling ONNX Runtime via CMake with `-Donnxruntime_USE_CUDA=ON`; the CI build script always overrode `onnxruntime_NVCC_THREADS` with a string value:
https://github.com/microsoft/onnxruntime/blob/f1fef19b6e248023ec23b85bea8644ab2b95e831/tools/ci_build/build.py#L1152-L1154