### PR TITLE
Fix "./onnxruntime_test_all --help" segfault

### DIFF
--- a/onnxruntime/test/unittest_main/test_main.cc
+++ b/onnxruntime/test/unittest_main/test_main.cc
@@ -92,8 +92,8 @@ int TEST_MAIN(int argc, char** argv) {
   int status = 0;
 
   ORT_TRY {
-    ortenv_setup();
     ::testing::InitGoogleTest(&argc, argv);
+    ortenv_setup();
 
     status = RUN_ALL_TESTS();
   }


### PR DESCRIPTION
### Description
Makes sure the GTest parameters are processed before ORT Env is set up in unittests binary. In this way, binary won't segfault on exit if --help arg is used



### Motivation and Context
Fixes #22838 


