### PR TITLE
[webgpu] Simplify o2i_output implementation

### DIFF
--- a/onnxruntime/core/providers/webgpu/shader_variable.cc
+++ b/onnxruntime/core/providers/webgpu/shader_variable.cc
@@ -159,10 +159,8 @@ void ShaderIndicesHelper::Impl(std::ostream& ss) const {
       SS_APPEND(ss, "  var current = offset;\n");
       for (int i = 0; i < rank_ - 1; i++) {
         auto current_stride = GetElementAt(stride, i, rank_ - 1);
-        SS_APPEND(ss, "  let dim", i, " = current / ", current_stride, ";\n");
-        SS_APPEND(ss, "  let rest", i, " = current % ", current_stride, ";\n");
-        SS_APPEND(ss, "  indices[", i, "] = dim", i, ";\n");
-        SS_APPEND(ss, "  current = rest", i, ";\n");
+        SS_APPEND(ss, "  indices[", i, "] = current / ", current_stride, ";\n");
+        SS_APPEND(ss, "  current = current % ", current_stride, ";\n");
       }
       SS_APPEND(ss, "  indices[", rank_ - 1, "] = current;\n");
       SS_APPEND(ss, "  return indices;\n");


### PR DESCRIPTION

### Description
This change simplifies the o2i_output implementation by reducing unnecessary intermediate variables, with no change in functionality.

### Motivation and Context
As above.


