### PR TITLE
Remove net8.0-android MAUI target for patch release

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.MAUI/Microsoft.ML.OnnxRuntime.Tests.MAUI.csproj
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.MAUI/Microsoft.ML.OnnxRuntime.Tests.MAUI.csproj
@@ -7,7 +7,9 @@
 
     <!-- General app properties -->
     <PropertyGroup>
-        <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+        <!-- TODO: Add net8.0-android target back in once IndexOutOfRangeException for MAUI net8.0-android issue is
+        resolved. -->
+        <TargetFrameworks>net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
         <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
 
         <!-- Note for MacCatalyst:


### PR DESCRIPTION
### Description
Removing net8.0-android target from the MAUI test project. This test is not currently being run in the pipelines, but build issues is blocking the patch release.

[Pipeline run](https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=674060&view=results) (Still running into unrelated Failure to get the "onnxruntimepackagetest" image errors)


