### PR TITLE
Remove OrtSessionOptionsAppendExecutionProvider_CUDA

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -758,7 +758,6 @@ endif()
 if (onnxruntime_USE_CUDA)
     list(APPEND ORT_PROVIDER_FLAGS -DUSE_CUDA=1)
     list(APPEND ORT_PROVIDER_CMAKE_FLAGS -Donnxruntime_USE_CUDA=1)
-    list(APPEND ONNXRUNTIME_PROVIDER_NAMES cuda)
 
     if (onnxruntime_USE_FLASH_ATTENTION)
       message( STATUS "Enable flash attention for CUDA EP")


### PR DESCRIPTION
### Description
Remove OrtSessionOptionsAppendExecutionProvider_CUDA function from libonnxruntime.so / onnxruntime.dll. 

### Motivation and Context
It has caused a lot of confusion since we have three different functions for registering CUDA EP. The OrtSessionOptionsAppendExecutionProvider_CUDA is the oldest one and has been deprecated. 

We never provided binary backward compatibility for Linux apps. So this change won't break Linux usages.
In terms of Windows,  CUDA usages are few, and I don't hear any of them needs binary backward compatibility.



