### PR TITLE
WIP: Dp4MatMulNBits accuracy level 4 matmul for WebGPU EP

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.cc
@@ -675,7 +675,7 @@ Status DP4AMatMulNBitsProgram::GenerateShaderCode(ShaderHelper& shader) const {
       return local_sum;
   }
 
-  // Implement a 16x64x16 matrix multipy primitive using the 16 lanes of the subgroup.
+  // Implement a 16x64x16 matrix multiply primitive using the 16 lanes of the subgroup.
   // Each Lane first loads a row of A and a column of B.
   // Then each lane becomes responsible for a row and loops through the columns to compute
   // dot product. The columns are fetched from other owning lanes using subgroupShuffle.

--- a/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.cc
@@ -589,7 +589,7 @@ Status DP4AMatMulNBitsProgram::GenerateShaderCode(ShaderHelper& shader) const {
   // The entire workgroup which has N subgroups first loads a tile into shared memory,
   // Then each subgroup loads a subtile from shared memory into registers and uses
   // the medium size matrix multiply primitive to perform the math.
-  // The values for tile/subtile size are choosen to conform to the resource limits
+  // The values for tile/subtile size are chosen to conform to the resource limits
   // of an alderlake/tiger lake gpu. A tile is 64x64, workgroup is 256 threads -
   // therefore there are 16 subgroups and 16 lanes in each subgroup.
   // K the hidden dimension is paged in from RAM at k tile size which is 64.
@@ -599,9 +599,9 @@ Status DP4AMatMulNBitsProgram::GenerateShaderCode(ShaderHelper& shader) const {
   //
   // Each subgroup performs a 16 x 64 x 16 multiply which is implemented with
   // subgroup shuffle as a placeholder for the day the medium matrix mul primitive
-  // becomes available in WGSL. The registy requirements is ~2KB per subgroup, on
+  // becomes available in WGSL. The registry requirements is ~2KB per subgroup, on
   // Alderlake/Tigerlake subgroup has 8KB of registry space pooling the
-  // 512B of registery from each lane.
+  // 512B of registry from each lane.
   //
   // The medium size matmul is implemented using dot4I8Packed, so the inputs for
   // this shader require A to be int8 quantized with block size 64. B is regular

--- a/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.cc
@@ -828,7 +828,7 @@ Status MatMulNBits::ComputeInternal(onnxruntime::webgpu::ComputeContext& context
 
   const bool has_zero_points = zero_points != nullptr;
   if (accuracy_level_ == 4 && block_size == 32 &&
-      batch_count == 1 && components_a == 4 && K % 64 == 0 &&
+      batch_count == 1 && components_a == 4 && K % 64 == 0 && N % 16 == 0 &&
       !has_zero_points && M >= kMinMForTileOptimization) {
     constexpr uint32_t kVec4Components = 4;
     constexpr uint32_t kVec2Components = 2;

--- a/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.h
+++ b/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.h
@@ -41,12 +41,6 @@ class DP4AMatMulQuantizeProgram final : public Program<DP4AMatMulQuantizeProgram
   Status GenerateShaderCode(ShaderHelper& sh) const override;
 };
 
-class DP4AMatMulDeQuantizeProgram final : public Program<DP4AMatMulDeQuantizeProgram> {
- public:
-  DP4AMatMulDeQuantizeProgram() : Program{"DP4ADeMatMulQuantize"} {}
-  Status GenerateShaderCode(ShaderHelper& sh) const override;
-};
-
 class DP4AMatMulNBitsProgram final : public Program<DP4AMatMulNBitsProgram> {
  public:
   DP4AMatMulNBitsProgram() : Program{"DP4AMatMulNBits"} {}
@@ -66,6 +60,7 @@ class MatMulNBits final : public WebGpuKernel {
     N_ = info.GetAttr<int64_t>("N");
     block_size_ = info.GetAttr<int64_t>("block_size");
     int64_t bits = info.GetAttr<int64_t>("bits");
+    accuracy_level_ = info.GetAttrOrDefault<int64_t>("accuracy_level", 4);
     ORT_ENFORCE(bits == 4,
                 "Only 4b quantization is supported for MatMulNBits op, additional bits support is planned.");
   }
@@ -76,6 +71,7 @@ class MatMulNBits final : public WebGpuKernel {
   int64_t K_;
   int64_t N_;
   int64_t block_size_;
+  int64_t accuracy_level_;
 };
 
 }  // namespace webgpu

--- a/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.h
+++ b/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.h
@@ -46,11 +46,11 @@ class DP4AMatMulNBitsProgram final : public Program<DP4AMatMulNBitsProgram> {
   DP4AMatMulNBitsProgram() : Program{"DP4AMatMulNBits"} {}
   Status GenerateShaderCode(ShaderHelper& sh) const override;
   WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
-    {"M", ProgramUniformVariableDataType::Uint32},
-    {"N", ProgramUniformVariableDataType::Uint32},
-    {"K", ProgramUniformVariableDataType::Uint32},
-    {"K8", ProgramUniformVariableDataType::Uint32},
-    {"K16", ProgramUniformVariableDataType::Uint32});
+      {"M", ProgramUniformVariableDataType::Uint32},
+      {"N", ProgramUniformVariableDataType::Uint32},
+      {"K", ProgramUniformVariableDataType::Uint32},
+      {"K8", ProgramUniformVariableDataType::Uint32},
+      {"K16", ProgramUniformVariableDataType::Uint32});
 };
 
 class MatMulNBits final : public WebGpuKernel {

--- a/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.h
+++ b/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.h
@@ -35,6 +35,30 @@ class MatMulNBitsProgram final : public Program<MatMulNBitsProgram> {
   bool use_subgroup_;
 };
 
+class DP4AMatMulQuantizeProgram final : public Program<DP4AMatMulQuantizeProgram> {
+ public:
+  DP4AMatMulQuantizeProgram() : Program{"DP4AMatMulQuantize"} {}
+  Status GenerateShaderCode(ShaderHelper& sh) const override;
+};
+
+class DP4AMatMulDeQuantizeProgram final : public Program<DP4AMatMulDeQuantizeProgram> {
+ public:
+  DP4AMatMulDeQuantizeProgram() : Program{"DP4ADeMatMulQuantize"} {}
+  Status GenerateShaderCode(ShaderHelper& sh) const override;
+};
+
+class DP4AMatMulNBitsProgram final : public Program<DP4AMatMulNBitsProgram> {
+ public:
+  DP4AMatMulNBitsProgram() : Program{"DP4AMatMulNBits"} {}
+  Status GenerateShaderCode(ShaderHelper& sh) const override;
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
+    {"M", ProgramUniformVariableDataType::Uint32},
+    {"N", ProgramUniformVariableDataType::Uint32},
+    {"K", ProgramUniformVariableDataType::Uint32},
+    {"K8", ProgramUniformVariableDataType::Uint32},
+    {"K16", ProgramUniformVariableDataType::Uint32});
+};
+
 class MatMulNBits final : public WebGpuKernel {
  public:
   MatMulNBits(const OpKernelInfo& info) : WebGpuKernel(info) {


### PR DESCRIPTION
### Description

This change implements accuracy level 4 - quantize A to int8 matmul for the WebGPU EP. The matmul kernel here uses DP4A for matrix multiplication, in order to keep the DP4A fed co-operative matrix multiplication is implemented which preloads the row/col into local variables before the multiplication operation.

Credits to @qjia7 for help with the quantizer shader.

Performance metrics on intel ADL/TGL GPU.

```
PS C:\onnxruntime> C:\model_benchmark\model_benchmark.exe -i C:\Phi-3.5-mini-instruct-onnx-web\Phi-3.5-mini-instruct-onnx-web -l 500
Batch size: 1, prompt tokens: 501, tokens to generate: 128
Prompt processing (time to first token):
        avg (us):       2.76762e+06
        **avg (tokens/s): 181.022**   <<< Prefill speed
        p50 (us):       2.74843e+06
        stddev (us):    41756.4
        n:              5 * 501 token(s)
Token generation:
        avg (us):       81500.7
        avg (tokens/s): 12.2698
        p50 (us):       81104.1
        stddev (us):    2961.31
        n:              635 * 1 token(s)
Token sampling:
        avg (us):       13.1836
        avg (tokens/s): 75851.9
        p50 (us):       12
        stddev (us):    6.47085
        n:              640 * 1 token(s)
E2E generation (entire generation loop):
        avg (ms):       13120
        p50 (ms):       13081.6
        stddev (ms):    114.689
        n:              5
Peak working set size (bytes): 5467533312
WebGPU device lost (2): Device was destroyed.

```
This kernel is 2.10x faster than its F16 counterpart for a 500 token prefill. Previous prefill record is 86tks/s.

In order to support devices with subgroup size 8/32, a no subgroup version of the same shader is included. Performance is slower than the subgroup version on ADL.

```
PS C:\onnxruntime> C:\model_benchmark\model_benchmark.exe -i C:\Phi-3.5-mini-instruct-onnx-web\Phi-3.5-mini-instruct-onnx-web -l 500 
Batch size: 1, prompt tokens: 501, tokens to generate: 128
Prompt processing (time to first token):
        avg (us):       4.11989e+06
        avg (tokens/s): 121.605
        p50 (us):       4.11847e+06
        stddev (us):    2147.48
        n:              5 * 501 token(s)
Token generation:
        avg (us):       81174.9
        avg (tokens/s): 12.3191
        p50 (us):       81301.1
        stddev (us):    2177.2
        n:              635 * 1 token(s)
Token sampling:
        avg (us):       14.7998
        avg (tokens/s): 67568.3
        p50 (us):       12.3
        stddev (us):    11.5481
        n:              640 * 1 token(s)
E2E generation (entire generation loop):
        avg (ms):       14431.1
        p50 (ms):       14433.8
        stddev (ms):    5.02473
        n:              5
Peak working set size (bytes): 5466480640
WebGPU device lost (2): Device was destroyed.
```
