### PR TITLE
Change to std::fill

### DIFF
--- a/onnxruntime/core/providers/cpu/math/matmul.cc
+++ b/onnxruntime/core/providers/cpu/math/matmul.cc
@@ -106,7 +106,8 @@ Status MatMul<T>::Compute(OpKernelContext* ctx) const {
   if (helper.K() == 0) {
     // When we have (M, 0, N) then the inputs are empty, but the output should
     // be filled out with zeros.
-    memset(y->MutableDataRaw(), 0, y->SizeInBytes());
+    auto output_span = y->MutableDataAsSpan<T>();
+    std::fill(output_span.begin(), output_span.end(), T{});
     return Status::OK();
   }
 


### PR DESCRIPTION
### Description
Replace `memset(0)` with `std::fill(T{})`. This would ensure that all the types are initialized in a portable way.

### Motivation and Context
Some platforms exhibit intermittent failures with NaN results.
Follow up to: https://github.com/microsoft/onnxruntime/pull/21525

Cc: @ranjitshs
