### PR TITLE
Update python version metadata (remove 3.7, 3.8, 3.9; add 3.13).

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,7 +59,6 @@ jobs:
         run: |
           set -e -x
           python -m pip install --user -r requirements-dev.txt
-          python -m pip install --user lintrunner
           lintrunner init
       - name: Run lintrunner on all files
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          # Version range or exact version of Python to use, using SemVer's version range syntax. Reads from .python-version if unset.
+          # Use the version configured in target-version of [tool.black] section in pyproject.toml.
           python-version: "3.10"
       - name: Setup Rust
         uses: actions-rs/toolchain@v1
@@ -55,12 +55,11 @@ jobs:
       - name: Update PATH
         run: |
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
       - name: Install dependencies
         run: |
           set -e -x
           python -m pip install --user -r requirements-dev.txt
-          python -m pip install --user lintrunner lintrunner-adapters
+          python -m pip install --user -r lintrunner
           lintrunner init
       - name: Run lintrunner on all files
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           set -e -x
           python -m pip install --user -r requirements-dev.txt
-          python -m pip install --user -r lintrunner
+          python -m pip install --user lintrunner
           lintrunner init
       - name: Run lintrunner on all files
         run: |

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -2,31 +2,23 @@
 # You can install the dependencies and initialize with
 #
 # ```sh
-# pip install lintrunner lintrunner-adapters
+# pip install lintrunner
 # lintrunner init
 # ```
 #
 # This will install lintrunner on your system and download all the necessary
 # dependencies to run linters locally.
-# If you want to see what lintrunner init will install, run
-# `lintrunner init --dry-run`.
 #
-# To lint local changes:
+# To format local changes:
 #
 # ```bash
-# lintrunner
+# lintrunner -a
 # ```
 #
-# To lint all files:
+# To format all files:
 #
 # ```bash
-# lintrunner --all-files
-# ```
-#
-# To format files:
-#
-# ```bash
-# lintrunner f --all-files
+# lintrunner -a --all-files
 # ```
 #
 # To read more about lintrunner, see [wiki](https://github.com/pytorch/pytorch/wiki/lintrunner).

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -2,7 +2,7 @@
 # You can install the dependencies and initialize with
 #
 # ```sh
-# pip install lintrunner
+# pip install -r requirements-lintrunner.txt
 # lintrunner init
 # ```
 #

--- a/docs/Coding_Conventions_and_Standards.md
+++ b/docs/Coding_Conventions_and_Standards.md
@@ -155,7 +155,7 @@ Using `Show Code Coverage Coloring` will allow you to visually inspect which lin
 This project uses [lintrunner](https://github.com/suo/lintrunner) for linting. It provides a consistent linting experience locally and in CI. You can install the dependencies and initialize with
 
 ```sh
-pip install lintrunner
+pip install -r requirements-lintrunner.txt
 lintrunner init
 ```
 

--- a/docs/Coding_Conventions_and_Standards.md
+++ b/docs/Coding_Conventions_and_Standards.md
@@ -155,7 +155,7 @@ Using `Show Code Coverage Coloring` will allow you to visually inspect which lin
 This project uses [lintrunner](https://github.com/suo/lintrunner) for linting. It provides a consistent linting experience locally and in CI. You can install the dependencies and initialize with
 
 ```sh
-pip install -r requirements-lintrunner.txt
+pip install lintrunner
 lintrunner init
 ```
 
@@ -164,22 +164,16 @@ dependencies to run linters locally.
 If you want to see what lintrunner init will install, run
 `lintrunner init --dry-run`.
 
-To lint local changes:
-
-```bash
-lintrunner
-```
-
-To format files and apply suggestions:
+To format local changes:
 
 ```bash
 lintrunner -a
 ```
 
-To lint all files:
+To format all files:
 
 ```bash
-lintrunner --all-files
+lintrunner -a --all-files
 ```
 
 To show help text:

--- a/orttraining/orttraining/python/training/artifacts.py
+++ b/orttraining/orttraining/python/training/artifacts.py
@@ -185,10 +185,13 @@ def generate_artifacts(
         logging.info("Custom op library provided: %s", custom_op_library)
         custom_op_library_path = pathlib.Path(custom_op_library)
 
-    with onnxblock.base(loaded_model, model_path), (
-        onnxblock.custom_op_library(custom_op_library_path)
-        if custom_op_library is not None
-        else contextlib.nullcontext()
+    with (
+        onnxblock.base(loaded_model, model_path),
+        (
+            onnxblock.custom_op_library(custom_op_library_path)
+            if custom_op_library is not None
+            else contextlib.nullcontext()
+        ),
     ):
         _ = training_block(*[output.name for output in loaded_model.graph.output])
         training_model, eval_model = training_block.to_model_proto()

--- a/orttraining/orttraining/python/training/ortmodule/_graph_transition_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_transition_manager.py
@@ -867,8 +867,9 @@ class GraphTransitionManager:
         assert model_info_for_export.export_mode is not None, "Please use a concrete instance of ExecutionManager"
 
         try:
-            with torch.no_grad(), stage3_export_context(
-                enable_zero_stage3_support, stage3_param_handle, flattened_module
+            with (
+                torch.no_grad(),
+                stage3_export_context(enable_zero_stage3_support, stage3_param_handle, flattened_module),
             ):
                 required_export_kwargs = {
                     "input_names": model_info_for_export.onnx_graph_input_names,  # did not contains parameters as its input yet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,8 @@
 line-length = 120
 # NOTE: Do not extend the exclude list. Edit .lintrunner.toml instead
 extend-exclude = "cmake|onnxruntime/core/flatbuffers/"
-target-version = ["py37", "py38", "py39", "py310", "py311"]
+# NOTE: use the minimum supported python version as target-version
+target-version = ["py310"]
 
 [tool.isort]
 # NOTE: Do not extend the exclude list. Edit .lintrunner.toml instead

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
-black>=22.3
+-r requirements-lintrunner.txt
 cerberus
 flatbuffers
-isort
 jinja2
 numpy
 onnx

--- a/setup.py
+++ b/setup.py
@@ -529,6 +529,8 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: POSIX :: Linux",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: MacOS",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Mathematics",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
@@ -537,14 +539,10 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Operating System :: Microsoft :: Windows",
-    "Operating System :: MacOS",
+    "Programming Language :: Python :: 3.13",
 ]
 
 if enable_training or enable_training_apis:


### PR DESCRIPTION
### Description

* Update python version metadata to be in sync with latest python packages (onnxruntime, onnxruntime-gpu and onnxruntime-qnn).
* Update black format target-version to 3.10, and use lintrunner to format all files.
* Update the lintrunner installation command line to be consistent.
* Include `requirements-lintrunner.txt` in `requirements-dev.txt` to avoid duplicated settings.

### Motivation and Context

https://github.com/microsoft/onnxruntime/issues/22993

Python support by numpy:
https://numpy.org/neps/nep-0029-deprecation_policy.html#drop-schedule
```
On Apr 05, 2024 drop support for Python 3.9
On Apr 04, 2025 drop support for Python 3.10
On Apr 24, 2026 drop support for Python 3.11
```


