### PR TITLE
Add python_requires to package metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -784,6 +784,7 @@ setup(
     download_url="https://github.com/microsoft/onnxruntime/tags",
     data_files=data_files,
     install_requires=install_requires,
+    python_requires=">=3.10",
     keywords="onnx machine learning",
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Support for python 3.8 and python 3.9 was dropped at 1.20.  Declare the 3.10 requirement in metadata

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Helps solvers like uv and poetry to build accurate solutions eg see https://github.com/python-poetry/poetry/issues/10151, https://github.com/astral-sh/uv/issues/11274

