### PR TITLE
[VitisAI] support run_options in vitisai EP end

### DIFF
--- a/onnxruntime/core/providers/vitisai/imp/global_api.cc
+++ b/onnxruntime/core/providers/vitisai/imp/global_api.cc
@@ -50,7 +50,7 @@ struct OrtVitisAIEpAPI {
       const std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>& eps,
       vaip_core::DllSafe<std::vector<Node*>>* ret_value) = nullptr;
   int (*vitisai_ep_on_run_start)(
-       const std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>& eps, const void* state,
+      const std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>& eps, const void* state,
       vaip_core::DllSafe<std::string> (*get_config_entry)(const void* state, const char* entry_name)) = nullptr;
   void Ensure() {
     if (handle_)

--- a/onnxruntime/core/providers/vitisai/imp/global_api.cc
+++ b/onnxruntime/core/providers/vitisai/imp/global_api.cc
@@ -110,7 +110,7 @@ std::optional<std::vector<Node*>> create_ep_context_nodes(
 }
 
 int vitisai_ep_on_run_start(
-    const std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>& eps, void* state,
+    const std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>& eps, const void* state,
     vaip_core::DllSafe<std::string> (*get_config_entry)(const void* state, const char* entry_name)) {
   if (s_library_vitisaiep.vitisai_ep_on_run_start) {
     return s_library_vitisaiep.vitisai_ep_on_run_start(eps, state, get_config_entry);

--- a/onnxruntime/core/providers/vitisai/include/vaip/global_api.h
+++ b/onnxruntime/core/providers/vitisai/include/vaip/global_api.h
@@ -16,3 +16,7 @@ std::shared_ptr<onnxruntime::KernelRegistry> get_kernel_registry_vitisaiep();
 const std::vector<OrtCustomOpDomain*>& get_domains_vitisaiep();
 std::optional<std::vector<onnxruntime::Node*>> create_ep_context_nodes(
     const std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>& eps);
+
+int vitisai_ep_on_run_start(
+    const std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>& eps, const void* state,
+    vaip_core::DllSafe<std::string> (*get_config_entry)(const void* state, const char* entry_name));

--- a/onnxruntime/core/providers/vitisai/vitisai_execution_provider.cc
+++ b/onnxruntime/core/providers/vitisai/vitisai_execution_provider.cc
@@ -97,4 +97,22 @@ common::Status VitisAIExecutionProvider::Compile(const std::vector<FusedNodeAndG
   return Status::OK();
 }
 
+common::Status VitisAIExecutionProvider::OnRunStart(const onnxruntime::RunOptions& run_options) {
+  InlinedVector<const Node*> ep_context_node_ptrs;
+  auto get_config_entry = [](const void* state, const char* entry_name) -> vaip_core::DllSafe<std::string> {
+    const onnxruntime::RunOptions& run_options = *static_cast<const onnxruntime::RunOptions*>(state);
+    auto ret = run_options.GetConfigOptions().GetConfigEntry(std::string(entry_name));
+    if (ret) {
+      return vaip_core::DllSafe<std::string>(new std::string(ret.value()));
+    } else {
+      return {};
+    };
+  };
+  auto error_code = vitisai_ep_on_run_start(**execution_providers_, (const void*)&run_options, get_config_entry);
+  if (error_code) {
+    return Status(onnxruntime::common::ONNXRUNTIME, onnxruntime::common::StatusCode::FAIL, std::to_string(error_code));
+  }
+  return Status::OK();
+}
+
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/vitisai/vitisai_execution_provider.h
+++ b/onnxruntime/core/providers/vitisai/vitisai_execution_provider.h
@@ -31,7 +31,7 @@ class VitisAIExecutionProvider : public IExecutionProvider {
                                                                 const IKernelLookup& /*kernel_lookup*/) const override;
 
   int GetDeviceId() const { return 0; }
-
+  common::Status OnRunStart(const onnxruntime::RunOptions& /*run_options*/) override;
   common::Status Compile(const std::vector<FusedNodeAndGraph>& fused_nodes_and_graphs,
                          std::vector<NodeComputeInfo>& node_compute_funcs) override;
   std::shared_ptr<KernelRegistry> GetKernelRegistry() const override;


### PR DESCRIPTION
### Description
add OnRunStart() method for Vitis AI execution provider



### Motivation and Context
To dynamically obtain some runtime parameters during execution, use run_options within the Vitis AI execution provider (EP).


