### PR TITLE
[js/web] make ort-web export compatible with webpack

### DIFF
--- a/js/web/lib/build-def.d.ts
+++ b/js/web/lib/build-def.d.ts
@@ -29,10 +29,6 @@ interface BuildDefinitions {
    */
   readonly DISABLE_WASM_PROXY: boolean;
   /**
-   * defines whether to disable training APIs in WebAssembly backend.
-   */
-  readonly DISABLE_TRAINING: boolean;
-  /**
    * defines whether to disable dynamic importing WASM module in the build.
    */
   readonly DISABLE_DYNAMIC_IMPORT: boolean;
@@ -48,9 +44,38 @@ interface BuildDefinitions {
   /**
    * placeholder for the import.meta.url in ESM. in CJS, this is undefined.
    */
-  readonly ESM_IMPORT_META_URL: string|undefined;
+  readonly ESM_IMPORT_META_URL: string | undefined;
 
   // #endregion
+
+  /**
+   * placeholder for the bundle filename.
+   *
+   * This is used for bundler compatibility fix when using Webpack with `import.meta.url` inside ESM module.
+   *
+   * The default behavior of some bundlers (eg. Webpack) is to rewrite `import.meta.url` to the file local path at
+   * compile time. This behavior will break the following code:
+   * ```js
+   * new Worker(new URL(import.meta.url), { type: 'module' });
+   * ```
+   *
+   * This is because the `import.meta.url` will be rewritten to a local path, so the line above will be equivalent to:
+   * ```js
+   * new Worker(new URL('file:///path/to/your/file.js'), { type: 'module' });
+   * ```
+   *
+   * This will cause the browser fails to load the worker script.
+   *
+   * To fix this, we need to align with how the bundlers deal with `import.meta.url`:
+   * ```js
+   * new Worker(new URL('path-to-bundle.mjs', import.meta.url), { type: 'module' });
+   * ```
+   *
+   * This will make the browser load the worker script correctly.
+   *
+   * Since we have multiple bundle outputs, we need to define this placeholder in the build definitions.
+   */
+  readonly BUNDLE_FILENAME: string;
 }
 
 declare const BUILD_DEFS: BuildDefinitions;

--- a/js/web/package.json
+++ b/js/web/package.json
@@ -85,7 +85,7 @@
     },
     "./wasm": {
       "node": null,
-      "import": "./dist/ort.wasm.min.mjs",
+      "import": "./dist/ort.wasm.bundle.min.mjs",
       "require": "./dist/ort.wasm.min.js",
       "types": "./types.d.ts"
     },


### PR DESCRIPTION
### Description

This PR fixes a few problems when using onnxruntime-web as dependency in webpack.

### Context

While onnxruntime-web fully supports ESM since v1.19, there are still issues reported for consuming onnxruntime-web in some frameworks like Next.js. After some investigation, one of the root causes is identified: onnxruntime-web depends on runtime evaluation of `import.meta.url` to create workers for proxy feature and web assembly multi-threading, but the runtime evaluation of `import.meta.url` is not supported by default for the mainstream version of the bundlers like Webpack.

Back to the old days when browsers didn't support `import.meta.url`, the bundlers encourages to use it in the form of:
```js
new URL('my-file-name.js', import.meta.url)
```
This URL will be pre-processed at compile time to be replaced by a modified URL (can be script/asset/...) and it worked perfectly with bundler to resolve a lot of resource bundling requirement.

Today, most of the browsers support evaluating `import.meta.url` at runtime. It is expected to return the runtime URL of the current running script. This feature helps ESM scripts to load (both statically and dynamically) resources in a "modern" way. Unfortunately, this is conflicted with the "old way" that the bundler's default behavior.

Issues like #22113 is exactly caused by this problem.

### Workaround

Ideally the solution should be provided by the bundler. However considering the wide usage of webpack and its ecosystem, we need to make a workaround to let onnxruntime-web working with bundlers with default configuration, before webpack fully supports ESM. (it is going to be a while for [Webpack itself](https://github.com/webpack/webpack/issues/2933) and features (eg. HMR))

The workaround is simple:

```js
if (import.meta.url.startsWith('file:')) {
  // only when webpack overwrites `import.meta.url`
  url = new URL('ort.bundle.min.mjs', import.meta.url);
} else {
  url = new URL(import.meta.url);
}
```

This workaround works with the "bundled" build and tested with the following usage:
- proxy off, multi-threading off
- proxy on, multi-threading off
- proxy off, multi-threading on
- proxy on, multi-threading on