### PR TITLE
Move jobs in onnxruntime-Win2022-GPU-T4 machine pool to onnxruntime-Win2022-GPU-A10

### DIFF
--- a/tools/ci_build/github/azure-pipelines/stages/java-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/java-cuda-packaging-stage.yml
@@ -81,7 +81,7 @@ stages:
       Jar_Packaging_GPU
     workspace:
       clean: all
-    pool: 'onnxruntime-Win2022-GPU-T4'
+    pool: 'onnxruntime-Win2022-GPU-A10'
     timeoutInMinutes: 60
     variables:
     - name: runCodesignValidationInjection

--- a/tools/ci_build/github/azure-pipelines/stages/nuget-win-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nuget-win-cuda-packaging-stage.yml
@@ -42,7 +42,7 @@ stages:
 # Windows CUDA without TensorRT Packaging
 - template: ../templates/win-ci.yml
   parameters:
-    ort_build_pool_name: 'onnxruntime-Win2022-GPU-T4'
+    ort_build_pool_name: 'onnxruntime-Win2022-GPU-A10'
     DoCompliance: ${{ parameters.DoCompliance }}
     DoEsrp: ${{ parameters.DoEsrp }}
     stage_name_suffix: CUDA
@@ -60,7 +60,7 @@ stages:
 # Windows CUDA with TensorRT Packaging
 - template: ../templates/win-ci.yml
   parameters:
-    ort_build_pool_name: 'onnxruntime-Win2022-GPU-T4'
+    ort_build_pool_name: 'onnxruntime-Win2022-GPU-A10'
     DoCompliance: ${{ parameters.DoCompliance }}
     DoEsrp: ${{ parameters.DoEsrp }}
     stage_name_suffix: TensorRT
@@ -87,7 +87,7 @@ stages:
     - job: Windows_Packaging_combined_GPU
       workspace:
         clean: all
-      pool: 'onnxruntime-Win2022-GPU-T4'
+      pool: 'onnxruntime-Win2022-GPU-A10'
       variables:
         CUDA_MODULE_LOADINGL: 'LAZY'
         GRADLE_OPTS: '-Dorg.gradle.daemon=false'

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-selectable-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-selectable-stage.yml
@@ -387,7 +387,7 @@ stages:
     - job: Windows_py_GPU_Wheels
       workspace:
         clean: all
-      pool: 'onnxruntime-Win2022-GPU-T4'
+      pool: 'onnxruntime-Win2022-GPU-A10'
       timeoutInMinutes:  300
       variables:
         CUDA_VERSION: '11.8'

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -297,7 +297,7 @@ stages:
 - ${{ if eq(parameters.enable_windows_gpu, true) }}:
     - template: py-win-gpu.yml
       parameters:
-        MACHINE_POOL: 'onnxruntime-Win2022-GPU-T4'
+        MACHINE_POOL: 'onnxruntime-Win2022-GPU-A10'
         PYTHON_VERSION: '3.8'
         EP_BUILD_FLAGS: --use_tensorrt --tensorrt_home="$(Agent.TempDirectory)\TensorRT-10.0.1.6.Windows10.x86_64.cuda-11.8" --cuda_home="$(Agent.TempDirectory)\v11.8"  --cmake_extra_defines "CMAKE_CUDA_ARCHITECTURES=52;60;61;70;75;80"
         ENV_SETUP_SCRIPT: setup_env_gpu.bat
@@ -307,7 +307,7 @@ stages:
 
     - template: py-win-gpu.yml
       parameters:
-        MACHINE_POOL: 'onnxruntime-Win2022-GPU-T4'
+        MACHINE_POOL: 'onnxruntime-Win2022-GPU-A10'
         PYTHON_VERSION: '3.9'
         EP_BUILD_FLAGS: --use_tensorrt --tensorrt_home="$(Agent.TempDirectory)\TensorRT-10.0.1.6.Windows10.x86_64.cuda-11.8" --cuda_home="$(Agent.TempDirectory)\v11.8"  --cmake_extra_defines "CMAKE_CUDA_ARCHITECTURES=52;60;61;70;75;80"
         ENV_SETUP_SCRIPT: setup_env_gpu.bat
@@ -317,7 +317,7 @@ stages:
 
     - template: py-win-gpu.yml
       parameters:
-        MACHINE_POOL: 'onnxruntime-Win2022-GPU-T4'
+        MACHINE_POOL: 'onnxruntime-Win2022-GPU-A10'
         PYTHON_VERSION: '3.10'
         EP_BUILD_FLAGS: --use_tensorrt --tensorrt_home="$(Agent.TempDirectory)\TensorRT-10.0.1.6.Windows10.x86_64.cuda-11.8" --cuda_home="$(Agent.TempDirectory)\v11.8"  --cmake_extra_defines "CMAKE_CUDA_ARCHITECTURES=52;60;61;70;75;80"
         ENV_SETUP_SCRIPT: setup_env_gpu.bat
@@ -327,7 +327,7 @@ stages:
 
     - template: py-win-gpu.yml
       parameters:
