### PR TITLE
Rearrange Andriod RN steps

### DIFF
--- a/tools/ci_build/github/azure-pipelines/stages/jobs/react-natvie-andriod-e2e-test-job.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/jobs/react-natvie-andriod-e2e-test-job.yml
@@ -13,6 +13,16 @@ parameters:
   type: string
   default: 'dev'
 
+- name: RunAndroidE2eTests
+  displayName: 'Run E2E tests'
+  type: boolean
+  default: true
+
+- name: PublishNpmPackages
+  displayName: 'Publish NPM packages'
+  type: boolean
+  default: true
+
 jobs:
 - job: ReactNative_CI_Android
   pool: 'onnxruntime-Ubuntu2204-AMD-CPU'
@@ -82,46 +92,55 @@ jobs:
       ORT_JS_PACK_MODE: e2e
     displayName: Pack NPM packages
 
-  - script: |
-      mv $(Build.SourcesDirectory)/js/common/onnxruntime-common*.tgz onnxruntime-common.tgz
-      yarn add --no-lockfile file:./onnxruntime-common.tgz
-      mv $(Build.SourcesDirectory)/js/react_native/onnxruntime-react-native*.tgz onnxruntime-react-native.tgz
-      yarn add --no-lockfile file:./onnxruntime-react-native.tgz
-      yarn
-    workingDirectory: '$(Build.SourcesDirectory)/js/react_native/e2e'
-    displayName: Bootstrap Android and iOS e2e tests
+  - ${{ if eq(parameters.PublishNpmPackages, true) }}:
+    - task: CopyFiles@2
+      inputs:
+        sourceFolder: $(Build.SourcesDirectory)/js/common
+        contents: onnxruntime-common*.tgz
+        targetFolder: $(Build.ArtifactStagingDirectory)
+      displayName: 'Create Artifacts onnxruntime-common'
 
-  - script: |
-      yarn add --dev jest-junit
-    workingDirectory: '$(Build.SourcesDirectory)/js/react_native/e2e'
-    displayName: install jest junit reporter js/react_native/e2e
+    - task: CopyFiles@2
+      inputs:
+        sourceFolder: $(Build.SourcesDirectory)/js/react_native
+        contents: onnxruntime-react-native*.tgz
+        targetFolder: $(Build.ArtifactStagingDirectory)
+      displayName: Create Artifacts onnxruntime-react-native
 
-  - script: |
-      keytool -genkey -v -keystore debug.keystore -alias androiddebugkey -storepass android \
-        -keypass android -keyalg RSA -keysize 2048 -validity 999999 -dname "CN=Android Debug,O=Android,C=US"
-    workingDirectory: '$(Build.SourcesDirectory)/js/react_native/e2e/android'
-    displayName: Generate a debug keystore
+    - task: PublishPipelineArtifact@0
+      inputs:
+        artifactName: '${{parameters.PackageName}}'
+        targetPath: '$(Build.ArtifactStagingDirectory)'
+      displayName: Publish Pipeline Artifact
 
-  - task: CopyFiles@2
-    inputs:
-      sourceFolder: $(Build.BinariesDirectory)/android-full-aar
-      contents: onnxruntime-*.aar
-      targetFolder: $(Build.SourcesDirectory)/js/react_native/e2e/android/app/libs
-    displayName: Copy Android package to Android e2e test directory
+  - ${{ if eq(parameters.RunAndroidE2eTests, true) }}:
+    - script: |
+        mv $(Build.SourcesDirectory)/js/common/onnxruntime-common*.tgz onnxruntime-common.tgz
+        yarn add --no-lockfile file:./onnxruntime-common.tgz
+        mv $(Build.SourcesDirectory)/js/react_native/onnxruntime-react-native*.tgz onnxruntime-react-native.tgz
+        yarn add --no-lockfile file:./onnxruntime-react-native.tgz
+        yarn
+      workingDirectory: '$(Build.SourcesDirectory)/js/react_native/e2e'
+      displayName: Bootstrap Android and e2e tests
 
-  - script: |
-      yarn global add detox-cli
-      echo "Path: $PATH"
-      echo "##vso[task.prependpath]$(yarn global bin)"
-      echo "Updated PATH: $PATH"
-      echo "Detox bin directory: $(yarn global bin)"
-      ls $(yarn global bin)
-    displayName: Install detox cli tools and prepend to PATH
+    - script: |
+        yarn add --dev jest-junit
+      workingDirectory: '$(Build.SourcesDirectory)/js/react_native/e2e'
+      displayName: install jest junit reporter js/react_native/e2e
 
-  - script: |
-      detox build --configuration android.emu.release
-    workingDirectory: '$(Build.SourcesDirectory)/js/react_native/e2e'
-    displayName: Build React Native Detox Android e2e Tests
+    - script: |
+        keytool -genkey -v -keystore debug.keystore -alias androiddebugkey -storepass android \
+          -keypass android -keyalg RSA -keysize 2048 -validity 999999 -dname "CN=Android Debug,O=Android,C=US"
+      workingDirectory: '$(Build.SourcesDirectory)/js/react_native/e2e/android'
+      displayName: Generate a debug keystore
+
+    - task: CopyFiles@2
+      inputs:
+        sourceFolder: $(Build.BinariesDirectory)/android-full-aar
+        contents: onnxruntime-*.aar
+        targetFolder: $(Build.SourcesDirectory)/js/react_native/e2e/android/app/libs
+      displayName: Copy Android package to Android e2e test directory
+
 
   #
   # Unit tests and E2E tests with Android emulator
