### PR TITLE
Fix training artifacts for 2GB+ models and `MSELoss`

### DIFF
--- a/orttraining/orttraining/python/training/onnxblock/blocks.py
+++ b/orttraining/orttraining/python/training/onnxblock/blocks.py
@@ -54,8 +54,10 @@ class Block(ABC):
         output = self.build(*args, **kwargs)
 
         if accessor._GLOBAL_ACCESSOR.has_path:
+            # `save` will destructively access any external data
+            copied_model = copy.deepcopy(accessor._GLOBAL_ACCESSOR.model)
             onnx.save(
-                accessor._GLOBAL_ACCESSOR.model,
+                copied_model,
                 self.temp_onnx_file_path,
                 save_as_external_data=True,
                 all_tensors_to_one_file=True,

--- a/orttraining/orttraining/test/python/orttraining_test_ort_apis_onnxblock.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ort_apis_onnxblock.py
@@ -1159,7 +1159,8 @@ def test_generate_artifacts_external_data_one_file():
         assert os.path.exists(os.path.join(temp_dir, "checkpoint"))
 
 
-def test_generate_artifacts_external_data_separate_files():
+@pytest.mark.parametrize("loss", [loss_t for loss_t in artifacts.LossType])
+def test_generate_artifacts_external_data_separate_files(loss):
     with tempfile.TemporaryDirectory() as temp_dir:
         _, simple_net = _get_models("cpu", 32, 28, 10, 10)
 
@@ -1176,7 +1177,7 @@ def test_generate_artifacts_external_data_separate_files():
         artifacts.generate_artifacts(
             os.path.join(temp_dir, "simple_net.onnx"),
             requires_grad=requires_grad_params,
-            loss=artifacts.LossType.CrossEntropyLoss,
+            loss=loss,
             optimizer=artifacts.OptimType.AdamW,
             artifact_directory=temp_dir,
         )


### PR DESCRIPTION
### Description
`generate_artifacts` fails when creating training artifacts for a model using external data and `MSELoss`.

The use of a global base model when creating new training `Blocks` and `onnx.save` destroying any external data means any loss block (e.g. `MSELoss`) that builds more than one sub-`Block` will fail validation due to missing external data and raise an exception.

### Fix
Saving using a deep copy of the global model circumvents this at the cost of holding 2x the model size in memory.

### Other Implementations
An alternative approach using less memory would load the on-disk external data before it is deleted in `Block::__del__` and insert the appropriate fields into the global `ModelProto`.
This seems a bit brittle due to the coupling to the specific way external data is destructively accessed in `onnx.save`. If there exists a non-modifying save in the `onnx` repo it would be ideal to use that in `Block::__call__` instead.

### Motivation and Context
Fixes `generate_artifacts` bug reported in https://github.com/microsoft/onnxruntime/issues/22411

