### PR TITLE
Use suggest-changes@v2

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -41,12 +41,12 @@ jobs:
 
       - name: Install dependencies and run lintrunner on all files
         run: |
-          set -e
           python -m pip install --user -r requirements-dev.txt
-          python -m pip install --user lintrunner lintrunner-adapters	  
+          python -m pip install --user lintrunner lintrunner-adapters
           lintrunner init
+          set -e
           lintrunner f --all-files -v
           exit 0
-      - uses: parkerbxyz/suggest-changes@v1
+      - uses: parkerbxyz/suggest-changes@v2
         with:
           comment: 'You can commit the suggested changes from lintrunner.'

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -44,7 +44,7 @@ jobs:
           python -m pip install --user -r requirements-dev.txt
           python -m pip install --user lintrunner lintrunner-adapters
           lintrunner init
-          set -e
+          set +e
           lintrunner f --all-files -v
           exit 0
       - uses: parkerbxyz/suggest-changes@v2


### PR DESCRIPTION
Use suggest-changes@v2 (https://github.com/parkerbxyz/suggest-changes/issues/36#issuecomment-2447605058) to post suggested changes as comments instead of requested changes to streamline the review process.

- Also updated the script to `set +e` to ignore exit code only for the linter run. So that if there is errors in dependency installation we can still get signals.
