### PR TITLE
Add _ALLOW_COMPILER_AND_STL_VERSION_MISMATCH for cuda compilation

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1528,7 +1528,8 @@ def generate_build_tree(
         if is_windows() and not args.ios and not args.android and not args.build_wasm:
             njobs = number_of_parallel_jobs(args)
             if args.use_cuda:
-                cudaflags.append("-allow-unsupported-compiler")
+                cudaflags.append("--allow-unsupported-compiler")
+                cudaflags.append("-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH")
             if njobs > 1:
                 if args.parallel == 0:
                     cflags += ["/MP"]


### PR DESCRIPTION
### Description
This helps compilation with recent updates to 19.41 in Visual Studio.

Still a WIP but check for compilation progress in https://github.com/conda-forge/onnxruntime-feedstock/pull/128

We build for 11.8 and 12.0


### Motivation and Context
- Helps with build compatibility on windows


