### PR TITLE
[C# MauiModelTester] Fix icon name in Info.plist

### DIFF
--- a/csharp/tools/MauiModelTester/Platforms/iOS/Info.plist
+++ b/csharp/tools/MauiModelTester/Platforms/iOS/Info.plist
@@ -27,6 +27,6 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>XSAppIconAssets</key>
-	<string>Assets.xcassets/appicon.appiconset</string>
+	<string>Assets.xcassets/onnxruntime_icon.appiconset</string>
 </dict>
 </plist>


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Fix icon name in Info.plist. It now matches the icon at `csharp/tools/MauiModelTester/Resources/AppIcon/onnxruntime_icon.png`.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

See https://github.com/dotnet/maui/issues/14721#issuecomment-1628998369