### PR TITLE
CMake: Refactor Build Folder Structure

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -17,6 +17,11 @@ cmake_policy(SET CMP0104 OLD)
 # Enable Hot Reload for MSVC compilers if supported.
 cmake_policy(SET CMP0141 NEW)
 
+# Disable subbuild system with CMP0168 NEW
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.30")
+  cmake_policy(SET CMP0168 NEW)
+endif()
+
 # Project
 project(onnxruntime C CXX ASM)
 
@@ -381,10 +386,22 @@ if (onnxruntime_USE_ROCM)
 endif()
 
 
+get_filename_component(BUILD_DIR_NO_CONFIG "${CMAKE_BINARY_DIR}" DIRECTORY)
 
 # Single output director for all binaries
-set(RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin CACHE PATH "Single output directory for all binaries.")
-
+get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if (isMultiConfig)
+  foreach(OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES})
+    string( TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG )
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${CMAKE_BINARY_DIR}/bin CACHE PATH "Single output directory for all binaries.")
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${CMAKE_BINARY_DIR}/lib CACHE PATH "Single output directory for all libararies.")
+    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${CMAKE_BINARY_DIR}/archive CACHE PATH "Single output directory for all archives.")
+  endforeach(OUTPUTCONFIG CMAKE_CONFIGURATION_TYPES)
+else()
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin CACHE PATH "Single output directory for all binaries.")
+  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib CACHE PATH "Single output directory for all libararies.")
+  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/arch CACHE PATH "Single output directory for all librarries." )
+endif()
 
 include(FetchContent)
 
@@ -630,6 +647,9 @@ if (WIN32)
     list(APPEND ORT_WARNING_FLAGS "/wd5054")
     # Enable warning: data member 'member' will be initialized after data member 'member2' / base class 'base_class'
     list(APPEND ORT_WARNING_FLAGS "/w15038")
+
+    # This flag helps pass eigen3 build.
+    list(APPEND ORT_WARNING_FLAGS "/wd4996")
 
     # set linker flags to minimize the binary size.
     if (MSVC)

--- a/cmake/external/abseil-cpp.cmake
+++ b/cmake/external/abseil-cpp.cmake
@@ -10,7 +10,7 @@ set(ABSL_BUILD_TESTING OFF)
 set(ABSL_BUILD_TEST_HELPERS OFF)
 set(ABSL_USE_EXTERNAL_GOOGLETEST ON)
 if(Patch_FOUND AND WIN32)
-  set(ABSL_PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/abseil/absl_windows.patch)
+  set(ABSL_PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 --input=${PROJECT_SOURCE_DIR}/patches/abseil/absl_windows.patch)
 else()
   set(ABSL_PATCH_COMMAND "")
 endif()
@@ -27,6 +27,9 @@ FetchContent_Declare(
     URL ${DEP_URL_abseil_cpp}
     URL_HASH SHA1=${DEP_SHA1_abseil_cpp}
     PATCH_COMMAND ${ABSL_PATCH_COMMAND}
+    SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/abseil_cpp-src
+    BINARY_DIR ${CMAKE_BINARY_DIR}/deps/abseil_cpp-build
+    DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/abseil_cpp-download
     FIND_PACKAGE_ARGS 20240722 NAMES absl
 )
 

--- a/cmake/external/composable_kernel.cmake
+++ b/cmake/external/composable_kernel.cmake
@@ -5,6 +5,10 @@ include(FetchContent)
 FetchContent_Declare(composable_kernel
   URL ${DEP_URL_composable_kernel}
   URL_HASH SHA1=${DEP_SHA1_composable_kernel}
+
+  SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/composable_kernel-src
+  BINARY_DIR ${CMAKE_BINARY_DIR}/deps/composable_kernel-build
+  DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/composable_kernel-download
   PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PATCH_CLANG} &&
                 ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PATCH_GFX12X}
 )

--- a/cmake/external/cudnn_frontend.cmake
+++ b/cmake/external/cudnn_frontend.cmake
@@ -3,6 +3,9 @@ FetchContent_Declare(
   cudnn_frontend
   URL ${DEP_URL_cudnn_frontend}
   URL_HASH SHA1=${DEP_SHA1_cudnn_frontend}
+  SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/cudnn_frontend-src
+  BINARY_DIR ${CMAKE_BINARY_DIR}/deps/cudnn_frontend-build
+  DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/cudnn_frontend-download
 )
 
 set(CUDNN_FRONTEND_BUILD_SAMPLES OFF)

--- a/cmake/external/cutlass.cmake
+++ b/cmake/external/cutlass.cmake
@@ -3,6 +3,9 @@ FetchContent_Declare(
   cutlass
   URL ${DEP_URL_cutlass}
   URL_HASH SHA1=${DEP_SHA1_cutlass}
+  SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/cutlass-src
+  BINARY_DIR ${CMAKE_BINARY_DIR}/deps/cutlass-build
+  DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/cutlass-download
 )
 
 FetchContent_GetProperties(cutlass)

