### PR TITLE
Update onnxruntime_c_api.h to work with MinGW

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -46,7 +46,7 @@ extern "C" {
 
 //! @}
 // SAL2 Definitions
-#ifndef _WIN32
+#ifndef _MSC_VER
 #define _In_
 #define _In_z_
 #define _In_opt_


### PR DESCRIPTION
The SAL2 macros are not always available there

### Description

Make SAL2 macros only available on MSVC.

### Motivation and Context

https://github.com/microsoft/onnxruntime/issues/1175


