### PR TITLE
Fix Android CI Pipeline code coverage failure

### DIFF
--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -174,19 +174,19 @@ stages:
 
     - template: templates/clean-agent-build-directory-step.yml
 
-- stage: MASTER_BUILD_STAGE
-  # The below jobs only run on master build.
+- stage: MAIN_BUILD_STAGE
+  # The below jobs only run on build of main branch.
   # because coverage report is hard to support in cross machines.
-  displayName: NNAPI MASTER BUILD&TEST
+  displayName: NNAPI MAIN BUILD&TEST
   dependsOn: []
-  condition: in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')
+  # condition: in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')
   jobs:
   - job: NNAPI_EP_MASTER
     pool: onnxruntime-Ubuntu2204-AMD-CPU
     timeoutInMinutes: 180
     workspace:
       clean: all
-    condition: in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')
+    # condition: in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')
     steps:
       - task: UsePythonVersion@0
         displayName: Use Python $(pythonVersion)
@@ -225,28 +225,28 @@ stages:
           --code_coverage
         displayName: NNAPI EP, Build, Test, CodeCoverage on Android Emulator
 
+      # We need to use llvm-cov from the NDK.
       - script: |
-          python3 -m pip install gcovr && \
-          python3 tools/ci_build/coverage.py \
-            --build_dir build_nnapi \
-            --android_sdk_path $ANDROID_HOME
+          export GCOV="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-cov gcov"
+          python3 -m pip install gcovr
+          python3 tools/ci_build/coverage.py --build_dir build_nnapi --android_sdk_path $ANDROID_HOME
         displayName: Retrieve runtime code coverage files from the emulator and analyze
 
       - script: cat '$(Build.SourcesDirectory)/build_nnapi/Debug/coverage_rpt.txt'
         displayName: Print coverage report
 
+      # - task: AzureCLI@2
+      #   displayName: 'Post Android Code Coverage To DashBoard'
+      #   inputs:
+      #     azureSubscription: AIInfraBuild
+      #     scriptType: bash
+      #     scriptPath: $(Build.SourcesDirectory)/tools/ci_build/github/linux/upload_code_coverage_data.sh
+      #     arguments: '"$(Build.SourcesDirectory)/build_nnapi/Debug/coverage_rpt.txt" "https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=$(Build.BuildId)" arm android nnapi'
+      #     workingDirectory: '$(Build.BinariesDirectory)'
+
       - script: /bin/bash tools/ci_build/github/linux/ort_minimal/nnapi_minimal_build_minimal_ort_and_run_tests.sh $(pwd)
         # Build Minimal ORT with NNAPI and reduced Ops, run unit tests on Android Emulator
         displayName: Build Minimal ORT with NNAPI and run tests
-
-      - task: AzureCLI@2
-        displayName: 'Post Android Code Coverage To DashBoard'
-        inputs:
-          azureSubscription: AIInfraBuild
-          scriptType: bash
-          scriptPath: $(Build.SourcesDirectory)/tools/ci_build/github/linux/upload_code_coverage_data.sh
-          arguments: '"$(Build.SourcesDirectory)/build_nnapi/Debug/coverage_rpt.txt" "https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=$(Build.BuildId)" arm android nnapi'
-          workingDirectory: '$(Build.BinariesDirectory)'
 
       - template: templates/use-android-emulator.yml
         parameters:

--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -179,14 +179,14 @@ stages:
   # because coverage report is hard to support in cross machines.
   displayName: NNAPI MAIN BUILD&TEST
   dependsOn: []
-  # condition: in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')
+  condition: in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')
   jobs:
   - job: NNAPI_EP_MASTER
     pool: onnxruntime-Ubuntu2204-AMD-CPU
     timeoutInMinutes: 180
     workspace:
       clean: all
-    # condition: in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')
+    condition: in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')
     steps:
       - task: UsePythonVersion@0
         displayName: Use Python $(pythonVersion)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Current failure is due to a version mismatch.

Use llvm-cov from the Android NDK instead of the system gcov so that the version is correct.

Also comment out publishing to the Azure dashboard to simplify the setup. The CI prints out the stats for review by developers. 

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Fix CI pipeline

