### PR TITLE
Fix typo in Python code block on home page

### DIFF
--- a/docs/tutorials/mobile/deploy-android.md
+++ b/docs/tutorials/mobile/deploy-android.md
@@ -38,7 +38,7 @@ The pre-trained [TorchVision MOBILENET V2](https://pytorch.org/hub/pytorch_visio
    - Quantize the FP32 ONNX model to an uint8 ONNX model
    - Convert both FP32 and uint8 ONNX models to ORT models
 
-   Note: this step is optional, you can download the FP32 and uint8 ORT models [here](https://onnxruntimeexamplesdata.z13.web.core.windows.net/mobilenet_v2_ort_models.zip).
+   Note: this step is optional, you can download the FP32 and uint8 ORT models [here](https://github.com/onnx/models/tree/main/validated/vision/classification/mobilenet/model).
 
 2. Download the model class labels
 

--- a/src/routes/components/code-blocks.svelte
+++ b/src/routes/components/code-blocks.svelte
@@ -11,7 +11,7 @@
 	import github from "svelte-highlight/styles/github";
 
 	let pythonCode =
-		'import onnxruntime as ort\n# Load the model and create InferenceSession\nmodel_path = "path/to/your/onnx/model"\nsession = ort.InferenceSession(model_path)\n# "Load and preprocess the input image inputTensor"\n...\n# Run inference\noutputs = session.run(None {"input": inputTensor})\nprint(outputs)';
+		'import onnxruntime as ort\n# Load the model and create InferenceSession\nmodel_path = "path/to/your/onnx/model"\nsession = ort.InferenceSession(model_path)\n# "Load and preprocess the input image inputTensor"\n...\n# Run inference\noutputs = session.run(None, {"input": inputTensor})\nprint(outputs)';
 	let csharpCode =
 		'using Microsoft.ML.OnnxRuntime;\n// Load the model and create InferenceSession\nstring model_path = "path/to/your/onnx/model";\nvar session = new InferenceSession(model_path);\n// Load and preprocess the input image to inputTensor\n...\n// Run inference\nvar outputs = session.Run(inputTensor).ToList();\nConsole.WriteLine(outputs[0].AsTensor()[0]);';
 	let javascriptCode =


### PR DESCRIPTION
### Description
Python code block on home page contained typo

Previous: outputs = session.run(None {"input": inputTensor})
Correction: outputs = session.run(None, {"input": inputTensor})

Fixes issue #21146



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


