### PR TITLE
[Fix] use cmdline in Final Jar Testing Stage for new managed Windows Image

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/final-jar-testing.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/final-jar-testing.yml
@@ -53,24 +53,35 @@ stages:
         SpecificArtifact: ${{ parameters.SpecificArtifact }}
         BuildId: ${{ parameters.BuildId }}
 
-    - task: Bash@3
-      inputs:
-        targetType: 'inline'
-        script: |
-          echo "Java Version"
-          java --version
-          mkdir test
-          pushd test
-          jar xf '$(Build.BinariesDirectory)/final-jar/testing.jar'
-          popd
-          # if you want to run the tests in the power shell, you need to replace ':' to ';', that is,  "-cp .;.\test;protobuf-java-3.21.7.jar;onnxruntime-$(OnnxRuntimeVersion).jar"
-          java -jar ./junit-platform-console-standalone-1.6.2.jar -cp .:./test:./protobuf-java-3.21.7.jar:./onnxruntime-$(OnnxRuntimeVersion).jar --scan-class-path --fail-if-no-tests --disable-banner
-        workingDirectory: '$(Build.BinariesDirectory)/final-jar'
-      env:
-        ${{ if eq(parameters.OS, 'MacOS') }}:
-          DYLD_LIBRARY_PATH: '$(Build.BinariesDirectory)/final-jar/test:$(DYLD_LIBRARY_PATH)'
-        ${{ if eq(parameters.OS, 'Linux') }}:
-          LD_LIBRARY_PATH: '$(Build.BinariesDirectory)/final-jar/test:$(LD_LIBRARY_PATH)'
+    - ${{ if eq(parameters.OS, 'Windows') }}:
+      - task: CmdLine@2
+        inputs:
+          script: |
+            mkdir test
+            pushd test
+            jar xf $(Build.BinariesDirectory)\final-jar\testing.jar
+            popd
+            java -jar junit-platform-console-standalone-1.6.2.jar -cp .;.\test;protobuf-java-3.21.7.jar;onnxruntime-$(OnnxRuntimeVersion).jar --scan-class-path --fail-if-no-tests --disable-banner
+          workingDirectory: '$(Build.BinariesDirectory)\final-jar'
+    - ${{ else }}:
+      - task: Bash@3
+        inputs:
+          targetType: 'inline'
+          script: |
+            echo "Java Version"
+            java --version
+            mkdir test
+            pushd test
+            jar xf '$(Build.BinariesDirectory)/final-jar/testing.jar'
+            popd
+            # if you want to run the tests in the power shell, you need to replace ':' to ';', that is,  "-cp .;.\test;protobuf-java-3.21.7.jar;onnxruntime-$(OnnxRuntimeVersion).jar"
+            java -jar ./junit-platform-console-standalone-1.6.2.jar -cp .:./test:./protobuf-java-3.21.7.jar:./onnxruntime-$(OnnxRuntimeVersion).jar --scan-class-path --fail-if-no-tests --disable-banner
+          workingDirectory: '$(Build.BinariesDirectory)/final-jar'
+        env:
+          ${{ if eq(parameters.OS, 'MacOS') }}:
+            DYLD_LIBRARY_PATH: '$(Build.BinariesDirectory)/final-jar/test:$(DYLD_LIBRARY_PATH)'
+          ${{ if eq(parameters.OS, 'Linux') }}:
+            LD_LIBRARY_PATH: '$(Build.BinariesDirectory)/final-jar/test:$(LD_LIBRARY_PATH)'
 
     - ${{ if eq(parameters['OS'], 'MacOS') }}:
       - template: use-xcode-version.yml


### PR DESCRIPTION
### Description
No bash command in Managed Windows image.
Use CmdlLine step instead.



### Verified Link
https://dev.azure.com/aiinfra/Lotus/_build/results?buildId=491902&view=logs&j=f1f8e11e-a9fa-53e5-cd29-3ba2c1988550


