### PR TITLE
Move Python Training CUDA 12.2 pipeline to another pool.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-cuda12.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-cuda12.yml
@@ -13,4 +13,4 @@ stages:
     agent_pool: Onnxruntime-Linux-GPU
     upload_wheel: 'yes'
     debug_build: false
-    build_pool_name: 'onnxruntime-Ubuntu2204-AMD-CPU'
+    build_pool_name: 'onnxruntime-Ubuntu-2204-Training-CPU'

--- a/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-cuda12.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-cuda12.yml
@@ -13,4 +13,4 @@ stages:
     agent_pool: Onnxruntime-Linux-GPU
     upload_wheel: 'yes'
     debug_build: false
-    build_pool_name: 'onnxruntime-Ubuntu-2204-Training-CPU'
+    build_pool_name: 'onnxruntime-Ubuntu2204-AMD-CPU'

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-training-cuda-stage-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-training-cuda-stage-steps.yml
@@ -66,7 +66,7 @@ stages:
               --build-arg OPSET_VERSION=${{ parameters.opset_version }}
               --build-arg PYTHON_VERSION=${{ parameters.python_version }}
               --build-arg INSTALL_DEPS_EXTRA_ARGS=-tu
-              --build-arg BUILD_UID=$(id -u)              
+              --build-arg BUILD_UID=$(id -u)
             Repository: $(Repository)
 
         - task: CmdLine@2
@@ -173,14 +173,12 @@ stages:
           parameters:
             Dockerfile: tools/ci_build/github/linux/docker/${{ parameters.docker_file }}
             Context: tools/ci_build/github/linux/docker
-            UpdateDepsTxt: false
             DockerBuildArgs: >-
               --build-arg TORCH_VERSION=${{ parameters.torch_version }}
               --build-arg OPSET_VERSION=${{ parameters.opset_version }}
               --build-arg PYTHON_VERSION=${{ parameters.python_version }}
               --build-arg INSTALL_DEPS_EXTRA_ARGS=-tu
               --build-arg BUILD_UID=$(id -u)
-              --network=host
             Repository: $(Repository)
 
         - task: CmdLine@2


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->



### Motivation and Context
 [Python Training CUDA 12.2 pipeline](https://dev.azure.com/aiinfra/Lotus/_build?definitionId=1308&_a=summary) has been always cancelled by remote provider since Aug 2nd.
But other workflows with the same pool haven't this issue.
 It looks like there're some weird things in Azure devops.
 It works by using another pool. In fact, the SKU is smaller than the old.

### Verification
https://dev.azure.com/aiinfra/Lotus/_build?definitionId=1308&_a=summary


