### PR TITLE
[JSEP/WebGPU] Add a fatal error message for unsupported GQA do_rotary attribute.

### DIFF
--- a/js/web/lib/wasm/jsep/webgpu/ops/group-query-attention.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/group-query-attention.ts
@@ -24,6 +24,9 @@ export const validateInputs = (
   inputs: readonly TensorView[],
   attributes: GroupQueryAttentionAttributes,
 ): AttentionParameters => {
+  if (attributes.doRotary) {
+    throw new Error('GroupQuerryAttention do_rotary attribute is not supported');
+  }
   if (attributes.doRotary && inputs.length <= 7) {
     throw new Error('cos_cache and sin_cache inputs are required if do_rotary is specified');
   }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Added a fatal error message for unsupported GroupQuerryAttention do_rotary attribute.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
https://github.com/microsoft/onnxruntime/issues/22987
Help user understand that this attribute is not supported.

