### PR TITLE
[CUDA] Page Attention

### DIFF
--- a/cmake/external/cutlass.cmake
+++ b/cmake/external/cutlass.cmake
@@ -4,9 +4,10 @@ FetchContent_Declare(
   URL ${DEP_URL_cutlass}
   URL_HASH SHA1=${DEP_SHA1_cutlass}
   PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/cutlass/cutlass_3.5.0.patch
+  EXCLUDE_FROM_ALL
 )
 
 FetchContent_GetProperties(cutlass)
 if(NOT cutlass_POPULATED)
-  FetchContent_Populate(cutlass)
+  FetchContent_MakeAvailable(cutlass)
 endif()

--- a/cmake/onnxruntime_providers_cuda.cmake
+++ b/cmake/onnxruntime_providers_cuda.cmake
@@ -71,7 +71,8 @@
     endif()
     # add using ONNXRUNTIME_ROOT so they show up under the 'contrib_ops' folder in Visual Studio
     source_group(TREE ${ONNXRUNTIME_ROOT} FILES ${onnxruntime_cuda_contrib_ops_cc_srcs} ${onnxruntime_cuda_contrib_ops_cu_srcs})
-    list(APPEND onnxruntime_providers_cuda_src ${onnxruntime_cuda_contrib_ops_cc_srcs} ${onnxruntime_cuda_contrib_ops_cu_srcs})
+    include(${ONNXRUNTIME_ROOT}/contrib_ops/cuda/bert/paged/paged_attention/paged_attention.cmake)
+    list(APPEND onnxruntime_providers_cuda_src ${onnxruntime_cuda_contrib_ops_cc_srcs} ${onnxruntime_cuda_contrib_ops_cu_srcs} ${paged_attention_generated_srcs})
   endif()
 
   if (onnxruntime_ENABLE_TRAINING_OPS)

--- a/cmake/onnxruntime_providers_cuda.cmake
+++ b/cmake/onnxruntime_providers_cuda.cmake
@@ -72,6 +72,11 @@
     # add using ONNXRUNTIME_ROOT so they show up under the 'contrib_ops' folder in Visual Studio
     source_group(TREE ${ONNXRUNTIME_ROOT} FILES ${onnxruntime_cuda_contrib_ops_cc_srcs} ${onnxruntime_cuda_contrib_ops_cu_srcs})
     include(${ONNXRUNTIME_ROOT}/contrib_ops/cuda/bert/paged/paged_attention/paged_attention.cmake)
+    file(GLOB_RECURSE paged_attention_srcs CONFIGURE_DEPENDS
+      "${ONNXRUNTIME_ROOT}/contrib_ops/cuda/bert/paged/*.cc"
+      "${ONNXRUNTIME_ROOT}/contrib_ops/cuda/bert/paged/*.cu"
+    )
+    set_property(SOURCE ${paged_attention_srcs} ${paged_attention_generated_srcs} PROPERTY COMPILE_DEFINITIONS PAGED_SPLIT_COMPILATION=1)
     list(APPEND onnxruntime_providers_cuda_src ${onnxruntime_cuda_contrib_ops_cc_srcs} ${onnxruntime_cuda_contrib_ops_cu_srcs} ${paged_attention_generated_srcs})
   endif()
 

--- a/onnxruntime/contrib_ops/cuda/bert/paged/Float8_e4m3fn.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/Float8_e4m3fn.cuh
@@ -1,0 +1,124 @@
+// Modifications Copyright (c) Microsoft.
+// Copyright (c) 2016-present, Facebook, Inc.
+// Licensed under the BSD-3-Clause License.
+
+// copied from https://github.com/pytorch/pytorch/blob/8f82a44a5b/c10/util/Float8_e4m3fn.h
+// and https://github.com/pytorch/pytorch/blob/8f82a44a5b/c10/util/floating_point_utils.h
+
+#pragma once
+
+/// Defines the Float8_e4m3fn type (8-bit floating-point) including conversions
+/// to standard C types and basic arithmetic operations. Note that arithmetic
+/// operations are implemented by converting to floating point and
+/// performing the operation in float32.
+/// Binary configuration:
+/// s eeee mmm
+/// 1 sign bit
+/// 4 exponent bits
+/// 3 mantissa bits
+/// bias = 7
+///
+/// Implementation based on the paper https://arxiv.org/pdf/2209.05433.pdf
+/// and inspired by Half implementation from pytorch/c10/util/Half.h
+
+#include <type_traits>
+
+#include <cmath>
+#include <cstdint>
+#include <climits>
+#include <cstdint>
+#include <cstring>
+#include <iosfwd>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+
+__forceinline__ __host__ __device__ float
+fp32_from_bits(uint32_t w) {
+  union {
+    uint32_t as_bits;
+    float as_value;
+  } fp32 = {w};
+  return fp32.as_value;
+}
+
+__forceinline__ __host__ __device__ uint32_t
+fp32_to_bits(float f) {
+  union {
+    float as_value;
+    uint32_t as_bits;
+  } fp32 = {f};
+  return fp32.as_bits;
+}
+
+/*
+ * Convert a 32-bit floating-point number in IEEE single-precision format to a
+ * 8-bit floating-point number in fp8 E4M3FN format, in bit representation.
+ */
+__forceinline__ __host__ __device__ uint8_t
+fp8e4m3fn_from_fp32_value(float f) {
+  /*
+   * Binary representation of 480.0f, which is the first value
+   * not representable in fp8e4m3fn range:
+   * 0 1111 111 - fp8e4m3fn
+   * 0 10000111 11100000000000000000000 - fp32
+   */
+  constexpr uint32_t fp8_max = UINT32_C(1087) << 20;
+
+  /*
+   * A mask for converting fp32 numbers lower than fp8e4m3fn normal range
+   * into denorm representation
+   * magic number: ((127 - 7) + (23 - 3) + 1)
+   */
+  constexpr uint32_t denorm_mask = UINT32_C(141) << 23;
+
+  uint32_t f_bits = fp32_to_bits(f);
+
+  uint8_t result = 0u;
+
+  /*
+   * Extract the sign of the input number into the high bit of the 32-bit word:
+   *
+   *      +---+----------------------------------+
+   *      | S |0000000 00000000 00000000 00000000|
+   *      +---+----------------------------------+
+   * Bits  31                 0-31
+   */
+  const uint32_t sign = f_bits & UINT32_C(0x80000000);
+
+  /*
+   * Set sign bit to 0
+   */
+  f_bits ^= sign;
+
+  if (f_bits >= fp8_max) {
+    // NaN - all exponent and mantissa bits set to 1
+    result = 0x7f;
+  } else {
+    if (f_bits < (UINT32_C(121) << 23)) {
+      // Input number is smaller than 2^(-6), which is the smallest
+      // fp8e4m3fn normal number
+      f_bits =
+          fp32_to_bits(fp32_from_bits(f_bits) + fp32_from_bits(denorm_mask));
+      result = static_cast<uint8_t>(f_bits - denorm_mask);
+    } else {
+      // resulting mantissa is odd
+      uint8_t mant_odd = (f_bits >> 20) & 1;
+
+      // update exponent, rounding bias part 1
+      f_bits += ((uint32_t)(7 - 127) << 23) + 0x7FFFF;
+
+      // rounding bias part 2
+      f_bits += mant_odd;
+
+      // take the bits!
+      result = static_cast<uint8_t>(f_bits >> 20);
+    }
+  }
+
+  result |= static_cast<uint8_t>(sign >> 24);
+  return result;
+}

--- a/onnxruntime/contrib_ops/cuda/bert/paged/algorithms.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/algorithms.cuh
@@ -1,0 +1,212 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#if !defined(__HIPCC__)
+#include <cuda_fp16.h>
+#include "contrib_ops/cuda/bert/paged/platform_ext.cuh"
+#else
+#include <hip/hip_fp16.h>
+#include "contrib_ops/rocm/bert/paged/platform_ext.cuh"
+#endif
+
+#include "cute/tensor.hpp"
+
+#include "contrib_ops/cuda/bert/paged/cuda_common.cuh"
+#include "contrib_ops/cuda/bert/paged/type_convert.cuh"
+
+namespace onnxruntime::contrib::paged {
+
+using namespace cute;
+
+// workaround https://github.com/NVIDIA/cutlass/issues/1612
+template <typename Tensor>
+__host__ __device__ constexpr auto
+coalesce_tensor(Tensor&& t) {
+  return make_tensor(static_cast<Tensor&&>(t).data(), coalesce(t.layout()));
+}
+
+// TODO: not safe due to the tiler derivation. Should be removed in the future
+template <typename ThrLayout, typename ValLayout, typename Layout>
+__host__ __device__ constexpr auto
+make_tv_layout(
+    const Layout& target,
+    const ThrLayout& thr_layout = {},  // (t0,...) -> thr_idx
+    const ValLayout& val_layout = {}   // (v0,...) -> val_idx
+) {
+  auto layout = raked_product(thr_layout, val_layout);  // (t0*v0,t1*v1,...) -> (thr_idx,val_idx)
+  auto layout_tv = right_inverse(layout).with_shape(make_shape(size(thr_layout), size(val_layout)));
+  return zipped_divide(target, layout).compose(layout_tv, _);
+}
+
+template <typename T>
+__forceinline__ __device__ bool
+is_inf_or_nan(const T& v);
+
+template <>
+__forceinline__ __device__ bool
+is_inf_or_nan(const float& v) {
+#if PAGED_LITTLE_ENDIAN_BIT_TEST_IS_INF_OR_NAN
+  union {
+    float f;
+    uint32_t u;
+  };
+  f = v;
+  constexpr uint32_t exp = 0x7F800000;
+  return (u & exp) == exp;
+#else
+  return isinf(v) || isnan(v);
+#endif
+}
+
+template <>
+__forceinline__ __device__ bool
+is_inf_or_nan(const half& v) {
+#if PAGED_LITTLE_ENDIAN_BIT_TEST_IS_INF_OR_NAN
+  union {
+    half h;
+    uint16_t u;
+  };
+  h = v;
+  constexpr uint16_t exp = 0x7C00;
+  return (u & exp) == exp;
+#else
+  return __hisinf(v) || __hisnan(v);
+#endif
+}
+
+template <typename T>
+__forceinline__ __device__ T
+filter_inf_nan(const T& v) {
+  return is_inf_or_nan(v) ? T{} : v;
+}
+
+namespace detail {
+
+template <typename T, int N>
+struct Vec;
+
+template <>
+struct Vec<float, 2> {
+  using type = float2;
+};
+
+template <>
+struct Vec<half, 2> {
+  using type = half2;
+};
+
+template <
+    int N, typename T,
+    typename TensorAEngine, typename TensorALayout,
+    typename TensorBEngine, typename TensorBLayout>
+__forceinline__ __device__ T
+small_vec_inner_product(const Tensor<TensorAEngine, TensorALayout>& a, const Tensor<TensorBEngine, TensorBLayout>& b) {
+  using TA = std::remove_const_t<typename TensorAEngine::element_type>;
+  using TB = std::remove_const_t<typename TensorBEngine::element_type>;
+
+#define HALF_ACC 0
+  static_assert(N == 1 || N == 2 || N == 4 || N == 8 || N == 16);
+  if constexpr (N == 1) {
+    return type_convert<T>(a(0)) * type_convert<T>(b(0));
+  } else {
+    using A2 = typename Vec<TA, 2>::type;
+    using B2 = typename Vec<TB, 2>::type;
+    const auto a2 = cute::recast<A2>(a);
+    const auto b2 = cute::recast<B2>(b);
+    // print_type(a, a2, b, b2, size(a), size(a2), size(b), size(b2));
+
+    if constexpr (
+        std::is_same_v<TA, float> &&
+        std::is_same_v<TB, float>
+    ) {
+      float acc = 0.0f;
+      CUTE_UNROLL
+      for (int i = 0; i < N; i++) {
+        acc = __fmaf_rn(a(i), b(i), acc);
+      }
+      return acc;
+    } else if constexpr (
+        std::is_same_v<TA, float> &&
+        std::is_same_v<TB, half>
+    ) {
+#if HALF_ACC
+      half2 acc{};
+      CUTE_UNROLL
+      for (int i = 0; i < size(a2); i++) {
+        const half2 a2_fp16 = type_convert<half2>(*reinterpret_cast<const float2*>(&a2(i)));
+        const half2& b2_fp16 = *reinterpret_cast<const half2*>(&b2(i));
+        acc = __hfma2(a2_fp16, b2_fp16, acc);
+      }
+      auto acc_f32 = type_convert<float2>(acc);
+      return acc_f32.x + acc_f32.y;
+#else
+      float acc{};
+      CUTE_UNROLL
+      for (int i = 0; i < size(a2); i++) {
+        const float2 a2_f2 = *reinterpret_cast<const float2*>(&a2(i));
+        const float2 b2_f2 = __half22float2(*reinterpret_cast<const half2*>(&b2(i)));
+        acc = __fmaf_rn(a2_f2.x, b2_f2.x, acc);
+        acc = __fmaf_rn(a2_f2.y, b2_f2.y, acc);
+      }
+      return acc;
+#endif
+#undef HALF_ACC
+    } else if constexpr (
+        std::is_same_v<TA, half> &&
+        std::is_same_v<TB, half>
+    ) {
+#if PAGED_INNER_PRODUCT_FP16_ARITHMETIC_FP32_ACC
+      float acc{};
+      CUTE_UNROLL
+      for (int i = 0; i < size(a2); i++) {
+        acc = hfma2(a2(i), b2(i), acc);
+      }
+      return acc;
+#else
+      half2 acc{};
+      CUTE_UNROLL
+      for (int i = 0; i < size(a2); i++) {
+        acc = __hfma2(a2(i), b2(i), acc);
+      }
+      auto acc_f32x2 = type_convert<float2>(acc);
+      return acc_f32x2.x + acc_f32x2.y;
+#endif
+    } else {
+      static_assert(always_false<TensorAEngine, TensorBEngine>, "not implemented");
+      return std::numeric_limits<float>::quiet_NaN();
+    }
+  }
+}
+
+}  // namespace detail
+
+template <
+    typename T,
+    typename TensorAEngine, typename TensorALayout,
+    typename TensorBEngine, typename TensorBLayout>
+__forceinline__ __device__ T
+inner_product(const Tensor<TensorAEngine, TensorALayout>& a, const Tensor<TensorBEngine, TensorBLayout>& b) {
+  static_assert(std::is_same_v<T, float>, "only float return value is implemented");
+
+  const auto a_coalesced = coalesce_tensor(a);
+  const auto b_coalesced = coalesce_tensor(b);
+  static_assert(rank(a_coalesced) == 1 && rank(b_coalesced) == 1);
+  static_assert(size(a_coalesced) == size(b_coalesced));
+
+  constexpr auto SmallVec = gcd(size(a_coalesced), 16);
+  static_assert(SmallVec == 1 || SmallVec == 2 || SmallVec == 4 || SmallVec == 8 || SmallVec == 16);
+
+  const auto av = tiled_divide(a_coalesced, make_tile(Int<SmallVec>{}));  // ((SmallVec),Iter...)
+  const auto bv = tiled_divide(b_coalesced, make_tile(Int<SmallVec>{}));  // ((SmallVec),Iter...)
+
+  float acc{};
+  CUTE_UNROLL
+  for (int i = 0; i < size(av) / SmallVec; i++) {
+    acc += detail::small_vec_inner_product<SmallVec, float>(av(_, i), bv(_, i));
+  }
+  return acc;
+}
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/atomics.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/atomics.cuh
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+namespace onnxruntime::contrib::paged {
+
+template <typename T>
+__forceinline__ __device__ T
+atomic_load_relaxed(const T* address) {
+  const volatile T* v{address};
+  return *v;
+}
+
+__forceinline__ __device__ float
+atomic_max(float* address, float val) {
+  union {
+    uint32_t u32;
+    float f32;
+  } cvt;
+  cvt.f32 = val;
+
+  // https://stackoverflow.com/a/51549250/2091555
+  // https://github.com/NVIDIA/cutlass/blob/ffa34e7075/include/cutlass/functional.h#L621-L623
+  return (cvt.u32 & 0x80000000) == 0  // extract signbit, aka, if positive
+             ? __int_as_float(atomicMax((int*)address, __float_as_int(val)))
+             : __uint_as_float(atomicMin((unsigned int*)address, __float_as_uint(val)));
+}
+
+__forceinline__ __device__ float
+atomic_min(float* address, float val) {
+  union {
+    uint32_t u32;
+    float f32;
+  } cvt;
+  cvt.f32 = val;
+
+  // https://stackoverflow.com/a/51549250/2091555
+  return (cvt.u32 & 0x80000000) == 0  // extract signbit, aka, if positive
+             ? __int_as_float(atomicMin((int*)address, __float_as_int(val)))
+             : __uint_as_float(atomicMax((unsigned int*)address, __float_as_uint(val)));
+}
+
+// temporarily put them here
+template <typename T>
+__forceinline__ __device__ T volatile_load(const volatile T* address) {
+  return *address;
+}
+
+template <>
+__forceinline__ __device__ float2 volatile_load(const volatile float2* address) {
+  union {
+    float2 f32x2;
+    uint64_t u64;
+  };
+  u64 = *reinterpret_cast<const volatile uint64_t*>(address);
+  return f32x2;
+}
+
+template <>
+__forceinline__ __device__ int2 volatile_load(const volatile int2* address) {
+  union {
+    int2 i32x2;
+    uint64_t u64;
+  };
+  u64 = *reinterpret_cast<const volatile uint64_t*>(address);
+  return i32x2;
+}
+
+template <typename T>
+__forceinline__ __device__ void volatile_store(volatile T* address, const T& val) {
+  *address = val;
+}
+
+template <>
+__forceinline__ __device__ void volatile_store(volatile float2* address, const float2& val) {
+  union {
+    float2 f32x2;
+    uint64_t u64;
+  };
+  f32x2 = val;
+  *reinterpret_cast<volatile uint64_t*>(address) = u64;
+}
+
+template <>
+__forceinline__ __device__ void volatile_store(volatile int2* address, const int2& val) {
+  union {
+    int2 i32x2;
+    uint64_t u64;
+  };
+  i32x2 = val;
+  *reinterpret_cast<volatile uint64_t*>(address) = u64;
+}
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/config.h
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/config.h
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#define PAGED_INNER_PRODUCT_FP16_ARITHMETIC_FP32_ACC 0
+
+#define PAGED_LITTLE_ENDIAN_BIT_TEST_IS_INF_OR_NAN 0

--- a/onnxruntime/contrib_ops/cuda/bert/paged/cuda_common.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/cuda_common.cuh
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cstdint>
+#include "contrib_ops/cuda/bert/paged/cuda_common.h"
+#if !defined(__HIPCC__)
+#include "contrib_ops/cuda/bert/paged/platform_ext.cuh"
+#else
+#include "contrib_ops/rocm/bert/paged/platform_ext.cuh"
+#endif
+
+#if !defined(__HIPCC__)
+#define SHFL_XOR_SYNC(var, lane_mask) __shfl_xor_sync(uint32_t(-1), var, lane_mask)
+#else
+#define SHFL_XOR_SYNC(var, lane_mask) __shfl_xor(var, lane_mask)
+#endif
+
+#if !defined(__HIPCC__)
+#define SHFL_SYNC(var, src_lane) __shfl_sync(uint32_t(-1), var, src_lane)
+#else
+#define SHFL_SYNC(var, src_lane) __shfl(var, src_lane)
+#endif
+
+namespace onnxruntime::contrib::paged {
+
+__forceinline__ __device__ auto
+lane_id() {
+  return threadIdx.x % constant::WarpSize;
+}
+
+__forceinline__ __device__ auto
+warp_id() {
+  return threadIdx.x / constant::WarpSize;
+}
+
+#if !defined(__CUDACC__)
+__forceinline__
+#endif
+__host__ __device__ constexpr uint32_t
+ceil_log2(uint32_t n) {
+  return n <= 1 ? 0 : 1 + ceil_log2((n + 1) / 2);
+}
+
+__forceinline__ __host__ __device__ constexpr uint32_t
+next_power_of_two(uint32_t n) {
+  return uint32_t(1) << ceil_log2(n);
+}
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/cuda_common.h
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/cuda_common.h
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cstdio>
+
+// TODO: split cuda and hip
+
+#if !defined(__HIP_PLATFORM_AMD__)
+#include <cuda_runtime.h>
+#include "contrib_ops/cuda/bert/paged/config.h"
+#else
+#include <hip/hip_runtime.h>
+#include "contrib_ops/rocm/bert/paged/config.h"
+#endif
+
+#if !defined(__HIP_PLATFORM_AMD__)
+#define CUDA_CHECK(expr)                                                                               \
+  do {                                                                                                 \
+    cudaError_t err = (expr);                                                                          \
+    if (err != cudaSuccess) {                                                                          \
+      fprintf(stderr, "CUDA Error on %s:%d\n", __FILE__, __LINE__);                                    \
+      fprintf(stderr, "CUDA Error Code  : %d\n     Error String: %s\n", err, cudaGetErrorString(err)); \
+      exit(err);                                                                                       \
+    }                                                                                                  \
+  } while (0)
+#else
+#define HIP_CHECK(expr)                                                                              \
+  do {                                                                                               \
+    hipError_t err = (expr);                                                                         \
+    if (err != hipSuccess) {                                                                         \
+      fprintf(stderr, "HIP Error on %s:%d\n", __FILE__, __LINE__);                                   \
+      fprintf(stderr, "HIP Error Code  : %d\n     Error String: %s\n", err, hipGetErrorString(err)); \
+      exit(err);                                                                                     \
+    }                                                                                                \
+  } while (0)
+#define CUDA_CHECK(expr) HIP_CHECK(expr)
+#endif
+
+#if defined(__HIPCC__)
+#define cudaMallocAsync hipMallocAsync
+#define cudaFreeAsync hipFreeAsync
+#define cudaMemsetAsync hipMemsetAsync
+#endif
+
+namespace onnxruntime::contrib::paged {
+
+template <typename... Ts>
+constexpr bool always_false = false;
+
+#if !defined(__HIP_PLATFORM_AMD__)
+using stream_t = cudaStream_t;
+#else
+using stream_t = hipStream_t;
+#endif
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/cuda_common.h
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/cuda_common.h
@@ -55,4 +55,11 @@ using stream_t = cudaStream_t;
 using stream_t = hipStream_t;
 #endif
 
+#if !defined(__HIP_PLATFORM_AMD__)
+using dev_props_ptr = const cudaDeviceProp*;
+#else
+using dev_props_ptr = const hipDeviceProp*;
+#endif
+
+
 }  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/load_balance/bwd.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/load_balance/bwd.cuh
@@ -1,0 +1,120 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+namespace onnxruntime::contrib::paged {
+
+template <int N, typename T>
+class BrokerWorkDistributor {
+  using Ticket = uint32_t;
+  using HT_t = uint32_t;
+  using HT = uint64_t;
+
+  volatile Ticket tickets[N];
+  T ring_buffer[N];
+
+  HT head_tail;
+  int count;
+
+  template <typename L>
+  __device__ __forceinline__ L atomicLoad(L* l) {
+    return *l;
+  }
+
+  __device__ HT_t* head(HT* head_tail) {
+    return reinterpret_cast<HT_t*>(head_tail) + 1;
+  }
+
+  __device__ HT_t* tail(HT* head_tail) {
+    return reinterpret_cast<HT_t*>(head_tail);
+  }
+
+  __forceinline__ __device__ void waitForTicket(const unsigned int P, const Ticket number) {
+    while (tickets[P] != number) {
+      backoff();  // back off
+    }
+  }
+
+  __forceinline__ __device__ bool ensureDequeue() {
+    int Num = atomicLoad(&count);
+    bool ensurance = false;
+
+    while (!ensurance && Num > 0) {
+      if (atomicSub(&count, 1) > 0) {
+        ensurance = true;
+      } else {
+        Num = atomicAdd(&count, 1) + 1;
+      }
+    }
+    return ensurance;
+  }
+
+  __forceinline__ __device__ bool ensureEnqueue() {
+    int Num = atomicLoad(&count);
+    bool ensurance = false;
+
+    while (!ensurance && Num < N) {
+      if (atomicAdd(&count, 1) < N) {
+        ensurance = true;
+      } else {
+        Num = atomicSub(&count, 1) - 1;
+      }
+    }
+    return ensurance;
+  }
+
+  __forceinline__ __device__ void readData(T& val) {
+    const unsigned int Pos = atomicAdd(head(const_cast<HT*>(&head_tail)), 1);
+    const unsigned int P = Pos % N;
+
+    waitForTicket(P, 2 * (Pos / N) + 1);
+    val = ring_buffer[P];
+    __threadfence();
+    tickets[P] = 2 * ((Pos + N) / N);
+  }
+
+  __forceinline__ __device__ void putData(const T data) {
+    const unsigned int Pos = atomicAdd(tail(const_cast<HT*>(&head_tail)), 1);
+    const unsigned int P = Pos % N;
+    const unsigned int B = 2 * (Pos / N);
+
+    waitForTicket(P, B);
+    ring_buffer[P] = data;
+    __threadfence();
+    tickets[P] = B + 1;
+  }
+
+public:
+  __device__ void init() {
+    const int lid = threadIdx.x + blockIdx.x * blockDim.x;
+
+    if (lid == 0) {
+      count = 0;
+      head_tail = 0x0ULL;
+    }
+
+    for (int v = lid; v < N; v += blockDim.x * gridDim.x) {
+      ring_buffer[v] = T(0x0);
+      tickets[v] = 0x0;
+    }
+  }
+
+  __forceinline__ __device__ bool enqueue(const T& data) {
+    bool writeData = ensureEnqueue();
+    if (writeData) {
+      putData(data);
+    }
+    return writeData;
+  }
+
+  __forceinline__ __device__ bool dequeue(T& data) {
+    bool hasData = ensureDequeue();
+    if (hasData) {
+      readData(data);
+    }
+    return hasData;
+  }
+};
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/load_balance/bwd_weak.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/load_balance/bwd_weak.cuh
@@ -1,0 +1,244 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "contrib_ops/cuda/bert/paged/cuda_common.h"
+#include "contrib_ops/cuda/bert/paged/cuda_common.cuh"
+#include "contrib_ops/cuda/bert/paged/mutex.cuh"
+
+namespace onnxruntime::contrib::paged {
+
+// TODO: move to atomics.cuh
+namespace memory_order {
+struct Acquire {};
+struct Release {};
+struct Relaxed {};
+};  // namespace memory_order
+
+namespace memory_scope {
+struct Sys {};
+struct Gpu {};
+// struct Cluster{};
+// struct Cta{};
+}  // namespace memory_scope
+
+template <typename Sem, typename Scope = memory_scope::Gpu>
+__forceinline__ __device__ int32_t
+atomic_load_global_i32(const int32_t* address) {
+  int32_t ret;
+  if constexpr (std::is_same_v<Sem, memory_order::Relaxed> && std::is_same_v<Scope, memory_scope::Gpu>) {
+#if !defined(__HIPCC__)
+    asm volatile("ld.relaxed.gpu.global.s32 %0, [%1];" : "=r"(ret) : "l"(address));
+#else
+    // ret = __atomic_load_n(address, __ATOMIC_RELAXED);
+    ret = volatile_load(address);
+#endif
+  } else {
+    static_assert(onnxruntime::contrib::paged::always_false<Sem, Scope>, "not implemented");
+  }
+  return ret;
+}
+
+template <typename Sem, typename Scope = memory_scope::Gpu>
+__forceinline__ __device__ uint32_t
+atomic_load_global_u32(uint32_t* address) {
+  uint32_t ret;
+  if constexpr (std::is_same_v<Sem, memory_order::Relaxed> && std::is_same_v<Scope, memory_scope::Gpu>) {
+#if !defined(__HIPCC__)
+    asm volatile("ld.relaxed.gpu.global.u32 %0, [%1];" : "=r"(ret) : "l"(address));
+#else
+    ret = __atomic_load_n(address, __ATOMIC_RELAXED);
+#endif
+  } else {
+    static_assert(onnxruntime::contrib::paged::always_false<Sem, Scope>, "not implemented");
+  }
+  return ret;
+}
+
+template <typename Sem, typename Scope = memory_scope::Gpu>
+__forceinline__ __device__ void
+atomic_store_global_u32(uint32_t* address, uint32_t val) {
+  if constexpr (std::is_same_v<Sem, memory_order::Relaxed> && std::is_same_v<Scope, memory_scope::Gpu>) {
+#if !defined(__HIPCC__)
+    asm volatile("st.relaxed.gpu.global.u32 [%0], %1;" ::"l"(address), "r"(val));
+#else
+    // __atomic_store_n(address, val, __ATOMIC_RELAXED);
+    volatile_store(address, val);
+#endif
+  } else if constexpr (std::is_same_v<Sem, memory_order::Release> && std::is_same_v<Scope, memory_scope::Gpu>) {
+#if !defined(__HIPCC__)
+    asm volatile("st.release.gpu.global.u32 [%0], %1;" ::"l"(address), "r"(val));
+#else
+    // __atomic_store_n(address, val, __ATOMIC_RELEASE);
+    __threadfence();
+    volatile_store(address, val);
+#endif
+  } else {
+    static_assert(onnxruntime::contrib::paged::always_false<Sem, Scope>, "not implemented");
+  }
+}
+
+template <typename Sem, typename Scope = memory_scope::Gpu>
+__forceinline__ __device__ int32_t
+atomic_add_global_i32(int32_t* address, int32_t val) {
+  int32_t old;
+  if constexpr (std::is_same_v<Sem, memory_order::Relaxed> && std::is_same_v<Scope, memory_scope::Gpu>) {
+#if !defined(__HIPCC__)
+    asm volatile("atom.relaxed.gpu.global.add.s32 %0, [%1], %2;" : "=r"(old) : "l"(address), "r"(val));
+#else
+    old = __atomic_fetch_add(address, val, __ATOMIC_RELAXED);
+#endif
+  } else {
+    static_assert(onnxruntime::contrib::paged::always_false<Sem, Scope>, "not implemented");
+  }
+  return old;
+}
+
+template <typename Sem, typename Scope = memory_scope::Gpu>
+__forceinline__ __device__ int32_t
+atomic_sub_global_i32(int32_t* address, int32_t val) {
+  return atomic_add_global_i32<Sem, Scope>(address, -val);
+}
+
+template <typename Sem, typename Scope = memory_scope::Gpu>
+__forceinline__ __device__ uint32_t
+atomic_add_global_u32(uint32_t* address, uint32_t val) {
+  uint32_t old;
+  if constexpr (std::is_same_v<Sem, memory_order::Relaxed> && std::is_same_v<Scope, memory_scope::Gpu>) {
+#if !defined(__HIPCC__)
+    asm volatile("atom.relaxed.gpu.global.add.u32 %0, [%1], %2;" : "=r"(old) : "l"(address), "r"(val));
+#else
+    old = __atomic_fetch_add(address, val, __ATOMIC_RELAXED);
+#endif
+  } else {
+    static_assert(onnxruntime::contrib::paged::always_false<Sem, Scope>, "not implemented");
+  }
+  return old;
+}
+
+template <typename Sem, typename Scope = memory_scope::Gpu>
+__forceinline__ __device__ void
+memory_barrier() {
+  if constexpr (std::is_same_v<Scope, memory_scope::Gpu>) {
+#if !defined(__HIPCC__)
+    asm volatile("fence.acq_rel.gpu;" ::);
+#else
+    // __atomic_thread_fence(__ATOMIC_ACQ_REL);
+    __threadfence();
+#endif
+  } else {
+    static_assert(onnxruntime::contrib::paged::always_false<Sem, Scope>, "not implemented");
+  }
+}
+
+template <int N, typename T>
+class BrokerWorkDistributor {
+  static_assert(next_power_of_two(N) == N, "queue size must be power of two");
+
+public:
+  __device__ void init() {
+    // Just manually initialize (memset) the BrokerWorkDistributor to 0 will be OK!
+    const int lid = threadIdx.x + blockIdx.x * blockDim.x;
+    if (lid == 0) {
+      size_ = 0;
+      head_ = 0;
+      tail_ = 0;
+    }
+
+    for (int v = lid; v < N; v += blockDim.x * gridDim.x) {
+      // ring_buffer_[v] = T{};
+      tickets_[v] = 0;
+    }
+  }
+
+  __forceinline__ __device__ bool
+  enqueue(const T& data) {
+    if (ensure_enqueue()) {
+      put_data(data);
+      return true;
+    }
+    return false;
+  }
+
+  __forceinline__ __device__ bool
+  dequeue(T& data) {
+    if (ensure_dequeue()) {
+      read_data(data);
+      return true;
+    }
+    return false;
+  }
+
+private:
+  using ticket_t = uint32_t;
+  using head_tail_t = uint32_t;
+
+  T ring_buffer_[N];
+  ticket_t tickets_[N];
+  head_tail_t head_;
+  head_tail_t tail_;
+  int32_t size_;
+
+  __forceinline__ __device__ void
+  wait_for_ticket(const uint32_t i, const ticket_t number) {
+    while (atomic_load_global_u32<memory_order::Relaxed>(&tickets_[i]) != number) {
+      backoff();
+    }
+  }
+
+  __forceinline__ __device__ bool
+  ensure_enqueue() {
+    int32_t num = atomic_load_global_i32<memory_order::Relaxed>(&size_);
+    while (true) {
+      if (num >= N) {
+        return false;
+      }
+      if (atomic_add_global_i32<memory_order::Relaxed>(&size_, 1) < N) {
+        break;
+      }
+      num = atomic_sub_global_i32<memory_order::Relaxed>(&size_, 1) - 1;
+    }
+    return true;
+  }
+
+  __forceinline__ __device__ bool
+  ensure_dequeue() {
+    int32_t num = atomic_load_global_i32<memory_order::Relaxed>(&size_);
+    int ns = 1;
+    while (true) {
+      if (num <= 0) {
+        return false;
+      }
+      if (atomic_sub_global_i32<memory_order::Relaxed>(&size_, 1) > 0) {
+        break;
+      }
+      backoff(ns);
+      ns = min(ns * 2, 256);
+      num = atomic_add_global_i32<memory_order::Relaxed>(&size_, 1) + 1;
+    }
+    return true;
+  }
+
+  __forceinline__ __device__ void
+  read_data(T& data) {
+    uint32_t pos = atomic_add_global_u32<memory_order::Relaxed>(&head_, 1);
+    uint32_t p = pos % N;
+    wait_for_ticket(p, 2 * (pos / N) + 1);
+    memory_barrier<memory_order::Acquire>();
+    data = ring_buffer_[p];
+    atomic_store_global_u32<memory_order::Release>(&tickets_[p], 2 * ((pos + N) / N));  // store_ticket
+  }
+
+  __forceinline__ __device__ void
+  put_data(const T& data) {
+    uint32_t pos = atomic_add_global_u32<memory_order::Relaxed>(&tail_, 1);
+    uint32_t p = pos % N;
+    uint32_t b = 2 * (pos / N);
+    wait_for_ticket(p, b);
+    ring_buffer_[p] = data;
+    atomic_store_global_u32<memory_order::Release>(&tickets_[p], b + 1);  // store_ticket
+  }
+};
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/mutex.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/mutex.cuh
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#if !defined(__HIP_PLATFORM_AMD__)
+#include <cuda_runtime_api.h>
+#else
+#include <hip/hip_runtime_api.h>
+#endif
+
+#include <cstdint>
+
+namespace onnxruntime::contrib::paged {
+
+using mutex_t = uint32_t;
+
+namespace detail {
+
+__forceinline__ __device__ void
+nanosleep(uint32_t duration_ns) {
+#if !defined(__HIPCC__)
+  __nanosleep(duration_ns);
+#else
+  asm volatile(R"asm(
+      S_NOP 0
+      S_NOP 0
+      S_NOP 0
+      S_NOP 0
+      S_NOP 0
+      S_NOP 0
+      S_NOP 0
+      S_NOP 0
+    )asm" ::);
+#endif
+}
+}  // namespace detail
+
+// TODO: move to task.cuh
+__forceinline__ __device__ void
+backoff(uint32_t duration_ns = 32) {
+  detail::nanosleep(duration_ns);
+}
+
+__forceinline__ __device__ void
+mutex_lock(mutex_t& mutex) {
+  uint32_t ns = 8;
+  while (atomicCAS(&mutex, 0, 1) == 1) {
+    backoff(ns);
+    if (ns < 256) {
+      ns *= 2;
+    }
+  }
+}
+
+__forceinline__ __device__ bool
+try_mutex_lock(mutex_t& mutex) {
+  return atomicCAS(&mutex, 0, 1) == 0;
+}
+
+__forceinline__ __device__ void
+mutex_unlock(mutex_t& mutex) {
+  atomicExch(&mutex, 0);
+}
+
+struct lock_guard {
+  mutex_t& mutex_;
+  __forceinline__ __device__
+  lock_guard(mutex_t& mutex)
+      : mutex_{mutex} {
+    mutex_lock(mutex_);
+  }
+
+  __forceinline__ __device__
+  ~lock_guard() {
+    mutex_unlock(mutex_);
+  }
+};
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/attention_common.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/attention_common.cuh
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "cute/tensor.hpp"
+#include "contrib_ops/cuda/bert/paged/cuda_common.cuh"
+
+namespace onnxruntime::contrib::paged {
+
+// Utility function for attention softmax.
+template <int NUM_WARPS>
+__forceinline__ __device__ float
+block_sum(float* red_smem, float sum) {
+  int warp = threadIdx.x / constant::WarpSize;
+  int lane = threadIdx.x % constant::WarpSize;
+
+  CUTE_UNROLL
+  for (int mask = constant::WarpSize / 2; mask >= 1; mask /= 2) {
+    sum += SHFL_XOR_SYNC(sum, mask);
+  }
+
+  if (lane == 0) {
+    red_smem[warp] = sum;
+  }
+
+  __syncthreads();
+
+  if (lane < NUM_WARPS) {
+    sum = red_smem[lane];
+  }
+
+  CUTE_UNROLL
+  for (int mask = NUM_WARPS / 2; mask >= 1; mask /= 2) {
+    sum += SHFL_XOR_SYNC(sum, mask);
+  }
+
+  // Broadcast to other threads.
+  return SHFL_SYNC(sum, 0);
+}
+
+template <int NumThreads, int GroupSize, int NumWarps>
+__forceinline__ __device__ void
+softmax_cta(
+    float* reduction_buffer, float qk_max_of_group,
+    float* logits, int logits_size,      // buffer desc
+    int start_tok_idx, int end_tok_idx,  // valid range
+    float2* max_sum = nullptr            // optional output for max and sum of the chunk
+) {
+  auto lane_idx = lane_id();
+  float qk_max = qk_max_of_group;
+  // Perform reduction across the threads in the same warp to get the
+  // max qk value for each "warp" (not across the thread block yet).
+  // The leading thread of each group already has its max qk value.
+  CUTE_UNROLL
+  for (int mask = constant::WarpSize / 2; mask >= GroupSize; mask /= 2) {
+    qk_max = fmaxf(qk_max, SHFL_XOR_SYNC(qk_max, mask));
+  }
+  if (lane_idx == 0) {
+    reduction_buffer[warp_id()] = qk_max;
+  }
+  __syncthreads();
+
+  // Get the max qk value for the sequence.
+  qk_max = lane_idx < NumWarps ? reduction_buffer[lane_idx] : std::numeric_limits<float>::lowest();
+  CUTE_UNROLL
+  for (int mask = NumWarps / 2; mask >= 1; mask /= 2) {
+    qk_max = fmaxf(qk_max, SHFL_XOR_SYNC(qk_max, mask));
+  }
+  // Broadcast the max qk value to all threads.
+  qk_max = SHFL_SYNC(qk_max, 0);
+
+  // Get the sum of the exp values.
+  float exp_sum = 0.f;
+  for (int i = threadIdx.x; i < logits_size; i += NumThreads) {
+    float val = (start_tok_idx <= i && i < end_tok_idx) ? __expf(logits[i] - qk_max) : 0.0f;
+    logits[i] = val;
+    exp_sum += val;
+  }
+  exp_sum = block_sum<NumWarps>(&reduction_buffer[NumWarps], exp_sum);
+
+  // Compute softmax.
+  const float inv_sum = __frcp_rn(exp_sum + 1e-6f);
+  for (int i = threadIdx.x; i < logits_size; i += NumThreads) {
+    logits[i] *= inv_sum;
+  }
+
+  if (max_sum != nullptr && threadIdx.x == 0) {
+    *max_sum = float2{qk_max, exp_sum};
+  }
+  __syncthreads();
+}
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/attention_common.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/attention_common.cuh
@@ -5,6 +5,9 @@
 
 #include "cute/tensor.hpp"
 #include "contrib_ops/cuda/bert/paged/cuda_common.cuh"
+#include "contrib_ops/cuda/bert/paged/mutex.cuh"
+#include "contrib_ops/cuda/bert/paged/type_convert.cuh"
+#include "contrib_ops/cuda/bert/paged/warp_utilities.cuh"
 
 namespace onnxruntime::contrib::paged {
 
@@ -39,11 +42,11 @@ block_sum(float* red_smem, float sum) {
   return SHFL_SYNC(sum, 0);
 }
 
-template <int NumThreads, int GroupSize, int NumWarps>
+template <int NumThreads, int GroupSize, int NumWarps, int NumLogits>
 __forceinline__ __device__ void
 softmax_cta(
     float* reduction_buffer, float qk_max_of_group,
-    float* logits, int logits_size,      // buffer desc
+    float* logits,
     int start_tok_idx, int end_tok_idx,  // valid range
     float2* max_sum = nullptr            // optional output for max and sum of the chunk
 ) {
@@ -72,7 +75,8 @@ softmax_cta(
 
   // Get the sum of the exp values.
   float exp_sum = 0.f;
-  for (int i = threadIdx.x; i < logits_size; i += NumThreads) {
+  CUTE_UNROLL
+  for (int i = threadIdx.x; i < NumLogits; i += NumThreads) {
     float val = (start_tok_idx <= i && i < end_tok_idx) ? __expf(logits[i] - qk_max) : 0.0f;
     logits[i] = val;
     exp_sum += val;
@@ -81,7 +85,8 @@ softmax_cta(
 
   // Compute softmax.
   const float inv_sum = __frcp_rn(exp_sum + 1e-6f);
-  for (int i = threadIdx.x; i < logits_size; i += NumThreads) {
+  CUTE_UNROLL
+  for (int i = threadIdx.x; i < NumLogits; i += NumThreads) {
     logits[i] *= inv_sum;
   }
 
@@ -90,5 +95,313 @@ softmax_cta(
   }
   __syncthreads();
 }
+
+#if 0
+template <int NumLogits>
+__forceinline__ __device__ void
+softmax_warp(
+    float* logits,
+    int start_tok_idx, int end_tok_idx,  // valid range
+    float2* max_sum = nullptr            // optional output for max and sum of the chunk
+) {
+  auto lane_idx = lane_id();
+
+  // compute max along logits
+  float max_val = std::numeric_limits<float>::lowest();
+  CUTE_UNROLL
+  for (int i = lane_idx; i < NumLogits; i += constant::WarpSize) {
+    float val = (start_tok_idx <= i && i < end_tok_idx) ? logits[i] : std::numeric_limits<float>::lowest();
+    max_val = fmaxf(max_val, val);
+  }
+  max_val = warp::reduce<constant::WarpSize>(max_val, [](float a, float b) { return fmaxf(a, b); });
+  max_val = warp::broadcast<constant::WarpSize>(max_val);
+
+  // compute the sum of exp
+  float exp_sum = 0.f;
+  CUTE_UNROLL
+  for (int i = lane_idx; i < NumLogits; i += constant::WarpSize) {
+    float val = (start_tok_idx <= i && i < end_tok_idx) ? __expf(logits[i] - max_val) : 0.0f;
+    logits[i] = val;
+    exp_sum += val;
+  }
+  exp_sum = warp::reduce<constant::WarpSize>(exp_sum, [](float a, float b) { return a + b; });
+  exp_sum = warp::broadcast<constant::WarpSize>(exp_sum);
+
+  // apply softmax denominator
+  const float inv_sum = __frcp_rn(exp_sum + 1e-6f);
+  CUTE_UNROLL
+  for (int i = lane_idx; i < NumLogits; i += constant::WarpSize) {
+    logits[i] *= inv_sum;
+  }
+
+  if (max_sum != nullptr && lane_idx == 0) {
+    *max_sum = float2{max_val, exp_sum};
+  }
+}
+#else
+template <int NumLogits>
+__forceinline__ __device__ void
+softmax_warp(
+    float* logits_ptr,
+    int start_tok_idx, int end_tok_idx,  // valid range
+    float2* max_sum = nullptr            // optional output for max and sum of the chunk
+) {
+  static_assert(ceil_div(NumLogits, constant::WarpSize) <= 96);
+
+  auto lane_idx = lane_id();
+
+  constexpr auto LogitsLayout = make_layout(Int<NumLogits>{});
+  auto tiled_copy = make_tiled_copy(
+      Copy_Atom<UniversalCopy<float>, float>{},
+      make_layout(Int<constant::WarpSize>{}),
+      make_layout(_1{})
+  );
+  auto thr_copy = tiled_copy.get_thread_slice(lane_idx);
+  auto logits = thr_copy.partition_D(make_tensor(make_smem_ptr(logits_ptr), LogitsLayout));
+  auto tcoord = thr_copy.partition_D(make_identity_tensor(shape(LogitsLayout)));
+
+  auto regs = make_tensor_like(logits);
+  fill(regs, std::numeric_limits<float>::lowest());
+  CUTE_UNROLL
+  for (int i = 0; i < size(regs); i++) {
+    if (start_tok_idx <= tcoord(i) && tcoord(i) < end_tok_idx) {
+      regs(i) = logits(i);
+    }
+  }
+
+  float max_val = std::numeric_limits<float>::lowest();
+  CUTE_UNROLL
+  for (int i = 0; i < size(regs); i++) {
+    max_val = fmaxf(max_val, regs(i));
+  }
+  max_val = warp::reduce<constant::WarpSize>(max_val, [](float a, float b) { return fmaxf(a, b); });
+  max_val = warp::broadcast<constant::WarpSize>(max_val);
+
+  float exp_sum = 0.f;
+  for (int i = 0; i < size(regs); i++) {
+    regs(i) = __expf(regs(i) - max_val);
+    exp_sum += regs(i);
+  }
+  exp_sum = warp::reduce<constant::WarpSize>(exp_sum, [](float a, float b) { return a + b; });
+  exp_sum = warp::broadcast<constant::WarpSize>(exp_sum);
+
+  const float inv_sum = __frcp_rn(exp_sum + 1e-6f);
+  CUTE_UNROLL
+  for (int i = 0; i < size(regs); i++) {
+    logits(i) = regs(i) * inv_sum;  // if predicate is false, will be set to 0
+  }
+
+  if (max_sum != nullptr && lane_idx == 0) {
+    *max_sum = float2{max_val, exp_sum};
+  }
+}
+#endif
+
+#define BROADCAST0_BUFFER_SIZE_IN_BYTES 128
+
+template <typename T, typename Func>
+__forceinline__ __device__ T
+broadcast0(void* buffer, Func&& value_producer) {
+  if (threadIdx.x == 0) {
+    *static_cast<T*>(buffer) = value_producer();
+  }
+  __syncthreads();
+  return *static_cast<T*>(buffer);
+}
+
+template <int NumThreads, int HeadSize>
+struct FlashAccCta {
+  __forceinline__ __device__ static void
+  acc(
+      float* acc, float2* acc_max_sum,             // accumulative part
+      const float* inc, const float2* inc_max_sum  // incremental part
+  ) {
+    float prev_max = acc_max_sum->x;
+    float prev_sum = acc_max_sum->y;
+
+    float curr_max = inc_max_sum->x;
+    float curr_sum = inc_max_sum->y;
+
+    float new_max = max(prev_max, curr_max);
+
+    float prev_factor = new_max == prev_max ? 1.0f : __expf(prev_max - new_max);
+    float curr_factor = new_max == curr_max ? 1.0f : __expf(curr_max - new_max);
+
+    float new_sum = prev_factor * prev_sum + curr_factor * curr_sum;
+    float new_sum_inv = 1.0f / new_sum;
+    __syncthreads();  // ensure prev_max, prev_sum loaded
+    if (threadIdx.x == 0) {
+      *acc_max_sum = float2{new_max, new_sum};
+    }
+
+    bool load_prev_acc = prev_sum != 0.0f;
+    CUTE_UNROLL
+    for (int i = threadIdx.x; i < HeadSize; i += NumThreads) {
+      // NOTE: In flash attention paper, curr_sum is not included, because it does not apply the denominator.
+      // curr_sum cancels out the denominator for our implementation
+      float old_val = load_prev_acc ? acc[i] : 0.0f;
+      float new_val = prev_factor * (prev_sum * new_sum_inv) * old_val +
+                      curr_factor * (curr_sum * new_sum_inv) * inc[i];
+      // if (new_val != new_val) {
+      //   printf(
+      //       "acc[%d] new_val:%f new_sum:%f prev_factor:%f prev_sum:%f curr_factor:%f curr_sum:%f %f %f\n",
+      //       i, new_val, new_sum, prev_factor, prev_sum, curr_factor, curr_sum, acc[i], inc[i]
+      //   );
+      // }
+      acc[i] = new_val;
+    }
+  }
+
+  template <typename TO>
+  __forceinline__ __device__ static void
+  atomic_acc(
+      void* broadcast_buffer,
+      volatile TO* acc, float2* acc_max_sum,
+      float* inc, float2* inc_max_sum
+  ) {
+    float2 old = broadcast0<float2>(broadcast_buffer, [&]() {
+      auto acc_max_sum_ull = reinterpret_cast<unsigned long long*>(acc_max_sum);
+      constexpr uint64_t lock_bits = 0xFFFF'F000'FFF0'0000;  // float2{NaN, NaN};
+      uint64_t old, assumed = lock_bits;
+      bool locked = false;
+      do {
+        if (assumed == lock_bits) {
+          // assumed = volatile_load(gmem_max_sum_ull);
+          // __threadfence();
+          assumed = atomicAdd(acc_max_sum_ull, 0);
+          locked = false;
+          continue;
+        }
+        old = atomicCAS(acc_max_sum_ull, assumed, lock_bits);
+        locked = old == assumed;
+        if (!locked) {
+          assumed = old;
+          backoff();
+        }
+      } while (!locked);
+      union {
+        float2 f32x2;
+        uint64_t packed;
+      };
+      packed = old;
+      return f32x2;
+    });
+    __syncthreads();
+    __threadfence();
+
+    float prev_max = old.x;
+    float prev_sum = old.y;
+
+    float curr_max = inc_max_sum->x;
+    float curr_sum = inc_max_sum->y;
+
+    float new_max = max(prev_max, curr_max);
+
+    float prev_factor = new_max == prev_max ? 1.0f : __expf(prev_max - new_max);
+    float curr_factor = new_max == curr_max ? 1.0f : __expf(curr_max - new_max);
+
+    float new_sum = prev_factor * prev_sum + curr_factor * curr_sum;
+    float new_sum_inv = 1.0f / new_sum;
+
+    bool load_prev_acc = prev_sum != 0.0f;
+    CUTE_UNROLL
+    for (int i = threadIdx.x; i < HeadSize; i += NumThreads) {
+      float old_val = load_prev_acc ? type_convert<float>(volatile_load(acc + i)) : 0.0f;
+      float new_val = prev_factor * (prev_sum * new_sum_inv) * old_val +
+                      curr_factor * (curr_sum * new_sum_inv) * inc[i];
+      // if (new_val != new_val) {
+      //   printf(
+      //       "acc[%d] new_val:%f new_sum:%f prev_factor:%f prev_sum:%f curr_factor:%f curr_sum:%f %f %f\n",
+      //       i, new_val, new_sum, prev_factor, prev_sum, curr_factor, curr_sum, old_val, inc[i]
+      //   );
+      // }
+      acc[i] = type_convert<TO>(new_val);
+    }
+
+    __syncthreads();
+    __threadfence();
+    if (threadIdx.x == 0) {
+      union {
+        float2 f32x2;
+        uint64_t packed;
+      };
+      f32x2 = float2{new_max, new_sum};
+      atomicExch(reinterpret_cast<unsigned long long*>(acc_max_sum), packed);
+    }
+  }
+
+  template <typename TO>
+  __forceinline__ __device__ static void
+  write_inc(
+      TO* gmem, float2* gmem_max_sum,
+      float* inc, float2* inc_max_sum
+  ) {
+    if (gmem_max_sum != nullptr && threadIdx.x == 0) {
+      *gmem_max_sum = *inc_max_sum;
+    }
+    CUTE_UNROLL
+    for (int i = threadIdx.x; i < HeadSize; i += NumThreads) {
+      gmem[i] = type_convert<TO>(inc[i]);
+    }
+  }
+};
+
+template <int NumThreads, int HeadSize>
+struct FlashAccWarp {
+  __forceinline__ __device__ static void
+  acc(
+      float* acc, float2* acc_max_sum,             // accumulative part
+      const float* inc, const float2* inc_max_sum  // incremental part
+  ) {
+    float prev_max = acc_max_sum->x;
+    float prev_sum = acc_max_sum->y;
+
+    float curr_max = inc_max_sum->x;
+    float curr_sum = inc_max_sum->y;
+
+    float new_max = max(prev_max, curr_max);
+
+    float prev_factor = new_max == prev_max ? 1.0f : __expf(prev_max - new_max);
+    float curr_factor = new_max == curr_max ? 1.0f : __expf(curr_max - new_max);
+
+    float new_sum = prev_factor * prev_sum + curr_factor * curr_sum;
+    float new_sum_inv = 1.0f / new_sum;
+    if (lane_id() == 0) {
+      *acc_max_sum = float2{new_max, new_sum};
+    }
+
+    bool load_prev_acc = prev_sum != 0.0f;
+    CUTE_UNROLL
+    for (int i = lane_id(); i < HeadSize; i += constant::WarpSize) {
+      // NOTE: In flash attention paper, curr_sum is not included, because it does not apply the denominator.
+      // curr_sum cancels out the denominator for our implementation
+      float old_val = load_prev_acc ? acc[i] : 0.0f;
+      float new_val = prev_factor * (prev_sum * new_sum_inv) * old_val +
+                      curr_factor * (curr_sum * new_sum_inv) * inc[i];
+      // if (new_val != new_val) {
+      //   printf(
+      //       "acc[%d] new_val:%f new_sum:%f prev_factor:%f prev_sum:%f curr_factor:%f curr_sum:%f %f %f\n",
+      //       i, new_val, new_sum, prev_factor, prev_sum, curr_factor, curr_sum, acc[i], inc[i]
+      //   );
+      // }
+      acc[i] = new_val;
+    }
+  }
+
+  template <typename TO>
+  __forceinline__ __device__ static void
+  write_inc(
+      TO* gmem, float2* gmem_max_sum,
+      float* inc, float2* inc_max_sum
+  ) {
+    if (gmem_max_sum != nullptr && lane_id() == 0) {
+      *gmem_max_sum = *inc_max_sum;
+    }
+    CUTE_UNROLL
+    for (int i = lane_id(); i < HeadSize; i += constant::WarpSize) {
+      gmem[i] = type_convert<TO>(inc[i]);
+    }
+  }
+};
 
 }  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/copy_pages_fp8.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/copy_pages_fp8.cuh
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "cute/config.hpp"
+#include "cute/numeric/numeric_types.hpp"
+#include "cute/int_tuple.hpp"
+
+#include "contrib_ops/cuda/bert/paged/cuda_common.cuh"
+
+namespace onnxruntime::contrib::paged {
+
+using namespace cute;
+
+__global__ void copy_pages_fp8_kernel(
+    int64_t* k_cache_ptrs,
+    int64_t* v_cache_ptrs,
+    int64_t* kv_scalebias_ptrs,
+    const int64_t* __restrict__ page_mapping,
+    const int num_k_elems_per_page,
+    const int num_v_elems_per_page,
+    const int num_sb_elems_per_page
+) {
+  const int layer_idx = blockIdx.x;
+  const int pair_idx = blockIdx.y;
+
+  float_e4m3_t* k_cache = reinterpret_cast<float_e4m3_t*>(k_cache_ptrs[layer_idx]);
+  float_e4m3_t* v_cache = reinterpret_cast<float_e4m3_t*>(v_cache_ptrs[layer_idx]);
+  half* kv_scalebias = reinterpret_cast<half*>(kv_scalebias_ptrs[layer_idx]);
+
+  const int64_t src_page_id = page_mapping[2 * pair_idx];
+  const int64_t dst_page_id = page_mapping[2 * pair_idx + 1];
+
+  for (int i = threadIdx.x; i < num_k_elems_per_page; i += blockDim.x) {
+    int64_t src_offset = src_page_id * num_k_elems_per_page + i;
+    int64_t dst_offset = dst_page_id * num_k_elems_per_page + i;
+    k_cache[dst_offset] = k_cache[src_offset];
+  }
+  for (int i = threadIdx.x; i < num_v_elems_per_page; i += blockDim.x) {
+    int64_t src_offset = src_page_id * num_v_elems_per_page + i;
+    int64_t dst_offset = dst_page_id * num_v_elems_per_page + i;
+    v_cache[dst_offset] = v_cache[src_offset];
+  }
+
+  for (int i = threadIdx.x; i < num_sb_elems_per_page; i += blockDim.x) {
+    int64_t src_offset = src_page_id * num_sb_elems_per_page + i;
+    int64_t dst_offset = dst_page_id * num_sb_elems_per_page + i;
+    kv_scalebias[dst_offset] = kv_scalebias[src_offset];
+  }
+}
+
+void launch_copy_pages_fp8_kernel(
+    stream_t stream,
+    int64_t* k_cache_ptrs,                     // [num_layers] of ptrs, each ptr points to num_k_elems_per_page  of fp8
+    int64_t* v_cache_ptrs,                     // [num_layers] of ptrs, each ptr points to num_v_elems_per_page  of fp8
+    int64_t* kv_scalebias_ptrs,                // [num_layers] of ptrs, each ptr points to num_sb_elems_per_page of half (k_scale, k_bias, v_scale, v_bias)
+    const int64_t* __restrict__ page_mapping,  // [num_pairs, 2], aka, num_pairs of (src, dst)
+    const int num_layers,
+    const int num_pairs,
+    const int num_heads,
+    const int head_size,
+    const int page_size
+) {
+  constexpr int x = 16 / sizeof(float_e4m3_t);
+  constexpr int ChunkSize = 32;
+  const int num_k_elems_per_page = num_heads * (head_size / x) * page_size * x;
+  const int num_v_elems_per_page = num_heads * head_size * page_size;
+  const int num_sb_elems_per_page = 4 * num_heads * ceil_div(head_size, ChunkSize) * page_size;
+
+  dim3 grid(num_layers, num_pairs);
+  dim3 block(std::min(1024, num_v_elems_per_page));
+  copy_pages_fp8_kernel<<<grid, block, 0, stream>>>(
+      k_cache_ptrs,
+      v_cache_ptrs,
+      kv_scalebias_ptrs,
+      page_mapping,
+      num_k_elems_per_page,
+      num_v_elems_per_page,
+      num_sb_elems_per_page
+  );
+}
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention.cu
@@ -1,0 +1,548 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// #include "contrib_ops/cuda/bert/paged/paged_attention/lbp_attention.h"
+
+#include "contrib_ops/cuda/bert/paged/cuda_common.cuh"
+#include "contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_dp.cuh"
+#include "contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_ws.cuh"
+
+namespace onnxruntime::contrib::paged {
+
+struct DataParallelOutOfPlace {};
+struct DataParallelInPlace {};
+struct WorkStealing {};
+
+namespace detail {
+
+template <typename Sch>
+struct IsGroupQuerySupported {
+  static constexpr bool value = false;
+};
+
+template <>
+struct IsGroupQuerySupported<DataParallelOutOfPlace> {
+  static constexpr bool value = true;
+};
+
+template <>
+struct IsGroupQuerySupported<DataParallelInPlace> {
+  static constexpr bool value = true;
+};
+
+template <typename Sch>
+inline constexpr bool is_group_query_supported_v = IsGroupQuerySupported<Sch>::value;
+
+template <typename TIO, typename TKV, typename TSB, typename Sch, int NumQueriesPerCta>
+struct LBPAttentionKernel {
+  static void launch(
+      stream_t stream,
+      int num_processors,
+      void* workspace,
+      TIO* out_ptr,
+      const TIO* q_ptr,
+      const TKV* k_cache_ptr,
+      const TKV* v_cache_ptr,
+      const int* page_table_ptr,
+      const int* context_lens_ptr,
+      const float* alibi_slopes_ptr,
+      const float scale,
+      const int num_seqs,
+      const int num_heads,
+      const int num_kv_heads,
+      const int head_size,
+      const int page_size,
+      const int max_num_pages_per_seq,
+      const int q_stride,
+      const int max_context_len
+  );
+
+  static void create_workspace(stream_t stream, void** workspace, size_t* size, int num_seqs, int num_heads, int head_size, int max_context_len);
+  static void destroy_workspace(stream_t stream, void* workspace);
+  static void init_workspace(stream_t stream, void* workspace, int num_seqs, int num_heads, int head_size, int max_context_len);
+};
+
+template <typename TIO, typename TKV, typename TSB, int NumQueriesPerCta>
+struct LBPAttentionKernel<TIO, TKV, TSB, WorkStealing, NumQueriesPerCta> {
+  static void launch(
+      stream_t stream,
+      int num_processors,
+      void* workspace,
+      TIO* out_ptr,
+      const TIO* q_ptr,
+      const TKV* k_cache_ptr,
+      const TKV* v_cache_ptr,
+      const TSB* scalebias_ptr,
+      const int* page_table_ptr,
+      const int* context_lens_ptr,
+      const float* alibi_slopes_ptr,
+      const float scale,
+      const int num_seqs,
+      const int num_heads,
+      const int num_kv_heads,
+      const int head_size,
+      const int page_size,
+      const int max_num_pages_per_seq,
+      const int q_stride,
+      const int max_context_len
+  ) {
+    constexpr int NumThreads = 128;
+    constexpr int NumCtaPerProcessor = 2;
+    dim3 grid(NumCtaPerProcessor * num_processors);
+    dim3 block(NumThreads);
+#define LAUNCH_LBP_ATTENTION_WORK_STEALING_KERNEL_AND_BREAK(HEAD_SIZE, PAGE_SIZE)     \
+  lbp_attention_work_stealing_kernel<NumThreads, HEAD_SIZE, PAGE_SIZE, TIO, TKV, TSB> \
+      <<<grid, block, 0, stream>>>(                                                   \
+          workspace,                                                                  \
+          out_ptr,                                                                    \
+          q_ptr,                                                                      \
+          k_cache_ptr,                                                                \
+          v_cache_ptr,                                                                \
+          scalebias_ptr,                                                              \
+          page_table_ptr,                                                             \
+          context_lens_ptr,                                                           \
+          alibi_slopes_ptr,                                                           \
+          scale,                                                                      \
+          num_seqs,                                                                   \
+          num_heads,                                                                  \
+          num_kv_heads,                                                               \
+          max_num_pages_per_seq,                                                      \
+          q_stride                                                                    \
+      );                                                                              \
+  break;
+
+    // TODO: zero-ing out workspace
+
+    do {
+      if (page_size == 32) {
+        if (head_size == 64) {
+          LAUNCH_LBP_ATTENTION_WORK_STEALING_KERNEL_AND_BREAK(64, 32);
+        } else if (head_size == 80) {
+          LAUNCH_LBP_ATTENTION_WORK_STEALING_KERNEL_AND_BREAK(80, 32);
+        } else if (head_size == 96) {
+          LAUNCH_LBP_ATTENTION_WORK_STEALING_KERNEL_AND_BREAK(96, 32);
+        } else if (head_size == 112) {
+          LAUNCH_LBP_ATTENTION_WORK_STEALING_KERNEL_AND_BREAK(112, 32);
+        } else if (head_size == 128) {
+          LAUNCH_LBP_ATTENTION_WORK_STEALING_KERNEL_AND_BREAK(128, 32);
+        } else if (head_size == 256) {
+          LAUNCH_LBP_ATTENTION_WORK_STEALING_KERNEL_AND_BREAK(256, 32);
+        } else {
+          throw std::runtime_error(std::string("Unsupported head size: ") + std::to_string(head_size));
+        }
+      } else if (page_size == 16) {
+        if (head_size == 64) {
+          LAUNCH_LBP_ATTENTION_WORK_STEALING_KERNEL_AND_BREAK(64, 16);
+        } else if (head_size == 80) {
+          LAUNCH_LBP_ATTENTION_WORK_STEALING_KERNEL_AND_BREAK(80, 16);
+        } else if (head_size == 96) {
+          LAUNCH_LBP_ATTENTION_WORK_STEALING_KERNEL_AND_BREAK(96, 16);
+        } else if (head_size == 112) {
+          LAUNCH_LBP_ATTENTION_WORK_STEALING_KERNEL_AND_BREAK(112, 16);
+        } else if (head_size == 128) {
+          LAUNCH_LBP_ATTENTION_WORK_STEALING_KERNEL_AND_BREAK(128, 16);
+        } else if (head_size == 256) {
+          LAUNCH_LBP_ATTENTION_WORK_STEALING_KERNEL_AND_BREAK(256, 16);
+        } else {
+          throw std::runtime_error(std::string("Unsupported head size: ") + std::to_string(head_size));
+        }
+      } else if (page_size == 8) {
+        if (head_size == 64) {
+          LAUNCH_LBP_ATTENTION_WORK_STEALING_KERNEL_AND_BREAK(64, 8);
+        } else if (head_size == 80) {
+          LAUNCH_LBP_ATTENTION_WORK_STEALING_KERNEL_AND_BREAK(80, 8);
+        } else if (head_size == 96) {
+          LAUNCH_LBP_ATTENTION_WORK_STEALING_KERNEL_AND_BREAK(96, 8);
+        } else if (head_size == 112) {
+          LAUNCH_LBP_ATTENTION_WORK_STEALING_KERNEL_AND_BREAK(112, 8);
+        } else if (head_size == 128) {
+          LAUNCH_LBP_ATTENTION_WORK_STEALING_KERNEL_AND_BREAK(128, 8);
+        } else if (head_size == 256) {
+          LAUNCH_LBP_ATTENTION_WORK_STEALING_KERNEL_AND_BREAK(256, 8);
+        } else {
+          throw std::runtime_error(std::string("Unsupported head size: ") + std::to_string(head_size));
+        }
+      } else {
+        throw std::runtime_error(std::string("Unsupported page size: ") + std::to_string(page_size));
+      }
+    } while (0);
+  }
+
+  static void create_workspace(stream_t stream, void** workspace, size_t* size, int num_seqs, int num_heads, int head_size, int max_context_len) {
+    // TODO: workspace logic leaked, move to ws header
+    size_t total_bytes = sizeof(WorkStealingWorkspace);
+    if (size != nullptr) {
+      *size = total_bytes;
+    }
+    if (workspace != nullptr) {
+      CUDA_CHECK(cudaMallocAsync(workspace, total_bytes, stream));
+    }
+  }
+
+  static void destroy_workspace(stream_t stream, void* workspace) {
+    CUDA_CHECK(cudaFreeAsync(workspace, stream));
+  }
+
+  static void init_workspace(stream_t stream, void* workspace, int num_seqs, int num_heads, int head_size, int max_context_len) {
+    auto* ws = reinterpret_cast<WorkStealingWorkspace*>(workspace);
+    size_t size_in_bytes = reinterpret_cast<char*>(&ws->max_sum_) - reinterpret_cast<char*>(ws);
+    CUDA_CHECK(cudaMemsetAsync(workspace, 0, size_in_bytes, stream));
+  }
+};
+
+template <typename TIO, typename TKV, typename TSB, int NumQueriesPerCta>
+struct LBPAttentionKernel<TIO, TKV, TSB, DataParallelOutOfPlace, NumQueriesPerCta> {
+  using Config = DataParallelConfig<false, false, NumQueriesPerCta>;
+  using Workspace = DataParallelWorkspace<Config>;
+
+  static void launch(
+      stream_t stream,
+      int num_processors,
+      void* workspace,
+      TIO* out_ptr,
+      const TIO* q_ptr,
+      const TKV* k_cache_ptr,
+      const TKV* v_cache_ptr,
+      const TSB* scalebias_ptr,
+      const int* page_table_ptr,
+      const int* context_lens_ptr,
+      const float* alibi_slopes_ptr,
+      const float scale,
+      const int num_seqs,
+      const int num_heads,
+      const int num_kv_heads,
+      const int head_size,
+      const int page_size,
+      const int max_num_pages_per_seq,
+      const int q_stride,
+      const int max_context_len
+  ) {
+    constexpr int NumThreads = 128;
+
+    const int num_queries_per_kv = num_heads / num_kv_heads;
+    if (num_queries_per_kv % NumQueriesPerCta != 0) {
+      throw std::runtime_error(
+          std::string("Unsupported NumQueriesPerCta ") + std::to_string(NumQueriesPerCta) +
+          " for num_queries_per_kv " + std::to_string(num_queries_per_kv)
+      );
+    }
+
+    int max_task_chunks = ceil_div(max_context_len, Config::TaskChunkSeqLen);
+    dim3 grid((num_heads / NumQueriesPerCta) * num_seqs, max_task_chunks);
+    dim3 block(NumThreads);
+#define LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(HEAD_SIZE, PAGE_SIZE)             \
+  lbp_attention_data_parallel_kernel<NumThreads, HEAD_SIZE, PAGE_SIZE, TIO, TKV, TSB, Config> \
+      <<<grid, block, 0, stream>>>(                                                           \
+          workspace,                                                                          \
+          out_ptr,                                                                            \
+          q_ptr,                                                                              \
+          k_cache_ptr,                                                                        \
+          v_cache_ptr,                                                                        \
+          scalebias_ptr,                                                                      \
+          page_table_ptr,                                                                     \
+          context_lens_ptr,                                                                   \
+          alibi_slopes_ptr,                                                                   \
+          scale,                                                                              \
+          num_seqs,                                                                           \
+          num_heads,                                                                          \
+          num_kv_heads,                                                                       \
+          max_num_pages_per_seq,                                                              \
+          q_stride,                                                                           \
+          max_context_len                                                                     \
+      );                                                                                      \
+  lbp_attention_reduction_kernel<NumThreads, HEAD_SIZE, PAGE_SIZE, TIO, TKV, Config>          \
+      <<<num_heads * num_seqs, block, 0, stream>>>(                                           \
+          workspace,                                                                          \
+          out_ptr,                                                                            \
+          context_lens_ptr,                                                                   \
+          num_seqs,                                                                           \
+          num_heads,                                                                          \
+          max_context_len                                                                     \
+      );                                                                                      \
+  break;
+
+    do {
+      if (page_size == 32) {
+        if (head_size == 64) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(64, 32);
+        } else if (head_size == 80) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(80, 32);
+        } else if (head_size == 96) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(96, 32);
+        } else if (head_size == 112) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(112, 32);
+        } else if (head_size == 128) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(128, 32);
+        } else if (head_size == 256) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(256, 32);
+        } else {
+          throw std::runtime_error(std::string("Unsupported head size: ") + std::to_string(head_size));
+        }
+      } else if (page_size == 16) {
+        if (head_size == 64) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(64, 16);
+        } else if (head_size == 80) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(80, 16);
+        } else if (head_size == 96) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(96, 16);
+        } else if (head_size == 112) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(112, 16);
+        } else if (head_size == 128) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(128, 16);
+        } else if (head_size == 256) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(256, 16);
+        } else {
+          throw std::runtime_error(std::string("Unsupported head size: ") + std::to_string(head_size));
+        }
+      } else if (page_size == 8) {
+        if (head_size == 64) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(64, 8);
+        } else if (head_size == 80) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(80, 8);
+        } else if (head_size == 96) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(96, 8);
+        } else if (head_size == 112) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(112, 8);
+        } else if (head_size == 128) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(128, 8);
+        } else if (head_size == 256) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(256, 8);
+        } else {
+          throw std::runtime_error(std::string("Unsupported head size: ") + std::to_string(head_size));
+        }
+      } else {
+        throw std::runtime_error(std::string("Unsupported page size: ") + std::to_string(page_size));
+      }
+    } while (0);
+#undef LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK
+  }
+
+  static void create_workspace(stream_t stream, void** workspace, size_t* size, int num_seqs, int num_heads, int head_size, int max_context_len) {
+    DataParallelWorkspace<Config>::create(stream, workspace, size, num_seqs, num_heads, head_size, max_context_len);
+  }
+
+  static void destroy_workspace(stream_t stream, void* workspace) {
+    DataParallelWorkspace<Config>::destroy(stream, workspace);
+  }
+
+  static void init_workspace(stream_t stream, void* workspace, int num_seqs, int num_heads, int head_size, int max_context_len) {
+    DataParallelWorkspace<Config>::init(stream, workspace, num_seqs, num_heads, head_size, max_context_len);
+  }
+};
+
+template <typename TIO, typename TKV, typename TSB, int NumQueriesPerCta>
+struct LBPAttentionKernel<TIO, TKV, TSB, DataParallelInPlace, NumQueriesPerCta> {
+  using Config = DataParallelConfig<true, true>;
+  using Workspace = DataParallelWorkspace<Config>;
+
+  static void launch(
+      stream_t stream,
+      int num_processors,
+      void* workspace,
+      TIO* out_ptr,
+      const TIO* q_ptr,
+      const TKV* k_cache_ptr,
+      const TKV* v_cache_ptr,
+      const TSB* scalebias_ptr,
+      const int* page_table_ptr,
+      const int* context_lens_ptr,
+      const float* alibi_slopes_ptr,
+      const float scale,
+      const int num_seqs,
+      const int num_heads,
+      const int num_kv_heads,
+      const int head_size,
+      const int page_size,
+      const int max_num_pages_per_seq,
+      const int q_stride,
+      const int max_context_len
+  ) {
+    constexpr int NumThreads = 128;
+    int max_task_chunks = ceil_div(max_context_len, Config::TaskChunkSeqLen);
+
+    const int num_queries_per_kv = num_heads / num_kv_heads;
+    if (num_queries_per_kv % NumQueriesPerCta != 0) {
+      throw std::runtime_error(
+          std::string("Unsupported NumQueriesPerCta ") + std::to_string(NumQueriesPerCta) +
+          " for num_queries_per_kv " + std::to_string(num_queries_per_kv)
+      );
+    }
+
+    dim3 grid((num_heads / NumQueriesPerCta) * num_seqs, max_task_chunks);
+    dim3 block(NumThreads);
+#define LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(HEAD_SIZE, PAGE_SIZE)             \
+  lbp_attention_data_parallel_kernel<NumThreads, HEAD_SIZE, PAGE_SIZE, TIO, TKV, TSB, Config> \
+      <<<grid, block, 0, stream>>>(                                                           \
+          workspace,                                                                          \
+          out_ptr,                                                                            \
+          q_ptr,                                                                              \
+          k_cache_ptr,                                                                        \
+          v_cache_ptr,                                                                        \
+          scalebias_ptr,                                                                      \
+          page_table_ptr,                                                                     \
+          context_lens_ptr,                                                                   \
+          alibi_slopes_ptr,                                                                   \
+          scale,                                                                              \
+          num_seqs,                                                                           \
+          num_heads,                                                                          \
+          num_kv_heads,                                                                       \
+          max_num_pages_per_seq,                                                              \
+          q_stride,                                                                           \
+          max_context_len                                                                     \
+      );                                                                                      \
+  break;
+
+    do {
+      if (page_size == 32) {
+        if (head_size == 64) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(64, 32);
+        } else if (head_size == 80) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(80, 32);
+        } else if (head_size == 96) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(96, 32);
+        } else if (head_size == 112) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(112, 32);
+        } else if (head_size == 128) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(128, 32);
+        } else if (head_size == 256) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(256, 32);
+        } else {
+          throw std::runtime_error(std::string("Unsupported head size: ") + std::to_string(head_size));
+        }
+      } else if (page_size == 16) {
+        if (head_size == 64) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(64, 16);
+        } else if (head_size == 80) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(80, 16);
+        } else if (head_size == 96) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(96, 16);
+        } else if (head_size == 112) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(112, 16);
+        } else if (head_size == 128) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(128, 16);
+        } else if (head_size == 256) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(256, 16);
+        } else {
+          throw std::runtime_error(std::string("Unsupported head size: ") + std::to_string(head_size));
+        }
+      } else if (page_size == 8) {
+        if (head_size == 64) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(64, 8);
+        } else if (head_size == 80) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(80, 8);
+        } else if (head_size == 96) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(96, 8);
+        } else if (head_size == 112) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(112, 8);
+        } else if (head_size == 128) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(128, 8);
+        } else if (head_size == 256) {
+          LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK(256, 8);
+        } else {
+          throw std::runtime_error(std::string("Unsupported head size: ") + std::to_string(head_size));
+        }
+      } else {
+        throw std::runtime_error(std::string("Unsupported page size: ") + std::to_string(page_size));
+      }
+    } while (0);
+#undef LAUNCH_LBP_ATTENTION_DATA_PARALLEL_KERNEL_AND_BREAK
+  }
+
+  static void create_workspace(stream_t stream, void** workspace, size_t* size, int num_seqs, int num_heads, int head_size, int max_context_len) {
+    DataParallelWorkspace<Config>::create(stream, workspace, size, num_seqs, num_heads, head_size, max_context_len);
+  }
+
+  static void destroy_workspace(stream_t stream, void* workspace) {
+    DataParallelWorkspace<Config>::destroy(stream, workspace);
+  }
+
+  static void init_workspace(stream_t stream, void* workspace, int num_seqs, int num_heads, int head_size, int max_context_len) {
+    DataParallelWorkspace<Config>::init(stream, workspace, num_seqs, num_heads, head_size, max_context_len);
+  }
+};
+
+}  // namespace detail
+
+template <typename TIO, typename TKV, typename TSB, typename Sch>
+struct LBPAttentionKernel {
+  using LBPAttentionKernelImpl = detail::LBPAttentionKernel<TIO, TKV, TSB, Sch, 1>;
+  using LBPAttentionKernelImpl4 = std::conditional_t<
+      detail::is_group_query_supported_v<Sch>,
+      detail::LBPAttentionKernel<TIO, TKV, TSB, Sch, 4>,
+      detail::LBPAttentionKernel<TIO, TKV, TSB, Sch, 1>>;  // otherwise, we fallback to non-gqa optimized version
+
+  inline static void launch(
+      stream_t stream,
+      int num_processors,
+      void* workspace,
+      TIO* out_ptr,
+      const TIO* q_ptr,
+      const TKV* k_cache_ptr,
+      const TKV* v_cache_ptr,
+      const TSB* scalebias_ptr,
+      const int* page_table_ptr,
+      const int* context_lens_ptr,
+      const float* alibi_slopes_ptr,
+      const float scale,
+      const int num_seqs,
+      const int num_heads,
+      const int num_kv_heads,
+      const int head_size,
+      const int page_size,
+      const int max_num_pages_per_seq,
+      const int q_stride,
+      const int max_context_len
+  ) {
+    if ((num_heads / num_kv_heads) % 4 == 0) {
+      return LBPAttentionKernelImpl4::launch(
+          stream, num_processors, workspace,
+          out_ptr, q_ptr, k_cache_ptr, v_cache_ptr, scalebias_ptr, page_table_ptr, context_lens_ptr, alibi_slopes_ptr, scale,
+          num_seqs, num_heads, num_kv_heads, head_size, page_size, max_num_pages_per_seq, q_stride, max_context_len
+      );
+    } else {
+      return LBPAttentionKernelImpl::launch(
+          stream, num_processors, workspace,
+          out_ptr, q_ptr, k_cache_ptr, v_cache_ptr, scalebias_ptr, page_table_ptr, context_lens_ptr, alibi_slopes_ptr, scale,
+          num_seqs, num_heads, num_kv_heads, head_size, page_size, max_num_pages_per_seq, q_stride, max_context_len
+      );
+    }
+  }
+
+  inline static void create_workspace(stream_t stream, void** workspace, size_t* size, int num_seqs, int num_heads, int num_kv_heads, int head_size, int max_context_len) {
+    if ((num_heads / num_kv_heads) % 4 == 0) {
+      return LBPAttentionKernelImpl4::create_workspace(stream, workspace, size, num_seqs, num_heads, head_size, max_context_len);
+    } else {
+      return LBPAttentionKernelImpl::create_workspace(stream, workspace, size, num_seqs, num_heads, head_size, max_context_len);
+    }
+  }
+
+  inline static void destroy_workspace(stream_t stream, void* workspace, int num_seqs, int num_heads, int num_kv_heads, int head_size, int max_context_len) {
+    if ((num_heads / num_kv_heads) % 4 == 0) {
+      return LBPAttentionKernelImpl4::destroy_workspace(stream, workspace);
+    } else {
+      return LBPAttentionKernelImpl::destroy_workspace(stream, workspace);
+    }
+  }
+
+  inline static void init_workspace(stream_t stream, void* workspace, int num_seqs, int num_heads, int num_kv_heads, int head_size, int max_context_len) {
+    if ((num_heads / num_kv_heads) % 4 == 0) {
+      return LBPAttentionKernelImpl4::init_workspace(stream, workspace, num_seqs, num_heads, head_size, max_context_len);
+    } else {
+      return LBPAttentionKernelImpl::init_workspace(stream, workspace, num_seqs, num_heads, head_size, max_context_len);
+    }
+  }
+};
+
+// template class LBPAttentionKernel<float, float, void, DataParallelOutOfPlace>;
+template class LBPAttentionKernel<half, half, void, DataParallelOutOfPlace>;
+template class LBPAttentionKernel<half, cute::float_e4m3_t, half, DataParallelOutOfPlace>;
+
+// template class LBPAttentionKernel<float, float, void, DataParallelInPlace>;
+template class LBPAttentionKernel<half, half, void, DataParallelInPlace>;
+template class LBPAttentionKernel<half, cute::float_e4m3_t, half, DataParallelInPlace>;
+
+// template class LBPAttentionKernel<float, float, void, WorkStealing>;
+template class LBPAttentionKernel<half, half, void, WorkStealing>;
+template class LBPAttentionKernel<half, cute::float_e4m3_t, half, WorkStealing>;
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention.h
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention.h
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "contrib_ops/cuda/bert/paged/cuda_common.h"
+
+namespace onnxruntime::contrib::paged {
+
+struct DataParallelOutOfPlace {};
+struct DataParallelInPlace {};
+struct WorkStealing {};
+
+template <typename TIO, typename TKV, typename TSB, typename Sch>
+struct LBPAttentionKernel {
+  static void launch(
+      stream_t stream,
+      int num_processors,
+      void* workspace,
+      TIO* out_ptr,
+      const TIO* q_ptr,
+      const TKV* k_cache_ptr,
+      const TKV* v_cache_ptr,
+      const TSB* scalebias_ptr,
+      const int* page_table_ptr,
+      const int* context_lens_ptr,
+      const float* alibi_slopes_ptr,
+      const float scale,
+      const int num_seqs,
+      const int num_heads,
+      const int num_kv_heads,
+      const int head_size,
+      const int page_size,
+      const int max_num_pages_per_seq,
+      const int q_stride,
+      const int max_context_len
+  );
+
+  static void create_workspace(stream_t stream, void** workspace, size_t* size, int num_seqs, int num_heads, int num_kv_heads, int head_size, int max_context_len);
+  static void destroy_workspace(stream_t stream, void* workspace, int num_seqs, int num_heads, int num_kv_heads, int head_size, int max_context_len);
+  static void init_workspace(stream_t stream, void* workspace, int num_seqs, int num_heads, int num_kv_heads, int head_size, int max_context_len);
+};
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention.h
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention.h
@@ -15,7 +15,7 @@ template <typename TIO, typename TKV, typename TSB, typename Sch>
 struct LBPAttentionKernel {
   static void launch(
       stream_t stream,
-      int num_processors,
+      dev_props_ptr dev_props,
       void* workspace,
       TIO* out_ptr,
       const TIO* q_ptr,

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_dp.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_dp.cuh
@@ -1,0 +1,344 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cstdint>
+
+#include "contrib_ops/cuda/bert/paged/atomics.cuh"
+#include "contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_task.cuh"
+#include "contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_gqa_task.cuh"
+
+namespace onnxruntime::contrib::paged {
+
+template <bool InplaceFlashAcc, bool UseHeadSeq, int NumQueriesPerCta = 1>
+struct DataParallelConfig : public TaskConfig<256, InplaceFlashAcc, UseHeadSeq, true, NumQueriesPerCta> {
+  inline static constexpr int MaxNumSeqs = 1024;
+  inline static constexpr int MaxNumHeads = 256;
+};
+
+struct DataParallelWorker : public IWorker<DataParallelWorker> {
+  bool has_work = true;
+
+  __forceinline__ __device__ void
+  take_work(int& chunk_start, int& chunk_end) {
+    if (has_work) {
+      has_work = false;
+      chunk_start = blockIdx.y;
+      chunk_end = blockIdx.y + 1;
+    }
+  }
+
+  __forceinline__ __device__ void broadcast_work(void*, int&, int&) { /* do nothing */ };
+};
+
+template <typename Config>
+struct DataParallelWorkspace;
+
+template <int NumQueriesPerCta>
+struct DataParallelWorkspace<DataParallelConfig<true, true, NumQueriesPerCta>> {
+  using Config = DataParallelConfig<true, true, NumQueriesPerCta>;
+  float2 max_sum_[Config::MaxNumSeqs * Config::MaxNumHeads];
+
+  static void
+  create(stream_t stream, void** workspace, size_t* size, int /*num_seqs*/, int /*num_heads*/, int /*head_size*/, int /*max_context_len*/) {
+    size_t total_bytes = sizeof(DataParallelWorkspace);
+    if (size != nullptr) {
+      *size = total_bytes;
+    }
+    if (workspace != nullptr) {
+      CUDA_CHECK(cudaMallocAsync(workspace, total_bytes, stream));
+    }
+  }
+
+  static void
+  init(stream_t stream, void* workspace, int /*num_seqs*/, int /*num_heads*/, int /*head_size*/, int /*max_context_len*/) {
+    CUDA_CHECK(cudaMemsetAsync(workspace, 0, sizeof(DataParallelWorkspace), stream));
+  }
+
+  static void
+  destroy(stream_t stream, void* workspace) {
+    CUDA_CHECK(cudaFreeAsync(workspace, stream));
+  }
+
+  __forceinline__ __device__ static auto
+  max_sum(void* workspace, int /*num_seqs*/, int /*num_heads*/, int /*max_context_len*/) {
+    static_assert(Config::UseHeadSeq);
+    return make_tensor(
+        make_gmem_ptr<float2>(workspace),
+        Layout<
+            Shape<_1, Int<Config::MaxNumSeqs>, Int<Config::MaxNumHeads>>,
+            Stride<_0, _1, Int<Config::MaxNumSeqs>>>{}
+    );
+  }
+};
+
+template <int NumQueriesPerCta>
+struct DataParallelWorkspace<DataParallelConfig<false, false, NumQueriesPerCta>> {
+  using Config = DataParallelConfig<false, false, NumQueriesPerCta>;
+
+  static void create(stream_t stream, void** workspace, size_t* size, int num_seqs, int num_heads, int head_size, int max_context_len) {
+    int num_task_chunks = ceil_div(max_context_len, Config::TaskChunkSeqLen);
+    size_t maxsum_bytes = ceil_div(num_task_chunks * num_seqs * num_heads * sizeof(float2), 256) * 256;
+    size_t out_bytes = num_task_chunks * num_seqs * num_heads * head_size * sizeof(float);
+    size_t total_bytes = maxsum_bytes + out_bytes;
+    if (size != nullptr) {
+      *size = total_bytes;
+    }
+    if (workspace != nullptr) {
+      CUDA_CHECK(cudaMallocAsync(workspace, total_bytes, stream));
+    }
+  }
+
+  static void
+  init(stream_t stream, void* workspace, int num_seqs, int num_heads, int head_size, int max_context_len) {
+    // do nothing
+  }
+
+  static void
+  destroy(stream_t stream, void* workspace) {
+    CUDA_CHECK(cudaFreeAsync(workspace, stream));
+  }
+
+  __forceinline__ __device__ static auto
+  max_sum(void* workspace, int num_seqs, int num_heads, int max_context_len) {
+    static_assert(!Config::UseHeadSeq);
+    constexpr int TaskChunkSeqLen = Config::TaskChunkSeqLen;
+    int num_task_chunks = ceil_div(max_context_len, TaskChunkSeqLen);
+    return make_tensor(
+        make_gmem_ptr<float2>(workspace),
+        make_layout(make_shape(num_task_chunks, num_seqs, num_heads), LayoutRight{})
+    );
+  }
+
+  __forceinline__ __device__ static auto
+  out(void* workspace, int num_seqs, int num_heads, int head_size, int max_context_len) {
+    constexpr int TaskChunkSeqLen = Config::TaskChunkSeqLen;
+    int num_task_chunks = ceil_div(max_context_len, TaskChunkSeqLen);
+    size_t maxsum_bytes = ceil_div(num_task_chunks * num_seqs * num_heads * sizeof(float2), 256) * 256;
+    auto* out_base = reinterpret_cast<float*>(static_cast<char*>(workspace) + maxsum_bytes);
+    return make_tensor(
+        make_gmem_ptr<float>(out_base),
+        make_layout(make_shape(num_task_chunks, num_seqs, num_heads, head_size), LayoutRight{})
+    );
+  }
+};
+
+template <int NumThreads, int HeadSize, int PageSize, typename TIO, typename TKV, typename TSB, typename Config>
+__global__ void
+__launch_bounds__(NumThreads, NumThreads / constant::WarpSize) lbp_attention_data_parallel_kernel(
+    void* __restrict__ workspace,
+    TIO* __restrict__ out,                   // [num_seqs, num_heads, head_size]
+    const TIO* __restrict__ q,               // [num_seqs, num_heads, head_size]
+    const TKV* __restrict__ k_cache,         // [num_pages, num_kv_heads, head_size/x, page_size, x]
+    const TKV* __restrict__ v_cache,         // [num_pages, num_kv_heads, head_size, page_size]
+    const TSB* __restrict__ scalebias,       // [num_pages, 2, num_kv_heads, 2, head_size/chunk_size, page_size]
+    const int* __restrict__ page_table,      // [num_seqs, max_num_pages_per_seq]
+    const int* __restrict__ context_lens,    // [num_seqs]
+    const float* __restrict__ alibi_slopes,  // [num_heads]
+    const float scale,
+    const int num_seqs,
+    const int num_heads,
+    const int num_kv_heads,
+    const int max_num_pages_per_seq,
+    const int q_stride,
+    const int max_context_len
+)
+#if !defined(PAGED_SPLIT_COMPILATION) || defined(PAGED_ATTENTION_KERNEL_IMPL)
+{
+  __shared__ char broadcast_buffer[BROADCAST0_BUFFER_SIZE_IN_BYTES];
+
+  int seq_head_idx = blockIdx.x;
+  int task_chunk_start = blockIdx.y;
+  int num_queries_per_kv = num_heads / num_kv_heads;
+
+  int seq_idx = seq_head_idx / (num_heads / Config::NumQueriesPerCta);
+  int head_idx = (seq_head_idx % (num_heads / Config::NumQueriesPerCta)) * Config::NumQueriesPerCta;
+  int kv_head_idx = head_idx / num_queries_per_kv;
+
+  // NOTE: nvcc bug?
+  //  error: identifier "onnxruntime::contrib::paged::TaskConfig<(int)512> ::TaskChunkSeqLen" is undefined in device code
+  constexpr int TaskChunkSeqLen = Config::TaskChunkSeqLen;
+  if (task_chunk_start >= ceil_div(context_lens[seq_idx], TaskChunkSeqLen)) {
+    return;
+  }
+
+  using TI = TIO;
+  using TO = std::conditional_t<Config::InplaceFlashAcc, TIO, float>;
+  using Task = std::conditional_t<
+      Config::NumQueriesPerCta == 1,
+      PagedAttentionTask<NumThreads, HeadSize, PageSize, TI, TO, TKV, DataParallelWorker, Config, KVConfig<TSB>>,
+      PagedGroupQueryAttentionTask<NumThreads, HeadSize, PageSize, TI, TO, TKV, DataParallelWorker, Config, KVConfig<TSB>>>;
+  using WorkspaceT = DataParallelWorkspace<Config>;
+
+  auto workspace_max_sum_tensor = WorkspaceT::max_sum(workspace, num_seqs, num_heads, max_context_len);
+  float2* ws_max_sum;
+  TO* maybe_ws_out;
+  if constexpr (Config::InplaceFlashAcc) {
+    ws_max_sum = &workspace_max_sum_tensor(_0{}, _0{}, _0{});
+    maybe_ws_out = out;  // inplace flash acc to the final output
+  } else {
+    ws_max_sum = &workspace_max_sum_tensor(task_chunk_start, _0{}, _0{});
+    auto ws_out_tensor = WorkspaceT::out(workspace, num_seqs, num_heads, HeadSize, max_context_len);
+    maybe_ws_out = &ws_out_tensor(task_chunk_start, _0{}, _0{}, _0{});
+  }
+
+  DataParallelWorker w{};
+  Task::attention(
+      broadcast_buffer, &w, seq_idx, head_idx, kv_head_idx, maybe_ws_out, ws_max_sum,
+      q, k_cache, v_cache, scalebias, page_table, context_lens, alibi_slopes,
+      scale, num_seqs, num_heads, num_kv_heads, max_num_pages_per_seq, q_stride
+  );
+}
+#else
+    ;
+#endif
+
+template <int NumThreads, typename Tensor>
+__forceinline__ __device__ float2
+flash_acc_precompute_global_stats(
+    const Tensor& max_sum_view,
+    int task_chunk_start, int task_chunk_end
+) {
+  constexpr int NumWarps = NumThreads / constant::WarpSize;
+
+  __shared__ float reduction_buffer[NumWarps];
+  __shared__ float2 smem_max_sum[1];
+
+  float global_max = std::numeric_limits<float>::lowest();
+  float global_sum = 0.0f;
+
+  // 1. compute the global max of multiple TaskChunks
+  for (int t = task_chunk_start + threadIdx.x; t < task_chunk_end; t += NumThreads) {
+    float curr_max = max_sum_view(t).x;
+    global_max = max(global_max, curr_max);
+  }
+  global_max = warp::reduce<constant::WarpSize>(global_max, [](float a, float b) { return max(a, b); });
+  if (lane_id() == 0) {
+    reduction_buffer[warp_id()] = global_max;
+  }
+  __syncthreads();
+  if (threadIdx.x == 0) {
+    for (int i = 1; i < NumWarps; i++) {
+      global_max = max(reduction_buffer[i], global_max);
+    }
+    smem_max_sum->x = global_max;
+  }
+  __syncthreads();
+  global_max = smem_max_sum->x;
+
+  // 2. compute the global sum of multiple TaskChunks
+  for (int t = task_chunk_start + threadIdx.x; t < task_chunk_end; t += NumThreads) {
+    auto max_sum = max_sum_view(t);
+    float curr_max = max_sum.x;
+    float curr_sum = max_sum.y;
+    float curr_factor = __expf(curr_max - global_max);
+    global_sum += curr_factor * curr_sum;
+  }
+  global_sum = warp::reduce<constant::WarpSize>(global_sum, [](float a, float b) { return a + b; });
+  if (lane_id() == 0) {
+    reduction_buffer[warp_id()] = global_sum;
+  }
+  __syncthreads();
+  if (threadIdx.x == 0) {
+    for (int i = 1; i < NumWarps; i++) {
+      global_sum += reduction_buffer[i];
+    }
+    smem_max_sum->y = global_sum;
+  }
+  __syncthreads();
+  global_sum = smem_max_sum->y;
+
+  return float2{global_max, global_sum};
+}
+
+template <int NumThreads, int HeadSize, typename Tensor1, typename Tensor2>
+__forceinline__ __device__ void
+flash_acc_with_global_stats(
+    float* acc, float2 global_max_sum,               // accumulative part
+    const Tensor1& inc, const Tensor2& inc_max_sum,  // incremental part, indexed as (chunk) and (chunk,dim)
+    int task_chunk_start, int task_chunk_end
+) {
+  float global_max = global_max_sum.x;
+  float global_sum = global_max_sum.y;
+  float global_sum_inv = 1.0f / global_sum;
+
+  CUTE_UNROLL
+  for (int i = threadIdx.x; i < HeadSize; i += NumThreads) {
+    float gloabl_acc = acc[i];
+    for (int t = task_chunk_start; t < task_chunk_end; t++) {
+      float curr_max = inc_max_sum(t).x;
+      float curr_sum = inc_max_sum(t).y;
+      float curr_factor = __expf(curr_max - global_max);
+      gloabl_acc += curr_factor * (curr_sum * global_sum_inv) * inc(t, i);
+    }
+    acc[i] = gloabl_acc;
+  }
+}
+
+template <int NumThreads, int HeadSize, int PageSize, typename TIO, typename TKV, typename Config>
+__global__ void
+__launch_bounds__(NumThreads) lbp_attention_reduction_kernel(
+    void* __restrict__ workspace,
+    TIO* __restrict__ out,                 // [num_seqs, num_heads, head_size]
+    const int* __restrict__ context_lens,  // [num_seqs]
+    const int num_seqs,
+    const int num_heads,
+    const int max_context_len
+)
+#if !defined(PAGED_SPLIT_COMPILATION) || defined(PAGED_ATTENTION_KERNEL_IMPL)
+{
+  static_assert(!Config::InplaceFlashAcc);
+  static_assert(!Config::UseHeadSeq);
+
+  using TI = TIO;
+  using TO = TIO;
+  using Task = PagedAttentionTask<
+      NumThreads, HeadSize, PageSize, TI, TO, TKV,
+      DataParallelWorker, Config>;
+  using WorkspaceT = DataParallelWorkspace<Config>;
+
+  auto ws_max_sum = WorkspaceT::max_sum(workspace, num_seqs, num_heads, max_context_len);
+  auto ws_out = WorkspaceT::out(workspace, num_seqs, num_heads, HeadSize, max_context_len);
+
+  __shared__ float smem_out[HeadSize];
+  // __shared__ float2 smem_max_sum[1];
+  // smem_out will not be loaded if sum in smem_max_sum is 0.0f
+  // if (threadIdx.x == 0) {
+  //   smem_max_sum[0] = float2{std::numeric_limits<float>::lowest(), 0.0f};
+  // }
+  // __syncthreads();
+
+  int seq_head_idx = blockIdx.x;
+  int seq_idx = seq_head_idx / num_heads;
+  int head_idx = seq_head_idx % num_heads;
+  int task_chunk_start = 0;
+  constexpr int TaskChunkSeqLen = Config::TaskChunkSeqLen;
+  int task_chunk_end = ceil_div(context_lens[seq_idx], TaskChunkSeqLen);
+
+  // implements a variant of flash_acc reduction over the workspace output
+  // for (int t = task_chunk_start; t < task_chunk_end; t++) {
+  //   Task::flash_acc(
+  //       smem_out, smem_max_sum,
+  //       &ws_out(t, seq_idx, head_idx, _0{}), &ws_max_sum(t, seq_idx, head_idx)
+  //   );
+  // }
+  CUTE_UNROLL
+  for (int i = threadIdx.x; i < HeadSize; i += NumThreads) {
+    smem_out[i] = 0.0f;
+  }
+  // __syncthreads();
+  float2 global_max_sum = flash_acc_precompute_global_stats<NumThreads>(ws_max_sum(_, seq_idx, head_idx), task_chunk_start, task_chunk_end);
+  flash_acc_with_global_stats<NumThreads, HeadSize>(smem_out, global_max_sum, ws_out(_, seq_idx, head_idx, _), ws_max_sum(_, seq_idx, head_idx), task_chunk_start, task_chunk_end);
+
+  auto gO = make_tensor(make_gmem_ptr(out), make_layout(make_shape(num_seqs, num_heads, Int<HeadSize>{}), LayoutRight{}));
+  Task::write_flash_inc(
+      &gO(seq_idx, head_idx, _0{}), nullptr,
+      smem_out, nullptr
+  );
+}
+#else
+    ;
+#endif
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_dp.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_dp.cuh
@@ -6,8 +6,7 @@
 #include <cstdint>
 
 #include "contrib_ops/cuda/bert/paged/atomics.cuh"
-#include "contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_task.cuh"
-#include "contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_gqa_task.cuh"
+#include "contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_task_selector.cuh"
 
 namespace onnxruntime::contrib::paged {
 
@@ -124,9 +123,13 @@ struct DataParallelWorkspace<DataParallelConfig<false, false, NumQueriesPerCta>>
   }
 };
 
+#if !defined(PAGED_ATTENTION_MAXNREG)
+#define PAGED_ATTENTION_MAXNREG 128
+#endif
+
 template <int NumThreads, int HeadSize, int PageSize, typename TIO, typename TKV, typename TSB, typename Config>
 __global__ void
-__launch_bounds__(NumThreads, NumThreads / constant::WarpSize) lbp_attention_data_parallel_kernel(
+PAGED_LAUNCH_BOUNDS(NumThreads, PAGED_ATTENTION_MAXNREG) lbp_attention_data_parallel_kernel(
     void* __restrict__ workspace,
     TIO* __restrict__ out,                   // [num_seqs, num_heads, head_size]
     const TIO* __restrict__ q,               // [num_seqs, num_heads, head_size]
@@ -165,10 +168,8 @@ __launch_bounds__(NumThreads, NumThreads / constant::WarpSize) lbp_attention_dat
 
   using TI = TIO;
   using TO = std::conditional_t<Config::InplaceFlashAcc, TIO, float>;
-  using Task = std::conditional_t<
-      Config::NumQueriesPerCta == 1,
-      PagedAttentionTask<NumThreads, HeadSize, PageSize, TI, TO, TKV, DataParallelWorker, Config, KVConfig<TSB>>,
-      PagedGroupQueryAttentionTask<NumThreads, HeadSize, PageSize, TI, TO, TKV, DataParallelWorker, Config, KVConfig<TSB>>>;
+  using Task = typename PagedAttentionTaskSelector<
+      NumThreads, HeadSize, PageSize, TI, TO, TKV, DataParallelWorker, Config, KVConfig<TSB>>::Task;
   using WorkspaceT = DataParallelWorkspace<Config>;
 
   auto workspace_max_sum_tensor = WorkspaceT::max_sum(workspace, num_seqs, num_heads, max_context_len);
@@ -188,153 +189,6 @@ __launch_bounds__(NumThreads, NumThreads / constant::WarpSize) lbp_attention_dat
       broadcast_buffer, &w, seq_idx, head_idx, kv_head_idx, maybe_ws_out, ws_max_sum,
       q, k_cache, v_cache, scalebias, page_table, context_lens, alibi_slopes,
       scale, num_seqs, num_heads, num_kv_heads, max_num_pages_per_seq, q_stride
-  );
-}
-#else
-    ;
-#endif
-
-template <int NumThreads, typename Tensor>
-__forceinline__ __device__ float2
-flash_acc_precompute_global_stats(
-    const Tensor& max_sum_view,
-    int task_chunk_start, int task_chunk_end
-) {
-  constexpr int NumWarps = NumThreads / constant::WarpSize;
-
-  __shared__ float reduction_buffer[NumWarps];
-  __shared__ float2 smem_max_sum[1];
-
-  float global_max = std::numeric_limits<float>::lowest();
-  float global_sum = 0.0f;
-
-  // 1. compute the global max of multiple TaskChunks
-  for (int t = task_chunk_start + threadIdx.x; t < task_chunk_end; t += NumThreads) {
-    float curr_max = max_sum_view(t).x;
-    global_max = max(global_max, curr_max);
-  }
-  global_max = warp::reduce<constant::WarpSize>(global_max, [](float a, float b) { return max(a, b); });
-  if (lane_id() == 0) {
-    reduction_buffer[warp_id()] = global_max;
-  }
-  __syncthreads();
-  if (threadIdx.x == 0) {
-    for (int i = 1; i < NumWarps; i++) {
-      global_max = max(reduction_buffer[i], global_max);
-    }
-    smem_max_sum->x = global_max;
-  }
-  __syncthreads();
-  global_max = smem_max_sum->x;
-
-  // 2. compute the global sum of multiple TaskChunks
-  for (int t = task_chunk_start + threadIdx.x; t < task_chunk_end; t += NumThreads) {
-    auto max_sum = max_sum_view(t);
-    float curr_max = max_sum.x;
-    float curr_sum = max_sum.y;
-    float curr_factor = __expf(curr_max - global_max);
-    global_sum += curr_factor * curr_sum;
-  }
-  global_sum = warp::reduce<constant::WarpSize>(global_sum, [](float a, float b) { return a + b; });
-  if (lane_id() == 0) {
-    reduction_buffer[warp_id()] = global_sum;
-  }
-  __syncthreads();
-  if (threadIdx.x == 0) {
-    for (int i = 1; i < NumWarps; i++) {
-      global_sum += reduction_buffer[i];
-    }
-    smem_max_sum->y = global_sum;
-  }
-  __syncthreads();
-  global_sum = smem_max_sum->y;
-
-  return float2{global_max, global_sum};
-}
-
-template <int NumThreads, int HeadSize, typename Tensor1, typename Tensor2>
-__forceinline__ __device__ void
-flash_acc_with_global_stats(
-    float* acc, float2 global_max_sum,               // accumulative part
-    const Tensor1& inc, const Tensor2& inc_max_sum,  // incremental part, indexed as (chunk) and (chunk,dim)
-    int task_chunk_start, int task_chunk_end
-) {
-  float global_max = global_max_sum.x;
-  float global_sum = global_max_sum.y;
-  float global_sum_inv = 1.0f / global_sum;
-
-  CUTE_UNROLL
-  for (int i = threadIdx.x; i < HeadSize; i += NumThreads) {
-    float gloabl_acc = acc[i];
-    for (int t = task_chunk_start; t < task_chunk_end; t++) {
-      float curr_max = inc_max_sum(t).x;
-      float curr_sum = inc_max_sum(t).y;
-      float curr_factor = __expf(curr_max - global_max);
-      gloabl_acc += curr_factor * (curr_sum * global_sum_inv) * inc(t, i);
-    }
-    acc[i] = gloabl_acc;
-  }
-}
-
-template <int NumThreads, int HeadSize, int PageSize, typename TIO, typename TKV, typename Config>
-__global__ void
-__launch_bounds__(NumThreads) lbp_attention_reduction_kernel(
-    void* __restrict__ workspace,
-    TIO* __restrict__ out,                 // [num_seqs, num_heads, head_size]
-    const int* __restrict__ context_lens,  // [num_seqs]
-    const int num_seqs,
-    const int num_heads,
-    const int max_context_len
-)
-#if !defined(PAGED_SPLIT_COMPILATION) || defined(PAGED_ATTENTION_KERNEL_IMPL)
-{
-  static_assert(!Config::InplaceFlashAcc);
-  static_assert(!Config::UseHeadSeq);
-
-  using TI = TIO;
-  using TO = TIO;
-  using Task = PagedAttentionTask<
-      NumThreads, HeadSize, PageSize, TI, TO, TKV,
-      DataParallelWorker, Config>;
-  using WorkspaceT = DataParallelWorkspace<Config>;
-
-  auto ws_max_sum = WorkspaceT::max_sum(workspace, num_seqs, num_heads, max_context_len);
-  auto ws_out = WorkspaceT::out(workspace, num_seqs, num_heads, HeadSize, max_context_len);
-
-  __shared__ float smem_out[HeadSize];
-  // __shared__ float2 smem_max_sum[1];
-  // smem_out will not be loaded if sum in smem_max_sum is 0.0f
-  // if (threadIdx.x == 0) {
-  //   smem_max_sum[0] = float2{std::numeric_limits<float>::lowest(), 0.0f};
-  // }
-  // __syncthreads();
-
-  int seq_head_idx = blockIdx.x;
-  int seq_idx = seq_head_idx / num_heads;
-  int head_idx = seq_head_idx % num_heads;
-  int task_chunk_start = 0;
-  constexpr int TaskChunkSeqLen = Config::TaskChunkSeqLen;
-  int task_chunk_end = ceil_div(context_lens[seq_idx], TaskChunkSeqLen);
-
-  // implements a variant of flash_acc reduction over the workspace output
-  // for (int t = task_chunk_start; t < task_chunk_end; t++) {
-  //   Task::flash_acc(
-  //       smem_out, smem_max_sum,
-  //       &ws_out(t, seq_idx, head_idx, _0{}), &ws_max_sum(t, seq_idx, head_idx)
-  //   );
-  // }
-  CUTE_UNROLL
-  for (int i = threadIdx.x; i < HeadSize; i += NumThreads) {
-    smem_out[i] = 0.0f;
-  }
-  // __syncthreads();
-  float2 global_max_sum = flash_acc_precompute_global_stats<NumThreads>(ws_max_sum(_, seq_idx, head_idx), task_chunk_start, task_chunk_end);
-  flash_acc_with_global_stats<NumThreads, HeadSize>(smem_out, global_max_sum, ws_out(_, seq_idx, head_idx, _), ws_max_sum(_, seq_idx, head_idx), task_chunk_start, task_chunk_end);
-
-  auto gO = make_tensor(make_gmem_ptr(out), make_layout(make_shape(num_seqs, num_heads, Int<HeadSize>{}), LayoutRight{}));
-  Task::write_flash_inc(
-      &gO(seq_idx, head_idx, _0{}), nullptr,
-      smem_out, nullptr
   );
 }
 #else

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_dpi.cu.in
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_dpi.cu.in
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#define PAGED_ATTENTION_KERNEL_IMPL 1
+#include "contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_dp.cuh"
+
+namespace onnxruntime::contrib::paged {
+
+using float8_e4m3fn_t = cute::float_e4m3_t;
+
+// clang-format off
+#define NUM_THREADS @NUM_THREADS@
+#define HEAD_SIZE @HEAD_SIZE@
+#define PAGE_SIZE @PAGE_SIZE@
+#define TIO @TIO@
+#define TKV @TKV@
+#define TSB @TSB@
+// clang-format on
+
+using DPIConfig = DataParallelConfig<true, true>;
+using DPIConfig4 = DataParallelConfig<true, true, 4>;
+
+template __global__ void lbp_attention_data_parallel_kernel<NUM_THREADS, HEAD_SIZE, PAGE_SIZE, TIO, TKV, TSB, DPIConfig>(
+    void* workspace,
+    TIO* __restrict__ out,                   // [num_seqs, num_heads, head_size]
+    const TIO* __restrict__ q,               // [num_seqs, num_heads, head_size]
+    const TKV* __restrict__ k_cache,         // [num_pages, num_kv_heads, head_size/x, page_size, x]
+    const TKV* __restrict__ v_cache,         // [num_pages, num_kv_heads, head_size, page_size]
+    const TSB* __restrict__ scalebias,       // [num_pages, 2, num_kv_heads, 2, head_size/chunk_size, page_size]
+    const int* __restrict__ page_table,      // [num_seqs, max_num_pages_per_seq]
+    const int* __restrict__ context_lens,    // [num_seqs]
+    const float* __restrict__ alibi_slopes,  // [num_heads]
+    const float scale,
+    const int num_seqs,
+    const int num_heads,
+    const int num_kv_heads,
+    const int max_num_pages_per_seq,
+    const int q_stride,
+    const int max_context_len
+);
+
+template __global__ void lbp_attention_data_parallel_kernel<NUM_THREADS, HEAD_SIZE, PAGE_SIZE, TIO, TKV, TSB, DPIConfig4>(
+    void* workspace,
+    TIO* __restrict__ out,                   // [num_seqs, num_heads, head_size]
+    const TIO* __restrict__ q,               // [num_seqs, num_heads, head_size]
+    const TKV* __restrict__ k_cache,         // [num_pages, num_kv_heads, head_size/x, page_size, x]
+    const TKV* __restrict__ v_cache,         // [num_pages, num_kv_heads, head_size, page_size]
+    const TSB* __restrict__ scalebias,       // [num_pages, 2, num_kv_heads, 2, head_size/chunk_size, page_size]
+    const int* __restrict__ page_table,      // [num_seqs, max_num_pages_per_seq]
+    const int* __restrict__ context_lens,    // [num_seqs]
+    const float* __restrict__ alibi_slopes,  // [num_heads]
+    const float scale,
+    const int num_seqs,
+    const int num_heads,
+    const int num_kv_heads,
+    const int max_num_pages_per_seq,
+    const int q_stride,
+    const int max_context_len
+);
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_dpi.cu.in
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_dpi.cu.in
@@ -12,34 +12,15 @@ using float8_e4m3fn_t = cute::float_e4m3_t;
 #define NUM_THREADS @NUM_THREADS@
 #define HEAD_SIZE @HEAD_SIZE@
 #define PAGE_SIZE @PAGE_SIZE@
+#define NUM_QUERIES_PER_KV @NUM_QUERIES_PER_KV@
 #define TIO @TIO@
 #define TKV @TKV@
 #define TSB @TSB@
 // clang-format on
 
-using DPIConfig = DataParallelConfig<true, true>;
-using DPIConfig4 = DataParallelConfig<true, true, 4>;
+using DPIConfig = DataParallelConfig<true, true, NUM_QUERIES_PER_KV>;
 
 template __global__ void lbp_attention_data_parallel_kernel<NUM_THREADS, HEAD_SIZE, PAGE_SIZE, TIO, TKV, TSB, DPIConfig>(
-    void* workspace,
-    TIO* __restrict__ out,                   // [num_seqs, num_heads, head_size]
-    const TIO* __restrict__ q,               // [num_seqs, num_heads, head_size]
-    const TKV* __restrict__ k_cache,         // [num_pages, num_kv_heads, head_size/x, page_size, x]
-    const TKV* __restrict__ v_cache,         // [num_pages, num_kv_heads, head_size, page_size]
-    const TSB* __restrict__ scalebias,       // [num_pages, 2, num_kv_heads, 2, head_size/chunk_size, page_size]
-    const int* __restrict__ page_table,      // [num_seqs, max_num_pages_per_seq]
-    const int* __restrict__ context_lens,    // [num_seqs]
-    const float* __restrict__ alibi_slopes,  // [num_heads]
-    const float scale,
-    const int num_seqs,
-    const int num_heads,
-    const int num_kv_heads,
-    const int max_num_pages_per_seq,
-    const int q_stride,
-    const int max_context_len
-);
-
-template __global__ void lbp_attention_data_parallel_kernel<NUM_THREADS, HEAD_SIZE, PAGE_SIZE, TIO, TKV, TSB, DPIConfig4>(
     void* workspace,
     TIO* __restrict__ out,                   // [num_seqs, num_heads, head_size]
     const TIO* __restrict__ q,               // [num_seqs, num_heads, head_size]

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_dpo.cu.in
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_dpo.cu.in
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#define PAGED_ATTENTION_KERNEL_IMPL 1
+#include "contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_dp.cuh"
+
+namespace onnxruntime::contrib::paged {
+
+using float8_e4m3fn_t = cute::float_e4m3_t;
+
+// clang-format off
+#define NUM_THREADS @NUM_THREADS@
+#define HEAD_SIZE @HEAD_SIZE@
+#define PAGE_SIZE @PAGE_SIZE@
+#define TIO @TIO@
+#define TKV @TKV@
+#define TSB @TSB@
+// clang-format on
+
+using DPOConfig = DataParallelConfig<false, false>;
+using DPOConfig4 = DataParallelConfig<false, false, 4>;
+
+template __global__ void lbp_attention_data_parallel_kernel<NUM_THREADS, HEAD_SIZE, PAGE_SIZE, TIO, TKV, TSB, DPOConfig>(
+    void* workspace,
+    TIO* __restrict__ out,                   // [num_seqs, num_heads, head_size]
+    const TIO* __restrict__ q,               // [num_seqs, num_heads, head_size]
+    const TKV* __restrict__ k_cache,         // [num_pages, num_kv_heads, head_size/x, page_size, x]
+    const TKV* __restrict__ v_cache,         // [num_pages, num_kv_heads, head_size, page_size]
+    const TSB* __restrict__ scalebias,       // [num_pages, 2, num_kv_heads, 2, head_size/chunk_size, page_size]
+    const int* __restrict__ page_table,      // [num_seqs, max_num_pages_per_seq]
+    const int* __restrict__ context_lens,    // [num_seqs]
+    const float* __restrict__ alibi_slopes,  // [num_heads]
+    const float scale,
+    const int num_seqs,
+    const int num_heads,
+    const int num_kv_heads,
+    const int max_num_pages_per_seq,
+    const int q_stride,
+    const int max_context_len
+);
+
+template __global__ void lbp_attention_reduction_kernel<NUM_THREADS, HEAD_SIZE, PAGE_SIZE, TIO, TKV, DPOConfig>(
+    void* __restrict__ workspace,
+    TIO* __restrict__ out,                 // [num_seqs, num_heads, head_size]
+    const int* __restrict__ context_lens,  // [num_seqs]
+    const int num_seqs,
+    const int num_heads,
+    const int max_context_len
+);
+
+template __global__ void lbp_attention_data_parallel_kernel<NUM_THREADS, HEAD_SIZE, PAGE_SIZE, TIO, TKV, TSB, DPOConfig4>(
+    void* workspace,
+    TIO* __restrict__ out,                   // [num_seqs, num_heads, head_size]
+    const TIO* __restrict__ q,               // [num_seqs, num_heads, head_size]
+    const TKV* __restrict__ k_cache,         // [num_pages, num_kv_heads, head_size/x, page_size, x]
+    const TKV* __restrict__ v_cache,         // [num_pages, num_kv_heads, head_size, page_size]
+    const TSB* __restrict__ scalebias,       // [num_pages, 2, num_kv_heads, 2, head_size/chunk_size, page_size]
+    const int* __restrict__ page_table,      // [num_seqs, max_num_pages_per_seq]
+    const int* __restrict__ context_lens,    // [num_seqs]
+    const float* __restrict__ alibi_slopes,  // [num_heads]
+    const float scale,
+    const int num_seqs,
+    const int num_heads,
+    const int num_kv_heads,
+    const int max_num_pages_per_seq,
+    const int q_stride,
+    const int max_context_len
+);
+
+template __global__ void lbp_attention_reduction_kernel<NUM_THREADS, HEAD_SIZE, PAGE_SIZE, TIO, TKV, DPOConfig4>(
+    void* __restrict__ workspace,
+    TIO* __restrict__ out,                 // [num_seqs, num_heads, head_size]
+    const int* __restrict__ context_lens,  // [num_seqs]
+    const int num_seqs,
+    const int num_heads,
+    const int max_context_len
+);
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_dpo.cu.in
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_dpo.cu.in
@@ -12,13 +12,13 @@ using float8_e4m3fn_t = cute::float_e4m3_t;
 #define NUM_THREADS @NUM_THREADS@
 #define HEAD_SIZE @HEAD_SIZE@
 #define PAGE_SIZE @PAGE_SIZE@
+#define NUM_QUERIES_PER_KV @NUM_QUERIES_PER_KV@
 #define TIO @TIO@
 #define TKV @TKV@
 #define TSB @TSB@
 // clang-format on
 
-using DPOConfig = DataParallelConfig<false, false>;
-using DPOConfig4 = DataParallelConfig<false, false, 4>;
+using DPOConfig = DataParallelConfig<false, false, NUM_QUERIES_PER_KV>;
 
 template __global__ void lbp_attention_data_parallel_kernel<NUM_THREADS, HEAD_SIZE, PAGE_SIZE, TIO, TKV, TSB, DPOConfig>(
     void* workspace,
@@ -36,43 +36,6 @@ template __global__ void lbp_attention_data_parallel_kernel<NUM_THREADS, HEAD_SI
     const int num_kv_heads,
     const int max_num_pages_per_seq,
     const int q_stride,
-    const int max_context_len
-);
-
-template __global__ void lbp_attention_reduction_kernel<NUM_THREADS, HEAD_SIZE, PAGE_SIZE, TIO, TKV, DPOConfig>(
-    void* __restrict__ workspace,
-    TIO* __restrict__ out,                 // [num_seqs, num_heads, head_size]
-    const int* __restrict__ context_lens,  // [num_seqs]
-    const int num_seqs,
-    const int num_heads,
-    const int max_context_len
-);
-
-template __global__ void lbp_attention_data_parallel_kernel<NUM_THREADS, HEAD_SIZE, PAGE_SIZE, TIO, TKV, TSB, DPOConfig4>(
-    void* workspace,
-    TIO* __restrict__ out,                   // [num_seqs, num_heads, head_size]
-    const TIO* __restrict__ q,               // [num_seqs, num_heads, head_size]
-    const TKV* __restrict__ k_cache,         // [num_pages, num_kv_heads, head_size/x, page_size, x]
-    const TKV* __restrict__ v_cache,         // [num_pages, num_kv_heads, head_size, page_size]
-    const TSB* __restrict__ scalebias,       // [num_pages, 2, num_kv_heads, 2, head_size/chunk_size, page_size]
-    const int* __restrict__ page_table,      // [num_seqs, max_num_pages_per_seq]
-    const int* __restrict__ context_lens,    // [num_seqs]
-    const float* __restrict__ alibi_slopes,  // [num_heads]
-    const float scale,
-    const int num_seqs,
-    const int num_heads,
-    const int num_kv_heads,
-    const int max_num_pages_per_seq,
-    const int q_stride,
-    const int max_context_len
-);
-
-template __global__ void lbp_attention_reduction_kernel<NUM_THREADS, HEAD_SIZE, PAGE_SIZE, TIO, TKV, DPOConfig4>(
-    void* __restrict__ workspace,
-    TIO* __restrict__ out,                 // [num_seqs, num_heads, head_size]
-    const int* __restrict__ context_lens,  // [num_seqs]
-    const int num_seqs,
-    const int num_heads,
     const int max_context_len
 );
 

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_dpo_reduction.cu.in
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_dpo_reduction.cu.in
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#define PAGED_ATTENTION_KERNEL_IMPL 1
+#include "contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_dpo_reduction.cuh"
+
+namespace onnxruntime::contrib::paged {
+
+using float8_e4m3fn_t = cute::float_e4m3_t;
+
+// clang-format off
+#define HEAD_SIZE @HEAD_SIZE@
+#define TIO @TIO@
+// clang-format on
+
+#define NUM_THREADS 128
+#define NUM_QUERIES_PER_KV 1
+using DPOConfig = DataParallelConfig<false, false, NUM_QUERIES_PER_KV>;
+
+template __global__ void lbp_attention_reduction_kernel<NUM_THREADS, HEAD_SIZE, TIO, DPOConfig>(
+    void* __restrict__ workspace,
+    TIO* __restrict__ out,                 // [num_seqs, num_heads, head_size]
+    const int* __restrict__ context_lens,  // [num_seqs]
+    const int num_seqs,
+    const int num_heads,
+    const int max_context_len
+);
+
+#if INSTANTIATE_SPLIT_HEAD_KERNEL
+template __global__ void lbp_attention_split_head_reduction_kernel<TIO, DPOConfig>(
+    void* __restrict__ workspace,
+    TIO* __restrict__ out,                 // [num_seqs, num_heads, head_size]
+    const int* __restrict__ context_lens,  // [num_seqs]
+    const int num_seqs,
+    const int num_heads,
+    const int head_size,
+    const int max_context_len
+);
+#endif
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_dpo_reduction.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_dpo_reduction.cuh
@@ -1,0 +1,313 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cstdint>
+
+#include "contrib_ops/cuda/bert/paged/atomics.cuh"
+#include "contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_dp.cuh"
+
+namespace onnxruntime::contrib::paged {
+
+__forceinline__ __device__ float2
+single_pass_flash_acc(const float2& acc_max_sum, const float2& inc_max_sum) {
+  float prev_max = acc_max_sum.x;
+  float prev_sum = acc_max_sum.y;
+
+  float curr_max = inc_max_sum.x;
+  float curr_sum = inc_max_sum.y;
+
+  float new_max = max(prev_max, curr_max);
+
+  float prev_factor = new_max == prev_max ? 1.0f : __expf(prev_max - new_max);
+  float curr_factor = new_max == curr_max ? 1.0f : __expf(curr_max - new_max);
+
+  float new_sum = prev_factor * prev_sum + curr_factor * curr_sum;
+  return float2{new_max, new_sum};
+}
+
+template <int NumThreads, int GroupSize = constant::WarpSize, int Strided = false>
+__forceinline__ __device__ float2
+flash_acc_global_stats_reduction_cta(float2 global_max_sum) {
+  constexpr int NumWarps = NumThreads / constant::WarpSize;
+
+  __shared__ float2 reduction_buffer[NumWarps];
+
+  global_max_sum = warp::reduce<GroupSize, Strided>(global_max_sum, single_pass_flash_acc);
+  if (lane_id() == 0) {
+    reduction_buffer[warp_id()] = global_max_sum;
+  }
+  __syncthreads();
+  if (threadIdx.x == 0) {
+    CUTE_UNROLL
+    for (int i = 1; i < NumWarps; i++) {
+      global_max_sum = single_pass_flash_acc(global_max_sum, reduction_buffer[i]);
+    }
+    reduction_buffer[0] = global_max_sum;
+  }
+  __syncthreads();
+  global_max_sum = reduction_buffer[0];
+  return global_max_sum;
+}
+
+template <int NumThreads, int HeadSize, typename Tensor1, typename Tensor2>
+__forceinline__ __device__ void
+flash_acc_with_global_stats(
+    float* acc, float2 global_max_sum,               // accumulative part
+    const Tensor1& inc, const Tensor2& inc_max_sum,  // incremental part, indexed as (chunk) and (chunk,dim)
+    int task_chunk_start, int task_chunk_end
+) {
+  float global_max = global_max_sum.x;
+  float global_sum = global_max_sum.y;
+  float global_sum_inv = 1.0f / global_sum;
+
+  CUTE_UNROLL
+  for (int i = threadIdx.x; i < HeadSize; i += NumThreads) {
+    float gloabl_acc = acc[i];
+    for (int t = task_chunk_start; t < task_chunk_end; t++) {
+      float curr_max = inc_max_sum(t).x;
+      float curr_sum = inc_max_sum(t).y;
+      float curr_factor = __expf(curr_max - global_max);
+      gloabl_acc += curr_factor * (curr_sum * global_sum_inv) * inc(t, i);
+    }
+    acc[i] = gloabl_acc;
+  }
+}
+
+template <int NumThreads, int HeadSize, typename TIO, typename Config>
+__global__ void
+lbp_attention_reduction_kernel(
+    void* __restrict__ workspace,
+    TIO* __restrict__ out,                 // [num_seqs, num_heads, head_size]
+    const int* __restrict__ context_lens,  // [num_seqs]
+    const int num_seqs,
+    const int num_heads,
+    const int max_context_len
+)
+#if !defined(PAGED_SPLIT_COMPILATION) || defined(PAGED_ATTENTION_KERNEL_IMPL)
+{
+  static_assert(!Config::InplaceFlashAcc);
+  static_assert(!Config::UseHeadSeq);
+
+  using TI = TIO;
+  using TO = TIO;
+  using WorkspaceT = DataParallelWorkspace<Config>;
+
+  using FashAccCta = FlashAccCta<NumThreads, HeadSize>;
+
+  auto ws_max_sum = WorkspaceT::max_sum(workspace, num_seqs, num_heads, max_context_len);
+  auto ws_out = WorkspaceT::out(workspace, num_seqs, num_heads, HeadSize, max_context_len);
+
+  __shared__ float smem_out[HeadSize];
+
+  int seq_head_idx = blockIdx.x;
+  int seq_idx = seq_head_idx / num_heads;
+  int head_idx = seq_head_idx % num_heads;
+  int task_chunk_start = 0;
+  constexpr int TaskChunkSeqLen = Config::TaskChunkSeqLen;
+  int task_chunk_end = ceil_div(context_lens[seq_idx], TaskChunkSeqLen);
+
+  CUTE_UNROLL
+  for (int i = threadIdx.x; i < HeadSize; i += NumThreads) {
+    smem_out[i] = 0.0f;
+  }
+  // __syncthreads();
+
+  auto max_sum_view = ws_max_sum(_, seq_idx, head_idx);
+  float2 global_max_sum;
+  init_max_sum(&global_max_sum);
+
+  // compute the global max and global sum of multiple TaskChunks in single pass
+  for (int t = task_chunk_start + threadIdx.x; t < task_chunk_end; t += NumThreads) {
+    global_max_sum = single_pass_flash_acc(global_max_sum, max_sum_view(t));
+  }
+
+  global_max_sum = flash_acc_global_stats_reduction_cta<NumThreads>(global_max_sum);
+  flash_acc_with_global_stats<NumThreads, HeadSize>(
+      smem_out, global_max_sum,
+      ws_out(_, seq_idx, head_idx, _), ws_max_sum(_, seq_idx, head_idx),
+      task_chunk_start, task_chunk_end
+  );
+
+  auto gO = make_tensor(make_gmem_ptr(out), make_layout(make_shape(num_seqs, num_heads, Int<HeadSize>{}), LayoutRight{}));
+  FashAccCta::write_inc(
+      &gO(seq_idx, head_idx, _0{}), nullptr,
+      smem_out, nullptr
+  );
+}
+#else
+    ;
+#endif
+
+template <int VecSize, typename TAcc, typename TInc>
+__forceinline__ __device__ void
+flash_acc_thread(
+    TAcc* acc, float2* acc_max_sum,             // accumulative part
+    const TInc& inc, const float2* inc_max_sum  // incremental part
+) {
+  float prev_max = acc_max_sum->x;
+  float prev_sum = acc_max_sum->y;
+
+  float curr_max = inc_max_sum->x;
+  float curr_sum = inc_max_sum->y;
+
+  float new_max = max(prev_max, curr_max);
+
+  float prev_factor = new_max == prev_max ? 1.0f : __expf(prev_max - new_max);
+  float curr_factor = new_max == curr_max ? 1.0f : __expf(curr_max - new_max);
+
+  float new_sum = prev_factor * prev_sum + curr_factor * curr_sum;
+  float new_sum_inv = 1.0f / new_sum;
+
+  *acc_max_sum = float2{new_max, new_sum};
+  bool load_prev_acc = prev_sum != 0.0f;
+  CUTE_UNROLL
+  for (int i = 0; i < VecSize; i++) {
+    float old_val = load_prev_acc ? type_convert<float>(acc[i]) : 0.0f;
+    float new_val = prev_factor * (prev_sum * new_sum_inv) * old_val +
+                    curr_factor * (curr_sum * new_sum_inv) * type_convert<float>(inc[i]);
+    acc[i] = type_convert<TAcc>(new_val);
+  }
+}
+
+template <typename TIO, typename Config>
+__global__ void
+lbp_attention_split_head_reduction_kernel(
+    void* __restrict__ workspace,
+    TIO* __restrict__ out,                 // [num_seqs, num_heads, head_size]
+    const int* __restrict__ context_lens,  // [num_seqs]
+    const int num_seqs,
+    const int num_heads,
+    const int head_size,
+    const int max_context_len
+)
+#if !defined(PAGED_SPLIT_COMPILATION) || defined(PAGED_ATTENTION_KERNEL_IMPL)
+{
+  static_assert(!Config::InplaceFlashAcc);
+  static_assert(!Config::UseHeadSeq);
+
+  constexpr int NumThreads = 128;
+  constexpr int NumWarps = NumThreads / constant::WarpSize;
+
+  constexpr int CachelineSize = 32;
+  constexpr int LdgSize = 16;
+  constexpr int VecSize = LdgSize / sizeof(TIO);
+  constexpr int NumVecH = CachelineSize / LdgSize;  // number of vectors along HeadSize
+  constexpr int NumVecT = NumThreads / NumVecH;     // number of vectors along each TaskChunk
+  auto dim_idx = (blockIdx.x * NumVecH + threadIdx.x % NumVecH) * VecSize;
+
+  int seq_idx = blockIdx.z;
+  int head_idx = blockIdx.y;
+  using WorkspaceT = DataParallelWorkspace<Config>;
+  auto ws_max_sum = WorkspaceT::max_sum(workspace, num_seqs, num_heads, max_context_len)(_, seq_idx, head_idx);        // (task_chunk_idx,seq_idx,head_idx)
+  auto ws_out = WorkspaceT::out(workspace, num_seqs, num_heads, head_size, max_context_len)(_, seq_idx, head_idx, _);  // (task_chunk_idx,seq_idx,head_idx,dim_idx)
+  auto cta_ws_out = local_tile(ws_out, make_shape(max_context_len, Int<VecSize>{}), make_coord(_0{}, dim_idx / VecSize));
+
+  int task_chunk_start = 0;
+  constexpr int TaskChunkSeqLen = Config::TaskChunkSeqLen;
+  int task_chunk_end = ceil_div(context_lens[seq_idx], TaskChunkSeqLen);
+  auto task_chunk_idx = task_chunk_start + threadIdx.x / NumVecH;
+
+  auto acc = make_tensor<float>(Int<VecSize>{});
+  float2 acc_max_sum;
+  init_max_sum(&acc_max_sum);
+  for (int t = task_chunk_idx; t < task_chunk_end; t += NumVecT) {
+    auto inc = make_tensor<TIO>(Int<VecSize>{});
+    copy(cta_ws_out(t, _), inc);
+    float2 inc_max_sum = ws_max_sum(t);
+    flash_acc_thread<VecSize>(&acc(_0{}), &acc_max_sum, &inc(_0{}), &inc_max_sum);
+  }
+
+  __shared__ float reduction_buffer[cute::max(VecSize * NumVecH, NumWarps)];
+
+  // re-normalize local acc vector with global stats
+  float2 global_max_sum = flash_acc_global_stats_reduction_cta<NumThreads, constant::WarpSize / NumVecH, true>(acc_max_sum);
+  float curr_max = acc_max_sum.x;
+  float curr_sum = acc_max_sum.y;
+  float global_max = global_max_sum.x;
+  float global_sum = global_max_sum.y;
+  float curr_factor = __expf(curr_max - global_max);
+  float factor = curr_factor * (curr_sum / global_sum);
+  transform(acc, [&](auto v) { return v * factor; });
+
+  // local acc -> global acc
+  acc = warp::reduce<constant::WarpSize / NumVecH, true>(acc, [](float a, float b) { return a + b; });
+  for (int warp = 0; warp < NumWarps; warp++) {
+    __syncthreads();
+    if (warp_id() == warp && lane_id() < NumVecH) {
+      if (warp == 0) {
+        CUTE_UNROLL
+        for (int i = 0; i < VecSize; i++) {
+          reduction_buffer[lane_id() * VecSize + i] = acc(i);
+        }
+      } else {
+        CUTE_UNROLL
+        for (int i = 0; i < VecSize; i++) {
+          reduction_buffer[lane_id() * VecSize + i] += acc(i);
+        }
+      }
+    }
+  }
+  __syncthreads();
+
+  // write global acc
+  if (threadIdx.x < NumVecH) {
+    auto gO = make_tensor(make_gmem_ptr(out), make_layout(make_shape(num_seqs, num_heads, head_size), LayoutRight{}));
+    CUTE_UNROLL
+    for (int i = 0; i < VecSize; i++) {
+      gO(seq_idx, head_idx, dim_idx + i) = reduction_buffer[threadIdx.x * VecSize + i];
+    }
+  }
+}
+#else
+    ;
+#endif
+
+template <int NumThreads, int HeadSize, typename TIO, typename Config>
+inline void
+launch_lbp_attention_reduction_kernel(
+    stream_t stream,
+    dev_props_ptr dev_props,
+    void* __restrict__ workspace,
+    TIO* __restrict__ out_ptr,                 // [num_seqs, num_heads, head_size]
+    const int* __restrict__ context_lens_ptr,  // [num_seqs]
+    const int num_seqs,
+    const int num_heads,
+    const int max_context_len
+) {
+  constexpr int CachelineSize = 32;
+  constexpr int LdgSize = 16;
+  constexpr int VecSize = LdgSize / sizeof(TIO);
+  constexpr int NumVecH = CachelineSize / LdgSize;  // number of vectors along HeadSize
+  constexpr int NumCtaPerHead = HeadSize / (VecSize * NumVecH);
+  static_assert(HeadSize % (VecSize * NumVecH) == 0);
+
+  float num_blk_per_sm = float(num_heads * num_seqs) / dev_props->multiProcessorCount;
+  // float num_blk_per_sm_split_head = float(num_heads * num_seqs * NumCtaPerHead) / dev_props->multiProcessorCount;
+
+  if (num_blk_per_sm >= 2) {
+    lbp_attention_reduction_kernel<NumThreads, HeadSize, TIO, Config>
+        <<<num_heads * num_seqs, NumThreads, 0, stream>>>(
+            workspace,
+            out_ptr,
+            context_lens_ptr,
+            num_seqs,
+            num_heads,
+            max_context_len
+        );
+  } else {
+    lbp_attention_split_head_reduction_kernel<TIO, Config>
+        <<<dim3(NumCtaPerHead, num_heads, num_seqs), NumThreads, 0, stream>>>(
+            workspace,
+            out_ptr,
+            context_lens_ptr,
+            num_seqs,
+            num_heads,
+            HeadSize,
+            max_context_len
+        );
+  }
+}
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_gqa_task.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_gqa_task.cuh
@@ -1,0 +1,582 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "cute/layout.hpp"
+#include "cute/tensor.hpp"
+
+#include "contrib_ops/cuda/bert/paged/algorithms.cuh"
+#include "contrib_ops/cuda/bert/paged/cuda_common.cuh"
+#include "contrib_ops/cuda/bert/paged/mutex.cuh"
+#include "contrib_ops/cuda/bert/paged/paged_attention/attention_common.cuh"
+#include "contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_task.cuh"
+#include "contrib_ops/cuda/bert/paged/type_convert.cuh"
+#include "contrib_ops/cuda/bert/paged/warp_utilities.cuh"
+
+#ifndef TASK_DPRINTF1
+#define DUMMY_TASK_DPRINTF1(...)
+#define TASK_DPRINTF1 DUMMY_TASK_DPRINTF1
+#endif
+
+namespace onnxruntime::contrib::paged {
+
+template <
+    int NumThreads,
+    int HeadSize,
+    int PageSize,
+    typename TI,
+    typename TO_,
+    typename TKV,
+    typename Worker,
+    typename Config,
+    typename KVConfig = DefaultKV>
+struct PagedGroupQueryAttentionTask : public PagedAttentionTask<NumThreads, HeadSize, PageSize, TI, TO_, TKV, Worker, Config, KVConfig> {
+  using BaseTask = PagedAttentionTask<NumThreads, HeadSize, PageSize, TI, TO_, TKV, Worker, Config, KVConfig>;
+  using TQ = TI;
+  using TO = TO_;
+  using TK = TKV;
+  using TV = TKV;
+  using TSB_ = typename BaseTask::TSB_;
+
+  using BaseTask::HasSB;
+  using TSB = typename BaseTask::TSB;
+
+  using BaseTask::atomic_flash_acc;
+  using BaseTask::flash_acc;
+  using BaseTask::write_flash_inc;
+
+  template <
+      typename TensorInEngine, typename TensorInLayout,
+      typename TensorOutEngine, typename TensorOutLayout>
+  __forceinline__ __device__ static void
+  inplace_convert_attn_scores(
+      const Tensor<TensorInEngine, TensorInLayout>& logits,
+      Tensor<TensorOutEngine, TensorOutLayout>& attn_scores
+  ) {
+    using TLogits = typename TensorInEngine::element_type;
+    using TScores = typename TensorOutEngine::element_type;
+    if constexpr (!std::is_same_v<TQ, float>) {
+      const auto in = coalesce_tensor(logits);
+      auto out = coalesce_tensor(attn_scores);
+      static_assert(rank(in) == 1 && rank(out) == 1);  // can be viewed as 1d contiguous
+
+      static_assert(size(TensorInLayout{}) % NumThreads == 0);
+      constexpr int NumElemsPerThread = size(TensorInLayout{}) / NumThreads;
+      constexpr int NumIters = ceil_div(NumElemsPerThread, 64);  // Max NumElemsPerThreadPerIter is 64
+      constexpr int Val = NumElemsPerThread / NumIters;          // NumElemsPerThreadPerIter
+
+      const auto tiled_copy = make_tiled_copy(
+          Copy_Atom<UniversalCopy<TQ>, TQ>{},  // dummy
+          make_layout(Int<NumThreads>{}),
+          make_layout(Int<Val>{})
+      );
+      const auto thr_copy = tiled_copy.get_thread_slice(threadIdx.x);
+      const auto ld = thr_copy.partition_S(in);
+      auto st = thr_copy.partition_D(out);
+      auto regs = make_tensor<TLogits>(make_layout(size<0>(ld)));
+      auto cvts = make_tensor_like<TScores>(regs);
+
+      CUTE_UNROLL
+      for (int iter = 0; iter < size<1>(ld); iter++) {
+        copy(AutoVectorizingCopyWithAssumedAlignment<cute::min(8 * sizeof(TLogits) * Val, 128)>{}, ld(_, iter), regs);
+        CUTE_UNROLL
+        for (int i = 0; i < size(regs); i++) {
+          cvts(i) = type_convert<TO>(regs(i));
+        }
+        __syncthreads();  // ensure load because we are doing conversion inplace
+        copy(AutoVectorizingCopyWithAssumedAlignment<cute::min(8 * sizeof(TLogits) * Val, 128)>{}, cvts, st(_, iter));
+      }
+      __syncthreads();
+    }
+  }
+
+  __forceinline__ __device__ static void
+  attention(
+      void* __restrict__ broadcast_buffer,
+      Worker* __restrict__ worker,
+      const int seq_idx,
+      const int head_idx,
+      const int kv_head_idx,
+      TO* __restrict__ out,                    // [num_seqs, num_heads, head_size]
+      float2* __restrict__ out_max_sum,        // [num_seqs, num_heads], running max and sum of gmem out
+      const TI* __restrict__ q,                // [num_seqs, num_heads, head_size]
+      const TKV* __restrict__ k_cache,         // [num_pages, num_kv_heads, head_size/x, page_size, x]
+      const TKV* __restrict__ v_cache,         // [num_pages, num_kv_heads, head_size, page_size]
+      const TSB_* __restrict__ kv_scalebias,   // [num_pages, 2, num_kv_heads, 2, head_size/chunk_size, page_size], optional
+      const int* __restrict__ page_table,      // [num_seqs, max_num_pages_per_seq]
+      const int* __restrict__ context_lens,    // [num_seqs]
+      const float* __restrict__ alibi_slopes,  // [num_heads]
+      const float scale,
+      const int num_seqs,
+      const int num_heads,
+      const int num_kv_heads,
+      const int max_num_pages_per_seq,
+      const int q_stride
+  ) {
+    constexpr int NumPagesPerTaskChunk = ceil_div(Config::TaskChunkSeqLen, PageSize);
+    __shared__ int chunk_page_table[ceil_div(Config::TaskChunkSeqLen, PageSize)];
+    __shared__ float logits_or_attn_scores_buffer[Config::NumQueriesPerCta * Config::TaskChunkSeqLen];
+    // taking account other smem, use 40KB instead of 48KB
+    static_assert(Config::NumQueriesPerCta * Config::TaskChunkSeqLen * sizeof(float) < 40 * 1024,
+                  "Kernels relying on shared memory allocations over 48 KB per block are architecture-specific,"
+                  "and must use dynamic shared memory rather than statically sized shared memory arrays.");
+    __shared__ float smem_out[Config::NumQueriesPerCta][HeadSize];
+    __shared__ float2 max_sum[2][Config::NumQueriesPerCta];
+    __shared__ TSB sSB_buffer[NumWarps][PageSize * ScaleBiasNumChunks * 2];
+    __shared__ float alibi_slopes_smem[Config::NumQueriesPerCta];
+    // NOTE: __shared__ float2 smem_max_sum compiles but crash with unaligned access
+    float2* smem_max_sum = &max_sum[0][0];
+    float2* chunk_max_sum = &max_sum[1][0];
+
+    // zero-ing out __shared__ buffers
+    // attn_scores will be initialize by softmax_cta
+    // smem_out will not be loaded if sum in smem_max_sum is 0.0f
+    if (threadIdx.x < Config::NumQueriesPerCta) {
+      smem_max_sum[threadIdx.x] = float2{std::numeric_limits<float>::lowest(), 0.0f};
+      alibi_slopes_smem[threadIdx.x] = alibi_slopes == nullptr ? 0.f : alibi_slopes[head_idx + threadIdx.x];
+    }
+    // chunk_max_sum must be initialize per chunk-wise
+
+    const int num_tokens = context_lens[seq_idx];
+    const int64_t dummy_shape = 1073741824;  // 2^30, can be used for the slowest dim
+    const auto num_pages = dummy_shape;
+
+    auto gO = make_tensor(make_gmem_ptr(out), make_layout(make_shape(Int<HeadSize>{}, num_heads, num_seqs)))(_, _, seq_idx);                                                    // [num_seqs, num_heads, head_size]
+    const auto gQ = make_tensor(make_gmem_ptr(q), make_layout(make_shape(Int<HeadSize>{}, num_heads, num_seqs), make_stride(_1{}, Int<HeadSize>{}, q_stride)))(_, _, seq_idx);  // [num_seqs, num_heads, head_size]
+    const auto gK = [&]() {
+      auto l_raw = make_layout(make_shape(Int<x>{}, Int<PageSize>{}, Int<HeadSize / x>{}, num_kv_heads, num_pages));
+      auto l = group<1, 3>(select<1, 0, 2, 3, 4>(l_raw));  // [page_size, (x * head_size/x), num_kv_heads, num_pages]
+      return make_tensor(make_gmem_ptr(k_cache), l)(/*tok_idx_in_page*/ _, /*dim_idx_in_head*/ _, kv_head_idx, /*physical_page_id*/ _);
+    }();
+    const auto gV = [&]() {
+      auto l = select<1, 0, 2, 3>(make_layout(make_shape(Int<PageSize>{}, Int<HeadSize>{}, num_kv_heads, num_pages)));
+      return make_tensor(make_gmem_ptr(v_cache), l)(/*dim_idx_in_head*/ _, /*tok_idx_in_page*/ _, kv_head_idx, /*physical_page_id*/ _);
+    }();
+    const auto gSB = [&]() {
+      if constexpr (HasSB) {
+        auto l = make_layout(make_shape(Int<PageSize * ScaleBiasNumChunks * 2>{}, _1{}, num_kv_heads, _2{}, num_pages));
+        return make_tensor(make_gmem_ptr(kv_scalebias), l)(/*copy_dim*/ _, /*cute_bug_workaround*/ _, kv_head_idx, /*k_or_v*/ _, /*physical_page_id*/ _);
+      } else {
+        return Unused();
+      }
+    }();
+    // K: (tok_idx_in_page,(dim_idx_in_head),physical_page_id) -> val_idx
+    // V: (dim_idx_in_head,  tok_idx_in_page,physical_page_id) -> val_idx
+
+    auto [tSB_should_copy, tSB_copy_src, tSB_copy_dst] = [&]() {
+      if constexpr (HasSB) {
+        auto sSB = make_tensor(make_smem_ptr(sSB_buffer[warp_id()]), make_layout(make_shape(Int<PageSize * ScaleBiasNumChunks * 2>{}, _1{})));
+        auto cSB = make_identity_tensor(shape(sSB));
+        ScaleBiasWarpCopy tiled_copy{};
+        auto thr_copy = tiled_copy.get_thread_slice(lane_id());
+        const auto src_view = thr_copy.partition_S(gSB);
+        auto dst_view = thr_copy.partition_S(sSB);
+        auto coord = thr_copy.partition_S(cSB);
+        bool should_copy = elem_less(coord(_0{}, _0{}, _0{}), shape(cSB));
+        static_assert(size<1>(src_view) == 1 && size<2>(src_view) == 1);
+        static_assert(size<1>(dst_view) == 1 && size<2>(dst_view) == 1);
+        // static_assert(rank(coord) == 1);
+        return std::make_tuple(
+            should_copy,
+            coalesce(src_view(_, /*iter0*/ _0{}, /*iter1*/ _0{}, /*k_or_v*/ _, /*physical_page_id*/ _), make_shape(_1{}, _1{}, _1{})),
+            coalesce(dst_view(_, /*iter0*/ _0{}, /*iter1*/ _0{}))
+        );
+      } else {
+        return std::make_tuple(false, Unused(), Unused());
+      }
+    }();
+    auto tSB_copy_staging = make_tensor<TSB>(Int<ScaleBiasCopyValPerThread>{});
+    auto sSB = make_tensor(
+        make_smem_ptr(sSB_buffer[warp_id()]),
+        Layout<Shape<Int<PageSize>, Shape<Int<KVConfig::ChunkSize>, Int<ScaleBiasNumChunks>>, _2>, Stride<_1, Stride<_0, Int<PageSize>>, Int<PageSize * ScaleBiasNumChunks>>>{}
+    );
+
+    const auto gPageTable = make_tensor(make_gmem_ptr(page_table), make_layout(make_shape(num_seqs, max_num_pages_per_seq), LayoutRight{}));
+    const auto ctaSeqPageTable = gPageTable(seq_idx, _);
+
+    // cooperative load q to sA (sQ)
+    constexpr const auto SmemQLayout = make_layout(make_shape(Int<HeadSize>{}, Int<Config::NumQueriesPerCta>{}));
+    __shared__ TQ sQ_buffer[cosize(SmemQLayout)];
+    {
+      auto sQ = make_tensor(make_smem_ptr(sQ_buffer), SmemQLayout);
+      auto cQ = make_identity_tensor(shape(SmemQLayout));
+      constexpr int QLoadVec = cute::min(next_power_of_two(ceil_div(size(SmemQLayout), NumThreads)), 8);  // load n elems per thread
+      static_assert(HeadSize % QLoadVec == 0);
+      constexpr int ThrD = HeadSize / QLoadVec;
+      constexpr int ThrH = ceil_div(NumThreads, ThrD);
+      constexpr int ValD = QLoadVec;
+      constexpr int ValH = 1;
+      const auto tiled_copy = make_tiled_copy(
+          Copy_Atom<UniversalCopy<TQ>, TQ>{},
+          make_layout(make_shape(Int<ThrD>{}, Int<ThrH>{})),
+          make_layout(make_shape(Int<ValD>{}, Int<ValH>{}))
+      );
+      const auto thr_copy = tiled_copy.get_thread_slice(threadIdx.x);
+      const auto ctaQ = local_tile(gQ, SmemQLayout.shape(), make_coord(_0{}, head_idx / Config::NumQueriesPerCta));
+      const auto thr_cQ = thr_copy.partition_S(cQ);
+      const auto thr_ld = thr_copy.partition_S(ctaQ);
+      auto thr_st = thr_copy.partition_D(sQ);
+      CUTE_UNROLL
+      for (int i = 0; i < size<1>(thr_ld); i++) {
+        CUTE_UNROLL
+        for (int j = 0; j < size<2>(thr_ld); j++) {
+          if (elem_less(thr_cQ(_0{}, i, j), shape(sQ))) {
+            copy(thr_ld, thr_st);
+          }
+        }
+      }
+      cp_async_fence();
+      cp_async_wait<0>();
+      __syncthreads();
+    }
+
+    const auto gemv1_thr_copy = Gemv1TiledCopy{}.get_thread_slice(lane_id());
+    const auto gemv2_thr_copy = Gemv2TiledCopy{}.get_thread_slice(lane_id());
+
+    // gemv1 A
+    const auto gemv1_sA = make_tensor(make_smem_ptr(sQ_buffer), Layout<Shape<_1, Int<HeadSize>, Int<Config::NumQueriesPerCta>>, Stride<_0, _1, Int<HeadSize>>>{});
+    const auto gemv1_tA_view = gemv1_thr_copy.partition_S(gemv1_sA);
+    // gemv1 B
+    const auto gemv1_page_coord = make_identity_tensor(make_shape(Int<PageSize>{}, Int<HeadSize>{}));
+    const auto gemv1_tB_view = gemv1_thr_copy.partition_S(gK);                 // (val,j,p,physical_page_id) -> idx
+    const auto gemv1_tB_coord = gemv1_thr_copy.partition_S(gemv1_page_coord);  // (val,j,p)                  -> coord
+    const auto gemv1_tSB_view = [&]() {
+      if constexpr (HasSB) {
+        return gemv1_thr_copy.partition_S(sSB);
+      } else {
+        return Unused();
+      }
+    }();
+
+    // gemv2 A
+    TQ* attn_scores_ptr = reinterpret_cast<TQ*>(&logits_or_attn_scores_buffer[0]);
+    auto attn_scores = make_tensor(make_smem_ptr(attn_scores_ptr), Layout<Shape<Int<Config::TaskChunkSeqLen>, Int<Config::NumQueriesPerCta>>>{});
+    const auto gemv2_sA = make_tensor(make_smem_ptr(attn_scores_ptr), Layout<Shape<_1, Int<PageSize>, Int<NumPagesPerTaskChunk>, Int<Config::NumQueriesPerCta>>>{});
+    const auto gemv2_tA_view = gemv2_thr_copy.partition_S(gemv2_sA);
+    // gemv2 B
+    const auto gemv2_page_coord = make_identity_tensor(make_shape(Int<HeadSize>{}, Int<PageSize>{}));                  // (n,k)
+    const auto gemv2_tB_view = coalesce(gemv2_thr_copy.partition_S(gV), make_shape(_1{}, _1{}, _1{}, _1{}));           // (val,j,p,physical_page_id) -> idx
+    const auto gemv2_tB_coord = coalesce(gemv2_thr_copy.partition_S(gemv2_page_coord), make_shape(_1{}, _1{}, _1{}));  // (val,j,p)                  -> coord
+    const auto gemv2_tSB_view = [&]() {
+      if constexpr (HasSB) {
+        auto sSB_gemv2_nk = make_tensor(sSB.data(), select<1, 0, 2>(sSB.layout()));
+        return gemv2_thr_copy.partition_S(sSB_gemv2_nk);
+      } else {
+        return Unused();
+      }
+    }();
+    static_assert(rank(gemv2_tB_view) == 4 && size<2>(gemv2_tB_view) == 1, "iter mode p is assumed to be 1");
+    static_assert(rank(gemv2_tB_coord) == 3 && size<2>(gemv2_tB_coord) == 1, "iter mode p is assumed to be 1");
+
+    bool is_first_iter = true;
+    constexpr int NumLpidPreloadPerThread = ceil_div(NumPagesPerTaskChunk, NumThreads);
+    auto next_lpids = make_tensor<int>(Int<NumLpidPreloadPerThread>{});
+    auto next_chunk = int2{-1, -1};
+    worker->take_work(next_chunk.x, next_chunk.y);
+
+    while (true) {
+      worker->broadcast_work(broadcast_buffer, next_chunk.x, next_chunk.y);
+      int2 chunk = next_chunk;
+      if (chunk.x >= chunk.y) {
+        break;
+      }
+      if (threadIdx.x < Config::NumQueriesPerCta) {
+        chunk_max_sum[threadIdx.x] = float2{std::numeric_limits<float>::lowest(), 0.0f};
+      }
+
+      int chunk_start_tok_idx = max(chunk.x * Config::TaskChunkSeqLen, 0);
+      int chunk_end_tok_idx = min(chunk.y * Config::TaskChunkSeqLen, num_tokens);
+      int chunk_start_logical_page_id = chunk_start_tok_idx / PageSize;
+      int chunk_end_logical_page_id = ceil_div(chunk_end_tok_idx, PageSize);
+
+      TASK_DPRINTF1(
+          "  worker[%d]: work on tok[%d,%d) of seq:%d, head:%d, kv_head:%d\n",
+          worker->worker_id(), chunk_start_tok_idx, chunk_end_tok_idx, seq_idx, head_idx, kv_head_idx
+      );
+
+      static_assert(NumPagesPerTaskChunk <= NumLpidPreloadPerThread * NumThreads);
+      if (const int lid_in_chunk = NumLpidPreloadPerThread * threadIdx.x; lid_in_chunk < NumPagesPerTaskChunk) {
+        if (!is_first_iter) {
+          CUTE_UNROLL
+          for (int i = 0; i < NumLpidPreloadPerThread; i++) {
+            chunk_page_table[lid_in_chunk + i] = next_lpids(i);
+          }
+        } else {
+          // if is first chunk, load current page table
+          CUTE_UNROLL
+          for (int i = 0; i < NumLpidPreloadPerThread; i++) {
+            chunk_page_table[lid_in_chunk + i] =
+                chunk_start_logical_page_id + lid_in_chunk + i < chunk_end_logical_page_id
+                    ? ctaSeqPageTable(chunk_start_logical_page_id + lid_in_chunk + i)
+                    : -1;
+          }
+        }
+      }
+      is_first_iter = false;
+      __syncthreads();
+
+      BaseTask::template load_sb_to_reg<0>(tSB_copy_src, tSB_should_copy, chunk_page_table[warp_id()], tSB_copy_staging);
+      // output for first GEMV
+      float* logits_ptr = &logits_or_attn_scores_buffer[0];
+      auto logits = make_tensor(make_smem_ptr(logits_ptr), Layout<Shape<Int<Config::TaskChunkSeqLen>, Int<Config::NumQueriesPerCta>>>{});
+      auto qk_max = make_tensor<float>(Int<Config::NumQueriesPerCta>{});
+      fill(qk_max, std::numeric_limits<float>::lowest());
+#pragma unroll 1
+      for (int lid_in_chunk = warp_id(); lid_in_chunk < NumPagesPerTaskChunk; lid_in_chunk += NumWarps) {
+        const int64_t physical_page_id = chunk_page_table[lid_in_chunk];
+        const int64_t next_physical_page_id = lid_in_chunk + NumWarps < NumPagesPerTaskChunk ? chunk_page_table[lid_in_chunk + NumWarps] : -1;
+        store_sb_to_smem(tSB_copy_staging, tSB_should_copy, physical_page_id, tSB_copy_dst);                           // if curr is valid, store
+        BaseTask::template load_sb_to_reg<0>(tSB_copy_src, tSB_should_copy, next_physical_page_id, tSB_copy_staging);  // if next is valid, load
+        if (physical_page_id == -1) {
+          continue;
+        }
+
+        const auto tA_view = gemv1_tA_view;
+        auto tA = make_tensor_like(gemv1_tA_view(_, _0{}, _0{}, _0{}));
+
+        const auto tB_view = gemv1_tB_view(_, _, _, physical_page_id);
+        const auto tSB_view = gemv1_tSB_view;
+        static_assert(size<1>(gemv1_tB_view) == 1);  // IterN over PageSize can be omitted
+        auto tB = make_fragment_like<TQ>(tB_view(_, _0{}, _0{}));
+
+        auto qk = make_tensor<float>(Int<Config::NumQueriesPerCta>{});
+        clear(qk);
+        CUTE_UNROLL
+        for (int p = 0; p < size<2>(tB_view); p++) {  // IterK over HeadSize
+          if (elem_less(gemv1_tB_coord(_0{}, _0{}, p), shape(gemv1_page_coord))) {
+            BaseTask::template load_tB(tB, tB_view(_, _0{}, p), tSB_view(_, _0{}, p, _));
+            CUTE_UNROLL
+            for (int i = 0; i < Config::NumQueriesPerCta; i++) {
+              copy(AutoVectorizingCopyWithAssumedAlignment<cute::min(8 * sizeof(TQ) * size(tA), 128)>{}, tA_view(_, _0{}, p, i), tA);
+              qk(i) += inner_product<float>(tA, tB);
+              schedule_barrier();
+            }
+          }
+        }
+        auto tid_in_group = get<1>(Gemv1ThrLayout{}.get_hier_coord(int(threadIdx.x)));
+        auto tok_idx_in_page = get<0>(gemv1_tB_coord(_0{}, _0{}, _0{}));
+        const int token_idx = (chunk_start_logical_page_id + lid_in_chunk) * PageSize + tok_idx_in_page;
+        CUTE_UNROLL
+        for (int i = 0; i < Config::NumQueriesPerCta; i++) {
+          qk(i) *= scale;
+          // reduce in thread group to get the full qk
+          qk(i) = warp::reduce<Gemv1ThrK, /*Strided=*/Gemv1TransThrLayout>(qk(i), [](float a, float b) { return a + b; });
+          qk(i) += alibi_slopes ? alibi_slopes_smem[i] * (token_idx - num_tokens + 1) : 0;
+          if (tid_in_group == 0) {
+            logits(token_idx % Config::TaskChunkSeqLen, i) = token_idx < num_tokens ? qk(i) : 0.f;  // TODO: start boundary
+            qk_max(i) = token_idx < num_tokens ? fmaxf(qk_max(i), qk(i)) : qk_max(i);
+          }
+        }
+      }
+
+      if constexpr (!Config::SingleChunk) {
+        if (const int lid_in_chunk = NumLpidPreloadPerThread * threadIdx.x; lid_in_chunk < NumPagesPerTaskChunk) {
+          // proactively load next page table for next chunk, even though maybe wasted due to stealing, or out of bound
+          CUTE_UNROLL
+          for (int i = 0; i < NumLpidPreloadPerThread; i++) {
+            next_lpids(i) = chunk_start_logical_page_id + NumPagesPerTaskChunk + lid_in_chunk + i < ceil_div(num_tokens, PageSize)
+                                ? ctaSeqPageTable(chunk_start_logical_page_id + NumPagesPerTaskChunk + lid_in_chunk + i)
+                                : -1;
+          }
+        }
+      }
+
+      // reuse broadcast buffer for reduction
+      static_assert(2 * NumWarps <= (BROADCAST0_BUFFER_SIZE_IN_BYTES / sizeof(float)));
+      int prefix = chunk_start_tok_idx - (chunk_start_tok_idx % Config::TaskChunkSeqLen);
+      CUTE_UNROLL
+      for (int i = 0; i < Config::NumQueriesPerCta; i++) {
+        softmax_cta<NumThreads, Gemv1ThrK, NumWarps>(
+            static_cast<float*>(broadcast_buffer), qk_max(i), &logits(_0{}, i),
+            Config::TaskChunkSeqLen,
+            chunk_start_tok_idx - prefix,
+            chunk_end_tok_idx - prefix,
+            &chunk_max_sum[i]
+        );
+      }
+      inplace_convert_attn_scores(logits, attn_scores);
+
+      if constexpr (!Config::SingleChunk) {
+        next_chunk = {-1, -1};
+        worker->take_work(next_chunk.x, next_chunk.y);
+      }
+
+      BaseTask::template load_sb_to_reg<1>(tSB_copy_src, tSB_should_copy, chunk_page_table[warp_id()], tSB_copy_staging);
+      auto acc = make_tensor<float>(make_shape(Int<size<1>(gemv2_tB_view)>{}, Int<Config::NumQueriesPerCta>{}));
+      clear(acc);
+      int num_pages_in_chunk = chunk_end_logical_page_id - chunk_start_logical_page_id;
+#pragma unroll 1
+      for (int lid_in_chunk = warp_id(); lid_in_chunk < num_pages_in_chunk; lid_in_chunk += NumWarps) {
+        const int64_t physical_page_id = chunk_page_table[lid_in_chunk];
+        const int64_t next_physical_page_id = lid_in_chunk + NumWarps < NumPagesPerTaskChunk ? chunk_page_table[lid_in_chunk + NumWarps] : -1;
+        store_sb_to_smem(tSB_copy_staging, tSB_should_copy, physical_page_id, tSB_copy_dst);                           // if curr is valid, store
+        BaseTask::template load_sb_to_reg<1>(tSB_copy_src, tSB_should_copy, next_physical_page_id, tSB_copy_staging);  // if next is valid, load
+
+        const auto tA_view = filter_zeros(gemv2_tA_view(_, _, _, lid_in_chunk, _))(_, _1{}, _1{}, _);
+        const auto tB_view = gemv2_tB_view(_, _, _0{}, physical_page_id);
+        const auto tB_coord = gemv2_tB_coord(_, _, _0{});
+        const auto tSB_view = [&]() {
+          if constexpr (HasSB) {
+            return gemv2_tSB_view(_, _, _0{}, _);
+          } else {
+            return Unused();
+          }
+        }();
+
+        static_assert(rank(tA_view) == 2);
+        static_assert(size<1>(gemv2_tB_view) == size<0>(acc));
+        static_assert(size<2>(gemv2_tB_view) == 1);  // IterK over PageSize can be omitted
+
+        auto tA = make_fragment_like(tA_view(_, _0{}));
+        auto tB = make_fragment_like<TQ>(tB_view(_, _0{}));
+
+        bool is_full_chunk = chunk_end_tok_idx - chunk_start_tok_idx == Config::TaskChunkSeqLen;
+        bool is_full_page = lid_in_chunk != 0 && lid_in_chunk != num_pages_in_chunk - 1;
+        if (is_full_chunk || is_full_page) {
+          CUTE_UNROLL
+          for (int j = 0; j < size<1>(tB_view); j++) {
+            if (elem_less(tB_coord(_0{}, j), shape(gemv2_page_coord))) {
+              BaseTask::template load_tB(tB, tB_view(_, j), tSB_view(_, j, _));
+              CUTE_UNROLL
+              for (int i = 0; i < Config::NumQueriesPerCta; i++) {
+                copy(AutoVectorizingCopyWithAssumedAlignment<cute::min(8 * sizeof(float) * Gemv2ValK, 128)>{}, tA_view(_, i), tA);
+                acc(j, i) += inner_product<float>(tA, tB);
+                schedule_barrier();
+              }
+            }
+          }
+        } else {
+          enforce_uniform();
+          auto token_idx_in_page = get<1>(tB_coord(_0{}, _0{}));
+          auto logical_page_id = chunk_start_logical_page_id + lid_in_chunk;
+          int valid_tokens = num_tokens - (logical_page_id * PageSize + token_idx_in_page);
+
+          auto pred = make_tensor_like<bool>(tA);
+          CUTE_UNROLL
+          for (int p = 0; p < size(pred); p++) {
+            pred(p) = p < valid_tokens;
+          }
+
+          auto masked_tB = make_fragment_like(tB);
+
+          CUTE_UNROLL
+          for (int j = 0; j < size<1>(tB_view); j++) {
+            if (elem_less(tB_coord(_0{}, j), shape(gemv2_page_coord))) {
+              BaseTask::template load_tB(tB, tB_view(_, j), tSB_view(_, j, _));
+              copy_if(pred, tB, masked_tB);
+              CUTE_UNROLL
+              for (int i = 0; i < Config::NumQueriesPerCta; i++) {
+                copy(AutoVectorizingCopyWithAssumedAlignment<cute::min(8 * sizeof(float) * Gemv2ValK, 128)>{}, tA_view(_, i), tA);
+                acc(j, i) += inner_product<float>(tA, masked_tB);
+              }
+            }
+          }
+        }
+      }
+
+      CUTE_UNROLL
+      for (int i = 0; i < Config::NumQueriesPerCta; i++) {
+        CUTE_UNROLL
+        for (int v = 0; v < size<0>(acc); v++) {
+          acc(v, i) = warp::reduce<Gemv2ThrK>(acc(v, i), [](float a, float b) { return a + b; });
+        }
+      }
+
+      __syncthreads();  // sync to reuse logits
+      auto& chunk_out = logits;
+      static_assert(HeadSize <= Config::TaskChunkSeqLen);
+
+      constexpr auto OutThrCoord = make_identity_tensor(make_shape(Int<Gemv2ThrK>{}, Int<Gemv2ThrN>{}));
+      const auto thr_coord = OutThrCoord(lane_id());
+      const auto thr_k = get<0>(thr_coord);  // thr_k == 0 is the leading threads in previous warp reduction
+      const auto thr_n = get<1>(thr_coord);
+
+      if (warp_id() == 0 && thr_k == 0) {
+        CUTE_UNROLL
+        for (int v = 0; v < size<0>(acc); v++) {
+          int dim_idx = thr_n + v * Gemv2ThrN;  // strided
+          if (dim_idx < HeadSize) {
+            CUTE_UNROLL
+            for (int i = 0; i < Config::NumQueriesPerCta; i++) {
+              chunk_out(dim_idx, i) = acc(v, i);
+            }
+          }
+        }
+      }
+      __syncthreads();
+      CUTE_UNROLL
+      for (int warp = 1; warp < NumWarps; warp++) {
+        if (warp_id() == warp && thr_k == 0) {
+          CUTE_UNROLL
+          for (int v = 0; v < size<0>(acc); v++) {
+            int dim_idx = thr_n + v * Gemv2ThrN;  // strided
+            if (dim_idx < HeadSize) {
+              CUTE_UNROLL
+              for (int i = 0; i < Config::NumQueriesPerCta; i++) {
+                chunk_out(dim_idx, i) += acc(v, i);
+              }
+            }
+          }
+        }
+        __syncthreads();
+      }
+
+      CUTE_UNROLL
+      for (int i = 0; i < Config::NumQueriesPerCta; i++) {
+        flash_acc(smem_out[i], &smem_max_sum[i], &chunk_out(_0{}, i), &chunk_max_sum[i]);
+      }
+      if constexpr (Config::SingleChunk) {
+        break;
+      }
+    }
+
+    __syncthreads();
+    for (int i = 0; i < Config::NumQueriesPerCta; ++i) {
+      int max_sum_idx = [&]() {
+        if constexpr (Config::UseHeadSeq) {
+          return (head_idx + i) * Config::MaxNumSeqs + seq_idx;
+        } else {
+          return seq_idx * num_heads + (head_idx + i);
+        }
+      }();
+      TO* gmem_out = &gO(_0{}, head_idx + i);
+      if constexpr (Config::InplaceFlashAcc) {
+        atomic_flash_acc(broadcast_buffer, gmem_out, &out_max_sum[max_sum_idx], smem_out[i], &smem_max_sum[i]);
+      } else {
+        write_flash_inc(gmem_out, out_max_sum ? &out_max_sum[max_sum_idx] : nullptr, smem_out[i], &smem_max_sum[i]);
+      }
+    }
+  }
+
+protected:
+  using BaseTask::NumWarps;
+  using BaseTask::x;
+
+  using BaseTask::Gemv1ThrK;
+  using BaseTask::Gemv1ThrN;
+  using BaseTask::Gemv1TransThrLayout;
+  using BaseTask::Gemv1ValK;
+  using BaseTask::Gemv1ValN;
+  using Gemv1ThrLayout = typename BaseTask::Gemv1ThrLayout;
+  using Gemv1TiledCopy = typename BaseTask::Gemv1TiledCopy;
+
+  using BaseTask::Gemv2ThrK;
+  using BaseTask::Gemv2ThrN;
+  using BaseTask::Gemv2ValK;
+  using BaseTask::Gemv2ValN;
+  using Gemv2TiledCopy = typename BaseTask::Gemv2TiledCopy;
+
+  using BaseTask::ScaleBiasCopyValPerThread;
+  using BaseTask::ScaleBiasNumChunks;
+  using ScaleBiasWarpCopy = typename BaseTask::ScaleBiasWarpCopy;
+
+  using BaseTask::store_sb_to_smem;
+};
+
+}  // namespace onnxruntime::contrib::paged
+
+#ifdef DUMMY_TASK_DPRINTF1
+#undef DUMMY_TASK_DPRINTF1
+#undef TASK_DPRINTF1
+#endif

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_gqa_tc_sm80_task.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_gqa_tc_sm80_task.cuh
@@ -1,0 +1,493 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "cute/layout.hpp"
+#include "cute/tensor.hpp"
+
+#include "contrib_ops/cuda/bert/paged/algorithms.cuh"
+#include "contrib_ops/cuda/bert/paged/cuda_common.cuh"
+#include "contrib_ops/cuda/bert/paged/paged_attention/attention_common.cuh"
+#include "contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_task.cuh"
+#include "contrib_ops/cuda/bert/paged/type_convert.cuh"
+
+#ifndef TASK_DPRINTF1
+#define DUMMY_TASK_DPRINTF1(...)
+#define TASK_DPRINTF1 DUMMY_TASK_DPRINTF1
+#endif
+
+namespace onnxruntime::contrib::paged {
+
+template <int KSize, int NumElemsPerLoad, typename MMA_Atom>
+struct KVectorizeTiler {};
+
+template <int KSize, int NumElemsPerLoad>
+struct KVectorizeTiler<KSize, NumElemsPerLoad, SM80_16x8x8_F32F16F16F32_TN> {
+  // These are MMA_Atom dependent
+  static constexpr int MmaThrK = 4;  // 4 thr consecutive
+  static constexpr int MmaValK = 2;  // 2 val consecutive
+  static_assert(KSize % (MmaThrK * NumElemsPerLoad) == 0);
+
+  // shuffle and packed
+  static constexpr int NumMmaTilePacked = NumElemsPerLoad / MmaValK;
+  using Tiler = decltype(select<0, 2, 1, 3>(make_layout(Shape<_2, Int<NumMmaTilePacked>, _4, Int<KSize / (NumMmaTilePacked * 8)>>{})));
+};
+
+template <
+    int NumThreads,
+    int HeadSize,
+    int PageSize,
+    typename TI,
+    typename TO_,
+    typename TKV,
+    typename Worker,
+    typename Config,
+    typename KVConfig = DefaultKV>
+struct PagedGroupQueryAttentionTcSm80Task : public PagedAttentionTask<NumThreads, HeadSize, PageSize, TI, TO_, TKV, Worker, Config, KVConfig> {
+  static_assert(PageSize == 8 || PageSize == 16 || PageSize == 32);
+  static_assert(Config::NumQueriesPerCta == 8);
+
+  using BaseTask = PagedAttentionTask<NumThreads, HeadSize, PageSize, TI, TO_, TKV, Worker, Config, KVConfig>;
+  using TQ = TI;
+  using TO = TO_;
+  using TK = TKV;
+  using TV = TKV;
+  using TSB_ = typename BaseTask::TSB_;
+
+  using BaseTask::HasSB;
+  using TSB = typename BaseTask::TSB;
+
+  using TaskChunk = onnxruntime::contrib::paged::TaskChunk<Config::TaskChunkSeqLen, PageSize>;
+  using FlashAccCta = onnxruntime::contrib::paged::FlashAccCta<NumThreads, HeadSize>;
+  using FlashAccWarp = onnxruntime::contrib::paged::FlashAccWarp<NumThreads, HeadSize>;
+
+  static_assert(sizeof(TKV) <= 2, "not implemented for float kv");
+
+  __forceinline__ __device__ static void
+  attention(
+      void* __restrict__ broadcast_buffer,
+      Worker* __restrict__ worker,
+      const int seq_idx,
+      const int head_idx,
+      const int kv_head_idx,
+      TO* __restrict__ out,                    // [num_seqs, num_heads, head_size]
+      float2* __restrict__ out_max_sum,        // [num_seqs, num_heads], running max and sum of gmem out
+      const TI* __restrict__ q,                // [num_seqs, num_heads, head_size]
+      const TKV* __restrict__ k_cache,         // [num_pages, num_kv_heads, head_size/x, page_size, x]
+      const TKV* __restrict__ v_cache,         // [num_pages, num_kv_heads, head_size, page_size]
+      const TSB_* __restrict__ kv_scalebias,   // [num_pages, 2, num_kv_heads, 2, head_size/chunk_size, page_size], optional
+      const int* __restrict__ page_table,      // [num_seqs, max_num_pages_per_seq]
+      const int* __restrict__ context_lens,    // [num_seqs]
+      const float* __restrict__ alibi_slopes,  // [num_heads]
+      const float scale,
+      const int num_seqs,
+      const int num_heads,
+      const int num_kv_heads,
+      const int max_num_pages_per_seq,
+      const int q_stride
+  ) {
+    __shared__ int chunk_page_table[ceil_div(Config::TaskChunkSeqLen, PageSize)];
+    __align__(128) __shared__ float smem_out[Config::NumQueriesPerCta][HeadSize];
+    __shared__ float2 smem_max_sum[Config::NumQueriesPerCta];
+    __shared__ float2 chunk_max_sum[Config::NumQueriesPerCta];
+    __align__(128) __shared__ TSB sSB_buffer[NumWarps][PageSize * ScaleBiasNumChunks * 2];
+    __shared__ float alibi_slopes_smem[Config::NumQueriesPerCta];
+    __align__(128) __shared__ float logits_or_attn_scores_buffer[Config::NumQueriesPerCta * (Config::TaskChunkSeqLen + 4)];
+    static_assert(Config::NumQueriesPerCta * Config::TaskChunkSeqLen * sizeof(float) < 40 * 1024,
+                  "Kernels relying on shared memory allocations over 48 KB per block are architecture-specific,"
+                  "and must use dynamic shared memory rather than statically sized shared memory arrays.");
+
+    // zero-ing out __shared__ buffers
+    // attn_scores will be initialize by softmax_cta
+    // smem_out will not be loaded if sum in smem_max_sum is 0.0f
+    if (threadIdx.x < Config::NumQueriesPerCta) {
+      smem_max_sum[threadIdx.x] = float2{std::numeric_limits<float>::lowest(), 0.0f};
+      alibi_slopes_smem[threadIdx.x] = alibi_slopes == nullptr ? 0.f : alibi_slopes[head_idx + threadIdx.x];
+    }
+    // chunk_max_sum must be initialize per chunk-wise
+
+    const int num_tokens = context_lens[seq_idx];
+    const int64_t dummy_shape = 1073741824;  // 2^30, can be used for the slowest dim
+    const auto num_pages = dummy_shape;
+
+    auto gO = make_tensor(make_gmem_ptr(out), make_layout(make_shape(Int<HeadSize>{}, num_heads, num_seqs)))(_, _, seq_idx);                                                    // [num_seqs, num_heads, head_size]
+    const auto gQ = make_tensor(make_gmem_ptr(q), make_layout(make_shape(Int<HeadSize>{}, num_heads, num_seqs), make_stride(_1{}, Int<HeadSize>{}, q_stride)))(_, _, seq_idx);  // [num_seqs, num_heads, head_size]
+    const auto gK = [&]() {
+      auto l_raw = make_layout(make_shape(Int<x>{}, Int<PageSize>{}, Int<HeadSize / x>{}, num_kv_heads, num_pages));
+      auto l = group<1, 3>(select<1, 0, 2, 3, 4>(l_raw));  // [page_size, (x, head_size/x), num_kv_heads, num_pages]
+      return make_tensor(make_gmem_ptr(k_cache), l)(/*tok_idx_in_page*/ _, /*dim_idx_in_head*/ _, kv_head_idx, /*physical_page_id*/ _);
+    }();
+    const auto gV = [&]() {
+      auto l = select<1, 0, 2, 3>(make_layout(make_shape(Int<PageSize>{}, Int<HeadSize>{}, num_kv_heads, num_pages)));
+      return make_tensor(make_gmem_ptr(v_cache), l)(/*dim_idx_in_head*/ _, /*tok_idx_in_page*/ _, kv_head_idx, /*physical_page_id*/ _);
+    }();
+    const auto gSB = [&]() {
+      if constexpr (HasSB) {
+        auto l = make_layout(make_shape(Int<PageSize>{}, Int<ScaleBiasNumChunks>{}, _2{}, num_kv_heads, _2{}, num_pages));
+        auto t = make_tensor(make_gmem_ptr(kv_scalebias), l)(/*tok_idx_in_page*/ _, /*chunk_idx*/ _, /*s_or_b*/ _, kv_head_idx, /*k_or_v*/ _, /*physical_page_id*/ _);
+        return t.compose(_, Layout<Shape<Int<KVConfig::ChunkSize>, Int<ScaleBiasNumChunks>>, Stride<_0, _1>>{}, _, _, _);
+      } else {
+        return Unused();
+      }
+    }();
+    auto gKSB = gSB(_, _, _, _0{}, _);
+    auto gVSB = [&]() {
+      if constexpr (HasSB) {
+        return select_tensor<1, 0, 2, 3>(gSB(_, _, _, _1{}, _));
+      } else {
+        return Unused();
+      }
+    }();
+
+    const auto seq_page_table = &(make_tensor(make_gmem_ptr(page_table), make_layout(make_shape(num_seqs, max_num_pages_per_seq), LayoutRight{}))(seq_idx, _0{}));
+
+    // cooperative load q to sA (sQ)
+    // constexpr const auto SmemQLayout = make_layout(make_shape(Int<Config::NumQueriesPerCta>{}, Int<HeadSize>{}), LayoutRight{});
+    constexpr const auto SmemQLayout = make_layout(make_shape(Int<Config::NumQueriesPerCta>{}, Int<HeadSize>{}), make_stride(Int<HeadSize + 8>{}, _1{}));
+    __align__(128) __shared__ TQ sQ_buffer[cosize(SmemQLayout)];
+    auto sQ = make_tensor(make_smem_ptr(sQ_buffer), SmemQLayout);
+    {
+      auto sQ = make_tensor(make_smem_ptr(sQ_buffer), select<1, 0>(SmemQLayout));  // transposed view for copy
+      auto cQ = make_identity_tensor(sQ.shape());
+      constexpr int QLoadVec = cute::min(next_power_of_two(ceil_div(size(sQ.shape()), NumThreads)), 8);  // load n elems per thread
+      static_assert(HeadSize % QLoadVec == 0);
+      constexpr int ThrD = HeadSize / QLoadVec;
+      constexpr int ThrH = ceil_div(NumThreads, ThrD);
+      constexpr int ValD = QLoadVec;
+      constexpr int ValH = 1;
+      const auto tiled_copy = make_tiled_copy(
+          Copy_Atom<UniversalCopy<TQ>, TQ>{},
+          make_layout(make_shape(Int<ThrD>{}, Int<ThrH>{})),
+          make_layout(make_shape(Int<ValD>{}, Int<ValH>{}))
+      );
+      const auto thr_copy = tiled_copy.get_thread_slice(threadIdx.x);
+      const auto ctaQ = local_tile(gQ, sQ.shape(), make_coord(_0{}, head_idx / Config::NumQueriesPerCta));
+      const auto thr_cQ = thr_copy.partition_S(cQ);
+      const auto thr_ld = thr_copy.partition_S(ctaQ);
+      auto thr_st = thr_copy.partition_D(sQ);
+      CUTE_UNROLL
+      for (int i = 0; i < size<1>(thr_ld); i++) {
+        CUTE_UNROLL
+        for (int j = 0; j < size<2>(thr_ld); j++) {
+          if (elem_less(thr_cQ(_0{}, i, j), shape(sQ))) {
+            copy(thr_ld(_, i, j), thr_st(_, i, j));
+          }
+        }
+      }
+      cp_async_fence();
+      cp_async_wait<0>();
+      __syncthreads();
+    }
+
+    float* logits_ptr = &logits_or_attn_scores_buffer[0];
+    using LogitsLayout = Layout<Shape<Int<Config::TaskChunkSeqLen>, Int<Config::NumQueriesPerCta>>, Stride<_1, Int<Config::TaskChunkSeqLen + 4>>>;
+    auto logits = make_tensor(make_smem_ptr(logits_ptr), LogitsLayout{});
+    auto cL = make_identity_tensor(shape(logits));
+    auto logits_paged = coalesce_tensor(flat_divide(logits, make_tile(Int<PageSize>{}, Int<Config::NumQueriesPerCta>{})));  // (tid_in_page,hidx_in_group,lpid)
+    auto cL_paged = coalesce_tensor(flat_divide(cL, make_tile(Int<PageSize>{}, Int<Config::NumQueriesPerCta>{})));          // (tid_in_page,hidx_in_group,lpid)
+
+    auto tiled_mma1 = make_tiled_mma(SM80_16x8x8_F32F16F16F32_TN{});
+    auto thr_mma1 = tiled_mma1.get_thread_slice(lane_id());
+    using KVectorizeTiler1 = KVectorizeTiler<HeadSize, 4, SM80_16x8x8_F32F16F16F32_TN>;
+    constexpr auto KTiler1 = typename KVectorizeTiler1::Tiler{};
+    auto tCgK = thr_mma1.partition_A(gK.compose(_, KTiler1, _));  // GEMM1 A
+    auto tCsQ = thr_mma1.partition_B(sQ.compose(_, KTiler1));     // GEMM1 B
+    auto tCsL = thr_mma1.partition_C(logits_paged);               // GEMM1 C
+    auto tCcL = thr_mma1.partition_C(cL_paged);                   // GEMM1 C coord
+    auto tCgKSB = [&]() {
+      if constexpr (HasSB) {
+        constexpr int HeadSizePadded = ceil_div(HeadSize, KVConfig::ChunkSize) * KVConfig::ChunkSize;
+        using KVectorizeTiler1Padded = KVectorizeTiler<HeadSizePadded, 4, SM80_16x8x8_F32F16F16F32_TN>;
+        constexpr auto KTiler1 = typename KVectorizeTiler1Padded::Tiler{};
+        return thr_mma1.partition_A(gKSB.compose(_, KTiler1, _, _));
+      } else {
+        return Unused();
+      }
+    }();
+
+    float* attn_scores_ptr = &logits_or_attn_scores_buffer[0];
+    using AttnScoresLayout = Layout<Shape<Int<PageSize>, Int<Config::TaskChunkSeqLen / PageSize>, Int<Config::NumQueriesPerCta>>, Stride<_1, Int<PageSize>, Int<Config::TaskChunkSeqLen + 4>>>;
+    auto attn_scores = make_tensor(make_smem_ptr(attn_scores_ptr), AttnScoresLayout{});
+
+    auto tiled_mma2 = make_tiled_mma(SM80_16x8x8_F32F16F16F32_TN{});
+    auto thr_mma2 = tiled_mma2.get_thread_slice(lane_id());
+    constexpr bool Gemm2IsFullMma = PageSize % 16 == 0;  // otherwise, half of mma input and out is valid
+    using KVectorizeTiler2 = KVectorizeTiler<PageSize, Gemm2IsFullMma ? 4 : 2, SM80_16x8x8_F32F16F16F32_TN>;
+    constexpr auto KTiler2 = typename KVectorizeTiler2::Tiler{};
+    auto tCgV = thr_mma2.partition_A(gV.compose(_, KTiler2, _));
+    auto tCsS = thr_mma2.partition_B(select_tensor<2, 0, 1>(attn_scores).compose(_, KTiler2, _));
+    auto tCgVSB = [&]() {
+      if constexpr (HasSB) {
+        return thr_mma2.partition_A(gVSB.compose(_, KTiler2, _, _));
+      } else {
+        return Unused();
+      }
+    }();
+
+    static_assert(HeadSize <= Config::TaskChunkSeqLen);
+    auto chunk_out = logits.compose(make_tile(Int<HeadSize>{}, _));  // reuse logits as chunk_out
+    auto tCsO = thr_mma2.partition_C(chunk_out);
+
+    constexpr int NumPidsPreloadPerThread = ceil_div(TaskChunk::NumPages, NumThreads);
+    static_assert(TaskChunk::NumPages <= NumPidsPreloadPerThread * NumThreads);
+    auto preload_pids = make_tensor<int>(Int<NumPidsPreloadPerThread>{});
+
+    TaskChunk chunk{-1, -1};
+    worker->take_work(chunk.start, chunk.end);
+    worker->broadcast_work(broadcast_buffer, chunk.start, chunk.end);
+    chunk.preload_page_table_for_chunk<0>(seq_page_table, preload_pids, 0, num_tokens);
+
+    while (chunk.is_valid()) {
+      TASK_DPRINTF1(
+          "  worker[%d]: work on tok[%d,%d) of seq:%d, head:%d, kv_head:%d\n",
+          worker->worker_id(), chunk.start_tok_idx(0), chunk.end_tok_idx(num_tokens), seq_idx, head_idx, kv_head_idx
+      );
+
+      if (threadIdx.x == 0) {
+        *chunk_max_sum = float2{std::numeric_limits<float>::lowest(), 0.0f};
+      }
+      chunk.commit_preloaded_page_table(preload_pids, chunk_page_table);
+      __syncthreads();
+
+      // GEMM1 ---------------------------------------------------------------------------------------------------------
+      for (int lid_in_chunk = warp_id(); lid_in_chunk < TaskChunk::NumPages; lid_in_chunk += NumWarps) {
+        const int64_t physical_page_id = chunk_page_table[lid_in_chunk];
+        if (physical_page_id == -1) {
+          continue;
+        }
+
+        auto tCgK_page = tCgK(_, _, _, physical_page_id);
+        auto tCgK_vec_view = tiled_divide(tCgK_page, make_tile(make_tile(_2{}, _1{}), _1{}, Int<KVectorizeTiler1::NumMmaTilePacked>{}));  // ((Frag),(FragIters...), IterM, IterK)
+        auto tCgK_vec0 = make_tensor_like<half>(tCgK_vec_view(_, make_coord(_0{}, _0{}), _, _0{}));                                       // ((HalfFrag),IterM)
+        auto tCgK_vec1 = make_tensor_like<half>(tCgK_vec_view(_, make_coord(_0{}, _0{}), _, _0{}));                                       // ((HalfFrag),IterM)
+        auto tCgKSB_vec_view = [&]() {                                                                                                    // ((Frag),(FragIters...), IterM, IterK,SB)
+          if constexpr (HasSB) {
+            auto tCgKSB_page = tCgKSB(_, _, _, /*s_or_b*/ _, physical_page_id);
+            return tiled_divide(tCgKSB_page, make_tile(make_tile(_2{}, _1{}), _1{}, Int<KVectorizeTiler1::NumMmaTilePacked>{}));
+          } else {
+            return Unused();
+          }
+        }();
+
+        auto tCrA = thr_mma1.make_fragment_A(append_tensor<3>(tCgK(/*Frag*/ _, /*IterM*/ _, /*IterK*/ _0{}, /*lpid*/ _0{})));
+        auto tCrB = thr_mma1.make_fragment_B(append_tensor<3>(tCsQ(/*Frag*/ _, /*IterN*/ _, /*IterK*/ _0{})));
+        auto tCrC = thr_mma1.make_fragment_C(append_tensor<3>(tCsL(/*Frag*/ _, /*IterM*/ _, /*IterN*/ _, /*lpid*/ _0{})));
+
+        clear(tCrC);
+        if constexpr (!Gemm2IsFullMma) {
+          clear(tCgK_vec1);
+        }
+        for_each(make_int_sequence<size<3>(tCgK_vec_view)>{}, [&](auto p) {
+          if constexpr (!HasSB) {  // direct copy
+            copy(tCgK_vec_view(_, make_coord(_0{}, _0{}), _, p), tCgK_vec0);
+            if constexpr (Gemm2IsFullMma) {
+              copy(tCgK_vec_view(_, make_coord(_0{}, _1{}), _, p), tCgK_vec1);
+            }
+          } else {  // copy then dequantize
+            auto copy_then_dequantize = [&](auto&& half_frag_idx, auto& out) {
+              auto tCgK_copy = make_tensor_like<TK>(tCgK_vec0);
+              auto tCgKSB_vec = make_tensor_like(tCgKSB_vec_view(_, make_coord(_0{}, _0{}), _, _0{}, /*s_or_b*/ _));
+              copy(tCgK_vec_view(_, make_coord(_0{}, half_frag_idx), _, p), tCgK_copy);
+              copy(tCgKSB_vec_view(_, make_coord(_0{}, half_frag_idx), _, p, _), tCgKSB_vec);
+#if 0
+              // FIXME: slow and incorrect! incorrectness is cause by recast in tensor_convert
+              tensor_convert(tCgK_copy, tCgKSB_vec(_, _, _0{}), tCgKSB_vec(_, _, _1{}), out);
+#else
+              // scalebias must be broadcasting
+              static_assert(layout(tCgKSB_vec)(_0{}) == layout(tCgKSB_vec)(_1{}));
+              static_assert(layout(tCgKSB_vec)(_0{}) == layout(tCgKSB_vec)(_2{}));
+              static_assert(layout(tCgKSB_vec)(_0{}) == layout(tCgKSB_vec)(_3{}));
+
+              const auto tCgK_copy4 = recast<array<float_e4m3_t, 4>>(tCgK_copy);
+              const auto out2x2 = recast<half2x2>(out);
+              CUTE_UNROLL
+              for (int v_ = 0; v_ < size(tCgK_copy4); v_++) {
+                int v = layout(tCgK_copy4)(v_);
+                auto b = tCgKSB_vec(_, _, _1{})(4 * v);
+                auto s = tCgKSB_vec(_, _, _0{})(4 * v);
+                half2 scale2{s, s};
+                half2 bias2{b, b};
+                auto in2x2 = fast_type_convert<half2x2>(tCgK_copy4(v));
+                out2x2(v)[0] = __hfma2(scale2, in2x2[0], bias2);
+                out2x2(v)[1] = __hfma2(scale2, in2x2[1], bias2);
+              }
+#endif
+            };
+
+            copy_then_dequantize(_0{}, tCgK_vec0);
+            if constexpr (Gemm2IsFullMma) {
+              copy_then_dequantize(_1{}, tCgK_vec1);
+            }
+          }
+          CUTE_UNROLL
+          for (int pp = 0; pp < KVectorizeTiler1::NumMmaTilePacked; pp++) {
+            copy(tCgK_vec0(make_coord(_, _, pp), _), tCrA(make_coord(_, _0{}), _, _));
+            copy(tCgK_vec1(make_coord(_, _, pp), _), tCrA(make_coord(_, _1{}), _, _));
+            copy(tCsQ(_, _, make_coord(pp, p)), tCrB);
+            gemm(tiled_mma1, tCrC, tCrA, tCrB, tCrC);
+          }
+        });
+        transform(tCrC, [&](auto v) { return v * scale; });
+        if (alibi_slopes) {
+          for_each(make_int_sequence<size<0>(tCrC)>{}, [&](auto&& v) {  // IterFrag
+            const auto frag_coord = layout<0>(tCrC).get_hier_coord(v);
+            for_each(make_int_sequence<size<1>(tCrC)>{}, [&](auto&& i) {  // IterM
+              const auto [tok_id_in_chunk, hidx_in_group] = tCcL(frag_coord, i, _0{}, lid_in_chunk);
+              const int token_idx = chunk.start_logical_page_id(0) * PageSize + tok_id_in_chunk;
+              tCrC(frag_coord, i, _0{}) += alibi_slopes_smem[hidx_in_group] * (token_idx - num_tokens + 1);
+            });
+          });
+          // NOTE: we don't need to handle oob here, softmax_warp automatically ignore them and zero them out
+        }
+        if constexpr (Gemm2IsFullMma) {
+          copy(tCrC, tCsL(_, _, _, lid_in_chunk));
+        } else {
+          // only store the first half of the output when PageSize == 8
+          copy(tCrC(make_coord(_, _0{}), _, _), tCsL(make_coord(_, _0{}), _, _, lid_in_chunk));
+        }
+      }
+
+      if constexpr (!Config::SingleChunk) {
+        chunk.preload_page_table_for_chunk<TaskChunk::NumPages>(seq_page_table, preload_pids, 0, num_tokens);
+      }
+
+      // reuse broadcast buffer for reduction
+      static_assert(2 * NumWarps <= (BROADCAST0_BUFFER_SIZE_IN_BYTES / sizeof(float)));
+      int prefix = chunk.start_tok_idx(0) - (chunk.start_tok_idx(0) % Config::TaskChunkSeqLen);
+      __syncthreads();
+      CUTE_UNROLL
+      for (int i = warp_id(); i < Config::NumQueriesPerCta; i += NumWarps) {
+        softmax_warp<Config::TaskChunkSeqLen>(
+            &logits(_0{}, i),
+            chunk.start_tok_idx(0) - prefix,
+            chunk.end_tok_idx(num_tokens) - prefix,
+            &chunk_max_sum[i]
+        );
+      }
+      __syncthreads();
+
+      TaskChunk next_chunk{-1, -1};
+      if constexpr (!Config::SingleChunk) {
+        worker->take_work(next_chunk.start, next_chunk.end);
+      }
+
+      // GEMM2 ---------------------------------------------------------------------------------------------------------
+      auto tCrC = thr_mma2.make_fragment_C(tCsO);
+      clear(tCrC);
+      int num_pages_in_chunk = chunk.end_logical_page_id(num_tokens) - chunk.start_logical_page_id(0);
+#pragma unroll(HeadSize < 128 ? 2 : 1)
+      for (int lid_in_chunk = warp_id(); lid_in_chunk < num_pages_in_chunk; lid_in_chunk += NumWarps) {
+        const int64_t physical_page_id = chunk_page_table[lid_in_chunk];
+
+        auto tCrA = thr_mma2.make_fragment_A(append_tensor<3>(tCgV(_, _, _, _0{})));
+        auto tCrB = thr_mma2.make_fragment_B(append_tensor<3>(tCsS(_, _, _, _0{})));
+
+        auto tCgV_page = tCgV(_, _, _, physical_page_id);
+        auto tCgVSB_page = tCgVSB(_, _, _, /*s_or_b*/ _, physical_page_id);
+        for_each(make_int_sequence<size<1>(tCrC)>{}, [&](auto i) {
+          auto tCgV_vec = make_tensor_like<half>(tCgV_page(_, _0{}, _));
+
+          if constexpr (!HasSB) {
+            copy(tCgV_page(_, i, _), tCgV_vec);
+          } else {  // copy then dequantize
+            auto tCgV_copy = make_tensor_like<TV>(tCgV_vec);
+            auto tCgVSB_vec = make_tensor_like<TSB>(tCgVSB_page(_, _0{}, _, _));
+            copy(tCgV_page(_, i, _), tCgV_copy);
+            copy(tCgVSB_page(_, i, _, _), tCgVSB_vec);
+#if 0
+            // FIXME: slow and incorrect! incorrectness is cause by recast in tensor_convert
+            // tensor_convert(tCgV_copy, tCgVSB_vec(_, _, _0{}), tCgVSB_vec(_, _, _1{}), tCgV_vec);
+#else
+            const auto tCgV_copy2 = recast<array<float_e4m3_t, 2>>(tCgV_copy);
+            const auto scale2 = recast<half2>(tCgVSB_vec(_, _, _0{}));
+            const auto bias2 = recast<half2>(tCgVSB_vec(_, _, _1{}));
+            const auto tCgV_vec2 = recast<half2>(tCgV_vec);
+            CUTE_UNROLL
+            for (int v = 0; v < size(tCgV_copy2); v++) {
+              tCgV_vec2(v) = __hfma2(scale2(v), fast_type_convert<half2>(tCgV_copy2(v)), bias2(v));
+            }
+#endif
+          }
+          copy(tCgV_vec, tCrA(_, i, _));
+        });
+
+        auto logical_page_id = chunk.start_logical_page_id(0) + lid_in_chunk;
+        bool is_full_page = (logical_page_id >= ceil_div(chunk.start_tok_idx(0), PageSize)) &&
+                            (logical_page_id < chunk.end_tok_idx(num_tokens) / PageSize);
+        if (!is_full_page) {
+          enforce_uniform();
+          filter_inf_nan(tCrA);
+        }
+
+        auto tCsS_page = tCsS(_, _, _, lid_in_chunk);
+        CUTE_UNROLL
+        for (int j = 0; j < size<2>(tCrC); j++) {
+          auto tCsS_vec = make_tensor_like<float>(tCsS_page(_, _, _));
+          copy(tCsS_page(_, j, _), tCsS_vec);
+          transform(tCsS_vec, tCrB(_, j, _), [](auto v) { return type_convert<half>(v); });
+        }
+
+        gemm(tiled_mma2, tCrC, tCrA, tCrB, tCrC);
+      }
+
+      __syncthreads();  // sync to reuse logits as chunk_out
+
+      if (warp_id() == 0) {
+        copy(tCrC, tCsO);
+      }
+      __syncthreads();
+      CUTE_UNROLL
+      for (int warp = 1; warp < NumWarps; warp++) {
+        if (warp_id() == warp) {
+          transform(tCsO, tCrC, tCsO, [](auto a, auto b) { return a + b; });
+        }
+        __syncthreads();
+      }
+
+      CUTE_UNROLL
+      for (int i = warp_id(); i < Config::NumQueriesPerCta; i += NumWarps) {
+        FlashAccWarp::acc(smem_out[i], &smem_max_sum[i], &chunk_out(_0{}, i), &chunk_max_sum[i]);
+      }
+      if constexpr (Config::SingleChunk) {
+        break;
+      } else {
+        worker->broadcast_work(broadcast_buffer, next_chunk.start, next_chunk.end);
+        chunk = next_chunk;
+      }
+    }
+
+    __syncthreads();
+    auto get_max_sum_idx = [=](int i) {  // i in range [0,NumQueriesPerCta)
+      if constexpr (Config::UseHeadSeq) {
+        return (head_idx + i) * Config::MaxNumSeqs + seq_idx;
+      } else {
+        return seq_idx * num_heads + (head_idx + i);
+      }
+    };
+    if constexpr (Config::InplaceFlashAcc) {
+      for (int i = 0; i < Config::NumQueriesPerCta; ++i) {
+        TO* gmem_out = &gO(_0{}, head_idx + i);
+        FlashAccCta::atomic_acc(broadcast_buffer, gmem_out, &out_max_sum[get_max_sum_idx(i)], smem_out[i], &smem_max_sum[i]);
+      }
+    } else {
+      for (int i = warp_id(); i < Config::NumQueriesPerCta; i += NumWarps) {
+        TO* gmem_out = &gO(_0{}, head_idx + i);
+        FlashAccWarp::write_inc(gmem_out, out_max_sum ? &out_max_sum[get_max_sum_idx(i)] : nullptr, smem_out[i], &smem_max_sum[i]);
+      }
+    }
+  }
+
+protected:
+  using BaseTask::NumWarps;
+  using BaseTask::x;
+
+  using BaseTask::ScaleBiasNumChunks;
+};
+
+}  // namespace onnxruntime::contrib::paged
+
+#ifdef DUMMY_TASK_DPRINTF1
+#undef DUMMY_TASK_DPRINTF1
+#undef TASK_DPRINTF1
+#endif

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_task.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_task.cuh
@@ -1,0 +1,773 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "cute/layout.hpp"
+#include "cute/tensor.hpp"
+
+#include "contrib_ops/cuda/bert/paged/algorithms.cuh"
+#include "contrib_ops/cuda/bert/paged/cuda_common.cuh"
+#include "contrib_ops/cuda/bert/paged/mutex.cuh"
+#include "contrib_ops/cuda/bert/paged/paged_attention/attention_common.cuh"
+#include "contrib_ops/cuda/bert/paged/type_convert.cuh"
+#include "contrib_ops/cuda/bert/paged/warp_utilities.cuh"
+
+#ifndef TASK_DPRINTF1
+#define DUMMY_TASK_DPRINTF1(...)
+#define TASK_DPRINTF1 DUMMY_TASK_DPRINTF1
+#endif
+
+namespace onnxruntime::contrib::paged {
+
+using namespace cute;
+
+#define BROADCAST0_BUFFER_SIZE_IN_BYTES 128
+
+template <typename T, typename Func>
+__forceinline__ __device__ T
+broadcast0(void* buffer, Func&& value_producer) {
+  if (threadIdx.x == 0) {
+    *static_cast<T*>(buffer) = value_producer();
+  }
+  __syncthreads();
+  return *static_cast<T*>(buffer);
+}
+
+__forceinline__ __device__ void
+init_max_sum(float2* max_sum) {
+  *max_sum = float2{std::numeric_limits<float>::lowest(), 0.0f};
+}
+
+__forceinline__ __device__ void
+atomic_init_max_sum(float2* max_sum) {
+  union {
+    float2 f32x2;
+    uint64_t packed;
+  };
+  f32x2 = float2{std::numeric_limits<float>::lowest(), 0.0f};
+  atomicExch(reinterpret_cast<unsigned long long*>(max_sum), packed);
+}
+
+template <typename WorkerImpl>
+struct IWorker {
+  __forceinline__ __device__ void
+  take_work(int& chunk_start, int& chunk_end) {
+    static_cast<WorkerImpl*>(this)->take_work(chunk_start, chunk_end);
+  }
+
+  __forceinline__ __device__ void
+  broadcast_work(void* broadcast_buffer, int& chunk_start, int& chunk_end) {
+    static_cast<WorkerImpl*>(this)->broadcast_work(broadcast_buffer, chunk_start, chunk_end);
+  }
+};
+
+template <
+    int TaskChunkSeqLen_ = 256,
+    bool InplaceFlashAcc_ = true,
+    bool UseHeadSeq_ = true,
+    bool SingleChunk_ = false,
+    int NumQueriesPerCta_ = 1>
+struct TaskConfig {
+  inline static constexpr int TaskChunkSeqLen = TaskChunkSeqLen_;
+  inline static constexpr bool InplaceFlashAcc = InplaceFlashAcc_;
+  inline static constexpr bool UseHeadSeq = UseHeadSeq_;
+  inline static constexpr bool SingleChunk = SingleChunk_;
+  inline static constexpr int NumQueriesPerCta = NumQueriesPerCta_;
+};
+
+template <typename T_ = half, int ChunkSize_ = 32>
+struct KVConfig {
+  using TSB = T_;
+  inline static constexpr int ChunkSize = ChunkSize_;
+};
+
+struct DefaultKV {
+  using TSB = void;
+  inline static constexpr int ChunkSize = 32;
+};
+
+struct Unused {
+  template <typename... Coords>
+  __forceinline__ __device__ constexpr Unused
+  operator()(const Coords&... coords) const {
+    return Unused{};
+  }
+
+  template <typename... Coords>
+  __forceinline__ __device__ constexpr Unused
+  operator()(const Coords&... coords) {
+    return Unused{};
+  }
+};
+
+template <
+    int NumThreads,
+    int HeadSize,
+    int PageSize,
+    typename TI,
+    typename TO_,
+    typename TKV,
+    typename Worker,
+    typename Config,
+    typename KVConfig = DefaultKV>
+struct PagedAttentionTask {
+  using TQ = TI;
+  using TO = TO_;
+  using TK = TKV;
+  using TV = TKV;
+  using TSB_ = typename KVConfig::TSB;
+
+  static constexpr bool HasSB = !std::is_same_v<typename KVConfig::TSB, void>;
+  using TSB = std::conditional_t<HasSB, typename KVConfig::TSB, Unused>;
+
+  __forceinline__ __device__ static void
+  flash_acc(
+      float* acc, float2* acc_max_sum,             // accumulative part
+      const float* inc, const float2* inc_max_sum  // incremental part
+  ) {
+    float prev_max = acc_max_sum->x;
+    float prev_sum = acc_max_sum->y;
+
+    float curr_max = inc_max_sum->x;
+    float curr_sum = inc_max_sum->y;
+
+    float new_max = max(prev_max, curr_max);
+
+    float prev_factor = __expf(prev_max - new_max);
+    float curr_factor = __expf(curr_max - new_max);
+
+    float new_sum = prev_factor * prev_sum + curr_factor * curr_sum;
+    float new_sum_inv = 1.0f / new_sum;
+    __syncthreads();  // ensure prev_max, prev_sum loaded
+    if (threadIdx.x == 0) {
+      *acc_max_sum = float2{new_max, new_sum};
+    }
+
+    bool load_prev_acc = prev_sum != 0.0f;
+    for (int i = threadIdx.x; i < HeadSize; i += NumThreads) {
+      // NOTE: In flash attention paper, curr_sum is not included, because it does not apply the denominator.
+      // curr_sum cancels out the denominator for our implementation
+      float old_val = load_prev_acc ? acc[i] : 0.0f;
+      float new_val = prev_factor * (prev_sum * new_sum_inv) * old_val +
+                      curr_factor * (curr_sum * new_sum_inv) * inc[i];
+      // if (new_val != new_val) {
+      //   printf(
+      //       "acc[%d] new_val:%f new_sum:%f prev_factor:%f prev_sum:%f curr_factor:%f curr_sum:%f %f %f\n",
+      //       i, new_val, new_sum, prev_factor, prev_sum, curr_factor, curr_sum, acc[i], inc[i]
+      //   );
+      // }
+      acc[i] = new_val;
+    }
+  }
+
+  __forceinline__ __device__ static void
+  atomic_flash_acc(
+      void* broadcast_buffer,
+      volatile TO* acc, float2* acc_max_sum,
+      float* inc, float2* inc_max_sum
+  ) {
+    float2 old = broadcast0<float2>(broadcast_buffer, [&]() {
+      auto acc_max_sum_ull = reinterpret_cast<unsigned long long*>(acc_max_sum);
+      constexpr uint64_t lock_bits = 0xFFFF'F000'FFF0'0000;  // float2{NaN, NaN};
+      uint64_t old, assumed = lock_bits;
+      bool locked = false;
+      do {
+        if (assumed == lock_bits) {
+          // assumed = volatile_load(gmem_max_sum_ull);
+          // __threadfence();
+          assumed = atomicAdd(acc_max_sum_ull, 0);
+          locked = false;
+          continue;
+        }
+        old = atomicCAS(acc_max_sum_ull, assumed, lock_bits);
+        locked = old == assumed;
+        if (!locked) {
+          assumed = old;
+          backoff();
+        }
+      } while (!locked);
+      union {
+        float2 f32x2;
+        uint64_t packed;
+      };
+      packed = old;
+      return f32x2;
+    });
+    __syncthreads();
+    __threadfence();
+
+    float prev_max = old.x;
+    float prev_sum = old.y;
+
+    float curr_max = inc_max_sum->x;
+    float curr_sum = inc_max_sum->y;
+
+    float new_max = max(prev_max, curr_max);
+
+    float prev_factor = __expf(prev_max - new_max);
+    float curr_factor = __expf(curr_max - new_max);
+
+    float new_sum = prev_factor * prev_sum + curr_factor * curr_sum;
+    float new_sum_inv = 1.0f / new_sum;
+
+    bool load_prev_acc = prev_sum != 0.0f;
+    for (int i = threadIdx.x; i < HeadSize; i += NumThreads) {
+      float old_val = load_prev_acc ? type_convert<float>(volatile_load(acc + i)) : 0.0f;
+      float new_val = prev_factor * (prev_sum * new_sum_inv) * old_val +
+                      curr_factor * (curr_sum * new_sum_inv) * inc[i];
+      // if (new_val != new_val) {
+      //   printf(
+      //       "acc[%d] new_val:%f new_sum:%f prev_factor:%f prev_sum:%f curr_factor:%f curr_sum:%f %f %f\n",
+      //       i, new_val, new_sum, prev_factor, prev_sum, curr_factor, curr_sum, old_val, inc[i]
+      //   );
+      // }
+      acc[i] = type_convert<TO>(new_val);
+    }
+
+    __syncthreads();
+    __threadfence();
+    if (threadIdx.x == 0) {
+      union {
+        float2 f32x2;
+        uint64_t packed;
+      };
+      f32x2 = float2{new_max, new_sum};
+      atomicExch(reinterpret_cast<unsigned long long*>(acc_max_sum), packed);
+    }
+  }
+
+  __forceinline__ __device__ static void
+  write_flash_inc(
+      TO* gmem, float2* gmem_max_sum,
+      float* inc, float2* inc_max_sum
+  ) {
+    if (gmem_max_sum != nullptr && threadIdx.x == 0) {
+      *gmem_max_sum = *inc_max_sum;
+    }
+    for (int i = threadIdx.x; i < HeadSize; i += NumThreads) {
+      gmem[i] = type_convert<TO>(inc[i]);
+    }
+  }
+
+  __forceinline__ __device__ static void
+  attention(
+      void* __restrict__ broadcast_buffer,
+      Worker* __restrict__ worker,
+      const int seq_idx,
+      const int head_idx,
+      const int kv_head_idx,
+      TO* __restrict__ out,                    // [num_seqs, num_heads, head_size]
+      float2* __restrict__ out_max_sum,        // [num_seqs, num_heads], running max and sum of gmem out
+      const TI* __restrict__ q,                // [num_seqs, num_heads, head_size]
+      const TKV* __restrict__ k_cache,         // [num_pages, num_kv_heads, head_size/x, page_size, x]
+      const TKV* __restrict__ v_cache,         // [num_pages, num_kv_heads, head_size, page_size]
+      const TSB_* __restrict__ kv_scalebias,   // [num_pages, 2, num_kv_heads, 2, head_size/chunk_size, page_size], optional
+      const int* __restrict__ page_table,      // [num_seqs, max_num_pages_per_seq]
+      const int* __restrict__ context_lens,    // [num_seqs]
+      const float* __restrict__ alibi_slopes,  // [num_heads]
+      const float scale,
+      const int num_seqs,
+      const int num_heads,
+      const int num_kv_heads,
+      const int max_num_pages_per_seq,
+      const int q_stride
+  ) {
+    // static_assert(Config::NumQueriesPerCta == 1);
+    constexpr int NumPagesPerTaskChunk = ceil_div(Config::TaskChunkSeqLen, PageSize);
+    __shared__ int chunk_page_table[ceil_div(Config::TaskChunkSeqLen, PageSize)];
+    __shared__ float attn_scores[Config::TaskChunkSeqLen];
+    __shared__ float smem_out[HeadSize];
+    __shared__ float2 max_sum[2];
+    __shared__ TSB sSB_buffer[NumWarps][PageSize * ScaleBiasNumChunks * 2];
+    // NOTE: __shared__ float2 smem_max_sum compiles but crash with unaligned access
+    float2* smem_max_sum = &max_sum[0];
+    float2* chunk_max_sum = &max_sum[1];
+
+    // zero-ing out __shared__ buffers
+    // attn_scores will be initialize by softmax_cta
+    // smem_out will not be loaded if sum in smem_max_sum is 0.0f
+    if (threadIdx.x == 0) {
+      *smem_max_sum = float2{std::numeric_limits<float>::lowest(), 0.0f};
+    }
+    // chunk_max_sum must be initialize per chunk-wise
+
+    const int num_tokens = context_lens[seq_idx];
+    const int64_t dummy_shape = 1073741824;  // 2^30, can be used for the slowest dim
+    const auto num_pages = dummy_shape;
+
+    auto gO = make_tensor(make_gmem_ptr(out), make_layout(make_shape(num_seqs, num_heads, Int<HeadSize>{}), LayoutRight{}))(_, head_idx, _);                                     // [num_seqs, num_heads, head_size]
+    const auto gQ = make_tensor(make_gmem_ptr(q), make_layout(make_shape(num_seqs, num_heads, Int<HeadSize>{}), make_stride(q_stride, Int<HeadSize>{}, _1{})))(_, head_idx, _);  // [num_seqs, num_heads, head_size]
+    const auto gK = [&]() {
+      auto l_raw = make_layout(make_shape(Int<x>{}, Int<PageSize>{}, Int<HeadSize / x>{}, num_kv_heads, num_pages));
+      auto l = group<1, 3>(select<1, 0, 2, 3, 4>(l_raw));  // [page_size, (x * head_size/x), num_kv_heads, num_pages]
+      return make_tensor(make_gmem_ptr(k_cache), l)(/*tok_idx_in_page*/ _, /*dim_idx_in_head*/ _, kv_head_idx, /*physical_page_id*/ _);
+    }();
+    const auto gV = [&]() {
+      auto l = select<1, 0, 2, 3>(make_layout(make_shape(Int<PageSize>{}, Int<HeadSize>{}, num_kv_heads, num_pages)));
+      return make_tensor(make_gmem_ptr(v_cache), l)(/*dim_idx_in_head*/ _, /*tok_idx_in_page*/ _, kv_head_idx, /*physical_page_id*/ _);
+    }();
+    const auto gSB = [&]() {
+      if constexpr (HasSB) {
+        auto l = make_layout(make_shape(Int<PageSize * ScaleBiasNumChunks * 2>{}, num_kv_heads, _2{}, num_pages));
+        return make_tensor(make_gmem_ptr(kv_scalebias), l)(/*copy_dim*/ _, kv_head_idx, /*k_or_v*/ _, /*physical_page_id*/ _);
+      } else {
+        return Unused();
+      }
+    }();
+    // K: (tok_idx_in_page,(dim_idx_in_head),physical_page_id) -> val_idx
+    // V: (dim_idx_in_head,  tok_idx_in_page,physical_page_id) -> val_idx
+
+    auto [tSB_should_copy, tSB_copy_src, tSB_copy_dst] = [&]() {
+      if constexpr (HasSB) {
+        auto sSB = make_tensor(make_smem_ptr(sSB_buffer[warp_id()]), make_layout(Int<PageSize * ScaleBiasNumChunks * 2>{}));
+        auto cSB = make_identity_tensor(shape(sSB));
+        ScaleBiasWarpCopy tiled_copy{};
+        auto thr_copy = tiled_copy.get_thread_slice(lane_id());
+        const auto src_view = thr_copy.partition_S(gSB);
+        auto dst_view = thr_copy.partition_S(sSB);
+        auto coord = thr_copy.partition_S(cSB);
+        bool should_copy = elem_less(coord(_0{}, _0{}), shape(cSB));
+        static_assert(size<1>(src_view) == 1);
+        static_assert(size<1>(dst_view) == 1);
+        return std::make_tuple(
+            should_copy,
+            coalesce(src_view(_, /*iter*/ _0{}, /*k_or_v*/ _, /*physical_page_id*/ _), make_shape(_1{}, _1{}, _1{})),
+            coalesce(dst_view(_, /*iter*/ _0{}))
+        );
+      } else {
+        return std::make_tuple(false, Unused(), Unused());
+      }
+    }();
+    auto tSB_copy_staging = make_tensor<TSB>(Int<ScaleBiasCopyValPerThread>{});
+    auto sSB = make_tensor(
+        make_smem_ptr(sSB_buffer[warp_id()]),
+        Layout<Shape<Int<PageSize>, Shape<Int<KVConfig::ChunkSize>, Int<ScaleBiasNumChunks>>, _2>, Stride<_1, Stride<_0, Int<PageSize>>, Int<PageSize * ScaleBiasNumChunks>>>{}
+    );
+
+    const auto gPageTable = make_tensor(make_gmem_ptr(page_table), make_layout(make_shape(num_seqs, max_num_pages_per_seq), LayoutRight{}));
+    const auto ctaSeqPageTable = gPageTable(seq_idx, _);
+
+    const float alibi_slope = alibi_slopes == nullptr ? 0.f : alibi_slopes[head_idx];
+
+    // cooperative load q to sA (sQ)
+    constexpr const auto SmemQLayout = make_layout(Int<HeadSize>{});
+    __shared__ TQ sQ_buffer[cosize(SmemQLayout)];
+
+    auto sQ = make_tensor(make_smem_ptr(sQ_buffer), SmemQLayout);
+    auto cQ = make_identity_tensor(shape(SmemQLayout));
+    {
+      constexpr int QLoadVec = cute::min(ceil_div(HeadSize, NumThreads), 8);  // load n elems per thread
+      auto load_q_head = make_tv_layout(SmemQLayout, make_layout(Int<NumThreads>{}), make_layout(Int<QLoadVec>{}));
+
+      auto coord = make_coord(make_coord(threadIdx.x, _), _);
+      auto thr_ld = gQ(seq_idx, _).compose(load_q_head)(coord);
+      auto thr_st = sQ.compose(load_q_head)(coord);
+      auto thr_cQ = cQ.compose(load_q_head)(coord);
+      CUTE_UNROLL
+      for (int i = 0; i < QLoadVec; i++) {
+        if (elem_less(thr_cQ(i), shape(cQ))) {
+          thr_st(i) = thr_ld(i);
+        }
+      }
+      cp_async_fence();
+      cp_async_wait<0>();
+      __syncthreads();
+    }
+
+    const auto gemv1_thr_copy = Gemv1TiledCopy{}.get_thread_slice(lane_id());
+    const auto gemv2_thr_copy = Gemv2TiledCopy{}.get_thread_slice(lane_id());
+
+    // gemv1 A
+    const auto gemv1_sA = make_tensor(make_smem_ptr(sQ_buffer), make_layout(make_shape(_1{}, Int<HeadSize>{}), make_stride(_0{}, _1{})));  // [1,k], m=1, broadcast
+    const auto gemv1_tA_view = gemv1_thr_copy.partition_S(gemv1_sA);                                                                       // (val,j,p)
+    // gemv1 B
+    const auto gemv1_page_coord = make_identity_tensor(make_shape(Int<PageSize>{}, Int<HeadSize>{}));
+    const auto gemv1_tB_view = gemv1_thr_copy.partition_S(gK);                 // (val,j,p,physical_page_id) -> idx
+    const auto gemv1_tB_coord = gemv1_thr_copy.partition_S(gemv1_page_coord);  // (val,j,p)                  -> coord
+    const auto gemv1_tSB_view = [&]() {
+      if constexpr (HasSB) {
+        return gemv1_thr_copy.partition_S(sSB);
+      } else {
+        return Unused();
+      }
+    }();
+
+    // gemv2 A
+    const auto gemv2_sA = make_tensor(make_smem_ptr(attn_scores), make_layout(make_shape(_1{}, Int<PageSize>{}, Int<NumPagesPerTaskChunk>{})));  // [1,k,lid_in_chunk], m=1
+    const auto gemv2_tA_view = gemv2_thr_copy.partition_S(gemv2_sA);                                                                             // (val,i,p,lid_in_chunk), p is token_idx_in page
+    // gemv2 B
+    const auto gemv2_page_coord = make_identity_tensor(make_shape(Int<HeadSize>{}, Int<PageSize>{}));                  // (n,k)
+    const auto gemv2_tB_view = coalesce(gemv2_thr_copy.partition_S(gV), make_shape(_1{}, _1{}, _1{}, _1{}));           // (val,j,p,physical_page_id) -> idx
+    const auto gemv2_tB_coord = coalesce(gemv2_thr_copy.partition_S(gemv2_page_coord), make_shape(_1{}, _1{}, _1{}));  // (val,j,p)                  -> coord
+    const auto gemv2_tSB_view = [&]() {
+      if constexpr (HasSB) {
+        auto sSB_gemv2_nk = make_tensor(sSB.data(), select<1, 0, 2>(sSB.layout()));
+        return gemv2_thr_copy.partition_S(sSB_gemv2_nk);
+      } else {
+        return Unused();
+      }
+    }();
+    static_assert(rank(gemv2_tB_view) == 4 && size<2>(gemv2_tB_view) == 1, "iter mode p is assumed to be 1");
+    static_assert(rank(gemv2_tB_coord) == 3 && size<2>(gemv2_tB_coord) == 1, "iter mode p is assumed to be 1");
+
+    bool is_first_iter = true;
+    constexpr int NumLpidPreloadPerThread = ceil_div(NumPagesPerTaskChunk, NumThreads);
+    auto next_lpids = make_tensor<int>(Int<NumLpidPreloadPerThread>{});
+    auto next_chunk = int2{-1, -1};
+    worker->take_work(next_chunk.x, next_chunk.y);
+
+    while (true) {
+      worker->broadcast_work(broadcast_buffer, next_chunk.x, next_chunk.y);
+      int2 chunk = next_chunk;
+      if (chunk.x >= chunk.y) {
+        break;
+      }
+      if (threadIdx.x == 0) {
+        *chunk_max_sum = float2{std::numeric_limits<float>::lowest(), 0.0f};
+      }
+
+      int chunk_start_tok_idx = max(chunk.x * Config::TaskChunkSeqLen, 0);
+      int chunk_end_tok_idx = min(chunk.y * Config::TaskChunkSeqLen, num_tokens);
+      int chunk_start_logical_page_id = chunk_start_tok_idx / PageSize;
+      int chunk_end_logical_page_id = ceil_div(chunk_end_tok_idx, PageSize);
+
+      TASK_DPRINTF1(
+          "  worker[%d]: work on tok[%d,%d) of seq:%d, head:%d, kv_head:%d\n",
+          worker->worker_id(), chunk_start_tok_idx, chunk_end_tok_idx, seq_idx, head_idx, kv_head_idx
+      );
+
+      static_assert(NumPagesPerTaskChunk <= NumLpidPreloadPerThread * NumThreads);
+      if (const int lid_in_chunk = NumLpidPreloadPerThread * threadIdx.x; lid_in_chunk < NumPagesPerTaskChunk) {
+        if (!is_first_iter) {
+          CUTE_UNROLL
+          for (int i = 0; i < NumLpidPreloadPerThread; i++) {
+            chunk_page_table[lid_in_chunk + i] = next_lpids(i);
+          }
+        } else {
+          // if is first chunk, load current page table
+          CUTE_UNROLL
+          for (int i = 0; i < NumLpidPreloadPerThread; i++) {
+            chunk_page_table[lid_in_chunk + i] =
+                chunk_start_logical_page_id + lid_in_chunk + i < chunk_end_logical_page_id
+                    ? ctaSeqPageTable(chunk_start_logical_page_id + lid_in_chunk + i)
+                    : -1;
+          }
+        }
+      }
+      is_first_iter = false;
+      __syncthreads();
+
+      load_sb_to_reg<0>(tSB_copy_src, tSB_should_copy, chunk_page_table[warp_id()], tSB_copy_staging);
+      // output for first GEMV
+      float* logits = attn_scores;
+      float qk_max = std::numeric_limits<float>::lowest();
+#pragma unroll 1
+      for (int lid_in_chunk = warp_id(); lid_in_chunk < NumPagesPerTaskChunk; lid_in_chunk += NumWarps) {
+        const int64_t physical_page_id = chunk_page_table[lid_in_chunk];
+        const int64_t next_physical_page_id = lid_in_chunk + NumWarps < NumPagesPerTaskChunk ? chunk_page_table[lid_in_chunk + NumWarps] : -1;
+        store_sb_to_smem(tSB_copy_staging, tSB_should_copy, physical_page_id, tSB_copy_dst);        // if curr is valid, store
+        load_sb_to_reg<0>(tSB_copy_src, tSB_should_copy, next_physical_page_id, tSB_copy_staging);  // if next is valid, load
+        if (physical_page_id == -1) {
+          continue;
+        }
+
+        const auto tA_view = gemv1_tA_view;
+        auto tA = make_tensor_like(tA_view(_, _0{}, _0{}));
+
+        const auto tB_view = gemv1_tB_view(_, _, _, physical_page_id);
+        const auto& tSB_view = gemv1_tSB_view;
+        static_assert(size<1>(gemv1_tB_view) == 1);  // IterN over PageSize can be omitted
+        auto tB = make_fragment_like<TQ>(tB_view(_, _0{}, _0{}));
+
+        float qk{};
+        CUTE_UNROLL
+        for (int p = 0; p < size<2>(tB_view); p++) {  // IterK over HeadSize
+          copy(AutoVectorizingCopyWithAssumedAlignment<cute::min(8 * sizeof(TQ) * size(tA), 128)>{}, tA_view(_, _0{}, p), tA);
+          if (elem_less(gemv1_tB_coord(_0{}, _0{}, p), shape(gemv1_page_coord))) {
+            load_tB(tB, tB_view(_, _0{}, p), tSB_view(_, _0{}, p, _));
+            qk += inner_product<float>(tA, tB);
+          }
+          schedule_barrier();
+        }
+        qk *= scale;
+        // reduce in thread group to get the full qk
+        qk = warp::reduce<Gemv1ThrK, /*Strided=*/Gemv1TransThrLayout>(qk, [](float a, float b) { return a + b; });
+        auto tid_in_group = get<1>(Gemv1ThrLayout{}.get_hier_coord(int(threadIdx.x)));
+        auto tok_idx_in_page = get<0>(gemv1_tB_coord(_0{}, _0{}, _0{}));
+        const int token_idx = (chunk_start_logical_page_id + lid_in_chunk) * PageSize + tok_idx_in_page;
+        qk += (alibi_slope != 0) ? alibi_slope * (token_idx - num_tokens + 1) : 0;
+        if (tid_in_group == 0) {
+          logits[token_idx % Config::TaskChunkSeqLen] = token_idx < num_tokens ? qk : 0.f;  // TODO: start boundary
+          qk_max = token_idx < num_tokens ? fmaxf(qk_max, qk) : qk_max;
+        }
+      }
+
+      if constexpr (!Config::SingleChunk) {
+        if (const int lid_in_chunk = NumLpidPreloadPerThread * threadIdx.x; lid_in_chunk < NumPagesPerTaskChunk) {
+          // proactively load next page table for next chunk, even though maybe wasted due to stealing, or out of bound
+          CUTE_UNROLL
+          for (int i = 0; i < NumLpidPreloadPerThread; i++) {
+            next_lpids(i) = chunk_start_logical_page_id + NumPagesPerTaskChunk + lid_in_chunk + i < ceil_div(num_tokens, PageSize)
+                                ? ctaSeqPageTable(chunk_start_logical_page_id + NumPagesPerTaskChunk + lid_in_chunk + i)
+                                : -1;
+          }
+        }
+      }
+
+      // reuse broadcast buffer for reduction
+      static_assert(2 * NumWarps <= (BROADCAST0_BUFFER_SIZE_IN_BYTES / sizeof(float)));
+      int prefix = chunk_start_tok_idx - (chunk_start_tok_idx % Config::TaskChunkSeqLen);
+      softmax_cta<NumThreads, Gemv1ThrK, NumWarps>(
+          static_cast<float*>(broadcast_buffer), qk_max, logits,
+          Config::TaskChunkSeqLen,
+          chunk_start_tok_idx - prefix,
+          chunk_end_tok_idx - prefix,
+          chunk_max_sum
+      );
+
+      if constexpr (!Config::SingleChunk) {
+        next_chunk = {-1, -1};
+        worker->take_work(next_chunk.x, next_chunk.y);
+      }
+
+      load_sb_to_reg<1>(tSB_copy_src, tSB_should_copy, chunk_page_table[warp_id()], tSB_copy_staging);
+      auto acc = make_tensor<float>(Int<size<1>(gemv2_tB_view)>{});
+      clear(acc);
+      int num_pages_in_chunk = chunk_end_logical_page_id - chunk_start_logical_page_id;
+#pragma unroll 1
+      for (int lid_in_chunk = warp_id(); lid_in_chunk < num_pages_in_chunk; lid_in_chunk += NumWarps) {
+        const int64_t physical_page_id = chunk_page_table[lid_in_chunk];
+        const int64_t next_physical_page_id = lid_in_chunk + NumWarps < NumPagesPerTaskChunk ? chunk_page_table[lid_in_chunk + NumWarps] : -1;
+        store_sb_to_smem(tSB_copy_staging, tSB_should_copy, physical_page_id, tSB_copy_dst);        // if curr is valid, store
+        load_sb_to_reg<1>(tSB_copy_src, tSB_should_copy, next_physical_page_id, tSB_copy_staging);  // if next is valid, load
+
+        const auto tA_view = coalesce(filter_zeros(gemv2_tA_view(_, _, _, lid_in_chunk)));
+        const auto tB_view = gemv2_tB_view(_, _, _0{}, physical_page_id);
+        const auto tB_coord = gemv2_tB_coord(_, _, _0{});
+        const auto tSB_view = [&]() {
+          if constexpr (HasSB) {
+            return gemv2_tSB_view(_, _, _0{}, _);
+          } else {
+            return Unused();
+          }
+        }();
+
+        static_assert(rank(tA_view) == 1);  // tA_view is not related to j
+        static_assert(size<1>(gemv2_tB_view) == size(acc));
+        static_assert(size<2>(gemv2_tB_view) == 1);  // IterK over PageSize can be omitted
+
+        auto tA = make_fragment_like(tA_view);
+        auto tB = make_fragment_like<TQ>(tB_view(_, _0{}));
+
+        bool is_full_chunk = chunk_end_tok_idx - chunk_start_tok_idx == Config::TaskChunkSeqLen;
+        bool is_full_page = lid_in_chunk != 0 && lid_in_chunk != num_pages_in_chunk - 1;
+        if (is_full_chunk || is_full_page) {
+          copy(AutoVectorizingCopyWithAssumedAlignment<cute::min(8 * sizeof(float) * Gemv2ValK, 128)>{}, tA_view, tA);
+          CUTE_UNROLL
+          for (int j = 0; j < size<1>(tB_view); j++) {  // IterN over HeadSize
+            if (elem_less(tB_coord(_0{}, j), shape(gemv2_page_coord))) {
+              load_tB(tB, tB_view(_, j), tSB_view(_, j, _));
+              acc(j) += inner_product<float>(tA, tB);
+            }
+            schedule_barrier();
+          }
+        } else {
+          enforce_uniform();
+          auto token_idx_in_page = get<1>(tB_coord(_0{}, _0{}));
+          auto logical_page_id = chunk_start_logical_page_id + lid_in_chunk;
+          int valid_tokens = num_tokens - (logical_page_id * PageSize + token_idx_in_page);
+
+          auto pred = make_tensor_like<bool>(tA);
+          CUTE_UNROLL
+          for (int p = 0; p < size(pred); p++) {
+            pred(p) = p < valid_tokens;
+          }
+
+          auto masked_tB = make_fragment_like(tB);
+
+          copy(AutoVectorizingCopyWithAssumedAlignment<cute::min(8 * sizeof(float) * Gemv2ValK, 128)>{}, tA_view, tA);
+          CUTE_UNROLL
+          for (int j = 0; j < size<1>(tB_view); j++) {  // IterN over HeadSize
+            if (elem_less(tB_coord(_0{}, j), shape(gemv2_page_coord))) {
+              load_tB(tB, tB_view(_, j), tSB_view(_, j, _));
+              copy_if(pred, tB, masked_tB);
+              acc(j) += inner_product<float>(tA, masked_tB);
+            }
+          }
+        }
+      }
+
+      acc = warp::reduce<Gemv2ThrK>(acc, [](float a, float b) { return a + b; });
+
+      __syncthreads();  // sync to reuse attn_scores
+      auto chunk_out = attn_scores;
+      static_assert(HeadSize <= Config::TaskChunkSeqLen);
+
+      constexpr auto OutThrCoord = make_identity_tensor(make_shape(Int<Gemv2ThrK>{}, Int<Gemv2ThrN>{}));
+      const auto thr_coord = OutThrCoord(lane_id());
+      const auto thr_k = get<0>(thr_coord);  // thr_k == 0 is the leading threads in previous warp reduction
+      const auto thr_n = get<1>(thr_coord);
+
+      if (warp_id() == 0 && thr_k == 0) {
+        CUTE_UNROLL
+        for (int v = 0; v < size(acc); v++) {
+          int dim_idx = thr_n + v * Gemv2ThrN;  // strided
+          if (dim_idx < HeadSize) {
+            chunk_out[dim_idx] = acc(v);
+          }
+        }
+      }
+      __syncthreads();
+      CUTE_UNROLL
+      for (int warp = 1; warp < NumWarps; warp++) {
+        if (warp_id() == warp && thr_k == 0) {
+          CUTE_UNROLL
+          for (int v = 0; v < size(acc); v++) {
+            int dim_idx = thr_n + v * Gemv2ThrN;  // strided
+            if (dim_idx < HeadSize) {
+              chunk_out[dim_idx] += acc(v);
+            }
+          }
+        }
+        __syncthreads();
+      }
+
+      flash_acc(smem_out, smem_max_sum, chunk_out, chunk_max_sum);
+      if constexpr (Config::SingleChunk) {
+        break;
+      }
+    }
+
+    __syncthreads();
+    int max_sum_idx = [&]() {
+      if constexpr (Config::UseHeadSeq) {
+        return head_idx * Config::MaxNumSeqs + seq_idx;
+      } else {
+        return seq_idx * num_heads + head_idx;
+      }
+    }();
+    TO* gmem_out = &gO(seq_idx, 0);
+    if constexpr (Config::InplaceFlashAcc) {
+      atomic_flash_acc(broadcast_buffer, gmem_out, &out_max_sum[max_sum_idx], smem_out, smem_max_sum);
+    } else {
+      write_flash_inc(gmem_out, out_max_sum ? &out_max_sum[max_sum_idx] : nullptr, smem_out, smem_max_sum);
+    }
+  }
+
+protected:
+  static constexpr int NumWarps = NumThreads / constant::WarpSize;
+  static constexpr int x = 16 / sizeof(TK);
+
+  static constexpr int Gemv1ThrN = PageSize;
+  static constexpr int Gemv1ThrK = ceil_div(constant::WarpSize, Gemv1ThrN);
+  static constexpr int Gemv1ValN = 1;
+  static constexpr int Gemv1ValK = cute::min(next_power_of_two(ceil_div(HeadSize, Gemv1ThrK)), x);
+  static_assert(
+      Gemv1ThrK == 1 || Gemv1ThrK == 2 || Gemv1ThrK == 4 || Gemv1ThrK == 8 ||
+      Gemv1ThrK == 32 || Gemv1ThrK == constant::WarpSize
+  );
+  static_assert(constant::WarpSize % PageSize == 0);
+  static_assert(x % Gemv1ValK == 0);
+
+  static constexpr bool Gemv1TransThrLayout = true;
+  using Gemv1ThrLayout = decltype(make_layout(
+      make_shape(Int<Gemv1ThrN>{}, Int<Gemv1ThrK>{}),
+      std::conditional_t<Gemv1TransThrLayout, LayoutLeft, LayoutRight>{}
+  ));
+  using Gemv1TiledCopy = decltype(make_tiled_copy(
+      Copy_Atom<AutoVectorizingCopyWithAssumedAlignment<cute::min(8 * sizeof(TK) * Gemv1ValK, 128)>, TK>{},
+      Gemv1ThrLayout{},
+      make_layout(make_shape(Int<Gemv1ValN>{}, Int<Gemv1ValK>{}), LayoutRight{})
+  ));
+
+  // LDG is slow enough, so target v cache to use ldg.128
+  // loading from logits is LDS (maybe with different datatype)
+  static constexpr int Gemv2ValK = cute::min(16 / sizeof(TV), PageSize);
+  static constexpr int Gemv2ThrK = PageSize / Gemv2ValK;
+  static constexpr int Gemv2ThrN = constant::WarpSize / Gemv2ThrK;
+  static constexpr int Gemv2ValN = 1;
+
+  using Gemv2TiledCopy = decltype(make_tiled_copy(
+      Copy_Atom<AutoVectorizingCopyWithAssumedAlignment<cute::min(8 * sizeof(TV) * Gemv2ValK, 128)>, TV>{},
+      make_layout(make_shape(Int<Gemv2ThrN>{}, Int<Gemv2ThrK>{}), LayoutRight{}),
+      make_layout(make_shape(_1{}, Int<Gemv2ValK>{}), LayoutRight{})
+  ));
+
+  // (PageSize * ScaleBiasNumChunks,2):(1,?), 2 for scale or bias
+  [[maybe_unused]] static constexpr int ScaleBiasNumChunks = ceil_div(HeadSize, KVConfig::ChunkSize);
+  // Thr and Val config along ScaleBiasNumChunks(C) and PageSize(P) axis
+  [[maybe_unused]] static constexpr int ScaleBiasCopyValPerThread = ceil_div(PageSize * next_power_of_two(ScaleBiasNumChunks) * 2, constant::WarpSize);
+  static_assert((PageSize * ScaleBiasNumChunks * 2) % ScaleBiasCopyValPerThread == 0);
+
+  using ScaleBiasWarpCopy = std::conditional_t<
+      HasSB,
+      decltype(make_tiled_copy(
+          Copy_Atom<UniversalCopy<TSB>, TSB>{},
+          make_layout(Int<constant::WarpSize>{}),
+          make_layout(Int<ScaleBiasCopyValPerThread>{})
+      )),
+      void>;
+
+  template <int KVIdx, typename STensor, typename DTensor>
+  __forceinline__ __device__ static void
+  load_sb_to_reg(const STensor& src, bool should_copy, int physical_page_id, DTensor& dst) {
+    if constexpr (HasSB) {
+      if (should_copy) {
+        if (physical_page_id >= 0) {
+          copy(AutoVectorizingCopyWithAssumedAlignment<cute::min(128, 8 * sizeof(TSB) * ScaleBiasCopyValPerThread)>{}, src(_, Int<KVIdx>{}, physical_page_id), dst);
+        }
+      }
+    }
+  }
+
+  template <typename STensor, typename DTensor>
+  __forceinline__ __device__ static void
+  store_sb_to_smem(const STensor& src, bool should_copy, int physical_page_id, DTensor& dst) {
+    if constexpr (HasSB) {
+      if (should_copy) {
+        if (physical_page_id >= 0) {
+          copy(AutoVectorizingCopyWithAssumedAlignment<cute::min(128, 8 * sizeof(TSB) * ScaleBiasCopyValPerThread)>{}, src, dst);
+        }
+      }
+    }
+  }
+
+  template <typename TensorBDst, typename TensorBSrc, typename TensorSB>
+  __forceinline__ __device__ static void
+  load_tB(TensorBDst& tB, const TensorBSrc& tB_view, const TensorSB& tSB_view) {
+    using Src = std::remove_const_t<typename TensorBSrc::element_type>;
+    using Dst = std::remove_const_t<typename TensorBDst::element_type>;
+    constexpr int NElem = size(typename TensorBDst::layout_type{});
+
+    if constexpr (HasSB) {
+      auto tB_copy = make_tensor_like<Src>(tB);
+      copy(AutoVectorizingCopyWithAssumedAlignment<8 * sizeof(Src) * NElem>{}, tB_view, tB_copy);
+
+      constexpr auto SBTileLayout = coalesce(get<0>(typename TensorSB::layout_type{}));
+      if constexpr (
+          rank(SBTileLayout) == 1 && depth(SBTileLayout) == 0 &&  // no hierarchy
+          stride(SBTileLayout) == _0{}                            // is broadcasting
+      ) {
+        auto scale = tSB_view(_0{}, _0{});
+        auto bias = tSB_view(_0{}, _1{});
+        tensor_convert(tB_copy, scale, bias, tB);
+      } else {
+        auto tSB = make_tensor<TSB>(make_layout(make_shape(Int<NElem>{}, _2{})));
+        copy(AutoVectorizingCopyWithAssumedAlignment<8 * sizeof(TSB)>{}, tSB_view, tSB);
+        tensor_convert(tB_copy, tSB(_, _0{}), tSB(_, _1{}), tB);
+      }
+
+    } else {
+      static_assert(std::is_same_v<Src, Dst>);
+      copy(AutoVectorizingCopyWithAssumedAlignment<8 * sizeof(Src) * NElem>{}, tB_view, tB);
+    }
+  }
+};
+
+}  // namespace onnxruntime::contrib::paged
+
+#ifdef DUMMY_TASK_DPRINTF1
+#undef DUMMY_TASK_DPRINTF1
+#undef TASK_DPRINTF1
+#endif

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_task_selector.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_task_selector.cuh
@@ -26,7 +26,11 @@ private:
     if constexpr (RequestedNumQueriesPerCta == 1) {
       return PagedAttentionTask<NumThreads, HeadSize, PageSize, TI, TO, TKV, Worker, Config, KVConfig>{};
     } else if constexpr (RequestedNumQueriesPerCta == 4) {
-      return PagedGroupQueryAttentionTask<NumThreads, HeadSize, PageSize, TI, TO, TKV, Worker, Config, KVConfig>{};
+      if constexpr (std::is_same_v<TKV, float>) {
+        return PagedGroupQueryAttentionTask<NumThreads, HeadSize, PageSize, TI, TO, TKV, Worker, Config, KVConfig>{};
+      } else {
+        return PagedGroupQueryAttentionTcSm80Task<NumThreads, HeadSize, PageSize, TI, TO, TKV, Worker, Config, KVConfig>{};
+      }
     } else if constexpr (RequestedNumQueriesPerCta == 8) {
       return PagedGroupQueryAttentionTcSm80Task<NumThreads, HeadSize, PageSize, TI, TO, TKV, Worker, Config, KVConfig>{};
     } else {

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_task_selector.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_task_selector.cuh
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_task.cuh"
+#include "contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_gqa_task.cuh"
+#include "contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_gqa_tc_sm80_task.cuh"
+
+namespace onnxruntime::contrib::paged {
+
+template <
+    int NumThreads,
+    int HeadSize,
+    int PageSize,
+    typename TI,
+    typename TO,
+    typename TKV,
+    typename Worker,
+    typename Config,
+    typename KVConfig = DefaultKV>
+struct PagedAttentionTaskSelector {
+private:
+  __device__ static constexpr auto select_task() {
+    constexpr int RequestedNumQueriesPerCta = Config::NumQueriesPerCta;
+    if constexpr (RequestedNumQueriesPerCta == 1) {
+      return PagedAttentionTask<NumThreads, HeadSize, PageSize, TI, TO, TKV, Worker, Config, KVConfig>{};
+    } else if constexpr (RequestedNumQueriesPerCta == 4) {
+      return PagedGroupQueryAttentionTask<NumThreads, HeadSize, PageSize, TI, TO, TKV, Worker, Config, KVConfig>{};
+    } else if constexpr (RequestedNumQueriesPerCta == 8) {
+      return PagedGroupQueryAttentionTcSm80Task<NumThreads, HeadSize, PageSize, TI, TO, TKV, Worker, Config, KVConfig>{};
+    } else {
+      static_assert(always_false<Config>, "Unsupported TaskConfig");
+      return;
+    }
+  }
+
+public:
+  using Task = decltype(PagedAttentionTaskSelector::select_task());
+};
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_ws.cu.in
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_ws.cu.in
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#define PAGED_ATTENTION_KERNEL_IMPL 1
+#include "contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_ws.cuh"
+
+namespace onnxruntime::contrib::paged {
+
+using float8_e4m3fn_t = cute::float_e4m3_t;
+
+// clang-format off
+#define NUM_THREADS @NUM_THREADS@
+#define HEAD_SIZE @HEAD_SIZE@
+#define PAGE_SIZE @PAGE_SIZE@
+#define TIO @TIO@
+#define TKV @TKV@
+#define TSB @TSB@
+// clang-format on
+
+template __global__ void lbp_attention_work_stealing_kernel<NUM_THREADS, HEAD_SIZE, PAGE_SIZE, TIO, TKV, TSB>(
+    void* workspace,
+    TIO* __restrict__ out,                   // [num_seqs, num_heads, head_size]
+    const TIO* __restrict__ q,               // [num_seqs, num_heads, head_size]
+    const TKV* __restrict__ k_cache,         // [num_pages, num_kv_heads, head_size/x, page_size, x]
+    const TKV* __restrict__ v_cache,         // [num_pages, num_kv_heads, head_size, page_size]
+    const TSB* __restrict__ scalebias,       // [num_pages, 2, num_kv_heads, 2, head_size/chunk_size, page_size]
+    const int* __restrict__ page_table,      // [num_seqs, max_num_pages_per_seq]
+    const int* __restrict__ context_lens,    // [num_seqs]
+    const float* __restrict__ alibi_slopes,  // [num_heads]
+    const float scale,
+    const int num_seqs,
+    const int num_heads,
+    const int num_kv_heads,
+    const int max_num_pages_per_seq,
+    const int q_stride
+);
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_ws.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_ws.cuh
@@ -1,0 +1,326 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cstdint>
+
+#include "contrib_ops/cuda/bert/paged/atomics.cuh"
+#include "contrib_ops/cuda/bert/paged/load_balance/bwd_weak.cuh"
+
+#define TASK_DPRINTF_ENABLE 0
+#define TASK_DPRINTF(fmt, ...)       \
+  if constexpr (TASK_DPRINTF_ENABLE) \
+    printf(fmt, ##__VA_ARGS__);
+#define TASK_DPRINTF1(fmt, ...)      \
+  if constexpr (TASK_DPRINTF_ENABLE) \
+    if (threadIdx.x == 1)            \
+      printf(fmt, ##__VA_ARGS__);
+
+#define my_worker_id blockIdx.x
+
+#include "contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_task.cuh"
+
+namespace onnxruntime::contrib::paged {
+
+struct WorkStealingConfig : public TaskConfig<256> {
+  inline static constexpr int MaxNumSeqs = 1024;
+  inline static constexpr int MaxNumHeads = 256;
+  inline static constexpr int MaxNumWorkers = 1536;
+};
+
+struct WorkStealingTaskItem {
+  static constexpr uint64_t ChunkEndMask = /*  22 bits*/ 0xFFFF'FC00'0000'0000;
+  static constexpr uint64_t ChunkStartMask = /*22 bits*/ 0x0000'03FF'FFF0'0000;
+  static constexpr uint64_t SeqHeadMask = /*   20 bits*/ 0x0000'0000'000F'FFFF;
+  static constexpr uint64_t ChunkEndOffset = 42;
+  static constexpr uint64_t ChunkStartOffset = 20;
+  static constexpr uint64_t SeqHeadOffset = 0;
+
+  union {
+    uint64_t packed_u64_;
+    unsigned long long packed_ull_;
+  };
+
+  __forceinline__ __device__ static uint64_t
+  task(int64_t seq_head, int64_t chunk_start, int64_t chunk_end) {
+    return ((uint64_t(seq_head) << SeqHeadOffset) & SeqHeadMask) |
+           ((uint64_t(chunk_start) << ChunkStartOffset) & ChunkStartMask) |
+           ((uint64_t(chunk_end) << ChunkEndOffset) & ChunkEndMask);
+  }
+
+  __forceinline__ __device__ static uint64_t
+  interval(int64_t chunk_start, int64_t chunk_end) {
+    return ((uint64_t(chunk_start) << ChunkStartOffset) & ChunkStartMask) |
+           ((uint64_t(chunk_end) << ChunkEndOffset) & ChunkEndMask);
+  }
+
+  __forceinline__ __device__ static constexpr uint64_t
+  delta(int64_t chunk_start_delta, int64_t chunk_end_delta) {
+    return ((uint64_t(chunk_start_delta) << ChunkStartOffset) & ChunkStartMask) |
+           ((uint64_t(chunk_end_delta) << ChunkEndOffset) & ChunkEndMask);
+  }
+
+  __forceinline__ __device__ int
+  chunk_end() const {
+    return (packed_u64_ & ChunkEndMask) >> ChunkEndOffset;
+  }
+
+  __forceinline__ __device__ int
+  chunk_start() const {
+    return (packed_u64_ & ChunkStartMask) >> ChunkStartOffset;
+  }
+
+  __forceinline__ __device__ int
+  seq_head() const {
+    return (packed_u64_ & SeqHeadMask) >> SeqHeadOffset;
+  }
+};
+
+struct WorkStealingWorker : public IWorker<WorkStealingWorker> {
+  WorkStealingTaskItem item_;
+
+  __forceinline__ __device__ void
+  initialize_tok(int seq_head_idx, int tok_start, int tok_end, int task_chunk_size) {
+    auto chunk_start = tok_start / task_chunk_size;
+    auto chunk_end = ceil_div(tok_end, task_chunk_size);
+    initialize_chunk(seq_head_idx, chunk_start, chunk_end);
+  }
+
+  __forceinline__ __device__ void
+  initialize_chunk(int seq_head_idx, int chunk_start, int chunk_end) {
+    atomicExch(&item_.packed_ull_, WorkStealingTaskItem::task(seq_head_idx, chunk_start, chunk_end));
+  }
+
+  __forceinline__ __device__ void
+  take_work(int& chunk_start, int& chunk_end) {
+    if (threadIdx.x != 0) {
+      return;
+    }
+    constexpr uint64_t delta = WorkStealingTaskItem::delta(1, 0);
+    WorkStealingTaskItem old;
+    old.packed_ull_ = atomicAdd(&item_.packed_ull_, delta);
+    auto remain_chunk_start = old.chunk_start();
+    auto remain_chunk_end = old.chunk_end();
+    if (remain_chunk_start >= remain_chunk_end) {
+      return;
+    }
+    chunk_start = remain_chunk_start;
+    chunk_end = remain_chunk_start + 1;
+  }
+
+  __forceinline__ __device__ void
+  broadcast_work(void* broadcast_buffer, int& chunk_start, int& chunk_end) {
+    auto broadcasted = broadcast0<int2>(broadcast_buffer, [&]() {
+      return int2{chunk_start, chunk_end};
+    });
+    chunk_start = broadcasted.x;
+    chunk_end = broadcasted.y;
+  }
+
+  // steal portion of the workload with consideration of workload chunk size
+  __forceinline__ __device__ int
+  steal(int& stolen_start, int& stolen_end, int& remain_start, int& remain_end) {
+    // return start tok index and end tok index to work on
+    WorkStealingTaskItem old, assumed_old, newval;
+    old.packed_u64_ = volatile_load(&item_.packed_u64_);  // relaxed atomic load?
+    int to_steal;
+    do {
+      auto old_chunk_start = old.chunk_start();
+      auto old_chunk_end = old.chunk_end();
+      auto remain = old_chunk_end - old_chunk_start;
+      to_steal = (remain - 1) / 2 + 1;
+      if (remain < 1 || to_steal < 1) {
+        return -1;
+      }
+      newval.packed_u64_ = old.packed_u64_ + WorkStealingTaskItem::delta(0, -to_steal);
+      assumed_old = old;
+      old.packed_ull_ = atomicCAS(&item_.packed_ull_, assumed_old.packed_ull_, newval.packed_ull_);
+    } while (assumed_old.packed_ull_ != old.packed_ull_);
+    remain_start = newval.chunk_start();
+    remain_end = newval.chunk_end();
+    stolen_start = remain_end;
+    stolen_end = stolen_start + to_steal;
+    return old.seq_head();
+  }
+};
+
+// NOTE: lbp_attention_init_workspace is in charge of workspace initialization
+struct WorkStealingWorkspace {
+  WorkStealingWorker workers_[WorkStealingConfig::MaxNumWorkers];
+  BrokerWorkDistributor<next_power_of_two(WorkStealingConfig::MaxNumWorkers * 2), int> work_queue_;
+  int logical_seq_head_idx_;
+  int32_t num_busy_workers_;
+  uint32_t steal_barrier_;
+  float2 max_sum_[WorkStealingConfig::MaxNumSeqs * WorkStealingConfig::MaxNumHeads];
+
+  static void init(WorkStealingWorkspace* self, stream_t stream) {
+    size_t size_in_bytes = reinterpret_cast<char*>(&self->max_sum_) - reinterpret_cast<char*>(self);
+    CUDA_CHECK(cudaMemsetAsync(self, 0, size_in_bytes, stream));
+  }
+};
+
+template <int NumThreads, int HeadSize, int PageSize, typename TIO, typename TKV, typename TSB>
+__global__ void
+__launch_bounds__(NumThreads, NumThreads / constant::WarpSize) lbp_attention_work_stealing_kernel(
+    void* __restrict__ workspace,
+    TIO* __restrict__ out,                   // [num_seqs, num_heads, head_size]
+    const TIO* __restrict__ q,               // [num_seqs, num_heads, head_size]
+    const TKV* __restrict__ k_cache,         // [num_pages, num_kv_heads, head_size/x, page_size, x]
+    const TKV* __restrict__ v_cache,         // [num_pages, num_kv_heads, head_size, page_size]
+    const TSB* __restrict__ scalebias,       // [num_pages, 2, num_kv_heads, 2, head_size/chunk_size, page_size]
+    const int* __restrict__ page_table,      // [num_seqs, max_num_pages_per_seq]
+    const int* __restrict__ context_lens,    // [num_seqs]
+    const float* __restrict__ alibi_slopes,  // [num_heads]
+    const float scale,
+    const int num_seqs,
+    const int num_heads,
+    const int num_kv_heads,
+    const int max_num_pages_per_seq,
+    const int q_stride
+)
+#if !defined(PAGED_SPLIT_COMPILATION) || defined(PAGED_ATTENTION_KERNEL_IMPL)
+{
+  using Task = PagedAttentionTask<
+      NumThreads, HeadSize, PageSize, TIO, TIO, TKV,
+      WorkStealingWorker, WorkStealingConfig, KVConfig<TSB>>;
+
+  __shared__ char broadcast_buffer[BROADCAST0_BUFFER_SIZE_IN_BYTES];
+  auto* ws = static_cast<WorkStealingWorkspace*>(workspace);
+
+  constexpr int NumWarps = NumThreads / constant::WarpSize;
+  constexpr int StatusAllWorkAssigned = -1;
+  auto& w = ws->workers_[my_worker_id];
+
+  while (true) {
+    int my_seq_head_idx = broadcast0<int>(broadcast_buffer, [&]() {
+      ws->work_queue_.enqueue(my_worker_id);
+      int my_seq_head_idx = atomicAdd(&(ws->logical_seq_head_idx_), 1);
+      if (my_seq_head_idx >= num_seqs * num_heads) {
+        return StatusAllWorkAssigned;
+      }
+
+      atomic_add_global_i32<memory_order::Relaxed>(&ws->num_busy_workers_, 1);
+
+      int seq_idx = my_seq_head_idx / num_heads;
+      int head_idx = my_seq_head_idx % num_heads;
+
+      if constexpr (WorkStealingConfig::UseHeadSeq) {
+        int head_seq_idx = head_idx * WorkStealingConfig::MaxNumSeqs + seq_idx;
+        atomic_init_max_sum(&ws->max_sum_[head_seq_idx]);
+      } else {
+        atomic_init_max_sum(&ws->max_sum_[my_seq_head_idx]);
+      }
+
+      w.initialize_tok(my_seq_head_idx, 0, context_lens[seq_idx], WorkStealingConfig::TaskChunkSeqLen);
+      TASK_DPRINTF("worker[%d]: seqhead:%d, seq:%d, head:%d, tok[%d,%d)\n", my_worker_id, my_seq_head_idx, seq_idx, my_seq_head_idx % num_heads, 0, context_lens[seq_idx]);
+      atomic_store_global_u32<memory_order::Relaxed>(&ws->steal_barrier_, 1);
+      return my_seq_head_idx;
+    });
+    if (my_seq_head_idx == StatusAllWorkAssigned) {
+      break;
+    }
+    __syncthreads();
+    int seq_idx = my_seq_head_idx / num_heads;
+    int head_idx = my_seq_head_idx % num_heads;
+    int num_queries_per_kv = num_heads / num_kv_heads;
+    int kv_head_idx = head_idx / (num_queries_per_kv / WorkStealingConfig::NumQueriesPerCta);  // broadcasting kv_head
+    Task::attention(
+        broadcast_buffer, &w, seq_idx, head_idx, kv_head_idx, out, ws->max_sum_,
+        q, k_cache, v_cache, scalebias, page_table, context_lens, alibi_slopes,
+        scale, num_seqs, num_heads, num_kv_heads, max_num_pages_per_seq, q_stride
+    );
+    if (threadIdx.x == (NumWarps - 1) * constant::WarpSize) {
+      atomic_add_global_i32<memory_order::Relaxed>(&ws->num_busy_workers_, -1);
+    }
+    __syncthreads();
+  }
+
+  if (threadIdx.x == 0) {
+    while (!atomic_load_global_u32<memory_order::Relaxed>(&ws->steal_barrier_));
+  }
+  __syncthreads();
+  TASK_DPRINTF1("worker[%d] enter stealing state...\n", my_worker_id);
+
+  while (true) {
+    constexpr int StatusAllWorkDone = -1;
+    constexpr int StatusStealFailure = -2;
+
+    // get worker_id to steal from
+    int status_or_stolen_seq_head_idx = broadcast0<int>(broadcast_buffer, [&]() {
+      if (atomic_load_global_u32<memory_order::Relaxed>((uint32_t*)&ws->num_busy_workers_) == 0) {
+        return StatusAllWorkDone;
+      }
+      int victim_id = -1;
+      if (!ws->work_queue_.dequeue(victim_id)) {
+        return StatusStealFailure;
+      }
+      if (victim_id == my_worker_id) {
+        return StatusStealFailure;
+      }
+      TASK_DPRINTF("??worker[%d]: tried to steal from worker[%d]\n", my_worker_id, victim_id);
+
+      int stolen_seq_head_idx, stolen_chunk_start, stolen_chunk_end, remain_chunk_start, remain_chunk_end;
+      auto& victim = ws->workers_[victim_id];
+      stolen_seq_head_idx = victim.steal(stolen_chunk_start, stolen_chunk_end, remain_chunk_start, remain_chunk_end);
+      if (stolen_seq_head_idx < 0) {
+        return StatusStealFailure;
+      }
+
+      // the victim might be eligible being victim again, it is rich!
+      if (remain_chunk_end - remain_chunk_start > 0) {
+        ws->work_queue_.enqueue(victim_id);
+      }
+      TASK_DPRINTF(
+          "!!worker[%d]: stole from worker[%d], seqhead:%d, chunk[%d,%d), remain chunk[%d,%d)\n",
+          my_worker_id, victim_id, stolen_seq_head_idx, stolen_chunk_start, stolen_chunk_end, remain_chunk_start, remain_chunk_end
+      );
+
+      auto& w = ws->workers_[my_worker_id];
+      w.initialize_chunk(stolen_seq_head_idx, stolen_chunk_start, stolen_chunk_end);
+      atomic_add_global_i32<memory_order::Relaxed>(&ws->num_busy_workers_, 1);
+      if (stolen_chunk_end - stolen_chunk_start > 1) {
+        TASK_DPRINTF("$$worker[%d]: volunteered\n", my_worker_id);
+        ws->work_queue_.enqueue(my_worker_id);  // rich now, volunteered to be stolen ==)
+      }
+      return stolen_seq_head_idx;
+    });
+    __syncthreads();
+
+    int status = status_or_stolen_seq_head_idx;
+    if (status == StatusAllWorkDone) {
+      break;
+    }
+    if (status == StatusStealFailure) {
+      continue;
+    }
+
+    int stolen_seq_head_idx = status_or_stolen_seq_head_idx;
+    int seq_idx = stolen_seq_head_idx / num_heads;
+    int head_idx = stolen_seq_head_idx % num_heads;
+    int num_queries_per_kv = num_heads / num_kv_heads;
+    int kv_head_idx = head_idx / (num_queries_per_kv / WorkStealingConfig::NumQueriesPerCta);  // broadcasting kv_head
+    Task::attention(
+        broadcast_buffer, &w, seq_idx, head_idx, kv_head_idx, out, ws->max_sum_,
+        q, k_cache, v_cache, scalebias, page_table, context_lens, alibi_slopes,
+        scale, num_seqs, num_heads, num_kv_heads, max_num_pages_per_seq, q_stride
+    );
+    if (threadIdx.x == (1 % NumWarps) * constant::WarpSize) {
+      atomic_add_global_i32<memory_order::Relaxed>(&ws->num_busy_workers_, -1);
+    }
+    __syncthreads();
+  }
+
+  static_assert(WorkStealingConfig::InplaceFlashAcc);
+  TASK_DPRINTF1("worker[%d] exit\n", my_worker_id);
+}
+#else
+    ;
+#endif
+
+}  // namespace onnxruntime::contrib::paged
+
+#undef TASK_DPRINTF_ENABLE
+#undef TASK_DPRINTF
+#undef TASK_DPRINTF1
+#undef my_worker_id

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/paged_attention.cmake
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/paged_attention.cmake
@@ -1,0 +1,280 @@
+set(dtype_mapping_void "void")
+set(dtype_mapping_fp32 "float")
+set(dtype_mapping_fp16 "half")
+set(dtype_mapping_bf16 "__nv_bfloat16")
+set(dtype_mapping_f8e4m3fn "float8_e4m3fn_t")
+set(dtype_mapping_f8e4m3fnuz "float8_e4m3fnuz_t")
+set(dtype_mapping_i8 "int8_t")
+
+function(expand_template_to_srcs)
+  set(options "")
+  set(one_value_keywords "GENERATE" "TEMPLATE" "PREFIX")
+  set(multi_value_keywords "DTYPEIO_DTYPEKV_DTYPESB_NUMTHREAD_HEADSIZE_PAGESIZE")
+  cmake_parse_arguments(expand "${options}" "${one_value_keywords}" "${multi_value_keywords}" ${ARGN})
+
+  set(generated_files)
+  foreach(item_str ${expand_DTYPEIO_DTYPEKV_DTYPESB_NUMTHREAD_HEADSIZE_PAGESIZE})
+    # list(GET ${item})
+    string(REPLACE " " ";" items ${item_str})
+    set(items ${items} "")
+    list(GET items 0 TIO)
+    list(GET items 1 TKV)
+    list(GET items 2 TSB)
+    list(GET items 3 NUM_THREADS)
+    list(GET items 4 HEAD_SIZE)
+    list(GET items 5 PAGE_SIZE)
+    list(GET items 6 defs)
+    set(out "${CMAKE_CURRENT_BINARY_DIR}/${expand_PREFIX}_${TIO}_${TKV}_${TSB}_${NUM_THREADS}_${HEAD_SIZE}_${PAGE_SIZE}.cu")
+
+    set(TIO ${dtype_mapping_${TIO}})
+    set(TKV ${dtype_mapping_${TKV}})
+    set(TSB ${dtype_mapping_${TSB}})
+    configure_file(${expand_TEMPLATE} ${out} @ONLY)
+
+    if (defs)
+      string(REPLACE "," ";" defs ${defs})
+      set_property(SOURCE ${out} PROPERTY COMPILE_DEFINITIONS ${defs})  # NOTE: will append, overwrite if key is duplicated
+    endif()
+
+    list(APPEND generated_files ${out})
+  endforeach()
+
+  set_source_files_properties(${generated_files} PROPERTIES GENERATED TRUE)
+  set(${expand_GENERATE} ${generated_files} PARENT_SCOPE)
+endfunction()
+
+if (NOT paged_attention_template_dir)
+  set(paged_attention_template_dir ${CMAKE_CURRENT_LIST_DIR})
+endif()
+
+expand_template_to_srcs(
+  GENERATE paged_attention_srcs_paged
+  TEMPLATE ${paged_attention_template_dir}/paged_attention.cu.in
+  PREFIX paged
+  DTYPEIO_DTYPEKV_DTYPESB_NUMTHREAD_HEADSIZE_PAGESIZE
+  # fp32 kernels
+  "fp32 fp32 void 128 64 8"
+  "fp32 fp32 void 128 80 8"
+  "fp32 fp32 void 128 96 8"
+  "fp32 fp32 void 128 112 8"
+  "fp32 fp32 void 128 128 8"
+  "fp32 fp32 void 128 256 8"
+  "fp32 fp32 void 128 64 16"
+  "fp32 fp32 void 128 80 16"
+  "fp32 fp32 void 128 96 16"
+  "fp32 fp32 void 128 112 16"
+  "fp32 fp32 void 128 128 16"
+  "fp32 fp32 void 128 256 16"
+  "fp32 fp32 void 128 64 32"
+  "fp32 fp32 void 128 80 32"
+  "fp32 fp32 void 128 96 32"
+  "fp32 fp32 void 128 112 32"
+  "fp32 fp32 void 128 128 32"
+  "fp32 fp32 void 128 256 32"
+  # fp16 kernels
+  "fp16 fp16 void 128 64 8"
+  "fp16 fp16 void 128 80 8"
+  "fp16 fp16 void 128 96 8"
+  "fp16 fp16 void 128 112 8"
+  "fp16 fp16 void 128 128 8"
+  "fp16 fp16 void 128 256 8"
+  "fp16 fp16 void 128 64 16"
+  "fp16 fp16 void 128 80 16"
+  "fp16 fp16 void 128 96 16 PAGED_ATTENTION_MAXNREG=72"
+  "fp16 fp16 void 128 112 16"
+  "fp16 fp16 void 128 128 16 PAGED_ATTENTION_MAXNREG=80"
+  "fp16 fp16 void 128 256 16"
+  "fp16 fp16 void 128 64 32"
+  "fp16 fp16 void 128 80 32"
+  "fp16 fp16 void 128 96 32"
+  "fp16 fp16 void 128 112 32"
+  "fp16 fp16 void 128 128 32"
+  "fp16 fp16 void 128 256 32"
+  # fp8 kernels
+  "fp16 f8e4m3fn fp16 128 64 8"
+  "fp16 f8e4m3fn fp16 128 80 8"
+  "fp16 f8e4m3fn fp16 128 96 8"
+  "fp16 f8e4m3fn fp16 128 112 8"
+  "fp16 f8e4m3fn fp16 128 128 8"
+  "fp16 f8e4m3fn fp16 128 256 8"
+  "fp16 f8e4m3fn fp16 128 64 16"
+  "fp16 f8e4m3fn fp16 128 80 16"
+  "fp16 f8e4m3fn fp16 128 96 16 PAGED_ATTENTION_MAXNREG=80"
+  "fp16 f8e4m3fn fp16 128 112 16"
+  "fp16 f8e4m3fn fp16 128 128 16 PAGED_ATTENTION_MAXNREG=96"
+  "fp16 f8e4m3fn fp16 128 256 16"
+  "fp16 f8e4m3fn fp16 128 64 32"
+  "fp16 f8e4m3fn fp16 128 80 32"
+  "fp16 f8e4m3fn fp16 128 96 32"
+  "fp16 f8e4m3fn fp16 128 112 32"
+  "fp16 f8e4m3fn fp16 128 128 32"
+  "fp16 f8e4m3fn fp16 128 256 32"
+)
+
+expand_template_to_srcs(
+  GENERATE paged_attention_srcs_lbp_ws
+  TEMPLATE ${paged_attention_template_dir}/lbp_attention_ws.cu.in
+  PREFIX lbp_ws
+  DTYPEIO_DTYPEKV_DTYPESB_NUMTHREAD_HEADSIZE_PAGESIZE
+  # fp16 kernels
+  "fp16 fp16 void 128 64 8"
+  "fp16 fp16 void 128 80 8"
+  "fp16 fp16 void 128 96 8"
+  "fp16 fp16 void 128 112 8"
+  "fp16 fp16 void 128 128 8"
+  "fp16 fp16 void 128 256 8"
+  "fp16 fp16 void 128 64 16"
+  "fp16 fp16 void 128 80 16"
+  "fp16 fp16 void 128 96 16"
+  "fp16 fp16 void 128 112 16"
+  "fp16 fp16 void 128 128 16"
+  "fp16 fp16 void 128 256 16"
+  "fp16 fp16 void 128 64 32"
+  "fp16 fp16 void 128 80 32"
+  "fp16 fp16 void 128 96 32"
+  "fp16 fp16 void 128 112 32"
+  "fp16 fp16 void 128 128 32"
+  "fp16 fp16 void 128 256 32"
+  # fp8 kernels
+  "fp16 f8e4m3fn fp16 128 64 8"
+  "fp16 f8e4m3fn fp16 128 80 8"
+  "fp16 f8e4m3fn fp16 128 96 8"
+  "fp16 f8e4m3fn fp16 128 112 8"
+  "fp16 f8e4m3fn fp16 128 128 8"
+  "fp16 f8e4m3fn fp16 128 256 8"
+  "fp16 f8e4m3fn fp16 128 64 16"
+  "fp16 f8e4m3fn fp16 128 80 16"
+  "fp16 f8e4m3fn fp16 128 96 16"
+  "fp16 f8e4m3fn fp16 128 112 16"
+  "fp16 f8e4m3fn fp16 128 128 16"
+  "fp16 f8e4m3fn fp16 128 256 16"
+  "fp16 f8e4m3fn fp16 128 64 32"
+  "fp16 f8e4m3fn fp16 128 80 32"
+  "fp16 f8e4m3fn fp16 128 96 32"
+  "fp16 f8e4m3fn fp16 128 112 32"
+  "fp16 f8e4m3fn fp16 128 128 32"
+  "fp16 f8e4m3fn fp16 128 256 32"
+)
+
+expand_template_to_srcs(
+  GENERATE paged_attention_srcs_lbp_dpi
+  TEMPLATE ${paged_attention_template_dir}/lbp_attention_dpi.cu.in
+  PREFIX lbp_dpi
+  DTYPEIO_DTYPEKV_DTYPESB_NUMTHREAD_HEADSIZE_PAGESIZE
+  # fp16 kernels
+  "fp16 fp16 void 128 64 8"
+  "fp16 fp16 void 128 80 8"
+  "fp16 fp16 void 128 96 8"
+  "fp16 fp16 void 128 112 8"
+  "fp16 fp16 void 128 128 8"
+  "fp16 fp16 void 128 256 8"
+  "fp16 fp16 void 128 64 16"
+  "fp16 fp16 void 128 80 16"
+  "fp16 fp16 void 128 96 16 PAGED_ATTENTION_MAXNREG=72"
+  "fp16 fp16 void 128 112 16"
+  "fp16 fp16 void 128 128 16 PAGED_ATTENTION_MAXNREG=80"
+  "fp16 fp16 void 128 256 16"
+  "fp16 fp16 void 128 64 32"
+  "fp16 fp16 void 128 80 32"
+  "fp16 fp16 void 128 96 32"
+  "fp16 fp16 void 128 112 32"
+  "fp16 fp16 void 128 128 32"
+  "fp16 fp16 void 128 256 32"
+  # fp8 kernels
+  "fp16 f8e4m3fn fp16 128 64 8"
+  "fp16 f8e4m3fn fp16 128 80 8"
+  "fp16 f8e4m3fn fp16 128 96 8"
+  "fp16 f8e4m3fn fp16 128 112 8"
+  "fp16 f8e4m3fn fp16 128 128 8"
+  "fp16 f8e4m3fn fp16 128 256 8"
+  "fp16 f8e4m3fn fp16 128 64 16"
+  "fp16 f8e4m3fn fp16 128 80 16"
+  "fp16 f8e4m3fn fp16 128 96 16 PAGED_ATTENTION_MAXNREG=96"
+  "fp16 f8e4m3fn fp16 128 112 16"
+  "fp16 f8e4m3fn fp16 128 128 16 PAGED_ATTENTION_MAXNREG=96"
+  "fp16 f8e4m3fn fp16 128 256 16"
+  "fp16 f8e4m3fn fp16 128 64 32"
+  "fp16 f8e4m3fn fp16 128 80 32"
+  "fp16 f8e4m3fn fp16 128 96 32"
+  "fp16 f8e4m3fn fp16 128 112 32"
+  "fp16 f8e4m3fn fp16 128 128 32"
+  "fp16 f8e4m3fn fp16 128 256 32"
+)
+
+expand_template_to_srcs(
+  GENERATE paged_attention_srcs_lbp_dpo
+  TEMPLATE ${paged_attention_template_dir}/lbp_attention_dpo.cu.in
+  PREFIX lbp_dpo
+  DTYPEIO_DTYPEKV_DTYPESB_NUMTHREAD_HEADSIZE_PAGESIZE
+  # fp16 kernels
+  "fp16 fp16 void 128 64 8"
+  "fp16 fp16 void 128 80 8"
+  "fp16 fp16 void 128 96 8"
+  "fp16 fp16 void 128 112 8"
+  "fp16 fp16 void 128 128 8"
+  "fp16 fp16 void 128 256 8"
+  "fp16 fp16 void 128 64 16"
+  "fp16 fp16 void 128 80 16"
+  "fp16 fp16 void 128 96 16 PAGED_ATTENTION_MAXNREG=72"
+  "fp16 fp16 void 128 112 16"
+  "fp16 fp16 void 128 128 16 PAGED_ATTENTION_MAXNREG=80"
+  "fp16 fp16 void 128 256 16"
+  "fp16 fp16 void 128 64 32"
+  "fp16 fp16 void 128 80 32"
+  "fp16 fp16 void 128 96 32"
+  "fp16 fp16 void 128 112 32"
+  "fp16 fp16 void 128 128 32"
+  "fp16 fp16 void 128 256 32"
+  # fp8 kernels
+  "fp16 f8e4m3fn fp16 128 64 8"
+  "fp16 f8e4m3fn fp16 128 80 8"
+  "fp16 f8e4m3fn fp16 128 96 8"
+  "fp16 f8e4m3fn fp16 128 112 8"
+  "fp16 f8e4m3fn fp16 128 128 8"
+  "fp16 f8e4m3fn fp16 128 256 8"
+  "fp16 f8e4m3fn fp16 128 64 16"
+  "fp16 f8e4m3fn fp16 128 80 16"
+  "fp16 f8e4m3fn fp16 128 96 16 PAGED_ATTENTION_MAXNREG=96"
+  "fp16 f8e4m3fn fp16 128 112 16"
+  "fp16 f8e4m3fn fp16 128 128 16 PAGED_ATTENTION_MAXNREG=96"
+  "fp16 f8e4m3fn fp16 128 256 16"
+  "fp16 f8e4m3fn fp16 128 64 32"
+  "fp16 f8e4m3fn fp16 128 80 32"
+  "fp16 f8e4m3fn fp16 128 96 32"
+  "fp16 f8e4m3fn fp16 128 112 32"
+  "fp16 f8e4m3fn fp16 128 128 32"
+  "fp16 f8e4m3fn fp16 128 256 32"
+)
+
+expand_template_to_srcs(
+  GENERATE paged_attention_srcs_reshape_and_cache
+  TEMPLATE ${paged_attention_template_dir}/reshape_and_cache.cu.in
+  PREFIX reshape_and_cache
+  DTYPEIO_DTYPEKV_DTYPESB_NUMTHREAD_HEADSIZE_PAGESIZE
+  "fp16 f8e4m3fn fp16 128 64 8"
+  "fp16 f8e4m3fn fp16 128 80 8"
+  "fp16 f8e4m3fn fp16 128 96 8"
+  "fp16 f8e4m3fn fp16 128 112 8"
+  "fp16 f8e4m3fn fp16 128 128 8"
+  "fp16 f8e4m3fn fp16 128 256 8"
+  "fp16 f8e4m3fn fp16 128 64 16"
+  "fp16 f8e4m3fn fp16 128 80 16"
+  "fp16 f8e4m3fn fp16 128 96 16"
+  "fp16 f8e4m3fn fp16 128 112 16"
+  "fp16 f8e4m3fn fp16 128 128 16"
+  "fp16 f8e4m3fn fp16 128 256 16"
+  "fp16 f8e4m3fn fp16 128 64 32"
+  "fp16 f8e4m3fn fp16 128 80 32"
+  "fp16 f8e4m3fn fp16 128 96 32"
+  "fp16 f8e4m3fn fp16 128 112 32"
+  "fp16 f8e4m3fn fp16 128 128 32"
+  "fp16 f8e4m3fn fp16 128 256 32"
+)
+
+set(paged_attention_generated_srcs
+  ${paged_attention_srcs_paged}
+  ${paged_attention_srcs_lbp_ws}
+  ${paged_attention_srcs_lbp_dpi}
+  ${paged_attention_srcs_lbp_dpo}
+  ${paged_attention_srcs_reshape_and_cache}
+)

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/paged_attention.cmake
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/paged_attention.cmake
@@ -1,3 +1,7 @@
+if (NOT paged_attention_template_dir)
+  set(paged_attention_template_dir ${CMAKE_CURRENT_LIST_DIR})
+endif()
+
 set(dtype_mapping_void "void")
 set(dtype_mapping_fp32 "float")
 set(dtype_mapping_fp16 "half")
@@ -8,27 +12,41 @@ set(dtype_mapping_i8 "int8_t")
 
 function(expand_template_to_srcs)
   set(options "")
-  set(one_value_keywords "GENERATE" "TEMPLATE" "PREFIX")
-  set(multi_value_keywords "DTYPEIO_DTYPEKV_DTYPESB_NUMTHREAD_HEADSIZE_PAGESIZE")
+  set(one_value_keywords "GENERATE" "TEMPLATE" "PREFIX" "NUM_QUERIES_PER_KV")
+  set(multi_value_keywords "CONFIGS")
   cmake_parse_arguments(expand "${options}" "${one_value_keywords}" "${multi_value_keywords}" ${ARGN})
 
+  list(GET expand_CONFIGS 0 config_header)
+  list(REMOVE_AT expand_CONFIGS 0)
+  string(REPLACE " " ";" config_header ${config_header})
+  list(LENGTH config_header num_keywords)  # then value at num_keywords is defs
+  math(EXPR num_keywords_1 "${num_keywords}-1")
+
   set(generated_files)
-  foreach(item_str ${expand_DTYPEIO_DTYPEKV_DTYPESB_NUMTHREAD_HEADSIZE_PAGESIZE})
+  foreach(item_str ${expand_CONFIGS})
     # list(GET ${item})
     string(REPLACE " " ";" items ${item_str})
     set(items ${items} "")
-    list(GET items 0 TIO)
-    list(GET items 1 TKV)
-    list(GET items 2 TSB)
-    list(GET items 3 NUM_THREADS)
-    list(GET items 4 HEAD_SIZE)
-    list(GET items 5 PAGE_SIZE)
-    list(GET items 6 defs)
-    set(out "${CMAKE_CURRENT_BINARY_DIR}/${expand_PREFIX}_${TIO}_${TKV}_${TSB}_${NUM_THREADS}_${HEAD_SIZE}_${PAGE_SIZE}.cu")
+    set(basename)
+    foreach(idx RANGE ${num_keywords_1})
+      list(GET config_header ${idx} key)
+      list(GET items ${idx} value)
+      string(APPEND basename " ${value}")
 
-    set(TIO ${dtype_mapping_${TIO}})
-    set(TKV ${dtype_mapping_${TKV}})
-    set(TSB ${dtype_mapping_${TSB}})
+      # apply local value for local expend
+      set(dtype_expended "${dtype_mapping_${value}}")
+      if (dtype_expended)
+        set(${key} ${dtype_expended})
+      else()
+        set(${key} ${value})
+      endif()
+    endforeach()
+
+    list(GET items ${num_keywords} defs)  # then value at num_keywords is defs
+    string(STRIP ${basename} basename)
+    string(REPLACE " " "_" basename ${basename})
+
+    set(out "${CMAKE_CURRENT_BINARY_DIR}/${expand_PREFIX}_${basename}.cu")
     configure_file(${expand_TEMPLATE} ${out} @ONLY)
 
     if (defs)
@@ -43,79 +61,172 @@ function(expand_template_to_srcs)
   set(${expand_GENERATE} ${generated_files} PARENT_SCOPE)
 endfunction()
 
-if (NOT paged_attention_template_dir)
-  set(paged_attention_template_dir ${CMAKE_CURRENT_LIST_DIR})
-endif()
-
 expand_template_to_srcs(
   GENERATE paged_attention_srcs_paged
   TEMPLATE ${paged_attention_template_dir}/paged_attention.cu.in
   PREFIX paged
-  DTYPEIO_DTYPEKV_DTYPESB_NUMTHREAD_HEADSIZE_PAGESIZE
+  CONFIGS
+  "TIO TKV TSB NUM_THREADS HEAD_SIZE PAGE_SIZE NUM_QUERIES_PER_KV"
   # fp32 kernels
-  "fp32 fp32 void 128 64 8"
-  "fp32 fp32 void 128 80 8"
-  "fp32 fp32 void 128 96 8"
-  "fp32 fp32 void 128 112 8"
-  "fp32 fp32 void 128 128 8"
-  "fp32 fp32 void 128 256 8"
-  "fp32 fp32 void 128 64 16"
-  "fp32 fp32 void 128 80 16"
-  "fp32 fp32 void 128 96 16"
-  "fp32 fp32 void 128 112 16"
-  "fp32 fp32 void 128 128 16"
-  "fp32 fp32 void 128 256 16"
-  "fp32 fp32 void 128 64 32"
-  "fp32 fp32 void 128 80 32"
-  "fp32 fp32 void 128 96 32"
-  "fp32 fp32 void 128 112 32"
-  "fp32 fp32 void 128 128 32"
-  "fp32 fp32 void 128 256 32"
+  "fp32 fp32 void 128 64 8 1"
+  "fp32 fp32 void 128 80 8 1"
+  "fp32 fp32 void 128 96 8 1"
+  "fp32 fp32 void 128 112 8 1"
+  "fp32 fp32 void 128 128 8 1"
+  "fp32 fp32 void 128 256 8 1"
+  "fp32 fp32 void 128 64 16 1"
+  "fp32 fp32 void 128 80 16 1"
+  "fp32 fp32 void 128 96 16 1"
+  "fp32 fp32 void 128 112 16 1"
+  "fp32 fp32 void 128 128 16 1"
+  "fp32 fp32 void 128 256 16 1"
+  "fp32 fp32 void 128 64 32 1"
+  "fp32 fp32 void 128 80 32 1"
+  "fp32 fp32 void 128 96 32 1"
+  "fp32 fp32 void 128 112 32 1"
+  "fp32 fp32 void 128 128 32 1"
+  "fp32 fp32 void 128 256 32 1"
   # fp16 kernels
-  "fp16 fp16 void 128 64 8"
-  "fp16 fp16 void 128 80 8"
-  "fp16 fp16 void 128 96 8"
-  "fp16 fp16 void 128 112 8"
-  "fp16 fp16 void 128 128 8"
-  "fp16 fp16 void 128 256 8"
-  "fp16 fp16 void 128 64 16"
-  "fp16 fp16 void 128 80 16"
-  "fp16 fp16 void 128 96 16 PAGED_ATTENTION_MAXNREG=72"
-  "fp16 fp16 void 128 112 16"
-  "fp16 fp16 void 128 128 16 PAGED_ATTENTION_MAXNREG=80"
-  "fp16 fp16 void 128 256 16"
-  "fp16 fp16 void 128 64 32"
-  "fp16 fp16 void 128 80 32"
-  "fp16 fp16 void 128 96 32"
-  "fp16 fp16 void 128 112 32"
-  "fp16 fp16 void 128 128 32"
-  "fp16 fp16 void 128 256 32"
+  "fp16 fp16 void 128 64 8 1"
+  "fp16 fp16 void 128 80 8 1"
+  "fp16 fp16 void 128 96 8 1"
+  "fp16 fp16 void 128 112 8 1"
+  "fp16 fp16 void 128 128 8 1"
+  "fp16 fp16 void 128 256 8 1"
+  "fp16 fp16 void 128 64 16 1"
+  "fp16 fp16 void 128 80 16 1"
+  "fp16 fp16 void 128 96 16 1 PAGED_ATTENTION_MAXNREG=72"
+  "fp16 fp16 void 128 112 16 1"
+  "fp16 fp16 void 128 128 16 1 PAGED_ATTENTION_MAXNREG=80"
+  "fp16 fp16 void 128 256 16 1"
+  "fp16 fp16 void 128 64 32 1"
+  "fp16 fp16 void 128 80 32 1"
+  "fp16 fp16 void 128 96 32 1"
+  "fp16 fp16 void 128 112 32 1"
+  "fp16 fp16 void 128 128 32 1"
+  "fp16 fp16 void 128 256 32 1"
   # fp8 kernels
-  "fp16 f8e4m3fn fp16 128 64 8"
-  "fp16 f8e4m3fn fp16 128 80 8"
-  "fp16 f8e4m3fn fp16 128 96 8"
-  "fp16 f8e4m3fn fp16 128 112 8"
-  "fp16 f8e4m3fn fp16 128 128 8"
-  "fp16 f8e4m3fn fp16 128 256 8"
-  "fp16 f8e4m3fn fp16 128 64 16"
-  "fp16 f8e4m3fn fp16 128 80 16"
-  "fp16 f8e4m3fn fp16 128 96 16 PAGED_ATTENTION_MAXNREG=80"
-  "fp16 f8e4m3fn fp16 128 112 16"
-  "fp16 f8e4m3fn fp16 128 128 16 PAGED_ATTENTION_MAXNREG=96"
-  "fp16 f8e4m3fn fp16 128 256 16"
-  "fp16 f8e4m3fn fp16 128 64 32"
-  "fp16 f8e4m3fn fp16 128 80 32"
-  "fp16 f8e4m3fn fp16 128 96 32"
-  "fp16 f8e4m3fn fp16 128 112 32"
-  "fp16 f8e4m3fn fp16 128 128 32"
-  "fp16 f8e4m3fn fp16 128 256 32"
+  "fp16 f8e4m3fn fp16 128 64 8 1"
+  "fp16 f8e4m3fn fp16 128 80 8 1"
+  "fp16 f8e4m3fn fp16 128 96 8 1"
+  "fp16 f8e4m3fn fp16 128 112 8 1"
+  "fp16 f8e4m3fn fp16 128 128 8 1"
+  "fp16 f8e4m3fn fp16 128 256 8 1"
+  "fp16 f8e4m3fn fp16 128 64 16 1"
+  "fp16 f8e4m3fn fp16 128 80 16 1"
+  "fp16 f8e4m3fn fp16 128 96 16 1 PAGED_ATTENTION_MAXNREG=80"
+  "fp16 f8e4m3fn fp16 128 112 16 1"
+  "fp16 f8e4m3fn fp16 128 128 16 1 PAGED_ATTENTION_MAXNREG=96"
+  "fp16 f8e4m3fn fp16 128 256 16 1"
+  "fp16 f8e4m3fn fp16 128 64 32 1"
+  "fp16 f8e4m3fn fp16 128 80 32 1"
+  "fp16 f8e4m3fn fp16 128 96 32 1"
+  "fp16 f8e4m3fn fp16 128 112 32 1"
+  "fp16 f8e4m3fn fp16 128 128 32 1"
+  "fp16 f8e4m3fn fp16 128 256 32 1"
+  # fp32 kernels gqa4
+  "fp32 fp32 void 128 64 8 4"
+  "fp32 fp32 void 128 80 8 4"
+  "fp32 fp32 void 128 96 8 4"
+  "fp32 fp32 void 128 112 8 4"
+  "fp32 fp32 void 128 128 8 4"
+  "fp32 fp32 void 128 256 8 4"
+  "fp32 fp32 void 128 64 16 4"
+  "fp32 fp32 void 128 80 16 4"
+  "fp32 fp32 void 128 96 16 4"
+  "fp32 fp32 void 128 112 16 4"
+  "fp32 fp32 void 128 128 16 4"
+  "fp32 fp32 void 128 256 16 4"
+  "fp32 fp32 void 128 64 32 4"
+  "fp32 fp32 void 128 80 32 4"
+  "fp32 fp32 void 128 96 32 4"
+  "fp32 fp32 void 128 112 32 4"
+  "fp32 fp32 void 128 128 32 4"
+  "fp32 fp32 void 128 256 32 4"
+  # fp16 kernels gqa4
+  "fp16 fp16 void 128 64 8 4"
+  "fp16 fp16 void 128 80 8 4"
+  "fp16 fp16 void 128 96 8 4"
+  "fp16 fp16 void 128 112 8 4"
+  "fp16 fp16 void 128 128 8 4"
+  "fp16 fp16 void 128 256 8 4"
+  "fp16 fp16 void 128 64 16 4"
+  "fp16 fp16 void 128 80 16 4"
+  "fp16 fp16 void 128 96 16 4"
+  "fp16 fp16 void 128 112 16 4"
+  "fp16 fp16 void 128 128 16 4"
+  "fp16 fp16 void 128 256 16 4"
+  "fp16 fp16 void 128 64 32 4"
+  "fp16 fp16 void 128 80 32 4"
+  "fp16 fp16 void 128 96 32 4"
+  "fp16 fp16 void 128 112 32 4"
+  "fp16 fp16 void 128 128 32 4"
+  "fp16 fp16 void 128 256 32 4"
+  # fp8 kernels gqa4
+  "fp16 f8e4m3fn fp16 128 64 8 4"
+  "fp16 f8e4m3fn fp16 128 80 8 4"
+  "fp16 f8e4m3fn fp16 128 96 8 4"
+  "fp16 f8e4m3fn fp16 128 112 8 4"
+  "fp16 f8e4m3fn fp16 128 128 8 4"
+  "fp16 f8e4m3fn fp16 128 256 8 4"
+  "fp16 f8e4m3fn fp16 128 64 16 4"
+  "fp16 f8e4m3fn fp16 128 80 16 4"
+  "fp16 f8e4m3fn fp16 128 96 16 4"
+  "fp16 f8e4m3fn fp16 128 112 16 4"
+  "fp16 f8e4m3fn fp16 128 128 16 4"
+  "fp16 f8e4m3fn fp16 128 256 16 4"
+  "fp16 f8e4m3fn fp16 128 64 32 4"
+  "fp16 f8e4m3fn fp16 128 80 32 4"
+  "fp16 f8e4m3fn fp16 128 96 32 4"
+  "fp16 f8e4m3fn fp16 128 112 32 4"
+  "fp16 f8e4m3fn fp16 128 128 32 4"
+  "fp16 f8e4m3fn fp16 128 256 32 4"
+  # fp16 kernels gqa8
+  "fp16 fp16 void 128 64 8 8"
+  "fp16 fp16 void 128 80 8 8"
+  "fp16 fp16 void 128 96 8 8"
+  "fp16 fp16 void 128 112 8 8"
+  "fp16 fp16 void 128 128 8 8"
+  "fp16 fp16 void 128 256 8 8"
+  "fp16 fp16 void 128 64 16 8"
+  "fp16 fp16 void 128 80 16 8"
+  "fp16 fp16 void 128 96 16 8"
+  "fp16 fp16 void 128 112 16 8"
+  "fp16 fp16 void 128 128 16 8"
+  "fp16 fp16 void 128 256 16 8"
+  "fp16 fp16 void 128 64 32 8"
+  "fp16 fp16 void 128 80 32 8"
+  "fp16 fp16 void 128 96 32 8"
+  "fp16 fp16 void 128 112 32 8"
+  "fp16 fp16 void 128 128 32 8"
+  "fp16 fp16 void 128 256 32 8"
+  # fp8 kernels gqa8
+  "fp16 f8e4m3fn fp16 128 64 8 8"
+  "fp16 f8e4m3fn fp16 128 80 8 8"
+  "fp16 f8e4m3fn fp16 128 96 8 8"
+  "fp16 f8e4m3fn fp16 128 112 8 8"
+  "fp16 f8e4m3fn fp16 128 128 8 8"
+  "fp16 f8e4m3fn fp16 128 256 8 8"
+  "fp16 f8e4m3fn fp16 128 64 16 8"
+  "fp16 f8e4m3fn fp16 128 80 16 8"
+  "fp16 f8e4m3fn fp16 128 96 16 8"
+  "fp16 f8e4m3fn fp16 128 112 16 8"
+  "fp16 f8e4m3fn fp16 128 128 16 8"
+  "fp16 f8e4m3fn fp16 128 256 16 8"
+  "fp16 f8e4m3fn fp16 128 64 32 8"
+  "fp16 f8e4m3fn fp16 128 80 32 8"
+  "fp16 f8e4m3fn fp16 128 96 32 8"
+  "fp16 f8e4m3fn fp16 128 112 32 8"
+  "fp16 f8e4m3fn fp16 128 128 32 8"
+  "fp16 f8e4m3fn fp16 128 256 32 8"
 )
 
 expand_template_to_srcs(
   GENERATE paged_attention_srcs_lbp_ws
   TEMPLATE ${paged_attention_template_dir}/lbp_attention_ws.cu.in
   PREFIX lbp_ws
-  DTYPEIO_DTYPEKV_DTYPESB_NUMTHREAD_HEADSIZE_PAGESIZE
+  CONFIGS
+  "TIO TKV TSB NUM_THREADS HEAD_SIZE PAGE_SIZE"
   # fp16 kernels
   "fp16 fp16 void 128 64 8"
   "fp16 fp16 void 128 80 8"
@@ -160,97 +271,274 @@ expand_template_to_srcs(
   GENERATE paged_attention_srcs_lbp_dpi
   TEMPLATE ${paged_attention_template_dir}/lbp_attention_dpi.cu.in
   PREFIX lbp_dpi
-  DTYPEIO_DTYPEKV_DTYPESB_NUMTHREAD_HEADSIZE_PAGESIZE
+  CONFIGS
+  "TIO TKV TSB NUM_THREADS HEAD_SIZE PAGE_SIZE NUM_QUERIES_PER_KV"
   # fp16 kernels
-  "fp16 fp16 void 128 64 8"
-  "fp16 fp16 void 128 80 8"
-  "fp16 fp16 void 128 96 8"
-  "fp16 fp16 void 128 112 8"
-  "fp16 fp16 void 128 128 8"
-  "fp16 fp16 void 128 256 8"
-  "fp16 fp16 void 128 64 16"
-  "fp16 fp16 void 128 80 16"
-  "fp16 fp16 void 128 96 16 PAGED_ATTENTION_MAXNREG=72"
-  "fp16 fp16 void 128 112 16"
-  "fp16 fp16 void 128 128 16 PAGED_ATTENTION_MAXNREG=80"
-  "fp16 fp16 void 128 256 16"
-  "fp16 fp16 void 128 64 32"
-  "fp16 fp16 void 128 80 32"
-  "fp16 fp16 void 128 96 32"
-  "fp16 fp16 void 128 112 32"
-  "fp16 fp16 void 128 128 32"
-  "fp16 fp16 void 128 256 32"
+  "fp16 fp16 void 128 64 8 1"
+  "fp16 fp16 void 128 80 8 1"
+  "fp16 fp16 void 128 96 8 1"
+  "fp16 fp16 void 128 112 8 1"
+  "fp16 fp16 void 128 128 8 1"
+  "fp16 fp16 void 128 256 8 1"
+  "fp16 fp16 void 128 64 16 1"
+  "fp16 fp16 void 128 80 16 1"
+  "fp16 fp16 void 128 96 16 1 PAGED_ATTENTION_MAXNREG=72"
+  "fp16 fp16 void 128 112 16 1"
+  "fp16 fp16 void 128 128 16 1 PAGED_ATTENTION_MAXNREG=80"
+  "fp16 fp16 void 128 256 16 1"
+  "fp16 fp16 void 128 64 32 1"
+  "fp16 fp16 void 128 80 32 1"
+  "fp16 fp16 void 128 96 32 1"
+  "fp16 fp16 void 128 112 32 1"
+  "fp16 fp16 void 128 128 32 1"
+  "fp16 fp16 void 128 256 32 1"
   # fp8 kernels
-  "fp16 f8e4m3fn fp16 128 64 8"
-  "fp16 f8e4m3fn fp16 128 80 8"
-  "fp16 f8e4m3fn fp16 128 96 8"
-  "fp16 f8e4m3fn fp16 128 112 8"
-  "fp16 f8e4m3fn fp16 128 128 8"
-  "fp16 f8e4m3fn fp16 128 256 8"
-  "fp16 f8e4m3fn fp16 128 64 16"
-  "fp16 f8e4m3fn fp16 128 80 16"
-  "fp16 f8e4m3fn fp16 128 96 16 PAGED_ATTENTION_MAXNREG=96"
-  "fp16 f8e4m3fn fp16 128 112 16"
-  "fp16 f8e4m3fn fp16 128 128 16 PAGED_ATTENTION_MAXNREG=96"
-  "fp16 f8e4m3fn fp16 128 256 16"
-  "fp16 f8e4m3fn fp16 128 64 32"
-  "fp16 f8e4m3fn fp16 128 80 32"
-  "fp16 f8e4m3fn fp16 128 96 32"
-  "fp16 f8e4m3fn fp16 128 112 32"
-  "fp16 f8e4m3fn fp16 128 128 32"
-  "fp16 f8e4m3fn fp16 128 256 32"
+  "fp16 f8e4m3fn fp16 128 64 8 1"
+  "fp16 f8e4m3fn fp16 128 80 8 1"
+  "fp16 f8e4m3fn fp16 128 96 8 1"
+  "fp16 f8e4m3fn fp16 128 112 8 1"
+  "fp16 f8e4m3fn fp16 128 128 8 1"
+  "fp16 f8e4m3fn fp16 128 256 8 1"
+  "fp16 f8e4m3fn fp16 128 64 16 1"
+  "fp16 f8e4m3fn fp16 128 80 16 1"
+  "fp16 f8e4m3fn fp16 128 96 16 1 PAGED_ATTENTION_MAXNREG=96"
+  "fp16 f8e4m3fn fp16 128 112 16 1"
+  "fp16 f8e4m3fn fp16 128 128 16 1 PAGED_ATTENTION_MAXNREG=96"
+  "fp16 f8e4m3fn fp16 128 256 16 1"
+  "fp16 f8e4m3fn fp16 128 64 32 1"
+  "fp16 f8e4m3fn fp16 128 80 32 1"
+  "fp16 f8e4m3fn fp16 128 96 32 1"
+  "fp16 f8e4m3fn fp16 128 112 32 1"
+  "fp16 f8e4m3fn fp16 128 128 32 1"
+  "fp16 f8e4m3fn fp16 128 256 32 1"
+  # fp16 kernels gqa4
+  "fp16 fp16 void 128 64 8 4"
+  "fp16 fp16 void 128 80 8 4"
+  "fp16 fp16 void 128 96 8 4"
+  "fp16 fp16 void 128 112 8 4"
+  "fp16 fp16 void 128 128 8 4"
+  "fp16 fp16 void 128 256 8 4"
+  "fp16 fp16 void 128 64 16 4"
+  "fp16 fp16 void 128 80 16 4"
+  "fp16 fp16 void 128 96 16 4"
+  "fp16 fp16 void 128 112 16 4"
+  "fp16 fp16 void 128 128 16 4"
+  "fp16 fp16 void 128 256 16 4"
+  "fp16 fp16 void 128 64 32 4"
+  "fp16 fp16 void 128 80 32 4"
+  "fp16 fp16 void 128 96 32 4"
+  "fp16 fp16 void 128 112 32 4"
+  "fp16 fp16 void 128 128 32 4"
+  "fp16 fp16 void 128 256 32 4"
+  # fp8 kernels gqa4
+  "fp16 f8e4m3fn fp16 128 64 8 4"
+  "fp16 f8e4m3fn fp16 128 80 8 4"
+  "fp16 f8e4m3fn fp16 128 96 8 4"
+  "fp16 f8e4m3fn fp16 128 112 8 4"
+  "fp16 f8e4m3fn fp16 128 128 8 4"
+  "fp16 f8e4m3fn fp16 128 256 8 4"
+  "fp16 f8e4m3fn fp16 128 64 16 4"
+  "fp16 f8e4m3fn fp16 128 80 16 4"
+  "fp16 f8e4m3fn fp16 128 96 16 4"
+  "fp16 f8e4m3fn fp16 128 112 16 4"
+  "fp16 f8e4m3fn fp16 128 128 16 4"
+  "fp16 f8e4m3fn fp16 128 256 16 4"
+  "fp16 f8e4m3fn fp16 128 64 32 4"
+  "fp16 f8e4m3fn fp16 128 80 32 4"
+  "fp16 f8e4m3fn fp16 128 96 32 4"
+  "fp16 f8e4m3fn fp16 128 112 32 4"
+  "fp16 f8e4m3fn fp16 128 128 32 4"
+  "fp16 f8e4m3fn fp16 128 256 32 4"
+  # fp16 kernels gqa8
+  "fp16 fp16 void 128 64 8 8"
+  "fp16 fp16 void 128 80 8 8"
+  "fp16 fp16 void 128 96 8 8"
+  "fp16 fp16 void 128 112 8 8"
+  "fp16 fp16 void 128 128 8 8"
+  "fp16 fp16 void 128 256 8 8"
+  "fp16 fp16 void 128 64 16 8"
+  "fp16 fp16 void 128 80 16 8"
+  "fp16 fp16 void 128 96 16 8"
+  "fp16 fp16 void 128 112 16 8"
+  "fp16 fp16 void 128 128 16 8"
+  "fp16 fp16 void 128 256 16 8"
+  "fp16 fp16 void 128 64 32 8"
+  "fp16 fp16 void 128 80 32 8"
+  "fp16 fp16 void 128 96 32 8"
+  "fp16 fp16 void 128 112 32 8"
+  "fp16 fp16 void 128 128 32 8"
+  "fp16 fp16 void 128 256 32 8"
+  # fp8 kernels gqa8
+  "fp16 f8e4m3fn fp16 128 64 8 8"
+  "fp16 f8e4m3fn fp16 128 80 8 8"
+  "fp16 f8e4m3fn fp16 128 96 8 8"
+  "fp16 f8e4m3fn fp16 128 112 8 8"
+  "fp16 f8e4m3fn fp16 128 128 8 8"
+  "fp16 f8e4m3fn fp16 128 256 8 8"
+  "fp16 f8e4m3fn fp16 128 64 16 8"
+  "fp16 f8e4m3fn fp16 128 80 16 8"
+  "fp16 f8e4m3fn fp16 128 96 16 8"
+  "fp16 f8e4m3fn fp16 128 112 16 8"
+  "fp16 f8e4m3fn fp16 128 128 16 8"
+  "fp16 f8e4m3fn fp16 128 256 16 8"
+  "fp16 f8e4m3fn fp16 128 64 32 8"
+  "fp16 f8e4m3fn fp16 128 80 32 8"
+  "fp16 f8e4m3fn fp16 128 96 32 8"
+  "fp16 f8e4m3fn fp16 128 112 32 8"
+  "fp16 f8e4m3fn fp16 128 128 32 8"
+  "fp16 f8e4m3fn fp16 128 256 32 8"
 )
 
 expand_template_to_srcs(
   GENERATE paged_attention_srcs_lbp_dpo
   TEMPLATE ${paged_attention_template_dir}/lbp_attention_dpo.cu.in
   PREFIX lbp_dpo
-  DTYPEIO_DTYPEKV_DTYPESB_NUMTHREAD_HEADSIZE_PAGESIZE
+  CONFIGS
+  "TIO TKV TSB NUM_THREADS HEAD_SIZE PAGE_SIZE NUM_QUERIES_PER_KV"
+  # fp16 kernels mha
+  "fp16 fp16 void 128 64 8 1"
+  "fp16 fp16 void 128 80 8 1"
+  "fp16 fp16 void 128 96 8 1"
+  "fp16 fp16 void 128 112 8 1"
+  "fp16 fp16 void 128 128 8 1"
+  "fp16 fp16 void 128 256 8 1"
+  "fp16 fp16 void 128 64 16 1"
+  "fp16 fp16 void 128 80 16 1"
+  "fp16 fp16 void 128 96 16 1 PAGED_ATTENTION_MAXNREG=72"
+  "fp16 fp16 void 128 112 16 1"
+  "fp16 fp16 void 128 128 16 1 PAGED_ATTENTION_MAXNREG=80"
+  "fp16 fp16 void 128 256 16 1"
+  "fp16 fp16 void 128 64 32 1"
+  "fp16 fp16 void 128 80 32 1"
+  "fp16 fp16 void 128 96 32 1"
+  "fp16 fp16 void 128 112 32 1"
+  "fp16 fp16 void 128 128 32 1"
+  "fp16 fp16 void 128 256 32 1"
+  # fp8 kernels mha
+  "fp16 f8e4m3fn fp16 128 64 8 1"
+  "fp16 f8e4m3fn fp16 128 80 8 1"
+  "fp16 f8e4m3fn fp16 128 96 8 1"
+  "fp16 f8e4m3fn fp16 128 112 8 1"
+  "fp16 f8e4m3fn fp16 128 128 8 1"
+  "fp16 f8e4m3fn fp16 128 256 8 1"
+  "fp16 f8e4m3fn fp16 128 64 16 1"
+  "fp16 f8e4m3fn fp16 128 80 16 1"
+  "fp16 f8e4m3fn fp16 128 96 16 1 PAGED_ATTENTION_MAXNREG=96"
+  "fp16 f8e4m3fn fp16 128 112 16 1"
+  "fp16 f8e4m3fn fp16 128 128 16 1 PAGED_ATTENTION_MAXNREG=96"
+  "fp16 f8e4m3fn fp16 128 256 16 1"
+  "fp16 f8e4m3fn fp16 128 64 32 1"
+  "fp16 f8e4m3fn fp16 128 80 32 1"
+  "fp16 f8e4m3fn fp16 128 96 32 1"
+  "fp16 f8e4m3fn fp16 128 112 32 1"
+  "fp16 f8e4m3fn fp16 128 128 32 1"
+  "fp16 f8e4m3fn fp16 128 256 32 1"
+  # fp16 kernels gqa4
+  "fp16 fp16 void 128 64 8 4"
+  "fp16 fp16 void 128 80 8 4"
+  "fp16 fp16 void 128 96 8 4"
+  "fp16 fp16 void 128 112 8 4"
+  "fp16 fp16 void 128 128 8 4"
+  "fp16 fp16 void 128 256 8 4"
+  "fp16 fp16 void 128 64 16 4"
+  "fp16 fp16 void 128 80 16 4"
+  "fp16 fp16 void 128 96 16 4"
+  "fp16 fp16 void 128 112 16 4"
+  "fp16 fp16 void 128 128 16 4"
+  "fp16 fp16 void 128 256 16 4"
+  "fp16 fp16 void 128 64 32 4"
+  "fp16 fp16 void 128 80 32 4"
+  "fp16 fp16 void 128 96 32 4"
+  "fp16 fp16 void 128 112 32 4"
+  "fp16 fp16 void 128 128 32 4"
+  "fp16 fp16 void 128 256 32 4"
+  # fp8 kernels gqa4
+  "fp16 f8e4m3fn fp16 128 64 8 4"
+  "fp16 f8e4m3fn fp16 128 80 8 4"
+  "fp16 f8e4m3fn fp16 128 96 8 4"
+  "fp16 f8e4m3fn fp16 128 112 8 4"
+  "fp16 f8e4m3fn fp16 128 128 8 4"
+  "fp16 f8e4m3fn fp16 128 256 8 4"
+  "fp16 f8e4m3fn fp16 128 64 16 4"
+  "fp16 f8e4m3fn fp16 128 80 16 4"
+  "fp16 f8e4m3fn fp16 128 96 16 4"
+  "fp16 f8e4m3fn fp16 128 112 16 4"
+  "fp16 f8e4m3fn fp16 128 128 16 4"
+  "fp16 f8e4m3fn fp16 128 256 16 4"
+  "fp16 f8e4m3fn fp16 128 64 32 4"
+  "fp16 f8e4m3fn fp16 128 80 32 4"
+  "fp16 f8e4m3fn fp16 128 96 32 4"
+  "fp16 f8e4m3fn fp16 128 112 32 4"
+  "fp16 f8e4m3fn fp16 128 128 32 4"
+  "fp16 f8e4m3fn fp16 128 256 32 4"
+  # fp16 kernels gqa8
+  "fp16 fp16 void 128 64 8 8"
+  "fp16 fp16 void 128 80 8 8"
+  "fp16 fp16 void 128 96 8 8"
+  "fp16 fp16 void 128 112 8 8"
+  "fp16 fp16 void 128 128 8 8"
+  "fp16 fp16 void 128 256 8 8"
+  "fp16 fp16 void 128 64 16 8"
+  "fp16 fp16 void 128 80 16 8"
+  "fp16 fp16 void 128 96 16 8"
+  "fp16 fp16 void 128 112 16 8"
+  "fp16 fp16 void 128 128 16 8"
+  "fp16 fp16 void 128 256 16 8"
+  "fp16 fp16 void 128 64 32 8"
+  "fp16 fp16 void 128 80 32 8"
+  "fp16 fp16 void 128 96 32 8"
+  "fp16 fp16 void 128 112 32 8"
+  "fp16 fp16 void 128 128 32 8"
+  "fp16 fp16 void 128 256 32 8"
+  # fp8 kernels gqa8
+  "fp16 f8e4m3fn fp16 128 64 8 8"
+  "fp16 f8e4m3fn fp16 128 80 8 8"
+  "fp16 f8e4m3fn fp16 128 96 8 8"
+  "fp16 f8e4m3fn fp16 128 112 8 8"
+  "fp16 f8e4m3fn fp16 128 128 8 8"
+  "fp16 f8e4m3fn fp16 128 256 8 8"
+  "fp16 f8e4m3fn fp16 128 64 16 8"
+  "fp16 f8e4m3fn fp16 128 80 16 8"
+  "fp16 f8e4m3fn fp16 128 96 16 8"
+  "fp16 f8e4m3fn fp16 128 112 16 8"
+  "fp16 f8e4m3fn fp16 128 128 16 8"
+  "fp16 f8e4m3fn fp16 128 256 16 8"
+  "fp16 f8e4m3fn fp16 128 64 32 8"
+  "fp16 f8e4m3fn fp16 128 80 32 8"
+  "fp16 f8e4m3fn fp16 128 96 32 8"
+  "fp16 f8e4m3fn fp16 128 112 32 8"
+  "fp16 f8e4m3fn fp16 128 128 32 8"
+  "fp16 f8e4m3fn fp16 128 256 32 8"
+)
+
+expand_template_to_srcs(
+  GENERATE paged_attention_srcs_lbp_dpo_reduction
+  TEMPLATE ${paged_attention_template_dir}/lbp_attention_dpo_reduction.cu.in
+  PREFIX lbp_dpo_reduction
+  CONFIGS
+  "TIO NUM_THREADS HEAD_SIZE"
+  # fp32 kernels
+  "fp32 128 64 INSTANTIATE_SPLIT_HEAD_KERNEL=1"
+  "fp32 128 80"
+  "fp32 128 96"
+  "fp32 128 112"
+  "fp32 128 128"
+  "fp32 128 256"
   # fp16 kernels
-  "fp16 fp16 void 128 64 8"
-  "fp16 fp16 void 128 80 8"
-  "fp16 fp16 void 128 96 8"
-  "fp16 fp16 void 128 112 8"
-  "fp16 fp16 void 128 128 8"
-  "fp16 fp16 void 128 256 8"
-  "fp16 fp16 void 128 64 16"
-  "fp16 fp16 void 128 80 16"
-  "fp16 fp16 void 128 96 16 PAGED_ATTENTION_MAXNREG=72"
-  "fp16 fp16 void 128 112 16"
-  "fp16 fp16 void 128 128 16 PAGED_ATTENTION_MAXNREG=80"
-  "fp16 fp16 void 128 256 16"
-  "fp16 fp16 void 128 64 32"
-  "fp16 fp16 void 128 80 32"
-  "fp16 fp16 void 128 96 32"
-  "fp16 fp16 void 128 112 32"
-  "fp16 fp16 void 128 128 32"
-  "fp16 fp16 void 128 256 32"
-  # fp8 kernels
-  "fp16 f8e4m3fn fp16 128 64 8"
-  "fp16 f8e4m3fn fp16 128 80 8"
-  "fp16 f8e4m3fn fp16 128 96 8"
-  "fp16 f8e4m3fn fp16 128 112 8"
-  "fp16 f8e4m3fn fp16 128 128 8"
-  "fp16 f8e4m3fn fp16 128 256 8"
-  "fp16 f8e4m3fn fp16 128 64 16"
-  "fp16 f8e4m3fn fp16 128 80 16"
-  "fp16 f8e4m3fn fp16 128 96 16 PAGED_ATTENTION_MAXNREG=96"
-  "fp16 f8e4m3fn fp16 128 112 16"
-  "fp16 f8e4m3fn fp16 128 128 16 PAGED_ATTENTION_MAXNREG=96"
-  "fp16 f8e4m3fn fp16 128 256 16"
-  "fp16 f8e4m3fn fp16 128 64 32"
-  "fp16 f8e4m3fn fp16 128 80 32"
-  "fp16 f8e4m3fn fp16 128 96 32"
-  "fp16 f8e4m3fn fp16 128 112 32"
-  "fp16 f8e4m3fn fp16 128 128 32"
-  "fp16 f8e4m3fn fp16 128 256 32"
+  "fp16 128 64 INSTANTIATE_SPLIT_HEAD_KERNEL=1"
+  "fp16 128 80"
+  "fp16 128 96"
+  "fp16 128 112"
+  "fp16 128 128"
+  "fp16 128 256"
 )
 
 expand_template_to_srcs(
   GENERATE paged_attention_srcs_reshape_and_cache
   TEMPLATE ${paged_attention_template_dir}/reshape_and_cache.cu.in
   PREFIX reshape_and_cache
-  DTYPEIO_DTYPEKV_DTYPESB_NUMTHREAD_HEADSIZE_PAGESIZE
+  CONFIGS
+  "TIO TKV TSB NUM_THREADS HEAD_SIZE PAGE_SIZE"
   "fp16 f8e4m3fn fp16 128 64 8"
   "fp16 f8e4m3fn fp16 128 80 8"
   "fp16 f8e4m3fn fp16 128 96 8"
@@ -276,5 +564,6 @@ set(paged_attention_generated_srcs
   ${paged_attention_srcs_lbp_ws}
   ${paged_attention_srcs_lbp_dpi}
   ${paged_attention_srcs_lbp_dpo}
+  ${paged_attention_srcs_lbp_dpo_reduction}
   ${paged_attention_srcs_reshape_and_cache}
 )

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/paged_attention.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/paged_attention.cu
@@ -1,0 +1,226 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "contrib_ops/cuda/bert/paged/paged_attention/paged_attention.h"
+
+#include "contrib_ops/cuda/bert/paged/cuda_common.cuh"
+#include "contrib_ops/cuda/bert/paged/paged_attention/paged_attention.cuh"
+
+namespace onnxruntime::contrib::paged {
+
+template <typename TIO, typename TKV, typename TSB, int NumQueriesPerCta>
+void launch_paged_attention_kernel(
+    stream_t stream,
+    TIO* out_ptr,
+    const TIO* q_ptr,
+    const TKV* k_cache_ptr,
+    const TKV* v_cache_ptr,
+    const TSB* scalebias_ptr,
+    const int* page_table_ptr,
+    const int* context_lens_ptr,
+    const float* alibi_slopes_ptr,
+    const float scale,
+    const int num_seqs,
+    const int num_heads,
+    const int num_kv_heads,
+    const int head_size,
+    const int page_size,
+    const int max_num_pages_per_seq,
+    const int q_stride,
+    const int max_context_len,
+    const int num_queries_per_kv
+) {
+  constexpr int NumThreads = 128;
+  constexpr int ChunkSize = 32;  // only useful for fp8
+
+  if constexpr(std::is_same_v<TSB, void>) {
+    if (scalebias_ptr != nullptr) {
+      throw std::runtime_error("scalebias is not supported by this kernel");
+    }
+  }
+
+  if (num_queries_per_kv % NumQueriesPerCta != 0) {
+    throw std::runtime_error(
+        std::string("Unsupported NumQueriesPerCta ") + std::to_string(NumQueriesPerCta) +
+        " for num_queries_per_kv " + std::to_string(num_queries_per_kv)
+    );
+  }
+
+#define LAUNCH_PAGED_ATTENTION_KERNEL_AND_BREAK(NUM_THREADS, HEAD_SIZE, PAGE_SIZE, CHUNK_SIZE, NUM_QUERIES_PER_CTA, TIO, TKV, TSB) \
+  paged_attention_kernel<NUM_THREADS, HEAD_SIZE, PAGE_SIZE, CHUNK_SIZE, NUM_QUERIES_PER_CTA, TIO, TKV, TSB>                        \
+      <<<(num_heads / NUM_QUERIES_PER_CTA) * num_seqs, NumThreads, 0, stream>>>(                                                   \
+          out_ptr,                                                                                                                 \
+          q_ptr,                                                                                                                   \
+          k_cache_ptr,                                                                                                             \
+          v_cache_ptr,                                                                                                             \
+          scalebias_ptr,                                                                                                           \
+          page_table_ptr,                                                                                                          \
+          context_lens_ptr,                                                                                                        \
+          alibi_slopes_ptr,                                                                                                        \
+          scale,                                                                                                                   \
+          num_seqs,                                                                                                                \
+          num_heads,                                                                                                               \
+          num_kv_heads,                                                                                                            \
+          max_num_pages_per_seq,                                                                                                   \
+          q_stride,                                                                                                                \
+          max_context_len                                                                                                          \
+      );                                                                                                                           \
+  break;
+
+  do {
+    if (page_size == 32) {
+      if (head_size == 64) {
+        LAUNCH_PAGED_ATTENTION_KERNEL_AND_BREAK(NumThreads, 64, 32, ChunkSize, NumQueriesPerCta, TIO, TKV, TSB);
+      } else if (head_size == 80) {
+        LAUNCH_PAGED_ATTENTION_KERNEL_AND_BREAK(NumThreads, 80, 32, ChunkSize, NumQueriesPerCta, TIO, TKV, TSB);
+      } else if (head_size == 96) {
+        LAUNCH_PAGED_ATTENTION_KERNEL_AND_BREAK(NumThreads, 96, 32, ChunkSize, NumQueriesPerCta, TIO, TKV, TSB);
+      } else if (head_size == 112) {
+        LAUNCH_PAGED_ATTENTION_KERNEL_AND_BREAK(NumThreads, 112, 32, ChunkSize, NumQueriesPerCta, TIO, TKV, TSB);
+      } else if (head_size == 128) {
+        LAUNCH_PAGED_ATTENTION_KERNEL_AND_BREAK(NumThreads, 128, 32, ChunkSize, NumQueriesPerCta, TIO, TKV, TSB);
+      } else if (head_size == 256) {
+        LAUNCH_PAGED_ATTENTION_KERNEL_AND_BREAK(NumThreads, 256, 32, ChunkSize, NumQueriesPerCta, TIO, TKV, TSB);
+      } else {
+        throw std::runtime_error(std::string("Unsupported head size: ") + std::to_string(head_size));
+      }
+    } else if (page_size == 16) {
+      if (head_size == 64) {
+        LAUNCH_PAGED_ATTENTION_KERNEL_AND_BREAK(NumThreads, 64, 16, ChunkSize, NumQueriesPerCta, TIO, TKV, TSB);
+      } else if (head_size == 80) {
+        LAUNCH_PAGED_ATTENTION_KERNEL_AND_BREAK(NumThreads, 80, 16, ChunkSize, NumQueriesPerCta, TIO, TKV, TSB);
+      } else if (head_size == 96) {
+        LAUNCH_PAGED_ATTENTION_KERNEL_AND_BREAK(NumThreads, 96, 16, ChunkSize, NumQueriesPerCta, TIO, TKV, TSB);
+      } else if (head_size == 112) {
+        LAUNCH_PAGED_ATTENTION_KERNEL_AND_BREAK(NumThreads, 112, 16, ChunkSize, NumQueriesPerCta, TIO, TKV, TSB);
+      } else if (head_size == 128) {
+        LAUNCH_PAGED_ATTENTION_KERNEL_AND_BREAK(NumThreads, 128, 16, ChunkSize, NumQueriesPerCta, TIO, TKV, TSB);
+      } else if (head_size == 256) {
+        LAUNCH_PAGED_ATTENTION_KERNEL_AND_BREAK(NumThreads, 256, 16, ChunkSize, NumQueriesPerCta, TIO, TKV, TSB);
+      } else {
+        throw std::runtime_error(std::string("Unsupported head size: ") + std::to_string(head_size));
+      }
+    } else if (page_size == 8) {
+      if (head_size == 64) {
+        LAUNCH_PAGED_ATTENTION_KERNEL_AND_BREAK(NumThreads, 64, 8, ChunkSize, NumQueriesPerCta, TIO, TKV, TSB);
+      } else if (head_size == 80) {
+        LAUNCH_PAGED_ATTENTION_KERNEL_AND_BREAK(NumThreads, 80, 8, ChunkSize, NumQueriesPerCta, TIO, TKV, TSB);
+      } else if (head_size == 96) {
+        LAUNCH_PAGED_ATTENTION_KERNEL_AND_BREAK(NumThreads, 96, 8, ChunkSize, NumQueriesPerCta, TIO, TKV, TSB);
+      } else if (head_size == 112) {
+        LAUNCH_PAGED_ATTENTION_KERNEL_AND_BREAK(NumThreads, 112, 8, ChunkSize, NumQueriesPerCta, TIO, TKV, TSB);
+      } else if (head_size == 128) {
+        LAUNCH_PAGED_ATTENTION_KERNEL_AND_BREAK(NumThreads, 128, 8, ChunkSize, NumQueriesPerCta, TIO, TKV, TSB);
+      } else if (head_size == 256) {
+        LAUNCH_PAGED_ATTENTION_KERNEL_AND_BREAK(NumThreads, 256, 8, ChunkSize, NumQueriesPerCta, TIO, TKV, TSB);
+      } else {
+        throw std::runtime_error(std::string("Unsupported head size: ") + std::to_string(head_size));
+      }
+    } else {
+      throw std::runtime_error(std::string("Unsupported page size: ") + std::to_string(page_size));
+    }
+  } while (0);
+}
+
+template <typename TIO, typename TKV, typename TSB>
+void launch_paged_attention_kernel(
+    stream_t stream,
+    TIO* out_ptr,
+    const TIO* q_ptr,
+    const TKV* k_cache_ptr,
+    const TKV* v_cache_ptr,
+    const TSB* scalebias_ptr,
+    const int* page_table_ptr,
+    const int* context_lens_ptr,
+    const float* alibi_slopes_ptr,
+    const float scale,
+    const int num_seqs,
+    const int num_heads,
+    const int num_kv_heads,
+    const int head_size,
+    const int page_size,
+    const int max_num_pages_per_seq,
+    const int q_stride,
+    const int max_context_len
+) {
+  int num_queries_per_kv = num_heads / num_kv_heads;
+
+  if (num_queries_per_kv % 4 == 0) {
+    launch_paged_attention_kernel<TIO, TKV, TSB, 4>(
+        stream, out_ptr, q_ptr, k_cache_ptr, v_cache_ptr, scalebias_ptr, page_table_ptr, context_lens_ptr, alibi_slopes_ptr,
+        scale, num_seqs, num_heads, num_kv_heads, head_size, page_size, max_num_pages_per_seq, q_stride, max_context_len,
+        num_queries_per_kv
+    );
+  } else {
+    launch_paged_attention_kernel<TIO, TKV, TSB, 1>(
+        stream, out_ptr, q_ptr, k_cache_ptr, v_cache_ptr, scalebias_ptr, page_table_ptr, context_lens_ptr, alibi_slopes_ptr,
+        scale, num_seqs, num_heads, num_kv_heads, head_size, page_size, max_num_pages_per_seq, q_stride, max_context_len,
+        num_queries_per_kv
+    );
+  }
+}
+
+template void launch_paged_attention_kernel<float, float, void>(
+    stream_t stream,
+    float* out_ptr,
+    const float* q_ptr,
+    const float* k_cache_ptr,
+    const float* v_cache_ptr,
+    const void* scalebias_ptr,
+    const int* page_table_ptr,
+    const int* context_lens_ptr,
+    const float* alibi_slopes_ptr,
+    const float scale,
+    const int num_seqs,
+    const int num_heads,
+    const int num_kv_heads,
+    const int head_size,
+    const int page_size,
+    const int max_num_pages_per_seq,
+    const int q_stride,
+    const int max_context_len
+);
+
+template void launch_paged_attention_kernel<half, half, void>(
+    stream_t stream,
+    half* out_ptr,
+    const half* q_ptr,
+    const half* k_cache_ptr,
+    const half* v_cache_ptr,
+    const void* scalebias_ptr,
+    const int* page_table_ptr,
+    const int* context_lens_ptr,
+    const float* alibi_slopes_ptr,
+    const float scale,
+    const int num_seqs,
+    const int num_heads,
+    const int num_kv_heads,
+    const int head_size,
+    const int page_size,
+    const int max_num_pages_per_seq,
+    const int q_stride,
+    const int max_context_len
+);
+
+template void launch_paged_attention_kernel<half, cute::float_e4m3_t, half>(
+    stream_t stream,
+    half* out_ptr,
+    const half* q_ptr,
+    const cute::float_e4m3_t* k_cache_ptr,
+    const cute::float_e4m3_t* v_cache_ptr,
+    const half* scalebias_ptr,
+    const int* page_table_ptr,
+    const int* context_lens_ptr,
+    const float* alibi_slopes_ptr,
+    const float scale,
+    const int num_seqs,
+    const int num_heads,
+    const int num_kv_heads,
+    const int head_size,
+    const int page_size,
+    const int max_num_pages_per_seq,
+    const int q_stride,
+    const int max_context_len
+);
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/paged_attention.cu.in
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/paged_attention.cu.in
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#define PAGED_ATTENTION_KERNEL_IMPL 1
+#include "contrib_ops/cuda/bert/paged/paged_attention/paged_attention.cuh"
+
+namespace onnxruntime::contrib::paged {
+
+using float8_e4m3fn_t = cute::float_e4m3_t;
+
+// clang-format off
+#define NUM_THREADS @NUM_THREADS@
+#define HEAD_SIZE @HEAD_SIZE@
+#define PAGE_SIZE @PAGE_SIZE@
+#define CHUNK_SIZE 32  // only useful for fp8
+#define TIO @TIO@
+#define TKV @TKV@
+#define TSB @TSB@
+// clang-format on
+
+template __global__ void paged_attention_kernel<NUM_THREADS, HEAD_SIZE, PAGE_SIZE, CHUNK_SIZE, 1, TIO, TKV, TSB>(
+    TIO* __restrict__ out,                   // [num_seqs, num_heads, head_size]
+    const TIO* __restrict__ q,               // [num_seqs, num_heads, head_size]
+    const TKV* __restrict__ k_cache,         // [num_pages, num_kv_heads, head_size/x, page_size, x]
+    const TKV* __restrict__ v_cache,         // [num_pages, num_kv_heads, head_size, page_size]
+    const TSB* __restrict__ scalebias,       // [num_pages, 2, num_kv_heads, 2, head_size/chunk_size, page_size]
+    const int* __restrict__ page_table,      // [num_seqs, max_num_pages_per_seq]
+    const int* __restrict__ context_lens,    // [num_seqs]
+    const float* __restrict__ alibi_slopes,  // [num_heads]
+    const float scale,
+    const int num_seqs,
+    const int num_heads,
+    const int num_kv_heads,
+    const int max_num_pages_per_seq,
+    const int q_stride,
+    const int max_context_len
+);
+
+template __global__ void paged_attention_kernel<NUM_THREADS, HEAD_SIZE, PAGE_SIZE, CHUNK_SIZE, 4, TIO, TKV, TSB>(
+    TIO* __restrict__ out,                   // [num_seqs, num_heads, head_size]
+    const TIO* __restrict__ q,               // [num_seqs, num_heads, head_size]
+    const TKV* __restrict__ k_cache,         // [num_pages, num_kv_heads, head_size/x, page_size, x]
+    const TKV* __restrict__ v_cache,         // [num_pages, num_kv_heads, head_size, page_size]
+    const TSB* __restrict__ scalebias,       // [num_pages, 2, num_kv_heads, 2, head_size/chunk_size, page_size]
+    const int* __restrict__ page_table,      // [num_seqs, max_num_pages_per_seq]
+    const int* __restrict__ context_lens,    // [num_seqs]
+    const float* __restrict__ alibi_slopes,  // [num_heads]
+    const float scale,
+    const int num_seqs,
+    const int num_heads,
+    const int num_kv_heads,
+    const int max_num_pages_per_seq,
+    const int q_stride,
+    const int max_context_len
+);
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/paged_attention.cu.in
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/paged_attention.cu.in
@@ -13,30 +13,13 @@ using float8_e4m3fn_t = cute::float_e4m3_t;
 #define HEAD_SIZE @HEAD_SIZE@
 #define PAGE_SIZE @PAGE_SIZE@
 #define CHUNK_SIZE 32  // only useful for fp8
+#define NUM_QUERIES_PER_KV @NUM_QUERIES_PER_KV@
 #define TIO @TIO@
 #define TKV @TKV@
 #define TSB @TSB@
 // clang-format on
 
-template __global__ void paged_attention_kernel<NUM_THREADS, HEAD_SIZE, PAGE_SIZE, CHUNK_SIZE, 1, TIO, TKV, TSB>(
-    TIO* __restrict__ out,                   // [num_seqs, num_heads, head_size]
-    const TIO* __restrict__ q,               // [num_seqs, num_heads, head_size]
-    const TKV* __restrict__ k_cache,         // [num_pages, num_kv_heads, head_size/x, page_size, x]
-    const TKV* __restrict__ v_cache,         // [num_pages, num_kv_heads, head_size, page_size]
-    const TSB* __restrict__ scalebias,       // [num_pages, 2, num_kv_heads, 2, head_size/chunk_size, page_size]
-    const int* __restrict__ page_table,      // [num_seqs, max_num_pages_per_seq]
-    const int* __restrict__ context_lens,    // [num_seqs]
-    const float* __restrict__ alibi_slopes,  // [num_heads]
-    const float scale,
-    const int num_seqs,
-    const int num_heads,
-    const int num_kv_heads,
-    const int max_num_pages_per_seq,
-    const int q_stride,
-    const int max_context_len
-);
-
-template __global__ void paged_attention_kernel<NUM_THREADS, HEAD_SIZE, PAGE_SIZE, CHUNK_SIZE, 4, TIO, TKV, TSB>(
+template __global__ void paged_attention_kernel<NUM_THREADS, HEAD_SIZE, PAGE_SIZE, CHUNK_SIZE, NUM_QUERIES_PER_KV, TIO, TKV, TSB>(
     TIO* __restrict__ out,                   // [num_seqs, num_heads, head_size]
     const TIO* __restrict__ q,               // [num_seqs, num_heads, head_size]
     const TKV* __restrict__ k_cache,         // [num_pages, num_kv_heads, head_size/x, page_size, x]

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/paged_attention.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/paged_attention.cuh
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "cute/tensor.hpp"
+
+#include "contrib_ops/cuda/bert/paged/cuda_common.cuh"
+#include "contrib_ops/cuda/bert/paged/paged_attention/paged_attention.cuh"
+#include "contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_task.cuh"
+#include "contrib_ops/cuda/bert/paged/paged_attention/lbp_attention_gqa_task.cuh"
+
+namespace onnxruntime::contrib::paged {
+
+using namespace cute;
+
+struct NaiveWorker : public IWorker<NaiveWorker> {
+  int num_task_chunks;
+  int i = 0;
+
+  __forceinline__ __device__ void
+  take_work(int& chunk_start, int& chunk_end) {
+    if (i < num_task_chunks) {
+      int curr_task_chunk = i++;
+      chunk_start = curr_task_chunk;
+      chunk_end = curr_task_chunk + 1;
+    }
+  }
+
+  __forceinline__ __device__ void broadcast_work(void*, int&, int&) { /* do nothing */ };
+};
+
+template <int NumThreads, int HeadSize, int PageSize, int ChunkSize, int NumQueriesPerCta, typename TIO, typename TKV, typename TSB>
+__global__ void
+__launch_bounds__(NumThreads, NumThreads / constant::WarpSize) paged_attention_kernel(
+    TIO* __restrict__ out,                   // [num_seqs, num_heads, head_size]
+    const TIO* __restrict__ q,               // [num_seqs, num_heads, head_size]
+    const TKV* __restrict__ k_cache,         // [num_pages, num_kv_heads, head_size/x, page_size, x]
+    const TKV* __restrict__ v_cache,         // [num_pages, num_kv_heads, head_size, page_size]
+    const TSB* __restrict__ scalebias,       // [num_pages, 2, num_kv_heads, 2, head_size/chunk_size, page_size]
+    const int* __restrict__ page_table,      // [num_seqs, max_num_pages_per_seq]
+    const int* __restrict__ context_lens,    // [num_seqs]
+    const float* __restrict__ alibi_slopes,  // [num_heads]
+    const float scale,
+    const int num_seqs,
+    const int num_heads,
+    const int num_kv_heads,
+    const int max_num_pages_per_seq,
+    const int q_stride,
+    const int max_context_len
+)
+#if !defined(PAGED_SPLIT_COMPILATION) || defined(PAGED_ATTENTION_KERNEL_IMPL)
+{
+  __shared__ char broadcast_buffer[BROADCAST0_BUFFER_SIZE_IN_BYTES];
+
+  using TI = TIO;
+  using NaiveConfig = TaskConfig<
+      /*TaskChunkSeqLen*/ 512,
+      /*InplaceFlashAcc*/ false,
+      /*UseHeadSeq*/ false,
+      /*SingleChunk*/ false,
+      NumQueriesPerCta>;
+
+  NaiveWorker w{};
+  int seq_head_idx = blockIdx.x;
+  int num_queries_per_kv = num_heads / num_kv_heads;
+
+  int seq_idx = seq_head_idx / (num_heads / NaiveConfig::NumQueriesPerCta);
+  int head_idx = (seq_head_idx % (num_heads / NaiveConfig::NumQueriesPerCta)) * NaiveConfig::NumQueriesPerCta;
+  int kv_head_idx = head_idx / num_queries_per_kv;
+
+  constexpr int TaskChunkSeqLen = NaiveConfig::TaskChunkSeqLen;
+  w.num_task_chunks = ceil_div(context_lens[seq_idx], TaskChunkSeqLen);
+
+  using Task = std::conditional_t<
+      NumQueriesPerCta == 1,
+      PagedAttentionTask<NumThreads, HeadSize, PageSize, TIO, TIO, TKV, NaiveWorker, NaiveConfig, KVConfig<TSB, ChunkSize>>,
+      PagedGroupQueryAttentionTask<NumThreads, HeadSize, PageSize, TIO, TIO, TKV, NaiveWorker, NaiveConfig, KVConfig<TSB, ChunkSize>>>;
+  Task::attention(
+      broadcast_buffer, &w, seq_idx, head_idx, kv_head_idx, out, nullptr,
+      q, k_cache, v_cache, scalebias, page_table, context_lens, alibi_slopes,
+      scale, num_seqs, num_heads, num_kv_heads, max_num_pages_per_seq, q_stride
+  );
+}
+#else
+    ;
+#endif
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/paged_attention.h
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/paged_attention.h
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "contrib_ops/cuda/bert/paged/cuda_common.h"
+
+namespace onnxruntime::contrib::paged {
+
+template <typename TIO, typename TKV, typename TSB = void>
+void launch_paged_attention_kernel(
+    stream_t stream,
+    TIO* out,
+    const TIO* q,
+    const TKV* k_cache,
+    const TKV* v_cache,
+    const TSB* scalebias,
+    const int* page_table,
+    const int* context_lens,
+    const float* alibi_slopes,
+    const float scale,
+    const int num_seqs,
+    const int num_heads,
+    const int num_kv_heads,
+    const int head_size,
+    const int page_size,
+    const int max_num_pages_per_seq,
+    const int q_stride,
+    const int max_context_len
+);
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/paged_attention.h
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/paged_attention.h
@@ -10,6 +10,7 @@ namespace onnxruntime::contrib::paged {
 template <typename TIO, typename TKV, typename TSB = void>
 void launch_paged_attention_kernel(
     stream_t stream,
+    dev_props_ptr dev_props,
     TIO* out,
     const TIO* q,
     const TKV* k_cache,

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/reshape_and_cache.cu.in
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/reshape_and_cache.cu.in
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#define RESHAPE_AND_CACHE_KERNEL_IMPL 1
+#include "contrib_ops/cuda/bert/paged/paged_attention/reshape_and_cache.cuh"
+
+#include <type_traits>
+
+namespace onnxruntime::contrib::paged {
+
+using float8_e4m3fn_t = cute::float_e4m3_t;
+
+// clang-format off
+#define NUM_THREADS @NUM_THREADS@
+#define HEAD_SIZE @HEAD_SIZE@
+#define PAGE_SIZE @PAGE_SIZE@
+#define TIO @TIO@
+#define TKV @TKV@
+#define TSB @TSB@
+// clang-format on
+
+static_assert(NUM_THREADS == 128);
+static_assert(std::is_same_v<TIO, half>);
+static_assert(std::is_same_v<TKV, float8_e4m3fn_t>);
+static_assert(std::is_same_v<TSB, half>);
+
+constexpr int ChunkSize = 32;
+constexpr int VecSize = 8 / sizeof(TIO);  // target LDG.64
+
+template __global__ void reshape_and_cache_kernel<NUM_THREADS, HEAD_SIZE, PAGE_SIZE, ChunkSize, VecSize, TIO, TKV, TSB>(
+    TKV* __restrict__ k_cache_out,             // [num_pages, num_heads, head_size/x, page_size, x]
+    TKV* __restrict__ v_cache_out,             // [num_pages, num_heads, head_size, page_size]
+    TSB* __restrict__ kv_scalebias_out,        // [num_pages, 2, num_heads, 2, num_chunks, page_size], in k_scale, k_bias, v_scale, v_bias order
+    const TIO* __restrict__ k_in,              // [num_tokens, num_heads, head_size]
+    const TIO* __restrict__ v_in,              // [num_tokens, num_heads, head_size]
+    const int64_t* __restrict__ slot_mapping,  // [num_tokens]
+    int num_pages,
+    int num_tokens,
+    int num_heads,
+    int k_in_stride,  // stride of num_tokens dim
+    int v_in_stride   // stride of num_tokens dim
+);
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/reshape_and_cache.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/reshape_and_cache.cuh
@@ -1,0 +1,193 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "cute/tensor.hpp"
+
+#include "contrib_ops/cuda/bert/paged/algorithms.cuh"
+#include "contrib_ops/cuda/bert/paged/cuda_common.cuh"
+#include "contrib_ops/cuda/bert/paged/type_convert.cuh"
+#include "contrib_ops/cuda/bert/paged/warp_utilities.cuh"
+
+namespace onnxruntime::contrib::paged {
+
+using namespace cute;
+
+template <int NumThreads, int HeadSize, int PageSize, int ChunkSize, int VecSize, typename TIO, typename TKV, typename TSB>
+__global__ void
+__launch_bounds__(NumThreads) reshape_and_cache_kernel(
+    TKV* __restrict__ k_cache_out,    // [num_pages, num_heads, head_size/x, page_size, x]
+    TKV* __restrict__ v_cache_out,    // [num_pages, num_heads, head_size, page_size]
+    TSB* __restrict__ kv_scalebias_out,       // [num_pages, 2, num_heads, 2, num_chunks, page_size], in k_scale, k_bias, v_scale, v_bias order
+    const TIO* __restrict__ k_in,             // [num_tokens, num_heads, head_size]
+    const TIO* __restrict__ v_in,             // [num_tokens, num_heads, head_size]
+    const int64_t* __restrict__ slot_mapping,  // [num_tokens]
+    int num_pages,
+    int num_tokens,
+    int num_heads,
+    int k_in_stride,  // stride of num_tokens dim
+    int v_in_stride   // stride of num_tokens dim
+)
+#if !defined(PAGED_SPLIT_COMPILATION) || defined(RESHAPE_AND_CACHE_KERNEL_IMPL)
+{
+  using input_t = half;
+  using cache_t = float_e4m3_t;
+  constexpr int NumInputBits = 8 * sizeof(input_t) * VecSize;
+  constexpr int NumOutputBits = 8 * sizeof(cache_t) * VecSize;
+
+  constexpr int NumElemPerCta = NumThreads * VecSize;
+  constexpr int HeadSizeNextPowerOfTwo = onnxruntime::contrib::paged::next_power_of_two(HeadSize);
+  const int num_heads_per_cta = NumElemPerCta / HeadSizeNextPowerOfTwo;
+  const int head_idx_in_cta = threadIdx.x * VecSize / HeadSizeNextPowerOfTwo;
+  const int chunk_idx = (threadIdx.x * VecSize % HeadSizeNextPowerOfTwo) / ChunkSize;
+  if (head_idx_in_cta >= num_heads) {
+    return;
+  }
+
+  constexpr int x = 16 / sizeof(cache_t);
+  static_assert(x % VecSize == 0);
+  static_assert(PageSize % VecSize == 0);
+  static_assert(HeadSize % VecSize == 0);
+
+  const bool is_key = blockIdx.y == 0;
+  const int64_t token_idx = blockIdx.x / ceil_div(num_heads, num_heads_per_cta);
+  const int64_t head_group_idx = blockIdx.x % ceil_div(num_heads, num_heads_per_cta);
+
+  const int64_t slot_idx = slot_mapping[token_idx];
+  const int64_t page_id = slot_idx / PageSize;
+  const int64_t tok_idx_in_page = slot_idx % PageSize;
+  const bool is_valid_token = slot_idx >= 0;
+
+  auto gKO = make_tensor(make_gmem_ptr(k_cache_out), make_layout(make_shape(Int<x>{}, Int<PageSize>{}, Int<HeadSize / x>{}, num_heads, num_pages)));
+  auto gVO = make_tensor(make_gmem_ptr(v_cache_out), make_layout(make_shape(Int<PageSize>{}, Int<HeadSize>{}, num_heads, num_pages)));
+  auto gSB = make_tensor(make_gmem_ptr(kv_scalebias_out), make_layout(make_shape(Int<PageSize>{}, Int<ceil_div(HeadSize, ChunkSize)>{}, _2{}, num_heads, _2{}, num_pages)));
+  const auto gKV = make_tensor(
+      make_gmem_ptr(is_key ? k_in : v_in),
+      make_layout(make_shape(Int<HeadSize>{}, num_heads, num_tokens),make_stride(_1{}, Int<HeadSize>{}, is_key ? k_in_stride : v_in_stride))
+  );
+
+#define PAD_HEAD_SIZE_DIM_TO_POWER_OF_2(t) t.compose(make_tile(make_tile(Int<HeadSizeNextPowerOfTwo>{}, _)))
+
+  // ((dim_idx, head_idx_in_cta))
+  const auto ctaI = [&]() {
+    auto t = group_modes<0, 2>(local_tile(
+        gKV,
+        make_shape(Int<HeadSize>{}, num_heads_per_cta, _1{}),
+        make_coord(_0{}, head_group_idx, token_idx)
+    )(_, _, _0{}));
+    return PAD_HEAD_SIZE_DIM_TO_POWER_OF_2(t);
+  }();
+  const auto cta_cI = make_identity_tensor(make_shape(make_shape(Int<HeadSizeNextPowerOfTwo>{}, num_heads_per_cta)));
+
+  // (tok_idx_in_page, chunk_idx, head_idx_in_cta, sb_idx)
+  const auto ctaSB = local_tile(
+      gSB,
+      make_shape(Int<PageSize>{}, shape<1>(gSB), _2{}, num_heads_per_cta, _1{}, _1{}),
+      make_coord(_0{}, _0{}, _0{}, head_group_idx, is_key ? 0 : 1, page_id)
+  )(_, _, _, _, _0{}, _0{});
+
+  // TODO: we need a tiler to pad dim_idx to next_power_of_two before applying the partition,
+  // TODO: conditionally mask out the copy result
+  auto tiled_copy = make_tiled_copy(
+      Copy_Atom<DefaultCopy, input_t>{},  // placeholder
+      make_layout(Int<NumThreads>{}),
+      make_layout(Int<VecSize>{})
+  );
+  auto thr_copy = tiled_copy.get_thread_slice(threadIdx.x);
+  auto tI_view = thr_copy.partition_S(ctaI);  // ((vec), iter), where iter == 1 due to tiled_copy design. TODO: enforce iter == 1
+  auto cI = thr_copy.partition_S(cta_cI);
+  auto tI = make_tensor<input_t>(Int<VecSize>{});
+  auto tI_cvt = make_tensor<float>(Int<VecSize>{});
+  auto tO = make_tensor<cache_t>(Int<VecSize>{});
+
+  const bool is_valid_vec = get<0, 0>(cI(_0{})) < HeadSize;
+
+  clear(tI);
+  if (is_valid_token && is_valid_vec) {
+    copy(AutoVectorizingCopyWithAssumedAlignment<NumInputBits>{}, tI_view, tI);
+  }
+
+  CUTE_UNROLL
+  for (int i = 0; i < size(tI); i++) {
+    tI_cvt(i) = type_convert<float>(tI(i));
+  }
+
+  constexpr int GroupSize = ChunkSize / VecSize;
+
+  float acc{};
+  int num = is_valid_vec ? VecSize : 0;
+  CUTE_UNROLL
+  for (int i = 0; i < size(tI); i++) {
+    acc += tI_cvt(i);
+  }
+  acc = warp::reduce<GroupSize>(acc, [](float a, float b) { return a + b; });
+  num = warp::reduce<GroupSize>(num, [](int a, int b) { return a + b; });
+  // original = a * scaled + b
+  float b = acc / num;
+  // b = broadcast_in_warp<GroupSize>(b);
+  CUTE_UNROLL
+  for (int i = 0; i < size(tI); i++) {
+    tI_cvt(i) = tI_cvt(i) - b;
+  }
+  float amax{};
+  CUTE_UNROLL
+  for (int i = 0; i < size(tI); i++) {
+    amax = fmaxf(amax, fabsf(tI_cvt(i)));
+  }
+  amax = warp::reduce<GroupSize>(amax, [](float a, float b) { return fmaxf(a, fabsf(b)); });
+  float target_max = 416.0f;
+  // float a = amax / target_max;
+  // // a = broadcast_in_warp<GroupSize>(a);
+  // float scale = __frcp_rn(a);
+  float scale = target_max / amax;
+  float a = __frcp_rn(scale);
+  CUTE_UNROLL
+  for (int i = 0; i < size(tI); i++) {
+    tO(i) = fast_type_convert<float_e4m3_t>(__float2half(tI_cvt(i) * scale));
+  }
+
+  // additional computing is not allowed after return!
+  if (!is_valid_token || !is_valid_vec) {
+    return;
+  }
+  if (is_key) {
+    // (((dim_idx), head_idx_in_cta))
+    auto ctaO = [&]() {
+      auto t = local_tile(  // [x, head_size/x, num_heads_per_cta]
+          gKO,
+          make_shape(shape<0>(gKO), _1{}, shape<2>(gKO), num_heads_per_cta, _1{}),
+          make_coord(_0{}, tok_idx_in_page, _0{}, head_group_idx, page_id)
+      )(_, _0{}, _, _, _0{});
+      auto t2 = group_modes<0, 2>(group_modes<0, 2>(t));  // [((x, head_size/x), num_heads_per_cta)]
+      return PAD_HEAD_SIZE_DIM_TO_POWER_OF_2(t2);
+    }();
+
+    auto tO_view = thr_copy.partition_D(ctaO);
+    copy(AutoVectorizingCopyWithAssumedAlignment<NumOutputBits>{}, tO, tO_view);
+  } else {
+    // ((dim_idx, head_idx_in_cta))
+    auto ctaO = [&]() {
+      auto t = group_modes<0, 2>(local_tile(  // [head_size, num_heads_per_cta]
+          gVO,
+          make_shape(_1{}, shape<1>(gVO), num_heads_per_cta, _1{}),
+          make_coord(tok_idx_in_page, _0{}, head_group_idx, page_id)
+      )(_0{}, _, _, _0{}));
+      return PAD_HEAD_SIZE_DIM_TO_POWER_OF_2(t);
+    }();
+
+    auto tO_view = thr_copy.partition_D(ctaO);
+    copy(AutoVectorizingCopyWithAssumedAlignment<NumOutputBits>{}, tO, tO_view);
+  }
+  if (threadIdx.x % GroupSize == 0) {
+    auto tSB = ctaSB(tok_idx_in_page, chunk_idx, _, head_idx_in_cta);
+    tSB(_0{}) = type_convert<half>(a);
+    tSB(_1{}) = type_convert<half>(b);
+  }
+#undef PAD_HEAD_SIZE_DIM_TO_POWER_OF_2
+}
+#else
+    ;
+#endif
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/reshape_and_cache_fp8.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/reshape_and_cache_fp8.cu
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "cute/tensor.hpp"
+
+#include "contrib_ops/cuda/bert/paged/cuda_common.cuh"
+#include "contrib_ops/cuda/bert/paged/paged_attention/reshape_and_cache.cuh"
+
+namespace onnxruntime::contrib::paged {
+
+using namespace cute;
+
+void launch_reshape_and_cache_fp8(
+    stream_t stream,
+    float_e4m3_t* k_cache_out,    // [num_pages,    num_heads, head_size/x, page_size, x]
+    float_e4m3_t* v_cache_out,    // [num_pages,    num_heads, head_size,   page_size]
+    half* kv_scalebias_out,       // [num_pages, 2, num_heads, 2, num_chunks,  page_size]
+    const half* k_in,             // [num_tokens,   num_heads, head_size]
+    const half* v_in,             // [num_tokens,   num_heads, head_size]
+    const int64_t* slot_mapping,  // [num_tokens]
+    int num_pages,
+    int num_tokens,
+    int num_heads,
+    int head_size,
+    int page_size,
+    int k_in_stride,
+    int v_in_stride
+) {
+  constexpr int ChunkSize = 32;
+  constexpr int VecSize = 8 / sizeof(half);  // target LDG.64
+  constexpr int NumThreads = 128;
+  constexpr int NumElemPerCta = NumThreads * VecSize;
+
+#define LAUNCH_RESHAPE_AND_CACHE_KERNEL_AND_BREAK(HEAD_SIZE, PAGE_SIZE)                                    \
+  const int num_heads_per_cta = NumElemPerCta / onnxruntime::contrib::paged::next_power_of_two(head_size);                 \
+  const int num_ctas = num_tokens * ceil_div(num_heads, num_heads_per_cta);                                \
+  reshape_and_cache_kernel<NumThreads, HEAD_SIZE, PAGE_SIZE, ChunkSize, VecSize, half, float_e4m3_t, half> \
+      <<<dim3(num_ctas, /*0 for k, 1 for v*/ 2), NumThreads, 0, stream>>>(                                 \
+          k_cache_out, v_cache_out, kv_scalebias_out,                                                      \
+          k_in, v_in, slot_mapping,                                                                        \
+          num_pages, num_tokens, num_heads,                                                                \
+          k_in_stride, v_in_stride                                                                         \
+      );                                                                                                   \
+  break;
+
+  do {
+    if (page_size == 32) {
+      if (head_size == 64) {
+        LAUNCH_RESHAPE_AND_CACHE_KERNEL_AND_BREAK(64, 32);
+      } else if (head_size == 80) {
+        LAUNCH_RESHAPE_AND_CACHE_KERNEL_AND_BREAK(80, 32);
+      } else if (head_size == 96) {
+        LAUNCH_RESHAPE_AND_CACHE_KERNEL_AND_BREAK(96, 32);
+      } else if (head_size == 112) {
+        LAUNCH_RESHAPE_AND_CACHE_KERNEL_AND_BREAK(112, 32);
+      } else if (head_size == 128) {
+        LAUNCH_RESHAPE_AND_CACHE_KERNEL_AND_BREAK(128, 32);
+      } else if (head_size == 256) {
+        LAUNCH_RESHAPE_AND_CACHE_KERNEL_AND_BREAK(256, 32);
+      } else {
+        throw std::runtime_error(std::string("Unsupported head size: ") + std::to_string(head_size));
+      }
+    } else if (page_size == 16) {
+      if (head_size == 64) {
+        LAUNCH_RESHAPE_AND_CACHE_KERNEL_AND_BREAK(64, 16);
+      } else if (head_size == 80) {
+        LAUNCH_RESHAPE_AND_CACHE_KERNEL_AND_BREAK(80, 16);
+      } else if (head_size == 96) {
+        LAUNCH_RESHAPE_AND_CACHE_KERNEL_AND_BREAK(96, 16);
+      } else if (head_size == 112) {
+        LAUNCH_RESHAPE_AND_CACHE_KERNEL_AND_BREAK(112, 16);
+      } else if (head_size == 128) {
+        LAUNCH_RESHAPE_AND_CACHE_KERNEL_AND_BREAK(128, 16);
+      } else if (head_size == 256) {
+        LAUNCH_RESHAPE_AND_CACHE_KERNEL_AND_BREAK(256, 16);
+      } else {
+        throw std::runtime_error(std::string("Unsupported head size: ") + std::to_string(head_size));
+      }
+    } else if (page_size == 8) {
+      if (head_size == 64) {
+        LAUNCH_RESHAPE_AND_CACHE_KERNEL_AND_BREAK(64, 8);
+      } else if (head_size == 80) {
+        LAUNCH_RESHAPE_AND_CACHE_KERNEL_AND_BREAK(80, 8);
+      } else if (head_size == 96) {
+        LAUNCH_RESHAPE_AND_CACHE_KERNEL_AND_BREAK(96, 8);
+      } else if (head_size == 112) {
+        LAUNCH_RESHAPE_AND_CACHE_KERNEL_AND_BREAK(112, 8);
+      } else if (head_size == 128) {
+        LAUNCH_RESHAPE_AND_CACHE_KERNEL_AND_BREAK(128, 8);
+      } else if (head_size == 256) {
+        LAUNCH_RESHAPE_AND_CACHE_KERNEL_AND_BREAK(256, 8);
+      } else {
+        throw std::runtime_error(std::string("Unsupported head size: ") + std::to_string(head_size));
+      }
+    } else {
+      throw std::runtime_error(std::string("Unsupported page size: ") + std::to_string(page_size));
+    }
+  } while (0);
+#undef LAUNCH_RESHAPE_AND_CACHE_KERNEL_AND_BREAK
+}
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/reshape_and_cache_fp8.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/reshape_and_cache_fp8.cu
@@ -12,6 +12,7 @@ using namespace cute;
 
 void launch_reshape_and_cache_fp8(
     stream_t stream,
+    dev_props_ptr dev_props,
     float_e4m3_t* k_cache_out,    // [num_pages,    num_heads, head_size/x, page_size, x]
     float_e4m3_t* v_cache_out,    // [num_pages,    num_heads, head_size,   page_size]
     half* kv_scalebias_out,       // [num_pages, 2, num_heads, 2, num_chunks,  page_size]

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/reshape_and_cache_fp8.h
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/reshape_and_cache_fp8.h
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "cute/config.hpp"
+#include "cute/numeric/numeric_types.hpp"
+
+#include "contrib_ops/cuda/bert/paged/cuda_common.h"
+
+namespace onnxruntime::contrib::paged {
+
+void launch_reshape_and_cache_fp8(
+    stream_t stream,
+    cute::float_e4m3_t* k_cache_out,    // [num_pages,    num_heads, head_size/x, page_size, x]
+    cute::float_e4m3_t* v_cache_out,    // [num_pages,    num_heads, head_size,   page_size]
+    half* kv_scalebias_out,       // [num_pages, 2, num_heads, 2, num_chunks,  page_size]
+    const half* k_in,             // [num_tokens,   num_heads, head_size]
+    const half* v_in,             // [num_tokens,   num_heads, head_size]
+    const int64_t* slot_mapping,  // [num_tokens]
+    int num_pages,
+    int num_tokens,
+    int num_heads,
+    int head_size,
+    int page_size,
+    int k_in_stride,
+    int v_in_stride
+);
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/reshape_and_cache_fp8.h
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/paged_attention/reshape_and_cache_fp8.h
@@ -12,6 +12,7 @@ namespace onnxruntime::contrib::paged {
 
 void launch_reshape_and_cache_fp8(
     stream_t stream,
+    dev_props_ptr dev_props,
     cute::float_e4m3_t* k_cache_out,    // [num_pages,    num_heads, head_size/x, page_size, x]
     cute::float_e4m3_t* v_cache_out,    // [num_pages,    num_heads, head_size,   page_size]
     half* kv_scalebias_out,       // [num_pages, 2, num_heads, 2, num_chunks,  page_size]

--- a/onnxruntime/contrib_ops/cuda/bert/paged/platform_ext.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/platform_ext.cuh
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "contrib_ops/cuda/bert/paged/config.h"
+
+namespace onnxruntime::contrib::paged {
+
+namespace constant {
+inline constexpr const int WarpSize = 32;
+}  // namespace constant
+
+__forceinline__ __device__ void
+schedule_barrier() {
+  // do nothing
+}
+
+__noinline__ __device__ static void
+enforce_uniform() {
+  asm("ret.uni;\n" ::);
+  // __syncwarp();  // be old-school
+}
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/platform_ext.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/platform_ext.cuh
@@ -22,4 +22,23 @@ enforce_uniform() {
   // __syncwarp();  // be old-school
 }
 
+__host__ __device__ inline constexpr int
+compute_min_resident_blocks(int threads_per_block, int registers_per_thread) {
+  // at warp level register allocation granularity, stable date back to sm_52
+  constexpr int register_alloc_unit = 256;
+
+  // hardware resource of registers, stable date back to sm_60
+  constexpr int max_registers_per_block = 65536;
+
+  int registers_per_warp = ((registers_per_thread * constant::WarpSize - 1) / register_alloc_unit + 1) * register_alloc_unit;
+  int resident_warps = max_registers_per_block / registers_per_warp;
+  int warps_per_block = threads_per_block / constant::WarpSize;
+  return resident_warps / warps_per_block;
+}
+
 }  // namespace onnxruntime::contrib::paged
+
+
+// original second parameter of __launch_bounds__ constraints the desired min_resident_blocks
+#define PAGED_LAUNCH_BOUNDS(threads_per_block, registers_per_thread) \
+  __launch_bounds__(threads_per_block, compute_min_resident_blocks(threads_per_block, registers_per_thread))

--- a/onnxruntime/contrib_ops/cuda/bert/paged/type_convert.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/type_convert.cuh
@@ -1,0 +1,257 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+// FIXME: stop using it
+#include "contrib_ops/cuda/bert/paged/Float8_e4m3fn.cuh"
+
+namespace onnxruntime::contrib::paged {
+
+using namespace cute;
+
+template <typename T, typename F>
+__forceinline__ __device__ T
+type_convert(const F& from) {
+  if constexpr (std::is_same_v<T, F>) {
+    return from;
+  } else {
+    static_assert(always_false<T, F>, "not implemented");
+    return {};
+  }
+}
+
+template <>
+__forceinline__ __device__ half
+type_convert<half, float>(const float& from) {
+  return __float2half(from);
+}
+
+template <>
+__forceinline__ __device__ half2
+type_convert<half2, float2>(const float2& from) {
+  return __float22half2_rn(from);
+}
+
+template <>
+__forceinline__ __device__ float
+type_convert<float, half>(const half& from) {
+  return __half2float(from);
+}
+
+template <>
+__forceinline__ __device__ float2
+type_convert<float2, half2>(const half2& from) {
+  return __half22float2(from);
+}
+
+template <>
+__forceinline__ __device__ half
+type_convert<half, cute::float_e4m3_t>(const cute::float_e4m3_t& from) {
+  return cute::float_e4m3_t::to_half(from);
+}
+
+template <typename T, typename F>
+__forceinline__ __device__ T
+fast_type_convert(const F& from) {
+  return type_convert<T, F>(from);
+}
+
+template <>
+__forceinline__ __device__ half
+fast_type_convert<half, float_e4m3_t>(const float_e4m3_t& from) {
+#if defined(CUDA_PTX_FP8_CVT_ENABLED)
+  const __nv_fp8_storage_t& x = reinterpret_cast<const __nv_fp8_storage_t&>(from);
+  return half(__nv_cvt_fp8_to_halfraw(x, __NV_E4M3));
+#else
+  constexpr const uint16_t mask = 0x7fff;
+  constexpr const uint16_t sign_mask = 0x8000;
+  constexpr const uint16_t exp_compensate = 0x2000;
+
+  uint8_t x_u8 = reinterpret_cast<const uint8_t&>(from);
+  uint16_t x_u16 = static_cast<uint16_t>(x_u8) << 8;
+  uint16_t exp = (x_u16 & mask) >> 1;
+  uint16_t y = (x_u16 & sign_mask) | (exp + exp_compensate);
+  return reinterpret_cast<half&>(y);
+#endif
+}
+
+template <>
+__forceinline__ __device__ half2
+fast_type_convert<half2, array<float_e4m3_t, 2>>(const array<float_e4m3_t, 2>& from) {
+#if defined(CUDA_PTX_FP8_CVT_ENABLED)
+  const __nv_fp8x2_storage_t& x2 = reinterpret_cast<const __nv_fp8x2_storage_t&>(from);
+  return half2(__nv_cvt_fp8x2_to_halfraw2(x2, __NV_E4M3));
+#else
+  constexpr const uint32_t mask = 0x7fff7fff;
+  constexpr const uint32_t sign_mask = 0x80008000;
+  constexpr const uint32_t exp_compensate = 0x20002000;
+
+  const uchar2& x2_u8 = reinterpret_cast<const uchar2&>(from);
+  uchar4 x{0, x2_u8.x, 0, x2_u8.y};
+  uint32_t x_u32 = reinterpret_cast<uint32_t&>(x);
+
+  uint32_t exp = (x_u32 & mask) >> 1;
+  uint32_t v = (x_u32 & sign_mask) | (exp + exp_compensate);
+  return reinterpret_cast<half2&>(v);
+#endif
+}
+
+using half2x2 = array<half2, 2>;
+
+template <>
+__forceinline__ __device__ half2x2
+fast_type_convert<half2x2, array<float_e4m3_t, 4>>(const array<float_e4m3_t, 4>& from) {
+#if defined(CUDA_PTX_FP8_CVT_ENABLED)
+  using fp8x2x2 = array<__nv_fp8x2_storage_t, 2>;
+  half2x2 ret;
+  const fp8x2x2& x2x2 = reinterpret_cast<const fp8x2x2&>(from);
+  ret[0] = half2(__nv_cvt_fp8x2_to_halfraw2(x2x2[0], __NV_E4M3));
+  ret[1] = half2(__nv_cvt_fp8x2_to_halfraw2(x2x2[1], __NV_E4M3));
+  return ret;
+#else
+  constexpr const uint32_t mask = 0x7fff7fff;
+  constexpr const uint32_t sign_mask = 0x80008000;
+  constexpr const uint32_t exp_compensate = 0x20002000;
+
+  uint32_t xs_u32 = reinterpret_cast<const uint32_t&>(from);
+  uint32_t x_u32_0 = __byte_perm(xs_u32, 0, 0x1504);
+  uint32_t x_u32_1 = __byte_perm(xs_u32, 0, 0x3726);
+  uint32_t exp_0 = (x_u32_0 & mask) >> 1;
+  uint32_t exp_1 = (x_u32_1 & mask) >> 1;
+  uint32_t v_0 = (x_u32_0 & sign_mask) | (exp_0 + exp_compensate);
+  uint32_t v_1 = (x_u32_1 & sign_mask) | (exp_1 + exp_compensate);
+  uint64_t v = v_0 | uint64_t(v_1) << 32;
+  half2x2 ret = reinterpret_cast<half2x2&>(v);
+  return ret;
+#endif
+}
+
+using half4 = array<half, 4>;
+
+template <>
+__forceinline__ __device__ half4
+fast_type_convert<half4, array<float_e4m3_t, 4>>(const array<float_e4m3_t, 4>& from) {
+  auto ret = fast_type_convert<half2x2>(from);
+  return reinterpret_cast<half4&>(ret);
+}
+
+template <>
+__forceinline__ __device__ float_e4m3_t
+fast_type_convert<float_e4m3_t, half>(const half& from) {
+#if defined(CUDA_PTX_FP8_CVT_ENABLED)
+  return float_e4m3_t::bitcast(__nv_cvt_halfraw_to_fp8(from, __NV_SATFINITE, __NV_E4M3));
+#else
+  auto c10_tmp = fp8e4m3fn_from_fp32_value(__half2float(from));
+  float_e4m3_t tmp = reinterpret_cast<float_e4m3_t&>(c10_tmp);
+  return tmp;
+
+  // constexpr const uint16_t mask = 0x7fff;
+  // constexpr const uint16_t sign_mask = 0x8000;
+  // constexpr const uint16_t exp_compensate = 0x2000;
+
+  // uint16_t x_u16 = reinterpret_cast<const uint16_t&>(from);
+  // uint8_t sign = uint8_t((x_u16 & sign_mask) >> 8);
+  // uint8_t exp = uint8_t(((x_u16 - exp_compensate) & mask) >> 7);
+  // uint8_t y = sign | exp;
+  // return reinterpret_cast<float_e4m3_t&>(y);
+#endif
+}
+
+// convert with tensor scale bias
+template <
+    typename TensorInEngine, typename TensorInLayout,
+    typename TensorSBEngine, typename TensorSBLayout,
+    typename TensorOutEngine, typename TensorOutLayout>
+__forceinline__ __device__ void
+tensor_convert(
+    const Tensor<TensorInEngine, TensorInLayout>& in,
+    const Tensor<TensorSBEngine, TensorSBLayout>& scale,
+    const Tensor<TensorSBEngine, TensorSBLayout>& bias,
+    Tensor<TensorOutEngine, TensorOutLayout>& out
+) {
+  using TI = typename TensorInEngine::element_type;
+  using TO = typename TensorOutEngine::element_type;
+  static_assert(is_same_v<TI, cute::float_e4m3_t>);
+  static_assert(is_same_v<TO, half>);
+  constexpr auto len = size(TensorInLayout{});
+  // static_assert(len == size(scale) && len == size(bias) && len == size(TensorOutLayout{}));
+
+  if constexpr (len % 4 == 0) {
+    const auto in4 = recast<array<float_e4m3_t, 4>>(in);
+    const auto scale4 = recast<onnxruntime::contrib::paged::half2x2>(scale);
+    const auto bias4 = recast<onnxruntime::contrib::paged::half2x2>(bias);
+    auto out4 = recast<onnxruntime::contrib::paged::half2x2>(out);
+
+    CUTE_UNROLL
+    for (int i = 0; i < size(in4); i++) {
+      auto v = fast_type_convert<onnxruntime::contrib::paged::half2x2>(in4(i));
+      auto a = scale4(i);
+      auto b = bias4(i);
+      out4(i)[0] = __hfma2(a[0], v[0], b[0]);
+      out4(i)[1] = __hfma2(a[1], v[1], b[1]);
+    }
+  } else if constexpr (len % 2 == 0) {
+    const auto in2 = recast<array<float_e4m3_t, 2>>(in);
+    const auto scale2 = recast<half2>(scale);
+    const auto bias2 = recast<half2>(bias);
+    auto out2 = recast<half2>(out);
+
+    CUTE_UNROLL
+    for (int i = 0; i < size(in2); i++) {
+      out2(i) = __hfma2(scale2(i), fast_type_convert<half2>(in2(i)), bias2(i));
+    }
+  } else {
+    CUTE_UNROLL
+    for (int i = 0; i < size(in); i++) {
+      out(i) = scale(i) * fast_type_convert<TO>(in(i)) + bias(i);
+    }
+  }
+}
+
+// convert with scalar scale bias
+template <
+    typename TensorInEngine, typename TensorInLayout,
+    typename TensorOutEngine, typename TensorOutLayout>
+__forceinline__ __device__ void
+tensor_convert(
+    const Tensor<TensorInEngine, TensorInLayout>& in,
+    const half& scale, const half& bias,
+    Tensor<TensorOutEngine, TensorOutLayout>& out
+) {
+  using TI = typename TensorInEngine::element_type;
+  using TO = typename TensorOutEngine::element_type;
+  static_assert(is_same_v<TI, cute::float_e4m3_t>);
+  static_assert(is_same_v<TO, half>);
+  constexpr auto len = size(TensorInLayout{});
+
+  const half2 scale2{scale, scale};
+  const half2 bias2{bias, bias};
+
+  if constexpr (len % 4 == 0) {
+    const auto in4 = recast<array<float_e4m3_t, 4>>(in);
+    auto out4 = recast<onnxruntime::contrib::paged::half2x2>(out);
+
+    CUTE_UNROLL
+    for (int i = 0; i < size(in4); i++) {
+      auto v = fast_type_convert<onnxruntime::contrib::paged::half2x2>(in4(i));
+      out4(i)[0] = __hfma2(scale2, v[0], bias2);
+      out4(i)[1] = __hfma2(scale2, v[1], bias2);
+    }
+  } else if constexpr (len % 2 == 0) {
+    const auto in2 = recast<array<float_e4m3_t, 2>>(in);
+    auto out2 = recast<half2>(out);
+
+    CUTE_UNROLL
+    for (int i = 0; i < size(in2); i++) {
+      out2(i) = __hfma2(scale2, fast_type_convert<half2>(in2(i)), bias2);
+    }
+  } else {
+    CUTE_UNROLL
+    for (int i = 0; i < size(in); i++) {
+      out(i) = scale * fast_type_convert<TO>(in(i)) + bias;
+    }
+  }
+}
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged/warp_utilities.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/paged/warp_utilities.cuh
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+namespace onnxruntime::contrib::paged {
+namespace warp {
+
+// Perform (sub-)warp reduction. The resulting value will be available at leading thread in the group.
+template <int GroupSize, bool Strided, typename T, typename Func>
+__forceinline__ __device__ T
+reduce(const T& in, Func&& elementwise_reduce_operator) {
+  static_assert(
+      GroupSize == 1 || GroupSize == 2 || GroupSize == 4 || GroupSize == 8 ||
+      GroupSize == 16 || GroupSize == 32 || GroupSize == constant::WarpSize
+  );
+  constexpr int Stride = Strided ? constant::WarpSize / GroupSize : 1;
+
+  if constexpr (!cute::is_tensor<T>::value) {
+    T val = in;
+    CUTE_UNROLL
+    for (int mask = (GroupSize * Stride) / 2; mask >= Stride; mask /= 2) {
+      val = std::forward<Func&&>(elementwise_reduce_operator)(val, SHFL_XOR_SYNC(val, mask));
+    }
+    return val;
+  } else {
+    static_assert(cute::is_rmem<typename T::engine_type>());
+    auto vec = make_fragment_like(in);
+    CUTE_UNROLL
+    for (int i = 0; i < size(in); i++) {
+      vec(i) = in(i);
+    }
+
+    CUTE_UNROLL
+    for (int mask = (GroupSize * Stride) / 2; mask >= Stride; mask /= 2) {
+      CUTE_UNROLL
+      for (int i = 0; i < size(in); i++) {
+        vec(i) = std::forward<Func&&>(elementwise_reduce_operator)(vec(i), SHFL_XOR_SYNC(vec(i), mask));
+      }
+    }
+    return vec;
+  }
+}
+
+template <int GroupSize, typename T, typename Func>
+__forceinline__ __device__ T
+reduce(const T& in, Func&& elementwise_reduce_operator) {
+  return reduce<GroupSize, false, T, Func>(in, std::forward<Func>(elementwise_reduce_operator));
+}
+
+// Broadcast values in the leading threads to the whole groups.
+template <int GroupSize, typename T>
+__forceinline__ __device__ T
+broadcast(const T& in) {
+  static_assert(
+      GroupSize == 1 || GroupSize == 2 || GroupSize == 4 || GroupSize == 8 ||
+      GroupSize == 16 || GroupSize == 32 || GroupSize == constant::WarpSize
+  );
+
+#if !defined(__HIPCC__)
+  __shfl_sync(uint32_t(-1), in, 0, GroupSize);
+#else
+  __shfl(in, 0, GroupSize);
+#endif
+}
+
+}  // namespace warp
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention.cu
@@ -1,0 +1,141 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "contrib_ops/cuda/bert/paged_attention.h"
+
+#include "cute/config.hpp"
+#include "cute/numeric/numeric_types.hpp"
+
+#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/shared_inc/fpgeneric.h"
+#include "contrib_ops/cuda/bert/paged/paged_attention/paged_attention.h"
+
+using namespace onnxruntime::cuda;
+using namespace ::onnxruntime::common;
+using namespace ONNX_NAMESPACE;
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+
+#define REGISTER_KERNEL()                                                                    \
+  ONNX_OPERATOR_KERNEL_EX(                                                                   \
+      PagedAttention,                                                                        \
+      kMSDomain,                                                                             \
+      1,                                                                                     \
+      kCudaExecutionProvider,                                                                \
+      (*KernelDefBuilder::Create())                                                          \
+          .InputMemoryType(OrtMemTypeCPUInput, 5)                                            \
+          .TypeConstraint("T", BuildKernelDefConstraints<float, MLFloat16>())                \
+          .TypeConstraint("C", BuildKernelDefConstraints<float, MLFloat16, Float8E4M3FN>()), \
+      PagedAttention)
+
+REGISTER_KERNEL();
+
+PagedAttention::PagedAttention(const OpKernelInfo& info) : CudaKernel(info) {
+  scale_ = info.GetAttrOrDefault<float>("beta", 0);
+  ORT_ENFORCE(info.GetAttr<int64_t>("page_size", &page_size_).IsOK());
+  ORT_ENFORCE(info.GetAttr<int64_t>("num_heads", &num_heads_).IsOK());
+  ORT_ENFORCE(info.GetAttr<int64_t>("num_kv_heads", &num_kv_heads_).IsOK());
+  ORT_ENFORCE(info.GetAttr<int64_t>("kv_quant_group_size", &kv_quant_group_size_).IsOK());
+}
+
+Status PagedAttention::ComputeInternal(OpKernelContext* ctx) const {
+  const Tensor* query = ctx->Input<Tensor>(0);
+  const Tensor* key_cache = ctx->Input<Tensor>(1);
+  const Tensor* value_cache = ctx->Input<Tensor>(2);
+  const Tensor* page_table = ctx->Input<Tensor>(3);
+  const Tensor* context_lens = ctx->Input<Tensor>(4);
+  const Tensor* max_context_len_tensor = ctx->Input<Tensor>(5);
+  const Tensor* alibi = ctx->Input<Tensor>(6);
+  const Tensor* kv_quant_param = ctx->Input<Tensor>(7);
+
+  int32_t max_context_len = 32768;  // NOTE: when omitted, will cause some scheduling overhead
+  if (max_context_len_tensor) {
+    max_context_len = max_context_len_tensor->Data<int32_t>()[0];
+  }
+
+  auto q_shape = query->Shape();
+  int32_t num_seqs = q_shape[0];
+  int32_t num_heads = q_shape[1];
+  int32_t head_size = q_shape[2];
+  ORT_ENFORCE(num_heads == num_heads_);
+  int32_t q_stride = num_heads * head_size;
+
+  auto key_cache_shape = key_cache->Shape();
+  int32_t num_pages = key_cache_shape[0];
+  int32_t packed_page_size = key_cache_shape[1];
+  ORT_ENFORCE(packed_page_size == page_size_ * num_kv_heads_ * head_size);
+
+  auto value_cache_shape = value_cache->Shape();
+  ORT_ENFORCE(num_pages == value_cache_shape[0]);
+  ORT_ENFORCE(packed_page_size == value_cache_shape[1]);
+
+  auto page_table_shape = page_table->Shape();
+  ORT_ENFORCE(num_seqs == page_table_shape[0]);
+  int32_t max_num_pages_per_seq = page_table_shape[1];
+
+  ORT_ENFORCE(num_seqs == context_lens->Shape()[0]);
+
+  TensorShapeVector output_shape{num_seqs, num_heads, head_size};
+  Tensor* output = ctx->Output(0, output_shape);
+
+  auto cuda_stream = static_cast<cudaStream_t>(ctx->GetComputeStream()->GetHandle());
+
+  auto kv_onnx_type = key_cache->DataType();
+
+  if (kv_onnx_type == DataTypeImpl::GetType<float>()) {
+    const void* scalebias = nullptr;
+    paged::launch_paged_attention_kernel(
+        cuda_stream,
+        output->MutableData<float>(),
+        query->Data<float>(),
+        key_cache->Data<float>(),
+        value_cache->Data<float>(),
+        scalebias,
+        page_table->Data<int32_t>(),
+        context_lens->Data<int32_t>(),
+        alibi == nullptr ? nullptr : alibi->Data<float>(),
+        scale_ == 0.0f ? 1.0f / sqrt(head_size) : scale_,
+        num_seqs, num_heads_, num_kv_heads_, head_size, page_size_,
+        max_num_pages_per_seq, q_stride, max_context_len);
+  } else if (kv_onnx_type == DataTypeImpl::GetType<MLFloat16>()) {
+    const void* scalebias = nullptr;
+    paged::launch_paged_attention_kernel(
+        cuda_stream,
+        reinterpret_cast<half*>(output->MutableData<MLFloat16>()),
+        reinterpret_cast<const half*>(query->Data<MLFloat16>()),
+        reinterpret_cast<const half*>(key_cache->Data<MLFloat16>()),
+        reinterpret_cast<const half*>(value_cache->Data<MLFloat16>()),
+        scalebias,
+        page_table->Data<int32_t>(),
+        context_lens->Data<int32_t>(),
+        alibi == nullptr ? nullptr : alibi->Data<float>(),
+        scale_ == 0.0f ? 1.0f / sqrt(head_size) : scale_,
+        num_seqs, num_heads_, num_kv_heads_, head_size, page_size_,
+        max_num_pages_per_seq, q_stride, max_context_len);
+  } else if (kv_onnx_type == DataTypeImpl::GetType<Float8E4M3FN>()) {
+    using TKV = cute::float_e4m3_t;
+    paged::launch_paged_attention_kernel(
+        cuda_stream,
+        reinterpret_cast<half*>(output->MutableData<MLFloat16>()),
+        reinterpret_cast<const half*>(query->Data<MLFloat16>()),
+        reinterpret_cast<const TKV*>(key_cache->Data<Float8E4M3FN>()),
+        reinterpret_cast<const TKV*>(value_cache->Data<Float8E4M3FN>()),
+        reinterpret_cast<const half*>(kv_quant_param->Data<MLFloat16>()),
+        page_table->Data<int32_t>(),
+        context_lens->Data<int32_t>(),
+        alibi == nullptr ? nullptr : alibi->Data<float>(),
+        scale_ == 0.0f ? 1.0f / sqrt(head_size) : scale_,
+        num_seqs, num_heads_, num_kv_heads_, head_size, page_size_,
+        max_num_pages_per_seq, q_stride, max_context_len);
+  } else {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL, "kv cache datatype not implemented.");
+  }
+
+  return Status::OK();
+}
+
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention.cu
@@ -84,10 +84,12 @@ Status PagedAttention::ComputeInternal(OpKernelContext* ctx) const {
 
   auto kv_onnx_type = key_cache->DataType();
 
+  auto dev_props = &GetDeviceProp();
+
   if (kv_onnx_type == DataTypeImpl::GetType<float>()) {
     const void* scalebias = nullptr;
     paged::launch_paged_attention_kernel(
-        cuda_stream,
+        cuda_stream, dev_props,
         output->MutableData<float>(),
         query->Data<float>(),
         key_cache->Data<float>(),
@@ -102,7 +104,7 @@ Status PagedAttention::ComputeInternal(OpKernelContext* ctx) const {
   } else if (kv_onnx_type == DataTypeImpl::GetType<MLFloat16>()) {
     const void* scalebias = nullptr;
     paged::launch_paged_attention_kernel(
-        cuda_stream,
+        cuda_stream, dev_props,
         reinterpret_cast<half*>(output->MutableData<MLFloat16>()),
         reinterpret_cast<const half*>(query->Data<MLFloat16>()),
         reinterpret_cast<const half*>(key_cache->Data<MLFloat16>()),
@@ -117,7 +119,7 @@ Status PagedAttention::ComputeInternal(OpKernelContext* ctx) const {
   } else if (kv_onnx_type == DataTypeImpl::GetType<Float8E4M3FN>()) {
     using TKV = cute::float_e4m3_t;
     paged::launch_paged_attention_kernel(
-        cuda_stream,
+        cuda_stream, dev_props,
         reinterpret_cast<half*>(output->MutableData<MLFloat16>()),
         reinterpret_cast<const half*>(query->Data<MLFloat16>()),
         reinterpret_cast<const TKV*>(key_cache->Data<Float8E4M3FN>()),

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention.h
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention.h
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/common/common.h"
+#include "core/providers/cuda/cuda_kernel.h"
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+
+class PagedAttention final : public onnxruntime::cuda::CudaKernel {
+ public:
+  PagedAttention(const OpKernelInfo& info);
+
+  Status ComputeInternal(OpKernelContext* context) const override;
+
+ private:
+  float scale_;
+  int64_t page_size_;
+  int64_t num_heads_;
+  int64_t num_kv_heads_;
+  int64_t kv_quant_group_size_;
+};
+
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/cuda_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/cuda/cuda_contrib_kernels.cc
@@ -79,6 +79,7 @@ class CUDA_MS_OP_TYPED_CLASS_NAME(1, float, PackedAttention);
 class CUDA_MS_OP_TYPED_CLASS_NAME(1, MLFloat16, PackedAttention);
 class CUDA_MS_OP_TYPED_CLASS_NAME(1, float, PackedMultiHeadAttention);
 class CUDA_MS_OP_TYPED_CLASS_NAME(1, MLFloat16, PackedMultiHeadAttention);
+class CUDA_MS_OP_CLASS_NAME(1,  PagedAttention);
 class CUDA_MS_OP_CLASS_NAME(1, BeamSearch);
 class CUDA_MS_OP_CLASS_NAME(1, WhisperBeamSearch);
 class CUDA_MS_OP_TYPED_CLASS_NAME(1, float, ConvTransposeWithDynamicPads);
@@ -283,6 +284,7 @@ Status RegisterCudaContribKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, MLFloat16, PackedAttention)>,
       BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, float, PackedMultiHeadAttention)>,
       BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, MLFloat16, PackedMultiHeadAttention)>,
+      BuildKernelCreateInfo<CUDA_MS_OP_CLASS_NAME(1, PagedAttention)>,
       BuildKernelCreateInfo<CUDA_MS_OP_CLASS_NAME(1, BeamSearch)>,
       BuildKernelCreateInfo<CUDA_MS_OP_CLASS_NAME(1, WhisperBeamSearch)>,
       BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, float, ConvTransposeWithDynamicPads)>,

--- a/onnxruntime/contrib_ops/rocm/bert/paged/config.h
+++ b/onnxruntime/contrib_ops/rocm/bert/paged/config.h
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+// See https://rocm.docs.amd.com/projects/install-on-linux/en/docs-6.1.0/reference/system-requirements.html
+// for llvm target code
+#if defined(__gfx942__) || defined(__gfx90a__) || defined(__gfx908__)
+#define PAGED_INNER_PRODUCT_FP16_ARITHMETIC_FP32_ACC 1
+#else
+#define PAGED_INNER_PRODUCT_FP16_ARITHMETIC_FP32_ACC 0
+#endif
+
+#define PAGED_LITTLE_ENDIAN_BIT_TEST_IS_INF_OR_NAN 0

--- a/onnxruntime/contrib_ops/rocm/bert/paged/platform_ext.cuh
+++ b/onnxruntime/contrib_ops/rocm/bert/paged/platform_ext.cuh
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "contrib_ops/rocm/bert/paged/config.h"
+#include "hip/hip_fp16.h"
+
+// https://github.com/llvm/llvm-project/blob/main/clang/include/clang/Basic/BuiltinsAMDGPU.def
+
+namespace onnxruntime::contrib::paged {
+
+namespace constant {
+inline constexpr const int WarpSize = 64;
+}  // namespace constant
+
+__forceinline__ __device__ void
+schedule_barrier() {
+  __builtin_amdgcn_sched_barrier(0);
+}
+
+__forceinline__ __device__ void
+enforce_uniform() {
+  // do nothing
+}
+
+__forceinline__ __device__ float
+hfma2(const half2& a, const half2& b, float& c) {
+#if __HIP_DEVICE_COMPILE__
+#if PAGED_INNER_PRODUCT_FP16_ARITHMETIC_FP32_ACC
+  // asm volatile("\n v_dot2c_f32_f16 %0, %1, %2\n s_nop 4" : "+v"(c) : "v"(a), "v"(b));
+  c = __builtin_amdgcn_fdot2(a, b, c, false);
+  return c;
+#else
+  // static_assert(false, "not implemented");
+#endif
+  return std::numeric_limits<float>::quiet_NaN();
+#endif
+}
+
+}  // namespace onnxruntime::contrib::paged

--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -708,6 +708,77 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
           PackedMultiHeadAttentionTypeAndShapeInference(ctx);
         }));
 
+void propagateShapeAndTypeFromFirstInputAndParam(ONNX_NAMESPACE::InferenceContext& ctx) {
+  propagateShapeAndTypeFromFirstInput(ctx);
+  // fix output_shape
+  auto* output_shape =
+      ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
+
+  for (int i = 0; i < output_shape->dim_size(); i++) {
+    auto* dim_i = output_shape->mutable_dim(i);
+    if (dim_i->has_dim_param() && dim_i->dim_value() == 0) {
+      dim_i->set_dim_value(-1);
+    }
+  }
+}
+
+constexpr const char* PagedAttention_ver1_doc = R"DOC(
+PagedAttention Implementation for ONNXRuntime
+)DOC";
+ONNX_MS_OPERATOR_SET_SCHEMA(
+    PagedAttention, 1,
+    OpSchema()
+        .SetDomain(kMSDomain)
+        .Attr("scale",
+              "Custom scale will be used if specified. Default value is 1/sqrt(head_size)",
+              AttributeProto::FLOAT,
+              OPTIONAL_VALUE)
+        .Attr("page_size", "Number of slots (tokens) per page", AttributeProto::INT)
+        .Attr("num_heads", "Number of attention heads for q", AttributeProto::INT)
+        .Attr("num_kv_heads", "Number of attention heads for k and v", AttributeProto::INT)
+        .Attr("kv_quant_group_size", "Size of the groupwise quantization",
+              AttributeProto::INT, static_cast<int64_t>(32))
+        .Input(0,
+               "query",
+               "Query with shape [num_seqs, num_heads, head_size]",
+               "T")
+        .Input(1,
+               "key_cache",
+               "Page based key cache with shape [num_pages, page_size*num_kv_heads*head_size]",
+               "C")
+        .Input(2,
+               "value_cache",
+               "Page based value cache with shape [num_pages, page_size*num_kv_heads*head_size]",
+               "C")
+        .Input(3,
+               "page_table",
+               "Mapping each sequence to paged form. Map pages from logical to physical page ids."
+               "With shape [num_seqs, max_num_pages_per_sequence]",
+               "tensor(int32)")
+        .Input(4,
+               "context_lens",
+               "Context length of each sequence in the batch. Tensor of shape [num_seqs]",
+               "tensor(int32)")
+        .Input(5,
+               "max_context_len",
+               "Max length of the context among all sequences. Used by scheduling. A tensor of single element on CPU."
+               "Must be specified if max_context_len > 32768",
+               "tensor(int32)",
+               OpSchema::Optional)
+        .Input(6, "alibi_bias", "Input for Alibi", "tensor(float)", OpSchema::Optional)
+        .Input(7,
+               "kv_quant_param",
+               "Additional input for kvcache dequantization. Scale and bias or scale and zeropoint"
+               "Tensor of shape [num_pages, 2*page_size*num_kv_heads*head_size/group_size]",
+               "tensor(float16)",
+               OpSchema::Optional)
+        .Output(0, "output", "Attention output", "T")
+        .TypeConstraint("T", {"tensor(float)", "tensor(float16)", "tensor(float)"}, "Constrains input and output types.")
+        .TypeConstraint("C", {"tensor(float)", "tensor(float16)", "tensor(float8e4m3fn)"}, "Constrains key and value cache types.")
+        .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+          propagateShapeAndTypeFromFirstInputAndParam(ctx);
+        }));
+
 constexpr const char* DecoderMaskedSelfAttention_ver1_doc = R"DOC(
 Self attention that supports input sequence length of 1.
 

--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -773,7 +773,7 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
                "tensor(float16)",
                OpSchema::Optional)
         .Output(0, "output", "Attention output", "T")
-        .TypeConstraint("T", {"tensor(float)", "tensor(float16)", "tensor(float)"}, "Constrains input and output types.")
+        .TypeConstraint("T", {"tensor(float)", "tensor(float16)", "tensor(bfloat16)"}, "Constrains input and output types.")
         .TypeConstraint("C", {"tensor(float)", "tensor(float16)", "tensor(float8e4m3fn)"}, "Constrains key and value cache types.")
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
           propagateShapeAndTypeFromFirstInputAndParam(ctx);

--- a/onnxruntime/core/graph/contrib_ops/ms_opset.h
+++ b/onnxruntime/core/graph/contrib_ops/ms_opset.h
@@ -92,6 +92,7 @@ class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, NGramRepeatBlock);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, Pad);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, PackedAttention);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, PackedMultiHeadAttention);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, PagedAttention);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, RelativePositionBias);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, GatedRelativePositionBias);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, RemovePadding);
@@ -202,6 +203,7 @@ class OpSet_Microsoft_ver1 {
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, Pad)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, PackedAttention)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, PackedMultiHeadAttention)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, PagedAttention)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, QAttention)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, QEmbedLayerNormalization)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, RelativePositionBias)>());

--- a/onnxruntime/test/python/transformers/test_paged_attn_cuda.py
+++ b/onnxruntime/test/python/transformers/test_paged_attn_cuda.py
@@ -1,0 +1,748 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+from typing import Any, List, Tuple
+
+import os
+import gc
+import itertools
+import random
+import unittest
+
+import numpy as np
+import torch
+import torch.distributions as dist
+import pytest
+from parameterized import parameterized
+
+from onnx import TensorProto, helper
+from onnxruntime import InferenceSession, OrtValue, SessionOptions
+
+
+DTYPES = ["float16", "float32", "float8_e4m3fn"]
+NUM_GEN_SEQS = [1, 7]
+NUM_HEADS = [(32, 2), (32, 4), (19, 19)]
+HEAD_SIZES = [64, 80, 96, 112, 128]
+PAGE_SIZES = [8, 16, 32]
+
+
+def generate_page_mapping(
+    max_num_pages: int,
+    num_seqs: int,
+    max_context_len: int,
+    page_size: int,
+):
+    unique_page_mapping = [i for i in range(max_num_pages)]
+    max_num_pages_per_seq = (max_context_len + page_size - 1) // page_size
+    random.shuffle(unique_page_mapping)
+    page_table = []
+    for i in range(num_seqs):
+        page_table.append(unique_page_mapping[i * max_num_pages_per_seq : (i + 1) * max_num_pages_per_seq])
+    assert len(page_table[-1]) == max_num_pages_per_seq, "alloc more pages to allow generating unique page mapping"
+    return page_table
+
+
+def get_useful_slots(
+    fill_non_used: float | None,
+    page_size: int,
+    page_table: list[list[int]],
+    context_lens: list[int],
+):
+    useful_slots = None
+    if fill_non_used is not None:
+        useful_slots = []
+        for seq, end in enumerate(context_lens):
+            seq_num_pages = (end - 1) // page_size + 1
+            seq_useful_slots = []
+            for logical_pid in range(seq_num_pages):
+                physical_pid = page_table[seq][logical_pid]
+                seq_useful_slots.extend(list(range(physical_pid * page_size, physical_pid * page_size + page_size)))
+            useful_slots.extend(seq_useful_slots[:end])
+    return useful_slots
+
+
+def get_dtypes(kv_dtype) -> Tuple[Any]:
+    if isinstance(kv_dtype, str):
+        kv_dtype = getattr(torch, kv_dtype)
+    mapping = {
+        None: (torch.float16, torch.float16, None),
+        torch.float16: (torch.float16, torch.float16, None),
+        torch.float32: (torch.float32, torch.float32, None),
+        torch.float8_e4m3fn: (torch.float16, torch.float8_e4m3fn, torch.float16),
+    }
+    return mapping.get(kv_dtype)
+
+
+def masked_mha(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    scale: float,
+    attn_mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    attn_weights = scale * torch.einsum("qhd,khd->hqk", q, k).float()
+    if attn_mask is not None:
+        attn_weights = attn_weights + attn_mask.float()
+    attn_weights = torch.softmax(attn_weights, dim=-1).to(v.dtype)
+    out = torch.einsum("hqk,khd->qhd", attn_weights, v)
+    return out
+
+
+def reconstruct_kv(
+    page_mapping_of_seq: torch.Tensor,
+    context_len: int,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    kv_scalebias: torch.Tensor | None = None,
+    chunksize=32,
+):
+    #  (num_pages, num_heads, head_size//chunksize, page_size)
+    k_padded = k_cache.view(torch.int8).index_select(0, page_mapping_of_seq).view(k_cache.dtype).clone()
+    v_padded = v_cache.view(torch.int8).index_select(0, page_mapping_of_seq).view(v_cache.dtype).clone()
+    #  (num_pages, 2, num_heads, 2, head_size//chunksize, page_size)
+    if kv_scalebias is not None:
+        sb_padded = kv_scalebias.index_select(0, page_mapping_of_seq).clone()
+
+    k_padded = k_padded.moveaxis(0, -3)  #  (num_heads, head_size//x, num_pages, page_size, x)
+    k_padded = k_padded.moveaxis(-1, -3)  # (num_heads, head_size//x, x, num_pages, page_size)
+    v_padded = v_padded.moveaxis(0, -2)  #  (num_heads, head_size,    num_pages, page_size)
+    # print(k_padded.shape)
+    # print(v_padded.shape)
+    if kv_scalebias is not None:
+        sb_padded = sb_padded.moveaxis(0, -2)  #  (2, num_heads, 2, head_size//chunksize, num_pages, page_size)
+        # print(sb_padded.shape)
+
+    k_padded = k_padded.reshape(
+        (k_padded.shape[0], k_padded.shape[1] * k_padded.shape[2], k_padded.shape[3] * k_padded.shape[4])
+    )
+    v_padded = v_padded.reshape(v_padded.shape[:2] + (v_padded.shape[2] * v_padded.shape[3],))
+    # print(k_padded.shape)
+    # print(v_padded.shape)
+    if kv_scalebias is not None:
+        sb_padded = sb_padded.reshape(sb_padded.shape[:4] + (sb_padded.shape[4] * sb_padded.shape[5],))
+        sb_padded = sb_padded.repeat_interleave(chunksize, dim=3)
+        # print(sb_padded.shape)
+
+    # (num_heads, head_size, context_len)
+    k = k_padded[:, :, :context_len]
+    v = v_padded[:, :, :context_len]
+    # print(k.shape, k.dtype)
+    # print(v.shape, v.dtype)
+    if kv_scalebias is not None:
+        valid_head_size = k.shape[1]
+        sb = sb_padded[:, :, :, :valid_head_size, :context_len]
+        k = sb[0, :, 0] * k.to(sb.dtype) + sb[0, :, 1]
+        v = sb[1, :, 0] * v.to(sb.dtype) + sb[1, :, 1]
+        # print("k scale", sb[0, :, 0].max())
+        # print("k bias ", sb[0, :, 1].max())
+        # print("v scale", sb[1, :, 0].max())
+        # print("v bias ", sb[1, :, 1].max())
+
+    # (context_len, num_heads, head_size)
+    original_k = k.moveaxis(-1, 0).contiguous()
+    original_v = v.moveaxis(-1, 0).contiguous()
+    if kv_scalebias is None:
+        # print(original_k.shape, original_v.shape)
+        return original_k, original_v
+    else:
+        sb_chunked = sb[:, :, :, ::chunksize].moveaxis(-1, 0).contiguous()
+        # print(original_k.shape, original_v.shape, sb_chunked.shape)
+        return original_k, original_v, sb_chunked
+
+
+def reconstruct_kv_then_mha(
+    output: torch.Tensor,
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    kv_scalebias: torch.Tensor | None,
+    page_table: torch.Tensor,
+    context_lens: torch.Tensor,
+    scale: float,
+    alibi_slopes: torch.Tensor | None,
+) -> None:
+    num_q_heads = q.shape[1]
+    num_seqs = q.shape[0]
+    _, num_kv_heads, head_size, page_size = v_cache.shape
+    context_lens = context_lens.cpu().tolist()
+    if kv_scalebias is not None:
+        num_chunks = kv_scalebias.shape[-2]
+        chunk_size = head_size // num_chunks
+
+        assert k_cache.dtype == torch.float8_e4m3fn
+        assert v_cache.dtype == torch.float8_e4m3fn
+
+    for i in range(num_seqs):
+        context_len = int(context_lens[i])
+        num_pages = (context_len - 1) // page_size + 1
+        page_mapping_of_seq = page_table[i].to(torch.int64)[:num_pages]
+        reconstructed_kv = reconstruct_kv(page_mapping_of_seq, context_len, k_cache, v_cache, kv_scalebias)
+        k = reconstructed_kv[0]
+        v = reconstructed_kv[1]
+
+        num_query_heads_per_kv_head = num_q_heads // num_kv_heads
+        assert num_q_heads % num_kv_heads == 0
+        if num_query_heads_per_kv_head > 1:
+            k = torch.repeat_interleave(k, num_query_heads_per_kv_head, dim=1)
+            v = torch.repeat_interleave(v, num_query_heads_per_kv_head, dim=1)
+
+        attn_bias = None
+        if alibi_slopes is not None:
+            position_ids = torch.arange(context_len, device="cuda").int()
+            attn_bias = (position_ids - context_len + 1).float()
+            attn_bias = alibi_slopes.view(-1, 1, 1) * attn_bias.view(1, 1, -1)
+
+        out = masked_mha(q[i].unsqueeze(0), k, v, scale, attn_bias)
+        out = out.view(num_q_heads, head_size)
+        output[i].copy_(out, non_blocking=True)
+    torch.cuda.synchronize()
+
+
+def gen_kv(num_pages, num_heads, head_size, page_size, scale, multidist=False):
+    if multidist:
+        num_dist = num_pages * num_heads * page_size
+
+        b = (torch.rand(num_dist).cuda().abs() * 16 + 0.0005) * scale
+        a = torch.zeros_like(b)
+        a = a.uniform_(-4, 4) * scale
+
+        uniform_dist = dist.Normal(a, b)  # a batch of Uniform distributions
+        samples = uniform_dist.sample((head_size,))  # (head_size, num_dist)
+
+        kv_data = samples.reshape(
+            (head_size, num_heads, num_pages, page_size)
+        )  # (head_size, num_heads, num_pages, page_size)
+        kv_data = kv_data.swapaxes(0, 2)  # (num_pages, num_heads, head_size, page_size)
+    else:
+        kv_data = torch.empty(size=(num_pages, num_heads, head_size, page_size), dtype=torch.float32, device="cuda")
+        kv_data = kv_data.uniform_(-scale, scale)
+    return kv_data.contiguous()
+
+
+def div_x(tensor, x):
+    shape = tensor.shape  # (num_pages, num_heads, head_size, page_size)
+    assert shape[-2] % x == 0
+    tensor = tensor.reshape(
+        shape[:-2] + (shape[-2] // x, x) + shape[-1:]
+    )  # (num_pages, num_heads, head_size//x, x, page_size)
+    return torch.swapaxes(tensor, -1, -2).contiguous()  # (num_pages, num_heads, head_size//x, page_size, x)
+
+
+def fill_unused_slots(kv_data, useful_slots, fill_value):
+    # kv_data.shape (num_pages, num_heads, head_size, page_size)
+    kv_data = kv_data.swapaxes(0, 2)  # (head_size, num_heads, num_pages, page_size)
+    old_shape = kv_data.shape
+    kv_data = kv_data.reshape(kv_data.shape[:2] + (-1,))
+    kv_data_new = torch.full_like(kv_data, fill_value=fill_value)
+    kv_data_new[:, :, useful_slots] = kv_data[:, :, useful_slots]
+    kv_data_new = kv_data_new.reshape(old_shape)
+    return kv_data_new.swapaxes(0, 2).contiguous()
+
+
+def create_kv_caches(
+    num_pages: int,
+    page_size: int,
+    num_layers: int,
+    num_heads: int,
+    head_size: int,
+    kv_dtype: torch.dtype,
+    useful_slots=None,
+    fill_value=None,
+    multidist_key=True,
+) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
+    gc.collect()
+
+    dtype = kv_dtype
+    scale = head_size**-0.5
+    x = 16 // torch.tensor([], dtype=dtype).element_size()
+
+    key_caches = []
+    for _ in range(num_layers):
+        key_cache = gen_kv(num_pages, num_heads, head_size, page_size, scale, multidist=multidist_key).to(kv_dtype)
+        if useful_slots is not None:
+            key_cache = fill_unused_slots(key_cache, useful_slots, fill_value)
+        key_cache = div_x(key_cache, x)
+        key_caches.append(key_cache)
+
+    value_caches = []
+    for _ in range(num_layers):
+        value_cache = gen_kv(num_pages, num_heads, head_size, page_size, scale, multidist=False).to(kv_dtype)
+        if useful_slots is not None:
+            value_cache = fill_unused_slots(value_cache, useful_slots, fill_value)
+        value_caches.append(value_cache)
+
+    return key_caches, value_caches
+
+
+def pad_to_chunksize(tensor, chunksize) -> Tuple[bool, torch.Tensor]:
+    def ceil_div(x, y):
+        return (x - 1) // y + 1
+
+    shape = tensor.shape  # (num_pages, num_heads, head_size, page_size)
+    needs_pad = shape[2] % chunksize != 0
+    if needs_pad:
+        padder_shape = [shape[0], shape[1], ceil_div(shape[2], chunksize) * chunksize - shape[2], shape[3]]
+        tensor_padder = torch.ones(padder_shape, dtype=tensor.dtype, device=tensor.device) * float("nan")
+        tensor = torch.cat([tensor, tensor_padder], dim=2)
+    return needs_pad, tensor
+
+
+def get_scaled_and_scalebias(tensor, chunksize, scaled_dtype, scalebias_dtype):
+    dummy = False
+    # dummy = True  # FIXME: dummy values
+    target_max = torch.finfo(scaled_dtype).max - 32
+    if dummy:
+        target_max = 400
+    print("[get_scaled_and_scalebias] target_max =", target_max)
+
+    original_head_size = tensor.shape[2]
+    is_padded, tensor = pad_to_chunksize(tensor, chunksize)
+    shape = tensor.shape  # (num_pages, num_heads, head_size, page_size)
+    # (num_pages, num_heads, ceil_div(head_size,chunksize), chunksize, page_size)
+    chunked_shape = [shape[0], shape[1], shape[2] // chunksize, chunksize, shape[3]]
+    tensor = tensor.clone().to(torch.float32)
+    tensor = tensor.reshape(chunked_shape)
+    masked_inf = tensor.isinf()
+    tensor[masked_inf] = float("nan")
+    mean = torch.nanmean(tensor, -2, True)
+    if dummy:
+        mean = torch.zeros_like(mean)
+
+    shifted = tensor - mean
+    if is_padded:
+        shifted = torch.nan_to_num(shifted, 0)
+
+    amax, _ = torch.max(shifted.abs(), -2, True)
+    if dummy:
+        amax = 0.1 * torch.ones_like(amax)
+
+    scaled = (shifted / amax) * target_max
+    scaled[masked_inf] = float("inf")
+    scaled = scaled.reshape(shape)
+    if is_padded:
+        scaled = scaled[:, :, :original_head_size, :]
+    scaled = scaled.to(scaled_dtype).contiguous()
+
+    # original = a * scaled + b
+    b = mean
+    a = amax / target_max
+
+    # (num_pages, num_heads, ceil_div(head_size, chunksize), 1, page_size) -> (num_pages, num_heads, ceil_div(head_size, chunksize), page_size)
+    a = torch.squeeze(a, -2)
+    b = torch.squeeze(b, -2)
+
+    scalebias = torch.stack([a, b], dim=2).unsqueeze(1).to(scalebias_dtype)
+
+    return scaled, scalebias
+
+
+def create_fp8_kv_caches(
+    num_pages: int,
+    page_size: int,
+    num_layers: int,
+    num_heads: int,
+    head_size: int,
+    kv_dtype: torch.dtype,
+    kv_scalebias_dtype=torch.float16,
+    kv_scalebias_chunk_size: int = 32,
+    useful_slots=None,
+    fill_value=None,
+    multidist_key=True,
+) -> Tuple[List[torch.Tensor], List[torch.Tensor], List[torch.Tensor]]:
+    gc.collect()
+    assert kv_dtype in (torch.float8_e4m3fn,)
+    # assert head_size % kv_scalebias_chunk_size == 0
+
+    scale = head_size**-0.5
+    x = 16 // torch.tensor([], dtype=kv_dtype).element_size()
+
+    key_caches = []
+    value_caches = []
+    kv_scalebias = []
+    for _ in range(num_layers):
+        k_cache = gen_kv(num_pages, num_heads, head_size, page_size, scale, multidist=multidist_key)
+        v_cache = gen_kv(num_pages, num_heads, head_size, page_size, scale, multidist=False)
+
+        if useful_slots is not None:
+            k_cache = fill_unused_slots(k_cache, useful_slots, fill_value)
+            v_cache = fill_unused_slots(v_cache, useful_slots, fill_value)
+
+        k_cache, k_scalebias = get_scaled_and_scalebias(k_cache, kv_scalebias_chunk_size, kv_dtype, kv_scalebias_dtype)
+        v_cache, v_scalebias = get_scaled_and_scalebias(v_cache, kv_scalebias_chunk_size, kv_dtype, kv_scalebias_dtype)
+
+        k_cache = div_x(k_cache, x)
+
+        key_caches.append(k_cache)
+        value_caches.append(v_cache)
+
+        scalebias = torch.cat([k_scalebias, v_scalebias], dim=1)
+        kv_scalebias.append(scalebias)
+
+    return key_caches, value_caches, kv_scalebias
+
+
+def create_kv_caches_wrapper(*args, **kwargs):
+    if kwargs.get("kv_dtype", None) == torch.float8_e4m3fn:
+        return create_fp8_kv_caches(*args, **kwargs)
+    else:
+        kwargs.pop("kv_scalebias_dtype", None)
+        key_caches, value_caches = create_kv_caches(*args, **kwargs)
+        dummy_scalebias = [None] * len(key_caches[0])
+        return key_caches, value_caches, dummy_scalebias
+
+
+def torch_dtype_to_tensor_proto(dtype):
+    return {
+        torch.bfloat16: TensorProto.BFLOAT16,
+        torch.float32: TensorProto.FLOAT,
+        torch.float16: TensorProto.FLOAT16,
+        torch.float8_e4m3fn: TensorProto.FLOAT8E4M3FN,
+        torch.int32: TensorProto.INT32,
+    }[dtype]
+
+
+def torch_dtype_to_numpy_dtype(dtype):
+    return {
+        torch.bfloat16: None,
+        torch.float32: np.float32,
+        torch.float16: np.float16,
+        torch.float8_e4m3fn: None,
+        torch.int32: np.int32,
+    }[dtype]
+
+
+class TestMHA(unittest.TestCase):
+
+    def run_paged_attention_opkernel_with_torch_tensor(
+        self,
+        output,
+        q,
+        k_cache,
+        v_cache,
+        kv_scalebias,
+        num_kv_heads,
+        scale,
+        page_table,
+        context_lens,
+        page_size,
+        max_context_len,
+        alibi_slopes,
+    ):
+        num_seqs, num_heads, head_size = q.size()
+        assert output.size() == q.size()
+        num_pages, num_kv_heads, head_size, _ = v_cache.size()
+        assert v_cache.size(3) == page_size
+        assert k_cache.size(0) == num_pages
+        assert k_cache[0].numel() == page_size * num_kv_heads * head_size
+        group_size = 32  # NOTE: only support group_size 32 for now
+        if kv_scalebias is not None:
+            assert kv_scalebias.size(0) == num_pages
+            assert kv_scalebias[0].numel() == page_size * num_kv_heads * head_size // 32
+        assert page_table.size(0) == num_seqs
+        max_num_pages_per_sequence = page_table.size(1)
+        assert context_lens.size() == (num_seqs,)
+        if alibi_slopes is not None:
+            assert alibi_slopes.size() == (num_heads,)
+
+        nodes = [
+            helper.make_node(
+                "PagedAttention",
+                [
+                    "query",
+                    "key_cache",
+                    "value_cache",
+                    "page_table",
+                    "context_lens",
+                    "max_context_len",
+                    "" if alibi_slopes is None else "alibi_bias",
+                    "" if kv_scalebias is None else "kv_quant_param",
+                ],
+                ["output"],
+                "PagedAttention_0",
+                scale=scale,
+                page_size=page_size,
+                num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
+                domain="com.microsoft",
+            ),
+        ]
+        graph_input = [
+            helper.make_tensor_value_info(
+                "query",
+                torch_dtype_to_tensor_proto(q.dtype),
+                [num_seqs, num_heads, head_size],
+            ),
+            helper.make_tensor_value_info(
+                "key_cache",
+                torch_dtype_to_tensor_proto(k_cache.dtype),
+                [num_pages, page_size * num_kv_heads * head_size],
+            ),
+            helper.make_tensor_value_info(
+                "value_cache",
+                torch_dtype_to_tensor_proto(v_cache.dtype),
+                [num_pages, page_size * num_kv_heads * head_size],
+            ),
+            helper.make_tensor_value_info(
+                "page_table",
+                torch_dtype_to_tensor_proto(page_table.dtype),
+                [num_seqs, max_num_pages_per_sequence],
+            ),
+            helper.make_tensor_value_info(
+                "context_lens",
+                torch_dtype_to_tensor_proto(context_lens.dtype),
+                [num_seqs],
+            ),
+            helper.make_tensor_value_info(
+                "max_context_len",
+                TensorProto.INT32,
+                [1],
+            ),
+            helper.make_tensor_value_info(
+                "alibi_bias",
+                TensorProto.FLOAT,
+                [num_heads],
+            ),
+            helper.make_tensor_value_info(
+                "kv_quant_param",
+                TensorProto.FLOAT16,
+                [num_pages, 2 * page_size * num_kv_heads * head_size // group_size],
+            ),
+        ]
+
+        graph_output = [
+            helper.make_tensor_value_info(
+                "output",
+                torch_dtype_to_tensor_proto(output.dtype),
+                [num_seqs, num_heads, head_size],
+            ),
+        ]
+
+        graph = helper.make_graph(
+            nodes,
+            "PagedAttention_Graph",
+            graph_input,
+            graph_output,
+        )
+
+        model = helper.make_model(graph)
+        sess_options = SessionOptions()
+
+        ort_session = InferenceSession(model.SerializeToString(), sess_options, providers=["CUDAExecutionProvider"])
+        # We do not have a way to test fp8 kv cache as we cannot pass FLOAT8E4M3FN tensors as inputs into the session
+        testable = torch_dtype_to_tensor_proto(k_cache.dtype) != TensorProto.FLOAT8E4M3FN
+        if not testable:
+            pytest.skip("unable to test")
+
+        k_cache_packed = k_cache.reshape((num_pages, -1))
+        v_cache_packed = v_cache.reshape((num_pages, -1))
+        max_context_len_tensor = np.array([max_context_len], dtype=np.int32)
+
+        use_io_binding = True
+        if use_io_binding:
+            io_binding = ort_session.io_binding()
+
+            def bind_torch(io_binding, name, torch_tensor):
+                if torch_tensor is None:
+                    return
+                io_binding.bind_input(
+                    name,
+                    "cuda",
+                    0,
+                    torch_dtype_to_numpy_dtype(torch_tensor.dtype),
+                    tuple(torch_tensor.shape),
+                    torch_tensor.data_ptr(),
+                )
+
+            bind_torch(io_binding, "query", q)
+            bind_torch(io_binding, "key_cache", k_cache_packed)
+            bind_torch(io_binding, "value_cache", v_cache_packed)
+            bind_torch(io_binding, "page_table", page_table)
+            bind_torch(io_binding, "context_lens", context_lens)
+            io_binding.bind_cpu_input("max_context_len", max_context_len_tensor)
+            if alibi_slopes is not None:
+                bind_torch(io_binding, "alibi_bias", alibi_slopes)
+            if kv_scalebias is not None:
+                bind_torch(io_binding, "kv_quant_param", kv_scalebias)
+
+            io_binding.bind_output("output")
+
+            ort_session.run_with_iobinding(io_binding)
+            outputs = io_binding.copy_outputs_to_cpu()
+            output[:] = torch.tensor(outputs[0]).cuda()
+
+        else:
+            outputs = ort_session.run(
+                ["output"],
+                {
+                    "query": q.cpu().numpy(),
+                    "key_cache": k_cache_packed.reshape((num_pages, -1)).cpu().numpy(),
+                    "value_cache": v_cache_packed.cpu().numpy(),
+                    "page_table": page_table.cpu().numpy(),
+                    "context_lens": context_lens.cpu().numpy(),
+                    "max_context_len": max_context_len_tensor,
+                    "alibi_bias": None if alibi_slopes is None else alibi_slopes.cpu().numpy(),
+                    "kv_quant_param": (
+                        None if kv_scalebias is None else kv_scalebias.reshape((num_pages, -1)).cpu().numpy()
+                    ),
+                },
+            )
+            output[:] = torch.tensor(outputs[0]).cuda()
+
+    @torch.inference_mode()
+    def _test_paged_attention(
+        self,
+        num_seqs: int,
+        seq_len: int | None,
+        num_q_heads: int,
+        num_kv_heads: int,
+        head_size: int,
+        page_size: int,
+        kv_dtype: str | torch.dtype | None,
+        use_alibi: bool,
+        seed: int = int(os.environ.get("SEED", "0")),
+        max_seq_len: int = 4096,
+        max_num_pages: int = 5000,
+        fill_non_used: float | None = None,
+    ):
+        dtype, kv_dtype, kv_scalebias_dtype = get_dtypes(kv_dtype)
+        print(dtype, kv_dtype, kv_scalebias_dtype)
+
+        random.seed(seed)
+        torch.random.manual_seed(seed)
+        torch.cuda.manual_seed(seed)
+
+        scale = float(1.0 / (head_size**0.5))
+        q = torch.empty(num_seqs, num_q_heads, head_size, dtype=dtype, device="cuda")
+        q.uniform_(-scale, scale)
+        # q = torch.randn((num_seqs, num_q_heads, head_size), dtype=dtype, device="cuda")
+
+        assert num_q_heads % num_kv_heads == 0
+
+        alibi_slopes = None
+        if use_alibi:
+            alibi_slopes = torch.randn(num_q_heads, dtype=torch.float, device="cuda") * scale * 4
+
+        if seq_len is None:
+            seq_len = os.getenv("SEQ_LEN", None)
+            seq_len = int(seq_len) if seq_len is not None else None
+        if seq_len is None:
+            context_lens = [random.randint(1, max_seq_len) for _ in range(num_seqs)]
+        elif isinstance(seq_len, int):
+            context_lens = [seq_len for _ in range(num_seqs)]
+        else:
+            context_lens = seq_len
+            assert len(context_lens) == num_seqs
+        max_context_len = max(context_lens)
+        context_lens_py = context_lens
+        context_lens = torch.tensor(context_lens_py, dtype=torch.int, device="cuda")
+        print("context_lens:", context_lens_py)
+
+        page_table_py = generate_page_mapping(max_num_pages, num_seqs, max_context_len, page_size)
+        page_table = torch.tensor(page_table_py, dtype=torch.int, device="cuda")
+        print("page_table:", page_table_py)
+
+        useful_slots = get_useful_slots(fill_non_used, page_size, page_table_py, context_lens_py)
+
+        k_caches, v_caches, kv_scalebiases = create_kv_caches_wrapper(
+            max_num_pages,
+            page_size,
+            1,
+            num_kv_heads,
+            head_size,
+            kv_dtype=kv_dtype,
+            kv_scalebias_dtype=kv_scalebias_dtype,
+            useful_slots=useful_slots,
+            fill_value=fill_non_used,
+        )
+        k_cache, v_cache, kv_scalebias = k_caches[0], v_caches[0], kv_scalebiases[0]
+
+        if kv_dtype == torch.float8_e4m3fn:
+            assert kv_scalebias is not None
+        else:
+            assert kv_scalebias_dtype is None
+            assert kv_scalebias is None
+
+        output = torch.empty_like(q)
+        self.run_paged_attention_opkernel_with_torch_tensor(
+            output,
+            q,
+            k_cache,
+            v_cache,
+            kv_scalebias,
+            num_kv_heads,
+            scale,
+            page_table,
+            context_lens,
+            page_size,
+            max_context_len,
+            alibi_slopes,
+        )
+
+        ref_output = torch.empty_like(q)
+        reconstruct_kv_then_mha(
+            ref_output,
+            q,
+            k_cache,
+            v_cache,
+            kv_scalebias,
+            page_table,
+            context_lens,
+            scale,
+            alibi_slopes,
+        )
+        torch.cuda.synchronize()
+
+        if bool(int(os.environ.get("DUMP_RESULTS", "0"))):
+            print(ref_output)
+            diff = output - ref_output
+            print(diff.abs().max())
+            print(diff)
+
+            import numpy as np
+
+            np.save("ref.npy", ref_output.cpu().numpy())
+            np.save("our.npy", output.cpu().numpy())
+
+        if dtype == torch.float32:
+            assert torch.allclose(output, ref_output, atol=1e-5, rtol=1e-6)
+        else:
+            assert torch.allclose(output, ref_output, atol=2e-4, rtol=2e-5)
+
+    @parameterized.expand(
+        itertools.product(
+            NUM_GEN_SEQS,
+            [None],
+            NUM_HEADS,
+            HEAD_SIZES,
+            PAGE_SIZES,
+            [dtype for dtype in DTYPES if "float8" not in dtype],
+            [False, True],
+        )
+    )
+    def test_paged_attention(
+        self,
+        num_seqs: int,
+        seq_len: int | None,
+        num_heads: Tuple[int, int],
+        head_size: int,
+        page_size: int,
+        kv_dtype: str,
+        use_alibi: bool,
+    ):
+        num_q_heads, num_kv_heads = num_heads
+        self._test_paged_attention(
+            num_seqs,
+            seq_len,
+            num_q_heads,
+            num_kv_heads,
+            head_size,
+            page_size,
+            kv_dtype,
+            use_alibi,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/onnxruntime/test/python/transformers/test_paged_attn_cuda.py
+++ b/onnxruntime/test/python/transformers/test_paged_attn_cuda.py
@@ -23,8 +23,12 @@ from onnxruntime import InferenceSession, OrtValue, SessionOptions
 
 DTYPES = ["float16", "float32", "float8_e4m3fn"]
 NUM_GEN_SEQS = [1, 7]
-NUM_HEADS = [(32, 2), (32, 4), (19, 19)]
-HEAD_SIZES = [64, 80, 96, 112, 128]
+NUM_HEADS = [
+  (19, 19),  # mha
+  (16, 4),   # gqa4
+  (32, 2),   # gqa8 with 2x broadcasting
+]
+HEAD_SIZES = [64, 80, 96, 112, 128, 256]
 PAGE_SIZES = [8, 16, 32]
 
 


### PR DESCRIPTION
The set of kernels was integrated in our fork of vllm previously, now porting them to onnxruntime as a native OpKernel for potential future development.

Feature set:

Decomposed scheduler and task, enables future experiment on scheduler implementation

paged attention kernel:
- Similar to vllm's v1 kernel, but can handle arbitrary length of sequence
  - Not smem limited due to flash attention like in smem reduction (`flash_acc` in my word and in code)
- Parallelism is governed by `num_seqs * num_kv_heads`
   - Good perf with large parallelism
   - Hardware can be under utilized when batch is not large enough, can also be bad when GQA ration is large but batch is not large enough 

load balanced paged attention kernels (lbp kernels for short):
- Various scheduler:
  - DataParallelOutOfPlace: The default. Similar to vllm's v2 impl. Needs a second kernel to do the reduction
  - DataParallelInPlace: Experimental. Perf limited by the inplace reduction, atomics related. Highly experimental, not optimized and tested.
  - WorkStealing: Experimental.  L2 atomics performance is the critical perf limiter. Automatically load balance. Perf is not good on data center card (with multiple L2 partitions), good on customer cards (with single L2 partition).

GQA support:
- GQA ratio 8, (GQA8 for short in code): Tensor core enabled
- GQA4: Scalar core as of 2024-08-27, can be switched to tensor core version with minor midification
- MHA: Scalar core only

FP8 support:
- float8_e4m3fn kv cache is supported on any kind of devices
   - Native on H100 and 4090
   - Emulated on V100, A100, MI200 (any device that does not natively support fp8 to fp16 conversion)
- chunked scale and bias
   - Scale and offset the kv cache per 32 elements. 
   - No accuracy loss compare to per tensor scale.
   - More overhead on scalebias tensor loading
   - Due to scalebias, 9bpw instead of 8bpw (depending on the chunk size)

The only tested devices are H100, A100, 4090, MI200. Since the introduction of sm80 m16n8k8 tensor core, the code currently cannot be built for MI200 anymore.