### PR TITLE
Avoid compiling wil on non-Windows platforms

### DIFF
--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -537,11 +537,13 @@ endif()
 
 include(external/eigen.cmake)
 
-if(onnxruntime_USE_VCPKG AND WIN32)
-  find_package(wil CONFIG REQUIRED)
-  set(WIL_TARGET "WIL::WIL")
-else()
-  include(wil) # FetchContent
+if(WIN32)
+  if(onnxruntime_USE_VCPKG)
+    find_package(wil CONFIG REQUIRED)
+    set(WIL_TARGET "WIL::WIL")
+  else()
+    include(wil) # FetchContent
+  endif()
 endif()
 
 # XNNPACK EP


### PR DESCRIPTION
### Description

Avoid compiling wil on non-Windows platforms

### Motivation and Context

To resolve an issue reported in https://github.com/microsoft/onnxruntime/issues/23661#issuecomment-2655110677 