### PR TITLE
Add microbenchmark for layer normalization and improve latency

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -1128,7 +1128,8 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
       ${BENCHMARK_DIR}/gelu.cc
       ${BENCHMARK_DIR}/activation.cc
       ${BENCHMARK_DIR}/quantize.cc
-      ${BENCHMARK_DIR}/reduceminmax.cc)
+      ${BENCHMARK_DIR}/reduceminmax.cc
+      ${BENCHMARK_DIR}/layer_normalization.cc)
     target_include_directories(onnxruntime_benchmark PRIVATE ${ONNXRUNTIME_ROOT} ${onnxruntime_graph_header} ${ONNXRUNTIME_ROOT}/core/mlas/inc)
     target_compile_definitions(onnxruntime_benchmark PRIVATE BENCHMARK_STATIC_DEFINE)
     if(WIN32)

--- a/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
+++ b/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
@@ -260,24 +260,12 @@ Status SkipLayerNorm<T, simplified>::Compute(OpKernelContext* p_ctx) const {
   int64_t task_count = input->Shape().SizeToDimension(input_dims_size - 1);
 
   const T* input_data = input->Data<T>();
-  if (!input_data) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "The input data should not be null.");
-  }
   const T* skip_data = skip->Data<T>();
-  if (!skip_data) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "The skip data should not be null.");
-  }
   const T* gamma_data = gamma->Data<T>();
-  if (!gamma_data) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "The gamma data should not be null.");
-  }
   const T* beta_data = beta == nullptr ? nullptr : beta->Data<T>();
   const T* bias_data = bias == nullptr ? nullptr : bias->Data<T>();
 
   T* output_data = output->MutableData<T>();
-  if (!output_data) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "The output data pointer should not be null.");
-  }
 
   // For inferencing, we support one more optional output which is the sum of the input and skip tensors
   T* skip_input_bias_add_output_data = skip_input_bias_add_output == nullptr ? nullptr : skip_input_bias_add_output->MutableData<T>();

--- a/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
+++ b/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
@@ -40,18 +40,15 @@ REGISTER_KERNEL_TYPED(MLFloat16)
 
 namespace {
 
-ORT_FORCEINLINE double* CreateBufferIfMLFloat16(double* p_output, int num_elems)
-{
+ORT_FORCEINLINE double* CreateBufferIfMLFloat16(double* p_output, int num_elems) {
   return p_output;
 }
 
-ORT_FORCEINLINE float* CreateBufferIfMLFloat16(float* p_output, int num_elems)
-{
+ORT_FORCEINLINE float* CreateBufferIfMLFloat16(float* p_output, int num_elems) {
   return p_output;
 }
 
-ORT_FORCEINLINE float* CreateBufferIfMLFloat16(MLFloat16* p_output, int num_elems)
-{
+ORT_FORCEINLINE float* CreateBufferIfMLFloat16(MLFloat16* p_output, int num_elems) {
   return p_output == nullptr ? nullptr : new float[num_elems];
 }
 
@@ -61,14 +58,12 @@ ORT_FORCEINLINE std::shared_ptr<std::vector<float>> ConvertHalfToFloatBufferIfNe
 
 template <typename T>
 ORT_FORCEINLINE std::shared_ptr<std::vector<float>> ConvertHalfToFloatBufferIfNeeded(
-  const std::enable_if_t<std::is_same_v<T,float> || std::is_same_v<T, double>, T>* p_input, int num_elems)
-{
+  const std::enable_if_t<std::is_same_v<T,float> || std::is_same_v<T, double>, T>* p_input, int num_elems) {
   return nullptr;
 }
 
 template<>
-std::shared_ptr<std::vector<float>> ConvertHalfToFloatBufferIfNeeded<MLFloat16>(const MLFloat16* p_input, int num_elems)
-{
+std::shared_ptr<std::vector<float>> ConvertHalfToFloatBufferIfNeeded<MLFloat16>(const MLFloat16* p_input, int num_elems) {
   if (!p_input) {
     return nullptr;
   }
@@ -81,8 +76,7 @@ std::shared_ptr<std::vector<float>> ConvertHalfToFloatBufferIfNeeded<MLFloat16>(
 }
 
 
-void ConvertFloatBufferToMLFloat16(const float* output_buffer, MLFloat16* p_output, int num_elems)
-{
+void ConvertFloatBufferToMLFloat16(const float* output_buffer, MLFloat16* p_output, int num_elems) {
   if (!output_buffer || !p_output) {
     return;
   }

--- a/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
+++ b/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
@@ -40,31 +40,27 @@ REGISTER_KERNEL_TYPED(MLFloat16)
 
 namespace {
 
-double* CreateBufferIfMLFloat16(double* p_output, int num_elems)
+ORT_FORCEINLINE double* CreateBufferIfMLFloat16(double* p_output, int num_elems)
 {
   return p_output;
 }
 
-float* CreateBufferIfMLFloat16(float* p_output, int num_elems)
+ORT_FORCEINLINE float* CreateBufferIfMLFloat16(float* p_output, int num_elems)
 {
   return p_output;
 }
 
-float* CreateBufferIfMLFloat16(MLFloat16* p_output, int num_elems)
+ORT_FORCEINLINE float* CreateBufferIfMLFloat16(MLFloat16* p_output, int num_elems)
 {
-  if (!p_output) {
-    return nullptr;
-  }
-
-  return new float[num_elems];
+  return p_output == nullptr ? nullptr : new float[num_elems];
 }
 
 
 template <typename T>
-std::shared_ptr<std::vector<float>> ConvertHalfToFloatBufferIfNeeded(const T* p_input, int num_elems);
+ORT_FORCEINLINE std::shared_ptr<std::vector<float>> ConvertHalfToFloatBufferIfNeeded(const T* p_input, int num_elems);
 
 template <typename T>
-std::shared_ptr<std::vector<float>> ConvertHalfToFloatBufferIfNeeded(
+ORT_FORCEINLINE std::shared_ptr<std::vector<float>> ConvertHalfToFloatBufferIfNeeded(
   const std::enable_if_t<std::is_same_v<T,float> || std::is_same_v<T, double>, T>* p_input, int num_elems)
 {
   return nullptr;

--- a/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
+++ b/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
@@ -121,38 +121,19 @@ Status ComputeJob(
   float mean_square(0.0f);
   const size_t num_elems = static_cast<size_t>(hidden_size);
 
-  float* float_input = nullptr;
-  try {
-    float_input = new float[num_elems];
-    MlasConvertHalfToFloatBuffer(p_input, float_input, num_elems);
-  } catch (const std::exception& e) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, RUNTIME_EXCEPTION, "Failed to convert input data to float: ", e.what());
-  }
+  float* float_input = new float[num_elems];
+  MlasConvertHalfToFloatBuffer(p_input, float_input, num_elems);
 
-  float* float_skip = nullptr;
-  try {
-    float_skip = new float[num_elems];
-    MlasConvertHalfToFloatBuffer(p_skip, float_skip, num_elems);
-  } catch (const std::exception& e) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, RUNTIME_EXCEPTION, "Failed to convert skip data to float: ", e.what());
-  }
+  float* float_skip = new float[num_elems];
+  MlasConvertHalfToFloatBuffer(p_skip, float_skip, num_elems);
 
   float* float_bias = nullptr;
   if (bias_data != nullptr) {
-    try {
-      float_bias = new float[num_elems];
-      MlasConvertHalfToFloatBuffer(bias_data, float_bias, num_elems);
-    } catch (const std::exception& e) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, RUNTIME_EXCEPTION, "Failed to convert bias data to float: ", e.what());
-    }
+    float_bias = new float[num_elems];
+    MlasConvertHalfToFloatBuffer(bias_data, float_bias, num_elems);
   }
 
-  float* float_output = nullptr;
-  try {
-    float_output = new float[num_elems];
-  } catch (const std::exception& e) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, RUNTIME_EXCEPTION, "Failed to allocate memory for float output.", e.what());
-  }
+  float* float_output = new float[num_elems];
 
   for (size_t h = 0; h < num_elems; h++) {
     float val = float_input[h] + float_skip[h];
@@ -171,11 +152,7 @@ Status ComputeJob(
   }
 
   if (nullptr != p_skip_input_bias_add_output) {
-    try {
-      MlasConvertFloatToHalfBuffer(float_output, p_skip_input_bias_add_output, num_elems);
-    } catch (const std::exception& e) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, RUNTIME_EXCEPTION, "Failed to convert skip_input_bias_add_output data to MLFLoat16: ", e.what());
-    }
+    MlasConvertFloatToHalfBuffer(float_output, p_skip_input_bias_add_output, num_elems);
   }
 
   mean = mean / hidden_size;
@@ -186,20 +163,12 @@ Status ComputeJob(
   }
 
   float* float_gamma = float_input;  // overwrite float_input with gamma values, since they have the same size
-  try {
-    MlasConvertHalfToFloatBuffer(gamma_data, float_gamma, num_elems);
-  } catch (const std::exception& e) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, RUNTIME_EXCEPTION, "Failed to convert gamma data to float: ", e.what());
-  }
+  MlasConvertHalfToFloatBuffer(gamma_data, float_gamma, num_elems);
 
   float* float_beta = nullptr;  // overwrite float_skip with beta values, since they have the same size
   if (beta_data) {
     float_beta = float_skip;
-    try {
-      MlasConvertHalfToFloatBuffer(beta_data, float_beta, num_elems);
-    } catch (const std::exception& e) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, RUNTIME_EXCEPTION, "Failed to convert beta data to float: ", e.what());
-    }
+    MlasConvertHalfToFloatBuffer(beta_data, float_beta, num_elems);
   }
 
   for (size_t h = 0; h < num_elems; h++) {
@@ -214,12 +183,7 @@ Status ComputeJob(
   delete[] float_gamma;  // also deletes float_input
   delete[] float_skip;   // also deletes float_beta if used
 
-  try {
-    MlasConvertFloatToHalfBuffer(float_output, p_output, num_elems);
-  } catch (const std::exception& e) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, RUNTIME_EXCEPTION, "Failed to convert float output data to MLFLoat16: ", e.what());
-  }
-
+  MlasConvertFloatToHalfBuffer(float_output, p_output, num_elems);
   delete[] float_output;
 
   return Status::OK();

