### PR TITLE
Fix warnings

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlRuntimeFusedGraphKernel.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlRuntimeFusedGraphKernel.cpp
@@ -170,11 +170,11 @@ namespace Dml
                 const uint32_t fusedNodeInputCount = gsl::narrow_cast<uint32_t>(m_indexedSubGraph->GetMetaDef()->inputs.size());
                 std::vector<DML_BUFFER_BINDING> initInputBindings(fusedNodeInputCount);
                 std::vector<uint8_t> isInputsUploadedByDmlEP(fusedNodeInputCount);
-                auto providerImpl = static_cast<const ExecutionProvider*>(Info().GetExecutionProvider())->GetImpl();
+                const ExecutionProviderImpl* cProviderImpl = static_cast<const ExecutionProvider*>(Info().GetExecutionProvider())->GetImpl();
 
                 // Convert partitionONNXGraph into DML EP GraphDesc
                 ComPtr<IDMLDevice> device;
-                ORT_THROW_IF_FAILED(providerImpl->GetDmlDevice(device.GetAddressOf()));
+                ORT_THROW_IF_FAILED(cProviderImpl->GetDmlDevice(device.GetAddressOf()));
                 // This map will be used to transfer the initializer to D3D12 system heap memory.
                 // 'serializedDmlGraphDesc' will have constant input as intermediate edges, that's why
                 // we need a mapping between intermediateEdgeIndex and indexedSubGraph's (a given partition)
@@ -192,7 +192,7 @@ namespace Dml
                     isInputsUploadedByDmlEP.size(),
                     m_isInitializerTransferable,
                     m_partitionNodePropsMap,
-                    providerImpl,
+                    cProviderImpl,
                     m_modelPath,
                     m_subgraphNodePointers,
                     m_subgraphInputs,
@@ -220,7 +220,7 @@ namespace Dml
                 m_compiledExecutionPlanOperator = DmlGraphFusionHelper::TryCreateCompiledOperator(
                     graphDesc,
                     *m_indexedSubGraph,
-                    providerImpl,
+                    cProviderImpl,
                     &serializedGraphInputIndexToSubgraphInputIndex,
                     &serializedGraphLargeConstantNameToSubgraphInputIndex);
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
@@ -991,7 +991,6 @@ namespace Dml
             srcDatas.push_back(srcAllocInfo->GetResource());
         }
 
-        const uint64_t srcOffset = 0;
         const auto srcState = D3D12_RESOURCE_STATE_UNORDERED_ACCESS; // GPU resources are always kept in UAV state
 
         // Performs a blocking call to synchronize and read back data from the GPU into the destination buffer

--- a/winml/adapter/winml_adapter_model.cpp
+++ b/winml/adapter/winml_adapter_model.cpp
@@ -1029,7 +1029,7 @@ ORT_API_STATUS_IMPL(
   }
 
   // add identity ops to rename all of the first model outputs to secondmodel inputs with prefix for each linkage
-  for (int i = 0; i < num_linkages; i++) {
+  for (size_t i = 0; i < num_linkages; i++) {
     auto op_output_name = second_model_prefix + *(input_names + i);
     const char* const op_output_name_const_str = op_output_name.c_str();
     std::string name = "IdentityTo";


### PR DESCRIPTION
### Description
Minor changes to resolve some warnings in ORT

### Motivation and Context
Binskim for WindowsAI (which consumes ORT) treats warnings as errors, and has hit these warnings.
As a security requirement, warnings like "signed/unsigned mismatch" must be resolved.


