### PR TITLE
[VitisAI] Fix the issue where the model saved by graph_save is not sorted.

### DIFF
--- a/onnxruntime/core/providers/vitisai/imp/graph.cc
+++ b/onnxruntime/core/providers/vitisai/imp/graph.cc
@@ -109,6 +109,8 @@ void graph_save(const Graph& graph, const std::string& filename, const std::stri
   *model_proto->mutable_graph() = *graph_proto_subgraph;
   auto& logger = logging::LoggingManager::DefaultLogger();
   auto model = Model::Create(std::move(*model_proto), ToPathString(filename), nullptr, logger);
+  auto status = model->MainGraph().Resolve();
+  vai_assert(status.IsOK(), "graph resolve error:" + status.ErrorMessage());
   if (initializer_size_threshold == std::numeric_limits<size_t>::max()) {
     model_proto = model->ToProto();
   } else {


### PR DESCRIPTION
### Description
This PR ensures that the graph_save function calls the resolve function before saving the model, ensuring that the nodes are sorted.



### Motivation and Context
An unsorted model can cause errors in some scenarios. This change ensures that the saved model is a valid model.


