### PR TITLE
Add changes for strided calibration

### DIFF
--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -413,7 +413,6 @@ class MinMaxCalibrater(CalibraterBase):
             raise TypeError(f"compute_data must return a TensorsData not {type(t)}.")
         self.clear_collected_data()
 
-
     def merge_range(self, old_range, new_range):
         if not old_range:
             return new_range
@@ -446,7 +445,6 @@ class MinMaxCalibrater(CalibraterBase):
                 new_range[key] = (min_value, max_value)
 
         return new_range
-
 
     def compute_data(self) -> TensorsData:
         """

--- a/onnxruntime/python/tools/quantization/execution_providers/qnn/quant_config.py
+++ b/onnxruntime/python/tools/quantization/execution_providers/qnn/quant_config.py
@@ -52,6 +52,7 @@ def get_qnn_qdq_config(
     activation_symmetric: bool = False,
     weight_symmetric: bool | None = None,
     keep_removable_activations: bool = False,
+    stride: int = None,
 ) -> StaticQuantConfig:
     """
     Returns a static quantization configuration suitable for running QDQ models on QNN EP.
@@ -171,6 +172,7 @@ def get_qnn_qdq_config(
         "TensorQuantOverrides": overrides_helper.get_dict(),
         "ActivationSymmetric": activation_symmetric,
         "WeightSymmetric": weight_symmetric,
+        "CalibStridedMinMax": stride,
     }
 
     # ONNX opset < 21 does not support 16-bit quantization, so must use 'com.microsoft' domain

