### PR TITLE
[Build] Very basic GitHub Actions workflow for Emscripten(WASM) build with vcpkg

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -7,13 +7,25 @@ concurrency: # cancel running build if new push on the same branch
   cancel-in-progress: true
 
 jobs:
-  linux:
+  linux: # see azure-pipelines/templates/linux-wasm-ci.yml
     name: WASM(Linux)
     runs-on: ubuntu-latest
     container:
       image: emscripten/emsdk:3.1.74 # https://hub.docker.com/r/emscripten/emsdk
+    env:
+      # https://emscripten.org/docs/tools_reference/emcc.html
+      # https://github.com/emscripten-core/emscripten/blob/3.1.74/emcc.py
+      # https://emscripten.org/docs/tools_reference/settings_reference.html
+      # https://github.com/emscripten-core/emscripten/blob/3.1.74/tools/settings.py
+      # https://github.com/emscripten-core/emscripten/blob/3.1.74/tools/feature_matrix.py
+      # wasm-ld: error: --shared-memory is disallowed by ...o because it was not compiled with 'atomics' or 'bulk-memory' features.
+      EMCC_CFLAGS: "-sBULK_MEMORY -sPTHREADS"
+      # EM_CONFIG: /emsdk/.emscripten
     steps:
       - uses: actions/checkout@v4
+
+      - name: "Run git config"
+        run: git config --global --add safe.directory /__w/onnxruntime/onnxruntime
 
       - name: "Run apt"
         run: |
@@ -26,7 +38,7 @@ jobs:
         run: |
           # "/emsdk/node/20.18.0_64bit/bin/..."
           node_path=$(which node)
-          echo "Using Node.js: $node_path" >> "$GITHUB_STEP_SUMMARY"
+          echo "* $node_path" >> "$GITHUB_STEP_SUMMARY"
           echo "EMSDK_NODE=$node_path" >> "$GITHUB_ENV"
 
       - uses: lukka/get-cmake@latest
@@ -43,14 +55,15 @@ jobs:
         env:
           VCPKG_INSTALLED_DIR: "${{ github.workspace }}/.build"
           VCPKG_DEFAULT_TRIPLET: "wasm32-emscripten"
+          VCPKG_KEEP_ENV_VARS: "EMCC_CFLAGS" # forward these in the install
 
       - name: "Detect protoc"
-        id: protoc-detect
+        id: protoc
         run: |
           set -e -x
           export PROTOC_DIR="$(pwd)/.build/x64-linux/tools/protobuf"
           export PATH="$PROTOC_DIR:$PATH"
-          protoc --version
+          echo "* $(protoc --version)" >> "$GITHUB_STEP_SUMMARY"
           echo "protoc_path=$(which protoc)" >> "$GITHUB_OUTPUT"
         shell: bash
 
@@ -59,15 +72,13 @@ jobs:
           set -e -x
           export FLATC_DIR="$(pwd)/.build/x64-linux/tools/flatbuffers"
           export PATH="$FLATC_DIR:$PATH"
-          flatc --version
+          echo "* $(flatc --version)" >> "$GITHUB_STEP_SUMMARY"
           python3 onnxruntime/core/flatbuffers/schema/compile_schema.py --flatc "$(which flatc)"
           python3 onnxruntime/lora/adapter_format/compile_schema.py --flatc "$(which flatc)"
         shell: bash
 
       - name: "Run build.py"
         run: |
-          git config --global --add safe.directory ${{ github.workspace }}
-          git config --global --add safe.directory /__w/onnxruntime/onnxruntime
           python3 ./tools/ci_build/build.py --allow_running_as_root --compile_no_warning_as_error \
             --build_dir ./build \
             --build_wasm \
@@ -76,10 +87,10 @@ jobs:
             --skip_submodule_sync \
             --enable_wasm_simd \
             --enable_wasm_threads \
-            --path_to_protoc_exe "${{ steps.protoc-detect.outputs.protoc_path }}" \
+            --path_to_protoc_exe "${{ steps.protoc.outputs.protoc_path }}" \
             --cmake_extra_defines "CMAKE_TOOLCHAIN_FILE:FILEPATH=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" \
-            --cmake_extra_defines "VCPKG_TARGET_TRIPLET=wasm32-emscripten" \
             --cmake_extra_defines "VCPKG_INSTALLED_DIR:PATH=${{ github.workspace }}/.build"
         shell: bash
         env:
           VCPKG_INSTALLATION_ROOT: "/usr/local/share/vcpkg"
