### PR TITLE
[PyBind] Expose enable_mem_arena property for SessionOptions

### DIFF
--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -1689,6 +1689,13 @@ Serialized model format will default to ONNX unless:
 
 )pbdoc")
       .def_property(
+          "enable_cpu_mem_arena",
+          [](const PySessionOptions* options) -> bool { return options->value.enable_cpu_mem_arena; },
+          [](PySessionOptions* options, bool enable_cpu_mem_arena) -> void {
+            options->value.enable_cpu_mem_arena = enable_cpu_mem_arena;
+          },
+          R"pbdoc(Enable memory arena on CPU. Default is true.)pbdoc")
+      .def_property(
           "enable_mem_pattern",
           [](const PySessionOptions* options) -> bool { return options->value.enable_mem_pattern; },
           [](PySessionOptions* options, bool enable_mem_pattern) -> void {


### PR DESCRIPTION
### Description
Expose enable_mem_arena property for SessionOptions

### Motivation and Context
https://github.com/microsoft/onnxruntime/issues/22271