### PR TITLE
[TensorRT EP] Add new provider option to exclude nodes from running on TRT

### DIFF
--- a/include/onnxruntime/core/providers/tensorrt/tensorrt_provider_options.h
+++ b/include/onnxruntime/core/providers/tensorrt/tensorrt_provider_options.h
@@ -88,6 +88,6 @@ struct OrtTensorRTProviderOptionsV2 {
 
   const char* trt_engine_cache_prefix{nullptr};  // specify engine cache prefix
   int trt_engine_hw_compatible{0};               // Enable hardware compatibility. Default 0 = false, nonzero = true
-  const char* trt_nodes_to_exclude{nullptr};     // Exclude specific nodes from running on TRT e.g. "NonMaxSuppression,NonZero,RoiAlign".
-                                                 // Adding '~' followed by a node e.g. '~NonZero', indicates that TRT EP will ensure this node is included for input to the TRT parser.
+  const char* trt_op_types_to_exclude{nullptr};  // Exclude specific ops from running on TRT e.g. "NonMaxSuppression,NonZero,RoiAlign".
+                                                 // Adding '~' followed by a op type e.g. '~NonZero', indicates that TRT EP will ensure this op is included for input to the TRT parser.
 };

--- a/include/onnxruntime/core/providers/tensorrt/tensorrt_provider_options.h
+++ b/include/onnxruntime/core/providers/tensorrt/tensorrt_provider_options.h
@@ -88,4 +88,6 @@ struct OrtTensorRTProviderOptionsV2 {
 
   const char* trt_engine_cache_prefix{nullptr};  // specify engine cache prefix
   int trt_engine_hw_compatible{0};               // Enable hardware compatibility. Default 0 = false, nonzero = true
+  const char* trt_nodes_to_exclude{nullptr};     // Exclude specific nodes from running on TRT e.g. "NonMaxSuppression,NonZero,RoiAlign".
+                                                 // Adding '~' followed by a node e.g. '~NonZero', indicates that TRT EP will ensure this node is included for input to the TRT parser.
 };

