### PR TITLE
Fix reading path of ORT_VERSION in rust/onnxruntime-sys.

### DIFF
--- a/rust/onnxruntime-sys/build.rs
+++ b/rust/onnxruntime-sys/build.rs
@@ -17,7 +17,7 @@ use anyhow::{anyhow, Context, Result};
 /// WARNING: If version is changed, bindings for all platforms will have to be re-generated.
 ///          To do so, run this:
 ///              cargo build --package onnxruntime-sys --features generate-bindings
-const ORT_VERSION: &str = include_str!("./vendor/onnxruntime-src/VERSION_NUMBER");
+const ORT_VERSION: &str = include_str!("../../VERSION_NUMBER");
 
 /// Base Url from which to download pre-built releases/
 const ORT_RELEASE_BASE_URL: &str = "https://github.com/microsoft/onnxruntime/releases/download";


### PR DESCRIPTION
### Description
This PR changes the path that is required for reading ORT_VERSION.



### Motivation and Context
When I tried using onnxruntime in my rust code, I set `ORT_RUST_STRATEGY = "system"` and added the package in `Cargo.toml` as follows:

```toml
[dependencies]
onnxruntime = { git = "https://github.com/microsoft/onnxruntime.git", tag = "v1.18.1"}
```

But this was failed because cargo can't find `./vendor/onnxruntime-src/VERSION_NUMBER`. So I changed the path and it works!


