### PR TITLE
deprecate total seqlen

### DIFF
--- a/include/onnxruntime/core/framework/op_kernel_context.h
+++ b/include/onnxruntime/core/framework/op_kernel_context.h
@@ -61,6 +61,10 @@ class OpKernelContext {
     return p_ml_value ? p_ml_value->GetMutable<T>() : nullptr;
   }
 
+  bool OutputTensorAllocated(int index) {
+    return GetOutputMLValue(index) != nullptr && GetOutputMLValue(index)->IsTensor();
+  }
+
   // In the case that memory allocation has not been done for an output tensor,
   // The memory allocation will be done on-the-fly with given tensor shape.
   // Return nullptr if the output is an unused optional output.

--- a/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
@@ -55,12 +55,20 @@ Status GroupQueryAttention<T>::Compute(OpKernelContext* context) const {
   const Tensor* past_key = context->Input<Tensor>(3);
   const Tensor* past_value = context->Input<Tensor>(4);
   const Tensor* seqlens_k = context->Input<Tensor>(5);
-  const Tensor* total_seqlen = context->Input<Tensor>(6);
-  const Tensor* cos_cache = context->Input<Tensor>(7);
-  const Tensor* sin_cache = context->Input<Tensor>(8);
+  const Tensor* cos_cache = context->Input<Tensor>(6);
+  const Tensor* sin_cache = context->Input<Tensor>(7);
 
   GroupQueryAttentionParameters parameters = {};
   constexpr float scale = 1.0f;
+
+  parameters.kv_share_buffer = false;
+  if (past_key != nullptr) {
+    const T* past_key_data = past_key->Data<T>();
+    if (context->OutputTensorAllocated(1) && context->Output<Tensor>(1)->MutableData<T>() == past_key_data) {
+      parameters.kv_share_buffer = true;
+    }
+  }
+
   ORT_RETURN_IF_ERROR(group_query_attention_helper::CheckInputs(query,
                                                                 key,
                                                                 value,
@@ -72,7 +80,6 @@ Status GroupQueryAttention<T>::Compute(OpKernelContext* context) const {
                                                                 num_heads_,
                                                                 kv_num_heads_,
                                                                 seqlens_k,
-                                                                total_seqlen,
                                                                 scale));
 
   const int batch_size = parameters.batch_size;

--- a/onnxruntime/contrib_ops/cpu/bert/group_query_attention_helper.h
+++ b/onnxruntime/contrib_ops/cpu/bert/group_query_attention_helper.h
@@ -11,6 +11,15 @@ namespace onnxruntime {
 namespace contrib {
 namespace group_query_attention_helper {
 
+bool all_zeroes(const int* data, int size) {
+  for (int i = 0; i < size; i++) {
+    if (data[i] != 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
 Status CheckInputs(const Tensor* query,
                    const Tensor* key,
                    const Tensor* value,
@@ -18,11 +27,10 @@ Status CheckInputs(const Tensor* query,
                    const Tensor* past_value,
                    const Tensor* cos_cache,
                    const Tensor* sin_cache,
-                   void* parameters,
+                   GroupQueryAttentionParameters* parameters,
                    int num_heads,
                    int kv_num_heads,
                    const Tensor* seqlens_k,
-                   const Tensor* total_seqlen,
                    float scale) {
   // Note: Here S* is seqlen_past_kv_cache, S+ is seqlen_present_kv_cache
   //     past_key                   : (B, N_k, S*, H) or (B, N_k, S+, H) or nullptr
@@ -174,13 +182,7 @@ Status CheckInputs(const Tensor* query,
                            "seqlens_k must be shape (batch_size).");
   }
 
-  // Set present sequence length and kv_share_buffer from input total_seqlen tensor
-  if (!onnxruntime::IsScalarOr1ElementVector(total_seqlen)) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                           "total_sequence_length tensor must be of one element.");
-  }
-  int total_sequence_length = *((*total_seqlen).template Data<int32_t>());
-  int present_sequence_length = std::max(total_sequence_length, past_sequence_length);
+  int present_sequence_length = parameters->kv_share_buffer ? past_sequence_length : past_sequence_length + sequence_length;
 
   int rotary_dim = 0;
   if (cos_cache != nullptr && sin_cache != nullptr) {
@@ -192,13 +194,13 @@ Status CheckInputs(const Tensor* query,
                              "head_size shall be a multiple of 16. Got head_size % 16 == ",
                              head_size % 16);
     }
-    if (cos_dims[0] < total_sequence_length) {
+    if (cos_dims[0] < present_sequence_length) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                             "cos_cache dimension 0 should be not be less than total_sequence_length.");
+                             "cos_cache dimension 0 should be not be less than present_sequence_length.");
     }
-    if (sin_dims[0] < total_sequence_length) {
+    if (sin_dims[0] < present_sequence_length) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                             "sin_cache dimension 0 should be not be less than total_sequence_length.");
+                             "sin_cache dimension 0 should be not be less than present_sequence_length.");
     }
     if (cos_dims[1] > (head_size / 16) * 8 || cos_dims[1] % 8 != 0) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
@@ -218,26 +220,29 @@ Status CheckInputs(const Tensor* query,
                            "Input 'cos_cache' and 'sin_cache' shall be both present or both absent.");
   }
 
-  bool is_prompt = sequence_length != 1;
+  bool is_prompt = parameters->kv_share_buffer ? sequence_length > 1 || (sequence_length == 1 && all_zeroes(seqlens_k->Data<int>(), batch_size)) : (sequence_length == present_sequence_length);
+  if (!is_prompt && sequence_length != 1) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "sequence_length shall be 1 when it is not prompt.");
+  }
 
   if (parameters != nullptr) {
-    GroupQueryAttentionParameters* output_parameters = reinterpret_cast<GroupQueryAttentionParameters*>(parameters);
-    output_parameters->batch_size = batch_size;
-    output_parameters->sequence_length = sequence_length;                  // sequence length of Q
-    output_parameters->seqlen_past_kv_cache = past_sequence_length;        // max sequence length of past kv tensors
-    output_parameters->seqlen_present_kv_cache = present_sequence_length;  // max sequence length of present kv tensors
-    output_parameters->hidden_size = q_hidden_size;
-    output_parameters->num_heads = num_heads;
-    output_parameters->head_size = head_size;
-    output_parameters->kv_hidden_size = kv_hidden_size;
-    output_parameters->kv_num_heads = kv_num_heads;
-    output_parameters->rotary_dim = rotary_dim;
-    output_parameters->is_packed_qkv = is_packed_qkv;
-    output_parameters->is_unidirectional = true;
-    output_parameters->is_prompt = is_prompt;
-    output_parameters->scale = scale;
-    output_parameters->qkv_format = qkv_format;
-    output_parameters->past_kv_format = past_kv_format;
+    parameters->batch_size = batch_size;
+    parameters->sequence_length = sequence_length;                  // sequence length of Q
+    parameters->seqlen_past_kv_cache = past_sequence_length;        // max sequence length of past kv tensors
+    parameters->seqlen_present_kv_cache = present_sequence_length;  // max sequence length of present kv tensors
+    parameters->hidden_size = q_hidden_size;
+    parameters->num_heads = num_heads;
+    parameters->head_size = head_size;
+    parameters->kv_hidden_size = kv_hidden_size;
+    parameters->kv_num_heads = kv_num_heads;
+    parameters->rotary_dim = rotary_dim;
+    parameters->is_packed_qkv = is_packed_qkv;
+    parameters->is_unidirectional = true;
+    parameters->is_prompt = is_prompt;
+    parameters->scale = scale;
+    parameters->qkv_format = qkv_format;
+    parameters->past_kv_format = past_kv_format;
   }
 
   return Status::OK();
