### PR TITLE
[WebNN] Remove wasm.currentContext check

### DIFF
--- a/js/web/lib/wasm/wasm-core-impl.ts
+++ b/js/web/lib/wasm/wasm-core-impl.ts
@@ -291,9 +291,6 @@ export const createSession = async (
       const providerName = typeof provider === 'string' ? provider : provider.name;
       if (providerName === 'webnn') {
         wasm.shouldTransferToMLTensor = false;
-        if (wasm.currentContext) {
-          throw new Error('WebNN execution provider is already set.');
-        }
         if (typeof provider !== 'string') {
           const webnnOptions = provider as InferenceSession.WebNNExecutionProviderOption;
           const context = (webnnOptions as InferenceSession.WebNNOptionsWithMLContext)?.context;


### PR DESCRIPTION
If a WebNN session is threw early, this check for `wasm.currentContext` will break all the following WebNN sessions, this often happens in npm tests.