### PR TITLE
disable symbolic shape inference by default

### DIFF
--- a/onnxruntime/python/tools/quantization/preprocess.py
+++ b/onnxruntime/python/tools/quantization/preprocess.py
@@ -53,11 +53,11 @@ Essentially this tool performs the following three (skippable) steps:
         " reduce the effectiveness of quantization, as a tensor with unknown"
         " shape can not be quantized.",
     )
+
     parser.add_argument(
-        "--skip_symbolic_shape",
-        type=bool,
-        default=False,
-        help="Skip symbolic shape inference. Symbolic shape inference is most"
+        "--enable_symbolic_shape",
+        action="store_true",
+        help="Enable symbolic shape inference. Symbolic shape inference is most"
         " effective with transformer based models. Skipping all shape"
         " inferences may reduce the effectiveness of quantization, as a tensor"
         " with unknown shape can not be quantized.",
@@ -114,7 +114,7 @@ Essentially this tool performs the following three (skippable) steps:
 
 if __name__ == "__main__":
     args = parse_arguments()
-    if args.skip_optimization and args.skip_onnx_shape and args.skip_symbolic_shape:
+    if args.skip_optimization and args.skip_onnx_shape and not args.enable_symbolic_shape:
         logger.error("Skipping all three steps, nothing to be done. Quitting...")
         sys.exit()
 
@@ -129,7 +129,7 @@ if __name__ == "__main__":
         args.output,
         args.skip_optimization,
         args.skip_onnx_shape,
-        args.skip_symbolic_shape,
+        args.enable_symbolic_shape,
         args.auto_merge,
         args.int_max,
         args.guess_output_rank,

--- a/onnxruntime/test/python/quantization/test_quant_issues.py
+++ b/onnxruntime/test/python/quantization/test_quant_issues.py
@@ -56,7 +56,7 @@ class TestQuantIssues(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp:
             preprocessed_path = os.path.join(temp, "preprocessed.onnx")
             quantized_path = os.path.join(temp, "quantized.onnx")
-            oq.quant_pre_process(onnx_path, preprocessed_path, skip_symbolic_shape=True)
+            oq.quant_pre_process(onnx_path, preprocessed_path, enable_symbolic_shape=False)
             oq.quantize_static(
                 preprocessed_path,
                 quantized_path,


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
symbolic shape inference is not useful for standard onnx model and it is prone to fail. disable it by  default #21277.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


