### PR TITLE
Fix all instances of 4244 and 4267 warnings in OV EP code

### DIFF
--- a/cmake/onnxruntime_providers_openvino.cmake
+++ b/cmake/onnxruntime_providers_openvino.cmake
@@ -53,7 +53,7 @@
   target_compile_definitions(onnxruntime_providers_openvino PRIVATE FILE_NAME=\"onnxruntime_providers_openvino.dll\")
 
   if(MSVC)
-    target_compile_options(onnxruntime_providers_openvino PUBLIC /wd4099 /wd4275 /wd4100 /wd4005 /wd4244 /wd4267)
+    target_compile_options(onnxruntime_providers_openvino PRIVATE /wd4099 /wd4275 /wd4100 /wd4005)
   endif()
 
   # Needed for the provider interface, as it includes training headers when training is enabled

--- a/onnxruntime/core/providers/openvino/backend_utils.cc
+++ b/onnxruntime/core/providers/openvino/backend_utils.cc
@@ -110,7 +110,7 @@ GetOutputTensor(Ort::KernelContext& context,
                 std::unordered_map<std::string, int> output_names,
                 std::shared_ptr<ov::Node> node) {
   // Find position of '/' in the output_name
-  int pos = output_name.find("/");
+  auto pos = output_name.find("/");
   // Copy the substring from start to pos
   output_name = output_name.substr(0, pos);
 

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -129,7 +129,7 @@ BasicBackend::BasicBackend(std::unique_ptr<ONNX_NAMESPACE::ModelProto>& model_pr
   } catch (const char* msg) {
     ORT_THROW(msg);
   }
-  int num_infer_req = (global_context_.num_of_threads > 0) ? global_context_.num_of_threads : 1;
+  size_t num_infer_req = (global_context_.num_of_threads > 0) ? global_context_.num_of_threads : 1;
   inferRequestsQueue_ = std::unique_ptr<InferRequestsQueue>(new InferRequestsQueue(exe_network_, num_infer_req));
 }
 
@@ -339,7 +339,7 @@ void BasicBackend::EnableStreams() {
 void BasicBackend::SetNumThreads(ov::AnyMap& device_config) {
   // inference_num_threads is applicable only for the CPU device
   if (global_context_.device_type.find("CPU") != std::string::npos)
-    device_config.emplace(ov::inference_num_threads(global_context_.num_of_threads));
+    device_config.emplace(ov::inference_num_threads(static_cast<int>(global_context_.num_of_threads)));
 }
 
 // Starts an asynchronous inference request for data in slice indexed by batch_slice_idx on

--- a/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
+++ b/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
@@ -148,7 +148,7 @@ struct OpenVINO_Provider : Provider {
       }
       if (deprecated_device_types.find(device_type) != deprecated_device_types.end()) {
         std::string deprecated_device = device_type;
-        int delimit = device_type.find("_");
+        auto delimit = device_type.find("_");
         device_type = deprecated_device.substr(0, delimit);
         precision = deprecated_device.substr(delimit + 1);
         LOGS_DEFAULT(WARNING) << "[OpenVINO] Selected 'device_type' " + deprecated_device + " is deprecated. \n"

--- a/onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc
+++ b/onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc
@@ -391,7 +391,7 @@ static bool CheckQRuleSet(const NodeUnit& node_unit,
 
 static bool HandleDoubleQDQ(onnxruntime::Graph& dst_graph, const onnxruntime::GraphViewer& src_graph,
                             const NodeUnit& node_unit, std::set<std::string>& initializers_to_keep) {
-  int node_unit_input_edge_count = node_unit.InputEdgeCount();
+  int node_unit_input_edge_count = static_cast<int>(node_unit.InputEdgeCount());
   int node_unit_output_edge_count = [&]() {
     int count = 0;
     for (auto it = node_unit.OutputEdgesBegin(); it != node_unit.OutputEdgesEnd(); ++it)


### PR DESCRIPTION
### Description
Remove MSVC warnings 4244, 4267 from the list of disabled warnings in cmake.
Fix the code that generates the warnings so that it no longer does.

### Motivation and Context
This makes onnxruntime_providers_openvino.dll pass BinSkim analysis.  Without this change BinSkim complains about the disabled warnings.
