### PR TITLE
Set default `op_types_to_quantize` as a list ["MatMul"] in matmul_4bits_quantizer.py

### DIFF
--- a/onnxruntime/python/tools/quantization/matmul_4bits_quantizer.py
+++ b/onnxruntime/python/tools/quantization/matmul_4bits_quantizer.py
@@ -1062,7 +1062,7 @@ set of 4b integers with a scaling factor and an optional offset.
     )
     parser.add_argument(
         "--op_types_to_quantize",
-        default="MatMul",
+        default=["MatMul"],
         type=str,
         nargs="+",
         choices=["MatMul", "Gather"],


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Set default `op_types_to_quantize` as a list ["MatMul"] in matmul_4bits_quantizer.py

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
When `nargs='+'` is used, it expects a `list` instead of a `string`. Therefore, the default `op_types_to_quantize "MatMul"` will cause `tuple(args.op_types_to_quantize)` to become `('M', 'a', 't', 'M', 'u', 'l')`, which is not expected.
