### PR TITLE
Address React Native pipeline component detection timeout

### DIFF
--- a/tools/ci_build/github/azure-pipelines/mac-react-native-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-react-native-ci-pipeline.yml
@@ -47,7 +47,7 @@ resources:
     ref: 5eda9aded5462201e6310105728d33016e637ea7
 
 variables:
-  ComponentDetection.Timeout: 660
+  skipComponentGovernanceDetection: true
   ${{ if eq(parameters.NpmPublish, 'nightly (@dev)') }}:
     NpmPackagingMode: 'dev'
   ${{ if eq(parameters.NpmPublish, 'release candidate (@rc)') }}:

--- a/tools/ci_build/github/azure-pipelines/templates/component-governance-component-detection-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/component-governance-component-detection-steps.yml
@@ -33,5 +33,3 @@ steps:
         $(Build.Repository.LocalPath)/js/react_native/e2e/node_modules,
         $(Build.SourcesDirectory)/onnxruntime-inference-examples,
         $(Build.BinariesDirectory)'
-      verbosity: Verbose
-    timeoutInMinutes: 30

--- a/tools/ci_build/github/azure-pipelines/templates/component-governance-component-detection-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/component-governance-component-detection-steps.yml
@@ -33,3 +33,5 @@ steps:
         $(Build.Repository.LocalPath)/js/react_native/e2e/node_modules,
         $(Build.SourcesDirectory)/onnxruntime-inference-examples,
         $(Build.BinariesDirectory)'
+      verbosity: Verbose
+    timeoutInMinutes: 30

--- a/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
@@ -52,7 +52,6 @@ stages:
 
     variables:
       runCodesignValidationInjection: false
-      ComponentDetection.Timeout: 660
       TODAY: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]
       ORT_CACHE_DIR: '$(Pipeline.Workspace)/ccache_ort'
 
@@ -120,7 +119,7 @@ stages:
       vmImage: 'macOS-12'
     variables:
       runCodesignValidationInjection: false
-    timeoutInMinutes: 60
+    timeoutInMinutes: 90
     steps:
     - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
       displayName: Clean Agent Directories

--- a/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
@@ -399,10 +399,6 @@ stages:
         targetFolder: $(Build.ArtifactStagingDirectory)
       displayName: Create Artifacts onnxruntime-react-native
 
-    - template: component-governance-component-detection-steps.yml
-      parameters :
-        condition : 'succeeded'
-
     - task: PublishPipelineArtifact@1
       inputs:
         artifact: e2e_test_logs_$(Build.BuildId)_$(Build.BuildNumber)_$(System.JobAttempt)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

mac-react-native-ci-pipeline.yml:
- We don't need to run component detection for PR builds so just disable it there.

npm-packaging-pipeline.yml:
- Manually added component detection task was being added twice - removed one.
- Increased timeout of stage where component detection is run since the existing timeout was close for some builds.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Address pipeline failures due to component detection task timeout.