### PR TITLE
Catch statement causing build failures for flavors with EHsc disabled

### DIFF
--- a/onnxruntime/core/platform/windows/logging/etw_sink.cc
+++ b/onnxruntime/core/platform/windows/logging/etw_sink.cc
@@ -151,22 +151,21 @@ EtwRegistrationManager::~EtwRegistrationManager() {
 EtwRegistrationManager::EtwRegistrationManager() {
 }
 
-void EtwRegistrationManager::LazyInitialize() try {
+void EtwRegistrationManager::LazyInitialize() {
   if (initialization_status_ == InitializationStatus::NotInitialized) {
     std::lock_guard<OrtMutex> lock(init_mutex_);
     if (initialization_status_ == InitializationStatus::NotInitialized) {  // Double-check locking pattern
       initialization_status_ = InitializationStatus::Initializing;
       etw_status_ = ::TraceLoggingRegisterEx(etw_provider_handle, ORT_TL_EtwEnableCallback, nullptr);
       if (FAILED(etw_status_)) {
+        initialization_status_ = InitializationStatus::Failed;
         ORT_THROW("ETW registration failed. Logging will be broken: " + std::to_string(etw_status_));
       }
       initialization_status_ = InitializationStatus::Initialized;
     }
   }
-} catch (...) {
-  initialization_status_ = InitializationStatus::Failed;
-  throw;
 }
+
 
 void EtwRegistrationManager::InvokeCallbacks(LPCGUID SourceId, ULONG IsEnabled, UCHAR Level, ULONGLONG MatchAnyKeyword,
                                              ULONGLONG MatchAllKeyword, PEVENT_FILTER_DESCRIPTOR FilterData,


### PR DESCRIPTION
### Description
Catch in etw_sink.cc is causing build failures for flavors with EHsc disabled.
Remove the catch and set the Failure state as a response the FAILED check.


### Motivation and Context
Catch in etw_sink.cc is causing build failures for flavors with EHsc disabled.

