### PR TITLE
[DML] Add support for AppendExecutionProvider_DML1 with C#.

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.shared.cs
@@ -275,6 +275,19 @@ namespace Microsoft.ML.OnnxRuntime
 #endif
         }
 
+        /// <summary>
+        /// Use only if you have the onnxruntime package specific to this Execution Provider.
+        /// </summary>
+        /// <param name="dmlDevice">A IDMLDevice reference</param>
+        /// <param name="commandQueue">A ID3D12CommandQueue reference</param>
+        public void AppendExecutionProvider_DML1(IntPtr dmlDevice, IntPtr commandQueue)
+        {
+#if __MOBILE__
+            throw new NotSupportedException("The DML Execution Provider is not supported in this build");
+#else
+            NativeApiStatus.VerifySuccess(NativeMethods.OrtSessionOptionsAppendExecutionProvider_DML1(handle, dmlDevice, commandQueue));
+#endif
+        }
 
         /// <summary>
         /// Use only if you have the onnxruntime package specific to this Execution Provider.


### PR DESCRIPTION
### Description
Adds the ability to use the SessionOptionsAppendExecutionProvider_DML1 method with C#.

### Motivation and Context
It was not possible to use the SessionOptionsAppendExecutionProvider_DML1 method with C# before. This PR adds adds the mapping of the DML EP, only for the SessionOptionsAppendExecutionProvider_DML1 method. The user of the library is still required to create the IDMLDevice and ID3D12CommandQueue manually, however that may be.

We validated that this works BY using CsWin32 to create projections of the native types and copying the logic from the [ESRGAN super-resolution model sample](https://github.com/microsoft/DirectML/tree/master/Samples/DirectML_ESRGAN), in particular, the SelectAdapter and CreateDmlDeviceAndCommandQueue methods from the helpers.cpp class.

A follow-up PR could make this process even simpler and provide this helper method, but it seemed a little bit too much for the basic support.