@@ -250,18 +255,17 @@ Status CheckInputs(const Tensor* query,
                    const Tensor* past_value,
                    const Tensor* cos_cache,
                    const Tensor* sin_cache,
-                   void* parameters,
+                   GroupQueryAttentionParameters* parameters,
                    int num_heads,
                    int kv_num_heads,
                    const Tensor* seqlens_k,
-                   const Tensor* total_seqlen,
                    float scale,
                    int max_threads_per_block) {
   if (max_threads_per_block > 0 && num_heads > max_threads_per_block) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "num_heads should be no larger than ", max_threads_per_block);
   }
 
-  return CheckInputs(query, key, value, past_key, past_value, cos_cache, sin_cache, parameters, num_heads, kv_num_heads, seqlens_k, total_seqlen, scale);
+  return CheckInputs(query, key, value, past_key, past_value, cos_cache, sin_cache, parameters, num_heads, kv_num_heads, seqlens_k, scale);
 }
 
 template <typename T>

--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention.cc
@@ -79,14 +79,21 @@ Status GroupQueryAttention<T>::ComputeInternal(OpKernelContext* context) const {
   const Tensor* past_key = context->Input<Tensor>(3);
   const Tensor* past_value = context->Input<Tensor>(4);
   const Tensor* seqlens_k = context->Input<Tensor>(5);
-  const Tensor* total_seqlen = context->Input<Tensor>(6);
-  const Tensor* cos_cache = context->Input<Tensor>(7);
-  const Tensor* sin_cache = context->Input<Tensor>(8);
+  const Tensor* cos_cache = context->Input<Tensor>(6);
+  const Tensor* sin_cache = context->Input<Tensor>(7);
 
   auto& device_prop = GetDeviceProp();
   GroupQueryAttentionParameters parameters;
   typedef typename ToCudaType<T>::MappedType CudaT;
   GroupQueryAttentionData<CudaT> data;
+
+  parameters.kv_share_buffer = false;
+  if (past_key != nullptr) {
+    const T* past_key_data = past_key->Data<T>();
+    if (context->OutputTensorAllocated(1) && context->Output<Tensor>(1)->MutableData<T>() == past_key_data) {
+      parameters.kv_share_buffer = true;
+    }
+  }
 
   ORT_RETURN_IF_ERROR(group_query_attention_helper::CheckInputs(query,
                                                                 key,
@@ -99,7 +106,6 @@ Status GroupQueryAttention<T>::ComputeInternal(OpKernelContext* context) const {
                                                                 num_heads_,
                                                                 kv_num_heads_,
                                                                 seqlens_k,
-                                                                total_seqlen,
                                                                 is_past_bsnh_,
                                                                 scale_,
                                                                 device_prop.maxThreadsPerBlock));
@@ -230,11 +236,6 @@ Status GroupQueryAttention<T>::ComputeInternal(OpKernelContext* context) const {
   data.seqlens_k = const_cast<int*>(seqlens_k->Data<int>());
   data.use_flash_attention = use_flash_attention;
   data.use_memory_efficient_attention = use_memory_efficient_attention;
-  if (data.past_key == data.present_key) {
-    parameters.kv_share_buffer = true;
-  } else {
-    parameters.kv_share_buffer = false;
-  }
   // Flash Buffers
   if (softmax_lse_buffer != nullptr) {
     data.softmax_lse = reinterpret_cast<CudaT*>(softmax_lse_buffer.get());

--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention_helper.h
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention_helper.h
@@ -18,11 +18,10 @@ Status CheckInputs(const Tensor* query,
                    const Tensor* past_value,
                    const Tensor* cos_cache,
                    const Tensor* sin_cache,
-                   void* parameters,
+                   GroupQueryAttentionParameters* parameters,
                    int num_heads,
                    int kv_num_heads,
                    const Tensor* seqlens_k,
-                   const Tensor* total_seqlen,
                    bool is_past_bsnh,
                    float scale) {
   // Note: Here S* is past_cache_sequence_length, S- is past_sequence_length, S+ is sequence_length
@@ -195,13 +194,7 @@ Status CheckInputs(const Tensor* query,
                            "seqlens_k must be shape (batch_size).");
   }
 
-  // Set present sequence length and kv_share_buffer from input total_seqlen tensor
-  if (!onnxruntime::IsScalarOr1ElementVector(total_seqlen)) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                           "total_sequence_length tensor must be of one element.");
-  }
-  int total_sequence_length = *((*total_seqlen).template Data<int32_t>());
-  int present_sequence_length = std::max(total_sequence_length, past_sequence_length);
+  int present_sequence_length = parameters->kv_share_buffer ? past_sequence_length : past_sequence_length + sequence_length;
 
   int rotary_dim = 0;
   if (cos_cache != nullptr && sin_cache != nullptr) {
@@ -213,13 +206,13 @@ Status CheckInputs(const Tensor* query,
                              "head_size shall be a multiple of 16. Got head_size % 16 == ",
                              head_size % 16);
     }
-    if (cos_dims[0] < total_sequence_length) {
+    if (cos_dims[0] < present_sequence_length) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                             "cos_cache dimension 0 should be not be less than total_sequence_length.");
+                             "cos_cache dimension 0 should be not be less than present_sequence_length.");
     }
