### PR TITLE
allow build flag --use_external_dawn

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -148,6 +148,7 @@ option(onnxruntime_TVM_USE_HASH "Build ipp-crypto library for support hash algor
 option(onnxruntime_USE_XNNPACK "Build with XNNPACK support. Provides an alternative math library on ARM, WebAssembly and x86." OFF)
 option(onnxruntime_USE_WEBNN "Build with WebNN support. Enable hardware acceleration in web browsers." OFF)
 option(onnxruntime_USE_WEBGPU "Build with WebGPU support. Enable WebGPU via C/C++ interface." OFF)
+option(onnxruntime_USE_EXTERNAL_DAWN "Build with treating Dawn as external dependency. Will not link Dawn at build time." OFF)
 
 # Options related to reducing the binary size produced by the build
 # XNNPACK EP requires the internal NHWC contrib ops to be available, so this option must be OFF when onnxruntime_USE_XNNPACK is ON
@@ -948,6 +949,9 @@ if (onnxruntime_USE_WEBGPU)
   list(APPEND ORT_PROVIDER_FLAGS -DUSE_WEBGPU=1)
   list(APPEND ORT_PROVIDER_CMAKE_FLAGS -Donnxruntime_USE_WEBGPU=1)
   list(APPEND ONNXRUNTIME_PROVIDER_NAMES webgpu)
+  if (onnxruntime_USE_EXTERNAL_DAWN)
+    list(APPEND ORT_PROVIDER_FLAGS -DUSE_EXTERNAL_DAWN=1)
+  endif()
 endif()
 if (onnxruntime_USE_CANN)
     list(APPEND ORT_PROVIDER_FLAGS  -DUSE_CANN=1)

--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -662,7 +662,10 @@ if (onnxruntime_USE_WEBGPU)
 
   onnxruntime_fetchcontent_makeavailable(dawn)
 
-  list(APPEND onnxruntime_EXTERNAL_LIBRARIES dawn::dawn_native dawn::dawn_proc)
+  if (NOT onnxruntime_USE_EXTERNAL_DAWN)
+    list(APPEND onnxruntime_EXTERNAL_LIBRARIES dawn::dawn_native)
+  endif()
+  list(APPEND onnxruntime_EXTERNAL_LIBRARIES dawn::dawn_proc)
 endif()
 
 set(onnxruntime_LINK_DIRS)

--- a/cmake/onnxruntime_providers_webgpu.cmake
+++ b/cmake/onnxruntime_providers_webgpu.cmake
@@ -22,6 +22,9 @@
   onnxruntime_add_static_library(onnxruntime_providers_webgpu ${onnxruntime_providers_webgpu_cc_srcs})
   onnxruntime_add_include_to_target(onnxruntime_providers_webgpu
     onnxruntime_common dawn::dawncpp_headers dawn::dawn_headers onnx onnx_proto flatbuffers::flatbuffers Boost::mp11 safeint_interface)
-  target_link_libraries(onnxruntime_providers_webgpu dawn::dawn_native dawn::dawn_proc)
+  if (NOT onnxruntime_USE_EXTERNAL_DAWN)
+    target_link_libraries(onnxruntime_providers_webgpu dawn::dawn_native)
+  endif()
+  target_link_libraries(onnxruntime_providers_webgpu dawn::dawn_proc)
 
   set_target_properties(onnxruntime_providers_webgpu PROPERTIES FOLDER "ONNXRuntime")

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -523,6 +523,9 @@ set (onnxruntime_global_thread_pools_test_SRC
           ${ONNXRUNTIME_GLOBAL_THREAD_POOLS_TEST_SRC_DIR}/test_main.cc
           ${ONNXRUNTIME_GLOBAL_THREAD_POOLS_TEST_SRC_DIR}/test_inference.cc)
 
+set (onnxruntime_webgpu_external_dawn_test_SRC
+          ${TEST_SRC_DIR}/webgpu/external_dawn/main.cc)
+
 # tests from lowest level library up.
 # the order of libraries should be maintained, with higher libraries being added first in the list
 
@@ -1414,6 +1417,17 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
               LIBS ${onnxruntime_shared_lib_test_LIBS}
               DEPENDS ${all_dependencies}
       )
