### PR TITLE
[SymbolicShapeInference] Support 10 Reduce* ops 

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -1603,36 +1603,47 @@ class SymbolicShapeInference:
 
     def _infer_ReduceMean(self, node):  # noqa: N802
         keep_dims = get_attribute(node, "keepdims", 1)
-        if get_opset(self.out_mp_) >= 13 and len(node.input) > 1:
-            # ReduceMean changes axes to input[1] in opset 13
+        opset = get_opset(self.out_mp_)
+
+        if opset >= 13 and len(node.input) > 1:
             axes = self._try_get_value(node, 1)
-            vi = self.known_vi_[node.output[0]]
-            if axes is None:
-                assert keep_dims  # can only handle keep_dims==True when axes is unknown, by generating new ranks
-                vi.CopyFrom(
-                    helper.make_tensor_value_info(
-                        node.output[0],
-                        self.known_vi_[node.input[0]].type.tensor_type.elem_type,
-                        get_shape_from_sympy_shape(self._new_symbolic_shape(self._get_shape_rank(node, 0), node)),
-                    )
+        else:
+            axes = get_attribute(node, "axes")
+
+        vi = self.known_vi_[node.output[0]]
+
+        if axes is None:
+            assert keep_dims == 1, "ReduceMean Op: Cannot infer shape when axes is unknown and keepdims is not 1."
+            rank = self._get_shape_rank(node, 0)
+            new_shape = self._new_symbolic_shape(rank, node)
+            vi.CopyFrom(
+                helper.make_tensor_value_info(
+                    node.output[0],
+                    self.known_vi_[node.input[0]].type.tensor_type.elem_type,
+                    get_shape_from_sympy_shape(new_shape),
                 )
-            else:
-                shape = self._get_shape(node, 0)
-                output_shape = []
-                axes = [handle_negative_axis(a, len(shape)) for a in axes]
-                for i, d in enumerate(shape):
-                    if i in axes:
-                        if keep_dims:
-                            output_shape.append(1)
+            )
+        else:
+            input_shape = self._get_shape(node, 0)
+            assert input_shape, "ReduceMean Op: Reduction over an empty set of values yields undefined."
+
+            axes = [handle_negative_axis(a, len(input_shape)) for a in axes]
+            output_shape = []
+            for i, dim in enumerate(input_shape):
+                if i in axes:
+                    if keep_dims == 1:
+                        output_shape.append(1)
                     else:
-                        output_shape.append(d)
-                vi.CopyFrom(
-                    helper.make_tensor_value_info(
-                        node.output[0],
-                        self.known_vi_[node.input[0]].type.tensor_type.elem_type,
-                        output_shape,
-                    )
+                        continue
+                else:
+                    output_shape.append(dim)
+            vi.CopyFrom(
+                helper.make_tensor_value_info(
+                    node.output[0],
+                    self.known_vi_[node.input[0]].type.tensor_type.elem_type,
+                    output_shape,
                 )
+            )
 
     def _infer_ReduceProd(self, node):  # noqa: N802
         axes = get_attribute(node, "axes")

--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -1581,7 +1581,9 @@ class SymbolicShapeInference:
         keep_dims = get_attribute(node, "keepdims", 1)
         opset = get_opset(self.out_mp_)
 
-        if opset >= 13 and len(node.input) > 1:
+        # Fetch axes from inputs if there are two inputs
+        # Otherwise, fetch axes from attribute (general pattern when opset <= 13)
+        if len(node.input) > 1:
             axes = self._try_get_value(node, 1)
         else:
             axes = get_attribute(node, "axes")


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Extend existing Reduce_Sum func to all 10 Reduce-series ops
i.e ReduceMean def: https://onnx.ai/onnx/operators/onnx__ReduceMean.html

| Op              | Defintions (**bold**: diff)                                  |
| --------------- | ------------------------------------------------------------ |
| ReduceL1        | Computes the **L1 norm** of the input tensor’s elements along  the provided axes. The resulting tensor has the same rank as the input if  keepdims equals 1. If keepdims equals 0, then the resulting tensor has the  reduced dimension pruned. Input tensors of rank zero are valid. **Reduction over an empty set of values yields 0.** |
| ReduceL2        | Computes the **L2 norm** of the input tensor’s elements along  the provided axes. The resulting tensor has the same rank as the input if  keepdims equals 1. If keepdims equals 0, then the resulting tensor has the  reduced dimension pruned. Input tensors of rank zero are valid. **Reduction over an empty set of values yields 0**. |
| ReduceLogSum    | Computes the log  sum of the input tensor’s elements along the provided axes. The resulting  tensor has the same rank as the input if keepdims equals 1. If keepdims  equals 0, then the resulting tensor has the reduced dimension pruned. Input  tensors of rank zero are valid. **Reduction over  an empty set of values yields minus infinity (if supported by the datatype)  or undefined otherwise**. |
| ReduceLogSumExp | Computes the **log sum exponent** of the input tensor’s  elements along the provided axes. The resulting tensor has the same rank as  the input if keepdims equals 1. If keepdims equals 0, then the resulting  tensor has the reduced dimension pruned. Input tensors of rank zero are  valid. **Reduction over an empty set of values  yields minus infinity (if supported by the datatype) or undefined otherwise**. |
| ReduceMax       | Computes the **max** of the input tensor’s elements along the  provided axes. The resulting tensor has the same rank as the input if  keepdims equals 1. If keepdims equals 0, then the resulting tensor has the  reduced dimension pruned. Input tensors of rank zero are valid. **Reduction over an empty set of values yields minus  infinity (if supported by the datatype) or the minimum value of the data type  otherwise.**     **If the input data type is Boolean, the comparison  should consider False < True.** |
| ReduceMean      | Computes the **mean** of the input tensor’s elements along the  provided axes. The resulting tensor has the same rank as the input if  keepdims equals 1. If keepdims equals 0, then the resulting tensor has the  reduced dimension pruned. Input tensors of rank zero are valid. **Reduction over an empty set of values yields  undefined.** |
| ReduceMin       | Computes the **min** of the input tensor’s elements along the  provided axes. The resulting tensor has the same rank as the input if  keepdims equals 1. If keepdims equals 0, then the resulting tensor has the  reduced dimension pruned. Input tensors of rank zero are valid. **Reduction over an empty set of values yields plus  infinity (if supported by the datatype) or the maximum value of the data type  otherwise.**     **If the input data type is Boolean, the comparison  should consider False < True.** |
| ReduceProd      | Computes the **product** of the input tensor’s elements along  the provided axes. The resulting tensor has the same rank as the input if  keepdims equals 1. If keepdims equals 0, then the resulting tensor has the  reduced dimension pruned. Input tensors of rank zero are valid. Reduction  over an empty set of values yields 1. |
| ReduceSum       | Computes the **sum** of the input tensor’s elements along the  provided axes. The resulting tensor has the same rank as the input if  keepdims equals 1. If keepdims equals 0, then the resulting tensor has the  reduced dimension pruned. Input tensors of rank zero are valid. **Reduction over an empty set of values yields 0.** |
| ReduceSumSquare | Computes the **sum square** of the input tensor’s elements  along the provided axes. The resulting tensor has the same rank as the input  if keepdims equals 1. If keepdims equals 0, then the resulting tensor has the  reduced dimension pruned. Input tensors of rank zero are valid. **Reduction over an empty set of values yields 0.** |
### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
https://github.com/microsoft/onnxruntime/issues/22662
This ReduceMean op is not supported by current script


