### PR TITLE
Change docker buildx's driver to default

### DIFF
--- a/tools/ci_build/get_docker_image.py
+++ b/tools/ci_build/get_docker_image.py
@@ -98,7 +98,6 @@ def main():
         )
 
     if use_container_registry:
-        run(args.docker_path, "buildx", "create", "--driver=docker-container", "--name=container_builder")
         run(
             args.docker_path,
             "--log-level",
@@ -109,8 +108,6 @@ def main():
             "--tag",
             full_image_name,
             "--cache-from=type=registry,ref=" + full_image_name,
-            "--builder",
-            "container_builder",
             "--build-arg",
             "BUILDKIT_INLINE_CACHE=1",
             *shlex.split(args.docker_build_args),


### PR DESCRIPTION
### Description
Docker's buildx has four different drivers:
1. default
2. docker-container
3. kubernetes
4. remote 
 
Now we are using "docker-container".  This PR change it to the default driver, because the container driver needs to fetch an image from docker hub which is no longer free and has a rate limit.

### Motivation and Context



