### PR TITLE
Update ORT website w/ 1.20.0 + 1.20.1 changes

### DIFF
--- a/src/routes/getting-started/table.svelte
+++ b/src/routes/getting-started/table.svelte
@@ -77,16 +77,16 @@
 	const TrainingBuildIds = ['ot_stable', 'ot_nightly'];
 	const validCombos = {
 		'windows,C-API,X64,CUDA':
-			"For CUDA 11.X (default): Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.Gpu' target='_blank'>Microsoft.ML.OnnxRuntime.Gpu</a>. <br/>For CUDA 12.X: Follow instructions <a class='text-blue-500' href='https://onnxruntime.ai/docs/install/#install-onnx-runtime-gpu-cuda-12x-1' target='_blank'>here</a>. <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",
+			"For CUDA 12.X (default): Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.Gpu.Windows' target='_blank'>Microsoft.ML.OnnxRuntime.Gpu.Windows</a>. <br/>For CUDA 11.X: Follow instructions <a class='text-blue-500' href='https://onnxruntime.ai/docs/install/#install-onnx-runtime-gpu-cuda-118' target='_blank'>here</a>. <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",
 
 		'windows,C++,X64,CUDA':
-			"For CUDA 11.X (default): Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.Gpu' target='_blank'>Microsoft.ML.OnnxRuntime.Gpu</a>. <br/>For CUDA 12.X: Follow instructions <a class='text-blue-500' href='https://onnxruntime.ai/docs/install/#install-onnx-runtime-gpu-cuda-12x-1' target='_blank'>here</a>. <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",
+			"For CUDA 12.X (default): Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.Gpu.Windows' target='_blank'>Microsoft.ML.OnnxRuntime.Gpu.Windows</a>. <br/>For CUDA 11.X: Follow instructions <a class='text-blue-500' href='https://onnxruntime.ai/docs/install/#install-onnx-runtime-gpu-cuda-118' target='_blank'>here</a>. <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",
 
 		'windows,C#,X64,CUDA':
-			"For CUDA 11.X (default): Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.Gpu' target='_blank'>Microsoft.ML.OnnxRuntime.Gpu</a>. <br/>For CUDA 12.X: Follow instructions <a class='text-blue-500' href='https://onnxruntime.ai/docs/install/#install-onnx-runtime-gpu-cuda-12x-1' target='_blank'>here</a>. <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",
+			"For CUDA 12.X (default): Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.Gpu.Windows' target='_blank'>Microsoft.ML.OnnxRuntime.Gpu.Windows</a>. <br/>For CUDA 11.X: Follow instructions <a class='text-blue-500' href='https://onnxruntime.ai/docs/install/#install-onnx-runtime-gpu-cuda-118' target='_blank'>here</a>. <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",
 
 		'windows,Python,X64,CUDA':
-			"For CUDA 11.X (default): <br/>pip install onnxruntime-gpu <br/>For CUDA 12.X: <br/>pip install onnxruntime-gpu --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-12/pypi/simple/ <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",
+			"For CUDA 12.X (default): <br/>pip install onnxruntime-gpu <br/>For CUDA 11.X: <br/>pip install onnxruntime-gpu --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-11/pypi/simple/ <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",
 
 		'linux,Python,ARM64,CUDA':
 			"For Jetpack 4.4+, follow installation instructions from <a class='text-blue-500' href='https://elinux.org/Jetson_Zoo#ONNX_Runtime' target='_blank'>here</a>. <br/>Note: We do not have CUDA 12.X ARM64 support at this time.",
@@ -95,13 +95,13 @@
 			"Download .tgz file from&nbsp;<a class='text-blue-500' href='https://github.com/microsoft/onnxruntime/releases' target='_blank'>Github</a> <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",
 
 		'linux,C++,X64,CUDA':
-			"For CUDA 11.X (default): Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.Gpu' target='_blank'>Microsoft.ML.OnnxRuntime.Gpu</a>. <br/>For CUDA 12.X: Follow instructions <a class='text-blue-500' href='https://onnxruntime.ai/docs/install/#install-onnx-runtime-gpu-cuda-12x-1' target='_blank'>here</a>. <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",
+			"For CUDA 12.X (default): Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.Gpu.Linux' target='_blank'>Microsoft.ML.OnnxRuntime.Gpu.Linux</a>. <br/>For CUDA 11.X: Follow instructions <a class='text-blue-500' href='https://onnxruntime.ai/docs/install/#install-onnx-runtime-gpu-cuda-118' target='_blank'>here</a>. <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",
 
 		'linux,C#,X64,CUDA':
-			"For CUDA 11.X (default): Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.Gpu' target='_blank'>Microsoft.ML.OnnxRuntime.Gpu</a>. <br/>For CUDA 12.X: Follow instructions <a class='text-blue-500' href='https://onnxruntime.ai/docs/install/#install-onnx-runtime-gpu-cuda-12x-1' target='_blank'>here</a>. <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",
+			"For CUDA 12.X (default): Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.Gpu.Linux' target='_blank'>Microsoft.ML.OnnxRuntime.Gpu.Linux</a>. <br/>For CUDA 11.X: Follow instructions <a class='text-blue-500' href='https://onnxruntime.ai/docs/install/#install-onnx-runtime-gpu-cuda-118' target='_blank'>here</a>. <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",
 
 		'linux,Python,X64,CUDA':
-			"For CUDA 11.X (default): <br/>pip install onnxruntime-gpu <br/>For CUDA 12.X: <br/>pip install onnxruntime-gpu --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-12/pypi/simple/ <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",
+			"For CUDA 12.X (default): <br/>pip install onnxruntime-gpu <br/>For CUDA 11.X: <br/>pip install onnxruntime-gpu --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-11/pypi/simple/ <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",
 
 		'linux,C-API,ARM32,DefaultCPU':
 			"Follow build instructions from&nbsp;<a class='text-blue-500' href='https://aka.ms/build-ort-arm' target='_blank'>here</a>",
@@ -119,13 +119,13 @@
 			"Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>",
 
 		'windows,C-API,ARM32,DefaultCPU':
-			"Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>",
+			"Follow build instructions from&nbsp;<a class='text-blue-500' href='https://aka.ms/build-ort-arm' target='_blank'>here</a>",
 
 		'windows,C++,ARM32,DefaultCPU':
-			"Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>",
+			"Follow build instructions from&nbsp;<a class='text-blue-500' href='https://aka.ms/build-ort-arm' target='_blank'>here</a>",
 
 		'windows,C#,ARM32,DefaultCPU':
-			"Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>",
+			"Follow build instructions from&nbsp;<a class='text-blue-500' href='https://aka.ms/build-ort-arm' target='_blank'>here</a>",
 
 		'windows,C-API,ARM64,DefaultCPU':
 			"Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>",
@@ -157,6 +157,12 @@
 		'linux,C#,X64,DefaultCPU':
 			"Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>",
 
+		'linux,C-API,ARM64,DefaultCPU':
+			"Download .tgz file from&nbsp;<a class='text-blue-500' href='https://github.com/microsoft/onnxruntime/releases' target='_blank'>Github</a>",
+
+		'linux,C#,ARM64,DefaultCPU':
+			"Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>",
+
 		'mac,C-API,X64,DefaultCPU':
 			"Add 'onnxruntime-c' using CocoaPods or download the .tgz file from&nbsp;<a class='text-blue-500' href='https://github.com/microsoft/onnxruntime/releases' target='_blank'>Github</a>.",
 
@@ -164,12 +170,14 @@
 			"Add 'onnxruntime-c' using CocoaPods or download the .tgz file from&nbsp;<a class='text-blue-500' href='https://github.com/microsoft/onnxruntime/releases' target='_blank'>Github</a>.",
 
 		'mac,C#,X64,DefaultCPU':
-			"Download .tgz file from&nbsp;<a class='text-blue-500' href='https://github.com/microsoft/onnxruntime/releases' target='_blank'>Github</a>",
+			"Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>",
 
 		'mac,C#,X64,CoreML':
-			"Download .tgz file from&nbsp;<a class='text-blue-500' href='https://github.com/microsoft/onnxruntime/releases' target='_blank'>Github</a>",
+			"Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>",
 
 		'windows,Python,X64,DefaultCPU': 'pip install onnxruntime',
+
+		'windows,Python,X86,DefaultCPU': 'pip install onnxruntime',
 
 		'mac,Python,X64,DefaultCPU': 'pip install onnxruntime',
 
@@ -267,31 +275,28 @@
 		'windows,Python,X64,OpenVINO': 'pip install onnxruntime-openvino',
 
 		'windows,C-API,X64,TensorRT':
-			"Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.Gpu' target='_blank'>Microsoft.ML.OnnxRuntime.Gpu</a> <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html' target='_blank'>docs</a> for usage details.",
+			"Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.Gpu.Windows' target='_blank'>Microsoft.ML.OnnxRuntime.Gpu.Windows</a> <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html' target='_blank'>docs</a> for usage details.",
 
 		'windows,C++,X64,TensorRT':
-			"Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.Gpu' target='_blank'>Microsoft.ML.OnnxRuntime.Gpu</a> <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html' target='_blank'>docs</a> for usage details.",
+			"Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.Gpu.Windows' target='_blank'>Microsoft.ML.OnnxRuntime.Gpu.Windows</a> <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html' target='_blank'>docs</a> for usage details.",
 
 		'windows,C#,X64,TensorRT':
-			"Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.Gpu' target='_blank'>Microsoft.ML.OnnxRuntime.Gpu</a> <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html' target='_blank'>docs</a> for usage details.",
+			"Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.Gpu.Windows' target='_blank'>Microsoft.ML.OnnxRuntime.Gpu.Windows</a> <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html' target='_blank'>docs</a> for usage details.",
 
 		'windows,Python,X64,TensorRT':
 			"pip install onnxruntime-gpu <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",
 
 		'linux,C-API,X64,TensorRT':
-			"Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.Gpu' target='_blank'>Microsoft.ML.OnnxRuntime.Gpu</a> <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html' target='_blank'>docs</a> for usage details.",
+			"Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.Gpu.Linux' target='_blank'>Microsoft.ML.OnnxRuntime.Gpu.Linux</a> <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html' target='_blank'>docs</a> for usage details.",
 
 		'linux,C++,X64,TensorRT':
-			"Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.Gpu' target='_blank'>Microsoft.ML.OnnxRuntime.Gpu</a> <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html' target='_blank'>docs</a> for usage details.",
+			"Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.Gpu.Linux' target='_blank'>Microsoft.ML.OnnxRuntime.Gpu.Linux</a> <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html' target='_blank'>docs</a> for usage details.",
 
 		'linux,C#,X64,TensorRT':
-			"Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.Gpu' target='_blank'>Microsoft.ML.OnnxRuntime.Gpu</a> <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html' target='_blank'>docs</a> for usage details.",
+			"Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.Gpu.Linux' target='_blank'>Microsoft.ML.OnnxRuntime.Gpu.Linux</a> <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html' target='_blank'>docs</a> for usage details.",
 
 		'linux,Python,X64,TensorRT':
 			"pip install onnxruntime-gpu <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",
-
-		'linux,C#,ARM64,DefaultCPU':
-			"Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime",
 
 		'linux,Python,ARM64,TensorRT':
 			"pip install onnxruntime-gpu <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",
@@ -335,7 +340,7 @@
 			"Add a dependency on <a class='text-blue-500' href='https://search.maven.org/artifact/com.microsoft.onnxruntime/onnxruntime' target='_blank'>com.microsoft.onnxruntime:onnxruntime</a> using Maven/Gradle",
 
 		'linux,Java,X64,CUDA':
-			"Add a dependency on <a class='text-blue-500' href='https://search.maven.org/artifact/com.microsoft.onnxruntime/onnxruntime_gpu' target='_blank'>com.microsoft.onnxruntime:onnxruntime_gpu</a> using Maven/Gradle. <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements. <br/>Note: CUDA 12.X is not currently available with the Java GPU package due to low demand.",
+			"Add a dependency on <a class='text-blue-500' href='https://search.maven.org/artifact/com.microsoft.onnxruntime/onnxruntime_gpu' target='_blank'>com.microsoft.onnxruntime:onnxruntime_gpu</a> using Maven/Gradle. <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",
 
 		'mac,Java,X64,DefaultCPU':
 			"Add a dependency on <a class='text-blue-500' href='https://search.maven.org/artifact/com.microsoft.onnxruntime/onnxruntime' target='_blank'>com.microsoft.onnxruntime:onnxruntime</a> using Maven/Gradle",
@@ -382,7 +387,7 @@
 			"Add a dependency on <a class='text-blue-500' href='https://search.maven.org/artifact/com.microsoft.onnxruntime/onnxruntime' target='_blank'>com.microsoft.onnxruntime:onnxruntime</a> using Maven/Gradle",
 
 		'windows,Java,X64,CUDA':
-			"Add a dependency on <a class='text-blue-500' href='https://search.maven.org/artifact/com.microsoft.onnxruntime/onnxruntime_gpu' target='_blank'>com.microsoft.onnxruntime:onnxruntime_gpu</a> using Maven/Gradle. <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements. <br/>Note: CUDA 12.X is not currently available with the Java GPU package due to low demand.",
+			"Add a dependency on <a class='text-blue-500' href='https://search.maven.org/artifact/com.microsoft.onnxruntime/onnxruntime_gpu' target='_blank'>com.microsoft.onnxruntime:onnxruntime_gpu</a> using Maven/Gradle. <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",
 
 		'windows,Java,X64,TensorRT':
 			"Add a dependency on <a class='text-blue-500' href='https://search.maven.org/artifact/com.microsoft.onnxruntime/onnxruntime_gpu' target='_blank'>com.microsoft.onnxruntime:onnxruntime_gpu</a> using Maven/Gradle. <br/>Refer to <a class='text-blue-500' href='http://www.onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html' target='_blank'>docs</a> for usage details.",
@@ -635,13 +640,22 @@
 
 		//QNN
 		'windows,C-API,ARM64,QNN':
-			"View installation instructions <a class='text-blue-500' href='https://aka.ms/build-ort-qnn' target='_blank'>here</a>",
+			"Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.QNN' target='_blank'>Microsoft.ML.OnnxRuntime.QNN</a>.",
 
 		'windows,C++,ARM64,QNN':
-			"View installation instructions <a class='text-blue-500' href='https://aka.ms/build-ort-qnn' target='_blank'>here</a>",
+			"Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.QNN' target='_blank'>Microsoft.ML.OnnxRuntime.QNN</a>.",
 
 		'windows,C#,ARM64,QNN':
-			"View installation instructions <a class='text-blue-500' href='https://aka.ms/build-ort-qnn' target='_blank'>here</a>",
+			"Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.QNN' target='_blank'>Microsoft.ML.OnnxRuntime.QNN</a>.",
+
+		'windows,C-API,X64,QNN':
+			"Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.QNN' target='_blank'>Microsoft.ML.OnnxRuntime.QNN</a>.",
+
+		'windows,C++,X64,QNN':
+			"Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.QNN' target='_blank'>Microsoft.ML.OnnxRuntime.QNN</a>.",
+
+		'windows,C#,X64,QNN':
+			"Install Nuget package&nbsp;<a class='text-blue-500' href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.QNN' target='_blank'>Microsoft.ML.OnnxRuntime.QNN</a>.",
 
 		'linux,C-API,ARM64,QNN':
 			"Follow build instructions from <a class='text-blue-500' href='https://aka.ms/build-ort-qnn' target='_blank'>here</a>",
@@ -654,6 +668,15 @@
 
 		'android,C++,ARM64,QNN':
 			"Follow build instructions from <a class='text-blue-500' href='https://aka.ms/build-ort-qnn' target='_blank'>here</a>",
+
+		'windows,Python,ARM64,QNN':
+			"pip install onnxruntime-qnn",
+
+		'windows,Python,X64,QNN':
+			"pip install onnxruntime-qnn",
+
+		'android,Java,ARM64,QNN':
+			"Add a dependency on <a class='text-blue-500' href='https://mvnrepository.com/artifact/com.microsoft.onnxruntime/onnxruntime-android-qnn' target='_blank'>com.microsoft.onnxruntime:onnxruntime-android-qnn</a> using Maven/Gradle and refer to the <a class='text-blue-500' href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
 
 		//Xnnpack
 		'ios,C-API,ARM64,XNNPACK':

--- a/src/routes/roadmap/+page.svelte
+++ b/src/routes/roadmap/+page.svelte
@@ -1,6 +1,6 @@
 <script>
 	let description = 'ONNX Runtime Release Roadmap - find the latest release information for ONNX Runtime.';
-	let keywords = 'onnx runtime, onnx runtime roadmap, onnx runtime release, onnx runtime 1.20';
+	let keywords = 'onnx runtime, onnx runtime roadmap, onnx runtime release, onnx runtime 1.20, onnx runtime 1.21, onnx runtime 1.20.1';
 </script>
 <svelte:head>
 	<!-- Dynamic meta tags -->
@@ -37,8 +37,8 @@
 					>
 				</div>
 				<div class="stat-title">Previous release</div>
-				<div class="stat-value text-success">1.19.2</div>
-				<div class="stat-desc">Release date: 9/4/2024</div>
+				<div class="stat-value text-success">1.20.0</div>
+				<div class="stat-desc">Release date: 11/1/2024</div>
 			</div>
 
 			<div class="stat">
@@ -59,8 +59,8 @@
 					>
 				</div>
 				<div class="font-bold underline">In-Progress Release</div>
-				<div class="stat-value text-warning">1.20</div>
-				<div class="stat-desc">Release date: 10/30/2024</div>
+				<div class="stat-value text-warning">1.20.1</div>
+				<div class="stat-desc">Release date: 11/20/2024</div>
 			</div>
 
 			<div class="stat">
@@ -87,54 +87,38 @@
 			</div>
 		</div>
 	</div>
+
 	<h2 class="text-xl font-bold mt-2">Announcements</h2>
 	<ul class="list-disc ml-8">
-		<li><strong>All ONNX Runtime Training packages have been deprecated.</strong> ORT 1.19.2 was the last
-		release for which onnxruntime-training (PyPI), onnxruntime-training-cpu (PyPI), Microsoft.ML.OnnxRuntime.Training
-		(Nuget), onnxruntime-training-c (CocoaPods), onnxruntime-training-objc (CocoaPods), and onnxruntime-training-android
-		(Maven Central) were published.</li>
-		<li><strong>ONNX Runtime packages will stop supporting Python 3.8 and Python 3.9.</strong> This decision aligns with 
-		NumPy Python version support. To continue using ORT with Python 3.8 and Python 3.9, you can use ORT 1.19.2 and earlier.</li>
-		<li><strong>ONNX Runtime 1.20 CUDA packages will include new dependencies that were not required in 1.19 packages.</strong>
-		The following dependencies are new: libcudnn_adv.so.9, libcudnn_cnn.so.9, libcudnn_engines_precompiled.so.9,
-		libcudnn_engines_runtime_compiled.so.9, libcudnn_graph.so.9, libcudnn_heuristic.so.9, libcudnn_ops.so.9, libnvrtc.so.12, 
-		and libz.so.1.</li>
-	</ul>
-	<h2 class="text-xl font-bold mt-2">New Packages</h2>
-	<p class="font-thin">We are planning to start releasing the following packages:</p>
-	<ul class="list-disc ml-8">
-		<li>Maven package with Android support for QNN EP</li>
-		<li>CocoaPods package with Mac / iOS support for ORT generate() API</li>
+		<li><strong>The onnxruntime-gpu v1.10.0 will be removed from PyPI.</strong> We have hit our PyPI project size limit for onnxruntime-gpu,
+		so we will be removing our oldest package version to free up the necessary space.</li>
+		<li><strong>ONNX Runtime v1.20.0 is now officially released.</strong> For release notes, assets, and more, visit our <a
+			href="https://github.com/microsoft/onnxruntime/releases/tag/v1.20.0"
+			class="text-blue-600 underline">GitHub Releases page</a
+		>.</li>
 	</ul>
 
 	<h2 class="text-xl font-bold mt-2">Versioning Updates</h2>
 	<p class="font-thin">
 		We are planning to upgrade ONNX Runtime support for the following (where the first value is the
 		highest version previously supported and the second value is the version support that will be
-		added in ORT 1.20):
+		added in ORT 1.20.1):
 	</p>
 	<ul class="list-disc ml-8">
