### PR TITLE
[js/webgpu] Support Chrome Canary in unit tests

### DIFF
--- a/js/web/script/test-runner-cli-args.ts
+++ b/js/web/script/test-runner-cli-args.ts
@@ -131,7 +131,7 @@ Examples:
 export declare namespace TestRunnerCliArgs {
   type Mode = 'suite0' | 'suite1' | 'model' | 'unittest' | 'op';
   type Backend = 'cpu' | 'webgl' | 'webgpu' | 'wasm' | 'onnxruntime' | 'webnn';
-  type Environment = 'chrome' | 'edge' | 'firefox' | 'electron' | 'safari' | 'node' | 'bs';
+  type Environment = 'chrome' | 'chromecanary' | 'edge' | 'firefox' | 'electron' | 'safari' | 'node' | 'bs';
   type BundleMode = 'dev' | 'perf';
   type IOBindingMode = 'none' | 'gpu-tensor' | 'gpu-location';
 }
@@ -385,7 +385,7 @@ export function parseTestRunnerCliArgs(cmdlineArgs: string[]): TestRunnerCliArgs
   // Option: -e=<...>, --env=<...>
   const envArg = args.env || args.e;
   const env = typeof envArg !== 'string' ? 'chrome' : envArg;
-  if (['chrome', 'edge', 'firefox', 'electron', 'safari', 'node', 'bs'].indexOf(env) === -1) {
+  if (['chrome', 'chromecanary', 'edge', 'firefox', 'electron', 'safari', 'node', 'bs'].indexOf(env) === -1) {
     throw new Error(`not supported env ${env}`);
   }
 

--- a/js/web/script/test-runner-cli.ts
+++ b/js/web/script/test-runner-cli.ts
@@ -708,6 +708,8 @@ async function main() {
     switch (env) {
       case 'chrome':
         return 'ChromeTest';
+      case 'chromecanary':
+        return 'ChromeCanaryTest';
       case 'edge':
         return 'EdgeTest';
       case 'firefox':


### PR DESCRIPTION
Chrome Canary is helpful to test some new features. With this PR, we can enable Chrome Canary in unit tests with command like "npm test -- op abs.jsonc -b=webgpu -e=chromecanary".



