### PR TITLE
[Fix] Dependencies find_package Eigen error

### DIFF
--- a/cmake/external/eigen.cmake
+++ b/cmake/external/eigen.cmake
@@ -2,11 +2,12 @@ set(EIGEN_BUILD_DOC OFF CACHE BOOL "" FORCE)
 set(EIGEN_BUILD_BLAS OFF CACHE BOOL "" FORCE)
 set(EIGEN_BUILD_LAPACK OFF CACHE BOOL "" FORCE)
 set(EIGEN_BUILD_PKGCONFIG OFF CACHE BOOL "" FORCE)
+set(EIGEN_BUILD_CMAKE_PACKAGE ON CACHE BOOL "" FORCE)
 
 onnxruntime_fetchcontent_declare(
-    eigen
+    Eigen3
     URL ${DEP_URL_eigen}
     URL_HASH SHA1=${DEP_SHA1_eigen}
     EXCLUDE_FROM_ALL
 )
-onnxruntime_fetchcontent_makeavailable(eigen)
+onnxruntime_fetchcontent_makeavailable(Eigen3)


### PR DESCRIPTION
### Description
To fix the CMake configuration error when a dependency brought in via FetchContent uses find_package(Eigen3 REQUIRED)

Major Changes：
- enable EIGEN_BUILD_CMAKE_PACKAGE
- [optional] rename eigen to Eigen3 

### Motivation and Context

Get the following build error when Dependencies use find_package(Eigen3 REQUIRED) 
```
By not providing "FindEigen3.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "Eigen3", but
  CMake did not find one.

  Could not find a package configuration file provided by "Eigen3" with any
  of the following names:

    Eigen3Config.cmake
    eigen3-config.cmake

  Add the installation prefix of "Eigen3" to CMAKE_PREFIX_PATH or set
  "Eigen3_DIR" to a directory containing one of the above files.  If "Eigen3"
  provides a separate development package or SDK, be sure it has been
  installed.
```
Eigen need enable  **EIGEN_BUILD_CMAKE_PACKAGE** when FetchContent for generate  **Eigen3Config.cmake**
https://gitlab.com/libeigen/eigen/-/blob/master/CMakeLists.txt?ref_type=heads#L213

in addition ， the eigen‘s project name is "Eigen3" and providing the cmake configuration file is "Eigen3Config.cmake" :
https://gitlab.com/libeigen/eigen/-/blob/master/CMakeLists.txt?ref_type=heads#L36
https://gitlab.com/libeigen/eigen/-/blob/master/CMakeLists.txt?ref_type=heads#L252
So I think it's best for FetchContent_Declare Name to be consistent with the project name to avoid potential errors.  






