### PR TITLE
Fix Linux CI pipeline where ep was not provided for py-packaging-linux-test-cpu.yml

### DIFF
--- a/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
@@ -307,6 +307,7 @@ stages:
   - template: templates/py-packaging-linux-test-cpu.yml
     parameters:
       arch: 'aarch64'
+      ep: 'cpu'
       machine_pool: 'onnxruntime-linux-ARM64-CPU-2019'
 
 - stage: arm64_build_xnnpack
@@ -328,4 +329,5 @@ stages:
   - template: templates/py-packaging-linux-test-cpu.yml
     parameters:
       arch: 'aarch64'
+      ep: 'XNNPack'
       machine_pool: 'onnxruntime-linux-ARM64-CPU-2019'


### PR DESCRIPTION
### Description
Current linux-ci-pipeline was broken due to missing parameters from `py-packaging-linux-test-cpu.yml` template


### Motivation and Context
Fix Linux CI pipeline


