### PR TITLE
Correct ONNX and Protobuf version in vcpkg build

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -124,13 +124,14 @@ jobs:
       uses: lukka/run-vcpkg@v11
       with:
         vcpkgDirectory: "${{ runner.temp }}/vcpkg"
-        vcpkgGitCommitId: "1de2026f28ead93ff1773e6e680387643e914ea1" # 2024.07.12
-        runVcpkgInstall: true
+        vcpkgGitCommitId: "b322364f06308bdd24823f9d8f03fe0cc86fd46f" # 2024.12.16
+        runVcpkgInstall: true # vcpkg install --x-manifest-root cmake --x-install-root .build --overlay-triplets cmake/vcpkg-triplets
         vcpkgJsonGlob: "cmake/vcpkg.json"
         vcpkgConfigurationJsonGlob: "cmake/vcpkg-configuration.json"
       env:
         VCPKG_INSTALLED_DIR: "${{ github.workspace }}/.build"
         VCPKG_DEFAULT_TRIPLET: "x64-osx"
+        VCPKG_OVERLAY_TRIPLETS: "${{ github.workspace }}/cmake/vcpkg-triplets"
         # VCPKG_BINARY_SOURCES: "default" # https://learn.microsoft.com/en-us/vcpkg/reference/binarycaching
 
     - name: "Run compile_schema.py"
@@ -172,13 +173,14 @@ jobs:
       uses: lukka/run-vcpkg@v11
       with:
         vcpkgDirectory: "${{ runner.temp }}/vcpkg"
-        vcpkgGitCommitId: "1de2026f28ead93ff1773e6e680387643e914ea1" # 2024.07.12
-        runVcpkgInstall: true
+        doNotUpdateVcpkg: true
+        runVcpkgInstall: true # vcpkg install --x-manifest-root cmake --x-install-root .build --overlay-triplets cmake/vcpkg-triplets
         vcpkgJsonGlob: "cmake/vcpkg.json"
         vcpkgConfigurationJsonGlob: "cmake/vcpkg-configuration.json"
       env:
         VCPKG_INSTALLED_DIR: "${{ github.workspace }}/.build"
         VCPKG_DEFAULT_TRIPLET: "arm64-osx"
+        VCPKG_OVERLAY_TRIPLETS: "${{ github.workspace }}/cmake/vcpkg-triplets"
         # VCPKG_BINARY_SOURCES: "default" # https://learn.microsoft.com/en-us/vcpkg/reference/binarycaching
 
     - name: "Run build.py(arm64-osx)"

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -167,6 +167,8 @@ jobs:
           --cmake_extra_defines "VCPKG_TARGET_TRIPLET=x64-osx" \
           --cmake_extra_defines "VCPKG_INSTALLED_DIR:PATH=${{ github.workspace }}/.build" \
           --cmake_extra_defines "VCPKG_INSTALL_OPTIONS=--x-feature=tests"
+      env:
+        VCPKG_OVERLAY_TRIPLETS: "${{ github.workspace }}/cmake/vcpkg-triplets"
       shell: bash
 
     - name: "Run vcpkg(arm64-osx)"
@@ -198,6 +200,8 @@ jobs:
           --cmake_extra_defines "VCPKG_TARGET_TRIPLET=arm64-osx" \
           --cmake_extra_defines "VCPKG_INSTALLED_DIR:PATH=${{ github.workspace }}/.build" \
           --cmake_extra_defines "VCPKG_INSTALL_OPTIONS=--x-feature=tests"
+      env:
+        VCPKG_OVERLAY_TRIPLETS: "${{ github.workspace }}/cmake/vcpkg-triplets"
       shell: bash
 
   Objective-C-StaticAnalysis:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -117,6 +117,9 @@ jobs:
       with:
         python-version: ${{ env.python_version }}
 
+    - name: "Run Homebrew"
+      run: brew install autoconf automake autoconf-archive
+
     - name: "Run vcpkg(x64-osx)"
       uses: lukka/run-vcpkg@v11
       with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -56,12 +56,14 @@ jobs:
         uses: lukka/run-vcpkg@v11
         with:
           vcpkgDirectory: "C:/vcpkg" # use VCPKG_INSTALLATION_ROOT of the image
-          runVcpkgInstall: true
+          vcpkgGitCommitId: "b322364f06308bdd24823f9d8f03fe0cc86fd46f" # 2024.12.16
+          runVcpkgInstall: true # vcpkg install --x-manifest-root cmake --x-install-root .build --overlay-triplets cmake/vcpkg-triplets
           vcpkgJsonGlob: "cmake/vcpkg.json"
           vcpkgConfigurationJsonGlob: "cmake/vcpkg-configuration.json"
         env:
           VCPKG_INSTALLED_DIR: "${{ github.workspace }}/.build"
           VCPKG_DEFAULT_TRIPLET: "x64-windows"
