### PR TITLE
Disable CodeQL in python packaging pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/stages/py-win-gpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/py-win-gpu-stage.yml
@@ -60,6 +60,9 @@ stages:
             enabled: true
             scanOutputDirectoryOnly: true
             targetPathPattern: '+:file|*.dll;-:file|DirectML.dll'
+          codeql:
+            compiled:
+              enabled: false #Otherwise the job will run more than 6 hours and timeout
         outputs:
         - output: pipelineArtifact
           targetPath: $(Build.ArtifactStagingDirectory)


### PR DESCRIPTION
Disable the scanner because it is causing timeout issues. 
See:
https://aiinfra.visualstudio.com/Lotus/_build?definitionId=1299&_a=summary