### PR TITLE
Update Android NDK version to 27.0.12077973.

### DIFF
--- a/tools/android_custom_build/Dockerfile
+++ b/tools/android_custom_build/Dockerfile
@@ -55,7 +55,7 @@ WORKDIR /workspace
 
 # install Android SDK and tools
 ENV ANDROID_HOME=~/android-sdk
-ENV NDK_VERSION=26.1.10909125
+ENV NDK_VERSION=27.0.12077973
 ENV ANDROID_NDK_HOME=${ANDROID_HOME}/ndk/${NDK_VERSION}
 
 RUN aria2c -q -d /tmp -o cmdline-tools.zip \

--- a/tools/ci_build/github/azure-pipelines/templates/use-android-ndk.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/use-android-ndk.yml
@@ -3,7 +3,7 @@
   parameters:
   - name: AndroidNdkVersion
     type: string
-    default: "26.1.10909125"  # LTS version
+    default: "27.0.12077973"  # LTS version
 
   steps:
   - bash: |


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Update Android NDK version to 27.0.12077973.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Upgrade to newer version. r26 will be unsupported soon.