### PR TITLE
Fix warnings and errors on cpu benchmark

### DIFF
--- a/onnxruntime/python/tools/transformers/models/llama/llama_inputs.py
+++ b/onnxruntime/python/tools/transformers/models/llama/llama_inputs.py
@@ -466,7 +466,7 @@ def get_initial_inputs_and_outputs(
         past_key = torch.zeros(
             batch_size,
             num_heads,
-            max_sequence_length if engine == "ort" and use_buffer_share else 0,
+            max_sequence_length if use_buffer_share else 0,
             head_size,
             device=device,
             dtype=torch_dtype,
@@ -474,7 +474,7 @@ def get_initial_inputs_and_outputs(
         past_value = torch.zeros(
             batch_size,
             num_heads,
-            max_sequence_length if engine == "ort" and use_buffer_share else 0,
+            max_sequence_length if use_buffer_share else 0,
             head_size,
             device=device,
             dtype=torch_dtype,

--- a/onnxruntime/python/tools/transformers/models/llama/llama_inputs.py
+++ b/onnxruntime/python/tools/transformers/models/llama/llama_inputs.py
@@ -54,7 +54,6 @@ def get_sample_inputs(
         "attention_mask": attention_mask,
         "position_ids": position_ids,
     }
-
     return inputs
 
 
@@ -98,7 +97,7 @@ def get_sample_with_past_kv_inputs(
     inputs = {
         "input_ids": input_ids,
         "attention_mask": attention_mask,
-        "position_ids":  position_ids,
+        "position_ids": position_ids,
     }
     if engine == "ort":
         assert isinstance(past_kv, dict)
@@ -301,7 +300,6 @@ def verify_ort_inputs(model: InferenceSession, ort_inputs: dict):
     unnecessary_inputs = user_inputs - model_inputs
     if len(unnecessary_inputs):
         for unnecessary_input in unnecessary_inputs:
-            print(f"Removing unnecessary input '{unnecessary_input}' from user provided inputs")
             del ort_inputs[unnecessary_input]
 
     return ort_inputs

--- a/onnxruntime/python/tools/transformers/models/llama/llama_inputs.py
+++ b/onnxruntime/python/tools/transformers/models/llama/llama_inputs.py
@@ -382,7 +382,11 @@ def add_io_bindings_as_tensors(
     for output in model.get_outputs():
         name = output.name
         # Bind KV cache outputs to KV cache inputs
-        v = inputs[name.replace("present", "past_key_values")] if use_buffer_share and "present" in name else outputs[name]
+        v = (
+            inputs[name.replace("present", "past_key_values")]
+            if use_buffer_share and "present" in name
+            else outputs[name]
+        )
         io_binding.bind_output(
             name=name,
             device_type=device.type,

--- a/onnxruntime/python/tools/transformers/models/llama/llama_inputs.py
+++ b/onnxruntime/python/tools/transformers/models/llama/llama_inputs.py
@@ -35,7 +35,6 @@ def get_sample_inputs(
     seq_len: int,
     engine: str = "pt",
     return_dict: bool = False,
-    use_position_ids: bool = True,
 ):
     input_ids = torch.randint(low=0, high=config.vocab_size, size=(batch_size, seq_len), dtype=torch.int64)
     attention_mask = torch.ones(batch_size, seq_len, dtype=torch.int64)
@@ -53,9 +52,8 @@ def get_sample_inputs(
     inputs = {
         "input_ids": input_ids,
         "attention_mask": attention_mask,
+        "position_ids": position_ids,
     }
-    if use_position_ids:
-        inputs["position_ids"] = position_ids
 
     return inputs
 
@@ -75,7 +73,6 @@ def get_sample_with_past_kv_inputs(
     engine: str = "pt",
     return_dict: bool = False,
     world_size: int = 1,
-    use_position_ids: bool = True,
 ):
     input_ids = torch.randint(low=0, high=config.vocab_size, size=(batch_size, 1), dtype=torch.int64)
     attention_mask = torch.ones(batch_size, past_seq_len + 1, dtype=torch.int64)
@@ -101,9 +98,8 @@ def get_sample_with_past_kv_inputs(
     inputs = {
         "input_ids": input_ids,
         "attention_mask": attention_mask,
+        "position_ids":  position_ids,
     }
-    if use_position_ids:
-        inputs["position_ids"] = position_ids
     if engine == "ort":
         assert isinstance(past_kv, dict)
         inputs.update(past_kv)
@@ -136,7 +132,6 @@ def get_merged_sample_with_past_kv_inputs(
     engine: str = "pt",
     return_dict: bool = False,
     world_size: int = 1,
-    use_position_ids: bool = True,
 ):
     input_ids = torch.randint(low=0, high=config.vocab_size, size=(batch_size, seq_len), dtype=torch.int64)
     attention_mask = torch.ones(batch_size, past_seq_len + seq_len, dtype=torch.int64)
@@ -162,9 +157,8 @@ def get_merged_sample_with_past_kv_inputs(
     inputs = {
         "input_ids": input_ids,
         "attention_mask": attention_mask,
+        "position_ids": position_ids,
     }
-    if use_position_ids:
-        inputs["position_ids"] = position_ids
     if engine == "ort":
         assert isinstance(past_kv, dict)
         inputs.update(past_kv)
@@ -413,7 +407,6 @@ def get_initial_inputs_and_outputs(
     use_fp16: bool,
     use_buffer_share: bool,
     engine: str,
-    use_position_ids: bool = True,
 ):
     tokenizer.pad_token = tokenizer.eos_token
     encodings_dict = tokenizer.batch_encode_plus(prompt, padding=True)
@@ -449,9 +442,8 @@ def get_initial_inputs_and_outputs(
     inputs = {
         "input_ids": input_ids.contiguous() if engine == "ort" else input_ids,
         "attention_mask": attention_mask.contiguous() if engine == "ort" else attention_mask,
+        "position_ids": position_ids.contiguous() if engine == "ort" else position_ids,
     }
-    if use_position_ids:
-        inputs["position_ids"] = position_ids.contiguous() if engine == "ort" else position_ids
     if engine != "ort":
         inputs["past_key_values"] = []
 


### PR DESCRIPTION
Several changes to remove warnings or errors on CPU benchmark and other benchmarks.

- Phi-3 codes doesn't require auth token, but trust_remote_code flag. Add "--trust" to enable only trust_remote_code.
- Phi3 models are not working with sdpa and needs to be run with eager mode.
- Fix CPU io binding error with null device id and element_type mismatch.
- use_buffer_share only when engine is ort.