### PR TITLE
[WebGPU EP] Remove unused variable.

### DIFF
--- a/onnxruntime/core/providers/webgpu/webgpu_context.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.h
@@ -119,7 +119,6 @@ class WebGpuContext final {
   void WriteTimestamp(uint32_t query_index);
 
   TimestampQueryType query_type_;
-  uint64_t query_time_base_;
   wgpu::QuerySet query_set_;
   wgpu::Buffer query_resolve_buffer_;
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Remove unused variable.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix Android build error:

```
onnxruntime/onnxruntime/core/providers/webgpu/webgpu_context.h:122:12: error: private field 'query_time_base_' is not used [-Werror,-Wunused-private-field]
  122 |   uint64_t query_time_base_;
      |            ^
1 error generated.
```