--- a/cmake/external/dml.cmake
+++ b/cmake/external/dml.cmake
@@ -104,6 +104,9 @@ FetchContent_Declare(
     directx_headers
     URL ${DEP_URL_directx_headers}
     URL_HASH SHA1=${DEP_SHA1_directx_headers}
+    SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/directx_headers-src
+    BINARY_DIR ${CMAKE_BINARY_DIR}/deps/directx_headers-build
+    DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/directx_headers-download
 )
 
 FetchContent_Populate(directx_headers)

--- a/cmake/external/eigen.cmake
+++ b/cmake/external/eigen.cmake
@@ -8,13 +8,19 @@ else ()
             eigen
             URL ${DEP_URL_eigen}
             URL_HASH SHA1=${DEP_SHA1_eigen}
-            PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/eigen/eigen-aix.patch
+            PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 --input=${PROJECT_SOURCE_DIR}/patches/eigen/eigen-aix.patch
+            SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/eigen-src
+            BINARY_DIR ${CMAKE_BINARY_DIR}/deps/eigen-build
+            DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/eigen-download
         )
     else()
         FetchContent_Declare(
             eigen
             URL ${DEP_URL_eigen}
             URL_HASH SHA1=${DEP_SHA1_eigen}
+            SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/eigen-src
+            BINARY_DIR ${CMAKE_BINARY_DIR}/deps/eigen-build
+            DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/eigen-download
         )
     endif()
 

--- a/cmake/external/extensions.cmake
+++ b/cmake/external/extensions.cmake
@@ -42,6 +42,9 @@ if (NOT onnxruntime_EXTENSIONS_OVERRIDDEN)
     extensions
     URL ${DEP_URL_extensions}
     URL_HASH SHA1=${DEP_SHA1_extensions}
+    SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/extensions-src
+    BINARY_DIR ${CMAKE_BINARY_DIR}/deps/extensions-build
+    DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/extensions-download
   )
   onnxruntime_fetchcontent_makeavailable(extensions)
 else()
@@ -62,4 +65,3 @@ onnxruntime_add_include_to_target(noexcep_operators ${PROTOBUF_LIB} ${ABSEIL_LIB
 
 add_dependencies(ocos_operators ${onnxruntime_EXTERNAL_DEPENDENCIES})
 add_dependencies(ortcustomops ${onnxruntime_EXTERNAL_DEPENDENCIES})
-

--- a/cmake/external/helper_functions.cmake
+++ b/cmake/external/helper_functions.cmake
@@ -146,7 +146,6 @@ macro(onnxruntime_fetchcontent_makeavailable)
     else()
       unset(__cmake_haveFpArgs)
     endif()
-
     FetchContent_GetProperties(${__cmake_contentName})
     if(NOT ${__cmake_contentNameLower}_POPULATED)
       FetchContent_Populate(${__cmake_contentName})

--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -36,10 +36,13 @@ include(external/abseil-cpp.cmake)
 set(RE2_BUILD_TESTING OFF CACHE BOOL "" FORCE)
 
 FetchContent_Declare(
-    re2
-    URL ${DEP_URL_re2}
-    URL_HASH SHA1=${DEP_SHA1_re2}
-    FIND_PACKAGE_ARGS NAMES re2
+  re2
+  URL ${DEP_URL_re2}
+  URL_HASH SHA1=${DEP_SHA1_re2}
+  SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/re2-src
+  BINARY_DIR ${CMAKE_BINARY_DIR}/deps/re2-build
+  DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/re2-download
+  FIND_PACKAGE_ARGS NAMES re2
 )
 onnxruntime_fetchcontent_makeavailable(re2)
 
@@ -66,6 +69,9 @@ if (onnxruntime_BUILD_UNIT_TESTS)
     googletest
     URL ${DEP_URL_googletest}
     URL_HASH SHA1=${DEP_SHA1_googletest}
+    SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/googletest-src
+    BINARY_DIR ${CMAKE_BINARY_DIR}/deps/googletest-build
+    DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/googletest-download
     FIND_PACKAGE_ARGS 1.14.0...<2.0.0 NAMES GTest
   )
   FetchContent_MakeAvailable(googletest)
@@ -81,17 +87,22 @@ if (onnxruntime_BUILD_BENCHMARKS)
     google_benchmark
     URL ${DEP_URL_google_benchmark}
     URL_HASH SHA1=${DEP_SHA1_google_benchmark}
+    SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/google_benchmark-src
+    BINARY_DIR ${CMAKE_BINARY_DIR}/deps/google_benchmark-build
+    DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/google_benchmark-download
     FIND_PACKAGE_ARGS NAMES benchmark
   )
   onnxruntime_fetchcontent_makeavailable(google_benchmark)
 endif()