-		<li>TensorRT 10.2 --> 10.4</li>
-		<li>DirectML 1.15.1 --> 1.15.2</li>
-		<li>Python 3.13 support will also be added.</li>
+		<li>QNN SDK 2.27 --> 2.28</li>
+		<li>DirectML 1.15.2 --> 1.16</li>
 		<li>ONNX 1.17 support will be included in a future release.</li>
 	</ul>
 
 	<h2 class="text-xl font-bold mt-2">Major Updates</h2>
 	<p class="font-thin">
-		In addition to various bug fixes and performance improvements, ORT 1.20 will include the
-		following major updates:
+		In addition to various bug fixes and performance improvements, ORT 1.20.1 will include the
+		following updates:
 	</p>
 	<ul class="list-disc ml-8">
-		<li>Add MultiLoRA support.</li>
-		<li>Improve CPU FP16 and INT4 performance.</li>
-		<li>
-			Increase generate() API model support, including Phi-3.5-vision multi-frame and more.
-		</li>
-		<li>
-			Expand mobile support to include GPU EP and FP16 support for CoreML EP and XNNPACK kernels.
-		</li>
-		<li>Add Apple support for AI Toolkit for VS Code.</li>
+		<li>CPU FP16 implementation fixes for the following kernels: LayerNormalization, SimplifiedLayerNormalization, SkipLayerNormalization, SkipSimplifiedLayerNormalization.</li>
+		<li>Python quantization tool updates.</li>
+		<li>New QNN SDK version support.</li>
 	</ul>
 
 	<h2 class="text-xl font-bold mt-2">Feature Requests</h2>
