### PR TITLE
[WebNN] Add op support validation for decomposed WebNN ops

### DIFF
--- a/onnxruntime/core/providers/webnn/builders/helper.cc
+++ b/onnxruntime/core/providers/webnn/builders/helper.cc
@@ -107,11 +107,7 @@ std::unordered_set<const Node*> GetSupportedNodes(const GraphViewer& graph_viewe
   std::unordered_set<const Node*> supported_nodes;
 
   for (const auto& node : graph_viewer.Nodes()) {
-    bool supported = false;
-    // Firstly check if platform supports the WebNN op.
-    if (CheckSingleOp(node.OpType(), wnn_builder, device_type)) {
-      supported = IsNodeSupported(node, graph_viewer, device_type, wnn_limits, logger);
-    }
+    const bool supported = IsNodeSupported(node, graph_viewer, device_type, wnn_limits, logger);
     LOGS(logger, VERBOSE) << "Operator type: [" << node.OpType()
                           << "] index: [" << node.Index()
                           << "] name: [" << node.Name()
@@ -140,7 +136,7 @@ bool AreInputDataTypesSame(const std::string& op_type,
   return true;
 }
 
-bool IsSupportedDataType(const int32_t onnx_data_type, const emscripten::val& webnn_supported_data_types) {
+bool IsSupportedDataType(const int32_t& onnx_data_type, const emscripten::val& webnn_supported_data_types) {
   auto it = onnx_to_webnn_data_type_map.find(static_cast<ONNX_NAMESPACE::TensorProto_DataType>(onnx_data_type));
   if (it == onnx_to_webnn_data_type_map.end())
     return false;
@@ -155,7 +151,7 @@ bool IsSupportedDataType(const int32_t onnx_data_type, const emscripten::val& we
 
 // Check if the input or output data type of ONNX node is supported by the WebNN operator.
 bool IsDataTypeSupportedByOp(const std::string& onnx_op_type,
-                             const int32_t onnx_data_type,
+                             const int32_t& onnx_data_type,
                              const emscripten::val& wnn_limits,
                              const std::string& webnn_input_output_name,
                              const std::string& onnx_input_output_name,
@@ -170,7 +166,7 @@ bool IsDataTypeSupportedByOp(const std::string& onnx_op_type,
 
 bool IsDataTypeSupportedByWebNNOp(const std::string& onnx_op_type,
                                   const std::string& webnn_op_type,
-                                  const int32_t onnx_data_type,
+                                  const int32_t& onnx_data_type,
                                   const emscripten::val& wnn_limits,
                                   const std::string& webnn_input_output_name,
                                   const std::string& onnx_input_output_name,
@@ -179,6 +175,7 @@ bool IsDataTypeSupportedByWebNNOp(const std::string& onnx_op_type,
     LOGS(logger, VERBOSE) << "[" << onnx_op_type << "] WebNN op [" << webnn_op_type << "] is not supported for now";
     return false;
   }
+
   if (wnn_limits[webnn_op_type][webnn_input_output_name].isUndefined()) {
     LOGS(logger, VERBOSE) << "[" << onnx_op_type << "] WebNN op [" << webnn_op_type << "] doesn't have parameter ["
                           << webnn_input_output_name << "]";

--- a/onnxruntime/core/providers/webnn/builders/helper.cc
+++ b/onnxruntime/core/providers/webnn/builders/helper.cc
@@ -121,7 +121,7 @@ std::unordered_set<const Node*> GetSupportedNodes(const GraphViewer& graph_viewe
   return supported_nodes;
 }
 
-bool AreInputDataTypesSame(const std::string& op_type,
+bool AreInputDataTypesSame(const std::string_view op_type,
                            gsl::span<const int32_t> input_types,
                            const logging::Logger& logger) {
   for (size_t i = 1; i < input_types.size(); i++) {
@@ -136,52 +136,52 @@ bool AreInputDataTypesSame(const std::string& op_type,
   return true;
 }
 
-bool IsSupportedDataType(const int32_t& onnx_data_type, const emscripten::val& webnn_supported_data_types) {
+bool IsSupportedDataType(const int32_t onnx_data_type, const emscripten::val& webnn_supported_data_types) {
   auto it = onnx_to_webnn_data_type_map.find(static_cast<ONNX_NAMESPACE::TensorProto_DataType>(onnx_data_type));
   if (it == onnx_to_webnn_data_type_map.end())
     return false;
 
-  std::string webnn_data_type = it->second;
+  const std::string_view webnn_data_type = it->second;
 
   // Check if WebNN supports the data type.
-  emscripten::val is_supported = webnn_supported_data_types.call<emscripten::val>("includes",
-                                                                                  emscripten::val(webnn_data_type));
+  emscripten::val is_supported =
+      webnn_supported_data_types.call<emscripten::val>("includes", emscripten::val(webnn_data_type.data()));
   return is_supported.as<bool>();
 }
 
 // Check if the input or output data type of ONNX node is supported by the WebNN operator.
-bool IsDataTypeSupportedByOp(const std::string& onnx_op_type,
-                             const int32_t& onnx_data_type,
+bool IsDataTypeSupportedByOp(const std::string_view onnx_op_type,
+                             const int32_t onnx_data_type,
                              const emscripten::val& wnn_limits,
-                             const std::string& webnn_input_output_name,
-                             const std::string& onnx_input_output_name,
+                             const std::string_view webnn_input_output_name,
+                             const std::string_view onnx_input_output_name,
                              const logging::Logger& logger) {
-  std::string webnn_op_type;
-  if (!GetWebNNOpType(onnx_op_type, webnn_op_type))
-    return false;
+  const std::string_view webnn_op_type = GetWebNNOpType(onnx_op_type);
 
-  return IsDataTypeSupportedByWebNNOp(onnx_op_type, webnn_op_type, onnx_data_type, wnn_limits,
+  return !webnn_op_type.empty() &&
+         IsDataTypeSupportedByWebNNOp(onnx_op_type, webnn_op_type, onnx_data_type, wnn_limits,
                                       webnn_input_output_name, onnx_input_output_name, logger);
 }
 
-bool IsDataTypeSupportedByWebNNOp(const std::string& onnx_op_type,
-                                  const std::string& webnn_op_type,
-                                  const int32_t& onnx_data_type,
+bool IsDataTypeSupportedByWebNNOp(const std::string_view onnx_op_type,
+                                  const std::string_view webnn_op_type,
+                                  const int32_t onnx_data_type,
                                   const emscripten::val& wnn_limits,
-                                  const std::string& webnn_input_output_name,
-                                  const std::string& onnx_input_output_name,
+                                  const std::string_view webnn_input_output_name,
+                                  const std::string_view onnx_input_output_name,
                                   const logging::Logger& logger) {
-  if (wnn_limits[webnn_op_type].isUndefined()) {
+  if (wnn_limits[webnn_op_type.data()].isUndefined()) {
     LOGS(logger, VERBOSE) << "[" << onnx_op_type << "] WebNN op [" << webnn_op_type << "] is not supported for now";
     return false;
   }
 
-  if (wnn_limits[webnn_op_type][webnn_input_output_name].isUndefined()) {
+  if (wnn_limits[webnn_op_type.data()][webnn_input_output_name.data()].isUndefined()) {
     LOGS(logger, VERBOSE) << "[" << onnx_op_type << "] WebNN op [" << webnn_op_type << "] doesn't have parameter ["
                           << webnn_input_output_name << "]";
     return false;
   }
-  if (!IsSupportedDataType(onnx_data_type, wnn_limits[webnn_op_type][webnn_input_output_name]["dataTypes"])) {
+  if (!IsSupportedDataType(
+          onnx_data_type, wnn_limits[webnn_op_type.data()][webnn_input_output_name.data()]["dataTypes"])) {
     LOGS(logger, VERBOSE) << "[" << onnx_op_type << "] " << onnx_input_output_name << "'s data type: ["
                           << onnx_data_type << "] is not supported by WebNN op [" << webnn_op_type << "] for now";
     return false;

--- a/onnxruntime/core/providers/webnn/builders/helper.cc
+++ b/onnxruntime/core/providers/webnn/builders/helper.cc
@@ -145,7 +145,7 @@ bool IsSupportedDataType(const int32_t onnx_data_type, const emscripten::val& we
 
   // Check if WebNN supports the data type.
   emscripten::val is_supported =
-      webnn_supported_data_types.call<emscripten::val>("includes", emscripten::val(webnn_data_type.data()));
+      webnn_supported_data_types.call<emscripten::val>("includes", emscripten::val(std::string(webnn_data_type)));
   return is_supported.as<bool>();
 }
 
@@ -170,18 +170,18 @@ bool IsDataTypeSupportedByWebNNOp(const std::string_view onnx_op_type,
                                   const std::string_view webnn_input_output_name,
                                   const std::string_view onnx_input_output_name,
                                   const logging::Logger& logger) {
-  if (wnn_limits[webnn_op_type.data()].isUndefined()) {
+  if (wnn_limits[std::string(webnn_op_type)].isUndefined()) {
     LOGS(logger, VERBOSE) << "[" << onnx_op_type << "] WebNN op [" << webnn_op_type << "] is not supported for now";
     return false;
   }
 
-  if (wnn_limits[webnn_op_type.data()][webnn_input_output_name.data()].isUndefined()) {
+  if (wnn_limits[std::string(webnn_op_type)][std::string(webnn_input_output_name)].isUndefined()) {
     LOGS(logger, VERBOSE) << "[" << onnx_op_type << "] WebNN op [" << webnn_op_type << "] doesn't have parameter ["
                           << webnn_input_output_name << "]";
     return false;
   }
   if (!IsSupportedDataType(
-          onnx_data_type, wnn_limits[webnn_op_type.data()][webnn_input_output_name.data()]["dataTypes"])) {
+          onnx_data_type, wnn_limits[std::string(webnn_op_type)][std::string(webnn_input_output_name)]["dataTypes"])) {
     LOGS(logger, VERBOSE) << "[" << onnx_op_type << "] " << onnx_input_output_name << "'s data type: ["
                           << onnx_data_type << "] is not supported by WebNN op [" << webnn_op_type << "] for now";
     return false;

--- a/onnxruntime/core/providers/webnn/builders/helper.h
+++ b/onnxruntime/core/providers/webnn/builders/helper.h
@@ -194,8 +194,15 @@ std::unordered_set<const Node*> GetSupportedNodes(const GraphViewer& graph_viewe
                                                   const WebnnDeviceType device_type,
                                                   const emscripten::val& wnn_limits,
                                                   const logging::Logger& logger);
-// TODO(@Honry): Some ONNX ops are supported by decomposed WebNN ops,
-// we need to check the support of the decomposed ops.
+
+// Some ONNX ops are supported by decomposed WebNN ops.
+static const InlinedHashMap<std::string, std::vector<std::string>> decomposed_op_map = {
+    {"LRN", {"add", "averagePool2d", "div", "mul", "pad", "pow", "transpose"}},
+    {"RotaryEmbedding", {"add", "concat", "gather", "mul", "reshape", "split"}},
+    {"SimplifiedLayerNormalization", {"add", "div", "mul", "pow", "reduceMean", "sqrt"}},
+    {"SkipSimplifiedLayerNormalization", {"add", "div", "mul", "pow", "reduceMean", "sqrt"}},
+};
+// ONNX op type to WebNN op type mapping.
 static const InlinedHashMap<std::string, std::string> op_map = {
     {"Abs", "abs"},
     {"Add", "add"},
@@ -247,7 +254,6 @@ static const InlinedHashMap<std::string, std::string> op_map = {
     {"Log", "log"},
     {"LpPool", "l2Pool2d"},
     {"LSTM", "lstm"},
-    {"LRN", "averagePool2d"},
     {"MatMul", "matmul"},
     {"MatMulInteger", "matmulInteger"},
     {"Max", "max"},
@@ -275,17 +281,14 @@ static const InlinedHashMap<std::string, std::string> op_map = {
     {"Relu", "relu"},
     {"Reshape", "reshape"},
     {"Resize", "resample2d"},
-    {"RotaryEmbedding", "gather"},
     {"ScatterElements", "scatterElements"},
     {"ScatterND", "scatterND"},
     {"Shape", "slice"},
     {"Sigmoid", "sigmoid"},
     {"Sign", "sign"},
-    {"SimplifiedLayerNormalization", "layerNormalization"},
     {"Softplus", "softplus"},
     {"Softsign", "softsign"},
     {"Sin", "sin"},
-    {"SkipSimplifiedLayerNormalization", "layerNormalization"},
     {"Slice", "slice"},
     {"Softmax", "softmax"},
     {"Split", "split"},
@@ -302,16 +305,37 @@ static const InlinedHashMap<std::string, std::string> op_map = {
     {"Xor", "logicalXor"},
 };
 
-inline bool CheckSingleOp(const std::string& op_type, const emscripten::val& wnn_builder,
-                          const WebnnDeviceType device_type) {
-  auto op_map_entry = op_map.find(op_type);
-  // Returns false if the op_type is not listed in the op_map or
-  // if the WebNN op has not been implemented in MLGraphBuilder in current browser.
-  if (op_map_entry == op_map.end() || !wnn_builder[op_map_entry->second].as<bool>()) {
-    return false;
-  }
+// WebNN op name to its first input name mapping, only record the name that is different from "input".
+// This map is used to determine the first input name of a WebNN op and is utilized by OpSupportLimits.
+static const InlinedHashMap<std::string, std::string> webnn_op_first_input_name_map = {
+    {"add", "a"},
+    {"concat", "inputs"},
+    {"div", "a"},
+    {"equal", "a"},
+    {"gemm", "a"},
+    {"greater", "a"},
+    {"greaterOrEqual", "a"},
+    {"lesser", "a"},
+    {"lesserOrEqual", "a"},
+    {"logicalAnd", "a"},
+    {"logicalNot", "a"},
+    {"logicalOr", "a"},
+    {"logicalXor", "a"},
+    {"matmul", "a"},
+    {"max", "a"},
+    {"min", "a"},
+    {"mul", "a"},
+    {"pow", "a"},
+    {"sub", "a"},
+    {"where", "condition"},
+};
 
-  return true;
+// Retrieve the first input name of a WebNN op used for validating supported input data types.
+// WebNN ops have various first input names such as 'a', 'input', 'inputs', etc.
+// Special names other than 'input' are recorded in the webnn_op_first_input_name_map.
+inline std::string GetWebNNOpFirstInputName(const std::string& webnn_op_type) {
+  auto it = webnn_op_first_input_name_map.find(webnn_op_type);
+  return (it != webnn_op_first_input_name_map.end()) ? it->second : "input";
 }
 
 inline bool GetWebNNOpType(const std::string& op_type, std::string& webnn_op_type) {
@@ -341,16 +365,16 @@ static const InlinedHashMap<ONNX_NAMESPACE::TensorProto_DataType, std::string> o
 bool AreInputDataTypesSame(const std::string& op_type,
                            gsl::span<const int32_t> input_types,
                            const logging::Logger& logger);
-bool IsSupportedDataType(const int32_t onnx_data_type, const emscripten::val& webnn_supported_data_types);
+bool IsSupportedDataType(const int32_t& onnx_data_type, const emscripten::val& webnn_supported_data_types);
 bool IsDataTypeSupportedByOp(const std::string& onnx_op_type,
-                             const int32_t onnx_data_type,
+                             const int32_t& onnx_data_type,
                              const emscripten::val& wnn_limits,
                              const std::string& webnn_input_output_name,
                              const std::string& onnx_input_output_name,
                              const logging::Logger& logger);
 bool IsDataTypeSupportedByWebNNOp(const std::string& onnx_op_type,
                                   const std::string& webnn_op_type,
-                                  const int32_t onnx_data_type,
+                                  const int32_t& onnx_data_type,
                                   const emscripten::val& wnn_limits,
                                   const std::string& webnn_input_output_name,
                                   const std::string& onnx_input_output_name,

--- a/onnxruntime/core/providers/webnn/builders/helper.h
+++ b/onnxruntime/core/providers/webnn/builders/helper.h
@@ -196,14 +196,14 @@ std::unordered_set<const Node*> GetSupportedNodes(const GraphViewer& graph_viewe
                                                   const logging::Logger& logger);
 
 // Some ONNX ops are supported by decomposed WebNN ops.
-static const InlinedHashMap<std::string, std::vector<std::string>> decomposed_op_map = {
+const std::map<std::string_view, std::vector<std::string_view>> decomposed_op_map = {
     {"LRN", {"add", "averagePool2d", "div", "mul", "pad", "pow", "transpose"}},
     {"RotaryEmbedding", {"add", "concat", "gather", "mul", "reshape", "split"}},
     {"SimplifiedLayerNormalization", {"add", "div", "mul", "pow", "reduceMean", "sqrt"}},
     {"SkipSimplifiedLayerNormalization", {"add", "div", "mul", "pow", "reduceMean", "sqrt"}},
 };
 // ONNX op type to WebNN op type mapping.
-static const InlinedHashMap<std::string, std::string> op_map = {
+const std::map<std::string_view, std::string_view> op_map = {
     {"Abs", "abs"},
     {"Add", "add"},
     {"And", "logicalAnd"},
@@ -307,7 +307,7 @@ static const InlinedHashMap<std::string, std::string> op_map = {
 
 // WebNN op name to its first input name mapping, only record the name that is different from "input".
 // This map is used to determine the first input name of a WebNN op and is utilized by OpSupportLimits.
-static const InlinedHashMap<std::string, std::string> webnn_op_first_input_name_map = {
+const std::map<std::string_view, std::string_view> webnn_op_first_input_name_map = {
     {"add", "a"},
     {"concat", "inputs"},
     {"div", "a"},
@@ -333,22 +333,18 @@ static const InlinedHashMap<std::string, std::string> webnn_op_first_input_name_
 // Retrieve the first input name of a WebNN op used for validating supported input data types.
 // WebNN ops have various first input names such as 'a', 'input', 'inputs', etc.
 // Special names other than 'input' are recorded in the webnn_op_first_input_name_map.
-inline std::string GetWebNNOpFirstInputName(const std::string& webnn_op_type) {
+inline std::string_view GetWebNNOpFirstInputName(const std::string_view webnn_op_type) {
   auto it = webnn_op_first_input_name_map.find(webnn_op_type);
   return (it != webnn_op_first_input_name_map.end()) ? it->second : "input";
 }
 
-inline bool GetWebNNOpType(const std::string& op_type, std::string& webnn_op_type) {
+inline std::string_view GetWebNNOpType(const std::string_view op_type) {
   auto it = op_map.find(op_type);
-  // Returns false if the op_type is not listed in the op_map.
-  if (it == op_map.end()) {
-    return false;
-  }
-  webnn_op_type = it->second;
-  return true;
+  // Return an empty string if the op_type is not listed in the op_map.
+  return (it != op_map.end()) ? it->second : "";
 }
 
-static const InlinedHashMap<ONNX_NAMESPACE::TensorProto_DataType, std::string> onnx_to_webnn_data_type_map = {
+const std::map<ONNX_NAMESPACE::TensorProto_DataType, std::string_view> onnx_to_webnn_data_type_map = {
     {ONNX_NAMESPACE::TensorProto_DataType_INT4, "int4"},
     {ONNX_NAMESPACE::TensorProto_DataType_UINT4, "uint4"},
     {ONNX_NAMESPACE::TensorProto_DataType_BOOL, "uint8"},
@@ -362,22 +358,22 @@ static const InlinedHashMap<ONNX_NAMESPACE::TensorProto_DataType, std::string> o
     {ONNX_NAMESPACE::TensorProto_DataType_UINT64, "uint64"},
 };
 
-bool AreInputDataTypesSame(const std::string& op_type,
+bool AreInputDataTypesSame(const std::string_view op_type,
                            gsl::span<const int32_t> input_types,
                            const logging::Logger& logger);
-bool IsSupportedDataType(const int32_t& onnx_data_type, const emscripten::val& webnn_supported_data_types);
-bool IsDataTypeSupportedByOp(const std::string& onnx_op_type,
-                             const int32_t& onnx_data_type,
+bool IsSupportedDataType(const int32_t onnx_data_type, const emscripten::val& webnn_supported_data_types);
+bool IsDataTypeSupportedByOp(const std::string_view onnx_op_type,
+                             const int32_t onnx_data_type,
                              const emscripten::val& wnn_limits,
-                             const std::string& webnn_input_output_name,
-                             const std::string& onnx_input_output_name,
+                             const std::string_view webnn_input_output_name,
+                             const std::string_view onnx_input_output_name,
                              const logging::Logger& logger);
-bool IsDataTypeSupportedByWebNNOp(const std::string& onnx_op_type,
-                                  const std::string& webnn_op_type,
-                                  const int32_t& onnx_data_type,
+bool IsDataTypeSupportedByWebNNOp(const std::string_view onnx_op_type,
+                                  const std::string_view webnn_op_type,
+                                  const int32_t onnx_data_type,
                                   const emscripten::val& wnn_limits,
-                                  const std::string& webnn_input_output_name,
-                                  const std::string& onnx_input_output_name,
+                                  const std::string_view webnn_input_output_name,
+                                  const std::string_view onnx_input_output_name,
                                   const logging::Logger& logger);
 
 bool GetBidirectionalBroadcastShape(std::vector<int64_t>& shape_a,

--- a/onnxruntime/core/providers/webnn/builders/impl/base_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/base_op_builder.cc
@@ -58,15 +58,15 @@ bool BaseOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet& initializ
                                            const logging::Logger& logger) const {
   // We only check the type of input 0 by default, specific op builder can override this.
   const auto& input = *node.InputDefs()[0];
-  const auto& op_type = node.OpType();
+  const std::string_view op_type = node.OpType();
   int32_t input_type;
   if (!GetType(input, input_type, logger))
     return false;
-  std::string webnn_op_type;
-  if (!GetWebNNOpType(op_type, webnn_op_type))
+  const std::string_view webnn_op_type = GetWebNNOpType(op_type);
+  if (webnn_op_type.empty())
     return false;
 
-  const auto webnn_input_name = GetWebNNOpFirstInputName(op_type);
+  const std::string_view webnn_input_name = GetWebNNOpFirstInputName(webnn_op_type);
   return IsDataTypeSupportedByWebNNOp(op_type, webnn_op_type, input_type, wnn_limits,
                                       webnn_input_name, "input", logger);
 }
@@ -88,7 +88,7 @@ bool BaseOpBuilder::HasSupportedOutputsImpl(const Node& node,
                                             const logging::Logger& logger) const {
   // We only check the type of output 0 by default, specific op builder can override this.
   const auto& output = *node.OutputDefs()[0];
-  const auto& op_type = node.OpType();
+  const std::string_view op_type = node.OpType();
   int32_t output_type;
   if (!GetType(output, output_type, logger))
     return false;

--- a/onnxruntime/core/providers/webnn/builders/impl/base_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/base_op_builder.cc
@@ -62,8 +62,13 @@ bool BaseOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet& initializ
   int32_t input_type;
   if (!GetType(input, input_type, logger))
     return false;
+  std::string webnn_op_type;
+  if (!GetWebNNOpType(op_type, webnn_op_type))
+    return false;
 
-  return IsDataTypeSupportedByOp(op_type, input_type, wnn_limits, "input", "Input", logger);
+  const auto webnn_input_name = GetWebNNOpFirstInputName(op_type);
+  return IsDataTypeSupportedByWebNNOp(op_type, webnn_op_type, input_type, wnn_limits,
+                                      webnn_input_name, "input", logger);
 }
 
 bool BaseOpBuilder::HasSupportedOutputs(const Node& node, const emscripten::val& wnn_limits,

--- a/onnxruntime/core/providers/webnn/builders/impl/binary_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/binary_op_builder.cc
@@ -60,7 +60,7 @@ Status BinaryOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const
 bool BinaryOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet& /* initializers */, const Node& node,
                                              const emscripten::val& wnn_limits, const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
-  const auto& op_type = node.OpType();
+  const std::string_view op_type = node.OpType();
   int32_t input0_type;
   int32_t input1_type;
 

--- a/onnxruntime/core/providers/webnn/builders/impl/cast_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/cast_op_builder.cc
@@ -18,11 +18,6 @@ class CastOpBuilder : public BaseOpBuilder {
  private:
   Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node,
                                const logging::Logger& logger) const override ORT_MUST_USE_RESULT;
-
-  // Operator support related.
- private:
-  bool HasSupportedInputsImpl(const InitializedTensorSet& /* initializers */, const Node& node,
-                              const emscripten::val& wnn_limits, const logging::Logger& logger) const override;
 };
 
 // Add operator related.
@@ -83,25 +78,6 @@ Status CastOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
 
   model_builder.AddOperand(node.OutputDefs()[0]->Name(), std::move(output));
   return Status::OK();
-}
-
-// Operator support related.
-bool CastOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet& /* initializers */, const Node& node,
-                                           const emscripten::val& wnn_limits, const logging::Logger& logger) const {
-  const auto& input_defs = node.InputDefs();
-  const auto& op_type = node.OpType();
-  int32_t input_type;
-
-  if (!GetType(*input_defs[0], input_type, logger))
-    return false;
-
-  if (!IsDataTypeSupportedByOp(op_type, input_type, wnn_limits, "input", "input", logger))
-    return false;
-
-  NodeAttrHelper helper(node);
-  // Check cast to type.
-  const auto to_type = helper.Get("to", ONNX_NAMESPACE::TensorProto_DataType_UNDEFINED);
-  return IsDataTypeSupportedByOp(op_type, to_type, wnn_limits, "output", "to", logger);
 }
 
 void CreateCastOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {

--- a/onnxruntime/core/providers/webnn/builders/impl/concat_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/concat_op_builder.cc
@@ -58,7 +58,7 @@ Status ConcatOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
 bool ConcatOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet& /* initializers */, const Node& node,
                                              const emscripten::val& wnn_limits, const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
-  const auto& op_type = node.OpType();
+  const std::string_view op_type = node.OpType();
   int32_t input0_type;
 
   if (!GetType(*input_defs[0], input0_type, logger))

--- a/onnxruntime/core/providers/webnn/builders/impl/conv_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/conv_op_builder.cc
@@ -384,7 +384,7 @@ bool ConvOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
 bool ConvOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet& /* initializers */, const Node& node,
                                            const emscripten::val& wnn_limits, const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
-  const auto& op_type = node.OpType();
+  const std::string_view op_type = node.OpType();
   int32_t input0_type;  // input data type
   int32_t input1_type;  // weight data type
   int32_t input2_type;  // bias or x_zero_point data type

--- a/onnxruntime/core/providers/webnn/builders/impl/einsum_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/einsum_op_builder.cc
@@ -739,7 +739,7 @@ bool EinsumOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet& /* init
                                              const emscripten::val& wnn_limits, const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
 
-  const auto& op_type = node.OpType();
+  const std::string_view op_type = node.OpType();
   int32_t input0_type;
   int32_t input1_type;
   bool has_input1 = TensorExists(input_defs, 1);

--- a/onnxruntime/core/providers/webnn/builders/impl/gatherElements_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/gatherElements_op_builder.cc
@@ -54,7 +54,7 @@ bool GatherElementsOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet&
                                                      const logging::Logger& logger) const {
   const auto& data = *node.InputDefs()[0];
   const auto& indices = *node.InputDefs()[1];
-  const auto& op_type = node.OpType();
+  const std::string_view op_type = node.OpType();
 
   int32_t data_type;
   int32_t indices_type;

--- a/onnxruntime/core/providers/webnn/builders/impl/gatherND_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/gatherND_op_builder.cc
@@ -59,7 +59,7 @@ bool GatherNDOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet& /* in
                                                const emscripten::val& wnn_limits, const logging::Logger& logger) const {
   const auto& data = *node.InputDefs()[0];
   const auto& indices = *node.InputDefs()[1];
-  const auto& op_type = node.OpType();
+  const std::string_view op_type = node.OpType();
 
   int32_t data_type;
   int32_t indices_type;

--- a/onnxruntime/core/providers/webnn/builders/impl/gather_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/gather_op_builder.cc
@@ -73,7 +73,7 @@ bool GatherOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet& /* init
                                              const emscripten::val& wnn_limits, const logging::Logger& logger) const {
   const auto& input = *node.InputDefs()[0];
   const auto& indices = *node.InputDefs()[1];
-  const auto& op_type = node.OpType();
+  const std::string_view op_type = node.OpType();
   int32_t input_type;
   int32_t indices_type;
   if (!GetType(input, input_type, logger) ||

--- a/onnxruntime/core/providers/webnn/builders/impl/gemm_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/gemm_op_builder.cc
@@ -218,7 +218,7 @@ bool GemmOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& /* initializer
 bool GemmOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet& /* initializers */, const Node& node,
                                            const emscripten::val& wnn_limits, const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
-  const auto& op_type = node.OpType();
+  const std::string_view op_type = node.OpType();
   int32_t input0_type;  // A data type
   int32_t input1_type;  // B data type
   int32_t input2_type;  // C or a_zero_point data type

--- a/onnxruntime/core/providers/webnn/builders/impl/gru_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/gru_op_builder.cc
@@ -190,7 +190,7 @@ bool GruOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers, c
 bool GruOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet& /* initializers */, const Node& node,
                                           const emscripten::val& wnn_limits, const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
-  const auto& op_type = node.OpType();
+  const std::string_view op_type = node.OpType();
   int32_t input_X_type = 0;          // input data type
   int32_t input_W_type = 0;          // weight data type
   int32_t input_R_type = 0;          // recurrent weight data type
@@ -226,7 +226,7 @@ bool GruOpBuilder::HasSupportedOutputsImpl(const Node& node,
                                            const emscripten::val& wnn_limits,
                                            const logging::Logger& logger) const {
   const auto& output_defs = node.OutputDefs();
-  const auto& op_type = node.OpType();
+  const std::string_view op_type = node.OpType();
   int32_t Y_type = 0;
   int32_t Y_h_type = 0;
   bool has_Y = TensorExists(output_defs, 0);

--- a/onnxruntime/core/providers/webnn/builders/impl/logical_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/logical_op_builder.cc
@@ -43,10 +43,11 @@ Status LogicalOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, cons
 
   if (input_defs.size() == 1) {
     // Not
-    output = model_builder.GetBuilder().call<emscripten::val>(webnn_op_type.data(), input0, options);
+    output = model_builder.GetBuilder().call<emscripten::val>(std::string(webnn_op_type).c_str(), input0, options);
   } else {
     input1 = model_builder.GetOperand(input_defs[1]->Name());
-    output = model_builder.GetBuilder().call<emscripten::val>(webnn_op_type.data(), input0, input1, options);
+    output = model_builder.GetBuilder().call<emscripten::val>(
+        std::string(webnn_op_type).c_str(), input0, input1, options);
   }
 
   model_builder.AddOperand(node.OutputDefs()[0]->Name(), std::move(output));

--- a/onnxruntime/core/providers/webnn/builders/impl/logical_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/logical_op_builder.cc
@@ -38,15 +38,15 @@ Status LogicalOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, cons
   emscripten::val options = emscripten::val::object();
   options.set("label", node.Name());
 
-  std::string webnn_op_type;
-  ORT_RETURN_IF_NOT(GetWebNNOpType(op_type, webnn_op_type), "Cannot get WebNN op type");
+  const std::string_view webnn_op_type = GetWebNNOpType(op_type);
+  ORT_RETURN_IF(webnn_op_type.empty(), "Cannot get WebNN op type");
 
   if (input_defs.size() == 1) {
     // Not
-    output = model_builder.GetBuilder().call<emscripten::val>(webnn_op_type.c_str(), input0, options);
+    output = model_builder.GetBuilder().call<emscripten::val>(webnn_op_type.data(), input0, options);
   } else {
     input1 = model_builder.GetOperand(input_defs[1]->Name());
-    output = model_builder.GetBuilder().call<emscripten::val>(webnn_op_type.c_str(), input0, input1, options);
+    output = model_builder.GetBuilder().call<emscripten::val>(webnn_op_type.data(), input0, input1, options);
   }
 
   model_builder.AddOperand(node.OutputDefs()[0]->Name(), std::move(output));
@@ -74,7 +74,7 @@ bool LogicalOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& /* initiali
 bool LogicalOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet& /* initializers */, const Node& node,
                                               const emscripten::val& wnn_limits, const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
-  const auto& op_type = node.OpType();
+  const std::string_view op_type = node.OpType();
   int32_t input0_type;
   int32_t input1_type;
 

--- a/onnxruntime/core/providers/webnn/builders/impl/lrn_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/lrn_op_builder.cc
@@ -23,6 +23,10 @@ class LRNOpBuilder : public BaseOpBuilder {
  private:
   bool IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
                          const WebnnDeviceType /* device_type */, const logging::Logger& logger) const override;
+  bool HasSupportedInputsImpl(const InitializedTensorSet& /* initializers */, const Node& node,
+                              const emscripten::val& wnn_limits, const logging::Logger& logger) const override;
+  bool HasSupportedOutputsImpl(const Node& node, const emscripten::val& wnn_limits,
+                               const logging::Logger& logger) const override;
 };
 
 Status LRNOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
@@ -137,6 +141,47 @@ bool LRNOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
     LOGS(logger, VERBOSE) << "LRN only supports 4D input shape, input is "
                           << input_size << "D shape";
     return false;
+  }
+
+  return true;
+}
+
+bool LRNOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet& /* initializers */, const Node& node,
+                                          const emscripten::val& wnn_limits, const logging::Logger& logger) const {
+  const auto& input_defs = node.InputDefs();
+  const auto& op_type = node.OpType();
+  int32_t input_type = 0;
+  if (!GetType(*input_defs[0], input_type, logger)) {
+    return false;
+  }
+
+  // Check if the input data type is supported by each decomposed WebNN op.
+  // Decomposed ops include: "add", "averagePool2d", "div", "mul", "pad", "pow" and "transpose".
+  for (const auto& webnn_op_type : decomposed_op_map.at(op_type)) {
+    const auto webnn_input_name = GetWebNNOpFirstInputName(webnn_op_type);
+    if (!IsDataTypeSupportedByWebNNOp(op_type, webnn_op_type, input_type, wnn_limits, webnn_input_name, "X", logger)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool LRNOpBuilder::HasSupportedOutputsImpl(const Node& node,
+                                           const emscripten::val& wnn_limits,
+                                           const logging::Logger& logger) const {
+  const auto& output_defs = node.OutputDefs();
+  const auto& op_type = node.OpType();
+  int32_t output_type = 0;
+  if (!GetType(*output_defs[0], output_type, logger)) {
+    return false;
+  }
+
+  // Check if the output data type is supported by every decomposed WebNN op.
+  for (const auto& webnn_op_type : decomposed_op_map.at(op_type)) {
+    if (!IsDataTypeSupportedByWebNNOp(op_type, webnn_op_type, output_type, wnn_limits, "output", "Y", logger)) {
+      return false;
+    }
   }
 
   return true;

--- a/onnxruntime/core/providers/webnn/builders/impl/lrn_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/lrn_op_builder.cc
@@ -149,7 +149,7 @@ bool LRNOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
 bool LRNOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet& /* initializers */, const Node& node,
                                           const emscripten::val& wnn_limits, const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
-  const auto& op_type = node.OpType();
+  const std::string_view op_type = node.OpType();
   int32_t input_type = 0;
   if (!GetType(*input_defs[0], input_type, logger)) {
     return false;
@@ -157,8 +157,8 @@ bool LRNOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet& /* initial
 
   // Check if the input data type is supported by each decomposed WebNN op.
   // Decomposed ops include: "add", "averagePool2d", "div", "mul", "pad", "pow" and "transpose".
-  for (const auto& webnn_op_type : decomposed_op_map.at(op_type)) {
-    const auto webnn_input_name = GetWebNNOpFirstInputName(webnn_op_type);
+  for (const std::string_view webnn_op_type : decomposed_op_map.at(op_type)) {
+    const std::string_view webnn_input_name = GetWebNNOpFirstInputName(webnn_op_type);
     if (!IsDataTypeSupportedByWebNNOp(op_type, webnn_op_type, input_type, wnn_limits, webnn_input_name, "X", logger)) {
       return false;
     }
@@ -171,14 +171,14 @@ bool LRNOpBuilder::HasSupportedOutputsImpl(const Node& node,
                                            const emscripten::val& wnn_limits,
                                            const logging::Logger& logger) const {
   const auto& output_defs = node.OutputDefs();
-  const auto& op_type = node.OpType();
+  const std::string_view op_type = node.OpType();
   int32_t output_type = 0;
   if (!GetType(*output_defs[0], output_type, logger)) {
     return false;
   }
 
   // Check if the output data type is supported by every decomposed WebNN op.
-  for (const auto& webnn_op_type : decomposed_op_map.at(op_type)) {
+  for (const std::string_view webnn_op_type : decomposed_op_map.at(op_type)) {
     if (!IsDataTypeSupportedByWebNNOp(op_type, webnn_op_type, output_type, wnn_limits, "output", "Y", logger)) {
       return false;
     }

--- a/onnxruntime/core/providers/webnn/builders/impl/lstm_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/lstm_op_builder.cc
@@ -201,7 +201,7 @@ bool LstmOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers, 
 bool LstmOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet& /* initializers */, const Node& node,
                                            const emscripten::val& wnn_limits, const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
-  const auto& op_type = node.OpType();
+  const std::string_view op_type = node.OpType();
   int32_t input0_type = 0;  // input data type
   int32_t input1_type = 0;  // weight data type
   int32_t input2_type = 0;  // recurrentWeight data type

--- a/onnxruntime/core/providers/webnn/builders/impl/max_min_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/max_min_op_builder.cc
@@ -90,7 +90,7 @@ bool MaxMinOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& /* initializ
 bool MaxMinOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet& /* initializers */, const Node& node,
                                              const emscripten::val& wnn_limits, const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
-  const auto& op_type = node.OpType();
+  const std::string_view op_type = node.OpType();
   int32_t input0_type;
 
   if (!GetType(*input_defs[0], input0_type, logger))

--- a/onnxruntime/core/providers/webnn/builders/impl/normalization_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/normalization_op_builder.cc
@@ -275,7 +275,7 @@ bool NormalizationOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet& 
                                                     const emscripten::val& wnn_limits,
                                                     const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
-  const auto& op_type = node.OpType();
+  const std::string_view op_type = node.OpType();
   int32_t input0_type;  // input data type
   int32_t input1_type;  // scale data type
   int32_t input2_type;  // B data type
@@ -311,8 +311,8 @@ bool NormalizationOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet& 
     // SkipSimplifiedLayerNormalization and SimplifiedLayerNormalization are supported by decomposed WebNN ops.
     // Check if the input data type is supported by each decomposed WebNN op.
     // Decomposed ops include: "add", "div", "mul", "pow", "reduceMean" and "sqrt".
-    for (const auto& webnn_op_type : decomposed_op_map.at(op_type)) {
-      const auto webnn_input_name = GetWebNNOpFirstInputName(webnn_op_type);
+    for (const std::string_view webnn_op_type : decomposed_op_map.at(op_type)) {
+      const std::string_view webnn_input_name = GetWebNNOpFirstInputName(webnn_op_type);
       if (!IsDataTypeSupportedByWebNNOp(
               op_type, webnn_op_type, input0_type, wnn_limits, webnn_input_name, "input", logger)) {
         return false;
@@ -328,7 +328,7 @@ bool NormalizationOpBuilder::HasSupportedOutputsImpl(const Node& node,
                                                      const emscripten::val& wnn_limits,
                                                      const logging::Logger& logger) const {
   const auto& output_defs = node.OutputDefs();
-  const auto& op_type = node.OpType();
+  const std::string_view op_type = node.OpType();
   int32_t output_type = 0;
   if (!GetType(*output_defs[0], output_type, logger)) {
     return false;
@@ -336,7 +336,7 @@ bool NormalizationOpBuilder::HasSupportedOutputsImpl(const Node& node,
 
   if (op_type == "SimplifiedLayerNormalization" || op_type == "SkipSimplifiedLayerNormalization") {
     // Check if the output data type is supported by every decomposed WebNN op.
-    for (const auto& webnn_op_type : decomposed_op_map.at(op_type)) {
+    for (const std::string_view webnn_op_type : decomposed_op_map.at(op_type)) {
       if (!IsDataTypeSupportedByWebNNOp(op_type, webnn_op_type, output_type, wnn_limits, "output", "output", logger)) {
         return false;
       }

--- a/onnxruntime/core/providers/webnn/builders/impl/normalization_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/normalization_op_builder.cc
@@ -27,6 +27,8 @@ class NormalizationOpBuilder : public BaseOpBuilder {
                          const WebnnDeviceType /* device_type */, const logging::Logger& logger) const override;
   bool HasSupportedInputsImpl(const InitializedTensorSet& /* initializers */, const Node& node,
                               const emscripten::val& wnn_limits, const logging::Logger& logger) const override;
+  bool HasSupportedOutputsImpl(const Node& node, const emscripten::val& wnn_limits,
+                               const logging::Logger& logger) const override;
 };
 
 Status NormalizationOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
@@ -305,7 +307,44 @@ bool NormalizationOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet& 
     return false;
   }
 
-  return IsDataTypeSupportedByOp(op_type, input0_type, wnn_limits, "input", "X", logger);
+  if (op_type == "SimplifiedLayerNormalization" || op_type == "SkipSimplifiedLayerNormalization") {
+    // SkipSimplifiedLayerNormalization and SimplifiedLayerNormalization are supported by decomposed WebNN ops.
+    // Check if the input data type is supported by each decomposed WebNN op.
+    // Decomposed ops include: "add", "div", "mul", "pow", "reduceMean" and "sqrt".
+    for (const auto& webnn_op_type : decomposed_op_map.at(op_type)) {
+      const auto webnn_input_name = GetWebNNOpFirstInputName(webnn_op_type);
+      if (!IsDataTypeSupportedByWebNNOp(
+              op_type, webnn_op_type, input0_type, wnn_limits, webnn_input_name, "input", logger)) {
+        return false;
+      }
+    }
+    return true;
+  } else {
+    return IsDataTypeSupportedByOp(op_type, input0_type, wnn_limits, "input", "X", logger);
+  }
+}
+
+bool NormalizationOpBuilder::HasSupportedOutputsImpl(const Node& node,
+                                                     const emscripten::val& wnn_limits,
+                                                     const logging::Logger& logger) const {
+  const auto& output_defs = node.OutputDefs();
+  const auto& op_type = node.OpType();
+  int32_t output_type = 0;
+  if (!GetType(*output_defs[0], output_type, logger)) {
+    return false;
+  }
+
+  if (op_type == "SimplifiedLayerNormalization" || op_type == "SkipSimplifiedLayerNormalization") {
+    // Check if the output data type is supported by every decomposed WebNN op.
+    for (const auto& webnn_op_type : decomposed_op_map.at(op_type)) {
+      if (!IsDataTypeSupportedByWebNNOp(op_type, webnn_op_type, output_type, wnn_limits, "output", "output", logger)) {
+        return false;
+      }
+    }
+    return true;
+  } else {
+    return IsDataTypeSupportedByOp(op_type, output_type, wnn_limits, "output", "Output", logger);
+  }
 }
 
 void CreateNormalizationOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {

--- a/onnxruntime/core/providers/webnn/builders/impl/qdq_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/qdq_op_builder.cc
@@ -113,8 +113,8 @@ Status QDQOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
   const std::string_view webnn_op_type = GetWebNNOpType(op_type);
   ORT_RETURN_IF(webnn_op_type.empty(), "Cannot get WebNN op type");
 
-  emscripten::val output =
-      model_builder.GetBuilder().call<emscripten::val>(webnn_op_type.data(), input, scale, zero_point, options);
+  emscripten::val output = model_builder.GetBuilder().call<emscripten::val>(
+      std::string(webnn_op_type).c_str(), input, scale, zero_point, options);
 
   model_builder.AddOperand(output_defs[0]->Name(), std::move(output));
 

--- a/onnxruntime/core/providers/webnn/builders/impl/qdq_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/qdq_op_builder.cc
@@ -110,10 +110,11 @@ Status QDQOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
 
   emscripten::val options = emscripten::val::object();
   options.set("label", node.Name());
-  std::string webnn_op_type;
-  ORT_RETURN_IF_NOT(GetWebNNOpType(op_type, webnn_op_type), "Cannot get WebNN op type");
+  const std::string_view webnn_op_type = GetWebNNOpType(op_type);
+  ORT_RETURN_IF(webnn_op_type.empty(), "Cannot get WebNN op type");
+
   emscripten::val output =
-      model_builder.GetBuilder().call<emscripten::val>(webnn_op_type.c_str(), input, scale, zero_point, options);
+      model_builder.GetBuilder().call<emscripten::val>(webnn_op_type.data(), input, scale, zero_point, options);
 
   model_builder.AddOperand(output_defs[0]->Name(), std::move(output));
 
@@ -155,7 +156,7 @@ bool QDQOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& /* initializers
 bool QDQOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet& /* initializers */, const Node& node,
                                           const emscripten::val& wnn_limits, const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
-  const auto& op_type = node.OpType();
+  const std::string_view op_type = node.OpType();
   int32_t input0_type = 0;  // input data type
   int32_t input1_type = 0;  // x_scale data type
   int32_t input2_type = 0;  // x_zero_point data type

--- a/onnxruntime/core/providers/webnn/builders/impl/rotaryEmbedding_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/rotaryEmbedding_op_builder.cc
@@ -59,6 +59,10 @@ class RotaryEmbeddingOpBuilder : public BaseOpBuilder {
  private:
   bool IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
                          const WebnnDeviceType /* device_type */, const logging::Logger& logger) const override;
+  bool HasSupportedInputsImpl(const InitializedTensorSet& /* initializers */, const Node& node,
+                              const emscripten::val& wnn_limits, const logging::Logger& logger) const override;
+  bool HasSupportedOutputsImpl(const Node& node, const emscripten::val& wnn_limits,
+                               const logging::Logger& logger) const override;
 };
 
 Status RotaryEmbeddingOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node,
@@ -300,6 +304,67 @@ bool RotaryEmbeddingOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& ini
   if (rotary_embedding_dim > 0 && num_heads == 0) {
     LOGS(logger, VERBOSE) << "RotaryEmbedding: num_heads must be provided if rotary_embedding_dim is specified";
     return false;
+  }
+
+  return true;
+}
+
+bool RotaryEmbeddingOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet& /* initializers */,
+                                                      const Node& node,
+                                                      const emscripten::val& wnn_limits,
+                                                      const logging::Logger& logger) const {
+  const auto& input_defs = node.InputDefs();
+  const auto& op_type = node.OpType();
+  int32_t input_type = 0;
+  int32_t position_ids_type = 0;
+  int32_t cos_cache_type = 0;
+  int32_t sin_cache_type = 0;
+  if (!GetType(*input_defs[0], input_type, logger) ||
+      !GetType(*input_defs[1], position_ids_type, logger) ||
+      !GetType(*input_defs[2], cos_cache_type, logger) ||
+      !GetType(*input_defs[3], sin_cache_type, logger)) {
+    return false;
+  }
+
+  std::array<int32_t, 3> input_types{input_type, cos_cache_type, sin_cache_type};
+  if (!AreInputDataTypesSame(op_type, input_types, logger)) {
+    return false;
+  }
+
+  if (position_ids_type != ONNX_NAMESPACE::TensorProto_DataType_INT64) {
+    return false;
+  }
+
+  // Check if the input data type is supported by each decomposed WebNN op.
+  // Decomposed ops include: "add", "concat", "gather", "mul", "reshape" and "split".
+  for (const auto& webnn_op_type : decomposed_op_map.at(op_type)) {
+    const auto webnn_input_name = GetWebNNOpFirstInputName(webnn_op_type);
+    if (!IsDataTypeSupportedByWebNNOp(
+            op_type, webnn_op_type, input_type, wnn_limits, webnn_input_name, "input", logger)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool RotaryEmbeddingOpBuilder::HasSupportedOutputsImpl(const Node& node,
+                                                       const emscripten::val& wnn_limits,
+                                                       const logging::Logger& logger) const {
+  const auto& output_defs = node.OutputDefs();
+  const auto& op_type = node.OpType();
+  int32_t output_type = 0;
+  if (!GetType(*output_defs[0], output_type, logger)) {
+    return false;
+  }
+
+  // Check if the output data type is supported by every decomposed WebNN op.
+  for (const auto& webnn_op_type : decomposed_op_map.at(op_type)) {
+    const std::string webnn_output_name = webnn_op_type == "split" ? "outputs" : "output";
+    if (!IsDataTypeSupportedByWebNNOp(
+            op_type, webnn_op_type, output_type, wnn_limits, webnn_output_name, "output", logger)) {
+      return false;
+    }
   }
 
   return true;

--- a/onnxruntime/core/providers/webnn/builders/impl/rotaryEmbedding_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/rotaryEmbedding_op_builder.cc
@@ -314,7 +314,7 @@ bool RotaryEmbeddingOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet
                                                       const emscripten::val& wnn_limits,
                                                       const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
-  const auto& op_type = node.OpType();
+  const std::string_view op_type = node.OpType();
   int32_t input_type = 0;
   int32_t position_ids_type = 0;
   int32_t cos_cache_type = 0;
@@ -337,8 +337,8 @@ bool RotaryEmbeddingOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet
 
   // Check if the input data type is supported by each decomposed WebNN op.
   // Decomposed ops include: "add", "concat", "gather", "mul", "reshape" and "split".
-  for (const auto& webnn_op_type : decomposed_op_map.at(op_type)) {
-    const auto webnn_input_name = GetWebNNOpFirstInputName(webnn_op_type);
+  for (const std::string_view webnn_op_type : decomposed_op_map.at(op_type)) {
+    const std::string_view webnn_input_name = GetWebNNOpFirstInputName(webnn_op_type);
     if (!IsDataTypeSupportedByWebNNOp(
             op_type, webnn_op_type, input_type, wnn_limits, webnn_input_name, "input", logger)) {
       return false;
@@ -352,15 +352,15 @@ bool RotaryEmbeddingOpBuilder::HasSupportedOutputsImpl(const Node& node,
                                                        const emscripten::val& wnn_limits,
                                                        const logging::Logger& logger) const {
   const auto& output_defs = node.OutputDefs();
-  const auto& op_type = node.OpType();
+  const std::string_view op_type = node.OpType();
   int32_t output_type = 0;
   if (!GetType(*output_defs[0], output_type, logger)) {
     return false;
   }
 
   // Check if the output data type is supported by every decomposed WebNN op.
-  for (const auto& webnn_op_type : decomposed_op_map.at(op_type)) {
-    const std::string webnn_output_name = webnn_op_type == "split" ? "outputs" : "output";
+  for (const std::string_view webnn_op_type : decomposed_op_map.at(op_type)) {
+    const std::string_view webnn_output_name = webnn_op_type == "split" ? "outputs" : "output";
     if (!IsDataTypeSupportedByWebNNOp(
             op_type, webnn_op_type, output_type, wnn_limits, webnn_output_name, "output", logger)) {
       return false;

--- a/onnxruntime/core/providers/webnn/builders/impl/scatterElements_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/scatterElements_op_builder.cc
@@ -71,7 +71,7 @@ bool ScatterElementsOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet
   const auto& data = *node.InputDefs()[0];
   const auto& indices = *node.InputDefs()[1];
   const auto& updates = *node.InputDefs()[2];
-  const auto& op_type = node.OpType();
+  const std::string_view op_type = node.OpType();
 
   int32_t data_type;
   int32_t indices_type;

--- a/onnxruntime/core/providers/webnn/builders/impl/scatterND_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/scatterND_op_builder.cc
@@ -63,7 +63,7 @@ bool ScatterNDOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet& /* i
   const auto& data = *node.InputDefs()[0];
   const auto& indices = *node.InputDefs()[1];
   const auto& updates = *node.InputDefs()[2];
-  const auto& op_type = node.OpType();
+  const std::string_view op_type = node.OpType();
 
   int32_t data_type;
   int32_t indices_type;

--- a/onnxruntime/core/providers/webnn/builders/impl/slice_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/slice_op_builder.cc
@@ -167,7 +167,7 @@ bool SliceOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet& initiali
                                             const emscripten::val& wnn_limits, const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
   const auto& input = *input_defs[0];
-  const auto& op_type = node.OpType();
+  const std::string_view op_type = node.OpType();
   int32_t input_type;
   if (!GetType(input, input_type, logger))
     return false;

--- a/onnxruntime/core/providers/webnn/builders/impl/split_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/split_op_builder.cc
@@ -169,13 +169,13 @@ bool SplitOpBuilder::HasSupportedOutputsImpl(const Node& node,
                                              const emscripten::val& wnn_limits,
                                              const logging::Logger& logger) const {
   const auto& output_defs = node.OutputDefs();
-  const auto& op_type = node.OpType();
+  const std::string_view op_type = node.OpType();
   int32_t output_type = 0;
 
   if (GetType(*output_defs[0], output_type, logger)) {
     // Chromium has changed the output name of split from 'output' to 'outputs',
     // to avoid breaking the existing API, we need to check both names.
-    std::string wnn_output_name = wnn_limits["split"]["output"].isUndefined() ? "outputs" : "output";
+    const std::string_view wnn_output_name = wnn_limits["split"]["output"].isUndefined() ? "outputs" : "output";
     return IsDataTypeSupportedByOp(op_type, output_type, wnn_limits, wnn_output_name, "outputs", logger);
   }
 

--- a/onnxruntime/core/providers/webnn/builders/impl/ternary_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/ternary_op_builder.cc
@@ -49,7 +49,7 @@ Status TernaryOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, cons
 bool TernaryOpBuilder::HasSupportedInputsImpl(const InitializedTensorSet& /* initializers */, const Node& node,
                                               const emscripten::val& wnn_limits, const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
-  const auto& op_type = node.OpType();
+  const std::string_view op_type = node.OpType();
   int32_t input0_type;  // condition data type
   int32_t input1_type;  // X data type
   int32_t input2_type;  // Y data type


### PR DESCRIPTION
- Some ONNX op are supported by decomposed WebNN ops, defines a `decomposed_op_map` map to specific decomposed WebNN ops list.
- WebNN ops have various first input names such as 'a', 'input', 'inputs', etc. Defines a `webnn_op_first_input_name_map` map to record special names other than 'input', and a `GetWebNNOpFirstInputName` function to retrieve the first input name of a WebNN op.
- Check if the input and output data types are supported by each decomposed WebNN op.
- Remove the unnecessary `CheckSingleOp` function, because WebNN's `OpSupportLimits` has already covered op supported check.


