### PR TITLE
Fix big models exception caused by timm upgrade

### DIFF
--- a/onnxruntime/python/tools/transformers/models/stable_diffusion/requirements.txt
+++ b/onnxruntime/python/tools/transformers/models/stable_diffusion/requirements.txt
@@ -9,7 +9,7 @@ packaging
 protobuf==3.20.3
 psutil
 sympy
-controlnet_aux==0.0.7
+controlnet_aux==0.0.9
 # The following are for SDXL
 optimum==1.20.0
 safetensors

--- a/onnxruntime/python/tools/transformers/models/stable_diffusion/requirements.txt
+++ b/onnxruntime/python/tools/transformers/models/stable_diffusion/requirements.txt
@@ -15,4 +15,5 @@ optimum==1.20.0
 safetensors
 invisible_watermark
 # newer version of opencv-python migth encounter module 'cv2.dnn' has no attribute 'DictValue' error
+opencv-python==4.8.0.76
 opencv-python-headless==4.8.0.76

--- a/onnxruntime/python/tools/transformers/models/stable_diffusion/requirements.txt
+++ b/onnxruntime/python/tools/transformers/models/stable_diffusion/requirements.txt
@@ -9,10 +9,10 @@ packaging
 protobuf==3.20.3
 psutil
 sympy
-controlnet_aux==0.0.9
+controlnet_aux==0.0.7
 # The following are for SDXL
 optimum==1.20.0
 safetensors
 invisible_watermark
 # newer version of opencv-python migth encounter module 'cv2.dnn' has no attribute 'DictValue' error
-opencv-python==4.8.0.74
+opencv-python-headless==4.8.0.76

--- a/onnxruntime/python/tools/transformers/models/stable_diffusion/requirements.txt
+++ b/onnxruntime/python/tools/transformers/models/stable_diffusion/requirements.txt
@@ -15,5 +15,5 @@ optimum==1.20.0
 safetensors
 invisible_watermark
 # newer version of opencv-python migth encounter module 'cv2.dnn' has no attribute 'DictValue' error
-opencv-python==4.8.0.76
-opencv-python-headless==4.8.0.76
+opencv-python==4.8.0.74
+opencv-python-headless==4.8.0.74


### PR DESCRIPTION
### Description
Today, stable diffusion stage failed due to there's a upgrade in timm. (https://pypi.org/project/timm/1.0.10/)
controlnet_aux depends on it.
And its latest version limit the timm version less than 0.6.7.
So upgrading controlnet_aux can solve it.
And controlnet_aux uses opencv-python-headless, pin opencv-python-headless to 4.8.0.74 too.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


