### PR TITLE
Fix type cast build error

### DIFF
--- a/onnxruntime/core/framework/debug_node_inputs_outputs_utils.cc
+++ b/onnxruntime/core/framework/debug_node_inputs_outputs_utils.cc
@@ -8,7 +8,10 @@
 #include "core/framework/print_tensor_statistics_utils.h"
 #include <iomanip>
 #include <cctype>
+#include <vector>
 #include <string>
+#include <algorithm>
+#include <utility>
 
 #ifdef DEBUG_NODE_INPUTS_OUTPUTS_ENABLE_DUMP_TO_SQLDB
 #include <sqlite3.h>

--- a/onnxruntime/core/framework/debug_node_inputs_outputs_utils.h
+++ b/onnxruntime/core/framework/debug_node_inputs_outputs_utils.h
@@ -20,6 +20,7 @@
 #include "core/framework/session_state.h"
 #include "core/graph/graph.h"
 #include <unordered_set>
+#include <unordered_map>
 #include <mutex>
 #include <string>
 

--- a/onnxruntime/core/framework/print_tensor_statistics_utils.h
+++ b/onnxruntime/core/framework/print_tensor_statistics_utils.h
@@ -89,8 +89,8 @@ void PrintCommonStats(const T* data, size_t count, TensorStatisticsData& tensor_
   // Statistics for float and double only for now.
   if constexpr (std::is_same<T, float>::value) {
     tensor_statistics.is_float = true;
-    tensor_statistics.float_min = static_cast<double>(min);
-    tensor_statistics.float_max = static_cast<double>(max);
+    tensor_statistics.float_min = static_cast<float>(min);
+    tensor_statistics.float_max = static_cast<float>(max);
   }
 }
 


### PR DESCRIPTION
### Description

- Fix a type cast in https://github.com/microsoft/onnxruntime/pull/23363.
- Include some headers which are suggested by code scanning in that PR.

### Motivation and Context

PostMerge has build error:
```
onnxruntime\core\framework\print_tensor_statistics_utils.h(92,55): error C2220: the following warning is treated as an error [D:\a\_work\1\b\Debug\onnxruntime_framework.vcxproj]
```



