### PR TITLE
[WebNN EP] Fixed bug in usage of Array.reduce()

### DIFF
--- a/js/web/lib/wasm/jsep/webnn/tensor-manager.ts
+++ b/js/web/lib/wasm/jsep/webnn/tensor-manager.ts
@@ -78,7 +78,7 @@ const calculateByteLength = (dataType: MLOperandDataType, shape: readonly number
   if (!size) {
     throw new Error('Unsupported data type.');
   }
-  return Math.ceil((shape.reduce((a, b) => a * b) * size) / 8);
+  return shape.length > 0 ? Math.ceil((shape.reduce((a, b) => a * b) * size) / 8) : 0;
 };
 
 /**


### PR DESCRIPTION
In JS, reduce of empty array with no initial value will throw error. Fix it by checking the array length firstly.
