### PR TITLE
Disable BrowserStack testing stage

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar-test.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar-test.yml
@@ -72,6 +72,7 @@ jobs:
       stop: true
 
   # we run e2e tests on one older device (Pixel 3) and one newer device (Galaxy 23)
+  # disabling this step until BrowserStack account issues are resolved
   - script: |
       set -e -x
       pip install requests
@@ -83,6 +84,7 @@ jobs:
     displayName: Run E2E tests using Browserstack
     workingDirectory: $(Build.BinariesDirectory)/android_test/android/app/build/outputs/apk
     timeoutInMinutes: 15
+    enabled: false
     env:
       BROWSERSTACK_ID: $(browserstack_username)
       BROWSERSTACK_TOKEN: $(browserstack_access_key)


### PR DESCRIPTION
### Description
We are seeing this [packaging pipeline](https://aiinfra.visualstudio.com/Lotus/_build?definitionId=940&_a=summary) fail because we are running into BrowserStack account issues. Disabling this step until issues are resolved



