### PR TITLE
[StableDiffusion] Pin huggingface_hub to 0.25.2 due to breaking changes in 0.26.0

### DIFF
--- a/onnxruntime/python/tools/transformers/models/stable_diffusion/requirements.txt
+++ b/onnxruntime/python/tools/transformers/models/stable_diffusion/requirements.txt
@@ -1,3 +1,4 @@
+huggingface_hub==0.25.2
 diffusers==0.28.0
 transformers==4.41.2
 numpy>=1.24.1


### PR DESCRIPTION
### Description
Pin huggingface_hub to 0.25.2 due to breaking changes in 0.26.0.



### Motivation and Context
We depend on `diffusers==0.28.0`, which [depends on](https://github.com/huggingface/diffusers/blob/v0.28.0-release/setup.py#L104) `huggingface_hub>=0.20.2`. There are breaking changes with the latest huggingface_hub 0.26.0 release that break our Big Models pipeline:
[Release v0.26.0: Multi-tokens support, conversational VLMs and quality of life improvements · huggingface/huggingface_hub](https://github.com/huggingface/huggingface_hub/releases/tag/v0.26.0)

Specifically, the breaking changes to `cached_download()` cause our pipeline to fail.
![image](https://github.com/user-attachments/assets/c1d15c7e-9a5d-4ef3-8d1b-35bde0a2ca82)


