### PR TITLE
Base commit for using EMSDK 3.1.74 (LTO disabled)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,4 +7,4 @@
 [submodule "cmake/external/emsdk"]
 	path = cmake/external/emsdk
 	url = https://github.com/emscripten-core/emsdk.git
-	branch = 3.1.59
+	branch = 3.1.74

--- a/cgmanifests/generated/cgmanifest.json
+++ b/cgmanifests/generated/cgmanifest.json
@@ -6,7 +6,7 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "d52c46520124845b1e0e0525f2759299d840143f",
+          "commitHash": "3d6d8ee910466516a53e665b86458faa81dae9ba",
           "repositoryUrl": "https://github.com/emscripten-core/emsdk.git"
         },
         "comments": "git submodule at cmake/external/emsdk"

--- a/cmake/adjust_global_compile_flags.cmake
+++ b/cmake/adjust_global_compile_flags.cmake
@@ -29,8 +29,8 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     # (2) "-flto=thin" does not work correctly for wasm-ld.
     #     we don't set onnxruntime_ENABLE_LTO because it appends flag "-flto=thin"
     #     instead, we manually set CMAKE_CXX_FLAGS "-flto"
-    string(APPEND CMAKE_C_FLAGS " -flto")
-    string(APPEND CMAKE_CXX_FLAGS " -flto")
+    #string(APPEND CMAKE_C_FLAGS " -flto")
+    #string(APPEND CMAKE_CXX_FLAGS " -flto")
   endif()
 
   if (onnxruntime_ENABLE_WEBASSEMBLY_DEBUG_INFO)

--- a/cmake/onnxruntime_webassembly.cmake
+++ b/cmake/onnxruntime_webassembly.cmake
@@ -466,4 +466,59 @@ jsepDownload:_pp_")
   endif()
 
   set_target_properties(onnxruntime_webassembly PROPERTIES OUTPUT_NAME ${target_name} SUFFIX ".mjs")
+
+  #
+  # The following POST_BUILD script is a workaround for enabling:
+  # - using onnxruntime-web with Multi-threading enabled when import from CDN
+  # - using onnxruntime-web when consumed in some frameworks like Vite
+  #
+  # In the use case mentioned above, the file name of the script may be changed. So we need to replace the line:
+  # `new Worker(new URL("ort-wasm-*.mjs", import.meta.url),`
+  # with
+  # `new Worker(new URL(import.meta.url),`
+  #
+  # This behavior is introduced in https://github.com/emscripten-core/emscripten/pull/22165. Since it's unlikely to be
+  # reverted, and there is no config to disable this behavior, we have to use a post-build script to workaround it.
+  #
+
+  # Generate a script to do the post-build work
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/wasm_post_build.js "
+    const fs = require('fs');
+    const path = require('path');
+
+    // node wasm_post_build.js <mjsFilePath>
+    const mjsFilePath = process.argv[2];
+    let contents = fs.readFileSync(mjsFilePath).toString();
+
+    const regex = 'new Worker\\\\(new URL\\\\(\".+?\", ?import\\\\.meta\\\\.url\\\\),';
+    const matches = [...contents.matchAll(new RegExp(regex, 'g'))];
+    if (matches.length !== 1) {
+      throw new Error(
+        `Unexpected number of matches for \"${regex}\" in \"${filepath}\": ${matches.length}.`,
+      );
+    }
+
+    // Replace the only occurrence.
+    contents = contents.replace(
+      new RegExp(regex),
+      `new Worker(new URL(import.meta.url),`,
+    );
+
+    fs.writeFileSync(mjsFilePath, contents);
+  "
+  )
+
+  find_program(NODE_EXECUTABLE node required)
+  if (NOT NODE_EXECUTABLE)
+    message(FATAL_ERROR "Node is required to run the post-build script")
+  endif()
+
+  add_custom_command(
+    TARGET onnxruntime_webassembly
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E echo "Backup file at $<TARGET_FILE_NAME:onnxruntime_webassembly>.bak"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE_NAME:onnxruntime_webassembly>" "$<TARGET_FILE_NAME:onnxruntime_webassembly>.bak"
+    COMMAND ${CMAKE_COMMAND} -E echo "Performing workaround for $<TARGET_FILE_NAME:onnxruntime_webassembly>"
+    COMMAND ${NODE_EXECUTABLE} "${CMAKE_CURRENT_BINARY_DIR}/wasm_post_build.js" "$<TARGET_FILE_NAME:onnxruntime_webassembly>"
+  )
 endif()

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -478,7 +478,7 @@ def parse_arguments():
     # WebAssembly build
     parser.add_argument("--build_wasm", action="store_true", help="Build for WebAssembly")
     parser.add_argument("--build_wasm_static_lib", action="store_true", help="Build for WebAssembly static library")
-    parser.add_argument("--emsdk_version", default="3.1.59", help="Specify version of emsdk")
+    parser.add_argument("--emsdk_version", default="3.1.74", help="Specify version of emsdk")
 
     parser.add_argument("--enable_wasm_simd", action="store_true", help="Enable WebAssembly SIMD")
     parser.add_argument("--enable_wasm_threads", action="store_true", help="Enable WebAssembly multi-threads support")

--- a/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
@@ -86,15 +86,15 @@ jobs:
       - script: |
           set -ex
           cd '$(Build.SourcesDirectory)/cmake/external/emsdk'
-          ./emsdk install 3.1.59 ccache-git-emscripten-64bit
-          ./emsdk activate 3.1.59 ccache-git-emscripten-64bit
+          ./emsdk install 3.1.74 ccache-git-emscripten-64bit
+          ./emsdk activate 3.1.74 ccache-git-emscripten-64bit
         displayName: 'emsdk install and activate ccache for emscripten'
   - ${{if eq(parameters.WithCache, false)}}:
       - script: |
           set -ex
           cd '$(Build.SourcesDirectory)/cmake/external/emsdk'
-          ./emsdk install 3.1.59
-          ./emsdk activate 3.1.59
+          ./emsdk install 3.1.74
+          ./emsdk activate 3.1.74
         displayName: 'emsdk install and activate ccache for emscripten'
 
   - template: build-linux-wasm-step.yml


### PR DESCRIPTION
### Description

Upgrade EMSDK to `3.1.74`.

This PR is currently marked as "draft", as LTO is disabled temporarily because of a crash in wasm-ld. Related issue is being tracked in upstream at https://github.com/llvm/llvm-project/issues/122166.

Once a workaround is available, LTO should be re-enabled.