### PR TITLE
Update CUDA install instructions for generate() API

### DIFF
--- a/docs/genai/howto/install.md
+++ b/docs/genai/howto/install.md
@@ -38,17 +38,15 @@ The CUDA toolkit can be downloaded from the [CUDA Toolkit Archive](https://devel
 
 Ensure that the `CUDA_PATH` environment variable is set to the location of your CUDA installation.
 
-#### CUDA 11
-
-```bash
-pip install onnxruntime-genai-cuda --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-11/pypi/simple/
-```
-
 #### CUDA 12
 
 ```bash
 pip install onnxruntime-genai-cuda
 ```
+
+#### CUDA 11
+
+To use this API with CUDA 11, you need to [build and install from source](build-from-source.md).
 
 
 ## Nuget package installation

--- a/docs/genai/tutorials/phi3-python.md
+++ b/docs/genai/tutorials/phi3-python.md
@@ -83,7 +83,6 @@ Are you on a Windows machine with GPU?
 2. Install the generate() API
 
    ```
-   pip install numpy
    pip install --pre onnxruntime-genai-directml
    ```
 
@@ -125,8 +124,7 @@ Are you on a Windows machine with GPU?
 2. Install the generate() API
 
    ```
-   pip install numpy
-   pip install --pre onnxruntime-genai-cuda --index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-genai/pypi/simple/
+   pip install --pre onnxruntime-genai-cuda
    ```
 
 3. Run the model
@@ -159,7 +157,6 @@ Are you on a Windows machine with GPU?
 2. Install the generate() API for CPU
    
    ```
-   pip install numpy
    pip install --pre onnxruntime-genai
    ```
 

--- a/docs/genai/tutorials/phi3-v.md
+++ b/docs/genai/tutorials/phi3-v.md
@@ -102,13 +102,7 @@ You can download the models here:
 
 3. Install the generate() API
 
-   * CUDA 11
-
-   ```bash
-   pip install onnxruntime-genai-cuda --index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-11/pypi/simple/
-   ```
-
-   * CUDA 12
+   Note: this package uses CUDA 12. To use CUDA 11, you need to [build and install from source](../howto/build-from-source.md).
 
    ```bash
    pip install onnxruntime-genai-cuda


### PR DESCRIPTION
Removed CUDA 11 package install and explicit numpy install

Staged here: https://natke.github.io/onnxruntime/docs/genai 


