### PR TITLE
[MIGraphX EP Support]Remove default noopt for Migraphx EP in Benchmark.py

### DIFF
--- a/onnxruntime/python/tools/transformers/benchmark.py
+++ b/onnxruntime/python/tools/transformers/benchmark.py
@@ -135,15 +135,6 @@ def run_onnxruntime(
             )
             return results
 
-    if provider == "migraphx":
-        optimizer_info = OptimizerInfo.NOOPT
-        warm_up_repeat = 5
-        if "MIGraphXExecutionProvider" not in onnxruntime.get_available_providers():
-            logger.error(
-                "Please install onnxruntime-rocm package, and use a machine with GPU for testing gpu performance."
-            )
-            return results
-
     if optimizer_info == OptimizerInfo.NOOPT:
         logger.warning(
             f"OptimizerInfo is set to {optimizer_info}, graph optimizations specified in FusionOptions are not applied."


### PR DESCRIPTION
…ripts (#58)

### Description
<!-- Describe your changes. -->
Removes the heavy handed no opt for all MIGraphX using the benchmark.py scripts


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Finding this hurts performance if we remove all optimizations. Let the fine tuning occur at the script level instead of a blanket NoOPT being selected 

