### PR TITLE
Miscellaneous cleanups

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -4612,6 +4612,8 @@ struct OrtApi {
    * \param[in] num_keys
    *
    * \snippet{doc} snippets.dox OrtStatus Return Value
+   *
+   * \since Version 1.17.
    */
   ORT_API2_STATUS(SessionOptionsAppendExecutionProvider_OpenVINO_V2,
                   _In_ OrtSessionOptions* options,
@@ -4629,6 +4631,8 @@ struct OrtApi {
    * \param[in] num_keys
    *
    * \snippet{doc} snippets.dox OrtStatus Return Value
+   *
+   * \since Version 1.18.
    */
   ORT_API2_STATUS(SessionOptionsAppendExecutionProvider_VitisAI,
                   _In_ OrtSessionOptions* options,
@@ -4642,7 +4646,10 @@ struct OrtApi {
    *  \param[in] mem_info OrtMemoryInfo instance
    *  \param[in] count_or_bytes How many bytes is this scratch buffer
    *  \param[out] out A pointer to the scrach buffer
+   *
    *  \snippet{doc} snippets.dox OrtStatus Return Value
+   *
+   * \since Version 1.18.
    */
   ORT_API2_STATUS(KernelContext_GetScratchBuffer, _In_ const OrtKernelContext* context, _In_ const OrtMemoryInfo* mem_info, _In_ size_t count_or_bytes, _Outptr_ void** out);
 
@@ -4653,6 +4660,8 @@ struct OrtApi {
    * \param[out] out A pointer to OrtAllocator
    *
    * \snippet{doc} snippets.dox OrtStatus Return Value
+   *
+   * \since Version 1.18.
    */
   ORT_API2_STATUS(KernelInfoGetAllocator, _In_ const OrtKernelInfo* info, _In_ OrtMemType mem_type, _Outptr_ OrtAllocator** out);
 
@@ -4674,6 +4683,8 @@ struct OrtApi {
    * \param[in] num_external_initializer_files Number of external files
    *
    * \snippet{doc} snippets.dox OrtStatus Return Value
+   *
+   * \since Version 1.18.
    */
   ORT_API2_STATUS(AddExternalInitializersFromFilesInMemory, _In_ OrtSessionOptions* options,
                   _In_reads_(num_external_initializer_files) const ORTCHAR_T* const* external_initializer_file_names,
@@ -4696,6 +4707,8 @@ struct OrtApi {
    *                  OrtApi::ReleaseLoraAdapter.
    *
    * \snippet{doc} snippets.dox OrtStatus Return Value
+   *
+   * \since Version 1.20.
    */
   ORT_API2_STATUS(CreateLoraAdapter, const ORTCHAR_T* adapter_file_path, _In_ OrtAllocator* allocator,
                   _Outptr_ OrtLoraAdapter** out);
@@ -4714,6 +4727,8 @@ struct OrtApi {
    *                  OrtApi::ReleaseLoraAdapter.
    *
    * \snippet{doc} snippets.dox OrtStatus Return Value
+   *
+   * \since Version 1.20.
    */
   ORT_API2_STATUS(CreateLoraAdapterFromArray, _In_ const void* bytes, size_t num_bytes, _In_ OrtAllocator* allocator,
                   _Outptr_ OrtLoraAdapter** out);
@@ -4735,6 +4750,8 @@ struct OrtApi {
    * \param[in] adapter OrtLoraAdapter instance
    *
    * \snippet{doc} snippets.dox OrtStatus Return Value
+   *
+   * \since Version 1.20.
    */
   ORT_API2_STATUS(RunOptionsAddActiveLoraAdapter, _Inout_ OrtRunOptions* options, _In_ const OrtLoraAdapter* adapter);
 
@@ -4753,6 +4770,8 @@ struct OrtApi {
    * \param[in] kv_len Number of elements in the keys and values arrays
    *
    * \snippet{doc} snippets.dox OrtStatus Return Value
+   *
+   * \since Version 1.20.
    */
   ORT_API2_STATUS(SetEpDynamicOptions, _Inout_ OrtSession* sess, _In_reads_(kv_len) const char* const* keys,
                   _In_reads_(kv_len) const char* const* values, _In_ size_t kv_len);

--- a/onnxruntime/core/graph/contrib_ops/quantization_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/quantization_defs.cc
@@ -164,7 +164,8 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
                "T2", OpSchema::Optional)
         .Output(0, "y", "N-D quantized output tensor. It has same shape as input 'x'.", "T2")
         .TypeConstraint("T1", {"tensor(float16)", "tensor(float)"}, "Constrain 'x', 'y_scale' to float tensors.")
-        .TypeConstraint("T2", {"tensor(int8)", "tensor(uint8)", "tensor(int16)", "tensor(uint16)", "tensor(int4)", "tensor(uint4)"},
+        .TypeConstraint("T2", {"tensor(int8)", "tensor(uint8)", "tensor(int16)", "tensor(uint16)", "tensor(int4)",
+                               "tensor(uint4)"},
                         "Constrain 'y_zero_point' and 'y' to 8-bit and 16-bit integer tensors.")
         .SetDoc(QuantizeLinear_ver1_doc)
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
@@ -205,7 +206,9 @@ ONNX_MS_OPERATOR_SET_SCHEMA(DequantizeLinear, 1,
                                        "T1", OpSchema::Optional)
                                 .Output(0, "y", "N-D full precision output tensor. It has same shape as input 'x'.",
                                         "T2")
-                                .TypeConstraint("T1", {"tensor(int8)", "tensor(uint8)", "tensor(int16)", "tensor(uint16)", "tensor(int32)", "tensor(int4)", "tensor(uint4)"},
+                                .TypeConstraint("T1", {"tensor(int8)", "tensor(uint8)", "tensor(int16)",
+                                                       "tensor(uint16)", "tensor(int32)", "tensor(int4)",
+                                                       "tensor(uint4)"},
                                                 "Constrain 'x' and 'x_zero_point' to 8-bit integer tensors, "
                                                 "16-bit integer tensors, or 32-bit signed integer tensors.")
                                 .TypeConstraint("T2", {"tensor(float16)", "tensor(float)"},
@@ -824,17 +827,41 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
           }
         }));
 
-ONNX_MS_OPERATOR_SET_SCHEMA(QLinearWhere, 1, OpSchema().SetDoc("Return elements, either from X or Y, depending on condition.").Input(0, "condition", " When True (nonzero), yield x, otherwise yield y", "B").Input(1, "X", "Y's zero point.", "T").Input(2, "x_scale", "X's scale.", "TF").Input(3, "x_zero_point", "X's zero point.", "T").Input(4, "Y", "Y's zero point.", "T").Input(5, "y_scale", "Y's scale.", "TF").Input(6, "y_zero_point", "Y's zero point.", "T").Input(7, "z_scale", "Z's scale.", "TF").Input(8, "z_zero_point", "Z's zero point.", "T").Output(0, "Z", "Tensor of shape equal to the broadcasted shape of condition, X, and Y", "T").TypeConstraint("B", {"tensor(bool)"}, "Constrain input and output types to 8 bit signed and unsigned tensors.").TypeConstraint("TF", {"tensor(float)"}, "Constrain scale types to any float tensor type.").TypeConstraint("T", {"tensor(uint8)", "tensor(int8)"}, "Constrain input and output types to 8 bit signed and unsigned tensors.").TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-  propagateElemTypeFromInputToOutput(ctx, 1, 0);
-  if (hasNInputShapes(ctx, 9)) {
-    std::vector<const onnx::TensorShapeProto*> shapes;
-    shapes.push_back(&ctx.getInputType(0)->tensor_type().shape());
-    shapes.push_back(&ctx.getInputType(1)->tensor_type().shape());
-    shapes.push_back(&ctx.getInputType(4)->tensor_type().shape());
-    multidirectionalBroadcastShapeInference(
-        shapes, *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape());
-  }
-}));
+  ONNX_MS_OPERATOR_SET_SCHEMA(QLinearWhere, 1, OpSchema()
+    .SetDoc("Return elements, either from X or Y, depending on condition.")
+      .Input(0, "condition", " When True (nonzero), yield x, otherwise yield y", "B")
+      .Input(1, "X", "Y's zero point.", "T")
+      .Input(2, "x_scale", "X's scale.", "TF")
+      .Input(3, "x_zero_point", "X's zero point.", "T")
+      .Input(4, "Y", "Y's zero point.", "T")
+      .Input(5, "y_scale", "Y's scale.", "TF")
+      .Input(6, "y_zero_point", "Y's zero point.", "T")
+      .Input(7, "z_scale", "Z's scale.", "TF")
+      .Input(8, "z_zero_point", "Z's zero point.", "T")
+      .Output(0, "Z", "Tensor of shape equal to the broadcasted shape of condition, X, and Y", "T")
+      .TypeConstraint(
+        "B",
+        {"tensor(bool)"},
+        "Constrain input and output types to 8 bit signed and unsigned tensors.")
+      .TypeConstraint(
+        "TF",
+        {"tensor(float)"},
+        "Constrain scale types to any float tensor type.")
+      .TypeConstraint(
+        "T",
+        {"tensor(uint8)", "tensor(int8)"},
+        "Constrain input and output types to 8 bit signed and unsigned tensors.")
+      .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+        propagateElemTypeFromInputToOutput(ctx, 1, 0);
+        if (hasNInputShapes(ctx, 9)) {
+          std::vector<const onnx::TensorShapeProto*> shapes;
+          shapes.push_back(&ctx.getInputType(0)->tensor_type().shape());
+          shapes.push_back(&ctx.getInputType(1)->tensor_type().shape());
+          shapes.push_back(&ctx.getInputType(4)->tensor_type().shape());
+          multidirectionalBroadcastShapeInference(
+              shapes, *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape());
+        }
+      }));
 
 ONNX_MS_OPERATOR_SET_SCHEMA(
     QGemm, 1,

--- a/onnxruntime/core/graph/contrib_ops/quantization_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/quantization_defs.cc
@@ -9,7 +9,7 @@
 #include "core/graph/constants.h"
 #include "core/graph/contrib_ops/contrib_defs.h"
 #include "core/graph/contrib_ops/shape_inference_functions.h"
-#include "onnx/onnx-ml.pb.h" // ?
+#include "core/graph/onnx_protobuf.h"
 
 // Suppress a warning: global initializer calls a non-constexpr function 'symbol' which is from
 // ONNX_OPERATOR_SET_SCHEMA_EX macro and only happens in debug build
@@ -23,7 +23,7 @@ void convTransposeShapeInference(InferenceContext& ctx);
 void convPoolShapeInference(ONNX_NAMESPACE::InferenceContext& ctx, bool use_dilation, bool require_kernel_shape,
                             int input1Idx, int input2Idx);
 namespace defs::math::utils {
-  void MatMulShapeInference(ONNX_NAMESPACE::InferenceContext& ctx, int input1Idx, int input2Idx);
+void MatMulShapeInference(ONNX_NAMESPACE::InferenceContext& ctx, int input1Idx, int input2Idx);
 }
 
 }  // namespace ONNX_NAMESPACE
@@ -164,8 +164,7 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
                "T2", OpSchema::Optional)
         .Output(0, "y", "N-D quantized output tensor. It has same shape as input 'x'.", "T2")
         .TypeConstraint("T1", {"tensor(float16)", "tensor(float)"}, "Constrain 'x', 'y_scale' to float tensors.")
-        .TypeConstraint("T2", {"tensor(int8)", "tensor(uint8)", "tensor(int16)", "tensor(uint16)", "tensor(int4)",
-                               "tensor(uint4)"},
+        .TypeConstraint("T2", {"tensor(int8)", "tensor(uint8)", "tensor(int16)", "tensor(uint16)", "tensor(int4)", "tensor(uint4)"},
                         "Constrain 'y_zero_point' and 'y' to 8-bit and 16-bit integer tensors.")
         .SetDoc(QuantizeLinear_ver1_doc)
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
@@ -206,9 +205,7 @@ ONNX_MS_OPERATOR_SET_SCHEMA(DequantizeLinear, 1,
                                        "T1", OpSchema::Optional)
                                 .Output(0, "y", "N-D full precision output tensor. It has same shape as input 'x'.",
                                         "T2")
-                                .TypeConstraint("T1", {"tensor(int8)", "tensor(uint8)", "tensor(int16)",
-                                                       "tensor(uint16)", "tensor(int32)", "tensor(int4)",
-                                                       "tensor(uint4)"},
+                                .TypeConstraint("T1", {"tensor(int8)", "tensor(uint8)", "tensor(int16)", "tensor(uint16)", "tensor(int32)", "tensor(int4)", "tensor(uint4)"},
                                                 "Constrain 'x' and 'x_zero_point' to 8-bit integer tensors, "
                                                 "16-bit integer tensors, or 32-bit signed integer tensors.")
                                 .TypeConstraint("T2", {"tensor(float16)", "tensor(float)"},
@@ -822,46 +819,22 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
             }
           }
 
-        if (all_lengths_known) {
-          output_shape->mutable_dim(axis)->set_dim_value(total_length);
-        }
-      }));
+          if (all_lengths_known) {
+            output_shape->mutable_dim(axis)->set_dim_value(total_length);
+          }
+        }));
 
