### PR TITLE
Update vcpkg.json - lock flatbuffer version

### DIFF
--- a/cmake/vcpkg.json
+++ b/cmake/vcpkg.json
@@ -66,6 +66,12 @@
       "platform": "windows"
     }
   ],
+  "overrides": [
+    {
+      "name": "flatbuffers",
+      "version": "23.5.26"
+    }
+  ],
   "features": {
     "tests": {
       "description": "Build ONNXRuntime unit tests",


### PR DESCRIPTION
### Description
Locking version introduced in:
https://github.com/microsoft/onnxruntime/blob/03ea5dc495bfb48977d23705fa7cf184866a9f7f/onnxruntime/core/flatbuffers/schema/ort_training_checkpoint.fbs.h#L11-L13

### Motivation and Context
Resolve issue for version `>=1.20.` 
https://github.com/microsoft/onnxruntime/issues/22666