### PR TITLE
[ARM CPU] add notrans hgemm mlas kernel 

### DIFF
--- a/onnxruntime/core/mlas/lib/halfgemm.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm.cpp
@@ -430,7 +430,7 @@ HGemmOperation(
             }
             // When M is small, B is visited once. The overhead of Pack(B) exceeds the benefits
             // from A x Pack(B). Therefore directly calculate A x B.
-            // Iterate full K.
+            // Iterate full K. max 8 accumulators.
             constexpr size_t StrideN = 64;
             for (size_t n = 0, countN; n < RangeCountN; n += countN) {
                 countN = std::min(StrideN, RangeCountN - n);

--- a/onnxruntime/core/mlas/lib/halfgemm.h
+++ b/onnxruntime/core/mlas/lib/halfgemm.h
@@ -524,6 +524,14 @@ void HPackB_TransposedB_Kernel(
     size_t ldb
 );
 
+void HPackB_B_Kernel(
+    const MLAS_FP16* B,
+    MLAS_FP16* PackedB,
+    size_t CountN,
+    size_t CountK,
+    size_t ldb
+);
+
 void HGemm_TransposedB_Kernel(
     const MLAS_FP16* A,
     const MLAS_FP16* B,
@@ -538,7 +546,21 @@ void HGemm_TransposedB_Kernel(
     _mlas_fp16_ beta
 );
 
-void HGemm_TransposedPackedB_Kernel(
+void HGemm_B_Kernel(
+    const MLAS_FP16* A,
+    const MLAS_FP16* B,
+    MLAS_FP16* C,
+    size_t CountM,
+    size_t CountN,
+    size_t CountK,
+    size_t lda,
+    size_t ldb,
+    size_t ldc,
+    _mlas_fp16_ alpha,
+    _mlas_fp16_ beta
+);
+
+void HGemm_PackedB_Kernel(
     const MLAS_FP16* A,
     const MLAS_FP16* PackedB,
     MLAS_FP16* C,
@@ -563,6 +585,7 @@ struct MLAS_HGEMM_DISPATCH {
      * @param[out] PackedB             the first element of the packed B matrix segment.
      * @param      CountN              the number of columns of B chunk.
      * @param      CountK              the number of rows of B chunk.
+     * @param      ldb                 the leading dimension of B.
      */
     typedef void(HPackBKernel_TransposedB_Fn) (
         const MLAS_FP16* B,
@@ -573,6 +596,27 @@ struct MLAS_HGEMM_DISPATCH {
     );
 
     HPackBKernel_TransposedB_Fn* HPackBKernel_TransposedB = nullptr;
+
+    /**
+     * @brief Pack the B matrix segment. B is row-major. Elements from CountK rows x N columns are packed
+     *        continuously in row-major.
+     *        First pack CountK rows x 16 columns, then pack CountK rows x 8 columns.
+     *        If there are < 8 columns left, pad the columns with 0.
+     * @param      B                   the first element of the B matrix segment. Row major.
+     * @param[out] PackedB             the first element of the packed B matrix segment.
+     * @param      CountN              the number of columns of B chunk.
+     * @param      CountK              the number of rows of B chunk.
+     * @param      ldb                 the leading dimension of B.
+     */
+    typedef void(HPackBKernel_B_Fn) (
+        const MLAS_FP16* B,
+        MLAS_FP16* PackedB,
+        size_t CountN,
+        size_t CountK,
+        size_t ldb
+    );
+
+    HPackBKernel_B_Fn* HPackBKernel_B = nullptr;
 
     /**
      * @brief C = alpha * A * Transpose(B) + beta * C. CountM <= 2. B is not packed. Used when M is small.
@@ -605,9 +649,40 @@ struct MLAS_HGEMM_DISPATCH {
 
     HGemmKernel_TransposedB_Fn* HGemmKernel_TransposedB = nullptr;
 
-     /**
-     * @brief C = alpha * A * Transpose(B) + beta * C. CountM <= 2. B has been packed using HPackBKernel_TransposedB_Fn.
-     *        Use when M is large.
+    /**
+     * @brief C = alpha * A * B + beta * C. CountM <= 2. B is not packed. Used when M is small.
+     *
+     * @param       A                   first row of the A matrix segment. Row major.
+     * @param       B                   first row of the B matrix segment. Row major.
+     * @param[out]  C                   first element of the output matrix segment. Row major.
+     * @param       CountM              the number of rows of A chunk.
+     * @param       CountN              the number of columns of B chunk.
+     * @param       CountK              the number of columns of A chunk and the number of rows of B chunk.
+     * @param       lda                 the leading dimension of A.
+     * @param       ldb                 the leading dimension of B.
+     * @param       ldc                 the leading dimension of C.
+     * @param       alpha               the alpha scalar value.
+     * @param       beta                the beta scalar value.
+     */
+    typedef void(HGemmKernel_B_Fn)(
+        const MLAS_FP16* A,
+        const MLAS_FP16* B,
+        MLAS_FP16* C,
+        size_t CountM,
+        size_t CountN,
+        size_t CountK,
+        size_t lda,
+        size_t ldb,
+        size_t ldc,
+        _mlas_fp16_ alpha,
+        _mlas_fp16_ beta
+    );
+
+    HGemmKernel_B_Fn* HGemmKernel_B = nullptr;
+
+    /**
+     * @brief C = alpha * A * Transpose(B) + beta * C. CountM <= 2. B has been packed using
+     *        HPackBKernel_TransposedB_Fn or HPackBKernel_B_Fn. Use when M is large.
      *
      * @param       A                   first row of the A matrix segment. Row major.
      * @param       PackedB             first element of the packed B buffer.
@@ -620,7 +695,7 @@ struct MLAS_HGEMM_DISPATCH {
      * @param       alpha               the alpha scalar value.
      * @param       beta                the beta scalar value.
      */
-    typedef void(HGemmKernel_TransposedPackedB_Fn)(
+    typedef void(HGemmKernel_PackedB_Fn)(
         const MLAS_FP16* A,
         const MLAS_FP16* PackedB,
         MLAS_FP16* C,
@@ -633,5 +708,5 @@ struct MLAS_HGEMM_DISPATCH {
         _mlas_fp16_ beta
     );
 
-    HGemmKernel_TransposedPackedB_Fn* HGemmKernel_TransposedPackedB = nullptr;
+    HGemmKernel_PackedB_Fn* HGemmKernel_PackedB = nullptr;
 };

--- a/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
@@ -303,6 +303,169 @@ void HPackB_TransposedB_Kernel(
     }
 }
 
+void HPackB_B_Kernel(
+    const MLAS_FP16* B,
+    MLAS_FP16* PackedB,
+    size_t CountN,
+    size_t CountK,
+    size_t ldb
+) {
+    const _mlas_fp16_* B_data = reinterpret_cast<const _mlas_fp16_*>(B);
+    _mlas_fp16_* PackedB_data = reinterpret_cast<_mlas_fp16_*>(PackedB);
+    const size_t ldb8 = ldb * 8;
+
+    for (; CountN >= 16; CountN -= 16, B_data += 16) {
+        const _mlas_fp16_* b = B_data;
+        size_t k = CountK;
+        constexpr size_t step = 8 * 16; // pack 8 * 16
+        for (; k >= 8; k -= 8, b += ldb8, PackedB_data += step) {
+            float16x8_t v0 = MlasLoadFloat16x8(b);
+            float16x8_t v1 = MlasLoadFloat16x8(b + 8);
+            float16x8_t v2 = MlasLoadFloat16x8(b + ldb);
+            float16x8_t v3 = MlasLoadFloat16x8(b + ldb + 8);
+            float16x8_t v4 = MlasLoadFloat16x8(b + 2 * ldb);
+            float16x8_t v5 = MlasLoadFloat16x8(b + 2 * ldb + 8);
+            float16x8_t v6 = MlasLoadFloat16x8(b + 3 * ldb);
+            float16x8_t v7 = MlasLoadFloat16x8(b + 3 * ldb + 8);
+            float16x8_t v8 = MlasLoadFloat16x8(b + 4 * ldb);
+            float16x8_t v9 = MlasLoadFloat16x8(b + 4 * ldb + 8);
+            float16x8_t vA = MlasLoadFloat16x8(b + 5 * ldb);
+            float16x8_t vB = MlasLoadFloat16x8(b + 5 * ldb + 8);
+            float16x8_t vC = MlasLoadFloat16x8(b + 6 * ldb);
+            float16x8_t vD = MlasLoadFloat16x8(b + 6 * ldb + 8);
+            float16x8_t vE = MlasLoadFloat16x8(b + 7 * ldb);
+            float16x8_t vF = MlasLoadFloat16x8(b + 7 * ldb + 8);
+
+            MlasStoreFloat16x8(PackedB_data, v0);
+            MlasStoreFloat16x8(PackedB_data + 8, v1);
+            MlasStoreFloat16x8(PackedB_data + 16, v2);
+            MlasStoreFloat16x8(PackedB_data + 24, v3);
+            MlasStoreFloat16x8(PackedB_data + 32, v4);
+            MlasStoreFloat16x8(PackedB_data + 40, v5);
+            MlasStoreFloat16x8(PackedB_data + 48, v6);
+            MlasStoreFloat16x8(PackedB_data + 56, v7);
+            MlasStoreFloat16x8(PackedB_data + 64, v8);
+            MlasStoreFloat16x8(PackedB_data + 72, v9);
+            MlasStoreFloat16x8(PackedB_data + 80, vA);
+            MlasStoreFloat16x8(PackedB_data + 88, vB);
+            MlasStoreFloat16x8(PackedB_data + 96, vC);
+            MlasStoreFloat16x8(PackedB_data + 104, vD);
+            MlasStoreFloat16x8(PackedB_data + 112, vE);
+            MlasStoreFloat16x8(PackedB_data + 120, vF);
+        }
+
+        if (k & 4) {
+            float16x8_t v0 = MlasLoadFloat16x8(b);
+            float16x8_t v1 = MlasLoadFloat16x8(b + 8);
+            float16x8_t v2 = MlasLoadFloat16x8(b + ldb);
+            float16x8_t v3 = MlasLoadFloat16x8(b + ldb + 8);
+            float16x8_t v4 = MlasLoadFloat16x8(b + 2 * ldb);
+            float16x8_t v5 = MlasLoadFloat16x8(b + 2 * ldb + 8);
+            float16x8_t v6 = MlasLoadFloat16x8(b + 3 * ldb);
+            float16x8_t v7 = MlasLoadFloat16x8(b + 3 * ldb + 8);
+            MlasStoreFloat16x8(PackedB_data, v0);
+            MlasStoreFloat16x8(PackedB_data + 8, v1);
+            MlasStoreFloat16x8(PackedB_data + 16, v2);
+            MlasStoreFloat16x8(PackedB_data + 24, v3);
+            MlasStoreFloat16x8(PackedB_data + 32, v4);
+            MlasStoreFloat16x8(PackedB_data + 40, v5);
+            MlasStoreFloat16x8(PackedB_data + 48, v6);
+            MlasStoreFloat16x8(PackedB_data + 56, v7);
+
+            b += 4 * ldb, PackedB_data += 4 * 16;
+        }
+
+        if (k & 2) {
+            float16x8_t v0 = MlasLoadFloat16x8(b);
+            float16x8_t v1 = MlasLoadFloat16x8(b + 8);
+            float16x8_t v2 = MlasLoadFloat16x8(b + ldb);
+            float16x8_t v3 = MlasLoadFloat16x8(b + ldb + 8);
+            MlasStoreFloat16x8(PackedB_data, v0);
+            MlasStoreFloat16x8(PackedB_data + 8, v1);
+            MlasStoreFloat16x8(PackedB_data + 16, v2);
+            MlasStoreFloat16x8(PackedB_data + 24, v3);
+
+            b += 2 * ldb, PackedB_data += 2 * 16;
+        }
+
+        if (k & 1) {
+            float16x8_t v0 = MlasLoadFloat16x8(b);
+            float16x8_t v1 = MlasLoadFloat16x8(b + 8);
+            MlasStoreFloat16x8(PackedB_data, v0);
+            MlasStoreFloat16x8(PackedB_data + 8, v1);
+
+            PackedB_data += 16;
+        }
+    }
+
+    if (CountN & 8) {
+        const _mlas_fp16_* b = B_data;
+        size_t k = CountK;
+        constexpr size_t step = 8 * 8; // pack 8 * 8
+        for (; k >= 8; k -= 8, b += ldb8, PackedB_data += step) {
+            float16x8_t v0 = MlasLoadFloat16x8(b);
+            float16x8_t v1 = MlasLoadFloat16x8(b + ldb);
+            float16x8_t v2 = MlasLoadFloat16x8(b + 2 * ldb);
+            float16x8_t v3 = MlasLoadFloat16x8(b + 3 * ldb);
+            float16x8_t v4 = MlasLoadFloat16x8(b + 4 * ldb);
+            float16x8_t v5 = MlasLoadFloat16x8(b + 5 * ldb);
+            float16x8_t v6 = MlasLoadFloat16x8(b + 6 * ldb);
+            float16x8_t v7 = MlasLoadFloat16x8(b + 7 * ldb);
+
+            MlasStoreFloat16x8(PackedB_data, v0);
+            MlasStoreFloat16x8(PackedB_data + 8, v1);
+            MlasStoreFloat16x8(PackedB_data + 16, v2);
+            MlasStoreFloat16x8(PackedB_data + 24, v3);
+            MlasStoreFloat16x8(PackedB_data + 32, v4);
+            MlasStoreFloat16x8(PackedB_data + 40, v5);
+            MlasStoreFloat16x8(PackedB_data + 48, v6);
+            MlasStoreFloat16x8(PackedB_data + 56, v7);
+        }
+
+        if (k & 4) {
+            float16x8_t v0 = MlasLoadFloat16x8(b);
+            float16x8_t v1 = MlasLoadFloat16x8(b + ldb);
+            float16x8_t v2 = MlasLoadFloat16x8(b + 2 * ldb);
+            float16x8_t v3 = MlasLoadFloat16x8(b + 3 * ldb);
+            MlasStoreFloat16x8(PackedB_data, v0);
+            MlasStoreFloat16x8(PackedB_data + 8, v1);
+            MlasStoreFloat16x8(PackedB_data + 16, v2);
+            MlasStoreFloat16x8(PackedB_data + 24, v3);
+            b += 4 * ldb, PackedB_data += 4 * 8;
+        }
+
+        if (k & 2) {
+            float16x8_t v0 = MlasLoadFloat16x8(b);
+            float16x8_t v1 = MlasLoadFloat16x8(b + ldb);
+            MlasStoreFloat16x8(PackedB_data, v0);
+            MlasStoreFloat16x8(PackedB_data + 8, v1);
+            b += 2 * ldb, PackedB_data += 2 * 8;
+        }
+
+        if (k & 1) {
+            float16x8_t v0 = MlasLoadFloat16x8(b);
+            MlasStoreFloat16x8(PackedB_data, v0);
+            PackedB_data += 8;
+        }
+
+        B_data += 8;
+        CountN -= 8;
+    }
+
+    // TODO
+    if (CountN == 7) {
+        const _mlas_fp16_* b = B_data;
+        for (size_t i = 0; i < CountK; ++i, b += ldb, PackedB_data += 8) {
+            float16x4_t v0 = MlasLoadFloat16x4(b);
+            float16x4_t v1 = MlasLoadPartialFloat16x4(b + 4, 3);
+            MlasStoreFloat16x4(PackedB_data, v0);
+            MlasStoreFloat16x4(PackedB_data + 4, v1);
+        }
+    } else {
+
+    }
+}
+
 MLAS_FORCEINLINE
 float16x8_t addq_f16x4(float16x8_t v0, float16x8_t v1, float16x8_t v2, float16x8_t v3) {
     v0 = vaddq_f16(v0, v1);
@@ -972,7 +1135,7 @@ void HGemm_TransposedB_Kernel(
 }
 
 template <int beta_behavior> // 0: beta == 0, 1: beta == 1, 2: beta != 0 && beta != 1
-void HGemm_TransposedPackedB_Kernel_M1(
+void HGemm_PackedB_Kernel_M1(
     const _mlas_fp16_* A,
     const _mlas_fp16_* PackedB,
     _mlas_fp16_* C,
@@ -1216,7 +1379,7 @@ void HGemm_TransposedPackedB_Kernel_M1(
 }
 
 template <int beta_behavior> // 0: beta == 0, 1: beta == 1, 2: beta != 0 && beta != 1
-void HGemm_TransposedPackedB_Kernel_M2(
+void HGemm_PackedB_Kernel_M2(
     const _mlas_fp16_* A,
     const _mlas_fp16_* PackedB,
     _mlas_fp16_* C,
@@ -1529,7 +1692,7 @@ void HGemm_TransposedPackedB_Kernel_M2(
     }
 }
 
-void HGemm_TransposedPackedB_Kernel(
+void HGemm_PackedB_Kernel(
     const MLAS_FP16* A,
     const MLAS_FP16* PackedB,
     MLAS_FP16* C,
@@ -1542,7 +1705,7 @@ void HGemm_TransposedPackedB_Kernel(
     _mlas_fp16_ beta
 ) {
     if (CountM > 2) {
-        MLAS_THROW_EX(std::runtime_error, "HGemm_TransposedPackedB_Kernel only support <= 2 rows");
+        MLAS_THROW_EX(std::runtime_error, "HGemm_PackedB_Kernel only support <= 2 rows");
     }
 
     const auto* A_data = reinterpret_cast<const _mlas_fp16_*>(A);
@@ -1552,19 +1715,19 @@ void HGemm_TransposedPackedB_Kernel(
     const auto f16_1 = MLAS_FP16(1.0f);
     if (CountM == 1) {
         if (beta == f16_0.val) {
-            HGemm_TransposedPackedB_Kernel_M1<0>(A_data, PackedB_data, C_data, CountN, CountK, alpha, beta);
+            HGemm_PackedB_Kernel_M1<0>(A_data, PackedB_data, C_data, CountN, CountK, alpha, beta);
         } else if (beta == f16_1.val) {
-            HGemm_TransposedPackedB_Kernel_M1<1>(A_data, PackedB_data, C_data, CountN, CountK, alpha, beta);
+            HGemm_PackedB_Kernel_M1<1>(A_data, PackedB_data, C_data, CountN, CountK, alpha, beta);
         } else {
-            HGemm_TransposedPackedB_Kernel_M1<2>(A_data, PackedB_data, C_data, CountN, CountK, alpha, beta);
+            HGemm_PackedB_Kernel_M1<2>(A_data, PackedB_data, C_data, CountN, CountK, alpha, beta);
         }
     } else {
         if (beta == f16_0.val) {
-            HGemm_TransposedPackedB_Kernel_M2<0>(A_data, PackedB_data, C_data, CountN, CountK, lda, ldc, alpha, beta);
+            HGemm_PackedB_Kernel_M2<0>(A_data, PackedB_data, C_data, CountN, CountK, lda, ldc, alpha, beta);
         } else if (beta == f16_1.val) {
-            HGemm_TransposedPackedB_Kernel_M2<1>(A_data, PackedB_data, C_data, CountN, CountK, lda, ldc, alpha, beta);
+            HGemm_PackedB_Kernel_M2<1>(A_data, PackedB_data, C_data, CountN, CountK, lda, ldc, alpha, beta);
         } else {
-            HGemm_TransposedPackedB_Kernel_M2<2>(A_data, PackedB_data, C_data, CountN, CountK, lda, ldc, alpha, beta);
+            HGemm_PackedB_Kernel_M2<2>(A_data, PackedB_data, C_data, CountN, CountK, lda, ldc, alpha, beta);
         }
     }
 }

--- a/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
@@ -380,7 +380,7 @@ void HPackB_B_Kernel_Last8(
         }
 
         if (CountK & 1) {
-            float16x4_t v0 = MlasLoadPartialFloat16x4(B, CountN);
+            float16x4_t v0 = MlasLoadFloat16x4(B);
             float16x4_t v1 = MlasLoadPartialFloat16x4(B + 4, CountN - 4);
             MlasStoreFloat16x4(PackedB, v0);
             MlasStoreFloat16x4(PackedB + 4, v1);
@@ -411,9 +411,9 @@ void HPackB_B_Kernel_Last8(
             float16x4_t v2 = MlasLoadPartialFloat16x4(B + 2 * ldb, CountN);
             float16x4_t v3 = MlasLoadPartialFloat16x4(B + 3 * ldb, CountN);
             MlasStoreFloat16x4(PackedB, v0);
-            MlasStoreFloat16x4(PackedB + 4, v1);
-            MlasStoreFloat16x4(PackedB + 8, v2);
-            MlasStoreFloat16x4(PackedB + 12, v3);
+            MlasStoreFloat16x4(PackedB + 8, v1);
+            MlasStoreFloat16x4(PackedB + 16, v2);
+            MlasStoreFloat16x4(PackedB + 24, v3);
             B += 4 * ldb, PackedB += 32;
         }
 
@@ -421,7 +421,7 @@ void HPackB_B_Kernel_Last8(
             float16x4_t v0 = MlasLoadPartialFloat16x4(B, CountN);
             float16x4_t v1 = MlasLoadPartialFloat16x4(B + ldb, CountN);
             MlasStoreFloat16x4(PackedB, v0);
-            MlasStoreFloat16x4(PackedB + 4, v1);
+            MlasStoreFloat16x4(PackedB + 8, v1);
             B += 2 * ldb, PackedB += 16;
         }
 
@@ -646,256 +646,9 @@ float16x4_t ma_lane_f16_accu(float16x4_t accu, float16x4_t v0, float16x4_t v1, f
     return accu;
 }
 
-template <int beta_behavior> // 0: beta == 0.0f16, 1: beta == 1.0f16, 2: beta != 0.0f16 && beta != 1.0f16
-void HGemm_TransposedB_Kernel_M1(
-    const _mlas_fp16_* A_data,
-    const _mlas_fp16_* B_data,
-    _mlas_fp16_* C_data,
-    size_t CountN,
-    size_t CountK,
-    size_t ldb,
-    _mlas_fp16_ alpha,
-    _mlas_fp16_ beta
-) {
-    for (; CountN >= 8; CountN -= 8, B_data += 8 * ldb, C_data += 8) {
-        const auto* a = A_data;
-        const auto* b = B_data;
-        size_t k = CountK;
-        float16x8_t accu0 = MlasZeroFloat16x8();
-        float16x8_t accu1 = MlasZeroFloat16x8();
-        float16x8_t accu2 = MlasZeroFloat16x8();
-        float16x8_t accu3 = MlasZeroFloat16x8();
-        float16x8_t accu4 = MlasZeroFloat16x8();
-        float16x8_t accu5 = MlasZeroFloat16x8();
-        float16x8_t accu6 = MlasZeroFloat16x8();
-        float16x8_t accu7 = MlasZeroFloat16x8();
-        for (; k >= 8; k -= 8, a += 8, b += 8) {
-            float16x8_t b0 = MlasLoadFloat16x8(b);
-            float16x8_t b1 = MlasLoadFloat16x8(b + ldb);
-            float16x8_t b2 = MlasLoadFloat16x8(b + 2 * ldb);
-            float16x8_t b3 = MlasLoadFloat16x8(b + 3 * ldb);
-            float16x8_t b4 = MlasLoadFloat16x8(b + 4 * ldb);
-            float16x8_t b5 = MlasLoadFloat16x8(b + 5 * ldb);
-            float16x8_t b6 = MlasLoadFloat16x8(b + 6 * ldb);
-            float16x8_t b7 = MlasLoadFloat16x8(b + 7 * ldb);
-            float16x8_t a0 = MlasLoadFloat16x8(a);
-            accu0 = vfmaq_f16(accu0, b0, a0);
-            accu1 = vfmaq_f16(accu1, b1, a0);
-            accu2 = vfmaq_f16(accu2, b2, a0);
-            accu3 = vfmaq_f16(accu3, b3, a0);
-            accu4 = vfmaq_f16(accu4, b4, a0);
-            accu5 = vfmaq_f16(accu5, b5, a0);
-            accu6 = vfmaq_f16(accu6, b6, a0);
-            accu7 = vfmaq_f16(accu7, b7, a0);
-        }
-        Transpose8x8(accu0, accu1, accu2, accu3, accu4, accu5, accu6, accu7);
-        accu0 = addq_f16x8(accu0, accu1, accu2, accu3, accu4, accu5, accu6, accu7); // accumulator of 8 columns
-
-        if (k & 4) {
-            float16x4_t b0 = MlasLoadFloat16x4(b);
-            float16x4_t b1 = MlasLoadFloat16x4(b + ldb);
-            float16x4_t b2 = MlasLoadFloat16x4(b + 2 * ldb);
-            float16x4_t b3 = MlasLoadFloat16x4(b + 3 * ldb);
-            float16x4_t b4 = MlasLoadFloat16x4(b + 4 * ldb);
-            float16x4_t b5 = MlasLoadFloat16x4(b + 5 * ldb);
-            float16x4_t b6 = MlasLoadFloat16x4(b + 6 * ldb);
-            float16x4_t b7 = MlasLoadFloat16x4(b + 7 * ldb);
-            Transpose4x4(b0, b1, b2, b3);
-            Transpose4x4(b4, b5, b6, b7);
-            float16x8_t v0 = vcombine_f16(b0, b4);
-            float16x8_t v1 = vcombine_f16(b1, b5);
-            float16x8_t v2 = vcombine_f16(b2, b6);
-            float16x8_t v3 = vcombine_f16(b3, b7);
-            float16x4_t a0 = MlasLoadFloat16x4(a);
-            accu0 = maq_lane_f16_accu(accu0, v0, v1, v2, v3, a0);
-            k -= 4, a += 4, b += 4;
-        }
-
-        if (k > 0) {
-            float16x4_t b0 = MlasLoadPartialFloat16x4(b, k);
-            float16x4_t b1 = MlasLoadPartialFloat16x4(b + ldb, k);
-            float16x4_t b2 = MlasLoadPartialFloat16x4(b + 2 * ldb, k);
-            float16x4_t b3 = MlasLoadPartialFloat16x4(b + 3 * ldb, k);
-            float16x4_t b4 = MlasLoadPartialFloat16x4(b + 4 * ldb, k);
-            float16x4_t b5 = MlasLoadPartialFloat16x4(b + 5 * ldb, k);
-            float16x4_t b6 = MlasLoadPartialFloat16x4(b + 6 * ldb, k);
-            float16x4_t b7 = MlasLoadPartialFloat16x4(b + 7 * ldb, k);
-            Transpose4x4(b0, b1, b2, b3);
-            Transpose4x4(b4, b5, b6, b7);
-            float16x8_t v0 = vcombine_f16(b0, b4), v1, v2;
-            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k);
-            accu0 = vfmaq_lane_f16(accu0, v0, a0, 0);
-            if (k > 1) {
-                v1 = vcombine_f16(b1, b5);
-                accu0 = vfmaq_lane_f16(accu0, v1, a0, 1);
-            }
-            if (k > 2) {
-                v2 = vcombine_f16(b2, b6);
-                accu0 = vfmaq_lane_f16(accu0, v2, a0, 2);
-            }
-        }
-
-        if constexpr (beta_behavior == 1) {
-            float16x8_t c = MlasLoadFloat16x8(C_data);
-            float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
-            accu0 = vfmaq_f16(c, accu0, alpha_v);
-            MlasStoreFloat16x8(C_data, accu0);
-        } else if constexpr (beta_behavior == 2) {
-            float16x8_t c = MlasLoadFloat16x8(C_data);
-            float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
-            float16x8_t beta_v = MlasBroadcastFloat16x8(beta);
-            accu0 = vfmaq_f16(vmulq_f16(c, beta_v), accu0, alpha_v);
-            MlasStoreFloat16x8(C_data, accu0);
-        } else {
-            float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
-            accu0 = vmulq_f16(accu0, alpha_v);
-            MlasStoreFloat16x8(C_data, accu0);
-        }
-    }
-
-    if (CountN & 4) {
-        const auto* a = A_data;
-        const auto* b = B_data;
-        size_t k = CountK;
-        float16x8_t accu0 = MlasZeroFloat16x8();
-        float16x8_t accu1 = MlasZeroFloat16x8();
-        float16x8_t accu2 = MlasZeroFloat16x8();
-        float16x8_t accu3 = MlasZeroFloat16x8();
-        for (; k >= 8; k -= 8, a += 8, b += 8) {
-            float16x8_t b0 = MlasLoadFloat16x8(b);
-            float16x8_t b1 = MlasLoadFloat16x8(b + ldb);
-            float16x8_t b2 = MlasLoadFloat16x8(b + 2 * ldb);
-            float16x8_t b3 = MlasLoadFloat16x8(b + 3 * ldb);
-            float16x8_t a0 = MlasLoadFloat16x8(a);
-            accu0 = vfmaq_f16(accu0, b0, a0);
-            accu1 = vfmaq_f16(accu1, b1, a0);
-            accu2 = vfmaq_f16(accu2, b2, a0);
-            accu3 = vfmaq_f16(accu3, b3, a0);
-        }
-        Transpose4x8(accu0, accu1, accu2, accu3);
-        accu0 = addq_f16x4(accu0, accu1, accu2, accu3); // accumulator of 4 columns
-        float16x4_t accu = vadd_f16(vget_low_f16(accu0), vget_high_f16(accu0));
-
-        if (k & 4) {
-            float16x4_t b0 = MlasLoadFloat16x4(b);
-            float16x4_t b1 = MlasLoadFloat16x4(b + ldb);
-            float16x4_t b2 = MlasLoadFloat16x4(b + 2 * ldb);
-            float16x4_t b3 = MlasLoadFloat16x4(b + 3 * ldb);
-            Transpose4x4(b0, b1, b2, b3);
-            float16x4_t a0 = MlasLoadFloat16x4(a);
-            accu = ma_lane_f16_accu(accu, b0, b1, b2, b3, a0);
-            k -= 4, a += 4, b += 4;
-        }
-
-        if (k > 0) {
-            float16x4_t b0 = MlasLoadPartialFloat16x4(b, k);
-            float16x4_t b1 = MlasLoadPartialFloat16x4(b + ldb, k);
-            float16x4_t b2 = MlasLoadPartialFloat16x4(b + 2 * ldb, k);
-            float16x4_t b3 = MlasLoadPartialFloat16x4(b + 3 * ldb, k);
-            Transpose4x4(b0, b1, b2, b3);
-            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k);
-            accu = vfma_lane_f16(accu, b0, a0, 0);
-            if (k > 1) {
-                accu = vfma_lane_f16(accu, b1, a0, 1);
-            }
-            if (k > 2) {
-                accu = vfma_lane_f16(accu, b2, a0, 2);
-            }
-        }
-
-        if constexpr (beta_behavior == 1) {
-            float16x4_t c = MlasLoadFloat16x4(C_data);
-            float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
-            accu = vfma_f16(c, accu, alpha_v);
-            MlasStoreFloat16x4(C_data, accu);
-        } else if constexpr (beta_behavior == 2) {
-            float16x4_t c = MlasLoadFloat16x4(C_data);
-            float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
-            float16x4_t beta_v = MlasBroadcastFloat16x4(beta);
-            accu = vfma_f16(vmul_f16(c, beta_v), accu, alpha_v);
-            MlasStoreFloat16x4(C_data, accu);
-        } else {
-            float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
-            accu = vmul_f16(accu, alpha_v);
-            MlasStoreFloat16x4(C_data, accu);
-        }
-
-        CountN -= 4, B_data += 4 * ldb, C_data += 4;
-    }
-
-    if (CountN > 0) {
-        const auto* a = A_data;
-        const auto* b = B_data;
-        size_t k = CountK;
-        float16x8_t accus[4];
-        size_t i = 0;
-        for (i = 0; i < 4; ++i) {
-            accus[i] = MlasZeroFloat16x8();
-        }
-        for (; k >= 8; k -= 8, a += 8, b += 8) {
-            float16x8_t a0 = MlasLoadFloat16x8(a);
-            for (i = 0; i < CountN; ++i) {
-                accus[i] = vfmaq_f16(accus[i], MlasLoadFloat16x8(b + i * ldb), a0);
-            }
-        }
-        Transpose4x8(accus[0], accus[1], accus[2], accus[3]);
-        float16x8_t accu0 = addq_f16x4(accus[0], accus[1], accus[2], accus[3]); // accumulator of 4 columns
-        float16x4_t accu = vadd_f16(vget_low_f16(accu0), vget_high_f16(accu0));
-
-        if (k & 4) {
-            float16x4_t bs[4];
-            for (i = 0; i < CountN; ++i) {
-                bs[i] = MlasLoadFloat16x4(b + i * ldb);
-            }
-            for (; i < 4; ++i) {
-                bs[i] = MlasZeroFloat16x4();
-            }
-            Transpose4x4(bs[0], bs[1], bs[2], bs[3]);
-            float16x4_t a0 = MlasLoadFloat16x4(a);
-            accu = ma_lane_f16_accu(accu, bs[0], bs[1], bs[2], bs[3], a0);
-            k -= 4, a += 4, b += 4;
-        }
-
-        if (k > 0) {
-            float16x4_t bs[4];
-            for (i = 0; i < CountN; ++i) {
-                bs[i] = MlasLoadPartialFloat16x4(b + i * ldb, k);
-            }
-            for (; i < 4; ++i) {
-                bs[i] = MlasZeroFloat16x4();
-            }
-            Transpose4x4(bs[0], bs[1], bs[2], bs[3]);
-            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k);
-            accu = vfma_lane_f16(accu, bs[0], a0, 0);
-            if (k > 1) {
-                accu = vfma_lane_f16(accu, bs[1], a0, 1);
-            }
-            if (k > 2) {
-                accu = vfma_lane_f16(accu, bs[2], a0, 2);
-            }
-        }
-
-        if constexpr (beta_behavior == 1) {
-            float16x4_t c = MlasLoadPartialFloat16x4(C_data, CountN);
-            float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
-            accu = vfma_f16(c, accu, alpha_v);
-            MlasStorePartialFloat16x4(C_data, accu, CountN);
-        } else if constexpr (beta_behavior == 2) {
-            float16x4_t c = MlasLoadPartialFloat16x4(C_data, CountN);
-            float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
-            float16x4_t beta_v = MlasBroadcastFloat16x4(beta);
-            accu = vfma_f16(vmul_f16(c, beta_v), accu, alpha_v);
-            MlasStorePartialFloat16x4(C_data, accu, CountN);
-        } else {
-            float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
-            accu = vmul_f16(accu, alpha_v);
-            MlasStorePartialFloat16x4(C_data, accu, CountN);
-        }
-    }
-}
-
-template <int beta_behavior> // 0: beta == 0.0f16, 1: beta == 1.0f16, 2: beta != 0.0f16 && beta != 1.0f16
-void HGemm_TransposedB_Kernel_M2(
+// beta_behavior: beta == 0.0f16 -> 0, beta == 1.0f16 -> 1, otherwise -> 2
+template <int beta_behavior, int CountM>
+void HGemm_TransposedB_Kernel_Impl(
     const _mlas_fp16_* A_data,
     const _mlas_fp16_* B_data,
     _mlas_fp16_* C_data,
@@ -919,14 +672,17 @@ void HGemm_TransposedB_Kernel_M2(
         float16x8_t accu05 = MlasZeroFloat16x8();
         float16x8_t accu06 = MlasZeroFloat16x8();
         float16x8_t accu07 = MlasZeroFloat16x8();
-        float16x8_t accu10 = MlasZeroFloat16x8();
-        float16x8_t accu11 = MlasZeroFloat16x8();
-        float16x8_t accu12 = MlasZeroFloat16x8();
-        float16x8_t accu13 = MlasZeroFloat16x8();
-        float16x8_t accu14 = MlasZeroFloat16x8();
-        float16x8_t accu15 = MlasZeroFloat16x8();
-        float16x8_t accu16 = MlasZeroFloat16x8();
-        float16x8_t accu17 = MlasZeroFloat16x8();
+        float16x8_t accu10, accu11, accu12, accu13, accu14, accu15, accu16, accu17;
+        if constexpr (CountM == 2) {
+            accu10 = MlasZeroFloat16x8();
+            accu11 = MlasZeroFloat16x8();
+            accu12 = MlasZeroFloat16x8();
+            accu13 = MlasZeroFloat16x8();
+            accu14 = MlasZeroFloat16x8();
+            accu15 = MlasZeroFloat16x8();
+            accu16 = MlasZeroFloat16x8();
+            accu17 = MlasZeroFloat16x8();
+        }
         for (; k >= 8; k -= 8, a += 8, b += 8) {
             float16x8_t b0 = MlasLoadFloat16x8(b);
             float16x8_t b1 = MlasLoadFloat16x8(b + ldb);
@@ -937,7 +693,6 @@ void HGemm_TransposedB_Kernel_M2(
             float16x8_t b6 = MlasLoadFloat16x8(b + 6 * ldb);
             float16x8_t b7 = MlasLoadFloat16x8(b + 7 * ldb);
             float16x8_t a0 = MlasLoadFloat16x8(a);
-            float16x8_t a1 = MlasLoadFloat16x8(a + lda);
             accu00 = vfmaq_f16(accu00, b0, a0);
             accu01 = vfmaq_f16(accu01, b1, a0);
             accu02 = vfmaq_f16(accu02, b2, a0);
@@ -946,19 +701,25 @@ void HGemm_TransposedB_Kernel_M2(
             accu05 = vfmaq_f16(accu05, b5, a0);
             accu06 = vfmaq_f16(accu06, b6, a0);
             accu07 = vfmaq_f16(accu07, b7, a0);
-            accu10 = vfmaq_f16(accu10, b0, a1);
-            accu11 = vfmaq_f16(accu11, b1, a1);
-            accu12 = vfmaq_f16(accu12, b2, a1);
-            accu13 = vfmaq_f16(accu13, b3, a1);
-            accu14 = vfmaq_f16(accu14, b4, a1);
-            accu15 = vfmaq_f16(accu15, b5, a1);
-            accu16 = vfmaq_f16(accu16, b6, a1);
-            accu17 = vfmaq_f16(accu17, b7, a1);
+            if constexpr (CountM == 2) {
+                float16x8_t a1 = MlasLoadFloat16x8(a + lda);
+                accu10 = vfmaq_f16(accu10, b0, a1);
+                accu11 = vfmaq_f16(accu11, b1, a1);
+                accu12 = vfmaq_f16(accu12, b2, a1);
+                accu13 = vfmaq_f16(accu13, b3, a1);
+                accu14 = vfmaq_f16(accu14, b4, a1);
+                accu15 = vfmaq_f16(accu15, b5, a1);
+                accu16 = vfmaq_f16(accu16, b6, a1);
+                accu17 = vfmaq_f16(accu17, b7, a1);
+            }
+
         }
         Transpose8x8(accu00, accu01, accu02, accu03, accu04, accu05, accu06, accu07);
-        Transpose8x8(accu10, accu11, accu12, accu13, accu14, accu15, accu16, accu17);
         accu00 = addq_f16x8(accu00, accu01, accu02, accu03, accu04, accu05, accu06, accu07);
-        accu10 = addq_f16x8(accu10, accu11, accu12, accu13, accu14, accu15, accu16, accu17);
+        if constexpr (CountM == 2) {
+            Transpose8x8(accu10, accu11, accu12, accu13, accu14, accu15, accu16, accu17);
+            accu10 = addq_f16x8(accu10, accu11, accu12, accu13, accu14, accu15, accu16, accu17);
+        }
 
         if (k & 4) {
             float16x4_t b0 = MlasLoadFloat16x4(b);
@@ -976,9 +737,11 @@ void HGemm_TransposedB_Kernel_M2(
             float16x8_t v2 = vcombine_f16(b2, b6);
             float16x8_t v3 = vcombine_f16(b3, b7);
             float16x4_t a0 = MlasLoadFloat16x4(a);
-            float16x4_t a1 = MlasLoadFloat16x4(a + lda);
             accu00 = maq_lane_f16_accu(accu00, v0, v1, v2, v3, a0);
-            accu10 = maq_lane_f16_accu(accu10, v0, v1, v2, v3, a1);
+            if constexpr (CountM == 2) {
+                float16x4_t a1 = MlasLoadFloat16x4(a + lda);
+                accu10 = maq_lane_f16_accu(accu10, v0, v1, v2, v3, a1);
+            }
             k -= 4, a += 4, b += 4;
         }
 
@@ -994,45 +757,57 @@ void HGemm_TransposedB_Kernel_M2(
             Transpose4x4(b0, b1, b2, b3);
             Transpose4x4(b4, b5, b6, b7);
             float16x8_t v0 = vcombine_f16(b0, b4);
-            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k);
-            float16x4_t a1 = MlasLoadPartialFloat16x4(a + lda, k);
+            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1;
             accu00 = vfmaq_lane_f16(accu00, v0, a0, 0);
-            accu10 = vfmaq_lane_f16(accu10, v0, a1, 0);
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadPartialFloat16x4(a + lda, k);
+                accu10 = vfmaq_lane_f16(accu10, v0, a1, 0);
+            }
             if (k > 1) {
                 float16x8_t v1 = vcombine_f16(b1, b5);
                 accu00 = vfmaq_lane_f16(accu00, v1, a0, 1);
-                accu10 = vfmaq_lane_f16(accu10, v1, a1, 1);
+                if constexpr (CountM == 2) {
+                    accu10 = vfmaq_lane_f16(accu10, v1, a1, 1);
+                }
             }
             if (k > 2) {
                 float16x8_t v2 = vcombine_f16(b2, b6);
                 accu00 = vfmaq_lane_f16(accu00, v2, a0, 2);
-                accu10 = vfmaq_lane_f16(accu10, v2, a1, 2);
+                if constexpr (CountM == 2) {
+                    accu10 = vfmaq_lane_f16(accu10, v2, a1, 2);
+                }
             }
         }
 
         if constexpr (beta_behavior == 1) {
-            float16x8_t c0 = MlasLoadFloat16x8(C_data);
-            float16x8_t c1 = MlasLoadFloat16x8(C_data + ldc);
             float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
-            accu00 = vfmaq_f16(c0, accu00, alpha_v);
-            accu10 = vfmaq_f16(c1, accu10, alpha_v);
-            MlasStoreFloat16x8(C_data, accu00);
-            MlasStoreFloat16x8(C_data + ldc, accu10);
-        } else if constexpr (beta_behavior == 2) {
             float16x8_t c0 = MlasLoadFloat16x8(C_data);
-            float16x8_t c1 = MlasLoadFloat16x8(C_data + ldc);
+            accu00 = vfmaq_f16(c0, accu00, alpha_v);
+            MlasStoreFloat16x8(C_data, accu00);
+            if constexpr (CountM == 2) {
+                float16x8_t c1 = MlasLoadFloat16x8(C_data + ldc);
+                accu10 = vfmaq_f16(c1, accu10, alpha_v);
+                MlasStoreFloat16x8(C_data + ldc, accu10);
+            }
+        } else if constexpr (beta_behavior == 2) {
             float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
             float16x8_t beta_v = MlasBroadcastFloat16x8(beta);
+            float16x8_t c0 = MlasLoadFloat16x8(C_data);
             accu00 = vfmaq_f16(vmulq_f16(c0, beta_v), accu00, alpha_v);
-            accu10 = vfmaq_f16(vmulq_f16(c1, beta_v), accu10, alpha_v);
             MlasStoreFloat16x8(C_data, accu00);
-            MlasStoreFloat16x8(C_data + ldc, accu10);
+            if constexpr (CountM == 2) {
+                float16x8_t c1 = MlasLoadFloat16x8(C_data + ldc);
+                accu10 = vfmaq_f16(vmulq_f16(c1, beta_v), accu10, alpha_v);
+                MlasStoreFloat16x8(C_data + ldc, accu10);
+            }
         } else {
             float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
             accu00 = vmulq_f16(accu00, alpha_v);
-            accu10 = vmulq_f16(accu10, alpha_v);
             MlasStoreFloat16x8(C_data, accu00);
-            MlasStoreFloat16x8(C_data + ldc, accu10);
+            if constexpr (CountM == 2) {
+                accu10 = vmulq_f16(accu10, alpha_v);
+                MlasStoreFloat16x8(C_data + ldc, accu10);
+            }
         }
     }
 
@@ -1044,32 +819,39 @@ void HGemm_TransposedB_Kernel_M2(
         float16x8_t accu01 = MlasZeroFloat16x8();
         float16x8_t accu02 = MlasZeroFloat16x8();
         float16x8_t accu03 = MlasZeroFloat16x8();
-        float16x8_t accu10 = MlasZeroFloat16x8();
-        float16x8_t accu11 = MlasZeroFloat16x8();
-        float16x8_t accu12 = MlasZeroFloat16x8();
-        float16x8_t accu13 = MlasZeroFloat16x8();
+        float16x8_t accu10, accu11, accu12, accu13;
+        if constexpr (CountM == 2) {
+            accu10 = MlasZeroFloat16x8();
+            accu11 = MlasZeroFloat16x8();
+            accu12 = MlasZeroFloat16x8();
+            accu13 = MlasZeroFloat16x8();
+        }
         for (; k >= 8; k -= 8, a += 8, b += 8) {
             float16x8_t b0 = MlasLoadFloat16x8(b);
             float16x8_t b1 = MlasLoadFloat16x8(b + ldb);
             float16x8_t b2 = MlasLoadFloat16x8(b + 2 * ldb);
             float16x8_t b3 = MlasLoadFloat16x8(b + 3 * ldb);
             float16x8_t a0 = MlasLoadFloat16x8(a);
-            float16x8_t a1 = MlasLoadFloat16x8(a + lda);
             accu00 = vfmaq_f16(accu00, b0, a0);
             accu01 = vfmaq_f16(accu01, b1, a0);
             accu02 = vfmaq_f16(accu02, b2, a0);
             accu03 = vfmaq_f16(accu03, b3, a0);
-            accu10 = vfmaq_f16(accu10, b0, a1);
-            accu11 = vfmaq_f16(accu11, b1, a1);
-            accu12 = vfmaq_f16(accu12, b2, a1);
-            accu13 = vfmaq_f16(accu13, b3, a1);
+            if constexpr (CountM == 2) {
+                float16x8_t a1 = MlasLoadFloat16x8(a + lda);
+                accu10 = vfmaq_f16(accu10, b0, a1);
+                accu11 = vfmaq_f16(accu11, b1, a1);
+                accu12 = vfmaq_f16(accu12, b2, a1);
+                accu13 = vfmaq_f16(accu13, b3, a1);
+            }
         }
         Transpose4x8(accu00, accu01, accu02, accu03);
-        Transpose4x8(accu10, accu11, accu12, accu13);
         accu00 = addq_f16x4(accu00, accu01, accu02, accu03);
-        accu10 = addq_f16x4(accu10, accu11, accu12, accu13);
-        float16x4_t accu0 = vadd_f16(vget_low_f16(accu00), vget_high_f16(accu00));
-        float16x4_t accu1 = vadd_f16(vget_low_f16(accu10), vget_high_f16(accu10));
+        float16x4_t accu0 = vadd_f16(vget_low_f16(accu00), vget_high_f16(accu00)), accu1;
+        if constexpr (CountM == 2) {
+            Transpose4x8(accu10, accu11, accu12, accu13);
+            accu10 = addq_f16x4(accu10, accu11, accu12, accu13);
+            accu1 = vadd_f16(vget_low_f16(accu10), vget_high_f16(accu10));
+        }
 
         if (k & 4) {
             float16x4_t b0 = MlasLoadFloat16x4(b);
@@ -1078,9 +860,11 @@ void HGemm_TransposedB_Kernel_M2(
             float16x4_t b3 = MlasLoadFloat16x4(b + 3 * ldb);
             Transpose4x4(b0, b1, b2, b3);
             float16x4_t a0 = MlasLoadFloat16x4(a);
-            float16x4_t a1 = MlasLoadFloat16x4(a + lda);
             accu0 = ma_lane_f16_accu(accu0, b0, b1, b2, b3, a0);
-            accu1 = ma_lane_f16_accu(accu1, b0, b1, b2, b3, a1);
+            if constexpr (CountM == 2) {
+                float16x4_t a1 = MlasLoadFloat16x4(a + lda);
+                accu1 = ma_lane_f16_accu(accu1, b0, b1, b2, b3, a1);
+            }
             k -= 4, a += 4, b += 4;
         }
 
@@ -1090,43 +874,55 @@ void HGemm_TransposedB_Kernel_M2(
             float16x4_t b2 = MlasLoadPartialFloat16x4(b + 2 * ldb, k);
             float16x4_t b3 = MlasLoadPartialFloat16x4(b + 3 * ldb, k);
             Transpose4x4(b0, b1, b2, b3);
-            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k);
-            float16x4_t a1 = MlasLoadPartialFloat16x4(a + lda, k);
+            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1;
             accu0 = vfma_lane_f16(accu0, b0, a0, 0);
-            accu1 = vfma_lane_f16(accu1, b0, a1, 0);
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadPartialFloat16x4(a + lda, k);
+                accu1 = vfma_lane_f16(accu1, b0, a1, 0);
+            }
             if (k > 1) {
                 accu0 = vfma_lane_f16(accu0, b1, a0, 1);
-                accu1 = vfma_lane_f16(accu1, b1, a1, 1);
+                if constexpr (CountM == 2) {
+                    accu1 = vfma_lane_f16(accu1, b1, a1, 1);
+                }
             }
             if (k > 2) {
                 accu0 = vfma_lane_f16(accu0, b2, a0, 2);
-                accu1 = vfma_lane_f16(accu1, b2, a1, 2);
+                if constexpr (CountM == 2) {
+                    accu1 = vfma_lane_f16(accu1, b2, a1, 2);
+                }
             }
         }
 
         if constexpr (beta_behavior == 1) {
-            float16x4_t c0 = MlasLoadFloat16x4(C_data);
-            float16x4_t c1 = MlasLoadFloat16x4(C_data + ldc);
             float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
-            accu0 = vfma_f16(c0, accu0, alpha_v);
-            accu1 = vfma_f16(c1, accu1, alpha_v);
-            MlasStoreFloat16x4(C_data, accu0);
-            MlasStoreFloat16x4(C_data + ldc, accu1);
-        } else if constexpr (beta_behavior == 2) {
             float16x4_t c0 = MlasLoadFloat16x4(C_data);
-            float16x4_t c1 = MlasLoadFloat16x4(C_data + ldc);
+            accu0 = vfma_f16(c0, accu0, alpha_v);
+            MlasStoreFloat16x4(C_data, accu0);
+            if constexpr (CountM == 2) {
+                float16x4_t c1 = MlasLoadFloat16x4(C_data + ldc);
+                accu1 = vfma_f16(c1, accu1, alpha_v);
+                MlasStoreFloat16x4(C_data + ldc, accu1);
+            }
+        } else if constexpr (beta_behavior == 2) {
             float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
             float16x4_t beta_v = MlasBroadcastFloat16x4(beta);
+            float16x4_t c0 = MlasLoadFloat16x4(C_data);
             accu0 = vfma_f16(vmul_f16(c0, beta_v), accu0, alpha_v);
-            accu1 = vfma_f16(vmul_f16(c1, beta_v), accu1, alpha_v);
             MlasStoreFloat16x4(C_data, accu0);
-            MlasStoreFloat16x4(C_data + ldc, accu1);
+            if constexpr (CountM == 2) {
+                float16x4_t c1 = MlasLoadFloat16x4(C_data + ldc);
+                accu1 = vfma_f16(vmul_f16(c1, beta_v), accu1, alpha_v);
+                MlasStoreFloat16x4(C_data + ldc, accu1);
+            }
         } else {
             float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
             accu0 = vmul_f16(accu0, alpha_v);
-            accu1 = vmul_f16(accu1, alpha_v);
             MlasStoreFloat16x4(C_data, accu0);
-            MlasStoreFloat16x4(C_data + ldc, accu1);
+            if constexpr (CountM == 2) {
+                accu1 = vmul_f16(accu1, alpha_v);
+                MlasStoreFloat16x4(C_data + ldc, accu1);
+            }
         }
 
         CountN -= 4, B_data += 4 * ldb, C_data += 4;
@@ -1136,28 +932,35 @@ void HGemm_TransposedB_Kernel_M2(
         const auto* a = A_data;
         const auto* b = B_data;
         size_t k = CountK;
-        float16x8_t accu0[4];
-        float16x8_t accu1[4];
+        float16x8_t accu0[4], accu1[4];
         size_t i = 0;
         for (i = 0; i < 4; ++i) {
             accu0[i] = MlasZeroFloat16x8();
-            accu1[i] = MlasZeroFloat16x8();
+            if constexpr (CountM == 2) {
+                accu1[i] = MlasZeroFloat16x8();
+            }
         }
         for (; k >= 8; k -= 8, a += 8, b += 8) {
-            float16x8_t a0 = MlasLoadFloat16x8(a);
-            float16x8_t a1 = MlasLoadFloat16x8(a + lda);
+            float16x8_t a0 = MlasLoadFloat16x8(a), a1;
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadFloat16x8(a + lda);
+            }
             for (i = 0; i < CountN; ++i) {
                 float16x8_t bi = MlasLoadFloat16x8(b + i * ldb);
                 accu0[i] = vfmaq_f16(accu0[i], bi, a0);
-                accu1[i] = vfmaq_f16(accu1[i], bi, a1);
+                if constexpr (CountM == 2) {
+                    accu1[i] = vfmaq_f16(accu1[i], bi, a1);
+                }
             }
         }
         Transpose4x8(accu0[0], accu0[1], accu0[2], accu0[3]);
-        Transpose4x8(accu1[0], accu1[1], accu1[2], accu1[3]);
         float16x8_t accu00 = addq_f16x4(accu0[0], accu0[1], accu0[2], accu0[3]);
-        float16x4_t accu_0 = vadd_f16(vget_low_f16(accu00), vget_high_f16(accu00));
-        float16x8_t accu10 = addq_f16x4(accu1[0], accu1[1], accu1[2], accu1[3]);
-        float16x4_t accu_1 = vadd_f16(vget_low_f16(accu10), vget_high_f16(accu10));
+        float16x4_t accu_0 = vadd_f16(vget_low_f16(accu00), vget_high_f16(accu00)), accu_1;
+        if constexpr (CountM == 2) {
+            Transpose4x8(accu1[0], accu1[1], accu1[2], accu1[3]);
+            float16x8_t accu10 = addq_f16x4(accu1[0], accu1[1], accu1[2], accu1[3]);
+            accu_1 = vadd_f16(vget_low_f16(accu10), vget_high_f16(accu10));
+        }
 
         if (k & 4) {
             float16x4_t bs[4];
@@ -1169,9 +972,11 @@ void HGemm_TransposedB_Kernel_M2(
             }
             Transpose4x4(bs[0], bs[1], bs[2], bs[3]);
             float16x4_t a0 = MlasLoadFloat16x4(a);
-            float16x4_t a1 = MlasLoadFloat16x4(a + lda);
             accu_0 = ma_lane_f16_accu(accu_0, bs[0], bs[1], bs[2], bs[3], a0);
-            accu_1 = ma_lane_f16_accu(accu_1, bs[0], bs[1], bs[2], bs[3], a1);
+            if constexpr (CountM == 2) {
+                float16x4_t a1 = MlasLoadFloat16x4(a + lda);
+                accu_1 = ma_lane_f16_accu(accu_1, bs[0], bs[1], bs[2], bs[3], a1);
+            }
             k -= 4, a += 4, b += 4;
         }
 
@@ -1184,43 +989,55 @@ void HGemm_TransposedB_Kernel_M2(
                 bs[i] = MlasZeroFloat16x4();
             }
             Transpose4x4(bs[0], bs[1], bs[2], bs[3]);
-            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k);
-            float16x4_t a1 = MlasLoadPartialFloat16x4(a + lda, k);
+            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1;
             accu_0 = vfma_lane_f16(accu_0, bs[0], a0, 0);
-            accu_1 = vfma_lane_f16(accu_1, bs[0], a1, 0);
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadPartialFloat16x4(a + lda, k);
+                accu_1 = vfma_lane_f16(accu_1, bs[0], a1, 0);
+            }
             if (k > 1) {
                 accu_0 = vfma_lane_f16(accu_0, bs[1], a0, 1);
-                accu_1 = vfma_lane_f16(accu_1, bs[1], a1, 1);
+                if constexpr (CountM == 2) {
+                    accu_1 = vfma_lane_f16(accu_1, bs[1], a1, 1);
+                }
             }
             if (k > 2) {
                 accu_0 = vfma_lane_f16(accu_0, bs[2], a0, 2);
-                accu_1 = vfma_lane_f16(accu_1, bs[2], a1, 2);
+                if constexpr (CountM == 2) {
+                    accu_1 = vfma_lane_f16(accu_1, bs[2], a1, 2);
+                }
             }
         }
 
         if constexpr (beta_behavior == 1) {
-            float16x4_t c0 = MlasLoadPartialFloat16x4(C_data, CountN);
-            float16x4_t c1 = MlasLoadPartialFloat16x4(C_data + ldc, CountN);
             float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
-            accu_0 = vfma_f16(c0, accu_0, alpha_v);
-            accu_1 = vfma_f16(c1, accu_1, alpha_v);
-            MlasStorePartialFloat16x4(C_data, accu_0, CountN);
-            MlasStorePartialFloat16x4(C_data + ldc, accu_1, CountN);
-        } else if constexpr (beta_behavior == 2) {
             float16x4_t c0 = MlasLoadPartialFloat16x4(C_data, CountN);
-            float16x4_t c1 = MlasLoadPartialFloat16x4(C_data + ldc, CountN);
+            accu_0 = vfma_f16(c0, accu_0, alpha_v);
+            MlasStorePartialFloat16x4(C_data, accu_0, CountN);
+            if constexpr (CountM == 2) {
+                float16x4_t c1 = MlasLoadPartialFloat16x4(C_data + ldc, CountN);
+                accu_1 = vfma_f16(c1, accu_1, alpha_v);
+                MlasStorePartialFloat16x4(C_data + ldc, accu_1, CountN);
+            }
+        } else if constexpr (beta_behavior == 2) {
             float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
             float16x4_t beta_v = MlasBroadcastFloat16x4(beta);
+            float16x4_t c0 = MlasLoadPartialFloat16x4(C_data, CountN);
             accu_0 = vfma_f16(vmul_f16(c0, beta_v), accu_0, alpha_v);
-            accu_1 = vfma_f16(vmul_f16(c1, beta_v), accu_1, alpha_v);
             MlasStorePartialFloat16x4(C_data, accu_0, CountN);
-            MlasStorePartialFloat16x4(C_data + ldc, accu_1, CountN);
+            if constexpr (CountM == 2) {
+                float16x4_t c1 = MlasLoadPartialFloat16x4(C_data + ldc, CountN);
+                accu_1 = vfma_f16(vmul_f16(c1, beta_v), accu_1, alpha_v);
+                MlasStorePartialFloat16x4(C_data + ldc, accu_1, CountN);
+            }
         } else {
             float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
             accu_0 = vmul_f16(accu_0, alpha_v);
-            accu_1 = vmul_f16(accu_1, alpha_v);
             MlasStorePartialFloat16x4(C_data, accu_0, CountN);
-            MlasStorePartialFloat16x4(C_data + ldc, accu_1, CountN);
+            if constexpr (CountM == 2) {
+                accu_1 = vmul_f16(accu_1, alpha_v);
+                MlasStorePartialFloat16x4(C_data + ldc, accu_1, CountN);
+            }
         }
     }
 }
@@ -1249,19 +1066,754 @@ void HGemm_TransposedB_Kernel(
     const auto f16_1 = MLAS_FP16(1.0f);
     if (CountM == 1) {
         if (beta == f16_0.val) {
-            HGemm_TransposedB_Kernel_M1<0>(A_data, B_data, C_data, CountN, CountK, ldb, alpha, beta);
+            HGemm_TransposedB_Kernel_Impl<0, 1>(A_data, B_data, C_data, CountN, CountK, lda, ldb, ldc, alpha, beta);
         } else if (beta == f16_1.val) {
-            HGemm_TransposedB_Kernel_M1<1>(A_data, B_data, C_data, CountN, CountK, ldb, alpha, beta);
+            HGemm_TransposedB_Kernel_Impl<1, 1>(A_data, B_data, C_data, CountN, CountK, lda, ldb, ldc, alpha, beta);
         } else {
-            HGemm_TransposedB_Kernel_M1<2>(A_data, B_data, C_data, CountN, CountK, ldb, alpha, beta);
+            HGemm_TransposedB_Kernel_Impl<2, 1>(A_data, B_data, C_data, CountN, CountK, lda, ldb, ldc, alpha, beta);
         }
     } else {
         if (beta == f16_0.val) {
-            HGemm_TransposedB_Kernel_M2<0>(A_data, B_data, C_data, CountN, CountK, lda, ldb, ldc, alpha, beta);
+            HGemm_TransposedB_Kernel_Impl<0, 2>(A_data, B_data, C_data, CountN, CountK, lda, ldb, ldc, alpha, beta);
         } else if (beta == f16_1.val) {
-            HGemm_TransposedB_Kernel_M2<1>(A_data, B_data, C_data, CountN, CountK, lda, ldb, ldc, alpha, beta);
+            HGemm_TransposedB_Kernel_Impl<1, 2>(A_data, B_data, C_data, CountN, CountK, lda, ldb, ldc, alpha, beta);
         } else {
-            HGemm_TransposedB_Kernel_M2<2>(A_data, B_data, C_data, CountN, CountK, lda, ldb, ldc, alpha, beta);
+            HGemm_TransposedB_Kernel_Impl<2, 2>(A_data, B_data, C_data, CountN, CountK, lda, ldb, ldc, alpha, beta);
+        }
+    }
+}
+
+template <int CountM>
+MLAS_FORCEINLINE
+void ma_lane_accu(
+    const _mlas_fp16_* b,
+    size_t ldb,
+    float16x8_t a0,
+    float16x8_t& accu0,
+    float16x8_t a1,
+    float16x8_t& accu1
+) {
+    float16x8_t b0 = MlasLoadFloat16x8(b);
+    float16x8_t b1 = MlasLoadFloat16x8(b + ldb);
+    float16x8_t b2 = MlasLoadFloat16x8(b + 2 * ldb);
+    float16x8_t b3 = MlasLoadFloat16x8(b + 3 * ldb);
+    float16x8_t b4 = MlasLoadFloat16x8(b + 4 * ldb);
+    float16x8_t b5 = MlasLoadFloat16x8(b + 5 * ldb);
+    float16x8_t b6 = MlasLoadFloat16x8(b + 6 * ldb);
+    float16x8_t b7 = MlasLoadFloat16x8(b + 7 * ldb);
+    accu0 = vfmaq_laneq_f16(accu0, b0, a0, 0);
+    accu0 = vfmaq_laneq_f16(accu0, b1, a0, 1);
+    accu0 = vfmaq_laneq_f16(accu0, b2, a0, 2);
+    accu0 = vfmaq_laneq_f16(accu0, b3, a0, 3);
+    accu0 = vfmaq_laneq_f16(accu0, b4, a0, 4);
+    accu0 = vfmaq_laneq_f16(accu0, b5, a0, 5);
+    accu0 = vfmaq_laneq_f16(accu0, b6, a0, 6);
+    accu0 = vfmaq_laneq_f16(accu0, b7, a0, 7);
+    if constexpr (CountM == 2) {
+        accu1 = vfmaq_laneq_f16(accu1, b0, a1, 0);
+        accu1 = vfmaq_laneq_f16(accu1, b1, a1, 1);
+        accu1 = vfmaq_laneq_f16(accu1, b2, a1, 2);
+        accu1 = vfmaq_laneq_f16(accu1, b3, a1, 3);
+        accu1 = vfmaq_laneq_f16(accu1, b4, a1, 4);
+        accu1 = vfmaq_laneq_f16(accu1, b5, a1, 5);
+        accu1 = vfmaq_laneq_f16(accu1, b6, a1, 6);
+        accu1 = vfmaq_laneq_f16(accu1, b7, a1, 7);
+    }
+}
+
+template <int CountM>
+MLAS_FORCEINLINE
+void ma_lane_accu(
+    const _mlas_fp16_* b,
+    size_t ldb,
+    float16x8_t a0,
+    float16x4_t& accu0,
+    float16x8_t a1,
+    float16x4_t& accu1
+) {
+    float16x4_t b0 = MlasLoadFloat16x4(b);
+    float16x4_t b1 = MlasLoadFloat16x4(b + ldb);
+    float16x4_t b2 = MlasLoadFloat16x4(b + 2 * ldb);
+    float16x4_t b3 = MlasLoadFloat16x4(b + 3 * ldb);
+    float16x4_t b4 = MlasLoadFloat16x4(b + 4 * ldb);
+    float16x4_t b5 = MlasLoadFloat16x4(b + 5 * ldb);
+    float16x4_t b6 = MlasLoadFloat16x4(b + 6 * ldb);
+    float16x4_t b7 = MlasLoadFloat16x4(b + 7 * ldb);
+    accu0 = vfma_laneq_f16(accu0, b0, a0, 0);
+    accu0 = vfma_laneq_f16(accu0, b1, a0, 1);
+    accu0 = vfma_laneq_f16(accu0, b2, a0, 2);
+    accu0 = vfma_laneq_f16(accu0, b3, a0, 3);
+    accu0 = vfma_laneq_f16(accu0, b4, a0, 4);
+    accu0 = vfma_laneq_f16(accu0, b5, a0, 5);
+    accu0 = vfma_laneq_f16(accu0, b6, a0, 6);
+    accu0 = vfma_laneq_f16(accu0, b7, a0, 7);
+    if constexpr (CountM == 2) {
+        accu1 = vfma_laneq_f16(accu1, b0, a1, 0);
+        accu1 = vfma_laneq_f16(accu1, b1, a1, 1);
+        accu1 = vfma_laneq_f16(accu1, b2, a1, 2);
+        accu1 = vfma_laneq_f16(accu1, b3, a1, 3);
+        accu1 = vfma_laneq_f16(accu1, b4, a1, 4);
+        accu1 = vfma_laneq_f16(accu1, b5, a1, 5);
+        accu1 = vfma_laneq_f16(accu1, b6, a1, 6);
+        accu1 = vfma_laneq_f16(accu1, b7, a1, 7);
+    }
+}
+
+template <int CountM>
+MLAS_FORCEINLINE
+void ma_lane_partial_accu(
+    const _mlas_fp16_* b,
+    size_t ldb,
+    float16x8_t a0,
+    float16x4_t& accu0,
+    float16x8_t a1,
+    float16x4_t& accu1,
+    size_t countN
+) {
+    float16x4_t b0 = MlasLoadPartialFloat16x4(b, countN);
+    float16x4_t b1 = MlasLoadPartialFloat16x4(b + ldb, countN);
+    float16x4_t b2 = MlasLoadPartialFloat16x4(b + 2 * ldb, countN);
+    float16x4_t b3 = MlasLoadPartialFloat16x4(b + 3 * ldb, countN);
+    float16x4_t b4 = MlasLoadPartialFloat16x4(b + 4 * ldb, countN);
+    float16x4_t b5 = MlasLoadPartialFloat16x4(b + 5 * ldb, countN);
+    float16x4_t b6 = MlasLoadPartialFloat16x4(b + 6 * ldb, countN);
+    float16x4_t b7 = MlasLoadPartialFloat16x4(b + 7 * ldb, countN);
+    accu0 = vfma_laneq_f16(accu0, b0, a0, 0);
+    accu0 = vfma_laneq_f16(accu0, b1, a0, 1);
+    accu0 = vfma_laneq_f16(accu0, b2, a0, 2);
+    accu0 = vfma_laneq_f16(accu0, b3, a0, 3);
+    accu0 = vfma_laneq_f16(accu0, b4, a0, 4);
+    accu0 = vfma_laneq_f16(accu0, b5, a0, 5);
+    accu0 = vfma_laneq_f16(accu0, b6, a0, 6);
+    accu0 = vfma_laneq_f16(accu0, b7, a0, 7);
+    if constexpr (CountM == 2) {
+        accu1 = vfma_laneq_f16(accu1, b0, a1, 0);
+        accu1 = vfma_laneq_f16(accu1, b1, a1, 1);
+        accu1 = vfma_laneq_f16(accu1, b2, a1, 2);
+        accu1 = vfma_laneq_f16(accu1, b3, a1, 3);
+        accu1 = vfma_laneq_f16(accu1, b4, a1, 4);
+        accu1 = vfma_laneq_f16(accu1, b5, a1, 5);
+        accu1 = vfma_laneq_f16(accu1, b6, a1, 6);
+        accu1 = vfma_laneq_f16(accu1, b7, a1, 7);
+    }
+}
+
+template <int CountM>
+MLAS_FORCEINLINE
+void ma_lane_accu(
+    const _mlas_fp16_* b,
+    size_t ldb,
+    float16x4_t a0,
+    float16x8_t& accu0,
+    float16x4_t a1,
+    float16x8_t& accu1
+) {
+    float16x8_t b0 = MlasLoadFloat16x8(b);
+    float16x8_t b1 = MlasLoadFloat16x8(b + ldb);
+    float16x8_t b2 = MlasLoadFloat16x8(b + 2 * ldb);
+    float16x8_t b3 = MlasLoadFloat16x8(b + 3 * ldb);
+    accu0 = vfmaq_lane_f16(accu0, b0, a0, 0);
+    accu0 = vfmaq_lane_f16(accu0, b1, a0, 1);
+    accu0 = vfmaq_lane_f16(accu0, b2, a0, 2);
+    accu0 = vfmaq_lane_f16(accu0, b3, a0, 3);
+    if constexpr (CountM == 2) {
+        accu1 = vfmaq_lane_f16(accu1, b0, a1, 0);
+        accu1 = vfmaq_lane_f16(accu1, b1, a1, 1);
+        accu1 = vfmaq_lane_f16(accu1, b2, a1, 2);
+        accu1 = vfmaq_lane_f16(accu1, b3, a1, 3);
+    }
+}
+
+template <int CountM>
+MLAS_FORCEINLINE
+void ma_lane_accu(
+    const _mlas_fp16_* b,
+    size_t ldb,
+    float16x4_t a0,
+    float16x4_t& accu0,
+    float16x4_t a1,
+    float16x4_t& accu1
+) {
+    float16x4_t b0 = MlasLoadFloat16x4(b);
+    float16x4_t b1 = MlasLoadFloat16x4(b + ldb);
+    float16x4_t b2 = MlasLoadFloat16x4(b + 2 * ldb);
+    float16x4_t b3 = MlasLoadFloat16x4(b + 3 * ldb);
+    accu0 = vfma_lane_f16(accu0, b0, a0, 0);
+    accu0 = vfma_lane_f16(accu0, b1, a0, 1);
+    accu0 = vfma_lane_f16(accu0, b2, a0, 2);
+    accu0 = vfma_lane_f16(accu0, b3, a0, 3);
+    if constexpr (CountM == 2) {
+        accu1 = vfma_lane_f16(accu1, b0, a1, 0);
+        accu1 = vfma_lane_f16(accu1, b1, a1, 1);
+        accu1 = vfma_lane_f16(accu1, b2, a1, 2);
+        accu1 = vfma_lane_f16(accu1, b3, a1, 3);
+    }
+}
+
+template <int CountM>
+MLAS_FORCEINLINE
+void ma_lane_partial_accu(
+    const _mlas_fp16_* b,
+    size_t ldb,
+    float16x4_t a0,
+    float16x4_t& accu0,
+    float16x4_t a1,
+    float16x4_t& accu1,
+    size_t countN
+) {
+    float16x4_t b0 = MlasLoadPartialFloat16x4(b, countN);
+    float16x4_t b1 = MlasLoadPartialFloat16x4(b + ldb, countN);
+    float16x4_t b2 = MlasLoadPartialFloat16x4(b + 2 * ldb, countN);
+    float16x4_t b3 = MlasLoadPartialFloat16x4(b + 3 * ldb, countN);
+    accu0 = vfma_lane_f16(accu0, b0, a0, 0);
+    accu0 = vfma_lane_f16(accu0, b1, a0, 1);
+    accu0 = vfma_lane_f16(accu0, b2, a0, 2);
+    accu0 = vfma_lane_f16(accu0, b3, a0, 3);
+    if constexpr (CountM == 2) {
+        accu1 = vfma_lane_f16(accu1, b0, a1, 0);
+        accu1 = vfma_lane_f16(accu1, b1, a1, 1);
+        accu1 = vfma_lane_f16(accu1, b2, a1, 2);
+        accu1 = vfma_lane_f16(accu1, b3, a1, 3);
+    }
+}
+
+template <int CountM>
+MLAS_FORCEINLINE
+void ma_lane_accu(
+    const _mlas_fp16_* b,
+    size_t ldb,
+    float16x4_t a0,
+    float16x8_t& accu0,
+    float16x4_t a1,
+    float16x8_t& accu1,
+    size_t countK
+) {
+    float16x8_t b0 = MlasLoadFloat16x8(b), b1, b2, b3;
+    accu0 = vfmaq_lane_f16(accu0, b0, a0, 0);
+    if constexpr (CountM == 2) {
+        accu1 = vfmaq_lane_f16(accu1, b0, a1, 0);
+    }
+    if (countK > 1) {
+        b1 = MlasLoadFloat16x8(b + ldb);
+        accu0 = vfmaq_lane_f16(accu0, b1, a0, 1);
+        if constexpr (CountM == 2) {
+            accu1 = vfmaq_lane_f16(accu1, b0, a1, 1);
+        }
+    }
+    if (countK > 2) {
+        b2 = MlasLoadFloat16x8(b + 2 * ldb);
+        accu0 = vfmaq_lane_f16(accu0, b2, a0, 2);
+        if constexpr (CountM == 2) {
+            accu1 = vfmaq_lane_f16(accu1, b0, a1, 2);
+        }
+    }
+    if (countK > 3) {
+        b3 = MlasLoadFloat16x8(b + 3 * ldb);
+        accu0 = vfmaq_lane_f16(accu0, b3, a0, 3);
+        if constexpr (CountM == 2) {
+            accu1 = vfmaq_lane_f16(accu1, b0, a1, 3);
+        }
+    }
+}
+
+template <int CountM>
+MLAS_FORCEINLINE
+void ma_lane_accu(
+    const _mlas_fp16_* b,
+    size_t ldb,
+    float16x4_t a0,
+    float16x4_t& accu0,
+    float16x4_t a1,
+    float16x4_t& accu1,
+    size_t countK
+) {
+    float16x4_t b0 = MlasLoadFloat16x4(b), b1, b2, b3;
+    accu0 = vfma_lane_f16(accu0, b0, a0, 0);
+    if constexpr (CountM == 2) {
+        accu1 = vfma_lane_f16(accu1, b0, a1, 0);
+    }
+    if (countK > 1) {
+        b1 = MlasLoadFloat16x4(b + ldb);
+        accu0 = vfma_lane_f16(accu0, b1, a0, 1);
+        if constexpr (CountM == 2) {
+            accu1 = vfma_lane_f16(accu1, b0, a1, 1);
+        }
+    }
+    if (countK > 2) {
+        b2 = MlasLoadFloat16x4(b + 2 * ldb);
+        accu0 = vfma_lane_f16(accu0, b2, a0, 2);
+        if constexpr (CountM == 2) {
+            accu1 = vfma_lane_f16(accu1, b0, a1, 2);
+        }
+    }
+    if (countK > 3) {
+        b3 = MlasLoadFloat16x4(b + 3 * ldb);
+        accu0 = vfma_lane_f16(accu0, b3, a0, 3);
+        if constexpr (CountM == 2) {
+            accu1 = vfma_lane_f16(accu1, b0, a1, 3);
+        }
+    }
+}
+
+template <int CountM>
+MLAS_FORCEINLINE
+void ma_lane_partial_accu(
+    const _mlas_fp16_* b,
+    size_t ldb,
+    float16x4_t a0,
+    float16x4_t& accu0,
+    float16x4_t a1,
+    float16x4_t& accu1,
+    size_t countK,
+    size_t countN
+) {
+    float16x4_t b0 = MlasLoadPartialFloat16x4(b, countN), b1, b2, b3;
+    accu0 = vfma_lane_f16(accu0, b0, a0, 0);
+    if constexpr (CountM == 2) {
+        accu1 = vfma_lane_f16(accu1, b0, a1, 0);
+    }
+    if (countK > 1) {
+        b1 = MlasLoadPartialFloat16x4(b + ldb, countN);
+        accu0 = vfma_lane_f16(accu0, b1, a0, 1);
+        if constexpr (CountM == 2) {
+            accu1 = vfma_lane_f16(accu1, b0, a1, 1);
+        }
+    }
+    if (countK > 2) {
+        b2 = MlasLoadPartialFloat16x4(b + 2 * ldb, countN);
+        accu0 = vfma_lane_f16(accu0, b2, a0, 2);
+        if constexpr (CountM == 2) {
+            accu1 = vfma_lane_f16(accu1, b0, a1, 2);
+        }
+    }
+    if (countK > 3) {
+        b3 = MlasLoadPartialFloat16x4(b + 3 * ldb, countN);
+        accu0 = vfma_lane_f16(accu0, b3, a0, 3);
+        if constexpr (CountM == 2) {
+            accu1 = vfma_lane_f16(accu1, b0, a1, 3);
+        }
+    }
+}
+
+// beta_behavior: beta == 0.0f16 -> 0, beta == 1.0f16 -> 1, otherwise -> 2
+template <int beta_behavior, int CountM>
+void HGemm_B_Kernel_Impl(
+    const _mlas_fp16_* A_data,
+    const _mlas_fp16_* B_data,
+    _mlas_fp16_* C_data,
+    size_t CountN,
+    size_t CountK,
+    size_t lda,
+    size_t ldb,
+    size_t ldc,
+    _mlas_fp16_ alpha,
+    _mlas_fp16_ beta
+) {
+    const size_t ldb8 = ldb * 8;
+    for (; CountN >= 32; CountN -= 32, B_data += 32, C_data += 32) {
+        const auto* a = A_data;
+        const auto* b = B_data;
+        size_t k = CountK;
+        float16x8_t accu00 = MlasZeroFloat16x8();
+        float16x8_t accu01 = MlasZeroFloat16x8();
+        float16x8_t accu02 = MlasZeroFloat16x8();
+        float16x8_t accu03 = MlasZeroFloat16x8();
+        float16x8_t accu10, accu11, accu12, accu13;
+        if constexpr (CountM == 2) {
+            accu10 = MlasZeroFloat16x8();
+            accu11 = MlasZeroFloat16x8();
+            accu12 = MlasZeroFloat16x8();
+            accu13 = MlasZeroFloat16x8();
+        }
+        for (; k >= 8; k -= 8, a += 8, b += ldb8) {
+            float16x8_t a0 = MlasLoadFloat16x8(a), a1;
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadFloat16x8(a + lda);
+            }
+            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10);
+            ma_lane_accu<CountM>(b + 8, ldb, a0, accu01, a1, accu11);
+            ma_lane_accu<CountM>(b + 16, ldb, a0, accu02, a1, accu12);
+            ma_lane_accu<CountM>(b + 24, ldb, a0, accu03, a1, accu13);
+        }
+
+        if (k & 4) {
+            float16x4_t a0 = MlasLoadFloat16x4(a), a1;
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadFloat16x4(a + lda);
+            }
+            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10);
+            ma_lane_accu<CountM>(b + 8, ldb, a0, accu01, a1, accu11);
+            ma_lane_accu<CountM>(b + 16, ldb, a0, accu02, a1, accu12);
+            ma_lane_accu<CountM>(b + 24, ldb, a0, accu03, a1, accu13);
+
+            k -= 4, a += 4, b += 4 * ldb;
+        }
+
+        if (k > 0) {
+            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1;
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadPartialFloat16x4(a + lda, k);
+            }
+            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10, k);
+            ma_lane_accu<CountM>(b + 8, ldb, a0, accu01, a1, accu11, k);
+            ma_lane_accu<CountM>(b + 16, ldb, a0, accu02, a1, accu12, k);
+            ma_lane_accu<CountM>(b + 24, ldb, a0, accu03, a1, accu13, k);
+        }
+
+        if constexpr (beta_behavior == 1) {
+            float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
+            float16x8_t c00 = MlasLoadFloat16x8(C_data);
+            float16x8_t c01 = MlasLoadFloat16x8(C_data + 8);
+            float16x8_t c02 = MlasLoadFloat16x8(C_data + 16);
+            float16x8_t c03 = MlasLoadFloat16x8(C_data + 24);
+            MlasStoreFloat16x8(C_data, vfmaq_f16(c00, accu00, alpha_v));
+            MlasStoreFloat16x8(C_data + 8, vfmaq_f16(c01, accu01, alpha_v));
+            MlasStoreFloat16x8(C_data + 16, vfmaq_f16(c02, accu02, alpha_v));
+            MlasStoreFloat16x8(C_data + 24, vfmaq_f16(c03, accu03, alpha_v));
+            if constexpr (CountM == 2) {
+                float16x8_t c10 = MlasLoadFloat16x8(C_data + ldc);
+                float16x8_t c11 = MlasLoadFloat16x8(C_data + ldc + 8);
+                float16x8_t c12 = MlasLoadFloat16x8(C_data + ldc + 16);
+                float16x8_t c13 = MlasLoadFloat16x8(C_data + ldc + 24);
+                MlasStoreFloat16x8(C_data + ldc, vfmaq_f16(c10, accu10, alpha_v));
+                MlasStoreFloat16x8(C_data + ldc + 8, vfmaq_f16(c11, accu11, alpha_v));
+                MlasStoreFloat16x8(C_data + ldc + 16, vfmaq_f16(c12, accu12, alpha_v));
+                MlasStoreFloat16x8(C_data + ldc + 24, vfmaq_f16(c13, accu13, alpha_v));
+            }
+        } else if constexpr (beta_behavior == 2) {
+            float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
+            float16x8_t beta_v = MlasBroadcastFloat16x8(beta);
+            float16x8_t c00 = MlasLoadFloat16x8(C_data);
+            float16x8_t c01 = MlasLoadFloat16x8(C_data + 8);
+            float16x8_t c02 = MlasLoadFloat16x8(C_data + 16);
+            float16x8_t c03 = MlasLoadFloat16x8(C_data + 24);
+            MlasStoreFloat16x8(C_data, vfmaq_f16(vmulq_f16(c00, beta_v), accu00, alpha_v));
+            MlasStoreFloat16x8(C_data + 8, vfmaq_f16(vmulq_f16(c01, beta_v), accu01, alpha_v));
+            MlasStoreFloat16x8(C_data + 16, vfmaq_f16(vmulq_f16(c02, beta_v), accu02, alpha_v));
+            MlasStoreFloat16x8(C_data + 24, vfmaq_f16(vmulq_f16(c03, beta_v), accu03, alpha_v));
+            if constexpr (CountM == 2) {
+                float16x8_t c10 = MlasLoadFloat16x8(C_data + ldc);
+                float16x8_t c11 = MlasLoadFloat16x8(C_data + ldc + 8);
+                float16x8_t c12 = MlasLoadFloat16x8(C_data + ldc + 16);
+                float16x8_t c13 = MlasLoadFloat16x8(C_data + ldc + 24);
+                MlasStoreFloat16x8(C_data + ldc, vfmaq_f16(vmulq_f16(c10, beta_v), accu10, alpha_v));
+                MlasStoreFloat16x8(C_data + ldc + 8, vfmaq_f16(vmulq_f16(c11, beta_v), accu11, alpha_v));
+                MlasStoreFloat16x8(C_data + ldc + 16, vfmaq_f16(vmulq_f16(c12, beta_v), accu12, alpha_v));
+                MlasStoreFloat16x8(C_data + ldc + 24, vfmaq_f16(vmulq_f16(c13, beta_v), accu13, alpha_v));
+            }
+        } else {
+            float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
+            MlasStoreFloat16x8(C_data, vmulq_f16(accu00, alpha_v));
+            MlasStoreFloat16x8(C_data + 8, vmulq_f16(accu01, alpha_v));
+            MlasStoreFloat16x8(C_data + 16, vmulq_f16(accu02, alpha_v));
+            MlasStoreFloat16x8(C_data + 24, vmulq_f16(accu03, alpha_v));
+            if constexpr (CountM == 2) {
+                MlasStoreFloat16x8(C_data + ldc, vmulq_f16(accu10, alpha_v));
+                MlasStoreFloat16x8(C_data + ldc + 8, vmulq_f16(accu11, alpha_v));
+                MlasStoreFloat16x8(C_data + ldc + 16, vmulq_f16(accu12, alpha_v));
+                MlasStoreFloat16x8(C_data + ldc + 24, vmulq_f16(accu13, alpha_v));
+            }
+        }
+    }
+
+    if (CountN & 16) {
+        const auto* a = A_data;
+        const auto* b = B_data;
+        size_t k = CountK;
+        float16x8_t accu00 = MlasZeroFloat16x8();
+        float16x8_t accu01 = MlasZeroFloat16x8();
+        float16x8_t accu10, accu11;
+        if constexpr (CountM == 2) {
+            accu10 = MlasZeroFloat16x8();
+            accu11 = MlasZeroFloat16x8();
+        }
+        for (; k >= 8; k -= 8, a += 8, b += ldb8) {
+            float16x8_t a0 = MlasLoadFloat16x8(a), a1;
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadFloat16x8(a + lda);
+            }
+            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10);
+            ma_lane_accu<CountM>(b + 8, ldb, a0, accu01, a1, accu11);
+        }
+
+        if (k & 4) {
+            float16x4_t a0 = MlasLoadFloat16x4(a), a1;
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadFloat16x4(a + lda);
+            }
+            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10);
+            ma_lane_accu<CountM>(b + 8, ldb, a0, accu01, a1, accu11);
+            k -= 4, a += 4, b += 4 * ldb;
+        }
+
+        if (k > 0) {
+            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1;
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadPartialFloat16x4(a + lda, k);
+            }
+            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10, k);
+            ma_lane_accu<CountM>(b + 8, ldb, a0, accu01, a1, accu11, k);
+        }
+
+        if constexpr (beta_behavior == 1) {
+            float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
+            float16x8_t c00 = MlasLoadFloat16x8(C_data);
+            float16x8_t c01 = MlasLoadFloat16x8(C_data + 8);
+            MlasStoreFloat16x8(C_data, vfmaq_f16(c00, accu00, alpha_v));
+            MlasStoreFloat16x8(C_data + 8, vfmaq_f16(c01, accu01, alpha_v));
+            if constexpr (CountM == 2) {
+                float16x8_t c10 = MlasLoadFloat16x8(C_data + ldc);
+                float16x8_t c11 = MlasLoadFloat16x8(C_data + ldc + 8);
+                MlasStoreFloat16x8(C_data + ldc, vfmaq_f16(c10, accu10, alpha_v));
+                MlasStoreFloat16x8(C_data + ldc + 8, vfmaq_f16(c11, accu11, alpha_v));
+            }
+        } else if constexpr (beta_behavior == 2) {
+            float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
+            float16x8_t beta_v = MlasBroadcastFloat16x8(beta);
+            float16x8_t c00 = MlasLoadFloat16x8(C_data);
+            float16x8_t c01 = MlasLoadFloat16x8(C_data + 8);
+            MlasStoreFloat16x8(C_data, vfmaq_f16(vmulq_f16(c00, beta_v), accu00, alpha_v));
+            MlasStoreFloat16x8(C_data + 8, vfmaq_f16(vmulq_f16(c01, beta_v), accu01, alpha_v));
+            if constexpr (CountM == 2) {
+                float16x8_t c10 = MlasLoadFloat16x8(C_data + ldc);
+                float16x8_t c11 = MlasLoadFloat16x8(C_data + ldc + 8);
+                MlasStoreFloat16x8(C_data + ldc, vfmaq_f16(vmulq_f16(c10, beta_v), accu10, alpha_v));
+                MlasStoreFloat16x8(C_data + ldc + 8, vfmaq_f16(vmulq_f16(c11, beta_v), accu11, alpha_v));
+            }
+        } else {
+            float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
+            MlasStoreFloat16x8(C_data, vmulq_f16(accu00, alpha_v));
+            MlasStoreFloat16x8(C_data + 8, vmulq_f16(accu01, alpha_v));
+            if constexpr (CountM == 2) {
+                MlasStoreFloat16x8(C_data + ldc, vmulq_f16(accu10, alpha_v));
+                MlasStoreFloat16x8(C_data + ldc + 8, vmulq_f16(accu11, alpha_v));
+            }
+        }
+
+        CountN -= 16, B_data += 16, C_data += 16;
+    }
+
+    if (CountN & 8) {
+        const auto* a = A_data;
+        const auto* b = B_data;
+        size_t k = CountK;
+        float16x8_t accu00 = MlasZeroFloat16x8();
+        float16x8_t accu10;
+        if constexpr (CountM == 2) {
+            accu10 = MlasZeroFloat16x8();
+        }
+        for (; k >= 8; k -= 8, a += 8, b += ldb8) {
+            float16x8_t a0 = MlasLoadFloat16x8(a), a1;
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadFloat16x8(a + lda);
+            }
+            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10);
+        }
+
+        if (k & 4) {
+            float16x4_t a0 = MlasLoadFloat16x4(a), a1;
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadFloat16x4(a + lda);
+            }
+            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10);
+            k -= 4, a += 4, b += 4 * ldb;
+        }
+
+        if (k > 0) {
+            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1;
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadPartialFloat16x4(a + lda, k);
+            }
+            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10, k);
+        }
+
+        if constexpr (beta_behavior == 1) {
+            float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
+            float16x8_t c00 = MlasLoadFloat16x8(C_data);
+            MlasStoreFloat16x8(C_data, vfmaq_f16(c00, accu00, alpha_v));
+            if constexpr (CountM == 2) {
+                float16x8_t c10 = MlasLoadFloat16x8(C_data + ldc);
+                MlasStoreFloat16x8(C_data + ldc, vfmaq_f16(c10, accu10, alpha_v));
+            }
+        } else if constexpr (beta_behavior == 2) {
+            float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
+            float16x8_t beta_v = MlasBroadcastFloat16x8(beta);
+            float16x8_t c00 = MlasLoadFloat16x8(C_data);
+            MlasStoreFloat16x8(C_data, vfmaq_f16(vmulq_f16(c00, beta_v), accu00, alpha_v));
+            if constexpr (CountM == 2) {
+                float16x8_t c10 = MlasLoadFloat16x8(C_data + ldc);
+                MlasStoreFloat16x8(C_data + ldc, vfmaq_f16(vmulq_f16(c10, beta_v), accu10, alpha_v));
+            }
+        } else {
+            float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
+            MlasStoreFloat16x8(C_data, vmulq_f16(accu00, alpha_v));
+            if constexpr (CountM == 2) {
+                MlasStoreFloat16x8(C_data + ldc, vmulq_f16(accu10, alpha_v));
+            }
+        }
+
+        CountN -= 8, B_data += 8, C_data += 8;
+    }
+
+    if (CountN & 4) {
+        const auto* a = A_data;
+        const auto* b = B_data;
+        size_t k = CountK;
+        float16x4_t accu00 = MlasZeroFloat16x4();
+        float16x4_t accu10;
+        if constexpr (CountM == 2) {
+            accu10 = MlasZeroFloat16x4();
+        }
+        for (; k >= 8; k -= 8, a += 8, b += ldb8) {
+            float16x8_t a0 = MlasLoadFloat16x8(a), a1;
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadFloat16x8(a + lda);
+            }
+            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10);
+        }
+
+        if (k & 4) {
+            float16x4_t a0 = MlasLoadFloat16x4(a), a1;
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadFloat16x4(a + lda);
+            }
+            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10);
+            k -= 4, a += 4, b += 4 * ldb;
+        }
+
+        if (k > 0) {
+            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1;
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadPartialFloat16x4(a + lda, k);
+            }
+            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10, k);
+        }
+
+        if constexpr (beta_behavior == 1) {
+            float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
+            float16x4_t c00 = MlasLoadFloat16x4(C_data);
+            MlasStoreFloat16x4(C_data, vfma_f16(c00, accu00, alpha_v));
+            if constexpr (CountM == 2) {
+                float16x4_t c10 = MlasLoadFloat16x4(C_data + ldc);
+                MlasStoreFloat16x4(C_data + ldc, vfma_f16(c10, accu10, alpha_v));
+            }
+        } else if constexpr (beta_behavior == 2) {
+            float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
+            float16x4_t beta_v = MlasBroadcastFloat16x4(beta);
+            float16x4_t c00 = MlasLoadFloat16x4(C_data);
+            MlasStoreFloat16x4(C_data, vfma_f16(vmul_f16(c00, beta_v), accu00, alpha_v));
+            if constexpr (CountM == 2) {
+                float16x4_t c10 = MlasLoadFloat16x4(C_data + ldc);
+                MlasStoreFloat16x4(C_data + ldc, vfma_f16(vmul_f16(c10, beta_v), accu10, alpha_v));
+            }
+        } else {
+            float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
+            MlasStoreFloat16x4(C_data, vmul_f16(accu00, alpha_v));
+            if constexpr (CountM == 2) {
+                MlasStoreFloat16x4(C_data + ldc, vmul_f16(accu10, alpha_v));
+            }
+        }
+
+        CountN -= 4, B_data += 4, C_data += 4;
+    }
+
+    if (CountN > 0) {
+        const auto* a = A_data;
+        const auto* b = B_data;
+        size_t k = CountK;
+        float16x4_t accu00 = MlasZeroFloat16x4();
+        float16x4_t accu10;
+        if constexpr (CountM == 2) {
+            accu10 = MlasZeroFloat16x4();
+        }
+        for (; k >= 8; k -= 8, a += 8, b += ldb8) {
+            float16x8_t a0 = MlasLoadFloat16x8(a), a1;
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadFloat16x8(a + lda);
+            }
+            ma_lane_partial_accu<CountM>(b, ldb, a0, accu00, a1, accu10, CountN);
+        }
+
+        if (k & 4) {
+            float16x4_t a0 = MlasLoadFloat16x4(a), a1;
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadFloat16x4(a + lda);
+            }
+            ma_lane_partial_accu<CountM>(b, ldb, a0, accu00, a1, accu10, CountN);
+            k -= 4, a += 4, b += 4 * ldb;
+        }
+
+        if (k > 0) {
+            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1;
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadPartialFloat16x4(a + lda, k);
+            }
+            ma_lane_partial_accu<CountM>(b, ldb, a0, accu00, a1, accu10, k, CountN);
+        }
+
+        if constexpr (beta_behavior == 1) {
+            float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
+            float16x4_t c00 = MlasLoadPartialFloat16x4(C_data, CountN);
+            MlasStorePartialFloat16x4(C_data, vfma_f16(c00, accu00, alpha_v), CountN);
+            if constexpr (CountM == 2) {
+                float16x4_t c10 = MlasLoadPartialFloat16x4(C_data + ldc, CountN);
+                MlasStorePartialFloat16x4(C_data + ldc, vfma_f16(c10, accu10, alpha_v), CountN);
+            }
+        } else if constexpr (beta_behavior == 2) {
+            float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
+            float16x4_t beta_v = MlasBroadcastFloat16x4(beta);
+            float16x4_t c00 = MlasLoadPartialFloat16x4(C_data, CountN);
+            MlasStorePartialFloat16x4(C_data, vfma_f16(vmul_f16(c00, beta_v), accu00, alpha_v), CountN);
+            if constexpr (CountM == 2) {
+                float16x4_t c10 = MlasLoadPartialFloat16x4(C_data + ldc, CountN);
+                MlasStorePartialFloat16x4(C_data + ldc, vfma_f16(vmul_f16(c10, beta_v), accu10, alpha_v), CountN);
+            }
+        } else {
+            float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
+            MlasStorePartialFloat16x4(C_data, vmul_f16(accu00, alpha_v), CountN);
+            if constexpr (CountM == 2) {
+                MlasStorePartialFloat16x4(C_data + ldc, vmul_f16(accu10, alpha_v), CountN);
+            }
+        }
+    }
+}
+
+void HGemm_B_Kernel(
+    const MLAS_FP16* A,
+    const MLAS_FP16* B,
+    MLAS_FP16* C,
+    size_t CountM,
+    size_t CountN,
+    size_t CountK,
+    size_t lda,
+    size_t ldb,
+    size_t ldc,
+    _mlas_fp16_ alpha,
+    _mlas_fp16_ beta
+) {
+    if (CountM > 2) {
+        MLAS_THROW_EX(std::runtime_error, "HGemm_TransposedB_Kernel only support <= 2 rows");
+    }
+    const auto* A_data = reinterpret_cast<const _mlas_fp16_*>(A);
+    const auto* B_data = reinterpret_cast<const _mlas_fp16_*>(B);
+    auto* C_data = reinterpret_cast<_mlas_fp16_*>(C);
+    const auto f16_0 = MLAS_FP16(0.0f);
+    const auto f16_1 = MLAS_FP16(1.0f);
+    if (CountM == 1) {
+        if (beta == f16_0.val) {
+            HGemm_B_Kernel_Impl<0, 1>(A_data, B_data, C_data, CountN, CountK, lda, ldb, ldc, alpha, beta);
+        } else if (beta == f16_1.val) {
+            HGemm_B_Kernel_Impl<1, 1>(A_data, B_data, C_data, CountN, CountK, lda, ldb, ldc, alpha, beta);
+        } else {
+            HGemm_B_Kernel_Impl<2, 1>(A_data, B_data, C_data, CountN, CountK, lda, ldb, ldc, alpha, beta);
+        }
+    } else {
+        if (beta == f16_0.val) {
+            HGemm_B_Kernel_Impl<0, 2>(A_data, B_data, C_data, CountN, CountK, lda, ldb, ldc, alpha, beta);
+        } else if (beta == f16_1.val) {
+            HGemm_B_Kernel_Impl<1, 2>(A_data, B_data, C_data, CountN, CountK, lda, ldb, ldc, alpha, beta);
+        } else {
+            HGemm_B_Kernel_Impl<2, 2>(A_data, B_data, C_data, CountN, CountK, lda, ldb, ldc, alpha, beta);
         }
     }
 }

