### PR TITLE
[WebNN EP] Remove workaround for scalar

### DIFF
--- a/onnxruntime/core/providers/webnn/builders/model.cc
+++ b/onnxruntime/core/providers/webnn/builders/model.cc
@@ -142,10 +142,6 @@ Status Model::Predict(const InlinedHashMap<std::string, OnnxTensorData>& inputs,
   return Status::OK();
 }
 
-bool Model::IsScalarOutput(const std::string& output_name) const {
-  return Contains(scalar_outputs_, output_name);
-}
-
 const OnnxTensorInfo& Model::GetInputOutputInfo(const std::string& name) const {
   return input_output_info_.at(name);
 }

--- a/onnxruntime/core/providers/webnn/builders/model.h
+++ b/onnxruntime/core/providers/webnn/builders/model.h
@@ -34,8 +34,6 @@ class Model {
   onnxruntime::common::Status Predict(const InlinedHashMap<std::string, OnnxTensorData>& inputs,
                                       const InlinedHashMap<std::string, OnnxTensorData>& outputs);
 
-  bool IsScalarOutput(const std::string& output_name) const;
-
   // Mutex for exclusive lock to this model object.
   OrtMutex& GetMutex() { return mutex_; }
 
@@ -65,8 +63,6 @@ class Model {
   emscripten::val wnn_inputs_ = emscripten::val::object();
   emscripten::val wnn_outputs_ = emscripten::val::object();
 
-  InlinedHashSet<std::string> scalar_outputs_;
-
   std::vector<std::string> inputs_;
   std::vector<std::string> outputs_;
 
@@ -81,10 +77,6 @@ class Model {
 
   void SetInputOutputInfo(InlinedHashMap<std::string, OnnxTensorInfo>&& input_output_info) {
     input_output_info_ = std::move(input_output_info);
-  }
-
-  void SetScalarOutputs(InlinedHashSet<std::string>&& scalar_outputs) {
-    scalar_outputs_ = std::move(scalar_outputs);
   }
 
   void AllocateInputOutputBuffers();

--- a/onnxruntime/core/providers/webnn/builders/model_builder.h
+++ b/onnxruntime/core/providers/webnn/builders/model_builder.h
@@ -69,8 +69,8 @@ class ModelBuilder {
   InlinedHashMap<std::string, emscripten::val> wnn_operands_;
   std::vector<std::string> input_names_;
   std::vector<std::string> output_names_;
+  std::vector<std::vector<uint8_t>> unpacked_tensors_;
 
-  InlinedHashSet<std::string> scalar_outputs_;
   InlinedHashMap<std::string, OnnxTensorInfo> input_output_info_;
 
   InlinedHashSet<std::string> skipped_initializers_;
@@ -91,9 +91,6 @@ class ModelBuilder {
   Status RegisterModelInputs() ORT_MUST_USE_RESULT;
   Status RegisterModelOutputs() ORT_MUST_USE_RESULT;
   Status RegisterModelInputOutput(const NodeArg& node_arg, bool is_input) ORT_MUST_USE_RESULT;
-
-  // Record the onnx scalar output names.
-  void AddScalarOutput(const std::string& output_name);
 
   static const IOpBuilder* GetOpBuilder(const Node& node);
 };

--- a/onnxruntime/core/providers/webnn/webnn_execution_provider.cc
+++ b/onnxruntime/core/providers/webnn/webnn_execution_provider.cc
@@ -272,10 +272,6 @@ common::Status WebNNExecutionProvider::Compile(const std::vector<FusedNodeAndGra
         auto input_tensor = ctx.GetInput(input_idx);
         auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
         auto shape = tensor_info.GetShape();
-        // If we have an empty shape, this is a scalar input,
-        // Since all the input output of WebNN EP is MultiArray, we will make the scalar input as a {1} MultiArray.
-        if (shape.empty())
-          shape.push_back(1);
         const void* inputBuffer = const_cast<void*>(input_tensor.GetTensorRawData());
         inputs.emplace(
             input_name,
@@ -297,12 +293,6 @@ common::Status WebNNExecutionProvider::Compile(const std::vector<FusedNodeAndGra
           const auto& output_info = model->GetInputOutputInfo(output_name);
           auto output_shape = output_info.shape;
           auto output_type = output_info.data_type;
-
-          // Since WebNN EP use {1} tensor as scalar, if the model output should have empty shape.
-          // We are going to replace the {1} shape of the output back to {}.
-          if (model->IsScalarOutput(output_name))
-            output_shape.clear();
-
           auto output_tensor =
               ctx.GetOutput(i, output_shape.data(), output_shape.size());
 


### PR DESCRIPTION
Currently Chromium has supported scalar with dims = {}, remove legacy workaround for supporting scalar.