### PR TITLE
Set ANDROID_AVD_HOME env variable

### DIFF
--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -112,6 +112,7 @@ stages:
   dependsOn: []
   condition: notIn(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')
   variables:
+    ANDROID_AVD_HOME: $(Agent.TempDirectory)
     Codeql.ProjectConfigPath: .github/workflows
     Codeql.Enabled: true
     Codeql.Language: cpp
@@ -182,6 +183,8 @@ stages:
   displayName: NNAPI MAIN BUILD&TEST
   dependsOn: []
   condition: in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')
+  variables:
+    ANDROID_AVD_HOME: $(Agent.TempDirectory)
   jobs:
   - job: NNAPI_EP_MASTER
     pool: onnxruntime-Ubuntu2204-AMD-CPU

--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -53,6 +53,7 @@ stages:
   dependsOn: []
   variables:
     Codeql.Enabled: false
+    ANDROID_AVD_HOME: $(Agent.TempDirectory)
   jobs:
   - job: BUILD_AND_TEST_CPU
     pool: onnxruntime-Ubuntu2204-AMD-CPU

--- a/tools/ci_build/github/azure-pipelines/stages/jobs/react-natvie-andriod-e2e-test-job.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/jobs/react-natvie-andriod-e2e-test-job.yml
@@ -18,6 +18,7 @@ jobs:
   pool: 'onnxruntime-Ubuntu2204-AMD-CPU'
   variables:
     runCodesignValidationInjection: false
+    ANDROID_AVD_HOME: $(Agent.TempDirectory)
   timeoutInMinutes: 90
   steps:
   - task: UsePythonVersion@0

--- a/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar-test.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar-test.yml
@@ -26,6 +26,7 @@ jobs:
     clean: all
   variables:
     runCodesignValidationInjection: false
+    ANDROID_AVD_HOME: $(Agent.TempDirectory)
   timeoutInMinutes: 90
   steps:
   - template: set-version-number-variables-step.yml


### PR DESCRIPTION
### Description
Set ANDROID_AVD_HOME env variable

To run Android tests on Linux we need two command line tools:
1. Android  avdmanager for creating AVDs
2. Android "emulator" for running AVDs

By default "avdmanager" put images in ~/.android/avd/  

Android emulator by default search AVD files in the following places:

-  $ANDROID_AVD_HOME
-  $ANDROID_SDK_HOME/avd
-  $HOME/.android/avd

However, somehow sometimes "avdmanager" put images in "$HOME/.config/.android/avd" folder instead of "$HOME/.android/avd/ ". Cannot explain. A lot of people have hit this issue. For example: https://github.com/orgs/NativeScript/discussions/10546 and https://stackoverflow.com/questions/78919031/has-android-studio-recently-changed-its-default-avd-storage-location .

So I set the "ANDROID_AVD_HOME" environment variable to avoid such confusions. 

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


