### PR TITLE
Fix a deadlock bug in EigenNonBlockingThreadPool.h

### DIFF
--- a/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
+++ b/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
@@ -1473,7 +1473,11 @@ class ThreadPoolTempl : public onnxruntime::concurrency::ExtendedThreadPoolInter
       auto old_status = status.exchange(ThreadStatus::Blocking, std::memory_order_seq_cst);
       if (old_status != ThreadStatus::Spinning) {
         // Encountered a logical error
+#ifdef ORT_NO_EXCEPTIONS
+        abort();
+#else
         throw std::runtime_error("The state transition is not allowed");
+#endif
       }
       if (should_block()) {
         status.store(ThreadStatus::Blocked, std::memory_order_relaxed);

--- a/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
+++ b/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
@@ -1467,17 +1467,13 @@ class ThreadPoolTempl : public onnxruntime::concurrency::ExtendedThreadPoolInter
       status = ThreadStatus::Spinning;
     }
 
-    void SetBlocked(std::function<bool()> should_block,
+    bool SetBlocked(std::function<bool()> should_block,
                     std::function<void()> post_block) {
       std::unique_lock<std::mutex> lk(mutex);
       auto old_status = status.exchange(ThreadStatus::Blocking, std::memory_order_seq_cst);
       if (old_status != ThreadStatus::Spinning) {
         // Encountered a logical error
-#ifdef ORT_NO_EXCEPTIONS
-        abort();
-#else
-        throw std::runtime_error("The state transition is not allowed");
-#endif
+        return false;
       }
       if (should_block()) {
         status.store(ThreadStatus::Blocked, std::memory_order_relaxed);
@@ -1487,6 +1483,7 @@ class ThreadPoolTempl : public onnxruntime::concurrency::ExtendedThreadPoolInter
         post_block();
       }
       status.store(ThreadStatus::Spinning, std::memory_order_relaxed);
+      return true;
     }
 
    private:
@@ -1565,62 +1562,66 @@ class ThreadPoolTempl : public onnxruntime::concurrency::ExtendedThreadPoolInter
 
         // Attempt to block
         if (!t) {
-          td.SetBlocked(  // Pre-block test
-              [&]() -> bool {
-                bool should_block = true;
-                // Check whether work was pushed to us while attempting to block.  We make
-                // this test while holding the per-thread status lock, and after setting
-                // our status to ThreadStatus::Blocking.
-                //
-                // This synchronizes with ThreadPool::Schedule which pushes work to the queue
-                // and then tests for ThreadStatus::Blocking/Blocked (via EnsureAwake):
-                //
-                // Main thread:                    Worker:
-                //   #1 Push work                   #A Set status blocking
-                //   #2 Read worker status          #B Check queue
-                //   #3 Wake if blocking/blocked
-                //
-                // If #A is before #2 then main sees worker blocked and wakes
-                //
-                // If #A if after #2 then #B will see #1, and we abandon blocking
-                assert(!t);
-                t = q.PopFront();
-                if (t) {
-                  should_block = false;
-                }
-
-                // No work pushed to us, continue attempting to block.  The remaining
-                // test  is to synchronize with termination requests.  If we are
-                // shutting down and all worker threads blocked without work, that's
-                // we are done.
-                if (should_block) {
-                  blocked_++;
-                  if (done_ && blocked_ == num_threads_) {
-                    should_block = false;
-                    // Almost done, but need to re-check queues.
-                    // Consider that all queues are empty and all worker threads are preempted
-                    // right after incrementing blocked_ above. Now a free-standing thread
-                    // submits work and calls destructor (which sets done_). If we don't
-                    // re-check queues, we will exit leaving the work unexecuted.
-                    if (NonEmptyQueueIndex() != -1) {
-                      // Note: we must not pop from queues before we decrement blocked_,
-                      // otherwise the following scenario is possible. Consider that instead
-                      // of checking for emptiness we popped the only element from queues.
-                      // Now other worker threads can start exiting, which is bad if the
-                      // work item submits other work. So we just check emptiness here,
-                      // which ensures that all worker threads exit at the same time.
-                      blocked_--;
-                    } else {
-                      should_exit = true;
+          if (!td.SetBlocked(  // Pre-block test
+                  [&]() -> bool {
+                    bool should_block = true;
+                    // Check whether work was pushed to us while attempting to block.  We make
+                    // this test while holding the per-thread status lock, and after setting
+                    // our status to ThreadStatus::Blocking.
+                    //
+                    // This synchronizes with ThreadPool::Schedule which pushes work to the queue
+                    // and then tests for ThreadStatus::Blocking/Blocked (via EnsureAwake):
+                    //
+                    // Main thread:                    Worker:
+                    //   #1 Push work                   #A Set status blocking
+                    //   #2 Read worker status          #B Check queue
+                    //   #3 Wake if blocking/blocked
+                    //
+                    // If #A is before #2 then main sees worker blocked and wakes
+                    //
+                    // If #A if after #2 then #B will see #1, and we abandon blocking
+                    assert(!t);
+                    t = q.PopFront();
+                    if (t) {
+                      should_block = false;
                     }
-                  }
-                }
-                return should_block;
-              },
-              // Post-block update (executed only if we blocked)
-              [&]() {
-                blocked_--;
-              });
+
+                    // No work pushed to us, continue attempting to block.  The remaining
+                    // test  is to synchronize with termination requests.  If we are
+                    // shutting down and all worker threads blocked without work, that's
+                    // we are done.
+                    if (should_block) {
+                      blocked_++;
+                      if (done_ && blocked_ == num_threads_) {
+                        should_block = false;
+                        // Almost done, but need to re-check queues.
+                        // Consider that all queues are empty and all worker threads are preempted
+                        // right after incrementing blocked_ above. Now a free-standing thread
+                        // submits work and calls destructor (which sets done_). If we don't
+                        // re-check queues, we will exit leaving the work unexecuted.
+                        if (NonEmptyQueueIndex() != -1) {
+                          // Note: we must not pop from queues before we decrement blocked_,
+                          // otherwise the following scenario is possible. Consider that instead
+                          // of checking for emptiness we popped the only element from queues.
+                          // Now other worker threads can start exiting, which is bad if the
+                          // work item submits other work. So we just check emptiness here,
+                          // which ensures that all worker threads exit at the same time.
+                          blocked_--;
+                        } else {
+                          should_exit = true;
+                        }
+                      }
+                    }
+                    return should_block;
+                  },
+                  // Post-block update (executed only if we blocked)
+                  [&]() {
+                    blocked_--;
+                  })) {
+            // Encountered a fatal logic error in SetBlocked
+            should_exit = true;
+            break;
+          }
           // Thread just unblocked.  Unless we picked up work while
           // blocking, or are exiting, then either work was pushed to
           // us, or it was pushed to an overloaded queue


### PR DESCRIPTION
### Description
In July,2024 an Intel engineer created a PR(#21545) that reduced the spin count of our Eigen thread pool. Then I found it triggered a deadlock bug in EigenNonBlockingThreadPool.h. 

Here is how to reproduce the issue:

1. Create an ARM64 VM in Azure with only 4 vCPUs. I used Standard_D4plds_v5. The more CPUs you have, the less likely you will see the bug.
2. Create a local branch and apply the following changes to EigenNonBlockingThreadPool.h
```diff
-    constexpr int log2_spin = 20;
-    const int spin_count = allow_spinning_ ? (1ull << log2_spin) : 0;
-    const int steal_count = spin_count / 100;
+    //constexpr int log2_spin = 20;
+    const int spin_count = 10000;
+    const int steal_count = 100;
```
3. Build the source code locally:
  python3 tools/ci_build/build.py --skip_submodule_sync --parallel --config RelWithDebInfo --build_dir b1 --update --build
4. Run the following script
```bash
#!/bin/bash
for i in {1..1000}
do
    ./onnx_test_runner -c 1 -j 1 -x  model.onnx
done
```

Then quickly a "onnx_test_runner" process will stick in the loop, and you will see one of the CPU's usage is 100%, while all the other CPUs are idle. Sorry I cannot make the model file public. But it has nothing special. 

Furthermore, to confirm we saw the same bug, please use gdb to attach the hang process and examine each worker thread(the threads that are idle).  To examine the Nth thread, you should run the following gdb commands:
```
thr N
f 8
p {this->queue.back_._M_i & (1024-1), this->queue.front_._M_i & (1024-1)}
```
The last command prints two integers. If they are different, it means the thread's worker queue is not empty, and the thread should not wait there and idling.  That's the bug I mean. 

I have a hypothesis about the root cause, unfortunately I couldn't fully prove it.  I think Heisenberg's indeterminacy principle plays magic here that blocked me seeing what was actually happening.  When two threads run simultaneously on multiple CPUs,  I want to know the relative order of the actual executions, but I cannot get the information without adding additional synchronizations to the threads, which in turn may impact the real behavior.  Anyway, when debugging the issue, my approach was adding a logical clock to each thread.  The clock was just an atomic integer counter that can be read/write by multiple threads. Whoever reads it must also increase it by one at the same time.  Let's assume there are two threads: a producer who produces tasks and a consumer who executes tasks. Then I believe I observed the following thing:

1. Producer Thread:  called PushBack function that inserted a new task to the consumer thread's worker queue.
2. Consumer Thread: called SetBlocked function and entered the mutex region
3. Producer Thread: called EnsureAwake() function and load the status
4. Consumer Thread:  SetBlocked function went to sleep
6. Producer Thread: In the EnsureAwake function, it skipped alert because it believed the consumer thread was spinning. 
7. Since nobody woke up the consumer thread, the producer thread idled there forever though its worker queue was not empty.
(I have low confidence in the above. )

It is very counterintuitive because at step 4 before the consumer thread went to sleep, the consumer thread should have seen the queue was not empty.  My explanation is : it was because ARM has a weaker memory model than x86. We have got used to x86 too long. 

My fix is to enable an assert.  Though I don't believe the assert will ever hit, the updated code actually will insert a memory barrier there to ensure total ordering.  std::atomic class's exchange function is a read-modify-write operation, while a store function is write-only.  I tried to change the store function to use a stronger memory order, but it didn't fix the problem. Semantically, since we are going to read the queue, we need a read barrier here. 

Still, I didn't get fully persuaded.  It would be better if I can add some assert there, find a contradiction and abort the process.  If you have ideal to prove it, please let me know.

### Motivation and Context
5 weeks ago @goldsteinn suggested me to replace all std::memory_order_relaxed to std::memory_order_seq_cst. I didn't take his suggestion because any change to this file could make the bug not reproducible, however, it doesn't mean the bug is fixed. I have found a lot of different ways to make the bug disappear or harder to find.  ("harder" means I need to run the test process 10k or 100k times to get a hang up instead of 1K. )

@yuslepukhin and @tlh20 also helped me a lot.




