### PR TITLE
[js/web] skip default locateFile() when dynamic import is disabled

### DIFF
--- a/js/web/lib/backend-wasm.ts
+++ b/js/web/lib/backend-wasm.ts
@@ -54,9 +54,11 @@ export const initializeFlags = (): void => {
     }
   }
 
-  // overwrite wasm paths override if not set
-  if (env.wasm.wasmPaths === undefined && scriptSrc && scriptSrc.indexOf('blob:') !== 0) {
-    env.wasm.wasmPaths = scriptSrc.substring(0, scriptSrc.lastIndexOf('/') + 1);
+  if (!BUILD_DEFS.DISABLE_DYNAMIC_IMPORT) {
+    // overwrite wasm paths override if not set
+    if (env.wasm.wasmPaths === undefined && scriptSrc && scriptSrc.indexOf('blob:') !== 0) {
+      env.wasm.wasmPaths = scriptSrc.substring(0, scriptSrc.lastIndexOf('/') + 1);
+    }
   }
 };
 

--- a/js/web/lib/wasm/wasm-factory.ts
+++ b/js/web/lib/wasm/wasm-factory.ts
@@ -133,13 +133,17 @@ export const initializeWebAssembly = async(flags: Env.WebAssemblyFlags): Promise
        * created.
        */
       numThreads,
+    };
+
+    if (wasmPathOverride || wasmPrefixOverride) {
       /**
        * A callback function to locate the WebAssembly file. The function should return the full path of the file.
        *
        * Since Emscripten 3.1.58, this function is only called for the .wasm file.
        */
-      locateFile: (fileName, scriptDirectory) => wasmPathOverride ?? (wasmPrefixOverride ?? scriptDirectory) + fileName
-    };
+      config.locateFile = (fileName, scriptDirectory) =>
+          wasmPathOverride ?? (wasmPrefixOverride ?? scriptDirectory) + fileName;
+    }
 
     ortWasmFactory(config).then(
         // wasm module initialized successfully


### PR DESCRIPTION
### Description
skip default `locateFile()` when dynamic import is disabled. This allows the file to work with bundlers to load WebAssembly file correctly if `env.wasm.wasmPaths` is not set.

