### PR TITLE
[QNN EP] Add QNN EP to ARM64X build targets

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1929,5 +1929,12 @@ endif()
 
 if(DEFINED BUILD_AS_ARM64X)
   set(ARM64X_TARGETS onnxruntime)
+
+  # Add additional ARM64X build targets
+  if (onnxruntime_USE_QNN AND NOT onnxruntime_BUILD_QNN_EP_STATIC_LIB)
+    list(APPEND ARM64X_TARGETS onnxruntime_providers_shared)
+    list(APPEND ARM64X_TARGETS onnxruntime_providers_qnn)
+  endif()
+
   include("${CMAKE_CURRENT_SOURCE_DIR}/arm64x.cmake")
 endif()


### PR DESCRIPTION
### Description
Currently when we build with --buildasx, only the onnxruntime.dll is built as ARM64X binary.

This change addresses the above issue by adding onnxruntime_provider_shared and
onnxruntime_provider_qnn targets to the ARM64X_TARGETS build target list.

### Motivation and Context
For QNN EP which supports ARM64, --buildasx does not build the EP dll' such as onnxruntime_provider_shared.dll and onnxruntime_provider_qnn.dll as ARM64X binary.


