### PR TITLE
Rework memcpy transformer to support WebGPU EP being added

### DIFF
--- a/include/onnxruntime/core/common/const_pointer_container.h
+++ b/include/onnxruntime/core/common/const_pointer_container.h
@@ -31,8 +31,9 @@ class ConstPointerContainer {
     ConstIterator(const ConstIterator& other) = default;
     ConstIterator& operator=(const ConstIterator& other) = default;
 
-    bool operator==(const ConstIterator& other) const noexcept { return current_ == other.current_; }
-    bool operator!=(const ConstIterator& other) const noexcept { return current_ != other.current_; }
+    bool operator==(const ConstIterator& rhs) const noexcept { return current_ == rhs.current_; }
+    bool operator!=(const ConstIterator& rhs) const noexcept { return current_ != rhs.current_; }
+    size_t operator-(const ConstIterator& rhs) const noexcept { return current_ - rhs.current_; }
 
     ConstIterator& operator++() {
       ++current_;

--- a/onnxruntime/core/optimizer/transformer_memcpy.cc
+++ b/onnxruntime/core/optimizer/transformer_memcpy.cc
@@ -106,7 +106,7 @@ common::Status MemcpyTransformer::ApplyImpl(Graph& graph, bool& modified, int gr
   ORT_ENFORCE(!incompatible_gpu_eps, "Mixing CUDA/TensorRT, ROCm/MIGraphX, and WebGPU is not supported.");
 
   for (auto& provider : provider_types_) {
-    if (!ProviderIsGpuBased(provider)) {
+    if (ProviderIsGpuBased(provider)) {
       TransformerMemcpyImpl copy_impl(graph, provider);
 
       int copy_node_counter = 0;

--- a/onnxruntime/core/optimizer/transformer_memcpy.cc
+++ b/onnxruntime/core/optimizer/transformer_memcpy.cc
@@ -322,7 +322,7 @@ void TransformerMemcpyImpl::BuildDefsMapping(const NodeArg* arg, const KernelReg
       continue;
     }
 
-    auto node_provider_type = cur_node.GetExecutionProviderType();
+    const auto& node_provider_type = cur_node.GetExecutionProviderType();
     // TODO: This runs post-partitioning so a better fix is to ensure all nodes are assigned earlier.
     if (ProviderIsGpuBased(node_provider_type)) {
       auto input_it = std::find(cur_node.InputDefs().begin(), cur_node.InputDefs().end(), arg);


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Rework the memcpy transformer to simplify and support an additional GPU based EP.

- Treat nodes as being GPU based or not and change provider/non-provider naming to be GPU/CPU. 
  - easier to understand the code and supports additional GPU based EPs 
- Detect incompatible GPU EPs
  - the implementation doesn't handle copies between incompatible GPUs (e.g. nVidia <-> AMD) 
  - this isn't an expected use case. the GPU EPs (CUDA/TensorRT vs ROCm/MIGraphX vs WebGPU) have fairly comprehensive supported operators so you wouldn't enable multiple at the same time

Miscellaneous:
- Improve const-ness and removing most const_cast's
- Remove unnecessary 'onnxruntime::' prefix
- Update 2 tests to assign a control flow node
  - test with control flow node being assigned to CPU and CUDA EPs

Easier to review with whitespace diffs hidden.

<img width="187" alt="image" src="https://github.com/user-attachments/assets/46445836-1871-402b-b58f-9b6f21a4751b">

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Fix CI failures when WebGPU and CUDA EPs are enabled in the same build.

