### PR TITLE
Add one log to show more details of op unit tests

### DIFF
--- a/onnxruntime/test/providers/base_tester.cc
+++ b/onnxruntime/test/providers/base_tester.cc
@@ -405,9 +405,9 @@ void BaseTester::ExecuteModel(Model& model, SessionType& session,
           }
         }
       }
-    }  
+    }
     LOGS_DEFAULT(INFO) << provider_type << " : kernel's output verfication passed";
-  } // end if (verify_output_)
+  }  // end if (verify_output_)
 }
 
 bool SetEpsForAllNodes(Graph& graph,

--- a/onnxruntime/test/providers/base_tester.cc
+++ b/onnxruntime/test/providers/base_tester.cc
@@ -405,8 +405,9 @@ void BaseTester::ExecuteModel(Model& model, SessionType& session,
           }
         }
       }
-    }
-  }
+    }  
+    LOGS_DEFAULT(INFO) << provider_type << " : kernel's output verfication passed";
+  } // end if (verify_output_)
 }
 
 bool SetEpsForAllNodes(Graph& graph,


### PR DESCRIPTION
### Description
1. Show which EPs have been tested
2. Show whether the kernel executed.

set ORT_UNIT_TEST_MAIN_LOG_LEVEL=1

For example:
```
←[0;93m2024-11-05 15:27:54.8583783 [W:onnxruntime:Default, base_tester.cc:410 onnxruntime::test::BaseTester::ExecuteModel] CPUExecutionProvider : kernel's output verfication passed←[m
←[0;93m2024-11-05 15:27:54.8654171 [W:onnxruntime:Default, base_tester.cc:410 onnxruntime::test::BaseTester::ExecuteModel] XnnpackExecutionProvider : kernel's output verfication passed←[m
[       OK ] MathOpTest.MatMulFloatType (432 ms)
[----------] 1 test from MathOpTest (433 ms total)
```


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


