### PR TITLE
Fix tensor external data info length parsing issue.

### DIFF
--- a/onnxruntime/core/framework/tensor_external_data_info.h
+++ b/onnxruntime/core/framework/tensor_external_data_info.h
@@ -32,8 +32,6 @@ class ExternalDataInfo {
 
   const std::string& GetChecksum() const { return checksum_; }
 
-  // If the value of 'offset' or 'length' field is larger the max value of ssize_t, this function will treat it as a
-  // wrong value and return FAIL.
   static common::Status Create(
       const ::google::protobuf::RepeatedPtrField<::ONNX_NAMESPACE::StringStringEntryProto>& input,
       std::unique_ptr<ExternalDataInfo>& out);

--- a/onnxruntime/test/framework/tensorutils_test.cc
+++ b/onnxruntime/test/framework/tensorutils_test.cc
@@ -2,12 +2,16 @@
 // Licensed under the MIT License.
 
 #include "core/common/inlined_containers.h"
+#include "core/common/parse_string.h"
 #include "core/framework/prepacked_weights.h"
 #include "core/framework/prepacked_weights_container.h"
 #include "core/framework/tensorprotoutils.h"
 #include "core/graph/onnx_protobuf.h"
 #include "test/util/include/asserts.h"
 #include "file_util.h"
+
+#include <cstdint>
+#include <limits>
 
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
@@ -21,6 +25,72 @@ using namespace ONNX_NAMESPACE;
 
 namespace onnxruntime {
 namespace test {
+
+static void TestExternalDataInfoParsingOffsetAndLengthWithStrings(
+    std::string_view offset_str,
+    std::string_view length_str,
+    const char* expected_error_message_substring = nullptr) {
+  SCOPED_TRACE(MakeString("offset: ", offset_str, ", length: ", length_str));
+
+  ONNX_NAMESPACE::TensorProto tensor_proto;
+  const std::filesystem::path kExternalDataPath("test.bin");
+
+  tensor_proto.set_data_location(ONNX_NAMESPACE::TensorProto_DataLocation::TensorProto_DataLocation_EXTERNAL);
+
+  auto* location_entry = tensor_proto.add_external_data();
+  location_entry->set_key("location");
+  location_entry->set_value(ToUTF8String(kExternalDataPath.native()));
+
+  auto* offset_entry = tensor_proto.add_external_data();
+  offset_entry->set_key("offset");
+  offset_entry->set_value(offset_str.data(), offset_str.size());
+
+  auto* length_entry = tensor_proto.add_external_data();
+  length_entry->set_key("length");
+  length_entry->set_value(length_str.data(), length_str.size());
+
+  std::unique_ptr<ExternalDataInfo> external_data_info{};
+  const auto create_status = ExternalDataInfo::Create(tensor_proto.external_data(), external_data_info);
+  if (expected_error_message_substring) {
+    ASSERT_STATUS_NOT_OK_AND_HAS_SUBSTR(create_status, expected_error_message_substring);
+    return;
+  }
+  ASSERT_STATUS_OK(create_status);
+
+  // now we assume that offset_str and length_str are able to be parsed
+  const auto expected_offset = ParseStringWithClassicLocale<ExternalDataInfo::OFFSET_TYPE>(offset_str);
+  const auto expected_length = ParseStringWithClassicLocale<size_t>(length_str);
+
+  ASSERT_EQ(external_data_info->GetOffset(), expected_offset);
+  ASSERT_EQ(external_data_info->GetLength(), expected_length);
+}
+
+static void TestExternalDataInfoParsingOffsetAndLength(intmax_t offset,
+                                                       uintmax_t length,
+                                                       const char* expected_error_message_substring = nullptr) {
+  TestExternalDataInfoParsingOffsetAndLengthWithStrings(std::to_string(offset), std::to_string(length),
+                                                        expected_error_message_substring);
+}
+
+TEST(TensorProtoUtilsTest, ParseExternalDataInfoOffsetAndLength) {
+  TestExternalDataInfoParsingOffsetAndLength(0, 0);
+
+  TestExternalDataInfoParsingOffsetAndLength(0, 1024);
+  TestExternalDataInfoParsingOffsetAndLength(0, std::numeric_limits<size_t>::max());
+
+  TestExternalDataInfoParsingOffsetAndLength(1024, 1024);
+  TestExternalDataInfoParsingOffsetAndLength(std::numeric_limits<ExternalDataInfo::OFFSET_TYPE>::max(), 1024);
+
+  {
+    // assuming that this value is too large to fit in either size_t or ExternalDataInfo::OFFSET_TYPE
+    const std::string_view two_to_the_65th_power = "36893488147419103232";
+    const std::string_view zero = "0";
+    TestExternalDataInfoParsingOffsetAndLengthWithStrings(two_to_the_65th_power, zero, "Failed to parse value");
+    TestExternalDataInfoParsingOffsetAndLengthWithStrings(zero, two_to_the_65th_power, "Failed to parse value");
+  }
+
+  // TODO should ExternalDataInfo::Create() also reject negative offset values?
+}
 
 // Test ExternalData functionality
 TEST(TensorProtoUtilsTest, SetExternalDataInformation) {

--- a/onnxruntime/test/framework/tensorutils_test.cc
+++ b/onnxruntime/test/framework/tensorutils_test.cc
@@ -26,11 +26,12 @@ using namespace ONNX_NAMESPACE;
 namespace onnxruntime {
 namespace test {
 
+// if `expected_error_message_substring` is nullptr, parsing is expected to be successful
 static void TestExternalDataInfoParsingOffsetAndLengthWithStrings(
     std::string_view offset_str,
     std::string_view length_str,
     const char* expected_error_message_substring = nullptr) {
-  SCOPED_TRACE(MakeString("offset: ", offset_str, ", length: ", length_str));
+  SCOPED_TRACE(MakeString("offset: \"", offset_str, "\", length: \"", length_str, "\""));
 
   ONNX_NAMESPACE::TensorProto tensor_proto;
   const std::filesystem::path kExternalDataPath("test.bin");
@@ -57,7 +58,7 @@ static void TestExternalDataInfoParsingOffsetAndLengthWithStrings(
   }
   ASSERT_STATUS_OK(create_status);
 
-  // now we assume that offset_str and length_str are able to be parsed
+  // if we got this far, assume that offset_str and length_str are able to be parsed.
   const auto expected_offset = ParseStringWithClassicLocale<ExternalDataInfo::OFFSET_TYPE>(offset_str);
   const auto expected_length = ParseStringWithClassicLocale<size_t>(length_str);
 
@@ -65,6 +66,7 @@ static void TestExternalDataInfoParsingOffsetAndLengthWithStrings(
   ASSERT_EQ(external_data_info->GetLength(), expected_length);
 }
 
+// if `expected_error_message_substring` is nullptr, parsing is expected to be successful
 static void TestExternalDataInfoParsingOffsetAndLength(intmax_t offset,
                                                        uintmax_t length,
                                                        const char* expected_error_message_substring = nullptr) {


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Fix tensor external data info length parsing issue.

The old implementation was parsing a `size_t` value with `strtol` (via `OrtStrToPtrDiff`) on ARM64 MSVC.
https://github.com/microsoft/onnxruntime/blob/bf023ab3d565668c13a5334b505df0eb6acf3625/onnxruntime/core/platform/path_lib.h#L74
If we have `sizeof(size_t) == 8` and `sizeof(long) == 4` (as is the case for x64 and ARM64 MSVC), `strtol` will return a maximum value of `2^31-1` even for a larger, valid `size_t` value. `strtol` will also set `errno` to `ERANGE`, but we weren't checking that.

Updated to use `ParseStringWithClassicLocale` which will parse directly to the target type.

Added some tests.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix issue where tensor data length was being parsed as `2^31-1`.