-
 
 if(onnxruntime_USE_MIMALLOC)
   FetchContent_Declare(
     mimalloc
     URL ${DEP_URL_mimalloc}
     URL_HASH SHA1=${DEP_SHA1_mimalloc}
+    SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/mimalloc-src
+    BINARY_DIR ${CMAKE_BINARY_DIR}/deps/mimalloc-build
+    DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/mimalloc-download
     FIND_PACKAGE_ARGS NAMES mimalloc
   )
   FetchContent_MakeAvailable(mimalloc)
@@ -99,10 +110,13 @@ endif()
 
 #Protobuf depends on utf8_range
 FetchContent_Declare(
-    utf8_range
-    URL ${DEP_URL_utf8_range}
-    URL_HASH SHA1=${DEP_SHA1_utf8_range}
-    FIND_PACKAGE_ARGS NAMES utf8_range
+  utf8_range
+  URL ${DEP_URL_utf8_range}
+  URL_HASH SHA1=${DEP_SHA1_utf8_range}
+  SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/utf8_range-src
+  BINARY_DIR ${CMAKE_BINARY_DIR}/deps/utf8_range-build
+  DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/utf8_range-download
+  FIND_PACKAGE_ARGS NAMES utf8_range
 )
 
 set(utf8_range_ENABLE_TESTS OFF CACHE BOOL "Build test suite" FORCE)
@@ -122,7 +136,14 @@ if(NOT ONNX_CUSTOM_PROTOC_EXECUTABLE)
     # Using CMAKE_CROSSCOMPILING is not recommended for Apple target devices.
     # https://cmake.org/cmake/help/v3.26/variable/CMAKE_CROSSCOMPILING.html
     # To keep it simple, just download and use the universal protoc binary for all Apple host builds.
-    FetchContent_Declare(protoc_binary URL ${DEP_URL_protoc_mac_universal} URL_HASH SHA1=${DEP_SHA1_protoc_mac_universal})
+    FetchContent_Declare(
+      protoc_binary
+      URL ${DEP_URL_protoc_mac_universal}
+      URL_HASH SHA1=${DEP_SHA1_protoc_mac_universal}
+      SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/protoc_binary-src
+      BINARY_DIR ${CMAKE_BINARY_DIR}/deps/protoc_binary-build
+      DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/protoc_binary-download
+    )
     FetchContent_Populate(protoc_binary)
     if(protoc_binary_SOURCE_DIR)
       message(STATUS "Use prebuilt protoc")
@@ -133,10 +154,24 @@ if(NOT ONNX_CUSTOM_PROTOC_EXECUTABLE)
     message(STATUS "CMAKE_HOST_SYSTEM_NAME: ${CMAKE_HOST_SYSTEM_NAME}")
     if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
       if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "AMD64")
-        FetchContent_Declare(protoc_binary URL ${DEP_URL_protoc_win64} URL_HASH SHA1=${DEP_SHA1_protoc_win64})
+        FetchContent_Declare(
+          protoc_binary
+          URL ${DEP_URL_protoc_win64}
+          URL_HASH SHA1=${DEP_SHA1_protoc_win64}
+          SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/protoc_binary-src
+          BINARY_DIR ${CMAKE_BINARY_DIR}/deps/protoc_binary-build
+          DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/protoc_binary-download
+        )
         FetchContent_Populate(protoc_binary)
       elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86")
-        FetchContent_Declare(protoc_binary URL ${DEP_URL_protoc_win32} URL_HASH SHA1=${DEP_SHA1_protoc_win32})
+        FetchContent_Declare(
+          protoc_binary
+          URL ${DEP_URL_protoc_win32}
+          URL_HASH SHA1=${DEP_SHA1_protoc_win32}
+          SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/protoc_binary-src
+          BINARY_DIR ${CMAKE_BINARY_DIR}/deps/protoc_binary-build
+          DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/protoc_binary-download
+        )
         FetchContent_Populate(protoc_binary)
       endif()
 
@@ -147,13 +182,34 @@ if(NOT ONNX_CUSTOM_PROTOC_EXECUTABLE)
       endif()
     elseif(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
       if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64)$")
-        FetchContent_Declare(protoc_binary URL ${DEP_URL_protoc_linux_x64} URL_HASH SHA1=${DEP_SHA1_protoc_linux_x64})
+        FetchContent_Declare(
+          protoc_binary
+          URL ${DEP_URL_protoc_linux_x64}
+          URL_HASH SHA1=${DEP_SHA1_protoc_linux_x64}
+          SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/protoc_binary-src
+          BINARY_DIR ${CMAKE_BINARY_DIR}/deps/protoc_binary-build
+          DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/protoc_binary-download
+        )
         FetchContent_Populate(protoc_binary)
       elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(i.86|x86?)$")
-        FetchContent_Declare(protoc_binary URL ${DEP_URL_protoc_linux_x86} URL_HASH SHA1=${DEP_SHA1_protoc_linux_x86})
+        FetchContent_Declare(
+          protoc_binary
+          URL ${DEP_URL_protoc_linux_x86}
+          URL_HASH SHA1=${DEP_SHA1_protoc_linux_x86}
+          SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/protoc_binary-src
+          BINARY_DIR ${CMAKE_BINARY_DIR}/deps/protoc_binary-build
+          DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/protoc_binary-download
+        )
         FetchContent_Populate(protoc_binary)
       elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64.*")
