### PR TITLE
Adding $(Build.SourcesDirectory)s to the  ignoreDirectories

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/component-governance-component-detection-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/component-governance-component-detection-steps.yml
@@ -7,7 +7,7 @@ parameters:
 steps:
 - ${{ if eq(variables['System.TeamProject'], 'Lotus') }}:
   - powershell: |
-      Remove-Item $(Build.BinariesDirectory)/* -Recurse -Force
+      Remove-Item $(Build.BinariesDirectory)\* -Recurse -Force
     displayName: 'Clean up build directory'
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
@@ -28,12 +28,12 @@ steps:
       # ignore onnxruntime-inference-examples directory. onnxruntime-inference-examples directory is used for inference examples, not for onnxruntime package
       # ignore BinariesDirectory. BinariesDirectory is used for build output, not for onnxruntime package
       ignoreDirectories:
-        '$(Build.Repository.LocalPath)/cmake/external/emsdk/upstream/emscripten/tests,
-        $(Build.Repository.LocalPath)/cmake/external/onnx/third_party/benchmark,
-        $(Build.Repository.LocalPath)/cmake/external/onnx/third_party/pybind11,
-        $(Build.Repository.LocalPath)/cmake/external/onnx/third_party/pybind11/tests,
-        $(Build.Repository.LocalPath)/cmake/external/onnxruntime-extensions,
-        $(Build.Repository.LocalPath)/js/react_native/e2e/node_modules,
-        $(Build.Repository.LocalPath)/js/node_modules,
-        $(Build.SourcesDirectory)/onnxruntime-inference-examples,
+        '$(Build.Repository.LocalPath)\cmake\external\emsdk\upstream\emscripten\tests,
+        $(Build.Repository.LocalPath)\cmake\external\onnx\third_party\benchmark,
+        $(Build.Repository.LocalPath)\cmake\external\onnx\third_party\pybind11,
+        $(Build.Repository.LocalPath)\cmake\external\onnx\third_party\pybind11\tests,
+        $(Build.Repository.LocalPath)\cmake\external\onnxruntime-extensions,
+        $(Build.Repository.LocalPath)\js\react_native\e2e\node_modules,
+        $(Build.Repository.LocalPath)\js\node_modules,
+        $(Build.SourcesDirectory)\onnxruntime-inference-examples,
         $(Build.BinariesDirectory)'

--- a/tools/ci_build/github/azure-pipelines/templates/component-governance-component-detection-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/component-governance-component-detection-steps.yml
@@ -7,7 +7,7 @@ parameters:
 steps:
 - ${{ if eq(variables['System.TeamProject'], 'Lotus') }}:
   - powershell: |
-      Remove-Item $(Build.BinariesDirectory)\* -Recurse -Force
+      Remove-Item $(Build.BinariesDirectory)/* -Recurse -Force
     displayName: 'Clean up build directory'
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
@@ -28,12 +28,20 @@ steps:
       # ignore onnxruntime-inference-examples directory. onnxruntime-inference-examples directory is used for inference examples, not for onnxruntime package
       # ignore BinariesDirectory. BinariesDirectory is used for build output, not for onnxruntime package
       ignoreDirectories:
-        '$(Build.Repository.LocalPath)\cmake\external\emsdk\upstream\emscripten\tests,
-        $(Build.Repository.LocalPath)\cmake\external\onnx\third_party\benchmark,
-        $(Build.Repository.LocalPath)\cmake\external\onnx\third_party\pybind11,
-        $(Build.Repository.LocalPath)\cmake\external\onnx\third_party\pybind11\tests,
-        $(Build.Repository.LocalPath)\cmake\external\onnxruntime-extensions,
-        $(Build.Repository.LocalPath)\js\react_native\e2e\node_modules,
-        $(Build.Repository.LocalPath)\js\node_modules,
-        $(Build.SourcesDirectory)\onnxruntime-inference-examples,
+        '$(Build.Repository.LocalPath)/cmake/external/emsdk/upstream/emscripten/tests,
+        $(Build.Repository.LocalPath)/cmake/external/onnx/third_party/benchmark,
+        $(Build.Repository.LocalPath)/cmake/external/onnx/third_party/pybind11,
+        $(Build.Repository.LocalPath)/cmake/external/onnx/third_party/pybind11/tests,
+        $(Build.Repository.LocalPath)/cmake/external/onnxruntime-extensions,
+        $(Build.Repository.LocalPath)/js/react_native/e2e/node_modules,
+        $(Build.Repository.LocalPath)/js/node_modules,
+        $(Build.Repository.LocalPath)/onnxruntime-inference-examples,
+        $(Build.SourcesDirectory)/cmake/external/emsdk/upstream/emscripten/tests,
+        $(Build.SourcesDirectory)/cmake/external/onnx/third_party/benchmark,
+        $(Build.SourcesDirectory)/cmake/external/onnx/third_party/pybind11,
+        $(Build.SourcesDirectory)/cmake/external/onnx/third_party/pybind11/tests,
+        $(Build.SourcesDirectory)/cmake/external/onnxruntime-extensions,
+        $(Build.SourcesDirectory)/js/react_native/e2e/node_modules,
+        $(Build.SourcesDirectory)/js/node_modules,
+        $(Build.SourcesDirectory)/onnxruntime-inference-examples,
         $(Build.BinariesDirectory)'


### PR DESCRIPTION
### Description
Copying all `$(Build.Repository.LocalPath)` directories under `$(Build.SourcesDirectory)` directories to the ignoreDirectories



### Motivation and Context
The purpise of this PR is to address issue from our Component Gov dashboard. Some of the previously defined ingored directory were still scanned because our pipelines have case where multiple repo and single repo are checked out, we need both `$(Build.SourcesDirectory)`, for the single scenario, and `$(Build.Repository.LocalPath)`, for the multiple repo scenario.

