### PR TITLE
RC releases to Maven for Android 

### DIFF
--- a/java/build-android.gradle
+++ b/java/build-android.gradle
@@ -15,23 +15,26 @@ def releaseVersionSuffix = System.properties['releaseVersionSuffix'] ?: ""
 def qnnVersion = System.properties['qnnVersion']
 
 // Since Android requires higher numbers indicating more recent versions
-// This function assumes ORT version number will be in the format of A.B.C[-rcX] such as 1.20.0 or 1.20.0-rc1
-// We generate version code A[0{0,1}]B[0{0,1}]C[0{0,1}]X,
-// for example '1.19.0' -> 10190099, '1.19.0-rc1' -> 10190098
+// This function assumes ORT version number will be in the format of A.B.C[-rc/beta/alpha.D] such as 1.20.0 or 1.20.0-rc.1
+// We generate version code A[0{0,1}]B[0{0,1}]C[0{0,1}]{1,2,3,4}D[01-99]
+// for example '1.20.0' -> 12000400, '1.20.0-rc.1 ' -> 12000301
+// '1.20.0-beta.1' -> 12000201, '1.20.0-alpha.1' -> 12000101
 def getVersionCode(String version) {
-	String[] mainAndRc = version.split('-')
-	String[] codes = mainAndRc[0].split('\\.')
+	String[] versionAndRelSufx = version.split('-')
+	String[] codes = versionAndRelSufx[0].split('\\.')
 	// This will have problem if we have 3 digit [sub]version number, such as 1.7.199
 	// but it is highly unlikely to happen
-	String versionCodeStr = String.format("%d%02d%02d", codes[0] as int, codes[1] as int, codes[2] as int)
-	if (mainAndRc.length > 1 && mainAndRc[1].startsWith('rc')) {
-		// assuming there won't be more than 99 rc versions
-		String rcNumber = mainAndRc[1].substring(3)
-		println("rcNumber: $rcNumber")
-		versionCodeStr += String.format("%02d", 99 - (rcNumber as int))
+	String versionCodeStr  = String.format("%d%02d%02d", codes[0] as int, codes[1] as int, codes[2] as int)
+
+	if (versionAndRelSufx.length > 1) {
+		String suffixType = versionAndRelSufx[1].split('\\.')[0]
+		String suffixNumber = versionAndRelSufx[1].split('\\.')[1]
+		def suffixMap = ['alpha': '1', 'beta': '2', 'rc': '3']
+		versionCodeStr += suffixMap[suffixType] + String.format("%02d", suffixNumber as int)
 	} else {
-		versionCodeStr += "99"
+		versionCodeStr += "400" // For a normal release version without suffix, get the highest version code
 	}
+	println "Version code for $version is $versionCodeStr"
 	return versionCodeStr as int
 }
 

--- a/java/build-android.gradle
+++ b/java/build-android.gradle
@@ -8,25 +8,36 @@ def publishDir = System.properties['publishDir']
 def minSdkVer = System.properties['minSdkVer']
 def targetSdkVer = System.properties['targetSdkVer']
 boolean enableTrainingApis = (System.properties['ENABLE_TRAINING_APIS'] ?: "0") == "1"
+def releaseVersionSuffix = System.properties['releaseVersionSuffix'] ?: ""
 // Expected format for qnnVersion: major.minor.patch (e.g., 2.26.0)
 // QNN package version does not follow Semantic Versioning (SemVer) format.
 // For non qnn builds, qnnVersion will be null
 def qnnVersion = System.properties['qnnVersion']
 
-// Since Android requires a higher numbers indicating more recent versions
-// This function assume ORT version number will be in formart of A.B.C such as 1.7.0
-// We generate version code A[0{0,1}]B[0{0,1}]C,
-// for example '1.7.0' -> 10700, '1.6.15' -> 10615
-def getVersionCode(String version){
-	String[] codes = version.split('\\.');
+// Since Android requires higher numbers indicating more recent versions
+// This function assumes ORT version number will be in the format of A.B.C[-rcX] such as 1.20.0 or 1.20.0-rc1
+// We generate version code A[0{0,1}]B[0{0,1}]C[0{0,1}]X,
+// for example '1.19.0' -> 10190099, '1.19.0-rc1' -> 10190098
+def getVersionCode(String version) {
+	String[] mainAndRc = version.split('-')
+	String[] codes = mainAndRc[0].split('\\.')
 	// This will have problem if we have 3 digit [sub]version number, such as 1.7.199
 	// but it is highly unlikely to happen
-	String versionCodeStr = String.format("%d%02d%02d", codes[0] as int, codes[1] as int, codes[2] as int);
-	return versionCodeStr as int;
+	String versionCodeStr = String.format("%d%02d%02d", codes[0] as int, codes[1] as int, codes[2] as int)
+	if (mainAndRc.length > 1 && mainAndRc[1].startsWith('rc')) {
+		// assuming there won't be more than 99 rc versions
+		String rcNumber = mainAndRc[1].substring(3)
+		println("rcNumber: $rcNumber")
+		versionCodeStr += String.format("%02d", 99 - (rcNumber as int))
+	} else {
+		versionCodeStr += "99"
+	}
+	return versionCodeStr as int
 }
 
 project.buildDir = buildDir
-project.version = rootProject.file('../VERSION_NUMBER').text.trim()
+def project_version = rootProject.file('../VERSION_NUMBER').text.trim()
+project.version = releaseVersionSuffix ? "${project_version}${releaseVersionSuffix}" : project_version
 project.group = "com.microsoft.onnxruntime"
 
 def tmpArtifactId = enableTrainingApis ? project.name + "-training" : project.name

--- a/tools/ci_build/github/android/build_aar_and_copy_artifacts.sh
+++ b/tools/ci_build/github/android/build_aar_and_copy_artifacts.sh
@@ -47,16 +47,20 @@ fi
 # Execute the build command
 eval $COMMAND
 
+# debug
+ls /build/aar_out/${BUILD_CONFIG}/com/microsoft/onnxruntime/${PACKAGE_NAME}
+ls /build/aar_out/${BUILD_CONFIG}/com/microsoft/onnxruntime/${PACKAGE_NAME}/${ORT_VERSION}${RELEASE_VERSION_SUFFIX}
+
 # Copy the built artifacts to give folder for publishing
-BASE_PATH=/build/aar_out/${BUILD_CONFIG}/com/microsoft/onnxruntime/${PACKAGE_NAME}/${ORT_VERSION}
-cp ${BASE_PATH}/${PACKAGE_NAME}-${ORT_VERSION}-javadoc.jar  /home/onnxruntimedev/.artifacts
-cp ${BASE_PATH}/${PACKAGE_NAME}-${ORT_VERSION}-sources.jar  /home/onnxruntimedev/.artifacts
-cp ${BASE_PATH}/${PACKAGE_NAME}-${ORT_VERSION}.aar          /home/onnxruntimedev/.artifacts
-cp ${BASE_PATH}/${PACKAGE_NAME}-${ORT_VERSION}.pom          /home/onnxruntimedev/.artifacts
+BASE_PATH=/build/aar_out/${BUILD_CONFIG}/com/microsoft/onnxruntime/${PACKAGE_NAME}/${ORT_VERSION}${RELEASE_VERSION_SUFFIX}
+cp ${BASE_PATH}/${PACKAGE_NAME}-${ORT_VERSION}${RELEASE_VERSION_SUFFIX}-javadoc.jar  /home/onnxruntimedev/.artifacts
+cp ${BASE_PATH}/${PACKAGE_NAME}-${ORT_VERSION}${RELEASE_VERSION_SUFFIX}-sources.jar  /home/onnxruntimedev/.artifacts
+cp ${BASE_PATH}/${PACKAGE_NAME}-${ORT_VERSION}${RELEASE_VERSION_SUFFIX}.aar          /home/onnxruntimedev/.artifacts
+cp ${BASE_PATH}/${PACKAGE_NAME}-${ORT_VERSION}${RELEASE_VERSION_SUFFIX}.pom          /home/onnxruntimedev/.artifacts
 
 # Copy executables if necessary
 if [ "$PUBLISH_EXECUTABLES" == "1" ]; then
     pushd /build/intermediates/executables/${BUILD_CONFIG}
-    tar -czvf /home/onnxruntimedev/.artifacts/${PACKAGE_NAME}-${ORT_VERSION}-executables.tgz *
+    tar -czvf /home/onnxruntimedev/.artifacts/${PACKAGE_NAME}-${ORT_VERSION}${RELEASE_VERSION_SUFFIX}-executables.tgz *
     popd
 fi

--- a/tools/ci_build/github/android/build_aar_and_copy_artifacts.sh
+++ b/tools/ci_build/github/android/build_aar_and_copy_artifacts.sh
@@ -47,10 +47,6 @@ fi
 # Execute the build command
 eval $COMMAND
 
-# debug
-ls /build/aar_out/${BUILD_CONFIG}/com/microsoft/onnxruntime/${PACKAGE_NAME}
-ls /build/aar_out/${BUILD_CONFIG}/com/microsoft/onnxruntime/${PACKAGE_NAME}/${ORT_VERSION}${RELEASE_VERSION_SUFFIX}
-
 # Copy the built artifacts to give folder for publishing
 BASE_PATH=/build/aar_out/${BUILD_CONFIG}/com/microsoft/onnxruntime/${PACKAGE_NAME}/${ORT_VERSION}${RELEASE_VERSION_SUFFIX}
 cp ${BASE_PATH}/${PACKAGE_NAME}-${ORT_VERSION}${RELEASE_VERSION_SUFFIX}-javadoc.jar  /home/onnxruntimedev/.artifacts

--- a/tools/ci_build/github/android/build_aar_package.py
+++ b/tools/ci_build/github/android/build_aar_package.py
@@ -177,6 +177,7 @@ def _build_aar(args):
             if "--enable_training_apis" in build_settings["build_params"]
             else "-DENABLE_TRAINING_APIS=0"
         ),
+        "-DreleaseVersionSuffix=" + os.getenv("RELEASE_VERSION_SUFFIX", ""),
     ]
 
     # Add qnn specific parameters

