### PR TITLE
Update onnxruntime_external_deps.cmake: add missing EXCLUDE_FROM_ALL

### DIFF
--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -301,6 +301,7 @@ if(NOT TARGET Boost::mp11)
     onnxruntime_fetchcontent_declare(
      mp11
      URL ${DEP_URL_mp11}
+     EXCLUDE_FROM_ALL
      FIND_PACKAGE_ARGS NAMES Boost
     )
     onnxruntime_fetchcontent_makeavailable(mp11)    


### PR DESCRIPTION
### Description
To resolve #23821 


### Motivation and Context
Similar to #23641 .

