### PR TITLE
Fix C# warnings.

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/DisposableNamedOnnxValue.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/DisposableNamedOnnxValue.shared.cs
@@ -83,7 +83,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// Ctor
         /// </summary>
         /// <param name="name">Name of the output value</param>
-        /// <param name="value">Managed object created to represent output value, such as DenseTensor<T>
+        /// <param name="value">Managed object created to represent output value, such as DenseTensor{T};
         /// List or Dictionary
         /// </param>
         /// <param name="elementType">Tensor element type if value type is a Tensor</param>
@@ -133,7 +133,7 @@ namespace Microsoft.ML.OnnxRuntime
         public TensorElementType ElementType { get; }
 
         /// <summary>
-        /// Overrides the base class method. With respect to pinnedMemoryHandle, it has no operation
+        /// Overrides the base class method. With respect to memoryHolder, it has no operation
         /// to do, as this class maintains a native buffer via _ortValueHolder and the memory will be
         /// disposed by it. This is the case when we are dealing with an OrtValue that is backed by native memory
         /// and not by pinned managed memory.
@@ -142,7 +142,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// but the interface (derived from NamedOnnxValue) allows it to be passed as output and one of the test
         /// cases does it. Unless we deprecate and re-do the interface, we must support it.
         /// </summary>
-        /// <param name="pinnedMemoryHandle">always set to null</param>
+        /// <param name="memoryHolder">always set to null</param>
         /// <returns>Native OrtValue handle</returns>
         internal override IntPtr InputToOrtValueHandle(NodeMetadata metadata, out IDisposable memoryHolder)
         {
@@ -150,7 +150,7 @@ namespace Microsoft.ML.OnnxRuntime
             {
                 throw new InvalidOperationException("The instance of this class does not own an OrtValue");
             }
-            // PinnedMemoryHandle holds the default value as DisposableNamedOnnxValue
+            // memoryHolder holds the default value as DisposableNamedOnnxValue
             // doesn't hold any managed buffer (that needs to be pinned)
             memoryHolder = null;
             // Return non-owning instance of OrtValue

--- a/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.shared.cs
@@ -908,7 +908,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// </summary>
         /// <param name="values">names to convert to zero terminated utf8 and pin</param>
         /// <param name="nameExtractor">extractor functor that helps extracting names from inputs</param>
-        /// <param name="metaDict">inputs/outputs metadata</param>
+        /// <param name="metaLookup">inputs/outputs metadata</param>
         /// <returns></returns>
         private static IntPtr[] LookupUtf8Names<T>(IReadOnlyCollection<T> values, NameExtractor<T> nameExtractor,
             MetadataLookup metaLookup)
@@ -1222,7 +1222,6 @@ namespace Microsoft.ML.OnnxRuntime
         /// Initializes the session object with a native session handle
         /// </summary>
         /// <param name="session">Value of a native session object</param>
-        /// <param name="options">Session options</param>
         private void InitWithSessionHandle(IntPtr session)
         {
             _nativeHandle = session;
@@ -2075,7 +2074,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// <summary>
         /// Custom metadata key/value pairs
         /// </summary>
-        /// <value>An instance of a Dictionary<string,string></value>
+        /// <value>An instance of a Dictionary{string,string}</value>
         public Dictionary<string, string> CustomMetadataMap
         {
             get

--- a/csharp/src/Microsoft.ML.OnnxRuntime/ManagedProjections.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/ManagedProjections.shared.cs
@@ -65,7 +65,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// The function creates OrtValue objects for each element of the sequence
         /// and then creates an OrtValue for the whole sequence.
         /// </summary>
-        /// <param name="namedOnnxValue">NamedOnnxValue containing a IEnumerable<NameOnnValue></param>
+        /// <param name="namedOnnxValue">NamedOnnxValue containing a IEnumerable{NamedOnnxValue}</param>
         /// <param name="metadata">sequence metadata</param>
         /// <returns>OrtValue that represents a sequence</returns>
         /// <exception cref="OnnxRuntimeException"></exception>

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NamedOnnxValue.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NamedOnnxValue.shared.cs
@@ -53,13 +53,13 @@ namespace Microsoft.ML.OnnxRuntime
     /// Other sequences and maps. Although the OnnxValueType is exposed,
     /// the caller is supposed to know the actual data type contained.
     /// 
-    /// The convention is that for tensors, it would contain a DenseTensor<T> instance or
-    /// anything derived from Tensor<T>.
+    /// The convention is that for tensors, it would contain a DenseTensor{T} instance or
+    /// anything derived from Tensor{T}.
     /// 
-    /// For sequences, it would contain a IList<T> where T is an instance of NamedOnnxValue that
+    /// For sequences, it would contain a IList{T} where T is an instance of NamedOnnxValue that
     /// would contain a tensor or another type.
     /// 
-    /// For Maps, it would contain a IDictionary<K, V> where K,V are primitive types or strings.
+    /// For Maps, it would contain a IDictionary{K, V} where K,V are primitive types or strings.
     /// 
     /// </summary>
     public class NamedOnnxValue
@@ -153,7 +153,7 @@ namespace Microsoft.ML.OnnxRuntime
         }
 
         /// <summary>
-        /// Instantiates NamedOnnxValue that contains IDictionary<K, V>
+        /// Instantiates NamedOnnxValue that contains IDictionary{K, V}
         /// </summary>
         /// <typeparam name="K">Keys type</typeparam>
         /// <typeparam name="V">Values type</typeparam>
@@ -225,7 +225,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// based on the pinned managed memory. The caller is responsible for Disposing
         /// both OrtValue and pinnedMemoryHandle
         /// </summary>
-        /// <param name="pinnedMemoryHandle">dispose after returned OrtValus is disposed</param>
+        /// <param name="memoryOwner">dispose after returned OrtValue is disposed</param>
         /// <returns>The native OrtValue handle</returns>
         internal virtual IntPtr InputToOrtValueHandle(NodeMetadata metadata, out IDisposable memoryOwner)
         {
@@ -272,12 +272,6 @@ namespace Microsoft.ML.OnnxRuntime
                 $" Use Run() overloads that return DisposableNamedOnnxValue to get access to all Onnx value types that may be returned as output.");
         }
 
-        /// <summary>
-        /// This method is used internally to feed dictionary keys
-        /// to create an OrtValue for map keys
-        /// </summary>
-        /// <typeparam name="K"></typeparam>
-        /// <returns>DenseTensor<K>"</returns>
         internal TensorBase GetDictionaryKeys()
         {
             if (ValueType != OnnxValueType.ONNX_TYPE_MAP)
@@ -289,11 +283,6 @@ namespace Microsoft.ML.OnnxRuntime
             return _mapHelper.Keys;
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <typeparam name="V"></typeparam>
-        /// <returns>DenseTensor<V>"</returns>
         internal TensorBase GetDictionaryValues()
         {
             if (ValueType != OnnxValueType.ONNX_TYPE_MAP)

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
@@ -1506,7 +1506,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// <summary>
         /// Destroy OrtIoBinding instance created by OrtCreateIoBinding
         /// </summary>
-        /// <param name="io_bidning">instance of OrtIoBinding</param>
+        /// <param name="io_binding">instance of OrtIoBinding</param>
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         public delegate void DOrtReleaseIoBinding(IntPtr /*(OrtIoBinding)*/ io_binding);
 
@@ -1516,7 +1516,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// Bind OrtValue to the model input with the specified name
         /// If binding with the specified name already exists, it will be replaced
         /// </summary>
-        /// <param name="io_bidning">instance of OrtIoBinding</param>
+        /// <param name="io_binding">instance of OrtIoBinding</param>
         /// <param name="name">model input name (utf-8)</param>
         /// <param name="ort_value">OrtValue that is used for input (may wrap arbitrary memory).
         ///      The param instance is copied internally so this argument may be released.
@@ -1544,7 +1544,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// Bind OrtValue to the model output with the specified name
         /// If binding with the specified name already exists, it will be replaced
         /// </summary>
-        /// <param name="io_bidning">instance of OrtIoBinding</param>
+        /// <param name="io_binding">instance of OrtIoBinding</param>
         /// <param name="name">model output name (utf-8)</param>
         /// <param name="ort_value">OrtValue that is used for output (may wrap arbitrary memory).
         ///      The param instance is copied internally so this argument may be released.
@@ -1605,7 +1605,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// The function returns output values after the model has been run with RunWithBinding()
         /// It returns a natively allocated buffer of OrtValue pointers. All of the OrtValues must be individually
         /// released after no longer needed. You may use OrtValue disposable class to wrap the native handle and properly dispose it
-        /// in connection with DisposableList<T>. All values are returned in the same order as they were bound.
+        /// in connection with DisposableList{T}. All values are returned in the same order as they were bound.
         /// The buffer that contains OrtValues must deallocated using the same allocator that was specified as an argument.
         /// You may use an instance OrtMemoryAllocation to properly dispose of the native memory.
         /// </summary>
@@ -1643,9 +1643,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// <summary>
         /// Provides element-level access into a tensor.
         /// </summary>
-        /// <param name="location_values">a pointer to an array of index values that specify an element's location in the tensor data blob</param>
-        /// <param name="location_values_count">length of location_values</param>
-        /// <param name="out">a pointer to the element specified by location_values</param>
+        /// <param name="io_binding">instance of OrtIoBinding</param>
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         public delegate void DOrtTensorAt(IntPtr /*(OrtIoBinding)*/ io_binding);
 
@@ -1656,10 +1654,11 @@ namespace Microsoft.ML.OnnxRuntime
         /// sharing between multiple sessions that use the same env instance.
         /// Lifetime of the created allocator will be valid for the duration of the environment.
         /// Returns an error if an allocator with the same OrtMemoryInfo is already registered.
+        /// </summary>
         /// <param name="env">Native OrtEnv instance</param>
         /// <param name="memInfo">Native OrtMemoryInfo instance</param>
         /// <param name="arenaCfg">Native OrtArenaCfg instance</param>
-        /// <retruns>A pointer to native ortStatus indicating success/failure</retruns>
+        /// <returns>A pointer to native ortStatus indicating success/failure</returns>
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         public delegate IntPtr /*(OrtStatus*)*/ DOrtCreateAndRegisterAllocator(IntPtr /*(OrtEnv*)*/ env,
                                                                                IntPtr /*(const OrtMemoryInfo*)*/ memInfo,
@@ -1890,7 +1889,7 @@ namespace Microsoft.ML.OnnxRuntime
         public static DOrtFillStringTensor OrtFillStringTensor;
 
         /// \param value A tensor created from OrtCreateTensor... function.
-        /// \param index The index of the entry in the tensor to resize. <summary>
+        /// \param index The index of the entry in the tensor to resize.
         /// \param length_in_bytes Length to resize the string to.
         /// \param buffer The resized buffer.
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeOnnxValueHelper.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeOnnxValueHelper.shared.cs
@@ -226,7 +226,7 @@ namespace Microsoft.ML.OnnxRuntime
         }
 
         /// <summary>
-        // Native allocation (UTF8-8 string length with terminating zero)
+        /// Native allocation (UTF8-8 string length with terminating zero)
         /// </summary>
         internal int Length { get; private set; }
 

--- a/csharp/src/Microsoft.ML.OnnxRuntime/OrtEnv.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OrtEnv.shared.cs
@@ -126,7 +126,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// <param name="severity"></param>
         /// <param name="category"></param>
         /// <param name="logid"></param>
-        /// <param name="code_location"></param>
+        /// <param name="codeLocation"></param>
         /// <param name="message"></param>
         private static void LoggingFunctionThunk(IntPtr param,
                 IntPtr severity,

--- a/csharp/src/Microsoft.ML.OnnxRuntime/OrtFloat16.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OrtFloat16.shared.cs
@@ -134,11 +134,11 @@ namespace Microsoft.ML.OnnxRuntime
         }
 
         /// <summary>
-        /// Creates float NaN with the given sign and fp16 significand shifted << 54
+        /// Creates float NaN with the given sign and fp16 significand shifted &lt;&lt; 54
         /// </summary>
         /// <param name="sign">true for negative</param>
         /// <param name="significand">should be shifted 54 bits left before calling the function
-        /// so only 8 bits of signidicand remains</param>
+        /// so only 8 bits of significand remains</param>
         /// <returns></returns>
         internal static float CreateSingleNaN(bool sign, ulong significand)
         {
@@ -416,12 +416,11 @@ namespace Microsoft.ML.OnnxRuntime
 
         /// <summary>
         /// Compares values of two Float16
-        /// 
         /// </summary>
         /// <param name="left">left hand side</param>
         /// <param name="right">right hand side</param>
         /// <returns>returns true if left is greater or equal than right according to IEEE</returns>
-        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther, TResult}.op_GreaterThanOrEqual(TSelf, TOther)" />
+        /// <inheritdoc />
         public static bool operator >=(Float16 left, Float16 right)
         {
             return right <= left;
@@ -492,7 +491,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// Determines whether the specified value is negative.
         /// </summary>
         /// <param name="value">Float16 instance</param>
-        /// <returns>true if the value is negative</returns></returns>
+        /// <returns>true if the value is negative</returns>
         public static bool IsNegative(Float16 value)
         {
             return (short)(value.value) < 0;
@@ -1115,7 +1114,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// Determines whether the specified value is negative.
         /// </summary>
         /// <param name="value">BFloat16 instance</param>
-        /// <returns>true if the value is negative</returns></returns>
+        /// <returns>true if the value is negative</returns>
         public static bool IsNegative(BFloat16 value)
         {
             return (short)(value.value) < 0;

--- a/csharp/src/Microsoft.ML.OnnxRuntime/ProviderOptions.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/ProviderOptions.shared.cs
@@ -318,9 +318,9 @@ namespace Microsoft.ML.OnnxRuntime
     }
 
     /// <summary>
-    /// CoreML flags for use with SessionOptions
+    /// CoreML flags for use with SessionOptions.
+    /// See https://github.com/microsoft/onnxruntime/blob/main/include/onnxruntime/core/providers/coreml/coreml_provider_factory.h
     /// </summary>
-    /// <see cref="https://github.com/microsoft/onnxruntime/blob/main/include/onnxruntime/core/providers/coreml/coreml_provider_factory.h"/>
     [Flags]
     public enum CoreMLFlags : uint
     {
@@ -332,9 +332,9 @@ namespace Microsoft.ML.OnnxRuntime
     }
 
     /// <summary>
-    /// NNAPI flags for use with SessionOptions
+    /// NNAPI flags for use with SessionOptions.
+    /// See https://github.com/microsoft/onnxruntime/blob/main/include/onnxruntime/core/providers/nnapi/nnapi_provider_factory.h
     /// </summary>
-    /// <see cref="https://github.com/microsoft/onnxruntime/blob/main/include/onnxruntime/core/providers/nnapi/nnapi_provider_factory.h"/>
     [Flags]
     public enum NnapiFlags
     {

--- a/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.shared.cs
@@ -768,8 +768,8 @@ namespace Microsoft.ML.OnnxRuntime
         private int _logVerbosityLevel = 0;
 
         /// <summary>
-        // Sets the number of threads used to parallelize the execution within nodes
-        // A value of 0 means ORT will pick a default
+        /// Sets the number of threads used to parallelize the execution within nodes
+        /// A value of 0 means ORT will pick a default
         /// </summary>
         /// <value>returns _intraOpNumThreads value</value>
         public int IntraOpNumThreads
@@ -787,9 +787,9 @@ namespace Microsoft.ML.OnnxRuntime
         private int _intraOpNumThreads = 0; // set to what is set in C++ SessionOptions by default;
 
         /// <summary>
-        // Sets the number of threads used to parallelize the execution of the graph (across nodes)
-        // If sequential execution is enabled this value is ignored
-        // A value of 0 means ORT will pick a default
+        /// Sets the number of threads used to parallelize the execution of the graph (across nodes)
+        /// If sequential execution is enabled this value is ignored
+        /// A value of 0 means ORT will pick a default
         /// </summary>
         /// <value>returns _interOpNumThreads value</value>
         public int InterOpNumThreads

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/InferenceTest.cs
@@ -255,7 +255,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             {
                 Assert.NotNull(session);
                 Assert.NotNull(session.InputMetadata);
-                Assert.Equal(1, session.InputMetadata.Count); // 1 input node
+                Assert.Single(session.InputMetadata); // 1 input node
                 Assert.True(session.InputMetadata.ContainsKey("data_0")); // input node name
                 Assert.Equal(typeof(float), session.InputMetadata["data_0"].ElementType);
                 Assert.True(session.InputMetadata["data_0"].IsTensor);
@@ -267,7 +267,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 }
 
                 Assert.NotNull(session.OutputMetadata);
-                Assert.Equal(1, session.OutputMetadata.Count); // 1 output node
+                Assert.Single(session.OutputMetadata); // 1 output node
                 Assert.True(session.OutputMetadata.ContainsKey("softmaxout_1")); // output node name
                 Assert.Equal(typeof(float), session.OutputMetadata["softmaxout_1"].ElementType);
                 Assert.True(session.OutputMetadata["softmaxout_1"].IsTensor);
@@ -614,7 +614,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             // validate the results
             foreach (var r in results)
             {
-                Assert.Equal(1, results.Count);
+                Assert.Single(results);
                 Assert.Equal("softmaxout_1", r.Name);
 
                 float[] expectedOutput = TestDataLoader.LoadTensorFromEmbeddedResource("bench.expected_out");
@@ -798,7 +798,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
         }
 
         [Fact(DisplayName = "TestMultiThreads")]
-        private void TestMultiThreads()
+        private async Task TestMultiThreads()
         {
             var numThreads = 10;
             var loop = 10;
@@ -824,7 +824,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                     }
                 }));
             };
-            Task.WaitAll(tasks);
+            await Task.WhenAll(tasks);
             session.Dispose();
         }
 
@@ -838,7 +838,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 Assert.True(session.InputMetadata.ContainsKey("Label"));
                 Assert.True(session.InputMetadata.ContainsKey("F2"));
 
-                Assert.Equal(1, session.OverridableInitializerMetadata.Count);
+                Assert.Single(session.OverridableInitializerMetadata);
                 Assert.True(session.OverridableInitializerMetadata.ContainsKey("F1"));
                 Assert.True(session.OverridableInitializerMetadata["F1"].IsTensor);
                 Assert.Equal(typeof(float), session.OverridableInitializerMetadata["F1"].ElementType);
@@ -886,7 +886,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 var outputs = session.OutputMetadata;
 
                 Assert.Equal(2, inputs.Count);
-                Assert.Equal(1, session.OutputMetadata.Count);
+                Assert.Single(session.OutputMetadata);
                 Assert.True(inputs.ContainsKey("A"));
                 Assert.True(inputs.ContainsKey("B"));
                 Assert.True(outputs.ContainsKey("C"));
@@ -1432,6 +1432,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 {
                     // first output is a tensor containing label
                     var outNode0 = outputs.ElementAtOrDefault(0);
+                    Assert.NotNull(outNode0);
                     Assert.Equal("label", outNode0.Name);
                     Assert.Equal(OnnxValueType.ONNX_TYPE_TENSOR, outNode0.ValueType);
                     Assert.Equal(Tensors.TensorElementType.Int64, outNode0.ElementType);
@@ -1446,6 +1447,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                     // second output is a sequence<map<int64, float>>
                     // try-cast to an sequence of NOV
                     var outNode1 = outputs.ElementAtOrDefault(1);
+                    Assert.NotNull(outNode1);
                     Assert.Equal("probabilities", outNode1.Name);
                     Assert.Equal(OnnxValueType.ONNX_TYPE_SEQUENCE, outNode1.ValueType);
 
@@ -1525,6 +1527,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 {
                     // first output is a tensor containing label
                     var outNode0 = outputs.ElementAtOrDefault(0);
+                    Assert.NotNull(outNode0);
                     Assert.Equal("label", outNode0.Name);
                     Assert.Equal(OnnxValueType.ONNX_TYPE_TENSOR, outNode0.ValueType);
                     Assert.Equal(TensorElementType.String, outNode0.ElementType);
@@ -1539,6 +1542,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                     // second output is a sequence<map<string, float>>
                     // try-cast to an sequence of NOV
                     var outNode1 = outputs.ElementAtOrDefault(1);
+                    Assert.NotNull(outNode1);
                     Assert.Equal("probabilities", outNode1.Name);
                     Assert.Equal(OnnxValueType.ONNX_TYPE_SEQUENCE, outNode1.ValueType);
 
@@ -1592,6 +1596,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                     // output is a sequence<tensors>
                     // try-cast to an sequence of NOV
                     var outNode = outputs.ElementAtOrDefault(0);
+                    Assert.NotNull(outNode);
                     Assert.Equal("output_sequence", outNode.Name);
                     Assert.Equal(OnnxValueType.ONNX_TYPE_SEQUENCE, outNode.ValueType);
 
@@ -2035,7 +2040,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
         }
 
         [Fact(DisplayName = "TestModelRunAsyncTask")]
-        private async void TestModelRunAsyncTask()
+        private async Task TestModelRunAsyncTask()
         {
             Float16[] inputData = { new Float16(15360), new Float16(16384), new Float16(16896), new Float16(17408), new Float16(17664) };
             long[] shape = { 1, 5 };
@@ -2070,7 +2075,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
         }
 
         [Fact(DisplayName = "TestModelRunAsyncTaskFail")]
-        private async void TestModelRunAsyncTaskFail()
+        private async Task TestModelRunAsyncTaskFail()
         {
             Float16[] inputData = { new Float16(15360), new Float16(16384), new Float16(16896), new Float16(17408), new Float16(17664) };
             long[] shape = { 1, 5 };

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/Microsoft.ML.OnnxRuntime.Tests.Common.csproj
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/Microsoft.ML.OnnxRuntime.Tests.Common.csproj
@@ -117,10 +117,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
     <PackageReference Include="Google.Protobuf" Version="3.21.12" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/OrtIoBindingAllocationTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/OrtIoBindingAllocationTest.cs
@@ -33,6 +33,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
         private readonly DisposableListTest<IDisposable> _dispList = new DisposableListTest<IDisposable>();
 
         private bool _disposed = false;
+        private OrtEnv _env = OrtEnv.Instance();
 
         public OrtIoBindingAllocationTests()
         {

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/Tensors/TensorTests.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/Tensors/TensorTests.cs
@@ -2220,7 +2220,9 @@ namespace Microsoft.ML.OnnxRuntime.Tensors.Tests
                 new[] { 0, 0, 1, 2, 3, 4, 5, 6 };
             Assert.Equal(expected, actual);
 
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
             Assert.Throws<ArgumentNullException>(() => tensorCollection.CopyTo(null, 0));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
             Assert.Throws<ArgumentException>(() => tensorCollection.CopyTo(new int[3, 4], 0));
             Assert.Throws<ArgumentException>(() => tensorCollection.CopyTo(new int[5], 0));
             Assert.Throws<ArgumentException>(() => tensorCollection.CopyTo(new int[6], 1));
@@ -2311,7 +2313,9 @@ namespace Microsoft.ML.OnnxRuntime.Tensors.Tests
                 new[] { 0, 0, 1, 2, 3, 4, 5, 6 };
             Assert.Equal(expected, actual);
 
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
             Assert.Throws<ArgumentNullException>(() => tensorCollection.CopyTo(null, 0));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
             Assert.Throws<ArgumentException>(() => tensorCollection.CopyTo(new int[5], 0));
             Assert.Throws<ArgumentException>(() => tensorCollection.CopyTo(new int[6], 1));
 

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Droid/Microsoft.ML.OnnxRuntime.Tests.Droid.csproj
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Droid/Microsoft.ML.OnnxRuntime.Tests.Droid.csproj
@@ -126,7 +126,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="xunit">
-      <Version>2.4.1</Version>
+      <Version>2.9.0</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.devices">
       <Version>2.5.25</Version>

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
@@ -42,7 +42,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             {
                 Assert.NotNull(session);
                 Assert.NotNull(session.InputMetadata);
-                Assert.Equal(1, session.InputMetadata.Count); // 1 input nodeMeta
+                Assert.Single(session.InputMetadata); // 1 input nodeMeta
                 Assert.True(session.InputMetadata.ContainsKey("data_0")); // input nodeMeta name
                 Assert.Equal(typeof(float), session.InputMetadata["data_0"].ElementType);
                 Assert.True(session.InputMetadata["data_0"].IsTensor);
@@ -54,7 +54,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 }
 
                 Assert.NotNull(session.OutputMetadata);
-                Assert.Equal(1, session.OutputMetadata.Count); // 1 output nodeMeta
+                Assert.Single(session.OutputMetadata); // 1 output nodeMeta
                 Assert.True(session.OutputMetadata.ContainsKey("softmaxout_1")); // output nodeMeta name
                 Assert.Equal(typeof(float), session.OutputMetadata["softmaxout_1"].ElementType);
                 Assert.True(session.OutputMetadata["softmaxout_1"].IsTensor);
@@ -665,7 +665,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                             }
                             break;
                         default:
-                            Assert.True(false, $"TestPreTrainedModels cannot handle Onnxtype: {outputValue.ValueType}");
+                            Assert.Fail($"TestPreTrainedModels cannot handle Onnxtype: {outputValue.ValueType}");
                             break;
                     }
                 }
@@ -720,7 +720,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                     }
                     else
                     {
-                        Assert.True(false, $"TestPreTrainedModels cannot handle Onnxtype: {outputMeta.OnnxValueType}");
+                        Assert.Fail($"TestPreTrainedModels cannot handle Onnxtype: {outputMeta.OnnxValueType}");
                     }
                 }
             }
