### PR TITLE
Remove webgpu ep in mobile packaging stages

### DIFF
--- a/tools/ci_build/github/android/default_full_aar_build_settings.json
+++ b/tools/ci_build/github/android/default_full_aar_build_settings.json
@@ -16,7 +16,6 @@
         "--build_shared_lib",
         "--use_nnapi",
         "--use_xnnpack",
-        "--use_webgpu",
         "--skip_tests"
     ]
 }

--- a/tools/ci_build/github/apple/default_full_apple_framework_build_settings.json
+++ b/tools/ci_build/github/apple/default_full_apple_framework_build_settings.json
@@ -19,7 +19,6 @@
             "--build_apple_framework",
             "--use_coreml",
             "--use_xnnpack",
-            "--use_webgpu",
             "--skip_tests",
             "--cmake_extra_defines=onnxruntime_BUILD_UNIT_TESTS=OFF"
         ],

--- a/tools/ci_build/github/apple/default_full_ios_framework_build_settings.json
+++ b/tools/ci_build/github/apple/default_full_ios_framework_build_settings.json
@@ -24,14 +24,12 @@
             "--ios",
             "--use_xcode",
             "--use_xnnpack",
-            "--use_webgpu",
             "--apple_deploy_target=13.0"
         ],
         "iphonesimulator": [
             "--ios",
             "--use_xcode",
             "--use_xnnpack",
-            "--use_webgpu",
             "--apple_deploy_target=13.0"
         ],
         "macabi":[


### PR DESCRIPTION
### Description
The nuget-zip-java packaging pipeline has been failed for 4 days since it's introduced in #22591



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

### Test Run
https://dev.azure.com/aiinfra/Lotus/_build/results?buildId=597832&view=logs&s=951e40a3-7e3a-5be5-e535-0c4500e244c3


