### PR TITLE
Fix QNN random crash for UT with multi-thread run

### DIFF
--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -36,7 +36,7 @@ constexpr const char* QNN = "QNN";
 static std::unique_ptr<std::vector<std::function<void()>>> s_run_on_unload_;
 
 void RunOnUnload(std::function<void()> function) {
-  OrtMutex mutex;
+  static OrtMutex mutex;
   std::lock_guard<OrtMutex> guard(mutex);
   if (!s_run_on_unload_) {
     s_run_on_unload_ = std::make_unique<std::vector<std::function<void()>>>();


### PR DESCRIPTION
### Description
Fix random crash for QNN UTs with multi-thread run like  QnnHTPBackendTests.MultithreadHtpPowerCfgDefaultAndRunOption

Root cause, last minute code change
https://github.com/microsoft/onnxruntime/pull/19521/commits/b4e26bd5f929cee7d303aaf7eccd262f7ae4099a
static std::mutex mutex; -> OrtMutex mutex;
missed static.


