### PR TITLE
Fix `einsum` operator for empty inputs

### DIFF
--- a/onnxruntime/core/providers/cpu/math/einsum_utils/einsum_typed_compute_processor.cc
+++ b/onnxruntime/core/providers/cpu/math/einsum_utils/einsum_typed_compute_processor.cc
@@ -306,9 +306,20 @@ std::unique_ptr<Tensor> EinsumTypedComputeProcessor<T>::PairwiseOperandProcess(c
   }
 
   // Multiply the mutated inputs
-  auto output = EinsumOp::MatMul<T>(current_left ? *current_left : left, TensorShapeVector{lro_size, lo_size, reduced_size},
-                                    current_right ? *current_right : right, TensorShapeVector{lro_size, reduced_size, ro_size},
-                                    allocator_, tp_, einsum_ep_assets_, device_matmul_func_);
+  auto output = std::make_unique<Tensor>(left.DataType(), output_dims, allocator_);
+
+  bool input_has_zero_dim = left.Shape().Size() == 0 || right.Shape().Size() == 0;
+  if (!input_has_zero_dim) {
+    output = EinsumOp::MatMul<T>(current_left ? *current_left : left, TensorShapeVector{lro_size, lo_size, reduced_size},
+                                 current_right ? *current_right : right, TensorShapeVector{lro_size, reduced_size, ro_size},
+                                 allocator_, tp_, einsum_ep_assets_, device_matmul_func_);
+  } else {
+    if constexpr (std::is_integral<T>::value) {
+      std::fill_n(reinterpret_cast<T*>(output->MutableDataRaw()), output->Shape().Size(), T(0));
+    } else {
+      std::fill_n(reinterpret_cast<T*>(output->MutableDataRaw()), output->Shape().Size(), T(0.f));
+    }
+  }
 
   output->Reshape(output_dims);
 

--- a/onnxruntime/test/providers/cpu/math/einsum_test.cc
+++ b/onnxruntime/test/providers/cpu/math/einsum_test.cc
@@ -755,6 +755,44 @@ TEST(Einsum, ExplicitEinsumAsTensorContraction_Half) {
   test.Run();
 }
 
+// Theme: Dimensions of size 0
+TEST(Einsum, EinsumZeroDimensionOuterProduct) {
+  OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
+  test.AddAttribute<std::string>("equation", "i,j->ij");
+  test.AddInput<float>("x", {0}, {});
+  test.AddInput<float>("y", {0}, {});
+  test.AddOutput<float>("o", {0, 0}, {});
+  test.Run();
+  std::cout << "Ending" << std::endl;
+}
+
+TEST(Einsum, EinsumZeroDimensionTranspose) {
+  OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
+  test.AddAttribute<std::string>("equation", "ab,ba->ab");
+  test.AddInput<float>("x", {0, 1}, {});
+  test.AddInput<float>("y", {1, 0}, {});
+  test.AddOutput<float>("o", {0, 1}, {});
+  test.Run();
+}
+
+TEST(Einsum, EinsumZeroDimensionVanish) {
+  OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
+  test.AddAttribute<std::string>("equation", "ab,ba->a");
+  test.AddInput<float>("x", {1, 0}, {});
+  test.AddInput<float>("y", {0, 1}, {});
+  test.AddOutput<float>("o", {1}, {0.f});
+  test.Run();
+}
+
+TEST(Einsum, EinsumZeroDimensionVanish3d) {
+  OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
+  test.AddAttribute<std::string>("equation", "abc,bad->ad");
+  test.AddInput<float>("x", {10, 0, 10}, {});
+  test.AddInput<float>("y", {0, 10, 1}, {});
+  test.AddOutput<float>("o", {10, 1}, std::vector<float>(10, 0.f));
+  test.Run();
+}
+
 // Theme: Tests involving MatMul(s) interleaved with Transpose(s)
 // for two and three inputs (most common use-case of Einsum operator)
 

--- a/onnxruntime/test/providers/cpu/math/einsum_test.cc
+++ b/onnxruntime/test/providers/cpu/math/einsum_test.cc
@@ -755,18 +755,17 @@ TEST(Einsum, ExplicitEinsumAsTensorContraction_Half) {
   test.Run();
 }
 
-// Theme: Dimensions of size 0
-TEST(Einsum, EinsumZeroDimensionOuterProduct) {
+// Theme: Empty inputs
+TEST(Einsum, EinsumEmptyInputOuterProduct) {
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", "i,j->ij");
   test.AddInput<float>("x", {0}, {});
   test.AddInput<float>("y", {0}, {});
   test.AddOutput<float>("o", {0, 0}, {});
   test.Run();
-  std::cout << "Ending" << std::endl;
 }
 
-TEST(Einsum, EinsumZeroDimensionTranspose) {
+TEST(Einsum, EinsumEmptyInputTranspose) {
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", "ab,ba->ab");
   test.AddInput<float>("x", {0, 1}, {});
@@ -775,7 +774,7 @@ TEST(Einsum, EinsumZeroDimensionTranspose) {
   test.Run();
 }
 
-TEST(Einsum, EinsumZeroDimensionVanish) {
+TEST(Einsum, EinsumEmptyInputVanish) {
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", "ab,ba->a");
   test.AddInput<float>("x", {1, 0}, {});
@@ -784,7 +783,7 @@ TEST(Einsum, EinsumZeroDimensionVanish) {
   test.Run();
 }
 
-TEST(Einsum, EinsumZeroDimensionVanish3d) {
+TEST(Einsum, EinsumEmptyInputVanish3d) {
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", "abc,bad->ad");
   test.AddInput<float>("x", {10, 0, 10}, {});


### PR DESCRIPTION
### Description
Implement a short-circuit to take care of the case of an empty input in `einsum` for the `cpu` provider. 


### Motivation and Context
Currently the `einsum` operator was segmentation faulting whenever it was passed an empty input. All the related test cases are demonstrating this. 


