### PR TITLE
Add S8U8 model type to GEMM and other quantized layers

### DIFF
--- a/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_matmul.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_matmul.cc
@@ -329,7 +329,7 @@ ONNX_OPERATOR_TYPED_KERNEL_EX(
     kCpuExecutionProvider,
     KernelDefBuilder()
         .TypeConstraint("T1", DataTypeImpl::GetTensorType<int8_t>())
-        .TypeConstraint("T2", DataTypeImpl::GetTensorType<int8_t>())
+        .TypeConstraint("T2", {DataTypeImpl::GetTensorType<uint8_t>(), DataTypeImpl::GetTensorType<int8_t>()})
         .TypeConstraint("T3", DataTypeImpl::GetTensorType<float>()),
     MatMulIntegerToFloat);
 

--- a/onnxruntime/contrib_ops/cpu/quantization/quant_gemm.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/quant_gemm.cc
@@ -236,7 +236,7 @@ ONNX_OPERATOR_TYPED_KERNEL_EX(
     KernelDefBuilder()
         .TypeConstraint("T", DataTypeImpl::GetTensorType<float>())
         .TypeConstraint("TA", DataTypeImpl::GetTensorType<int8_t>())
-        .TypeConstraint("TB", DataTypeImpl::GetTensorType<int8_t>())
+        .TypeConstraint("TB", {DataTypeImpl::GetTensorType<uint8_t>(), DataTypeImpl::GetTensorType<int8_t>()})
         .TypeConstraint("TC", DataTypeImpl::GetTensorType<int32_t>())
         .TypeConstraint("TYZ", DataTypeImpl::GetTensorType<int8_t>())
         .TypeConstraint("TY", {DataTypeImpl::GetTensorType<float>(), DataTypeImpl::GetTensorType<int8_t>()}),

--- a/onnxruntime/core/providers/cpu/quantization/matmul_integer.cc
+++ b/onnxruntime/core/providers/cpu/quantization/matmul_integer.cc
@@ -48,7 +48,7 @@ ONNX_OPERATOR_TYPED_KERNEL_EX(
     kCpuExecutionProvider,
     KernelDefBuilder()
         .TypeConstraint("T1", DataTypeImpl::GetTensorType<int8_t>())
-        .TypeConstraint("T2", DataTypeImpl::GetTensorType<int8_t>())
+        .TypeConstraint("T2", {DataTypeImpl::GetTensorType<uint8_t>(), DataTypeImpl::GetTensorType<int8_t>()})
         .TypeConstraint("T3", DataTypeImpl::GetTensorType<int32_t>()),
     MatMulInteger);
 

--- a/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
+++ b/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
@@ -316,7 +316,7 @@ ONNX_OPERATOR_TYPED_KERNEL_EX(
         .TypeConstraint("T4", DataTypeImpl::GetTensorType<int32_t>()),
     QLinearConv<uint8_t>);
 
-// int8_t kernel only supports weight being int8_t
+// int8_t kernel supports weight being either uint8_t or int8_t
 #define REGISTER_QLINEARCONV_INT8_KERNEL(domain, version)                \
   ONNX_OPERATOR_TYPED_KERNEL_EX(                                         \
       QLinearConv,                                                       \
@@ -326,7 +326,7 @@ ONNX_OPERATOR_TYPED_KERNEL_EX(
       kCpuExecutionProvider,                                             \
       KernelDefBuilder()                                                 \
           .TypeConstraint("T1", DataTypeImpl::GetTensorType<int8_t>())   \
-          .TypeConstraint("T2", DataTypeImpl::GetTensorType<int8_t>())   \
+          .TypeConstraint("T2", {DataTypeImpl::GetTensorType<uint8_t>(), DataTypeImpl::GetTensorType<int8_t>()})   \
           .TypeConstraint("T3", DataTypeImpl::GetTensorType<int8_t>())   \
           .TypeConstraint("T4", DataTypeImpl::GetTensorType<int32_t>()), \
       QLinearConv<int8_t>);

--- a/onnxruntime/core/providers/cpu/quantization/quantize_linear_matmul.cc
+++ b/onnxruntime/core/providers/cpu/quantization/quantize_linear_matmul.cc
@@ -26,7 +26,7 @@ ONNX_OPERATOR_TYPED_KERNEL_EX(
         .TypeConstraint("T3", DataTypeImpl::GetTensorType<uint8_t>()),
     QLinearMatMul);
 
-// int8_t kernel only supports weight being int8_t
+// int8_t kernel supports weight being either uint8_t or int8_t
 #define REGISTER_QLINEARMATMUL_INT8_KERNEL()                            \
   ONNX_OPERATOR_TYPED_KERNEL_EX(                                        \
       QLinearMatMul,                                                    \
@@ -36,7 +36,7 @@ ONNX_OPERATOR_TYPED_KERNEL_EX(
       kCpuExecutionProvider,                                            \
       KernelDefBuilder()                                                \
           .TypeConstraint("T1", DataTypeImpl::GetTensorType<int8_t>())  \
-          .TypeConstraint("T2", DataTypeImpl::GetTensorType<int8_t>())  \
+          .TypeConstraint("T2", {DataTypeImpl::GetTensorType<uint8_t>(), DataTypeImpl::GetTensorType<int8_t>()})  \
           .TypeConstraint("T3", DataTypeImpl::GetTensorType<int8_t>()), \
       QLinearMatMul);
 

--- a/onnxruntime/test/mlas/unittest/test_scaleoutput.cpp
+++ b/onnxruntime/test/mlas/unittest/test_scaleoutput.cpp
@@ -52,7 +52,7 @@ class MlasScaleOutputTest : public MlasTestBase {
     constexpr float epsilon = 1e-6f;
 
     for (size_t n = 0; n < M * N; n++) {
-      float diff = std::fabs((Output[n] - OutputRef[n]) / OutputRef[n]);
+      float diff = OutputRef[n] == 0 ? std::fabs(Output[n] - OutputRef[n]) : std::fabs((Output[n] - OutputRef[n]) / OutputRef[n]);
       ASSERT_LE(diff, epsilon)
           << " @[" << n / N << "," << n % N << "], total:[" << M << "," << N << "], got:"
           << Output[n] << ", expecting:" << OutputRef[n];


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Enable S8U8 model type in runtime. Add uint8_t to a valid weight type when using signed int8_t inputs.

(Also found a divide by 0 bug in short unit tests, so fixed that too)


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

The ONNX spec and MSFT documentation indicates that S8U8 is a valid combination for quantized GEMM and convolution layers. However, the runtime did not support these layer types to be created. This change allows models using the S8U8 format to be created and run.
In PR https://github.com/microsoft/onnxruntime/pull/21984 support was added for S8S8 and S8U8 GEMM kernels to run with AVX-VNNI-INT8 instructions.

