### PR TITLE
Add project context to PropertyPageSchema

### DIFF
--- a/csharp/src/Microsoft.AI.MachineLearning.Interop/Microsoft.AI.MachineLearning.props
+++ b/csharp/src/Microsoft.AI.MachineLearning.Interop/Microsoft.AI.MachineLearning.props
@@ -10,7 +10,9 @@
   </ItemDefinitionGroup>
 
   <ItemGroup>
-    <PropertyPageSchema Include="$(MSBuildThisFileDirectory)\Microsoft.AI.MachineLearning.Rules.Project.xml"/>
+    <PropertyPageSchema Include="$(MSBuildThisFileDirectory)\Microsoft.AI.MachineLearning.Rules.Project.xml">
+      <Context>Project</Context>
+    </PropertyPageSchema>
   </ItemGroup>
 
   <PropertyGroup>

--- a/csharp/src/Microsoft.AI.MachineLearning/Microsoft.AI.MachineLearning.props
+++ b/csharp/src/Microsoft.AI.MachineLearning/Microsoft.AI.MachineLearning.props
@@ -10,7 +10,9 @@
   </ItemDefinitionGroup>
 
   <ItemGroup>
-    <PropertyPageSchema Include="$(MSBuildThisFileDirectory)\Microsoft.AI.MachineLearning.Rules.Project.xml"/>
+    <PropertyPageSchema Include="$(MSBuildThisFileDirectory)\Microsoft.AI.MachineLearning.Rules.Project.xml">
+      <Context>Project</Context>
+    </PropertyPageSchema>
   </ItemGroup>
 
   <PropertyGroup Label="Globals">


### PR DESCRIPTION
### Description

The PropertyPageSchema entries in the .props files are missing context entries, which this PR adds.


### Motivation and Context

Fixes #20574

This leads to problems in VS where extensions start to crash when the DirectML Onnxruntime NuGet package is added to the project. See https://github.com/dotnet/project-system/issues/8418 and https://github.com/AvaloniaUI/AvaloniaVS/issues/472#issuecomment-2358142471 for more details.

