### PR TITLE
Fix TypeError when mT5 repository only have tokenizer.json

### DIFF
--- a/onnxruntime/python/tools/transformers/convert_generation.py
+++ b/onnxruntime/python/tools/transformers/convert_generation.py
@@ -66,6 +66,7 @@ from transformers import (
     T5Config,
     T5ForConditionalGeneration,
     T5Tokenizer,
+    AutoTokenizer,
 )
 
 from onnxruntime import GraphOptimizationLevel, InferenceSession, SessionOptions, get_available_providers
@@ -2887,8 +2888,10 @@ def test_t5_model(args: argparse.Namespace, sentences: Optional[List[str]] = Non
     if args.prefix_vocab_mask:
         logger.debug("Skipping parity test as prefix vocab mask is not implemented by Hugging Face")
         return None
-
-    tokenizer = T5Tokenizer.from_pretrained(args.model_name_or_path, cache_dir=args.cache_dir)
+    try:
+        tokenizer = T5Tokenizer.from_pretrained(args.model_name_or_path, cache_dir=args.cache_dir)
+    except TypeError:
+        tokenizer = AutoTokenizer.from_pretrained(args.model_name_or_path, cache_dir=args.cache_dir)
     tokenizer.padding_side = "left"
 
     if args.model_type == "t5":


### PR DESCRIPTION
### Description
Change `convert_generation.py` where the tokenizer of mT5 translation neural network was loaded. The original one cannot handle mT5 variations finetuned by huggingface users where only a `tokenizer.json` is included.



### Motivation and Context
The original `convert_generation.py` cannot convert this huggingface repo: larryvrh/mt5-translation-ja_zh


