### PR TITLE
Update react-native version to 0.77.0

### DIFF
--- a/js/react_native/e2e/package.json
+++ b/js/react_native/e2e/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "react": "^18.1.0",
-    "react-native": "^0.70.15",
+    "react-native": "^0.77.0",
     "react-native-fs": "^2.20.0"
   },
   "devDependencies": {

--- a/js/react_native/package.json
+++ b/js/react_native/package.json
@@ -24,7 +24,7 @@
     "pod-install": "^0.1.36",
     "prettier": "^2.6.2",
     "react": "^18.1.0",
-    "react-native": "^0.70.15",
+    "react-native": "^0.77.0",
     "react-native-builder-bob": "^0.18.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Description
Update the `react-native` version to `0.77.0` to transitively update websocket(ws) version to 6.2.3 because ws v6.2.3 has key fix to mitigate a dos vuln.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


