### PR TITLE
Suppress Eigen warning in onnxruntime/test/onnx/microbenchmark/eigen.cc.

### DIFF
--- a/onnxruntime/test/onnx/microbenchmark/eigen.cc
+++ b/onnxruntime/test/onnx/microbenchmark/eigen.cc
@@ -1,3 +1,5 @@
+#include "onnxruntime_config.h"
+
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #if __GNUC__ >= 6
@@ -6,6 +8,15 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wunused-result"
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+
+// _deps/eigen-src/unsupported/Eigen/CXX11/../../../Eigen/src/Core/arch/NEON/PacketMath.h:1671:9:
+// error: ‘void* memcpy(void*, const void*, size_t)’ copying an object of non-trivial type ‘Eigen::internal::Packet4c’
+//   {aka ‘struct Eigen::internal::eigen_packet_wrapper<int, 2>’} from an array of ‘const int8_t’
+//   {aka ‘const signed char’} [-Werror=class-memaccess]
+#ifdef HAS_CLASS_MEMACCESS
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
+
 #elif defined(_MSC_VER)
 // build\windows\debug\external\eigen3\unsupported\eigen\cxx11\src/Tensor/Tensor.h(76):
 // warning C4554: '&': check operator precedence for possible error; use parentheses to clarify precedence


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Suppress Eigen warning in onnxruntime/test/onnx/microbenchmark/eigen.cc.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix ARM64 GCC build with `--build_micro_benchmarks`.