@@ -843,7 +843,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                         }
                         break;
                     default:
-                        Assert.True(false, "VerifySequenceResults cannot handle Onnxtype: " + resultItem.ValueType.ToString());
+                        Assert.Fail("VerifySequenceResults cannot handle Onnxtype: " + resultItem.ValueType.ToString());
                         break;
                 }
                 Assert.Equal(resultItem.AsTensor<float>(), expectedItem.AsTensor<float>(), new FloatComparer());
@@ -897,7 +897,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                     Assert.Equal(expectedValue.AsTensor<string>(), result.AsTensor<string>(), new ExactComparer<string>());
                     break;
                 default:
-                    Assert.True(false, "TestPreTrainedModels does not yet support output of type: " + elementType.ToString());
+                    Assert.Fail("TestPreTrainedModels does not yet support output of type: " + elementType.ToString());
                     break;
             }
         }
@@ -937,7 +937,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                             }
                             break;
                         default:
-                            Assert.True(false, $"VerifySequenceResults cannot handle Onnxtype: {elementMeta.OnnxValueType}");
+                            Assert.Fail($"VerifySequenceResults cannot handle Onnxtype: {elementMeta.OnnxValueType}");
                             break;
                     }
                 }
@@ -1009,7 +1009,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                                                new BFloat16Comparer { tolerance = 2 });
                     break;
                 default:
