### PR TITLE
[Fix] Make python API doc generation in Microsoft-hosted Agent

### DIFF
--- a/.github/workflows/publish-python-apidocs.yml
+++ b/.github/workflows/publish-python-apidocs.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   build:
     name: Generate Python API docs
-    runs-on: ["self-hosted", "1ES.Pool=onnxruntime-github-ubuntu-CPU"]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install tools

--- a/.github/workflows/publish-python-apidocs.yml
+++ b/.github/workflows/publish-python-apidocs.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   build:
     name: Generate Python API docs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install tools

--- a/.github/workflows/publish-python-apidocs.yml
+++ b/.github/workflows/publish-python-apidocs.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   build:
     name: Generate Python API docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - name: Install tools

--- a/docs/python/requirements.txt
+++ b/docs/python/requirements.txt
@@ -2,7 +2,7 @@ autopep8
 matplotlib
 scikit-learn
 skl2onnx
-sphinx==5.3.0
+sphinx
 sphinx-gallery
 sphinxcontrib.imagesvg
 sphinxcontrib.googleanalytics

--- a/docs/python/requirements.txt
+++ b/docs/python/requirements.txt
@@ -13,7 +13,7 @@ pandas
 pydot
 coloredlogs
 flatbuffers
-numpy<=2.0.0
+numpy<2.0.0
 packaging
 protobuf
 sympy

--- a/docs/python/requirements.txt
+++ b/docs/python/requirements.txt
@@ -2,7 +2,7 @@ autopep8
 matplotlib
 scikit-learn
 skl2onnx
-sphinx
+sphinx==5.3.0
 sphinx-gallery
 sphinxcontrib.imagesvg
 sphinxcontrib.googleanalytics
@@ -13,7 +13,7 @@ pandas
 pydot
 coloredlogs
 flatbuffers
-numpy
+numpy<=2.0.0
 packaging
 protobuf
 sympy


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->



### Motivation and Context
1. Python API doc needs to be merged from a fork,  but 1ES self-hosted pool is only for one github repo.
2. ubuntu-latest will be install numpy above 2.0 by default, and current python API doc generation doesn't support it.
So I pin numpy < 2.0.0


