### PR TITLE
Fix typo for react native pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/android-dump-logs-from-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/android-dump-logs-from-steps.yml
@@ -14,7 +14,7 @@ steps:
       else
         echo "Emulator is not running."
       fi
-  name: Determine if emulator is running
+  displayName: "Determine if emulator is running"
 
 - task: CmdLine@2
   inputs:

--- a/tools/ci_build/github/azure-pipelines/templates/android-dump-logs-from-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/android-dump-logs-from-steps.yml
@@ -6,7 +6,7 @@ parameters:
 
 steps:
 - task: CmdLine@2
-  input:
+  inputs:
     script: |
       if [ -f $(Build.BinariesDirectory)/emulator.pid ]; then
         echo "Emulator is running."


### PR DESCRIPTION
### Description
fix typo

### Motivation and Context
[RN pipeline failing](https://dev.azure.com/onnxruntime/onnxruntime/_build?definitionId=188&_a=summary) since #21578 with this error:
![image](https://github.com/user-attachments/assets/75e5b968-572f-42cc-9816-7940de464cfa)