-        FetchContent_Declare(protoc_binary URL ${DEP_URL_protoc_linux_aarch64} URL_HASH SHA1=${DEP_SHA1_protoc_linux_aarch64})
+        FetchContent_Declare(
+          protoc_binary
+          URL ${DEP_URL_protoc_linux_aarch64}
+          URL_HASH SHA1=${DEP_SHA1_protoc_linux_aarch64}
+          SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/protoc_binary-src
+          BINARY_DIR ${CMAKE_BINARY_DIR}/deps/protoc_binary-build
+          DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/protoc_binary-download
+        )
         FetchContent_Populate(protoc_binary)
       endif()
 
@@ -185,7 +241,7 @@ endif()
 #   for cross-compiling
 #2. if ONNX_CUSTOM_PROTOC_EXECUTABLE is not set, Compile everything(including protoc) from source code.
 if(Patch_FOUND)
-  set(ONNXRUNTIME_PROTOBUF_PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/protobuf/protobuf_cmake.patch)
+  set(ONNXRUNTIME_PROTOBUF_PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 --input=${PROJECT_SOURCE_DIR}/patches/protobuf/protobuf_cmake.patch)
 else()
  set(ONNXRUNTIME_PROTOBUF_PATCH_COMMAND "")
 endif()
@@ -196,6 +252,9 @@ FetchContent_Declare(
   URL ${DEP_URL_protobuf}
   URL_HASH SHA1=${DEP_SHA1_protobuf}
   PATCH_COMMAND ${ONNXRUNTIME_PROTOBUF_PATCH_COMMAND}
+  SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/Protobuf-src
+  BINARY_DIR ${CMAKE_BINARY_DIR}/deps/Protobuf-build
+  DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/Protobuf-download
   FIND_PACKAGE_ARGS NAMES Protobuf protobuf
 )
 
@@ -270,6 +329,9 @@ FetchContent_Declare(
   date
   URL ${DEP_URL_date}
   URL_HASH SHA1=${DEP_SHA1_date}
+  SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/date-src
+  BINARY_DIR ${CMAKE_BINARY_DIR}/deps/date-build
+  DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/date-download
   FIND_PACKAGE_ARGS 3...<4 NAMES date
 )
 onnxruntime_fetchcontent_makeavailable(date)
@@ -278,6 +340,9 @@ FetchContent_Declare(
   mp11
   URL ${DEP_URL_mp11}
   URL_HASH SHA1=${DEP_SHA1_mp11}
+  SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/mp11-src
+  BINARY_DIR ${CMAKE_BINARY_DIR}/deps/mp11-build
+  DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/mp11-download
   FIND_PACKAGE_ARGS NAMES Boost
 )
 onnxruntime_fetchcontent_makeavailable(mp11)
@@ -293,10 +358,13 @@ set(JSON_BuildTests OFF CACHE INTERNAL "")
 set(JSON_Install OFF CACHE INTERNAL "")
 
 FetchContent_Declare(
-    nlohmann_json
-    URL ${DEP_URL_json}
-    URL_HASH SHA1=${DEP_SHA1_json}
-    FIND_PACKAGE_ARGS 3.10 NAMES nlohmann_json
+  nlohmann_json
+  URL ${DEP_URL_json}
+  URL_HASH SHA1=${DEP_SHA1_json}
+  SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/nlohmann_json-src
+  BINARY_DIR ${CMAKE_BINARY_DIR}/deps/nlohmann_json-build
+  DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/nlohmann_json-download
+  FIND_PACKAGE_ARGS 3.10 NAMES nlohmann_json
 )
 onnxruntime_fetchcontent_makeavailable(nlohmann_json)
 
@@ -358,7 +426,10 @@ if (CPUINFO_SUPPORTED)
         pytorch_cpuinfo
         URL ${DEP_URL_pytorch_cpuinfo}
         URL_HASH SHA1=${DEP_SHA1_pytorch_cpuinfo}
-        PATCH_COMMAND ${Patch_EXECUTABLE} -p1 < ${PROJECT_SOURCE_DIR}/patches/cpuinfo/9bb12d342fd9479679d505d93a478a6f9cd50a47.patch
+        PATCH_COMMAND ${Patch_EXECUTABLE} -p1 --input=${PROJECT_SOURCE_DIR}/patches/cpuinfo/9bb12d342fd9479679d505d93a478a6f9cd50a47.patch
+        SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/pytorch_cpuinfo-src
+        BINARY_DIR ${CMAKE_BINARY_DIR}/deps/pytorch_cpuinfo-build
+        DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/pytorch_cpuinfo-download
         FIND_PACKAGE_ARGS NAMES cpuinfo
       )
   else()
