### PR TITLE
disables qnn in ort training cpu pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-cpu.yml
@@ -22,3 +22,5 @@ stages:
     enable_windows_gpu: false
     enable_mac_cpu: true
     enable_linux_arm: false
+    enable_windows_arm64_qnn: false
+    enable_windows_x64_qnn: false


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

`enable_windows_arm64_qnn` and `enable_windows_x64_qnn` are true by default but unnecessary for training. This change explicitly sets these parameters to false for training pipeline.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

ORT 1.19 Release Preparation

