### PR TITLE
Move ClipQuantFusion and ReluQuantFusion back to level1

### DIFF
--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -134,12 +134,12 @@ InlinedVector<std::unique_ptr<RewriteRule>> GenerateRewriteRules(
       rules.push_back(std::make_unique<ConvBNFusion>());
       rules.push_back(std::make_unique<PadFusion>());
       rules.push_back(std::make_unique<MatmulBNFusion>());
+      rules.push_back(std::make_unique<ReluQuantFusion>());
       rules.push_back(std::make_unique<LabelEncoderFusion>());
       break;
 
     case TransformerLevel::Level2:
       rules.push_back(std::make_unique<ClipQuantFusion>());
-      rules.push_back(std::make_unique<ReluQuantFusion>());
       rules.push_back(std::make_unique<GemmTransposeFusion>());
       break;
 

--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -134,13 +134,14 @@ InlinedVector<std::unique_ptr<RewriteRule>> GenerateRewriteRules(
       rules.push_back(std::make_unique<ConvBNFusion>());
       rules.push_back(std::make_unique<PadFusion>());
       rules.push_back(std::make_unique<MatmulBNFusion>());
+      rules.push_back(std::make_unique<ClipQuantFusion>());
       rules.push_back(std::make_unique<ReluQuantFusion>());
       rules.push_back(std::make_unique<LabelEncoderFusion>());
       break;
 
     case TransformerLevel::Level2:
-      rules.push_back(std::make_unique<ClipQuantFusion>());
       rules.push_back(std::make_unique<GemmTransposeFusion>());
+      // No level2 rules available today
       break;
 
     case TransformerLevel::Level3:

--- a/onnxruntime/core/optimizer/qdq_transformer/clip_quantizelinear.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/clip_quantizelinear.cc
@@ -83,15 +83,13 @@ static bool GetQConstantLowerUpper(const Graph& graph, const Node& node, float& 
 
 bool ClipQuantFusion::SatisfyCondition(const Graph& graph, const Node& node, const logging::Logger& /*logger*/) const {
   if (!graph_utils::IsSupportedOptypeVersionAndDomain(node, "Clip", {1, 6, 11, 12, 13}) ||
-      !graph_utils::IsSupportedProvider(node, {kCpuExecutionProvider}) ||
       !optimizer_utils::CheckOutputEdges(graph, node, 1)) {
     return false;
   }
 
   // if Clip is followed by QuantizeLinear, it can be fused into QuantizeLinear potentially
   const auto& next_node = *node.OutputNodesBegin();
-  if (!graph_utils::IsSupportedProvider(next_node, {kCpuExecutionProvider}) ||
-      !QDQ::MatchQNode(next_node)) {
+  if (!QDQ::MatchQNode(next_node)) {
     return false;
   }
 

--- a/onnxruntime/core/optimizer/qdq_transformer/relu_quantizelinear.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/relu_quantizelinear.cc
@@ -13,15 +13,13 @@ namespace onnxruntime {
 
 bool ReluQuantFusion::SatisfyCondition(const Graph& graph, const Node& node, const logging::Logger& /*logger*/) const {
   if (!graph_utils::IsSupportedOptypeVersionAndDomain(node, "Relu", {6, 13, 14}) ||
-      !graph_utils::IsSupportedProvider(node, {kCpuExecutionProvider}) ||
       !optimizer_utils::CheckOutputEdges(graph, node, 1)) {
     return false;
   }
 
   // if Relu is followed by QuantizeLinear, it can be fused into QuantizeLinear potentially
   const auto& next_node = *node.OutputNodesBegin();
-  if (!graph_utils::IsSupportedProvider(next_node, {kCpuExecutionProvider}) ||
-      !QDQ::MatchQNode(next_node)) {
+  if (!QDQ::MatchQNode(next_node)) {
     return false;
   }
 

--- a/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
+++ b/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
@@ -57,6 +57,12 @@ std::unique_ptr<IExecutionProvider> OpenVINOProviderFactory::CreateProvider() {
   std::string so_cache_path = config_options_.GetConfigOrDefault("ep.context_file_path", "").c_str();
   bool so_allow_stripping_qdq = config_options_.GetConfigOrDefault(kOrtSessionOptionsAllowStrippingQDQ, "0") == "1";
 
+  if (!so_allow_stripping_qdq && enable_qdq_optimizer_) {
+    ORT_THROW(
+        MakeString("[ERROR] [OpenVINO] provider option enable_qdq_optimizer is set to true but session option ",
+                   kOrtSessionOptionsAllowStrippingQDQ, " is not set to true. ",
+                   "This will break some optimizations precondition."));
+  }
   if (so_allow_stripping_qdq && !enable_qdq_optimizer_) {
     LOGS_DEFAULT(WARNING) << "[OpenVINO] enable_qdq_optimizer is set to false with provider option but is enabled at "
                           << "session level with " << kOrtSessionOptionsAllowStrippingQDQ << " set to true. "

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1759,10 +1759,9 @@ common::Status InferenceSession::Initialize() {
       }
     }
 
-    bool have_openvino_ep = execution_providers_.Get(onnxruntime::kOpenVINOExecutionProvider) != nullptr;
-    if (have_openvino_ep) {
-      LOGS(*session_logger_, INFO) << "Excluding ClipQuantFusion and ReluQuantFusion for OpenVINO provider.";
-      std::cout<< "Excluding ClipQuantFusion and ReluQuantFusion for OpenVINO provider." << std::endl;
+    if (session_options_.config_options.GetConfigOrDefault(kOrtSessionOptionsAllowStrippingQDQ, "0") == "1") {
+      LOGS(*session_logger_, INFO) << "Session option " << kOrtSessionOptionsAllowStrippingQDQ << " is set to true. "
+                                   << "Excluding ClipQuantFusion and ReluQuantFusion from optimizations";
       optimizers_to_disable_.insert("ClipQuantRewrite");
       optimizers_to_disable_.insert("ReluQuantRewrite");
     }

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1759,6 +1759,14 @@ common::Status InferenceSession::Initialize() {
       }
     }
 
+    bool have_openvino_ep = execution_providers_.Get(onnxruntime::kOpenVINOExecutionProvider) != nullptr;
+    if (have_openvino_ep) {
+      LOGS(*session_logger_, INFO) << "Excluding ClipQuantFusion and ReluQuantFusion for OpenVINO provider.";
+      std::cout<< "Excluding ClipQuantFusion and ReluQuantFusion for OpenVINO provider." << std::endl;
+      optimizers_to_disable_.insert("ClipQuantRewrite");
+      optimizers_to_disable_.insert("ReluQuantRewrite");
+    }
+
 #if !defined(ORT_MINIMAL_BUILD) && defined(ORT_MEMORY_PROFILE)
     // Don't want to pollute SessionState constructor since memory profile is enabled optionally.
     session_state_->SetMemoryProfiler(&memory_profiler_);

--- a/onnxruntime/test/optimizer/qdq_transformer_test.cc
+++ b/onnxruntime/test/optimizer/qdq_transformer_test.cc
@@ -3101,57 +3101,6 @@ TEST(QDQTransformerTests, Clip) {
   }
 }
 
-// Test that the ReluQuantFusion transformer only runs for optimization level >= 2.
-TEST(QDQTransformerTests, ReluQuantFusion_Level2Only) {
-  auto test_case = [&](TransformerLevel opt_level, int8_t zp) {
-    auto build_test_case = [&](ModelTestBuilder& builder) {
-      auto* input_arg = builder.MakeInput<int8_t>({1, 2, 2, 2},
-                                                  {-4, -3, -2, 0, 1, 2, 3, 4});
-      auto* output_arg = builder.MakeOutput();
-
-      // add DQ
-      auto* dq_output = builder.MakeIntermediate();
-      builder.AddDequantizeLinearNode<int8_t>(input_arg, 1.0f, zp, dq_output);
-
-      // add Relu
-      auto* relu_output = builder.MakeIntermediate();
-      builder.AddNode("Relu", {dq_output}, {relu_output});
-
-      // add Q + DQ
-      auto* q_output = builder.MakeIntermediate();
-      builder.AddQuantizeLinearNode<int8_t>(relu_output, 1.0f, zp, q_output);
-      builder.AddDequantizeLinearNode<int8_t>(q_output, 1.0f, zp, output_arg);
-    };
-
-    auto check_relu_graph = [&](InferenceSessionWrapper& session) {
-      auto op_to_count = CountOpsInGraph(session.GetGraph());
-      const QDQOpKeys qdq_keys = GetQDQOpKeys(false);
-      // Only fuse relu into Q if level >= 2 and zero_point == -128 for int8.
-      // Level1 graph:   input -> DQ -> Relu -> Q -> DQ -> output
-      // Level2+ graph: input -> DQ -> output (QuantReluFusion + QDQFinalCleanupTransformer transformers)
-      const bool fuse_relu = (zp == -128) &&
-                             (opt_level == TransformerLevel::Level2 || opt_level == TransformerLevel::Level3);
-      EXPECT_EQ(op_to_count[qdq_keys.quantize_linear], fuse_relu ? 0 : 1);
-      EXPECT_EQ(op_to_count["Relu"], fuse_relu ? 0 : 1);
-      EXPECT_EQ(op_to_count[qdq_keys.dequantize_linear], fuse_relu ? 1 : 2);
-    };
-
-    constexpr float epsilon = std::numeric_limits<float>::epsilon();
-
-    TransformerTester(build_test_case, check_relu_graph,
-                      TransformerLevel::Default,
-                      opt_level,
-                      18,
-                      epsilon,
-                      epsilon);
-  };
-
-  test_case(TransformerLevel::Level1, -128);  // Will not fuse Relu into QuantizeLinear due to level1 opt.
-  test_case(TransformerLevel::Level2, -128);  // Will fuse Relu into QuantizeLinear.
-  test_case(TransformerLevel::Level3, -128);  // Will fuse Relu into QuantizeLinear.
-  test_case(TransformerLevel::Level3, 0);     // Will not fuse Relu into QuantizeLinear due to zero-point != -128
-}
-
 TEST(QDQTransformerTests, Concat) {
   auto test_case = [&](const std::vector<std::vector<int64_t>>& input_shapes,
                        int64_t axis,

--- a/onnxruntime/test/optimizer/qdq_transformer_test.cc
+++ b/onnxruntime/test/optimizer/qdq_transformer_test.cc
@@ -3037,7 +3037,7 @@ TEST(QDQTransformerTests, Clip) {
 
     TransformerTester(build_test_case, check_clip_graph,
                       TransformerLevel::Default,
-                      TransformerLevel::Level2,
+                      TransformerLevel::Level1,
                       opset_version,
                       epsilon,
                       epsilon);


### PR DESCRIPTION
And exclude OpenVINO EP conditionally on session creation.

In [#20627](https://github.com/microsoft/onnxruntime/pull/20627) and [#21329](https://github.com/microsoft/onnxruntime/pull/21329) the Clip and Relu Quant fusion is moved to Level 2. But it caused more problem since then in QNN EP.

For QNN EP after L1 Optimizer, the Graph after assigning to QNN EP is be EP nodes thus the Level 2 optimizers will not be applicable.

Then QNN EP implements a DQ -> Conv ->  Relu/Clip -> Q fusion pattern. The we discover DQs -> Add -> Relu -> Q

More similar patterns yet to take into consideration but is valid. This basically doubled the launched kernel in QNN graph which in some models contribute to about 50% of the total runtime.