### PR TITLE
[ARM CPU] hgemm optimized for gqa

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -95,6 +95,7 @@ function(setup_mlas_source_for_windows)
         ${MLAS_SRC_DIR}/rotary_embedding_kernel_neon.h
         ${MLAS_SRC_DIR}/rotary_embedding_kernel_neon.cpp
         ${MLAS_SRC_DIR}/rotary_embedding_kernel_neon_fp16.cpp
+        ${MLAS_SRC_DIR}/halfgemm_kernel_neon_fp16.cpp
       )
 
       set(mlas_platform_preprocess_srcs
@@ -394,6 +395,7 @@ else()
             ${MLAS_SRC_DIR}/cast_kernel_neon.cpp
             ${MLAS_SRC_DIR}/hqnbitgemm_kernel_neon_fp16.cpp
             ${MLAS_SRC_DIR}/rotary_embedding_kernel_neon_fp16.cpp
+            ${MLAS_SRC_DIR}/halfgemm_kernel_neon_fp16.cpp
           )
           set_source_files_properties(${MLAS_SRC_DIR}/aarch64/HalfGemmKernelNeon.S PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+fp16 ")
           set_source_files_properties(${MLAS_SRC_DIR}/aarch64/QgemmS8S8KernelSmmla.S PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+i8mm ")
@@ -406,6 +408,7 @@ else()
           set_source_files_properties(${MLAS_SRC_DIR}/cast_kernel_neon.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+fp16 ")
           set_source_files_properties(${MLAS_SRC_DIR}/hqnbitgemm_kernel_neon_fp16.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+fp16 ")
           set_source_files_properties(${MLAS_SRC_DIR}/rotary_embedding_kernel_neon_fp16.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+fp16 ")
+          set_source_files_properties(${MLAS_SRC_DIR}/halfgemm_kernel_neon_fp16.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+fp16 ")
         endif()
 
         if(ONNXRUNTIME_MLAS_MULTI_ARCH)

--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -95,6 +95,7 @@ function(setup_mlas_source_for_windows)
         ${MLAS_SRC_DIR}/rotary_embedding_kernel_neon.h
         ${MLAS_SRC_DIR}/rotary_embedding_kernel_neon.cpp
         ${MLAS_SRC_DIR}/rotary_embedding_kernel_neon_fp16.cpp
+        ${MLAS_SRC_DIR}/hgemm_kernel_neon.cpp
         ${MLAS_SRC_DIR}/halfgemm_kernel_neon_fp16.cpp
       )
 
@@ -375,6 +376,7 @@ else()
           ${MLAS_SRC_DIR}/sqnbitgemm_kernel_neon_int8.cpp
           ${MLAS_SRC_DIR}/rotary_embedding_kernel_neon.h
           ${MLAS_SRC_DIR}/rotary_embedding_kernel_neon.cpp
+          ${MLAS_SRC_DIR}/hgemm_kernel_neon.cpp
         )
         set_source_files_properties(${MLAS_SRC_DIR}/sqnbitgemm_kernel_neon_int8.cpp
                                     PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+dotprod")

--- a/onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h
+++ b/onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h
@@ -198,8 +198,10 @@ class GQAAttentionBase {
           math::GemmEx<float, ThreadPool>(CblasNoTrans, CblasTrans, sequence_length, total_seqlen, head_size, alpha, q,
                                           static_cast<int>(head_size), k, static_cast<int>(head_size), 0.0f /*bata*/,
                                           output, static_cast<int>(present_buffer_sequence_length), nullptr);
-        } else if (GetMlasPlatform().HasFP16Support()) {
-          // TODO: if kernel available, call MlasHGemmEx
+        } else if (MlasHGemmSupported(CblasNoTrans, CblasTrans)) {
+          MlasGemm(CblasNoTrans, CblasTrans, sequence_length, total_seqlen, head_size,
+                   q, static_cast<int>(head_size), k, static_cast<int>(head_size), output,
+                   static_cast<int>(present_buffer_sequence_length), alpha, 0.0f /*beta*/, nullptr);
         } else {
           size_t bytes = head_size * (sequence_length + total_seqlen) * sizeof(float);
           auto q_k_fp32 = allocator->Alloc(bytes);

--- a/onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h
+++ b/onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h
@@ -198,6 +198,8 @@ class GQAAttentionBase {
           math::GemmEx<float, ThreadPool>(CblasNoTrans, CblasTrans, sequence_length, total_seqlen, head_size, alpha, q,
                                           static_cast<int>(head_size), k, static_cast<int>(head_size), 0.0f /*bata*/,
                                           output, static_cast<int>(present_buffer_sequence_length), nullptr);
+        } else if (GetMlasPlatform().HasFP16Support()) {
+          // TODO: if kernel available, call MlasHGemmEx
         } else {
           size_t bytes = head_size * (sequence_length + total_seqlen) * sizeof(float);
           auto q_k_fp32 = allocator->Alloc(bytes);

--- a/onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h
+++ b/onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h
@@ -75,6 +75,7 @@ class GQAAttentionBase {
     int seqlen_present_kv_cache = static_cast<int>(present_key->Shape().GetDims()[2]);
 
     // Compute the attention score.
+    // TODO(fajin): type depends on kernel supportability
     size_t bytes = SafeInt<size_t>(batch_size) * num_heads_ * sequence_length * seqlen_present_kv_cache * sizeof(float);
     auto attention_probs = allocator->Alloc(bytes);
     BufferUniquePtr scratch_buffer(attention_probs, BufferDeleter(allocator));
@@ -198,10 +199,11 @@ class GQAAttentionBase {
           math::GemmEx<float, ThreadPool>(CblasNoTrans, CblasTrans, sequence_length, total_seqlen, head_size, alpha, q,
                                           static_cast<int>(head_size), k, static_cast<int>(head_size), 0.0f /*bata*/,
                                           output, static_cast<int>(present_buffer_sequence_length), nullptr);
-        } else if (MlasHGemmSupported(CblasNoTrans, CblasTrans)) {
-          MlasGemm(CblasNoTrans, CblasTrans, sequence_length, total_seqlen, head_size,
-                   q, static_cast<int>(head_size), k, static_cast<int>(head_size), output,
-                   static_cast<int>(present_buffer_sequence_length), alpha, 0.0f /*beta*/, nullptr);
+        // TODO(fajin): update later
+        // } else if (MlasHGemmSupported(CblasNoTrans, CblasTrans)) {
+        //   MlasGemm(CblasNoTrans, CblasTrans, sequence_length, total_seqlen, head_size,
+        //            q, static_cast<int>(head_size), k, static_cast<int>(head_size), output,
+        //            static_cast<int>(present_buffer_sequence_length), alpha, 0.0f /*beta*/, nullptr);
         } else {
           size_t bytes = head_size * (sequence_length + total_seqlen) * sizeof(float);
           auto q_k_fp32 = allocator->Alloc(bytes);

--- a/onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h
+++ b/onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h
@@ -199,11 +199,11 @@ class GQAAttentionBase {
           math::GemmEx<float, ThreadPool>(CblasNoTrans, CblasTrans, sequence_length, total_seqlen, head_size, alpha, q,
                                           static_cast<int>(head_size), k, static_cast<int>(head_size), 0.0f /*bata*/,
                                           output, static_cast<int>(present_buffer_sequence_length), nullptr);
-        // TODO(fajin): update later
-        // } else if (MlasHGemmSupported(CblasNoTrans, CblasTrans)) {
-        //   MlasGemm(CblasNoTrans, CblasTrans, sequence_length, total_seqlen, head_size,
-        //            q, static_cast<int>(head_size), k, static_cast<int>(head_size), output,
-        //            static_cast<int>(present_buffer_sequence_length), alpha, 0.0f /*beta*/, nullptr);
+          // TODO(fajin): update later
+          // } else if (MlasHGemmSupported(CblasNoTrans, CblasTrans)) {
+          //   MlasGemm(CblasNoTrans, CblasTrans, sequence_length, total_seqlen, head_size,
+          //            q, static_cast<int>(head_size), k, static_cast<int>(head_size), output,
+          //            static_cast<int>(present_buffer_sequence_length), alpha, 0.0f /*beta*/, nullptr);
         } else {
           size_t bytes = head_size * (sequence_length + total_seqlen) * sizeof(float);
           auto q_k_fp32 = allocator->Alloc(bytes);

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -1458,6 +1458,56 @@ MlasRotaryEmbedOneRow(
     T* output
 );
 
+/**
+ * @brief Check whether current CPU supports half precision gemm.
+ */
+bool
+MLASCALL
+MlasHGemmSupported(
+    CBLAS_TRANSPOSE TransA,
+    CBLAS_TRANSPOSE TransB);
+
+/**
+ * @brief  half precision matrix/matrix multiply operation (HGEMM)
+ *         C = alpha * op(A) * op(B) + beta * C
+ *
+ * @param TransA  Supplies the transpose operation for matrix A. Currently only support CblasNoTrans.
+ * @param TransB  Supplies the transpose operation for matrix B. Currently only support CblasTrans.
+ * @param M       Supplies the number of rows of matrix A and matrix C.
+ * @param N       Supplies the number of columns of matrix B and matrix C.
+ * @param K       Supplies the number of columns of matrix A and the number of rows of matrix B.
+ * @param A       Supplies the address of matrix A
+ * @param lda     Supplies the first dimension of matrix A.
+ * @param B       Supplies the address of matrix B
+ * @param ldb     Supplies the first dimension of matrix B.
+ * @param C       Supplies the address of matrix C
+ * @param ldc     Supplies the first dimension of matrix C.
+ * @param alpha   Supplies the scalar alpha multiplier (see GEMM definition)
+ * @param beta    Supplies the scalar beta multiplier (see GEMM definition)
+ * @param ThreadPool Supplies the thread pool object to use, else nullptr if the base library threading support
+ *                   should be used.
+ */
+void
+MLASCALL
+MlasGemm(
+    CBLAS_TRANSPOSE TransA,
+    CBLAS_TRANSPOSE TransB,
+    size_t M,
+    size_t N,
+    size_t K,
+    const MLAS_FP16* A,
+    size_t lda,
+    const MLAS_FP16* B,
+    size_t ldb,
+    MLAS_FP16* C,
+    size_t ldc,
+    MLAS_FP16 alpha,
+    MLAS_FP16 beta,
+    MLAS_THREADPOOL* ThreadPool
+) {
+    // TODO: call MlasGemmBatch for hgemm
+}
+
     /**
  * @brief Whether current CPU supports FP16 acceleration.
 */

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -1462,14 +1462,14 @@ MlasRotaryEmbedOneRow(
  * @brief Supply matrices data information to half precision gemm functions
  */
 struct MLAS_HGEMM_DATA_PARAMS {
-    const MLAS_FP16* A = nullptr;      /**< Supplies the address of matrix A */
-    size_t lda = 0;                    /**< Supplies the first dimension of matrix A. */
-    const MLAS_FP16* B = nullptr;      /**< Supplies the address of matrix B */
-    size_t ldb = 0;                    /**< Supplies the first dimension of matrix B. */
-    MLAS_FP16* C = nullptr;            /**< Supplies the address of matrix C */
-    size_t ldc = 0;                    /**< Supplies the first dimension of matrix C. */
-    MLAS_FP16 alpha = MLAS_FP16(1.0f); /**< Supplies the scalar alpha multiplier (see GEMM definition) */
-    MLAS_FP16 beta = MLAS_FP16(0.0f);  /**< Supplies the scalar beta multiplier (see GEMM definition) */
+    const MLAS_FP16* A; /**< Supplies the address of matrix A */
+    size_t lda;         /**< Supplies the first dimension of matrix A. */
+    const MLAS_FP16* B; /**< Supplies the address of matrix B */
+    size_t ldb;         /**< Supplies the first dimension of matrix B. */
+    MLAS_FP16* C;       /**< Supplies the address of matrix C */
+    size_t ldc;         /**< Supplies the first dimension of matrix C. */
+    uint16_t alpha;     /**< Supplies the scalar alpha multiplier (see GEMM definition). FP16 encoding. */
+    uint16_t beta;      /**< Supplies the scalar beta multiplier (see GEMM definition). FP16 encoding. */
 };
 
 /**
@@ -1542,19 +1542,19 @@ MlasGemm(
     size_t ldb,
     MLAS_FP16* C,
     size_t ldc,
-    MLAS_FP16 alpha,
-    MLAS_FP16 beta,
+    uint16_t alpha,
+    uint16_t beta,
     MLAS_THREADPOOL* ThreadPool
 ) {
     MLAS_HGEMM_DATA_PARAMS Data;
-    Data.alpha = alpha;
     Data.A = A;
     Data.lda = lda;
     Data.B = B;
     Data.ldb = ldb;
-    Data.beta = beta;
     Data.C = C;
     Data.ldc = ldc;
+    Data.alpha = alpha;
+    Data.beta = beta;
     MlasGemmBatch(TransA, TransB, M, N, K, &Data, 1, ThreadPool);
 }
 

--- a/onnxruntime/core/mlas/lib/fp16_common.h
+++ b/onnxruntime/core/mlas/lib/fp16_common.h
@@ -16,6 +16,7 @@ Abstract:
 
 #pragma once
 
+#include <arm_neon.h>
 #include "mlas_float16.h"
 #include "mlasi.h"
 
@@ -347,6 +348,105 @@ MLAS_FLOAT16X4
 MlasBitwiseSelectFloat16x4(MLAS_UINT16X4 select, MLAS_FLOAT16X4 ones, MLAS_FLOAT16X4 zeros)
 {
     return vbsl_f16(select, ones, zeros);
+}
+
+MLAS_FORCEINLINE
+void
+Transpose8x8(MLAS_FLOAT16X8& v0, MLAS_FLOAT16X8& v1, MLAS_FLOAT16X8& v2, MLAS_FLOAT16X8& v3,
+             MLAS_FLOAT16X8& v4, MLAS_FLOAT16X8& v5, MLAS_FLOAT16X8& v6, MLAS_FLOAT16X8& v7)
+{
+    // |v00|v01|v02|v03|v04|v05|v06|v07|
+    // |v10|v11|v12|v13|v14|v15|v16|v17|
+    // |v20|v21|v22|v23|v24|v25|v26|v27|
+    // |v30|v31|v32|v33|v34|v35|v36|v37|
+    // |v40|v41|v42|v43|v44|v45|v46|v47|
+    // |v50|v51|v52|v53|v54|v55|v56|v57|
+    // |v60|v61|v62|v63|v64|v65|v66|v67|
+    // |v70|v71|v72|v73|v74|v75|v76|v77|
+    float16x8x2_t t01 = vtrnq_f16(v0, v1);
+    float16x8x2_t t23 = vtrnq_f16(v2, v3);
+    float16x8x2_t t45 = vtrnq_f16(v4, v5);
+    float16x8x2_t t67 = vtrnq_f16(v6, v7);
+    // |v00|v10|v02|v12|v04|v14|v06|v16|
+    // |v01|v11|v03|v13|v05|v15|v07|v17|
+    // |v20|v30|v22|v32|v24|v34|v26|v36|
+    // |v21|v31|v23|v33|v25|v35|v27|v37|
+    // |v40|v50|v42|v52|v44|v54|v46|v56|
+    // |v41|v51|v43|v53|v45|v55|v47|v57|
+    // |v60|v70|v62|v72|v64|v74|v66|v76|
+    // |v61|v71|v63|v73|v65|v75|v67|v77|
+    float32x4x2_t t02 = vtrnq_f32(vreinterpretq_f32_f16(t01.val[0]), vreinterpretq_f32_f16(t23.val[0]));
+    float32x4x2_t t13 = vtrnq_f32(vreinterpretq_f32_f16(t01.val[1]), vreinterpretq_f32_f16(t23.val[1]));
+    float32x4x2_t t46 = vtrnq_f32(vreinterpretq_f32_f16(t45.val[0]), vreinterpretq_f32_f16(t67.val[0]));
+    float32x4x2_t t57 = vtrnq_f32(vreinterpretq_f32_f16(t45.val[1]), vreinterpretq_f32_f16(t67.val[1]));
+    // |v00|v10|v20|v30|v04|v14|v24|v34|
+    // |v01|v11|v21|v31|v05|v15|v25|v35|
+    // |v02|v12|v22|v32|v06|v16|v26|v36|
+    // |v03|v13|v23|v33|v07|v17|v27|v37|
+    // |v40|v50|v60|v70|v44|v54|v64|v74|
+    // |v41|v51|v61|v71|v45|v55|v65|v75|
+    // |v42|v52|v62|v72|v46|v56|v66|v76|
+    // |v43|v53|v63|v73|v47|v57|v67|v77|
+    v0 = vreinterpretq_f16_f64(vtrn1q_f64(vreinterpretq_f64_f32(t02.val[0]), vreinterpretq_f64_f32(t46.val[0])));
+    v4 = vreinterpretq_f16_f64(vtrn2q_f64(vreinterpretq_f64_f32(t02.val[0]), vreinterpretq_f64_f32(t46.val[0])));
+    v2 = vreinterpretq_f16_f64(vtrn1q_f64(vreinterpretq_f64_f32(t02.val[1]), vreinterpretq_f64_f32(t46.val[1])));
+    v6 = vreinterpretq_f16_f64(vtrn2q_f64(vreinterpretq_f64_f32(t02.val[1]), vreinterpretq_f64_f32(t46.val[1])));
+    v1 = vreinterpretq_f16_f64(vtrn1q_f64(vreinterpretq_f64_f32(t13.val[0]), vreinterpretq_f64_f32(t57.val[0])));
+    v5 = vreinterpretq_f16_f64(vtrn2q_f64(vreinterpretq_f64_f32(t13.val[0]), vreinterpretq_f64_f32(t57.val[0])));
+    v3 = vreinterpretq_f16_f64(vtrn1q_f64(vreinterpretq_f64_f32(t13.val[1]), vreinterpretq_f64_f32(t57.val[1])));
+    v7 = vreinterpretq_f16_f64(vtrn2q_f64(vreinterpretq_f64_f32(t13.val[1]), vreinterpretq_f64_f32(t57.val[1])));
+    // |v00|v10|v20|v30|v40|v50|v60|v70|
+    // |v01|v11|v21|v31|v41|v51|v61|v71|
+    // |v02|v12|v22|v32|v42|v52|v62|v72|
+    // |v03|v13|v23|v33|v43|v53|v63|v73|
+    // |v04|v14|v24|v34|v44|v54|v64|v74|
+    // |v05|v15|v25|v35|v45|v55|v65|v75|
+    // |v06|v16|v26|v36|v46|v56|v66|v76|
+    // |v07|v17|v27|v37|v47|v57|v67|v77|
+}
+
+MLAS_FORCEINLINE
+void
+Transpose4x8(MLAS_FLOAT16X8& v0, MLAS_FLOAT16X8& v1, MLAS_FLOAT16X8& v2, MLAS_FLOAT16X8& v3)
+{
+    // |v00|v01|v02|v03|v04|v05|v06|v07|
+    // |v10|v11|v12|v13|v14|v15|v16|v17|
+    // |v20|v21|v22|v23|v24|v25|v26|v27|
+    // |v30|v31|v32|v33|v34|v35|v36|v37|
+    //  =>
+    // |v00|v10|v20|v30|v04|v14|v24|v34|
+    // |v01|v11|v21|v31|v05|v15|v25|v35|
+    // |v02|v12|v22|v32|v06|v16|v26|v36|
+    // |v03|v13|v23|v33|v07|v17|v27|v37|
+    float16x8x2_t t01 = vtrnq_f16(v0, v1);
+    float16x8x2_t t23 = vtrnq_f16(v2, v3);
+
+    v0 = vreinterpretq_f16_f32(vtrn1q_f32(vreinterpretq_f32_f16(t01.val[0]), vreinterpretq_f32_f16(t23.val[0])));
+    v2 = vreinterpretq_f16_f32(vtrn2q_f32(vreinterpretq_f32_f16(t01.val[0]), vreinterpretq_f32_f16(t23.val[0])));
+    v1 = vreinterpretq_f16_f32(vtrn1q_f32(vreinterpretq_f32_f16(t01.val[1]), vreinterpretq_f32_f16(t23.val[1])));
+    v3 = vreinterpretq_f16_f32(vtrn2q_f32(vreinterpretq_f32_f16(t01.val[1]), vreinterpretq_f32_f16(t23.val[1])));
+}
+
+MLAS_FORCEINLINE
+void
+Transpose4x4(MLAS_FLOAT16X4& v0, MLAS_FLOAT16X4& v1, MLAS_FLOAT16X4& v2, MLAS_FLOAT16X4& v3)
+{
+    // |v00|v01|v02|v03|
+    // |v10|v11|v12|v13|
+    // |v20|v21|v22|v23|
+    // |v30|v31|v32|v33|
+    //  =>
+    // |v00|v10|v20|v30|
+    // |v01|v11|v21|v31|
+    // |v02|v12|v22|v32|
+    // |v03|v13|v23|v33|
+    float16x4x2_t t01 = vtrn_f16(v0, v1);
+    float16x4x2_t t23 = vtrn_f16(v2, v3);
+
+    v0 = vreinterpret_f16_f32(vtrn1_f32(vreinterpret_f32_f16(t01.val[0]), vreinterpret_f32_f16(t23.val[0])));
+    v1 = vreinterpret_f16_f32(vtrn1_f32(vreinterpret_f32_f16(t01.val[1]), vreinterpret_f32_f16(t23.val[1])));
+    v2 = vreinterpret_f16_f32(vtrn2_f32(vreinterpret_f32_f16(t01.val[0]), vreinterpret_f32_f16(t23.val[0])));
+    v3 = vreinterpret_f16_f32(vtrn2_f32(vreinterpret_f32_f16(t01.val[1]), vreinterpret_f32_f16(t23.val[1])));
 }
 
 #endif  // fp16 vector intrinsic supported

--- a/onnxruntime/core/mlas/lib/fp16_common.h
+++ b/onnxruntime/core/mlas/lib/fp16_common.h
@@ -16,7 +16,6 @@ Abstract:
 
 #pragma once
 
-#include <arm_neon.h>
 #include "mlas_float16.h"
 #include "mlasi.h"
 

--- a/onnxruntime/core/mlas/lib/halfgemm.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm.cpp
@@ -324,6 +324,34 @@ MlasHalfGemmKernel<MLAS_HALF_GEMM_KERNEL_DEFAULT>(
     }
 }
 
+bool
+MLASCALL
+MlasHGemmSupported(
+    CBLAS_TRANSPOSE TransA,
+    CBLAS_TRANSPOSE TransB
+) {
+    auto* dispatch = GetMlasPlatform().HGemmDispatch;
+    if (TransA == CblasNoTrans && TransB == CblasTrans) {
+        return dispatch && dispatch->HGemmKernel_TransposeB;
+    }
+
+    return false;
+}
+
+void
+MLASCALL
+MlasGemmBatch(
+    CBLAS_TRANSPOSE TransA,
+    CBLAS_TRANSPOSE TransB,
+    size_t M,
+    size_t N,
+    size_t K,
+    const MLAS_HGEMM_DATA_PARAMS* Data,
+    size_t BatchSize,
+    MLAS_THREADPOOL* ThreadPool
+) {
+
+}
 
 const MLAS_HALFGEMM_DISPATCH MlasHalfGemmDispatchDefault = {
     MlasHalfGemmOperation<MLAS_HALF_GEMM_KERNEL_DEFAULT>,

--- a/onnxruntime/core/mlas/lib/halfgemm.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm.cpp
@@ -355,8 +355,8 @@ HGemmOperation(
     const size_t lda = DataParams->lda;
     const size_t ldb = DataParams->ldb;
     const size_t ldc = DataParams->ldc;
-    const MLAS_FP16 alpha = DataParams->alpha;
-    const MLAS_FP16 beta = DataParams->beta;
+    const _mlas_fp16_ alpha = DataParams->alpha;
+    const _mlas_fp16_ beta = DataParams->beta;
     auto* dispatch = GetMlasPlatform().HGemmDispatch;
     constexpr size_t StrideM = 2;
     const auto beta_add = MLAS_FP16(1.0f);
@@ -403,7 +403,7 @@ HGemmOperation(
                         countM = std::min(StrideM, RangeCountM - m);
                         // First K iteration, beta is applied to the whole C. In rest K iterations, use add mode.
                         dispatch->HGemmKernel_TransposedPackedB(
-                            aa, PackedB, cc, countM, countN, countK, lda, ldc, alpha, k == 0 ? beta : beta_add);
+                            aa, PackedB, cc, countM, countN, countK, lda, ldc, alpha, k == 0 ? beta : beta_add.val);
                         aa += countM * lda;
                         cc += countM * ldc;
                     }

--- a/onnxruntime/core/mlas/lib/halfgemm.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm.cpp
@@ -372,8 +372,8 @@ HGemmOperation(
             if (!dispatch || !dispatch->HGemmKernel_TransposedB) {
                 MLAS_THROW_EX(std::runtime_error, "hgemm does not have A x Transposed(B) kernels");
             }
-            // When M is small, B is visited once. The overhead of Pack(B) exceeds the benefits
-            // from A x Pack(B). Therefore directly calculate A x B.
+            // When M is small, B is visited once. The overhead of Pack(B') exceeds the benefits
+            // from A x Pack(B'). Therefore directly calculate A x B'.
             // Without PackB, to utilize memory locality, iterate full K.
             const size_t StrideN = 16;
             for (size_t n = 0, countN; n < RangeCountN; n += countN) {

--- a/onnxruntime/core/mlas/lib/halfgemm.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm.cpp
@@ -375,7 +375,7 @@ HGemmOperation(
             // When M is small, B is visited once. The overhead of Pack(B') exceeds the benefits
             // from A x Pack(B'). Therefore directly calculate A x B'.
             // Without PackB, to utilize memory locality, iterate full K.
-            const size_t StrideN = 16;
+            constexpr size_t StrideN = 16;
             for (size_t n = 0, countN; n < RangeCountN; n += countN) {
                 countN = std::min(StrideN, RangeCountN - n);
                 dispatch->HGemmKernel_TransposedB(A, B, C, RangeCountM, countN, K, lda, ldb, ldc, alpha, beta);

--- a/onnxruntime/core/mlas/lib/halfgemm.h
+++ b/onnxruntime/core/mlas/lib/halfgemm.h
@@ -514,6 +514,24 @@ MlasHalfGemmGetDispatch()
 #endif
 }
 
+namespace hgemm_neon {
+
+void HGemm_TransposeB_Kernel(
+    const MLAS_FP16* A,
+    const MLAS_FP16* B,
+    MLAS_FP16* C,
+    size_t CountM,
+    size_t CountN,
+    size_t CountK,
+    size_t lda,
+    size_t ldb,
+    size_t ldc,
+    MLAS_FP16 alpha,
+    MLAS_FP16 beta
+);
+
+}  // namespace hgemm_neon
+
 struct MLAS_HGEMM_DISPATCH {
      /**
      * @brief C = alpha * A * Transpose(B) + beta * C

--- a/onnxruntime/core/mlas/lib/halfgemm.h
+++ b/onnxruntime/core/mlas/lib/halfgemm.h
@@ -513,3 +513,36 @@ MlasHalfGemmGetDispatch()
     return &MlasHalfGemmDispatchDefault;
 #endif
 }
+
+struct MLAS_HGEMM_DISPATCH {
+     /**
+     * @brief C = alpha * A * Transpose(B) + beta * C
+     *
+     * @param       A                   first row of the A matrix segment. Row major.
+     * @param       B                   first column of the B matrix segment. Column major.
+     * @param[out]  C                   first element of the output matrix segment. Row major.
+     * @param       CountM              the number of rows of A chunk.
+     * @param       CountN              the number of columns of B chunk.
+     * @param       CountK              the number of columns of A chunk and the number of rows of B chunk.
+     * @param       lda                 the leading dimension of A.
+     * @param       ldb                 the leading dimension of B.
+     * @param       ldc                 the leading dimension of C.
+     * @param       alpha               the alpha scalar value.
+     * @param       beta                the beta scalar value.
+     */
+    typedef void(HGemmKernel_TransposeB_Fn)(
+        const MLAS_FP16* A,
+        const MLAS_FP16* B,
+        MLAS_FP16* C,
+        size_t CountM,
+        size_t CountN,
+        size_t CountK,
+        size_t lda,
+        size_t ldb,
+        size_t ldc,
+        MLAS_FP16 alpha,
+        MLAS_FP16 beta
+    );
+
+    HGemmKernel_TransposeB_Fn* HGemmKernel_TransposeB = nullptr;
+};

--- a/onnxruntime/core/mlas/lib/halfgemm.h
+++ b/onnxruntime/core/mlas/lib/halfgemm.h
@@ -534,8 +534,8 @@ void HGemm_TransposedB_Kernel(
     size_t lda,
     size_t ldb,
     size_t ldc,
-    MLAS_FP16 alpha,
-    MLAS_FP16 beta
+    _mlas_fp16_ alpha,
+    _mlas_fp16_ beta
 );
 
 void HGemm_TransposedPackedB_Kernel(
@@ -547,8 +547,8 @@ void HGemm_TransposedPackedB_Kernel(
     size_t CountK,
     size_t lda,
     size_t ldc,
-    MLAS_FP16 alpha,
-    MLAS_FP16 beta
+    _mlas_fp16_ alpha,
+    _mlas_fp16_ beta
 );
 
 }  // namespace hgemm_neon
@@ -599,8 +599,8 @@ struct MLAS_HGEMM_DISPATCH {
         size_t lda,
         size_t ldb,
         size_t ldc,
-        MLAS_FP16 alpha,
-        MLAS_FP16 beta
+        _mlas_fp16_ alpha,
+        _mlas_fp16_ beta
     );
 
     HGemmKernel_TransposedB_Fn* HGemmKernel_TransposedB = nullptr;
@@ -629,8 +629,8 @@ struct MLAS_HGEMM_DISPATCH {
         size_t CountK,
         size_t lda,
         size_t ldc,
-        MLAS_FP16 alpha,
-        MLAS_FP16 beta
+        _mlas_fp16_ alpha,
+        _mlas_fp16_ beta
     );
 
     HGemmKernel_TransposedPackedB_Fn* HGemmKernel_TransposedPackedB = nullptr;

--- a/onnxruntime/core/mlas/lib/halfgemm.h
+++ b/onnxruntime/core/mlas/lib/halfgemm.h
@@ -516,7 +516,7 @@ MlasHalfGemmGetDispatch()
 
 namespace hgemm_neon {
 
-void HTransposePackB_Kernel(
+void HPackB_TransposedB_Kernel(
     const MLAS_FP16* B,
     MLAS_FP16* PackedB,
     size_t CountN,
@@ -524,7 +524,7 @@ void HTransposePackB_Kernel(
     size_t ldb
 );
 
-void HGemm_TransposeB_Kernel(
+void HGemm_TransposedB_Kernel(
     const MLAS_FP16* A,
     const MLAS_FP16* B,
     MLAS_FP16* C,
@@ -538,7 +538,7 @@ void HGemm_TransposeB_Kernel(
     MLAS_FP16 beta
 );
 
-void HGemm_TransposePackB_Kernel(
+void HGemm_TransposedPackedB_Kernel(
     const MLAS_FP16* A,
     const MLAS_FP16* PackedB,
     MLAS_FP16* C,
@@ -555,7 +555,8 @@ void HGemm_TransposePackB_Kernel(
 
 struct MLAS_HGEMM_DISPATCH {
     /**
-     * @brief Transpose and pack the B matrix segment. Elements from the same row are packed continuously.
+     * @brief Pack the B matrix segment. B is column-major. Elements from CountK rows x N columns are packed
+     *        continuously in row-major.
      *        First pack CountK rows x 16 columns, then pack CountK rows x 8 columns.
      *        If there are < 8 columns left, pad the columns with 0.
      * @param      B                   the first element of the B matrix segment. Column major.
@@ -563,7 +564,7 @@ struct MLAS_HGEMM_DISPATCH {
      * @param      CountN              the number of columns of B chunk.
      * @param      CountK              the number of rows of B chunk.
      */
-    typedef void(HTransposePackBKernel_Fn) (
+    typedef void(HPackBKernel_TransposedB_Fn) (
         const MLAS_FP16* B,
         MLAS_FP16* PackedB,
         size_t CountN,
@@ -571,7 +572,7 @@ struct MLAS_HGEMM_DISPATCH {
         size_t ldb
     );
 
-    HTransposePackBKernel_Fn* HTransposePackB = nullptr;
+    HPackBKernel_TransposedB_Fn* HPackBKernel_TransposedB = nullptr;
 
     /**
      * @brief C = alpha * A * Transpose(B) + beta * C. CountM <= 2. B is not packed. Used when M is small.
@@ -588,7 +589,7 @@ struct MLAS_HGEMM_DISPATCH {
      * @param       alpha               the alpha scalar value.
      * @param       beta                the beta scalar value.
      */
-    typedef void(HGemmKernel_TransposeB_Fn)(
+    typedef void(HGemmKernel_TransposedB_Fn)(
         const MLAS_FP16* A,
         const MLAS_FP16* B,
         MLAS_FP16* C,
@@ -602,11 +603,11 @@ struct MLAS_HGEMM_DISPATCH {
         MLAS_FP16 beta
     );
 
-    HGemmKernel_TransposeB_Fn* HGemmKernel_TransposeB = nullptr;
+    HGemmKernel_TransposedB_Fn* HGemmKernel_TransposedB = nullptr;
 
      /**
-     * @brief C = alpha * A * Transpose(B) + beta * C. CountM <= 2. B is packed using HTransposePackBKernel_Fn.
-     *        Used when M is large.
+     * @brief C = alpha * A * Transpose(B) + beta * C. CountM <= 2. B has been packed using HPackBKernel_TransposedB_Fn.
+     *        Use when M is large.
      *
      * @param       A                   first row of the A matrix segment. Row major.
      * @param       PackedB             first element of the packed B buffer.
@@ -619,7 +620,7 @@ struct MLAS_HGEMM_DISPATCH {
      * @param       alpha               the alpha scalar value.
      * @param       beta                the beta scalar value.
      */
-    typedef void(HGemmKernel_TransposePackB_Fn)(
+    typedef void(HGemmKernel_TransposedPackedB_Fn)(
         const MLAS_FP16* A,
         const MLAS_FP16* PackedB,
         MLAS_FP16* C,
@@ -632,5 +633,5 @@ struct MLAS_HGEMM_DISPATCH {
         MLAS_FP16 beta
     );
 
-    HGemmKernel_TransposePackB_Fn* HGemmKernel_TransposePackB = nullptr;
+    HGemmKernel_TransposedPackedB_Fn* HGemmKernel_TransposedPackedB = nullptr;
 };

--- a/onnxruntime/core/mlas/lib/halfgemm_kernel_neon.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm_kernel_neon.cpp
@@ -189,7 +189,9 @@ const MLAS_HALFGEMM_DISPATCH MlasHalfGemmDispatchNeon = {
 const MLAS_HGEMM_DISPATCH MlasHGemmDispatchNeon = [](){
     MLAS_HGEMM_DISPATCH d;
 #if defined(MLAS_F16VEC_INTRINSICS_SUPPORTED) && defined(MLAS_TARGET_ARM64)
+    d.HTransposePackB = hgemm_neon::HTransposePackB_Kernel;
     d.HGemmKernel_TransposeB = hgemm_neon::HGemm_TransposeB_Kernel;
+    d.HGemmKernel_TransposePackB = hgemm_neon::HGemm_TransposePackB_Kernel;
 #endif
     return d;
 }();

--- a/onnxruntime/core/mlas/lib/halfgemm_kernel_neon.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm_kernel_neon.cpp
@@ -189,7 +189,7 @@ const MLAS_HALFGEMM_DISPATCH MlasHalfGemmDispatchNeon = {
 const MLAS_HGEMM_DISPATCH MlasHGemmDispatchNeon = [](){
     MLAS_HGEMM_DISPATCH d;
 #if defined(MLAS_F16VEC_INTRINSICS_SUPPORTED) && defined(MLAS_TARGET_ARM64)
-    d.HGemmKernel_TransposeB = nullptr;
+    d.HGemmKernel_TransposeB = hgemm_neon::HGemm_TransposeB_Kernel;
 #endif
     return d;
 }();

--- a/onnxruntime/core/mlas/lib/halfgemm_kernel_neon.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm_kernel_neon.cpp
@@ -185,3 +185,11 @@ const MLAS_HALFGEMM_DISPATCH MlasHalfGemmDispatchNeon = {
     MLAS_HALF_GEMM_KERNEL_NEON::KernelMaxM,
     32 // kernel may read beyond buffer end by 32 bytes
 };
+
+const MLAS_HGEMM_DISPATCH MlasHGemmDispatchNeon = [](){
+    MLAS_HGEMM_DISPATCH d;
+#if defined(MLAS_F16VEC_INTRINSICS_SUPPORTED) && defined(MLAS_TARGET_ARM64)
+    d.HGemmKernel_TransposeB = nullptr;
+#endif
+    return d;
+}();

--- a/onnxruntime/core/mlas/lib/halfgemm_kernel_neon.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm_kernel_neon.cpp
@@ -189,9 +189,9 @@ const MLAS_HALFGEMM_DISPATCH MlasHalfGemmDispatchNeon = {
 const MLAS_HGEMM_DISPATCH MlasHGemmDispatchNeon = [](){
     MLAS_HGEMM_DISPATCH d;
 #if defined(MLAS_F16VEC_INTRINSICS_SUPPORTED) && defined(MLAS_TARGET_ARM64)
-    d.HTransposePackB = hgemm_neon::HTransposePackB_Kernel;
-    d.HGemmKernel_TransposeB = hgemm_neon::HGemm_TransposeB_Kernel;
-    d.HGemmKernel_TransposePackB = hgemm_neon::HGemm_TransposePackB_Kernel;
+    d.HPackBKernel_TransposedB = hgemm_neon::HPackB_TransposedB_Kernel;
+    d.HGemmKernel_TransposedB = hgemm_neon::HGemm_TransposedB_Kernel;
+    d.HGemmKernel_TransposedPackedB = hgemm_neon::HGemm_TransposedPackedB_Kernel;
 #endif
     return d;
 }();

--- a/onnxruntime/core/mlas/lib/halfgemm_kernel_neon.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm_kernel_neon.cpp
@@ -185,13 +185,3 @@ const MLAS_HALFGEMM_DISPATCH MlasHalfGemmDispatchNeon = {
     MLAS_HALF_GEMM_KERNEL_NEON::KernelMaxM,
     32 // kernel may read beyond buffer end by 32 bytes
 };
-
-const MLAS_HGEMM_DISPATCH MlasHGemmDispatchNeon = [](){
-    MLAS_HGEMM_DISPATCH d;
-#if defined(MLAS_F16VEC_INTRINSICS_SUPPORTED) && defined(MLAS_TARGET_ARM64)
-    d.HPackBKernel_TransposedB = hgemm_neon::HPackB_TransposedB_Kernel;
-    d.HGemmKernel_TransposedB = hgemm_neon::HGemm_TransposedB_Kernel;
-    d.HGemmKernel_TransposedPackedB = hgemm_neon::HGemm_TransposedPackedB_Kernel;
-#endif
-    return d;
-}();

--- a/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
@@ -20,6 +20,193 @@ Abstract:
 
 namespace hgemm_neon {
 
+template <size_t CountN, size_t CountM>
+typename std::enable_if_t<((CountN >= 1 && CountN <= 8 && ((CountN - 1) & CountN) == 0) && (CountM == 1 || CountM == 2)), void>
+HGemmTransB_Kernel_Block(
+    const _mlas_fp16_* A,
+    const _mlas_fp16_* B,
+    const _mlas_fp16_* Bias,
+    _mlas_fp16_* C,
+    size_t K,
+    size_t lda,
+    size_t ldb,
+    size_t ldc
+) {
+    using RegisterType = typename std::conditional_t<(CountN < 8), float16x4_t, float16x8_t>;
+
+    RegisterType accu00, accu01, accu10, accu11;
+    constexpr size_t b_step = CountN >= 8 ? 8 : 1;
+    constexpr size_t N = CountN == 16 ? 8 : CountN;
+
+    if constexpr (CountM == 2) {
+        accu00 = accu10 = PrepareAccumulator<N>(Bias);
+    } else {
+        accu00 = PrepareAccumulator<N>(Bias);
+    }
+    if constexpr (CountN == 16) {
+        if constexpr (CountM == 2) {
+            accu01 = accu11 = PrepareAccumulator<N>(Bias ? Bias + 8 : nullptr);
+        } else {
+            accu01 = PrepareAccumulator<N>(Bias ? Bias + 8 : nullptr);
+        }
+    }
+
+    size_t k = 0;
+    for (; k + 8 <= K; k += 8, A += 8, B += b_step * 8) {
+        accu00 = HQ4BitGemmMicroKernel<N, 1, 8>(A, B, ldb, accu00);
+        if constexpr (CountN == 16) {
+            accu01 = HQ4BitGemmMicroKernel<N, 1, 8>(A, B + b_step * ldb, ldb, accu01);
+        }
+        if constexpr (CountM == 2) {
+            accu10 = HQ4BitGemmMicroKernel<N, 1, 8>(A + lda, B, ldb, accu10);
+            if constexpr (CountN == 16) {
+                accu11 = HQ4BitGemmMicroKernel<N, 1, 8>(A + lda, B + b_step * ldb, ldb, accu11);
+            }
+        }
+    }
+
+    if (K & 4) {
+        accu00 = HQ4BitGemmMicroKernel<N, 1, 4>(A, B, ldb, accu00);
+        if constexpr (CountN == 16) {
+            accu01 = HQ4BitGemmMicroKernel<N, 1, 4>(A, B + b_step * ldb, ldb, accu01);
+        }
+        if constexpr (CountM == 2) {
+            accu10 = HQ4BitGemmMicroKernel<N, 1, 4>(A + lda, B, ldb, accu10);
+            if constexpr (CountN == 16) {
+                accu11 = HQ4BitGemmMicroKernel<N, 1, 4>(A + lda, B + b_step * ldb, ldb, accu11);
+            }
+        }
+        k += 4, A += 4, B += b_step * 4;
+    }
+
+    if (K & 2) {
+        accu00 = HQ4BitGemmMicroKernel<N, 1, 2>(A, B, ldb, accu00);
+        if constexpr (CountN == 16) {
+            accu01 = HQ4BitGemmMicroKernel<N, 1, 2>(A, B + b_step * ldb, ldb, accu01);
+        }
+        if constexpr (CountM == 2) {
+            accu10 = HQ4BitGemmMicroKernel<N, 1, 2>(A + lda, B, ldb, accu10);
+            if constexpr (CountN == 16) {
+                accu11 = HQ4BitGemmMicroKernel<N, 1, 2>(A + lda, B + b_step * ldb, ldb, accu11);
+            }
+        }
+        k += 2, A += 2, B += b_step * 2;
+    }
+
+    if (k < K) {
+        accu00 = HQ4BitGemmMicroKernel<N, 1, 1>(A, B, ldb, accu00);
+        if constexpr (CountN == 16) {
+            accu01 = HQ4BitGemmMicroKernel<N, 1, 1>(A, B + b_step * ldb, ldb, accu01);
+        }
+        if constexpr (CountM == 2) {
+            accu10 = HQ4BitGemmMicroKernel<N, 1, 1>(A + lda, B, ldb, accu10);
+            if constexpr (CountN == 16) {
+                accu11 = HQ4BitGemmMicroKernel<N, 1, 1>(A + lda, B + b_step * ldb, ldb, accu11);
+            }
+        }
+    }
+
+    if constexpr (CountN >= 8) {
+        MlasStoreFloat16x8(C, accu00);
+        if constexpr (CountN == 16) {
+            MlasStoreFloat16x8(C + 8, accu01);
+        }
+    } else if constexpr (CountN == 4) {
+        MlasStoreFloat16x4(C, accu00);
+    } else {
+        MlasStoreLaneFloat16x4<0>(C, accu00);
+        if constexpr (CountN == 2) {
+            MlasStoreLaneFloat16x4<1>(C + 1, accu00);
+        }
+    }
+
+    if constexpr (CountM == 2) {
+        if constexpr (CountN >= 8) {
+            MlasStoreFloat16x8(C + ldc, accu10);
+            if constexpr (CountN == 16) {
+                MlasStoreFloat16x8(C + ldc + 8, accu11);
+            }
+        } else if constexpr (CountN == 4) {
+            MlasStoreFloat16x4(C + ldc, accu10);
+        } else {
+            MlasStoreLaneFloat16x4<0>(C + ldc, accu10);
+            if constexpr (CountN == 2) {
+                MlasStoreLaneFloat16x4<1>(C + ldc + 1, accu10);
+            }
+        }
+    }
+}
+
+void HTransposePackB_Kernel(
+    const MLAS_FP16* B,
+    MLAS_FP16* PackedB,
+    size_t CountN,
+    size_t CountK,
+    size_t ldb
+) {
+    const _mlas_fp16_* B_data = reinterpret_cast<const _mlas_fp16_*>(B);
+    _mlas_fp16_* PackedB_data = reinterpret_cast<_mlas_fp16_*>(PackedB);
+
+    for (; CountN >= 16; CountN -= 16) {
+        const _mlas_fp16_* b = B_data;
+        size_t k = 0;
+        constexpr size_t step = 16 * 8;
+        for (; k + 7 < CountK; k += 8) {
+            float16x8_t v0 = MlasLoadFloat16x8(b);
+            float16x8_t v1 = MlasLoadFloat16x8(b + ldb);
+            float16x8_t v2 = MlasLoadFloat16x8(b + 2 * ldb);
+            float16x8_t v3 = MlasLoadFloat16x8(b + 3 * ldb);
+            float16x8_t v4 = MlasLoadFloat16x8(b + 4 * ldb);
+            float16x8_t v5 = MlasLoadFloat16x8(b + 5 * ldb);
+            float16x8_t v6 = MlasLoadFloat16x8(b + 6 * ldb);
+            float16x8_t v7 = MlasLoadFloat16x8(b + 7 * ldb);
+            float16x8_t v8 = MlasLoadFloat16x8(b + 8 * ldb);
+            float16x8_t v9 = MlasLoadFloat16x8(b + 9 * ldb);
+            float16x8_t vA = MlasLoadFloat16x8(b + 10 * ldb);
+            float16x8_t vB = MlasLoadFloat16x8(b + 11 * ldb);
+            float16x8_t vC = MlasLoadFloat16x8(b + 12 * ldb);
+            float16x8_t vD = MlasLoadFloat16x8(b + 13 * ldb);
+            float16x8_t vE = MlasLoadFloat16x8(b + 14 * ldb);
+            float16x8_t vF = MlasLoadFloat16x8(b + 15 * ldb);
+            Transpose8x8(v0, v1, v2, v3, v4, v5, v6, v7);
+            Transpose8x8(v8, v9, vA, vB, vC, vD, vE, vF);
+
+            MlasStoreFloat16x8(PackedB_data, v0);
+            MlasStoreFloat16x8(PackedB_data + 8, v1);
+            MlasStoreFloat16x8(PackedB_data + 16, v2);
+            MlasStoreFloat16x8(PackedB_data + 24, v3);
+            MlasStoreFloat16x8(PackedB_data + 32, v4);
+            MlasStoreFloat16x8(PackedB_data + 40, v5);
+            MlasStoreFloat16x8(PackedB_data + 48, v6);
+            MlasStoreFloat16x8(PackedB_data + 56, v7);
+            MlasStoreFloat16x8(PackedB_data + 64, v8);
+            MlasStoreFloat16x8(PackedB_data + 72, v9);
+            MlasStoreFloat16x8(PackedB_data + 80, vA);
+            MlasStoreFloat16x8(PackedB_data + 88, vB);
+            MlasStoreFloat16x8(PackedB_data + 96, vC);
+            MlasStoreFloat16x8(PackedB_data + 104, vD);
+            MlasStoreFloat16x8(PackedB_data + 112, vE);
+            MlasStoreFloat16x8(PackedB_data + 120, vF);
+
+            b += 8, PackedB_data += step;
+        }
+
+        // TODO: remaining K
+
+        B_data += 16 * ldb;
+    }
+
+    if (CountN & 8) {
+
+        B_data += 8 * ldb;
+        CountN -= 8;
+    }
+
+    if (CountN > 0) {
+
+    }
+}
+
 void HGemm_TransposeB_Kernel(
     const MLAS_FP16* A,
     const MLAS_FP16* B,
@@ -33,7 +220,69 @@ void HGemm_TransposeB_Kernel(
     MLAS_FP16 alpha,
     MLAS_FP16 beta
 ) {
+    if (CountM > 2) {
+        MLAS_THROW_EX(std::runtime_error, "HGemm_TransposeB_Kernel only support <= 2 rows");
+    }
+}
 
+void HGemm_TransposePackB_Kernel(
+    const MLAS_FP16* A,
+    const MLAS_FP16* PackedB,
+    MLAS_FP16* C,
+    size_t CountM,
+    size_t CountN,
+    size_t CountK,
+    size_t lda,
+    size_t ldc,
+    MLAS_FP16 alpha,
+    MLAS_FP16 beta
+) {
+    if (CountM > 2) {
+        MLAS_THROW_EX(std::runtime_error, "HGemm_TransposePackB_Kernel only support <= 2 rows");
+    }
+
+    const auto* a = reinterpret_cast<const _mlas_fp16_*>(A);
+    const auto* b = reinterpret_cast<const _mlas_fp16_*>(PackedB);
+    auto* c = reinterpret_cast<_mlas_fp16_*>(C);
+
+    // 2M_8N as register block. 16 accumulators.
+    for (; CountN >= 8; CountN -= 8) {
+        if (CountM == 2) {
+            HGemmTransB_Kernel_Block<16, 2>(a, b, bias, c, K, lda, ldb, ldc);
+        } else {
+            HGemmTransB_Kernel_Block<16, 1>(a, b, bias, c, K, lda, ldb, ldc);
+        }
+        b += 16 * ldb, c += 16;
+        if (bias) bias += 16;
+    }
+
+    if (CountN & 4) {
+        if (CountM == 2) {
+            HGemmTransB_Kernel_Block<4, 2>(a, b, bias, c, K, lda, ldb, ldc);
+        } else {
+            HGemmTransB_Kernel_Block<4, 1>(a, b, bias, c, K, lda, ldb, ldc);
+        }
+        b += 4 * ldb, c += 4;
+        if (bias) bias += 4;
+    }
+
+    if (CountN & 2) {
+        if (CountM == 2) {
+            HGemmTransB_Kernel_Block<2, 2>(a, b, bias, c, K, lda, ldb, ldc);
+        } else {
+            HGemmTransB_Kernel_Block<2, 1>(a, b, bias, c, K, lda, ldb, ldc);
+        }
+        b += 2 * ldb, c += 2;
+        if (bias) bias += 2;
+    }
+
+    if (CountN & 1) {
+        if (CountM == 2) {
+            HGemmTransB_Kernel_Block<1, 2>(a, b, bias, c, K, lda, ldb, ldc);
+        } else {
+            HGemmTransB_Kernel_Block<1, 1>(a, b, bias, c, K, lda, ldb, ldc);
+        }
+    }
 }
 
 }  // namespace hgemm_neon

--- a/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
@@ -1,0 +1,39 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    halfgemm_kernel_neon_fp16.cpp
+
+Abstract:
+
+    This module implements half precision GEMM kernel for neon.
+
+--*/
+
+#include <arm_neon.h>
+
+#include "halfgemm.h"
+
+namespace hgemm_neon {
+
+void HGemm_TransposeB_Kernel(
+    const MLAS_FP16* A,
+    const MLAS_FP16* B,
+    MLAS_FP16* C,
+    size_t CountM,
+    size_t CountN,
+    size_t CountK,
+    size_t lda,
+    size_t ldb,
+    size_t ldc,
+    MLAS_FP16 alpha,
+    MLAS_FP16 beta
+) {
+
+}
+
+}  // namespace hgemm_neon

--- a/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
@@ -926,23 +926,23 @@ void HGemm_TransposedB_Kernel(
     const auto* A_data = reinterpret_cast<const _mlas_fp16_*>(A);
     const auto* B_data = reinterpret_cast<const _mlas_fp16_*>(B);
     auto* C_data = reinterpret_cast<_mlas_fp16_*>(C);
-    auto alpha_f16 = *reinterpret_cast<float16_t*>(&alpha);
-    auto beta_f16 = *reinterpret_cast<float16_t*>(&beta);
+    auto* alpha_f16 = reinterpret_cast<float16_t*>(&alpha);
+    auto* beta_f16 = reinterpret_cast<float16_t*>(&beta);
     if (CountM == 1) {
-        if (beta_f16 == 0.0f16) {
-            HGemm_TransposedB_Kernel_M1<0>(A_data, B_data, C_data, CountN, CountK, ldb, alpha_f16, beta_f16);
-        } else if (beta_f16 == 1.0f) {
-            HGemm_TransposedB_Kernel_M1<1>(A_data, B_data, C_data, CountN, CountK, ldb, alpha_f16, beta_f16);
+        if (*beta_f16 == 0.0f16) {
+            HGemm_TransposedB_Kernel_M1<0>(A_data, B_data, C_data, CountN, CountK, ldb, *alpha_f16, *beta_f16);
+        } else if (*beta_f16 == 1.0f) {
+            HGemm_TransposedB_Kernel_M1<1>(A_data, B_data, C_data, CountN, CountK, ldb, *alpha_f16, *beta_f16);
         } else {
-            HGemm_TransposedB_Kernel_M1<2>(A_data, B_data, C_data, CountN, CountK, ldb, alpha_f16, beta_f16);
+            HGemm_TransposedB_Kernel_M1<2>(A_data, B_data, C_data, CountN, CountK, ldb, *alpha_f16, *beta_f16);
         }
     } else {
-        if (beta_f16 == 0.0f16) {
-            HGemm_TransposedB_Kernel_M2<0>(A_data, B_data, C_data, CountN, CountK, lda, ldb, ldc, alpha_f16, beta_f16);
-        } else if (beta_f16 == 1.0f16) {
-            HGemm_TransposedB_Kernel_M2<1>(A_data, B_data, C_data, CountN, CountK, lda, ldb, ldc, alpha_f16, beta_f16);
+        if (*beta_f16 == 0.0f16) {
+            HGemm_TransposedB_Kernel_M2<0>(A_data, B_data, C_data, CountN, CountK, lda, ldb, ldc, *alpha_f16, *beta_f16);
+        } else if (*beta_f16 == 1.0f16) {
+            HGemm_TransposedB_Kernel_M2<1>(A_data, B_data, C_data, CountN, CountK, lda, ldb, ldc, *alpha_f16, *beta_f16);
         } else {
-            HGemm_TransposedB_Kernel_M2<2>(A_data, B_data, C_data, CountN, CountK, lda, ldb, ldc, alpha_f16, beta_f16);
+            HGemm_TransposedB_Kernel_M2<2>(A_data, B_data, C_data, CountN, CountK, lda, ldb, ldc, *alpha_f16, *beta_f16);
         }
     }
 }
@@ -1489,23 +1489,23 @@ void HGemm_TransposedPackedB_Kernel(
     const auto* A_data = reinterpret_cast<const _mlas_fp16_*>(A);
     const auto* PackedB_data = reinterpret_cast<const _mlas_fp16_*>(PackedB);
     auto* C_data = reinterpret_cast<_mlas_fp16_*>(C);
-    auto alpha_fp16 = *reinterpret_cast<float16_t*>(&alpha);
-    auto beta_fp16 = *reinterpret_cast<float16_t*>(&beta);
+    auto* alpha_fp16 = reinterpret_cast<float16_t*>(&alpha);
+    auto* beta_fp16 = reinterpret_cast<float16_t*>(&beta);
     if (CountM == 1) {
-        if (beta_fp16 == 0.0f16) {
-            HGemm_TransposedPackedB_Kernel_M1<0>(A_data, PackedB_data, C_data, CountN, CountK, alpha_fp16, beta_fp16);
-        } else if (beta_fp16 == 1.0f16) {
-            HGemm_TransposedPackedB_Kernel_M1<1>(A_data, PackedB_data, C_data, CountN, CountK, alpha_fp16, beta_fp16);
+        if (*beta_fp16 == 0.0f16) {
+            HGemm_TransposedPackedB_Kernel_M1<0>(A_data, PackedB_data, C_data, CountN, CountK, *alpha_fp16, *beta_fp16);
+        } else if (*beta_fp16 == 1.0f16) {
+            HGemm_TransposedPackedB_Kernel_M1<1>(A_data, PackedB_data, C_data, CountN, CountK, *alpha_fp16, *beta_fp16);
         } else {
-            HGemm_TransposedPackedB_Kernel_M1<2>(A_data, PackedB_data, C_data, CountN, CountK, alpha_fp16, beta_fp16);
+            HGemm_TransposedPackedB_Kernel_M1<2>(A_data, PackedB_data, C_data, CountN, CountK, *alpha_fp16, *beta_fp16);
         }
     } else {
-        if (beta_fp16 == 0.0f16) {
-            HGemm_TransposedPackedB_Kernel_M2<0>(A_data, PackedB_data, C_data, CountN, CountK, lda, ldc, alpha_fp16, beta_fp16);
-        } else if (beta_fp16 == 1.0f16) {
-            HGemm_TransposedPackedB_Kernel_M2<1>(A_data, PackedB_data, C_data, CountN, CountK, lda, ldc, alpha_fp16, beta_fp16);
+        if (*beta_fp16 == 0.0f16) {
+            HGemm_TransposedPackedB_Kernel_M2<0>(A_data, PackedB_data, C_data, CountN, CountK, lda, ldc, *alpha_fp16, *beta_fp16);
+        } else if (*beta_fp16 == 1.0f16) {
+            HGemm_TransposedPackedB_Kernel_M2<1>(A_data, PackedB_data, C_data, CountN, CountK, lda, ldc, *alpha_fp16, *beta_fp16);
         } else {
-            HGemm_TransposedPackedB_Kernel_M2<2>(A_data, PackedB_data, C_data, CountN, CountK, lda, ldc, alpha_fp16, beta_fp16);
+            HGemm_TransposedPackedB_Kernel_M2<2>(A_data, PackedB_data, C_data, CountN, CountK, lda, ldc, *alpha_fp16, *beta_fp16);
         }
     }
 }

--- a/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
@@ -953,7 +953,7 @@ void HGemm_TransposedB_Kernel(
     }
 }
 
-template <int beta_behaviour> // 0: beta == 0, 1: beta == 1, 2: beta != 0 && beta != 1
+template <int beta_behavior> // 0: beta == 0, 1: beta == 1, 2: beta != 0 && beta != 1
 void HGemm_TransposedPackedB_Kernel_M1(
     const _mlas_fp16_* A,
     const _mlas_fp16_* PackedB,
@@ -1027,14 +1027,14 @@ void HGemm_TransposedPackedB_Kernel_M1(
             PackedB += k * 16;
         }
 
-        if constexpr (beta_behaviour == 1) {
+        if constexpr (beta_behavior == 1) {
             float16x8_t c0 = MlasLoadFloat16x8(C);
             float16x8_t c1 = MlasLoadFloat16x8(C + 8);
             accu0 = vfmaq_n_f16(c0, accu0, alpha);
             accu1 = vfmaq_n_f16(c1, accu1, alpha);
             MlasStoreFloat16x8(C, accu0);
             MlasStoreFloat16x8(C + 8, accu1);
-        } else if constexpr (beta_behaviour == 2) {
+        } else if constexpr (beta_behavior == 2) {
             float16x8_t c0 = MlasLoadFloat16x8(C);
             float16x8_t c1 = MlasLoadFloat16x8(C + 8);
             accu0 = vfmaq_n_f16(vmulq_n_f16(c0, beta), accu0, alpha);
@@ -1091,11 +1091,11 @@ void HGemm_TransposedPackedB_Kernel_M1(
             PackedB += k * 8;
         }
 
-        if constexpr (beta_behaviour == 1) {
+        if constexpr (beta_behavior == 1) {
             float16x8_t c0 = MlasLoadFloat16x8(C);
             accu0 = vfmaq_n_f16(c0, accu0, alpha);
             MlasStoreFloat16x8(C, accu0);
-        } else if constexpr (beta_behaviour == 2) {
+        } else if constexpr (beta_behavior == 2) {
             float16x8_t c0 = MlasLoadFloat16x8(C);
             accu0 = vfmaq_n_f16(vmulq_n_f16(c0, beta), accu0, alpha);
             MlasStoreFloat16x8(C, accu0);
@@ -1153,10 +1153,10 @@ void HGemm_TransposedPackedB_Kernel_M1(
         float16x4_t accu_high = vget_high_f16(accu0);
 
         if (CountN & 4) {
-            if constexpr (beta_behaviour == 1) {
+            if constexpr (beta_behavior == 1) {
                 float16x4_t c0 = MlasLoadFloat16x4(C);
                 MlasStoreFloat16x4(C, vfma_n_f16(c0, accu_low, alpha));
-            } else if constexpr (beta_behaviour == 2) {
+            } else if constexpr (beta_behavior == 2) {
                 float16x4_t c0 = MlasLoadFloat16x4(C);
                 MlasStoreFloat16x4(C, vfma_n_f16(vmul_n_f16(c0, beta), accu_low, alpha));
             } else {
@@ -1167,10 +1167,10 @@ void HGemm_TransposedPackedB_Kernel_M1(
         }
 
         if (CountN) {
-            if constexpr (beta_behaviour == 1) {
+            if constexpr (beta_behavior == 1) {
                 float16x4_t c0 = MlasLoadPartialFloat16x4(C, CountN);
                 MlasStorePartialFloat16x4(C, vfma_n_f16(c0, accu_high, alpha), CountN);
-            } else if constexpr (beta_behaviour == 2) {
+            } else if constexpr (beta_behavior == 2) {
                 float16x4_t c0 = MlasLoadPartialFloat16x4(C, CountN);
                 MlasStorePartialFloat16x4(C, vfma_n_f16(vmul_n_f16(c0, beta), accu_high, alpha), CountN);
             } else {
@@ -1180,7 +1180,7 @@ void HGemm_TransposedPackedB_Kernel_M1(
     }
 }
 
-template <int beta_behaviour> // 0: beta == 0, 1: beta == 1, 2: beta != 0 && beta != 1
+template <int beta_behavior> // 0: beta == 0, 1: beta == 1, 2: beta != 0 && beta != 1
 void HGemm_TransposedPackedB_Kernel_M2(
     const _mlas_fp16_* A,
     const _mlas_fp16_* PackedB,
@@ -1270,7 +1270,7 @@ void HGemm_TransposedPackedB_Kernel_M2(
             PackedB += k * 16;
         }
 
-        if constexpr (beta_behaviour == 1) {
+        if constexpr (beta_behavior == 1) {
             float16x8_t c00 = MlasLoadFloat16x8(C);
             float16x8_t c01 = MlasLoadFloat16x8(C + 8);
             float16x8_t c10 = MlasLoadFloat16x8(C + ldc);
@@ -1283,7 +1283,7 @@ void HGemm_TransposedPackedB_Kernel_M2(
             MlasStoreFloat16x8(C + 8, accu01);
             MlasStoreFloat16x8(C + ldc, accu10);
             MlasStoreFloat16x8(C + ldc + 8, accu11);
-        } else if constexpr (beta_behaviour == 2) {
+        } else if constexpr (beta_behavior == 2) {
             float16x8_t c00 = MlasLoadFloat16x8(C);
             float16x8_t c01 = MlasLoadFloat16x8(C + 8);
             float16x8_t c10 = MlasLoadFloat16x8(C + ldc);
@@ -1359,14 +1359,14 @@ void HGemm_TransposedPackedB_Kernel_M2(
             PackedB += k * 8;
         }
 
-        if constexpr (beta_behaviour == 1) {
+        if constexpr (beta_behavior == 1) {
             float16x8_t c0 = MlasLoadFloat16x8(C);
             float16x8_t c1 = MlasLoadFloat16x8(C + ldc);
             accu00 = vfmaq_n_f16(c0, accu00, alpha);
             accu10 = vfmaq_n_f16(c1, accu10, alpha);
             MlasStoreFloat16x8(C, accu00);
             MlasStoreFloat16x8(C + ldc, accu10);
-        } else if constexpr (beta_behaviour == 2) {
+        } else if constexpr (beta_behavior == 2) {
             float16x8_t c0 = MlasLoadFloat16x8(C);
             float16x8_t c1 = MlasLoadFloat16x8(C + ldc);
             accu00 = vfmaq_n_f16(vmulq_n_f16(c0, beta), accu00, alpha);
@@ -1440,12 +1440,12 @@ void HGemm_TransposedPackedB_Kernel_M2(
         float16x4_t accu1_high = vget_high_f16(accu1);
 
         if (CountN & 4) {
-            if constexpr (beta_behaviour == 1) {
+            if constexpr (beta_behavior == 1) {
                 float16x4_t c0 = MlasLoadFloat16x4(C);
                 float16x4_t c1 = MlasLoadFloat16x4(C + ldc);
                 MlasStoreFloat16x4(C, vfma_n_f16(c0, accu0_low, alpha));
                 MlasStoreFloat16x4(C + ldc, vfma_n_f16(c1, accu1_low, alpha));
-            } else if constexpr (beta_behaviour == 2) {
+            } else if constexpr (beta_behavior == 2) {
                 float16x4_t c0 = MlasLoadFloat16x4(C);
                 float16x4_t c1 = MlasLoadFloat16x4(C + ldc);
                 MlasStoreFloat16x4(C, vfma_n_f16(vmul_n_f16(c0, beta), accu0_low, alpha));
@@ -1458,12 +1458,12 @@ void HGemm_TransposedPackedB_Kernel_M2(
         }
 
         if (CountN) {
-            if constexpr (beta_behaviour == 1) {
+            if constexpr (beta_behavior == 1) {
                 float16x4_t c0 = MlasLoadPartialFloat16x4(C, CountN);
                 float16x4_t c1 = MlasLoadPartialFloat16x4(C + ldc, CountN);
                 MlasStorePartialFloat16x4(C, vfma_n_f16(c0, accu0_high, alpha), CountN);
                 MlasStorePartialFloat16x4(C + ldc, vfma_n_f16(c1, accu1_high, alpha), CountN);
-            } else if constexpr (beta_behaviour == 2) {
+            } else if constexpr (beta_behavior == 2) {
                 float16x4_t c0 = MlasLoadPartialFloat16x4(C, CountN);
                 float16x4_t c1 = MlasLoadPartialFloat16x4(C + ldc, CountN);
                 MlasStorePartialFloat16x4(C, vfma_n_f16(vmul_n_f16(c0, beta), accu0_high, alpha), CountN);

--- a/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
@@ -327,6 +327,20 @@ float16x8_t maq_lane_f16_accu(float16x8_t accu0, float16x8_t v0, float16x8_t v1,
 }
 
 MLAS_FORCEINLINE
+float16x8_t maq_laneq_f16_accu(float16x8_t accu0, float16x8_t v0, float16x8_t v1, float16x8_t v2, float16x8_t v3,
+                               float16x8_t v4, float16x8_t v5, float16x8_t v6, float16x8_t v7, float16x8_t a0) {
+    accu0 = vfmaq_laneq_f16(accu0, v0, a0, 0);
+    accu0 = vfmaq_laneq_f16(accu0, v1, a0, 1);
+    accu0 = vfmaq_laneq_f16(accu0, v2, a0, 2);
+    accu0 = vfmaq_laneq_f16(accu0, v3, a0, 3);
+    accu0 = vfmaq_laneq_f16(accu0, v4, a0, 4);
+    accu0 = vfmaq_laneq_f16(accu0, v5, a0, 5);
+    accu0 = vfmaq_laneq_f16(accu0, v6, a0, 6);
+    accu0 = vfmaq_laneq_f16(accu0, v7, a0, 7);
+    return accu0;
+}
+
+MLAS_FORCEINLINE
 float16x4_t ma_lane_f16_accu(float16x4_t accu, float16x4_t v0, float16x4_t v1, float16x4_t v2, float16x4_t v3,
                              float16x4_t a0) {
     accu = vfma_lane_f16(accu, v0, a0, 0);
@@ -336,6 +350,7 @@ float16x4_t ma_lane_f16_accu(float16x4_t accu, float16x4_t v0, float16x4_t v1, f
     return accu;
 }
 
+template <int beta_behavior> // 0: beta == 0.0f16, 1: beta == 1.0f16, 2: beta != 0.0f16 && beta != 1.0f16
 void HGemm_TransposedB_Kernel_M1(
     const _mlas_fp16_* A_data,
     const _mlas_fp16_* B_data,
@@ -427,11 +442,11 @@ void HGemm_TransposedB_Kernel_M1(
             }
         }
 
-        if (beta == 1.0f16) {
+        if const (beta_behavior == 1) {
             float16x8_t c = MlasLoadFloat16x8(C_data);
             accu0 = vfmaq_n_f16(c, accu0, alpha);
             MlasStoreFloat16x8(C_data, accu0);
-        } else if (beta != 0.0f16) {
+        } else if const (beta_behavior == 2) {
             float16x8_t c = MlasLoadFloat16x8(C_data);
             accu0 = vfmaq_n_f16(vmulq_n_f16(c, beta), accu0, alpha);
             MlasStoreFloat16x8(C_data, accu0);
@@ -491,11 +506,11 @@ void HGemm_TransposedB_Kernel_M1(
             }
         }
 
-        if (beta == 1.0f16) {
+        if const (beta_behavior == 1) {
             float16x4_t c = MlasLoadFloat16x4(C_data);
             accu = vfma_n_f16(c, accu, alpha);
             MlasStoreFloat16x4(C_data, accu);
-        } else if (beta != 0.0f16) {
+        } else if const (beta_behavior == 2) {
             float16x4_t c = MlasLoadFloat16x4(C_data);
             accu = vfma_n_f16(vmul_n_f16(c, beta), accu, alpha);
             MlasStoreFloat16x4(C_data, accu);
@@ -559,11 +574,11 @@ void HGemm_TransposedB_Kernel_M1(
             }
         }
 
-        if (beta == 1.0f16) {
+        if const (beta_behavior == 1) {
             float16x4_t c = MlasLoadPartialFloat16x4(C_data, CountN);
             accu = vfma_n_f16(c, accu, alpha);
             MlasStorePartialFloat16x4(C_data, accu, CountN);
-        } else if (beta != 0.0f16) {
+        } else if const (beta_behavior == 2) {
             float16x4_t c = MlasLoadPartialFloat16x4(C_data, CountN);
             accu = vfma_n_f16(vmul_n_f16(c, beta), accu, alpha);
             MlasStorePartialFloat16x4(C_data, accu, CountN);
@@ -574,6 +589,7 @@ void HGemm_TransposedB_Kernel_M1(
     }
 }
 
+template <int beta_behavior> // 0: beta == 0.0f16, 1: beta == 1.0f16, 2: beta != 0.0f16 && beta != 1.0f16
 void HGemm_TransposedB_Kernel_M2(
     const _mlas_fp16_* A,
     const _mlas_fp16_* B,
@@ -690,14 +706,14 @@ void HGemm_TransposedB_Kernel_M2(
             }
         }
 
-        if (beta == 1.0f16) {
+        if const (beta_behavior == 1) {
             float16x8_t c0 = MlasLoadFloat16x8(C_data);
             float16x8_t c1 = MlasLoadFloat16x8(C_data + ldc);
             accu00 = vfmaq_n_f16(c0, accu00, alpha);
             accu10 = vfmaq_n_f16(c1, accu10, alpha);
             MlasStoreFloat16x8(C_data, accu00);
             MlasStoreFloat16x8(C_data + ldc, accu10);
-        } else if (beta != 0.0f16) {
+        } else if const (beta_behavior == 2) {
             float16x8_t c0 = MlasLoadFloat16x8(C_data);
             float16x8_t c1 = MlasLoadFloat16x8(C_data + ldc);
             accu00 = vfmaq_n_f16(vmulq_n_f16(c0, beta), accu00, alpha);
@@ -780,14 +796,14 @@ void HGemm_TransposedB_Kernel_M2(
             }
         }
 
-        if (beta == 1.0f16) {
+        if const (beta_behavior == 1) {
             float16x4_t c0 = MlasLoadFloat16x4(C_data);
             float16x4_t c1 = MlasLoadFloat16x4(C_data + ldc);
             accu0 = vfma_n_f16(c0, accu0, alpha);
             accu1 = vfma_n_f16(c1, accu1, alpha);
             MlasStoreFloat16x4(C_data, accu0);
             MlasStoreFloat16x4(C_data + ldc, accu1);
-        } else if (beta != 0.0f16) {
+        } else if const (beta_behavior == 2) {
             float16x4_t c0 = MlasLoadFloat16x4(C_data);
             float16x4_t c1 = MlasLoadFloat16x4(C_data + ldc);
             accu0 = vfma_n_f16(vmul_n_f16(c0, beta), accu0, alpha);
@@ -870,14 +886,14 @@ void HGemm_TransposedB_Kernel_M2(
             }
         }
 
-        if (beta == 1.0f16) {
+        if const (beta_behavior == 1) {
             float16x4_t c0 = MlasLoadPartialFloat16x4(C_data, CountN);
             float16x4_t c1 = MlasLoadPartialFloat16x4(C_data + ldc, CountN);
             accu_0 = vfma_n_f16(c0, accu_0, alpha);
             accu_1 = vfma_n_f16(c1, accu_1, alpha);
             MlasStorePartialFloat16x4(C_data, accu_0, CountN);
             MlasStorePartialFloat16x4(C_data + ldc, accu_1, CountN);
-        } else if (beta != 0.0f16) {
+        } else if const (beta_behavior == 2) {
             float16x4_t c0 = MlasLoadPartialFloat16x4(C_data, CountN);
             float16x4_t c1 = MlasLoadPartialFloat16x4(C_data + ldc, CountN);
             accu_0 = vfma_n_f16(vmul_n_f16(c0, beta), accu_0, alpha);
@@ -913,16 +929,28 @@ void HGemm_TransposedB_Kernel(
     const auto* A_data = reinterpret_cast<const _mlas_fp16_*>(A);
     const auto* B_data = reinterpret_cast<const _mlas_fp16_*>(B);
     auto* C_data = reinterpret_cast<_mlas_fp16_*>(C);
+    auto alpha_f16 = *reinterpret_cast<float16_t*>(&alpha);
+    auto beta_f16 = *reinterpret_cast<float16_t*>(&beta);
     if (CountM == 1) {
-        HGemm_TransposedB_Kernel_M1(A_data, B_data, C_data, CountM, CountN, CountK, lda, ldb, ldc,
-            reinterpret_cast<float16_t>(alpha), reinterpret_cast<float16_t>(beta));
+        if (beta_f16 == 0.0f16) {
+            HGemm_TransposedB_Kernel_M1<0>(A_data, B_data, C_data, CountM, CountN, CountK, lda, ldb, ldc, alpha_f16, beta_f16);
+        } else if (beta_f16 == 1.0f) {
+            HGemm_TransposedB_Kernel_M1<1>(A_data, B_data, C_data, CountM, CountN, CountK, lda, ldb, ldc, alpha_f16, beta_f16);
+        } else {
+            HGemm_TransposedB_Kernel_M1<2>(A_data, B_data, C_data, CountM, CountN, CountK, lda, ldb, ldc, alpha_f16, beta_f16);
+        }
     } else {
-        HGemm_TransposedB_Kernel_M2(A_data, B_data, C_data, CountM, CountN, CountK, lda, ldb, ldc,
-            reinterpret_cast<float16_t>(alpha), reinterpret_cast<float16_t>(beta));
+        if (beta_f16 == 0.0f16) {
+            HGemm_TransposedB_Kernel_M2<0>(A_data, B_data, C_data, CountM, CountN, CountK, lda, ldb, ldc, alpha_f16, beta_f16);
+        } else if (beta_f16 == 1.0f16) {
+            HGemm_TransposedB_Kernel_M2<1>(A_data, B_data, C_data, CountM, CountN, CountK, lda, ldb, ldc, alpha_f16, beta_f16);
+        } else {
+            HGemm_TransposedB_Kernel_M2<2>(A_data, B_data, C_data, CountM, CountN, CountK, lda, ldb, ldc, alpha_f16, beta_f16);
+        }
     }
 }
 
-// TODO: refactor
+template <int beta_behaviour> // 0: beta == 0, 1: beta == 1, 2: beta != 0 && beta != 1
 void HGemm_TransposedPackedB_Kernel_M1(
     const _mlas_fp16_* A,
     const _mlas_fp16_* PackedB,
@@ -958,22 +986,8 @@ void HGemm_TransposedPackedB_Kernel_M1(
             float16x8_t b70 = MlasLoadFloat16x8(PackedB + 112);
             float16x8_t b71 = MlasLoadFloat16x8(PackedB + 120);
             float16x8_t a0 = MlasLoadFloat16x8(a);
-            accu0 = vfmaq_laneq_f16(accu0, b00, a0, 0);
-            accu1 = vfmaq_laneq_f16(accu1, b01, a0, 0);
-            accu0 = vfmaq_laneq_f16(accu0, b10, a0, 1);
-            accu1 = vfmaq_laneq_f16(accu1, b11, a0, 1);
-            accu0 = vfmaq_laneq_f16(accu0, b20, a0, 2);
-            accu1 = vfmaq_laneq_f16(accu1, b21, a0, 2);
-            accu0 = vfmaq_laneq_f16(accu0, b30, a0, 3);
-            accu1 = vfmaq_laneq_f16(accu1, b31, a0, 3);
-            accu0 = vfmaq_laneq_f16(accu0, b40, a0, 4);
-            accu1 = vfmaq_laneq_f16(accu1, b41, a0, 4);
-            accu0 = vfmaq_laneq_f16(accu0, b50, a0, 5);
-            accu1 = vfmaq_laneq_f16(accu1, b51, a0, 5);
-            accu0 = vfmaq_laneq_f16(accu0, b60, a0, 6);
-            accu1 = vfmaq_laneq_f16(accu1, b61, a0, 6);
-            accu0 = vfmaq_laneq_f16(accu0, b70, a0, 7);
-            accu1 = vfmaq_laneq_f16(accu1, b71, a0, 7);
+            accu0 = maq_laneq_f16_accu(accu0, b00, b10, b20, b30, b40, b50, b60, b70, a0);
+            accu1 = maq_laneq_f16_accu(accu1, b01, b11, b21, b31, b41, b51, b61, b71, a0);
         }
 
         if (k & 4) {
@@ -986,14 +1000,8 @@ void HGemm_TransposedPackedB_Kernel_M1(
             float16x8_t b30 = MlasLoadFloat16x8(PackedB + 48);
             float16x8_t b31 = MlasLoadFloat16x8(PackedB + 56);
             float16x4_t a0 = MlasLoadFloat16x4(a);
-            accu0 = vfmaq_lane_f16(accu0, b00, a0, 0);
-            accu1 = vfmaq_lane_f16(accu1, b01, a0, 0);
-            accu0 = vfmaq_lane_f16(accu0, b10, a0, 1);
-            accu1 = vfmaq_lane_f16(accu1, b11, a0, 1);
-            accu0 = vfmaq_lane_f16(accu0, b20, a0, 2);
-            accu1 = vfmaq_lane_f16(accu1, b21, a0, 2);
-            accu0 = vfmaq_lane_f16(accu0, b30, a0, 3);
-            accu1 = vfmaq_lane_f16(accu1, b31, a0, 3);
+            accu0 = maq_lane_f16_accu(accu0, b00, b10, b20, b30, a0);
+            accu1 = maq_lane_f16_accu(accu1, b01, b11, b21, b31, a0);
             k -= 4, a += 4, PackedB += 4 * 16;
         }
 
@@ -1019,14 +1027,14 @@ void HGemm_TransposedPackedB_Kernel_M1(
             PackedB += k * 16;
         }
 
-        if (beta == 1.0f16) {
+        if const (beta_behaviour == 1) {
             float16x8_t c0 = MlasLoadFloat16x8(C);
             float16x8_t c1 = MlasLoadFloat16x8(C + 8);
             accu0 = vfmaq_n_f16(c0, accu0, alpha);
             accu1 = vfmaq_n_f16(c1, accu1, alpha);
             MlasStoreFloat16x8(C, accu0);
             MlasStoreFloat16x8(C + 8, accu1);
-        } else if (beta != 0.0f16) {
+        } else if const (beta_behaviour == 2) {
             float16x8_t c0 = MlasLoadFloat16x8(C);
             float16x8_t c1 = MlasLoadFloat16x8(C + 8);
             accu0 = vfmaq_n_f16(vmulq_n_f16(c0, beta), accu0, alpha);
@@ -1055,14 +1063,7 @@ void HGemm_TransposedPackedB_Kernel_M1(
             float16x8_t b6 = MlasLoadFloat16x8(PackedB + 48);
             float16x8_t b7 = MlasLoadFloat16x8(PackedB + 56);
             float16x8_t a0 = MlasLoadFloat16x8(a);
-            accu0 = vfmaq_laneq_f16(accu0, b0, a0, 0);
-            accu0 = vfmaq_laneq_f16(accu0, b1, a0, 1);
-            accu0 = vfmaq_laneq_f16(accu0, b2, a0, 2);
-            accu0 = vfmaq_laneq_f16(accu0, b3, a0, 3);
-            accu0 = vfmaq_laneq_f16(accu0, b4, a0, 4);
-            accu0 = vfmaq_laneq_f16(accu0, b5, a0, 5);
-            accu0 = vfmaq_laneq_f16(accu0, b6, a0, 6);
-            accu0 = vfmaq_laneq_f16(accu0, b7, a0, 7);
+            accu0 = maq_laneq_f16_accu(accu0, b0, b1, b2, b3, b4, b5, b6, b7, a0);
         }
 
         if (k & 4) {
@@ -1071,10 +1072,7 @@ void HGemm_TransposedPackedB_Kernel_M1(
             float16x8_t b2 = MlasLoadFloat16x8(PackedB + 16);
             float16x8_t b3 = MlasLoadFloat16x8(PackedB + 24);
             float16x4_t a0 = MlasLoadFloat16x4(a);
-            accu0 = vfmaq_lane_f16(accu0, b0, a0, 0);
-            accu0 = vfmaq_lane_f16(accu0, b1, a0, 1);
-            accu0 = vfmaq_lane_f16(accu0, b2, a0, 2);
-            accu0 = vfmaq_lane_f16(accu0, b3, a0, 3);
+            accu0 = maq_lane_f16_accu(accu0, b0, b1, b2, b3, a0);
             k -= 4, a += 4, PackedB += 4 * 8;
         }
 
@@ -1093,11 +1091,11 @@ void HGemm_TransposedPackedB_Kernel_M1(
             PackedB += k * 8;
         }
 
-        if (beta == 1.0f16) {
+        if const (beta_behaviour == 1) {
             float16x8_t c0 = MlasLoadFloat16x8(C);
             accu0 = vfmaq_n_f16(c0, accu0, alpha);
             MlasStoreFloat16x8(C, accu0);
-        } else if (beta != 0.0f16) {
+        } else if const (beta_behaviour == 2) {
             float16x8_t c0 = MlasLoadFloat16x8(C);
             accu0 = vfmaq_n_f16(vmulq_n_f16(c0, beta), accu0, alpha);
             MlasStoreFloat16x8(C, accu0);
@@ -1123,14 +1121,7 @@ void HGemm_TransposedPackedB_Kernel_M1(
             float16x8_t b6 = MlasLoadFloat16x8(PackedB + 48);
             float16x8_t b7 = MlasLoadFloat16x8(PackedB + 56);
             float16x8_t a0 = MlasLoadFloat16x8(a);
-            accu0 = vfmaq_laneq_f16(accu0, b0, a0, 0);
-            accu0 = vfmaq_laneq_f16(accu0, b1, a0, 1);
-            accu0 = vfmaq_laneq_f16(accu0, b2, a0, 2);
-            accu0 = vfmaq_laneq_f16(accu0, b3, a0, 3);
-            accu0 = vfmaq_laneq_f16(accu0, b4, a0, 4);
-            accu0 = vfmaq_laneq_f16(accu0, b5, a0, 5);
-            accu0 = vfmaq_laneq_f16(accu0, b6, a0, 6);
-            accu0 = vfmaq_laneq_f16(accu0, b7, a0, 7);
+            accu0 = maq_laneq_f16_accu(accu0, b0, b1, b2, b3, b4, b5, b6, b7, a0);
         }
 
         if (k & 4) {
@@ -1139,10 +1130,7 @@ void HGemm_TransposedPackedB_Kernel_M1(
             float16x8_t b2 = MlasLoadFloat16x8(PackedB + 16);
             float16x8_t b3 = MlasLoadFloat16x8(PackedB + 24);
             float16x4_t a0 = MlasLoadFloat16x4(a);
-            accu0 = vfmaq_lane_f16(accu0, b0, a0, 0);
-            accu0 = vfmaq_lane_f16(accu0, b1, a0, 1);
-            accu0 = vfmaq_lane_f16(accu0, b2, a0, 2);
-            accu0 = vfmaq_lane_f16(accu0, b3, a0, 3);
+            accu0 = maq_lane_f16_accu(accu0, b0, b1, b2, b3, a0);
             k -= 4, a += 4, PackedB += 4 * 8;
         }
 
@@ -1165,10 +1153,10 @@ void HGemm_TransposedPackedB_Kernel_M1(
         float16x4_t accu_high = vget_high_f16(accu0);
 
         if (CountN & 4) {
-            if (beta == 1.0f16) {
+            if const (beta_behaviour == 1) {
                 float16x4_t c0 = MlasLoadFloat16x4(C);
                 MlasStoreFloat16x4(C, vfma_n_f16(c0, accu_low, alpha));
-            } else if (beta != 0.0f16) {
+            } else if const (beta_behaviour == 2) {
                 float16x4_t c0 = MlasLoadFloat16x4(C);
                 MlasStoreFloat16x4(C, vfma_n_f16(vmul_n_f16(c0, beta), accu_low, alpha));
             } else {
@@ -1179,10 +1167,10 @@ void HGemm_TransposedPackedB_Kernel_M1(
         }
 
         if (CountN) {
-            if (beta == 1.0f16) {
+            if const (beta_behaviour == 1) {
                 float16x4_t c0 = MlasLoadPartialFloat16x4(C, CountN);
                 MlasStorePartialFloat16x4(C, vfma_n_f16(c0, accu_high, alpha), CountN);
-            } else if (beta != 0.0f16) {
+            } else if const (beta_behaviour == 2) {
                 float16x4_t c0 = MlasLoadFloat16x4(C, CountN);
                 MlasStorePartialFloat16x4(C, vfma_n_f16(vmul_n_f16(c0, beta), accu_high, alpha), CountN);
             } else {
@@ -1192,7 +1180,7 @@ void HGemm_TransposedPackedB_Kernel_M1(
     }
 }
 
-// TODO: add M2, refactor
+template <int beta_behaviour> // 0: beta == 0, 1: beta == 1, 2: beta != 0 && beta != 1
 void HGemm_TransposedPackedB_Kernel_M2(
     const _mlas_fp16_* A,
     const _mlas_fp16_* PackedB,
@@ -1231,22 +1219,10 @@ void HGemm_TransposedPackedB_Kernel_M2(
             float16x8_t b71 = MlasLoadFloat16x8(PackedB + 120);
             float16x8_t a0 = MlasLoadFloat16x8(a);
             float16x8_t a1 = MlasLoadFloat16x8(a + lda);
-            accu00 = vfmaq_laneq_f16(accu00, b00, a0, 0);
-            accu01 = vfmaq_laneq_f16(accu01, b01, a0, 0);
-            accu00 = vfmaq_laneq_f16(accu00, b10, a0, 1);
-            accu01 = vfmaq_laneq_f16(accu01, b11, a0, 1);
-            accu00 = vfmaq_laneq_f16(accu00, b20, a0, 2);
-            accu01 = vfmaq_laneq_f16(accu01, b21, a0, 2);
-            accu00 = vfmaq_laneq_f16(accu00, b30, a0, 3);
-            accu01 = vfmaq_laneq_f16(accu01, b31, a0, 3);
-            accu00 = vfmaq_laneq_f16(accu00, b40, a0, 4);
-            accu01 = vfmaq_laneq_f16(accu01, b41, a0, 4);
-            accu00 = vfmaq_laneq_f16(accu00, b50, a0, 5);
-            accu01 = vfmaq_laneq_f16(accu01, b51, a0, 5);
-            accu00 = vfmaq_laneq_f16(accu00, b60, a0, 6);
-            accu01 = vfmaq_laneq_f16(accu01, b61, a0, 6);
-            accu00 = vfmaq_laneq_f16(accu00, b70, a0, 7);
-            accu01 = vfmaq_laneq_f16(accu01, b71, a0, 7);
+            accu00 = maq_laneq_f16_accu(accu00, b00, b10, b20, b30, b40, b50, b60, b70, a0);
+            accu01 = maq_laneq_f16_accu(accu01, b01, b11, b21, b31, b41, b51, b61, b71, a0);
+            accu10 = maq_laneq_f16_accu(accu10, b00, b10, b20, b30, b40, b50, b60, b70, a1);
+            accu11 = maq_laneq_f16_accu(accu11, b01, b11, b21, b31, b41, b51, b61, b71, a1);
         }
 
         if (k & 4) {
@@ -1259,65 +1235,85 @@ void HGemm_TransposedPackedB_Kernel_M2(
             float16x8_t b30 = MlasLoadFloat16x8(PackedB + 48);
             float16x8_t b31 = MlasLoadFloat16x8(PackedB + 56);
             float16x4_t a0 = MlasLoadFloat16x4(a);
-            accu0 = vfmaq_lane_f16(accu0, b00, a0, 0);
-            accu1 = vfmaq_lane_f16(accu1, b01, a0, 0);
-            accu0 = vfmaq_lane_f16(accu0, b10, a0, 1);
-            accu1 = vfmaq_lane_f16(accu1, b11, a0, 1);
-            accu0 = vfmaq_lane_f16(accu0, b20, a0, 2);
-            accu1 = vfmaq_lane_f16(accu1, b21, a0, 2);
-            accu0 = vfmaq_lane_f16(accu0, b30, a0, 3);
-            accu1 = vfmaq_lane_f16(accu1, b31, a0, 3);
+            float16x4_t a1 = MlasLoadFloat16x4(a + lda);
+            accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
+            accu01 = maq_lane_f16_accu(accu01, b01, b11, b21, b31, a0);
+            accu10 = maq_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
+            accu11 = maq_lane_f16_accu(accu11, b01, b11, b21, b31, a1);
             k -= 4, a += 4, PackedB += 4 * 16;
         }
 
         if (k > 0) {
             float16x4_t a0 = MlasLoadPartialFloat16x4(a, k);
+            float16x4_t a1 = MlasLoadPartialFloat16x4(a + lda, k);
             float16x8_t b00 = MlasLoadFloat16x8(PackedB);
             float16x8_t b01 = MlasLoadFloat16x8(PackedB + 8);
-            accu0 = vfmaq_lane_f16(accu0, b00, a0, 0);
-            accu1 = vfmaq_lane_f16(accu1, b01, a0, 0);
+            accu00 = vfmaq_lane_f16(accu00, b00, a0, 0);
+            accu01 = vfmaq_lane_f16(accu01, b01, a0, 0);
+            accu10 = vfmaq_lane_f16(accu10, b00, a1, 0);
+            accu11 = vfmaq_lane_f16(accu11, b01, a1, 0);
             if (k > 1) {
                 float16x8_t b10 = MlasLoadFloat16x8(PackedB + 16);
                 float16x8_t b11 = MlasLoadFloat16x8(PackedB + 24);
-                accu0 = vfmaq_lane_f16(accu0, b10, a0, 1);
-                accu1 = vfmaq_lane_f16(accu1, b11, a0, 1);
+                accu00 = vfmaq_lane_f16(accu00, b10, a0, 1);
+                accu01 = vfmaq_lane_f16(accu01, b11, a0, 1);
+                accu10 = vfmaq_lane_f16(accu10, b10, a1, 1);
+                accu11 = vfmaq_lane_f16(accu11, b11, a1, 1);
             }
             if (k > 2) {
                 float16x8_t b20 = MlasLoadFloat16x8(PackedB + 32);
                 float16x8_t b21 = MlasLoadFloat16x8(PackedB + 40);
-                accu0 = vfmaq_lane_f16(accu0, b20, a0, 2);
-                accu1 = vfmaq_lane_f16(accu1, b21, a0, 2);
+                accu00 = vfmaq_lane_f16(accu00, b20, a0, 2);
+                accu01 = vfmaq_lane_f16(accu01, b21, a0, 2);
+                accu10 = vfmaq_lane_f16(accu10, b20, a1, 2);
+                accu11 = vfmaq_lane_f16(accu11, b21, a1, 2);
             }
-
             PackedB += k * 16;
         }
 
-        if (beta == 1.0f16) {
-            float16x8_t c0 = MlasLoadFloat16x8(C);
-            float16x8_t c1 = MlasLoadFloat16x8(C + 8);
-            accu0 = vfmaq_n_f16(c0, accu0, alpha);
-            accu1 = vfmaq_n_f16(c1, accu1, alpha);
-            MlasStoreFloat16x8(C, accu0);
-            MlasStoreFloat16x8(C + 8, accu1);
-        } else if (beta != 0.0f16) {
-            float16x8_t c0 = MlasLoadFloat16x8(C);
-            float16x8_t c1 = MlasLoadFloat16x8(C + 8);
-            accu0 = vfmaq_n_f16(vmulq_n_f16(c0, beta), accu0, alpha);
-            accu1 = vfmaq_n_f16(vmulq_n_f16(c1, beta), accu1, alpha);
-            MlasStoreFloat16x8(C, accu0);
-            MlasStoreFloat16x8(C + 8, accu1);
+        if const (beta_behaviour == 1) {
+            float16x8_t c00 = MlasLoadFloat16x8(C);
+            float16x8_t c01 = MlasLoadFloat16x8(C + 8);
+            float16x8_t c10 = MlasLoadFloat16x8(C + ldc);
+            float16x8_t c11 = MlasLoadFloat16x8(C + ldc + 8);
+            accu00 = vfmaq_n_f16(c00, accu00, alpha);
+            accu01 = vfmaq_n_f16(c01, accu01, alpha);
+            accu10 = vfmaq_n_f16(c10, accu10, alpha);
+            accu11 = vfmaq_n_f16(c11, accu11, alpha);
+            MlasStoreFloat16x8(C, accu00);
+            MlasStoreFloat16x8(C + 8, accu01);
+            MlasStoreFloat16x8(C + ldc, accu10);
+            MlasStoreFloat16x8(C + ldc + 8, accu11);
+        } else if const (beta_behaviour == 2) {
+            float16x8_t c00 = MlasLoadFloat16x8(C);
+            float16x8_t c01 = MlasLoadFloat16x8(C + 8);
+            float16x8_t c10 = MlasLoadFloat16x8(C + ldc);
+            float16x8_t c11 = MlasLoadFloat16x8(C + ldc + 8);
+            accu00 = vfmaq_n_f16(vmulq_n_f16(c00, beta), accu00, alpha);
+            accu01 = vfmaq_n_f16(vmulq_n_f16(c01, beta), accu01, alpha);
+            accu10 = vfmaq_n_f16(vmulq_n_f16(c10, beta), accu10, alpha);
+            accu11 = vfmaq_n_f16(vmulq_n_f16(c11, beta), accu11, alpha);
+            MlasStoreFloat16x8(C, accu00);
+            MlasStoreFloat16x8(C + 8, accu01);
+            MlasStoreFloat16x8(C + ldc, accu10);
+            MlasStoreFloat16x8(C + ldc + 8, accu11);
         } else {
-            accu0 = vmulq_n_f16(accu0, alpha);
-            accu1 = vmulq_n_f16(accu1, alpha);
-            MlasStoreFloat16x8(C, accu0);
-            MlasStoreFloat16x8(C + 8, accu1);
+            accu00 = vmulq_n_f16(accu00, alpha);
+            accu01 = vmulq_n_f16(accu01, alpha);
+            accu10 = vmulq_n_f16(accu10, alpha);
+            accu11 = vmulq_n_f16(accu11, alpha);
+            MlasStoreFloat16x8(C, accu00);
+            MlasStoreFloat16x8(C + 8, accu01);
+            MlasStoreFloat16x8(C + ldc, accu10);
+            MlasStoreFloat16x8(C + ldc + 8, accu11);
         }
     }
 
     if (CountN & 8) {
         const auto* a = A;
         size_t k = CountK;
-        float16x8_t accu0 = MlasZeroFloat16x8();
+        float16x8_t accu00 = MlasZeroFloat16x8();
+        float16x8_t accu10 = MlasZeroFloat16x8();
         for (; k >= 8; k -= 8, a += 8, PackedB += 8 * 8) {
             float16x8_t b0 = MlasLoadFloat16x8(PackedB);
             float16x8_t b1 = MlasLoadFloat16x8(PackedB + 8);
@@ -1328,14 +1324,9 @@ void HGemm_TransposedPackedB_Kernel_M2(
             float16x8_t b6 = MlasLoadFloat16x8(PackedB + 48);
             float16x8_t b7 = MlasLoadFloat16x8(PackedB + 56);
             float16x8_t a0 = MlasLoadFloat16x8(a);
-            accu0 = vfmaq_laneq_f16(accu0, b0, a0, 0);
-            accu0 = vfmaq_laneq_f16(accu0, b1, a0, 1);
-            accu0 = vfmaq_laneq_f16(accu0, b2, a0, 2);
-            accu0 = vfmaq_laneq_f16(accu0, b3, a0, 3);
-            accu0 = vfmaq_laneq_f16(accu0, b4, a0, 4);
-            accu0 = vfmaq_laneq_f16(accu0, b5, a0, 5);
-            accu0 = vfmaq_laneq_f16(accu0, b6, a0, 6);
-            accu0 = vfmaq_laneq_f16(accu0, b7, a0, 7);
+            float16x8_t a1 = MlasLoadFloat16x8(a + lda);
+            accu00 = maq_laneq_f16_accu(accu00, b0, b1, b2, b3, b4, b5, b6, b7, a0);
+            accu10 = maq_laneq_f16_accu(accu10, b0, b1, b2, b3, b4, b5, b6, b7, a1);
         }
 
         if (k & 4) {
@@ -1344,39 +1335,50 @@ void HGemm_TransposedPackedB_Kernel_M2(
             float16x8_t b2 = MlasLoadFloat16x8(PackedB + 16);
             float16x8_t b3 = MlasLoadFloat16x8(PackedB + 24);
             float16x4_t a0 = MlasLoadFloat16x4(a);
-            accu0 = vfmaq_lane_f16(accu0, b0, a0, 0);
-            accu0 = vfmaq_lane_f16(accu0, b1, a0, 1);
-            accu0 = vfmaq_lane_f16(accu0, b2, a0, 2);
-            accu0 = vfmaq_lane_f16(accu0, b3, a0, 3);
+            float16x4_t a1 = MlasLoadFloat16x4(a + lda);
+            accu00 = maq_lane_f16_accu(accu00, b0, b1, b2, b3, a0);
+            accu10 = maq_lane_f16_accu(accu10, b0, b1, b2, b3, a1);
             k -= 4, a += 4, PackedB += 4 * 8;
         }
 
         if (k > 0) {
             float16x4_t a0 = MlasLoadPartialFloat16x4(a, k);
+            float16x4_t a1 = MlasLoadPartialFloat16x4(a + lda, k);
             float16x8_t b0 = MlasLoadFloat16x8(PackedB);
-            accu0 = vfmaq_lane_f16(accu0, b0, a0, 0);
+            accu00 = vfmaq_lane_f16(accu00, b0, a0, 0);
+            accu10 = vfmaq_lane_f16(accu10, b0, a1, 0);
             if (k > 1) {
                 float16x8_t b1 = MlasLoadFloat16x8(PackedB + 8);
-                accu0 = vfmaq_lane_f16(accu0, b1, a0, 1);
+                accu00 = vfmaq_lane_f16(accu00, b1, a0, 1);
+                accu10 = vfmaq_lane_f16(accu10, b1, a1, 1);
             }
             if (k > 2) {
                 float16x8_t b2 = MlasLoadFloat16x8(PackedB + 16);
-                accu0 = vfmaq_lane_f16(accu0, b2, a0, 2);
+                accu00 = vfmaq_lane_f16(accu00, b2, a0, 2);
+                accu10 = vfmaq_lane_f16(accu10, b2, a1, 2);
             }
             PackedB += k * 8;
         }
 
-        if (beta == 1.0f16) {
+        if const (beta_behaviour == 1) {
             float16x8_t c0 = MlasLoadFloat16x8(C);
-            accu0 = vfmaq_n_f16(c0, accu0, alpha);
-            MlasStoreFloat16x8(C, accu0);
-        } else if (beta != 0.0f16) {
+            float16x8_t c1 = MlasLoadFloat16x8(C + ldc);
+            accu00 = vfmaq_n_f16(c0, accu00, alpha);
+            accu10 = vfmaq_n_f16(c1, accu10, alpha);
+            MlasStoreFloat16x8(C, accu00);
+            MlasStoreFloat16x8(C + ldc, accu10);
+        } else if const (beta_behaviour == 2) {
             float16x8_t c0 = MlasLoadFloat16x8(C);
-            accu0 = vfmaq_n_f16(vmulq_n_f16(c0, beta), accu0, alpha);
-            MlasStoreFloat16x8(C, accu0);
+            float16x8_t c1 = MlasLoadFloat16x8(C + ldc);
+            accu00 = vfmaq_n_f16(vmulq_n_f16(c0, beta), accu00, alpha);
+            accu10 = vfmaq_n_f16(vmulq_n_f16(c1, beta), accu10, alpha);
+            MlasStoreFloat16x8(C, accu00);
+            MlasStoreFloat16x8(C + ldc, accu10);
         } else {
-            accu0 = vmulq_n_f16(accu0, alpha);
-            MlasStoreFloat16x8(C, accu0);
+            accu00 = vmulq_n_f16(accu00, alpha);
+            accu10 = vmulq_n_f16(accu10, alpha);
+            MlasStoreFloat16x8(C, accu00);
+            MlasStoreFloat16x8(C + ldc, accu10);
         }
 
         CountN -= 8, C += 8;
@@ -1386,6 +1388,7 @@ void HGemm_TransposedPackedB_Kernel_M2(
         const auto* a = A;
         size_t k = CountK;
         float16x8_t accu0 = MlasZeroFloat16x8();
+        float16x8_t accu1 = MlasZeroFloat16x8();
         for (; k >= 8; k -= 8, a += 8, PackedB += 8 * 8) {
             float16x8_t b0 = MlasLoadFloat16x8(PackedB);
             float16x8_t b1 = MlasLoadFloat16x8(PackedB + 8);
@@ -1396,14 +1399,9 @@ void HGemm_TransposedPackedB_Kernel_M2(
             float16x8_t b6 = MlasLoadFloat16x8(PackedB + 48);
             float16x8_t b7 = MlasLoadFloat16x8(PackedB + 56);
             float16x8_t a0 = MlasLoadFloat16x8(a);
-            accu0 = vfmaq_laneq_f16(accu0, b0, a0, 0);
-            accu0 = vfmaq_laneq_f16(accu0, b1, a0, 1);
-            accu0 = vfmaq_laneq_f16(accu0, b2, a0, 2);
-            accu0 = vfmaq_laneq_f16(accu0, b3, a0, 3);
-            accu0 = vfmaq_laneq_f16(accu0, b4, a0, 4);
-            accu0 = vfmaq_laneq_f16(accu0, b5, a0, 5);
-            accu0 = vfmaq_laneq_f16(accu0, b6, a0, 6);
-            accu0 = vfmaq_laneq_f16(accu0, b7, a0, 7);
+            float16x8_t a1 = MlasLoadFloat16x8(a + lda);
+            accu0 = maq_laneq_f16_accu(accu0, b0, b1, b2, b3, b4, b5, b6, b7, a0);
+            accu1 = maq_laneq_f16_accu(accu1, b0, b1, b2, b3, b4, b5, b6, b7, a1);
         }
 
         if (k & 4) {
@@ -1412,54 +1410,68 @@ void HGemm_TransposedPackedB_Kernel_M2(
             float16x8_t b2 = MlasLoadFloat16x8(PackedB + 16);
             float16x8_t b3 = MlasLoadFloat16x8(PackedB + 24);
             float16x4_t a0 = MlasLoadFloat16x4(a);
-            accu0 = vfmaq_lane_f16(accu0, b0, a0, 0);
-            accu0 = vfmaq_lane_f16(accu0, b1, a0, 1);
-            accu0 = vfmaq_lane_f16(accu0, b2, a0, 2);
-            accu0 = vfmaq_lane_f16(accu0, b3, a0, 3);
+            float16x4_t a1 = MlasLoadFloat16x4(a + lda);
+            accu0 = maq_lane_f16_accu(accu0, b0, b1, b2, b3, a0);
+            accu1 = maq_lane_f16_accu(accu1, b0, b1, b2, b3, a1);
             k -= 4, a += 4, PackedB += 4 * 8;
         }
 
         if (k > 0) {
             float16x4_t a0 = MlasLoadPartialFloat16x4(a, k);
+            float16x4_t a1 = MlasLoadPartialFloat16x4(a + lda, k);
             float16x8_t b0 = MlasLoadFloat16x8(PackedB);
             accu0 = vfmaq_lane_f16(accu0, b0, a0, 0);
+            accu1 = vfmaq_lane_f16(accu1, b0, a1, 0);
             if (k > 1) {
                 float16x8_t b1 = MlasLoadFloat16x8(PackedB + 8);
                 accu0 = vfmaq_lane_f16(accu0, b1, a0, 1);
+                accu1 = vfmaq_lane_f16(accu1, b1, a1, 1);
             }
             if (k > 2) {
                 float16x8_t b2 = MlasLoadFloat16x8(PackedB + 16);
                 accu0 = vfmaq_lane_f16(accu0, b2, a0, 2);
+                accu1 = vfmaq_lane_f16(accu1, b2, a1, 2);
             }
             PackedB += k * 8;
         }
 
-        float16x4_t accu_low = vget_low_f16(accu0);
-        float16x4_t accu_high = vget_high_f16(accu0);
+        float16x4_t accu0_low = vget_low_f16(accu0);
+        float16x4_t accu0_high = vget_high_f16(accu0);
+        float16x4_t accu1_low = vget_low_f16(accu1);
+        float16x4_t accu1_high = vget_high_f16(accu1);
 
         if (CountN & 4) {
-            if (beta == 1.0f16) {
+            if const (beta_behaviour == 1) {
                 float16x4_t c0 = MlasLoadFloat16x4(C);
-                MlasStoreFloat16x4(C, vfma_n_f16(c0, accu_low, alpha));
-            } else if (beta != 0.0f16) {
+                float16x4_t c1 = MlasLoadFloat16x4(C + ldc);
+                MlasStoreFloat16x4(C, vfma_n_f16(c0, accu0_low, alpha));
+                MlasStoreFloat16x4(C + ldc, vfma_n_f16(c1, accu1_low, alpha));
+            } else if const (beta_behaviour == 2) {
                 float16x4_t c0 = MlasLoadFloat16x4(C);
-                MlasStoreFloat16x4(C, vfma_n_f16(vmul_n_f16(c0, beta), accu_low, alpha));
+                float16x4_t c1 = MlasLoadFloat16x4(C + ldc);
+                MlasStoreFloat16x4(C, vfma_n_f16(vmul_n_f16(c0, beta), accu0_low, alpha));
+                MlasStoreFloat16x4(C + ldc, vfma_n_f16(vmul_n_f16(c1, beta), accu1_low, alpha));
             } else {
-                MlasStoreFloat16x4(C, vmul_n_f16(accu_low, alpha));
+                MlasStoreFloat16x4(C, vmul_n_f16(accu0_low, alpha));
+                MlasStoreFloat16x4(C + ldc, vmul_n_f16(accu1_low, alpha));
             }
-
             CountN -= 4;
         }
 
         if (CountN) {
-            if (beta == 1.0f16) {
+            if const (beta_behaviour == 1) {
                 float16x4_t c0 = MlasLoadPartialFloat16x4(C, CountN);
-                MlasStorePartialFloat16x4(C, vfma_n_f16(c0, accu_high, alpha), CountN);
-            } else if (beta != 0.0f16) {
+                float16x4_t c1 = MlasLoadPartialFloat16x4(C + ldc, CountN);
+                MlasStorePartialFloat16x4(C, vfma_n_f16(c0, accu0_high, alpha), CountN);
+                MlasStorePartialFloat16x4(C + ldc, vfma_n_f16(c1, accu1_high, alpha), CountN);
+            } else if const (beta_behaviour == 2) {
                 float16x4_t c0 = MlasLoadFloat16x4(C, CountN);
-                MlasStorePartialFloat16x4(C, vfma_n_f16(vmul_n_f16(c0, beta), accu_high, alpha), CountN);
+                float16x4_t c1 = MlasLoadFloat16x4(C + ldc, CountN);
+                MlasStorePartialFloat16x4(C, vfma_n_f16(vmul_n_f16(c0, beta), accu0_high, alpha), CountN);
+                MlasStorePartialFloat16x4(C + ldc, vfma_n_f16(vmul_n_f16(c1, beta), accu1_high, alpha), CountN);
             } else {
-                MlasStorePartialFloat16x4(C, vmul_n_f16(accu_high, alpha), CountN);
+                MlasStorePartialFloat16x4(C, vmul_n_f16(accu0_high, alpha), CountN);
+                MlasStorePartialFloat16x4(C + ldc, vmul_n_f16(accu1_high, alpha), CountN);
             }
         }
     }
@@ -1484,12 +1496,24 @@ void HGemm_TransposedPackedB_Kernel(
     const auto* A_data = reinterpret_cast<const _mlas_fp16_*>(A);
     const auto* PackedB_data = reinterpret_cast<const _mlas_fp16_*>(PackedB);
     auto* C_data = reinterpret_cast<_mlas_fp16_*>(C);
+    auto alpha_fp16 = *reinterpret_cast<float16_t*>(&alpha);
+    auto beta_fp16 = *reinterpret_cast<float16_t*>(&beta);
     if (CountM == 1) {
-        HGemm_TransposedPackedB_Kernel_M1(A_data, PackedB_data, C_data, CountM, CountN, CountK, lda, ldc,
-            reinterpret_cast<float16_t>(alpha), reinterpret_cast<float16_t>(beta));
+        if (beta_fp16 == 0.0f16) {
+            HGemm_TransposedPackedB_Kernel_M1<0>(A_data, PackedB_data, C_data, CountM, CountN, CountK, lda, ldc, alpha_fp16, beta_fp16);
+        } else if (beta_fp16 == 1.0f16) {
+            HGemm_TransposedPackedB_Kernel_M1<1>(A_data, PackedB_data, C_data, CountM, CountN, CountK, lda, ldc, alpha_fp16, beta_fp16);
+        } else {
+            HGemm_TransposedPackedB_Kernel_M1<2>(A_data, PackedB_data, C_data, CountM, CountN, CountK, lda, ldc, alpha_fp16, beta_fp16);
+        }
     } else {
-        HGemm_TransposedPackedB_Kernel_M2(A_data, PackedB_data, C_data, CountM, CountN, CountK, lda, ldc,
-            reinterpret_cast<float16_t>(alpha), reinterpret_cast<float16_t>(beta));
+        if (beta_fp16 == 0.0f16) {
+            HGemm_TransposedPackedB_Kernel_M2<0>(A_data, PackedB_data, C_data, CountM, CountN, CountK, lda, ldc, alpha_fp16, beta_fp16);
+        } else if (beta_fp16 == 1.0f16) {
+            HGemm_TransposedPackedB_Kernel_M2<1>(A_data, PackedB_data, C_data, CountM, CountN, CountK, lda, ldc, alpha_fp16, beta_fp16);
+        } else {
+            HGemm_TransposedPackedB_Kernel_M2<2>(A_data, PackedB_data, C_data, CountM, CountN, CountK, lda, ldc, alpha_fp16, beta_fp16);
+        }
     }
 }
 

--- a/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
@@ -1163,18 +1163,19 @@ void HGemm_TransposedPackedB_Kernel_M1(
                 MlasStoreFloat16x4(C, vmul_n_f16(accu_low, alpha));
             }
 
-            CountN -= 4;
+            CountN -= 4, C += 4;
+            accu_low = accu_high;
         }
 
         if (CountN) {
             if constexpr (beta_behavior == 1) {
                 float16x4_t c0 = MlasLoadPartialFloat16x4(C, CountN);
-                MlasStorePartialFloat16x4(C, vfma_n_f16(c0, accu_high, alpha), CountN);
+                MlasStorePartialFloat16x4(C, vfma_n_f16(c0, accu_low, alpha), CountN);
             } else if constexpr (beta_behavior == 2) {
                 float16x4_t c0 = MlasLoadPartialFloat16x4(C, CountN);
-                MlasStorePartialFloat16x4(C, vfma_n_f16(vmul_n_f16(c0, beta), accu_high, alpha), CountN);
+                MlasStorePartialFloat16x4(C, vfma_n_f16(vmul_n_f16(c0, beta), accu_low, alpha), CountN);
             } else {
-                MlasStorePartialFloat16x4(C, vmul_n_f16(accu_high, alpha), CountN);
+                MlasStorePartialFloat16x4(C, vmul_n_f16(accu_low, alpha), CountN);
             }
         }
     }
@@ -1454,23 +1455,25 @@ void HGemm_TransposedPackedB_Kernel_M2(
                 MlasStoreFloat16x4(C, vmul_n_f16(accu0_low, alpha));
                 MlasStoreFloat16x4(C + ldc, vmul_n_f16(accu1_low, alpha));
             }
-            CountN -= 4;
+            CountN -= 4, C += 4;
+            accu0_low = accu0_high;
+            accu1_low = accu1_high;
         }
 
         if (CountN) {
             if constexpr (beta_behavior == 1) {
                 float16x4_t c0 = MlasLoadPartialFloat16x4(C, CountN);
                 float16x4_t c1 = MlasLoadPartialFloat16x4(C + ldc, CountN);
-                MlasStorePartialFloat16x4(C, vfma_n_f16(c0, accu0_high, alpha), CountN);
-                MlasStorePartialFloat16x4(C + ldc, vfma_n_f16(c1, accu1_high, alpha), CountN);
+                MlasStorePartialFloat16x4(C, vfma_n_f16(c0, accu0_low, alpha), CountN);
+                MlasStorePartialFloat16x4(C + ldc, vfma_n_f16(c1, accu1_low, alpha), CountN);
             } else if constexpr (beta_behavior == 2) {
                 float16x4_t c0 = MlasLoadPartialFloat16x4(C, CountN);
                 float16x4_t c1 = MlasLoadPartialFloat16x4(C + ldc, CountN);
-                MlasStorePartialFloat16x4(C, vfma_n_f16(vmul_n_f16(c0, beta), accu0_high, alpha), CountN);
-                MlasStorePartialFloat16x4(C + ldc, vfma_n_f16(vmul_n_f16(c1, beta), accu1_high, alpha), CountN);
+                MlasStorePartialFloat16x4(C, vfma_n_f16(vmul_n_f16(c0, beta), accu0_low, alpha), CountN);
+                MlasStorePartialFloat16x4(C + ldc, vfma_n_f16(vmul_n_f16(c1, beta), accu1_low, alpha), CountN);
             } else {
-                MlasStorePartialFloat16x4(C, vmul_n_f16(accu0_high, alpha), CountN);
-                MlasStorePartialFloat16x4(C + ldc, vmul_n_f16(accu1_high, alpha), CountN);
+                MlasStorePartialFloat16x4(C, vmul_n_f16(accu0_low, alpha), CountN);
+                MlasStorePartialFloat16x4(C + ldc, vmul_n_f16(accu1_low, alpha), CountN);
             }
         }
     }

--- a/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
@@ -137,7 +137,7 @@ HGemmTransB_Kernel_Block(
     }
 }
 
-void HTransposePackB_Kernel(
+void HPackB_TransposedB_Kernel(
     const MLAS_FP16* B,
     MLAS_FP16* PackedB,
     size_t CountN,
@@ -207,7 +207,7 @@ void HTransposePackB_Kernel(
     }
 }
 
-void HGemm_TransposeB_Kernel(
+void HGemm_TransposedB_Kernel(
     const MLAS_FP16* A,
     const MLAS_FP16* B,
     MLAS_FP16* C,
@@ -221,11 +221,11 @@ void HGemm_TransposeB_Kernel(
     MLAS_FP16 beta
 ) {
     if (CountM > 2) {
-        MLAS_THROW_EX(std::runtime_error, "HGemm_TransposeB_Kernel only support <= 2 rows");
+        MLAS_THROW_EX(std::runtime_error, "HGemm_TransposedB_Kernel only support <= 2 rows");
     }
 }
 
-void HGemm_TransposePackB_Kernel(
+void HGemm_TransposedPackedB_Kernel(
     const MLAS_FP16* A,
     const MLAS_FP16* PackedB,
     MLAS_FP16* C,
@@ -238,7 +238,7 @@ void HGemm_TransposePackB_Kernel(
     MLAS_FP16 beta
 ) {
     if (CountM > 2) {
-        MLAS_THROW_EX(std::runtime_error, "HGemm_TransposePackB_Kernel only support <= 2 rows");
+        MLAS_THROW_EX(std::runtime_error, "HGemm_TransposedPackedB_Kernel only support <= 2 rows");
     }
 
     const auto* a = reinterpret_cast<const _mlas_fp16_*>(A);

--- a/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
@@ -16,6 +16,12 @@ Abstract:
 
 #include <arm_neon.h>
 
+// Check if float16_t is defined, if not, define it
+#ifndef __FLT16_MIN__
+#define __FLT16_MIN__ 6.103515625e-05F16
+typedef __fp16 float16_t;
+#endif
+
 #include "halfgemm.h"
 #include "fp16_common.h"
 

--- a/onnxruntime/core/mlas/lib/hgemm_kernel_neon.cpp
+++ b/onnxruntime/core/mlas/lib/hgemm_kernel_neon.cpp
@@ -1,0 +1,28 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    hgemm_kernel_neon.cpp
+
+Abstract:
+
+    This module implements half precision GEMM kernel for neon.
+
+--*/
+
+#include "mlasi.h"
+#include "halfgemm.h"
+
+const MLAS_HGEMM_DISPATCH MlasHGemmDispatchNeon = [](){
+    MLAS_HGEMM_DISPATCH d;
+#if defined(MLAS_F16VEC_INTRINSICS_SUPPORTED) && defined(MLAS_TARGET_ARM64)
+    d.HPackBKernel_TransposedB = hgemm_neon::HPackB_TransposedB_Kernel;
+    d.HGemmKernel_TransposedB = hgemm_neon::HGemm_TransposedB_Kernel;
+    d.HGemmKernel_TransposedPackedB = hgemm_neon::HGemm_TransposedPackedB_Kernel;
+#endif
+    return d;
+}();

--- a/onnxruntime/core/mlas/lib/hqnbitgemm_kernel_neon_fp16.cpp
+++ b/onnxruntime/core/mlas/lib/hqnbitgemm_kernel_neon_fp16.cpp
@@ -93,39 +93,6 @@ Transpose8x8(uint8x8_t& v0, uint8x8_t& v1, uint8x8_t& v2, uint8x8_t& v3,
     v7 = vreinterpret_u8_u32(c3.val[1]);
 }
 
-MLAS_FORCEINLINE void
-Transpose4x8(float16x8_t& v0, float16x8_t& v1, float16x8_t& v2, float16x8_t& v3)
-{
-    // |v00|v01|v02|v03|v04|v05|v06|v07|
-    // |v10|v11|v12|v13|v14|v15|v16|v17|
-    // |v20|v21|v22|v23|v24|v25|v26|v27|
-    // |v30|v31|v32|v33|v34|v35|v36|v37|
-    //  =>
-    // |v00|v10|v20|v30|v04|v14|v24|v34|
-    // |v01|v11|v21|v31|v05|v15|v25|v35|
-    // |v02|v12|v22|v32|v06|v16|v26|v36|
-    // |v03|v13|v23|v33|v07|v17|v27|v37|
-    float16x8x2_t t01 = vtrnq_f16(v0, v1);
-    float16x8x2_t t23 = vtrnq_f16(v2, v3);
-
-    v0 = vreinterpretq_f16_f32(vtrn1q_f32(vreinterpretq_f32_f16(t01.val[0]), vreinterpretq_f32_f16(t23.val[0])));
-    v1 = vreinterpretq_f16_f32(vtrn1q_f32(vreinterpretq_f32_f16(t01.val[1]), vreinterpretq_f32_f16(t23.val[1])));
-    v2 = vreinterpretq_f16_f32(vtrn2q_f32(vreinterpretq_f32_f16(t01.val[0]), vreinterpretq_f32_f16(t23.val[0])));
-    v3 = vreinterpretq_f16_f32(vtrn2q_f32(vreinterpretq_f32_f16(t01.val[1]), vreinterpretq_f32_f16(t23.val[1])));
-}
-
-MLAS_FORCEINLINE void
-Transpose4x4(float16x4_t& v0, float16x4_t& v1, float16x4_t& v2, float16x4_t& v3)
-{
-    float16x4x2_t t01 = vtrn_f16(v0, v1);
-    float16x4x2_t t23 = vtrn_f16(v2, v3);
-
-    v0 = vreinterpret_f16_f32(vtrn1_f32(vreinterpret_f32_f16(t01.val[0]), vreinterpret_f32_f16(t23.val[0])));
-    v1 = vreinterpret_f16_f32(vtrn1_f32(vreinterpret_f32_f16(t01.val[1]), vreinterpret_f32_f16(t23.val[1])));
-    v2 = vreinterpret_f16_f32(vtrn2_f32(vreinterpret_f32_f16(t01.val[0]), vreinterpret_f32_f16(t23.val[0])));
-    v3 = vreinterpret_f16_f32(vtrn2_f32(vreinterpret_f32_f16(t01.val[1]), vreinterpret_f32_f16(t23.val[1])));
-}
-
 void
 HQ4BitGemmPackQuantBData_CompFp16(
     size_t N,

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -317,6 +317,7 @@ static_assert(sizeof(MLAS_FP16) == FP16_SIZE);
 // the effort at this time.
 //
 
+#define MLAS_HGEMM_STRIDEN_THREAD_ALIGN             16
 #define MLAS_SGEMM_STRIDEN_THREAD_ALIGN             16
 #define MLAS_DGEMM_STRIDEN_THREAD_ALIGN             8
 #define MLAS_QGEMM_STRIDEN_THREAD_ALIGN             16
@@ -944,6 +945,7 @@ extern "C" {
 #define MLAS_SGEMM_THREAD_COMPLEXITY                (size_t(64) * size_t(1024))
 #define MLAS_DGEMM_THREAD_COMPLEXITY                (size_t(64) * size_t(1024))
 #define MLAS_QGEMM_THREAD_COMPLEXITY                65536
+#define MLAS_HGEMM_THREAD_COMPLEXITY                65536
 
 #if defined(__aarch64__) && defined(__linux__)
 #define MLAS_SBGEMM_THREAD_COMPLEXITY (size_t(64) * size_t(1024))

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -1055,6 +1055,12 @@ extern const MLAS_QNBIT_GEMM_DISPATCH MlasSQNBitGemmDispatchAvx512vnni;
 struct MLAS_ROPE_DISPATCH;
 extern const MLAS_ROPE_DISPATCH MlasRopeDispatchNeon;
 
+//
+// half gemm dispatch structure
+//
+struct MLAS_HGEMM_DISPATCH;
+extern const MLAS_HGEMM_DISPATCH MlasHgemmDispatchNeon;
+
 
 //
 // Quantized depthwise convolution kernels.
@@ -1217,6 +1223,7 @@ struct MLAS_PLATFORM {
     MLAS_CAST_F32_TO_F16_KERNEL* CastF32ToF16Kernel;
 
     const MLAS_ROPE_DISPATCH* RopeDispatch{nullptr};
+    const MLAS_HGEMM_DISPATCH* HGemmDIspatch{nullptr};
 };
 
 inline

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -301,6 +301,8 @@ static_assert(sizeof(MLAS_FP16) == FP16_SIZE);
 // Define the default strides to step through slices of the input matrices.
 //
 
+#define MLAS_HGEMM_STRIDEN                          32
+#define MLAS_HGEMM_STRIDEK                          512
 #define MLAS_SGEMM_STRIDEN                          128
 #define MLAS_SGEMM_STRIDEK                          128
 #define MLAS_SGEMM_PACKED_STRIDEN                   128

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -1059,7 +1059,7 @@ extern const MLAS_ROPE_DISPATCH MlasRopeDispatchNeon;
 // half gemm dispatch structure
 //
 struct MLAS_HGEMM_DISPATCH;
-extern const MLAS_HGEMM_DISPATCH MlasHgemmDispatchNeon;
+extern const MLAS_HGEMM_DISPATCH MlasHGemmDispatchNeon;
 
 
 //
@@ -1223,7 +1223,7 @@ struct MLAS_PLATFORM {
     MLAS_CAST_F32_TO_F16_KERNEL* CastF32ToF16Kernel;
 
     const MLAS_ROPE_DISPATCH* RopeDispatch{nullptr};
-    const MLAS_HGEMM_DISPATCH* HGemmDIspatch{nullptr};
+    const MLAS_HGEMM_DISPATCH* HGemmDispatch{nullptr};
 };
 
 inline

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -544,6 +544,7 @@ Return Value:
     this->ConvSymS8S8Dispatch = &MlasConvSymS8DispatchNeon;
     this->QNBitGemmDispatch = &MlasSQNBitGemmDispatchNeon;
     this->RopeDispatch = &MlasRopeDispatchNeon;
+    this->HGemmDispatch = &MlasHGemmDispatchNeon;
 
     //
     // Check if the processor supports ASIMD dot product instructions.

--- a/onnxruntime/test/mlas/bench/bench_hgemm.cpp
+++ b/onnxruntime/test/mlas/bench/bench_hgemm.cpp
@@ -48,20 +48,20 @@ void HGEMM(benchmark::State& state, bool transA, bool transB) {
 
   for (auto _ : state) {
     MlasGemm(
-      transA ? CblasTrans : CblasNoTrans,
-      transB ? CblasTrans : CblasNoTrans,
-      static_cast<size_t>(M),
-      static_cast<size_t>(N),
-      static_cast<size_t>(K),
-      A.data(),
-      transA ? M : K,
-      B.data(),
-      transB ? K : N,
-      C.data(),
-      N,
-      alpha.val,
-      beta.val,
-      tp.get());
+        transA ? CblasTrans : CblasNoTrans,
+        transB ? CblasTrans : CblasNoTrans,
+        static_cast<size_t>(M),
+        static_cast<size_t>(N),
+        static_cast<size_t>(K),
+        A.data(),
+        transA ? M : K,
+        B.data(),
+        transB ? K : N,
+        C.data(),
+        N,
+        alpha.val,
+        beta.val,
+        tp.get());
   }
 }
 

--- a/onnxruntime/test/mlas/bench/bench_hgemm.cpp
+++ b/onnxruntime/test/mlas/bench/bench_hgemm.cpp
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "mlas.h"
+#include "bench_util.h"
+#include "core/util/thread_utils.h"
+
+#include <stdexcept>
+#include <numeric>
+
+static const std::vector<std::string> hgemm_bench_arg_names = {"M", "N", "K"};
+
+void HGEMM(benchmark::State& state, bool transA, bool transB) {
+  if (state.range(0) <= 0) throw std::invalid_argument("M must greater than 0!");
+  if (state.range(1) <= 0) throw std::invalid_argument("N must greater than 0!");
+  if (state.range(2) <= 0) throw std::invalid_argument("K must greater than 0!");
+  const size_t M = static_cast<size_t>(state.range(0));
+  const size_t N = static_cast<size_t>(state.range(1));
+  const size_t K = static_cast<size_t>(state.range(2));
+
+  auto A = RandomVectorUniform(static_cast<size_t>(M * K), MLAS_FP16(-1.0f), MLAS_FP16(1.0f));
+  auto B = RandomVectorUniform(static_cast<size_t>(N * K), MLAS_FP16(-1.0f), MLAS_FP16(1.0f));
+  std::vector<MLAS_FP16> C(static_cast<size_t>(M * N));
+
+  MLAS_FP16 alpha = MLAS_FP16(1.0f);
+  MLAS_FP16 beta = MLAS_FP16(0.0f);
+  OrtThreadPoolParams tpo;
+  tpo.thread_pool_size = 8;
+  tpo.auto_set_affinity = true;
+  std::unique_ptr<onnxruntime::concurrency::ThreadPool> tp(
+      onnxruntime::concurrency::CreateThreadPool(&onnxruntime::Env::Default(),
+                                                 tpo, onnxruntime::concurrency::ThreadPoolType::INTRA_OP));
+  MlasGemm(
+      transA ? CblasTrans : CblasNoTrans,
+      transB ? CblasTrans : CblasNoTrans,
+      static_cast<size_t>(M),
+      static_cast<size_t>(N),
+      static_cast<size_t>(K),
+      A.data(),
+      transA ? M : K,
+      B.data(),
+      transB ? K : N,
+      C.data(),
+      N,
+      alpha.val,
+      beta.val,
+      tp.get());
+
+  for (auto _ : state) {
+    MlasGemm(
+      transA ? CblasTrans : CblasNoTrans,
+      transB ? CblasTrans : CblasNoTrans,
+      static_cast<size_t>(M),
+      static_cast<size_t>(N),
+      static_cast<size_t>(K),
+      A.data(),
+      transA ? M : K,
+      B.data(),
+      transB ? K : N,
+      C.data(),
+      N,
+      alpha.val,
+      beta.val,
+      tp.get());
+  }
+}
+
+static void GemmSizeWithOne(benchmark::internal::Benchmark* b) {
+  b->ArgNames(hgemm_bench_arg_names);
+  b->ArgsProduct({{1}, {63, 255, 1023}, {63, 255, 1023}});
+  b->ArgsProduct({{63, 255, 1023}, {1}, {63, 255, 1023}});
+  b->ArgsProduct({{63, 255, 1023}, {63, 255, 1023}, {1}});
+}
+BENCHMARK_CAPTURE(HGEMM, GEMV_TransB, false, true)->Apply(GemmSizeWithOne)->UseRealTime();
+
+static void GemmSizeProducts(benchmark::internal::Benchmark* b) {
+  b->ArgNames(hgemm_bench_arg_names);
+  b->ArgsProduct({{63, 255, 1023}, {63, 255, 1023}, {63, 255, 1023}});
+}
+BENCHMARK_CAPTURE(HGEMM, NORMAL_TransB, false, true)->Apply(GemmSizeProducts)->UseRealTime();
+
+static void GemmLLMSizeProducts(benchmark::internal::Benchmark* b) {
+  b->ArgNames(hgemm_bench_arg_names);
+  b->ArgsProduct({{1, 1024, 2048}, {4096, 11008}, {4096, 11008}});
+}
+BENCHMARK_CAPTURE(HGEMM, LLM, false, true)->Apply(GemmLLMSizeProducts)->UseRealTime();

--- a/onnxruntime/test/mlas/unittest/test_hgemm_neon.cpp
+++ b/onnxruntime/test/mlas/unittest/test_hgemm_neon.cpp
@@ -88,7 +88,7 @@ class MlasNeonHGemmPackBTest : public MlasTestBase {
 
  public:
   MlasNeonHGemmPackBTest()
-    : seed_(rd_()), gen_(seed_), distrib_(-100.f, 100.f) {
+      : seed_(rd_()), gen_(seed_), distrib_(-100.f, 100.f) {
   }
 
   static const char* GetTestSuiteName() {
@@ -144,9 +144,9 @@ class MlasNeonHGemmTransposedBTest : public MlasTestBase {
     size_t n = M * N;
     for (size_t i = 0; i < n; ++i) {
       ASSERT_TRUE(FloatEqual(C[i], ref[i], 0.02f, 0.055f))
-        << " seed " << seed_ << " i " << i
-        << " M " << M << " N " << N << " K " << K
-        << " v0 " << C[i] << " v1 " << ref[i];
+          << " seed " << seed_ << " i " << i
+          << " M " << M << " N " << N << " K " << K
+          << " v0 " << C[i] << " v1 " << ref[i];
     }
   }
 
@@ -169,7 +169,7 @@ class MlasNeonHGemmTransposedBTest : public MlasTestBase {
 
  public:
   MlasNeonHGemmTransposedBTest()
-    : seed_(1928375), gen_(seed_), distrib_(-1.f, 1.f) {
+      : seed_(1928375), gen_(seed_), distrib_(-1.f, 1.f) {
   }
 
   static const char* GetTestSuiteName() {
@@ -251,9 +251,9 @@ class MlasNeonHGemmTransposedPackedBTest : public MlasTestBase {
     size_t n = M * N;
     for (size_t i = 0; i < n; ++i) {
       ASSERT_TRUE(FloatEqual(C[i], ref[i], 0.02f, 0.055f))
-        << " seed " << seed_ << " i " << i
-        << " M " << M << " K " << K << " N " << N
-        << " v0 " << C[i] << " v1 " << ref[i];
+          << " seed " << seed_ << " i " << i
+          << " M " << M << " K " << K << " N " << N
+          << " v0 " << C[i] << " v1 " << ref[i];
     }
   }
 
@@ -276,7 +276,7 @@ class MlasNeonHGemmTransposedPackedBTest : public MlasTestBase {
 
  public:
   MlasNeonHGemmTransposedPackedBTest()
-    : seed_(1928372), gen_(seed_), distrib_(-1.f, 1.f) {
+      : seed_(1928372), gen_(seed_), distrib_(-1.f, 1.f) {
   }
 
   static const char* GetTestSuiteName() {
@@ -332,9 +332,9 @@ class MlasNeonHGemmTest : public MlasTestBase {
     for (size_t i = 0; i < M; ++i) {
       for (size_t j = 0; j < N; ++j) {
         ASSERT_TRUE(FloatEqual(C[i * N + j], ref[i * N + j], 0.02f, 0.055f))
-          << " seed " << seed_ << " i " << i << " j " << j
-          << " M " << M << " K " << K << " N " << N
-          << " v0 " << C[i * N + j] << " v1 " << ref[i * N + j];
+            << " seed " << seed_ << " i " << i << " j " << j
+            << " M " << M << " K " << K << " N " << N
+            << " v0 " << C[i * N + j] << " v1 " << ref[i * N + j];
       }
     }
   }
@@ -358,7 +358,7 @@ class MlasNeonHGemmTest : public MlasTestBase {
 
  public:
   MlasNeonHGemmTest()
-    : seed_(192837), gen_(seed_), distrib_(-0.25f, 0.25f) {
+      : seed_(192837), gen_(seed_), distrib_(-0.25f, 0.25f) {
   }
 
   static const char* GetTestSuiteName() {

--- a/onnxruntime/test/mlas/unittest/test_hgemm_neon.cpp
+++ b/onnxruntime/test/mlas/unittest/test_hgemm_neon.cpp
@@ -25,6 +25,7 @@ Abstract:
 
 class MlasNeonHGemmPackBTest : public MlasTestBase {
  private:
+  std::random_device rd_;
   unsigned int seed_;
   std::mt19937 gen_;  // mersenne_twister_engine seeded with rd()
   std::uniform_real_distribution<float> distrib_;
@@ -87,7 +88,7 @@ class MlasNeonHGemmPackBTest : public MlasTestBase {
 
  public:
   MlasNeonHGemmPackBTest()
-    : seed_(std::rand()), gen_(seed_), distrib_(-100.f, 100.f) {
+    : seed_(rd_()), gen_(seed_), distrib_(-100.f, 100.f) {
   }
 
   static const char* GetTestSuiteName() {
@@ -111,6 +112,7 @@ class MlasNeonHGemmPackBTest : public MlasTestBase {
 
 class MlasNeonHGemmTransposedBTest : public MlasTestBase {
  private:
+  std::random_device rd_;
   unsigned int seed_;
   std::mt19937 gen_;  // mersenne_twister_engine seeded with rd()
   std::uniform_real_distribution<float> distrib_;
@@ -167,7 +169,7 @@ class MlasNeonHGemmTransposedBTest : public MlasTestBase {
 
  public:
   MlasNeonHGemmTransposedBTest()
-    : seed_(192872), gen_(seed_), distrib_(-1.f, 1.f) {
+    : seed_(1928375), gen_(seed_), distrib_(-1.f, 1.f) {
   }
 
   static const char* GetTestSuiteName() {
@@ -191,6 +193,7 @@ class MlasNeonHGemmTransposedBTest : public MlasTestBase {
 
 class MlasNeonHGemmTransposedPackedBTest : public MlasTestBase {
  private:
+  std::random_device rd_;
   unsigned int seed_;
   std::mt19937 gen_;  // mersenne_twister_engine seeded with rd()
   std::uniform_real_distribution<float> distrib_;
@@ -273,7 +276,7 @@ class MlasNeonHGemmTransposedPackedBTest : public MlasTestBase {
 
  public:
   MlasNeonHGemmTransposedPackedBTest()
-    : seed_(1928378), gen_(seed_), distrib_(-1.f, 1.f) {
+    : seed_(1928372), gen_(seed_), distrib_(-1.f, 1.f) {
   }
 
   static const char* GetTestSuiteName() {
@@ -295,7 +298,86 @@ class MlasNeonHGemmTransposedPackedBTest : public MlasTestBase {
   }
 };
 
-// TODO: add mlas call UT
+class MlasNeonHGemmTest : public MlasTestBase {
+ private:
+  std::random_device rd_;
+  unsigned int seed_;
+  std::mt19937 gen_;  // mersenne_twister_engine seeded with rd()
+  std::uniform_real_distribution<float> distrib_;
+  MatrixGuardBuffer<MLAS_FP16> A_, B_, ref_, C_;
+
+  template <size_t M, size_t K, size_t N>
+  MLAS_FORCEINLINE void HGemm(const MLAS_FP16* A, const MLAS_FP16* B, MLAS_FP16* C, MLAS_FP16 alpha, MLAS_FP16 beta) {
+    float alphaf = alpha.ToFloat();
+    float betaf = beta.ToFloat();
+    for (size_t i = 0; i < M; ++i) {
+      for (size_t j = 0; j < N; ++j) {
+        float accu = 0.0f;
+        for (size_t k = 0; k < K; ++k) {
+          accu += (A[i * K + k].ToFloat()) * (B[j * K + k].ToFloat());
+        }
+        C[i * N + j] = MLAS_FP16(accu * alphaf + C[i * N + j].ToFloat() * betaf);
+      }
+    }
+  }
+
+  MLAS_FORCEINLINE
+  bool FloatEqual(MLAS_FP16 v0, MLAS_FP16 v1, float rtol, float atol) {
+    float f0 = v0.ToFloat(), f1 = v1.ToFloat();
+    return std::abs(f0 - f1) <= std::abs(f1 * rtol) + atol;
+  }
+
+  template <size_t M, size_t K, size_t N>
+  MLAS_FORCEINLINE void Check(const MLAS_FP16* C, const MLAS_FP16* ref) {
+    for (size_t i = 0; i < M; ++i) {
+      for (size_t j = 0; j < N; ++j) {
+        ASSERT_TRUE(FloatEqual(C[i * N + j], ref[i * N + j], 0.02f, 0.055f))
+          << " seed " << seed_ << " i " << i << " j " << j
+          << " M " << M << " K " << K << " N " << N
+          << " v0 " << C[i * N + j] << " v1 " << ref[i * N + j];
+      }
+    }
+  }
+
+  template <size_t M, size_t K, size_t N>
+  void TestHGemm(MLAS_FP16 alpha, MLAS_FP16 beta) {
+    auto InitializeBuffer = [this](MLAS_FP16* buffer, size_t count) {
+      for (size_t i = 0; i < count; i++) {
+        buffer[i] = MLAS_FP16(distrib_(gen_));
+      }
+    };
+
+    const auto* A = A_.GetFilledBuffer(M * K, InitializeBuffer);
+    const auto* B = B_.GetFilledBuffer(K * N, InitializeBuffer);
+    auto* C = C_.GetBuffer(M * N, true);
+    auto* ref = ref_.GetBuffer(M * N, true);
+    MlasGemm(CblasNoTrans, CblasTrans, M, N, K, A, K, B, K, C, N, alpha.val, beta.val, nullptr);
+    HGemm<M, K, N>(A, B, ref, alpha, beta);
+    Check<M, K, N>(C, ref);
+  }
+
+ public:
+  MlasNeonHGemmTest()
+    : seed_(192837), gen_(seed_), distrib_(-0.25f, 0.25f) {
+  }
+
+  static const char* GetTestSuiteName() {
+    return "NeonHGemm";
+  }
+
+  void ExecuteShort(void) override {
+    TestHGemm<2, 1, 1>(MLAS_FP16(1.0f), MLAS_FP16(0.0f));
+    TestHGemm<1, 128, 512>(MLAS_FP16(0.5f), MLAS_FP16(1.0f));
+    TestHGemm<2, 128, 513>(MLAS_FP16(1.5f), MLAS_FP16(0.5f));
+    TestHGemm<1, 128, 511>(MLAS_FP16(1.0f), MLAS_FP16(0.0f));
+    TestHGemm<2, 129, 512>(MLAS_FP16(0.5f), MLAS_FP16(1.0f));
+    TestHGemm<1, 127, 512>(MLAS_FP16(1.5f), MLAS_FP16(0.5f));
+    TestHGemm<1, 513, 1023>(MLAS_FP16(0.5f), MLAS_FP16(1.0f));
+    TestHGemm<2, 511, 1025>(MLAS_FP16(1.5f), MLAS_FP16(0.5f));
+    TestHGemm<127, 513, 1023>(MLAS_FP16(1.0f), MLAS_FP16(0.0f));
+    TestHGemm<129, 511, 1025>(MLAS_FP16(0.5f), MLAS_FP16(1.0f));
+  }
+};
 
 static UNUSED_VARIABLE bool added_to_main = AddTestRegister([](bool is_short_execute) {
   size_t count = 0;
@@ -303,6 +385,7 @@ static UNUSED_VARIABLE bool added_to_main = AddTestRegister([](bool is_short_exe
     count += MlasDirectShortExecuteTests<MlasNeonHGemmPackBTest>::RegisterShortExecute();
     count += MlasDirectShortExecuteTests<MlasNeonHGemmTransposedBTest>::RegisterShortExecute();
     count += MlasDirectShortExecuteTests<MlasNeonHGemmTransposedPackedBTest>::RegisterShortExecute();
+    count += MlasDirectShortExecuteTests<MlasNeonHGemmTest>::RegisterShortExecute();
   }
   return count;
 });

--- a/onnxruntime/test/mlas/unittest/test_hgemm_neon.cpp
+++ b/onnxruntime/test/mlas/unittest/test_hgemm_neon.cpp
@@ -1,0 +1,302 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    test_hgemm_neon.cpp
+
+Abstract:
+
+    Tests for MLAS fp16 GEMM on ARM CPU.
+
+--*/
+
+#include <vector>
+#include <random>
+
+#include "test/mlas/unittest/test_util.h"
+#include "core/mlas/lib/mlasi.h"
+#include "core/mlas/lib/halfgemm.h"
+
+#if defined(MLAS_F16VEC_INTRINSICS_SUPPORTED) && defined(MLAS_TARGET_ARM64)
+
+class MlasNeonHGemmPackBTest : public MlasTestBase {
+ private:
+  unsigned int seed_;
+  std::mt19937 gen_;  // mersenne_twister_engine seeded with rd()
+  std::uniform_int_distribution<uint16_t> distrib_;
+  MatrixGuardBuffer<MLAS_FP16> input_, ref_, packed_;
+
+  template <size_t N, size_t K>
+  MLAS_FORCEINLINE void PackB(const MLAS_FP16* src, MLAS_FP16* dst) {
+    size_t i = 0;
+    for (; i + 16 <= N; i += 16) {
+      for (size_t j = 0; j < K; ++j) {
+        for (size_t k = 0; k < 16; ++k) {
+          *dst = src[(i + k) * K + j];
+          ++dst;
+        }
+      }
+    }
+    if (i + 8 <= N) {
+      for (size_t j = 0; j < K; ++j) {
+        for (size_t k = 0; k < 8; ++k) {
+          *dst = src[(i + k) * K + j];
+          ++dst;
+        }
+      }
+      i += 8;
+    }
+    if (i < N) {
+      for (size_t j = 0; j < K; ++j) {
+        for (size_t k = 0; k < N; ++k) {
+          *dst = src[(i + k) * K + j];
+          ++dst;
+        }
+        dst += 8 - N;
+      }
+    }
+  }
+
+  template <size_t N, size_t K>
+  MLAS_FORCEINLINE void Check(const MLAS_FP16* packed, const MLAS_FP16* ref) {
+    size_t n = ((N + 7) & ~7) * K;
+    for (size_t i = 0; i < n; ++i) {
+      ASSERT_EQ(packed[i], ref[i]) << " seed " << seed_ << " i " << i;
+    }
+  }
+
+  template <size_t N, size_t K>
+  void TestPackB() {
+    auto InitializeBuffer = [this](MLAS_FP16* buffer, size_t count) {
+      for (size_t i = 0; i < count; i++) {
+        buffer[i] = MLAS_FP16::FromBits(distrib_(gen_));
+      }
+    };
+
+    const auto* input = input_.GetFilledBuffer(N * K, InitializeBuffer);
+    auto* packed = packed_.GetBuffer(K * ((N + 7) / 8 * 8), true);
+    auto* ref = ref_.GetBuffer(K * ((N + 7) / 8 * 8), true);
+    hgemm_neon::HPackB_TransposedB_Kernel(input, packed, N, K, K);
+    PackB<N, K>(input, ref);
+    Check<N, K>(packed, ref);
+  }
+
+ public:
+  MlasNeonHGemmPackBTest()
+      : seed_(19287), gen_(seed_), distrib_(0, 65535) {
+  }
+
+  static const char* GetTestSuiteName() {
+    return "NeonHGemmPackB";
+  }
+
+  void ExecuteShort(void) override {
+    TestPackB<1, 1>();
+    TestPackB<1, 15>();
+    TestPackB<1, 31>();
+    TestPackB<8, 1>();
+    TestPackB<8, 16>();
+    TestPackB<9, 31>();
+    TestPackB<9, 33>();
+    TestPackB<15, 33>();
+    TestPackB<17, 67>();
+    TestPackB<17, 96>();
+    TestPackB<265, 263>();
+  }
+};
+
+class MlasNeonHGemmTransposedBTest : public MlasTestBase {
+ private:
+  unsigned int seed_;
+  std::mt19937 gen_;  // mersenne_twister_engine seeded with rd()
+  std::uniform_real_distribution<float> distrib_;
+  MatrixGuardBuffer<MLAS_FP16> A_, B_, ref_, C_;
+
+  template <size_t M, size_t K, size_t N>
+  MLAS_FORCEINLINE void HGemm(const MLAS_FP16* A, const MLAS_FP16* B, MLAS_FP16* C, MLAS_FP16 alpha, MLAS_FP16 beta) {
+    float alphaf = alpha.ToFloat();
+    float betaf = beta.ToFloat();
+    for (size_t m = 0; m < M; ++m) {
+      for (size_t n = 0; n < N; ++n) {
+        float accu = 0.0f;
+        for (size_t k = 0; k < K; ++k) {
+          accu += (A[m * K + k].ToFloat()) * (B[n * K + k].ToFloat());
+        }
+        C[m * N + n] = MLAS_FP16(accu * alphaf + C[m * N + n].ToFloat() * betaf);
+      }
+    }
+  }
+
+  MLAS_FORCEINLINE
+  bool FloatEqual(MLAS_FP16 v0, MLAS_FP16 v1, float rtol, float atol) {
+    float f0 = v0.ToFloat(), f1 = v1.ToFloat();
+    return std::abs(f0 - f1) <= std::abs(f1 * rtol) + atol;
+  }
+
+  template <size_t M, size_t K, size_t N>
+  MLAS_FORCEINLINE void Check(const MLAS_FP16* C, const MLAS_FP16* ref) {
+    size_t n = M * N;
+    for (size_t i = 0; i < n; ++i) {
+      ASSERT_TRUE(FloatEqual(C[i], ref[i], 0.02f, 0.055f)) << " seed " << seed_ << " i " << i;
+    }
+  }
+
+  template <size_t M, size_t K, size_t N>
+  void TestHGemm(MLAS_FP16 alpha, MLAS_FP16 beta) {
+    auto InitializeBuffer = [this](MLAS_FP16* buffer, size_t count) {
+      for (size_t i = 0; i < count; i++) {
+        buffer[i] = MLAS_FP16(distrib_(gen_));
+      }
+    };
+
+    const auto* A = A_.GetFilledBuffer(M * K, InitializeBuffer);
+    const auto* B = B_.GetFilledBuffer(K * N, InitializeBuffer);
+    auto* C = C_.GetBuffer(M * N, true);
+    auto* ref = ref_.GetBuffer(M * N, true);
+    hgemm_neon::HGemm_TransposedB_Kernel(A, B, C, M, N, K, K, K, N, alpha.val, beta.val);
+    HGemm<M, K, N>(A, B, ref, alpha, beta);
+    Check<M, K, N>(C, ref);
+  }
+
+ public:
+  MlasNeonHGemmTransposedBTest()
+      : seed_(19287), gen_(seed_), distrib_(-100.f, 100.f) {
+  }
+
+  static const char* GetTestSuiteName() {
+    return "NeonHGemmTransposedB";
+  }
+
+  void ExecuteShort(void) override {
+    TestHGemm<2, 1, 1>(MLAS_FP16(1.0f), MLAS_FP16(0.0f));
+    TestHGemm<1, 1, 1>(MLAS_FP16(0.5f), MLAS_FP16(1.0f));
+    TestHGemm<2, 1, 1>(MLAS_FP16(1.5f), MLAS_FP16(0.5f));
+    TestHGemm<1, 15, 17>(MLAS_FP16(1.0f), MLAS_FP16(0.0f));
+    TestHGemm<2, 17, 15>(MLAS_FP16(0.5f), MLAS_FP16(1.0f));
+    TestHGemm<1, 17, 15>(MLAS_FP16(1.5f), MLAS_FP16(0.5f));
+    TestHGemm<1, 33, 31>(MLAS_FP16(1.0f), MLAS_FP16(0.0f));
+    TestHGemm<2, 31, 32>(MLAS_FP16(0.5f), MLAS_FP16(1.0f));
+    TestHGemm<1, 32, 33>(MLAS_FP16(1.5f), MLAS_FP16(0.5f));
+    TestHGemm<1, 78, 263>(MLAS_FP16(0.5f), MLAS_FP16(0.0f));
+    TestHGemm<2, 267, 79>(MLAS_FP16(1.5f), MLAS_FP16(1.0f));
+  }
+};
+
+class MlasNeonHGemmTransposedPackedBTest : public MlasTestBase {
+ private:
+  unsigned int seed_;
+  std::mt19937 gen_;  // mersenne_twister_engine seeded with rd()
+  std::uniform_real_distribution<float> distrib_;
+  MatrixGuardBuffer<MLAS_FP16> A_, B_, ref_, C_;
+
+  template <size_t M, size_t K, size_t N>
+  MLAS_FORCEINLINE void HGemm(const MLAS_FP16* A, const MLAS_FP16* B, MLAS_FP16* C, MLAS_FP16 alpha, MLAS_FP16 beta) {
+    float alphaf = alpha.ToFloat();
+    float betaf = beta.ToFloat();
+    size_t n = 0;
+    for (; n + 16 <= N; n += 16) {
+      for (size_t i = 0; i < 16; ++i) {
+        for (size_t m = 0; m < M; ++m) {
+          float accu = 0.0f;
+          for (size_t k = 0; k < K; ++k) {
+            accu += (A[m * K + k].ToFloat()) * (B[n * K + k * 16 + i].ToFloat());
+          }
+          C[m * N + n + i] = MLAS_FP16(accu * alphaf + C[m * N + n + i].ToFloat() * betaf);
+        }
+      }
+    }
+    if (n + 8 <= N) {
+      for (size_t i = 0; i < 8; ++i) {
+        for (size_t m = 0; m < M; ++m) {
+          float accu = 0.0f;
+          for (size_t k = 0; k < K; ++k) {
+            accu += (A[m * K + k].ToFloat()) * (B[n * K + k * 8 + i].ToFloat());
+          }
+          C[m * N + n + i] = MLAS_FP16(accu * alphaf + C[m * N + n + i].ToFloat() * betaf);
+        }
+      }
+      n += 8;
+    }
+    if (n < N) {
+      for (size_t i = 0; i < N - n; ++i) {
+        for (size_t m = 0; m < M; ++m) {
+          float accu = 0.0f;
+          for (size_t k = 0; k < K; ++k) {
+            accu += (A[m * K + k].ToFloat()) * (B[n * K + k * 8 + i].ToFloat());
+          }
+          C[m * N + n + i] = MLAS_FP16(accu * alphaf + C[m * N + n + i].ToFloat() * betaf);
+        }
+      }
+    }
+  }
+
+  MLAS_FORCEINLINE
+  bool FloatEqual(MLAS_FP16 v0, MLAS_FP16 v1, float rtol, float atol) {
+    float f0 = v0.ToFloat(), f1 = v1.ToFloat();
+    return std::abs(f0 - f1) <= std::abs(f1 * rtol) + atol;
+  }
+
+  template <size_t M, size_t K, size_t N>
+  MLAS_FORCEINLINE void Check(const MLAS_FP16* C, const MLAS_FP16* ref) {
+    size_t n = M * N;
+    for (size_t i = 0; i < n; ++i) {
+      ASSERT_TRUE(FloatEqual(C[i], ref[i], 0.02f, 0.055f)) << " seed " << seed_ << " i " << i;
+    }
+  }
+
+  template <size_t M, size_t K, size_t N>
+  void TestHGemm(MLAS_FP16 alpha, MLAS_FP16 beta) {
+    auto InitializeBuffer = [this](MLAS_FP16* buffer, size_t count) {
+      for (size_t i = 0; i < count; i++) {
+        buffer[i] = MLAS_FP16(distrib_(gen_));
+      }
+    };
+
+    const auto* A = A_.GetFilledBuffer(M * K, InitializeBuffer);
+    const auto* B = B_.GetFilledBuffer(K * ((N + 7) & ~7), InitializeBuffer);
+    auto* C = C_.GetBuffer(M * N, true);
+    auto* ref = ref_.GetBuffer(M * N, true);
+    hgemm_neon::HGemm_TransposedPackedB_Kernel(A, B, C, M, N, K, K, N, alpha.val, beta.val);
+    HGemm<M, K, N>(A, B, ref, alpha, beta);
+    Check<M, K, N>(C, ref);
+  }
+
+ public:
+  MlasNeonHGemmTransposedPackedBTest()
+      : seed_(19287), gen_(seed_), distrib_(-100.f, 100.f) {
+  }
+
+  static const char* GetTestSuiteName() {
+    return "NeonHGemmTransposedPackedB";
+  }
+
+  void ExecuteShort(void) override {
+    TestHGemm<2, 1, 1>(MLAS_FP16(1.0f), MLAS_FP16(0.0f));
+    TestHGemm<1, 1, 1>(MLAS_FP16(0.5f), MLAS_FP16(1.0f));
+    TestHGemm<2, 1, 1>(MLAS_FP16(1.5f), MLAS_FP16(0.5f));
+    TestHGemm<1, 15, 17>(MLAS_FP16(1.0f), MLAS_FP16(0.0f));
+    TestHGemm<2, 17, 15>(MLAS_FP16(0.5f), MLAS_FP16(1.0f));
+    TestHGemm<1, 17, 15>(MLAS_FP16(1.5f), MLAS_FP16(0.5f));
+    TestHGemm<1, 33, 31>(MLAS_FP16(1.0f), MLAS_FP16(0.0f));
+    TestHGemm<2, 31, 32>(MLAS_FP16(0.5f), MLAS_FP16(1.0f));
+    TestHGemm<1, 32, 33>(MLAS_FP16(1.5f), MLAS_FP16(0.5f));
+    TestHGemm<1, 78, 263>(MLAS_FP16(0.5f), MLAS_FP16(0.0f));
+    TestHGemm<2, 267, 79>(MLAS_FP16(1.5f), MLAS_FP16(1.0f));
+  }
+};
+
+static UNUSED_VARIABLE bool added_to_main = AddTestRegister([](bool is_short_execute) {
+  size_t count = 0;
+  if (is_short_execute) {
+    count += MlasDirectShortExecuteTests<MlasNeonHGemmPackBTest>::RegisterShortExecute();
+    count += MlasDirectShortExecuteTests<MlasNeonHGemmTransposedBTest>::RegisterShortExecute();
+    count += MlasDirectShortExecuteTests<MlasNeonHGemmTransposedPackedBTest>::RegisterShortExecute();
+  }
+  return count;
+});
+
+#endif  // defined(MLAS_F16VEC_INTRINSICS_SUPPORTED) && defined(MLAS_TARGET_ARM64)


### PR DESCRIPTION
### Description
Add fp16 kernels for GQA matmul on ARM CPU.
The kernels are mlas hgemm for C = alpha * A x B' + beta * C


### Motivation and Context
Add fp16 support for GQA, speed up the operator and reduce memory usage.

__Token Generation__
|                        | HGEMM Runtime (ns) | SGEMM Runtime (ns) | Speed-up (%) |
|---------------------------------|--------------------|--------------------|--------------|
| M:1/N:4096/K:4096               | 251551             | 1775905            | 85.84        |
| M:1/N:11008/K:4096              | 892507             | 4649145            | 80.80        |
| M:1/N:4096/K:11008              | 866860             | 3240015            | 73.25        |
| M:1/N:11008/K:11008             | 2631615            |8783877            | 70.04        |

__Prompting__
|                       | HGEMM Runtime (ns) | SGEMM Runtime (ns) | Speed-up (%) |
|---------------------------------|--------------------|--------------------|--------------|
| M:1024/N:4096/K:4096            | 90508701           | 111283029          | 18.67        |
| M:2048/N:4096/K:4096            | 181307522          | 240211107          | 24.52        |
| M:1024/N:11008/K:4096           | 241120234          | 307707933          | 21.64        |
| M:2048/N:11008/K:4096           | 481091232          | 648921367          | 25.86        |
| M:1024/N:4096/K:11008           | 241736343          | 310129880          | 22.05        |
| M:2048/N:4096/K:11008           | 480456703          | 644814999          | 25.49        |
| M:1024/N:11008/K:11008          | 642121440          | 847925766          | 24.27        |
| M:2048/N:11008/K:11008          | 1276097154         | 1731314509         | 26.29

