### PR TITLE
Fix 1.20 cuda minimal build failure

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -67,7 +67,10 @@ function(AddTest)
     if(onnxruntime_USE_CUDA)
       #XXX: we should not need to do this. onnxruntime_test_all.exe should not have direct dependency on CUDA DLLs,
       # otherwise it will impact when CUDA DLLs can be unloaded.
-      target_link_libraries(${_UT_TARGET} PRIVATE CUDA::cudart cudnn_frontend)
+      target_link_libraries(${_UT_TARGET} PRIVATE CUDA::cudart)
+      if(NOT onnxruntime_CUDA_MINIMAL)
+          target_link_libraries(${_UT_TARGET} PRIVATE cudnn_frontend)
+      endif()
     endif()
     target_link_libraries(${_UT_TARGET} PRIVATE ${_UT_LIBS} GTest::gtest GTest::gmock ${onnxruntime_EXTERNAL_LIBRARIES})
   endif()

--- a/onnxruntime/core/providers/cuda/cudnn_fe_call.cc
+++ b/onnxruntime/core/providers/cuda/cudnn_fe_call.cc
@@ -4,7 +4,7 @@
 #include "core/providers/cuda/shared_inc/cudnn_fe_call.h"
 #include "core/providers/shared_library/provider_api.h"
 #include <core/platform/env.h>
-#if !defined(__CUDACC__)
+#if !defined(__CUDACC__) && !defined(USE_CUDA_MINIMAL)
 #include <cudnn_frontend.h>
 #endif
 #ifdef _WIN32
@@ -22,7 +22,7 @@ const char* CudaErrString(ERRTYPE) {
   ORT_NOT_IMPLEMENTED();
 }
 
-#if !defined(__CUDACC__)
+#if !defined(__CUDACC__) && !defined(USE_CUDA_MINIMAL)
 #define CASE_ENUM_TO_STR_CUDNN_FE(x)    \
   case cudnn_frontend::error_code_t::x: \
     return #x

--- a/onnxruntime/core/providers/cuda/shared_inc/cudnn_fe_call.h
+++ b/onnxruntime/core/providers/cuda/shared_inc/cudnn_fe_call.h
@@ -5,7 +5,7 @@
 #include "core/common/common.h"
 #include "core/providers/cuda/cuda_pch.h"
 #include "core/providers/cuda/shared_inc/cuda_call.h"
-#if !defined(__CUDACC__)
+#if !defined(__CUDACC__) && !defined(USE_CUDA_MINIMAL)
 #include <cudnn_frontend.h>
 #endif
 namespace onnxruntime {
@@ -14,10 +14,12 @@ namespace onnxruntime {
 // Error handling
 // -----------------------------------------------------------------------
 
+#ifndef USE_CUDA_MINIMAL
 #define CUDNN_FE_CALL(expr) (CudaCall<cudnn_frontend::error_t, false,                                                   \
                                       cudnn_frontend::error_code_t>((cudnn_frontend::error_t)(expr), #expr, "CUDNN_FE", \
                                                                     cudnn_frontend::error_code_t::OK, "", __FILE__, __LINE__))
 #define CUDNN_FE_CALL_THROW(expr) (CudaCall<cudnn_frontend::error_t, true,                                                    \
                                             cudnn_frontend::error_code_t>((cudnn_frontend::error_t)(expr), #expr, "CUDNN_FE", \
                                                                           cudnn_frontend::error_code_t::OK, "", __FILE__, __LINE__))
+#endif
 }  // namespace onnxruntime


### PR DESCRIPTION
### Description
Fixes build failure for the cuda minimal build




### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
[This change](https://github.com/microsoft/onnxruntime/pull/19470) in 1.20 is causing build failures for the cuda minimal build.
Essentially, some cudnn logic was not guarded by the `USE_CUDA_MINIMAL`. Also the build is looking for cudnn while in the cuda minimal build it shouldn't depend on it, resulting in linking error. 


cc @gedoensmax @chilo-ms 