### PR TITLE
[MIGraphX EP Support]Add rocm to transformers/benchmark.py script

### DIFF
--- a/onnxruntime/python/tools/transformers/benchmark.py
+++ b/onnxruntime/python/tools/transformers/benchmark.py
@@ -787,7 +787,7 @@ def main():
         logger.error("fp16 is for GPU only")
         return
 
-    if args.precision == Precision.INT8 and args.use_gpu and args.provider != "migraphx":
+    if args.precision == Precision.INT8 and args.use_gpu and args.provider not in ["migraphx", "rocm"]:
         logger.error("int8 is for CPU only")
         return
 


### PR DESCRIPTION
### Description
Add ROCm EP option to benchmark.py script when using int8 quantization.



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Without this change benchmarks with int8 quantization cannot be run with ROCm execution provider.


