### PR TITLE
Update c-api-noopenmp-packaging-pipelines.yml: remove CUDA version parameter

### DIFF
--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -59,15 +59,6 @@ parameters:
   displayName: Build flags to append to build command
   type: string
   default: '--use_azure'
-
-- name: CudaVersion
-  displayName: CUDA version
-  type: string
-  default: '11.8'
-  values:
-    - 11.8
-    - 12.2
-
 - name: QnnSdk
   displayName: QNN SDK Version
   type: string
@@ -88,27 +79,13 @@ resources:
 variables:
 - name: ReleaseVersionSuffix
   value: ''
-- name: docker_base_image
-  ${{ if eq(parameters.CudaVersion, '11.8') }}:
-    value: nvidia/cuda:11.8.0-cudnn8-devel-ubi8
-  ${{ if eq(parameters.CudaVersion, '12.2') }}:
-    value: nvidia/cuda:12.2.2-cudnn8-devel-ubi8
 - name: win_trt_version
-  ${{ if eq(parameters.CudaVersion, '11.8') }}:
-    value: 11.8
-  ${{ if eq(parameters.CudaVersion, '12.2') }}:
-    value: 12.4
+  value: 11.8
 
 - name: win_trt_home
-  ${{ if eq(parameters.CudaVersion, '11.8') }}:
-    value: $(Agent.TempDirectory)\TensorRT-10.0.1.6.Windows10.x86_64.cuda-11.8
-  ${{ if eq(parameters.CudaVersion, '12.2') }}:
-    value: $(Agent.TempDirectory)\TensorRT-10.0.1.6.Windows10.x86_64.cuda-12.4
+  value: $(Agent.TempDirectory)\TensorRT-10.0.1.6.Windows10.x86_64.cuda-11.8
 - name: win_cuda_home
-  ${{ if eq(parameters.CudaVersion, '11.8') }}:
-    value: $(Agent.TempDirectory)\v11.8
-  ${{ if eq(parameters.CudaVersion, '12.2') }}:
-    value: $(Agent.TempDirectory)\v12.2
+  value: $(Agent.TempDirectory)\v11.8
 
 stages:
 - template: stages/set_packaging_variables_stage.yml
@@ -170,15 +147,15 @@ stages:
 
 - template: stages/java-cuda-packaging-stage.yml
   parameters:
-    CudaVersion: ${{ parameters.CudaVersion }}
+    CudaVersion: 11.8
     SpecificArtifact: ${{ parameters.SpecificArtifact }}
     BuildId: ${{ parameters.BuildId }}
 
 - template: stages/nuget-combine-cuda-stage.yml
   parameters:
       DoCompliance: ${{ parameters.DoCompliance }}
-      CudaVersion: ${{ parameters.CudaVersion }}
-      docker_base_image: ${{ variables.docker_base_image }}
+      CudaVersion: 11.8
+      docker_base_image: 'nvidia/cuda:11.8.0-cudnn8-devel-ubi8'
       RunOnnxRuntimeTests: ${{ parameters.RunOnnxRuntimeTests }}
       UseIncreasedTimeoutForTests: ${{ parameters.UseIncreasedTimeoutForTests }}
       win_trt_home: ${{ variables.win_trt_home }}


### PR DESCRIPTION
### Description
Update c-api-noopenmp-packaging-pipelines.yml: remove CUDA version parameter
To reduce confusion. This pipeline is for generating CUDA 11 packages. Just it. Not CUDA 12. 

### Motivation and Context
In the last release we accidentally published CUDA 12(instead of CUDA 11) packages to nuget.org.  
We also tried to publish CUDA 12 packages to https://aiinfra.visualstudio.com/PublicPackages/_artifacts/feed/ORT-Nightly. Luckily it didn't go through because a package with the same version number already existed there.  Every time when someone runs this pipeline with CUDA version set to 12, the built packages will be published to https://aiinfra.visualstudio.com/PublicPackages/_artifacts/feed/ORT-Nightly. And GenAI team's build pipelines are based on the nightly packages. So sometimes GenAI team builds their packages with CUDA 12 and sometimes with CUDA 11, which is very random. 
Therefore, please limit the use of pipeline parameters. Most Azure DevOps yml files are template files. They should use parameters.  But the top level yml files should be more careful on that. 

## How the mistake happened
In 1.17.0 release, we had two nuget pipelines that build CUDA packages:
One is called "Nuget-CUDA-Packaging-Pipeline", which by default build CUDA 12 packages.
Another one is called "Zip-Nuget-Java-Nodejs Packaging Pipeline", which by default build CUDA 11 packages.
They both have a "CudaVersion" parameter, which means any of them can produce both CUDA 12 and CUDA 11 packages. 
The pipeline that publishes packages to nuget.org only picks packages from "Nuget-CUDA-Packaging-Pipeline". By design we should publish CUDA 11 packages to nuget.org. 
So, it was fine.
Then, in 1.18.0 release, we deleted the "Nuget-CUDA-Packaging-Pipeline" in a rush when adding Java's CUDA packages: #20583 .  Then the release manager ran the "Zip-Nuget-Java-Nodejs Packaging Pipeline" twice with different parameters, and accidentally picked the wrong one when manually ran the publishing pipeline that publishes packages to nuget.org.



