### PR TITLE
pin pytorch lightning version for training CI

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage2/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage2/requirements.txt
@@ -8,7 +8,7 @@ rsa==4.9
 tensorboard==2.13.0
 h5py
 wget
-pytorch-lightning
+pytorch-lightning==2.3.3
 deepspeed==0.9.0
 fairscale==0.4.6
 parameterized>=0.8.1


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Pins pytorch-lightning package to version 2.3.3 since version >=2.4.0 requires torch > 2.1.0 which is not compatible with cu118.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

ORT 1.19 Release Preparation