--- a/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
@@ -303,6 +303,135 @@ void HPackB_TransposedB_Kernel(
     }
 }
 
+template <int CountN>
+MLAS_FORCEINLINE
+void HPackB_B_Kernel_Last8(
+    const _mlas_fp16_ *B,
+    _mlas_fp16_ *PackedB,
+    size_t CountK,
+    size_t ldb
+) {
+    if constexpr (CountN > 4) {
+        for (; CountK >= 8; B += ldb * 8, PackedB += 64, CountK -= 8) {
+            float16x4_t v0 = MlasLoadFloat16x4(B);
+            float16x4_t v1 = MlasLoadPartialFloat16x4(B + 4, CountN - 4);
+            float16x4_t v2 = MlasLoadFloat16x4(B + ldb);
+            float16x4_t v3 = MlasLoadPartialFloat16x4(B + ldb + 4, CountN - 4);
+            float16x4_t v4 = MlasLoadFloat16x4(B + 2 * ldb);
+            float16x4_t v5 = MlasLoadPartialFloat16x4(B + 2 * ldb + 4, CountN - 4);
+            float16x4_t v6 = MlasLoadFloat16x4(B + 3 * ldb);
+            float16x4_t v7 = MlasLoadPartialFloat16x4(B + 3 * ldb + 4, CountN - 4);
+            float16x4_t v8 = MlasLoadFloat16x4(B + 4 * ldb);
+            float16x4_t v9 = MlasLoadPartialFloat16x4(B + 4 * ldb + 4, CountN - 4);
+            float16x4_t vA = MlasLoadFloat16x4(B + 5 * ldb);
+            float16x4_t vB = MlasLoadPartialFloat16x4(B + 5 * ldb + 4, CountN - 4);
+            float16x4_t vC = MlasLoadFloat16x4(B + 6 * ldb);
+            float16x4_t vD = MlasLoadPartialFloat16x4(B + 6 * ldb + 4, CountN - 4);
+            float16x4_t vE = MlasLoadFloat16x4(B + 7 * ldb);
+            float16x4_t vF = MlasLoadPartialFloat16x4(B + 7 * ldb + 4, CountN - 4);
+            MlasStoreFloat16x4(PackedB, v0);
+            MlasStoreFloat16x4(PackedB + 4, v1);
+            MlasStoreFloat16x4(PackedB + 8, v2);
+            MlasStoreFloat16x4(PackedB + 12, v3);
+            MlasStoreFloat16x4(PackedB + 16, v4);
+            MlasStoreFloat16x4(PackedB + 20, v5);
+            MlasStoreFloat16x4(PackedB + 24, v6);
+            MlasStoreFloat16x4(PackedB + 28, v7);
+            MlasStoreFloat16x4(PackedB + 32, v8);
+            MlasStoreFloat16x4(PackedB + 36, v9);
+            MlasStoreFloat16x4(PackedB + 40, vA);
+            MlasStoreFloat16x4(PackedB + 44, vB);
+            MlasStoreFloat16x4(PackedB + 48, vC);
+            MlasStoreFloat16x4(PackedB + 52, vD);
+            MlasStoreFloat16x4(PackedB + 56, vE);
+            MlasStoreFloat16x4(PackedB + 60, vF);
+        }
+
+        if (CountK & 4) {
+            float16x4_t v0 = MlasLoadFloat16x4(B);
+            float16x4_t v1 = MlasLoadPartialFloat16x4(B + 4, CountN - 4);
+            float16x4_t v2 = MlasLoadFloat16x4(B + ldb);
+            float16x4_t v3 = MlasLoadPartialFloat16x4(B + ldb + 4, CountN - 4);
+            float16x4_t v4 = MlasLoadFloat16x4(B + 2 * ldb);
+            float16x4_t v5 = MlasLoadPartialFloat16x4(B + 2 * ldb + 4, CountN - 4);
+            float16x4_t v6 = MlasLoadFloat16x4(B + 3 * ldb);
+            float16x4_t v7 = MlasLoadPartialFloat16x4(B + 3 * ldb + 4, CountN - 4);
+            MlasStoreFloat16x4(PackedB, v0);
+            MlasStoreFloat16x4(PackedB + 4, v1);
+            MlasStoreFloat16x4(PackedB + 8, v2);
+            MlasStoreFloat16x4(PackedB + 12, v3);
+            MlasStoreFloat16x4(PackedB + 16, v4);
+            MlasStoreFloat16x4(PackedB + 20, v5);
+            MlasStoreFloat16x4(PackedB + 24, v6);
+            MlasStoreFloat16x4(PackedB + 28, v7);
+            B += 4 * ldb, PackedB += 32;
+        }
+
+        if (CountK & 2) {
+            float16x4_t v0 = MlasLoadFloat16x4(B);
+            float16x4_t v1 = MlasLoadPartialFloat16x4(B + 4, CountN - 4);
+            float16x4_t v2 = MlasLoadFloat16x4(B + ldb);
+            float16x4_t v3 = MlasLoadPartialFloat16x4(B + ldb + 4, CountN - 4);
+            MlasStoreFloat16x4(PackedB, v0);
+            MlasStoreFloat16x4(PackedB + 4, v1);
+            MlasStoreFloat16x4(PackedB + 8, v2);
+            MlasStoreFloat16x4(PackedB + 12, v3);
+            B += 2 * ldb, PackedB += 16;
+        }
+
+        if (CountK & 1) {
+            float16x4_t v0 = MlasLoadPartialFloat16x4(B, CountN);
+            float16x4_t v1 = MlasLoadPartialFloat16x4(B + 4, CountN - 4);
+            MlasStoreFloat16x4(PackedB, v0);
+            MlasStoreFloat16x4(PackedB + 4, v1);
+        }
+    } else {
+        for (; CountK >= 8; B += 8 * ldb, PackedB += 64, CountK -= 8) {
+            float16x4_t v0 = MlasLoadPartialFloat16x4(B, CountN);
+            float16x4_t v1 = MlasLoadPartialFloat16x4(B + ldb, CountN);
+            float16x4_t v2 = MlasLoadPartialFloat16x4(B + 2 * ldb, CountN);
+            float16x4_t v3 = MlasLoadPartialFloat16x4(B + 3 * ldb, CountN);
+            float16x4_t v4 = MlasLoadPartialFloat16x4(B + 4 * ldb, CountN);
+            float16x4_t v5 = MlasLoadPartialFloat16x4(B + 5 * ldb, CountN);
+            float16x4_t v6 = MlasLoadPartialFloat16x4(B + 6 * ldb, CountN);
+            float16x4_t v7 = MlasLoadPartialFloat16x4(B + 7 * ldb, CountN);
+            MlasStoreFloat16x4(PackedB, v0);
+            MlasStoreFloat16x4(PackedB + 8, v1);
+            MlasStoreFloat16x4(PackedB + 16, v2);
+            MlasStoreFloat16x4(PackedB + 24, v3);
+            MlasStoreFloat16x4(PackedB + 32, v4);
+            MlasStoreFloat16x4(PackedB + 40, v5);
+            MlasStoreFloat16x4(PackedB + 48, v6);
+            MlasStoreFloat16x4(PackedB + 56, v7);
+        }
+
+        if (CountK & 4) {
+            float16x4_t v0 = MlasLoadPartialFloat16x4(B, CountN);
+            float16x4_t v1 = MlasLoadPartialFloat16x4(B + ldb, CountN);
+            float16x4_t v2 = MlasLoadPartialFloat16x4(B + 2 * ldb, CountN);
+            float16x4_t v3 = MlasLoadPartialFloat16x4(B + 3 * ldb, CountN);
+            MlasStoreFloat16x4(PackedB, v0);
+            MlasStoreFloat16x4(PackedB + 4, v1);
+            MlasStoreFloat16x4(PackedB + 8, v2);
+            MlasStoreFloat16x4(PackedB + 12, v3);
+            B += 4 * ldb, PackedB += 32;
+        }
+
+        if (CountK & 2) {
+            float16x4_t v0 = MlasLoadPartialFloat16x4(B, CountN);
+            float16x4_t v1 = MlasLoadPartialFloat16x4(B + ldb, CountN);
+            MlasStoreFloat16x4(PackedB, v0);
+            MlasStoreFloat16x4(PackedB + 4, v1);
+            B += 2 * ldb, PackedB += 16;
+        }
+
+        if (CountK & 1) {
+            float16x4_t v0 = MlasLoadPartialFloat16x4(B, CountN);
+            MlasStoreFloat16x4(PackedB, v0);
+        }
+    }
+}
+
 void HPackB_B_Kernel(
     const MLAS_FP16* B,
     MLAS_FP16* PackedB,
@@ -452,17 +581,20 @@ void HPackB_B_Kernel(
         CountN -= 8;
     }
 
-    // TODO
     if (CountN == 7) {
-        const _mlas_fp16_* b = B_data;
-        for (size_t i = 0; i < CountK; ++i, b += ldb, PackedB_data += 8) {
-            float16x4_t v0 = MlasLoadFloat16x4(b);
-            float16x4_t v1 = MlasLoadPartialFloat16x4(b + 4, 3);
-            MlasStoreFloat16x4(PackedB_data, v0);
-            MlasStoreFloat16x4(PackedB_data + 4, v1);
-        }
-    } else {
-
+        HPackB_B_Kernel_Last8<7>(B_data, PackedB_data, CountK, ldb);
+    } else if (CountN == 6) {
+        HPackB_B_Kernel_Last8<6>(B_data, PackedB_data, CountK, ldb);
+    } else if (CountN == 5) {
+        HPackB_B_Kernel_Last8<5>(B_data, PackedB_data, CountK, ldb);
+    } else if (CountN == 4) {
+        HPackB_B_Kernel_Last8<4>(B_data, PackedB_data, CountK, ldb);
+    } else if (CountN == 3) {
+        HPackB_B_Kernel_Last8<3>(B_data, PackedB_data, CountK, ldb);
+    } else if (CountN == 2) {
+        HPackB_B_Kernel_Last8<2>(B_data, PackedB_data, CountK, ldb);
+    } else if (CountN == 1) {
+        HPackB_B_Kernel_Last8<1>(B_data, PackedB_data, CountK, ldb);
     }
 }
 

