### PR TITLE
Suppress some strict-aliasing related warnings in WebGPU EP

### DIFF
--- a/onnxruntime/core/providers/webgpu/generator/range.cc
+++ b/onnxruntime/core/providers/webgpu/generator/range.cc
@@ -25,6 +25,11 @@ Status Range<T>::ComputeInternal(ComputeContext& context) const {
 
   uint32_t output_size = gsl::narrow<uint32_t>(n);
   RangeProgram program{};
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif
+
   program.AddOutput({output_tensor, ProgramTensorMetadataDependency::Type})
       .SetDispatchGroupSize((output_size + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE)
       .AddUniformVariables({
@@ -32,6 +37,10 @@ Status Range<T>::ComputeInternal(ComputeContext& context) const {
           *reinterpret_cast<uint32_t*>(&start),
           *reinterpret_cast<uint32_t*>(&delta),
       });
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
   return context.RunProgram(program);
 }

--- a/onnxruntime/core/providers/webgpu/math/unary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/webgpu/math/unary_elementwise_ops.cc
@@ -194,6 +194,10 @@ class Clip final : public UnaryElementwise {
                          "Clip",
                          std::is_same_v<T, MLFloat16> ? ClipF16Impl : ClipImpl,
                          "", ShaderUsage::UseElementTypeAlias} {}
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif
 
   Status ConfigureProgram(const ComputeContext& context, UnaryElementwiseProgram& program) const override {
     const auto* clip_min_tensor = context.Input<Tensor>(1);
@@ -214,6 +218,9 @@ class Clip final : public UnaryElementwise {
     }
     return Status::OK();
   }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
   // uniforms.attr is a f32 value. It is encoded as a float for 2 f16 values.
   // bitcast<vec2<f16>>(uniforms.attr)[0] is clip_min, bitcast<vec2<f16>>(uniforms.attr)[1] is clip_max

--- a/onnxruntime/core/providers/webgpu/program.h
+++ b/onnxruntime/core/providers/webgpu/program.h
@@ -150,6 +150,11 @@ enum class ProgramTensorMetadataDependency : int {
 };
 std::ostream& operator<<(std::ostream& os, ProgramTensorMetadataDependency);
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif
+
 inline ProgramTensorMetadataDependency operator|(ProgramTensorMetadataDependency a, ProgramTensorMetadataDependency b) {
   return (ProgramTensorMetadataDependency)((int&)a | (int&)b);
 }
@@ -162,6 +167,10 @@ inline ProgramTensorMetadataDependency& operator|=(ProgramTensorMetadataDependen
 inline ProgramTensorMetadataDependency& operator&=(ProgramTensorMetadataDependency& a, ProgramTensorMetadataDependency b) {
   return (ProgramTensorMetadataDependency&)((int&)a &= (int&)b);
 }
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 constexpr SafeInt<uint32_t> WORKGROUP_SIZE = 64;
 

--- a/onnxruntime/core/providers/webgpu/shader_variable.h
+++ b/onnxruntime/core/providers/webgpu/shader_variable.h
@@ -189,6 +189,10 @@ class ShaderVariableHelper : public ShaderIndicesHelper {
 
   friend class ShaderHelper;
 };
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif
 
 inline ShaderUsage operator|(ShaderUsage a, ShaderUsage b) {
   return (uint32_t)a.usage | (uint32_t)b.usage;
@@ -204,6 +208,10 @@ inline ShaderUsage& operator&=(ShaderUsage& a, ShaderUsage b) {
   (uint32_t&)a.usage &= (uint32_t)b.usage;
   return a;
 }
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 namespace detail {
 template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>

--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -4,11 +4,19 @@
 #include <memory>
 #include <cmath>
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif
+
 #if !defined(__wasm__)
 #include "dawn/dawn_proc.h"
 #if !defined(USE_EXTERNAL_DAWN)
 #include "dawn/native/DawnNative.h"
 #endif
+#endif
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
 #endif
 
 #include "core/common/common.h"


### PR DESCRIPTION
### Description
Suppress some strict-aliasing related warnings in WebGPU EP

For example:
```
/home/chasun/src/onnxruntime/onnxruntime/core/providers/webgpu/math/unary_elementwise_ops.cc:208:30: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
  208 |       float encoded_value = *reinterpret_cast<const float*>(attr);
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This PR does not really fix the problems. It just suppresses the warnings to make build pass. Some issues related to strict aliasing may be fixed by using std::bit_cast, which requires c++20 however.


### Motivation and Context
Build the code on Azure Linux 3 fails.  To reproduce the issue, you may get an AzureLinux3 machine and run:
```
 python3 tools/ci_build/build.py --update --build  --build_wheel --use_xnnpack --build_nodejs   --use_webgpu --build_dir b --skip_submodule_sync --parallel --use_binskim_compliant_compile_flags --build_shared_lib --config Release
```