+          VCPKG_OVERLAY_TRIPLETS: "${{ github.workspace }}/cmake/vcpkg-triplets"
           # VCPKG_BINARY_SOURCES: "default" # https://learn.microsoft.com/en-us/vcpkg/reference/binarycaching
 
       - name: "Run compile_schema.py"
@@ -106,12 +108,13 @@ jobs:
         with:
           vcpkgDirectory: "C:/vcpkg" # use VCPKG_INSTALLATION_ROOT of the image
           doNotUpdateVcpkg: true
-          runVcpkgInstall: true
+          runVcpkgInstall: true # vcpkg install --x-manifest-root cmake --x-install-root .build --overlay-triplets cmake/vcpkg-triplets
           vcpkgJsonGlob: "cmake/vcpkg.json"
           vcpkgConfigurationJsonGlob: "cmake/vcpkg-configuration.json"
         env:
           VCPKG_INSTALLED_DIR: "${{ github.workspace }}/.build"
           VCPKG_DEFAULT_TRIPLET: "arm64-windows"
+          VCPKG_OVERLAY_TRIPLETS: "${{ github.workspace }}/cmake/vcpkg-triplets"
           # VCPKG_BINARY_SOURCES: "default" # https://learn.microsoft.com/en-us/vcpkg/reference/binarycaching
 
       - name: "Run build.py(arm64-windows)"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -101,6 +101,8 @@ jobs:
             --cmake_extra_defines "VCPKG_TARGET_TRIPLET=x64-windows" `
             --cmake_extra_defines "VCPKG_INSTALLED_DIR:PATH=${{ github.workspace }}/.build" `
             --cmake_extra_defines "VCPKG_INSTALL_OPTIONS=--x-feature=tests"
+        env:
+          VCPKG_OVERLAY_TRIPLETS: "${{ github.workspace }}/cmake/vcpkg-triplets"
         shell: pwsh
 
       - name: "Run vcpkg(arm64-windows)"
@@ -131,4 +133,6 @@ jobs:
             --cmake_extra_defines "VCPKG_TARGET_TRIPLET=arm64-windows" `
             --cmake_extra_defines "VCPKG_INSTALLED_DIR:PATH=${{ github.workspace }}/.build" `
             --cmake_extra_defines "VCPKG_INSTALL_OPTIONS=--x-feature=tests"
+        env:
+          VCPKG_OVERLAY_TRIPLETS: "${{ github.workspace }}/cmake/vcpkg-triplets"
         shell: pwsh

--- a/cmake/CMakePresets.json
+++ b/cmake/CMakePresets.json
@@ -14,6 +14,7 @@
                 "VCPKG_INSTALLED_DIR": "${sourceParentDir}/.build"
             },
             "environment": {
+                "VCPKG_OVERLAY_TRIPLETS": "${sourceDir}/vcpkg-triplets",
                 "VCPKG_FEATURE_FLGAS": "manifests,versions"
             }
         },

--- a/cmake/vcpkg-configuration.json
+++ b/cmake/vcpkg-configuration.json
@@ -2,7 +2,7 @@
     "default-registry": {
         "kind": "git",
         "repository": "https://github.com/Microsoft/vcpkg",
-        "baseline": "c82f74667287d3dc386bce81e44964370c91a289"
+        "baseline": "b322364f06308bdd24823f9d8f03fe0cc86fd46f"
     },
     "registries": []
 }

--- a/cmake/vcpkg-configuration.json
+++ b/cmake/vcpkg-configuration.json
@@ -2,7 +2,7 @@
     "default-registry": {
         "kind": "git",
         "repository": "https://github.com/Microsoft/vcpkg",
-        "baseline": "b322364f06308bdd24823f9d8f03fe0cc86fd46f"
+        "baseline": "93570a28ecdf49d3d9676cec8aa0cc72935d43db"
     },
     "registries": []
 }

--- a/cmake/vcpkg-triplets/arm64-osx.cmake
+++ b/cmake/vcpkg-triplets/arm64-osx.cmake
@@ -1,0 +1,14 @@
+# https://learn.microsoft.com/en-us/vcpkg/users/triplets
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+
+set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
+set(VCPKG_OSX_ARCHITECTURES arm64)
+
+# provide build options for vcpkg installed packages
+if(PORT MATCHES "onnx")
+    list(APPEND VCPKG_CMAKE_CONFIGURE_OPTIONS
+        "-DONNX_DISABLE_STATIC_REGISTRATION=ON"
+    )
+endif()

