### PR TITLE
[VitisAI] Add vaip Integration Using FetchContent

### DIFF
--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -60,4 +60,4 @@ directx_headers;https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v
 cudnn_frontend;https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.7.0.zip;d0753d8d5b39947ca0729d7773cb84653a129eb1
 dawn;https://github.com/google/dawn/archive/40a9fa79f76e6c76cca9e2fa69ea07f202f1d2e6.zip;e224563d5ab4a8e53a517b06f721242533bce722
 kleidiai;https://gitlab.arm.com/kleidi/kleidiai/-/archive/d15722976120710080ca098fe8ddabf4556cb40f/kleidiai-d15722976120710080ca098fe8ddabf4556cb40f.zip;d6c840d00c3b05aedf06e957ddaece1013d1f40b
-vaip;https://github.com/amd/vaip/archive/refs/tags/v1.1.0-rc0.zip;f8b91313ae17712662cc71dce032b4789c25d662
+vaip;https://github.com/amd/vaip/archive/refs/tags/v1.1.0-rc1.zip;b4dfe89188c61a8b690e3e9ae41c913a96fa66c8

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -60,4 +60,4 @@ directx_headers;https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v
 cudnn_frontend;https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.7.0.zip;d0753d8d5b39947ca0729d7773cb84653a129eb1
 dawn;https://github.com/google/dawn/archive/40a9fa79f76e6c76cca9e2fa69ea07f202f1d2e6.zip;e224563d5ab4a8e53a517b06f721242533bce722
 kleidiai;https://gitlab.arm.com/kleidi/kleidiai/-/archive/d15722976120710080ca098fe8ddabf4556cb40f/kleidiai-d15722976120710080ca098fe8ddabf4556cb40f.zip;d6c840d00c3b05aedf06e957ddaece1013d1f40b
-vaip;https://gitenterprise.xilinx.com/VitisAI/vaip.git;cp_dev_open_src
+vaip;https://github.com/amd/vaip.git;main

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -60,4 +60,4 @@ directx_headers;https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v
 cudnn_frontend;https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.7.0.zip;d0753d8d5b39947ca0729d7773cb84653a129eb1
 dawn;https://github.com/google/dawn/archive/40a9fa79f76e6c76cca9e2fa69ea07f202f1d2e6.zip;e224563d5ab4a8e53a517b06f721242533bce722
 kleidiai;https://gitlab.arm.com/kleidi/kleidiai/-/archive/d15722976120710080ca098fe8ddabf4556cb40f/kleidiai-d15722976120710080ca098fe8ddabf4556cb40f.zip;d6c840d00c3b05aedf06e957ddaece1013d1f40b
-vaip;https://gitenterprise.xilinx.com/chunywan/vaip.git;refactor-vaip
+vaip;https://github.com/amd/vaip.git;main

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -60,4 +60,4 @@ directx_headers;https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v
 cudnn_frontend;https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.7.0.zip;d0753d8d5b39947ca0729d7773cb84653a129eb1
 dawn;https://github.com/google/dawn/archive/40a9fa79f76e6c76cca9e2fa69ea07f202f1d2e6.zip;e224563d5ab4a8e53a517b06f721242533bce722
 kleidiai;https://gitlab.arm.com/kleidi/kleidiai/-/archive/d15722976120710080ca098fe8ddabf4556cb40f/kleidiai-d15722976120710080ca098fe8ddabf4556cb40f.zip;d6c840d00c3b05aedf06e957ddaece1013d1f40b
-vaip;https://github.com/amd/vaip.git;main
+vaip;https://gitenterprise.xilinx.com/VitisAI/vaip.git;win24_open_src

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -60,4 +60,4 @@ directx_headers;https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v
 cudnn_frontend;https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.7.0.zip;d0753d8d5b39947ca0729d7773cb84653a129eb1
 dawn;https://github.com/google/dawn/archive/40a9fa79f76e6c76cca9e2fa69ea07f202f1d2e6.zip;e224563d5ab4a8e53a517b06f721242533bce722
 kleidiai;https://gitlab.arm.com/kleidi/kleidiai/-/archive/d15722976120710080ca098fe8ddabf4556cb40f/kleidiai-d15722976120710080ca098fe8ddabf4556cb40f.zip;d6c840d00c3b05aedf06e957ddaece1013d1f40b
-vaip;https://github.com/amd/vaip/archive/refs/tags/v1.0.0-rc0.zip;e084b71c0277e2e3263179a4682300d427ff83e7
+vaip;https://github.com/amd/vaip/archive/refs/tags/v1.1.0-rc0.zip;f8b91313ae17712662cc71dce032b4789c25d662

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -60,3 +60,4 @@ directx_headers;https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v
 cudnn_frontend;https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.7.0.zip;d0753d8d5b39947ca0729d7773cb84653a129eb1
 dawn;https://github.com/google/dawn/archive/40a9fa79f76e6c76cca9e2fa69ea07f202f1d2e6.zip;e224563d5ab4a8e53a517b06f721242533bce722
 kleidiai;https://gitlab.arm.com/kleidi/kleidiai/-/archive/d15722976120710080ca098fe8ddabf4556cb40f/kleidiai-d15722976120710080ca098fe8ddabf4556cb40f.zip;d6c840d00c3b05aedf06e957ddaece1013d1f40b
+vaip;https://gitenterprise.xilinx.com/chunywan/vaip.git;refactor-vaip

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -60,4 +60,4 @@ directx_headers;https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v
 cudnn_frontend;https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.7.0.zip;d0753d8d5b39947ca0729d7773cb84653a129eb1
 dawn;https://github.com/google/dawn/archive/40a9fa79f76e6c76cca9e2fa69ea07f202f1d2e6.zip;e224563d5ab4a8e53a517b06f721242533bce722
 kleidiai;https://gitlab.arm.com/kleidi/kleidiai/-/archive/d15722976120710080ca098fe8ddabf4556cb40f/kleidiai-d15722976120710080ca098fe8ddabf4556cb40f.zip;d6c840d00c3b05aedf06e957ddaece1013d1f40b
-vaip;https://gitenterprise.xilinx.com/VitisAI/vaip.git;win24_open_src
+vaip;https://gitenterprise.xilinx.com/VitisAI/vaip.git;cp_dev_open_src

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -60,4 +60,4 @@ directx_headers;https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v
 cudnn_frontend;https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.7.0.zip;d0753d8d5b39947ca0729d7773cb84653a129eb1
 dawn;https://github.com/google/dawn/archive/40a9fa79f76e6c76cca9e2fa69ea07f202f1d2e6.zip;e224563d5ab4a8e53a517b06f721242533bce722
 kleidiai;https://gitlab.arm.com/kleidi/kleidiai/-/archive/d15722976120710080ca098fe8ddabf4556cb40f/kleidiai-d15722976120710080ca098fe8ddabf4556cb40f.zip;d6c840d00c3b05aedf06e957ddaece1013d1f40b
-vaip;https://github.com/amd/vaip.git;main
+vaip;https://github.com/amd/vaip/archive/refs/tags/v1.0.0-rc0.zip;e084b71c0277e2e3263179a4682300d427ff83e7

--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -210,7 +210,6 @@ onnxruntime_fetchcontent_declare(
   EXCLUDE_FROM_ALL
   FIND_PACKAGE_ARGS NAMES Protobuf protobuf
 )
-
 set(protobuf_BUILD_TESTS OFF CACHE BOOL "Build protobuf tests" FORCE)
 #TODO: we'd better to turn the following option off. However, it will cause
 # ".\build.bat --config Debug --parallel --skip_submodule_sync --update" fail with an error message:

--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -210,6 +210,7 @@ onnxruntime_fetchcontent_declare(
   EXCLUDE_FROM_ALL
   FIND_PACKAGE_ARGS NAMES Protobuf protobuf
 )
+
 set(protobuf_BUILD_TESTS OFF CACHE BOOL "Build protobuf tests" FORCE)
 #TODO: we'd better to turn the following option off. However, it will cause
 # ".\build.bat --config Debug --parallel --skip_submodule_sync --update" fail with an error message:

--- a/cmake/onnxruntime_providers_vitisai.cmake
+++ b/cmake/onnxruntime_providers_vitisai.cmake
@@ -53,6 +53,10 @@
     target_compile_options(onnxruntime_providers_vitisai PRIVATE -Wno-unused-parameter)
   endif(MSVC)
 
+  if(MSVC)
+    target_link_options(onnxruntime_providers_vitisai PRIVATE "/NODEFAULTLIB:libucrt.lib" "/DEFAULTLIB:ucrt.lib")
+  endif(MSVC)
+
   set_target_properties(onnxruntime_providers_vitisai PROPERTIES FOLDER "ONNXRuntime")
   set_target_properties(onnxruntime_providers_vitisai PROPERTIES LINKER_LANGUAGE CXX)
 

--- a/cmake/onnxruntime_providers_vitisai.cmake
+++ b/cmake/onnxruntime_providers_vitisai.cmake
@@ -2,10 +2,8 @@
 # Licensed under the MIT License.
   FetchContent_Declare(
     vaip
-    GIT_REPOSITORY ${DEP_URL_vaip}
-    GIT_TAG ${DEP_SHA1_vaip}
-    GIT_SUBMODULES_RECURSE FALSE
-    GIT_SHALLOW TRUE
+    URL ${DEP_URL_vaip}
+    URL_HASH SHA1=${DEP_SHA1_vaip}
     OVERRIDE_FIND_PACKAGE
   )
   find_package(vaip)

--- a/cmake/onnxruntime_providers_vitisai.cmake
+++ b/cmake/onnxruntime_providers_vitisai.cmake
@@ -37,7 +37,7 @@
     set_property(TARGET onnxruntime_providers_vitisai APPEND_STRING PROPERTY LINK_FLAGS "-Xlinker --version-script=${ONNXRUNTIME_ROOT}/core/providers/vitisai/version_script.lds -Xlinker --gc-sections")
   endif(MSVC)
 
-  target_include_directories(onnxruntime_providers_vitisai PRIVATE "${ONNXRUNTIME_ROOT}/core/providers/vitisai/include" ${XRT_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR}/VitisAI)
+  target_include_directories(onnxruntime_providers_vitisai PRIVATE "${ONNXRUNTIME_ROOT}/core/providers/vitisai/include" ${CMAKE_CURRENT_BINARY_DIR}/VitisAI)
   if(MSVC)
     target_compile_options(onnxruntime_providers_vitisai PRIVATE "/Zc:__cplusplus")
     # for dll interface warning.

--- a/cmake/onnxruntime_providers_vitisai.cmake
+++ b/cmake/onnxruntime_providers_vitisai.cmake
@@ -1,5 +1,26 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+  FetchContent_Declare(
+    vaip
+    GIT_REPOSITORY ${DEP_URL_vaip}
+    GIT_TAG ${DEP_SHA1_vaip}
+    GIT_SUBMODULES_RECURSE FALSE
+    GIT_SHALLOW TRUE
+    OVERRIDE_FIND_PACKAGE
+  )
+  set(WITH_XCOMPILER ON CACHE BOOL "enable XCOMPILER")
+  set(WITH_OPENSSL OFF CACHE BOOL "enable open ssl")
+  set(WITH_CPURUNNER ON CACHE BOOL "enable cpu runner")
+  set(BUILD_PYTHON_EXT OFF CACHE BOOL "enable python ext")
+  set(EN_LLM_DOD_OPS OFF CACHE BOOL "enable dd flow")
+  set(EN_VAIML OFF CACHE BOOL "enable vaiml flow")
+  set(TRIM_CONFIG OFF CACHE BOOL "enable config trimming")
+  set(ENABLE_VITIS_AI_CUSTOM_OP OFF "enable vitis ai custom op")
+  set(PACK_XCLBIN_PATH "" CACHE STRING "list of xclbin files")
+  set(ENABLE_BUILD_VOE_WHEEL OFF CACHE BOOL "internal used only" FORCE)
+  set(INSTALL_USER ON CACHE BOOL "internal used only" FORCE)
+  set(ENABLE_XRT_SHARED_CONTEXT ON CACHE BOOL "internal used only" FORCE)
+  find_package(vaip)
 
   if ("${GIT_COMMIT_ID}" STREQUAL "")
   execute_process(
@@ -21,10 +42,11 @@
   source_group(TREE ${ONNXRUNTIME_ROOT}/core FILES ${onnxruntime_providers_vitisai_cc_srcs})
   onnxruntime_add_shared_library(onnxruntime_providers_vitisai ${onnxruntime_providers_vitisai_cc_srcs})
   onnxruntime_add_include_to_target(onnxruntime_providers_vitisai ${ONNXRUNTIME_PROVIDERS_SHARED} ${GSL_TARGET} safeint_interface flatbuffers::flatbuffers)
-  target_link_libraries(onnxruntime_providers_vitisai PRIVATE ${ONNXRUNTIME_PROVIDERS_SHARED})
+  target_link_libraries(onnxruntime_providers_vitisai PRIVATE ${ONNXRUNTIME_PROVIDERS_SHARED} onnxruntime_vitisai_ep::onnxruntime_vitisai_ep)
   if(MSVC)
     onnxruntime_add_include_to_target(onnxruntime_providers_vitisai dbghelp)
     set_property(TARGET onnxruntime_providers_vitisai APPEND_STRING PROPERTY LINK_FLAGS "-DEF:${ONNXRUNTIME_ROOT}/core/providers/vitisai/symbols.def")
+    target_sources(onnxruntime_providers_vitisai PRIVATE ${vaip_BINARY_DIR}/onnxruntime_vitisai_ep/onnxruntime_vitisai_ep.def)
   else(MSVC)
     set_property(TARGET onnxruntime_providers_vitisai APPEND_STRING PROPERTY LINK_FLAGS "-Xlinker --version-script=${ONNXRUNTIME_ROOT}/core/providers/vitisai/version_script.lds -Xlinker --gc-sections")
   endif(MSVC)

--- a/cmake/onnxruntime_providers_vitisai.cmake
+++ b/cmake/onnxruntime_providers_vitisai.cmake
@@ -8,18 +8,6 @@
     GIT_SHALLOW TRUE
     OVERRIDE_FIND_PACKAGE
   )
-  set(WITH_XCOMPILER ON CACHE BOOL "enable XCOMPILER")
-  set(WITH_OPENSSL OFF CACHE BOOL "enable open ssl")
-  set(WITH_CPURUNNER ON CACHE BOOL "enable cpu runner")
-  set(BUILD_PYTHON_EXT OFF CACHE BOOL "enable python ext")
-  set(EN_LLM_DOD_OPS OFF CACHE BOOL "enable dd flow")
-  set(EN_VAIML OFF CACHE BOOL "enable vaiml flow")
-  set(TRIM_CONFIG OFF CACHE BOOL "enable config trimming")
-  set(ENABLE_VITIS_AI_CUSTOM_OP OFF "enable vitis ai custom op")
-  set(PACK_XCLBIN_PATH "" CACHE STRING "list of xclbin files")
-  set(ENABLE_BUILD_VOE_WHEEL OFF CACHE BOOL "internal used only" FORCE)
-  set(INSTALL_USER ON CACHE BOOL "internal used only" FORCE)
-  set(ENABLE_XRT_SHARED_CONTEXT ON CACHE BOOL "internal used only" FORCE)
   find_package(vaip)
 
   if ("${GIT_COMMIT_ID}" STREQUAL "")

--- a/cmake/onnxruntime_providers_vitisai.cmake
+++ b/cmake/onnxruntime_providers_vitisai.cmake
@@ -52,7 +52,10 @@
   endif(MSVC)
 
   if(MSVC)
-    target_link_options(onnxruntime_providers_vitisai PRIVATE "/NODEFAULTLIB:libucrt.lib" "/DEFAULTLIB:ucrt.lib")
+    target_link_options(onnxruntime_providers_vitisai PRIVATE
+      "$<$<CONFIG:Debug>:/NODEFAULTLIB:libucrtd.lib /DEFAULTLIB:ucrtd.lib>"
+      "$<$<CONFIG:Release>:/NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib>"
+      )
   endif(MSVC)
 
   set_target_properties(onnxruntime_providers_vitisai PROPERTIES FOLDER "ONNXRuntime")

--- a/onnxruntime/core/providers/vitisai/imp/global_api.cc
+++ b/onnxruntime/core/providers/vitisai/imp/global_api.cc
@@ -61,6 +61,7 @@ int vitisai_ep_set_ep_dynamic_options_c(
 void profiler_collect_c(
     std::vector<EventInfo>& api_events,
     std::vector<EventInfo>& kernel_events);
+void deinitialize_onnxruntime_vitisai_ep_c();
 };
 vaip_core::OrtApiForVaip* create_org_api_hook();
 struct OrtVitisAIEpAPI {
@@ -70,7 +71,7 @@ struct OrtVitisAIEpAPI {
   std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>* (*compile_onnx_model_vitisai_ep_with_error_handling)(
       const std::string& model_path, const onnxruntime::Graph& graph, const onnxruntime::ProviderOptions& options, void* status, vaip_core::error_report_func func);
   std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>* (*compile_onnx_model_vitisai_ep_v3)(
-      const std::filesystem::path& model_path, const onnxruntime::Graph& graph, const onnxruntime::ProviderOptions& options, void* status, vaip_core::error_report_func func);
+      const std::filesystem::path& model_path, const onnxruntime::Graph& graph, const onnxruntime::ProviderOptions& options, void* status, vaip_core::error_report_func func) = nullptr;
   uint32_t (*vaip_get_version)();
   int (*create_ep_context_nodes)(
       const std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>& eps,
@@ -108,6 +109,7 @@ struct OrtVitisAIEpAPI {
     this->vitisai_ep_set_ep_dynamic_options = vitisai_ep_set_ep_dynamic_options_c;
     this->vaip_get_version = vaip_get_version_c;
     this->profiler_collect = profiler_collect_c;
+    this->deinitialize_onnxruntime_vitisai_ep = deinitialize_onnxruntime_vitisai_ep_c;
 
     auto& env = Provider_GetHost()->Env__Default();
     auto& logger = *Provider_GetHost()->LoggingManager_GetDefaultLogger();

--- a/onnxruntime/core/providers/vitisai/imp/global_api.cc
+++ b/onnxruntime/core/providers/vitisai/imp/global_api.cc
@@ -42,6 +42,16 @@ using namespace onnxruntime;
 #define LIBRARY_EXTENSION ".so"
 #endif
 
+namespace vaip_core {
+
+void initialize_onnxruntime_vitisai_ep(vaip_core::OrtApiForVaip* api, std::vector<OrtCustomOpDomain*>& ret_domain);
+uint32_t vaip_get_version();
+extern "C" int create_ep_context_nodes(
+    const std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>& eps,
+    vaip_core::DllSafe<std::vector<Node*>>* ret_value);
+std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>* compile_onnx_model_with_options(
+    const std::string& model_path, const onnxruntime::Graph& graph, const onnxruntime::ProviderOptions& options);
+}  // namespace vaip_core
 vaip_core::OrtApiForVaip* create_org_api_hook();
 struct OrtVitisAIEpAPI {
   void (*initialize_onnxruntime_vitisai_ep)(vaip_core::OrtApiForVaip* api, std::vector<OrtCustomOpDomain*>& ret_domain);
@@ -52,7 +62,7 @@ struct OrtVitisAIEpAPI {
   std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>* (*compile_onnx_model_vitisai_ep_v3)(
       const std::filesystem::path& model_path, const onnxruntime::Graph& graph, const onnxruntime::ProviderOptions& options, void* status, vaip_core::error_report_func func);
   uint32_t (*vaip_get_version)();
-  void (*create_ep_context_nodes)(
+  int (*create_ep_context_nodes)(
       const std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>& eps,
       vaip_core::DllSafe<std::vector<Node*>>* ret_value) = nullptr;
   int (*vitisai_ep_on_run_start)(
@@ -66,36 +76,37 @@ struct OrtVitisAIEpAPI {
       std::vector<EventInfo>& api_events,
       std::vector<EventInfo>& kernel_events);
   void (*deinitialize_onnxruntime_vitisai_ep)();
+  int (*vaip_xcompiler_compile)(const char* input_xmodel,
+                                size_t input_xmodel_size,
+                                const char* config_xmodel,
+                                size_t config_xmodel_size, void* state,
+                                char* (*allocator)(void*, size_t)) = nullptr;
   void Ensure() {
-    if (handle_)
-      return;
+    this->initialize_onnxruntime_vitisai_ep = vaip_core::initialize_onnxruntime_vitisai_ep;
+    this->compile_onnx_model_with_options = vaip_core::compile_onnx_model_with_options;
+    this->create_ep_context_nodes = vaip_core::create_ep_context_nodes;
+    this->vaip_get_version = vaip_core::vaip_get_version;
+    //
     auto& env = Provider_GetHost()->Env__Default();
+    auto& logger = *Provider_GetHost()->LoggingManager_GetDefaultLogger();
+
 #ifdef _WIN32
     // this dll is already linked to the executable, normally a test program
     handle_ = reinterpret_cast<void*>(GetModuleHandle(TEXT("onnxruntime_vitisai_ep.dll")));
+    auto status = Status::OK();
     if (!handle_) {
       auto full_path = env.GetRuntimePath() + PathString(LIBRARY_PREFIX ORT_TSTR("onnxruntime_vitisai_ep") LIBRARY_EXTENSION);
-      ORT_THROW_IF_ERROR(env.LoadDynamicLibrary(full_path, true, &handle_));
+      status = env.LoadDynamicLibrary(full_path, true, &handle_);
+      if (!status.IsOK()) {
+        LOGS(logger, VERBOSE) << "cannot load onnxruntime_vitisai_ep.dll, can only deploy ep_context onnx model.";
+        return;
+      }
     }
 #else
     auto full_path = env.GetRuntimePath() + PathString(LIBRARY_PREFIX ORT_TSTR("onnxruntime_vitisai_ep") LIBRARY_EXTENSION);
     ORT_THROW_IF_ERROR(env.LoadDynamicLibrary(full_path, true, &handle_));
 #endif
-    ORT_THROW_IF_ERROR(env.GetSymbolFromLibrary(handle_, "initialize_onnxruntime_vitisai_ep", (void**)&initialize_onnxruntime_vitisai_ep));
-    auto status1 = env.GetSymbolFromLibrary(handle_, "compile_onnx_model_vitisai_ep_with_error_handling", (void**)&compile_onnx_model_vitisai_ep_with_error_handling);
-    auto status2 = env.GetSymbolFromLibrary(handle_, "compile_onnx_model_vitisai_ep_with_options", (void**)&compile_onnx_model_with_options);
-    auto status3 = env.GetSymbolFromLibrary(handle_, "compile_onnx_model_vitisai_ep_v3", (void**)&compile_onnx_model_vitisai_ep_v3);
-    if ((!status1.IsOK()) && (!status2.IsOK()) && (!status3.IsOK())) {
-      ::onnxruntime::LogRuntimeError(0, status2, __FILE__, static_cast<const char*>(__FUNCTION__), __LINE__);
-      ORT_THROW(status2);
-    }
-    std::ignore = env.GetSymbolFromLibrary(handle_, "vaip_get_version",
-                                           (void**)&vaip_get_version);
-    std::ignore = env.GetSymbolFromLibrary(handle_, "profiler_collect", (void**)&profiler_collect);
-    ORT_THROW_IF_ERROR(env.GetSymbolFromLibrary(handle_, "create_ep_context_nodes", (void**)&create_ep_context_nodes));
-    ORT_THROW_IF_ERROR(env.GetSymbolFromLibrary(handle_, "vitisai_ep_on_run_start", (void**)&vitisai_ep_on_run_start));
-    ORT_THROW_IF_ERROR(env.GetSymbolFromLibrary(handle_, "vitisai_ep_set_ep_dynamic_options", (void**)&vitisai_ep_set_ep_dynamic_options));
-    std::ignore = env.GetSymbolFromLibrary(handle_, "deinitialize_onnxruntime_vitisai_ep", (void**)&deinitialize_onnxruntime_vitisai_ep);
+    ORT_THROW_IF_ERROR(env.GetSymbolFromLibrary(handle_, "vaip_xcompiler_compile", (void**)&vaip_xcompiler_compile));
   }
   void Clear() {
     if (handle_) {
@@ -112,9 +123,10 @@ struct OrtVitisAIEpAPI {
 
 static OrtVitisAIEpAPI s_library_vitisaiep;
 static std::shared_ptr<KernelRegistry> s_kernel_registry_vitisaiep;
-static std::vector<OrtCustomOpDomain*> s_domains_vitisaiep;
 static vaip_core::OrtApiForVaip the_global_api;
-std::shared_ptr<KernelRegistry> get_kernel_registry_vitisaiep() { return s_kernel_registry_vitisaiep; }
+g
+    std::shared_ptr<KernelRegistry>
+    get_kernel_registry_vitisaiep() { return s_kernel_registry_vitisaiep; }
 const std::vector<OrtCustomOpDomain*>& get_domains_vitisaiep() { return s_domains_vitisaiep; }
 
 void profiler_collect(
@@ -510,6 +522,7 @@ vaip_core::OrtApiForVaip* create_org_api_hook() {
     }
   };
   the_global_api.node_arg_external_location = vaip::node_arg_external_location;
+
   the_global_api.model_to_proto = [](onnxruntime::Model& model) { return model.ToProto().release(); };
   the_global_api.model_proto_serialize_as_string = [](ONNX_NAMESPACE::ModelProto& model_proto) {
     return vaip_core::DllSafe(model_proto.SerializeAsString());
@@ -535,4 +548,6 @@ vaip_core::OrtApiForVaip* create_org_api_hook() {
   } else {
     return &the_global_api;
   }
+  the_global_api.vaip_xcompiler_compile = s_library_vitisaiep.vaip_xcompiler_compile;
+  return &the_global_api;
 }

--- a/onnxruntime/core/providers/vitisai/imp/global_api.cc
+++ b/onnxruntime/core/providers/vitisai/imp/global_api.cc
@@ -568,12 +568,8 @@ vaip_core::OrtApiForVaip* create_org_api_hook() {
   the_global_api.graph_remove_initialized_tensor = [](Graph& graph, const std::string& tensor_name) {
     graph.RemoveInitializedTensor(tensor_name);
   };
+
   the_global_api.graph_reverse_dfs_from_preemp = vaip::graph_reverse_dfs_from;
-  if (!s_library_vitisaiep.vaip_get_version) {
-    return reinterpret_cast<vaip_core::OrtApiForVaip*>(&(the_global_api.host_));
-  } else {
-    return &the_global_api;
-  }
   the_global_api.vaip_xcompiler_compile = s_library_vitisaiep.vaip_xcompiler_compile;
   the_global_api.vaip_get_default_config = s_library_vitisaiep.vaip_get_default_config;
   the_global_api.vaip_get_pattern_as_binary = s_library_vitisaiep.vaip_get_pattern_as_binary;

--- a/onnxruntime/core/providers/vitisai/imp/global_api.cc
+++ b/onnxruntime/core/providers/vitisai/imp/global_api.cc
@@ -49,6 +49,8 @@ int create_ep_context_nodes_c(
     vaip_core::DllSafe<std::vector<Node*>>* ret_value);
 std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>* compile_onnx_model_with_options_c(
     const std::string& model_path, const onnxruntime::Graph& graph, const onnxruntime::ProviderOptions& options);
+std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>* compile_onnx_model_vitisai_ep_with_error_handling_c(
+    const std::string& model_path, const onnxruntime::Graph& graph, const onnxruntime::ProviderOptions& options, void* status, vaip_core::error_report_func func);
 int vitisai_ep_on_run_start_c(
     const std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>& eps, const void* state,
     vaip_core::DllSafe<std::string> (*get_config_entry)(const void* state, const char* entry_name));
@@ -56,6 +58,9 @@ int vitisai_ep_set_ep_dynamic_options_c(
     const std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>& eps,
     const char* const* keys,
     const char* const* values, size_t kv_len);
+void profiler_collect_c(
+    std::vector<EventInfo>& api_events,
+    std::vector<EventInfo>& kernel_events);
 };
 vaip_core::OrtApiForVaip* create_org_api_hook();
 struct OrtVitisAIEpAPI {
@@ -97,10 +102,12 @@ struct OrtVitisAIEpAPI {
 
     this->initialize_onnxruntime_vitisai_ep = initialize_onnxruntime_vitisai_ep_c;
     this->compile_onnx_model_with_options = compile_onnx_model_with_options_c;
+    this->compile_onnx_model_vitisai_ep_with_error_handling = compile_onnx_model_vitisai_ep_with_error_handling_c;
     this->create_ep_context_nodes = create_ep_context_nodes_c;
     this->vitisai_ep_on_run_start = vitisai_ep_on_run_start_c;
     this->vitisai_ep_set_ep_dynamic_options = vitisai_ep_set_ep_dynamic_options_c;
     this->vaip_get_version = vaip_get_version_c;
+    this->profiler_collect = profiler_collect_c;
 
     auto& env = Provider_GetHost()->Env__Default();
     auto& logger = *Provider_GetHost()->LoggingManager_GetDefaultLogger();

--- a/onnxruntime/core/providers/vitisai/imp/global_api.cc
+++ b/onnxruntime/core/providers/vitisai/imp/global_api.cc
@@ -41,17 +41,15 @@ using namespace onnxruntime;
 #define LIBRARY_PREFIX "lib"
 #define LIBRARY_EXTENSION ".so"
 #endif
-
-namespace vaip_core {
-
-void initialize_onnxruntime_vitisai_ep(vaip_core::OrtApiForVaip* api, std::vector<OrtCustomOpDomain*>& ret_domain);
-uint32_t vaip_get_version();
-extern "C" int create_ep_context_nodes(
+extern "C" {
+void initialize_onnxruntime_vitisai_ep_c(vaip_core::OrtApiForVaip* api, std::vector<OrtCustomOpDomain*>& ret_domain);
+uint32_t vaip_get_version_c();
+int create_ep_context_nodes_c(
     const std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>& eps,
     vaip_core::DllSafe<std::vector<Node*>>* ret_value);
-std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>* compile_onnx_model_with_options(
+std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>* compile_onnx_model_with_options_c(
     const std::string& model_path, const onnxruntime::Graph& graph, const onnxruntime::ProviderOptions& options);
-}  // namespace vaip_core
+};
 vaip_core::OrtApiForVaip* create_org_api_hook();
 struct OrtVitisAIEpAPI {
   void (*initialize_onnxruntime_vitisai_ep)(vaip_core::OrtApiForVaip* api, std::vector<OrtCustomOpDomain*>& ret_domain);
@@ -80,13 +78,21 @@ struct OrtVitisAIEpAPI {
                                 size_t input_xmodel_size,
                                 const char* config_xmodel,
                                 size_t config_xmodel_size, void* state,
-                                char* (*allocator)(void*, size_t)) = nullptr;
+                                void (*k)(void*, void*, size_t)) = nullptr;
+  const char* (*vaip_get_default_config)() = nullptr;
+  int (*vaip_get_pattern_as_binary)(const char* name, void* state, void (*k)(void*, void*, size_t)) = nullptr;
+  void (*vaip_get_pattern_list)(void* state, void (*k)(void*, void*, size_t)) = nullptr;
+  int (*vaip_get_mem_xclbin)(const char* name, void* state, void (*k)(void*, void*, size_t)) = nullptr;
+  bool (*vaip_has_mem_xclbin)(const char* name) = nullptr;
   void Ensure() {
-    this->initialize_onnxruntime_vitisai_ep = vaip_core::initialize_onnxruntime_vitisai_ep;
-    this->compile_onnx_model_with_options = vaip_core::compile_onnx_model_with_options;
-    this->create_ep_context_nodes = vaip_core::create_ep_context_nodes;
-    this->vaip_get_version = vaip_core::vaip_get_version;
-    //
+    if (handle_)
+      return;
+
+    this->initialize_onnxruntime_vitisai_ep = initialize_onnxruntime_vitisai_ep_c;
+    this->compile_onnx_model_with_options = compile_onnx_model_with_options_c;
+    this->create_ep_context_nodes = create_ep_context_nodes_c;
+    this->vaip_get_version = vaip_get_version_c;
+
     auto& env = Provider_GetHost()->Env__Default();
     auto& logger = *Provider_GetHost()->LoggingManager_GetDefaultLogger();
 
@@ -107,6 +113,11 @@ struct OrtVitisAIEpAPI {
     ORT_THROW_IF_ERROR(env.LoadDynamicLibrary(full_path, true, &handle_));
 #endif
     ORT_THROW_IF_ERROR(env.GetSymbolFromLibrary(handle_, "vaip_xcompiler_compile", (void**)&vaip_xcompiler_compile));
+    ORT_THROW_IF_ERROR(env.GetSymbolFromLibrary(handle_, "vaip_get_default_config", (void**)&vaip_get_default_config));
+    ORT_THROW_IF_ERROR(env.GetSymbolFromLibrary(handle_, "vaip_get_pattern_as_binary", (void**)&vaip_get_pattern_as_binary));
+    ORT_THROW_IF_ERROR(env.GetSymbolFromLibrary(handle_, "vaip_get_pattern_list", (void**)&vaip_get_pattern_list));
+    ORT_THROW_IF_ERROR(env.GetSymbolFromLibrary(handle_, "vaip_get_mem_xclbin", (void**)&vaip_get_mem_xclbin));
+    ORT_THROW_IF_ERROR(env.GetSymbolFromLibrary(handle_, "vaip_has_mem_xclbin", (void**)&vaip_has_mem_xclbin));
   }
   void Clear() {
     if (handle_) {
@@ -123,10 +134,9 @@ struct OrtVitisAIEpAPI {
 
 static OrtVitisAIEpAPI s_library_vitisaiep;
 static std::shared_ptr<KernelRegistry> s_kernel_registry_vitisaiep;
+static std::vector<OrtCustomOpDomain*> s_domains_vitisaiep;
 static vaip_core::OrtApiForVaip the_global_api;
-g
-    std::shared_ptr<KernelRegistry>
-    get_kernel_registry_vitisaiep() { return s_kernel_registry_vitisaiep; }
+std::shared_ptr<KernelRegistry> get_kernel_registry_vitisaiep() { return s_kernel_registry_vitisaiep; }
 const std::vector<OrtCustomOpDomain*>& get_domains_vitisaiep() { return s_domains_vitisaiep; }
 
 void profiler_collect(
@@ -549,5 +559,14 @@ vaip_core::OrtApiForVaip* create_org_api_hook() {
     return &the_global_api;
   }
   the_global_api.vaip_xcompiler_compile = s_library_vitisaiep.vaip_xcompiler_compile;
-  return &the_global_api;
+  the_global_api.vaip_get_default_config = s_library_vitisaiep.vaip_get_default_config;
+  the_global_api.vaip_get_pattern_as_binary = s_library_vitisaiep.vaip_get_pattern_as_binary;
+  the_global_api.vaip_get_pattern_list = s_library_vitisaiep.vaip_get_pattern_list;
+  the_global_api.vaip_get_mem_xclbin = s_library_vitisaiep.vaip_get_mem_xclbin;
+  the_global_api.vaip_has_mem_xclbin = s_library_vitisaiep.vaip_has_mem_xclbin;
+  if (!s_library_vitisaiep.vaip_get_version) {
+    return reinterpret_cast<vaip_core::OrtApiForVaip*>(&(the_global_api.host_));
+  } else {
+    return &the_global_api;
+  }
 }

--- a/onnxruntime/core/providers/vitisai/imp/global_api.cc
+++ b/onnxruntime/core/providers/vitisai/imp/global_api.cc
@@ -49,6 +49,13 @@ int create_ep_context_nodes_c(
     vaip_core::DllSafe<std::vector<Node*>>* ret_value);
 std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>* compile_onnx_model_with_options_c(
     const std::string& model_path, const onnxruntime::Graph& graph, const onnxruntime::ProviderOptions& options);
+int vitisai_ep_on_run_start_c(
+    const std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>& eps, const void* state,
+    vaip_core::DllSafe<std::string> (*get_config_entry)(const void* state, const char* entry_name));
+int vitisai_ep_set_ep_dynamic_options_c(
+    const std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>& eps,
+    const char* const* keys,
+    const char* const* values, size_t kv_len);
 };
 vaip_core::OrtApiForVaip* create_org_api_hook();
 struct OrtVitisAIEpAPI {
@@ -91,6 +98,8 @@ struct OrtVitisAIEpAPI {
     this->initialize_onnxruntime_vitisai_ep = initialize_onnxruntime_vitisai_ep_c;
     this->compile_onnx_model_with_options = compile_onnx_model_with_options_c;
     this->create_ep_context_nodes = create_ep_context_nodes_c;
+    this->vitisai_ep_on_run_start = vitisai_ep_on_run_start_c;
+    this->vitisai_ep_set_ep_dynamic_options = vitisai_ep_set_ep_dynamic_options_c;
     this->vaip_get_version = vaip_get_version_c;
 
     auto& env = Provider_GetHost()->Env__Default();

--- a/onnxruntime/core/providers/vitisai/include/vaip/vaip_ort_api.h
+++ b/onnxruntime/core/providers/vitisai/include/vaip/vaip_ort_api.h
@@ -235,7 +235,7 @@ struct OrtApiForVaip {
   DllSafe<std::string> (*model_proto_serialize_as_string)(ModelProto& model_proto);                                                                   // [96]
   void (*model_proto_delete)(ModelProto* p);                                                                                                          // [97]
   DllSafe<std::string> (*attr_proto_release_string)(AttributeProto* attr);                                                                            // [98]
-  bool (*is_profiling_enabled)(void* session_options);                                                                                                // [99]                                                                                        // [98]
+  bool (*is_profiling_enabled)(void* session_options);                                                                                                // [99]
   TensorProto* (*tensor_proto_new_i4)(const std::string& name,
                                       const std::vector<int64_t>& shape,
                                       const std::vector<int8_t>& data);  // [100]
@@ -243,6 +243,7 @@ struct OrtApiForVaip {
                                       const std::vector<int64_t>& shape,
                                       const std::vector<uint8_t>& data);                  // [101]
   void (*graph_remove_initialized_tensor)(Graph& graph, const std::string& tensor_name);  // [102]
+
   void (*graph_reverse_dfs_from_preemp)(
       const Graph& graph, gsl::span<const Node* const> from,
       const std::function<bool(const Node*)>& enter,
@@ -250,6 +251,12 @@ struct OrtApiForVaip {
       const std::function<bool(const Node*, const Node*)>& comp,
       const std::function<bool(const Node* from, const Node* to)>&
           stop);  // [103]
+
+  int (*vaip_xcompiler_compile)(const char* input_xmodel,
+                                size_t input_xmodel_size,
+                                const char* config_xmodel,
+                                size_t config_xmodel_size, void* state,
+                                char* (*allocator)(void*, size_t));  // [104]
 };
 
 #ifndef USE_VITISAI

--- a/onnxruntime/core/providers/vitisai/include/vaip/vaip_ort_api.h
+++ b/onnxruntime/core/providers/vitisai/include/vaip/vaip_ort_api.h
@@ -256,7 +256,12 @@ struct OrtApiForVaip {
                                 size_t input_xmodel_size,
                                 const char* config_xmodel,
                                 size_t config_xmodel_size, void* state,
-                                char* (*allocator)(void*, size_t));  // [104]
+                                void (*k)(void*, void*, size_t));                                     // [103]
+  const char* (*vaip_get_default_config)();                                                           // [104]
+  int (*vaip_get_pattern_as_binary)(const char* name, void* state, void (*k)(void*, void*, size_t));  // [105]
+  void (*vaip_get_pattern_list)(void* state, void (*k)(void*, void*, size_t));                        // [106]
+  int (*vaip_get_mem_xclbin)(const char* name, void* state, void (*k)(void*, void*, size_t));         // [107]
+  bool (*vaip_has_mem_xclbin)(const char* name);                                                      // [108]
 };
 
 #ifndef USE_VITISAI


### PR DESCRIPTION
### Description
Integrating the VitisAI EP implement repository into ONNXRuntime using FetchContent.
Statically linking core EP functionality and limiting dynamic links to C-style ABI functions.



### Motivation and Context
Addressing ABI and build compatibility ensures smoother integration and broader applicability of the VitisAI EP.


