### PR TITLE
Enable Android 16 KB page size support

### DIFF
--- a/cmake/adjust_global_compile_flags.cmake
+++ b/cmake/adjust_global_compile_flags.cmake
@@ -1,11 +1,15 @@
 # work around Android NDK bug which doesn't include -O flag for Release configuration
 # https://github.com/android/ndk/issues/1740
 # TODO: remove this when the NDK version(s) we support get fixed
-if (CMAKE_SYSTEM_NAME STREQUAL "Android")
+if (Android)
   # NB: attempting to match the effects of this fix: https://android-review.googlesource.com/c/platform/ndk/+/2168845
   string(APPEND CMAKE_C_FLAGS_RELEASE " -O3")
   string(APPEND CMAKE_CXX_FLAGS_RELEASE " -O3")
   string(APPEND CMAKE_ASM_FLAGS_RELEASE " -O3")
+
+  # Build shared libraries with support for 16 KB ELF alignment
+  # https://source.android.com/docs/core/architecture/16kb-page-size/16kb#build-lib-16kb-alignment
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,max-page-size=16384")
 endif()
 
 # Suggested by https://gitlab.kitware.com/cmake/cmake/-/issues/20132

--- a/cmake/adjust_global_compile_flags.cmake
+++ b/cmake/adjust_global_compile_flags.cmake
@@ -1,7 +1,7 @@
 # work around Android NDK bug which doesn't include -O flag for Release configuration
 # https://github.com/android/ndk/issues/1740
 # TODO: remove this when the NDK version(s) we support get fixed
-if (Android)
+if (ANDROID)
   # NB: attempting to match the effects of this fix: https://android-review.googlesource.com/c/platform/ndk/+/2168845
   string(APPEND CMAKE_C_FLAGS_RELEASE " -O3")
   string(APPEND CMAKE_CXX_FLAGS_RELEASE " -O3")


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Add linker flags to support 16KB page size support on Android. 

See  https://source.android.com/docs/core/architecture/16kb-page-size/16kb#build-lib-16kb-alignment

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
#21837

