### PR TITLE
Support more FP16 XNNPack kernels and refactoring

### DIFF
--- a/onnxruntime/core/framework/kernel_registry.cc
+++ b/onnxruntime/core/framework/kernel_registry.cc
@@ -314,7 +314,7 @@ Status KernelRegistry::Register(KernelCreateInfo&& create_info) {
       std::string since_version_str = std::to_string(since_version);
       return Status(common::ONNXRUNTIME, common::FAIL,
                     "Failed to add kernel for " + key +
-                        ": Conflicting with a registered kernel with op versions. the since version is: " + 
+                        ": Conflicting with a registered kernel with op versions. the since version is: " +
                         since_version_str);
     }
   }

--- a/onnxruntime/core/framework/kernel_registry.cc
+++ b/onnxruntime/core/framework/kernel_registry.cc
@@ -310,9 +310,12 @@ Status KernelRegistry::Register(KernelCreateInfo&& create_info) {
   for (auto i = range.first; i != range.second; ++i) {
     if (i->second.kernel_def &&
         i->second.kernel_def->IsConflict(*create_info.kernel_def)) {
+      int since_version = i->second.kernel_def->SinceVersion().first;
+      std::string since_version_str = std::to_string(since_version);
       return Status(common::ONNXRUNTIME, common::FAIL,
                     "Failed to add kernel for " + key +
-                        ": Conflicting with a registered kernel with op versions.");
+                        ": Conflicting with a registered kernel with op versions. the since version is: " + 
+                        since_version_str);
     }
   }
 

--- a/onnxruntime/core/framework/kernel_registry.cc
+++ b/onnxruntime/core/framework/kernel_registry.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <memory>
 #include <numeric>
+#include <string>
 #include <unordered_map>
 
 #include "core/framework/kernel_type_str_resolver.h"

--- a/onnxruntime/core/providers/xnnpack/detail/node_support_checker.cc
+++ b/onnxruntime/core/providers/xnnpack/detail/node_support_checker.cc
@@ -90,6 +90,17 @@ const NodeUnit* ClipReluChecker(const NodeUnit& node_unit,
 }  // namespace
 
 bool NodeSupportChecker::IsNodeSupported(const NodeUnit& nodeunit) {
+#ifndef XNNPACK_FP16_SUPPORTED
+  // check whether the hardware support XNNPack FP16
+  // Note. In CI, ios pipeline on ADO doesn't support XNNPack FP16. Because ADO mac pool is still x64.
+  const auto& inputs = nodeunit.Inputs();
+  const auto& x_arg = inputs[0].node_arg;
+  const auto* x_type = x_arg.TypeAsProto();
+  if (x_type == nullptr || x_type->tensor_type().elem_type() == ONNX_NAMESPACE::TensorProto_DataType_FLOAT16) {
+    return false;
+  }
+#endif
+
   static std::unordered_map<std::string, CheckerFn> checkers{
       {"Conv", Conv::IsOnnxNodeSupported},
       {"ConvTranspose", ConvTranspose::IsOnnxNodeSupported},

--- a/onnxruntime/core/providers/xnnpack/math/gemm.cc
+++ b/onnxruntime/core/providers/xnnpack/math/gemm.cc
@@ -234,38 +234,24 @@ Status Gemm::Compute(OpKernelContext* context) const {
 }
 
 ONNX_OPERATOR_VERSIONED_KERNEL_EX(Gemm, kOnnxDomain, 7, 8, kXnnpackExecutionProvider,
-                                  KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+                                  KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
+                                                                          DataTypeImpl::GetTensorType<MLFloat16>()}),
                                   Gemm);
 
 ONNX_OPERATOR_VERSIONED_KERNEL_EX(Gemm, kOnnxDomain, 9, 10, kXnnpackExecutionProvider,
-                                  KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+                                  KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
+                                                                          DataTypeImpl::GetTensorType<MLFloat16>()}),
                                   Gemm);
 
 ONNX_OPERATOR_VERSIONED_KERNEL_EX(Gemm, kOnnxDomain, 11, 12, kXnnpackExecutionProvider,
-                                  KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+                                  KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
+                                                                          DataTypeImpl::GetTensorType<MLFloat16>()}),
                                   Gemm);
 
 ONNX_OPERATOR_KERNEL_EX(Gemm, kOnnxDomain, 13, kXnnpackExecutionProvider,
-                        KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+                        KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
+                                                                DataTypeImpl::GetTensorType<MLFloat16>()}),
                         Gemm);
-
-#ifdef XNNPACK_FP16_SUPPORTED
-ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Gemm, kOnnxDomain, 7, 8, MLFloat16, kXnnpackExecutionProvider,
-                                        KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
-                                        Gemm);
-
-ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Gemm, kOnnxDomain, 9, 10, MLFloat16, kXnnpackExecutionProvider,
-                                        KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
-                                        Gemm);
-
-ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Gemm, kOnnxDomain, 11, 12, MLFloat16, kXnnpackExecutionProvider,
-                                        KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
-                                        Gemm);
-
-ONNX_OPERATOR_TYPED_KERNEL_EX(Gemm, kOnnxDomain, 13, MLFloat16, kXnnpackExecutionProvider,
-                              KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
-                              Gemm);
-#endif
 
 }  // namespace xnnpack
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/xnnpack/math/gemm.h
+++ b/onnxruntime/core/providers/xnnpack/math/gemm.h
@@ -41,6 +41,8 @@ class Gemm : protected GemmBase, public XnnpackKernel {
 
   float alpha_;
   float beta_;
+
+  OpComputeType op_type_ = OpComputeType::op_compute_type_invalid;
 };
 
 }  // namespace xnnpack

--- a/onnxruntime/core/providers/xnnpack/math/matmul.cc
+++ b/onnxruntime/core/providers/xnnpack/math/matmul.cc
@@ -3,6 +3,7 @@
 
 #include "matmul.h"
 #include "core/providers/cpu/math/matmul_helper.h"
+#include "core/providers/xnnpack/xnnpack_init.h"
 
 // Todo -
 // 1. Integrate activation layers - Cliping & Relu
@@ -34,7 +35,8 @@ bool MatMul::IsOnnxNodeSupported(const NodeUnit& node_unit, const GraphViewer& g
     const auto* A_shape = A_arg.Shape();
     const auto* B_shape = B_arg.Shape();
 
-    if (A_type->tensor_type().elem_type() != ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {
+    if (A_type->tensor_type().elem_type() != ONNX_NAMESPACE::TensorProto_DataType_FLOAT &&
+        A_type->tensor_type().elem_type() != ONNX_NAMESPACE::TensorProto_DataType_FLOAT16) {
       break;
     }
 
@@ -62,7 +64,20 @@ bool MatMul::IsOnnxNodeSupported(const NodeUnit& node_unit, const GraphViewer& g
   return supported;
 }
 
-MatMul::MatMul(const OpKernelInfo& info) : XnnpackKernel(info, /*enable_caches*/ true) {}
+MatMul::MatMul(const OpKernelInfo& info) : XnnpackKernel(info, /*enable_caches*/ true) {
+  const auto& node{Node()};
+  const auto& input_defs = node.InputDefs();
+  const NodeArg& X = *input_defs[0];
+  auto input_dtype = X.TypeAsProto()->tensor_type().elem_type();
+  op_type_str_ = DataTypeImpl::ToString(DataTypeImpl::TypeFromProto(*X.TypeAsProto()));
+  if (input_dtype == ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {
+    op_type_ = OpComputeType::op_compute_type_fp32;
+  } else if (input_dtype == ONNX_NAMESPACE::TensorProto_DataType_FLOAT16) {
+    op_type_ = OpComputeType::op_compute_type_fp16;
+  } else {
+    ORT_THROW("unsupported Gemm in XnnpackEP, we have FLOAT|FLOAT16, but got ", op_type_str_);
+  }
+}
 
 Status MatMul::PrePack(const Tensor& tensor, int input_idx, AllocatorPtr alloc,
                        /*out*/ bool& is_packed,
@@ -78,8 +93,7 @@ Status MatMul::PrePack(const Tensor& tensor, int input_idx, AllocatorPtr alloc,
   is_packed = true;
 
   uint32_t flags = XNN_FLAG_TRANSPOSE_WEIGHTS;
-  float output_min = -INFINITY;
-  float output_max = INFINITY;
+
   xnn_status status = xnn_status::xnn_status_uninitialized;
 
   struct xnn_operator* p = nullptr;
@@ -88,27 +102,51 @@ Status MatMul::PrePack(const Tensor& tensor, int input_idx, AllocatorPtr alloc,
   if (b_shape_.NumDimensions() == 1) {
     shape_broadcast.push_back(1);
   }
-  status = xnn_create_fully_connected_nc_f32(
-      shape_broadcast[0],    // size_t input_channels,
-      shape_broadcast[1],    // size_t output_channels,
-      shape_broadcast[0],    // size_t input_stride,
-      shape_broadcast[1],    // size_t output_stride,
-      tensor.Data<float>(),  // const float* kernel,
-      nullptr,               // const float* bias,
-      output_min,
-      output_max,
-      flags,
+
 #ifdef XNN_CACHE_ENABLE
-      GetCodeCache(),
-      GetWeightsCache(),
+  xnn_code_cache_t code_cache = GetCodeCache();
+  xnn_weights_cache_t weight_cache = GetWeightsCache();
 #else
-      nullptr,
-      nullptr,
+  xnn_code_cache_t code_cache = nullptr;
+  xnn_weights_cache_t weight_cache = nullptr;
 #endif
-      &p);
+
+  if (op_type_ == OpComputeType::op_compute_type_fp32) {
+    float output_min = -INFINITY;
+    float output_max = INFINITY;
+    status = xnn_create_fully_connected_nc_f32(
+        shape_broadcast[0],    // size_t input_channels,
+        shape_broadcast[1],    // size_t output_channels,
+        shape_broadcast[0],    // size_t input_stride,
+        shape_broadcast[1],    // size_t output_stride,
+        tensor.Data<float>(),  // const float* kernel,
+        nullptr,               // const float* bias,
+        output_min,
+        output_max,
+        flags,
+        code_cache,
+        weight_cache,
+        &p);
+  } else if (op_type_ == OpComputeType::op_compute_type_fp16) {
+    float output_min = -65504.0f;
+    float output_max = 65504.0f;
+    status = xnn_create_fully_connected_nc_f16(
+        shape_broadcast[0],        // size_t input_channels,
+        shape_broadcast[1],        // size_t output_channels,
+        shape_broadcast[0],        // size_t input_stride,
+        shape_broadcast[1],        // size_t output_stride,
+        tensor.Data<MLFloat16>(),  // const MLFloat16* kernel,
+        nullptr,                   // const MLFloat16* bias,
+        output_min,
+        output_max,
+        flags,
+        code_cache,
+        weight_cache,
+        &p);
+  }
 
   if (status != xnn_status_success) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "xnn_create_fully_connected_nc_f32 returned ", status);
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "xnn_create_fully_connected_nc_", op_type_str_, " returned ", status);
   }
 
   op0_.reset(p);
@@ -129,13 +167,20 @@ Status MatMul::Compute(OpKernelContext* ctx) const {
   auto* y_data = y->MutableData<float>();
 
   xnn_status status = xnn_reshape_fully_connected_nc_f32(op0_.get(), a->Shape()[0], threadpool);
+  if (op_type_ == OpComputeType::op_compute_type_fp16) {
+    status = xnn_reshape_fully_connected_nc_f16(op0_.get(), a->Shape()[0], threadpool);
+  }
+
   if (status != xnn_status_success) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "xnn_reshape_fully_connected_nc_f32 returned ", status);
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "xnn_reshape_fully_connected_nc_", op_type_str_, " returned ", status);
   }
 
   status = xnn_setup_fully_connected_nc_f32(op0_.get(), a->Data<float>(), y_data);
+  if (op_type_ == OpComputeType::op_compute_type_fp16) {
+    status = xnn_setup_fully_connected_nc_f16(op0_.get(), a->Data<MLFloat16>(), y_data);
+  }
   if (status != xnn_status_success) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "xnn_setup_fully_connected_nc_f32 returned ", status);
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "xnn_setup_fully_connected_nc_", op_type_str_, " returned ", status);
   }
 
   status = xnn_run_operator(op0_.get(), nullptr);
