### PR TITLE
set CMAKE_SYSTEM_PROCESSOR in xnnpack.cmake

### DIFF
--- a/cmake/external/xnnpack.cmake
+++ b/cmake/external/xnnpack.cmake
@@ -80,6 +80,9 @@ MESSAGE(STATUS "Building for ORT_TARGET_PROCESSOR: ${ORT_TARGET_PROCESSOR}")
 # KleidiAI is only used in Arm64 platform and not supported by MSVC, the details can be seen in
 # https://github.com/google/XNNPACK/blob/3b3f7b8a6668f6ab3b6ce33b9f1d1fce971549d1/CMakeLists.txt#L206C82-L206C117
 if(ORT_TARGET_PROCESSOR MATCHES "^arm64.*" AND NOT CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+  # kleidiAI use CMAKE_SYSTEM_PROCESSOR to determine whether includes aarch64/arm64 ukernels
+  # https://gitlab.arm.com/kleidi/kleidiai/-/blob/main/CMakeLists.txt#L134
+  set(CMAKE_SYSTEM_PROCESSOR arm64)
   FetchContent_Declare(kleidiai URL ${DEP_URL_kleidiai} URL_HASH SHA1=${DEP_SHA1_kleidiai})
   onnxruntime_fetchcontent_makeavailable(kleidiai)
   set(KLEIDIAI_SOURCE_DIR ${kleidiai_SOURCE_DIR})

--- a/tools/ci_build/github/apple/default_full_apple_framework_build_settings.json
+++ b/tools/ci_build/github/apple/default_full_apple_framework_build_settings.json
@@ -24,7 +24,7 @@
         ],
         "macosx": [
             "--macos=MacOSX",
-            "--apple_deploy_target=13.3"
+            "--apple_deploy_target=11.0"
         ],
         "iphoneos": [
             "--ios",


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->



### Motivation and Context
By default, CMAKE_SYSTEM_PROCESSOR is same CMAKE_HOST_SYSTEM_PROCESSOR
https://cmake.org/cmake/help/latest/variable/CMAKE_SYSTEM_PROCESSOR.html
KleidiAI uses CMAKE_SYSTEM_PROCESSOR to determine whether to include some arm64 ukernels.
https://gitlab.arm.com/kleidi/kleidiai/-/blob/main/CMakeLists.txt#L134
We use Mac with Intel CPU to cross compile MAC with ARM in ios packaging pipeline
So  we need to make CMAKE_SYSTEM_PROCESSOR same with ORT_TARGET_PROCESSOR