-  ONNX_MS_OPERATOR_SET_SCHEMA(QLinearWhere, 1, OpSchema()
-    .SetDoc("Return elements, either from X or Y, depending on condition.")
-      .Input(0, "condition", " When True (nonzero), yield x, otherwise yield y", "B")
-      .Input(1, "X", "Y's zero point.", "T")
-      .Input(2, "x_scale", "X's scale.", "TF")
-      .Input(3, "x_zero_point", "X's zero point.", "T")
-      .Input(4, "Y", "Y's zero point.", "T")
-      .Input(5, "y_scale", "Y's scale.", "TF")
-      .Input(6, "y_zero_point", "Y's zero point.", "T")
-      .Input(7, "z_scale", "Z's scale.", "TF")
-      .Input(8, "z_zero_point", "Z's zero point.", "T")
-      .Output(0, "Z", "Tensor of shape equal to the broadcasted shape of condition, X, and Y", "T")
-      .TypeConstraint(
-        "B",
-        {"tensor(bool)"},
-        "Constrain input and output types to 8 bit signed and unsigned tensors.")
-      .TypeConstraint(
-        "TF",
-        {"tensor(float)"},
-        "Constrain scale types to any float tensor type.")
-      .TypeConstraint(
-        "T",
-        {"tensor(uint8)", "tensor(int8)"},
-        "Constrain input and output types to 8 bit signed and unsigned tensors.")
-      .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-        propagateElemTypeFromInputToOutput(ctx, 1, 0);
-        if (hasNInputShapes(ctx, 9)) {
-          std::vector<const onnx::TensorShapeProto*> shapes;
-          shapes.push_back(&ctx.getInputType(0)->tensor_type().shape());
-          shapes.push_back(&ctx.getInputType(1)->tensor_type().shape());
-          shapes.push_back(&ctx.getInputType(4)->tensor_type().shape());
-          multidirectionalBroadcastShapeInference(
-              shapes, *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape());
-        }
-      }));
+ONNX_MS_OPERATOR_SET_SCHEMA(QLinearWhere, 1, OpSchema().SetDoc("Return elements, either from X or Y, depending on condition.").Input(0, "condition", " When True (nonzero), yield x, otherwise yield y", "B").Input(1, "X", "Y's zero point.", "T").Input(2, "x_scale", "X's scale.", "TF").Input(3, "x_zero_point", "X's zero point.", "T").Input(4, "Y", "Y's zero point.", "T").Input(5, "y_scale", "Y's scale.", "TF").Input(6, "y_zero_point", "Y's zero point.", "T").Input(7, "z_scale", "Z's scale.", "TF").Input(8, "z_zero_point", "Z's zero point.", "T").Output(0, "Z", "Tensor of shape equal to the broadcasted shape of condition, X, and Y", "T").TypeConstraint("B", {"tensor(bool)"}, "Constrain input and output types to 8 bit signed and unsigned tensors.").TypeConstraint("TF", {"tensor(float)"}, "Constrain scale types to any float tensor type.").TypeConstraint("T", {"tensor(uint8)", "tensor(int8)"}, "Constrain input and output types to 8 bit signed and unsigned tensors.").TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+  propagateElemTypeFromInputToOutput(ctx, 1, 0);
+  if (hasNInputShapes(ctx, 9)) {
+    std::vector<const onnx::TensorShapeProto*> shapes;
+    shapes.push_back(&ctx.getInputType(0)->tensor_type().shape());
+    shapes.push_back(&ctx.getInputType(1)->tensor_type().shape());
+    shapes.push_back(&ctx.getInputType(4)->tensor_type().shape());
+    multidirectionalBroadcastShapeInference(
+        shapes, *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape());
+  }
+}));
 
 ONNX_MS_OPERATOR_SET_SCHEMA(
     QGemm, 1,
@@ -955,7 +928,8 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
               AttributeProto::INT, static_cast<int64_t>(0))
         .Attr("do_rotary", "Whether to use rotary position embedding. Default value is 0.",
               AttributeProto::INT, OPTIONAL_VALUE)
