### PR TITLE
Migrate stale bot workflow to updateStaleIssues.yml policy

### DIFF
--- a/.github/policies/updateStaleIssues.yml
+++ b/.github/policies/updateStaleIssues.yml
@@ -57,7 +57,7 @@ configuration:
           - payloadType: Issue_Comment
           - and:
               - not:
-                  - isOpen
+                  isOpen
               - hasLabel:
                   label: stale
         then:

--- a/.github/policies/updateStaleIssues.yml
+++ b/.github/policies/updateStaleIssues.yml
@@ -26,7 +26,7 @@ configuration:
           - addReply:
               reply: "Applying stale label due to no activity in 30 days"
           - addLabel:
-              reply: stale
+              label: stale
       - description: Close open, unassigned issues labeled stale that have not been updated in the last 30 days
         frequencies:
           - daily:

--- a/.github/policies/updateStaleIssues.yml
+++ b/.github/policies/updateStaleIssues.yml
@@ -1,0 +1,65 @@
+name: Update Stale Issues
+description: Update stale issues
+resource: repository
+configuration:
+  resourceManagementConfiguration:
+    scheduledSearches:
+      - description: Apply stale label to open, unassigned issues that have not been updated in the last 30 days
+        frequencies:
+          - daily:
+              time: 15:00
+        filters:
+          - isIssue
+          - isOpen
+          - isNotAssigned
+          - isNotLabeledWith:
+              label: contributions welcome
+          - isNotLabeledWith:
+              label: documentation
+          - isNotLabeledWith:
+              label: feature request
+          - isNotLabeledWith:
+              label: regression
+          - noActivitySince:
+              days: 30
+        actions:
+          - addReply:
+              reply: "Applying stale label due to no activity in 30 days"
+          - addLabel:
+              reply: stale
+      - description: Close open, unassigned issues labeled stale that have not been updated in the last 30 days
+        frequencies:
+          - daily:
+              time: 15:00
+        filters:
+          - hasLabel:
+              label: stale
+          - isIssue
+          - isOpen
+          - isNotAssigned
+          - noActivitySince:
+              days: 30
+        actions:
+          - addReply:
+              reply: "Closing issue due to no activity in 30 days"
+          - closeIssue
+    eventResponderTasks:
+      - description: Remove stale label if open stale issue is commented on
+        if:
+          - payloadType: Issue_Comment
+          - hasLabel:
+              label: stale
+        then:
+          - removeLabel:
+              label: stale
+      - description: Re-open stale issue if closed stale issue is commented on
+        if:
+          - payloadType: Issue_Comment
+          - and:
+              - not:
+                  - isOpen
+              - hasLabel:
+                  label: stale
+        then:
+          - reopenIssue
+      


### PR DESCRIPTION
Replace existing GitHub Actions workflow to update stale issues with updateStaleIssues.yml GitHub policy

Will disable existing workflow before merging this PR to confirm desired behavior and delete files associated with previous issue labeler if policy works as intended

May wait to merge until after ORT 1.19

### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


