### PR TITLE
Add QDQ handling for Expand/Flatten/Tile if CPU EP is taking them

### DIFF
--- a/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selector_action_transformer.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selector_action_transformer.cc
@@ -61,8 +61,11 @@ void DropQDQNodesRules(SelectorActionRegistry& qdq_selector_action_registry) {
 
   std::unique_ptr<NodeSelector> selector = std::make_unique<QDQ::DropQDQNodesSelector>(true);
   qdq_selector_action_registry.RegisterSelectorAndAction(drop_action_name,
-                                                         {{"Gather", {}},
+                                                         {{"Expand", {}},
+                                                          {"Flatten", {}},
+                                                          {"Gather", {}},
                                                           {"Reshape", {}},
+                                                          {"Tile", {}},
                                                           {"Transpose", {}},
                                                           {"Squeeze", {}},
                                                           {"Unsqueeze", {}}},


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Drop QDQ nodes around Expand, Flatten and Tile if CPU EP is going to take them.
CPU EP supports 8-bit data and the ops are data movement only.

Makes handling of ops in https://github.com/microsoft/onnxruntime/blob/2580d935cbecd756cef435fb173a2f10237e9d2a/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/shared/utils.cc#L34-L44 consistent.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
#21375


