### PR TITLE
Revert "Fix ETW Sink Initialize unproperly locking"

### DIFF
--- a/onnxruntime/core/platform/windows/logging/etw_sink.h
+++ b/onnxruntime/core/platform/windows/logging/etw_sink.h
@@ -66,6 +66,9 @@ class EtwRegistrationManager {
   // Get the current keyword
   uint64_t Keyword() const;
 
+  // Get the ETW registration status
+  HRESULT Status() const;
+
   void RegisterInternalCallback(const EtwInternalCallback& callback);
 
   void UnregisterInternalCallback(const EtwInternalCallback& callback);
@@ -97,6 +100,7 @@ class EtwRegistrationManager {
   bool is_enabled_;
   UCHAR level_;
   ULONGLONG keyword_;
+  HRESULT etw_status_;
 };
 
 }  // namespace logging


### PR DESCRIPTION
Reverts microsoft/onnxruntime#21226

Causes any onnxruntime app to hang on Windows ARM64. Our pipelines do not have the same ETW environment, so we couldn't catch it.

![image](https://github.com/user-attachments/assets/80edbf7d-be50-4cb0-a016-f390b81dc798)
The call to TraceLoggingRegisterEx() recursively calls back into LazyInitialize():
LazyInitialize() -> TraceLoggingRegisterEx() -> ORT_TL_EtwEnableCallback() -> Instance() -> LazyInitialize()

The original code got out of the recursive loop by checking the `initialized_` flag.