### PR TITLE
Check bias shape in operator Conv

### DIFF
--- a/onnxruntime/core/providers/cpu/nn/conv.cc
+++ b/onnxruntime/core/providers/cpu/nn/conv.cc
@@ -32,7 +32,7 @@ Status Conv<T>::Compute(OpKernelContext* context) const {
   const int64_t N = X->Shape()[0];
   const int64_t C = X->Shape()[1];
   const int64_t M = W->Shape()[0];
-  ORT_RETURN_IF_ERROR(conv_attrs_.ValidateInputShape(X, W));
+  ORT_RETURN_IF_ERROR(conv_attrs_.ValidateInputShape(X, W, B));
 
   TensorShapeVector kernel_shape;
   ORT_RETURN_IF_ERROR(conv_attrs_.ComputeKernelShape(W->Shape(), kernel_shape));

--- a/onnxruntime/core/providers/cpu/nn/conv_attributes.h
+++ b/onnxruntime/core/providers/cpu/nn/conv_attributes.h
@@ -152,9 +152,9 @@ struct ConvAttributes {
     return status;
   }
 
-  Status ValidateInputShape(const Tensor* input, const Tensor* weight, const Tensor* bias=nullptr) const {
+  Status ValidateInputShape(const Tensor* input, const Tensor* weight, const Tensor* bias = nullptr) const {
     if (bias == nullptr)
-        return ValidateInputShape(input->Shape(), weight->Shape());
+      return ValidateInputShape(input->Shape(), weight->Shape());
     return ValidateInputShape(input->Shape(), weight->Shape(), bias->Shape());
   }
 

--- a/onnxruntime/core/providers/cpu/nn/conv_attributes.h
+++ b/onnxruntime/core/providers/cpu/nn/conv_attributes.h
@@ -131,8 +131,31 @@ struct ConvAttributes {
     return Status::OK();
   }
 
-  Status ValidateInputShape(const Tensor* input, const Tensor* weight) const {
-    return ValidateInputShape(input->Shape(), weight->Shape());
+  Status ValidateInputShape(const TensorShape& input_shape,
+                            const TensorShape& weight_shape,
+                            const TensorShape& bias_shape,
+                            bool input_channels_last = false,
+                            bool weight_channels_last = false) const {
+    Status status = ValidateInputShape(input_shape, weight_shape, input_channels_last, weight_channels_last);
+    if (status.IsOK()) {
+      if (bias_shape.Size() > 1) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Input bias must be a 1D tensor");
+      }
+      if (bias_shape.Size() == 1 && bias_shape[0] != weight_shape[0]) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                               "Input bias must be a 1D tensor of size W.shape[0], "
+                               "bias.shape[0] = ",
+                               bias_shape[0],
+                               ", weight.shape[0] =", weight_shape[0]);
+      }
+    }
+    return status;
+  }
+
+  Status ValidateInputShape(const Tensor* input, const Tensor* weight, const Tensor* bias=nullptr) const {
+    if (bias == nullptr)
+        return ValidateInputShape(input->Shape(), weight->Shape());
+    return ValidateInputShape(input->Shape(), weight->Shape(), bias->Shape());
   }
 
   Status InferPadsAndOutputShape(const TensorShape& input_shape,


### PR DESCRIPTION
### Description
The bias shape is not checked as the other shapes when operator Conv is called. That could lead to unwanted memory access.



### Motivation and Context
Catch potential memory issue.

