### PR TITLE
[JS/WebGPU] Upgrade emsdk to 3.1.61

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,4 +7,4 @@
 [submodule "cmake/external/emsdk"]
 	path = cmake/external/emsdk
 	url = https://github.com/emscripten-core/emsdk.git
-	branch = 3.1.59
+	branch = 3.1.61

--- a/cgmanifests/generated/cgmanifest.json
+++ b/cgmanifests/generated/cgmanifest.json
@@ -6,7 +6,7 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "d52c46520124845b1e0e0525f2759299d840143f",
+          "commitHash": "ca7b40ae222a2d8763b6ac845388744b0e57cfb7",
           "repositoryUrl": "https://github.com/emscripten-core/emsdk.git"
         },
         "comments": "git submodule at cmake/external/emsdk"

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -464,7 +464,7 @@ def parse_arguments():
     # WebAssembly build
     parser.add_argument("--build_wasm", action="store_true", help="Build for WebAssembly")
     parser.add_argument("--build_wasm_static_lib", action="store_true", help="Build for WebAssembly static library")
-    parser.add_argument("--emsdk_version", default="3.1.59", help="Specify version of emsdk")
+    parser.add_argument("--emsdk_version", default="3.1.61", help="Specify version of emsdk")
 
     parser.add_argument("--enable_wasm_simd", action="store_true", help="Enable WebAssembly SIMD")
     parser.add_argument("--enable_wasm_threads", action="store_true", help="Enable WebAssembly multi-threads support")

--- a/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
@@ -93,15 +93,15 @@ jobs:
       - script: |
           set -ex
           cd '$(Build.SourcesDirectory)/cmake/external/emsdk'
-          ./emsdk install 3.1.59 ccache-git-emscripten-64bit
-          ./emsdk activate 3.1.59 ccache-git-emscripten-64bit
+          ./emsdk install 3.1.61 ccache-git-emscripten-64bit
+          ./emsdk activate 3.1.61 ccache-git-emscripten-64bit
         displayName: 'emsdk install and activate ccache for emscripten'
   - ${{if eq(parameters.WithCache, false)}}:
       - script: |
           set -ex
           cd '$(Build.SourcesDirectory)/cmake/external/emsdk'
-          ./emsdk install 3.1.59
-          ./emsdk activate 3.1.59
+          ./emsdk install 3.1.61
+          ./emsdk activate 3.1.61
         displayName: 'emsdk install and activate ccache for emscripten'
 
   - template: build-linux-wasm-step.yml


### PR DESCRIPTION
### Description
Upgrade emsdk from 3.1.59 to 3.1.61.



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
This upgrade is required to support wasm64.


