### PR TITLE
Add support of ARM in SpinPause

### DIFF
--- a/include/onnxruntime/core/common/spin_pause.h
+++ b/include/onnxruntime/core/common/spin_pause.h
@@ -11,7 +11,7 @@
 #include <xmmintrin.h>
 #endif
 
-#if defined(_WIN32) && defined(_MSC_VER) defined(_M_ARM)
+#if defined(_MSC_VER) && (defined(_M_ARM64) || defined(_M_ARM))
 extern "C" void YieldProcessor();
 #endif
 
@@ -24,19 +24,13 @@ inline void SpinPause() {
 #if defined(_M_AMD64) || defined(__x86_64__)
   _mm_pause();
 
-#elif defined(_M_ARM64) || defined(_M_ARM) || defined(__arm__) || defined(__aarch64__)
-
-#if defined(_WIN32) && defined(_MSC_VER) && defined(_M_ARM)
+#elif defined(_MSC_VER) && (defined(_M_ARM64) || defined(_M_ARM))
   YieldProcessor();
-#elif defined(__aarch64__)
+
+#elif defined(__aarch64__) || (defined(__ARM_ARCH) && __ARM_ARCH >= 8)
   asm volatile("yield" ::: "memory");
-#else
-  asm volatile("nop" ::: "memory")
 #endif
 
-#elif defined(__powerpc__) || defined(__POWERPC__)
-  asm volatile("" ::: "memory");
-#endif
 }
 
 }  // namespace concurrency

--- a/include/onnxruntime/core/common/spin_pause.h
+++ b/include/onnxruntime/core/common/spin_pause.h
@@ -11,15 +11,31 @@
 #include <xmmintrin.h>
 #endif
 
+#if defined(_WIN32) && defined(_MSC_VER) defined(_M_ARM)
+extern "C" void YieldProcessor();
+#endif
+
 namespace onnxruntime {
 
 namespace concurrency {
 
 // Intrinsic to use in spin-loops
-
 inline void SpinPause() {
 #if defined(_M_AMD64) || defined(__x86_64__)
   _mm_pause();
+
+#elif defined(_M_ARM64) || defined(_M_ARM) || defined(__arm__) || defined(__aarch64__)
+
+#if defined(_WIN32) && defined(_MSC_VER) && defined(_M_ARM)
+  YieldProcessor();
+#elif defined(__aarch64__)
+  asm volatile("yield" ::: "memory");
+#else
+  asm volatile("nop" ::: "memory")
+#endif
+
+#elif defined(__powerpc__) || defined(__POWERPC__)
+  asm volatile("" ::: "memory");
 #endif
 }
 

--- a/include/onnxruntime/core/common/spin_pause.h
+++ b/include/onnxruntime/core/common/spin_pause.h
@@ -27,10 +27,10 @@ inline void SpinPause() {
 #elif defined(_MSC_VER) && (defined(_M_ARM64) || defined(_M_ARM))
   YieldProcessor();
 
-#elif defined(__aarch64__) || (defined(__ARM_ARCH) && __ARM_ARCH >= 8)
+// yield is supported from ARMv6k onwards.
+#elif defined(__aarch64__) || (defined(__ARM_ARCH) && __ARM_ARCH >= 7)
   asm volatile("yield" ::: "memory");
 #endif
-
 }
 
 }  // namespace concurrency


### PR DESCRIPTION
### Description

Add support of ARM in SpinPause. 

TODO: Need some benchmarks to see whether it could help ARM device.

### Motivation and Context

Currently, SpinPause is empty for ARM, which means CPU might be very busy when nothing is called in a loop.

Some References if we want to support other platforms:

https://github.com/boostorg/atomic/blob/b202228311eb4f5a9568d40b9314dfbb4ef20607/include/boost/atomic/detail/pause.hpp#L40-L59

https://github.com/boostorg/fiber/blob/7838ab09d700214e3d7dd7104fce241ca7552336/include/boost/fiber/detail/cpu_relax.hpp#L32-L78

https://github.com/tpn/winsdk-10/blob/9b69fd26ac0c7d0b83d378dba01080e93349c2ed/Include/10.0.14393.0/um/ntarm_x.h#L82-L90

https://chromium.googlesource.com/chromium/src/third_party/WebKit/Source/wtf/+/823d62cdecdbd5f161634177e130e5ac01eb7b48/SpinLock.cpp#17

https://github.com/wine-mirror/wine/blob/c9a8333c0f274201faf33d27abda1ebb5ae07cec/include/winnt.h#L7387C25-L7398

https://github.com/Tencent/mars/blob/master/mars/comm/thread/spinlock.h#L92-L107