@@ -366,6 +437,9 @@ if (CPUINFO_SUPPORTED)
         pytorch_cpuinfo
         URL ${DEP_URL_pytorch_cpuinfo}
         URL_HASH SHA1=${DEP_SHA1_pytorch_cpuinfo}
+        SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/pytorch_cpuinfo-src
+        BINARY_DIR ${CMAKE_BINARY_DIR}/deps/pytorch_cpuinfo-build
+        DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/pytorch_cpuinfo-download
         FIND_PACKAGE_ARGS NAMES cpuinfo
       )
   endif()
@@ -386,6 +460,9 @@ if ((CPUINFO_SUPPORTED OR onnxruntime_USE_XNNPACK) AND NOT ANDROID)
     URL ${DEP_URL_pytorch_cpuinfo}
     URL_HASH SHA1=${DEP_SHA1_pytorch_cpuinfo}
     SOURCE_SUBDIR deps/clog
+    SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/pytorch_clog-src
+    BINARY_DIR ${CMAKE_BINARY_DIR}/deps/pytorch_clog-build
+    DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/pytorch_clog-download
     FIND_PACKAGE_ARGS NAMES cpuinfo
   )
   set(ONNXRUNTIME_CLOG_PROJ pytorch_clog)
@@ -405,7 +482,10 @@ if(onnxruntime_USE_CUDA)
     GSL
     URL ${DEP_URL_microsoft_gsl}
     URL_HASH SHA1=${DEP_SHA1_microsoft_gsl}
-    PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/gsl/1064.patch
+    PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 --input=${PROJECT_SOURCE_DIR}/patches/gsl/1064.patch
+    SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/GSL-src
+    BINARY_DIR ${CMAKE_BINARY_DIR}/deps/GSL-build
+    DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/GSL-download
     FIND_PACKAGE_ARGS 4.0 NAMES Microsoft.GSL
   )
 else()
@@ -413,6 +493,9 @@ else()
     GSL
     URL ${DEP_URL_microsoft_gsl}
     URL_HASH SHA1=${DEP_SHA1_microsoft_gsl}
+    SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/GSL-src
+    BINARY_DIR ${CMAKE_BINARY_DIR}/deps/GSL-build
+    DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/GSL-download
     FIND_PACKAGE_ARGS 4.0 NAMES Microsoft.GSL
   )
 endif()
@@ -424,9 +507,12 @@ find_path(safeint_SOURCE_DIR NAMES "SafeInt.hpp")
 if(NOT safeint_SOURCE_DIR)
   unset(safeint_SOURCE_DIR)
   FetchContent_Declare(
-      safeint
-      URL ${DEP_URL_safeint}
-      URL_HASH SHA1=${DEP_SHA1_safeint}
+    safeint
+    URL ${DEP_URL_safeint}
+    URL_HASH SHA1=${DEP_SHA1_safeint}
+    SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/safeint-src
+    BINARY_DIR ${CMAKE_BINARY_DIR}/deps/safeint-build
+    DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/safeint-download
   )
 
   # use fetch content rather than makeavailable because safeint only includes unconditional test targets
@@ -446,18 +532,21 @@ set(FLATBUFFERS_INSTALL OFF CACHE BOOL "FLATBUFFERS_INSTALL" FORCE)
 set(FLATBUFFERS_BUILD_FLATHASH OFF CACHE BOOL "FLATBUFFERS_BUILD_FLATHASH" FORCE)
 set(FLATBUFFERS_BUILD_FLATLIB ON CACHE BOOL "FLATBUFFERS_BUILD_FLATLIB" FORCE)
 if(Patch_FOUND)
-  set(ONNXRUNTIME_FLATBUFFERS_PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/flatbuffers/flatbuffers.patch)
+  set(ONNXRUNTIME_FLATBUFFERS_PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 --input=${PROJECT_SOURCE_DIR}/patches/flatbuffers/flatbuffers.patch)
 else()
  set(ONNXRUNTIME_FLATBUFFERS_PATCH_COMMAND "")
 endif()
 
 #flatbuffers 1.11.0 does not have flatbuffers::IsOutRange, therefore we require 1.12.0+
 FetchContent_Declare(
-    flatbuffers
-    URL ${DEP_URL_flatbuffers}
-    URL_HASH SHA1=${DEP_SHA1_flatbuffers}
-    PATCH_COMMAND ${ONNXRUNTIME_FLATBUFFERS_PATCH_COMMAND}
-    FIND_PACKAGE_ARGS 23.5.9 NAMES Flatbuffers flatbuffers
+  flatbuffers
+  URL ${DEP_URL_flatbuffers}
+  URL_HASH SHA1=${DEP_SHA1_flatbuffers}
+  PATCH_COMMAND ${ONNXRUNTIME_FLATBUFFERS_PATCH_COMMAND}
+  SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/flatbuffers-src
+  BINARY_DIR ${CMAKE_BINARY_DIR}/deps/flatbuffers-build
+  DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/flatbuffers-download
+  FIND_PACKAGE_ARGS 23.5.9 NAMES Flatbuffers flatbuffers
 )
 
 onnxruntime_fetchcontent_makeavailable(flatbuffers)
