### PR TITLE
DMMHA: add  unit tests; fix CPU, CUDA kernel

### DIFF
--- a/docs/ContribOperators.md
+++ b/docs/ContribOperators.md
@@ -1186,7 +1186,7 @@ This version of the operator has been available since version 1 of the 'com.micr
 
 <dl>
 <dt><tt>output</tt> : T</dt>
-<dd>3D output tensor with shape (batch_size, num_heads, v_hidden_size)</dd>
+<dd>3D output tensor with shape (batch_size, sequence_length, v_hidden_size)</dd>
 <dt><tt>present_key</tt> (optional) : T</dt>
 <dd>present state for key with shape (batch_size, num_heads, total_sequence_length, head_size). If past_present_share_buffer is set, its shape is (batch_size, num_heads, max_sequence_length, head_size), while effective_seq_length = (past_sequence_length + kv_sequence_length).</dd>
 <dt><tt>present_value</tt> (optional) : T</dt>

--- a/docs/ContribOperators.md
+++ b/docs/ContribOperators.md
@@ -1186,7 +1186,7 @@ This version of the operator has been available since version 1 of the 'com.micr
 
 <dl>
 <dt><tt>output</tt> : T</dt>
-<dd>3D output tensor with shape (batch_size, sequence_length, v_hidden_size)</dd>
+<dd>3D output tensor with shape (batch_size, num_heads, v_hidden_size)</dd>
 <dt><tt>present_key</tt> (optional) : T</dt>
 <dd>present state for key with shape (batch_size, num_heads, total_sequence_length, head_size). If past_present_share_buffer is set, its shape is (batch_size, num_heads, max_sequence_length, head_size), while effective_seq_length = (past_sequence_length + kv_sequence_length).</dd>
 <dt><tt>present_value</tt> (optional) : T</dt>

--- a/onnxruntime/contrib_ops/cpu/bert/attention_cpu_base.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_cpu_base.h
@@ -77,7 +77,7 @@ class AttentionCPUBase : public AttentionBase {
       // Convert mask from boolean (0/1) to float (mask_filter_value/0.0f).
       // Merge padding mask with causal mask, and broadcast to 3D (BxSxT).
       PrepareMask(mask_index_data, mask_index_dims, static_cast<T*>(mask_data),
-                  causal, batch_size, sequence_length, past_sequence_length, mask_filter_value_);
+                  causal, batch_size, sequence_length, kv_sequence_length, past_sequence_length, mask_filter_value_);
       DUMP_CPU_TENSOR("Mask3D", static_cast<T*>(mask_data), batch_size, sequence_length, total_sequence_length);
     }
 

--- a/onnxruntime/contrib_ops/cpu/bert/attention_helper.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_helper.h
@@ -120,9 +120,10 @@ void PrepareMask(const int32_t* mask_index,
                  bool causal,
                  int batch_size,
                  int sequence_length,
+                 int kv_sequence_length,
                  int past_sequence_length,
                  float mask_filter_value) {
-  const int all_sequence_length = past_sequence_length + sequence_length;
+  const int all_sequence_length = past_sequence_length + kv_sequence_length;
 
   // mask_data has been filled with 0, and its shape is BxSxT
   T* p_mask = mask_data;

--- a/onnxruntime/contrib_ops/cpu/bert/decoder_masked_multihead_attention.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/decoder_masked_multihead_attention.cc
@@ -339,6 +339,7 @@ void DecoderMaskedMultiHeadAttention<T>::ComputeAttentionProbsWithBeams(
         T* attention_probs_ptr = reinterpret_cast<T*>(attention_probs) + last_offset;
         math::Dot<float, CPUMathUtil>(head_size, q_vec, K + i * head_size, attention_probs_ptr, nullptr);
 
+        *attention_probs_ptr *= scale;
         // Apply the attention bias and mask
         if (attn_bias_data != nullptr) {
           *attention_probs_ptr += attn_bias_data[attn_bias_base_offset + past_sequence_length];
@@ -348,7 +349,6 @@ void DecoderMaskedMultiHeadAttention<T>::ComputeAttentionProbsWithBeams(
         if (is_masked) {
           *attention_probs_ptr += mask_filter_value_;
         }
-        *attention_probs_ptr *= scale;
       }
 
       {
@@ -362,6 +362,8 @@ void DecoderMaskedMultiHeadAttention<T>::ComputeAttentionProbsWithBeams(
           const T* past_k_vec = past_key_data + beam_batch_offset + beam_offset + j * head_size;
           T* output = reinterpret_cast<T*>(attention_probs) + j + i * probs_matrix_size;
           math::Dot<float, CPUMathUtil>(head_size, q_vec, past_k_vec, output, nullptr);
+
+          *output *= scale;
           // Apply the attention bias and mask
           if (attn_bias_data != nullptr) {
             *output += attn_bias_data[attn_bias_base_offset + j];
@@ -371,7 +373,6 @@ void DecoderMaskedMultiHeadAttention<T>::ComputeAttentionProbsWithBeams(
           if (is_masked) {
             *output += mask_filter_value_;
           }
-          *output *= scale;
         }
       }
       // Append current key to present key (past_present_share_buffer_ is true)

--- a/onnxruntime/contrib_ops/cpu/bert/decoder_masked_multihead_attention.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/decoder_masked_multihead_attention.cc
@@ -375,7 +375,8 @@ void DecoderMaskedMultiHeadAttention<T>::ComputeAttentionProbsWithBeams(
         }
       }
       // Append current key to present key (past_present_share_buffer_ is true)
-      memcpy(present_key_data + i * max_sequence_length * head_size, K + i * head_size, head_size * sizeof(T));
+      memcpy(present_key_data + (i * max_sequence_length + past_sequence_length) * head_size,
+             K + i * head_size, head_size * sizeof(T));
     }
   });
 
@@ -460,7 +461,7 @@ void DecoderMaskedMultiHeadAttention<T>::ComputeVxAttentionScoreWithBeams(
             }
           }
           // Append current value to present value (past_present_share_buffer_ is true)
