### PR TITLE
[js/webgpu] Refactor trace

### DIFF
--- a/js/common/lib/inference-session-impl.ts
+++ b/js/common/lib/inference-session-impl.ts
@@ -6,7 +6,7 @@ import {InferenceSessionHandler} from './backend.js';
 import {InferenceSession as InferenceSessionInterface} from './inference-session.js';
 import {OnnxValue} from './onnx-value.js';
 import {Tensor} from './tensor.js';
-import {TRACE_FUNC_BEGIN, TRACE_FUNC_END} from './trace.js';
+import {traceFunc} from './trace.js';
 
 type SessionOptions = InferenceSessionInterface.SessionOptions;
 type RunOptions = InferenceSessionInterface.RunOptions;
@@ -20,8 +20,9 @@ export class InferenceSession implements InferenceSessionInterface {
   }
   run(feeds: FeedsType, options?: RunOptions): Promise<ReturnType>;
   run(feeds: FeedsType, fetches: FetchesType, options?: RunOptions): Promise<ReturnType>;
+
+  @traceFunc
   async run(feeds: FeedsType, arg1?: FetchesType|RunOptions, arg2?: RunOptions): Promise<ReturnType> {
-    TRACE_FUNC_BEGIN();
     const fetches: {[name: string]: OnnxValue|null} = {};
     let options: RunOptions = {};
     // check inputs
@@ -119,7 +120,6 @@ export class InferenceSession implements InferenceSessionInterface {
         }
       }
     }
-    TRACE_FUNC_END();
     return returnValue;
   }
 
@@ -132,10 +132,11 @@ export class InferenceSession implements InferenceSessionInterface {
   static create(buffer: ArrayBufferLike, byteOffset: number, byteLength?: number, options?: SessionOptions):
       Promise<InferenceSessionInterface>;
   static create(buffer: Uint8Array, options?: SessionOptions): Promise<InferenceSessionInterface>;
+
+  @traceFunc
   static async create(
-      arg0: string|ArrayBufferLike|Uint8Array, arg1?: SessionOptions|number, arg2?: number,
-      arg3?: SessionOptions): Promise<InferenceSessionInterface> {
-    TRACE_FUNC_BEGIN();
+      arg0: string|ArrayBufferLike|Uint8Array, arg1?: SessionOptions|number, arg2?: number, arg3?: SessionOptions):
+      Promise<InferenceSessionInterface> {
     // either load from a file or buffer
     let filePathOrUint8Array: string|Uint8Array;
     let options: SessionOptions = {};
@@ -198,7 +199,6 @@ export class InferenceSession implements InferenceSessionInterface {
     // resolve backend, update session options with validated EPs, and create session handler
     const [backend, optionsWithValidatedEPs] = await resolveBackendAndExecutionProviders(options);
     const handler = await backend.createInferenceSessionHandler(filePathOrUint8Array, optionsWithValidatedEPs);
-    TRACE_FUNC_END();
     return new InferenceSession(handler);
   }
 

--- a/js/common/lib/trace.ts
+++ b/js/common/lib/trace.ts
@@ -14,40 +14,16 @@ export const TRACE = (deviceType: string, label: string) => {
   console.timeStamp(`${deviceType}::ORT::${label}`);
 };
 
-const TRACE_FUNC = (msg: string, extraMsg?: string) => {
-  const stack = new Error().stack?.split(/\r\n|\r|\n/g) || [];
-  let hasTraceFunc = false;
-  for (let i = 0; i < stack.length; i++) {
-    if (hasTraceFunc && !stack[i].includes('TRACE_FUNC')) {
-      let label = `FUNC_${msg}::${stack[i].trim().split(' ')[1]}`;
-      if (extraMsg) {
-        label += `::${extraMsg}`;
-      }
-      TRACE('CPU', label);
-      return;
-    }
-    if (stack[i].includes('TRACE_FUNC')) {
-      hasTraceFunc = true;
-    }
-  }
-};
-
-/**
- * @ignore
- */
-export const TRACE_FUNC_BEGIN = (extraMsg?: string) => {
+export const traceFunc = (originalMethod: any, context: ClassMethodDecoratorContext) => {
   if (typeof env.trace === 'undefined' ? !env.wasm.trace : !env.trace) {
     return;
   }
-  TRACE_FUNC('BEGIN', extraMsg);
-};
 
-/**
- * @ignore
- */
-export const TRACE_FUNC_END = (extraMsg?: string) => {
-  if (typeof env.trace === 'undefined' ? !env.wasm.trace : !env.trace) {
-    return;
-  }
-  TRACE_FUNC('END', extraMsg);
-};
+  const methodName = String(context.name);
+  return function(this: any, ...args: any[]) {
+    TRACE('CPU', `FUNC_BEGIN::${methodName}`);
+    const result = originalMethod.apply(this, ...args);
+    TRACE('CPU', `FUNC_END::${methodName}`);
+    return result;
+  };
+}

--- a/js/web/lib/wasm/jsep/webgpu/program-manager.ts
+++ b/js/web/lib/wasm/jsep/webgpu/program-manager.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import {TRACE_FUNC_BEGIN, TRACE_FUNC_END} from 'onnxruntime-common';
+import {TRACE} from 'onnxruntime-common';
 
 import {WebGpuBackend} from '../backend-webgpu';
 import {LOG_DEBUG} from '../log';
@@ -32,9 +32,10 @@ export class ProgramManager {
   setArtifact(key: unknown, artifact: Artifact): void {
     this.repo.set(key, artifact);
   }
+
   run(buildArtifact: Artifact, inputs: GpuData[], outputs: GpuData[], dispatchGroup: [number, number, number],
       uniformBufferBinding: GPUBindingResource|undefined): void {
-    TRACE_FUNC_BEGIN(buildArtifact.programInfo.name);
+    TRACE('CPU', `FUNC_BEGIN::ProgramManager::run::${buildArtifact.programInfo.name}`);
     const device = this.backend.device;
     const computePassEncoder = this.backend.getComputePassEncoder();
     this.backend.writeTimestamp(this.backend.pendingDispatchNumber * 2);
@@ -75,13 +76,14 @@ export class ProgramManager {
     if (this.backend.pendingDispatchNumber >= this.backend.maxDispatchNumber) {
       this.backend.flush();
     }
-    TRACE_FUNC_END(buildArtifact.programInfo.name);
+    TRACE('CPU', `FUNC_END::ProgramManager::run::${buildArtifact.programInfo.name}`);
   }
   dispose(): void {
     // this.repo.forEach(a => this.glContext.deleteProgram(a.program));
   }
+
   build(programInfo: ProgramInfo, normalizedDispatchGroupSize: [number, number, number]): Artifact {
-    TRACE_FUNC_BEGIN(programInfo.name);
+    TRACE('CPU', `FUNC_BEGIN::ProgramManager::run::${programInfo.name}`);
     const device = this.backend.device;
     const extensions: string[] = [];
     if (device.features.has('shader-f16')) {
@@ -96,7 +98,7 @@ export class ProgramManager {
     const computePipeline = device.createComputePipeline(
         {compute: {module: shaderModule, entryPoint: 'main'}, layout: 'auto', label: programInfo.name});
 
-    TRACE_FUNC_END(programInfo.name);
+    TRACE('CPU', `FUNC_BEGIN::ProgramManager::run::${programInfo.name}`);
     return {programInfo, computePipeline, uniformVariablesInfo: shaderHelper.variablesInfo};
   }
 


### PR DESCRIPTION
Current trace impl relies on unmangled JS to get the function names, which causes some inconvenience and perf impact. This refactoring removes this dependence.