### PR TITLE
Unblock Python packaging pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/py-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/py-packaging-pipeline.yml
@@ -77,5 +77,3 @@ stages:
     build_py_parameters: ${{ parameters.build_py_parameters }}
     cmake_build_type: ${{ parameters.cmake_build_type }}
     qnn_sdk_version: ${{ parameters.qnn_sdk_version }}
-    publish_symbols: true
-


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Regarding failures over python packaging ci: 
`/tools/ci_build/github/azure-pipelines/py-packaging-pipeline.yml (Line: 80, Col: 22): Unexpected parameter 'publish_symbols'`

As template `stages/py-cpu-packaging-stage.yml` no longer offers `publish_symbols`, remove this usage to fix CI

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


