### PR TITLE
[ROCm] Update rocm to 6.3.2

### DIFF
--- a/tools/ci_build/github/azure-pipelines/linux-rocm-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-rocm-ci-pipeline.yml
@@ -37,7 +37,7 @@ variables:
   - name: render
     value: 109
   - name: RocmVersion
-    value: 6.1.3
+    value: 6.3.2
 
 jobs:
 - job: Linux_Build
@@ -223,7 +223,7 @@ jobs:
           -e MKL_NUM_THREADS=1 \
           -e KERNEL_EXPLORER_BUILD_DIR=/build/Release \
           -e KERNEL_EXPLORER_BATCHED_GEMM_MAX_BATCH_SIZE=8 \
-          -e KERNEL_EXPLORER_TEST_USE_CUPY=1 \
+          -e KERNEL_EXPLORER_TEST_USE_CUPY=0 \
           -e CUPY_CACHE_DIR=/build/Release \
           onnxruntimerocm-cibuild-rocm$(RocmVersion) \
           /bin/bash -c "

--- a/tools/ci_build/github/linux/docker/rocm-ci-pipeline-env.Dockerfile
+++ b/tools/ci_build/github/linux/docker/rocm-ci-pipeline-env.Dockerfile
@@ -1,7 +1,7 @@
 # Refer to https://github.com/RadeonOpenCompute/ROCm-docker/blob/master/dev/Dockerfile-ubuntu-22.04-complete
 FROM ubuntu:22.04
 
-ARG ROCM_VERSION=6.1.3
+ARG ROCM_VERSION=6.3.2
 ARG AMDGPU_VERSION=${ROCM_VERSION}
 ARG APT_PREF='Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600'
 
@@ -88,13 +88,3 @@ RUN pip install packaging \
                 numpy==1.26.4
 
 RUN apt install -y git
-
-# Install Cupy to decrease CPU utilization
-# Note that the version of Cupy requires numpy < 1.27
-RUN git clone https://github.com/ROCm/cupy && cd cupy && \
-    git checkout 432a8683351d681e00903640489cb2f4055d2e09 && \
-    export CUPY_INSTALL_USE_HIP=1 && \
-    export ROCM_HOME=/opt/rocm && \
-    export HCC_AMDGPU_TARGET=gfx906,gfx908,gfx90a && \
-    git submodule update --init && \
-    pip install -e . --no-cache-dir -vvvv


### PR DESCRIPTION
### Description
* Update rocm to 6.3.2;
* Remove dependency on cupy (which does not support rocm 6.3 yet).

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


