### PR TITLE
[WebNN] Fix MLTensorUsage is undefined issue

### DIFF
--- a/js/web/lib/wasm/jsep/webnn/tensor-manager.ts
+++ b/js/web/lib/wasm/jsep/webnn/tensor-manager.ts
@@ -195,7 +195,7 @@ class TensorIdTracker {
     }
 
     // eslint-disable-next-line no-bitwise
-    const usage = MLTensorUsage.READ | MLTensorUsage.WRITE;
+    const usage = typeof MLTensorUsage == 'undefined' ? undefined : MLTensorUsage.READ | MLTensorUsage.WRITE;
     this.wrapper = await this.tensorManager.getCachedTensor(dataType, shape, usage, true, true);
 
     if (copyOld && this.activeUpload) {
@@ -349,7 +349,7 @@ class TensorManagerImpl implements TensorManager {
   public async getCachedTensor(
     dataType: MLOperandDataType,
     shape: readonly number[],
-    usage: MLTensorUsageFlags,
+    usage: MLTensorUsageFlags | undefined,
     writable: boolean,
     readable: boolean,
   ): Promise<TensorWrapper> {

--- a/js/web/lib/wasm/jsep/webnn/webnn.d.ts
+++ b/js/web/lib/wasm/jsep/webnn/webnn.d.ts
@@ -400,7 +400,8 @@ declare const MLTensorUsage: {
 };
 
 interface MLTensorDescriptor extends MLOperandDescriptor {
-  usage: MLTensorUsageFlags;
+  /** @deprecated Use readable/writeable instead of usage */
+  usage: MLTensorUsageFlags | undefined;
   importableToWebGPU?: boolean;
   readable?: boolean;
   writable?: boolean;

--- a/js/web/test/test-runner.ts
+++ b/js/web/test/test-runner.ts
@@ -661,7 +661,7 @@ async function createMLTensorForOutput(mlContext: MLContext, type: ort.Tensor.Ty
     shape: dims as number[],
     // Assign both shape and dimensions while transitioning to new API.
     dimensions: dims as number[],
-    usage: MLTensorUsage.READ,
+    usage: typeof MLTensorUsage == 'undefined' ? undefined : MLTensorUsage.READ,
     readable: true,
   });
 
@@ -686,7 +686,7 @@ async function createMLTensorForInput(mlContext: MLContext, cpuTensor: ort.Tenso
     shape: cpuTensor.dims as number[],
     // Assign both shape and dimensions while transitioning to new API.
     dimensions: cpuTensor.dims as number[],
-    usage: MLTensorUsage.WRITE,
+    usage: typeof MLTensorUsage == 'undefined' ? undefined : MLTensorUsage.WRITE,
     writable: true,
   });
   mlContext.writeTensor(mlTensor, cpuTensor.data);


### PR DESCRIPTION
`MLTensorUsage` has been removed from Chromium: https://chromium-review.googlesource.com/c/chromium/src/+/6015318, but we still need to make it compatible with old Chrome versions, so just make it `undefined` for latest Chrome version.