### PR TITLE
Fix a path problem in onnxruntime_perf_test

### DIFF
--- a/onnxruntime/test/onnx/TestCase.h
+++ b/onnxruntime/test/onnx/TestCase.h
@@ -54,7 +54,7 @@ class TestModelInfo {
   virtual const std::filesystem::path& GetModelUrl() const = 0;
   virtual std::filesystem::path GetDir() const {
     auto ret = GetModelUrl().parent_path();
-    return ret.empty() ? std::filesystem::current_path() : ret;
+    return GetModelUrl().has_parent_path() ? ret : std::filesystem::current_path();
   }
   virtual const std::string& GetNodeName() const = 0;
   virtual const ONNX_NAMESPACE::ValueInfoProto* GetInputInfoFromModel(size_t i) const = 0;

--- a/onnxruntime/test/onnx/TestCase.h
+++ b/onnxruntime/test/onnx/TestCase.h
@@ -53,7 +53,8 @@ class TestModelInfo {
  public:
   virtual const std::filesystem::path& GetModelUrl() const = 0;
   virtual std::filesystem::path GetDir() const {
-    return GetModelUrl().parent_path();
+    auto ret = GetModelUrl().parent_path();
+    return ret.empty() ? std::filesystem::current_path() : ret;
   }
   virtual const std::string& GetNodeName() const = 0;
   virtual const ONNX_NAMESPACE::ValueInfoProto* GetInputInfoFromModel(size_t i) const = 0;

--- a/onnxruntime/test/onnx/TestCase.h
+++ b/onnxruntime/test/onnx/TestCase.h
@@ -53,8 +53,8 @@ class TestModelInfo {
  public:
   virtual const std::filesystem::path& GetModelUrl() const = 0;
   virtual std::filesystem::path GetDir() const {
-    auto ret = GetModelUrl().parent_path();
-    return GetModelUrl().has_parent_path() ? ret : std::filesystem::current_path();
+    const auto& p = GetModelUrl();
+    return p.has_parent_path() ? p.parent_path() : std::filesystem::current_path();
   }
   virtual const std::string& GetNodeName() const = 0;
   virtual const ONNX_NAMESPACE::ValueInfoProto* GetInputInfoFromModel(size_t i) const = 0;


### PR DESCRIPTION
### Description
Resolve #21267 . onnxruntime_perf_test does not work properly if the input model path url is just a single filename without any path separator. For example,

```
./onnxruntime_perf_test -t 10 model.onnx
```

The problem was introduced in #19196 by me.



