### PR TITLE
feat(onnxruntime-web): Allow the WASM backend to import the emscripten Module via a user-land defined loader

### DIFF
--- a/js/common/lib/env.ts
+++ b/js/common/lib/env.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import {env as envImpl} from './env-impl.js';
+import type {OrtWasmModule} from 'onnxruntime-web';
 
 export declare namespace Env {
   export type WasmPathPrefix = string;
@@ -80,6 +81,15 @@ export declare namespace Env {
      * @defaultValue `false`
      */
     proxy?: boolean;
+
+    /**
+     * Set a custom function to import the WebAssembly module from user-land code (Inversion of Control, IoC).
+     *
+     * @defaultValue undefined
+     */
+    importWasmModule?: (mjsPathOverride: string, wasmPrefixOverride: string, numThreads: boolean) => Promise<[
+      string | undefined, EmscriptenModuleFactory<OrtWasmModule>
+    ]>;
   }
 
   export interface WebGLFlags {

--- a/js/web/lib/wasm/wasm-factory.ts
+++ b/js/web/lib/wasm/wasm-factory.ts
@@ -108,8 +108,9 @@ export const initializeWebAssembly = async(flags: Env.WebAssemblyFlags): Promise
   const mjsPathOverride = (mjsPathOverrideFlag as URL)?.href ?? mjsPathOverrideFlag;
   const wasmPathOverrideFlag = (wasmPaths as Env.WasmFilePaths)?.wasm;
   const wasmPathOverride = (wasmPathOverrideFlag as URL)?.href ?? wasmPathOverrideFlag;
+  const importFunction = typeof flags.importWasmModule === "function" ? flags.importWasmModule : importWasmModule;
 
-  const [objectUrl, ortWasmFactory] = (await importWasmModule(mjsPathOverride, wasmPrefixOverride, numThreads > 1));
+  const [objectUrl, ortWasmFactory] = (await importFunction(mjsPathOverride, wasmPrefixOverride, numThreads > 1));
 
   let isTimeout = false;
 


### PR DESCRIPTION
### Description
This minimal change will allow defining a custom loader for the WASM backend to be passed via `flags.importWasmModule` (aka `env`), allowing for Inversion of Control (IoC) and increased flexibility in loading the WASM backend. The change is minimally invasive.

### Motivation and Context
As described at length in #20876, and confirmed by [other users as well](
https://github.com/microsoft/onnxruntime/issues/20876#issuecomment-2240820108), specifically @asadm the current WASM backend implementation suffers from the inflexibility of not being able to load the WASM module in user-land code. This leads to issues in contexts like Web Extensions, specifically their background scripts, where dynamic loading isn't possible, as it is prohibited by W3C standards. The issue expands to other areas where complexities in downstream build processes lead to the loader code not being able to load the Module and, in effect, to the WASM backend not being available.

### Considerations 
Regarding this implementation, I'm concerned that the type import from `onnxruntime-web` to `onnxruntime-common` (for the `Env` interface) which imports the type `OrtWasmModule` from `onnxruntime-web` leads to a cyclic dependency and a package boundary issue. This isn't an issue at runtime, as it only affects the type system, but it's clearly not what I'd wish to see in my projects. Maybe it would be a good idea to move the specific `Env`-extending type definitions of the WASM backend implementation into the `onnxruntime-web` package, or the `OrtWasmModule` into `common`? Duplicate type definitions aren't a good idea either, nor is `any` a good idea. 

As this is my first PR to this repository and as I'm not familiar with the processes, I'm kindly asking for advice. Please guide me in finishing this PR. Thank you in advance!