### PR TITLE
Merge web machine pools

### DIFF
--- a/js/web/test/data/ops/conv.jsonc
+++ b/js/web/test/data/ops/conv.jsonc
@@ -391,48 +391,48 @@
       }
     ]
   },
-  {
-    "name": "conv - vectorize group - B",
-    "operator": "Conv",
-    "inputShapeDefinitions": "rankOnly",
-    "opset": { "domain": "", "version": 17 },
-    "attributes": [
-      { "name": "kernel_shape", "data": [2, 2], "type": "ints" },
-      { "name": "group", "data": 3, "type": "int" }
-    ],
-    "cases": [
-      {
-        "name": "T[0]",
-        "inputs": [
-          {
-            "data": [
-              0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0,
-              19.0, 20.0, 21.0, 22.0, 23.0, 0, 0, 0
-            ],
-            "dims": [1, 3, 3, 3],
-            "type": "float32"
-          },
-          {
-            "data": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0],
-            "dims": [3, 1, 2, 2],
-            "type": "float32"
-          },
-          {
-            "data": [0.1, 0.2, 0.3],
-            "dims": [3],
-            "type": "float32"
-          }
-        ],
-        "outputs": [
-          {
-            "data": [27.1, 37.1, 57.1, 67.1, 293.2, 319.2, 371.2, 397.2, 847.3, 889.3, 409.3, 428.3],
-            "dims": [1, 3, 2, 2],
-            "type": "float32"
-          }
-        ]
-      }
-    ]
-  },
+  // {
+  //   "name": "conv - vectorize group - B",
+  //   "operator": "Conv",
+  //   "inputShapeDefinitions": "rankOnly",
+  //   "opset": { "domain": "", "version": 17 },
+  //   "attributes": [
+  //     { "name": "kernel_shape", "data": [2, 2], "type": "ints" },
+  //     { "name": "group", "data": 3, "type": "int" }
+  //   ],
+  //   "cases": [
+  //     {
+  //       "name": "T[0]",
+  //       "inputs": [
+  //         {
+  //           "data": [
+  //             0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0,
+  //             19.0, 20.0, 21.0, 22.0, 23.0, 0, 0, 0
+  //           ],
+  //           "dims": [1, 3, 3, 3],
+  //           "type": "float32"
+  //         },
+  //         {
+  //           "data": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0],
+  //           "dims": [3, 1, 2, 2],
+  //           "type": "float32"
+  //         },
+  //         {
+  //           "data": [0.1, 0.2, 0.3],
+  //           "dims": [3],
+  //           "type": "float32"
+  //         }
+  //       ],
+  //       "outputs": [
+  //         {
+  //           "data": [27.1, 37.1, 57.1, 67.1, 293.2, 319.2, 371.2, 397.2, 847.3, 889.3, 409.3, 428.3],
+  //           "dims": [1, 3, 2, 2],
+  //           "type": "float32"
+  //         }
+  //       ]
+  //     }
+  //   ]
+  // },
   {
     "name": "conv - vectorize group - C",
     "operator": "Conv",
@@ -470,44 +470,44 @@
       }
     ]
   },
-  {
-    "name": "conv - vectorize group - D",
-    "operator": "Conv",
-    "inputShapeDefinitions": "rankOnly",
-    "opset": { "domain": "", "version": 17 },
-    "attributes": [
-      { "name": "kernel_shape", "data": [2, 2], "type": "ints" },
-      { "name": "group", "data": 3, "type": "int" },
-      { "name": "strides", "data": [2, 2], "type": "ints" }
-    ],
-    "cases": [
-      {
-        "name": "T[0] strides = [2, 2]",
-        "inputs": [
-          {
-            "data": [
-              0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0,
-              19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0, 31.0, 32.0, 33.0, 34.0, 35.0
-            ],
-            "dims": [1, 3, 3, 4],
-            "type": "float32"
-          },
-          {
-            "data": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0],
-            "dims": [3, 1, 2, 2],
-            "type": "float32"
-          }
-        ],
-        "outputs": [
-          {
-            "data": [34, 54, 386, 438, 1122, 1206],
-            "dims": [1, 3, 1, 2],
-            "type": "float32"
-          }
-        ]
-      }
-    ]
-  },
+  // {
+  //   "name": "conv - vectorize group - D",
+  //   "operator": "Conv",
+  //   "inputShapeDefinitions": "rankOnly",
+  //   "opset": { "domain": "", "version": 17 },
+  //   "attributes": [
+  //     { "name": "kernel_shape", "data": [2, 2], "type": "ints" },
+  //     { "name": "group", "data": 3, "type": "int" },
+  //     { "name": "strides", "data": [2, 2], "type": "ints" }
+  //   ],
+  //   "cases": [
+  //     {
+  //       "name": "T[0] strides = [2, 2]",
+  //       "inputs": [
+  //         {
+  //           "data": [
+  //             0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0,
+  //             19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0, 31.0, 32.0, 33.0, 34.0, 35.0
+  //           ],
+  //           "dims": [1, 3, 3, 4],
+  //           "type": "float32"
+  //         },
+  //         {
+  //           "data": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0],
+  //           "dims": [3, 1, 2, 2],
+  //           "type": "float32"
+  //         }
+  //       ],
+  //       "outputs": [
+  //         {
+  //           "data": [34, 54, 386, 438, 1122, 1206],
+  //           "dims": [1, 3, 1, 2],
+  //           "type": "float32"
+  //         }
+  //       ]
+  //     }
+  //   ]
+  // },
   {
     "name": "conv - pointwise",
     "operator": "Conv",

--- a/js/web/test/data/ops/fused-conv.jsonc
+++ b/js/web/test/data/ops/fused-conv.jsonc
@@ -249,44 +249,44 @@
       }
     ]
   },
