### PR TITLE
[CI] Set up proper permissions for linting workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,6 +37,9 @@ jobs:
     # Required workflow
     name: Python format
     runs-on: ["self-hosted", "1ES.Pool=onnxruntime-github-Ubuntu2204-AMD-CPU"]
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python


### PR DESCRIPTION
Allow writing security events to post lint messages on PRs.

