### PR TITLE
VitisAI C# ExecutionProvider

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
@@ -302,6 +302,7 @@ namespace Microsoft.ML.OnnxRuntime
         public IntPtr ReleaseROCMProviderOptions;
         public IntPtr CreateAndRegisterAllocatorV2;
         public IntPtr RunAsync;
+        public IntPtr SessionOptionsAppendExecutionProvider_VitisAI;
     }
 
     internal static class NativeMethods
@@ -1115,6 +1116,9 @@ namespace Microsoft.ML.OnnxRuntime
 
         [DllImport(NativeLib.DllName, CharSet = CharSet.Ansi)]
         public static extern IntPtr /*(OrtStatus*)*/ OrtSessionOptionsAppendExecutionProvider_Tvm(IntPtr /*(OrtSessionOptions*) */ options, byte[] /*(char char*)*/ settings);
+
+        [DllImport(NativeLib.DllName, CharSet = CharSet.Ansi)]
+        public static extern IntPtr /*(OrtStatus*)*/ OrtSessionOptionsAppendExecutionProvider_VitisAI(IntPtr /*(OrtSessionOptions*) */ options, byte[] /*(char char*)*/ settings);
 #endif
         /// <summary>
         /// Append a TensorRT EP instance (configured based on given provider options) to the native OrtSessionOptions instance

--- a/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.shared.cs
@@ -411,6 +411,17 @@ namespace Microsoft.ML.OnnxRuntime
 #endif
         }
 
+        public void AppendExecutionProvider_VitisAI(string settings = "")
+        {
+#if __MOBILE__
+            throw new NotSupportedException("The VitisAI Execution Provider is not supported in this build");
+#else
+            var utf8 = NativeOnnxValueHelper.StringToZeroTerminatedUtf8(settings);
+            NativeApiStatus.VerifySuccess(NativeMethods.OrtSessionOptionsAppendExecutionProvider_VitisAI(handle, utf8));
+#endif
+        }
+
+
         private class ExecutionProviderAppender
         {
             private byte[] _utf8ProviderName;

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -2762,3 +2762,17 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider_VitisAI, _In_
   return nullptr;
   API_IMPL_END
 }
+
+ORT_API_STATUS_IMPL(OrtSessionOptionsAppendExecutionProvider_VitisAI, _In_ OrtSessionOptions* options, char* settings) {
+  API_IMPL_BEGIN
+  ORT_UNUSED_PARAMETER(settings);
+  onnxruntime::ProviderOptions provider_options;
+  auto factory = onnxruntime::VitisAIProviderFactoryCreator::Create(provider_options);
+  if (!factory) {
+    return OrtApis::CreateStatus(ORT_FAIL, "OrtSessionOptionsAppendExecutionProvider_VitisAI: Failed to load shared library");
+  }
+
+  options->provider_factories.push_back(factory);
+  return nullptr;
+  API_IMPL_END
+}

--- a/onnxruntime/core/session/provider_registration.cc
+++ b/onnxruntime/core/session/provider_registration.cc
@@ -22,6 +22,10 @@
 #include "core/providers/dml/dml_provider_factory_creator.h"
 #endif
 
+#if defined(USE_VITISAI)
+#include "core/providers/vitisai/vitisai_provider_factory_creator.h"
+#endif
+
 using namespace onnxruntime;
 
 namespace {
@@ -112,7 +116,11 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider,
 #else
     status = create_not_supported_status();
 #endif
-
+#if defined(USE_VITISAI)
+    options->provider_factories.push_back(VitisAIProviderFactoryCreator::Create(provider_options));
+#else
+    status = create_not_supported_status();
+#endif
   } else if (strcmp(provider_name, "SNPE") == 0) {
 #if defined(USE_SNPE)
     options->provider_factories.push_back(SNPEProviderFactoryCreator::Create(provider_options));
@@ -208,6 +216,15 @@ ORT_API_STATUS_IMPL(OrtSessionOptionsAppendExecutionProvider_Tvm,
   ORT_UNUSED_PARAMETER(options);
   ORT_UNUSED_PARAMETER(settings);
   return CreateNotEnabledStatus("Tvm");
+}
+#endif
+
+#ifndef USE_VITISAI
+ORT_API_STATUS_IMPL(OrtSessionOptionsAppendExecutionProvider_VitisAI,
+                    _In_ OrtSessionOptions* options, _In_ const char* settings) {
+  ORT_UNUSED_PARAMETER(options);
+  ORT_UNUSED_PARAMETER(settings);
+  return CreateNotEnabledStatus("VitisAI");
 }
 #endif
 


### PR DESCRIPTION
### Description
Add support for VitisAI C# ExecutionProvider


### Motivation and Context
Working on a C# VitisAI application and am trying to get the C# Execution provider implemented, however I am only a C# developer so am having a bit of a card time with the C code.

Unable to get past this error `System.EntryPointNotFoundException: 'Unable to find an entry point named 'OrtSessionOptionsAppendExecutionProvider_VitisAI' in DLL 'onnxruntime'.'`

Any help or pointers would be epic.


