### PR TITLE
Ignore all whitespace lint messages for cpplint

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,1 @@
+filter=-whitespace

--- a/onnxruntime/core/providers/dml/CPPLINT.cfg
+++ b/onnxruntime/core/providers/dml/CPPLINT.cfg
@@ -1,1 +1,0 @@
-filter=-whitespace/braces,-whitespace/parens,-whitespace/line_length,-whitespace/indent,-whitespace/newline

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/External/CPPLINT.cfg
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/External/CPPLINT.cfg
@@ -1,1 +1,1 @@
-filter=-whitespace/comments,-readability/todo,-whitespace/end_of_line,-runtime/indentation_namespace
+filter=-readability/todo


### PR DESCRIPTION
### Description

Ignore all whitespace lint messages for cpplint. Remove redundant configs in dml/.

### Motivation and Context

They are handled automatically by clang-format and creates too much noise in the PR files tab.
