### PR TITLE
Fix possible deadlock when using RunAsync

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.shared.cs
@@ -1144,13 +1144,16 @@ namespace Microsoft.ML.OnnxRuntime
         /// <param name="outputValues">output of ort values</param>
         /// <returns>task to be awaited</returns>
         /// <exception cref="OnnxRuntimeException"></exception>
-        public async Task<IReadOnlyCollection<OrtValue>> RunAsync(RunOptions options,
+        public Task<IReadOnlyCollection<OrtValue>> RunAsync(RunOptions options,
                                                                   IReadOnlyCollection<string> inputNames,
                                                                   IReadOnlyCollection<OrtValue> inputValues,
                                                                   IReadOnlyCollection<string> outputNames,
                                                                   IReadOnlyCollection<OrtValue> outputValues)
         {
-            var promise = new TaskCompletionSource<IReadOnlyCollection<OrtValue>>();
+            var promise = new TaskCompletionSource<IReadOnlyCollection<OrtValue>>(
+                TaskCreationOptions.RunContinuationsAsynchronously
+            );
+
             RunAsyncInternal(options,
                      inputNames,
                      inputValues,
@@ -1168,7 +1171,7 @@ namespace Microsoft.ML.OnnxRuntime
                              promise.SetException(ex);
                          }
                      });
-            return await promise.Task;
+            return promise.Task;
         }
 
         #endregion

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/InferenceTest.cs
@@ -2039,8 +2039,6 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             }
         }
 
-        // Test hangs on mobile.
-#if !(ANDROID || IOS)  
         [Fact(DisplayName = "TestModelRunAsyncTask")]
         private async Task TestModelRunAsyncTask()
         {
@@ -2075,7 +2073,6 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 }
             }
         }
-#endif
 
         [Fact(DisplayName = "TestModelRunAsyncTaskFail")]
         private async Task TestModelRunAsyncTaskFail()


### PR DESCRIPTION
### Description
Make sure the Task returned by InferenceSession.RunAsync runs continuations asynchronously to avoid possible deadlocks.

### Motivation and Context
By default calling TaskCompletionSource will run all continuations synchronously when calling SetResult, which can lead to some unexpected behavior. Consider how InferenceSession is used in the current unit test:
https://github.com/microsoft/onnxruntime/blob/d0b0ecfdb9357818dba08a25c121d5e7173f22fd/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/InferenceTest.cs#L2061-L2075
In this case execution will leave the using block and dispose the InferenceSession while we are still inside of the OrtRunAsync callback, so the inference is effectively still running. I ran into this problem in simple console application, where this scenario reliably causes the Dispose call to hang forever. I was unable to reproduce this in the unit test, but I suspect this is the reason behind it hanging on mobile. The issue might be sensitive to timing as well, as using a bigger model, or freezing the test with the debugger does produce a hang.

See this article for more details on how TaskCompletionSource can cause these sorts of problems: https://devblogs.microsoft.com/premier-developer/the-danger-of-taskcompletionsourcet-class/