### PR TITLE
[OpenVINO] Fix a build warning

### DIFF
--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -653,7 +653,7 @@ void BasicBackend::CompleteAsyncInference(Ort::KernelContext& context, OVInferRe
         const auto& out_name = item.first;
         auto node = item.second;
         Ort::UnownedValue output_tensor = GetOutputTensor(context,
-                                                          std::move(out_name),
+                                                          out_name,
                                                           subgraph_context_.output_names,
                                                           node);
         auto mem_info = output_tensor.GetTensorMemoryInfo();


### PR DESCRIPTION
### Description
Fix a warning with std::move usage



### Motivation and Context
Possibly allow building without --compile_no_warning_as_error flag