@@ -157,5 +202,18 @@ ONNX_OPERATOR_KERNEL_EX(MatMul, kOnnxDomain, 13, kXnnpackExecutionProvider,
                         KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
                         MatMul);
 
+#ifdef XNNPACK_FP16_SUPPORTED
+ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(MatMul, kOnnxDomain, 1, 8, MLFloat16, kXnnpackExecutionProvider,
+                                        KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
+                                        MatMul);
+
+ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(MatMul, kOnnxDomain, 9, 12, MLFloat16, kXnnpackExecutionProvider,
+                                        KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
+                                        MatMul);
+
+ONNX_OPERATOR_TYPED_KERNEL_EX(MatMul, kOnnxDomain, 13, MLFloat16, kXnnpackExecutionProvider,
+                              KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
+                              MatMul);
+#endif
 }  // namespace xnnpack
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/xnnpack/math/matmul.cc
+++ b/onnxruntime/core/providers/xnnpack/math/matmul.cc
@@ -75,7 +75,7 @@ MatMul::MatMul(const OpKernelInfo& info) : XnnpackKernel(info, /*enable_caches*/
   } else if (input_dtype == ONNX_NAMESPACE::TensorProto_DataType_FLOAT16) {
     op_type_ = OpComputeType::op_compute_type_fp16;
   } else {
-    ORT_THROW("unsupported Gemm in XnnpackEP, we have FLOAT|FLOAT16, but got ", op_type_str_);
+    ORT_THROW("unsupported MatMul in XnnpackEP, we have FLOAT|FLOAT16, but got ", op_type_str_);
   }
 }
 

--- a/onnxruntime/core/providers/xnnpack/math/matmul.cc
+++ b/onnxruntime/core/providers/xnnpack/math/matmul.cc
@@ -191,29 +191,19 @@ Status MatMul::Compute(OpKernelContext* ctx) const {
 }
 
 ONNX_OPERATOR_VERSIONED_KERNEL_EX(MatMul, kOnnxDomain, 1, 8, kXnnpackExecutionProvider,
-                                  KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+                                  KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
+                                                                          DataTypeImpl::GetTensorType<MLFloat16>()}),
                                   MatMul);
 
 ONNX_OPERATOR_VERSIONED_KERNEL_EX(MatMul, kOnnxDomain, 9, 12, kXnnpackExecutionProvider,
-                                  KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+                                  KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
+                                                                          DataTypeImpl::GetTensorType<MLFloat16>()}),
                                   MatMul);
 
 ONNX_OPERATOR_KERNEL_EX(MatMul, kOnnxDomain, 13, kXnnpackExecutionProvider,
-                        KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+                        KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
+                                                                DataTypeImpl::GetTensorType<MLFloat16>()}),
                         MatMul);
 
-#ifdef XNNPACK_FP16_SUPPORTED
-ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(MatMul, kOnnxDomain, 1, 8, MLFloat16, kXnnpackExecutionProvider,
-                                        KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
-                                        MatMul);
-
-ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(MatMul, kOnnxDomain, 9, 12, MLFloat16, kXnnpackExecutionProvider,
-                                        KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
-                                        MatMul);
-
-ONNX_OPERATOR_TYPED_KERNEL_EX(MatMul, kOnnxDomain, 13, MLFloat16, kXnnpackExecutionProvider,
-                              KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
-                              MatMul);
-#endif
 }  // namespace xnnpack
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/xnnpack/math/matmul.h
+++ b/onnxruntime/core/providers/xnnpack/math/matmul.h
@@ -31,6 +31,9 @@ class MatMul : public XnnpackKernel {
   BufferUniquePtr packed_b_;
   AllocatorPtr myAlloc;
 
+  OpComputeType op_type_ = OpComputeType::op_compute_type_invalid;
+  std::string op_type_str_ = "";
+
   XnnpackOperator op0_ = nullptr;
 };
 

--- a/onnxruntime/core/providers/xnnpack/math/softmax.cc
+++ b/onnxruntime/core/providers/xnnpack/math/softmax.cc
@@ -6,8 +6,9 @@
 #include <utility>
 
 #include "core/framework/op_kernel.h"
-#include "core/providers/cpu/math/softmax_shared.h"
 #include "core/optimizer/initializer.h"
