### PR TITLE
[js/webgpu] Prefer adapter.info to adapter.requestAdapterInfo

### DIFF
--- a/js/web/lib/wasm/jsep/backend-webgpu.ts
+++ b/js/web/lib/wasm/jsep/backend-webgpu.ts
@@ -233,7 +233,7 @@ export class WebGpuBackend {
     }
 
     this.device = await adapter.requestDevice(deviceDescriptor);
-    this.adapterInfo = new AdapterInfoImpl(await adapter.requestAdapterInfo());
+    this.adapterInfo = new AdapterInfoImpl(adapter.info || await adapter.requestAdapterInfo());
     this.gpuDataManager = createGpuDataManager(this);
     this.programManager = new ProgramManager(this);
     this.kernels = new Map();

--- a/js/web/package-lock.json
+++ b/js/web/package-lock.json
@@ -25,7 +25,7 @@
         "@types/minimatch": "^5.1.2",
         "@types/minimist": "^1.2.2",
         "@types/platform": "^1.3.4",
-        "@webgpu/types": "^0.1.38",
+        "@webgpu/types": "^0.1.42",
         "base64-js": "^1.5.1",
         "chai": "^4.3.7",
         "electron": "^28.1.4",
@@ -46,14 +46,6 @@
         "numpy-parser": "^1.2.3",
         "source-map": "^0.7.4",
         "strip-json-comments": "^5.0.0"
-      }
-    },
-    "../common": {
-      "name": "onnxruntime-common",
-      "version": "1.19.0",
-      "license": "MIT",
-      "devDependencies": {
-        "typedoc": "^0.25.7"
       }
     },
     "node_modules/@chiragrupani/karma-chromium-edge-launcher": {
@@ -324,9 +316,9 @@
       }
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.38",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.38.tgz",
-      "integrity": "sha512-7LrhVKz2PRh+DD7+S+PVaFd5HxaWQvoMqBbsV9fNJO1pjUs1P8bM2vQVNfk+3URTqbuTI7gkXi0rfsN0IadoBA==",
+      "version": "0.1.42",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.42.tgz",
+      "integrity": "sha512-uvJtt4OD1Vjdebrrz3kNLgpOicYbikwnM8WPG6YD2lkCOHDtPdEtCINJFIFtbOCtPfA8SreR/vKyUNbAt92IwQ==",
       "dev": true
     },
     "node_modules/accepts": {
@@ -2534,8 +2526,9 @@
       }
     },
     "node_modules/onnxruntime-common": {
-      "resolved": "../common",
-      "link": true
+      "version": "1.19.0",
+      "resolved": "file:../common",
+      "license": "MIT"
     },
     "node_modules/p-cancelable": {
       "version": "2.1.1",
@@ -3774,9 +3767,9 @@
       }
     },
     "@webgpu/types": {
-      "version": "0.1.38",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.38.tgz",
-      "integrity": "sha512-7LrhVKz2PRh+DD7+S+PVaFd5HxaWQvoMqBbsV9fNJO1pjUs1P8bM2vQVNfk+3URTqbuTI7gkXi0rfsN0IadoBA==",
+      "version": "0.1.42",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.42.tgz",
+      "integrity": "sha512-uvJtt4OD1Vjdebrrz3kNLgpOicYbikwnM8WPG6YD2lkCOHDtPdEtCINJFIFtbOCtPfA8SreR/vKyUNbAt92IwQ==",
       "dev": true
     },
     "accepts": {
@@ -5520,10 +5513,7 @@
       }
     },
     "onnxruntime-common": {
-      "version": "file:../common",
-      "requires": {
-        "typedoc": "^0.25.7"
-      }
+      "version": "1.19.0"
     },
     "p-cancelable": {
       "version": "2.1.1",

--- a/js/web/package-lock.json
+++ b/js/web/package-lock.json
@@ -48,6 +48,14 @@
         "strip-json-comments": "^5.0.0"
       }
     },
+    "../common": {
+      "name": "onnxruntime-common",
+      "version": "1.19.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typedoc": "^0.25.7"
+      }
+    },
     "node_modules/@chiragrupani/karma-chromium-edge-launcher": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@chiragrupani/karma-chromium-edge-launcher/-/karma-chromium-edge-launcher-2.2.2.tgz",
@@ -319,7 +327,8 @@
       "version": "0.1.42",
       "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.42.tgz",
       "integrity": "sha512-uvJtt4OD1Vjdebrrz3kNLgpOicYbikwnM8WPG6YD2lkCOHDtPdEtCINJFIFtbOCtPfA8SreR/vKyUNbAt92IwQ==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -2526,9 +2535,8 @@
       }
     },
     "node_modules/onnxruntime-common": {
-      "version": "1.19.0",
-      "resolved": "file:../common",
-      "license": "MIT"
+      "resolved": "../common",
+      "link": true
     },
     "node_modules/p-cancelable": {
       "version": "2.1.1",
@@ -5513,7 +5521,10 @@
       }
     },
     "onnxruntime-common": {
-      "version": "1.19.0"
+      "version": "file:../common",
+      "requires": {
+        "typedoc": "^0.25.7"
+      }
     },
     "p-cancelable": {
       "version": "2.1.1",

--- a/js/web/package.json
+++ b/js/web/package.json
@@ -43,7 +43,7 @@
     "@types/minimatch": "^5.1.2",
     "@types/minimist": "^1.2.2",
     "@types/platform": "^1.3.4",
-    "@webgpu/types": "^0.1.38",
+    "@webgpu/types": "^0.1.42",
     "base64-js": "^1.5.1",
     "chai": "^4.3.7",
     "electron": "^28.1.4",


### PR DESCRIPTION
WebGPU is deprecating async adapter.requestAdapterInfo, and replacing it with sync adapter.info.
Spec change: https://github.com/gpuweb/gpuweb/pull/4662