### PR TITLE
[mobile] Fix for mac-ios-packaging pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/stages/mac-ios-packaging-build-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/stages/mac-ios-packaging-build-stage.yml
@@ -161,7 +161,8 @@ stages:
     # Publish the BrowserStack artifacts first so that if the next step fails, the artifacts will still be published
     # so that users can attempt to locally debug
     - publish: "$(Build.ArtifactStagingDirectory)"
-      artifact: "browserstack_test_artifacts"
+      artifact: "ios_packaging_artifacts_${{ lower(parameters.packageVariant) }}"
+      artifact: "browserstack_test_artifacts_${{ lower(parameters.packageVariant) }}"
       displayName: "Publish BrowserStack test artifacts"
 
     - script: |

--- a/tools/ci_build/github/azure-pipelines/templates/stages/mac-ios-packaging-build-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/stages/mac-ios-packaging-build-stage.yml
@@ -161,7 +161,6 @@ stages:
     # Publish the BrowserStack artifacts first so that if the next step fails, the artifacts will still be published
     # so that users can attempt to locally debug
     - publish: "$(Build.ArtifactStagingDirectory)"
-      artifact: "ios_packaging_artifacts_${{ lower(parameters.packageVariant) }}"
       artifact: "browserstack_test_artifacts_${{ lower(parameters.packageVariant) }}"
       displayName: "Publish BrowserStack test artifacts"
 


### PR DESCRIPTION
### Description
Appends variant name to the Browserstack artifacts that are published so that we don't run into the error:
"##[error]Artifact browserstack_test_artifacts already exists for build 609095."

[Working pipeline run](https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=609503&view=results)


### Motivation and Context
- onnxruntime-ios-packaging-pipeline has been failing


