### PR TITLE
DML EP set tensor default minimum rank to 1

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperator.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperator.h
@@ -40,7 +40,7 @@ namespace Dml
             const std::optional<const std::vector<std::optional<uint32_t>>>& kernelOutputIndices = std::nullopt,
             const std::optional<gsl::span<const uint32_t>> inputShape = std::nullopt,
             const std::optional<gsl::span<const uint32_t>> outputShape = std::nullopt,
-            uint32_t minDimensionCount = NchwDimensionCount
+            uint32_t minDimensionCount = 1
             );
 
         // This first tries to create TensorDesc with the given input and output shapes, no broadcasting.
@@ -52,21 +52,21 @@ namespace Dml
             const std::optional<const std::vector<std::optional<uint32_t>>>& kernelOutputIndices = std::nullopt,
             const std::optional<gsl::span<gsl::span<const uint32_t>>> inputShapes = std::nullopt,
             const std::optional<gsl::span<gsl::span<const uint32_t>>> outputShapes = std::nullopt,
-            uint32_t minDimensionCount = NchwDimensionCount
+            uint32_t minDimensionCount = 1
             );
 
         void InitializeInputsWithShapes(
             const MLOperatorKernelCreationContext& kernelInfo,
             const std::optional<const std::vector<std::optional<uint32_t>>>& kernelInputIndices = std::nullopt,
             const std::optional<gsl::span<gsl::span<const uint32_t>>> inputShapes = std::nullopt,
-            uint32_t minDimensionCount = NchwDimensionCount
+            uint32_t minDimensionCount = 1
             );
 
         void InitializeOutputsWithShapes(
             const MLOperatorKernelCreationContext& kernelInfo,
             const std::optional<const std::vector<std::optional<uint32_t>>>& kernelOutputIndices = std::nullopt,
             const std::optional<gsl::span<gsl::span<const uint32_t>>> outputShapes = std::nullopt,
-            uint32_t minDimensionCount = NchwDimensionCount
+            uint32_t minDimensionCount = 1
             );
 
         bool AllowHalfPrecisionComputation() const;
@@ -126,7 +126,7 @@ namespace Dml
             int32_t placement = TensorAxis::W,
             int32_t leftAlignedDimensionCount = TensorAxis::RightAligned,
             std::optional<gsl::span<const uint32_t>> tensorShape = std::nullopt,
