### PR TITLE
Fix bench_sqnbitgemm.cpp benchmark argument name list.

### DIFF
--- a/onnxruntime/test/mlas/bench/bench_sqnbitgemm.cpp
+++ b/onnxruntime/test/mlas/bench/bench_sqnbitgemm.cpp
@@ -111,7 +111,7 @@ void SQNBITGEMM(benchmark::State& state) {
 }
 
 static void SQNBitGemmArgs(benchmark::internal::Benchmark* b) {
-  b->ArgNames({"BlkLen", "M", "N", "K", "Threads", "Symmetric", "ComputeType"});
+  b->ArgNames({"BlkLen", "M", "N", "K", "Threads", "Symmetric", "HasBias", "ComputeType"});
 
   b->ArgsProduct({
       {16, 32, 64, 128, 256},                  // BlkLen


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Add the "HasBias" argument to the ArgNames() call so it matches with the ArgsProduct() call.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix bug. It causes a runtime check failure in a debug build.