### PR TITLE
DML EP EinSum make more generic to avoid EP fallback

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlCommon.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlCommon.cpp
@@ -166,7 +166,7 @@ uint32_t CountLeastSignificantZeros(uint32_t value) noexcept
     return count;
 }
 
-void GetDescendingPackedStrides(gsl::span<const uint32_t> sizes, /*out*/ gsl::span<uint32_t> strides)
+void GetDescendingPackedStrides(gsl::span<const uint32_t> sizes, /*out*/ gsl::span<uint32_t> strides) noexcept
 {
     assert(sizes.size() == strides.size());
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlCommon.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlCommon.cpp
@@ -32,7 +32,7 @@ DML_TENSOR_DATA_TYPE GetDmlDataTypeFromMlDataTypeNoThrow(MLOperatorTensorDataTyp
     };
 }
 
-bool IsSigned(DML_TENSOR_DATA_TYPE dataType)
+bool IsSigned(DML_TENSOR_DATA_TYPE dataType) noexcept
 {
     switch (dataType)
     {
@@ -138,6 +138,32 @@ uint32_t GetSupportedDeviceDataTypeMask(IDMLDevice* dmlDevice)
     }
 
     return deviceTypeMask;
+}
+
+uint32_t GetBitMaskFromIndices(gsl::span<const uint32_t> indices) noexcept
+{
+    uint32_t bitMask = 0;
+    for (auto i : indices)
+    {
+        assert(i < 32);
+        bitMask |= (1 << i);
+    }
+    return bitMask;
+}
+
+uint32_t CountLeastSignificantZeros(uint32_t value) noexcept
+{
+    // *Use std::countr_zero instead when codebase updated to C++20.
+    // Use bit twiddling hack rather than for loop.
+    uint32_t count = 32;
+    value &= -int32_t(value);
+    if (value) count--;
+    if (value & 0x0000FFFF) count -= 16;
+    if (value & 0x00FF00FF) count -= 8;
+    if (value & 0x0F0F0F0F) count -= 4;
+    if (value & 0x33333333) count -= 2;
+    if (value & 0x55555555) count -= 1;
+    return count;
 }
 
 void GetDescendingPackedStrides(gsl::span<const uint32_t> sizes, /*out*/ gsl::span<uint32_t> strides)

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlCommon.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlCommon.h
@@ -23,9 +23,11 @@ namespace Dml
     size_t ComputeByteSizeFromDimensions(gsl::span<const DimensionType> dimensions, MLOperatorTensorDataType tensorDataType);
     size_t ComputeByteSizeFromTensor(IMLOperatorTensor& tensor);
     uint32_t GetSupportedDeviceDataTypeMask(IDMLDevice* dmlDevice);
+    uint32_t GetBitMaskFromIndices(gsl::span<const uint32_t> indices) noexcept;
+    uint32_t CountLeastSignificantZeros(uint32_t value) noexcept;
     void GetDescendingPackedStrides(gsl::span<const uint32_t> sizes, /*out*/ gsl::span<uint32_t> strides);
 
-    bool IsSigned(DML_TENSOR_DATA_TYPE dataType);
+    bool IsSigned(DML_TENSOR_DATA_TYPE dataType) noexcept;
 
     template <typename T>
     void CastToClampedScalarUnion(DML_TENSOR_DATA_TYPE dataType, T value, DML_SCALAR_UNION* outputValue)

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlCommon.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlCommon.h
@@ -25,7 +25,7 @@ namespace Dml
     uint32_t GetSupportedDeviceDataTypeMask(IDMLDevice* dmlDevice);
     uint32_t GetBitMaskFromIndices(gsl::span<const uint32_t> indices) noexcept;
     uint32_t CountLeastSignificantZeros(uint32_t value) noexcept;
-    void GetDescendingPackedStrides(gsl::span<const uint32_t> sizes, /*out*/ gsl::span<uint32_t> strides);
+    void GetDescendingPackedStrides(gsl::span<const uint32_t> sizes, /*out*/ gsl::span<uint32_t> strides) noexcept;
 
     bool IsSigned(DML_TENSOR_DATA_TYPE dataType) noexcept;
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorEinSum.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorEinSum.cpp
@@ -133,6 +133,8 @@ public:
                 // - the reduced axis is the term missing from the output.
                 // - height and width are the unique axes respectively found in only input A or input B.
                 // - the batch (if present) is the first axis shared by both inputs, and the channel is the subsequent common one.
+                // If any axis is not found (say it's a 2D GEMM), then the axis value will be beyond the rank, which is
+                // safely handled correctly during projection as an inserted axis.
 
                 auto findAndClearAxis = [](uint32_t& currentAxesMask, uint32_t contraintAxesMask) -> uint32_t
                 {

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorEinSum.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorEinSum.cpp
@@ -51,7 +51,7 @@
 // 3. Multiply elementwise every input tensor to compute the internal product.
 // 4. Sum reduce the product tensor to the final output shape, reducing along any missing dimensions.
 //    So a product shape of [b,j,i,k] and output shape of [b,i,k] reduces along j.
-// 
+//
 //  ReduceSum(
 //      Mul(
 //          ExpandTransposeCollapseAsNeeded(A, aAxesToProductAxes),
@@ -90,7 +90,7 @@ public:
         uint32_t bindableInputCount = kernelCreationContext.GetInputCount();
         if (IsMatMulOperatorType())
         {
-            ++bindableInputCount; // Account for the optional C tensor.
+            ++bindableInputCount;  // Account for the optional C tensor.
         }
         inputIndices.resize(bindableInputCount);
 
@@ -231,8 +231,8 @@ public:
 
                 const DML_OPERATOR_DESC* operatorDescPointers[2] =
                 {
-                    &multiplyOperatorDescWithEnum,  // NodeIndexMultiply
-                    &reduceSumOperatorDescWithEnum, // NodeIndexReduceSum
+                    &multiplyOperatorDescWithEnum,   // NodeIndexMultiply
+                    &reduceSumOperatorDescWithEnum,  // NodeIndexReduceSum
                 };
 
                 DML_INPUT_GRAPH_EDGE_DESC inputEdges[2];
@@ -280,9 +280,9 @@ public:
 
     // Reproject all inputs and the output to the intermediate product tensor.
     // e.g.
-    // 
+    //
     //      Equation: i,j->ji
-    // 
+    //
     //      [1] [4,5,6,7]     [4, 8,12]
     //      [2]           ->  [5,10,15]
     //      [3]               [6,12,18]
@@ -347,14 +347,14 @@ public:
         // Set default sizes for shape compatibility with the product tensor, and
         // set strides to 0's initially to broadcast any missing dimensions.
         std::vector<uint32_t> newSizes;
-        std::vector<uint32_t> newStrides(newRank, 0u); // Default to 0 to broadcast missing entries.
+        std::vector<uint32_t> newStrides(newRank, 0u);  // Default to 0 to broadcast missing entries.
         if (isReduced)
         {
-            newSizes.resize(newRank, 1u); // Fill with 1's initially for any missing (reduced) dimensions.
+            newSizes.resize(newRank, 1u);  // Fill with 1's initially for any missing (reduced) dimensions.
         }
         else
         {
-            newSizes = m_productDimensions; // Use the product tensor shape directly. Missing axes will be broadcasted.
+            newSizes = m_productDimensions;  // Use the product tensor shape directly. Missing axes will be broadcasted.
         }
 
         // Scatter the original sizes and strides into the corresponding product tensor axis.
@@ -364,7 +364,7 @@ public:
             if (productAxis < newRank)
             {
                 newSizes[productAxis] = originalSizes[i];
-                newStrides[productAxis] += originalStrides[i]; // Add to combine diagonal cases like i,j,i->i,j
+                newStrides[productAxis] += originalStrides[i];  // Add to combine diagonal cases like i,j,i->i,j
             }
         }
         tensorDesc.SetDimensionsAndStrides(newSizes, newStrides);

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorEinSum.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorEinSum.cpp
@@ -3,6 +3,69 @@
 
 #include "precomp.h"
 