-            uint32_t minDimensionCount = NchwDimensionCount
+            uint32_t minDimensionCount = 1
             ) const;
 
         TensorSequenceDesc CreateTensorSequenceDescFromInput(
@@ -136,7 +136,7 @@ namespace Dml
             int32_t placement = TensorAxis::W,
             int32_t leftAlignedDimensionCount = TensorAxis::RightAligned,
             std::optional<gsl::span<const uint32_t>> tensorShape = std::nullopt,
-            uint32_t minDimensionCount = NchwDimensionCount
+            uint32_t minDimensionCount = 1
             ) const;
 
         TensorDesc CreateTensorDescFromOutput(
@@ -146,7 +146,7 @@ namespace Dml
             int32_t placement = TensorAxis::W,
             int32_t leftAlignedDimensionCount = TensorAxis::RightAligned,
             std::optional<gsl::span<const uint32_t>> tensorShape = std::nullopt,
-            uint32_t minDimensionCount = NchwDimensionCount
+            uint32_t minDimensionCount = 1
             ) const;
 
         static void TryConvertTensorToBroadcastScalar(

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorBiasAdd.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorBiasAdd.cpp
@@ -17,7 +17,7 @@ public:
 
         // Broadcast bias to have the same dimensions as the input
         std::vector<uint32_t> inputTensorShape = kernelCreationContext.GetTensorShapeDescription().GetInputTensorShape(0);
-        DmlOperator::Initialize(kernelCreationContext, std::nullopt, std::nullopt, inputTensorShape);
+        DmlOperator::Initialize(kernelCreationContext, std::nullopt, std::nullopt, inputTensorShape, std::nullopt, NchwDimensionCount);
 
         ML_CHECK_VALID_ARGUMENT(m_inputTensorDescs.size() == 3);
         ML_CHECK_VALID_ARGUMENT(m_outputTensorDescs.size() == 1);

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorBiasSplitGelu.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorBiasSplitGelu.cpp
@@ -17,7 +17,7 @@ public:
 
         // Broadcast bias to have the same dimensions as the input
         std::vector<uint32_t> inputTensorShape = kernelCreationContext.GetTensorShapeDescription().GetInputTensorShape(0);
-        DmlOperator::Initialize(kernelCreationContext, std::nullopt, std::nullopt, inputTensorShape);
+        DmlOperator::Initialize(kernelCreationContext, std::nullopt, std::nullopt, inputTensorShape, std::nullopt, NchwDimensionCount);
 
         ML_CHECK_VALID_ARGUMENT(m_inputTensorDescs.size() == 2);
         ML_CHECK_VALID_ARGUMENT(m_outputTensorDescs.size() == 1);

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorConvolution.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorConvolution.cpp
@@ -26,15 +26,15 @@ public:
 
         std::vector<std::optional<uint32_t>> kernelInputIndices = { 0, 1, biasIndex };
 
-        DmlOperator::Initialize(kernelInfo, kernelInputIndices);
+        DmlOperator::Initialize(kernelInfo, kernelInputIndices, std::nullopt, std::nullopt, std::nullopt, NchwDimensionCount);
 
         // Vibranium DirectML is limited to handle only 2D and 3D convolution (4D and 5D tensors). So for 1D tensors,
         // massage the tensor descriptions. By default, the TensorDesc simply right aligns all the values up to 4D
         // (padding the leading dimensions with 1's), but 1D tensors actually need to insert the 1 between C and W.
         // e.g. [2,3,4] becomes [2,3,1,4]
-        m_inputTensorDescs[0] = CreateTensorDescFromInput(kernelInfo, 0, TensorAxis::DoNotCoerce, TensorAxis::NoPlacementAdjustment, NonspatialDimensionCount, std::nullopt);
-        m_inputTensorDescs[1] = CreateTensorDescFromInput(kernelInfo, 1, TensorAxis::DoNotCoerce, TensorAxis::NoPlacementAdjustment, NonspatialDimensionCount, std::nullopt);
-        m_outputTensorDescs[0] = CreateTensorDescFromOutput(kernelInfo, 0, TensorAxis::DoNotCoerce, TensorAxis::NoPlacementAdjustment, NonspatialDimensionCount, std::nullopt);
+        m_inputTensorDescs[0] = CreateTensorDescFromInput(kernelInfo, 0, TensorAxis::DoNotCoerce, TensorAxis::NoPlacementAdjustment, NonspatialDimensionCount, std::nullopt, NchwDimensionCount);
+        m_inputTensorDescs[1] = CreateTensorDescFromInput(kernelInfo, 1, TensorAxis::DoNotCoerce, TensorAxis::NoPlacementAdjustment, NonspatialDimensionCount, std::nullopt, NchwDimensionCount);
+        m_outputTensorDescs[0] = CreateTensorDescFromOutput(kernelInfo, 0, TensorAxis::DoNotCoerce, TensorAxis::NoPlacementAdjustment, NonspatialDimensionCount, std::nullopt, NchwDimensionCount);
 
         if (isNhwc)
         {

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorDynamicQuantizeLinear.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorDynamicQuantizeLinear.cpp
@@ -29,11 +29,11 @@ public:
 
         DmlOperator::Initialize(kernelCreationContext);
 
-        m_inputTensorDescs[IN_A] = CreateTensorDescFromInput(kernelCreationContext, 0/*A OnnxIndex*/, TensorAxis::DoNotCoerce, TensorAxis::W, TensorAxis::RightAligned);
+        m_inputTensorDescs[IN_A] = CreateTensorDescFromInput(kernelCreationContext, 0/*A OnnxIndex*/, TensorAxis::DoNotCoerce, TensorAxis::W, TensorAxis::RightAligned, std::nullopt, NchwDimensionCount);
 
-        m_outputTensorDescs[OUT_Y] = CreateTensorDescFromOutput(kernelCreationContext, 0/*Y OnnxIndex*/, TensorAxis::DoNotCoerce, TensorAxis::W, TensorAxis::RightAligned);
-        m_outputTensorDescs[OUT_Y_SCALE] = CreateTensorDescFromOutput(kernelCreationContext, 1/*Y Scale OnnxIndex*/, TensorAxis::DoNotCoerce, TensorAxis::W, TensorAxis::RightAligned);
-        m_outputTensorDescs[OUT_Y_ZERO_POINT] = CreateTensorDescFromOutput(kernelCreationContext, 2/*Y Zero point OnnxIndex*/, TensorAxis::DoNotCoerce, TensorAxis::W, TensorAxis::RightAligned);
+        m_outputTensorDescs[OUT_Y] = CreateTensorDescFromOutput(kernelCreationContext, 0/*Y OnnxIndex*/, TensorAxis::DoNotCoerce, TensorAxis::W, TensorAxis::RightAligned, std::nullopt, NchwDimensionCount);
+        m_outputTensorDescs[OUT_Y_SCALE] = CreateTensorDescFromOutput(kernelCreationContext, 1/*Y Scale OnnxIndex*/, TensorAxis::DoNotCoerce, TensorAxis::W, TensorAxis::RightAligned, std::nullopt, NchwDimensionCount);
+        m_outputTensorDescs[OUT_Y_ZERO_POINT] = CreateTensorDescFromOutput(kernelCreationContext, 2/*Y Zero point OnnxIndex*/, TensorAxis::DoNotCoerce, TensorAxis::W, TensorAxis::RightAligned, std::nullopt, NchwDimensionCount);
         
         std::vector<DML_TENSOR_DESC> inputDescs = GetDmlInputDescs();
         std::vector<DML_TENSOR_DESC> outputDescs = GetDmlOutputDescs();

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorDynamicQuantizeMatMul.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorDynamicQuantizeMatMul.cpp
@@ -23,7 +23,7 @@ public:
     DmlOperatorDynamicQuantizeMatMul(const MLOperatorKernelCreationContext& kernelCreationContext)
     :   DmlOperator(kernelCreationContext)
     {
-        DmlOperator::Initialize(kernelCreationContext);
+        DmlOperator::Initialize(kernelCreationContext, NchwDimensionCount);
 
         const bool hasBias = kernelCreationContext.IsInputValid(OnnxInputIndex::Bias);
         const bool hasBZP = kernelCreationContext.IsInputValid(OnnxInputIndex::B_zero_point);
@@ -37,7 +37,8 @@ public:
                 TensorAxis::DoNotCoerce,
                 TensorAxis::W,
                 TensorAxis::RightAligned,
-                kernelCreationContext.GetTensorShapeDescription().GetOutputTensorShape(0)
+                kernelCreationContext.GetTensorShapeDescription().GetOutputTensorShape(0),
+                NchwDimensionCount
             );
         }
         MLOperatorTensorDataType BDatatype = kernelCreationContext.GetInputEdgeDescription(OnnxInputIndex::B).tensorDataType;

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorExpand.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorExpand.cpp
@@ -30,7 +30,7 @@ public:
                 TensorAxis::DoNotCoerce,
                 TensorAxis::W,
                 TensorAxis::RightAligned,
-                NchwDimensionCount, // minDimensionCount
+                1, // minDimensionCount
                 0);
         
         TensorDesc outputTensorDesc = 