@@ -130,7 +149,7 @@ jobs:
     parameters:
       create: true
       start: true
-
+  # Instrumented tests
   - template: ../../templates/android-dump-logs-from-steps.yml
     parameters:
       steps:
@@ -147,65 +166,46 @@ jobs:
           spotBugsAnalysis: false
         displayName: Run React Native Android Instrumented Tests
 
-  - script: |
-      JEST_JUNIT_OUTPUT_FILE=$(Build.SourcesDirectory)/js/react_native/e2e/android-test-results.xml \
-        detox test --record-logs all \
-                   --configuration android.emu.release \
-                   --loglevel trace \
-                   --take-screenshots failing
-    workingDirectory: '$(Build.SourcesDirectory)/js/react_native/e2e'
-    displayName: Run React Native Detox Android e2e Tests
+  # E2E tests
+  - ${{ if eq(parameters.RunAndroidE2eTests, true) }}:
+    - script: |
+        yarn global add detox-cli
+        echo "Path: $PATH"
+        echo "##vso[task.prependpath]$(yarn global bin)"
+        echo "Updated PATH: $PATH"
+        echo "Detox bin directory: $(yarn global bin)"
+        ls $(yarn global bin)
+      displayName: Install detox cli tools and prepend to PATH
+
+    - script: |
+        detox build --configuration android.emu.release
+      workingDirectory: '$(Build.SourcesDirectory)/js/react_native/e2e'
+      displayName: Build React Native Detox Android e2e Tests
+
+    - script: |
+        JEST_JUNIT_OUTPUT_FILE=$(Build.SourcesDirectory)/js/react_native/e2e/android-test-results.xml \
+          detox test --record-logs all \
+                     --configuration android.emu.release \
+                     --loglevel trace \
+                     --take-screenshots failing
+      workingDirectory: '$(Build.SourcesDirectory)/js/react_native/e2e'
+      displayName: Run React Native Detox Android e2e Tests
+
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFiles: '$(Build.SourcesDirectory)/js/react_native/e2e/android-test-results.xml'
+        failTaskOnFailedTests: true
+        testRunTitle: 'React Native Detox Android e2e Test Results'
+      condition: succeededOrFailed()
+      displayName: Publish React Native Detox Android e2e Test Results
+    - task: PublishPipelineArtifact@1
+      inputs:
+        artifact: android_e2e_test_logs_$(Build.BuildId)_$(Build.BuildNumber)_$(System.JobAttempt)
+        targetPath: '$(Build.SourcesDirectory)/js/react_native/e2e/artifacts'
+      condition: succeededOrFailed()
+      displayName: Publish React Native Detox E2E test logs
 
   - template: ../../templates/use-android-emulator.yml
     parameters:
       stop: true
-
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFiles: '$(Build.SourcesDirectory)/js/react_native/e2e/android-test-results.xml'
-      failTaskOnFailedTests: true
-      testRunTitle: 'React Native Detox Android e2e Test Results'
-    condition: succeededOrFailed()
-    displayName: Publish React Native Detox Android e2e Test Results
-
-  - script: |
-      git restore .
-    workingDirectory: '$(Build.SourcesDirectory)/js'
-    displayName: Restore git changes
-
-  - task: PowerShell@2
-    inputs:
-      filePath: '$(Build.SourcesDirectory)/tools/ci_build/github/js/pack-npm-packages.ps1'
-      arguments: '"${{parameters.NpmPackagingMode}}" $(Build.SourcesDirectory) react_native'
-      workingDirectory: '$(Build.SourcesDirectory)'
-      errorActionPreference: stop
-    displayName: Pack NPM packages
-
-  - task: CopyFiles@2
-    inputs:
-      sourceFolder: $(Build.SourcesDirectory)/js/common
-      contents: onnxruntime-common*.tgz
-      targetFolder: $(Build.ArtifactStagingDirectory)
-    displayName: 'Create Artifacts onnxruntime-common'
-
-  - task: CopyFiles@2
-    inputs:
-      sourceFolder: $(Build.SourcesDirectory)/js/react_native
-      contents: onnxruntime-react-native*.tgz
-      targetFolder: $(Build.ArtifactStagingDirectory)
-    displayName: Create Artifacts onnxruntime-react-native
-
-  - task: PublishPipelineArtifact@1
-    inputs:
-      artifact: android_e2e_test_logs_$(Build.BuildId)_$(Build.BuildNumber)_$(System.JobAttempt)
-      targetPath: '$(Build.SourcesDirectory)/js/react_native/e2e/artifacts'
-    condition: succeededOrFailed()
-    displayName: Publish React Native Detox E2E test logs
-
-  - task: PublishPipelineArtifact@0
-    inputs:
-      artifactName: '${{parameters.PackageName}}'
-      targetPath: '$(Build.ArtifactStagingDirectory)'
-    displayName: Publish Pipeline Artifact
-
   - template: ../../templates/explicitly-defined-final-tasks.yml


### PR DESCRIPTION


### Description
This PR allows optionalluy disage Android E2E test, and move NPM packging before Android E2E test.



### Motivation and Context
Allow to speed up debuging when upgrading RN version by disabling the E2E tests.


