### PR TITLE
Increase React Native E2E 

### DIFF
--- a/js/react_native/e2e/.detoxrc.js
+++ b/js/react_native/e2e/.detoxrc.js
@@ -6,7 +6,7 @@ module.exports = {
       config: 'test/jest.config.js',
     },
     jest: {
-      setupTimeout: 120000,
+      setupTimeout: 240000,
     },
   },
   apps: {


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Increase the detox setup timeout to 4 minutes. 

The iOS RN E2E tests are taking slightly around 2 mins to setup causing flakiness.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Improve RN CI pass rate