+          # EMCC_DEBUG: ${{ runner.debug }}

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -1,0 +1,26 @@
+name: WebAssembly
+
+on: [push]
+
+jobs:
+  Vcpkg:
+    runs-on: ubuntu-latest
+    container:
+      image: emscripten/emsdk:3.1.74
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Run apt"
+        run: |
+          sudo apt update -y
+          sudo apt install -y pkg-config
+
+      - name: "Run vcpkg(wasm32-emscripten)"
+        uses: lukka/run-vcpkg@v11.5
+        with:
+          vcpkgDirectory: "/usr/local/share/vcpkg" # VCPKG_INSTALLATION_ROOT
+          runVcpkgInstall: true
+          vcpkgJsonGlob: "cmake/vcpkg.json"
+          vcpkgConfigurationJsonGlob: "cmake/vcpkg-configuration.json"
+        env:
+          VCPKG_INSTALLED_DIR: "${{ github.workspace }}/.build"
+          VCPKG_DEFAULT_TRIPLET: "wasm32-emscripten"

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -54,14 +54,17 @@ jobs:
       - name: "Run build.py"
         run: |
           git config --global --add safe.directory ${{ github.workspace }}
+          git config --global --add safe.directory /__w/onnxruntime/onnxruntime
           # "/emsdk/node/20.18.0_64bit/bin/..."
           export EMSDK_NODE=$(which node)
-          python3 ./tools/ci_build/build.py --allow_running_as_root \
+          python3 ./tools/ci_build/build.py --allow_running_as_root --compile_no_warning_as_error \
             --build_dir ./build \
             --build_wasm \
             --parallel \
             --use_vcpkg \
             --skip_submodule_sync \
+            --enable_wasm_simd \
+            --enable_wasm_threads \
             --cmake_extra_defines "CMAKE_TOOLCHAIN_FILE:FILEPATH=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" \
             --cmake_extra_defines "VCPKG_TARGET_TRIPLET=wasm32-emscripten" \
             --cmake_extra_defines "VCPKG_INSTALLED_DIR:PATH=${{ github.workspace }}/.build"

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -17,9 +17,7 @@ jobs:
       # https://github.com/emscripten-core/emscripten/blob/3.1.74/emcc.py
       # https://emscripten.org/docs/tools_reference/settings_reference.html
       # https://github.com/emscripten-core/emscripten/blob/3.1.74/tools/settings.py
-      # https://github.com/emscripten-core/emscripten/blob/3.1.74/tools/feature_matrix.py
-      # wasm-ld: error: --shared-memory is disallowed by ...o because it was not compiled with 'atomics' or 'bulk-memory' features.
-      EMCC_CFLAGS: "-sBULK_MEMORY -sPTHREADS"
+      EMCC_CFLAGS: "-mbulk-memory -matomics -pthread"
       # EM_CONFIG: /emsdk/.emscripten
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +53,7 @@ jobs:
         env:
           VCPKG_INSTALLED_DIR: "${{ github.workspace }}/.build"
           VCPKG_DEFAULT_TRIPLET: "wasm32-emscripten"
-          VCPKG_KEEP_ENV_VARS: "EMCC_CFLAGS" # forward these in the install
+          VCPKG_KEEP_ENV_VARS: "EM_CONFIG;EMCC_CFLAGS" # forward to the vcpkg sub-processes
 
       - name: "Detect protoc"
         id: protoc
@@ -93,4 +91,4 @@ jobs:
         shell: bash
         env:
           VCPKG_INSTALLATION_ROOT: "/usr/local/share/vcpkg"
-          # EMCC_DEBUG: ${{ runner.debug }}
+          VCPKG_KEEP_ENV_VARS: "EM_CONFIG;EMCC_CFLAGS"

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -9,10 +9,13 @@ jobs:
       image: emscripten/emsdk:3.1.74
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
       - name: "Run apt"
         run: |
           sudo apt update -y
-          sudo apt install -y pkg-config
+          sudo apt install -y python3 pkg-config autoconf automake autoconf-archive file
 
       - name: "Run vcpkg(wasm32-emscripten)"
         uses: lukka/run-vcpkg@v11.5
@@ -24,3 +27,35 @@ jobs:
         env:
           VCPKG_INSTALLED_DIR: "${{ github.workspace }}/.build"
           VCPKG_DEFAULT_TRIPLET: "wasm32-emscripten"
