### PR TITLE
Adjust max chunk size to fix error limit check from DX12 for large resources that are CPU accessible.

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/PooledUploadHeap.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/PooledUploadHeap.cpp
@@ -126,7 +126,7 @@ namespace Dml
         // No chunks were able to accommodate the allocation - create a new chunk and return that instead
 
         // At least double the capacity of the pool, limit to c_maxChunkSize so DX12 does not reject size
-        const size_t newChunkSize = std::min(std::max({ m_totalCapacity, c_minChunkSize, sizeInBytes }), c_maxChunkSize);;
+        const size_t newChunkSize = std::min(std::max({ m_totalCapacity, c_minChunkSize, sizeInBytes }), c_maxChunkSize);
         m_chunks.push_back(CreateChunk(m_device.Get(), newChunkSize));
         m_totalCapacity += newChunkSize;
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/PooledUploadHeap.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/PooledUploadHeap.cpp
@@ -125,8 +125,8 @@ namespace Dml
 
         // No chunks were able to accommodate the allocation - create a new chunk and return that instead
 
-        // At least double the capacity of the pool
-        const size_t newChunkSize = std::max({ m_totalCapacity, c_minChunkSize, sizeInBytes });
+        // At least double the capacity of the pool, limit to c_maxChunkSize so DX12 does not reject size
+        const size_t newChunkSize = std::min(std::max({ m_totalCapacity, c_minChunkSize, sizeInBytes }), c_maxChunkSize);;
         m_chunks.push_back(CreateChunk(m_device.Get(), newChunkSize));
         m_totalCapacity += newChunkSize;
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/PooledUploadHeap.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/PooledUploadHeap.h
@@ -32,6 +32,7 @@ namespace Dml
     private:
         static constexpr size_t c_minChunkSize = 1024 * 1024; // 1MB
         static constexpr size_t c_allocationAlignment = 512; // In bytes; as per D3D12 requirement for buffers
+		static constexpr size_t c_maxChunkSize = 0xffff0000; // ~4 GiB dx12 limitation for DX12 CPU visible resource
 
         // A suballoction from a chunk
         struct Allocation

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/PooledUploadHeap.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/PooledUploadHeap.h
@@ -32,7 +32,7 @@ namespace Dml
     private:
         static constexpr size_t c_minChunkSize = 1024 * 1024; // 1MB
         static constexpr size_t c_allocationAlignment = 512; // In bytes; as per D3D12 requirement for buffers
-		static constexpr size_t c_maxChunkSize = 0xffff0000; // ~4 GiB dx12 limitation for DX12 CPU visible resource
+        static constexpr size_t c_maxChunkSize = 0xFFFF0000; // ~4 GiB limitation for DX12 CPU-visible resource
 
         // A suballoction from a chunk
         struct Allocation


### PR DESCRIPTION
Adjust max chunk size to fix error limit check from DX12 for large resources that are CPU accessible.

### Description
Current agility SDK restricts CPU visible buffers to 0xFFFF0000 bytes or slightly smaller than 4GiB.  Verified restriction is still in latest Agility SDK 1.614.1.


### Motivation and Context
Allocation of Resources 4GiB or larger fail in DX12 verification layer.


