### PR TITLE
Set ANDROID_USE_LEGACY_TOOLCHAIN_FILE to false

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1334,6 +1334,7 @@ def generate_build_tree(
             "-DANDROID_PLATFORM=android-" + str(args.android_api),
             "-DANDROID_ABI=" + str(args.android_abi),
             "-DANDROID_MIN_SDK=" + str(args.android_api),
+            "-DANDROID_USE_LEGACY_TOOLCHAIN_FILE=false",
         ]
         if not args.use_vcpkg:
             cmake_args.append("-DCMAKE_TOOLCHAIN_FILE=" + android_toolchain_cmake_path)

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1336,6 +1336,10 @@ def generate_build_tree(
             "-DANDROID_MIN_SDK=" + str(args.android_api),
             "-DANDROID_USE_LEGACY_TOOLCHAIN_FILE=false",
         ]
+        if args.disable_rtti:
+            add_default_definition(cmake_extra_defines, "CMAKE_ANDROID_RTTI", "OFF")
+        if args.disable_exceptions:
+            add_default_definition(cmake_extra_defines, "CMAKE_ANDROID_EXCEPTIONS", "OFF")
         if not args.use_vcpkg:
             cmake_args.append("-DCMAKE_TOOLCHAIN_FILE=" + android_toolchain_cmake_path)
         else:


### PR DESCRIPTION
NDK has two toolchain cmake files as you can see in 
 https://android.googlesource.com/platform/ndk/+/refs/heads/main/build/cmake

By default NDK use the legacy one for providing the best compatibility. We don't need to.  This PR changes to use the new one.

The new toolchain cmake file uses standard cmake flags like CMAKE_ANDROID_RTTI to control C++ features. 