### PR TITLE
Disable using symlinks in mac-catalyst package. 

### DIFF
--- a/tools/ci_build/github/apple/build_apple_framework.py
+++ b/tools/ci_build/github/apple/build_apple_framework.py
@@ -92,7 +92,13 @@ def _build_for_apple_sysroot(
 
     # macos requires different framework structure:
     # https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPFrameworks/Concepts/FrameworkAnatomy.html
-    if sysroot == "macosx" or sysroot == "macabi":
+    #
+    # We need to update the CI that builds the nuget package to be able to handle symlinks in the xcframework. That is
+    # non-trivial as it needs to move from running on Windows to running on Linux or macOS. Short term the mac-catalyst
+    # xcframework will have the incorrect structure.
+    #
+    # if sysroot == "macosx" or sysroot == "macabi":
+    if sysroot == "macosx":
         # create headers and resources directory
         header_dir = os.path.join(framework_dir, "Versions", "A", "Headers")
         resource_dir = os.path.join(framework_dir, "Versions", "A", "Resources")


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Disable creating the correct package structure for mac-catalyst temporarily. The CI needs significant updates to handle creating symlinks in a nuget package as it will need to run on macOS or Linux instead of Windows.

This will mean a MAUI app using mac-catalyst won't be able to publish to the Apple store until resolved. 

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Unblock building native nuget package

