### PR TITLE
[TensorRT EP Plugin] Add cuda::Impl_Cast

### DIFF
--- a/samples/tensorRTEp/CMakeLists.txt
+++ b/samples/tensorRTEp/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(CUDAToolkit REQUIRED)
 add_definitions(-DONNX_NAMESPACE=onnx)
 add_definitions(-DONNX_ML)
 add_definitions(-DNV_TENSORRT_MAJOR=10)
-file(GLOB tensorrt_src CONFIGURE_DEPENDS "./*.cc" "../utils/status.cc" "./cuda/unary_elementwise_ops_impl.cu")
+file(GLOB tensorrt_src "./*.cc" "../utils/status.cc" "./cuda/unary_elementwise_ops_impl.cu")
 add_library(TensorRTEp SHARED ${tensorrt_src})
 target_include_directories(TensorRTEp PUBLIC "../../include/onnxruntime"
                                              "../utils"

--- a/samples/tensorRTEp/CMakeLists.txt
+++ b/samples/tensorRTEp/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(CUDAToolkit REQUIRED)
 add_definitions(-DONNX_NAMESPACE=onnx)
 add_definitions(-DONNX_ML)
 add_definitions(-DNV_TENSORRT_MAJOR=10)
-file(GLOB tensorrt_src "./*.cc" "../utils/status.cc")
+file(GLOB tensorrt_src CONFIGURE_DEPENDS "./*.cc" "../utils/status.cc" "./cuda/unary_elementwise_ops_impl.cu")
 add_library(TensorRTEp SHARED ${tensorrt_src})
 target_include_directories(TensorRTEp PUBLIC "../../include/onnxruntime"
                                              "../utils"

--- a/samples/tensorRTEp/cuda/cu_inc/unary_elementwise_impl.cuh
+++ b/samples/tensorRTEp/cuda/cu_inc/unary_elementwise_impl.cuh
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#include <stdint.h>
+//#include "core/providers/cuda/shared_inc/cuda_utils.h"
+//#include "core/providers/cuda/cu_inc/common.cuh"
+
+namespace onnxruntime {
+namespace cuda {
+
+// We would like to use 64-bit integer to support large matrices. However, CUDA seems to support only 32-bit integer
+// For now, use int32_t to ensure that both Linux and Windows see this as 32 bit integer type.
+#ifndef CUDA_LONG
+#define CUDA_LONG int32_t
+#endif
+
+template <class INT, class INT2>
+inline __host__ __device__ INT CeilDiv(INT a, INT2 b)  // ceil(a/b)
+{
+  return (INT)(((size_t)a + (size_t)b - 1) / (size_t)b);  // these size_t casts are necessary since b may be INT_MAX (for maxGridSize[])
+}
+
+struct GridDim {
+  enum : CUDA_LONG {
+    maxThreadsPerBlock = 256,  // max threads per block
+    maxElementsPerThread = 4,  // max element processed per thread
+  };
+};
+
+template <typename InT, typename OutT, typename FuncT, int NumThreadsPerBlock, int NumElementsPerThread>
+__global__ void _UnaryElementWise(
+    const InT* input_data,
+    OutT* output_data,
+    const FuncT functor,
+    CUDA_LONG N) {
+  CUDA_LONG start = NumElementsPerThread * NumThreadsPerBlock * blockIdx.x + threadIdx.x;
+  InT value[NumElementsPerThread];
+
+  CUDA_LONG id = start;
+  #pragma unroll
+  for (int i = 0; i < NumElementsPerThread; i++) {
+    if (id < N) {
+      value[i] = input_data[id];
+      id += NumThreadsPerBlock;
+    }
+  }
+
+  id = start;
+  #pragma unroll
+  for (int i = 0; i < NumElementsPerThread; i++) {
+    if (id < N) {
+      output_data[id] = functor(value[i]);
+      id += NumThreadsPerBlock;
+    }
+  }
+}
+
+template <typename InT, typename OutT, typename FuncT>
+void UnaryElementWiseImpl(
+    cudaStream_t stream,
+    const InT* input_data,
+    OutT* output_data,
+    const FuncT& func,
+    size_t count) {
+  if (count == 0)  // special case where there's a dim value of 0 in the shape
+    return;
+
+  int blocksPerGrid = static_cast<int>(CeilDiv(count, GridDim::maxThreadsPerBlock * GridDim::maxElementsPerThread));
+  CUDA_LONG N = static_cast<CUDA_LONG>(count);
+  _UnaryElementWise<InT, OutT, FuncT, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread>
+      <<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
+          input_data,
+          output_data,
+          func,
+          N);
+}
+
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/samples/tensorRTEp/cuda/cu_inc/unary_elementwise_impl.cuh
+++ b/samples/tensorRTEp/cuda/cu_inc/unary_elementwise_impl.cuh
@@ -3,8 +3,6 @@
 
 #pragma once
 #include <stdint.h>
-//#include "core/providers/cuda/shared_inc/cuda_utils.h"
-//#include "core/providers/cuda/cu_inc/common.cuh"
 
 namespace onnxruntime {
 namespace cuda {

--- a/samples/tensorRTEp/cuda/unary_elementwise_ops_impl.cu
+++ b/samples/tensorRTEp/cuda/unary_elementwise_ops_impl.cu
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 
 #include <cuda_runtime.h>
-//#include "unary_elementwise_ops_impl.h"
-//#include "core/providers/cuda/cu_inc/common.cuh"
 #include "cu_inc/unary_elementwise_impl.cuh"
 
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 11080
@@ -41,19 +39,9 @@ struct ViaTypeMap<half> {
   typedef float ViaT;
 };
 
-//template <>
-//struct ViaTypeMap<BFloat16> {
-  //typedef float ViaT;
-//};
-
 template <typename InT, typename OutT>
 struct OP_Cast {
   __device__ __inline__ OutT operator()(const InT& a) const {
-    //const bool any_float16 = std::is_same<half, InT>::value || std::is_same<half, OutT>::value;
-    //const bool any_bf16 = std::is_same<BFloat16, InT>::value || std::is_same<BFloat16, OutT>::value;
-    //typedef typename std::conditional<any_bf16, BFloat16, OutT>::type T1;
-    //typedef typename std::conditional<any_float16, half, T1>::type T;
-    //typedef typename ViaTypeMap<T>::ViaT ViaT;
     typedef typename ViaTypeMap<OutT>::ViaT ViaT;
     return (OutT)((ViaT)a);
   }
@@ -98,74 +86,6 @@ IMPL_CAST_IMPL_FROM(uint32_t)
 IMPL_CAST_IMPL_FROM(uint64_t)
 IMPL_CAST_IMPL_FROM(bool)
 //IMPL_CAST_IMPL_FROM(BFloat16)
-
-//template <typename InT, typename OutT>
-//struct OP_CastSat {
-  //__device__ __inline__ OutT operator()(const InT& a) const;
-//};
-
-//template <typename InT, typename OutT>
-//struct OP_CastNoSat {
-  //__device__ __inline__ OutT operator()(const InT& a) const;
-//};
-
-//#if defined(CUDA_VERSION) && CUDA_VERSION >= 11080
-
-//#define OP_CAST(T, NVT)                                                                                     \
-  //template <>                                                                                               \
-  //struct OP_CastSat<half, T> {                                                                              \
-    //__device__ __inline__ T operator()(const half& v) const {                                               \
-      //return T(static_cast<unsigned char>(__nv_cvt_halfraw_to_fp8(v, __NV_SATFINITE, NVT)), T::FromBits()); \
-    //}                                                                                                       \
-  //};                                                                                                        \
-  //template <>                                                                                               \
-  //struct OP_CastNoSat<half, T> {                                                                            \
-    //__device__ __inline__ T operator()(const half& v) const {                                               \
-      //return T(static_cast<unsigned char>(__nv_cvt_halfraw_to_fp8(v, __NV_NOSAT, NVT)), T::FromBits());     \
-    //}                                                                                                       \
-  //};                                                                                                        \
-  //template <>                                                                                               \
-  //struct OP_CastSat<float, T> {                                                                             \
-    //__device__ __inline__ T operator()(const float& v) const {                                              \
-      //return T(static_cast<unsigned char>(__nv_cvt_float_to_fp8(v, __NV_SATFINITE, NVT)), T::FromBits());   \
-    //}                                                                                                       \
-  //};                                                                                                        \
-  //template <>                                                                                               \
-  //struct OP_CastNoSat<float, T> {                                                                           \
-    //__device__ __inline__ T operator()(const float& v) const {                                              \
-      //return T(static_cast<unsigned char>(__nv_cvt_float_to_fp8(v, __NV_NOSAT, NVT)), T::FromBits());       \
-    //}                                                                                                       \
-  //};
-
-//#else
-
-//#define OP_CAST(T, NVT)                                        \
-  //template <>                                                  \
-  //struct OP_CastSat<half, T> {                                 \
-    //__device__ __inline__ T operator()(const half& v) const {  \
-      //return T(__half2float(v), true);                         \
-    //}                                                          \
-  //};                                                           \
-  //template <>                                                  \
-  //struct OP_CastNoSat<half, T> {                               \
-    //__device__ __inline__ T operator()(const half& v) const {  \
-      //return T(__half2float(v), false);                        \
-    //}                                                          \
-  //};                                                           \
-  //template <>                                                  \
-  //struct OP_CastSat<float, T> {                                \
-    //__device__ __inline__ T operator()(const float& v) const { \
-      //return T(v, true);                                       \
-    //}                                                          \
-  //};                                                           \
-  //template <>                                                  \
-  //struct OP_CastNoSat<float, T> {                              \
-    //__device__ __inline__ T operator()(const float& v) const { \
-      //return T(v, false);                                      \
-    //}                                                          \
-  //};
-
-//#endif
 
 }  // namespace cuda
 }  // namespace onnxruntime

--- a/samples/tensorRTEp/cuda/unary_elementwise_ops_impl.cu
+++ b/samples/tensorRTEp/cuda/unary_elementwise_ops_impl.cu
@@ -1,0 +1,171 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <cuda_runtime.h>
+//#include "unary_elementwise_ops_impl.h"
+//#include "core/providers/cuda/cu_inc/common.cuh"
+#include "cu_inc/unary_elementwise_impl.cuh"
+
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 11080
+#include "cuda_fp8.h"
+#endif
+#include <cuda_fp16.h>
+
+namespace onnxruntime {
+
+namespace cuda {
+
+// the postfix of means the types supported by the op:
+// B: uint8_t
+// W: uint16_t
+// U: uint32_t
+// Z: uint64_t
+// C: int8_t
+// S: int16_t
+// I: int32_t
+// L: int64_t
+// H: float16
+// F: float
+// D: double
+// O: bool
+// X: BFloat16
+
+// When casting, half needs to be converted via float type from most other types
+template <typename T>
+struct ViaTypeMap {
+  typedef T ViaT;
+};
+
+template <>
+struct ViaTypeMap<half> {
+  typedef float ViaT;
+};
+
+//template <>
+//struct ViaTypeMap<BFloat16> {
+  //typedef float ViaT;
+//};
+
+template <typename InT, typename OutT>
+struct OP_Cast {
+  __device__ __inline__ OutT operator()(const InT& a) const {
+    //const bool any_float16 = std::is_same<half, InT>::value || std::is_same<half, OutT>::value;
+    //const bool any_bf16 = std::is_same<BFloat16, InT>::value || std::is_same<BFloat16, OutT>::value;
+    //typedef typename std::conditional<any_bf16, BFloat16, OutT>::type T1;
+    //typedef typename std::conditional<any_float16, half, T1>::type T;
+    //typedef typename ViaTypeMap<T>::ViaT ViaT;
+    typedef typename ViaTypeMap<OutT>::ViaT ViaT;
+    return (OutT)((ViaT)a);
+  }
+};
+
+#define IMPL_CAST_IMPL(InT, OutT)                                                                        \
+  void Explicit_Impl_Cast(cudaStream_t stream, const InT* input_data, OutT* output_data, size_t count) { \
+    UnaryElementWiseImpl(stream, input_data, output_data, OP_Cast<InT, OutT>(), count);                  \
+  }
+
+#define IMPL_CAST_IMPL_THROW(InT, OutT)                                                              \
+  void Explicit_Impl_Cast(cudaStream_t /*stream*/, const InT* /*input_data*/, OutT* /*output_data*/, \
+                          size_t /*count*/) {                                                        \
+    ORT_THROW("Cast from " #InT " to " #OutT " must define saturate.");                              \
+  }
+
+#define IMPL_CAST_IMPL_FROM(T) \
+  IMPL_CAST_IMPL(T, half)      \
+  IMPL_CAST_IMPL(T, float)     \
+  IMPL_CAST_IMPL(T, double)    \
+  IMPL_CAST_IMPL(T, int8_t)    \
+  IMPL_CAST_IMPL(T, int16_t)   \
+  IMPL_CAST_IMPL(T, int32_t)   \
+  IMPL_CAST_IMPL(T, int64_t)   \
+  IMPL_CAST_IMPL(T, uint8_t)   \
+  IMPL_CAST_IMPL(T, uint16_t)  \
+  IMPL_CAST_IMPL(T, uint32_t)  \
+  IMPL_CAST_IMPL(T, uint64_t)  \
+  IMPL_CAST_IMPL(T, bool)      \
+  //IMPL_CAST_IMPL(T, BFloat16)
+
+IMPL_CAST_IMPL_FROM(half)
+IMPL_CAST_IMPL_FROM(float)
+IMPL_CAST_IMPL_FROM(double)
+IMPL_CAST_IMPL_FROM(int8_t)
+IMPL_CAST_IMPL_FROM(int16_t)
+IMPL_CAST_IMPL_FROM(int32_t)
+IMPL_CAST_IMPL_FROM(int64_t)
+IMPL_CAST_IMPL_FROM(uint8_t)
+IMPL_CAST_IMPL_FROM(uint16_t)
+IMPL_CAST_IMPL_FROM(uint32_t)
+IMPL_CAST_IMPL_FROM(uint64_t)
+IMPL_CAST_IMPL_FROM(bool)
+//IMPL_CAST_IMPL_FROM(BFloat16)
+
+//template <typename InT, typename OutT>
+//struct OP_CastSat {
+  //__device__ __inline__ OutT operator()(const InT& a) const;
+//};
+
+//template <typename InT, typename OutT>
+//struct OP_CastNoSat {
+  //__device__ __inline__ OutT operator()(const InT& a) const;
+//};
+
+//#if defined(CUDA_VERSION) && CUDA_VERSION >= 11080
+
+//#define OP_CAST(T, NVT)                                                                                     \
+  //template <>                                                                                               \
+  //struct OP_CastSat<half, T> {                                                                              \
+    //__device__ __inline__ T operator()(const half& v) const {                                               \
+      //return T(static_cast<unsigned char>(__nv_cvt_halfraw_to_fp8(v, __NV_SATFINITE, NVT)), T::FromBits()); \
+    //}                                                                                                       \
+  //};                                                                                                        \
+  //template <>                                                                                               \
+  //struct OP_CastNoSat<half, T> {                                                                            \
+    //__device__ __inline__ T operator()(const half& v) const {                                               \
+      //return T(static_cast<unsigned char>(__nv_cvt_halfraw_to_fp8(v, __NV_NOSAT, NVT)), T::FromBits());     \
+    //}                                                                                                       \
+  //};                                                                                                        \
+  //template <>                                                                                               \
+  //struct OP_CastSat<float, T> {                                                                             \
+    //__device__ __inline__ T operator()(const float& v) const {                                              \
+      //return T(static_cast<unsigned char>(__nv_cvt_float_to_fp8(v, __NV_SATFINITE, NVT)), T::FromBits());   \
+    //}                                                                                                       \
+  //};                                                                                                        \
+  //template <>                                                                                               \
+  //struct OP_CastNoSat<float, T> {                                                                           \
+    //__device__ __inline__ T operator()(const float& v) const {                                              \
+      //return T(static_cast<unsigned char>(__nv_cvt_float_to_fp8(v, __NV_NOSAT, NVT)), T::FromBits());       \
+    //}                                                                                                       \
+  //};
+
+//#else
+
+//#define OP_CAST(T, NVT)                                        \
+  //template <>                                                  \
+  //struct OP_CastSat<half, T> {                                 \
+    //__device__ __inline__ T operator()(const half& v) const {  \
+      //return T(__half2float(v), true);                         \
+    //}                                                          \
+  //};                                                           \
+  //template <>                                                  \
+  //struct OP_CastNoSat<half, T> {                               \
+    //__device__ __inline__ T operator()(const half& v) const {  \
+      //return T(__half2float(v), false);                        \
+    //}                                                          \
+  //};                                                           \
+  //template <>                                                  \
+  //struct OP_CastSat<float, T> {                                \
+    //__device__ __inline__ T operator()(const float& v) const { \
+      //return T(v, true);                                       \
+    //}                                                          \
+  //};                                                           \
+  //template <>                                                  \
+  //struct OP_CastNoSat<float, T> {                              \
+    //__device__ __inline__ T operator()(const float& v) const { \
+      //return T(v, false);                                      \
+    //}                                                          \
+  //};
+
+//#endif
+
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/samples/tensorRTEp/cuda/unary_elementwise_ops_impl.h
+++ b/samples/tensorRTEp/cuda/unary_elementwise_ops_impl.h
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <stdint.h>
+//#include "core/providers/cuda/shared_inc/cuda_utils.h"
+//#include "core/framework/float8.h"
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+namespace onnxruntime {
+namespace cuda {
+
+// Cast
+
+#define DECL_IMPL_CAST(InT, OutT) \
+  void Explicit_Impl_Cast(cudaStream_t stream, const InT* input_data, OutT* output_data, size_t count);
+
+#define DECL_IMPL_CAST_FROM(T) \
+  DECL_IMPL_CAST(T, half)      \
+  DECL_IMPL_CAST(T, float)     \
+  DECL_IMPL_CAST(T, double)    \
+  DECL_IMPL_CAST(T, int8_t)    \
+  DECL_IMPL_CAST(T, int16_t)   \
+  DECL_IMPL_CAST(T, int32_t)   \
+  DECL_IMPL_CAST(T, int64_t)   \
+  DECL_IMPL_CAST(T, uint8_t)   \
+  DECL_IMPL_CAST(T, uint16_t)  \
+  DECL_IMPL_CAST(T, uint32_t)  \
+  DECL_IMPL_CAST(T, uint64_t)  \
+  DECL_IMPL_CAST(T, bool)      \
+  //DECL_IMPL_CAST(T, BFloat16)
+
+DECL_IMPL_CAST_FROM(half)
+DECL_IMPL_CAST_FROM(float)
+DECL_IMPL_CAST_FROM(double)
+DECL_IMPL_CAST_FROM(int8_t)
+DECL_IMPL_CAST_FROM(int16_t)
+DECL_IMPL_CAST_FROM(int32_t)
+DECL_IMPL_CAST_FROM(int64_t)
+DECL_IMPL_CAST_FROM(uint8_t)
+DECL_IMPL_CAST_FROM(uint16_t)
+DECL_IMPL_CAST_FROM(uint32_t)
+DECL_IMPL_CAST_FROM(uint64_t)
+DECL_IMPL_CAST_FROM(bool)
+//DECL_IMPL_CAST_FROM(BFloat16)
+
+template <typename InT, typename OutT>
+void Impl_Cast(cudaStream_t stream, const InT* input_data, OutT* output_data, size_t count) {
+  Explicit_Impl_Cast(stream, input_data, output_data, count);
+}
+
+}  // namespace cuda
+
+}  // namespace onnxruntime

--- a/samples/tensorRTEp/cuda/unary_elementwise_ops_impl.h
+++ b/samples/tensorRTEp/cuda/unary_elementwise_ops_impl.h
@@ -4,8 +4,6 @@
 #pragma once
 
 #include <stdint.h>
-//#include "core/providers/cuda/shared_inc/cuda_utils.h"
-//#include "core/framework/float8.h"
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
 

--- a/samples/tensorRTEp/tensorrt_execution_provider.cc
+++ b/samples/tensorRTEp/tensorrt_execution_provider.cc
@@ -10,6 +10,7 @@
 #include "tensorrt_cuda_allocator.h"
 #include "onnx_ctx_model_helper.h"
 #include "onnx/onnx_pb.h"
+#include "cuda/unary_elementwise_ops_impl.h"
 
 #ifdef _WIN32
 #include <windows.h>
@@ -671,19 +672,19 @@ OrtStatusPtr ApplyProfileShapesFromInputTensorValue(std::vector<nvinfer1::IOptim
     break;                                                                                  \
   }
 
-//#define CASE_GET_CAST_INPUT_TENSOR(DATA_TYPE, SrcT, DstT)                                                         \
-//  case DATA_TYPE: {                                                                                               \
-//    auto input_tensor_ptr = input_tensor.GetTensorData<SrcT>();                                                   \
-//    if (input_tensor_ptr != nullptr && elem_cnt > 0) {                                                            \
-//      scratch_buffers.push_back(MakeUniquePtrFromOrtAllocator<void>(alloc, elem_cnt * sizeof(DstT))); \
-//      data = scratch_buffers.back().get();                                                                        \
-//      cuda::Impl_Cast<SrcT, DstT>(stream, input_tensor_ptr, reinterpret_cast<DstT*>(data), elem_cnt);             \
-//    } else {                                                                                                      \
-//      scratch_buffers.push_back(MakeUniquePtrFromOrtAllocator<void>(alloc, 1));                       \
-//      data = scratch_buffers.back().get();                                                                        \
-//    }                                                                                                             \
-//    break;                                                                                                        \
-//  }
+#define CASE_GET_CAST_INPUT_TENSOR(DATA_TYPE, SrcT, DstT)                                                         \
+  case DATA_TYPE: {                                                                                               \
+    auto input_tensor_ptr = input_tensor.GetTensorData<SrcT>();                                                   \
+    if (input_tensor_ptr != nullptr && elem_cnt > 0) {                                                            \
+      scratch_buffers.push_back(MakeUniquePtrFromOrtAllocator<void>(alloc, elem_cnt * sizeof(DstT))); \
+      data = scratch_buffers.back().get();                                                                        \
+      cuda::Impl_Cast<SrcT, DstT>(stream, input_tensor_ptr, reinterpret_cast<DstT*>(data), elem_cnt);             \
+    } else {                                                                                                      \
+      scratch_buffers.push_back(MakeUniquePtrFromOrtAllocator<void>(alloc, 1));                       \
+      data = scratch_buffers.back().get();                                                                        \
+    }                                                                                                             \
+    break;                                                                                                        \
+  }
 
 #define CASE_GET_OUTPUT_TENSOR(DATA_TYPE, SrcT)                                             \
   case DATA_TYPE: {                                                                         \
@@ -721,14 +722,14 @@ OrtStatusPtr ApplyProfileShapesFromInputTensorValue(std::vector<nvinfer1::IOptim
     break;                                                                                                                                         \
   }
 
-//#define CASE_CAST_TENSOR(DATA_TYPE, SrcT, DstT)                                                                                                   \
-//  case DATA_TYPE: {                                                                                                                               \
-//    auto output_tensor_ptr = output_tensor.GetTensorMutableData<DstT>();                                                                          \
-//    if (output_tensor_ptr != nullptr && elem_cnt > 0) {                                                                                           \
-//      cuda::Impl_Cast<SrcT, DstT>(stream, reinterpret_cast<SrcT*>(allocator->getBuffer()), reinterpret_cast<DstT*>(output_tensor_ptr), elem_cnt); \
-//    }                                                                                                                                             \
-//    break;                                                                                                                                        \
-//  }
+#define CASE_CAST_TENSOR(DATA_TYPE, SrcT, DstT)                                                                                                   \
+  case DATA_TYPE: {                                                                                                                               \
+    auto output_tensor_ptr = output_tensor.GetTensorMutableData<DstT>();                                                                          \
+    if (output_tensor_ptr != nullptr && elem_cnt > 0) {                                                                                           \
+      cuda::Impl_Cast<SrcT, DstT>(stream, reinterpret_cast<SrcT*>(allocator->getBuffer()), reinterpret_cast<DstT*>(output_tensor_ptr), elem_cnt); \
+    }                                                                                                                                             \
+    break;                                                                                                                                        \
+  }
 
 OrtStatusPtr BindContextInput(Ort::KernelContext& ctx,
                         nvinfer1::ICudaEngine* trt_engine,
@@ -836,10 +837,10 @@ OrtStatusPtr BindContextInput(Ort::KernelContext& ctx,
       CASE_GET_INPUT_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, int64_t)
 #else
       // Cast int64 input to int32 input because TensorRT < 10 doesn't support int64
-//      CASE_GET_CAST_INPUT_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, int64_t, int32_t)
+      CASE_GET_CAST_INPUT_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, int64_t, int32_t)
 #endif
       // Cast double input to float because TensorRT doesn't support double
-//      CASE_GET_CAST_INPUT_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE, double, float)
+      CASE_GET_CAST_INPUT_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE, double, float)
       default: {
         return TensorrtExecutionProvider::api_->CreateStatus(ORT_EP_FAIL, std::string("TensorRT EP input onnx tensor data type: " + std::to_string(tensor_type) + " not supported.").c_str());
       }
@@ -3314,20 +3315,20 @@ OrtStatusPtr TensorrtExecutionProvider::CreateNodeComputeInfoFromGraph(const Ort
         }
       } else {
         auto& output_tensor = output_tensors[i];
-//#if NV_TENSORRT_MAJOR < 10
-//        if (output_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64) {
-//          auto output_tensor_ptr = output_tensor.GetTensorMutableData<int64_t>();
-//          if (output_tensor_ptr != nullptr) {
-//            cuda::Impl_Cast<int32_t, int64_t>(stream, reinterpret_cast<int32_t*>(buffers[output_name]), output_tensor_ptr, output_dim_sizes[i]);
-//          }
-//        }
-//#endif
-//        if (output_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE) {
-//          auto output_tensor_ptr = output_tensor.GetTensorMutableData<double>();
-//          if (output_tensor_ptr != nullptr) {
-//            cuda::Impl_Cast<float, double>(stream, reinterpret_cast<float*>(buffers[output_name]), output_tensor_ptr, output_dim_sizes[i]);
-//          }
-//        }
+#if NV_TENSORRT_MAJOR < 10
+        if (output_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64) {
+          auto output_tensor_ptr = output_tensor.GetTensorMutableData<int64_t>();
+          if (output_tensor_ptr != nullptr) {
+            cuda::Impl_Cast<int32_t, int64_t>(stream, reinterpret_cast<int32_t*>(buffers[output_name]), output_tensor_ptr, output_dim_sizes[i]);
+          }
+        }
+#endif
+        if (output_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE) {
+          auto output_tensor_ptr = output_tensor.GetTensorMutableData<double>();
+          if (output_tensor_ptr != nullptr) {
+            cuda::Impl_Cast<float, double>(stream, reinterpret_cast<float*>(buffers[output_name]), output_tensor_ptr, output_dim_sizes[i]);
+          }
+        }
       }
     }
 
@@ -3479,6 +3480,7 @@ OrtStatusPtr TensorrtExecutionProvider::CreateNodeComputeInfoFromPrecompiledEngi
     const std::unordered_map<std::string, size_t>& output_indexes = (trt_state->output_info)[0];
     const std::unordered_map<std::string, size_t>& output_types = (trt_state->output_info)[1];
     auto fused_node_name = trt_state->fused_node_name;
+    std::cout << fused_node_name << std::endl;
     auto& dds_output_allocator_map = this_->dds_output_allocator_maps_[fused_node_name];
     auto trt_engine = trt_state->engine->get();
     auto trt_context = trt_state->context->get();
@@ -3644,10 +3646,10 @@ OrtStatusPtr TensorrtExecutionProvider::CreateNodeComputeInfoFromPrecompiledEngi
         }
 #endif
         if (output_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE) {
-//          auto output_tensor_ptr = output_tensor.GetTensorMutableData<double>();
-//          if (output_tensor_ptr != nullptr) {
-//            cuda::Impl_Cast<float, double>(stream, reinterpret_cast<float*>(buffers[output_name]), output_tensor_ptr, output_dim_sizes[i]);
-//          }
+          auto output_tensor_ptr = output_tensor.GetTensorMutableData<double>();
+          if (output_tensor_ptr != nullptr) {
+            cuda::Impl_Cast<float, double>(stream, reinterpret_cast<float*>(buffers[output_name]), output_tensor_ptr, output_dim_sizes[i]);
+          }
         }
       }
     }


### PR DESCRIPTION
TRT 8 doesn't support INT64 and DOUBLE data type.
TRT 10 doesn't support DOUBLE data type.

Therefore, TRT EP internally needs to convert INT64 to INT32, and DOUBLE to FLOAT, which needs the cuda::Impl_Cast function.
The implementation is copied from CUDA EP.


