### PR TITLE
Propagate NaNs in the CPU min and max operators

### DIFF
--- a/onnxruntime/core/providers/cpu/math/element_wise_ops.cc
+++ b/onnxruntime/core/providers/cpu/math/element_wise_ops.cc
@@ -729,7 +729,8 @@ struct Min_8::ComputeImpl {
         },
         [](BroadcastHelper& per_iter_bh) {
           per_iter_bh.OutputEigen<T>() =
-              per_iter_bh.EigenInput0<T>().array().template min<Eigen::PropagateNaN>(per_iter_bh.EigenInput1<T>().array());
+              per_iter_bh.EigenInput0<T>().array().template min<Eigen::PropagateNaN>(
+                  per_iter_bh.EigenInput1<T>().array());
         }};
 
     int input_count = inst.Node().InputArgCount().front();
@@ -756,9 +757,11 @@ static Status MinMaxMLFloat16(const OpKernel& inst, OpKernelContext* context) {
         EigenVectorArrayMap<Eigen::half> output_vec_map(output, num_elements);
 
         if (is_min) {
-          output_vec_map = input_1_vec_map.template min<Eigen::PropagateNaN>(static_cast<Eigen::half>(per_iter_bh.ScalarInput0<MLFloat16>()));
+          output_vec_map = input_1_vec_map.template min<Eigen::PropagateNaN>(
+              static_cast<Eigen::half>(per_iter_bh.ScalarInput0<MLFloat16>()));
         } else {
-          output_vec_map = input_1_vec_map.template max<Eigen::PropagateNaN>(static_cast<Eigen::half>(per_iter_bh.ScalarInput0<MLFloat16>()));
+          output_vec_map = input_1_vec_map.template max<Eigen::PropagateNaN>(
+              static_cast<Eigen::half>(per_iter_bh.ScalarInput0<MLFloat16>()));
         }
       },
       [](BroadcastHelper& per_iter_bh) {
@@ -771,9 +774,11 @@ static Status MinMaxMLFloat16(const OpKernel& inst, OpKernelContext* context) {
         EigenVectorArrayMap<Eigen::half> output_vec_map(output, num_elements);
 
         if (is_min) {
-          output_vec_map = input_0_vec_map.template min<Eigen::PropagateNaN>(static_cast<Eigen::half>(per_iter_bh.ScalarInput1<MLFloat16>()));
+          output_vec_map = input_0_vec_map.template min<Eigen::PropagateNaN>(
+              static_cast<Eigen::half>(per_iter_bh.ScalarInput1<MLFloat16>()));
         } else {
-          output_vec_map = input_0_vec_map.template max<Eigen::PropagateNaN>(static_cast<Eigen::half>(per_iter_bh.ScalarInput1<MLFloat16>()));
+          output_vec_map = input_0_vec_map.template max<Eigen::PropagateNaN>(
+              static_cast<Eigen::half>(per_iter_bh.ScalarInput1<MLFloat16>()));
         }
       },
       [](BroadcastHelper& per_iter_bh) {
@@ -851,7 +856,8 @@ struct Max_8::ComputeImpl {
         },
         [](BroadcastHelper& per_iter_bh) {
           per_iter_bh.OutputEigen<T>() =
-              per_iter_bh.EigenInput0<T>().array().template max<Eigen::PropagateNaN>(per_iter_bh.EigenInput1<T>().array());
+              per_iter_bh.EigenInput0<T>().array().template max<Eigen::PropagateNaN>(
+                  per_iter_bh.EigenInput1<T>().array());
         }};
 
     int input_count = inst.Node().InputArgCount().front();

--- a/onnxruntime/core/providers/cpu/math/element_wise_ops.cc
+++ b/onnxruntime/core/providers/cpu/math/element_wise_ops.cc
@@ -757,11 +757,9 @@ static Status MinMaxMLFloat16(const OpKernel& inst, OpKernelContext* context) {
         EigenVectorArrayMap<Eigen::half> output_vec_map(output, num_elements);
 
         if (is_min) {
-          output_vec_map = input_1_vec_map.template min<Eigen::PropagateNaN>(
-              static_cast<Eigen::half>(per_iter_bh.ScalarInput0<MLFloat16>()));
+          output_vec_map = input_1_vec_map.min(static_cast<Eigen::half>(per_iter_bh.ScalarInput0<MLFloat16>()));
         } else {
-          output_vec_map = input_1_vec_map.template max<Eigen::PropagateNaN>(
-              static_cast<Eigen::half>(per_iter_bh.ScalarInput0<MLFloat16>()));
+          output_vec_map = input_1_vec_map.max(static_cast<Eigen::half>(per_iter_bh.ScalarInput0<MLFloat16>()));
         }
       },
       [](BroadcastHelper& per_iter_bh) {
@@ -774,11 +772,9 @@ static Status MinMaxMLFloat16(const OpKernel& inst, OpKernelContext* context) {
         EigenVectorArrayMap<Eigen::half> output_vec_map(output, num_elements);
 
         if (is_min) {
-          output_vec_map = input_0_vec_map.template min<Eigen::PropagateNaN>(
-              static_cast<Eigen::half>(per_iter_bh.ScalarInput1<MLFloat16>()));
+          output_vec_map = input_0_vec_map.min(static_cast<Eigen::half>(per_iter_bh.ScalarInput1<MLFloat16>()));
         } else {
-          output_vec_map = input_0_vec_map.template max<Eigen::PropagateNaN>(
-              static_cast<Eigen::half>(per_iter_bh.ScalarInput1<MLFloat16>()));
+          output_vec_map = input_0_vec_map.max(static_cast<Eigen::half>(per_iter_bh.ScalarInput1<MLFloat16>()));
         }
       },
       [](BroadcastHelper& per_iter_bh) {
@@ -794,9 +790,9 @@ static Status MinMaxMLFloat16(const OpKernel& inst, OpKernelContext* context) {
         EigenVectorArrayMap<Eigen::half> output_vec_map(output, num_elements);
 
         if (is_min) {
-          output_vec_map = input_0_vec_map.template min<Eigen::PropagateNaN>(input_1_vec_map);
+          output_vec_map = input_0_vec_map.min(input_1_vec_map);
         } else {
-          output_vec_map = input_0_vec_map.template max<Eigen::PropagateNaN>(input_1_vec_map);
+          output_vec_map = input_0_vec_map.max(input_1_vec_map);
         }
       }};
 

--- a/onnxruntime/core/providers/cpu/math/element_wise_ops.cc
+++ b/onnxruntime/core/providers/cpu/math/element_wise_ops.cc
@@ -756,9 +756,9 @@ static Status MinMaxMLFloat16(const OpKernel& inst, OpKernelContext* context) {
         EigenVectorArrayMap<Eigen::half> output_vec_map(output, num_elements);
 
         if (is_min) {
-          output_vec_map = input_1_vec_map.min(static_cast<Eigen::half>(per_iter_bh.ScalarInput0<MLFloat16>()));
+          output_vec_map = input_1_vec_map.template min<Eigen::PropagateNaN>(static_cast<Eigen::half>(per_iter_bh.ScalarInput0<MLFloat16>()));
         } else {
-          output_vec_map = input_1_vec_map.max(static_cast<Eigen::half>(per_iter_bh.ScalarInput0<MLFloat16>()));
+          output_vec_map = input_1_vec_map.template max<Eigen::PropagateNaN>(static_cast<Eigen::half>(per_iter_bh.ScalarInput0<MLFloat16>()));
         }
       },
       [](BroadcastHelper& per_iter_bh) {
@@ -771,9 +771,9 @@ static Status MinMaxMLFloat16(const OpKernel& inst, OpKernelContext* context) {
         EigenVectorArrayMap<Eigen::half> output_vec_map(output, num_elements);
 
         if (is_min) {
-          output_vec_map = input_0_vec_map.min(static_cast<Eigen::half>(per_iter_bh.ScalarInput1<MLFloat16>()));
+          output_vec_map = input_0_vec_map.template min<Eigen::PropagateNaN>(static_cast<Eigen::half>(per_iter_bh.ScalarInput1<MLFloat16>()));
         } else {
-          output_vec_map = input_0_vec_map.max(static_cast<Eigen::half>(per_iter_bh.ScalarInput1<MLFloat16>()));
+          output_vec_map = input_0_vec_map.template max<Eigen::PropagateNaN>(static_cast<Eigen::half>(per_iter_bh.ScalarInput1<MLFloat16>()));
         }
       },
       [](BroadcastHelper& per_iter_bh) {
@@ -789,9 +789,9 @@ static Status MinMaxMLFloat16(const OpKernel& inst, OpKernelContext* context) {
         EigenVectorArrayMap<Eigen::half> output_vec_map(output, num_elements);
 
         if (is_min) {
-          output_vec_map = input_0_vec_map.min(input_1_vec_map);
+          output_vec_map = input_0_vec_map.template min<Eigen::PropagateNaN>(input_1_vec_map);
         } else {
-          output_vec_map = input_0_vec_map.max(input_1_vec_map);
+          output_vec_map = input_0_vec_map.template max<Eigen::PropagateNaN>(input_1_vec_map);
         }
       }};
 

--- a/onnxruntime/core/providers/cpu/math/element_wise_ops.cc
+++ b/onnxruntime/core/providers/cpu/math/element_wise_ops.cc
@@ -705,7 +705,7 @@ Status Min_6<float>::Compute(OpKernelContext* ctx) const {
   for (int index = 1; index < inputCount; index++) {
     auto& data_n = *ctx->Input<Tensor>(index);
     ORT_ENFORCE(data_n.Shape() == shape, "All inputs must have the same shape");
-    min = min.array().min(EigenMap<float>(data_n).array());
+    min = min.array().template min<Eigen::PropagateNaN>(EigenMap<float>(data_n).array());
   }
 
   return Status::OK();
@@ -721,15 +721,15 @@ struct Min_8::ComputeImpl {
     ProcessBroadcastSpanFuncs funcs{
         [](BroadcastHelper& per_iter_bh) {
           per_iter_bh.OutputEigen<T>() =
-              per_iter_bh.EigenInput1<T>().array().min(per_iter_bh.ScalarInput0<T>());
+              per_iter_bh.EigenInput1<T>().array().template min<Eigen::PropagateNaN>(per_iter_bh.ScalarInput0<T>());
         },
         [](BroadcastHelper& per_iter_bh) {
           per_iter_bh.OutputEigen<T>() =
-              per_iter_bh.EigenInput0<T>().array().min(per_iter_bh.ScalarInput1<T>());
+              per_iter_bh.EigenInput0<T>().array().template min<Eigen::PropagateNaN>(per_iter_bh.ScalarInput1<T>());
         },
         [](BroadcastHelper& per_iter_bh) {
           per_iter_bh.OutputEigen<T>() =
-              per_iter_bh.EigenInput0<T>().array().min(per_iter_bh.EigenInput1<T>().array());
+              per_iter_bh.EigenInput0<T>().array().template min<Eigen::PropagateNaN>(per_iter_bh.EigenInput1<T>().array());
         }};
 
     int input_count = inst.Node().InputArgCount().front();
@@ -827,7 +827,7 @@ Status Max_6<float>::Compute(OpKernelContext* ctx) const {
   for (int index = 1; index < inputCount; index++) {
     auto& data_n = *ctx->Input<Tensor>(index);
     ORT_ENFORCE(data_n.Shape() == shape, "All inputs must have the same shape");
-    max = max.array().max(EigenMap<float>(data_n).array());
+    max = max.array().template max<Eigen::PropagateNaN>(EigenMap<float>(data_n).array());
   }
 
   return Status::OK();
@@ -843,15 +843,15 @@ struct Max_8::ComputeImpl {
     ProcessBroadcastSpanFuncs funcs{
         [](BroadcastHelper& per_iter_bh) {
           per_iter_bh.OutputEigen<T>() =
-              per_iter_bh.EigenInput1<T>().array().max(per_iter_bh.ScalarInput0<T>());
+              per_iter_bh.EigenInput1<T>().array().template max<Eigen::PropagateNaN>(per_iter_bh.ScalarInput0<T>());
         },
         [](BroadcastHelper& per_iter_bh) {
           per_iter_bh.OutputEigen<T>() =
-              per_iter_bh.EigenInput0<T>().array().max(per_iter_bh.ScalarInput1<T>());
+              per_iter_bh.EigenInput0<T>().array().template max<Eigen::PropagateNaN>(per_iter_bh.ScalarInput1<T>());
         },
         [](BroadcastHelper& per_iter_bh) {
           per_iter_bh.OutputEigen<T>() =
-              per_iter_bh.EigenInput0<T>().array().max(per_iter_bh.EigenInput1<T>().array());
+              per_iter_bh.EigenInput0<T>().array().template max<Eigen::PropagateNaN>(per_iter_bh.EigenInput1<T>().array());
         }};
 
     int input_count = inst.Node().InputArgCount().front();

--- a/onnxruntime/test/providers/checkers.cc
+++ b/onnxruntime/test/providers/checkers.cc
@@ -411,7 +411,7 @@ struct TensorCheck<MLFloat16> {
 
     for (int64_t i = 0; i < size; ++i) {
       if (std::isnan(f_expected[i])) {
-        EXPECT_TRUE(std::isnan(f_expected[i])) << "Expected NaN. i:" << i;
+        EXPECT_TRUE(std::isnan(f_actual[i])) << "Expected NaN. i:" << i;
       } else if (std::isinf(f_expected[i])) {  // Test infinity for equality
         EXPECT_EQ(f_expected[i], f_actual[i]) << "Expected infinity. i:" << i;
       } else {

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -1787,60 +1787,6 @@ TEST(MathOpTest, Min_12_MLFloat16_Scalar1) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  // TensorRT: Input batch size is inconsistent
 }
 
-TEST(MathOpTest, Min_12_MLFloat16_Nan) {
-  OpTester test("Min", 12);
-  test.AddInput<MLFloat16>("data_2", {3, 3},
-                           MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(),
-                                          std::numeric_limits<float>::quiet_NaN(),
-                                          std::numeric_limits<float>::quiet_NaN(),
-                                          -0.5f, 0.0f, -2.0f,
-                                          0.5f, 0.0f, 2.0f}));
-  test.AddInput<MLFloat16>("data_1", {3, 1},
-                           MakeMLFloat16({0.0f, -1.0f, 1.0f}));
-  test.AddOutput<MLFloat16>("min", {3, 3},
-                            MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(),
-                                           std::numeric_limits<float>::quiet_NaN(),
-                                           std::numeric_limits<float>::quiet_NaN(),
-                                           -1.0f, -1.0f, -2.0f,
-                                           0.5f, 0.0f, 1.0f}));
-  if (nullptr != DefaultCpuExecutionProvider()) {
-    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
-    execution_providers.push_back(DefaultCpuExecutionProvider());
-    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
-  }
-}
-
-TEST(MathOpTest, Min_12_MLFloat16_Nan_with_scalar) {
-  OpTester test("Min", 12);
-  test.AddInput<MLFloat16>("data_1", {3, 1},
-                           MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(), -0.5f, 0.5f}));
-  test.AddInput<MLFloat16>("data_2", {1}, MakeMLFloat16({0.25f}));
-  test.AddOutput<MLFloat16>("min", {3, 1},
-                            MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(), -0.5f, 0.25f}));
-  if (nullptr != DefaultCpuExecutionProvider()) {
-    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
-    execution_providers.push_back(DefaultCpuExecutionProvider());
-    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
-  }
-}
-
-TEST(MathOpTest, Min_12_MLFloat16_with_scalar_Nan) {
-  OpTester test("Min", 12);
-  test.AddInput<MLFloat16>("data_1", {2, 2},
-                           MakeMLFloat16({0.25f, -0.25f, -0.5f, 0.5f}));
-  test.AddInput<MLFloat16>("data_2", {1}, MakeMLFloat16({std::numeric_limits<float>::quiet_NaN()}));
-  test.AddOutput<MLFloat16>("min", {2, 2},
-                            MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(),
-                                           std::numeric_limits<float>::quiet_NaN(),
-                                           std::numeric_limits<float>::quiet_NaN(),
-                                           std::numeric_limits<float>::quiet_NaN()}));
-  if (nullptr != DefaultCpuExecutionProvider()) {
-    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
-    execution_providers.push_back(DefaultCpuExecutionProvider());
-    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
-  }
-}
-
 TEST(MathOpTest, Max_6) {
   OpTester test("Max", 6);
   std::vector<int64_t> dims{3, 3};
@@ -2189,60 +2135,6 @@ TEST(MathOpTest, Max_12_MLFloat16_Scalar1) {
   test.AddOutput<MLFloat16>("max", {1, 3},
                             MakeMLFloat16({2.f, 2.f, 2.f}));
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  // TensorRT: Input batch size is inconsistent
-}
-
-TEST(MathOpTest, Max_12_MLFloat16_Nan) {
-  OpTester test("Max", 12);
-  test.AddInput<MLFloat16>("data_2", {3, 3},
-                           MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(),
-                                          std::numeric_limits<float>::quiet_NaN(),
-                                          std::numeric_limits<float>::quiet_NaN(),
-                                          -0.5f, 0.0f, -2.0f,
-                                          0.5f, 0.0f, 2.0f}));
-  test.AddInput<MLFloat16>("data_1", {3, 1},
-                           MakeMLFloat16({0.0f, -1.0f, 1.0f}));
-  test.AddOutput<MLFloat16>("max", {3, 3},
-                            MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(),
-                                           std::numeric_limits<float>::quiet_NaN(),
-                                           std::numeric_limits<float>::quiet_NaN(),
-                                           -0.5f, 0.0f, -1.0f,
-                                           1.0f, 1.0f, 2.0f}));
-  if (nullptr != DefaultCpuExecutionProvider()) {
-    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
-    execution_providers.push_back(DefaultCpuExecutionProvider());
-    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
-  }
-}
-
-TEST(MathOpTest, Max_12_MLFloat16_Nan_with_scalar) {
-  OpTester test("Max", 12);
-  test.AddInput<MLFloat16>("data_1", {3, 1},
-                           MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(), -0.5f, 0.5f}));
-  test.AddInput<MLFloat16>("data_2", {1}, MakeMLFloat16({0.25f}));
-  test.AddOutput<MLFloat16>("max", {3, 1},
-                            MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(), 0.25f, 0.5f}));
-  if (nullptr != DefaultCpuExecutionProvider()) {
-    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
-    execution_providers.push_back(DefaultCpuExecutionProvider());
-    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
-  }
-}
-
-TEST(MathOpTest, Max_12_MLFloat16_with_scalar_Nan) {
-  OpTester test("Max", 12);
-  test.AddInput<MLFloat16>("data_1", {2, 2},
-                           MakeMLFloat16({0.25f, -0.25f, -0.5f, 0.5f}));
-  test.AddInput<MLFloat16>("data_2", {1}, MakeMLFloat16({std::numeric_limits<float>::quiet_NaN()}));
-  test.AddOutput<MLFloat16>("max", {2, 2},
-                            MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(),
-                                           std::numeric_limits<float>::quiet_NaN(),
-                                           std::numeric_limits<float>::quiet_NaN(),
-                                           std::numeric_limits<float>::quiet_NaN()}));
-  if (nullptr != DefaultCpuExecutionProvider()) {
-    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
-    execution_providers.push_back(DefaultCpuExecutionProvider());
-    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
-  }
 }
 
 TEST(MathOpTest, Not) {

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -1553,6 +1553,25 @@ TEST(MathOpTest, Min_12_Float_Nan) {
   }
 }
 
