### PR TITLE
[CUDA] Fix BeamSearchTest.DummyT5WithSequenceInputIds test failure in Windows

### DIFF
--- a/onnxruntime/contrib_ops/cpu/transformers/generation_shared.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/generation_shared.h
@@ -8,7 +8,7 @@
 #include <gsl/gsl>
 #include "core/framework/allocator.h"
 #include "core/framework/ort_value.h"
-#include "contrib_ops/cpu/utils/debug_macros.h"
+#include "contrib_ops/cpu/utils/console_dumper.h"
 
 namespace onnxruntime {
 

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_cuda_impl.h
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_cuda_impl.h
@@ -6,6 +6,8 @@
 #include <stdint.h>
 #include <cuda_fp16.h>
 #include <curand_kernel.h>
+#include <cstdio>
+#include "contrib_ops/cpu/transformers/generation_shared.h"
 
 namespace onnxruntime {
 namespace contrib {
@@ -49,6 +51,21 @@ struct HypothesisScore {
   const int32_t* hypothesis;
   int hypothesis_length;
   float score;
+
+#ifdef DEBUG_GENERATION
+  __device__ void Print() const {
+    printf("HypothesisScore (hypothesis_length=%d, score=%f) \n", hypothesis_length, score);
+    printf("  hypothesis:");
+    if (hypothesis_length > 0 && hypothesis != NULL) {
+        for (int i = 0; i < hypothesis_length; ++i) {
+            printf("%d ", hypothesis[i]);
+        }
+    } else {
+        printf("(empty)");
+    }
+    printf("\n");
+}
+#endif
 };
 
 struct BeamHypotheses {
@@ -71,6 +88,22 @@ struct BeamHypotheses {
                          int pad_token_id,      // pad token
                          int32_t* sequences,    // buffer with pad token, shape (num_return_sequences, max_length)
                          T* sequences_scores);  // buffer for sequence scores, with shape (num_return_sequences)
+
+#ifdef DEBUG_GENERATION
+  __device__ void Print() const {
+    printf("BeamHypotheses:\n");
+    printf("  beams_count: %d\n", beams_count_);
+    printf("  beams_used: %d\n", beams_used_);
+    printf("  length_penalty: %f\n", length_penalty_);
+    printf("  done: %s\n", done_ ? "true" : "false");
+
+    printf("  beams:\n");
+    for (int i = 0; i < beams_used_; ++i) {
+        printf("    Beam %d:\n", i + 1);
+        beams_[i].Print();
+    }
+  }
+#endif
 };
 
 struct BeamScorerState {
@@ -82,8 +115,22 @@ struct BeamScorerState {
   int eos_token_id_;
   bool early_stopping_;
   int not_done_count_;  // When zero, every batch entry is done (starts at batch_size_)
-
   int hypothesis_buffer_used_;  // Offset of available buffer, or length of used buffer.
+
+#ifdef DEBUG_GENERATION
+  __host__ __device__ void Print(bool is_cpu) const {
+    printf("BeamScorerState (cpu=%d) Dump:\n", is_cpu ? 1 : 0);
+    printf("  batch_size_: %d\n", batch_size_);
+    printf("  num_beams_: %d\n", num_beams_);
+    printf("  max_length_: %d\n", max_length_);
+    printf("  num_return_sequences_: %d\n", num_return_sequences_);
+    printf("  pad_token_id_: %d\n", pad_token_id_);
+    printf("  eos_token_id_: %d\n", eos_token_id_);
+    printf("  early_stopping_: %s\n", early_stopping_ ? "true" : "false");
+    printf("  not_done_count_: %d\n", not_done_count_);
+    printf("  hypothesis_buffer_used_: %d\n", hypothesis_buffer_used_);
+  }
+#endif
 };
 
 void LaunchInitializeBeamHypotheses(gsl::span<BeamHypotheses> beam_hyps, float length_penalty, gsl::span<HypothesisScore> beams, int num_beams, cudaStream_t stream);

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_cuda_impl.h
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_cuda_impl.h
@@ -57,14 +57,14 @@ struct HypothesisScore {
     printf("HypothesisScore (hypothesis_length=%d, score=%f) \n", hypothesis_length, score);
     printf("  hypothesis:");
     if (hypothesis_length > 0 && hypothesis != NULL) {
-        for (int i = 0; i < hypothesis_length; ++i) {
-            printf("%d ", hypothesis[i]);
-        }
+      for (int i = 0; i < hypothesis_length; ++i) {
+        printf("%d ", hypothesis[i]);
+      }
     } else {
-        printf("(empty)");
+      printf("(empty)");
     }
     printf("\n");
-}
+  }
 #endif
 };
 
@@ -99,8 +99,8 @@ struct BeamHypotheses {
 
     printf("  beams:\n");
     for (int i = 0; i < beams_used_; ++i) {
-        printf("    Beam %d:\n", i + 1);
-        beams_[i].Print();
+      printf("    Beam %d:\n", i + 1);
+      beams_[i].Print();
     }
   }
 #endif
@@ -114,7 +114,7 @@ struct BeamScorerState {
   int pad_token_id_;
   int eos_token_id_;
   bool early_stopping_;
-  int not_done_count_;  // When zero, every batch entry is done (starts at batch_size_)
+  int not_done_count_;          // When zero, every batch entry is done (starts at batch_size_)
   int hypothesis_buffer_used_;  // Offset of available buffer, or length of used buffer.
 
 #ifdef DEBUG_GENERATION

--- a/onnxruntime/test/contrib_ops/beam_search_test.cc
+++ b/onnxruntime/test/contrib_ops/beam_search_test.cc
@@ -423,9 +423,6 @@ TEST(BeamSearchTest, DummyT5WithOuterScopeInitializers) {
 }
 
 TEST(BeamSearchTest, DummyT5WithSequenceInputIds) {
-#if defined(USE_CUDA) && defined(USE_DML)
-  SKIP_CUDA_TEST_WITH_DML;
-#endif
   // dummy_t5_with_sequence_input_ids.onnx model generated using following command:
   // python onnxruntime/test/testdata/dummy_t5_generator.py --output-path dummy_t5_with_sequence_input_ids.onnx --sequence-as-input
   ModelTester tester(CurrentTestName(), ORT_TSTR("testdata/dummy_t5_with_sequence_input_ids.onnx"));


### PR DESCRIPTION
### Description
BeamSearchTest.DummyT5WithSequenceInputIds failed in Windows due to early stopping triggered. The cause is state.early_stopping_ is interpreted as true in cuda kernel at some point, however printf still show its value is false. The root cause is unknown.

Update the code to use early_stopping as template parameter seems walk around the issue.

Other changes: 
* Add some debug code (will not be built into binary unless DEBUG_GENERATION is fined) to assist debugging beam search scorer in CUDA.
* Enable DummyT5WithSequenceInputIds test in CI. This test was not run in Windows CUDA CI pipeline previously.

### Motivation and Context

Fix a unit test BeamSearchTest.DummyT5WithSequenceInputIds failure in Windows. 


