### PR TITLE
Fix Maven Sha256 Checksum Issue

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/jar-maven-signing-linux.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jar-maven-signing-linux.yml
@@ -45,7 +45,8 @@ steps:
 
         for file in $(find $jar_file_directory -type f); do
             echo "Adding checksum of sha256 to file: $file"
-            sha256sum $file | awk '{print $1}' >$file.sha256
+            sha256_value=$(sha256sum $file | awk '{print $1}')
+            echo $sha256_value" *"$(basename "$file") >$file.sha256
             echo "Added checksum of sha256 to file: $file"
         done
 

--- a/tools/ci_build/github/azure-pipelines/templates/jar-maven-signing-win.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jar-maven-signing-win.yml
@@ -15,6 +15,7 @@ steps:
     displayName: 'Sign jar files: GnuPG and sha256'
     inputs:
       targetType: 'inline'
+      pwsh: true
       workingDirectory: '$(Build.SourcesDirectory)'
       script: |
         $jar_file_directory = '${{ parameters.JarFileDirectory }}'
@@ -53,15 +54,22 @@ steps:
             Write-Host "GnuPG signed to file: "$file_path
         }
 
+        $PSDefaultParameterValues['Out-File:Encoding'] = 'utf8NoBOM'
+        $sha256sum_exe_path = "C:\Program Files\Git\usr\bin\sha256sum.exe"
         $targeting_asc_files = Get-ChildItem $jar_file_directory -Recurse -Force -File -Name
+        $original_location = Get-Location
+        Set-Location $jar_file_directory
         foreach ($file in $targeting_asc_files) {
-            $file_path = Join-Path $jar_file_directory -ChildPath $file
-            Write-Host "Adding checksum of sha256 to file: "$file_path
-            $file_path_sha256 = $file_path + ".sha256"
-            CertUtil -hashfile $file_path SHA256
-            CertUtil -hashfile $file_path SHA256 | find /v `"hash`" | Out-File -FilePath $file_path_sha256
-            Write-Host "Added checksum of sha256 to file: "$file_path
+            Write-Host "Adding checksum of sha256 to file: "$file
+            $file_path_sha256 = $file + ".sha256"
+            & $sha256sum_exe_path $file  1>$file_path_sha256
+            if ($lastExitCode -ne 0) {
+                Write-Host -Object "sha256sum command failed. Exitcode: $exitCode"
+                exit $lastExitCode
+            }
+            Write-Host "Added checksum of sha256 to file: "$file
         }
+        Set-Location $original_location
 
         Write-Host "GnuPG and sha256 signing to files completed."
         Write-Host "Deleting GnuPG key files."


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
**Changes applied to maven related signing:** 
* Windows sha256 file encoded by utf8(no BOM)
* powershell script task used latest version, previous 5.1 version only supports utf8 with BOM. 
* Windows sha256 file content in format 'sha256value *filename.extension'.
* Linux sha256 file content in format 'sha256value *filename.extension'.

**More information about powershell encoding:**
Windows powershell encoding reference: [about_Character_Encoding - PowerShell | Microsoft Learn](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_character_encoding?view=powershell-7.4)
- for version 5.1, it only has 'UTF8 Uses UTF-8 (with BOM).'
- for version v7.1 and higher, it has:
     utf8: Encodes in UTF-8 format (no BOM).
     utf8BOM: Encodes in UTF-8 format with Byte Order Mark (BOM)
     utf8NoBOM: Encodes in UTF-8 format without Byte Order Mark (BOM)



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


