### PR TITLE
[MIGraphX EP] enable compilation and execution on Windows (#36)

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1474,9 +1474,6 @@ if (onnxruntime_USE_CUDA)
 endif()
 
 if (onnxruntime_USE_MIGRAPHX)
-  if (WIN32)
-    message(FATAL_ERROR "MIGraphX does not support build in Windows!")
-  endif()
   set(AMD_MIGRAPHX_HOME ${onnxruntime_MIGRAPHX_HOME})
 endif()
 

--- a/cmake/onnxruntime_providers_migraphx.cmake
+++ b/cmake/onnxruntime_providers_migraphx.cmake
@@ -19,23 +19,25 @@
   endif()
 
   # Add search paths for default rocm installation
-  list(APPEND CMAKE_PREFIX_PATH /opt/rocm/hcc /opt/rocm/hip /opt/rocm)
+  list(APPEND CMAKE_PREFIX_PATH /opt/rocm/hcc /opt/rocm/hip /opt/rocm $ENV{HIP_PATH})
 
-  find_package(hip)
-  find_package(migraphx PATHS ${AMD_MIGRAPHX_HOME})
+  # Suppress the warning about the small capitals of the package name
+  cmake_policy(SET CMP0144 NEW)
 
-  find_package(miopen)
-  find_package(rocblas)
+  if(WIN32 AND NOT HIP_PLATFORM)
+    set(HIP_PLATFORM "amd")
+  endif()
 
-  set(migraphx_libs migraphx::c hip::host MIOpen roc::rocblas)
+  find_package(hip REQUIRED)
+  find_package(migraphx REQUIRED PATHS ${AMD_MIGRAPHX_HOME})
+
+  set(migraphx_libs migraphx::c hip::host)
 
   file(GLOB_RECURSE onnxruntime_providers_migraphx_cc_srcs CONFIGURE_DEPENDS
     "${ONNXRUNTIME_ROOT}/core/providers/migraphx/*.h"
     "${ONNXRUNTIME_ROOT}/core/providers/migraphx/*.cc"
     "${ONNXRUNTIME_ROOT}/core/providers/shared_library/*.h"
     "${ONNXRUNTIME_ROOT}/core/providers/shared_library/*.cc"
-    "${ONNXRUNTIME_ROOT}/core/providers/rocm/rocm_stream_handle.h"
-    "${ONNXRUNTIME_ROOT}/core/providers/rocm/rocm_stream_handle.cc"
   )
   source_group(TREE ${ONNXRUNTIME_ROOT}/core FILES ${onnxruntime_providers_migraphx_cc_srcs})
   onnxruntime_add_shared_library_module(onnxruntime_providers_migraphx ${onnxruntime_providers_migraphx_cc_srcs})
@@ -46,18 +48,16 @@
   set_target_properties(onnxruntime_providers_migraphx PROPERTIES LINKER_LANGUAGE CXX)
   set_target_properties(onnxruntime_providers_migraphx PROPERTIES FOLDER "ONNXRuntime")
   target_compile_definitions(onnxruntime_providers_migraphx PRIVATE ONNXIFI_BUILD_LIBRARY=1)
-  target_compile_options(onnxruntime_providers_migraphx PRIVATE -Wno-error=sign-compare)
-  set_property(TARGET onnxruntime_providers_migraphx APPEND_STRING PROPERTY COMPILE_FLAGS "-Wno-deprecated-declarations")
-  set_property(TARGET onnxruntime_providers_migraphx APPEND_STRING PROPERTY LINK_FLAGS "-Xlinker --version-script=${ONNXRUNTIME_ROOT}/core/providers/migraphx/version_script.lds -Xlinker --gc-sections")
-  target_link_libraries(onnxruntime_providers_migraphx PRIVATE nsync::nsync_cpp)
-
-  include(CheckLibraryExists)
-  check_library_exists(migraphx::c "migraphx_program_run_async" "/opt/rocm/migraphx/lib" HAS_STREAM_SYNC)
-  if(HAS_STREAM_SYNC)
-      target_compile_definitions(onnxruntime_providers_migraphx PRIVATE -DMIGRAPHX_STREAM_SYNC)
-      message(STATUS "MIGRAPHX GPU STREAM SYNC is ENABLED")
+  if(MSVC)
+    set_property(TARGET onnxruntime_providers_migraphx APPEND_STRING PROPERTY LINK_FLAGS /DEF:${ONNXRUNTIME_ROOT}/core/providers/migraphx/symbols.def)
+    target_link_libraries(onnxruntime_providers_migraphx PRIVATE ws2_32)
   else()
-      message(STATUS "MIGRAPHX GPU STREAM SYNC is DISABLED")
+    target_compile_options(onnxruntime_providers_migraphx PRIVATE -Wno-error=sign-compare)
+    set_property(TARGET onnxruntime_providers_migraphx APPEND_STRING PROPERTY COMPILE_FLAGS "-Wno-deprecated-declarations")
+  endif()
+  if(UNIX)
+    set_property(TARGET onnxruntime_providers_migraphx APPEND_STRING PROPERTY LINK_FLAGS "-Xlinker --version-script=${ONNXRUNTIME_ROOT}/core/providers/migraphx/version_script.lds -Xlinker --gc-sections")
+    target_link_libraries(onnxruntime_providers_migraphx PRIVATE nsync::nsync_cpp stdc++fs)
   endif()
 
   if (onnxruntime_ENABLE_TRAINING_OPS)
@@ -68,8 +68,16 @@
     endif()
   endif()
 
-  install(TARGETS onnxruntime_providers_migraphx
-          ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR}
-          LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}
-          RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR}
-  )
+  if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    install(TARGETS onnxruntime_providers_migraphx
+            ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            LIBRARY  DESTINATION ${CMAKE_INSTALL_BINDIR}
+            RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+  else()
+    install(TARGETS onnxruntime_providers_migraphx
+            ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+  endif()

--- a/onnxruntime/core/providers/migraphx/gpu_data_transfer.cc
+++ b/onnxruntime/core/providers/migraphx/gpu_data_transfer.cc
@@ -60,17 +60,7 @@ common::Status GPUDataTransfer::CopyTensorAsync(const Tensor& src, Tensor& dst, 
       HIP_CALL_THROW(hipMemcpy(dst_data, src_data, bytes, hipMemcpyHostToDevice));
     }
   } else if (src_device.Type() == OrtDevice::GPU) {
-#ifndef MIGRAPHX_STREAM_SYNC
-    if (dst_device.Type() == OrtDevice::CPU && dst_device.MemType() == OrtDevice::MemType::HIP_PINNED) {
-      // copying from GPU to pinned memory, this is non-blocking
-      HIP_CALL_THROW(hipMemcpyAsync(dst_data, src_data, bytes, hipMemcpyDeviceToHost, static_cast<hipStream_t>(stream.GetHandle())));
-    } else {
-      // copying from GPU to CPU memory, this is blocking
-      HIP_CALL_THROW(hipMemcpy(dst_data, src_data, bytes, hipMemcpyDeviceToHost));
-    }
-#else
     HIP_CALL_THROW(hipMemcpyAsync(dst_data, src_data, bytes, hipMemcpyDeviceToHost, static_cast<hipStream_t>(stream.GetHandle())));
-#endif
   } else {
     // copying between cpu memory
     memcpy(dst_data, src_data, bytes);

--- a/onnxruntime/core/providers/migraphx/migraphx_allocator.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_allocator.cc
@@ -3,7 +3,7 @@
 
 #include "core/providers/shared_library/provider_api.h"
 #include "migraphx_call.h"
-#include "hip_allocator.h"
+#include "migraphx_allocator.h"
 #include "core/common/status.h"
 #include "core/framework/float16.h"
 #include "core/common/status.h"
@@ -11,7 +11,7 @@
 
 namespace onnxruntime {
 
-void HIPAllocator::CheckDevice() const {
+void MIGraphXAllocator::CheckDevice() const {
 #ifndef NDEBUG
   // check device to match at debug build
   // if it's expected to change, call hipSetDevice instead of the check
@@ -23,7 +23,7 @@ void HIPAllocator::CheckDevice() const {
 #endif
 }
 
-void* HIPAllocator::Alloc(size_t size) {
+void* MIGraphXAllocator::Alloc(size_t size) {
   CheckDevice();
   void* p = nullptr;
   if (size > 0) {
@@ -32,12 +32,12 @@ void* HIPAllocator::Alloc(size_t size) {
   return p;
 }
 
-void HIPAllocator::Free(void* p) {
+void MIGraphXAllocator::Free(void* p) {
   CheckDevice();
   (void)hipFree(p);  // do not throw error since it's OK for hipFree to fail during shutdown
 }
 
-void* HIPExternalAllocator::Alloc(size_t size) {
+void* MIGraphXExternalAllocator::Alloc(size_t size) {
   void* p = nullptr;
   if (size > 0) {
     p = alloc_(size);
@@ -49,7 +49,7 @@ void* HIPExternalAllocator::Alloc(size_t size) {
   return p;
 }
 
-void HIPExternalAllocator::Free(void* p) {
+void MIGraphXExternalAllocator::Free(void* p) {
   free_(p);
   std::lock_guard<OrtMutex> lock(lock_);
   auto it = reserved_.find(p);
@@ -59,7 +59,7 @@ void HIPExternalAllocator::Free(void* p) {
   }
 }
 
-void* HIPExternalAllocator::Reserve(size_t size) {
+void* MIGraphXExternalAllocator::Reserve(size_t size) {
   void* p = Alloc(size);
   if (!p) return nullptr;
   std::lock_guard<OrtMutex> lock(lock_);

--- a/onnxruntime/core/providers/migraphx/migraphx_allocator.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_allocator.h
@@ -9,12 +9,12 @@
 
 namespace onnxruntime {
 
-class HIPAllocator : public IAllocator {
+class MIGraphXAllocator : public IAllocator {
  public:
-  HIPAllocator(int device_id, const char* name)
+  MIGraphXAllocator(int device_id, const char* name)
       : IAllocator(
             OrtMemoryInfo(name, OrtAllocatorType::OrtDeviceAllocator,
-                          OrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT, device_id),
+                          OrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT, static_cast<OrtDevice::DeviceId>(device_id)),
                           device_id, OrtMemTypeDefault)) {}
 
   virtual void* Alloc(size_t size) override;
@@ -24,14 +24,14 @@ class HIPAllocator : public IAllocator {
   void CheckDevice() const;
 };
 
-class HIPExternalAllocator : public HIPAllocator {
+class MIGraphXExternalAllocator : public MIGraphXAllocator {
   typedef void* (*ExternalAlloc)(size_t size);
   typedef void (*ExternalFree)(void* p);
   typedef void (*ExternalEmptyCache)();
 
  public:
-  HIPExternalAllocator(OrtDevice::DeviceId device_id, const char* name, void* alloc, void* free, void* empty_cache)
-      : HIPAllocator(device_id, name) {
+  MIGraphXExternalAllocator(OrtDevice::DeviceId device_id, const char* name, void* alloc, void* free, void* empty_cache)
+      : MIGraphXAllocator(device_id, name) {
     alloc_ = reinterpret_cast<ExternalAlloc>(alloc);
     free_ = reinterpret_cast<ExternalFree>(free);
     empty_cache_ = reinterpret_cast<ExternalEmptyCache>(empty_cache);
@@ -55,7 +55,7 @@ class HIPPinnedAllocator : public IAllocator {
   HIPPinnedAllocator(int device_id, const char* name)
       : IAllocator(
             OrtMemoryInfo(name, OrtAllocatorType::OrtDeviceAllocator,
-                          OrtDevice(OrtDevice::CPU, OrtDevice::MemType::HIP_PINNED, device_id),
+                          OrtDevice(OrtDevice::CPU, OrtDevice::MemType::HIP_PINNED, static_cast<OrtDevice::DeviceId>(device_id)),
                           device_id, OrtMemTypeCPUOutput)) {}
 
   virtual void* Alloc(size_t size) override;

--- a/onnxruntime/core/providers/migraphx/migraphx_call.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_call.h
@@ -4,8 +4,6 @@
 #pragma once
 #include "migraphx_inc.h"
 
-#pragma once
-
 namespace onnxruntime {
 
 // -----------------------------------------------------------------------

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.h
@@ -14,7 +14,7 @@ namespace onnxruntime {
 // Information needed to construct trt execution providers.
 struct MIGraphXExecutionProviderInfo {
   std::string target_device;
-  int device_id{0};
+  OrtDevice::DeviceId device_id{0};
   bool fp16_enable{false};
   bool int8_enable{false};
   std::string int8_calibration_table_name{""};

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_utils.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_utils.h
@@ -28,7 +28,7 @@ bool IsGraphInput(const GraphViewer& graph, const std::string& name) {
   return (std::find(input_names.begin(), input_names.end(), name) != input_names.end());
 }
 
-bool IsGraphInitializer(const GraphViewer& graph, const std::string& name, bool check_outer_scope = true) {
+bool IsGraphInitializer(const GraphViewer& graph, const std::string& name, [[maybe_unused]] bool check_outer_scope = true) {
   const ONNX_NAMESPACE::TensorProto* initializer = nullptr;
   return graph.GetInitializedTensor(name, initializer);
 }

--- a/onnxruntime/core/providers/migraphx/migraphx_inc.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_inc.h
@@ -4,5 +4,5 @@
 #pragma once
 
 #include <hip/hip_runtime.h>
-#include <migraphx/migraphx.h>
+#include <iso646.h>
 #include <migraphx/migraphx.hpp>

--- a/onnxruntime/core/providers/migraphx/migraphx_provider_factory.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_provider_factory.h
@@ -10,4 +10,13 @@ struct IExecutionProviderFactory;
 struct MIGraphXExecutionProviderInfo;
 enum class ArenaExtendStrategy : int32_t;
 struct MIGraphXExecutionProviderExternalAllocatorInfo;
+
+struct ProviderInfo_MIGraphX {
+  virtual std::unique_ptr<onnxruntime::IAllocator> CreateMIGraphXAllocator(int16_t device_id, const char* name) = 0;
+  virtual std::unique_ptr<onnxruntime::IAllocator> CreateMIGraphXPinnedAllocator(int16_t device_id, const char* name) = 0;
+
+ protected:
+  ~ProviderInfo_MIGraphX() = default;  // Can only be destroyed through a subclass instance
+};
+
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/migraphx/migraphx_stream_handle.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_stream_handle.cc
@@ -1,0 +1,171 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <core/providers/rocm/rocm_resource.h>
+#include "migraphx_stream_handle.h"
+
+namespace onnxruntime {
+
+struct MIGraphXNotification : public synchronize::Notification {
+  MIGraphXNotification(Stream& s) : Notification(s) {
+    HIP_CALL_THROW(hipEventCreateWithFlags(&event_, hipEventDisableTiming));
+  }
+
+  ~MIGraphXNotification() {
+    if (event_)
+      HIP_CALL_THROW(hipEventDestroy(event_));
+  }
+
+  void Activate() override {
+    // record event with hipEventBlockingSync so we can support sync on host without busy wait.
+    HIP_CALL_THROW(hipEventRecord(event_, static_cast<hipStream_t>(stream_.GetHandle())));
+  }
+
+  void wait_on_device(Stream& device_stream) {
+    ORT_ENFORCE(device_stream.GetDevice().Type() == OrtDevice::GPU, "Unexpected device:", device_stream.GetDevice().ToString());
+    // launch a wait command to the migraphx stream
+    HIP_CALL_THROW(hipStreamWaitEvent(static_cast<hipStream_t>(device_stream.GetHandle()), event_, 0));
+  };
+
+  void wait_on_host() {
+    // CUDA_CALL_THROW(cudaStreamSynchronize(stream_));
+    HIP_CALL_THROW(hipEventSynchronize(event_));
+  }
+
+  hipEvent_t event_;
+};
+
+MIGraphXStream::MIGraphXStream(hipStream_t stream,
+                               const OrtDevice& device,
+                               AllocatorPtr cpu_allocator,
+                               bool release_cpu_buffer_on_migraphx_stream)
+    : Stream(stream, device),
+      cpu_allocator_(cpu_allocator),
+      release_cpu_buffer_on_migraphx_stream_(release_cpu_buffer_on_migraphx_stream) {
+}
+
+MIGraphXStream::~MIGraphXStream() {
+  ORT_IGNORE_RETURN_VALUE(CleanUpOnRunEnd());
+  if (own_stream_) {
+    auto* handle = GetHandle();
+    if (handle)
+      HIP_CALL_THROW(hipStreamDestroy(static_cast<hipStream_t>(handle)));
+  }
+}
+
+std::unique_ptr<synchronize::Notification> MIGraphXStream::CreateNotification(size_t /*num_consumers*/) {
+  return std::make_unique<MIGraphXNotification>(*this);
+}
+
+void MIGraphXStream::Flush() {
+  if (own_stream_)
+    HIP_CALL_THROW(hipStreamSynchronize(static_cast<hipStream_t>(GetHandle())));
+}
+
+void MIGraphXStream::EnqueDeferredCPUBuffer(void* cpu_buffer) {
+  // stream is per thread, so don't need lock
+  deferred_cpu_buffers_.push_back(cpu_buffer);
+}
+
+struct CpuBuffersInfo {
+  // This struct stores the information needed
+  // to release CPU buffers allocated for GPU kernels.
+  // It's used to enqueue their release after
+  // associated GPU kernels in a MIGraphX stream.
+
+  // This is a CPU allocator in MIGraphX EP.
+  // It must be the one used to allocate the
+  // following pointers.
+  AllocatorPtr allocator;
+  // buffers[i] is the i-th pointer added by
+  // AddDeferredReleaseCPUPtr for a specific
+  // MIGraphX stream. For example, this fields
+  // should contain all values in
+  // deferred_release_buffer_pool_[my_stream]
+  // when release my_stream's buffers.
+  std::unique_ptr<void*[]> buffers;
+  // CPU buffer buffers[i].
+  // Number of buffer points in "buffers".
+  size_t n_buffers;
+};
+
+static void ReleaseCpuBufferCallback(void* raw_info) {
+  std::unique_ptr<CpuBuffersInfo> info = std::make_unique<CpuBuffersInfo>();
+  info.reset(reinterpret_cast<CpuBuffersInfo*>(raw_info));
+  for (size_t i = 0; i < info->n_buffers; ++i) {
+    info->allocator->Free(info->buffers[i]);
+  }
+}
+
+Status MIGraphXStream::CleanUpOnRunEnd() {
+  if (deferred_cpu_buffers_.empty())
+    return Status::OK();
+  // Release the ownership of cpu_buffers_info so that the underlying
+  // object will keep alive until the end of ReleaseCpuBufferCallback.
+  if (release_cpu_buffer_on_migraphx_stream_ && cpu_allocator_->Info().alloc_type == OrtArenaAllocator) {
+    std::unique_ptr<CpuBuffersInfo> cpu_buffers_info = std::make_unique<CpuBuffersInfo>();
+    cpu_buffers_info->allocator = cpu_allocator_;
+    cpu_buffers_info->buffers = std::make_unique<void*[]>(deferred_cpu_buffers_.size());
+    for (size_t i = 0; i < deferred_cpu_buffers_.size(); ++i) {
+      cpu_buffers_info->buffers[i] = deferred_cpu_buffers_.at(i);
+    }
+    cpu_buffers_info->n_buffers = deferred_cpu_buffers_.size();
+    HIP_RETURN_IF_ERROR(hipLaunchHostFunc(static_cast<hipStream_t>(GetHandle()), ReleaseCpuBufferCallback, cpu_buffers_info.release()));
+  } else {
+    HIP_RETURN_IF_ERROR(hipStreamSynchronize(static_cast<hipStream_t>(GetHandle())));
+    for (auto* buffer : deferred_cpu_buffers_) {
+      cpu_allocator_->Free(buffer);
+    }
+  }
+
+  deferred_cpu_buffers_.clear();
+  return Status::OK();
+}
+
+void* MIGraphXStream::GetResource(int version, int id) const {
+  ORT_ENFORCE(version <= ORT_ROCM_RESOUCE_VERSION, "resource version unsupported!");
+  void* resource{};
+  switch (id) {
+    case RocmResource::hip_stream_t:
+      return reinterpret_cast<void*>(GetHandle());
+    default:
+      break;
+  }
+  return resource;
+}
+
+// CPU Stream command handles
+void WaitMIGraphXNotificationOnDevice(Stream& stream, synchronize::Notification& notification) {
+  static_cast<MIGraphXNotification*>(&notification)->wait_on_device(stream);
+}
+
+void WaitMIGraphXNotificationOnHost(Stream& /*stream*/, synchronize::Notification& notification) {
+  static_cast<MIGraphXNotification*>(&notification)->wait_on_host();
+}
+
+void RegisterMIGraphXStreamHandles(IStreamCommandHandleRegistry& stream_handle_registry,
+                                   const OrtDevice::DeviceType device_type,
+                                   AllocatorPtr cpu_allocator,
+                                   bool release_cpu_buffer_on_migraphx_stream,
+                                   hipStream_t external_stream,
+                                   bool use_existing_stream) {
+  // wait migraphx notification on migraphx ep
+  stream_handle_registry.RegisterWaitFn(device_type, device_type, WaitMIGraphXNotificationOnDevice);
+  // wait migraphx notification on cpu ep
+  stream_handle_registry.RegisterWaitFn(device_type, OrtDevice::CPU, WaitMIGraphXNotificationOnHost);
+  if (!use_existing_stream)
+    stream_handle_registry.RegisterCreateStreamFn(device_type, [cpu_allocator, release_cpu_buffer_on_migraphx_stream](const OrtDevice& device) {
+      HIP_CALL_THROW(hipSetDevice(device.Id()));
+      hipStream_t stream = nullptr;
+      HIP_CALL_THROW(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
+      return std::make_unique<MIGraphXStream>(stream, device, cpu_allocator, release_cpu_buffer_on_migraphx_stream);
+    });
+  else
+    stream_handle_registry.RegisterCreateStreamFn(device_type, [cpu_allocator,
+                                                                release_cpu_buffer_on_migraphx_stream,
+                                                                external_stream](const OrtDevice& device) {
+      return std::make_unique<MIGraphXStream>(external_stream, device, cpu_allocator, release_cpu_buffer_on_migraphx_stream);
+    });
+}
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/migraphx/migraphx_stream_handle.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_stream_handle.h
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#include "core/framework/stream_handles.h"
+#include "migraphx_inc.h"
+#include "migraphx_call.h"
+
+#define HIP_RETURN_IF_ERROR(expr) ORT_RETURN_IF_ERROR(HIP_CALL(expr))
+
+namespace onnxruntime {
+void WaitMIGraphXNotificationOnDevice(Stream& stream, synchronize::Notification& notification);
+
+struct MIGraphXStream : Stream {
+  MIGraphXStream(hipStream_t stream,
+                 const OrtDevice& device,
+                 AllocatorPtr cpu_allocator,
+                 bool release_cpu_buffer_on_migraphx_stream);
+
+  ~MIGraphXStream();
+
+  std::unique_ptr<synchronize::Notification> CreateNotification(size_t /*num_consumers*/) override;
+
+  void Flush() override;
+
+  Status CleanUpOnRunEnd() override;
+
+  void EnqueDeferredCPUBuffer(void* cpu_buffer);
+
+  bool own_stream_{true};
+
+  virtual void* GetResource(int version, int id) const;
+
+  virtual WaitNotificationFn GetWaitNotificationFn() const { return WaitMIGraphXNotificationOnDevice; }
+
+ private:
+  std::vector<void*> deferred_cpu_buffers_;
+  AllocatorPtr cpu_allocator_;
+  bool release_cpu_buffer_on_migraphx_stream_{true};
+};
+
+void RegisterMIGraphXStreamHandles(IStreamCommandHandleRegistry& stream_handle_registry,
+                                   const OrtDevice::DeviceType device_type,
+                                   AllocatorPtr cpu_allocator,
+                                   bool release_cpu_buffer_on_migraphx_stream,
+                                   hipStream_t external_stream,
+                                   bool use_existing_stream);
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/shared_library/provider_api.h
+++ b/onnxruntime/core/providers/shared_library/provider_api.h
@@ -279,6 +279,9 @@ std::unique_ptr<IAllocator> CreateCPUAllocator(const OrtMemoryInfo& memory_info)
 std::unique_ptr<IAllocator> CreateCUDAAllocator(int16_t device_id, const char* name);
 std::unique_ptr<IAllocator> CreateCUDAPinnedAllocator(const char* name);
 
+std::unique_ptr<IAllocator> CreateMIGraphXAllocator(int16_t device_id, const char* name);
+std::unique_ptr<IAllocator> CreateMIGraphXPinnedAllocator(int16_t device_id, const char* name);
+
 std::unique_ptr<IAllocator> CreateROCMAllocator(int16_t device_id, const char* name);
 std::unique_ptr<IAllocator> CreateROCMPinnedAllocator(const char* name);
 

--- a/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
+++ b/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
@@ -353,16 +353,12 @@ std::unique_ptr<IDataTransfer> CreateGPUDataTransfer() {
 #endif
 
 #ifdef USE_MIGRAPHX
-std::unique_ptr<IAllocator> CreateROCMAllocator(int16_t device_id, const char* name) {
-  return g_host->CreateROCMAllocator(device_id, name);
+std::unique_ptr<IAllocator> CreateMIGraphXAllocator(int16_t device_id, const char* name) {
+  return g_host->CreateMIGraphXAllocator(device_id, name);
 }
 
-std::unique_ptr<IAllocator> CreateROCMPinnedAllocator(const char* name) {
-  return g_host->CreateROCMPinnedAllocator(name);
-}
-
-std::unique_ptr<IDataTransfer> CreateGPUDataTransfer() {
-  return g_host->CreateGPUDataTransfer();
+std::unique_ptr<IAllocator> CreateMIGraphXPinnedAllocator(int16_t device_id, const char* name) {
+  return g_host->CreateMIGraphXPinnedAllocator(device_id, name);
 }
 #endif
 

--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -178,6 +178,11 @@ struct ProviderHost {
   virtual void CudaCall_true(int retCode, const char* exprString, const char* libName, int successCode, const char* msg, const char* file, const int line) = 0;
 #endif
 
+#ifdef USE_MIGRAPHX
+  virtual std::unique_ptr<IAllocator> CreateMIGraphXAllocator(int16_t device_id, const char* name) = 0;
+  virtual std::unique_ptr<IAllocator> CreateMIGraphXPinnedAllocator(int16_t device_id, const char* name) = 0;
+#endif
+
 #ifdef USE_ROCM
   virtual std::unique_ptr<IAllocator> CreateROCMAllocator(int16_t device_id, const char* name) = 0;
   virtual std::unique_ptr<IAllocator> CreateROCMPinnedAllocator(const char* name) = 0;

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ wheel_name_suffix = parse_arg_remove_string(sys.argv, "--wheel_name_suffix=")
 
 cuda_version = None
 rocm_version = None
+is_migraphx = False
 is_rocm = False
 is_openvino = False
 # The following arguments are mutually exclusive
@@ -64,8 +65,9 @@ if wheel_name_suffix == "gpu":
     cuda_version = parse_arg_remove_string(sys.argv, "--cuda_version=")
 elif parse_arg_remove_boolean(sys.argv, "--use_rocm"):
     is_rocm = True
-    package_name = "onnxruntime-rocm" if not nightly_build else "ort-rocm-nightly"
     rocm_version = parse_arg_remove_string(sys.argv, "--rocm_version=")
+elif parse_arg_remove_boolean(sys.argv, "--use_migraphx"):
+    is_migraphx = True
 elif parse_arg_remove_boolean(sys.argv, "--use_openvino"):
     is_openvino = True
     package_name = "onnxruntime-openvino"
@@ -86,6 +88,9 @@ elif parse_arg_remove_boolean(sys.argv, "--use_azure"):
     pass
 elif parse_arg_remove_boolean(sys.argv, "--use_qnn"):
     package_name = "onnxruntime-qnn"
+
+if is_rocm or is_migraphx:
+    package_name = "onnxruntime-rocm" if not nightly_build else "ort-rocm-nightly"
 
 # PEP 513 defined manylinux1_x86_64 and manylinux1_i686
 # PEP 571 defined manylinux2010_x86_64 and manylinux2010_i686
@@ -280,10 +285,21 @@ class InstallCommand(InstallCommandBase):
         return ret
 
 
-providers_cuda_or_rocm = "libonnxruntime_providers_" + ("rocm.so" if is_rocm else "cuda.so")
-providers_tensorrt_or_migraphx = "libonnxruntime_providers_" + ("migraphx.so" if is_rocm else "tensorrt.so")
-providers_openvino = "libonnxruntime_providers_openvino.so"
-providers_cann = "libonnxruntime_providers_cann.so"
+providers_cuda_or_rocm = "onnxruntime_providers_" + ("rocm" if is_rocm else "cuda")
+providers_tensorrt_or_migraphx = "onnxruntime_providers_" + ("migraphx" if is_migraphx else "tensorrt")
+providers_openvino = "onnxruntime_providers_openvino"
+providers_cann = "onnxruntime_providers_cann"
+
+if platform.system() == "Linux":
+    providers_cuda_or_rocm = "lib" + providers_cuda_or_rocm + ".so"
+    providers_tensorrt_or_migraphx = "lib" + providers_tensorrt_or_migraphx + ".so"
+    providers_openvino = "lib" + providers_openvino + ".so"
+    providers_cann = "lib" + providers_cann + ".so"
+elif platform.system() == "Windows":
+    providers_cuda_or_rocm = providers_cuda_or_rocm + ".dll"
+    providers_tensorrt_or_migraphx = providers_tensorrt_or_migraphx + ".dll"
+    providers_openvino = providers_openvino + ".dll"
+    providers_cann = providers_cann + ".dll"
 
 # Additional binaries
 dl_libs = []
@@ -297,19 +313,22 @@ if platform.system() == "Linux":
         "libmklml_gnu.so",
         "libiomp5.so",
         "mimalloc.so",
+        # DNNL, TensorRT & OpenVINO EPs are built as shared libs
+        "libonnxruntime_providers_shared.so",
+        "libonnxruntime_providers_dnnl.so",
+        "libonnxruntime_providers_openvino.so",
+        "libonnxruntime_providers_vitisai.so",
+        providers_cuda_or_rocm,
+        providers_tensorrt_or_migraphx,
+        providers_cann,
     ]
-    dl_libs = ["libonnxruntime_providers_shared.so"]
-    dl_libs.append(providers_cuda_or_rocm)
-    dl_libs.append(providers_tensorrt_or_migraphx)
-    dl_libs.append(providers_cann)
-    # DNNL, TensorRT & OpenVINO EPs are built as shared libs
-    libs.extend(["libonnxruntime_providers_shared.so"])
-    libs.extend(["libonnxruntime_providers_dnnl.so"])
-    libs.extend(["libonnxruntime_providers_openvino.so"])
-    libs.extend(["libonnxruntime_providers_vitisai.so"])
-    libs.append(providers_cuda_or_rocm)
-    libs.append(providers_tensorrt_or_migraphx)
-    libs.append(providers_cann)
+    dl_libs = [
+        "libonnxruntime_providers_shared.so",
+        providers_cuda_or_rocm,
+        providers_tensorrt_or_migraphx,
+        providers_cann,
+    ]
+
     if nightly_build:
         libs.extend(["libonnxruntime_pywrapper.so"])
 elif platform.system() == "Darwin":
@@ -323,7 +342,15 @@ elif platform.system() == "Darwin":
     if nightly_build:
         libs.extend(["libonnxruntime_pywrapper.dylib"])
 else:
-    libs = ["onnxruntime_pybind11_state.pyd", "dnnl.dll", "mklml.dll", "libiomp5md.dll"]
+    libs = [
+        "onnxruntime_pybind11_state.pyd",
+        "dnnl.dll",
+        "mklml.dll",
+        "libiomp5md.dll",
+        providers_cuda_or_rocm,
+        providers_tensorrt_or_migraphx,
+        providers_cann,
+    ]
     # DNNL, TensorRT & OpenVINO EPs are built as shared libs
     libs.extend(["onnxruntime_providers_shared.dll"])
     libs.extend(["onnxruntime_providers_dnnl.dll"])

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -612,6 +612,7 @@ def parse_arguments():
             "MinGW Makefiles",
             "Ninja",
             "NMake Makefiles",
+            "NMake Makefiles JOM",
             "Unix Makefiles",
             "Visual Studio 17 2022",
             "Xcode",
@@ -2207,6 +2208,7 @@ def build_python_wheel(
     use_cuda,
     cuda_version,
     use_rocm,
+    use_migraphx,
     rocm_version,
     use_dnnl,
     use_tensorrt,
@@ -2258,6 +2260,8 @@ def build_python_wheel(
             args.append("--use_rocm")
             if rocm_version:
                 args.append(f"--rocm_version={rocm_version}")
+        elif use_migraphx:
+            args.append("--use_migraphx")
         elif use_openvino:
             args.append("--use_openvino")
         elif use_dnnl:
@@ -2583,9 +2587,6 @@ def main():
     if args.use_tensorrt:
         args.use_cuda = True
 
-    if args.use_migraphx:
-        args.use_rocm = True
-
     if args.build_wheel or args.gen_doc or args.use_tvm or args.enable_training:
         args.enable_pybind = True
 
@@ -2872,7 +2873,8 @@ def main():
     # fail unexpectedly. Similar, if your packaging step forgot to copy a file into the package, we don't know it
     # either.
     if args.build:
-        # TODO: find asan DLL and copy it to onnxruntime/capi folder when args.enable_address_sanitizer is True and the target OS is Windows
+        # TODO: find asan DLL and copy it to onnxruntime/capi folder when args.enable_address_sanitizer is True and
+        #  the target OS is Windows
         if args.build_wheel:
             nightly_build = bool(os.getenv("NIGHTLY_BUILD") == "1")
             default_training_package_device = bool(os.getenv("DEFAULT_TRAINING_PACKAGE_DEVICE") == "1")
@@ -2883,6 +2885,7 @@ def main():
                 args.use_cuda,
                 args.cuda_version,
                 args.use_rocm,
+                args.use_migraphx,
                 args.rocm_version,
                 args.use_dnnl,
                 args.use_tensorrt,


### PR DESCRIPTION
* enable MIGraphX EP on Windows

* [MIGraphX EP] Fix provider options

* fix formatting

* unify the package name for both rocm and migraphx

* fix compilation after moving to rocm6.2

* make STREAM_SYNC the default

* workaround hip sdk bug on windows

* Revert rename of private var for now

---------

### Description
<!-- Describe your changes. -->
Adds Windows compile for the MIGraphX EP


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Allows for additional OS support for MIGraphX Execution provider.