+#include "core/providers/cpu/math/softmax_shared.h"
+#include "core/providers/xnnpack/xnnpack_init.h"
 
 namespace onnxruntime {
 namespace xnnpack {
@@ -70,6 +71,7 @@ bool Softmax::IsOnnxNodeSupported(const NodeUnit& node_unit,
     const auto* x_type = x_arg.TypeAsProto();
     if (x_type == nullptr ||
         (x_type->tensor_type().elem_type() != ONNX_NAMESPACE::TensorProto_DataType_FLOAT &&
+         x_type->tensor_type().elem_type() != ONNX_NAMESPACE::TensorProto_DataType_FLOAT16 &&
          x_type->tensor_type().elem_type() != ONNX_NAMESPACE::TensorProto_DataType_UINT8)) {
       break;
     }
@@ -120,14 +122,16 @@ Softmax::Softmax(const OpKernelInfo& info) : XnnpackKernel{info} {
   ORT_ENFORCE(GetType(*input_defs[0], x_dtype));
   if (x_dtype == ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {
     op_type_ = OpComputeType::op_compute_type_fp32;
+  } else if (x_dtype == ONNX_NAMESPACE::TensorProto_DataType_FLOAT16) {
+    op_type_ = OpComputeType::op_compute_type_fp16;
   } else if (x_dtype == ONNX_NAMESPACE::TensorProto_DataType_UINT8) {
     op_type_ = OpComputeType::op_compute_type_qu8;
   } else {
     auto stype = DataTypeImpl::ToString(DataTypeImpl::TypeFromProto(*input_defs[0]->TypeAsProto()));
-    ORT_THROW("unsupported Conv in softmax, we have FLOAT|UINT8, but got ", stype);
+    ORT_THROW("unsupported Conv in softmax, we have FLOAT|FLOAT16|UINT8, but got ", stype);
   }
 
-  if (op_type_ == OpComputeType::op_compute_type_fp32) {
+  if (op_type_ == OpComputeType::op_compute_type_fp32 || op_type_ == OpComputeType::op_compute_type_fp16) {
     opset_ = node.SinceVersion();
   } else {
     // Qlinearsoftmax's opset keep 1, we have to parse it by "opset"
@@ -176,6 +180,10 @@ Softmax::Softmax(const OpKernelInfo& info) : XnnpackKernel{info} {
     xstatus = xnn_create_softmax_nc_f32(
         0,  // flags,
         &p);
+  } else if (op_type_ == OpComputeType::op_compute_type_fp16) {
+    xstatus = xnn_create_softmax_nc_f16(
+        0,  // flags,
+        &p);
   }
 
   ORT_ENFORCE(xstatus == xnn_status_success, "xnn_create_softmax_nc_",
@@ -200,8 +208,13 @@ Status Softmax::Compute(OpKernelContext* ctx) const {
   // const size_t D = X_shape.SizeFromDimension(axis_); // the step D is 1
   xnn_status status = xnn_status_invalid_state;
 
-  auto reshape_fn = op_type_ == OpComputeType::op_compute_type_qu8 ? xnn_reshape_softmax_nc_qu8
-                                                                   : xnn_reshape_softmax_nc_f32;
+  auto reshape_fn = xnn_reshape_softmax_nc_f32;
+  if (op_type_ == OpComputeType::op_compute_type_fp16) {
+    reshape_fn = xnn_reshape_softmax_nc_f16;
+  } else if (op_type_ == OpComputeType::op_compute_type_qu8) {
+    reshape_fn = xnn_reshape_softmax_nc_qu8;
+  }
+
   status = reshape_fn(op0_.get(), channel_dim_, channel_dim_, channel_dim_, N, threadpool);
 
   if (status != xnn_status_success) {
@@ -211,8 +224,10 @@ Status Softmax::Compute(OpKernelContext* ctx) const {
 
   if (op_type_ == OpComputeType::op_compute_type_qu8) {
     status = xnn_setup_softmax_nc_qu8(op0_.get(), X->Data<uint8_t>(), Y->MutableData<uint8_t>());
-  } else {
+  } else if (op_type_ == op_compute_type_fp32) {
     status = xnn_setup_softmax_nc_f32(op0_.get(), X->Data<float>(), Y->MutableData<float>());
+  } else if (op_type_ == op_compute_type_fp16) {
+    status = xnn_setup_softmax_nc_f16(op0_.get(), X->Data<MLFloat16>(), Y->MutableData<MLFloat16>());
   }
 
   if (status != xnn_status_success) {
@@ -243,6 +258,20 @@ ONNX_OPERATOR_KERNEL_EX(Softmax, kOnnxDomain, 13, kXnnpackExecutionProvider,
 ONNX_OPERATOR_KERNEL_EX(QLinearSoftmax, kDynamicDomainByCreate, 1, kXnnpackExecutionProvider,
                         KernelDefBuilder(),  // dynamic schema
                         Softmax);
+
+#ifdef XNNPACK_FP16_SUPPORTED
+ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Softmax, kOnnxDomain, 1, 10, MLFloat16, kXnnpackExecutionProvider,
+                                        KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
+                                        Softmax);
+
+ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Softmax, kOnnxDomain, 11, 12, MLFloat16, kXnnpackExecutionProvider,
+                                        KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
+                                        Softmax);
+
+ONNX_OPERATOR_TYPED_KERNEL_EX(Softmax, kOnnxDomain, 13, MLFloat16, kXnnpackExecutionProvider,
+                              KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
+                              Softmax);
+#endif
 
 }  // namespace xnnpack
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/xnnpack/math/softmax.cc
+++ b/onnxruntime/core/providers/xnnpack/math/softmax.cc
@@ -128,7 +128,7 @@ Softmax::Softmax(const OpKernelInfo& info) : XnnpackKernel{info} {
     op_type_ = OpComputeType::op_compute_type_qu8;
   } else {
     auto stype = DataTypeImpl::ToString(DataTypeImpl::TypeFromProto(*input_defs[0]->TypeAsProto()));
-    ORT_THROW("unsupported Conv in softmax, we have FLOAT|FLOAT16|UINT8, but got ", stype);
+    ORT_THROW("unsupported compute type in softmax, we have FLOAT|FLOAT16|UINT8, but got ", stype);
   }
 
   if (op_type_ == OpComputeType::op_compute_type_fp32 || op_type_ == OpComputeType::op_compute_type_fp16) {

--- a/onnxruntime/core/providers/xnnpack/math/softmax.cc
+++ b/onnxruntime/core/providers/xnnpack/math/softmax.cc
@@ -244,34 +244,23 @@ Status Softmax::Compute(OpKernelContext* ctx) const {
 }
 
 ONNX_OPERATOR_VERSIONED_KERNEL_EX(Softmax, kOnnxDomain, 1, 10, kXnnpackExecutionProvider,
-                                  KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+                                  KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
+                                                                          DataTypeImpl::GetTensorType<MLFloat16>()}),
                                   Softmax);
 
 ONNX_OPERATOR_VERSIONED_KERNEL_EX(Softmax, kOnnxDomain, 11, 12, kXnnpackExecutionProvider,
-                                  KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+                                  KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
+                                                                          DataTypeImpl::GetTensorType<MLFloat16>()}),
                                   Softmax);
 
 ONNX_OPERATOR_KERNEL_EX(Softmax, kOnnxDomain, 13, kXnnpackExecutionProvider,
-                        KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+                        KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
+                                                                DataTypeImpl::GetTensorType<MLFloat16>()}),
                         Softmax);
 
 ONNX_OPERATOR_KERNEL_EX(QLinearSoftmax, kDynamicDomainByCreate, 1, kXnnpackExecutionProvider,
                         KernelDefBuilder(),  // dynamic schema
                         Softmax);
-
-#ifdef XNNPACK_FP16_SUPPORTED
-ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Softmax, kOnnxDomain, 1, 10, MLFloat16, kXnnpackExecutionProvider,
-                                        KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
-                                        Softmax);
-
-ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Softmax, kOnnxDomain, 11, 12, MLFloat16, kXnnpackExecutionProvider,
-                                        KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
-                                        Softmax);
-
-ONNX_OPERATOR_TYPED_KERNEL_EX(Softmax, kOnnxDomain, 13, MLFloat16, kXnnpackExecutionProvider,
-                              KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
-                              Softmax);
-#endif
 
 }  // namespace xnnpack
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/xnnpack/nn/average_pool.cc
+++ b/onnxruntime/core/providers/xnnpack/nn/average_pool.cc
@@ -325,19 +325,19 @@ ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(
     AveragePool);
 
 ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(
-    AveragePool, kMSInternalNHWCDomain, 10, 10,
+    AveragePool, kMSInternalNHWCDomain, 10, 10, MLFloat,
     kXnnpackExecutionProvider,
     KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat>()),
     AveragePool);
 
 ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(
-    AveragePool, kMSInternalNHWCDomain, 11, 18,
+    AveragePool, kMSInternalNHWCDomain, 11, 18, MLFloat,
     kXnnpackExecutionProvider,
     KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat>()),
     AveragePool);
 
 ONNX_OPERATOR_TYPED_KERNEL_EX(
-    AveragePool, kMSInternalNHWCDomain, 19,
+    AveragePool, kMSInternalNHWCDomain, 19, MLFloat,
     kXnnpackExecutionProvider,
     KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat>()),
     AveragePool);

--- a/onnxruntime/core/providers/xnnpack/nn/average_pool.cc
+++ b/onnxruntime/core/providers/xnnpack/nn/average_pool.cc
@@ -319,27 +319,27 @@ ONNX_OPERATOR_KERNEL_EX(
 
 #ifdef XNNPACK_FP16_SUPPORTED
 ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(
-    AveragePool, kMSInternalNHWCDomain, 7, 9, MLFloat,
+    AveragePool, kMSInternalNHWCDomain, 7, 9, MLFloat16,
     kXnnpackExecutionProvider,
-    KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat>()),
+    KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
     AveragePool);
 
 ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(
-    AveragePool, kMSInternalNHWCDomain, 10, 10, MLFloat,
+    AveragePool, kMSInternalNHWCDomain, 10, 10, MLFloat16,
     kXnnpackExecutionProvider,
-    KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat>()),
+    KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
     AveragePool);
 
 ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(
-    AveragePool, kMSInternalNHWCDomain, 11, 18, MLFloat,
+    AveragePool, kMSInternalNHWCDomain, 11, 18, MLFloat16,
     kXnnpackExecutionProvider,
-    KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat>()),
+    KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
     AveragePool);
 
 ONNX_OPERATOR_TYPED_KERNEL_EX(
-    AveragePool, kMSInternalNHWCDomain, 19, MLFloat,
+    AveragePool, kMSInternalNHWCDomain, 19, MLFloat16,
     kXnnpackExecutionProvider,
-    KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat>()),
+    KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
     AveragePool);
 #endif
 

--- a/onnxruntime/core/providers/xnnpack/nn/average_pool.cc
+++ b/onnxruntime/core/providers/xnnpack/nn/average_pool.cc
@@ -290,25 +290,29 @@ Status AveragePool::Compute(OpKernelContext* context) const {
 ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     AveragePool, kMSInternalNHWCDomain, 7, 9,
     kXnnpackExecutionProvider,
-    KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
+                                            DataTypeImpl::GetTensorType<MLFloat16>()}),
     AveragePool);
 
 ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     AveragePool, kMSInternalNHWCDomain, 10, 10,
     kXnnpackExecutionProvider,
-    KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
+                                            DataTypeImpl::GetTensorType<MLFloat16>()}),
     AveragePool);
 
 ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     AveragePool, kMSInternalNHWCDomain, 11, 18,
     kXnnpackExecutionProvider,
-    KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
+                                            DataTypeImpl::GetTensorType<MLFloat16>()}),
     AveragePool);
 
 ONNX_OPERATOR_KERNEL_EX(
     AveragePool, kMSInternalNHWCDomain, 19,
     kXnnpackExecutionProvider,
-    KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
+                                            DataTypeImpl::GetTensorType<MLFloat16>()}),
     AveragePool);
 
 ONNX_OPERATOR_KERNEL_EX(
@@ -316,32 +320,6 @@ ONNX_OPERATOR_KERNEL_EX(
     kXnnpackExecutionProvider,
     KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<uint8_t>()),
     AveragePool);