+    endif()
+
+    if (onnxruntime_USE_WEBGPU AND onnxruntime_USE_EXTERNAL_DAWN)
+      AddTest(DYN
+              TARGET onnxruntime_webgpu_external_dawn_test
+              SOURCES ${onnxruntime_webgpu_external_dawn_test_SRC}
+              LIBS ${onnxruntime_shared_lib_test_LIBS}
+              DEPENDS ${all_dependencies}
+      )
+      onnxruntime_add_include_to_target(onnxruntime_webgpu_external_dawn_test dawn::dawncpp_headers dawn::dawn_headers)
+      target_link_libraries(onnxruntime_webgpu_external_dawn_test PRIVATE dawn::dawn_native)
     endif()
   endif()
 

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -1418,17 +1418,6 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
               DEPENDS ${all_dependencies}
       )
     endif()
-
-    if (onnxruntime_USE_WEBGPU AND onnxruntime_USE_EXTERNAL_DAWN)
-      AddTest(DYN
-              TARGET onnxruntime_webgpu_external_dawn_test
-              SOURCES ${onnxruntime_webgpu_external_dawn_test_SRC}
-              LIBS ${onnxruntime_shared_lib_test_LIBS}
-              DEPENDS ${all_dependencies}
-      )
-      onnxruntime_add_include_to_target(onnxruntime_webgpu_external_dawn_test dawn::dawncpp_headers dawn::dawn_headers)
-      target_link_libraries(onnxruntime_webgpu_external_dawn_test PRIVATE dawn::dawn_native)
-    endif()
   endif()
 
   # the debug node IO functionality uses static variables, so it is best tested
