### PR TITLE
Increase ComponentDetection timeout for React Native CI

### DIFF
--- a/tools/ci_build/github/azure-pipelines/mac-react-native-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-react-native-ci-pipeline.yml
@@ -47,6 +47,7 @@ resources:
     ref: 5eda9aded5462201e6310105728d33016e637ea7
 
 variables:
+  ComponentDetection.Timeout: 660
   ${{ if eq(parameters.NpmPublish, 'nightly (@dev)') }}:
     NpmPackagingMode: 'dev'
   ${{ if eq(parameters.NpmPublish, 'release candidate (@rc)') }}:

--- a/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
@@ -52,6 +52,7 @@ stages:
 
     variables:
       runCodesignValidationInjection: false
+      ComponentDetection.Timeout: 660
       TODAY: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]
       ORT_CACHE_DIR: '$(Pipeline.Workspace)/ccache_ort'
 


### PR DESCRIPTION
### Description
Runs of the React Native CI are timing out during ComponentDetection after 8 minutes. This increases the timeout value.



### Motivation and Context
Runs of the React Native CI are timing out during ComponentDetection.


