### PR TITLE
Add SetEpDynamicOptions and remove workload_type from run/session options 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,5 +22,8 @@
         "-build/include_subdir",
         "-runtime/references"
     ],
-    "C_Cpp.autoAddFileAssociations": false
+    "C_Cpp.autoAddFileAssociations": false,
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "main"
+    ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,8 +22,5 @@
         "-build/include_subdir",
         "-runtime/references"
     ],
-    "C_Cpp.autoAddFileAssociations": false,
-    "githubPullRequests.ignoredPullRequestBranches": [
-        "main"
-    ]
+    "C_Cpp.autoAddFileAssociations": false
 }

--- a/include/onnxruntime/core/framework/execution_provider.h
+++ b/include/onnxruntime/core/framework/execution_provider.h
@@ -218,8 +218,8 @@ class IExecutionProvider {
      Called when InferenceSession::SetEpDynamicOptions is called
      TODO: what is the right way of passing parameters?
   */
-  virtual common::Status SetEpDynamicOptions(gsl::span<const char*> /*keys*/,
-                                             gsl::span<const char*> /*values*/) {
+  virtual common::Status SetEpDynamicOptions(gsl::span<const char* const> /*keys*/,
+                                             gsl::span<const char* const> /*values*/) {
     return Status::OK();
   }
 

--- a/include/onnxruntime/core/framework/execution_provider.h
+++ b/include/onnxruntime/core/framework/execution_provider.h
@@ -216,7 +216,6 @@ class IExecutionProvider {
 
   /**
      Called when InferenceSession::SetEpDynamicOptions is called
-     TODO: what is the right way of passing parameters?
   */
   virtual common::Status SetEpDynamicOptions(gsl::span<const char* const> /*keys*/,
                                              gsl::span<const char* const> /*values*/) {

--- a/include/onnxruntime/core/framework/execution_provider.h
+++ b/include/onnxruntime/core/framework/execution_provider.h
@@ -215,6 +215,15 @@ class IExecutionProvider {
   }
 
   /**
+     Called when InferenceSession::SetEpDynamicOptions is called
+     TODO: what is the right way of passing parameters?
+  */
+  virtual common::Status SetEpDynamicOptions(gsl::span<const std::string> /*keys*/,
+                                             gsl::span<const std::string> /*values*/) {
+    return Status::OK();
+  }
+
+  /**
      Indicate whether the graph capturing mode (e.g., cuda graph) is enabled for
      the provider.
    */

--- a/include/onnxruntime/core/framework/execution_provider.h
+++ b/include/onnxruntime/core/framework/execution_provider.h
@@ -218,8 +218,8 @@ class IExecutionProvider {
      Called when InferenceSession::SetEpDynamicOptions is called
      TODO: what is the right way of passing parameters?
   */
-  virtual common::Status SetEpDynamicOptions(gsl::span<const std::string> /*keys*/,
-                                             gsl::span<const std::string> /*values*/) {
+  virtual common::Status SetEpDynamicOptions(gsl::span<const char*> /*keys*/,
+                                             gsl::span<const char*> /*values*/) {
     return Status::OK();
   }
 

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -1312,6 +1312,24 @@ struct OrtApi {
   ORT_API2_STATUS(RunOptionsUnsetTerminate, _Inout_ OrtRunOptions* options);
 
   /// @}
+  /// \name OrtEpDynamicOptions
+  /// @{
+
+  /** \brief Set DynamicOptions for EPs
+   *
+   * \param[in] session
+   * \param[in] list of keys represented by null-terminated strings
+   * \param[in] list of values represented by null-terminated strings
+   * \param[in] number of key-value pairs
+   *
+   * \since Version xxx
+   * @TODO: update version number
+   * @TODO: should it be SetExecutionProvider... instead of SetEp...?
+   */
+  ORT_API2_STATUS(SetEpDynamicOptions, _In_ OrtSession* sess, _In_ const char** keys, _In_ const char** values,
+                  _In_ size_t kv_len);
+
+  /// @}
   /// \name OrtValue
   /// @{
 

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -4738,8 +4738,8 @@ struct OrtApi {
    * @TODO: update version number
    * @TODO: should it be SetExecutionProvider... instead of SetEp...?
    */
-  ORT_API2_STATUS(SetEpDynamicOptions, _In_ OrtSession* sess, _In_ const char** keys, _In_ const char** values,
-                  _In_ size_t kv_len);
+  ORT_API2_STATUS(SetEpDynamicOptions, _Inout_ OrtSession* sess, _In_reads_(kv_len) const char* const* keys,
+                  _In_reads_(kv_len) const char* const* values, _In_ size_t kv_len);
 };
 
 /*

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -1312,24 +1312,6 @@ struct OrtApi {
   ORT_API2_STATUS(RunOptionsUnsetTerminate, _Inout_ OrtRunOptions* options);
 
   /// @}
-  /// \name OrtEpDynamicOptions
-  /// @{
-
-  /** \brief Set DynamicOptions for EPs
-   *
-   * \param[in] session
-   * \param[in] list of keys represented by null-terminated strings
-   * \param[in] list of values represented by null-terminated strings
-   * \param[in] number of key-value pairs
-   *
-   * \since Version xxx
-   * @TODO: update version number
-   * @TODO: should it be SetExecutionProvider... instead of SetEp...?
-   */
-  ORT_API2_STATUS(SetEpDynamicOptions, _In_ OrtSession* sess, _In_ const char** keys, _In_ const char** values,
-                  _In_ size_t kv_len);
-
-  /// @}
   /// \name OrtValue
   /// @{
 
@@ -4740,6 +4722,24 @@ struct OrtApi {
    * \param[in] adapter OrtLoraAdapter instance
    */
   ORT_API2_STATUS(RunOptionsAddActiveLoraAdapter, _Inout_ OrtRunOptions* options, _In_ const OrtLoraAdapter* adapter);
+
+  /// @}
+  /// \name OrtEpDynamicOptions
+  /// @{
+
+  /** \brief Set DynamicOptions for EPs
+   *
+   * \param[in] session
+   * \param[in] list of keys represented by null-terminated strings
+   * \param[in] list of values represented by null-terminated strings
+   * \param[in] number of key-value pairs
+   *
+   * \since Version xxx
+   * @TODO: update version number
+   * @TODO: should it be SetExecutionProvider... instead of SetEp...?
+   */
+  ORT_API2_STATUS(SetEpDynamicOptions, _In_ OrtSession* sess, _In_ const char** keys, _In_ const char** values,
+                  _In_ size_t kv_len);
 };
 
 /*

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -4727,16 +4727,17 @@ struct OrtApi {
   /// \name OrtEpDynamicOptions
   /// @{
 
-  /** \brief Set DynamicOptions for EPs
+  /** \brief Set DynamicOptions for EPs (Execution Providers)
+   *
+   * Valid options can be found in `include\onnxruntime\core\session\onnxruntime_session_options_config_keys.h`
+   * Look for `kOrtEpDynamicOptions`
    *
    * \param[in] session
    * \param[in] list of keys represented by null-terminated strings
    * \param[in] list of values represented by null-terminated strings
    * \param[in] number of key-value pairs
    *
-   * \since Version xxx
-   * @TODO: update version number
-   * @TODO: should it be SetExecutionProvider... instead of SetEp...?
+   * \since Version 1.20
    */
   ORT_API2_STATUS(SetEpDynamicOptions, _Inout_ OrtSession* sess, _In_reads_(kv_len) const char* const* keys,
                   _In_reads_(kv_len) const char* const* values, _In_ size_t kv_len);

--- a/include/onnxruntime/core/session/onnxruntime_run_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_run_options_config_keys.h
@@ -49,8 +49,3 @@ static const char* const kOrtRunOptionsConfigQnnRpcControlLatency = "qnn.rpc_con
 // If the value is set to -1, cuda graph capture/replay is disabled in that run.
 // User are not expected to set the value to 0 as it is reserved for internal use.
 static const char* const kOrtRunOptionsConfigCudaGraphAnnotation = "gpu_graph_id";
-
-// Specify the type of workload for this run.
-// “Default”: OS determines the scheduling priority and processor performance to service this workload. [Default]
-// “Efficient”: OS treats this workload is efficiency oriented with low scheduling priority and efficient processor performance.
-static const char* const kOrtRunOptionsWorkloadType = "run.workload_type";

--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -282,8 +282,3 @@ static const char* const kOrtSessionOptionsMlasGemmFastMathArm64Bfloat16 = "mlas
 // Refer to MatMulNBits op schema for more details.
 // If not provided, default is 4.
 static const char* const kOrtSessionOptionsQDQMatMulNBitsAccuracyLevel = "session.qdq_matmulnbits_accuracy_level";
-
-// Specify the type of workload for this session.
-// “Default”: OS determines the scheduling priority and processor performance to service this workload. [Default]
-// “Efficient”: OS treats this workload is efficiency oriented with low scheduling priority and efficient processor performance.
-static const char* const kOrtSessionOptionsWorkloadType = "session.workload_type";

--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -288,5 +288,4 @@ static const char* const kOrtSessionOptionsQDQMatMulNBitsAccuracyLevel = "sessio
 // Specify the type of workload for this session.
 // “Default”: OS determines the scheduling priority and processor performance to service this workload. [Default]
 // “Efficient”: OS treats this workload is efficiency oriented with low scheduling priority and efficient processor performance.
-// TODO: ep_dynamic.workload_type VS ep.dynamic.workload.type
 static const char* const kOrtEpDynamicOptionsWorkloadType = "ep.dynamic.workload_type";

--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -282,3 +282,11 @@ static const char* const kOrtSessionOptionsMlasGemmFastMathArm64Bfloat16 = "mlas
 // Refer to MatMulNBits op schema for more details.
 // If not provided, default is 4.
 static const char* const kOrtSessionOptionsQDQMatMulNBitsAccuracyLevel = "session.qdq_matmulnbits_accuracy_level";
+
+// THIS OPTION IS NOT A REGULAR SESSION OPTION SINCE IT CAN BE MODIFIED AT ANY TIME
+// Meant to be used with SetEpDynamicOptions
+// Specify the type of workload for this session.
+// “Default”: OS determines the scheduling priority and processor performance to service this workload. [Default]
+// “Efficient”: OS treats this workload is efficiency oriented with low scheduling priority and efficient processor performance.
+// TODO: ep_dynamic.workload_type VS ep.dynamic.workload.type
+static const char* const kOrtEpDynamicOptionsWorkloadType = "ep.dynamic.workload_type";

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -2477,8 +2477,8 @@ struct ThreadPoolSpinningSwitch {
 
 // TODO: are we going to do all the ttracing and logging and telemetry for this?
 // TODO: is this the right type? How do we convert to string?
-Status InferenceSession::SetEpDynamicOptions(gsl::span<const char*> keys,
-                                             gsl::span<const char*> values) {
+Status InferenceSession::SetEpDynamicOptions(gsl::span<const char* const> keys,
+                                             gsl::span<const char* const> values) {
   Status retval = Status::OK();
 
   ORT_TRY {
@@ -2494,7 +2494,6 @@ Status InferenceSession::SetEpDynamicOptions(gsl::span<const char*> keys,
       ORT_CHECK_AND_SET_RETVAL(status);
     }
   }
-
   ORT_CATCH(const std::exception& e) {
     ORT_HANDLE_EXCEPTION([&]() {
       retval = Status(common::ONNXRUNTIME, common::FAIL, e.what());

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -2476,11 +2476,10 @@ struct ThreadPoolSpinningSwitch {
 }  // namespace
 
 // TODO: are we going to do all the ttracing and logging and telemetry for this?
-// TODO: is this the right type?
-Status InferenceSession::SetEpDynamicOptions(gsl::span<const std::string> keys,
-                                             gsl::span<const std::string> values) {
+// TODO: is this the right type? How do we convert to string?
+Status InferenceSession::SetEpDynamicOptions(gsl::span<const char*> keys,
+                                             gsl::span<const char*> values) {
   Status retval = Status::OK();
-  const Env& env = Env::Default();
 
   ORT_TRY {
     if (!is_inited_) {

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -2475,8 +2475,6 @@ struct ThreadPoolSpinningSwitch {
 };
 }  // namespace
 
-// TODO: are we going to do all the ttracing and logging and telemetry for this?
-// TODO: is this the right type? How do we convert to string?
 Status InferenceSession::SetEpDynamicOptions(gsl::span<const char* const> keys,
                                              gsl::span<const char* const> values) {
   Status retval = Status::OK();

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -2481,26 +2481,15 @@ Status InferenceSession::SetEpDynamicOptions(gsl::span<const char* const> keys,
                                              gsl::span<const char* const> values) {
   Status retval = Status::OK();
 
-  ORT_TRY {
-    if (!is_inited_) {
-      LOGS(*session_logger_, ERROR) << "Session was not initialized";
-      return Status(common::ONNXRUNTIME, common::FAIL, "Session not initialized.");
-    }
+  if (!is_inited_) {
+    LOGS(*session_logger_, ERROR) << "Session was not initialized";
+    return Status(common::ONNXRUNTIME, common::FAIL, "Session not initialized.");
+  }
 
-    // info all execution providers InferenceSession:Run started
-    // TODO: only call SetEpDynamicOptions for all providers in-use
-    for (auto& xp : execution_providers_) {
-      auto status = xp->SetEpDynamicOptions(keys, values);
-      ORT_CHECK_AND_SET_RETVAL(status);
-    }
-  }
-  ORT_CATCH(const std::exception& e) {
-    ORT_HANDLE_EXCEPTION([&]() {
-      retval = Status(common::ONNXRUNTIME, common::FAIL, e.what());
-    });
-  }
-  ORT_CATCH(...) {
-    retval = Status(common::ONNXRUNTIME, common::RUNTIME_EXCEPTION, "Encountered unknown exception in SetEpDynamicOptions()");
+  // TODO: only call SetEpDynamicOptions for all providers in-use
+  for (auto& xp : execution_providers_) {
+    auto status = xp->SetEpDynamicOptions(keys, values);
+    ORT_CHECK_AND_SET_RETVAL(status);
   }
 
   return retval;

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -330,6 +330,9 @@ class InferenceSession {
    */
   [[nodiscard]] common::Status Initialize();
 
+  [[nodiscard]] common::Status SetEpDynamicOptions(gsl::span<const char*> keys,
+                                                   gsl::span<const char*> values);
+
   [[nodiscard]] common::Status Run(const RunOptions& run_options, gsl::span<const std::string> feed_names,
                                    gsl::span<const OrtValue> feeds, gsl::span<const std::string> output_names,
                                    std::vector<OrtValue>* p_fetches,

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -330,8 +330,8 @@ class InferenceSession {
    */
   [[nodiscard]] common::Status Initialize();
 
-  [[nodiscard]] common::Status SetEpDynamicOptions(gsl::span<const char*> keys,
-                                                   gsl::span<const char*> values);
+  [[nodiscard]] common::Status SetEpDynamicOptions(gsl::span<const char* const> keys,
+                                                   gsl::span<const char* const> values);
 
   [[nodiscard]] common::Status Run(const RunOptions& run_options, gsl::span<const std::string> feed_names,
                                    gsl::span<const OrtValue> feeds, gsl::span<const std::string> output_names,

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -843,6 +843,28 @@ void CheckAndAdjustInputSpansForLora(const OrtRunOptions& run_options,
 
 }  // namespace
 
+ORT_API_STATUS_IMPL(OrtApis::SetEpDynamicOptions, _In_ OrtSession* sess, _In_ const char** keys,
+                  _In_ const char** values, _In_ size_t kv_len); {
+  API_IMPL_BEGIN
+  auto session = reinterpret_cast<::onnxruntime::InferenceSession*>(sess);
+
+  // TODO: is this what we're supposed to do with strings?
+  auto keys_span = gsl::make_span(keys, kv_len);
+  auto values_span = gsl::make_span(values, kv_len);
+
+  Status status;
+
+  if (kv_len == 0) {
+    // TODO: how does one return OK or no_values_passed
+    status = 0;
+  } else {
+    status = session->SetEpDynamicOptions(keys_span,
+                                          values_span);
+  }
+  return ToOrtStatus(status);
+  API_IMPL_END
+}
+
 ORT_API_STATUS_IMPL(OrtApis::Run, _Inout_ OrtSession* sess, _In_opt_ const OrtRunOptions* run_options,
                     _In_reads_(input_len) const char* const* input_names,
                     _In_reads_(input_len) const OrtValue* const* input, size_t input_len,
@@ -2785,6 +2807,8 @@ static constexpr OrtApi ort_api_1_to_20 = {
     &OrtApis::CreateLoraAdapterFromArray,
     &OrtApis::ReleaseLoraAdapter,
     &OrtApis::RunOptionsAddActiveLoraAdapter,
+
+    &OrtApis::SetEpDynamicOptions,
 };
 
 // OrtApiBase can never change as there is no way to know what version of OrtApiBase is returned by OrtGetApiBase.

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -844,7 +844,7 @@ void CheckAndAdjustInputSpansForLora(const OrtRunOptions& run_options,
 }  // namespace
 
 ORT_API_STATUS_IMPL(OrtApis::SetEpDynamicOptions, _In_ OrtSession* sess, _In_ const char** keys,
-                  _In_ const char** values, _In_ size_t kv_len); {
+                  _In_ const char** values, _In_ size_t kv_len) {
   API_IMPL_BEGIN
   auto session = reinterpret_cast<::onnxruntime::InferenceSession*>(sess);
 
@@ -856,7 +856,7 @@ ORT_API_STATUS_IMPL(OrtApis::SetEpDynamicOptions, _In_ OrtSession* sess, _In_ co
 
   if (kv_len == 0) {
     // TODO: how does one return OK or no_values_passed
-    status = 0;
+    status = Status::OK();
   } else {
     status = session->SetEpDynamicOptions(keys_span,
                                           values_span);

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -843,8 +843,10 @@ void CheckAndAdjustInputSpansForLora(const OrtRunOptions& run_options,
 
 }  // namespace
 
-ORT_API_STATUS_IMPL(OrtApis::SetEpDynamicOptions, _Inout_ OrtSession* sess, _In_reads_(kv_len) const char* const* keys,
-                    _In_reads_(kv_len) const char* const* values, _In_ size_t kv_len) {
+ORT_API_STATUS_IMPL(OrtApis::SetEpDynamicOptions, _Inout_ OrtSession* sess,
+                    _In_reads_(kv_len) const char* const* keys,
+                    _In_reads_(kv_len) const char* const* values,
+                    _In_ size_t kv_len) {
   API_IMPL_BEGIN
   auto session = reinterpret_cast<::onnxruntime::InferenceSession*>(sess);
 
@@ -854,8 +856,7 @@ ORT_API_STATUS_IMPL(OrtApis::SetEpDynamicOptions, _Inout_ OrtSession* sess, _In_
   Status status;
 
   if (kv_len == 0) {
-    // TODO: how does one return OK or no_values_passed
-    status = Status::OK();
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "no imputs were passed");
   } else {
     status = session->SetEpDynamicOptions(keys_span,
                                           values_span);

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -843,12 +843,11 @@ void CheckAndAdjustInputSpansForLora(const OrtRunOptions& run_options,
 
 }  // namespace
 
-ORT_API_STATUS_IMPL(OrtApis::SetEpDynamicOptions, _In_ OrtSession* sess, _In_ const char** keys,
-                  _In_ const char** values, _In_ size_t kv_len) {
+ORT_API_STATUS_IMPL(OrtApis::SetEpDynamicOptions, _Inout_ OrtSession* sess, _In_reads_(kv_len) const char* const* keys,
+                    _In_reads_(kv_len) const char* const* values, _In_ size_t kv_len) {
   API_IMPL_BEGIN
   auto session = reinterpret_cast<::onnxruntime::InferenceSession*>(sess);
 
-  // TODO: is this what we're supposed to do with strings?
   auto keys_span = gsl::make_span(keys, kv_len);
   auto values_span = gsl::make_span(values, kv_len);
 

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -531,6 +531,6 @@ ORT_API_STATUS_IMPL(CreateLoraAdapterFromArray, _In_ const void* bytes, size_t n
 ORT_API(void, ReleaseLoraAdapter, _Frees_ptr_opt_ OrtLoraAdapter*);
 ORT_API_STATUS_IMPL(RunOptionsAddActiveLoraAdapter, _Inout_ OrtRunOptions* options, _In_ const OrtLoraAdapter* adapter);
 
-ORT_API_STATUS_IMPL(SetEpDynamicOptions, _In_ OrtSession* sess, _In_ const char** keys, _In_ const char** values,
-                  _In_ size_t kv_len);
+ORT_API_STATUS_IMPL(SetEpDynamicOptions, _Inout_ OrtSession* sess, _In_reads_(kv_len) const char* const* keys,
+                    _In_reads_(kv_len) const char* const* values, _In_ size_t kv_len);
 }  // namespace OrtApis

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -119,6 +119,9 @@ ORT_API_STATUS_IMPL(RunOptionsGetRunTag, _In_ const OrtRunOptions*, _Out_ const 
 ORT_API_STATUS_IMPL(RunOptionsSetTerminate, _Inout_ OrtRunOptions* options);
 ORT_API_STATUS_IMPL(RunOptionsUnsetTerminate, _Inout_ OrtRunOptions* options);
 
+ORT_API_STATUS_IMP(SetEpDynamicOptions, _In_ OrtSession* sess, _In_ const char** keys, _In_ const char** values,
+                  _In_ size_t kv_len);
+
 ORT_API_STATUS_IMPL(CreateTensorAsOrtValue, _Inout_ OrtAllocator* allocator,
                     _In_ const int64_t* shape, size_t shape_len, ONNXTensorElementDataType type,
                     _Outptr_ OrtValue** out);

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -119,9 +119,6 @@ ORT_API_STATUS_IMPL(RunOptionsGetRunTag, _In_ const OrtRunOptions*, _Out_ const 
 ORT_API_STATUS_IMPL(RunOptionsSetTerminate, _Inout_ OrtRunOptions* options);
 ORT_API_STATUS_IMPL(RunOptionsUnsetTerminate, _Inout_ OrtRunOptions* options);
 
-ORT_API_STATUS_IMP(SetEpDynamicOptions, _In_ OrtSession* sess, _In_ const char** keys, _In_ const char** values,
-                  _In_ size_t kv_len);
-
 ORT_API_STATUS_IMPL(CreateTensorAsOrtValue, _Inout_ OrtAllocator* allocator,
                     _In_ const int64_t* shape, size_t shape_len, ONNXTensorElementDataType type,
                     _Outptr_ OrtValue** out);
@@ -534,4 +531,6 @@ ORT_API_STATUS_IMPL(CreateLoraAdapterFromArray, _In_ const void* bytes, size_t n
 ORT_API(void, ReleaseLoraAdapter, _Frees_ptr_opt_ OrtLoraAdapter*);
 ORT_API_STATUS_IMPL(RunOptionsAddActiveLoraAdapter, _Inout_ OrtRunOptions* options, _In_ const OrtLoraAdapter* adapter);
 
+ORT_API_STATUS_IMPL(SetEpDynamicOptions, _In_ OrtSession* sess, _In_ const char** keys, _In_ const char** values,
+                  _In_ size_t kv_len);
 }  // namespace OrtApis


### PR DESCRIPTION
### Description
Add SetEpDynamicOptions and Remove workload_type from run/session options.

### Motivation and Context
Added SetEpDynamicOptions as a dynamic way of changing EP settings even in the middle of a Run
Using workload_type run/session options to set Efficient/Default mode for workloads does not cover all the scenarios and can lead to priority inversions. Working on a new API to support setting Efficient/Default mode for workloads.

