### PR TITLE
delete the supported domain version upper bounds

### DIFF
--- a/onnxruntime/core/providers/cann/cann_graph.cc
+++ b/onnxruntime/core/providers/cann/cann_graph.cc
@@ -10,7 +10,7 @@
 namespace onnxruntime {
 namespace cann {
 
-static int lower_bound = 8;   // Supported domain version lower bounds
+static int lower_bound = 8;  // Supported domain version lower bounds
 
 std::once_flag flag;
 

--- a/onnxruntime/core/providers/cann/cann_graph.cc
+++ b/onnxruntime/core/providers/cann/cann_graph.cc
@@ -11,7 +11,6 @@ namespace onnxruntime {
 namespace cann {
 
 static int lower_bound = 8;   // Supported domain version lower bounds
-static int upper_bound = 15;  // Supported domain version upper bounds
 
 std::once_flag flag;
 
@@ -62,7 +61,7 @@ std::vector<NodeIndex> SupportONNXModel(const GraphViewer& graph_viewer) {
   for (const auto& index : graph_viewer.GetNodesInTopologicalOrder()) {
     const auto& node = graph_viewer.GetNode(index);
 
-    if (node->Domain() != kOnnxDomain || domain_version < lower_bound || domain_version > upper_bound ||
+    if (node->Domain() != kOnnxDomain || domain_version < lower_bound ||
         !cann_supported_ops.count(node->OpType())) {
       unsupported_nodes.push_back(index);
       continue;


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

This PR changes the range of ONNX versions supported by CANN graph inference to no upper limit (the previous version supports between 8 and 15), because the CANN version is further upgraded to support some developers' requirements for higher ONNX versions.
### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


