### PR TITLE
Re-enable test symbolic shape infer

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -1679,7 +1679,7 @@ class SymbolicShapeInference:
         if get_opset(self.out_mp_) <= 10:
             scales = self._try_get_value(node, 1)
             if scales is not None:
-                new_sympy_shape = [sympy.simplify(sympy.floor(d * s)) for d, s in zip(input_sympy_shape, scales)]
+                new_sympy_shape = [sympy.simplify(float(sympy.floor(d * s))) for d, s in zip(input_sympy_shape, scales)]
                 self._update_computed_dims(new_sympy_shape)
                 vi.CopyFrom(
                     helper.make_tensor_value_info(
@@ -1706,7 +1706,7 @@ class SymbolicShapeInference:
                     roi_end = [1] * rank
                 scales = list(scales)
                 new_sympy_shape = [
-                    sympy.simplify(sympy.floor(d * (end - start) * scale))
+                    sympy.simplify(float(sympy.floor(d * (end - start) * scale)))
                     for d, start, end, scale in zip(input_sympy_shape, roi_start, roi_end, scales)
                 ]
                 self._update_computed_dims(new_sympy_shape)

--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -1679,7 +1679,7 @@ class SymbolicShapeInference:
         if get_opset(self.out_mp_) <= 10:
             scales = self._try_get_value(node, 1)
             if scales is not None:
-                new_sympy_shape = [sympy.simplify(float(sympy.floor(d * s))) for d, s in zip(input_sympy_shape, scales)]
+                new_sympy_shape = [sympy.simplify(sympy.floor(d * s)) for d, s in zip(input_sympy_shape, scales)]
                 self._update_computed_dims(new_sympy_shape)
                 vi.CopyFrom(
                     helper.make_tensor_value_info(
@@ -1693,7 +1693,7 @@ class SymbolicShapeInference:
             scales = self._try_get_value(node, 2)
             sizes = self._try_get_value(node, 3)
             if sizes is not None:
-                new_sympy_shape = [sympy.simplify(float(sympy.floor(s))) for s in sizes]
+                new_sympy_shape = [sympy.simplify(sympy.floor(s)) for s in sizes]
                 self._update_computed_dims(new_sympy_shape)
             elif scales is not None:
                 rank = len(scales)
@@ -1706,7 +1706,7 @@ class SymbolicShapeInference:
                     roi_end = [1] * rank
                 scales = list(scales)
                 new_sympy_shape = [
-                    sympy.simplify(float(sympy.floor(d * (end - start) * scale)))
+                    sympy.simplify(sympy.floor(d * (end - start) * scale))
                     for d, start, end, scale in zip(input_sympy_shape, roi_start, roi_end, scales)
                 ]
                 self._update_computed_dims(new_sympy_shape)

--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -1693,7 +1693,7 @@ class SymbolicShapeInference:
             scales = self._try_get_value(node, 2)
             sizes = self._try_get_value(node, 3)
             if sizes is not None:
-                new_sympy_shape = [sympy.simplify(sympy.floor(s)) for s in sizes]
+                new_sympy_shape = [sympy.simplify(float(sympy.floor(s))) for s in sizes]
                 self._update_computed_dims(new_sympy_shape)
             elif scales is not None:
                 rank = len(scales)

--- a/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
@@ -347,8 +347,8 @@ class TestSymbolicShapeInferenceForOperators(unittest.TestCase):
         graph_output = onnx.helper.make_tensor_value_info("output", TensorProto.FLOAT, None)
 
         # initializers
-        value = float(numpy.array([0.5], dtype=numpy.float32))
-        constant = numpy_helper.from_array(numpy.array([value], dtype=numpy.float32), name="constant")
+        value = numpy.array([0.5], dtype=numpy.float32)
+        constant = numpy_helper.from_array(value, name="constant")
 
         nodes = [
             # Get the shape of the input tensor: `input_tensor_shape = [1024]`.
@@ -372,8 +372,8 @@ class TestSymbolicShapeInferenceForOperators(unittest.TestCase):
         graph_output = onnx.helper.make_tensor_value_info("output", TensorProto.FLOAT, None)
 
         # initializers
-        value = float(numpy.array([1.5], dtype=numpy.float32))
-        constant = numpy_helper.from_array(numpy.array([value], dtype=numpy.float32), name="constant")
+        value = numpy.array([1.5], dtype=numpy.float32)
+        constant = numpy_helper.from_array(value, name="constant")
 
         nodes = [
             # Get the shape of the input tensor: `input_tensor_shape = [768]`.

--- a/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
@@ -39,27 +39,26 @@ skipped_models = ["SSD-MobilenetV1", "SSD-int8", "Inception-1-int8"]
 
 
 class TestSymbolicShapeInference(unittest.TestCase):
-    # TODO: investigate why symbolic shape infer test failed for Python 3.10
-    # def test_symbolic_shape_infer(self):
-    #     from pathlib import Path
-    #     cwd = os.getcwd()
-    #     test_model_dir = os.path.join(cwd, "..", "models")
-    #     for filename in Path(test_model_dir).rglob("*.onnx"):
-    #         if filename.name.startswith("."):
-    #             continue  # skip some bad model files
-    #
-    #         # https://github.com/onnx/models/issues/562
-    #         if any(model_name in str(filename) for model_name in skipped_models):
-    #             print(f"Skip symbolic shape inference on : {filename!s}")
-    #             continue
-    #
-    #         print("Running symbolic shape inference on : " + str(filename))
-    #         SymbolicShapeInference.infer_shapes(
-    #             in_mp=onnx.load(str(filename)),
-    #             auto_merge=True,
-    #             int_max=100000,
-    #             guess_output_rank=True,
-    #         )
+    def test_symbolic_shape_infer(self):
+        from pathlib import Path
+        cwd = os.getcwd()
+        test_model_dir = os.path.join(cwd, "..", "models")
+        for filename in Path(test_model_dir).rglob("*.onnx"):
+            if filename.name.startswith("."):
+                continue  # skip some bad model files
+
+            # https://github.com/onnx/models/issues/562
+            if any(model_name in str(filename) for model_name in skipped_models):
+                print(f"Skip symbolic shape inference on : {filename!s}")
+                continue
+
+            print("Running symbolic shape inference on : " + str(filename))
+            SymbolicShapeInference.infer_shapes(
+                in_mp=onnx.load(str(filename)),
+                auto_merge=True,
+                int_max=100000,
+                guess_output_rank=True,
+            )
 
     def test_mismatched_types(self):
         graph = helper.make_graph(
@@ -343,56 +342,55 @@ class TestSymbolicShapeInferenceForOperators(unittest.TestCase):
     def test_einsum_transpose(self):
         self._test_einsum_one_input_impl(["a", "b"], ["b", "a"], "ij -> ji")
 
-    # TODO: investigate why symbolic shape infer test failed for Python 3.10
-    # def test_mul_precision(self):
-    #     graph_input = onnx.helper.make_tensor_value_info("input", TensorProto.FLOAT, [1024])
-    #     graph_output = onnx.helper.make_tensor_value_info("output", TensorProto.FLOAT, None)
-    #
-    #     # initializers
-    #     value = numpy.array([0.5], dtype=numpy.float32)
-    #     constant = numpy_helper.from_array(value, name="constant")
-    #
-    #     nodes = [
-    #         # Get the shape of the input tensor: `input_tensor_shape = [1024]`.
-    #         onnx.helper.make_node("Shape", ["input"], ["input_shape"]),
-    #         # mul(1024, 0.5) => 512
-    #         onnx.helper.make_node("Mul", ["input_shape", "constant"], ["output_shape"]),
-    #         # Resize input
-    #         onnx.helper.make_node(
-    #             "Resize", inputs=["input", "", "", "output_shape"], outputs=["output"], mode="nearest"
-    #         ),
-    #     ]
-    #
-    #     graph_def = onnx.helper.make_graph(nodes, "TestMulPrecision", [graph_input], [graph_output], [constant])
-    #     model = SymbolicShapeInference.infer_shapes(onnx.helper.make_model(graph_def))
-    #     output_dims = unique_element(model.graph.output).type.tensor_type.shape.dim
-    #     self.assertEqual(len(output_dims), 1)
-    #     self.assertEqual(output_dims[0].dim_value, 512)
+    def test_mul_precision(self):
+        graph_input = onnx.helper.make_tensor_value_info("input", TensorProto.FLOAT, [1024])
+        graph_output = onnx.helper.make_tensor_value_info("output", TensorProto.FLOAT, None)
 
-    # def test_div_precision(self):
-    #     graph_input = onnx.helper.make_tensor_value_info("input", TensorProto.FLOAT, [768])
-    #     graph_output = onnx.helper.make_tensor_value_info("output", TensorProto.FLOAT, None)
-    #
-    #     # initializers
-    #     value = numpy.array([1.5], dtype=numpy.float32)
-    #     constant = numpy_helper.from_array(value, name="constant")
-    #
-    #     nodes = [
-    #         # Get the shape of the input tensor: `input_tensor_shape = [768]`.
-    #         onnx.helper.make_node("Shape", ["input"], ["input_shape"]),
-    #         # div(768, 1.5) => 512
-    #         onnx.helper.make_node("Div", ["input_shape", "constant"], ["output_shape"]),
-    #         # Resize input
-    #         onnx.helper.make_node(
-    #             "Resize", inputs=["input", "", "", "output_shape"], outputs=["output"], mode="nearest"
-    #         ),
-    #     ]
-    #
-    #     graph_def = onnx.helper.make_graph(nodes, "TestDivPrecision", [graph_input], [graph_output], [constant])
-    #     model = SymbolicShapeInference.infer_shapes(onnx.helper.make_model(graph_def))
-    #     output_dims = unique_element(model.graph.output).type.tensor_type.shape.dim
-    #     self.assertEqual(len(output_dims), 1)
-    #     self.assertEqual(output_dims[0].dim_value, 512)
+        # initializers
+        value = numpy.array([0.5], dtype=numpy.float32)
+        constant = numpy_helper.from_array(value, name="constant")
+
+        nodes = [
+            # Get the shape of the input tensor: `input_tensor_shape = [1024]`.
+            onnx.helper.make_node("Shape", ["input"], ["input_shape"]),
+            # mul(1024, 0.5) => 512
+            onnx.helper.make_node("Mul", ["input_shape", "constant"], ["output_shape"]),
+            # Resize input
+            onnx.helper.make_node(
+                "Resize", inputs=["input", "", "", "output_shape"], outputs=["output"], mode="nearest"
+            ),
+        ]
+
+        graph_def = onnx.helper.make_graph(nodes, "TestMulPrecision", [graph_input], [graph_output], [constant])
+        model = SymbolicShapeInference.infer_shapes(onnx.helper.make_model(graph_def))
+        output_dims = unique_element(model.graph.output).type.tensor_type.shape.dim
+        self.assertEqual(len(output_dims), 1)
+        self.assertEqual(output_dims[0].dim_value, 512)
+
+    def test_div_precision(self):
+        graph_input = onnx.helper.make_tensor_value_info("input", TensorProto.FLOAT, [768])
+        graph_output = onnx.helper.make_tensor_value_info("output", TensorProto.FLOAT, None)
+
+        # initializers
+        value = numpy.array([1.5], dtype=numpy.float32)
+        constant = numpy_helper.from_array(value, name="constant")
+
+        nodes = [
+            # Get the shape of the input tensor: `input_tensor_shape = [768]`.
+            onnx.helper.make_node("Shape", ["input"], ["input_shape"]),
+            # div(768, 1.5) => 512
+            onnx.helper.make_node("Div", ["input_shape", "constant"], ["output_shape"]),
+            # Resize input
+            onnx.helper.make_node(
+                "Resize", inputs=["input", "", "", "output_shape"], outputs=["output"], mode="nearest"
+            ),
+        ]
+
+        graph_def = onnx.helper.make_graph(nodes, "TestDivPrecision", [graph_input], [graph_output], [constant])
+        model = SymbolicShapeInference.infer_shapes(onnx.helper.make_model(graph_def))
+        output_dims = unique_element(model.graph.output).type.tensor_type.shape.dim
+        self.assertEqual(len(output_dims), 1)
+        self.assertEqual(output_dims[0].dim_value, 512)
 
     def test_quantize_linear(self):
         """

--- a/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
@@ -347,8 +347,8 @@ class TestSymbolicShapeInferenceForOperators(unittest.TestCase):
         graph_output = onnx.helper.make_tensor_value_info("output", TensorProto.FLOAT, None)
 
         # initializers
-        value = numpy.array([0.5], dtype=numpy.float32)
-        constant = numpy_helper.from_array(value, name="constant")
+        value = float(numpy.array([0.5], dtype=numpy.float32))
+        constant = numpy_helper.from_array(numpy.array([value], dtype=numpy.float32), name="constant")
 
         nodes = [
             # Get the shape of the input tensor: `input_tensor_shape = [1024]`.
@@ -372,8 +372,8 @@ class TestSymbolicShapeInferenceForOperators(unittest.TestCase):
         graph_output = onnx.helper.make_tensor_value_info("output", TensorProto.FLOAT, None)
 
         # initializers
-        value = numpy.array([1.5], dtype=numpy.float32)
-        constant = numpy_helper.from_array(value, name="constant")
+        value = float(numpy.array([1.5], dtype=numpy.float32))
+        constant = numpy_helper.from_array(numpy.array([value], dtype=numpy.float32), name="constant")
 
         nodes = [
             # Get the shape of the input tensor: `input_tensor_shape = [768]`.

--- a/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
@@ -41,6 +41,7 @@ skipped_models = ["SSD-MobilenetV1", "SSD-int8", "Inception-1-int8"]
 class TestSymbolicShapeInference(unittest.TestCase):
     def test_symbolic_shape_infer(self):
         from pathlib import Path
+
         cwd = os.getcwd()
         test_model_dir = os.path.join(cwd, "..", "models")
         for filename in Path(test_model_dir).rglob("*.onnx"):

--- a/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
@@ -6,7 +6,8 @@ setuptools>=68.2.2
 wheel
 onnx==1.16.1
 protobuf==4.21.12
-sympy==1.12
+sympy==1.12 ; python_version < '3.9'
+sympy==1.13 ; python_version >= '3.9'
 flatbuffers
 neural-compressor>=2.2.1
 triton


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
It seems after CI updated to py310, numpy got updated to 2.0 and sympy 1.2 failed to cast float numpy array.
Pointing sympy to 1.13 when py>=3.9 and re-enable unit test

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Error: [Linux CPU CI](https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=1548489&view=logs&j=16c0bd13-8620-5d4e-8b4e-a8485ed7c5bb&t=8ada27dc-8ed6-53e5-79d8-b1163ebfb942&l=73552)

