### PR TITLE
add vitisai ep build stage to Windows CPU Pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
@@ -137,6 +137,25 @@ stages:
         WITH_CACHE: false
         MachinePool: 'onnxruntime-Win-CPU-2022'
 
+# Build only. Does not run any tests.
+- stage: x64_release_vitisai
+  dependsOn: []
+  jobs:
+    - template: templates/jobs/win-ci-vs-2022-job.yml
+      parameters:
+        BuildConfig: 'RelWithDebInfo'
+        buildArch: x64
+        additionalBuildFlags: --build_wheel --use_vitisai
+        msbuildPlatform: x64
+        isX86: false
+        job_name_suffix: x64_release
+        RunOnnxRuntimeTests: false
+        isTraining: false
+        ORT_EP_NAME: VITISAI
+        GenerateDocumentation: false
+        WITH_CACHE: false
+        MachinePool: 'onnxruntime-Win-CPU-2022'
+
 - stage: x64_release_winml
   dependsOn: []
   jobs:


### PR DESCRIPTION
We need to prevent VitisAI EP build breaks, add a stage in Windows CPU CI Pipeline to build Vitis AI EP on Windows.
There are no external dependencies for builds. Tests have to be disabled though as the EP has external SW/HW dependencies.
This will at least allow us to prevent build breaks which has happened on multiple occasions recently.

tested https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=1432346&view=results and it seems to run fine.