--- a/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
+++ b/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
@@ -37,24 +37,22 @@ REGISTER_KERNEL_TYPED(float)
 REGISTER_KERNEL_TYPED(double)
 REGISTER_KERNEL_TYPED(MLFloat16)
 
-
 namespace {
 
 template <typename T, typename = std::enable_if_t<std::is_same_v<T, float> || std::is_same_v<T, double>, void>>
 void ComputeJob(
-  const T* input_data,
-  const T* skip_data,
-  const T* gamma_data,
-  const T* beta_data,
-  const T* bias_data,
-  ptrdiff_t task_idx,
-  int hidden_size,
-  int64_t skip_size,
-  float epsilon,
-  bool simplified,
-  T* output_data,
-  T* skip_input_bias_add_output_data
-) {
+    const T* input_data,
+    const T* skip_data,
+    const T* gamma_data,
+    const T* beta_data,
+    const T* bias_data,
+    ptrdiff_t task_idx,
+    int hidden_size,
+    int64_t skip_size,
+    float epsilon,
+    bool simplified,
+    T* output_data,
+    T* skip_input_bias_add_output_data) {
   auto offset = task_idx * hidden_size;
   const T* p_input = input_data + offset;
   const T* p_skip = skip_data + (offset % skip_size);
@@ -99,19 +97,18 @@ void ComputeJob(
 }
 
 void ComputeJob(
-  const MLFloat16* input_data,
-  const MLFloat16* skip_data,
-  const MLFloat16* gamma_data,
-  const MLFloat16* beta_data,
-  const MLFloat16* bias_data,
-  ptrdiff_t task_idx,
-  int hidden_size,
-  int64_t skip_size,
-  float epsilon,
-  bool simplified,
-  MLFloat16* output_data,
-  MLFloat16* skip_input_bias_add_output_data
-) {
+    const MLFloat16* input_data,
+    const MLFloat16* skip_data,
+    const MLFloat16* gamma_data,
+    const MLFloat16* beta_data,
+    const MLFloat16* bias_data,
+    ptrdiff_t task_idx,
+    int hidden_size,
+    int64_t skip_size,
+    float epsilon,
+    bool simplified,
+    MLFloat16* output_data,
+    MLFloat16* skip_input_bias_add_output_data) {
   auto offset = task_idx * hidden_size;
   const MLFloat16* p_input = input_data + offset;
   const MLFloat16* p_skip = skip_data + (offset % skip_size);
@@ -174,8 +171,7 @@ void ComputeJob(
   MlasConvertFloatToHalfBuffer(&float_output[0], p_output, hidden_size);
 }
 
-} // namespace
-
+}  // namespace
 
 template <typename T, bool simplified>
 SkipLayerNorm<T, simplified>::SkipLayerNorm(const OpKernelInfo& op_kernel_info)
@@ -226,7 +222,7 @@ Status SkipLayerNorm<T, simplified>::Compute(OpKernelContext* p_ctx) const {
       p_ctx->GetOperatorThreadPool(), static_cast<int32_t>(task_count),
       [&](ptrdiff_t task_idx) {
         ComputeJob(input_data, skip_data, gamma_data, beta_data, bias_data, task_idx, hidden_size, skip_size, epsilon_,
-          simplified, output_data, skip_input_bias_add_output_data);
+                   simplified, output_data, skip_input_bias_add_output_data);
       },
       0);
 

--- a/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
+++ b/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
@@ -156,9 +156,9 @@ void ComputeJob(
     mean_square = sqrt(mean_square / hidden_size - mean * mean + epsilon);
   }
 
-  float* float_gamma = float_input; // overwrite float_input with gamma values, since they have the same size
+  float* float_gamma = float_input;  // overwrite float_input with gamma values, since they have the same size
   MlasConvertHalfToFloatBuffer(gamma_data, float_gamma, num_elems);
-  float* float_beta = float_skip; // overwrite float_input with beta values, since they have the same size
+  float* float_beta = float_skip;  // overwrite float_skip with beta values, since they have the same size
   MlasConvertHalfToFloatBuffer(beta_data, float_beta, num_elems);
   for (size_t h = 0; h < num_elems; h++) {
     if (simplified) {
@@ -169,8 +169,8 @@ void ComputeJob(
       float_output[h] = (float_output[h] - mean) / mean_square * float_gamma[h] + float_beta[h];
     }
   }
-  delete[] float_gamma; // also deletes float_input
-  delete[] float_beta; // also deletes float_skip
+  delete[] float_gamma;  // also deletes float_input
+  delete[] float_beta;   // also deletes float_skip
 
   MlasConvertFloatToHalfBuffer(float_output, p_output, num_elems);
   delete[] float_output;

--- a/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
+++ b/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
@@ -224,7 +224,7 @@ Status SkipLayerNorm<T, simplified>::Compute(OpKernelContext* p_ctx) const {
           }
         }
 