-    if (sin_dims[0] < total_sequence_length) {
+    if (sin_dims[0] < present_sequence_length) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                             "sin_cache dimension 0 should be not be less than total_sequence_length.");
+                             "sin_cache dimension 0 should be not be less than present_sequence_length.");
     }
     if (cos_dims[1] > (head_size / 16) * 8 || cos_dims[1] % 8 != 0) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
@@ -239,29 +232,21 @@ Status CheckInputs(const Tensor* query,
                            "Input 'cos_cache' and 'sin_cache' shall be both present or both absent.");
   }
 
-  bool is_prompt = (sequence_length == total_sequence_length);
-  if (!is_prompt && sequence_length != 1) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                           "sequence_length shall be 1 when it is not prompt.");
-  }
-
   if (parameters != nullptr) {
-    GroupQueryAttentionParameters* output_parameters = reinterpret_cast<GroupQueryAttentionParameters*>(parameters);
-    output_parameters->batch_size = batch_size;
-    output_parameters->sequence_length = sequence_length;                  // sequence length of Q
-    output_parameters->seqlen_past_kv_cache = past_sequence_length;        // max sequence length of past kv tensors
-    output_parameters->seqlen_present_kv_cache = present_sequence_length;  // max sequence length of present kv tensors
-    output_parameters->hidden_size = q_hidden_size;
-    output_parameters->num_heads = num_heads;
-    output_parameters->head_size = head_size;
-    output_parameters->kv_hidden_size = kv_hidden_size;
-    output_parameters->kv_num_heads = kv_num_heads;
-    output_parameters->rotary_dim = rotary_dim;
-    output_parameters->is_packed_qkv = is_packed_qkv;
-    output_parameters->is_prompt = is_prompt;
-    output_parameters->scale = scale;
-    output_parameters->qkv_format = qkv_format;
-    output_parameters->past_kv_format = past_kv_format;
+    parameters->batch_size = batch_size;
+    parameters->sequence_length = sequence_length;                  // sequence length of Q
+    parameters->seqlen_past_kv_cache = past_sequence_length;        // max sequence length of past kv tensors
+    parameters->seqlen_present_kv_cache = present_sequence_length;  // max sequence length of present kv tensors
+    parameters->hidden_size = q_hidden_size;
+    parameters->num_heads = num_heads;
+    parameters->head_size = head_size;
+    parameters->kv_hidden_size = kv_hidden_size;
+    parameters->kv_num_heads = kv_num_heads;
+    parameters->rotary_dim = rotary_dim;
+    parameters->is_packed_qkv = is_packed_qkv;
+    parameters->scale = scale;
+    parameters->qkv_format = qkv_format;
+    parameters->past_kv_format = past_kv_format;
   }
 
   return Status::OK();
