### PR TITLE
Support onnx data types (bfloat16, float8) in python I/O binding APIs

### DIFF
--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -602,7 +602,7 @@ class IOBinding:
         :param name: input name
         :param device_type: e.g. cpu, cuda, cann
         :param device_id: device id, e.g. 0
-        :param element_type: input element type, which can be either numpy type or onnx type.
+        :param element_type: input element type. It can be either numpy type (like numpy.float32) or an integer for onnx type (like onnx.TensorProto.BFLOAT16)
         :param shape: input shape
         :param buffer_ptr: memory pointer to input data
         """
@@ -641,7 +641,7 @@ class IOBinding:
         :param name: output name
         :param device_type: e.g. cpu, cuda, cann, cpu by default
         :param device_id: device id, e.g. 0
-        :param element_type: output element type
+        :param element_type: output element type. It can be either numpy type (like numpy.float32) or an integer for onnx type (like onnx.TensorProto.BFLOAT16)
         :param shape: output shape
         :param buffer_ptr: memory pointer to output data
         """
@@ -777,7 +777,7 @@ class OrtValue:
         Factory method to construct an OrtValue (which holds a Tensor) from given shape and element_type
 
         :param shape: List of integers indicating the shape of the OrtValue
-        :param element_type: The data type of the elements. It can be either numpy type or onnx element type.
+        :param element_type: The data type of the elements. It can be either numpy type (like numpy.float32) or an integer for onnx type (like onnx.TensorProto.BFLOAT16).
         :param device_type: e.g. cpu, cuda, cann, cpu by default
         :param device_id: device id, e.g. 0
         """

--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -602,7 +602,7 @@ class IOBinding:
         :param name: input name
         :param device_type: e.g. cpu, cuda, cann
         :param device_id: device id, e.g. 0
-        :param element_type: input element type
+        :param element_type: input element type, which can be either numpy type or onnx type.
         :param shape: input shape
         :param buffer_ptr: memory pointer to input data
         """
@@ -772,12 +772,12 @@ class OrtValue:
         return OrtValue(C.OrtValue.ortvalue_from_numpy_with_onnxtype(data, onnx_element_type), data)
 
     @staticmethod
-    def ortvalue_from_shape_and_type(shape=None, element_type=None, device_type="cpu", device_id=0):
+    def ortvalue_from_shape_and_type(shape, element_type, device_type: str = "cpu", device_id: int = 0):
         """
         Factory method to construct an OrtValue (which holds a Tensor) from given shape and element_type
 
         :param shape: List of integers indicating the shape of the OrtValue
-        :param element_type: The data type of the elements in the OrtValue (numpy type)
+        :param element_type: The numpy data type of the elements in the OrtValue
         :param device_type: e.g. cpu, cuda, cann, cpu by default
         :param device_id: device id, e.g. 0
         """
