### PR TITLE
Remove core/common/gsl.h

### DIFF
--- a/include/onnxruntime/core/common/gsl.h
+++ b/include/onnxruntime/core/common/gsl.h
@@ -1,6 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-#pragma once
-
-#include "gsl/gsl"

--- a/include/onnxruntime/core/common/logging/capture.h
+++ b/include/onnxruntime/core/common/logging/capture.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <cstdarg>
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/common/common.h"
 #include "core/common/code_location.h"
 #include "core/common/logging/severity.h"

--- a/include/onnxruntime/core/common/span_utils.h
+++ b/include/onnxruntime/core/common/span_utils.h
@@ -6,7 +6,7 @@
 #include <algorithm>
 #include <cstddef>
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 namespace onnxruntime {
 

--- a/include/onnxruntime/core/framework/data_types.h
+++ b/include/onnxruntime/core/framework/data_types.h
@@ -9,7 +9,7 @@
 #include <type_traits>
 #include <map>
 #include <unordered_map>
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/common/common.h"
 #include "core/common/exceptions.h"
 #include "core/framework/endian.h"

--- a/include/onnxruntime/core/framework/int4.h
+++ b/include/onnxruntime/core/framework/int4.h
@@ -6,7 +6,7 @@
 #include <cassert>
 #include <type_traits>
 #include "core/common/common.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 namespace onnxruntime {
 

--- a/include/onnxruntime/core/framework/op_kernel.h
+++ b/include/onnxruntime/core/framework/op_kernel.h
@@ -25,7 +25,7 @@
 #include "core/graph/constants.h"
 #include "core/graph/graph_viewer.h"
 #include "core/graph/onnx_protobuf.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 namespace onnxruntime {
 class OpKernelContext;
 }

--- a/include/onnxruntime/core/framework/op_kernel_info.h
+++ b/include/onnxruntime/core/framework/op_kernel_info.h
@@ -8,7 +8,7 @@
 #include "core/framework/ort_value.h"
 #include "core/framework/op_node_proto_helper.h"
 #include "core/graph/graph_viewer.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 namespace onnxruntime {
 

--- a/include/onnxruntime/core/framework/op_node_proto_helper.h
+++ b/include/onnxruntime/core/framework/op_node_proto_helper.h
@@ -7,7 +7,7 @@
 #include "core/common/status.h"
 #include "core/framework/tensor_shape.h"
 #include "core/graph/graph_viewer.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #endif
 
 class IMLOpKernel;

--- a/include/onnxruntime/core/framework/tensor.h
+++ b/include/onnxruntime/core/framework/tensor.h
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/common/common.h"
 #include "core/framework/allocator.h"
 #include "core/framework/tensor_shape.h"

--- a/include/onnxruntime/core/framework/tensor_shape.h
+++ b/include/onnxruntime/core/framework/tensor_shape.h
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/common/inlined_containers_fwd.h"
 #include "core/common/span_utils.h"
 #include "onnxruntime_config.h"

--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -14,7 +14,7 @@
 
 #include "core/common/flatbuffers.h"
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include "core/common/common.h"
 #include "core/common/path_string.h"

