### PR TITLE
[CUDA] stable diffusion benchmark allows IO binding for optimum

### DIFF
--- a/onnxruntime/python/tools/transformers/models/stable_diffusion/benchmark.py
+++ b/onnxruntime/python/tools/transformers/models/stable_diffusion/benchmark.py
@@ -374,7 +374,7 @@ def run_optimum_ort_pipeline(
     batch_count,
     start_memory,
     memory_monitor_type,
-    use_num_images_per_prompt = False,
+    use_num_images_per_prompt=False,
 ):
     from optimum.onnxruntime import ORTStableDiffusionPipeline, ORTStableDiffusionXLPipeline
 
@@ -391,7 +391,7 @@ def run_optimum_ort_pipeline(
                 width=width,
                 num_inference_steps=steps,
                 negative_prompt=negative,
-                num_images_per_prompt=batch_count
+                num_images_per_prompt=batch_count,
             )
         else:
             pipe(
@@ -413,25 +413,17 @@ def run_optimum_ort_pipeline(
     for i, prompt in enumerate(prompts):
         if i >= num_prompts:
             break
+        inference_start = time.time()
         if use_num_images_per_prompt:
-            for j in range(batch_count):
-                inference_start = time.time()
-                images = pipe(
-                    prompt=prompt,
-                    height=height,
-                    width=width,
-                    num_inference_steps=steps,
-                    negative_prompt=negative_prompt,
-                    num_images_per_prompt=batch_size,
-                ).images
-                inference_end = time.time()
-                latency = inference_end - inference_start
-                latency_list.append(latency)
-                print(f"Inference took {latency:.3f} seconds")
-                for k, image in enumerate(images):
-                    image.save(f"{image_filename_prefix}_{i}_{j}_{k}.jpg")
+            images = pipe(
+                prompt=prompt,
+                height=height,
+                width=width,
+                num_inference_steps=steps,
+                negative_prompt=negative_prompt,
+                num_images_per_prompt=batch_size,
+            ).images
         else:
-            inference_start = time.time()
             images = pipe(
                 prompt=[prompt] * batch_size,
                 height=height,
@@ -439,12 +431,12 @@ def run_optimum_ort_pipeline(
                 num_inference_steps=steps,
                 negative_prompt=[negative_prompt] * batch_size,
             ).images
-            inference_end = time.time()
-            latency = inference_end - inference_start
-            latency_list.append(latency)
-            print(f"Inference took {latency:.3f} seconds")
-            for k, image in enumerate(images):
-                image.save(f"{image_filename_prefix}_{i}_{k}.jpg")
+        inference_end = time.time()
+        latency = inference_end - inference_start
+        latency_list.append(latency)
+        print(f"Inference took {latency:.3f} seconds")
+        for k, image in enumerate(images):
+            image.save(f"{image_filename_prefix}_{i}_{k}.jpg")
 
     from onnxruntime import __version__ as ort_version
 
@@ -1220,8 +1212,8 @@ def parse_arguments():
         "--num_prompts",
         required=False,
         type=int,
-        default=1,
-        help="Number of prompts. Default is 1.",
+        default=10,
+        help="Number of prompts. Default is 10.",
     )
 
     parser.add_argument(


### PR DESCRIPTION
### Description

Update stable diffusion benchmark:
(1) allow IO binding for optimum.
(2) do not use num_images_per_prompt across all engines for fair comparison.

Example to run benchmark of optimum on stable diffusion 1.5:
```
git clone https://github.com/tianleiwu/optimum
cd optimum
git checkout tlwu/diffusers-io-binding
pip install -e .

pip install -U onnxruntime-gpu
git clone https://github.com/microsoft/onnxruntime
cd onnxruntime/onnxruntime/python/tools/transformers/models/stable_diffusion
git checkout tlwu/benchmark_sd_optimum_io_binding
pip install -r requirements/cuda12/requirements.txt

optimum-cli export onnx --model runwayml/stable-diffusion-v1-5  --task text-to-image ./sd_onnx_fp32

python optimize_pipeline.py -i ./sd_onnx_fp32 -o ./sd_onnx_fp16 --float16
python benchmark.py -e optimum -r cuda -v 1.5 -p ./sd_onnx_fp16
python benchmark.py -e optimum -r cuda -v 1.5 -p ./sd_onnx_fp16 --use_io_binding
```

Example output in H100_80GB_HBM3: 572 ms with IO Binding; 588 ms without IO Binding; IO binding gains 16ms, or 2.7%,

### Motivation and Context

Optimum is working on enabling I/O binding: https://github.com/huggingface/optimum/pull/2056. This could help testing the impact of I/O binding on the performance of the stable diffusion.


