### PR TITLE
fix webgpu delay load test

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -130,8 +130,7 @@ option(onnxruntime_DEBUG_NODE_INPUTS_OUTPUTS "Dump debug information about node 
 cmake_dependent_option(onnxruntime_DEBUG_NODE_INPUTS_OUTPUTS_ENABLE_DUMP_TO_SQLDB "Build dump debug information about node inputs and outputs with support for sql database." OFF "onnxruntime_DEBUG_NODE_INPUTS_OUTPUTS" OFF)
 
 # When loading a delay loaded DLL, Windows searches the main EXE's folder first.
-# In a Python process, it searches where python.exe lives, but it doesn't search the python package's installation folder. Therefore we cannot enable this flag when Python is enabled.
-cmake_dependent_option(onnxruntime_ENABLE_DELAY_LOADING_WIN_DLLS "Delay load some of the dependent DLls that are part of the OS" ON "WIN32;NOT GDK_PLATFORM;NOT onnxruntime_ENABLE_PYTHON" OFF)
+cmake_dependent_option(onnxruntime_ENABLE_DELAY_LOADING_WIN_DLLS "Delay load some of the dependent DLls that are part of the OS" ON "WIN32;NOT GDK_PLATFORM" OFF)
 option(onnxruntime_USE_DML "Build with DirectML support" OFF)
 option(onnxruntime_USE_MIGRAPHX "Build with AMDMIGraphX support" OFF)
 option(onnxruntime_USE_WINML "Build with WinML support" OFF)

--- a/onnxruntime/core/dll/delay_load_hook.cc
+++ b/onnxruntime/core/dll/delay_load_hook.cc
@@ -67,7 +67,7 @@ FARPROC WINAPI delay_load_hook(unsigned dliNotify, PDelayLoadInfo pdli) {
         // Try to load the DLL from the same directory as onnxruntime.dll
 
         // First, get the path to onnxruntime.dll
-        auto path = Env::Default().GetRuntimePath();
+        auto path = onnxruntime::Env::Default().GetRuntimePath();
         if (path.empty()) {
           // Failed to get the path to onnxruntime.dll. In this case, we will just return NULL and let the system
           // search for the DLL in the default search order.

--- a/onnxruntime/core/dll/delay_load_hook.cc
+++ b/onnxruntime/core/dll/delay_load_hook.cc
@@ -24,8 +24,16 @@
 // - both USE_WEBGPU and BUILD_DAWN_MONOLITHIC_LIBRARY are defined
 // - USE_DML is defined
 //
-#define ORT_DELAY_LOAD_WEBGPU_DAWN_DLL (defined(USE_WEBGPU) && defined(BUILD_DAWN_MONOLITHIC_LIBRARY))
-#define ORT_DELAY_LOAD_DIRECTML_DLL defined(USE_DML)
+#if defined(USE_WEBGPU) && defined(BUILD_DAWN_MONOLITHIC_LIBRARY)
+#define ORT_DELAY_LOAD_WEBGPU_DAWN_DLL 1
+#else
+#define ORT_DELAY_LOAD_WEBGPU_DAWN_DLL 0
+#endif
+#if defined(USE_DML)
+#define ORT_DELAY_LOAD_DIRECTML_DLL 1
+#else
+#define ORT_DELAY_LOAD_DIRECTML_DLL 0
+#endif
 #if defined(_MSC_VER) && (ORT_DELAY_LOAD_WEBGPU_DAWN_DLL || ORT_DELAY_LOAD_DIRECTML_DLL)
 
 #include <Windows.h>

--- a/onnxruntime/test/webgpu/delay_load/main.cc
+++ b/onnxruntime/test/webgpu/delay_load/main.cc
@@ -118,6 +118,7 @@ int test_main() {
   HMODULE hModule = LoadLibraryA("dlls\\onnxruntime.dll");
   if (hModule == NULL) {
     std::cout << "Failed to load dlls\\onnxruntime.dll" << std::endl;
+    std::cout << "Error code: " << GetLastError() << std::endl;
     return 1;
   }
 


### PR DESCRIPTION
### Description

This change fixes the WebGPU delay load test.


<details>
<summary>Fix UB in macro</summary>

The following C++ code outputs `2, 1` in MSVC, while it outputs `1, 1` in GCC:

```c++
#include <iostream>

#define A 1
#define B 1

#define ENABLE defined(A) && defined(B)

#if ENABLE
int x = 1;
#else
int x = 2;
#endif

#if defined(A) && defined(B)
int y = 1;
#else
int y = 2;
#endif

int main()
{
    std::cout << x << ", " << y << "\n";
}
```

Clang reports `macro expansion producing 'defined' has undefined behavior [-Wexpansion-to-defined]`.

</details>

<details>
<summary>Fix condition of build option onnxruntime_ENABLE_DELAY_LOADING_WIN_DLLS</summary>

Delay load is explicitly disabled when python binding is being built. modifies the condition.

</details>