--- a/onnxruntime/contrib_ops/cpu/attnlstm/attention_mechanism.h
+++ b/onnxruntime/contrib_ops/cpu/attnlstm/attention_mechanism.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 namespace onnxruntime {
 namespace contrib {

--- a/onnxruntime/contrib_ops/cpu/attnlstm/uni_dir_attn_lstm.h
+++ b/onnxruntime/contrib_ops/cpu/attnlstm/uni_dir_attn_lstm.h
@@ -11,7 +11,7 @@
 #include "core/common/logging/logging.h"
 #include "core/framework/allocator.h"
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 namespace onnxruntime {
 namespace contrib {

--- a/onnxruntime/contrib_ops/cpu/crop.h
+++ b/onnxruntime/contrib_ops/cpu/crop.h
@@ -6,7 +6,7 @@
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 namespace onnxruntime {
 namespace contrib {

--- a/onnxruntime/contrib_ops/cpu/quantization/qlinear_softmax.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/qlinear_softmax.cc
@@ -15,7 +15,7 @@
 
 #include "core/mlas/inc/mlas.h"
 #include "core/platform/threadpool.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 namespace onnxruntime {
 namespace contrib {

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search.cc
@@ -26,7 +26,7 @@
 #include "core/framework/TensorSeq.h"
 #include "core/framework/allocator.h"
 #include "core/framework/ort_value.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "contrib_ops/cpu/transformers/beam_search.h"
 #include "contrib_ops/cpu/transformers/logits_processor.h"
 #include "contrib_ops/cpu/transformers/sequences.h"

--- a/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.cc
@@ -8,7 +8,7 @@
 #include "core/providers/cpu/math/softmax_shared.h"
 #include "core/providers/cpu/generator/random.h"
 #include "core/common/safeint.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "contrib_ops/cpu/transformers/sequences.h"
 #include "contrib_ops/cpu/transformers/beam_search_scorer.h"
 #include "contrib_ops/cpu/transformers/generation_device_helper.h"

--- a/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.h
@@ -10,7 +10,7 @@
 #endif
 
 #include <vector>
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "contrib_ops/cpu/transformers/logits_processor.h"
 #include "contrib_ops/cpu/transformers/generation_shared.h"
 

--- a/onnxruntime/contrib_ops/cpu/transformers/generation_shared.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/generation_shared.h
@@ -5,7 +5,7 @@
 
 #include <utility>
 #include <random>
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/framework/allocator.h"
 #include "core/framework/ort_value.h"
 #include "contrib_ops/cpu/utils/debug_macros.h"

--- a/onnxruntime/contrib_ops/cpu/transformers/greedy_search.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/greedy_search.cc
@@ -26,7 +26,7 @@
 #include "core/framework/session_options.h"
 #include "core/framework/TensorSeq.h"
 #include "core/framework/ort_value.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "contrib_ops/cpu/transformers/greedy_search.h"
 #include "contrib_ops/cpu/transformers/logits_processor.h"
 #include "contrib_ops/cpu/transformers/sequences.h"

--- a/onnxruntime/contrib_ops/cpu/transformers/sequences.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/sequences.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "contrib_ops/cpu/transformers/generation_shared.h"
 
 namespace onnxruntime {

--- a/onnxruntime/contrib_ops/cpu/transformers/subgraph_base.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/subgraph_base.cc
@@ -7,7 +7,7 @@
 #include "core/framework/tensorprotoutils.h"
 #include "core/framework/utils.h"
 #include "core/providers/cpu/tensor/utils.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "contrib_ops/cpu/transformers/subgraph_base.h"
 #include "contrib_ops/cpu/utils/dump_tensor.h"
 

--- a/onnxruntime/contrib_ops/cpu/transformers/subgraph_base.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/subgraph_base.h
@@ -5,7 +5,7 @@
 
 #include <vector>
 #include <string>
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/framework/allocator.h"
 #include "core/framework/feeds_fetches_manager.h"
 #include "contrib_ops/cpu/transformers/generation_device_helper.h"

--- a/onnxruntime/contrib_ops/cpu/transformers/subgraph_gpt.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/subgraph_gpt.cc
@@ -6,7 +6,7 @@
 #include "core/framework/tensorprotoutils.h"
 #include "core/framework/utils.h"
 #include "core/providers/cpu/tensor/utils.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "contrib_ops/cpu/transformers/subgraph_gpt.h"
 #include "contrib_ops/cpu/utils/dump_tensor.h"
 

--- a/onnxruntime/contrib_ops/cpu/transformers/subgraph_t5_decoder.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/subgraph_t5_decoder.cc
@@ -6,7 +6,7 @@
 #include "core/framework/tensorprotoutils.h"
 #include "core/framework/utils.h"
 #include "core/providers/cpu/tensor/utils.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "contrib_ops/cpu/transformers/subgraph_t5_decoder.h"
 #include "contrib_ops/cpu/utils/dump_tensor.h"
 #include "contrib_ops/cpu/transformers/generation_device_helper.h"

--- a/onnxruntime/contrib_ops/cpu/transformers/subgraph_t5_encoder.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/subgraph_t5_encoder.cc
@@ -6,7 +6,7 @@
 #include "core/framework/tensorprotoutils.h"
 #include "core/framework/utils.h"
 #include "core/providers/cpu/tensor/utils.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "contrib_ops/cpu/transformers/subgraph_t5_encoder.h"
 
 namespace onnxruntime {

--- a/onnxruntime/contrib_ops/cpu/transformers/subgraph_whisper_decoder.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/subgraph_whisper_decoder.cc
@@ -6,7 +6,7 @@
 #include "core/framework/tensorprotoutils.h"
 #include "core/framework/utils.h"
 #include "core/providers/cpu/tensor/utils.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "contrib_ops/cpu/transformers/subgraph_t5_decoder.h"
 #include "contrib_ops/cpu/transformers/subgraph_whisper_decoder.h"
 #include "contrib_ops/cpu/utils/dump_tensor.h"

--- a/onnxruntime/contrib_ops/cpu/transformers/subgraph_whisper_encoder.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/subgraph_whisper_encoder.cc
@@ -6,7 +6,7 @@
 #include "core/framework/tensorprotoutils.h"
 #include "core/framework/utils.h"
 #include "core/providers/cpu/tensor/utils.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "contrib_ops/cpu/transformers/subgraph_t5_encoder.h"
 #include "contrib_ops/cpu/transformers/subgraph_whisper_encoder.h"
 

--- a/onnxruntime/contrib_ops/cuda/bert/attention_impl.h
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_impl.h
@@ -5,7 +5,7 @@
 
 #include <cuda_fp16.h>
 #include <cublas_v2.h>
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/framework/allocator.h"
 #include "contrib_ops/cpu/bert/attention_common.h"
 

--- a/onnxruntime/contrib_ops/cuda/collective/sharding_spec.cc
+++ b/onnxruntime/contrib_ops/cuda/collective/sharding_spec.cc
@@ -4,7 +4,7 @@
 #include "sharding_spec.h"
 
 #include "core/common/common.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/framework/tensor_shape.h"
 
 #include <cctype>

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.h
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.h
@@ -7,7 +7,7 @@
 #include "core/providers/cpu/tensor/utils.h"
 #include "core/providers/cuda/cuda_common.h"
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "contrib_ops/cpu/transformers/sequences.h"
 #include "contrib_ops/cpu/transformers/generation_shared.h"
 

--- a/onnxruntime/core/codegen/mti/mti_tvm_utils.h
+++ b/onnxruntime/core/codegen/mti/mti_tvm_utils.h
@@ -5,7 +5,7 @@
 
 #include <string>
 #include <vector>
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include <tvm/tvm.h>
 #include "core/codegen/mti/common.h"
 

--- a/onnxruntime/core/codegen/mti/tensor/concat_ops.cc
+++ b/onnxruntime/core/codegen/mti/tensor/concat_ops.cc
@@ -4,7 +4,7 @@
 #include "core/codegen/mti/tensor/concat_ops.h"
 
 #include "core/codegen/mti/mti_tvm_utils.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include <topi/transform.h>
 
 namespace onnxruntime {

--- a/onnxruntime/core/codegen/mti/tensor/gather.cc
+++ b/onnxruntime/core/codegen/mti/tensor/gather.cc
@@ -4,7 +4,7 @@
 #include "core/codegen/mti/tensor/gather.h"
 
 #include "core/codegen/mti/mti_tvm_utils.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include <topi/transform.h>
 
 namespace onnxruntime {

--- a/onnxruntime/core/codegen/mti/tensor/slice.cc
+++ b/onnxruntime/core/codegen/mti/tensor/slice.cc
@@ -5,7 +5,7 @@
 
 #include "core/codegen/mti/mti_tvm_utils.h"
 #include <climits>
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include <topi/transform.h>
 #include <tvm/ir_pass.h>
 

--- a/onnxruntime/core/codegen/mti/tensor/split.cc
+++ b/onnxruntime/core/codegen/mti/tensor/split.cc
@@ -4,7 +4,7 @@
 #include "core/codegen/mti/tensor/split.h"
 
 #include "core/codegen/mti/mti_tvm_utils.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include <topi/transform.h>
 
 namespace onnxruntime {

--- a/onnxruntime/core/codegen/mti/tensor/tile.cc
+++ b/onnxruntime/core/codegen/mti/tensor/tile.cc
@@ -3,7 +3,7 @@
 
 #include "core/codegen/mti/tensor/tile.h"
 #include "core/codegen/mti/mti_tvm_utils.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 namespace onnxruntime {
 namespace tvm_codegen {

--- a/onnxruntime/core/codegen/passes/utils/ort_tvm_utils.cc
+++ b/onnxruntime/core/codegen/passes/utils/ort_tvm_utils.cc
@@ -7,7 +7,7 @@
 #include "core/codegen/passes/utils/codegen_context.h"
 #include "core/framework/tensorprotoutils.h"
 #include "core/providers/common.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include <topi/detail/extern.h>
 

--- a/onnxruntime/core/common/logging/capture.cc
+++ b/onnxruntime/core/common/logging/capture.cc
@@ -3,7 +3,7 @@
 
 #include "core/common/logging/capture.h"
 #include "core/common/logging/logging.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 namespace onnxruntime {
 namespace logging {

--- a/onnxruntime/core/flatbuffers/flatbuffers_utils.cc
+++ b/onnxruntime/core/flatbuffers/flatbuffers_utils.cc
@@ -4,7 +4,7 @@
 #include "core/flatbuffers/flatbuffers_utils.h"
 
 #include "core/common/common.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/flatbuffers/schema/ort.fbs.h"
 #include "core/graph/constants.h"
 #include "core/graph/onnx_protobuf.h"

--- a/onnxruntime/core/framework/data_transfer_utils.h
+++ b/onnxruntime/core/framework/data_transfer_utils.h
@@ -5,7 +5,7 @@
 
 #include <type_traits>
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include "core/common/common.h"
 #include "core/framework/tensor.h"

--- a/onnxruntime/core/framework/endian_utils.h
+++ b/onnxruntime/core/framework/endian_utils.h
@@ -5,7 +5,7 @@
 
 #include <type_traits>
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include "core/common/status.h"
 #include "core/common/common.h"

--- a/onnxruntime/core/framework/fallback_cpu_capability.h
+++ b/onnxruntime/core/framework/fallback_cpu_capability.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/common/inlined_containers_fwd.h"
 #include "core/framework/execution_provider.h"  // for IExecutionProvider::IKernelLookup
 #include "core/graph/graph_viewer.h"

--- a/onnxruntime/core/framework/kernel_lookup.h
+++ b/onnxruntime/core/framework/kernel_lookup.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "core/common/common.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/framework/execution_provider.h"  // for IExecutionProvider::IKernelLookup
 #include "core/framework/kernel_registry.h"
 #include "core/framework/kernel_type_str_resolver.h"

--- a/onnxruntime/core/framework/kernel_registry_manager.h
+++ b/onnxruntime/core/framework/kernel_registry_manager.h
@@ -7,7 +7,7 @@
 #include <variant>
 #include <unordered_map>
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/common/inlined_containers.h"
 #include "core/common/status.h"
 #include "core/framework/kernel_type_str_resolver.h"

--- a/onnxruntime/core/framework/kernel_type_str_resolver.h
+++ b/onnxruntime/core/framework/kernel_type_str_resolver.h
@@ -13,7 +13,7 @@
 #include "core/graph/onnx_protobuf.h"
 #endif  // !defined(ORT_MINIMAL_BUILD)
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/common/inlined_containers.h"
 #include "core/common/status.h"
 #include "core/graph/op_identifier.h"

--- a/onnxruntime/core/framework/kernel_type_str_resolver_utils.h
+++ b/onnxruntime/core/framework/kernel_type_str_resolver_utils.h
@@ -5,7 +5,7 @@
 
 #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/common/status.h"
 #include "core/framework/kernel_type_str_resolver.h"
 #include "core/graph/op_identifier.h"

--- a/onnxruntime/core/framework/op_node_proto_helper.cc
+++ b/onnxruntime/core/framework/op_node_proto_helper.cc
@@ -6,7 +6,7 @@
 #include "core/framework/tensorprotoutils.h"
 #include "core/graph/onnx_protobuf.h"
 #include "core/graph/op.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 using namespace ONNX_NAMESPACE;
 using namespace ::onnxruntime::common;

--- a/onnxruntime/core/framework/session_options.h
+++ b/onnxruntime/core/framework/session_options.h
@@ -8,7 +8,7 @@
 #include <iostream>
 #include <codecvt>
 #include <filesystem>
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/common/inlined_containers.h"
 #include "core/framework/config_options.h"
 #include "core/framework/ort_value.h"

--- a/onnxruntime/core/framework/session_state.h
+++ b/onnxruntime/core/framework/session_state.h
@@ -10,7 +10,7 @@
 
 #include "core/common/flatbuffers.h"
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include "core/common/common.h"
 #include "core/common/inlined_containers.h"

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -11,7 +11,7 @@
 #include <emscripten.h>
 #endif
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/common/logging/logging.h"
 #include "core/common/narrow.h"
 #include "core/common/span_utils.h"

--- a/onnxruntime/core/framework/transpose_helper.h
+++ b/onnxruntime/core/framework/transpose_helper.h
@@ -37,7 +37,7 @@ We fall back to the default implementation in all other cases, and if the input 
 #include "core/framework/tensor.h"
 #include "core/platform/threadpool.h"
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 namespace onnxruntime {
 bool IsTransposeMovingSingleAxis(gsl::span<const size_t> permutations, size_t& from, size_t& to);

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -11,7 +11,7 @@
 #include <queue>
 
 #include "core/common/common.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/common/inlined_containers.h"
 #include "core/common/logging/logging.h"
 #include "core/common/narrow.h"

--- a/onnxruntime/core/graph/model.cc
+++ b/onnxruntime/core/graph/model.cc
@@ -20,7 +20,7 @@
 #endif
 #include "core/util/protobuf_parsing_utils.h"
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include "core/platform/env.h"
 

--- a/onnxruntime/core/graph/node_attr_utils.h
+++ b/onnxruntime/core/graph/node_attr_utils.h
@@ -5,7 +5,7 @@
 
 #include <string>
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include "core/graph/onnx_protobuf.h"
 #include "core/graph/basic_types.h"

--- a/onnxruntime/core/graph/runtime_optimization_record_container.cc
+++ b/onnxruntime/core/graph/runtime_optimization_record_container.cc
@@ -7,7 +7,7 @@
 
 #include <algorithm>
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include "core/flatbuffers/flatbuffers_utils.h"
 #include "core/flatbuffers/schema/ort.fbs.h"

--- a/onnxruntime/core/optimizer/free_dim_override_transformer.h
+++ b/onnxruntime/core/optimizer/free_dim_override_transformer.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include "core/common/common.h"
 #include "core/optimizer/graph_transformer.h"

--- a/onnxruntime/core/optimizer/initializer.cc
+++ b/onnxruntime/core/optimizer/initializer.cc
@@ -6,7 +6,7 @@
 #include <functional>
 #include <memory>
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/framework/tensorprotoutils.h"
 #include "core/framework/tensor_external_data_info.h"
 #include "core/platform/env.h"

--- a/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/shared/utils.h
+++ b/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/shared/utils.h
@@ -5,7 +5,7 @@
 
 #include <string>
 #include "core/common/common.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/common/inlined_containers.h"
 #include "core/framework/node_unit.h"
 #include "core/graph/basic_types.h"

--- a/onnxruntime/core/optimizer/selectors_actions/actions.h
+++ b/onnxruntime/core/optimizer/selectors_actions/actions.h
@@ -6,7 +6,7 @@
 #include <vector>
 
 #include "core/common/common.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/graph/graph_utils.h"  // TODO: Minimize usage of this given we want to use Actions in a minimal build
 #include "core/graph/runtime_optimization_record.h"
 #include "core/optimizer/selectors_actions/helpers.h"

--- a/onnxruntime/core/optimizer/selectors_actions/helpers.h
+++ b/onnxruntime/core/optimizer/selectors_actions/helpers.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "core/common/basic_types.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/common/inlined_containers.h"
 #include "core/graph/graph.h"
 #include "core/graph/runtime_optimization_record.h"

--- a/onnxruntime/core/optimizer/transpose_optimization/onnx_transpose_optimization.cc
+++ b/onnxruntime/core/optimizer/transpose_optimization/onnx_transpose_optimization.cc
@@ -12,7 +12,7 @@
 #include <utility>
 #include <vector>
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/common/make_string.h"
 #include "core/graph/constants.h"
 

--- a/onnxruntime/core/platform/env.h
+++ b/onnxruntime/core/platform/env.h
@@ -22,7 +22,7 @@ limitations under the License.
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include "core/common/common.h"
 #include "core/common/path_string.h"

--- a/onnxruntime/core/platform/posix/env.cc
+++ b/onnxruntime/core/platform/posix/env.cc
@@ -44,7 +44,7 @@ limitations under the License.
 #endif
 
 #include "core/common/common.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/common/logging/logging.h"
 #include "core/common/narrow.h"
 #include "core/platform/scoped_resource.h"

--- a/onnxruntime/core/platform/windows/env.cc
+++ b/onnxruntime/core/platform/windows/env.cc
@@ -26,7 +26,7 @@ limitations under the License.
 #include <fcntl.h>
 #include <io.h>
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/common/logging/logging.h"
 #include "core/common/narrow.h"
 #include "core/common/span_utils.h"

--- a/onnxruntime/core/platform/windows/stacktrace.cc
+++ b/onnxruntime/core/platform/windows/stacktrace.cc
@@ -12,7 +12,7 @@
 #endif
 
 #include "core/common/logging/logging.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 namespace onnxruntime {
 

--- a/onnxruntime/core/providers/coreml/builders/impl/builder_utils.h
+++ b/onnxruntime/core/providers/coreml/builders/impl/builder_utils.h
@@ -7,7 +7,7 @@
 
 #include <optional>
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/common/status.h"
 #include "core/graph/basic_types.h"
 #include "core/providers/common.h"

--- a/onnxruntime/core/providers/coreml/model/model.h
+++ b/onnxruntime/core/providers/coreml/model/model.h
@@ -8,7 +8,7 @@
 #include <unordered_set>
 
 #include "core/common/common.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/common/logging/logging.h"
 #include "core/common/status.h"
 #include "core/platform/ort_mutex.h"

--- a/onnxruntime/core/providers/coreml/model/model.mm
+++ b/onnxruntime/core/providers/coreml/model/model.mm
@@ -13,7 +13,7 @@
 #include <vector>
 
 #include "core/common/common.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/common/inlined_containers.h"
 #include "core/common/logging/logging.h"
 #include "core/common/narrow.h"

--- a/onnxruntime/core/providers/coreml/shape_utils.h
+++ b/onnxruntime/core/providers/coreml/shape_utils.h
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/common/logging/logging.h"
 #include "core/graph/node_arg.h"
 

--- a/onnxruntime/core/providers/cpu/controlflow/loop.cc
+++ b/onnxruntime/core/providers/cpu/controlflow/loop.cc
@@ -23,7 +23,7 @@
 #include "core/framework/TensorSeq.h"
 #include "core/providers/utils.h"
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/onnxruntime/core/providers/cpu/controlflow/scan.h
+++ b/onnxruntime/core/providers/cpu/controlflow/scan.h
@@ -3,7 +3,7 @@
 
 #pragma once
 #include <functional>
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #ifndef SHARED_PROVIDER
 #include "core/common/common.h"

--- a/onnxruntime/core/providers/cpu/controlflow/scan_9.cc
+++ b/onnxruntime/core/providers/cpu/controlflow/scan_9.cc
@@ -21,7 +21,7 @@
 #include "core/providers/cpu/tensor/utils.h"
 #include "core/providers/cpu/tensor/transpose.h"
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/onnxruntime/core/providers/cpu/generator/random.h
+++ b/onnxruntime/core/providers/cpu/generator/random.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <random>
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"

--- a/onnxruntime/core/providers/cpu/math/hardmax.h
+++ b/onnxruntime/core/providers/cpu/math/hardmax.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"

--- a/onnxruntime/core/providers/cpu/math/sign.cc
+++ b/onnxruntime/core/providers/cpu/math/sign.cc
@@ -3,7 +3,7 @@
 
 #include <type_traits>
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include "core/common/common.h"
 #include "core/framework/data_types.h"

--- a/onnxruntime/core/providers/cpu/math/softmax.h
+++ b/onnxruntime/core/providers/cpu/math/softmax.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"

--- a/onnxruntime/core/providers/cpu/math/softmax_shared.cc
+++ b/onnxruntime/core/providers/cpu/math/softmax_shared.cc
@@ -22,7 +22,7 @@
 
 #include <algorithm>
 #include <cmath>
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include "core/util/math.h"
 #include "core/util/math_cpuonly.h"

--- a/onnxruntime/core/providers/cpu/ml/cast_map.cc
+++ b/onnxruntime/core/providers/cpu/ml/cast_map.cc
@@ -3,7 +3,7 @@
 
 #include "core/providers/cpu/ml/cast_map.h"
 #include <algorithm>
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 using namespace ::onnxruntime::common;
 
 namespace {

--- a/onnxruntime/core/providers/cpu/ml/category_mapper.cc
+++ b/onnxruntime/core/providers/cpu/ml/category_mapper.cc
@@ -3,7 +3,7 @@
 
 #include "core/providers/cpu/ml/category_mapper.h"
 #include <algorithm>
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 using namespace ::onnxruntime::common;
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cpu/ml/feature_vectorizer.cc
+++ b/onnxruntime/core/providers/cpu/ml/feature_vectorizer.cc
@@ -3,7 +3,7 @@
 
 #include "core/providers/cpu/ml/feature_vectorizer.h"
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 namespace onnxruntime {
 namespace ml {

--- a/onnxruntime/core/providers/cpu/ml/label_encoder.cc
+++ b/onnxruntime/core/providers/cpu/ml/label_encoder.cc
@@ -3,7 +3,7 @@
 
 #include "core/providers/cpu/ml/label_encoder.h"
 #include <algorithm>
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 using namespace ::onnxruntime::common;
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cpu/nn/flatten.h
+++ b/onnxruntime/core/providers/cpu/nn/flatten.h
@@ -5,7 +5,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/providers/cpu/tensor/utils.h"
 #include "core/providers/common.h"
 

--- a/onnxruntime/core/providers/cpu/nn/lrn.h
+++ b/onnxruntime/core/providers/cpu/nn/lrn.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include "core/common/common.h"
 #include "core/common/exceptions.h"

--- a/onnxruntime/core/providers/cpu/rnn/rnn_helpers.h
+++ b/onnxruntime/core/providers/cpu/rnn/rnn_helpers.h
@@ -18,7 +18,7 @@
 #include "core/common/safeint.h"
 #include "core/platform/threadpool.h"
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 namespace onnxruntime {
 namespace rnn {

--- a/onnxruntime/core/providers/cpu/tensor/cast_op.cc
+++ b/onnxruntime/core/providers/cpu/tensor/cast_op.cc
@@ -6,7 +6,7 @@
 #include <string>
 #include <type_traits>
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include "core/common/common.h"
 #include "core/common/narrow.h"

--- a/onnxruntime/core/providers/cpu/tensor/mean_variance_normalization.cc
+++ b/onnxruntime/core/providers/cpu/tensor/mean_variance_normalization.cc
@@ -6,7 +6,7 @@
 #include <algorithm>
 #include <optional>
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/providers/common.h"
 #include "core/providers/cpu/tensor/transpose.h"
 #include "core/util/math_cpuonly.h"

--- a/onnxruntime/core/providers/cpu/tensor/reverse_sequence.cc
+++ b/onnxruntime/core/providers/cpu/tensor/reverse_sequence.cc
@@ -11,7 +11,7 @@
 #pragma warning(disable : 4996)
 #endif
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/onnxruntime/core/providers/cpu/tensor/shape_op.h
+++ b/onnxruntime/core/providers/cpu/tensor/shape_op.h
@@ -9,7 +9,7 @@
 #include "core/framework/op_kernel.h"
 #endif
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include <limits>
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cpu/tensor/slice_compute_metadata.h
+++ b/onnxruntime/core/providers/cpu/tensor/slice_compute_metadata.h
@@ -6,7 +6,7 @@
 
 #include <cstdint>
 #include <vector>
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/framework/tensor_shape.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cpu/tensor/split.cc
+++ b/onnxruntime/core/providers/cpu/tensor/split.cc
@@ -4,7 +4,7 @@
 #include "core/providers/cpu/tensor/split.h"
 
 #include "core/common/narrow.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/common/safeint.h"
 #include "core/framework/copy.h"
 #include "core/framework/element_type_lists.h"

--- a/onnxruntime/core/providers/cpu/tensor/transpose.h
+++ b/onnxruntime/core/providers/cpu/tensor/transpose.h
@@ -10,7 +10,7 @@
 #include "core/framework/op_kernel.h"
 #endif
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include <sstream>
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cpu/tensor/unique.cc
+++ b/onnxruntime/core/providers/cpu/tensor/unique.cc
@@ -4,7 +4,7 @@
 #include "core/providers/cpu/tensor/unique.h"
 #include <map>
 #include <core/common/safeint.h>
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/framework/op_kernel_type_control_utils.h"
 #include "core/providers/common.h"
 #include "core/providers/op_kernel_type_control.h"

--- a/onnxruntime/core/providers/cpu/tensor/utils.h
+++ b/onnxruntime/core/providers/cpu/tensor/utils.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/common/narrow.h"
 
 #ifndef SHARED_PROVIDER

--- a/onnxruntime/core/providers/cuda/cuda_common.h
+++ b/onnxruntime/core/providers/cuda/cuda_common.h
@@ -16,7 +16,7 @@
 #include "core/providers/cuda/cuda_pch.h"
 #include "core/providers/cuda/shared_inc/cuda_call.h"
 #include "core/providers/cuda/shared_inc/fast_divmod.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/cuda_provider_factory.cc
+++ b/onnxruntime/core/providers/cuda/cuda_provider_factory.cc
@@ -10,7 +10,7 @@
 #include <memory>
 #include <chrono>
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include "core/providers/cuda/cuda_execution_provider.h"
 #include "core/providers/cuda/cuda_execution_provider_info.h"

--- a/onnxruntime/core/providers/cuda/cudnn_common.cc
+++ b/onnxruntime/core/providers/cuda/cudnn_common.cc
@@ -6,7 +6,7 @@
 
 #include "core/providers/cuda/cudnn_common.h"
 #include "core/common/inlined_containers.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "shared_inc/cuda_call.h"
 #include "core/providers/cpu/tensor/utils.h"
 #ifndef USE_CUDA_MINIMAL

--- a/onnxruntime/core/providers/cuda/math/softmax.h
+++ b/onnxruntime/core/providers/cuda/math/softmax.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cuda/multi_tensor/common.cuh
+++ b/onnxruntime/core/providers/cuda/multi_tensor/common.cuh
@@ -10,7 +10,7 @@
 #include <vector>
 
 #include "core/common/common.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/rnn/cudnn_rnn_base.h
+++ b/onnxruntime/core/providers/cuda/rnn/cudnn_rnn_base.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cuda/cudnn_common.h"

--- a/onnxruntime/core/providers/cuda/rnn/gru.h
+++ b/onnxruntime/core/providers/cuda/rnn/gru.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "cudnn_rnn_base.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/providers/cuda/cuda_common.h"
 #include <cudnn.h>
 

--- a/onnxruntime/core/providers/cuda/shared_inc/cuda_utils.h
+++ b/onnxruntime/core/providers/cuda/shared_inc/cuda_utils.h
@@ -11,7 +11,7 @@
 #include <type_traits>
 #include <vector>
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/framework/float16.h"
 #include "core/providers/cuda/shared_inc/fast_divmod.h"
 

--- a/onnxruntime/core/providers/cuda/tensor/transpose.h
+++ b/onnxruntime/core/providers/cuda/tensor/transpose.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "core/providers/shared_library/provider_api.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/tensor/transpose.h"
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/precomp.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/precomp.h
@@ -26,7 +26,7 @@
 #include <wil/wrl.h>
 #include <wil/result.h>
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #ifdef _GAMING_XBOX_SCARLETT
 #include <d3d12_xs.h>

--- a/onnxruntime/core/providers/dml/GraphTransformers/precomp.h
+++ b/onnxruntime/core/providers/dml/GraphTransformers/precomp.h
@@ -14,4 +14,4 @@
 #include <wil/wrl.h>
 #include <wil/result.h>
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/MLOperatorAuthorHelper.h
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/MLOperatorAuthorHelper.h
@@ -5,7 +5,7 @@
 
 #include "core/providers/dml/DmlExecutionProvider/inc/MLOperatorAuthor.h"
 #include "MLOperatorAuthorPrivate.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include <optional>
 
 #ifdef ORT_NO_EXCEPTIONS

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/precomp.h
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/precomp.h
@@ -17,4 +17,4 @@
 #include <wil/wrl.h>
 #include <wil/result.h>
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>

--- a/onnxruntime/core/providers/js/operators/conv_transpose.h
+++ b/onnxruntime/core/providers/js/operators/conv_transpose.h
@@ -5,7 +5,7 @@
 
 #include <algorithm>
 #include <string>
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/providers/cpu/nn/conv_transpose_attributes.h"
 #include "core/providers/js/js_kernel.h"
 namespace onnxruntime {

--- a/onnxruntime/core/providers/js/operators/transpose.h
+++ b/onnxruntime/core/providers/js/operators/transpose.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "core/providers/js/js_kernel.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/providers/cpu/tensor/transpose.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.h
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.h
@@ -9,7 +9,7 @@
 #include "core/common/inlined_containers.h"
 #include "core/graph/basic_types.h"
 #include "core/providers/nnapi/nnapi_builtin/nnapi_lib/NeuralNetworksTypes.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 // This is the minimal Android API Level required by ORT NNAPI EP to run
 // ORT running on any host system with Android API level less than this will fall back to CPU EP

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder_helpers.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder_helpers.cc
@@ -8,7 +8,7 @@
 #include <optional>
 #include <utility>
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include "core/common/inlined_containers_fwd.h"
 #include "core/common/logging/logging.h"

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -13,7 +13,7 @@
 // #include "GPU/QnnGpuCommon.h"
 #include "DSP/QnnDspCommon.h"
 #include "HTP/QnnHtpCommon.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/framework/endian_utils.h"
 #include "core/common/logging/capture.h"
 #include "core/providers/qnn/builder/onnx_ctx_model_helper.h"

--- a/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.h
@@ -5,7 +5,7 @@
 #include <memory>
 #include "QnnTypes.h"
 #include "core/common/common.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/framework/node_unit.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/rocm/math/softmax.h
+++ b/onnxruntime/core/providers/rocm/math/softmax.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/providers/rocm/rocm_kernel.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/rocm/miopen_common.cc
+++ b/onnxruntime/core/providers/rocm/miopen_common.cc
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #include "miopen_common.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/providers/cpu/tensor/utils.h"
 #include "core/providers/rocm/shared_inc/rocm_call.h"
 

--- a/onnxruntime/core/providers/rocm/rocm_common.h
+++ b/onnxruntime/core/providers/rocm/rocm_common.h
@@ -10,7 +10,7 @@
 #include "core/providers/rocm/shared_inc/rocm_call.h"
 #include "core/providers/rocm/shared_inc/fast_divmod.h"
 #include "core/util/math.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 namespace onnxruntime {
 namespace rocm {

--- a/onnxruntime/core/providers/rocm/rocm_provider_factory.cc
+++ b/onnxruntime/core/providers/rocm/rocm_provider_factory.cc
@@ -5,7 +5,7 @@
 #include "core/providers/rocm/rocm_provider_factory.h"
 #include "core/providers/rocm/rocm_provider_factory_creator.h"
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include "core/providers/rocm/rocm_execution_provider.h"
 #include "core/providers/rocm/rocm_execution_provider_info.h"

--- a/onnxruntime/core/providers/shared_library/provider_api.h
+++ b/onnxruntime/core/providers/shared_library/provider_api.h
@@ -12,7 +12,7 @@
 #include <vector>
 #include <string>
 #include <map>
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include <unordered_map>
 #include <unordered_set>
 #include <stddef.h>

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -18,7 +18,7 @@
 #include "core/providers/cuda/gpu_data_transfer.h"
 #include "core/session/allocator_adapters.h"
 #include "cuda_runtime_api.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include <unordered_map>
 #include <utility>
 #include <limits>

--- a/onnxruntime/core/providers/tvm/tvm_api.cc
+++ b/onnxruntime/core/providers/tvm/tvm_api.cc
@@ -16,7 +16,7 @@
 #include <tvm/target/codegen.h>
 
 #include "core/common/common.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include "tvm_api.h"
 

--- a/onnxruntime/core/providers/vitisai/imp/attr_proto.h
+++ b/onnxruntime/core/providers/vitisai/imp/attr_proto.h
@@ -3,7 +3,7 @@
 #pragma once
 #include <functional>
 #include "vaip/my_ort.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 namespace vaip {
 

--- a/onnxruntime/core/providers/vitisai/include/vaip/vaip_gsl.h
+++ b/onnxruntime/core/providers/vitisai/include/vaip/vaip_gsl.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #ifdef ONNXRUNTIME_VITISAI_EP_STUB
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #else
 #include <gsl/gsl>
 #endif

--- a/onnxruntime/core/providers/xnnpack/nn/conv.cc
+++ b/onnxruntime/core/providers/xnnpack/nn/conv.cc
@@ -5,7 +5,7 @@
 
 #include <cassert>
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/common/inlined_containers_fwd.h"
 #include "core/framework/tensorprotoutils.h"
 #include "core/framework/transpose_helper.h"

--- a/onnxruntime/core/session/custom_ops.cc
+++ b/onnxruntime/core/session/custom_ops.cc
@@ -10,7 +10,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/framework/data_types.h"
 #include "core/framework/error_code_helper.h"
 #include "core/framework/onnxruntime_typeinfo.h"

--- a/onnxruntime/core/util/matrix_layout.h
+++ b/onnxruntime/core/util/matrix_layout.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <cstdint>
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #if defined(_MSC_VER)
 #define ORT_FORCEINLINE __forceinline

--- a/onnxruntime/test/common/random_generator.h
+++ b/onnxruntime/test/common/random_generator.h
@@ -8,7 +8,7 @@
 
 #include "gtest/gtest.h"
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/common/common.h"
 #include "core/common/optional.h"
 #include "core/common/type_utils.h"

--- a/onnxruntime/test/common/tensor_op_test_utils.h
+++ b/onnxruntime/test/common/tensor_op_test_utils.h
@@ -6,7 +6,7 @@
 #include <random>
 #include <type_traits>
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include "gtest/gtest.h"
 

--- a/onnxruntime/test/contrib_ops/beam_search_test.cc
+++ b/onnxruntime/test/contrib_ops/beam_search_test.cc
@@ -4,7 +4,7 @@
 #include <memory>
 #include <vector>
 #include "gtest/gtest.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/session/onnxruntime_cxx_api.h"
 #include "test/common/cuda_op_test_utils.h"
 

--- a/onnxruntime/test/contrib_ops/greedy_search_test.cc
+++ b/onnxruntime/test/contrib_ops/greedy_search_test.cc
@@ -4,7 +4,7 @@
 #include <memory>
 #include <vector>
 #include "gtest/gtest.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/session/onnxruntime_cxx_api.h"
 #include "test/common/cuda_op_test_utils.h"
 

--- a/onnxruntime/test/contrib_ops/sampling_test.cc
+++ b/onnxruntime/test/contrib_ops/sampling_test.cc
@@ -4,7 +4,7 @@
 #include <memory>
 #include <vector>
 #include "gtest/gtest.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/session/onnxruntime_cxx_api.h"
 #include "test/common/cuda_op_test_utils.h"
 

--- a/onnxruntime/test/framework/test_utils.h
+++ b/onnxruntime/test/framework/test_utils.h
@@ -9,7 +9,7 @@
 #include "core/providers/cpu/cpu_execution_provider.h"
 #include "core/framework/ort_value.h"
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #ifdef USE_CUDA
 #include "core/providers/providers.h"

--- a/onnxruntime/test/optimizer/initializer_test.cc
+++ b/onnxruntime/test/optimizer/initializer_test.cc
@@ -8,7 +8,7 @@
 #include <numeric>
 #include <type_traits>
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include "gtest/gtest.h"
 

--- a/onnxruntime/test/platform/file_io_test.cc
+++ b/onnxruntime/test/platform/file_io_test.cc
@@ -14,7 +14,7 @@
 #include <Windows.h>
 #endif
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include "gtest/gtest.h"
 

--- a/onnxruntime/test/providers/cpu/ml/array_feature_extractor_test.cc
+++ b/onnxruntime/test/providers/cpu/ml/array_feature_extractor_test.cc
@@ -5,7 +5,7 @@
 
 #include "gtest/gtest.h"
 #include "test/providers/provider_test_utils.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 using namespace std;
 namespace onnxruntime {
 namespace test {

--- a/onnxruntime/test/providers/cpu/tensor/cast_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/cast_op_test.cc
@@ -5,7 +5,7 @@
 
 #include "boost/mp11.hpp"
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include "gtest/gtest.h"
 

--- a/onnxruntime/test/providers/cpu/tensor/where_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/where_op_test.cc
@@ -3,7 +3,7 @@
 
 #include "gtest/gtest.h"
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include "test/providers/provider_test_utils.h"
 

--- a/onnxruntime/test/providers/cuda/test_cases/cuda_test_provider.cc
+++ b/onnxruntime/test/providers/cuda/test_cases/cuda_test_provider.cc
@@ -10,7 +10,7 @@
 #include <memory>
 #include <chrono>
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/providers/cuda/cuda_execution_provider.h"
 #include "core/providers/cuda/cuda_execution_provider_info.h"
 #include "core/providers/cuda/cuda_allocator.h"

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -31,7 +31,7 @@
 #include "test_fixture.h"
 #include "utils.h"
 #include "custom_op_utils.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #ifdef _WIN32
 #include <Windows.h>

--- a/onnxruntime/test/shared_lib/test_nontensor_types.cc
+++ b/onnxruntime/test/shared_lib/test_nontensor_types.cc
@@ -9,7 +9,7 @@
 #include "core/session/onnxruntime_cxx_api.h"
 #include "test_allocator.h"
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/onnxruntime/test/testdata/custom_execution_provider_library/my_ep_factory.cc
+++ b/onnxruntime/test/testdata/custom_execution_provider_library/my_ep_factory.cc
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 #include "my_ep_factory.h"
 #include "my_execution_provider.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/providers/shared/common.h"
 #include <iostream>
 #include "core/framework/provider_options_utils.h"

--- a/onnxruntime/test/util/include/test_utils.h
+++ b/onnxruntime/test/util/include/test_utils.h
@@ -11,7 +11,7 @@
 #include <variant>
 #include <vector>
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/framework/execution_provider.h"
 #include "core/framework/framework_common.h"
 #include "core/framework/ort_value.h"

--- a/orttraining/orttraining/core/optimizer/graph_transformer_utils.h
+++ b/orttraining/orttraining/core/optimizer/graph_transformer_utils.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include "core/optimizer/graph_transformer.h"
 #include "orttraining/core/optimizer/graph_transformer_config.h"

--- a/orttraining/orttraining/test/training_api/common/synthetic_data_loader.h
+++ b/orttraining/orttraining/test/training_api/common/synthetic_data_loader.h
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include <onnxruntime_cxx_api.h>
 

--- a/orttraining/orttraining/training_ops/cpu/activation/activations_grad.cc
+++ b/orttraining/orttraining/training_ops/cpu/activation/activations_grad.cc
@@ -3,7 +3,7 @@
 
 #include "orttraining/training_ops/cpu/activation/activations_grad.h"
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #if defined(_MSC_VER)
 #pragma warning(push)

--- a/orttraining/orttraining/training_ops/cpu/loss/cross_entropy.cc
+++ b/orttraining/orttraining/training_ops/cpu/loss/cross_entropy.cc
@@ -7,7 +7,7 @@
 #include "core/providers/common.h"
 #include <unsupported/Eigen/SpecialFunctions>
 #include "core/providers/cpu/math/matmul_helper.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 namespace onnxruntime {
 namespace contrib {

--- a/orttraining/orttraining/training_ops/cpu/loss/softmax_cross_entropy_loss.cc
+++ b/orttraining/orttraining/training_ops/cpu/loss/softmax_cross_entropy_loss.cc
@@ -10,7 +10,7 @@
 #include "core/providers/cpu/controlflow/scan_utils.h"
 #include "orttraining/training_ops/cpu/loss/cross_entropy.h"
 #include "orttraining/training_ops/cpu/loss/softmax_cross_entropy_loss.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 namespace onnxruntime {
 namespace contrib {

--- a/orttraining/orttraining/training_ops/cpu/op_gradients.cc
+++ b/orttraining/orttraining/training_ops/cpu/op_gradients.cc
@@ -3,7 +3,7 @@
 
 #include "orttraining/training_ops/cpu/op_gradients.h"
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/mlas/inc/mlas.h"
 #include "core/providers/common.h"
 #include "core/providers/cpu/math/element_wise_ops.h"

--- a/orttraining/orttraining/training_ops/cpu/tensor/split.cc
+++ b/orttraining/orttraining/training_ops/cpu/tensor/split.cc
@@ -3,7 +3,7 @@
 
 #include "orttraining/training_ops/cpu/tensor/split.h"
 
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 #include "core/common/narrow.h"
 #include "core/providers/common.h"
 #include "core/util/math.h"

--- a/winml/lib/Api.Ort/OnnxruntimeEngine.h
+++ b/winml/lib/Api.Ort/OnnxruntimeEngine.h
@@ -3,7 +3,7 @@
 
 #include "iengine.h"
 #include "UniqueOrtPtr.h"
-#include "core/common/gsl.h"
+#include <gsl/gsl>
 
 #include <memory>
 #include <mutex>


### PR DESCRIPTION
### Description
It might be easier if we just directly include the original gsl headers.  "core/common/gsl.h" is an indirection that doesn't provide extra help. 

### Motivation and Context



