### PR TITLE
Replace gradle/wrapper-validation-action with gradle/actions/wrapper-validation-action

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -11,4 +11,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v3
+      - uses: gradle/actions/wrapper-validation@v3


### PR DESCRIPTION


### Description
Replace gradle/wrapper-validation-action with gradle/actions/wrapper-validation-action


### Motivation and Context
This is recommended by https://github.com/gradle/wrapper-validation-action. This job uses deprecated functionality from the 'gradle/wrapper-validation-action' action.


