### PR TITLE
[MLAS] Use C-style casting for power vector instructions

### DIFF
--- a/onnxruntime/core/mlas/lib/power/QuantizePower.cpp
+++ b/onnxruntime/core/mlas/lib/power/QuantizePower.cpp
@@ -2,6 +2,9 @@
 #include "mlasi.h"
 #include <altivec.h>
 
+// NOTE: Vector commands (e.g., vec_xst) need C-style casting to support various compiler versions.
+// ONNX Runtime CI pipelines do not build with all compiler versions.
+
 template<typename OutputType>
 void
 MLASCALL
@@ -194,7 +197,7 @@ Return Value:
         auto ShortVector1 = vec_pack(IntegerVector2, IntegerVector3);
 
         auto CharVector = vec_pack(ShortVector0, ShortVector1);
-        vec_xst(CharVector, 0, static_cast<int8_t *>(&TmpOutput[0]));
+        vec_xst(CharVector, 0, (int8_t *)(&TmpOutput[0]));
 
         MlasPackInt4Elements(Output++, TmpOutput[0], TmpOutput[1]);
         MlasPackInt4Elements(Output++, TmpOutput[2], TmpOutput[3]);


### PR DESCRIPTION
### Description
Uses C-style casting for Power vector instructions in `MlasQuantizeLinearInt4Kernel`.



### Motivation and Context
Vector commands (e.g., vec_xst) need C-style casting to support various compiler versions.
ONNX Runtime CI pipelines do not build with all compiler versions. The recent INT4 PR broke the powerpc build for certain compiler versions because it uses C++-style `static_cast<>`.

See: https://github.com/microsoft/onnxruntime/pull/20362#discussion_r1630106164


