### PR TITLE
Dynamo export and improve benchmark script for SAM2 encoder

### DIFF
--- a/onnxruntime/python/tools/transformers/models/sam2/README.md
+++ b/onnxruntime/python/tools/transformers/models/sam2/README.md
@@ -96,8 +96,7 @@ We can create a conda environment then run GPU benchmark like the following:
 conda create -n sam2_gpu python=3.11 -y
 conda activate sam2_gpu
 install_dir=$HOME
-profiling=true
-bash benchmark_sam2.sh $install_dir gpu $profiling
+bash benchmark_sam2.sh $install_dir gpu
 ```
 
 or create a new conda environment for CPU benchmark:
@@ -107,16 +106,27 @@ conda activate sam2_cpu
 bash benchmark_sam2.sh $HOME cpu
 ```
 
-The first parameter is a directory to clone git repositories or install CUDA/cuDNN for benchmark.
-The second parameter can be either "gpu" or "cpu", which indicates the device to run benchmark.
-The third parameter is optional. Value "true" will enable profiling after running benchmarking on GPU.
+The usage of the script like the following:
+```
+bash benchmark_sam2.sh <install_dir> <cpu_or_gpu> [profiling] [benchmarking] [nightly] [dynamo]
+```
 
-The script will automatically install required packages in current conda environment, download checkpoints, export onnx,
-and run demo, benchmark and optionally run profiling.
+| Parameter| Default  | Description |
+|----------|----------| ------------|
+| install_dir | $HOME | a directory to clone git repositories or install CUDA/cuDNN for benchmark |
+| cpu_or_gpu | gpu | the device to run benchmark. The value can be either "gpu" or "cpu" |
+| profiling | false | run gpu profiling |
+| benchmarking | true | run benchmark |
+| nightly | false | install onnxruntime nightly or official release package |
+| dynamo | false | export image encoder using dynamo or not. |
 
-* The performance test result is in sam2_gpu.csv or sam2_cpu.csv, which can be loaded into Excel.
-* The demo output is sam2_demo_fp16_gpu.png or sam2_demo_fp32_cpu.png.
-* The profiling results are in *.nsys-rep or *.json files in current directory. Use Nvidia NSight System to view the *.nsys-rep file.
+The dynamo export is experimental since graph optimization still need extra works for this model.
+
+Output files:
+* sam2_cpu_[timestamp].csv or sam2_gpu_[timestamp].csv has benchmark results. Use Excel to load the file to view it.
+* onnxruntime_image_[encoder|decoder].json has ONNX Runtime profiling results. Use `chrome://tracing` in Chrome browser to view it.
+* torch_image_[encoder|decoder].json has PyTorch profiling results. Use `chrome://tracing` in Chrome browser to view it.
+* sam2_fp16_profile_image_[encoder|decoder]_[ort|torch]_gpu.[nsys-rep|sqlite] has NVTX profiling. Use Nvidia NSight System to view it.
 
 ## Limitations
 - The exported image_decoder model does not support batch mode for now.

--- a/onnxruntime/python/tools/transformers/models/sam2/README.md
+++ b/onnxruntime/python/tools/transformers/models/sam2/README.md
@@ -127,6 +127,7 @@ Output files:
 * onnxruntime_image_[encoder|decoder].json has ONNX Runtime profiling results. Use `chrome://tracing` in Chrome browser to view it.
 * torch_image_[encoder|decoder].json has PyTorch profiling results. Use `chrome://tracing` in Chrome browser to view it.
 * sam2_fp16_profile_image_[encoder|decoder]_[ort|torch]_gpu.[nsys-rep|sqlite] has NVTX profiling. Use Nvidia NSight System to view it.
+* torch_image_encoder_compiled_code.txt has the compiled kernel code from Pytorch.
 
 ## Limitations
 - The exported image_decoder model does not support batch mode for now.

--- a/onnxruntime/python/tools/transformers/models/sam2/benchmark_sam2.py
+++ b/onnxruntime/python/tools/transformers/models/sam2/benchmark_sam2.py
@@ -46,6 +46,7 @@ class TestConfig:
         prefer_nhwc: bool = False,
         warm_up: int = 5,
         enable_nvtx_profile: bool = False,
+        enable_ort_profile: bool = False,
         enable_torch_profile: bool = False,
         repeats: int = 1000,
         verbose: bool = False,
@@ -74,6 +75,7 @@ class TestConfig:
         self.prefer_nhwc = prefer_nhwc
         self.warm_up = warm_up
         self.enable_nvtx_profile = enable_nvtx_profile
