### PR TITLE
[webgpu-native] Fix CI errors on MacOS

### DIFF
--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -571,17 +571,21 @@ void WebGpuContext::EndProfiling(TimePoint /* tp */, profiling::Events& events, 
   // This function is called when no active inference is ongoing.
   ORT_ENFORCE(!is_profiling_, "Profiling is ongoing in an inference run.");
 
-  // When profiling is disabled, should never run into this function.
-  ORT_ENFORCE(query_type_ != TimestampQueryType::None, "Timestamp query is not enabled.");
+  if (query_type_ != TimestampQueryType::None) {
+    // No pending kernels or queries should be present at this point. They should have been collected in CollectProfilingData.
+    ORT_ENFORCE(pending_kernels_.empty() && pending_queries_.empty(), "Pending kernels or queries are not empty.");
 
-  // No pending kernels or queries should be present at this point. They should have been collected in CollectProfilingData.
-  ORT_ENFORCE(pending_kernels_.empty() && pending_queries_.empty(), "Pending kernels or queries are not empty.");
+    events.insert(events.end(),
+                  std::make_move_iterator(cached_events.begin()),
+                  std::make_move_iterator(cached_events.end()));
 
-  events.insert(events.end(),
-                std::make_move_iterator(cached_events.begin()),
-                std::make_move_iterator(cached_events.end()));
-
-  cached_events.clear();
+    cached_events.clear();
+  } else {
+    LOGS_DEFAULT(WARNING) << "TimestampQuery is not supported in this device. Zero is presented.";
+    const std::unordered_map<std::string, std::string>& event_args = {};
+    profiling::EventRecord event(profiling::API_EVENT, -1, -1, "", 0, 0, event_args);
+    events.emplace_back(std::move(event));
+  }
 }
 
 void WebGpuContext::Flush() {

--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -581,10 +581,7 @@ void WebGpuContext::EndProfiling(TimePoint /* tp */, profiling::Events& events, 
 
     cached_events.clear();
   } else {
-    LOGS_DEFAULT(WARNING) << "TimestampQuery is not supported in this device. Zero is presented.";
-    const std::unordered_map<std::string, std::string>& event_args = {};
-    profiling::EventRecord event(profiling::API_EVENT, -1, -1, "", 0, 0, event_args);
-    events.emplace_back(std::move(event));
+    LOGS_DEFAULT(WARNING) << "TimestampQuery is not supported in this device.";
   }
 }
 

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -740,7 +740,8 @@ TEST(InferenceSessionTests, CheckRunProfilerWithSessionOptions2) {
     }
   }
 
-#if (defined(USE_ROCM) && defined(ENABLE_ROCM_PROFILING)) || defined(USE_WEBGPU)
+// Note that the apple device is a paravirtual device which may not support webgpu timestamp query. So skip the check on it.
+#if (defined(USE_ROCM) && defined(ENABLE_ROCM_PROFILING)) || (defined(USE_WEBGPU) && !defined(__APPLE__))
   ASSERT_TRUE(has_api_info);
 #endif
 }


### PR DESCRIPTION
The MacOS device on CI is an Apple Paravirtual device, which may not support TimestampQuery. In this PR, If TimestampQuery is not supported, a warning is printed to not block profiling cpu data.

