### PR TITLE
[TensorRT] Fix perf issue for DDS nodes run by TRT 10

### DIFF
--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -2481,7 +2481,7 @@ TensorrtExecutionProvider::GetCapability(const GraphViewer& graph,
   std::vector<size_t> nodes_vector(number_of_ort_nodes);
   std::iota(std::begin(nodes_vector), std::end(nodes_vector), 0);
 
-  std::set<std::string> exclude_ops_set; // currently not support to exclude ops
+  std::set<std::string> exclude_ops_set;  // currently not support to exclude ops
 
   /*
    * There is a known performance issue with the DDS ops (NonMaxSuppression, NonZero and RoiAlign) when running TRT EP with TRT 10.
@@ -2668,10 +2668,10 @@ TensorrtExecutionProvider::GetCapability(const GraphViewer& graph,
     }
   }
 
-  #if NV_TENSORRT_MAJOR >= 10
+#if NV_TENSORRT_MAJOR >= 10
   // TRT EP will take appropriate actions later to prevent performance degradation if the graph has DDS op that run by TRT 10.
   is_dds_op_in_graph_ = IsDDSOpInSubGraph(graph, result, dds_op_set_);
-  #endif
+#endif
 
   const size_t number_of_subgraphs = supported_nodes_vector.size();
   if (number_of_trt_nodes == 0) {
@@ -2773,8 +2773,7 @@ common::Status TensorrtExecutionProvider::RefitEngine(std::string onnx_model_fil
 
 common::Status TensorrtExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& fused_nodes_and_graphs,
                                                   std::vector<NodeComputeInfo>& node_compute_funcs) {
-  
- #if NV_TENSORRT_MAJOR >= 10
+#if NV_TENSORRT_MAJOR >= 10
   // There is a known performance issue with the DDS ops (NonMaxSuppression, NonZero and RoiAlign) when running TRT EP with TRT 10.
   // The issue arises because when cudaStreamSynchronize is called after inference, GPU memory is released back to the OS.
   // As a result, for the next inference run, TRT reallocates GPU memory from the OS, introducing overhead and leading to performance degradation.
@@ -2784,7 +2783,7 @@ common::Status TensorrtExecutionProvider::Compile(const std::vector<FusedNodeAnd
     runtime_->setGpuAllocator(trt_gpu_allocator_.get());
   }
 #endif
-    
+
   for (auto& fused_node_graph : fused_nodes_and_graphs) {
     const GraphViewer& graph_body_viewer = fused_node_graph.filtered_graph;
     const Node& fused_node = fused_node_graph.fused_node;

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -1723,6 +1723,8 @@ TensorrtExecutionProvider::TensorrtExecutionProvider(const TensorrtExecutionProv
   {
     auto lock = GetApiLock();
     runtime_ = std::unique_ptr<nvinfer1::IRuntime>(nvinfer1::createInferRuntime(GetTensorrtLogger(detailed_build_log_)));
+    trt_gpu_allocator_ = std::unique_ptr<PoolAllocator>();
+    runtime_->setGpuAllocator(trt_gpu_allocator_.get());
   }
 
   trt_version_ = getInferLibVersion();

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
@@ -638,5 +638,12 @@ class TensorrtExecutionProvider : public IExecutionProvider {
    * This function only creates the instance at the first time it's being called."
    */
   nvinfer1::IBuilder* GetBuilder(TensorrtLogger& trt_logger) const;
+
+  /**
+   * Check if DDS op is in the ComputeCapability/subgraph.
+   */ 
+  bool IsDDSOpInSubGraph(const GraphViewer& graph,
+                         std::vector<std::unique_ptr<ComputeCapability>>& compute_capabilities,
+                         std::unordered_set<std::string>& dds_op_set) const;
 };
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
@@ -136,12 +136,20 @@ class PoolAllocator : public nvinfer1::IGpuAsyncAllocator {
     cudaMemPoolSetAttribute(mPool, cudaMemPoolAttrReleaseThreshold, &maxThreshold);
   }
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4100)
+#endif
   void* allocateAsync(uint64_t const size, uint64_t const alignment, nvinfer1::AllocatorFlags const flags,
                       cudaStream_t stream) noexcept override {
     void* memory{nullptr};
     cudaMallocFromPoolAsync(&memory, size, mPool, stream);
     return memory;
   }
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
   bool deallocateAsync(void* const memory, cudaStream_t stream) noexcept override {
     cudaFreeAsync(memory, stream);
     return true;

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
@@ -641,7 +641,7 @@ class TensorrtExecutionProvider : public IExecutionProvider {
 
   /**
    * Check if DDS op is in the ComputeCapability/subgraph.
-   */ 
+   */
   bool IsDDSOpInSubGraph(const GraphViewer& graph,
                          std::vector<std::unique_ptr<ComputeCapability>>& compute_capabilities,
                          std::unordered_set<std::string>& dds_op_set) const;

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_helper.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_helper.cc
@@ -261,13 +261,13 @@ void TensorrtExecutionProvider::SetAllGraphInputs(Graph& graph) const {
 
 // Check if DDS op is in the ComputeCapability/subgraph.
 bool TensorrtExecutionProvider::IsDDSOpInSubGraph(const GraphViewer& graph,
-                       std::vector<std::unique_ptr<ComputeCapability>>& compute_capabilities,
-                       std::unordered_set<std::string>& dds_op_set) const {
+                                                  std::vector<std::unique_ptr<ComputeCapability>>& compute_capabilities,
+                                                  std::unordered_set<std::string>& dds_op_set) const {
   auto is_dds_op = [&](const auto& node) {
     if (dds_op_set.find(node->OpType()) != dds_op_set.end()) return true;
     return false;
   };
-    
+
   for (auto& compute_capability : compute_capabilities) {
     auto& indexed_sub_graph = compute_capability->SubGraph();
     for (auto i : indexed_sub_graph->Nodes()) {

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_helper.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_helper.cc
@@ -258,4 +258,22 @@ void TensorrtExecutionProvider::SetAllGraphInputs(Graph& graph) const {
 
   graph.SetInputs(graph_inputs_including_initializers);
 }
+
+// Check if DDS op is in the ComputeCapability/subgraph.
+bool TensorrtExecutionProvider::IsDDSOpInSubGraph(const GraphViewer& graph,
+                       std::vector<std::unique_ptr<ComputeCapability>>& compute_capabilities,
+                       std::unordered_set<std::string>& dds_op_set) const {
+  auto is_dds_op = [&](const auto& node) {
+    if (dds_op_set.find(node->OpType()) != dds_op_set.end()) return true;
+    return false;
+  };
+    
+  for (auto& compute_capability : compute_capabilities) {
+    auto& indexed_sub_graph = compute_capability->SubGraph();
+    for (auto i : indexed_sub_graph->Nodes()) {
+      if (is_dds_op(graph.GetNode(i))) return true;
+    }
+  }
+  return false;
+}
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/object_detection/non_max_suppression_test.cc
+++ b/onnxruntime/test/providers/cpu/object_detection/non_max_suppression_test.cc
@@ -63,13 +63,23 @@ TEST(NonMaxSuppressionOpTest, TwoClasses) {
   test.AddInput<int64_t>("max_output_boxes_per_class", {}, {6L});
   test.AddInput<float>("iou_threshold", {}, {0.5f});
   test.AddInput<float>("score_threshold", {}, {0.0f});
+
+// The selected_indices in ORT is sorted by class, whereas in TRT the selected_indices is sorted by score,
+// So it needs to sort the output to pass the output check when there is more than one class using TRT EP.
+#ifdef USE_TENSORRT
+  bool sort_output = true;
+#else
+  bool sort_output = false;  // default
+#endif
+
   test.AddOutput<int64_t>("selected_indices", {6, 3},
                           {0L, 0L, 3L,
                            0L, 0L, 0L,
                            0L, 0L, 5L,
                            0L, 1L, 3L,
                            0L, 1L, 0L,
-                           0L, 1L, 5L});
+                           0L, 1L, 5L},
+                          sort_output);
   test.Run();
 }
 
@@ -125,6 +135,15 @@ TEST(NonMaxSuppressionOpTest, TwoBatches_TwoClasses) {
                         0.1f, 0.2f, 0.6f, 0.3f, 0.9f});
   test.AddInput<int64_t>("max_output_boxes_per_class", {}, {2L});
   test.AddInput<float>("iou_threshold", {}, {0.8f});
+
+// The selected_indices in ORT is sorted by class, whereas in TRT the selected_indices is sorted by score,
+// So it needs to sort the output to pass the output check when there is more than one class using TRT EP.
+#ifdef USE_TENSORRT
+  bool sort_output = true;
+#else
+  bool sort_output = false;  // default
+#endif
+
   test.AddOutput<int64_t>("selected_indices", {8, 3},
                           {0L, 0L, 4L,
                            0L, 0L, 2L,
@@ -134,7 +153,8 @@ TEST(NonMaxSuppressionOpTest, TwoBatches_TwoClasses) {
                            1L, 0L, 4L,
                            1L, 0L, 1L,
                            1L, 1L, 4L,
-                           1L, 1L, 1L});
+                           1L, 1L, 1L},
+                          sort_output);
   test.Run();
 }
 


### PR DESCRIPTION
There is a known performance issue with the DDS ops (NonMaxSuppression, NonZero and RoiAlign) when running TRT EP with TRT 10. The issue arises because when cudaStreamSynchronize is called after inference, GPU memory is released back to the OS. As a result, for the next inference run, TRT reallocates GPU memory again from the OS, introducing overhead and leading to performance degradation.
The solution is to increase the memory pool threshold, allowing TRT to retain the allocated memory and reduce this overhead.


