### PR TITLE
[ARM CPU] Enable FP16 kernels for GQA op 

### DIFF
--- a/onnxruntime/contrib_ops/cpu/bert/attention_helper.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_helper.h
@@ -27,19 +27,7 @@ inline void ComputeAttentionSoftmaxInplace(T* score, int N, int D, ThreadPool* t
 }
 
 template <typename T>
-void ComputeAttentionSoftcapInplace(T* scores, int sequence_length, T softcap);
-
-template <>
-void ComputeAttentionSoftcapInplace<float>(float* scores, int sequence_length, float softcap) {
-  for (int i = 0; i < sequence_length; i++) {
-    scores[i] = scores[i] / softcap;
-    scores[i] = std::tanh(scores[i]);
-    scores[i] = scores[i] * softcap;
-  }
-}
-
-template <>
-void ComputeAttentionSoftcapInplace<MLFloat16>(MLFloat16* scores, int sequence_length, MLFloat16 softcap) {
+void ComputeAttentionSoftcapInplace(T* scores, int sequence_length, T softcap) {
   MlasComputeSoftcap(scores, scores, sequence_length, softcap);
 }
 

--- a/onnxruntime/contrib_ops/cpu/bert/attention_helper.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_helper.h
@@ -17,93 +17,20 @@ namespace onnxruntime {
 namespace contrib {
 
 template <typename T>
-void ComputeSmoothSoftmaxInplace(T* score, int N, int D, ThreadPool* tp) {
-  ThreadPool::TryParallelFor(tp, N, D * 2.0, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
-    for (std::ptrdiff_t j = begin; j != end; ++j) {
-      float* x = reinterpret_cast<T*>(score) + j * D;
-      float* y = x;
-
-      float max = -std::numeric_limits<float>::infinity();
-      for (int i = 0; i < D; i++) {
-        if (max < x[i])
-          max = x[i];
-      }
-
-      if (max < 0.0f) {
-        max = 0.0f;
-      }
-
-      for (int i = 0; i < D; i++) {
-        y[i] = expf(x[i] - max);
-      }
-
-      double sum = 0.0;
-
-      for (int i = 0; i < D; i++) {
-        sum += x[i];
-      }
-
-      sum += exp(static_cast<double>(-max));
-
-      for (int i = 0; i < D; i++) {
-        y[i] = x[i] / (float)sum;
-      }
-    }
-  });
-}
-
-template <>
-inline void ComputeSmoothSoftmaxInplace(float* score, int N, int D, ThreadPool* tp) {
+inline void ComputeSmoothSoftmaxInplace(T* score, int N, int D, ThreadPool* tp) {
   MlasComputeSoftmax(score, score, N, D, false, true, tp);
 }
 
 template <typename T>
-void ComputeAttentionSoftmaxInplace(T* score, int N, int D, ThreadPool* tp) {
-  ThreadPool::TryParallelFor(tp, N, D * 2.0, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
-    for (std::ptrdiff_t j = begin; j != end; ++j) {
-      float* x = reinterpret_cast<T*>(score) + j * D;
-      float* y = x;
-
-      // e^x is represented as infinity if x is large enough, like 100.f.
-      // Infinity divided by Infinity is a NAN. Thus, softmax gets a NAN if
-      // one or more item are large enough. a math transform as below is
-      // leveraged to get a stable softmax: e^xi/(e^x1 + ...e^xn) = e^(xi -
-      // max) / (e^(x1 - max) + ... + e^(xn - max))
-      float max = -std::numeric_limits<float>::infinity();
-      for (int i = 0; i < D; i++) {
-        if (max < x[i])
-          max = x[i];
-      }
-      for (int i = 0; i < D; i++) {
-        y[i] = expf(x[i] - max);
-      }
-
-      double sum = 0.0;
-
-      for (int i = 0; i < D; i++) {
-        sum += x[i];
-      }
-
-      if (sum == 0) {
-        for (int i = 0; i < D; i++) {
-          y[i] = 1.0f / (float)D;
-        }
-      } else {
-        for (int i = 0; i < D; i++) {
-          y[i] = x[i] / (float)sum;
-        }
-      }
-    }
-  });
-}
-
-template <>
-inline void ComputeAttentionSoftmaxInplace(float* score, int N, int D, ThreadPool* tp) {
+inline void ComputeAttentionSoftmaxInplace(T* score, int N, int D, ThreadPool* tp) {
   MlasComputeSoftmax(score, score, N, D, false, false, tp);
 }
 
 template <typename T>
-void ComputeAttentionSoftcapInplace(T* scores, int sequence_length, float softcap) {
+void ComputeAttentionSoftcapInplace(T* scores, int sequence_length, T softcap);
+
+template <>
+void ComputeAttentionSoftcapInplace<float>(float* scores, int sequence_length, float softcap) {
   for (int i = 0; i < sequence_length; i++) {
     scores[i] = scores[i] / softcap;
     scores[i] = std::tanh(scores[i]);
@@ -111,7 +38,10 @@ void ComputeAttentionSoftcapInplace(T* scores, int sequence_length, float softca
   }
 }
 
-template void ComputeAttentionSoftcapInplace<float>(float* scores, int sequence_length, float softcap);
+template <>
+void ComputeAttentionSoftcapInplace<MLFloat16>(MLFloat16* scores, int sequence_length, MLFloat16 softcap) {
+  MlasComputeSoftcap(scores, scores, sequence_length, softcap);
+}
 
 template <typename T>
 void PrepareMask(const int32_t* mask_index,

--- a/onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h
+++ b/onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h
@@ -221,7 +221,7 @@ class GQAAttentionBase {
           MlasGemm(CblasNoTrans, CblasTrans, sequence_length, total_seqlen, head_size,
                    q, static_cast<int>(head_size), k, static_cast<int>(head_size), output,
                    static_cast<int>(present_buffer_sequence_length),
-                   MLFloat16(alpha).val, static_cast<uint16_t>(0)/*beta*/, nullptr);
+                   MLFloat16(alpha).val, static_cast<uint16_t>(0) /*beta*/, nullptr);
         } else {
           size_t bytes = head_size * (sequence_length + total_seqlen) * sizeof(float);
           auto q_k_fp32 = allocator->Alloc(bytes);
@@ -244,22 +244,22 @@ class GQAAttentionBase {
           size_t seq_causal_length = past_seqlen + seq + 1;
           if (local_window_size_ > 0 && seq_causal_length > static_cast<size_t>(local_window_size_) + 1) {
             for (size_t total_seq_id = 0; total_seq_id < seq_causal_length - local_window_size_ - 1; total_seq_id++) {
-                if constexpr (std::is_same<U, float>::value) {
-                  output_softmax[total_seq_id] = 0.f;
-                } else {
-                  output_softmax[total_seq_id] = MLFloat16::FromBits(static_cast<uint16_t>(0));
-                }
+              if constexpr (std::is_same<U, float>::value) {
+                output_softmax[total_seq_id] = 0.f;
+              } else {
+                output_softmax[total_seq_id] = MLFloat16::FromBits(static_cast<uint16_t>(0));
+              }
             }
             if (softcap_ > 0.f) {
               ComputeAttentionSoftcapInplace(output_softmax + seq_causal_length - local_window_size_ - 1,
-                                            local_window_size_ + 1, static_cast<U>(softcap_));
+                                             local_window_size_ + 1, static_cast<U>(softcap_));
             }
             if (use_smooth_softmax_) {
               ComputeSmoothSoftmaxInplace(output_softmax + seq_causal_length - local_window_size_ - 1, 1,
                                           local_window_size_ + 1, nullptr);
             } else {
               ComputeAttentionSoftmaxInplace(output_softmax + seq_causal_length - local_window_size_ - 1, 1,
-                                            local_window_size_ + 1, nullptr);
+                                             local_window_size_ + 1, nullptr);
             }
           } else {
             if (softcap_ > 0.f) {
@@ -275,11 +275,11 @@ class GQAAttentionBase {
 
           // set causal [seq_causal_length, total_seqlen) to 0.f
           for (size_t total_seq_id = seq_causal_length; total_seq_id < total_seqlen; total_seq_id++) {
-              if constexpr (std::is_same<U, float>::value) {
-                output_softmax[total_seq_id] = 0.f;
-              } else {
-                output_softmax[total_seq_id] = MLFloat16::FromBits(static_cast<uint16_t>(0));
-              }
+            if constexpr (std::is_same<U, float>::value) {
+              output_softmax[total_seq_id] = 0.f;
+            } else {
+              output_softmax[total_seq_id] = MLFloat16::FromBits(static_cast<uint16_t>(0));
+            }
           }
 
           output_softmax += present_buffer_sequence_length;
@@ -382,7 +382,7 @@ class GQAAttentionBase {
           MlasGemm(CblasNoTrans, CblasNoTrans, sequence_length, head_size, total_seqlen,
                    attention_probs + attention_probs_offset, static_cast<int>(present_buffer_sequence_length),
                    v, static_cast<int>(head_size), output_current, static_cast<int>(hidden_size),
-                   MLFloat16(1.0f).val, static_cast<uint16_t>(0)/*beta*/, nullptr);
+                   MLFloat16(1.0f).val, static_cast<uint16_t>(0) /*beta*/, nullptr);
         } else {
           size_t bytes = head_size * total_seqlen * sizeof(float);
           auto v_fp32 = allocator->Alloc(bytes);

--- a/onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h
+++ b/onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h
@@ -75,8 +75,10 @@ class GQAAttentionBase {
     int seqlen_present_kv_cache = static_cast<int>(present_key->Shape().GetDims()[2]);
 
     // Compute the attention score.
-    // TODO(fajin): type depends on kernel supportability
-    size_t bytes = SafeInt<size_t>(batch_size) * num_heads_ * sequence_length * seqlen_present_kv_cache * sizeof(float);
+    bool gqa_mlas_supported = MlasGQASupported<T>(CblasNoTrans, CblasTrans) &&
+                              MlasGQASupported<T>(CblasNoTrans, CblasNoTrans);
+    size_t bytes = SafeInt<size_t>(batch_size) * num_heads_ * sequence_length * seqlen_present_kv_cache *
+                   (gqa_mlas_supported ? sizeof(T) : sizeof(float));
     auto attention_probs = allocator->Alloc(bytes);
     BufferUniquePtr scratch_buffer(attention_probs, BufferDeleter(allocator));
 
@@ -88,17 +90,32 @@ class GQAAttentionBase {
     bool past_present_share_buffer = past_key_data == present_key_data && past_value_data == present_value_data;
 
     const T* k = packed_qkv ? Q + num_heads_ * sequence_length * head_size : K;
-    ComputeAttentionProbs<T>(static_cast<float*>(attention_probs), Q, k, seqlens_k->Data<int32_t>(), batch_size,
-                             sequence_length, seqlen_past_kv_cache, seqlen_present_kv_cache, head_size, past_key_data,
-                             present_key_data, past_present_share_buffer, packed_qkv, is_prompt, tp, allocator);
 
-    // Compute the attentionScore * Value: out(B, N, S, H_v) = attention_probs(B, N, S, T) x V(B, N, T, H_v)
-    const T* v = packed_qkv ? Q + (num_heads_ + kv_num_heads_) * sequence_length * head_size : V;
-    ComputeVxAttentionScore(output->MutableData<T>(), static_cast<float*>(attention_probs), v,
-                            seqlens_k->Data<int32_t>(),
-                            batch_size, sequence_length, seqlen_past_kv_cache, seqlen_present_kv_cache, head_size,
-                            hidden_size, past_value_data, present_value_data, past_present_share_buffer, packed_qkv,
-                            is_prompt, tp, allocator);
+    if (gqa_mlas_supported) {
+      ComputeAttentionProbs(static_cast<T*>(attention_probs), Q, k, seqlens_k->Data<int32_t>(), batch_size,
+                            sequence_length, seqlen_past_kv_cache, seqlen_present_kv_cache, head_size, past_key_data,
+                            present_key_data, past_present_share_buffer, packed_qkv, is_prompt, tp, allocator);
+
+      // Compute the attentionScore * Value: out(B, N, S, H_v) = attention_probs(B, N, S, T) x V(B, N, T, H_v)
+      const T* v = packed_qkv ? Q + (num_heads_ + kv_num_heads_) * sequence_length * head_size : V;
+      ComputeVxAttentionScore(output->MutableData<T>(), static_cast<T*>(attention_probs), v,
+                              seqlens_k->Data<int32_t>(),
+                              batch_size, sequence_length, seqlen_past_kv_cache, seqlen_present_kv_cache, head_size,
+                              hidden_size, past_value_data, present_value_data, past_present_share_buffer, packed_qkv,
+                              is_prompt, tp, allocator);
+    } else {
+      ComputeAttentionProbs(static_cast<float*>(attention_probs), Q, k, seqlens_k->Data<int32_t>(), batch_size,
+                            sequence_length, seqlen_past_kv_cache, seqlen_present_kv_cache, head_size, past_key_data,
+                            present_key_data, past_present_share_buffer, packed_qkv, is_prompt, tp, allocator);
+
+      // Compute the attentionScore * Value: out(B, N, S, H_v) = attention_probs(B, N, S, T) x V(B, N, T, H_v)
+      const T* v = packed_qkv ? Q + (num_heads_ + kv_num_heads_) * sequence_length * head_size : V;
+      ComputeVxAttentionScore(output->MutableData<T>(), static_cast<float*>(attention_probs), v,
+                              seqlens_k->Data<int32_t>(),
+                              batch_size, sequence_length, seqlen_past_kv_cache, seqlen_present_kv_cache, head_size,
+                              hidden_size, past_value_data, present_value_data, past_present_share_buffer, packed_qkv,
+                              is_prompt, tp, allocator);
+    }
 
     return Status::OK();
   }
@@ -107,8 +124,9 @@ class GQAAttentionBase {
   // Helper function to compute the attention probs. It does 2 things:
   //  attention_probs(B, N, S, T) = 1/sqrt(H) x Q(B, N, S, H) x K'(B, N, T, H -> B, N, H, T)
   //  attention_probs(B, N, S, T) = Softmax(attention_probs)
-  template <typename T>
-  void ComputeAttentionProbs(float* attention_probs,                       // output buffer with size BxNxSxT
+  // If T is float32, U is float32. If T is float16, U could be float16 or float32.
+  template <typename T, typename U>
+  void ComputeAttentionProbs(U* attention_probs,                           // output buffer with size BxNxSxT
                              const T* Q,                                   // Q data. Its size is BxNxSxH
                              const T* K,                                   // k data. Its size is BxNxLxH
                              const int32_t* seqlens_k,                     // total - 1 sequence lengths tensor
@@ -169,7 +187,7 @@ class GQAAttentionBase {
         const size_t past_chunk_length = past_seqlen * head_size;
 
         const ptrdiff_t output_offset = SafeInt<ptrdiff_t>(i) * sequence_length * present_buffer_sequence_length;
-        float* output = attention_probs + output_offset;
+        U* output = attention_probs + output_offset;
 
         const T* k;
         if (packed_qkv) {
@@ -199,11 +217,11 @@ class GQAAttentionBase {
           math::GemmEx<float, ThreadPool>(CblasNoTrans, CblasTrans, sequence_length, total_seqlen, head_size, alpha, q,
                                           static_cast<int>(head_size), k, static_cast<int>(head_size), 0.0f /*bata*/,
                                           output, static_cast<int>(present_buffer_sequence_length), nullptr);
-          // TODO(fajin): update later
-          // } else if (MlasHGemmSupported(CblasNoTrans, CblasTrans)) {
-          //   MlasGemm(CblasNoTrans, CblasTrans, sequence_length, total_seqlen, head_size,
-          //            q, static_cast<int>(head_size), k, static_cast<int>(head_size), output,
-          //            static_cast<int>(present_buffer_sequence_length), alpha, 0.0f /*beta*/, nullptr);
+        } else if constexpr (std::is_same<U, MLFloat16>::value) {
+          MlasGemm(CblasNoTrans, CblasTrans, sequence_length, total_seqlen, head_size,
+                   q, static_cast<int>(head_size), k, static_cast<int>(head_size), output,
+                   static_cast<int>(present_buffer_sequence_length),
+                   MLFloat16(alpha).val, static_cast<uint16_t>(0)/*beta*/, nullptr);
         } else {
           size_t bytes = head_size * (sequence_length + total_seqlen) * sizeof(float);
           auto q_k_fp32 = allocator->Alloc(bytes);
@@ -221,27 +239,29 @@ class GQAAttentionBase {
         }
 
         // compute Softmax
-        float* output_softmax = output;
+        U* output_softmax = output;
         for (size_t seq = 0; seq < sequence_length; seq++) {
           size_t seq_causal_length = past_seqlen + seq + 1;
           if (local_window_size_ > 0 && seq_causal_length > static_cast<size_t>(local_window_size_) + 1) {
             for (size_t total_seq_id = 0; total_seq_id < seq_causal_length - local_window_size_ - 1; total_seq_id++) {
-              output_softmax[total_seq_id] = 0.f;
+              output_softmax[total_seq_id] =
+                constexpr std::is_same<U, float>::value ? 0.f : MLFloat16::FromBits(static_cast<uint16_t>(0));
             }
             if (softcap_ > 0.f) {
               ComputeAttentionSoftcapInplace(output_softmax + seq_causal_length - local_window_size_ - 1,
-                                             local_window_size_ + 1, softcap_);
+                                            local_window_size_ + 1, staic_cast<U>(softcap_));
             }
             if (use_smooth_softmax_) {
               ComputeSmoothSoftmaxInplace(output_softmax + seq_causal_length - local_window_size_ - 1, 1,
                                           local_window_size_ + 1, nullptr);
             } else {
               ComputeAttentionSoftmaxInplace(output_softmax + seq_causal_length - local_window_size_ - 1, 1,
-                                             local_window_size_ + 1, nullptr);
+                                            local_window_size_ + 1, nullptr);
             }
           } else {
             if (softcap_ > 0.f) {
-              ComputeAttentionSoftcapInplace(output_softmax, static_cast<int>(seq_causal_length), softcap_);
+              ComputeAttentionSoftcapInplace(output_softmax, static_cast<int>(seq_causal_length),
+                                             static_cast<U>(softcap_));
             }
             if (use_smooth_softmax_) {
               ComputeSmoothSoftmaxInplace(output_softmax, 1, static_cast<int>(seq_causal_length), nullptr);
@@ -252,7 +272,8 @@ class GQAAttentionBase {
 
           // set causal [seq_causal_length, total_seqlen) to 0.f
           for (size_t total_seq_id = seq_causal_length; total_seq_id < total_seqlen; total_seq_id++) {
-            output_softmax[total_seq_id] = 0.f;
+            output_softmax[total_seq_id] =
+              constexpr std::is_same<U, float>::value ? 0.f : MLFloat16::FromBits(static_cast<uint16_t>(0));
           }
 
           output_softmax += present_buffer_sequence_length;
@@ -261,9 +282,9 @@ class GQAAttentionBase {
     });
   }
 
-  template <typename T>
+  template <typename T, typename U>
   void ComputeVxAttentionScore(T* output,                                    // buffer for the result with size BxSxNxH
-                               const float* attention_probs,                 // Attention probs with size BxNxSxT
+                               const U* attention_probs,                     // Attention probs with size BxNxSxT
                                const T* V,                                   // V value with size BxN_kvxSxH
                                const int32_t* seqlens_k,                     // total - 1 sequence lengths tensor
                                const size_t batch_size,                      // batch size
@@ -315,7 +336,7 @@ class GQAAttentionBase {
     unit_cost.bytes_stored += bytes_to_copy_trans_all;
 
     size_t output_fp32_bytes = 0;
-    if constexpr (std::is_same<T, MLFloat16>::value) {
+    if constexpr (std::is_same<T, MLFloat16>::value && std::is_same<U, float>::value) {
       output_fp32_bytes = SafeInt<size_t>(sequence_length) * batch_size * num_heads_ * head_size * sizeof(float);
     }
     auto output_fp32 = allocator->Alloc(output_fp32_bytes);
@@ -350,6 +371,12 @@ class GQAAttentionBase {
                                           static_cast<int>(present_buffer_sequence_length), v,
                                           static_cast<int>(head_size), 0.0f /*beta*/, output_current,
                                           static_cast<int>(hidden_size), nullptr);
+        } else if constexpr (std::is_same<U, MLFloat16>::value) {
+          T* output_current = output + (batch_index * sequence_length * num_heads_ + head_index) * head_size;
+          MlasGemm(CblasNoTrans, CblasNoTrans, sequence_length, head_size, total_seqlen,
+                   attention_probs + attention_probs_offset, static_cast<int>(present_buffer_sequence_length),
+                   v, static_cast<int>(head_size), output_current, static_cast<int>(hidden_size),
+                   MLFloat16(1.0f).val, static_cast<uint16_t>(0)/*beta*/, nullptr);
         } else {
           size_t bytes = head_size * total_seqlen * sizeof(float);
           auto v_fp32 = allocator->Alloc(bytes);
@@ -369,7 +396,7 @@ class GQAAttentionBase {
       }
     });
 
-    if constexpr (std::is_same<T, MLFloat16>::value) {
+    if constexpr (std::is_same<T, MLFloat16>::value && std::is_same<U, float>::value) {
       MlasConvertFloatToHalfBuffer(static_cast<float*>(output_fp32),
                                    output,
                                    SafeInt<size_t>(sequence_length) * batch_size * num_heads_ * head_size);

--- a/onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h
+++ b/onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h
@@ -244,12 +244,15 @@ class GQAAttentionBase {
           size_t seq_causal_length = past_seqlen + seq + 1;
           if (local_window_size_ > 0 && seq_causal_length > static_cast<size_t>(local_window_size_) + 1) {
             for (size_t total_seq_id = 0; total_seq_id < seq_causal_length - local_window_size_ - 1; total_seq_id++) {
-              output_softmax[total_seq_id] =
-                constexpr std::is_same<U, float>::value ? 0.f : MLFloat16::FromBits(static_cast<uint16_t>(0));
+                if constexpr (std::is_same<U, float>::value) {
+                  output_softmax[total_seq_id] = 0.f;
+                } else {
+                  output_softmax[total_seq_id] = MLFloat16::FromBits(static_cast<uint16_t>(0));
+                }
             }
             if (softcap_ > 0.f) {
               ComputeAttentionSoftcapInplace(output_softmax + seq_causal_length - local_window_size_ - 1,
-                                            local_window_size_ + 1, staic_cast<U>(softcap_));
+                                            local_window_size_ + 1, static_cast<U>(softcap_));
             }
             if (use_smooth_softmax_) {
               ComputeSmoothSoftmaxInplace(output_softmax + seq_causal_length - local_window_size_ - 1, 1,
@@ -272,8 +275,11 @@ class GQAAttentionBase {
 
           // set causal [seq_causal_length, total_seqlen) to 0.f
           for (size_t total_seq_id = seq_causal_length; total_seq_id < total_seqlen; total_seq_id++) {
-            output_softmax[total_seq_id] =
-              constexpr std::is_same<U, float>::value ? 0.f : MLFloat16::FromBits(static_cast<uint16_t>(0));
+              if constexpr (std::is_same<U, float>::value) {
+                output_softmax[total_seq_id] = 0.f;
+              } else {
+                output_softmax[total_seq_id] = MLFloat16::FromBits(static_cast<uint16_t>(0));
+              }
           }
 
           output_softmax += present_buffer_sequence_length;

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -1496,6 +1496,17 @@ MlasHGemmSupported(
     );
 
 /**
+ * @brief Check whether mlas supports GQA kernels with the type and transpose settings.
+ */
+template <typename T>
+bool
+MLASCALL
+MlasGQASupported(
+    CBLAS_TRANSPOSE TransA,
+    CBLAS_TRANSPOSE TransB
+    );
+
+/**
  * @brief  Batched half precision matrix/matrix multiply operation (HGEMM)
  *
  * @param TransA     Supplies the transpose operation for matrix A.

--- a/onnxruntime/core/mlas/lib/compute.cpp
+++ b/onnxruntime/core/mlas/lib/compute.cpp
@@ -1144,5 +1144,7 @@ MlasGQASupported<float>(
     CBLAS_TRANSPOSE TransA,
     CBLAS_TRANSPOSE TransB
 ) {
+    MLAS_UNREFERENCED_PARAMETER(TransA);
+    MLAS_UNREFERENCED_PARAMETER(TransB);
     return true;
 }

--- a/onnxruntime/core/mlas/lib/compute.cpp
+++ b/onnxruntime/core/mlas/lib/compute.cpp
@@ -1112,3 +1112,37 @@ MlasComputeSoftmax<MLAS_FP16>(
     bool SmoothSoftmax,
     MLAS_THREADPOOL* ThreadPool
 );
+
+template <>
+bool
+MLASCALL
+MlasGQASupported<MLAS_FP16>(
+    CBLAS_TRANSPOSE TransA,
+    CBLAS_TRANSPOSE TransB
+) {
+    if (!MlasHGemmSupported(TransA, TransB)) {
+        return false;
+    }
+
+    const auto* softmax_dispatch = GetMlasPlatform().SoftmaxDispatch;
+    if (softmax_dispatch == nullptr ||
+        softmax_dispatch->Tanh_Fp16 == nullptr ||
+        softmax_dispatch->Softcap_Fp16 == nullptr ||
+        softmax_dispatch->SumExp_Fp16 == nullptr ||
+        softmax_dispatch->Softmax_Fp16 == nullptr ||
+        softmax_dispatch->ReduceMax_Fp16 == nullptr) {
+        return false;
+    }
+
+    return true;
+}
+
+template <>
+bool
+MLASCALL
+MlasGQASupported<float>(
+    CBLAS_TRANSPOSE TransA,
+    CBLAS_TRANSPOSE TransB
+) {
+    return true;
+}

--- a/onnxruntime/core/mlas/lib/halfgemm.h
+++ b/onnxruntime/core/mlas/lib/halfgemm.h
@@ -579,7 +579,7 @@ struct MLAS_HGEMM_DISPATCH {
     /**
      * @brief Pack the B matrix segment. B is column-major. Elements from CountK rows x N columns are packed
      *        continuously in row-major.
-     *        First pack CountK rows x 16 columns, then pack CountK rows x 8 columns.
+     *        First pack CountK rows x 32 columns, then pack CountK rows x 16 columns, then 8.
      *        If there are < 8 columns left, pad the columns with 0.
      * @param      B                   the first element of the B matrix segment. Column major.
      * @param[out] PackedB             the first element of the packed B matrix segment.
@@ -600,7 +600,7 @@ struct MLAS_HGEMM_DISPATCH {
     /**
      * @brief Pack the B matrix segment. B is row-major. Elements from CountK rows x N columns are packed
      *        continuously in row-major.
-     *        First pack CountK rows x 16 columns, then pack CountK rows x 8 columns.
+     *        First pack CountK rows x 32 columns, then pack CountK rows x 16 columns, then 8.
      *        If there are < 8 columns left, pad the columns with 0.
      * @param      B                   the first element of the B matrix segment. Row major.
      * @param[out] PackedB             the first element of the packed B matrix segment.

--- a/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
@@ -3101,7 +3101,9 @@ void HGemm_PackedB_Kernel_Impl(
             }
             CountN -= 4, C += 4;
             accu0_low = accu0_high;
-            accu1_low = accu1_high;
+            if constexpr (CountM == 2) {
+                accu1_low = accu1_high;
+            }
         }
 
         if (CountN) {

--- a/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
@@ -36,6 +36,8 @@ void HPackB_TransposedB_Kernel(
         size_t k = CountK;
         constexpr size_t step = 8 * 32; // pack 8 * 16
         for (; k >= 8; k -= 8, b += 8, PackedB_data += step) {
+            size_t baseb = 0;
+            size_t basep = 0;
             float16x8_t v0 = MlasLoadFloat16x8(b);
             float16x8_t v1 = MlasLoadFloat16x8(b + ldb);
             float16x8_t v2 = MlasLoadFloat16x8(b + 2 * ldb);
@@ -44,72 +46,39 @@ void HPackB_TransposedB_Kernel(
             float16x8_t v5 = MlasLoadFloat16x8(b + 5 * ldb);
             float16x8_t v6 = MlasLoadFloat16x8(b + 6 * ldb);
             float16x8_t v7 = MlasLoadFloat16x8(b + 7 * ldb);
+            for (size_t i = 0; i < 3; ++i, baseb += 8 * ldb, basep += 8) {
+                Transpose8x8(v0, v1, v2, v3, v4, v5, v6, v7);
+                MlasStoreFloat16x8(PackedB_data + basep, v0);
+                MlasStoreFloat16x8(PackedB_data + basep + 32, v1);
+                MlasStoreFloat16x8(PackedB_data + basep + 64, v2);
+                MlasStoreFloat16x8(PackedB_data + basep + 96, v3);
+                MlasStoreFloat16x8(PackedB_data + basep + 128, v4);
+                MlasStoreFloat16x8(PackedB_data + basep + 160, v5);
+                MlasStoreFloat16x8(PackedB_data + basep + 192, v6);
+                MlasStoreFloat16x8(PackedB_data + basep + 224, v7);
+                v0 = MlasLoadFloat16x8(b + baseb + 8 * ldb);
+                v1 = MlasLoadFloat16x8(b + baseb + 9 * ldb);
+                v2 = MlasLoadFloat16x8(b + baseb + 10 * ldb);
+                v3 = MlasLoadFloat16x8(b + baseb + 11 * ldb);
+                v4 = MlasLoadFloat16x8(b + baseb + 12 * ldb);
+                v5 = MlasLoadFloat16x8(b + baseb + 13 * ldb);
+                v6 = MlasLoadFloat16x8(b + baseb + 14 * ldb);
+                v7 = MlasLoadFloat16x8(b + baseb + 15 * ldb);
+            }
             Transpose8x8(v0, v1, v2, v3, v4, v5, v6, v7);
-            MlasStoreFloat16x8(PackedB_data, v0);
-            MlasStoreFloat16x8(PackedB_data + 32, v1);
-            MlasStoreFloat16x8(PackedB_data + 64, v2);
-            MlasStoreFloat16x8(PackedB_data + 96, v3);
-            MlasStoreFloat16x8(PackedB_data + 128, v4);
-            MlasStoreFloat16x8(PackedB_data + 160, v5);
-            MlasStoreFloat16x8(PackedB_data + 192, v6);
-            MlasStoreFloat16x8(PackedB_data + 224, v7);
-
-            float16x8_t v8 = MlasLoadFloat16x8(b + 8 * ldb);
-            float16x8_t v9 = MlasLoadFloat16x8(b + 9 * ldb);
-            float16x8_t vA = MlasLoadFloat16x8(b + 10 * ldb);
-            float16x8_t vB = MlasLoadFloat16x8(b + 11 * ldb);
-            float16x8_t vC = MlasLoadFloat16x8(b + 12 * ldb);
-            float16x8_t vD = MlasLoadFloat16x8(b + 13 * ldb);
-            float16x8_t vE = MlasLoadFloat16x8(b + 14 * ldb);
-            float16x8_t vF = MlasLoadFloat16x8(b + 15 * ldb);
-            Transpose8x8(v8, v9, vA, vB, vC, vD, vE, vF);
-            MlasStoreFloat16x8(PackedB_data + 8, v8);
-            MlasStoreFloat16x8(PackedB_data + 40, v9);
-            MlasStoreFloat16x8(PackedB_data + 72, vA);
-            MlasStoreFloat16x8(PackedB_data + 104, vB);
-            MlasStoreFloat16x8(PackedB_data + 136, vC);
-            MlasStoreFloat16x8(PackedB_data + 168, vD);
-            MlasStoreFloat16x8(PackedB_data + 200, vE);
-            MlasStoreFloat16x8(PackedB_data + 232, vF);
-
-            v0 = MlasLoadFloat16x8(b + 16 * ldb);
-            v1 = MlasLoadFloat16x8(b + 17 * ldb);
-            v2 = MlasLoadFloat16x8(b + 18 * ldb);
-            v3 = MlasLoadFloat16x8(b + 19 * ldb);
-            v4 = MlasLoadFloat16x8(b + 20 * ldb);
-            v5 = MlasLoadFloat16x8(b + 21 * ldb);
-            v6 = MlasLoadFloat16x8(b + 22 * ldb);
-            v7 = MlasLoadFloat16x8(b + 23 * ldb);
-            Transpose8x8(v0, v1, v2, v3, v4, v5, v6, v7);
-            MlasStoreFloat16x8(PackedB_data + 16, v0);
-            MlasStoreFloat16x8(PackedB_data + 48, v1);
-            MlasStoreFloat16x8(PackedB_data + 80, v2);
-            MlasStoreFloat16x8(PackedB_data + 112, v3);
-            MlasStoreFloat16x8(PackedB_data + 144, v4);
-            MlasStoreFloat16x8(PackedB_data + 176, v5);
-            MlasStoreFloat16x8(PackedB_data + 208, v6);
-            MlasStoreFloat16x8(PackedB_data + 240, v7);
-
-            v8 = MlasLoadFloat16x8(b + 24 * ldb);
-            v9 = MlasLoadFloat16x8(b + 25 * ldb);
-            vA = MlasLoadFloat16x8(b + 26 * ldb);
-            vB = MlasLoadFloat16x8(b + 27 * ldb);
-            vC = MlasLoadFloat16x8(b + 28 * ldb);
-            vD = MlasLoadFloat16x8(b + 29 * ldb);
-            vE = MlasLoadFloat16x8(b + 30 * ldb);
-            vF = MlasLoadFloat16x8(b + 31 * ldb);
-            Transpose8x8(v8, v9, vA, vB, vC, vD, vE, vF);
-            MlasStoreFloat16x8(PackedB_data + 24, v8);
-            MlasStoreFloat16x8(PackedB_data + 56, v9);
-            MlasStoreFloat16x8(PackedB_data + 88, vA);
-            MlasStoreFloat16x8(PackedB_data + 120, vB);
-            MlasStoreFloat16x8(PackedB_data + 152, vC);
-            MlasStoreFloat16x8(PackedB_data + 184, vD);
-            MlasStoreFloat16x8(PackedB_data + 216, vE);
-            MlasStoreFloat16x8(PackedB_data + 248, vF);
+            MlasStoreFloat16x8(PackedB_data + basep, v0);
+            MlasStoreFloat16x8(PackedB_data + basep + 32, v1);
+            MlasStoreFloat16x8(PackedB_data + basep + 64, v2);
+            MlasStoreFloat16x8(PackedB_data + basep + 96, v3);
+            MlasStoreFloat16x8(PackedB_data + basep + 128, v4);
+            MlasStoreFloat16x8(PackedB_data + basep + 160, v5);
+            MlasStoreFloat16x8(PackedB_data + basep + 192, v6);
+            MlasStoreFloat16x8(PackedB_data + basep + 224, v7);
         }
 
         if (k & 4) {
+            size_t baseb = 0;
+            size_t basep = 0;
             float16x4_t v0 = MlasLoadFloat16x4(b);
             float16x4_t v1 = MlasLoadFloat16x4(b + ldb);
             float16x4_t v2 = MlasLoadFloat16x4(b + 2 * ldb);
@@ -118,78 +87,42 @@ void HPackB_TransposedB_Kernel(
             float16x4_t v5 = MlasLoadFloat16x4(b + 5 * ldb);
             float16x4_t v6 = MlasLoadFloat16x4(b + 6 * ldb);
             float16x4_t v7 = MlasLoadFloat16x4(b + 7 * ldb);
+            for (size_t i = 0; i < 3; ++i, baseb += 8 * ldb, basep += 8) {
+                Transpose4x4(v0, v1, v2, v3);
+                Transpose4x4(v4, v5, v6, v7);
+                MlasStoreFloat16x4(PackedB_data + basep, v0);
+                MlasStoreFloat16x4(PackedB_data + basep + 4, v4);
+                MlasStoreFloat16x4(PackedB_data + basep + 32, v1);
+                MlasStoreFloat16x4(PackedB_data + basep + 36, v5);
+                MlasStoreFloat16x4(PackedB_data + basep + 64, v2);
+                MlasStoreFloat16x4(PackedB_data + basep + 68, v6);
+                MlasStoreFloat16x4(PackedB_data + basep + 96, v3);
+                MlasStoreFloat16x4(PackedB_data + basep + 100, v7);
+                v0 = MlasLoadFloat16x4(b + baseb + 8 * ldb);
+                v1 = MlasLoadFloat16x4(b + baseb + 9 * ldb);
+                v2 = MlasLoadFloat16x4(b + baseb + 10 * ldb);
+                v3 = MlasLoadFloat16x4(b + baseb + 11 * ldb);
+                v4 = MlasLoadFloat16x4(b + baseb + 12 * ldb);
+                v5 = MlasLoadFloat16x4(b + baseb + 13 * ldb);
+                v6 = MlasLoadFloat16x4(b + baseb + 14 * ldb);
+                v7 = MlasLoadFloat16x4(b + baseb + 15 * ldb);
+            }
             Transpose4x4(v0, v1, v2, v3);
             Transpose4x4(v4, v5, v6, v7);
-            MlasStoreFloat16x4(PackedB_data, v0);
-            MlasStoreFloat16x4(PackedB_data + 4, v4);
-            MlasStoreFloat16x4(PackedB_data + 32, v1);
-            MlasStoreFloat16x4(PackedB_data + 36, v5);
-            MlasStoreFloat16x4(PackedB_data + 64, v2);
-            MlasStoreFloat16x4(PackedB_data + 68, v6);
-            MlasStoreFloat16x4(PackedB_data + 96, v3);
-            MlasStoreFloat16x4(PackedB_data + 100, v7);
-
-            float16x4_t v8 = MlasLoadFloat16x4(b + 8 * ldb);
-            float16x4_t v9 = MlasLoadFloat16x4(b + 9 * ldb);
-            float16x4_t vA = MlasLoadFloat16x4(b + 10 * ldb);
-            float16x4_t vB = MlasLoadFloat16x4(b + 11 * ldb);
-            float16x4_t vC = MlasLoadFloat16x4(b + 12 * ldb);
-            float16x4_t vD = MlasLoadFloat16x4(b + 13 * ldb);
-            float16x4_t vE = MlasLoadFloat16x4(b + 14 * ldb);
-            float16x4_t vF = MlasLoadFloat16x4(b + 15 * ldb);
-            Transpose4x4(v8, v9, vA, vB);
-            Transpose4x4(vC, vD, vE, vF);
-            MlasStoreFloat16x4(PackedB_data + 8, v8);
-            MlasStoreFloat16x4(PackedB_data + 12, vC);
-            MlasStoreFloat16x4(PackedB_data + 40, v9);
-            MlasStoreFloat16x4(PackedB_data + 44, vD);
-            MlasStoreFloat16x4(PackedB_data + 72, vA);
-            MlasStoreFloat16x4(PackedB_data + 76, vE);
-            MlasStoreFloat16x4(PackedB_data + 104, vB);
-            MlasStoreFloat16x4(PackedB_data + 108, vF);
-
-            v0 = MlasLoadFloat16x4(b + 16 * ldb);
-            v1 = MlasLoadFloat16x4(b + 17 * ldb);
-            v2 = MlasLoadFloat16x4(b + 18 * ldb);
-            v3 = MlasLoadFloat16x4(b + 19 * ldb);
-            v4 = MlasLoadFloat16x4(b + 20 * ldb);
-            v5 = MlasLoadFloat16x4(b + 21 * ldb);
-            v6 = MlasLoadFloat16x4(b + 22 * ldb);
-            v7 = MlasLoadFloat16x4(b + 23 * ldb);
-            Transpose4x4(v0, v1, v2, v3);
-            Transpose4x4(v4, v5, v6, v7);
-            MlasStoreFloat16x4(PackedB_data + 16, v0);
-            MlasStoreFloat16x4(PackedB_data + 20, v4);
-            MlasStoreFloat16x4(PackedB_data + 48, v1);
-            MlasStoreFloat16x4(PackedB_data + 52, v5);
-            MlasStoreFloat16x4(PackedB_data + 80, v2);
-            MlasStoreFloat16x4(PackedB_data + 84, v6);
-            MlasStoreFloat16x4(PackedB_data + 112, v3);
-            MlasStoreFloat16x4(PackedB_data + 116, v7);
-
-            v8 = MlasLoadFloat16x4(b + 24 * ldb);
-            v9 = MlasLoadFloat16x4(b + 25 * ldb);
-            vA = MlasLoadFloat16x4(b + 26 * ldb);
-            vB = MlasLoadFloat16x4(b + 27 * ldb);
-            vC = MlasLoadFloat16x4(b + 28 * ldb);
-            vD = MlasLoadFloat16x4(b + 29 * ldb);
-            vE = MlasLoadFloat16x4(b + 30 * ldb);
-            vF = MlasLoadFloat16x4(b + 31 * ldb);
-            Transpose4x4(v8, v9, vA, vB);
-            Transpose4x4(vC, vD, vE, vF);
-            MlasStoreFloat16x4(PackedB_data + 24, v8);
-            MlasStoreFloat16x4(PackedB_data + 28, vC);
-            MlasStoreFloat16x4(PackedB_data + 56, v9);
-            MlasStoreFloat16x4(PackedB_data + 60, vD);
-            MlasStoreFloat16x4(PackedB_data + 88, vA);
-            MlasStoreFloat16x4(PackedB_data + 92, vE);
-            MlasStoreFloat16x4(PackedB_data + 120, vB);
-            MlasStoreFloat16x4(PackedB_data + 124, vF);
-
+            MlasStoreFloat16x4(PackedB_data + basep, v0);
+            MlasStoreFloat16x4(PackedB_data + basep + 4, v4);
+            MlasStoreFloat16x4(PackedB_data + basep + 32, v1);
+            MlasStoreFloat16x4(PackedB_data + basep + 36, v5);
+            MlasStoreFloat16x4(PackedB_data + basep + 64, v2);
+            MlasStoreFloat16x4(PackedB_data + basep + 68, v6);
+            MlasStoreFloat16x4(PackedB_data + basep + 96, v3);
+            MlasStoreFloat16x4(PackedB_data + basep + 100, v7);
             k -= 4, b += 4, PackedB_data += 4 * 32;
         }
 
         if (k > 0) {
+            size_t baseb = 0;
+            size_t basep = 0;
             float16x4_t v0 = MlasLoadPartialFloat16x4(b, k);
             float16x4_t v1 = MlasLoadPartialFloat16x4(b + ldb, k);
             float16x4_t v2 = MlasLoadPartialFloat16x4(b + 2 * ldb, k);
@@ -198,82 +131,41 @@ void HPackB_TransposedB_Kernel(
             float16x4_t v5 = MlasLoadPartialFloat16x4(b + 5 * ldb, k);
             float16x4_t v6 = MlasLoadPartialFloat16x4(b + 6 * ldb, k);
             float16x4_t v7 = MlasLoadPartialFloat16x4(b + 7 * ldb, k);
+            for (size_t i = 0; i < 3; ++i, baseb += 8 * ldb, basep += 8) {
+                Transpose4x4(v0, v1, v2, v3);
+                Transpose4x4(v4, v5, v6, v7);
+                MlasStoreFloat16x4(PackedB_data + basep, v0);
+                MlasStoreFloat16x4(PackedB_data + basep + 4, v4);
+                if (k > 1) {
+                    MlasStoreFloat16x4(PackedB_data + basep + 32, v1);
+                    MlasStoreFloat16x4(PackedB_data + basep + 36, v5);
+                }
+                if (k > 2) {
+                    MlasStoreFloat16x4(PackedB_data + basep + 64, v2);
+                    MlasStoreFloat16x4(PackedB_data + basep + 68, v6);
+                }
+                v0 = MlasLoadPartialFloat16x4(b + baseb + 8 * ldb, k);
+                v1 = MlasLoadPartialFloat16x4(b + baseb + 9 * ldb, k);
+                v2 = MlasLoadPartialFloat16x4(b + baseb + 10 * ldb, k);
+                v3 = MlasLoadPartialFloat16x4(b + baseb + 11 * ldb, k);
+                v4 = MlasLoadPartialFloat16x4(b + baseb + 12 * ldb, k);
+                v5 = MlasLoadPartialFloat16x4(b + baseb + 13 * ldb, k);
+                v6 = MlasLoadPartialFloat16x4(b + baseb + 14 * ldb, k);
+                v7 = MlasLoadPartialFloat16x4(b + baseb + 15 * ldb, k);
+
+            }
             Transpose4x4(v0, v1, v2, v3);
             Transpose4x4(v4, v5, v6, v7);
-            MlasStoreFloat16x4(PackedB_data, v0);
-            MlasStoreFloat16x4(PackedB_data + 4, v4);
+            MlasStoreFloat16x4(PackedB_data + basep, v0);
+            MlasStoreFloat16x4(PackedB_data + basep + 4, v4);
             if (k > 1) {
-                MlasStoreFloat16x4(PackedB_data + 32, v1);
-                MlasStoreFloat16x4(PackedB_data + 36, v5);
+                MlasStoreFloat16x4(PackedB_data + basep + 32, v1);
+                MlasStoreFloat16x4(PackedB_data + basep + 36, v5);
             }
             if (k > 2) {
-                MlasStoreFloat16x4(PackedB_data + 64, v2);
-                MlasStoreFloat16x4(PackedB_data + 68, v6);
+                MlasStoreFloat16x4(PackedB_data + basep + 64, v2);
+                MlasStoreFloat16x4(PackedB_data + basep + 68, v6);
             }
-
-            float16x4_t v8 = MlasLoadPartialFloat16x4(b + 8 * ldb, k);
-            float16x4_t v9 = MlasLoadPartialFloat16x4(b + 9 * ldb, k);
-            float16x4_t vA = MlasLoadPartialFloat16x4(b + 10 * ldb, k);
-            float16x4_t vB = MlasLoadPartialFloat16x4(b + 11 * ldb, k);
-            float16x4_t vC = MlasLoadPartialFloat16x4(b + 12 * ldb, k);
-            float16x4_t vD = MlasLoadPartialFloat16x4(b + 13 * ldb, k);
-            float16x4_t vE = MlasLoadPartialFloat16x4(b + 14 * ldb, k);
-            float16x4_t vF = MlasLoadPartialFloat16x4(b + 15 * ldb, k);
-            Transpose4x4(v8, v9, vA, vB);
-            Transpose4x4(vC, vD, vE, vF);
-            MlasStoreFloat16x4(PackedB_data + 8, v8);
-            MlasStoreFloat16x4(PackedB_data + 12, vC);
-            if (k > 1) {
-                MlasStoreFloat16x4(PackedB_data + 40, v9);
-                MlasStoreFloat16x4(PackedB_data + 44, vD);
-            }
-            if (k > 2) {
-                MlasStoreFloat16x4(PackedB_data + 72, vA);
-                MlasStoreFloat16x4(PackedB_data + 76, vE);
-            }
-
-            v0 = MlasLoadPartialFloat16x4(b + 16 * ldb, k);
-            v1 = MlasLoadPartialFloat16x4(b + 17 * ldb, k);
-            v2 = MlasLoadPartialFloat16x4(b + 18 * ldb, k);
-            v3 = MlasLoadPartialFloat16x4(b + 19 * ldb, k);
-            v4 = MlasLoadPartialFloat16x4(b + 20 * ldb, k);
-            v5 = MlasLoadPartialFloat16x4(b + 21 * ldb, k);
-            v6 = MlasLoadPartialFloat16x4(b + 22 * ldb, k);
-            v7 = MlasLoadPartialFloat16x4(b + 23 * ldb, k);
-            Transpose4x4(v0, v1, v2, v3);
-            Transpose4x4(v4, v5, v6, v7);
-            MlasStoreFloat16x4(PackedB_data + 16, v0);
-            MlasStoreFloat16x4(PackedB_data + 20, v4);
-            if (k > 1) {
-                MlasStoreFloat16x4(PackedB_data + 48, v1);
-                MlasStoreFloat16x4(PackedB_data + 52, v5);
-            }
-            if (k > 2) {
-                MlasStoreFloat16x4(PackedB_data + 80, v2);
-                MlasStoreFloat16x4(PackedB_data + 84, v6);
-            }
-
-            v8 = MlasLoadPartialFloat16x4(b + 24 * ldb, k);
-            v9 = MlasLoadPartialFloat16x4(b + 25 * ldb, k);
-            vA = MlasLoadPartialFloat16x4(b + 26 * ldb, k);
-            vB = MlasLoadPartialFloat16x4(b + 27 * ldb, k);
-            vC = MlasLoadPartialFloat16x4(b + 28 * ldb, k);
-            vD = MlasLoadPartialFloat16x4(b + 29 * ldb, k);
-            vE = MlasLoadPartialFloat16x4(b + 30 * ldb, k);
-            vF = MlasLoadPartialFloat16x4(b + 31 * ldb, k);
-            Transpose4x4(v8, v9, vA, vB);
-            Transpose4x4(vC, vD, vE, vF);
-            MlasStoreFloat16x4(PackedB_data + 24, v8);
-            MlasStoreFloat16x4(PackedB_data + 28, vC);
-            if (k > 1) {
-                MlasStoreFloat16x4(PackedB_data + 56, v9);
-                MlasStoreFloat16x4(PackedB_data + 60, vD);
-            }
-            if (k > 2) {
-                MlasStoreFloat16x4(PackedB_data + 88, vA);
-                MlasStoreFloat16x4(PackedB_data + 92, vE);
-            }
-
             PackedB_data += k * 32;
         }
     }
@@ -561,144 +453,65 @@ void HPackB_B_Kernel(
 ) {
     const _mlas_fp16_* B_data = reinterpret_cast<const _mlas_fp16_*>(B);
     _mlas_fp16_* PackedB_data = reinterpret_cast<_mlas_fp16_*>(PackedB);
-    const size_t ldb4 = ldb * 4;
 
     for (; CountN >= 32; CountN -= 32, B_data += 32) {
         const _mlas_fp16_* b = B_data;
         size_t k = CountK;
-        constexpr size_t step = 4 * 32;
-        for (; k >= 4; k -= 4, b += ldb4, PackedB_data += step) {
-            vst4q_u16(PackedB_data, vld4q_u16(b));
-            vst4q_u16(PackedB_data + 32, vld4q_u16(b + ldb));
-            vst4q_u16(PackedB_data + 64, vld4q_u16(b + 2 * ldb));
-            vst4q_u16(PackedB_data + 96, vld4q_u16(b + 3 * ldb));
+        uint16x8x4_t v0 = vld4q_u16(b);
+        for (; k >= 2; --k, b += ldb, PackedB_data += 32) {
+            vst4q_u16(PackedB_data, v0);
+            v0 = vld4q_u16(b + ldb);
         }
-
-        if (k & 2) {
-            vst4q_u16(PackedB_data, vld4q_u16(b));
-            vst4q_u16(PackedB_data + 32, vld4q_u16(b + ldb));
-            b += 2 * ldb, PackedB_data += 2 * 32;
-        }
-
-        if (k & 1) {
-            vst4q_u16(PackedB_data, vld4q_u16(b));
-            PackedB_data += 32;
-        }
+        vst4q_u16(PackedB_data, v0);
+        PackedB_data += 32;
     }
 
     if (CountN & 16) {
         const _mlas_fp16_* b = B_data;
         size_t k = CountK;
-        constexpr size_t step = 4 * 16;
-        for (; k >= 4; k -= 4, b += ldb4, PackedB_data += step) {
-            vst2q_u16(PackedB_data, vld2q_u16(b));
-            vst2q_u16(PackedB_data + 16, vld2q_u16(b + ldb));
-            vst2q_u16(PackedB_data + 32, vld2q_u16(b + 2 * ldb));
-            vst2q_u16(PackedB_data + 48, vld2q_u16(b + 3 * ldb));
+        uint16x8x2_t v0 = vld2q_u16(b);
+        for (; k >= 2; --k, b += ldb, PackedB_data += 16) {
+            vst2q_u16(PackedB_data, v0);
+            v0 = vld2q_u16(b + ldb);
         }
-
-        if (k & 2) {
-            vst2q_u16(PackedB_data, vld2q_u16(b));
-            vst2q_u16(PackedB_data + 16, vld2q_u16(b + ldb));
-            b += 2 * ldb, PackedB_data += 2 * 16;
-        }
-
-        if (k & 1) {
-            vst2q_u16(PackedB_data, vld2q_u16(b));
-            PackedB_data += 16;
-        }
-
+        vst2q_u16(PackedB_data, v0);
+        PackedB_data += 16;
         CountN -= 16, B_data += 16;
     }
 
     if (CountN & 8) {
         const _mlas_fp16_* b = B_data;
         size_t k = CountK;
-        constexpr size_t step = 4 * 8;
-        for (; k >= 4; k -= 4, b += ldb4, PackedB_data += step) {
-            vst1q_u16(PackedB_data, vld1q_u16(b));
-            vst1q_u16(PackedB_data + 8, vld1q_u16(b + ldb));
-            vst1q_u16(PackedB_data + 16, vld1q_u16(b + 2 * ldb));
-            vst1q_u16(PackedB_data + 24, vld1q_u16(b + 3 * ldb));
+        uint16x8_t v0 = vld1q_u16(b);
+        for (; k >= 2; --k, b += ldb, PackedB_data += 8) {
+            vst1q_u16(PackedB_data, v0);
+            v0 = vld1q_u16(b + ldb);
         }
-
-        if (k & 2) {
-            vst1q_u16(PackedB_data, vld1q_u16(b));
-            vst1q_u16(PackedB_data + 8, vld1q_u16(b + ldb));
-            b += 2 * ldb, PackedB_data += 2 * 8;
-        }
-
-        if (k & 1) {
-            vst1q_u16(PackedB_data, vld1q_u16(b));
-            PackedB_data += 8;
-        }
+        vst1q_u16(PackedB_data, v0);
+        PackedB_data += 8;
 
         B_data += 8;
         CountN -= 8;
     }
 
     if (CountN > 4) {
-        for (; CountK >= 4; B_data += ldb * 4, PackedB_data += 32, CountK -= 4) {
-            float16x4_t v0 = MlasLoadFloat16x4(B_data);
-            float16x4_t v1 = MlasLoadPartialFloat16x4(B_data + 4, CountN - 4);
-            float16x4_t v2 = MlasLoadFloat16x4(B_data + ldb);
-            float16x4_t v3 = MlasLoadPartialFloat16x4(B_data + ldb + 4, CountN - 4);
-            float16x4_t v4 = MlasLoadFloat16x4(B_data + 2 * ldb);
-            float16x4_t v5 = MlasLoadPartialFloat16x4(B_data + 2 * ldb + 4, CountN - 4);
-            float16x4_t v6 = MlasLoadFloat16x4(B_data + 3 * ldb);
-            float16x4_t v7 = MlasLoadPartialFloat16x4(B_data + 3 * ldb + 4, CountN - 4);
+        float16x4_t v0 = MlasLoadFloat16x4(B_data);
+        float16x4_t v1 = MlasLoadPartialFloat16x4(B_data + 4, CountN - 4);
+        for (; CountK >= 2; B_data += ldb, PackedB_data += 8, --CountK) {
             MlasStoreFloat16x4(PackedB_data, v0);
             MlasStoreFloat16x4(PackedB_data + 4, v1);
-            MlasStoreFloat16x4(PackedB_data + 8, v2);
-            MlasStoreFloat16x4(PackedB_data + 12, v3);
-            MlasStoreFloat16x4(PackedB_data + 16, v4);
-            MlasStoreFloat16x4(PackedB_data + 20, v5);
-            MlasStoreFloat16x4(PackedB_data + 24, v6);
-            MlasStoreFloat16x4(PackedB_data + 28, v7);
+            v0 = MlasLoadFloat16x4(B_data + ldb);
+            v1 = MlasLoadPartialFloat16x4(B_data + ldb + 4, CountN - 4);
         }
-
-        if (CountK & 2) {
-            float16x4_t v0 = MlasLoadFloat16x4(B_data);
-            float16x4_t v1 = MlasLoadPartialFloat16x4(B_data + 4, CountN - 4);
-            float16x4_t v2 = MlasLoadFloat16x4(B_data + ldb);
-            float16x4_t v3 = MlasLoadPartialFloat16x4(B_data + ldb + 4, CountN - 4);
-            MlasStoreFloat16x4(PackedB_data, v0);
-            MlasStoreFloat16x4(PackedB_data + 4, v1);
-            MlasStoreFloat16x4(PackedB_data + 8, v2);
-            MlasStoreFloat16x4(PackedB_data + 12, v3);
-            B_data += 2 * ldb, PackedB_data += 16;
-        }
-
-        if (CountK & 1) {
-            float16x4_t v0 = MlasLoadFloat16x4(B_data);
-            float16x4_t v1 = MlasLoadPartialFloat16x4(B_data + 4, CountN - 4);
-            MlasStoreFloat16x4(PackedB_data, v0);
-            MlasStoreFloat16x4(PackedB_data + 4, v1);
-        }
+        MlasStoreFloat16x4(PackedB_data, v0);
+        MlasStoreFloat16x4(PackedB_data + 4, v1);
     } else if (CountN > 0) {
-        for (; CountK >= 4; B_data += 4 * ldb, PackedB_data += 32, CountK -= 4) {
-            float16x4_t v0 = MlasLoadPartialFloat16x4(B_data, CountN);
-            float16x4_t v1 = MlasLoadPartialFloat16x4(B_data + ldb, CountN);
-            float16x4_t v2 = MlasLoadPartialFloat16x4(B_data + 2 * ldb, CountN);
-            float16x4_t v3 = MlasLoadPartialFloat16x4(B_data + 3 * ldb, CountN);
+        float16x4_t v0 = MlasLoadPartialFloat16x4(B_data, CountN);
+        for (; CountK >= 2; B_data += ldb, PackedB_data += 8, --CountK) {
             MlasStoreFloat16x4(PackedB_data, v0);
-            MlasStoreFloat16x4(PackedB_data + 8, v1);
-            MlasStoreFloat16x4(PackedB_data + 16, v2);
-            MlasStoreFloat16x4(PackedB_data + 24, v3);
+            v0 = MlasLoadPartialFloat16x4(B_data + ldb, CountN);
         }
-
-        if (CountK & 2) {
-            float16x4_t v0 = MlasLoadPartialFloat16x4(B_data, CountN);
-            float16x4_t v1 = MlasLoadPartialFloat16x4(B_data + ldb, CountN);
-            MlasStoreFloat16x4(PackedB_data, v0);
-            MlasStoreFloat16x4(PackedB_data + 8, v1);
-            B_data += 2 * ldb, PackedB_data += 16;
-        }
-
-        if (CountK & 1) {
-            float16x4_t v0 = MlasLoadPartialFloat16x4(B_data, CountN);
-            MlasStoreFloat16x4(PackedB_data, v0);
-        }
+        MlasStoreFloat16x4(PackedB_data, v0);
     }
 }
 
@@ -2793,9 +2606,6 @@ void HGemm_PackedB_Kernel_Impl(
     }
 }
 
-// TODO:
-//  - surface spec.
-//  - process 32 columns
 void HGemm_PackedB_Kernel(
     const MLAS_FP16* A,
     const MLAS_FP16* PackedB,

--- a/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
@@ -1391,6 +1391,10 @@ void HGemm_B_Kernel_Complicated(
     const size_t ldb8 = ldb * 8;
     const float16x8_t zero_v8 = MlasZeroFloat16x8();
     const float16x4_t zero_v4 = MlasZeroFloat16x4();
+    float16x8_t alpha_v8 = MlasBroadcastFloat16x8(alpha);
+    float16x8_t beta_v8 = MlasBroadcastFloat16x8(beta);
+    float16x4_t alpha_v4 = MlasBroadcastFloat16x4(alpha);
+    float16x4_t beta_v4 = MlasBroadcastFloat16x4(beta);
     for (; CountN >= 32; CountN -= 32, B_data += 32, C_data += 32) {
         const auto* a = A_data;
         const auto* b = B_data;
@@ -1441,25 +1445,23 @@ void HGemm_B_Kernel_Complicated(
             ma_lane_accu<CountM>(b + 24, ldb, a0, accu03, a1, accu13, k);
         }
 
-        float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
-        float16x8_t beta_v = MlasBroadcastFloat16x8(beta);
         float16x8_t c00 = MlasLoadFloat16x8(C_data);
         float16x8_t c01 = MlasLoadFloat16x8(C_data + 8);
         float16x8_t c02 = MlasLoadFloat16x8(C_data + 16);
         float16x8_t c03 = MlasLoadFloat16x8(C_data + 24);
-        MlasStoreFloat16x8(C_data, vfmaq_f16(vmulq_f16(c00, beta_v), accu00, alpha_v));
-        MlasStoreFloat16x8(C_data + 8, vfmaq_f16(vmulq_f16(c01, beta_v), accu01, alpha_v));
-        MlasStoreFloat16x8(C_data + 16, vfmaq_f16(vmulq_f16(c02, beta_v), accu02, alpha_v));
-        MlasStoreFloat16x8(C_data + 24, vfmaq_f16(vmulq_f16(c03, beta_v), accu03, alpha_v));
+        MlasStoreFloat16x8(C_data, vfmaq_f16(vmulq_f16(c00, beta_v8), accu00, alpha_v8));
+        MlasStoreFloat16x8(C_data + 8, vfmaq_f16(vmulq_f16(c01, beta_v8), accu01, alpha_v8));
+        MlasStoreFloat16x8(C_data + 16, vfmaq_f16(vmulq_f16(c02, beta_v8), accu02, alpha_v8));
+        MlasStoreFloat16x8(C_data + 24, vfmaq_f16(vmulq_f16(c03, beta_v8), accu03, alpha_v8));
         if constexpr (CountM == 2) {
             float16x8_t c10 = MlasLoadFloat16x8(C_data + ldc);
             float16x8_t c11 = MlasLoadFloat16x8(C_data + ldc + 8);
             float16x8_t c12 = MlasLoadFloat16x8(C_data + ldc + 16);
             float16x8_t c13 = MlasLoadFloat16x8(C_data + ldc + 24);
-            MlasStoreFloat16x8(C_data + ldc, vfmaq_f16(vmulq_f16(c10, beta_v), accu10, alpha_v));
-            MlasStoreFloat16x8(C_data + ldc + 8, vfmaq_f16(vmulq_f16(c11, beta_v), accu11, alpha_v));
-            MlasStoreFloat16x8(C_data + ldc + 16, vfmaq_f16(vmulq_f16(c12, beta_v), accu12, alpha_v));
-            MlasStoreFloat16x8(C_data + ldc + 24, vfmaq_f16(vmulq_f16(c13, beta_v), accu13, alpha_v));
+            MlasStoreFloat16x8(C_data + ldc, vfmaq_f16(vmulq_f16(c10, beta_v8), accu10, alpha_v8));
+            MlasStoreFloat16x8(C_data + ldc + 8, vfmaq_f16(vmulq_f16(c11, beta_v8), accu11, alpha_v8));
+            MlasStoreFloat16x8(C_data + ldc + 16, vfmaq_f16(vmulq_f16(c12, beta_v8), accu12, alpha_v8));
+            MlasStoreFloat16x8(C_data + ldc + 24, vfmaq_f16(vmulq_f16(c13, beta_v8), accu13, alpha_v8));
         }
     }
 
@@ -1502,17 +1504,15 @@ void HGemm_B_Kernel_Complicated(
             ma_lane_accu<CountM>(b + 8, ldb, a0, accu01, a1, accu11, k);
         }
 
-        float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
-        float16x8_t beta_v = MlasBroadcastFloat16x8(beta);
         float16x8_t c00 = MlasLoadFloat16x8(C_data);
         float16x8_t c01 = MlasLoadFloat16x8(C_data + 8);
-        MlasStoreFloat16x8(C_data, vfmaq_f16(vmulq_f16(c00, beta_v), accu00, alpha_v));
-        MlasStoreFloat16x8(C_data + 8, vfmaq_f16(vmulq_f16(c01, beta_v), accu01, alpha_v));
+        MlasStoreFloat16x8(C_data, vfmaq_f16(vmulq_f16(c00, beta_v8), accu00, alpha_v8));
+        MlasStoreFloat16x8(C_data + 8, vfmaq_f16(vmulq_f16(c01, beta_v8), accu01, alpha_v8));
         if constexpr (CountM == 2) {
             float16x8_t c10 = MlasLoadFloat16x8(C_data + ldc);
             float16x8_t c11 = MlasLoadFloat16x8(C_data + ldc + 8);
-            MlasStoreFloat16x8(C_data + ldc, vfmaq_f16(vmulq_f16(c10, beta_v), accu10, alpha_v));
-            MlasStoreFloat16x8(C_data + ldc + 8, vfmaq_f16(vmulq_f16(c11, beta_v), accu11, alpha_v));
+            MlasStoreFloat16x8(C_data + ldc, vfmaq_f16(vmulq_f16(c10, beta_v8), accu10, alpha_v8));
+            MlasStoreFloat16x8(C_data + ldc + 8, vfmaq_f16(vmulq_f16(c11, beta_v8), accu11, alpha_v8));
         }
 
         CountN -= 16, B_data += 16, C_data += 16;
@@ -1552,13 +1552,11 @@ void HGemm_B_Kernel_Complicated(
             ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10, k);
         }
 
-        float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
-        float16x8_t beta_v = MlasBroadcastFloat16x8(beta);
         float16x8_t c00 = MlasLoadFloat16x8(C_data);
-        MlasStoreFloat16x8(C_data, vfmaq_f16(vmulq_f16(c00, beta_v), accu00, alpha_v));
+        MlasStoreFloat16x8(C_data, vfmaq_f16(vmulq_f16(c00, beta_v8), accu00, alpha_v8));
         if constexpr (CountM == 2) {
             float16x8_t c10 = MlasLoadFloat16x8(C_data + ldc);
-            MlasStoreFloat16x8(C_data + ldc, vfmaq_f16(vmulq_f16(c10, beta_v), accu10, alpha_v));
+            MlasStoreFloat16x8(C_data + ldc, vfmaq_f16(vmulq_f16(c10, beta_v8), accu10, alpha_v8));
         }
 
         CountN -= 8, B_data += 8, C_data += 8;
@@ -1598,13 +1596,11 @@ void HGemm_B_Kernel_Complicated(
             ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10, k);
         }
 
-        float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
-        float16x4_t beta_v = MlasBroadcastFloat16x4(beta);
         float16x4_t c00 = MlasLoadFloat16x4(C_data);
-        MlasStoreFloat16x4(C_data, vfma_f16(vmul_f16(c00, beta_v), accu00, alpha_v));
+        MlasStoreFloat16x4(C_data, vfma_f16(vmul_f16(c00, beta_v4), accu00, alpha_v4));
         if constexpr (CountM == 2) {
             float16x4_t c10 = MlasLoadFloat16x4(C_data + ldc);
-            MlasStoreFloat16x4(C_data + ldc, vfma_f16(vmul_f16(c10, beta_v), accu10, alpha_v));
+            MlasStoreFloat16x4(C_data + ldc, vfma_f16(vmul_f16(c10, beta_v4), accu10, alpha_v4));
         }
 
         CountN -= 4, B_data += 4, C_data += 4;
@@ -1644,13 +1640,11 @@ void HGemm_B_Kernel_Complicated(
             ma_lane_partial_accu<CountM>(b, ldb, a0, accu00, a1, accu10, k, CountN);
         }
 
-        float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
-        float16x4_t beta_v = MlasBroadcastFloat16x4(beta);
         float16x4_t c00 = MlasLoadPartialFloat16x4(C_data, CountN);
-        MlasStorePartialFloat16x4(C_data, vfma_f16(vmul_f16(c00, beta_v), accu00, alpha_v), CountN);
+        MlasStorePartialFloat16x4(C_data, vfma_f16(vmul_f16(c00, beta_v4), accu00, alpha_v4), CountN);
         if constexpr (CountM == 2) {
             float16x4_t c10 = MlasLoadPartialFloat16x4(C_data + ldc, CountN);
-            MlasStorePartialFloat16x4(C_data + ldc, vfma_f16(vmul_f16(c10, beta_v), accu10, alpha_v), CountN);
+            MlasStorePartialFloat16x4(C_data + ldc, vfma_f16(vmul_f16(c10, beta_v4), accu10, alpha_v4), CountN);
         }
     }
 }
@@ -2071,252 +2065,9 @@ void HGemm_B_Kernel(
     }
 }
 
-template <int beta_behavior> // 0: beta == 0, 1: beta == 1, 2: beta != 0 && beta != 1
-void HGemm_PackedB_Kernel_M1(
-    const _mlas_fp16_* A,
-    const _mlas_fp16_* PackedB,
-    _mlas_fp16_* C,
-    size_t CountN,
-    size_t CountK,
-    _mlas_fp16_ alpha,
-    _mlas_fp16_ beta
-) {
-    for (; CountN >= 16; CountN -= 16, C += 16) {
-        const auto* a = A;
-        size_t k = CountK;
-        float16x8_t accu0 = MlasZeroFloat16x8();
-        float16x8_t accu1 = MlasZeroFloat16x8();
-        for (; k >= 8; k -= 8, a += 8, PackedB += 8 * 16) {
-            float16x8_t b00 = MlasLoadFloat16x8(PackedB);
-            float16x8_t b01 = MlasLoadFloat16x8(PackedB + 8);
-            float16x8_t b10 = MlasLoadFloat16x8(PackedB + 16);
-            float16x8_t b11 = MlasLoadFloat16x8(PackedB + 24);
-            float16x8_t b20 = MlasLoadFloat16x8(PackedB + 32);
-            float16x8_t b21 = MlasLoadFloat16x8(PackedB + 40);
-            float16x8_t b30 = MlasLoadFloat16x8(PackedB + 48);
-            float16x8_t b31 = MlasLoadFloat16x8(PackedB + 56);
-            float16x8_t b40 = MlasLoadFloat16x8(PackedB + 64);
-            float16x8_t b41 = MlasLoadFloat16x8(PackedB + 72);
-            float16x8_t b50 = MlasLoadFloat16x8(PackedB + 80);
-            float16x8_t b51 = MlasLoadFloat16x8(PackedB + 88);
-            float16x8_t b60 = MlasLoadFloat16x8(PackedB + 96);
-            float16x8_t b61 = MlasLoadFloat16x8(PackedB + 104);
-            float16x8_t b70 = MlasLoadFloat16x8(PackedB + 112);
-            float16x8_t b71 = MlasLoadFloat16x8(PackedB + 120);
-            float16x8_t a0 = MlasLoadFloat16x8(a);
-            accu0 = maq_laneq_f16_accu(accu0, b00, b10, b20, b30, b40, b50, b60, b70, a0);
-            accu1 = maq_laneq_f16_accu(accu1, b01, b11, b21, b31, b41, b51, b61, b71, a0);
-        }
-
-        if (k & 4) {
-            float16x8_t b00 = MlasLoadFloat16x8(PackedB);
-            float16x8_t b01 = MlasLoadFloat16x8(PackedB + 8);
-            float16x8_t b10 = MlasLoadFloat16x8(PackedB + 16);
-            float16x8_t b11 = MlasLoadFloat16x8(PackedB + 24);
-            float16x8_t b20 = MlasLoadFloat16x8(PackedB + 32);
-            float16x8_t b21 = MlasLoadFloat16x8(PackedB + 40);
-            float16x8_t b30 = MlasLoadFloat16x8(PackedB + 48);
-            float16x8_t b31 = MlasLoadFloat16x8(PackedB + 56);
-            float16x4_t a0 = MlasLoadFloat16x4(a);
-            accu0 = maq_lane_f16_accu(accu0, b00, b10, b20, b30, a0);
-            accu1 = maq_lane_f16_accu(accu1, b01, b11, b21, b31, a0);
-            k -= 4, a += 4, PackedB += 4 * 16;
-        }
-
-        if (k > 0) {
-            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k);
-            float16x8_t b00 = MlasLoadFloat16x8(PackedB);
-            float16x8_t b01 = MlasLoadFloat16x8(PackedB + 8);
-            accu0 = vfmaq_lane_f16(accu0, b00, a0, 0);
-            accu1 = vfmaq_lane_f16(accu1, b01, a0, 0);
-            if (k > 1) {
-                float16x8_t b10 = MlasLoadFloat16x8(PackedB + 16);
-                float16x8_t b11 = MlasLoadFloat16x8(PackedB + 24);
-                accu0 = vfmaq_lane_f16(accu0, b10, a0, 1);
-                accu1 = vfmaq_lane_f16(accu1, b11, a0, 1);
-            }
-            if (k > 2) {
-                float16x8_t b20 = MlasLoadFloat16x8(PackedB + 32);
-                float16x8_t b21 = MlasLoadFloat16x8(PackedB + 40);
-                accu0 = vfmaq_lane_f16(accu0, b20, a0, 2);
-                accu1 = vfmaq_lane_f16(accu1, b21, a0, 2);
-            }
-
-            PackedB += k * 16;
-        }
-
-        if constexpr (beta_behavior == 1) {
-            float16x8_t c0 = MlasLoadFloat16x8(C);
-            float16x8_t c1 = MlasLoadFloat16x8(C + 8);
-            float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
-            accu0 = vfmaq_f16(c0, accu0, alpha_v);
-            accu1 = vfmaq_f16(c1, accu1, alpha_v);
-            MlasStoreFloat16x8(C, accu0);
-            MlasStoreFloat16x8(C + 8, accu1);
-        } else if constexpr (beta_behavior == 2) {
-            float16x8_t c0 = MlasLoadFloat16x8(C);
-            float16x8_t c1 = MlasLoadFloat16x8(C + 8);
-            float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
-            float16x8_t beta_v = MlasBroadcastFloat16x8(beta);
-            accu0 = vfmaq_f16(vmulq_f16(c0, beta_v), accu0, alpha_v);
-            accu1 = vfmaq_f16(vmulq_f16(c1, beta_v), accu1, alpha_v);
-            MlasStoreFloat16x8(C, accu0);
-            MlasStoreFloat16x8(C + 8, accu1);
-        } else {
-            float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
-            accu0 = vmulq_f16(accu0, alpha_v);
-            accu1 = vmulq_f16(accu1, alpha_v);
-            MlasStoreFloat16x8(C, accu0);
-            MlasStoreFloat16x8(C + 8, accu1);
-        }
-    }
-
-    if (CountN & 8) {
-        const auto* a = A;
-        size_t k = CountK;
-        float16x8_t accu0 = MlasZeroFloat16x8();
-        for (; k >= 8; k -= 8, a += 8, PackedB += 8 * 8) {
-            float16x8_t b0 = MlasLoadFloat16x8(PackedB);
-            float16x8_t b1 = MlasLoadFloat16x8(PackedB + 8);
-            float16x8_t b2 = MlasLoadFloat16x8(PackedB + 16);
-            float16x8_t b3 = MlasLoadFloat16x8(PackedB + 24);
-            float16x8_t b4 = MlasLoadFloat16x8(PackedB + 32);
-            float16x8_t b5 = MlasLoadFloat16x8(PackedB + 40);
-            float16x8_t b6 = MlasLoadFloat16x8(PackedB + 48);
-            float16x8_t b7 = MlasLoadFloat16x8(PackedB + 56);
-            float16x8_t a0 = MlasLoadFloat16x8(a);
-            accu0 = maq_laneq_f16_accu(accu0, b0, b1, b2, b3, b4, b5, b6, b7, a0);
-        }
-
-        if (k & 4) {
-            float16x8_t b0 = MlasLoadFloat16x8(PackedB);
-            float16x8_t b1 = MlasLoadFloat16x8(PackedB + 8);
-            float16x8_t b2 = MlasLoadFloat16x8(PackedB + 16);
-            float16x8_t b3 = MlasLoadFloat16x8(PackedB + 24);
-            float16x4_t a0 = MlasLoadFloat16x4(a);
-            accu0 = maq_lane_f16_accu(accu0, b0, b1, b2, b3, a0);
-            k -= 4, a += 4, PackedB += 4 * 8;
-        }
-
-        if (k > 0) {
-            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k);
-            float16x8_t b0 = MlasLoadFloat16x8(PackedB);
-            accu0 = vfmaq_lane_f16(accu0, b0, a0, 0);
-            if (k > 1) {
-                float16x8_t b1 = MlasLoadFloat16x8(PackedB + 8);
-                accu0 = vfmaq_lane_f16(accu0, b1, a0, 1);
-            }
-            if (k > 2) {
-                float16x8_t b2 = MlasLoadFloat16x8(PackedB + 16);
-                accu0 = vfmaq_lane_f16(accu0, b2, a0, 2);
-            }
-            PackedB += k * 8;
-        }
-
-        if constexpr (beta_behavior == 1) {
-            float16x8_t c0 = MlasLoadFloat16x8(C);
-            float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
-            accu0 = vfmaq_f16(c0, accu0, alpha_v);
-            MlasStoreFloat16x8(C, accu0);
-        } else if constexpr (beta_behavior == 2) {
-            float16x8_t c0 = MlasLoadFloat16x8(C);
-            float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
-            float16x8_t beta_v = MlasBroadcastFloat16x8(beta);
-            accu0 = vfmaq_f16(vmulq_f16(c0, beta_v), accu0, alpha_v);
-            MlasStoreFloat16x8(C, accu0);
-        } else {
-            float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
-            accu0 = vmulq_f16(accu0, alpha_v);
-            MlasStoreFloat16x8(C, accu0);
-        }
-
-        CountN -= 8, C += 8;
-    }
-
-    if (CountN > 0) {
-        const auto* a = A;
-        size_t k = CountK;
-        float16x8_t accu0 = MlasZeroFloat16x8();
-        for (; k >= 8; k -= 8, a += 8, PackedB += 8 * 8) {
-            float16x8_t b0 = MlasLoadFloat16x8(PackedB);
-            float16x8_t b1 = MlasLoadFloat16x8(PackedB + 8);
-            float16x8_t b2 = MlasLoadFloat16x8(PackedB + 16);
-            float16x8_t b3 = MlasLoadFloat16x8(PackedB + 24);
-            float16x8_t b4 = MlasLoadFloat16x8(PackedB + 32);
-            float16x8_t b5 = MlasLoadFloat16x8(PackedB + 40);
-            float16x8_t b6 = MlasLoadFloat16x8(PackedB + 48);
-            float16x8_t b7 = MlasLoadFloat16x8(PackedB + 56);
-            float16x8_t a0 = MlasLoadFloat16x8(a);
-            accu0 = maq_laneq_f16_accu(accu0, b0, b1, b2, b3, b4, b5, b6, b7, a0);
-        }
-
-        if (k & 4) {
-            float16x8_t b0 = MlasLoadFloat16x8(PackedB);
-            float16x8_t b1 = MlasLoadFloat16x8(PackedB + 8);
-            float16x8_t b2 = MlasLoadFloat16x8(PackedB + 16);
-            float16x8_t b3 = MlasLoadFloat16x8(PackedB + 24);
-            float16x4_t a0 = MlasLoadFloat16x4(a);
-            accu0 = maq_lane_f16_accu(accu0, b0, b1, b2, b3, a0);
-            k -= 4, a += 4, PackedB += 4 * 8;
-        }
-
-        if (k > 0) {
-            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k);
-            float16x8_t b0 = MlasLoadFloat16x8(PackedB);
-            accu0 = vfmaq_lane_f16(accu0, b0, a0, 0);
-            if (k > 1) {
-                float16x8_t b1 = MlasLoadFloat16x8(PackedB + 8);
-                accu0 = vfmaq_lane_f16(accu0, b1, a0, 1);
-            }
-            if (k > 2) {
-                float16x8_t b2 = MlasLoadFloat16x8(PackedB + 16);
-                accu0 = vfmaq_lane_f16(accu0, b2, a0, 2);
-            }
-            PackedB += k * 8;
-        }
-
-        float16x4_t accu_low = vget_low_f16(accu0);
-        float16x4_t accu_high = vget_high_f16(accu0);
-
-        if (CountN & 4) {
-            if constexpr (beta_behavior == 1) {
-                float16x4_t c0 = MlasLoadFloat16x4(C);
-                float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
-                MlasStoreFloat16x4(C, vfma_f16(c0, accu_low, alpha_v));
-            } else if constexpr (beta_behavior == 2) {
-                float16x4_t c0 = MlasLoadFloat16x4(C);
-                float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
-                float16x4_t beta_v = MlasBroadcastFloat16x4(beta);
-                MlasStoreFloat16x4(C, vfma_f16(vmul_f16(c0, beta_v), accu_low, alpha_v));
-            } else {
-                float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
-                MlasStoreFloat16x4(C, vmul_f16(accu_low, alpha_v));
-            }
-
-            CountN -= 4, C += 4;
-            accu_low = accu_high;
-        }
-
-        if (CountN) {
-            if constexpr (beta_behavior == 1) {
-                float16x4_t c0 = MlasLoadPartialFloat16x4(C, CountN);
-                float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
-                MlasStorePartialFloat16x4(C, vfma_f16(c0, accu_low, alpha_v), CountN);
-            } else if constexpr (beta_behavior == 2) {
-                float16x4_t c0 = MlasLoadPartialFloat16x4(C, CountN);
-                float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
-                float16x4_t beta_v = MlasBroadcastFloat16x4(beta);
-                MlasStorePartialFloat16x4(C, vfma_f16(vmul_f16(c0, beta_v), accu_low, alpha_v), CountN);
-            } else {
-                float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
-                MlasStorePartialFloat16x4(C, vmul_f16(accu_low, alpha_v), CountN);
-            }
-        }
-    }
-}
-
-template <int beta_behavior> // 0: beta == 0, 1: beta == 1, 2: beta != 0 && beta != 1
-void HGemm_PackedB_Kernel_M2(
+// beta_behavior: 0 -> beta == 0, 1 -> beta == 1, 2 -> beta != 0 && beta != 1
+template <int beta_behavior, int CountM>
+void HGemm_PackedB_Kernel_Impl(
     const _mlas_fp16_* A,
     const _mlas_fp16_* PackedB,
     _mlas_fp16_* C,
@@ -2327,13 +2078,19 @@ void HGemm_PackedB_Kernel_M2(
     _mlas_fp16_ alpha,
     _mlas_fp16_ beta
 ) {
+    float16x8_t alpha_v8 = MlasBroadcastFloat16x8(alpha);
+    float16x4_t alpha_v4 = MlasBroadcastFloat16x4(alpha);
+    float16x8_t beta_v8 = MlasBroadcastFloat16x8(beta);
+    float16x4_t beta_v4 = MlasBroadcastFloat16x4(beta);
     for (; CountN >= 16; CountN -= 16, C += 16) {
         const auto* a = A;
         size_t k = CountK;
         float16x8_t accu00 = MlasZeroFloat16x8();
-        float16x8_t accu01 = MlasZeroFloat16x8();
-        float16x8_t accu10 = MlasZeroFloat16x8();
-        float16x8_t accu11 = MlasZeroFloat16x8();
+        float16x8_t accu01 = MlasZeroFloat16x8(), accu10, accu11;
+        if constexpr (CountM == 2) {
+            accu10 = MlasZeroFloat16x8();
+            accu11 = MlasZeroFloat16x8();
+        }
         for (; k >= 8; k -= 8, a += 8, PackedB += 8 * 16) {
             float16x8_t b00 = MlasLoadFloat16x8(PackedB);
             float16x8_t b01 = MlasLoadFloat16x8(PackedB + 8);
@@ -2352,11 +2109,13 @@ void HGemm_PackedB_Kernel_M2(
             float16x8_t b70 = MlasLoadFloat16x8(PackedB + 112);
             float16x8_t b71 = MlasLoadFloat16x8(PackedB + 120);
             float16x8_t a0 = MlasLoadFloat16x8(a);
-            float16x8_t a1 = MlasLoadFloat16x8(a + lda);
             accu00 = maq_laneq_f16_accu(accu00, b00, b10, b20, b30, b40, b50, b60, b70, a0);
             accu01 = maq_laneq_f16_accu(accu01, b01, b11, b21, b31, b41, b51, b61, b71, a0);
-            accu10 = maq_laneq_f16_accu(accu10, b00, b10, b20, b30, b40, b50, b60, b70, a1);
-            accu11 = maq_laneq_f16_accu(accu11, b01, b11, b21, b31, b41, b51, b61, b71, a1);
+            if constexpr (CountM == 2) {
+                float16x8_t a1 = MlasLoadFloat16x8(a + lda);
+                accu10 = maq_laneq_f16_accu(accu10, b00, b10, b20, b30, b40, b50, b60, b70, a1);
+                accu11 = maq_laneq_f16_accu(accu11, b01, b11, b21, b31, b41, b51, b61, b71, a1);
+            }
         }
 
         if (k & 4) {
@@ -2369,38 +2128,46 @@ void HGemm_PackedB_Kernel_M2(
             float16x8_t b30 = MlasLoadFloat16x8(PackedB + 48);
             float16x8_t b31 = MlasLoadFloat16x8(PackedB + 56);
             float16x4_t a0 = MlasLoadFloat16x4(a);
-            float16x4_t a1 = MlasLoadFloat16x4(a + lda);
             accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
             accu01 = maq_lane_f16_accu(accu01, b01, b11, b21, b31, a0);
-            accu10 = maq_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
-            accu11 = maq_lane_f16_accu(accu11, b01, b11, b21, b31, a1);
+            if constexpr (CountM == 2) {
+                float16x4_t a1 = MlasLoadFloat16x4(a + lda);
+                accu10 = maq_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
+                accu11 = maq_lane_f16_accu(accu11, b01, b11, b21, b31, a1);
+            }
             k -= 4, a += 4, PackedB += 4 * 16;
         }
 
         if (k > 0) {
-            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k);
-            float16x4_t a1 = MlasLoadPartialFloat16x4(a + lda, k);
             float16x8_t b00 = MlasLoadFloat16x8(PackedB);
             float16x8_t b01 = MlasLoadFloat16x8(PackedB + 8);
+            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1;
             accu00 = vfmaq_lane_f16(accu00, b00, a0, 0);
             accu01 = vfmaq_lane_f16(accu01, b01, a0, 0);
-            accu10 = vfmaq_lane_f16(accu10, b00, a1, 0);
-            accu11 = vfmaq_lane_f16(accu11, b01, a1, 0);
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadPartialFloat16x4(a + lda, k);
+                accu10 = vfmaq_lane_f16(accu10, b00, a1, 0);
+                accu11 = vfmaq_lane_f16(accu11, b01, a1, 0);
+            }
             if (k > 1) {
                 float16x8_t b10 = MlasLoadFloat16x8(PackedB + 16);
                 float16x8_t b11 = MlasLoadFloat16x8(PackedB + 24);
                 accu00 = vfmaq_lane_f16(accu00, b10, a0, 1);
                 accu01 = vfmaq_lane_f16(accu01, b11, a0, 1);
-                accu10 = vfmaq_lane_f16(accu10, b10, a1, 1);
-                accu11 = vfmaq_lane_f16(accu11, b11, a1, 1);
+                if constexpr (CountM == 2) {
+                    accu10 = vfmaq_lane_f16(accu10, b10, a1, 1);
+                    accu11 = vfmaq_lane_f16(accu11, b11, a1, 1);
+                }
             }
             if (k > 2) {
                 float16x8_t b20 = MlasLoadFloat16x8(PackedB + 32);
                 float16x8_t b21 = MlasLoadFloat16x8(PackedB + 40);
                 accu00 = vfmaq_lane_f16(accu00, b20, a0, 2);
                 accu01 = vfmaq_lane_f16(accu01, b21, a0, 2);
-                accu10 = vfmaq_lane_f16(accu10, b20, a1, 2);
-                accu11 = vfmaq_lane_f16(accu11, b21, a1, 2);
+                if constexpr (CountM == 2) {
+                    accu10 = vfmaq_lane_f16(accu10, b20, a1, 2);
+                    accu11 = vfmaq_lane_f16(accu11, b21, a1, 2);
+                }
             }
             PackedB += k * 16;
         }
@@ -2408,42 +2175,44 @@ void HGemm_PackedB_Kernel_M2(
         if constexpr (beta_behavior == 1) {
             float16x8_t c00 = MlasLoadFloat16x8(C);
             float16x8_t c01 = MlasLoadFloat16x8(C + 8);
-            float16x8_t c10 = MlasLoadFloat16x8(C + ldc);
-            float16x8_t c11 = MlasLoadFloat16x8(C + ldc + 8);
-            float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
-            accu00 = vfmaq_f16(c00, accu00, alpha_v);
-            accu01 = vfmaq_f16(c01, accu01, alpha_v);
-            accu10 = vfmaq_f16(c10, accu10, alpha_v);
-            accu11 = vfmaq_f16(c11, accu11, alpha_v);
+            accu00 = vfmaq_f16(c00, accu00, alpha_v8);
+            accu01 = vfmaq_f16(c01, accu01, alpha_v8);
             MlasStoreFloat16x8(C, accu00);
             MlasStoreFloat16x8(C + 8, accu01);
-            MlasStoreFloat16x8(C + ldc, accu10);
-            MlasStoreFloat16x8(C + ldc + 8, accu11);
+            if constexpr (CountM == 2) {
+                float16x8_t c10 = MlasLoadFloat16x8(C + ldc);
+                float16x8_t c11 = MlasLoadFloat16x8(C + ldc + 8);
+                accu10 = vfmaq_f16(c10, accu10, alpha_v8);
+                accu11 = vfmaq_f16(c11, accu11, alpha_v8);
+                MlasStoreFloat16x8(C + ldc, accu10);
+                MlasStoreFloat16x8(C + ldc + 8, accu11);
+            }
         } else if constexpr (beta_behavior == 2) {
             float16x8_t c00 = MlasLoadFloat16x8(C);
             float16x8_t c01 = MlasLoadFloat16x8(C + 8);
-            float16x8_t c10 = MlasLoadFloat16x8(C + ldc);
-            float16x8_t c11 = MlasLoadFloat16x8(C + ldc + 8);
-            float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
-            float16x8_t beta_v = MlasBroadcastFloat16x8(beta);
-            accu00 = vfmaq_f16(vmulq_f16(c00, beta_v), accu00, alpha_v);
-            accu01 = vfmaq_f16(vmulq_f16(c01, beta_v), accu01, alpha_v);
-            accu10 = vfmaq_f16(vmulq_f16(c10, beta_v), accu10, alpha_v);
-            accu11 = vfmaq_f16(vmulq_f16(c11, beta_v), accu11, alpha_v);
+            accu00 = vfmaq_f16(vmulq_f16(c00, beta_v8), accu00, alpha_v8);
+            accu01 = vfmaq_f16(vmulq_f16(c01, beta_v8), accu01, alpha_v8);
             MlasStoreFloat16x8(C, accu00);
             MlasStoreFloat16x8(C + 8, accu01);
-            MlasStoreFloat16x8(C + ldc, accu10);
-            MlasStoreFloat16x8(C + ldc + 8, accu11);
+            if constexpr (CountM == 2) {
+                float16x8_t c10 = MlasLoadFloat16x8(C + ldc);
+                float16x8_t c11 = MlasLoadFloat16x8(C + ldc + 8);
+                accu10 = vfmaq_f16(vmulq_f16(c10, beta_v8), accu10, alpha_v8);
+                accu11 = vfmaq_f16(vmulq_f16(c11, beta_v8), accu11, alpha_v8);
+                MlasStoreFloat16x8(C + ldc, accu10);
+                MlasStoreFloat16x8(C + ldc + 8, accu11);
+            }
         } else {
-            float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
-            accu00 = vmulq_f16(accu00, alpha_v);
-            accu01 = vmulq_f16(accu01, alpha_v);
-            accu10 = vmulq_f16(accu10, alpha_v);
-            accu11 = vmulq_f16(accu11, alpha_v);
+            accu00 = vmulq_f16(accu00, alpha_v8);
+            accu01 = vmulq_f16(accu01, alpha_v8);
             MlasStoreFloat16x8(C, accu00);
             MlasStoreFloat16x8(C + 8, accu01);
-            MlasStoreFloat16x8(C + ldc, accu10);
-            MlasStoreFloat16x8(C + ldc + 8, accu11);
+            if constexpr (CountM == 2) {
+                accu10 = vmulq_f16(accu10, alpha_v8);
+                accu11 = vmulq_f16(accu11, alpha_v8);
+                MlasStoreFloat16x8(C + ldc, accu10);
+                MlasStoreFloat16x8(C + ldc + 8, accu11);
+            }
         }
     }
 
@@ -2462,9 +2231,11 @@ void HGemm_PackedB_Kernel_M2(
             float16x8_t b6 = MlasLoadFloat16x8(PackedB + 48);
             float16x8_t b7 = MlasLoadFloat16x8(PackedB + 56);
             float16x8_t a0 = MlasLoadFloat16x8(a);
-            float16x8_t a1 = MlasLoadFloat16x8(a + lda);
             accu00 = maq_laneq_f16_accu(accu00, b0, b1, b2, b3, b4, b5, b6, b7, a0);
-            accu10 = maq_laneq_f16_accu(accu10, b0, b1, b2, b3, b4, b5, b6, b7, a1);
+            if constexpr (CountM == 2) {
+                float16x8_t a1 = MlasLoadFloat16x8(a + lda);
+                accu10 = maq_laneq_f16_accu(accu10, b0, b1, b2, b3, b4, b5, b6, b7, a1);
+            }
         }
 
         if (k & 4) {
@@ -2473,54 +2244,64 @@ void HGemm_PackedB_Kernel_M2(
             float16x8_t b2 = MlasLoadFloat16x8(PackedB + 16);
             float16x8_t b3 = MlasLoadFloat16x8(PackedB + 24);
             float16x4_t a0 = MlasLoadFloat16x4(a);
-            float16x4_t a1 = MlasLoadFloat16x4(a + lda);
             accu00 = maq_lane_f16_accu(accu00, b0, b1, b2, b3, a0);
-            accu10 = maq_lane_f16_accu(accu10, b0, b1, b2, b3, a1);
+            if constexpr (CountM == 2) {
+                float16x4_t a1 = MlasLoadFloat16x4(a + lda);
+                accu10 = maq_lane_f16_accu(accu10, b0, b1, b2, b3, a1);
+            }
             k -= 4, a += 4, PackedB += 4 * 8;
         }
 
         if (k > 0) {
-            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k);
-            float16x4_t a1 = MlasLoadPartialFloat16x4(a + lda, k);
+            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1;
             float16x8_t b0 = MlasLoadFloat16x8(PackedB);
             accu00 = vfmaq_lane_f16(accu00, b0, a0, 0);
-            accu10 = vfmaq_lane_f16(accu10, b0, a1, 0);
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadPartialFloat16x4(a + lda, k);
+                accu10 = vfmaq_lane_f16(accu10, b0, a1, 0);
+            }
             if (k > 1) {
                 float16x8_t b1 = MlasLoadFloat16x8(PackedB + 8);
                 accu00 = vfmaq_lane_f16(accu00, b1, a0, 1);
-                accu10 = vfmaq_lane_f16(accu10, b1, a1, 1);
+                if constexpr (CountM == 2) {
+                    accu10 = vfmaq_lane_f16(accu10, b1, a1, 1);
+                }
             }
             if (k > 2) {
                 float16x8_t b2 = MlasLoadFloat16x8(PackedB + 16);
                 accu00 = vfmaq_lane_f16(accu00, b2, a0, 2);
-                accu10 = vfmaq_lane_f16(accu10, b2, a1, 2);
+                if constexpr (CountM == 2) {
+                    accu10 = vfmaq_lane_f16(accu10, b2, a1, 2);
+                }
             }
             PackedB += k * 8;
         }
 
         if constexpr (beta_behavior == 1) {
             float16x8_t c0 = MlasLoadFloat16x8(C);
-            float16x8_t c1 = MlasLoadFloat16x8(C + ldc);
-            float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
-            accu00 = vfmaq_f16(c0, accu00, alpha_v);
-            accu10 = vfmaq_f16(c1, accu10, alpha_v);
+            accu00 = vfmaq_f16(c0, accu00, alpha_v8);
             MlasStoreFloat16x8(C, accu00);
-            MlasStoreFloat16x8(C + ldc, accu10);
+            if constexpr (CountM == 2) {
+                float16x8_t c1 = MlasLoadFloat16x8(C + ldc);
+                accu10 = vfmaq_f16(c1, accu10, alpha_v8);
+                MlasStoreFloat16x8(C + ldc, accu10);
+            }
         } else if constexpr (beta_behavior == 2) {
             float16x8_t c0 = MlasLoadFloat16x8(C);
-            float16x8_t c1 = MlasLoadFloat16x8(C + ldc);
-            float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
-            float16x8_t beta_v = MlasBroadcastFloat16x8(beta);
-            accu00 = vfmaq_f16(vmulq_f16(c0, beta_v), accu00, alpha_v);
-            accu10 = vfmaq_f16(vmulq_f16(c1, beta_v), accu10, alpha_v);
+            accu00 = vfmaq_f16(vmulq_f16(c0, beta_v8), accu00, alpha_v8);
             MlasStoreFloat16x8(C, accu00);
-            MlasStoreFloat16x8(C + ldc, accu10);
+            if constexpr (CountM == 2) {
+                float16x8_t c1 = MlasLoadFloat16x8(C + ldc);
+                accu10 = vfmaq_f16(vmulq_f16(c1, beta_v8), accu10, alpha_v8);
+                MlasStoreFloat16x8(C + ldc, accu10);
+            }
         } else {
-            float16x8_t alpha_v = MlasBroadcastFloat16x8(alpha);
-            accu00 = vmulq_f16(accu00, alpha_v);
-            accu10 = vmulq_f16(accu10, alpha_v);
+            accu00 = vmulq_f16(accu00, alpha_v8);
             MlasStoreFloat16x8(C, accu00);
-            MlasStoreFloat16x8(C + ldc, accu10);
+            if constexpr (CountM == 2) {
+                accu10 = vmulq_f16(accu10, alpha_v8);
+                MlasStoreFloat16x8(C + ldc, accu10);
+            }
         }
 
         CountN -= 8, C += 8;
@@ -2529,8 +2310,10 @@ void HGemm_PackedB_Kernel_M2(
     if (CountN > 0) {
         const auto* a = A;
         size_t k = CountK;
-        float16x8_t accu0 = MlasZeroFloat16x8();
-        float16x8_t accu1 = MlasZeroFloat16x8();
+        float16x8_t accu0 = MlasZeroFloat16x8(), accu1;
+        if constexpr (CountM == 2) {
+            accu1 = MlasZeroFloat16x8();
+        }
         for (; k >= 8; k -= 8, a += 8, PackedB += 8 * 8) {
             float16x8_t b0 = MlasLoadFloat16x8(PackedB);
             float16x8_t b1 = MlasLoadFloat16x8(PackedB + 8);
@@ -2541,9 +2324,11 @@ void HGemm_PackedB_Kernel_M2(
             float16x8_t b6 = MlasLoadFloat16x8(PackedB + 48);
             float16x8_t b7 = MlasLoadFloat16x8(PackedB + 56);
             float16x8_t a0 = MlasLoadFloat16x8(a);
-            float16x8_t a1 = MlasLoadFloat16x8(a + lda);
             accu0 = maq_laneq_f16_accu(accu0, b0, b1, b2, b3, b4, b5, b6, b7, a0);
-            accu1 = maq_laneq_f16_accu(accu1, b0, b1, b2, b3, b4, b5, b6, b7, a1);
+            if constexpr (CountM == 2) {
+                float16x8_t a1 = MlasLoadFloat16x8(a + lda);
+                accu1 = maq_laneq_f16_accu(accu1, b0, b1, b2, b3, b4, b5, b6, b7, a1);
+            }
         }
 
         if (k & 4) {
@@ -2552,54 +2337,67 @@ void HGemm_PackedB_Kernel_M2(
             float16x8_t b2 = MlasLoadFloat16x8(PackedB + 16);
             float16x8_t b3 = MlasLoadFloat16x8(PackedB + 24);
             float16x4_t a0 = MlasLoadFloat16x4(a);
-            float16x4_t a1 = MlasLoadFloat16x4(a + lda);
             accu0 = maq_lane_f16_accu(accu0, b0, b1, b2, b3, a0);
-            accu1 = maq_lane_f16_accu(accu1, b0, b1, b2, b3, a1);
+            if constexpr (CountM == 2) {
+                float16x4_t a1 = MlasLoadFloat16x4(a + lda);
+                accu1 = maq_lane_f16_accu(accu1, b0, b1, b2, b3, a1);
+            }
             k -= 4, a += 4, PackedB += 4 * 8;
         }
 
         if (k > 0) {
-            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k);
-            float16x4_t a1 = MlasLoadPartialFloat16x4(a + lda, k);
+            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1;
             float16x8_t b0 = MlasLoadFloat16x8(PackedB);
             accu0 = vfmaq_lane_f16(accu0, b0, a0, 0);
-            accu1 = vfmaq_lane_f16(accu1, b0, a1, 0);
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadPartialFloat16x4(a + lda, k);
+                accu1 = vfmaq_lane_f16(accu1, b0, a1, 0);
+            }
             if (k > 1) {
                 float16x8_t b1 = MlasLoadFloat16x8(PackedB + 8);
                 accu0 = vfmaq_lane_f16(accu0, b1, a0, 1);
-                accu1 = vfmaq_lane_f16(accu1, b1, a1, 1);
+                if constexpr (CountM == 2) {
+                    accu1 = vfmaq_lane_f16(accu1, b1, a1, 1);
+                }
             }
             if (k > 2) {
                 float16x8_t b2 = MlasLoadFloat16x8(PackedB + 16);
                 accu0 = vfmaq_lane_f16(accu0, b2, a0, 2);
-                accu1 = vfmaq_lane_f16(accu1, b2, a1, 2);
+                if constexpr (CountM == 2) {
+                    accu1 = vfmaq_lane_f16(accu1, b2, a1, 2);
+                }
             }
             PackedB += k * 8;
         }
 
         float16x4_t accu0_low = vget_low_f16(accu0);
         float16x4_t accu0_high = vget_high_f16(accu0);
-        float16x4_t accu1_low = vget_low_f16(accu1);
-        float16x4_t accu1_high = vget_high_f16(accu1);
+        float16x4_t accu1_low, accu1_high;
+        if constexpr (CountM == 2) {
+            accu1_low = vget_low_f16(accu1);
+            accu1_high = vget_high_f16(accu1);
+        }
 
         if (CountN & 4) {
             if constexpr (beta_behavior == 1) {
                 float16x4_t c0 = MlasLoadFloat16x4(C);
-                float16x4_t c1 = MlasLoadFloat16x4(C + ldc);
-                float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
-                MlasStoreFloat16x4(C, vfma_f16(c0, accu0_low, alpha_v));
-                MlasStoreFloat16x4(C + ldc, vfma_f16(c1, accu1_low, alpha_v));
+                MlasStoreFloat16x4(C, vfma_f16(c0, accu0_low, alpha_v4));
+                if constexpr (CountM == 2) {
+                    float16x4_t c1 = MlasLoadFloat16x4(C + ldc);
+                    MlasStoreFloat16x4(C + ldc, vfma_f16(c1, accu1_low, alpha_v4));
+                }
             } else if constexpr (beta_behavior == 2) {
                 float16x4_t c0 = MlasLoadFloat16x4(C);
-                float16x4_t c1 = MlasLoadFloat16x4(C + ldc);
-                float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
-                float16x4_t beta_v = MlasBroadcastFloat16x4(beta);
-                MlasStoreFloat16x4(C, vfma_f16(vmul_f16(c0, beta_v), accu0_low, alpha_v));
-                MlasStoreFloat16x4(C + ldc, vfma_f16(vmul_f16(c1, beta_v), accu1_low, alpha_v));
+                MlasStoreFloat16x4(C, vfma_f16(vmul_f16(c0, beta_v4), accu0_low, alpha_v4));
+                if constexpr (CountM == 2) {
+                    float16x4_t c1 = MlasLoadFloat16x4(C + ldc);
+                    MlasStoreFloat16x4(C + ldc, vfma_f16(vmul_f16(c1, beta_v4), accu1_low, alpha_v4));
+                }
             } else {
-                float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
-                MlasStoreFloat16x4(C, vmul_f16(accu0_low, alpha_v));
-                MlasStoreFloat16x4(C + ldc, vmul_f16(accu1_low, alpha_v));
+                MlasStoreFloat16x4(C, vmul_f16(accu0_low, alpha_v4));
+                if constexpr (CountM == 2) {
+                    MlasStoreFloat16x4(C + ldc, vmul_f16(accu1_low, alpha_v4));
+                }
             }
             CountN -= 4, C += 4;
             accu0_low = accu0_high;
@@ -2609,26 +2407,31 @@ void HGemm_PackedB_Kernel_M2(
         if (CountN) {
             if constexpr (beta_behavior == 1) {
                 float16x4_t c0 = MlasLoadPartialFloat16x4(C, CountN);
-                float16x4_t c1 = MlasLoadPartialFloat16x4(C + ldc, CountN);
-                float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
-                MlasStorePartialFloat16x4(C, vfma_f16(c0, accu0_low, alpha_v), CountN);
-                MlasStorePartialFloat16x4(C + ldc, vfma_f16(c1, accu1_low, alpha_v), CountN);
+                MlasStorePartialFloat16x4(C, vfma_f16(c0, accu0_low, alpha_v4), CountN);
+                if constexpr (CountM == 2) {
+                    float16x4_t c1 = MlasLoadPartialFloat16x4(C + ldc, CountN);
+                    MlasStorePartialFloat16x4(C + ldc, vfma_f16(c1, accu1_low, alpha_v4), CountN);
+                }
             } else if constexpr (beta_behavior == 2) {
                 float16x4_t c0 = MlasLoadPartialFloat16x4(C, CountN);
-                float16x4_t c1 = MlasLoadPartialFloat16x4(C + ldc, CountN);
-                float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
-                float16x4_t beta_v = MlasBroadcastFloat16x4(beta);
-                MlasStorePartialFloat16x4(C, vfma_f16(vmul_f16(c0, beta_v), accu0_low, alpha_v), CountN);
-                MlasStorePartialFloat16x4(C + ldc, vfma_f16(vmul_f16(c1, beta_v), accu1_low, alpha_v), CountN);
+                MlasStorePartialFloat16x4(C, vfma_f16(vmul_f16(c0, beta_v4), accu0_low, alpha_v4), CountN);
+                if constexpr (CountM == 2) {
+                    float16x4_t c1 = MlasLoadPartialFloat16x4(C + ldc, CountN);
+                    MlasStorePartialFloat16x4(C + ldc, vfma_f16(vmul_f16(c1, beta_v4), accu1_low, alpha_v4), CountN);
+                }
             } else {
-                float16x4_t alpha_v = MlasBroadcastFloat16x4(alpha);
-                MlasStorePartialFloat16x4(C, vmul_f16(accu0_low, alpha_v), CountN);
-                MlasStorePartialFloat16x4(C + ldc, vmul_f16(accu1_low, alpha_v), CountN);
+                MlasStorePartialFloat16x4(C, vmul_f16(accu0_low, alpha_v4), CountN);
+                if constexpr (CountM == 2) {
+                    MlasStorePartialFloat16x4(C + ldc, vmul_f16(accu1_low, alpha_v4), CountN);
+                }
             }
         }
     }
 }
 
+// TODO:
+//  - surface spec.
+//  - process 32 columns
 void HGemm_PackedB_Kernel(
     const MLAS_FP16* A,
     const MLAS_FP16* PackedB,
@@ -2652,19 +2455,19 @@ void HGemm_PackedB_Kernel(
     const auto f16_1 = MLAS_FP16(1.0f);
     if (CountM == 1) {
         if (beta == f16_0.val) {
-            HGemm_PackedB_Kernel_M1<0>(A_data, PackedB_data, C_data, CountN, CountK, alpha, beta);
+            HGemm_PackedB_Kernel_Impl<0, 1>(A_data, PackedB_data, C_data, CountN, CountK, lda, ldc, alpha, beta);
         } else if (beta == f16_1.val) {
-            HGemm_PackedB_Kernel_M1<1>(A_data, PackedB_data, C_data, CountN, CountK, alpha, beta);
+            HGemm_PackedB_Kernel_Impl<1, 1>(A_data, PackedB_data, C_data, CountN, CountK, lda, ldc, alpha, beta);
         } else {
-            HGemm_PackedB_Kernel_M1<2>(A_data, PackedB_data, C_data, CountN, CountK, alpha, beta);
+            HGemm_PackedB_Kernel_Impl<2, 1>(A_data, PackedB_data, C_data, CountN, CountK, lda, ldc, alpha, beta);
         }
     } else {
         if (beta == f16_0.val) {
-            HGemm_PackedB_Kernel_M2<0>(A_data, PackedB_data, C_data, CountN, CountK, lda, ldc, alpha, beta);
+            HGemm_PackedB_Kernel_Impl<0, 2>(A_data, PackedB_data, C_data, CountN, CountK, lda, ldc, alpha, beta);
         } else if (beta == f16_1.val) {
-            HGemm_PackedB_Kernel_M2<1>(A_data, PackedB_data, C_data, CountN, CountK, lda, ldc, alpha, beta);
+            HGemm_PackedB_Kernel_Impl<1, 2>(A_data, PackedB_data, C_data, CountN, CountK, lda, ldc, alpha, beta);
         } else {
-            HGemm_PackedB_Kernel_M2<2>(A_data, PackedB_data, C_data, CountN, CountK, lda, ldc, alpha, beta);
+            HGemm_PackedB_Kernel_Impl<2, 2>(A_data, PackedB_data, C_data, CountN, CountK, lda, ldc, alpha, beta);
         }
     }
 }

--- a/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
@@ -31,7 +31,254 @@ void HPackB_TransposedB_Kernel(
     const _mlas_fp16_* B_data = reinterpret_cast<const _mlas_fp16_*>(B);
     _mlas_fp16_* PackedB_data = reinterpret_cast<_mlas_fp16_*>(PackedB);
 
-    for (; CountN >= 16; CountN -= 16, B_data += 16 * ldb) {
+    for (; CountN >= 32; CountN -= 32, B_data += 32 * ldb) {
+        const _mlas_fp16_* b = B_data;
+        size_t k = CountK;
+        constexpr size_t step = 8 * 32; // pack 8 * 16
+        for (; k >= 8; k -= 8, b += 8, PackedB_data += step) {
+            float16x8_t v0 = MlasLoadFloat16x8(b);
+            float16x8_t v1 = MlasLoadFloat16x8(b + ldb);
+            float16x8_t v2 = MlasLoadFloat16x8(b + 2 * ldb);
+            float16x8_t v3 = MlasLoadFloat16x8(b + 3 * ldb);
+            float16x8_t v4 = MlasLoadFloat16x8(b + 4 * ldb);
+            float16x8_t v5 = MlasLoadFloat16x8(b + 5 * ldb);
+            float16x8_t v6 = MlasLoadFloat16x8(b + 6 * ldb);
+            float16x8_t v7 = MlasLoadFloat16x8(b + 7 * ldb);
+            Transpose8x8(v0, v1, v2, v3, v4, v5, v6, v7);
+            MlasStoreFloat16x8(PackedB_data, v0);
+            MlasStoreFloat16x8(PackedB_data + 32, v1);
+            MlasStoreFloat16x8(PackedB_data + 64, v2);
+            MlasStoreFloat16x8(PackedB_data + 96, v3);
+            MlasStoreFloat16x8(PackedB_data + 128, v4);
+            MlasStoreFloat16x8(PackedB_data + 160, v5);
+            MlasStoreFloat16x8(PackedB_data + 192, v6);
+            MlasStoreFloat16x8(PackedB_data + 224, v7);
+
+            float16x8_t v8 = MlasLoadFloat16x8(b + 8 * ldb);
+            float16x8_t v9 = MlasLoadFloat16x8(b + 9 * ldb);
+            float16x8_t vA = MlasLoadFloat16x8(b + 10 * ldb);
+            float16x8_t vB = MlasLoadFloat16x8(b + 11 * ldb);
+            float16x8_t vC = MlasLoadFloat16x8(b + 12 * ldb);
+            float16x8_t vD = MlasLoadFloat16x8(b + 13 * ldb);
+            float16x8_t vE = MlasLoadFloat16x8(b + 14 * ldb);
+            float16x8_t vF = MlasLoadFloat16x8(b + 15 * ldb);
+            Transpose8x8(v8, v9, vA, vB, vC, vD, vE, vF);
+            MlasStoreFloat16x8(PackedB_data + 8, v8);
+            MlasStoreFloat16x8(PackedB_data + 40, v9);
+            MlasStoreFloat16x8(PackedB_data + 72, vA);
+            MlasStoreFloat16x8(PackedB_data + 104, vB);
+            MlasStoreFloat16x8(PackedB_data + 136, vC);
+            MlasStoreFloat16x8(PackedB_data + 168, vD);
+            MlasStoreFloat16x8(PackedB_data + 200, vE);
+            MlasStoreFloat16x8(PackedB_data + 232, vF);
+
+            v0 = MlasLoadFloat16x8(b + 16 * ldb);
+            v1 = MlasLoadFloat16x8(b + 17 * ldb);
+            v2 = MlasLoadFloat16x8(b + 18 * ldb);
+            v3 = MlasLoadFloat16x8(b + 19 * ldb);
+            v4 = MlasLoadFloat16x8(b + 20 * ldb);
+            v5 = MlasLoadFloat16x8(b + 21 * ldb);
+            v6 = MlasLoadFloat16x8(b + 22 * ldb);
+            v7 = MlasLoadFloat16x8(b + 23 * ldb);
+            Transpose8x8(v0, v1, v2, v3, v4, v5, v6, v7);
+            MlasStoreFloat16x8(PackedB_data + 16, v0);
+            MlasStoreFloat16x8(PackedB_data + 48, v1);
+            MlasStoreFloat16x8(PackedB_data + 80, v2);
+            MlasStoreFloat16x8(PackedB_data + 112, v3);
+            MlasStoreFloat16x8(PackedB_data + 144, v4);
+            MlasStoreFloat16x8(PackedB_data + 176, v5);
+            MlasStoreFloat16x8(PackedB_data + 208, v6);
+            MlasStoreFloat16x8(PackedB_data + 240, v7);
+
+            v8 = MlasLoadFloat16x8(b + 24 * ldb);
+            v9 = MlasLoadFloat16x8(b + 25 * ldb);
+            vA = MlasLoadFloat16x8(b + 26 * ldb);
+            vB = MlasLoadFloat16x8(b + 27 * ldb);
+            vC = MlasLoadFloat16x8(b + 28 * ldb);
+            vD = MlasLoadFloat16x8(b + 29 * ldb);
+            vE = MlasLoadFloat16x8(b + 30 * ldb);
+            vF = MlasLoadFloat16x8(b + 31 * ldb);
+            Transpose8x8(v8, v9, vA, vB, vC, vD, vE, vF);
+            MlasStoreFloat16x8(PackedB_data + 24, v8);
+            MlasStoreFloat16x8(PackedB_data + 56, v9);
+            MlasStoreFloat16x8(PackedB_data + 88, vA);
+            MlasStoreFloat16x8(PackedB_data + 120, vB);
+            MlasStoreFloat16x8(PackedB_data + 152, vC);
+            MlasStoreFloat16x8(PackedB_data + 184, vD);
+            MlasStoreFloat16x8(PackedB_data + 216, vE);
+            MlasStoreFloat16x8(PackedB_data + 248, vF);
+        }
+
+        if (k & 4) {
+            float16x4_t v0 = MlasLoadFloat16x4(b);
+            float16x4_t v1 = MlasLoadFloat16x4(b + ldb);
+            float16x4_t v2 = MlasLoadFloat16x4(b + 2 * ldb);
+            float16x4_t v3 = MlasLoadFloat16x4(b + 3 * ldb);
+            float16x4_t v4 = MlasLoadFloat16x4(b + 4 * ldb);
+            float16x4_t v5 = MlasLoadFloat16x4(b + 5 * ldb);
+            float16x4_t v6 = MlasLoadFloat16x4(b + 6 * ldb);
+            float16x4_t v7 = MlasLoadFloat16x4(b + 7 * ldb);
+            Transpose4x4(v0, v1, v2, v3);
+            Transpose4x4(v4, v5, v6, v7);
+            MlasStoreFloat16x4(PackedB_data, v0);
+            MlasStoreFloat16x4(PackedB_data + 4, v4);
+            MlasStoreFloat16x4(PackedB_data + 32, v1);
+            MlasStoreFloat16x4(PackedB_data + 36, v5);
+            MlasStoreFloat16x4(PackedB_data + 64, v2);
+            MlasStoreFloat16x4(PackedB_data + 68, v6);
+            MlasStoreFloat16x4(PackedB_data + 96, v3);
+            MlasStoreFloat16x4(PackedB_data + 100, v7);
+
+            float16x4_t v8 = MlasLoadFloat16x4(b + 8 * ldb);
+            float16x4_t v9 = MlasLoadFloat16x4(b + 9 * ldb);
+            float16x4_t vA = MlasLoadFloat16x4(b + 10 * ldb);
+            float16x4_t vB = MlasLoadFloat16x4(b + 11 * ldb);
+            float16x4_t vC = MlasLoadFloat16x4(b + 12 * ldb);
+            float16x4_t vD = MlasLoadFloat16x4(b + 13 * ldb);
+            float16x4_t vE = MlasLoadFloat16x4(b + 14 * ldb);
+            float16x4_t vF = MlasLoadFloat16x4(b + 15 * ldb);
+            Transpose4x4(v8, v9, vA, vB);
+            Transpose4x4(vC, vD, vE, vF);
+            MlasStoreFloat16x4(PackedB_data + 8, v8);
+            MlasStoreFloat16x4(PackedB_data + 12, vC);
+            MlasStoreFloat16x4(PackedB_data + 40, v9);
+            MlasStoreFloat16x4(PackedB_data + 44, vD);
+            MlasStoreFloat16x4(PackedB_data + 72, vA);
+            MlasStoreFloat16x4(PackedB_data + 76, vE);
+            MlasStoreFloat16x4(PackedB_data + 104, vB);
+            MlasStoreFloat16x4(PackedB_data + 108, vF);
+
+            v0 = MlasLoadFloat16x4(b + 16 * ldb);
+            v1 = MlasLoadFloat16x4(b + 17 * ldb);
+            v2 = MlasLoadFloat16x4(b + 18 * ldb);
+            v3 = MlasLoadFloat16x4(b + 19 * ldb);
+            v4 = MlasLoadFloat16x4(b + 20 * ldb);
+            v5 = MlasLoadFloat16x4(b + 21 * ldb);
+            v6 = MlasLoadFloat16x4(b + 22 * ldb);
+            v7 = MlasLoadFloat16x4(b + 23 * ldb);
+            Transpose4x4(v0, v1, v2, v3);
+            Transpose4x4(v4, v5, v6, v7);
+            MlasStoreFloat16x4(PackedB_data + 16, v0);
+            MlasStoreFloat16x4(PackedB_data + 20, v4);
+            MlasStoreFloat16x4(PackedB_data + 48, v1);
+            MlasStoreFloat16x4(PackedB_data + 52, v5);
+            MlasStoreFloat16x4(PackedB_data + 80, v2);
+            MlasStoreFloat16x4(PackedB_data + 84, v6);
+            MlasStoreFloat16x4(PackedB_data + 112, v3);
+            MlasStoreFloat16x4(PackedB_data + 116, v7);
+
+            v8 = MlasLoadFloat16x4(b + 24 * ldb);
+            v9 = MlasLoadFloat16x4(b + 25 * ldb);
+            vA = MlasLoadFloat16x4(b + 26 * ldb);
+            vB = MlasLoadFloat16x4(b + 27 * ldb);
+            vC = MlasLoadFloat16x4(b + 28 * ldb);
+            vD = MlasLoadFloat16x4(b + 29 * ldb);
+            vE = MlasLoadFloat16x4(b + 30 * ldb);
+            vF = MlasLoadFloat16x4(b + 31 * ldb);
+            Transpose4x4(v8, v9, vA, vB);
+            Transpose4x4(vC, vD, vE, vF);
+            MlasStoreFloat16x4(PackedB_data + 24, v8);
+            MlasStoreFloat16x4(PackedB_data + 28, vC);
+            MlasStoreFloat16x4(PackedB_data + 56, v9);
+            MlasStoreFloat16x4(PackedB_data + 60, vD);
+            MlasStoreFloat16x4(PackedB_data + 88, vA);
+            MlasStoreFloat16x4(PackedB_data + 92, vE);
+            MlasStoreFloat16x4(PackedB_data + 120, vB);
+            MlasStoreFloat16x4(PackedB_data + 124, vF);
+
+            k -= 4, b += 4, PackedB_data += 4 * 32;
+        }
+
+        if (k > 0) {
+            float16x4_t v0 = MlasLoadPartialFloat16x4(b, k);
+            float16x4_t v1 = MlasLoadPartialFloat16x4(b + ldb, k);
+            float16x4_t v2 = MlasLoadPartialFloat16x4(b + 2 * ldb, k);
+            float16x4_t v3 = MlasLoadPartialFloat16x4(b + 3 * ldb, k);
+            float16x4_t v4 = MlasLoadPartialFloat16x4(b + 4 * ldb, k);
+            float16x4_t v5 = MlasLoadPartialFloat16x4(b + 5 * ldb, k);
+            float16x4_t v6 = MlasLoadPartialFloat16x4(b + 6 * ldb, k);
+            float16x4_t v7 = MlasLoadPartialFloat16x4(b + 7 * ldb, k);
+            Transpose4x4(v0, v1, v2, v3);
+            Transpose4x4(v4, v5, v6, v7);
+            MlasStoreFloat16x4(PackedB_data, v0);
+            MlasStoreFloat16x4(PackedB_data + 4, v4);
+            if (k > 1) {
+                MlasStoreFloat16x4(PackedB_data + 32, v1);
+                MlasStoreFloat16x4(PackedB_data + 36, v5);
+            }
+            if (k > 2) {
+                MlasStoreFloat16x4(PackedB_data + 64, v2);
+                MlasStoreFloat16x4(PackedB_data + 68, v6);
+            }
+
+            float16x4_t v8 = MlasLoadPartialFloat16x4(b + 8 * ldb, k);
+            float16x4_t v9 = MlasLoadPartialFloat16x4(b + 9 * ldb, k);
+            float16x4_t vA = MlasLoadPartialFloat16x4(b + 10 * ldb, k);
+            float16x4_t vB = MlasLoadPartialFloat16x4(b + 11 * ldb, k);
+            float16x4_t vC = MlasLoadPartialFloat16x4(b + 12 * ldb, k);
+            float16x4_t vD = MlasLoadPartialFloat16x4(b + 13 * ldb, k);
+            float16x4_t vE = MlasLoadPartialFloat16x4(b + 14 * ldb, k);
+            float16x4_t vF = MlasLoadPartialFloat16x4(b + 15 * ldb, k);
+            Transpose4x4(v8, v9, vA, vB);
+            Transpose4x4(vC, vD, vE, vF);
+            MlasStoreFloat16x4(PackedB_data + 8, v8);
+            MlasStoreFloat16x4(PackedB_data + 12, vC);
+            if (k > 1) {
+                MlasStoreFloat16x4(PackedB_data + 40, v9);
+                MlasStoreFloat16x4(PackedB_data + 44, vD);
+            }
+            if (k > 2) {
+                MlasStoreFloat16x4(PackedB_data + 72, vA);
+                MlasStoreFloat16x4(PackedB_data + 76, vE);
+            }
+
+            v0 = MlasLoadPartialFloat16x4(b + 16 * ldb, k);
+            v1 = MlasLoadPartialFloat16x4(b + 17 * ldb, k);
+            v2 = MlasLoadPartialFloat16x4(b + 18 * ldb, k);
+            v3 = MlasLoadPartialFloat16x4(b + 19 * ldb, k);
+            v4 = MlasLoadPartialFloat16x4(b + 20 * ldb, k);
+            v5 = MlasLoadPartialFloat16x4(b + 21 * ldb, k);
+            v6 = MlasLoadPartialFloat16x4(b + 22 * ldb, k);
+            v7 = MlasLoadPartialFloat16x4(b + 23 * ldb, k);
+            Transpose4x4(v0, v1, v2, v3);
+            Transpose4x4(v4, v5, v6, v7);
+            MlasStoreFloat16x4(PackedB_data + 16, v0);
+            MlasStoreFloat16x4(PackedB_data + 20, v4);
+            if (k > 1) {
+                MlasStoreFloat16x4(PackedB_data + 48, v1);
+                MlasStoreFloat16x4(PackedB_data + 52, v5);
+            }
+            if (k > 2) {
+                MlasStoreFloat16x4(PackedB_data + 80, v2);
+                MlasStoreFloat16x4(PackedB_data + 84, v6);
+            }
+
+            v8 = MlasLoadPartialFloat16x4(b + 24 * ldb, k);
+            v9 = MlasLoadPartialFloat16x4(b + 25 * ldb, k);
+            vA = MlasLoadPartialFloat16x4(b + 26 * ldb, k);
+            vB = MlasLoadPartialFloat16x4(b + 27 * ldb, k);
+            vC = MlasLoadPartialFloat16x4(b + 28 * ldb, k);
+            vD = MlasLoadPartialFloat16x4(b + 29 * ldb, k);
+            vE = MlasLoadPartialFloat16x4(b + 30 * ldb, k);
+            vF = MlasLoadPartialFloat16x4(b + 31 * ldb, k);
+            Transpose4x4(v8, v9, vA, vB);
+            Transpose4x4(vC, vD, vE, vF);
+            MlasStoreFloat16x4(PackedB_data + 24, v8);
+            MlasStoreFloat16x4(PackedB_data + 28, vC);
+            if (k > 1) {
+                MlasStoreFloat16x4(PackedB_data + 56, v9);
+                MlasStoreFloat16x4(PackedB_data + 60, vD);
+            }
+            if (k > 2) {
+                MlasStoreFloat16x4(PackedB_data + 88, vA);
+                MlasStoreFloat16x4(PackedB_data + 92, vE);
+            }
+
+            PackedB_data += k * 32;
+        }
+    }
+
+    if (CountN & 16) {
         const _mlas_fp16_* b = B_data;
         size_t k = CountK;
         constexpr size_t step = 8 * 16; // pack 8 * 16
@@ -154,6 +401,8 @@ void HPackB_TransposedB_Kernel(
 
             PackedB_data += k * 16;
         }
+
+        CountN -= 16, B_data += 16 * ldb;
     }
 
     if (CountN & 8) {
@@ -303,135 +552,6 @@ void HPackB_TransposedB_Kernel(
     }
 }
 
-template <int CountN>
-MLAS_FORCEINLINE
-void HPackB_B_Kernel_Last8(
-    const _mlas_fp16_ *B,
-    _mlas_fp16_ *PackedB,
-    size_t CountK,
-    size_t ldb
-) {
-    if constexpr (CountN > 4) {
-        for (; CountK >= 8; B += ldb * 8, PackedB += 64, CountK -= 8) {
-            float16x4_t v0 = MlasLoadFloat16x4(B);
-            float16x4_t v1 = MlasLoadPartialFloat16x4(B + 4, CountN - 4);
-            float16x4_t v2 = MlasLoadFloat16x4(B + ldb);
-            float16x4_t v3 = MlasLoadPartialFloat16x4(B + ldb + 4, CountN - 4);
-            float16x4_t v4 = MlasLoadFloat16x4(B + 2 * ldb);
-            float16x4_t v5 = MlasLoadPartialFloat16x4(B + 2 * ldb + 4, CountN - 4);
-            float16x4_t v6 = MlasLoadFloat16x4(B + 3 * ldb);
-            float16x4_t v7 = MlasLoadPartialFloat16x4(B + 3 * ldb + 4, CountN - 4);
-            float16x4_t v8 = MlasLoadFloat16x4(B + 4 * ldb);
-            float16x4_t v9 = MlasLoadPartialFloat16x4(B + 4 * ldb + 4, CountN - 4);
-            float16x4_t vA = MlasLoadFloat16x4(B + 5 * ldb);
-            float16x4_t vB = MlasLoadPartialFloat16x4(B + 5 * ldb + 4, CountN - 4);
-            float16x4_t vC = MlasLoadFloat16x4(B + 6 * ldb);
-            float16x4_t vD = MlasLoadPartialFloat16x4(B + 6 * ldb + 4, CountN - 4);
-            float16x4_t vE = MlasLoadFloat16x4(B + 7 * ldb);
-            float16x4_t vF = MlasLoadPartialFloat16x4(B + 7 * ldb + 4, CountN - 4);
-            MlasStoreFloat16x4(PackedB, v0);
-            MlasStoreFloat16x4(PackedB + 4, v1);
-            MlasStoreFloat16x4(PackedB + 8, v2);
-            MlasStoreFloat16x4(PackedB + 12, v3);
-            MlasStoreFloat16x4(PackedB + 16, v4);
-            MlasStoreFloat16x4(PackedB + 20, v5);
-            MlasStoreFloat16x4(PackedB + 24, v6);
-            MlasStoreFloat16x4(PackedB + 28, v7);
-            MlasStoreFloat16x4(PackedB + 32, v8);
-            MlasStoreFloat16x4(PackedB + 36, v9);
-            MlasStoreFloat16x4(PackedB + 40, vA);
-            MlasStoreFloat16x4(PackedB + 44, vB);
-            MlasStoreFloat16x4(PackedB + 48, vC);
-            MlasStoreFloat16x4(PackedB + 52, vD);
-            MlasStoreFloat16x4(PackedB + 56, vE);
-            MlasStoreFloat16x4(PackedB + 60, vF);
-        }
-
-        if (CountK & 4) {
-            float16x4_t v0 = MlasLoadFloat16x4(B);
-            float16x4_t v1 = MlasLoadPartialFloat16x4(B + 4, CountN - 4);
-            float16x4_t v2 = MlasLoadFloat16x4(B + ldb);
-            float16x4_t v3 = MlasLoadPartialFloat16x4(B + ldb + 4, CountN - 4);
-            float16x4_t v4 = MlasLoadFloat16x4(B + 2 * ldb);
-            float16x4_t v5 = MlasLoadPartialFloat16x4(B + 2 * ldb + 4, CountN - 4);
-            float16x4_t v6 = MlasLoadFloat16x4(B + 3 * ldb);
-            float16x4_t v7 = MlasLoadPartialFloat16x4(B + 3 * ldb + 4, CountN - 4);
-            MlasStoreFloat16x4(PackedB, v0);
-            MlasStoreFloat16x4(PackedB + 4, v1);
-            MlasStoreFloat16x4(PackedB + 8, v2);
-            MlasStoreFloat16x4(PackedB + 12, v3);
-            MlasStoreFloat16x4(PackedB + 16, v4);
-            MlasStoreFloat16x4(PackedB + 20, v5);
-            MlasStoreFloat16x4(PackedB + 24, v6);
-            MlasStoreFloat16x4(PackedB + 28, v7);
-            B += 4 * ldb, PackedB += 32;
-        }
-
-        if (CountK & 2) {
-            float16x4_t v0 = MlasLoadFloat16x4(B);
-            float16x4_t v1 = MlasLoadPartialFloat16x4(B + 4, CountN - 4);
-            float16x4_t v2 = MlasLoadFloat16x4(B + ldb);
-            float16x4_t v3 = MlasLoadPartialFloat16x4(B + ldb + 4, CountN - 4);
-            MlasStoreFloat16x4(PackedB, v0);
-            MlasStoreFloat16x4(PackedB + 4, v1);
-            MlasStoreFloat16x4(PackedB + 8, v2);
-            MlasStoreFloat16x4(PackedB + 12, v3);
-            B += 2 * ldb, PackedB += 16;
-        }
-
-        if (CountK & 1) {
-            float16x4_t v0 = MlasLoadFloat16x4(B);
-            float16x4_t v1 = MlasLoadPartialFloat16x4(B + 4, CountN - 4);
-            MlasStoreFloat16x4(PackedB, v0);
-            MlasStoreFloat16x4(PackedB + 4, v1);
-        }
-    } else {
-        for (; CountK >= 8; B += 8 * ldb, PackedB += 64, CountK -= 8) {
-            float16x4_t v0 = MlasLoadPartialFloat16x4(B, CountN);
-            float16x4_t v1 = MlasLoadPartialFloat16x4(B + ldb, CountN);
-            float16x4_t v2 = MlasLoadPartialFloat16x4(B + 2 * ldb, CountN);
-            float16x4_t v3 = MlasLoadPartialFloat16x4(B + 3 * ldb, CountN);
-            float16x4_t v4 = MlasLoadPartialFloat16x4(B + 4 * ldb, CountN);
-            float16x4_t v5 = MlasLoadPartialFloat16x4(B + 5 * ldb, CountN);
-            float16x4_t v6 = MlasLoadPartialFloat16x4(B + 6 * ldb, CountN);
-            float16x4_t v7 = MlasLoadPartialFloat16x4(B + 7 * ldb, CountN);
-            MlasStoreFloat16x4(PackedB, v0);
-            MlasStoreFloat16x4(PackedB + 8, v1);
-            MlasStoreFloat16x4(PackedB + 16, v2);
-            MlasStoreFloat16x4(PackedB + 24, v3);
-            MlasStoreFloat16x4(PackedB + 32, v4);
-            MlasStoreFloat16x4(PackedB + 40, v5);
-            MlasStoreFloat16x4(PackedB + 48, v6);
-            MlasStoreFloat16x4(PackedB + 56, v7);
-        }
-
-        if (CountK & 4) {
-            float16x4_t v0 = MlasLoadPartialFloat16x4(B, CountN);
-            float16x4_t v1 = MlasLoadPartialFloat16x4(B + ldb, CountN);
-            float16x4_t v2 = MlasLoadPartialFloat16x4(B + 2 * ldb, CountN);
-            float16x4_t v3 = MlasLoadPartialFloat16x4(B + 3 * ldb, CountN);
-            MlasStoreFloat16x4(PackedB, v0);
-            MlasStoreFloat16x4(PackedB + 8, v1);
-            MlasStoreFloat16x4(PackedB + 16, v2);
-            MlasStoreFloat16x4(PackedB + 24, v3);
-            B += 4 * ldb, PackedB += 32;
-        }
-
-        if (CountK & 2) {
-            float16x4_t v0 = MlasLoadPartialFloat16x4(B, CountN);
-            float16x4_t v1 = MlasLoadPartialFloat16x4(B + ldb, CountN);
-            MlasStoreFloat16x4(PackedB, v0);
-            MlasStoreFloat16x4(PackedB + 8, v1);
-            B += 2 * ldb, PackedB += 16;
-        }
-
-        if (CountK & 1) {
-            float16x4_t v0 = MlasLoadPartialFloat16x4(B, CountN);
-            MlasStoreFloat16x4(PackedB, v0);
-        }
-    }
-}
-
 void HPackB_B_Kernel(
     const MLAS_FP16* B,
     MLAS_FP16* PackedB,
@@ -441,139 +561,75 @@ void HPackB_B_Kernel(
 ) {
     const _mlas_fp16_* B_data = reinterpret_cast<const _mlas_fp16_*>(B);
     _mlas_fp16_* PackedB_data = reinterpret_cast<_mlas_fp16_*>(PackedB);
-    const size_t ldb8 = ldb * 8;
+    const size_t ldb4 = ldb * 4;
 
-    for (; CountN >= 16; CountN -= 16, B_data += 16) {
+    for (; CountN >= 32; CountN -= 32, B_data += 32) {
         const _mlas_fp16_* b = B_data;
         size_t k = CountK;
-        constexpr size_t step = 8 * 16; // pack 8 * 16
-        for (; k >= 8; k -= 8, b += ldb8, PackedB_data += step) {
-            float16x8_t v0 = MlasLoadFloat16x8(b);
-            float16x8_t v1 = MlasLoadFloat16x8(b + 8);
-            float16x8_t v2 = MlasLoadFloat16x8(b + ldb);
-            float16x8_t v3 = MlasLoadFloat16x8(b + ldb + 8);
-            float16x8_t v4 = MlasLoadFloat16x8(b + 2 * ldb);
-            float16x8_t v5 = MlasLoadFloat16x8(b + 2 * ldb + 8);
-            float16x8_t v6 = MlasLoadFloat16x8(b + 3 * ldb);
-            float16x8_t v7 = MlasLoadFloat16x8(b + 3 * ldb + 8);
-            float16x8_t v8 = MlasLoadFloat16x8(b + 4 * ldb);
-            float16x8_t v9 = MlasLoadFloat16x8(b + 4 * ldb + 8);
-            float16x8_t vA = MlasLoadFloat16x8(b + 5 * ldb);
-            float16x8_t vB = MlasLoadFloat16x8(b + 5 * ldb + 8);
-            float16x8_t vC = MlasLoadFloat16x8(b + 6 * ldb);
-            float16x8_t vD = MlasLoadFloat16x8(b + 6 * ldb + 8);
-            float16x8_t vE = MlasLoadFloat16x8(b + 7 * ldb);
-            float16x8_t vF = MlasLoadFloat16x8(b + 7 * ldb + 8);
-
-            MlasStoreFloat16x8(PackedB_data, v0);
-            MlasStoreFloat16x8(PackedB_data + 8, v1);
-            MlasStoreFloat16x8(PackedB_data + 16, v2);
-            MlasStoreFloat16x8(PackedB_data + 24, v3);
-            MlasStoreFloat16x8(PackedB_data + 32, v4);
-            MlasStoreFloat16x8(PackedB_data + 40, v5);
-            MlasStoreFloat16x8(PackedB_data + 48, v6);
-            MlasStoreFloat16x8(PackedB_data + 56, v7);
-            MlasStoreFloat16x8(PackedB_data + 64, v8);
-            MlasStoreFloat16x8(PackedB_data + 72, v9);
-            MlasStoreFloat16x8(PackedB_data + 80, vA);
-            MlasStoreFloat16x8(PackedB_data + 88, vB);
-            MlasStoreFloat16x8(PackedB_data + 96, vC);
-            MlasStoreFloat16x8(PackedB_data + 104, vD);
-            MlasStoreFloat16x8(PackedB_data + 112, vE);
-            MlasStoreFloat16x8(PackedB_data + 120, vF);
-        }
-
-        if (k & 4) {
-            float16x8_t v0 = MlasLoadFloat16x8(b);
-            float16x8_t v1 = MlasLoadFloat16x8(b + 8);
-            float16x8_t v2 = MlasLoadFloat16x8(b + ldb);
-            float16x8_t v3 = MlasLoadFloat16x8(b + ldb + 8);
-            float16x8_t v4 = MlasLoadFloat16x8(b + 2 * ldb);
-            float16x8_t v5 = MlasLoadFloat16x8(b + 2 * ldb + 8);
-            float16x8_t v6 = MlasLoadFloat16x8(b + 3 * ldb);
-            float16x8_t v7 = MlasLoadFloat16x8(b + 3 * ldb + 8);
-            MlasStoreFloat16x8(PackedB_data, v0);
-            MlasStoreFloat16x8(PackedB_data + 8, v1);
-            MlasStoreFloat16x8(PackedB_data + 16, v2);
-            MlasStoreFloat16x8(PackedB_data + 24, v3);
-            MlasStoreFloat16x8(PackedB_data + 32, v4);
-            MlasStoreFloat16x8(PackedB_data + 40, v5);
-            MlasStoreFloat16x8(PackedB_data + 48, v6);
-            MlasStoreFloat16x8(PackedB_data + 56, v7);
-
-            b += 4 * ldb, PackedB_data += 4 * 16;
+        constexpr size_t step = 4 * 32;
+        for (; k >= 4; k -= 4, b += ldb4, PackedB_data += step) {
+            vst4q_u16(PackedB_data, vld4q_u16(b));
+            vst4q_u16(PackedB_data + 32, vld4q_u16(b + ldb));
+            vst4q_u16(PackedB_data + 64, vld4q_u16(b + 2 * ldb));
+            vst4q_u16(PackedB_data + 96, vld4q_u16(b + 3 * ldb));
         }
 
         if (k & 2) {
-            float16x8_t v0 = MlasLoadFloat16x8(b);
-            float16x8_t v1 = MlasLoadFloat16x8(b + 8);
-            float16x8_t v2 = MlasLoadFloat16x8(b + ldb);
-            float16x8_t v3 = MlasLoadFloat16x8(b + ldb + 8);
-            MlasStoreFloat16x8(PackedB_data, v0);
-            MlasStoreFloat16x8(PackedB_data + 8, v1);
-            MlasStoreFloat16x8(PackedB_data + 16, v2);
-            MlasStoreFloat16x8(PackedB_data + 24, v3);
+            vst4q_u16(PackedB_data, vld4q_u16(b));
+            vst4q_u16(PackedB_data + 32, vld4q_u16(b + ldb));
+            b += 2 * ldb, PackedB_data += 2 * 32;
+        }
 
+        if (k & 1) {
+            vst4q_u16(PackedB_data, vld4q_u16(b));
+            PackedB_data += 32;
+        }
+    }
+
+    if (CountN & 16) {
+        const _mlas_fp16_* b = B_data;
+        size_t k = CountK;
+        constexpr size_t step = 4 * 16;
+        for (; k >= 4; k -= 4, b += ldb4, PackedB_data += step) {
+            vst2q_u16(PackedB_data, vld2q_u16(b));
+            vst2q_u16(PackedB_data + 16, vld2q_u16(b + ldb));
+            vst2q_u16(PackedB_data + 32, vld2q_u16(b + 2 * ldb));
+            vst2q_u16(PackedB_data + 48, vld2q_u16(b + 3 * ldb));
+        }
+
+        if (k & 2) {
+            vst2q_u16(PackedB_data, vld2q_u16(b));
+            vst2q_u16(PackedB_data + 16, vld2q_u16(b + ldb));
             b += 2 * ldb, PackedB_data += 2 * 16;
         }
 
         if (k & 1) {
-            float16x8_t v0 = MlasLoadFloat16x8(b);
-            float16x8_t v1 = MlasLoadFloat16x8(b + 8);
-            MlasStoreFloat16x8(PackedB_data, v0);
-            MlasStoreFloat16x8(PackedB_data + 8, v1);
-
+            vst2q_u16(PackedB_data, vld2q_u16(b));
             PackedB_data += 16;
         }
+
+        CountN -= 16, B_data += 16;
     }
 
     if (CountN & 8) {
         const _mlas_fp16_* b = B_data;
         size_t k = CountK;
-        constexpr size_t step = 8 * 8; // pack 8 * 8
-        for (; k >= 8; k -= 8, b += ldb8, PackedB_data += step) {
-            float16x8_t v0 = MlasLoadFloat16x8(b);
-            float16x8_t v1 = MlasLoadFloat16x8(b + ldb);
-            float16x8_t v2 = MlasLoadFloat16x8(b + 2 * ldb);
-            float16x8_t v3 = MlasLoadFloat16x8(b + 3 * ldb);
-            float16x8_t v4 = MlasLoadFloat16x8(b + 4 * ldb);
-            float16x8_t v5 = MlasLoadFloat16x8(b + 5 * ldb);
-            float16x8_t v6 = MlasLoadFloat16x8(b + 6 * ldb);
-            float16x8_t v7 = MlasLoadFloat16x8(b + 7 * ldb);
-
-            MlasStoreFloat16x8(PackedB_data, v0);
-            MlasStoreFloat16x8(PackedB_data + 8, v1);
-            MlasStoreFloat16x8(PackedB_data + 16, v2);
-            MlasStoreFloat16x8(PackedB_data + 24, v3);
-            MlasStoreFloat16x8(PackedB_data + 32, v4);
-            MlasStoreFloat16x8(PackedB_data + 40, v5);
-            MlasStoreFloat16x8(PackedB_data + 48, v6);
-            MlasStoreFloat16x8(PackedB_data + 56, v7);
-        }
-
-        if (k & 4) {
-            float16x8_t v0 = MlasLoadFloat16x8(b);
-            float16x8_t v1 = MlasLoadFloat16x8(b + ldb);
-            float16x8_t v2 = MlasLoadFloat16x8(b + 2 * ldb);
-            float16x8_t v3 = MlasLoadFloat16x8(b + 3 * ldb);
-            MlasStoreFloat16x8(PackedB_data, v0);
-            MlasStoreFloat16x8(PackedB_data + 8, v1);
-            MlasStoreFloat16x8(PackedB_data + 16, v2);
-            MlasStoreFloat16x8(PackedB_data + 24, v3);
-            b += 4 * ldb, PackedB_data += 4 * 8;
+        constexpr size_t step = 4 * 8;
+        for (; k >= 4; k -= 4, b += ldb4, PackedB_data += step) {
+            vst1q_u16(PackedB_data, vld1q_u16(b));
+            vst1q_u16(PackedB_data + 8, vld1q_u16(b + ldb));
+            vst1q_u16(PackedB_data + 16, vld1q_u16(b + 2 * ldb));
+            vst1q_u16(PackedB_data + 24, vld1q_u16(b + 3 * ldb));
         }
 
         if (k & 2) {
-            float16x8_t v0 = MlasLoadFloat16x8(b);
-            float16x8_t v1 = MlasLoadFloat16x8(b + ldb);
-            MlasStoreFloat16x8(PackedB_data, v0);
-            MlasStoreFloat16x8(PackedB_data + 8, v1);
+            vst1q_u16(PackedB_data, vld1q_u16(b));
+            vst1q_u16(PackedB_data + 8, vld1q_u16(b + ldb));
             b += 2 * ldb, PackedB_data += 2 * 8;
         }
 
         if (k & 1) {
-            float16x8_t v0 = MlasLoadFloat16x8(b);
-            MlasStoreFloat16x8(PackedB_data, v0);
+            vst1q_u16(PackedB_data, vld1q_u16(b));
             PackedB_data += 8;
         }
 
@@ -581,20 +637,68 @@ void HPackB_B_Kernel(
         CountN -= 8;
     }
 
-    if (CountN == 7) {
-        HPackB_B_Kernel_Last8<7>(B_data, PackedB_data, CountK, ldb);
-    } else if (CountN == 6) {
-        HPackB_B_Kernel_Last8<6>(B_data, PackedB_data, CountK, ldb);
-    } else if (CountN == 5) {
-        HPackB_B_Kernel_Last8<5>(B_data, PackedB_data, CountK, ldb);
-    } else if (CountN == 4) {
-        HPackB_B_Kernel_Last8<4>(B_data, PackedB_data, CountK, ldb);
-    } else if (CountN == 3) {
-        HPackB_B_Kernel_Last8<3>(B_data, PackedB_data, CountK, ldb);
-    } else if (CountN == 2) {
-        HPackB_B_Kernel_Last8<2>(B_data, PackedB_data, CountK, ldb);
-    } else if (CountN == 1) {
-        HPackB_B_Kernel_Last8<1>(B_data, PackedB_data, CountK, ldb);
+    if (CountN > 4) {
+        for (; CountK >= 4; B_data += ldb * 4, PackedB_data += 32, CountK -= 4) {
+            float16x4_t v0 = MlasLoadFloat16x4(B_data);
+            float16x4_t v1 = MlasLoadPartialFloat16x4(B_data + 4, CountN - 4);
+            float16x4_t v2 = MlasLoadFloat16x4(B_data + ldb);
+            float16x4_t v3 = MlasLoadPartialFloat16x4(B_data + ldb + 4, CountN - 4);
+            float16x4_t v4 = MlasLoadFloat16x4(B_data + 2 * ldb);
+            float16x4_t v5 = MlasLoadPartialFloat16x4(B_data + 2 * ldb + 4, CountN - 4);
+            float16x4_t v6 = MlasLoadFloat16x4(B_data + 3 * ldb);
+            float16x4_t v7 = MlasLoadPartialFloat16x4(B_data + 3 * ldb + 4, CountN - 4);
+            MlasStoreFloat16x4(PackedB_data, v0);
+            MlasStoreFloat16x4(PackedB_data + 4, v1);
+            MlasStoreFloat16x4(PackedB_data + 8, v2);
+            MlasStoreFloat16x4(PackedB_data + 12, v3);
+            MlasStoreFloat16x4(PackedB_data + 16, v4);
+            MlasStoreFloat16x4(PackedB_data + 20, v5);
+            MlasStoreFloat16x4(PackedB_data + 24, v6);
+            MlasStoreFloat16x4(PackedB_data + 28, v7);
+        }
+
+        if (CountK & 2) {
+            float16x4_t v0 = MlasLoadFloat16x4(B_data);
+            float16x4_t v1 = MlasLoadPartialFloat16x4(B_data + 4, CountN - 4);
+            float16x4_t v2 = MlasLoadFloat16x4(B_data + ldb);
+            float16x4_t v3 = MlasLoadPartialFloat16x4(B_data + ldb + 4, CountN - 4);
+            MlasStoreFloat16x4(PackedB_data, v0);
+            MlasStoreFloat16x4(PackedB_data + 4, v1);
+            MlasStoreFloat16x4(PackedB_data + 8, v2);
+            MlasStoreFloat16x4(PackedB_data + 12, v3);
+            B_data += 2 * ldb, PackedB_data += 16;
+        }
+
+        if (CountK & 1) {
+            float16x4_t v0 = MlasLoadFloat16x4(B_data);
+            float16x4_t v1 = MlasLoadPartialFloat16x4(B_data + 4, CountN - 4);
+            MlasStoreFloat16x4(PackedB_data, v0);
+            MlasStoreFloat16x4(PackedB_data + 4, v1);
+        }
+    } else if (CountN > 0) {
+        for (; CountK >= 4; B_data += 4 * ldb, PackedB_data += 32, CountK -= 4) {
+            float16x4_t v0 = MlasLoadPartialFloat16x4(B_data, CountN);
+            float16x4_t v1 = MlasLoadPartialFloat16x4(B_data + ldb, CountN);
+            float16x4_t v2 = MlasLoadPartialFloat16x4(B_data + 2 * ldb, CountN);
+            float16x4_t v3 = MlasLoadPartialFloat16x4(B_data + 3 * ldb, CountN);
+            MlasStoreFloat16x4(PackedB_data, v0);
+            MlasStoreFloat16x4(PackedB_data + 8, v1);
+            MlasStoreFloat16x4(PackedB_data + 16, v2);
+            MlasStoreFloat16x4(PackedB_data + 24, v3);
+        }
+
+        if (CountK & 2) {
+            float16x4_t v0 = MlasLoadPartialFloat16x4(B_data, CountN);
+            float16x4_t v1 = MlasLoadPartialFloat16x4(B_data + ldb, CountN);
+            MlasStoreFloat16x4(PackedB_data, v0);
+            MlasStoreFloat16x4(PackedB_data + 8, v1);
+            B_data += 2 * ldb, PackedB_data += 16;
+        }
+
+        if (CountK & 1) {
+            float16x4_t v0 = MlasLoadPartialFloat16x4(B_data, CountN);
+            MlasStoreFloat16x4(PackedB_data, v0);
+        }
     }
 }
 
@@ -633,6 +737,20 @@ float16x8_t maq_laneq_f16_accu(float16x8_t accu0, float16x8_t v0, float16x8_t v1
     accu0 = vfmaq_laneq_f16(accu0, v5, a0, 5);
     accu0 = vfmaq_laneq_f16(accu0, v6, a0, 6);
     accu0 = vfmaq_laneq_f16(accu0, v7, a0, 7);
+    return accu0;
+}
+
+MLAS_FORCEINLINE
+float16x4_t ma_laneq_f16_accu(float16x4_t accu0, float16x4_t v0, float16x4_t v1, float16x4_t v2, float16x4_t v3,
+                              float16x4_t v4, float16x4_t v5, float16x4_t v6, float16x4_t v7, float16x8_t a0) {
+    accu0 = vfma_laneq_f16(accu0, v0, a0, 0);
+    accu0 = vfma_laneq_f16(accu0, v1, a0, 1);
+    accu0 = vfma_laneq_f16(accu0, v2, a0, 2);
+    accu0 = vfma_laneq_f16(accu0, v3, a0, 3);
+    accu0 = vfma_laneq_f16(accu0, v4, a0, 4);
+    accu0 = vfma_laneq_f16(accu0, v5, a0, 5);
+    accu0 = vfma_laneq_f16(accu0, v6, a0, 6);
+    accu0 = vfma_laneq_f16(accu0, v7, a0, 7);
     return accu0;
 }
 
@@ -1083,297 +1201,6 @@ void HGemm_TransposedB_Kernel(
     }
 }
 
-template <int CountM>
-MLAS_FORCEINLINE
-void ma_lane_accu(
-    const _mlas_fp16_* b,
-    size_t ldb,
-    float16x8_t a0,
-    float16x8_t& accu0,
-    float16x8_t a1,
-    float16x8_t& accu1
-) {
-    float16x8_t b0 = MlasLoadFloat16x8(b);
-    float16x8_t b1 = MlasLoadFloat16x8(b + ldb);
-    float16x8_t b2 = MlasLoadFloat16x8(b + 2 * ldb);
-    float16x8_t b3 = MlasLoadFloat16x8(b + 3 * ldb);
-    float16x8_t b4 = MlasLoadFloat16x8(b + 4 * ldb);
-    float16x8_t b5 = MlasLoadFloat16x8(b + 5 * ldb);
-    float16x8_t b6 = MlasLoadFloat16x8(b + 6 * ldb);
-    float16x8_t b7 = MlasLoadFloat16x8(b + 7 * ldb);
-    accu0 = vfmaq_laneq_f16(accu0, b0, a0, 0);
-    accu0 = vfmaq_laneq_f16(accu0, b1, a0, 1);
-    accu0 = vfmaq_laneq_f16(accu0, b2, a0, 2);
-    accu0 = vfmaq_laneq_f16(accu0, b3, a0, 3);
-    accu0 = vfmaq_laneq_f16(accu0, b4, a0, 4);
-    accu0 = vfmaq_laneq_f16(accu0, b5, a0, 5);
-    accu0 = vfmaq_laneq_f16(accu0, b6, a0, 6);
-    accu0 = vfmaq_laneq_f16(accu0, b7, a0, 7);
-    if constexpr (CountM == 2) {
-        accu1 = vfmaq_laneq_f16(accu1, b0, a1, 0);
-        accu1 = vfmaq_laneq_f16(accu1, b1, a1, 1);
-        accu1 = vfmaq_laneq_f16(accu1, b2, a1, 2);
-        accu1 = vfmaq_laneq_f16(accu1, b3, a1, 3);
-        accu1 = vfmaq_laneq_f16(accu1, b4, a1, 4);
-        accu1 = vfmaq_laneq_f16(accu1, b5, a1, 5);
-        accu1 = vfmaq_laneq_f16(accu1, b6, a1, 6);
-        accu1 = vfmaq_laneq_f16(accu1, b7, a1, 7);
-    }
-}
-
-template <int CountM>
-MLAS_FORCEINLINE
-void ma_lane_accu(
-    const _mlas_fp16_* b,
-    size_t ldb,
-    float16x8_t a0,
-    float16x4_t& accu0,
-    float16x8_t a1,
-    float16x4_t& accu1
-) {
-    float16x4_t b0 = MlasLoadFloat16x4(b);
-    float16x4_t b1 = MlasLoadFloat16x4(b + ldb);
-    float16x4_t b2 = MlasLoadFloat16x4(b + 2 * ldb);
-    float16x4_t b3 = MlasLoadFloat16x4(b + 3 * ldb);
-    float16x4_t b4 = MlasLoadFloat16x4(b + 4 * ldb);
-    float16x4_t b5 = MlasLoadFloat16x4(b + 5 * ldb);
-    float16x4_t b6 = MlasLoadFloat16x4(b + 6 * ldb);
-    float16x4_t b7 = MlasLoadFloat16x4(b + 7 * ldb);
-    accu0 = vfma_laneq_f16(accu0, b0, a0, 0);
-    accu0 = vfma_laneq_f16(accu0, b1, a0, 1);
-    accu0 = vfma_laneq_f16(accu0, b2, a0, 2);
-    accu0 = vfma_laneq_f16(accu0, b3, a0, 3);
-    accu0 = vfma_laneq_f16(accu0, b4, a0, 4);
-    accu0 = vfma_laneq_f16(accu0, b5, a0, 5);
-    accu0 = vfma_laneq_f16(accu0, b6, a0, 6);
-    accu0 = vfma_laneq_f16(accu0, b7, a0, 7);
-    if constexpr (CountM == 2) {
-        accu1 = vfma_laneq_f16(accu1, b0, a1, 0);
-        accu1 = vfma_laneq_f16(accu1, b1, a1, 1);
-        accu1 = vfma_laneq_f16(accu1, b2, a1, 2);
-        accu1 = vfma_laneq_f16(accu1, b3, a1, 3);
-        accu1 = vfma_laneq_f16(accu1, b4, a1, 4);
-        accu1 = vfma_laneq_f16(accu1, b5, a1, 5);
-        accu1 = vfma_laneq_f16(accu1, b6, a1, 6);
-        accu1 = vfma_laneq_f16(accu1, b7, a1, 7);
-    }
-}
-
-template <int CountM>
-MLAS_FORCEINLINE
-void ma_lane_partial_accu(
-    const _mlas_fp16_* b,
-    size_t ldb,
-    float16x8_t a0,
-    float16x4_t& accu0,
-    float16x8_t a1,
-    float16x4_t& accu1,
-    size_t countN
-) {
-    float16x4_t b0 = MlasLoadPartialFloat16x4(b, countN);
-    float16x4_t b1 = MlasLoadPartialFloat16x4(b + ldb, countN);
-    float16x4_t b2 = MlasLoadPartialFloat16x4(b + 2 * ldb, countN);
-    float16x4_t b3 = MlasLoadPartialFloat16x4(b + 3 * ldb, countN);
-    float16x4_t b4 = MlasLoadPartialFloat16x4(b + 4 * ldb, countN);
-    float16x4_t b5 = MlasLoadPartialFloat16x4(b + 5 * ldb, countN);
-    float16x4_t b6 = MlasLoadPartialFloat16x4(b + 6 * ldb, countN);
-    float16x4_t b7 = MlasLoadPartialFloat16x4(b + 7 * ldb, countN);
-    accu0 = vfma_laneq_f16(accu0, b0, a0, 0);
-    accu0 = vfma_laneq_f16(accu0, b1, a0, 1);
-    accu0 = vfma_laneq_f16(accu0, b2, a0, 2);
-    accu0 = vfma_laneq_f16(accu0, b3, a0, 3);
-    accu0 = vfma_laneq_f16(accu0, b4, a0, 4);
-    accu0 = vfma_laneq_f16(accu0, b5, a0, 5);
-    accu0 = vfma_laneq_f16(accu0, b6, a0, 6);
-    accu0 = vfma_laneq_f16(accu0, b7, a0, 7);
-    if constexpr (CountM == 2) {
-        accu1 = vfma_laneq_f16(accu1, b0, a1, 0);
-        accu1 = vfma_laneq_f16(accu1, b1, a1, 1);
-        accu1 = vfma_laneq_f16(accu1, b2, a1, 2);
-        accu1 = vfma_laneq_f16(accu1, b3, a1, 3);
-        accu1 = vfma_laneq_f16(accu1, b4, a1, 4);
-        accu1 = vfma_laneq_f16(accu1, b5, a1, 5);
-        accu1 = vfma_laneq_f16(accu1, b6, a1, 6);
-        accu1 = vfma_laneq_f16(accu1, b7, a1, 7);
-    }
-}
-
-template <int CountM>
-MLAS_FORCEINLINE
-void ma_lane_accu(
-    const _mlas_fp16_* b,
-    size_t ldb,
-    float16x4_t a0,
-    float16x8_t& accu0,
-    float16x4_t a1,
-    float16x8_t& accu1
-) {
-    float16x8_t b0 = MlasLoadFloat16x8(b);
-    float16x8_t b1 = MlasLoadFloat16x8(b + ldb);
-    float16x8_t b2 = MlasLoadFloat16x8(b + 2 * ldb);
-    float16x8_t b3 = MlasLoadFloat16x8(b + 3 * ldb);
-    accu0 = vfmaq_lane_f16(accu0, b0, a0, 0);
-    accu0 = vfmaq_lane_f16(accu0, b1, a0, 1);
-    accu0 = vfmaq_lane_f16(accu0, b2, a0, 2);
-    accu0 = vfmaq_lane_f16(accu0, b3, a0, 3);
-    if constexpr (CountM == 2) {
-        accu1 = vfmaq_lane_f16(accu1, b0, a1, 0);
-        accu1 = vfmaq_lane_f16(accu1, b1, a1, 1);
-        accu1 = vfmaq_lane_f16(accu1, b2, a1, 2);
-        accu1 = vfmaq_lane_f16(accu1, b3, a1, 3);
-    }
-}
-
-template <int CountM>
-MLAS_FORCEINLINE
-void ma_lane_accu(
-    const _mlas_fp16_* b,
-    size_t ldb,
-    float16x4_t a0,
-    float16x4_t& accu0,
-    float16x4_t a1,
-    float16x4_t& accu1
-) {
-    float16x4_t b0 = MlasLoadFloat16x4(b);
-    float16x4_t b1 = MlasLoadFloat16x4(b + ldb);
-    float16x4_t b2 = MlasLoadFloat16x4(b + 2 * ldb);
-    float16x4_t b3 = MlasLoadFloat16x4(b + 3 * ldb);
-    accu0 = vfma_lane_f16(accu0, b0, a0, 0);
-    accu0 = vfma_lane_f16(accu0, b1, a0, 1);
-    accu0 = vfma_lane_f16(accu0, b2, a0, 2);
-    accu0 = vfma_lane_f16(accu0, b3, a0, 3);
-    if constexpr (CountM == 2) {
-        accu1 = vfma_lane_f16(accu1, b0, a1, 0);
-        accu1 = vfma_lane_f16(accu1, b1, a1, 1);
-        accu1 = vfma_lane_f16(accu1, b2, a1, 2);
-        accu1 = vfma_lane_f16(accu1, b3, a1, 3);
-    }
-}
-
-template <int CountM>
-MLAS_FORCEINLINE
-void ma_lane_partial_accu(
-    const _mlas_fp16_* b,
-    size_t ldb,
-    float16x4_t a0,
-    float16x4_t& accu0,
-    float16x4_t a1,
-    float16x4_t& accu1,
-    size_t countN
-) {
-    float16x4_t b0 = MlasLoadPartialFloat16x4(b, countN);
-    float16x4_t b1 = MlasLoadPartialFloat16x4(b + ldb, countN);
-    float16x4_t b2 = MlasLoadPartialFloat16x4(b + 2 * ldb, countN);
-    float16x4_t b3 = MlasLoadPartialFloat16x4(b + 3 * ldb, countN);
-    accu0 = vfma_lane_f16(accu0, b0, a0, 0);
-    accu0 = vfma_lane_f16(accu0, b1, a0, 1);
-    accu0 = vfma_lane_f16(accu0, b2, a0, 2);
-    accu0 = vfma_lane_f16(accu0, b3, a0, 3);
-    if constexpr (CountM == 2) {
-        accu1 = vfma_lane_f16(accu1, b0, a1, 0);
-        accu1 = vfma_lane_f16(accu1, b1, a1, 1);
-        accu1 = vfma_lane_f16(accu1, b2, a1, 2);
-        accu1 = vfma_lane_f16(accu1, b3, a1, 3);
-    }
-}
-
-template <int CountM>
-MLAS_FORCEINLINE
-void ma_lane_accu(
-    const _mlas_fp16_* b,
-    size_t ldb,
-    float16x4_t a0,
-    float16x8_t& accu0,
-    float16x4_t a1,
-    float16x8_t& accu1,
-    size_t countK
-) {
-    float16x8_t b0 = MlasLoadFloat16x8(b);
-    accu0 = vfmaq_lane_f16(accu0, b0, a0, 0);
-    if constexpr (CountM == 2) {
-        accu1 = vfmaq_lane_f16(accu1, b0, a1, 0);
-    }
-    if (countK > 1) {
-        float16x8_t b1 = MlasLoadFloat16x8(b + ldb);
-        accu0 = vfmaq_lane_f16(accu0, b1, a0, 1);
-        if constexpr (CountM == 2) {
-            accu1 = vfmaq_lane_f16(accu1, b1, a1, 1);
-        }
-    }
-    if (countK > 2) {
-        float16x8_t b2 = MlasLoadFloat16x8(b + 2 * ldb);
-        accu0 = vfmaq_lane_f16(accu0, b2, a0, 2);
-        if constexpr (CountM == 2) {
-            accu1 = vfmaq_lane_f16(accu1, b2, a1, 2);
-        }
-    }
-}
-
-template <int CountM>
-MLAS_FORCEINLINE
-void ma_lane_accu(
-    const _mlas_fp16_* b,
-    size_t ldb,
-    float16x4_t a0,
-    float16x4_t& accu0,
-    float16x4_t a1,
-    float16x4_t& accu1,
-    size_t countK
-) {
-    float16x4_t b0 = MlasLoadFloat16x4(b);
-    accu0 = vfma_lane_f16(accu0, b0, a0, 0);
-    if constexpr (CountM == 2) {
-        accu1 = vfma_lane_f16(accu1, b0, a1, 0);
-    }
-    if (countK > 1) {
-        float16x4_t b1 = MlasLoadFloat16x4(b + ldb);
-        accu0 = vfma_lane_f16(accu0, b1, a0, 1);
-        if constexpr (CountM == 2) {
-            accu1 = vfma_lane_f16(accu1, b1, a1, 1);
-        }
-    }
-    if (countK > 2) {
-        float16x4_t b2 = MlasLoadFloat16x4(b + 2 * ldb);
-        accu0 = vfma_lane_f16(accu0, b2, a0, 2);
-        if constexpr (CountM == 2) {
-            accu1 = vfma_lane_f16(accu1, b2, a1, 2);
-        }
-    }
-}
-
-template <int CountM>
-MLAS_FORCEINLINE
-void ma_lane_partial_accu(
-    const _mlas_fp16_* b,
-    size_t ldb,
-    float16x4_t a0,
-    float16x4_t& accu0,
-    float16x4_t a1,
-    float16x4_t& accu1,
-    size_t countK,
-    size_t countN
-) {
-    float16x4_t b0 = MlasLoadPartialFloat16x4(b, countN);
-    accu0 = vfma_lane_f16(accu0, b0, a0, 0);
-    if constexpr (CountM == 2) {
-        accu1 = vfma_lane_f16(accu1, b0, a1, 0);
-    }
-    if (countK > 1) {
-        float16x4_t b1 = MlasLoadPartialFloat16x4(b + ldb, countN);
-        accu0 = vfma_lane_f16(accu0, b1, a0, 1);
-        if constexpr (CountM == 2) {
-            accu1 = vfma_lane_f16(accu1, b1, a1, 1);
-        }
-    }
-    if (countK > 2) {
-        float16x4_t b2 = MlasLoadPartialFloat16x4(b + 2 * ldb, countN);
-        accu0 = vfma_lane_f16(accu0, b2, a0, 2);
-        if constexpr (CountM == 2) {
-            accu1 = vfma_lane_f16(accu1, b2, a1, 2);
-        }
-    }
-}
-
 // handle C = alpha * A * B + beta * C where alpha != 1 or beta != 0 or 1
 template <int CountM>
 void HGemm_B_Kernel_Complicated(
@@ -1388,9 +1215,7 @@ void HGemm_B_Kernel_Complicated(
     _mlas_fp16_ alpha,
     _mlas_fp16_ beta
 ) {
-    const size_t ldb8 = ldb * 8;
-    const float16x8_t zero_v8 = MlasZeroFloat16x8();
-    const float16x4_t zero_v4 = MlasZeroFloat16x4();
+    const size_t ldb4 = ldb * 4;
     float16x8_t alpha_v8 = MlasBroadcastFloat16x8(alpha);
     float16x8_t beta_v8 = MlasBroadcastFloat16x8(beta);
     float16x4_t alpha_v4 = MlasBroadcastFloat16x4(alpha);
@@ -1410,39 +1235,90 @@ void HGemm_B_Kernel_Complicated(
             accu12 = MlasZeroFloat16x8();
             accu13 = MlasZeroFloat16x8();
         }
-        for (; k >= 8; k -= 8, a += 8, b += ldb8) {
-            float16x8_t a0 = MlasLoadFloat16x8(a), a1 = zero_v8;
-            if constexpr (CountM == 2) {
-                a1 = MlasLoadFloat16x8(a + lda);
-            }
-            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10);
-            ma_lane_accu<CountM>(b + 8, ldb, a0, accu01, a1, accu11);
-            ma_lane_accu<CountM>(b + 16, ldb, a0, accu02, a1, accu12);
-            ma_lane_accu<CountM>(b + 24, ldb, a0, accu03, a1, accu13);
-        }
-
-        if (k & 4) {
-            float16x4_t a0 = MlasLoadFloat16x4(a), a1 = zero_v4;
+        for (; k >= 4; k -= 4, a += 4, b += ldb4) {
+            float16x4_t a0 = MlasLoadFloat16x4(a), a1;
             if constexpr (CountM == 2) {
                 a1 = MlasLoadFloat16x4(a + lda);
             }
-            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10);
-            ma_lane_accu<CountM>(b + 8, ldb, a0, accu01, a1, accu11);
-            ma_lane_accu<CountM>(b + 16, ldb, a0, accu02, a1, accu12);
-            ma_lane_accu<CountM>(b + 24, ldb, a0, accu03, a1, accu13);
-
-            k -= 4, a += 4, b += 4 * ldb;
+            float16x8_t b00 = MlasLoadFloat16x8(b);
+            float16x8_t b10 = MlasLoadFloat16x8(b + ldb);
+            float16x8_t b20 = MlasLoadFloat16x8(b + 2 * ldb);
+            float16x8_t b30 = MlasLoadFloat16x8(b + 3 * ldb);
+            accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
+            float16x8_t b01 = MlasLoadFloat16x8(b + 8);
+            float16x8_t b11 = MlasLoadFloat16x8(b + ldb + 8);
+            float16x8_t b21 = MlasLoadFloat16x8(b + 2 * ldb + 8);
+            float16x8_t b31 = MlasLoadFloat16x8(b + 3 * ldb + 8);
+            accu01 = maq_lane_f16_accu(accu01, b01, b11, b21, b31, a0);
+            float16x8_t b02 = MlasLoadFloat16x8(b + 16);
+            float16x8_t b12 = MlasLoadFloat16x8(b + ldb + 16);
+            float16x8_t b22 = MlasLoadFloat16x8(b + 2 * ldb + 16);
+            float16x8_t b32 = MlasLoadFloat16x8(b + 3 * ldb + 16);
+            accu02 = maq_lane_f16_accu(accu02, b02, b12, b22, b32, a0);
+            float16x8_t b03 = MlasLoadFloat16x8(b + 24);
+            float16x8_t b13 = MlasLoadFloat16x8(b + ldb + 24);
+            float16x8_t b23 = MlasLoadFloat16x8(b + 2 * ldb + 24);
+            float16x8_t b33 = MlasLoadFloat16x8(b + 3 * ldb + 24);
+            accu03 = maq_lane_f16_accu(accu03, b03, b13, b23, b33, a0);
+            if constexpr (CountM == 2) {
+                accu10 = maq_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
+                accu11 = maq_lane_f16_accu(accu11, b01, b11, b21, b31, a1);
+                accu12 = maq_lane_f16_accu(accu12, b02, b12, b22, b32, a1);
+                accu13 = maq_lane_f16_accu(accu13, b03, b13, b23, b33, a1);
+            }
         }
 
         if (k > 0) {
-            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1 = zero_v4;
+            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1;
             if constexpr (CountM == 2) {
                 a1 = MlasLoadPartialFloat16x4(a + lda, k);
             }
-            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10, k);
-            ma_lane_accu<CountM>(b + 8, ldb, a0, accu01, a1, accu11, k);
-            ma_lane_accu<CountM>(b + 16, ldb, a0, accu02, a1, accu12, k);
-            ma_lane_accu<CountM>(b + 24, ldb, a0, accu03, a1, accu13, k);
+            float16x8_t b00 = MlasLoadFloat16x8(b);
+            float16x8_t b01 = MlasLoadFloat16x8(b + 8);
+            float16x8_t b02 = MlasLoadFloat16x8(b + 16);
+            float16x8_t b03 = MlasLoadFloat16x8(b + 24);
+            accu00 = vfmaq_lane_f16(accu00, b00, a0, 0);
+            accu01 = vfmaq_lane_f16(accu01, b01, a0, 0);
+            accu02 = vfmaq_lane_f16(accu02, b02, a0, 0);
+            accu03 = vfmaq_lane_f16(accu03, b03, a0, 0);
+            if constexpr (CountM == 2) {
+                accu10 = vfmaq_lane_f16(accu10, b00, a1, 0);
+                accu11 = vfmaq_lane_f16(accu11, b01, a1, 0);
+                accu12 = vfmaq_lane_f16(accu12, b02, a1, 0);
+                accu13 = vfmaq_lane_f16(accu13, b03, a1, 0);
+            }
+            if (k > 1) {
+                float16x8_t b10 = MlasLoadFloat16x8(b + ldb);
+                float16x8_t b11 = MlasLoadFloat16x8(b + ldb + 8);
+                float16x8_t b12 = MlasLoadFloat16x8(b + ldb + 16);
+                float16x8_t b13 = MlasLoadFloat16x8(b + ldb + 24);
+                accu00 = vfmaq_lane_f16(accu00, b10, a0, 1);
+                accu01 = vfmaq_lane_f16(accu01, b11, a0, 1);
+                accu02 = vfmaq_lane_f16(accu02, b12, a0, 1);
+                accu03 = vfmaq_lane_f16(accu03, b13, a0, 1);
+                if constexpr (CountM == 2) {
+                    accu10 = vfmaq_lane_f16(accu10, b10, a1, 1);
+                    accu11 = vfmaq_lane_f16(accu11, b11, a1, 1);
+                    accu12 = vfmaq_lane_f16(accu12, b12, a1, 1);
+                    accu13 = vfmaq_lane_f16(accu13, b13, a1, 1);
+                }
+            }
+            if (k > 2) {
+                float16x8_t b20 = MlasLoadFloat16x8(b + 2 * ldb);
+                float16x8_t b21 = MlasLoadFloat16x8(b + 2 * ldb + 8);
+                float16x8_t b22 = MlasLoadFloat16x8(b + 2 * ldb + 16);
+                float16x8_t b23 = MlasLoadFloat16x8(b + 2 * ldb + 24);
+                accu00 = vfmaq_lane_f16(accu00, b20, a0, 2);
+                accu01 = vfmaq_lane_f16(accu01, b21, a0, 2);
+                accu02 = vfmaq_lane_f16(accu02, b22, a0, 2);
+                accu03 = vfmaq_lane_f16(accu03, b23, a0, 2);
+                if constexpr (CountM == 2) {
+                    accu10 = vfmaq_lane_f16(accu10, b20, a1, 2);
+                    accu11 = vfmaq_lane_f16(accu11, b21, a1, 2);
+                    accu12 = vfmaq_lane_f16(accu12, b22, a1, 2);
+                    accu13 = vfmaq_lane_f16(accu13, b23, a1, 2);
+                }
+            }
         }
 
         float16x8_t c00 = MlasLoadFloat16x8(C_data);
@@ -1476,32 +1352,60 @@ void HGemm_B_Kernel_Complicated(
             accu10 = MlasZeroFloat16x8();
             accu11 = MlasZeroFloat16x8();
         }
-        for (; k >= 8; k -= 8, a += 8, b += ldb8) {
-            float16x8_t a0 = MlasLoadFloat16x8(a), a1 = zero_v8;
-            if constexpr (CountM == 2) {
-                a1 = MlasLoadFloat16x8(a + lda);
-            }
-            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10);
-            ma_lane_accu<CountM>(b + 8, ldb, a0, accu01, a1, accu11);
-        }
-
-        if (k & 4) {
-            float16x4_t a0 = MlasLoadFloat16x4(a), a1 = zero_v4;
+        for (; k >= 4; k -= 4, a += 4, b += ldb4) {
+            float16x4_t a0 = MlasLoadFloat16x4(a), a1;
             if constexpr (CountM == 2) {
                 a1 = MlasLoadFloat16x4(a + lda);
             }
-            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10);
-            ma_lane_accu<CountM>(b + 8, ldb, a0, accu01, a1, accu11);
-            k -= 4, a += 4, b += 4 * ldb;
+            float16x8_t b00 = MlasLoadFloat16x8(b);
+            float16x8_t b10 = MlasLoadFloat16x8(b + ldb);
+            float16x8_t b20 = MlasLoadFloat16x8(b + 2 * ldb);
+            float16x8_t b30 = MlasLoadFloat16x8(b + 3 * ldb);
+            accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
+            float16x8_t b01 = MlasLoadFloat16x8(b + 8);
+            float16x8_t b11 = MlasLoadFloat16x8(b + ldb + 8);
+            float16x8_t b21 = MlasLoadFloat16x8(b + 2 * ldb + 8);
+            float16x8_t b31 = MlasLoadFloat16x8(b + 3 * ldb + 8);
+            accu01 = maq_lane_f16_accu(accu01, b01, b11, b21, b31, a0);
+            if constexpr (CountM == 2) {
+                accu10 = maq_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
+                accu11 = maq_lane_f16_accu(accu11, b01, b11, b21, b31, a1);
+            }
         }
 
         if (k > 0) {
-            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1 = zero_v4;
+            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1;
             if constexpr (CountM == 2) {
                 a1 = MlasLoadPartialFloat16x4(a + lda, k);
             }
-            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10, k);
-            ma_lane_accu<CountM>(b + 8, ldb, a0, accu01, a1, accu11, k);
+            float16x8_t b00 = MlasLoadFloat16x8(b);
+            float16x8_t b01 = MlasLoadFloat16x8(b + 8);
+            accu00 = vfmaq_lane_f16(accu00, b00, a0, 0);
+            accu01 = vfmaq_lane_f16(accu01, b01, a0, 0);
+            if constexpr (CountM == 2) {
+                accu10 = vfmaq_lane_f16(accu10, b00, a1, 0);
+                accu11 = vfmaq_lane_f16(accu11, b01, a1, 0);
+            }
+            if (k > 1) {
+                float16x8_t b10 = MlasLoadFloat16x8(b + ldb);
+                float16x8_t b11 = MlasLoadFloat16x8(b + ldb + 8);
+                accu00 = vfmaq_lane_f16(accu00, b10, a0, 1);
+                accu01 = vfmaq_lane_f16(accu01, b11, a0, 1);
+                if constexpr (CountM == 2) {
+                    accu10 = vfmaq_lane_f16(accu10, b10, a1, 1);
+                    accu11 = vfmaq_lane_f16(accu11, b11, a1, 1);
+                }
+            }
+            if (k > 2) {
+                float16x8_t b20 = MlasLoadFloat16x8(b + 2 * ldb);
+                float16x8_t b21 = MlasLoadFloat16x8(b + 2 * ldb + 8);
+                accu00 = vfmaq_lane_f16(accu00, b20, a0, 2);
+                accu01 = vfmaq_lane_f16(accu01, b21, a0, 2);
+                if constexpr (CountM == 2) {
+                    accu10 = vfmaq_lane_f16(accu10, b20, a1, 2);
+                    accu11 = vfmaq_lane_f16(accu11, b21, a1, 2);
+                }
+            }
         }
 
         float16x8_t c00 = MlasLoadFloat16x8(C_data);
@@ -1527,29 +1431,45 @@ void HGemm_B_Kernel_Complicated(
         if constexpr (CountM == 2) {
             accu10 = MlasZeroFloat16x8();
         }
-        for (; k >= 8; k -= 8, a += 8, b += ldb8) {
-            float16x8_t a0 = MlasLoadFloat16x8(a), a1 = zero_v8;
-            if constexpr (CountM == 2) {
-                a1 = MlasLoadFloat16x8(a + lda);
-            }
-            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10);
-        }
-
-        if (k & 4) {
-            float16x4_t a0 = MlasLoadFloat16x4(a), a1 = zero_v4;
+        for (; k >= 4; k -= 4, a += 4, b += ldb4) {
+            float16x4_t a0 = MlasLoadFloat16x4(a), a1;
             if constexpr (CountM == 2) {
                 a1 = MlasLoadFloat16x4(a + lda);
             }
-            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10);
-            k -= 4, a += 4, b += 4 * ldb;
+            float16x8_t b00 = MlasLoadFloat16x8(b);
+            float16x8_t b10 = MlasLoadFloat16x8(b + ldb);
+            float16x8_t b20 = MlasLoadFloat16x8(b + 2 * ldb);
+            float16x8_t b30 = MlasLoadFloat16x8(b + 3 * ldb);
+            accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
+            if constexpr (CountM == 2) {
+                accu10 = maq_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
+            }
         }
 
         if (k > 0) {
-            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1 = zero_v4;
+            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1;
             if constexpr (CountM == 2) {
                 a1 = MlasLoadPartialFloat16x4(a + lda, k);
             }
-            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10, k);
+            float16x8_t b00 = MlasLoadFloat16x8(b);
+            accu00 = vfmaq_lane_f16(accu00, b00, a0, 0);
+            if constexpr (CountM == 2) {
+                accu10 = vfmaq_lane_f16(accu10, b00, a1, 0);
+            }
+            if (k > 1) {
+                float16x8_t b10 = MlasLoadFloat16x8(b + ldb);
+                accu00 = vfmaq_lane_f16(accu00, b10, a0, 1);
+                if constexpr (CountM == 2) {
+                    accu10 = vfmaq_lane_f16(accu10, b10, a1, 1);
+                }
+            }
+            if (k > 2) {
+                float16x8_t b20 = MlasLoadFloat16x8(b + 2 * ldb);
+                accu00 = vfmaq_lane_f16(accu00, b20, a0, 2);
+                if constexpr (CountM == 2) {
+                    accu10 = vfmaq_lane_f16(accu10, b20, a1, 2);
+                }
+            }
         }
 
         float16x8_t c00 = MlasLoadFloat16x8(C_data);
@@ -1571,29 +1491,45 @@ void HGemm_B_Kernel_Complicated(
         if constexpr (CountM == 2) {
             accu10 = MlasZeroFloat16x4();
         }
-        for (; k >= 8; k -= 8, a += 8, b += ldb8) {
-            float16x8_t a0 = MlasLoadFloat16x8(a), a1 = zero_v8;
-            if constexpr (CountM == 2) {
-                a1 = MlasLoadFloat16x8(a + lda);
-            }
-            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10);
-        }
-
-        if (k & 4) {
-            float16x4_t a0 = MlasLoadFloat16x4(a), a1 = zero_v4;
+        for (; k >= 4; k -= 4, a += 4, b += ldb4) {
+            float16x4_t a0 = MlasLoadFloat16x4(a), a1;
             if constexpr (CountM == 2) {
                 a1 = MlasLoadFloat16x4(a + lda);
             }
-            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10);
-            k -= 4, a += 4, b += 4 * ldb;
+            float16x4_t b00 = MlasLoadFloat16x4(b);
+            float16x4_t b10 = MlasLoadFloat16x4(b + ldb);
+            float16x4_t b20 = MlasLoadFloat16x4(b + 2 * ldb);
+            float16x4_t b30 = MlasLoadFloat16x4(b + 3 * ldb);
+            accu00 = ma_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
+            if constexpr (CountM == 2) {
+                accu10 = ma_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
+            }
         }
 
         if (k > 0) {
-            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1 = zero_v4;
+            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1;
             if constexpr (CountM == 2) {
                 a1 = MlasLoadPartialFloat16x4(a + lda, k);
             }
-            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10, k);
+            float16x4_t b00 = MlasLoadFloat16x4(b);
+            accu00 = vfma_lane_f16(accu00, b00, a0, 0);
+            if constexpr (CountM == 2) {
+                accu10 = vfma_lane_f16(accu10, b00, a1, 0);
+            }
+            if (k > 1) {
+                float16x4_t b10 = MlasLoadFloat16x4(b + ldb);
+                accu00 = vfma_lane_f16(accu00, b10, a0, 1);
+                if constexpr (CountM == 2) {
+                    accu10 = vfma_lane_f16(accu10, b10, a1, 1);
+                }
+            }
+            if (k > 2) {
+                float16x4_t b20 = MlasLoadFloat16x4(b + 2 * ldb);
+                accu00 = vfma_lane_f16(accu00, b20, a0, 2);
+                if constexpr (CountM == 2) {
+                    accu10 = vfma_lane_f16(accu10, b20, a1, 2);
+                }
+            }
         }
 
         float16x4_t c00 = MlasLoadFloat16x4(C_data);
@@ -1615,29 +1551,45 @@ void HGemm_B_Kernel_Complicated(
         if constexpr (CountM == 2) {
             accu10 = MlasZeroFloat16x4();
         }
-        for (; k >= 8; k -= 8, a += 8, b += ldb8) {
-            float16x8_t a0 = MlasLoadFloat16x8(a), a1 = zero_v8;
-            if constexpr (CountM == 2) {
-                a1 = MlasLoadFloat16x8(a + lda);
-            }
-            ma_lane_partial_accu<CountM>(b, ldb, a0, accu00, a1, accu10, CountN);
-        }
-
-        if (k & 4) {
-            float16x4_t a0 = MlasLoadFloat16x4(a), a1 = zero_v4;
+        for (; k >= 4; k -= 4, a += 4, b += ldb4) {
+            float16x4_t a0 = MlasLoadFloat16x4(a), a1;
             if constexpr (CountM == 2) {
                 a1 = MlasLoadFloat16x4(a + lda);
             }
-            ma_lane_partial_accu<CountM>(b, ldb, a0, accu00, a1, accu10, CountN);
-            k -= 4, a += 4, b += 4 * ldb;
+            float16x4_t b00 = MlasLoadPartialFloat16x4(b, CountN);
+            float16x4_t b10 = MlasLoadPartialFloat16x4(b + ldb, CountN);
+            float16x4_t b20 = MlasLoadPartialFloat16x4(b + 2 * ldb, CountN);
+            float16x4_t b30 = MlasLoadPartialFloat16x4(b + 3 * ldb, CountN);
+            accu00 = ma_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
+            if constexpr (CountM == 2) {
+                accu10 = ma_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
+            }
         }
 
         if (k > 0) {
-            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1 = zero_v4;
+            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1;
             if constexpr (CountM == 2) {
                 a1 = MlasLoadPartialFloat16x4(a + lda, k);
             }
-            ma_lane_partial_accu<CountM>(b, ldb, a0, accu00, a1, accu10, k, CountN);
+            float16x4_t b00 = MlasLoadPartialFloat16x4(b, CountN);
+            accu00 = vfma_lane_f16(accu00, b00, a0, 0);
+            if constexpr (CountM == 2) {
+                accu10 = vfma_lane_f16(accu10, b00, a1, 0);
+            }
+            if (k > 1) {
+                float16x4_t b10 = MlasLoadPartialFloat16x4(b + ldb, CountN);
+                accu00 = vfma_lane_f16(accu00, b10, a0, 1);
+                if constexpr (CountM == 2) {
+                    accu10 = vfma_lane_f16(accu10, b10, a1, 1);
+                }
+            }
+            if (k > 2) {
+                float16x4_t b20 = MlasLoadPartialFloat16x4(b + 2 * ldb, CountN);
+                accu00 = vfma_lane_f16(accu00, b20, a0, 2);
+                if constexpr (CountM == 2) {
+                    accu10 = vfma_lane_f16(accu10, b20, a1, 2);
+                }
+            }
         }
 
         float16x4_t c00 = MlasLoadPartialFloat16x4(C_data, CountN);
@@ -1661,140 +1613,276 @@ void HGemm_B_Kernel_Simple(
     size_t ldb,
     size_t ldc
 ) {
-    const size_t ldb8 = ldb * 8;
-    const float16x8_t zero_v8 = MlasZeroFloat16x8();
-    const float16x4_t zero_v4 = MlasZeroFloat16x4();
+    const size_t ldb4 = ldb * 4;
     if constexpr (zero_mode) {
         // process first K
-        if (CountK >= 8) {
-            float16x8_t a0 = MlasLoadFloat16x8(A_data), a1 = zero_v8;
-            if constexpr (CountM == 2) {
-                a1 = MlasLoadFloat16x8(A_data + lda);
-            }
-            size_t n = CountN;
-            const auto* b = B_data;
-            auto* c = C_data;
-            for (; n >= 16; n -= 16, b += 16, c += 16) {
-                float16x8_t accu00 = zero_v8, accu01 = zero_v8;
-                float16x8_t accu10 = zero_v8, accu11 = zero_v8;
-
-                ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10);
-                ma_lane_accu<CountM>(b + 8, ldb, a0, accu01, a1, accu11);
-                MlasStoreFloat16x8(c, accu00);
-                MlasStoreFloat16x8(c + 8, accu01);
-                if constexpr (CountM == 2) {
-                    MlasStoreFloat16x8(c + ldc, accu10);
-                    MlasStoreFloat16x8(c + ldc + 8, accu11);
-                }
-            }
-            if (n & 8) {
-                float16x8_t accu00 = zero_v8;
-                float16x8_t accu10 = zero_v8;
-
-                ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10);
-                MlasStoreFloat16x8(c, accu00);
-                if constexpr (CountM == 2) {
-                    MlasStoreFloat16x8(c + ldc, accu10);
-                }
-                n -= 8, b += 8, c += 8;
-            }
-            if (n & 4) {
-                float16x4_t accu00 = zero_v4;
-                float16x4_t accu10 = zero_v4;
-
-                ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10);
-                MlasStoreFloat16x4(c, accu00);
-                if constexpr (CountM == 2) {
-                    MlasStoreFloat16x4(c + ldc, accu10);
-                }
-                n -= 4, b += 4, c += 4;
-            }
-            if (n > 0) {
-                float16x4_t accu00 = zero_v4;
-                float16x4_t accu10 = zero_v4;
-
-                ma_lane_partial_accu<CountM>(b, ldb, a0, accu00, a1, accu10, n);
-                MlasStorePartialFloat16x4(c, accu00, n);
-                if constexpr (CountM == 2) {
-                    MlasStorePartialFloat16x4(c + ldc, accu10, n);
-                }
-            }
-            CountK -= 8, B_data += ldb8, A_data += 8;
-        } else if (CountK >= 4) {
-            float16x4_t a0 = MlasLoadFloat16x4(A_data), a1 = zero_v4;
+        if (CountK >= 4) {
+            float16x4_t a0 = MlasLoadFloat16x4(A_data), a1;
             if constexpr (CountM == 2) {
                 a1 = MlasLoadFloat16x4(A_data + lda);
             }
             size_t n = CountN;
             const auto* b = B_data;
             auto* c = C_data;
-            for (; n >= 16; n -= 16, b += 16, c += 16) {
-                float16x8_t accu00 = zero_v8, accu01 = zero_v8;
-                float16x8_t accu10 = zero_v8, accu11 = zero_v8;
-                ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10);
-                ma_lane_accu<CountM>(b + 8, ldb, a0, accu01, a1, accu11);
+            for (; n >= 32; n -= 32, b += 32, c += 32) {
+                float16x8_t accu00 = MlasZeroFloat16x8();
+                float16x8_t accu01 = MlasZeroFloat16x8();
+                float16x8_t accu02 = MlasZeroFloat16x8();
+                float16x8_t accu03 = MlasZeroFloat16x8();
+                float16x8_t b00 = MlasLoadFloat16x8(b);
+                float16x8_t b10 = MlasLoadFloat16x8(b + ldb);
+                float16x8_t b20 = MlasLoadFloat16x8(b + 2 * ldb);
+                float16x8_t b30 = MlasLoadFloat16x8(b + 3 * ldb);
+                float16x8_t b01 = MlasLoadFloat16x8(b + 8);
+                float16x8_t b11 = MlasLoadFloat16x8(b + ldb + 8);
+                float16x8_t b21 = MlasLoadFloat16x8(b + 2 * ldb + 8);
+                float16x8_t b31 = MlasLoadFloat16x8(b + 3 * ldb + 8);
+                float16x8_t b02 = MlasLoadFloat16x8(b + 16);
+                float16x8_t b12 = MlasLoadFloat16x8(b + ldb + 16);
+                float16x8_t b22 = MlasLoadFloat16x8(b + 2 * ldb + 16);
+                float16x8_t b32 = MlasLoadFloat16x8(b + 3 * ldb + 16);
+                float16x8_t b03 = MlasLoadFloat16x8(b + 24);
+                float16x8_t b13 = MlasLoadFloat16x8(b + ldb + 24);
+                float16x8_t b23 = MlasLoadFloat16x8(b + 2 * ldb + 24);
+                float16x8_t b33 = MlasLoadFloat16x8(b + 3 * ldb + 24);
+                accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
+                accu01 = maq_lane_f16_accu(accu01, b01, b11, b21, b31, a0);
+                accu02 = maq_lane_f16_accu(accu02, b02, b12, b22, b32, a0);
+                accu03 = maq_lane_f16_accu(accu03, b03, b13, b23, b33, a0);
+                MlasStoreFloat16x8(c, accu00);
+                MlasStoreFloat16x8(c + 8, accu01);
+                MlasStoreFloat16x8(c + 16, accu02);
+                MlasStoreFloat16x8(c + 24, accu03);
+                if constexpr (CountM == 2) {
+                    float16x8_t accu10 = MlasZeroFloat16x8();
+                    float16x8_t accu11 = MlasZeroFloat16x8();
+                    float16x8_t accu12 = MlasZeroFloat16x8();
+                    float16x8_t accu13 = MlasZeroFloat16x8();
+                    accu10 = maq_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
+                    accu11 = maq_lane_f16_accu(accu11, b01, b11, b21, b31, a1);
+                    accu12 = maq_lane_f16_accu(accu12, b02, b12, b22, b32, a1);
+                    accu13 = maq_lane_f16_accu(accu13, b03, b13, b23, b33, a1);
+                    MlasStoreFloat16x8(c + ldc, accu10);
+                    MlasStoreFloat16x8(c + ldc + 8, accu11);
+                    MlasStoreFloat16x8(c + ldc + 16, accu12);
+                    MlasStoreFloat16x8(c + ldc + 24, accu13);
+                }
+            }
+            if (n & 16) {
+                float16x8_t accu00 = MlasZeroFloat16x8();
+                float16x8_t accu01 = MlasZeroFloat16x8();
+                float16x8_t b00 = MlasLoadFloat16x8(b);
+                float16x8_t b10 = MlasLoadFloat16x8(b + ldb);
+                float16x8_t b20 = MlasLoadFloat16x8(b + 2 * ldb);
+                float16x8_t b30 = MlasLoadFloat16x8(b + 3 * ldb);
+                float16x8_t b01 = MlasLoadFloat16x8(b + 8);
+                float16x8_t b11 = MlasLoadFloat16x8(b + ldb + 8);
+                float16x8_t b21 = MlasLoadFloat16x8(b + 2 * ldb + 8);
+                float16x8_t b31 = MlasLoadFloat16x8(b + 3 * ldb + 8);
+                accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
+                accu01 = maq_lane_f16_accu(accu01, b01, b11, b21, b31, a0);
                 MlasStoreFloat16x8(c, accu00);
                 MlasStoreFloat16x8(c + 8, accu01);
                 if constexpr (CountM == 2) {
+                    float16x8_t accu10 = MlasZeroFloat16x8();
+                    float16x8_t accu11 = MlasZeroFloat16x8();
+                    accu10 = maq_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
+                    accu11 = maq_lane_f16_accu(accu11, b01, b11, b21, b31, a1);
                     MlasStoreFloat16x8(c + ldc, accu10);
                     MlasStoreFloat16x8(c + ldc + 8, accu11);
                 }
+                n -= 16, b += 16, c += 16;
             }
             if (n & 8) {
-                float16x8_t accu00 = zero_v8;
-                float16x8_t accu10 = zero_v8;
-                ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10);
+                float16x8_t accu00 = MlasZeroFloat16x8();
+                float16x8_t b00 = MlasLoadFloat16x8(b);
+                float16x8_t b10 = MlasLoadFloat16x8(b + ldb);
+                float16x8_t b20 = MlasLoadFloat16x8(b + 2 * ldb);
+                float16x8_t b30 = MlasLoadFloat16x8(b + 3 * ldb);
+                accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
                 MlasStoreFloat16x8(c, accu00);
                 if constexpr (CountM == 2) {
+                    float16x8_t accu10 = MlasZeroFloat16x8();
+                    accu10 = maq_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
                     MlasStoreFloat16x8(c + ldc, accu10);
                 }
                 n -= 8, b += 8, c += 8;
             }
             if (n & 4) {
-                float16x4_t accu00 = zero_v4;
-                float16x4_t accu10 = zero_v4;
-                ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10);
+                float16x4_t accu00 = MlasZeroFloat16x4();
+                float16x4_t b0 = MlasLoadFloat16x4(b);
+                float16x4_t b1 = MlasLoadFloat16x4(b + ldb);
+                float16x4_t b2 = MlasLoadFloat16x4(b + 2 * ldb);
+                float16x4_t b3 = MlasLoadFloat16x4(b + 3 * ldb);
+                accu00 = ma_lane_f16_accu(accu00, b0, b1, b2, b3, a0);
                 MlasStoreFloat16x4(c, accu00);
                 if constexpr (CountM == 2) {
+                    float16x4_t accu10 = MlasZeroFloat16x4();
+                    accu10 = ma_lane_f16_accu(accu10, b0, b1, b2, b3, a1);
                     MlasStoreFloat16x4(c + ldc, accu10);
                 }
                 n -= 4, b += 4, c += 4;
             }
             if (n > 0) {
-                float16x4_t accu00 = zero_v4;
-                float16x4_t accu10 = zero_v4;
-                ma_lane_partial_accu<CountM>(b, ldb, a0, accu00, a1, accu10, n);
+                float16x4_t accu00 = MlasZeroFloat16x4();
+                float16x4_t b0 = MlasLoadPartialFloat16x4(b, n);
+                float16x4_t b1 = MlasLoadPartialFloat16x4(b + ldb, n);
+                float16x4_t b2 = MlasLoadPartialFloat16x4(b + 2 * ldb, n);
+                float16x4_t b3 = MlasLoadPartialFloat16x4(b + 3 * ldb, n);
+                accu00 = ma_lane_f16_accu(accu00, b0, b1, b2, b3, a0);
                 MlasStorePartialFloat16x4(c, accu00, n);
                 if constexpr (CountM == 2) {
+                    float16x4_t accu10 = MlasZeroFloat16x4();
+                    accu10 = ma_lane_f16_accu(accu10, b0, b1, b2, b3, a1);
                     MlasStorePartialFloat16x4(c + ldc, accu10, n);
                 }
             }
-
-            CountK -= 4, B_data += ldb * 4, A_data += 4;
+            CountK -= 4, B_data += ldb4, A_data += 4;
         } else if (CountK > 0) {
-            float16x4_t a0 = MlasLoadPartialFloat16x4(A_data, CountK), a1 = zero_v4;
+            float16x4_t a0 = MlasLoadPartialFloat16x4(A_data, CountK), a1;
             if constexpr (CountM == 2) {
                 a1 = MlasLoadPartialFloat16x4(A_data + lda, CountK);
             }
             size_t n = CountN;
             const auto* b = B_data;
             auto* c = C_data;
-            for (; n >= 16; n -= 16, b += 16, c += 16) {
-                float16x8_t accu00 = zero_v8, accu01 = zero_v8;
-                float16x8_t accu10 = zero_v8, accu11 = zero_v8;
-                ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10, CountK);
-                ma_lane_accu<CountM>(b + 8, ldb, a0, accu01, a1, accu11, CountK);
+            for (; n >= 32; n -= 32, b += 32, c += 32) {
+                float16x8_t accu00 = MlasZeroFloat16x8();
+                float16x8_t accu01 = MlasZeroFloat16x8();
+                float16x8_t accu02 = MlasZeroFloat16x8();
+                float16x8_t accu03 = MlasZeroFloat16x8();
+                float16x8_t accu10, accu11, accu12, accu13;
+                if constexpr (CountM == 2) {
+                    accu10 = MlasZeroFloat16x8();
+                    accu11 = MlasZeroFloat16x8();
+                    accu12 = MlasZeroFloat16x8();
+                    accu13 = MlasZeroFloat16x8();
+                }
+                float16x8_t b00 = MlasLoadFloat16x8(b);
+                float16x8_t b01 = MlasLoadFloat16x8(b + 8);
+                float16x8_t b02 = MlasLoadFloat16x8(b + 16);
+                float16x8_t b03 = MlasLoadFloat16x8(b + 24);
+                accu00 = vfmaq_lane_f16(accu00, b00, a0, 0);
+                accu01 = vfmaq_lane_f16(accu01, b01, a0, 0);
+                accu02 = vfmaq_lane_f16(accu02, b02, a0, 0);
+                accu03 = vfmaq_lane_f16(accu03, b03, a0, 0);
+                if constexpr (CountM == 2) {
+                    accu10 = vfmaq_lane_f16(accu10, b00, a1, 0);
+                    accu11 = vfmaq_lane_f16(accu11, b01, a1, 0);
+                    accu12 = vfmaq_lane_f16(accu12, b02, a1, 0);
+                    accu13 = vfmaq_lane_f16(accu13, b03, a1, 0);
+                }
+                if (CountK > 1) {
+                    float16x8_t b10 = MlasLoadFloat16x8(b + ldb);
+                    float16x8_t b11 = MlasLoadFloat16x8(b + ldb + 8);
+                    float16x8_t b12 = MlasLoadFloat16x8(b + ldb + 16);
+                    float16x8_t b13 = MlasLoadFloat16x8(b + ldb + 24);
+                    accu00 = vfmaq_lane_f16(accu00, b10, a0, 1);
+                    accu01 = vfmaq_lane_f16(accu01, b11, a0, 1);
+                    accu02 = vfmaq_lane_f16(accu02, b12, a0, 1);
+                    accu03 = vfmaq_lane_f16(accu03, b13, a0, 1);
+                    if constexpr (CountM == 2) {
+                        accu10 = vfmaq_lane_f16(accu10, b10, a1, 1);
+                        accu11 = vfmaq_lane_f16(accu11, b11, a1, 1);
+                        accu12 = vfmaq_lane_f16(accu12, b12, a1, 1);
+                        accu13 = vfmaq_lane_f16(accu13, b13, a1, 1);
+                    }
+                }
+                if (CountK > 2) {
+                    float16x8_t b20 = MlasLoadFloat16x8(b + 2 * ldb);
+                    float16x8_t b21 = MlasLoadFloat16x8(b + 2 * ldb + 8);
+                    float16x8_t b22 = MlasLoadFloat16x8(b + 2 * ldb + 16);
+                    float16x8_t b23 = MlasLoadFloat16x8(b + 2 * ldb + 24);
+                    accu00 = vfmaq_lane_f16(accu00, b20, a0, 2);
+                    accu01 = vfmaq_lane_f16(accu01, b21, a0, 2);
+                    accu02 = vfmaq_lane_f16(accu02, b22, a0, 2);
+                    accu03 = vfmaq_lane_f16(accu03, b23, a0, 2);
+                    if constexpr (CountM == 2) {
+                        accu10 = vfmaq_lane_f16(accu10, b20, a1, 2);
+                        accu11 = vfmaq_lane_f16(accu11, b21, a1, 2);
+                        accu12 = vfmaq_lane_f16(accu12, b22, a1, 2);
+                        accu13 = vfmaq_lane_f16(accu13, b23, a1, 2);
+                    }
+                }
+                MlasStoreFloat16x8(c, accu00);
+                MlasStoreFloat16x8(c + 8, accu01);
+                MlasStoreFloat16x8(c + 16, accu02);
+                MlasStoreFloat16x8(c + 24, accu03);
+                if constexpr (CountM == 2) {
+                    MlasStoreFloat16x8(c + ldc, accu10);
+                    MlasStoreFloat16x8(c + ldc + 8, accu11);
+                    MlasStoreFloat16x8(c + ldc + 16, accu12);
+                    MlasStoreFloat16x8(c + ldc + 24, accu13);
+                }
+            }
+            if (n & 16) {
+                float16x8_t accu00 = MlasZeroFloat16x8();
+                float16x8_t accu01 = MlasZeroFloat16x8();
+                float16x8_t accu10, accu11;
+                if constexpr (CountM == 2) {
+                    accu10 = MlasZeroFloat16x8();
+                    accu11 = MlasZeroFloat16x8();
+                }
+                float16x8_t b00 = MlasLoadFloat16x8(b);
+                float16x8_t b01 = MlasLoadFloat16x8(b + 8);
+                accu00 = vfmaq_lane_f16(accu00, b00, a0, 0);
+                accu01 = vfmaq_lane_f16(accu01, b01, a0, 0);
+                if constexpr (CountM == 2) {
+                    accu10 = vfmaq_lane_f16(accu10, b00, a1, 0);
+                    accu11 = vfmaq_lane_f16(accu11, b01, a1, 0);
+                }
+                if (CountK > 1) {
+                    float16x8_t b10 = MlasLoadFloat16x8(b + ldb);
+                    float16x8_t b11 = MlasLoadFloat16x8(b + ldb + 8);
+                    accu00 = vfmaq_lane_f16(accu00, b10, a0, 1);
+                    accu01 = vfmaq_lane_f16(accu01, b11, a0, 1);
+                    if constexpr (CountM == 2) {
+                        accu10 = vfmaq_lane_f16(accu10, b10, a1, 1);
+                        accu11 = vfmaq_lane_f16(accu11, b11, a1, 1);
+                    }
+                }
+                if (CountK > 2) {
+                    float16x8_t b20 = MlasLoadFloat16x8(b + 2 * ldb);
+                    float16x8_t b21 = MlasLoadFloat16x8(b + 2 * ldb + 8);
+                    accu00 = vfmaq_lane_f16(accu00, b20, a0, 2);
+                    accu01 = vfmaq_lane_f16(accu01, b21, a0, 2);
+                    if constexpr (CountM == 2) {
+                        accu10 = vfmaq_lane_f16(accu10, b20, a1, 2);
+                        accu11 = vfmaq_lane_f16(accu11, b21, a1, 2);
+                    }
+                }
                 MlasStoreFloat16x8(c, accu00);
                 MlasStoreFloat16x8(c + 8, accu01);
                 if constexpr (CountM == 2) {
                     MlasStoreFloat16x8(c + ldc, accu10);
                     MlasStoreFloat16x8(c + ldc + 8, accu11);
                 }
+                n -= 16, b += 16, c += 16;
             }
             if (n & 8) {
-                float16x8_t accu00 = zero_v8;
-                float16x8_t accu10 = zero_v8;
-                ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10, CountK);
+                float16x8_t accu00 = MlasZeroFloat16x8(), accu10;
+                if constexpr (CountM == 2) {
+                    accu10 = MlasZeroFloat16x8();
+                }
+                float16x8_t b0 = MlasLoadFloat16x8(b);
+                accu00 = vfmaq_lane_f16(accu00, b0, a0, 0);
+                if constexpr (CountM == 2) {
+                    accu10 = vfmaq_lane_f16(accu10, b0, a1, 0);
+                }
+                if (CountK > 1) {
+                    float16x8_t b1 = MlasLoadFloat16x8(b + ldb);
+                    accu00 = vfmaq_lane_f16(accu00, b1, a0, 1);
+                    if constexpr (CountM == 2) {
+                        accu10 = vfmaq_lane_f16(accu10, b1, a1, 1);
+                    }
+                }
+                if (CountK > 2) {
+                    float16x8_t b2 = MlasLoadFloat16x8(b + 2 * ldb);
+                    accu00 = vfmaq_lane_f16(accu00, b2, a0, 2);
+                    if constexpr (CountM == 2) {
+                        accu10 = vfmaq_lane_f16(accu10, b2, a1, 2);
+                    }
+                }
                 MlasStoreFloat16x8(c, accu00);
                 if constexpr (CountM == 2) {
                     MlasStoreFloat16x8(c + ldc, accu10);
@@ -1802,9 +1890,29 @@ void HGemm_B_Kernel_Simple(
                 n -= 8, b += 8, c += 8;
             }
             if (n & 4) {
-                float16x4_t accu00 = zero_v4;
-                float16x4_t accu10 = zero_v4;
-                ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10, CountK);
+                float16x4_t accu00 = MlasZeroFloat16x4(), accu10;
+                if constexpr (CountM == 2) {
+                    accu10 = MlasZeroFloat16x4();
+                }
+                float16x4_t b0 = MlasLoadFloat16x4(b);
+                accu00 = vfma_lane_f16(accu00, b0, a0, 0);
+                if constexpr (CountM == 2) {
+                    accu10 = vfma_lane_f16(accu10, b0, a1, 0);
+                }
+                if (CountK > 1) {
+                    float16x4_t b1 = MlasLoadFloat16x4(b + ldb);
+                    accu00 = vfma_lane_f16(accu00, b1, a0, 1);
+                    if constexpr (CountM == 2) {
+                        accu10 = vfma_lane_f16(accu10, b1, a1, 1);
+                    }
+                }
+                if (CountK > 2) {
+                    float16x4_t b2 = MlasLoadFloat16x4(b + 2 * ldb);
+                    accu00 = vfma_lane_f16(accu00, b2, a0, 2);
+                    if constexpr (CountM == 2) {
+                        accu10 = vfma_lane_f16(accu10, b2, a1, 2);
+                    }
+                }
                 MlasStoreFloat16x4(c, accu00);
                 if constexpr (CountM == 2) {
                     MlasStoreFloat16x4(c + ldc, accu10);
@@ -1812,9 +1920,29 @@ void HGemm_B_Kernel_Simple(
                 n -= 4, b += 4, c += 4;
             }
             if (n > 0) {
-                float16x4_t accu00 = zero_v4;
-                float16x4_t accu10 = zero_v4;
-                ma_lane_partial_accu<CountM>(b, ldb, a0, accu00, a1, accu10, CountK, n);
+                float16x4_t accu00 = MlasZeroFloat16x4(), accu10;
+                if constexpr (CountM == 2) {
+                    accu10 = MlasZeroFloat16x4();
+                }
+                float16x4_t b0 = MlasLoadPartialFloat16x4(b, n);
+                accu00 = vfma_lane_f16(accu00, b0, a0, 0);
+                if constexpr (CountM == 2) {
+                    accu10 = vfma_lane_f16(accu10, b0, a1, 0);
+                }
+                if (CountK > 1) {
+                    float16x4_t b1 = MlasLoadPartialFloat16x4(b + ldb, n);
+                    accu00 = vfma_lane_f16(accu00, b1, a0, 1);
+                    if constexpr (CountM == 2) {
+                        accu10 = vfma_lane_f16(accu10, b1, a1, 1);
+                    }
+                }
+                if (CountK > 2) {
+                    float16x4_t b2 = MlasLoadPartialFloat16x4(b + 2 * ldb, n);
+                    accu00 = vfma_lane_f16(accu00, b2, a0, 2);
+                    if constexpr (CountM == 2) {
+                        accu10 = vfma_lane_f16(accu10, b2, a1, 2);
+                    }
+                }
                 MlasStorePartialFloat16x4(c, accu00, n);
                 if constexpr (CountM == 2) {
                     MlasStorePartialFloat16x4(c + ldc, accu10, n);
@@ -1825,170 +1953,275 @@ void HGemm_B_Kernel_Simple(
         }
     }
 
-    for (; CountK >= 8; CountK -= 8, B_data += ldb8, A_data += 8) {
-        float16x8_t a0 = MlasLoadFloat16x8(A_data), a1 = zero_v8;
-        if constexpr (CountM == 2) {
-            a1 = MlasLoadFloat16x8(A_data + lda);
-        }
-        size_t n = CountN;
-        const auto* b = B_data;
-        auto* c = C_data;
-        for (; n >= 16; n -= 16, b += 16, c += 16) {
-            float16x8_t accu00 = MlasLoadFloat16x8(c);
-            float16x8_t accu01 = MlasLoadFloat16x8(c + 8);
-            float16x8_t accu10 = zero_v8, accu11 = zero_v8;
-            if constexpr (CountM == 2) {
-                accu10 = MlasLoadFloat16x8(c + ldb);
-                accu11 = MlasLoadFloat16x8(c + ldb + 8);
-            }
-            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10);
-            ma_lane_accu<CountM>(b + 8, ldb, a0, accu01, a1, accu11);
-            MlasStoreFloat16x8(c, accu00);
-            MlasStoreFloat16x8(c + 8, accu01);
-            if constexpr (CountM == 2) {
-                MlasStoreFloat16x8(c + ldc, accu10);
-                MlasStoreFloat16x8(c + ldc + 8, accu11);
-            }
-        }
-        if (n & 8) {
-            float16x8_t accu00 = MlasLoadFloat16x8(c);
-            float16x8_t accu10 = zero_v8;
-            if constexpr (CountM == 2) {
-                accu10 = MlasLoadFloat16x8(c + ldc);
-            }
-            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10);
-            MlasStoreFloat16x8(c, accu00);
-            if constexpr (CountM == 2) {
-                MlasStoreFloat16x8(c + ldc, accu10);
-            }
-            n -= 8, b += 8, c += 8;
-        }
-        if (n & 4) {
-            float16x4_t accu00 = MlasLoadFloat16x4(c);
-            float16x4_t accu10 = zero_v4;
-            if constexpr (CountM == 2) {
-                accu10 = MlasLoadFloat16x4(c + ldc);
-            }
-            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10);
-            MlasStoreFloat16x4(c, accu00);
-            if constexpr (CountM == 2) {
-                MlasStoreFloat16x4(c + ldc, accu10);
-            }
-            n -= 4, b += 4, c += 4;
-        }
-        if (n > 0) {
-            float16x4_t accu00 = MlasLoadPartialFloat16x4(c, n);
-            float16x4_t accu10 = zero_v4;
-            if constexpr (CountM == 2) {
-                accu10 = MlasLoadPartialFloat16x4(c + ldc, n);
-            }
-            ma_lane_partial_accu<CountM>(b, ldb, a0, accu00, a1, accu10, n);
-            MlasStorePartialFloat16x4(c, accu00, n);
-            if constexpr (CountM == 2) {
-                MlasStorePartialFloat16x4(c + ldc, accu10, n);
-            }
-        }
-    }
-
-    if (CountK & 4) {
-        float16x4_t a0 = MlasLoadFloat16x4(A_data), a1 = zero_v4;
+    for (; CountK >= 4; CountK -= 4, B_data += ldb4, A_data += 4) {
+        float16x4_t a0 = MlasLoadFloat16x4(A_data), a1;
         if constexpr (CountM == 2) {
             a1 = MlasLoadFloat16x4(A_data + lda);
         }
         size_t n = CountN;
         const auto* b = B_data;
         auto* c = C_data;
-        for (; n >= 16; n -= 16, b += 16, c += 16) {
+        for (; n >= 32; n -= 32, b += 32, c += 32) {
             float16x8_t accu00 = MlasLoadFloat16x8(c);
             float16x8_t accu01 = MlasLoadFloat16x8(c + 8);
-            float16x8_t accu10 = zero_v8, accu11 = zero_v8;
+            float16x8_t accu02 = MlasLoadFloat16x8(c + 16);
+            float16x8_t accu03 = MlasLoadFloat16x8(c + 24);
+            float16x8_t b00 = MlasLoadFloat16x8(b);
+            float16x8_t b10 = MlasLoadFloat16x8(b + ldb);
+            float16x8_t b20 = MlasLoadFloat16x8(b + 2 * ldb);
+            float16x8_t b30 = MlasLoadFloat16x8(b + 3 * ldb);
+            float16x8_t b01 = MlasLoadFloat16x8(b + 8);
+            float16x8_t b11 = MlasLoadFloat16x8(b + ldb + 8);
+            float16x8_t b21 = MlasLoadFloat16x8(b + 2 * ldb + 8);
+            float16x8_t b31 = MlasLoadFloat16x8(b + 3 * ldb + 8);
+            float16x8_t b02 = MlasLoadFloat16x8(b + 16);
+            float16x8_t b12 = MlasLoadFloat16x8(b + ldb + 16);
+            float16x8_t b22 = MlasLoadFloat16x8(b + 2 * ldb + 16);
+            float16x8_t b32 = MlasLoadFloat16x8(b + 3 * ldb + 16);
+            float16x8_t b03 = MlasLoadFloat16x8(b + 24);
+            float16x8_t b13 = MlasLoadFloat16x8(b + ldb + 24);
+            float16x8_t b23 = MlasLoadFloat16x8(b + 2 * ldb + 24);
+            float16x8_t b33 = MlasLoadFloat16x8(b + 3 * ldb + 24);
+            accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
+            accu01 = maq_lane_f16_accu(accu01, b01, b11, b21, b31, a0);
+            accu02 = maq_lane_f16_accu(accu02, b02, b12, b22, b32, a0);
+            accu03 = maq_lane_f16_accu(accu03, b03, b13, b23, b33, a0);
+            MlasStoreFloat16x8(c, accu00);
+            MlasStoreFloat16x8(c + 8, accu01);
+            MlasStoreFloat16x8(c + 16, accu02);
+            MlasStoreFloat16x8(c + 24, accu03);
             if constexpr (CountM == 2) {
-                accu10 = MlasLoadFloat16x8(c + ldb);
-                accu11 = MlasLoadFloat16x8(c + ldb + 8);
+                float16x8_t accu10 = MlasLoadFloat16x8(c + ldb);
+                float16x8_t accu11 = MlasLoadFloat16x8(c + ldb + 8);
+                float16x8_t accu12 = MlasLoadFloat16x8(c + ldb + 16);
+                float16x8_t accu13 = MlasLoadFloat16x8(c + ldb + 24);
+                accu10 = maq_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
+                accu11 = maq_lane_f16_accu(accu11, b01, b11, b21, b31, a1);
+                accu12 = maq_lane_f16_accu(accu12, b02, b12, b22, b32, a1);
+                accu13 = maq_lane_f16_accu(accu13, b03, b13, b23, b33, a1);
+                MlasStoreFloat16x8(c + ldc, accu10);
+                MlasStoreFloat16x8(c + ldc + 8, accu11);
+                MlasStoreFloat16x8(c + ldc + 16, accu12);
+                MlasStoreFloat16x8(c + ldc + 24, accu13);
             }
-            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10);
-            ma_lane_accu<CountM>(b + 8, ldb, a0, accu01, a1, accu11);
+        }
+        if (n & 16) {
+            float16x8_t accu00 = MlasLoadFloat16x8(c);
+            float16x8_t accu01 = MlasLoadFloat16x8(c + 8);
+            float16x8_t b00 = MlasLoadFloat16x8(b);
+            float16x8_t b10 = MlasLoadFloat16x8(b + ldb);
+            float16x8_t b20 = MlasLoadFloat16x8(b + 2 * ldb);
+            float16x8_t b30 = MlasLoadFloat16x8(b + 3 * ldb);
+            float16x8_t b01 = MlasLoadFloat16x8(b + 8);
+            float16x8_t b11 = MlasLoadFloat16x8(b + ldb + 8);
+            float16x8_t b21 = MlasLoadFloat16x8(b + 2 * ldb + 8);
+            float16x8_t b31 = MlasLoadFloat16x8(b + 3 * ldb + 8);
+            accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
+            accu01 = maq_lane_f16_accu(accu01, b01, b11, b21, b31, a0);
             MlasStoreFloat16x8(c, accu00);
             MlasStoreFloat16x8(c + 8, accu01);
             if constexpr (CountM == 2) {
+                float16x8_t accu10 = MlasLoadFloat16x8(c + ldb);
+                float16x8_t accu11 = MlasLoadFloat16x8(c + ldb + 8);
+                accu10 = maq_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
+                accu11 = maq_lane_f16_accu(accu11, b01, b11, b21, b31, a1);
                 MlasStoreFloat16x8(c + ldc, accu10);
                 MlasStoreFloat16x8(c + ldc + 8, accu11);
             }
+            n -= 16, b += 16, c += 16;
         }
         if (n & 8) {
             float16x8_t accu00 = MlasLoadFloat16x8(c);
-            float16x8_t accu10 = zero_v8;
-            if constexpr (CountM == 2) {
-                accu10 = MlasLoadFloat16x8(c + ldc);
-            }
-            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10);
+            float16x8_t b00 = MlasLoadFloat16x8(b);
+            float16x8_t b10 = MlasLoadFloat16x8(b + ldb);
+            float16x8_t b20 = MlasLoadFloat16x8(b + 2 * ldb);
+            float16x8_t b30 = MlasLoadFloat16x8(b + 3 * ldb);
+            accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
             MlasStoreFloat16x8(c, accu00);
             if constexpr (CountM == 2) {
+                float16x8_t accu10 = MlasLoadFloat16x8(c + ldc);
+                accu10 = maq_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
                 MlasStoreFloat16x8(c + ldc, accu10);
             }
             n -= 8, b += 8, c += 8;
         }
         if (n & 4) {
             float16x4_t accu00 = MlasLoadFloat16x4(c);
-            float16x4_t accu10 = zero_v4;
-            if constexpr (CountM == 2) {
-                accu10 = MlasLoadFloat16x4(c + ldc);
-            }
-            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10);
+            float16x4_t b0 = MlasLoadFloat16x4(b);
+            float16x4_t b1 = MlasLoadFloat16x4(b + ldb);
+            float16x4_t b2 = MlasLoadFloat16x4(b + 2 * ldb);
+            float16x4_t b3 = MlasLoadFloat16x4(b + 3 * ldb);
+            accu00 = ma_lane_f16_accu(accu00, b0, b1, b2, b3, a0);
             MlasStoreFloat16x4(c, accu00);
             if constexpr (CountM == 2) {
+                float16x4_t accu10 = MlasLoadFloat16x4(c + ldc);
+                accu10 = ma_lane_f16_accu(accu10, b0, b1, b2, b3, a1);
                 MlasStoreFloat16x4(c + ldc, accu10);
             }
             n -= 4, b += 4, c += 4;
         }
         if (n > 0) {
             float16x4_t accu00 = MlasLoadPartialFloat16x4(c, n);
-            float16x4_t accu10 = zero_v4;
-            if constexpr (CountM == 2) {
-                accu10 = MlasLoadPartialFloat16x4(c + ldc, n);
-            }
-            ma_lane_partial_accu<CountM>(b, ldb, a0, accu00, a1, accu10, n);
+            float16x4_t b0 = MlasLoadPartialFloat16x4(b, n);
+            float16x4_t b1 = MlasLoadPartialFloat16x4(b + ldb, n);
+            float16x4_t b2 = MlasLoadPartialFloat16x4(b + 2 * ldb, n);
+            float16x4_t b3 = MlasLoadPartialFloat16x4(b + 3 * ldb, n);
+            accu00 = ma_lane_f16_accu(accu00, b0, b1, b2, b3, a0);
             MlasStorePartialFloat16x4(c, accu00, n);
             if constexpr (CountM == 2) {
+                float16x4_t accu10 = MlasLoadPartialFloat16x4(c + ldc, n);
+                accu10 = ma_lane_f16_accu(accu10, b0, b1, b2, b3, a1);
                 MlasStorePartialFloat16x4(c + ldc, accu10, n);
             }
         }
-
-        CountK -= 4, B_data += ldb * 4, A_data += 4;
     }
 
     if (CountK > 0) {
-        float16x4_t a0 = MlasLoadPartialFloat16x4(A_data, CountK), a1 = zero_v4;
+        float16x4_t a0 = MlasLoadPartialFloat16x4(A_data, CountK), a1;
         if constexpr (CountM == 2) {
             a1 = MlasLoadPartialFloat16x4(A_data + lda, CountK);
         }
         size_t n = CountN;
         const auto* b = B_data;
         auto* c = C_data;
-        for (; n >= 16; n -= 16, b += 16, c += 16) {
+        for (; n >= 32; n -= 32, b += 32, c += 32) {
             float16x8_t accu00 = MlasLoadFloat16x8(c);
             float16x8_t accu01 = MlasLoadFloat16x8(c + 8);
-            float16x8_t accu10 = zero_v8, accu11 = zero_v8;
+            float16x8_t accu02 = MlasLoadFloat16x8(c + 16);
+            float16x8_t accu03 = MlasLoadFloat16x8(c + 24);
+            float16x8_t accu10, accu11, accu12, accu13;
             if constexpr (CountM == 2) {
                 accu10 = MlasLoadFloat16x8(c + ldb);
                 accu11 = MlasLoadFloat16x8(c + ldb + 8);
+                accu12 = MlasLoadFloat16x8(c + ldb + 16);
+                accu13 = MlasLoadFloat16x8(c + ldb + 24);
             }
-            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10, CountK);
-            ma_lane_accu<CountM>(b + 8, ldb, a0, accu01, a1, accu11, CountK);
+            float16x8_t b00 = MlasLoadFloat16x8(b);
+            float16x8_t b01 = MlasLoadFloat16x8(b + 8);
+            float16x8_t b02 = MlasLoadFloat16x8(b + 16);
+            float16x8_t b03 = MlasLoadFloat16x8(b + 24);
+            accu00 = vfmaq_lane_f16(accu00, b00, a0, 0);
+            accu01 = vfmaq_lane_f16(accu01, b01, a0, 0);
+            accu02 = vfmaq_lane_f16(accu02, b02, a0, 0);
+            accu03 = vfmaq_lane_f16(accu03, b03, a0, 0);
+            if constexpr (CountM == 2) {
+                accu10 = vfmaq_lane_f16(accu10, b00, a1, 0);
+                accu11 = vfmaq_lane_f16(accu11, b01, a1, 0);
+                accu12 = vfmaq_lane_f16(accu12, b02, a1, 0);
+                accu13 = vfmaq_lane_f16(accu13, b03, a1, 0);
+            }
+            if (CountK > 1) {
+                float16x8_t b10 = MlasLoadFloat16x8(b + ldb);
+                float16x8_t b11 = MlasLoadFloat16x8(b + ldb + 8);
+                float16x8_t b12 = MlasLoadFloat16x8(b + ldb + 16);
+                float16x8_t b13 = MlasLoadFloat16x8(b + ldb + 24);
+                accu00 = vfmaq_lane_f16(accu00, b10, a0, 1);
+                accu01 = vfmaq_lane_f16(accu01, b11, a0, 1);
+                accu02 = vfmaq_lane_f16(accu02, b12, a0, 1);
+                accu03 = vfmaq_lane_f16(accu03, b13, a0, 1);
+                if constexpr (CountM == 2) {
+                    accu10 = vfmaq_lane_f16(accu10, b10, a1, 1);
+                    accu11 = vfmaq_lane_f16(accu11, b11, a1, 1);
+                    accu12 = vfmaq_lane_f16(accu12, b12, a1, 1);
+                    accu13 = vfmaq_lane_f16(accu13, b13, a1, 1);
+                }
+            }
+            if (CountK > 2) {
+                float16x8_t b20 = MlasLoadFloat16x8(b + 2 * ldb);
+                float16x8_t b21 = MlasLoadFloat16x8(b + 2 * ldb + 8);
+                float16x8_t b22 = MlasLoadFloat16x8(b + 2 * ldb + 16);
+                float16x8_t b23 = MlasLoadFloat16x8(b + 2 * ldb + 24);
+                accu00 = vfmaq_lane_f16(accu00, b20, a0, 2);
+                accu01 = vfmaq_lane_f16(accu01, b21, a0, 2);
+                accu02 = vfmaq_lane_f16(accu02, b22, a0, 2);
+                accu03 = vfmaq_lane_f16(accu03, b23, a0, 2);
+                if constexpr (CountM == 2) {
+                    accu10 = vfmaq_lane_f16(accu10, b20, a1, 2);
+                    accu11 = vfmaq_lane_f16(accu11, b21, a1, 2);
+                    accu12 = vfmaq_lane_f16(accu12, b22, a1, 2);
+                    accu13 = vfmaq_lane_f16(accu13, b23, a1, 2);
+                }
+            }
+            MlasStoreFloat16x8(c, accu00);
+            MlasStoreFloat16x8(c + 8, accu01);
+            MlasStoreFloat16x8(c + 16, accu02);
+            MlasStoreFloat16x8(c + 24, accu03);
+            if constexpr (CountM == 2) {
+                MlasStoreFloat16x8(c + ldc, accu10);
+                MlasStoreFloat16x8(c + ldc + 8, accu11);
+                MlasStoreFloat16x8(c + ldc + 16, accu12);
+                MlasStoreFloat16x8(c + ldc + 24, accu13);
+            }
+        }
+        if (n & 16) {
+            float16x8_t accu00 = MlasLoadFloat16x8(c);
+            float16x8_t accu01 = MlasLoadFloat16x8(c + 8);
+            float16x8_t accu10, accu11;
+            if constexpr (CountM == 2) {
+                accu10 = MlasLoadFloat16x8(c + ldc);
+                accu11 = MlasLoadFloat16x8(c + ldc + 8);
+            }
+            float16x8_t b00 = MlasLoadFloat16x8(b);
+            float16x8_t b01 = MlasLoadFloat16x8(b + 8);
+            accu00 = vfmaq_lane_f16(accu00, b00, a0, 0);
+            accu01 = vfmaq_lane_f16(accu01, b01, a0, 0);
+            if constexpr (CountM == 2) {
+                accu10 = vfmaq_lane_f16(accu10, b00, a1, 0);
+                accu11 = vfmaq_lane_f16(accu11, b01, a1, 0);
+            }
+            if (CountK > 1) {
+                float16x8_t b10 = MlasLoadFloat16x8(b + ldb);
+                float16x8_t b11 = MlasLoadFloat16x8(b + ldb + 8);
+                accu00 = vfmaq_lane_f16(accu00, b10, a0, 1);
+                accu01 = vfmaq_lane_f16(accu01, b11, a0, 1);
+                if constexpr (CountM == 2) {
+                    accu10 = vfmaq_lane_f16(accu10, b10, a1, 1);
+                    accu11 = vfmaq_lane_f16(accu11, b11, a1, 1);
+                }
+            }
+            if (CountK > 2) {
+                float16x8_t b20 = MlasLoadFloat16x8(b + 2 * ldb);
+                float16x8_t b21 = MlasLoadFloat16x8(b + 2 * ldb + 8);
+                accu00 = vfmaq_lane_f16(accu00, b20, a0, 2);
+                accu01 = vfmaq_lane_f16(accu01, b21, a0, 2);
+                if constexpr (CountM == 2) {
+                    accu10 = vfmaq_lane_f16(accu10, b20, a1, 2);
+                    accu11 = vfmaq_lane_f16(accu11, b21, a1, 2);
+                }
+            }
             MlasStoreFloat16x8(c, accu00);
             MlasStoreFloat16x8(c + 8, accu01);
             if constexpr (CountM == 2) {
                 MlasStoreFloat16x8(c + ldc, accu10);
                 MlasStoreFloat16x8(c + ldc + 8, accu11);
             }
+            n -= 16, b += 16, c += 16;
         }
         if (n & 8) {
             float16x8_t accu00 = MlasLoadFloat16x8(c);
-            float16x8_t accu10 = zero_v8;
+            float16x8_t accu10;
             if constexpr (CountM == 2) {
                 accu10 = MlasLoadFloat16x8(c + ldc);
             }
-            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10, CountK);
+            float16x8_t b0 = MlasLoadFloat16x8(b);
+            accu00 = vfmaq_lane_f16(accu00, b0, a0, 0);
+            if constexpr (CountM == 2) {
+                accu10 = vfmaq_lane_f16(accu10, b0, a1, 0);
+            }
+            if (CountK > 1) {
+                float16x8_t b1 = MlasLoadFloat16x8(b + ldb);
+                accu00 = vfmaq_lane_f16(accu00, b1, a0, 1);
+                if constexpr (CountM == 2) {
+                    accu10 = vfmaq_lane_f16(accu10, b1, a1, 1);
+                }
+            }
+            if (CountK > 2) {
+                float16x8_t b2 = MlasLoadFloat16x8(b + 2 * ldb);
+                accu00 = vfmaq_lane_f16(accu00, b2, a0, 2);
+                if constexpr (CountM == 2) {
+                    accu10 = vfmaq_lane_f16(accu10, b2, a1, 2);
+                }
+            }
             MlasStoreFloat16x8(c, accu00);
             if constexpr (CountM == 2) {
                 MlasStoreFloat16x8(c + ldc, accu10);
@@ -1997,11 +2230,29 @@ void HGemm_B_Kernel_Simple(
         }
         if (n & 4) {
             float16x4_t accu00 = MlasLoadFloat16x4(c);
-            float16x4_t accu10 = zero_v4;
+            float16x4_t accu10;
             if constexpr (CountM == 2) {
                 accu10 = MlasLoadFloat16x4(c + ldc);
             }
-            ma_lane_accu<CountM>(b, ldb, a0, accu00, a1, accu10, CountK);
+            float16x4_t b0 = MlasLoadFloat16x4(b);
+            accu00 = vfma_lane_f16(accu00, b0, a0, 0);
+            if constexpr (CountM == 2) {
+                accu10 = vfma_lane_f16(accu10, b0, a1, 0);
+            }
+            if (CountK > 1) {
+                float16x4_t b1 = MlasLoadFloat16x4(b + ldb);
+                accu00 = vfma_lane_f16(accu00, b1, a0, 1);
+                if constexpr (CountM == 2) {
+                    accu10 = vfma_lane_f16(accu10, b1, a1, 1);
+                }
+            }
+            if (CountK > 2) {
+                float16x4_t b2 = MlasLoadFloat16x4(b + 2 * ldb);
+                accu00 = vfma_lane_f16(accu00, b2, a0, 2);
+                if constexpr (CountM == 2) {
+                    accu10 = vfma_lane_f16(accu10, b2, a1, 2);
+                }
+            }
             MlasStoreFloat16x4(c, accu00);
             if constexpr (CountM == 2) {
                 MlasStoreFloat16x4(c + ldc, accu10);
@@ -2010,11 +2261,29 @@ void HGemm_B_Kernel_Simple(
         }
         if (n > 0) {
             float16x4_t accu00 = MlasLoadPartialFloat16x4(c, n);
-            float16x4_t accu10 = zero_v4;
+            float16x4_t accu10;
             if constexpr (CountM == 2) {
                 accu10 = MlasLoadPartialFloat16x4(c + ldc, n);
             }
-            ma_lane_partial_accu<CountM>(b, ldb, a0, accu00, a1, accu10, CountK, n);
+            float16x4_t b0 = MlasLoadPartialFloat16x4(b, n);
+            accu00 = vfma_lane_f16(accu00, b0, a0, 0);
+            if constexpr (CountM == 2) {
+                accu10 = vfma_lane_f16(accu10, b0, a1, 0);
+            }
+            if (CountK > 1) {
+                float16x4_t b1 = MlasLoadPartialFloat16x4(b + ldb, n);
+                accu00 = vfma_lane_f16(accu00, b1, a0, 1);
+                if constexpr (CountM == 2) {
+                    accu10 = vfma_lane_f16(accu10, b1, a1, 1);
+                }
+            }
+            if (CountK > 2) {
+                float16x4_t b2 = MlasLoadPartialFloat16x4(b + 2 * ldb, n);
+                accu00 = vfma_lane_f16(accu00, b2, a0, 2);
+                if constexpr (CountM == 2) {
+                    accu10 = vfma_lane_f16(accu10, b2, a1, 2);
+                }
+            }
             MlasStorePartialFloat16x4(c, accu00, n);
             if constexpr (CountM == 2) {
                 MlasStorePartialFloat16x4(c + ldc, accu10, n);
@@ -2079,10 +2348,163 @@ void HGemm_PackedB_Kernel_Impl(
     _mlas_fp16_ beta
 ) {
     float16x8_t alpha_v8 = MlasBroadcastFloat16x8(alpha);
-    float16x4_t alpha_v4 = MlasBroadcastFloat16x4(alpha);
     float16x8_t beta_v8 = MlasBroadcastFloat16x8(beta);
+    float16x4_t alpha_v4 = MlasBroadcastFloat16x4(alpha);
     float16x4_t beta_v4 = MlasBroadcastFloat16x4(beta);
-    for (; CountN >= 16; CountN -= 16, C += 16) {
+    for (; CountN >= 32; CountN -= 32, C += 32) {
+        const auto* a = A;
+        size_t k = CountK;
+        float16x8_t accu00 = MlasZeroFloat16x8();
+        float16x8_t accu01 = MlasZeroFloat16x8();
+        float16x8_t accu02 = MlasZeroFloat16x8();
+        float16x8_t accu03 = MlasZeroFloat16x8();
+        float16x8_t accu10, accu11, accu12, accu13;
+        if constexpr (CountM == 2) {
+            accu10 = MlasZeroFloat16x8();
+            accu11 = MlasZeroFloat16x8();
+            accu12 = MlasZeroFloat16x8();
+            accu13 = MlasZeroFloat16x8();
+        }
+        for (; k >= 4; k -= 4, a += 4, PackedB += 4 * 32) {
+            float16x4_t a0 = MlasLoadFloat16x4(a);
+            float16x8_t b00 = MlasLoadFloat16x8(PackedB);
+            float16x8_t b10 = MlasLoadFloat16x8(PackedB + 32);
+            float16x8_t b20 = MlasLoadFloat16x8(PackedB + 64);
+            float16x8_t b30 = MlasLoadFloat16x8(PackedB + 96);
+            float16x8_t b01 = MlasLoadFloat16x8(PackedB + 8);
+            float16x8_t b11 = MlasLoadFloat16x8(PackedB + 40);
+            float16x8_t b21 = MlasLoadFloat16x8(PackedB + 72);
+            float16x8_t b31 = MlasLoadFloat16x8(PackedB + 104);
+            float16x8_t b02 = MlasLoadFloat16x8(PackedB + 16);
+            float16x8_t b12 = MlasLoadFloat16x8(PackedB + 48);
+            float16x8_t b22 = MlasLoadFloat16x8(PackedB + 80);
+            float16x8_t b32 = MlasLoadFloat16x8(PackedB + 112);
+            float16x8_t b03 = MlasLoadFloat16x8(PackedB + 24);
+            float16x8_t b13 = MlasLoadFloat16x8(PackedB + 56);
+            float16x8_t b23 = MlasLoadFloat16x8(PackedB + 88);
+            float16x8_t b33 = MlasLoadFloat16x8(PackedB + 120);
+            accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
+            accu01 = maq_lane_f16_accu(accu01, b01, b11, b21, b31, a0);
+            accu02 = maq_lane_f16_accu(accu02, b02, b12, b22, b32, a0);
+            accu03 = maq_lane_f16_accu(accu03, b03, b13, b23, b33, a0);
+            if constexpr (CountM == 2) {
+                float16x4_t a1 = MlasLoadFloat16x4(a + lda);
+                accu10 = maq_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
+                accu11 = maq_lane_f16_accu(accu11, b01, b11, b21, b31, a1);
+                accu12 = maq_lane_f16_accu(accu12, b02, b12, b22, b32, a1);
+                accu13 = maq_lane_f16_accu(accu13, b03, b13, b23, b33, a1);
+            }
+        }
+
+        if (k > 0) {
+            float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1;
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadPartialFloat16x4(a + lda, k);
+            }
+            float16x8_t b00 = MlasLoadFloat16x8(PackedB);
+            float16x8_t b01 = MlasLoadFloat16x8(PackedB + 8);
+            float16x8_t b02 = MlasLoadFloat16x8(PackedB + 16);
+            float16x8_t b03 = MlasLoadFloat16x8(PackedB + 24);
+            accu00 = vfmaq_lane_f16(accu00, b00, a0, 0);
+            accu01 = vfmaq_lane_f16(accu01, b01, a0, 0);
+            accu02 = vfmaq_lane_f16(accu02, b02, a0, 0);
+            accu03 = vfmaq_lane_f16(accu03, b03, a0, 0);
+            if constexpr (CountM == 2) {
+                accu10 = vfmaq_lane_f16(accu10, b00, a1, 0);
+                accu11 = vfmaq_lane_f16(accu11, b01, a1, 0);
+                accu12 = vfmaq_lane_f16(accu12, b02, a1, 0);
+                accu13 = vfmaq_lane_f16(accu13, b03, a1, 0);
+            }
+            if (k > 1) {
+                float16x8_t b10 = MlasLoadFloat16x8(PackedB + 32);
+                float16x8_t b11 = MlasLoadFloat16x8(PackedB + 40);
+                float16x8_t b12 = MlasLoadFloat16x8(PackedB + 48);
+                float16x8_t b13 = MlasLoadFloat16x8(PackedB + 56);
+                accu00 = vfmaq_lane_f16(accu00, b10, a0, 1);
+                accu01 = vfmaq_lane_f16(accu01, b11, a0, 1);
+                accu02 = vfmaq_lane_f16(accu02, b12, a0, 1);
+                accu03 = vfmaq_lane_f16(accu03, b13, a0, 1);
+                if constexpr (CountM == 2) {
+                    accu10 = vfmaq_lane_f16(accu10, b10, a1, 1);
+                    accu11 = vfmaq_lane_f16(accu11, b11, a1, 1);
+                    accu12 = vfmaq_lane_f16(accu12, b12, a1, 1);
+                    accu13 = vfmaq_lane_f16(accu13, b13, a1, 1);
+                }
+            }
+            if (k > 2) {
+                float16x8_t b20 = MlasLoadFloat16x8(PackedB + 64);
+                float16x8_t b21 = MlasLoadFloat16x8(PackedB + 72);
+                float16x8_t b22 = MlasLoadFloat16x8(PackedB + 80);
+                float16x8_t b23 = MlasLoadFloat16x8(PackedB + 88);
+                accu00 = vfmaq_lane_f16(accu00, b20, a0, 2);
+                accu01 = vfmaq_lane_f16(accu01, b21, a0, 2);
+                accu02 = vfmaq_lane_f16(accu02, b22, a0, 2);
+                accu03 = vfmaq_lane_f16(accu03, b23, a0, 2);
+                if constexpr (CountM == 2) {
+                    accu10 = vfmaq_lane_f16(accu10, b20, a1, 2);
+                    accu11 = vfmaq_lane_f16(accu11, b21, a1, 2);
+                    accu12 = vfmaq_lane_f16(accu12, b22, a1, 2);
+                    accu13 = vfmaq_lane_f16(accu13, b23, a1, 2);
+                }
+            }
+            PackedB += k * 32;
+        }
+
+        if constexpr (beta_behavior == 1) {
+            float16x8_t c00 = MlasLoadFloat16x8(C);
+            float16x8_t c01 = MlasLoadFloat16x8(C + 8);
+            float16x8_t c02 = MlasLoadFloat16x8(C + 16);
+            float16x8_t c03 = MlasLoadFloat16x8(C + 24);
+
+            MlasStoreFloat16x8(C, vfmaq_f16(c00, accu00, alpha_v8));
+            MlasStoreFloat16x8(C + 8, vfmaq_f16(c01, accu01, alpha_v8));
+            MlasStoreFloat16x8(C + 16, vfmaq_f16(c02, accu02, alpha_v8));
+            MlasStoreFloat16x8(C + 24, vfmaq_f16(c03, accu03, alpha_v8));
+            if constexpr (CountM == 2) {
+                float16x8_t c10 = MlasLoadFloat16x8(C + ldc);
+                float16x8_t c11 = MlasLoadFloat16x8(C + ldc + 8);
+                float16x8_t c12 = MlasLoadFloat16x8(C + ldc + 16);
+                float16x8_t c13 = MlasLoadFloat16x8(C + ldc + 24);
+                MlasStoreFloat16x8(C + ldc, vfmaq_f16(c10, accu10, alpha_v8));
+                MlasStoreFloat16x8(C + ldc + 8, vfmaq_f16(c11, accu11, alpha_v8));
+                MlasStoreFloat16x8(C + ldc + 16, vfmaq_f16(c12, accu12, alpha_v8));
+                MlasStoreFloat16x8(C + ldc + 24, vfmaq_f16(c13, accu13, alpha_v8));
+            }
+        } else if constexpr (beta_behavior == 2) {
+            float16x8_t c00 = MlasLoadFloat16x8(C);
+            float16x8_t c01 = MlasLoadFloat16x8(C + 8);
+            float16x8_t c02 = MlasLoadFloat16x8(C + 16);
+            float16x8_t c03 = MlasLoadFloat16x8(C + 24);
+
+            MlasStoreFloat16x8(C, vfmaq_f16(vmulq_f16(c00, beta_v8), accu00, alpha_v8));
+            MlasStoreFloat16x8(C + 8, vfmaq_f16(vmulq_f16(c01, beta_v8), accu01, alpha_v8));
+            MlasStoreFloat16x8(C + 16, vfmaq_f16(vmulq_f16(c02, beta_v8), accu02, alpha_v8));
+            MlasStoreFloat16x8(C + 24, vfmaq_f16(vmulq_f16(c03, beta_v8), accu03, alpha_v8));
+            if constexpr (CountM == 2) {
+                float16x8_t c10 = MlasLoadFloat16x8(C + ldc);
+                float16x8_t c11 = MlasLoadFloat16x8(C + ldc + 8);
+                float16x8_t c12 = MlasLoadFloat16x8(C + ldc + 16);
+                float16x8_t c13 = MlasLoadFloat16x8(C + ldc + 24);
+                MlasStoreFloat16x8(C + ldc, vfmaq_f16(vmulq_f16(c10, beta_v8), accu10, alpha_v8));
+                MlasStoreFloat16x8(C + ldc + 8, vfmaq_f16(vmulq_f16(c11, beta_v8), accu11, alpha_v8));
+                MlasStoreFloat16x8(C + ldc + 16, vfmaq_f16(vmulq_f16(c12, beta_v8), accu12, alpha_v8));
+                MlasStoreFloat16x8(C + ldc + 24, vfmaq_f16(vmulq_f16(c13, beta_v8), accu13, alpha_v8));
+            }
+        } else {
+            MlasStoreFloat16x8(C, vmulq_f16(accu00, alpha_v8));
+            MlasStoreFloat16x8(C + 8, vmulq_f16(accu01, alpha_v8));
+            MlasStoreFloat16x8(C + 16, vmulq_f16(accu02, alpha_v8));
+            MlasStoreFloat16x8(C + 24, vmulq_f16(accu03, alpha_v8));
+            if constexpr (CountM == 2) {
+                MlasStoreFloat16x8(C + ldc, vmulq_f16(accu10, alpha_v8));
+                MlasStoreFloat16x8(C + ldc + 8, vmulq_f16(accu11, alpha_v8));
+                MlasStoreFloat16x8(C + ldc + 16, vmulq_f16(accu12, alpha_v8));
+                MlasStoreFloat16x8(C + ldc + 24, vmulq_f16(accu13, alpha_v8));
+            }
+        }
+    }
+
+    if (CountN & 16) {
         const auto* a = A;
         size_t k = CountK;
         float16x8_t accu00 = MlasZeroFloat16x8();
@@ -2091,43 +2513,16 @@ void HGemm_PackedB_Kernel_Impl(
             accu10 = MlasZeroFloat16x8();
             accu11 = MlasZeroFloat16x8();
         }
-        for (; k >= 8; k -= 8, a += 8, PackedB += 8 * 16) {
-            float16x8_t b00 = MlasLoadFloat16x8(PackedB);
-            float16x8_t b01 = MlasLoadFloat16x8(PackedB + 8);
-            float16x8_t b10 = MlasLoadFloat16x8(PackedB + 16);
-            float16x8_t b11 = MlasLoadFloat16x8(PackedB + 24);
-            float16x8_t b20 = MlasLoadFloat16x8(PackedB + 32);
-            float16x8_t b21 = MlasLoadFloat16x8(PackedB + 40);
-            float16x8_t b30 = MlasLoadFloat16x8(PackedB + 48);
-            float16x8_t b31 = MlasLoadFloat16x8(PackedB + 56);
-            float16x8_t b40 = MlasLoadFloat16x8(PackedB + 64);
-            float16x8_t b41 = MlasLoadFloat16x8(PackedB + 72);
-            float16x8_t b50 = MlasLoadFloat16x8(PackedB + 80);
-            float16x8_t b51 = MlasLoadFloat16x8(PackedB + 88);
-            float16x8_t b60 = MlasLoadFloat16x8(PackedB + 96);
-            float16x8_t b61 = MlasLoadFloat16x8(PackedB + 104);
-            float16x8_t b70 = MlasLoadFloat16x8(PackedB + 112);
-            float16x8_t b71 = MlasLoadFloat16x8(PackedB + 120);
-            float16x8_t a0 = MlasLoadFloat16x8(a);
-            accu00 = maq_laneq_f16_accu(accu00, b00, b10, b20, b30, b40, b50, b60, b70, a0);
-            accu01 = maq_laneq_f16_accu(accu01, b01, b11, b21, b31, b41, b51, b61, b71, a0);
-            if constexpr (CountM == 2) {
-                float16x8_t a1 = MlasLoadFloat16x8(a + lda);
-                accu10 = maq_laneq_f16_accu(accu10, b00, b10, b20, b30, b40, b50, b60, b70, a1);
-                accu11 = maq_laneq_f16_accu(accu11, b01, b11, b21, b31, b41, b51, b61, b71, a1);
-            }
-        }
-
-        if (k & 4) {
-            float16x8_t b00 = MlasLoadFloat16x8(PackedB);
-            float16x8_t b01 = MlasLoadFloat16x8(PackedB + 8);
-            float16x8_t b10 = MlasLoadFloat16x8(PackedB + 16);
-            float16x8_t b11 = MlasLoadFloat16x8(PackedB + 24);
-            float16x8_t b20 = MlasLoadFloat16x8(PackedB + 32);
-            float16x8_t b21 = MlasLoadFloat16x8(PackedB + 40);
-            float16x8_t b30 = MlasLoadFloat16x8(PackedB + 48);
-            float16x8_t b31 = MlasLoadFloat16x8(PackedB + 56);
+        for (; k >= 4; k -= 4, a += 4, PackedB += 4 * 16) {
             float16x4_t a0 = MlasLoadFloat16x4(a);
+            float16x8_t b00 = MlasLoadFloat16x8(PackedB);
+            float16x8_t b01 = MlasLoadFloat16x8(PackedB + 8);
+            float16x8_t b10 = MlasLoadFloat16x8(PackedB + 16);
+            float16x8_t b11 = MlasLoadFloat16x8(PackedB + 24);
+            float16x8_t b20 = MlasLoadFloat16x8(PackedB + 32);
+            float16x8_t b21 = MlasLoadFloat16x8(PackedB + 40);
+            float16x8_t b30 = MlasLoadFloat16x8(PackedB + 48);
+            float16x8_t b31 = MlasLoadFloat16x8(PackedB + 56);
             accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
             accu01 = maq_lane_f16_accu(accu01, b01, b11, b21, b31, a0);
             if constexpr (CountM == 2) {
@@ -2135,7 +2530,6 @@ void HGemm_PackedB_Kernel_Impl(
                 accu10 = maq_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
                 accu11 = maq_lane_f16_accu(accu11, b01, b11, b21, b31, a1);
             }
-            k -= 4, a += 4, PackedB += 4 * 16;
         }
 
         if (k > 0) {
@@ -2214,6 +2608,8 @@ void HGemm_PackedB_Kernel_Impl(
                 MlasStoreFloat16x8(C + ldc + 8, accu11);
             }
         }
+
+        CountN -= 16, C += 16;
     }
 
     if (CountN & 8) {
@@ -2221,43 +2617,27 @@ void HGemm_PackedB_Kernel_Impl(
         size_t k = CountK;
         float16x8_t accu00 = MlasZeroFloat16x8();
         float16x8_t accu10 = MlasZeroFloat16x8();
-        for (; k >= 8; k -= 8, a += 8, PackedB += 8 * 8) {
-            float16x8_t b0 = MlasLoadFloat16x8(PackedB);
-            float16x8_t b1 = MlasLoadFloat16x8(PackedB + 8);
-            float16x8_t b2 = MlasLoadFloat16x8(PackedB + 16);
-            float16x8_t b3 = MlasLoadFloat16x8(PackedB + 24);
-            float16x8_t b4 = MlasLoadFloat16x8(PackedB + 32);
-            float16x8_t b5 = MlasLoadFloat16x8(PackedB + 40);
-            float16x8_t b6 = MlasLoadFloat16x8(PackedB + 48);
-            float16x8_t b7 = MlasLoadFloat16x8(PackedB + 56);
-            float16x8_t a0 = MlasLoadFloat16x8(a);
-            accu00 = maq_laneq_f16_accu(accu00, b0, b1, b2, b3, b4, b5, b6, b7, a0);
-            if constexpr (CountM == 2) {
-                float16x8_t a1 = MlasLoadFloat16x8(a + lda);
-                accu10 = maq_laneq_f16_accu(accu10, b0, b1, b2, b3, b4, b5, b6, b7, a1);
-            }
-        }
-
-        if (k & 4) {
-            float16x8_t b0 = MlasLoadFloat16x8(PackedB);
-            float16x8_t b1 = MlasLoadFloat16x8(PackedB + 8);
-            float16x8_t b2 = MlasLoadFloat16x8(PackedB + 16);
-            float16x8_t b3 = MlasLoadFloat16x8(PackedB + 24);
+        for (; k >= 4; k -= 4, a += 4, PackedB += 4 * 8) {
             float16x4_t a0 = MlasLoadFloat16x4(a);
+            float16x8_t b0 = MlasLoadFloat16x8(PackedB);
+            float16x8_t b1 = MlasLoadFloat16x8(PackedB + 8);
+            float16x8_t b2 = MlasLoadFloat16x8(PackedB + 16);
+            float16x8_t b3 = MlasLoadFloat16x8(PackedB + 24);
             accu00 = maq_lane_f16_accu(accu00, b0, b1, b2, b3, a0);
             if constexpr (CountM == 2) {
                 float16x4_t a1 = MlasLoadFloat16x4(a + lda);
                 accu10 = maq_lane_f16_accu(accu10, b0, b1, b2, b3, a1);
             }
-            k -= 4, a += 4, PackedB += 4 * 8;
         }
 
         if (k > 0) {
             float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1;
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadPartialFloat16x4(a + lda, k);
+            }
             float16x8_t b0 = MlasLoadFloat16x8(PackedB);
             accu00 = vfmaq_lane_f16(accu00, b0, a0, 0);
             if constexpr (CountM == 2) {
-                a1 = MlasLoadPartialFloat16x4(a + lda, k);
                 accu10 = vfmaq_lane_f16(accu10, b0, a1, 0);
             }
             if (k > 1) {
@@ -2314,43 +2694,27 @@ void HGemm_PackedB_Kernel_Impl(
         if constexpr (CountM == 2) {
             accu1 = MlasZeroFloat16x8();
         }
-        for (; k >= 8; k -= 8, a += 8, PackedB += 8 * 8) {
-            float16x8_t b0 = MlasLoadFloat16x8(PackedB);
-            float16x8_t b1 = MlasLoadFloat16x8(PackedB + 8);
-            float16x8_t b2 = MlasLoadFloat16x8(PackedB + 16);
-            float16x8_t b3 = MlasLoadFloat16x8(PackedB + 24);
-            float16x8_t b4 = MlasLoadFloat16x8(PackedB + 32);
-            float16x8_t b5 = MlasLoadFloat16x8(PackedB + 40);
-            float16x8_t b6 = MlasLoadFloat16x8(PackedB + 48);
-            float16x8_t b7 = MlasLoadFloat16x8(PackedB + 56);
-            float16x8_t a0 = MlasLoadFloat16x8(a);
-            accu0 = maq_laneq_f16_accu(accu0, b0, b1, b2, b3, b4, b5, b6, b7, a0);
-            if constexpr (CountM == 2) {
-                float16x8_t a1 = MlasLoadFloat16x8(a + lda);
-                accu1 = maq_laneq_f16_accu(accu1, b0, b1, b2, b3, b4, b5, b6, b7, a1);
-            }
-        }
-
-        if (k & 4) {
-            float16x8_t b0 = MlasLoadFloat16x8(PackedB);
-            float16x8_t b1 = MlasLoadFloat16x8(PackedB + 8);
-            float16x8_t b2 = MlasLoadFloat16x8(PackedB + 16);
-            float16x8_t b3 = MlasLoadFloat16x8(PackedB + 24);
+        for (; k >= 4; k -= 4, a += 4, PackedB += 4 * 8) {
             float16x4_t a0 = MlasLoadFloat16x4(a);
+            float16x8_t b0 = MlasLoadFloat16x8(PackedB);
+            float16x8_t b1 = MlasLoadFloat16x8(PackedB + 8);
+            float16x8_t b2 = MlasLoadFloat16x8(PackedB + 16);
+            float16x8_t b3 = MlasLoadFloat16x8(PackedB + 24);
             accu0 = maq_lane_f16_accu(accu0, b0, b1, b2, b3, a0);
             if constexpr (CountM == 2) {
                 float16x4_t a1 = MlasLoadFloat16x4(a + lda);
                 accu1 = maq_lane_f16_accu(accu1, b0, b1, b2, b3, a1);
             }
-            k -= 4, a += 4, PackedB += 4 * 8;
         }
 
         if (k > 0) {
             float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1;
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadPartialFloat16x4(a + lda, k);
+            }
             float16x8_t b0 = MlasLoadFloat16x8(PackedB);
             accu0 = vfmaq_lane_f16(accu0, b0, a0, 0);
             if constexpr (CountM == 2) {
-                a1 = MlasLoadPartialFloat16x4(a + lda, k);
                 accu1 = vfmaq_lane_f16(accu1, b0, a1, 0);
             }
             if (k > 1) {

--- a/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm_kernel_neon_fp16.cpp
@@ -30,7 +30,10 @@ void HPackB_TransposedB_Kernel(
 ) {
     const _mlas_fp16_* B_data = reinterpret_cast<const _mlas_fp16_*>(B);
     _mlas_fp16_* PackedB_data = reinterpret_cast<_mlas_fp16_*>(PackedB);
-
+    const bool Kr0 = (CountK % 4) > 0;
+    const bool Kr1 = (CountK % 4) > 1;
+    const bool Kr2 = (CountK % 4) > 2;
+    const bool Kr3 = CountK & 4;
     for (; CountN >= 32; CountN -= 32, B_data += 32 * ldb) {
         const _mlas_fp16_* b = B_data;
         size_t k = CountK;
@@ -76,7 +79,7 @@ void HPackB_TransposedB_Kernel(
             MlasStoreFloat16x8(PackedB_data + basep + 224, v7);
         }
 
-        if (k & 4) {
+        if (Kr3) {
             size_t baseb = 0;
             size_t basep = 0;
             float16x4_t v0 = MlasLoadFloat16x4(b);
@@ -120,7 +123,7 @@ void HPackB_TransposedB_Kernel(
             k -= 4, b += 4, PackedB_data += 4 * 32;
         }
 
-        if (k > 0) {
+        if (Kr0) {
             size_t baseb = 0;
             size_t basep = 0;
             float16x4_t v0 = MlasLoadPartialFloat16x4(b, k);
@@ -136,11 +139,11 @@ void HPackB_TransposedB_Kernel(
                 Transpose4x4(v4, v5, v6, v7);
                 MlasStoreFloat16x4(PackedB_data + basep, v0);
                 MlasStoreFloat16x4(PackedB_data + basep + 4, v4);
-                if (k > 1) {
+                if (Kr1) {
                     MlasStoreFloat16x4(PackedB_data + basep + 32, v1);
                     MlasStoreFloat16x4(PackedB_data + basep + 36, v5);
                 }
-                if (k > 2) {
+                if (Kr2) {
                     MlasStoreFloat16x4(PackedB_data + basep + 64, v2);
                     MlasStoreFloat16x4(PackedB_data + basep + 68, v6);
                 }
@@ -158,11 +161,11 @@ void HPackB_TransposedB_Kernel(
             Transpose4x4(v4, v5, v6, v7);
             MlasStoreFloat16x4(PackedB_data + basep, v0);
             MlasStoreFloat16x4(PackedB_data + basep + 4, v4);
-            if (k > 1) {
+            if (Kr1) {
                 MlasStoreFloat16x4(PackedB_data + basep + 32, v1);
                 MlasStoreFloat16x4(PackedB_data + basep + 36, v5);
             }
-            if (k > 2) {
+            if (Kr2) {
                 MlasStoreFloat16x4(PackedB_data + basep + 64, v2);
                 MlasStoreFloat16x4(PackedB_data + basep + 68, v6);
             }
@@ -212,7 +215,7 @@ void HPackB_TransposedB_Kernel(
             MlasStoreFloat16x8(PackedB_data + 120, vF);
         }
 
-        if (k & 4) {
+        if (Kr3) {
             float16x4_t v0 = MlasLoadFloat16x4(b);
             float16x4_t v1 = MlasLoadFloat16x4(b + ldb);
             float16x4_t v2 = MlasLoadFloat16x4(b + 2 * ldb);
@@ -253,7 +256,7 @@ void HPackB_TransposedB_Kernel(
             k -= 4, b += 4, PackedB_data += 4 * 16;
         }
 
-        if (k > 0) {
+        if (Kr0) {
             float16x4_t v0 = MlasLoadPartialFloat16x4(b, k);
             float16x4_t v1 = MlasLoadPartialFloat16x4(b + ldb, k);
             float16x4_t v2 = MlasLoadPartialFloat16x4(b + 2 * ldb, k);
@@ -278,13 +281,13 @@ void HPackB_TransposedB_Kernel(
             MlasStoreFloat16x4(PackedB_data + 4, v4);
             MlasStoreFloat16x4(PackedB_data + 8, v8);
             MlasStoreFloat16x4(PackedB_data + 12, vC);
-            if (k > 1) {
+            if (Kr1) {
                 MlasStoreFloat16x4(PackedB_data + 16, v1);
                 MlasStoreFloat16x4(PackedB_data + 20, v5);
                 MlasStoreFloat16x4(PackedB_data + 24, v9);
                 MlasStoreFloat16x4(PackedB_data + 28, vD);
             }
-            if (k > 2) {
+            if (Kr2) {
                 MlasStoreFloat16x4(PackedB_data + 32, v2);
                 MlasStoreFloat16x4(PackedB_data + 36, v6);
                 MlasStoreFloat16x4(PackedB_data + 40, vA);
@@ -322,7 +325,7 @@ void HPackB_TransposedB_Kernel(
             MlasStoreFloat16x8(PackedB_data + 56, v7);
         }
 
-        if (k & 4) {
+        if (Kr3) {
             float16x4_t v0 = MlasLoadFloat16x4(b);
             float16x4_t v1 = MlasLoadFloat16x4(b + ldb);
             float16x4_t v2 = MlasLoadFloat16x4(b + 2 * ldb);
@@ -344,7 +347,7 @@ void HPackB_TransposedB_Kernel(
             k -= 4, b += 4, PackedB_data += 4 * 8;
         }
 
-        if (k > 0) {
+        if (Kr0) {
             float16x4_t v0 = MlasLoadPartialFloat16x4(b, k);
             float16x4_t v1 = MlasLoadPartialFloat16x4(b + ldb, k);
             float16x4_t v2 = MlasLoadPartialFloat16x4(b + 2 * ldb, k);
@@ -357,11 +360,11 @@ void HPackB_TransposedB_Kernel(
             Transpose4x4(v4, v5, v6, v7);
             MlasStoreFloat16x4(PackedB_data, v0);
             MlasStoreFloat16x4(PackedB_data + 4, v4);
-            if (k > 1) {
+            if (Kr1) {
                 MlasStoreFloat16x4(PackedB_data + 8, v1);
                 MlasStoreFloat16x4(PackedB_data + 12, v5);
             }
-            if (k > 2) {
+            if (Kr2) {
                 MlasStoreFloat16x4(PackedB_data + 16, v2);
                 MlasStoreFloat16x4(PackedB_data + 20, v6);
             }
@@ -397,7 +400,7 @@ void HPackB_TransposedB_Kernel(
             MlasStoreFloat16x8(PackedB_data + 56, v[7]);
         }
 
-        if (k & 4) {
+        if (Kr3) {
             float16x4_t v[8];
             size_t i = 0;
             for (; i < CountN; ++i) {
@@ -419,7 +422,7 @@ void HPackB_TransposedB_Kernel(
             k -= 4, b += 4, PackedB_data += 4 * 8;
         }
 
-        if (k > 0) {
+        if (Kr0) {
             float16x4_t v[8];
             size_t i = 0;
             for (; i < CountN; ++i) {
@@ -432,11 +435,11 @@ void HPackB_TransposedB_Kernel(
             Transpose4x4(v[4], v[5], v[6], v[7]);
             MlasStoreFloat16x4(PackedB_data, v[0]);
             MlasStoreFloat16x4(PackedB_data + 4, v[4]);
-            if (k > 1) {
+            if (Kr1) {
                 MlasStoreFloat16x4(PackedB_data + 8, v[1]);
                 MlasStoreFloat16x4(PackedB_data + 12, v[5]);
             }
-            if (k > 2) {
+            if (Kr2) {
                 MlasStoreFloat16x4(PackedB_data + 16, v[2]);
                 MlasStoreFloat16x4(PackedB_data + 20, v[6]);
             }
@@ -591,6 +594,11 @@ void HGemm_TransposedB_Kernel_Impl(
     _mlas_fp16_ alpha,
     _mlas_fp16_ beta
 ) {
+    const bool largeK = CountK >= 8;
+    const bool Kr0 = (CountK & 3);
+    const bool Kr1 = (CountK & 3) > 1;
+    const bool Kr2 = (CountK & 3) > 2;
+    const bool Kr3 = (CountK & 4);
     for (; CountN >= 8; CountN -= 8, B_data += 8 * ldb, C_data += 8) {
         const auto* a = A_data;
         const auto* b = B_data;
@@ -614,7 +622,7 @@ void HGemm_TransposedB_Kernel_Impl(
             accu16 = MlasZeroFloat16x8();
             accu17 = MlasZeroFloat16x8();
         }
-        for (; k >= 8; k -= 8, a += 8, b += 8) {
+        if (largeK) {
             float16x8_t b0 = MlasLoadFloat16x8(b);
             float16x8_t b1 = MlasLoadFloat16x8(b + ldb);
             float16x8_t b2 = MlasLoadFloat16x8(b + 2 * ldb);
@@ -624,6 +632,36 @@ void HGemm_TransposedB_Kernel_Impl(
             float16x8_t b6 = MlasLoadFloat16x8(b + 6 * ldb);
             float16x8_t b7 = MlasLoadFloat16x8(b + 7 * ldb);
             float16x8_t a0 = MlasLoadFloat16x8(a);
+            for (; k >= 16; k -= 8, a += 8, b += 8) {
+                accu00 = vfmaq_f16(accu00, b0, a0);
+                accu01 = vfmaq_f16(accu01, b1, a0);
+                accu02 = vfmaq_f16(accu02, b2, a0);
+                accu03 = vfmaq_f16(accu03, b3, a0);
+                accu04 = vfmaq_f16(accu04, b4, a0);
+                accu05 = vfmaq_f16(accu05, b5, a0);
+                accu06 = vfmaq_f16(accu06, b6, a0);
+                accu07 = vfmaq_f16(accu07, b7, a0);
+                if constexpr (CountM == 2) {
+                    float16x8_t a1 = MlasLoadFloat16x8(a + lda);
+                    accu10 = vfmaq_f16(accu10, b0, a1);
+                    accu11 = vfmaq_f16(accu11, b1, a1);
+                    accu12 = vfmaq_f16(accu12, b2, a1);
+                    accu13 = vfmaq_f16(accu13, b3, a1);
+                    accu14 = vfmaq_f16(accu14, b4, a1);
+                    accu15 = vfmaq_f16(accu15, b5, a1);
+                    accu16 = vfmaq_f16(accu16, b6, a1);
+                    accu17 = vfmaq_f16(accu17, b7, a1);
+                }
+                b0 = MlasLoadFloat16x8(b + 8);
+                b1 = MlasLoadFloat16x8(b + 8 + ldb);
+                b2 = MlasLoadFloat16x8(b + 8 + 2 * ldb);
+                b3 = MlasLoadFloat16x8(b + 8 + 3 * ldb);
+                b4 = MlasLoadFloat16x8(b + 8 + 4 * ldb);
+                b5 = MlasLoadFloat16x8(b + 8 + 5 * ldb);
+                b6 = MlasLoadFloat16x8(b + 8 + 6 * ldb);
+                b7 = MlasLoadFloat16x8(b + 8 + 7 * ldb);
+                a0 = MlasLoadFloat16x8(a + 8);
+            }
             accu00 = vfmaq_f16(accu00, b0, a0);
             accu01 = vfmaq_f16(accu01, b1, a0);
             accu02 = vfmaq_f16(accu02, b2, a0);
@@ -643,7 +681,7 @@ void HGemm_TransposedB_Kernel_Impl(
                 accu16 = vfmaq_f16(accu16, b6, a1);
                 accu17 = vfmaq_f16(accu17, b7, a1);
             }
-
+            k -= 8, a += 8, b += 8;
         }
         Transpose8x8(accu00, accu01, accu02, accu03, accu04, accu05, accu06, accu07);
         accu00 = addq_f16x8(accu00, accu01, accu02, accu03, accu04, accu05, accu06, accu07);
@@ -652,7 +690,7 @@ void HGemm_TransposedB_Kernel_Impl(
             accu10 = addq_f16x8(accu10, accu11, accu12, accu13, accu14, accu15, accu16, accu17);
         }
 
-        if (k & 4) {
+        if (Kr3) {
             float16x4_t b0 = MlasLoadFloat16x4(b);
             float16x4_t b1 = MlasLoadFloat16x4(b + ldb);
             float16x4_t b2 = MlasLoadFloat16x4(b + 2 * ldb);
@@ -676,7 +714,7 @@ void HGemm_TransposedB_Kernel_Impl(
             k -= 4, a += 4, b += 4;
         }
 
-        if (k > 0) {
+        if (Kr0) {
             float16x4_t b0 = MlasLoadPartialFloat16x4(b, k);
             float16x4_t b1 = MlasLoadPartialFloat16x4(b + ldb, k);
             float16x4_t b2 = MlasLoadPartialFloat16x4(b + 2 * ldb, k);
@@ -694,14 +732,14 @@ void HGemm_TransposedB_Kernel_Impl(
                 a1 = MlasLoadPartialFloat16x4(a + lda, k);
                 accu10 = vfmaq_lane_f16(accu10, v0, a1, 0);
             }
-            if (k > 1) {
+            if (Kr1) {
                 float16x8_t v1 = vcombine_f16(b1, b5);
                 accu00 = vfmaq_lane_f16(accu00, v1, a0, 1);
                 if constexpr (CountM == 2) {
                     accu10 = vfmaq_lane_f16(accu10, v1, a1, 1);
                 }
             }
-            if (k > 2) {
+            if (Kr2) {
                 float16x8_t v2 = vcombine_f16(b2, b6);
                 accu00 = vfmaq_lane_f16(accu00, v2, a0, 2);
                 if constexpr (CountM == 2) {
@@ -757,12 +795,30 @@ void HGemm_TransposedB_Kernel_Impl(
             accu12 = MlasZeroFloat16x8();
             accu13 = MlasZeroFloat16x8();
         }
-        for (; k >= 8; k -= 8, a += 8, b += 8) {
+        if (largeK) {
             float16x8_t b0 = MlasLoadFloat16x8(b);
             float16x8_t b1 = MlasLoadFloat16x8(b + ldb);
             float16x8_t b2 = MlasLoadFloat16x8(b + 2 * ldb);
             float16x8_t b3 = MlasLoadFloat16x8(b + 3 * ldb);
             float16x8_t a0 = MlasLoadFloat16x8(a);
+            for (; k >= 16; k -= 8, a += 8, b += 8) {
+                accu00 = vfmaq_f16(accu00, b0, a0);
+                accu01 = vfmaq_f16(accu01, b1, a0);
+                accu02 = vfmaq_f16(accu02, b2, a0);
+                accu03 = vfmaq_f16(accu03, b3, a0);
+                if constexpr (CountM == 2) {
+                    float16x8_t a1 = MlasLoadFloat16x8(a + lda);
+                    accu10 = vfmaq_f16(accu10, b0, a1);
+                    accu11 = vfmaq_f16(accu11, b1, a1);
+                    accu12 = vfmaq_f16(accu12, b2, a1);
+                    accu13 = vfmaq_f16(accu13, b3, a1);
+                }
+                b0 = MlasLoadFloat16x8(b + 8);
+                b1 = MlasLoadFloat16x8(b + 8 + ldb);
+                b2 = MlasLoadFloat16x8(b + 8 + 2 * ldb);
+                b3 = MlasLoadFloat16x8(b + 8 + 3 * ldb);
+                a0 = MlasLoadFloat16x8(a + 8);
+            }
             accu00 = vfmaq_f16(accu00, b0, a0);
             accu01 = vfmaq_f16(accu01, b1, a0);
             accu02 = vfmaq_f16(accu02, b2, a0);
@@ -774,6 +830,7 @@ void HGemm_TransposedB_Kernel_Impl(
                 accu12 = vfmaq_f16(accu12, b2, a1);
                 accu13 = vfmaq_f16(accu13, b3, a1);
             }
+            k -= 8, a += 8, b += 8;
         }
         Transpose4x8(accu00, accu01, accu02, accu03);
         accu00 = addq_f16x4(accu00, accu01, accu02, accu03);
@@ -784,7 +841,7 @@ void HGemm_TransposedB_Kernel_Impl(
             accu1 = vadd_f16(vget_low_f16(accu10), vget_high_f16(accu10));
         }
 
-        if (k & 4) {
+        if (Kr3) {
             float16x4_t b0 = MlasLoadFloat16x4(b);
             float16x4_t b1 = MlasLoadFloat16x4(b + ldb);
             float16x4_t b2 = MlasLoadFloat16x4(b + 2 * ldb);
@@ -799,7 +856,7 @@ void HGemm_TransposedB_Kernel_Impl(
             k -= 4, a += 4, b += 4;
         }
 
-        if (k > 0) {
+        if (Kr0) {
             float16x4_t b0 = MlasLoadPartialFloat16x4(b, k);
             float16x4_t b1 = MlasLoadPartialFloat16x4(b + ldb, k);
             float16x4_t b2 = MlasLoadPartialFloat16x4(b + 2 * ldb, k);
@@ -811,13 +868,13 @@ void HGemm_TransposedB_Kernel_Impl(
                 a1 = MlasLoadPartialFloat16x4(a + lda, k);
                 accu1 = vfma_lane_f16(accu1, b0, a1, 0);
             }
-            if (k > 1) {
+            if (Kr1) {
                 accu0 = vfma_lane_f16(accu0, b1, a0, 1);
                 if constexpr (CountM == 2) {
                     accu1 = vfma_lane_f16(accu1, b1, a1, 1);
                 }
             }
-            if (k > 2) {
+            if (Kr2) {
                 accu0 = vfma_lane_f16(accu0, b2, a0, 2);
                 if constexpr (CountM == 2) {
                     accu1 = vfma_lane_f16(accu1, b2, a1, 2);
@@ -893,7 +950,7 @@ void HGemm_TransposedB_Kernel_Impl(
             accu_1 = vadd_f16(vget_low_f16(accu10), vget_high_f16(accu10));
         }
 
-        if (k & 4) {
+        if (Kr3) {
             float16x4_t bs[4];
             for (i = 0; i < CountN; ++i) {
                 bs[i] = MlasLoadFloat16x4(b + i * ldb);
@@ -911,7 +968,7 @@ void HGemm_TransposedB_Kernel_Impl(
             k -= 4, a += 4, b += 4;
         }
 
-        if (k > 0) {
+        if (Kr0) {
             float16x4_t bs[4];
             for (i = 0; i < CountN; ++i) {
                 bs[i] = MlasLoadPartialFloat16x4(b + i * ldb, k);
@@ -926,13 +983,13 @@ void HGemm_TransposedB_Kernel_Impl(
                 a1 = MlasLoadPartialFloat16x4(a + lda, k);
                 accu_1 = vfma_lane_f16(accu_1, bs[0], a1, 0);
             }
-            if (k > 1) {
+            if (Kr1) {
                 accu_0 = vfma_lane_f16(accu_0, bs[1], a0, 1);
                 if constexpr (CountM == 2) {
                     accu_1 = vfma_lane_f16(accu_1, bs[1], a1, 1);
                 }
             }
-            if (k > 2) {
+            if (Kr2) {
                 accu_0 = vfma_lane_f16(accu_0, bs[2], a0, 2);
                 if constexpr (CountM == 2) {
                     accu_1 = vfma_lane_f16(accu_1, bs[2], a1, 2);
@@ -1033,6 +1090,10 @@ void HGemm_B_Kernel_Complicated(
     float16x8_t beta_v8 = MlasBroadcastFloat16x8(beta);
     float16x4_t alpha_v4 = MlasBroadcastFloat16x4(alpha);
     float16x4_t beta_v4 = MlasBroadcastFloat16x4(beta);
+    const bool largeK = CountK >= 4;
+    const bool Kr0 = CountK & 3;
+    const bool Kr1 = (CountK & 3 ) > 1;
+    const bool Kr2 = (CountK & 3 ) > 2;
     for (; CountN >= 32; CountN -= 32, B_data += 32, C_data += 32) {
         const auto* a = A_data;
         const auto* b = B_data;
@@ -1048,7 +1109,7 @@ void HGemm_B_Kernel_Complicated(
             accu12 = MlasZeroFloat16x8();
             accu13 = MlasZeroFloat16x8();
         }
-        for (; k >= 4; k -= 4, a += 4, b += ldb4) {
+        if (largeK) {
             float16x4_t a0 = MlasLoadFloat16x4(a), a1;
             if constexpr (CountM == 2) {
                 a1 = MlasLoadFloat16x4(a + lda);
@@ -1057,21 +1118,53 @@ void HGemm_B_Kernel_Complicated(
             float16x8_t b10 = MlasLoadFloat16x8(b + ldb);
             float16x8_t b20 = MlasLoadFloat16x8(b + 2 * ldb);
             float16x8_t b30 = MlasLoadFloat16x8(b + 3 * ldb);
-            accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
             float16x8_t b01 = MlasLoadFloat16x8(b + 8);
             float16x8_t b11 = MlasLoadFloat16x8(b + ldb + 8);
             float16x8_t b21 = MlasLoadFloat16x8(b + 2 * ldb + 8);
             float16x8_t b31 = MlasLoadFloat16x8(b + 3 * ldb + 8);
-            accu01 = maq_lane_f16_accu(accu01, b01, b11, b21, b31, a0);
             float16x8_t b02 = MlasLoadFloat16x8(b + 16);
             float16x8_t b12 = MlasLoadFloat16x8(b + ldb + 16);
             float16x8_t b22 = MlasLoadFloat16x8(b + 2 * ldb + 16);
             float16x8_t b32 = MlasLoadFloat16x8(b + 3 * ldb + 16);
-            accu02 = maq_lane_f16_accu(accu02, b02, b12, b22, b32, a0);
             float16x8_t b03 = MlasLoadFloat16x8(b + 24);
             float16x8_t b13 = MlasLoadFloat16x8(b + ldb + 24);
             float16x8_t b23 = MlasLoadFloat16x8(b + 2 * ldb + 24);
             float16x8_t b33 = MlasLoadFloat16x8(b + 3 * ldb + 24);
+            for (; k >= 8; k -= 4, a += 4, b += ldb4) {
+                accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
+                accu01 = maq_lane_f16_accu(accu01, b01, b11, b21, b31, a0);
+                accu02 = maq_lane_f16_accu(accu02, b02, b12, b22, b32, a0);
+                accu03 = maq_lane_f16_accu(accu03, b03, b13, b23, b33, a0);
+                if constexpr (CountM == 2) {
+                    accu10 = maq_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
+                    accu11 = maq_lane_f16_accu(accu11, b01, b11, b21, b31, a1);
+                    accu12 = maq_lane_f16_accu(accu12, b02, b12, b22, b32, a1);
+                    accu13 = maq_lane_f16_accu(accu13, b03, b13, b23, b33, a1);
+                }
+                a0 = MlasLoadFloat16x4(a + 4);
+                if constexpr (CountM == 2) {
+                    a1 = MlasLoadFloat16x4(a + 4 + lda);
+                }
+                b00 = MlasLoadFloat16x8(b + ldb4);
+                b10 = MlasLoadFloat16x8(b + 5 * ldb);
+                b20 = MlasLoadFloat16x8(b + 6 * ldb);
+                b30 = MlasLoadFloat16x8(b + 7 * ldb);
+                b01 = MlasLoadFloat16x8(b + ldb4 + 8);
+                b11 = MlasLoadFloat16x8(b + 5 * ldb + 8);
+                b21 = MlasLoadFloat16x8(b + 6 * ldb + 8);
+                b31 = MlasLoadFloat16x8(b + 7 * ldb + 8);
+                b02 = MlasLoadFloat16x8(b + ldb4 + 16);
+                b12 = MlasLoadFloat16x8(b + 5 * ldb + 16);
+                b22 = MlasLoadFloat16x8(b + 6 * ldb + 16);
+                b32 = MlasLoadFloat16x8(b + 7 * ldb + 16);
+                b03 = MlasLoadFloat16x8(b + ldb4 + 24);
+                b13 = MlasLoadFloat16x8(b + 5 * ldb + 24);
+                b23 = MlasLoadFloat16x8(b + 6 * ldb + 24);
+                b33 = MlasLoadFloat16x8(b + 7 * ldb + 24);
+            }
+            accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
+            accu01 = maq_lane_f16_accu(accu01, b01, b11, b21, b31, a0);
+            accu02 = maq_lane_f16_accu(accu02, b02, b12, b22, b32, a0);
             accu03 = maq_lane_f16_accu(accu03, b03, b13, b23, b33, a0);
             if constexpr (CountM == 2) {
                 accu10 = maq_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
@@ -1079,9 +1172,10 @@ void HGemm_B_Kernel_Complicated(
                 accu12 = maq_lane_f16_accu(accu12, b02, b12, b22, b32, a1);
                 accu13 = maq_lane_f16_accu(accu13, b03, b13, b23, b33, a1);
             }
+            k -= 4, a += 4, b += ldb4;
         }
 
-        if (k > 0) {
+        if (Kr0) {
             float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1;
             if constexpr (CountM == 2) {
                 a1 = MlasLoadPartialFloat16x4(a + lda, k);
@@ -1100,7 +1194,7 @@ void HGemm_B_Kernel_Complicated(
                 accu12 = vfmaq_lane_f16(accu12, b02, a1, 0);
                 accu13 = vfmaq_lane_f16(accu13, b03, a1, 0);
             }
-            if (k > 1) {
+            if (Kr1) {
                 float16x8_t b10 = MlasLoadFloat16x8(b + ldb);
                 float16x8_t b11 = MlasLoadFloat16x8(b + ldb + 8);
                 float16x8_t b12 = MlasLoadFloat16x8(b + ldb + 16);
@@ -1116,7 +1210,7 @@ void HGemm_B_Kernel_Complicated(
                     accu13 = vfmaq_lane_f16(accu13, b13, a1, 1);
                 }
             }
-            if (k > 2) {
+            if (Kr2) {
                 float16x8_t b20 = MlasLoadFloat16x8(b + 2 * ldb);
                 float16x8_t b21 = MlasLoadFloat16x8(b + 2 * ldb + 8);
                 float16x8_t b22 = MlasLoadFloat16x8(b + 2 * ldb + 16);
@@ -1165,7 +1259,7 @@ void HGemm_B_Kernel_Complicated(
             accu10 = MlasZeroFloat16x8();
             accu11 = MlasZeroFloat16x8();
         }
-        for (; k >= 4; k -= 4, a += 4, b += ldb4) {
+        if (largeK) {
             float16x4_t a0 = MlasLoadFloat16x4(a), a1;
             if constexpr (CountM == 2) {
                 a1 = MlasLoadFloat16x4(a + lda);
@@ -1174,19 +1268,41 @@ void HGemm_B_Kernel_Complicated(
             float16x8_t b10 = MlasLoadFloat16x8(b + ldb);
             float16x8_t b20 = MlasLoadFloat16x8(b + 2 * ldb);
             float16x8_t b30 = MlasLoadFloat16x8(b + 3 * ldb);
-            accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
             float16x8_t b01 = MlasLoadFloat16x8(b + 8);
             float16x8_t b11 = MlasLoadFloat16x8(b + ldb + 8);
             float16x8_t b21 = MlasLoadFloat16x8(b + 2 * ldb + 8);
             float16x8_t b31 = MlasLoadFloat16x8(b + 3 * ldb + 8);
+            for (; k >= 8; k -= 4, a += 4, b += ldb4) {
+                accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
+                accu01 = maq_lane_f16_accu(accu01, b01, b11, b21, b31, a0);
+                if constexpr (CountM == 2) {
+                    accu10 = maq_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
+                    accu11 = maq_lane_f16_accu(accu11, b01, b11, b21, b31, a1);
+                }
+                a0 = MlasLoadFloat16x4(a + 4);
+                if constexpr (CountM == 2) {
+                    a1 = MlasLoadFloat16x4(a + 4 + lda);
+                }
+                b00 = MlasLoadFloat16x8(b + ldb4);
+                b10 = MlasLoadFloat16x8(b + 5 * ldb);
+                b20 = MlasLoadFloat16x8(b + 6 * ldb);
+                b30 = MlasLoadFloat16x8(b + 7 * ldb);
+                b01 = MlasLoadFloat16x8(b + ldb4 + 8);
+                b11 = MlasLoadFloat16x8(b + 5 * ldb + 8);
+                b21 = MlasLoadFloat16x8(b + 6 * ldb + 8);
+                b31 = MlasLoadFloat16x8(b + 7 * ldb + 8);
+
+            }
+            accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
             accu01 = maq_lane_f16_accu(accu01, b01, b11, b21, b31, a0);
             if constexpr (CountM == 2) {
                 accu10 = maq_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
                 accu11 = maq_lane_f16_accu(accu11, b01, b11, b21, b31, a1);
             }
+            k -= 4, a += 4, b += ldb4;
         }
 
-        if (k > 0) {
+        if (Kr0) {
             float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1;
             if constexpr (CountM == 2) {
                 a1 = MlasLoadPartialFloat16x4(a + lda, k);
@@ -1199,7 +1315,7 @@ void HGemm_B_Kernel_Complicated(
                 accu10 = vfmaq_lane_f16(accu10, b00, a1, 0);
                 accu11 = vfmaq_lane_f16(accu11, b01, a1, 0);
             }
-            if (k > 1) {
+            if (Kr1) {
                 float16x8_t b10 = MlasLoadFloat16x8(b + ldb);
                 float16x8_t b11 = MlasLoadFloat16x8(b + ldb + 8);
                 accu00 = vfmaq_lane_f16(accu00, b10, a0, 1);
@@ -1209,7 +1325,7 @@ void HGemm_B_Kernel_Complicated(
                     accu11 = vfmaq_lane_f16(accu11, b11, a1, 1);
                 }
             }
-            if (k > 2) {
+            if (Kr2) {
                 float16x8_t b20 = MlasLoadFloat16x8(b + 2 * ldb);
                 float16x8_t b21 = MlasLoadFloat16x8(b + 2 * ldb + 8);
                 accu00 = vfmaq_lane_f16(accu00, b20, a0, 2);
@@ -1244,7 +1360,7 @@ void HGemm_B_Kernel_Complicated(
         if constexpr (CountM == 2) {
             accu10 = MlasZeroFloat16x8();
         }
-        for (; k >= 4; k -= 4, a += 4, b += ldb4) {
+        if (largeK) {
             float16x4_t a0 = MlasLoadFloat16x4(a), a1;
             if constexpr (CountM == 2) {
                 a1 = MlasLoadFloat16x4(a + lda);
@@ -1253,13 +1369,28 @@ void HGemm_B_Kernel_Complicated(
             float16x8_t b10 = MlasLoadFloat16x8(b + ldb);
             float16x8_t b20 = MlasLoadFloat16x8(b + 2 * ldb);
             float16x8_t b30 = MlasLoadFloat16x8(b + 3 * ldb);
+            for (; k >= 8; k -= 4, a += 4, b += ldb4) {
+                accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
+                if constexpr (CountM == 2) {
+                    accu10 = maq_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
+                }
+                a0 = MlasLoadFloat16x4(a + 4);
+                if constexpr (CountM == 2) {
+                    a1 = MlasLoadFloat16x4(a + 4 + lda);
+                }
+                b00 = MlasLoadFloat16x8(b + ldb4);
+                b10 = MlasLoadFloat16x8(b + 5 * ldb);
+                b20 = MlasLoadFloat16x8(b + 6 * ldb);
+                b30 = MlasLoadFloat16x8(b + 7 * ldb);
+            }
             accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
             if constexpr (CountM == 2) {
                 accu10 = maq_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
             }
+            k -= 4, a += 4, b += ldb4;
         }
 
-        if (k > 0) {
+        if (Kr0) {
             float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1;
             if constexpr (CountM == 2) {
                 a1 = MlasLoadPartialFloat16x4(a + lda, k);
@@ -1269,14 +1400,14 @@ void HGemm_B_Kernel_Complicated(
             if constexpr (CountM == 2) {
                 accu10 = vfmaq_lane_f16(accu10, b00, a1, 0);
             }
-            if (k > 1) {
+            if (Kr1) {
                 float16x8_t b10 = MlasLoadFloat16x8(b + ldb);
                 accu00 = vfmaq_lane_f16(accu00, b10, a0, 1);
                 if constexpr (CountM == 2) {
                     accu10 = vfmaq_lane_f16(accu10, b10, a1, 1);
                 }
             }
-            if (k > 2) {
+            if (Kr2) {
                 float16x8_t b20 = MlasLoadFloat16x8(b + 2 * ldb);
                 accu00 = vfmaq_lane_f16(accu00, b20, a0, 2);
                 if constexpr (CountM == 2) {
@@ -1304,7 +1435,7 @@ void HGemm_B_Kernel_Complicated(
         if constexpr (CountM == 2) {
             accu10 = MlasZeroFloat16x4();
         }
-        for (; k >= 4; k -= 4, a += 4, b += ldb4) {
+        if (largeK) {
             float16x4_t a0 = MlasLoadFloat16x4(a), a1;
             if constexpr (CountM == 2) {
                 a1 = MlasLoadFloat16x4(a + lda);
@@ -1313,13 +1444,28 @@ void HGemm_B_Kernel_Complicated(
             float16x4_t b10 = MlasLoadFloat16x4(b + ldb);
             float16x4_t b20 = MlasLoadFloat16x4(b + 2 * ldb);
             float16x4_t b30 = MlasLoadFloat16x4(b + 3 * ldb);
+            for (; k >= 8; k -= 4, a += 4, b += ldb4) {
+                accu00 = ma_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
+                if constexpr (CountM == 2) {
+                    accu10 = ma_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
+                }
+                a0 = MlasLoadFloat16x4(a + 4);
+                if constexpr (CountM == 2) {
+                    a1 = MlasLoadFloat16x4(a + 4 + lda);
+                }
+                b00 = MlasLoadFloat16x4(b + ldb4);
+                b10 = MlasLoadFloat16x4(b + 5 * ldb);
+                b20 = MlasLoadFloat16x4(b + 6 * ldb);
+                b30 = MlasLoadFloat16x4(b + 7 * ldb);
+            }
             accu00 = ma_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
             if constexpr (CountM == 2) {
                 accu10 = ma_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
             }
+            k -= 4, a += 4, b += ldb4;
         }
 
-        if (k > 0) {
+        if (Kr0) {
             float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1;
             if constexpr (CountM == 2) {
                 a1 = MlasLoadPartialFloat16x4(a + lda, k);
@@ -1329,14 +1475,14 @@ void HGemm_B_Kernel_Complicated(
             if constexpr (CountM == 2) {
                 accu10 = vfma_lane_f16(accu10, b00, a1, 0);
             }
-            if (k > 1) {
+            if (Kr1) {
                 float16x4_t b10 = MlasLoadFloat16x4(b + ldb);
                 accu00 = vfma_lane_f16(accu00, b10, a0, 1);
                 if constexpr (CountM == 2) {
                     accu10 = vfma_lane_f16(accu10, b10, a1, 1);
                 }
             }
-            if (k > 2) {
+            if (Kr2) {
                 float16x4_t b20 = MlasLoadFloat16x4(b + 2 * ldb);
                 accu00 = vfma_lane_f16(accu00, b20, a0, 2);
                 if constexpr (CountM == 2) {
@@ -1364,7 +1510,7 @@ void HGemm_B_Kernel_Complicated(
         if constexpr (CountM == 2) {
             accu10 = MlasZeroFloat16x4();
         }
-        for (; k >= 4; k -= 4, a += 4, b += ldb4) {
+        if (largeK) {
             float16x4_t a0 = MlasLoadFloat16x4(a), a1;
             if constexpr (CountM == 2) {
                 a1 = MlasLoadFloat16x4(a + lda);
@@ -1373,13 +1519,28 @@ void HGemm_B_Kernel_Complicated(
             float16x4_t b10 = MlasLoadPartialFloat16x4(b + ldb, CountN);
             float16x4_t b20 = MlasLoadPartialFloat16x4(b + 2 * ldb, CountN);
             float16x4_t b30 = MlasLoadPartialFloat16x4(b + 3 * ldb, CountN);
+            for (; k >= 8; k -= 4, a += 4, b += ldb4) {
+                accu00 = ma_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
+                if constexpr (CountM == 2) {
+                    accu10 = ma_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
+                }
+                a0 = MlasLoadFloat16x4(a + 4);
+                if constexpr (CountM == 2) {
+                    a1 = MlasLoadFloat16x4(a + 4 + lda);
+                }
+                b00 = MlasLoadPartialFloat16x4(b + ldb4, CountN);
+                b10 = MlasLoadPartialFloat16x4(b + 5 * ldb, CountN);
+                b20 = MlasLoadPartialFloat16x4(b + 6 * ldb, CountN);
+                b30 = MlasLoadPartialFloat16x4(b + 7 * ldb, CountN);
+            }
             accu00 = ma_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
             if constexpr (CountM == 2) {
                 accu10 = ma_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
             }
+            k -= 4, a += 4, b += ldb4;
         }
 
-        if (k > 0) {
+        if (Kr0) {
             float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1;
             if constexpr (CountM == 2) {
                 a1 = MlasLoadPartialFloat16x4(a + lda, k);
@@ -1389,14 +1550,14 @@ void HGemm_B_Kernel_Complicated(
             if constexpr (CountM == 2) {
                 accu10 = vfma_lane_f16(accu10, b00, a1, 0);
             }
-            if (k > 1) {
+            if (Kr1) {
                 float16x4_t b10 = MlasLoadPartialFloat16x4(b + ldb, CountN);
                 accu00 = vfma_lane_f16(accu00, b10, a0, 1);
                 if constexpr (CountM == 2) {
                     accu10 = vfma_lane_f16(accu10, b10, a1, 1);
                 }
             }
-            if (k > 2) {
+            if (Kr2) {
                 float16x4_t b20 = MlasLoadPartialFloat16x4(b + 2 * ldb, CountN);
                 accu00 = vfma_lane_f16(accu00, b20, a0, 2);
                 if constexpr (CountM == 2) {
@@ -1427,6 +1588,10 @@ void HGemm_B_Kernel_Simple(
     size_t ldc
 ) {
     const size_t ldb4 = ldb * 4;
+    const bool largeN = CountN >= 32;
+    const bool Nr0 = (CountN % 4) > 0;
+    const bool Kr1 = (CountK % 4) > 1;
+    const bool Kr2 = (CountK % 4) > 2;
     if constexpr (zero_mode) {
         // process first K
         if (CountK >= 4) {
@@ -1437,11 +1602,7 @@ void HGemm_B_Kernel_Simple(
             size_t n = CountN;
             const auto* b = B_data;
             auto* c = C_data;
-            for (; n >= 32; n -= 32, b += 32, c += 32) {
-                float16x8_t accu00 = MlasZeroFloat16x8();
-                float16x8_t accu01 = MlasZeroFloat16x8();
-                float16x8_t accu02 = MlasZeroFloat16x8();
-                float16x8_t accu03 = MlasZeroFloat16x8();
+            if (largeN) {
                 float16x8_t b00 = MlasLoadFloat16x8(b);
                 float16x8_t b10 = MlasLoadFloat16x8(b + ldb);
                 float16x8_t b20 = MlasLoadFloat16x8(b + 2 * ldb);
@@ -1458,6 +1619,54 @@ void HGemm_B_Kernel_Simple(
                 float16x8_t b13 = MlasLoadFloat16x8(b + ldb + 24);
                 float16x8_t b23 = MlasLoadFloat16x8(b + 2 * ldb + 24);
                 float16x8_t b33 = MlasLoadFloat16x8(b + 3 * ldb + 24);
+                for (; n >= 64; n -= 32, b += 32, c += 32) {
+                    float16x8_t accu00 = MlasZeroFloat16x8();
+                    float16x8_t accu01 = MlasZeroFloat16x8();
+                    float16x8_t accu02 = MlasZeroFloat16x8();
+                    float16x8_t accu03 = MlasZeroFloat16x8();
+                    accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
+                    accu01 = maq_lane_f16_accu(accu01, b01, b11, b21, b31, a0);
+                    accu02 = maq_lane_f16_accu(accu02, b02, b12, b22, b32, a0);
+                    accu03 = maq_lane_f16_accu(accu03, b03, b13, b23, b33, a0);
+                    MlasStoreFloat16x8(c, accu00);
+                    MlasStoreFloat16x8(c + 8, accu01);
+                    MlasStoreFloat16x8(c + 16, accu02);
+                    MlasStoreFloat16x8(c + 24, accu03);
+                    if constexpr (CountM == 2) {
+                        float16x8_t accu10 = MlasZeroFloat16x8();
+                        float16x8_t accu11 = MlasZeroFloat16x8();
+                        float16x8_t accu12 = MlasZeroFloat16x8();
+                        float16x8_t accu13 = MlasZeroFloat16x8();
+                        accu10 = maq_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
+                        accu11 = maq_lane_f16_accu(accu11, b01, b11, b21, b31, a1);
+                        accu12 = maq_lane_f16_accu(accu12, b02, b12, b22, b32, a1);
+                        accu13 = maq_lane_f16_accu(accu13, b03, b13, b23, b33, a1);
+                        MlasStoreFloat16x8(c + ldc, accu10);
+                        MlasStoreFloat16x8(c + ldc + 8, accu11);
+                        MlasStoreFloat16x8(c + ldc + 16, accu12);
+                        MlasStoreFloat16x8(c + ldc + 24, accu13);
+                    }
+                    b00 = MlasLoadFloat16x8(b + 32);
+                    b10 = MlasLoadFloat16x8(b + ldb + 32);
+                    b20 = MlasLoadFloat16x8(b + 2 * ldb + 32);
+                    b30 = MlasLoadFloat16x8(b + 3 * ldb + 32);
+                    b01 = MlasLoadFloat16x8(b + 40);
+                    b11 = MlasLoadFloat16x8(b + ldb + 40);
+                    b21 = MlasLoadFloat16x8(b + 2 * ldb + 40);
+                    b31 = MlasLoadFloat16x8(b + 3 * ldb + 40);
+                    b02 = MlasLoadFloat16x8(b + 48);
+                    b12 = MlasLoadFloat16x8(b + ldb + 48);
+                    b22 = MlasLoadFloat16x8(b + 2 * ldb + 48);
+                    b32 = MlasLoadFloat16x8(b + 3 * ldb + 48);
+                    b03 = MlasLoadFloat16x8(b + 56);
+                    b13 = MlasLoadFloat16x8(b + ldb + 56);
+                    b23 = MlasLoadFloat16x8(b + 2 * ldb + 56);
+                    b33 = MlasLoadFloat16x8(b + 3 * ldb + 56);
+                }
+                float16x8_t accu00 = MlasZeroFloat16x8();
+                float16x8_t accu01 = MlasZeroFloat16x8();
+                float16x8_t accu02 = MlasZeroFloat16x8();
+                float16x8_t accu03 = MlasZeroFloat16x8();
                 accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
                 accu01 = maq_lane_f16_accu(accu01, b01, b11, b21, b31, a0);
                 accu02 = maq_lane_f16_accu(accu02, b02, b12, b22, b32, a0);
@@ -1480,6 +1689,7 @@ void HGemm_B_Kernel_Simple(
                     MlasStoreFloat16x8(c + ldc + 16, accu12);
                     MlasStoreFloat16x8(c + ldc + 24, accu13);
                 }
+                n -= 32, b += 32, c += 32;
             }
             if (n & 16) {
                 float16x8_t accu00 = MlasZeroFloat16x8();
@@ -1536,7 +1746,7 @@ void HGemm_B_Kernel_Simple(
                 }
                 n -= 4, b += 4, c += 4;
             }
-            if (n > 0) {
+            if (Nr0) {
                 float16x4_t accu00 = MlasZeroFloat16x4();
                 float16x4_t b0 = MlasLoadPartialFloat16x4(b, n);
                 float16x4_t b1 = MlasLoadPartialFloat16x4(b + ldb, n);
@@ -1559,7 +1769,104 @@ void HGemm_B_Kernel_Simple(
             size_t n = CountN;
             const auto* b = B_data;
             auto* c = C_data;
-            for (; n >= 32; n -= 32, b += 32, c += 32) {
+            if (largeN) {
+                float16x8_t b00 = MlasLoadFloat16x8(b);
+                float16x8_t b01 = MlasLoadFloat16x8(b + 8);
+                float16x8_t b02 = MlasLoadFloat16x8(b + 16);
+                float16x8_t b03 = MlasLoadFloat16x8(b + 24);
+                float16x8_t b10 = MlasZeroFloat16x8();
+                float16x8_t b11 = MlasZeroFloat16x8();
+                float16x8_t b12 = MlasZeroFloat16x8();
+                float16x8_t b13 = MlasZeroFloat16x8();
+                float16x8_t b20 = MlasZeroFloat16x8();
+                float16x8_t b21 = MlasZeroFloat16x8();
+                float16x8_t b22 = MlasZeroFloat16x8();
+                float16x8_t b23 = MlasZeroFloat16x8();
+                if (Kr1) {
+                    b10 = MlasLoadFloat16x8(b + ldb);
+                    b11 = MlasLoadFloat16x8(b + ldb + 8);
+                    b12 = MlasLoadFloat16x8(b + ldb + 16);
+                    b13 = MlasLoadFloat16x8(b + ldb + 24);
+                }
+                if (Kr2) {
+                    b20 = MlasLoadFloat16x8(b + 2 * ldb);
+                    b21 = MlasLoadFloat16x8(b + 2 * ldb + 8);
+                    b22 = MlasLoadFloat16x8(b + 2 * ldb + 16);
+                    b23 = MlasLoadFloat16x8(b + 2 * ldb + 24);
+                }
+                for (; n >= 64; n -= 32, b += 32, c += 32) {
+                    float16x8_t accu00 = MlasZeroFloat16x8();
+                    float16x8_t accu01 = MlasZeroFloat16x8();
+                    float16x8_t accu02 = MlasZeroFloat16x8();
+                    float16x8_t accu03 = MlasZeroFloat16x8();
+                    float16x8_t accu10, accu11, accu12, accu13;
+                    if constexpr (CountM == 2) {
+                        accu10 = MlasZeroFloat16x8();
+                        accu11 = MlasZeroFloat16x8();
+                        accu12 = MlasZeroFloat16x8();
+                        accu13 = MlasZeroFloat16x8();
+                    }
+                    accu00 = vfmaq_lane_f16(accu00, b00, a0, 0);
+                    accu01 = vfmaq_lane_f16(accu01, b01, a0, 0);
+                    accu02 = vfmaq_lane_f16(accu02, b02, a0, 0);
+                    accu03 = vfmaq_lane_f16(accu03, b03, a0, 0);
+                    if constexpr (CountM == 2) {
+                        accu10 = vfmaq_lane_f16(accu10, b00, a1, 0);
+                        accu11 = vfmaq_lane_f16(accu11, b01, a1, 0);
+                        accu12 = vfmaq_lane_f16(accu12, b02, a1, 0);
+                        accu13 = vfmaq_lane_f16(accu13, b03, a1, 0);
+                    }
+                    if (Kr1) {
+                        accu00 = vfmaq_lane_f16(accu00, b10, a0, 1);
+                        accu01 = vfmaq_lane_f16(accu01, b11, a0, 1);
+                        accu02 = vfmaq_lane_f16(accu02, b12, a0, 1);
+                        accu03 = vfmaq_lane_f16(accu03, b13, a0, 1);
+                        if constexpr (CountM == 2) {
+                            accu10 = vfmaq_lane_f16(accu10, b10, a1, 1);
+                            accu11 = vfmaq_lane_f16(accu11, b11, a1, 1);
+                            accu12 = vfmaq_lane_f16(accu12, b12, a1, 1);
+                            accu13 = vfmaq_lane_f16(accu13, b13, a1, 1);
+                        }
+                    }
+                    if (Kr2) {
+                        accu00 = vfmaq_lane_f16(accu00, b20, a0, 2);
+                        accu01 = vfmaq_lane_f16(accu01, b21, a0, 2);
+                        accu02 = vfmaq_lane_f16(accu02, b22, a0, 2);
+                        accu03 = vfmaq_lane_f16(accu03, b23, a0, 2);
+                        if constexpr (CountM == 2) {
+                            accu10 = vfmaq_lane_f16(accu10, b20, a1, 2);
+                            accu11 = vfmaq_lane_f16(accu11, b21, a1, 2);
+                            accu12 = vfmaq_lane_f16(accu12, b22, a1, 2);
+                            accu13 = vfmaq_lane_f16(accu13, b23, a1, 2);
+                        }
+                    }
+                    MlasStoreFloat16x8(c, accu00);
+                    MlasStoreFloat16x8(c + 8, accu01);
+                    MlasStoreFloat16x8(c + 16, accu02);
+                    MlasStoreFloat16x8(c + 24, accu03);
+                    if constexpr (CountM == 2) {
+                        MlasStoreFloat16x8(c + ldc, accu10);
+                        MlasStoreFloat16x8(c + ldc + 8, accu11);
+                        MlasStoreFloat16x8(c + ldc + 16, accu12);
+                        MlasStoreFloat16x8(c + ldc + 24, accu13);
+                    }
+                    b00 = MlasLoadFloat16x8(b + 32);
+                    b01 = MlasLoadFloat16x8(b + 40);
+                    b02 = MlasLoadFloat16x8(b + 48);
+                    b03 = MlasLoadFloat16x8(b + 56);
+                    if (Kr1) {
+                        b10 = MlasLoadFloat16x8(b + ldb + 32);
+                        b11 = MlasLoadFloat16x8(b + ldb + 40);
+                        b12 = MlasLoadFloat16x8(b + ldb + 48);
+                        b13 = MlasLoadFloat16x8(b + ldb + 56);
+                    }
+                    if (Kr2) {
+                        b20 = MlasLoadFloat16x8(b + 2 * ldb + 32);
+                        b21 = MlasLoadFloat16x8(b + 2 * ldb + 40);
+                        b22 = MlasLoadFloat16x8(b + 2 * ldb + 48);
+                        b23 = MlasLoadFloat16x8(b + 2 * ldb + 56);
+                    }
+                }
                 float16x8_t accu00 = MlasZeroFloat16x8();
                 float16x8_t accu01 = MlasZeroFloat16x8();
                 float16x8_t accu02 = MlasZeroFloat16x8();
@@ -1571,10 +1878,6 @@ void HGemm_B_Kernel_Simple(
                     accu12 = MlasZeroFloat16x8();
                     accu13 = MlasZeroFloat16x8();
                 }
-                float16x8_t b00 = MlasLoadFloat16x8(b);
-                float16x8_t b01 = MlasLoadFloat16x8(b + 8);
-                float16x8_t b02 = MlasLoadFloat16x8(b + 16);
-                float16x8_t b03 = MlasLoadFloat16x8(b + 24);
                 accu00 = vfmaq_lane_f16(accu00, b00, a0, 0);
                 accu01 = vfmaq_lane_f16(accu01, b01, a0, 0);
                 accu02 = vfmaq_lane_f16(accu02, b02, a0, 0);
@@ -1585,11 +1888,7 @@ void HGemm_B_Kernel_Simple(
                     accu12 = vfmaq_lane_f16(accu12, b02, a1, 0);
                     accu13 = vfmaq_lane_f16(accu13, b03, a1, 0);
                 }
-                if (CountK > 1) {
-                    float16x8_t b10 = MlasLoadFloat16x8(b + ldb);
-                    float16x8_t b11 = MlasLoadFloat16x8(b + ldb + 8);
-                    float16x8_t b12 = MlasLoadFloat16x8(b + ldb + 16);
-                    float16x8_t b13 = MlasLoadFloat16x8(b + ldb + 24);
+                if (Kr1) {
                     accu00 = vfmaq_lane_f16(accu00, b10, a0, 1);
                     accu01 = vfmaq_lane_f16(accu01, b11, a0, 1);
                     accu02 = vfmaq_lane_f16(accu02, b12, a0, 1);
@@ -1601,11 +1900,7 @@ void HGemm_B_Kernel_Simple(
                         accu13 = vfmaq_lane_f16(accu13, b13, a1, 1);
                     }
                 }
-                if (CountK > 2) {
-                    float16x8_t b20 = MlasLoadFloat16x8(b + 2 * ldb);
-                    float16x8_t b21 = MlasLoadFloat16x8(b + 2 * ldb + 8);
-                    float16x8_t b22 = MlasLoadFloat16x8(b + 2 * ldb + 16);
-                    float16x8_t b23 = MlasLoadFloat16x8(b + 2 * ldb + 24);
+                if (Kr2) {
                     accu00 = vfmaq_lane_f16(accu00, b20, a0, 2);
                     accu01 = vfmaq_lane_f16(accu01, b21, a0, 2);
                     accu02 = vfmaq_lane_f16(accu02, b22, a0, 2);
@@ -1627,6 +1922,7 @@ void HGemm_B_Kernel_Simple(
                     MlasStoreFloat16x8(c + ldc + 16, accu12);
                     MlasStoreFloat16x8(c + ldc + 24, accu13);
                 }
+                n -= 32, b += 32, c += 32;
             }
             if (n & 16) {
                 float16x8_t accu00 = MlasZeroFloat16x8();
@@ -1644,7 +1940,7 @@ void HGemm_B_Kernel_Simple(
                     accu10 = vfmaq_lane_f16(accu10, b00, a1, 0);
                     accu11 = vfmaq_lane_f16(accu11, b01, a1, 0);
                 }
-                if (CountK > 1) {
+                if (Kr1) {
                     float16x8_t b10 = MlasLoadFloat16x8(b + ldb);
                     float16x8_t b11 = MlasLoadFloat16x8(b + ldb + 8);
                     accu00 = vfmaq_lane_f16(accu00, b10, a0, 1);
@@ -1654,7 +1950,7 @@ void HGemm_B_Kernel_Simple(
                         accu11 = vfmaq_lane_f16(accu11, b11, a1, 1);
                     }
                 }
-                if (CountK > 2) {
+                if (Kr2) {
                     float16x8_t b20 = MlasLoadFloat16x8(b + 2 * ldb);
                     float16x8_t b21 = MlasLoadFloat16x8(b + 2 * ldb + 8);
                     accu00 = vfmaq_lane_f16(accu00, b20, a0, 2);
@@ -1682,14 +1978,14 @@ void HGemm_B_Kernel_Simple(
                 if constexpr (CountM == 2) {
                     accu10 = vfmaq_lane_f16(accu10, b0, a1, 0);
                 }
-                if (CountK > 1) {
+                if (Kr1) {
                     float16x8_t b1 = MlasLoadFloat16x8(b + ldb);
                     accu00 = vfmaq_lane_f16(accu00, b1, a0, 1);
                     if constexpr (CountM == 2) {
                         accu10 = vfmaq_lane_f16(accu10, b1, a1, 1);
                     }
                 }
-                if (CountK > 2) {
+                if (Kr2) {
                     float16x8_t b2 = MlasLoadFloat16x8(b + 2 * ldb);
                     accu00 = vfmaq_lane_f16(accu00, b2, a0, 2);
                     if constexpr (CountM == 2) {
@@ -1712,14 +2008,14 @@ void HGemm_B_Kernel_Simple(
                 if constexpr (CountM == 2) {
                     accu10 = vfma_lane_f16(accu10, b0, a1, 0);
                 }
-                if (CountK > 1) {
+                if (Kr1) {
                     float16x4_t b1 = MlasLoadFloat16x4(b + ldb);
                     accu00 = vfma_lane_f16(accu00, b1, a0, 1);
                     if constexpr (CountM == 2) {
                         accu10 = vfma_lane_f16(accu10, b1, a1, 1);
                     }
                 }
-                if (CountK > 2) {
+                if (Kr2) {
                     float16x4_t b2 = MlasLoadFloat16x4(b + 2 * ldb);
                     accu00 = vfma_lane_f16(accu00, b2, a0, 2);
                     if constexpr (CountM == 2) {
@@ -1732,7 +2028,7 @@ void HGemm_B_Kernel_Simple(
                 }
                 n -= 4, b += 4, c += 4;
             }
-            if (n > 0) {
+            if (Nr0) {
                 float16x4_t accu00 = MlasZeroFloat16x4(), accu10;
                 if constexpr (CountM == 2) {
                     accu10 = MlasZeroFloat16x4();
@@ -1742,14 +2038,14 @@ void HGemm_B_Kernel_Simple(
                 if constexpr (CountM == 2) {
                     accu10 = vfma_lane_f16(accu10, b0, a1, 0);
                 }
-                if (CountK > 1) {
+                if (Kr1) {
                     float16x4_t b1 = MlasLoadPartialFloat16x4(b + ldb, n);
                     accu00 = vfma_lane_f16(accu00, b1, a0, 1);
                     if constexpr (CountM == 2) {
                         accu10 = vfma_lane_f16(accu10, b1, a1, 1);
                     }
                 }
-                if (CountK > 2) {
+                if (Kr2) {
                     float16x4_t b2 = MlasLoadPartialFloat16x4(b + 2 * ldb, n);
                     accu00 = vfma_lane_f16(accu00, b2, a0, 2);
                     if constexpr (CountM == 2) {
@@ -1774,11 +2070,7 @@ void HGemm_B_Kernel_Simple(
         size_t n = CountN;
         const auto* b = B_data;
         auto* c = C_data;
-        for (; n >= 32; n -= 32, b += 32, c += 32) {
-            float16x8_t accu00 = MlasLoadFloat16x8(c);
-            float16x8_t accu01 = MlasLoadFloat16x8(c + 8);
-            float16x8_t accu02 = MlasLoadFloat16x8(c + 16);
-            float16x8_t accu03 = MlasLoadFloat16x8(c + 24);
+        if (largeN) {
             float16x8_t b00 = MlasLoadFloat16x8(b);
             float16x8_t b10 = MlasLoadFloat16x8(b + ldb);
             float16x8_t b20 = MlasLoadFloat16x8(b + 2 * ldb);
@@ -1795,6 +2087,54 @@ void HGemm_B_Kernel_Simple(
             float16x8_t b13 = MlasLoadFloat16x8(b + ldb + 24);
             float16x8_t b23 = MlasLoadFloat16x8(b + 2 * ldb + 24);
             float16x8_t b33 = MlasLoadFloat16x8(b + 3 * ldb + 24);
+            for (; n >= 64; n -= 32, b += 32, c += 32) {
+                float16x8_t accu00 = MlasLoadFloat16x8(c);
+                float16x8_t accu01 = MlasLoadFloat16x8(c + 8);
+                float16x8_t accu02 = MlasLoadFloat16x8(c + 16);
+                float16x8_t accu03 = MlasLoadFloat16x8(c + 24);
+                accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
+                accu01 = maq_lane_f16_accu(accu01, b01, b11, b21, b31, a0);
+                accu02 = maq_lane_f16_accu(accu02, b02, b12, b22, b32, a0);
+                accu03 = maq_lane_f16_accu(accu03, b03, b13, b23, b33, a0);
+                MlasStoreFloat16x8(c, accu00);
+                MlasStoreFloat16x8(c + 8, accu01);
+                MlasStoreFloat16x8(c + 16, accu02);
+                MlasStoreFloat16x8(c + 24, accu03);
+                if constexpr (CountM == 2) {
+                    float16x8_t accu10 = MlasLoadFloat16x8(c + ldc);
+                    float16x8_t accu11 = MlasLoadFloat16x8(c + ldc + 8);
+                    float16x8_t accu12 = MlasLoadFloat16x8(c + ldc + 16);
+                    float16x8_t accu13 = MlasLoadFloat16x8(c + ldc + 24);
+                    accu10 = maq_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
+                    accu11 = maq_lane_f16_accu(accu11, b01, b11, b21, b31, a1);
+                    accu12 = maq_lane_f16_accu(accu12, b02, b12, b22, b32, a1);
+                    accu13 = maq_lane_f16_accu(accu13, b03, b13, b23, b33, a1);
+                    MlasStoreFloat16x8(c + ldc, accu10);
+                    MlasStoreFloat16x8(c + ldc + 8, accu11);
+                    MlasStoreFloat16x8(c + ldc + 16, accu12);
+                    MlasStoreFloat16x8(c + ldc + 24, accu13);
+                }
+                b00 = MlasLoadFloat16x8(b + 32);
+                b10 = MlasLoadFloat16x8(b + ldb + 32);
+                b20 = MlasLoadFloat16x8(b + 2 * ldb + 32);
+                b30 = MlasLoadFloat16x8(b + 3 * ldb + 32);
+                b01 = MlasLoadFloat16x8(b + 40);
+                b11 = MlasLoadFloat16x8(b + ldb + 40);
+                b21 = MlasLoadFloat16x8(b + 2 * ldb + 40);
+                b31 = MlasLoadFloat16x8(b + 3 * ldb + 40);
+                b02 = MlasLoadFloat16x8(b + 48);
+                b12 = MlasLoadFloat16x8(b + ldb + 48);
+                b22 = MlasLoadFloat16x8(b + 2 * ldb + 48);
+                b32 = MlasLoadFloat16x8(b + 3 * ldb + 48);
+                b03 = MlasLoadFloat16x8(b + 56);
+                b13 = MlasLoadFloat16x8(b + ldb + 56);
+                b23 = MlasLoadFloat16x8(b + 2 * ldb + 56);
+                b33 = MlasLoadFloat16x8(b + 3 * ldb + 56);
+            }
+            float16x8_t accu00 = MlasLoadFloat16x8(c);
+            float16x8_t accu01 = MlasLoadFloat16x8(c + 8);
+            float16x8_t accu02 = MlasLoadFloat16x8(c + 16);
+            float16x8_t accu03 = MlasLoadFloat16x8(c + 24);
             accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
             accu01 = maq_lane_f16_accu(accu01, b01, b11, b21, b31, a0);
             accu02 = maq_lane_f16_accu(accu02, b02, b12, b22, b32, a0);
@@ -1804,10 +2144,10 @@ void HGemm_B_Kernel_Simple(
             MlasStoreFloat16x8(c + 16, accu02);
             MlasStoreFloat16x8(c + 24, accu03);
             if constexpr (CountM == 2) {
-                float16x8_t accu10 = MlasLoadFloat16x8(c + ldb);
-                float16x8_t accu11 = MlasLoadFloat16x8(c + ldb + 8);
-                float16x8_t accu12 = MlasLoadFloat16x8(c + ldb + 16);
-                float16x8_t accu13 = MlasLoadFloat16x8(c + ldb + 24);
+                float16x8_t accu10 = MlasLoadFloat16x8(c + ldc);
+                float16x8_t accu11 = MlasLoadFloat16x8(c + ldc + 8);
+                float16x8_t accu12 = MlasLoadFloat16x8(c + ldc + 16);
+                float16x8_t accu13 = MlasLoadFloat16x8(c + ldc + 24);
                 accu10 = maq_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
                 accu11 = maq_lane_f16_accu(accu11, b01, b11, b21, b31, a1);
                 accu12 = maq_lane_f16_accu(accu12, b02, b12, b22, b32, a1);
@@ -1817,6 +2157,7 @@ void HGemm_B_Kernel_Simple(
                 MlasStoreFloat16x8(c + ldc + 16, accu12);
                 MlasStoreFloat16x8(c + ldc + 24, accu13);
             }
+            n -= 32, b += 32, c += 32;
         }
         if (n & 16) {
             float16x8_t accu00 = MlasLoadFloat16x8(c);
@@ -1834,8 +2175,8 @@ void HGemm_B_Kernel_Simple(
             MlasStoreFloat16x8(c, accu00);
             MlasStoreFloat16x8(c + 8, accu01);
             if constexpr (CountM == 2) {
-                float16x8_t accu10 = MlasLoadFloat16x8(c + ldb);
-                float16x8_t accu11 = MlasLoadFloat16x8(c + ldb + 8);
+                float16x8_t accu10 = MlasLoadFloat16x8(c + ldc);
+                float16x8_t accu11 = MlasLoadFloat16x8(c + ldc + 8);
                 accu10 = maq_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
                 accu11 = maq_lane_f16_accu(accu11, b01, b11, b21, b31, a1);
                 MlasStoreFloat16x8(c + ldc, accu10);
@@ -1873,7 +2214,7 @@ void HGemm_B_Kernel_Simple(
             }
             n -= 4, b += 4, c += 4;
         }
-        if (n > 0) {
+        if (Nr0) {
             float16x4_t accu00 = MlasLoadPartialFloat16x4(c, n);
             float16x4_t b0 = MlasLoadPartialFloat16x4(b, n);
             float16x4_t b1 = MlasLoadPartialFloat16x4(b + ldb, n);
@@ -1897,22 +2238,115 @@ void HGemm_B_Kernel_Simple(
         size_t n = CountN;
         const auto* b = B_data;
         auto* c = C_data;
-        for (; n >= 32; n -= 32, b += 32, c += 32) {
+        if (largeN) {
+            float16x8_t b00 = MlasLoadFloat16x8(b);
+            float16x8_t b01 = MlasLoadFloat16x8(b + 8);
+            float16x8_t b02 = MlasLoadFloat16x8(b + 16);
+            float16x8_t b03 = MlasLoadFloat16x8(b + 24);
+            float16x8_t b10 = MlasZeroFloat16x8();
+            float16x8_t b11 = MlasZeroFloat16x8();
+            float16x8_t b12 = MlasZeroFloat16x8();
+            float16x8_t b13 = MlasZeroFloat16x8();
+            float16x8_t b20 = MlasZeroFloat16x8();
+            float16x8_t b21 = MlasZeroFloat16x8();
+            float16x8_t b22 = MlasZeroFloat16x8();
+            float16x8_t b23 = MlasZeroFloat16x8();
+            if (Kr1) {
+                b10 = MlasLoadFloat16x8(b + ldb);
+                b11 = MlasLoadFloat16x8(b + ldb + 8);
+                b12 = MlasLoadFloat16x8(b + ldb + 16);
+                b13 = MlasLoadFloat16x8(b + ldb + 24);
+            }
+            if (Kr2) {
+                b20 = MlasLoadFloat16x8(b + 2 * ldb);
+                b21 = MlasLoadFloat16x8(b + 2 * ldb + 8);
+                b22 = MlasLoadFloat16x8(b + 2 * ldb + 16);
+                b23 = MlasLoadFloat16x8(b + 2 * ldb + 24);
+            }
+            for (; n >= 64; n -= 32, b += 32, c += 32) {
+                float16x8_t accu00 = MlasLoadFloat16x8(c);
+                float16x8_t accu01 = MlasLoadFloat16x8(c + 8);
+                float16x8_t accu02 = MlasLoadFloat16x8(c + 16);
+                float16x8_t accu03 = MlasLoadFloat16x8(c + 24);
+                float16x8_t accu10, accu11, accu12, accu13;
+                if constexpr (CountM == 2) {
+                    accu10 = MlasLoadFloat16x8(c + ldc);
+                    accu11 = MlasLoadFloat16x8(c + ldc + 8);
+                    accu12 = MlasLoadFloat16x8(c + ldc + 16);
+                    accu13 = MlasLoadFloat16x8(c + ldc + 24);
+                }
+                accu00 = vfmaq_lane_f16(accu00, b00, a0, 0);
+                accu01 = vfmaq_lane_f16(accu01, b01, a0, 0);
+                accu02 = vfmaq_lane_f16(accu02, b02, a0, 0);
+                accu03 = vfmaq_lane_f16(accu03, b03, a0, 0);
+                if constexpr (CountM == 2) {
+                    accu10 = vfmaq_lane_f16(accu10, b00, a1, 0);
+                    accu11 = vfmaq_lane_f16(accu11, b01, a1, 0);
+                    accu12 = vfmaq_lane_f16(accu12, b02, a1, 0);
+                    accu13 = vfmaq_lane_f16(accu13, b03, a1, 0);
+                }
+                if (Kr1) {
+                    accu00 = vfmaq_lane_f16(accu00, b10, a0, 1);
+                    accu01 = vfmaq_lane_f16(accu01, b11, a0, 1);
+                    accu02 = vfmaq_lane_f16(accu02, b12, a0, 1);
+                    accu03 = vfmaq_lane_f16(accu03, b13, a0, 1);
+                    if constexpr (CountM == 2) {
+                        accu10 = vfmaq_lane_f16(accu10, b10, a1, 1);
+                        accu11 = vfmaq_lane_f16(accu11, b11, a1, 1);
+                        accu12 = vfmaq_lane_f16(accu12, b12, a1, 1);
+                        accu13 = vfmaq_lane_f16(accu13, b13, a1, 1);
+                    }
+                }
+                if (Kr2) {
+                    accu00 = vfmaq_lane_f16(accu00, b20, a0, 2);
+                    accu01 = vfmaq_lane_f16(accu01, b21, a0, 2);
+                    accu02 = vfmaq_lane_f16(accu02, b22, a0, 2);
+                    accu03 = vfmaq_lane_f16(accu03, b23, a0, 2);
+                    if constexpr (CountM == 2) {
+                        accu10 = vfmaq_lane_f16(accu10, b20, a1, 2);
+                        accu11 = vfmaq_lane_f16(accu11, b21, a1, 2);
+                        accu12 = vfmaq_lane_f16(accu12, b22, a1, 2);
+                        accu13 = vfmaq_lane_f16(accu13, b23, a1, 2);
+                    }
+                }
+                MlasStoreFloat16x8(c, accu00);
+                MlasStoreFloat16x8(c + 8, accu01);
+                MlasStoreFloat16x8(c + 16, accu02);
+                MlasStoreFloat16x8(c + 24, accu03);
+                if constexpr (CountM == 2) {
+                    MlasStoreFloat16x8(c + ldc, accu10);
+                    MlasStoreFloat16x8(c + ldc + 8, accu11);
+                    MlasStoreFloat16x8(c + ldc + 16, accu12);
+                    MlasStoreFloat16x8(c + ldc + 24, accu13);
+                }
+                b00 = MlasLoadFloat16x8(b + 32);
+                b01 = MlasLoadFloat16x8(b + 40);
+                b02 = MlasLoadFloat16x8(b + 48);
+                b03 = MlasLoadFloat16x8(b + 56);
+                if (Kr1) {
+                    b10 = MlasLoadFloat16x8(b + ldb + 32);
+                    b11 = MlasLoadFloat16x8(b + ldb + 40);
+                    b12 = MlasLoadFloat16x8(b + ldb + 48);
+                    b13 = MlasLoadFloat16x8(b + ldb + 56);
+                }
+                if (Kr2) {
+                    b20 = MlasLoadFloat16x8(b + 2 * ldb + 32);
+                    b21 = MlasLoadFloat16x8(b + 2 * ldb + 40);
+                    b22 = MlasLoadFloat16x8(b + 2 * ldb + 48);
+                    b23 = MlasLoadFloat16x8(b + 2 * ldb + 56);
+                }
+            }
             float16x8_t accu00 = MlasLoadFloat16x8(c);
             float16x8_t accu01 = MlasLoadFloat16x8(c + 8);
             float16x8_t accu02 = MlasLoadFloat16x8(c + 16);
             float16x8_t accu03 = MlasLoadFloat16x8(c + 24);
             float16x8_t accu10, accu11, accu12, accu13;
             if constexpr (CountM == 2) {
-                accu10 = MlasLoadFloat16x8(c + ldb);
-                accu11 = MlasLoadFloat16x8(c + ldb + 8);
-                accu12 = MlasLoadFloat16x8(c + ldb + 16);
-                accu13 = MlasLoadFloat16x8(c + ldb + 24);
+                accu10 = MlasLoadFloat16x8(c + ldc);
+                accu11 = MlasLoadFloat16x8(c + ldc + 8);
+                accu12 = MlasLoadFloat16x8(c + ldc + 16);
+                accu13 = MlasLoadFloat16x8(c + ldc + 24);
             }
-            float16x8_t b00 = MlasLoadFloat16x8(b);
-            float16x8_t b01 = MlasLoadFloat16x8(b + 8);
-            float16x8_t b02 = MlasLoadFloat16x8(b + 16);
-            float16x8_t b03 = MlasLoadFloat16x8(b + 24);
             accu00 = vfmaq_lane_f16(accu00, b00, a0, 0);
             accu01 = vfmaq_lane_f16(accu01, b01, a0, 0);
             accu02 = vfmaq_lane_f16(accu02, b02, a0, 0);
@@ -1923,11 +2357,7 @@ void HGemm_B_Kernel_Simple(
                 accu12 = vfmaq_lane_f16(accu12, b02, a1, 0);
                 accu13 = vfmaq_lane_f16(accu13, b03, a1, 0);
             }
-            if (CountK > 1) {
-                float16x8_t b10 = MlasLoadFloat16x8(b + ldb);
-                float16x8_t b11 = MlasLoadFloat16x8(b + ldb + 8);
-                float16x8_t b12 = MlasLoadFloat16x8(b + ldb + 16);
-                float16x8_t b13 = MlasLoadFloat16x8(b + ldb + 24);
+            if (Kr1) {
                 accu00 = vfmaq_lane_f16(accu00, b10, a0, 1);
                 accu01 = vfmaq_lane_f16(accu01, b11, a0, 1);
                 accu02 = vfmaq_lane_f16(accu02, b12, a0, 1);
@@ -1939,11 +2369,7 @@ void HGemm_B_Kernel_Simple(
                     accu13 = vfmaq_lane_f16(accu13, b13, a1, 1);
                 }
             }
-            if (CountK > 2) {
-                float16x8_t b20 = MlasLoadFloat16x8(b + 2 * ldb);
-                float16x8_t b21 = MlasLoadFloat16x8(b + 2 * ldb + 8);
-                float16x8_t b22 = MlasLoadFloat16x8(b + 2 * ldb + 16);
-                float16x8_t b23 = MlasLoadFloat16x8(b + 2 * ldb + 24);
+            if (Kr2) {
                 accu00 = vfmaq_lane_f16(accu00, b20, a0, 2);
                 accu01 = vfmaq_lane_f16(accu01, b21, a0, 2);
                 accu02 = vfmaq_lane_f16(accu02, b22, a0, 2);
@@ -1965,6 +2391,7 @@ void HGemm_B_Kernel_Simple(
                 MlasStoreFloat16x8(c + ldc + 16, accu12);
                 MlasStoreFloat16x8(c + ldc + 24, accu13);
             }
+            n -= 32, b += 32, c += 32;
         }
         if (n & 16) {
             float16x8_t accu00 = MlasLoadFloat16x8(c);
@@ -1982,7 +2409,7 @@ void HGemm_B_Kernel_Simple(
                 accu10 = vfmaq_lane_f16(accu10, b00, a1, 0);
                 accu11 = vfmaq_lane_f16(accu11, b01, a1, 0);
             }
-            if (CountK > 1) {
+            if (Kr1) {
                 float16x8_t b10 = MlasLoadFloat16x8(b + ldb);
                 float16x8_t b11 = MlasLoadFloat16x8(b + ldb + 8);
                 accu00 = vfmaq_lane_f16(accu00, b10, a0, 1);
@@ -1992,7 +2419,7 @@ void HGemm_B_Kernel_Simple(
                     accu11 = vfmaq_lane_f16(accu11, b11, a1, 1);
                 }
             }
-            if (CountK > 2) {
+            if (Kr2) {
                 float16x8_t b20 = MlasLoadFloat16x8(b + 2 * ldb);
                 float16x8_t b21 = MlasLoadFloat16x8(b + 2 * ldb + 8);
                 accu00 = vfmaq_lane_f16(accu00, b20, a0, 2);
@@ -2021,14 +2448,14 @@ void HGemm_B_Kernel_Simple(
             if constexpr (CountM == 2) {
                 accu10 = vfmaq_lane_f16(accu10, b0, a1, 0);
             }
-            if (CountK > 1) {
+            if (Kr1) {
                 float16x8_t b1 = MlasLoadFloat16x8(b + ldb);
                 accu00 = vfmaq_lane_f16(accu00, b1, a0, 1);
                 if constexpr (CountM == 2) {
                     accu10 = vfmaq_lane_f16(accu10, b1, a1, 1);
                 }
             }
-            if (CountK > 2) {
+            if (Kr2) {
                 float16x8_t b2 = MlasLoadFloat16x8(b + 2 * ldb);
                 accu00 = vfmaq_lane_f16(accu00, b2, a0, 2);
                 if constexpr (CountM == 2) {
@@ -2052,14 +2479,14 @@ void HGemm_B_Kernel_Simple(
             if constexpr (CountM == 2) {
                 accu10 = vfma_lane_f16(accu10, b0, a1, 0);
             }
-            if (CountK > 1) {
+            if (Kr1) {
                 float16x4_t b1 = MlasLoadFloat16x4(b + ldb);
                 accu00 = vfma_lane_f16(accu00, b1, a0, 1);
                 if constexpr (CountM == 2) {
                     accu10 = vfma_lane_f16(accu10, b1, a1, 1);
                 }
             }
-            if (CountK > 2) {
+            if (Kr2) {
                 float16x4_t b2 = MlasLoadFloat16x4(b + 2 * ldb);
                 accu00 = vfma_lane_f16(accu00, b2, a0, 2);
                 if constexpr (CountM == 2) {
@@ -2072,7 +2499,7 @@ void HGemm_B_Kernel_Simple(
             }
             n -= 4, b += 4, c += 4;
         }
-        if (n > 0) {
+        if (Nr0) {
             float16x4_t accu00 = MlasLoadPartialFloat16x4(c, n);
             float16x4_t accu10;
             if constexpr (CountM == 2) {
@@ -2083,14 +2510,14 @@ void HGemm_B_Kernel_Simple(
             if constexpr (CountM == 2) {
                 accu10 = vfma_lane_f16(accu10, b0, a1, 0);
             }
-            if (CountK > 1) {
+            if (Kr1) {
                 float16x4_t b1 = MlasLoadPartialFloat16x4(b + ldb, n);
                 accu00 = vfma_lane_f16(accu00, b1, a0, 1);
                 if constexpr (CountM == 2) {
                     accu10 = vfma_lane_f16(accu10, b1, a1, 1);
                 }
             }
-            if (CountK > 2) {
+            if (Kr2) {
                 float16x4_t b2 = MlasLoadPartialFloat16x4(b + 2 * ldb, n);
                 accu00 = vfma_lane_f16(accu00, b2, a0, 2);
                 if constexpr (CountM == 2) {
@@ -2160,10 +2587,14 @@ void HGemm_PackedB_Kernel_Impl(
     _mlas_fp16_ alpha,
     _mlas_fp16_ beta
 ) {
-    float16x8_t alpha_v8 = MlasBroadcastFloat16x8(alpha);
-    float16x8_t beta_v8 = MlasBroadcastFloat16x8(beta);
-    float16x4_t alpha_v4 = MlasBroadcastFloat16x4(alpha);
-    float16x4_t beta_v4 = MlasBroadcastFloat16x4(beta);
+    const float16x8_t alpha_v8 = MlasBroadcastFloat16x8(alpha);
+    const float16x8_t beta_v8 = MlasBroadcastFloat16x8(beta);
+    const float16x4_t alpha_v4 = MlasBroadcastFloat16x4(alpha);
+    const float16x4_t beta_v4 = MlasBroadcastFloat16x4(beta);
+    const bool Kr0 = CountK & 3;
+    const bool Kr1 = (CountK & 3) > 1;
+    const bool Kr2 = (CountK & 3) > 2;
+    const bool largeK = CountK >= 4;
     for (; CountN >= 32; CountN -= 32, C += 32) {
         const auto* a = A;
         size_t k = CountK;
@@ -2178,8 +2609,11 @@ void HGemm_PackedB_Kernel_Impl(
             accu12 = MlasZeroFloat16x8();
             accu13 = MlasZeroFloat16x8();
         }
-        for (; k >= 4; k -= 4, a += 4, PackedB += 4 * 32) {
-            float16x4_t a0 = MlasLoadFloat16x4(a);
+        if (largeK) {
+            float16x4_t a0 = MlasLoadFloat16x4(a), a1;
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadFloat16x4(a + lda);
+            }
             float16x8_t b00 = MlasLoadFloat16x8(PackedB);
             float16x8_t b10 = MlasLoadFloat16x8(PackedB + 32);
             float16x8_t b20 = MlasLoadFloat16x8(PackedB + 64);
@@ -2196,20 +2630,52 @@ void HGemm_PackedB_Kernel_Impl(
             float16x8_t b13 = MlasLoadFloat16x8(PackedB + 56);
             float16x8_t b23 = MlasLoadFloat16x8(PackedB + 88);
             float16x8_t b33 = MlasLoadFloat16x8(PackedB + 120);
+            for (; k >= 8; k -= 4, a += 4, PackedB += 4 * 32) {
+                accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
+                accu01 = maq_lane_f16_accu(accu01, b01, b11, b21, b31, a0);
+                accu02 = maq_lane_f16_accu(accu02, b02, b12, b22, b32, a0);
+                accu03 = maq_lane_f16_accu(accu03, b03, b13, b23, b33, a0);
+                if constexpr (CountM == 2) {
+                    accu10 = maq_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
+                    accu11 = maq_lane_f16_accu(accu11, b01, b11, b21, b31, a1);
+                    accu12 = maq_lane_f16_accu(accu12, b02, b12, b22, b32, a1);
+                    accu13 = maq_lane_f16_accu(accu13, b03, b13, b23, b33, a1);
+                }
+                a0 = MlasLoadFloat16x4(a + 4);
+                if constexpr (CountM == 2) {
+                    a1 = MlasLoadFloat16x4(a + lda + 4);
+                }
+                b00 = MlasLoadFloat16x8(PackedB + 128);
+                b10 = MlasLoadFloat16x8(PackedB + 160);
+                b20 = MlasLoadFloat16x8(PackedB + 192);
+                b30 = MlasLoadFloat16x8(PackedB + 224);
+                b01 = MlasLoadFloat16x8(PackedB + 136);
+                b11 = MlasLoadFloat16x8(PackedB + 168);
+                b21 = MlasLoadFloat16x8(PackedB + 200);
+                b31 = MlasLoadFloat16x8(PackedB + 232);
+                b02 = MlasLoadFloat16x8(PackedB + 144);
+                b12 = MlasLoadFloat16x8(PackedB + 176);
+                b22 = MlasLoadFloat16x8(PackedB + 208);
+                b32 = MlasLoadFloat16x8(PackedB + 240);
+                b03 = MlasLoadFloat16x8(PackedB + 152);
+                b13 = MlasLoadFloat16x8(PackedB + 184);
+                b23 = MlasLoadFloat16x8(PackedB + 216);
+                b33 = MlasLoadFloat16x8(PackedB + 248);
+            }
             accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
             accu01 = maq_lane_f16_accu(accu01, b01, b11, b21, b31, a0);
             accu02 = maq_lane_f16_accu(accu02, b02, b12, b22, b32, a0);
             accu03 = maq_lane_f16_accu(accu03, b03, b13, b23, b33, a0);
             if constexpr (CountM == 2) {
-                float16x4_t a1 = MlasLoadFloat16x4(a + lda);
                 accu10 = maq_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
                 accu11 = maq_lane_f16_accu(accu11, b01, b11, b21, b31, a1);
                 accu12 = maq_lane_f16_accu(accu12, b02, b12, b22, b32, a1);
                 accu13 = maq_lane_f16_accu(accu13, b03, b13, b23, b33, a1);
             }
+            k -= 4, a += 4, PackedB += 4 * 32;
         }
 
-        if (k > 0) {
+        if (Kr0) {
             float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1;
             if constexpr (CountM == 2) {
                 a1 = MlasLoadPartialFloat16x4(a + lda, k);
@@ -2228,7 +2694,7 @@ void HGemm_PackedB_Kernel_Impl(
                 accu12 = vfmaq_lane_f16(accu12, b02, a1, 0);
                 accu13 = vfmaq_lane_f16(accu13, b03, a1, 0);
             }
-            if (k > 1) {
+            if (Kr1) {
                 float16x8_t b10 = MlasLoadFloat16x8(PackedB + 32);
                 float16x8_t b11 = MlasLoadFloat16x8(PackedB + 40);
                 float16x8_t b12 = MlasLoadFloat16x8(PackedB + 48);
@@ -2244,7 +2710,7 @@ void HGemm_PackedB_Kernel_Impl(
                     accu13 = vfmaq_lane_f16(accu13, b13, a1, 1);
                 }
             }
-            if (k > 2) {
+            if (Kr2) {
                 float16x8_t b20 = MlasLoadFloat16x8(PackedB + 64);
                 float16x8_t b21 = MlasLoadFloat16x8(PackedB + 72);
                 float16x8_t b22 = MlasLoadFloat16x8(PackedB + 80);
@@ -2326,8 +2792,11 @@ void HGemm_PackedB_Kernel_Impl(
             accu10 = MlasZeroFloat16x8();
             accu11 = MlasZeroFloat16x8();
         }
-        for (; k >= 4; k -= 4, a += 4, PackedB += 4 * 16) {
-            float16x4_t a0 = MlasLoadFloat16x4(a);
+        if (largeK) {
+            float16x4_t a0 = MlasLoadFloat16x4(a), a1;
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadFloat16x4(a + lda);
+            }
             float16x8_t b00 = MlasLoadFloat16x8(PackedB);
             float16x8_t b01 = MlasLoadFloat16x8(PackedB + 8);
             float16x8_t b10 = MlasLoadFloat16x8(PackedB + 16);
@@ -2336,16 +2805,36 @@ void HGemm_PackedB_Kernel_Impl(
             float16x8_t b21 = MlasLoadFloat16x8(PackedB + 40);
             float16x8_t b30 = MlasLoadFloat16x8(PackedB + 48);
             float16x8_t b31 = MlasLoadFloat16x8(PackedB + 56);
+            for (; k >= 8; k -= 4, a += 4, PackedB += 4 * 16) {
+                accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
+                accu01 = maq_lane_f16_accu(accu01, b01, b11, b21, b31, a0);
+                if constexpr (CountM == 2) {
+                    accu10 = maq_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
+                    accu11 = maq_lane_f16_accu(accu11, b01, b11, b21, b31, a1);
+                }
+                a0 = MlasLoadFloat16x4(a + 4);
+                if constexpr (CountM == 2) {
+                    a1 = MlasLoadFloat16x4(a + lda + 4);
+                }
+                b00 = MlasLoadFloat16x8(PackedB + 64);
+                b01 = MlasLoadFloat16x8(PackedB + 72);
+                b10 = MlasLoadFloat16x8(PackedB + 80);
+                b11 = MlasLoadFloat16x8(PackedB + 88);
+                b20 = MlasLoadFloat16x8(PackedB + 96);
+                b21 = MlasLoadFloat16x8(PackedB + 104);
+                b30 = MlasLoadFloat16x8(PackedB + 112);
+                b31 = MlasLoadFloat16x8(PackedB + 120);
+            }
             accu00 = maq_lane_f16_accu(accu00, b00, b10, b20, b30, a0);
             accu01 = maq_lane_f16_accu(accu01, b01, b11, b21, b31, a0);
             if constexpr (CountM == 2) {
-                float16x4_t a1 = MlasLoadFloat16x4(a + lda);
                 accu10 = maq_lane_f16_accu(accu10, b00, b10, b20, b30, a1);
                 accu11 = maq_lane_f16_accu(accu11, b01, b11, b21, b31, a1);
             }
+            k -= 4, a += 4, PackedB += 4 * 16;
         }
 
-        if (k > 0) {
+        if (Kr0) {
             float16x8_t b00 = MlasLoadFloat16x8(PackedB);
             float16x8_t b01 = MlasLoadFloat16x8(PackedB + 8);
             float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1;
@@ -2356,7 +2845,7 @@ void HGemm_PackedB_Kernel_Impl(
                 accu10 = vfmaq_lane_f16(accu10, b00, a1, 0);
                 accu11 = vfmaq_lane_f16(accu11, b01, a1, 0);
             }
-            if (k > 1) {
+            if (Kr1) {
                 float16x8_t b10 = MlasLoadFloat16x8(PackedB + 16);
                 float16x8_t b11 = MlasLoadFloat16x8(PackedB + 24);
                 accu00 = vfmaq_lane_f16(accu00, b10, a0, 1);
@@ -2366,7 +2855,7 @@ void HGemm_PackedB_Kernel_Impl(
                     accu11 = vfmaq_lane_f16(accu11, b11, a1, 1);
                 }
             }
-            if (k > 2) {
+            if (Kr2) {
                 float16x8_t b20 = MlasLoadFloat16x8(PackedB + 32);
                 float16x8_t b21 = MlasLoadFloat16x8(PackedB + 40);
                 accu00 = vfmaq_lane_f16(accu00, b20, a0, 2);
@@ -2430,20 +2919,37 @@ void HGemm_PackedB_Kernel_Impl(
         size_t k = CountK;
         float16x8_t accu00 = MlasZeroFloat16x8();
         float16x8_t accu10 = MlasZeroFloat16x8();
-        for (; k >= 4; k -= 4, a += 4, PackedB += 4 * 8) {
-            float16x4_t a0 = MlasLoadFloat16x4(a);
+        if (largeK) {
+            float16x4_t a0 = MlasLoadFloat16x4(a), a1;
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadFloat16x4(a + lda);
+            }
             float16x8_t b0 = MlasLoadFloat16x8(PackedB);
             float16x8_t b1 = MlasLoadFloat16x8(PackedB + 8);
             float16x8_t b2 = MlasLoadFloat16x8(PackedB + 16);
             float16x8_t b3 = MlasLoadFloat16x8(PackedB + 24);
+            for (; k >= 8; k -= 4, a += 4, PackedB += 4 * 8) {
+                accu00 = maq_lane_f16_accu(accu00, b0, b1, b2, b3, a0);
+                if constexpr (CountM == 2) {
+                    accu10 = maq_lane_f16_accu(accu10, b0, b1, b2, b3, a1);
+                }
+                a0 = MlasLoadFloat16x4(a + 4);
+                if constexpr (CountM == 2) {
+                    a1 = MlasLoadFloat16x4(a + lda + 4);
+                }
+                b0 = MlasLoadFloat16x8(PackedB + 32);
+                b1 = MlasLoadFloat16x8(PackedB + 40);
+                b2 = MlasLoadFloat16x8(PackedB + 48);
+                b3 = MlasLoadFloat16x8(PackedB + 56);
+            }
             accu00 = maq_lane_f16_accu(accu00, b0, b1, b2, b3, a0);
             if constexpr (CountM == 2) {
-                float16x4_t a1 = MlasLoadFloat16x4(a + lda);
                 accu10 = maq_lane_f16_accu(accu10, b0, b1, b2, b3, a1);
             }
+            k -= 4, a += 4, PackedB += 4 * 8;
         }
 
-        if (k > 0) {
+        if (Kr0) {
             float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1;
             if constexpr (CountM == 2) {
                 a1 = MlasLoadPartialFloat16x4(a + lda, k);
@@ -2453,14 +2959,14 @@ void HGemm_PackedB_Kernel_Impl(
             if constexpr (CountM == 2) {
                 accu10 = vfmaq_lane_f16(accu10, b0, a1, 0);
             }
-            if (k > 1) {
+            if (Kr1) {
                 float16x8_t b1 = MlasLoadFloat16x8(PackedB + 8);
                 accu00 = vfmaq_lane_f16(accu00, b1, a0, 1);
                 if constexpr (CountM == 2) {
                     accu10 = vfmaq_lane_f16(accu10, b1, a1, 1);
                 }
             }
-            if (k > 2) {
+            if (Kr2) {
                 float16x8_t b2 = MlasLoadFloat16x8(PackedB + 16);
                 accu00 = vfmaq_lane_f16(accu00, b2, a0, 2);
                 if constexpr (CountM == 2) {
@@ -2507,20 +3013,37 @@ void HGemm_PackedB_Kernel_Impl(
         if constexpr (CountM == 2) {
             accu1 = MlasZeroFloat16x8();
         }
-        for (; k >= 4; k -= 4, a += 4, PackedB += 4 * 8) {
-            float16x4_t a0 = MlasLoadFloat16x4(a);
+        if (largeK) {
+            float16x4_t a0 = MlasLoadFloat16x4(a), a1;
+            if constexpr (CountM == 2) {
+                a1 = MlasLoadFloat16x4(a + lda);
+            }
             float16x8_t b0 = MlasLoadFloat16x8(PackedB);
             float16x8_t b1 = MlasLoadFloat16x8(PackedB + 8);
             float16x8_t b2 = MlasLoadFloat16x8(PackedB + 16);
             float16x8_t b3 = MlasLoadFloat16x8(PackedB + 24);
+            for (; k >= 8; k -= 4, a += 4, PackedB += 4 * 8) {
+                accu0 = maq_lane_f16_accu(accu0, b0, b1, b2, b3, a0);
+                if constexpr (CountM == 2) {
+                    accu1 = maq_lane_f16_accu(accu1, b0, b1, b2, b3, a1);
+                }
+                a0 = MlasLoadFloat16x4(a + 4);
+                if constexpr (CountM == 2) {
+                    a1 = MlasLoadFloat16x4(a + lda + 4);
+                }
+                b0 = MlasLoadFloat16x8(PackedB + 32);
+                b1 = MlasLoadFloat16x8(PackedB + 40);
+                b2 = MlasLoadFloat16x8(PackedB + 48);
+                b3 = MlasLoadFloat16x8(PackedB + 56);
+            }
             accu0 = maq_lane_f16_accu(accu0, b0, b1, b2, b3, a0);
             if constexpr (CountM == 2) {
-                float16x4_t a1 = MlasLoadFloat16x4(a + lda);
                 accu1 = maq_lane_f16_accu(accu1, b0, b1, b2, b3, a1);
             }
+            k -= 4, a += 4, PackedB += 4 * 8;
         }
 
-        if (k > 0) {
+        if (Kr0) {
             float16x4_t a0 = MlasLoadPartialFloat16x4(a, k), a1;
             if constexpr (CountM == 2) {
                 a1 = MlasLoadPartialFloat16x4(a + lda, k);
@@ -2530,14 +3053,14 @@ void HGemm_PackedB_Kernel_Impl(
             if constexpr (CountM == 2) {
                 accu1 = vfmaq_lane_f16(accu1, b0, a1, 0);
             }
-            if (k > 1) {
+            if (Kr1) {
                 float16x8_t b1 = MlasLoadFloat16x8(PackedB + 8);
                 accu0 = vfmaq_lane_f16(accu0, b1, a0, 1);
                 if constexpr (CountM == 2) {
                     accu1 = vfmaq_lane_f16(accu1, b1, a1, 1);
                 }
             }
-            if (k > 2) {
+            if (Kr2) {
                 float16x8_t b2 = MlasLoadFloat16x8(PackedB + 16);
                 accu0 = vfmaq_lane_f16(accu0, b2, a0, 2);
                 if constexpr (CountM == 2) {

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -301,8 +301,8 @@ static_assert(sizeof(MLAS_FP16) == FP16_SIZE);
 // Define the default strides to step through slices of the input matrices.
 //
 
-#define MLAS_HGEMM_STRIDEN                          32
-#define MLAS_HGEMM_STRIDEK                          512
+#define MLAS_HGEMM_STRIDEN                          128
+#define MLAS_HGEMM_STRIDEK                          128
 #define MLAS_SGEMM_STRIDEN                          128
 #define MLAS_SGEMM_STRIDEK                          128
 #define MLAS_SGEMM_PACKED_STRIDEN                   128
@@ -319,7 +319,7 @@ static_assert(sizeof(MLAS_FP16) == FP16_SIZE);
 // the effort at this time.
 //
 
-#define MLAS_HGEMM_STRIDEN_THREAD_ALIGN             16
+#define MLAS_HGEMM_STRIDEN_THREAD_ALIGN             32
 #define MLAS_SGEMM_STRIDEN_THREAD_ALIGN             16
 #define MLAS_DGEMM_STRIDEN_THREAD_ALIGN             8
 #define MLAS_QGEMM_STRIDEN_THREAD_ALIGN             16

--- a/onnxruntime/core/mlas/lib/rotary_embedding_kernel_neon_fp16.cpp
+++ b/onnxruntime/core/mlas/lib/rotary_embedding_kernel_neon_fp16.cpp
@@ -46,15 +46,26 @@ RopeKernel_Fp16_Impl<false>(
 ) {
     const size_t half_dim = dim >> 1;
     size_t i = 0, j = half_dim;
-    for (; i + 7 < half_dim; i += 8, j += 8) {
+    if (i + 7 < half_dim) {
         float16x8_t real = MlasLoadFloat16x8(input + i);
         float16x8_t imag = MlasLoadFloat16x8(input + j);
         float16x8_t sin_val = MlasLoadFloat16x8(sin + i);
         float16x8_t cos_val = MlasLoadFloat16x8(cos + i);
+        for (; i + 15 < half_dim; i += 8, j += 8) {
+            float16x8_t real_out = vfmsq_f16(vmulq_f16(real, cos_val), imag, sin_val);
+            float16x8_t imag_out = vfmaq_f16(vmulq_f16(real, sin_val), imag, cos_val);
+            MlasStoreFloat16x8(output + i, real_out);
+            MlasStoreFloat16x8(output + j, imag_out);
+            real = MlasLoadFloat16x8(input + i + 8);
+            imag = MlasLoadFloat16x8(input + j + 8);
+            sin_val = MlasLoadFloat16x8(sin + i + 8);
+            cos_val = MlasLoadFloat16x8(cos + i + 8);
+        }
         float16x8_t real_out = vfmsq_f16(vmulq_f16(real, cos_val), imag, sin_val);
         float16x8_t imag_out = vfmaq_f16(vmulq_f16(real, sin_val), imag, cos_val);
         MlasStoreFloat16x8(output + i, real_out);
         MlasStoreFloat16x8(output + j, imag_out);
+        i += 8, j += 8;
     }
     for (; i + 3 < half_dim; i += 4, j += 4) {
         float16x4_t real = MlasLoadFloat16x4(input + i);
@@ -136,19 +147,34 @@ RopeKernel_Fp16_Impl<true>(
     _mlas_fp16_* output
 ) {
     size_t i = 0;
-    for (; i + 15 < dim; i += 16) {
+    if (i + 15 < dim) {
         float16x8_t x0 = MlasLoadFloat16x8(input + i);
         float16x8_t x1 = MlasLoadFloat16x8(input + i + 8);
-        float16x8_t real = vuzp1q_f16(x0, x1);
-        float16x8_t imag = vuzp2q_f16(x0, x1);
         float16x8_t sin_val = MlasLoadFloat16x8(sin + i);
         float16x8_t cos_val = MlasLoadFloat16x8(cos + i);
+        for (; i + 31 < dim; i += 16) {
+            float16x8_t real = vuzp1q_f16(x0, x1);
+            float16x8_t imag = vuzp2q_f16(x0, x1);
+            float16x8_t real_out = vfmsq_f16(vmulq_f16(real, cos_val), imag, sin_val);
+            float16x8_t imag_out = vfmaq_f16(vmulq_f16(real, sin_val), imag, cos_val);
+            float16x8_t y0 = vzip1q_f16(real_out, imag_out);
+            float16x8_t y1 = vzip2q_f16(real_out, imag_out);
+            MlasStoreFloat16x8(output + i, y0);
+            MlasStoreFloat16x8(output + i + 8, y1);
+            x0 = MlasLoadFloat16x8(input + i + 16);
+            x1 = MlasLoadFloat16x8(input + i + 24);
+            sin_val = MlasLoadFloat16x8(sin + i + 16);
+            cos_val = MlasLoadFloat16x8(cos + i + 16);
+        }
+        float16x8_t real = vuzp1q_f16(x0, x1);
+        float16x8_t imag = vuzp2q_f16(x0, x1);
         float16x8_t real_out = vfmsq_f16(vmulq_f16(real, cos_val), imag, sin_val);
         float16x8_t imag_out = vfmaq_f16(vmulq_f16(real, sin_val), imag, cos_val);
         float16x8_t y0 = vzip1q_f16(real_out, imag_out);
         float16x8_t y1 = vzip2q_f16(real_out, imag_out);
         MlasStoreFloat16x8(output + i, y0);
         MlasStoreFloat16x8(output + i + 8, y1);
+        i += 16;
     }
     for (; i + 7 < dim; i += 8) {
         float16x4_t x0 = MlasLoadFloat16x4(input + i);
@@ -226,7 +252,6 @@ RopeKernel_Fp16_Impl<true>(
 
 }  // namespace
 
-// TODO(fajin): intra-loop parallelism
 void
 RopeKernel_Fp16(
     const MLAS_FP16* input,

--- a/onnxruntime/core/mlas/lib/rotary_embedding_kernel_neon_fp16.cpp
+++ b/onnxruntime/core/mlas/lib/rotary_embedding_kernel_neon_fp16.cpp
@@ -226,6 +226,7 @@ RopeKernel_Fp16_Impl<true>(
 
 }  // namespace
 
+// TODO(fajin): intra-loop parallelism
 void
 RopeKernel_Fp16(
     const MLAS_FP16* input,

--- a/onnxruntime/core/mlas/lib/softmax_kernel_neon_fp16.cpp
+++ b/onnxruntime/core/mlas/lib/softmax_kernel_neon_fp16.cpp
@@ -20,6 +20,7 @@ Abstract:
 #include "softmax.h"
 #include "softmax_kernel_neon.h"
 
+// TODO(fajin): intra-loop parallelism
 namespace softmax_neon {
 
 template <typename T>

--- a/onnxruntime/core/mlas/lib/tanh.cpp
+++ b/onnxruntime/core/mlas/lib/tanh.cpp
@@ -209,7 +209,7 @@ MlasComputeSoftcap<float>(
     size_t N,
     float cap
 ) {
-    for (int i = 0; i < N; i++) {
+    for (size_t i = 0; i < N; i++) {
         Output[i] = Input[i] / cap;
         Output[i] = std::tanh(Output[i]);
         Output[i] = Output[i] * cap;

--- a/onnxruntime/core/mlas/lib/tanh.cpp
+++ b/onnxruntime/core/mlas/lib/tanh.cpp
@@ -203,6 +203,22 @@ MlasComputeTanh<MLAS_FP16>(
 template <>
 void
 MLASCALL
+MlasComputeSoftcap<float>(
+    const float* Input,
+    float* Output,
+    size_t N,
+    float cap
+) {
+    for (int i = 0; i < N; i++) {
+        Output[i] = Input[i] / cap;
+        Output[i] = std::tanh(Output[i]);
+        Output[i] = Output[i] * cap;
+    }
+}
+
+template <>
+void
+MLASCALL
 MlasComputeSoftcap<MLAS_FP16>(
     const MLAS_FP16* Input,
     MLAS_FP16* Output,

--- a/onnxruntime/test/mlas/unittest/test_hgemm_neon.cpp
+++ b/onnxruntime/test/mlas/unittest/test_hgemm_neon.cpp
@@ -537,6 +537,7 @@ class MlasNeonHGemmTest : public MlasTestBase {
     return "NeonHGemm";
   }
 
+  // TODO(fajin): test beta
   void ExecuteShort(void) override {
     TestHGemm<2, 1, 1, false, true>(MLAS_FP16(1.0f), MLAS_FP16(0.0f));
     TestHGemm<1, 128, 512, false, true>(MLAS_FP16(0.5f), MLAS_FP16(1.0f));

--- a/onnxruntime/test/mlas/unittest/test_hgemm_neon.cpp
+++ b/onnxruntime/test/mlas/unittest/test_hgemm_neon.cpp
@@ -435,8 +435,8 @@ class MlasNeonHGemmPackedBTest : public MlasTestBase {
 
   template <size_t M, size_t K, size_t N>
   MLAS_FORCEINLINE void HGemm(
-    const MLAS_FP16* A, const MLAS_FP16* B, MLAS_FP16* C, MLAS_FP16 alpha, MLAS_FP16 beta,
-    size_t lda, size_t ldc) {
+      const MLAS_FP16* A, const MLAS_FP16* B, MLAS_FP16* C, MLAS_FP16 alpha, MLAS_FP16 beta,
+      size_t lda, size_t ldc) {
     float alphaf = alpha.ToFloat();
     float betaf = beta.ToFloat();
     size_t n = 0;


### PR DESCRIPTION
### Description
 - Enable hgemm and softmax fp16 kernels for GQA
 - add intra-loop parallelism to RoPE fp16 kernel

__Benchmarking models__
- float32: [phi-3 cpu accuracy level 0](https://huggingface.co/microsoft/Phi-3-mini-4k-instruct-onnx/tree/main/cpu_and_mobile/cpu-int4-rtn-block-32)
- float16: [phi-3 gpu accuracy level 0](https://huggingface.co/microsoft/Phi-3-mini-4k-instruct-onnx/tree/main/cuda/cuda-int4-rtn-block-32)

Note: 
- Both fp32 and fp16 models share the same model structure and operator settings.
- GQA takes ~15% of the runtime.
- prompt length 256, token generation length 512

Linux (ubuntu 24.04) Standard D16pls v5 (16 vcpus, 32 GiB memory)
| | fp32 (tps) | old fp16 (tps) | new fp16 (tps) | new fp16 vs old fp16 | new fp16 vs fp32 |
|--|--|--|--|--|--|
| prompt processing | 31.22 | 44.24 | 46.29 | +4.6% | +48.25% |
| token generation | 4.75  | 7.2 | 7.95 | +10.39% | +67.43% |

### Motivation and Context
Speed up GQA on FP16