-
-#ifdef XNNPACK_FP16_SUPPORTED
-ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(
-    AveragePool, kMSInternalNHWCDomain, 7, 9, MLFloat16,
-    kXnnpackExecutionProvider,
-    KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
-    AveragePool);
-
-ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(
-    AveragePool, kMSInternalNHWCDomain, 10, 10, MLFloat16,
-    kXnnpackExecutionProvider,
-    KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
-    AveragePool);
-
-ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(
-    AveragePool, kMSInternalNHWCDomain, 11, 18, MLFloat16,
-    kXnnpackExecutionProvider,
-    KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
-    AveragePool);
-
-ONNX_OPERATOR_TYPED_KERNEL_EX(
-    AveragePool, kMSInternalNHWCDomain, 19, MLFloat16,
-    kXnnpackExecutionProvider,
-    KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
-    AveragePool);
-#endif
 
 }  // namespace xnnpack
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/xnnpack/nn/conv.cc
+++ b/onnxruntime/core/providers/xnnpack/nn/conv.cc
@@ -148,21 +148,18 @@ Status Conv::Compute(OpKernelContext* context) const {
 }
 
 ONNX_OPERATOR_VERSIONED_KERNEL_EX(Conv, kMSInternalNHWCDomain, 1, 10, kXnnpackExecutionProvider,
-                                  KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+                                  KernelDefBuilder().TypeConstraint("T", {
+                                                                             DataTypeImpl::GetTensorType<float>(),
+                                                                             DataTypeImpl::GetTensorType<MLFloat16>(),
+                                                                         }),
                                   Conv);
 
 ONNX_OPERATOR_KERNEL_EX(Conv, kMSInternalNHWCDomain, 11, kXnnpackExecutionProvider,
-                        KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+                        KernelDefBuilder().TypeConstraint("T", {
+                                                                   DataTypeImpl::GetTensorType<float>(),
+                                                                   DataTypeImpl::GetTensorType<MLFloat16>(),
+                                                               }),
                         Conv);
-#ifdef XNNPACK_FP16_SUPPORTED
-ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Conv, kMSInternalNHWCDomain, 1, 10, MLFloat16, kXnnpackExecutionProvider,
-                                        KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
-                                        Conv);
-
-ONNX_OPERATOR_TYPED_KERNEL_EX(Conv, kMSInternalNHWCDomain, 11, MLFloat16, kXnnpackExecutionProvider,
-                              KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
-                              Conv);
-#endif
 
 ONNX_OPERATOR_TYPED_KERNEL_EX(
     QLinearConv,

--- a/onnxruntime/core/providers/xnnpack/nn/conv_transpose.cc
+++ b/onnxruntime/core/providers/xnnpack/nn/conv_transpose.cc
@@ -170,12 +170,14 @@ Status ConvTranspose::Compute(OpKernelContext* context) const {
 
 ONNX_OPERATOR_VERSIONED_KERNEL_EX(ConvTranspose, kMSInternalNHWCDomain, 1, 10, kXnnpackExecutionProvider,
                                   KernelDefBuilder().TypeConstraint(
-                                      "T", DataTypeImpl::GetTensorType<float>()),
+                                      "T", {DataTypeImpl::GetTensorType<float>(),
+                                            DataTypeImpl::GetTensorType<MLFloat16>()}),
                                   ConvTranspose);
 
 ONNX_OPERATOR_KERNEL_EX(ConvTranspose, kMSInternalNHWCDomain, 11, kXnnpackExecutionProvider,
                         KernelDefBuilder().TypeConstraint(
-                            "T", DataTypeImpl::GetTensorType<float>()),
+                            "T", {DataTypeImpl::GetTensorType<float>(),
+                                  DataTypeImpl::GetTensorType<MLFloat16>()}),
                         ConvTranspose);
 
 ONNX_OPERATOR_KERNEL_EX(QLinearConvTranspose, kMSInternalNHWCDomain, 1, kXnnpackExecutionProvider,
@@ -186,18 +188,5 @@ ONNX_OPERATOR_KERNEL_EX(QLinearConvTranspose, kMSInternalNHWCDomain, 1, kXnnpack
                                  DataTypeImpl::GetTensorType<int8_t>()}),
                         ConvTranspose);
 
-#ifdef XNNPACK_FP16_SUPPORTED
-ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(ConvTranspose, kMSInternalNHWCDomain, 1, 10, MLFloat16,
-                                        kXnnpackExecutionProvider,
-                                        KernelDefBuilder().TypeConstraint(
-                                            "T", DataTypeImpl::GetTensorType<MLFloat16>()),
-                                        ConvTranspose);
-
-ONNX_OPERATOR_TYPED_KERNEL_EX(ConvTranspose, kMSInternalNHWCDomain, 11, MLFloat16, kXnnpackExecutionProvider,
-                              KernelDefBuilder().TypeConstraint(
-                                  "T", DataTypeImpl::GetTensorType<MLFloat16>()),
-                              ConvTranspose);
-
-#endif
 }  // namespace xnnpack
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/xnnpack/nn/max_pool.cc
+++ b/onnxruntime/core/providers/xnnpack/nn/max_pool.cc
@@ -282,18 +282,21 @@ Status MaxPool::Compute(OpKernelContext* context) const {
 
 ONNX_OPERATOR_VERSIONED_KERNEL_EX(MaxPool, kMSInternalNHWCDomain, 8, 9, kXnnpackExecutionProvider,
                                   KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
+                                                                          DataTypeImpl::GetTensorType<MLFloat16>(),
                                                                           DataTypeImpl::GetTensorType<uint8_t>(),
                                                                           DataTypeImpl::GetTensorType<int8_t>()}),
                                   MaxPool);
 
 ONNX_OPERATOR_VERSIONED_KERNEL_EX(MaxPool, kMSInternalNHWCDomain, 10, 10, kXnnpackExecutionProvider,
                                   KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
+                                                                          DataTypeImpl::GetTensorType<MLFloat16>(),
                                                                           DataTypeImpl::GetTensorType<uint8_t>(),
                                                                           DataTypeImpl::GetTensorType<int8_t>()}),
                                   MaxPool);
 
 ONNX_OPERATOR_VERSIONED_KERNEL_EX(MaxPool, kMSInternalNHWCDomain, 11, 11, kXnnpackExecutionProvider,
                                   KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
+                                                                          DataTypeImpl::GetTensorType<MLFloat16>(),
                                                                           DataTypeImpl::GetTensorType<uint8_t>(),
                                                                           DataTypeImpl::GetTensorType<int8_t>()}),
                                   MaxPool);
@@ -301,27 +304,10 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(MaxPool, kMSInternalNHWCDomain, 11, 11, kXnnpa
 ONNX_OPERATOR_KERNEL_EX(MaxPool, kMSInternalNHWCDomain, 12, kXnnpackExecutionProvider,
                         KernelDefBuilder()
                             .TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
+                                                  DataTypeImpl::GetTensorType<MLFloat16>(),
                                                   DataTypeImpl::GetTensorType<uint8_t>(),
                                                   DataTypeImpl::GetTensorType<int8_t>()}),
                         MaxPool);
-
-#ifdef XNNPACK_FP16_SUPPORTED
-ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(MaxPool, kMSInternalNHWCDomain, 8, 9, MLFloat16, kXnnpackExecutionProvider,
-                                        KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
-                                        MaxPool);
-
-ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(MaxPool, kMSInternalNHWCDomain, 10, 10, MLFloat16, kXnnpackExecutionProvider,
-                                        KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
-                                        MaxPool);
-
-ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(MaxPool, kMSInternalNHWCDomain, 11, 11, MLFloat16, kXnnpackExecutionProvider,
-                                        KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
-                                        MaxPool);
-
-ONNX_OPERATOR_TYPED_KERNEL_EX(MaxPool, kMSInternalNHWCDomain, 12, MLFloat16, kXnnpackExecutionProvider,
-                              KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
-                              MaxPool);
-#endif
 
 }  // namespace xnnpack
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/xnnpack/tensor/resize.cc
+++ b/onnxruntime/core/providers/xnnpack/tensor/resize.cc
@@ -366,16 +366,16 @@ ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 10, 10, M
                                   KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<MLFloat16>()}),
                                   Resize);
 ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 11, 12, MLFloat16, kXnnpackExecutionProvider,
-                                  KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<MLFloat16>()}),
+                                  KernelDefBuilder().TypeConstraint("T1", {DataTypeImpl::GetTensorType<MLFloat16>()}),
                                   Resize);
 ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 13, 17, MLFloat16, kXnnpackExecutionProvider,
-                                  KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<MLFloat16>()}),
+                                  KernelDefBuilder().TypeConstraint("T1", {DataTypeImpl::GetTensorType<MLFloat16>()}),
                                   Resize);
 ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 18, 18, MLFloat16, kXnnpackExecutionProvider,
-                                  KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<MLFloat16>()}),
+                                  KernelDefBuilder().TypeConstraint("T1", {DataTypeImpl::GetTensorType<MLFloat16>()}),
                                   Resize);
 ONNX_OPERATOR_TYPED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 19, MLFloat16, kXnnpackExecutionProvider,
-                                KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<MLFloat16>()}),
+                                KernelDefBuilder().TypeConstraint("T1", {DataTypeImpl::GetTensorType<MLFloat16>()}),
                                 Resize);
 #endif
 }  // namespace xnnpack