@@ -274,11 +259,10 @@ Status CheckInputs(const Tensor* query,
                    const Tensor* past_value,
                    const Tensor* cos_cache,
                    const Tensor* sin_cache,
-                   void* parameters,
+                   GroupQueryAttentionParameters* parameters,
                    int num_heads,
                    int kv_num_heads,
                    const Tensor* seqlens_k,
-                   const Tensor* total_seqlen,
                    bool is_past_bsnh,
                    float scale,
                    int max_threads_per_block) {
@@ -286,7 +270,7 @@ Status CheckInputs(const Tensor* query,
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "num_heads should be no larger than ", max_threads_per_block);
   }
 
-  return CheckInputs(query, key, value, past_key, past_value, cos_cache, sin_cache, parameters, num_heads, kv_num_heads, seqlens_k, total_seqlen, is_past_bsnh, scale);
+  return CheckInputs(query, key, value, past_key, past_value, cos_cache, sin_cache, parameters, num_heads, kv_num_heads, seqlens_k, is_past_bsnh, scale);
 }
 
 }  // namespace group_query_attention_helper

--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -1104,19 +1104,15 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
                OpSchema::Optional)
         .Input(5,
                "seqlens_k",
-               // For prompt, the value is number of tokens (excluding padding) - 1.
-               "1d Tensor of shape (batch_size). Indicates past sequence lengths for token generation case.",
+               "1d Tensor of shape (batch_size). Indicates past sequence lengths for token generation case."
+               "For prompt, the value is number of tokens (excluding padding) - 1.",
                "M")
         .Input(6,
-               "total_sequence_length",
-               "Scalar tensor of total sequence length (past + new).",
-               "M")
-        .Input(7,
                "cos_cache",
                "2D tensor with shape (max_sequence_length, head_size / 2).",
                "T",
                OpSchema::Optional)
