### PR TITLE
Refactor recent change to the thread pool to minimize binary size impact

### DIFF
--- a/include/onnxruntime/core/platform/threadpool.h
+++ b/include/onnxruntime/core/platform/threadpool.h
@@ -129,8 +129,11 @@ struct TensorOpCost {
 
 namespace concurrency {
 
-template <typename Environment, bool kIsHybrid>
-class ThreadPoolTempl;
+template <typename Environment>
+class NormalThreadPoolTempl;
+
+template <typename Environment>
+class HybridThreadPoolTempl;
 
 class ExtendedThreadPoolInterface;
 class LoopCounter;
@@ -424,8 +427,8 @@ class ThreadPool {
   ExtendedThreadPoolInterface* underlying_threadpool_ = nullptr;
 
   // If used, underlying_threadpool_ is instantiated and owned by the ThreadPool.
-  std::unique_ptr<ThreadPoolTempl<Env, true>> extended_eigen_hybrid_threadpool_;
-  std::unique_ptr<ThreadPoolTempl<Env, false>> extended_eigen_normal_threadpool_;
+  std::unique_ptr<HybridThreadPoolTempl<Env>> extended_eigen_hybrid_threadpool_;
+  std::unique_ptr<NormalThreadPoolTempl<Env>> extended_eigen_normal_threadpool_;
 
   // Force the thread pool to run in hybrid mode on a normal cpu.
   bool force_hybrid_ = false;

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -391,19 +391,19 @@ ThreadPool::ThreadPool(Env* env,
 
     if (force_hybrid_) {
       extended_eigen_hybrid_threadpool_ =
-          std::make_unique<ThreadPoolTempl<Env, true> >(name,
-                                                        threads_to_create,
-                                                        low_latency_hint,
-                                                        *env,
-                                                        thread_options_);
+          std::make_unique<HybridThreadPoolTempl<Env>>(name,
+                                                       threads_to_create,
+                                                       low_latency_hint,
+                                                       *env,
+                                                       thread_options_);
       underlying_threadpool_ = extended_eigen_hybrid_threadpool_.get();
     } else {
       extended_eigen_normal_threadpool_ =
-          std::make_unique<ThreadPoolTempl<Env, false> >(name,
-                                                         threads_to_create,
-                                                         low_latency_hint,
-                                                         *env,
-                                                         thread_options_);
+          std::make_unique<NormalThreadPoolTempl<Env>>(name,
+                                                       threads_to_create,
+                                                       low_latency_hint,
+                                                       *env,
+                                                       thread_options_);
       underlying_threadpool_ = extended_eigen_normal_threadpool_.get();
     }
   }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
A recent change (#21545) added a bool template parameter to a reasonably large class, causing a 16KB increase in the baseline minimal build.

Refactor to pass in the bool as a parameter to reduce the binary size growth to 1KB. 

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Minimal build binary size.

