### PR TITLE
Revert to QNN SDK 2.28.0 for android qnn package

### DIFF
--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -62,7 +62,7 @@ parameters:
 - name: QnnSdk
   displayName: QNN SDK Version
   type: string
-  default: 2.28.2.241116
+  default: 2.28.0.241029
 
 resources:
   repositories:


### PR DESCRIPTION
### Description
Revert to QNN SDK 2.28.0 for android qnn package



### Motivation and Context
The qnn-runtime maven package only has version 2.28.0. We would need to either wait for qnn-runtime 2.28.2 to be released (not guaranteed), or we would have to change the way we parse qnn-runtime versions to allow a QNN SDK **2.28.X** to be used with qnn-runtime 2.28.0.