@@ -166,15 +150,9 @@
 		<em>Note: All timelines and features listed on this page are subject to change.</em>
 	</p>
 	<div class="divider"></div>
-	<h2 class="text-xl font-bold mt-2">ONNX Runtime 1.20</h2>
+	<h2 class="text-xl font-bold mt-2">ONNX Runtime 1.20.1</h2>
 	<p class="font-thin">
-		<strong>Tentative release date:</strong> 10/30/2024
-	</p>
-	<p class="font-thin">
-		<strong>Release candidate now available on GitHub <a
-			href="https://github.com/microsoft/onnxruntime/issues/22604"
-			class="text-blue-600 underline">here</a
-		>.</strong>
+		<strong>Tentative release date:</strong> 11/20/2024
 	</p>
 
 	<div class="join join-vertical w-full p-2">
@@ -184,16 +162,9 @@
 			<div class="collapse-title text-xl font-bold">Announcements</div>
 			<div class="collapse-content">
 				<ul class="list-disc ml-8">
-					<li><strong>All ONNX Runtime Training packages have been deprecated.</strong> ORT 1.19.2 was the last
-					release for which onnxruntime-training (PyPI), onnxruntime-training-cpu (PyPI), Microsoft.ML.OnnxRuntime.Training
-					(Nuget), onnxruntime-training-c (CocoaPods), onnxruntime-training-objc (CocoaPods), and onnxruntime-training-android
-					(Maven Central) were published.</li>
-					<li><strong>ONNX Runtime packages will stop supporting Python 3.8 and Python 3.9.</strong> This decision aligns with 
-					NumPy Python version support. To continue using ORT with Python 3.8 and Python 3.9, you can use ORT 1.19.2 and earlier.</li>
-					<li><strong>ONNX Runtime 1.20 CUDA packages will include new dependencies that were not required in 1.19 packages.</strong>
-					The following dependencies are new: libcudnn_adv.so.9, libcudnn_cnn.so.9, libcudnn_engines_precompiled.so.9,
-					libcudnn_engines_runtime_compiled.so.9, libcudnn_graph.so.9, libcudnn_heuristic.so.9, libcudnn_ops.so.9, libnvrtc.so.12, 
-					and libz.so.1.</li>
+					<li><strong>The onnxruntime-gpu v1.10.0 will be removed from PyPI.</strong> We have hit our PyPI project size limit for onnxruntime-gpu,
+						so we will be removing our oldest package version to free up the necessary space.
+					</li>
 				</ul>
 			</div>
 		</div>
