### PR TITLE
Revert to err logging instead of LOGS_DEFAULT macro

### DIFF
--- a/onnxruntime/core/platform/windows/logging/etw_sink.cc
+++ b/onnxruntime/core/platform/windows/logging/etw_sink.cc
@@ -160,6 +160,8 @@ void EtwRegistrationManager::LazyInitialize() {
       if (FAILED(etw_status_)) {
         // Registration can fail when running under Low Integrity process, and should be non-fatal
         initialization_status_ = InitializationStatus::Failed;
+        // Injection of ETW logger can happen very early if ETW provider was already listening.
+        // Don't use LOGS_DEFAULT here or can get "Attempt to use DefaultLogger but none has been registered"
         std::cerr << "Error in ETW registration: " << std::to_string(etw_status_) << std::endl;
       }
       initialization_status_ = InitializationStatus::Initialized;

--- a/onnxruntime/core/platform/windows/logging/etw_sink.cc
+++ b/onnxruntime/core/platform/windows/logging/etw_sink.cc
@@ -160,7 +160,7 @@ void EtwRegistrationManager::LazyInitialize() {
       if (FAILED(etw_status_)) {
         // Registration can fail when running under Low Integrity process, and should be non-fatal
         initialization_status_ = InitializationStatus::Failed;
-        LOGS_DEFAULT(WARNING) << "Error in ETW registration: " << std::to_string(etw_status_);
+        std::cerr << "Error in ETW registration: " << std::to_string(etw_status_) << std::endl;
       }
       initialization_status_ = InitializationStatus::Initialized;
     }


### PR DESCRIPTION
Revert to err logging instead of LOGS_DEFAULT macro due to issue seen during testing. "onnxruntime::logging::LoggingManager::DefaultLogger Attempt to use DefaultLogger but none has been registered."

### Description
Revert part of PR suggestion to prevent crash for scenario seen in #22699. Previously we had tested w/o this macro

### Motivation and Context
Previous PR #22699 it was suggested to use LOGS_DEFAULT() but that does not work during early init. Safer to use std::cerr instead like the original PR had it.

