### PR TITLE
Update upload pages artifact action version

### DIFF
--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -117,7 +117,7 @@ jobs:
           sudo mv ./build/* ./_site
 
       - name: Upload site
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           retention-days: 21
 


### PR DESCRIPTION
Current publish is failing due to use of deprecated action version