### PR TITLE
Fix enable_pix_capture build for WebGPU

### DIFF
--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -304,7 +304,7 @@ if(NOT TARGET Boost::mp11)
      EXCLUDE_FROM_ALL
      FIND_PACKAGE_ARGS NAMES Boost
     )
-    onnxruntime_fetchcontent_makeavailable(mp11)    
+    onnxruntime_fetchcontent_makeavailable(mp11)
     if(NOT TARGET Boost::mp11)
       add_library(Boost::mp11 ALIAS Boost::headers)
     endif()
@@ -672,17 +672,10 @@ if (onnxruntime_USE_WEBGPU)
 
     # disable things we don't use
     set(DAWN_DXC_ENABLE_ASSERTS_IN_NDEBUG OFF)
-    set(DAWN_ENABLE_DESKTOP_GL OFF CACHE BOOL "" FORCE)
-    set(DAWN_ENABLE_OPENGLES OFF CACHE BOOL "" FORCE)
-    set(DAWN_SUPPORTS_GLFW_FOR_WINDOWING OFF CACHE BOOL "" FORCE)
-    set(DAWN_USE_GLFW OFF CACHE BOOL "" FORCE)
-    set(DAWN_USE_WINDOWS_UI OFF CACHE BOOL "" FORCE)
     set(DAWN_USE_X11 OFF CACHE BOOL "" FORCE)
 
     set(TINT_BUILD_TESTS OFF CACHE BOOL "" FORCE)
     set(TINT_BUILD_CMD_TOOLS OFF CACHE BOOL "" FORCE)
-    set(TINT_BUILD_GLSL_WRITER OFF CACHE BOOL "" FORCE)
-    set(TINT_BUILD_GLSL_VALIDATOR OFF CACHE BOOL "" FORCE)
     set(TINT_BUILD_IR_BINARY OFF CACHE BOOL "" FORCE)
     set(TINT_BUILD_SPV_READER OFF CACHE BOOL "" FORCE)  # don't need. disabling is a large binary size saving
     set(TINT_BUILD_WGSL_WRITER ON CACHE BOOL "" FORCE)  # needed to create cache key. runtime error if not enabled.

--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -165,7 +165,6 @@ void WebGpuContext::Initialize(const WebGpuBufferCacheConfig& buffer_cache_confi
 #if defined(ENABLE_PIX_FOR_WEBGPU_EP)
       // set pix frame generator
       pix_frame_generator_ = std::make_unique<WebGpuPIXFrameGenerator>(instance_,
-                                                                       Adapter(),
                                                                        Device());
 #else
     ORT_THROW("Support PIX capture requires extra build flags (--enable_pix_capture)");

--- a/onnxruntime/core/providers/webgpu/webgpu_context.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.h
@@ -75,7 +75,6 @@ class WebGpuContext final {
 
   Status Wait(wgpu::Future f);
 
-  const wgpu::Adapter& Adapter() const { return adapter_; }
   const wgpu::Device& Device() const { return device_; }
 
   const wgpu::AdapterInfo& AdapterInfo() const { return adapter_info_; }
@@ -200,7 +199,6 @@ class WebGpuContext final {
   LibraryHandles modules_;
 
   wgpu::Instance instance_;
-  wgpu::Adapter adapter_;
   wgpu::Device device_;
 
   webgpu::ValidationMode validation_mode_;

--- a/onnxruntime/core/providers/webgpu/webgpu_context.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.h
@@ -75,6 +75,7 @@ class WebGpuContext final {
 
   Status Wait(wgpu::Future f);
 
+  const wgpu::Adapter& Adapter() const { return adapter_; }
   const wgpu::Device& Device() const { return device_; }
 
   const wgpu::AdapterInfo& AdapterInfo() const { return adapter_info_; }
@@ -199,6 +200,7 @@ class WebGpuContext final {
   LibraryHandles modules_;
 
   wgpu::Instance instance_;
+  wgpu::Adapter adapter_;
   wgpu::Device device_;
 
   webgpu::ValidationMode validation_mode_;

--- a/onnxruntime/core/providers/webgpu/webgpu_pix_frame_generator.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_pix_frame_generator.cc
@@ -11,7 +11,7 @@
 namespace onnxruntime {
 namespace webgpu {
 
-WebGpuPIXFrameGenerator::WebGpuPIXFrameGenerator(wgpu::Instance instance, wgpu::Adapter adapter, wgpu::Device device) {
+WebGpuPIXFrameGenerator::WebGpuPIXFrameGenerator(wgpu::Instance instance, wgpu::Device device) {
   // Trivial window size for surface texture creation and provide frame concept for PIX.
   static constexpr uint32_t kWidth = 512u;
   static constexpr uint32_t kHeight = 512u;
@@ -32,7 +32,7 @@ WebGpuPIXFrameGenerator::WebGpuPIXFrameGenerator(wgpu::Instance instance, wgpu::
 
   wgpu::TextureFormat format;
   wgpu::SurfaceCapabilities capabilities;
-  surface_.GetCapabilities(adapter, &capabilities);
+  surface_.GetCapabilities(device.GetAdapter(), &capabilities);
   format = capabilities.formats[0];
 
   wgpu::SurfaceConfiguration config;

--- a/onnxruntime/core/providers/webgpu/webgpu_pix_frame_generator.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_pix_frame_generator.h
@@ -41,7 +41,7 @@ namespace webgpu {
 // WebGpuContext destruction.
 class WebGpuPIXFrameGenerator {
  public:
-  WebGpuPIXFrameGenerator(wgpu::Instance instance, wgpu::Adapter adapter, wgpu::Device device);
+  WebGpuPIXFrameGenerator(wgpu::Instance instance, wgpu::Device device);
   ~WebGpuPIXFrameGenerator();
   void GeneratePIXFrame();
 


### PR DESCRIPTION
The build option --enable_pix_capture is broken. This fixes the problem.