### PR TITLE
[ROCm] fix: obtain AMD GPU memory info through rocm_smi library

### DIFF
--- a/cmake/onnxruntime_providers_rocm.cmake
+++ b/cmake/onnxruntime_providers_rocm.cmake
@@ -49,7 +49,10 @@
 
   find_library(RCCL_LIB rccl REQUIRED)
   find_library(ROCTRACER_LIB roctracer64 REQUIRED)
-  set(ONNXRUNTIME_ROCM_LIBS roc::rocblas MIOpen hip::hipfft ${RCCL_LIB} ${ROCTRACER_LIB})
+  find_package(rocm_smi REQUIRED)
+  set(ONNXRUNTIME_ROCM_LIBS roc::rocblas MIOpen hip::hipfft ${ROCM_SMI_LIBRARY} ${RCCL_LIB} ${ROCTRACER_LIB})
+  include_directories(${ROCM_SMI_INCLUDE_DIR})
+  link_directories(${ROCM_SMI_LIB_DIR})
 
   file(GLOB_RECURSE onnxruntime_providers_rocm_cc_srcs CONFIGURE_DEPENDS
     "${ONNXRUNTIME_ROOT}/core/providers/rocm/*.h"

--- a/onnxruntime/core/providers/rocm/rocm_call.cc
+++ b/onnxruntime/core/providers/rocm/rocm_call.cc
@@ -143,6 +143,8 @@ template Status RocmCall<hiprandStatus_t, false>(hiprandStatus_t retCode, const 
 template void RocmCall<hiprandStatus_t, true>(hiprandStatus_t retCode, const char* exprString, const char* libName, hiprandStatus_t successCode, const char* msg, const char* file, const int line);
 template Status RocmCall<hipfftResult, false>(hipfftResult retCode, const char* exprString, const char* libName, hipfftResult successCode, const char* msg, const char* file, const int line);
 template void RocmCall<hipfftResult, true>(hipfftResult retCode, const char* exprString, const char* libName, hipfftResult successCode, const char* msg, const char* file, const int line);
+template Status RocmCall<rsmi_status_t, false>(rsmi_status_t retCode, const char* exprString, const char* libName, rsmi_status_t successCode, const char* msg, const char* file, const int line);
+template void RocmCall<rsmi_status_t, true>(rsmi_status_t retCode, const char* exprString, const char* libName, rsmi_status_t successCode, const char* msg, const char* file, const int line);
 
 #ifdef ORT_USE_NCCL
 template Status RocmCall<ncclResult_t, false>(ncclResult_t retCode, const char* exprString, const char* libName, ncclResult_t successCode, const char* msg, const char* file, const int line);

--- a/onnxruntime/core/providers/rocm/rocm_common.h
+++ b/onnxruntime/core/providers/rocm/rocm_common.h
@@ -68,13 +68,15 @@ inline int warpSizeDynamic() {
 }
 
 inline void hipMemGetInfoAlt(uint32_t deviceId, size_t* pFree, size_t* pTotal) {
-  size_t usedMemory = 0;
-
-  ROCMSMI_CALL_THROW(rsmi_init(0));
-  ROCMSMI_CALL_THROW(rsmi_dev_memory_total_get(deviceId, RSMI_MEM_TYPE_VIS_VRAM, pTotal));
-  ROCMSMI_CALL_THROW(rsmi_dev_memory_usage_get(deviceId, RSMI_MEM_TYPE_VIS_VRAM, &usedMemory));
-  *pFree = *pTotal - usedMemory;
-  ROCMSMI_CALL_THROW(rsmi_shut_down());
+  const auto status = hipMemGetInfo(pFree, pTotal);
+  if (status != hipSuccess){
+    size_t usedMemory = 0;
+    ROCMSMI_CALL_THROW(rsmi_init(0));
+    ROCMSMI_CALL_THROW(rsmi_dev_memory_total_get(deviceId, RSMI_MEM_TYPE_VIS_VRAM, pTotal));
+    ROCMSMI_CALL_THROW(rsmi_dev_memory_usage_get(deviceId, RSMI_MEM_TYPE_VIS_VRAM, &usedMemory));
+    *pFree = *pTotal - usedMemory;
+    ROCMSMI_CALL_THROW(rsmi_shut_down());
+  }
 }
 
 }  // namespace rocm

--- a/onnxruntime/core/providers/rocm/rocm_common.h
+++ b/onnxruntime/core/providers/rocm/rocm_common.h
@@ -67,5 +67,15 @@ inline int warpSizeDynamic() {
   return deviceProp.warpSize;
 }
 
+inline void hipMemGetInfoAlt(uint32_t deviceId, size_t* pFree, size_t* pTotal) {
+  size_t usedMemory = 0;
+
+  ROCMSMI_CALL_THROW(rsmi_init(0));
+  ROCMSMI_CALL_THROW(rsmi_dev_memory_total_get(deviceId, RSMI_MEM_TYPE_VIS_VRAM, pTotal));
+  ROCMSMI_CALL_THROW(rsmi_dev_memory_usage_get(deviceId, RSMI_MEM_TYPE_VIS_VRAM, &usedMemory));
+  *pFree = *pTotal - usedMemory;
+  ROCMSMI_CALL_THROW(rsmi_shut_down());
+}
+
 }  // namespace rocm
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/rocm/rocm_common.h
+++ b/onnxruntime/core/providers/rocm/rocm_common.h
@@ -69,7 +69,7 @@ inline int warpSizeDynamic() {
 
 inline void hipMemGetInfoAlt(uint32_t deviceId, size_t* pFree, size_t* pTotal) {
   const auto status = hipMemGetInfo(pFree, pTotal);
-  if (status != hipSuccess){
+  if (status != hipSuccess) {
     size_t usedMemory = 0;
     ROCMSMI_CALL_THROW(rsmi_init(0));
     ROCMSMI_CALL_THROW(rsmi_dev_memory_total_get(deviceId, RSMI_MEM_TYPE_VIS_VRAM, pTotal));

--- a/onnxruntime/core/providers/rocm/rocm_execution_provider.cc
+++ b/onnxruntime/core/providers/rocm/rocm_execution_provider.cc
@@ -261,7 +261,7 @@ ROCMExecutionProvider::ROCMExecutionProvider(const ROCMExecutionProviderInfo& in
 
   size_t free = 0;
   size_t total = 0;
-  HIP_CALL_THROW(hipMemGetInfo(&free, &total));
+  onnxruntime::rocm::hipMemGetInfoAlt(info_.device_id, &free, &total);
 
   OverrideTunableOpInfoByEnv(info_);
 

--- a/onnxruntime/core/providers/rocm/rocm_pch.h
+++ b/onnxruntime/core/providers/rocm/rocm_pch.h
@@ -14,6 +14,7 @@
 #include <hipsparse/hipsparse.h>
 #include <miopen/miopen.h>
 #include <rocblas/rocblas.h>
+#include <rocm_smi/rocm_smi.h>
 
 #ifdef ORT_USE_NCCL
 #include <rccl/rccl.h>

--- a/onnxruntime/core/providers/rocm/shared_inc/rocm_call.h
+++ b/onnxruntime/core/providers/rocm/shared_inc/rocm_call.h
@@ -17,6 +17,7 @@ std::conditional_t<THRW, void, Status> RocmCall(
 
 #define HIP_CALL(expr) (RocmCall<hipError_t, false>((expr), #expr, "HIP", hipSuccess, "", __FILE__, __LINE__))
 #define ROCBLAS_CALL(expr) (RocmCall<rocblas_status, false>((expr), #expr, "ROCBLAS", rocblas_status_success, "", __FILE__, __LINE__))
+#define ROCMSMI_CALL(expr) (RocmCall<rsmi_status_t, false>((expr), #expr, "ROCMSMI", RSMI_STATUS_SUCCESS, "", __FILE__, __LINE__))
 
 #define HIPSPARSE_CALL(expr) (RocmCall<hipsparseStatus_t, false>((expr), #expr, "HIPSPARSE", HIPSPARSE_STATUS_SUCCESS, "", __FILE__, __LINE__))
 #define HIPRAND_CALL(expr) (RocmCall<hiprandStatus_t, false>((expr), #expr, "HIPRAND", HIPRAND_STATUS_SUCCESS, "", __FILE__, __LINE__))
@@ -27,6 +28,7 @@ std::conditional_t<THRW, void, Status> RocmCall(
 
 #define HIP_CALL_THROW(expr) (RocmCall<hipError_t, true>((expr), #expr, "HIP", hipSuccess, "", __FILE__, __LINE__))
 #define ROCBLAS_CALL_THROW(expr) (RocmCall<rocblas_status, true>((expr), #expr, "ROCBLAS", rocblas_status_success, "", __FILE__, __LINE__))
+#define ROCMSMI_CALL_THROW(expr) (RocmCall<rsmi_status_t, true>((expr), #expr, "ROCMSMI", RSMI_STATUS_SUCCESS, "", __FILE__, __LINE__))
 
 #define HIPSPARSE_CALL_THROW(expr) (RocmCall<hipsparseStatus_t, true>((expr), #expr, "HIPSPARSE", HIPSPARSE_STATUS_SUCCESS, "", __FILE__, __LINE__))
 #define HIPRAND_CALL_THROW(expr) (RocmCall<hiprandStatus_t, true>((expr), #expr, "HIPRAND", HIPRAND_STATUS_SUCCESS, "", __FILE__, __LINE__))

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -2812,6 +2812,10 @@ def main():
         if args.enable_external_custom_op_schemas and not is_linux():
             raise BuildError("Registering external custom op schemas is only supported on Linux.")
 
+        n_jobs = number_of_parallel_jobs(args)
+        if isinstance(n_jobs, int) and n_jobs > 1:
+            cmake_extra_defines.append(f"CMAKE_BUILD_PARALLEL_LEVEL={n_jobs}")
+
         generate_build_tree(
             cmake_path,
             source_dir,

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -2812,10 +2812,6 @@ def main():
         if args.enable_external_custom_op_schemas and not is_linux():
             raise BuildError("Registering external custom op schemas is only supported on Linux.")
 
-        n_jobs = number_of_parallel_jobs(args)
-        if isinstance(n_jobs, int) and n_jobs > 1:
-            cmake_extra_defines.append(f"CMAKE_BUILD_PARALLEL_LEVEL={n_jobs}")
-
         generate_build_tree(
             cmake_path,
             source_dir,


### PR DESCRIPTION
### Description
Previously ROCMExecutionProvider uses `hipMemGetInfo` to obtain the sizes of total memory and available memory. However, this API has been broken since ROCm 5.7. In this PR, we use `rocm_smi` library instead of `hipMemGetInfo`.


### Motivation and Context

`hipMemGetInfo` API has been broken since ROCm 5.7 and inference with ROCMExecutionProvider will lead to following errors:

```
HIP failure 1: invalid argument ; GPU=0 ; hostname=4cc4900475fe ; file=/onnxruntime/onnxruntime/core/providers/rocm/rocm_execution_provider.cc ; line=229 ; expr=hipMemGetInfo(&free, &total);
```

MIOpen has a brute-force fix for this (https://github.com/ROCm/MIOpen/blob/911e67189592c311374940493f2099f3abced60d/src/hip/handlehip.cpp#L72). Instead of hard-coding available memory to 16GB, I suppose we could obtain memory info through `rocm_smi` library as in this PR.