--- a/include/onnxruntime/core/providers/tensorrt/tensorrt_provider_options.h
+++ b/include/onnxruntime/core/providers/tensorrt/tensorrt_provider_options.h
@@ -71,22 +71,22 @@ struct OrtTensorRTProviderOptionsV2 {
    *    directory by means of the "trt_onnx_model_folder_path" option.
    *
    */
-  int trt_dump_ep_context_model{0};                 // Dump EP context node model
-  const char* trt_ep_context_file_path{nullptr};    // Specify file name to dump EP context node model. Can be a path or a file name or a file name with path.
-  int trt_ep_context_embed_mode{0};                 // Specify EP context embed mode. Default 0 = context is engine cache path, 1 = context is engine binary data
-  int trt_weight_stripped_engine_enable{0};         // Enable weight-stripped engine build. Default 0 = false,
-                                                    // nonzero = true
-  const char* trt_onnx_model_folder_path{nullptr};  // Folder path relative to the current working directory for
-                                                    // the ONNX model containing the weights (applicable only when
-                                                    // the "trt_weight_stripped_engine_enable" option is enabled)
-  const void* trt_onnx_bytestream{nullptr};         // The byte stream of th original ONNX model containing the weights
-                                                    // (applicable only when the "trt_weight_stripped_engine_enable"
-                                                    // option is enabled)
-                                                    // can be updated using: UpdateTensorRTProviderOptionsWithValue
-  size_t trt_onnx_bytestream_size{0};               // size of the byte stream provided as "trt_onnx_bytestream"
-                                                    // can be updated using: UpdateTensorRTProviderOptionsWithValue
-  const char* trt_engine_cache_prefix{nullptr};     // specify engine cache prefix
-  int trt_engine_hw_compatible{0};                  // Enable hardware compatibility. Default 0 = false, nonzero = true
+  int trt_dump_ep_context_model{0};                                           // Dump EP context node model
+  const char* trt_ep_context_file_path{nullptr};                              // Specify file name to dump EP context node model. Can be a path or a file name or a file name with path.
+  int trt_ep_context_embed_mode{0};                                           // Specify EP context embed mode. Default 0 = context is engine cache path, 1 = context is engine binary data
+  int trt_weight_stripped_engine_enable{0};                                   // Enable weight-stripped engine build. Default 0 = false,
+                                                                              // nonzero = true
+  const char* trt_onnx_model_folder_path{nullptr};                            // Folder path relative to the current working directory for
+                                                                              // the ONNX model containing the weights (applicable only when
+                                                                              // the "trt_weight_stripped_engine_enable" option is enabled)
+  const void* trt_onnx_bytestream{nullptr};                                   // The byte stream of th original ONNX model containing the weights
+                                                                              // (applicable only when the "trt_weight_stripped_engine_enable"
+                                                                              // option is enabled)
+                                                                              // can be updated using: UpdateTensorRTProviderOptionsWithValue
+  size_t trt_onnx_bytestream_size{0};                                         // size of the byte stream provided as "trt_onnx_bytestream"
+                                                                              // can be updated using: UpdateTensorRTProviderOptionsWithValue
+  const char* trt_engine_cache_prefix{nullptr};                               // specify engine cache prefix
+  int trt_engine_hw_compatible{0};                                            // Enable hardware compatibility. Default 0 = false, nonzero = true
   const char* trt_op_types_to_exclude{"NonMaxSuppression,NonZero,RoiAlign"};  // Exclude specific ops from running on TRT.
                                                                               // There is a known performance issue with the DDS ops (NonMaxSuppression, NonZero and RoiAlign) from TRT versions 10.0 to 10.7.
                                                                               // TRT EP excludes DDS ops from running on TRT by default, user can override default value with empty string to include all ops.

--- a/include/onnxruntime/core/providers/tensorrt/tensorrt_provider_options.h
+++ b/include/onnxruntime/core/providers/tensorrt/tensorrt_provider_options.h
@@ -88,7 +88,6 @@ struct OrtTensorRTProviderOptionsV2 {
 
   const char* trt_engine_cache_prefix{nullptr};  // specify engine cache prefix
   int trt_engine_hw_compatible{0};               // Enable hardware compatibility. Default 0 = false, nonzero = true
-  //const char* trt_dds_ops = "NonMaxSuppression,NonZero,RoiAlign";                                               
   const char* trt_op_types_to_exclude{"NonMaxSuppression,NonZero,RoiAlign"};  // Exclude specific ops from running on TRT.
                                                                               // There is a known performance issue with the DDS ops (NonMaxSuppression, NonZero and RoiAlign) from TRT versions 10.0 to 10.7.
                                                                               // TRT EP excludes DDS ops from running on TRT by default, user can override default value with empty string to include all ops.

--- a/include/onnxruntime/core/providers/tensorrt/tensorrt_provider_options.h
+++ b/include/onnxruntime/core/providers/tensorrt/tensorrt_provider_options.h
@@ -85,9 +85,8 @@ struct OrtTensorRTProviderOptionsV2 {
                                                     // can be updated using: UpdateTensorRTProviderOptionsWithValue
   size_t trt_onnx_bytestream_size{0};               // size of the byte stream provided as "trt_onnx_bytestream"
                                                     // can be updated using: UpdateTensorRTProviderOptionsWithValue
-
-  const char* trt_engine_cache_prefix{nullptr};  // specify engine cache prefix
-  int trt_engine_hw_compatible{0};               // Enable hardware compatibility. Default 0 = false, nonzero = true
+  const char* trt_engine_cache_prefix{nullptr};     // specify engine cache prefix
+  int trt_engine_hw_compatible{0};                  // Enable hardware compatibility. Default 0 = false, nonzero = true
   const char* trt_op_types_to_exclude{"NonMaxSuppression,NonZero,RoiAlign"};  // Exclude specific ops from running on TRT.
                                                                               // There is a known performance issue with the DDS ops (NonMaxSuppression, NonZero and RoiAlign) from TRT versions 10.0 to 10.7.
                                                                               // TRT EP excludes DDS ops from running on TRT by default, user can override default value with empty string to include all ops.

--- a/include/onnxruntime/core/providers/tensorrt/tensorrt_provider_options.h
+++ b/include/onnxruntime/core/providers/tensorrt/tensorrt_provider_options.h
@@ -88,6 +88,8 @@ struct OrtTensorRTProviderOptionsV2 {
 
   const char* trt_engine_cache_prefix{nullptr};  // specify engine cache prefix
   int trt_engine_hw_compatible{0};               // Enable hardware compatibility. Default 0 = false, nonzero = true
-  const char* trt_op_types_to_exclude{nullptr};  // Exclude specific ops from running on TRT e.g. "NonMaxSuppression,NonZero,RoiAlign".
-                                                 // Adding '~' followed by a op type e.g. '~NonZero', indicates that TRT EP will ensure this op is included for input to the TRT parser.
+  //const char* trt_dds_ops = "NonMaxSuppression,NonZero,RoiAlign";                                               
+  const char* trt_op_types_to_exclude{"NonMaxSuppression,NonZero,RoiAlign"};  // Exclude specific ops from running on TRT.
+                                                                              // There is a known performance issue with the DDS ops (NonMaxSuppression, NonZero and RoiAlign) from TRT versions 10.0 to 10.7.
+                                                                              // TRT EP excludes DDS ops from running on TRT by default, user can override default value with empty string to include all ops.
 };

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -1567,7 +1567,7 @@ TensorrtExecutionProvider::TensorrtExecutionProvider(const TensorrtExecutionProv
         cuda_graph_enable_ = (std::stoi(cuda_graph_enable_env) == 0 ? false : true);
       }
 
-      const std::string op_types_to_exclude_env = onnxruntime::GetEnvironmentVar(tensorrt_env_vars::kNodesToExclude);
+      const std::string op_types_to_exclude_env = onnxruntime::GetEnvironmentVar(tensorrt_env_vars::kOpTypesToExclude);
       if (!op_types_to_exclude_env.empty()) {
         op_types_to_exclude_ = op_types_to_exclude_env;
       }

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -2489,12 +2489,12 @@ TensorrtExecutionProvider::GetCapability(const GraphViewer& graph,
   std::set<std::string> exclude_set = GetExcludedNodeSet(op_types_to_exclude_);
 
   /*
-   * There is a known performance issue with the DDS ops (NonMaxSuppression, NonZero and RoiAlign) from TRT versions 10.0 to 10.6.
+   * There is a known performance issue with the DDS ops (NonMaxSuppression, NonZero and RoiAlign) from TRT versions 10.0 to 10.7.
    * TRT EP automatically excludes DDS ops from running on TRT unless the user explicitly specifies that those ops should be included.
    *
    * Note: "~op_type" means to include the op type.
    */
-  if (trt_version_ >= 100000 && trt_version_ < 100700) {
+  if (trt_version_ >= 100000 && trt_version_ < 100800) {
     if (exclude_set.find("~NonMaxSuppression") == exclude_set.end()) exclude_set.insert("NonMaxSuppression");
     if (exclude_set.find("~NonZero") == exclude_set.end()) exclude_set.insert("NonZero");
     if (exclude_set.find("~RoiAlign") == exclude_set.end()) exclude_set.insert("RoiAlign");

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -1380,7 +1380,7 @@ TensorrtExecutionProvider::TensorrtExecutionProvider(const TensorrtExecutionProv
     cuda_graph_enable_ = info.cuda_graph_enable;
     engine_hw_compatible_ = info.engine_hw_compatible;
     nodes_to_exclude_ = info.nodes_to_exclude;
-    
+
   } else {
     try {
       const std::string max_partition_iterations_env = onnxruntime::GetEnvironmentVar(tensorrt_env_vars::kMaxPartitionIterations);
@@ -2491,13 +2491,13 @@ TensorrtExecutionProvider::GetCapability(const GraphViewer& graph,
   /*
    * There is a known performance issue with the DDS nodes (NonMaxSuppression, NonZero and RoiAlign) from TRT versions 10.0 to 10.6.
    * TRT EP automatically excludes DDS nodes from running on TRT unless the user explicitly specifies that those nodes should be included.
-   * 
+   *
    * Note: "~node_name" means to include the node.
    */
   if (trt_version_ >= 100000 && trt_version_ < 100700) {
-    if (exclude_set.find("~NonMaxSuppression") == exclude_set.end()) exclude_set.insert("NonMaxSuppression"); 
-    if (exclude_set.find("~NonZero") == exclude_set.end()) exclude_set.insert("NonZero"); 
-    if (exclude_set.find("~RoiAlign") == exclude_set.end()) exclude_set.insert("RoiAlign"); 
+    if (exclude_set.find("~NonMaxSuppression") == exclude_set.end()) exclude_set.insert("NonMaxSuppression");
+    if (exclude_set.find("~NonZero") == exclude_set.end()) exclude_set.insert("NonZero");
+    if (exclude_set.find("~RoiAlign") == exclude_set.end()) exclude_set.insert("RoiAlign");
   }
 
   // Print excluded nodes, if any.
@@ -2505,9 +2505,9 @@ TensorrtExecutionProvider::GetCapability(const GraphViewer& graph,
   for (it = exclude_set.begin(); it != exclude_set.end(); ++it) {
     std::string node = *it;
     if (node.find("~") == 0) continue;
-    LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Exclude " << node << " from running on TRT";
+    LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Exclude " << node << " from running on TRT, if any.";
     if (node == "NonMaxSuppression" || node == "NonZero" || node == "RoiAlign") {
-      LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Add \"~" << node << "\" in trt_nodes_to_exclude if " << node << " should be included in the input to TRT parser. However, it still depends on TRT parser to determine the eligibility of this node for TRT";
+      LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Add \"~" << node << "\" in trt_nodes_to_exclude if " << node << " should be included in the input to TRT parser. However, it still depends on TRT parser to determine the eligibility of this node for TRT.";
     }
   }
 
@@ -2516,7 +2516,7 @@ TensorrtExecutionProvider::GetCapability(const GraphViewer& graph,
   bool new_subgraph = true;
 
   /* Iterate all the nodes and exclude the node if:
-   *   1. It's a control flow op and its subgraph(s) is not fully TRT eligible. 
+   *   1. It's a control flow op and its subgraph(s) is not fully TRT eligible.
    *   2. It's in the exlucded set which specified by trt_nodes_to_exclude.
    */
   for (const auto& index : nodes_vector) {

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -2488,27 +2488,12 @@ TensorrtExecutionProvider::GetCapability(const GraphViewer& graph,
 
   std::set<std::string> exclude_set = GetExcludedNodeSet(op_types_to_exclude_);
 
-  /*
-   * There is a known performance issue with the DDS ops (NonMaxSuppression, NonZero and RoiAlign) from TRT versions 10.0 to 10.7.
-   * TRT EP automatically excludes DDS ops from running on TRT unless the user explicitly specifies that those ops should be included.
-   *
-   * Note: "~op_type" means to include the op type.
-   */
-  if (trt_version_ >= 100000 && trt_version_ < 100800) {
-    if (exclude_set.find("~NonMaxSuppression") == exclude_set.end()) exclude_set.insert("NonMaxSuppression");
-    if (exclude_set.find("~NonZero") == exclude_set.end()) exclude_set.insert("NonZero");
-    if (exclude_set.find("~RoiAlign") == exclude_set.end()) exclude_set.insert("RoiAlign");
-  }
-
   // Print excluded nodes, if any.
   std::set<std::string>::iterator it;
   for (it = exclude_set.begin(); it != exclude_set.end(); ++it) {
     std::string op = *it;
-    if (op.find("~") == 0) continue;
-    LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Exclude " << op << " from running on TRT, if any.";
-    if (op == "NonMaxSuppression" || op == "NonZero" || op == "RoiAlign") {
-      LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Add \"~" << op << "\" in trt_op_types_to_exclude if " << op << " should be included in the input to TRT parser. However, it still depends on TRT parser to determine the eligibility of this op for TRT.";
-    }
+    LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Exclude \"" << op << "\" from running on TRT, if any.";
+    LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Remove \"" << op << "\" from trt_op_types_to_exclude or specify trt_op_types_to_exclude with empty string to include the op in the input to TRT parser. However, it still depends on TRT parser to determine the eligibility of this op for TRT.";
   }
 
   SubGraphCollection_t parser_nodes_vector, supported_nodes_vector;

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -2462,8 +2462,7 @@ TensorrtExecutionProvider::GetCapability(const GraphViewer& graph,
   std::vector<size_t> nodes_vector(number_of_ort_nodes);
   std::iota(std::begin(nodes_vector), std::end(nodes_vector), 0);
 
-  //std::vector<size_t> filtered_nodes_vector;
-  SubGraphCollection_t supported_nodes_vector;
+  SubGraphCollection_t parser_nodes_vector, supported_nodes_vector;
   bool new_subgraph = true;
   bool supported_node = true;
 
@@ -2506,18 +2505,17 @@ TensorrtExecutionProvider::GetCapability(const GraphViewer& graph,
 
     if (supported_node) {
       if (new_subgraph) {
-        supported_nodes_vector.emplace_back();
+        parser_nodes_vector.emplace_back();
         // Mark all new graphs as "UnKnown" and will later be parsed by TRT parser
-        supported_nodes_vector.back().second = false;
+        parser_nodes_vector.back().second = false;
         new_subgraph = false;
       }
-      supported_nodes_vector.back().first.emplace_back(index);
+      parser_nodes_vector.back().first.emplace_back(index);
     } else {
       new_subgraph = true;
     }
   }
 
-  SubGraphCollection_t supported_nodes_vector, parser_nodes_vector = {{filtered_nodes_vector, false}};
   bool early_termination = false;
   supported_nodes_vector = GetSupportedList(parser_nodes_vector, 0, max_partition_iterations_, graph, &early_termination);
   if (early_termination) {

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
@@ -333,7 +333,7 @@ class TensorrtExecutionProvider : public IExecutionProvider {
   std::string nodes_to_exclude_;
 
   // The format is as for TENSORRT_VERSION: (MAJOR * 100 + MINOR) * 100 + PATCH
-  int32_t trt_version_; 
+  int32_t trt_version_;
 
   // The OrtAllocator object will be get during ep compute time
   // and should be kept for the lifetime of TRT EP object.

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
@@ -57,7 +57,7 @@ static const std::string kDumpEpContextModel = "ORT_DUMP_EP_CONTEXT_MODEL";
 static const std::string kEpContextEmbedMode = "ORT_EP_CONTEXT_EMBED_MODE";
 static const std::string kEpContextComputeCapabilityEnable = "ORT_EP_CONTEXT_COMPUTE_CAPABILITY_ENABLE";
 static const std::string kEngineCachePrefix = "ORT_TENSORRT_CACHE_PREFIX";
-static const std::string kNodesToExclude = "ORT_TENSORRT_NODES_TO_EXCLUDE";
+static const std::string kNodesToExclude = "ORT_TENSORRT_OP_TYPES_TO_EXCLUDE";
 // Old env variable for backward compatibility
 static const std::string kEngineCachePath = "ORT_TENSORRT_ENGINE_CACHE_PATH";
 }  // namespace tensorrt_env_vars
@@ -330,7 +330,7 @@ class TensorrtExecutionProvider : public IExecutionProvider {
   bool cuda_graph_enable_ = false;
   std::string cache_prefix_;
   bool engine_hw_compatible_ = false;
-  std::string nodes_to_exclude_;
+  std::string op_types_to_exclude_;
 
   // The format is as for TENSORRT_VERSION: (MAJOR * 100 + MINOR) * 100 + PATCH
   int32_t trt_version_;

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
@@ -57,6 +57,7 @@ static const std::string kDumpEpContextModel = "ORT_DUMP_EP_CONTEXT_MODEL";
 static const std::string kEpContextEmbedMode = "ORT_EP_CONTEXT_EMBED_MODE";
 static const std::string kEpContextComputeCapabilityEnable = "ORT_EP_CONTEXT_COMPUTE_CAPABILITY_ENABLE";
 static const std::string kEngineCachePrefix = "ORT_TENSORRT_CACHE_PREFIX";
+static const std::string kNodesToExclude = "ORT_TENSORRT_NODES_TO_EXCLUDE";
 // Old env variable for backward compatibility
 static const std::string kEngineCachePath = "ORT_TENSORRT_ENGINE_CACHE_PATH";
 }  // namespace tensorrt_env_vars
@@ -329,6 +330,10 @@ class TensorrtExecutionProvider : public IExecutionProvider {
   bool cuda_graph_enable_ = false;
   std::string cache_prefix_;
   bool engine_hw_compatible_ = false;
+  std::string nodes_to_exclude_;
+
+  // The format is as for TENSORRT_VERSION: (MAJOR * 100 + MINOR) * 100 + PATCH
+  int32_t trt_version_; 
 
   // The OrtAllocator object will be get during ep compute time
   // and should be kept for the lifetime of TRT EP object.

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
@@ -57,7 +57,7 @@ static const std::string kDumpEpContextModel = "ORT_DUMP_EP_CONTEXT_MODEL";
 static const std::string kEpContextEmbedMode = "ORT_EP_CONTEXT_EMBED_MODE";
 static const std::string kEpContextComputeCapabilityEnable = "ORT_EP_CONTEXT_COMPUTE_CAPABILITY_ENABLE";
 static const std::string kEngineCachePrefix = "ORT_TENSORRT_CACHE_PREFIX";
-static const std::string kNodesToExclude = "ORT_TENSORRT_OP_TYPES_TO_EXCLUDE";
+static const std::string kOpTypesToExclude = "ORT_TENSORRT_OP_TYPES_TO_EXCLUDE";
 // Old env variable for backward compatibility
 static const std::string kEngineCachePath = "ORT_TENSORRT_ENGINE_CACHE_PATH";
 }  // namespace tensorrt_env_vars

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_info.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_info.cc
@@ -56,6 +56,7 @@ constexpr const char* kDumpEpContextModel = "trt_dump_ep_context_model";
 constexpr const char* kEngineHwCompatible = "trt_engine_hw_compatible";
 constexpr const char* kONNXBytestream = "trt_onnx_bytestream";
 constexpr const char* kONNXBytestreamSize = "trt_onnx_bytestream_size";
+constexpr const char* kNodesToExclude = "trt_nodes_to_exclude";
 
 }  // namespace provider_option_names
 }  // namespace tensorrt
@@ -134,6 +135,7 @@ TensorrtExecutionProviderInfo TensorrtExecutionProviderInfo::FromProviderOptions
                 return Status::OK();
               })
           .AddAssignmentToReference(tensorrt::provider_option_names::kONNXBytestreamSize, info.onnx_bytestream_size)
+          .AddAssignmentToReference(tensorrt::provider_option_names::kNodesToExclude, info.nodes_to_exclude)
           .Parse(options));  // add new provider option here.
 
   info.user_compute_stream = user_compute_stream;
@@ -188,6 +190,7 @@ ProviderOptions TensorrtExecutionProviderInfo::ToProviderOptions(const TensorrtE
       {tensorrt::provider_option_names::kEngineHwCompatible, MakeStringWithClassicLocale(info.engine_hw_compatible)},
       {tensorrt::provider_option_names::kONNXBytestream, MakeStringWithClassicLocale(info.onnx_bytestream)},
       {tensorrt::provider_option_names::kONNXBytestreamSize, MakeStringWithClassicLocale(info.onnx_bytestream_size)},
+      {tensorrt::provider_option_names::kNodesToExclude, MakeStringWithClassicLocale(info.nodes_to_exclude)},
   };
   return options;
 }
@@ -206,6 +209,7 @@ ProviderOptions TensorrtExecutionProviderInfo::ToProviderOptions(const OrtTensor
   const std::string kProfilesOptShapes_ = empty_if_null(info.trt_profile_opt_shapes);
   const std::string kEpContextFilePath_ = empty_if_null(info.trt_ep_context_file_path);
   const std::string kOnnxModelFolderPath_ = empty_if_null(info.trt_onnx_model_folder_path);
+  const std::string kNodesToExclude_ = empty_if_null(info.trt_nodes_to_exclude);
 
   const ProviderOptions options{
       {tensorrt::provider_option_names::kDeviceId, MakeStringWithClassicLocale(info.device_id)},
@@ -251,6 +255,7 @@ ProviderOptions TensorrtExecutionProviderInfo::ToProviderOptions(const OrtTensor
       {tensorrt::provider_option_names::kEngineHwCompatible, MakeStringWithClassicLocale(info.trt_engine_hw_compatible)},
       {tensorrt::provider_option_names::kONNXBytestream, MakeStringWithClassicLocale(reinterpret_cast<size_t>(info.trt_onnx_bytestream))},
       {tensorrt::provider_option_names::kONNXBytestreamSize, MakeStringWithClassicLocale(info.trt_onnx_bytestream_size)},
+      {tensorrt::provider_option_names::kNodesToExclude, kNodesToExclude_},
   };
   return options;
 }
@@ -355,5 +360,6 @@ void TensorrtExecutionProviderInfo::UpdateProviderOptions(void* provider_options
   trt_provider_options_v2.trt_engine_hw_compatible = internal_options.engine_hw_compatible;
   trt_provider_options_v2.trt_onnx_bytestream = internal_options.onnx_bytestream;
   trt_provider_options_v2.trt_onnx_bytestream_size = internal_options.onnx_bytestream_size;
+  trt_provider_options_v2.trt_nodes_to_exclude = copy_string_if_needed(internal_options.nodes_to_exclude);
 }
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_info.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_info.cc
@@ -56,7 +56,7 @@ constexpr const char* kDumpEpContextModel = "trt_dump_ep_context_model";
 constexpr const char* kEngineHwCompatible = "trt_engine_hw_compatible";
 constexpr const char* kONNXBytestream = "trt_onnx_bytestream";
 constexpr const char* kONNXBytestreamSize = "trt_onnx_bytestream_size";
-constexpr const char* kNodesToExclude = "trt_nodes_to_exclude";
+constexpr const char* kOpTypesToExclude = "trt_op_types_to_exclude";
 
 }  // namespace provider_option_names
 }  // namespace tensorrt
@@ -135,7 +135,7 @@ TensorrtExecutionProviderInfo TensorrtExecutionProviderInfo::FromProviderOptions
                 return Status::OK();
               })
           .AddAssignmentToReference(tensorrt::provider_option_names::kONNXBytestreamSize, info.onnx_bytestream_size)
-          .AddAssignmentToReference(tensorrt::provider_option_names::kNodesToExclude, info.nodes_to_exclude)
+          .AddAssignmentToReference(tensorrt::provider_option_names::kOpTypesToExclude, info.op_types_to_exclude)
           .Parse(options));  // add new provider option here.
 
   info.user_compute_stream = user_compute_stream;
@@ -190,7 +190,7 @@ ProviderOptions TensorrtExecutionProviderInfo::ToProviderOptions(const TensorrtE
       {tensorrt::provider_option_names::kEngineHwCompatible, MakeStringWithClassicLocale(info.engine_hw_compatible)},
       {tensorrt::provider_option_names::kONNXBytestream, MakeStringWithClassicLocale(info.onnx_bytestream)},
       {tensorrt::provider_option_names::kONNXBytestreamSize, MakeStringWithClassicLocale(info.onnx_bytestream_size)},
-      {tensorrt::provider_option_names::kNodesToExclude, MakeStringWithClassicLocale(info.nodes_to_exclude)},
+      {tensorrt::provider_option_names::kOpTypesToExclude, MakeStringWithClassicLocale(info.op_types_to_exclude)},
   };
   return options;
 }
@@ -209,7 +209,7 @@ ProviderOptions TensorrtExecutionProviderInfo::ToProviderOptions(const OrtTensor
   const std::string kProfilesOptShapes_ = empty_if_null(info.trt_profile_opt_shapes);
   const std::string kEpContextFilePath_ = empty_if_null(info.trt_ep_context_file_path);
   const std::string kOnnxModelFolderPath_ = empty_if_null(info.trt_onnx_model_folder_path);
-  const std::string kNodesToExclude_ = empty_if_null(info.trt_nodes_to_exclude);
+  const std::string kOpTypesToExclude_ = empty_if_null(info.trt_op_types_to_exclude);
 
   const ProviderOptions options{
       {tensorrt::provider_option_names::kDeviceId, MakeStringWithClassicLocale(info.device_id)},
@@ -255,7 +255,7 @@ ProviderOptions TensorrtExecutionProviderInfo::ToProviderOptions(const OrtTensor
       {tensorrt::provider_option_names::kEngineHwCompatible, MakeStringWithClassicLocale(info.trt_engine_hw_compatible)},
       {tensorrt::provider_option_names::kONNXBytestream, MakeStringWithClassicLocale(reinterpret_cast<size_t>(info.trt_onnx_bytestream))},
       {tensorrt::provider_option_names::kONNXBytestreamSize, MakeStringWithClassicLocale(info.trt_onnx_bytestream_size)},
-      {tensorrt::provider_option_names::kNodesToExclude, kNodesToExclude_},
+      {tensorrt::provider_option_names::kOpTypesToExclude, kOpTypesToExclude_},
   };
   return options;
 }
@@ -360,6 +360,6 @@ void TensorrtExecutionProviderInfo::UpdateProviderOptions(void* provider_options
   trt_provider_options_v2.trt_engine_hw_compatible = internal_options.engine_hw_compatible;
   trt_provider_options_v2.trt_onnx_bytestream = internal_options.onnx_bytestream;
   trt_provider_options_v2.trt_onnx_bytestream_size = internal_options.onnx_bytestream_size;
-  trt_provider_options_v2.trt_nodes_to_exclude = copy_string_if_needed(internal_options.nodes_to_exclude);
+  trt_provider_options_v2.trt_op_types_to_exclude = copy_string_if_needed(internal_options.op_types_to_exclude);
 }
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_info.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_info.h
@@ -60,6 +60,7 @@ struct TensorrtExecutionProviderInfo {
   int ep_context_embed_mode{0};
   std::string engine_cache_prefix{""};
   bool engine_hw_compatible{false};
+  std::string nodes_to_exclude{""};
 
   static TensorrtExecutionProviderInfo FromProviderOptions(const ProviderOptions& options);
   static ProviderOptions ToProviderOptions(const TensorrtExecutionProviderInfo& info);

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_info.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_info.h
@@ -60,7 +60,9 @@ struct TensorrtExecutionProviderInfo {
   int ep_context_embed_mode{0};
   std::string engine_cache_prefix{""};
   bool engine_hw_compatible{false};
-  std::string op_types_to_exclude{""};
+  // There is a known performance issue with the DDS ops (NonMaxSuppression, NonZero and RoiAlign) from TRT versions 10.0 to 10.7.
+  // TRT EP excludes DDS ops from running on TRT by default, user can override default value of trt_op_types_to_exclude with empty string to include all ops.
+  std::string op_types_to_exclude{"NonMaxSuppression,NonZero,RoiAlign"};
 
   static TensorrtExecutionProviderInfo FromProviderOptions(const ProviderOptions& options);
   static ProviderOptions ToProviderOptions(const TensorrtExecutionProviderInfo& info);

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_info.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_info.h
@@ -60,7 +60,7 @@ struct TensorrtExecutionProviderInfo {
   int ep_context_embed_mode{0};
   std::string engine_cache_prefix{""};
   bool engine_hw_compatible{false};
-  std::string nodes_to_exclude{""};
+  std::string op_types_to_exclude{""};
 
   static TensorrtExecutionProviderInfo FromProviderOptions(const ProviderOptions& options);
   static ProviderOptions ToProviderOptions(const TensorrtExecutionProviderInfo& info);

--- a/onnxruntime/core/providers/tensorrt/tensorrt_provider_factory.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_provider_factory.cc
@@ -118,6 +118,7 @@ struct Tensorrt_Provider : Provider {
     info.engine_hw_compatible = options.trt_engine_hw_compatible != 0;
     info.onnx_bytestream = options.trt_onnx_bytestream;
     info.onnx_bytestream_size = options.trt_onnx_bytestream_size;
+    info.nodes_to_exclude = options.trt_nodes_to_exclude==nullptr ? "" : options.trt_nodes_to_exclude;
 
     return std::make_shared<TensorrtProviderFactory>(info);
   }

--- a/onnxruntime/core/providers/tensorrt/tensorrt_provider_factory.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_provider_factory.cc
@@ -118,7 +118,7 @@ struct Tensorrt_Provider : Provider {
     info.engine_hw_compatible = options.trt_engine_hw_compatible != 0;
     info.onnx_bytestream = options.trt_onnx_bytestream;
     info.onnx_bytestream_size = options.trt_onnx_bytestream_size;
-    info.nodes_to_exclude = options.trt_nodes_to_exclude==nullptr ? "" : options.trt_nodes_to_exclude;
+    info.nodes_to_exclude = options.trt_nodes_to_exclude == nullptr ? "" : options.trt_nodes_to_exclude;
 
     return std::make_shared<TensorrtProviderFactory>(info);
   }

--- a/onnxruntime/core/providers/tensorrt/tensorrt_provider_factory.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_provider_factory.cc
@@ -118,7 +118,7 @@ struct Tensorrt_Provider : Provider {
     info.engine_hw_compatible = options.trt_engine_hw_compatible != 0;
     info.onnx_bytestream = options.trt_onnx_bytestream;
     info.onnx_bytestream_size = options.trt_onnx_bytestream_size;
-    info.nodes_to_exclude = options.trt_nodes_to_exclude == nullptr ? "" : options.trt_nodes_to_exclude;
+    info.op_types_to_exclude = options.trt_op_types_to_exclude == nullptr ? "" : options.trt_op_types_to_exclude;
 
     return std::make_shared<TensorrtProviderFactory>(info);
   }

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -2293,8 +2293,11 @@ ORT_API_STATUS_IMPL(OrtApis::UpdateTensorRTProviderOptions,
 #ifdef USE_TENSORRT
   onnxruntime::ProviderOptions provider_options_map;
   for (size_t i = 0; i != num_keys; ++i) {
-    if (provider_options_keys[i] == nullptr || provider_options_keys[i][0] == '\0' ||
-        provider_options_values[i] == nullptr || provider_options_values[i][0] == '\0') {
+    // Don't allow key and value to be empty except the value of trt_op_types_to_exclude
+    if (provider_options_keys[i] == nullptr ||
+        provider_options_keys[i][0] == '\0' ||
+        (provider_options_values[i] == nullptr && strcmp("trt_op_types_to_exclude", provider_options_keys[i])) ||
+        (provider_options_values[i][0] == '\0' && strcmp("trt_op_types_to_exclude", provider_options_keys[i]))) {
       return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "key/value cannot be empty");
     }
 
@@ -2409,7 +2412,7 @@ ORT_API(void, OrtApis::ReleaseTensorRTProviderOptions, _Frees_ptr_opt_ OrtTensor
     delete[] ptr->trt_profile_opt_shapes;
     delete[] ptr->trt_ep_context_file_path;
     delete[] ptr->trt_onnx_model_folder_path;
-    delete[] ptr->trt_op_types_to_exclude;
+    if (!ptr->trt_op_types_to_exclude) delete[] ptr->trt_op_types_to_exclude;
   }
 
   std::unique_ptr<OrtTensorRTProviderOptionsV2> p(ptr);

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -2409,7 +2409,7 @@ ORT_API(void, OrtApis::ReleaseTensorRTProviderOptions, _Frees_ptr_opt_ OrtTensor
     delete[] ptr->trt_profile_opt_shapes;
     delete[] ptr->trt_ep_context_file_path;
     delete[] ptr->trt_onnx_model_folder_path;
-    delete[] ptr->trt_nodes_to_exclude;
+    delete[] ptr->trt_op_types_to_exclude;
   }
 
   std::unique_ptr<OrtTensorRTProviderOptionsV2> p(ptr);

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -2409,6 +2409,7 @@ ORT_API(void, OrtApis::ReleaseTensorRTProviderOptions, _Frees_ptr_opt_ OrtTensor
     delete[] ptr->trt_profile_opt_shapes;
     delete[] ptr->trt_ep_context_file_path;
     delete[] ptr->trt_onnx_model_folder_path;
+    delete[] ptr->trt_nodes_to_exclude;
   }
 
   std::unique_ptr<OrtTensorRTProviderOptionsV2> p(ptr);

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -525,7 +525,7 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
       // (The reason is string copy is involved, for example params.trt_engine_cache_path = cache_path.c_str() and those std::string variable is referenced by OrtTensorRTProviderOptionsV2 instance
       // and TRT EP instance, so it won't be released.)
       std::string calibration_table, cache_path, cache_prefix, timing_cache_path, lib_path, trt_tactic_sources,
-          trt_extra_plugin_lib_paths, min_profile, max_profile, opt_profile, ep_context_file_path,
+          trt_extra_plugin_lib_paths, min_profile, max_profile, opt_profile, ep_context_file_path, trt_nodes_to_exclude
           onnx_model_folder_path;
       auto it = provider_options_map.find(type);
       if (it != provider_options_map.end()) {
@@ -823,6 +823,13 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
               params.trt_engine_hw_compatible = false;
             } else {
               ORT_THROW("[ERROR] [TensorRT] The value for the key 'trt_engine_hw_compatible' should be 'True' or 'False'. Default value is 'False'.\n");
+            }
+          } else if (option.first == "trt_nodes_to_exclude") {
+            if (!option.second.empty()) {
+              trt_nodes_to_exclude = option.second;
+              params.trt_nodes_to_exclude = trt_nodes_to_exclude.c_str();
+            } else {
+              ORT_THROW("[ERROR] [TensorRT] The value for the key 'trt_nodes_to_exclude' should be a string.\n");
             }
           } else {
             ORT_THROW("Invalid TensorRT EP option: ", option.first);

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -525,8 +525,8 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
       // (The reason is string copy is involved, for example params.trt_engine_cache_path = cache_path.c_str() and those std::string variable is referenced by OrtTensorRTProviderOptionsV2 instance
       // and TRT EP instance, so it won't be released.)
       std::string calibration_table, cache_path, cache_prefix, timing_cache_path, lib_path, trt_tactic_sources,
-          trt_extra_plugin_lib_paths, min_profile, max_profile, opt_profile, ep_context_file_path, trt_nodes_to_exclude
-          onnx_model_folder_path;
+          trt_extra_plugin_lib_paths, min_profile, max_profile, opt_profile, ep_context_file_path,
+          onnx_model_folder_path, trt_op_types_to_exclude;
       auto it = provider_options_map.find(type);
       if (it != provider_options_map.end()) {
         OrtTensorRTProviderOptionsV2 params;
@@ -824,12 +824,12 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
             } else {
               ORT_THROW("[ERROR] [TensorRT] The value for the key 'trt_engine_hw_compatible' should be 'True' or 'False'. Default value is 'False'.\n");
             }
-          } else if (option.first == "trt_nodes_to_exclude") {
+          } else if (option.first == "trt_op_types_to_exclude") {
             if (!option.second.empty()) {
-              trt_nodes_to_exclude = option.second;
-              params.trt_nodes_to_exclude = trt_nodes_to_exclude.c_str();
+              trt_op_types_to_exclude = option.second;
+              params.trt_op_types_to_exclude = trt_op_types_to_exclude.c_str();
             } else {
-              ORT_THROW("[ERROR] [TensorRT] The value for the key 'trt_nodes_to_exclude' should be a string.\n");
+              ORT_THROW("[ERROR] [TensorRT] The value for the key 'trt_op_types_to_exclude' should be a string.\n");
             }
           } else {
             ORT_THROW("Invalid TensorRT EP option: ", option.first);

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -526,7 +526,7 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
       // and TRT EP instance, so it won't be released.)
       std::string calibration_table, cache_path, cache_prefix, timing_cache_path, lib_path, trt_tactic_sources,
           trt_extra_plugin_lib_paths, min_profile, max_profile, opt_profile, ep_context_file_path,
-          onnx_model_folder_path, trt_op_types_to_exclude;
+          onnx_model_folder_path, trt_op_types_to_exclude{"NonMaxSuppression","NonZero","RoiAlign"};
       auto it = provider_options_map.find(type);
       if (it != provider_options_map.end()) {
         OrtTensorRTProviderOptionsV2 params;

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -526,7 +526,7 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
       // and TRT EP instance, so it won't be released.)
       std::string calibration_table, cache_path, cache_prefix, timing_cache_path, lib_path, trt_tactic_sources,
           trt_extra_plugin_lib_paths, min_profile, max_profile, opt_profile, ep_context_file_path,
-          onnx_model_folder_path, trt_op_types_to_exclude{"NonMaxSuppression","NonZero","RoiAlign"};
+          onnx_model_folder_path, trt_op_types_to_exclude{"NonMaxSuppression,NonZero,RoiAlign"};
       auto it = provider_options_map.find(type);
       if (it != provider_options_map.end()) {
         OrtTensorRTProviderOptionsV2 params;
@@ -825,12 +825,8 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
               ORT_THROW("[ERROR] [TensorRT] The value for the key 'trt_engine_hw_compatible' should be 'True' or 'False'. Default value is 'False'.\n");
             }
           } else if (option.first == "trt_op_types_to_exclude") {
-            if (!option.second.empty()) {
-              trt_op_types_to_exclude = option.second;
-              params.trt_op_types_to_exclude = trt_op_types_to_exclude.c_str();
-            } else {
-              ORT_THROW("[ERROR] [TensorRT] The value for the key 'trt_op_types_to_exclude' should be a string.\n");
-            }
+            trt_op_types_to_exclude = option.second;
+            params.trt_op_types_to_exclude = trt_op_types_to_exclude.c_str();
           } else {
             ORT_THROW("Invalid TensorRT EP option: ", option.first);
           }

--- a/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
+++ b/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
@@ -648,27 +648,28 @@ TEST(TensorrtExecutionProviderTest, ExcludeOpsTest) {
   NameMLValMap feeds;
   feeds.insert(std::make_pair("Input3", ml_value_x));
 
-   // prepare outputs
-   std::vector<std::string> output_names;
-   output_names.push_back("Plus214_Output_0");
-   std::vector<OrtValue> fetches;
+  // prepare outputs
+  std::vector<std::string> output_names;
+  output_names.push_back("Plus214_Output_0");
+  std::vector<OrtValue> fetches;
 
-   OrtTensorRTProviderOptionsV2 params;
-   params.trt_engine_cache_enable = 1;
-   params.trt_op_types_to_exclude = "MaxPool";
-   std::unique_ptr<IExecutionProvider> execution_provider = TensorrtExecutionProviderWithOptions(&params);
-   EXPECT_TRUE(session_object.RegisterExecutionProvider(std::move(execution_provider)).IsOK());
-   auto status = session_object.Load(model_name);
-   ASSERT_TRUE(status.IsOK());
-   status = session_object.Initialize();
-   ASSERT_TRUE(status.IsOK());
-   status = session_object.Run(run_options, feeds, output_names, &fetches);
-   ASSERT_TRUE(status.IsOK());
+  RemoveCachesByType("./", ".engine");
+  OrtTensorRTProviderOptionsV2 params;
+  params.trt_engine_cache_enable = 1;
+  params.trt_op_types_to_exclude = "MaxPool";
+  std::unique_ptr<IExecutionProvider> execution_provider = TensorrtExecutionProviderWithOptions(&params);
+  EXPECT_TRUE(session_object.RegisterExecutionProvider(std::move(execution_provider)).IsOK());
+  auto status = session_object.Load(model_name);
+  ASSERT_TRUE(status.IsOK());
+  status = session_object.Initialize();
+  ASSERT_TRUE(status.IsOK());
+  status = session_object.Run(run_options, feeds, output_names, &fetches);
+  ASSERT_TRUE(status.IsOK());
 
-   std::vector<fs::path> engine_files;
-   engine_files = GetCachesByType("./", ".engine");
-   // The whole graph should be partitioned into 3 TRT subgraphs and 2 cpu nodes
-   ASSERT_EQ(engine_files.size(), 3);
+  std::vector<fs::path> engine_files;
+  engine_files = GetCachesByType("./", ".engine");
+  // The whole graph should be partitioned into 3 TRT subgraphs and 2 cpu nodes
+  ASSERT_EQ(engine_files.size(), 3);
 }
 
 TEST(TensorrtExecutionProviderTest, TRTPluginsCustomOpTest) {

--- a/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
+++ b/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
@@ -612,6 +612,43 @@ TEST(TensorrtExecutionProviderTest, EPContextNode) {
   RunSession(session_object9, run_options, feeds, output_names, expected_dims_mul_m, expected_values_mul_m);
 }
 
+TEST(TensorrtExecutionProviderTest, ExcludeOpsTest) {
+  PathString model_name = ORT_TSTR("testdata/mnist.onnx");
+  SessionOptions so;
+  so.session_logid = "TensorrtExecutionProviderExcludeOpsTest";
+  RunOptions run_options;
+  run_options.run_tag = so.session_logid;
+  InferenceSession session_object{so, GetEnvironment()};
+  auto cuda_provider = DefaultCudaExecutionProvider();
+  auto cpu_allocator = cuda_provider->CreatePreferredAllocators()[1];
+  std::vector<int64_t> dims_op_x = {1, 1, 28, 28};
+  std::vector<float> values_op_x(784, 1.0f); // 784=1*1*28*28
+  OrtValue ml_value_x;
+  CreateMLValue<float>(cpu_allocator, dims_op_x, values_op_x, &ml_value_x);
+  NameMLValMap feeds;
+  feeds.insert(std::make_pair("Input3", ml_value_x));
+
+   // prepare outputs
+   std::vector<std::string> output_names;
+   output_names.push_back("Plus214_Output_0");
+   std::vector<OrtValue> fetches;
+
+   OrtTensorRTProviderOptionsV2 params;
+   //params.trt_engine_cache_enable = 1;
+   std::unique_ptr<IExecutionProvider> execution_provider = TensorrtExecutionProviderWithOptions(&params);
+   EXPECT_TRUE(session_object.RegisterExecutionProvider(std::move(execution_provider)).IsOK());
+   auto status = session_object.Load(model_name);
+   ASSERT_TRUE(status.IsOK());
+   status = session_object.Initialize();
+   ASSERT_TRUE(status.IsOK());
+   status = session_object.Run(run_options, feeds, output_names, &fetches);
+   ASSERT_TRUE(status.IsOK());
+
+   std::vector<fs::path> engine_files;
+   engine_files = GetCachesByType("./", ".engine");
+   ASSERT_EQ(engine_files.size(), 1);
+}
+
 TEST(TensorrtExecutionProviderTest, TRTPluginsCustomOpTest) {
   PathString model_name = ORT_TSTR("testdata/trt_plugin_custom_op_test.onnx");
   SessionOptions so;

--- a/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
+++ b/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
@@ -642,7 +642,7 @@ TEST(TensorrtExecutionProviderTest, ExcludeOpsTest) {
   auto cuda_provider = DefaultCudaExecutionProvider();
   auto cpu_allocator = cuda_provider->CreatePreferredAllocators()[1];
   std::vector<int64_t> dims_op_x = {1, 1, 28, 28};
-  std::vector<float> values_op_x(784, 1.0f); // 784=1*1*28*28
+  std::vector<float> values_op_x(784, 1.0f);// 784=1*1*28*28
   OrtValue ml_value_x;
   CreateMLValue<float>(cpu_allocator, dims_op_x, values_op_x, &ml_value_x);
   NameMLValMap feeds;

--- a/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
+++ b/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
@@ -642,7 +642,7 @@ TEST(TensorrtExecutionProviderTest, ExcludeOpsTest) {
   auto cuda_provider = DefaultCudaExecutionProvider();
   auto cpu_allocator = cuda_provider->CreatePreferredAllocators()[1];
   std::vector<int64_t> dims_op_x = {1, 1, 28, 28};
-  std::vector<float> values_op_x(784, 1.0f);// 784=1*1*28*28
+  std::vector<float> values_op_x(784, 1.0f);  // 784=1*1*28*28
   OrtValue ml_value_x;
   CreateMLValue<float>(cpu_allocator, dims_op_x, values_op_x, &ml_value_x);
   NameMLValMap feeds;


### PR DESCRIPTION
Add new provider option `trt_op_types_to_exclude`:
- User can provide op type list to be excluded from running on TRT
- e.g. `trt_op_types_to_exclude="MaxPool"`

There is a known performance issue with the DDS ops (NonMaxSuppression, NonZero and RoiAlign) from TRT versions 10.0 to 10.7. TRT EP excludes DDS ops from running on TRT by default, user can override default value with empty string to include all ops.




