### PR TITLE
Add dependent stages in nuget packaging pipelines

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -492,6 +492,9 @@ stages:
   - Linux_C_API_Packaging_CPU
   - Linux_C_API_Packaging_GPU
   - MacOS_C_API_Package_Publish
+  - Windows_Packaging_CPU_x86_${{ parameters.BuildVariant }}
+  - Windows_Packaging_CPU_x64_${{ parameters.BuildVariant }}
+  - Windows_Packaging_CPU_arm64_${{ parameters.BuildVariant }}
   condition: succeeded()
   jobs:
   - job: Nodejs_Packaging


### PR DESCRIPTION
### Description
Since the stage need to download drop-extra, it should add the dependencies



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


