### PR TITLE
[webgpu/js] Optimize resize webgpu op & fix precision issues

### DIFF
--- a/js/web/lib/wasm/jsep/webgpu/ops/resize.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/resize.ts
@@ -770,9 +770,7 @@ const createResizeProgramInfo = (
     shaderCache: {
       hint: `${attributes.cacheKey}|${opsetVersion}|${
         scales.length > 0 ? (attributes.mode === 'cubic' ? scales : scales.length) : ''
-      }|${
-        sizes.length > 0 ? sizes : ''
-      }|${roi.length > 0 ? roi : ''}|${noScale}|${
+      }|${sizes.length > 0 ? sizes : ''}|${roi.length > 0 ? roi : ''}|${noScale}|${
         attributes.mode === 'nearest' ? inputShape.length : inputShape
       }`,
       inputDependencies: ['rank'],


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

This PR is a follow-up to https://github.com/microsoft/onnxruntime/pull/23488 and partially improves upon https://github.com/microsoft/onnxruntime/issues/23403. It does the following:
- Prevents unnecessary cache shader recompilation for 'nearest' resize operation.
- Fixes precision (offset-by-one) errors with asymmetric coordinate transform. When running the Kokoro TTS model, values for the `/decoder/decoder/generator/f0_upsamp/Resize_output_0` results in differences at the end bounds due to precision issues when dividing 21600 by 72 (should be 300, but seemingly results in 299.999, which causes issues when flooring)

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

I did a deep dive over the weekend to try fix Kokoro TTS on WebGPU and found that the above node had a large difference. Thinking this was a major issue, I spent some time fixing it. Turns out, it only happens for a small number of values, leading to high maximum error, but most values are correct (as seen here).

BEFORE:
```
[/decoder/decoder/generator/f0_upsamp/Resize_output_0] atol: 78.6640682220459 | rtol: 24.13991587587724 | avgDiff: 0.009967932171121087 | medianDiff: 0.000030517578125
```

AFTER:
```
[/decoder/decoder/generator/f0_upsamp/Resize_output_0] atol: 0.0011138916015625 | rtol: 0.0020059924232260704 | avgDiff: 0.00008570214675873825 | medianDiff: 0.000030517578125
```

So, although it has a very small impact on the final output (waveform), this bug could appear with other models in a more severe way.

BEFORE:
```
[waveform] atol: 0.04784199967980385 | rtol: 1366.0462001093495 | avgDiff: 0.0009544936942737713 | medianDiff: 0.00015346752479672432
```

AFTER:
```
[waveform] atol: 0.04775865003466606 | rtol: 1354.7002460360852 | avgDiff: 0.000954830244055033 | medianDiff: 0.00015274062752723694
```