### PR TITLE
Fix for C4267 warning

### DIFF
--- a/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
+++ b/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
@@ -148,7 +148,7 @@ std::string ParsePrecision(const ProviderOptions& provider_options, std::string&
                             << "Update the 'device_type' to specified types 'CPU', 'GPU', 'GPU.0', "
                             << "'GPU.1', 'NPU' or from"
                             << " HETERO/MULTI/AUTO options and set 'precision' separately. \n";
-      int delimit = device_type.find("_");
+      auto delimit = device_type.find("_");
       device_type = device_type.substr(0, delimit);
       return device_type.substr(delimit + 1);
     }

--- a/onnxruntime/core/providers/openvino/ov_interface.cc
+++ b/onnxruntime/core/providers/openvino/ov_interface.cc
@@ -233,7 +233,7 @@ void OVInferRequest::SetTensor(const std::string& name, OVTensorPtr& blob) {
 }
 
 uint32_t OVInferRequest::GetNumInputs() {
-  return ovInfReq.get_compiled_model().inputs().size();
+  return static_cast<uint32_t>(ovInfReq.get_compiled_model().inputs().size());
 }
 
 void OVInferRequest::StartAsync() {


### PR DESCRIPTION
### Description
A recent [commit](https://github.com/microsoft/onnxruntime/commit/1fce51b3b25b369f5e0486cf3223e5caa53e44bd) is causing an OVEP warning in [openvino_provider_factory.cc](https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/providers/openvino/openvino_provider_factory.cc#L151). This PR fixes the warning.

### Motivation and Context
Minor fix


