### PR TITLE
Fixed a minor bug in layout transformation for Resize

### DIFF
--- a/onnxruntime/core/optimizer/layout_transformation/layout_transformation.cc
+++ b/onnxruntime/core/optimizer/layout_transformation/layout_transformation.cc
@@ -177,7 +177,11 @@ Status TransformLayoutForEP(Graph& graph, bool& modified, const IExecutionProvid
         for (size_t i = 2; i < node->Inputs().size(); i++) {
           auto constant = api_graph->GetConstant(node->Inputs()[i]);
           if (constant != nullptr && constant->Data().size() > 0) {
-            input_perms.push_back(&input_perm);
+            // Starting from opset version 18, 'scales' and 'sizes' can be 2D tensors.
+            // However, our current implementation only supports the transposition of 4D tensors.
+            if (constant->NumElements() == 4) {
+              input_perms.push_back(&input_perm);
+            }
           } else {
             // TODO: Fix inconsistency. We should Transpose the non-const inputs so that the result of our changes
             // is consistent - all layout specific inputs are in NHWC format when we're done.

--- a/onnxruntime/core/optimizer/layout_transformation/layout_transformation.cc
+++ b/onnxruntime/core/optimizer/layout_transformation/layout_transformation.cc
@@ -177,7 +177,7 @@ Status TransformLayoutForEP(Graph& graph, bool& modified, const IExecutionProvid
         for (size_t i = 2; i < node->Inputs().size(); i++) {
           auto constant = api_graph->GetConstant(node->Inputs()[i]);
           if (constant != nullptr && constant->Data().size() > 0) {
-            // Starting from opset version 18, 'scales' and 'sizes' can be 2D tensors.
+            // Starting from opset version 18, the 'scales' and 'sizes' can be any length up to the input rank.
             // However, our current implementation only supports the transposition of 4D tensors.
             if (constant->NumElements() == 4) {
               input_perms.push_back(&input_perm);


### PR DESCRIPTION
Since opset 18, 'scales' and 'sizes' constant inputs can be 2D tensors, transpose for 2D tensors are not supported at current implementation, fix it by only allowing 4D constant inputs.