### PR TITLE
Delete RoslynAnalyzers

### DIFF
--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -408,22 +408,6 @@ stages:
         msbuildArguments: '-t:Clean -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=Microsoft.ML.OnnxRuntime.ROCm'
         workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
-    - task: RoslynAnalyzers@2
-      displayName: 'Run Roslyn Analyzers'
-      inputs:
-        userProvideBuildInfo: msBuildInfo
-        msBuildCommandline: >
-          "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe"
-          $(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln
-          -p:configuration="RelWithDebInfo"
-          -p:Platform="Any CPU"
-          -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)"
-          -p:OrtPackageId=Microsoft.ML.OnnxRuntime.ROCm
-          -p:IsLinuxBuild=true
-          -p:IsWindowsBuild=false
-          -p:IsMacOSBuild=false
-      condition: and(succeeded(), eq('${{ parameters.DoCompliance }}', true))
-
     - template: templates/component-governance-component-detection-steps.yml
       parameters :
         condition : 'succeeded'

--- a/tools/ci_build/github/azure-pipelines/stages/nuget-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nuget-cuda-packaging-stage.yml
@@ -193,13 +193,6 @@ stages:
             msbuildArguments: '-t:Clean -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=Microsoft.ML.OnnxRuntime.Gpu'
             workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
-        - task: RoslynAnalyzers@2
-          displayName: 'Run Roslyn Analyzers'
-          inputs:
-            userProvideBuildInfo: msBuildInfo
-            msBuildCommandline: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" $(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln -p:configuration="RelWithDebInfo" -p:Platform="Any CPU" -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=Microsoft.ML.OnnxRuntime.Gpu'
-          condition: and(succeeded(), eq('${{ parameters.DoCompliance }}', true))
-
         - template: ../templates/component-governance-component-detection-steps.yml
           parameters:
             condition: 'succeeded'

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -478,13 +478,6 @@ stages:
         msbuildArguments: '-t:Clean -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=$(OrtPackageId)'
         workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
-    - task: RoslynAnalyzers@2
-      displayName: 'Run Roslyn Analyzers'
-      inputs:
-        userProvideBuildInfo: msBuildInfo
-        msBuildCommandline: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" $(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln -p:configuration="RelWithDebInfo" -p:Platform="Any CPU" -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=$(OrtPackageId)'
-      condition: and(succeeded(), eq('${{ parameters.DoCompliance }}', true))
-
     - template: component-governance-component-detection-steps.yml
       parameters :
         condition : 'succeeded'

--- a/tools/ci_build/github/azure-pipelines/templates/ondevice-training-cpu-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/ondevice-training-cpu-packaging-pipeline.yml
@@ -288,13 +288,6 @@ stages:
         msbuildArguments: '-t:Clean -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=$(OrtPackageId)'
         workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
-    - task: RoslynAnalyzers@2
-      displayName: 'Run Roslyn Analyzers'
-      inputs:
-        userProvideBuildInfo: msBuildInfo
-        msBuildCommandline: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" $(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln -p:configuration="RelWithDebInfo" -p:Platform="Any CPU" -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=$(OrtPackageId)'
-      condition: and(succeeded(), eq('${{ parameters.DoCompliance }}', true))
-
     - template: component-governance-component-detection-steps.yml
       parameters :
         condition : 'succeeded'


### PR DESCRIPTION
### Description
Delete RoslynAnalyzers. Use CodeQL instead.



### Motivation and Context
Now we already have CodeQL which is modern and also covers C# code.  The RoslynAnalyzers one is not in our pull request pipelines.  The "RoslynAnalyzers@2" task is outdated and needs be upgraded. I will delete it for now since we already have CodeQL.