+// With a single equation, the Einstein summation operator can represent a variety of operators including: matmul,
+// summation, transposition, diagonal slice, diagonal sum (trace), inner (dot) product, outer product...
+//
+// Parameters                   NumPy equivalent                Description
+// -------------------------------------------------------------------------------------------------------------
+// ('i', A1)                    A1                              returns a view of A1
+// ('i->', A1)                  sum(A1)                         sums the values of A1
+// ('i,i->i', A1, B1)           A1 * B1                         element-wise multiplication of A1 and B1
+// ('i,i->', A1, B1)            inner(A1, B1) or dot(A1, B1)    inner product of A1 and B1
+// ('i,i', A1, B1)              inner(A1, B1) or dot(A1, B1)    inner product of A1 and B1
+// ('i,j->ij', A1, B1)          outer(A1, B1)                   outer product of A1 and B1
+// ('ij->ij', A2)               A2                              returns a view of A2
+// ('ij', A2)                   A2                              returns a view of A2
+// ('ji', A2)                   A2.T                            view transpose of A2
+// ('ji->ij', A2)               A2.T                            view transpose of A2
+// ('ii->i', A2)                diag(A2)                        view main diagonal of A2
+// ('ii->', A2)                 trace(A2)                       sums main diagonal of A2
+// ('ij->', A2)                 sum(A2)                         sums the values of A2
+// ('ij->j', A2)                sum(A2, axis=0)                 sum down the columns of A2 (across rows)
+// ('ij->i', A2)                sum(A2, axis=1)                 sum horizontally along the rows of A2
+// ('ij,ij->ij', A2, B2)        A2 * B2                         element-wise multiplication of A2 and B2
+// ('ij,ji->ij', A2, B2)        A2 * B2.transpose()             element-wise multiplication of A2 and B2.T
+// ('ij,jk', A2, B2)            matmul(A2, B2) or dot(A2, B2)   matrix multiplication of A2 and B2
+// ('ij,jk->ik', A2, B2)        matmul(A2, B2) or dot(A2, B2)   matrix multiplication of A2 and B2
+// ('bij,bjk->bik', A2, B2)     matmul(A3, B3)                  matrix multiplication of A3 and B3 (a stack of 2D matrices)
+// ('bij,bkj->bik', A2, B2)     matmul(A3, transpose(B3))       matrix multiplication of A3 and B3 (a stack of 2D matrices)
+// ('ij,kj->ik', A2, B2)        inner(A2, B2)                   inner product of A2 and B2
+// ('ij,kj->ikj', A2, B2)       A2[:, None] * B2                each row of A2 multiplied by B2
+// ('ij,kl->ijkl', A2, B2)      A2[:, :, None, None] * B2       each value of A2 multiplied by B2
+// (',ij', 3, B2)                                               Scalar times array: array([[ 0, 3, 6], [ 9, 12, 15]])
+// ("ij,j", A2, B1)             matvec(A2, B1)                  Matrix and vector.
+// ("ii,ii->i", A2, B2)         A2.diag() * B2.diag()           diagonals multiplied by each other
+// ("ii,ii->", A2, B2)          dot(A2.diag(), B2.diag())       dot product of diagonals
+//
+// Decomposition:
+//
+// Ultimately though EinSum is equivalent to an elementwise multiplication into an internal product tensor
+// (given a helper function to reproject all inputs so they're shape-compatible) followed by sum reduction.
+//
+// 1. Determine the size of the internal product tensor by concatenating the dimensions of all inputs,
+//    counting each unique label once. So "bij,bjk->bik" would yield an internal product of shape [b,i,j,k].
+// 2. Project each input tensor as needed to the internal product shape (transposing and/or broadcasting).
+//    So an input of shape [b,i] with product shape of [b,j,i,k] would insert broadcasted j and k dimensions.
+//    An input of shape [a,b,c] with product shape of [b,c,a] would require a transpose.
+// 3. Multiply elementwise every input tensor into the internal product.
+// 4. Sum reduce the product tensor to the final output shape, reducing along the missing dimensions.
+//    So a product shape of [b,j,i,k] and output shape of [b,i,k] reduces along j.
+// 
+//  ReduceSum(
+//      Mul(
+//          ExpandAndTransposeAsNeeded(A, aAxesToProductAxes),
+//          ExpandAndTransposeAsNeeded(B, bAxesToProductAxes),
+//      ),
+//      reductionAxes,
+//      keepdims=false
+//  )
+//
+// Notes:
+//
+// - DirectML has no direct EinSum operator, but common cases map to existing operators.
+// - EinSum can accept a variable number of input tensors, but the DML EP only supports a limited count
+//   (falling back to CPU otherwise).
+
 namespace Dml
 {
 
@@ -13,9 +76,13 @@ public:
     :   DmlOperator(kernelCreationContext),
         EinSumHelper(kernelCreationContext, kernelCreationContext.GetTensorShapeDescription(), opsetVersion)
     {
-        ML_CHECK_VALID_ARGUMENT(static_cast<uint64_t>(kernelCreationContext.GetInputCount()) + 1 == m_components.size(),
-            "EinSum input tensor count is inconsistent with the equation component count.");
+        ML_CHECK_VALID_ARGUMENT(kernelCreationContext.GetInputCount() >= 1, "EinSum expects at least one input tensor.");
         ML_CHECK_VALID_ARGUMENT(kernelCreationContext.GetOutputCount() == 1, "EinSum expects one output tensor.");
+        ML_CHECK_VALID_ARGUMENT(
+            static_cast<uint64_t>(kernelCreationContext.GetInputCount()) + 1 == m_components.size(),
+            "EinSum input tensor count is inconsistent with the equation component count."
+        );
+        assert(m_recognizedOperatorType != RecognizedOperatorType::None); // Should not have reached here because fallback to CPU happened.
 
         std::vector<std::optional<uint32_t>> inputIndices = {0,1,2};
         std::vector<std::optional<uint32_t>> outputIndices = {0};
@@ -26,8 +93,8 @@ public:
         }
         inputIndices.resize(bindableInputCount);
 
-        constexpr uint32_t dimCount = 2;
-        DmlOperator::Initialize(kernelCreationContext, inputIndices, outputIndices, std::nullopt, std::nullopt, dimCount);
+        uint32_t minimumDimensionCount = 1;
+        DmlOperator::Initialize(kernelCreationContext, inputIndices, outputIndices, std::nullopt, std::nullopt, minimumDimensionCount);
 
         std::vector<DML_TENSOR_DESC> inputDescs = GetDmlInputDescs();
         std::vector<DML_TENSOR_DESC> outputDescs = GetDmlOutputDescs();
@@ -37,6 +104,8 @@ public:
         {
         case RecognizedOperatorType::Multiply:
             {
+                ReprojectTensorDescsToProductTensor();
+
                 DML_ELEMENT_WISE_MULTIPLY_OPERATOR_DESC operatorDesc = {};
                 operatorDesc.ATensor = &inputDescs[0];
                 operatorDesc.BTensor = &inputDescs[1];
@@ -46,115 +115,57 @@ public:
             }
             break;
 
-        case RecognizedOperatorType::OuterProduct:
-            {
-                std::array<uint32_t, 2> aSizes = {m_inputTensorDescs[0].GetSizes().back(), 1};
-                TensorDesc aTensorDesc = TensorDesc(m_inputTensorDescs[0].GetDmlDataType(), aSizes);
-                auto aDmlTensorDesc = aTensorDesc.GetDmlDesc();
-
-                std::array<uint32_t, 2> bSizes = {1, m_inputTensorDescs[1].GetSizes().back()};
-                TensorDesc bTensorDesc = TensorDesc(m_inputTensorDescs[1].GetDmlDataType(), bSizes);
-                auto bDmlTensorDesc = bTensorDesc.GetDmlDesc();
-
-                DML_GEMM_OPERATOR_DESC operatorDesc = {};
-                operatorDesc.ATensor = &aDmlTensorDesc;
-                operatorDesc.BTensor = &bDmlTensorDesc;
-                operatorDesc.OutputTensor = &outputDescs[0];
-                operatorDesc.Alpha = 1.0;
-                operatorDesc.Beta = 0.0;
-                operatorDesc.FusedActivation = nullptr;
-
-                SetDmlOperatorDesc({ DML_OPERATOR_GEMM, &operatorDesc }, kernelCreationContext);
-            }
-            break;
-
         case RecognizedOperatorType::MatMul:
         case RecognizedOperatorType::MatMulTransposeA:
         case RecognizedOperatorType::MatMulTransposeB:
-            {
-                DML_GEMM_OPERATOR_DESC operatorDesc = {};
-                operatorDesc.ATensor = &inputDescs[0];
-                operatorDesc.BTensor = &inputDescs[1];
-                // No operatorDesc.CTensor
-                operatorDesc.OutputTensor = &outputDescs[0];
-                operatorDesc.TransA = (m_recognizedOperatorType == RecognizedOperatorType::MatMulTransposeA) ? DML_MATRIX_TRANSFORM_TRANSPOSE : DML_MATRIX_TRANSFORM_NONE;
-                operatorDesc.TransB = (m_recognizedOperatorType == RecognizedOperatorType::MatMulTransposeB) ? DML_MATRIX_TRANSFORM_TRANSPOSE : DML_MATRIX_TRANSFORM_NONE;
-                operatorDesc.Alpha = 1.0;
-                operatorDesc.Beta = 0.0;
-                operatorDesc.FusedActivation = nullptr;
-
-                SetDmlOperatorDesc({ DML_OPERATOR_GEMM, &operatorDesc }, kernelCreationContext);
-            }
-            break;
         case RecognizedOperatorType::MatMulNhcw:
         case RecognizedOperatorType::MatMulNhcwTransposeA:
         case RecognizedOperatorType::MatMulNhcwTransposeB:
+        case RecognizedOperatorType::MatMulGeneral:
             {
-                // Transpose via input strides. The output tensor is not strided. Support only 4D for now.
-                assert(m_components.size() == 3);
-                assert(m_components[0].GetDimensionCount() == m_components[2].GetDimensionCount());
-                assert(m_components[1].GetDimensionCount() == m_components[2].GetDimensionCount());
-                assert(m_components[2].GetDimensionCount() == 4);
+                assert(m_components.size() == 3); // 2 inputs, 1 output
+                assert(m_productDimensions.size() - 1 <= 4); // Up to 4D, as MatMul reduces 1 dimension from the internal product.
 
-                // Remap transposed strides from NCHW to NHCW
-                constexpr std::array<uint32_t, 4> labelIndices = {0, 2, 1, 3};
+                // Generate bitmasks for each of the active axes per tensor using their labels.
+                const auto input0Labels = m_components[0].GetLabels(m_labelIndices);
+                const auto input1Labels = m_components[1].GetLabels(m_labelIndices);
+                const auto outputLabels = m_components[2].GetLabels(m_labelIndices);
+                const uint32_t input0AxesMask = GetBitMaskFromIndices(input0Labels);
+                const uint32_t input1AxesMask = GetBitMaskFromIndices(input1Labels);
+                const uint32_t outputAxesMask = GetBitMaskFromIndices(outputLabels);
 
-                assert(m_inputTensorDescs.size() >= 2);
-                for (uint32_t inputIndex = 0; inputIndex < 2; ++inputIndex)
+                // Find each of the interesting axes, including the one being reduced, height, width, batch, and channel.
+                // - the reduced axis is the term missing from the output.
+                // - height and width are the unique axes respectively found in only input A or input B.
+                // - the batch (if present) is the first axis shared by both inputs, and the channel is the subsequent common one.
+
+                auto findAndClearAxis = [](uint32_t& currentAxesMask, uint32_t contraintAxesMask) -> uint32_t
                 {
-                    TensorDesc& tensorDesc = m_inputTensorDescs[inputIndex];
-                    auto originalStrides = tensorDesc.GetStrides();
-                    std::vector<uint32_t> inputSizes = kernelCreationContext.GetTensorShapeDescription().GetInputTensorShape(inputIndex);
-                    std::vector<uint32_t> inputStrides(inputSizes.size());
+                    uint32_t foundAxis = CountLeastSignificantZeros(currentAxesMask & ~contraintAxesMask);
+                    currentAxesMask &= ~(1 << foundAxis);
+                    return foundAxis;
+                };
 
-                    // If there were no strides, compute them based in descending packed order
-                    // based on the input sizes.
-                    if (originalStrides.empty())
-                    {
-                        Dml::GetDescendingPackedStrides(inputSizes, /*out*/ inputStrides);
-                    }
-                    else // Copy the original strides.
-                    {
-                        assert(originalStrides.size() >= inputStrides.size());
-                        size_t offset = originalStrides.size() - inputStrides.size();
-                        inputStrides.assign(originalStrides.begin() + offset, originalStrides.end());
-                    }
+                uint32_t remainingAxesMask = ~0u;
+                uint32_t reductionAxis     = findAndClearAxis(/*inout*/ remainingAxesMask, outputAxesMask);
+                uint32_t heightAxis        = findAndClearAxis(/*inout*/ remainingAxesMask, input1AxesMask);
+                uint32_t widthAxis         = findAndClearAxis(/*inout*/ remainingAxesMask, input0AxesMask);
+                uint32_t batchAxis         = findAndClearAxis(/*inout*/ remainingAxesMask, 0);
+                uint32_t channelAxis       = findAndClearAxis(/*inout*/ remainingAxesMask, 0);
 
-                    std::vector<uint32_t> newStrides(inputStrides.size());
-                    std::vector<uint32_t> newSizes(inputStrides.size());
-                    for (size_t dim = 0, dimensionCount = inputStrides.size(); dim < dimensionCount; ++dim)
-                    {
-                        uint32_t labelIndex = labelIndices[dim];
-                        assert(labelIndex < inputStrides.size());
-                        newSizes[dim] = inputSizes[labelIndex];
-                        newStrides[dim] = inputStrides[labelIndex];
-                    }
-
-                    // Override the initial input tensor with the new strides.
-                    tensorDesc = TensorDesc(tensorDesc.GetDmlDataType(), newSizes, newStrides, 0);
-                    tensorDesc.GetDmlDesc(); // Discard value, but keep side effect of refreshing the DML view.
-                }
-
-                std::vector<uint32_t> outputSizes = kernelCreationContext.GetTensorShapeDescription().GetOutputTensorShape(0);
-                std::vector<uint32_t> newOutputSizes(outputSizes.size());
-                assert(outputSizes.size() == labelIndices.size());
-
-                for (size_t dim = 0; dim < outputSizes.size(); ++dim)
-                {
-                    uint32_t labelIndex = labelIndices[dim];
-                    newOutputSizes[dim] = outputSizes[labelIndex];
-                }
-
-                m_outputTensorDescs.front() = TensorDesc(m_outputTensorDescs.front().GetDmlDataType(), newOutputSizes, std::nullopt, 0);
-                m_outputTensorDescs.front().GetDmlDesc(); // Discard value, but keep side effect of refreshing the DML view.
+                // Reproject all inputs and the output to the needed order pattern for DML compatibility,
+                // which only accepts the rightmost axis as GEMM-reducible when TransB is true.
+                ReprojectTensorDescToGivenAxes(/*inout*/ m_inputTensorDescs[0],  input0Labels, {{batchAxis, channelAxis, heightAxis, reductionAxis}});
+                ReprojectTensorDescToGivenAxes(/*inout*/ m_inputTensorDescs[1],  input1Labels, {{batchAxis, channelAxis, widthAxis, reductionAxis}});
+                ReprojectTensorDescToGivenAxes(/*inout*/ m_outputTensorDescs[0], outputLabels, {{batchAxis, channelAxis, heightAxis, widthAxis}});
 
                 DML_GEMM_OPERATOR_DESC operatorDesc = {};
                 operatorDesc.ATensor = &inputDescs[0];
                 operatorDesc.BTensor = &inputDescs[1];
                 // No operatorDesc.CTensor
                 operatorDesc.OutputTensor = &outputDescs[0];
-                operatorDesc.TransA = (m_recognizedOperatorType == RecognizedOperatorType::MatMulNhcwTransposeA) ? DML_MATRIX_TRANSFORM_TRANSPOSE : DML_MATRIX_TRANSFORM_NONE;
-                operatorDesc.TransB = (m_recognizedOperatorType == RecognizedOperatorType::MatMulNhcwTransposeB) ? DML_MATRIX_TRANSFORM_TRANSPOSE : DML_MATRIX_TRANSFORM_NONE;
+                operatorDesc.TransA = DML_MATRIX_TRANSFORM_NONE;
+                operatorDesc.TransB = DML_MATRIX_TRANSFORM_TRANSPOSE;
                 operatorDesc.Alpha = 1.0;
                 operatorDesc.Beta = 0.0;
                 operatorDesc.FusedActivation = nullptr;
@@ -165,39 +176,24 @@ public:
 
         case RecognizedOperatorType::ReduceSum:
             {
-                // Get how many axes are kept in the final output, either 0 or 1 supported
-                // meaning full reduction or partial with one dimension left. *It could be
-                // generalized to support any number of output dimensions, but it would need
-                // to accomodate for Transposition too if the output labels are reordered.
-                auto keptAxes = m_components.back().GetLabels(m_labelIndices);
-                assert(keptAxes.size() <= 1);
+                ReprojectTensorDescsToProductTensor();
 
-                // DML expects output rank to match input rank (as if ONNX ReduceSum keepdims=1).
-                // So replace the existing tensor description with the input sizes, except that
-                // reduced dimensions have size 1.
+                // Determine which axes are reduced by looking for any output dimensions of size 1.
+                // Note this could include dimensions that are not actually being reduced and simply
+                // already had size 1 from the input, but such cases harmless nops either way.
+                // DML expects the input rank to match output rank (as if ONNX ReduceSum keepdims=1)
+                // with reduced output dimensions having size 1, which is handled naturally in the
+                // projection call.
+
+                auto outputSizes = m_outputTensorDescs.front().GetSizes();
                 std::vector<uint32_t> reducedAxes;
-                std::vector<uint32_t> inputSizes = kernelCreationContext.GetTensorShapeDescription().GetInputTensorShape(0);
-                std::vector<uint32_t> outputSizes = inputSizes;
-
-                // Determine which axes are being reduced by taking the opposite of those kept.
-                uint32_t keptAxesMask = 0;
-                for (auto axis : keptAxes)
-                {
-                    keptAxesMask |= (1 << axis);
-                }
                 for (uint32_t axis = 0, axisCount = static_cast<uint32_t>(outputSizes.size()); axis < axisCount; ++axis)
                 {
-                    if (~keptAxesMask & (1<<axis))
+                    if (outputSizes[axis] == 1)
                     {
                         reducedAxes.push_back(axis);
-                        outputSizes[axis] = 1;
                     }
                 }
-
-                m_inputTensorDescs.front() = TensorDesc(m_inputTensorDescs.front().GetDmlDataType(), inputSizes, std::nullopt, 0);
-                m_outputTensorDescs.front() = TensorDesc(m_outputTensorDescs.front().GetDmlDataType(), outputSizes, std::nullopt, 0);
-                m_inputTensorDescs.front().GetDmlDesc(); // Discard value, but keep side effect of refreshing the DML view.
-                m_outputTensorDescs.front().GetDmlDesc(); // Discard value, but keep side effect of refreshing the DML view.
 
                 DML_REDUCE_OPERATOR_DESC operatorDesc = {};
                 operatorDesc.InputTensor = inputDescs.data();
@@ -215,43 +211,8 @@ public:
             {
                 if (m_recognizedOperatorType == RecognizedOperatorType::Transpose)
                 {
-                    // Transpose via input strides. The output tensor is not strided.
-                    assert(m_components.front().GetDimensionCount() == m_components.back().GetDimensionCount());
-                    auto originalStrides = m_inputTensorDescs.front().GetStrides();
-                    std::vector<uint32_t> inputSizes = kernelCreationContext.GetTensorShapeDescription().GetInputTensorShape(0);
-                    std::vector<uint32_t> inputStrides(inputSizes.size());
-
-                    // If there were no strides, compute them based in descending packed order
-                    // based on the input sizes.
-                    if (originalStrides.empty())
-                    {
-                        Dml::GetDescendingPackedStrides(inputSizes, /*out*/ inputStrides);
-                    }
-                    else // Copy the original strides.
-                    {
-                        assert(originalStrides.size() >= inputStrides.size());
-                        size_t offset = originalStrides.size() - inputStrides.size();
-                        inputStrides.assign(originalStrides.begin() + offset, originalStrides.end());
-                    }
-
-                    // Remap transposed strides using the component labels from input to output.
-                    auto labelIndices = m_components.back().GetLabels(m_labelIndices);
-
-                    std::vector<uint32_t> newStrides(inputStrides.size());
-                    std::vector<uint32_t> newSizes(inputStrides.size());
-                    for (size_t i = 0, dimensionCount = inputStrides.size(); i < dimensionCount; ++i)
-                    {
-                        uint32_t labelIndex = labelIndices[i];
-                        assert(labelIndex < inputStrides.size());
-                        newSizes[i] = inputSizes[labelIndex];
-                        newStrides[i] = inputStrides[labelIndex];
-                    }
-
-                    // Override the initial input tensor with the new strides.
-                    m_inputTensorDescs.front() = TensorDesc(m_inputTensorDescs.front().GetDmlDataType(), newSizes, newStrides, 0);
-                    m_outputTensorDescs.front() = TensorDesc(m_outputTensorDescs.front().GetDmlDataType(), newSizes, std::nullopt, 0);
-                    m_inputTensorDescs.front().GetDmlDesc(); // Discard value, but keep side effect of refreshing the DML view.
-                    m_outputTensorDescs.front().GetDmlDesc(); // Discard value, but keep side effect of refreshing the DML view.
+                    // Needed if transposing but not if identity.
+                    ReprojectTensorDescsToProductTensor();
                 }
 
                 DML_ELEMENT_WISE_IDENTITY_OPERATOR_DESC operatorDesc = {};
@@ -265,6 +226,106 @@ public:
         default:
             return;
         }
+    }
+
+    // Reproject all inputs and output to the intermediate product tensor.
+    // e.g.
+    // 
+    //      Equation: i,j->ij
+    // 
+    //      [1,2,3] [4]    [4, 8,12]
+    //              [5] -> [5,10,15]
+    //              [6]    [6,12,18]
+    //
+    //      Inputs 0 and 1 are expanded to be directly broadcast-compatible.
+    //
+    //      [1,2,3] [4,4,4]    [4, 8,12]
+    //      [1,2,3] [5,5,5] -> [5,10,15]
+    //      [1,2,3] [6,6,6]    [6,12,18]
+    //
+    void ReprojectTensorDescsToProductTensor()
+    {
+        assert(!m_components.empty());
+        assert(m_inputTensorDescs.size() + m_outputTensorDescs.size() == m_components.size());
+
+        for (size_t i = 0, count = m_inputTensorDescs.size(); i < count; ++i)
+        {
+            auto inputLabels = m_components[i].GetLabels(m_labelIndices);
+            ReprojectTensorDescToProductTensor(/*inout*/ m_inputTensorDescs[i], inputLabels, /*isReduced*/ false);
+        }
+        auto outputLabels = m_components.back().GetLabels(m_labelIndices);
+        ReprojectTensorDescToProductTensor(/*inout*/ m_outputTensorDescs.front(), outputLabels, /*isReduced*/ true);
+    }
+
+    // Transpose/broadcast the given tensor for shape compatibility to the internal product tensor.
+    // e.g.
+    //
+    //      Original tensor shape:   [2,3,4]
+    //      Original tensor strides: [12,4,1]    // packed strides right-to-left
+    //      Product tensor shape:    [3,5,4,2]   // transposed, with 1 additional axis not in input tensor
+    //      Reprojected shape:       [3,5,4,2]   or [3,1,4,2] when isReduced is true
+    //      Reprojected strides:     [4,0,1,12]
+    //
+    void ReprojectTensorDescToProductTensor(
+        /*inout*/ TensorDesc& tensorDesc,
+        gsl::span<const uint32_t> axisLabels,
+        bool isReduced // Return 1's for any missing dimensions not in axisLabels.
+    )
+    {
+        assert(m_productDimensions.size() == m_uniqueLabelCount);
+        const size_t newRank = m_productDimensions.size();
+
+        // Compute the default strides of the tensor (non-transposed).
+        tensorDesc.EnsureStridesExist();
+        const auto originalSizes = tensorDesc.GetSizes();
+        const auto originalStrides = tensorDesc.GetStrides();
+        assert(originalSizes.size() >= axisLabels.size());
+        assert(originalStrides.size() >= axisLabels.size());
+
+        // Set default sizes for shape compatibility with the product tensor, and
+        // set strides to 0's initially to broadcast any missing dimensions.
+        std::vector<uint32_t> newSizes;
+        std::vector<uint32_t> newStrides(newRank, 0u); // Default to 0 to broadcast missing entries.
+        if (isReduced)
+        {
+            newSizes.resize(newRank, 1u); // Fill with 1's initially for any missing dimensions (reduced).
+        }
+        else
+        {
+            newSizes = m_productDimensions; // Use the product tensor shape directly. Missing axes will be broadcasted.
+        }
+
+        // Scatter the original sizes and strides into the corresponding product tensor axis.
+        for (size_t i = 0, count = axisLabels.size(); i < count; ++i)
+        {
+            uint32_t productAxis = axisLabels[i];
+            if (productAxis < newRank)
+            {
+                newSizes[productAxis] = originalSizes[i];
+                newStrides[productAxis] += originalStrides[i]; // Add to handle diagonal cases like i,j,i->i,j
+            }
+        }
+        tensorDesc.SetDimensionsAndStrides(newSizes, newStrides);
+        tensorDesc.EnsureDimensionCount(1, TensorAxis::RightAligned);
+    }
+
+    // Reproject a tensor to the given axis arrangement.
+    // The new tensor will have rank == newAxes.size().
+    // e.g.
+    //
+    //      product tensor shape = [2,3,4,5,6] // m_productDimensions
+    //      newAxes              = [4,2,0,1]
+    //      new tensor shape     = [6,4,2,3]
+    //
+    void ReprojectTensorDescToGivenAxes(
+        /*inout*/ TensorDesc& tensorDesc,
+        gsl::span<const uint32_t> axisLabels,
+        gsl::span<const uint32_t> newAxes
+    )
+    {
+        // First, reproject the original dimensions up to the product tensor.
+        ReprojectTensorDescToProductTensor(/*inout*/ tensorDesc, axisLabels, /*isReduced*/ false);
+        tensorDesc.PermuteDimensions(newAxes, TensorAxis::LeftAligned);
     }
 };
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/TensorDesc.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/TensorDesc.cpp
@@ -212,14 +212,14 @@ gsl::span<const uint32_t> TensorDesc::GetStrides() const
 
 void TensorDesc::SetStrides(gsl::span<const uint32_t> strides)
 {
-    m_bufferTensorDesc.Strides = strides.empty() ? nullptr : strides.data();
-
     if (!strides.empty())
     {
         ML_CHECK_VALID_ARGUMENT(strides.size() <= std::size(m_strides));
         ML_CHECK_VALID_ARGUMENT(strides.size() == m_bufferTensorDesc.DimensionCount);
         std::copy(strides.begin(), strides.end(), m_strides);
     }
+
+    m_bufferTensorDesc.Strides = strides.empty() ? nullptr : m_strides;
 
     m_bufferTensorDesc.TotalTensorSizeInBytes = DMLCalcBufferTensorSize(
         m_bufferTensorDesc.DataType,
@@ -289,6 +289,15 @@ void TensorDesc::ForceUnsignedDataType()
     }
 }
 
+// Add additional padding 1's to ensure the count is at least that large.
+void TensorDesc::EnsureDimensionCount(uint32_t newDimensionCount, TensorAxis alignment)
+{
+    if (m_bufferTensorDesc.DimensionCount < newDimensionCount)
+    {
+        SetDimensionCount(newDimensionCount, alignment);
+    }
+}
+
 void TensorDesc::SetDimensionCount(uint32_t newDimensionCount, TensorAxis alignment)
 {
     ML_CHECK_VALID_ARGUMENT(newDimensionCount <= MaximumDimensionCount);
@@ -321,20 +330,32 @@ void TensorDesc::SetDimensionCount(uint32_t newDimensionCount, TensorAxis alignm
     m_bufferTensorDesc.DimensionCount = newDimensionCount;
 }
 
-// Uses dimensionMapping to reorder m_sizes and m_strides to match specific Tensor layout
+void TensorDesc::SetDimensionsAndStrides(gsl::span<const uint32_t> sizes, gsl::span<const uint32_t> strides)
+{
+    static_assert(sizeof(m_sizes) == sizeof(m_strides));
+    ML_CHECK_VALID_ARGUMENT(sizes.size() <= std::size(m_sizes));
+    ML_CHECK_VALID_ARGUMENT(strides.empty() || strides.size() == sizes.size());
+
+    std::copy(sizes.begin(), sizes.end(), m_sizes);
+    m_bufferTensorDesc.DimensionCount = static_cast<uint32_t>(sizes.size());
+    SetStrides(strides);
+}
+
 void TensorDesc::PermuteDimensions(gsl::span<const uint32_t> dimensionMapping, const TensorAxis alignment)
 {
+    const uint32_t oldRank = m_bufferTensorDesc.DimensionCount;
     EnsureStridesExist();
     SetDimensionCount(static_cast<uint32_t>(dimensionMapping.size()), alignment);
 
-    // Shuffle m_sizes and m_strides according to the indexes pointed by dimensionMapping
-    std::vector<uint32_t> tempSizes{m_sizes, m_sizes + MaximumDimensionCount};
-    std::vector<uint32_t> tempStrides{m_strides, m_strides + MaximumDimensionCount};
+    // Shuffle m_sizes and m_strides according to the indexes pointed by dimensionMapping.
+    std::vector<uint32_t> oldSizes{m_sizes, m_sizes + MaximumDimensionCount};
+    std::vector<uint32_t> oldStrides{m_strides, m_strides + MaximumDimensionCount};
 
     for (size_t i = 0; i < dimensionMapping.size(); i++)
     {
-        m_sizes[i] = tempSizes[dimensionMapping[i]];
-        m_strides[i] = tempStrides[dimensionMapping[i]];
+        uint32_t sourceAxis = dimensionMapping[i];
+        m_sizes[i] = sourceAxis < oldRank ? oldSizes[sourceAxis] : 1;
+        m_strides[i] = sourceAxis < oldRank ? oldStrides[sourceAxis] : 0;
     }
 
     m_bufferTensorDesc.Sizes = m_sizes;
@@ -345,14 +366,10 @@ void TensorDesc::EnsureStridesExist()
 {
     if (m_bufferTensorDesc.Strides != nullptr)
     {
-        // Strides are populated
+        // Strides are already populated
         return;
     }
 
-    uint32_t stride = 1;
-    for (uint32_t i = m_bufferTensorDesc.DimensionCount; i-- > 0;)
-    {
-        m_strides[i] = stride;
-        stride *= m_sizes[i];
-    }
+    GetDescendingPackedStrides({m_sizes, m_bufferTensorDesc.DimensionCount}, {m_strides, m_bufferTensorDesc.DimensionCount});
+    m_bufferTensorDesc.Strides = m_strides;
 }

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/TensorDesc.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/TensorDesc.cpp
@@ -348,6 +348,8 @@ void TensorDesc::PermuteDimensions(gsl::span<const uint32_t> dimensionMapping, c
     SetDimensionCount(static_cast<uint32_t>(dimensionMapping.size()), alignment);
 
     // Shuffle m_sizes and m_strides according to the indexes pointed by dimensionMapping.
+    // Note using MaximumDimensionCount instead of oldRank is intentional here, because the old rank could
+    // be smaller or larger than the new rank, but it will never be larger than MaximumDimensionCount.
     std::vector<uint32_t> oldSizes{m_sizes, m_sizes + MaximumDimensionCount};
     std::vector<uint32_t> oldStrides{m_strides, m_strides + MaximumDimensionCount};
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/TensorDesc.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/TensorDesc.cpp
@@ -201,7 +201,7 @@ TensorDesc::TensorDesc(
     assert(m_bufferTensorDesc.TotalTensorSizeInBytes >= ComputeByteSizeFromDimensions(nonBroadcastDimensions, dataType));
 }
 
-gsl::span<const uint32_t> TensorDesc::GetStrides() const
+gsl::span<const uint32_t> TensorDesc::GetStrides() const noexcept
 {
     if (m_bufferTensorDesc.Strides == nullptr)
     {
@@ -228,7 +228,7 @@ void TensorDesc::SetStrides(gsl::span<const uint32_t> strides)
         strides.empty() ? nullptr : m_strides);
 }
 
-DML_TENSOR_DESC TensorDesc::GetDmlDesc()
+DML_TENSOR_DESC TensorDesc::GetDmlDesc() noexcept
 {
     if (m_tensorType == DML_TENSOR_TYPE_INVALID)
     {
@@ -364,7 +364,7 @@ void TensorDesc::PermuteDimensions(gsl::span<const uint32_t> dimensionMapping, c
     m_bufferTensorDesc.Strides = m_strides;
 }
 
-void TensorDesc::EnsureStridesExist()
+void TensorDesc::EnsureStridesExist() noexcept
 {
     if (m_bufferTensorDesc.Strides != nullptr)
     {

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/TensorDesc.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/TensorDesc.h
@@ -52,7 +52,7 @@ namespace Dml
 
         // Rearranges existing m_sizes and m_strides by gathering axes from dimensionMapping.
         // It IS legal to change the number of dimensions by adding filler, dropping entire dimensions for a new view,
-        // and even duplicate logical dimensions. Axes beyond the original rank will be filled by size 1 and stride 0.
+        // and even duplicating logical dimensions. Axes beyond the original rank will be filled by size 1 and stride 0.
         // e.g. Existing sizes [2,3,4] with [2,0] yields [4,2].
         void PermuteDimensions(gsl::span<const uint32_t> dimensionMapping, const TensorAxis alignment);
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/TensorDesc.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/TensorDesc.h
@@ -41,9 +41,19 @@ namespace Dml
         inline bool IsValid() const { return m_tensorType != DML_TENSOR_TYPE_INVALID; }
         inline uint32_t GetDimensionCount() const { return m_bufferTensorDesc.DimensionCount; }
         void SetDimensionCount(uint32_t newDimensionCount, TensorAxis alignment);
+        void EnsureDimensionCount(uint32_t newDimensionCount, TensorAxis alignment);
+
         gsl::span<const uint32_t> GetSizes() const { return { m_sizes, m_sizes + m_bufferTensorDesc.DimensionCount }; }
         gsl::span<const uint32_t> GetStrides() const;
         void SetStrides(gsl::span<const uint32_t> strides);
+        void EnsureStridesExist();
+
+        void SetDimensionsAndStrides(gsl::span<const uint32_t> sizes, gsl::span<const uint32_t> strides);
+
+        // Rearranges existing m_sizes and m_strides by gathering axes from dimensionMapping.
+        // It IS legal to change the number of dimensions by adding filler, dropping entire dimensions for a new view,
+        // and even duplicate logical dimensions. Axes beyond the original rank will be filled by size 1 and stride 0.
+        // e.g. Existing sizes [2,3,4] with [2,0] yields [4,2].
         void PermuteDimensions(gsl::span<const uint32_t> dimensionMapping, const TensorAxis alignment);
 
         inline uint64_t GetBufferSizeInBytes() const
@@ -91,8 +101,6 @@ namespace Dml
         uint32_t m_sizes[MaximumDimensionCount] = {};
         uint32_t m_strides[MaximumDimensionCount] = {};
         DML_BUFFER_TENSOR_DESC m_bufferTensorDesc = {};
-
-        void EnsureStridesExist();
     };
 
     class TensorDescBuilder

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/TensorDesc.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/TensorDesc.h
@@ -32,21 +32,21 @@ namespace Dml
             uint32_t guaranteedBaseOffsetAlignment
             );
 
-        DML_TENSOR_DESC GetDmlDesc();
+        DML_TENSOR_DESC GetDmlDesc() noexcept;
 
-        inline DML_TENSOR_DATA_TYPE GetDmlDataType() const { return m_bufferTensorDesc.DataType; }
-        inline MLOperatorTensorDataType GetMlOperatorDataType() const { return m_mlOperatorTensorDataType; }
+        inline DML_TENSOR_DATA_TYPE GetDmlDataType() const noexcept { return m_bufferTensorDesc.DataType; }
+        inline MLOperatorTensorDataType GetMlOperatorDataType() const noexcept { return m_mlOperatorTensorDataType; }
         void ForceUnsignedDataType();
 
-        inline bool IsValid() const { return m_tensorType != DML_TENSOR_TYPE_INVALID; }
+        inline bool IsValid() const noexcept { return m_tensorType != DML_TENSOR_TYPE_INVALID; }
         inline uint32_t GetDimensionCount() const { return m_bufferTensorDesc.DimensionCount; }
         void SetDimensionCount(uint32_t newDimensionCount, TensorAxis alignment);
         void EnsureDimensionCount(uint32_t newDimensionCount, TensorAxis alignment);
 
-        gsl::span<const uint32_t> GetSizes() const { return { m_sizes, m_sizes + m_bufferTensorDesc.DimensionCount }; }
-        gsl::span<const uint32_t> GetStrides() const;
+        gsl::span<const uint32_t> GetSizes() const noexcept { return { m_sizes, m_sizes + m_bufferTensorDesc.DimensionCount }; }
+        gsl::span<const uint32_t> GetStrides() const noexcept;
         void SetStrides(gsl::span<const uint32_t> strides);
-        void EnsureStridesExist();
+        void EnsureStridesExist() noexcept;
 
         void SetDimensionsAndStrides(gsl::span<const uint32_t> sizes, gsl::span<const uint32_t> strides);
 

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.cpp
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.cpp
@@ -1497,14 +1497,8 @@ namespace OperatorHelper
     {
         if (m_components.empty())
         {
-            return RecognizedOperatorType::None; // Parsing may have found unsupported components - treating as unknown.
+            return RecognizedOperatorType::None;  // Parsing may have found unsupported components - treating as unknown.
         }
-
-        // std::ranges::equal is not supported yet.
-        auto equals = [](gsl::span<const uint32_t> a, gsl::span<const uint32_t> b) -> bool
-        {
-            return std::equal(a.begin(), a.end(), b.begin(), b.end());
-        };
 
         auto areIdenticalAxes = [](gsl::span<const uint32_t> a, gsl::span<const uint32_t> b) -> bool
         {
@@ -1519,14 +1513,14 @@ namespace OperatorHelper
         // Identify any common patterns that map to existing DirectML operators
         // (identity, transpose, sum reduction, matmul, multiplication...).
 
-        constexpr size_t maximumSupportedComponentCount = 3; // 2 inputs + 1 output
+        constexpr size_t maximumSupportedComponentCount = 3;  // 2 inputs + 1 output
         // Bail if more than 2 inputs. EinSum is generic and can handle any variable number of inputs,
         // but 3-input models have yet to be seen.
         if (m_components.size() > maximumSupportedComponentCount)
         {
             return RecognizedOperatorType::None;
         }
-        else if (m_components.size() == 2) // 1 input, 1 output
+        else if (m_components.size() == 2)  // 1 input, 1 output
         {
             auto outputLabels = m_components.back().GetLabels(m_labelIndices);
 
@@ -1544,7 +1538,7 @@ namespace OperatorHelper
                 return RecognizedOperatorType::Transpose;
             }
         }
-        else if (m_components.size() == 3) // 2 inputs, 1 output
+        else if (m_components.size() == 3)  // 2 inputs, 1 output
         {
             auto input0Labels = m_components[0].GetLabels(m_labelIndices);
             auto input1Labels = m_components[1].GetLabels(m_labelIndices);
@@ -1601,7 +1595,7 @@ namespace OperatorHelper
         //
         //  label sizes = [3,2,4,5]
         //
-        assert(!m_components.empty()); // Should have already parsed components.
+        assert(!m_components.empty());  // Should have already parsed components.
 
         uint32_t inputCount  = kernelInformation.GetInputCount();
         uint32_t outputCount = kernelInformation.GetOutputCount();
@@ -1643,7 +1637,7 @@ namespace OperatorHelper
 
     std::vector<EdgeShapes> EinSumHelper::GetOutputShapes(const MLShapeInferenceContext& shapeInfo) const
     {
-        assert(!m_components.empty()); // Should have already parsed components.
+        assert(!m_components.empty());  // Should have already parsed components.
 
         // Generate output dimensions from corresponding input tensor labels.
         // e.g. Given ij,jk->ij with [2,3] and [3,5], the output is [2,5].

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.h
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.h
@@ -762,9 +762,9 @@ public:
 
 class EinSumHelper
 {
-public:
     void Initialize();
 
+public:
     // Info_t is used to obtain attributes which will be used for calculating the output shape later.
     // Shape_t is used to obtain input shape which will be used for adjusting attribute value.
     template <typename Info_t, typename Shape_t>
@@ -772,6 +772,7 @@ public:
     {
         m_equation = info.GetAttribute(AttrName::Equation);
         Initialize();
+        ExtractLabelSizesFromTensors(KernelInformationAdapter(info), ShapeInformationAdapter(shape));
     }
 
     EinSumHelper(const MLOperatorAttributes& info)
@@ -787,10 +788,10 @@ public:
         None,
         Identity,
         Multiply,
-        OuterProduct,
         MatMul,
         MatMulTransposeA,
         MatMulTransposeB,
+        MatMulGeneral,
         MatMulNhcw,
         MatMulNhcwTransposeA,
         MatMulNhcwTransposeB,
@@ -805,7 +806,11 @@ public:
 
 protected:
     void ParseEquationComponents();
-    RecognizedOperatorType DetermineRecognizedOperatorType();
+    void ExtractLabelSizesFromTensors(
+        const IKernelInformationAdapter& kernelInformation,
+        const IShapeInformationAdapter& shapeInformation
+    );
+    RecognizedOperatorType DetermineRecognizedOperatorType() const;
 
 protected:
     struct Component
@@ -824,9 +829,10 @@ protected:
     };
 
     std::string m_equation;
+    size_t m_uniqueLabelCount = 0;
     std::vector<uint32_t> m_labelIndices; // Concatenation of all labels as rebased indices ("ij,ai" -> 0,1,2,0).
     std::vector<Component> m_components; // All components in order, including inputs and output.
-    std::vector<uint32_t> m_outputDimensions;
+    std::vector<uint32_t> m_productDimensions; // Dimensions of each unique label (size() == m_uniqueLabelCount).
     RecognizedOperatorType m_recognizedOperatorType = RecognizedOperatorType::None;
 };
 

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.h
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.h
@@ -823,10 +823,10 @@ protected:
     };
 
     std::string m_equation;
-    size_t m_uniqueLabelCount = 0; // e.g. ij,jk->ij has 3 unique labels.
-    std::vector<uint32_t> m_labelIndices; // Concatenation of all labels as rebased indices ("ij,ai" -> 0,1,2,0).
-    std::vector<Component> m_components; // All components in order, including inputs and output.
-    std::vector<uint32_t> m_productDimensions; // Dimensions of each unique label (size() == m_uniqueLabelCount).
+    size_t m_uniqueLabelCount = 0;  // e.g. ij,jk->ij has 3 unique labels.
+    std::vector<uint32_t> m_labelIndices;  // Concatenation of all labels as rebased indices ("ij,ai" -> 0,1,2,0).
+    std::vector<Component> m_components;  // All components in order, including inputs and output.
+    std::vector<uint32_t> m_productDimensions;  // Dimensions of each unique label (size() == m_uniqueLabelCount).
     RecognizedOperatorType m_recognizedOperatorType = RecognizedOperatorType::None;
 };
 

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.h
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.h
@@ -786,17 +786,11 @@ public:
     enum class RecognizedOperatorType
     {
         None,
-        Identity,
-        Multiply,
-        MatMul,
-        MatMulTransposeA,
-        MatMulTransposeB,
-        MatMulGeneral,
-        MatMulNhcw,
-        MatMulNhcwTransposeA,
-        MatMulNhcwTransposeB,
-        ReduceSum,
-        Transpose,
+        Transpose,          // 1 input, rearrangement or diagonal slice, no reduction
+        ReduceSum,          // 1 input, no multiplication, just sum reduction
+        Multiply,           // 2 inputs, elementwise multiplication, no sum reduction
+        MatMul,             // 2 inputs, elementwise multiplication, sum reduction on 1 axis.
+        MultiplyReduceSum,  // 2 inputs, elementwise multiplication, sum reduction on multiple axes
         Total,
     };
 

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.h
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.h
@@ -823,7 +823,7 @@ protected:
     };
 
     std::string m_equation;
-    size_t m_uniqueLabelCount = 0;
+    size_t m_uniqueLabelCount = 0; // e.g. ij,jk->ij has 3 unique labels.
     std::vector<uint32_t> m_labelIndices; // Concatenation of all labels as rebased indices ("ij,ai" -> 0,1,2,0).
     std::vector<Component> m_components; // All components in order, including inputs and output.
     std::vector<uint32_t> m_productDimensions; // Dimensions of each unique label (size() == m_uniqueLabelCount).

--- a/onnxruntime/test/providers/cpu/math/einsum_test.cc
+++ b/onnxruntime/test/providers/cpu/math/einsum_test.cc
@@ -274,16 +274,11 @@ TEST(Einsum, ExplicitEinsumAsMatmul_OutputTransposed) {
 }
 
 TEST(Einsum, ExplicitEinsumAsMatmul_2) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(2068): The parameter is incorrect.";
-  }
-
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", "ij,jk->ik");
   test.AddInput<float>("x", {2, 1}, {2.f, 3.f});
-  test.AddInput<float>("y", {2, 2}, {1.f, 2.f, 3.f, 4.f});
-  test.AddOutput<float>("o", {2, 2}, {8.f, 12.f, 12.f, 18.f});
+  test.AddInput<float>("y", {1, 2}, {1.f, 2.f});
+  test.AddOutput<float>("o", {2, 2}, {2.f, 4.f, 3.f, 6.f});
   test.Run();
 }
 
@@ -325,16 +320,11 @@ TEST(Einsum, ImplicitEinsumAsBatchedMatmulWithBroadcasting_0) {
 }
 
 TEST(Einsum, ImplicitEinsumAsMatmul_2) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(2068): The parameter is incorrect.";
-  }
-
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", "ij,jk");
   test.AddInput<float>("x", {2, 1}, {2.f, 3.f});
-  test.AddInput<float>("y", {2, 2}, {1.f, 2.f, 3.f, 4.f});
-  test.AddOutput<float>("o", {2, 2}, {8.f, 12.f, 12.f, 18.f});
+  test.AddInput<float>("y", {1, 2}, {1.f, 2.f});
+  test.AddOutput<float>("o", {2, 2}, {2.f, 4.f, 3.f, 6.f});
   test.Run();
 }
 
@@ -434,11 +424,6 @@ TEST(Einsum, ExplicitEinsumAsBatchedDiagonalOp_1) {
 
 // Implicit (Implicit diagonal ops will sum up diagonal values)
 TEST(Einsum, ImplicitEinsumAsDiagonalOp) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: The difference between expected[i] and output[i] is 5, which exceeds threshold";
-  }
-
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", "ii");
   test.AddInput<float>("x", {2, 2}, {1.f, 2.f, 3.f, 4.f});
@@ -447,11 +432,6 @@ TEST(Einsum, ImplicitEinsumAsDiagonalOp) {
 }
 
 TEST(Einsum, ImplicitEinsumAsDiagonalOp_1) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: error: The difference between expected[i] and output[i] is 15, which exceeds threshold";
-  }
-
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", "iii");
   test.AddInput<float>("x", {2, 2, 2}, {1.f, 2.f, 3.f, 4.f, 1.f, 2.f, 3.f, 4.f});
