### PR TITLE
Re-enable CUDA 12 python package test pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/py-cuda-package-test-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/py-cuda-package-test-pipeline.yml
@@ -18,7 +18,7 @@ stages:
           machine_pool: 'Onnxruntime-Linux-GPU'
           python_wheel_suffix: '_gpu'
           timeout: 480
-          docker_base_image: onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntime/build/cuda12_x64_ubi8_gcc12:20240719.1
+          docker_base_image: onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntime/build/cuda12_x64_ubi8_gcc12:20241008.1
           trt_version: '10.4.0.26-1.cuda12.6'
           cuda_version: '12.2'
 

--- a/tools/ci_build/github/azure-pipelines/py-cuda-package-test-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/py-cuda-package-test-pipeline.yml
@@ -12,12 +12,13 @@ stages:
   - stage: Linux_Test_GPU_x86_64_stage
     dependsOn:
     jobs:
-      - template: stages/jobs/py-linux-cuda-package-test-job.yml
+      - template: templates/py-packaging-linux-test-cuda.yml
         parameters:
-          CudaVersion: '12.2'
+          arch: 'x86_64'
           machine_pool: 'Onnxruntime-Linux-GPU'
+          python_wheel_suffix: '_gpu'
           timeout: 480
-          build_id: ${{ parameters.build_id }}
-          project: ${{ parameters.project }}
-          pipeline: ${{ parameters.pipeline }}
+          docker_base_image: onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntime/build/cuda12_x64_ubi8_gcc12:20240719.1
+          trt_version: '10.4.0.26-1.cuda12.6'
+          cuda_version: '12.2'
 

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-linux-test-cuda.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-linux-test-cuda.yml
@@ -100,7 +100,7 @@ jobs:
     inputs:
       targetType: filePath
       filePath: tools/ci_build/github/linux/run_python_dockertest.sh
-      arguments: -d GPU -c ${{parameters.cmake_build_type}} -i onnxruntimecuda118xtrt86build${{ parameters.arch }}
+      arguments: -d GPU -c ${{parameters.cmake_build_type}} -i onnxruntimecuda${{ replace(parameters.cuda_version, '.', '') }}xtrt86build${{ parameters.arch }}
 
   - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
     displayName: 'Clean Agent Directories'


### PR DESCRIPTION
### Description
It runs after "Python-CUDA-Packaging-Pipeline" that runs on a CPU machine that skipped all tests. 
This testing pipeline is for doing the tests. 



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


