### PR TITLE
Fix eigen external deps

### DIFF
--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -522,12 +522,7 @@ if(TARGET ONNX::onnx_proto AND NOT TARGET onnx_proto)
   add_library(onnx_proto ALIAS ONNX::onnx_proto)
 endif()
 
-find_package(Eigen3 CONFIG)
-if(Eigen3_FOUND)
-  get_target_property(eigen_INCLUDE_DIRS Eigen3::Eigen INTERFACE_INCLUDE_DIRECTORIES)
-else()
-  include(eigen) # FetchContent
-endif()
+include(external/eigen.cmake)
 
 if(onnxruntime_USE_VCPKG)
   find_package(wil CONFIG REQUIRED)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

I think we should not use the eigen in the system directly, but should first use the eigen specified in deps.txt. in ubuntu22.04, ORT fails to compile when I install libeigen3-dev (which ROS2 humble depends on). The error message is below:

```
[ 62%] Built target onnxruntime_lora
[ 62%] Building CXX object CMakeFiles/onnxruntime_session.dir/home/junchao/work/plugin/ai/onnxruntime/onnxruntime/core/session/IOBinding.cc.o
/home/junchao/work/plugin/ai/onnxruntime/onnxruntime/core/providers/cpu/math/element_wise_ops.cc: In member function ‘onnxruntime::common::Status onnxruntime::Min_6<T>::Compute(onnxruntime::OpKernelContext*) const [with T = float]’:
/home/junchao/work/plugin/ai/onnxruntime/onnxruntime/core/providers/cpu/math/element_wise_ops.cc:750:56: error: no matching function for call to ‘Eigen::ArrayWrapper<Eigen::Map<Eigen::Matrix<float, -1, 1>, 0, Eigen::Stride<0, 0> > >::min<Eigen::PropagateNaN>(Eigen::ArrayWrapper<Eigen::Map<const Eigen::Matrix<float, -1, 1>, 0, Eigen::Stride<0, 0> > >)’
  750 |     min = min.array().template min<Eigen::PropagateNaN>(EigenMap<float>(data_n).array());
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/eigen3/Eigen/Core:19,
                 from /home/junchao/work/plugin/ai/onnxruntime/onnxruntime/core/util/math_cpuonly.h:68,
                 from /home/junchao/work/plugin/ai/onnxruntime/onnxruntime/core/providers/cpu/math/element_wise_ops.h:10,
                 from /home/junchao/work/plugin/ai/onnxruntime/onnxruntime/core/providers/cpu/math/element_wise_ops.cc:4:
/usr/include/eigen3/Eigen/src/Core/../plugins/ArrayCwiseBinaryOps.h:33:28: note: candidate: ‘template<class OtherDerived> const Eigen::CwiseBinaryOp<Eigen::internal::scalar_min_op<typename Eigen::internal::traits<T>::Scalar, typename Eigen::internal::traits<OtherDerived>::Scalar>, const Derived, const OtherDerived> Eigen::ArrayBase<Derived>::min(const Eigen::ArrayBase<OtherDerived>&) const [with OtherDerived = OtherDerived; Derived = Eigen::ArrayWrapper<Eigen::Map<Eigen::Matrix<float, -1, 1>, 0, Eigen::Stride<0, 0> > >]’
   33 | EIGEN_MAKE_CWISE_BINARY_OP(min,min)
      |                            ^~~
/usr/include/eigen3/Eigen/src/Core/util/Macros.h:1339:4: note: in definition of macro ‘EIGEN_MAKE_CWISE_BINARY_OP’
 1339 |   (METHOD)(const EIGEN_CURRENT_STORAGE_BASE_CLASS<OtherDerived> &other) const \
      |    ^~~~~~
/usr/include/eigen3/Eigen/src/Core/../plugins/ArrayCwiseBinaryOps.h:33:28: note:   template argument deduction/substitution failed:
   33 | EIGEN_MAKE_CWISE_BINARY_OP(min,min)
      |                            ^~~
/usr/include/eigen3/Eigen/src/Core/util/Macros.h:1339:4: note: in definition of macro ‘EIGEN_MAKE_CWISE_BINARY_OP’
 1339 |   (METHOD)(const EIGEN_CURRENT_STORAGE_BASE_CLASS<OtherDerived> &other) const \
      |    ^~~~~~
/home/junchao/work/plugin/ai/onnxruntime/onnxruntime/core/providers/cpu/math/element_wise_ops.cc:750:56: error: type/value mismatch at argument 1 in template parameter list for ‘template<class OtherDerived> const Eigen::CwiseBinaryOp<Eigen::internal::scalar_min_op<typename Eigen::internal::traits<T>::Scalar, typename Eigen::internal::traits<OtherDerived>::Scalar>, const Derived, const OtherDerived> Eigen::ArrayBase<Derived>::min(const Eigen::ArrayBase<OtherDerived>&) const [with OtherDerived = OtherDerived; Derived = Eigen::ArrayWrapper<Eigen::Map<Eigen::Matrix<float, -1, 1>, 0, Eigen::Stride<0, 0> > >]’
  750 |     min = min.array().template min<Eigen::PropagateNaN>(EigenMap<float>(data_n).array());
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/junchao/work/plugin/ai/onnxruntime/onnxruntime/core/providers/cpu/math/element_wise_ops.cc:750:56: note:   expected a type, got ‘Eigen::PropagateNaN’
/home/junchao/work/plugin/ai/onnxruntime/onnxruntime/core/providers/cpu/math/element_wise_ops.cc: In lambda function:
/home/junchao/work/plugin/ai/onnxruntime/onnxruntime/core/providers/cpu/math/element_wise_ops.cc:802:77: error: no matching function for call to ‘Eigen::Map<const Eigen::Array<Eigen::half, -1, 1, 0, -1, 1>, 0, Eigen::Stride<0, 0> >::min<Eigen::PropagateNaN>(Eigen::half)’
  802 |           output_vec_map = input_1_vec_map.template min<Eigen::PropagateNaN>(
      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
  803 |               static_cast<Eigen::half>(per_iter_bh.ScalarInput0<MLFloat16>()));
      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/eigen3/Eigen/Core:19,
                 from /home/junchao/work/plugin/ai/onnxruntime/onnxruntime/core/util/math_cpuonly.h:68,
                 from /home/junchao/work/plugin/ai/onnxruntime/onnxruntime/core/providers/cpu/math/element_wise_ops.h:10,
                 from /home/junchao/work/plugin/ai/onnxruntime/onnxruntime/core/providers/cpu/math/element_wise_ops.cc:4:
/usr/include/eigen3/Eigen/src/Core/../plugins/ArrayCwiseBinaryOps.h:33:28: note: candidate: ‘template<class OtherDerived> const Eigen::CwiseBinaryOp<Eigen::internal::scalar_min_op<typename Eigen::internal::traits<T>::Scalar, typename Eigen::internal::traits<OtherDerived>::Scalar>, const Derived, const OtherDerived> Eigen::ArrayBase<Derived>::min(const Eigen::ArrayBase<OtherDerived>&) const [with OtherDerived = OtherDerived; Derived = Eigen::Map<const Eigen::Array<Eigen::half, -1, 1, 0, -1, 1>, 0, Eigen::Stride<0, 0> >]’
   33 | EIGEN_MAKE_CWISE_BINARY_OP(min,min)
      |                            ^~~
/usr/include/eigen3/Eigen/src/Core/util/Macros.h:1339:4: note: in definition of macro ‘EIGEN_MAKE_CWISE_BINARY_OP’
 1339 |   (METHOD)(const EIGEN_CURRENT_STORAGE_BASE_CLASS<OtherDerived> &other) const \
      |    ^~~~~~
/usr/include/eigen3/Eigen/src/Core/../plugins/ArrayCwiseBinaryOps.h:33:28: note:   template argument deduction/substitution failed:
   33 | EIGEN_MAKE_CWISE_BINARY_OP(min,min)
      |                            ^~~
/usr/include/eigen3/Eigen/src/Core/util/Macros.h:1339:4: note: in definition of macro ‘EIGEN_MAKE_CWISE_BINARY_OP’
 1339 |   (METHOD)(const EIGEN_CURRENT_STORAGE_BASE_CLASS<OtherDerived> &other) const \
      |    ^~~~~~
/home/junchao/work/plugin/ai/onnxruntime/onnxruntime/core/providers/cpu/math/element_wise_ops.cc:802:77: error: type/value mismatch at argument 1 in template parameter list for ‘template<class OtherDerived> const Eigen::CwiseBinaryOp<Eigen::internal::scalar_min_op<typename Eigen::internal::traits<T>::Scalar, typename Eigen::internal::traits<OtherDerived>::Scalar>, const Derived, const OtherDerived> Eigen::ArrayBase<Derived>::min(const Eigen::ArrayBase<OtherDerived>&) const [with OtherDerived = OtherDerived; Derived = Eigen::Map<const Eigen::Array<Eigen::half, -1, 1, 0, -1, 1>, 0, Eigen::Stride<0, 0> >]’
  802 |           output_vec_map = input_1_vec_map.template min<Eigen::PropagateNaN>(
      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
  803 |               static_cast<Eigen::half>(per_iter_bh.ScalarInput0<MLFloat16>()));
      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/junchao/work/plugin/ai/onnxruntime/onnxruntime/core/providers/cpu/math/element_wise_ops.cc:802:77: note:   expected a type, got ‘Eigen::PropagateNaN’
/home/junchao/work/plugin/ai/onnxruntime/onnxruntime/core/providers/cpu/math/element_wise_ops.cc:805:77: error: no matching function for call to ‘Eigen::Map<const Eigen::Array<Eigen::half, -1, 1, 0, -1, 1>, 0, Eigen::Stride<0, 0> >::max<Eigen::PropagateNaN>(Eigen::half)’
  805 |           output_vec_map = input_1_vec_map.template max<Eigen::PropagateNaN>(
      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
  806 |               static_cast<Eigen::half>(per_iter_bh.ScalarInput0<MLFloat16>()));
      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix #23407

@lixing-star
