### PR TITLE
Exclude node quantization in RTN

### DIFF
--- a/onnxruntime/python/tools/quantization/matmul_4bits_quantizer.py
+++ b/onnxruntime/python/tools/quantization/matmul_4bits_quantizer.py
@@ -1213,6 +1213,13 @@ class MatMul4BitsQuantizer:
 
             kwargs["ratios"] = self.algo_config.ratios
 
+            """
+            neural-compressor uses fp32 to represent the node that skip quantization, it does not mean this node is fp32 type though.
+            https://github.com/intel/neural-compressor/blob/a617115b1490bbe6163c0024fb55bd260c8914df/neural_compressor/adaptor/ox_utils/weight_only.py#L343
+            """
+            for n in self.nodes_to_exclude:
+                weight_only_node_config[n] = "fp32"
+
             self.model = rtn_quantize(
                 model=self.model_path if self.model_path is not None else self.model.model,
                 weight_config=weight_only_node_config,


### PR DESCRIPTION
### Description
Exclude node quantization in RTN



### Motivation and Context
We want to do mixed quantization. Tested locally with success.
I originally submitted a PR https://github.com/intel/neural-compressor/pull/2114
But they suggested me to add `nodes_to_exclude` into `weight_config` when we call the API


