### PR TITLE
build_aar_package.py - Check that executable is present before trying to copy it.

### DIFF
--- a/tools/ci_build/github/android/build_aar_package.py
+++ b/tools/ci_build/github/android/build_aar_package.py
@@ -120,9 +120,13 @@ def _build_aar(args):
         # copy executables for each abi, in case we want to publish those as well
         abi_exe_dir = os.path.join(exe_dir, abi)
         for exe_name in ["libonnxruntime.so", "onnxruntime_perf_test", "onnx_test_runner"]:
+            src_exe_path = os.path.join(abi_build_dir, build_config, exe_name)
+            if not os.path.exists(src_exe_path):
+                continue
+
             os.makedirs(abi_exe_dir, exist_ok=True)
-            target_exe_name = os.path.join(abi_exe_dir, exe_name)
-            shutil.copyfile(os.path.join(abi_build_dir, build_config, exe_name), target_exe_name)
+            dest_exe_path = os.path.join(abi_exe_dir, exe_name)
+            shutil.copyfile(src_exe_path, dest_exe_path)
 
         # we only need to define the header files path once
         if not header_files_path:

--- a/tools/ci_build/github/android/build_aar_package.py
+++ b/tools/ci_build/github/android/build_aar_package.py
@@ -118,6 +118,7 @@ def _build_aar(args):
             os.symlink(os.path.join(abi_build_dir, build_config, lib_name), target_lib_name)
 
         # copy executables for each abi, in case we want to publish those as well
+        # some of them might not exist, e.g., if we skip building the tests
         abi_exe_dir = os.path.join(exe_dir, abi)
         for exe_name in ["libonnxruntime.so", "onnxruntime_perf_test", "onnx_test_runner"]:
             src_exe_path = os.path.join(abi_build_dir, build_config, exe_name)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Check that executable is present before trying to copy it.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Accommodate builds where we skip building the test executables.