--- a/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar-test.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar-test.yml
@@ -62,7 +62,7 @@ jobs:
       cp -av $(Build.SourcesDirectory)/java/src/test/android ./
       cd ./android
       mkdir -p app/libs
-      cp $(Build.BinariesDirectory)/final-android-aar/${{parameters.packageName}}-$(OnnxRuntimeVersion)-${{parameters.ReleaseVersionSuffix}}.aar app/libs/onnxruntime-android.aar
+      cp $(Build.BinariesDirectory)/final-android-aar/${{parameters.packageName}}-$(OnnxRuntimeVersion)${{parameters.ReleaseVersionSuffix}}.aar app/libs/onnxruntime-android.aar
       $(Build.SourcesDirectory)/java/gradlew --no-daemon clean connectedDebugAndroidTest --stacktrace
     displayName: Run E2E test using Emulator
     workingDirectory: $(Build.BinariesDirectory)

--- a/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar-test.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar-test.yml
@@ -14,6 +14,11 @@ parameters:
   type: string
   default: 'onnxruntime-android'
 
+- name: ReleaseVersionSuffix
+  displayName: Release Version Suffix
+  type: string
+  default: ''
+
 jobs:
 - job: Final_AAR_Testing_Android_${{ parameters.job_name_suffix }}
   workspace:
