### PR TITLE
Release backward inputs per static graph ref count

### DIFF
--- a/onnxruntime/core/framework/allocation_planner.cc
+++ b/onnxruntime/core/framework/allocation_planner.cc
@@ -294,7 +294,7 @@ class PlannerImpl {
 #endif
 
   // Find if there exists some input tensor that we can use in-place for output_arg_num-th output in the node.
-  bool FindReusableInput(const onnxruntime::Node& node, int output_arg_num, OrtValueIndex* reusable_input,
+  bool FindReusableInput(const GraphViewer& graph, const onnxruntime::Node& node, int output_arg_num, OrtValueIndex* reusable_input,
                          bool* is_strided_tensor) {
     *is_strided_tensor = false;
 #ifdef ENABLE_TRAINING
@@ -326,8 +326,15 @@ class PlannerImpl {
         if ((0 <= pair.first) && (static_cast<size_t>(pair.first) < input_args.size())) {
           auto p_input_arg = input_args[pair.first];
           if (p_input_arg->Exists()) {
+            // If the producer node does not have external output, then we can reuse the input buffer; Otherwise,
+            // we cannot.
+            const Node* producer_node = graph.GetProducerNode(p_input_arg->Name());
+            if (producer_node == nullptr || !HasExternalOutputs(*producer_node)) {
             *reusable_input = Index(p_input_arg->Name());
             return true;
+            } else {
+              ORT_ENFORCE(false, "Node ", node.Name(), " cannot reuse input buffer for node ", producer_node->Name(), " as it has external outputs");
+            }
           }
         }
       }
@@ -342,8 +349,16 @@ class PlannerImpl {
       if (alias_input_index >= 0 && static_cast<size_t>(alias_input_index) < input_args.size()) {
         auto p_input_arg = input_args[alias_input_index];
         if (p_input_arg->Exists()) {
-          *reusable_input = Index(p_input_arg->Name());
-          return true;
+          // If the producer node does not have external output, then we can reuse the input buffer; Otherwise,
+          // we cannot.
+          const Node* producer_node = graph.GetProducerNode(p_input_arg->Name());
+          if (producer_node == nullptr || !HasExternalOutputs(*producer_node)) {
+            *reusable_input = Index(p_input_arg->Name());
+            return true;
+          } else {
+            ORT_ENFORCE(false, "Node ", node.Name(), " cannot reuse input buffer for node ", producer_node->Name(), " as it has external outputs");
+
+          }
         }
       }
     }
@@ -357,16 +372,24 @@ class PlannerImpl {
             auto input_arg_index = Index(p_input_arg->Name());
             auto original = Buffer(input_arg_index);
             if (1 == UseCount(original)) {
+                  // If the producer node does not have external output, then we can reuse the input buffer; Otherwise,
+          // we cannot.
+          const Node* producer_node = graph.GetProducerNode(p_input_arg->Name());
+          if (producer_node == nullptr || !HasExternalOutputs(*producer_node)) {
               if (SameSize(*p_input_arg, *p_output_arg)) {
                 // we can reuse this input since it is its last use and permitted for in-place update
                 *reusable_input = input_arg_index;  // or original; both should be okay
                 return true;
               }
+          } else {
+            std::cout  << "Node " << node.Name()<< " cannot reuse input buffer for node " << producer_node->Name()<< " as it has external outputs" << std::endl;
+          }
+            }
             }
           }
         }
       }
-    }
+
 
 #ifdef ENABLE_STRIDED_TENSORS
     // If any output of the kernel can support strided tensor, and all its consumers' inputs also support
@@ -604,13 +627,14 @@ class PlannerImpl {
 
         auto outputs = pnode->OutputDefs();
         auto num_outputs = outputs.size();
-        bool has_external_outputs = HasExternalOutputs(*pnode);
+        // bool has_external_outputs = HasExternalOutputs(*pnode);
         for (size_t i = 0; i < num_outputs; ++i) {
           auto* node_output = outputs[i];
           if (!node_output->Exists()) continue;
           OrtValueIndex index = Index(node_output->Name());
           // Ensures external outputs will not be reused.
-          UseCount(index) += (has_external_outputs ? 2 : 1);
+          // UseCount(index) += (has_external_outputs ? 2 : 1);
+          UseCount(index) += 1;
         }
       }
     }
