### PR TITLE
[CUDA] update test_flash_attn_cuda.py for Windows

### DIFF
--- a/onnxruntime/test/python/transformers/test_flash_attn_cuda.py
+++ b/onnxruntime/test/python/transformers/test_flash_attn_cuda.py
@@ -47,14 +47,16 @@ class Config:
     kv_num_heads = 0
     head_size = 0
 
-    def __init__(self, b, s, s2, sp, n, n2, h):
-        self.batch_size = b
-        self.sequence_length = s
-        self.kv_sequence_length = s2
-        self.past_sequence_length = sp
-        self.num_heads = n
-        self.kv_num_heads = n2
-        self.head_size = h
+    def __init__(
+        self, batch_size, sequence_length, kv_sequence_length, past_sequence_length, num_heads, kv_num_heads, head_size
+    ):
+        self.batch_size = batch_size
+        self.sequence_length = sequence_length
+        self.kv_sequence_length = kv_sequence_length
+        self.past_sequence_length = past_sequence_length
+        self.num_heads = num_heads
+        self.kv_num_heads = kv_num_heads
+        self.head_size = head_size
 
     def __repr__(self):
         return (
@@ -73,14 +75,23 @@ class PromptConfig:
     kv_num_heads = 0
     head_size = 0
 
-    def __init__(self, b, sq, skv, sb, n, n2, h):
-        self.batch_size = b
-        self.q_sequence_length = sq
-        self.kv_sequence_length = skv
-        self.buffer_sequence_length = sb
-        self.num_heads = n
-        self.kv_num_heads = n2
-        self.head_size = h
+    def __init__(
+        self,
+        batch_size,
+        q_sequence_length,
+        kv_sequence_length,
+        buffer_sequence_length,
+        num_heads,
+        kv_num_heads,
+        head_size,
+    ):
+        self.batch_size = batch_size
+        self.q_sequence_length = q_sequence_length
+        self.kv_sequence_length = kv_sequence_length
+        self.buffer_sequence_length = buffer_sequence_length
+        self.num_heads = num_heads
+        self.kv_num_heads = kv_num_heads
+        self.head_size = head_size
 
     def __repr__(self):
         return (

--- a/onnxruntime/test/python/transformers/test_flash_attn_cuda.py
+++ b/onnxruntime/test/python/transformers/test_flash_attn_cuda.py
@@ -763,7 +763,7 @@ def mha_func(q, k, v, config):
 
 
 def rotary_options_for_current_os():
-    # Reference implementation of rotary uses triton, which is not availabe in Windows.
+    # Reference implementation of rotary uses triton, which is not available in Windows.
     # So we only test rotary in Linux right now.
     return [(False, False)] if platform.system() != "Linux" else [(True, False), (True, True), (False, False)]
 


### PR DESCRIPTION
### Description

Currently test_flash_attn_cuda.py can only run in Linux. It is because it uses triton for rotary reference implementation, and triton python package is not available in Windows. 

This changes the script to allow the test run in Windows, so that we can test memory efficient attention in Windows.

Due to limitation, rotary is excluded in testing on Windows.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


