### PR TITLE
Enable large models with generate_artifacts API

### DIFF
--- a/orttraining/orttraining/python/training/artifacts.py
+++ b/orttraining/orttraining/python/training/artifacts.py
@@ -98,10 +98,10 @@ def generate_artifacts(
 
     loss_block = None
     if loss is None:
-        loss_block = onnxblock.blocks.PassThrough()
+        loss_block = onnxblock.blocks.PassThrough(enable_checker = not enable_large_model)
         logging.info("No loss function enum provided. Loss node will not be added to the graph.")
     elif isinstance(loss, LossType):
-        loss_block = loss_blocks[loss]()
+        loss_block = loss_blocks[loss](enable_checker = not enable_large_model)
         logging.info("Loss function enum provided: %s", loss.name)
     else:
         # If a custom implementation of the loss was provided, then it should be

--- a/orttraining/orttraining/python/training/onnxblock/blocks.py
+++ b/orttraining/orttraining/python/training/onnxblock/blocks.py
@@ -28,8 +28,9 @@ class Block(ABC):
         base (onnx.ModelProto): The base model that the subclass can manipulate.
     """
 
-    def __init__(self):
+    def __init__(self, enable_checker = True):
         self.base = None
+        self.enable_checker = enable_checker
 
     @abstractmethod
     def build(self, *args, **kwargs):
@@ -47,7 +48,8 @@ class Block(ABC):
 
         output = self.build(*args, **kwargs)
 
-        onnx.checker.check_model(self.base, True)
+        if self.enable_checker:
+            onnx.checker.check_model(self.base, True)
 
         return output
 

--- a/orttraining/orttraining/python/training/onnxblock/onnxblock.py
+++ b/orttraining/orttraining/python/training/onnxblock/onnxblock.py
@@ -187,7 +187,7 @@ class TrainingBlock(blocks.Block):
 
         output = self.build(*args, **kwargs)
 
-        model = onnx.shape_inference.infer_shapes(accessor._GLOBAL_ACCESSOR.model)
+        model = onnx.shape_inference.infer_shapes(accessor._GLOBAL_ACCESSOR.model) if self._enable_shape_inference else accessor._GLOBAL_ACCESSOR.model
 
         _graph_utils.register_graph_outputs(model, output)
 

--- a/orttraining/orttraining/python/training/onnxblock/onnxblock.py
+++ b/orttraining/orttraining/python/training/onnxblock/onnxblock.py
@@ -102,8 +102,8 @@ class TrainingBlock(blocks.Block):
     starting from the output of the loss function.
     """
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, enable_checker = True):
+        super().__init__(enable_checker)
         self._requires_grad = set()
         self._frozen_params = set()
         self._parameters = None


### PR DESCRIPTION
### Description
Added enable_large_models flag to generate_artifacts API call

### Motivation and Context
* ONNX function calls such as shape_inference and the ONNX checker run into errors when passed a ModelProto > 2GB (issue tracked [here](https://github.com/onnx/onnx/issues/6150))
* This PR adds the option to disable these API calls in generate_artifacts until the ONNX serialization issue is resolved