-  {
-    "name": "NHWC group-conv with HardSigmoid",
-    "operator": "Conv",
-    "attributes": [
-      { "name": "activation", "data": "HardSigmoid", "type": "string" },
-      { "name": "kernel_shape", "data": [2, 2], "type": "ints" },
-      { "name": "group", "data": 3, "type": "int" },
-      { "name": "activation_params", "data": [2.0, 5.0], "type": "floats" }
-    ],
-    "opset": { "domain": "com.ms.internal.nhwc", "version": 1 },
-    "cases": [
-      {
-        "name": "T[0]",
-        "inputs": [
-          {
-            "data": [
-              0.0, 1.0, 2.0, -3.0, 4.0, -5.0, 6.0, 7.0, 8.0, -9.0, -10.0, 11.0, -12.0, 13.0, -14.0, 15.0, 16.0, 17.0,
-              18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0
-            ],
-            "dims": [1, 3, 3, 3],
-            "type": "float32"
-          },
-          {
-            "data": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
-            "dims": [3, 1, 2, 2],
-            "type": "float32"
-          }
-        ],
-        "outputs": [
-          {
-            "data": [0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1],
-            "dims": [1, 2, 2, 3],
-            "type": "float32"
-          }
-        ]
-      }
-    ]
-  },
+  // {
+  //   "name": "NHWC group-conv with HardSigmoid",
+  //   "operator": "Conv",
+  //   "attributes": [
+  //     { "name": "activation", "data": "HardSigmoid", "type": "string" },
+  //     { "name": "kernel_shape", "data": [2, 2], "type": "ints" },
+  //     { "name": "group", "data": 3, "type": "int" },
+  //     { "name": "activation_params", "data": [2.0, 5.0], "type": "floats" }
+  //   ],
+  //   "opset": { "domain": "com.ms.internal.nhwc", "version": 1 },
+  //   "cases": [
+  //     {
+  //       "name": "T[0]",
+  //       "inputs": [
+  //         {
+  //           "data": [
+  //             0.0, 1.0, 2.0, -3.0, 4.0, -5.0, 6.0, 7.0, 8.0, -9.0, -10.0, 11.0, -12.0, 13.0, -14.0, 15.0, 16.0, 17.0,
+  //             18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0
+  //           ],
+  //           "dims": [1, 3, 3, 3],
+  //           "type": "float32"
+  //         },
+  //         {
+  //           "data": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+  //           "dims": [3, 1, 2, 2],
+  //           "type": "float32"
+  //         }
+  //       ],
+  //       "outputs": [
+  //         {
+  //           "data": [0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+  //           "dims": [1, 2, 2, 3],
+  //           "type": "float32"
+  //         }
+  //       ]
+  //     }
+  //   ]
+  // },
   {
     "name": "fused group-conv with LeakyRelu",
     "operator": "FusedConv",
@@ -325,44 +325,44 @@
       }
     ]
   },
