### PR TITLE
Fix a tiny problem in winml.cmake

### DIFF
--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -782,7 +782,7 @@ add_dependencies(winml_dll winml_api_native)
 add_dependencies(winml_dll winml_api_native_internal)
 
 # Link libraries
-target_link_libraries(winml_dll PRIVATE re2)
+target_link_libraries(winml_dll PRIVATE re2::re2)
 target_link_libraries(winml_dll PRIVATE ${WIL_TARGET})
 target_link_libraries(winml_dll PRIVATE winml_lib_api)
 if (NOT winml_is_inbox)


### PR DESCRIPTION
### Description
CMake's [target_link_libraries](https://cmake.org/cmake/help/latest/command/target_link_libraries.html#id2) function accepts plain library name(like `re2`) or target name(like `re2::re2`) or some other kinds of names. "plain library names" are old-fashioned, for compatibility only.  We should use target names. 

### Motivation and Context
To make vcpkg work with winml build. See #23158 

