### PR TITLE
arm64: fix compilation failed when -mcpu is set by the toolchain

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -62,6 +62,20 @@ endif()
 
 set(ONNXRUNTIME_MLAS_LIBS onnxruntime_mlas)
 
+function(remove_mcpu_flags var_name)
+  set(_original "${${var_name}}")
+  string(REGEX REPLACE "-mcpu=[^ ]*" "" _updated "${_original}")
+  if (NOT _original STREQUAL _updated)
+      message("Dropped -mcpu flags from ${var_name} updated to: ${_updated}")
+      set(${var_name} "${_updated}" PARENT_SCOPE)
+  endif()
+endfunction()
+
+# Remove -mcpu flags from ASM, C and CXX flags
+remove_mcpu_flags(CMAKE_ASM_FLAGS)
+remove_mcpu_flags(CMAKE_C_FLAGS)
+remove_mcpu_flags(CMAKE_CXX_FLAGS)
+
 #TODO: set MASM flags properly
 function(setup_mlas_source_for_windows)
 


### PR DESCRIPTION
### Description
When building with a cross-toolchain some CXX_FLAGS could be set to a specific CPU.

This leads to a CPU not compatible with some specific functions compiles with ARCH v8.2+bf16

Error is :
cc1: error: switch '-mcpu=XXXX' conflicts with '-march=armv8.2-a+i8mm' switch

### Motivation and Context
As these functions are dispatched at runtime and as there is no -mno-cpu, force the -mcpu to be valid by forcing it to a valid combination of -march and -mcpu