### PR TITLE
Add overload of `TryParseStringWithClassicLocale()` that uses `std::from_chars()`

### DIFF
--- a/include/onnxruntime/core/common/parse_string.h
+++ b/include/onnxruntime/core/common/parse_string.h
@@ -18,14 +18,14 @@ namespace detail {
 // Whether we will use std::from_chars() to parse to `T`.
 #if defined(__ANDROID__)
 // Note: As of Android NDK r27c, std::from_chars() doesn't support floating point types.
-template<typename T>
+template <typename T>
 constexpr bool ParseWithFromChars = !std::is_same_v<bool, T> && std::is_integral_v<T>;
 #else
 template <typename T>
 constexpr bool ParseWithFromChars = !std::is_same_v<bool, T> && (std::is_integral_v<T> || std::is_floating_point_v<T>);
 #endif
 
-}
+}  // namespace detail
 
 /**
  * Tries to parse a value from an entire string.

--- a/include/onnxruntime/core/common/parse_string.h
+++ b/include/onnxruntime/core/common/parse_string.h
@@ -16,8 +16,8 @@ namespace onnxruntime {
 namespace detail {
 
 // Whether we will use std::from_chars() to parse to `T`.
-#if defined(__ANDROID__)
-// Note: As of Android NDK r27c, std::from_chars() doesn't support floating point types.
+#if defined(_LIBCPP_VERSION)
+// Note: Currently (e.g., in LLVM 19), libc++'s std::from_chars() doesn't support floating point types yet.
 template <typename T>
 constexpr bool ParseWithFromChars = !std::is_same_v<bool, T> && std::is_integral_v<T>;
 #else

--- a/include/onnxruntime/core/common/parse_string.h
+++ b/include/onnxruntime/core/common/parse_string.h
@@ -17,12 +17,12 @@ namespace detail {
 
 // Whether we will use std::from_chars() to parse to `T`.
 #if defined(__ANDROID__)
-// Note: As of Android NDK r27c, std::from_chars() doesn't support floating point types
+// Note: As of Android NDK r27c, std::from_chars() doesn't support floating point types.
 template<typename T>
-constexpr bool ParseWithFromChars = std::is_integral_v<T>;
+constexpr bool ParseWithFromChars = !std::is_same_v<bool, T> && std::is_integral_v<T>;
 #else
 template <typename T>
-constexpr bool ParseWithFromChars = std::is_integral_v<T> || std::is_floating_point_v<T>;
+constexpr bool ParseWithFromChars = !std::is_same_v<bool, T> && (std::is_integral_v<T> || std::is_floating_point_v<T>);
 #endif
 
 }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Add overload of `TryParseStringWithClassicLocale()` that uses `std::from_chars()` for certain types.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Reduce binary size. It recently increased after PR #23526.

Commit|Android baseline minimal build size in bytes
-|-
baseline (e3e41739a7ca0ce0806805aa7e2814c72748d0e5) |1236839 
after #23526 (d5338da1f556eddff636293c97e0921443fe0fc4) |1239111
updated (41bd59c9ba9399e476e319f48cdc82a9f4436b38) |1235535