### PR TITLE
update pipeline name list in run_CIs_for_external_pr.py

### DIFF
--- a/tools/python/run_CIs_for_external_pr.py
+++ b/tools/python/run_CIs_for_external_pr.py
@@ -35,20 +35,22 @@ def get_pipeline_names():
         # mac
         "MacOS CI Pipeline",
         # training
-        "orttraining-amd-gpu-ci-pipeline",
         "orttraining-linux-ci-pipeline",
         "orttraining-linux-gpu-ci-pipeline",
-        "orttraining-ortmodule-distributed",
         # checks
         "onnxruntime-binary-size-checks-ci-pipeline",
         # big models
         "Big Models",
         # android
         "Linux Android Emulator QNN CI Pipeline",
-        # not currently required, but running ensures we're hitting all mobile platforms
+        # not currently required, but running these like internal PRs.
         "Android CI Pipeline",
         "iOS CI Pipeline",
         "ONNX Runtime React Native CI Pipeline",
+        "CoreML CI Pipeline",
+        "Linux DNNL CI Pipeline",
+        "Linux MIGraphX CI Pipeline",
+        "Linux ROCm CI Pipeline",
     ]
 
     return pipelines


### PR DESCRIPTION
### Description
Update list of CI pipelines to trigger for external PRs.

### Motivation and Context
The pipelines triggered for external PRs are not consistent with internal PRs. 


