### PR TITLE
fix more dml warnings

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionHelper.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionHelper.cpp
@@ -845,11 +845,11 @@ namespace DmlGraphFusionHelper
             .Provider(onnxruntime::kDmlExecutionProvider);
 
         // Force the CPU inputs to be allocated on the CPU
-        for (int i = 0; i < subGraphInputArgNames.size(); ++i)
+        for (size_t i = 0; i < subGraphInputArgNames.size(); ++i)
         {
             if (dynamicCpuInputMap.find(subGraphInputArgNames[i]) != dynamicCpuInputMap.end())
             {
-                builder.InputMemoryType(OrtMemTypeCPUInput, i);
+                builder.InputMemoryType(OrtMemTypeCPUInput, static_cast<int>(i));
             }
         }
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionHelper.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionHelper.cpp
@@ -368,7 +368,7 @@ namespace DmlGraphFusionHelper
 
                     DML_CONSTANT_DATA_GRAPH_NODE_DESC* constantNode = allocator.template Allocate<DML_CONSTANT_DATA_GRAPH_NODE_DESC>();
                     constantNode->Name = node.Name.data();
-                    constantNode->DataSize = constantData.dataSize;
+                    constantNode->DataSize = gsl::narrow_cast<size_t>(constantData.dataSize);
                     constantNode->Data = constantData.data;
                     dmlGraphNodes.push_back(DML_GRAPH_NODE_DESC{DML_GRAPH_NODE_TYPE_CONSTANT, constantNode});
                 }

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlRuntimeFusedGraphKernel.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlRuntimeFusedGraphKernel.cpp
@@ -122,7 +122,7 @@ namespace Dml
                     {
                         if (initializerIter->second.first->raw_data().length() == inputProto.raw_data().length())
                         {
-                            for (int i = 0; i < inputProto.raw_data().length(); ++i)
+                            for (size_t i = 0; i < inputProto.raw_data().length(); ++i)
                             {
                                 if (initializerIter->second.first->raw_data()[i] != inputProto.raw_data()[i])
                                 {

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphDescBuilder.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphDescBuilder.cpp
@@ -365,7 +365,7 @@ namespace Dml::GraphDescBuilder
             );
 
             ORT_THROW_HR_IF(E_UNEXPECTED, outputShapes.EdgeCount() != node.OutputDefs().size());
-            for (int i = 0; i < node.OutputDefs().size(); ++i)
+            for (size_t i = 0; i < node.OutputDefs().size(); ++i)
             {
                 inferredOutputShapes[node.OutputDefs()[i]->Name()] = outputShapes.GetShape(i);
             }

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphDescBuilder.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphDescBuilder.cpp
@@ -333,7 +333,7 @@ namespace Dml::GraphDescBuilder
             EdgeShapes inputShapesOverrides(node.InputDefs().size());
 
             // Override the input shapes with shapes that were previously inferred
-            for (int inputIndex = 0; inputIndex < node.InputDefs().size(); ++inputIndex)
+            for (size_t inputIndex = 0; inputIndex < node.InputDefs().size(); ++inputIndex)
             {
                 auto inputDef = node.InputDefs()[inputIndex];
 
@@ -344,7 +344,7 @@ namespace Dml::GraphDescBuilder
                 }
                 else if (inputDef->HasTensorOrScalarShape())
                 {
-                    for (int i = 0; i < inputDef->Shape()->dim_size(); ++i)
+                    for (size_t i = 0; i < inputDef->Shape()->dim_size(); ++i)
                     {
                         ORT_THROW_HR_IF(E_INVALIDARG, !inputDef->Shape()->dim(i).has_dim_value());
                         inputShapesOverrides.GetMutableShape(inputIndex).push_back(gsl::narrow_cast<uint32_t>(inputDef->Shape()->dim(i).dim_value()));

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphDescBuilder.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphDescBuilder.cpp
@@ -344,7 +344,8 @@ namespace Dml::GraphDescBuilder
                 }
                 else if (inputDef->HasTensorOrScalarShape())
                 {
-                    for (size_t i = 0; i < inputDef->Shape()->dim_size(); ++i)
+                    int dimSize = gsl::narrow_cast<int>(inputDef->Shape()->dim_size());
+                    for (int i = 0; i < dimSize; ++i)
                     {
                         ORT_THROW_HR_IF(E_INVALIDARG, !inputDef->Shape()->dim(i).has_dim_value());
                         inputShapesOverrides.GetMutableShape(inputIndex).push_back(gsl::narrow_cast<uint32_t>(inputDef->Shape()->dim(i).dim_value()));

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorResize.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorResize.cpp
@@ -60,7 +60,7 @@ void ComputePixelOffsetsAndScales(
     // Fill in all the input/output pixel offset for each axis,
     // and recompute the scale for certain modes.
 
-    for (uint64_t i = 0; i < rank; ++i)
+    for (uint32_t i = 0; i < rank; ++i)
     {
         float inputPixelOffset = 0;
         float outputPixelOffset = 0;

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.cpp
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.cpp
@@ -1150,10 +1150,10 @@ namespace OperatorHelper
         }
 
         uint32_t numAxes = gsl::narrow_cast<uint32_t>(axes.size());
-        for (int32_t i = 0; i < axes.size(); i++)
+        for (uint32_t i = 0; i < numAxes; i++)
         {
             auto xi_begin = padding[i];
-            auto xi_end = padding[i+axes.size()];
+            auto xi_end = padding[i+numAxes];
             m_startPadding[axes[i]] = xi_begin;
             m_endPadding[axes[i]] = xi_end;
         }

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.cpp
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.cpp
@@ -1888,7 +1888,7 @@ namespace OperatorHelper
         m_outputShape.resize(2 + m_imageShape.size());
         m_outputShape[0] = m_inputShape[0];                     // N
         m_outputShape[1] = m_inputShape[1] / blockShapeProduct; // C
-        for (int i = 2; i < m_outputShape.size(); i++)
+        for (size_t i = 2; i < m_outputShape.size(); i++)
         {
             m_outputShape[i] = m_imageShape[i - 2];
         };

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.cpp
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.cpp
@@ -1149,8 +1149,8 @@ namespace OperatorHelper
             HandleEmptyAxes(axes, inputShape, false);
         }
 
-        uint32_t numAxes = gsl::narrow_cast<uint32_t>(axes.size());
-        for (uint32_t i = 0; i < numAxes; i++)
+        size_t numAxes = axes.size();
+        for (size_t i = 0; i < numAxes; i++)
         {
             auto xi_begin = padding[i];
             auto xi_end = padding[i+numAxes];


### PR DESCRIPTION
### Description
Fixes more warnings in DML execution provider that lead to security issues in binskim


### Motivation and Context
OS components that include ORT must treat certain warnings as errors, and cannot disable critical compiler warnings 
https://github.com/microsoft/binskim/blob/main/src/BinSkim.Rules/PERules/BA2007.EnableCriticalCompilerWarnings.cs


