### PR TITLE
Add UsePython Task in Nuget Publish workflow

### DIFF
--- a/tools/ci_build/github/azure-pipelines/publish-nuget.yml
+++ b/tools/ci_build/github/azure-pipelines/publish-nuget.yml
@@ -29,6 +29,12 @@ stages:
 
     - checkout: self
       submodules: false
+
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.8'
+      addToPath: true
+
     - template: templates/set-version-number-variables-step.yml
 
     - script: mkdir "$(Build.BinariesDirectory)\nuget-artifact\final-package"

--- a/tools/ci_build/github/azure-pipelines/publish-nuget.yml
+++ b/tools/ci_build/github/azure-pipelines/publish-nuget.yml
@@ -32,7 +32,7 @@ stages:
 
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '3.8'
+        versionSpec: '3.9'
         addToPath: true
 
     - template: templates/set-version-number-variables-step.yml

--- a/tools/ci_build/github/azure-pipelines/publish-nuget.yml
+++ b/tools/ci_build/github/azure-pipelines/publish-nuget.yml
@@ -30,10 +30,10 @@ stages:
     - checkout: self
       submodules: false
 
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '3.8'
-      addToPath: true
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.8'
+        addToPath: true
 
     - template: templates/set-version-number-variables-step.yml
 


### PR DESCRIPTION
### Description
Otherwise it would fail in 
https://github.com/microsoft/onnxruntime/blob/b95982e588e2d433958aa9aa82557b714ec4e3de/tools/ci_build/github/azure-pipelines/publish-nuget.yml#L78-L81



### Motivation and Context
The Windows CPU image is migrated  to managed image


### Verification Link
https://dev.azure.com/aiinfra/Lotus/_build?definitionId=1313