@@ -203,12 +174,9 @@
 			<input type="checkbox" name="build" />
 			<div class="collapse-title text-xl font-bold">Build System & Packages</div>
 			<div class="collapse-content">
-				<ul class="list-disc ml-8">
-					<li>Python 3.13 support is included in PyPI packages.</li>
-					<li>ONNX 1.17 support will be delayed until a future release, but the ONNX version used by ONNX Runtime has been patched to include a shape inference change to the Einsum op.</li>
-					<li>DLLs in the Maven build are now digitally signed.</li>
-					<li>(Experimental) vcpkg support added for the CPU EP. The DML EP does not yet support vcpkg, and other EPs have not been tested.</li>
-				</ul>
+				<p class="font-thin">
+					No features planned for 1.20.1. Stay tuned for 1.21 features.
+				</p>
 			</div>
 		</div>
 
@@ -217,10 +185,9 @@
 			<input type="checkbox" name="core" />
 			<div class="collapse-title text-xl font-bold">Core</div>
 			<div class="collapse-content">
-				<ul class="list-disc ml-8">
-					<li>MultiLoRA support.</li>
-					<li>Memory utilization (specifically related to external weights) and partitioning improvements.</li>
-				</ul>
+				<p class="font-thin">
+					No features planned for 1.20.1. Stay tuned for 1.21 features.
+				</p>
 			</div>
 		</div>
 
