### PR TITLE
Remove "--enable_pybind" from webgpu pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/win-gpu-webgpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-webgpu-ci-pipeline.yml
@@ -45,7 +45,6 @@ stages:
         buildArch: x64
         # add --build_java if necessary
         additionalBuildFlags: >-
-          --enable_pybind
           --build_nodejs
           --use_webgpu
           --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=ON onnxruntime_BUILD_DAWN_MONOLITHIC_LIBRARY=ON


### PR DESCRIPTION
There is a crash in the WebGPU CI pipeline.  It crashed at process shutdown when unloading onnxruntime_pybind11_state.pyd.
Here is the callstack:

```
 	dxil.dll!DxcSwapThreadMalloc()	Unknown
 	dxil.dll!DxcThreadMalloc::DxcThreadMalloc(struct IMalloc *)	Unknown
 	dxil.dll!DxcValidator::Release(void)	Unknown
 	[Inline Frame] webgpu_dawn.dll!Microsoft::WRL::ComPtr<IDxcValidator>::InternalRelease() Line 235	C++
 	[Inline Frame] webgpu_dawn.dll!Microsoft::WRL::ComPtr<IDxcValidator>::{dtor}() Line 290	C++
 	webgpu_dawn.dll!dawn::native::d3d12::Backend::`scalar deleting destructor'(unsigned int)	C++
 	webgpu_dawn.dll!`eh vector destructor iterator'(void * ptr, unsigned __int64 size, unsigned __int64 count, void(*)(void *) destructor)	C++
 	webgpu_dawn.dll!dawn::native::InstanceBase::~InstanceBase() Line 197	C++
 	webgpu_dawn.dll!dawn::native::InstanceBase::`scalar deleting destructor'(unsigned int)	C++
 	webgpu_dawn.dll!dawn::native::InstanceBase::DeleteThis() Line 218	C++
 	ucrtbase.dll!<lambda>(void)()	Unknown
 	ucrtbase.dll!__crt_seh_guarded_call<int>::operator()<<lambda_7777bce6b2f8c936911f934f8298dc43>,<lambda>(void) &,<lambda_3883c3dff614d5e0c5f61bb1ac94921c>>()	Unknown
 	ucrtbase.dll!_execute_onexit_table()	Unknown
 	onnxruntime_pybind11_state.pyd!dllmain_crt_process_detach(const bool is_terminating) Line 182	C++
>	onnxruntime_pybind11_state.pyd!dllmain_dispatch(HINSTANCE__ * const instance, const unsigned long reason, void * const reserved) Line 293	C++
 	ntdll.dll!LdrpCallInitRoutine()	Unknown
 	ntdll.dll!LdrShutdownProcess()	Unknown
 	ntdll.dll!RtlExitUserProcess()	Unknown
 	kernel32.dll!ExitProcessImplementation()	Unknown
 	ucrtbase.dll!exit_or_terminate_process()	Unknown
 	ucrtbase.dll!common_exit()	Unknown
 	python312.dll!00007ff9cab3ec8d()	Unknown
 	python312.dll!00007ff9cab3efbf()	Unknown
 	python312.dll!00007ff9cab3edee()	Unknown
 	python312.dll!00007ff9cab57f4c()	Unknown
 	python312.dll!00007ff9cab57579()	Unknown
 	python312.dll!00007ff9cab573be()	Unknown
 	python312.dll!00007ff9cab5729b()	Unknown
 	python312.dll!00007ff9cabacfcb()	Unknown
 	python312.dll!00007ff9cabacd7d()	Unknown
 	python312.dll!00007ff9cab99e2d()	Unknown
 	python.exe!00007ff78a641230()	Unknown
 	kernel32.dll!BaseThreadInitThunk()	Unknown
 	ntdll.dll!RtlUserThreadStart()	Unknown
```
It might be because the destruct order of some global variables was wrong.  I saw DX DLLs were getting destroyed earlier than the WebGPU instance in our code in onnxruntime_pybind11_state.pyd.  


