### PR TITLE
Exclude azure ep from gen_def.cc

### DIFF
--- a/tools/ci_build/gen_def.py
+++ b/tools/ci_build/gen_def.py
@@ -79,6 +79,7 @@ with open(args.output_source, "w") as file:
             "cann",
             "dnnl",
             "tensorrt",
+            "azure",
         ):
             file.write(f"#include <core/providers/{c}/{c}_provider_factory.h>\n")
     file.write("void* GetFunctionEntryByName(const char* name){\n")


### PR DESCRIPTION
Addresses python packaging pipeline failure.