### PR TITLE
Fix Crash When Enabling and Disabling ETW with Old Callbacks

### DIFF
--- a/onnxruntime/core/framework/execution_providers.h
+++ b/onnxruntime/core/framework/execution_providers.h
@@ -24,10 +24,6 @@ namespace onnxruntime {
 Class for managing lookup of the execution providers in a session.
 */
 class ExecutionProviders {
-#ifdef _WIN32
-  WindowsTelemetry::EtwInternalCallback etw_callback_;
-#endif
-
  public:
   ExecutionProviders() {
 #ifdef _WIN32
@@ -170,5 +166,9 @@ class ExecutionProviders {
   // Whether the CPU provider was implicitly added to a session for fallback (true),
   // or whether it was explicitly added by the caller.
   bool cpu_execution_provider_was_implicitly_added_ = false;
-};  // namespace onnxruntime
+
+#ifdef _WIN32
+  WindowsTelemetry::EtwInternalCallback etw_callback_;
+#endif
+};
 }  // namespace onnxruntime

--- a/onnxruntime/core/framework/execution_providers.h
+++ b/onnxruntime/core/framework/execution_providers.h
@@ -48,7 +48,7 @@ class ExecutionProviders {
     LogProviderOptions(provider_id, providerOptions, false);
 
     // Register callback for ETW capture state (rundown)
-    WindowsTelemetry::RegisterInternalCallback(
+    auto callback_MLORT_provider = std::make_shared<onnxruntime::WindowsTelemetry::EtwInternalCallback>(
         [this](
             LPCGUID SourceId,
             ULONG IsEnabled,
@@ -79,6 +79,7 @@ class ExecutionProviders {
             }
           }
         });
+    WindowsTelemetry::RegisterInternalCallback(callback_MLORT_provider);
 #endif
 
     exec_provider_ids_.push_back(provider_id);

--- a/onnxruntime/core/platform/windows/logging/etw_sink.h
+++ b/onnxruntime/core/platform/windows/logging/etw_sink.h
@@ -69,9 +69,9 @@ class EtwRegistrationManager {
   // Get the ETW registration status
   HRESULT Status() const;
 
-  void RegisterInternalCallback(std::shared_ptr<EtwInternalCallback> callback);
+  void RegisterInternalCallback(const EtwInternalCallback& callback);
 
-  void UnregisterInternalCallback(std::shared_ptr<EtwInternalCallback> callback);
+  void UnregisterInternalCallback(const EtwInternalCallback& callback);
 
  private:
   EtwRegistrationManager();
@@ -92,7 +92,7 @@ class EtwRegistrationManager {
       _In_opt_ PEVENT_FILTER_DESCRIPTOR FilterData,
       _In_opt_ PVOID CallbackContext);
 
-  std::vector<std::shared_ptr<EtwInternalCallback>> callbacks_;
+  std::vector<const EtwInternalCallback*> callbacks_;
   OrtMutex callbacks_mutex_;
   mutable OrtMutex provider_change_mutex_;
   OrtMutex init_mutex_;

--- a/onnxruntime/core/platform/windows/logging/etw_sink.h
+++ b/onnxruntime/core/platform/windows/logging/etw_sink.h
@@ -69,7 +69,9 @@ class EtwRegistrationManager {
   // Get the ETW registration status
   HRESULT Status() const;
 
-  void RegisterInternalCallback(const EtwInternalCallback& callback);
+  void RegisterInternalCallback(std::shared_ptr<EtwInternalCallback> callback);
+
+  void UnregisterInternalCallback(std::shared_ptr<EtwInternalCallback> callback);
 
  private:
   EtwRegistrationManager();
@@ -90,7 +92,7 @@ class EtwRegistrationManager {
       _In_opt_ PEVENT_FILTER_DESCRIPTOR FilterData,
       _In_opt_ PVOID CallbackContext);
 
-  std::vector<EtwInternalCallback> callbacks_;
+  std::vector<std::shared_ptr<EtwInternalCallback>> callbacks_;
   OrtMutex callbacks_mutex_;
   mutable OrtMutex provider_change_mutex_;
   OrtMutex init_mutex_;

--- a/onnxruntime/core/platform/windows/telemetry.cc
+++ b/onnxruntime/core/platform/windows/telemetry.cc
@@ -64,7 +64,7 @@ bool WindowsTelemetry::enabled_ = true;
 uint32_t WindowsTelemetry::projection_ = 0;
 UCHAR WindowsTelemetry::level_ = 0;
 UINT64 WindowsTelemetry::keyword_ = 0;
-std::vector<WindowsTelemetry::EtwInternalCallback> WindowsTelemetry::callbacks_;
+std::vector<std::shared_ptr<WindowsTelemetry::EtwInternalCallback>> WindowsTelemetry::callbacks_;
 OrtMutex WindowsTelemetry::callbacks_mutex_;
 
 WindowsTelemetry::WindowsTelemetry() {
@@ -86,6 +86,9 @@ WindowsTelemetry::~WindowsTelemetry() {
       TraceLoggingUnregister(telemetry_provider_handle);
     }
   }
+
+  std::lock_guard<OrtMutex> lock_callbacks(callbacks_mutex_);
+  callbacks_.clear();
 }
 
 bool WindowsTelemetry::IsEnabled() const {
@@ -107,9 +110,14 @@ UINT64 WindowsTelemetry::Keyword() const {
 //     return etw_status_;
 // }
 
-void WindowsTelemetry::RegisterInternalCallback(const EtwInternalCallback& callback) {
-  std::lock_guard<OrtMutex> lock(callbacks_mutex_);
+void WindowsTelemetry::RegisterInternalCallback(std::shared_ptr<EtwInternalCallback> callback) {
+  std::lock_guard<OrtMutex> lock_callbacks(callbacks_mutex_);
   callbacks_.push_back(callback);
+}
+
+void WindowsTelemetry::UnregisterInternalCallback(std::shared_ptr<EtwInternalCallback> callback) {
+  std::lock_guard<OrtMutex> lock_callbacks(callbacks_mutex_);
+  callbacks_.erase(std::remove(callbacks_.begin(), callbacks_.end(), callback), callbacks_.end());
 }
 
 void NTAPI WindowsTelemetry::ORT_TL_EtwEnableCallback(
@@ -131,9 +139,9 @@ void NTAPI WindowsTelemetry::ORT_TL_EtwEnableCallback(
 void WindowsTelemetry::InvokeCallbacks(LPCGUID SourceId, ULONG IsEnabled, UCHAR Level, ULONGLONG MatchAnyKeyword,
                                        ULONGLONG MatchAllKeyword, PEVENT_FILTER_DESCRIPTOR FilterData,
                                        PVOID CallbackContext) {
-  std::lock_guard<OrtMutex> lock(callbacks_mutex_);
+  std::lock_guard<OrtMutex> lock_callbacks(callbacks_mutex_);
   for (const auto& callback : callbacks_) {
-    callback(SourceId, IsEnabled, Level, MatchAnyKeyword, MatchAllKeyword, FilterData, CallbackContext);
+    (*callback)(SourceId, IsEnabled, Level, MatchAnyKeyword, MatchAllKeyword, FilterData, CallbackContext);
   }
 }
 

--- a/onnxruntime/core/platform/windows/telemetry.h
+++ b/onnxruntime/core/platform/windows/telemetry.h
@@ -64,9 +64,9 @@ class WindowsTelemetry : public Telemetry {
                                                  ULONGLONG MatchAnyKeyword, ULONGLONG MatchAllKeyword,
                                                  PEVENT_FILTER_DESCRIPTOR FilterData, PVOID CallbackContext)>;
 
-  static void RegisterInternalCallback(std::shared_ptr<EtwInternalCallback> callback);
+  static void RegisterInternalCallback(const EtwInternalCallback& callback);
 
-  static void UnregisterInternalCallback(std::shared_ptr<EtwInternalCallback> callback);
+  static void UnregisterInternalCallback(const EtwInternalCallback& callback);
 
  private:
   static OrtMutex mutex_;
@@ -74,7 +74,7 @@ class WindowsTelemetry : public Telemetry {
   static bool enabled_;
   static uint32_t projection_;
 
-  static std::vector<std::shared_ptr<EtwInternalCallback>> callbacks_;
+  static std::vector<const EtwInternalCallback*> callbacks_;
   static OrtMutex callbacks_mutex_;
   static OrtMutex provider_change_mutex_;
   static UCHAR level_;

--- a/onnxruntime/core/platform/windows/telemetry.h
+++ b/onnxruntime/core/platform/windows/telemetry.h
@@ -64,7 +64,9 @@ class WindowsTelemetry : public Telemetry {
                                                  ULONGLONG MatchAnyKeyword, ULONGLONG MatchAllKeyword,
                                                  PEVENT_FILTER_DESCRIPTOR FilterData, PVOID CallbackContext)>;
 
-  static void RegisterInternalCallback(const EtwInternalCallback& callback);
+  static void RegisterInternalCallback(std::shared_ptr<EtwInternalCallback> callback);
+
+  static void UnregisterInternalCallback(std::shared_ptr<EtwInternalCallback> callback);
 
  private:
   static OrtMutex mutex_;
@@ -72,7 +74,7 @@ class WindowsTelemetry : public Telemetry {
   static bool enabled_;
   static uint32_t projection_;
 
-  static std::vector<EtwInternalCallback> callbacks_;
+  static std::vector<std::shared_ptr<EtwInternalCallback>> callbacks_;
   static OrtMutex callbacks_mutex_;
   static OrtMutex provider_change_mutex_;
   static UCHAR level_;

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -233,7 +233,7 @@ QNNExecutionProvider::QNNExecutionProvider(const ProviderOptions& provider_optio
 #ifdef _WIN32
   auto& etwRegistrationManager = logging::EtwRegistrationManager::Instance();
   // Register callback for ETW capture state (rundown)
-  auto callback_ETWSink_provider = std::make_shared<onnxruntime::logging::EtwRegistrationManager::EtwInternalCallback>(
+  callback_ETWSink_provider_ = onnxruntime::logging::EtwRegistrationManager::EtwInternalCallback(
       [&etwRegistrationManager, this](
           LPCGUID SourceId,
           ULONG IsEnabled,
@@ -270,8 +270,7 @@ QNNExecutionProvider::QNNExecutionProvider(const ProviderOptions& provider_optio
           (void)qnn_backend_manager_->ResetQnnLogLevel();
         }
       });
-  etwRegistrationManager.RegisterInternalCallback(callback_ETWSink_provider);
-  this->callback_ETWSinkprovider = callback_ETWSink_provider;
+  etwRegistrationManager.RegisterInternalCallback(callback_ETWSink_provider_);
 #endif
 
   // In case ETW gets disabled later
@@ -402,7 +401,7 @@ QNNExecutionProvider::~QNNExecutionProvider() {
 
   // Unregister the ETW callback
 #ifdef _WIN32
-  logging::EtwRegistrationManager::Instance().UnregisterInternalCallback(callback_ETWSinkprovider);
+  logging::EtwRegistrationManager::Instance().UnregisterInternalCallback(callback_ETWSink_provider_);
 #endif
 }
 

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -233,7 +233,7 @@ QNNExecutionProvider::QNNExecutionProvider(const ProviderOptions& provider_optio
 #ifdef _WIN32
   auto& etwRegistrationManager = logging::EtwRegistrationManager::Instance();
   // Register callback for ETW capture state (rundown)
-  etwRegistrationManager.RegisterInternalCallback(
+  auto callback_ETWSink_provider = std::make_shared<onnxruntime::logging::EtwRegistrationManager::EtwInternalCallback>(
       [&etwRegistrationManager, this](
           LPCGUID SourceId,
           ULONG IsEnabled,
@@ -270,6 +270,8 @@ QNNExecutionProvider::QNNExecutionProvider(const ProviderOptions& provider_optio
           (void)qnn_backend_manager_->ResetQnnLogLevel();
         }
       });
+  etwRegistrationManager.RegisterInternalCallback(callback_ETWSink_provider);
+  this->callback_ETWSinkprovider = callback_ETWSink_provider;
 #endif
 
   // In case ETW gets disabled later
@@ -397,6 +399,11 @@ QNNExecutionProvider::~QNNExecutionProvider() {
     if (!cache) continue;
     ORT_IGNORE_RETURN_VALUE(cache->erase(this));
   }
+
+  // Unregister the ETW callback
+#ifdef _WIN32
+  logging::EtwRegistrationManager::Instance().UnregisterInternalCallback(callback_ETWSinkprovider);
+#endif
 }
 
 bool QNNExecutionProvider::IsNodeSupported(qnn::QnnModelWrapper& qnn_model_wrapper, const NodeUnit& node_unit,

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -90,7 +90,7 @@ class QNNExecutionProvider : public IExecutionProvider {
   uint32_t default_rpc_control_latency_ = 0;
   bool enable_HTP_FP16_precision_ = false;
 #ifdef _WIN32
-  std::shared_ptr<onnxruntime::logging::EtwRegistrationManager::EtwInternalCallback> callback_ETWSinkprovider;
+  onnxruntime::logging::EtwRegistrationManager::EtwInternalCallback callback_ETWSink_provider_;
 #endif
 
   class PerThreadContext final {

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -15,6 +15,9 @@
 #include <vector>
 #include <set>
 #include <unordered_map>
+#ifdef _WIN32
+#include "core/platform/windows/logging/etw_sink.h"
+#endif
 
 namespace onnxruntime {
 
@@ -86,6 +89,9 @@ class QNNExecutionProvider : public IExecutionProvider {
   qnn::HtpPerformanceMode default_htp_performance_mode_ = qnn::HtpPerformanceMode::kHtpDefault;
   uint32_t default_rpc_control_latency_ = 0;
   bool enable_HTP_FP16_precision_ = false;
+#ifdef _WIN32
+  std::shared_ptr<onnxruntime::logging::EtwRegistrationManager::EtwInternalCallback> callback_ETWSinkprovider;
+#endif
 
   class PerThreadContext final {
    public:

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -128,8 +128,8 @@ class InferenceSession {
   static std::map<uint32_t, InferenceSession*> active_sessions_;
 #ifdef _WIN32
   static OrtMutex active_sessions_mutex_;  // Protects access to active_sessions_
-  static std::shared_ptr<onnxruntime::WindowsTelemetry::EtwInternalCallback> callback_ML_ORT_provider;
-  std::shared_ptr<onnxruntime::logging::EtwRegistrationManager::EtwInternalCallback> callback_ETWSinkprovider;
+  static onnxruntime::WindowsTelemetry::EtwInternalCallback callback_ML_ORT_provider_;
+  onnxruntime::logging::EtwRegistrationManager::EtwInternalCallback callback_ETWSink_provider_;
 #endif
 
  public:

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -35,6 +35,10 @@
 #include "core/platform/tracing.h"
 #include <TraceLoggingActivity.h>
 #endif
+#ifdef _WIN32
+#include "core/platform/windows/logging/etw_sink.h"
+#include "core/platform/windows/telemetry.h"
+#endif
 
 namespace ONNX_NAMESPACE {
 class ModelProto;
@@ -124,6 +128,8 @@ class InferenceSession {
   static std::map<uint32_t, InferenceSession*> active_sessions_;
 #ifdef _WIN32
   static OrtMutex active_sessions_mutex_;  // Protects access to active_sessions_
+  static std::shared_ptr<onnxruntime::WindowsTelemetry::EtwInternalCallback> callback_ML_ORT_provider;
+  std::shared_ptr<onnxruntime::logging::EtwRegistrationManager::EtwInternalCallback> callback_ETWSinkprovider;
 #endif
 
  public:


### PR DESCRIPTION
### Description
Under certain conditions with enabling & disabling ETW continuously, we got a crash report.
Allows ETW callbacks to be de-registered upon class destructor.
Related to #20537

### Motivation and Context
Fixes crash

### Callstack
We see it crash in
[0x0]   onnxruntime!<lambda_967a738fca8512372f170fcaf2d094d4>::operator()+0x34   0x12941ff570   0x7ffa994f0a04   

[0x1]   onnxruntime!std::_Func_class<void,_GUID const *,unsigned long,unsigned char,unsigned __int64,unsigned __int64,_EVENT_FILTER_DESCRIPTOR *,void *>::operator()+0x54   0x12941ff7b0   0x7ffa994f0d64   

[0x2]   onnxruntime!onnxruntime::logging::EtwRegistrationManager::InvokeCallbacks+0xcc   0x12941ff7b0   0x7ffa994f0d64   

[0x3]   onnxruntime!onnxruntime::logging::EtwRegistrationManager::ORT_TL_EtwEnableCallback+0x94   0x12941ff860   0x7ffa98d19628   
 

and seems to us that the this pointer captured in 
etwRegistrationManager.RegisterInternalCallback(
      [&etwRegistrationManager, this](
...
is no longer valid when the callback is called.
 
 