+
+      - name: "Detect protoc"
+        id: protoc-detect
+        run: |
+          set -e -x
+          export PROTOC_DIR="$(pwd)/.build/x64-linux/tools/protobuf"
+          export PATH="$PROTOC_DIR:$PATH"
+          protoc --version
+          echo "protoc_path=$(which protoc)" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: "Run compile_schema.py"
+        run: |
+          set -e -x
+          export FLATC_DIR="$(pwd)/.build/x64-linux/tools/flatbuffers"
+          export PATH="$FLATC_DIR:$PATH"
+          flatc --version
+          python3 onnxruntime/core/flatbuffers/schema/compile_schema.py --flatc "$(which flatc)"
+          python3 onnxruntime/lora/adapter_format/compile_schema.py --flatc "$(which flatc)"
+        shell: bash
+
+      - name: "Run build.py"
+        run: |
+          git config --global --add safe.directory ${{ github.workspace }}
+          python3 ./tools/ci_build/build.py --allow_running_as_root \
+            --build_dir ./build \
+            --build_wasm \
+            --skip_submodule_sync \
+            --cmake_extra_defines "CMAKE_TOOLCHAIN_FILE:FILEPATH=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" \
+            --cmake_extra_defines "VCPKG_TARGET_TRIPLET=wasm32-emscripten" \
+            --cmake_extra_defines "VCPKG_INSTALLED_DIR:PATH=${{ github.workspace }}/.build"
+        shell: bash

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -32,12 +32,11 @@ jobs:
             autoconf automake autoconf-archive \
             linux-libc-dev
 
-      - name: "Detect Node.js"
+      - name: "Detect Node.js" # create env.EMSDK_NODE for unit tests
         run: |
-          # "/emsdk/node/20.18.0_64bit/bin/..."
           node_path=$(which node)
-          echo "* $node_path" >> "$GITHUB_STEP_SUMMARY"
           echo "EMSDK_NODE=$node_path" >> "$GITHUB_ENV"
+          echo "* EMSDK_NODE: $node_path" >> "$GITHUB_STEP_SUMMARY"
 
       - uses: lukka/get-cmake@latest
         with:

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -1,20 +1,33 @@
 name: WebAssembly
 
-on: [push]
+on: [push, pull_request]
+
+concurrency: # cancel running build if new push on the same branch
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
-  linux-wasm:
+  linux:
     name: WASM(Linux)
     runs-on: ubuntu-latest
     container:
-      image: emscripten/emsdk:3.1.74
+      image: emscripten/emsdk:3.1.74 # https://hub.docker.com/r/emscripten/emsdk
     steps:
       - uses: actions/checkout@v4
 
       - name: "Run apt"
         run: |
           sudo apt update -y
-          sudo apt install -y python3 pkg-config autoconf automake autoconf-archive file
+          sudo apt install -y python3 pkg-config file \
+            autoconf automake autoconf-archive \
+            linux-libc-dev
+
+      - name: "Detect Node.js"
+        run: |
+          # "/emsdk/node/20.18.0_64bit/bin/..."
+          node_path=$(which node)
+          echo "Using Node.js: $node_path" >> "$GITHUB_STEP_SUMMARY"
+          echo "EMSDK_NODE=$node_path" >> "$GITHUB_ENV"
 
       - uses: lukka/get-cmake@latest
         with:
@@ -55,8 +68,6 @@ jobs:
         run: |
           git config --global --add safe.directory ${{ github.workspace }}
           git config --global --add safe.directory /__w/onnxruntime/onnxruntime
-          # "/emsdk/node/20.18.0_64bit/bin/..."
-          export EMSDK_NODE=$(which node)
           python3 ./tools/ci_build/build.py --allow_running_as_root --compile_no_warning_as_error \
             --build_dir ./build \
             --build_wasm \
@@ -65,6 +76,7 @@ jobs:
             --skip_submodule_sync \
             --enable_wasm_simd \
             --enable_wasm_threads \
+            --path_to_protoc_exe "${{ steps.protoc-detect.outputs.protoc_path }}" \
             --cmake_extra_defines "CMAKE_TOOLCHAIN_FILE:FILEPATH=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" \
             --cmake_extra_defines "VCPKG_TARGET_TRIPLET=wasm32-emscripten" \
             --cmake_extra_defines "VCPKG_INSTALLED_DIR:PATH=${{ github.workspace }}/.build"

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -3,19 +3,22 @@ name: WebAssembly
 on: [push]
 
 jobs:
-  Vcpkg:
+  linux-wasm:
+    name: WASM(Linux)
     runs-on: ubuntu-latest
     container:
       image: emscripten/emsdk:3.1.74
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: 'recursive'
 
       - name: "Run apt"
         run: |
           sudo apt update -y
           sudo apt install -y python3 pkg-config autoconf automake autoconf-archive file
+
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.31.0"
 
       - name: "Run vcpkg(wasm32-emscripten)"
         uses: lukka/run-vcpkg@v11.5
@@ -51,11 +54,17 @@ jobs:
       - name: "Run build.py"
         run: |
           git config --global --add safe.directory ${{ github.workspace }}
+          # "/emsdk/node/20.18.0_64bit/bin/..."
+          export EMSDK_NODE=$(which node)
           python3 ./tools/ci_build/build.py --allow_running_as_root \
             --build_dir ./build \
             --build_wasm \
