### PR TITLE
[MLAS] add q4 quantize and transpose kernel to support MatMulNBits QDQ fuse

### DIFF
--- a/onnxruntime/core/mlas/inc/mlas_q4.h
+++ b/onnxruntime/core/mlas/inc/mlas_q4.h
@@ -358,3 +358,70 @@ MlasDequantizeBlockwise(
     int columns,
     MLAS_THREADPOOL* thread_pool
     );
+
+/**
+ * @brief Blockwise 2 bits or 4 bits quantization. After quantization, the weights and zero points
+ *        are packed row-wise. In terms of the qbits type, dst and src have the same shape, and
+ *        scales and zero_points have the same shape.
+ *        columns must be multiple of 8 / qbits.
+ * @tparam Tin
+ * @tparam qbits            number of bits used for quantization, 2 or 4
+ * @param src               points to the floating point matrix, to be quantized, row major shape [rows, columns]
+ * @param scales            points to the scales matrix, row major
+ * @param zero_points       points to the zero_points matrix, row major
+ * @param dst               points to the quantized matrix, shape [rows, columns] row major in qbits type.
+ *                          In uint8_t type, shape is [rows, columns * qbits / 8].
+ * @param columnwise        true when quantize elements in a column, false when quantize elements in a row.
+ * @param rows
+ * @param columns
+ * @param quant_block_size  number of elements in a quantize block
+ * @param thread_pool
+ */
+template <typename Tin, int qbits>
+void
+MlasQDQQuantizeBlockwise(
+    const Tin* src,
+    Tin* scales,
+    uint8_t* zero_points,
+    uint8_t* dst,
+    bool columnwise,
+    int rows,
+    int columns,
+    int quant_block_size,
+    MLAS_THREADPOOL* thread_pool
+);
+
+/**
+ * @brief Transpose blockwise quantized tensors. The src tensors are row major. src weights and zero
+ *        points are packed row-wise. The dst tensors are column major. dst weights and zero points
+ *        are packed column-wise.
+ * @tparam Tin
+ * @tparam qbits            number of bits used for quantization, 2 or 4
+ * @param src_weights       points to the quantized matrix, row major, shape [rows, columns] in qbits type.
+ *                          In uint8_t type, shape is [rows, columns * qbits / 8].
+ * @param src_scales        points to the scales matrix, row major
+ * @param src_zero_points   points to the zero_points matrix, row major. Packed row-wise.
+ * @param dst_weights       points to the quantized matrix, column major. Packed column-wise.
+ * @param dst_scales        points to the scales matrix, column major
+ * @param dst_zero_points   points to the zero_points matrix, column major. Packed column-wise.
+ * @param columnwise        true when quantize elements in a column, false when quantize elements in a row.
+ * @param rows
+ * @param columns
+ * @param quant_block_size  number of elements in a quantize block
+ * @param thread_pool
+ */
+template <typename Tin, int qbits>
+void
+MlasQDQTransposeBlockwiseQuantized(
+    const uint8_t* src_weights,
+    const Tin* src_scales,
+    const uint8_t* src_zero_points,
+    uint8_t* dst_weights,
+    Tin* dst_scales,
+    uint8_t* dst_zero_points,
+    bool columnwise,
+    int rows,
+    int columns,
+    int quant_block_size,
+    MLAS_THREADPOOL* thread_pool
+);