--- a/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
@@ -1288,30 +1288,23 @@ void ma_lane_accu(
     float16x8_t& accu1,
     size_t countK
 ) {
-    float16x8_t b0 = MlasLoadFloat16x8(b), b1, b2, b3;
+    float16x8_t b0 = MlasLoadFloat16x8(b);
     accu0 = vfmaq_lane_f16(accu0, b0, a0, 0);
     if constexpr (CountM == 2) {
         accu1 = vfmaq_lane_f16(accu1, b0, a1, 0);
     }
     if (countK > 1) {
-        b1 = MlasLoadFloat16x8(b + ldb);
+        float16x8_t b1 = MlasLoadFloat16x8(b + ldb);
         accu0 = vfmaq_lane_f16(accu0, b1, a0, 1);
         if constexpr (CountM == 2) {
-            accu1 = vfmaq_lane_f16(accu1, b0, a1, 1);
+            accu1 = vfmaq_lane_f16(accu1, b1, a1, 1);
         }
     }
     if (countK > 2) {
-        b2 = MlasLoadFloat16x8(b + 2 * ldb);
+        float16x8_t b2 = MlasLoadFloat16x8(b + 2 * ldb);
         accu0 = vfmaq_lane_f16(accu0, b2, a0, 2);
         if constexpr (CountM == 2) {
-            accu1 = vfmaq_lane_f16(accu1, b0, a1, 2);
-        }
-    }
-    if (countK > 3) {
-        b3 = MlasLoadFloat16x8(b + 3 * ldb);
-        accu0 = vfmaq_lane_f16(accu0, b3, a0, 3);
-        if constexpr (CountM == 2) {
-            accu1 = vfmaq_lane_f16(accu1, b0, a1, 3);
+            accu1 = vfmaq_lane_f16(accu1, b2, a1, 2);
         }
     }
 }