-        if (std::is_same_v<decltype(p_output), MLFloat16>) {
+        if (std::is_same_v<decltype(p_output), MLFloat16*>) {
           ConvertFloatBufferToMLFloat16(
             reinterpret_cast<float*>(output_buffer), reinterpret_cast<MLFloat16*>(p_output), hidden_size);
           delete[] output_buffer;

--- a/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
+++ b/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
@@ -279,7 +279,7 @@ Status SkipLayerNorm<T, simplified>::Compute(OpKernelContext* p_ctx) const {
       p_ctx->GetOperatorThreadPool(), static_cast<int32_t>(task_count),
       [&](ptrdiff_t task_idx) {
         ComputeJob(input_data, skip_data, gamma_data, beta_data, bias_data, skip_fp32_, gamma_fp32_, beta_fp32_,
-                   bias_fp32_, task_idx, hidden_size, skip_size, epsilon_, simplified,output_data,
+                   bias_fp32_, task_idx, hidden_size, skip_size, epsilon_, simplified, output_data,
                    skip_input_bias_add_output_data);
       },
       0);

--- a/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
+++ b/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
@@ -39,17 +39,17 @@ REGISTER_KERNEL_TYPED(MLFloat16)
 
 
 template <typename T>
-std::shared_ptr<std::vector<float>> ConvertHalfToFloatIfNeeded(const T* p_input, int num_elems);
+std::shared_ptr<std::vector<float>> ConvertHalfToFloatBufferIfNeeded(const T* p_input, int num_elems);
 
 template <typename T>
-std::shared_ptr<std::vector<float>> ConvertHalfToFloatIfNeeded(
+std::shared_ptr<std::vector<float>> ConvertHalfToFloatBufferIfNeeded(
   const std::enable_if_t<std::is_same_v<T,float> || std::is_same_v<T, double>, T>* p_input, int num_elems)
 {
   return nullptr;
 }
 
 template<>
-std::shared_ptr<std::vector<float>> ConvertHalfToFloatIfNeeded<MLFloat16>(const MLFloat16* p_input, int num_elems)
+std::shared_ptr<std::vector<float>> ConvertHalfToFloatBufferIfNeeded<MLFloat16>(const MLFloat16* p_input, int num_elems)
 {
   if (!p_input) {
     return nullptr;
@@ -148,17 +148,17 @@ Status SkipLayerNorm<T, simplified>::Compute(OpKernelContext* p_ctx) const {
         DoubleOrFloat mean(0.0f);
         DoubleOrFloat mean_square(0.0f);
 
-        std::shared_ptr<std::vector<float>> float_input = ConvertHalfToFloatIfNeeded<T>(p_input, hidden_size);
+        std::shared_ptr<std::vector<float>> float_input = ConvertHalfToFloatBufferIfNeeded<T>(p_input, hidden_size);
         const DoubleOrFloat* converted_input =
           float_input == nullptr
           ? reinterpret_cast<const DoubleOrFloat*>(p_input)
           : reinterpret_cast<const DoubleOrFloat*>(&(*float_input)[0]);
-        std::shared_ptr<std::vector<float>> float_skip = ConvertHalfToFloatIfNeeded<T>(p_skip, hidden_size);
+        std::shared_ptr<std::vector<float>> float_skip = ConvertHalfToFloatBufferIfNeeded<T>(p_skip, hidden_size);
         const DoubleOrFloat* converted_skip =
           float_skip == nullptr
           ? reinterpret_cast<const DoubleOrFloat*>(p_skip)
           : reinterpret_cast<const DoubleOrFloat*>(&(*float_skip)[0]);
-        std::shared_ptr<std::vector<float>> float_bias = ConvertHalfToFloatIfNeeded<T>(bias_data, hidden_size);
+        std::shared_ptr<std::vector<float>> float_bias = ConvertHalfToFloatBufferIfNeeded<T>(bias_data, hidden_size);
         const DoubleOrFloat* converted_bias =
           float_bias == nullptr
           ? reinterpret_cast<const DoubleOrFloat*>(bias_data)
@@ -189,12 +189,12 @@ Status SkipLayerNorm<T, simplified>::Compute(OpKernelContext* p_ctx) const {
           mean_square = sqrt(mean_square / hidden_size - mean * mean + epsilon_);
         }
 
-        std::shared_ptr<std::vector<float>> float_gamma = ConvertHalfToFloatIfNeeded<T>(gamma_data, hidden_size);
+        std::shared_ptr<std::vector<float>> float_gamma = ConvertHalfToFloatBufferIfNeeded<T>(gamma_data, hidden_size);
         const DoubleOrFloat* converted_gamma =
           float_gamma == nullptr
           ? reinterpret_cast<const DoubleOrFloat*>(gamma_data)
           : reinterpret_cast<const DoubleOrFloat*>(&(*float_gamma)[0]);
-        std::shared_ptr<std::vector<float>> float_beta = ConvertHalfToFloatIfNeeded<T>(beta_data, hidden_size);
+        std::shared_ptr<std::vector<float>> float_beta = ConvertHalfToFloatBufferIfNeeded<T>(beta_data, hidden_size);
         const DoubleOrFloat* converted_beta =
           float_beta == nullptr
           ? reinterpret_cast<const DoubleOrFloat*>(beta_data)

--- a/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
+++ b/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
@@ -119,19 +119,17 @@ void ComputeJob(
   float mean_square(0.0f);
 
   const size_t num_elems = static_cast<size_t>(hidden_size);
-
-  std::unique_ptr<float[]> float_input = std::make_unique<float[]>(num_elems);
-  MlasConvertHalfToFloatBuffer(p_input, float_input.get(), num_elems);
-
-  std::unique_ptr<float[]> float_skip = std::make_unique<float[]>(num_elems);
-  MlasConvertHalfToFloatBuffer(p_skip, float_skip.get(), num_elems);
-  std::unique_ptr<float[]> float_bias = nullptr;
+  float* float_input = new float[num_elems];
+  MlasConvertHalfToFloatBuffer(p_input, float_input, num_elems);
+  float* float_skip = new float[num_elems];
+  MlasConvertHalfToFloatBuffer(p_skip, float_skip, num_elems);
+  float* float_bias = nullptr;
   if (bias_data != nullptr) {
-    float_bias = std::make_unique<float[]>(num_elems);
-    MlasConvertHalfToFloatBuffer(bias_data, float_bias.get(), num_elems);
+    float_bias = new float[num_elems];
+    MlasConvertHalfToFloatBuffer(bias_data, float_bias, num_elems);
   }
 
-  std::unique_ptr<float[]> float_output = std::make_unique<float[]>(num_elems);
+  float* float_output = new float[num_elems];
   for (size_t h = 0; h < num_elems; h++) {
     float val = float_input[h] + float_skip[h];
 
@@ -143,9 +141,12 @@ void ComputeJob(
     mean += val;
     mean_square += val * val;
   }
+  if (float_bias != nullptr) {
+    delete[] float_bias;
+  }
 
   if (nullptr != p_skip_input_bias_add_output) {
-    MlasConvertFloatToHalfBuffer(float_output.get(), p_skip_input_bias_add_output, num_elems);
+    MlasConvertFloatToHalfBuffer(float_output, p_skip_input_bias_add_output, num_elems);
   }
 
   mean = mean / hidden_size;
@@ -155,9 +156,9 @@ void ComputeJob(
     mean_square = sqrt(mean_square / hidden_size - mean * mean + epsilon);
   }
 
-  float* float_gamma = float_input.get(); // overwrite float_input with gamma values, since they have the same size
+  float* float_gamma = float_input; // overwrite float_input with gamma values, since they have the same size
   MlasConvertHalfToFloatBuffer(gamma_data, float_gamma, num_elems);
-  float* float_beta = float_skip.get(); // overwrite float_skip with beta values, since they have the same size
+  float* float_beta = float_skip; // overwrite float_input with beta values, since they have the same size
   MlasConvertHalfToFloatBuffer(beta_data, float_beta, num_elems);
   for (size_t h = 0; h < num_elems; h++) {
     if (simplified) {
@@ -168,8 +169,11 @@ void ComputeJob(
       float_output[h] = (float_output[h] - mean) / mean_square * float_gamma[h] + float_beta[h];
     }
   }
+  delete[] float_gamma; // also deletes float_input
+  delete[] float_beta; // also deletes float_skip
 
-  MlasConvertFloatToHalfBuffer(float_output.get(), p_output, num_elems);
+  MlasConvertFloatToHalfBuffer(float_output, p_output, num_elems);
+  delete[] float_output;
 }
 
 }  // namespace

--- a/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
+++ b/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
@@ -209,7 +209,7 @@ void ComputeJob(
     }
   }
 
-  alloc->Free(float_input); // also takes care of float_gamma if reused
+  alloc->Free(float_input);  // also takes care of float_gamma if reused
   if (float_skip && (nullptr == skip_fp32)) {
     alloc->Free(float_skip);
   }

--- a/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
+++ b/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
@@ -40,11 +40,11 @@ REGISTER_KERNEL_TYPED(MLFloat16)
 
 namespace {
 
-ORT_FORCEINLINE double* CreateBufferIfMLFloat16(double* p_output, int num_elems) {
+ORT_FORCEINLINE double* CreateBufferIfMLFloat16(double* p_output, [[maybe_unused]] int num_elems) {
   return p_output;
 }
 
-ORT_FORCEINLINE float* CreateBufferIfMLFloat16(float* p_output, int num_elems) {
+ORT_FORCEINLINE float* CreateBufferIfMLFloat16(float* p_output, [[maybe_unused]] int num_elems) {
   return p_output;
 }
 
@@ -54,11 +54,13 @@ ORT_FORCEINLINE float* CreateBufferIfMLFloat16(MLFloat16* p_output, int num_elem
 
 
 template <typename T>
-ORT_FORCEINLINE std::shared_ptr<std::vector<float>> ConvertHalfToFloatBufferIfNeeded(const T* p_input, int num_elems);
+ORT_FORCEINLINE std::shared_ptr<std::vector<float>> ConvertHalfToFloatBufferIfNeeded(
+  [[maybe_unused]] const T* p_input, [[maybe_unused]] int num_elems);
 
 template <typename T>
 ORT_FORCEINLINE std::shared_ptr<std::vector<float>> ConvertHalfToFloatBufferIfNeeded(
-  const std::enable_if_t<std::is_same_v<T,float> || std::is_same_v<T, double>, T>* p_input, int num_elems) {
+  [[maybe_unused]] const std::enable_if_t<std::is_same_v<T,float> || std::is_same_v<T, double>, T>* p_input,
+  [[maybe_unused]] int num_elems) {
   return nullptr;
 }
 

--- a/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
+++ b/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
@@ -119,22 +119,17 @@ void ComputeJob(
   float mean_square(0.0f);
 
   const size_t num_elems = static_cast<size_t>(hidden_size);
-  float* float_output = new float[num_elems];
   float* float_input = new float[num_elems];
+  MlasConvertHalfToFloatBuffer(p_input, float_input, num_elems);
   float* float_skip = new float[num_elems];
-  float* float_gamma = new float[num_elems];
-  float* float_beta = new float[num_elems];
+  MlasConvertHalfToFloatBuffer(p_skip, float_skip, num_elems);
   float* float_bias = nullptr;
   if (bias_data != nullptr) {
     float_bias = new float[num_elems];
     MlasConvertHalfToFloatBuffer(bias_data, float_bias, num_elems);
   }
-  MlasConvertFloatToHalfBuffer(float_output, p_output, num_elems);
-  MlasConvertHalfToFloatBuffer(p_input, float_input, num_elems);
-  MlasConvertHalfToFloatBuffer(p_skip, float_skip, num_elems);
-  MlasConvertHalfToFloatBuffer(gamma_data, float_gamma, num_elems);
-  MlasConvertHalfToFloatBuffer(beta_data, float_beta, num_elems);
 
+  float* float_output = new float[num_elems];
   for (size_t h = 0; h < num_elems; h++) {
     float val = float_input[h] + float_skip[h];
 
@@ -145,6 +140,9 @@ void ComputeJob(
     float_output[h] = val;
     mean += val;
     mean_square += val * val;
+  }
+  if (float_bias != nullptr) {
+    delete[] float_bias;
   }
 
   if (nullptr != p_skip_input_bias_add_output) {
@@ -158,6 +156,10 @@ void ComputeJob(
     mean_square = sqrt(mean_square / hidden_size - mean * mean + epsilon);
   }
 
+  float* float_gamma = float_input; // overwrite float_input with gamma values, since they have the same size
+  MlasConvertHalfToFloatBuffer(gamma_data, float_gamma, num_elems);
+  float* float_beta = float_skip; // overwrite float_input with beta values, since they have the same size
+  MlasConvertHalfToFloatBuffer(beta_data, float_beta, num_elems);
   for (size_t h = 0; h < num_elems; h++) {
     if (simplified) {
       float_output[h] = float_output[h] / mean_square * float_gamma[h];
@@ -167,16 +169,11 @@ void ComputeJob(
       float_output[h] = (float_output[h] - mean) / mean_square * float_gamma[h] + float_beta[h];
     }
   }
+  delete[] float_gamma; // also deletes float_input
+  delete[] float_beta; // also deletes float_skip
 
   MlasConvertFloatToHalfBuffer(float_output, p_output, num_elems);
   delete[] float_output;
-  delete[] float_input;
-  delete[] float_skip;
-  delete[] float_gamma;
-  delete[] float_beta;
-  if (float_bias != nullptr) {
-    delete[] float_bias;
-  }
 }
 
 }  // namespace

--- a/onnxruntime/contrib_ops/cpu/skip_layer_norm.h
+++ b/onnxruntime/contrib_ops/cpu/skip_layer_norm.h
@@ -16,8 +16,15 @@ class SkipLayerNorm final : public OpKernel {
   SkipLayerNorm(const OpKernelInfo& op_kernel_info);
   Status Compute(OpKernelContext* p_op_kernel_context) const override;
 
+  Status PrePack(const Tensor& tensor, int input_idx, AllocatorPtr alloc,
+                 bool& is_packed, PrePackedWeights* prepacked_weights) override;
+
  private:
   float epsilon_;
+  IAllocatorUniquePtr<float> skip_fp32_;
+  IAllocatorUniquePtr<float> gamma_fp32_;
+  IAllocatorUniquePtr<float> beta_fp32_;
+  IAllocatorUniquePtr<float> bias_fp32_;
 };
 
 }  // namespace contrib

--- a/onnxruntime/contrib_ops/cpu/skip_layer_norm.h
+++ b/onnxruntime/contrib_ops/cpu/skip_layer_norm.h
@@ -21,10 +21,10 @@ class SkipLayerNorm final : public OpKernel {
 
  private:
   float epsilon_;
-  IAllocatorUniquePtr<float> skip_fp32_;
-  IAllocatorUniquePtr<float> gamma_fp32_;
-  IAllocatorUniquePtr<float> beta_fp32_;
-  IAllocatorUniquePtr<float> bias_fp32_;
+  mutable IAllocatorUniquePtr<float> skip_fp32_;
+  mutable IAllocatorUniquePtr<float> gamma_fp32_;
+  mutable IAllocatorUniquePtr<float> beta_fp32_;
+  mutable IAllocatorUniquePtr<float> bias_fp32_;
 };
 
 }  // namespace contrib

--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
@@ -24,11 +24,6 @@ ORT_FORCEINLINE float ConvertMLFloat16ToDoubleOrFloatIfNeeded<MLFloat16, float>(
 }
 
 template <>
-ORT_FORCEINLINE double ConvertMLFloat16ToDoubleOrFloatIfNeeded<MLFloat16, double>(MLFloat16 val) {
-  return double(ConvertMLFloat16ToDoubleOrFloatIfNeeded<MLFloat16, float>(val));
-}
-
-template <>
 ORT_FORCEINLINE constexpr float ConvertMLFloat16ToDoubleOrFloatIfNeeded<float, float>(float val) {
   return val;
 }

--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
@@ -173,7 +173,9 @@ Status LayerNormImpl::ComputeImpl(OpKernelContext* p_ctx, int64_t orig_axis, flo
   U* mean_data = nullptr;
   if (!simplified) {
     Tensor* mean = p_ctx->Output(output_index++, TensorShape(mean_inv_std_dev_dim));
-    mean_data = mean->MutableData<U>();
+    if (mean != nullptr) {
+      mean_data = mean->MutableData<U>();
+    }
   }
 
   U* inv_std_dev_data = nullptr;

--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
@@ -104,7 +104,7 @@ void ComputeJob(
     mean_square = sqrt(mean_square / norm_size - mean * mean + epsilon);
   }
 
-  float* float_scale = float_input; // overwrite float_input with scale values, since they have the same size
+  float* float_scale = float_input;  // overwrite float_input with scale values, since they have the same size
   MlasConvertHalfToFloatBuffer(scale_data, float_scale, num_elems);
   float* float_bias = new float[num_elems];
   MlasConvertHalfToFloatBuffer(bias_data, float_bias, num_elems);
@@ -117,7 +117,7 @@ void ComputeJob(
       float_output[h] = (float_output[h] - mean) / mean_square * float_scale[h] + float_bias[h];
     }
   }
-  delete[] float_scale; // also deletes float_input
+  delete[] float_scale;  // also deletes float_input
   delete[] float_bias;
 
   MlasConvertFloatToHalfBuffer(float_output, p_output, num_elems);
@@ -228,7 +228,7 @@ Status LayerNormImpl::ComputeWithoutContext(
       thread_pool, static_cast<int32_t>(norm_count),
       [&](ptrdiff_t task_idx) {
         ComputeJob(X_data, scale_data, bias_data, task_idx, norm_size, epsilon, simplified,
-            Y_data, mean_data, inv_std_dev_data);
+                   Y_data, mean_data, inv_std_dev_data);
       },
       0);
 

--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
@@ -12,6 +12,8 @@
 
 namespace onnxruntime {
 
+namespace {
+
 // Utility to convert from MLFloat16 to float only when the input type is MLFloat16.
 template <typename T, typename Ret>
 ORT_FORCEINLINE Ret ConvertMLFloat16ToDoubleOrFloatIfNeeded(T val);
@@ -63,15 +65,16 @@ ORT_FORCEINLINE constexpr double ConvertToMLFloat16IfNeeded(double val) {
   return val;
 }
 
+} // namespace
+
 LayerNormImpl::LayerNormImpl(const OpKernelInfo& op_kernel_info, bool simplified, bool contrib_op)
     : OpKernel(op_kernel_info), simplified_{simplified}, contrib_op_{contrib_op} {
   ORT_ENFORCE(op_kernel_info.GetAttr("axis", &axis_).IsOK());
   ORT_ENFORCE(op_kernel_info.GetAttr<float>("epsilon", &epsilon_).IsOK());
 }
 
-namespace {
 template <typename T, typename U>
-Status ComputeImpl(OpKernelContext* p_ctx, int64_t orig_axis, float epsilon, bool simplified) {
+Status LayerNormImpl::ComputeImpl(OpKernelContext* p_ctx, int64_t orig_axis, float epsilon, bool simplified) const {
   // Inputs
   const Tensor* X = p_ctx->Input<Tensor>(0);
   const Tensor* scale = p_ctx->Input<Tensor>(1);
@@ -81,21 +84,12 @@ Status ComputeImpl(OpKernelContext* p_ctx, int64_t orig_axis, float epsilon, boo
   const T* bias_data = (simplified || nullptr == bias) ? nullptr : bias->Data<T>();
 
   const TensorShape& x_shape = X->Shape();
-  const int64_t axis = HandleNegativeAxis(orig_axis, x_shape.NumDimensions());
-  int64_t norm_count = x_shape.SizeToDimension(onnxruntime::narrow<size_t>(axis));
-  int64_t norm_size = x_shape.SizeFromDimension(onnxruntime::narrow<size_t>(axis));
-
-  const auto scale_size = scale->Shape().Size();
-  const auto bias_size = (bias_data) ? bias->Shape().Size() : 0;
-  if (scale_size != norm_size || (bias_data && bias_size != norm_size)) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                           "Size of X.shape()[axis:] == ", norm_size,
-                           ". Size of scale and bias (if provided) must match this. Got scale size of ",
-                           scale_size, " and bias size of ", bias_size);
-  }
-
+  const TensorShape& scale_shape = scale->Shape();
+  const TensorShape& bias_shape = bias->Shape();
   Tensor* Y = p_ctx->Output(0, x_shape);
-  auto Y_data = Y->MutableData<T>();
+  T* Y_data = Y->MutableData<T>();
+
+  const int64_t axis = HandleNegativeAxis(orig_axis, x_shape.NumDimensions());
 
   std::vector<int64_t> mean_inv_std_dev_dim;
   mean_inv_std_dev_dim.reserve(x_shape.NumDimensions());
@@ -107,17 +101,11 @@ Status ComputeImpl(OpKernelContext* p_ctx, int64_t orig_axis, float epsilon, boo
     }
   }
 
-  AllocatorPtr alloc;
-  ORT_RETURN_IF_ERROR(p_ctx->GetTempSpaceAllocator(&alloc));
-
   int output_index = 1;
-
+  Tensor* mean = p_ctx->Output(output_index++, TensorShape(mean_inv_std_dev_dim));
   U* mean_data = nullptr;
-  if (!simplified) {
-    Tensor* mean = p_ctx->Output(output_index++, TensorShape(mean_inv_std_dev_dim));
-    if (mean != nullptr) {
-      mean_data = mean->MutableData<U>();
-    }
+  if (mean != nullptr) {
+    mean_data = mean->MutableData<U>();
   }
 
   U* inv_std_dev_data = nullptr;
@@ -126,8 +114,51 @@ Status ComputeImpl(OpKernelContext* p_ctx, int64_t orig_axis, float epsilon, boo
     inv_std_dev_data = inv_std_dev->MutableData<U>();
   }
 
+  onnxruntime::concurrency::ThreadPool* thread_pool = p_ctx->GetOperatorThreadPool();
+
+  return ComputeWithoutContext<T, U>(X_data, x_shape, scale_data, scale_shape, bias_data, bias_shape,
+    Y_data, mean_data, inv_std_dev_data, thread_pool, axis, epsilon, simplified);
+}
+
+Status LayerNormImpl::Compute(OpKernelContext* p_ctx) const {
+  const auto elem_type = p_ctx->Input<Tensor>(0)->GetElementType();
+
+  using SupportedTypeList = boost::mp11::mp_list<float, double, MLFloat16>;
+
+  utils::MLTypeCallDispatcherFromTypeList<SupportedTypeList> t_disp(elem_type);
+  return t_disp.InvokeRet<Status, SrcDispatcher>(this, p_ctx, axis_, epsilon_, simplified_, contrib_op_);
+}
+
+template<typename T, typename U>
+Status LayerNormImpl::ComputeWithoutContext(
+  const T* X_data,
+  const TensorShape& x_shape,
+  const T* scale_data,
+  const TensorShape& scale_shape,
+  const T* bias_data,
+  const TensorShape& bias_shape,
+  T* Y_data,
+  U* mean_data,
+  U* inv_std_dev_data,
+  onnxruntime::concurrency::ThreadPool* thread_pool,
+  int64_t axis,
+  float epsilon,
+  bool simplified
+) const {
+  int64_t norm_count = x_shape.SizeToDimension(onnxruntime::narrow<size_t>(axis));
+  int64_t norm_size = x_shape.SizeFromDimension(onnxruntime::narrow<size_t>(axis));
+
+  const auto scale_size = scale_shape.Size();
+  const auto bias_size = (bias_data) ? bias_shape.Size() : 0;
+  if (scale_size != norm_size || (bias_data && bias_size != norm_size)) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "Size of X.shape()[axis:] == ", norm_size,
+                           ". Size of scale and bias (if provided) must match this. Got scale size of ",
+                           scale_size, " and bias size of ", bias_size);
+  }
+
   concurrency::ThreadPool::TryBatchParallelFor(
-      p_ctx->GetOperatorThreadPool(), static_cast<int32_t>(norm_count),
+      thread_pool, static_cast<int32_t>(norm_count),
       [&](ptrdiff_t task_idx) {
         const T* p_input = X_data + task_idx * norm_size;
         T* p_output = Y_data + task_idx * norm_size;
@@ -159,7 +190,7 @@ Status ComputeImpl(OpKernelContext* p_ctx, int64_t orig_axis, float epsilon, boo
           DoubleOrFloat scale_value = ConvertMLFloat16ToDoubleOrFloatIfNeeded<T, DoubleOrFloat>(scale_data[h]);
           if (simplified) {
             p_output[h] = ConvertToMLFloat16IfNeeded<T>(input_value / mean_square * scale_value);
-          } else if (nullptr == bias) {
+          } else if (nullptr == bias_data) {
             p_output[h] = ConvertToMLFloat16IfNeeded<T>((input_value - mean) / mean_square * scale_value);
           } else {
             DoubleOrFloat bias_value = ConvertMLFloat16ToDoubleOrFloatIfNeeded<T, DoubleOrFloat>(bias_data[h]);
@@ -179,34 +210,6 @@ Status ComputeImpl(OpKernelContext* p_ctx, int64_t orig_axis, float epsilon, boo
       0);
 
   return Status::OK();
-}
-
-template <typename T>
-struct SrcDispatcher {
-  Status operator()(OpKernelContext* p_ctx, int64_t orig_axis, float epsilon, bool simplified, bool contrib_op) const {
-    // the contrib op kernel was always registered with the same type for all constraints.
-    // our implementation of the onnx op only supports 'float' as the U constraint.
-#if !defined(DISABLE_CONTRIB_OPS)
-    if (contrib_op) {
-      return ComputeImpl<T, T>(p_ctx, orig_axis, epsilon, simplified);
-    } else
-#else
-    ORT_UNUSED_PARAMETER(contrib_op);
-#endif
-    {
-      return ComputeImpl<T, float>(p_ctx, orig_axis, epsilon, simplified);
-    }
-  }
-};
-}  // namespace
-
-Status LayerNormImpl::Compute(OpKernelContext* p_ctx) const {
-  const auto elem_type = p_ctx->Input<Tensor>(0)->GetElementType();
-
-  using SupportedTypeList = boost::mp11::mp_list<float, double, MLFloat16>;
-
-  utils::MLTypeCallDispatcherFromTypeList<SupportedTypeList> t_disp(elem_type);
-  return t_disp.InvokeRet<Status, SrcDispatcher>(p_ctx, axis_, epsilon_, simplified_, contrib_op_);
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
@@ -240,7 +240,7 @@ Status LayerNormImpl::ComputeWithoutContext(
           }
         }
 
-        if (std::is_same_v<decltype(p_output), MLFloat16>) {
+        if (std::is_same_v<decltype(p_output), MLFloat16*>) {
           ConvertFloatBufferToMLFloat16(
             reinterpret_cast<float*>(output_buffer), reinterpret_cast<MLFloat16*>(p_output), norm_size);
           delete[] output_buffer;

--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
@@ -87,10 +87,10 @@ void ComputeJob(
   float mean_square(0.0f);
 
   const size_t num_elems = static_cast<size_t>(norm_size);
-  float* float_input = new float[num_elems];
-  MlasConvertHalfToFloatBuffer(p_input, float_input, num_elems);
+  std::unique_ptr<float[]> float_input = std::make_unique<float[]>(num_elems);
+  MlasConvertHalfToFloatBuffer(p_input, float_input.get(), num_elems);
 
-  float* float_output = new float[num_elems];
+  std::unique_ptr<float[]> float_output = std::make_unique<float[]>(num_elems);
   for (size_t h = 0; h < num_elems; h++) {
     float_output[h] = float_input[h];
     mean += float_input[h];
@@ -104,10 +104,10 @@ void ComputeJob(
     mean_square = sqrt(mean_square / norm_size - mean * mean + epsilon);
   }
 
-  float* float_scale = float_input; // overwrite float_input with scale values, since they have the same size
+  float* float_scale = float_input.get(); // overwrite float_input with scale values, since they have the same size
   MlasConvertHalfToFloatBuffer(scale_data, float_scale, num_elems);
-  float* float_bias = new float[num_elems];
-  MlasConvertHalfToFloatBuffer(bias_data, float_bias, num_elems);
+  std::unique_ptr<float[]> float_bias = std::make_unique<float[]>(num_elems);
+  MlasConvertHalfToFloatBuffer(bias_data, float_bias.get(), num_elems);
   for (size_t h = 0; h < num_elems; h++) {
     if (simplified) {
       float_output[h] = float_output[h] / mean_square * float_scale[h];
@@ -117,11 +117,8 @@ void ComputeJob(
       float_output[h] = (float_output[h] - mean) / mean_square * float_scale[h] + float_bias[h];
     }
   }
-  delete[] float_scale; // also deletes float_input
-  delete[] float_bias;
 
-  MlasConvertFloatToHalfBuffer(float_output, p_output, num_elems);
-  delete[] float_output;
+  MlasConvertFloatToHalfBuffer(float_output.get(), p_output, num_elems);
 
   if (mean_data != nullptr) {
     // ONNX spec doesn't support 'double' for 'U' so when 'T' == double, 'U' == float and we need to narrow

--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
@@ -15,15 +15,15 @@ namespace onnxruntime {
 
 namespace {
 
-ORT_FORCEINLINE double* OnlyCreateBufferIfMLFloat16(double* p_output, int num_elems) {
+ORT_FORCEINLINE double* OnlyCreateBufferIfMLFloat16(double* p_output, int64_t num_elems) {
   return p_output;
 }
 
-ORT_FORCEINLINE float* OnlyCreateBufferIfMLFloat16(float* p_output, int num_elems) {
+ORT_FORCEINLINE float* OnlyCreateBufferIfMLFloat16(float* p_output, int64_t num_elems) {
   return p_output;
 }
 
-ORT_FORCEINLINE float* OnlyCreateBufferIfMLFloat16(MLFloat16* p_output, int num_elems) {
+ORT_FORCEINLINE float* OnlyCreateBufferIfMLFloat16(MLFloat16* p_output, int64_t num_elems) {
   return p_output == nullptr ? nullptr : new float[num_elems];
 }
 

--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
@@ -15,11 +15,11 @@ namespace onnxruntime {
 
 namespace {
 
-ORT_FORCEINLINE double* OnlyCreateBufferIfMLFloat16(double* p_output, int64_t num_elems) {
+ORT_FORCEINLINE double* OnlyCreateBufferIfMLFloat16(double* p_output, [[maybe_unused]] int64_t num_elems) {
   return p_output;
 }
 
-ORT_FORCEINLINE float* OnlyCreateBufferIfMLFloat16(float* p_output, int64_t num_elems) {
+ORT_FORCEINLINE float* OnlyCreateBufferIfMLFloat16(float* p_output, [[maybe_unused]] int64_t num_elems) {
   return p_output;
 }
 
@@ -29,11 +29,13 @@ ORT_FORCEINLINE float* OnlyCreateBufferIfMLFloat16(MLFloat16* p_output, int64_t 
 
 
 template <typename T>
-ORT_FORCEINLINE std::shared_ptr<std::vector<float>> ConvertMLFloat16ToFloatBufferIfNeeded(const T* p_input, int64_t num_elems);
+ORT_FORCEINLINE std::shared_ptr<std::vector<float>> ConvertMLFloat16ToFloatBufferIfNeeded(
+  [[maybe_unused]] const T* p_input, [[maybe_unused]] int64_t num_elems);
 
 template <typename T>
 ORT_FORCEINLINE std::shared_ptr<std::vector<float>> ConvertMLFloat16ToFloatBufferIfNeeded(
-  const std::enable_if_t<std::is_same_v<T, float> || std::is_same_v<T, double>, T>* p_input, int64_t num_elems) {
+  [[maybe_unused]] const std::enable_if_t<std::is_same_v<T, float> || std::is_same_v<T, double>, T>* p_input,
+  [[maybe_unused]] int64_t num_elems) {
   return nullptr;
 }
 

--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
@@ -170,9 +170,9 @@ Status LayerNormImpl::ComputeImpl(OpKernelContext* p_ctx, int64_t orig_axis, flo
   }
 
   int output_index = 1;
-  Tensor* mean = p_ctx->Output(output_index++, TensorShape(mean_inv_std_dev_dim));
   U* mean_data = nullptr;
-  if (mean != nullptr) {
+  if (!simplified) {
+    Tensor* mean = p_ctx->Output(output_index++, TensorShape(mean_inv_std_dev_dim));
     mean_data = mean->MutableData<U>();
   }
 

--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
@@ -183,13 +183,7 @@ Status LayerNormImpl::ComputeImpl(OpKernelContext* p_ctx, int64_t orig_axis, flo
   const Tensor* scale = p_ctx->Input<Tensor>(1);
   const Tensor* bias = p_ctx->Input<Tensor>(2);
   const T* X_data = X->Data<T>();
-  if (!X_data) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "The input data should not be null.");
-  }
   const T* scale_data = scale->Data<T>();
-  if (!scale_data) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "The scale data should not be null.");
-  }
   const T* bias_data = (simplified || nullptr == bias) ? nullptr : bias->Data<T>();
 
   const TensorShape& x_shape = X->Shape();
@@ -197,9 +191,6 @@ Status LayerNormImpl::ComputeImpl(OpKernelContext* p_ctx, int64_t orig_axis, flo
   const TensorShape& bias_shape = bias->Shape();
   Tensor* Y = p_ctx->Output(0, x_shape);
   T* Y_data = Y->MutableData<T>();
-  if (!Y_data) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "The output data pointer should not be null.");
-  }
 
   const int64_t axis = HandleNegativeAxis(orig_axis, x_shape.NumDimensions());
 

--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
@@ -15,35 +15,30 @@ namespace onnxruntime {
 
 namespace {
 
-ORT_FORCEINLINE double* OnlyCreateBufferIfMLFloat16(double* p_output, int num_elems)
-{
+ORT_FORCEINLINE double* OnlyCreateBufferIfMLFloat16(double* p_output, int num_elems) {
   return p_output;
 }
 
-ORT_FORCEINLINE float* OnlyCreateBufferIfMLFloat16(float* p_output, int num_elems)
-{
+ORT_FORCEINLINE float* OnlyCreateBufferIfMLFloat16(float* p_output, int num_elems) {
   return p_output;
 }
 
-ORT_FORCEINLINE float* OnlyCreateBufferIfMLFloat16(MLFloat16* p_output, int num_elems)
-{
+ORT_FORCEINLINE float* OnlyCreateBufferIfMLFloat16(MLFloat16* p_output, int num_elems) {
   return p_output == nullptr ? nullptr : new float[num_elems];
 }
 
 
 template <typename T>
-ORT_FORCEINLINE std::shared_ptr<std::vector<float>> ConvertMLFloat16ToFloatBufferIfNeeded(const T* p_input, int num_elems);
+ORT_FORCEINLINE std::shared_ptr<std::vector<float>> ConvertMLFloat16ToFloatBufferIfNeeded(const T* p_input, int64_t num_elems);
 
 template <typename T>
 ORT_FORCEINLINE std::shared_ptr<std::vector<float>> ConvertMLFloat16ToFloatBufferIfNeeded(
-  const std::enable_if_t<std::is_same_v<T, float> || std::is_same_v<T, double>, T>* p_input, int num_elems)
-{
+  const std::enable_if_t<std::is_same_v<T, float> || std::is_same_v<T, double>, T>* p_input, int64_t num_elems) {
   return nullptr;
 }
 
 template<>
-std::shared_ptr<std::vector<float>> ConvertMLFloat16ToFloatBufferIfNeeded<MLFloat16>(const MLFloat16* p_input, int num_elems)
-{
+std::shared_ptr<std::vector<float>> ConvertMLFloat16ToFloatBufferIfNeeded<MLFloat16>(const MLFloat16* p_input, int64_t num_elems) {
   if (!p_input) {
     return nullptr;
   }
@@ -56,8 +51,7 @@ std::shared_ptr<std::vector<float>> ConvertMLFloat16ToFloatBufferIfNeeded<MLFloa
 }
 
 
-void ConvertFloatBufferToMLFloat16(const float* output_buffer, MLFloat16* p_output, int num_elems)
-{
+void ConvertFloatBufferToMLFloat16(const float* output_buffer, MLFloat16* p_output, int64_t num_elems) {
   if (!output_buffer || !p_output) {
     return;
   }

--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
@@ -15,15 +15,15 @@ namespace onnxruntime {
 
 namespace {
 
-ORT_FORCEINLINE double* OnlyCreateBufferIfMLFloat16(double* p_output, [[maybe_unused]] int64_t num_elems) {
+ORT_FORCEINLINE double* OnlyCreateBufferIfMLFloat16(double* p_output, [[maybe_unused]] size_t num_elems) {
   return p_output;
 }
 
-ORT_FORCEINLINE float* OnlyCreateBufferIfMLFloat16(float* p_output, [[maybe_unused]] int64_t num_elems) {
+ORT_FORCEINLINE float* OnlyCreateBufferIfMLFloat16(float* p_output, [[maybe_unused]] size_t num_elems) {
   return p_output;
 }
 
-ORT_FORCEINLINE float* OnlyCreateBufferIfMLFloat16(MLFloat16* p_output, int64_t num_elems) {
+ORT_FORCEINLINE float* OnlyCreateBufferIfMLFloat16(MLFloat16* p_output, size_t num_elems) {
   return p_output == nullptr ? nullptr : new float[num_elems];
 }
 
@@ -201,7 +201,8 @@ Status LayerNormImpl::ComputeWithoutContext(
 
         // If T is float or double, then output_buffer will be the same as p_output, so we don't allocate new memory.
         // If T is MLFloat16, then we allocate norm_size floats in output_buffer.
-        DoubleOrFloat* output_buffer = static_cast<DoubleOrFloat*>(OnlyCreateBufferIfMLFloat16(p_output, norm_size));
+        DoubleOrFloat* output_buffer = static_cast<DoubleOrFloat*>(
+            OnlyCreateBufferIfMLFloat16(p_output, static_cast<size_t>(norm_size)));
 
         for (int64_t h = 0; h < norm_size; h++) {
           output_buffer[h] = converted_input[h];

--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
@@ -99,6 +99,7 @@ ORT_FORCEINLINE constexpr double ConvertToMLFloat16IfNeeded(double val) {
 
 } // namespace
 
+
 LayerNormImpl::LayerNormImpl(const OpKernelInfo& op_kernel_info, bool simplified, bool contrib_op)
     : OpKernel(op_kernel_info), simplified_{simplified}, contrib_op_{contrib_op} {
   ORT_ENFORCE(op_kernel_info.GetAttr("axis", &axis_).IsOK());

--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
@@ -15,31 +15,27 @@ namespace onnxruntime {
 
 namespace {
 
-double* OnlyCreateBufferIfMLFloat16(double* p_output, int num_elems)
+ORT_FORCEINLINE double* OnlyCreateBufferIfMLFloat16(double* p_output, int num_elems)
 {
   return p_output;
 }
 
-float* OnlyCreateBufferIfMLFloat16(float* p_output, int num_elems)
+ORT_FORCEINLINE float* OnlyCreateBufferIfMLFloat16(float* p_output, int num_elems)
 {
   return p_output;
 }
 
-float* OnlyCreateBufferIfMLFloat16(MLFloat16* p_output, int num_elems)
+ORT_FORCEINLINE float* OnlyCreateBufferIfMLFloat16(MLFloat16* p_output, int num_elems)
 {
-  if (!p_output) {
-    return nullptr;
-  }
-
-  return new float[num_elems];
+  return p_output == nullptr ? nullptr : new float[num_elems];
 }
 
 
 template <typename T>
-std::shared_ptr<std::vector<float>> ConvertMLFloat16ToFloatBufferIfNeeded(const T* p_input, int num_elems);
+ORT_FORCEINLINE std::shared_ptr<std::vector<float>> ConvertMLFloat16ToFloatBufferIfNeeded(const T* p_input, int num_elems);
 
 template <typename T>
-std::shared_ptr<std::vector<float>> ConvertMLFloat16ToFloatBufferIfNeeded(
+ORT_FORCEINLINE std::shared_ptr<std::vector<float>> ConvertMLFloat16ToFloatBufferIfNeeded(
   const std::enable_if_t<std::is_same_v<T, float> || std::is_same_v<T, double>, T>* p_input, int num_elems)
 {
   return nullptr;

--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
@@ -89,20 +89,10 @@ Status ComputeJob(
   float mean_square(0.0f);
 
   const size_t num_elems = static_cast<size_t>(norm_size);
-  float* float_input = nullptr;
-  try {
-    float_input = new float[num_elems];
-    MlasConvertHalfToFloatBuffer(p_input, float_input, num_elems);
-  } catch (const std::exception& e) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, RUNTIME_EXCEPTION, "Failed to convert input data to float: ", e.what());
-  }
+  float* float_input = new float[num_elems];
+  MlasConvertHalfToFloatBuffer(p_input, float_input, num_elems);
 
-  float* float_output = nullptr;
-  try {
-    float_output = new float[num_elems];
-  } catch (const std::exception& e) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, RUNTIME_EXCEPTION, "Failed to allocate memory for float output.", e.what());
-  }
+  float* float_output = new float[num_elems];
 
   for (size_t h = 0; h < num_elems; h++) {
     float_output[h] = float_input[h];
@@ -118,20 +108,12 @@ Status ComputeJob(
   }
 
   float* float_scale = float_input;  // overwrite float_input with scale values, since they have the same size
-  try {
-    MlasConvertHalfToFloatBuffer(scale_data, float_scale, num_elems);
-  } catch (const std::exception& e) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, RUNTIME_EXCEPTION, "Failed to convert scale data to float: ", e.what());
-  }
+  MlasConvertHalfToFloatBuffer(scale_data, float_scale, num_elems);
 
   float* float_bias = nullptr;
   if (bias_data) {
-    try {
-      float_bias = new float[num_elems];
-      MlasConvertHalfToFloatBuffer(bias_data, float_bias, num_elems);
-    } catch (const std::exception& e) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, RUNTIME_EXCEPTION, "Failed to convert bias data to float: ", e.what());
-    }
+    float_bias = new float[num_elems];
+    MlasConvertHalfToFloatBuffer(bias_data, float_bias, num_elems);
   }
 
   for (size_t h = 0; h < num_elems; h++) {
@@ -148,11 +130,7 @@ Status ComputeJob(
     delete[] float_bias;
   }
 
-  try {
-    MlasConvertFloatToHalfBuffer(float_output, p_output, num_elems);
-  } catch (const std::exception& e) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, RUNTIME_EXCEPTION, "Failed to convert float output data to MLFLoat16: ", e.what());
-  }
+  MlasConvertFloatToHalfBuffer(float_output, p_output, num_elems);
 
   delete[] float_output;
 

--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
@@ -115,14 +115,14 @@ Status ComputeJob(
   }
 
   float* float_scale = scale_fp32.get();
-  if (float_scale == nullptr) {
+  if (nullptr == float_scale) {
     float_scale = float_input;  // overwrite float_input with scale values, since they have the same size
     MlasConvertHalfToFloatBuffer(scale_data, float_scale, num_elems);
   }
 
   float* float_bias = nullptr;
   if (bias_data) {
-    if (bias_fp32 != nullptr) {
+    if (nullptr != bias_fp32) {
       float_bias = bias_fp32.get();
     } else {
       float_bias = new float[num_elems];
@@ -141,7 +141,7 @@ Status ComputeJob(
   }
 
   delete[] float_input;  // also takes care of float_scale if reused
-  if (float_bias && (bias_fp32 == nullptr)) {
+  if (float_bias && (nullptr == bias_fp32)) {
     delete[] float_bias;
   }
 

--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
@@ -129,7 +129,7 @@ Status LayerNormImpl::Compute(OpKernelContext* p_ctx) const {
   return t_disp.InvokeRet<Status, SrcDispatcher>(this, p_ctx, axis_, epsilon_, simplified_, contrib_op_);
 }
 
-template<typename T, typename U>
+template <typename T, typename U>
 Status LayerNormImpl::ComputeWithoutContext(
   const T* X_data,
   const TensorShape& x_shape,

--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.h
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.h
@@ -14,7 +14,46 @@ class LayerNormImpl : public OpKernel {
   LayerNormImpl(const OpKernelInfo& op_kernel_info, bool simplified = false, bool contrib_op = false);
   Status Compute(OpKernelContext* p_op_kernel_context) const override;
 
+  // This method was created so that it can be called directly from `test/onnx/microbenchmark/layer_normalization.cc`.
+  template<typename T, typename U>
+  Status ComputeWithoutContext(
+    const T* X_data,
+    const TensorShape& x_shape,
+    const T* scale_data,
+    const TensorShape& scale_shape,
+    const T* bias_data,
+    const TensorShape& bias_shape,
+    T* Y_data,
+    U* mean_data,
+    U* inv_std_dev,
+    onnxruntime::concurrency::ThreadPool* thread_pool,
+    int64_t axis,
+    float epsilon = epsilon_,
+    bool simplified = simplified_
+  ) const;
+
  private:
+  template <typename T, typename U>
+  Status ComputeImpl(OpKernelContext* p_ctx, int64_t orig_axis, float epsilon, bool simplified) const;
+
+  template <typename T>
+  struct SrcDispatcher {
+    Status operator()(const LayerNormImpl* p_instance, OpKernelContext* p_ctx, int64_t orig_axis, float epsilon, bool simplified, bool contrib_op) const {
+      // the contrib op kernel was always registered with the same type for all constraints.
+      // our implementation of the onnx op only supports 'float' as the U constraint.
+  #if !defined(DISABLE_CONTRIB_OPS)
+      if (contrib_op) {
+        return p_instance->ComputeImpl<T, T>(p_ctx, orig_axis, epsilon, simplified);
+      } else
+  #else
+      ORT_UNUSED_PARAMETER(contrib_op);
+  #endif
+      {
+        return p_instance->ComputeImpl<T, float>(p_ctx, orig_axis, epsilon, simplified);
+      }
+    }
+  };
+
   int64_t axis_;
   float epsilon_;
   const bool simplified_;

--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.h
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "core/common/common.h"
+#include "core/framework/allocator.h"
 #include "core/framework/op_kernel.h"
 #include "core/framework/tensor.h"
 
@@ -13,6 +14,9 @@ class LayerNormImpl : public OpKernel {
  public:
   LayerNormImpl(const OpKernelInfo& op_kernel_info, bool simplified = false, bool contrib_op = false);
   Status Compute(OpKernelContext* p_op_kernel_context) const override;
+
+  Status PrePack(const Tensor& tensor, int input_idx, AllocatorPtr alloc,
+                 bool& is_packed, PrePackedWeights* prepacked_weights) override;
 
   // This method was created so that it can be called directly from `test/onnx/microbenchmark/layer_normalization.cc`.
   template <typename T, typename U>
@@ -58,6 +62,8 @@ class LayerNormImpl : public OpKernel {
   float epsilon_;
   const bool simplified_;
   const bool contrib_op_;
+  IAllocatorUniquePtr<float> scale_fp32_;
+  IAllocatorUniquePtr<float> bias_fp32_;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.h
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.h
@@ -15,7 +15,7 @@ class LayerNormImpl : public OpKernel {
   Status Compute(OpKernelContext* p_op_kernel_context) const override;
 
   // This method was created so that it can be called directly from `test/onnx/microbenchmark/layer_normalization.cc`.
-  template<typename T, typename U>
+  template <typename T, typename U>
   Status ComputeWithoutContext(
     const T* X_data,
     const TensorShape& x_shape,
@@ -28,8 +28,8 @@ class LayerNormImpl : public OpKernel {
     U* inv_std_dev,
     onnxruntime::concurrency::ThreadPool* thread_pool,
     int64_t axis,
-    float epsilon = epsilon_,
-    bool simplified = simplified_
+    float epsilon,
+    bool simplified
   ) const;
 
  private:

--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.h
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.h
@@ -63,8 +63,8 @@ class LayerNormImpl : public OpKernel {
   float epsilon_;
   const bool simplified_;
   const bool contrib_op_;
-  IAllocatorUniquePtr<float> scale_fp32_;
-  IAllocatorUniquePtr<float> bias_fp32_;
+  mutable IAllocatorUniquePtr<float> scale_fp32_;
+  mutable IAllocatorUniquePtr<float> bias_fp32_;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.h
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.h
@@ -17,19 +17,19 @@ class LayerNormImpl : public OpKernel {
   // This method was created so that it can be called directly from `test/onnx/microbenchmark/layer_normalization.cc`.
   template <typename T, typename U>
   Status ComputeWithoutContext(
-    const T* X_data,
-    const TensorShape& x_shape,
-    const T* scale_data,
-    const TensorShape& scale_shape,
-    const T* bias_data,
-    const TensorShape& bias_shape,
-    T* Y_data,
-    U* mean_data,
-    U* inv_std_dev,
-    onnxruntime::concurrency::ThreadPool* thread_pool,
-    int64_t axis,
-    float epsilon,
-    bool simplified) const;
+      const T* X_data,
+      const TensorShape& x_shape,
+      const T* scale_data,
+      const TensorShape& scale_shape,
+      const T* bias_data,
+      const TensorShape& bias_shape,
+      T* Y_data,
+      U* mean_data,
+      U* inv_std_dev,
+      onnxruntime::concurrency::ThreadPool* thread_pool,
+      int64_t axis,
+      float epsilon,
+      bool simplified) const;
 
  private:
   template <typename T, typename U>
@@ -38,16 +38,16 @@ class LayerNormImpl : public OpKernel {
   template <typename T>
   struct SrcDispatcher {
     Status operator()(const LayerNormImpl* p_instance, OpKernelContext* p_ctx, int64_t orig_axis,
-      float epsilon, bool simplified, bool contrib_op) const {
+                      float epsilon, bool simplified, bool contrib_op) const {
       // the contrib op kernel was always registered with the same type for all constraints.
       // our implementation of the onnx op only supports 'float' as the U constraint.
-  #if !defined(DISABLE_CONTRIB_OPS)
+#if !defined(DISABLE_CONTRIB_OPS)
       if (contrib_op) {
         return p_instance->ComputeImpl<T, T>(p_ctx, orig_axis, epsilon, simplified);
       } else
-  #else
+#else
       ORT_UNUSED_PARAMETER(contrib_op);
-  #endif
+#endif
       {
         return p_instance->ComputeImpl<T, float>(p_ctx, orig_axis, epsilon, simplified);
       }

--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.h
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.h
@@ -29,8 +29,7 @@ class LayerNormImpl : public OpKernel {
     onnxruntime::concurrency::ThreadPool* thread_pool,
     int64_t axis,
     float epsilon,
-    bool simplified
-  ) const;
+    bool simplified) const;
 
  private:
   template <typename T, typename U>
@@ -38,7 +37,8 @@ class LayerNormImpl : public OpKernel {
 
   template <typename T>
   struct SrcDispatcher {
-    Status operator()(const LayerNormImpl* p_instance, OpKernelContext* p_ctx, int64_t orig_axis, float epsilon, bool simplified, bool contrib_op) const {
+    Status operator()(const LayerNormImpl* p_instance, OpKernelContext* p_ctx, int64_t orig_axis,
+      float epsilon, bool simplified, bool contrib_op) const {
       // the contrib op kernel was always registered with the same type for all constraints.
       // our implementation of the onnx op only supports 'float' as the U constraint.
   #if !defined(DISABLE_CONTRIB_OPS)

--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.h
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.h
@@ -33,7 +33,8 @@ class LayerNormImpl : public OpKernel {
       onnxruntime::concurrency::ThreadPool* thread_pool,
       int64_t axis,
       float epsilon,
-      bool simplified) const;
+      bool simplified,
+      AllocatorPtr alloc) const;
 
  private:
   template <typename T, typename U>

--- a/onnxruntime/test/onnx/microbenchmark/layer_normalization.cc
+++ b/onnxruntime/test/onnx/microbenchmark/layer_normalization.cc
@@ -33,23 +33,22 @@ static const size_t num_elems = dims[0] * dims[1] * dims[2];
 static const std::vector<float> float_vals(num_elems, 1.0f);
 static const std::vector<MLFloat16> MLFloat16_vals(num_elems, MLFloat16(1.0f));
 
-} // namespace
+}  // namespace
 
 template <typename T>
 const T* getVector();
 
 template <>
 const float* getVector<float>() {
-    return float_vals.data();
+  return float_vals.data();
 }
 
 template <>
 const MLFloat16* getVector<MLFloat16>() {
-    return MLFloat16_vals.data();
+  return MLFloat16_vals.data();
 }
 
-
-template<typename T, typename U>
+template <typename T, typename U>
 static void BM_LayerNormalization(benchmark::State& state) {
   bool simplified = false;
   const float epsilon = 1e-05f;
@@ -69,7 +68,7 @@ static void BM_LayerNormalization(benchmark::State& state) {
   ConfigOptions config_options;
 
   OpKernelInfo op_kernel_info(node, kernel_def, *execution_provider, constant_initialized_tensors, mlvalue_name_idx_map,
-    data_transfer_mgr, allocators, config_options);
+                              data_transfer_mgr, allocators, config_options);
 
   LayerNormImpl layer_norm_impl(op_kernel_info);
 
@@ -88,20 +87,18 @@ static void BM_LayerNormalization(benchmark::State& state) {
   OrtThreadPoolParams tp_params;
   tp_params.name = ORT_TSTR("intra-op");
   std::unique_ptr<concurrency::ThreadPool> thread_pool = concurrency::CreateThreadPool(
-    &Env::Default(), tp_params, concurrency::ThreadPoolType::INTRA_OP);
+      &Env::Default(), tp_params, concurrency::ThreadPoolType::INTRA_OP);
 
   for (auto _ : state) {
     auto status = layer_norm_impl.ComputeWithoutContext(x_data, x_shape, scale_data, scale_shape, bias_data, bias_shape,
-      Y_data, mean_data, inv_std_dev_data, thread_pool.get(), axis, epsilon, simplified);
+                                                        Y_data, mean_data, inv_std_dev_data, thread_pool.get(), axis, epsilon, simplified);
 
-    if (! status.IsOK())
-    {
-       std::cout << "ComputeWithoutContext status not OK: " << status.ErrorMessage() << std::endl;
-       break;
+    if (!status.IsOK()) {
+      std::cout << "ComputeWithoutContext status not OK: " << status.ErrorMessage() << std::endl;
+      break;
     }
   }
 }
-
 
 BENCHMARK(BM_LayerNormalization<float, float>)
     ->Arg(1)

--- a/onnxruntime/test/onnx/microbenchmark/layer_normalization.cc
+++ b/onnxruntime/test/onnx/microbenchmark/layer_normalization.cc
@@ -1,0 +1,108 @@
+#include "core/platform/threadpool.h"
+#include "core/util/thread_utils.h"
+#include <benchmark/benchmark.h>
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
+#include "core/framework/allocator.h"
+#include "core/framework/config_options.h"
+#include "core/framework/data_transfer_manager.h"
+#include "core/framework/op_kernel_info.h"
+#include "core/framework/ort_value_name_idx_map.h"
+#include "core/platform/windows/env.h"
+#include "core/providers/cpu/nn/layer_norm_impl.h"
+#include "core/providers/cpu/cpu_provider_factory.h"
+#include "core/providers/cpu/cpu_provider_factory_creator.h"
+#include "core/util/thread_utils.h"
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+using namespace onnxruntime;
+
+template<typename T, typename U>
+static void BM_LayerNormalization(benchmark::State& state) {
+  bool simplified = false;
+  const float epsilon = 1e-05f;
+  int64_t axis = 1;
+
+  onnxruntime::Node node;
+  // Required by LayerNormImpl constructor
+  node.AddAttribute("axis", axis);
+  node.AddAttribute("epsilon", epsilon);
+
+  KernelDef kernel_def;
+  std::unique_ptr<IExecutionProvider> execution_provider = CPUProviderFactoryCreator::Create(true)->CreateProvider();
+  std::unordered_map<int, OrtValue> constant_initialized_tensors;
+  OrtValueNameIdxMap mlvalue_name_idx_map;
+  DataTransferManager data_transfer_mgr;
+  AllocatorMap allocators;
+  ConfigOptions config_options;
+
+  OpKernelInfo op_kernel_info(node, kernel_def, *execution_provider, constant_initialized_tensors, mlvalue_name_idx_map,
+    data_transfer_mgr, allocators, config_options);
+
+  LayerNormImpl layer_norm_impl(op_kernel_info);
+
+  std::vector<int64_t> x_dims{2, 2, 2};
+  TensorShape x_shape(x_dims);
+  std::vector<float> x{1, 1, 1, 1, 1, 1, 1, 1};
+
+  std::vector<int64_t> scale_bias_dims{1, 2, 2};
+  TensorShape scale_shape(scale_bias_dims);
+  TensorShape bias_shape(scale_bias_dims);
+  std::vector<float> scale{1, 1, 1, 1};
+  std::vector<float> bias{1, 1, 1, 1};
+
+  T* X_data = static_cast<T*>(malloc(x.size() * sizeof(T)));
+  T* scale_data = static_cast<T*>(malloc(scale.size() * sizeof(T)));
+  T* bias_data = static_cast<T*>(malloc(bias.size() * sizeof(T)));
+  for (size_t i = 0; i < x.size(); i++) {
+    X_data[i] = T(x[i]);
+  }
+  for (size_t i = 0; i < scale.size(); i++) {
+    scale_data[i] = T(scale[i]);
+  }
+  for (size_t i = 0; i < bias.size(); i++) {
+    bias_data[i] = T(bias[i]);
+  }
+
+  T* Y_data = static_cast<T*>(malloc(x.size() * sizeof(T)));
+  U* mean_data = static_cast<U*>(malloc(x.size() * sizeof(U)));
+  U* inv_std_dev_data = static_cast<U*>(malloc(x.size() * sizeof(U)));
+
+  OrtThreadPoolParams tp_params;
+  tp_params.name = ORT_TSTR("intra-op");
+  std::unique_ptr<concurrency::ThreadPool> thread_pool = concurrency::CreateThreadPool(
+    &Env::Default(), tp_params, concurrency::ThreadPoolType::INTRA_OP);
+
+  for (auto _ : state) {
+    auto status = layer_norm_impl.ComputeWithoutContext(X_data, x_shape, scale_data, scale_shape, bias_data, bias_shape,
+      Y_data, mean_data, inv_std_dev_data, thread_pool.get(), axis, epsilon, simplified);
+
+    if (! status.IsOK())
+    {
+       std::cout << "ComputeWithoutContext status not OK: " << status.ErrorMessage() << std::endl;
+       break;
+    }
+  }
+}
+
+
+BENCHMARK(BM_LayerNormalization<float, float>)
+    ->Arg(1)
+    ->Arg(256)
+    ->Arg(1024)
+    ->UseRealTime()
+    ->Unit(benchmark::TimeUnit::kMicrosecond);
+
+BENCHMARK(BM_LayerNormalization<MLFloat16, MLFloat16>)
+    ->Arg(1)
+    ->Arg(256)
+    ->Arg(1024)
+    ->UseRealTime()
+    ->Unit(benchmark::TimeUnit::kMicrosecond);

--- a/onnxruntime/test/onnx/microbenchmark/layer_normalization.cc
+++ b/onnxruntime/test/onnx/microbenchmark/layer_normalization.cc
@@ -108,11 +108,12 @@ static void BM_LayerNormalization(benchmark::State& state) {
   std::unique_ptr<concurrency::ThreadPool> thread_pool = concurrency::CreateThreadPool(
       &Env::Default(), tp_params, concurrency::ThreadPoolType::INTRA_OP);
 
+  OrtMemoryInfo memory_info(onnxruntime::CPU, OrtAllocatorType::OrtArenaAllocator);
+  AllocatorPtr alloc = std::make_shared<CPUAllocator>(memory_info);
   for (auto _ : state) {
     auto status = layer_norm_impl.ComputeWithoutContext(x_data, x_shape, scale_data, scale_shape, bias_data, bias_shape,
                                                         Y_data, mean_data, inv_std_dev_data, thread_pool.get(), axis,
-                                                        epsilon, simplified);
-
+                                                        epsilon, simplified, alloc);
     if (!status.IsOK()) {
       std::cout << "ComputeWithoutContext status not OK: " << status.ErrorMessage() << std::endl;
       break;

--- a/onnxruntime/test/onnx/microbenchmark/layer_normalization.cc
+++ b/onnxruntime/test/onnx/microbenchmark/layer_normalization.cc
@@ -1,3 +1,5 @@
+#ifdef _WIN32
+
 #include "core/platform/threadpool.h"
 #include "core/util/thread_utils.h"
 #include <benchmark/benchmark.h>
@@ -110,3 +112,5 @@ BENCHMARK(BM_LayerNormalization<MLFloat16, MLFloat16>)
     ->Arg(1)
     ->UseRealTime()
     ->Unit(benchmark::TimeUnit::kMicrosecond);
+
+#endif


### PR DESCRIPTION
- Added a microbenchmark for the `LayerNormalization` MLFloat16 support added in https://github.com/microsoft/onnxruntime/pull/22063.
- Updated the `LayerNormalization` MLFloat16 implementation to improve the latency.

```
----------------------------------------------------------------------------------------------
Original MLFloat16 support                                   Time             CPU   Iterations
----------------------------------------------------------------------------------------------
BM_LayerNormalization<MLFloat16, float>/1/real_time      15599 us        15625 us           47
BM_LayerNormalization<MLFloat16, float>/1/real_time      14714 us        14824 us           39
BM_LayerNormalization<MLFloat16, float>/1/real_time      14634 us        14688 us           50


----------------------------------------------------------------------------------------------
Updated MLFloat16 support                                    Time             CPU   Iterations
----------------------------------------------------------------------------------------------
BM_LayerNormalization<MLFloat16, float>/1/real_time       7276 us         7254 us           84
BM_LayerNormalization<MLFloat16, float>/1/real_time       6820 us         6720 us           93
BM_LayerNormalization<MLFloat16, float>/1/real_time       6840 us         6882 us           84
```