@@ -229,9 +196,34 @@
 			<input type="checkbox" name="performance" />
 			<div class="collapse-title text-xl font-bold">Performance</div>
 			<div class="collapse-content">
+				<p class="font-thin">
+					No features planned for 1.20.1. Stay tuned for 1.21 features.
+				</p>
+			</div>
+		</div>
+
+		<!-- Quantization Section -->
+		<div class="collapse collapse-arrow join-item border-base-300 border">
+			<input type="checkbox" name="quantization" />
+			<div class="collapse-title text-xl font-bold">Quantization</div>
+			<div class="collapse-content">
 				<ul class="list-disc ml-8">
-					<li>FP16 SLM model support on CPU EP.</li>
-					<li>INT4 quantized embedding support on CPU and CUDA EPs.</li>
+					<li>Introduce get_int_qdq_config() helper to get QDQ configurations (<a
+						href="https://github.com/microsoft/onnxruntime/pull/22677"
+						class="text-blue-600 underline">#22677</a
+					>).</li>
+					<li>Update QDQ Pad, Slice, Softmax (<a
+						href="https://github.com/microsoft/onnxruntime/pull/22676"
+						class="text-blue-600 underline">#22676</a
+					>).</li>
+					<li>Handle input models with pre-quantized weights (<a
+						href="https://github.com/microsoft/onnxruntime/pull/22633"
+						class="text-blue-600 underline">#22633</a
+					>).</li>
+					<li>Prevent int32 quantized bias from clipping by adjusting the weight's scale (<a
+						href="https://github.com/microsoft/onnxruntime/pull/22020"
+						class="text-blue-600 underline">#22020</a
+					>).</li>
 				</ul>
 			</div>
 		</div>
