### PR TITLE
Fix ETW trace logging crash in multithreading situations

### DIFF
--- a/onnxruntime/core/platform/windows/logging/etw_sink.cc
+++ b/onnxruntime/core/platform/windows/logging/etw_sink.cc
@@ -147,11 +147,11 @@ void EtwRegistrationManager::LazyInitialize() {
   if (!initialized_) {
     std::lock_guard<OrtMutex> lock(init_mutex_);
     if (!initialized_) {  // Double-check locking pattern
-      initialized_ = true;
       etw_status_ = ::TraceLoggingRegisterEx(etw_provider_handle, ORT_TL_EtwEnableCallback, nullptr);
       if (FAILED(etw_status_)) {
         ORT_THROW("ETW registration failed. Logging will be broken: " + std::to_string(etw_status_));
       }
+      initialized_ = true;
     }
   }
 }

--- a/onnxruntime/core/platform/windows/logging/etw_sink.cc
+++ b/onnxruntime/core/platform/windows/logging/etw_sink.cc
@@ -143,17 +143,24 @@ EtwRegistrationManager::~EtwRegistrationManager() {
 EtwRegistrationManager::EtwRegistrationManager() {
 }
 
-void EtwRegistrationManager::LazyInitialize() {
-  if (!initialized_) {
+void EtwRegistrationManager::LazyInitialize() try {
+  if (!initialized_ && !initializing_) {
     std::lock_guard<OrtMutex> lock(init_mutex_);
-    if (!initialized_) {  // Double-check locking pattern
+    if (!initialized_ && !initializing_) {  // Double-check locking pattern
+      initializing_ = true;
       etw_status_ = ::TraceLoggingRegisterEx(etw_provider_handle, ORT_TL_EtwEnableCallback, nullptr);
       if (FAILED(etw_status_)) {
         ORT_THROW("ETW registration failed. Logging will be broken: " + std::to_string(etw_status_));
       }
       initialized_ = true;
+      initializing_ = false;
     }
   }
+} catch (...)
+{
+  initialized_ = false;
+  initializing_ = false;
+  throw;
 }
 
 void EtwRegistrationManager::InvokeCallbacks(LPCGUID SourceId, ULONG IsEnabled, UCHAR Level, ULONGLONG MatchAnyKeyword,

--- a/onnxruntime/core/platform/windows/logging/etw_sink.cc
+++ b/onnxruntime/core/platform/windows/logging/etw_sink.cc
@@ -163,7 +163,7 @@ void EtwRegistrationManager::LazyInitialize() try {
       initialization_status_ = InitializationStatus::Initialized;
     }
   }
-} catch (...){
+} catch (...) {
   initialization_status_ = InitializationStatus::Failed;
   throw;
 }

--- a/onnxruntime/core/platform/windows/logging/etw_sink.cc
+++ b/onnxruntime/core/platform/windows/logging/etw_sink.cc
@@ -137,11 +137,11 @@ void NTAPI EtwRegistrationManager::ORT_TL_EtwEnableCallback(
 EtwRegistrationManager::~EtwRegistrationManager() {
   std::lock_guard<OrtMutex> lock(callbacks_mutex_);
   callbacks_.clear();
-  if (initialization_status_ == InitializationStatus::Intialized ||
+  if (initialization_status_ == InitializationStatus::Initialized ||
       initialization_status_ == InitializationStatus::Initializing) {
     std::lock_guard<OrtMutex> init_lock(init_mutex_);
     assert(initialization_status_ != InitializationStatus::Initializing);
-    if (initialization_status_ == InitializationStatus::Intialized) {
+    if (initialization_status_ == InitializationStatus::Initialized) {
       ::TraceLoggingUnregister(etw_provider_handle);
       initialization_status_ = InitializationStatus::NotInitialized;
     }
@@ -152,7 +152,7 @@ EtwRegistrationManager::EtwRegistrationManager() {
 }
 
 void EtwRegistrationManager::LazyInitialize() try {
-  if (initialization_status_ == InitializationStatus::NoitIntialized) {
+  if (initialization_status_ == InitializationStatus::NoitInitialized) {
     std::lock_guard<OrtMutex> lock(init_mutex_);
     if (initialization_status_ == InitializationStatus::NotInitialized) {  // Double-check locking pattern
       initialization_status_ == InitializationStatus::Initializing;

--- a/onnxruntime/core/platform/windows/logging/etw_sink.cc
+++ b/onnxruntime/core/platform/windows/logging/etw_sink.cc
@@ -155,17 +155,17 @@ void EtwRegistrationManager::LazyInitialize() try {
   if (initialization_status_ == InitializationStatus::NotInitialized) {
     std::lock_guard<OrtMutex> lock(init_mutex_);
     if (initialization_status_ == InitializationStatus::NotInitialized) {  // Double-check locking pattern
-      initialization_status_ == InitializationStatus::Initializing;
+      initialization_status_ = InitializationStatus::Initializing;
       etw_status_ = ::TraceLoggingRegisterEx(etw_provider_handle, ORT_TL_EtwEnableCallback, nullptr);
       if (FAILED(etw_status_)) {
         ORT_THROW("ETW registration failed. Logging will be broken: " + std::to_string(etw_status_));
       }
-      initialization_status_ == InitializationStatus::Initialized;
+      initialization_status_ = InitializationStatus::Initialized;
     }
   }
 } catch (...)
 {
-  initialization_status_ == InitializationStatus::Failed;
+  initialization_status_ = InitializationStatus::Failed;
   throw;
 }
 

--- a/onnxruntime/core/platform/windows/logging/etw_sink.cc
+++ b/onnxruntime/core/platform/windows/logging/etw_sink.cc
@@ -163,8 +163,7 @@ void EtwRegistrationManager::LazyInitialize() try {
       initialization_status_ = InitializationStatus::Initialized;
     }
   }
-} catch (...)
-{
+} catch (...){
   initialization_status_ = InitializationStatus::Failed;
   throw;
 }

--- a/onnxruntime/core/platform/windows/logging/etw_sink.cc
+++ b/onnxruntime/core/platform/windows/logging/etw_sink.cc
@@ -152,7 +152,7 @@ EtwRegistrationManager::EtwRegistrationManager() {
 }
 
 void EtwRegistrationManager::LazyInitialize() try {
-  if (initialization_status_ == InitializationStatus::NoitInitialized) {
+  if (initialization_status_ == InitializationStatus::NotInitialized) {
     std::lock_guard<OrtMutex> lock(init_mutex_);
     if (initialization_status_ == InitializationStatus::NotInitialized) {  // Double-check locking pattern
       initialization_status_ == InitializationStatus::Initializing;

--- a/onnxruntime/core/platform/windows/logging/etw_sink.h
+++ b/onnxruntime/core/platform/windows/logging/etw_sink.h
@@ -47,6 +47,8 @@ class EtwSink : public ISink {
 };
 
 class EtwRegistrationManager {
+  enum class InitializationStatus { NotInitialized, Initializing, Initialized, Failed};
+
  public:
   using EtwInternalCallback = std::function<void(LPCGUID SourceId, ULONG IsEnabled, UCHAR Level,
                                                  ULONGLONG MatchAnyKeyword, ULONGLONG MatchAllKeyword,
@@ -96,8 +98,7 @@ class EtwRegistrationManager {
   OrtMutex callbacks_mutex_;
   mutable OrtMutex provider_change_mutex_;
   OrtMutex init_mutex_;
-  bool initialized_ = false;
-  bool initializing_ = false;
+  InitializationStatus initialization_status_ = InitializationStatus::NotInitialized;
   bool is_enabled_;
   UCHAR level_;
   ULONGLONG keyword_;

--- a/onnxruntime/core/platform/windows/logging/etw_sink.h
+++ b/onnxruntime/core/platform/windows/logging/etw_sink.h
@@ -97,6 +97,7 @@ class EtwRegistrationManager {
   mutable OrtMutex provider_change_mutex_;
   OrtMutex init_mutex_;
   bool initialized_ = false;
+  bool initializing_ = false;
   bool is_enabled_;
   UCHAR level_;
   ULONGLONG keyword_;

--- a/onnxruntime/core/platform/windows/logging/etw_sink.h
+++ b/onnxruntime/core/platform/windows/logging/etw_sink.h
@@ -47,7 +47,10 @@ class EtwSink : public ISink {
 };
 
 class EtwRegistrationManager {
-  enum class InitializationStatus { NotInitialized, Initializing, Initialized, Failed};
+  enum class InitializationStatus { NotInitialized,
+                                    Initializing,
+                                    Initialized,
+                                    Failed };
 
  public:
   using EtwInternalCallback = std::function<void(LPCGUID SourceId, ULONG IsEnabled, UCHAR Level,


### PR DESCRIPTION
### Description
ETW trace logger is fakely registered as initialized_ is marked as true before the registration is done, causing crashing issue for Lenovo camera application.

A prior attempt to address was made here: https://github.com/microsoft/onnxruntime/pull/21226
It was reverted here: https://github.com/microsoft/onnxruntime/pull/21360

### Motivation and Context
The problem is that during initialization of TraceLoggingRegisterEx, it will reinvoke the callback and attempt reinitialization, which is not allowed. TraceLoggingRegisterEx however can be initialized concurrently when initialization happens on multiple threads. For these reasons it needs to be protected by a lock, but the lock cannot naively block because the callback's reinvocation will cause a deadlock.

To solve this problem another tracking variable is added : "initializing" which protects against reinitialization during the first initialization.

