### PR TITLE
[QNN EP] Add LoggingManager::HasDefaultLogger() to provider bridge API

### DIFF
--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -286,6 +286,7 @@ struct ProviderHost {
 
   // logging::LoggingManager
   virtual const logging::Logger& logging__LoggingManager__DefaultLogger() = 0;
+  virtual bool logging__LoggingManager__HasDefaultLogger() = 0;
 
   // logging::Capture
   virtual std::unique_ptr<logging::Capture> logging__Capture__construct(const logging::Logger& logger,

--- a/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
+++ b/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
@@ -32,6 +32,7 @@ struct Logger final {
 
 struct LoggingManager final {
   static const Logger& DefaultLogger() { return g_host->logging__LoggingManager__DefaultLogger(); }
+  static bool HasDefaultLogger() { return g_host->logging__LoggingManager__HasDefaultLogger(); }
 
   PROVIDER_DISALLOW_ALL(LoggingManager)
 };

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -399,7 +399,6 @@ struct ProviderHostImpl : ProviderHost {
   const logging::Logger& logging__LoggingManager__DefaultLogger() override { return logging::LoggingManager::DefaultLogger(); }
   bool logging__LoggingManager__HasDefaultLogger() override { return logging::LoggingManager::HasDefaultLogger(); }
 
-
   // logging::Capture (wrapped)
   std::unique_ptr<logging::Capture> logging__Capture__construct(const logging::Logger& logger,
                                                                 logging::Severity severity, const char* category,

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -397,6 +397,8 @@ struct ProviderHostImpl : ProviderHost {
 
   // logging::LoggingManager (wrapped)
   const logging::Logger& logging__LoggingManager__DefaultLogger() override { return logging::LoggingManager::DefaultLogger(); }
+  bool logging__LoggingManager__HasDefaultLogger() override { return logging::LoggingManager::HasDefaultLogger(); }
+
 
   // logging::Capture (wrapped)
   std::unique_ptr<logging::Capture> logging__Capture__construct(const logging::Logger& logger,


### PR DESCRIPTION
### Description
Fixes QNN EP builds due to missing function in provider bridge API: `logging::LoggingManager::HasDefaultLogger()`



### Motivation and Context
A [recent PR](https://github.com/microsoft/onnxruntime/pull/23120) made QNN EP a shared library. A [different PR](https://github.com/microsoft/onnxruntime/pull/23435) added use of a 
 new function to QNN EP that was not part of the provider bridge API. The CI did not catch it because main was not merged into the first PR before merging.


