### PR TITLE
Fix a few issues in "Zip-Nuget-Java-Nodejs Packaging Pipeline"

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/jobs/download_win_gpu_library.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/download_win_gpu_library.yml
@@ -35,19 +35,19 @@ steps:
 
   - ${{ if eq(parameters.DownloadTRT, true) }}:
     - ${{ if eq(parameters.CudaVersion, '11.8') }}:
-        - bash: |
-            echo "##vso[task.setvariable variable=trtCudaVersion]11.8"
+        - powershell: |
+            Write-Host "##vso[task.setvariable variable=trtCudaVersion;]11.8"
           displayName: Set trtCudaVersion
     - ${{ if and(eq(parameters.CudaVersion, '12.2'), eq(parameters.TrtVersion, '8.6.1.6')) }}:
-        - bash: |
-            echo "##vso[task.setvariable variable=trtCudaVersion]12.0"
+        - powershell: |
+            Write-Host "##vso[task.setvariable variable=trtCudaVersion;]12.0"
           displayName: Set trtCudaVersion
     - ${{ if and(eq(parameters.CudaVersion, '12.2'), eq(parameters.TrtVersion, '10.0.1.6')) }}:
-        - bash: |
-            echo "##vso[task.setvariable variable=trtCudaVersion]12.4"
+        - powershell: |
+            Write-Host "##vso[task.setvariable variable=trtCudaVersion;]12.4"
           displayName: Set trtCudaVersion
 
-    - bash: |
+    - script: |
         echo $(trtCudaVersion) && echo TensorRT-${{ parameters.TrtVersion }}.Windows10.x86_64.cuda-$(trtCudaVersion)
       displayName: Get trtCudaVersion and Directory Name
 


### PR DESCRIPTION
### Description
Fix a few issues in the Windows TRT job in  "Zip-Nuget-Java-Nodejs Packaging Pipeline":
1. It is a Windows job. It should not use bash(which is usually not available on Windows).
2. When it sets ADO vars, it missed a semicolon 

Here is the doc of how to set ADO vars via scripts: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/set-variables-scripts?view=azure-devops&tabs=bash

You could see it needs a semicolon . Without the semicolon , the vars will have an extra quotation mark in their values.

### Motivation and Context



