### PR TITLE
Update EP version info after ORT 1.20

### DIFF
--- a/docs/execution-providers/CUDA-ExecutionProvider.md
+++ b/docs/execution-providers/CUDA-ExecutionProvider.md
@@ -35,7 +35,7 @@ Because of [Nvidia CUDA Minor Version Compatibility](https://docs.nvidia.com/dep
 
 ONNX Runtime built with cuDNN 8.x is not compatible with cuDNN 9.x, and vice versa. You can choose the package based on CUDA and cuDNN major versions that match your runtime environment (e.g., PyTorch 2.3 uses cuDNN 8.x, while PyTorch 2.4 or later uses cuDNN 9.x).
 
-Note: Starting with ORT 1.19, **CUDA 12.x** becomes the default version when distributing [ONNX Runtime GPU packages](https://pypi.org/project/onnxruntime-gpu/) in PyPI.
+Note: Starting with version 1.19, **CUDA 12.x** becomes the default version when distributing [ONNX Runtime GPU packages](https://pypi.org/project/onnxruntime-gpu/) in PyPI.
 
 ### CUDA 12.x
 

--- a/docs/execution-providers/CUDA-ExecutionProvider.md
+++ b/docs/execution-providers/CUDA-ExecutionProvider.md
@@ -33,15 +33,16 @@ ONNX Runtime Training is aligned with PyTorch CUDA versions; refer to the Optimi
 
 Because of [Nvidia CUDA Minor Version Compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/#minor-version-compatibility), ONNX Runtime built with CUDA 11.8 are compatible with any CUDA 11.x version; ONNX Runtime built with CUDA 12.x are compatible with any CUDA 12.x version.
 
-ONNX Runtime built with cuDNN 8.x is not compatible with cuDNN 9.x, and vice versa. You can choose the package based on CUDA and cuDNN major versions that match your runtime environment (For example, PyTorch 2.3 uses cuDNN 8.x, while PyTorch 2.4 or later used cuDNN 9.x).
+ONNX Runtime built with cuDNN 8.x is not compatible with cuDNN 9.x, and vice versa. You can choose the package based on CUDA and cuDNN major versions that match your runtime environment (e.g., PyTorch 2.3 uses cuDNN 8.x, while PyTorch 2.4 or later uses cuDNN 9.x).
 
-Note: starting ORT 1.19, **CUDA 12.x** becomes default version when distributing ONNX Runtime GPU packages in pypi.
+Note: Starting with ORT 1.19, **CUDA 12.x** becomes the default version when distributing [ONNX Runtime GPU packages](https://pypi.org/project/onnxruntime-gpu/) in PyPI.
 
 ### CUDA 12.x
 
 | ONNX Runtime  | CUDA   | cuDNN | Notes                                                                |
 |---------------|--------|-------|----------------------------------------------------------------------|
-| 1.19.x        | 12.x   | 9.x   | Avaiable in pypi. Compatible with PyTorch >= 2.4.0 for cuda 12.x.    | 
+| 1.20.x        | 12.x   | 9.x   | Avaiable in PyPI. Compatible with PyTorch >= 2.4.0 for CUDA 12.x.    | 
+| 1.19.x        | 12.x   | 9.x   | Avaiable in PyPI. Compatible with PyTorch >= 2.4.0 for CUDA 12.x.    | 
 | 1.18.1        | 12.x   | 9.x   | cuDNN 9 is required. No Java package.                                | 
 | 1.18.0        | 12.x   | 8.x   | Java package is added.                                               |
 | 1.17.x        | 12.x   | 8.x   | Only C++/C# Nuget and Python packages are released. No Java package. |
@@ -50,8 +51,9 @@ Note: starting ORT 1.19, **CUDA 12.x** becomes default version when distributing
 
 | ONNX Runtime         | CUDA   | cuDNN                                   | Notes                                                                                                                                       |
 |----------------------|--------|-----------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
-| 1.19.x               | 11.8   | 8.x                                     | Not available in pypi. See [Install ORT](../install) for detail. Compatible with PyTorch <= 2.3.1 for CUDA 11.8.                            |
-| 1.18.x               | 11.8   | 8.x                                     | Available in pypi                                                                                                                           |
+| 1.20.x               | 11.8   | 8.x                                     | Not available in PyPI. See [Install ORT](../install) for details. Compatible with PyTorch <= 2.3.1 for CUDA 11.8.                           |
+| 1.19.x               | 11.8   | 8.x                                     | Not available in PyPI. See [Install ORT](../install) for details. Compatible with PyTorch <= 2.3.1 for CUDA 11.8.                           |
+| 1.18.x               | 11.8   | 8.x                                     | Available in PyPI.                                                                                                                          |
 | 1.17<br>1.16<br>1.15 | 11.8   | 8.2.4 (Linux)<br/>8.5.0.96 (Windows)    | Tested with CUDA versions from 11.6 up to 11.8, and cuDNN from 8.2 up to 8.9                                                                |
 | 1.14<br>1.13         | 11.6   | 8.2.4 (Linux)<br/>8.5.0.96 (Windows)    | libcudart 11.4.43<br/>libcufft 10.5.2.100<br/>libcurand 10.2.5.120<br/>libcublasLt 11.6.5.2<br/>libcublas 11.6.5.2<br/>libcudnn 8.2.4       |
 | 1.12<br>1.11         | 11.4   | 8.2.4 (Linux)<br/>8.2.2.26 (Windows)    | libcudart 11.4.43<br/>libcufft 10.5.2.100<br/>libcurand 10.2.5.120<br/>libcublasLt 11.6.5.2<br/>libcublas 11.6.5.2<br/>libcudnn 8.2.4       |

--- a/docs/execution-providers/DirectML-ExecutionProvider.md
+++ b/docs/execution-providers/DirectML-ExecutionProvider.md
@@ -16,7 +16,7 @@ DirectML is a high-performance, hardware-accelerated DirectX 12 library for mach
 
 When used standalone, the DirectML API is a low-level DirectX 12 library and is suitable for high-performance, low-latency applications such as frameworks, games, and other real-time applications. The seamless interoperability of DirectML with Direct3D 12 as well as its low overhead and conformance across hardware makes DirectML ideal for accelerating machine learning when both high performance is desired, and the reliability and predictability of results across hardware is critical.
 
-The DirectML Execution Provider currently uses DirectML version 1.14.1 and supports up to ONNX opset 17 ([ONNX v1.12](https://github.com/onnx/onnx/releases/tag/v1.12.0)). Evaluating models which require a higher opset version is unsupported and will yield poor performance.
+**The DirectML Execution Provider currently uses DirectML version 1.15.2** and supports up to ONNX opset 17 ([ONNX v1.12](https://github.com/onnx/onnx/releases/tag/v1.12.0)). Evaluating models which require a higher opset version is unsupported and will yield poor performance.
 
 ## Contents
 {: .no_toc }

--- a/docs/execution-providers/DirectML-ExecutionProvider.md
+++ b/docs/execution-providers/DirectML-ExecutionProvider.md
@@ -16,7 +16,7 @@ DirectML is a high-performance, hardware-accelerated DirectX 12 library for mach
 
 When used standalone, the DirectML API is a low-level DirectX 12 library and is suitable for high-performance, low-latency applications such as frameworks, games, and other real-time applications. The seamless interoperability of DirectML with Direct3D 12 as well as its low overhead and conformance across hardware makes DirectML ideal for accelerating machine learning when both high performance is desired, and the reliability and predictability of results across hardware is critical.
 
-**The DirectML Execution Provider currently uses DirectML version 1.15.2** and supports up to ONNX opset 17 ([ONNX v1.12](https://github.com/onnx/onnx/releases/tag/v1.12.0)). Evaluating models which require a higher opset version is unsupported and will yield poor performance.
+**The DirectML Execution Provider currently uses DirectML version 1.15.2** and supports up to ONNX opset 20 ([ONNX v1.15](https://github.com/onnx/onnx/releases/tag/v1.15.0)) with the exception of Gridsample 20: 5d and DeformConv, which are not yet supported. Evaluating models which require a higher opset version is unsupported and will yield poor performance.
 
 ## Contents
 {: .no_toc }

--- a/docs/execution-providers/DirectML-ExecutionProvider.md
+++ b/docs/execution-providers/DirectML-ExecutionProvider.md
@@ -16,7 +16,7 @@ DirectML is a high-performance, hardware-accelerated DirectX 12 library for mach
 
 When used standalone, the DirectML API is a low-level DirectX 12 library and is suitable for high-performance, low-latency applications such as frameworks, games, and other real-time applications. The seamless interoperability of DirectML with Direct3D 12 as well as its low overhead and conformance across hardware makes DirectML ideal for accelerating machine learning when both high performance is desired, and the reliability and predictability of results across hardware is critical.
 
-**The DirectML Execution Provider currently uses DirectML version 1.15.2** and supports up to ONNX opset 20 ([ONNX v1.15](https://github.com/onnx/onnx/releases/tag/v1.15.0)) with the exception of Gridsample 20: 5d and DeformConv, which are not yet supported. Evaluating models which require a higher opset version is unsupported and will yield poor performance.
+**The DirectML Execution Provider currently uses DirectML version 1.15.2** and supports up to ONNX opset 20 ([ONNX v1.15](https://github.com/onnx/onnx/releases/tag/v1.15.0)) with the exception of Gridsample 20: 5d and DeformConv, which are not yet supported. Evaluating models which require a higher opset version is unsupported and will yield poor performance. *Note: DirectML ONNX opset support may differ from that of ONNX Runtime, which can be found [here](https://onnxruntime.ai/docs/reference/compatibility.html#onnx-opset-support).*
 
 ## Contents
 {: .no_toc }

--- a/docs/execution-providers/TensorRT-ExecutionProvider.md
+++ b/docs/execution-providers/TensorRT-ExecutionProvider.md
@@ -27,7 +27,7 @@ See [Build instructions](../build/eps.md#tensorrt).
 
 ## Requirements
 
-Note: Starting ORT 1.19, **CUDA 12** becomes the default version when distributing ONNX Runtime GPU packages.
+Note: Starting with version 1.19, **CUDA 12** becomes the default version when distributing ONNX Runtime GPU packages.
 
 | ONNX Runtime | TensorRT | CUDA           |
 | :----------- | :------- | :------------- |

--- a/docs/execution-providers/TensorRT-ExecutionProvider.md
+++ b/docs/execution-providers/TensorRT-ExecutionProvider.md
@@ -20,18 +20,20 @@ The TensorRT execution provider in the ONNX Runtime makes use of NVIDIA's [Tenso
 {:toc}
 
 ## Install
-Please select the GPU (CUDA/TensorRT) version of OnnxRuntime: https://onnxruntime.ai/docs/install. Pre-built packages and Docker images are available for Jetpack in the [Jetson Zoo](https://elinux.org/Jetson_Zoo#ONNX_Runtime).
+Please select the GPU (CUDA/TensorRT) version of Onnx Runtime: https://onnxruntime.ai/docs/install. Pre-built packages and Docker images are available for Jetpack in the [Jetson Zoo](https://elinux.org/Jetson_Zoo#ONNX_Runtime).
 
 ## Build from source
 See [Build instructions](../build/eps.md#tensorrt).
 
 ## Requirements
 
-Note: starting ORT 1.19, **CUDA 12** becomes default version when distributing ONNX Runtime GPU packages.
+Note: Starting ORT 1.19, **CUDA 12** becomes the default version when distributing ONNX Runtime GPU packages.
 
 | ONNX Runtime | TensorRT | CUDA           |
 | :----------- | :------- | :------------- |
-| 1.19-main    | 10.2     | **12.x**, 11.8 |
+| main         | 10.5     | **12.x**, 11.8 |
+| 1.20         | 10.5     | **12.x**, 11.8 |
+| 1.19         | 10.2     | **12.x**, 11.8 |
 | 1.18         | 10.0     | 11.8, 12.x     |
 | 1.17         | 8.6      | 11.8, 12.x     |
 | 1.16         | 8.6      | 11.8           |


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Included new version info for CUDA, TensorRT, and DirectML execution providers following ORT 1.20 release publish.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


