### PR TITLE
Update eps.md about Python wheels for MIGraphX and ROCm

### DIFF
--- a/docs/build/eps.md
+++ b/docs/build/eps.md
@@ -548,10 +548,16 @@ See more information on the MIGraphX Execution Provider [here](../execution-prov
 #### Linux
 
 ```bash
-./build.sh --config <Release|Debug|RelWithDebInfo> --use_migraphx --migraphx_home <path to MIGraphX home>
+./build.sh --config <Release|Debug|RelWithDebInfo> --parallel --use_migraphx --migraphx_home <path to MIGraphX home>
 ```
 
 Dockerfile instructions are available [here](https://github.com/microsoft/onnxruntime/blob/main/dockerfiles#migraphx).
+
+#### Build Phython Wheel
+
+`./build.sh --config Release --build --build_wheel --parallel --use_migraphx --migraphx_home /opt/rocm`
+
+---
 
 ## AMD ROCm
 
@@ -569,10 +575,16 @@ See more information on the ROCm Execution Provider [here](../execution-provider
 #### Linux
 
 ```bash
-./build.sh --config <Release|Debug|RelWithDebInfo> --use_rocm --rocm_home <path to ROCm home>
+./build.sh --config <Release|Debug|RelWithDebInfo> --parallel --use_rocm --rocm_home <path to ROCm home>
 ```
 
 Dockerfile instructions are available [here](https://github.com/microsoft/onnxruntime/tree/main/dockerfiles#rocm).
+
+#### Build Phython Wheel
+
+`./build.sh --config Release --build --build_wheel --parallel --use_rocm --rocm_home /opt/rocm`
+
+---
 
 ## NNAPI
 

--- a/docs/build/eps.md
+++ b/docs/build/eps.md
@@ -557,6 +557,8 @@ Dockerfile instructions are available [here](https://github.com/microsoft/onnxru
 
 `./build.sh --config Release --build --build_wheel --parallel --use_migraphx --migraphx_home /opt/rocm`
 
+Then the python wheels(*.whl) could be found at ```./build/Linux/Release/dist```.
+
 ---
 
 ## AMD ROCm
@@ -583,6 +585,8 @@ Dockerfile instructions are available [here](https://github.com/microsoft/onnxru
 #### Build Phython Wheel
 
 `./build.sh --config Release --build --build_wheel --parallel --use_rocm --rocm_home /opt/rocm`
+
+Then the python wheels(*.whl) could be found at ```./build/Linux/Release/dist```.
 
 ---
 


### PR DESCRIPTION
### Description
Update eps.md about Python wheels for MIGraphX and ROCm



### Motivation and Context
There was no instructions to show how to build python wheels for MIGraphX and ROCm backends. It is neccesary to add these command examples.


