### PR TITLE
[Fix] Throwes one excepiton while Llama2 parity_check fails

### DIFF
--- a/onnxruntime/python/tools/transformers/models/llama/convert_to_onnx.py
+++ b/onnxruntime/python/tools/transformers/models/llama/convert_to_onnx.py
@@ -1052,8 +1052,8 @@ def main():
             logger.info(f"check parity with cmd: {parity_cmd}")
             parity_check(parity_cmd)
         except Exception as e:
-            logger.warning(f"An error occurred while verifying parity: {e}", exc_info=True)
-
+            logger.exception(f"An error occurred while verifying parity: {e}", exc_info=True)
+            sys.exit(-1)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
### Description



### Motivation and Context
The pipeline is green even Llama2 parity_check fails.

The PR should be merged after the below exception is solved.

