### PR TITLE
[build/openvino] fix build option when using use_openvino with hetero/multi/auto

### DIFF
--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.h
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.h
@@ -142,15 +142,15 @@ struct OpenVINOExecutionProviderInfo {
 #ifdef DEVICE_NAME
 #define DEVICE DEVICE_NAME
 #endif
-      dev_type = DEVICE;
+      std::string dev_type_(DEVICE);
 
-      if (dev_type.find("HETERO") == 0 || dev_type.find("MULTI") == 0 || dev_type.find("AUTO") == 0) {
-        std::vector<std::string> devices = parseDevices(dev_type, available_devices);
+      if (dev_type_.find("HETERO") == 0 || dev_type_.find("MULTI") == 0 || dev_type_.find("AUTO") == 0) {
+        std::vector<std::string> devices = parseDevices(dev_type_, available_devices);
         precision_ = "FP16";
         if (devices[0] == "CPU") {
           precision_ = "FP32";
         }
-        device_type_ = std::move(dev_type);
+        device_type_ = std::move(dev_type_);
       }
 #endif
     } else if (ov_supported_device_types.find(dev_type) != ov_supported_device_types.end()) {


### PR DESCRIPTION
### Description
fix openvino hetero/multi/auto config compile


### Motivation and Context
When building with the option `-- use_openvino` and values of `HETERO`/`MULTI`/`AUTO` (ex: AUTO: GPU, CPU...), the build will fail.
I used a temporary variable std:: string dev_type_ (DEVICE) to avoid this issue, as I was trying to assign DEVICE to const std:: string, which is const char *.

#22175 

