### PR TITLE
Fix std::chrono/date conflict for mac builds with C++20

### DIFF
--- a/include/onnxruntime/core/common/logging/logging.h
+++ b/include/onnxruntime/core/common/logging/logging.h
@@ -58,14 +58,40 @@ namespace logging {
 
 using Timestamp = std::chrono::time_point<std::chrono::system_clock>;
 
-// TODO: When other compilers support std::chrono::operator<<, update this.
-// TODO: Check support for other compilers' version before enable C++20 for other compilers.
-// Xcode added support for C++20's std::chrono::operator<< in SDK version 14.4.
-#if __cplusplus >= 202002L && __MAC_OS_X_VERSION_MAX_ALLOWED >= 140400L
+// C++20 has operator<< in std::chrono for Timestamp type but mac builds need additional checks
+// to ensure usage is valid.
+#define _USE_CXX20_STD_CHRONO __cplusplus >= 202002L
+
+// Apply constraints for mac builds
+#if __APPLE__
+#include <TargetConditionals.h>
+
+// Catalyst check must be first as it has both TARGET_OS_MACCATALYST and TARGET_OS_MAC set
+#if TARGET_OS_MACCATALYST
+// maccatalyst requires version 16.3
+#if (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED < 160300)
+#undef _USE_CXX20_STD_CHRONO
+#endif
+
+#elif TARGET_OS_MAC
+// Xcode added support for C++20's std::chrono::operator<< in SDK version 14.4,
+// but the target macOS version must also be >= 13.3 for it to be used.
+#if (defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED < 140400) || \
+    (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED < 130300)
+#undef _USE_CXX20_STD_CHRONO
+#endif
+
+#endif
+
+#endif  // __APPLE__
+
+#if _USE_CXX20_STD_CHRONO
 namespace timestamp_ns = std::chrono;
 #else
 namespace timestamp_ns = ::date;
 #endif
+
+#undef _USE_CXX20_STD_CHRONO
 
 #ifndef NDEBUG
 ORT_ATTRIBUTE_UNUSED static bool vlog_enabled = true;  // Set directly based on your needs.

--- a/include/onnxruntime/core/common/logging/logging.h
+++ b/include/onnxruntime/core/common/logging/logging.h
@@ -60,6 +60,7 @@ using Timestamp = std::chrono::time_point<std::chrono::system_clock>;
 
 // C++20 has operator<< in std::chrono for Timestamp type but mac builds need additional checks
 // to ensure usage is valid.
+// TODO: As we enable C++20 on other platforms we may need similar checks.
 #define _USE_CXX20_STD_CHRONO __cplusplus >= 202002L
 
 // Apply constraints for mac builds

--- a/include/onnxruntime/core/common/logging/logging.h
+++ b/include/onnxruntime/core/common/logging/logging.h
@@ -61,6 +61,7 @@ using Timestamp = std::chrono::time_point<std::chrono::system_clock>;
 // C++20 has operator<< in std::chrono for Timestamp type but mac builds need additional checks
 // to ensure usage is valid.
 // TODO: As we enable C++20 on other platforms we may need similar checks.
+// define a temporary value to determine whether to use the std::chrono or date implementation.
 #define TEMP_USE_CXX20_STD_CHRONO __cplusplus >= 202002L
 
 // Apply constraints for mac builds

--- a/include/onnxruntime/core/common/logging/logging.h
+++ b/include/onnxruntime/core/common/logging/logging.h
@@ -62,7 +62,7 @@ using Timestamp = std::chrono::time_point<std::chrono::system_clock>;
 // to ensure usage is valid.
 // TODO: As we enable C++20 on other platforms we may need similar checks.
 // define a temporary value to determine whether to use the std::chrono or date implementation.
-#define TEMP_USE_CXX20_STD_CHRONO __cplusplus >= 202002L
+#define ORT_USE_CXX20_STD_CHRONO __cplusplus >= 202002L
 
 // Apply constraints for mac builds
 #if __APPLE__
@@ -72,7 +72,7 @@ using Timestamp = std::chrono::time_point<std::chrono::system_clock>;
 #if TARGET_OS_MACCATALYST
 // maccatalyst requires version 16.3
 #if (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED < 160300)
-#undef TEMP_USE_CXX20_STD_CHRONO
+#undef ORT_USE_CXX20_STD_CHRONO
 #endif
 
 #elif TARGET_OS_MAC
@@ -80,20 +80,19 @@ using Timestamp = std::chrono::time_point<std::chrono::system_clock>;
 // but the target macOS version must also be >= 13.3 for it to be used.
 #if (defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED < 140400) || \
     (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED < 130300)
-#undef TEMP_USE_CXX20_STD_CHRONO
+#undef ORT_USE_CXX20_STD_CHRONO
 #endif
 
 #endif
-
 #endif  // __APPLE__
 
-#if TEMP_USE_CXX20_STD_CHRONO
+#if ORT_USE_CXX20_STD_CHRONO
 namespace timestamp_ns = std::chrono;
 #else
 namespace timestamp_ns = ::date;
 #endif
 
-#undef _USE_CXX20_STD_CHRONO
+#undef ORT_USE_CXX20_STD_CHRONO
 
 #ifndef NDEBUG
 ORT_ATTRIBUTE_UNUSED static bool vlog_enabled = true;  // Set directly based on your needs.

--- a/include/onnxruntime/core/common/logging/logging.h
+++ b/include/onnxruntime/core/common/logging/logging.h
@@ -61,7 +61,7 @@ using Timestamp = std::chrono::time_point<std::chrono::system_clock>;
 // C++20 has operator<< in std::chrono for Timestamp type but mac builds need additional checks
 // to ensure usage is valid.
 // TODO: As we enable C++20 on other platforms we may need similar checks.
-#define _USE_CXX20_STD_CHRONO __cplusplus >= 202002L
+#define TEMP_USE_CXX20_STD_CHRONO __cplusplus >= 202002L
 
 // Apply constraints for mac builds
 #if __APPLE__
@@ -71,7 +71,7 @@ using Timestamp = std::chrono::time_point<std::chrono::system_clock>;
 #if TARGET_OS_MACCATALYST
 // maccatalyst requires version 16.3
 #if (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED < 160300)
-#undef _USE_CXX20_STD_CHRONO
+#undef TEMP_USE_CXX20_STD_CHRONO
 #endif
 
 #elif TARGET_OS_MAC
@@ -79,14 +79,14 @@ using Timestamp = std::chrono::time_point<std::chrono::system_clock>;
 // but the target macOS version must also be >= 13.3 for it to be used.
 #if (defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED < 140400) || \
     (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED < 130300)
-#undef _USE_CXX20_STD_CHRONO
+#undef TEMP_USE_CXX20_STD_CHRONO
 #endif
 
 #endif
 
 #endif  // __APPLE__
 
-#if _USE_CXX20_STD_CHRONO
+#if TEMP_USE_CXX20_STD_CHRONO
 namespace timestamp_ns = std::chrono;
 #else
 namespace timestamp_ns = ::date;

--- a/onnxruntime/core/common/logging/sinks/ostream_sink.cc
+++ b/onnxruntime/core/common/logging/sinks/ostream_sink.cc
@@ -45,7 +45,8 @@ void OStreamSink::SendImpl(const Timestamp& timestamp, const std::string& logger
   }
 #endif
 
-  msg << timestamp << " [" << message.SeverityPrefix() << ":" << message.Category() << ":" << logger_id << ", "
+  timestamp_ns::operator<<(msg, timestamp);  // handle ambiguity with C++20 where date and std::chrono have operator<<
+  msg << " [" << message.SeverityPrefix() << ":" << message.Category() << ":" << logger_id << ", "
       << message.Location().ToString() << "] " << message.Message();
 
 #ifndef ORT_MINIMAL_BUILD

--- a/onnxruntime/core/platform/apple/logging/apple_log_sink.mm
+++ b/onnxruntime/core/platform/apple/logging/apple_log_sink.mm
@@ -15,7 +15,9 @@ namespace logging {
 void AppleLogSink::SendImpl(const Timestamp& timestamp, const std::string& logger_id, const Capture& message) {
   using timestamp_ns::operator<<;
   std::ostringstream msg;
-  msg << timestamp << " [" << message.SeverityPrefix() << ":" << message.Category() << ":" << logger_id << ", "
+
+  timestamp_ns::operator<<(msg, timestamp); // handle ambiguity with C++20 where date and std::chrono have operator<<
+  msg << " [" << message.SeverityPrefix() << ":" << message.Category() << ":" << logger_id << ", "
       << message.Location().ToString() << "] " << message.Message();
   NSLog(@"%s", msg.str().c_str());
 }

--- a/onnxruntime/core/platform/apple/logging/apple_log_sink.mm
+++ b/onnxruntime/core/platform/apple/logging/apple_log_sink.mm
@@ -16,7 +16,7 @@ void AppleLogSink::SendImpl(const Timestamp& timestamp, const std::string& logge
   using timestamp_ns::operator<<;
   std::ostringstream msg;
 
-  timestamp_ns::operator<<(msg, timestamp); // handle ambiguity with C++20 where date and std::chrono have operator<<
+  timestamp_ns::operator<<(msg, timestamp);  // handle ambiguity with C++20 where date and std::chrono have operator<<
   msg << " [" << message.SeverityPrefix() << ":" << message.Category() << ":" << logger_id << ", "
       << message.Location().ToString() << "] " << message.Message();
   NSLog(@"%s", msg.str().c_str());


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Fix usage of c++ std::chrono::operator<< in mac builds for wider range of xcode/targets.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Resolve #21033