--- a/onnxruntime/core/providers/xnnpack/tensor/resize.cc
+++ b/onnxruntime/core/providers/xnnpack/tensor/resize.cc
@@ -187,7 +187,7 @@ Resize::Resize(const OpKernelInfo& info) : UpsampleBase(info), XnnpackKernel{inf
       break;
     case ONNX_NAMESPACE::TensorProto_DataType_INT8:
       op_type_ = OpComputeType::op_compute_type_qs8;
-      break;      
+      break;
     default:
       auto stype = DataTypeImpl::ToString(DataTypeImpl::TypeFromProto(*input_defs[0]->TypeAsProto()));
       ORT_THROW("unsupported op in Resize, we have FLOAT|FLOAT16|UINT8|INT8, but get ", stype);
@@ -266,7 +266,7 @@ Status Resize::ComputeInternal(OpKernelContext* ctx, const Tensor* input,
   auto reshape_fn = xnn_reshape_resize_bilinear2d_nhwc_f32;
   if (op_type_ == OpComputeType::op_compute_type_fp16) {
     reshape_fn = xnn_reshape_resize_bilinear2d_nhwc_f16;
-  } else if(op_type_ == OpComputeType::op_compute_type_qu8) {
+  } else if (op_type_ == OpComputeType::op_compute_type_qu8) {
     reshape_fn = xnn_reshape_resize_bilinear2d_nhwc_u8;
   } else if (op_type_ == OpComputeType::op_compute_type_qs8) {
     reshape_fn = xnn_reshape_resize_bilinear2d_nhwc_s8;
@@ -286,7 +286,7 @@ Status Resize::ComputeInternal(OpKernelContext* ctx, const Tensor* input,
                                                   output->MutableData<float>());
   } else if (op_type_ == OpComputeType::op_compute_type_fp16) {
     status = xnn_setup_resize_bilinear2d_nhwc_f16(op0_.get(), workspace.get(), input->Data<MLFloat16>(),
-                                                 output->MutableData<MLFloat16>());
+                                                  output->MutableData<MLFloat16>());
   } else if (op_type_ == OpComputeType::op_compute_type_qu8) {
     status = xnn_setup_resize_bilinear2d_nhwc_u8(op0_.get(), workspace.get(), input->Data<uint8_t>(),
                                                  output->MutableData<uint8_t>());
@@ -363,20 +363,20 @@ ONNX_OPERATOR_KERNEL_EX(Resize, kMSInternalNHWCDomain, 19, kXnnpackExecutionProv
 
 #ifdef XNNPACK_FP16_SUPPORTED
 ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 10, 10, MLFloat16, kXnnpackExecutionProvider,
-                                  KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<MLFloat16>()}),
-                                  Resize);
+                                        KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<MLFloat16>()}),
+                                        Resize);
 ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 11, 12, MLFloat16, kXnnpackExecutionProvider,
-                                  KernelDefBuilder().TypeConstraint("T1", {DataTypeImpl::GetTensorType<MLFloat16>()}),
-                                  Resize);
+                                        KernelDefBuilder().TypeConstraint("T1", {DataTypeImpl::GetTensorType<MLFloat16>()}),
+                                        Resize);
 ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 13, 17, MLFloat16, kXnnpackExecutionProvider,
-                                  KernelDefBuilder().TypeConstraint("T1", {DataTypeImpl::GetTensorType<MLFloat16>()}),
-                                  Resize);
+                                        KernelDefBuilder().TypeConstraint("T1", {DataTypeImpl::GetTensorType<MLFloat16>()}),
+                                        Resize);
 ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 18, 18, MLFloat16, kXnnpackExecutionProvider,
-                                  KernelDefBuilder().TypeConstraint("T1", {DataTypeImpl::GetTensorType<MLFloat16>()}),
-                                  Resize);
+                                        KernelDefBuilder().TypeConstraint("T1", {DataTypeImpl::GetTensorType<MLFloat16>()}),
+                                        Resize);
 ONNX_OPERATOR_TYPED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 19, MLFloat16, kXnnpackExecutionProvider,
-                                KernelDefBuilder().TypeConstraint("T1", {DataTypeImpl::GetTensorType<MLFloat16>()}),
-                                Resize);
+                              KernelDefBuilder().TypeConstraint("T1", {DataTypeImpl::GetTensorType<MLFloat16>()}),
+                              Resize);
 #endif
 }  // namespace xnnpack
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/xnnpack/tensor/resize.cc
+++ b/onnxruntime/core/providers/xnnpack/tensor/resize.cc
@@ -363,19 +363,19 @@ ONNX_OPERATOR_KERNEL_EX(Resize, kMSInternalNHWCDomain, 19, kXnnpackExecutionProv
 
 #ifdef XNNPACK_FP16_SUPPORTED
 ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 10, 10, MLFloat16, kXnnpackExecutionProvider,
-                                        KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<MLFloat16>()}),
+                                        KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
                                         Resize);
 ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 11, 12, MLFloat16, kXnnpackExecutionProvider,
-                                        KernelDefBuilder().TypeConstraint("T1", {DataTypeImpl::GetTensorType<MLFloat16>()}),
+                                        KernelDefBuilder().TypeConstraint("T1", DataTypeImpl::GetTensorType<MLFloat16>()),
                                         Resize);
 ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 13, 17, MLFloat16, kXnnpackExecutionProvider,
-                                        KernelDefBuilder().TypeConstraint("T1", {DataTypeImpl::GetTensorType<MLFloat16>()}),
+                                        KernelDefBuilder().TypeConstraint("T1", DataTypeImpl::GetTensorType<MLFloat16>()),
                                         Resize);
 ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 18, 18, MLFloat16, kXnnpackExecutionProvider,
-                                        KernelDefBuilder().TypeConstraint("T1", {DataTypeImpl::GetTensorType<MLFloat16>()}),
+                                        KernelDefBuilder().TypeConstraint("T1", DataTypeImpl::GetTensorType<MLFloat16>()),
                                         Resize);
 ONNX_OPERATOR_TYPED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 19, MLFloat16, kXnnpackExecutionProvider,
-                              KernelDefBuilder().TypeConstraint("T1", {DataTypeImpl::GetTensorType<MLFloat16>()}),
+                              KernelDefBuilder().TypeConstraint("T1", DataTypeImpl::GetTensorType<MLFloat16>()),
                               Resize);
 #endif
 }  // namespace xnnpack

--- a/onnxruntime/core/providers/xnnpack/tensor/resize.cc
+++ b/onnxruntime/core/providers/xnnpack/tensor/resize.cc
@@ -29,9 +29,7 @@ bool Resize::IsOnnxNodeSupported(const NodeUnit& node_unit,
     const auto& x_arg = inputs[0].node_arg;
 
     const auto* x_type = x_arg.TypeAsProto();
-    if (x_type == nullptr || (x_type->tensor_type().elem_type() != ONNX_NAMESPACE::TensorProto_DataType_FLOAT &&
-                              x_type->tensor_type().elem_type() != ONNX_NAMESPACE::TensorProto_DataType_UINT8 &&
-                              x_type->tensor_type().elem_type() != ONNX_NAMESPACE::TensorProto_DataType_INT8)) {
+    if (x_type == nullptr || !IsComputeTypeSupported(x_type->tensor_type().elem_type())) {
       break;
     }
 
@@ -181,15 +179,18 @@ Resize::Resize(const OpKernelInfo& info) : UpsampleBase(info), XnnpackKernel{inf
     case ONNX_NAMESPACE::TensorProto_DataType_FLOAT:
       op_type_ = OpComputeType::op_compute_type_fp32;
       break;
+    case ONNX_NAMESPACE::TensorProto_DataType_FLOAT16:
+      op_type_ = OpComputeType::op_compute_type_fp16;
+      break;
     case ONNX_NAMESPACE::TensorProto_DataType_UINT8:
       op_type_ = OpComputeType::op_compute_type_qu8;
       break;
     case ONNX_NAMESPACE::TensorProto_DataType_INT8:
       op_type_ = OpComputeType::op_compute_type_qs8;
-      break;
+      break;      
     default:
       auto stype = DataTypeImpl::ToString(DataTypeImpl::TypeFromProto(*input_defs[0]->TypeAsProto()));
-      ORT_THROW("unsupported op in Resize, we have FLOAT|UINT8|INT8, but get ", stype);
+      ORT_THROW("unsupported op in Resize, we have FLOAT|FLOAT16|UINT8|INT8, but get ", stype);
   }
 
   const auto* x_shape = input_defs[0]->Shape();
@@ -229,6 +230,8 @@ Resize::Resize(const OpKernelInfo& info) : UpsampleBase(info), XnnpackKernel{inf
   auto out_w = output_dims_[2];
   if (op_type_ == OpComputeType::op_compute_type_fp32) {
     xstatus = xnn_create_resize_bilinear2d_nhwc_f32(out_h, out_w, flags, &p);
+  } else if (op_type_ == OpComputeType::op_compute_type_fp16) {
+    xstatus = xnn_create_resize_bilinear2d_nhwc_f16(out_h, out_w, flags, &p);
   } else if (op_type_ == OpComputeType::op_compute_type_qu8) {
     xstatus = xnn_create_resize_bilinear2d_nhwc_u8(out_h, out_w, flags, &p);
   } else {
@@ -261,7 +264,9 @@ Status Resize::ComputeInternal(OpKernelContext* ctx, const Tensor* input,
   std::unique_ptr<void, decltype(deallocator)> workspace(nullptr, deallocator);
 
   auto reshape_fn = xnn_reshape_resize_bilinear2d_nhwc_f32;
-  if (op_type_ == OpComputeType::op_compute_type_qu8) {
+  if (op_type_ == OpComputeType::op_compute_type_fp16) {
+    reshape_fn = xnn_reshape_resize_bilinear2d_nhwc_f16;
+  } else if(op_type_ == OpComputeType::op_compute_type_qu8) {
     reshape_fn = xnn_reshape_resize_bilinear2d_nhwc_u8;
   } else if (op_type_ == OpComputeType::op_compute_type_qs8) {
     reshape_fn = xnn_reshape_resize_bilinear2d_nhwc_s8;
@@ -279,6 +284,9 @@ Status Resize::ComputeInternal(OpKernelContext* ctx, const Tensor* input,
   if (op_type_ == OpComputeType::op_compute_type_fp32) {
     status = xnn_setup_resize_bilinear2d_nhwc_f32(op0_.get(), workspace.get(), input->Data<float>(),
                                                   output->MutableData<float>());
+  } else if (op_type_ == OpComputeType::op_compute_type_fp16) {
+    status = xnn_setup_resize_bilinear2d_nhwc_f16(op0_.get(), workspace.get(), input->Data<MLFloat16>(),
+                                                 output->MutableData<MLFloat16>());
   } else if (op_type_ == OpComputeType::op_compute_type_qu8) {
     status = xnn_setup_resize_bilinear2d_nhwc_u8(op0_.get(), workspace.get(), input->Data<uint8_t>(),
                                                  output->MutableData<uint8_t>());
@@ -352,5 +360,23 @@ ONNX_OPERATOR_KERNEL_EX(Resize, kMSInternalNHWCDomain, 19, kXnnpackExecutionProv
                                                                  DataTypeImpl::GetTensorType<uint8_t>(),
                                                                  DataTypeImpl::GetTensorType<int8_t>()}),
                         Resize);
+
+#ifdef XNNPACK_FP16_SUPPORTED
+ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 10, 10, MLFloat16, kXnnpackExecutionProvider,
+                                  KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<MLFloat16>()}),
+                                  Resize);
+ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 11, 12, MLFloat16, kXnnpackExecutionProvider,
+                                  KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<MLFloat16>()}),
+                                  Resize);
+ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 13, 17, MLFloat16, kXnnpackExecutionProvider,
+                                  KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<MLFloat16>()}),
+                                  Resize);
+ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 18, 18, MLFloat16, kXnnpackExecutionProvider,
+                                  KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<MLFloat16>()}),
+                                  Resize);
+ONNX_OPERATOR_TYPED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 19, MLFloat16, kXnnpackExecutionProvider,
+                                KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<MLFloat16>()}),
+                                Resize);
+#endif
 }  // namespace xnnpack
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/xnnpack/tensor/resize.cc
+++ b/onnxruntime/core/providers/xnnpack/tensor/resize.cc
@@ -335,22 +335,26 @@ Status Resize::Compute(OpKernelContext* ctx) const {
 
 ONNX_OPERATOR_VERSIONED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 10, 10, kXnnpackExecutionProvider,
                                   KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
+                                                                          DataTypeImpl::GetTensorType<MLFloat16>(),
                                                                           DataTypeImpl::GetTensorType<uint8_t>(),
                                                                           DataTypeImpl::GetTensorType<int8_t>()}),
                                   Resize);
 ONNX_OPERATOR_VERSIONED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 11, 12, kXnnpackExecutionProvider,
                                   KernelDefBuilder().TypeConstraint("T1", {DataTypeImpl::GetTensorType<float>(),
+                                                                           DataTypeImpl::GetTensorType<MLFloat16>(),
                                                                            DataTypeImpl::GetTensorType<uint8_t>(),
                                                                            DataTypeImpl::GetTensorType<int8_t>()}),
                                   Resize);
 ONNX_OPERATOR_VERSIONED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 13, 17, kXnnpackExecutionProvider,
                                   KernelDefBuilder().TypeConstraint("T1", {DataTypeImpl::GetTensorType<float>(),
+                                                                           DataTypeImpl::GetTensorType<MLFloat16>(),
                                                                            DataTypeImpl::GetTensorType<uint8_t>(),
                                                                            DataTypeImpl::GetTensorType<int8_t>()}),
                                   Resize);
 
 ONNX_OPERATOR_VERSIONED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 18, 18, kXnnpackExecutionProvider,
                                   KernelDefBuilder().TypeConstraint("T1", {DataTypeImpl::GetTensorType<float>(),
+                                                                           DataTypeImpl::GetTensorType<MLFloat16>(),
                                                                            DataTypeImpl::GetTensorType<uint8_t>(),
                                                                            DataTypeImpl::GetTensorType<int8_t>()}),
                                   Resize);
