### PR TITLE
Add a temporary path to RN 0.69.3 to update the boost url

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
@@ -200,14 +200,24 @@ stages:
 
 # TODO: remove this once we upgrade the RN to post 0.70.15 or 0.73.3+ versions this is just a temporary workaround
     - script: |
-        sed -i .bak "/boostorg.jfrog.io/c\spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2',|" boost.podspec
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+          sed -i .bak "/boostorg.jfrog.io/c\\
+        spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2', }" boost.podspec
+        else
+          sed -i .bak "/boostorg.jfrog.io/c\spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2', }" boost.podspec
+        fi
         rm -f .bak
       workingDirectory: '$(Build.SourcesDirectory)/js/react_native/node_modules/react-native/third-party-podspecs'
       displayName: Path the boost 1.76.0 source URL in boost.podspec js/react_native/node_modules/react-native/third-party-podspecs/boost.podspec
 
 # TODO: remove this once we upgrade the RN to post 0.70.15 or 0.73.3+ versions this is just a temporary workaround
     - script: |
-        sed -i .bak "/boostorg.jfrog.io/c\spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2',|" boost.podspec
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+          sed -i .bak "/boostorg.jfrog.io/c\\
+        spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2', }" boost.podspec
+        else
+          sed -i .bak "/boostorg.jfrog.io/c\spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2', }" boost.podspec
+        fi
         rm -f .bak
       workingDirectory: '$(Build.SourcesDirectory)/js/react_native/e2e/node_modules/react-native/third-party-podspecs'
       displayName: Path the boost 1.76.0 source URL in boost.podspec in js/react_native/e2e/node_modules/react-native/third-party-podspecs/boost.podspec

--- a/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
@@ -198,6 +198,20 @@ stages:
       workingDirectory: '$(Build.SourcesDirectory)/js/react_native/e2e'
       displayName: Bootstrap Android and iOS e2e tests
 
+# TODO: remove this once we upgrade the RN to post 0.70.15 or 0.73.3+ versions this is just a temporary workaround
+    - script: |
+        sed -i .bak "13s|.*boost_1_76_0.tar.bz2.*|spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2',|" boost.podspec
+        rm -f .bak
+      workingDirectory: '$(Build.SourcesDirectory)/js/react_native/node_modules/react-native/third-party-podspecs'
+      displayName: Path the boost 1.76.0 source URL in boost.podspec js/react_native/node_modules/react-native/third-party-podspecs/boost.podspec
+
+# TODO: remove this once we upgrade the RN to post 0.70.15 or 0.73.3+ versions this is just a temporary workaround
+    - script: |
+        sed -i .bak "13s|.*boost_1_76_0.tar.bz2.*|spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2',|" boost.podspec
+        rm -f .bak
+      workingDirectory: '$(Build.SourcesDirectory)/js/react_native/e2e/node_modules/react-native/third-party-podspecs'
+      displayName: Path the boost 1.76.0 source URL in boost.podspec in js/react_native/e2e/node_modules/react-native/third-party-podspecs/boost.podspec
+
     - script: |
         ORT_C_LOCAL_POD_PATH=$(Build.BinariesDirectory)/ios-full-pod/onnxruntime-c \
         pod install

--- a/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
@@ -200,14 +200,14 @@ stages:
 
 # TODO: remove this once we upgrade the RN to post 0.70.15 or 0.73.3+ versions this is just a temporary workaround
     - script: |
-        sed -i .bak "13s|.*boost_1_76_0.tar.bz2.*|spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2',|" boost.podspec
+        sed -i .bak "/boostorg.jfrog.io/c\spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2',|" boost.podspec
         rm -f .bak
       workingDirectory: '$(Build.SourcesDirectory)/js/react_native/node_modules/react-native/third-party-podspecs'
       displayName: Path the boost 1.76.0 source URL in boost.podspec js/react_native/node_modules/react-native/third-party-podspecs/boost.podspec
 
 # TODO: remove this once we upgrade the RN to post 0.70.15 or 0.73.3+ versions this is just a temporary workaround
     - script: |
-        sed -i .bak "13s|.*boost_1_76_0.tar.bz2.*|spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2',|" boost.podspec
+        sed -i .bak "/boostorg.jfrog.io/c\spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2',|" boost.podspec
         rm -f .bak
       workingDirectory: '$(Build.SourcesDirectory)/js/react_native/e2e/node_modules/react-native/third-party-podspecs'
       displayName: Path the boost 1.76.0 source URL in boost.podspec in js/react_native/e2e/node_modules/react-native/third-party-podspecs/boost.podspec

--- a/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
@@ -202,9 +202,9 @@ stages:
     - script: |
         if [[ "$OSTYPE" == "darwin"* ]]; then
           sed -i .bak "/boostorg.jfrog.io/c\\
-        spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2', }" boost.podspec
+        spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2', " boost.podspec
         else
-          sed -i .bak "/boostorg.jfrog.io/c\spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2', }" boost.podspec
+          sed -i .bak "/boostorg.jfrog.io/c\spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2', " boost.podspec
         fi
         rm -f .bak
       workingDirectory: '$(Build.SourcesDirectory)/js/react_native/node_modules/react-native/third-party-podspecs'
@@ -214,9 +214,9 @@ stages:
     - script: |
         if [[ "$OSTYPE" == "darwin"* ]]; then
           sed -i .bak "/boostorg.jfrog.io/c\\
-        spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2', }" boost.podspec
+        spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2', " boost.podspec
         else
-          sed -i .bak "/boostorg.jfrog.io/c\spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2', }" boost.podspec
+          sed -i .bak "/boostorg.jfrog.io/c\spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2', " boost.podspec
         fi
         rm -f .bak
       workingDirectory: '$(Build.SourcesDirectory)/js/react_native/e2e/node_modules/react-native/third-party-podspecs'

--- a/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
@@ -206,7 +206,7 @@ stages:
         else
           sed -i .bak "/boostorg.jfrog.io/c\spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2', " boost.podspec
         fi
-        rm -f .bak
+        rm -f boost.podspec.bak
       workingDirectory: '$(Build.SourcesDirectory)/js/react_native/node_modules/react-native/third-party-podspecs'
       displayName: Path the boost 1.76.0 source URL in boost.podspec js/react_native/node_modules/react-native/third-party-podspecs/boost.podspec
 
@@ -218,7 +218,7 @@ stages:
         else
           sed -i .bak "/boostorg.jfrog.io/c\spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2', " boost.podspec
         fi
-        rm -f .bak
+        rm -f boost.podspec.bak
       workingDirectory: '$(Build.SourcesDirectory)/js/react_native/e2e/node_modules/react-native/third-party-podspecs'
       displayName: Path the boost 1.76.0 source URL in boost.podspec in js/react_native/e2e/node_modules/react-native/third-party-podspecs/boost.podspec
 


### PR DESCRIPTION
### Description
Add a temporary path to RN 0.69.3 to update the boost url



### Motivation and Context
Fix the React-native CI until we update the RN to 0.70.15 or 0.73.3+ versions 


