### PR TITLE
[js/webgpu] allow set `env.webgpu.device`

### DIFF
--- a/js/common/lib/env.ts
+++ b/js/common/lib/env.ts
@@ -188,7 +188,11 @@ export declare namespace Env {
      * Set or get the adapter for WebGPU.
      *
      * Setting this property only has effect before the first WebGPU inference session is created. The value will be
-     * used as the GPU adapter for the underlying WebGPU backend to create GPU device.
+     * used as the GPU adapter for the underlying WebGPU backend to create GPU device, and for querying the adapter
+     * information. If this property is set, the `powerPreference` and `forceFallbackAdapter` properties will be
+     * ignored.
+     *
+     * The value of this property cannot be changed after the first WebGPU inference session is created.
      *
      * If this property is not set, it will be available to get after the first WebGPU inference session is created. The
      * value will be the GPU adapter that created by the underlying WebGPU backend.
@@ -200,16 +204,23 @@ export declare namespace Env {
      */
     adapter: unknown;
     /**
-     * Get the device for WebGPU.
+     * Set or get the device for WebGPU.
      *
-     * This property is only available after the first WebGPU inference session is created.
+     * Setting this property only has effect before the first WebGPU inference session is created. The value will be
+     * used to initialize the underlying WebGPU backend. It is required to set {@link env.webgpu.adapter} also, if this
+     * property is set.
+     *
+     * The value of this property cannot be changed after the first WebGPU inference session is created.
+     *
+     * If this property is not set, it will be available to get after the first WebGPU inference session is created. The
+     * value will be the GPU device that created by the underlying WebGPU backend.
      *
      * When use with TypeScript, the type of this property is `GPUDevice` defined in "@webgpu/types".
      * Use `const device = env.webgpu.device as GPUDevice;` in TypeScript to access this property with correct type.
      *
      * see comments on {@link Tensor.GpuBufferType} for more details about why not use types defined in "@webgpu/types".
      */
-    readonly device: unknown;
+    device: unknown;
     /**
      * Set or get whether validate input content.
      *

--- a/js/web/lib/wasm/wasm-core-impl.ts
+++ b/js/web/lib/wasm/wasm-core-impl.ts
@@ -99,8 +99,12 @@ export const initEp = async(env: Env, epName: string): Promise<void> => {
         throw new Error('WebGPU is not supported in current environment');
       }
 
-      let adapter = env.webgpu.adapter as GPUAdapter | null;
+      const device = env.webgpu.device as GPUDevice | undefined;
+      let adapter = env.webgpu.adapter as GPUAdapter | null | undefined;
       if (!adapter) {
+        if (device) {
+          throw new Error('`env.webgpu.device` is set but `env.webgpu.adapter` is omitted.');
+        }
         // if adapter is not set, request a new adapter.
         const powerPreference = env.webgpu.powerPreference;
         if (powerPreference !== undefined && powerPreference !== 'low-power' &&
@@ -125,7 +129,7 @@ export const initEp = async(env: Env, epName: string): Promise<void> => {
         }
       }
 
-      await initJsep('webgpu', getInstance(), env, adapter);
+      await initJsep('webgpu', getInstance(), env, adapter, device);
     }
     if (epName === 'webnn') {
       // perform WebNN availability check


### PR DESCRIPTION
### Description

This PR allows user to set a pre-created `GPUDevice` instance before ONNX Runtime Web starts to create the first inference session.