### PR TITLE
Update Python-Cuda-Publishing-Pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/stages/py-cuda-publishing-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/py-cuda-publishing-stage.yml
@@ -38,5 +38,12 @@ stages:
       displayName: 'Twine Authenticate '
       inputs:
         artifactFeed: PublicPackages/${{ parameters.artifact_feed }}
-    - script: find $(Pipeline.Workspace) -name \*.whl
+    - script: find $(Pipeline.Workspace) -name \*win_amd64.whl -exec mv {} $(Pipeline.Workspace)/build/onnxruntime_gpu \;
+      displayName: 'Merge files together'
 
+    - script: 'python -m twine upload -r ${{ parameters.artifact_feed }} --config-file $(PYPIRC_PATH) --non-interactive --skip-existing *.whl'
+      workingDirectory: '$(Pipeline.Workspace)/build/onnxruntime_gpu'
+      displayName: 'Uploading wheels to ${{ parameters.artifact_feed }}'
+      retryCountOnTaskFailure: 3
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/tools/ci_build/github/azure-pipelines/stages/py-cuda-publishing-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/py-cuda-publishing-stage.yml
@@ -13,6 +13,23 @@ stages:
     - download: build
       displayName: 'Download Pipeline Artifact - onnxruntime_gpu'
       artifact: 'onnxruntime_gpu'
+    - download: build
+      displayName: 'Download Pipeline Artifact - Win GPU 3.10'
+      artifact: 'win_gpu_wheel_3.10'
+      patterns: '*.whl'
+    - download: build
+      displayName: 'Download Pipeline Artifact - Win GPU 3.11'
+      artifact: 'win_gpu_wheel_3.11'
+      patterns: '*.whl'
+    - download: build
+      displayName: 'Download Pipeline Artifact - Win GPU 3.12'
+      artifact: 'win_gpu_wheel_3.12'
+      patterns: '*.whl'
+    - download: build
+      displayName: 'Download Pipeline Artifact - Win GPU 3.13'
+      artifact: 'win_gpu_wheel_3.13'
+      patterns: '*.whl'
+      
     - task: UsePythonVersion@0
       displayName: 'Use Python 3.x'
     - script: 'pip install twine==3.4.2'

--- a/tools/ci_build/github/azure-pipelines/stages/py-cuda-publishing-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/py-cuda-publishing-stage.yml
@@ -41,9 +41,6 @@ stages:
     - script: find $(Pipeline.Workspace) -name \*win_amd64.whl -exec mv {} $(Pipeline.Workspace)/build/onnxruntime_gpu \;
       displayName: 'Merge files together'
 
-    - script: 'python -m twine upload -r ${{ parameters.artifact_feed }} --config-file $(PYPIRC_PATH) --non-interactive --skip-existing *.whl'
+    - script: 'python -m twine upload -r ${{ parameters.artifact_feed }} --config-file $(PYPIRC_PATH) --non-interactive *.whl'
       workingDirectory: '$(Pipeline.Workspace)/build/onnxruntime_gpu'
       displayName: 'Uploading wheels to ${{ parameters.artifact_feed }}'
-      retryCountOnTaskFailure: 3
-      env:
-        SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/tools/ci_build/github/azure-pipelines/stages/py-cuda-publishing-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/py-cuda-publishing-stage.yml
@@ -38,10 +38,5 @@ stages:
       displayName: 'Twine Authenticate '
       inputs:
         artifactFeed: PublicPackages/${{ parameters.artifact_feed }}
-    - script: 'python -m twine upload -r ${{ parameters.artifact_feed }} --config-file $(PYPIRC_PATH) --non-interactive --skip-existing *.whl'
-      workingDirectory: '$(Pipeline.Workspace)/build/onnxruntime_gpu'
-      displayName: 'Uploading wheels to ${{ parameters.artifact_feed }}'
-      retryCountOnTaskFailure: 3
-      env:
-        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    - script: find $(Pipeline.Workspace) -name \*.whl
 

--- a/tools/ci_build/github/azure-pipelines/stages/py-win-gpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/py-win-gpu-stage.yml
@@ -59,7 +59,7 @@ stages:
           binskim:
             enabled: true
             scanOutputDirectoryOnly: true
-            targetPathPattern: '+:file|*.dll;-:file|DirectML.dll'
+            analyzeTargetGlob: '+:file|*.pyd;+:file|*.dll;-:file|DirectML.dll'
         outputs:
         - output: pipelineArtifact
           targetPath: $(Build.ArtifactStagingDirectory)
@@ -121,7 +121,7 @@ stages:
           - template: ../templates/set-nightly-build-option-variable-step.yml
 
           - task: PythonScript@0
-            displayName: 'Generate cmake config'
+            displayName: 'Build'
             inputs:
               scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
               arguments: >
@@ -131,7 +131,7 @@ stages:
                 --cmake_generator "$(VSGenerator)"
                 --enable_pybind
                 --enable_onnx_tests
-                --parallel --use_binskim_compliant_compile_flags --update --build
+                --parallel 8 --use_binskim_compliant_compile_flags --update --build
                 $(TelemetryOption) ${{ parameters.BUILD_PY_PARAMETERS }} ${{ parameters.EP_BUILD_FLAGS }} ${{ variables.trt_build_flag }}
               workingDirectory: '$(Build.BinariesDirectory)'
 

--- a/tools/ci_build/github/windows/eager/requirements.txt
+++ b/tools/ci_build/github/windows/eager/requirements.txt
@@ -1,7 +1,0 @@
-setuptools
-wheel
-numpy==1.21.6 ; python_version < '3.9'
-numpy==2.1.2 ; python_version >= '3.9'
-typing_extensions
-torch==2.2.0
-parameterized

--- a/tools/ci_build/requirements/pybind/requirements.txt
+++ b/tools/ci_build/requirements/pybind/requirements.txt
@@ -1,7 +1,7 @@
 setuptools
 wheel
 pytest
-numpy>=1.19.0
+numpy
 sympy>=1.10
 packaging
 cerberus


### PR DESCRIPTION
### Description
Currently Python-Cuda-Publishing-Pipeline only publishes Linux wheels, not Windows wheels. It is because recently we refactored the upstream pipeline("Python-CUDA-Packaging-Pipeline") to use 1ES PT. 
This PR fixes the pipeline. 

### Motivation and Context
Publish Windows wheels 


