### PR TITLE
[qnn ep] fix naming convention of ort-nightly-qnn package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ elif parse_arg_remove_boolean(sys.argv, "--use_azure"):
     pass
 elif parse_arg_remove_boolean(sys.argv, "--use_qnn"):
     is_qnn = True
-    package_name = "onnxruntime-qnn" if not nightly_build else "ort-qnn-nightly"
+    package_name = "onnxruntime-qnn" if not nightly_build else "ort-nightly-qnn"
 
 if is_rocm or is_migraphx:
     package_name = "onnxruntime-rocm" if not nightly_build else "ort-rocm-nightly"


### PR DESCRIPTION
followed the rocm example below it which isn't the naming convention we want to follow. didn't fix rocm because i'm not sure if there are consumers using its naming convention.