### PR TITLE
Remove references of  use-android-ndk.yml

### DIFF
--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -78,7 +78,6 @@ stages:
     - script: sudo apt-get update -y && sudo apt-get install -y coreutils ninja-build
       displayName: Install coreutils and ninja
 
-    - template: templates/use-android-ndk.yml
     - template: templates/use-android-emulator.yml
       parameters:
         create: true
@@ -200,7 +199,6 @@ stages:
           jdkArchitectureOption: 'x64'
           jdkSourceOption: 'PreInstalled'
 
-      - template: templates/use-android-ndk.yml
 
       - template: templates/use-android-emulator.yml
         parameters:

--- a/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
@@ -66,7 +66,6 @@ jobs:
     clean: true
     submodules: none
 
-  - template: "templates/use-android-ndk.yml"
 
   - template: templates/get-docker-image-steps.yml
     parameters:

--- a/tools/ci_build/github/azure-pipelines/templates/android-binary-size-check-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/android-binary-size-check-stage.yml
@@ -37,7 +37,6 @@ stages:
       clean: true
       submodules: none
 
-    - template: use-android-ndk.yml
     #TODO: use a different docker file since this job doesn't need to rely on manylinux
     - template: get-docker-image-steps.yml
       parameters:

--- a/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar-test.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar-test.yml
@@ -45,7 +45,6 @@ jobs:
       jdkArchitectureOption: 'x64'
       jdkSourceOption: 'PreInstalled'
 
-  - template: use-android-ndk.yml
 
   - template: install-appcenter.yml
 

--- a/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar.yml
@@ -73,7 +73,6 @@ jobs:
 
   - template: set-version-number-variables-step.yml
 
-  - template: use-android-ndk.yml
 
   - task: CmdLine@2
     displayName: Build Android AAR Packages


### PR DESCRIPTION
### Description
I just had a short discussion with Scott regarding the matter. The current approach has pros and cons.
Pros:
Make the pipelines more deterministic, since the NDK version is fixed. It won't get changed without notice.
Cons:
Need to manually update the use-android-ndk.yml file to keep the version up to date, otherwise our Android pipelines will download NDK in every run which is a big overhead. 

Given most customers prefer to use the latest NDK, we may remove this hardcoded version setting.
 
This PR will change the pipelines to use NDK 27 instead. Now they use NDK 26.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


