### PR TITLE
Enable xnnpack ep works in current windows xnn ci

### DIFF
--- a/onnxruntime/test/providers/cpu/model_tests.cc
+++ b/onnxruntime/test/providers/cpu/model_tests.cc
@@ -425,6 +425,9 @@ static constexpr ORT_STRING_VIEW provider_name_acl = ORT_TSTR("acl");
 #ifdef USE_ARMNN
 static constexpr ORT_STRING_VIEW provider_name_armnn = ORT_TSTR("armnn");
 #endif
+#ifdef USE_XNNPACK
+static constexpr ORT_STRING_VIEW provider_name_xnnpack = ORT_TSTR("xnnpack");
+#endif
 static constexpr ORT_STRING_VIEW provider_name_dml = ORT_TSTR("dml");
 
 ::std::vector<::std::basic_string<ORTCHAR_T>> GetParameterStrings() {
@@ -471,6 +474,9 @@ static constexpr ORT_STRING_VIEW provider_name_dml = ORT_TSTR("dml");
 #endif
 #ifdef USE_DML
   provider_names[provider_name_dml] = {opset7, opset8, opset9, opset10, opset11, opset12, opset13, opset14, opset15, opset16, opset17, opset18};
+#endif
+#ifdef USE_XNNPACK
+  provider_names[provider_name_xnnpack] = {opset7, opset8, opset9, opset10, opset11, opset12, opset13, opset14, opset15, opset16, opset17, opset18};
 #endif
 
 #if defined(ENABLE_TRAINING_CORE) && defined(USE_CUDA)

--- a/onnxruntime/test/providers/cpu/model_tests.cc
+++ b/onnxruntime/test/providers/cpu/model_tests.cc
@@ -262,6 +262,11 @@ TEST_P(ModelTest, Run) {
         ASSERT_ORT_STATUS_OK(OrtSessionOptionsAppendExecutionProvider_ArmNN(ortso));
       }
 #endif
+#ifdef USE_XNNPACK
+      else if (provider_name == "xnnpack") {
+        ortso.AppendExecutionProvider("XNNPACK");
+      }
+#endif
       OrtSession* ort_session;
       OrtStatus* ort_st = OrtApis::CreateSession(*ort_env, model_path.c_str(), ortso, &ort_session);
       if (ort_st != nullptr) {
@@ -476,7 +481,7 @@ static constexpr ORT_STRING_VIEW provider_name_dml = ORT_TSTR("dml");
   provider_names[provider_name_dml] = {opset7, opset8, opset9, opset10, opset11, opset12, opset13, opset14, opset15, opset16, opset17, opset18};
 #endif
 #ifdef USE_XNNPACK
-  provider_names[provider_name_xnnpack] = {opset7, opset8, opset9, opset10, opset11, opset12, opset13, opset14, opset15, opset16, opset17, opset18};
+  provider_names[provider_name_xnnpack] = {opset12, opset13, opset14, opset15, opset16, opset17, opset18};
 #endif
 
 #if defined(ENABLE_TRAINING_CORE) && defined(USE_CUDA)


### PR DESCRIPTION
### Description
The EP wasn't added in session option in onnxruntime_test_all.



### Motivation and Context
After this PR
onnxruntime_test_all --gtest_filter=\*xnnpack\*maxpool\* can step into https://github.com/microsoft/onnxruntime/blob/8c5336449d2279c0394cc4a742d336d7f3bd4124/onnxruntime/core/providers/xnnpack/nn/max_pool.cc#L209


