### PR TITLE
Increanse TensorRT tolerance from default 1e-5 to 1e-3 after TRT 10.4

### DIFF
--- a/java/src/test/java/ai/onnxruntime/InferenceTest.java
+++ b/java/src/test/java/ai/onnxruntime/InferenceTest.java
@@ -772,7 +772,7 @@ public class InferenceTest {
           assertArrayEquals(expectedOutput, resultArray, 1e-2f);
         } else if (provider == OrtProvider.CUDA || provider == OrtProvider.TENSOR_RT) {
           // CUDA gives slightly different answers on a H100 with CUDA 12.2
-          // Need larger tolerance since TRT 10.4 
+          // Need larger tolerance since TRT 10.4
           assertArrayEquals(expectedOutput, resultArray, 1e-3f);
         } else {
           assertArrayEquals(expectedOutput, resultArray, 1e-5f);

--- a/java/src/test/java/ai/onnxruntime/InferenceTest.java
+++ b/java/src/test/java/ai/onnxruntime/InferenceTest.java
@@ -772,7 +772,7 @@ public class InferenceTest {
           assertArrayEquals(expectedOutput, resultArray, 1e-2f);
         } else if (provider == OrtProvider.CUDA || provider == OrtProvider.TENSOR_RT) {
           // CUDA gives slightly different answers on a H100 with CUDA 12.2
-          // result diffference increased since TRT 10.4 
+          // Need larger tolerance since TRT 10.4 
           assertArrayEquals(expectedOutput, resultArray, 1e-3f);
         } else {
           assertArrayEquals(expectedOutput, resultArray, 1e-5f);

--- a/java/src/test/java/ai/onnxruntime/InferenceTest.java
+++ b/java/src/test/java/ai/onnxruntime/InferenceTest.java
@@ -770,8 +770,9 @@ public class InferenceTest {
         if (provider == OrtProvider.CORE_ML) {
           // CoreML gives slightly different answers on a 2020 13" M1 MBP
           assertArrayEquals(expectedOutput, resultArray, 1e-2f);
-        } else if (provider == OrtProvider.CUDA) {
+        } else if (provider == OrtProvider.CUDA || provider == OrtProvider.TENSOR_RT) {
           // CUDA gives slightly different answers on a H100 with CUDA 12.2
+          // result diffference increased since TRT 10.4 
           assertArrayEquals(expectedOutput, resultArray, 1e-3f);
         } else {
           assertArrayEquals(expectedOutput, resultArray, 1e-5f);


### PR DESCRIPTION
### Description
Increanse TensorRT tolerance from default 1e-5 to 1e-3 after TRT 10.4

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


