### PR TITLE
[TensorRT EP] update gen_trt_engine_wrapper_onnx_model.py script

### DIFF
--- a/onnxruntime/python/tools/tensorrt/gen_trt_engine_wrapper_onnx_model.py
+++ b/onnxruntime/python/tools/tensorrt/gen_trt_engine_wrapper_onnx_model.py
@@ -38,7 +38,7 @@ class TensorRTEngineWrapperCreator:
         # Deserialize an TRT engine
         runtime = trt.Runtime(logger)
         engine = runtime.deserialize_cuda_engine(engine_buffer)
-        num_bindings = engine.num_bindings
+        num_bindings = engine.num_io_tensors
 
         input_tensors = []
         output_tensors = []


### PR DESCRIPTION
update script which was using deprecated num_bindings to num_io_tensors
tested on an engine dumped by trtexec and loaded the engine using onnxruntime-gpu 1.19.2 python package.