@@ -1327,30 +1320,23 @@ void ma_lane_accu(
     float16x4_t& accu1,
     size_t countK
 ) {
-    float16x4_t b0 = MlasLoadFloat16x4(b), b1, b2, b3;
+    float16x4_t b0 = MlasLoadFloat16x4(b);
     accu0 = vfma_lane_f16(accu0, b0, a0, 0);
     if constexpr (CountM == 2) {
         accu1 = vfma_lane_f16(accu1, b0, a1, 0);
     }
     if (countK > 1) {
-        b1 = MlasLoadFloat16x4(b + ldb);
+        float16x4_t b1 = MlasLoadFloat16x4(b + ldb);
         accu0 = vfma_lane_f16(accu0, b1, a0, 1);
         if constexpr (CountM == 2) {
-            accu1 = vfma_lane_f16(accu1, b0, a1, 1);
+            accu1 = vfma_lane_f16(accu1, b1, a1, 1);
         }
     }
     if (countK > 2) {
-        b2 = MlasLoadFloat16x4(b + 2 * ldb);
+        float16x4_t b2 = MlasLoadFloat16x4(b + 2 * ldb);
         accu0 = vfma_lane_f16(accu0, b2, a0, 2);
         if constexpr (CountM == 2) {
-            accu1 = vfma_lane_f16(accu1, b0, a1, 2);
-        }
-    }
-    if (countK > 3) {
-        b3 = MlasLoadFloat16x4(b + 3 * ldb);
-        accu0 = vfma_lane_f16(accu0, b3, a0, 3);
-        if constexpr (CountM == 2) {
-            accu1 = vfma_lane_f16(accu1, b0, a1, 3);
+            accu1 = vfma_lane_f16(accu1, b2, a1, 2);
         }
     }
 }
