### PR TITLE
Fix bert profiler bug

### DIFF
--- a/onnxruntime/python/tools/transformers/profiler.py
+++ b/onnxruntime/python/tools/transformers/profiler.py
@@ -538,7 +538,9 @@ def create_bert_inputs(
         input_ids=input_ids,
         segment_ids=segment_ids,
         input_mask=input_mask,
-        random_mask_length=False,
+        average_sequence_length=sequence_length,
+        random_sequence_length=False,
+        mask_type=2,
     )
 
     return all_inputs


### PR DESCRIPTION
### Description
Fix BERT profiler as the [generate_test_data](https://github.com/microsoft/onnxruntime/blob/88336ffa92e188e0866799dc559a9b6154980cf3/onnxruntime/python/tools/transformers/bert_test_data.py#L241) function call is broken.


### Motivation and Context
Fail to profile BERT models:
    all_inputs = generate_test_data(
                 ^^^^^^^^^^^^^^^^^^^
TypeError: generate_test_data() got an unexpected keyword argument 'random_mask_length'

<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


