### PR TITLE
Make A100 jobs in PR checks again

### DIFF
--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -283,7 +283,7 @@ stages:
 - stage: Llama2_7B_ONNX
   dependsOn:
   - Build_Onnxruntime_Cuda
-  condition: and (succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/rel-')))
+  condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/rel-'), eq(variables['UseA100'], '1')
   jobs:
   - job: Llama2_7B_ONNX
     timeoutInMinutes: 120

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -283,7 +283,7 @@ stages:
 - stage: Llama2_7B_ONNX
   dependsOn:
   - Build_Onnxruntime_Cuda
-  condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/rel-'), eq(variables['UseA100'], '1')
+  condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/rel-'), eq(variables['UseA100'], '1'))
   jobs:
   - job: Llama2_7B_ONNX
     timeoutInMinutes: 120


### PR DESCRIPTION
### Description
if the variable is 1, the job running on A100 in PR checks.



### Motivation and Context
We wish more big models which need to run on A100 can be tested in PR checks, but Azure may decommission A100 agents without notifications sometimes, which will block merging PRs.
This PR is an improvement to make those jobs only  run main branch.
Once we find the A100 are all decommisioned by Azure, we could change the UseA100 variable to 0 to disable the A100 jobs in PR checks
![image](https://github.com/user-attachments/assets/da5e7af7-4d7a-44a0-8b9c-9e0b0463cb47)



