### PR TITLE
Make EP plugin be able to create and update EP Context graph

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api_ep.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api_ep.h
@@ -333,6 +333,18 @@ ORT_API2_STATUS(OrtGraph_ReleaseValueInfo, OrtValueInfoRef* value_info);
  *
  */
 ORT_API2_STATUS(OrtGraph_SerializeToArray, const OrtGraphViewer* graph, _Out_ void** data, _Out_ size_t* data_size);  // TODO(leca): review and discuss
+ 
+ORT_API2_STATUS(OrtGraph_DumpOnnxModel, const OrtGraphViewer* graph, const char* onnx_model_path);
+
+ORT_API2_STATUS(OrtGraph_GetEpContextGraph,
+                    const OrtGraphViewer* graph,
+                    const char* cache_path,
+                    char* cache_data,
+                    size_t size,
+                    const int64_t embed_mode,
+                    const char* compute_capability,
+                    const char* onnx_model_path,
+                    _Outptr_ const OrtGraphViewer** ep_context_graph); 
 
 /** \brief Construct a subgraph from the Graph with the given node indices.
  *

--- a/include/onnxruntime/core/session/onnxruntime_c_api_ep.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api_ep.h
@@ -334,7 +334,7 @@ ORT_API2_STATUS(OrtGraph_ReleaseValueInfo, OrtValueInfoRef* value_info);
  */
 ORT_API2_STATUS(OrtGraph_SerializeToArray, const OrtGraphViewer* graph, _Out_ void** data, _Out_ size_t* data_size);  // TODO(leca): review and discuss
  
-/** \brief Serialize graph/model and save it to disk.
+/** \brief Serialize the graph(model) to disk.
  *
  * \param[in] graph The graph to be serialized
  * \param[in] onnx_model_path The file path to save to
@@ -343,13 +343,13 @@ ORT_API2_STATUS(OrtGraph_SerializeToArray, const OrtGraphViewer* graph, _Out_ vo
 ORT_API2_STATUS(OrtGraph_DumpOnnxModel, const OrtGraph* graph, const char* onnx_model_path);
 
 /** \brief  Construct an "EP Context" graph if the given ep_context_graph graph is empty, otherwise: 
- *            1. if node doesn't exist, add an "EP Context" node to the existing ep_context_graph graph
- *            2. if node already exists, update the node attributes
+ *            1. if the given node name can't be found in the graph, add an new "EP Context" node to the existing graph
+ *            2. if the node being found with the givne node name, update the node attributes only
  *
  * Please see https://onnxruntime.ai/docs/execution-providers/EP-Context-Design.html for more details about EP Context design
  *
  * \param[in] graph The graph to create or add
- * \param[in] node_name The node to be added or replaced 
+ * \param[in] node_name The node to be added or updated 
  * \param[in] main_context The attribute of EP Context op 
  * \param[in] embed_mode The attribute of EP Context op 
  * \param[in] cache_path The cache or binary file path. It's for setting the ep_cache_context attribute if embed_mode is 0

--- a/include/onnxruntime/core/session/onnxruntime_c_api_ep.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api_ep.h
@@ -334,16 +334,42 @@ ORT_API2_STATUS(OrtGraph_ReleaseValueInfo, OrtValueInfoRef* value_info);
  */
 ORT_API2_STATUS(OrtGraph_SerializeToArray, const OrtGraphViewer* graph, _Out_ void** data, _Out_ size_t* data_size);  // TODO(leca): review and discuss
  
+/** \brief Serialize graph/model and save it to disk.
+ *
+ * \param[in] graph The graph to be serialized
+ * \param[in] onnx_model_path The file path to save to
+ *
+ */
 ORT_API2_STATUS(OrtGraph_DumpOnnxModel, const OrtGraph* graph, const char* onnx_model_path);
 
