### PR TITLE
sign native dll with correct cert

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/win-esrp-dll.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-esrp-dll.yml
@@ -26,6 +26,38 @@ steps:
     AuthAKVName: 'buildkeyvault'
     AuthCertName: '53d54d02-SSL-AutoRotate'
     AuthSignCertName: '53d54d02-978d-4305-8572-583cf6711c4f'
+    signConfigType: inlineSignParams
+    inlineOperation: |
+      [
+        {
+          "keyCode": "CP-230012",
+          "operationSetCode": "SigntoolSign",
+          "parameters": [
+            {
+              "parameterName": "OpusName",
+              "parameterValue": "Microsoft"
+            },
+            {
+              "parameterName": "OpusInfo",
+              "parameterValue": "http://www.microsoft.com"
+            },
+            {
+              "parameterName": "PageHash",
+              "parameterValue": "/NPH"
+            },
+            {
+              "parameterName": "FileDigest",
+              "parameterValue": "/fd sha256"
+            },
+            {
+              "parameterName": "TimeStamp",
+              "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+            }
+          ],
+          "toolName": "signtool.exe",
+          "toolVersion": "6.2.9304.0"
+        }
+      ]
 
     FolderPath: ${{ parameters.FolderPath }}
     Pattern: ${{ parameters.Pattern }}


### PR DESCRIPTION
### Description
Fixed #21775



### Motivation and Context
The dlls should be signed with Keycode CP-230012.
The default is the test code sign.