@@ -1079,7 +1103,7 @@ class PlannerImpl {
             int value_idx;
             ORT_RETURN_IF_ERROR(ort_value_name_idx_map_.GetIdx(name, value_idx));
             auto origin = AllocPlan(value_idx).reused_buffer;
-            if (AllocPlan(origin).alloc_kind == AllocKind::kAllocate) {
+            if (AllocPlan(origin).alloc_kind == AllocKind::kAllocate || AllocPlan(origin).alloc_kind == AllocKind::kAllocatedExternally) {
               // add current node as consumer for origin buffer
               value_consumer_map[origin].insert(node_index);
             }
@@ -1131,6 +1155,10 @@ class PlannerImpl {
             if ((0 <= pair.first) && (static_cast<size_t>(pair.first) < input_args.size())) {
               auto p_input_arg = input_args[pair.first];
               if (p_input_arg->Exists()) {
+                // If the producer node does not has external outputs, we can reuse the input buffer;
+                // Otherwise, we cannot reuse the buffer.
+                const Node* producer_node = graph_viewer.GetProducerNode(p_input_arg->Name());
+                if (producer_node == nullptr || !HasExternalOutputs(*producer_node)) {
                 OrtValueIndex reusable_input{};
                 if (value_map.GetIdx(p_input_arg->Name(), reusable_input).IsOK() /*&&
                     allocation_plan[reusable_input].alloc_kind == AllocKind::kAllocate*/
@@ -1143,6 +1171,9 @@ class PlannerImpl {
                   reused.insert(reusable_input);
                   found_reusable = true;
                   break;
+                }
+                } else {
+                  ORT_ENFORCE(false, "Cannot reuse input buffer for ", p_output_arg->Name(), " as input ", p_input_arg->Name());
                 }
               }
             }
@@ -1163,6 +1194,10 @@ class PlannerImpl {
             auto p_input_arg = input_args[alias_input_index];
 
             if (p_input_arg->Exists()) {
+             // If the producer node does not has external outputs, we can reuse the input buffer;
+                // Otherwise, we cannot reuse the buffer.
+                const Node* producer_node = graph_viewer.GetProducerNode(p_input_arg->Name());
+                if (producer_node == nullptr || !HasExternalOutputs(*producer_node)) {
               OrtValueIndex reusable_input{};
               if (value_map.GetIdx(p_input_arg->Name(), reusable_input).IsOK() &&
                   allocation_plan[reusable_input].alloc_kind == AllocKind::kAllocate) {
@@ -1173,6 +1208,9 @@ class PlannerImpl {
                 reused.insert(reusable_input);
                 continue;
               }  // if
+                } else {
+                  ORT_ENFORCE(false, "Cannot reuse input buffer for ", p_output_arg->Name(), " as input ", p_input_arg->Name());
+                }
             }    // if
           }
         }
@@ -1184,6 +1222,10 @@ class PlannerImpl {
             if ((0 <= pair.first) && (static_cast<size_t>(pair.first) < input_args.size())) {
               auto p_input_arg = input_args[pair.first];
               if (p_input_arg->Exists()) {
+                 // If the producer node does not has external outputs, we can reuse the input buffer;
+                // Otherwise, we cannot reuse the buffer.
+                const Node* producer_node = graph_viewer.GetProducerNode(p_input_arg->Name());
+                if (producer_node == nullptr || !HasExternalOutputs(*producer_node)) {
                 OrtValueIndex input_arg_index{};
                 if (value_map.GetIdx(p_input_arg->Name(), input_arg_index).IsOK() &&
                     allocation_plan[input_arg_index].alloc_kind == AllocKind::kAllocate) {
@@ -1194,6 +1236,10 @@ class PlannerImpl {
                                                                value_consumer_map[output_idx_global].end());
                     reused.insert(input_arg_index);
                   }
+                }
+                } else {
+                  std:: cout <<  "Cannot reuse input buffer for " << p_output_arg->Name() << " as input " << p_input_arg->Name() << std::endl;
+
                 }
               }
             }
@@ -1439,7 +1485,7 @@ class PlannerImpl {
             }
           }
         } else if (!context_->IsParallelExecutionEnabled() &&
-                   FindReusableInput(*pnode, static_cast<int>(output_arg_def_index), &reused, &is_strided_tensor)) {
+                   FindReusableInput(graph_viewer_, *pnode, static_cast<int>(output_arg_def_index), &reused, &is_strided_tensor)) {
           // Re-using inputs is applicable for tensors, sequence tensors,
           // and optional types if the kernel has marked certain inputs as
           // possible candidates for re-use
@@ -1522,7 +1568,7 @@ class PlannerImpl {
         if (!node_output->Exists()) continue;
         // OrtValue index of the considered output NodeArg.
         const auto current = Index(node_output->Name());
-        if (AllocPlan(current).alloc_kind == AllocKind::kAllocate) {
+        if (AllocPlan(current).alloc_kind == AllocKind::kAllocate || AllocPlan(current).alloc_kind == AllocKind::kAllocatedExternally) {
           AllocPlan(current).program_counter.AddStart(program_counter);
         }
       }
@@ -1570,7 +1616,7 @@ class PlannerImpl {
         // OrtValue index of the considered output NodeArg.
         const auto current = Index(node_output->Name());
         AllocPlan(current).life_interval.first = program_counter;
-        if (AllocPlan(current).alloc_kind == AllocKind::kAllocatedExternally ||
+        if (/*AllocPlan(current).alloc_kind == AllocKind::kAllocatedExternally ||*/
             AllocPlan(current).alloc_kind == AllocKind::kAllocateOutput) {
           AllocPlan(current).life_interval.second = execution_plan.size();
         }
@@ -1695,7 +1741,7 @@ class PlannerImpl {
             int value_idx;
             ORT_RETURN_IF_ERROR(ort_value_name_idx_map_.GetIdx(name, value_idx));
             auto origin = AllocPlan(value_idx).reused_buffer;
-            if (AllocPlan(origin).alloc_kind == AllocKind::kAllocate) {
+            if (AllocPlan(origin).alloc_kind == AllocKind::kAllocate || AllocPlan(origin).alloc_kind == AllocKind::kAllocatedExternally) {
               // add current node as consumer for origin buffer
               value_consumers[origin].push_back(node_index);
             }

--- a/onnxruntime/core/framework/allocation_planner.cc
+++ b/onnxruntime/core/framework/allocation_planner.cc
@@ -330,8 +330,8 @@ class PlannerImpl {
             // we cannot.
             const Node* producer_node = graph.GetProducerNode(p_input_arg->Name());
             if (producer_node == nullptr || !HasExternalOutputs(*producer_node)) {
-            *reusable_input = Index(p_input_arg->Name());
-            return true;
+              *reusable_input = Index(p_input_arg->Name());
+              return true;
             } else {
               ORT_ENFORCE(false, "Node ", node.Name(), " cannot reuse input buffer for node ", producer_node->Name(), " as it has external outputs");
             }
@@ -357,7 +357,6 @@ class PlannerImpl {
             return true;
           } else {
             ORT_ENFORCE(false, "Node ", node.Name(), " cannot reuse input buffer for node ", producer_node->Name(), " as it has external outputs");
-
           }
         }
       }
@@ -372,24 +371,23 @@ class PlannerImpl {
             auto input_arg_index = Index(p_input_arg->Name());
             auto original = Buffer(input_arg_index);
             if (1 == UseCount(original)) {
-                  // If the producer node does not have external output, then we can reuse the input buffer; Otherwise,
-          // we cannot.
-          const Node* producer_node = graph.GetProducerNode(p_input_arg->Name());
-          if (producer_node == nullptr || !HasExternalOutputs(*producer_node)) {
-              if (SameSize(*p_input_arg, *p_output_arg)) {
-                // we can reuse this input since it is its last use and permitted for in-place update
-                *reusable_input = input_arg_index;  // or original; both should be okay
-                return true;
+              // If the producer node does not have external output, then we can reuse the input buffer; Otherwise,
+              // we cannot.
+              const Node* producer_node = graph.GetProducerNode(p_input_arg->Name());
+              if (producer_node == nullptr || !HasExternalOutputs(*producer_node)) {
+                if (SameSize(*p_input_arg, *p_output_arg)) {
+                  // we can reuse this input since it is its last use and permitted for in-place update
+                  *reusable_input = input_arg_index;  // or original; both should be okay
+                  return true;
+                }
+              } else {
+                std::cout << "Node " << node.Name() << " cannot reuse input buffer for node " << producer_node->Name() << " as it has external outputs" << std::endl;
               }
-          } else {
-            std::cout  << "Node " << node.Name()<< " cannot reuse input buffer for node " << producer_node->Name()<< " as it has external outputs" << std::endl;
-          }
-            }
             }
           }
         }
       }
-
+    }
 
 #ifdef ENABLE_STRIDED_TENSORS
     // If any output of the kernel can support strided tensor, and all its consumers' inputs also support
@@ -1159,19 +1157,19 @@ class PlannerImpl {
                 // Otherwise, we cannot reuse the buffer.
                 const Node* producer_node = graph_viewer.GetProducerNode(p_input_arg->Name());
                 if (producer_node == nullptr || !HasExternalOutputs(*producer_node)) {
-                OrtValueIndex reusable_input{};
-                if (value_map.GetIdx(p_input_arg->Name(), reusable_input).IsOK() /*&&
-                    allocation_plan[reusable_input].alloc_kind == AllocKind::kAllocate*/
-                ) {
-                  std::cout << p_input_arg->Name() << " reused by " << p_output_arg->Name() << " as input" << std::endl;
-                  allocation_plan[output_idx_global].alloc_kind = AllocKind::kReuse;
-                  allocation_plan[output_idx_global].reused_buffer = reusable_input;
-                  value_consumer_map[reusable_input].insert(value_consumer_map[output_idx_global].begin(),
-                                                            value_consumer_map[output_idx_global].end());
-                  reused.insert(reusable_input);
-                  found_reusable = true;
-                  break;
-                }
+                  OrtValueIndex reusable_input{};
+                  if (value_map.GetIdx(p_input_arg->Name(), reusable_input).IsOK() /*&&
+                      allocation_plan[reusable_input].alloc_kind == AllocKind::kAllocate*/
+                  ) {
+                    std::cout << p_input_arg->Name() << " reused by " << p_output_arg->Name() << " as input" << std::endl;
+                    allocation_plan[output_idx_global].alloc_kind = AllocKind::kReuse;
+                    allocation_plan[output_idx_global].reused_buffer = reusable_input;
+                    value_consumer_map[reusable_input].insert(value_consumer_map[output_idx_global].begin(),
+                                                              value_consumer_map[output_idx_global].end());
+                    reused.insert(reusable_input);
+                    found_reusable = true;
+                    break;
+                  }
                 } else {
                   ORT_ENFORCE(false, "Cannot reuse input buffer for ", p_output_arg->Name(), " as input ", p_input_arg->Name());
                 }
@@ -1194,24 +1192,24 @@ class PlannerImpl {
             auto p_input_arg = input_args[alias_input_index];
 
             if (p_input_arg->Exists()) {
-             // If the producer node does not has external outputs, we can reuse the input buffer;
-                // Otherwise, we cannot reuse the buffer.
-                const Node* producer_node = graph_viewer.GetProducerNode(p_input_arg->Name());
-                if (producer_node == nullptr || !HasExternalOutputs(*producer_node)) {
-              OrtValueIndex reusable_input{};
-              if (value_map.GetIdx(p_input_arg->Name(), reusable_input).IsOK() &&
-                  allocation_plan[reusable_input].alloc_kind == AllocKind::kAllocate) {
-                allocation_plan[output_idx_global].alloc_kind = AllocKind::kReuse;
-                allocation_plan[output_idx_global].reused_buffer = reusable_input;
-                value_consumer_map[reusable_input].insert(value_consumer_map[output_idx_global].begin(),
-                                                          value_consumer_map[output_idx_global].end());
-                reused.insert(reusable_input);
-                continue;
-              }  // if
-                } else {
-                  ORT_ENFORCE(false, "Cannot reuse input buffer for ", p_output_arg->Name(), " as input ", p_input_arg->Name());
-                }
-            }    // if
+              // If the producer node does not has external outputs, we can reuse the input buffer;
+              // Otherwise, we cannot reuse the buffer.
+              const Node* producer_node = graph_viewer.GetProducerNode(p_input_arg->Name());
+              if (producer_node == nullptr || !HasExternalOutputs(*producer_node)) {
+                OrtValueIndex reusable_input{};
+                if (value_map.GetIdx(p_input_arg->Name(), reusable_input).IsOK() &&
+                    allocation_plan[reusable_input].alloc_kind == AllocKind::kAllocate) {
+                  allocation_plan[output_idx_global].alloc_kind = AllocKind::kReuse;
+                  allocation_plan[output_idx_global].reused_buffer = reusable_input;
+                  value_consumer_map[reusable_input].insert(value_consumer_map[output_idx_global].begin(),
+                                                            value_consumer_map[output_idx_global].end());
+                  reused.insert(reusable_input);
+                  continue;
+                }  // if
+              } else {
+                ORT_ENFORCE(false, "Cannot reuse input buffer for ", p_output_arg->Name(), " as input ", p_input_arg->Name());
+              }
+            }  // if
           }
         }
 
@@ -1222,24 +1220,23 @@ class PlannerImpl {
             if ((0 <= pair.first) && (static_cast<size_t>(pair.first) < input_args.size())) {
               auto p_input_arg = input_args[pair.first];
               if (p_input_arg->Exists()) {
-                 // If the producer node does not has external outputs, we can reuse the input buffer;
+                // If the producer node does not has external outputs, we can reuse the input buffer;
                 // Otherwise, we cannot reuse the buffer.
                 const Node* producer_node = graph_viewer.GetProducerNode(p_input_arg->Name());
                 if (producer_node == nullptr || !HasExternalOutputs(*producer_node)) {
-                OrtValueIndex input_arg_index{};
-                if (value_map.GetIdx(p_input_arg->Name(), input_arg_index).IsOK() &&
-                    allocation_plan[input_arg_index].alloc_kind == AllocKind::kAllocate) {
-                  if (value_consumer_map[input_arg_index].size() == 1 && SameSize(*p_input_arg, *p_output_arg)) {
-                    allocation_plan[output_idx_global].alloc_kind = AllocKind::kReuse;
-                    allocation_plan[output_idx_global].reused_buffer = input_arg_index;
-                    value_consumer_map[input_arg_index].insert(value_consumer_map[output_idx_global].begin(),
-                                                               value_consumer_map[output_idx_global].end());
-                    reused.insert(input_arg_index);
+                  OrtValueIndex input_arg_index{};
+                  if (value_map.GetIdx(p_input_arg->Name(), input_arg_index).IsOK() &&
+                      allocation_plan[input_arg_index].alloc_kind == AllocKind::kAllocate) {
+                    if (value_consumer_map[input_arg_index].size() == 1 && SameSize(*p_input_arg, *p_output_arg)) {
+                      allocation_plan[output_idx_global].alloc_kind = AllocKind::kReuse;
+                      allocation_plan[output_idx_global].reused_buffer = input_arg_index;
+                      value_consumer_map[input_arg_index].insert(value_consumer_map[output_idx_global].begin(),
+                                                                 value_consumer_map[output_idx_global].end());
+                      reused.insert(input_arg_index);
+                    }
                   }
-                }
                 } else {
-                  std:: cout <<  "Cannot reuse input buffer for " << p_output_arg->Name() << " as input " << p_input_arg->Name() << std::endl;
-
+                  std::cout << "Cannot reuse input buffer for " << p_output_arg->Name() << " as input " << p_input_arg->Name() << std::endl;
                 }
               }
             }

--- a/onnxruntime/core/framework/execution_frame.cc
+++ b/onnxruntime/core/framework/execution_frame.cc
@@ -898,9 +898,9 @@ void ExecutionFrame::TraceAllocate(int ort_value_idx, size_t size) {
     // don't trace the output tensors or external outputs.
     auto& allocation_plan = GetAllocationPlan(ort_value_idx);
     if (allocation_plan.alloc_kind == AllocKind::kAllocateOutput
-    //  ||
-    //     allocation_plan.alloc_kind == AllocKind::kAllocatedExternally
-        ) {
+        //  ||
+        //     allocation_plan.alloc_kind == AllocKind::kAllocatedExternally
+    ) {
       return;
     }
     auto status = planner_->TraceAllocation(ort_value_idx, size);

--- a/onnxruntime/core/framework/execution_frame.cc
+++ b/onnxruntime/core/framework/execution_frame.cc
@@ -897,8 +897,10 @@ void ExecutionFrame::TraceAllocate(int ort_value_idx, size_t size) {
   if (planner_.has_value()) {
     // don't trace the output tensors or external outputs.
     auto& allocation_plan = GetAllocationPlan(ort_value_idx);
-    if (allocation_plan.alloc_kind == AllocKind::kAllocateOutput ||
-        allocation_plan.alloc_kind == AllocKind::kAllocatedExternally) {
+    if (allocation_plan.alloc_kind == AllocKind::kAllocateOutput
+    //  ||
+    //     allocation_plan.alloc_kind == AllocKind::kAllocatedExternally
+        ) {
       return;
     }
     auto status = planner_->TraceAllocation(ort_value_idx, size);

--- a/onnxruntime/core/framework/partial_graph_execution_state.cc
+++ b/onnxruntime/core/framework/partial_graph_execution_state.cc
@@ -59,7 +59,7 @@ DeviceStreamCollection* PartialGraphExecutionState::GetDeviceStreamCollection(co
   return device_stream_collection_.get();
 }
 
-StreamExecutionContext& PartialGraphExecutionState::GetExecutionContext(gsl::span<const int>& feed_mlvalue_idxs, gsl::span<const OrtValue>& feeds,
+StreamExecutionContext& PartialGraphExecutionState::GetExecutionContext(gsl::span<const int>& feed_mlvalue_idxs, std::vector<OrtValue>& feeds,
                                                                         gsl::span<const int>& fetch_mlvalue_idxs, std::vector<OrtValue>& fetches,
                                                                         const std::unordered_map<size_t, IExecutor::CustomAllocator>& fetch_allocators,
                                                                         const SessionState& session_state,

--- a/onnxruntime/core/framework/partial_graph_execution_state.h
+++ b/onnxruntime/core/framework/partial_graph_execution_state.h
@@ -30,7 +30,7 @@ struct PartialGraphExecutionState {
 
   ProgramRegion& GetProgramRegions(const SessionState& session_state);
 
-  StreamExecutionContext& GetExecutionContext(gsl::span<const int>& feed_mlvalue_idxs, gsl::span<const OrtValue>& feeds,
+  StreamExecutionContext& GetExecutionContext(gsl::span<const int>& feed_mlvalue_idxs, std::vector<OrtValue>& feeds,
                                               gsl::span<const int>& fetch_mlvalue_idxs, std::vector<OrtValue>& fetches,
                                               const std::unordered_map<size_t, IExecutor::CustomAllocator>& fetch_allocators,
                                               const SessionState& session_state,

--- a/onnxruntime/core/framework/sequential_executor.cc
+++ b/onnxruntime/core/framework/sequential_executor.cc
@@ -631,7 +631,7 @@ onnxruntime::Status PartialExecuteThePlan(const SessionState& session_state, gsl
                                           int32_t partial_graph_index) {
   auto& ctx = state.GetExecutionContext(feed_mlvalue_idxs, feeds, fetch_mlvalue_idxs, fetches,
                                         fetch_allocators, session_state, logger, device_streams);
-  feeds.clear(); // Release the feeds at the earliest convenience.
+  feeds.clear();  // Release the feeds at the earliest convenience.
   auto* plan = session_state.GetExecutionPlan();
 
   ctx.SetCurrentRange(&state.GetProgramRegions(session_state));

--- a/onnxruntime/core/framework/sequential_executor.h
+++ b/onnxruntime/core/framework/sequential_executor.h
@@ -50,7 +50,7 @@ onnxruntime::Status ExecuteThePlan(const SessionState& session_state, gsl::span<
 
 #ifdef ENABLE_TRAINING
 onnxruntime::Status PartialExecuteThePlan(const SessionState& session_state, gsl::span<const int> feed_mlvalue_idxs,
-                                          gsl::span<const OrtValue> feeds, gsl::span<const int> fetch_mlvalue_idxs,
+                                          std::vector<OrtValue>& feeds, gsl::span<const int> fetch_mlvalue_idxs,
                                           std::vector<OrtValue>& fetches,
                                           const std::unordered_map<size_t, IExecutor::CustomAllocator>& fetch_allocators,
                                           const logging::Logger& logger,

--- a/onnxruntime/core/framework/stream_execution_context.cc
+++ b/onnxruntime/core/framework/stream_execution_context.cc
@@ -166,9 +166,11 @@ StreamExecutionContext::~StreamExecutionContext() {}
 void StreamExecutionContext::RecycleNodeInputs(onnxruntime::NodeIndex node_index) {
   auto* execution_plan = session_state_->GetExecutionPlan();
   for (auto idx : execution_plan->node_release_list[node_index]) {
+    // std::cout << "checking ort value " << execution_plan->release_actions[idx].value_index << " can be released? " << release_plan_[idx] << std::endl;
     if (--release_plan_[idx] == 0) {
       ORT_ENFORCE(frame_.ReleaseMLValue(static_cast<int>(execution_plan->release_actions[idx].value_index)).IsOK());
       VLOGS(*logger_, 0) << "ort value " << execution_plan->release_actions[idx].value_index << " released";
+      // std::cout << "ort value " << execution_plan->release_actions[idx].value_index << " released" << std::endl;
     }
   }
 }

--- a/onnxruntime/core/framework/utils.cc
+++ b/onnxruntime/core/framework/utils.cc
@@ -784,7 +784,7 @@ common::Status ExecuteGraph(const SessionState& session_state,
 
 #ifdef ENABLE_TRAINING
 common::Status ExecutePartialGraphImpl(const SessionState& session_state, FeedsFetchesManager& feeds_fetches_manager,
-                                       gsl::span<const OrtValue> feeds, std::vector<OrtValue>& fetches,
+                                       std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
                                        const logging::Logger& logger, PartialGraphExecutionState& state,
                                        const OrtValueCachePtr& cache, const bool& terminate_flag,
                                        DeviceStreamCollection* device_stream_collection,
@@ -882,7 +882,7 @@ common::Status ExecutePartialGraphImpl(const SessionState& session_state, FeedsF
 }
 
 common::Status ExecutePartialGraph(const SessionState& session_state, FeedsFetchesManager& feeds_fetches_manager,
-                                   gsl::span<const OrtValue> feeds, std::vector<OrtValue>& fetches,
+                                   std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
                                    const logging::Logger& logger, PartialGraphExecutionState& state,
                                    const OrtValueCachePtr& cache, const bool& terminate_flag,
                                    int32_t partial_graph_index,

--- a/onnxruntime/core/framework/utils.h
+++ b/onnxruntime/core/framework/utils.h
@@ -100,7 +100,7 @@ common::Status ExecuteGraph(const SessionState& session_state, FeedsFetchesManag
 
 #ifdef ENABLE_TRAINING
 common::Status ExecutePartialGraph(const SessionState& session_state, FeedsFetchesManager& feeds_fetches_manager,
-                                   gsl::span<const OrtValue> feeds, std::vector<OrtValue>& fetches,
+                                   std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
                                    const logging::Logger& logger, PartialGraphExecutionState& state,
                                    const OrtValueCachePtr& cache,
                                    const bool& terminate_flag,

--- a/onnxruntime/core/optimizer/gemm_sum_fusion.cc
+++ b/onnxruntime/core/optimizer/gemm_sum_fusion.cc
@@ -36,7 +36,7 @@ Status GemmSumFusion::Apply(Graph& graph, Node& gemm_node, RewriteRuleEffect& mo
   std::vector<NodeArg*> new_gemm_output_defs = sum_node.MutableOutputDefs();
   ORT_ENFORCE(new_gemm_output_defs.size() == 1);
 
-  Node& new_gemm_node = graph.AddNode(graph.GenerateNodeName(gemm_node.Name() + "_sum_transformed"),
+  Node& new_gemm_node = graph.AddNode(graph.GenerateNodeName(gemm_node.Name() + "/GemmSumFusion/"),
                                       gemm_node.OpType(),
                                       "Fused Gemm with Sum",
                                       new_gemm_input_defs,

--- a/onnxruntime/core/optimizer/matmul_add_fusion.cc
+++ b/onnxruntime/core/optimizer/matmul_add_fusion.cc
@@ -106,7 +106,7 @@ Status MatMulAddFusion::ApplyImpl(Graph& graph, bool& modified, int graph_level,
       continue;
     }
 
-    Node& gemm_node = graph.AddNode(graph.GenerateNodeName("gemm"),
+    Node& gemm_node = graph.AddNode(graph.GenerateNodeName(matmul_node.Name() + "/MatMulAddFusion/"),
                                     "Gemm",
                                     "fused Matmul and Add " + add_node.OpType(),
                                     gemm_input_defs,

--- a/onnxruntime/core/providers/cuda/tensor/cast_op.cc
+++ b/onnxruntime/core/providers/cuda/tensor/cast_op.cc
@@ -44,7 +44,8 @@ const std::vector<MLDataType>& CastOpTypeConstraints() {
       kCudaExecutionProvider,                                     \
       (*KernelDefBuilder::Create())                               \
           .TypeConstraint("T1", DataTypeImpl::GetTensorType<T>()) \
-          .TypeConstraint("T2", CastOpTypeConstraints()),         \
+          .TypeConstraint("T2", CastOpTypeConstraints())          \
+          .MayStridedInput(0),                                    \
       Cast<T>);                                                   \
   ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                        \
       Cast,                                                       \
@@ -54,7 +55,8 @@ const std::vector<MLDataType>& CastOpTypeConstraints() {
       kCudaExecutionProvider,                                     \
       (*KernelDefBuilder::Create())                               \
           .TypeConstraint("T1", DataTypeImpl::GetTensorType<T>()) \
-          .TypeConstraint("T2", CastOpTypeConstraints()),         \
+          .TypeConstraint("T2", CastOpTypeConstraints())          \
+          .MayStridedInput(0),                                    \
       Cast<T>);                                                   \
   ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                        \
       Cast,                                                       \
@@ -64,7 +66,8 @@ const std::vector<MLDataType>& CastOpTypeConstraints() {
       kCudaExecutionProvider,                                     \
       (*KernelDefBuilder::Create())                               \
           .TypeConstraint("T1", DataTypeImpl::GetTensorType<T>()) \
-          .TypeConstraint("T2", CastOpTypeConstraints()),         \
+          .TypeConstraint("T2", CastOpTypeConstraints())          \
+          .MayStridedInput(0),                                    \
       Cast<T>);                                                   \
   ONNX_OPERATOR_TYPED_KERNEL_EX(                                  \
       Cast,                                                       \
@@ -74,7 +77,8 @@ const std::vector<MLDataType>& CastOpTypeConstraints() {
       kCudaExecutionProvider,                                     \
       (*KernelDefBuilder::Create())                               \
           .TypeConstraint("T1", DataTypeImpl::GetTensorType<T>()) \
-          .TypeConstraint("T2", CastOpTypeConstraints()),         \
+          .TypeConstraint("T2", CastOpTypeConstraints())          \
+          .MayStridedInput(0),                                    \
       Cast<T>);
 
 #define CASE(TP_TYPE, DstT)                                                                 \
@@ -116,14 +120,40 @@ const std::vector<MLDataType>& CastOpTypeConstraints() {
 
 #endif
 
+namespace {
+int64_t GetElementCountForStrideTensor(const TensorShape& shape, gsl::span<const int64_t> strides) {
+  SafeInt<int64_t> size = 1;
+  for (size_t dim = 0; dim < shape.NumDimensions(); ++dim) {
+    if (shape[dim] == 0) {
+      size = 0;
+      break;
+    }
+    size += strides[dim] * (shape[dim] - 1);
+  }
+  return size;
+}
+}  // namespace
+
 template <typename SrcT>
 Status Cast<SrcT>::ComputeInternal(OpKernelContext* context) const {
   typedef typename ToCudaType<SrcT>::MappedType CudaSrcT;
   const Tensor* X = context->Input<Tensor>(0);
   const TensorShape& shape = X->Shape();
   Tensor* Y = context->Output(0, shape);
-  const auto* x_data = reinterpret_cast<const CudaSrcT*>(X->Data<SrcT>());
   size_t count = shape.Size();
+  if (!X->IsContiguous()) {
+    std::cout << "Cast<<IsContiguous-->0000" << std::endl;
+#ifdef ENABLE_STRIDED_TENSORS
+    gsl::span<const int64_t> input_strides = X->Strides();
+    // Out tensor should have the same shape as input tensor
+    Y->SetShapeAndStrides(shape, input_strides);
+    count = GetElementCountForStrideTensor(shape, input_strides);
+#else
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Strided tensors are not supported in this build.");
+#endif
+  }
+
+  const auto* x_data = reinterpret_cast<const CudaSrcT*>(X->Data<SrcT>());
 
   switch (to_) {
     CASE(TensorProto_DataType_FLOAT16, MLFloat16)
@@ -163,8 +193,14 @@ Status Cast<SrcT>::ComputeInternal(OpKernelContext* context) const {
     const Tensor* X = context->Input<Tensor>(0);                                                        \
     const TensorShape& shape = X->Shape();                                                              \
     Tensor* Y = context->Output(0, shape);                                                              \
-    const auto* x_data = reinterpret_cast<const CudaSrcT*>(X->Data<FLOAT_TYPE>());                      \
     size_t count = shape.Size();                                                                        \
+    if (!X->IsContiguous()) {                                                                           \
+      std::cout << "Cast<<IsContiguous-->11111" << std::endl;                                           \
+      gsl::span<const int64_t> input_strides = X->Strides();                                            \
+      Y->SetShapeAndStrides(shape, input_strides);                                                      \
+      count = GetElementCountForStrideTensor(shape, input_strides);                                     \
+    }                                                                                                   \
+    const auto* x_data = reinterpret_cast<const CudaSrcT*>(X->Data<FLOAT_TYPE>());                      \
     switch (to_) {                                                                                      \
       CASE(TensorProto_DataType_FLOAT16, MLFloat16)                                                     \
       CASE(TensorProto_DataType_BFLOAT16, BFloat16)                                                     \
@@ -200,8 +236,14 @@ Status Cast<SrcT>::ComputeInternal(OpKernelContext* context) const {
     const Tensor* X = context->Input<Tensor>(0);                                                        \
     const TensorShape& shape = X->Shape();                                                              \
     Tensor* Y = context->Output(0, shape);                                                              \
-    const auto* x_data = reinterpret_cast<const CudaSrcT*>(X->Data<FLOAT_TYPE>());                      \
     size_t count = shape.Size();                                                                        \
+    if (!X->IsContiguous()) {                                                                           \
+      std::cout << "Cast<<IsContiguous-->22222" << std::endl;                                           \
+      gsl::span<const int64_t> input_strides = X->Strides();                                            \
+      Y->SetShapeAndStrides(shape, input_strides);                                                      \
+      count = GetElementCountForStrideTensor(shape, input_strides);                                     \
+    }                                                                                                   \
+    const auto* x_data = reinterpret_cast<const CudaSrcT*>(X->Data<FLOAT_TYPE>());                      \
     switch (to_) {                                                                                      \
       CASE(TensorProto_DataType_FLOAT16, MLFloat16)                                                     \
       CASE(TensorProto_DataType_BFLOAT16, BFloat16)                                                     \
@@ -247,8 +289,14 @@ COMPUTE_INTERNAL_FL16_32(BFloat16)
     const Tensor* X = context->Input<Tensor>(0);                                            \
     const TensorShape& shape = X->Shape();                                                  \
     Tensor* Y = context->Output(0, shape);                                                  \
-    const auto* x_data = reinterpret_cast<const CudaSrcT*>(X->Data<FLOAT_TYPE>());          \
     size_t count = shape.Size();                                                            \
+    if (!X->IsContiguous()) {                                                               \
+      std::cout << "Cast<<IsContiguous-->33333" << std::endl;                               \
+      gsl::span<const int64_t> input_strides = X->Strides();                                \
+      Y->SetShapeAndStrides(shape, input_strides);                                          \
+      count = GetElementCountForStrideTensor(shape, input_strides);                         \
+    }                                                                                       \
+    const auto* x_data = reinterpret_cast<const CudaSrcT*>(X->Data<FLOAT_TYPE>());          \
     switch (to_) {                                                                          \
       case TensorProto_DataType_FLOAT16:                                                    \
         if (count > 0) {                                                                    \

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -2302,7 +2302,7 @@ common::Status InferenceSession::ValidateOutputs(gsl::span<const std::string> ou
 
 #ifdef ENABLE_TRAINING
 Status InferenceSession::PartialRun(onnxruntime::RunOptions& run_options,
-                                     std::vector<OrtValue>& feeds,
+                                    std::vector<OrtValue>& feeds,
                                     std::vector<OrtValue>& fetches,
                                     PartialGraphExecutionState& state,
                                     FeedsFetchesManager& feeds_fetches_manager,

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -2302,7 +2302,7 @@ common::Status InferenceSession::ValidateOutputs(gsl::span<const std::string> ou
 
 #ifdef ENABLE_TRAINING
 Status InferenceSession::PartialRun(onnxruntime::RunOptions& run_options,
-                                    const std::vector<OrtValue>& feeds,
+                                     std::vector<OrtValue>& feeds,
                                     std::vector<OrtValue>& fetches,
                                     PartialGraphExecutionState& state,
                                     FeedsFetchesManager& feeds_fetches_manager,

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -388,7 +388,7 @@ class InferenceSession {
    * @param partial_graph_index Index of the partial graph to run.
    */
   common::Status PartialRun(onnxruntime::RunOptions& run_options,
-                             std::vector<OrtValue>& feeds,
+                            std::vector<OrtValue>& feeds,
                             std::vector<OrtValue>& fetches,
                             PartialGraphExecutionState& state,
                             FeedsFetchesManager& feeds_fetches_manager,

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -388,7 +388,7 @@ class InferenceSession {
    * @param partial_graph_index Index of the partial graph to run.
    */
   common::Status PartialRun(onnxruntime::RunOptions& run_options,
-                            const std::vector<OrtValue>& feeds,
+                             std::vector<OrtValue>& feeds,
                             std::vector<OrtValue>& fetches,
                             PartialGraphExecutionState& state,
                             FeedsFetchesManager& feeds_fetches_manager,

--- a/orttraining/orttraining/core/agent/training_agent.cc
+++ b/orttraining/orttraining/core/agent/training_agent.cc
@@ -60,7 +60,7 @@ TrainingAgent::TrainingAgent(InferenceSession& session,
 
 TrainingAgent::~TrainingAgent() = default;
 
-common::Status TrainingAgent::RunForward( std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
+common::Status TrainingAgent::RunForward(std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
                                          PartialGraphExecutionState& state, const OrtValueCachePtr& cache) {
 #if !defined(ORT_MINIMAL_BUILD) && defined(ORT_MEMORY_PROFILE)
   inference_session_.GetMemoryProfiler().GetMemoryInfo().SetIteration(profile_step_);
@@ -74,7 +74,7 @@ common::Status TrainingAgent::RunForward( std::vector<OrtValue>& feeds, std::vec
   return RunCore(feeds, fetches, state, *fw_feeds_fetches_manager_, cache, partial_graph_index);
 }
 
-common::Status TrainingAgent::RunBackward( std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
+common::Status TrainingAgent::RunBackward(std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
                                           PartialGraphExecutionState& state) {
   state.SetProgramCounterStart(fw_program_counter_end_);
   state.SetProgramCounterEnd(bw_program_counter_end_);
@@ -82,7 +82,7 @@ common::Status TrainingAgent::RunBackward( std::vector<OrtValue>& feeds, std::ve
   return RunCore(feeds, fetches, state, *bw_feeds_fetches_manager_, nullptr, partial_graph_index);
 }
 
-common::Status TrainingAgent::RunCore( std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
+common::Status TrainingAgent::RunCore(std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
                                       PartialGraphExecutionState& state, FeedsFetchesManager& feeds_fetches_manager,
                                       const OrtValueCachePtr& cache, int32_t partial_graph_index) {
   auto fetches_size = feeds_fetches_manager.GetFeedsFetchesInfo().output_names.size();

--- a/orttraining/orttraining/core/agent/training_agent.cc
+++ b/orttraining/orttraining/core/agent/training_agent.cc
@@ -60,7 +60,7 @@ TrainingAgent::TrainingAgent(InferenceSession& session,
 
 TrainingAgent::~TrainingAgent() = default;
 
-common::Status TrainingAgent::RunForward(const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
+common::Status TrainingAgent::RunForward( std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
                                          PartialGraphExecutionState& state, const OrtValueCachePtr& cache) {
 #if !defined(ORT_MINIMAL_BUILD) && defined(ORT_MEMORY_PROFILE)
   inference_session_.GetMemoryProfiler().GetMemoryInfo().SetIteration(profile_step_);
@@ -74,7 +74,7 @@ common::Status TrainingAgent::RunForward(const std::vector<OrtValue>& feeds, std
   return RunCore(feeds, fetches, state, *fw_feeds_fetches_manager_, cache, partial_graph_index);
 }
 
-common::Status TrainingAgent::RunBackward(const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
+common::Status TrainingAgent::RunBackward( std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
                                           PartialGraphExecutionState& state) {
   state.SetProgramCounterStart(fw_program_counter_end_);
   state.SetProgramCounterEnd(bw_program_counter_end_);
@@ -82,7 +82,7 @@ common::Status TrainingAgent::RunBackward(const std::vector<OrtValue>& feeds, st
   return RunCore(feeds, fetches, state, *bw_feeds_fetches_manager_, nullptr, partial_graph_index);
 }
 
-common::Status TrainingAgent::RunCore(const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
+common::Status TrainingAgent::RunCore( std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
                                       PartialGraphExecutionState& state, FeedsFetchesManager& feeds_fetches_manager,
                                       const OrtValueCachePtr& cache, int32_t partial_graph_index) {
   auto fetches_size = feeds_fetches_manager.GetFeedsFetchesInfo().output_names.size();

--- a/orttraining/orttraining/core/agent/training_agent.h
+++ b/orttraining/orttraining/core/agent/training_agent.h
@@ -32,14 +32,14 @@ class TrainingAgent {
                          int local_rank = 0);
   ~TrainingAgent();
   // For ORTModule.forward()
-  [[nodiscard]] common::Status RunForward(const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
+  [[nodiscard]] common::Status RunForward( std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
                                           PartialGraphExecutionState& state, const OrtValueCachePtr& cache);
 
   // For ORTModule.backward()
-  [[nodiscard]] common::Status RunBackward(const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
+  [[nodiscard]] common::Status RunBackward(std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
                                            PartialGraphExecutionState& state);
 
-  [[nodiscard]] common::Status RunCore(const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
+  [[nodiscard]] common::Status RunCore(std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
                                        PartialGraphExecutionState& state, FeedsFetchesManager& feeds_fetches_manager,
                                        const OrtValueCachePtr& cache, int32_t partial_graph_index);
 

--- a/orttraining/orttraining/core/agent/training_agent.h
+++ b/orttraining/orttraining/core/agent/training_agent.h
@@ -32,7 +32,7 @@ class TrainingAgent {
                          int local_rank = 0);
   ~TrainingAgent();
   // For ORTModule.forward()
-  [[nodiscard]] common::Status RunForward( std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
+  [[nodiscard]] common::Status RunForward(std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
                                           PartialGraphExecutionState& state, const OrtValueCachePtr& cache);
 
   // For ORTModule.backward()

--- a/orttraining/orttraining/core/optimizer/memory_optimizer/transformer_specific.cc
+++ b/orttraining/orttraining/core/optimizer/memory_optimizer/transformer_specific.cc
@@ -26,6 +26,7 @@ bool IsLayerNormNode(const Node& node) {
       "SimplifiedLayerNormalization",
       "SkipSimplifiedLayerNormalization",
   };
+
   return layer_norm_ops.find(node.OpType()) != layer_norm_ops.end();
 }
 

--- a/orttraining/orttraining/python/orttraining_pybind_state.cc
+++ b/orttraining/orttraining/python/orttraining_pybind_state.cc
@@ -423,13 +423,17 @@ void addObjectMethodsForTraining(py::module& m) {
         return std::make_unique<TrainingAgent>(*session->GetSessionHandle(), fw_feed_names, fw_outputs_device_info,
                                                bw_fetches_names, bw_outputs_device_info, local_rank);
       }))
-      .def("run_forward", [](TrainingAgent* agent, const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches, PartialGraphExecutionState* state, OrtValueCachePtr cache) -> void {
+      .def("run_forward", [](TrainingAgent* agent, std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches, PartialGraphExecutionState* state, OrtValueCachePtr cache) -> void {
+        // std::vector<OrtValue> feeds_cloned = feeds;
+        // feeds.clear(); // Release the input feeds at the earliest convenience.
         Status status = agent->RunForward(feeds, fetches, *state, cache);
         if (!status.IsOK()) {
           throw std::runtime_error("Error in forward pass execution: " + status.ErrorMessage());
         }
       })
-      .def("run_backward", [](TrainingAgent* agent, const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches, PartialGraphExecutionState* state) -> void {
+      .def("run_backward", [](TrainingAgent* agent,  std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches, PartialGraphExecutionState* state) -> void {
+        // std::vector<OrtValue> feeds_cloned = feeds;
+        // feeds.clear(); // Release the input feeds at the earliest convenience.
         Status status = agent->RunBackward(feeds, fetches, *state);
         if (!status.IsOK()) {
           throw std::runtime_error("Error in backward pass execution: " + status.ErrorMessage());

--- a/orttraining/orttraining/python/orttraining_pybind_state.cc
+++ b/orttraining/orttraining/python/orttraining_pybind_state.cc
@@ -431,7 +431,7 @@ void addObjectMethodsForTraining(py::module& m) {
           throw std::runtime_error("Error in forward pass execution: " + status.ErrorMessage());
         }
       })
-      .def("run_backward", [](TrainingAgent* agent,  std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches, PartialGraphExecutionState* state) -> void {
+      .def("run_backward", [](TrainingAgent* agent, std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches, PartialGraphExecutionState* state) -> void {
         // std::vector<OrtValue> feeds_cloned = feeds;
         // feeds.clear(); // Release the input feeds at the earliest convenience.
         Status status = agent->RunBackward(feeds, fetches, *state);

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -179,7 +179,7 @@ class TrainingManager(GraphExecutionManager):
                     if grad_output is None:
                         shape, device, dtype = ctx.run_info.output_info[idx]
                         if idx in self._graph_info.output_grad_indices_require_full_shape:
-                            grad_output = torch.zeros(shape, device=device, dtype=dtype)  # noqa: PLW2901
+                            grad_output = torch.zeros(1, device=device, dtype=dtype).expand(shape)  # noqa: PLW2901
                         else:
                             grad_output = torch.tensor(0.0, device=device, dtype=dtype)  # noqa: PLW2901
                     elif not grad_output.is_contiguous():

--- a/orttraining/orttraining/python/training/ortmodule/_utils.py
+++ b/orttraining/orttraining/python/training/ortmodule/_utils.py
@@ -104,8 +104,8 @@ def _torch_tensor_to_dlpack(tensor: torch.Tensor):
     # We need to convert bool tensor to unit8 tensor to workaround this.
     # DLPack is discussing how to support bool type, we can remove this workaround once both DLPack
     # and PyTorch support bool type.
-    if not tensor.is_contiguous():
-        raise ORTModuleIOError("Only contiguous tensors are supported.")
+    # if not tensor.is_contiguous():
+    #     raise ORTModuleIOError("Only contiguous tensors are supported.")
     if tensor.dtype == torch.bool and LooseVersion(torch.__version__) >= LooseVersion("1.10.0"):
         tensor = tensor.to(torch.uint8)
     return to_dlpack(tensor)


### PR DESCRIPTION
### Release backward inputs per static graph ref count

For the output buffer marked as external output:
1. Remove the additional ref count we used for avoiding reusing buffer. Instead, when we find reuse input buffer, we will make sure the reused buffer not not generated by nodes that has external outputs. 
2. Remove the ref count of pybind feed inputs, which exists all the time until the run_backward completed. Instead, passing a mutuble feeds, and we clean the feeds vector once that is copied into session states and not needed any more before run the graph sequencentially.

#### Before the change:

One of the backward inputs is 3.9GB, it lives until the backward ends. 
![image](https://github.com/microsoft/onnxruntime/assets/10530022/e71e2072-eaaa-4be3-a39f-0ca74b507265)

#### With the change:
The 3.9GB is released when the last node depending on that tensor completed.

![image](https://github.com/microsoft/onnxruntime/assets/10530022/7b27d01f-c675-4faf-9a3e-f886b31b2afe)


Be noted: the peak did not change though, we have more work to do to reduce on the peak.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


