### PR TITLE
Don't save resources to be released later when the GPU is already done with them.

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/CommandQueue.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/CommandQueue.h
@@ -62,6 +62,7 @@ namespace Dml
         ComPtr<ID3D12Fence> m_fence;
         uint64_t m_lastFenceValue = 0;
         bool m_closing = false;
+        bool m_releasing = false;
         bool m_cpuSyncSpinningEnabled = false;
     };
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionContext.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionContext.cpp
@@ -162,9 +162,16 @@ namespace Dml
     {
         assert(!m_closed);
 
-        if (!m_currentRecorder || !m_currentRecorder->HasUnsubmittedWork())
+        if (!m_currentRecorder)
         {
             // Nothing to flush
+            return;
+        }
+
+        if (!m_currentRecorder->HasUnsubmittedWork())
+        {
+            // Even if we have no queued work, we can still release resources that may no longer be needed.
+            ReleaseCompletedReferences();
             return;
         }
 
@@ -183,7 +190,7 @@ namespace Dml
         assert(!m_closed);
         // If something has been recorded into a command list but not submitted yet, it means that the *next* fence
         // value is the one to signal completion.
-        bool waitForUnsubmittedWork = (m_currentRecorder != nullptr);
+        bool waitForUnsubmittedWork = ((m_currentRecorder != nullptr) && (m_currentRecorder->HasUnsubmittedWork()));
         m_queue->QueueReference(object, waitForUnsubmittedWork);
     }
 


### PR DESCRIPTION
Some resources were being pushed to a further fence unnecessarily.

### Motivation and Context
Allows VRAM to be freed earlier and more often, helping prevent unnecessary usage.