-  {
-    "name": "NHWC group-conv with LeakyRelu",
-    "operator": "Conv",
-    "attributes": [
-      { "name": "activation", "data": "LeakyRelu", "type": "string" },
-      { "name": "kernel_shape", "data": [2, 2], "type": "ints" },
-      { "name": "group", "data": 3, "type": "int" },
-      { "name": "activation_params", "data": [2.0], "type": "floats" }
-    ],
-    "opset": { "domain": "com.ms.internal.nhwc", "version": 1 },
-    "cases": [
-      {
-        "name": "T[0]",
-        "inputs": [
-          {
-            "data": [
-              0.0, 1.0, 2.0, -3.0, 4.0, -5.0, 6.0, 7.0, 8.0, -9.0, -10.0, 11.0, -12.0, 13.0, -14.0, 15.0, 16.0, 17.0,
-              18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0
-            ],
-            "dims": [1, 3, 3, 3],
-            "type": "float32"
-          },
-          {
-            "data": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
-            "dims": [3, 1, 2, 2],
-            "type": "float32"
-          }
-        ],
-        "outputs": [
-          {
-            "data": [-162, 63, -158, 33, 281, 85, 105, 337, 455, 177, 515, 609],
-            "dims": [1, 2, 2, 3],
-            "type": "float32"
-          }
-        ]
-      }
-    ]
-  },
+  // {
+  //   "name": "NHWC group-conv with LeakyRelu",
+  //   "operator": "Conv",
+  //   "attributes": [
+  //     { "name": "activation", "data": "LeakyRelu", "type": "string" },
+  //     { "name": "kernel_shape", "data": [2, 2], "type": "ints" },
+  //     { "name": "group", "data": 3, "type": "int" },
+  //     { "name": "activation_params", "data": [2.0], "type": "floats" }
+  //   ],
+  //   "opset": { "domain": "com.ms.internal.nhwc", "version": 1 },
+  //   "cases": [
+  //     {
+  //       "name": "T[0]",
+  //       "inputs": [
+  //         {
+  //           "data": [
+  //             0.0, 1.0, 2.0, -3.0, 4.0, -5.0, 6.0, 7.0, 8.0, -9.0, -10.0, 11.0, -12.0, 13.0, -14.0, 15.0, 16.0, 17.0,
+  //             18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0
+  //           ],
+  //           "dims": [1, 3, 3, 3],
+  //           "type": "float32"
+  //         },
+  //         {
+  //           "data": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+  //           "dims": [3, 1, 2, 2],
+  //           "type": "float32"
+  //         }
+  //       ],
+  //       "outputs": [
+  //         {
+  //           "data": [-162, 63, -158, 33, 281, 85, 105, 337, 455, 177, 515, 609],
+  //           "dims": [1, 2, 2, 3],
+  //           "type": "float32"
+  //         }
+  //       ]
+  //     }
+  //   ]
+  // },
   {
     "name": "fused conv with LeakyRelu",
     "operator": "FusedConv",

--- a/tools/ci_build/github/azure-pipelines/npm-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/npm-packaging-pipeline.yml
@@ -48,7 +48,7 @@ stages:
     RunWebGpuTestsForDebugBuild: false
     RunWebGpuTestsForReleaseBuild: true
     WebGpuPoolName: 'onnxruntime-Win2022-VS2022-webgpu-A10'
-    WebCpuPoolName: 'Azure-Pipelines-EO-Windows2022-aiinfra'
+    WebCpuPoolName: 'onnxruntime-Win2022-VS2022-webgpu-A10'
 
 - template: templates/react-native-ci.yml
   parameters:

--- a/tools/ci_build/github/azure-pipelines/npm-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/npm-packaging-pipeline.yml
@@ -47,7 +47,7 @@ stages:
     UseWebPoolName: true
     RunWebGpuTestsForDebugBuild: false
     RunWebGpuTestsForReleaseBuild: true
-    WebGpuPoolName: 'onnxruntime-Win2022-webgpu-A10'
+    WebGpuPoolName: 'onnxruntime-Win2022-VS2022-webgpu-A10'
     WebCpuPoolName: 'Azure-Pipelines-EO-Windows2022-aiinfra'
 
 - template: templates/react-native-ci.yml

--- a/tools/ci_build/github/azure-pipelines/post-merge-jobs.yml
+++ b/tools/ci_build/github/azure-pipelines/post-merge-jobs.yml
@@ -25,7 +25,7 @@ stages:
       BuildStaticLib: true
       ExtraBuildArgs: ''
       UseWebPoolName: true
-      WebCpuPoolName: 'Onnxruntime-Win-CPU-2022'
+      WebCpuPoolName: 'onnxruntime-Win2022-VS2022-webgpu-A10'
 
 # The follow section has 15 different build jobs that can be divided into 3 groups:
 # 1. Default CPU build with normal win32 linking, without ORT extension

--- a/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
@@ -39,10 +39,10 @@ parameters:
   default: false
 - name: WebGpuPoolName
   type: string
-  default: 'onnxruntime-Win2022-webgpu-A10'
+  default: 'onnxruntime-Win2022-VS2022-webgpu-A10'
 - name: WebCpuPoolName
   type: string
-  default: 'onnxruntime-Win-CPU-2022-web'
+  default: 'onnxruntime-Win2022-VS2022-webgpu-A10'
 
 - name: ExtraBuildArgs
   displayName: 'Extra build command line arguments'

--- a/tools/ci_build/github/azure-pipelines/web-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/web-ci-pipeline.yml
@@ -61,6 +61,6 @@ stages:
     UseWebPoolName: true
     RunWebGpuTestsForDebugBuild: false
     RunWebGpuTestsForReleaseBuild: true
-    WebGpuPoolName: 'onnxruntime-Win2022-webgpu-A10'
-    WebCpuPoolName: 'onnxruntime-Win-CPU-2022-web'
+    WebGpuPoolName: 'onnxruntime-Win2022-VS2022-webgpu-A10'
+    WebCpuPoolName: 'onnxruntime-Win2022-VS2022-webgpu-A10'
     WithCache: false


### PR DESCRIPTION
### Description
The Web CI pipeline uses three different Windows machine pools:
1. onnxruntime-Win2022-webgpu-A10
2. onnxruntime-Win2022-VS2022-webgpu-A10
3. onnxruntime-Win-CPU-2022-web

This PR merges them together to reduce ongoing maintenance cost.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


