### PR TITLE
Do not drop QDQ around linear Resize

### DIFF
--- a/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selector_action_transformer.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selector_action_transformer.cc
@@ -42,6 +42,7 @@ void DropQDQNodesRules(SelectorActionRegistry& qdq_selector_action_registry) {
   const std::string drop_action_name{"drop"};
   const std::string drop_action_no_int16_name{"drop_no_int16_support"};
   const std::string drop_action_no_int16_and_positive_scale_name{"drop_no_int16_support_and_positive_scale"};
+  const std::string drop_action_resize_nearest_name{"drop_resize_nearest"};
   NTO::NodeLocation dq{NTO::NodeType::kInput, 0};
   NTO::NodeLocation q{NTO::NodeType::kOutput, 0};
 
@@ -55,6 +56,8 @@ void DropQDQNodesRules(SelectorActionRegistry& qdq_selector_action_registry) {
       std::vector<NodeAndMoveInfo>(moves));  // Copy before std::move(moves)
   std::unique_ptr<Action> drop_action_no_int16_and_positive_scale = std::make_unique<MergeIntoTargetFixed>(
       std::vector<NodeAndMoveInfo>(moves));  // Copy before std::move(moves)
+  std::unique_ptr<Action> drop_action_resize_nearest = std::make_unique<MergeIntoTargetFixed>(
+      std::vector<NodeAndMoveInfo>(moves));  // Copy before std::move(moves)
   std::unique_ptr<Action> drop_action = std::make_unique<MergeIntoTargetFixed>(std::move(moves));
 
 #if !defined(ORT_MINIMAL_BUILD)
@@ -67,14 +70,11 @@ void DropQDQNodesRules(SelectorActionRegistry& qdq_selector_action_registry) {
   // And cannot eliminate the QDQ for MaxPool if the scale is not positive, as a negative
   // scale will change the ordering of the elements between quantized & de-quantized values.
   std::vector<const char*> providers = {kCpuExecutionProvider, kDmlExecutionProvider};
-  std::unique_ptr<NodeSelector> selector_no_16bit = std::make_unique<QDQ::DropQDQNodesSelector>(false,
-                                                                                                false,
-                                                                                                true,
-                                                                                                providers);
-  qdq_selector_action_registry.RegisterSelectorAndAction(drop_action_no_int16_name,
+  std::unique_ptr<NodeSelector> selector_resize_nearest = std::make_unique<QDQ::DropQDQNodesResizeNearestSelector>(false, false, true, providers);
+  qdq_selector_action_registry.RegisterSelectorAndAction(drop_action_resize_nearest_name,
                                                          {{"Resize", {}}},
-                                                         std::move(selector_no_16bit),
-                                                         std::move(drop_action_no_int16));
+                                                         std::move(selector_resize_nearest),
+                                                         std::move(drop_action_resize_nearest));
 
   std::unique_ptr<NodeSelector> selector_no_16bit_and_positive_scale =
       std::make_unique<QDQ::DropQDQNodesSelector>(false, true, false, providers);

--- a/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selectors.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selectors.cc
@@ -160,6 +160,19 @@ bool DropQDQNodeGroupSelector::Check(const GraphViewer& graph_viewer,
   return IsQDQPairSupported(q_node, dq_node, get_const_initializer, graph_viewer.ModelPath());
 }
 
+bool DropQDQNodeResizeNearestSelector::Check(const GraphViewer& graph_viewer,
+                                             const Node& node,
+                                             const std::vector<const Node*>& dq_nodes,
+                                             const std::vector<const Node*>& q_nodes) const {
+  if (!DropQDQNodeGroupSelector::Check(graph_viewer, node, dq_nodes, q_nodes)) {
+    return false;
+  }
+
+  const onnx::AttributeProto* mode = graph_utils::GetNodeAttribute(node, "mode");
+  // default mode is 'nearest'
+  return mode == nullptr || mode->s() == "nearest";
+}
+
 bool DropDQNodeGroupSelector::Check(const GraphViewer& graph_viewer,
                                     const Node& node,
                                     const std::vector<const Node*>& dq_nodes,

--- a/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selectors.h
+++ b/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selectors.h
@@ -52,14 +52,25 @@ class DropQDQNodeGroupSelector : public NodeGroupSelector {
                                     bool allow_nonpositive_scale = true)
       : allow_16bit_(allow_16bit), allow_4bit_(allow_4bit), allow_nonpositive_scale_(allow_nonpositive_scale) {}
 
- private:
+ protected:
   bool Check(const GraphViewer& graph_viewer, const Node& node,
              const std::vector<const Node*>& dq_nodes,
              const std::vector<const Node*>& q_nodes) const override;
 
+ private:
   bool allow_16bit_;
   bool allow_4bit_;
   bool allow_nonpositive_scale_;
+};
+
+class DropQDQNodeResizeNearestSelector : public DropQDQNodeGroupSelector {
+ public:
+  using DropQDQNodeGroupSelector::DropQDQNodeGroupSelector;
+
+ private:
+  bool Check(const GraphViewer& graph_viewer, const Node& node,
+             const std::vector<const Node*>& dq_nodes,
+             const std::vector<const Node*>& q_nodes) const override;
 };
 
 // Single DQ -> node.
@@ -306,6 +317,14 @@ class DropQDQNodesSelector : public BaseSelector {
                                 bool allow_nonpositive_scale = true,
                                 gsl::span<const char*> compatible_providers = {})
       : BaseSelector(std::make_unique<DropQDQNodeGroupSelector>(allow_16bit, allow_4bit, allow_nonpositive_scale),
+                     compatible_providers) {}
+};
+
+class DropQDQNodesResizeNearestSelector : public BaseSelector {
+ public:
+  explicit DropQDQNodesResizeNearestSelector(bool allow_16bit = false, bool allow_4bit = false, bool allow_nonpositive_scale = true,
+                                             gsl::span<const char*> compatible_providers = {})
+      : BaseSelector(std::make_unique<DropQDQNodeResizeNearestSelector>(allow_16bit, allow_4bit, allow_nonpositive_scale),
                      compatible_providers) {}
 };
 


### PR DESCRIPTION
It's not numerically equivalent to drop Q DQ nodes around a Resize when the Resize is using linear interpolation.
This PR only drops QDQ around resize using the `nearest` interpolation.

See https://github.com/microsoft/onnxruntime/issues/21319 for details.

fixes https://github.com/microsoft/onnxruntime/issues/21319