--- a/cmake/vcpkg-triplets/arm64-windows.cmake
+++ b/cmake/vcpkg-triplets/arm64-windows.cmake
@@ -1,0 +1,11 @@
+# https://learn.microsoft.com/en-us/vcpkg/users/triplets
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+
+# provide build options for vcpkg installed packages
+if(PORT MATCHES "onnx")
+    list(APPEND VCPKG_CMAKE_CONFIGURE_OPTIONS
+        "-DONNX_DISABLE_STATIC_REGISTRATION=ON"
+    )
+endif()

--- a/cmake/vcpkg-triplets/x64-osx.cmake
+++ b/cmake/vcpkg-triplets/x64-osx.cmake
@@ -1,0 +1,14 @@
+# https://learn.microsoft.com/en-us/vcpkg/users/triplets
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+
+set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
+set(VCPKG_OSX_ARCHITECTURES x86_64)
+
+# provide build options for vcpkg installed packages
+if(PORT MATCHES "onnx")
+    list(APPEND VCPKG_CMAKE_CONFIGURE_OPTIONS
+        "-DONNX_DISABLE_STATIC_REGISTRATION=ON"
+    )
+endif()

--- a/cmake/vcpkg-triplets/x64-windows.cmake
+++ b/cmake/vcpkg-triplets/x64-windows.cmake
@@ -1,0 +1,11 @@
+# https://learn.microsoft.com/en-us/vcpkg/users/triplets
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+
+# provide build options for vcpkg installed packages
+if(PORT MATCHES "onnx")
+    list(APPEND VCPKG_CMAKE_CONFIGURE_OPTIONS
+        "-DONNX_DISABLE_STATIC_REGISTRATION=ON"
+    )
+endif()

--- a/cmake/vcpkg.json
+++ b/cmake/vcpkg.json
@@ -32,12 +32,12 @@
     "nlohmann-json",
     {
       "name": "nsync",
-      "platform": "!windows"
-    },
-    {
-      "name": "nsync",
       "platform": "!windows",
       "version>=": "1.26.0"
+    },
+    {
+      "name": "onnx",
+      "version>=": "1.16.2"
     },
     "optional-lite",
     {
@@ -66,12 +66,6 @@
       "platform": "windows"
     }
   ],
-  "overrides": [
-    {
-      "name": "flatbuffers",
-      "version": "23.5.26"
-    }
-  ],
   "features": {
     "tests": {
       "description": "Build ONNXRuntime unit tests",
@@ -80,5 +74,11 @@
         "gtest"
       ]
     }
-  }
+  },
+  "overrides": [
+    {
+      "name": "flatbuffers",
+      "version": "23.5.26"
+    }
+  ]
 }

--- a/cmake/vcpkg.json
+++ b/cmake/vcpkg.json
@@ -77,6 +77,10 @@
   },
   "overrides": [
     {
+      "name": "protobuf",
+      "version": "3.21.12#4"
+    },
+    {
       "name": "flatbuffers",
       "version": "23.5.26"
     }


### PR DESCRIPTION
### Description

Changes vcpkg manifest and configuration file (vcpkg.json & vcpkg-configuration.json)

* Update vcpkg version to https://github.com/microsoft/vcpkg/releases/tag/2024.12.16
* Use protobuf 3.21.12(= `v21.12`) to sync with [cmake/deps.txt](https://github.com/microsoft/onnxruntime/blob/main/cmake/deps.txt)
  * Resolve https://github.com/microsoft/onnxruntime/issues/22750
* Add `onnx` to vcpkg manifest so `find_package(ONNX)` and `find_dependency(Protobuf)` can work as expected.
  * Currently, It uses 1.16.2
  * v1.17.0 will become available after https://github.com/microsoft/vcpkg/pull/42942

However, `onnx` in vcpkg doesn't configure `ONNX_DISABLE_STATIC_REGISTRATION` build option.

* https://github.com/microsoft/vcpkg/pull/38879
* Create "cmake/vcpkg-triplets/" folder and triplet files which use `VCPKG_CMAKE_CONFIGURE_OPTIONS` for the option
   * This requires `VCPKG_OVERLAY_TRIPLETS` environment variable for CI steps, which is a bit inconvenient.  
     I will try to find simple way to get same result

### Motivation and Context

* Help #23158 
  * "ONNX is not consumed from vcpkg"
  * "Mismatch protobuf version. When vcpkg is enabled , we should not fetch protoc from Github which may cause version mismatches."
* https://github.com/microsoft/vcpkg/pull/43126
* #21348
