### PR TITLE
Add trace event control for ORT Web performance profiling

### DIFF
--- a/js/common/lib/inference-session-impl.ts
+++ b/js/common/lib/inference-session-impl.ts
@@ -6,7 +6,7 @@ import { InferenceSessionHandler } from './backend.js';
 import { InferenceSession as InferenceSessionInterface } from './inference-session.js';
 import { OnnxValue } from './onnx-value.js';
 import { Tensor } from './tensor.js';
-import { TRACE_FUNC_BEGIN, TRACE_FUNC_END } from './trace.js';
+import { TRACE_FUNC_BEGIN, TRACE_FUNC_END, TRACE_EVENT_BEGIN, TRACE_EVENT_END } from './trace.js';
 
 type SessionOptions = InferenceSessionInterface.SessionOptions;
 type RunOptions = InferenceSessionInterface.RunOptions;
@@ -22,6 +22,7 @@ export class InferenceSession implements InferenceSessionInterface {
   run(feeds: FeedsType, fetches: FetchesType, options?: RunOptions): Promise<ReturnType>;
   async run(feeds: FeedsType, arg1?: FetchesType | RunOptions, arg2?: RunOptions): Promise<ReturnType> {
     TRACE_FUNC_BEGIN();
+    TRACE_EVENT_BEGIN('InferenceSession.run');
     const fetches: { [name: string]: OnnxValue | null } = {};
     let options: RunOptions = {};
     // check inputs
@@ -120,6 +121,7 @@ export class InferenceSession implements InferenceSessionInterface {
         }
       }
     }
+    TRACE_EVENT_END('InferenceSession.run');
     TRACE_FUNC_END();
     return returnValue;
   }
@@ -144,6 +146,7 @@ export class InferenceSession implements InferenceSessionInterface {
     arg3?: SessionOptions,
   ): Promise<InferenceSessionInterface> {
     TRACE_FUNC_BEGIN();
+    TRACE_EVENT_BEGIN('InferenceSession.create');
     // either load from a file or buffer
     let filePathOrUint8Array: string | Uint8Array;
     let options: SessionOptions = {};
@@ -207,6 +210,7 @@ export class InferenceSession implements InferenceSessionInterface {
     // resolve backend, update session options with validated EPs, and create session handler
     const [backend, optionsWithValidatedEPs] = await resolveBackendAndExecutionProviders(options);
     const handler = await backend.createInferenceSessionHandler(filePathOrUint8Array, optionsWithValidatedEPs);
+    TRACE_EVENT_END('InferenceSession.create');
     TRACE_FUNC_END();
     return new InferenceSession(handler);
   }

--- a/js/common/lib/trace.ts
+++ b/js/common/lib/trace.ts
@@ -59,6 +59,7 @@ export const TRACE_EVENT_BEGIN = (extraMsg?: string) => {
   if (typeof env.trace === 'undefined' ? !env.wasm.trace : !env.trace) {
     return;
   }
+  // eslint-disable-next-line no-console
   console.time(`ORT::${extraMsg}`);
 };
 
@@ -69,5 +70,6 @@ export const TRACE_EVENT_END = (extraMsg?: string) => {
   if (typeof env.trace === 'undefined' ? !env.wasm.trace : !env.trace) {
     return;
   }
+  // eslint-disable-next-line no-console
   console.timeEnd(`ORT::${extraMsg}`);
 };

--- a/js/common/lib/trace.ts
+++ b/js/common/lib/trace.ts
@@ -51,3 +51,23 @@ export const TRACE_FUNC_END = (extraMsg?: string) => {
   }
   TRACE_FUNC('END', extraMsg);
 };