+TEST(MathOpTest, Min_12_Float_Nan_with_scalar) {
+  OpTester test("Min", 12);
+  test.AddInput<float>("data_1", {3, 1},
+                       {std::numeric_limits<float>::quiet_NaN(), -0.5f, 0.5f});
+  test.AddInput<float>("data_2", {1}, {0.25f});
+  test.AddOutput<float>("min", {3, 1},
+                        {std::numeric_limits<float>::quiet_NaN(), -0.5f, 0.25f});
+  if (nullptr != DefaultCpuExecutionProvider()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCpuExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+  if (nullptr != DefaultCudaExecutionProvider()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCudaExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+}
+
 TEST(MathOpTest, Min_12_Double) {
   OpTester test("Min", 12);
   test.AddInput<double>("data_0", {1, 3},
@@ -1586,12 +1605,31 @@ TEST(MathOpTest, Min_12_Double_Nan) {
                           std::numeric_limits<double>::quiet_NaN(),
                           -1.0, -1.0, -2.0,
                           0.5, 0.0, 1.0});
-  if (nullptr != DefaultCpuExecutionProvider().get()) {
+  if (nullptr != DefaultCpuExecutionProvider()) {
     std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
     execution_providers.push_back(DefaultCpuExecutionProvider());
     test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
   }
-  if (nullptr != DefaultCudaExecutionProvider().get()) {
+  if (nullptr != DefaultCudaExecutionProvider()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCudaExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+}
+
+TEST(MathOpTest, Min_12_Double_Nan_with_scalar) {
+  OpTester test("Min", 12);
+  test.AddInput<double>("data_1", {3, 1},
+                        {std::numeric_limits<double>::quiet_NaN(), -0.5, 0.5});
+  test.AddInput<double>("data_2", {1}, {0.25});
+  test.AddOutput<double>("min", {3, 1},
+                         {std::numeric_limits<double>::quiet_NaN(), -0.5, 0.25});
+  if (nullptr != DefaultCpuExecutionProvider()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCpuExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+  if (nullptr != DefaultCudaExecutionProvider()) {
     std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
     execution_providers.push_back(DefaultCudaExecutionProvider());
     test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
@@ -1809,12 +1847,31 @@ TEST(MathOpTest, Max_12_Float_Nan) {
                          std::numeric_limits<float>::quiet_NaN(),
                          -0.5f, 0.0f, -1.0f,
                          1.0f, 1.0f, 2.0f});
-  if (nullptr != DefaultCpuExecutionProvider().get()) {
+  if (nullptr != DefaultCpuExecutionProvider()) {
     std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
     execution_providers.push_back(DefaultCpuExecutionProvider());
     test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
   }
-  if (nullptr != DefaultCudaExecutionProvider().get()) {
+  if (nullptr != DefaultCudaExecutionProvider()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCudaExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+}
+
+TEST(MathOpTest, Max_12_Float_Nan_with_scalar) {
+  OpTester test("Max", 12);
+  test.AddInput<float>("data_1", {3, 1},
+                       {std::numeric_limits<float>::quiet_NaN(), -0.5f, 0.5f});
+  test.AddInput<float>("data_2", {1}, {0.25f});
+  test.AddOutput<float>("max", {3, 1},
+                        {std::numeric_limits<float>::quiet_NaN(), 0.25f, 0.5f});
+  if (nullptr != DefaultCpuExecutionProvider()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCpuExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+  if (nullptr != DefaultCudaExecutionProvider()) {
     std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
     execution_providers.push_back(DefaultCudaExecutionProvider());
     test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
@@ -1854,12 +1911,31 @@ TEST(MathOpTest, Max_12_Double_Nan) {
                           std::numeric_limits<double>::quiet_NaN(),
                           -0.5, 0.0, -1.0,
                           1.0, 1.0, 2.0});
-  if (nullptr != DefaultCpuExecutionProvider().get()) {
+  if (nullptr != DefaultCpuExecutionProvider()) {
     std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
     execution_providers.push_back(DefaultCpuExecutionProvider());
     test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
   }
-  if (nullptr != DefaultCudaExecutionProvider().get()) {
+  if (nullptr != DefaultCudaExecutionProvider()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCudaExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+}
+
+TEST(MathOpTest, Max_12_Double_Nan_with_scalar) {
+  OpTester test("Max", 12);
+  test.AddInput<double>("data_1", {3, 1},
+                        {std::numeric_limits<double>::quiet_NaN(), -0.5, 0.5});
+  test.AddInput<double>("data_2", {1}, {0.25});
+  test.AddOutput<double>("max", {3, 1},
+                         {std::numeric_limits<double>::quiet_NaN(), 0.25, 0.5});
+  if (nullptr != DefaultCpuExecutionProvider()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCpuExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+  if (nullptr != DefaultCudaExecutionProvider()) {
     std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
     execution_providers.push_back(DefaultCudaExecutionProvider());
     test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -1704,7 +1704,7 @@ TEST(MathOpTest, Min_12_UInt64) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  // TensorRT: Input batch size is inconsistent
 }
 
-TEST(MathOpTest, Min_12_MLFLoat16) {
+TEST(MathOpTest, Min_12_MLFloat16) {
   OpTester test("Min", 12);
   test.AddInput<MLFloat16>("data_0", {1, 3},
                            MakeMLFloat16({1.f, 1.f, 1.f}));
@@ -1717,7 +1717,7 @@ TEST(MathOpTest, Min_12_MLFLoat16) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  // TensorRT: Input batch size is inconsistent
 }
 
-TEST(MathOpTest, Min_12_MLFLoat16_Scalar0) {
+TEST(MathOpTest, Min_12_MLFloat16_Scalar0) {
   OpTester test("Min", 12);
   test.AddInput<MLFloat16>("data_0", {},
                            MakeMLFloat16({-10.f}));
@@ -1730,7 +1730,7 @@ TEST(MathOpTest, Min_12_MLFLoat16_Scalar0) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  // TensorRT: Input batch size is inconsistent
 }
 
-TEST(MathOpTest, Min_12_MLFLoat16_Scalar1) {
+TEST(MathOpTest, Min_12_MLFloat16_Scalar1) {
   OpTester test("Min", 12);
   test.AddInput<MLFloat16>("data_0", {1, 3},
                            MakeMLFloat16({2.f, 3.f, 4.f}));
@@ -1741,6 +1741,43 @@ TEST(MathOpTest, Min_12_MLFLoat16_Scalar1) {
   test.AddOutput<MLFloat16>("min", {1, 3},
                             MakeMLFloat16({-10.f, -10.f, -10.f}));
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  // TensorRT: Input batch size is inconsistent
+}
+
+TEST(MathOpTest, Min_12_MLFloat16_Nan) {
+  OpTester test("Min", 12);
+  test.AddInput<MLFloat16>("data_2", {3, 3},
+                           MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(),
+                                          std::numeric_limits<float>::quiet_NaN(),
+                                          std::numeric_limits<float>::quiet_NaN(),
+                                          -0.5f, 0.0f, -2.0f,
+                                          0.5f, 0.0f, 2.0f}));
+  test.AddInput<MLFloat16>("data_1", {3, 1},
+                       MakeMLFloat16({0.0f, -1.0f, 1.0f}));
+  test.AddOutput<MLFloat16>("min", {3, 3},
+                            MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(),
+                                           std::numeric_limits<float>::quiet_NaN(),
+                                           std::numeric_limits<float>::quiet_NaN(),
+                                           -1.0f, -1.0f, -2.0f,
+                                           0.5f, 0.0f, 1.0f}));
+  if (nullptr != DefaultCpuExecutionProvider()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCpuExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+}
+
+TEST(MathOpTest, Min_12_MLFloat16_Nan_with_scalar) {
+  OpTester test("Min", 12);
+  test.AddInput<MLFloat16>("data_1", {3, 1},
+                           MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(), -0.5f, 0.5f}));
+  test.AddInput<MLFloat16>("data_2", {1}, MakeMLFloat16({0.25f}));
+  test.AddOutput<MLFloat16>("min", {3, 1},
+                            MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(), -0.5f, 0.25f}));
+  if (nullptr != DefaultCpuExecutionProvider()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCpuExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
 }
 
 TEST(MathOpTest, Max_6) {
@@ -2010,7 +2047,7 @@ TEST(MathOpTest, Max_12_UInt64) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  // TensorRT: Input batch size is inconsistent
 }
 
-TEST(MathOpTest, Max_12_MLFLoat16) {
+TEST(MathOpTest, Max_12_MLFloat16) {
   OpTester test("Max", 12);
   test.AddInput<MLFloat16>("data_0", {1, 3},
                            MakeMLFloat16({-1.f, -1.f, -1.f}));
@@ -2023,7 +2060,7 @@ TEST(MathOpTest, Max_12_MLFLoat16) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  // TensorRT: Input batch size is inconsistent
 }
 
-TEST(MathOpTest, Max_12_MLFLoat16_Scalar0) {
+TEST(MathOpTest, Max_12_MLFloat16_Scalar0) {
   OpTester test("Max", 12);
   test.AddInput<MLFloat16>("data_0", {},
                            MakeMLFloat16({-1.f}));
@@ -2036,7 +2073,7 @@ TEST(MathOpTest, Max_12_MLFLoat16_Scalar0) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  // TensorRT: Input batch size is inconsistent
 }
 
-TEST(MathOpTest, Max_12_MLFLoat16_Scalar1) {
+TEST(MathOpTest, Max_12_MLFloat16_Scalar1) {
   OpTester test("Max", 12);
   test.AddInput<MLFloat16>("data_0", {1, 3},
                            MakeMLFloat16({-1.f, -2.f, -3.f}));
@@ -2047,6 +2084,43 @@ TEST(MathOpTest, Max_12_MLFLoat16_Scalar1) {
   test.AddOutput<MLFloat16>("max", {1, 3},
                             MakeMLFloat16({2.f, 2.f, 2.f}));
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  // TensorRT: Input batch size is inconsistent
+}
+
+TEST(MathOpTest, Max_12_MLFloat16_Nan) {
+  OpTester test("Max", 12);
+  test.AddInput<MLFloat16>("data_2", {3, 3},
+                           MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(),
+                                          std::numeric_limits<float>::quiet_NaN(),
+                                          std::numeric_limits<float>::quiet_NaN(),
+                                          -0.5f, 0.0f, -2.0f,
+                                           0.5f, 0.0f, 2.0f}));
+  test.AddInput<MLFloat16>("data_1", {3, 1},
+                           MakeMLFloat16({0.0f, -1.0f, 1.0f}));
+  test.AddOutput<MLFloat16>("max", {3, 3},
+                            MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(),
+                                           std::numeric_limits<float>::quiet_NaN(),
+                                           std::numeric_limits<float>::quiet_NaN(),
+                                           -0.5f, 0.0f, -1.0f,
+                                           1.0f, 1.0f, 2.0f}));
+  if (nullptr != DefaultCpuExecutionProvider()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCpuExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+}
+
+TEST(MathOpTest, Max_12_MLFloat16_Nan_with_scalar) {
+  OpTester test("Max", 12);
+  test.AddInput<MLFloat16>("data_1", {3, 1},
+                           MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(), -0.5f, 0.5f}));
+  test.AddInput<MLFloat16>("data_2", {1}, MakeMLFloat16({0.25f}));
+  test.AddOutput<MLFloat16>("max", {3, 1},
+                            MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(), 0.25f, 0.5f}));
+  if (nullptr != DefaultCpuExecutionProvider()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCpuExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
 }
 
 TEST(MathOpTest, Not) {

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -1752,7 +1752,7 @@ TEST(MathOpTest, Min_12_MLFloat16_Nan) {
                                           -0.5f, 0.0f, -2.0f,
                                           0.5f, 0.0f, 2.0f}));
   test.AddInput<MLFloat16>("data_1", {3, 1},
-                       MakeMLFloat16({0.0f, -1.0f, 1.0f}));
+                           MakeMLFloat16({0.0f, -1.0f, 1.0f}));
   test.AddOutput<MLFloat16>("min", {3, 3},
                             MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(),
                                            std::numeric_limits<float>::quiet_NaN(),
@@ -2093,7 +2093,7 @@ TEST(MathOpTest, Max_12_MLFloat16_Nan) {
                                           std::numeric_limits<float>::quiet_NaN(),
                                           std::numeric_limits<float>::quiet_NaN(),
                                           -0.5f, 0.0f, -2.0f,
-                                           0.5f, 0.0f, 2.0f}));
+                                          0.5f, 0.0f, 2.0f}));
   test.AddInput<MLFloat16>("data_1", {3, 1},
                            MakeMLFloat16({0.0f, -1.0f, 1.0f}));
   test.AddOutput<MLFloat16>("max", {3, 3},

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -1572,6 +1572,28 @@ TEST(MathOpTest, Min_12_Float_Nan_with_scalar) {
   }
 }
 
+TEST(MathOpTest, Min_12_Float_with_scalar_Nan) {
+  OpTester test("Min", 12);
+  test.AddInput<float>("data_1", {2, 2},
+                       {0.25f, -0.25f, -0.5f, 0.5f});
+  test.AddInput<float>("data_2", {1}, {std::numeric_limits<float>::quiet_NaN()});
+  test.AddOutput<float>("min", {2, 2},
+                        {std::numeric_limits<float>::quiet_NaN(),
+                         std::numeric_limits<float>::quiet_NaN(),
+                         std::numeric_limits<float>::quiet_NaN(),
+                         std::numeric_limits<float>::quiet_NaN()});
+  if (nullptr != DefaultCpuExecutionProvider()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCpuExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+  if (nullptr != DefaultCudaExecutionProvider()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCudaExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+}
+
 TEST(MathOpTest, Min_12_Double) {
   OpTester test("Min", 12);
   test.AddInput<double>("data_0", {1, 3},
@@ -1624,6 +1646,28 @@ TEST(MathOpTest, Min_12_Double_Nan_with_scalar) {
   test.AddInput<double>("data_2", {1}, {0.25});
   test.AddOutput<double>("min", {3, 1},
                          {std::numeric_limits<double>::quiet_NaN(), -0.5, 0.25});
+  if (nullptr != DefaultCpuExecutionProvider()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCpuExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+  if (nullptr != DefaultCudaExecutionProvider()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCudaExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+}
+
+TEST(MathOpTest, Min_12_Double_with_scalar_Nan) {
+  OpTester test("Min", 12);
+  test.AddInput<double>("data_1", {2, 2},
+                        {0.25, -0.25, -0.5, 0.5});
+  test.AddInput<double>("data_2", {1}, {std::numeric_limits<double>::quiet_NaN()});
+  test.AddOutput<double>("min", {2, 2},
+                         {std::numeric_limits<double>::quiet_NaN(),
+                          std::numeric_limits<double>::quiet_NaN(),
+                          std::numeric_limits<double>::quiet_NaN(),
+                          std::numeric_limits<double>::quiet_NaN()});
   if (nullptr != DefaultCpuExecutionProvider()) {
     std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
     execution_providers.push_back(DefaultCpuExecutionProvider());
@@ -1780,6 +1824,23 @@ TEST(MathOpTest, Min_12_MLFloat16_Nan_with_scalar) {
   }
 }
 
+TEST(MathOpTest, Min_12_MLFloat16_with_scalar_Nan) {
+  OpTester test("Min", 12);
+  test.AddInput<MLFloat16>("data_1", {2, 2},
+                           MakeMLFloat16({0.25f, -0.25f, -0.5f, 0.5f}));
+  test.AddInput<MLFloat16>("data_2", {1}, MakeMLFloat16({std::numeric_limits<float>::quiet_NaN()}));
+  test.AddOutput<MLFloat16>("min", {2, 2},
+                            MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(),
+                                           std::numeric_limits<float>::quiet_NaN(),
+                                           std::numeric_limits<float>::quiet_NaN(),
+                                           std::numeric_limits<float>::quiet_NaN()}));
+  if (nullptr != DefaultCpuExecutionProvider()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCpuExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+}
+
 TEST(MathOpTest, Max_6) {
   OpTester test("Max", 6);
   std::vector<int64_t> dims{3, 3};
@@ -1915,6 +1976,28 @@ TEST(MathOpTest, Max_12_Float_Nan_with_scalar) {
   }
 }
 
+TEST(MathOpTest, Max_12_Float_with_scalar_Nan) {
+  OpTester test("Max", 12);
+  test.AddInput<float>("data_1", {2, 2},
+                       {0.25f, -0.25f, -0.5f, 0.5f});
+  test.AddInput<float>("data_2", {1}, {std::numeric_limits<float>::quiet_NaN()});
+  test.AddOutput<float>("max", {2, 2},
+                        {std::numeric_limits<float>::quiet_NaN(),
+                         std::numeric_limits<float>::quiet_NaN(),
+                         std::numeric_limits<float>::quiet_NaN(),
+                         std::numeric_limits<float>::quiet_NaN()});
+  if (nullptr != DefaultCpuExecutionProvider()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCpuExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+  if (nullptr != DefaultCudaExecutionProvider()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCudaExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+}
+
 TEST(MathOpTest, Max_12_Double) {
   OpTester test("Max", 12);
   test.AddInput<double>("data_0", {1, 3},
@@ -1967,6 +2050,28 @@ TEST(MathOpTest, Max_12_Double_Nan_with_scalar) {
   test.AddInput<double>("data_2", {1}, {0.25});
   test.AddOutput<double>("max", {3, 1},
                          {std::numeric_limits<double>::quiet_NaN(), 0.25, 0.5});
+  if (nullptr != DefaultCpuExecutionProvider()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCpuExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+  if (nullptr != DefaultCudaExecutionProvider()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCudaExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+}
+
+TEST(MathOpTest, Max_12_Double_with_scalar_Nan) {
+  OpTester test("Max", 12);
+  test.AddInput<double>("data_1", {2, 2},
+                        {0.25, -0.25, -0.5, 0.5});
+  test.AddInput<double>("data_2", {1}, {std::numeric_limits<double>::quiet_NaN()});
+  test.AddOutput<double>("max", {2, 2},
+                         {std::numeric_limits<double>::quiet_NaN(),
+                          std::numeric_limits<double>::quiet_NaN(),
+                          std::numeric_limits<double>::quiet_NaN(),
+                          std::numeric_limits<double>::quiet_NaN()});
   if (nullptr != DefaultCpuExecutionProvider()) {
     std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
     execution_providers.push_back(DefaultCpuExecutionProvider());
@@ -2116,6 +2221,23 @@ TEST(MathOpTest, Max_12_MLFloat16_Nan_with_scalar) {
   test.AddInput<MLFloat16>("data_2", {1}, MakeMLFloat16({0.25f}));
   test.AddOutput<MLFloat16>("max", {3, 1},
                             MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(), 0.25f, 0.5f}));
+  if (nullptr != DefaultCpuExecutionProvider()) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCpuExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+}
+
+TEST(MathOpTest, Max_12_MLFloat16_with_scalar_Nan) {
+  OpTester test("Max", 12);
+  test.AddInput<MLFloat16>("data_1", {2, 2},
+                           MakeMLFloat16({0.25f, -0.25f, -0.5f, 0.5f}));
+  test.AddInput<MLFloat16>("data_2", {1}, MakeMLFloat16({std::numeric_limits<float>::quiet_NaN()}));
+  test.AddOutput<MLFloat16>("max", {2, 2},
+                            MakeMLFloat16({std::numeric_limits<float>::quiet_NaN(),
+                                           std::numeric_limits<float>::quiet_NaN(),
+                                           std::numeric_limits<float>::quiet_NaN(),
+                                           std::numeric_limits<float>::quiet_NaN()}));
   if (nullptr != DefaultCpuExecutionProvider()) {
     std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
     execution_providers.push_back(DefaultCpuExecutionProvider());


### PR DESCRIPTION
### Description

Propagates NaN values in the min and max operators so that min or max with a NaN in either input always produces NaN.

### Motivation and Context

Fixes #21455