### PR TITLE
Enabling S8S8 and S8U8 handling in QGemm for AVX2 and AVX-VNNI

### DIFF
--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -1081,6 +1081,8 @@ struct MLAS_PLATFORM {
 #if defined(MLAS_TARGET_AMD64_IX86)
     const MLAS_GEMM_QUANT_DISPATCH* GemmU8S8Dispatch;
     const MLAS_GEMM_QUANT_DISPATCH* GemmU8U8Dispatch;
+    const MLAS_GEMM_QUANT_DISPATCH* GemmS8S8Dispatch{&MlasGemmQuantDispatchDefault};
+    const MLAS_GEMM_QUANT_DISPATCH* GemmS8U8Dispatch{&MlasGemmQuantDispatchDefault};
 #elif defined(MLAS_TARGET_ARM64)
     const MLAS_GEMM_QUANT_DISPATCH* GemmU8U8Dispatch;
     const MLAS_GEMM_QUANT_DISPATCH* GemmU8S8Dispatch;

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -357,6 +357,8 @@ Return Value:
                 this->GemmU8U8Dispatch = &MlasGemmU8U8DispatchAvx2;
                 this->GemmU8U8Kernel = MlasGemmU8U8KernelAvx2;
                 this->ConvSymU8S8Dispatch = &MlasConvSymDispatchAvx2;
+                this->GemmS8S8Dispatch = &MlasGemmU8S8DispatchAvx2;
+                this->GemmS8U8Dispatch = &MlasGemmU8S8DispatchAvx2;
 
                 this->GemmFloatKernel = MlasGemmFloatKernelFma3;
                 this->GemmDoubleKernel = MlasGemmDoubleKernelFma3;

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -357,8 +357,6 @@ Return Value:
                 this->GemmU8U8Dispatch = &MlasGemmU8U8DispatchAvx2;
                 this->GemmU8U8Kernel = MlasGemmU8U8KernelAvx2;
                 this->ConvSymU8S8Dispatch = &MlasConvSymDispatchAvx2;
-                this->GemmS8S8Dispatch = &MlasGemmU8S8DispatchAvx2;
-                this->GemmS8U8Dispatch = &MlasGemmU8S8DispatchAvx2;
 
                 this->GemmFloatKernel = MlasGemmFloatKernelFma3;
                 this->GemmDoubleKernel = MlasGemmDoubleKernelFma3;
@@ -401,6 +399,8 @@ Return Value:
                 if ((Cpuid7_1[0] & 0x10) != 0) {
 
                     this->GemmU8U8Dispatch = &MlasGemmU8S8DispatchAvx2;
+                    this->GemmS8S8Dispatch = &MlasGemmU8S8DispatchAvx2;
+                    this->GemmS8U8Dispatch = &MlasGemmU8S8DispatchAvx2;
                     this->GemmU8S8Kernel = MlasGemmU8S8KernelAvxVnni;
                     this->GemvU8S8Kernel = MlasGemvU8S8KernelAvxVnni;
                     this->ConvSymU8S8Dispatch = &MlasConvSymDispatchAvxVnni;

--- a/onnxruntime/core/mlas/lib/qgemm.h
+++ b/onnxruntime/core/mlas/lib/qgemm.h
@@ -337,7 +337,7 @@ Return Value:
 
     //
     // Fixup the sign bit of the per-matrix zero point offset of matrix A if the
-    // kernel requires signed data.
+    // kernel requires opposite-signed data.
     //
 
     ZeroPointA = MlasGemmQuantFixupZeroPointA<KernelType>(ZeroPointA, Shape->AIsSigned);
@@ -872,13 +872,12 @@ MlasGemmQuantGetDispatch(
     }
 
 #if defined(MLAS_TARGET_AMD64_IX86) || defined(MLAS_TARGET_LARCH64)
-    if (!AIsSigned) {
-        if (BIsSigned) {
-            GemmQuantDispatch = GetMlasPlatform().GemmU8S8Dispatch;
-        }
-        else {
-            GemmQuantDispatch = GetMlasPlatform().GemmU8U8Dispatch;
-        }
+    if (AIsSigned) {
+        GemmQuantDispatch =
+            BIsSigned ? GetMlasPlatform().GemmS8S8Dispatch : GetMlasPlatform().GemmS8U8Dispatch;
+    } else {
+        GemmQuantDispatch =
+            BIsSigned ? GetMlasPlatform().GemmU8S8Dispatch : GetMlasPlatform().GemmU8U8Dispatch;
     }
 #elif defined(MLAS_TARGET_ARM64)
     if(BIsSigned) {

--- a/onnxruntime/core/mlas/lib/qgemm_kernel_avx2.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm_kernel_avx2.cpp
@@ -38,7 +38,8 @@ extern "C" {
         size_t lda,
         size_t CountM,
         size_t CountK,
-        int32_t* RowSumBuffer
+        int32_t* RowSumBuffer,
+        bool AIsSigned
         );
 
     void
@@ -117,6 +118,21 @@ MlasGemmQuantTryGemvKernel<MLAS_GEMM_U8S8_KERNEL_AVX2>(
 template<>
 MLAS_FORCEINLINE constexpr
 int32_t
+MlasGemmQuantFixupZeroPointA<MLAS_GEMM_U8S8_KERNEL_AVX2>(
+    int32_t ZeroPointA,
+    bool AIsSigned
+    )
+{
+    if (AIsSigned) {
+        ZeroPointA = MLAS_GEMM_U8S8_KERNEL_AVX2::OffsetAType(ZeroPointA ^ 0x80);
+    }
+
+    return ZeroPointA;
+}
+
+template<>
+MLAS_FORCEINLINE constexpr
+int32_t
 MlasGemmQuantFixupZeroPointB<MLAS_GEMM_U8S8_KERNEL_AVX2>(
     int32_t ZeroPointB,
     bool BIsSigned
@@ -142,8 +158,7 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_U8S8_KERNEL_AVX2>(
     bool AIsSigned
     )
 {
-    MLAS_UNREFERENCED_PARAMETER(AIsSigned);
-    MlasGemmU8S8CopyPackAAvx2(D, A, lda, CountM, CountK, RowSumBuffer);
+    MlasGemmU8S8CopyPackAAvx2(D, A, lda, CountM, CountK, RowSumBuffer, AIsSigned);
 }
 
 template<>

--- a/onnxruntime/core/mlas/lib/x86_64/QgemmU8S8KernelAvx2.S
+++ b/onnxruntime/core/mlas/lib/x86_64/QgemmU8S8KernelAvx2.S
@@ -32,6 +32,7 @@ Abstract:
         .equ    .LGemmU8S8CopyPackAFrame_SavedRbx, 16
         .equ    .LGemmU8S8CopyPackAFrame_SavedRbp, 24
         .equ    .LGemmU8S8CopyPackAFrame_ReturnAddress, 32
+        .equ    .LGemmU8S8CopyPackAFrame_AIsSigned, 40
 
 //
 // Stack frame layout for the U8S8 CopyPackB routine.
@@ -92,6 +93,16 @@ Return Value:
         vpor    ymm9,ymm8,ymm9              # generate word vector [0x0101]
 
 //
+// Compute bit flip vector to convert S8 to U8
+//
+        vpxor   ymm11,ymm11,ymm11
+        cmp     BYTE PTR .LGemmU8S8CopyPackAFrame_AIsSigned[rsp],0
+        jz     .LCopyPackA.SkipSignedBitFlipVector
+        vpsllw  ymm11,ymm9,7                # generate word vector [0x8080]
+
+.LCopyPackA.SkipSignedBitFlipVector:
+
+//
 // Compute the conditional load/store mask for an unaligned CountK.
 //
 
@@ -104,12 +115,11 @@ Return Value:
         vmovdqu xmm10,XMMWORD PTR [rbx+rax*4]
 
 //
-// Zero initialize the padded stack buffers.
+// Initialize the padded stack buffers. Zeroed if unsigned, bit-flip values if signed
 //
 
-        vpxor   xmm0,xmm0,xmm0
-        vmovdqu YMMWORD PTR .LGemmU8S8CopyPackAFrame_PaddedMatrixAData[rsp],ymm0
-        vmovdqu YMMWORD PTR .LGemmU8S8CopyPackAFrame_PaddedMatrixAData[rsp+32],ymm0
+        vmovdqu YMMWORD PTR .LGemmU8S8CopyPackAFrame_PaddedMatrixAData[rsp],ymm11
+        vmovdqu YMMWORD PTR .LGemmU8S8CopyPackAFrame_PaddedMatrixAData[rsp+32],ymm11
 
 //
 // Process 4 rows of matrix A in a loop.
@@ -138,6 +148,10 @@ Return Value:
         vmovdqu ymm5,YMMWORD PTR [rdx+r10]
         vmovdqu ymm6,YMMWORD PTR [rdx+r10*2]
         vmovdqu ymm7,YMMWORD PTR [rdx+r13]
+        vpxor   ymm4,ymm4,ymm11
+        vpxor   ymm5,ymm5,ymm11
+        vpxor   ymm6,ymm6,ymm11
+        vpxor   ymm7,ymm7,ymm11
         vmovdqu YMMWORD PTR [rcx],ymm4
         vmovdqu YMMWORD PTR [rcx+r12],ymm5
         vmovdqu YMMWORD PTR [rcx+r12*2],ymm6
@@ -164,6 +178,10 @@ Return Value:
         vmovdqu xmm5,XMMWORD PTR [rdx+r10]
         vmovdqu xmm6,XMMWORD PTR [rdx+r10*2]
         vmovdqu xmm7,XMMWORD PTR [rdx+r13]
+        vpxor   xmm4,xmm4,xmm11
+        vpxor   xmm5,xmm5,xmm11
+        vpxor   xmm6,xmm6,xmm11
+        vpxor   xmm7,xmm7,xmm11
         vmovdqu XMMWORD PTR [rcx],xmm4
         vmovdqu XMMWORD PTR [rcx+r12],xmm5
         vmovdqu XMMWORD PTR [rcx+r12*2],xmm6
@@ -250,6 +268,10 @@ Return Value:
         vmovdqu xmm6,XMMWORD PTR .LGemmU8S8CopyPackAFrame_PaddedMatrixAData[rsp+32]
         vmovdqu xmm7,XMMWORD PTR .LGemmU8S8CopyPackAFrame_PaddedMatrixAData[rsp+48]
         lea     rax,[rcx+r12*2]             # compute matrix D plus 2 rows
+        vpxor   xmm4,xmm4,xmm11
+        vpxor   xmm5,xmm5,xmm11
+        vpxor   xmm6,xmm6,xmm11
+        vpxor   xmm7,xmm7,xmm11
         vpmaskmovd XMMWORD PTR [rcx],xmm10,xmm4
         vpmaskmovd XMMWORD PTR [rcx+r12],xmm10,xmm5
         vpmaskmovd XMMWORD PTR [rax],xmm10,xmm6
@@ -302,6 +324,7 @@ Return Value:
 
 .LCopyPackA.ProcessNextColumnLoopM1:
         vmovdqu ymm4,YMMWORD PTR [rdx]
+        vpxor   ymm4,ymm4,ymm11
         vmovdqu YMMWORD PTR [rcx],ymm4
         vpmaddubsw ymm4,ymm4,ymm9           # horizontal byte+byte=word per row
         vpaddw  ymm0,ymm0,ymm4              # add words to row accumulators
@@ -316,6 +339,7 @@ Return Value:
         test    bl,16                       # (CountK & 16) != 0?
         jz      .LCopyPackA.CopyRemainingCountKLessThan16M1
         vmovdqu xmm4,XMMWORD PTR [rdx]
+        vpxor   xmm4,xmm4,xmm11
         vmovdqu XMMWORD PTR [rcx],xmm4
         vpmaddubsw xmm4,xmm4,xmm9           # horizontal byte+byte=word per row
         vpaddw  ymm0,ymm0,ymm4              # add words to row accumulators
@@ -365,6 +389,7 @@ Return Value:
 
 .LCopyPackA.ProcessPaddedMatrixADataM1:
         vmovdqu xmm4,XMMWORD PTR .LGemmU8S8CopyPackAFrame_PaddedMatrixAData[rsp]
+        vpxor   xmm4,xmm4,xmm11
         vpmaskmovd XMMWORD PTR [rcx],xmm10,xmm4
         vpmaddubsw ymm4,ymm4,ymm9           # horizontal byte+byte=word per row
         vpaddw  ymm0,ymm0,ymm4              # accumulate per row along columns

--- a/onnxruntime/test/mlas/unittest/test_qgemm.cpp
+++ b/onnxruntime/test/mlas/unittest/test_qgemm.cpp
@@ -10,6 +10,8 @@ static size_t QGemmRegistLongExecute() {
   count += MlasLongExecuteTests<MlasQgemmTest<uint8_t, uint8_t, int32_t, true, false>>::RegisterLongExecute();
   count += MlasLongExecuteTests<MlasQgemmTest<int8_t, int8_t, int32_t, false, false>>::RegisterLongExecute();
   count += MlasLongExecuteTests<MlasQgemmTest<int8_t, int8_t, int32_t, true, false>>::RegisterLongExecute();
+  count += MlasLongExecuteTests<MlasQgemmTest<int8_t, uint8_t, int32_t, false, false>>::RegisterLongExecute();
+  count += MlasLongExecuteTests<MlasQgemmTest<int8_t, uint8_t, int32_t, true, false>>::RegisterLongExecute();
 
   if (GetMlasThreadPool() != nullptr) {
     count += MlasLongExecuteTests<MlasQgemmTest<uint8_t, int8_t, int32_t, false, true>>::RegisterLongExecute();
@@ -18,6 +20,8 @@ static size_t QGemmRegistLongExecute() {
     count += MlasLongExecuteTests<MlasQgemmTest<uint8_t, uint8_t, int32_t, true, true>>::RegisterLongExecute();
     count += MlasLongExecuteTests<MlasQgemmTest<int8_t, int8_t, int32_t, false, true>>::RegisterLongExecute();
     count += MlasLongExecuteTests<MlasQgemmTest<int8_t, int8_t, int32_t, true, true>>::RegisterLongExecute();
+    count += MlasLongExecuteTests<MlasQgemmTest<int8_t, uint8_t, int32_t, false, true>>::RegisterLongExecute();
+    count += MlasLongExecuteTests<MlasQgemmTest<int8_t, uint8_t, int32_t, true, true>>::RegisterLongExecute();
   }
 
   return count;
@@ -32,6 +36,8 @@ static size_t QGemmRegistShortExecute() {
   count += QgemmShortExecuteTest<uint8_t, uint8_t, int32_t, false, false>::RegisterShortExecuteTests();
   count += QgemmShortExecuteTest<int8_t, int8_t, float, false, false>::RegisterShortExecuteTests();
   count += QgemmShortExecuteTest<int8_t, int8_t, int32_t, false, false>::RegisterShortExecuteTests();
+  count += QgemmShortExecuteTest<int8_t, uint8_t, float, false, false>::RegisterShortExecuteTests();
+  count += QgemmShortExecuteTest<int8_t, uint8_t, int32_t, false, false>::RegisterShortExecuteTests();
   if (MlasGemmPackBSize(128, 128, false /*AIsSigned*/, false /*BIsSigned*/) > 0) {
     // QGEMM U8U8=float packed tests
     count += QgemmShortExecuteTest<uint8_t, uint8_t, float, true, false>::RegisterShortExecuteTests();
@@ -44,11 +50,22 @@ static size_t QGemmRegistShortExecute() {
     // QGEMM U8S8=int32_t packed tests
     count += QgemmShortExecuteTest<uint8_t, int8_t, int32_t, true, false>::RegisterShortExecuteTests();
   }
-  if (MlasGemmPackBSize(128, 128, true /*AIsSigned*/, true /*BIsSigned*/) > 0) {
-    // QGEMM U8S8=float packed tests
-    count += QgemmShortExecuteTest<int8_t, int8_t, float, true, false>::RegisterShortExecuteTests();
-    // QGEMM U8S8=int32_t packed tests
-    count += QgemmShortExecuteTest<int8_t, int8_t, int32_t, true, false>::RegisterShortExecuteTests();
+  try {
+    if (MlasGemmPackBSize(128, 128, true /*AIsSigned*/, true /*BIsSigned*/) > 0) {
+      // QGEMM S8S8=float packed tests
+      count += QgemmShortExecuteTest<int8_t, int8_t, float, true, false>::RegisterShortExecuteTests();
+      // QGEMM S8S8=int32_t packed tests
+      count += QgemmShortExecuteTest<int8_t, int8_t, int32_t, true, false>::RegisterShortExecuteTests();
+    }
+    if (MlasGemmPackBSize(128, 128, true /*AIsSigned*/, false /*BIsSigned*/) > 0) {
+      // QGEMM S8U8=float packed tests
+      count += QgemmShortExecuteTest<int8_t, uint8_t, float, true, false>::RegisterShortExecuteTests();
+      // QGEMM S8U8=int32_t packed tests
+      count += QgemmShortExecuteTest<int8_t, uint8_t, int32_t, true, false>::RegisterShortExecuteTests();
+    }
+  } catch (const std::invalid_argument& e) {
+    (void)e;
+    // no support for these types on this device, ignore and continue
   }
 
   if (GetMlasThreadPool() != nullptr) {
@@ -58,6 +75,8 @@ static size_t QGemmRegistShortExecute() {
     count += QgemmShortExecuteTest<uint8_t, uint8_t, int32_t, false, true>::RegisterShortExecuteTests();
     count += QgemmShortExecuteTest<int8_t, int8_t, float, false, true>::RegisterShortExecuteTests();
     count += QgemmShortExecuteTest<int8_t, int8_t, int32_t, false, true>::RegisterShortExecuteTests();
+    count += QgemmShortExecuteTest<int8_t, uint8_t, float, false, true>::RegisterShortExecuteTests();
+    count += QgemmShortExecuteTest<int8_t, uint8_t, int32_t, false, true>::RegisterShortExecuteTests();
     if (MlasGemmPackBSize(128, 128, false /*AIsSigned*/, false /*BIsSigned*/) > 0) {
       count += QgemmShortExecuteTest<uint8_t, uint8_t, float, true, true>::RegisterShortExecuteTests();
       count += QgemmShortExecuteTest<uint8_t, uint8_t, int32_t, true, true>::RegisterShortExecuteTests();
@@ -66,9 +85,18 @@ static size_t QGemmRegistShortExecute() {
       count += QgemmShortExecuteTest<uint8_t, int8_t, float, true, true>::RegisterShortExecuteTests();
       count += QgemmShortExecuteTest<uint8_t, int8_t, int32_t, true, true>::RegisterShortExecuteTests();
     }
-    if (MlasGemmPackBSize(128, 128, true /*AIsSigned*/, true /*BIsSigned*/) > 0) {
-      count += QgemmShortExecuteTest<int8_t, int8_t, float, true, true>::RegisterShortExecuteTests();
-      count += QgemmShortExecuteTest<int8_t, int8_t, int32_t, true, true>::RegisterShortExecuteTests();
+    try {
+      if (MlasGemmPackBSize(128, 128, true /*AIsSigned*/, true /*BIsSigned*/) > 0) {
+        count += QgemmShortExecuteTest<int8_t, int8_t, float, true, true>::RegisterShortExecuteTests();
+        count += QgemmShortExecuteTest<int8_t, int8_t, int32_t, true, true>::RegisterShortExecuteTests();
+      }
+      if (MlasGemmPackBSize(128, 128, true /*AIsSigned*/, false /*BIsSigned*/) > 0) {
+        count += QgemmShortExecuteTest<int8_t, uint8_t, float, true, false>::RegisterShortExecuteTests();
+        count += QgemmShortExecuteTest<int8_t, uint8_t, int32_t, true, false>::RegisterShortExecuteTests();
+      }
+    } catch (const std::invalid_argument& e) {
+      (void)e;
+      // no support for these types on this device, ignore and continue
     }
   }
 

--- a/onnxruntime/test/mlas/unittest/test_qgemm.cpp
+++ b/onnxruntime/test/mlas/unittest/test_qgemm.cpp
@@ -50,22 +50,17 @@ static size_t QGemmRegistShortExecute() {
     // QGEMM U8S8=int32_t packed tests
     count += QgemmShortExecuteTest<uint8_t, int8_t, int32_t, true, false>::RegisterShortExecuteTests();
   }
-  try {
-    if (MlasGemmPackBSize(128, 128, true /*AIsSigned*/, true /*BIsSigned*/) > 0) {
-      // QGEMM S8S8=float packed tests
-      count += QgemmShortExecuteTest<int8_t, int8_t, float, true, false>::RegisterShortExecuteTests();
-      // QGEMM S8S8=int32_t packed tests
-      count += QgemmShortExecuteTest<int8_t, int8_t, int32_t, true, false>::RegisterShortExecuteTests();
-    }
-    if (MlasGemmPackBSize(128, 128, true /*AIsSigned*/, false /*BIsSigned*/) > 0) {
-      // QGEMM S8U8=float packed tests
-      count += QgemmShortExecuteTest<int8_t, uint8_t, float, true, false>::RegisterShortExecuteTests();
-      // QGEMM S8U8=int32_t packed tests
-      count += QgemmShortExecuteTest<int8_t, uint8_t, int32_t, true, false>::RegisterShortExecuteTests();
-    }
-  } catch (const std::invalid_argument& e) {
-    (void)e;
-    // no support for these types on this device, ignore and continue
+  if (MlasGemmPackBSize(128, 128, true /*AIsSigned*/, true /*BIsSigned*/) > 0) {
+    // QGEMM S8S8=float packed tests
+    count += QgemmShortExecuteTest<int8_t, int8_t, float, true, false>::RegisterShortExecuteTests();
+    // QGEMM S8S8=int32_t packed tests
+    count += QgemmShortExecuteTest<int8_t, int8_t, int32_t, true, false>::RegisterShortExecuteTests();
+  }
+  if (MlasGemmPackBSize(128, 128, true /*AIsSigned*/, false /*BIsSigned*/) > 0) {
+    // QGEMM S8U8=float packed tests
+    count += QgemmShortExecuteTest<int8_t, uint8_t, float, true, false>::RegisterShortExecuteTests();
+    // QGEMM S8U8=int32_t packed tests
+    count += QgemmShortExecuteTest<int8_t, uint8_t, int32_t, true, false>::RegisterShortExecuteTests();
   }
 
   if (GetMlasThreadPool() != nullptr) {
@@ -85,18 +80,13 @@ static size_t QGemmRegistShortExecute() {
       count += QgemmShortExecuteTest<uint8_t, int8_t, float, true, true>::RegisterShortExecuteTests();
       count += QgemmShortExecuteTest<uint8_t, int8_t, int32_t, true, true>::RegisterShortExecuteTests();
     }
-    try {
-      if (MlasGemmPackBSize(128, 128, true /*AIsSigned*/, true /*BIsSigned*/) > 0) {
-        count += QgemmShortExecuteTest<int8_t, int8_t, float, true, true>::RegisterShortExecuteTests();
-        count += QgemmShortExecuteTest<int8_t, int8_t, int32_t, true, true>::RegisterShortExecuteTests();
-      }
-      if (MlasGemmPackBSize(128, 128, true /*AIsSigned*/, false /*BIsSigned*/) > 0) {
-        count += QgemmShortExecuteTest<int8_t, uint8_t, float, true, false>::RegisterShortExecuteTests();
-        count += QgemmShortExecuteTest<int8_t, uint8_t, int32_t, true, false>::RegisterShortExecuteTests();
-      }
-    } catch (const std::invalid_argument& e) {
-      (void)e;
-      // no support for these types on this device, ignore and continue
+    if (MlasGemmPackBSize(128, 128, true /*AIsSigned*/, true /*BIsSigned*/) > 0) {
+      count += QgemmShortExecuteTest<int8_t, int8_t, float, true, true>::RegisterShortExecuteTests();
+      count += QgemmShortExecuteTest<int8_t, int8_t, int32_t, true, true>::RegisterShortExecuteTests();
+    }
+    if (MlasGemmPackBSize(128, 128, true /*AIsSigned*/, false /*BIsSigned*/) > 0) {
+      count += QgemmShortExecuteTest<int8_t, uint8_t, float, true, false>::RegisterShortExecuteTests();
+      count += QgemmShortExecuteTest<int8_t, uint8_t, int32_t, true, false>::RegisterShortExecuteTests();
     }
   }
 

--- a/onnxruntime/test/mlas/unittest/test_qgemm.cpp
+++ b/onnxruntime/test/mlas/unittest/test_qgemm.cpp
@@ -85,8 +85,8 @@ static size_t QGemmRegistShortExecute() {
       count += QgemmShortExecuteTest<int8_t, int8_t, int32_t, true, true>::RegisterShortExecuteTests();
     }
     if (MlasGemmPackBSize(128, 128, true /*AIsSigned*/, false /*BIsSigned*/) > 0) {
-      count += QgemmShortExecuteTest<int8_t, uint8_t, float, true, false>::RegisterShortExecuteTests();
-      count += QgemmShortExecuteTest<int8_t, uint8_t, int32_t, true, false>::RegisterShortExecuteTests();
+      count += QgemmShortExecuteTest<int8_t, uint8_t, float, true, true>::RegisterShortExecuteTests();
+      count += QgemmShortExecuteTest<int8_t, uint8_t, int32_t, true, true>::RegisterShortExecuteTests();
     }
   }
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Implementation of sign flipping in QGemm CopyPackA to enable S8S8 and S8U8 handling in AVX2 and AVX-VNNI.
Added dispatching for S8S8 and S8U8 variants, defaulting to C++ implementation if AVX2 is not present.
Added unit testing triggers for S8S8 and S8U8.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
QGemm kernel expects data in U8S8 form to utilize AVX-VNNI dot product instructions and the corresponding performance benefits. 
Existing code can sign-flip the B matrix from unsigned to signed to allow U8U8 data to use this U8S8 VNNI instruction.
This code enables sign flipping in the A matrix to also allow S8S8 and S8U8 models to be translated into U8S8 form and use the VNNI instructions.
This change will enable models of any int8 data format to be handled by onnxruntime and see the same performance benefits.