@@ -1896,6 +1885,15 @@ if (NOT onnxruntime_MINIMAL_BUILD AND NOT onnxruntime_EXTENDED_MINIMAL_BUILD
   else()
     message(FATAL_ERROR "test_execution_provider unknown platform, need to specify shared library exports for it")
   endif()
+endif()
+
+if (onnxruntime_USE_WEBGPU AND onnxruntime_USE_EXTERNAL_DAWN)
+  AddTest(TARGET onnxruntime_webgpu_external_dawn_test
+          SOURCES ${onnxruntime_webgpu_external_dawn_test_SRC}
+          LIBS dawn::dawn_native ${onnxruntime_test_providers_libs}
+          DEPENDS ${all_dependencies}
+  )
+  onnxruntime_add_include_to_target(onnxruntime_webgpu_external_dawn_test dawn::dawncpp_headers dawn::dawn_headers)
 endif()
 
 include(onnxruntime_fuzz_test.cmake)

--- a/onnxruntime/test/webgpu/external_dawn/main.cc
+++ b/onnxruntime/test/webgpu/external_dawn/main.cc
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-FileCopyrightText: Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+// Licensed under the MIT License.
+
+#include <iostream>
+
+#include "core/session/onnxruntime_cxx_api.h"
+
+#include <google/protobuf/stubs/common.h>
+
+#include "dawn/native/DawnNative.h"
+
+#ifdef _WIN32
+int wmain(int argc, wchar_t* argv[]) {
+#else
+int main(int argc, char* argv[]) {
+#endif
+  bool no_proc_table = argc > 0 &&
+#ifdef _WIN32
+                       wcscmp(L"--no_proc_table", argv[argc - 1]) == 0;
+#else
+                       strcmp("--no_proc_table", argv[argc - 1]) == 0;
+#endif
+
+  int retval = 0;
+  Ort::Env env{nullptr};
+  try {
+    env = Ort::Env{ORT_LOGGING_LEVEL_WARNING, "Default"};
+
+    // model is https://github.com/onnx/onnx/blob/v1.15.0/onnx/backend/test/data/node/test_abs/model.onnx
+    constexpr uint8_t MODEL_DATA[] = {8, 7, 18, 12, 98, 97, 99, 107, 101, 110,
+                                      100, 45, 116, 101, 115, 116, 58, 73, 10, 11,
+                                      10, 1, 120, 18, 1, 121, 34, 3, 65, 98,
+                                      115, 18, 8, 116, 101, 115, 116, 95, 97, 98,
+                                      115, 90, 23, 10, 1, 120, 18, 18, 10, 16,
+                                      8, 1, 18, 12, 10, 2, 8, 3, 10, 2,
+                                      8, 4, 10, 2, 8, 5, 98, 23, 10, 1,
+                                      121, 18, 18, 10, 16, 8, 1, 18, 12, 10,
+                                      2, 8, 3, 10, 2, 8, 4, 10, 2, 8,
+                                      5, 66, 4, 10, 0, 16, 13};
+
+    Ort::SessionOptions session_options;
+    session_options.DisableMemPattern();
+    std::unordered_map<std::string, std::string> provider_options;
+    if (!no_proc_table) {
+      provider_options["dawnProcTable"] = std::to_string(reinterpret_cast<size_t>(&dawn::native::GetProcs()));
+    }
+    session_options.AppendExecutionProvider("WebGPU", provider_options);
+    Ort::Session session{env, MODEL_DATA, sizeof(MODEL_DATA), session_options};
+
+    if (no_proc_table) {
+      std::cerr << "DawnProcTable is not passing to ONNX Runtime, but no exception is thrown." << std::endl;
+      retval = -1;
+    } else {
+      // successfully initialized
+      std::cout << "Successfully initialized WebGPU EP." << std::endl;
+      retval = 0;
+    }
+  } catch (const std::exception& ex) {
+    std::cerr << ex.what() << std::endl;
+
+    if (no_proc_table) {
+      std::cout << "DawnProcTable is not passing to ONNX Runtime, so an exception is thrown as expected." << std::endl;
+      retval = 0;
+    } else {
+      std::cerr << "Unexpected exception." << std::endl;
+      retval = -1;
+    }
+  }
+
+  ::google::protobuf::ShutdownProtobufLibrary();
+  return retval;
+}

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -571,6 +571,7 @@ def parse_arguments():
     )
     parser.add_argument("--use_jsep", action="store_true", help="Build with JavaScript kernels.")
     parser.add_argument("--use_webgpu", action="store_true", help="Build with WebGPU support.")
+    parser.add_argument("--use_external_dawn", action="store_true", help="Treat Dawn as an external dependency.")
     parser.add_argument("--use_qnn", action="store_true", help="Build with QNN support.")
     parser.add_argument("--qnn_home", help="Path to QNN SDK dir.")
     parser.add_argument("--use_rknpu", action="store_true", help="Build with RKNPU.")
@@ -1058,6 +1059,7 @@ def generate_build_tree(
         "-Donnxruntime_ARMNN_BN_USE_CPU=" + ("OFF" if args.armnn_bn else "ON"),
         "-Donnxruntime_USE_JSEP=" + ("ON" if args.use_jsep else "OFF"),
         "-Donnxruntime_USE_WEBGPU=" + ("ON" if args.use_webgpu else "OFF"),
+        "-Donnxruntime_USE_EXTERNAL_DAWN=" + ("ON" if args.use_external_dawn else "OFF"),
         # Training related flags
         "-Donnxruntime_ENABLE_NVTX_PROFILE=" + ("ON" if args.enable_nvtx_profile else "OFF"),
         "-Donnxruntime_ENABLE_TRAINING=" + ("ON" if args.enable_training else "OFF"),
@@ -1319,6 +1321,9 @@ def generate_build_tree(
 
     if args.use_jsep and args.use_webgpu:
         raise BuildError("JSEP (--use_jsep) and WebGPU (--use_webgpu) cannot be enabled at the same time.")
+
+    if args.use_external_dawn and not args.use_webgpu:
+        raise BuildError("External Dawn (--use_external_dawn) must be enabled with WebGPU (--use_webgpu).")
 
     if args.use_snpe:
         cmake_args += ["-Donnxruntime_USE_SNPE=ON"]

--- a/tools/ci_build/github/azure-pipelines/win-gpu-webgpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-webgpu-ci-pipeline.yml
@@ -41,7 +41,7 @@ stages:
     - template: templates/jobs/win-ci-vs-2022-job.yml
       parameters:
         BuildConfig: 'RelWithDebInfo'
-        EnvSetupScript: setup_env_cuda.bat
+        EnvSetupScript: setup_env.bat
         buildArch: x64
         # add --build_java if necessary
         additionalBuildFlags: >-
@@ -57,3 +57,52 @@ stages:
         EnablePython: false
         WITH_CACHE: true
         MachinePool: onnxruntime-Win2022-VS2022-webgpu-A10
+
+- stage: webgpu_external_dawn
+  dependsOn: []
+  jobs:
+    - job: build_x64_RelWithDebInfo
+      variables:
+        DEPS_CACHE_DIR: $(Agent.TempDirectory)/deps_ccache
+        ORT_CACHE_DIR: $(Agent.TempDirectory)/ort_ccache
+        TODAY: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]
+      workspace:
+        clean: all
+      pool: onnxruntime-Win2022-VS2022-webgpu-A10
+      timeoutInMinutes:  300
+      steps:
+        - checkout: self
+          clean: true
+          submodules: none
+
+        - template: templates/jobs/win-ci-prebuild-steps.yml
+          parameters:
+            EnvSetupScript: setup_env.bat
+            DownloadCUDA: false
+            DownloadTRT: false
+            BuildArch: x64
+            BuildConfig: RelWithDebInfo
+            MachinePool: onnxruntime-Win2022-VS2022-webgpu-A10
+            WithCache: true
+            Today: $(Today)
+
+        - template: templates/jobs/win-ci-build-steps.yml
+          parameters:
+            WithCache: true
+            Today: $(TODAY)
+            CacheDir: $(ORT_CACHE_DIR)
+            AdditionalKey: " $(System.StageName) | RelWithDebInfo "
+            BuildPyArguments: '--config RelWithDebInfo --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --update --parallel --cmake_generator "Visual Studio 17 2022" --use_webgpu --use_external_dawn --skip_tests --target onnxruntime_webgpu_external_dawn_test'
+            MsbuildArguments: '-maxcpucount'
+            BuildArch: x64
+            Platform: x64
+            BuildConfig: RelWithDebInfo
+
+        - script: |
+            onnxruntime_webgpu_external_dawn_test.exe
+          displayName: Run tests (onnxruntime_webgpu_external_dawn_test)
+          workingDirectory: '$(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo'
+        - script: |
+            onnxruntime_webgpu_external_dawn_test.exe --no_proc_table
+          displayName: Run tests (onnxruntime_webgpu_external_dawn_test)
+          workingDirectory: '$(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo'


### PR DESCRIPTION
### Description

introduce this build flag --use_external_dawn to allow specifying Dawn as an external dependency. When it is specified, `dawn::native` is excluded from build of onnxruntime, and passing in dawn proc table is required.

I didn't find a good way to run the test. Currently I need to build with the following flags:
```sh
C:\code\onnxruntime>build --use_webgpu --use_external_dawn --skip_tests --target onnxruntime_webgpu_external_dawn_test
```

And run the test using:
```sh
# run test that passing dawn proc table. expect session to initialize successfully
C:\code\onnxruntime\build\Windows\Debug\Debug>onnxruntime_webgpu_external_dawn_test.exe

# run test that does not pass proc table. expect exception to throw.
C:\code\onnxruntime\build\Windows\Debug\Debug>onnxruntime_webgpu_external_dawn_test.exe --no_proc_table
```