+
+/**
+ * @ignore
+ */
+export const TRACE_EVENT_BEGIN = (extraMsg?: string) => {
+  if (typeof env.trace === 'undefined' ? !env.wasm.trace : !env.trace) {
+    return;
+  }
+  console.time(`ORT::${extraMsg}`);
+};
+
+/**
+ * @ignore
+ */
+export const TRACE_EVENT_END = (extraMsg?: string) => {
+  if (typeof env.trace === 'undefined' ? !env.wasm.trace : !env.trace) {
+    return;
+  }
+  console.timeEnd(`ORT::${extraMsg}`);
+};

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "js",
       "license": "MIT",
       "devDependencies": {
         "@types/fs-extra": "^11.0.4",

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "js",
       "license": "MIT",
       "devDependencies": {
         "@types/fs-extra": "^11.0.4",

--- a/js/web/lib/wasm/jsep/init.ts
+++ b/js/web/lib/wasm/jsep/init.ts
@@ -291,6 +291,8 @@ export const init = async (
       },
       // jsepDownloadTensor
       async (tensorId: number, dstBuffer: ArrayBufferView | ArrayBuffer) => backend.downloadTensor(tensorId, dstBuffer),
+      // jsepEnableTraceEvent
+      env.trace,
     ]);
   }
 };

--- a/js/web/lib/wasm/jsep/init.ts
+++ b/js/web/lib/wasm/jsep/init.ts
@@ -292,7 +292,7 @@ export const init = async (
       // jsepDownloadTensor
       async (tensorId: number, dstBuffer: ArrayBufferView | ArrayBuffer) => backend.downloadTensor(tensorId, dstBuffer),
       // jsepEnableTraceEvent
-      env.trace,
+      !!env.trace,
     ]);
   }
 };