--- a/onnxruntime/python/tools/quantization/execution_providers/qnn/quant_config.py
+++ b/onnxruntime/python/tools/quantization/execution_providers/qnn/quant_config.py
@@ -52,7 +52,7 @@ def get_qnn_qdq_config(
     activation_symmetric: bool = False,
     weight_symmetric: bool | None = None,
     keep_removable_activations: bool = False,
-    stride: int = None,
+    stride: int | None = None,
 ) -> StaticQuantConfig:
     """
     Returns a static quantization configuration suitable for running QDQ models on QNN EP.

--- a/onnxruntime/python/tools/quantization/quantize.py
+++ b/onnxruntime/python/tools/quantization/quantize.py
@@ -381,6 +381,9 @@ def quantize_static(
                 CalibTensorRangeSymmetric = True/False :
                     Default is False. If enabled, the final range of tensor during calibration will be explicitly
                     set to symmetric to central point "0".
+                CalibStridedMinMax = Optional[int] :
+                    Default is None. If set to an integer, during calculation of the min-max, only stride amount of
+                    data will be used and then all results will be merged in the end.
                 CalibMovingAverage = True/False :
                     Default is False. If enabled, the moving average of the minimum and maximum values will be
                     computed when the calibration method selected is MinMax.
@@ -470,6 +473,7 @@ def quantize_static(
         ("CalibMovingAverage", "moving_average"),
         ("CalibMovingAverageConstant", "averaging_constant"),
         ("CalibMaxIntermediateOutputs", "max_intermediate_outputs"),
+        ("CalibStridedMinMax", "stride"),
     ]
     calib_extra_options = {
         key: extra_options.get(name) for (name, key) in calib_extra_options_keys if name in extra_options
@@ -522,7 +526,19 @@ def quantize_static(
             use_external_data_format=use_external_data_format,
             extra_options=calib_extra_options,
         )
-        calibrator.collect_data(calibration_data_reader)
+
+        stride = extra_options.get("CalibStridedMinMax", None)
+        if stride:
+            total_data_size = len(calibration_data_reader)
+            if total_data_size % stride != 0:
+                raise ValueError(f"Total data size ({total_data_size}) is not divisible by stride size ({stride}).")
+
+            for start in range(0, total_data_size, stride):
+                end_index = start + stride
+                calibration_data_reader.set_range(start_index=start, end_index=end_index)
+                calibrator.collect_data(calibration_data_reader)
+        else:
+            calibrator.collect_data(calibration_data_reader)
         tensors_range = calibrator.compute_data()
         if not isinstance(tensors_range, TensorsData):
             raise TypeError(

--- a/onnxruntime/python/tools/quantization/quantize.py
+++ b/onnxruntime/python/tools/quantization/quantize.py
@@ -473,7 +473,6 @@ def quantize_static(
         ("CalibMovingAverage", "moving_average"),
         ("CalibMovingAverageConstant", "averaging_constant"),
         ("CalibMaxIntermediateOutputs", "max_intermediate_outputs"),
-        ("CalibStridedMinMax", "stride"),
     ]
     calib_extra_options = {
         key: extra_options.get(name) for (name, key) in calib_extra_options_keys if name in extra_options

--- a/onnxruntime/test/python/quantization/op_test_utils.py
+++ b/onnxruntime/test/python/quantization/op_test_utils.py
@@ -217,10 +217,13 @@ class TestDataFeeds(CalibrationDataReader):
         self.iter_next = iter(self.data_feeds)
 
 
-def input_feeds_neg_one_zero_one(n, name2shape):
+def input_feeds_neg_one_zero_one(n, name2shape, seed=None):
     """
     randomize n feed according to shape, its values are from -1, 0, and 1
     """
+    if seed is not None:
+        np.random.seed(seed)
+
     input_data_list = []
     for _i in range(n):
         inputs = {}
@@ -231,10 +234,13 @@ def input_feeds_neg_one_zero_one(n, name2shape):
     return dr
 
 
-def input_feeds_neg_one_zero_one_list(n, name2shape):
+def input_feeds_neg_one_zero_one_list(n, name2shape, seed=None):
     """
     randomize n feed according to shape, its values are from -1, 0, and 1
     """
+    if seed is not None:
+        np.random.seed(seed)
+
     input_data_list = []
     for _i in range(n):
         inputs = {}

--- a/onnxruntime/test/python/quantization/op_test_utils.py
+++ b/onnxruntime/test/python/quantization/op_test_utils.py
@@ -252,8 +252,8 @@ def input_feeds_neg_one_zero_one_list(n, name2shape, seed=None):
 
 class GenerateCalibrationData(CalibrationDataReader):
     def __init__(self, data_list, input_nodes, input_shapes, no_tensor_num, in_dtypes, inputs_conv_channel_last=None):
-        print("Generating calibration dataset from "+str(data_list))
-        print("input nodes are ",input_nodes,"input shapes are ", input_shapes)
+        print("Generating calibration dataset from " + str(data_list))
+        print("input nodes are ", input_nodes, "input shapes are ", input_shapes)
         if inputs_conv_channel_last:
             print(f"Inputs that will be converted to channel last: {inputs_conv_channel_last}")
 
@@ -282,12 +282,25 @@ class GenerateCalibrationData(CalibrationDataReader):
 
 
 class StridedDataReader(GenerateCalibrationData):
-    def __init__(self, data_list, input_nodes, input_shapes, no_tensor_num, in_dtypes, inputs_conv_channel_last=None, stride=1, start_index=0, end_index=None):
+    def __init__(
+        self,
+        data_list,
+        input_nodes,
+        input_shapes,
+        no_tensor_num,
+        in_dtypes,
+        inputs_conv_channel_last=None,
+        stride=1,
+        start_index=0,
+        end_index=None,
+    ):
         super().__init__(data_list, input_nodes, input_shapes, no_tensor_num, in_dtypes, inputs_conv_channel_last)
 
         self.stride = max(1, stride)  # Ensure stride is at least 1
         self.start_index = start_index
-        self.end_index = end_index if end_index is not None else len(self.calibration_dataset)  # Default to the end of the dataset
+        self.end_index = (
+            end_index if end_index is not None else len(self.calibration_dataset)
+        )  # Default to the end of the dataset
         self.enum_data_dicts = iter([])
 
     def get_next(self):
@@ -319,7 +332,7 @@ class StridedDataReader(GenerateCalibrationData):
 
     def process_data_item(self, data_item):
         feed_dict = {}
-        for i, node in enumerate(self.input_nodes):
+        for _, node in enumerate(self.input_nodes):
             # input_data = data_item[i].reshape(self.input_shapes[i])
             feed_dict[node] = data_item["input"]
         return feed_dict
@@ -348,6 +361,7 @@ def check_op_type_order(testcase, model_to_check, ops):
             node.op_type,
             f"op {node_idx} is not in order. Expected: {ops[node_idx]}, Actual: {node.op_type}",
         )
+
 
 def check_op_type_count(testcase, model_path, **kwargs):
     model = onnx.load(Path(model_path))

--- a/onnxruntime/test/python/quantization/test_quantize_static.py
+++ b/onnxruntime/test/python/quantization/test_quantize_static.py
@@ -13,10 +13,10 @@ from pathlib import Path
 import numpy as np
 import onnx
 from onnx import TensorProto, helper
-from op_test_utils import check_model_correctness, generate_random_initializer, input_feeds_neg_one_zero_one
+from op_test_utils import check_model_correctness, generate_random_initializer, input_feeds_neg_one_zero_one, strided_calibrater_data_reader
 
 from unittest.mock import MagicMock, patch
-from onnxruntime.quantization import QuantType, StaticQuantConfig, quantize, quantize_static, Calibrator, CalibrationDataReader
+from onnxruntime.quantization import QuantType, StaticQuantConfig, quantize, quantize_static
 
 
 def construct_test_model(test_model_path, channel_size):
@@ -93,11 +93,11 @@ class TestStaticQuantization(unittest.TestCase):
     def test_stride_effect_on_data_collection(self):
         # Define the stride and test quantize_static with different stride values
         strides = [1]
-        data_reader = input_feeds_neg_one_zero_one(10, {"input": [1, self._channel_size, 1, 3]})
+        data_reader = strided_calibrater_data_reader(10, {"input": [1, self._channel_size, 1, 3]})
 
         quant_model_path = str(Path(self._tmp_model_dir.name) / "quant.strided.onnx")
         for stride in strides:
-            quant_config = StaticQuantConfig(data_reader, extra_options={"CalibMaxIntermediateOutputs": "max_intermediate_outputs"})
+            quant_config = StaticQuantConfig(data_reader, extra_options={"CalibStridedMinMax": stride})
             with self.subTest(stride=stride):
                 quantize(self._model_fp32_path, quant_model_path, quant_config)
                 check_model_correctness(self, self._model_fp32_path, quant_model_path, data_reader.get_next())

--- a/onnxruntime/test/python/quantization/test_quantize_static.py
+++ b/onnxruntime/test/python/quantization/test_quantize_static.py
@@ -13,7 +13,13 @@ from pathlib import Path
 import numpy as np
 import onnx
 from onnx import TensorProto, helper
-from op_test_utils import check_model_correctness, generate_random_initializer, input_feeds_neg_one_zero_one, StridedDataReader, input_feeds_neg_one_zero_one_list
+from op_test_utils import (
+    StridedDataReader,
+    check_model_correctness,
+    generate_random_initializer,
+    input_feeds_neg_one_zero_one,
+    input_feeds_neg_one_zero_one_list,
+)
 
 import onnxruntime as ort
 from onnxruntime.quantization import QuantType, StaticQuantConfig, quantize, quantize_static
@@ -107,7 +113,9 @@ class TestStaticQuantization(unittest.TestCase):
 
         # strided calibration
         quant_model_path_1 = str(Path(self._tmp_model_dir.name) / "quant.strided.onnx")
-        data_reader_1 = StridedDataReader(data_list, input_nodes, input_shapes, no_tensor_num=0, in_dtypes=in_dtypes, stride=stride)
+        data_reader_1 = StridedDataReader(
+            data_list, input_nodes, input_shapes, no_tensor_num=0, in_dtypes=in_dtypes, stride=stride
+        )
         quant_config_1 = StaticQuantConfig(data_reader_1, extra_options={"CalibStridedMinMax": stride})
         quantize(str(self._model_fp32_path), str(quant_model_path_1), quant_config_1)
 
@@ -125,7 +133,13 @@ class TestStaticQuantization(unittest.TestCase):
         result_2 = self.run_inference(quant_model_path_2, input_data)
 
         # Assert that the outputs are close
-        np.testing.assert_allclose(result_1, result_2, rtol=0.01, atol=0.01, err_msg="Outputs from strided and non-strided models are not close enough.")
+        np.testing.assert_allclose(
+            result_1,
+            result_2,
+            rtol=0.01,
+            atol=0.01,
+            err_msg="Outputs from strided and non-strided models are not close enough.",
+        )
 
     def test_static_quant_config(self):
         data_reader = input_feeds_neg_one_zero_one(10, {"input": [1, self._channel_size, 1, 3]})


### PR DESCRIPTION
Context and motivation:
When quantizing large transformer models, we faced OOM issue when the number of calibration samples goes up.  To resolve this, in the PR we want to add support for reading quantization data in chunck, calculating ranges for intermediate tensors, then accumulating results for the final ranges.