@@ -41,7 +41,7 @@ public:
                 TensorAxis::DoNotCoerce,
                 TensorAxis::W,
                 TensorAxis::RightAligned,
-                NchwDimensionCount, // minDimensionCount
+                1, // minDimensionCount
                 0
             );
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorRotaryEmbedding.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorRotaryEmbedding.cpp
@@ -50,7 +50,7 @@ public:
         // When positionIds is a scalar, it represents the start offset for each sequence
         const bool positionIdsIsOffset = kernelInfo.GetInputTensorDimensionCount(positionIdsIndex) == 1;
 
-        Initialize(kernelInfo);
+        Initialize(kernelInfo, NchwDimensionCount);
 
         ML_CHECK_VALID_ARGUMENT(m_inputTensorDescs[inputDataIndex].GetDimensionCount() == 4);
         ML_CHECK_VALID_ARGUMENT(m_inputTensorDescs[positionIdsIndex].GetDimensionCount() == 4);

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorTile.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorTile.cpp
@@ -39,8 +39,8 @@ public:
 
         // Update the tensor descriptions.
         MLOperatorTensorDataType inputTensorDataType = kernelCreationContext.GetInputEdgeDescription(0).tensorDataType;
-        auto inputTensorDesc = TensorDesc(inputTensorDataType, squeezedInputShape, squeezedInputShape, TensorAxis::DoNotCoerce, TensorAxis::W, TensorAxis::RightAligned, NchwDimensionCount, 0);
-        auto outputTensorDesc = TensorDesc(inputTensorDataType, squeezedOutputShape, squeezedOutputShape, TensorAxis::DoNotCoerce, TensorAxis::W, TensorAxis::RightAligned, NchwDimensionCount, 0);
+        auto inputTensorDesc = TensorDesc(inputTensorDataType, squeezedInputShape, squeezedInputShape, TensorAxis::DoNotCoerce, TensorAxis::W, TensorAxis::RightAligned, 1, 0);
+        auto outputTensorDesc = TensorDesc(inputTensorDataType, squeezedOutputShape, squeezedOutputShape, TensorAxis::DoNotCoerce, TensorAxis::W, TensorAxis::RightAligned, 1, 0);
         m_inputTensorDescs[0] = inputTensorDesc;
         m_outputTensorDescs[0] = outputTensorDesc;
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/TensorDesc.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/TensorDesc.h
@@ -175,7 +175,7 @@ namespace Dml
         TensorAxis m_coerceAxis = TensorAxis::DoNotCoerce;
         TensorAxis m_placement = TensorAxis::NoPlacementAdjustment;
         int32_t m_leftAlignedDimensionCount = TensorAxis::RightAligned;