--- a/onnxruntime/core/mlas/lib/q4_dq.cpp
+++ b/onnxruntime/core/mlas/lib/q4_dq.cpp
@@ -651,9 +651,9 @@ template <typename Tin, int qbits>
 struct BlockwiseQDQQuantizer {
     static_assert(qbits == 4 || qbits == 2, "Only 4bit or 2bit block quantization is supported!");
 
-    const int32_t mask_ = (1 << qbits) - 1;
-    const int32_t pack_size_ = BitsTraits<qbits>::kPackSize;
-    constexpr int32_t shift_bit_ = qbits == 4 ? 1 : (qbits == 2 ? 2 : 0);
+    static const int32_t mask_ = (1 << qbits) - 1;
+    static const int32_t pack_size_ = BitsTraits<qbits>::kPackSize;
+    static constexpr int32_t shift_bit_ = qbits == 4 ? 1 : (qbits == 2 ? 2 : 0);
 
     static MLAS_FORCEINLINE uint8_t SetElem(uint8_t val, int32_t idx, uint8_t dst)
     {
@@ -661,7 +661,7 @@ struct BlockwiseQDQQuantizer {
         return ((val & mask_) << shift) | (dst & (~(mask_ << shift)));
     }
 
-    static MLAS_FORCEINLINE uint8_t Pack(uint8_t vals[pack_size])
+    static MLAS_FORCEINLINE uint8_t Pack(uint8_t vals[pack_size_])
     {
         return constexpr (qbits == 4)
                    ? ((vals[0] & 0xF) | ((vals[1] & 0xF) << 4))

--- a/onnxruntime/core/mlas/lib/q4_dq.cpp
+++ b/onnxruntime/core/mlas/lib/q4_dq.cpp
@@ -851,14 +851,14 @@ private:
         const auto num_row_thread_blk = (rows + quant_block_size - 1) / quant_block_size;
         const auto num_col_thread_blk = (columns + thread_blk_size - 1) / thread_blk_size;
         const auto num_thread_blk = num_row_thread_blk * num_col_thread_blk;
-        const auto minf = std::numeric_limits<float>::lowest();
-        const auto maxf = std::numeric_limits<float>::max();
+        constexpr auto minf = std::numeric_limits<float>::lowest();
+        constexpr auto maxf = std::numeric_limits<float>::max();
 
         MlasTryBatchParallel(
             thread_pool, static_cast<ptrdiff_t>(num_thread_blk),
             [&](ptrdiff_t thread_blk_idx) {
                 // !!warning!!: buffering the whole thread block
-                const int32_t buffer_size = 128;
+                constexpr int32_t buffer_size = 128;
                 ORT_ENFORCE(buffer_size == thread_blk_size, "buffer size must be equal to thread block size.");
                 float reciprocal_scale_t[buffer_size];
                 uint8_t zp_t[buffer_size];
@@ -952,7 +952,7 @@ private:
         MlasTryBatchParallel(
             thread_pool, static_cast<ptrdiff_t>(num_row_thread_blk),
             [&](ptrdiff_t thread_blk_idx) {
-                const int32_t buffer_size = 128;
+                constexpr int32_t buffer_size = 128;
                 float reciprocal_scale_t[buffer_size];
                 uint8_t zp_t[buffer_size];
                 float vmin_t[buffer_size];

--- a/onnxruntime/core/util/qmath.h
+++ b/onnxruntime/core/util/qmath.h
@@ -557,7 +557,7 @@ struct BlockedQuantizeLinear<float, TOut, 2> {
     constexpr auto low = static_cast<int32_t>(TOut::min_val);
     constexpr auto high = static_cast<int32_t>(TOut::max_val);
     auto size_thread_block = 2 * N;
-    auto num_thread_block = (M * K - 1) / 2;
+    auto num_thread_block = (M * K + 1) / 2;
     auto num_quant_block_K = (K + quant_block_size - 1) / quant_block_size;
     auto num_quant_block_KN = num_quant_block_K * N;
     auto MK = M * K;
@@ -591,7 +591,7 @@ struct BlockedQuantizeLinear<float, TOut, 2> {
               ++zp_idx_t;
             }
 
-            // TODO(fajin): 1> use SIMD, 2> set block to quant_block_size * thread_block_size
+            // TODO(fajin): use SIMD
             // aligned output
             auto output_t = reinterpret_cast<typename TOut::UnpackedType*>(output);
             for (; output_idx < output_idx_end - 1; output_idx += 2, zp_idx_t += 2) {
@@ -637,48 +637,52 @@ struct BlockedQuantizeLinear<float, TOut, 2> {
     ORT_UNUSED_PARAMETER(saturate);
     constexpr auto low = static_cast<int32_t>(TOut::min_val);
     constexpr auto high = static_cast<int32_t>(TOut::max_val);
-    // quant block size is used as thread block size
-    const auto num_thread_block_K = (K + quant_block_size - 1) / quant_block_size;
-    const auto num_thread_block = num_thread_block_K * M;
-    const TensorOpCost unit_cost{static_cast<double>(quant_block_size * sizeof(float)),
-                                 static_cast<double>(quant_block_size * sizeof(typename TOut ::UnpackedType)),
-                                 static_cast<double>(quant_block_size) * 2.0};
+    // to avoid a byte being writen from mutiple threads, use 2 * K as thread block
+    auto size_thread_block = 2 * K;
+    auto quant_block_num_K = (K + quant_block_size - 1) / quant_block_size;
+    auto num_thread_block = (M + 1) / 2;
+    TensorOpCost unit_cost{static_cast<double>(size_thread_block * sizeof(float)),
+                           static_cast<double>(size_thread_block * sizeof(typename TOut ::UnpackedType)),
+                           static_cast<double>(size_thread_block) * 2.0};
     concurrency::ThreadPool::TryParallelFor(
         thread_pool,
         num_thread_block,
         unit_cost,
         [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
-          auto m = begin / num_thread_block_K, k_blk = begin % num_thread_block_K, k = k_blk * quant_block_size;
-          auto output_idx = m * K + k;
+          begin <<= 1, end = std::min(end << 1, M);
+          auto output_idx = begin * K;
+          auto zp_idx = begin * quant_block_num_K;
 
-          for (; begin < end; ++begin) {
-            auto zp = zero_point ? static_cast<int32_t>(zero_point[begin >> 1].GetElem(begin & 1)) : 0;
-            auto sc = scale[begin];
-            size_t output_idx_end = std::min(K - k, quant_block_size) + output_idx;
-            size_t out_start = output_idx, out_end = output_idx_end;
+          for (; begin < end; ++begin, output_idx += K) {
+            auto output_row_idx_start = output_idx;
+            auto output_row_idx_end = output_row_idx_start + K;
 
-            if (out_start & 1) {
-              auto v = std::clamp(static_cast<int32_t>(std::nearbyint(input[out_start] / sc)) + zp, low, high);
-              output[out_start >> 1].SetElem(1, static_cast<typename TOut::UnpackedType>(v));
-              ++out_start;
+            for (; output_row_idx_start < output_row_idx_end; output_row_idx_start += quant_block_size, ++zp_idx) {
+              auto zp = zero_point ? static_cast<int32_t>(zero_point[zp_idx >> 1].GetElem(zp_idx & 1)) : 0;
+              auto sc = scale[zp_idx];
+              size_t out_start = output_row_idx_start;
+              size_t out_end = std::min(output_row_idx_start + quant_block_size, output_row_idx_end);
+
+              if (out_start & 1) {
+                auto v = std::clamp(static_cast<int32_t>(std::nearbyint(input[out_start] / sc)) + zp, low, high);
+                output[out_start >> 1].SetElem(1, static_cast<typename TOut::UnpackedType>(v));
+                ++out_start;
+              }
+
+              if (out_end & 1) {
+                --out_end;
+                auto v = std::clamp(static_cast<int32_t>(std::nearbyint(input[out_end] / sc)) + zp, low, high);
+                output[out_end >> 1].SetElem(0, static_cast<typename TOut::UnpackedType>(v));
+              }
+
+              if constexpr (std::is_same<TOut, Int4x2>::value) {
+                MlasQuantizeLinearS4(input + out_start, reinterpret_cast<uint8_t*>(&(output[out_start >> 1])),
+                                     out_end - out_start, sc, static_cast<int8_t>(zp));
+              } else {
+                MlasQuantizeLinearU4(input + out_start, reinterpret_cast<uint8_t*>(&(output[out_start >> 1])),
+                                     out_end - out_start, sc, static_cast<int8_t>(zp));
+              }
             }
-
-            if (out_end & 1) {
-              --out_end;
-              auto v = std::clamp(static_cast<int32_t>(std::nearbyint(input[out_end] / sc)) + zp, low, high);
-              output[out_end >> 1].SetElem(0, static_cast<typename TOut::UnpackedType>(v));
-            }
-
-            if constexpr (std::is_same<TOut, Int4x2>::value) {
-              MlasQuantizeLinearS4(input + out_start, reinterpret_cast<uint8_t*>(&(output[out_start >> 1])),
-                                   out_end - out_start, sc, static_cast<int8_t>(zp));
-            } else {
-              MlasQuantizeLinearU4(input + out_start, reinterpret_cast<uint8_t*>(&(output[out_start >> 1])),
-                                   out_end - out_start, sc, static_cast<int8_t>(zp));
-            }
-
-            output_idx = output_idx_end;
-            k = output_idx % K;
           }
         });
   }
@@ -693,54 +697,84 @@ struct BlockedQuantizeLinear<MLFloat16, TOut, 2> {
                             std::ptrdiff_t N, const std::ptrdiff_t quant_block_size,
                             const std::ptrdiff_t thread_block_size, bool saturate) {
     ORT_UNUSED_PARAMETER(saturate);
+    // to avoid a byte being writen from mutiple threads, use 2 * N as thread block
+    ORT_UNUSED_PARAMETER(thread_block_size);
     constexpr auto low = static_cast<int32_t>(TOut::min_val);
     constexpr auto high = static_cast<int32_t>(TOut::max_val);
-    const auto num_thread_block_N = (N + thread_block_size - 1) / thread_block_size;
-    const auto num_thread_block = M * K * num_thread_block_N;
-    const TensorOpCost unit_cost{static_cast<double>(thread_block_size * sizeof(MLFloat16) * 2),
-                                 static_cast<double>(thread_block_size * sizeof(typename TOut::UnpackedType)),
-                                 static_cast<double>(thread_block_size) * 2.0};
-    auto KN = K * N;
-    auto num_quant_block_KN = (K + quant_block_size - 1) / quant_block_size * N;
-    const auto num_thread_block_KN = K * num_thread_block_N;
+    auto size_thread_block = 2 * N;
+    auto num_thread_block = (M * K + 1) / 2;
+    auto num_quant_block_K = (K + quant_block_size - 1) / quant_block_size;
+    auto num_quant_block_KN = num_quant_block_K * N;
+    auto MK = M * K;
+    const TensorOpCost unit_cost{static_cast<double>(size_thread_block * sizeof(float) * 2),
+                                 static_cast<double>(size_thread_block * sizeof(typename TOut::UnpackedType)),
+                                 static_cast<double>(size_thread_block) * 2.0};
 
     concurrency::ThreadPool::TryParallelFor(
         thread_pool,
         num_thread_block,
         unit_cost,
         [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
-          auto m = begin / num_thread_block_KN, k = begin % num_thread_block_KN / num_thread_block_N;
-          auto n_blk = begin % num_thread_block_N, n = n_blk * thread_block_size;
-          auto output_idx = m * KN + k * N + n;
-          auto quant_param_idx = m * num_quant_block_KN + k / quant_block_size * N;
-          auto quant_param_idx_t = quant_param_idx + n;
+          begin <<= 1, end = std::min(end << 1, MK);
+          auto output_idx = begin * N;
+          auto m = begin / K, k = begin % K;
+          auto zp_idx = m * num_quant_block_KN + k / quant_block_size * N;
 
           for (; begin < end; ++begin) {
-            auto n_end = std::min(N, n + thread_block_size);
-            // TODO(fajin): 1> use SIMD, 2> set block to quant_block_size * thread_block_size
-            // TODO(fajin): process 2 elements at a time
-            for (; n < n_end; ++n, ++output_idx, ++quant_param_idx_t) {
-              // TODO(fajin): perf difference
+            auto zp_idx_t = zp_idx;
+            auto output_idx_end = output_idx + N;
+
+            // leading unaligned output
+            if (output_idx & 1) {
               auto zp = zero_point
-                            ? static_cast<int32_t>(zero_point[quant_param_idx_t >> 1].GetElem(quant_param_idx_t & 1))
+                            ? static_cast<int32_t>(zero_point[zp_idx_t >> 1].GetElem(zp_idx_t & 1))
                             : 0;
-              auto sc = scale[quant_param_idx_t].ToFloat();
-              auto v = std::clamp(static_cast<int32_t>(std::nearbyint(input[output_idx].ToFloat() / sc)) + zp,
-                                  low, high);
-              output[output_idx >> 1].SetElem(output_idx & 1, static_cast<typename TOut::UnpackedType>(v));
+              auto sc = scale[zp_idx_t].ToFloat();
+              auto v = std::clamp(
+                  static_cast<int32_t>(std::nearbyint(input[output_idx].ToFloat() / sc)) + zp, low, high);
+              output[output_idx >> 1].SetElem(1, static_cast<typename TOut::UnpackedType>(v));
+              ++output_idx;
+              ++zp_idx_t;
             }
 
-            if (n == N) {
-              n = 0;
-              ++k;
-              if (k == K) {
-                k = 0;
-                quant_param_idx += N;
-              } else if (k % quant_block_size == 0) {
-                quant_param_idx += N;
-              }
+            // TODO(fajin): use SIMD
+            // aligned output
+            auto output_t = reinterpret_cast<typename TOut::UnpackedType*>(output);
+            for (; output_idx < output_idx_end - 1; output_idx += 2, zp_idx_t += 2) {
+              auto zp0 = zero_point
+                             ? static_cast<int32_t>(zero_point[zp_idx_t >> 1].GetElem(zp_idx_t & 1))
+                             : 0;
+              auto zp1 = zero_point
+                             ? static_cast<int32_t>(zero_point[(zp_idx_t + 1) >> 1].GetElem((zp_idx_t + 1) & 1))
+                             : 0;
+              auto sc0 = scale[zp_idx_t].ToFloat();
+              auto sc1 = scale[zp_idx_t + 1].ToFloat();
+              auto v0 = std::clamp(
+                static_cast<int32_t>(std::nearbyint(input[output_idx].ToFloat() / sc0)) + zp0, low, high);
+              auto v1 = std::clamp(
+                static_cast<int32_t>(std::nearbyint(input[output_idx + 1].ToFloat() / sc1)) + zp1, low, high);
+              output_t = static_cast<typename TOut::UnpackedType>((v0 & 0xF) | ((v1 & 0xF) << 4));
+            }
 
-              quant_param_idx_t = quant_param_idx;
+            // tailing unaligned output
+            if (output_idx < output_idx_end) {
+              auto zp = zero_point
+                            ? static_cast<int32_t>(zero_point[zp_idx_t >> 1].GetElem(zp_idx_t & 1))
+                            : 0;
+              auto sc = scale[zp_idx_t].ToFloat();
+              auto v = std::clamp(
+                static_cast<int32_t>(std::nearbyint(input[output_idx].ToFloat() / sc)) + zp, low, high);
+              output[output_idx >> 1].SetElem(0, static_cast<typename TOut::UnpackedType>(v));
+
+              ++output_idx;
+            }
+
+            ++k;
+            if (k == K) {
+              k = 0;
+              zp_idx += N;
+            } else if (k % quant_block_size == 0) {
+              zp_idx += N;
             }
           }
         });
@@ -749,35 +783,58 @@ struct BlockedQuantizeLinear<MLFloat16, TOut, 2> {
   static void opLastAxis(concurrency::ThreadPool* thread_pool, const MLFloat16* input, const MLFloat16* scale,
                          const TOut* zero_point, TOut* output, std::ptrdiff_t M, std::ptrdiff_t K,
                          const std::ptrdiff_t quant_block_size, bool saturate) {
-    ORT_UNUSED_PARAMETER(saturate);
+                              ORT_UNUSED_PARAMETER(saturate);
     constexpr auto low = static_cast<int32_t>(TOut::min_val);
     constexpr auto high = static_cast<int32_t>(TOut::max_val);
-    // quant block size is used as thread block size
-    const auto num_thread_block_K = (K + quant_block_size - 1) / quant_block_size;
-    const auto num_thread_block = num_thread_block_K * M;
-    const TensorOpCost unit_cost{static_cast<double>(quant_block_size * sizeof(MLFloat16)),
-                                 static_cast<double>(quant_block_size * sizeof(typename TOut::UnpackedType)),
-                                 static_cast<double>(quant_block_size) * 2.0};
+    // to avoid a byte being writen from mutiple threads, use 2 * K as thread block
+    auto size_thread_block = 2 * K;
+    auto quant_block_num_K = (K + quant_block_size - 1) / quant_block_size;
+    auto num_thread_block = (M + 1) / 2;
+    TensorOpCost unit_cost{static_cast<double>(size_thread_block * sizeof(float)),
+                           static_cast<double>(size_thread_block * sizeof(typename TOut ::UnpackedType)),
+                           static_cast<double>(size_thread_block) * 2.0};
     concurrency::ThreadPool::TryParallelFor(
         thread_pool,
         num_thread_block,
         unit_cost,
         [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
-          auto m = begin / num_thread_block_K, k_blk = begin % num_thread_block_K, k = k_blk * quant_block_size;
-          auto output_idx = m * K + k;
+          begin <<= 1, end = std::min(end << 1, M);
+          auto output_idx = begin * K;
+          auto zp_idx = begin * quant_block_num_K;
 
-          for (; begin < end; ++begin) {
-            // each thread block is also a quantization block
-            auto zp = zero_point ? static_cast<int32_t>(zero_point[begin >> 1].GetElem(begin & 1)) : 0;
-            auto sc = scale[begin].ToFloat();
-            auto output_idx_end = std::min(K - k, quant_block_size) + output_idx;
-            for (; output_idx < output_idx_end; ++output_idx) {
-              auto v = std::clamp(static_cast<int32_t>(std::nearbyint(input[output_idx].ToFloat() / sc)) + zp,
-                                  low, high);
-              output[output_idx >> 1].SetElem(output_idx & 1, static_cast<typename TOut::UnpackedType>(v));
+          for (; begin < end; ++begin, output_idx += K) {
+            auto output_row_idx_start = output_idx;
+            auto output_row_idx_end = output_row_idx_start + K;
+
+            for (; output_row_idx_start < output_row_idx_end; output_row_idx_start += quant_block_size, ++zp_idx) {
+              auto zp = zero_point ? static_cast<int32_t>(zero_point[zp_idx >> 1].GetElem(zp_idx & 1)) : 0;
+              auto sc = scale[zp_idx].ToFloat();
+              size_t out_start = output_row_idx_start;
+              size_t out_end = std::min(output_row_idx_start + quant_block_size, output_row_idx_end);
+
+              if (out_start & 1) {
+                auto v = std::clamp(
+                  static_cast<int32_t>(std::nearbyint(input[out_start].ToFloat() / sc)) + zp, low, high);
+                output[out_start >> 1].SetElem(1, static_cast<typename TOut::UnpackedType>(v));
+                ++out_start;
+              }
+
+              if (out_end & 1) {
+                --out_end;
+                auto v = std::clamp(
+                  static_cast<int32_t>(std::nearbyint(input[out_end].ToFloat() / sc)) + zp, low, high);
+                output[out_end >> 1].SetElem(0, static_cast<typename TOut::UnpackedType>(v));
+              }
+
+              auto output_t = reinterpret_cast<typename TOut::UnpackedType*>(output);
+              for (out_start; out_start < out_end; out_start += 2) {
+                auto v0 = std::clamp(
+                  static_cast<int32_t>(std::nearbyint(input[out_start].ToFloat() / sc)) + zp, low, high);
+                auto v1 = std::clamp(
+                  static_cast<int32_t>(std::nearbyint(input[out_start + 1].ToFloat() / sc)) + zp, low, high);
+                output_t[out_start >> 1] = static_cast<typename TOut::UnpackedType>((v0 & 0xF) | ((v1 & 0xF) << 4));
+              }
             }
-
-            k = output_idx % K;
           }
         });
   }

--- a/onnxruntime/core/util/qmath.h
+++ b/onnxruntime/core/util/qmath.h
@@ -545,6 +545,8 @@ struct BlockedQuantizeLinear<MLFloat16, TOut, 0> {
   }
 };
 
+// Bug(fajin): the same byte in output / zero_point must not be written by different threads, otherwise
+// the result is undefined. This is not handled in the current implementation.
 template <typename TOut>
 struct BlockedQuantizeLinear<float, TOut, 2> {
   static void opNotLastAxis(concurrency::ThreadPool* thread_pool, const float* input, const float* scale,
@@ -657,6 +659,8 @@ struct BlockedQuantizeLinear<float, TOut, 2> {
   }
 };
 
+// Bug(fajin): the same byte in output / zero_point must not be written by different threads, otherwise
+// the result is undefined. This is not handled in the current implementation.
 template <typename TOut>
 struct BlockedQuantizeLinear<MLFloat16, TOut, 2> {
   static void opNotLastAxis(concurrency::ThreadPool* thread_pool, const MLFloat16* input, const MLFloat16* scale,

--- a/onnxruntime/core/util/qmath.h
+++ b/onnxruntime/core/util/qmath.h
@@ -827,7 +827,7 @@ struct BlockedQuantizeLinear<MLFloat16, TOut, 2> {
               }
 
               auto output_t = reinterpret_cast<typename TOut::UnpackedType*>(output);
-              for (out_start; out_start < out_end; out_start += 2) {
+              for (; out_start < out_end; out_start += 2) {
                 auto v0 = std::clamp(
                     static_cast<int32_t>(std::nearbyint(input[out_start].ToFloat() / sc)) + zp, low, high);
                 auto v1 = std::clamp(

--- a/onnxruntime/python/onnxruntime_pybind_quant.cc
+++ b/onnxruntime/python/onnxruntime_pybind_quant.cc
@@ -67,6 +67,37 @@ void QuantizeMatMul4BitsBlockwise(
 }
 
 template <typename T>
+void QuantizeQDQMatMul4BitsBlockwise(
+    py::array_t<uint8_t> dst,          // shape: [K, N / 2]
+    py::array_t<T> src,                // shape: [K, N]
+    py::array_t<T> scale,              // shape: [block_per_K, N]
+    py::array_t<uint8_t> zero_points,  // shape: [block_per_K, N / 2]
+    int32_t quant_block_size,
+    int32_t N,
+    int32_t K,
+    bool is_symmetric) {
+  OrtThreadPoolParams to;
+  auto tp = concurrency::CreateThreadPool(&onnxruntime::Env::Default(), to,
+                                          concurrency::ThreadPoolType::INTRA_OP);
+
+  py::buffer_info dst_buf = dst.request();
+  py::buffer_info src_buf = src.request();
+  py::buffer_info scale_buf = scale.request();
+  py::buffer_info zp_buf = zero_points.request();
+
+  MlasQDQQuantizeBlockwise<T, 4>(
+      reinterpret_cast<const T*>(src_buf.ptr),
+      reinterpret_cast<T*>(scale_buf.ptr),
+      is_symmetric ? nullptr : reinterpret_cast<uint8_t*>(zp_buf.ptr),
+      reinterpret_cast<uint8_t*>(dst_buf.ptr),
+      true,
+      K,
+      N,
+      quant_block_size,
+      tp.get());
+}
+
+template <typename T>
 void QuantizeMatMulBnb4Blockwise(
     py::array_t<uint8_t> dst,
     py::array_t<T> src,
@@ -99,6 +130,8 @@ void CreateQuantPybindModule(py::module& m) {
   m.def("quantize_matmul_4bits", &QuantizeMatMul4BitsBlockwise<MLFloat16>);
   m.def("quantize_matmul_bnb4", &QuantizeMatMulBnb4Blockwise<float>);
   m.def("quantize_matmul_bnb4", &QuantizeMatMulBnb4Blockwise<MLFloat16>);
+  m.def("quantize_qdq_matmul_4bits", &QuantizeQDQMatMul4BitsBlockwise<float>);
+  m.def("quantize_qdq_matmul_4bits", &QuantizeQDQMatMul4BitsBlockwise<MLFloat16>);
 }
 
 }  // namespace python

--- a/onnxruntime/test/mlas/bench/bench_q4dq.cpp
+++ b/onnxruntime/test/mlas/bench/bench_q4dq.cpp
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "mlas_q4.h"
+#include "bench_util.h"
+#include "core/util/thread_utils.h"
+
+#include <stdexcept>
+#include <numeric>
+
+static void BM_QDQBlockwiseQuantizer_QuantizeColumnwise(benchmark::State& state) {
+  int M = state.range(0);
+  int N = state.range(1);
+  int quant_block_size = state.range(2);
+  int threads = state.range(3);
+  size_t scale_size = (M + quant_block_size - 1) / quant_block_size * N;
+
+  auto src = RandomVectorUniform(M * N, -16.0f, 14.0f);
+  auto scales = std::vector<float>(scale_size);
+  auto zero_points = std::vector<uint8_t>((scale_size + 1) / 2);
+  auto dst = std::vector<uint8_t>((M * N + 1) / 2);
+
+  OrtThreadPoolParams tpo;
+  tpo.thread_pool_size = static_cast<int>(threads);
+  tpo.auto_set_affinity = true;
+  std::unique_ptr<onnxruntime::concurrency::ThreadPool> tp(
+      onnxruntime::concurrency::CreateThreadPool(&onnxruntime::Env::Default(),
+                                                 tpo, onnxruntime::concurrency::ThreadPoolType::INTRA_OP));
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(dst.data());
+    MlasQDQQuantizeBlockwise<float, 4>(
+        src.data(), scales.data(), zero_points.data(), dst.data(),
+        true, M, N, quant_block_size, tp.get());
+    benchmark::ClobberMemory();
+  }
+}
+
+static void BM_QDQBlockwiseQuantizer_TransposeColumnwise(benchmark::State& state) {
+  int M = state.range(0);
+  int N = state.range(1);
+  int quant_block_size = state.range(2);
+  int threads = state.range(3);
+  int quant_num_M = (M + quant_block_size - 1) / quant_block_size;
+  int blob_size = (quant_block_size + 1) / 2;
+  size_t scale_size = quant_num_M * N;
+
+  auto scales = RandomVectorUniform<float>(scale_size, -16.0f, 14.0f);
+  auto zero_points = RandomVectorUniform<uint8_t>(static_cast<size_t>((scale_size + 1) / 2), 0, 255);
+  auto dst = RandomVectorUniform<uint8_t>(static_cast<size_t>((M * N + 1) / 2), 0, 255);
+  auto scales_T = std::vector<float>(scale_size);
+  auto zero_points_T = std::vector<uint8_t>(((quant_num_M + 1) / 2) * N);
+  auto dst_T = std::vector<uint8_t>(quant_num_M * blob_size * N);
+
+  OrtThreadPoolParams tpo;
+  tpo.thread_pool_size = static_cast<int>(threads);
+  tpo.auto_set_affinity = true;
+  std::unique_ptr<onnxruntime::concurrency::ThreadPool> tp(
+      onnxruntime::concurrency::CreateThreadPool(&onnxruntime::Env::Default(),
+                                                 tpo, onnxruntime::concurrency::ThreadPoolType::INTRA_OP));
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(dst.data());
+    MlasQDQTransposeBlockwiseQuantized<float, 4>(
+        dst.data(), scales.data(), zero_points.data(), dst_T.data(), scales_T.data(), zero_points_T.data(),
+        true, M, N, quant_block_size, tp.get());
+    benchmark::ClobberMemory();
+  }
+}
+
+BENCHMARK_CAPTURE(BM_QDQBlockwiseQuantizer_QuantizeColumnwise)
+    ->UseRealTime()
+    ->Apply([](benchmark::internal::Benchmark* b) {
+      b->ArgNames({"M", "N", "quant_block_size", "threads"});
+      b->ArgsProduct({{1024, 4096}, {4096}, {64, 128}, {8}});
+    });
+
+BENCHMARK_CAPTURE(BM_QDQBlockwiseQuantizer_TransposeColumnwise)
+    ->UseRealTime()
+    ->Apply([](benchmark::internal::Benchmark* b) {
+      b->ArgNames({"M", "N", "quant_block_size", "threads"});
+      b->ArgsProduct({{1024, 4096}, {4096}, {64, 128}, {8}});
+    });

--- a/onnxruntime/test/mlas/bench/bench_q4dq.cpp
+++ b/onnxruntime/test/mlas/bench/bench_q4dq.cpp
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "mlas_q4.h"
-#include "bench_util.h"
-#include "core/util/thread_utils.h"
-
 #include <stdexcept>
 #include <numeric>
+
+#include "core/mlas/inc/mlas_q4.h"
+#include "test/mlas/bench/bench_util.h"
+#include "core/util/thread_utils.h"
 
 static void BM_QDQBlockwiseQuantizer_QuantizeColumnwise(benchmark::State& state) {
   int M = state.range(0);

--- a/onnxruntime/test/mlas/bench/bench_q4dq.cpp
+++ b/onnxruntime/test/mlas/bench/bench_q4dq.cpp
@@ -72,12 +72,12 @@ BENCHMARK_CAPTURE(BM_QDQBlockwiseQuantizer_QuantizeColumnwise)
     ->UseRealTime()
     ->Apply([](benchmark::internal::Benchmark* b) {
       b->ArgNames({"M", "N", "quant_block_size", "threads"});
-      b->ArgsProduct({{1024, 4096}, {4096}, {64, 128}, {8}});
+      b->ArgsProduct({{1024, 4096}, {4096, 4095}, {64, 128}, {8}});
     });
 
 BENCHMARK_CAPTURE(BM_QDQBlockwiseQuantizer_TransposeColumnwise)
     ->UseRealTime()
     ->Apply([](benchmark::internal::Benchmark* b) {
       b->ArgNames({"M", "N", "quant_block_size", "threads"});
-      b->ArgsProduct({{1024, 4096}, {4096}, {64, 128}, {8}});
+      b->ArgsProduct({{1024, 4096}, {4096, 4095}, {64, 128}, {8}});
     });

--- a/onnxruntime/test/mlas/unittest/test_blockq4.cpp
+++ b/onnxruntime/test/mlas/unittest/test_blockq4.cpp
@@ -39,15 +39,8 @@ class MlasBlockwiseQdqTest : public MlasTestBase {
   void Test(int rows, int columns, int block_size, bool columnwise, bool symmetric) {
     float* dequant_buf = FpBuf.GetBuffer(rows * columns, true);
     float* transposed = FpBuf2.GetBuffer(rows * columns, true);
-    size_t weight_size = (rows * columns + 1) / 2;
     size_t scale_size = (rows + block_size - 1) / block_size * columns;
     size_t zp_size = (scale_size + 1) / 2;
-    uint8_t* qdq_weights = QDQOutputElements.GetBuffer(weight_size, true);
-    float* qdq_scales = QDQOutputScales.GetBuffer(scale_size);
-    uint8_t* qdq_zp = symmetric ? nullptr : QDQOutputOffsets.GetBuffer(zp_size, true);
-    uint8_t* qdq_weights_T = QDQTransposedOutputElements.GetBuffer(weight_size, true);
-    float* qdq_scales_T = QDQTransposedOutputScales.GetBuffer(scale_size);
-    uint8_t* qdq_zp_T = symmetric ? nullptr : QDQTransposedOutputOffsets.GetBuffer(zp_size, true);
 
     MLAS_THREADPOOL* threadpool_ptr = GetMlasThreadPool();
 
@@ -64,6 +57,8 @@ class MlasBlockwiseQdqTest : public MlasTestBase {
                                       q_data_size_in_bytes, q_scale_size, &q_zp_size_in_bytes);
 
     uint8_t* elements = InputElements.GetBuffer(q_data_size_in_bytes, true);
+    uint8_t* qdq_weights = QDQOutputElements.GetBuffer((rows * columns + 1) / 2, true);
+    uint8_t* qdq_weights_T = QDQTransposedOutputElements.GetBuffer(q_data_size_in_bytes, true);
 
     int v = 7;
     for (int c = 0; c < columns; c++) {
@@ -90,7 +85,11 @@ class MlasBlockwiseQdqTest : public MlasTestBase {
     }
 
     float* scales = InputScales.GetBuffer(q_scale_size);
+    float* qdq_scales = QDQOutputScales.GetBuffer(scale_size);
+    float* qdq_scales_T = QDQTransposedOutputScales.GetBuffer(q_scale_size);
     uint8_t* zp = symmetric ? nullptr : InputOffsets.GetBuffer(q_zp_size_in_bytes, true);
+    uint8_t* qdq_zp = symmetric ? nullptr : QDQOutputOffsets.GetBuffer(zp_size, true);
+    uint8_t* qdq_zp_T = symmetric ? nullptr : QDQTransposedOutputOffsets.GetBuffer(q_zp_size_in_bytes, true);
     if (zp) {
       for (int c = 0; c < meta_cols; c++) {
         for (int r = 0; r < meta_rows; r += 2) {

--- a/onnxruntime/test/mlas/unittest/test_blockq4.cpp
+++ b/onnxruntime/test/mlas/unittest/test_blockq4.cpp
@@ -29,10 +29,25 @@ class MlasBlockwiseQdqTest : public MlasTestBase {
   MatrixGuardBuffer<uint8_t> OutputElements;
   MatrixGuardBuffer<float> OutputScales;
   MatrixGuardBuffer<uint8_t> OutputOffsets;
+  MatrixGuardBuffer<uint8_t> QDQOutputElements;
+  MatrixGuardBuffer<float> QDQOutputScales;
+  MatrixGuardBuffer<uint8_t> QDQOutputOffsets;
+  MatrixGuardBuffer<uint8_t> QDQTransposedOutputElements;
+  MatrixGuardBuffer<float> QDQTransposedOutputScales;
+  MatrixGuardBuffer<uint8_t> QDQTransposedOutputOffsets;
 
   void Test(int rows, int columns, int block_size, bool columnwise, bool symmetric) {
     float* dequant_buf = FpBuf.GetBuffer(rows * columns, true);
     float* transposed = FpBuf2.GetBuffer(rows * columns, true);
+    size_t weight_size = (rows * columns + 1) / 2;
+    size_t scale_size = (rows + block_size - 1) / block_size * columns;
+    size_t zp_size = (scale_size + 1) / 2;
+    uint8_t* qdq_weights = QDQOutputElements.GetBuffer(weight_size, true);
+    float* qdq_scales = QDQOutputScales.GetBuffer(scale_size);
+    uint8_t* qdq_zp = symmetric ? nullptr : QDQOutputOffsets.GetBuffer(zp_size, true);
+    uint8_t* qdq_weights_T = QDQTransposedOutputElements.GetBuffer(weight_size, true);
+    float* qdq_scales_T = QDQTransposedOutputScales.GetBuffer(scale_size);
+    uint8_t* qdq_zp_T = symmetric ? nullptr : QDQTransposedOutputOffsets.GetBuffer(zp_size, true);
 
     MLAS_THREADPOOL* threadpool_ptr = GetMlasThreadPool();
 
@@ -112,16 +127,37 @@ class MlasBlockwiseQdqTest : public MlasTestBase {
     MlasQuantizeBlockwise<float, 4>(o_elements, o_scales, o_zp, transposed, block_size,
                                     columnwise, rows, columns, columns, threadpool_ptr);
 
+    if (columnwise) {
+      MlasQDQQuantizeBlockwise<float, 4>(
+          transposed, qdq_scales, qdq_zp, qdq_weights,
+          true, rows, columns, block_size, threadpool_ptr);
+
+      MlasQDQTransposeBlockwiseQuantized<float, 4>(
+          qdq_weights, qdq_scales, qdq_zp, qdq_weights_T, qdq_scales_T, qdq_zp_T,
+          true, rows, columns, block_size, threadpool_ptr);
+    }
+
     for (int c = 0; c < columns; c++) {
       for (int r = 0; r < rows; r += 2) {
         int idx = c * q_rows + r / 2;
         ASSERT_EQ(o_elements[idx] & 0xf, elements[idx] & 0xf)
             << ", index=[" << r << "x" << c << "], shape=[" << rows << "x" << columns
             << "] block: " << block_size << ", symmetric: " << symmetric << ", columnwise: " << columnwise;
+        if (columnwise) {
+          ASSERT_EQ(qdq_weights_T[idx] & 0xf, elements[idx] & 0xf)
+              << ", index=[" << r << "x" << c << "], shape=[" << rows << "x" << columns
+              << "] block: " << block_size << ", symmetric: " << symmetric << ", columnwise: " << columnwise;
+        }
+
         if (r + 1 < rows) {
           ASSERT_EQ(o_elements[idx] >> 4, elements[idx] >> 4)
               << ", index=[" << r + 1 << "x" << c << "], shape=[" << rows << "x" << columns
               << "] block: " << block_size << ", symmetric: " << symmetric << ", columnwise: " << columnwise;
+          if (columnwise) {
+            ASSERT_EQ(qdq_weights_T[idx] >> 4, elements[idx] >> 4)
+                << ", index=[" << r + 1 << "x" << c << "], shape=[" << rows << "x" << columns
+                << "] block: " << block_size << ", symmetric: " << symmetric << ", columnwise: " << columnwise;
+          }
         }
       }
     }
@@ -132,6 +168,12 @@ class MlasBlockwiseQdqTest : public MlasTestBase {
         ASSERT_EQ(o_scales[idx], scales[idx])
             << ", index=" << r << "x" << c << ", shape=[" << rows << "x" << columns
             << "] block: " << block_size << ", symmetric: " << symmetric << ", columnwise: " << columnwise;
+
+        if (columnwise) {
+          ASSERT_EQ(qdq_scales_T[idx], scales[idx])
+              << ", index=" << r << "x" << c << ", shape=[" << rows << "x" << columns
+              << "] block: " << block_size << ", symmetric: " << symmetric << ", columnwise: " << columnwise;
+        }
       }
     }
 
@@ -142,10 +184,20 @@ class MlasBlockwiseQdqTest : public MlasTestBase {
         ASSERT_EQ(o_zp[idx] & 0xf, zp[idx] & 0xf)
             << ", index=" << r << "x" << c << ", shape=[" << rows << "x" << columns
             << "] block: " << block_size << ", symmetric: " << symmetric << ", columnwise: " << columnwise;
+        if (columnwise) {
+          ASSERT_EQ(qdq_zp_T[idx] & 0xf, zp[idx] & 0xf)
+              << ", index=" << r << "x" << c << ", shape=[" << rows << "x" << columns
+              << "] block: " << block_size << ", symmetric: " << symmetric << ", columnwise: " << columnwise;
+        }
         if (r + 1 < meta_rows) {
           ASSERT_EQ(o_zp[idx] >> 4, zp[idx] >> 4)
               << ", index=" << r + 1 << "x" << c << ", shape=[" << rows << "x" << columns
               << "] block: " << block_size << ", symmetric: " << symmetric << ", columnwise: " << columnwise;
+          if (columnwise) {
+            ASSERT_EQ(qdq_zp_T[idx] >> 4, zp[idx] >> 4)
+                << ", index=" << r + 1 << "x" << c << ", shape=[" << rows << "x" << columns
+                << "] block: " << block_size << ", symmetric: " << symmetric << ", columnwise: " << columnwise;
+          }
         }
       }
     }


### PR DESCRIPTION
### Description

1. added kernel to quantize matmul B tensor to q4, and store in the same shape as original tensor. scales and zero points are calculated as well. scales and zero points have the same shape.
2. added kernel to transpose q4 B tensor to B tensor in MatMulNBits. Scales and zero points are transposed as well.

####
Benchmark
<1024 x 4096 input, 64 quant block, 8 threads>: 
 - quantize: 23035923 ns
 - transpose: 718635 ns

<1024 x 4095 input, 64 quant block, 8 threads>: 
 - quantize: 26759319 ns
 - transpose: 1279064 ns

### Motivation and Context
The MatMulNbits tool chain current only supports converting a MatMul op direct to MatMulNBits op. MatMulNbits op is not an ONNX standard op.
Therefore, we need the tool chain to support converting MatMul to Q/DQ format, and later in the transform step converts DQ + MatMul to MatMulNBits. The tensors stored in DQ are the quantized constants and will be stored in the MatMulNBits.

