### PR TITLE
Exclude MAUI projects from GPU C# packaging builds

### DIFF
--- a/tools/ci_build/github/azure-pipelines/rocm-nuget-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/rocm-nuget-packaging-pipeline.yml
@@ -224,7 +224,7 @@ stages:
     - task: MSBuild@1
       displayName: 'Restore NuGet Packages and create project.assets.json'
       inputs:
-        solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln'
+        solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.DesktopOnly.CSharp.sln'
         platform: 'Any CPU'
         configuration: RelWithDebInfo
         msbuildArguments: '-t:restore -p:OrtPackageId="Microsoft.ML.OnnxRuntime.ROCm"'
@@ -233,7 +233,7 @@ stages:
     - task: MSBuild@1
       displayName: 'Build C# bindings'
       inputs:
-        solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln'
+        solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.DesktopOnly.CSharp.sln'
         platform: 'Any CPU'
         configuration: RelWithDebInfo
         msbuildArguments: >
@@ -317,7 +317,7 @@ stages:
     - task: MSBuild@1
       displayName: 'Clean C#'
       inputs:
-        solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln'
+        solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.DesktopOnly.CSharp.sln'
         platform: 'Any CPU'
         configuration: RelWithDebInfo
         msbuildArguments: '-t:Clean -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=Microsoft.ML.OnnxRuntime.ROCm'

--- a/tools/ci_build/github/azure-pipelines/stages/nuget-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nuget-cuda-packaging-stage.yml
@@ -96,18 +96,10 @@ stages:
           inputs:
             versionSpec: 6.10.x
 
-        - task: PowerShell@2
-          displayName: Install MAUI workloads
-          inputs:
-            targetType: 'inline'
-            script: |
-              dotnet workload install android ios maccatalyst
-            workingDirectory: '$(Build.SourcesDirectory)\csharp'
-
         - task: MSBuild@1
           displayName: 'Restore NuGet Packages and create project.assets.json'
           inputs:
-            solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln'
+            solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.DesktopOnly.CSharp.sln'
             platform: 'Any CPU'
             configuration: RelWithDebInfo
             msbuildArguments: '-t:restore -p:OrtPackageId="Microsoft.ML.OnnxRuntime.Gpu"'
@@ -116,7 +108,7 @@ stages:
         - task: MSBuild@1
           displayName: 'Build C# bindings'
           inputs:
-            solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln'
+            solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.DesktopOnly.CSharp.sln'
             configuration: RelWithDebInfo
             platform: 'Any CPU'
             msbuildArguments: >
@@ -208,7 +200,7 @@ stages:
         - task: MSBuild@1
           displayName: 'Clean C#'
           inputs:
-            solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln'
+            solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.DesktopOnly.CSharp.sln'
             platform: 'Any CPU'
             configuration: RelWithDebInfo
             msbuildArguments: '-t:Clean -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=Microsoft.ML.OnnxRuntime.Gpu'
@@ -223,4 +215,3 @@ stages:
           inputs:
             artifactName: 'drop-signed-nuget-GPU'
             targetPath: '$(Build.ArtifactStagingDirectory)'
-


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Use 'desktop only' solution in GPU C# packaging builds. We don't need to include any MAUI support for those builds.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


