### PR TITLE
[WebNN] Better int64 integration

### DIFF
--- a/js/web/lib/wasm/jsep/backend-webnn.ts
+++ b/js/web/lib/wasm/jsep/backend-webnn.ts
@@ -288,7 +288,7 @@ export class WebNNBackend {
     builder: MLGraphBuilder,
     desc: MLOperandDescriptor,
     mountedFiles: Map<string, Uint8Array> | undefined,
-    shouldConvertInt64ToInt32: boolean = false,
+    shouldConvertInt64ToInt32 = false,
   ): MLOperand {
     // If available, "Module.MountedFiles" is a Map for all preloaded files.
     if (!mountedFiles) {
@@ -373,7 +373,7 @@ export class WebNNBackend {
 
   public isInt64Supported(sessionId: number): boolean {
     const context = this.mlContextBySessionId.get(sessionId);
-    return !!context?.opSupportLimits()['input']['dataTypes'].includes('int64');
+    return !!context?.opSupportLimits().input.dataTypes.includes('int64');
   }
 
   public flush(): void {

--- a/js/web/lib/wasm/jsep/backend-webnn.ts
+++ b/js/web/lib/wasm/jsep/backend-webnn.ts
@@ -327,7 +327,7 @@ export class WebNNBackend {
       case 'int64':
         if (shouldConvertInt64ToInt32) {
           // Int64 is not supported by current context, use int32 instead.
-          bufferView = convertInt64ToInt32(new Uint8Array(buffer), false);
+          bufferView = convertInt64ToInt32(new Uint8Array(buffer), false) as Int32Array;
           desc.dataType = 'int32';
         } else {
           bufferView = new BigInt64Array(buffer);

--- a/js/web/lib/wasm/jsep/webnn/webnn.d.ts
+++ b/js/web/lib/wasm/jsep/webnn/webnn.d.ts
@@ -415,4 +415,13 @@ interface MLContext {
   readTensor(sourceTensor: MLTensor): Promise<ArrayBuffer>;
   readTensor(sourceTensor: MLTensor, destinationData: ArrayBufferView|ArrayBuffer): Promise<undefined>;
   dispatch(graph: MLGraph, inputs: MLNamedTensor, outputs: MLNamedTensor): void;
+  opSupportLimits() : MLOpSupportLimits;
+}
+
+interface MLOpSupportLimits {
+  input: MLSupportLimits;
+}
+
+interface MLSupportLimits {
+  dataTypes: MLOperandDataType[];
 }

--- a/js/web/lib/wasm/wasm-core-impl.ts
+++ b/js/web/lib/wasm/wasm-core-impl.ts
@@ -863,12 +863,18 @@ export const run = async (
             }
           } else if (preferredLocation === 'ml-tensor' && size > 0) {
             const ensureTensor = wasm.jsepEnsureTensor;
-            if (!ensureTensor) {
+            const isInt64Supported = wasm.jsepIsInt64Supported;
+            if (!ensureTensor || !isInt64Supported) {
               throw new Error('preferredLocation "ml-tensor" is not supported without using WebNN.');
             }
             const tensorSize = calculateTensorSizeInBytes(dataType, size);
             if (tensorSize === undefined || !isMLTensorSupportedType(type)) {
               throw new Error(`Unsupported data type: ${type}`);
+            }
+            if (type === 'int64' && !isInt64Supported(sessionId)) {
+              throw new Error(
+                `preferredLocation "ml-tensor" for int64 output is not supported by current WebNN Context.`,
+              );
             }
 
             // If the graph has been partitioned, the output tensor may have not been created. For this reason, we use

--- a/js/web/lib/wasm/wasm-types.ts
+++ b/js/web/lib/wasm/wasm-types.ts
@@ -249,6 +249,7 @@ export declare namespace JSEP {
      * @param dataLength - specify the external data length.
      * @param builder - specify the MLGraphBuilder used for constructing the Constant.
      * @param desc - specify the MLOperandDescriptor of the Constant.
+     * @param shouldConvertInt64ToInt32 - specify whether to convert int64 to int32.
      * @returns the WebNN Constant operand for the specified external data.
      */
     jsepRegisterMLConstant(
@@ -257,6 +258,7 @@ export declare namespace JSEP {
       dataLength: number,
       builder: MLGraphBuilder,
       desc: MLOperandDescriptor,
+      shouldConvertInt64ToInt32: boolean,
     ): MLOperand;
 
     /**
@@ -279,6 +281,12 @@ export declare namespace JSEP {
      * @returns the MLTensor ID for the temporary MLTensor.
      */
     jsepCreateTemporaryTensor: (sessionId: number, dataType: DataType, shape: readonly number[]) => Promise<number>;
+    /**
+     * [exported from pre-jsep.js] Check if a session's associated WebNN Context supports int64.
+     * @param sessionId - specify the session ID.
+     * @returns whether the WebNN Context supports int64.
+     */
+    jsepIsInt64Supported: (sessionId: number) => boolean;
   }
 }
 

--- a/onnxruntime/core/providers/webnn/builders/helper.cc
+++ b/onnxruntime/core/providers/webnn/builders/helper.cc
@@ -144,9 +144,19 @@ bool IsSupportedDataType(const int32_t onnx_data_type, const emscripten::val& we
   const std::string_view webnn_data_type = it->second;
 
   // Check if WebNN supports the data type.
-  emscripten::val is_supported =
-      webnn_supported_data_types.call<emscripten::val>("includes", emscripten::val(std::string(webnn_data_type)));
-  return is_supported.as<bool>();
+  bool is_supported = webnn_supported_data_types.call<emscripten::val>("includes",
+                                                                       emscripten::val(std::string(webnn_data_type)))
+                          .as<bool>();
+
+  if (webnn_data_type == "int64" &&
+      !is_supported &&
+      webnn_supported_data_types.call<emscripten::val>("includes", emscripten::val("int32")).as<bool>()) {
+    // Current context doesn't support int64, but int32 is supported.
+    // We can use int32 as a workaround.
+    is_supported = true;
+  }
+
+  return is_supported;
 }
 
 // Check if the input or output data type of ONNX node is supported by the WebNN operator.

--- a/onnxruntime/core/providers/webnn/builders/helper.h
+++ b/onnxruntime/core/providers/webnn/builders/helper.h
@@ -82,13 +82,14 @@ inline std::string GetTensorName(const ConstPointerContainer<std::vector<NodeArg
   return (input_defs.size() > index) ? std::string(input_defs[index]->Name()) : "";
 }
 
-inline std::vector<uint32_t> GetVecUint32FromVecInt64(gsl::span<const int64_t> int64_vec) {
-  std::vector<uint32_t> uint32_vec;
-  uint32_vec.reserve(int64_vec.size());
+template <typename T>
+inline std::vector<T> GetNarrowedIntfromInt64(gsl::span<const int64_t> int64_vec) {
+  std::vector<T> vec;
+  vec.reserve(int64_vec.size());
   std::transform(int64_vec.begin(), int64_vec.end(),
-                 std::back_inserter(uint32_vec),
-                 [](int64_t val) -> uint32_t { return SafeInt<uint32_t>(val); });
-  return uint32_vec;
+                 std::back_inserter(vec),
+                 [](int64_t val) -> T { return SafeInt<T>(val); });
+  return vec;
 }
 
 template <typename T>

--- a/onnxruntime/core/providers/webnn/builders/impl/argmax_min_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/argmax_min_op_builder.cc
@@ -43,8 +43,12 @@ Status ArgMaxMinOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
 
   emscripten::val options = emscripten::val::object();
   options.set("keepDimensions", keep_dims == 1);
-  // TODO(Honry): check whether int64 output data type is supported by WebNN opSupportLimits() API.
-  options.set("outputDataType", "int64");
+  std::string output_data_type = "int64";
+  if (!model_builder.IsInt64Supported()) {
+    // Int64 is not supported by current context, use int32 instead.
+    output_data_type = "int32";
+  }
+  options.set("outputDataType", output_data_type);
   options.set("label", node.Name());
   emscripten::val output = emscripten::val::object();
 

--- a/onnxruntime/core/providers/webnn/builders/impl/cast_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/cast_op_builder.cc
@@ -73,6 +73,10 @@ Status CastOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
   emscripten::val options = emscripten::val::object();
   options.set("label", node.Name());
 
+  if (to_type == ONNX_NAMESPACE::TensorProto_DataType_INT64 && !model_builder.IsInt64Supported()) {
+    // Int64 is not supported by current context, use int32 instead.
+    operand_type = "int32";
+  }
   emscripten::val output =
       model_builder.GetBuilder().call<emscripten::val>("cast", input, emscripten::val(operand_type), options);
 

--- a/onnxruntime/core/providers/webnn/builders/impl/cast_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/cast_op_builder.cc
@@ -56,7 +56,8 @@ Status CastOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
       operand_type = "int32";
       break;
     case ONNX_NAMESPACE::TensorProto_DataType_INT64:
-      operand_type = "int64";
+      // If int64 is not supported by current context, use int32 instead.
+      operand_type = model_builder.IsInt64Supported() ? "int64" : "int32";
       break;
     case ONNX_NAMESPACE::TensorProto_DataType_UINT32:
       operand_type = "uint32";
@@ -73,10 +74,6 @@ Status CastOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
   emscripten::val options = emscripten::val::object();
   options.set("label", node.Name());
 
-  if (to_type == ONNX_NAMESPACE::TensorProto_DataType_INT64 && !model_builder.IsInt64Supported()) {
-    // Int64 is not supported by current context, use int32 instead.
-    operand_type = "int32";
-  }
   emscripten::val output =
       model_builder.GetBuilder().call<emscripten::val>("cast", input, emscripten::val(operand_type), options);
 

--- a/onnxruntime/core/providers/webnn/builders/impl/conv_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/conv_op_builder.cc
@@ -76,7 +76,7 @@ common::Status SetConvBaseOptions(ModelBuilder& model_builder,
     if (output_padding.size() == 1 && is_conv1d) {
       output_padding.push_back(0);
     }
-    options.set("outputPadding", emscripten::val::array(GetVecUint32FromVecInt64(output_padding)));
+    options.set("outputPadding", emscripten::val::array(GetNarrowedIntfromInt64<uint32_t>(output_padding)));
 
     // If output shape is explicitly provided, compute the pads.
     // Otherwise compute the output shape, as well as the pads if the auto_pad attribute is SAME_UPPER/SAME_LOWER.
@@ -85,7 +85,7 @@ common::Status SetConvBaseOptions(ModelBuilder& model_builder,
                                                                auto_pad_type, pads_out, output_shape, !is_nhwc));
 
     if (output_shape[0] != -1 && output_shape[1] != -1) {
-      options.set("outputSizes", emscripten::val::array(GetVecUint32FromVecInt64(output_shape)));
+      options.set("outputSizes", emscripten::val::array(GetNarrowedIntfromInt64<uint32_t>(output_shape)));
     }
     pads = pads_out;
   } else {
@@ -95,13 +95,13 @@ common::Status SetConvBaseOptions(ModelBuilder& model_builder,
 
   const auto group = helper.Get("group", static_cast<uint32_t>(1));
   options.set("groups", group);
-  options.set("strides", emscripten::val::array(GetVecUint32FromVecInt64(strides)));
-  options.set("dilations", emscripten::val::array(GetVecUint32FromVecInt64(dilations)));
+  options.set("strides", emscripten::val::array(GetNarrowedIntfromInt64<uint32_t>(strides)));
+  options.set("dilations", emscripten::val::array(GetNarrowedIntfromInt64<uint32_t>(dilations)));
 
   // Permute the ONNX's pads, which is [beginning_height, beginning_width, ending_height, ending_width],
   // while WebNN's padding is [beginning_height, ending_height, beginning_width, ending_width].
   const std::vector<int64_t> padding{pads[0], pads[2], pads[1], pads[3]};
-  options.set("padding", emscripten::val::array(GetVecUint32FromVecInt64(padding)));
+  options.set("padding", emscripten::val::array(GetNarrowedIntfromInt64<uint32_t>(padding)));
 
   // Add bias if present.
   if (input_defs.size() > 2) {
@@ -120,7 +120,8 @@ Status AddInitializerInNewLayout(ModelBuilder& model_builder,
   auto data_type = tensor.data_type();
 
   const auto& shape = tensor.dims();
-  std::vector<uint32_t> dims = GetVecUint32FromVecInt64(std::vector<int64_t>(std::begin(shape), std::end(shape)));
+  std::vector<uint32_t> dims =
+      GetNarrowedIntfromInt64<uint32_t>(std::vector<int64_t>(std::begin(shape), std::end(shape)));
 
   if (is_conv1d) {
     // Support conv1d by prepending a 1 size dimension.
@@ -229,7 +230,7 @@ Status ConvOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const N
     } else {
       input_shape.push_back(1);
     }
-    std::vector<uint32_t> new_shape = GetVecUint32FromVecInt64(input_shape);
+    std::vector<uint32_t> new_shape = GetNarrowedIntfromInt64<uint32_t>(input_shape);
     input = model_builder.GetBuilder().call<emscripten::val>("reshape", input, emscripten::val::array(new_shape));
 
     weight_shape.resize(4, 1);  // Ensure 4D by appending 1's if needed.
@@ -276,7 +277,7 @@ Status ConvOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const N
     // Reshape weight to 4D for conv1d.
     if (!is_nhwc || !is_constant_weight) {
       // The weight_shape has been appended 1's, reshape weight operand.
-      std::vector<uint32_t> new_shape = GetVecUint32FromVecInt64(weight_shape);
+      std::vector<uint32_t> new_shape = GetNarrowedIntfromInt64<uint32_t>(weight_shape);
       emscripten::val reshape_options = emscripten::val::object();
       reshape_options.set("label", node.Name() + "_reshape_filter");
       filter = model_builder.GetBuilder().call<emscripten::val>("reshape",
@@ -329,7 +330,7 @@ Status ConvOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const N
     const auto& output_defs = node.OutputDefs();
     std::vector<int64_t> output_shape;
     ORT_RETURN_IF_NOT(GetShape(*output_defs[0], output_shape, logger), "Cannot get output shape");
-    std::vector<uint32_t> new_shape = GetVecUint32FromVecInt64(output_shape);
+    std::vector<uint32_t> new_shape = GetNarrowedIntfromInt64<uint32_t>(output_shape);
     emscripten::val reshape_options = emscripten::val::object();
     reshape_options.set("label", node.Name() + "_reshape_output");
     output = model_builder.GetBuilder().call<emscripten::val>("reshape",

--- a/onnxruntime/core/providers/webnn/builders/impl/dropout_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/dropout_op_builder.cc
@@ -58,7 +58,7 @@ Status DropoutOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
   if (output_defs.size() > 1) {
     std::vector<int64_t> mask_shape;
     ORT_RETURN_IF_NOT(GetShape(*output_defs[1], mask_shape, logger), "Cannot get mask output's shape");
-    std::vector<uint32_t> dims = GetVecUint32FromVecInt64(mask_shape);
+    std::vector<uint32_t> dims = GetNarrowedIntfromInt64<uint32_t>(mask_shape);
     emscripten::val one_constant = model_builder.CreateOrGetConstant<uint8_t>(
         ONNX_NAMESPACE::TensorProto_DataType_BOOL, 1, dims);
 

--- a/onnxruntime/core/providers/webnn/builders/impl/expand_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/expand_op_builder.cc
@@ -56,11 +56,8 @@ Status ExpandOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
   emscripten::val options = emscripten::val::object();
   options.set("label", node.Name());
 
-  emscripten::val output =
-      model_builder.GetBuilder().call<emscripten::val>("expand",
-                                                       input,
-                                                       emscripten::val::array(GetVecUint32FromVecInt64(output_shape)),
-                                                       options);
+  emscripten::val output_shape_arr = emscripten::val::array(GetNarrowedIntfromInt64<uint32_t>(output_shape));
+  emscripten::val output = model_builder.GetBuilder().call<emscripten::val>("expand", input, output_shape_arr, options);
   model_builder.AddOperand(node.OutputDefs()[0]->Name(), std::move(output));
   return Status::OK();
 }

--- a/onnxruntime/core/providers/webnn/builders/impl/gemm_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/gemm_op_builder.cc
@@ -55,22 +55,20 @@ Status GemmOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const N
     if (a_shape.size() == 1) {
       extended_a_shape = true;
       a_shape.insert(a_shape.begin(), 1);
+      emscripten::val a_shape_arr = emscripten::val::array(GetNarrowedIntfromInt64<uint32_t>(a_shape));
       emscripten::val reshape_a_options = emscripten::val::object();
       reshape_a_options.set("label", node.Name() + "_reshape_a");
-      a = model_builder.GetBuilder().call<emscripten::val>("reshape", a,
-                                                           emscripten::val::array(GetVecUint32FromVecInt64(a_shape)),
-                                                           reshape_a_options);
+      a = model_builder.GetBuilder().call<emscripten::val>("reshape", a, a_shape_arr, reshape_a_options);
     }
     // If the second argument is 1-D, it is promoted to a matrix by appending a 1 to its dimensions.
     bool extended_b_shape = false;
     if (b_shape.size() == 1) {
       extended_b_shape = true;
       b_shape.push_back(1);
+      emscripten::val b_shape_arr = emscripten::val::array(GetNarrowedIntfromInt64<uint32_t>(b_shape));
       emscripten::val reshape_b_options = emscripten::val::object();
       reshape_b_options.set("label", node.Name() + "_reshape_b");
-      b = model_builder.GetBuilder().call<emscripten::val>("reshape", b,
-                                                           emscripten::val::array(GetVecUint32FromVecInt64(b_shape)),
-                                                           reshape_b_options);
+      b = model_builder.GetBuilder().call<emscripten::val>("reshape", b, b_shape_arr, reshape_b_options);
     }
 
     output = model_builder.GetBuilder().call<emscripten::val>("matmul", a, b, options);

--- a/onnxruntime/core/providers/webnn/builders/impl/normalization_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/normalization_op_builder.cc
@@ -208,7 +208,7 @@ Status NormalizationOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder
     output = model_builder.GetBuilder().call<emscripten::val>("instanceNormalization", input, options);
     // Reshape back to the original output shape for 3D input.
     if (input_shape.size() != 4) {
-      std::vector<uint32_t> output_shape = GetVecUint32FromVecInt64(input_shape);
+      std::vector<uint32_t> output_shape = GetNarrowedIntfromInt64<uint32_t>(input_shape);
       emscripten::val reshape_output_options = emscripten::val::object();
       reshape_output_options.set("label", node.Name() + "reshape_output");
       output = model_builder.GetBuilder().call<emscripten::val>("reshape",

--- a/onnxruntime/core/providers/webnn/builders/impl/pool_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/pool_op_builder.cc
@@ -95,7 +95,7 @@ Status PoolOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
                                       auto_pad_type,
                                       pads_out,
                                       model_builder.GetPreferredLayout() == DataLayout::NCHW));
-    pads = GetVecUint32FromVecInt64(pads_out);
+    pads = GetNarrowedIntfromInt64<uint32_t>(pads_out);
   }
   // Permute the ONNX's pads, which is [beginning_height, beginning_width, ending_height, ending_width],
   // while WebNN's padding is [beginning_height, ending_height, beginning_width, ending_width].

--- a/onnxruntime/core/providers/webnn/builders/impl/qdq_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/qdq_op_builder.cc
@@ -100,7 +100,7 @@ Status QDQOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
   if (!has_zero_point) {
     if (zero_point_shape.empty()) {
       // zero_point has the same shape as the scale tensor.
-      zero_point_shape = GetVecUint32FromVecInt64(scale_shape);
+      zero_point_shape = GetNarrowedIntfromInt64<uint32_t>(scale_shape);
     }
     // Create a zero constant with the same shape as the scale tensor.
     // The zero value has been pre-processed in the CreateOrGetConstant function,

--- a/onnxruntime/core/providers/webnn/builders/impl/resize_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/resize_op_builder.cc
@@ -225,7 +225,7 @@ Status ResizeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
   if (using_sizes) {
     ORT_RETURN_IF_NOT(GetResizeSizesAndAxes(initializers, node, sizes, axes, is_nhwc, input_shape, logger),
                       "Error getting Resize sizes");
-    webnn_sizes = GetVecUint32FromVecInt64(sizes);
+    webnn_sizes = GetNarrowedIntfromInt64<uint32_t>(sizes);
     options.set("sizes", emscripten::val::array(webnn_sizes));
   } else {
     ORT_RETURN_IF_NOT(GetResizeScalesAndAxes(initializers, node, scales, axes, is_nhwc, logger),
@@ -233,7 +233,7 @@ Status ResizeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
     options.set("scales", emscripten::val::array(scales));
   }
 
-  std::vector<uint32_t> webnn_axes = GetVecUint32FromVecInt64(axes);
+  std::vector<uint32_t> webnn_axes = GetNarrowedIntfromInt64<uint32_t>(axes);
   options.set("axes", emscripten::val::array(webnn_axes));
 
   emscripten::val input = model_builder.GetOperand(input_defs[0]->Name());

--- a/onnxruntime/core/providers/webnn/builders/impl/rotaryEmbedding_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/rotaryEmbedding_op_builder.cc
@@ -275,7 +275,7 @@ Status RotaryEmbeddingOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_build
   }
 
   // Reshape the output to the original shape. The output shape is the same as the input shape.
-  const std::vector<uint32_t> output_shape = GetVecUint32FromVecInt64(input_shape);
+  const std::vector<uint32_t> output_shape = GetNarrowedIntfromInt64<uint32_t>(input_shape);
   emscripten::val reshape_output_options = emscripten::val::object();
   reshape_output_options.set("label", node_name + "_reshape_output");
   output = wnn_builder.call<emscripten::val>(

--- a/onnxruntime/core/providers/webnn/builders/impl/rotaryEmbedding_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/rotaryEmbedding_op_builder.cc
@@ -159,14 +159,22 @@ Status RotaryEmbeddingOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_build
   if (position_ids_is_offset) {
     // We generate a sequence from 0 to sequence_length and add the offset to it.
     const std::vector<uint32_t> position_ids_range_shape = {1, sequence_length};
-    emscripten::val position_ids_range_buffer = emscripten::val::global("BigInt64Array").new_(sequence_length);
+    std::string typed_array_name = "BigInt64Array";
+    int position_ids_data_type = ONNX_NAMESPACE::TensorProto_DataType_INT64;
+    const bool is_int64_supported = model_builder.IsInt64Supported();
+    if (!is_int64_supported) {
+      // Int64 is not supported by current context, use int32 instead.
+      typed_array_name = "Int32Array";
+      position_ids_data_type = ONNX_NAMESPACE::TensorProto_DataType_INT32;
+    }
+    emscripten::val position_ids_range_buffer = emscripten::val::global(typed_array_name.c_str()).new_(sequence_length);
     for (uint32_t i = 0; i < sequence_length; i++) {
-      position_ids_range_buffer.set(i, emscripten::val::global("BigInt")(i));
+      position_ids_range_buffer.set(i, is_int64_supported ? emscripten::val::global("BigInt")(i) : emscripten::val(i));
     }
     emscripten::val position_ids_range_desc = emscripten::val::object();
     position_ids_range_desc.set("shape", emscripten::val::array(position_ids_range_shape));
     position_ids_range_desc.set("dimensions", emscripten::val::array(position_ids_range_shape));
-    position_ids_range_desc.set("dataType", emscripten::val("int64"));
+    ORT_RETURN_IF_NOT(SetWebnnDataType(position_ids_range_desc, position_ids_data_type), "Unsupported data type");
     emscripten::val position_ids_range = wnn_builder.call<emscripten::val>(
         "constant", position_ids_range_desc, position_ids_range_buffer);
     // Add the offset to the sequence.

--- a/onnxruntime/core/providers/webnn/builders/impl/shape_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/shape_op_builder.cc
@@ -29,12 +29,20 @@ Status ShapeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
   const auto rank = static_cast<int32_t>(input_shape.size());
 
   emscripten::val desc = emscripten::val::object();
-  ORT_RETURN_IF_NOT(SetWebnnDataType(desc, ONNX_NAMESPACE::TensorProto_DataType_INT64), "Unsupported data type");
   emscripten::val dims = emscripten::val::array();
   dims.call<void>("push", rank);
   desc.set("dimensions", dims);
   desc.set("shape", dims);
-  emscripten::val shape_buffer = emscripten::val::global("BigInt64Array").new_(emscripten::val::array(input_shape));
+  int data_type = ONNX_NAMESPACE::TensorProto_DataType_INT64;
+  std::string typed_array_name = "BigInt64Array";
+  if (!model_builder.IsInt64Supported()) {
+    // Int64 is not supported by current context, use int32 instead.
+    data_type = ONNX_NAMESPACE::TensorProto_DataType_INT32;
+    typed_array_name = "Int32Array";
+  }
+  ORT_RETURN_IF_NOT(SetWebnnDataType(desc, data_type), "Unsupported data type");
+  emscripten::val shape_buffer =
+      emscripten::val::global(typed_array_name.c_str()).new_(emscripten::val::array(input_shape));
   emscripten::val shape_constant = model_builder.GetBuilder().call<emscripten::val>("constant", desc, shape_buffer);
 
   NodeAttrHelper helper(node);

--- a/onnxruntime/core/providers/webnn/builders/impl/slice_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/slice_op_builder.cc
@@ -116,8 +116,8 @@ Status SliceOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const 
 
   emscripten::val output = reverse_output;
   if (is_slice_required) {
-    std::vector<uint32_t> starts = GetVecUint32FromVecInt64(compute_metadata.starts_);
-    std::vector<uint32_t> steps = GetVecUint32FromVecInt64(compute_metadata.steps_);
+    std::vector<uint32_t> starts = GetNarrowedIntfromInt64<uint32_t>(compute_metadata.starts_);
+    std::vector<uint32_t> steps = GetNarrowedIntfromInt64<uint32_t>(compute_metadata.steps_);
     std::vector<uint32_t> sizes(rank);
     std::transform(compute_metadata.ends_.cbegin(), compute_metadata.ends_.cend(), compute_metadata.starts_.cbegin(),
                    sizes.begin(), [](int64_t i, int64_t j) { return SafeInt<uint32_t>(i - j); });

--- a/onnxruntime/core/providers/webnn/builders/impl/squeeze_unsqueeze_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/squeeze_unsqueeze_op_builder.cc
@@ -86,7 +86,7 @@ Status SqueezeUnsqueezeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_buil
 
   emscripten::val output = emscripten::val::undefined();
   // Use WebNN's reshape to implement Squeeze/Unsqueeze.
-  std::vector<uint32_t> new_shape = GetVecUint32FromVecInt64(input_shape);
+  std::vector<uint32_t> new_shape = GetNarrowedIntfromInt64<uint32_t>(input_shape);
   // Sort axes_data in ascending order.
   std::sort(axes_data.begin(), axes_data.end());
   if (op_type == "Squeeze") {

--- a/onnxruntime/core/providers/webnn/builders/impl/transpose_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/transpose_op_builder.cc
@@ -41,7 +41,7 @@ Status TransposeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
   emscripten::val input = model_builder.GetOperand(input_defs[0]->Name());
   emscripten::val options = emscripten::val::object();
   options.set("label", node.Name());
-  std::vector<uint32_t> permutation = GetVecUint32FromVecInt64(perm);
+  std::vector<uint32_t> permutation = GetNarrowedIntfromInt64<uint32_t>(perm);
   options.set("permutation", emscripten::val::array(permutation));
   emscripten::val output = model_builder.GetBuilder().call<emscripten::val>("transpose", input, options);
   model_builder.AddOperand(node.OutputDefs()[0]->Name(), std::move(output));

--- a/onnxruntime/core/providers/webnn/builders/model_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/model_builder.cc
@@ -204,15 +204,11 @@ Status ModelBuilder::RegisterInitializers() {
         }
 
         // If int64 is not supported, convert int64 to int32.
-        std::vector<int32_t> int32_data(num_elements);
+        std::vector<int32_t> int32_data;
         if (should_convert_int64_to_int32) {
           try {
-            std::transform(reinterpret_cast<int64_t*>(tensor_ptr),
-                           reinterpret_cast<int64_t*>(tensor_ptr) + static_cast<int64_t>(num_elements),
-                           int32_data.begin(),
-                           [](int64_t val) -> int32_t {
-                             return gsl::narrow<int32_t>(val);
-                           });
+            int32_data = GetNarrowedIntfromInt64<int32_t>(
+                gsl::span<const int64_t>(reinterpret_cast<int64_t*>(tensor_ptr), num_elements));
             LOGS(logger_, VERBOSE) << "Initializer '" << name << "' is converted from int64 to int32.";
           } catch (const std::exception& e) {
             return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, e.what());

--- a/onnxruntime/core/providers/webnn/builders/model_builder.h
+++ b/onnxruntime/core/providers/webnn/builders/model_builder.h
@@ -34,6 +34,8 @@ class ModelBuilder {
   const GraphViewer& GetGraphViewer() const { return graph_viewer_; }
   InitializedTensorSet GetInitializerTensors();
 
+  bool IsInt64Supported() const { return is_int64_supported_; }
+
   const emscripten::val& GetBuilder() const { return wnn_builder_; }
   const emscripten::val& GetContext() const { return wnn_context_; }
   const emscripten::val& GetOperand(const std::string& name) const { return wnn_operands_.at(name); }
@@ -74,6 +76,7 @@ class ModelBuilder {
 
   emscripten::val wnn_context_ = emscripten::val::undefined();
   emscripten::val wnn_builder_ = emscripten::val::undefined();
+  bool is_int64_supported_{false};
   DataLayout preferred_layout_;
   WebnnDeviceType wnn_device_type_;
   emscripten::val wnn_limits_ = emscripten::val::undefined();

--- a/onnxruntime/core/providers/webnn/builders/model_builder.h
+++ b/onnxruntime/core/providers/webnn/builders/model_builder.h
@@ -76,7 +76,7 @@ class ModelBuilder {
 
   emscripten::val wnn_context_ = emscripten::val::undefined();
   emscripten::val wnn_builder_ = emscripten::val::undefined();
-  bool is_int64_supported_{false};
+  bool is_int64_supported_ = false;
   DataLayout preferred_layout_;
   WebnnDeviceType wnn_device_type_;
   emscripten::val wnn_limits_ = emscripten::val::undefined();

--- a/onnxruntime/wasm/pre-jsep.js
+++ b/onnxruntime/wasm/pre-jsep.js
@@ -136,7 +136,8 @@ Module["jsepInit"] = (name, params) => {
       dataOffset,
       dataLength,
       builder,
-      desc
+      desc,
+      shouldConvertInt64ToInt32,
     ) => {
       return backend["registerMLConstant"](
         externalFilePath,
@@ -144,14 +145,13 @@ Module["jsepInit"] = (name, params) => {
         dataLength,
         builder,
         desc,
-        Module.MountedFiles
+        Module.MountedFiles,
+        shouldConvertInt64ToInt32,
       );
     };
-    Module["jsepRegisterGraphInput"] =
-      backend["registerGraphInput"].bind(backend);
-    Module["jsepIsGraphInput"] = backend["isGraphInput"].bind(backend);
-
-    Module["jsepCreateTemporaryTensor"] =
-      backend["createTemporaryTensor"].bind(backend);
+    Module['jsepRegisterGraphInput'] = backend['registerGraphInput'].bind(backend);
+    Module['jsepIsGraphInput'] = backend['isGraphInput'].bind(backend);
+    Module['jsepCreateTemporaryTensor'] = backend['createTemporaryTensor'].bind(backend);
+    Module['jsepIsInt64Supported'] = backend['isInt64Supported'].bind(backend);
   }
 };


### PR DESCRIPTION
This PR adds some workarounds to enable int64 support for some WebNN backends which don't support int64 data type.

- Do not fallback ops that are specifically due to the int64 limitation.
- Convert all int64 initializer and input values to int32 and handle potential overflow errors.
- Register all int64 model inputs and outputs as int32 ml-tensor.
- Handle ONNX ops that need inputs or outputs conversion between int64 and int32. e.g. ArgMax, ArgMin, Cast, etc.
- Convert int64 output data back to int32.
- Disallow int64 outputs as 'ml-tensor' preferredOutputLocation.

Fixed #21401



