### PR TITLE
Add UseDotNET to Nuget Packaging jobs

### DIFF
--- a/tools/ci_build/github/azure-pipelines/stages/nuget-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nuget-cuda-packaging-stage.yml
@@ -58,6 +58,10 @@ stages:
             ArtifactName: 'onnxruntime-linux-x64-tensorrt'
             TargetPath: '$(Build.BinariesDirectory)/nuget-artifact'
 
+        - task: UseDotNet@2
+          inputs:
+            version: 6.x
+
         # Reconstruct the build dir
         - task: PowerShell@2
           displayName: 'PS: Extract nuget files gpu'

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -364,6 +364,9 @@ stages:
       workingDirectory: '$(Build.BinariesDirectory)/nuget-artifact'
       displayName: 'List artifacts'
 
+    - task: UseDotNet@2
+      inputs:
+        version: 6.x
     # Reconstruct the build dir
     - task: PowerShell@2
       displayName: 'Extract native libraries for addition to nuget native package'


### PR DESCRIPTION
### Description
Recently I updated the VM images and installed .Net 8.0 there.  Then I got the following error message when running the Nuget pipeline:

`##[error]C:\Program Files\dotnet\sdk\8.0.300\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.EolTargetFrameworks.targets(38,5): Error NETSDK1202: The workload 'net6.0-android' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/maui-support-policy for more information about the support policy.`

So, add UseDotNET  there to temporarily revert the .Net SDK version back to 6.0. (7.0 is EOL)


### Motivation and Context
Related: #20415 