--- a/js/web/lib/wasm/wasm-core-impl.ts
+++ b/js/web/lib/wasm/wasm-core-impl.ts
@@ -713,7 +713,7 @@ export const run = async (
   try {
     [runOptionsHandle, runOptionsAllocs] = setRunOptions(options);
 
-    TRACE_EVENT_BEGIN("wasm prepareInputOutputTensor");
+    TRACE_EVENT_BEGIN('wasm prepareInputOutputTensor');
     // create input tensors
     for (let i = 0; i < inputCount; i++) {
       await prepareInputOutputTensor(
@@ -739,7 +739,7 @@ export const run = async (
         enableGraphCapture,
       );
     }
-    TRACE_EVENT_END("wasm prepareInputOutputTensor");
+    TRACE_EVENT_END('wasm prepareInputOutputTensor');
 
     for (let i = 0; i < inputCount; i++) {
       wasm.setValue(inputValuesOffset + i * ptrSize, inputTensorHandles[i], '*');
@@ -759,7 +759,7 @@ export const run = async (
         );
       }
 
-      TRACE_EVENT_BEGIN("wasm bindInputsOutputs");
+      TRACE_EVENT_BEGIN('wasm bindInputsOutputs');
       // process inputs
       for (let i = 0; i < inputCount; i++) {
         const index = inputIndices[i];
@@ -793,7 +793,7 @@ export const run = async (
           }
         }
       }
-      TRACE_EVENT_END("wasm bindInputsOutputs");
+      TRACE_EVENT_END('wasm bindInputsOutputs');
       activeSessions.set(sessionId, [
         sessionHandle,
         inputNamesUTF8Encoded,
@@ -836,7 +836,7 @@ export const run = async (
     const output: TensorMetadata[] = [];
     const outputPromises: Array<Promise<[number, Tensor.DataType]>> = [];
 
-    TRACE_EVENT_BEGIN("wasm ProcessOutputTensor");
+    TRACE_EVENT_BEGIN('wasm ProcessOutputTensor');
     for (let i = 0; i < outputCount; i++) {
       const tensor = Number(wasm.getValue(outputValuesOffset + i * ptrSize, '*'));
       if (tensor === outputTensorHandles[i]) {
@@ -1035,7 +1035,7 @@ export const run = async (
     for (const [index, data] of await Promise.all(outputPromises)) {
       output[index][2] = data;
     }
-    TRACE_EVENT_END("wasm ProcessOutputTensor");
+    TRACE_EVENT_END('wasm ProcessOutputTensor');
     return output;
   } finally {
     wasm.webnnOnRunEnd?.(sessionHandle);

--- a/js/web/lib/wasm/wasm-core-impl.ts
+++ b/js/web/lib/wasm/wasm-core-impl.ts
@@ -114,8 +114,6 @@ export const initEp = async (env: Env, epName: string): Promise<void> => {
   if (!BUILD_DEFS.DISABLE_JSEP) {
     // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
     const initJsep = require('./jsep/init').init;
-    const wasm = getInstance();
-    wasm.traceEvent = env.trace;
 
     if (epName === 'webgpu' && !BUILD_DEFS.USE_WEBGPU_EP) {
       // perform WebGPU availability check

--- a/js/web/lib/wasm/wasm-types.ts
+++ b/js/web/lib/wasm/wasm-types.ts
@@ -39,7 +39,6 @@ export declare namespace JSEP {
   ) => Promise<MLTensor>;
   type UploadTensorFunction = (tensorId: number, data: Uint8Array) => void;
   type DownloadTensorFunction = (tensorId: number, dstBuffer: ArrayBufferView | ArrayBuffer) => Promise<undefined>;
-  type EnableTraceEvent = unknown;
 
   export interface Module extends WebGpuModule, WebNnModule {
     /**

--- a/js/web/lib/wasm/wasm-types.ts
+++ b/js/web/lib/wasm/wasm-types.ts
@@ -71,7 +71,7 @@ export declare namespace JSEP {
         ensureTensor: EnsureTensorFunction,
         uploadTensor: UploadTensorFunction,
         downloadTensor: DownloadTensorFunction,
-	enableTraceEvent: boolean,
+        enableTraceEvent: boolean,
       ],
     ): void;
   }

--- a/js/web/lib/wasm/wasm-types.ts
+++ b/js/web/lib/wasm/wasm-types.ts
@@ -71,6 +71,7 @@ export declare namespace JSEP {
         ensureTensor: EnsureTensorFunction,
         uploadTensor: UploadTensorFunction,
         downloadTensor: DownloadTensorFunction,
+	enableTraceEvent: boolean,
       ],
     ): void;
   }

--- a/js/web/lib/wasm/wasm-types.ts
+++ b/js/web/lib/wasm/wasm-types.ts
@@ -39,6 +39,7 @@ export declare namespace JSEP {
   ) => Promise<MLTensor>;
   type UploadTensorFunction = (tensorId: number, data: Uint8Array) => void;
   type DownloadTensorFunction = (tensorId: number, dstBuffer: ArrayBufferView | ArrayBuffer) => Promise<undefined>;
+  type EnableTraceEvent = unknown;
 
   export interface Module extends WebGpuModule, WebNnModule {
     /**

--- a/onnxruntime/core/providers/webnn/builders/model.cc
+++ b/onnxruntime/core/providers/webnn/builders/model.cc
@@ -158,6 +158,11 @@ onnxruntime::common::Status Model::Dispatch(const InlinedHashMap<std::string, On
                                             const InlinedHashMap<std::string, OnnxTensorData>& outputs) {
   auto webnnEnsureTensor = emscripten::val::module_property("webnnEnsureTensor");
   auto promises = emscripten::val::array();
+  bool trace = emscripten::val::module_property("traceEvent").as<bool>();
+  emscripten::val console = emscripten::val::global("console");
+  if (trace) {
+    console.call<void>("time", emscripten::val("ORT::Dispatch::jsepEnsureTensor"));
+  }
   for (const auto& [_, tensor] : inputs) {
     emscripten::val shape = emscripten::val::array();
     for (const auto& dim : tensor.tensor_info.shape) {
@@ -175,6 +180,9 @@ onnxruntime::common::Status Model::Dispatch(const InlinedHashMap<std::string, On
     }
     auto ml_tensor = webnnEnsureTensor(emscripten::val::undefined(), reinterpret_cast<intptr_t>(tensor.buffer), tensor.tensor_info.data_type, shape, false);
     promises.call<void>("push", ml_tensor);
+  }
+  if (trace) {
+    console.call<void>("timeEnd", emscripten::val("ORT::Dispatch::jsepEnsureTensor"));
   }
   auto ml_tensors = emscripten::val::global("Promise").call<emscripten::val>("all", promises).await();
   for (const auto& [name, _] : inputs) {

--- a/onnxruntime/core/providers/webnn/builders/model.cc
+++ b/onnxruntime/core/providers/webnn/builders/model.cc
@@ -158,7 +158,7 @@ onnxruntime::common::Status Model::Dispatch(const InlinedHashMap<std::string, On
                                             const InlinedHashMap<std::string, OnnxTensorData>& outputs) {
   auto webnnEnsureTensor = emscripten::val::module_property("webnnEnsureTensor");
   auto promises = emscripten::val::array();
-  bool trace = emscripten::val::module_property("traceEvent").as<bool>();
+  bool trace = emscripten::val::module_property("webnnEnableTraceEvent").as<bool>();
   emscripten::val console = emscripten::val::global("console");
   if (trace) {
     console.call<void>("time", emscripten::val("ORT::Dispatch::jsepEnsureTensor"));

--- a/onnxruntime/core/providers/webnn/data_transfer.cc
+++ b/onnxruntime/core/providers/webnn/data_transfer.cc
@@ -20,6 +20,11 @@ common::Status DataTransfer::CopyTensor(const Tensor& src, Tensor& dst) const {
     // We don't need to transfer the tensor to an MLTensor, so we don't need to copy the data.
     return Status::OK();
   }
+  bool trace = emscripten::val::module_property("traceEvent").as<bool>();
+  emscripten::val console = emscripten::val::global("console");
+  if (trace) {
+    console.call<void>("time", emscripten::val("ORT::DataTransfer::CopyTensor"));
+  }
 
   size_t bytes = src.SizeInBytes();
   if (bytes > 0) {
@@ -30,12 +35,19 @@ common::Status DataTransfer::CopyTensor(const Tensor& src, Tensor& dst) const {
 
     if (dst_device.Type() == OrtDevice::GPU) {
       EM_ASM({ Module.webnnUploadTensor($0, HEAPU8.subarray($1, $1 + $2)); }, dst_data, reinterpret_cast<intptr_t>(src_data), bytes);
+      if (trace) {
+        console.call<void>("timeEnd", emscripten::val("ORT::DataTransfer::webnnUploadTensor"));
+      }
     } else {
       auto webnnDownloadTensor = emscripten::val::module_property("webnnDownloadTensor");
       auto subarray = emscripten::typed_memory_view(bytes, static_cast<char*>(dst_data));
       webnnDownloadTensor(reinterpret_cast<intptr_t>(src_data), subarray).await();
+      if (trace) {
+        console.call<void>("timeEnd", emscripten::val("ORT::DataTransfer::webnnDownloadTensor"));
+      }
     }
   }
+
 
   return Status::OK();
 }

--- a/onnxruntime/core/providers/webnn/data_transfer.cc
+++ b/onnxruntime/core/providers/webnn/data_transfer.cc
@@ -48,7 +48,6 @@ common::Status DataTransfer::CopyTensor(const Tensor& src, Tensor& dst) const {
     }
   }
 
-
   return Status::OK();
 }
 

--- a/onnxruntime/core/providers/webnn/data_transfer.cc
+++ b/onnxruntime/core/providers/webnn/data_transfer.cc
@@ -20,7 +20,7 @@ common::Status DataTransfer::CopyTensor(const Tensor& src, Tensor& dst) const {
     // We don't need to transfer the tensor to an MLTensor, so we don't need to copy the data.
     return Status::OK();
   }
-  bool trace = emscripten::val::module_property("traceEvent").as<bool>();
+  bool trace = emscripten::val::module_property("webnnEnableTraceEvent").as<bool>();
   emscripten::val console = emscripten::val::global("console");
   if (trace) {
     console.call<void>("time", emscripten::val("ORT::DataTransfer::CopyTensor"));

--- a/onnxruntime/wasm/pre-jsep.js
+++ b/onnxruntime/wasm/pre-jsep.js
@@ -104,6 +104,7 @@ Module["jsepInit"] = (name, params) => {
       Module["webnnEnsureTensor"],
       Module.webnnUploadTensor,
       Module["webnnDownloadTensor"],
+      Module["webnnEnableTraceEvent"],
     ] = params.slice(1);
 
     // This function is called from both JS and an EM_ASM block, it needs both a minifiable name and an explicit name.


### PR DESCRIPTION
### Description
Add trace event control to better profile ORT web performance 



### Motivation and Context
ORT Web's current tracing implementation lacks interfaces for performance profiling using about://tracing. This PR introduces these interfaces, enabling performance bottleneck identification in ORT Web and adding several trace events for WebNN.


