### PR TITLE
[js/webgpu] Fix issue to run model demucs

### DIFF
--- a/js/web/lib/wasm/jsep/webgpu/ops/conv-transpose.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/conv-transpose.ts
@@ -45,9 +45,7 @@ const calculateOutputShapeAndPads = (
   const spatialRank = inputShape.length - 2;
   const updateOutputShape = outputShape.length === 0;
   if (outputPadding.length < spatialRank) {
-    for (let i = 0; i < spatialRank - outputPadding.length; ++i) {
-      outputPadding.push(0);
-    }
+    outputPadding.push(...Array(spatialRank - outputPadding.length).fill(0));
   }
   const batchSize = inputShape[0];
   const outChannels = kernelShape[isChannelLast ? 3 : 1] * group;

--- a/js/web/lib/wasm/jsep/webgpu/ops/conv-transpose.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/conv-transpose.ts
@@ -44,8 +44,8 @@ const calculateOutputShapeAndPads = (
 ) => {
   const spatialRank = inputShape.length - 2;
   const updateOutputShape = outputShape.length === 0;
-  if (outputPadding.length === 0) {
-    for (let i = 0; i < spatialRank; ++i) {
+  if (outputPadding.length < spatialRank) {
+    for (let i = 0; i < spatialRank - outputPadding.length; ++i) {
       outputPadding.push(0);
     }
   }

--- a/js/web/lib/wasm/jsep/webgpu/ops/conv.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/conv.ts
@@ -103,7 +103,12 @@ const validateInputs = (inputs: readonly TensorView[], attributes: ConvAttribute
 
 const getAdjustedConvAttributes = <T extends ConvAttributes>(attributes: T, inputs: readonly TensorView[]): T => {
   const kernelShape = attributes.kernelShape.slice();
-  // if kernelShape is not specified in the attributes of this op, infer it from the weight tensor dims
+  // if kernelShape is not well specified in the attributes, infer it from the weight tensor dims
+  if (kernelShape.length < inputs[1].dims.length - 2) {
+    for (let i = 0; i < inputs[1].dims.length - 2 - kernelShape.length; ++i) {
+      kernelShape.push(0);
+    }
+  }
   for (let i = 2; i < inputs[1].dims.length; ++i) {
     if (kernelShape[i - 2] === 0) {
       kernelShape[i - 2] = inputs[1].dims[i];

--- a/js/web/lib/wasm/jsep/webgpu/ops/conv.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/conv.ts
@@ -105,9 +105,7 @@ const getAdjustedConvAttributes = <T extends ConvAttributes>(attributes: T, inpu
   const kernelShape = attributes.kernelShape.slice();
   // if kernelShape is not well specified in the attributes, infer it from the weight tensor dims
   if (kernelShape.length < inputs[1].dims.length - 2) {
-    for (let i = 0; i < inputs[1].dims.length - 2 - kernelShape.length; ++i) {
-      kernelShape.push(0);
-    }
+    kernelShape.push(...Array(inputs[1].dims.length - 2 - kernelShape.length).fill(0));
   }
   for (let i = 2; i < inputs[1].dims.length; ++i) {
     if (kernelShape[i - 2] === 0) {


### PR DESCRIPTION
This is to fix issue #22031 to run model demucs.
For conv-transpose, outputPadding.length could be 1, while spatialRank is 2. The fix is to append enough 0s to outputPadding. For conv, the issue is similar. kernelShape.length sometimes could be 1, while inputs[1].dims.length is 4. The fix is also to append enough 0s to kernelShape.