-          memcpy(present_value_data + i * max_sequence_length * v_head_size,
+          memcpy(present_value_data + (i * max_sequence_length + past_sequence_length) * v_head_size,
                  V + i * v_head_size,
                  v_head_size * sizeof(T));
         }

--- a/onnxruntime/contrib_ops/cpu/bert/decoder_masked_multihead_attention.h
+++ b/onnxruntime/contrib_ops/cpu/bert/decoder_masked_multihead_attention.h
@@ -33,7 +33,7 @@ class DecoderMaskedMultiHeadAttention final : public OpKernel, public AttentionC
                                  const Tensor* cache_indir,
                                  OpKernelContext* context,
                                  int beam_width,
-                                 Tensor* scaled_qk = nullptr) const;
+                                 Tensor* output_qk = nullptr) const;
   void ComputeAttentionProbsWithBeams(T* attention_probs,
                                       const T* Q,
                                       const T* K,
@@ -50,7 +50,7 @@ class DecoderMaskedMultiHeadAttention final : public OpKernel, public AttentionC
                                       bool broadcast_attn_bias_dim_1,
                                       const int32_t* cache_indir_data,
                                       int beam_width,
-                                      T* scaled_qk_data = nullptr) const;
+                                      T* output_qk_data = nullptr) const;
   void ComputeVxAttentionScoreWithBeams(T* output,
                                         T* tmp_buffer,
                                         const T* attention_probs,

--- a/onnxruntime/contrib_ops/cuda/bert/fastertransformer_decoder_attention/decoder_masked_multihead_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/fastertransformer_decoder_attention/decoder_masked_multihead_attention_impl.cu
@@ -537,7 +537,7 @@ __global__ void masked_multihead_attention_kernel(DecoderMaskedMultiHeadAttentio
 
   if (params.out_qk != nullptr) {
     // store cross qk before softmax, out_qk has shape [B(batchxbeam), #Head, 1, total_sequence_length]
-    float* target = ((float*)params.out_qk) + ((int64_t)bhi * (sum_tlength + 1));
+    float* target = (reinterpret_cast<float*>(params.out_qk)) + (static_cast<int64_t>(bhi) * (sum_tlength + 1));
     for (int ti = tidx; ti <= sum_tlength; ti += THREADS_PER_BLOCK) {
       target[ti] = (float)(qk_smem[ti]);
     }

--- a/onnxruntime/contrib_ops/cuda/bert/fastertransformer_decoder_attention/decoder_masked_multihead_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/fastertransformer_decoder_attention/decoder_masked_multihead_attention_impl.cu
@@ -534,7 +534,7 @@ __global__ void masked_multihead_attention_kernel(DecoderMaskedMultiHeadAttentio
 
   if (params.out_qk != nullptr) {
     // store cross qk before softmax, out_qk has shape [B(batchxbeam), #Head, 1, total_sequence_length]
-    float* target = ((float*)params.out_qk) + ((int64_t)bhi * tlength);
+    float* target = ((float*)params.out_qk) + ((int64_t)bhi * (tlength + 1));
     for (int ti = tidx; ti <= sum_tlength; ti += THREADS_PER_BLOCK) {
       target[ti] = (float)(qk_smem[ti]);
     }

--- a/onnxruntime/contrib_ops/cuda/bert/fastertransformer_decoder_attention/decoder_masked_multihead_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/fastertransformer_decoder_attention/decoder_masked_multihead_attention_impl.cu
@@ -298,6 +298,9 @@ __global__ void masked_multihead_attention_kernel(DecoderMaskedMultiHeadAttentio
       if (params.attention_bias != nullptr) {
         qk = add_vec(qk, reinterpret_cast<T*>(params.attention_bias)[attn_bias_offset + tlength]);
       }
+      if (params.mask != nullptr && params.mask[bi_total_seq_length + params.past_sequence_length] == 0) {
+        qk += params.mask_filter_value;
+      }
       qk_max = qk;
       qk_smem[tlength] = qk;
     }
@@ -534,7 +537,7 @@ __global__ void masked_multihead_attention_kernel(DecoderMaskedMultiHeadAttentio
 
   if (params.out_qk != nullptr) {
     // store cross qk before softmax, out_qk has shape [B(batchxbeam), #Head, 1, total_sequence_length]
-    float* target = ((float*)params.out_qk) + ((int64_t)bhi * tlength);
+    float* target = ((float*)params.out_qk) + ((int64_t)bhi * (sum_tlength + 1));
     for (int ti = tidx; ti <= sum_tlength; ti += THREADS_PER_BLOCK) {
       target[ti] = (float)(qk_smem[ti]);
     }

--- a/onnxruntime/contrib_ops/cuda/bert/fastertransformer_decoder_attention/decoder_masked_multihead_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/fastertransformer_decoder_attention/decoder_masked_multihead_attention_impl.cu
@@ -534,7 +534,7 @@ __global__ void masked_multihead_attention_kernel(DecoderMaskedMultiHeadAttentio
 
   if (params.out_qk != nullptr) {
     // store cross qk before softmax, out_qk has shape [B(batchxbeam), #Head, 1, total_sequence_length]
-    float* target = ((float*)params.out_qk) + ((int64_t)bhi * (tlength + 1));
+    float* target = ((float*)params.out_qk) + ((int64_t)bhi * tlength);
     for (int ti = tidx; ti <= sum_tlength; ti += THREADS_PER_BLOCK) {
       target[ti] = (float)(qk_smem[ti]);
     }

--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -919,7 +919,7 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
                OpSchema::Optional)
         .Output(0,
                 "output",
-                "3D output tensor with shape (batch_size, num_heads, v_hidden_size)",
+                "3D output tensor with shape (batch_size, sequence_length, v_hidden_size)",
                 "T")
         .Output(1,
                 "present_key",

--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -908,7 +908,6 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
                OpSchema::Optional)
         .Input(9,
                "cache_indirection",
-               // This input is useful for CUDA EP only.
                "A buffer of shape [batch_size, beam_width, max_output_length] where an `[i, j, k]` entry specifies "
                "which beam the `k`-th token came from for the `j`-th beam for batch `i` in the current iteration",
                "M",
@@ -920,7 +919,7 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
                OpSchema::Optional)
         .Output(0,
                 "output",
-                "3D output tensor with shape (batch_size, sequence_length, v_hidden_size)",
+                "3D output tensor with shape (batch_size, num_heads, v_hidden_size)",
                 "T")
         .Output(1,
                 "present_key",

--- a/onnxruntime/test/contrib_ops/decoder_masked_multihead_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/decoder_masked_multihead_attention_op_test.cc
@@ -634,7 +634,9 @@ std::vector<MLFloat16> Softmax_QK_Transpose_V(MLFloat16* softmax_qk_transpose_ma
 
   return output;
 }
-TEST(DecoderMaskedSelfAttentionTest, Test_fp32) {
+
+template <typename T>
+static void TestDecoderMaskedSelfAttention() {
   // The kernel is only supported on CC 5.3 or higher GPUs
   if (NeedSkipIfCudaArchLowerThan(530)) {
     return;
@@ -670,7 +672,7 @@ TEST(DecoderMaskedSelfAttentionTest, Test_fp32) {
 
     int head_size = (hidden_size / number_of_heads);
     int total_sequence_length = sequence_length + past_sequence_length;
-    int max_sequence_length = past_sequence_length + 1;  // Always keep >  past_sequence_length
+    int max_sequence_length = past_sequence_length + 1;  // Always keep > past_sequence_length
 
     OpTester tester("DecoderMaskedSelfAttention", 1, onnxruntime::kMSDomain);
     tester.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(number_of_heads));
@@ -681,14 +683,14 @@ TEST(DecoderMaskedSelfAttentionTest, Test_fp32) {
     std::vector<int64_t> bias_dims = {3 * hidden_size};
     std::vector<int64_t> output_dims = {batch_size, sequence_length, hidden_size};
 
-    auto input = CreateRandom<float>(batch_size * sequence_length * hidden_size);
-    tester.AddInput<float>("input", input_dims, input);
+    auto input = CreateRandom<T>(batch_size * sequence_length * hidden_size);
+    tester.AddInput<T>("input", input_dims, input);
 
-    auto weight = CreateRandom<float>(hidden_size * 3 * hidden_size);
-    tester.AddInput<float>("weight", weights_dims, weight);
+    auto weight = CreateRandom<T>(hidden_size * 3 * hidden_size);
+    tester.AddInput<T>("weight", weights_dims, weight);
 
-    auto bias = CreateRandom<float>(3 * hidden_size);
-    tester.AddInput<float>("bias", bias_dims, bias);
+    auto bias = CreateRandom<T>(3 * hidden_size);
+    tester.AddInput<T>("bias", bias_dims, bias);
 
     // Mask
     tester.AddOptionalInputEdge<int32_t>();
@@ -697,22 +699,22 @@ TEST(DecoderMaskedSelfAttentionTest, Test_fp32) {
     std::vector<int64_t> past_dims = {2, batch_size, number_of_heads, max_sequence_length, head_size};
     int past_present_size = 2 * batch_size * number_of_heads * max_sequence_length * head_size;
 
-    auto kv_cache = CreateRandom<float>(past_present_size);
+    auto kv_cache = CreateRandom<T>(past_present_size);
 
-    auto reordered_kv_cache = ReorderKVCache<float>(kv_cache, batch_size,
-                                                    number_of_heads, past_sequence_length, head_size, max_sequence_length);
+    auto reordered_kv_cache = ReorderKVCache<T>(kv_cache, batch_size,
+                                                number_of_heads, past_sequence_length, head_size, max_sequence_length);
 
     // Validate if reordering went well - by transposing and checking equality
-    int chunk_size = 16 / sizeof(float);
+    int chunk_size = 16 / sizeof(T);
     int num_chunks = head_size / chunk_size;
-    auto transposed = Transpose<float>(kv_cache.data(), batch_size, number_of_heads, num_chunks, max_sequence_length, chunk_size);
-    CheckEquality<float>(transposed.data(), reordered_kv_cache.data(), batch_size, number_of_heads, num_chunks,
-                         max_sequence_length, past_sequence_length, chunk_size);
+    auto transposed = Transpose<T>(kv_cache.data(), batch_size, number_of_heads, num_chunks, max_sequence_length, chunk_size);
+    CheckEquality<T>(transposed.data(), reordered_kv_cache.data(), batch_size, number_of_heads, num_chunks,
+                     max_sequence_length, past_sequence_length, chunk_size);
 
-    tester.AddInput<float>("past", past_dims, reordered_kv_cache);
+    tester.AddInput<T>("past", past_dims, reordered_kv_cache);
 
     // Rel
-    tester.AddOptionalInputEdge<float>();
+    tester.AddOptionalInputEdge<T>();
 
     // Past sequence length
     std::vector<int32_t> arr_past_sequence_len(1, past_sequence_length);
@@ -722,41 +724,45 @@ TEST(DecoderMaskedSelfAttentionTest, Test_fp32) {
     auto qkv = QKV(input, weight, bias, batch_size, sequence_length, hidden_size);
     auto* qkv_matrix = qkv.data();
 
-    auto pair = MergePastKWithPresentKAndTranspose<float>(kv_cache.data(), qkv_matrix + hidden_size, batch_size,
-                                                          number_of_heads, past_sequence_length,
-                                                          max_sequence_length, head_size);
+    auto pair = MergePastKWithPresentKAndTranspose<T>(kv_cache.data(), qkv_matrix + hidden_size, batch_size,
+                                                      number_of_heads, past_sequence_length,
+                                                      max_sequence_length, head_size);
 
     auto k_merged = pair.first;
     auto k_transpose = pair.second;
 
-    auto qk_transpose = QK_Transpose<float>(qkv_matrix, k_transpose.data(), batch_size, number_of_heads,
-                                            total_sequence_length, head_size);
+    auto qk_transpose = QK_Transpose<T>(qkv_matrix, k_transpose.data(), batch_size, number_of_heads,
+                                        total_sequence_length, head_size);
 
-    auto softmax_qk_transpose = Softmax_QK_Transpose<float>(qk_transpose.data(), batch_size, number_of_heads,
-                                                            sequence_length, total_sequence_length, head_size);
+    auto softmax_qk_transpose = Softmax_QK_Transpose<T>(qk_transpose.data(), batch_size, number_of_heads,
+                                                        sequence_length, total_sequence_length, head_size);
 
-    auto present = MergeReorderedKVCacheWithK<float>(reordered_kv_cache, qkv_matrix + hidden_size, batch_size,
-                                                     number_of_heads, past_sequence_length, max_sequence_length, head_size);
+    auto present = MergeReorderedKVCacheWithK<T>(reordered_kv_cache, qkv_matrix + hidden_size, batch_size,
+                                                 number_of_heads, past_sequence_length, max_sequence_length, head_size);
 
     // Validate our test logic
     // We want to validate if our merged "unordered" K is the same as
     // the merged "ordered" K so that the QKT we do in our test code
     // is equivalent to the QKT we do in the kernel
-    ValidateReorderedMergedKWithK<float>(k_merged.data(), present.data(), batch_size, number_of_heads, total_sequence_length, max_sequence_length, head_size);
+    ValidateReorderedMergedKWithK<T>(k_merged.data(), present.data(), batch_size, number_of_heads, total_sequence_length, max_sequence_length, head_size);
 
-    MergeReorderedKVCacheWithV<float>(present.data() + (past_present_size / 2), qkv_matrix + 2 * hidden_size, batch_size,
-                                      number_of_heads, past_sequence_length, max_sequence_length, head_size);
+    MergeReorderedKVCacheWithV<T>(present.data() + (past_present_size / 2), qkv_matrix + 2 * hidden_size, batch_size,
+                                  number_of_heads, past_sequence_length, max_sequence_length, head_size);
 
-    auto output = Softmax_QK_Transpose_V<float>(softmax_qk_transpose.data(), present.data() + (past_present_size / 2),
-                                                batch_size, number_of_heads,
-                                                sequence_length, total_sequence_length,
-                                                max_sequence_length, head_size);
+    auto output = Softmax_QK_Transpose_V<T>(softmax_qk_transpose.data(), present.data() + (past_present_size / 2),
+                                            batch_size, number_of_heads,
+                                            sequence_length, total_sequence_length,
+                                            max_sequence_length, head_size);
 
     // Output(s)
-    tester.AddOutput<float>("output", input_dims, output);
-    tester.AddOutput<float>("present", past_dims, present);
+    tester.AddOutput<T>("output", input_dims, output);
+    tester.AddOutput<T>("present", past_dims, present);
 
-    tester.SetOutputTolerance(0.001f, 0.001f);
+    if (std::is_same<T, MLFloat16>::value) {
+      tester.SetOutputTolerance(0.005f);
+    } else {
+      tester.SetOutputTolerance(0.001f, 0.001f);
+    }
 
     // Run - Regular kernel execution path
     {
@@ -778,147 +784,12 @@ TEST(DecoderMaskedSelfAttentionTest, Test_fp32) {
   }
 }
 
+TEST(DecoderMaskedSelfAttentionTest, Test_fp32) {
+  TestDecoderMaskedSelfAttention<float>();
+}
+
 TEST(DecoderMaskedSelfAttentionTest, Test_fp16) {
-  // The kernel is only supported on CC 5.3 or higher GPUs
-  if (NeedSkipIfCudaArchLowerThan(530)) {
-    return;
-  }
-
-  // Buckets for test data:
-  // batch_size: 1, >=2
-  // past_sequence_length 0, 1~30, 31~2046, >=2047 (so that total_sequence_length: 1, 2-31, 32~2047, >=2048)
-  // head_size: 32, 64, 128
-  struct MyTestCase {
-    int batch_size;
-    int past_sequence_length;
-    int hidden_size;
-  } test_cases[] = {
-      {1, 0, 768},
-      {1, 1, 768},
-      {3, 30, 384},
-      {8, 31, 1536},
-      {4, 256, 384},
-      {3, 1024, 768},
-      {2, 2046, 1536},
-      {1, 2047, 384},
-      {2, 3000, 768},
-  };
-
-  constexpr int sequence_length = 1;
-  constexpr int number_of_heads = 12;
-
-  for (MyTestCase test_case : test_cases) {
-    int batch_size = test_case.batch_size;
-    int past_sequence_length = test_case.past_sequence_length;
-    int hidden_size = test_case.hidden_size;
-
-    int head_size = (hidden_size / number_of_heads);
-    int total_sequence_length = sequence_length + past_sequence_length;
-    int max_sequence_length = past_sequence_length + 1;  // Always keep >  past_sequence_length
-
-    OpTester tester("DecoderMaskedSelfAttention", 1, onnxruntime::kMSDomain);
-    tester.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(number_of_heads));
-    tester.AddAttribute<int64_t>("past_present_share_buffer", static_cast<int64_t>(1));
-
-    std::vector<int64_t> input_dims = {batch_size, sequence_length, hidden_size};
-    std::vector<int64_t> weights_dims = {hidden_size, 3 * hidden_size};
-    std::vector<int64_t> bias_dims = {3 * hidden_size};
-    std::vector<int64_t> output_dims = {batch_size, sequence_length, hidden_size};
-
-    auto input = CreateRandom<MLFloat16>(batch_size * sequence_length * hidden_size);
-    tester.AddInput<MLFloat16>("input", input_dims, input);
-
-    auto weight = CreateRandom<MLFloat16>(hidden_size * 3 * hidden_size);
-    tester.AddInput<MLFloat16>("weight", weights_dims, weight);
-
-    auto bias = CreateRandom<MLFloat16>(3 * hidden_size);
-    tester.AddInput<MLFloat16>("bias", bias_dims, bias);
-
-    // Mask
-    tester.AddOptionalInputEdge<int32_t>();
-
-    // Past
-    std::vector<int64_t> past_dims = {2, batch_size, number_of_heads, max_sequence_length, head_size};
-    int past_present_size = 2 * batch_size * number_of_heads * max_sequence_length * head_size;
-
-    auto kv_cache = CreateRandom<MLFloat16>(past_present_size);
-
-    auto reordered_kv_cache = ReorderKVCache<MLFloat16>(kv_cache, batch_size,
-                                                        number_of_heads, past_sequence_length, head_size, max_sequence_length);
-
-    // Validate if reordering went well - by transposing and checking equality
-    int chunk_size = 16 / sizeof(MLFloat16);
-    int num_chunks = head_size / chunk_size;
-    auto transposed = Transpose<MLFloat16>(kv_cache.data(), batch_size, number_of_heads, num_chunks, max_sequence_length, chunk_size);
-    CheckEquality<MLFloat16>(transposed.data(), reordered_kv_cache.data(), batch_size, number_of_heads, num_chunks,
-                             max_sequence_length, past_sequence_length, chunk_size);
-
-    tester.AddInput<MLFloat16>("past", past_dims, reordered_kv_cache);
-
-    // Rel
-    tester.AddOptionalInputEdge<MLFloat16>();
-
-    // Past sequence length
-    std::vector<int32_t> arr_past_sequence_len(1, past_sequence_length);
-    tester.AddInput<int32_t>("past_sequence_length", {1}, arr_past_sequence_len);
-
-    // QKV MatMul
-    auto qkv = QKV(input, weight, bias, batch_size, sequence_length, hidden_size);
-    auto* qkv_matrix = qkv.data();
-
-    auto pair = MergePastKWithPresentKAndTranspose<MLFloat16>(kv_cache.data(), qkv_matrix + hidden_size, batch_size,
-                                                              number_of_heads, past_sequence_length,
-                                                              max_sequence_length, head_size);
-
-    auto k_merged = pair.first;
-    auto k_transpose = pair.second;
-
-    auto qk_transpose = QK_Transpose<MLFloat16>(qkv_matrix, k_transpose.data(), batch_size, number_of_heads,
-                                                total_sequence_length, head_size);
-
-    auto softmax_qk_transpose = Softmax_QK_Transpose<MLFloat16>(qk_transpose.data(), batch_size, number_of_heads,
-                                                                sequence_length, total_sequence_length, head_size);
-
-    auto present = MergeReorderedKVCacheWithK<MLFloat16>(reordered_kv_cache, qkv_matrix + hidden_size, batch_size,
-                                                         number_of_heads, past_sequence_length, max_sequence_length, head_size);
-
-    // Validate our test logic
-    // We want to validate if our merged "unordered" K is the same as
-    // the merged "ordered" K so that the QKT we do in our test code
-    // is equivalent to the QKT we do in the kernel
-    ValidateReorderedMergedKWithK<MLFloat16>(k_merged.data(), present.data(), batch_size, number_of_heads, total_sequence_length, max_sequence_length, head_size);
-
-    MergeReorderedKVCacheWithV<MLFloat16>(present.data() + (past_present_size / 2), qkv_matrix + 2 * hidden_size, batch_size,
-                                          number_of_heads, past_sequence_length, max_sequence_length, head_size);
-
-    auto output = Softmax_QK_Transpose_V(softmax_qk_transpose.data(), present.data() + (past_present_size / 2),
-                                         batch_size, number_of_heads,
-                                         sequence_length, total_sequence_length,
-                                         max_sequence_length, head_size);
-
-    // Output(s)
-    tester.AddOutput<MLFloat16>("output", input_dims, output);
-    tester.AddOutput<MLFloat16>("present", past_dims, present);
-
-    tester.SetOutputTolerance(0.005f);
-
-    // Run - Regular kernel execution path
-    {
-      std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
-      execution_providers.push_back(DefaultCudaExecutionProvider());
-      tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
-    }
-
-    // Test alternate kernel path of loading more KV data "in flight"
-    {
-      ScopedEnvironmentVariables scoped_env_vars{
-          EnvVarMap{{onnxruntime::contrib::attention::kDecoderMaskedAttentionLoadKVDataInFlight, "1"}}};
-
-      std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
-      execution_providers.push_back(DefaultCudaExecutionProvider());
-      tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
-    }
-  }
+  TestDecoderMaskedSelfAttention<MLFloat16>();
 }
 
 #endif

--- a/onnxruntime/test/contrib_ops/decoder_masked_multihead_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/decoder_masked_multihead_attention_op_test.cc
@@ -419,14 +419,15 @@ std::vector<T> Softmax_QK_Transpose(T* qk_transpose_matrix, int batch_size, int 
   }
 
   std::vector<T> softmax_qk_transpose;
-  softmax_qk_transpose.resize(batch_size * num_heads * sequence_length * total_sequence_length, static_cast<T>(0.f));
+  softmax_qk_transpose.resize(static_cast<size_t>(batch_size) * num_heads * sequence_length * total_sequence_length,
+                              static_cast<T>(0.f));
 
   for (int b = 0; b < batch_size; ++b) {
     for (int n = 0; n < num_heads; ++n) {
       int base_offset = (b * num_heads * sequence_length * total_sequence_length) +
                         (n * sequence_length * total_sequence_length);
 
-      float max = std::numeric_limits<float>::min();
+      float max = std::numeric_limits<float>::lowest();
       for (int s = 0; s < total_sequence_length; ++s) {
         auto val = ToFloat(qk_transpose_matrix[base_offset + s]);
         if (val > max) {
@@ -655,7 +656,7 @@ static std::vector<T> CalculateOutputQK(const std::vector<T>& q, const std::vect
   // mask_index (B, L), (optional) attention_bias (1, 1, 1, L)
   float scale = 1 / sqrt(static_cast<float>(head_size));
   std::vector<T> output_qk;
-  output_qk.resize(batch_size * num_heads * sequence_length, static_cast<T>(0.f));
+  output_qk.resize(static_cast<size_t>(batch_size) * num_heads * sequence_length, static_cast<T>(0.f));
   for (int b = 0; b < batch_size; ++b) {
     for (int n = 0; n < num_heads; ++n) {
       for (int s = 0; s < sequence_length; ++s) {
@@ -682,7 +683,7 @@ static std::vector<T> CalculateOutput(const std::vector<T>& softmax, const std::
                                       int num_heads, int sequence_length, int max_sequence_length, int head_size) {
   // softmax (B, N, 1, L) v (B, N, L(M), H) -> output (B, N, 1, H)
   std::vector<T> output;
-  output.resize(batch_size * num_heads * head_size, static_cast<T>(0.f));
+  output.resize(static_cast<size_t>(batch_size) * num_heads * head_size, static_cast<T>(0.f));
   for (int b = 0; b < batch_size; ++b) {
     for (int n = 0; n < num_heads; ++n) {
       for (int h = 0; h < head_size; ++h) {
@@ -853,7 +854,6 @@ static void TestDecoderMaskedMultiHeadAttention(bool is_cross_attn = true, bool 
 
       const std::vector<int64_t> cache_indir_dims = {batch_size, beam_width, max_sequence_length};
       auto value_candidates = ValueRange<int32_t>(beam_width);
-      FixedPatternValueGenerator generator{};
       auto cache_indir = generator.Discrete<int32_t>(cache_indir_dims, value_candidates);
       tester.AddInput<int32_t>("cache_indirection", cache_indir_dims, cache_indir);
 

--- a/onnxruntime/test/contrib_ops/decoder_masked_multihead_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/decoder_masked_multihead_attention_op_test.cc
@@ -667,7 +667,7 @@ static std::vector<T> CalculateOutputQK(const std::vector<T>& q, const std::vect
         }
 
         output_qk[b * num_heads * sequence_length + n * sequence_length + s] =
-            static_cast<T>(scale * (sum + mask_value + bias_value));
+            static_cast<T>(scale * sum + mask_value + bias_value);
       }
     }
   }

--- a/onnxruntime/test/contrib_ops/decoder_masked_multihead_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/decoder_masked_multihead_attention_op_test.cc
@@ -76,7 +76,7 @@ template <typename T>
 float ToFloat(T val);
 
 template <>
-float ToFloat(float val) {
+constexpr float ToFloat(float val) {
   return val;
 }
 
@@ -753,6 +753,8 @@ static void TestDecoderMaskedMultiHeadAttention(bool is_cross_attn = true, bool 
   int hidden_size = head_size * num_heads;
 
   OpTester tester("DecoderMaskedMultiHeadAttention", 1, onnxruntime::kMSDomain);
+  FixedPatternValueGenerator generator{};
+  RandomValueGenerator random{};
 
   // Attributes
   tester.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(num_heads));
@@ -864,7 +866,7 @@ static void TestDecoderMaskedMultiHeadAttention(bool is_cross_attn = true, bool 
   if (std::is_same<T, MLFloat16>::value) {
     tester.SetOutputTolerance(0.005f);
   } else {
-    tester.SetOutputTolerance(0.001f, 0.001f);
+    tester.SetOutputTolerance(0.0001f, 0.0001f);
   }
 
   {

--- a/onnxruntime/test/contrib_ops/decoder_masked_multihead_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/decoder_masked_multihead_attention_op_test.cc
@@ -413,7 +413,7 @@ std::vector<T> QK_Transpose(T* q_matrix, T* k_transpose_matrix,
 // Softmax_QK_Transpose
 template <typename T>
 std::vector<T> Softmax_QK_Transpose(T* qk_transpose_matrix, int batch_size, int num_heads,
-                                    int sequence_length, int total_sequence_length, int head_size) {
+                                    int sequence_length, int total_sequence_length) {
   if (sequence_length != 1) {
     throw std::runtime_error("Not supported");
   }
@@ -596,7 +596,7 @@ static void TestDecoderMaskedSelfAttention() {
                                         total_sequence_length, head_size);
 
     auto softmax_qk_transpose = Softmax_QK_Transpose<T>(qk_transpose.data(), batch_size, num_heads,
-                                                        sequence_length, total_sequence_length, head_size);
+                                                        sequence_length, total_sequence_length);
 
     auto present = MergeReorderedKVCacheWithK<T>(reordered_kv_cache, qkv_matrix + hidden_size, batch_size,
                                                  num_heads, past_sequence_length, max_sequence_length, head_size);
@@ -793,8 +793,7 @@ static void TestDecoderMaskedMultiHeadAttention(bool is_cross_attn = true, bool 
     for (size_t i = 0; i < output_qk.size(); ++i) {
       output_qk_float[i] = static_cast<float>(output_qk[i]);
     }
-    auto softmax = Softmax_QK_Transpose<T>(output_qk.data(), batch_size, num_heads,
-                                           1, kv_sequence_length, head_size);
+    auto softmax = Softmax_QK_Transpose<T>(output_qk.data(), batch_size, num_heads, 1, kv_sequence_length);
     auto output = CalculateOutput<T>(softmax, value, batch_size, num_heads,
                                      kv_sequence_length, kv_sequence_length, head_size);
 
@@ -870,8 +869,7 @@ static void TestDecoderMaskedMultiHeadAttention(bool is_cross_attn = true, bool 
     auto output_qk = CalculateOutputQK<T>(query, (beam_width > 1 ? mod_merged_key : merged_key),
                                           mask_index, attention_bias,
                                           batch_size, num_heads, total_sequence_length, max_sequence_length, head_size);
-    auto softmax = Softmax_QK_Transpose<T>(output_qk.data(),
-                                           batch_size, num_heads, 1, total_sequence_length, head_size);
+    auto softmax = Softmax_QK_Transpose<T>(output_qk.data(), batch_size, num_heads, 1, total_sequence_length);
     auto output = CalculateOutput<T>(softmax, (beam_width > 1 ? mod_merged_value : merged_value),
                                      batch_size, num_heads, total_sequence_length, max_sequence_length, head_size);
 

--- a/onnxruntime/test/contrib_ops/decoder_masked_multihead_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/decoder_masked_multihead_attention_op_test.cc
@@ -882,7 +882,7 @@ static void TestDecoderMaskedMultiHeadAttention(bool is_cross_attn = true, bool 
   }
 
   if (std::is_same<T, MLFloat16>::value) {
-    tester.SetOutputTolerance(0.005f);
+    tester.SetOutputTolerance(0.02f);
   } else {
     tester.SetOutputTolerance(0.0001f, 0.0001f);
   }

--- a/onnxruntime/test/contrib_ops/decoder_masked_multihead_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/decoder_masked_multihead_attention_op_test.cc
@@ -782,6 +782,10 @@ static void TestDecoderMaskedMultiHeadAttention(bool is_cross_attn = true, bool 
     std::vector<T> empty_attention_bias;
     auto output_qk = CalculateOutputQK(query, key, mask_index, empty_attention_bias, batch_size, num_heads,
                                        kv_sequence_length, kv_sequence_length, head_size);
+    std::vector<float> output_qk_float(output_qk.size());
+    for (size_t i = 0; i < output_qk.size(); ++i) {
+      output_qk_float[i] = static_cast<float>(output_qk[i]);
+    }
     auto softmax = Softmax_QK_Transpose<T>(output_qk.data(), batch_size, num_heads,
                                            1, kv_sequence_length, head_size);
     auto output = CalculateOutput<T>(softmax, value, batch_size, num_heads,


### PR DESCRIPTION
### Description

Fixes:
(1) cpu kernel: applying scale before bias and mask like other MHA ops
(2) cpu kernel: correct offset during appending past to present.
(3) cuda kernel: apply mask if provided; fix output_qk offset.

Add DMMHA unit tests

