### PR TITLE
Fix Memory Issue GQA CPU Rotary

### DIFF
--- a/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
@@ -106,7 +106,7 @@ Status GroupQueryAttention<T>::Compute(OpKernelContext* context) const {
   OrtValue RotaryQ;
   OrtValue RotaryK;
   T* q_rotary = Q.GetMutable<Tensor>()->MutableData<T>();
-  T* k_rotary = K.GetMutable<Tensor>()->MutableData<T>();
+  T* k_rotary = packed_qkv ? nullptr : K.GetMutable<Tensor>()->MutableData<T>();
   if (do_rotary_) {
     // Initialize rotary parameters
     rotary_embedding_helper::RotaryParameters rotary_params = {};

--- a/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
@@ -142,10 +142,14 @@ Status GroupQueryAttention<T>::Compute(OpKernelContext* context) const {
     const T* k_input;
     T* q_rotary;
     T* k_rotary;
+    // New OrtValues so data doesn't get freed
+    OrtValue Q_value_og;
+    OrtValue K_value_og;
     if (packed_qkv) {
       OrtValue RotaryQKV;
       Tensor::InitOrtValue(element_type, TensorShape({batch_size, num_heads_ + 2 * kv_num_heads_, sequence_length, head_size}), allocator, RotaryQKV);
-      q_input = Q.Get<Tensor>().Data<T>();
+      Q_value_og = Q;
+      q_input = Q_value_og.Get<Tensor>().Data<T>();
       k_input = q_input + num_heads_ * sequence_length * head_size;
       q_rotary = RotaryQKV.GetMutable<Tensor>()->MutableData<T>();
       k_rotary = q_rotary + num_heads_ * sequence_length * head_size;
@@ -155,8 +159,10 @@ Status GroupQueryAttention<T>::Compute(OpKernelContext* context) const {
       Tensor::InitOrtValue(element_type, TensorShape({batch_size, num_heads_, sequence_length, head_size}), allocator, RotaryQ);
       OrtValue RotaryK;
       Tensor::InitOrtValue(element_type, TensorShape({batch_size, kv_num_heads_, sequence_length, head_size}), allocator, RotaryK);
-      q_input = Q.Get<Tensor>().Data<T>();
-      k_input = K.Get<Tensor>().Data<T>();
+      Q_value_og = Q;
+      K_value_og = K;
+      q_input = Q_value_og.Get<Tensor>().Data<T>();
+      k_input = K_value_og.Get<Tensor>().Data<T>();
       q_rotary = RotaryQ.GetMutable<Tensor>()->MutableData<T>();
       k_rotary = RotaryK.GetMutable<Tensor>()->MutableData<T>();
       Q = RotaryQ;

--- a/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
@@ -102,6 +102,11 @@ Status GroupQueryAttention<T>::Compute(OpKernelContext* context) const {
         allocator, batch_size, kv_num_heads_, sequence_length, head_size, value, V));
   }
 
+  OrtValue RotaryQKV;
+  OrtValue RotaryQ;
+  OrtValue RotaryK;
+  T* q_rotary = Q.GetMutable<Tensor>()->MutableData<T>();
+  T* k_rotary = K.GetMutable<Tensor>()->MutableData<T>();
   if (do_rotary_) {
     // Initialize rotary parameters
     rotary_embedding_helper::RotaryParameters rotary_params = {};
@@ -124,7 +129,7 @@ Status GroupQueryAttention<T>::Compute(OpKernelContext* context) const {
     if (parameters.is_first_prompt) {
       pos_ids[0] = static_cast<int64_t>(0);
     } else {
-      // Note: As of now, interactive decoding supports only batch size 1 and token generation supports only sequence length 1.
+      // Note: As of now, continuous decoding supports only batch size 1 and token generation supports only sequence length 1.
       for (int b = 0; b < batch_size; b++) {
         const int total_seqlen = seqlens_k->Data<int32_t>()[b] + 1;
         const int past_seqlen = total_seqlen - sequence_length;
@@ -140,33 +145,19 @@ Status GroupQueryAttention<T>::Compute(OpKernelContext* context) const {
     // Initialize separate buffers for rotary embeddings
     const T* q_input;
     const T* k_input;
-    T* q_rotary;
-    T* k_rotary;
-    // New OrtValues so data doesn't get freed
-    OrtValue Q_value_og;
-    OrtValue K_value_og;
     if (packed_qkv) {
-      OrtValue RotaryQKV;
       Tensor::InitOrtValue(element_type, TensorShape({batch_size, num_heads_ + 2 * kv_num_heads_, sequence_length, head_size}), allocator, RotaryQKV);
-      Q_value_og = Q;
-      q_input = Q_value_og.Get<Tensor>().Data<T>();
+      q_input = Q.Get<Tensor>().Data<T>();
       k_input = q_input + num_heads_ * sequence_length * head_size;
       q_rotary = RotaryQKV.GetMutable<Tensor>()->MutableData<T>();
       k_rotary = q_rotary + num_heads_ * sequence_length * head_size;
-      Q = RotaryQKV;
     } else {
-      OrtValue RotaryQ;
       Tensor::InitOrtValue(element_type, TensorShape({batch_size, num_heads_, sequence_length, head_size}), allocator, RotaryQ);
-      OrtValue RotaryK;
       Tensor::InitOrtValue(element_type, TensorShape({batch_size, kv_num_heads_, sequence_length, head_size}), allocator, RotaryK);
-      Q_value_og = Q;
-      K_value_og = K;
-      q_input = Q_value_og.Get<Tensor>().Data<T>();
-      k_input = K_value_og.Get<Tensor>().Data<T>();
+      q_input = Q.Get<Tensor>().Data<T>();
+      k_input = K.Get<Tensor>().Data<T>();
       q_rotary = RotaryQ.GetMutable<Tensor>()->MutableData<T>();
       k_rotary = RotaryK.GetMutable<Tensor>()->MutableData<T>();
-      Q = RotaryQ;
-      K = RotaryK;
     }
     // Run rotary embedding for Q and K
     ORT_RETURN_IF_ERROR(RunRotaryEmbedding<T>(tp, rotary_params, q_input,
@@ -198,8 +189,8 @@ Status GroupQueryAttention<T>::Compute(OpKernelContext* context) const {
 
   ORT_RETURN_IF_ERROR(context->GetTempSpaceAllocator(&allocator));
   // Compute the attention score and apply the score to V
-  return ApplyAttention(Q.Get<Tensor>().Data<T>(), packed_qkv ? nullptr : K.Get<Tensor>().Data<T>(),
-                        packed_qkv ? nullptr : V.Get<Tensor>().Data<T>(), past_key, past_value, output, present_k, present_v,
+  return ApplyAttention(q_rotary, packed_qkv ? nullptr : k_rotary, packed_qkv ? nullptr : V.Get<Tensor>().Data<T>(),
+                        past_key, past_value, output, present_k, present_v,
                         seqlens_k, parameters, allocator, context);
 }
 }  // namespace contrib


### PR DESCRIPTION
### Description
In GQA there was a memory issue which was best described by @edgchen1 [here](https://github.com/microsoft/onnxruntime/issues/22252#issuecomment-2384559255)

> here's the problematic code:
> 
> https://github.com/microsoft/onnxruntime/blob/d9de054eb53034e3dc18c298e47c6cc08d5aa884/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc#L149-L157
> 
> annotated:
> 
> ```c++
>     if (packed_qkv) {
>       // Q is an OrtValue declared in the enclosing scope.
>       OrtValue RotaryQKV;
>       Tensor::InitOrtValue(element_type, TensorShape({batch_size, num_heads_ + 2 * kv_num_heads_, sequence_length, head_size}), allocator, RotaryQKV);
>       // Save pointer to Q's data in q_input.
>       q_input = Q.Get<Tensor>().Data<T>();
>       k_input = q_input + num_heads_ * sequence_length * head_size;
>       q_rotary = RotaryQKV.GetMutable<Tensor>()->MutableData<T>();
>       k_rotary = q_rotary + num_heads_ * sequence_length * head_size;
>       // Overwrite Q with RotaryQKV (OrtValues contain shared_ptr to contained value).
>       // Now, q_input is pointing to freed memory.
>       Q = RotaryQKV;
>     }
> ```
> 
> later on, when we use `q_input`, there is a read access violation.
> 
> https://github.com/microsoft/onnxruntime/blob/d9de054eb53034e3dc18c298e47c6cc08d5aa884/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc#L170-L172
> 
> this problem showed up when CPU allocator sharing between sessions was enabled. in that case, the CPU allocator's arena was disabled. I suspect that the default usage of the arena hid this issue.
> 
> though I debugged into the first branch, this appears to be a problem in both branches:
> 
> https://github.com/microsoft/onnxruntime/blob/d9de054eb53034e3dc18c298e47c6cc08d5aa884/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc#L149-L168





### Motivation and Context
Fixes a crucial bug. The issue was found here https://github.com/microsoft/onnxruntime/issues/22252 


