### PR TITLE
[WebNN] Remove validation for coordinate_transformation_mode

### DIFF
--- a/onnxruntime/core/providers/webnn/builders/impl/resize_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/resize_op_builder.cc
@@ -267,15 +267,9 @@ bool ResizeOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers
       return false;
     }
 
-    // coordinate_transformation_mode
-    // Spec issue for supporting more coordinate transformation modes:
-    // https://github.com/webmachinelearning/webnn/issues/270
-    const std::string coordinate_transformation_mode = helper.Get("coordinate_transformation_mode", "half_pixel");
-    if (coordinate_transformation_mode != "half_pixel") {
-      LOGS(logger, VERBOSE) << "Resize does not support coordinate_transformation_mode: "
-                            << coordinate_transformation_mode;
-      return false;
-    }
+    // Ignore coordinate_transformation_mode because WebNN only supports half_pixel mode.
+    // TODO: Validate coordinate_transformation_mode. Related spec issue for supporting attribute coordinate
+    // transformation modes: https://github.com/webmachinelearning/webnn/issues/270
 
     // exclude_outside
     const auto exclude_outside = helper.Get("exclude_outside", 0);


### PR DESCRIPTION
The performance cost of falling back to the CPU EP is high for several resampling nodes and causes multiple partitions in SD Turbo and VAE decoder. Since the asymmetric mode with nearest to floor and integer scales is identical to half_pixel anyway, stick with the WebNN EP.