### PR TITLE
Use the scalar MlasSgemm CopyPackB and TransposePackB implementation for RISCV

### DIFF
--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -53,6 +53,9 @@ Abstract:
 #if defined(_M_ARM) || defined(__arm__)
 #define MLAS_TARGET_ARM
 #endif
+#if defined(_M_RISCV) || defined(__riscv)
+#define MLAS_TARGET_RISCV
+#endif
 #if defined(MLAS_TARGET_ARM64) || defined(MLAS_TARGET_ARM64EC) || defined(MLAS_TARGET_ARM)
 #define MLAS_TARGET_ARM_ANY
 #endif

--- a/onnxruntime/core/mlas/lib/sgemm.cpp
+++ b/onnxruntime/core/mlas/lib/sgemm.cpp
@@ -208,7 +208,7 @@ Return Value:
     }
 }
 
-#if !defined(MLAS_TARGET_WASM_SCALAR)
+#if !defined(MLAS_TARGET_WASM_SCALAR) && !defined(MLAS_TARGET_RISCV)
 
 void
 MlasSgemmCopyPackB(


### PR DESCRIPTION
Add new define MLAS_TARGET_RISCV under _M_RISCV or __riscv.
Add MLAS_TARGET_RISCV in check across MlasSgemmCopyPackB and MlasSgemmTransposePackB implementation to use 4 wide packing functions.

For RISCV, the MlasSgemmKernel is used which has packing wide of 4. The default MlasSgemmCopyPackB (which was under just !defined(MLAS_TARGET_WASM_SCALAR) chack) has packing width of 16, causing the tests to mismatch.
