### PR TITLE
[JSEP/WebGPU] Remove explicit split operator in GQA when QKV packed.

### DIFF
--- a/js/web/lib/wasm/jsep/webgpu/ops/split.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/split.ts
@@ -71,7 +71,7 @@ const writeBufferDataImpl = (outputs: readonly IndicesHelper[]) => {
       }`;
 };
 
-export const createSplitProgramInfo = (inputs: readonly TensorView[], attributes: SplitAttributes): ProgramInfo => {
+const createSplitProgramInfo = (inputs: readonly TensorView[], attributes: SplitAttributes): ProgramInfo => {
   const inputShape = inputs[0].dims;
   const inputSize = ShapeUtil.size(inputShape);
   const dataType = inputs[0].dataType;


### PR DESCRIPTION
### Description
Remove the explicit split operation to support packed QKV. Instead use indexing to read the key/value data from Q input.



### Motivation and Context
Improve GQA performance.


