### PR TITLE
[js/webgpu] Fix the crash issue in unsqueeze

### DIFF
--- a/onnxruntime/core/providers/js/operators/unsqueeze.h
+++ b/onnxruntime/core/providers/js/operators/unsqueeze.h
@@ -29,9 +29,8 @@ class Unsqueeze final : public JsKernel, public UnsqueezeBase {
       ORT_ENFORCE(axes_tensor->Shape().NumDimensions() == 0 ||
                       axes_tensor->Shape().NumDimensions() == 1,
                   "An axes tensor must be a scalar or a vector tensor.");
-      auto nDims = static_cast<size_t>(axes_tensor->Shape()[0]);
-      const auto* data = axes_tensor->Data<int64_t>();
-      axes.assign(data, data + nDims);
+      auto data_span = axes_tensor->template DataAsSpan<int64_t>();
+      axes.assign(data_span.begin(), data_span.end());
     } else {
       axes.assign(axes_.begin(), axes_.end());
     }


### PR DESCRIPTION
While allowing axes in unsqueeze to be scalar, its shape couldn't be always accessed like a vector. This PR fixes issue #22031 so that the original model could run well.
