### PR TITLE
Fix C# doc generation workflow

### DIFF
--- a/.github/workflows/publish-csharp-apidocs.yml
+++ b/.github/workflows/publish-csharp-apidocs.yml
@@ -28,21 +28,25 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
+    - name: Install DocFX
+      run: |
+        dotnet tool update -g docfx
+    # NOTE: We need to restore Microsoft.ML.OnnxRuntime.csproj manually to set IncludeMobileTargets=false
+    # docfx doesn't seem to be able to do that properly resulting in build errors
     - name: Restore dependencies
-      run: dotnet restore csharp/ApiDocs/ApiDocs.csproj
-    - name: Download DocFX
       run: |
-        mkdir -p build/docfx
-        wget https://github.com/dotnet/docfx/releases/download/v${DOCFXVERSION}/docfx-linux-x64-v${DOCFXVERSION}.zip -O build/docfx/docfx.zip
-        unzip build/docfx/docfx.zip -d build/docfx
-    - name: Install NuGet
-      uses: nuget/setup-nuget@v2
-    - name: Build Documentation
+        dotnet restore csharp/ApiDocs/ApiDocs.csproj
+        dotnet restore /p:IncludeMobileTargets=false csharp/src/Microsoft.ML.OnnxRuntime/Microsoft.ML.OnnxRuntime.csproj
+    - name: docfx metadata
       run: |
-        build/docfx/docfx metadata csharp/ApiDocs/docfx.json
+        docfx metadata csharp/ApiDocs/docfx.json
+    - name: Build ApiDocs project
+      run: |
         dotnet build csharp/ApiDocs/ApiDocs.csproj --no-restore
-        build/docfx/docfx build csharp/ApiDocs/docfx.json
+    - name: docfx build
+      run: |
+        docfx build csharp/ApiDocs/docfx.json
     - name: Log source commit
       run: git rev-parse --short HEAD > csharp/ApiDocs/csharp/source-version.txt
     - name: Move C# docs into site

--- a/csharp/ApiDocs/docfx.json
+++ b/csharp/ApiDocs/docfx.json
@@ -12,11 +12,13 @@
       "dest": "api",
       "disableGitFeatures": false,
       "disableDefaultFilter": false,
+      "noRestore": true,
       "properties": {
         "AllowUnsafeBlocks": true,
-        "TargetFramework" : "net6.0",
-        "Nullable" : "enable",
+        "TargetFramework": "net8.0",
+        "Nullable": "enable",
         "LangVersion": "8.0",
+        "IncludeMobileTargets": "false",
         "EnableTrainingApis": "true"
       },
       "filter": "filterConfig.yml"


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Update docfx usage. 
  - The docfx cli is now a dotnet tool.
  - Split some commands up so it's easier to debug failures
- Update to .net8.
- Exclude mobile targets from build as the workloads aren't available and it doesn't change the generated documentation. 
  - The mobile specific APIs (e.g. enable CoreML EP) still exist in this case as we check in the implementation if it's valid to use them or not, so the workloads are not required to generate complete API documentation.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Fix doc gen.

