### PR TITLE
[js/webgpu] Manage model download with a specific unittest option

### DIFF
--- a/js/web/script/test-runner-cli-args.ts
+++ b/js/web/script/test-runner-cli-args.ts
@@ -48,6 +48,7 @@ Options:
                                  node
                                  bs         (for BrowserStack tests)
  -p, --profile                 Enable profiler.
+ -m, --download-model          Enable model download.
                                  Profiler will generate extra logs which include the information of events time consumption
  -t, --trace                   Enable trace.
  -P[=<...>], --perf[=<...>]    Generate performance number. Cannot be used with flag --debug.
@@ -168,6 +169,11 @@ export interface TestRunnerCliArgs {
    * Whether to enable InferenceSession's profiler
    */
   profile: boolean;
+
+  /**
+   * whether to enable model download
+   */
+  downloadModel: boolean;
 
   /**
    * Whether to enable file cache
@@ -429,6 +435,9 @@ export function parseTestRunnerCliArgs(cmdlineArgs: string[]): TestRunnerCliArgs
     logLevel = 'verbose';
   }
 
+  // Option: -m, --download-model
+  const downloadModel = args['download-model'] || args.m ? true : false;
+
   // Option: -t, --trace
   const trace = parseBooleanArg(args.trace || args.t, false);
 
@@ -515,6 +524,7 @@ export function parseTestRunnerCliArgs(cmdlineArgs: string[]): TestRunnerCliArgs
     env: env as TestRunnerCliArgs['env'],
     logConfig,
     profile,
+    downloadModel,
     times: perf ? times : undefined,
     ioBindingMode: ioBindingMode as TestRunnerCliArgs['ioBindingMode'],
     optimizedModelFilePath,

--- a/js/web/script/test-runner-cli.ts
+++ b/js/web/script/test-runner-cli.ts
@@ -161,6 +161,7 @@ async function main() {
     op: opTestGroups,
     log: args.logConfig,
     profile: args.profile,
+    downloadModel: args.downloadModel,
     options: {
       sessionOptions: {
         graphOptimizationLevel: args.graphOptimizationLevel,

--- a/js/web/test/test-main.ts
+++ b/js/web/test/test-main.ts
@@ -99,7 +99,11 @@ for (const group of ORT_WEB_TEST_CONFIG.op) {
 
         before('Initialize Context', async () => {
           context = useProtoOpTest
-            ? new ProtoOpTestContext(test, ORT_WEB_TEST_CONFIG.options.sessionOptions)
+            ? new ProtoOpTestContext(
+                test,
+                ORT_WEB_TEST_CONFIG.downloadModel,
+                ORT_WEB_TEST_CONFIG.options.sessionOptions,
+              )
             : new OpTestContext(test);
           await context.init();
           if (ORT_WEB_TEST_CONFIG.profile) {

--- a/js/web/test/test-runner.ts
+++ b/js/web/test/test-runner.ts
@@ -799,6 +799,7 @@ export class ProtoOpTestContext {
   readonly ioBindingMode: Test.IOBindingMode;
   constructor(
     test: Test.OperatorTest,
+    private readonly downloadModel: boolean,
     private readonly sessionOptions: ort.InferenceSession.SessionOptions = {},
   ) {
     const opsetImport = onnx.OperatorSetIdProto.create(test.opset);
@@ -986,7 +987,7 @@ export class ProtoOpTestContext {
     this.loadedData = onnx.ModelProto.encode(model).finish().slice();
 
     // in debug mode, open a new tab in browser for the generated onnx model.
-    if (ort.env.debug) {
+    if (this.downloadModel) {
       const modelFile = new File([this.loadedData], `op_test_generated_model_${test.name}.onnx`, {
         type: 'application/octet-stream',
       });

--- a/js/web/test/test-runner.ts
+++ b/js/web/test/test-runner.ts
@@ -986,7 +986,6 @@ export class ProtoOpTestContext {
     this.ioBindingMode = test.ioBinding;
     this.loadedData = onnx.ModelProto.encode(model).finish().slice();
 
-    // in debug mode, open a new tab in browser for the generated onnx model.
     if (this.downloadModel) {
       const modelFile = new File([this.loadedData], `op_test_generated_model_${test.name}.onnx`, {
         type: 'application/octet-stream',

--- a/js/web/test/test-types.ts
+++ b/js/web/test/test-types.ts
@@ -168,6 +168,7 @@ export declare namespace Test {
 
     log: ReadonlyArray<{ category: string; config: Logger.Config }>;
     profile: boolean;
+    downloadModel: boolean;
     options: Options;
   }
 }


### PR DESCRIPTION
Currently in debug mode, unit test will always download models to local file system, which is a bit annoying. This PR fixes this by adding a specific option to enable model download.