@@ -786,6 +786,31 @@ class OrtValue:
 
         return OrtValue(
             C.OrtValue.ortvalue_from_shape_and_type(
+                shape,
+                element_type,
+                C.OrtDevice(
+                    get_ort_device_type(device_type, device_id),
+                    C.OrtDevice.default_memory(),
+                    device_id,
+                ),
+            )
+        )
+
+    @staticmethod
+    def ortvalue_from_shape_and_onnxtype(shape, element_type: int, device_type: str = "cpu", device_id: int = 0):
+        """
+        Factory method to construct an OrtValue (which holds a Tensor) from given shape and element_type
+
+        :param shape: List of integers indicating the shape of the OrtValue
+        :param element_type: The onnx data type of the elements in the OrtValue
+        :param device_type: e.g. cpu, cuda, cann, cpu by default
+        :param device_id: device id, e.g. 0
+        """
+        if shape is None or element_type is None:
+            raise ValueError("`element_type` and `shape` are to be provided if pre-allocated memory is provided")
+
+        return OrtValue(
+            C.OrtValue.ortvalue_from_shape_and_onnxtype(
                 shape,
                 element_type,
                 C.OrtDevice(

--- a/onnxruntime/python/onnxruntime_pybind_iobinding.cc
+++ b/onnxruntime/python/onnxruntime_pybind_iobinding.cc
@@ -58,6 +58,18 @@ void addIoBindingMethods(pybind11::module& m) {
         }
       })
       // This binds input as a Tensor that wraps memory pointer along with the OrtMemoryInfo
+      .def("bind_input", [](SessionIOBinding* io_binding, const std::string& name, const OrtDevice& device, int32_t element_type, const std::vector<int64_t>& shape, int64_t data_ptr) -> void {
+        auto ml_type = OnnxTypeToOnnxRuntimeTensorType(element_type);
+        OrtValue ml_value;
+        OrtMemoryInfo info(GetDeviceName(device), OrtDeviceAllocator, device, device.Id());
+        Tensor::InitOrtValue(ml_type, gsl::make_span(shape), reinterpret_cast<void*>(data_ptr), info, ml_value);
+
+        auto status = io_binding->Get()->BindInput(name, ml_value);
+        if (!status.IsOK()) {
+          throw std::runtime_error("Error when binding input: " + status.ErrorMessage());
+        }
+      })
+      // This binds input as a Tensor that wraps memory pointer along with the OrtMemoryInfo
       .def("bind_input", [](SessionIOBinding* io_binding, const std::string& name, const OrtDevice& device, py::object& element_type, const std::vector<int64_t>& shape, int64_t data_ptr) -> void {
         PyArray_Descr* dtype;
         if (!PyArray_DescrConverter(element_type.ptr(), &dtype)) {
@@ -88,6 +100,39 @@ void addIoBindingMethods(pybind11::module& m) {
         auto status = io_binding->Get()->SynchronizeInputs();
         if (!status.IsOK()) {
           throw std::runtime_error("Error when synchronizing bound inputs: " + status.ErrorMessage());
+        }
+      })
+      // This binds output to a pre-allocated memory as a Tensor.
+      // The element type is onnx type , or key in onnx.mapping.TENSOR_TYPE_MAP (https://onnx.ai/onnx/api/mapping.html)
+      .def("bind_output", [](SessionIOBinding* io_binding, const std::string& name, const OrtDevice& device, int32_t element_type, const std::vector<int64_t>& shape, int64_t data_ptr) -> void {
+        ORT_ENFORCE(data_ptr != 0, "Pointer to data memory is not valid");
+
+        InferenceSession* sess = io_binding->GetInferenceSession();
+        auto px = sess->GetModelOutputs();
+        if (!px.first.IsOK() || !px.second) {
+          throw std::runtime_error("Either failed to get model inputs from the session object or the input def list was null");
+        }
+
+        // For now, limit binding support to only non-string Tensors
+        const auto& def_list = *px.second;
+        onnx::TypeProto type_proto;
+        if (!CheckIfTensor(def_list, name, type_proto)) {
+          throw std::runtime_error("Only binding Tensors is currently supported");
+        }
+
+        ORT_ENFORCE(utils::HasTensorType(type_proto) && utils::HasElemType(type_proto.tensor_type()));
+        if (type_proto.tensor_type().elem_type() == onnx::TensorProto::STRING) {
+          throw std::runtime_error("Only binding non-string Tensors is currently supported");
+        }
+
+        auto ml_type = OnnxTypeToOnnxRuntimeTensorType(element_type);
+        OrtValue ml_value;
+        OrtMemoryInfo info(GetDeviceName(device), OrtDeviceAllocator, device, device.Id());
+        Tensor::InitOrtValue(ml_type, gsl::make_span(shape), reinterpret_cast<void*>(data_ptr), info, ml_value);
+
+        auto status = io_binding->Get()->BindOutput(name, ml_value);
+        if (!status.IsOK()) {
+          throw std::runtime_error("Error when binding output: " + status.ErrorMessage());
         }
       })
       // This binds output to a pre-allocated memory as a Tensor

--- a/onnxruntime/python/onnxruntime_pybind_iobinding.cc
+++ b/onnxruntime/python/onnxruntime_pybind_iobinding.cc
@@ -20,6 +20,39 @@ namespace python {
 
 namespace py = pybind11;
 
+namespace {
+void BindOutput(SessionIOBinding* io_binding, const std::string& name, const OrtDevice& device,
+                MLDataType element_type, const std::vector<int64_t>& shape, int64_t data_ptr) {
+  ORT_ENFORCE(data_ptr != 0, "Pointer to data memory is not valid");
+  InferenceSession* sess = io_binding->GetInferenceSession();
+  auto px = sess->GetModelOutputs();
+  if (!px.first.IsOK() || !px.second) {
+    throw std::runtime_error("Either failed to get model inputs from the session object or the input def list was null");
+  }
+
+  // For now, limit binding support to only non-string Tensors
+  const auto& def_list = *px.second;
+  onnx::TypeProto type_proto;
+  if (!CheckIfTensor(def_list, name, type_proto)) {
+    throw std::runtime_error("Only binding Tensors is currently supported");
+  }
+
+  ORT_ENFORCE(utils::HasTensorType(type_proto) && utils::HasElemType(type_proto.tensor_type()));
+  if (type_proto.tensor_type().elem_type() == onnx::TensorProto::STRING) {
+    throw std::runtime_error("Only binding non-string Tensors is currently supported");
+  }
+
+  OrtValue ml_value;
+  OrtMemoryInfo info(GetDeviceName(device), OrtDeviceAllocator, device, device.Id());
+  Tensor::InitOrtValue(element_type, gsl::make_span(shape), reinterpret_cast<void*>(data_ptr), info, ml_value);
+
+  auto status = io_binding->Get()->BindOutput(name, ml_value);
+  if (!status.IsOK()) {
+    throw std::runtime_error("Error when binding output: " + status.ErrorMessage());
+  }
+}
+}  // namespace
+
 void addIoBindingMethods(pybind11::module& m) {
   py::class_<SessionIOBinding> session_io_binding(m, "SessionIOBinding");
   session_io_binding
@@ -105,58 +138,11 @@ void addIoBindingMethods(pybind11::module& m) {
       // This binds output to a pre-allocated memory as a Tensor.
       // The element type is onnx type , or key in onnx.mapping.TENSOR_TYPE_MAP (https://onnx.ai/onnx/api/mapping.html)
       .def("bind_output", [](SessionIOBinding* io_binding, const std::string& name, const OrtDevice& device, int32_t element_type, const std::vector<int64_t>& shape, int64_t data_ptr) -> void {
-        ORT_ENFORCE(data_ptr != 0, "Pointer to data memory is not valid");
-
-        InferenceSession* sess = io_binding->GetInferenceSession();
-        auto px = sess->GetModelOutputs();
-        if (!px.first.IsOK() || !px.second) {
-          throw std::runtime_error("Either failed to get model inputs from the session object or the input def list was null");
-        }
-
-        // For now, limit binding support to only non-string Tensors
-        const auto& def_list = *px.second;
-        onnx::TypeProto type_proto;
-        if (!CheckIfTensor(def_list, name, type_proto)) {
-          throw std::runtime_error("Only binding Tensors is currently supported");
-        }
-
-        ORT_ENFORCE(utils::HasTensorType(type_proto) && utils::HasElemType(type_proto.tensor_type()));
-        if (type_proto.tensor_type().elem_type() == onnx::TensorProto::STRING) {
-          throw std::runtime_error("Only binding non-string Tensors is currently supported");
-        }
-
-        auto ml_type = OnnxTypeToOnnxRuntimeTensorType(element_type);
-        OrtValue ml_value;
-        OrtMemoryInfo info(GetDeviceName(device), OrtDeviceAllocator, device, device.Id());
-        Tensor::InitOrtValue(ml_type, gsl::make_span(shape), reinterpret_cast<void*>(data_ptr), info, ml_value);
-
-        auto status = io_binding->Get()->BindOutput(name, ml_value);
-        if (!status.IsOK()) {
-          throw std::runtime_error("Error when binding output: " + status.ErrorMessage());
-        }
+        MLDataType ml_type = OnnxTypeToOnnxRuntimeTensorType(element_type);
+        BindOutput(io_binding, name, device, ml_type, shape, data_ptr);
       })
       // This binds output to a pre-allocated memory as a Tensor
       .def("bind_output", [](SessionIOBinding* io_binding, const std::string& name, const OrtDevice& device, py::object& element_type, const std::vector<int64_t>& shape, int64_t data_ptr) -> void {
-        ORT_ENFORCE(data_ptr != 0, "Pointer to data memory is not valid");
-
-        InferenceSession* sess = io_binding->GetInferenceSession();
-        auto px = sess->GetModelOutputs();
-        if (!px.first.IsOK() || !px.second) {
-          throw std::runtime_error("Either failed to get model inputs from the session object or the input def list was null");
-        }
-
-        // For now, limit binding support to only non-string Tensors
-        const auto& def_list = *px.second;
-        onnx::TypeProto type_proto;
-        if (!CheckIfTensor(def_list, name, type_proto)) {
-          throw std::runtime_error("Only binding Tensors is currently supported");
-        }
-
-        ORT_ENFORCE(utils::HasTensorType(type_proto) && utils::HasElemType(type_proto.tensor_type()));
-        if (type_proto.tensor_type().elem_type() == onnx::TensorProto::STRING) {
-          throw std::runtime_error("Only binding non-string Tensors is currently supported");
-        }
-
         PyArray_Descr* dtype;
         if (!PyArray_DescrConverter(element_type.ptr(), &dtype)) {
           throw std::runtime_error("Not a valid numpy type");
@@ -164,15 +150,8 @@ void addIoBindingMethods(pybind11::module& m) {
         int type_num = dtype->type_num;
         Py_DECREF(dtype);
 
-        OrtMemoryInfo info(GetDeviceName(device), OrtDeviceAllocator, device, device.Id());
         auto ml_type = NumpyTypeToOnnxRuntimeTensorType(type_num);
-        OrtValue ml_value;
-        Tensor::InitOrtValue(ml_type, gsl::make_span(shape), reinterpret_cast<void*>(data_ptr), info, ml_value);
-
-        auto status = io_binding->Get()->BindOutput(name, ml_value);
-        if (!status.IsOK()) {
-          throw std::runtime_error("Error when binding output: " + status.ErrorMessage());
-        }
+        BindOutput(io_binding, name, device, ml_type, shape, data_ptr);
       })
       // This binds output to a device. Meaning that the output OrtValue must be allocated on a specific device.
       .def("bind_output", [](SessionIOBinding* io_binding, const std::string& name, const OrtDevice& device) -> void {

--- a/onnxruntime/python/onnxruntime_pybind_mlvalue.cc
+++ b/onnxruntime/python/onnxruntime_pybind_mlvalue.cc
@@ -470,40 +470,7 @@ MLDataType NumpyTypeToOnnxRuntimeTensorType(int numpy_type) {
 #define ONNX_TO_ORT_TYPE_MAP(x, y) {onnx::TensorProto_DataType::TensorProto_DataType_##x, DataTypeImpl::GetType<y>()}
 
 MLDataType OnnxTypeToOnnxRuntimeTensorType(int onnx_element_type) {
-  static std::map<int, MLDataType> type_map{
-      ONNX_TO_ORT_TYPE_MAP(BOOL, bool),
-      ONNX_TO_ORT_TYPE_MAP(INT8, int8_t),
-      ONNX_TO_ORT_TYPE_MAP(INT16, int16_t),
-      ONNX_TO_ORT_TYPE_MAP(INT32, int32_t),
-      ONNX_TO_ORT_TYPE_MAP(INT64, int64_t),
-      ONNX_TO_ORT_TYPE_MAP(UINT8, uint8_t),
-      ONNX_TO_ORT_TYPE_MAP(UINT16, uint16_t),
-      ONNX_TO_ORT_TYPE_MAP(UINT32, uint32_t),
-      ONNX_TO_ORT_TYPE_MAP(UINT64, uint64_t),
-      ONNX_TO_ORT_TYPE_MAP(FLOAT16, MLFloat16),
-      ONNX_TO_ORT_TYPE_MAP(BFLOAT16, BFloat16),
-      ONNX_TO_ORT_TYPE_MAP(FLOAT, float),
-      ONNX_TO_ORT_TYPE_MAP(DOUBLE, double),
-#if !defined(DISABLE_FLOAT8_TYPES)
-      ONNX_TO_ORT_TYPE_MAP(FLOAT8E4M3FN, Float8E4M3FN),
-      ONNX_TO_ORT_TYPE_MAP(FLOAT8E4M3FNUZ, Float8E4M3FNUZ),
-      ONNX_TO_ORT_TYPE_MAP(FLOAT8E5M2, Float8E5M2),
-      ONNX_TO_ORT_TYPE_MAP(FLOAT8E5M2FNUZ, Float8E5M2FNUZ),
-#endif
-      ONNX_TO_ORT_TYPE_MAP(STRING, std::string),
-      ONNX_TO_ORT_TYPE_MAP(INT4, Int4x2),
-      ONNX_TO_ORT_TYPE_MAP(UINT4, UInt4x2)
-
-      // TODO: support FLOAT4E2M1, COMPLEX64, COMPLEX128
-  };
-
-  const auto it = type_map.find(onnx_element_type);
-  if (it == type_map.end()) {
-    throw std::runtime_error("Onnx_type " + std::to_string(onnx_element_type) +
-                             " can't be converted to MLDataType.");
-  } else {
-    return it->second;
-  }
+  return DataTypeImpl::TensorTypeFromONNXEnum(onnx_element_type)->GetElementType();
 }
 
 #undef ONNX_TO_ORT_TYPE_MAP

--- a/onnxruntime/python/onnxruntime_pybind_mlvalue.cc
+++ b/onnxruntime/python/onnxruntime_pybind_mlvalue.cc
@@ -467,13 +467,9 @@ MLDataType NumpyTypeToOnnxRuntimeTensorType(int numpy_type) {
   }
 }
 
-#define ONNX_TO_ORT_TYPE_MAP(x, y) {onnx::TensorProto_DataType::TensorProto_DataType_##x, DataTypeImpl::GetType<y>()}
-
 MLDataType OnnxTypeToOnnxRuntimeTensorType(int onnx_element_type) {
   return DataTypeImpl::TensorTypeFromONNXEnum(onnx_element_type)->GetElementType();
 }
-
-#undef ONNX_TO_ORT_TYPE_MAP
 
 // This is a one time use, ad-hoc allocator that allows Tensors to take ownership of
 // python array objects and use the underlying memory directly and

--- a/onnxruntime/python/onnxruntime_pybind_mlvalue.h
+++ b/onnxruntime/python/onnxruntime_pybind_mlvalue.h
@@ -40,6 +40,8 @@ int OnnxRuntimeTensorToNumpyType(const DataTypeImpl* tensor_type);
 
 MLDataType NumpyTypeToOnnxRuntimeTensorType(int numpy_type);
 
+MLDataType OnnxTypeToOnnxRuntimeTensorType(int onnx_element_type);
+
 using MemCpyFunc = void (*)(void*, const void*, size_t);
 
 using DataTransferAlternative = std::variant<const DataTransferManager*, MemCpyFunc>;

--- a/onnxruntime/python/onnxruntime_pybind_ortvalue.cc
+++ b/onnxruntime/python/onnxruntime_pybind_ortvalue.cc
@@ -144,7 +144,7 @@ void addOrtValueMethods(pybind11::module& m) {
       })
       // Create an ortvalue value on top of the numpy array, but interpret the data
       // as a different type with the same element size.
-      .def_static("ortvalue_from_numpy_with_onnxtype", [](py::array& data, int32_t onnx_element_type) -> std::unique_ptr<OrtValue> {
+      .def_static("ortvalue_from_numpy_with_onnx_type", [](py::array& data, int32_t onnx_element_type) -> std::unique_ptr<OrtValue> {
         if (!ONNX_NAMESPACE::TensorProto_DataType_IsValid(onnx_element_type)) {
           ORT_THROW("Not a valid ONNX Tensor data type: ", onnx_element_type);
         }
@@ -212,8 +212,8 @@ void addOrtValueMethods(pybind11::module& m) {
       })
       // Factory method to create an OrtValue (Tensor) from the given shape and element type with memory on the specified device
       // The memory is left uninitialized
-      .def_static("ortvalue_from_shape_and_onnxtype", [](const std::vector<int64_t>& shape, int32_t element_type, const OrtDevice& device) {
-        if (element_type == onnx::TensorProto_DataType::TensorProto_DataType_STRING) {
+      .def_static("ortvalue_from_shape_and_onnx_type", [](const std::vector<int64_t>& shape, int32_t onnx_element_type, const OrtDevice& device) {
+        if (onnx_element_type == onnx::TensorProto_DataType::TensorProto_DataType_STRING) {
           throw std::runtime_error("Creation of OrtValues is currently only supported from non-string numpy arrays");
         }
 
@@ -244,7 +244,7 @@ void addOrtValueMethods(pybind11::module& m) {
         }
 
         auto ml_value = std::make_unique<OrtValue>();
-        auto ml_type = OnnxTypeToOnnxRuntimeTensorType(element_type);
+        auto ml_type = OnnxTypeToOnnxRuntimeTensorType(onnx_element_type);
         Tensor::InitOrtValue(ml_type, gsl::make_span(shape), std::move(allocator), *ml_value);
         return ml_value;
       })

--- a/onnxruntime/python/onnxruntime_pybind_ortvalue.cc
+++ b/onnxruntime/python/onnxruntime_pybind_ortvalue.cc
@@ -21,6 +21,42 @@ namespace python {
 
 namespace py = pybind11;
 
+namespace {
+std::unique_ptr<OrtValue> OrtValueFromShapeAndType(const std::vector<int64_t>& shape,
+                                                   MLDataType element_type,
+                                                   const OrtDevice& device) {
+  AllocatorPtr allocator;
+  if (strcmp(GetDeviceName(device), CPU) == 0) {
+    allocator = GetAllocator();
+  } else if (strcmp(GetDeviceName(device), CUDA) == 0) {
+#ifdef USE_CUDA
+    if (!IsCudaDeviceIdValid(logging::LoggingManager::DefaultLogger(), device.Id())) {
+      throw std::runtime_error("The provided device id doesn't match any available GPUs on the machine.");
+    }
+    allocator = GetCudaAllocator(device.Id());
+#else
+    throw std::runtime_error(
+        "Can't allocate memory on the CUDA device using this package of OnnxRuntime. "
+        "Please use the CUDA package of OnnxRuntime to use this feature.");
+#endif
+  } else if (strcmp(GetDeviceName(device), DML) == 0) {
+#if USE_DML
+    allocator = GetDmlAllocator(device.Id());
+#else
+    throw std::runtime_error(
+        "Can't allocate memory on the DirectML device using this package of OnnxRuntime. "
+        "Please use the DirectML package of OnnxRuntime to use this feature.");
+#endif
+  } else {
+    throw std::runtime_error("Unsupported device: Cannot place the OrtValue on this device");
+  }
+
+  auto ml_value = std::make_unique<OrtValue>();
+  Tensor::InitOrtValue(element_type, gsl::make_span(shape), std::move(allocator), *ml_value);
+  return ml_value;
+}
+}  // namespace
+
 void addOrtValueMethods(pybind11::module& m) {
   py::class_<OrtValue> ortvalue_binding(m, "OrtValue");
   ortvalue_binding
@@ -149,8 +185,7 @@ void addOrtValueMethods(pybind11::module& m) {
           ORT_THROW("Not a valid ONNX Tensor data type: ", onnx_element_type);
         }
 
-        const auto element_type = DataTypeImpl::TensorTypeFromONNXEnum(onnx_element_type)
-                                      ->GetElementType();
+        const auto element_type = OnnxTypeToOnnxRuntimeTensorType(onnx_element_type);
 
         const auto element_size = element_type->Size();
         if (narrow<size_t>(data.itemsize()) != element_size) {
@@ -164,11 +199,11 @@ void addOrtValueMethods(pybind11::module& m) {
                              const_cast<void*>(data.data()), cpu_allocator->Info(), *ort_value);
         return ort_value;
       })
-      // Factory method to create an OrtValue (Tensor) from the given shape and element type with memory on the specified device
+      // Factory method to create an OrtValue from the given shape and numpy element type on the specified device.
       // The memory is left uninitialized
-      .def_static("ortvalue_from_shape_and_type", [](const std::vector<int64_t>& shape, py::object& element_type, const OrtDevice& device) {
+      .def_static("ortvalue_from_shape_and_type", [](const std::vector<int64_t>& shape, py::object& numpy_element_type, const OrtDevice& device) -> std::unique_ptr<OrtValue> {
         PyArray_Descr* dtype;
-        if (!PyArray_DescrConverter(element_type.ptr(), &dtype)) {
+        if (!PyArray_DescrConverter(numpy_element_type.ptr(), &dtype)) {
           throw std::runtime_error("Not a valid numpy type");
         }
 
@@ -179,74 +214,18 @@ void addOrtValueMethods(pybind11::module& m) {
           throw std::runtime_error("Creation of OrtValues is currently only supported from non-string numpy arrays");
         }
 
-        AllocatorPtr allocator;
-        if (strcmp(GetDeviceName(device), CPU) == 0) {
-          allocator = GetAllocator();
-        } else if (strcmp(GetDeviceName(device), CUDA) == 0) {
-#ifdef USE_CUDA
-          if (!IsCudaDeviceIdValid(logging::LoggingManager::DefaultLogger(), device.Id())) {
-            throw std::runtime_error("The provided device id doesn't match any available GPUs on the machine.");
-          }
-          allocator = GetCudaAllocator(device.Id());
-#else
-      throw std::runtime_error(
-          "Can't allocate memory on the CUDA device using this package of OnnxRuntime. "
-          "Please use the CUDA package of OnnxRuntime to use this feature.");
-#endif
-        } else if (strcmp(GetDeviceName(device), DML) == 0) {
-#if USE_DML
-          allocator = GetDmlAllocator(device.Id());
-#else
-          throw std::runtime_error(
-              "Can't allocate memory on the DirectML device using this package of OnnxRuntime. "
-              "Please use the DirectML package of OnnxRuntime to use this feature.");
-#endif
-        } else {
-          throw std::runtime_error("Unsupported device: Cannot place the OrtValue on this device");
-        }
-
-        auto ml_value = std::make_unique<OrtValue>();
-        auto ml_type = NumpyTypeToOnnxRuntimeTensorType(type_num);
-        Tensor::InitOrtValue(ml_type, gsl::make_span(shape), std::move(allocator), *ml_value);
-        return ml_value;
+        auto element_type = NumpyTypeToOnnxRuntimeTensorType(type_num);
+        return OrtValueFromShapeAndType(shape, element_type, device);
       })
-      // Factory method to create an OrtValue (Tensor) from the given shape and element type with memory on the specified device
+      // Factory method to create an OrtValue from the given shape and onnx element type on the specified device.
       // The memory is left uninitialized
-      .def_static("ortvalue_from_shape_and_onnx_type", [](const std::vector<int64_t>& shape, int32_t onnx_element_type, const OrtDevice& device) {
+      .def_static("ortvalue_from_shape_and_onnx_type", [](const std::vector<int64_t>& shape, int32_t onnx_element_type, const OrtDevice& device) -> std::unique_ptr<OrtValue> {
         if (onnx_element_type == onnx::TensorProto_DataType::TensorProto_DataType_STRING) {
           throw std::runtime_error("Creation of OrtValues is currently only supported from non-string numpy arrays");
         }
 
-        AllocatorPtr allocator;
-        if (strcmp(GetDeviceName(device), CPU) == 0) {
-          allocator = GetAllocator();
-        } else if (strcmp(GetDeviceName(device), CUDA) == 0) {
-#ifdef USE_CUDA
-          if (!IsCudaDeviceIdValid(logging::LoggingManager::DefaultLogger(), device.Id())) {
-            throw std::runtime_error("The provided device id doesn't match any available GPUs on the machine.");
-          }
-          allocator = GetCudaAllocator(device.Id());
-#else
-      throw std::runtime_error(
-          "Can't allocate memory on the CUDA device using this package of OnnxRuntime. "
-          "Please use the CUDA package of OnnxRuntime to use this feature.");
-#endif
-        } else if (strcmp(GetDeviceName(device), DML) == 0) {
-#if USE_DML
-          allocator = GetDmlAllocator(device.Id());
-#else
-          throw std::runtime_error(
-              "Can't allocate memory on the DirectML device using this package of OnnxRuntime. "
-              "Please use the DirectML package of OnnxRuntime to use this feature.");
-#endif
-        } else {
-          throw std::runtime_error("Unsupported device: Cannot place the OrtValue on this device");
-        }
-
-        auto ml_value = std::make_unique<OrtValue>();
-        auto ml_type = OnnxTypeToOnnxRuntimeTensorType(onnx_element_type);
-        Tensor::InitOrtValue(ml_type, gsl::make_span(shape), std::move(allocator), *ml_value);
-        return ml_value;
+        auto element_type = OnnxTypeToOnnxRuntimeTensorType(onnx_element_type);
+        return OrtValueFromShapeAndType(shape, element_type, device);
       })
 
 #if !defined(DISABLE_SPARSE_TENSORS)

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -1391,7 +1391,9 @@ class TestInferenceSession(unittest.TestCase):
 
         # test ort_value creation on top of the bytes
         float_tensor_data_type = 1  # TensorProto_DataType_FLOAT
-        ort_value_with_type = onnxrt.OrtValue.ortvalue_from_numpy_with_onnxtype(numpy_arr_input, float_tensor_data_type)
+        ort_value_with_type = onnxrt.OrtValue.ortvalue_from_numpy_with_onnx_type(
+            numpy_arr_input, float_tensor_data_type
+        )
         self.assertTrue(ort_value_with_type.is_tensor())
         self.assertEqual(float_tensor_data_type, ort_value_with_type.element_type())
         self.assertEqual([3, 2], ort_value_with_type.shape())
@@ -1843,8 +1845,8 @@ class TestInferenceSession(unittest.TestCase):
         param_1 = np.array(val).astype(np.float32).reshape(5, 2)
         param_2 = np.array(val).astype(np.int64).reshape(2, 5)
 
-        ort_val_1 = onnxrt.OrtValue.ortvalue_from_numpy_with_onnxtype(param_1, float_data_type)
-        ort_val_2 = onnxrt.OrtValue.ortvalue_from_numpy_with_onnxtype(param_2, int64_data_type)
+        ort_val_1 = onnxrt.OrtValue.ortvalue_from_numpy_with_onnx_type(param_1, float_data_type)
+        ort_val_2 = onnxrt.OrtValue.ortvalue_from_numpy_with_onnx_type(param_2, int64_data_type)
 
         params = {"param_1": ort_val_1, "param_2": ort_val_2}
 

--- a/onnxruntime/test/python/onnxruntime_test_python_iobinding.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_iobinding.py
@@ -9,7 +9,7 @@ from helper import get_name
 from numpy.testing import assert_almost_equal
 from onnx import TensorProto, helper
 from onnx.defs import onnx_opset_version
-from onnx.mapping import NP_TYPE_TO_TENSOR_TYPE, TENSOR_TYPE_MAP
+from onnx.mapping import TENSOR_TYPE_MAP
 
 import onnxruntime as onnxrt
 from onnxruntime.capi._pybind_state import OrtDevice as C_OrtDevice  # pylint: disable=E0611
@@ -104,7 +104,7 @@ class TestIOBinding(unittest.TestCase):
                     ]:
                         with self.subTest(dtype=dtype, inner_device=str(inner_device)):
                             x = np.arange(8).reshape((-1, 2)).astype(dtype)
-                            proto_dtype = NP_TYPE_TO_TENSOR_TYPE[x.dtype]
+                            proto_dtype = helper.np_dtype_to_tensor_dtype(x.dtype)
 
                             X = helper.make_tensor_value_info("X", proto_dtype, [None, x.shape[1]])  # noqa: N806
                             Y = helper.make_tensor_value_info("Y", proto_dtype, [None, x.shape[1]])  # noqa: N806
@@ -262,7 +262,7 @@ class TestIOBinding(unittest.TestCase):
                     # Create ortvalue with onnx type
                     x = torch.arange(16).to(torch_dtype)
                     y = torch.empty(16, dtype=torch_dtype)
-                    temp = onnxrt.OrtValue.ortvalue_from_shape_and_onnxtype(x.shape, onnx_dtype, x.device.type)
+                    temp = onnxrt.OrtValue.ortvalue_from_shape_and_type(x.shape, onnx_dtype, x.device.type)
 
                     bind = sess.io_binding()
                     bind.bind_input("X", x.device.type, 0, onnx_dtype, x.shape, x.data_ptr())

--- a/onnxruntime/test/python/onnxruntime_test_python_iobinding.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_iobinding.py
@@ -143,7 +143,7 @@ class TestIOBinding(unittest.TestCase):
                             y = ortvalue.numpy()
                             assert_almost_equal(x, y)
 
-    def test_bind_input_onnx_types(self):
+    def test_bind_onnx_types(self):
         opset = onnx_opset_version()
         devices = [
             (
@@ -206,12 +206,12 @@ class TestIOBinding(unittest.TestCase):
                     y = ortvalue.numpy()
                     assert_almost_equal(x, y)
 
-    # Test some onnx type that is not supported by numpy like bfloat16 etc.
-    def test_bind_input_onnx_types_not_supported_by_numpy(self):
+    # Test I/O binding with onnx type like bfloat16, which is not supported in numpy.
+    def test_bind_onnx_types_not_supported_by_numpy(self):
         try:
             import torch
         except ImportError:
-            self.skipTest("Skipping since torch is not imported.")
+            self.skipTest("Skipping since PyTorch is not installed.")
 
         opset = onnx_opset_version()
         devices = [


### PR DESCRIPTION
### Description
(1) Support onnx data types in python APIs:
* IOBinding.bind_input
* IOBinding.bind_output
* ortvalue_from_shape_and_type

(2) Add unit tests, which serves an example of running BFloat16 or Float8 models in Python.

Other minor changes:
(3) replace deprecated NP_TYPE_TO_TENSOR_TYPE by helper API.
(4) Rename ortvalue_from_numpy_with_onnxtype to ortvalue_from_numpy_with_onnx_type. 

The integer of onnx element type can be found in (https://onnx.ai/onnx/api/mapping.html). Note that FLOAT4E2M1 is not supported yet.

### Motivation and Context

Current python API does not support Bfloat16 and float8 (FLOAT8E4M3FN, FLOAT8E4M3FNUZ, FLOAT8E5M2, FLOAT8E5M2FNUZ) types, and other new data types like INT4, UInt4 etc.

This removes the limitation.

https://github.com/microsoft/onnxruntime/issues/13001
https://github.com/microsoft/onnxruntime/issues/20481
https://github.com/microsoft/onnxruntime/issues/20578