-        .Input(8,
+        .Input(7,
                "sin_cache",
                "2D tensor with shape (max_sequence_length, head_size / 2).",
                "T",

--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -888,6 +888,7 @@ struct ProviderHost {
   virtual Status OpKernelContext__GetTempSpaceAllocator(const OpKernelContext* p, AllocatorPtr* output) = 0;
   virtual Status OpKernelContext__GetTempSpaceCPUAllocator(const OpKernelContext* p, AllocatorPtr* output) = 0;
   virtual bool OpKernelContext__GetUseDeterministicCompute(const OpKernelContext* p) = 0;
+  virtual bool OpKernelContext__OutputTensorAllocated( OpKernelContext* p, int index) = 0;
   virtual bool OpKernelContext__TryGetInferredOutputShape(const OpKernelContext* p, int index, TensorShape& shape) = 0;
   virtual bool OpKernelContext__TryGetInferredInputShape(const OpKernelContext* p, int index, TensorShape& shape) = 0;
   virtual Stream* OpKernelContext__GetComputeStream(const OpKernelContext* p) = 0;

--- a/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
+++ b/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
@@ -939,6 +939,8 @@ struct OpKernelContext final {
 
   bool GetUseDeterministicCompute() const { return g_host->OpKernelContext__GetUseDeterministicCompute(this); }
 
+  bool OutputTensorAllocated(int index) { return g_host->OpKernelContext__OutputTensorAllocated(this, index); }
+
   bool TryGetInferredOutputShape(int index, TensorShape& shape) const { return g_host->OpKernelContext__TryGetInferredOutputShape(this, index, shape); }
   bool TryGetInferredInputShape(int index, TensorShape& shape) const { return g_host->OpKernelContext__TryGetInferredInputShape(this, index, shape); }
   Stream* GetComputeStream() const { return g_host->OpKernelContext__GetComputeStream(this); }

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -1129,6 +1129,7 @@ struct ProviderHostImpl : ProviderHost {
   Status OpKernelContext__GetTempSpaceAllocator(const OpKernelContext* p, AllocatorPtr* output) override { return p->GetTempSpaceAllocator(output); }
   Status OpKernelContext__GetTempSpaceCPUAllocator(const OpKernelContext* p, AllocatorPtr* output) override { return p->GetTempSpaceCPUAllocator(output); }
   bool OpKernelContext__GetUseDeterministicCompute(const OpKernelContext* p) override { return p->GetUseDeterministicCompute(); }
+  bool OpKernelContext__OutputTensorAllocated( OpKernelContext* p, int index) override { return p->OutputTensorAllocated(index); }
   bool OpKernelContext__TryGetInferredOutputShape(const OpKernelContext* p, int index, TensorShape& shape) override { return p->TryGetInferredOutputShape(index, shape); }
   bool OpKernelContext__TryGetInferredInputShape(const OpKernelContext* p, int index, TensorShape& shape) override { return p->TryGetInferredInputShape(index, shape); }
   Stream* OpKernelContext__GetComputeStream(const OpKernelContext* p) override { return p->GetComputeStream(); }


### PR DESCRIPTION
### Description
We can infer the total sequence length and no longer need to have it as an input to the model.



### Motivation and Context
Improves useability and simplicity of operator.