@@ -576,8 +556,8 @@ TEST(Einsum, ExplicitEinsumAsTensorContractionReshapeLeft) {
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", "bsnh,btnh->bnts");
   test.AddInput<float>("x", {2, 1, 2, 2}, {1.f, 2.f, 1.f, 2.f, 1.f, 2.f, 1.f, 2.f});
-  test.AddInput<float>("y", {2, 2, 2, 1}, {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f});
-  test.AddOutput<float>("o", {2, 2, 2, 1}, {3.f, 9.f, 6.f, 12.f, 15.f, 21.f, 18.f, 24.f});
+  test.AddInput<float>("y", {2, 2, 2, 2}, {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f, 13.f, 14.f, 15.f, 16.f});
+  test.AddOutput<float>("o", {2, 2, 2, 1}, {5.f, 17.f, 11.f, 23.f, 29.f, 41.f, 35.f, 47.f});
   test.Run();
 }
 

--- a/onnxruntime/test/providers/cpu/math/einsum_test.cc
+++ b/onnxruntime/test/providers/cpu/math/einsum_test.cc
@@ -561,6 +561,15 @@ TEST(Einsum, ExplicitEinsumAsTensorContractionReshapeLeft) {
   test.Run();
 }
 
+TEST(Einsum, ExplicitEinsumAsTensorContractionSameInput) {
+  OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
+  test.AddAttribute<std::string>("equation", "nchw,nchw->nch");
+  test.AddInput<float>("x", {1, 3, 2, 4}, {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f});
+  test.AddInput<float>("y", {1, 3, 2, 4}, {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f});
+  test.AddOutput<float>("o", {1, 3, 2}, {30.f, 174.f, 54.f, 230.f, 86.f, 294.f});
+  test.Run();
+}
+
 // Implicit
 TEST(Einsum, ImplicitEinsumAsTensorContraction) {
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);


### PR DESCRIPTION
### Problem
Newer models using more novel equations (e.g. `bhwc,hkc->bhwk` in Segment Anything's encoder or `bqc,bchw->bqhw`) cause fallback from DML to CPU, yielding performance issues. The EP had some pattern matching to map more common equations to existing DML operators, but the number of permutations was prohibitive and could not catch them all.

### Solution
So, ditch the static mapping, and instead handle any 1-input or 2-input cases via remapped strides and a mini-graph of elementwise multiplication & sum reduction (as if DML had a `DML_OPERATOR_DOT_PRODUCT` that took `axes`). A subset of mappings still exist for performance (GEMM, pure reduction, transpose...), but they are identified generally rather than via a pattern table. Also...

- Diagonals are supported now (e.g. iji->i).
- Removes any remaining DML-specific EinSum `GTEST_SKIP` statements.
- Handles any cases up to 8 unique labels (DML dimension limit is 8D).
- \>= 3 inputs and arbitrary size inputs via ellipsis are not handled, but we have yet to come across a model.