@@ -360,23 +364,5 @@ ONNX_OPERATOR_KERNEL_EX(Resize, kMSInternalNHWCDomain, 19, kXnnpackExecutionProv
                                                                  DataTypeImpl::GetTensorType<uint8_t>(),
                                                                  DataTypeImpl::GetTensorType<int8_t>()}),
                         Resize);
-
-#ifdef XNNPACK_FP16_SUPPORTED
-ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 10, 10, MLFloat16, kXnnpackExecutionProvider,
-                                        KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
-                                        Resize);
-ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 11, 12, MLFloat16, kXnnpackExecutionProvider,
-                                        KernelDefBuilder().TypeConstraint("T1", DataTypeImpl::GetTensorType<MLFloat16>()),
-                                        Resize);
-ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 13, 17, MLFloat16, kXnnpackExecutionProvider,
-                                        KernelDefBuilder().TypeConstraint("T1", DataTypeImpl::GetTensorType<MLFloat16>()),
-                                        Resize);
-ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 18, 18, MLFloat16, kXnnpackExecutionProvider,
-                                        KernelDefBuilder().TypeConstraint("T1", DataTypeImpl::GetTensorType<MLFloat16>()),
-                                        Resize);
-ONNX_OPERATOR_TYPED_KERNEL_EX(Resize, kMSInternalNHWCDomain, 19, MLFloat16, kXnnpackExecutionProvider,
-                              KernelDefBuilder().TypeConstraint("T1", DataTypeImpl::GetTensorType<MLFloat16>()),
-                              Resize);
-#endif
 }  // namespace xnnpack
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/xnnpack/xnnpack_execution_provider.cc
+++ b/onnxruntime/core/providers/xnnpack/xnnpack_execution_provider.cc
@@ -31,10 +31,6 @@ KernelCreateInfo BuildKernelCreateInfo<void>() {
   BuildKernelCreateInfo<                                     \
       ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, Domain, Start, End, Op)>
 
-#define KERNEL_CREATE_INFO_VERSIONED_TYPED(Start, End, Type, Op, Domain) \
-  BuildKernelCreateInfo<                                                 \
-      ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, Domain, Start, End, Type, Op)>
-
 #define KERNEL_CREATE_INFO(Start, Op, Domain) \
   BuildKernelCreateInfo<                      \
       ONNX_OPERATOR_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, Domain, Start, Op)>
@@ -43,39 +39,17 @@ KernelCreateInfo BuildKernelCreateInfo<void>() {
   BuildKernelCreateInfo<                                  \
       ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, Domain, Start, Type, Op)>
 
