### PR TITLE
Replace usage of jcenter in React Native build.gradle files

### DIFF
--- a/js/react_native/android/build.gradle
+++ b/js/react_native/android/build.gradle
@@ -145,7 +145,6 @@ android {
 
 repositories {
   mavenCentral()
-  jcenter()
   google()
 
   def found = false

--- a/js/react_native/android/build.gradle
+++ b/js/react_native/android/build.gradle
@@ -3,7 +3,7 @@ import java.nio.file.Paths
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 
   dependencies {

--- a/js/react_native/e2e/android/build.gradle
+++ b/js/react_native/e2e/android/build.gradle
@@ -37,7 +37,7 @@ allprojects {
         }
 
         google()
-        jcenter()
+        mavenCentral()
         maven { url 'https://www.jitpack.io' }
     }
 }

--- a/js/react_native/e2e/android/build.gradle
+++ b/js/react_native/e2e/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath('com.android.tools.build:gradle:7.1.1')
@@ -31,7 +31,7 @@ allprojects {
             // Android JSC is installed from npm
             url("$rootDir/../node_modules/jsc-android/dist")
         }
-        maven { 
+        maven {
           // Add Detox as a precompiled native dependency
           url("$rootDir/../node_modules/detox/Detox-android")
         }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Replace jcenter. It's deprecated and not responding.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Fix CIs

