### PR TITLE
Exclude cudnn 8 DLLs from manylinux package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -208,6 +208,12 @@ try:
                     "libcufft.so.10",
                     "libcufft.so.11",
                     "libcurand.so.10",
+                    "libcudnn_adv_infer.so.8",
+                    "libcudnn_adv_train.so.8",
+                    "libcudnn_cnn_infer.so.8",
+                    "libcudnn_cnn_train.so.8",
+                    "libcudnn_ops_infer.so.8",
+                    "libcudnn_ops_train.so.8",
                     "libcudnn_adv.so.9",
                     "libcudnn_cnn.so.9",
                     "libcudnn_engines_precompiled.so.9",
@@ -216,9 +222,12 @@ try:
                     "libcudnn_heuristic.so.9",
                     "libcudnn_ops.so.9",
                     "libnvJitLink.so.12",
+                    "libnvrtc.so.11",
                     "libnvrtc.so.12",
+                    "libnvrtc-builtins.so.11",
                     "libnvrtc-builtins.so.12",
                 ]
+
                 rocm_dependencies = [
                     "libamd_comgr.so.2",
                     "libamdhip64.so.5",


### PR DESCRIPTION
### Description
It is a follow up of https://github.com/microsoft/onnxruntime/pull/21738 to exclude cudnn 8 DLLs since some python packaging pipelines (like training package) are still using cudnn 8.9 and cuda 11.8.

### Motivation and Context

Size of python package for training pipeline increases a lot due to some DLLs are added to package:
![image](https://github.com/user-attachments/assets/643a808e-760b-4382-ba55-57d7d722ee9a)

