### PR TITLE
[DirectML] Broadcast NC-dims for Tensors A&B in DynamicQuantizeMatMul

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorDynamicQuantizeMatMul.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorDynamicQuantizeMatMul.cpp
@@ -47,9 +47,12 @@ public:
         std::vector<uint32_t> BTensorShape = kernelCreationContext.GetTensorShapeDescription().GetInputTensorShape(OnnxInputIndex::B);
         std::vector<uint32_t> ExpectedAScaleTensorShape = {1, 1, 1, 1};
         std::vector<uint32_t> ExpectedAZeroPointTensorShape = {1, 1, 1, 1};
-        auto& outputSizes = m_outputTensorDescs[0].GetSizes();
-        auto AShapeBroadcasted = std::array<uint32_t, 4> { outputSizes[0], outputSizes[1], ATensorShape.rbegin()[1], ATensorShape.rbegin()[0] };
-        auto BShapeBroadcasted = std::array<uint32_t, 4> { outputSizes[0], outputSizes[1], BTensorShape.rbegin()[1], BTensorShape.rbegin()[0] };
+        std::span<const uint32_t> outputSizes = m_outputTensorDescs[0].GetSizes();
+        ML_CHECK_VALID_ARGUMENT(outputSizes.size() >= 4);
+        ML_CHECK_VALID_ARGUMENT(ATensorShape.size() >= 2);
+        ML_CHECK_VALID_ARGUMENT(BTensorShape.size() >= 2);
+        std::array<uint32_t, 4> AShapeBroadcasted = { outputSizes[0], outputSizes[1], ATensorShape.rbegin()[1], ATensorShape.rbegin()[0] };
+        std::array<uint32_t, 4> BShapeBroadcasted = { outputSizes[0], outputSizes[1], BTensorShape.rbegin()[1], BTensorShape.rbegin()[0] };
 
         //  output edges between DynQL and MMItoFloat node
         TensorDesc intermediateQuantizedATensorDesc = TensorDesc(

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorDynamicQuantizeMatMul.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorDynamicQuantizeMatMul.cpp
@@ -51,6 +51,8 @@ public:
         ML_CHECK_VALID_ARGUMENT(outputSizes.size() >= 4);
         ML_CHECK_VALID_ARGUMENT(ATensorShape.size() >= 2);
         ML_CHECK_VALID_ARGUMENT(BTensorShape.size() >= 2);
+        ML_CHECK_VALID_ARGUMENT(ATensorShape.size() + 2 >=  outputSizes.size());
+        ML_CHECK_VALID_ARGUMENT(BTensorShape.size() + 2 >=  outputSizes.size());
         std::vector<uint32_t> AShapeBroadcasted(outputSizes.begin(), outputSizes.end());
         std::copy(ATensorShape.end() - (outputSizes.size() - 2),
                   ATensorShape.end(),

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorDynamicQuantizeMatMul.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorDynamicQuantizeMatMul.cpp
@@ -47,7 +47,7 @@ public:
         std::vector<uint32_t> BTensorShape = kernelCreationContext.GetTensorShapeDescription().GetInputTensorShape(OnnxInputIndex::B);
         std::vector<uint32_t> ExpectedAScaleTensorShape = {1, 1, 1, 1};
         std::vector<uint32_t> ExpectedAZeroPointTensorShape = {1, 1, 1, 1};
-        std::span<const uint32_t> outputSizes = m_outputTensorDescs[0].GetSizes();
+        gsl::span<const uint32_t> outputSizes = m_outputTensorDescs[0].GetSizes();
         ML_CHECK_VALID_ARGUMENT(outputSizes.size() >= 4);
         ML_CHECK_VALID_ARGUMENT(ATensorShape.size() >= 2);
         ML_CHECK_VALID_ARGUMENT(BTensorShape.size() >= 2);

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorDynamicQuantizeMatMul.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorDynamicQuantizeMatMul.cpp
@@ -52,11 +52,11 @@ public:
         ML_CHECK_VALID_ARGUMENT(ATensorShape.size() >= 2);
         ML_CHECK_VALID_ARGUMENT(BTensorShape.size() >= 2);
         std::vector<uint32_t> AShapeBroadcasted(outputSizes.begin(), outputSizes.end());
-        std::copy(ATensorShape.begin() + ATensorShape.size() - (outputSizes.size() - 2),
+        std::copy(ATensorShape.end() - (outputSizes.size() - 2),
                   ATensorShape.end(),
                   AShapeBroadcasted.begin() + 2);
         std::vector<uint32_t> BShapeBroadcasted(outputSizes.begin(), outputSizes.end());
-        std::copy(BTensorShape.begin() + BTensorShape.size() - (outputSizes.size() - 2),
+        std::copy(BTensorShape.end() - (outputSizes.size() - 2),
                   BTensorShape.end(),
                   BShapeBroadcasted.begin() + 2);
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorDynamicQuantizeMatMul.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorDynamicQuantizeMatMul.cpp
@@ -51,8 +51,14 @@ public:
         ML_CHECK_VALID_ARGUMENT(outputSizes.size() >= 4);
         ML_CHECK_VALID_ARGUMENT(ATensorShape.size() >= 2);
         ML_CHECK_VALID_ARGUMENT(BTensorShape.size() >= 2);
-        std::array<uint32_t, 4> AShapeBroadcasted = { outputSizes[0], outputSizes[1], ATensorShape.rbegin()[1], ATensorShape.rbegin()[0] };
-        std::array<uint32_t, 4> BShapeBroadcasted = { outputSizes[0], outputSizes[1], BTensorShape.rbegin()[1], BTensorShape.rbegin()[0] };
+        std::vector<uint32_t> AShapeBroadcasted(outputSizes.begin(), outputSizes.end());
+        std::copy(ATensorShape.begin() + ATensorShape.size() - (outputSizes.size() - 2),
+                  ATensorShape.end(),
+                  AShapeBroadcasted.begin() + 2);
+        std::vector<uint32_t> BShapeBroadcasted(outputSizes.begin(), outputSizes.end());
+        std::copy(BTensorShape.begin() + BTensorShape.size() - (outputSizes.size() - 2),
+                  BTensorShape.end(),
+                  BShapeBroadcasted.begin() + 2);
 
         //  output edges between DynQL and MMItoFloat node
         TensorDesc intermediateQuantizedATensorDesc = TensorDesc(

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorDynamicQuantizeMatMul.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorDynamicQuantizeMatMul.cpp
@@ -43,10 +43,11 @@ public:
         MLOperatorTensorDataType ADatatype = kernelCreationContext.GetInputEdgeDescription(OnnxInputIndex::A).tensorDataType;
         MLOperatorTensorDataType BDatatype = kernelCreationContext.GetInputEdgeDescription(OnnxInputIndex::B).tensorDataType;
 
+        gsl::span<const uint32_t> outputSizes = m_outputTensorDescs[0].GetSizes();
         std::vector<uint32_t> ATensorShape = kernelCreationContext.GetTensorShapeDescription().GetInputTensorShape(OnnxInputIndex::A);
         std::vector<uint32_t> BTensorShape = kernelCreationContext.GetTensorShapeDescription().GetInputTensorShape(OnnxInputIndex::B);
-        std::vector<uint32_t> ExpectedAScaleTensorShape = {1, 1, 1, 1};
-        std::vector<uint32_t> ExpectedAZeroPointTensorShape = {1, 1, 1, 1};
+        std::vector<uint32_t> ExpectedAScaleTensorShape(outputSizes.size(), 1);
+        std::vector<uint32_t> ExpectedAZeroPointTensorShape(outputSizes.size(), 1);
         gsl::span<const uint32_t> outputSizes = m_outputTensorDescs[0].GetSizes();
         ML_CHECK_VALID_ARGUMENT(outputSizes.size() >= 4);
         ML_CHECK_VALID_ARGUMENT(ATensorShape.size() >= 2);

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorDynamicQuantizeMatMul.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorDynamicQuantizeMatMul.cpp
@@ -48,7 +48,6 @@ public:
         std::vector<uint32_t> BTensorShape = kernelCreationContext.GetTensorShapeDescription().GetInputTensorShape(OnnxInputIndex::B);
         std::vector<uint32_t> ExpectedAScaleTensorShape(outputSizes.size(), 1);
         std::vector<uint32_t> ExpectedAZeroPointTensorShape(outputSizes.size(), 1);
-        gsl::span<const uint32_t> outputSizes = m_outputTensorDescs[0].GetSizes();
         ML_CHECK_VALID_ARGUMENT(outputSizes.size() >= 4);
         ML_CHECK_VALID_ARGUMENT(ATensorShape.size() >= 2);
         ML_CHECK_VALID_ARGUMENT(BTensorShape.size() >= 2);


### PR DESCRIPTION
### Description
[DirectML] Broadcast NC-dims for Tensors A&B in DynamicQuantizeMatMul
The DynamicQuantizeMatMul allows input tensors in NCHW format, and DirectML requires that input tensors share the same batch and channel dimensions. Tensors A and B should be broadcast (if possible) to the corresponding output NC dims.

### Motivation and Context
Certain models which use DynamicQuantizeMatMul hit a crash when the NC dims are intended to be broadcast.

