### PR TITLE
Fix DirectML package name in genai/howto/install.md

### DIFF
--- a/docs/genai/howto/install.md
+++ b/docs/genai/howto/install.md
@@ -48,7 +48,7 @@ dotnet add package Microsoft.ML.OnnxRuntimeGenAI.Cuda --prerelease
 For the package that has been optimized for DirectML:
 
 ```bash
-dotnet add package Microsoft.ML.OnnxRuntimeGenAI.Cuda --prerelease
+dotnet add package Microsoft.ML.OnnxRuntimeGenAI.DirectML --prerelease
 ```
 
 


### PR DESCRIPTION
### Description
Fix package name 
from ```dotnet add package Microsoft.ML.OnnxRuntimeGenAI.*Cuda* --prerelease``` to ```dotnet add package Microsoft.ML.OnnxRuntimeGenAI.DirectML --prerelease``` in DirectML section.


### Motivation and Context
Clearly confusing for beginners if not fixed (will break further processes)


