### PR TITLE
[CUDA] Update preload_dlls to coexist with PyTorch

### DIFF
--- a/onnxruntime/__init__.py
+++ b/onnxruntime/__init__.py
@@ -94,7 +94,7 @@ def _get_package_version(package_name: str):
     return package_version
 
 
-def _get_package_root(package_name, directory_name=None):
+def _get_package_root(package_name: str, directory_name: str | None = None):
     from importlib.metadata import PackageNotFoundError, distribution
 
     root_directory_name = directory_name or package_name
@@ -152,7 +152,6 @@ def _get_nvidia_dll_paths(is_windows: bool, cuda: bool = True, cudnn: bool = Tru
             ("nvidia", "cudnn", "lib", "libcudnn.so.9"),
         ]
 
-    # Try load DLLs from site packages.
     return (cuda_dll_paths if cuda else []) + (cudnn_dll_paths if cudnn else [])
 
 
@@ -173,11 +172,11 @@ def print_debug_info():
     for dist in distributions():
         package = dist.metadata["Name"]
         if package == "onnxruntime" or package.startswith(("onnxruntime-", "ort-")):
+            # Exclude packages whose root directory name is not onnxruntime.
             location = _get_package_root(package, "onnxruntime")
-            if location:
-                if package not in ort_packages:
-                    ort_packages.append(package)
-                    print(f"{package}=={dist.version} at {location}")
+            if location and (package not in ort_packages):
+                ort_packages.append(package)
+                print(f"{package}=={dist.version} at {location}")
 
     if len(ort_packages) > 1:
         print(
@@ -315,6 +314,7 @@ def preload_dlls(cuda: bool = True, cudnn: bool = True, msvc: bool = True, direc
         print("Skip loading CUDA and cuDNN DLLs since torch is imported.")
         return
 
+    # Try load DLLs from nvidia site packages.
     dll_paths = _get_nvidia_dll_paths(is_windows, cuda, cudnn)
     loaded_dlls = []
     for relative_path in dll_paths:

--- a/onnxruntime/__init__.py
+++ b/onnxruntime/__init__.py
@@ -170,16 +170,17 @@ def print_debug_info():
     print("platform:", platform.platform())
 
     print("\nPython package, version and location:")
-    ort_package_count = 0
+    ort_packages = []
     for dist in distributions():
         package = dist.metadata["Name"]
         if package == "onnxruntime" or package.startswith(("onnxruntime-", "ort-")):
             location = _get_package_root(package, "onnxruntime")
             if location:
-                ort_package_count += 1
-                print(f"{package}=={dist.version} at {location}")
+                if package not in ort_packages:
+                    ort_packages.append(package)
+                    print(f"{package}=={dist.version} at {location}")
 
-    if ort_package_count > 1:
+    if len(ort_packages) > 1:
         print(
             "\033[33mWARNING: multiple onnxruntime packages are installed to the same location. "
             "Please 'pip uninstall` all above packages, then `pip install` only one of them.\033[0m"

--- a/onnxruntime/__init__.py
+++ b/onnxruntime/__init__.py
@@ -84,11 +84,181 @@ if version:
 onnxruntime_validation.check_distro_info()
 
 
-def preload_dlls(cuda: bool = True, cudnn: bool = True, msvc: bool = True, verbose: bool = False):
+def _get_package_version(package_name: str):
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        package_version = version(package_name)
+    except PackageNotFoundError:
+        package_version = None
+    return package_version
+
+
+def _get_package_root(package_name, directory_name=None):
+    from importlib.metadata import PackageNotFoundError, distribution
+
+    root_directory_name = directory_name or package_name
+    try:
+        dist = distribution(package_name)
+        files = dist.files or []
+
+        # Find the first file that matches the package name and ends with '__init__.py'
+        for file in files:
+            if file.name.endswith("__init__.py") and root_directory_name in file.parts:
+                return file.locate().parent
+
+        # Fallback to the first __init__.py
+        if not directory_name:
+            for file in files:
+                if file.name.endswith("__init__.py"):
+                    return file.locate().parent
+    except PackageNotFoundError:
+        # package not found, do nothing
+        pass
+
+    return None
+
+
+def _get_nvidia_dll_paths(is_windows: bool, cuda: bool = True, cudnn: bool = True):
+    if is_windows:
+        # Path is relative to site-packages directory.
+        cuda_dll_paths = [
+            ("nvidia", "cublas", "bin", "cublasLt64_12.dll"),
+            ("nvidia", "cublas", "bin", "cublas64_12.dll"),
+            ("nvidia", "cufft", "bin", "cufft64_11.dll"),
+            ("nvidia", "cuda_runtime", "bin", "cudart64_12.dll"),
+        ]
+        cudnn_dll_paths = [
+            ("nvidia", "cudnn", "bin", "cudnn_engines_runtime_compiled64_9.dll"),
+            ("nvidia", "cudnn", "bin", "cudnn_engines_precompiled64_9.dll"),
+            ("nvidia", "cudnn", "bin", "cudnn_heuristic64_9.dll"),
+            ("nvidia", "cudnn", "bin", "cudnn_ops64_9.dll"),
+            ("nvidia", "cudnn", "bin", "cudnn_adv64_9.dll"),
+            ("nvidia", "cudnn", "bin", "cudnn_graph64_9.dll"),
+            ("nvidia", "cudnn", "bin", "cudnn64_9.dll"),
+        ]
+    else:  # Linux
+        # cublas64 depends on cublasLt64, so cublasLt64 should be loaded first.
+        cuda_dll_paths = [
+            ("nvidia", "cublas", "lib", "libcublasLt.so.12"),
+            ("nvidia", "cublas", "lib", "libcublas.so.12"),
+            ("nvidia", "cuda_nvrtc", "lib", "libnvrtc.so.12"),
+            ("nvidia", "curand", "lib", "libcurand.so.10"),
+            ("nvidia", "cufft", "lib", "libcufft.so.11"),
+            ("nvidia", "cuda_runtime", "lib", "libcudart.so.12"),
+        ]
+
+        # Do not load cudnn sub DLLs (they will be dynamically loaded later) to be consistent with PyTorch in Linux.
+        cudnn_dll_paths = [
+            ("nvidia", "cudnn", "lib", "libcudnn.so.9"),
+        ]
+
+    # Try load DLLs from site packages.
+    return (cuda_dll_paths if cuda else []) + (cudnn_dll_paths if cudnn else [])
+
+
+def print_debug_info():
+    """Print information to help debugging."""
+    import importlib.util
+    import os
+    import platform
+    from importlib.metadata import distributions
+
+    print(f"{package_name} version: {__version__}")
+    if cuda_version:
+        print(f"CUDA version used in build: {cuda_version}")
+    print("platform:", platform.platform())
+
+    print("\nPython package, version and location:")
+    ort_package_count = 0
+    for dist in distributions():
+        package = dist.metadata["Name"]
+        if package == "onnxruntime" or package.startswith(("onnxruntime-", "ort-")):
+            location = _get_package_root(package, "onnxruntime")
+            if location:
+                ort_package_count += 1
+                print(f"{package}=={dist.version} at {location}")
+
+    if ort_package_count > 1:
+        print(
+            "\033[33mWARNING: multiple onnxruntime packages are installed to the same location. "
+            "Please 'pip uninstall` all above packages, then `pip install` only one of them.\033[0m"
+        )
+
+    if cuda_version:
+        # Print version of installed packages that is related to CUDA or cuDNN DLLs.
+        packages = [
+            "torch",
+            "nvidia-cuda-runtime-cu12",
+            "nvidia-cudnn-cu12",
+            "nvidia-cublas-cu12",
+            "nvidia-cufft-cu12",
+            "nvidia-curand-cu12",
+            "nvidia-cuda-nvrtc-cu12",
+            "nvidia-nvjitlink-cu12",
+        ]
+        for package in packages:
+            directory_name = "nvidia" if package.startswith("nvidia-") else None
+            version = _get_package_version(package)
+            if version:
+                print(f"{package}=={version} at {_get_package_root(package, directory_name)}")
+            else:
+                print(f"{package} not installed")
+
+    if platform.system() == "Windows":
+        print(f"\nEnvironment variable:\nPATH={os.environ['PATH']}")
+    elif platform.system() == "Linux":
+        print(f"\nEnvironment variable:\nLD_LIBRARY_PATH={os.environ['LD_LIBRARY_PATH']}")
+
+    if importlib.util.find_spec("psutil"):
+
+        def is_target_dll(path: str):
+            target_keywords = ["vcruntime140", "msvcp140"]
+            if cuda_version:
+                target_keywords = ["cufft", "cublas", "cudart", "nvrtc", "curand", "cudnn", *target_keywords]
+            return any(keyword in path for keyword in target_keywords)
+
+        import psutil
+
+        p = psutil.Process(os.getpid())
+
+        print("\nList of loaded DLLs:")
+        for lib in p.memory_maps():
+            if is_target_dll(lib.path.lower()):
+                print(lib.path)
+
+        if importlib.util.find_spec("cpuinfo") and importlib.util.find_spec("py3nvml"):
+            from .transformers.machine_info import get_device_info
+
+            print("\nDevice information:")
+            print(get_device_info())
+        else:
+            print("please `pip install py-cpuinfo py3nvml` to show device information.")
+    else:
+        print("please `pip install psutil` to show loaded DLLs.")
+
+
+def preload_dlls(cuda: bool = True, cudnn: bool = True, msvc: bool = True, directory=None):
+    """Preload CUDA 12.x and cuDNN 9.x DLLs in Windows or Linux, and MSVC runtime DLLs in Windows.
+
+       When you installed PyTorch that is compatible with CUDA 12.x, set `torch_safe` to True is recommended.
+       Note that there is no need to call this function if `import torch` is done before `import onnxruntime`.
+
+    Args:
+        cuda (bool, optional): enable loading CUDA DLLs. Defaults to True.
+        cudnn (bool, optional): enable loading cuDNN DLLs. Defaults to True.
+        msvc (bool, optional): enable loading MSVC DLLs in Windows. Defaults to True.
+        directory(str, optional): a directory contains CUDA or cuDNN DLLs. It can be an absolute path,
+           or a path relative to the directory of this file.
+           If directory is None (default value), the search order: the lib directory of PyTorch for cuda 12.x in Windows,
+           then nvidia site packages, finally default DLL loading paths.
+           If directory is empty string (""), the search order: nvidia site packages, finally default DLL loading paths.
+           If directory is a path, the search order: the directory, then default DLL loading paths.
+    """
     import ctypes
     import os
     import platform
-    import site
+    import sys
 
     if platform.system() not in ["Windows", "Linux"]:
         return
@@ -104,74 +274,71 @@ def preload_dlls(cuda: bool = True, cudnn: bool = True, msvc: bool = True, verbo
             print("Microsoft Visual C++ Redistributable is not installed, this may lead to the DLL load failure.")
             print("It can be downloaded at https://aka.ms/vs/17/release/vc_redist.x64.exe.")
 
-    if cuda_version and cuda_version.startswith("12.") and (cuda or cudnn):
-        # Paths are relative to nvidia root in site packages.
-        if is_windows:
-            cuda_dll_paths = [
-                ("cublas", "bin", "cublasLt64_12.dll"),
-                ("cublas", "bin", "cublas64_12.dll"),
-                ("cufft", "bin", "cufft64_11.dll"),
-                ("cuda_runtime", "bin", "cudart64_12.dll"),
-            ]
-            cudnn_dll_paths = [
-                ("cudnn", "bin", "cudnn_graph64_9.dll"),
-                ("cudnn", "bin", "cudnn64_9.dll"),
-            ]
-        else:  # Linux
-            # cublas64 depends on cublasLt64, so cublasLt64 should be loaded first.
-            cuda_dll_paths = [
-                ("cublas", "lib", "libcublasLt.so.12"),
-                ("cublas", "lib", "libcublas.so.12"),
-                ("cuda_nvrtc", "lib", "libnvrtc.so.12"),
-                ("curand", "lib", "libcurand.so.10"),
-                ("cufft", "lib", "libcufft.so.11"),
-                ("cuda_runtime", "lib", "libcudart.so.12"),
-            ]
-            cudnn_dll_paths = [
-                ("cudnn", "lib", "libcudnn_graph.so.9"),
-                ("cudnn", "lib", "libcudnn.so.9"),
-            ]
+    if not (cuda_version and cuda_version.startswith("12.")) and (cuda or cudnn):
+        print(
+            f"\033[33mWARNING: {package_name} is not built with CUDA 12.x support. "
+            "Please install a version that supports CUDA 12.x, or call preload_dlls with cuda=False and cudnn=False.\033[0m"
+        )
+        return
 
-        # Try load DLLs from nvidia site packages.
-        dll_paths = (cuda_dll_paths if cuda else []) + (cudnn_dll_paths if cudnn else [])
-        loaded_dlls = []
-        for site_packages_path in reversed(site.getsitepackages()):
-            nvidia_path = os.path.join(site_packages_path, "nvidia")
-            if os.path.isdir(nvidia_path):
-                for relative_path in dll_paths:
-                    dll_path = os.path.join(nvidia_path, *relative_path)
-                    if os.path.isfile(dll_path):
-                        try:
-                            _ = ctypes.CDLL(dll_path)
-                            loaded_dlls.append(relative_path[-1])
-                        except Exception as e:
-                            print(f"Failed to load {dll_path}: {e}")
-                break
+    if not (cuda_version and cuda_version.startswith("12.") and (cuda or cudnn)):
+        return
 
-        # Try load DLLs with default path settings.
-        has_failure = False
-        for relative_path in dll_paths:
-            dll_filename = relative_path[-1]
-            if dll_filename not in loaded_dlls:
-                try:
-                    _ = ctypes.CDLL(dll_filename)
-                except Exception as e:
-                    has_failure = True
-                    print(f"Failed to load {dll_filename}: {e}")
+    is_cuda_cudnn_imported_by_torch = False
 
-        if has_failure:
-            print("Please follow https://onnxruntime.ai/docs/install/#cuda-and-cudnn to install CUDA and CuDNN.")
+    if is_windows:
+        torch_version = _get_package_version("torch")
+        is_torch_for_cuda_12 = torch_version and "+cu12" in torch_version
+        if "torch" in sys.modules:
+            is_cuda_cudnn_imported_by_torch = is_torch_for_cuda_12
+            if (torch_version and "+cu" in torch_version) and not is_torch_for_cuda_12:
+                print(
+                    f"\033[33mWARNING: The installed PyTorch {torch_version} does not support CUDA 12.x. "
+                    f"Please install PyTorch for CUDA 12.x to be compatible with {package_name}.\033[0m"
+                )
 
-    if verbose:
+        if is_torch_for_cuda_12 and directory is None:
+            torch_root = _get_package_root("torch", "torch")
+            if torch_root:
+                directory = os.path.join(torch_root, "lib")
 
-        def is_target_dll(path: str):
-            target_keywords = ["cufft", "cublas", "cudart", "nvrtc", "curand", "cudnn", "vcruntime140", "msvcp140"]
-            return any(keyword in path for keyword in target_keywords)
+    base_directory = directory or ".."
+    if not os.path.isabs(base_directory):
+        base_directory = os.path.join(os.path.dirname(__file__), base_directory)
+    base_directory = os.path.normpath(base_directory)
+    if not os.path.isdir(base_directory):
+        raise RuntimeError(f"Invalid paramter of directory={directory}. The directory does not exist!")
 
-        import psutil
+    if is_cuda_cudnn_imported_by_torch:
+        # In Windows, PyTorch has loaded CUDA and cuDNN DLLs during `import torch`, no need to load them again.
+        print("Skip loading CUDA and cuDNN DLLs since torch is imported.")
+        return
 
-        p = psutil.Process(os.getpid())
-        print("----List of loaded DLLs----")
-        for lib in p.memory_maps():
-            if is_target_dll(lib.path.lower()):
-                print(lib.path)
+    dll_paths = _get_nvidia_dll_paths(is_windows, cuda, cudnn)
+    loaded_dlls = []
+    for relative_path in dll_paths:
+        dll_path = (
+            os.path.join(base_directory, relative_path[-1])
+            if directory
+            else os.path.join(base_directory, *relative_path)
+        )
+        if os.path.isfile(dll_path):
+            try:
+                _ = ctypes.CDLL(dll_path)
+                loaded_dlls.append(relative_path[-1])
+            except Exception as e:
+                print(f"Failed to load {dll_path}: {e}")
+
+    # Try load DLLs with default path settings.
+    has_failure = False
+    for relative_path in dll_paths:
+        dll_filename = relative_path[-1]
+        if dll_filename not in loaded_dlls:
+            try:
+                _ = ctypes.CDLL(dll_filename)
+            except Exception as e:
+                has_failure = True
+                print(f"Failed to load {dll_filename}: {e}")
+
+    if has_failure:
+        print("Please follow https://onnxruntime.ai/docs/install/#cuda-and-cudnn to install CUDA and CuDNN.")

--- a/onnxruntime/__init__.py
+++ b/onnxruntime/__init__.py
@@ -241,8 +241,8 @@ def print_debug_info():
 def preload_dlls(cuda: bool = True, cudnn: bool = True, msvc: bool = True, directory=None):
     """Preload CUDA 12.x and cuDNN 9.x DLLs in Windows or Linux, and MSVC runtime DLLs in Windows.
 
-       When you installed PyTorch that is compatible with CUDA 12.x, set `torch_safe` to True is recommended.
-       Note that there is no need to call this function if `import torch` is done before `import onnxruntime`.
+       When the installed PyTorch is compatible (using same major version of CUDA and cuDNN),
+       there is no need to call this function if `import torch` is done before `import onnxruntime`.
 
     Args:
         cuda (bool, optional): enable loading CUDA DLLs. Defaults to True.
@@ -250,10 +250,10 @@ def preload_dlls(cuda: bool = True, cudnn: bool = True, msvc: bool = True, direc
         msvc (bool, optional): enable loading MSVC DLLs in Windows. Defaults to True.
         directory(str, optional): a directory contains CUDA or cuDNN DLLs. It can be an absolute path,
            or a path relative to the directory of this file.
-           If directory is None (default value), the search order: the lib directory of PyTorch for cuda 12.x in Windows,
-           then nvidia site packages, finally default DLL loading paths.
-           If directory is empty string (""), the search order: nvidia site packages, finally default DLL loading paths.
-           If directory is a path, the search order: the directory, then default DLL loading paths.
+           If directory is None (default value), the search order: the lib directory of compatible PyTorch in Windows,
+            nvidia site packages, default DLL loading paths.
+           If directory is empty string (""), the search order: nvidia site packages, default DLL loading paths.
+           If directory is a path, the search order: the directory, default DLL loading paths.
     """
     import ctypes
     import os

--- a/onnxruntime/__init__.py
+++ b/onnxruntime/__init__.py
@@ -102,7 +102,6 @@ def _get_package_root(package_name, directory_name=None):
         dist = distribution(package_name)
         files = dist.files or []
 
-        # Find the first file that matches the package name and ends with '__init__.py'
         for file in files:
             if file.name.endswith("__init__.py") and root_directory_name in file.parts:
                 return file.locate().parent
@@ -228,13 +227,14 @@ def print_debug_info():
             if is_target_dll(lib.path.lower()):
                 print(lib.path)
 
-        if importlib.util.find_spec("cpuinfo") and importlib.util.find_spec("py3nvml"):
-            from .transformers.machine_info import get_device_info
+        if cuda_version:
+            if importlib.util.find_spec("cpuinfo") and importlib.util.find_spec("py3nvml"):
+                from .transformers.machine_info import get_device_info
 
-            print("\nDevice information:")
-            print(get_device_info())
-        else:
-            print("please `pip install py-cpuinfo py3nvml` to show device information.")
+                print("\nDevice information:")
+                print(get_device_info())
+            else:
+                print("please `pip install py-cpuinfo py3nvml` to show device information.")
     else:
         print("please `pip install psutil` to show loaded DLLs.")
 
@@ -308,7 +308,7 @@ def preload_dlls(cuda: bool = True, cudnn: bool = True, msvc: bool = True, direc
         base_directory = os.path.join(os.path.dirname(__file__), base_directory)
     base_directory = os.path.normpath(base_directory)
     if not os.path.isdir(base_directory):
-        raise RuntimeError(f"Invalid paramter of directory={directory}. The directory does not exist!")
+        raise RuntimeError(f"Invalid parameter of directory={directory}. The directory does not exist!")
 
     if is_cuda_cudnn_imported_by_torch:
         # In Windows, PyTorch has loaded CUDA and cuDNN DLLs during `import torch`, no need to load them again.

--- a/onnxruntime/python/tools/transformers/machine_info.py
+++ b/onnxruntime/python/tools/transformers/machine_info.py
@@ -215,6 +215,14 @@ def get_machine_info(silent=True) -> str:
     return json.dumps(machine.machine_info, indent=2)
 
 
+def get_device_info(silent=True) -> str:
+    machine = MachineInfo(silent)
+    info = machine.machine_info
+    if info:
+        info = {key: value for key, value in info.items() if key in ["gpu", "cpu", "memory"]}
+    return json.dumps(info, indent=2)
+
+
 if __name__ == "__main__":
     args = parse_arguments()
     print(get_machine_info(args.silent))


### PR DESCRIPTION
### Description

Update preload_dlls:
(1) Add a parameter `directory` to specify the DLL location.
(2) In Windows, skip loading CUDA/cuDNN dlls when torch for cuda 12.x has been imported.
(3) In Windows, default search order for CUDA/cuDNN dlls: lib directory of torch for cuda 12.x in Windows; nvidia site packages; default DLL loading paths. User can use the directory parameter to change search order. Use empty string will change search order to `nvidia site packages; default DLL loading paths`. Use a path if user wants to load DLLs from a specific location.
(4) Do not load cudnn sub DLLs in Linux.

The benefit of such change is that ORT could work seamlessly with PyTorch in both Linux and Windows. We also provide option for advanced users to load CUDA/cuDNN from a location specified by them.

### Examples in Windows

By default, preload_dlls will load CUDA and cuDNN DLLs from PyTorch if it is compatible:
```
>>> import onnxruntime
>>> onnxruntime.preload_dlls()
>>> onnxruntime.print_debug_info()
onnxruntime-gpu version: 1.21.0
CUDA version used in build: 12.6
platform: Windows-10-10.0.22631-SP0

Python package, version and location:
onnxruntime==1.20.1 at c:\users\abcd\.conda\envs\py310\lib\site-packages\onnxruntime
onnxruntime-gpu==1.21.0 at c:\users\abcd\.conda\envs\py310\lib\site-packages\onnxruntime
WARNING: multiple onnxruntime packages are installed to the same location. Please 'pip uninstall` all above packages, then `pip install` only one of them.
torch==2.6.0+cu126 at c:\users\abcd\.conda\envs\py310\lib\site-packages\torch
nvidia-cuda-runtime-cu12==12.8.57 at c:\users\abcd\.conda\envs\py310\lib\site-packages\nvidia
nvidia-cudnn-cu12==9.7.1.26 at c:\users\abcd\.conda\envs\py310\lib\site-packages\nvidia
nvidia-cublas-cu12==12.8.3.14 at c:\users\abcd\.conda\envs\py310\lib\site-packages\nvidia
nvidia-cufft-cu12==11.3.3.41 at c:\users\abcd\.conda\envs\py310\lib\site-packages\nvidia
nvidia-curand-cu12==10.3.7.77 at c:\users\abcd\.conda\envs\py310\lib\site-packages\nvidia
nvidia-cuda-nvrtc-cu12==12.6.85 at c:\users\abcd\.conda\envs\py310\lib\site-packages\nvidia
nvidia-nvjitlink-cu12==12.8.61 at c:\users\abcd\.conda\envs\py310\lib\site-packages\nvidia

Environment variable:
PATH=c:\users\abcd\.conda\envs\py310;c:\users\abcd\.conda\envs\py310\Library\usr\bin;c:\users\abcd\.conda\envs\py310\Library\bin;c:\users\abcd\.conda\envs\py310\Scripts;c:\users\abcd\.conda\envs\py310\bin;C:\ProgramData\anaconda3\condabin;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8\bin;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8\libnvvp;C:\windows\system32;

List of loaded DLLs:
c:\users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\cudnn_adv64_9.dll
c:\users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\cudnn_engines_precompiled64_9.dll
c:\users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\cufft64_11.dll
c:\users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\cublasLt64_12.dll
c:\users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\cudnn_ops64_9.dll
c:\users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\cublas64_12.dll
c:\users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\cudnn_heuristic64_9.dll
c:\users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\cudnn_engines_runtime_compiled64_9.dll
c:\users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\cudnn_graph64_9.dll
c:\users\abcd\.conda\envs\py310\Lib\site-packages\numpy.libs\msvcp140-263139962577ecda4cd9469ca360a746.dll
c:\users\abcd\.conda\envs\py310\msvcp140.dll
c:\users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\cudart64_12.dll
c:\users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\cudnn64_9.dll
c:\users\abcd\.conda\envs\py310\vcruntime140_1.dll
c:\users\abcd\.conda\envs\py310\msvcp140_1.dll
c:\users\abcd\.conda\envs\py310\vcruntime140.dll

Device information:
{
  "gpu": {
    "driver_version": "571.96",
    "devices": [
      {
        "memory_total": 8589934592,
        "memory_available": 6032777216,
        "name": "NVIDIA GeForce GTX 1080"
      }
    ]
  },
  "cpu": {
    "brand": "Intel(R) Core(TM) i9-10900X CPU @ 3.70GHz",
    "cores": 10,
    "logical_cores": 20,
    "hz": "3696000000,0",
    "l2_cache": 10485760,
    "flags": "3dnow,3dnowprefetch,abm,acpi,adx,aes,apic,avx,avx2,avx512bw,avx512cd,avx512dq,avx512f,avx512vl,avx512vnni,bmi1,bmi2,clflush,clflushopt,clwb,cmov,cx16,cx8,de,dtes64,dts,erms,est,f16c,fma,fpu,fxsr,ht,hypervisor,ia64,invpcid,lahf_lm,mca,mce,mmx,monitor,movbe,mpx,msr,mtrr,osxsave,pae,pat,pbe,pcid,pclmulqdq,pdcm,pge,pni,popcnt,pqe,pqm,pse,pse36,rdrnd,rdseed,sep,serial,smap,smep,ss,sse,sse2,sse4_1,sse4_2,ssse3,tm,tm2,tsc,tscdeadline,vme,x2apic,xsave,xtpr",
    "processor": "Intel64 Family 6 Model 85 Stepping 7, GenuineIntel"
  },
  "memory": {
    "total": 68414291968,
    "available": 40240791552
  }
}
>>> import torch
```

In below example, we set `directory=""`, which prefers nvidia site package like the following:
```
>>> import onnxruntime
>>> onnxruntime.preload_dlls(directory="")
>>> onnxruntime.print_debug_info()
...
List of loaded DLLs:
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\nvidia\cudnn\bin\cudnn_adv64_9.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\nvidia\cudnn\bin\cudnn_ops64_9.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\nvidia\cudnn\bin\cudnn_engines_precompiled64_9.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\nvidia\cufft\bin\cufft64_11.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\nvidia\cublas\bin\cublasLt64_12.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\nvidia\cublas\bin\cublas64_12.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\nvidia\cudnn\bin\cudnn_heuristic64_9.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\nvidia\cudnn\bin\cudnn_engines_runtime_compiled64_9.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\nvidia\cudnn\bin\cudnn_graph64_9.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\nvidia\cuda_runtime\bin\cudart64_12.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\numpy.libs\msvcp140-263139962577ecda4cd9469ca360a746.dll
C:\Users\abcd\.conda\envs\py310\msvcp140.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\nvidia\cudnn\bin\cudnn64_9.dll
C:\Users\abcd\.conda\envs\py310\msvcp140_1.dll
C:\Users\abcd\.conda\envs\py310\vcruntime140_1.dll
C:\Users\abcd\.conda\envs\py310\vcruntime140.dll
...
```

In below example, we import torch before preload_dlls. In this case, ORT skips loading CUDA/cuDNN DLLs, and use the DLLs from torch:
```
>>> import onnxruntime
>>> import torch
>>> onnxruntime.preload_dlls()
Skip loading CUDA and cuDNN DLLs since torch is imported.
>>> onnxruntime.print_debug_info()
...
List of loaded DLLs:
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\nvrtc64_120_0.alt.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\curand64_10.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\cufft64_11.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\cudnn_heuristic64_9.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\cudnn_engines_precompiled64_9.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\cudnn_adv64_9.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\cublasLt64_12.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\cudnn_ops64_9.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\cublas64_12.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\cudnn_engines_runtime_compiled64_9.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\nvrtc64_120_0.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\nvrtc-builtins64_126.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\cudnn_cnn64_9.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\cudnn_graph64_9.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\cudart64_12.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\numpy.libs\msvcp140-263139962577ecda4cd9469ca360a746.dll
C:\Users\abcd\.conda\envs\py310\msvcp140.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\cudnn64_9.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\cufftw64_11.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\torch\lib\caffe2_nvrtc.dll
C:\Users\abcd\.conda\envs\py310\msvcp140_1.dll
C:\Users\abcd\.conda\envs\py310\vcruntime140_1.dll
C:\Users\abcd\.conda\envs\py310\vcruntime140.dll
...
```

Last example is to load CUDA and cuDNN separately from different locations. CUDA location is based on CUDA_PATH environment variable, and cuDNN path is a relative path points to cudnn in nvidia site package.
```
>>> import onnxruntime
>>> import os
>>> os.environ["CUDA_PATH"]
'C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v12.8'
>>> onnxruntime.preload_dlls(cuda=True, cudnn=False, directory=os.path.join(os.environ["CUDA_PATH"], "bin"))
>>> onnxruntime.preload_dlls(cuda=False, cudnn=True, directory="..\\nvidia\\cudnn\\bin")
>>> onnxruntime.print_debug_info()
...
List of loaded DLLs:
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\nvidia\cudnn\bin\cudnn_adv64_9.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\nvidia\cudnn\bin\cudnn_ops64_9.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\nvidia\cudnn\bin\cudnn_engines_precompiled64_9.dll
C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8\bin\cufft64_11.dll
C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8\bin\cublasLt64_12.dll
C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8\bin\cublas64_12.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\nvidia\cudnn\bin\cudnn_heuristic64_9.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\nvidia\cudnn\bin\cudnn_engines_runtime_compiled64_9.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\nvidia\cudnn\bin\cudnn_graph64_9.dll
C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8\bin\cudart64_12.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\numpy.libs\msvcp140-263139962577ecda4cd9469ca360a746.dll
C:\Users\abcd\.conda\envs\py310\msvcp140.dll
C:\Users\abcd\.conda\envs\py310\Lib\site-packages\nvidia\cudnn\bin\cudnn64_9.dll
C:\Users\abcd\.conda\envs\py310\vcruntime140_1.dll
C:\Users\abcd\.conda\envs\py310\msvcp140_1.dll
C:\Users\abcd\.conda\envs\py310\vcruntime140.dll
...
```

### Motivation and Context

To address issues mentioned in description of https://github.com/microsoft/onnxruntime/pull/23674 that onnxruntime preload might cause conflicts with PyTorch.

Before this change, `import torch` after `onnxruntime.preload_dlls` will cause issue:
```
>>> import onnxruntime
>>> onnxruntime.preload_dlls(verbose=True)
----List of loaded DLLs----
D:\anaconda3\envs\py310\Lib\site-packages\nvidia\cufft\bin\cufft64_11.dll
D:\anaconda3\envs\py310\Lib\site-packages\nvidia\cublas\bin\cublas64_12.dll
D:\anaconda3\envs\py310\Lib\site-packages\nvidia\cublas\bin\cublasLt64_12.dll
D:\anaconda3\envs\py310\Lib\site-packages\nvidia\cudnn\bin\cudnn_graph64_9.dll
D:\anaconda3\envs\py310\Lib\site-packages\nvidia\cuda_runtime\bin\cudart64_12.dll
D:\anaconda3\envs\py310\Lib\site-packages\numpy.libs\msvcp140-d64049c6e3865410a7dda6a7e9f0c575.dll
D:\anaconda3\envs\py310\Lib\site-packages\nvidia\cudnn\bin\cudnn64_9.dll
D:\anaconda3\envs\py310\msvcp140.dll
D:\anaconda3\envs\py310\vcruntime140_1.dll
D:\anaconda3\envs\py310\msvcp140_1.dll
D:\anaconda3\envs\py310\vcruntime140.dll
>>> import torch
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "D:\anaconda3\envs\py310\lib\site-packages\torch\__init__.py", line 137, in <module>
    raise err
OSError: [WinError 127] The specified procedure could not be found. Error loading "D:\anaconda3\envs\py310\lib\site-packages\torch\lib\cudnn_adv64_9.dll" or one of its dependencies.
```



