### PR TITLE
[Mobile] Move setting namespace to build.gradle 

### DIFF
--- a/js/react_native/android/build.gradle
+++ b/js/react_native/android/build.gradle
@@ -70,6 +70,7 @@ def REACT_NATIVE_VERSION = ['node', '--print', "JSON.parse(require('fs').readFil
 def REACT_NATIVE_MINOR_VERSION = REACT_NATIVE_VERSION.split("\\.")[1].toInteger()
 
 android {
+  namespace 'ai.onnxruntime.reactnative'
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
   defaultConfig {

--- a/js/react_native/android/src/main/AndroidManifest.xml
+++ b/js/react_native/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="ai.onnxruntime.reactnative">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
### Description
- Moves setting the namespace out of the AndroidManifest.xml to the build.gradle file

### Motivation and Context
- Resolves #21681 
- Setting namespace in AndroidManifest.xml isn't supported with gradle > 8.2


