### PR TITLE
[js/web] Update API for `ort.env.webgpu`

### DIFF
--- a/js/common/lib/env.ts
+++ b/js/common/lib/env.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import {env as envImpl} from './env-impl.js';
+import {TryGetTypeIfDeclared} from './type-helper.js';
 
 export declare namespace Env {
   export type WasmPathPrefix = string;
@@ -154,7 +155,7 @@ export declare namespace Env {
     /**
      * Set or get the profiling configuration.
      */
-    profiling?: {
+    profiling: {
       /**
        * Set or get the profiling mode.
        *
@@ -169,6 +170,9 @@ export declare namespace Env {
       ondata?: (data: WebGpuProfilingData) => void;
     };
     /**
+     * @deprecated Create your own GPUAdapter instance and set {@link adapter} property if you want to use an WebGPU
+     * adapter with specific power preference.
+     *
      * Set or get the power preference.
      *
      * Setting this property only has effect before the first WebGPU inference session is created. The value will be
@@ -180,6 +184,9 @@ export declare namespace Env {
      */
     powerPreference?: 'low-power'|'high-performance';
     /**
+     * @deprecated Create your own GPUAdapter instance and set property {@link adapter} if you want to use an WebGPU
+     * adapter with force fallback adapter.
+     *
      * Set or get the force fallback adapter flag.
      *
      * Setting this property only has effect before the first WebGPU inference session is created. The value will be
@@ -191,31 +198,42 @@ export declare namespace Env {
      */
     forceFallbackAdapter?: boolean;
     /**
-     * Set or get the adapter for WebGPU.
+     * Set the GPU adapter for WebGPU. The value will be used for the underlying WebGPU backend to create GPU device.
      *
-     * Setting this property only has effect before the first WebGPU inference session is created. The value will be
-     * used as the GPU adapter for the underlying WebGPU backend to create GPU device.
+     * Setting this property only has effect before either property {@link device} has been accessed or the first WebGPU
+     * inference session is created.
      *
-     * If this property is not set, it will be available to get after the first WebGPU inference session is created. The
-     * value will be the GPU adapter that created by the underlying WebGPU backend.
+     * When setting this property, the value should be a `GPUAdapter` object. If the value is not a `GPUAdapter` object,
+     * an error will be thrown.
      *
-     * When use with TypeScript, the type of this property is `GPUAdapter` defined in "@webgpu/types".
-     * Use `const adapter = env.webgpu.adapter as GPUAdapter;` in TypeScript to access this property with correct type.
-     *
-     * see comments on {@link Tensor.GpuBufferType}
+     * If this property is not set, the WebGPU backend will create a new GPU adapter just before creating the first
+     * WebGPU inference session.
      */
-    adapter: unknown;
+    set adapter(value: TryGetTypeIfDeclared<'GPUAdapter'>);
     /**
-     * Get the device for WebGPU.
+     * Set or get the GPU device for WebGPU.
      *
-     * This property is only available after the first WebGPU inference session is created.
+     * There are several scenarios of accessing this property:
+     * - Set a value before the first WebGPU inference session is created. The value will be used by the WebGPU backend
+     * to perform calculations. This operation can only be done once.
+     * - Set a value after the first WebGPU inference session is created. This operation is invalid and will cause an
+     * error to be thrown.
+     * - Get the value before the first WebGPU inference session is created. This will try to create a new GPUDevice
+     * instance. Use {@link adapter} if set or create a new GPU adapter to create a new GPU device. A `Promise` that
+     * resolves to a `GPUDevice` object will be returned. This operation can only be done once.
+     * - Get the value after the first WebGPU inference session is created. This will return a resolved `Promise` to the
+     * `GPUDevice` object used by the WebGPU backend. This operation can be done multiple times.
      *
-     * When use with TypeScript, the type of this property is `GPUDevice` defined in "@webgpu/types".
-     * Use `const device = env.webgpu.device as GPUDevice;` in TypeScript to access this property with correct type.
+     * When setting this property, the value should be a `GPUDevice` object. If the value is not a `GPUDevice` object,
+     * an error will be thrown.
      *
-     * see comments on {@link Tensor.GpuBufferType} for more details about why not use types defined in "@webgpu/types".
+     * When getting this property, the value will be a `Promise` that resolves to a `GPUDevice` object.
+     *
+     * If this property is neither set nor get, the WebGPU backend will create a new GPU device just before creating the
+     * first WebGPU inference session. You can still get the value after that.
      */
-    readonly device: unknown;
+    get device(): Promise<TryGetTypeIfDeclared<'GPUDevice'>>;
+    set device(value: TryGetTypeIfDeclared<'GPUDevice'>);
     /**
      * Set or get whether validate input content.
      *

--- a/js/common/lib/inference-session.ts
+++ b/js/common/lib/inference-session.ts
@@ -4,6 +4,7 @@
 import {InferenceSession as InferenceSessionImpl} from './inference-session-impl.js';
 import {OnnxModelOptions} from './onnx-model.js';
 import {OnnxValue, OnnxValueDataLocation} from './onnx-value.js';
+import {TryGetTypeIfDeclared} from './type-helper.js';
 
 /* eslint-disable @typescript-eslint/no-redeclare */
 
@@ -278,7 +279,7 @@ export declare namespace InferenceSession {
   export interface WebNNOptionsWithMLContext extends WebNNExecutionProviderName,
                                                      Omit<WebNNContextOptions, 'deviceType'>,
                                                      Required<Pick<WebNNContextOptions, 'deviceType'>> {
-    context: unknown /* MLContext */;
+    context: TryGetTypeIfDeclared<'MLContext'>;
   }
 
   /**
@@ -287,8 +288,8 @@ export declare namespace InferenceSession {
    * @see https://www.w3.org/TR/webnn/#dom-ml-createcontext-gpudevice
    */
   export interface WebNNOptionsWebGpu extends WebNNExecutionProviderName {
-    context: unknown /* MLContext */;
-    gpuDevice: unknown /* GPUDevice */;
+    context: TryGetTypeIfDeclared<'MLContext'>;
+    gpuDevice: TryGetTypeIfDeclared<'GPUDevice'>;
   }
 
   /**

--- a/js/common/lib/tensor.ts
+++ b/js/common/lib/tensor.ts
@@ -4,6 +4,7 @@
 import {TensorFactory} from './tensor-factory.js';
 import {Tensor as TensorImpl} from './tensor-impl.js';
 import {TypedTensorUtils} from './tensor-utils.js';
+import {TryGetTypeIfDeclared} from './type-helper.js';
 
 /* eslint-disable @typescript-eslint/no-redeclare */
 
@@ -120,17 +121,11 @@ export declare namespace Tensor {
    */
   export type TextureDataTypes = 'float32';
 
+  type GpuBufferTypeFallback = { size: number; mapState: 'unmapped' | 'pending' | 'mapped' };
   /**
    * type alias for WebGPU buffer
-   *
-   * The reason why we don't use type "GPUBuffer" defined in webgpu.d.ts from @webgpu/types is because "@webgpu/types"
-   * requires "@types/dom-webcodecs" as peer dependency when using TypeScript < v5.1 and its version need to be chosen
-   * carefully according to the TypeScript version being used. This means so far there is not a way to keep every
-   * TypeScript version happy. It turns out that we will easily broke users on some TypeScript version.
-   *
-   * for more info see https://github.com/gpuweb/types/issues/127
    */
-  export type GpuBufferType = {size: number; mapState: 'unmapped' | 'pending' | 'mapped'};
+  export type GpuBufferType = TryGetTypeIfDeclared<'GPUBuffer', GpuBufferTypeFallback>;
 
   /**
    * supported data types for constructing a tensor from a WebGPU buffer

--- a/js/common/lib/type-helper.ts
+++ b/js/common/lib/type-helper.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+/**
+ * A helper type to get certain types if they are declared in global scope.
+ *
+ * For example, if you installed "@webgpu/types" as a dev dependency, then `TryGetTypeIfDeclared<'GPUDevice'>` will
+ * be type `GPUDevice`, otherwise it will be type `unknown`.
+ *
+ *
+ * We don't want to introduce "@webgpu/types" as a dependency of this package because:
+ *
+ * (1) For JavaScript users, it's not needed. For TypeScript users, they can install it as dev dependency themselves.
+ *
+ * (2) because "@webgpu/types" requires "@types/dom-webcodecs" as peer dependency when using TypeScript < v5.1 and its
+ * version need to be chosen carefully according to the TypeScript version being used. This means so far there is not a
+ * way to keep every TypeScript version happy. It turns out that we will easily broke users on some TypeScript version.
+ *
+ * for more info see https://github.com/gpuweb/types/issues/127
+ *
+ * Update (2024-08-07): The reason (2) may be no longer valid. Most people should be using TypeScript >= 5.1 by now.
+ * However, we are still not sure whether introducing "@webgpu/types" as direct dependency is a good idea. We find this
+ * type helper is useful for TypeScript users.
+ *
+ * @ignore
+ */
+export type TryGetTypeIfDeclared<Name extends string, Fallback = unknown> =
+    typeof globalThis extends {[k in Name]: {prototype: infer T}} ? T : Fallback;


### PR DESCRIPTION
### Description

This PR is a replacement of #21553. It offers a new way for accessing the following:
- `ort.env.webgpu.adapter`:
  - change to set-only. There is no point to get the value of it.
- `ort.env.webgpu.device`:
  - set value of `GPUDevice` if user created it. Use at user's own risk.
  - get value of `Promise<GPUDevice>`. if not exist, create a new one. if exist return it.
- `ort.env.webgpu.powerPreference`:
  - deprecating. encouraging users to set `ort.env.webgpu.adapter` if necessary.
- `ort.env.webgpu.forceFallbackAdapter`:
  - deprecating. encouraging users to set `ort.env.webgpu.adapter` if necessary.

There is also a few TypeScript optimizations.


TODO: so far this PR is API only and in design review stage. After this stage, I will do the implementation.