### PR TITLE
Fix ETW trace logging crash in multithreading situations (#21566)

### DIFF
--- a/onnxruntime/core/platform/windows/logging/etw_sink.cc
+++ b/onnxruntime/core/platform/windows/logging/etw_sink.cc
@@ -126,28 +126,47 @@ void NTAPI EtwRegistrationManager::ORT_TL_EtwEnableCallback(
 }
 
 EtwRegistrationManager::~EtwRegistrationManager() {
-  ::TraceLoggingUnregister(etw_provider_handle);
+  std::lock_guard<OrtMutex> lock(callbacks_mutex_);
+  callbacks_.clear();
+  if (initialization_status_ == InitializationStatus::Initialized ||
+      initialization_status_ == InitializationStatus::Initializing) {
+    std::lock_guard<OrtMutex> init_lock(init_mutex_);
+    assert(initialization_status_ != InitializationStatus::Initializing);
+    if (initialization_status_ == InitializationStatus::Initialized) {
+      ::TraceLoggingUnregister(etw_provider_handle);
+      initialization_status_ = InitializationStatus::NotInitialized;
+    }
+  }
 }
 
 EtwRegistrationManager::EtwRegistrationManager() {
 }
 
-void EtwRegistrationManager::LazyInitialize() {
-  if (!initialized_) {
+void EtwRegistrationManager::LazyInitialize() try {
+  if (initialization_status_ == InitializationStatus::NotInitialized) {
     std::lock_guard<OrtMutex> lock(init_mutex_);
-    if (!initialized_) {  // Double-check locking pattern
-      initialized_ = true;
+    if (initialization_status_ == InitializationStatus::NotInitialized) {  // Double-check locking pattern
+      initialization_status_ = InitializationStatus::Initializing;
       etw_status_ = ::TraceLoggingRegisterEx(etw_provider_handle, ORT_TL_EtwEnableCallback, nullptr);
       if (FAILED(etw_status_)) {
         ORT_THROW("ETW registration failed. Logging will be broken: " + std::to_string(etw_status_));
       }
+      initialization_status_ = InitializationStatus::Initialized;
     }
   }
+} catch (...) {
+  initialization_status_ = InitializationStatus::Failed;
+  throw;
 }
 
 void EtwRegistrationManager::InvokeCallbacks(LPCGUID SourceId, ULONG IsEnabled, UCHAR Level, ULONGLONG MatchAnyKeyword,
                                              ULONGLONG MatchAllKeyword, PEVENT_FILTER_DESCRIPTOR FilterData,
                                              PVOID CallbackContext) {
+  if (initialization_status_ != InitializationStatus::Initialized) {
+    // Drop messages until manager is fully initialized.
+    return;
+  }
+
   std::lock_guard<OrtMutex> lock(callbacks_mutex_);
   for (const auto& callback : callbacks_) {
     callback(SourceId, IsEnabled, Level, MatchAnyKeyword, MatchAllKeyword, FilterData, CallbackContext);

--- a/onnxruntime/core/platform/windows/logging/etw_sink.h
+++ b/onnxruntime/core/platform/windows/logging/etw_sink.h
@@ -47,6 +47,11 @@ class EtwSink : public ISink {
 };
 
 class EtwRegistrationManager {
+  enum class InitializationStatus { NotInitialized,
+                                    Initializing,
+                                    Initialized,
+                                    Failed };
+
  public:
   using EtwInternalCallback = std::function<void(LPCGUID SourceId, ULONG IsEnabled, UCHAR Level,
                                                  ULONGLONG MatchAnyKeyword, ULONGLONG MatchAllKeyword,
@@ -94,7 +99,7 @@ class EtwRegistrationManager {
   OrtMutex callbacks_mutex_;
   mutable OrtMutex provider_change_mutex_;
   OrtMutex init_mutex_;
-  bool initialized_ = false;
+  InitializationStatus initialization_status_ = InitializationStatus::NotInitialized;
   bool is_enabled_;
   UCHAR level_;
   ULONGLONG keyword_;

--- a/tools/ci_build/github/azure-pipelines/binary-size-checks-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/binary-size-checks-pipeline.yml
@@ -15,13 +15,13 @@ resources:
 stages:
 
 # checks enabled in all builds
-
-- template: templates/android-binary-size-check-stage.yml
-  parameters:
-    Name: MinimalBaseline
-    BuildConfigFile: "tools/ci_build/github/linux/ort_minimal/build_check_binsize_config/android_minimal_baseline.config"
-    BinarySizeThresholdInBytes: 1306224
-    DoBuildWithDebugInfo: ${{ parameters.DoBuildWithDebugInfo }}
+- ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+  - template: templates/android-binary-size-check-stage.yml
+    parameters:
+      Name: MinimalBaseline
+      BuildConfigFile: "tools/ci_build/github/linux/ort_minimal/build_check_binsize_config/android_minimal_baseline.config"
+      BinarySizeThresholdInBytes: 1306224
+      DoBuildWithDebugInfo: ${{ parameters.DoBuildWithDebugInfo }}
 
 # checks excluded from PR builds
 

--- a/tools/ci_build/github/azure-pipelines/binary-size-checks-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/binary-size-checks-pipeline.yml
@@ -1,3 +1,12 @@
+trigger:
+  branches:
+    include:
+    - main
+pr:
+  branches:
+    include:
+    - main
+
 parameters:
 - name: DoBuildWithDebugInfo
   displayName: Create additional build with debug information?

--- a/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
@@ -16,7 +16,6 @@ pr:
   branches:
     include:
     - main
-    - rel-*
   paths:
     exclude:
     - docs/**
@@ -243,7 +242,7 @@ stages:
           ln -s /data/models $(Build.BinariesDirectory)/models
         displayName: link model dir
 
-      
+
 
       - task: PublishTestResults@2
         displayName: 'Publish unit test results'

--- a/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
@@ -37,7 +37,6 @@ pr:
   branches:
     include:
     - main
-    - rel-*
   paths:
     exclude:
     - docs/**

--- a/tools/ci_build/github/azure-pipelines/linux-gpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-ci-pipeline.yml
@@ -16,7 +16,6 @@ pr:
   branches:
     include:
     - main
-    - rel-*
   paths:
     exclude:
     - docs/**
@@ -78,9 +77,9 @@ jobs:
       Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2_28_cuda
       Context: tools/ci_build/github/linux/docker
       DockerBuildArgs: "
-      --network=host 
+      --network=host
       --build-arg BASEIMAGE=$(docker_base_image)
-      --build-arg TRT_VERSION=$(linux_trt_version) 
+      --build-arg TRT_VERSION=$(linux_trt_version)
       --build-arg BUILD_UID=$( id -u )
       "
       Repository: onnxruntimecuda11build
@@ -179,7 +178,7 @@ jobs:
       Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2_28_cuda
       Context: tools/ci_build/github/linux/docker
       DockerBuildArgs: "
-      --network=host 
+      --network=host
       --build-arg BASEIMAGE=$(docker_base_image)
       --build-arg TRT_VERSION=$(linux_trt_version)
       --build-arg BUILD_UID=$( id -u )

--- a/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-ci-pipeline.yml
@@ -16,7 +16,6 @@ pr:
   branches:
     include:
     - main
-    - rel-*
   paths:
     exclude:
     - docs/**

--- a/tools/ci_build/github/azure-pipelines/linux-openvino-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-openvino-ci-pipeline.yml
@@ -16,7 +16,6 @@ pr:
   branches:
     include:
     - main
-    - rel-*
   paths:
     exclude:
     - docs/**

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-ci-pipeline.yml
@@ -16,7 +16,6 @@ pr:
   branches:
     include:
     - main
-    - rel-*
   paths:
     exclude:
     - docs/**

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ci-pipeline.yml
@@ -16,7 +16,6 @@ pr:
   branches:
     include:
     - main
-    - rel-*
   paths:
     exclude:
     - docs/**

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ortmodule-distributed-test-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ortmodule-distributed-test-ci-pipeline.yml
@@ -16,7 +16,6 @@ pr:
   branches:
     include:
     - main
-    - rel-*
   paths:
     exclude:
     - docs/**

--- a/tools/ci_build/github/azure-pipelines/web-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/web-ci-pipeline.yml
@@ -14,7 +14,6 @@ pr:
   branches:
     include:
     - main
-    - rel-*
   paths:
     exclude:
     - docs/**

--- a/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
@@ -16,7 +16,6 @@ pr:
   branches:
     include:
     - main
-    - rel-*
   paths:
     exclude:
     - docs/**


### PR DESCRIPTION
ETW trace logger is fakely registered as initialized_ is marked as true before the registration is done, causing crashing issue for Lenovo camera application.

A prior attempt to address was made here:
https://github.com/microsoft/onnxruntime/pull/21226 It was reverted here:
https://github.com/microsoft/onnxruntime/pull/21360

The problem is that during initialization of TraceLoggingRegisterEx, it will reinvoke the callback and attempt reinitialization, which is not allowed. TraceLoggingRegisterEx however can be initialized concurrently when initialization happens on multiple threads. For these reasons it needs to be protected by a lock, but the lock cannot naively block because the callback's reinvocation will cause a deadlock.

To solve this problem another tracking variable is added : "initializing" which protects against reinitialization during the first initialization.

---------

### Description
A few CI pipelines are disabled because they are no longer compatible with this legacy GE branch. 



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


