### PR TITLE
fix LayerNorm f16 CPU implementation

### DIFF
--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
@@ -234,10 +234,10 @@ Status LayerNormImpl::PrePack(const Tensor& tensor, int input_idx, AllocatorPtr 
 
   is_packed = false;
   if (input_idx == 1) {  // scale
-    prepacked_scale_fp32_size_ = tensor.Shape().Size();
+    prepacked_scale_fp32_size_ = static_cast<size_t>(tensor.Shape().Size());
     ConvertMLFloat16ToFloatIfNeeded(tensor, alloc, prepacked_scale_fp32_data_, is_packed);
   } else if (input_idx == 2) {  // bias
-    prepacked_bias_fp32_size_ = tensor.Shape().Size();
+    prepacked_bias_fp32_size_ = static_cast<size_t>(tensor.Shape().Size());
     ConvertMLFloat16ToFloatIfNeeded(tensor, alloc, prepacked_bias_fp32_data_, is_packed);
   }
 

--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
@@ -179,8 +179,8 @@ Status LayerNormImpl::ComputeImpl(OpKernelContext* p_ctx, int64_t orig_axis, flo
   const T* bias_data = (simplified || nullptr == bias) ? nullptr : bias->Data<T>();
 
   const TensorShape& x_shape = X->Shape();
-  size_t scale_size = scale ? scale->Shape().Size() : prepacked_scale_fp32_size_;
-  size_t bias_size = bias ? bias->Shape().Size() : prepacked_bias_fp32_size_;
+  size_t scale_size = scale ? static_cast<size_t>(scale->Shape().Size()) : prepacked_scale_fp32_size_;
+  size_t bias_size = bias ? static_cast<size_t>(bias->Shape().Size()) : prepacked_bias_fp32_size_;
   Tensor* Y = p_ctx->Output(0, x_shape);
   T* Y_data = Y->MutableData<T>();
 

--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.h
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.h
@@ -26,7 +26,7 @@ class LayerNormImpl : public OpKernel {
       const T* scale_data,
       const TensorShape& scale_shape,
       const T* bias_data,
-      const TensorShape& bias_shape,
+      const TensorShape* bias_shape,
       T* Y_data,
       U* mean_data,
       U* inv_std_dev,
@@ -65,6 +65,7 @@ class LayerNormImpl : public OpKernel {
   const bool contrib_op_;
   mutable IAllocatorUniquePtr<float> scale_fp32_;
   mutable IAllocatorUniquePtr<float> bias_fp32_;
+  mutable OrtMutex mutex_;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.h
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.h
@@ -24,9 +24,9 @@ class LayerNormImpl : public OpKernel {
       const T* X_data,
       const TensorShape& x_shape,
       const T* scale_data,
-      const TensorShape& scale_shape,
+      size_t scale_size,
       const T* bias_data,
-      const TensorShape* bias_shape,
+      size_t bias_size,
       T* Y_data,
       U* mean_data,
       U* inv_std_dev,
@@ -63,9 +63,10 @@ class LayerNormImpl : public OpKernel {
   float epsilon_;
   const bool simplified_;
   const bool contrib_op_;
-  mutable IAllocatorUniquePtr<float> scale_fp32_;
-  mutable IAllocatorUniquePtr<float> bias_fp32_;
-  mutable OrtMutex mutex_;
+  IAllocatorUniquePtr<float> prepacked_scale_fp32_data_;
+  size_t prepacked_scale_fp32_size_;
+  IAllocatorUniquePtr<float> prepacked_bias_fp32_data_;
+  size_t prepacked_bias_fp32_size_;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/test/contrib_ops/layer_norm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/layer_norm_op_test.cc
@@ -151,6 +151,20 @@ TEST(LayerNormTest, LayerNorm_Scale_Float16InputScaleOutput) {
             kNnapiExecutionProvider, kQnnExecutionProvider, kCoreMLExecutionProvider});
 }
 
+TEST(LayerNormTest, LayerNorm_Scale_Float16InputScaleOutput_Initializers) {
+  OpTester test("LayerNormalization");
+  test.AddAttribute<float>("epsilon", 1e-05f);
+
+  std::vector<int64_t> dims{2, 2, 2};
+  test.AddInput<MLFloat16>("x", dims, ToFloat16({-10.264f, 8.6453f, 43.1561f, -0.641239f, -8.2164f, 0.11412f, 41.3156f, 3.0458f}));
+  test.AddInput<MLFloat16>("gamma", {2}, ToFloat16({-0.6953f, 5.1824f}), true);
+  test.AddOutput<MLFloat16>("output", dims, ToFloat16({0.6953f, 5.1824f, -0.6953f, -5.1824f, 0.6953f, 5.1824f, -0.6953f, -5.1824f}));
+  // TRT, DNNL, OpenVINO and NNAPI, CoreML don't support this combination of datatypes
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kTensorrtExecutionProvider, kDnnlExecutionProvider, kOpenVINOExecutionProvider,
+            kNnapiExecutionProvider, kQnnExecutionProvider, kCoreMLExecutionProvider});
+}
+
 TEST(LayerNormTest, LayerNorm_Scale_Bias) {
   OpTester test("LayerNormalization");
   test.AddAttribute<float>("epsilon", 1e-05f);
@@ -204,6 +218,21 @@ TEST(LayerNormTest, LayerNorm_Scale_Bias_Float16InputScaleBiasOutput) {
   test.AddInput<MLFloat16>("x", dims, ToFloat16({1.2416f, 0.946123f, 13.1685f, 0.36423f, 21.145f, 0.03941f}));
   test.AddInput<MLFloat16>("gamma", {2}, ToFloat16({-0.6953f, 5.1824f}));
   test.AddInput<MLFloat16>("bias", {2}, ToFloat16({0.6435f, -0.3964f}));
+  test.AddOutput<MLFloat16>("output", dims, ToFloat16({-0.0516f, -5.5776f, -0.0518f, -5.5788f, -0.0518f, -5.5788f}));
+  // TRT, DNNL, OpenVINO and NNAPI, CoreML don't support this combination of datatypes
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kTensorrtExecutionProvider, kDnnlExecutionProvider, kOpenVINOExecutionProvider,
+            kNnapiExecutionProvider, kQnnExecutionProvider, kCoreMLExecutionProvider});
+}
+
+TEST(LayerNormTest, LayerNorm_Scale_Bias_Float16InputScaleBiasOutput_Initializers) {
+  OpTester test("LayerNormalization");
+  test.AddAttribute<float>("epsilon", 1e-05f);
+
+  std::vector<int64_t> dims{1, 3, 2};
+  test.AddInput<MLFloat16>("x", dims, ToFloat16({1.2416f, 0.946123f, 13.1685f, 0.36423f, 21.145f, 0.03941f}));
+  test.AddInput<MLFloat16>("gamma", {2}, ToFloat16({-0.6953f, 5.1824f}), true);
+  test.AddInput<MLFloat16>("bias", {2}, ToFloat16({0.6435f, -0.3964f}), true);
   test.AddOutput<MLFloat16>("output", dims, ToFloat16({-0.0516f, -5.5776f, -0.0518f, -5.5788f, -0.0518f, -5.5788f}));
   // TRT, DNNL, OpenVINO and NNAPI, CoreML don't support this combination of datatypes
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",

--- a/onnxruntime/test/onnx/microbenchmark/layer_normalization.cc
+++ b/onnxruntime/test/onnx/microbenchmark/layer_normalization.cc
@@ -111,8 +111,8 @@ static void BM_LayerNormalization(benchmark::State& state) {
   OrtMemoryInfo memory_info(onnxruntime::CPU, OrtAllocatorType::OrtArenaAllocator);
   AllocatorPtr alloc = std::make_shared<CPUAllocator>(memory_info);
   for (auto _ : state) {
-    auto status = layer_norm_impl.ComputeWithoutContext(x_data, x_shape, scale_data, scale_shape, bias_data,
-                                                        &bias_shape, Y_data, mean_data, inv_std_dev_data,
+    auto status = layer_norm_impl.ComputeWithoutContext(x_data, x_shape, scale_data, scale_shape.Size(), bias_data,
+                                                        bias_shape.Size(), Y_data, mean_data, inv_std_dev_data,
                                                         thread_pool.get(), axis, epsilon, simplified, alloc);
     if (!status.IsOK()) {
       std::cout << "ComputeWithoutContext status not OK: " << status.ErrorMessage() << std::endl;

--- a/onnxruntime/test/onnx/microbenchmark/layer_normalization.cc
+++ b/onnxruntime/test/onnx/microbenchmark/layer_normalization.cc
@@ -111,9 +111,9 @@ static void BM_LayerNormalization(benchmark::State& state) {
   OrtMemoryInfo memory_info(onnxruntime::CPU, OrtAllocatorType::OrtArenaAllocator);
   AllocatorPtr alloc = std::make_shared<CPUAllocator>(memory_info);
   for (auto _ : state) {
-    auto status = layer_norm_impl.ComputeWithoutContext(x_data, x_shape, scale_data, scale_shape, bias_data, bias_shape,
-                                                        Y_data, mean_data, inv_std_dev_data, thread_pool.get(), axis,
-                                                        epsilon, simplified, alloc);
+    auto status = layer_norm_impl.ComputeWithoutContext(x_data, x_shape, scale_data, scale_shape, bias_data,
+                                                        &bias_shape, Y_data, mean_data, inv_std_dev_data,
+                                                        thread_pool.get(), axis, epsilon, simplified, alloc);
     if (!status.IsOK()) {
       std::cout << "ComputeWithoutContext status not OK: " << status.ErrorMessage() << std::endl;
       break;

--- a/onnxruntime/test/onnx/microbenchmark/layer_normalization.cc
+++ b/onnxruntime/test/onnx/microbenchmark/layer_normalization.cc
@@ -111,9 +111,20 @@ static void BM_LayerNormalization(benchmark::State& state) {
   OrtMemoryInfo memory_info(onnxruntime::CPU, OrtAllocatorType::OrtArenaAllocator);
   AllocatorPtr alloc = std::make_shared<CPUAllocator>(memory_info);
   for (auto _ : state) {
-    auto status = layer_norm_impl.ComputeWithoutContext(x_data, x_shape, scale_data, scale_shape.Size(), bias_data,
-                                                        bias_shape.Size(), Y_data, mean_data, inv_std_dev_data,
-                                                        thread_pool.get(), axis, epsilon, simplified, alloc);
+    auto status = layer_norm_impl.ComputeWithoutContext(x_data,
+                                                        x_shape,
+                                                        scale_data,
+                                                        static_cast<size_t>(scale_shape.Size()),
+                                                        bias_data,
+                                                        static_cast<size_t>(bias_shape.Size()),
+                                                        Y_data,
+                                                        mean_data,
+                                                        inv_std_dev_data,
+                                                        thread_pool.get(),
+                                                        axis,
+                                                        epsilon,
+                                                        simplified,
+                                                        alloc);
     if (!status.IsOK()) {
       std::cout << "ComputeWithoutContext status not OK: " << status.ErrorMessage() << std::endl;
       break;


### PR DESCRIPTION
### Description

The recent PR #22223 introduced 2 bugs in implementation of CPU LayerNorm f16:
- possible access to nullptr for bias
  `const TensorShape& bias_shape = bias->Shape();` will crash when `bias` does not exist. (amazingly seems this one is not coverred by any test case)
   - fix: guard with pointer check
- a racing condition inside ComputeJob
  `ComputeJob()` is dispatched to threadpool and it internally tries to modify `LayerNormImpl::scale_fp32_` and `LayerNormImpl::bias_fp32_`, which are `std::unique_ptr`s and are not thread-safe.
   - fix: move the modification of `LayerNormImpl::scale_fp32_` and `LayerNormImpl::bias_fp32_` out of `ComputeJob()` and put into `LayerNormImpl::ComputeWithoutContext()`. It may still have racing condition because `ConcurrentRunSupported` is set to `true` for CPU EP. Added an OrtMutex.

This should fixes the recent flaky tests as well.