### PR TITLE
[WebGPU EP] use LOGS_DEFAULT for device lost logging

### DIFF
--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -103,8 +103,7 @@ void WebGpuContext::Initialize(const WebGpuBufferCacheConfig& buffer_cache_confi
       });
       // TODO: revise temporary device lost handling
       device_desc.SetDeviceLostCallback(wgpu::CallbackMode::AllowSpontaneous, [](const wgpu::Device& /*device*/, wgpu::DeviceLostReason reason, const char* message) {
-        // cannot use ORT logger because it may be already destroyed
-        std::cerr << "WebGPU device lost (" << int(reason) << "): " << message;
+        LOGS_DEFAULT(INFO) << "WebGPU device lost (" << int(reason) << "): " << message;
       });
 
       ORT_ENFORCE(wgpu::WaitStatus::Success == instance_.WaitAny(adapter_.RequestDevice(


### PR DESCRIPTION
### Description

use LOGS_DEFAULT for device lost logging.

Now since the GPU device lifecycle is managed by WebGpuContext, it's now able to use ORT logging.