### PR TITLE
Refactor emulator start and stop functions for clarity and efficiency

### DIFF
--- a/tools/python/run_android_emulator.py
+++ b/tools/python/run_android_emulator.py
@@ -77,12 +77,13 @@ def main():
             sys.stdin.readline()
 
     elif args.start:
+        print(f"Starting emulator: {args.avd_name}")
         emulator_proc = android.start_emulator(**start_emulator_args)
-
         with open(args.emulator_pid_file, mode="w") as emulator_pid_file:
             print(f"{emulator_proc.pid}", file=emulator_pid_file)
 
     elif args.stop:
+        print (f"Stopping emulator: {args.avd_name}")
         with open(args.emulator_pid_file) as emulator_pid_file:
             emulator_pid = int(emulator_pid_file.readline().strip())
 

--- a/tools/python/run_android_emulator.py
+++ b/tools/python/run_android_emulator.py
@@ -77,13 +77,12 @@ def main():
             sys.stdin.readline()
 
     elif args.start:
-        log.info(f"Starting emulator: {args.avd_name}")
         emulator_proc = android.start_emulator(**start_emulator_args)
+
         with open(args.emulator_pid_file, mode="w") as emulator_pid_file:
             print(f"{emulator_proc.pid}", file=emulator_pid_file)
 
     elif args.stop:
-        log.info (f"Stopping emulator: {args.avd_name}")
         with open(args.emulator_pid_file) as emulator_pid_file:
             emulator_pid = int(emulator_pid_file.readline().strip())
 

--- a/tools/python/run_android_emulator.py
+++ b/tools/python/run_android_emulator.py
@@ -77,13 +77,13 @@ def main():
             sys.stdin.readline()
 
     elif args.start:
-        print(f"Starting emulator: {args.avd_name}")
+        log.info(f"Starting emulator: {args.avd_name}")
         emulator_proc = android.start_emulator(**start_emulator_args)
         with open(args.emulator_pid_file, mode="w") as emulator_pid_file:
             print(f"{emulator_proc.pid}", file=emulator_pid_file)
 
     elif args.stop:
-        print (f"Stopping emulator: {args.avd_name}")
+        log.info (f"Stopping emulator: {args.avd_name}")
         with open(args.emulator_pid_file) as emulator_pid_file:
             emulator_pid = int(emulator_pid_file.readline().strip())
 

--- a/tools/python/util/android/android.py
+++ b/tools/python/util/android/android.py
@@ -237,7 +237,11 @@ def is_emulator_running_by_avd(avd_name: str) -> bool:
         # Step 2: Check each running emulator's AVD name
         for emulator in running_emulators:
             try:
-                avd_info = subprocess.check_output(["adb", "-s", emulator, "emu", "avd", "name"], text=True).strip().split('\n')[0]
+                avd_info = (
+                    subprocess.check_output(["adb", "-s", emulator, "emu", "avd", "name"], text=True)
+                    .strip()
+                    .split("\n")[0]
+                )
                 _log.debug(f"AVD name for emulator {emulator}: {avd_info}")
                 if avd_info == avd_name:
                     return True

--- a/tools/python/util/android/android.py
+++ b/tools/python/util/android/android.py
@@ -237,7 +237,8 @@ def is_emulator_running_by_avd(avd_name: str) -> bool:
         # Step 2: Check each running emulator's AVD name
         for emulator in running_emulators:
             try:
-                avd_info = subprocess.check_output(["adb", "-s", emulator, "emu", "avd", "name"], text=True).strip()
+                avd_info = subprocess.check_output(["adb", "-s", emulator, "emu", "avd", "name"], text=True).strip().split('\n')[0]
+                _log.debug(f"AVD name for emulator {emulator}: {avd_info}")
                 if avd_info == avd_name:
                     return True
             except subprocess.SubprocessError:

