### PR TITLE
[js/web] improve workaround for bundlers

### DIFF
--- a/js/web/lib/wasm/proxy-wrapper.ts
+++ b/js/web/lib/wasm/proxy-wrapper.ts
@@ -12,7 +12,11 @@ import {
 } from './proxy-messages';
 import * as core from './wasm-core-impl';
 import { initializeWebAssembly } from './wasm-factory';
-import { importProxyWorker, inferWasmPathPrefixFromScriptSrc } from './wasm-utils-import';
+import {
+  importProxyWorker,
+  inferWasmPathPrefixFromScriptSrc,
+  isEsmImportMetaUrlHardcodedAsFileUri,
+} from './wasm-utils-import';
 
 const isProxy = (): boolean => !!env.wasm.proxy && typeof document !== 'undefined';
 let proxyWorker: Worker | undefined;
@@ -116,7 +120,7 @@ export const initializeWebAssemblyAndOrtRuntime = async (): Promise<void> => {
             BUILD_DEFS.IS_ESM &&
             BUILD_DEFS.ENABLE_BUNDLE_WASM_JS &&
             !message.in!.wasm.wasmPaths &&
-            (objectUrl || BUILD_DEFS.ESM_IMPORT_META_URL?.startsWith('file:'))
+            (objectUrl || isEsmImportMetaUrlHardcodedAsFileUri)
           ) {
             // for a build bundled the wasm JS, if either of the following conditions is met:
             // - the proxy worker is loaded from a blob URL

--- a/js/web/test/e2e/exports/main.js
+++ b/js/web/test/e2e/exports/main.js
@@ -31,7 +31,7 @@ module.exports = async function main(PRESERVE, PACKAGES_TO_INSTALL) {
     await runProdTest('vite-default', '\x1b[32m➜\x1b[39m  \x1b[1mLocal\x1b[22m:', 4173);
 
     await verifyAssets('vite-default', async (cwd) => {
-      const globby = require('globby');
+      const globby = await import('globby');
 
       return {
         test: 'File "dist/assets/**/ort.*.mjs" should not exist',

--- a/js/web/test/e2e/exports/main.js
+++ b/js/web/test/e2e/exports/main.js
@@ -3,7 +3,7 @@
 
 'use strict';
 
-const { runDevTest, runProdTest } = require('./test');
+const { runDevTest, runProdTest, verifyAssets } = require('./test');
 const { installOrtPackages } = require('./utils');
 
 /**
@@ -29,5 +29,14 @@ module.exports = async function main(PRESERVE, PACKAGES_TO_INSTALL) {
 
     await runDevTest('vite-default', '\x1b[32m➜\x1b[39m  \x1b[1mLocal\x1b[22m:', 5173);
     await runProdTest('vite-default', '\x1b[32m➜\x1b[39m  \x1b[1mLocal\x1b[22m:', 4173);
+
+    await verifyAssets('vite-default', async (cwd) => {
+      const globby = require('globby');
+
+      return {
+        test: 'File "dist/assets/**/ort.*.mjs" should not exist',
+        success: globby.globbySync('dist/assets/**/ort.*.mjs', { cwd }).length === 0,
+      };
+    });
   }
 };

--- a/js/web/test/e2e/exports/test.js
+++ b/js/web/test/e2e/exports/test.js
@@ -121,7 +121,29 @@ async function runProdTest(testCaseName, ready, port) {
   await runTest(testCaseName, ['prod'], ready, 'npm run start', port);
 }
 
+async function verifyAssets(testCaseName, testers) {
+  testers = Array.isArray(testers) ? testers : [testers];
+  const wd = path.join(__dirname, 'testcases', testCaseName);
+
+  console.log(`[${testCaseName}] Verifying assets...`);
+
+  const testResults = [];
+
+  try {
+    for (const tester of testers) {
+      testResults.push(await tester(wd));
+    }
+
+    if (testResults.some((r) => !r.success)) {
+      throw new Error(`[${testCaseName}] asset verification failed.`);
+    }
+  } finally {
+    console.log(`[${testCaseName}] asset verification result:`, testResults);
+  }
+}
+
 module.exports = {
   runDevTest,
   runProdTest,
+  verifyAssets,
 };


### PR DESCRIPTION
### Description
This PR improves the workaround for bundlers in onnxruntime-web. Specifically, the following changes have been made:

- Use [this workaround](https://github.com/xenova/onnxruntime/commit/9c50aa2c63bad4cb73ad77ff1c43e0c43da0907f) as suggested by @xenova in https://github.com/huggingface/transformers.js/pull/1161#issuecomment-2695785730

- Use `url > "file:" && url < "file;"` instead of `url.startsWith("file:")` to allow minifiers to remove dead code correctly.

This change allows to remove unnecessary dependencies of file parsed from `new URL("ort.bundle.min.js", import.meta.url)` in Vite, and optimize code like `if("file://filepath.js".startsWith("file:")) {do_sth1(); } else {do_sth2();}` into `do_sth1()` for webpack/terser usages.

Resolves https://github.com/huggingface/transformers.js/pull/1161

