### PR TITLE
Component Governance fix round 5

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/component-governance-component-detection-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/component-governance-component-detection-steps.yml
@@ -29,6 +29,7 @@ steps:
       ignoreDirectories:
         '$(Build.Repository.LocalPath)/cmake/external/emsdk/upstream/emscripten/tests,
         $(Build.Repository.LocalPath)/cmake/external/onnx/third_party,
+        $(Build.SourcesDirectory)/cmake/external/onnx/third_party,
         $(Build.Repository.LocalPath)/cmake/external/onnxruntime-extensions,
         $(Build.Repository.LocalPath)/js/react_native/e2e/node_modules,
         $(Build.SourcesDirectory)/onnxruntime-inference-examples,


### PR DESCRIPTION
…over the case where there is only single repo checked out

### Description
adding $(Build.SourcesDirectory)/cmake/external/onnx/third_party to cover the case where there is only single repo checked out



### Motivation and Context
Fix CG issue https://aiinfra.visualstudio.com/Lotus/_componentGovernance/97926/alert/8862110?typeId=16576846


