### PR TITLE
Remove a hack in adjust_global_compile_flags.cmake

### DIFF
--- a/cmake/adjust_global_compile_flags.cmake
+++ b/cmake/adjust_global_compile_flags.cmake
@@ -12,15 +12,6 @@ if (ANDROID)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,max-page-size=16384")
 endif()
 
-# Suggested by https://gitlab.kitware.com/cmake/cmake/-/issues/20132
-# MacCatalyst is not well supported in CMake
-# The error that can emerge without this flag can look like:
-# "clang : error : overriding '-mmacosx-version-min=11.0' option with '-target x86_64-apple-ios14.0-macabi' [-Werror,-Woverriding-t-option]"
-if (PLATFORM_NAME STREQUAL "macabi")
-  add_compile_options(-Wno-overriding-t-option)
-  add_link_options(-Wno-overriding-t-option)
-endif()
-
 # Enable space optimization for gcc/clang
 # Cannot use "-ffunction-sections -fdata-sections" if we enable bitcode (iOS)
 if (NOT MSVC AND NOT onnxruntime_ENABLE_BITCODE)


### PR DESCRIPTION

### Description

Remove a hack in adjust_global_compile_flags.cmake because the issue should have been resolved.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


