### PR TITLE
[WebGPU EP] increase abs error for test case MatMulNBits.Float16Large

### DIFF
--- a/onnxruntime/test/contrib_ops/matmul_4bits_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_4bits_test.cc
@@ -546,8 +546,8 @@ TEST(MatMulNBits, Float16Large) {
   // of elements in this test, ULPs should probably be used instead of absolute/relative tolerances.
   float abs_error = 0.3f;
 #elif USE_WEBGPU
-  // See Intel A770 to pass these tests with an absolute error of 0.08.
-  float abs_error = 0.08f;
+  // Use absolute error of 0.1 for WebGPU with subgroup implementation
+  float abs_error = 0.1f;
 #else
   float abs_error = 0.05f;
 #endif


### PR DESCRIPTION
### Description

increase absolute error for test case `MatMulNBits.Float16Large` to 0.1 for WebGPU with subgroup implementation.

Fixes webgpu CI pipeline.