-        MACHINE_POOL: 'onnxruntime-Win2022-GPU-T4'
+        MACHINE_POOL: 'onnxruntime-Win2022-GPU-A10'
         PYTHON_VERSION: '3.11'
         EP_BUILD_FLAGS: --use_tensorrt --tensorrt_home="$(Agent.TempDirectory)\TensorRT-10.0.1.6.Windows10.x86_64.cuda-11.8" --cuda_home="$(Agent.TempDirectory)\v11.8"  --cmake_extra_defines "CMAKE_CUDA_ARCHITECTURES=52;60;61;70;75;80"
         ENV_SETUP_SCRIPT: setup_env_gpu.bat
@@ -337,7 +337,7 @@ stages:
 
     - template: py-win-gpu.yml
       parameters:
-        MACHINE_POOL: 'onnxruntime-Win2022-GPU-T4'
+        MACHINE_POOL: 'onnxruntime-Win2022-GPU-A10'
         PYTHON_VERSION: '3.12'
         EP_BUILD_FLAGS: --use_tensorrt --tensorrt_home="$(Agent.TempDirectory)\TensorRT-10.0.1.6.Windows10.x86_64.cuda-11.8" --cuda_home="$(Agent.TempDirectory)\v11.8"  --cmake_extra_defines "CMAKE_CUDA_ARCHITECTURES=52;60;61;70;75;80"
         ENV_SETUP_SCRIPT: setup_env_gpu.bat

--- a/tools/ci_build/github/azure-pipelines/templates/py-win-gpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-win-gpu.yml
@@ -1,7 +1,7 @@
 parameters:
 - name: MACHINE_POOL
   type: string
-  default: 'onnxruntime-Win2022-GPU-T4'
+  default: 'onnxruntime-Win2022-GPU-A10'
 
 - name: EP_NAME
   type: string

--- a/tools/ci_build/github/azure-pipelines/win-gpu-reduce-op-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-reduce-op-ci-pipeline.yml
@@ -1,6 +1,6 @@
 jobs:
 - job: 'build'
-  pool: 'onnxruntime-Win2022-GPU-T4'
+  pool: 'onnxruntime-Win2022-GPU-A10'
   strategy:
     maxParallel: 2
     matrix:
@@ -22,7 +22,7 @@ jobs:
       DownloadCUDA: true
       BuildArch: 'x64'
       BuildConfig: $(BuildConfig)
-      MachinePool: 'onnxruntime-Win2022-GPU-T4'
+      MachinePool: 'onnxruntime-Win2022-GPU-A10'
       WithCache: true
       Today: $(Today)
 

--- a/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
@@ -29,7 +29,7 @@ pr:
 
 jobs:
 - job: 'build'
-  pool: 'onnxruntime-Win2022-GPU-T4'
+  pool: 'onnxruntime-Win2022-GPU-A10'
   variables:
     MsbuildArguments: '-detailedsummary -maxcpucount -consoleloggerparameters:PerformanceSummary'
     EnvSetupScript: setup_env_trt.bat
@@ -46,7 +46,7 @@ jobs:
       DownloadTRT: true
       BuildArch: 'x64'
       BuildConfig: RelWithDebInfo
-      MachinePool: 'onnxruntime-Win2022-GPU-T4'
+      MachinePool: 'onnxruntime-Win2022-GPU-A10'
       WithCache: true
       Today: $(Today)
 
@@ -55,7 +55,7 @@ jobs:
       WithCache: True
       Today: $(TODAY)
       AdditionalKey: "gpu-tensorrt | RelWithDebInfo"
-      BuildPyArguments: '--config RelWithDebInfo --parallel --use_binskim_compliant_compile_flags --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --update --cmake_generator "Visual Studio 17 2022" --build_wheel --enable_onnx_tests --use_tensorrt --tensorrt_home="$(Agent.TempDirectory)\TensorRT-10.0.1.6.Windows10.x86_64.cuda-11.8" --cuda_home="$(Agent.TempDirectory)\v11.8" --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=75'
+      BuildPyArguments: '--config RelWithDebInfo --parallel --use_binskim_compliant_compile_flags --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --update --cmake_generator "Visual Studio 17 2022" --build_wheel --enable_onnx_tests --use_tensorrt --tensorrt_home="$(Agent.TempDirectory)\TensorRT-10.0.1.6.Windows10.x86_64.cuda-11.8" --cuda_home="$(Agent.TempDirectory)\v11.8" --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=86'
       MsbuildArguments: $(MsbuildArguments)
       BuildArch: 'x64'
       Platform: 'x64'


### PR DESCRIPTION
### Description
Move jobs in onnxruntime-Win2022-GPU-T4 machine pool to onnxruntime-Win2022-GPU-A10

### Motivation and Context
To reduce the variants of VM images we need to maintain. Now we have 3:
1. Windows 2022 CPU
2. Windows 2022 GPU A10
3. Windows 2022 GPU T4

This change can remove the last one.  


