### PR TITLE
[VitisAI] Throw on compile error

### DIFF
--- a/onnxruntime/core/providers/vitisai/imp/global_api.cc
+++ b/onnxruntime/core/providers/vitisai/imp/global_api.cc
@@ -109,6 +109,7 @@ vaip_core::DllSafe<std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>> c
   auto status_ptr = reinterpret_cast<void*>(&status);
   auto ret = vaip_core::DllSafe(s_library_vitisaiep.compile_onnx_model_vitisai_ep_with_error_handling(model_path, graph_viewer.GetGraph(), options, status_ptr, change_status_with_error));
   if (!status.IsOK()) {
+    ORT_THROW(status);
   }
   return ret;
 }

--- a/onnxruntime/core/providers/vitisai/include/vaip/my_ort.h
+++ b/onnxruntime/core/providers/vitisai/include/vaip/my_ort.h
@@ -120,4 +120,5 @@ using InitializedTensorSet =
     std::unordered_map<std::string, const TensorProto*>;
 
 using ModelMetaData = std::unordered_map<std::string, std::string>;
+using error_report_func = void (*)(void*, int, const char*);
 }  // namespace vaip_core


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
We would like to add the ablility to throw an onnx error when user want to catch it.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
We would like to throw an error when the hardware is not compatible to run the model.

