### PR TITLE
compare the content of WEBGPU_BUFFER, not the address

### DIFF
--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -140,7 +140,7 @@ Status WebGpuContext::Run(const ComputeContext& context, const ProgramBase& prog
                 return tensor != nullptr &&
                        tensor->Location().mem_type == OrtMemType::OrtMemTypeDefault &&
                        tensor->Location().device.Type() == OrtDevice::GPU &&
-                       tensor->Location().name == WEBGPU_BUFFER;
+                       !strcmp(tensor->Location().name, WEBGPU_BUFFER);
               }),
               "All inputs must be tensors on WebGPU buffers.");
 
@@ -149,7 +149,7 @@ Status WebGpuContext::Run(const ComputeContext& context, const ProgramBase& prog
                 return tensor != nullptr &&
                        tensor->Location().mem_type == OrtMemType::OrtMemTypeDefault &&
                        tensor->Location().device.Type() == OrtDevice::GPU &&
-                       tensor->Location().name == WEBGPU_BUFFER;
+                       !strcmp(tensor->Location().name, WEBGPU_BUFFER);
               }),
               "All outputs must be tensors on WebGPU buffers.");
 #endif


### PR DESCRIPTION
On linux (not sure about windows) WEBGPU_BUFFER is defined in multiple object files and comparing the address is not sufficient - use strcmp.
onnxruntime uses strcmp for the most but there are some other places that compare against address which might make trouble if passed acrross object file boundary.
