### PR TITLE
[webgpu] Fix MatMulNBits prefill shader synchronization

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.cc
@@ -206,6 +206,7 @@ Status MatMulNBitsProgram::GenerateShaderCode(ShaderHelper& shader) const {
       shader.MainFunctionBody() << "        word_offset += " << 8 / a.NumComponents() << ";\n";
       shader.MainFunctionBody() << "      }\n";
       shader.MainFunctionBody() << "    }\n";
+      shader.MainFunctionBody() << "    workgroupBarrier();\n";
 
       shader.MainFunctionBody() << "  }\n";
       shader.MainFunctionBody() << "  if (local_idx < " << WorkgroupSizeY() * tile_m_ << ") {\n"


### PR DESCRIPTION
### Description
This commit adds a `workgroupBarrier` to the MatMulNBits prefill shader to ensure proper synchronization between workgroup invocations, resolving a potential race condition.

### Motivation and Context
See above.

