### PR TITLE
Fix failed Python_Packaging_Windows_ARM64_QNN.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -266,7 +266,7 @@ stages:
             SymbolServerType: TeamServices
             SymbolExpirationInDays: 3650
             SymbolsArtifactName: 'win_cpu_$(PythonVersion)_$(buildArch)_$(Build.BuildNumber)'
- 
+
       - task: TSAUpload@2
         displayName: 'TSA upload'
         condition: and(and (succeeded(), and(eq(variables['buildArch'], 'x64'), eq(variables['PythonVersion'], '3.8'))), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
@@ -485,7 +485,7 @@ stages:
       - template: py-linux.yml
         parameters:
           arch: 'x86_64'
-          machine_pool: 'onnxruntime-Ubuntu2204-AMD-CPU'          
+          machine_pool: 'onnxruntime-Ubuntu2204-AMD-CPU'
           extra_build_arg: ${{ parameters.build_py_parameters }}
           cmake_build_type: ${{ parameters.cmake_build_type }}
 
@@ -510,7 +510,6 @@ stages:
           MACHINE_POOL: 'onnxruntime-qnn-windows-vs-2022-arm64'
           QNN_SDK: ${{ parameters.qnn_sdk_version }}
           PYTHON_VERSION: '3.11'
-          NUMPY_VERSION: '1.26.4'
 
   - ${{ if eq(parameters.enable_windows_x64_qnn, true) }}:
     - stage: Python_Packaging_Windows_x64_QNN

--- a/tools/ci_build/github/azure-pipelines/templates/py-win-arm64-qnn.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-win-arm64-qnn.yml
@@ -13,10 +13,6 @@ parameters:
   type: string
   default: '3.11'
 
-- name: NUMPY_VERSION
-  type: string
-  default: '1.26.4'
-
 - name: ENV_SETUP_SCRIPT
   type: string
   default: ''
@@ -70,7 +66,7 @@ jobs:
           scriptSource: inline
           script: |
             import subprocess
-            subprocess.call(['pip', 'install', '-q', 'setuptools', 'wheel', 'numpy==${{parameters.NUMPY_VERSION}}'])
+            subprocess.call(['pip', 'install', '-q', 'setuptools', 'wheel'])
           workingDirectory: '$(Build.BinariesDirectory)'
           displayName: 'Install python modules'
 
@@ -93,7 +89,6 @@ jobs:
             --qnn_home $(QnnSDKRootDir)
             --enable_pybind
             --parallel --update
-            --numpy_version ${{ parameters.NUMPY_VERSION }}
             $(TelemetryOption) ${{ parameters.BUILD_PY_PARAMETERS }}
           workingDirectory: '$(Build.BinariesDirectory)'
 
@@ -157,7 +152,7 @@ jobs:
         condition: and (succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
         inputs:
           GdnPublishTsaOnboard: false
-          GdnPublishTsaConfigFile: '$(Build.sourcesDirectory)\.gdn\.gdntsa' 
+          GdnPublishTsaConfigFile: '$(Build.sourcesDirectory)\.gdn\.gdntsa'
 
       - template: component-governance-component-detection-steps.yml
         parameters:


### PR DESCRIPTION
### Description
Fix Python_Packaging_Windows_ARM64_QNN failure.





### Motivation and Context
`--numpy_version` is removed in #21106.


