### PR TITLE
[JSEP] fix scatter-nd jsep kernel

### DIFF
--- a/js/web/lib/wasm/jsep/webgpu/ops/scatter-nd.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/scatter-nd.ts
@@ -111,8 +111,29 @@ const createScatterNDProgramInfo = (inputs: readonly TensorView[], attributes: S
         .declareVariables(indices, updates, output)}
       ${shaderHelper.mainStart()}
         ${shaderHelper.guardAgainstOutOfBoundsWorkgroupSizes('uniforms.output_size')}
+  var hasDuplicates = false;
+  if (${attributes.reduction === "none"}) {
+    let n = ${ShapeUtil.size(indicesShape)};
+    for (var i = 0; i < n; i = i + 1) {
+      for (var j = i + 1; j < n; j = j + 1) {
+        var index_i = i32(indices[i].x);
+        var index_j = i32(indices[j].x);
+        if (index_i == index_j) {
+          hasDuplicates = true;
+          break;
+        }
+      }
+      if (hasDuplicates) {
+        break;
+      }
+    }
+  }
+
   var data_offset = 0u;
-  let indices_start = uniforms.last_index_dimension * global_idx;
+  var indices_start = uniforms.last_index_dimension * global_idx;
+  if (${attributes.reduction === "none"} && hasDuplicates) {
+    indices_start = 0u;
+  }
   let indices_end = indices_start + uniforms.last_index_dimension;
   for (var i = indices_start; i < indices_end; i++) {
     var index = i32(indices[i].x);

--- a/js/web/lib/wasm/jsep/webgpu/ops/scatter-nd.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/scatter-nd.ts
@@ -132,6 +132,9 @@ const createScatterNDProgramInfo = (inputs: readonly TensorView[], attributes: S
   var data_offset = 0u;
   var indices_start = uniforms.last_index_dimension * global_idx;
   if (${attributes.reduction === 'none'} && hasDuplicates) {
+    if (global_idx != 0u) {
+      return;
+    }
     indices_start = 0u;
   }
   let indices_end = indices_start + uniforms.last_index_dimension;

--- a/js/web/lib/wasm/jsep/webgpu/ops/scatter-nd.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/scatter-nd.ts
@@ -112,7 +112,7 @@ const createScatterNDProgramInfo = (inputs: readonly TensorView[], attributes: S
       ${shaderHelper.mainStart()}
         ${shaderHelper.guardAgainstOutOfBoundsWorkgroupSizes('uniforms.output_size')}
   var hasDuplicates = false;
-  if (${attributes.reduction === "none"}) {
+  if (${attributes.reduction === 'none'}) {
     let n = ${ShapeUtil.size(indicesShape)};
     for (var i = 0; i < n; i = i + 1) {
       for (var j = i + 1; j < n; j = j + 1) {
@@ -131,7 +131,7 @@ const createScatterNDProgramInfo = (inputs: readonly TensorView[], attributes: S
 
   var data_offset = 0u;
   var indices_start = uniforms.last_index_dimension * global_idx;
-  if (${attributes.reduction === "none"} && hasDuplicates) {
+  if (${attributes.reduction === 'none'} && hasDuplicates) {
     indices_start = 0u;
   }
   let indices_end = indices_start + uniforms.last_index_dimension;

--- a/js/web/test/data/ops/scatternd.jsonc
+++ b/js/web/test/data/ops/scatternd.jsonc
@@ -403,7 +403,7 @@
     "name": "ScatterND float16",
     "operator": "ScatterND",
     "attributes": [],
-    "opset": { "domain": "", "version": 11 },
+    "opset": { "domain": "", "version": 13 },
     "cases": [
       {
         "name": "float16",
@@ -428,6 +428,33 @@
           {
             "data": [1.1, 11.3, 3.1, 10.2, 9.1, 6.1, 7.8, 12.5],
             "dims": [8],
+            "type": "float16"
+          }
+        ]
+      },
+      {
+        "name": "SAM_float16",
+        "inputs": [
+          {
+            "data": [14446, 24198, 0, 0],
+            "dims": [1, 1, 2, 2],
+            "type": "float16"
+          },
+          {
+            "data": [0, 0, 0, 1, 0, 0, 1, 1],
+            "dims": [1, 1, 2, 1, 4],
+            "type": "int64"
+          },
+          {
+            "data": [13958, 0],
+            "dims": [1, 1, 2, 1],
+            "type": "float16"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [14446, 13958, 0, 0],
+            "dims": [1, 1, 2, 2],
             "type": "float16"
           }
         ]

--- a/onnxruntime/core/providers/js/js_execution_provider.cc
+++ b/onnxruntime/core/providers/js/js_execution_provider.cc
@@ -746,10 +746,10 @@ std::unique_ptr<KernelRegistry> RegisterKernels() {
 
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 16, 19, GridSample)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kJsExecutionProvider, kMSInternalNHWCDomain, 16, 19, GridSample)>,
-      // BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 11, 12, ScatterND)>,
-      // BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 13, 15, ScatterND)>,
-      // BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 16, 17, ScatterND)>,
-      // BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 18, ScatterND)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 11, 12, ScatterND)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 13, 15, ScatterND)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 16, 17, ScatterND)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 18, ScatterND)>,
   };
 
   for (auto& function_table_entry : function_table) {

--- a/onnxruntime/core/providers/js/operators/scatter_nd.h
+++ b/onnxruntime/core/providers/js/operators/scatter_nd.h
@@ -30,8 +30,7 @@ class ScatterND : public JsKernel {
     } else if (reduction == "max") {
       reduction_ = ScatterNDReduction::Max;
     } else if (reduction == "none") {
-      LOGS_DEFAULT(WARNING) << "ScatterND with reduction=='none' only guarantees "
-                            << "to be correct if indices are not duplicated.";
+      reduction_ = ScatterNDReduction::None;
     } else {
       ORT_THROW("Reduction '", reduction, "' is not supported on webgpu when opset <= 13.");
     }


### PR DESCRIPTION
Adjusts scatter-nd kernel implementation for the case when reduction=none and there are duplicate values in the indices input tensor. If duplicates are detected, a single thread processes all indices to ensure correct results.