@@ -495,7 +584,7 @@ else()
 endif()
 
 if(Patch_FOUND)
-  set(ONNXRUNTIME_ONNX_PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/onnx/onnx.patch)
+  set(ONNXRUNTIME_ONNX_PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 --input=${PROJECT_SOURCE_DIR}/patches/onnx/onnx.patch)
 else()
   set(ONNXRUNTIME_ONNX_PATCH_COMMAND "")
 endif()
@@ -505,6 +594,9 @@ FetchContent_Declare(
   URL ${DEP_URL_onnx}
   URL_HASH SHA1=${DEP_SHA1_onnx}
   PATCH_COMMAND ${ONNXRUNTIME_ONNX_PATCH_COMMAND}
+  SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/onnx-src
+  BINARY_DIR ${CMAKE_BINARY_DIR}/deps/onnx-build
+  DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/onnx-download
   FIND_PACKAGE_ARGS NAMES ONNX onnx
 )
 if (NOT onnxruntime_MINIMAL_BUILD)
@@ -582,6 +674,9 @@ if(onnxruntime_ENABLE_ATEN)
     dlpack
     URL ${DEP_URL_dlpack}
     URL_HASH SHA1=${DEP_SHA1_dlpack}
+    SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/dlpack-src
+    BINARY_DIR ${CMAKE_BINARY_DIR}/deps/dlpack-build
+    DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/dlpack-download
     FIND_PACKAGE_ARGS NAMES dlpack
   )
   # We can't use onnxruntime_fetchcontent_makeavailable since some part of the the dlpack code is Linux only.
@@ -596,6 +691,9 @@ if(onnxruntime_ENABLE_TRAINING OR (onnxruntime_ENABLE_TRAINING_APIS AND onnxrunt
     cxxopts
     URL ${DEP_URL_cxxopts}
     URL_HASH SHA1=${DEP_SHA1_cxxopts}
+    SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/cxxopts-src
+    BINARY_DIR ${CMAKE_BINARY_DIR}/deps/cxxopts-build
+    DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/cxxopts-download
     FIND_PACKAGE_ARGS NAMES cxxopts
   )
   set(CXXOPTS_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
@@ -608,7 +706,10 @@ if (onnxruntime_USE_COREML)
     coremltools
     URL ${DEP_URL_coremltools}
     URL_HASH SHA1=${DEP_SHA1_coremltools}
-    PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/coremltools/crossplatformbuild.patch
+    PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 --input=${PROJECT_SOURCE_DIR}/patches/coremltools/crossplatformbuild.patch
+    SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/coremltools-src
+    BINARY_DIR ${CMAKE_BINARY_DIR}/deps/coremltools-build
+    DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/coremltools-download
   )
   # we don't build directly so use Populate. selected files are built from onnxruntime_providers_coreml.cmake
   FetchContent_Populate(coremltools)
@@ -619,7 +720,10 @@ if (onnxruntime_USE_WEBGPU)
     dawn
     URL ${DEP_URL_dawn}
     URL_HASH SHA1=${DEP_SHA1_dawn}
-    PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/dawn/dawn.patch
+    PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 --input=${PROJECT_SOURCE_DIR}/patches/dawn/dawn.patch
+    SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/dawn-src
+    BINARY_DIR ${CMAKE_BINARY_DIR}/deps/dawn-build
+    DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/dawn-download
   )
 
   # use dawn::dawn_native and dawn::dawn_proc instead of the monolithic dawn::webgpu_dawn to minimize binary size
@@ -656,7 +760,8 @@ if (onnxruntime_USE_WEBGPU)
 
     # Vulkan may optionally be included in a Windows build. Exclude until we have an explicit use case that requires it.
     set(DAWN_ENABLE_VULKAN OFF CACHE BOOL "" FORCE)
-    # We are currently always using the D3D12 backend.
+
+    # Dawn D3D11 backend used for compatible mode. TBD if that we need compatible mode.
     set(DAWN_ENABLE_D3D11 OFF CACHE BOOL "" FORCE)
   endif()
 

--- a/cmake/external/pybind11.cmake
+++ b/cmake/external/pybind11.cmake
@@ -1,8 +1,11 @@
 FetchContent_Declare(
     pybind11_project
     URL ${DEP_URL_pybind11}
-	URL_HASH SHA1=${DEP_SHA1_pybind11}
-	FIND_PACKAGE_ARGS 2.6 NAMES pybind11
+	  URL_HASH SHA1=${DEP_SHA1_pybind11}
+    SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/pybind11_project-src
+    BINARY_DIR ${CMAKE_BINARY_DIR}/deps/pybind11_project-build
+    DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/pybind11_project-download
+	  FIND_PACKAGE_ARGS 2.6 NAMES pybind11
 )
 onnxruntime_fetchcontent_makeavailable(pybind11_project)
 