@@ -1367,30 +1353,23 @@ void ma_lane_partial_accu(
     size_t countK,
     size_t countN
 ) {
-    float16x4_t b0 = MlasLoadPartialFloat16x4(b, countN), b1, b2, b3;
+    float16x4_t b0 = MlasLoadPartialFloat16x4(b, countN);
     accu0 = vfma_lane_f16(accu0, b0, a0, 0);
     if constexpr (CountM == 2) {
         accu1 = vfma_lane_f16(accu1, b0, a1, 0);
     }
     if (countK > 1) {
-        b1 = MlasLoadPartialFloat16x4(b + ldb, countN);
+        float16x4_t b1 = MlasLoadPartialFloat16x4(b + ldb, countN);
         accu0 = vfma_lane_f16(accu0, b1, a0, 1);
         if constexpr (CountM == 2) {
-            accu1 = vfma_lane_f16(accu1, b0, a1, 1);
+            accu1 = vfma_lane_f16(accu1, b1, a1, 1);
         }
     }
     if (countK > 2) {
-        b2 = MlasLoadPartialFloat16x4(b + 2 * ldb, countN);
+        float16x4_t b2 = MlasLoadPartialFloat16x4(b + 2 * ldb, countN);
         accu0 = vfma_lane_f16(accu0, b2, a0, 2);
         if constexpr (CountM == 2) {
-            accu1 = vfma_lane_f16(accu1, b0, a1, 2);
-        }
-    }
-    if (countK > 3) {
-        b3 = MlasLoadPartialFloat16x4(b + 3 * ldb, countN);
-        accu0 = vfma_lane_f16(accu0, b3, a0, 3);
-        if constexpr (CountM == 2) {
-            accu1 = vfma_lane_f16(accu1, b0, a1, 3);
+            accu1 = vfma_lane_f16(accu1, b2, a1, 2);
         }
     }
 }

