### PR TITLE
[WebNN] Fixed WebNN Module undefined issue

### DIFF
--- a/js/web/lib/wasm/jsep/backend-webnn.ts
+++ b/js/web/lib/wasm/jsep/backend-webnn.ts
@@ -226,7 +226,7 @@ export class WebNNBackend {
     return id;
   }
 
-  // Register WebNN Constant operands from external data.
+  // Register a WebNN Constant operand from external data.
   public registerMLConstant(
     externalFilePath: string,
     dataOffset: number,

--- a/js/web/lib/wasm/wasm-types.ts
+++ b/js/web/lib/wasm/wasm-types.ts
@@ -232,6 +232,22 @@ export declare namespace JSEP {
      * @returns
      */
     jsepCreateMLContext(optionsOrGpuDevice?: MLContextOptions | GPUDevice): Promise<MLContext>;
+
+    /**
+     * [exported from pre-jsep.js] Register a WebNN Constant operand from external data.
+     * @param externalFilePath - specify the external file path.
+     * @param dataOffset - specify the external data offset.
+     * @param dataLength - specify the external data length.
+     * @param builder - specify the MLGraphBuilder used for constructing the Constant.
+     * @param desc - specify the MLOperandDescriptor of the Constant.
+     * @returns the WebNN Constant operand for the specified external data.
+     */
+    jsepRegisterMLConstant(
+      externalFilePath: string,
+      dataOffset: number,
+      dataLength: number,
+      builder: MLGraphBuilder,
+      desc: MLOperandDescriptor): MLOperand;
   }
 }
 

--- a/js/web/lib/wasm/wasm-types.ts
+++ b/js/web/lib/wasm/wasm-types.ts
@@ -247,7 +247,8 @@ export declare namespace JSEP {
       dataOffset: number,
       dataLength: number,
       builder: MLGraphBuilder,
-      desc: MLOperandDescriptor): MLOperand;
+      desc: MLOperandDescriptor,
+    ): MLOperand;
   }
 }
 

--- a/onnxruntime/wasm/pre-jsep.js
+++ b/onnxruntime/wasm/pre-jsep.js
@@ -241,7 +241,7 @@ Module['jsepInit'] = (name, params) => {
     Module['jsepCreateMLContext'] = (optionsOrGpuDevice) => {
       return backend['createMLContext'](optionsOrGpuDevice);
     };
-    Module.jsepRegisterMLConstant = (externalFilePath, dataOffset, dataLength, builder, desc) => {
+    Module['jsepRegisterMLConstant'] = (externalFilePath, dataOffset, dataLength, builder, desc) => {
       return backend['registerMLConstant'](
           externalFilePath, dataOffset, dataLength, builder, desc, Module.MountedFiles);
     };


### PR DESCRIPTION
`Module.jsepRegisterMLConstant` will be shorten by Closure Compiler in offical release, this would cause undefined error.

Fix it by using `Module['jsepRegisterMLConstant']`.