### PR TITLE
[TensorRT EP] Add doc for trt_op_types_to_exclude

### DIFF
--- a/docs/execution-providers/TensorRT-ExecutionProvider.md
+++ b/docs/execution-providers/TensorRT-ExecutionProvider.md
@@ -472,7 +472,12 @@ TensorRT configurations can be set by execution provider options. It's useful wh
 ##### trt_op_types_to_exclude
 
 
-* Description: exclude specific op types to run on TRT.
+* Description: exclude specific op types from running on TRT.
+  * The format is `op_type_1,op_type_2,op_type_3...`
+  * One use case is to mitigate this performance issue mentioned [here](https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#known-issues), users can use this option to prevent DDS ops from running on TensorRT, ensuring they are executed by CUDA EP or CPU EP instead:
+```bash
+    ./onnxruntime_perf_test -r 1 -e tensorrt -i "trt_op_types_to_exclude|NonMaxSuppression,NonZero,RoiAlign" /path/to/onnx/your_model.onnx
+```
 
 
 ### Environment Variables(deprecated)
@@ -800,13 +805,10 @@ Please note that there is a constraint of using this explicit shape range featur
 ### Data-dependant shape (DDS) ops
 The DDS operations — NonMaxSuppression, NonZero, and RoiAlign — have output shapes that are only determined at runtime. To ensure DDS ops are executed by TRT-EP/TRT instead of CUDA EP or CPU EP, please check the following:
 * For TensorRT < 10.7: Build ORT with [onnx-tensorrt OSS parser](https://github.com/onnx/onnx-tensorrt) and use `10.X-GA-ORT-DDS` branch.
-  For TensrRT >= 10.7: By default, DDS ops will be executed by TRT.
+* For TensorRT >= 10.7: By default, DDS ops will be executed by TRT.
 * For ORT: By default, ORT relies on the TRT parser to decide if DDS ops run with TRT. However, note that ORT versions 1.20.1 and 1.20.2 will **not** run DDS ops with TRT due to a [known performance issue](https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#known-issues).
 
-To mitigate this performance issue, use the `trt_op_types_to_exclude` option so that DDS ops will be run by CUDA EP or CPU EP:
-```bash
-    ./onnxruntime_perf_test -r 1 -e tensorrt -i "trt_op_types_to_exclude|NonMaxSuppression,NonZero,RoiAlign" /path/to/onnx/your_model.onnx
-```
+
 
 ## Samples
 

--- a/docs/execution-providers/TensorRT-ExecutionProvider.md
+++ b/docs/execution-providers/TensorRT-ExecutionProvider.md
@@ -472,12 +472,12 @@ TensorRT configurations can be set by execution provider options. It's useful wh
 ##### trt_op_types_to_exclude
 
 
-* Description: exclude specific op types from running on TRT.
+* Description: exclude specific op types from running on TRT. (Available in ORT 1.21.0)
   * The format is `op_type_1,op_type_2,op_type_3...`
-  * One use case is to mitigate this performance issue mentioned [here](https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#known-issues), users can use this option to prevent DDS ops from running on TensorRT, ensuring they are executed by CUDA EP or CPU EP instead:
-  ```bash
-  ./onnxruntime_perf_test -r 1 -e tensorrt -i "trt_op_types_to_exclude|NonMaxSuppression,NonZero,RoiAlign" /path/to/onnx/your_model.onnx
-  ```
+  * One use case is to mitigate the performance issue mentioned [below](https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#known-issues), it allows users to prevent DDS ops from running on TensorRT, ensuring they are executed by CUDA EP or CPU EP instead:
+    ```bash
+    ./onnxruntime_perf_test -r 1 -e tensorrt -i "trt_op_types_to_exclude|NonMaxSuppression,NonZero,RoiAlign" /path/to/onnx/your_model.onnx
+    ```
 
 
 ### Environment Variables(deprecated)

--- a/docs/execution-providers/TensorRT-ExecutionProvider.md
+++ b/docs/execution-providers/TensorRT-ExecutionProvider.md
@@ -475,9 +475,9 @@ TensorRT configurations can be set by execution provider options. It's useful wh
 * Description: exclude specific op types from running on TRT.
   * The format is `op_type_1,op_type_2,op_type_3...`
   * One use case is to mitigate this performance issue mentioned [here](https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#known-issues), users can use this option to prevent DDS ops from running on TensorRT, ensuring they are executed by CUDA EP or CPU EP instead:
-```bash
-    ./onnxruntime_perf_test -r 1 -e tensorrt -i "trt_op_types_to_exclude|NonMaxSuppression,NonZero,RoiAlign" /path/to/onnx/your_model.onnx
-```
+  ```bash
+  ./onnxruntime_perf_test -r 1 -e tensorrt -i "trt_op_types_to_exclude|NonMaxSuppression,NonZero,RoiAlign" /path/to/onnx/your_model.onnx
+  ```
 
 
 ### Environment Variables(deprecated)
@@ -803,10 +803,12 @@ sess.run(None, args)
 Please note that there is a constraint of using this explicit shape range feature, i.e., all the dynamic shape inputs should be provided with corresponding min/max/opt shapes.
 
 ### Data-dependant shape (DDS) ops
-The DDS operations — NonMaxSuppression, NonZero, and RoiAlign — have output shapes that are only determined at runtime. To ensure DDS ops are executed by TRT-EP/TRT instead of CUDA EP or CPU EP, please check the following:
+The DDS operations — *NonMaxSuppression*, *NonZero*, and *RoiAlign* — have output shapes that are only determined at runtime. 
+
+To ensure DDS ops are executed by TRT-EP/TRT instead of CUDA EP or CPU EP, please check the following:
 * For TensorRT < 10.7: Build ORT with [onnx-tensorrt OSS parser](https://github.com/onnx/onnx-tensorrt) and use `10.X-GA-ORT-DDS` branch.
 * For TensorRT >= 10.7: By default, DDS ops will be executed by TRT.
-* For ORT: By default, ORT relies on the TRT parser to decide if DDS ops run with TRT. However, note that ORT versions 1.20.1 and 1.20.2 will **not** run DDS ops with TRT due to a [known performance issue](https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#known-issues).
+* For ORT: By default, ORT relies on the TRT parser to decide if DDS ops run with TRT. However, note that ORT 1.20.1 and 1.20.2 will **not** run DDS ops with TRT due to a [known performance issue](https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#known-issues).
 
 
 
@@ -847,5 +849,5 @@ Please see [this Notebook](https://github.com/microsoft/onnxruntime/blob/main/do
 - TensorRT 8.6 built-in parser and TensorRT oss parser behaves differently. Namely built-in parser cannot recognize some custom plugin ops while OSS parser can. See [EfficientNMS_TRT missing attribute class_agnostic w/ TensorRT 8.6
 ](https://github.com/microsoft/onnxruntime/issues/16121).
 - There is a performance issue for TensorRT versions 10.0 to 10.5 when running models, such as Faster-RCNN, that:
-a) contain data-dependent shape (DDS) operations, like NonMaxSuppression, NonZero, and RoiAlign, and
-b) DDS ops are executed with TRT
+  - contain data-dependent shape (DDS) operations, like NonMaxSuppression, NonZero, and RoiAlign, and
+  - DDS ops are executed with TRT

--- a/docs/execution-providers/TensorRT-ExecutionProvider.md
+++ b/docs/execution-providers/TensorRT-ExecutionProvider.md
@@ -469,6 +469,12 @@ TensorRT configurations can be set by execution provider options. It's useful wh
   * Turing and former Nvidia GPU architecture and Nvidia Jetson Orin platform are not eligble to this option.
 
 
+##### trt_op_types_to_exclude
+
+
+* Description: exclude specific op types to run on TRT.
+
+
 ### Environment Variables(deprecated)
 
 Following environment variables can be set for TensorRT execution provider. Click below for more details.
@@ -791,6 +797,11 @@ sess.run(None, args)
 
 Please note that there is a constraint of using this explicit shape range feature, i.e., all the dynamic shape inputs should be provided with corresponding min/max/opt shapes.
 
+### Data-dependant shape (DDS) ops
+DDS ops are NonMaxSuppression, NonZero and RoiAlign. The output shape of the DDS op is not known until runtime.
+To enable DDS ops run by TRT-EP/TRT not by CUDA-EP, please check following two things:
+* For TensorRT < 10.7, you need to build ORT against [onnx-tensorrt OSS parser](https://github.com/onnx/onnx-tensorrt) and make sure using 
+*
 
 ## Samples
 
@@ -827,4 +838,5 @@ Please see [this Notebook](https://github.com/microsoft/onnxruntime/blob/main/do
 
 ## Known Issues
 - TensorRT 8.6 built-in parser and TensorRT oss parser behaves differently. Namely built-in parser cannot recognize some custom plugin ops while OSS parser can. See [EfficientNMS_TRT missing attribute class_agnostic w/ TensorRT 8.6
-](https://github.com/microsoft/onnxruntime/issues/16121). 
+](https://github.com/microsoft/onnxruntime/issues/16121).
+- There is a performance issue when running models, e.g. Faster-RCNN, that a) contains data-dependant shape (DDS) ops, e.g. NonMaxSuppression, NonZero and RoiAlign, and b) the DDS ops are run by TensorRT using TensorRT version 10.0 to 10.5.

--- a/docs/execution-providers/TensorRT-ExecutionProvider.md
+++ b/docs/execution-providers/TensorRT-ExecutionProvider.md
@@ -202,6 +202,7 @@ Ort::ThrowOnError(api.GetTensorRTProviderOptionsAsString(tensorrt_options,      
 | Set minimum size for subgraphs in partitioning     | [trt_min_subgraph_size](./TensorRT-ExecutionProvider.md#trt_min_subgraph_size)             | int    |
 | Dump optimized subgraphs for debugging             | [trt_dump_subgraphs](./TensorRT-ExecutionProvider.md#trt_dump_subgraphs)                   | bool   |
 | Force sequential engine builds under multi-GPU     | [trt_force_sequential_engine_build](./TensorRT-ExecutionProvider.md#trt_force_sequential_engine_build) | bool   |
+| Exclude specific op types from running on TRT      | [trt_op_types_to_exclude](./TensorRT-ExecutionProvider.md#trt_op_types_to_exclude)         | string |
 |                                                    |                                                                                            |        |
 | **Advanced Configuration and Profiling**           |                                                                                            |        |
 | Enable sharing of context memory between subgraphs | [trt_context_memory_sharing_enable](./TensorRT-ExecutionProvider.md#trt_context_memory_sharing_enable) | bool   |

--- a/docs/execution-providers/TensorRT-ExecutionProvider.md
+++ b/docs/execution-providers/TensorRT-ExecutionProvider.md
@@ -478,7 +478,7 @@ TensorRT configurations can be set by execution provider options. It's useful wh
     ```bash
     ./onnxruntime_perf_test -r 1 -e tensorrt -i "trt_op_types_to_exclude|NonMaxSuppression,NonZero,RoiAlign" /path/to/onnx/your_model.onnx
     ```
-
+  * Another use case is experimenting assigning ops to CUDA EP vs TRT EP
 
 ### Environment Variables(deprecated)
 

--- a/docs/execution-providers/TensorRT-ExecutionProvider.md
+++ b/docs/execution-providers/TensorRT-ExecutionProvider.md
@@ -800,8 +800,18 @@ Please note that there is a constraint of using this explicit shape range featur
 ### Data-dependant shape (DDS) ops
 DDS ops are NonMaxSuppression, NonZero and RoiAlign. The output shape of the DDS op is not known until runtime.
 To enable DDS ops run by TRT-EP/TRT not by CUDA-EP, please check following two things:
-* For TensorRT < 10.7, you need to build ORT against [onnx-tensorrt OSS parser](https://github.com/onnx/onnx-tensorrt) and make sure using 
-*
+* For TensorRT < 10.7, you need to build ORT against [onnx-tensorrt OSS parser](https://github.com/onnx/onnx-tensorrt) and make sure using the 10.X-GA-ORT-DDS branch.
+* For ORT, by default, it relies on TRT parser to determine whether the DDS ops will be run by TRT. But please note that ORT 1.20.1 and 1.20.2 are exceptions where they implicitly filters out DDS ops from being run by TRT
+  due to the [known performance issue](https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#known-issues).
+
+To avoid the performance issue mentioned above. please use `trt_op_types_to_exclude` so that DDS ops will be run by CUDA EP or CPU EP:
+```bash
+    # e.g.
+    # -r: set up test repeat time
+    # -e: set up execution provider
+    # -i: set up params for execution provider options
+    ./onnxruntime_perf_test -r 1 -e tensorrt -i "trt_op_types_to_exclude|NonMaxSuppression,NonZero,RoiAlign" /path/to/onnx/your_model.onnx
+```
 
 ## Samples
 


### PR DESCRIPTION
Add the usage of trt_op_types_to_exclude.
One use case is using this to prevent DDS ops from running on TensorRT to avoid the performance issue.

