### PR TITLE
[Training] Fix Overflow Handling in Cast Infer for ORTModule.

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -603,7 +603,12 @@ class SymbolicShapeInference:
             # If casting into int has precision loss: keep float output
             if allow_float_values and value % 1 != 0:
                 return value
-            return int(value)
+            # Handle NaN and inf values explicitly
+            if np.isinf(value):
+                # Use the maximum float value as the replacement
+                return np.finfo(np.float32).max
+            if np.isnan(value):
+                return 0
 
         values = [self._try_get_value(node, i) for i in range(len(node.input))]
         if all([v is not None for v in values]):


### PR DESCRIPTION
### Description

Infer cast function in symbolic shape infer cannot handle inf values and returns this error:
```python
  File "/usr/local/lib/python3.10/dist-packages/onnxruntime/tools/symbolic_shape_infer.py", line 607, in int_or_float
    return int(value)
OverflowError: cannot convert float infinity to integer
```

added a fix to handle NaN and inf values.