### PR TITLE
[webgpu] Add kernel type to profile info

### DIFF
--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -239,6 +239,7 @@ Status WebGpuContext::Run(ComputeContext& context, const ProgramBase& program) {
 
   if (is_profiling_) {
     PendingKernelInfo pending_kernel_info(context.KernelContext().GetNodeName(),
+                                          context.KernelContext().GetOpType(),
                                           program.Name(),
                                           key,
                                           inputs,

--- a/onnxruntime/core/providers/webgpu/webgpu_context.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.h
@@ -147,11 +147,12 @@ class WebGpuContext final {
 
   struct PendingKernelInfo {
     PendingKernelInfo(std::string_view kernel_name,
+                      std::string_view kernel_type,
                       std::string_view program_name,
                       std::string_view cache_key,
                       const std::vector<ProgramInput>& inputs,
                       const std::vector<ProgramOutput>& outputs)
-        : name{absl::StrJoin({kernel_name, program_name}, "_")}, cache_key{cache_key}, inputs{inputs}, outputs{outputs} {}
+        : name{absl::StrJoin({kernel_name, kernel_type, program_name}, "&")}, cache_key{cache_key}, inputs{inputs}, outputs{outputs} {}
 
     PendingKernelInfo(PendingKernelInfo&&) = default;
     PendingKernelInfo& operator=(PendingKernelInfo&&) = default;


### PR DESCRIPTION
### Description
This PR is convenient to do post processing for the generated json file when profiling is enabled. Kernel type can be used to aggregate the same type kernels' overall time.


