### PR TITLE
Enable C++20 in Windows build

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -40,7 +40,7 @@ include(FetchContent)
 include(CheckFunctionExists)
 
 # TODO: update this once all system adapt c++20
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" OR CMAKE_SYSTEM_NAME STREQUAL "Windows")
 set(CMAKE_CXX_STANDARD 20)
 else()
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Enable C++20 in Windows build.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


