### PR TITLE
[TensorRT EP] Add supportsModelV2

### DIFF
--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -2255,16 +2255,29 @@ SubGraphCollection_t TensorrtExecutionProvider::GetSupportedList(SubGraphCollect
         network_flags |= fp16_enable_ || int8_enable_ ? 0 : 1U << static_cast<uint32_t>(nvinfer1::NetworkDefinitionCreationFlag::kSTRONGLY_TYPED);
 #endif
         network_flags |= 1U << static_cast<uint32_t>(nvinfer1::NetworkDefinitionCreationFlag::kEXPLICIT_BATCH);
-        auto trt_network = std::unique_ptr<nvinfer1::INetworkDefinition>(trt_builder->createNetworkV2(network_flags));
 
+        auto trt_network = std::unique_ptr<nvinfer1::INetworkDefinition>(trt_builder->createNetworkV2(network_flags));
         auto trt_parser = tensorrt_ptr::unique_pointer<nvonnxparser::IParser>(nvonnxparser::createParser(*trt_network, trt_logger));
-#if defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable : 4996)
-#endif
+
+#if NV_TENSORRT_MAJOR == 10 && NV_TENSORRT_MINOR > 1 
+        auto is_model_supported = trt_parser->supportsModelV2(string_buf.data(), string_buf.size(), model_path_);
+
+        // Note: Calling getNbSubgraphs or getSubgraphNodes before calling supportsModelV2 results in undefined behavior.
+        auto num_subgraphs = trt_parser->getNbSubgraphs();
+        parser_nodes_list.reserve(num_subgraphs);
+
+        for (int64_t i = 0; i < num_subgraphs; ++i) {
+          int64_t subgraph_len = 0; 
+          int64_t* nodes = trt_parser->getSubgraphNodes(i, subgraph_len);  
+          parser_nodes_list.emplace_back();
+          parser_nodes_list.back().first.reserve(subgraph_len);
+          for (int64_t j = 0; j < subgraph_len; ++j) {
+            parser_nodes_list.back().first.push_back(nodes[j]);
+          }
+          parser_nodes_list.back().second = is_model_supported ? true : false;
+        }
+#else
         trt_parser->supportsModel(string_buf.data(), string_buf.size(), parser_nodes_list, model_path_);
-#if defined(_MSC_VER)
-#pragma warning(pop)
 #endif
 
         SubGraphCollection_t next_nodes_list;
@@ -2272,6 +2285,20 @@ SubGraphCollection_t TensorrtExecutionProvider::GetSupportedList(SubGraphCollect
         next_nodes_list = GetSupportedList(parser_nodes_list, iterations, max_iterations, *graph_viewer, early_termination);
         for (size_t i = 0, end = next_nodes_list.size(); i < end; ++i) {
           for (size_t j = 0, end = next_nodes_list[i].first.size(); j < end; ++j) {
+            /* Converting the supported node list returning from onnx-tensorrt parser to the node list recognized by ORT TRT.
+             *
+             * TRT EP reconstructs the graph based on the nodes in group.first as above and feeds this graph (converting to ModelProto and to string buffer) to onnx-tensorrt.
+             * The supported node index in the list returning from onnx-tensorrt parser might not be the same as the node index in group.first.
+             * Therefore, TRT EP needs a node index mapping table here, this is what "subgraph_node_index[next_nodes_list[i].first[j]]" is doining.
+             *
+             * The order of iterating the nodes in group.first and calling graph_build.AddNode() determines the node index of that node in the newly constructed graph (see Graph::AllocateNode() in graph.cc),
+             * since the iterating order is based on topo sort, the node order of the graph (ex: onnx-tensorrt calls model.graph().node() to iterate NodeProto in ModelProto) is the same as its topo sort order.
+             *
+             * In the past, TRT EP uses ORT's default reversed DFS topo sort which might end up with the sorting result not incremental, ex: the subgraph_node_index = [0,2,1,3,4].
+             * With the change of using ORT's priority-based topo sort (node with lower node index outputs first) the sorting result is incremental meaning subgraph_node_index is [0,1,2,3....],
+             * therefore subgraph_node_index as a mapping table is not needed anymore.
+             * TODO: Remove the subgraph_node_index
+             */
             next_nodes_list[i].first[j] = group.first[subgraph_node_index[next_nodes_list[i].first[j]]];
           }
           nodes_list_output.push_back(next_nodes_list[i]);

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -2294,11 +2294,11 @@ SubGraphCollection_t TensorrtExecutionProvider::GetSupportedList(SubGraphCollect
              * The order of iterating the nodes in group.first and calling graph_build.AddNode() determines the node order in the newly constructed graph (see Graph::AllocateNode() in graph.cc),
              * however, once the graph is converted to model proto, the node proto order in model proto (ex: onnx-tensorrt calls model.graph().node() to iterate NodeProto in ModelProto) is decided by topo sort.
              *
-             * The topo sort list, i.e. subgraph_node_index, acts as the node index mapping table:
+             * The topo sort list (i.e. subgraph_node_index) acts as the node index mapping table:
              * subgraph_node_index[node index from onnx-tensorrt parser] = index in group.first
              *
-             * In the past, TRT EP uses ORT's default reversed DFS topo sort which might end up with the sorting result not incremental, ex: the subgraph_node_index = [0,2,1,3,4].
-             * With the change of using ORT's priority-based topo sort (node with lower node index outputs first) the sorting result is incremental meaning subgraph_node_index is [0,1,2,3....],
+             * In the past, TRT EP uses ORT's default reversed DFS topo sort which might end up with the sorting result not sequence of 0, 1, ... n-1, ex: the subgraph_node_index = [0,2,1,3,4].
+             * With the change of using ORT's priority-based topo sort (node with lower node index outputs first) the sorting result is the sequence of 0, 1, ... n-1 for most of the cases,
              * therefore subgraph_node_index as a mapping table is not needed anymore.
              *
              * TODO: Remove the subgraph_node_index

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -2259,7 +2259,7 @@ SubGraphCollection_t TensorrtExecutionProvider::GetSupportedList(SubGraphCollect
         auto trt_network = std::unique_ptr<nvinfer1::INetworkDefinition>(trt_builder->createNetworkV2(network_flags));
         auto trt_parser = tensorrt_ptr::unique_pointer<nvonnxparser::IParser>(nvonnxparser::createParser(*trt_network, trt_logger));
 
-#if NV_TENSORRT_MAJOR == 10 && NV_TENSORRT_MINOR > 1 
+#if (NV_TENSORRT_MAJOR == 10 && NV_TENSORRT_MINOR > 1) || NV_TENSORRT_MAJOR > 10
         auto is_model_supported = trt_parser->supportsModelV2(string_buf.data(), string_buf.size(), model_path_);
 
         // Note: Calling getNbSubgraphs or getSubgraphNodes before calling supportsModelV2 results in undefined behavior.

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -2267,8 +2267,8 @@ SubGraphCollection_t TensorrtExecutionProvider::GetSupportedList(SubGraphCollect
         parser_nodes_list.reserve(num_subgraphs);
 
         for (int64_t i = 0; i < num_subgraphs; ++i) {
-          int64_t subgraph_len = 0; 
-          int64_t* nodes = trt_parser->getSubgraphNodes(i, subgraph_len);  
+          int64_t subgraph_len = 0;
+          int64_t* nodes = trt_parser->getSubgraphNodes(i, subgraph_len);
           parser_nodes_list.emplace_back();
           parser_nodes_list.back().first.reserve(subgraph_len);
           for (int64_t j = 0; j < subgraph_len; ++j) {
@@ -2285,8 +2285,7 @@ SubGraphCollection_t TensorrtExecutionProvider::GetSupportedList(SubGraphCollect
         next_nodes_list = GetSupportedList(parser_nodes_list, iterations, max_iterations, *graph_viewer, early_termination);
         for (size_t i = 0, end = next_nodes_list.size(); i < end; ++i) {
           for (size_t j = 0, end = next_nodes_list[i].first.size(); j < end; ++j) {
-
-            /* 
+            /*
              * Convert the supported node list returning from onnx-tensorrt parser to the node list recognized by ORT TRT.
              *
              * TRT EP reconstructs the graph based on the nodes in group.first and feeds this graph (converts to model proto and to string buffer) to onnx-tensorrt parser.
@@ -2296,7 +2295,7 @@ SubGraphCollection_t TensorrtExecutionProvider::GetSupportedList(SubGraphCollect
              * however, once the graph is converted to model proto, the node proto order in model proto (ex: onnx-tensorrt calls model.graph().node() to iterate NodeProto in ModelProto) is decided by topo sort.
              *
              * The topo sort list, i.e. subgraph_node_index, acts as the node index mapping table:
-             * subgraph_node_index[node index from onnx-tensorrt parser] = index in group.first  
+             * subgraph_node_index[node index from onnx-tensorrt parser] = index in group.first
              *
              * In the past, TRT EP uses ORT's default reversed DFS topo sort which might end up with the sorting result not incremental, ex: the subgraph_node_index = [0,2,1,3,4].
              * With the change of using ORT's priority-based topo sort (node with lower node index outputs first) the sorting result is incremental meaning subgraph_node_index is [0,1,2,3....],


### PR DESCRIPTION
`supportsModel` is deprecated in TRT 10.1.
Add `supportsModelV2 `but still keep `supportsModel` as we still need to support TRT 8.6 where `supportsModelV2 ` is not 
supported.

