### PR TITLE
Remove duplicate fp32_bits definition.

### DIFF
--- a/onnxruntime/core/mlas/lib/cast.cpp
+++ b/onnxruntime/core/mlas/lib/cast.cpp
@@ -15,11 +15,6 @@ Abstract:
 --*/
 #include "mlasi.h"
 
-union fp32_bits {
-    uint32_t u;
-    float f;
-};
-
 void
 MLASCALL
 MlasConvertHalfToFloatBuffer(


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Remove duplicate fp32_bits definition in cast.cpp.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix #22330
