### PR TITLE
[WebNN EP] Remove legacy MLOperandDescriptor.type

### DIFF
--- a/onnxruntime/core/providers/webnn/builders/helper.cc
+++ b/onnxruntime/core/providers/webnn/builders/helper.cc
@@ -161,41 +161,30 @@ bool IsValidMultidirectionalBroadcast(std::vector<int64_t>& shape_a,
 }
 
 bool SetWebnnDataType(emscripten::val& desc, const int32_t data_type) {
-  // WebNN changed the name of the MLOperandDescriptor's data type from "type" to "dataType",
-  // use a duplicate entry temporarily to workaround this API breaking issue.
-  // TODO: Remove legacy "type" once all browsers implement the new "dataType".
   switch (data_type) {
     case ONNX_NAMESPACE::TensorProto_DataType_BOOL:
     case ONNX_NAMESPACE::TensorProto_DataType_UINT8:
-      desc.set("type", emscripten::val("uint8"));
       desc.set("dataType", emscripten::val("uint8"));
       return true;
     case ONNX_NAMESPACE::TensorProto_DataType_INT8:
-      desc.set("type", emscripten::val("int8"));
       desc.set("dataType", emscripten::val("int8"));
       return true;
     case ONNX_NAMESPACE::TensorProto_DataType_FLOAT16:
-      desc.set("type", emscripten::val("float16"));
       desc.set("dataType", emscripten::val("float16"));
       return true;
     case ONNX_NAMESPACE::TensorProto_DataType_FLOAT:
-      desc.set("type", emscripten::val("float32"));
       desc.set("dataType", emscripten::val("float32"));
       return true;
     case ONNX_NAMESPACE::TensorProto_DataType_INT32:
-      desc.set("type", emscripten::val("int32"));
       desc.set("dataType", emscripten::val("int32"));
       return true;
     case ONNX_NAMESPACE::TensorProto_DataType_INT64:
-      desc.set("type", emscripten::val("int64"));
       desc.set("dataType", emscripten::val("int64"));
       return true;
     case ONNX_NAMESPACE::TensorProto_DataType_UINT32:
-      desc.set("type", emscripten::val("uint32"));
       desc.set("dataType", emscripten::val("uint32"));
       return true;
     case ONNX_NAMESPACE::TensorProto_DataType_UINT64:
-      desc.set("type", emscripten::val("uint64"));
       desc.set("dataType", emscripten::val("uint64"));
       return true;
     default:


### PR DESCRIPTION
Latest Chrome has supported MLOperandDescriptor.dataType, remove legacy MLOperandDescriptor.type.

