### PR TITLE
[js/web] remove "types" from "exports" field in package.json

### DIFF
--- a/js/web/package.json
+++ b/js/web/package.json
@@ -73,28 +73,23 @@
         "require": "./dist/ort.node.min.js"
       },
       "import": "./dist/ort.bundle.min.mjs",
-      "require": "./dist/ort.min.js",
-      "types": "./types.d.ts"
+      "require": "./dist/ort.min.js"
     },
     "./all": {
       "import": "./dist/ort.all.bundle.min.mjs",
-      "require": "./dist/ort.all.min.js",
-      "types": "./types.d.ts"
+      "require": "./dist/ort.all.min.js"
     },
     "./wasm": {
       "import": "./dist/ort.wasm.bundle.min.mjs",
-      "require": "./dist/ort.wasm.min.js",
-      "types": "./types.d.ts"
+      "require": "./dist/ort.wasm.min.js"
     },
     "./webgl": {
       "import": "./dist/ort.webgl.min.mjs",
-      "require": "./dist/ort.webgl.min.js",
-      "types": "./types.d.ts"
+      "require": "./dist/ort.webgl.min.js"
     },
     "./webgpu": {
       "import": "./dist/ort.webgpu.bundle.min.mjs",
-      "require": "./dist/ort.webgpu.min.js",
-      "types": "./types.d.ts"
+      "require": "./dist/ort.webgpu.min.js"
     }
   },
   "types": "./types.d.ts",


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Remove unused "types" field from "exports" field in package.json

### Motivation and Context

#23639 introduces update of esbuild. The new version warns about the "types" field in the "exports" field in package.json.

```
The condition "types" here will never be used as it comes after both "import" and "require" [package.json]

    web/package.json:77:6:
      77 │       "types": "./types.d.ts"
         ╵       ~~~~~~~
```