@@ -241,25 +233,17 @@
 			<input type="checkbox" name="eps" />
 			<div class="collapse-title text-xl font-bold">EPs</div>
 			<div class="collapse-content">
-				<h3 class="text-lg font-semibold">TensorRT</h3>
+				<h3 class="text-lg font-semibold">CPU</h3>
 				<ul class="list-disc ml-8">
-					<li>TensorRT 10.4 support.</li>
-					<li>DDS enablement and performance improvements for NMS.</li>
+					<li>Fix CPU FP16 implementations for the following kernels: LayerNormalization, SimplifiedLayerNormalization, SkipLayerNormalization, SkipSimplifiedLayerNormalization.</li>
 				</ul>
 				<h3 class="text-lg font-semibold">QNN</h3>
 				<ul class="list-disc ml-8">
-					<li>HTP shared weights context binary (offline tool).</li>
-					<li>Runtime support for QNN HTP shared weights in multiple ORT sessions.</li>
-					<li>Efficient mode support.</li>
-				</ul>
-				<h3 class="text-lg font-semibold">OpenVINO</h3>
-				<ul class="list-disc ml-8">
-					<li>Context generation memory optimizations.</li>
-					<li>Efficient mode support.</li>
+					<li>QNN SDK 2.28.x support.</li>
 				</ul>
 				<h3 class="text-lg font-semibold">DirectML</h3>
 				<ul class="list-disc ml-8">