-#ifdef XNNPACK_FP16_SUPPORTED
-#define CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(provider, domain, startver, endver, name) \
-  class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, domain,             \
-                                                        startver, endver, MLFloat16, name)
-
-#define CLASS_ONNX_OPERATOR_KERNEL_CLASS_NAME_FP16(provider, domain, startver, name)       \
-  class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, domain, startver, \
-                                              MLFloat16, name)
-#else
-#define CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(provider, domain, startver, endver, name)
-#define CLASS_ONNX_OPERATOR_KERNEL_CLASS_NAME_FP16(provider, domain, startver, name)
-#endif
-
 // Layout sensitive operators in NHWC domain
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 7, 9, AveragePool);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 10, 10, AveragePool);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 11, 18, AveragePool);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 19, AveragePool);
-CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 7, 9, AveragePool);
-CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 10, 10, AveragePool);
-CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 11, 18, AveragePool);
-CLASS_ONNX_OPERATOR_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 19, AveragePool);
 
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 1, 10, Conv);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 11, Conv);
-CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 1, 10, Conv);
-CLASS_ONNX_OPERATOR_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 11, Conv);
 
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 1, 10, ConvTranspose);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 11, ConvTranspose);
-CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 1, 10,
-                                                     ConvTranspose);
-CLASS_ONNX_OPERATOR_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 11, ConvTranspose);
 
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 10, uint8_t, QLinearConv);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 10, int8_t, QLinearConv);
@@ -89,44 +63,25 @@ class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSIn
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 13, 17, Resize);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 18, 18, Resize);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 19, Resize);
-CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 10, 10, Resize);
-CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 11, 12, Resize);
-CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 13, 17, Resize);
-CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 18, 18, Resize);
-CLASS_ONNX_OPERATOR_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 19, Resize);
 
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 8, 9, MaxPool);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 10, 10, MaxPool);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 11, 11, MaxPool);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 12, MaxPool);
-CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 8, 9, MaxPool);
-CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 10, 10, MaxPool);
-CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 11, 11, MaxPool);
-CLASS_ONNX_OPERATOR_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 12, MaxPool);
 
 // ONNX operators
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kOnnxDomain, 7, 8, Gemm);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kOnnxDomain, 9, 10, Gemm);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kOnnxDomain, 11, 12, Gemm);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kOnnxDomain, 13, Gemm);
-CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kOnnxDomain, 7, 8, Gemm);
-CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kOnnxDomain, 9, 10, Gemm);
-CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kOnnxDomain, 11, 12, Gemm);
-CLASS_ONNX_OPERATOR_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kOnnxDomain, 13, Gemm);
 
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kOnnxDomain, 1, 8, MatMul);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kOnnxDomain, 9, 12, MatMul);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kOnnxDomain, 13, MatMul);
-CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kOnnxDomain, 1, 8, MatMul);
-CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kOnnxDomain, 9, 12, MatMul);
-CLASS_ONNX_OPERATOR_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kOnnxDomain, 13, MatMul);
 
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kOnnxDomain, 1, 10, Softmax);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kOnnxDomain, 11, 12, Softmax);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kOnnxDomain, 13, Softmax);
-CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kOnnxDomain, 1, 10, Softmax);
-CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kOnnxDomain, 11, 12, Softmax);
-CLASS_ONNX_OPERATOR_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kOnnxDomain, 13, Softmax);
 
 // Internal domain
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kDynamicDomainByCreate, 1, QLinearSoftmax);
@@ -183,43 +138,6 @@ std::unique_ptr<KernelRegistry> RegisterKernels() {
       KERNEL_CREATE_INFO_TYPED(10, int8_t, QLinearConv, kMSInternalNHWCDomain),
 
       KERNEL_CREATE_INFO(1, QLinearSoftmax, kDynamicDomainByCreate),
-
-#ifdef XNNPACK_FP16_SUPPORTED
-      KERNEL_CREATE_INFO_VERSIONED_TYPED(7, 9, MLFloat16, AveragePool, kMSInternalNHWCDomain),
-      KERNEL_CREATE_INFO_VERSIONED_TYPED(10, 10, MLFloat16, AveragePool, kMSInternalNHWCDomain),
-      KERNEL_CREATE_INFO_VERSIONED_TYPED(11, 18, MLFloat16, AveragePool, kMSInternalNHWCDomain),
-      KERNEL_CREATE_INFO_TYPED(19, MLFloat16, AveragePool, kMSInternalNHWCDomain),
-
-      KERNEL_CREATE_INFO_VERSIONED_TYPED(1, 10, MLFloat16, Conv, kMSInternalNHWCDomain),
-      KERNEL_CREATE_INFO_TYPED(11, MLFloat16, Conv, kMSInternalNHWCDomain),
-
-      KERNEL_CREATE_INFO_VERSIONED_TYPED(1, 10, MLFloat16, ConvTranspose, kMSInternalNHWCDomain),
-      KERNEL_CREATE_INFO_TYPED(11, MLFloat16, ConvTranspose, kMSInternalNHWCDomain),
-
-      KERNEL_CREATE_INFO_VERSIONED_TYPED(10, 10, MLFloat16, Resize, kMSInternalNHWCDomain),
-      KERNEL_CREATE_INFO_VERSIONED_TYPED(11, 12, MLFloat16, Resize, kMSInternalNHWCDomain),
-      KERNEL_CREATE_INFO_VERSIONED_TYPED(13, 17, MLFloat16, Resize, kMSInternalNHWCDomain),
-      KERNEL_CREATE_INFO_VERSIONED_TYPED(18, 18, MLFloat16, Resize, kMSInternalNHWCDomain),
-      KERNEL_CREATE_INFO_TYPED(19, MLFloat16, Resize, kMSInternalNHWCDomain),
-
-      KERNEL_CREATE_INFO_VERSIONED_TYPED(8, 9, MLFloat16, MaxPool, kMSInternalNHWCDomain),
-      KERNEL_CREATE_INFO_VERSIONED_TYPED(10, 10, MLFloat16, MaxPool, kMSInternalNHWCDomain),
-      KERNEL_CREATE_INFO_VERSIONED_TYPED(11, 11, MLFloat16, MaxPool, kMSInternalNHWCDomain),
-      KERNEL_CREATE_INFO_TYPED(12, MLFloat16, MaxPool, kMSInternalNHWCDomain),
-
-      KERNEL_CREATE_INFO_VERSIONED_TYPED(7, 8, MLFloat16, Gemm, kOnnxDomain),
-      KERNEL_CREATE_INFO_VERSIONED_TYPED(9, 10, MLFloat16, Gemm, kOnnxDomain),
-      KERNEL_CREATE_INFO_VERSIONED_TYPED(11, 12, MLFloat16, Gemm, kOnnxDomain),
-      KERNEL_CREATE_INFO_TYPED(13, MLFloat16, Gemm, kOnnxDomain),
-
-      KERNEL_CREATE_INFO_VERSIONED_TYPED(1, 8, MLFloat16, MatMul, kOnnxDomain),
-      KERNEL_CREATE_INFO_VERSIONED_TYPED(9, 12, MLFloat16, MatMul, kOnnxDomain),
-      KERNEL_CREATE_INFO_TYPED(13, MLFloat16, MatMul, kOnnxDomain),
-
-      KERNEL_CREATE_INFO_VERSIONED_TYPED(1, 10, MLFloat16, Softmax, kOnnxDomain),
-      KERNEL_CREATE_INFO_VERSIONED_TYPED(11, 12, MLFloat16, Softmax, kOnnxDomain),
-      KERNEL_CREATE_INFO_TYPED(13, MLFloat16, Softmax, kOnnxDomain),
-#endif
   };
 
   for (auto& function_table_entry : function_table) {

--- a/onnxruntime/core/providers/xnnpack/xnnpack_execution_provider.cc
+++ b/onnxruntime/core/providers/xnnpack/xnnpack_execution_provider.cc
@@ -100,14 +100,24 @@ class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kOnnx
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kOnnxDomain, 9, 10, Gemm);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kOnnxDomain, 11, 12, Gemm);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kOnnxDomain, 13, Gemm);
+CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kOnnxDomain, 7, 8, Gemm);
+CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kOnnxDomain, 9, 10, Gemm);
+CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kOnnxDomain, 11, 12, Gemm);
+CLASS_ONNX_OPERATOR_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kOnnxDomain, 13, Gemm);
 
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kOnnxDomain, 1, 8, MatMul);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kOnnxDomain, 9, 12, MatMul);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kOnnxDomain, 13, MatMul);
+CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kOnnxDomain, 1, 8, MatMul);
+CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kOnnxDomain, 9, 12, MatMul);
+CLASS_ONNX_OPERATOR_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kOnnxDomain, 13, MatMul);
 
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kOnnxDomain, 1, 10, Softmax);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kOnnxDomain, 11, 12, Softmax);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kOnnxDomain, 13, Softmax);
+CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kOnnxDomain, 1, 10, Softmax);
+CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kOnnxDomain, 11, 12, Softmax);
+CLASS_ONNX_OPERATOR_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kOnnxDomain, 13, Softmax);
 
 // Internal domain
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kDynamicDomainByCreate, 1, QLinearSoftmax);
@@ -176,6 +186,19 @@ std::unique_ptr<KernelRegistry> RegisterKernels() {
       KERNEL_CREATE_INFO_VERSIONED_TYPED(10, 10, MLFloat16, MaxPool, kMSInternalNHWCDomain),
       KERNEL_CREATE_INFO_VERSIONED_TYPED(11, 11, MLFloat16, MaxPool, kMSInternalNHWCDomain),
       KERNEL_CREATE_INFO_TYPED(12, MLFloat16, MaxPool, kMSInternalNHWCDomain),
+
+      KERNEL_CREATE_INFO_VERSIONED_TYPED(7, 8, MLFloat16, Gemm, kOnnxDomain),
+      KERNEL_CREATE_INFO_VERSIONED_TYPED(9, 10, MLFloat16, Gemm, kOnnxDomain),
+      KERNEL_CREATE_INFO_VERSIONED_TYPED(11, 12, MLFloat16, Gemm, kOnnxDomain),
+      KERNEL_CREATE_INFO_TYPED(13, MLFloat16, Gemm, kOnnxDomain),
+
+      KERNEL_CREATE_INFO_VERSIONED_TYPED(1, 8, MLFloat16, MatMul, kOnnxDomain),
+      KERNEL_CREATE_INFO_VERSIONED_TYPED(9, 12, MLFloat16, MatMul, kOnnxDomain),
+      KERNEL_CREATE_INFO_TYPED(13, MLFloat16, MatMul, kOnnxDomain),
+
+      KERNEL_CREATE_INFO_VERSIONED_TYPED(1, 10, MLFloat16, Softmax, kOnnxDomain),
+      KERNEL_CREATE_INFO_VERSIONED_TYPED(11, 12, MLFloat16, Softmax, kOnnxDomain),
+      KERNEL_CREATE_INFO_TYPED(13, MLFloat16, Softmax, kOnnxDomain),
 #endif
   };
 

--- a/onnxruntime/core/providers/xnnpack/xnnpack_execution_provider.cc
+++ b/onnxruntime/core/providers/xnnpack/xnnpack_execution_provider.cc
@@ -89,6 +89,11 @@ class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSIn
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 13, 17, Resize);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 18, 18, Resize);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 19, Resize);
+CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 10, 10, Resize);
+CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 11, 12, Resize);
+CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 13, 17, Resize);
+CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 18, 18, Resize);
+CLASS_ONNX_OPERATOR_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 19, Resize);
 
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 8, 9, MaxPool);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 10, 10, MaxPool);
@@ -190,6 +195,12 @@ std::unique_ptr<KernelRegistry> RegisterKernels() {
 
       KERNEL_CREATE_INFO_VERSIONED_TYPED(1, 10, MLFloat16, ConvTranspose, kMSInternalNHWCDomain),
       KERNEL_CREATE_INFO_TYPED(11, MLFloat16, ConvTranspose, kMSInternalNHWCDomain),
+
+      KERNEL_CREATE_INFO_VERSIONED_TYPED(10, 10, MLFloat16, Resize, kMSInternalNHWCDomain),
+      KERNEL_CREATE_INFO_VERSIONED_TYPED(11, 12, MLFloat16, Resize, kMSInternalNHWCDomain),
+      KERNEL_CREATE_INFO_VERSIONED_TYPED(13, 17, MLFloat16, Resize, kMSInternalNHWCDomain),
+      KERNEL_CREATE_INFO_VERSIONED_TYPED(18, 18, MLFloat16, Resize, kMSInternalNHWCDomain),
+      KERNEL_CREATE_INFO_TYPED(19, MLFloat16, Resize, kMSInternalNHWCDomain),      
 
       KERNEL_CREATE_INFO_VERSIONED_TYPED(8, 9, MLFloat16, MaxPool, kMSInternalNHWCDomain),
       KERNEL_CREATE_INFO_VERSIONED_TYPED(10, 10, MLFloat16, MaxPool, kMSInternalNHWCDomain),

--- a/onnxruntime/core/providers/xnnpack/xnnpack_execution_provider.cc
+++ b/onnxruntime/core/providers/xnnpack/xnnpack_execution_provider.cc
@@ -200,7 +200,7 @@ std::unique_ptr<KernelRegistry> RegisterKernels() {
       KERNEL_CREATE_INFO_VERSIONED_TYPED(11, 12, MLFloat16, Resize, kMSInternalNHWCDomain),
       KERNEL_CREATE_INFO_VERSIONED_TYPED(13, 17, MLFloat16, Resize, kMSInternalNHWCDomain),
       KERNEL_CREATE_INFO_VERSIONED_TYPED(18, 18, MLFloat16, Resize, kMSInternalNHWCDomain),
-      KERNEL_CREATE_INFO_TYPED(19, MLFloat16, Resize, kMSInternalNHWCDomain),      
+      KERNEL_CREATE_INFO_TYPED(19, MLFloat16, Resize, kMSInternalNHWCDomain),
 
       KERNEL_CREATE_INFO_VERSIONED_TYPED(8, 9, MLFloat16, MaxPool, kMSInternalNHWCDomain),
       KERNEL_CREATE_INFO_VERSIONED_TYPED(10, 10, MLFloat16, MaxPool, kMSInternalNHWCDomain),

--- a/onnxruntime/core/providers/xnnpack/xnnpack_execution_provider.cc
+++ b/onnxruntime/core/providers/xnnpack/xnnpack_execution_provider.cc
@@ -61,6 +61,10 @@ class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSIn
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 10, 10, AveragePool);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 11, 18, AveragePool);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 19, AveragePool);
+CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 7, 9, AveragePool);
+CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 10, 10, AveragePool);
+CLASS_ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 11, 18, AveragePool);
+CLASS_ONNX_OPERATOR_KERNEL_CLASS_NAME_FP16(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 19, AveragePool);
 
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 1, 10, Conv);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kMSInternalNHWCDomain, 11, Conv);
@@ -176,6 +180,11 @@ std::unique_ptr<KernelRegistry> RegisterKernels() {
       KERNEL_CREATE_INFO(1, QLinearSoftmax, kDynamicDomainByCreate),
 
 #ifdef XNNPACK_FP16_SUPPORTED
+      KERNEL_CREATE_INFO_VERSIONED_TYPED(7, 9, MLFloat16, AveragePool, kMSInternalNHWCDomain),
+      KERNEL_CREATE_INFO_VERSIONED_TYPED(10, 10, MLFloat16, AveragePool, kMSInternalNHWCDomain),
+      KERNEL_CREATE_INFO_VERSIONED_TYPED(11, 18, MLFloat16, AveragePool, kMSInternalNHWCDomain),
+      KERNEL_CREATE_INFO_TYPED(19, MLFloat16, AveragePool, kMSInternalNHWCDomain),
+
       KERNEL_CREATE_INFO_VERSIONED_TYPED(1, 10, MLFloat16, Conv, kMSInternalNHWCDomain),
       KERNEL_CREATE_INFO_TYPED(11, MLFloat16, Conv, kMSInternalNHWCDomain),
 

--- a/onnxruntime/test/providers/cpu/math/gemm_test.cc
+++ b/onnxruntime/test/providers/cpu/math/gemm_test.cc
@@ -25,7 +25,7 @@ const constexpr auto run_with_tunable_op = &run_options;
 
 }  // namespace
 
