### PR TITLE
update ep_perf default pyenv to 310 to avoid error

### DIFF
--- a/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_cuda11_8_tensorrt8_6
+++ b/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_cuda11_8_tensorrt8_6
@@ -14,19 +14,23 @@ ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/src/tensorrt/bin:${ONNXR
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update &&\
-    apt-get install -y sudo git bash unattended-upgrades wget
-RUN unattended-upgrade
+    apt-get install -y sudo git bash unattended-upgrades wget software-properties-common &&\
+    add-apt-repository -y ppa:deadsnakes/ppa &&\
+    apt-get update
 
 # Install python3
 RUN apt-get install -y --no-install-recommends \
-    python3 \
+    python3.10 \
+    python3.10-dev \
+    python3.10-venv \
+    python3.10-distutils \
     python3-pip \
-    python3-dev \
     python3-wheel &&\
     cd /usr/local/bin &&\
-    ln -s /usr/bin/python3 python &&\
+    ln -sf /usr/bin/python3.10 python &&\
     ln -s /usr/bin/pip3 pip;
 
+RUN unattended-upgrade
 RUN pip install --upgrade pip 
 RUN pip install setuptools>=68.2.2
 

--- a/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_cuda11_tensorrt10
+++ b/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_cuda11_tensorrt10
@@ -14,19 +14,23 @@ ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/src/tensorrt/bin:${ONNXR
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update &&\
-    apt-get install -y sudo git bash unattended-upgrades wget
-RUN unattended-upgrade
+    apt-get install -y sudo git bash unattended-upgrades wget software-properties-common &&\
+    add-apt-repository -y ppa:deadsnakes/ppa &&\
+    apt-get update
 
 # Install python3
 RUN apt-get install -y --no-install-recommends \
-    python3 \
+    python3.10 \
+    python3.10-dev \
+    python3.10-venv \
+    python3.10-distutils \
     python3-pip \
-    python3-dev \
     python3-wheel &&\
     cd /usr/local/bin &&\
-    ln -s /usr/bin/python3 python &&\
+    ln -sf /usr/bin/python3.10 python &&\
     ln -s /usr/bin/pip3 pip;
 
+RUN unattended-upgrade
 RUN pip install --upgrade pip
 RUN pip install psutil setuptools>=68.2.2
 

--- a/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_cuda12_3_tensorrt8_6
+++ b/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_cuda12_3_tensorrt8_6
@@ -14,19 +14,23 @@ ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/src/tensorrt/bin:${ONNXR
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update &&\
-    apt-get install -y sudo git bash unattended-upgrades wget
-RUN unattended-upgrade
+    apt-get install -y sudo git bash unattended-upgrades wget software-properties-common &&\
+    add-apt-repository -y ppa:deadsnakes/ppa &&\
+    apt-get update
 
 # Install python3
 RUN apt-get install -y --no-install-recommends \
-    python3 \
+    python3.10 \
+    python3.10-dev \
+    python3.10-venv \
+    python3.10-distutils \
     python3-pip \
-    python3-dev \
     python3-wheel &&\
     cd /usr/local/bin &&\
-    ln -s /usr/bin/python3 python &&\
+    ln -sf /usr/bin/python3.10 python &&\
     ln -s /usr/bin/pip3 pip;
 
+RUN unattended-upgrade
 RUN pip install --upgrade pip 
 RUN pip install setuptools>=68.2.2
 

--- a/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_cuda12_tensorrt10
+++ b/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_cuda12_tensorrt10
@@ -14,19 +14,23 @@ ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/src/tensorrt/bin:${ONNXR
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update &&\
-    apt-get install -y sudo git bash unattended-upgrades wget
-RUN unattended-upgrade
+    apt-get install -y sudo git bash unattended-upgrades wget software-properties-common &&\
+    add-apt-repository -y ppa:deadsnakes/ppa &&\
+    apt-get update
 
 # Install python3
 RUN apt-get install -y --no-install-recommends \
-    python3 \
+    python3.10 \
+    python3.10-dev \
+    python3.10-venv \
+    python3.10-distutils \
     python3-pip \
-    python3-dev \
     python3-wheel &&\
     cd /usr/local/bin &&\
-    ln -s /usr/bin/python3 python &&\
+    ln -sf /usr/bin/python3.10 python &&\
     ln -s /usr/bin/pip3 pip;
 
+RUN unattended-upgrade
 RUN pip install --upgrade pip
 RUN pip install setuptools>=68.2.2 psutil
 

--- a/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_tensorrt_bin
+++ b/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_tensorrt_bin
@@ -14,19 +14,23 @@ ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${ONNXRUNTIME_LOCAL_CODE_DIR}
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update &&\
-    apt-get install -y sudo git bash unattended-upgrades wget
-RUN unattended-upgrade
+    apt-get install -y sudo git bash unattended-upgrades wget software-properties-common &&\
+    add-apt-repository -y ppa:deadsnakes/ppa &&\
+    apt-get update
 
 # Install python3
 RUN apt-get install -y --no-install-recommends \
-    python3 \
+    python3.10 \
+    python3.10-dev \
+    python3.10-venv \
+    python3.10-distutils \
     python3-pip \
-    python3-dev \
     python3-wheel &&\
     cd /usr/local/bin &&\
-    ln -s /usr/bin/python3 python &&\
+    ln -sf /usr/bin/python3.10 python &&\
     ln -s /usr/bin/pip3 pip;
 
+RUN unattended-upgrade
 RUN pip install --upgrade pip 
 RUN pip install setuptools>=68.2.2
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
EP_Perf CI was broken after https://github.com/microsoft/onnxruntime/pull/23401, 
as the host system is using py38 as default .
Updating to py310


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