-					<li>DirectML 1.15.2 support.</li>
+					<li>DirectML 1.16 support.</li>
 				</ul>
 			</div>
 		</div>
@@ -269,11 +253,9 @@
 			<input type="checkbox" name="mobile" />
 			<div class="collapse-title text-xl font-bold">Mobile</div>
 			<div class="collapse-content">
-				<ul class="list-disc ml-8">
-					<li>Android QNN support, including a pre-built Maven package, performance improvements, and Phi-3 model support.</li>
-					<li>Mobile GPU EP for support.</li>
-					<li>FP16 support for CoreML EP and XNNPACK kernels.</li>
-				</ul>
+				<p class="font-thin">
+					No features planned for 1.20.1. Stay tuned for 1.21 features.
+				</p>
 			</div>
 		</div>
 
@@ -282,14 +264,9 @@
 			<input type="checkbox" name="web" />
 			<div class="collapse-title text-xl font-bold">Web</div>
 			<div class="collapse-content">
-				<ul class="list-disc ml-8">
-					<li>Quantized embedding support.</li>
-					<li>On-demand weight loading support (offloads Wasm32 heap and enables 8B-parameter LLMs).</li>
-					<li>wasm64 support (available in custom builds but not included in released packages).</li>
-					<li>GQA support.</li>
-					<li>Integrated Intel GPU performance improvements.</li>
-					<li>Opset-21 support (Reshape, Shape, Gelu).</li>
-				</ul>
+				<p class="font-thin">
+					No features planned for 1.20.1. Stay tuned for 1.21 features.
+				</p>
 			</div>
 		</div>
 