--- a/cmake/external/tvm.cmake
+++ b/cmake/external/tvm.cmake
@@ -5,6 +5,9 @@ if (onnxruntime_USE_TVM)
     tvm
     GIT_REPOSITORY https://github.com/apache/tvm.git
     GIT_TAG        2379917985919ed3918dc12cad47f469f245be7a
+    SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/tvm-src
+    BINARY_DIR ${CMAKE_BINARY_DIR}/deps/tvm-build
+    DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/tvm-download
   )
 
   FetchContent_GetProperties(tvm)

--- a/cmake/external/wil.cmake
+++ b/cmake/external/wil.cmake
@@ -7,6 +7,9 @@ FetchContent_Declare(
   microsoft_wil
   URL ${DEP_URL_microsoft_wil}
   URL_HASH SHA1=${DEP_SHA1_microsoft_wil}
+  SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/microsoft_wil-src
+  BINARY_DIR ${CMAKE_BINARY_DIR}/deps/microsoft_wil-build
+  DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/microsoft_wil-download
   FIND_PACKAGE_ARGS NAMES wil
 )
 

--- a/cmake/external/xnnpack.cmake
+++ b/cmake/external/xnnpack.cmake
@@ -18,7 +18,14 @@ if(CMAKE_ANDROID_ARCH_ABI STREQUAL armeabi-v7a)
 endif()
 
 # fp16 depends on psimd
-FetchContent_Declare(psimd URL ${DEP_URL_psimd} URL_HASH SHA1=${DEP_SHA1_psimd})
+FetchContent_Declare(
+    psimd
+    URL ${DEP_URL_psimd}
+    URL_HASH SHA1=${DEP_SHA1_psimd}
+    SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/psimd-src
+    BINARY_DIR ${CMAKE_BINARY_DIR}/deps/psimd-build
+    DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/psimd-download
+)
 onnxruntime_fetchcontent_makeavailable(psimd)
 set(PSIMD_SOURCE_DIR ${psimd_SOURCE_DIR})
 
@@ -41,7 +48,7 @@ block(PROPAGATE fp16_PATCH_COMMAND)
   if(fp16_PATCH_REQUIRED)
     message(STATUS "Applying fp16 patch.")
     set(fp16_PATCH_FILE ${PROJECT_SOURCE_DIR}/patches/fp16/remove_math_h_dependency_from_fp16_h.patch)
-    set(fp16_PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${fp16_PATCH_FILE})
+    set(fp16_PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 --input=${fp16_PATCH_FILE})
   else()
     set(fp16_PATCH_COMMAND "")
   endif()
@@ -52,15 +59,32 @@ FetchContent_Declare(
     URL ${DEP_URL_fp16}
     URL_HASH SHA1=${DEP_SHA1_fp16}
     PATCH_COMMAND ${fp16_PATCH_COMMAND}
-    )
+    SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/fp16-src
+    BINARY_DIR ${CMAKE_BINARY_DIR}/deps/fp16-build
+    DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/fp16-download
+)
 onnxruntime_fetchcontent_makeavailable(fp16)
 
 # pthreadpool depends on fxdiv
-FetchContent_Declare(fxdiv URL ${DEP_URL_fxdiv} URL_HASH SHA1=${DEP_SHA1_fxdiv})
+FetchContent_Declare(
+    fxdiv
+    URL ${DEP_URL_fxdiv}
+    URL_HASH SHA1=${DEP_SHA1_fxdiv}
+    SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/fxdiv-src
+    BINARY_DIR ${CMAKE_BINARY_DIR}/deps/fxdiv-build
+    DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/fxdiv-download
+)
 onnxruntime_fetchcontent_makeavailable(fxdiv)
 set(FXDIV_SOURCE_DIR ${fxdiv_SOURCE_DIR})
 
-FetchContent_Declare(pthreadpool URL ${DEP_URL_pthreadpool} URL_HASH SHA1=${DEP_SHA1_pthreadpool})
+FetchContent_Declare(
+    pthreadpool
+    URL ${DEP_URL_pthreadpool}
+    URL_HASH SHA1=${DEP_SHA1_pthreadpool}
+    SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/pthreadpool-src
+    BINARY_DIR ${CMAKE_BINARY_DIR}/deps/pthreadpool-build
+    DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/pthreadpool-download
+)
 onnxruntime_fetchcontent_makeavailable(pthreadpool)
 
 # ---  Determine target processor