--- a/onnxruntime/core/mlas/lib/hgemm_kernel_neon.cpp
+++ b/onnxruntime/core/mlas/lib/hgemm_kernel_neon.cpp
@@ -21,8 +21,10 @@ const MLAS_HGEMM_DISPATCH MlasHGemmDispatchNeon = [](){
     MLAS_HGEMM_DISPATCH d;
 #if defined(MLAS_F16VEC_INTRINSICS_SUPPORTED) && defined(MLAS_TARGET_ARM64)
     d.HPackBKernel_TransposedB = hgemm_neon::HPackB_TransposedB_Kernel;
+    d.HPackBKernel_B = hgemm_neon::HPackB_B_Kernel;
     d.HGemmKernel_TransposedB = hgemm_neon::HGemm_TransposedB_Kernel;
-    d.HGemmKernel_TransposedPackedB = hgemm_neon::HGemm_TransposedPackedB_Kernel;
+    d.HGemmKernel_B = hgemm_neon::HGemm_B_Kernel;
+    d.HGemmKernel_PackedB = hgemm_neon::HGemm_PackedB_Kernel;
 #endif
     return d;
 }();

--- a/onnxruntime/test/mlas/bench/bench_hgemm.cpp
+++ b/onnxruntime/test/mlas/bench/bench_hgemm.cpp
@@ -72,15 +72,18 @@ static void GemmSizeWithOne(benchmark::internal::Benchmark* b) {
   b->ArgsProduct({{63, 255, 1023}, {63, 255, 1023}, {1}});
 }
 BENCHMARK_CAPTURE(HGEMM, GEMV_TransB, false, true)->Apply(GemmSizeWithOne)->UseRealTime();
