### PR TITLE
Check if HTMLCanvasElement exists (i.e. we are not running in a webworker)

### DIFF
--- a/js/common/lib/tensor-factory-impl.ts
+++ b/js/common/lib/tensor-factory-impl.ts
@@ -152,7 +152,7 @@ export const tensorFromImage = async (
     }
   };
   const createCanvasContext = (canvas: HTMLCanvasElement | OffscreenCanvas) => {
-    if (canvas instanceof HTMLCanvasElement) {
+    if (typeof HTMLCanvasElement !== undefined && canvas instanceof HTMLCanvasElement) {
       return canvas.getContext('2d');
     } else if (canvas instanceof OffscreenCanvas) {
       return canvas.getContext('2d') as OffscreenCanvasRenderingContext2D;

--- a/js/common/lib/tensor-factory-impl.ts
+++ b/js/common/lib/tensor-factory-impl.ts
@@ -152,7 +152,7 @@ export const tensorFromImage = async (
     }
   };
   const createCanvasContext = (canvas: HTMLCanvasElement | OffscreenCanvas) => {
-    if (typeof HTMLCanvasElement !== undefined && canvas instanceof HTMLCanvasElement) {
+    if (typeof HTMLCanvasElement !== 'undefined' && canvas instanceof HTMLCanvasElement) {
       return canvas.getContext('2d');
     } else if (canvas instanceof OffscreenCanvas) {
       return canvas.getContext('2d') as OffscreenCanvasRenderingContext2D;


### PR DESCRIPTION
This fixes #22152


### Description
Tensor.fromImage fails in a webworker context, because HTMLCanvasElement does not exist:

> HTMLCanvasElement is not defined



### Motivation and Context
This fixes #22152

