### PR TITLE
Mapping ORT verbose log level to QNN verbose log level

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -308,7 +308,7 @@ QnnLog_Level_t QnnBackendManager::MapOrtSeverityToQNNLogLevel(logging::Severity 
   // Map ORT log severity to Qnn log level
   switch (ort_log_level) {
     case logging::Severity::kVERBOSE:
-      return QNN_LOG_LEVEL_DEBUG;
+      return QNN_LOG_LEVEL_VERBOSE;
     case logging::Severity::kINFO:
       return QNN_LOG_LEVEL_INFO;
     case logging::Severity::kWARNING:


### PR DESCRIPTION

### Description
Mapping ORT verbose log level to QNN verbose log level instead of debug log level. QNN debug log level is suppose for debug build only. Which mean ORT is supposed to not able to see any debug logs from QNN release build.


