### PR TITLE
Update onnxruntime_external_deps.cmake: add missing EXCLUDE_FROM_ALL 

### DIFF
--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -301,6 +301,7 @@ if(NOT TARGET Boost::mp11)
     onnxruntime_fetchcontent_declare(
      mp11
      URL ${DEP_URL_mp11}
+     EXCLUDE_FROM_ALL
      FIND_PACKAGE_ARGS NAMES Boost
     )
     onnxruntime_fetchcontent_makeavailable(mp11)    


### PR DESCRIPTION
Cherry-pick (#23829) to [rel-1.21.0](https://github.com/microsoft/onnxruntime/tree/rel-1.21.0).

### Description
To resolve #23821 

### Motivation and Context
Similar to #23641 .

### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


