### PR TITLE
Use UTF8 string encoding in ORTSaveCodeAndDescriptionToError().

### DIFF
--- a/objectivec/error_utils.mm
+++ b/objectivec/error_utils.mm
@@ -11,7 +11,7 @@ void ORTSaveCodeAndDescriptionToError(int code, const char* descriptionCstr, NSE
   if (!error) return;
 
   NSString* description = [NSString stringWithCString:descriptionCstr
-                                             encoding:NSASCIIStringEncoding];
+                                             encoding:NSUTF8StringEncoding];
 
   *error = [NSError errorWithDomain:kOrtErrorDomain
                                code:code


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Update from ASCII to UTF8 string encoding when creating the `NSString` description.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Handle wider range of error description strings.