### PR TITLE
Publish Build Symbols for DML nightly nuget package

### DIFF
--- a/tools/ci_build/github/azure-pipelines/nuget/templates/dml-vs-2022.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/dml-vs-2022.yml
@@ -228,15 +228,14 @@ stages:
             artifactName: ${{ parameters.ArtifactName }}
             targetPath: '$(Build.ArtifactStagingDirectory)'
 
-        - ${{ if eq(parameters['IsReleaseBuild'], 'true') }}:
-          - task: PublishSymbols@2
-            displayName: 'Publish Build Symbols'
-            inputs:
-              symbolsFolder: '$(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo'
-              searchPattern: '**/*.pdb'
-              symbolServerType: teamServices
-
-
+        - task: PublishSymbols@2
+          displayName: 'Publish Build Symbols'
+          condition: and (succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/rel-')))
+          inputs:
+            SymbolsFolder: '$(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo'
+            SearchPattern: 'onnxruntime.pdb'
+            SymbolServerType: teamServices
+            SymbolExpirationInDays: 365
 
       # Node.js Publish
       - ${{ if eq(parameters['DoNodejsPack'], 'true') }}:


### PR DESCRIPTION
### Description
Publish Build Symbols for DML nightly nuget package. ONNX Runtime GenAI team uses the nightly packages, and they hit a hard to debug issue. They need the symbols. 


### Motivation and Context



