### PR TITLE
Add UsePythonVersion

### DIFF
--- a/tools/ci_build/github/azure-pipelines/stages/nuget-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nuget-cuda-packaging-stage.yml
@@ -116,6 +116,11 @@ stages:
             DisplayName: 'ESRP - Sign C# dlls'
             DoEsrp: ${{ parameters.DoEsrp }}
 
+        - task: UsePythonVersion@0
+          displayName: 'Use Python'
+          inputs:
+            versionSpec: 3.8
+
         - task: MSBuild@1
           displayName: 'Build Nuget Packages'
           inputs:

--- a/tools/ci_build/github/azure-pipelines/templates/ondevice-training-cpu-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/ondevice-training-cpu-packaging-pipeline.yml
@@ -228,6 +228,11 @@ stages:
           DisplayName: 'ESRP - Sign C# dlls'
           DoEsrp: ${{ parameters.DoEsrp }}
 
+    - task: UsePythonVersion@0
+      displayName: 'Use Python'
+      inputs:
+        versionSpec: 3.8
+
     - task: MSBuild@1
       displayName: 'Build Nuget Packages'
       inputs:


### PR DESCRIPTION
### Description
The machine has multiple python installations and none of them is in PATH. Therefore  we should explicitly set python version via this task to avoid having surprises. 

### Motivation and Context
Similar to #21095 


