### PR TITLE
[VitisAI] fix throw on dfs

### DIFF
--- a/onnxruntime/core/providers/vitisai/imp/global_api.cc
+++ b/onnxruntime/core/providers/vitisai/imp/global_api.cc
@@ -503,6 +503,7 @@ vaip_core::OrtApiForVaip* create_org_api_hook() {
   the_global_api.graph_remove_initialized_tensor = [](Graph& graph, const std::string& tensor_name) {
     graph.RemoveInitializedTensor(tensor_name);
   };
+  the_global_api.graph_reverse_dfs_from_preemp = vaip::graph_reverse_dfs_from;
   if (!s_library_vitisaiep.vaip_get_version) {
     return reinterpret_cast<vaip_core::OrtApiForVaip*>(&(the_global_api.host_));
   } else {

--- a/onnxruntime/core/providers/vitisai/include/vaip/graph.h
+++ b/onnxruntime/core/providers/vitisai/include/vaip/graph.h
@@ -3,6 +3,8 @@
 #pragma once
 #include "./node.h"
 #include "vaip/my_ort.h"
+#include <gsl/gsl>
+#include <functional>
 namespace vaip {
 using namespace onnxruntime;
 
@@ -16,4 +18,12 @@ Node& graph_fuse(Graph& graph, const std::string& name, const std::string& op_ty
                  const std::vector<std::string>& inputs, const std::vector<std::string>& outputs,
                  const std::vector<std::string>& constant_initializers);
 Model* model_clone(const Model& original_model, int64_t external_data_threshold);
+
+void graph_reverse_dfs_from(
+    const Graph& graph, gsl::span<const Node* const> from,
+    const std::function<bool(const Node*)>& enter,
+    const std::function<bool(const Node*)>& leave,
+    const std::function<bool(const Node*, const Node*)>& comp,
+    const std::function<bool(const Node* from, const Node* to)>&
+        stop);
 }  // namespace vaip

--- a/onnxruntime/core/providers/vitisai/include/vaip/vaip_ort_api.h
+++ b/onnxruntime/core/providers/vitisai/include/vaip/vaip_ort_api.h
@@ -13,7 +13,7 @@ struct OrtApi;
 
 namespace vaip_core {
 
-#define VAIP_ORT_API_MAJOR (13u)
+#define VAIP_ORT_API_MAJOR (14u)
 #define VAIP_ORT_API_MINOR (0u)
 #define VAIP_ORT_API_PATCH (0u)
 struct OrtApiForVaip {
@@ -243,6 +243,13 @@ struct OrtApiForVaip {
                                       const std::vector<int64_t>& shape,
                                       const std::vector<uint8_t>& data);                  // [101]
   void (*graph_remove_initialized_tensor)(Graph& graph, const std::string& tensor_name);  // [102]
+  void (*graph_reverse_dfs_from_preemp)(
+      const Graph& graph, gsl::span<const Node* const> from,
+      const std::function<bool(const Node*)>& enter,
+      const std::function<bool(const Node*)>& leave,
+      const std::function<bool(const Node*, const Node*)>& comp,
+      const std::function<bool(const Node* from, const Node* to)>&
+          stop);  // [103]
 };
 
 #ifndef USE_VITISAI


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Add customized version for reverse dfs which can exit early if the graph is altered.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
This is requested by MSFT. We used to use throw exception to exit reverse dfs and this is not preferred by MSFT.

