### PR TITLE
Address CodeQL security issues on comparison of different types

### DIFF
--- a/onnxruntime/core/framework/transpose_helper.cc
+++ b/onnxruntime/core/framework/transpose_helper.cc
@@ -27,7 +27,7 @@ typename std::enable_if<!has_mlas_transpose<T>::value, void>::type SimpleTranspo
   for (int64_t l = 0; l < num_loops; ++l) {
     T* output_for_first_writer = output_data;
 
-    for (auto wwpl = 0; wwpl < writes_per_writer_per_loop; ++wwpl) {
+    for (int64_t wwpl = 0; wwpl < writes_per_writer_per_loop; ++wwpl) {
       T* output_for_current_writer = output_for_first_writer;
 
       end = input_data + num_writers;
@@ -130,7 +130,7 @@ typename std::enable_if<!has_mlas_transpose<T>::value, void>::type SimpleTranspo
   for (int64_t l = 0; l < num_loops; ++l) {
     const T* input_for_first_reader = input_data;
 
-    for (auto rrpl = 0; rrpl < reads_per_reader_per_loop; ++rrpl) {
+    for (int64_t rrpl = 0; rrpl < reads_per_reader_per_loop; ++rrpl) {
       const T* input_for_current_reader = input_for_first_reader;
 
       end = output_data + num_readers;
@@ -210,7 +210,7 @@ void TransposeSingleAxisInwards(gsl::span<const size_t> permutations, const Tens
       for (int64_t l = 0; l < num_loops; ++l) {
         const uint8_t* input_for_first_reader = input_data;
 
-        for (auto rrpl = 0; rrpl < reads_per_reader_per_loop; ++rrpl) {
+        for (int64_t rrpl = 0; rrpl < reads_per_reader_per_loop; ++rrpl) {
           const uint8_t* input_for_current_reader = input_for_first_reader;
 
           for (int64_t r = 0; r < num_readers; ++r) {

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -2890,15 +2890,15 @@ void RegisterContribSchemas() {
         if (ctx.getNumOutputs() > 1) {
           auto saved_mean_shape = ctx.getOutputType(1)->mutable_tensor_type()->mutable_shape();
           saved_mean_shape->CopyFrom(input_shape);
-          for (int d = static_cast<int>(axis); d < input_ndim; ++d)
-            saved_mean_shape->mutable_dim(d)->set_dim_value(1);
+          for (int64_t d = axis; d < input_ndim; ++d)
+            saved_mean_shape->mutable_dim(static_cast<int>(d))->set_dim_value(1);
         }
 
         if (ctx.getNumOutputs() > 2) {
           auto saved_inv_std_dev_shape = ctx.getOutputType(2)->mutable_tensor_type()->mutable_shape();
           saved_inv_std_dev_shape->CopyFrom(input_shape);
-          for (int d = static_cast<int>(axis); d < input_ndim; ++d)
-            saved_inv_std_dev_shape->mutable_dim(d)->set_dim_value(1);
+          for (int64_t d = axis; d < input_ndim; ++d)
+            saved_inv_std_dev_shape->mutable_dim(static_cast<int>(d))->set_dim_value(1);
         }
       })
       .SetContextDependentFunctionBodyBuilder(

--- a/onnxruntime/core/graph/graph_utils.cc
+++ b/onnxruntime/core/graph/graph_utils.cc
@@ -869,13 +869,13 @@ bool RemoveNodesWithOneOutputBottomUp(Graph& graph, const Node& start_node) {
     }
 
     // push the parents of current node to the queue.
-    for (unsigned int i = 0; i < cur_node.InputDefs().size(); ++i) {
-      const std::string& input_name = GetNodeInputName(cur_node, i);
-      if (IsInitializer(graph, input_name, true) || IsGraphInput(graph, cur_node.InputDefs()[i])) {
+    for (size_t i = 0; i < cur_node.InputDefs().size(); ++i) {
+      const std::string& input_name = GetNodeInputName(cur_node, static_cast<int>(i));
+      if (IsInitializer(graph, input_name, true) || IsGraphInput(graph, cur_node.InputDefs()[static_cast<int>(i)])) {
         // skip initializers and graph inputs
         continue;
       }
-      const Node* parent_node = GetInputNode(cur_node, i);
+      const Node* parent_node = GetInputNode(cur_node, static_cast<int>(i));
       if (nullptr == parent_node) {
         continue;
       }

--- a/onnxruntime/core/optimizer/attention_fusion_helper.h
+++ b/onnxruntime/core/optimizer/attention_fusion_helper.h
@@ -281,8 +281,8 @@ bool ValidateUnidirMask(std::vector<T> mask_data, int64_t w, bool& is_undirectio
     is_undirectional = true;
 
     const T* p = mask_data.data();
-    for (int i = 0; i < w; i++) {
-      for (int j = 0; j < w; j++) {
+    for (int64_t i = 0; i < w; i++) {
+      for (int64_t j = 0; j < w; j++) {
         if (*p != static_cast<T>(1)) {
           is_one = false;
         }

--- a/onnxruntime/core/util/qmath.h
+++ b/onnxruntime/core/util/qmath.h
@@ -64,7 +64,7 @@ void GetQuantizationParameter(const float* data, int64_t num_of_elements, float&
     block_size = onnxruntime::narrow<std::ptrdiff_t>(num_of_elements);
   }
 
-  for (int i = 0; i < num_blocks; i++) {
+  for (int i = 0; i < narrow<int>(num_blocks); i++) {
     aggregate[i].min = std::numeric_limits<float>::max();
     aggregate[i].max = std::numeric_limits<float>::lowest();
   }
@@ -79,7 +79,7 @@ void GetQuantizationParameter(const float* data, int64_t num_of_elements, float&
 
   float& min = aggregate[0].min;
   float& max = aggregate[0].max;
-  for (int i = 1; i < num_blocks; i++) {
+  for (int i = 1; i < narrow<int>(num_blocks); i++) {
     min = std::min(min, aggregate[i].min);
     max = std::max(max, aggregate[i].max);
   }


### PR DESCRIPTION
### Description
Fix comparison of narrow type with wide type in loop condition.

### Motivation and Context
Comparison between types of different widths in a loop condition can cause the loop to fail to terminate.


