### PR TITLE
Fix ETW Sink Initialize unproperly locking (#21226)

### DIFF
--- a/onnxruntime/core/platform/windows/logging/etw_sink.cc
+++ b/onnxruntime/core/platform/windows/logging/etw_sink.cc
@@ -98,10 +98,6 @@ ULONGLONG EtwRegistrationManager::Keyword() const {
   return keyword_;
 }
 
-HRESULT EtwRegistrationManager::Status() const {
-  return etw_status_;
-}
-
 void EtwRegistrationManager::RegisterInternalCallback(const EtwInternalCallback& callback) {
   std::lock_guard<OrtMutex> lock(callbacks_mutex_);
   callbacks_.push_back(callback);
@@ -133,15 +129,9 @@ EtwRegistrationManager::EtwRegistrationManager() {
 }
 
 void EtwRegistrationManager::LazyInitialize() {
-  if (!initialized_) {
-    std::lock_guard<OrtMutex> lock(init_mutex_);
-    if (!initialized_) {  // Double-check locking pattern
-      initialized_ = true;
-      etw_status_ = ::TraceLoggingRegisterEx(etw_provider_handle, ORT_TL_EtwEnableCallback, nullptr);
-      if (FAILED(etw_status_)) {
-        ORT_THROW("ETW registration failed. Logging will be broken: " + std::to_string(etw_status_));
-      }
-    }
+  static HRESULT etw_status = ::TraceLoggingRegisterEx(etw_provider_handle, ORT_TL_EtwEnableCallback, nullptr);
+  if (FAILED(etw_status)) {
+    ORT_THROW("ETW registration failed. Logging will be broken: " + std::to_string(etw_status));
   }
 }
 
@@ -159,12 +149,6 @@ void EtwSink::SendImpl(const Timestamp& timestamp, const std::string& logger_id,
 
   // register on first usage
   static EtwRegistrationManager& etw_manager = EtwRegistrationManager::Instance();
-
-  // do something (not that meaningful) with etw_manager so it doesn't get optimized out
-  // as we want an instance around to do the unregister
-  if (FAILED(etw_manager.Status())) {
-    return;
-  }
 
   // TODO: Validate if this filtering makes sense.
   if (message.DataType() == DataType::USER) {

--- a/onnxruntime/core/platform/windows/logging/etw_sink.h
+++ b/onnxruntime/core/platform/windows/logging/etw_sink.h
@@ -66,9 +66,6 @@ class EtwRegistrationManager {
   // Get the current keyword
   uint64_t Keyword() const;
 
-  // Get the ETW registration status
-  HRESULT Status() const;
-
   void RegisterInternalCallback(const EtwInternalCallback& callback);
 
  private:
@@ -98,7 +95,6 @@ class EtwRegistrationManager {
   bool is_enabled_;
   UCHAR level_;
   ULONGLONG keyword_;
-  HRESULT etw_status_;
 };
 
 }  // namespace logging


### PR DESCRIPTION
### Description
ETW trace logger is fakely registered as initialized_ is marked as true before the registration is done, causing crashing issue for Lenovo camera application.

[Bug
42610244](https://microsoft.visualstudio.com/OS/_workitems/edit/42610244): [Watson Failure] caused by
SVCHOSTGROUP_Camera_INVALID_POINTER_READ_c0000005_onnxruntime.dll!onnxruntime::logging::Logger::Log

### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