@@ -57,7 +62,7 @@ jobs:
       cp -av $(Build.SourcesDirectory)/java/src/test/android ./
       cd ./android
       mkdir -p app/libs
-      cp $(Build.BinariesDirectory)/final-android-aar/${{parameters.packageName}}-$(OnnxRuntimeVersion).aar app/libs/onnxruntime-android.aar
+      cp $(Build.BinariesDirectory)/final-android-aar/${{parameters.packageName}}-$(OnnxRuntimeVersion)-${{parameters.ReleaseVersionSuffix}}.aar app/libs/onnxruntime-android.aar
       $(Build.SourcesDirectory)/java/gradlew --no-daemon clean connectedDebugAndroidTest --stacktrace
     displayName: Run E2E test using Emulator
     workingDirectory: $(Build.BinariesDirectory)

--- a/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar.yml
@@ -43,6 +43,11 @@ parameters:
   displayName: Use GPG to sign the jars
   type: boolean
 
+- name: ReleaseVersionSuffix
+  displayName: Release Version Suffix
+  type: string
+  default: ''
+
 jobs:
 - job: Android_Java_API_AAR_Packaging_${{ parameters.job_name_suffix }}
   timeoutInMinutes: 120
@@ -114,6 +119,7 @@ jobs:
           -e ORT_VERSION=$(OnnxRuntimeVersion) \
           -e PUBLISH_EXECUTABLES=${{parameters.publish_executables}} \
           -e PACKAGE_NAME=${{parameters.packageName}} \
