### PR TITLE
Add QNN UTs for QNN Pad Op with FP16 data on HTP backend

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/pad_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/pad_op_builder.cc
@@ -227,10 +227,10 @@ Status PadOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrap
   param_tensor_names.push_back(mode_param.GetParamTensorName());
   qnn_model_wrapper.AddParamWrapper(std::move(mode_param));
 
-  QnnParamWrapper multiples_param(node_unit.Index(), node_unit.Name(), QNN_OP_PAD_PARAM_PAD_AMOUNT,
+  QnnParamWrapper pad_amount_param(node_unit.Index(), node_unit.Name(), QNN_OP_PAD_PARAM_PAD_AMOUNT,
                                   std::move(pad_amount_dim), std::move(pad_amount));
-  param_tensor_names.push_back(multiples_param.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(multiples_param));
+  param_tensor_names.push_back(pad_amount_param.GetParamTensorName());
+  qnn_model_wrapper.AddParamWrapper(std::move(pad_amount_param));
 
   // Process optional input constant_value
   if (node_unit.Inputs().size() > 2) {

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/pad_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/pad_op_builder.cc
@@ -228,7 +228,7 @@ Status PadOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrap
   qnn_model_wrapper.AddParamWrapper(std::move(mode_param));
 
   QnnParamWrapper pad_amount_param(node_unit.Index(), node_unit.Name(), QNN_OP_PAD_PARAM_PAD_AMOUNT,
-                                  std::move(pad_amount_dim), std::move(pad_amount));
+                                   std::move(pad_amount_dim), std::move(pad_amount));
   param_tensor_names.push_back(pad_amount_param.GetParamTensorName());
   qnn_model_wrapper.AddParamWrapper(std::move(pad_amount_param));
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/pad_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/pad_op_builder.cc
@@ -51,7 +51,7 @@ Status PadOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
     auto& pads_input_name = inputs[1].node_arg.Name();
     ORT_RETURN_IF_NOT(qnn_model_wrapper.IsInitializerInput(pads_input_name),
                       "Qnn doesn't support dynamic pad input");
-    if (node_unit.Inputs().size() > 2) {
+    if (inputs.size() > 2 && inputs[2].node_arg.Exists()) {
       auto& constant_value_input_name = inputs[2].node_arg.Name();
       ORT_RETURN_IF_NOT(qnn_model_wrapper.IsInitializerInput(constant_value_input_name),
                         "Qnn doesn't support dynamic constant_value input");
@@ -233,7 +233,7 @@ Status PadOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrap
   qnn_model_wrapper.AddParamWrapper(std::move(pad_amount_param));
 
   // Process optional input constant_value
-  if (node_unit.Inputs().size() > 2) {
+  if (inputs.size() > 2 && inputs[2].node_arg.Exists()) {
     ORT_RETURN_IF_ERROR(ProcessConstantValue(qnn_model_wrapper, param_tensor_names, node_unit, inputs[2]));
   }  // constant_value
 

--- a/onnxruntime/test/providers/qnn/pad_op_test.cpp
+++ b/onnxruntime/test/providers/qnn/pad_op_test.cpp
@@ -98,18 +98,33 @@ static void RunPadOpTest(const TestInputDef<float>& data_def,
                          const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
                          ExpectedEPNodeAssignment expected_ep_assignment,
                          bool has_constant_value = true,
-                         int opset = 18) {
+                         int opset = 18,
+                         bool use_htp = false,
+                         bool enable_fp16_precision = false,
+                         float f32_abs_err = 1e-5f) {
   ProviderOptions provider_options;
+  if (use_htp) {
 #if defined(_WIN32)
-  provider_options["backend_path"] = "QnnCpu.dll";
+    provider_options["backend_path"] = "QnnHtp.dll";
 #else
-  provider_options["backend_path"] = "libQnnCpu.so";
+    provider_options["backend_path"] = "libQnnHtp.so";
 #endif
+  } else {
+#if defined(_WIN32)
+    provider_options["backend_path"] = "QnnCpu.dll";
+#else
+    provider_options["backend_path"] = "libQnnCpu.so";
+#endif
+  }
+
+  if (enable_fp16_precision) {
+    provider_options["enable_htp_fp16_precision"] = "1";
+  }
 
   RunQnnModelTest(BuildPadTestCase(data_def, pads_def, constant_value_def, attrs, has_constant_value),
                   provider_options,
                   opset,
-                  expected_ep_assignment);
+                  expected_ep_assignment, f32_abs_err);
 }
 
 // Runs a QDQ Pad model on the QNN HTP backend. Checks the graph node assignment, and that inference
@@ -229,6 +244,60 @@ TEST_F(QnnCPUBackendTests, Pad6d) {
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 //
 // HTP tests:
+TEST_F(QnnHTPBackendTests, PadNoConstantValue_fp16_test) {
+  bool has_constant_value_input = false;
+  bool use_htp = true;
+  bool enable_fp16_precision = true;
+  RunPadOpTest(TestInputDef<float>({3, 2}, false, {1.0f, 1.2f, 2.3f, 3.4f, 4.5f, 5.6f}),
+               TestInputDef<int64_t>({4}, true, {0, 2, 0, 0}),
+               TestInputDef<float>({1}, true, {0.0f}),
+               {utils::MakeAttribute("mode", "constant")},
+               ExpectedEPNodeAssignment::All,
+               has_constant_value_input,
+               18,  // opset
+               use_htp,
+               enable_fp16_precision,
+               2e-3f);
+}
+
+TEST_F(QnnHTPBackendTests, PadReflectMode_fp16) {
+  bool has_constant_value_input = false;
+  bool use_htp = true;
+  bool enable_fp16_precision = true;
+  RunPadOpTest(TestInputDef<float>({3, 2}, false, {1.0f, 1.2f, 2.3f, 3.4f, 4.5f, 5.6f}),
+               TestInputDef<int64_t>({4}, true, {0, 1, 0, 0}),
+               TestInputDef<float>({1}, true, {0.0f}),
+               {utils::MakeAttribute("mode", "reflect")},
+               ExpectedEPNodeAssignment::All,
+               has_constant_value_input,
+               18,     // opset
+               use_htp,
+               enable_fp16_precision,
+               2e-3f);
+}
+
+// HTP\HTP\src\hexagon\prepare\graph_prepare.cc:203:ERROR:could not create op: q::flat_from_vtcm
+// HTP\HTP\src\hexagon\prepare\graph_prepare.cc:1238:ERROR:Op 0x104100000011 preparation failed with err:-1
+// Completed stage: Graph Transformations and Optimizations (13372 us)
+// QnnDsp <E> "node" generated: could not create op
+// QnnDsp <E> RouterWindows graph prepare failed 12
+// QnnDsp <E> Failed to finalize graph (id: 1) with err 1002
+TEST_F(QnnHTPBackendTests, DISABLED_PadReflectMode_FP16_big_data) {
+  bool has_constant_value_input = false;
+  bool use_htp = true;
+  bool enable_fp16_precision = true;
+  RunPadOpTest(TestInputDef<float>({1, 4, 512, 512}, false, GetFloatDataInRange(1.0f, 10.0f, 4 * 512 * 512)),
+               TestInputDef<int64_t>({8}, true, {0, 0, 3, 3, 0, 0, 3, 3}),
+               TestInputDef<float>({1}, true, {0.0f}),
+               {utils::MakeAttribute("mode", "reflect")},
+               ExpectedEPNodeAssignment::All,
+               has_constant_value_input,
+               18,  // opset
+               use_htp,
+               enable_fp16_precision,
+               2e-3f);
+}
+
 //
 // QDQ Pad
 TEST_F(QnnHTPBackendTests, PadNoConstantValue) {

--- a/onnxruntime/test/providers/qnn/pad_op_test.cpp
+++ b/onnxruntime/test/providers/qnn/pad_op_test.cpp
@@ -270,7 +270,7 @@ TEST_F(QnnHTPBackendTests, PadReflectMode_fp16) {
                {utils::MakeAttribute("mode", "reflect")},
                ExpectedEPNodeAssignment::All,
                has_constant_value_input,
-               18,     // opset
+               18,  // opset
                use_htp,
                enable_fp16_precision,
                2e-3f);

--- a/onnxruntime/test/providers/qnn/reduce_op_test.cc
+++ b/onnxruntime/test/providers/qnn/reduce_op_test.cc
@@ -60,30 +60,42 @@ static GetTestModelFn BuildReduceOpTestCase(const std::string& reduce_op_type,
 }
 
 /**
- * Runs a ReduceOp model on the QNN CPU backend. Checks the graph node assignment, and that inference
+ * Runs a ReduceOp model on the QNN CPU/NPU backend. Checks the graph node assignment, and that inference
  * outputs for QNN and CPU match.
  *
  * \param op_type The ReduceOp type (e.g., ReduceSum).
  * \param input_def The input definition (shape, data, etc.)
  * \param axes The axes of reduction.
+ * \param keepdims Common attribute for all reduce operations.
  * \param opset The opset version. Some opset versions have "axes" as an attribute or input.
  * \param expected_ep_assignment How many nodes are expected to be assigned to QNN (All, Some, or None)
- * \param keepdims Common attribute for all reduce operations.
+ * \param fp32_abs_err Error tolerance.
+ * \param enable_fp16 Enable fp32 model with FP16 precision on NPU.
  */
 template <typename DataType>
-static void RunReduceOpCpuTest(const std::string& op_type,
-                               const TestInputDef<DataType>& input_def,
-                               const std::vector<int64_t>& axes,
-                               bool keepdims,
-                               int opset,
-                               ExpectedEPNodeAssignment expected_ep_assignment,
-                               float fp32_abs_err = 1e-5f) {
+static void RunReduceTest(const std::string& op_type,
+                          const TestInputDef<DataType>& input_def,
+                          const std::vector<int64_t>& axes,
+                          bool keepdims,
+                          int opset,
+                          ExpectedEPNodeAssignment expected_ep_assignment,
+                          float fp32_abs_err = 1e-5f,
+                          bool enable_fp16 = false) {
   ProviderOptions provider_options;
+  if (enable_fp16) {
 #if defined(_WIN32)
-  provider_options["backend_path"] = "QnnCpu.dll";
+    provider_options["backend_path"] = "QnnHtp.dll";
 #else
-  provider_options["backend_path"] = "libQnnCpu.so";
+    provider_options["backend_path"] = "libQnnHtp.so";
 #endif
+    provider_options["enable_htp_fp16_precision"] = "1";
+  } else {
+#if defined(_WIN32)
+    provider_options["backend_path"] = "QnnCpu.dll";
+#else
+    provider_options["backend_path"] = "libQnnCpu.so";
+#endif
+  }
 
   RunQnnModelTest(BuildReduceOpTestCase<DataType>(op_type,
                                                   input_def,  //{2, 2},  // input shape
@@ -107,12 +119,12 @@ static void RunReduceOpCpuTest(const std::string& op_type,
 // - The input and output data type is int32.
 // - Uses opset 13, which has "axes" as an input.
 TEST_F(QnnCPUBackendTests, ReduceSumOpset13_Int32) {
-  RunReduceOpCpuTest<int32_t>("ReduceSum",
-                              TestInputDef<int32_t>({2, 2}, false, -10.0f, 10.0f),
-                              std::vector<int64_t>{0, 1},
-                              true,  // keepdims
-                              13,
-                              ExpectedEPNodeAssignment::All);
+  RunReduceTest<int32_t>("ReduceSum",
+                         TestInputDef<int32_t>({2, 2}, false, -10.0f, 10.0f),
+                         std::vector<int64_t>{0, 1},
+                         true,  // keepdims
+                         13,
+                         ExpectedEPNodeAssignment::All);
 }
 
 // Test creates a graph with a ReduceSum node, and checks that all
@@ -121,12 +133,12 @@ TEST_F(QnnCPUBackendTests, ReduceSumOpset13_Int32) {
 // - The input and output data type is int32.
 // - Uses opset 11, which has "axes" as an attribute.
 TEST_F(QnnCPUBackendTests, ReduceSumOpset11_Int32) {
-  RunReduceOpCpuTest<int32_t>("ReduceSum",
-                              TestInputDef<int32_t>({2, 2}, false, -10.0f, 10.0f),
-                              std::vector<int64_t>{0, 1},
-                              true,  // keepdims
-                              11,
-                              ExpectedEPNodeAssignment::All);
+  RunReduceTest<int32_t>("ReduceSum",
+                         TestInputDef<int32_t>({2, 2}, false, -10.0f, 10.0f),
+                         std::vector<int64_t>{0, 1},
+                         true,  // keepdims
+                         11,
+                         ExpectedEPNodeAssignment::All);
 }
 
 // Test creates a graph with a ReduceSum node, and checks that all
@@ -135,12 +147,12 @@ TEST_F(QnnCPUBackendTests, ReduceSumOpset11_Int32) {
 // - The input and output data type is float.
 // - Uses opset 13, which has "axes" as an input.
 TEST_F(QnnCPUBackendTests, ReduceSumOpset13_Float) {
-  RunReduceOpCpuTest<float>("ReduceSum",
-                            TestInputDef<float>({2, 2}, false, -10.0f, 10.0f),
-                            std::vector<int64_t>{0, 1},
-                            true,  // keepdims
-                            13,
-                            ExpectedEPNodeAssignment::All);
+  RunReduceTest<float>("ReduceSum",
+                       TestInputDef<float>({2, 2}, false, -10.0f, 10.0f),
+                       std::vector<int64_t>{0, 1},
+                       true,  // keepdims
+                       13,
+                       ExpectedEPNodeAssignment::All);
 }
 
 // Test creates a graph with a ReduceSum node, and checks that all
@@ -149,12 +161,12 @@ TEST_F(QnnCPUBackendTests, ReduceSumOpset13_Float) {
 // - The input and output data type is float.
 // - Uses opset 11, which has "axes" as an attribute.
 TEST_F(QnnCPUBackendTests, ReduceSumOpset11_Float) {
-  RunReduceOpCpuTest<float>("ReduceSum",
-                            TestInputDef<float>({2, 2}, false, -10.0f, 10.0f),
-                            std::vector<int64_t>{0, 1},
-                            true,  // keepdims
-                            11,
-                            ExpectedEPNodeAssignment::All);
+  RunReduceTest<float>("ReduceSum",
+                       TestInputDef<float>({2, 2}, false, -10.0f, 10.0f),
+                       std::vector<int64_t>{0, 1},
+                       true,  // keepdims
+                       11,
+                       ExpectedEPNodeAssignment::All);
 }
 
 //
@@ -167,24 +179,24 @@ TEST_F(QnnCPUBackendTests, ReduceSumOpset11_Float) {
 // - The input and output data type is float.
 // - Uses opset 18, which has "axes" as an input.
 TEST_F(QnnCPUBackendTests, ReduceProdOpset18) {
-  RunReduceOpCpuTest<float>("ReduceProd",
-                            TestInputDef<float>({2, 2}, false, {-10.0f, -8.2f, 0.0f, 10.0f}),
-                            std::vector<int64_t>{0, 1},
-                            true,  // keepdims
-                            18,
-                            ExpectedEPNodeAssignment::All);
+  RunReduceTest<float>("ReduceProd",
+                       TestInputDef<float>({2, 2}, false, {-10.0f, -8.2f, 0.0f, 10.0f}),
+                       std::vector<int64_t>{0, 1},
+                       true,  // keepdims
+                       18,
+                       ExpectedEPNodeAssignment::All);
 }
 
 // TODO: Investigate slight inaccuracy. x64 Windows/Linux require a slightly larger error tolerance greater than 1.5e-5f.
 // LOG: ... the value pair (208.881729, 208.881744) at index #0 don't match, which is 1.52588e-05 from 208.882
 TEST_F(QnnCPUBackendTests, ReduceProdOpset18_SlightlyInaccurate_WindowsLinuxX64) {
-  RunReduceOpCpuTest<float>("ReduceProd",
-                            TestInputDef<float>({2, 2}, false, {3.21289f, -5.9981f, -1.72799f, 6.27263f}),
-                            std::vector<int64_t>{0, 1},
-                            true,  // keepdims
-                            18,
-                            ExpectedEPNodeAssignment::All,
-                            2e-5f);  // x64 Linux & Windows require larger tolerance.
+  RunReduceTest<float>("ReduceProd",
+                       TestInputDef<float>({2, 2}, false, {3.21289f, -5.9981f, -1.72799f, 6.27263f}),
+                       std::vector<int64_t>{0, 1},
+                       true,  // keepdims
+                       18,
+                       ExpectedEPNodeAssignment::All,
+                       2e-5f);  // x64 Linux & Windows require larger tolerance.
 }
 
 // Test creates a graph with a ReduceProd node, and checks that all
@@ -193,12 +205,12 @@ TEST_F(QnnCPUBackendTests, ReduceProdOpset18_SlightlyInaccurate_WindowsLinuxX64)
 // - The input and output data type is float.
 // - Uses opset 13, which has "axes" as an attribute.
 TEST_F(QnnCPUBackendTests, ReduceProdOpset13) {
-  RunReduceOpCpuTest<float>("ReduceProd",
-                            TestInputDef<float>({2, 2}, false, {-10.0f, -8.2f, 0.0f, 10.0f}),
-                            std::vector<int64_t>{0, 1},
-                            true,  // keepdims
-                            13,
-                            ExpectedEPNodeAssignment::All);
+  RunReduceTest<float>("ReduceProd",
+                       TestInputDef<float>({2, 2}, false, {-10.0f, -8.2f, 0.0f, 10.0f}),
+                       std::vector<int64_t>{0, 1},
+                       true,  // keepdims
+                       13,
+                       ExpectedEPNodeAssignment::All);
 }
 
 //
@@ -211,12 +223,12 @@ TEST_F(QnnCPUBackendTests, ReduceProdOpset13) {
 // - The input and output data type is float.
 // - Uses opset 18, which has "axes" as an input.
 TEST_F(QnnCPUBackendTests, ReduceMaxOpset18) {
-  RunReduceOpCpuTest<float>("ReduceMax",
-                            TestInputDef<float>({2, 2}, false, -10.0f, 10.0f),
-                            std::vector<int64_t>{0, 1},
-                            true,  // keepdims
-                            18,
-                            ExpectedEPNodeAssignment::All);
+  RunReduceTest<float>("ReduceMax",
+                       TestInputDef<float>({2, 2}, false, -10.0f, 10.0f),
+                       std::vector<int64_t>{0, 1},
+                       true,  // keepdims
+                       18,
+                       ExpectedEPNodeAssignment::All);
 }
 
 // Test creates a graph with a ReduceMax node, and checks that all
@@ -225,12 +237,12 @@ TEST_F(QnnCPUBackendTests, ReduceMaxOpset18) {
 // - The input and output data type is float.
 // - Uses opset 13, which has "axes" as an attribute.
 TEST_F(QnnCPUBackendTests, ReduceMaxOpset13) {
-  RunReduceOpCpuTest<float>("ReduceMax",
-                            TestInputDef<float>({2, 2}, false, -10.0f, 10.0f),
-                            std::vector<int64_t>{0, 1},
-                            true,  // keepdims
-                            13,
-                            ExpectedEPNodeAssignment::All);
+  RunReduceTest<float>("ReduceMax",
+                       TestInputDef<float>({2, 2}, false, -10.0f, 10.0f),
+                       std::vector<int64_t>{0, 1},
+                       true,  // keepdims
+                       13,
+                       ExpectedEPNodeAssignment::All);
 }
 
 //
@@ -243,12 +255,12 @@ TEST_F(QnnCPUBackendTests, ReduceMaxOpset13) {
 // - The input and output data type is float.
 // - Uses opset 18, which has "axes" as an input.
 TEST_F(QnnCPUBackendTests, ReduceMinOpset18) {
-  RunReduceOpCpuTest<float>("ReduceMin",
-                            TestInputDef<float>({2, 2}, false, -10.0f, 10.0f),
-                            std::vector<int64_t>{0, 1},
-                            true,  // keepdims
-                            18,
-                            ExpectedEPNodeAssignment::All);
+  RunReduceTest<float>("ReduceMin",
+                       TestInputDef<float>({2, 2}, false, -10.0f, 10.0f),
+                       std::vector<int64_t>{0, 1},
+                       true,  // keepdims
+                       18,
+                       ExpectedEPNodeAssignment::All);
 }
 
 // Test creates a graph with a ReduceMin node, and checks that all
@@ -257,12 +269,12 @@ TEST_F(QnnCPUBackendTests, ReduceMinOpset18) {
 // - The input and output data type is float.
 // - Uses opset 13, which has "axes" as an attribute.
 TEST_F(QnnCPUBackendTests, ReduceMinOpset13) {
-  RunReduceOpCpuTest<float>("ReduceMin",
-                            TestInputDef<float>({2, 2}, false, -10.0f, 10.0f),
-                            std::vector<int64_t>{0, 1},
-                            true,  // keepdims
-                            13,
-                            ExpectedEPNodeAssignment::All);
+  RunReduceTest<float>("ReduceMin",
+                       TestInputDef<float>({2, 2}, false, -10.0f, 10.0f),
+                       std::vector<int64_t>{0, 1},
+                       true,  // keepdims
+                       13,
+                       ExpectedEPNodeAssignment::All);
 }
 
 //
@@ -275,12 +287,12 @@ TEST_F(QnnCPUBackendTests, ReduceMinOpset13) {
 // - The input and output data type is float.
 // - Uses opset 18, which has "axes" as an input.
 TEST_F(QnnCPUBackendTests, ReduceMeanOpset18) {
-  RunReduceOpCpuTest<float>("ReduceMean",
-                            TestInputDef<float>({2, 2}, false, -10.0f, 10.0f),
-                            std::vector<int64_t>{0, 1},
-                            true,  // keepdims
-                            18,
-                            ExpectedEPNodeAssignment::All);
+  RunReduceTest<float>("ReduceMean",
+                       TestInputDef<float>({2, 2}, false, -10.0f, 10.0f),
+                       std::vector<int64_t>{0, 1},
+                       true,  // keepdims
+                       18,
+                       ExpectedEPNodeAssignment::All);
 }
 
 // Test creates a graph with a ReduceMean node, and checks that all
@@ -289,15 +301,32 @@ TEST_F(QnnCPUBackendTests, ReduceMeanOpset18) {
 // - The input and output data type is float.
 // - Uses opset 13, which has "axes" as an attribute.
 TEST_F(QnnCPUBackendTests, ReduceMeanOpset13) {
-  RunReduceOpCpuTest<float>("ReduceMean",
-                            TestInputDef<float>({2, 2}, false, -10.0f, 10.0f),
-                            std::vector<int64_t>{0, 1},
-                            true,  // keepdims
-                            13,
-                            ExpectedEPNodeAssignment::All);
+  RunReduceTest<float>("ReduceMean",
+                       TestInputDef<float>({2, 2}, false, -10.0f, 10.0f),
+                       std::vector<int64_t>{0, 1},
+                       true,  // keepdims
+                       13,
+                       ExpectedEPNodeAssignment::All);
 }
 
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+// Test creates a graph with a ReduceSum node, and checks that all nodes are supported by the QNN EP
+// HTP backend with FP16 precision, and that the inference results match the CPU EP results.
+//
+// Failed QNN Opvalidation because of 5D input. It runs OK if bypass the op validation
+TEST_F(QnnHTPBackendTests, DISABLED_ReduceSumOpset11_5D_FP16) {
+  float fp32_abs_err = 3e-2f;
+  bool enable_fp16 = true;
+  RunReduceTest<float>("ReduceSum",
+                       TestInputDef<float>({1, 12, 249, 2, 4}, false, -10.0f, 10.0f),
+                       std::vector<int64_t>{-1},
+                       false,  // keepdims
+                       13,
+                       ExpectedEPNodeAssignment::All,
+                       fp32_abs_err,
+                       enable_fp16);
+}
 
 // Creates the following graph if axes is an input (newer opsets):
 //                                _______________________


### PR DESCRIPTION
### Description
1. Add QNN UTs for QNN Pad Op with FP16 data on HTP backend
2. Improve Pad op builder to handle invalid optional input
3. Add UT for ReduceSum for FP16 precision with 5D for issue reproduce 

