### PR TITLE
Fix DML packaging CIs

### DIFF
--- a/tools/ci_build/github/azure-pipelines/nuget/templates/dml-vs-2022.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/dml-vs-2022.yml
@@ -43,7 +43,6 @@ stages:
       buildDirectory: '$(Build.BinariesDirectory)'
       BuildCommand: ${{ parameters.BuildCommand }}
       OnnxRuntimeBuildDirectory: '$(Build.BinariesDirectory)'
-      DotNetExe: 'dotnet.exe'
       runCodesignValidationInjection: and(${{ parameters.DoNodejsPack }},${{ parameters. DoEsrp}}) #For the others, code sign is in a separated job
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
       ALLOW_RELEASED_ONNX_OPSET_ONLY: ${{ parameters.AllowReleasedOpsetOnly }}
@@ -209,7 +208,14 @@ stages:
             filename: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat'
             arguments: ${{ parameters.BuildArch }}
             modifyEnvironment: true
-        # Esrp signing
+
+        # Esrp signing. Requires older .net SDK currently (ESRP v5.1.1)
+        - task: UseDotNet@2
+          inputs:
+            version: 6.x
+          env:
+            PROCESSOR_ARCHITECTURE: ${{ parameters.BuildArch }}
+
         - template: ../../templates/win-esrp-dll.yml
           parameters:
             FolderPath: '$(Build.BinariesDirectory)\$(BuildConfig)\$(BuildConfig)'

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/dml-vs-2022.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/dml-vs-2022.yml
@@ -97,6 +97,13 @@ stages:
           modifyEnvironment: true
           workingFolder: '$(Build.BinariesDirectory)'
 
+      # need to set PROCESSOR_ARCHITECTURE so the x86 SDK is installed correctly
+      - task: UseDotNet@2
+        inputs:
+          version: 8.x
+        env:
+          PROCESSOR_ARCHITECTURE: ${{ parameters.BuildArch }}
+
       - task: PowerShell@2
         displayName: 'Install ONNX'
         inputs:


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
The DML CIs build native and C# as well as sign DLLs in the same CI. Some parts of that require .net 8 and some .net 6.
Update to use .net 8 in general, and revert to .net 6 for the signing.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Fix packaging pipeline.