+BENCHMARK_CAPTURE(HGEMM, GEMV_B, false, false)->Apply(GemmSizeWithOne)->UseRealTime();
 
 static void GemmSizeProducts(benchmark::internal::Benchmark* b) {
   b->ArgNames(hgemm_bench_arg_names);
   b->ArgsProduct({{63, 255, 1023}, {63, 255, 1023}, {63, 255, 1023}});
 }
 BENCHMARK_CAPTURE(HGEMM, NORMAL_TransB, false, true)->Apply(GemmSizeProducts)->UseRealTime();
+BENCHMARK_CAPTURE(HGEMM, NORMAL_B, false, false)->Apply(GemmSizeProducts)->UseRealTime();
 
 static void GemmLLMSizeProducts(benchmark::internal::Benchmark* b) {
   b->ArgNames(hgemm_bench_arg_names);
   b->ArgsProduct({{1, 1024, 2048}, {4096, 11008}, {4096, 11008}});
 }
-BENCHMARK_CAPTURE(HGEMM, LLM, false, true)->Apply(GemmLLMSizeProducts)->UseRealTime();
+BENCHMARK_CAPTURE(HGEMM, LLM_TransB, false, true)->Apply(GemmLLMSizeProducts)->UseRealTime();
+BENCHMARK_CAPTURE(HGEMM, LLM_B, false, false)->Apply(GemmLLMSizeProducts)->UseRealTime();

