### PR TITLE
[TRT EP Perf Tool] Add annotations import to python script to support annotations on Python 3.8

### DIFF
--- a/onnxruntime/python/tools/tensorrt/perf/build/build_image.py
+++ b/onnxruntime/python/tools/tensorrt/perf/build/build_image.py
@@ -6,6 +6,8 @@
 Builds an Ubuntu-based Docker image with TensorRT.
 """
 
+from __future__ import annotations
+
 import argparse
 import os
 import pty


### PR DESCRIPTION
### Description
Adds `from __future__ import annotations` to python script to support annotations on Python 3.8.



### Motivation and Context
Pipeline that runs this script is using Ubuntu 20.04's default python version (3.8), which does not support annotations unless one imports from __future__.