-ORT_API2_STATUS(OrtGraph_GetEpContextGraph,
+/** \brief Construct an "EP Context" graph if the given ep_context_graph graph is empty, otherwise add an "EP Context" node to the existing ep_context_graph graph.
+ *
+ * Please see https://onnxruntime.ai/docs/execution-providers/EP-Context-Design.html for more details about EP Context design
+ *
+ * \param[in] graph The graph to create or add
+ * \param[in] main_context The attribute of EP Context op 
+ * \param[in] embed_mode The attribute of EP Context op 
+ * \param[in] cache_path The cache or binary file path. It's for setting the ep_cache_context attribute if embed_mode is 0
+ * \param[in] cache_data The cache or binary data. It's for setting the ep_cache_context attribute if embed_mode is 1
+ * \param[in] size The size of cache data.
+ * \param[in] extra_attr_keys The other attribute names
+ * \param[in] extra_attr_values The other attribute value in string
+ * \param[in] extra_attr_num Number of other attributes 
+ * \param[out] ep_context_graph The constructed or updated ep context graph
+ *
+ * \remarks The caller is responsible for releasing the ep_context_graph using OrtGraph_ReleaseGraph.
+ *
+ */
+ORT_API2_STATUS(OrtGraph_CreateOrUpdateEpCtxGraph,
                     const OrtGraphViewer* graph,
+                    const int64_t main_context,
+                    const int64_t embed_mode,
                     const char* cache_path,
                     char* cache_data,
                     size_t size,
-                    const int64_t embed_mode,
-                    const char* compute_capability,
-                    const char* onnx_model_path,
+                    const char* const* extra_attr_keys,
+                    const char* const* extra_attr_values,
+                    size_t extra_attr_num,
                     _Outptr_ OrtGraph** ep_context_graph);
 
 /** \brief Construct a subgraph from the Graph with the given node indices.
@@ -357,13 +383,22 @@ ORT_API2_STATUS(OrtGraph_GetEpContextGraph,
  *
  */
 ORT_API2_STATUS(OrtGraph_GetSubGraph, const OrtGraphViewer* graph, const int node_num, const size_t* node_indices, _Outptr_ const OrtGraphViewer** subgraph); // TODO(yang): review and discuss
-                                                                                                                                                              //
+                                                                                                                                                              
+/** \brief Release the graph instance.
+ *
+ * NOTE!!: Invoke this function after the use of OrtGraph_CreateOrUpdateEpCtxGraph. As OrtGraph_CreateOrUpdateEpCtxGraph allocates model instead of
+ * graph, this API releases graph's owning_model explicitly which in turn will release the graph
+ * (because graph is hosted in an unique_ptr in Model class)
+ *
+ * \param[in] graph The graph to release
+ *
+ */
 ORT_API2_STATUS(OrtGraph_ReleaseGraph, const OrtGraph* graph);
 
-/** \brief Release the graph.
+/** \brief Release the graph viewer instance.
  *
- * NOTE!!: Invoke this function after the use of OrtGraph_GetSubGraph. As OrtGraph_GetSubGraph allocate model instead of
- * graph, this API release graph's owning_model explicitly which in turn will release the graph
+ * NOTE!!: Invoke this function after the use of OrtGraph_GetSubGraph. As OrtGraph_GetSubGraph allocates model instead of
+ * graph, this API releases graph's owning_model explicitly which in turn will release the graph
  * (because graph is hosted in an unique_ptr in Model class)
  *
  * \param[in] graph The graph to release

--- a/include/onnxruntime/core/session/onnxruntime_c_api_ep.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api_ep.h
@@ -342,11 +342,14 @@ ORT_API2_STATUS(OrtGraph_SerializeToArray, const OrtGraphViewer* graph, _Out_ vo
  */
 ORT_API2_STATUS(OrtGraph_DumpOnnxModel, const OrtGraph* graph, const char* onnx_model_path);
 
-/** \brief Construct an "EP Context" graph if the given ep_context_graph graph is empty, otherwise add an "EP Context" node to the existing ep_context_graph graph.
+/** \brief  Construct an "EP Context" graph if the given ep_context_graph graph is empty, otherwise: 
+ *            1. if node doesn't exist, add an "EP Context" node to the existing ep_context_graph graph
+ *            2. if node already exists, update the node attributes
  *
  * Please see https://onnxruntime.ai/docs/execution-providers/EP-Context-Design.html for more details about EP Context design
  *
  * \param[in] graph The graph to create or add
+ * \param[in] node_name The node to be added or replaced 
  * \param[in] main_context The attribute of EP Context op 
  * \param[in] embed_mode The attribute of EP Context op 
  * \param[in] cache_path The cache or binary file path. It's for setting the ep_cache_context attribute if embed_mode is 0
@@ -362,6 +365,7 @@ ORT_API2_STATUS(OrtGraph_DumpOnnxModel, const OrtGraph* graph, const char* onnx_
  */
 ORT_API2_STATUS(OrtGraph_CreateOrUpdateEpCtxGraph,
                     const OrtGraphViewer* graph,
+                    const char* node_name, 
                     const int64_t main_context,
                     const int64_t embed_mode,
                     const char* cache_path,

--- a/include/onnxruntime/core/session/onnxruntime_c_api_ep.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api_ep.h
@@ -334,7 +334,7 @@ ORT_API2_STATUS(OrtGraph_ReleaseValueInfo, OrtValueInfoRef* value_info);
  */
 ORT_API2_STATUS(OrtGraph_SerializeToArray, const OrtGraphViewer* graph, _Out_ void** data, _Out_ size_t* data_size);  // TODO(leca): review and discuss
  
-ORT_API2_STATUS(OrtGraph_DumpOnnxModel, const OrtGraphViewer* graph, const char* onnx_model_path);
+ORT_API2_STATUS(OrtGraph_DumpOnnxModel, const OrtGraph* graph, const char* onnx_model_path);
 
 ORT_API2_STATUS(OrtGraph_GetEpContextGraph,
                     const OrtGraphViewer* graph,
@@ -344,7 +344,7 @@ ORT_API2_STATUS(OrtGraph_GetEpContextGraph,
                     const int64_t embed_mode,
                     const char* compute_capability,
                     const char* onnx_model_path,
-                    _Outptr_ const OrtGraphViewer** ep_context_graph); 
+                    _Outptr_ OrtGraph** ep_context_graph);
 
 /** \brief Construct a subgraph from the Graph with the given node indices.
  *
@@ -357,6 +357,8 @@ ORT_API2_STATUS(OrtGraph_GetEpContextGraph,
  *
  */
 ORT_API2_STATUS(OrtGraph_GetSubGraph, const OrtGraphViewer* graph, const int node_num, const size_t* node_indices, _Outptr_ const OrtGraphViewer** subgraph); // TODO(yang): review and discuss
+                                                                                                                                                              //
+ORT_API2_STATUS(OrtGraph_ReleaseGraph, const OrtGraph* graph);
 
 /** \brief Release the graph.
  *
@@ -367,7 +369,7 @@ ORT_API2_STATUS(OrtGraph_GetSubGraph, const OrtGraphViewer* graph, const int nod
  * \param[in] graph The graph to release
  *
  */
-ORT_API2_STATUS(OrtGraph_ReleaseGraph, const OrtGraphViewer* graph);
+ORT_API2_STATUS(OrtGraph_ReleaseGraphViewer, const OrtGraphViewer* graph);
 
 /** \brief Gets the name of the node
  *

--- a/onnxruntime/core/session/onnxruntime_c_api_ep.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api_ep.cc
@@ -510,9 +510,8 @@ ORT_API_STATUS_IMPL(OrtGraphApis::OrtGraph_DumpOnnxModel,
 }
 
 /* Construct an "EP Context" graph if the given ep_context_graph graph is empty, otherwise: 
- *   1. if node doesn't exist, add an "EP Context" node to the existing ep_context_graph graph
- *   2. if node already exists, update the node attributes
- *
+ *   1. if the given node name can't be found in the graph, add an new "EP Context" node to the existing graph
+ *   2. if the node being found with the givne node name, update the node attributes only
  */
 ORT_API_STATUS_IMPL(OrtGraphApis::OrtGraph_CreateOrUpdateEpCtxGraph,
                     const OrtGraphViewer* graph,

--- a/onnxruntime/core/session/onnxruntime_c_api_ep.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api_ep.cc
@@ -978,7 +978,7 @@ static constexpr OrtGraphApi ort_graph_api = {
     &OrtGraphApis::OrtGraph_ReleaseValueInfo,
     &OrtGraphApis::OrtGraph_SerializeToArray,
     &OrtGraphApis::OrtGraph_DumpOnnxModel,
-    &OrtGraphApis::OrtGraph_GetEpContextGraph,
+    &OrtGraphApis::OrtGraph_CreateOrUpdateEpCtxGraph,
     &OrtGraphApis::OrtGraph_GetSubGraph,
     &OrtGraphApis::OrtGraph_ReleaseGraph,
     &OrtGraphApis::OrtGraph_ReleaseGraphViewer,

--- a/onnxruntime/core/session/ort_apis_ep.h
+++ b/onnxruntime/core/session/ort_apis_ep.h
@@ -57,7 +57,7 @@ ORT_API_STATUS_IMPL(OrtGraph_SerializeToArray, const OrtGraphViewer* graph, _Out
 
 ORT_API_STATUS_IMPL(OrtGraph_DumpOnnxModel, const OrtGraph* graph, const char* onnx_model_path);
 
-ORT_API_STATUS_IMPL(OrtGraph_GetEpContextGraph,
+ORT_API_STATUS_IMPL(OrtGraph_CreateOrUpdateEpCtxGraph,
                     const OrtGraphViewer* graph,
                     const int64_t main_context,
                     const int64_t embed_mode,

--- a/onnxruntime/core/session/ort_apis_ep.h
+++ b/onnxruntime/core/session/ort_apis_ep.h
@@ -59,6 +59,7 @@ ORT_API_STATUS_IMPL(OrtGraph_DumpOnnxModel, const OrtGraph* graph, const char* o
 
 ORT_API_STATUS_IMPL(OrtGraph_CreateOrUpdateEpCtxGraph,
                     const OrtGraphViewer* graph,
+                    const char* node_name, 
                     const int64_t main_context,
                     const int64_t embed_mode,
                     const char* cache_path,

--- a/onnxruntime/core/session/ort_apis_ep.h
+++ b/onnxruntime/core/session/ort_apis_ep.h
@@ -59,12 +59,14 @@ ORT_API_STATUS_IMPL(OrtGraph_DumpOnnxModel, const OrtGraph* graph, const char* o
 
 ORT_API_STATUS_IMPL(OrtGraph_GetEpContextGraph,
                     const OrtGraphViewer* graph,
+                    const int64_t main_context,
+                    const int64_t embed_mode,
                     const char* cache_path,
                     char* cache_data,
                     size_t size,
-                    const int64_t embed_mode,
-                    const char* compute_capability,
-                    const char* onnx_model_path,
+                    const char* const* extra_attr_keys,
+                    const char* const* extra_attr_values,
+                    size_t extra_attr_num,
                     _Outptr_ OrtGraph** ep_context_graph); 
 
 ORT_API_STATUS_IMPL(OrtGraph_GetSubGraph, const OrtGraphViewer* graph, const int node_num, const size_t* node_indices, _Outptr_ const OrtGraphViewer** subgraph);

--- a/onnxruntime/core/session/ort_apis_ep.h
+++ b/onnxruntime/core/session/ort_apis_ep.h
@@ -55,6 +55,18 @@ ORT_API_STATUS_IMPL(OrtGraph_ReleaseValueInfo, OrtValueInfoRef* value_info);
 
 ORT_API_STATUS_IMPL(OrtGraph_SerializeToArray, const OrtGraphViewer* graph, _Out_ void** data, _Out_ size_t* data_size);
 
+ORT_API_STATUS_IMPL(OrtGraph_DumpOnnxModel, const OrtGraphViewer* graph, const char* onnx_model_path);
+
+ORT_API_STATUS_IMPL(OrtGraph_GetEpContextGraph,
+                    const OrtGraphViewer* graph,
+                    const char* cache_path,
+                    char* cache_data,
+                    size_t size,
+                    const int64_t embed_mode,
+                    const char* compute_capability,
+                    const char* onnx_model_path,
+                    _Outptr_ const OrtGraphViewer** ep_context_graph); 
+
 ORT_API_STATUS_IMPL(OrtGraph_GetSubGraph, const OrtGraphViewer* graph, const int node_num, const size_t* node_indices, _Outptr_ const OrtGraphViewer** subgraph);
 
 ORT_API_STATUS_IMPL(OrtGraph_ReleaseGraph, const OrtGraphViewer* graph);

--- a/onnxruntime/core/session/ort_apis_ep.h
+++ b/onnxruntime/core/session/ort_apis_ep.h
@@ -55,7 +55,7 @@ ORT_API_STATUS_IMPL(OrtGraph_ReleaseValueInfo, OrtValueInfoRef* value_info);
 
 ORT_API_STATUS_IMPL(OrtGraph_SerializeToArray, const OrtGraphViewer* graph, _Out_ void** data, _Out_ size_t* data_size);
 
-ORT_API_STATUS_IMPL(OrtGraph_DumpOnnxModel, const OrtGraphViewer* graph, const char* onnx_model_path);
+ORT_API_STATUS_IMPL(OrtGraph_DumpOnnxModel, const OrtGraph* graph, const char* onnx_model_path);
 
 ORT_API_STATUS_IMPL(OrtGraph_GetEpContextGraph,
                     const OrtGraphViewer* graph,
@@ -65,11 +65,13 @@ ORT_API_STATUS_IMPL(OrtGraph_GetEpContextGraph,
                     const int64_t embed_mode,
                     const char* compute_capability,
                     const char* onnx_model_path,
-                    _Outptr_ const OrtGraphViewer** ep_context_graph); 
+                    _Outptr_ OrtGraph** ep_context_graph); 
 
 ORT_API_STATUS_IMPL(OrtGraph_GetSubGraph, const OrtGraphViewer* graph, const int node_num, const size_t* node_indices, _Outptr_ const OrtGraphViewer** subgraph);
 
-ORT_API_STATUS_IMPL(OrtGraph_ReleaseGraph, const OrtGraphViewer* graph);
+ORT_API_STATUS_IMPL(OrtGraph_ReleaseGraph, const OrtGraph* graph);
+
+ORT_API_STATUS_IMPL(OrtGraph_ReleaseGraphViewer, const OrtGraphViewer* graph);
 
 ORT_API_STATUS_IMPL(OrtNode_GetName, const OrtNode* node, _Outptr_ const char** out);
 

--- a/samples/tensorRTEp/tensorrt_execution_provider.h
+++ b/samples/tensorRTEp/tensorrt_execution_provider.h
@@ -214,6 +214,10 @@ struct TensorrtShortFuncState {
 using DDSOutputAllocatorMap = std::unordered_map<std::string, std::unique_ptr<OutputAllocator>>;
 std::string GetWeightRefittedEnginePath(std::string engine_cache_path);
 
+static const std::string k_cc_hw_compatible = "80+";
+static const std::string k_ep_ctx_hardware_architecture = "hardware_architecture";
+static const std::string k_ep_ctx_onnx_model_filename = "onnx_model_filename";
+
 struct TensorrtExecutionProvider : public OrtExecutionProvider {
     TensorrtExecutionProvider(const char* ep_type, const ProviderOptions& provider_options);
     bool IsGraphCaptured(int graph_annotation_id) const { return false; }
@@ -309,6 +313,11 @@ private:
   std::string ctx_model_path_;
   std::string ep_cache_context_attr_;
   std::string engine_cache_relative_path_to_context_model_dir;
+
+  OrtGraph* ep_ctx_graph_ = nullptr;
+  std::vector<const char*> extra_attr_keys_;
+  std::vector<const char*> extra_attr_values_;
+
 //  std::unique_ptr<ONNX_NAMESPACE::ModelProto> model_proto_ = ONNX_NAMESPACE::ModelProto::Create();
 
   std::unordered_set<std::string> control_flow_op_set_ = {"If", "Loop", "Scan"};


### PR DESCRIPTION
This PR support several features:

- Add new graph API to create and update EP Context graph, and dump EP Context model.

1.  OrtGraph_CreateOrUpdateEpCtxGraph
2. OrtGraph_DumpOnnxModel
3. OrtGraph_ReleaseGraph 

- Add new graph API to dump onnx model
- The APIs provided by this PR can dump EP Context model when the whole model can be run by one EP, the APIs also aim to support the case where the whole model is partitioned into multiple EP's subgraphs. (Note: i haven't fully tested the partitioning case, please help review it)
- Modify TRT EP plugin to use those APIs.


