### PR TITLE
Move Linux DNNL/OpenVino pipelines to onnxruntime-Ubuntu2204-AMD-CPU machine pool

### DIFF
--- a/tools/ci_build/github/azure-pipelines/linux-dnnl-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-dnnl-ci-pipeline.yml
@@ -35,7 +35,7 @@ jobs:
     skipComponentGovernanceDetection: true
   workspace:
     clean: all
-  pool: Linux-CPU-2019
+  pool: onnxruntime-Ubuntu2204-AMD-CPU
   steps:
   - checkout: self
     clean: true

--- a/tools/ci_build/github/azure-pipelines/linux-openvino-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-openvino-ci-pipeline.yml
@@ -31,7 +31,7 @@ pr:
 jobs:
 - template: templates/linux-ci.yml
   parameters:
-    AgentPool : 'Linux-CPU-2019'
+    AgentPool : 'onnxruntime-Ubuntu2204-AMD-CPU'
     JobName: 'Linux_CI_Dev'
     RunDockerBuildArgs: '-o ubuntu22.04 -p 3.10 -d openvino -v 2024.5.0 -x "--enable_generic_interface --use_openvino CPU --build_wheel"'
     TimeoutInMinutes: 120


### PR DESCRIPTION
To reduce the number of pools we need to manage.