### PR TITLE
Add fusions for re-designed Phi-3 vision and Phi-3.5 vision ONNX models

### DIFF
--- a/onnxruntime/python/tools/transformers/fusion_gelu.py
+++ b/onnxruntime/python/tools/transformers/fusion_gelu.py
@@ -104,6 +104,7 @@ class FusionGelu(Fusion):
         fused_node.domain = "com.microsoft"
         self.nodes_to_add.append(fused_node)
         self.node_name_to_graph_name[fused_node.name] = self.this_graph_name
+        self.increase_counter("Gelu")
         return True
 
     def fuse_2(self, erf_node, input_name_to_nodes: Dict, output_name_to_node: Dict) -> Optional[bool]:
@@ -180,6 +181,7 @@ class FusionGelu(Fusion):
         fused_node.domain = "com.microsoft"
         self.nodes_to_add.append(fused_node)
         self.node_name_to_graph_name[fused_node.name] = self.this_graph_name
+        self.increase_counter("Gelu")
         return True
 
     def fuse_3(self, erf_node, input_name_to_nodes: Dict, output_name_to_node: Dict) -> Optional[bool]:
@@ -253,4 +255,5 @@ class FusionGelu(Fusion):
         fused_node.domain = "com.microsoft"
         self.nodes_to_add.append(fused_node)
         self.node_name_to_graph_name[fused_node.name] = self.this_graph_name
+        self.increase_counter("Gelu")
         return True

--- a/onnxruntime/python/tools/transformers/fusion_gelu.py
+++ b/onnxruntime/python/tools/transformers/fusion_gelu.py
@@ -98,7 +98,7 @@ class FusionGelu(Fusion):
             return
 
         self.nodes_to_remove.extend(subgraph_nodes)
-        fused_node = helper.make_node("Gelu", inputs=[subgraph_input], outputs=[subgraph_output])
+        fused_node = helper.make_node("Gelu", inputs=[subgraph_input], outputs=[subgraph_output], name=self.model.create_node_name("Gelu"))
         fused_node.domain = "com.microsoft"
         self.nodes_to_add.append(fused_node)
         self.node_name_to_graph_name[fused_node.name] = self.this_graph_name
@@ -172,7 +172,7 @@ class FusionGelu(Fusion):
             return
 
         self.nodes_to_remove.extend(subgraph_nodes)
-        fused_node = helper.make_node("Gelu", inputs=[root_node.output[0]], outputs=[mul.output[0]])
+        fused_node = helper.make_node("Gelu", inputs=[root_node.output[0]], outputs=[mul.output[0]], name=self.model.create_node_name("Gelu"))
         fused_node.domain = "com.microsoft"
         self.nodes_to_add.append(fused_node)
         self.node_name_to_graph_name[fused_node.name] = self.this_graph_name
@@ -243,7 +243,7 @@ class FusionGelu(Fusion):
             return
 
         self.nodes_to_remove.extend(subgraph_nodes)
-        fused_node = helper.make_node("Gelu", inputs=[root_node.output[0]], outputs=[last_mul.output[0]])
+        fused_node = helper.make_node("Gelu", inputs=[root_node.output[0]], outputs=[last_mul.output[0]], name=self.model.create_node_name("Gelu"))
         fused_node.domain = "com.microsoft"
         self.nodes_to_add.append(fused_node)
         self.node_name_to_graph_name[fused_node.name] = self.this_graph_name

--- a/onnxruntime/python/tools/transformers/fusion_gelu.py
+++ b/onnxruntime/python/tools/transformers/fusion_gelu.py
@@ -98,7 +98,9 @@ class FusionGelu(Fusion):
             return
 
         self.nodes_to_remove.extend(subgraph_nodes)
-        fused_node = helper.make_node("Gelu", inputs=[subgraph_input], outputs=[subgraph_output], name=self.model.create_node_name("Gelu"))
+        fused_node = helper.make_node(
+            "Gelu", inputs=[subgraph_input], outputs=[subgraph_output], name=self.model.create_node_name("Gelu")
+        )
         fused_node.domain = "com.microsoft"
         self.nodes_to_add.append(fused_node)
         self.node_name_to_graph_name[fused_node.name] = self.this_graph_name
@@ -172,7 +174,9 @@ class FusionGelu(Fusion):
             return
 
         self.nodes_to_remove.extend(subgraph_nodes)
-        fused_node = helper.make_node("Gelu", inputs=[root_node.output[0]], outputs=[mul.output[0]], name=self.model.create_node_name("Gelu"))
+        fused_node = helper.make_node(
+            "Gelu", inputs=[root_node.output[0]], outputs=[mul.output[0]], name=self.model.create_node_name("Gelu")
+        )
         fused_node.domain = "com.microsoft"
         self.nodes_to_add.append(fused_node)
         self.node_name_to_graph_name[fused_node.name] = self.this_graph_name