+            --parallel \
+            --use_vcpkg \
             --skip_submodule_sync \
             --cmake_extra_defines "CMAKE_TOOLCHAIN_FILE:FILEPATH=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" \
             --cmake_extra_defines "VCPKG_TARGET_TRIPLET=wasm32-emscripten" \
             --cmake_extra_defines "VCPKG_INSTALLED_DIR:PATH=${{ github.workspace }}/.build"
         shell: bash
+        env:
+          VCPKG_INSTALLATION_ROOT: "/usr/local/share/vcpkg"

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -75,7 +75,15 @@ jobs:
           python3 onnxruntime/lora/adapter_format/compile_schema.py --flatc "$(which flatc)"
         shell: bash
 
+      - uses: actions/cache/restore@v4
+        with:
+          path: |
+            /emsdk/upstream/emscripten/cache/symbol_lists
+          key: "emscripten-${{ runner.os }}-${{ github.ref_name }}"
+          fail-on-cache-miss: false
+
       - name: "Run build.py"
+        id: run-build
         run: |
           python3 ./tools/ci_build/build.py --allow_running_as_root --compile_no_warning_as_error \
             --build_dir ./build \
@@ -92,3 +100,11 @@ jobs:
         env:
           VCPKG_INSTALLATION_ROOT: "/usr/local/share/vcpkg"
           VCPKG_KEEP_ENV_VARS: "EM_CONFIG;EMCC_CFLAGS"
+
+      - uses: actions/cache/save@v4
+        # change the condition to ${{ steps.run-build.outcome == 'success' }} when test passes
+        if: always()
+        with:
+          path: |
+            /emsdk/upstream/emscripten/cache/symbol_lists
+          key: "emscripten-${{ runner.os }}-${{ github.ref_name }}"

--- a/cmake/onnxruntime_webassembly.cmake
+++ b/cmake/onnxruntime_webassembly.cmake
@@ -93,7 +93,10 @@ if (NOT onnxruntime_ENABLE_WEBASSEMBLY_THREADS)
   set_property(TARGET re2 PROPERTY COMPILE_OPTIONS )
 endif()
 
-target_compile_options(onnx PRIVATE -Wno-unused-parameter -Wno-unused-variable)
+get_target_property(onnx_is_aliased onnx ALIASED_TARGET)
+if(NOT onnx_is_aliased)
+  target_compile_options(onnx PRIVATE -Wno-unused-parameter -Wno-unused-variable)
+endif()
 
 if (onnxruntime_BUILD_WEBASSEMBLY_STATIC_LIB)
     bundle_static_library(onnxruntime_webassembly


### PR DESCRIPTION
### Description

* Create `emscripten.yml` which runs WebAssembly build with GitHub Actions
   * Need more works to cover various WASM build options.  
     This is the minimal work based on [azure-pipelines/templates/linux-wasm-ci.yml](https://github.com/microsoft/onnxruntime/blob/main/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml)
* Change build.py to support both `--use_vcpkg` and `--build_wasm`
* When using vcpkg, the triplet [`wasm32-emscripten.cmake`](https://github.com/microsoft/vcpkg/blob/2025.01.13/triplets/community/wasm32-emscripten.cmake) will be used.
   * Because this triplet is using `VCPKG_CHAINLOAD_TOOLCHAIN_FILE`, we can't use `VCPKG_CXX_FLAGS` or `VCPKG_LINKER_FLAGS` to customize build details of the external libraries in vcpkg.json
   * I used `EMCC_CFLAGS` to apply [`emcc` compiler options](https://emscripten.org/docs/tools_reference/emcc.html) globally

Without `EMCC_CFLAGS` customization, we will get the linkage errors.

```log
2025-01-31T18:35:38.8323800Z [ 30%] Building CXX object CMakeFiles/onnxruntime_framework.dir/__w/onnxruntime/onnxruntime/onnxruntime/core/framework/stream_execution_context.cc.o
2025-01-31T18:35:38.9889222Z wasm-ld: error: --shared-memory is disallowed by gtest-all.cc.o because it was not compiled with 'atomics' or 'bulk-memory' features.
2025-01-31T18:35:39.0098272Z em++: error: '/emsdk/upstream/bin/wasm-ld @/tmp/emscripten_mgozcgg0.rsp.utf-8' failed (returned 1)
```

> [!WARNING]  
> Currently, `wasm32-emscripten` fails the unit test phase of build.py, with "out of memory" exception.

I guess it's kind of `onnxruntime_ENABLE_WEBASSEMBLY_MEMORY64` issue.

### Motivation and Context

I don't have a WASM experience. Feel free to advice :D

* Help #23158 

#### References

* https://hub.docker.com/r/emscripten/emsdk
* https://emscripten.org/docs/tools_reference/emcc.html
* https://github.com/emscripten-core/emscripten/blob/3.1.74/emcc.py
* https://emscripten.org/docs/tools_reference/settings_reference.html
* https://github.com/emscripten-core/emscripten/blob/3.1.74/tools/settings.py
