### PR TITLE
Update upstream packaging pipeline name to make it more meaningful.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/nuget-cuda-publishing-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget-cuda-publishing-pipeline.yml
@@ -1,7 +1,7 @@
 resources:
   pipelines:
   - pipeline: build
-    source: 'Nuget-CUDA-Packaging-Pipeline'
+    source: 'CUDA-Zip-Nuget-Java-Packaging-Pipeline'
     trigger: 
       branches:
         include:


### PR DESCRIPTION
### Description
Update upstream packaging pipeline name to make it more meaningful.



### Motivation and Context
The upstream pipeline used to only building Nuget packages, but now it also builds Zip and Java. So change the name will make it more meaningful.

