### PR TITLE
Fix neural-speed ci failure

### DIFF
--- a/onnxruntime/contrib_ops/cpu/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/matmul_nbits.cc
@@ -105,17 +105,15 @@ class MatMulNBits final : public OpKernel {
     ORT_ENFORCE(nbits_ == 4,
                 "Only 4b quantization is supported for MatMulNBits op, additional bits support is planned.");
     const Tensor* tensor_zero_point = nullptr;
-    has_zp_input_ = info.TryGetConstantInput(3, &tensor_zero_point);
+    has_zp_input_ = info.TryGetConstantInput(InputIndex::zero_points, &tensor_zero_point);
 #ifdef ORT_NEURAL_SPEED
     const Tensor* tensor_B = nullptr;
     const Tensor* tensor_scale = nullptr;
-    const Tensor* tensor_zero_point = nullptr;
     bool B_constant = info.TryGetConstantInput(InputIndex::B, &tensor_B);
     bool scale_constant = info.TryGetConstantInput(InputIndex::scales, &tensor_scale);
-    bool zero_point_constant = info.TryGetConstantInput(InputIndex::zero_points, &tensor_zero_point);
     is_asym_ = zero_point_arg != nullptr;
     all_constant_ = B_constant && scale_constant;
-    all_constant_ = is_asym_ ? all_constant_ && zero_point_constant : all_constant_;
+    all_constant_ = is_asym_ ? all_constant_ && has_zp_input_ : all_constant_;
 #endif
   }
 


### PR DESCRIPTION
### Description
fix https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=1461029&view=logs&j=3565c00d-48fa-5c65-7ab9-a05e12e29ed0&t=e43fe03a-689e-5dc5-9ad5-9f116eba3e9d&l=6341



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


