### PR TITLE
Fix EmbedLayerNormalization fusion related to LayerNormalization optional input

### DIFF
--- a/onnxruntime/core/optimizer/embed_layer_norm_fusion.cc
+++ b/onnxruntime/core/optimizer/embed_layer_norm_fusion.cc
@@ -823,6 +823,12 @@ Status EmbedLayerNormFusion::ApplyImpl(Graph& graph, bool& modified, int graph_l
         !graph_utils::IsSupportedProvider(layer_norm_node, GetCompatibleExecutionProviders())) {
       continue;
     }
+
+    // The third input (beta) is optional in LayerNormalization-17 of onnx domain. Make sure 3 inputs are available.
+    if (!(layer_norm_node.InputDefs().size() == 3 && layer_norm_node.InputDefs()[2]->Exists())) {
+      continue;
+    }
+
     // Find Attention after LayerNormalization
     const Node* p_attention = graph_utils::FirstChildByType(layer_norm_node, "Attention");
     if (p_attention == nullptr) {


### PR DESCRIPTION
This fixes a bug found by libfuzzer: 

LayerNormalization third input (beta) is optional. The following code has potential out of bound access if the input is not available:
```
NodeArg* beta = layer_norm_node.MutableInputDefs()[2];
```

This adds a check to ensure the third input exists before fusion.

[AB#49036](https://aiinfra.visualstudio.com/6a833879-cd9b-44a4-a9de-adc2d818f13c/_workitems/edit/49036) 
