### PR TITLE
Replace gsl::narrow with narrow in WebNN code

### DIFF
--- a/onnxruntime/core/providers/webnn/builders/impl/split_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/split_op_builder.cc
@@ -73,8 +73,8 @@ Status SplitOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
   // Check that the splits evenly divide.
   if (split_count > 0 && splits.empty() && input_shape[axis] % split_count != 0) {
     // Divide inputs into variable size outputs:
-    splits.insert(splits.end(), split_count - 1, gsl::narrow<uint32_t>(input_shape[axis]) / split_count);
-    splits.insert(splits.end(), gsl::narrow<uint32_t>(input_shape[axis]) % split_count);
+    splits.insert(splits.end(), split_count - 1, narrow<uint32_t>(input_shape[axis]) / split_count);
+    splits.insert(splits.end(), narrow<uint32_t>(input_shape[axis]) % split_count);
   }
 
   if (splits.empty()) {


### PR DESCRIPTION
Replace use of `gsl::narrow` with `narrow` to build for WebNN @snnn 

### Description

Building for WebNN with exceptions disabled cannot use `gsl::narrow`. Replace with `narrow`

### Motivation and Context

Address issue #22712



