### PR TITLE
Swapping cuda 11 with cuda 12 in packing and publishing pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -121,7 +121,7 @@ stages:
   parameters:
       DoCompliance: ${{ parameters.DoCompliance }}
       CudaVersion: 12.2
-      docker_base_image: 'nvidia/cuda:12.2.2-cudnn8-devel-ubi8'
+      docker_base_image: onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntime/build/cuda12_x64_ubi8_gcc12:20240610.1
       RunOnnxRuntimeTests: ${{ parameters.RunOnnxRuntimeTests }}
       UseIncreasedTimeoutForTests: ${{ parameters.UseIncreasedTimeoutForTests }}
       win_trt_home: ${{ variables.win_trt_home }}

--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -80,12 +80,11 @@ variables:
 - name: ReleaseVersionSuffix
   value: ''
 - name: win_trt_version
-  value: 11.8
-
+  value: 12.2
 - name: win_trt_home
-  value: $(Agent.TempDirectory)\TensorRT-10.3.0.26.Windows10.x86_64.cuda-11.8
+  value: $(Agent.TempDirectory)\TensorRT-10.3.0.26.Windows10.x86_64.cuda-12.5
 - name: win_cuda_home
-  value: $(Agent.TempDirectory)\v11.8
+  value: $(Agent.TempDirectory)\v12.2
 
 stages:
 - template: stages/set_packaging_variables_stage.yml
@@ -114,15 +113,15 @@ stages:
 
 - template: stages/java-cuda-packaging-stage.yml
   parameters:
-    CudaVersion: 11.8
+    CudaVersion: 12.2
     SpecificArtifact: ${{ parameters.SpecificArtifact }}
     BuildId: ${{ parameters.BuildId }}
 
 - template: stages/nuget-combine-cuda-stage.yml
   parameters:
       DoCompliance: ${{ parameters.DoCompliance }}
-      CudaVersion: 11.8
-      docker_base_image: 'nvidia/cuda:11.8.0-cudnn8-devel-ubi8'
+      CudaVersion: 12.2
+      docker_base_image: 'nvidia/cuda:12.2.2-cudnn8-devel-ubi8'
       RunOnnxRuntimeTests: ${{ parameters.RunOnnxRuntimeTests }}
       UseIncreasedTimeoutForTests: ${{ parameters.UseIncreasedTimeoutForTests }}
       win_trt_home: ${{ variables.win_trt_home }}

--- a/tools/ci_build/github/azure-pipelines/cuda-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/cuda-packaging-pipeline.yml
@@ -67,7 +67,7 @@ variables:
     ${{ if eq(parameters.CudaVersion, '11.8') }}:
       value: nvidia/cuda:11.8.0-cudnn8-devel-ubi8
     ${{ if eq(parameters.CudaVersion, '12.2') }}:
-      value: nvidia/cuda:12.2.2-cudnn8-devel-ubi8
+      value: onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntime/build/cuda12_x64_ubi8_gcc12:20240610.1
   - name: win_trt_home
     ${{ if eq(parameters.CudaVersion, '11.8') }}:
       value: $(Agent.TempDirectory)\TensorRT-10.3.0.26.Windows10.x86_64.cuda-11.8

--- a/tools/ci_build/github/azure-pipelines/cuda-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/cuda-packaging-pipeline.yml
@@ -1,3 +1,5 @@
+#This is the packing pipeline to package the alternative cuda NuGet and java packages
+#The current alternative cuda version is 11.8
 parameters:
   - name: RunOnnxRuntimeTests
     displayName: Run Tests?

--- a/tools/ci_build/github/azure-pipelines/cuda-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/cuda-packaging-pipeline.yml
@@ -53,7 +53,7 @@ parameters:
   - name: CudaVersion
     displayName: CUDA version
     type: string
-    default: '12.2'
+    default: '11.8'
     values:
       - 11.8
       - 12.2

--- a/tools/ci_build/github/azure-pipelines/nuget-cuda-publishing-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget-cuda-publishing-pipeline.yml
@@ -1,4 +1,5 @@
 #This is the publishing pipeline to publish the alternative cuda NuGet packages to the Azure DevOps feed
+#This is not used for the publishing to the official feed
 #The current alternative cuda version is 11.8
 resources:
   pipelines:

--- a/tools/ci_build/github/azure-pipelines/nuget-cuda-publishing-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget-cuda-publishing-pipeline.yml
@@ -19,7 +19,7 @@ parameters:
 variables:
   - name: ArtifactFeed
     ${{ if eq(parameters.isReleaseBuild, false) }}:
-      value: rt-cuda-11-nightly
+      value: ort-cuda-11-nightly
     ${{ else }}:
       value: onnxruntime-cuda-11
 

--- a/tools/ci_build/github/azure-pipelines/nuget-cuda-publishing-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget-cuda-publishing-pipeline.yml
@@ -1,3 +1,5 @@
+#This is the publishing pipeline to publish the alternative cuda NuGet packages to the Azure DevOps feed
+#The current alternative cuda version is 11.8
 resources:
   pipelines:
   - pipeline: build
@@ -17,9 +19,9 @@ parameters:
 variables:
   - name: ArtifactFeed
     ${{ if eq(parameters.isReleaseBuild, false) }}:
-      value: ORT-Nightly
+      value: rt-cuda-11-nightly
     ${{ else }}:
-      value: onnxruntime-cuda-12
+      value: onnxruntime-cuda-11
 
 stages:
   - template: stages/nuget-cuda-publishing-stage.yml

--- a/tools/ci_build/github/azure-pipelines/publish-nuget.yml
+++ b/tools/ci_build/github/azure-pipelines/publish-nuget.yml
@@ -1,4 +1,5 @@
-#This is the publishing pipeline to publish the cpu nuget pacakge and default cuda NuGet packages to the Azure DevOps feed
+#This is the publishing pipeline to publish the cpu nuget package and default cuda NuGet packages to the Azure DevOps feed
+#This is not used for the publishing to the official feed
 #The current default cuda version is 12.2
 resources:
   pipelines:
@@ -34,7 +35,7 @@ stages:
           artifact: 'drop-signed-nuget-dml'
         - script: move "$(Pipeline.Workspace)\build\drop-signed-nuget-dml\*" $(Build.BinariesDirectory)\nuget-artifact\final-package
 
-  # Publish CUDA 11 Nuget/Java pkgs to ADO feed
+  # Publish CUDA 12 Nuget/Java pkgs to ADO feed
   - template: stages/nuget-cuda-publishing-stage.yml
     parameters:
       artifact_feed: $(ArtifactFeed)

--- a/tools/ci_build/github/azure-pipelines/publish-nuget.yml
+++ b/tools/ci_build/github/azure-pipelines/publish-nuget.yml
@@ -1,3 +1,5 @@
+#This is the publishing pipeline to publish the cpu nuget pacakge and default cuda NuGet packages to the Azure DevOps feed
+#The current default cuda version is 12.2
 resources:
   pipelines:
   - pipeline: build
@@ -17,9 +19,9 @@ parameters:
 variables:
   - name: ArtifactFeed
     ${{ if eq(parameters.isReleaseBuild, false) }}:
-      value: ort-cuda-11-nightly
+      value: ORT-Nightly
     ${{ else }}:
-      value: onnxruntime-cuda-11
+      value: onnxruntime-cuda-12
 
 stages:
   - template: templates/publish-nuget-steps.yml


### PR DESCRIPTION
### Description
Since we are switch to cuda 12 as the default on official releases, we would need to swap all current packaging pipeline and publishing pipeline to set the cuda 12 as the default.


### Motivation and Context
This is needed for current 1.19 release.

