### PR TITLE
Enable Android CI build stages to run in parallel.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -49,6 +49,7 @@ stages:
 # Separate stage for building CPU vs NNAPI as we only want CodeQL to run on one of them so we don't get duplicate
 # issues for code that is built in both. We pick NNAPI as that includes the NNAPI EP code.
 - stage: BUILD_CPU_STAGE
+  dependsOn: []
   variables:
     Codeql.Enabled: false
   jobs:
@@ -129,6 +130,7 @@ stages:
     - template: templates/clean-agent-build-directory-step.yml
 
 - stage: BUILD_NNAPI_STAGE
+  dependsOn: []
   variables:
     Codeql.ProjectConfigPath: .github/workflows
     Codeql.Enabled: true


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Enable Android CI build stages to run in parallel.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Possibly reduce total build time.