+          -e RELEASE_VERSION_SUFFIX=${{parameters.ReleaseVersionSuffix}} \
           onnxruntimecpubuild \
             /bin/bash /onnxruntime_src/tools/ci_build/github/android/build_aar_and_copy_artifacts.sh $USE_QNN
       workingDirectory: $(Build.SourcesDirectory)

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -62,7 +62,7 @@ stages:
     DoEsrp: ${{ parameters.DoEsrp }}
 
 - stage: Android_Java_API_AAR_Packaging_Full
-  dependsOn: Setup
+  dependsOn: Setup # Setup stage defined in set_packaging_variables_stage.yml creates the ReleaseVersionSuffix variable
   variables:
     ReleaseVersionSuffix: $[stageDependencies.Setup.Set_Variables.outputs['Set_Release_Version_Suffix.ReleaseVersionSuffix']]
   jobs:
@@ -84,7 +84,7 @@ stages:
       ReleaseVersionSuffix: $(ReleaseVersionSuffix)
 
 - stage: Android_Java_API_AAR_Packaging_QNN
-  dependsOn: Setup
+  dependsOn: Setup # Setup stage defined in set_packaging_variables_stage.yml creates the ReleaseVersionSuffix variable
   variables:
     ReleaseVersionSuffix: $[stageDependencies.Setup.Set_Variables.outputs['Set_Release_Version_Suffix.ReleaseVersionSuffix']]
   jobs:

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -62,7 +62,9 @@ stages:
     DoEsrp: ${{ parameters.DoEsrp }}
 
 - stage: Android_Java_API_AAR_Packaging_Full
-  dependsOn: []
+  dependsOn: Setup
+  variables:
+    ReleaseVersionSuffix: $[stageDependencies.Setup.Set_Variables.outputs['Set_Release_Version_Suffix.ReleaseVersionSuffix']]
   jobs:
   - template: android-java-api-aar.yml
     parameters:
@@ -73,14 +75,16 @@ stages:
       publish_executables: '1'
       enable_code_sign: ${{ parameters.DoEsrp }}
       packageName: 'onnxruntime-android'
+      ReleaseVersionSuffix: $(ReleaseVersionSuffix)
 
   - template: android-java-api-aar-test.yml
     parameters:
       artifactName: 'onnxruntime-android-full-aar'
       job_name_suffix: 'Full'
+      ReleaseVersionSuffix: $(ReleaseVersionSuffix)
 
 - stage: Android_Java_API_AAR_Packaging_QNN
-  dependsOn: []
+  dependsOn: Setup
   jobs:
   - template: android-java-api-aar.yml
     parameters:
@@ -91,6 +95,7 @@ stages:
       publish_executables: '0'
       enable_code_sign: ${{ parameters.DoEsrp }}
       packageName: 'onnxruntime-android-qnn'
+      ReleaseVersionSuffix: $(ReleaseVersionSuffix)
   #TODO: Add test job for QNN Android AAR
 
 - stage: iOS_Full_xcframework

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -85,6 +85,8 @@ stages:
 
 - stage: Android_Java_API_AAR_Packaging_QNN
   dependsOn: Setup
+  variables:
+    ReleaseVersionSuffix: $[stageDependencies.Setup.Set_Variables.outputs['Set_Release_Version_Suffix.ReleaseVersionSuffix']]
   jobs:
   - template: android-java-api-aar.yml
     parameters:


### PR DESCRIPTION
### Description
Aallows alpha, beta and rc version releases to Maven for Android artifacts.



### Motivation and Context
Helpful to release rc versions or test artifacts to Maven for testing. For example, a new QNN android package is being released and it will be nice to test the RC version for dependencies before release

## Future Work
Allow RC version for all Maven artifacts.

