### PR TITLE
Introduce session option "session.allow_stripping_qdq_nodes"

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -63,6 +63,13 @@ static const char* const kOrtSessionOptionsDisableDoubleQDQRemover = "session.di
 // Available since version 1.11.
 static const char* const kOrtSessionOptionsEnableQuantQDQCleanup = "session.enable_quant_qdq_cleanup";
 
+// Allow stripping Q and DQ nodes from a quantized model to fallback to a floating point model.
+// This can be used when a session is created with a quantized model but the EP or the device does not support it.
+// Option values:
+// - "0": disabled. [DEFAULT]
+// - "1": enabled.
+static const char* const kOrtSessionOptionsAllowStrippingQDQ = "session.allow_stripping_qdq_nodes";
+
 // Enable or disable gelu approximation in graph optimization. "0": disable; "1": enable. The default is "0".
 // GeluApproximation has side effects which may change the inference results. It is disabled by default due to this.
 static const char* const kOrtSessionOptionsEnableGeluApproximation = "optimization.enable_gelu_approximation";

--- a/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
+++ b/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
@@ -319,7 +319,7 @@ struct OpenVINO_Provider : Provider {
       else if (bool_flag == "false" || bool_flag == "False")
         enable_qdq_optimizer = false;
       else
-        ORT_THROW("[ERROR] [OpenVINO-EP] enable_qdq_optimiser should be a boolean.\n");
+        ORT_THROW("[ERROR] [OpenVINO-EP] enable_qdq_optimizer should be a boolean.\n");
       bool_flag = "";
     }
 

--- a/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
+++ b/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
@@ -60,7 +60,7 @@ std::unique_ptr<IExecutionProvider> OpenVINOProviderFactory::CreateProvider() {
   if (so_allow_stripping_qdq && !enable_qdq_optimizer_) {
     LOGS_DEFAULT(WARNING) << "[OpenVINO] enable_qdq_optimizer is set to false with provider option but is enabled at "
                           << "session level with " << kOrtSessionOptionsAllowStrippingQDQ << " set to true. "
-                          << "Override it with session options.";
+                          << "Overriding based on session options and setting enabled_qdq_optimizer to true.";
     enable_qdq_optimizer_ = so_allow_stripping_qdq;
   }
 


### PR DESCRIPTION
This is used to guard againt dangerous qdq node stripping logic. Some EP will conditionally remove qdq nodes from a quantized model to fallback to a floating point model. This is dangerous because it can change the inference results. Previously it was guarded at EP level but breaks session level optimization precondition so some optimizations are move solely to fix the perticular EP.

Related #22579
