### PR TITLE
Import 'optim' only if PyTorch is installed

### DIFF
--- a/orttraining/orttraining/python/training/__init__.py
+++ b/orttraining/orttraining/python/training/__init__.py
@@ -3,6 +3,8 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 # isort: skip_file
+import importlib.util
+
 from onnxruntime.capi._pybind_state import (
     PropagateCastOpsStrategy,
     TrainingParameters,
@@ -10,7 +12,7 @@ from onnxruntime.capi._pybind_state import (
 )
 
 # Options need to be imported before `ORTTrainer`.
-from . import amp, artifacts, optim
+from . import amp, artifacts
 
 __all__ = [
     "PropagateCastOpsStrategy",
@@ -18,8 +20,12 @@ __all__ = [
     "amp",
     "artifacts",
     "is_ortmodule_available",
-    "optim",
 ]
+
+if importlib.util.find_spec("torch") is not None:
+    from . import optim
+
+    __all__ += ["optim"]
 
 try:
     if is_ortmodule_available():


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Classes in `onnxruntime.training.optim` depend on 'torch' being installed. This dependency spreads to all packages in `onnxruntime.training` when adding it in `training/__init__.py`. By ensuring that it is only added if 'torch' is installed, we can avoid this dependency.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
The 'torch' package can be very large and its size can be problematic in some training environments on the edge. As it won't be used if not using `onnxruntime.training.optim` it would be great to not depend on it in these environments.
See also https://github.com/microsoft/onnxruntime/issues/22070


