### PR TITLE
Fixing typo in finetune.md application example

### DIFF
--- a/docs/genai/tutorials/finetune.md
+++ b/docs/genai/tutorials/finetune.md
@@ -156,7 +156,7 @@ else:
 ## Call the application
 
 ```bash
-python app.py -m <model folder> -a <.onnx_adapter files> -t <prompt template> -s <systemm prompt> -p <prompt>
+python app.py -m <model folder> -a <.onnx_adapter files> -t <prompt template> -s <system prompt> -p <prompt>
 ```
 
 ## References


### PR DESCRIPTION
### Description
Just saw that there were 2ms in system prompt at the end of the example and fixed that.



### Motivation and Context
Improves the docs



