### PR TITLE
Stop VSCode appending file associations to settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,7 +22,5 @@
         "-build/include_subdir",
         "-runtime/references"
     ],
-    "files.associations": {
-        "span": "cpp"
-    }
+    "C_Cpp.autoAddFileAssociations": false
 }


### PR DESCRIPTION
### Description

If you open onnxruntime source code using VSCode with C/C++ extension, it's keeping adding file associations for C/C++ headers into this settings.json. This is annoying when staging/committing changes.

Add a configuration to disable this behavior.

see:
- https://stackoverflow.com/questions/65220185/how-to-stop-vs-code-to-keep-adding-standard-c-libraries-to-the-file-associatio
- https://github.com/microsoft/vscode-cpptools/issues/722#issuecomment-480329005
