### PR TITLE
Updated build script for CUDA case

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1158,6 +1158,7 @@ def generate_build_tree(
                     f"Float 8 types require CUDA>=11.8. They must be disabled on CUDA=={args.cuda_version}. "
                     f"Add '--disable_types float8' to your command line. See option disable_types."
                 )
+        cmake_args.append(f"-DCMAKE_CUDA_COMPILER={cuda_home}/bin/nvcc")
     if args.use_rocm:
         cmake_args.append("-Donnxruntime_ROCM_HOME=" + rocm_home)
         cmake_args.append("-Donnxruntime_ROCM_VERSION=" + args.rocm_version)


### PR DESCRIPTION
### Description

In CUDA case, use the cuda_home variable to set CMAKE's CUDA compiler to a correct version of NVCC

Otherwise, an NVCC from a current PATH would be picked up, which could be from a different version of CUDA.



### Motivation and Context

I had a case when I had main CUDA installed, and it was a version 11.8.

I wanted to build against 12.5, so I downloaded and unpacked it into a separate directory and passed it as a `--cuda-home` parameter, however the ONNX builder was still picking the NVCC compiler from 11.8.

This would fix the issue https://github.com/microsoft/onnxruntime/issues/20928 


cc @gedoensmax 