@@ -243,7 +247,9 @@ class FusionGelu(Fusion):
             return
 
         self.nodes_to_remove.extend(subgraph_nodes)
-        fused_node = helper.make_node("Gelu", inputs=[root_node.output[0]], outputs=[last_mul.output[0]], name=self.model.create_node_name("Gelu"))
+        fused_node = helper.make_node(
+            "Gelu", inputs=[root_node.output[0]], outputs=[last_mul.output[0]], name=self.model.create_node_name("Gelu")
+        )
         fused_node.domain = "com.microsoft"
         self.nodes_to_add.append(fused_node)
         self.node_name_to_graph_name[fused_node.name] = self.this_graph_name

--- a/onnxruntime/python/tools/transformers/fusion_skiplayernorm.py
+++ b/onnxruntime/python/tools/transformers/fusion_skiplayernorm.py
@@ -56,19 +56,6 @@ class FusionSkipLayerNormalization(Fusion):
         # Root Mean Square Layer Normalization
         simplified = node.op_type == "SimplifiedLayerNormalization"
 
-        if self.shape_infer_helper is not None:
-            # TODO(tianleiwu): support broadcasting Skip shape (1, sequence_length, hidden_size) or (sequence_length, hidden_size)
-            if not self.shape_infer_helper.compare_shape(add.input[0], add.input[1]):
-                logger.debug(
-                    "skip SkipLayerNormalization fusion since shape of inputs (%s, %s) are not same",
-                    add.input[0],
-                    add.input[1],
-                )
-                return
-        else:
-            logger.debug("skip SkipLayerNormalization fusion since symbolic shape inference failed")
-            return
-
         gather_path = self.model.match_parent_path(add, ["Gather"], [None])
         if gather_path is not None and self.model.find_graph_input(gather_path[0].input[1]) is None:
             if self.model.match_parent_path(gather_path[0], ["ConstantOfShape"], [1]) is None:

--- a/onnxruntime/python/tools/transformers/fusion_skiplayernorm.py
+++ b/onnxruntime/python/tools/transformers/fusion_skiplayernorm.py
@@ -24,14 +24,15 @@ class FusionSkipLayerNormalization(Fusion):
         model: OnnxModel,
         fused_op_type: str = "SkipLayerNormalization",
         search_op_types: str = "LayerNormalization",
+        shape_infer: bool = True,
     ):
         super().__init__(model, fused_op_type, search_op_types)
-        # Update shape inference is needed since other fusions might add new edge which does not have shape info yet.
-        self.shape_infer_helper = self.model.infer_runtime_shape({"batch_size": 4, "seq_len": 7}, update=True)
-
-        if self.shape_infer_helper is None:
-            # TODO(tianleiwu): support subgraph in shape inference or add broadcasting in SkipLayerNormalization op.
-            logger.warning("symbolic shape inference disabled or failed.")
+        if shape_infer:
+            # Update shape inference is needed since other fusions might add new edge which does not have shape info yet.
+            self.shape_infer_helper = self.model.infer_runtime_shape({"batch_size": 4, "seq_len": 7}, update=True)
+            if self.shape_infer_helper is None:
+                # TODO(tianleiwu): support subgraph in shape inference or add broadcasting in SkipLayerNormalization op.
+                logger.warning("symbolic shape inference disabled or failed.")
 
     def fuse(self, node, input_name_to_nodes, output_name_to_node):
         add = self.model.get_parent(node, 0, output_name_to_node)
@@ -55,6 +56,20 @@ class FusionSkipLayerNormalization(Fusion):
 
         # Root Mean Square Layer Normalization
         simplified = node.op_type == "SimplifiedLayerNormalization"
+
+        if hasattr(self, "shape_infer_helper"):
+            if self.shape_infer_helper is not None:
+                # TODO(tianleiwu): support broadcasting Skip shape (1, sequence_length, hidden_size) or (sequence_length, hidden_size)
+                if not self.shape_infer_helper.compare_shape(add.input[0], add.input[1]):
+                    logger.debug(
+                        "skip SkipLayerNormalization fusion since shape of inputs (%s, %s) are not same",
+                        add.input[0],
+                        add.input[1],
+                    )
+                    return
+            else:
+                logger.debug("skip SkipLayerNormalization fusion since symbolic shape inference failed")
+                return
 
         gather_path = self.model.match_parent_path(add, ["Gather"], [None])
         if gather_path is not None and self.model.find_graph_input(gather_path[0].input[1]) is None:

--- a/onnxruntime/python/tools/transformers/onnx_model.py
+++ b/onnxruntime/python/tools/transformers/onnx_model.py
@@ -967,10 +967,10 @@ class OnnxModel:
 
             # For graphs with subgraphs, add dangling outputs from parent graph nodes to list of outputs to keep
             for node in self.model.graph.node:
+                # TODO: This for-loop logic currently assumes that Loop/Scan/If nodes will not be
+                # pruned because their subgraphs are needed for computations. This might not be
+                # true in all cases.
                 if node in subgraph_nodes:
-                    # TODO: This logic currently assumes that Loop/Scan/If nodes will not be pruned
-                    # because their subgraphs are needed for computations. This might not be true in
-                    # all cases.
                     continue
 
                 # Check if node output is an input of a subgraph node and not an input to a node in the main graph

--- a/onnxruntime/python/tools/transformers/onnx_model.py
+++ b/onnxruntime/python/tools/transformers/onnx_model.py
@@ -908,7 +908,7 @@ class OnnxModel:
         if len(unused_nodes) > 0:
             logger.debug(f"Removed unused constant nodes: {len(unused_nodes)}")
 
-    def get_subgraph_nodes_and_inputs(self, ops_with_graph_attrs={"Loop", "Scan", "If"}):
+    def get_subgraph_nodes_and_inputs(self, ops_with_graph_attrs):
         """
         Get input names to all nodes in all subgraphs where subgraphs are
         graph attributes of a node in the main graph
@@ -948,7 +948,9 @@ class OnnxModel:
 
         if len(self.graphs()) > 1:
             # Get input names for all nodes in all subgraphs
-            subgraph_nodes, subgraph_nodes_inputs = self.get_subgraph_nodes_and_inputs()
+            subgraph_nodes, subgraph_nodes_inputs = self.get_subgraph_nodes_and_inputs(
+                ops_with_graph_attrs={"Loop", "Scan", "If"}
+            )
             if len(subgraph_nodes) == 0:
                 # TODO: support other ops such as `BeamSearch` that have subgraphs as op attributes
                 logger.debug("Skip prune_graph since graph has subgraph")

--- a/onnxruntime/python/tools/transformers/onnx_model.py
+++ b/onnxruntime/python/tools/transformers/onnx_model.py
@@ -912,6 +912,7 @@ class OnnxModel:
         """
         Get inputs to all nodes in all subgraphs of a node
         """
+        # Note: This function only handles one-level subgraphs of child nodes.
         subgraph_nodes_inputs = set()
         for attr in node.attribute:
             if attr.type == AttributeProto.GRAPH:

--- a/onnxruntime/python/tools/transformers/onnx_model_bert.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_bert.py
@@ -115,8 +115,8 @@ class BertOnnxModel(OnnxModel):
         fusion = FusionSimplifiedLayerNormalization(self)
         fusion.apply()
 
-    def fuse_skip_layer_norm(self):
-        fusion = FusionSkipLayerNormalization(self)
+    def fuse_skip_layer_norm(self, shape_infer):
+        fusion = FusionSkipLayerNormalization(self, shape_infer=shape_infer)
         fusion.apply()
 
     def fuse_skip_simplified_layer_norm(self):
@@ -344,7 +344,7 @@ class BertOnnxModel(OnnxModel):
         self.fuse_reshape()
 
         if (options is None) or options.enable_skip_layer_norm:
-            self.fuse_skip_layer_norm()
+            self.fuse_skip_layer_norm(options.enable_shape_inference)
             self.fuse_skip_simplified_layer_norm()
 
         if (options is None) or options.enable_rotary_embeddings:

--- a/onnxruntime/python/tools/transformers/onnx_model_bert.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_bert.py
@@ -115,7 +115,7 @@ class BertOnnxModel(OnnxModel):
         fusion = FusionSimplifiedLayerNormalization(self)
         fusion.apply()
 
-    def fuse_skip_layer_norm(self, shape_infer):
+    def fuse_skip_layer_norm(self, shape_infer=True):
         fusion = FusionSkipLayerNormalization(self, shape_infer=shape_infer)
         fusion.apply()
 

--- a/onnxruntime/python/tools/transformers/onnx_model_clip.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_clip.py
@@ -24,6 +24,7 @@ class ClipOnnxModel(BertOnnxModel):
         op_count = {}
         ops = [
             "Attention",
+            "Gelu",
             "LayerNormalization",
             "QuickGelu",
             "SkipLayerNormalization",


### PR DESCRIPTION
### Description
This PR adds the optimizer logic to fuse the newly designed exported ONNX models for Phi-3 vision and Phi-3.5 vision. 

### Motivation and Context
After the re-designed export of Phi-3 vision and Phi-3.5 vision, the ONNX models for the vision component and embedding component contain `If` and `Loop` ops to handle multi-image support.