### PR TITLE
Fix the QNN nuget package issue

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/qnn-ep-win.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/qnn-ep-win.yml
@@ -131,7 +131,7 @@ stages:
           solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.proj'
           platform: 'Any CPU'
           configuration: ${{ parameters.build_config }}
-          msbuildArguments: '-t:CreatePackage -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=$(OrtPackageId) -p:IsReleaseBuild=${{ parameters.IsReleaseBuild }} -p:TargetArchitecture=${{ parameters.buildArch }}'
+          msbuildArguments: '-t:CreatePackage -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=$(OrtPackageId) -p:IsReleaseBuild=${{ parameters.IsReleaseBuild }} -p:TargetArchitecture=$(targetArchitecture)'
           workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
       - task: CopyFiles@2


### PR DESCRIPTION
Fix the QNN nuget package issue

### Description
Inside the package, folder name \runtimes\win-arm64\ was change to \runtimes\win-ARM64\, which breaks lib copy settings in Microsoft.ML.OnnxRuntime.QNN.props.


### Motivation and Context
Fix issue: https://github.com/microsoft/onnxruntime/issues/21692