-// Only CUDA, ROCM and CoreML kernels have float 16 support
+// Only CUDA, ROCM, CoreML and XNNPack kernels have float 16 support
 TEST(GemmOpTest, GemmNoTrans_f16) {
 #ifdef USE_CUDA
   int min_cuda_architecture = 530;

--- a/onnxruntime/test/providers/cpu/math/matmul_test.cc
+++ b/onnxruntime/test/providers/cpu/math/matmul_test.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "gtest/gtest.h"
+#include "core/providers/xnnpack/xnnpack_init.h"
 #include "test/providers/provider_test_utils.h"
 #include "test/providers/run_options_config_keys.h"
 #include "test/common/dnnl_op_test_utils.h"
@@ -246,7 +247,7 @@ TEST(MathOpTest, MatMulZeroKInt32Type) {
   RunMatMulZeroKTest<int32_t>();
 }
 
-#if defined(USE_CUDA) || defined(USE_ROCM) || defined(COREML_ENABLE_MLPROGRAM)
+#if defined(USE_CUDA) || defined(USE_ROCM) || defined(COREML_ENABLE_MLPROGRAM) || defined(XNNPACK_FP16_SUPPORTED)
 TEST(MathOpTest, MatMul_Float16) {
 #ifdef USE_CUDA
   int min_cuda_architecture = 530;

--- a/onnxruntime/test/providers/cpu/math/matmul_test.cc
+++ b/onnxruntime/test/providers/cpu/math/matmul_test.cc
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #include "gtest/gtest.h"
-#include "core/providers/xnnpack/xnnpack_init.h"
+
 #include "test/providers/provider_test_utils.h"
 #include "test/providers/run_options_config_keys.h"
 #include "test/common/dnnl_op_test_utils.h"
@@ -247,7 +247,7 @@ TEST(MathOpTest, MatMulZeroKInt32Type) {
   RunMatMulZeroKTest<int32_t>();
 }
 
-#if defined(USE_CUDA) || defined(USE_ROCM) || defined(COREML_ENABLE_MLPROGRAM) || defined(XNNPACK_FP16_SUPPORTED)
+#if defined(USE_CUDA) || defined(USE_ROCM) || defined(COREML_ENABLE_MLPROGRAM) || defined(ENABLE_XNNPACK_FP16_TESTS)
 TEST(MathOpTest, MatMul_Float16) {
 #ifdef USE_CUDA
   int min_cuda_architecture = 530;

--- a/onnxruntime/test/providers/cpu/math/softmax_test.cc
+++ b/onnxruntime/test/providers/cpu/math/softmax_test.cc
@@ -49,7 +49,7 @@ TEST(SoftmaxOperator, Simple) {
   RunTest(x_vals, expected_vals, dimensions);
 }
 
-#if defined(USE_CUDA) || defined(USE_ROCM)
+#if defined(USE_CUDA) || defined(USE_ROCM) || defined(USE_XNNPACK)
 TEST(SoftmaxOperator, Simple_fp16) {
 #ifdef USE_CUDA
   int min_cuda_architecture = 530;

--- a/onnxruntime/test/providers/cpu/math/softmax_test.cc
+++ b/onnxruntime/test/providers/cpu/math/softmax_test.cc
@@ -49,7 +49,7 @@ TEST(SoftmaxOperator, Simple) {
   RunTest(x_vals, expected_vals, dimensions);
 }
 
-#if defined(USE_CUDA) || defined(USE_ROCM) || defined(USE_XNNPACK)
+#if defined(USE_CUDA) || defined(USE_ROCM) || defined(ENABLE_XNNPACK_FP16_TESTS)
 TEST(SoftmaxOperator, Simple_fp16) {
 #ifdef USE_CUDA
   int min_cuda_architecture = 530;

--- a/onnxruntime/test/providers/cpu/nn/conv_fp16_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/conv_fp16_test.cc
@@ -2,10 +2,8 @@
 // Licensed under the MIT License.
 
 #include "core/mlas/inc/mlas.h"
-#include "core/providers/xnnpack/xnnpack_init.h"
 
-// XNNPACK_FP16_SUPPORTED scope is too big, so add USE_XNNPACK to avoid the FP16 tests enabled for other EPs
-#if defined(MLAS_F16VEC_INTRINSICS_SUPPORTED) || defined(COREML_ENABLE_MLPROGRAM) || (defined(USE_XNNPACK) && defined(XNNPACK_FP16_SUPPORTED))
+#if defined(MLAS_F16VEC_INTRINSICS_SUPPORTED) || defined(COREML_ENABLE_MLPROGRAM) || defined(ENABLE_XNNPACK_FP16_TESTS)
 
 #include "gtest/gtest.h"
 #include "test/providers/provider_test_utils.h"

--- a/onnxruntime/test/providers/cpu/nn/pool_fp16_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/pool_fp16_op_test.cc
@@ -3,7 +3,7 @@
 
 #include "core/mlas/inc/mlas.h"
 
-#if defined(MLAS_F16VEC_INTRINSICS_SUPPORTED) || defined(COREML_ENABLE_MLPROGRAM) || defined(XNNPACK_FP16_SUPPORTED)
+#if defined(MLAS_F16VEC_INTRINSICS_SUPPORTED) || defined(COREML_ENABLE_MLPROGRAM) || defined(ENABLE_XNNPACK_FP16_TESTS)
 
 #include "core/providers/cpu/nn/pool.h"
 #include "gtest/gtest.h"

--- a/onnxruntime/test/providers/provider_test_utils.h
+++ b/onnxruntime/test/providers/provider_test_utils.h
@@ -11,7 +11,7 @@
 
 // XNNPACK_FP16_SUPPORTED scope is too big, so add USE_XNNPACK to avoid the FP16 tests enabled for other EPs
 #if defined(USE_XNNPACK) && defined(XNNPACK_FP16_SUPPORTED)
-  #define ENABLE_XNNPACK_FP16_TESTS
+#define ENABLE_XNNPACK_FP16_TESTS
 #endif
 
 namespace onnxruntime {

--- a/onnxruntime/test/providers/provider_test_utils.h
+++ b/onnxruntime/test/providers/provider_test_utils.h
@@ -3,9 +3,16 @@
 
 #pragma once
 
+#include "core/providers/xnnpack/xnnpack_init.h"
+
 #include "test/providers/checkers.h"
 #include "test/providers/op_tester.h"
 #include "test/providers/model_tester.h"
+
+// XNNPACK_FP16_SUPPORTED scope is too big, so add USE_XNNPACK to avoid the FP16 tests enabled for other EPs
+#if defined(USE_XNNPACK) && defined(XNNPACK_FP16_SUPPORTED)
+  #define ENABLE_XNNPACK_FP16_TESTS
+#endif
 
 namespace onnxruntime {
 namespace test {


### PR DESCRIPTION
### Description
Add Gemm, MatMul, Softmax, AveragePool and Resize F16 kernels of XNNPack.
It includes the changes in PR #22381 and make some refactoring to make the code simpler.


### Motivation and Context
The refectory is that XNNPACK_FP16_SUPPORTED is only used in GetCapability().
If the hardware does not support XNNPACK FP16 and the input compute type is FP16, it will not return the capability.
Thus, we don't need to register new kernel functions for FP16 and code becomes simpler.

XNNPACK doesn't support mobile test on x86/x86_64 architecture, for example, iOS pipeline on ADO in CL.


