### PR TITLE
Nuget Windows AI Pipeline, Disable SDL Submodules. 

### DIFF
--- a/tools/ci_build/github/azure-pipelines/nuget-windows-ai.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget-windows-ai.yml
@@ -17,6 +17,8 @@ extends:
       name: onnxruntime-Win-CPU-2022
       os: windows
     sdl:
+      git:
+        submodules: false
       tsa:
         enabled: true
       policheck:


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Set SDL's git submodule to false. 


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
* Previous job's SDL logs:It has 'git submodule sync' command, which means 'git submodule sync synchronizes all submodules while git submodule sync'

* After set sdl git submodules to false, the logs don't have 'git submodule sync' command. 



