### PR TITLE
Implemenation of IObinding in Mixtral MoE Parity Script

### DIFF
--- a/onnxruntime/test/python/transformers/test_parity_mixtral_moe.py
+++ b/onnxruntime/test/python/transformers/test_parity_mixtral_moe.py
@@ -382,21 +382,21 @@ class MixtralSparseMoeBlock(nn.Module):
         # print_tensor("fc3_experts_weights", self.moe_experts_weight3.detach().numpy())
         # print_tensor("output", ort_output[0])
 
-        return ort_output
+        return None
 
     def parity_check(self):
         hidden_state = torch.randn(self.batch_size, self.sequence_length, self.hidden_dim)
         torch_output = self.forward(hidden_state)
-        ort_out = self.ort_forward(hidden_state, iobinding=True)
-        if ort_out is not None:
-            assert torch.allclose(torch_output, ort_out, rtol=1e-04, atol=1e-04)
+        ort_output = self.ort_forward(hidden_state, iobinding=True)
+        if ort_output is not None:
+            assert torch.allclose(torch_output, ort_output, rtol=1e-04, atol=1e-04)
             print(
                 "batch_size:",
                 self.batch_size,
                 " sequence_length:",
                 self.sequence_length,
                 " max_diff:",
-                (torch_output - ort_out).abs().max(),
+                (torch_output - ort_output).abs().max(),
                 " parity: OK",
             )
 

--- a/onnxruntime/test/python/transformers/test_parity_mixtral_moe.py
+++ b/onnxruntime/test/python/transformers/test_parity_mixtral_moe.py
@@ -372,8 +372,7 @@ class MixtralSparseMoeBlock(nn.Module):
             if not iobinding:
                 ort_output = self.ort_sess.run(None, ort_inputs)
             else:
-                for x in range(5):
-                    self.ort_run_with_iobinding(ort_inputs)
+                self.ort_run_with_iobinding(ort_inputs)
                 return None
 
         # print_tensor("input", ort_inputs["input"])

--- a/onnxruntime/test/python/transformers/test_parity_mixtral_moe.py
+++ b/onnxruntime/test/python/transformers/test_parity_mixtral_moe.py
@@ -321,7 +321,6 @@ class MixtralSparseMoeBlock(nn.Module):
         hidden_states = hidden_states.view(-1, hidden_dim)
         # router_logits: (batch * sequence_length, n_experts)
         router_logits = self.gate(hidden_states)
-        num_tokens = hidden_states.shape[0]
 
         routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
         routing_weights, selected_experts = torch.topk(routing_weights, self.top_k, dim=-1)

--- a/onnxruntime/test/python/transformers/test_parity_mixtral_moe.py
+++ b/onnxruntime/test/python/transformers/test_parity_mixtral_moe.py
@@ -91,22 +91,22 @@ def create_moe_onnx_graph(
             "fc1_experts_weights",
             ORT_DTYPE,
             fc1_shape,
-            fc1_experts_weights.to(torch_type).flatten().tolist(),
-            raw=False,
+            fc1_experts_weights.to(torch_type).detach().numpy().tobytes(),
+            raw=True,
         ),
         helper.make_tensor(
             "fc2_experts_weights",
             ORT_DTYPE,
             fc2_shape,
-            fc2_experts_weights.to(torch_type).flatten().tolist(),
-            raw=False,
+            fc2_experts_weights.to(torch_type).detach().numpy().tobytes(),
+            raw=True,
         ),
         helper.make_tensor(
             "fc3_experts_weights",
             ORT_DTYPE,
             fc3_shape,
-            fc3_experts_weights.to(torch_type).flatten().tolist(),
-            raw=False,
+            fc3_experts_weights.to(torch_type).detach().numpy().tobytes(),
+            raw=True,
         ),
     ]
     print(f"fc1_experts_weights dtype after conversion: {fc1_experts_weights.dtype}")
@@ -144,7 +144,12 @@ def create_moe_onnx_graph(
     print(f"Test 12")
 
     model = helper.make_model(graph)
-    return model.SerializeToString()
+    
+    import onnx
+    model_path = "mixtral_moe.onnx"
+    onnx.save_model(model, model_path, save_as_external_data=True, all_tensors_to_one_file=True)
+    
+    return model_path
 
 
 class ClassInstantier(OrderedDict):


### PR DESCRIPTION
### Motivation and Context

These changes were done to effectively use iobinding to mimic the results of kernel latencies with the MoE mixtral model. Now, benchmarking is available for the mixtral model through this parity script.


