### PR TITLE
allow to set a list for specifying force CPU nodes

### DIFF
--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.h
@@ -30,17 +30,22 @@ struct WebGpuExecutionProviderInfo {
         uniform_buffer_cache_mode{},
         query_resolve_buffer_cache_mode{},
         default_buffer_cache_mode{} {}
+  WebGpuExecutionProviderInfo(WebGpuExecutionProviderInfo&&) = default;
+  WebGpuExecutionProviderInfo& operator=(WebGpuExecutionProviderInfo&&) = default;
+  ORT_DISALLOW_COPY_AND_ASSIGNMENT(WebGpuExecutionProviderInfo);
+
   DataLayout data_layout;
   bool enable_graph_capture;
   webgpu::BufferCacheMode storage_buffer_cache_mode;
   webgpu::BufferCacheMode uniform_buffer_cache_mode;
   webgpu::BufferCacheMode query_resolve_buffer_cache_mode;
   webgpu::BufferCacheMode default_buffer_cache_mode;
+  std::vector<std::string> force_cpu_node_names;
 };
 
 class WebGpuExecutionProvider : public IExecutionProvider {
  public:
-  WebGpuExecutionProvider(int context_id, webgpu::WebGpuContext& context, const WebGpuExecutionProviderInfo& info);
+  WebGpuExecutionProvider(int context_id, webgpu::WebGpuContext& context, WebGpuExecutionProviderInfo&& info);
   ~WebGpuExecutionProvider() override;
 
   std::vector<std::unique_ptr<ComputeCapability>> GetCapability(
@@ -77,10 +82,11 @@ class WebGpuExecutionProvider : public IExecutionProvider {
   void IncrementRegularRunCountBeforeGraphCapture();
   int context_id_;
   webgpu::WebGpuContext& context_;
+  webgpu::WebGpuProfiler* profiler_ = nullptr;
   DataLayout preferred_data_layout_;
+  std::vector<std::string> force_cpu_node_names_;
   bool enable_graph_capture_ = false;
   bool is_graph_captured_ = false;
-  webgpu::WebGpuProfiler* profiler_ = nullptr;
   int regular_run_count_before_graph_capture_ = 0;
   const int min_num_runs_before_cuda_graph_capture_ = 1;  // required min regular runs before graph capture for the necessary memory allocations.
 };

--- a/onnxruntime/core/providers/webgpu/webgpu_provider_options.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_provider_options.h
@@ -24,6 +24,8 @@ constexpr const char* kDefaultBufferCacheMode = "WebGPU:defaultBufferCacheMode";
 
 constexpr const char* kValidationMode = "WebGPU:validationMode";
 
+constexpr const char* kForceCpuNodeNames = "WebGPU:forceCpuNodeNames";
+
 // The following are the possible values for the provider options.
 
 constexpr const char* kPreferredLayout_NCHW = "NCHW";


### PR DESCRIPTION
### Description

This change allows to set EP option "forceCpuNodeNames" in which includes a list of node names that will always be running on CPU.

Usage example:

```diff
            opt.executionProviders[0] = {
                name: "webgpu",
                validationMode: 'wgpuOnly',
                storageBufferCacheMode: 'bucket',
+               // force node "/model/embed_tokens/Gather" to be put on CPU
+               forceCpuNodeNames: "/model/embed_tokens/Gather"
            };

```