### PR TITLE
Enable test_gathernd_example_int32_batch_dim1

### DIFF
--- a/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
+++ b/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
@@ -36,7 +36,6 @@
         "^test_batchnorm_example_old",
         "^test_batchnorm_example_training_mode",
         "^test_col2im_pads",  // still one wrong value coming from the backtest example
-        "^test_gathernd_example_int32_batch_dim1",
         "^test_max_int16",
         "^test_max_int8",
         "^test_max_uint16",


### PR DESCRIPTION
This test passed locally, so I am enabling it to see if it also passes on the pipelines

`.\build\Windows\Debug\Debug\onnx_test_runner.exe "C:\work\onnxruntime\build\Windows\Debug\_deps\onnx-src\onnx\backend\test\data\node\test_gathernd_example_int32_batch_dim1"`
Load Test Case: gathernd_example_int32_batch_dim1 in C:\work\onnxruntime\build\Windows\Debug\_deps\onnx-src\onnx\backend\test\data\node\test_gathernd_example_int32_batch_dim1
result:
        Models: 1
        Total test cases: 1
                Succeeded: 1
                Not implemented: 0
                Failed: 0
        Stats by Operator type:
                Not implemented(0):
                Failed: