### PR TITLE
allow scalar axes for Unsqueeze for WebGPU

### DIFF
--- a/onnxruntime/core/providers/js/operators/unsqueeze.h
+++ b/onnxruntime/core/providers/js/operators/unsqueeze.h
@@ -28,7 +28,7 @@ class Unsqueeze final : public JsKernel, public UnsqueezeBase {
       ORT_ENFORCE(axes_tensor != nullptr, "Axes input is null");
       ORT_ENFORCE(axes_tensor->Shape().NumDimensions() == 0 ||
                       axes_tensor->Shape().NumDimensions() == 1,
-                  "An axes tensor must be a scalar or a 1-D tensor.");
+                  "An axes tensor must be a scalar or a vector tensor.");
       auto nDims = static_cast<size_t>(axes_tensor->Shape()[0]);
       const auto* data = axes_tensor->Data<int64_t>();
       axes.assign(data, data + nDims);

--- a/onnxruntime/core/providers/js/operators/unsqueeze.h
+++ b/onnxruntime/core/providers/js/operators/unsqueeze.h
@@ -26,8 +26,9 @@ class Unsqueeze final : public JsKernel, public UnsqueezeBase {
     if (num_inputs == 2) {  // axes is an input
       const Tensor* axes_tensor = context->Input<Tensor>(1);
       ORT_ENFORCE(axes_tensor != nullptr, "Axes input is null");
-      ORT_ENFORCE(axes_tensor->Shape().NumDimensions() == 1,
-                  "An axes tensor must be a vector tensor.");
+      ORT_ENFORCE(axes_tensor->Shape().NumDimensions() == 0 ||
+                      axes_tensor->Shape().NumDimensions() == 1,
+                  "An axes tensor must be a scalar or a 1-D tensor.");
       auto nDims = static_cast<size_t>(axes_tensor->Shape()[0]);
       const auto* data = axes_tensor->Data<int64_t>();
       axes.assign(data, data + nDims);


### PR DESCRIPTION
### Description

Align with CPU behavior.

https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/providers/cpu/tensor/unsqueeze.cc#L60-L62