### PR TITLE
Fix typo: change `Upample` to `Upsample`

### DIFF
--- a/onnxruntime/core/providers/cuda/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cuda/tensor/upsample.cc
@@ -290,7 +290,7 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
       scales_div[i] = fast_divmod(gsl::narrow_cast<int>(ceil(scales[i])));
     }
 
-    UpampleImpl(Stream(context),
+    UpsampleImpl(Stream(context),
                 mode_,
                 rank,
                 (UpsampleMode::LINEAR == mode_) ? (rank == 2 ? X_dims[0] : X_dims[2]) : 0,

--- a/onnxruntime/core/providers/cuda/tensor/upsample_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/upsample_impl.cu
@@ -8,7 +8,7 @@ namespace onnxruntime {
 namespace cuda {
 
 template <typename T, int RANK>
-__global__ void _UpampleNearestKernel(const TArray<int64_t> input_pitches,
+__global__ void _UpsampleNearestKernel(const TArray<int64_t> input_pitches,
                                       const TArray<fast_divmod> output_div_pitches,
                                       const TArray<fast_divmod> scales_div,
                                       const T* __restrict__ input_data,
@@ -36,7 +36,7 @@ __global__ void _UpampleNearestKernel(const TArray<int64_t> input_pitches,
 // This is the common use-case where the 4-D input (batched multi-channel images)
 // is usually of shape [N, C, H, W] and the scales are [1.0, 1.0, height_scale, width_scale]
 template <typename T>
-__global__ void _UpampleBilinear4DInputKernel(const int64_t input_dim2,
+__global__ void _UpsampleBilinear4DInputKernel(const int64_t input_dim2,
                                               const TArray<int64_t> input_pitches,
                                               const TArray<fast_divmod> output_div_pitches,
                                               const TArray<fast_divmod> scales_div,
@@ -95,7 +95,7 @@ __global__ void _UpampleBilinear4DInputKernel(const int64_t input_dim2,
 
 // The following method supports a 2-D input in 'Linear mode'
 template <typename T>
-__global__ void _UpampleBilinear2DInputKernel(const int64_t input_dim0,
+__global__ void _UpsampleBilinear2DInputKernel(const int64_t input_dim0,
                                               const TArray<int64_t> input_pitches,
                                               const TArray<fast_divmod> output_div_pitches,
                                               const TArray<fast_divmod> scales_div,
@@ -147,7 +147,7 @@ __global__ void _UpampleBilinear2DInputKernel(const int64_t input_dim0,
 }
 
 template <typename T>
-void UpampleImpl(cudaStream_t stream,
+void UpsampleImpl(cudaStream_t stream,
                  const onnxruntime::UpsampleMode upsample_mode,
                  const size_t rank,
                  const int64_t input_dim2,
@@ -160,19 +160,19 @@ void UpampleImpl(cudaStream_t stream,
   int blocksPerGrid = (int)(ceil(static_cast<float>(N) / GridDim::maxThreadsPerBlock));
   if (onnxruntime::UpsampleMode::NN == upsample_mode) {
     if (rank == 4) {
-      _UpampleNearestKernel<T, 4><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
+      _UpsampleNearestKernel<T, 4><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
           input_pitches, output_div_pitches, scales_div,
           input_data, output_data, N);
     } else if (rank == 3) {
-      _UpampleNearestKernel<T, 3><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
+      _UpsampleNearestKernel<T, 3><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
           input_pitches, output_div_pitches, scales_div,
           input_data, output_data, N);
     } else if (rank == 2) {
-      _UpampleNearestKernel<T, 2><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
+      _UpsampleNearestKernel<T, 2><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
           input_pitches, output_div_pitches, scales_div,
           input_data, output_data, N);
     } else if (rank == 1) {
-      _UpampleNearestKernel<T, 1><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
+      _UpsampleNearestKernel<T, 1><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
           input_pitches, output_div_pitches, scales_div,
           input_data, output_data, N);
     } else {
@@ -180,11 +180,11 @@ void UpampleImpl(cudaStream_t stream,
     }
   } else if (onnxruntime::UpsampleMode::LINEAR == upsample_mode) {
     if (rank == 4) {
-      _UpampleBilinear4DInputKernel<T><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
+      _UpsampleBilinear4DInputKernel<T><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
           input_dim2, input_pitches, output_div_pitches, scales_div,
           input_data, output_data, N);
     } else if (rank == 2) {
-      _UpampleBilinear2DInputKernel<T><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
+      _UpsampleBilinear2DInputKernel<T><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
           input_dim2, input_pitches, output_div_pitches, scales_div,
           input_data, output_data, N);
     } else {
@@ -198,7 +198,7 @@ void UpampleImpl(cudaStream_t stream,
 }
 
 #define SPECIALIZED_IMPL(T)                                                   \
-  template void UpampleImpl<T>(cudaStream_t stream,                           \
+  template void UpsampleImpl<T>(cudaStream_t stream,                           \
                                const onnxruntime::UpsampleMode upsample_mode, \
                                const size_t rank,                             \
                                const int64_t input_dim2,                      \

--- a/onnxruntime/core/providers/cuda/tensor/upsample_impl.h
+++ b/onnxruntime/core/providers/cuda/tensor/upsample_impl.h
@@ -11,7 +11,7 @@ namespace onnxruntime {
 namespace cuda {
 
 template <typename T>
-void UpampleImpl(cudaStream_t stream,
+void UpsampleImpl(cudaStream_t stream,
                  const onnxruntime::UpsampleMode upsample_mode,
                  const size_t rank,
                  const int64_t input_dim2,


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Fixed a typo in function names related to the Upsample CUDA kernel. Changed incorrect spelling `Upample` to `Upsample` across relevant functions.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

This change is necessary to maintain consistency and prevent potential confusion caused by incorrect function names.