--- a/tools/python/util/android/android.py
+++ b/tools/python/util/android/android.py
@@ -250,6 +250,7 @@ def is_emulator_running_by_avd(avd_name: str) -> bool:
             except subprocess.SubprocessError:
                 _log.warning(f"Error checking AVD name for emulator: {emulator}")
                 continue  # Skip if there's an issue querying a specific emulator
+
         _log.warning(f"No emulator running with AVD name: {avd_name}")
         return False  # No matching AVD name found
     except subprocess.SubprocessError as e:

--- a/tools/python/util/android/android.py
+++ b/tools/python/util/android/android.py
@@ -223,6 +223,7 @@ def is_emulator_running_by_avd(avd_name: str) -> bool:
     try:
         # Step 1: List running devices
         result = subprocess.check_output(["adb", "devices"], text=True).strip()
+        _log.info(f"adb devices output:\n{result}")
         running_emulators = [
             line.split("\t")[0] for line in result.splitlines()[1:] if "emulator" in line
         ]

--- a/tools/python/util/android/android.py
+++ b/tools/python/util/android/android.py
@@ -124,7 +124,7 @@ def start_emulator(
             "America/Los_Angeles",
             "-no-snapstorage",
             "-no-audio",
-            "-no-snapshot", # No bluetooth
+            "-no-snapshot",  # No bluetooth
             "-no-boot-anim",
             "-gpu",
             "guest",

--- a/tools/python/util/android/android.py
+++ b/tools/python/util/android/android.py
@@ -254,7 +254,7 @@ def is_emulator_running_by_proc(emulator_proc: subprocess.Popen) -> bool:
     """Check if the emulator process is running based on a Popen instance."""
     return emulator_proc.poll() is None
 
-
+import os
 def is_emulator_running_by_pid(emulator_pid: int) -> bool:
     """Check if the emulator process is running based on PID."""
     try:

--- a/tools/python/util/android/android.py
+++ b/tools/python/util/android/android.py
@@ -106,8 +106,10 @@ def _stop_process_with_pid(pid: int):
 
 
 def start_emulator(
-    sdk_tool_paths: SdkToolPaths, avd_name: str, extra_args: typing.Optional[typing.Sequence[str]] = None,
-        timeout_minutes: int = 20
+    sdk_tool_paths: SdkToolPaths,
+    avd_name: str,
+    extra_args: typing.Optional[typing.Sequence[str]] = None,
+    timeout_minutes: int = 20,
 ) -> subprocess.Popen:
     if is_emulator_running_by_avd(avd_name=avd_name):
         raise RuntimeError(

--- a/tools/python/util/android/android.py
+++ b/tools/python/util/android/android.py
@@ -4,6 +4,7 @@
 import collections
 import contextlib
 import datetime
+import os
 import signal
 import subprocess
 import time
@@ -123,11 +124,13 @@ def start_emulator(
             "America/Los_Angeles",
             "-no-snapstorage",
             "-no-audio",
-            "-no-bt", # No bluetooth
+            "-no-snapshot", # No bluetooth
             "-no-boot-anim",
             "-gpu",
             "guest",
             "-delay-adb",
+            "-prop persist.sys.disable_bluetooth=true",
+            "-verbose",
         ]
 
         # For Linux CIs we must use "-no-window" otherwise you'll get
@@ -229,7 +232,7 @@ def is_emulator_running_by_avd(avd_name: str) -> bool:
         running_emulators = [line.split("\t")[0] for line in result.splitlines()[1:] if "emulator" in line]
 
         if not running_emulators:
-            _log.warning("No emulators running.")
+            _log.debug("No emulators running.")
             return False  # No emulators running
 
         # Step 2: Check each running emulator's AVD name
@@ -252,7 +255,7 @@ def is_emulator_running_by_proc(emulator_proc: subprocess.Popen) -> bool:
     """Check if the emulator process is running based on a Popen instance."""
     return emulator_proc.poll() is None
 
-import os
+
 def is_emulator_running_by_pid(emulator_pid: int) -> bool:
     """Check if the emulator process is running based on PID."""
     try:

--- a/tools/python/util/android/android.py
+++ b/tools/python/util/android/android.py
@@ -16,8 +16,8 @@ from ..run import run
 
 _log = get_logger("util.android")
 
-SdkToolPaths = collections.namedtuple("SdkToolPaths",
-                                      ["emulator", "adb", "sdkmanager", "avdmanager"])
+
+SdkToolPaths = collections.namedtuple("SdkToolPaths", ["emulator", "adb", "sdkmanager", "avdmanager"])
 
 
 def get_sdk_tool_paths(sdk_root: str):
@@ -34,18 +34,15 @@ def get_sdk_tool_paths(sdk_root: str):
         emulator=str((sdk_root / "emulator" / filename("emulator", "exe")).resolve(strict=True)),
         adb=str((sdk_root / "platform-tools" / filename("adb", "exe")).resolve(strict=True)),
         sdkmanager=str(
-            (sdk_root / "cmdline-tools" / "latest" / "bin" / filename("sdkmanager", "bat")).resolve(
-                strict=True)
+            (sdk_root / "cmdline-tools" / "latest" / "bin" / filename("sdkmanager", "bat")).resolve(strict=True)
         ),
         avdmanager=str(
-            (sdk_root / "cmdline-tools" / "latest" / "bin" / filename("avdmanager", "bat")).resolve(
-                strict=True)
+            (sdk_root / "cmdline-tools" / "latest" / "bin" / filename("avdmanager", "bat")).resolve(strict=True)
         ),
     )
 
 
-def create_virtual_device(sdk_tool_paths: SdkToolPaths, system_image_package_name: str,
-                          avd_name: str):
+def create_virtual_device(sdk_tool_paths: SdkToolPaths, system_image_package_name: str, avd_name: str):
     run(sdk_tool_paths.sdkmanager, "--install", system_image_package_name, input=b"y")
 
     run(
@@ -108,13 +105,11 @@ def _stop_process_with_pid(pid: int):
 
 
 def start_emulator(
-        sdk_tool_paths: SdkToolPaths, avd_name: str,
-        extra_args: typing.Optional[typing.Sequence[str]] = None
+    sdk_tool_paths: SdkToolPaths, avd_name: str, extra_args: typing.Optional[typing.Sequence[str]] = None
 ) -> subprocess.Popen:
     if is_emulator_running_by_avd(avd_name=avd_name):
         raise RuntimeError(
             f"An emulator with avd_name{avd_name} is already running. Please close it before starting a new one.")
-
     with contextlib.ExitStack() as emulator_stack, contextlib.ExitStack() as waiter_stack:
         emulator_args = [
             sdk_tool_paths.emulator,
@@ -210,19 +205,16 @@ def start_emulator(
             elif datetime.datetime.now() > end_time:
                 raise RuntimeError("Emulator startup timeout. sys.boot_completed was not set.")
 
-            _log.debug(
-                f"sys.boot_completed='{getprop_value}'. Sleeping for {sleep_interval_seconds} before retrying.")
+            _log.debug(f"sys.boot_completed='{getprop_value}'. Sleeping for {sleep_interval_seconds} before retrying.")
             time.sleep(sleep_interval_seconds)
         # Verify if the emulator is now running
         if not is_emulator_running_by_avd(avd_name=avd_name):
             raise RuntimeError("Emulator failed to start.")
         return emulator_process
 
-
 def is_emulator_running_by_avd(avd_name: str) -> bool:
     """
     Check if an emulator is running based on the provided AVD name.
-
     :param avd_name: Name of the Android Virtual Device (AVD) to check.
     :return: True if an emulator with the given AVD name is running, False otherwise.
     """
@@ -270,7 +262,6 @@ def is_emulator_running_by_pid(emulator_pid: int) -> bool:
 def stop_emulator_by_proc(emulator_proc: subprocess.Popen, timeout: int = 120):
     """
     Stops the emulator process using a subprocess.Popen instance.
-
     :param emulator_proc: The emulator process as a subprocess.Popen instance.
     :param timeout: Maximum time (in seconds) to wait for the emulator to stop.
     """
@@ -298,7 +289,6 @@ def stop_emulator_by_proc(emulator_proc: subprocess.Popen, timeout: int = 120):
 def stop_emulator_by_pid(emulator_pid: int, timeout: int = 120):
     """
     Stops the emulator process using a PID.
-
     :param emulator_pid: The emulator process PID.
     :param timeout: Maximum time (in seconds) to wait for the emulator to stop.
     """
@@ -326,7 +316,6 @@ def stop_emulator_by_pid(emulator_pid: int, timeout: int = 120):
 def stop_emulator(emulator_proc_or_pid: typing.Union[subprocess.Popen, int], timeout: int = 120):
     """
     Stops the emulator process, checking its running status before and after stopping.
-
     :param emulator_proc_or_pid: The emulator process (subprocess.Popen) or PID (int).
     :param timeout: Maximum time (in seconds) to wait for the emulator to stop.
     """

--- a/tools/python/util/android/android.py
+++ b/tools/python/util/android/android.py
@@ -214,6 +214,7 @@ def start_emulator(
 
             _log.debug(f"sys.boot_completed='{getprop_value}'. Sleeping for {sleep_interval_seconds} before retrying.")
             time.sleep(sleep_interval_seconds)
+
         # Verify if the emulator is now running
         if not is_emulator_running_by_avd(avd_name=avd_name):
             raise RuntimeError("Emulator failed to start.")

--- a/tools/python/util/android/android.py
+++ b/tools/python/util/android/android.py
@@ -226,9 +226,7 @@ def is_emulator_running_by_avd(avd_name: str) -> bool:
         # Step 1: List running devices
         result = subprocess.check_output(["adb", "devices"], text=True).strip()
         _log.info(f"adb devices output:\n{result}")
-        running_emulators = [
-            line.split("\t")[0] for line in result.splitlines()[1:] if "emulator" in line
-        ]
+        running_emulators = [line.split("\t")[0] for line in result.splitlines()[1:] if "emulator" in line]
 
         if not running_emulators:
             _log.warning("No emulators running.")

--- a/tools/python/util/android/android.py
+++ b/tools/python/util/android/android.py
@@ -129,7 +129,6 @@ def start_emulator(
             "-gpu",
             "guest",
             "-delay-adb",
-            "-prop persist.sys.disable_bluetooth=true",
             "-verbose",
         ]
 


### PR DESCRIPTION
### Description
This pull request introduces several enhancements and new functionalities to the `tools/python/util/android/android.py` file, focusing on improving the management of Android emulators. The most important changes include adding a timeout parameter to the `start_emulator` function, adding checks to prevent multiple emulators from running simultaneously, and introducing new utility functions to manage emulator processes more effectively.

Enhancements to `start_emulator` function:

* Added a `timeout_minutes` parameter to the `start_emulator` function to make the startup timeout configurable. [[1]](diffhunk://#diff-c54db556a9c445989f830c09ab90ce2704e648deaccce9c9e0ee4875ddaa864dL108-R117) [[2]](diffhunk://#diff-c54db556a9c445989f830c09ab90ce2704e648deaccce9c9e0ee4875ddaa864dL158-R170)
* Added a check to prevent starting a new emulator if one with the same AVD name is already running.
* Included additional emulator arguments `-verbose` for better control and debugging.
* Added a final verification step to ensure the emulator has started successfully.

New utility functions for managing emulator processes:

* Introduced `check_emulator_running_using_avd_name `, `check_emulator_running_using_process`, and `check_emulator_running_using_pid` to check if an emulator is running based on AVD name, process instance, or PID, respectively.
* Added `stop_emulator_by_proc` and `stop_emulator_by_pid` functions to stop the emulator process using a `subprocess.Popen` instance or PID, with a configurable timeout.
* Updated the `stop_emulator` function to use the new utility functions for stopping the emulator process.

These changes enhance the robustness and flexibility of the emulator management utilities, making it easier to handle different scenarios in CI environments and development workflows.



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


