### PR TITLE
Fixes a crash on macOS 15 when using CoreML.

### DIFF
--- a/onnxruntime/core/providers/coreml/model/model.mm
+++ b/onnxruntime/core/providers/coreml/model/model.mm
@@ -394,7 +394,7 @@ Status Execution::LoadModel() {
 
       compiled_model_path_ = [compileUrl path];
 
-      MLModelConfiguration* config = [MLModelConfiguration alloc];
+      MLModelConfiguration* config = [[MLModelConfiguration alloc] init];
       config.computeUnits = (coreml_flags_ & COREML_FLAG_USE_CPU_ONLY)
                                 ? MLComputeUnitsCPUOnly
                                 : MLComputeUnitsAll;


### PR DESCRIPTION
### Description
In macOS 15, apps running with CoreML will crash with an error message like this one:
```
Terminating app due to uncaught exception 'NSGenericException', reason: 'Failed to set compute_device_types_mask E5RT: Cannot provide zero compute device types. (1)'
```

This can be easily seen when building ONNXRuntime from source and running the unit tests. The fix was suggested in [this bug report](https://forums.developer.apple.com/forums/thread/757040).
I've ported the change to ONNXRuntime and verified that:
* The issue is resolved in macOS 15 (all unit tests pass).
* The behaviour is unchanged in macOS 14. 


### Motivation and Context
This fixes #22275 allowing apps using ONNXRuntime with CoreML to work normally.