@@ -114,15 +138,28 @@ if(ORT_TARGET_PROCESSOR MATCHES "^arm64.*" AND NOT CMAKE_C_COMPILER_ID STREQUAL 
   # kleidiAI use CMAKE_SYSTEM_PROCESSOR to determine whether includes aarch64/arm64 ukernels
   # https://gitlab.arm.com/kleidi/kleidiai/-/blob/main/CMakeLists.txt#L134
   set(CMAKE_SYSTEM_PROCESSOR arm64)
-  FetchContent_Declare(kleidiai URL ${DEP_URL_kleidiai} URL_HASH SHA1=${DEP_SHA1_kleidiai})
+  FetchContent_Declare(
+      kleidiai
+      URL ${DEP_URL_kleidiai}
+      URL_HASH SHA1=${DEP_SHA1_kleidiai}
+      SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/kleidiai-src
+      BINARY_DIR ${CMAKE_BINARY_DIR}/deps/kleidiai-build
+      DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/kleidiai-download
+  )
   onnxruntime_fetchcontent_makeavailable(kleidiai)
   set(KLEIDIAI_SOURCE_DIR ${kleidiai_SOURCE_DIR})
 endif()
 
 
-FetchContent_Declare(googlexnnpack URL ${DEP_URL_googlexnnpack} URL_HASH SHA1=${DEP_SHA1_googlexnnpack}
-                     PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/xnnpack/AddEmscriptenAndIosSupport.patch
-                    )
+FetchContent_Declare(
+    googlexnnpack
+    URL ${DEP_URL_googlexnnpack}
+    URL_HASH SHA1=${DEP_SHA1_googlexnnpack}
+    PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 --input=${PROJECT_SOURCE_DIR}/patches/xnnpack/AddEmscriptenAndIosSupport.patch
+    SOURCE_DIR ${BUILD_DIR_NO_CONFIG}/_deps/googlexnnpack-src
+    BINARY_DIR ${CMAKE_BINARY_DIR}/deps/googlexnnpack-build
+    DOWNLOAD_DIR ${BUILD_DIR_NO_CONFIG}/_deps/googlexnnpack-download
+)
 onnxruntime_fetchcontent_makeavailable(googlexnnpack)
 set(XNNPACK_DIR ${googlexnnpack_SOURCE_DIR})
 set(XNNPACK_INCLUDE_DIR ${XNNPACK_DIR}/include)

--- a/cmake/patches/dawn/dawn.patch
+++ b/cmake/patches/dawn/dawn.patch
@@ -79,3 +79,25 @@ index 0037d83276..6372c4ee77 100644
    tint_lang_wgsl_program
    tint_lang_wgsl_sem
    tint_lang_wgsl_writer_ir_to_program
+diff --git a/third_party/CMakeLists.txt b/third_party/CMakeLists.txt
+index 05c7bb4b28..c45c1ce745 100644
+--- a/third_party/CMakeLists.txt
++++ b/third_party/CMakeLists.txt
+@@ -284,12 +284,11 @@ function(AddSubdirectoryDXC)
+     # as the rest of our binaries. Otherwise, DXC wants its outputs in bin and lib dirs.
+     get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+     if (isMultiConfig)
+-        set_target_properties(dxc dxcompiler PROPERTIES
+-            "RUNTIME_OUTPUT_DIRECTORY_DEBUG" "${CMAKE_BINARY_DIR}/$<CONFIG>"
+-            "RUNTIME_OUTPUT_DIRECTORY_RELEASE" "${CMAKE_BINARY_DIR}/$<CONFIG>"
+-            "LIBRARY_OUTPUT_DIRECTORY_DEBUG" "${CMAKE_BINARY_DIR}/$<CONFIG>"
+-            "LIBRARY_OUTPUT_DIRECTORY_RELEASE" "${CMAKE_BINARY_DIR}/$<CONFIG>"
+-        )
++        foreach( OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES} )
++            string( TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG )
++            set_target_properties(dxc dxcompiler PROPERTIES
++                                  "RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG}" "${CMAKE_BINARY_DIR}/dxc")
++        endforeach( OUTPUTCONFIG CMAKE_CONFIGURATION_TYPES )
+     else()
+         set_target_properties(dxc dxcompiler PROPERTIES
+             "RUNTIME_OUTPUT_DIRECTORY" "${CMAKE_BINARY_DIR}"


### PR DESCRIPTION
Previous build scripts (e.g. build.bat) generate build folder with multi-config system as:
- Nested config folders (e.g. build/Windows/Debug/Debug)
- Multiple deps sources in each build config folders (e.g. build/Windows/Debug/_deps and build/Windows/Release/_deps)

This PR refactors the build folder by:
- Remove nested config folder structure and use single "bin", "lib" and "arch" folder for each configuration with multi config system.
- Promote "_deps" folder from configuration folder to build root folder (e.g. From build/Windows/Debug/_deps to build/Windows/_deps).
- Created new "deps" folder in each configuration folder. (e.g. build/Windows/Debug/deps).
- The promoted _deps folder holds "deps_src" and "deps_download"(for old FetchContent behaviour).
- The new created "deps" folder holds "deps_build" to avoid redundant build caused by configuration project file overridding.
- A new command option in build.py to control whether update/download deps sources from remote url.

It achieves:
- No nested config folder structure in build folder.
- Single deps sources for each build configuration to avoid redundant downloads and builds.

### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