-        .Attr("past_present_share_buffer", "Corresponding past and present are same tensor, its shape is "
+        .Attr("past_present_share_buffer",
+              "Corresponding past and present are same tensor, its shape is "
               "(2, batch_size, num_heads, max_sequence_length, head_size)",
               AttributeProto::INT, OPTIONAL_VALUE)
         .Attr("mask_filter_value",

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2803,12 +2803,15 @@ static constexpr OrtApi ort_api_1_to_21 = {
     &OrtApis::KernelInfoGetAllocator,
     &OrtApis::AddExternalInitializersFromFilesInMemory,
     // End of Version 18 - DO NOT MODIFY ABOVE (see above text for more information)
+    // End of Version 19 - DO NOT MODIFY ABOVE (see above text for more information)
+
     &OrtApis::CreateLoraAdapter,
     &OrtApis::CreateLoraAdapterFromArray,
     &OrtApis::ReleaseLoraAdapter,
     &OrtApis::RunOptionsAddActiveLoraAdapter,
 
     &OrtApis::SetEpDynamicOptions,
+    // End of Version 20 - DO NOT MODIFY ABOVE (see above text for more information)
 };
 
 // OrtApiBase can never change as there is no way to know what version of OrtApiBase is returned by OrtGetApiBase.
@@ -2840,6 +2843,8 @@ static_assert(offsetof(OrtApi, GetBuildInfoString) / sizeof(void*) == 254, "Size
 static_assert(offsetof(OrtApi, KernelContext_GetResource) / sizeof(void*) == 265, "Size of version 16 API cannot change");
 static_assert(offsetof(OrtApi, SessionOptionsAppendExecutionProvider_OpenVINO_V2) / sizeof(void*) == 275, "Size of version 17 API cannot change");
 static_assert(offsetof(OrtApi, AddExternalInitializersFromFilesInMemory) / sizeof(void*) == 279, "Size of version 18 API cannot change");
+// no additions in version 19
+static_assert(offsetof(OrtApi, SetEpDynamicOptions) / sizeof(void*) == 284, "Size of version 20 API cannot change");
 
 // So that nobody forgets to finish an API version, this check will serve as a reminder:
 static_assert(std::string_view(ORT_VERSION) == "1.21.0",


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- fix some missing end of version markers and since_version info
- fix include to use onnx_protobuf.h which handles minimal builds
  - we should always prefer that header over directly using the onnx ones


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


