### PR TITLE
Compile lib instead of executable when checking compiler features

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -669,6 +669,8 @@ if (WIN32)
     endif()
 
 else()
+  # Default target type is executable. Set to static library to simplify these steps.
+  set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
   check_cxx_compiler_flag(-Wambiguous-reversed-operator HAS_AMBIGUOUS_REVERSED_OPERATOR)
   check_cxx_compiler_flag(-Wbitwise-instead-of-logical HAS_BITWISE_INSTEAD_OF_LOGICAL)
   check_cxx_compiler_flag(-Wcast-function-type HAS_CAST_FUNCTION_TYPE)


### PR DESCRIPTION
### Description
`check_cxx_compiler_flag` uses `try_compile` with a basic source file. `try_compile` can build a static library, but builds an executable by default. For mobile builds, this means using the SDK to create an app package, which adds unnecessary time to the configuration stage. 

### Motivation and Context
In particular, I am addressing a problem where an iOS build sometimes hangs during one of these calls, leading to a build timeout