### PR TITLE
[java] Fix for OnnxTensor creation when passing in a ByteBuffer containing elements of a different type

### DIFF
--- a/java/src/test/java/ai/onnxruntime/OnnxTensorTest.java
+++ b/java/src/test/java/ai/onnxruntime/OnnxTensorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 package ai.onnxruntime;
@@ -215,6 +215,30 @@ public class OnnxTensorTest {
     long[] shape = new long[] {2};
     try (OnnxTensor t = OnnxTensor.createTensor(env, data, shape, OnnxJavaType.UINT8)) {
       Assertions.assertArrayEquals(buf, (byte[]) t.getValue());
+    }
+  }
+
+  @Test
+  public void testByteBufferCreation() throws OrtException {
+    OrtEnvironment env = OrtEnvironment.getEnvironment();
+    ByteBuffer byteBuf = ByteBuffer.allocateDirect(Float.BYTES * 5).order(ByteOrder.nativeOrder());
+    FloatBuffer floatBuf = byteBuf.asFloatBuffer();
+    floatBuf.put(1.0f);
+    floatBuf.put(2.0f);
+    floatBuf.put(3.0f);
+    floatBuf.put(4.0f);
+    floatBuf.put(5.0f);
+    floatBuf.position(1);
+    float[] expected = new float[floatBuf.remaining()];
+    floatBuf.get(expected);
+    floatBuf.position(1);
+    byteBuf.position(4);
+    try (OnnxTensor t =
+        OnnxTensor.createTensor(
+            env, byteBuf, new long[] {floatBuf.remaining()}, OnnxJavaType.FLOAT)) {
+      Assertions.assertNotNull(t);
+      float[] actual = (float[]) t.getValue();
+      Assertions.assertArrayEquals(expected, actual);
     }
   }
 


### PR DESCRIPTION
### Description
Fixes a bug where the buffer offset and position was incorrectly computed if the user supplied a `ByteBuffer` to `createTensor` but set the type of the tensor to something other than `INT8`. This would be more common if the user was trying to load the initializers from a serialized representation and didn't want to bother with the type information (which is the case in #21321).

### Motivation and Context
Partial fix for #21321. The remainder of the fix is to add a helper which allows users to load initializers out of an `onnx_data` file, but that will require adding protobuf as a dependency for the Java API to allow the parsing of an ONNX file separately from the native code. It might be nicer to put that functionality into ORT's C API so it can return the lengths & offsets of the initializers when provided with an ONNX file containing external initializers. We hit this kind of thing in Java more often than other languages as in Java models can be supplied as classpath resources which we can easily read, but not materialize on disk for the ORT native library to read.


