### PR TITLE
Remove duplicated mimalloc def

### DIFF
--- a/cmake/external/mimalloc.cmake
+++ b/cmake/external/mimalloc.cmake
@@ -1,7 +1,0 @@
-add_definitions(-DUSE_MIMALLOC)
-
-set(MI_OVERRIDE OFF CACHE BOOL "" FORCE)
-set(MI_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-set(MI_DEBUG_FULL OFF CACHE BOOL "" FORCE)
-set(MI_BUILD_SHARED OFF CACHE BOOL "" FORCE)
-onnxruntime_fetchcontent_makeavailable(mimalloc)

--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -91,6 +91,12 @@ endif()
 
 
 if(onnxruntime_USE_MIMALLOC)
+  add_definitions(-DUSE_MIMALLOC)
+
+  set(MI_OVERRIDE OFF CACHE BOOL "" FORCE)
+  set(MI_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+  set(MI_DEBUG_FULL OFF CACHE BOOL "" FORCE)
+  set(MI_BUILD_SHARED OFF CACHE BOOL "" FORCE)
   onnxruntime_fetchcontent_declare(
     mimalloc
     URL ${DEP_URL_mimalloc}
@@ -568,16 +574,6 @@ if (onnxruntime_USE_XNNPACK)
   else()
     include(xnnpack)
   endif()
-endif()
-
-if (onnxruntime_USE_MIMALLOC)
-  add_definitions(-DUSE_MIMALLOC)
-
-  set(MI_OVERRIDE OFF CACHE BOOL "" FORCE)
-  set(MI_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-  set(MI_DEBUG_FULL OFF CACHE BOOL "" FORCE)
-  set(MI_BUILD_SHARED OFF CACHE BOOL "" FORCE)
-  onnxruntime_fetchcontent_makeavailable(mimalloc)
 endif()
 
 set(onnxruntime_EXTERNAL_LIBRARIES ${onnxruntime_EXTERNAL_LIBRARIES_XNNPACK} ${WIL_TARGET} nlohmann_json::nlohmann_json


### PR DESCRIPTION
### Description
Duo to merge conflicts, our cmake scripts accidentally have 3 copies of the same mimalloc definitions. This PR removes the duplicated mimalloc definitions from the cmake scripts.


### Motivation and Context


