### PR TITLE
Use output variable from InstallAppleProvisioningProfile task to set provisioning profile UUID.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/stages/mac-ios-packaging-build-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/stages/mac-ios-packaging-build-stage.yml
@@ -104,8 +104,7 @@ stages:
         xcodeDeveloperDir: '/Applications/Xcode_${{ variables.xcodeVersion }}.app/Contents/Developer'
         signingOption: 'manual'
         signingIdentity: '$(APPLE_CERTIFICATE_SIGNING_IDENTITY)'
-        provisioningProfileName: 'temporary *'  # temporary name, change it back to the original below later
-        #provisioningProfileName: 'iOS Team Provisioning Profile'
+        provisioningProfileUuid: '$(APPLE_PROV_PROFILE_UUID)'
         args: '-derivedDataPath $(Build.BinariesDirectory)/app_center_test/apple_package_test/DerivedData'
         workingDirectory: '$(Build.BinariesDirectory)/app_center_test/apple_package_test/'
         useXcpretty: false  # xcpretty can hide useful error output so we will disable it


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Use output variable from InstallAppleProvisioningProfile task to set provisioning profile UUID. This is more flexible than hardcoding the provisioning profile name or UUID. The name shouldn't usually change but it is not guaranteed to remain constant.

Following the example here:
https://learn.microsoft.com/en-us/azure/devops/pipelines/apps/mobile/app-signing?view=azure-devops&tabs=yaml#reference-the-secure-files-in-the-xcode-or-xamarinios-build-task

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix pipeline for new provisioning profile and make it easier to maintain.