+        self.enable_ort_profile = enable_ort_profile
         self.enable_torch_profile = enable_torch_profile
         self.repeats = repeats
         self.verbose = verbose
@@ -317,6 +319,7 @@ def run_test(
         repeats=args.repeats,
         warm_up=args.warm_up,
         enable_nvtx_profile=args.enable_nvtx_profile,
+        enable_ort_profile=args.enable_ort_profile,
         enable_torch_profile=args.enable_torch_profile,
         torch_compile_mode=args.torch_compile_mode,
         verbose=False,
@@ -325,7 +328,7 @@ def run_test(
     if args.engine == "ort":
         sess_options = SessionOptions()
         sess_options.intra_op_num_threads = args.intra_op_num_threads
-        if config.enable_nvtx_profile:
+        if config.enable_ort_profile:
             sess_options.enable_profiling = True
             sess_options.log_severity_level = 4
             sess_options.log_verbosity_level = 0
@@ -349,6 +352,8 @@ def run_test(
             with nvtx.annotate("one_run"):
                 _ = session.infer(input_dict)
             cudart.cudaProfilerStop()
+
+        if config.enable_ort_profile:
             session.ort_session.end_profiling()
 
         if repeats == 0:
@@ -552,6 +557,14 @@ def _parse_arguments():
         default=False,
         action="store_true",
         help="Enable nvtx profiling. It will add an extra run for profiling before performance test.",
+    )
+
+    parser.add_argument(
+        "--enable_ort_profile",
+        required=False,
+        default=False,
+        action="store_true",
+        help="Enable ORT profiling.",
     )
 
     parser.add_argument(

--- a/onnxruntime/python/tools/transformers/models/sam2/benchmark_sam2.sh
+++ b/onnxruntime/python/tools/transformers/models/sam2/benchmark_sam2.sh
@@ -5,16 +5,23 @@
 # -------------------------------------------------------------------------
 
 # Please refer to README.md for the prerequisites and usage of this script.
-#   bash benchmark_sam2.sh <install_dir> <cpu|gpu> [profiling]
+#   bash benchmark_sam2.sh <install_dir> <cpu|gpu> [profiling] [benchmarking] [nightly] [dynamo]
+# Note that dynamo need onnxruntime 1.21 or later, or nightly build.
+# Example:
+#   bash benchmark_sam2.sh $HOME gpu true true true false
+
+install_dir="${1:-$HOME}"
+cpu_or_gpu="${2:-gpu}"
+profiling="${3:-false}"
+benchmarking="${4:-true}"
+nightly="${5:-false}"
+dynamo="${6:-false}"
 
 python="$CONDA_PREFIX/bin/python3"
 
 # Directory of the script and ONNX models
 dir="$(cd "$(dirname "$0")" && pwd)"
 onnx_dir="$dir/sam2_onnx_models"
-
-# Installation directory (default: $HOME)
-install_dir="${1:-$HOME}"
 
 if [ ! -d "$install_dir" ]; then
     echo "Error: install_dir '$install_dir' does not exist."
@@ -26,7 +33,6 @@ sam2_dir="$install_dir/segment-anything-2"
 model="sam2_hiera_large"
 
 # Default to GPU, switch to CPU if specified
-cpu_or_gpu="${2:-gpu}"
 if [ "$cpu_or_gpu" != "gpu" ] && [ "$cpu_or_gpu" != "cpu" ]; then
     echo "Invalid option: $2. Please specify 'cpu' or 'gpu'."
     exit 1
@@ -35,40 +41,64 @@ fi
 echo "install_dir: $install_dir"
 echo "cpu_or_gpu: $cpu_or_gpu"
 
+cuda_version=12.6
 install_cuda_12()
 {
     pushd $install_dir
     wget https://developer.download.nvidia.com/compute/cuda/12.6.2/local_installers/cuda_12.6.2_560.35.03_linux.run
-    sh cuda_12.6.2_560.35.03_linux.run --toolkit --toolkitpath=$install_dir/cuda12.6 --silent --override --no-man-page
-
-    export PATH="$install_dir/cuda12.6/bin:$PATH"
-    export LD_LIBRARY_PATH="$install_dir/cuda12.6/lib64:$LD_LIBRARY_PATH"
+    sh cuda_12.6.2_560.35.03_linux.run --toolkit --toolkitpath=$install_dir/cuda${cuda_version} --silent --override --no-man-page
     popd
 }
 
-# Function to install cuDNN 9.4
+cudnn_version=9.5
 install_cudnn_9() {
     pushd "$install_dir"
     wget -q https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-9.5.0.50_cuda12-archive.tar.xz
-    mkdir -p "$install_dir/cudnn9.5"
-    tar -Jxvf cudnn-linux-x86_64-9.5.0.50_cuda12-archive.tar.xz -C "$install_dir/cudnn9.5" --strip=1
-    export LD_LIBRARY_PATH="$install_dir/cudnn9.5/lib:$LD_LIBRARY_PATH"
+    mkdir -p "$install_dir/cudnn${cudnn_version}"
+    tar -Jxvf cudnn-linux-x86_64-9.5.0.50_cuda12-archive.tar.xz -C "$install_dir/cudnn${cudnn_version}" --strip=1
     popd
+}
+
+set_env_vars() {
+    export PATH="$install_dir/cuda${cuda_version}/bin:$PATH"
+    export LD_LIBRARY_PATH="$install_dir/cuda${cuda_version}/lib64:$LD_LIBRARY_PATH"
+    export LD_LIBRARY_PATH="$install_dir/cudnn${cudnn_version}/lib:$LD_LIBRARY_PATH"
+    echo "PATH: $PATH"
+    echo "LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
+}
+
+install_ort() {
+    local ort="$1"
+    pip uninstall onnxruntime onnxruntime-gpu -y
+
+    if [ "$nightly" = "true" ]; then
+        pip install flatbuffers numpy packaging protobuf sympy
+        pip install --pre --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/ $ort
+    else
+        pip install $ort
+    fi
+
+    pip install onnx onnxscript opencv-python matplotlib
 }
 
 # Install GPU dependencies
 install_gpu() {
-    [ ! -d "$install_dir/cuda12.6" ] && install_cuda_12
-    [ ! -d "$install_dir/cudnn9.5" ] && install_cudnn_9
+    [ ! -d "$install_dir/cuda${cuda_version}" ] && install_cuda_12
+    [ ! -d "$install_dir/cudnn${cudnn_version}" ] && install_cudnn_9
 
-    pip install torch torchvision --index-url https://download.pytorch.org/whl/cu124
-    pip install onnxruntime-gpu onnx opencv-python matplotlib
+    set_env_vars
+
+    # Some dynamo export need torch 2.6.0 or later. Use the latest one.
+    pip install torch torchvision --index-url https://download.pytorch.org/whl/cu124 --upgrade
+
+    install_ort "onnxruntime-gpu"
 }
+
 
 # Install CPU dependencies
 install_cpu() {
     pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
-    pip install onnxruntime onnx opencv-python matplotlib
+    install_ort onnxruntime
 }
 
 # Clone and install SAM2 if not already installed
@@ -90,7 +120,12 @@ download_test_image() {
 
 run_cpu_benchmark() {
     local repeats="$1"
-    $python convert_to_onnx.py --sam2_dir "$sam2_dir" --optimize --demo
+
+    if [ "$dynamo" = "true" ]; then
+        $python convert_to_onnx.py --sam2_dir "$sam2_dir" --optimize --demo
+    else
+        $python convert_to_onnx.py --sam2_dir "$sam2_dir" --optimize --demo --dynamo
+    fi
 
     for component in image_encoder image_decoder; do
         $python benchmark_sam2.py --model_type "$model" --engine torch --sam2_dir "$sam2_dir" --repeats "$repeats" --dtype fp32 --component "$component"
@@ -103,32 +138,43 @@ run_cpu_benchmark() {
     done
 }
 
-run_gpu_benchmark() {
+run_ort_gpu_benchmark() {
     local repeats="$1"
-    $python convert_to_onnx.py --sam2_dir "$sam2_dir" --optimize --use_gpu --dtype fp32
-    $python convert_to_onnx.py --sam2_dir "$sam2_dir" --optimize --use_gpu --dtype fp16 --demo
 
-    for component in image_encoder image_decoder; do
-        for dtype in bf16 fp32 fp16; do
-            $python benchmark_sam2.py --model_type "$model" --engine torch --sam2_dir "$sam2_dir" --repeats "$repeats" --use_gpu --dtype $dtype --component "$component"
-        done
-    done
+    if [ "$dynamo" = "true" ]; then
+        $python convert_to_onnx.py --sam2_dir "$sam2_dir" --optimize --use_gpu --dtype fp32 --dynamo
+        $python convert_to_onnx.py --sam2_dir "$sam2_dir" --optimize --use_gpu --dtype fp16 --demo --dynamo
+    else
+        $python convert_to_onnx.py --sam2_dir "$sam2_dir" --optimize --use_gpu --dtype fp32
+        $python convert_to_onnx.py --sam2_dir "$sam2_dir" --optimize --use_gpu --dtype fp16 --demo
+    fi
 
     component="image_encoder"
     for dtype in fp32 fp16; do
-        #TODO: --prefer_nhwc does not help with performance
         $python benchmark_sam2.py --model_type "$model" --engine ort --sam2_dir "$sam2_dir" --repeats "$repeats" --use_gpu --dtype $dtype --component "$component" --onnx_path "${onnx_dir}/${model}_${component}_${dtype}_gpu.onnx" --use_cuda_graph
     done
+    # Test prefer_nhwc.
+    $python benchmark_sam2.py --model_type "$model" --engine ort --sam2_dir "$sam2_dir" --repeats "$repeats" --use_gpu --dtype fp16 --component "$component" --onnx_path "${onnx_dir}/${model}_${component}_${dtype}_gpu.onnx" --use_cuda_graph --prefer_nhwc
 
     component="image_decoder"
     for dtype in fp32 fp16; do
         # TODO: decoder does not work with cuda graph
         $python benchmark_sam2.py --model_type "$model" --engine ort --sam2_dir "$sam2_dir" --repeats "$repeats" --use_gpu --dtype $dtype --component "$component" --onnx_path "${onnx_dir}/${model}_${component}_${dtype}_gpu.onnx"
     done
+    # Test prefer_nhwc.
+    $python benchmark_sam2.py --model_type "$model" --engine ort --sam2_dir "$sam2_dir" --repeats "$repeats" --use_gpu --dtype fp16 --component "$component" --onnx_path "${onnx_dir}/${model}_${component}_${dtype}_gpu.onnx" --prefer_nhwc
 }
 
-run_torch_compile_gpu_benchmark() {
+
+run_torch_gpu_benchmark() {
     local repeats="$1"
+
+    # Test PyTorch eager mode.
+    for component in image_encoder image_decoder; do
+        for dtype in bf16 fp32 fp16; do
+            $python benchmark_sam2.py --model_type "$model" --engine torch --sam2_dir "$sam2_dir" --repeats "$repeats" --use_gpu --dtype $dtype --component "$component"
+        done
+    done
 
     # Test different torch compile modes on image encoder
     for torch_compile_mode in none max-autotune reduce-overhead max-autotune-no-cudagraphs
@@ -137,31 +183,27 @@ run_torch_compile_gpu_benchmark() {
     done
 }
 
-
-# Main script
-run_benchmarks() {
-    if [ ! -v CONDA_PREFIX ]; then
-        echo "Please activate conda environment before running this script."
-        exit 1
-    fi
-
-    # Install dependencies
+install_all() {
     [ "$cpu_or_gpu" = "gpu" ] && install_gpu || install_cpu
     install_sam2
     download_test_image
+}
 
-    # Run benchmarks
-    output_csv="sam2_${cpu_or_gpu}.csv"
+run_benchmarks() {
+    suffix=$(date +"%Y_%m_%d_%H_%M_%S")
+    [ "$dynamo" = "true" ] && suffix="${suffix}_dynamo"
+    output_csv="sam2_${cpu_or_gpu}_${suffix}.csv"
     if [ ! -f "$output_csv" ]; then
         echo "Running $cpu_or_gpu benchmark..."
         if [ "$cpu_or_gpu" = "gpu" ]; then
-            run_gpu_benchmark 1000
-            run_torch_compile_gpu_benchmark 1000
+            run_ort_gpu_benchmark 1000
+            run_torch_gpu_benchmark 1000
         else
             run_cpu_benchmark 100
         fi
         cat benchmark*.csv > combined_csv
         awk '!x[$0]++' combined_csv > "$output_csv"
+        rm benchmark*.csv
         rm combined_csv
         echo "Benchmark results saved in $output_csv"
     else
@@ -169,7 +211,16 @@ run_benchmarks() {
     fi
 }
 
-run_benchmarks
+if [ ! -v CONDA_PREFIX ]; then
+    echo "Please activate conda environment before running this script."
+    exit 1
+fi
+
+install_all
+
+if [ "$benchmarking" = "true" ]; then
+    run_benchmarks
+fi
 
 #--------------------------------------------------------------------------
 # Below are for profiling
@@ -182,74 +233,98 @@ build_onnxruntime_gpu_for_profiling() {
         git clone https://github.com/microsoft/onnxruntime
     fi
     cd onnxruntime
-    CUDA_ARCH=$(python3 -c "import torch; cc = torch.cuda.get_device_capability(); print(f'{cc[0]}{cc[1]}')")
-    if [ -n "$CUDA_ARCH" ]; then
-        pip install --upgrade pip cmake psutil setuptools wheel packaging ninja numpy==1.26.4
-        sh build.sh --config Release --build_dir build/cuda12 --build_shared_lib --parallel \
-                --use_cuda --cuda_version 12.6 --cuda_home $install_dir/cuda12.6 \
-                --cudnn_home $install_dir/cudnn9.5 \
-                --build_wheel --skip_tests \
-                --cmake_generator Ninja \
-                --compile_no_warning_as_error \
-                --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=$CUDA_ARCH \
-                --cmake_extra_defines onnxruntime_ENABLE_NVTX_PROFILE=ON \
-                --enable_cuda_line_info
-
-        pip install build/cuda12/Release/dist/onnxruntime_gpu-*-linux_x86_64.whl numpy==1.26.4
-    else
-        echo "No CUDA device found."
-        exit 1
-    fi
+    pip install --upgrade pip cmake psutil setuptools wheel packaging ninja numpy
+    build_dir=build/cuda${cuda_version}
+    rm -rf ${build_dir}/Release/dist
+    sh build.sh --config Release --build_dir ${build_dir} --build_shared_lib --parallel \
+            --use_cuda --cuda_version ${cuda_version} --cuda_home $install_dir/cuda${cuda_version} \
+            --cudnn_home $install_dir/cudnn${cudnn_version} \
+            --build_wheel --skip_tests \
+            --cmake_generator Ninja \
+            --compile_no_warning_as_error \
+            --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=native \
+            --cmake_extra_defines onnxruntime_ENABLE_NVTX_PROFILE=ON \
+            --enable_cuda_line_info
+    pip uninstall onnxruntime-gpu -y
+    pip install ${build_dir}/Release/dist/onnxruntime_gpu-*-linux_x86_64.whl
     popd
 }
 
 # Run profiling with NVTX.
 run_nvtx_profile()
 {
-    pip install nvtx cuda-python==12.6.0
-
+    local engine="$1"
     # Only trace one device to avoid huge output file size.
     device_id=0
-    envs="CUDA_VISIBLE_DEVICES=$device_id,ORT_ENABLE_CUDNN_FLASH_ATTENTION=1,LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
+    envs="CUDA_VISIBLE_DEVICES=$device_id,ORT_ENABLE_CUDNN_FLASH_ATTENTION=1,LD_LIBRARY_PATH=$LD_LIBRARY_PATH,TORCHINDUCTOR_UNIQUE_KERNEL_NAMES=1"
     cuda_graph_trace=node
-    for engine in ort torch; do
-        for component in image_encoder image_decoder; do
-            sudo $install_dir/cuda12.6/bin/nsys profile --capture-range=nvtx --nvtx-capture='one_run' \
-                --gpu-metrics-device $device_id --force-overwrite true \
-                --sample process-tree --backtrace fp --stats true \
-                -t cuda,cudnn,cublas,osrt,nvtx --cuda-memory-usage true --cudabacktrace all \
-                --cuda-graph-trace $cuda_graph_trace \
-                -e $envs,NSYS_NVTX_PROFILER_REGISTER_ONLY=0 \
-                -o sam2_fp16_profile_${component}_${engine}_${cpu_or_gpu} \
-                $python benchmark_sam2.py --model_type $model --engine $engine \
-                                          --sam2_dir  $sam2_dir --warm_up 1 --repeats 0 \
-                                          --onnx_path ${onnx_dir}/${model}_${component}_fp16_gpu.onnx \
-                                          --component $component \
-                                          --use_gpu --dtype fp16 --enable_nvtx_profile
-        done
+    for component in image_encoder image_decoder; do
+        sudo $install_dir/cuda${cuda_version}/bin/nsys profile --capture-range=nvtx --nvtx-capture='one_run' \
+            --gpu-metrics-devices $device_id --force-overwrite true \
+            --sample process-tree --backtrace fp --stats true \
+            -t cuda,cudnn,cublas,osrt,nvtx --cuda-memory-usage true --cudabacktrace all \
+            --cuda-graph-trace $cuda_graph_trace \
+            -e $envs,NSYS_NVTX_PROFILER_REGISTER_ONLY=0 \
+            -o sam2_fp16_profile_${component}_${engine}_${cpu_or_gpu} \
+            $python benchmark_sam2.py --model_type $model --engine $engine \
+                                        --sam2_dir  $sam2_dir --warm_up 1 --repeats 0 \
+                                        --onnx_path ${onnx_dir}/${model}_${component}_fp16_gpu.onnx \
+                                        --component $component \
+                                        --use_gpu --dtype fp16 --enable_nvtx_profile
+    done
+}
+
+
+run_ort_profile()
+{
+    export ORT_ENABLE_CUDNN_FLASH_ATTENTION=1
+    rm -f onnxruntime_*.json
+    for component in image_encoder image_decoder; do
+        $python benchmark_sam2.py --model_type $model --engine ort \
+                                    --sam2_dir  $sam2_dir --warm_up 1 --repeats 0 \
+                                    --onnx_path ${onnx_dir}/${model}_${component}_fp16_gpu.onnx \
+                                    --component $component \
+                                    --use_gpu --dtype fp16 --enable_ort_profile
+        mv onnxruntime_profile*.json onnxruntime_$component.json
     done
 }
 
 # Run profiling with PyTorch
 run_torch_profile() {
-    for component in image_encoder image_decoder; do
-        $python benchmark_sam2.py --model_type $model --engine torch \
-                                  --sam2_dir  $sam2_dir --warm_up 1 --repeats 0 \
-                                  --component $component \
-                                  --use_gpu --dtype fp16 --enable_torch_profile
-    done
+    # Enable logging might could help get the code of compiled kernels. You can turn it off to reduce overhead.
+    export TORCH_LOGS="+inductor,+output_code"
+    export TORCHINDUCTOR_UNIQUE_KERNEL_NAMES=1
+    component=image_encoder
+    $python benchmark_sam2.py --model_type $model --engine torch \
+                                --sam2_dir  $sam2_dir --warm_up 1 --repeats 0 \
+                                --component $component \
+                                --torch_compile_mode max-autotune \
+                                --use_gpu --dtype fp16 --enable_torch_profile > torch_${component}_compiled_code.txt
+
+    component=image_decoder
+    $python benchmark_sam2.py --model_type $model --engine torch \
+                                --sam2_dir  $sam2_dir --warm_up 1 --repeats 0 \
+                                --component $component \
+                                --torch_compile_mode none \
+                                --use_gpu --dtype fp16 --enable_torch_profile
+}
+
+run_nvtx_profilings() {
+    build_onnxruntime_gpu_for_profiling
+    rm -f *.nsys-rep *.sqlite
+    run_nvtx_profile ort
+    run_nvtx_profile torch
 }
 
 run_profilings() {
-    build_onnxruntime_gpu_for_profiling
-
-    rm -f *.nsys-rep *.sqlite
-    run_nvtx_profile
-
+    pip install nvtx cuda-python==${cuda_version}.0
+    run_ort_profile
     run_torch_profile
+
+    # NVTX profiling need to build onnxruntime-gpu from source so it is put as the last step.
+    run_nvtx_profilings
 }
 
-profiling="${3:-false}"
 if [ "$profiling" = "true" ] &&  [ "$cpu_or_gpu" = "gpu" ]; then
     run_profilings
 fi

--- a/onnxruntime/python/tools/transformers/models/sam2/benchmark_sam2.sh
+++ b/onnxruntime/python/tools/transformers/models/sam2/benchmark_sam2.sh
@@ -260,9 +260,9 @@ build_onnxruntime_gpu_for_profiling() {
     pip install --upgrade pip cmake psutil setuptools wheel packaging ninja numpy
     build_dir=build/cuda${cuda_version}
     rm -rf ${build_dir}/Release/dist
-    sh build.sh --config Release --build_dir ${build_dir} --build_shared_lib --parallel \
-            --use_cuda --cuda_version ${cuda_version} --cuda_home $install_dir/cuda${cuda_version} \
-            --cudnn_home $install_dir/cudnn${cudnn_version} \
+    sh build.sh --config Release --build_dir "${build_dir}" --build_shared_lib --parallel \
+            --use_cuda --cuda_version ${cuda_version} --cuda_home "$install_dir/cuda${cuda_version}" \
+            --cudnn_home "$install_dir/cudnn${cudnn_version}" \
             --build_wheel --skip_tests \
             --cmake_generator Ninja \
             --compile_no_warning_as_error \
@@ -270,7 +270,7 @@ build_onnxruntime_gpu_for_profiling() {
             --cmake_extra_defines onnxruntime_ENABLE_NVTX_PROFILE=ON \
             --enable_cuda_line_info
     pip uninstall onnxruntime-gpu -y
-    pip install ${build_dir}/Release/dist/onnxruntime_gpu-*-linux_x86_64.whl
+    pip install "${build_dir}/Release/dist/onnxruntime_gpu-*-linux_x86_64.whl"
     popd || exit
 }
 

--- a/onnxruntime/python/tools/transformers/models/sam2/convert_to_onnx.py
+++ b/onnxruntime/python/tools/transformers/models/sam2/convert_to_onnx.py
@@ -114,6 +114,14 @@ def parse_arguments():
     )
 
     parser.add_argument(
+        "--dynamo",
+        required=False,
+        default=False,
+        action="store_true",
+        help="Use dynamo for exporting onnx model. Only image_encoder supports dynamo right now.",
+    )
+
+    parser.add_argument(
         "--verbose",
         required=False,
         default=False,
@@ -151,8 +159,10 @@ def main():
         onnx_model_path = sam2_onnx_path(args.output_dir, args.model_type, component, args.multimask_output)
         if component == "image_encoder":
             if args.overwrite or not os.path.exists(onnx_model_path):
-                export_image_encoder_onnx(sam2_model, onnx_model_path, args.dynamic_batch_axes, args.verbose)
-                test_image_encoder_onnx(sam2_model, onnx_model_path, dynamic_batch_axes=False)
+                export_image_encoder_onnx(
+                    sam2_model, onnx_model_path, args.dynamic_batch_axes, args.verbose, args.dynamo
+                )
+                test_image_encoder_onnx(sam2_model, onnx_model_path, dynamic_batch_axes=args.dynamic_batch_axes)
 
         elif component == "mask_decoder":
             if args.overwrite or not os.path.exists(onnx_model_path):

--- a/onnxruntime/python/tools/transformers/models/sam2/image_decoder.py
+++ b/onnxruntime/python/tools/transformers/models/sam2/image_decoder.py
@@ -246,7 +246,7 @@ def test_decoder_onnx(
 
     import onnxruntime
 
-    ort_session = onnxruntime.InferenceSession(onnx_model_path, providers=onnxruntime.get_available_providers())
+    ort_session = onnxruntime.InferenceSession(onnx_model_path, providers=["CPUExecutionProvider"])
 
     model_inputs = ort_session.get_inputs()
     input_names = [model_inputs[i].name for i in range(len(model_inputs))]

--- a/onnxruntime/python/tools/transformers/models/sam2/image_encoder.py
+++ b/onnxruntime/python/tools/transformers/models/sam2/image_encoder.py
@@ -90,6 +90,7 @@ def export_image_encoder_onnx(
     onnx_model_path: str,
     dynamic_batch_axes: bool = False,
     verbose: bool = False,
+    dynamo: bool = False,
 ):
     image = random_sam2_input_image()
 
@@ -113,17 +114,65 @@ def export_image_encoder_onnx(
         if not verbose:
             warnings.filterwarnings("ignore", category=torch.jit.TracerWarning)
             warnings.filterwarnings("ignore", category=UserWarning)
-        torch.onnx.export(
-            sam2_encoder,
-            image,
-            onnx_model_path,
-            export_params=True,
-            opset_version=17,
-            do_constant_folding=True,
-            input_names=["image"],
-            output_names=["image_features_0", "image_features_1", "image_embeddings"],
-            dynamic_axes=dynamic_axes,
-        )
+
+        if not dynamo:
+            torch.onnx.export(
+                sam2_encoder,
+                image,
+                onnx_model_path,
+                export_params=True,
+                opset_version=17,
+                do_constant_folding=True,
+                input_names=["image"],
+                output_names=["image_features_0", "image_features_1", "image_embeddings"],
+                dynamic_axes=dynamic_axes,
+            )
+        else:
+            torch._dynamo.config.capture_scalar_outputs = True
+            ep = torch.export.export(
+                sam2_encoder,
+                args=(image,),
+                strict=False,
+                dynamic_shapes=[
+                    {0: torch.export.Dim.AUTO},
+                ],
+            )
+
+            onnx_program = torch.onnx.export(
+                ep,
+                (),
+                opset_version=17,
+                input_names=["image"],
+                output_names=["image_features_0", "image_features_1", "image_embeddings"],
+                dynamo=True,
+            )
+            onnx_program.optimize()
+            onnx_program.save(onnx_model_path + ".dynamo.onnx", external_data=False)
+            import onnx
+
+            from onnxruntime.transformers.dynamo_onnx_helper import DynamoOnnxHelper
+
+            onnx_model = onnx.load_model(onnx_model_path + ".dynamo.onnx", load_external_data=True)
+            if dynamic_batch_axes:
+                # Fix labels of dynamic axes since they can't be specified during Dynamo export currently
+                onnx_model.graph.input[0].type.tensor_type.shape.dim[0].dim_param = "batch_size"
+                onnx_model.graph.output[0].type.tensor_type.shape.dim[0].dim_param = "batch_size"
+                onnx_model.graph.output[1].type.tensor_type.shape.dim[0].dim_param = "batch_size"
+                onnx_model.graph.output[2].type.tensor_type.shape.dim[0].dim_param = "batch_size"
+
+            onnx_model_helper = DynamoOnnxHelper(onnx_model)
+            onnx_model_helper.convert_constants_to_initializers()
+            # onnx_model_helper.clear_metadata()
+
+            import os
+
+            if os.path.exists(onnx_model_path):
+                os.remove(onnx_model_path)
+            if os.path.exists(onnx_model_path + ".data"):
+                os.remove(onnx_model_path + ".data")
+            onnx_model_helper.model.save_model_to_file(
+                onnx_model_path, use_external_data_format=True, all_tensors_to_one_file=True, convert_attribute=True
+            )
 
     print("encoder onnx model saved to", onnx_model_path)
 
@@ -133,7 +182,7 @@ def test_image_encoder_onnx(
     onnx_model_path: str,
     dynamic_batch_axes=False,
 ):
-    ort_session = onnxruntime.InferenceSession(onnx_model_path, providers=onnxruntime.get_available_providers())
+    ort_session = onnxruntime.InferenceSession(onnx_model_path, providers=["CPUExecutionProvider"])
 
     model_inputs = ort_session.get_inputs()
     input_names = [model_inputs[i].name for i in range(len(model_inputs))]

--- a/onnxruntime/python/tools/transformers/models/sam2/image_encoder.py
+++ b/onnxruntime/python/tools/transformers/models/sam2/image_encoder.py
@@ -91,6 +91,7 @@ def export_image_encoder_onnx(
     dynamic_batch_axes: bool = False,
     verbose: bool = False,
     dynamo: bool = False,
+    clear_dynamo_metadata: bool = False,
 ):
     image = random_sam2_input_image()
 
@@ -156,13 +157,13 @@ def export_image_encoder_onnx(
             if dynamic_batch_axes:
                 # Fix labels of dynamic axes since they can't be specified during Dynamo export currently
                 onnx_model.graph.input[0].type.tensor_type.shape.dim[0].dim_param = "batch_size"
-                onnx_model.graph.output[0].type.tensor_type.shape.dim[0].dim_param = "batch_size"
-                onnx_model.graph.output[1].type.tensor_type.shape.dim[0].dim_param = "batch_size"
-                onnx_model.graph.output[2].type.tensor_type.shape.dim[0].dim_param = "batch_size"
+                for i in range(3):
+                    onnx_model.graph.output[i].type.tensor_type.shape.dim[0].dim_param = "batch_size"
 
             onnx_model_helper = DynamoOnnxHelper(onnx_model)
             onnx_model_helper.convert_constants_to_initializers()
-            # onnx_model_helper.clear_metadata()
+            if clear_dynamo_metadata:
+                onnx_model_helper.clear_metadata()
 
             import os
 

--- a/onnxruntime/python/tools/transformers/models/sam2/mask_decoder.py
+++ b/onnxruntime/python/tools/transformers/models/sam2/mask_decoder.py
@@ -177,7 +177,7 @@ def test_mask_decoder_onnx(
 
     import onnxruntime
 
-    ort_session = onnxruntime.InferenceSession(onnx_model_path, providers=onnxruntime.get_available_providers())
+    ort_session = onnxruntime.InferenceSession(onnx_model_path, providers=["CPUExecutionProvider"])
 
     model_inputs = ort_session.get_inputs()
     input_names = [model_inputs[i].name for i in range(len(model_inputs))]

--- a/onnxruntime/python/tools/transformers/models/sam2/prompt_encoder.py
+++ b/onnxruntime/python/tools/transformers/models/sam2/prompt_encoder.py
@@ -146,7 +146,7 @@ def test_prompt_encoder_onnx(
 
     import onnxruntime
 
-    ort_session = onnxruntime.InferenceSession(onnx_model_path, providers=onnxruntime.get_available_providers())
+    ort_session = onnxruntime.InferenceSession(onnx_model_path, providers=["CPUExecutionProvider"])
 
     model_inputs = ort_session.get_inputs()
     input_names = [model_inputs[i].name for i in range(len(model_inputs))]


### PR DESCRIPTION
### Description
* Add dynamo export for Sam2 image encoder
* Verify fp32 onnx model with CPU EP (to avoid error message from TRT EP).
* Update benchmark script:
  - output ORT profiling
  - output torch compiled code and unique kernel name for compiled kernel
  - add an option for nightly package installation
  - uninstall existing ort packages before installing

The node metadata of dynamo exported model can help mapping node in onnx model back to pytorch modeling script. Currently, the graph optimization is not done on dynamo exported model, so it is experimental right now.

### Motivation and Context

To support profiling of torch compiled CUDA kernel.


