### PR TITLE
fix typo in QNN backend

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -98,7 +98,7 @@ void QnnBackendManager::SetQnnBackendType(uint32_t backend_id) {
     case QNN_BACKEND_ID_CPU:
       qnn_backend_type_ = QnnBackendType::CPU;
       break;
-      // TODO: update once it's ready for Widows
+      // TODO: update once it's ready for Windows
       // case QNN_BACKEND_ID_GPU:
       //  qnn_backend_type_ = QnnBackendType::GPU;
       //  break;


### PR DESCRIPTION
### Description
fix a typo in onnxruntime's QNN backend



### Motivation and Context

fix a typo from "Widows" to "Windows" in [onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc#L101](https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc#L101)


