### PR TITLE
[VitisAI] Translate all session configs into provider options with prefix

### DIFF
--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -2952,7 +2952,7 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider_VitisAI, _In_
     provider_options[provider_options_keys[i]] = provider_options_values[i];
   }
   // EP context related session config options.
-  for(const auto& option: options->value.config_options.configurations) {
+  for (const auto& option : options->value.config_options.configurations) {
     auto key = std::string("ort_session_config.") + option.first;
     const auto& value = option.second;
     provider_options[key] = value;

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -2953,7 +2953,7 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider_VitisAI, _In_
   }
   // EP context related session config options.
   for(const auto &option: options->value.config_options.configurations) {
-    auto key = std::string("ort_session_configuration.") + option.first;
+    auto key = std::string("ort_session_config.") + option.first;
     const auto& value = option.second;
     provider_options[key] = value;
   }

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -2952,9 +2952,11 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider_VitisAI, _In_
     provider_options[provider_options_keys[i]] = provider_options_values[i];
   }
   // EP context related session config options.
-  provider_options["ep_context_enable"] = options->value.config_options.GetConfigOrDefault(kOrtSessionOptionEpContextEnable, "0");
-  provider_options["ep_context_embed_mode"] = options->value.config_options.GetConfigOrDefault(kOrtSessionOptionEpContextEmbedMode, "1");
-  provider_options["ep_context_file_path"] = options->value.config_options.GetConfigOrDefault(kOrtSessionOptionEpContextFilePath, "");
+  for(const auto &option: options->value.config_options.configurations) {
+    auto key = std::string("ort_session_configuration.") + option.first;
+    const auto& value = option.second;
+    provider_options[key] = value;
+  }
 
   auto factory = onnxruntime::VitisAIProviderFactoryCreator::Create(provider_options);
   if (!factory) {

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -2952,7 +2952,7 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider_VitisAI, _In_
     provider_options[provider_options_keys[i]] = provider_options_values[i];
   }
   // EP context related session config options.
-  for(const auto &option: options->value.config_options.configurations) {
+  for(const auto& option: options->value.config_options.configurations) {
     auto key = std::string("ort_session_config.") + option.first;
     const auto& value = option.second;
     provider_options[key] = value;

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -1134,7 +1134,7 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
     if (it != provider_options_map.end()) {
       info = it->second;
     }
-    for(const auto &option: session_options.config_options.configurations) {
+    for (const auto& option : session_options.config_options.configurations) {
       auto key = std::string("ort_session_config.") + option.first;
       const auto& value = option.second;
       info[key] = value;

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -1134,9 +1134,11 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
     if (it != provider_options_map.end()) {
       info = it->second;
     }
-    info["ep_context_enable"] = session_options.config_options.GetConfigOrDefault(kOrtSessionOptionEpContextEnable, "0");
-    info["ep_context_embed_mode"] = session_options.config_options.GetConfigOrDefault(kOrtSessionOptionEpContextEmbedMode, "1");
-    info["ep_context_file_path"] = session_options.config_options.GetConfigOrDefault(kOrtSessionOptionEpContextFilePath, "");
+    for(const auto &option: options->value.config_options.configurations) {
+      auto key = std::string("ort_session_config.") + option.first;
+      const auto& value = option.second;
+      info[key] = value;
+    }
     return onnxruntime::VitisAIProviderFactoryCreator::Create(info)->CreateProvider();
 #endif
   } else if (type == kAclExecutionProvider) {

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -1134,7 +1134,7 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
     if (it != provider_options_map.end()) {
       info = it->second;
     }
-    for(const auto &option: options->value.config_options.configurations) {
+    for(const auto &option: session_options.config_options.configurations) {
       auto key = std::string("ort_session_config.") + option.first;
       const auto& value = option.second;
       info[key] = value;


### PR DESCRIPTION
### Description
We need to translate all session configs into provider options, prefix with ort_session_config, so that we can pass ORT session options to VAIP 

### Motivation and Context
Based on this PR(https://github.com/microsoft/onnxruntime/pull/21781), we need to provide a comprehensive interface to handle both session_configs and provider_options together. To achieve this, we use prefixes on the onnxruntime side to differentiate between the two.



