### PR TITLE
Fix typo: change `Upample` to `Upsample`.

### DIFF
--- a/onnxruntime/core/providers/cuda/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cuda/tensor/upsample.cc
@@ -290,16 +290,16 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
       scales_div[i] = fast_divmod(gsl::narrow_cast<int>(ceil(scales[i])));
     }
 
-    UpampleImpl(Stream(context),
-                mode_,
-                rank,
-                (UpsampleMode::LINEAR == mode_) ? (rank == 2 ? X_dims[0] : X_dims[2]) : 0,
-                input_strides,
-                output_div_pitches,
-                scales_div,
-                reinterpret_cast<const CudaT*>(X->Data<T>()),
-                reinterpret_cast<CudaT*>(Y->MutableData<T>()),
-                output_count);
+    UpsampleImpl(Stream(context),
+                 mode_,
+                 rank,
+                 (UpsampleMode::LINEAR == mode_) ? (rank == 2 ? X_dims[0] : X_dims[2]) : 0,
+                 input_strides,
+                 output_div_pitches,
+                 scales_div,
+                 reinterpret_cast<const CudaT*>(X->Data<T>()),
+                 reinterpret_cast<CudaT*>(Y->MutableData<T>()),
+                 output_count);
   }
 
   return Status::OK();

--- a/onnxruntime/core/providers/cuda/tensor/upsample_impl.h
+++ b/onnxruntime/core/providers/cuda/tensor/upsample_impl.h
@@ -11,16 +11,16 @@ namespace onnxruntime {
 namespace cuda {
 
 template <typename T>
-void UpampleImpl(cudaStream_t stream,
-                 const onnxruntime::UpsampleMode upsample_mode,
-                 const size_t rank,
-                 const int64_t input_dim2,
-                 const TArray<int64_t>& input_pitches,
-                 const TArray<fast_divmod>& output_div_pitches,
-                 const TArray<fast_divmod>& scales_div,
-                 const T* input_data,
-                 T* output_data,
-                 const size_t N);
+void UpsampleImpl(cudaStream_t stream,
+                  const onnxruntime::UpsampleMode upsample_mode,
+                  const size_t rank,
+                  const int64_t input_dim2,
+                  const TArray<int64_t>& input_pitches,
+                  const TArray<fast_divmod>& output_div_pitches,
+                  const TArray<fast_divmod>& scales_div,
+                  const T* input_data,
+                  T* output_data,
+                  const size_t N);
 
 }  // namespace cuda
 }  // namespace onnxruntime


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Fixed a typo in function names related to the Upsample CUDA kernel. Changed incorrect spelling Upample to Upsample across relevant functions.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
This change is necessary to maintain consistency and prevent potential confusion caused by incorrect function names.