-                    Assert.True(false, "VerifyTensorResults cannot handle ElementType: " + expectedElementType.ToString());
+                    Assert.Fail("VerifyTensorResults cannot handle ElementType: " + expectedElementType.ToString());
                     break;
             }
         }
@@ -1077,7 +1077,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                         Assert.Equal(result.GetStringTensorAsArray(), expectedValue.AsTensor<string>().ToArray(), new ExactComparer<string>());
                         break;
                     default:
-                        Assert.True(false, $"VerifyTensorResults cannot handle ElementType: { resultTypeShape.ElementDataType}");
+                        Assert.Fail($"VerifyTensorResults cannot handle ElementType: { resultTypeShape.ElementDataType}");
                         break;
                 }
             }

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp.csproj
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp.csproj
@@ -53,9 +53,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.Targets" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Update some testing dependencies.
Fix various warnings. Mainly around documentation (existing) and unit test usage (mainly resulting from xunit update). 

Invalid angle brackets for generics in documentation were changed to use curly braces based on https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/
> To refer to generic identifiers in code reference (cref) elements, you can use either the escape characters (for example, cref="List&lt;T&gt;") or braces (cref="List{T}"). As a special case, the compiler parses the braces as angle brackets to make the documentation comment less cumbersome to the author when referring to generic identifiers.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


