### PR TITLE
Fix crash when running ORT under low integrity process like Edge where ETW registration can fail

### DIFF
--- a/onnxruntime/core/platform/windows/logging/etw_sink.cc
+++ b/onnxruntime/core/platform/windows/logging/etw_sink.cc
@@ -158,8 +158,9 @@ void EtwRegistrationManager::LazyInitialize() {
       initialization_status_ = InitializationStatus::Initializing;
       etw_status_ = ::TraceLoggingRegisterEx(etw_provider_handle, ORT_TL_EtwEnableCallback, nullptr);
       if (FAILED(etw_status_)) {
+        // Registration can fail when running under Low Integrity process, and should be non-fatal
         initialization_status_ = InitializationStatus::Failed;
-        ORT_THROW("ETW registration failed. Logging will be broken: " + std::to_string(etw_status_));
+        std::cerr << "Error in ETW registration: " << std::to_string(etw_status_) << std::endl;
       }
       initialization_status_ = InitializationStatus::Initialized;
     }
@@ -176,7 +177,9 @@ void EtwRegistrationManager::InvokeCallbacks(LPCGUID SourceId, ULONG IsEnabled, 
 
   std::lock_guard<std::mutex> lock(callbacks_mutex_);
   for (const auto& callback : callbacks_) {
-    (*callback)(SourceId, IsEnabled, Level, MatchAnyKeyword, MatchAllKeyword, FilterData, CallbackContext);
+    if (callback != nullptr) {
+      (*callback)(SourceId, IsEnabled, Level, MatchAnyKeyword, MatchAllKeyword, FilterData, CallbackContext);
+    }
   }
 }
 

--- a/onnxruntime/core/platform/windows/logging/etw_sink.cc
+++ b/onnxruntime/core/platform/windows/logging/etw_sink.cc
@@ -160,7 +160,7 @@ void EtwRegistrationManager::LazyInitialize() {
       if (FAILED(etw_status_)) {
         // Registration can fail when running under Low Integrity process, and should be non-fatal
         initialization_status_ = InitializationStatus::Failed;
-        std::cerr << "Error in ETW registration: " << std::to_string(etw_status_) << std::endl;
+        LOGS_DEFAULT(WARNING) << "Error in ETW registration: " << std::to_string(etw_status_);
       }
       initialization_status_ = InitializationStatus::Initialized;
     }

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -735,8 +735,12 @@ InferenceSession::~InferenceSession() {
   // Unregister the session and ETW callbacks
 #ifdef _WIN32
   std::lock_guard<std::mutex> lock(active_sessions_mutex_);
-  WindowsTelemetry::UnregisterInternalCallback(callback_ML_ORT_provider_);
-  logging::EtwRegistrationManager::Instance().UnregisterInternalCallback(callback_ETWSink_provider_);
+  if (callback_ML_ORT_provider_ != nullptr) {
+    WindowsTelemetry::UnregisterInternalCallback(callback_ML_ORT_provider_);
+  }
+  if (callback_ETWSink_provider_ != nullptr) {
+    logging::EtwRegistrationManager::Instance().UnregisterInternalCallback(callback_ETWSink_provider_);
+  }
 #endif
   active_sessions_.erase(session_id_);
 


### PR DESCRIPTION
### Description
Make ETW provider registration non-fatal and not throw an exception

Needs to work under build with exceptions enabled & --disable_exceptions

### Motivation and Context
ORT should not crash

Addresses #22475. Private tested by filer of that issue