--- a/onnxruntime/test/mlas/unittest/test_hgemm_neon.cpp
+++ b/onnxruntime/test/mlas/unittest/test_hgemm_neon.cpp
@@ -269,7 +269,7 @@ class MlasNeonHGemmTransposedPackedBTest : public MlasTestBase {
     const auto* B = B_.GetFilledBuffer(K * ((N + 7) & ~7), InitializeBuffer);
     auto* C = C_.GetBuffer(M * N, true);
     auto* ref = ref_.GetBuffer(M * N, true);
-    hgemm_neon::HGemm_TransposedPackedB_Kernel(A, B, C, M, N, K, K, N, alpha.val, beta.val);
+    hgemm_neon::HGemm_PackedB_Kernel(A, B, C, M, N, K, K, N, alpha.val, beta.val);
     HGemm<M, K, N>(A, B, ref, alpha, beta);
     Check<M, K, N>(C, ref);
   }

--- a/onnxruntime/test/mlas/unittest/test_hgemm_neon.cpp
+++ b/onnxruntime/test/mlas/unittest/test_hgemm_neon.cpp
@@ -348,6 +348,17 @@ class MlasNeonHGemmBTest : public MlasTestBase {
     TestHGemm<1, 32, 33>(MLAS_FP16(1.5f), MLAS_FP16(0.5f));
     TestHGemm<1, 78, 263>(MLAS_FP16(0.5f), MLAS_FP16(0.0f));
     TestHGemm<2, 267, 79>(MLAS_FP16(1.5f), MLAS_FP16(1.0f));
+    TestHGemm<2, 1, 1>(MLAS_FP16(1.0f), MLAS_FP16(1.0f));
+    TestHGemm<1, 1, 1>(MLAS_FP16(1.f), MLAS_FP16(0.0f));
+    TestHGemm<2, 1, 1>(MLAS_FP16(1.f), MLAS_FP16(0.f));
+    TestHGemm<1, 15, 17>(MLAS_FP16(1.0f), MLAS_FP16(0.0f));
+    TestHGemm<2, 17, 15>(MLAS_FP16(1.f), MLAS_FP16(1.0f));
+    TestHGemm<1, 17, 15>(MLAS_FP16(1.f), MLAS_FP16(1.f));
+    TestHGemm<1, 33, 31>(MLAS_FP16(1.0f), MLAS_FP16(0.0f));
+    TestHGemm<2, 31, 32>(MLAS_FP16(1.f), MLAS_FP16(1.0f));
+    TestHGemm<1, 32, 33>(MLAS_FP16(1.f), MLAS_FP16(0.f));
+    TestHGemm<1, 78, 263>(MLAS_FP16(1.f), MLAS_FP16(0.0f));
+    TestHGemm<2, 267, 79>(MLAS_FP16(1.f), MLAS_FP16(1.0f));
   }
 };
 

--- a/onnxruntime/test/mlas/unittest/test_hgemm_neon.cpp
+++ b/onnxruntime/test/mlas/unittest/test_hgemm_neon.cpp
@@ -99,13 +99,13 @@ class MlasNeonHGemmPackBTest : public MlasTestBase {
     for (; j + 15 < N; j += 16) {
       for (size_t i = 0; i < 16 * K; ++i) {
         ASSERT_EQ(packed[j * K + i].val, ref[j * K + i].val)
-          << " seed " << seed_ << " K " << i / 16 << " N " << j + i % 16;
+            << " seed " << seed_ << " K " << i / 16 << " N " << j + i % 16;
       }
     }
     if (j + 7 < N) {
       for (size_t i = 0; i < 8 * K; ++i) {
         ASSERT_EQ(packed[j * K + i].val, ref[j * K + i].val)
-          << " seed " << seed_ << " K " << i / 8 << " N " << j + i % 8;
+            << " seed " << seed_ << " K " << i / 8 << " N " << j + i % 8;
       }
       j += 8;
     }
@@ -113,7 +113,7 @@ class MlasNeonHGemmPackBTest : public MlasTestBase {
       for (size_t i = 0; i < K; ++i) {
         for (size_t k = 0; k < N - j; ++k) {
           ASSERT_EQ(packed[j * K + i * 8 + k].val, ref[j * K + i * 8 + k].val)
-            << " seed " << seed_ << " K " << i << " N " << j + k;
+              << " seed " << seed_ << " K " << i << " N " << j + k;
         }
       }
     }


### PR DESCRIPTION
### Description
add notrans hgemm mlas kernel for arm cpu. optimized for large K and small N.

| Test            | M    | N     | K     | HGEMM time (ns) | SGEMM time (ns) | HGEMM speed up % |
|-----------------|------|-------|-------|-----------------|-----------------|------------------|
| LLM  | 1    | 4096  | 4096  | 446793          | 1579150         | 71.71            |
| LLM  | 1024 | 4096  | 4096  | 100206500       | 115864382       | 13.51            |
| LLM  | 2048 | 4096  | 4096  | 201124807       | 257143151       | 21.78            |
| LLM  | 1    | 11008 | 4096  | 1270891         | 4310119         | 70.51            |
| LLM  | 1024 | 11008 | 4096  | 267071834       | 320892617       | 16.77            |
| LLM  | 2048 | 11008 | 4096  | 537345913       | 755739716       | 28.90            |
| LLM  | 1    | 4096  | 11008 | 1452455         | 3632642         | 60.02            |
| LLM  | 1024 | 4096  | 11008 | 281601378       | 326769587       | 13.82            |
| LLM  | 2048 | 4096  | 11008 | 562710674       | 704394097       | 20.11            |
| LLM  | 1    | 11008 | 11008 | 3695318         | 9442217         | 60.86            |
| LLM  | 1024 | 11008 | 11008 | 756445906       | 872947830       | 13.35            |
| LLM  | 2048 | 11008 | 11008 | 1521540547      | 1871241874      | 18.69            |

### Motivation and Context
used in gqa value calculation


