### PR TITLE
Update nodejs's cmake file to fix a file copy issue

### DIFF
--- a/js/node/CMakeLists.txt
+++ b/js/node/CMakeLists.txt
@@ -64,6 +64,9 @@ file(MAKE_DIRECTORY ${dist_folder})
 set_target_properties(onnxruntime_binding PROPERTIES
   PREFIX "" SUFFIX ".node"
   RUNTIME_OUTPUT_DIRECTORY ${dist_folder}
+  RUNTIME_OUTPUT_DIRECTORY_DEBUG ${dist_folder}
+  RUNTIME_OUTPUT_DIRECTORY_RELEASE ${dist_folder}
+  RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO ${dist_folder}
   BUILD_WITH_INSTALL_RPATH TRUE
   INSTALL_RPATH_USE_LINK_PATH FALSE)
 target_link_libraries(onnxruntime_binding PRIVATE ${CMAKE_JS_LIB})

--- a/js/node/CMakeLists.txt
+++ b/js/node/CMakeLists.txt
@@ -59,8 +59,11 @@ endif()
 file(GLOB ORT_NODEJS_BINDING_SOURCE_FILES ${CMAKE_SOURCE_DIR}/src/*.cc)
 
 add_library(onnxruntime_binding SHARED ${ORT_NODEJS_BINDING_SOURCE_FILES} ${CMAKE_JS_SRC})
+file(MAKE_DIRECTORY ${dist_folder})
+
 set_target_properties(onnxruntime_binding PROPERTIES
   PREFIX "" SUFFIX ".node"
+  RUNTIME_OUTPUT_DIRECTORY ${dist_folder}
   BUILD_WITH_INSTALL_RPATH TRUE
   INSTALL_RPATH_USE_LINK_PATH FALSE)
 target_link_libraries(onnxruntime_binding PRIVATE ${CMAKE_JS_LIB})
@@ -95,52 +98,20 @@ else()
   set_target_properties(onnxruntime_binding PROPERTIES INSTALL_RPATH "$ORIGIN/")
 endif()
 
-# post build
-
-add_custom_command(
-  TARGET onnxruntime_binding POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${dist_folder}
-    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:onnxruntime_binding> ${dist_folder}
-)
 
 if (WIN32)
-  add_custom_command(
-    TARGET onnxruntime_binding POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy
-      ${ONNXRUNTIME_WIN_BIN_DIR}/onnxruntime.dll
-      ${dist_folder}
-  )
+  file(COPY ${ONNXRUNTIME_WIN_BIN_DIR}/onnxruntime.dll
+      DESTINATION ${dist_folder})
   if (USE_DML)
-    add_custom_command(
-      TARGET onnxruntime_binding POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E copy
-      ${ONNXRUNTIME_WIN_BIN_DIR}/DirectML.dll
-      ${dist_folder}
-    )
+    file(COPY ${ONNXRUNTIME_WIN_BIN_DIR}/DirectML.dll
+      DESTINATION ${dist_folder})
   endif ()
-  if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-    add_custom_command(
-      TARGET onnxruntime_binding POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E copy
-        ${ONNXRUNTIME_WIN_BIN_DIR}/onnxruntime.pdb
-        ${dist_folder}
-      COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE_DIR:onnxruntime_binding>/onnxruntime_binding.pdb ${dist_folder}
-    )
-  endif()
 elseif (APPLE)
-  add_custom_command(
-    TARGET onnxruntime_binding POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy
-      ${ONNXRUNTIME_BUILD_DIR}/libonnxruntime.${ort_version}.dylib
-      ${dist_folder}
-  )
+  file(COPY ${ONNXRUNTIME_BUILD_DIR}/libonnxruntime.dylib
+      DESTINATION ${dist_folder} FOLLOW_SYMLINK_CHAIN)
 elseif (UNIX)
-  add_custom_command(
-    TARGET onnxruntime_binding POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy
-      ${ONNXRUNTIME_BUILD_DIR}/libonnxruntime.so.${ort_version}
-      ${dist_folder}
-  )
+  file(COPY ${ONNXRUNTIME_BUILD_DIR}/libonnxruntime.so
+      DESTINATION ${dist_folder} FOLLOW_SYMLINK_CHAIN)
 else()
   message(FATAL_ERROR "Platform not supported.")
 endif()

--- a/js/node/CMakeLists.txt
+++ b/js/node/CMakeLists.txt
@@ -67,6 +67,10 @@ set_target_properties(onnxruntime_binding PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY_DEBUG ${dist_folder}
   RUNTIME_OUTPUT_DIRECTORY_RELEASE ${dist_folder}
   RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO ${dist_folder}
+  LIBRARY_OUTPUT_DIRECTORY ${dist_folder}
+  LIBRARY_OUTPUT_DIRECTORY_DEBUG ${dist_folder}
+  LIBRARY_OUTPUT_DIRECTORY_RELEASE ${dist_folder}
+  LIBRARY_OUTPUT_DIRECTORY_RELWITHDEBINFO ${dist_folder}
   BUILD_WITH_INSTALL_RPATH TRUE
   INSTALL_RPATH_USE_LINK_PATH FALSE)
 target_link_libraries(onnxruntime_binding PRIVATE ${CMAKE_JS_LIB})
@@ -92,12 +96,12 @@ else()
 endif()
 
 if (WIN32)
-  target_link_libraries(onnxruntime_binding PRIVATE onnxruntime.lib)
+  target_link_libraries(onnxruntime_binding PRIVATE onnxruntime)
 elseif (APPLE)
   target_link_libraries(onnxruntime_binding PRIVATE libonnxruntime.${ort_version}.dylib)
   set_target_properties(onnxruntime_binding PROPERTIES INSTALL_RPATH "@loader_path")
 else()
-  target_link_libraries(onnxruntime_binding PRIVATE libonnxruntime.so.${ort_version})
+  target_link_libraries(onnxruntime_binding PRIVATE onnxruntime)
   set_target_properties(onnxruntime_binding PROPERTIES INSTALL_RPATH "$ORIGIN/")
 endif()
 


### PR DESCRIPTION
This commit e5f18ba2c14ced91e5f483fde0a7ef4b3b04abbe caused some nightly pipelines to fail. This PR fixes it.  
It is because recently I changed our Linux library's SONAME.   At runtime onnxruntime_binding depends on libonnxruntime.so.1 , instead of libonnxruntime.so.1.19.0(with the full version number). Therefore we need to keep the libonnxruntime.so.1 symlink. 

The packaging tools/ci_build/github/js/pack-npm-packages.ps1 still needs be updated. I will address it in another PR.
