### PR TITLE
Fix usability checker CoreML config file path.

### DIFF
--- a/tools/python/util/mobile_helpers/usability_checker.py
+++ b/tools/python/util/mobile_helpers/usability_checker.py
@@ -513,11 +513,11 @@ def check_nnapi_partitions(model, require_fixed_input_sizes: bool):
     return _check_ep_partitioning(model, config_path, require_fixed_input_sizes)
 
 
-def check_coreml_partitions(model: onnx.ModelProto, require_fixed_input_sizes: bool, config_filename):
+def check_coreml_partitions(model: onnx.ModelProto, require_fixed_input_sizes: bool, config_filename: str):
     # if we're running in the ORT python package the file should be local. otherwise assume we're running from the
     # ORT repo
     script_dir = pathlib.Path(__file__).parent
-    local_config = script_dir / "coreml_supported_ops.md"
+    local_config = script_dir / config_filename
     if local_config.exists():
         config_path = local_config
     else:


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Fix usability checker CoreML config file path. The files got renamed but one place was still referring to the old name.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix issue found when running usability checker script.