@@ -298,12 +275,9 @@
 			<input type="checkbox" name="generate" />
 			<div class="collapse-title text-xl font-bold">generate() API</div>
 			<div class="collapse-content">
-				<ul class="list-disc ml-8">
-					<li>Continuous decoding support, including chat mode and system prompt caching.</li>
-					<li>MultiLoRA API.</li>
-					<li>Additional model support, including Phi-3.5 Vision Multi-Frame and Qualcomm NPU support for Phi-3.5 and Llama-3.1.</li>
-					<li>Mac/iOS support available in pre-built packages.</li>
-				</ul>
+				<p class="font-thin">
+					No features planned for 1.20.1. Stay tuned for 1.21 features.
+				</p>
 			</div>
 		</div>
 
@@ -312,16 +286,8 @@
 			<input type="checkbox" name="extensions" />
 			<div class="collapse-title text-xl font-bold">Extensions</div>
 			<div class="collapse-content">
-				<ul class="list-disc ml-8">
-					<li>Tokenization performance improvements.</li>
-					<li>Additional multi-modal model support (CLIP and Mllama), including more kernel attributes.</li>
-					<li>Unigram tokenization model support.</li>
-					<li>OpenCV dependency removed from C API build.</li>
-				</ul>
 				<p class="font-thin">
-					Full release notes for ONNX Runtime Extensions v0.13 will be found <a
-					href="https://github.com/microsoft/onnxruntime-extensions/releases"
-					class="text-blue-600 underline">here</a> once they are available (10/30 target).
+					No features planned for 1.20.1. Stay tuned for 1.21 features.
 				</p>
 			</div>
 		</div>
@@ -331,15 +297,8 @@
 			<input type="checkbox" name="olive" />
 			<div class="collapse-title text-xl font-bold">Olive</div>
 			<div class="collapse-content">
-				<ul class="list-disc ml-8">
-					<li>Olive command line interface (CLI) now available with support to execute well-defined, concrete workflows without the need to create or edit configs manually.</li>
-					<li>Additional improvements, including support for YAML-based workflow configs, streamlined DataConfig management, simplified workflow configuration, and more.</li>
-					<li>Llama and Phi-3 model updates, including an updated MultiLoRA example using the ORT generate() API.</li>
-				</ul>
 				<p class="font-thin">
-					Full release notes for Olive v0.7.0 can be found <a
-					href="https://github.com/microsoft/Olive/releases/"
-					class="text-blue-600 underline">here</a>.
+					No features planned for 1.20.1. Stay tuned for 1.21 features.
 				</p>
 			</div>
 		</div>


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
The Getting Started support matrix and ORT Release Roadmap have changed since the ORT 1.20.0 release.

Updated w/ info about new pkgs + CUDA default version and added 1.20.1 patch release plans.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


