### PR TITLE
Update protobuf_cmake.patch to allow extra disablements configurable by projects that build ORT

### DIFF
--- a/cmake/patches/protobuf/protobuf_cmake.patch
+++ b/cmake/patches/protobuf/protobuf_cmake.patch
@@ -12,11 +12,12 @@ index 04cb3303a..4025805cf 100644
      /wd4305 # 'identifier' : truncation from 'type1' to 'type2'
      /wd4307 # 'operator' : integral constant overflow
      /wd4309 # 'conversion' : truncation of constant value
-@@ -259,7 +257,6 @@ if (MSVC)
+@@ -259,7 +257,7 @@ if (MSVC)
      /wd4355 # 'this' : used in base member initializer list
      /wd4506 # no definition for inline function 'function'
      /wd4800 # 'type' : forcing value to bool 'true' or 'false' (performance warning)
 -    /wd4996 # The compiler encountered a deprecated declaration.
++    ${onnxruntime_PROTOBUF_EXTRA_WARNING_DISABLEMENT}
    )
    # Allow big object
    add_definitions(/bigobj)


### PR DESCRIPTION
### Description
Update protobuf_cmake.patch to allow extra disablements. ORT repo already patches protobuf to not disable the warning 4996.


### Motivation and Context

To meet SDL requirements, Microsoft repos have to fail build if there is warning 4996
Binskim also gives errors if warning 4996 is disabled.
We can suppress the Binskim issues, but we need a way to disable the warnings for the minimal set of code that has them. 
Right now, WindowsAI disables 4996 for entirety of ORT, but it should only be disabled for protobuf.

