### PR TITLE
[webgpu] Always use tile matmulnbits for block_size = 32

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.h
+++ b/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.h
@@ -14,13 +14,12 @@ using namespace onnxruntime::webgpu;
 
 class MatMulNBitsProgram final : public Program<MatMulNBitsProgram> {
  public:
-  MatMulNBitsProgram(uint32_t output_number, uint32_t block_size, uint32_t tile_m, int components_b, bool has_zero_points, bool is_intel) : Program{"MatMulNBits"},
-                                                                                                                                            output_number_{output_number},
-                                                                                                                                            block_size_{block_size},
-                                                                                                                                            tile_m_{tile_m},
-                                                                                                                                            components_b_{components_b},
-                                                                                                                                            has_zero_points_{has_zero_points},
-                                                                                                                                            is_intel_{is_intel} {
+  MatMulNBitsProgram(uint32_t output_number, uint32_t block_size, uint32_t tile_m, int components_b, bool has_zero_points) : Program{"MatMulNBits"},
+                                                                                                                             output_number_{output_number},
+                                                                                                                             block_size_{block_size},
+                                                                                                                             tile_m_{tile_m},
+                                                                                                                             components_b_{components_b},
+                                                                                                                             has_zero_points_{has_zero_points} {
   }
 
   Status GenerateShaderCode(ShaderHelper& sh) const override;
@@ -32,7 +31,6 @@ class MatMulNBitsProgram final : public Program<MatMulNBitsProgram> {
   uint32_t tile_m_;
   int components_b_;
   bool has_zero_points_;
-  bool is_intel_;
 };
 
 class MatMulNBits final : public WebGpuKernel {


### PR DESCRIPTION
### Description
After the optimization of prefill time with #23102, it seems that always using the tile matmulnibits with block_size = 32 can bring better performance even for discrete gpu for phi3 model.

Phi3 becomes 42.64 tokens/sec from 32.82 tokens/sec in easy mode on my NV RTX 2000 GPU.


