### PR TITLE
[JS/WebGPU] Map Reshape operator with int64_t data type to JSEP.

### DIFF
--- a/onnxruntime/core/providers/js/operators/reshape.cc
+++ b/onnxruntime/core/providers/js/operators/reshape.cc
@@ -13,7 +13,12 @@ ONNX_OPERATOR_KERNEL_EX(
     14,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", JsepSupportedDataTypes())
+        .TypeConstraint("T", BuildKernelDefConstraintsFromTypeList<TypeList<float,
+                                                                            MLFloat16,
+                                                                            int32_t,
+                                                                            int64_t,
+                                                                            uint32_t,
+                                                                            bool>>())
         .TypeConstraint("shape", DataTypeImpl::GetTensorType<int64_t>())
         .Alias(0, 0)
         .InputMemoryType(OrtMemTypeCPU, 1),
@@ -25,7 +30,12 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     13, 13,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", JsepSupportedDataTypes())
+        .TypeConstraint("T", BuildKernelDefConstraintsFromTypeList<TypeList<float,
+                                                                            MLFloat16,
+                                                                            int32_t,
+                                                                            int64_t,
+                                                                            uint32_t,
+                                                                            bool>>())
         .TypeConstraint("shape", DataTypeImpl::GetTensorType<int64_t>())
         .Alias(0, 0)
         .InputMemoryType(OrtMemTypeCPU, 1),
@@ -37,7 +47,12 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     5, 12,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", JsepSupportedDataTypes())
+        .TypeConstraint("T", BuildKernelDefConstraintsFromTypeList<TypeList<float,
+                                                                            MLFloat16,
+                                                                            int32_t,
+                                                                            int64_t,
+                                                                            uint32_t,
+                                                                            bool>>())
         .TypeConstraint("shape", DataTypeImpl::GetTensorType<int64_t>())
         .Alias(0, 0)
         .InputMemoryType(OrtMemTypeCPU, 1),


### PR DESCRIPTION
### Description
Avoid copying tensors between CPU and GPU by mapping Reshape operations to JSEP.



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


