### PR TITLE
WebGPU: Remove deprecated subgroups-f16 from WebGPU native and JS EP

### DIFF
--- a/js/web/lib/wasm/jsep/init.ts
+++ b/js/web/lib/wasm/jsep/init.ts
@@ -15,7 +15,6 @@ import {
   AdapterInfo,
   ComputeContext,
   ComputeContextInputsOutputsMapping,
-  DeviceInfo,
   ProgramInfo,
 } from './webgpu/types';
 import { WebNNBackend } from './backend-webnn';
@@ -76,7 +75,6 @@ class TensorViewImpl implements TensorView {
 
 class ComputeContextImpl implements ComputeContext {
   readonly adapterInfo: AdapterInfo;
-  readonly deviceInfo: DeviceInfo;
   readonly opKernelContext: number;
   readonly inputs: readonly TensorView[];
   readonly outputCount: number;
@@ -94,7 +92,6 @@ class ComputeContextImpl implements ComputeContext {
     contextDataOffset: number,
   ) {
     this.adapterInfo = backend.adapterInfo;
-    this.deviceInfo = backend.deviceInfo;
 
     // extract context data
     const ptrSize = module.PTR_SIZE;

--- a/js/web/lib/wasm/jsep/init.ts
+++ b/js/web/lib/wasm/jsep/init.ts
@@ -11,12 +11,7 @@ import { WebGpuBackend } from './backend-webgpu';
 import { LOG_DEBUG } from './log';
 import { TensorView } from './tensor-view';
 import { ShapeUtil } from './util';
-import {
-  AdapterInfo,
-  ComputeContext,
-  ComputeContextInputsOutputsMapping,
-  ProgramInfo,
-} from './webgpu/types';
+import { AdapterInfo, ComputeContext, ComputeContextInputsOutputsMapping, ProgramInfo } from './webgpu/types';
 import { WebNNBackend } from './backend-webnn';
 
 /* eslint-disable no-bitwise */

--- a/js/web/lib/wasm/jsep/webgpu/program-manager.ts
+++ b/js/web/lib/wasm/jsep/webgpu/program-manager.ts
@@ -99,7 +99,6 @@ export class ProgramManager {
     const extensionsInfo: Array<{ feature: GPUFeatureName; extension: string }> = [
       { feature: 'shader-f16', extension: 'f16' },
       { feature: 'subgroups' as GPUFeatureName, extension: 'subgroups' },
-      { feature: 'subgroups-f16' as GPUFeatureName, extension: 'subgroups_f16' },
     ];
     extensionsInfo.forEach((info) => {
       if (device.features.has(info.feature)) {

--- a/js/web/lib/wasm/jsep/webgpu/types.ts
+++ b/js/web/lib/wasm/jsep/webgpu/types.ts
@@ -21,11 +21,6 @@ export interface AdapterInfo {
   isArchitecture: (architecture: GpuArchitecture) => boolean;
   isVendor: (vendor: GpuVendor) => boolean;
 }
-export interface DeviceInfo {
-  readonly subgroupsSupported: boolean;
-  readonly subgroupsF16Supported: boolean;
-  readonly subgroupSizeRange?: readonly [number, number];
-}
 
 export interface GpuData {
   type: GpuDataType;
@@ -164,11 +159,6 @@ export interface ComputeContext {
    * gpu adapter info
    */
   readonly adapterInfo: AdapterInfo;
-
-  /**
-   * gpu device info
-   */
-  readonly deviceInfo: DeviceInfo;
 
   /**
    * stores the pointer to OpKernelContext

--- a/onnxruntime/core/providers/webgpu/shader_helper.cc
+++ b/onnxruntime/core/providers/webgpu/shader_helper.cc
@@ -345,9 +345,6 @@ Status ShaderHelper::GenerateSourceCode(std::string& code, std::vector<int>& sha
                   })) {
     ORT_RETURN_IF_NOT(device_.HasFeature(wgpu::FeatureName::ShaderF16), "Program ", program_.Name(), " requires f16 but the device does not support it.");
     ss << "enable f16;\n";
-    if (device_.HasFeature(wgpu::FeatureName::SubgroupsF16)) {
-      ss << "enable subgroups_f16;\n";
-    }
   }
   if (device_.HasFeature(wgpu::FeatureName::Subgroups)) {
     ss << "enable subgroups;\n";

--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -490,8 +490,7 @@ std::vector<wgpu::FeatureName> WebGpuContext::GetAvailableRequiredFeatures(const
 #endif
       wgpu::FeatureName::TimestampQuery,
       wgpu::FeatureName::ShaderF16,
-      wgpu::FeatureName::Subgroups,
-      wgpu::FeatureName::SubgroupsF16};
+      wgpu::FeatureName::Subgroups};
   for (auto feature : features) {
     if (adapter.HasFeature(feature)) {
       required_features.push_back(feature);


### PR DESCRIPTION
This PR removes the deprecated subgroups-f16 from WebGPU native and JS EP, and also remove the unused deviceInfo in WebGPU JS EP.