-        uint32_t m_minDimensionCount = NchwDimensionCount;
+        uint32_t m_minDimensionCount = 1;
         uint32_t m_guaranteedBaseOffsetAlignment = 0;
     };
 


### PR DESCRIPTION
### Description
Long ago DirectML only supported 4D tensors, requiring the DML EP to coerce 1D-3D tensors up to 4D before passing them to DirectML, but that hasn't mattered for years now, ever since DirectML supported 1D-8D directly in the API, but this coercion and extra complicating adjustment logic still exists in various places (e.g. [pad](https://github.com/microsoft/onnxruntime/blob/fa287042ca05debb35b07f65147a9c3a39330231/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorPadding.cpp#L27-L36), [tile](https://github.com/microsoft/onnxruntime/blob/fa287042ca05debb35b07f65147a9c3a39330231/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorTile.cpp#L25-L45),...). So remove the 4D coercion.

### Motivation and Context
This enables us to delete extra logic that adjust axes/windows later, and it reduces the number of late-breaking surprises when first running model atop DML via the DML EP and later via the WebNN EP, because both code paths will receive the same dimension count. So we can be more confident that if a model works via the DML EP using an NPU, it should (more often anyway) work on NPU's via the WebNN EP too. Any performance impact to the DML DDI should be properly mitigated in the DirectML API itself (for HLSL code paths, DML already canonicalizes all tensors to 4D/8D).

<!-- failing tests

ModelTests/ModelTest.Run/keras2coreml_SimpleRNN_ImageNet_opset7_GPU, where GetParam() = (000002D8776D8BD0, 4-byte object <02-00 00-00>)

ModelTests/ModelTest.Run/keras2coreml_GRU_ImageNet_opset7_GPU, where GetParam() = (000002D877578170, 4-byte object <02-00 00-00>)

ModelTests/ModelTest.Run/keras2coreml_BiDirectional_ImageNet_opset7_GPU, where GetParam() = (000002D800804060, 4-byte object <02-00 00-00>)

ScenarioCppWinrtTests.MsftQuantizedModels

winml_test_scenario

-->