### PR TITLE
Missing datatype in assertion

### DIFF
--- a/onnxruntime/python/tools/quantization/base_quantizer.py
+++ b/onnxruntime/python/tools/quantization/base_quantizer.py
@@ -41,7 +41,7 @@ class QuantizationParams:
         for k, v in data.items():
             if not isinstance(k, str):
                 raise TypeError(f"Keys must be strings not {type(k)} for k={k!r}.")
-            if k != "axis" and not isinstance(v, (int, str, np.ndarray)):
+            if k != "axis" and not isinstance(v, (int, str, np.ndarray, float)):
                 raise TypeError(f"Values must be numpy arrays, int, float, str not {type(v)} for k={k!r}.")
             if k == "axis" and not isinstance(v, int) and v is not None:
                 raise TypeError(f"Axis value must be an int or None, not {type(v)}.")


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Adds float to the list of accepted dtypes for this assertion

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
When passing `TensorQuantOverrides` through `quantize_static`'s `extra_options`, any values of the dictionary that are floats are rejected. 
A simple workaround is to use numpy arrays to contain these floats, but this is a more correct fix.
