### PR TITLE
Add support custom position ids and attention mask to GQA CPU operator

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -27,6 +27,7 @@ onnxruntime_add_static_library(onnxruntime_mlas
   ${MLAS_SRC_DIR}/activate.cpp
   ${MLAS_SRC_DIR}/logistic.cpp
   ${MLAS_SRC_DIR}/tanh.cpp
+  ${MLAS_SRC_DIR}/eltwise_add.cpp
   ${MLAS_SRC_DIR}/erf.cpp
   ${MLAS_SRC_DIR}/compute.cpp
   ${MLAS_SRC_DIR}/quantize.cpp

--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -27,7 +27,8 @@ onnxruntime_add_static_library(onnxruntime_mlas
   ${MLAS_SRC_DIR}/activate.cpp
   ${MLAS_SRC_DIR}/logistic.cpp
   ${MLAS_SRC_DIR}/tanh.cpp
-  ${MLAS_SRC_DIR}/eltwise_add.cpp
+  ${MLAS_SRC_DIR}/eltwise.h
+  ${MLAS_SRC_DIR}/eltwise.cpp
   ${MLAS_SRC_DIR}/erf.cpp
   ${MLAS_SRC_DIR}/compute.cpp
   ${MLAS_SRC_DIR}/quantize.cpp
@@ -102,6 +103,9 @@ function(setup_mlas_source_for_windows)
         ${MLAS_SRC_DIR}/softmax_kernel_neon.h
         ${MLAS_SRC_DIR}/softmax_kernel_neon.cpp
         ${MLAS_SRC_DIR}/softmax_kernel_neon_fp16.cpp
+        ${MLAS_SRC_DIR}/eltwise_kernel_neon.h
+        ${MLAS_SRC_DIR}/eltwise_kernel_neon.cpp
+        ${MLAS_SRC_DIR}/eltwise_kernel_neon_fp16.cpp
       )
 
       set(mlas_platform_preprocess_srcs
@@ -388,6 +392,8 @@ else()
           ${MLAS_SRC_DIR}/hgemm_kernel_neon.cpp
           ${MLAS_SRC_DIR}/softmax_kernel_neon.h
           ${MLAS_SRC_DIR}/softmax_kernel_neon.cpp
+          ${MLAS_SRC_DIR}/eltwise_kernel_neon.h
+          ${MLAS_SRC_DIR}/eltwise_kernel_neon.cpp
         )
         set_source_files_properties(${MLAS_SRC_DIR}/sqnbitgemm_kernel_neon_int8.cpp
                                     PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+dotprod")
@@ -410,6 +416,7 @@ else()
             ${MLAS_SRC_DIR}/rotary_embedding_kernel_neon_fp16.cpp
             ${MLAS_SRC_DIR}/halfgemm_kernel_neon_fp16.cpp
             ${MLAS_SRC_DIR}/softmax_kernel_neon_fp16.cpp
+            ${MLAS_SRC_DIR}/eltwise_kernel_neon_fp16.cpp
           )
           set_source_files_properties(${MLAS_SRC_DIR}/aarch64/HalfGemmKernelNeon.S PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+fp16 ")
           set_source_files_properties(${MLAS_SRC_DIR}/aarch64/QgemmS8S8KernelSmmla.S PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+i8mm ")
@@ -424,6 +431,7 @@ else()
           set_source_files_properties(${MLAS_SRC_DIR}/rotary_embedding_kernel_neon_fp16.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+fp16 ")
           set_source_files_properties(${MLAS_SRC_DIR}/halfgemm_kernel_neon_fp16.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+fp16 ")
           set_source_files_properties(${MLAS_SRC_DIR}/softmax_kernel_neon_fp16.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+fp16 ")
+          set_source_files_properties(${MLAS_SRC_DIR}/eltwise_kernel_neon_fp16.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+fp16 ")
         endif()
 
         if(ONNXRUNTIME_MLAS_MULTI_ARCH)

--- a/onnxruntime/contrib_ops/cpu/bert/attention_helper.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_helper.h
@@ -31,6 +31,19 @@ void ComputeAttentionSoftcapInplace(T* scores, int sequence_length, T softcap) {
   MlasComputeSoftcap(scores, scores, sequence_length, softcap);
 }
 
+template<typename T>
+void ApplyAttentionMask(T* softmax_logits, const T* attention_mask, int N) {
+  MlasEltwiseAdd(softmax_logits, attention_mask, softmax_logits, N);
+
+  // for (int i = 0; i < N; i++) {
+  //   if constexpr (std::is_same<T, float>::value) {
+  //     softmax_logits[i] += static_cast<float>(attention_mask[i]);
+  //   } else {
+  //     softmax_logits[i] = MLFloat16(softmax_logits[i].ToFloat() + attention_mask[i].ToFloat());
+  //   }
+  // }
+}
+
 template <typename T>
 void PrepareMask(const int32_t* mask_index,
                  gsl::span<const int64_t> mask_index_dims,

--- a/onnxruntime/contrib_ops/cpu/bert/attention_helper.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_helper.h
@@ -31,17 +31,9 @@ void ComputeAttentionSoftcapInplace(T* scores, int sequence_length, T softcap) {
   MlasComputeSoftcap(scores, scores, sequence_length, softcap);
 }
 
-template<typename T>
+template <typename T>
 void ApplyAttentionMask(T* softmax_logits, const T* attention_mask, int N) {
   MlasEltwiseAdd(softmax_logits, attention_mask, softmax_logits, N);
-
-  // for (int i = 0; i < N; i++) {
-  //   if constexpr (std::is_same<T, float>::value) {
-  //     softmax_logits[i] += static_cast<float>(attention_mask[i]);
-  //   } else {
-  //     softmax_logits[i] = MLFloat16(softmax_logits[i].ToFloat() + attention_mask[i].ToFloat());
-  //   }
-  // }
 }
 
 template <typename T>

--- a/onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h
+++ b/onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h
@@ -50,7 +50,7 @@ class GQAAttentionBase {
   Status ApplyAttention(const T* Q,                                 // Q data with shape BxNxSxH
                         const T* K,                                 // K data with shape BxN_kvxSxH
                         const T* V,                                 // V data with shape BxN_kvxSxH
-                        const Tensor* attention_mask,                    // Causal attention mask to apply before
+                        const Tensor* attention_mask,               // Causal attention mask to apply before
                         const Tensor* past_key,                     // past K input tensor (if not using past state)
                         const Tensor* past_value,                   // past V input tensor (if not using past state)
                         Tensor* output,                             // output tensor
@@ -135,7 +135,7 @@ class GQAAttentionBase {
                              const T* Q,                                   // Q data. Its size is BxNxSxH
                              const T* K,                                   // k data. Its size is BxNxLxH
                              const int32_t* seqlens_k,                     // total - 1 sequence lengths tensor
-                             const T* attention_mask,
+                             const T* attention_mask,                      // optional causal attention mask
                              const size_t batch_size,                      // batch size of self-attention
                              const size_t sequence_length,                 // sequence length of self-attention (S)
                              const size_t attention_mask_total_seqlen,     // max total seqlen in batch used for attention last dim

--- a/onnxruntime/contrib_ops/cpu/bert/group_query_attention_helper.h
+++ b/onnxruntime/contrib_ops/cpu/bert/group_query_attention_helper.h
@@ -288,6 +288,54 @@ Status CheckInputs(const T* query,
 
   return CheckInputs(query, key, value, past_key, past_value, cos_cache, sin_cache, parameters, num_heads, kv_num_heads, seqlens_k, total_seqlen, scale, softcap);
 }
+
+template<typename T = Tensor>
+Status CheckCustomAttentionInputs(const T* custom_pos_ids,
+                                  const T* custom_causal_attention_mask,
+                                  const int max_seqlens_k,
+                                  const GroupQueryAttentionParameters& parameters)
+{
+  if (custom_pos_ids != nullptr) {
+    const auto& pos_ids_shape = custom_pos_ids->Shape();
+    if (parameters.is_first_prompt) {
+      if (pos_ids_shape[0] != 1 || pos_ids_shape[1] != 1) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                               "Shape of custom_pos_ids must be [1, 1] when processing the prompt");
+      }
+    } else {
+      if (pos_ids_shape[0] != parameters.batch_size) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                               "custom_pos_ids dimension 0 must be equal to the batch size, got ", pos_ids_shape[0]);
+      }
+
+      if (pos_ids_shape[1] < parameters.sequence_length) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                               "custom_pos_ids dimension 1 must be atleast sequence length, got ", pos_ids_shape[1]);
+      }
+    }
+  }
+
+  if (custom_causal_attention_mask != nullptr) {
+    const auto& mask_shape = custom_causal_attention_mask->Shape();
+    if (mask_shape[0] != parameters.batch_size) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "custom_causal_attention_mask dimension 0 must be equal to the batch size, got ", mask_shape[0]);
+    }
+
+    if (mask_shape[1] != parameters.sequence_length) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "custom_causal_attention_mask dimension 1 must be equal to the sequence length, got ", mask_shape[1]);
+    }
+
+    if (mask_shape[2] < max_seqlens_k + 1) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "custom_causal_attention_mask dimension 2 must be atleast max(seqlens_k) + 1, got ", mask_shape[2]);
+    }
+  }
+
+  return Status::OK();
+}
+
 }  // namespace group_query_attention_helper
 }  // namespace contrib
 }  // namespace onnxruntime

--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -1128,6 +1128,16 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
                "2D tensor with shape (max_sequence_length, head_size / 2).",
                "T",
                OpSchema::Optional)
+        .Input(9,
+               "custom_pos_ids",
+               "2D tensor with shape (batch_size, sequence_length).",
+               "tensor(int64)",
+               OpSchema::Optional)
+        .Input(10,
+               "custom_causal_attention_mask",
+               "3D tensor with shape (batch_size, sequence_length, total_sequence_length)",
+               "T",
+               OpSchema::Optional)
         .Output(0,
                 "output",
                 "3D output tensor with shape (batch_size, sequence_length, hidden_size)",

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -1030,6 +1030,16 @@ MlasComputeSoftcap(
     T cap
     );
 
+template <typename T>
+void
+MLASCALL
+MlasEltwiseAdd(
+    const T* left,
+    const T* right,
+    T* output,
+    size_t N
+    );
+
 template<typename T>
 void
 MLASCALL

--- a/onnxruntime/core/mlas/lib/eltwise.cpp
+++ b/onnxruntime/core/mlas/lib/eltwise.cpp
@@ -6,16 +6,19 @@ Licensed under the MIT License.
 
 Module Name:
 
-    eltwise_add.cpp
+    eltwise.cpp
 
 Abstract:
 
-    This module implements routines to compute eltwise addition of two vectors.
+    This module implements routines to compute eltwise operations on two vectors.
+
+    Currently supported eltwise operations:
+        - Add
 
 --*/
 
 #include "mlasi.h"
-#include <iostream>
+#include "eltwise.h"
 
 template <>
 void
@@ -26,11 +29,6 @@ MlasEltwiseAdd<float>(
     float* output,
     size_t N
 ) {
-    // std::cout << "running vectorized mlas kernel for fp32 addition" << std::endl;
-    // for (size_t i = 0; i < N; i++) {
-    //     output[i] = left[i] + right[i];
-    // }
-
     while (N > 0) {
         MLAS_FLOAT32X4 LeftVec, RightVec;
 
@@ -82,5 +80,9 @@ MlasEltwiseAdd<MLAS_FP16>(
     MLAS_FP16* output,
     size_t N
 ) {
-    MLAS_THROW_EX(std::runtime_error, "Mlas eltwise add for fp16 is not yet supported.");
+    const auto* dispatch = GetMlasPlatform().EltwiseDispatch;
+    if (dispatch == nullptr || dispatch->Add_Fp16 == nullptr) {
+        MLAS_THROW_EX(std::runtime_error, "Add_Fp16 is not supported.");
+    }
+    dispatch->Add_Fp16(left, right, output, N);
 }

--- a/onnxruntime/core/mlas/lib/eltwise.h
+++ b/onnxruntime/core/mlas/lib/eltwise.h
@@ -1,0 +1,37 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    eltwise.h
+
+Abstract:
+
+    This module includes kernel function prototypes and helper functions for
+    eltwise operations.
+
+--*/
+#pragma once
+
+#include "mlasi.h"
+
+struct MLAS_ELTWISE_DISPATCH {
+    /**
+     * @brief Compute the element-wise addition of the two given vectors
+     * @param left          Address of the left operand
+     * @param right         Address of the right operand
+     * @param output        Address of the output array. Could be the same as the input array.
+     * @param N             Number of elements in the input arrays
+     */
+    typedef void(Add_Fp16_Fn)(
+        const MLAS_FP16* left,
+        const MLAS_FP16* right,
+        MLAS_FP16* output,
+        size_t N
+    );
+
+    Add_Fp16_Fn* Add_Fp16 = nullptr;
+};

--- a/onnxruntime/core/mlas/lib/eltwise_add.cpp
+++ b/onnxruntime/core/mlas/lib/eltwise_add.cpp
@@ -1,0 +1,86 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    eltwise_add.cpp
+
+Abstract:
+
+    This module implements routines to compute eltwise addition of two vectors.
+
+--*/
+
+#include "mlasi.h"
+#include <iostream>
+
+template <>
+void
+MLASCALL
+MlasEltwiseAdd<float>(
+    const float* left,
+    const float* right,
+    float* output,
+    size_t N
+) {
+    // std::cout << "running vectorized mlas kernel for fp32 addition" << std::endl;
+    // for (size_t i = 0; i < N; i++) {
+    //     output[i] = left[i] + right[i];
+    // }
+
+    while (N > 0) {
+        MLAS_FLOAT32X4 LeftVec, RightVec;
+
+        if (N >= 4) {
+            LeftVec = MlasLoadFloat32x4(left);
+            RightVec = MlasLoadFloat32x4(right);
+        } else {
+#if defined(MLAS_SSE2_INTRINSICS)
+            // N.B. SSE2 lacks a broadcast load instruction, so avoid a shuffle
+            // and use zeroes for the upper elements.
+            LeftVec = _mm_load_ss(left);
+            RightVec = _mm_load_ss(right);
+#elif defined(MLAS_LSX_INTRINSICS)
+            LeftVec = (MLAS_FLOAT32X4)__lsx_vldrepl_w(left, 0);
+            RightVec = (MLAS_FLOAT32X4)__lsx_vldrepl_w(right, 0);
+#else
+            LeftVec = MlasBroadcastFloat32x4(left);
+            RightVec = MlasBroadcastFloat32x4(right);
+#endif
+        }
+
+        MLAS_FLOAT32X4 ResultVec = MlasAddFloat32x4(LeftVec, RightVec);
+
+        if (N >= 4) {
+            MlasStoreFloat32x4(output, ResultVec);
+
+            left += 4;
+            right += 4;
+            output += 4;
+            N -= 4;
+        } else {
+            MlasStoreLaneFloat32x4<0>(output, ResultVec);
+
+            left += 1;
+            right += 1;
+            output += 1;
+            N -= 1;
+        }
+    }
+}
+
+
+template <>
+void
+MLASCALL
+MlasEltwiseAdd<MLAS_FP16>(
+    const MLAS_FP16* left,
+    const MLAS_FP16* right,
+    MLAS_FP16* output,
+    size_t N
+) {
+    MLAS_THROW_EX(std::runtime_error, "Mlas eltwise add for fp16 is not yet supported.");
+}

--- a/onnxruntime/core/mlas/lib/eltwise_kernel_neon.cpp
+++ b/onnxruntime/core/mlas/lib/eltwise_kernel_neon.cpp
@@ -1,0 +1,32 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    eltwise_kernel_neon.cpp
+
+Abstract:
+
+    This module implements the eltwise kernels for ARM NEON.
+
+--*/
+
+#include "eltwise.h"
+#include "eltwise_kernel_neon.h"
+
+//
+// Kernel dispatch structure definition.
+//
+const MLAS_ELTWISE_DISPATCH MlasEltwiseDispatchNeon = []() {
+    MLAS_ELTWISE_DISPATCH d;
+
+#if defined(MLAS_F16VEC_INTRINSICS_SUPPORTED) && defined(MLAS_TARGET_ARM64)
+    if (MlasFp16AccelerationSupported()) {
+        d.Add_Fp16 = eltwise_neon::Add_Kernel_Fp16;
+    }
+#endif
+    return d;
+}();

--- a/onnxruntime/core/mlas/lib/eltwise_kernel_neon.h
+++ b/onnxruntime/core/mlas/lib/eltwise_kernel_neon.h
@@ -1,0 +1,28 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    eltwise_kernel_neon.h
+
+Abstract:
+
+    This module includes function declarations and common helper functions for
+    eltwise operations on ARM cpu.
+
+--*/
+
+#pragma once
+
+#include <arm_neon.h>
+
+#include "mlasi.h"
+
+namespace eltwise_neon {
+
+void Add_Kernel_Fp16(const MLAS_FP16* left, const MLAS_FP16* right, MLAS_FP16* output, size_t N);
+
+}  // namespace eltwise_neon

--- a/onnxruntime/core/mlas/lib/eltwise_kernel_neon_fp16.cpp
+++ b/onnxruntime/core/mlas/lib/eltwise_kernel_neon_fp16.cpp
@@ -88,7 +88,7 @@ void Add_Kernel_Fp16(const MLAS_FP16* left, const MLAS_FP16* right, MLAS_FP16* o
     if (N & 4) {
         auto l0 = MlasLoadFloat16x4(left_fp16);
         auto r0 = MlasLoadFloat16x4(right_fp16);
-        auto o0 = MlasAddFLoat16(l0, r0);
+        auto o0 = MlasAddFloat16(l0, r0);
         MlasStoreFloat16x4(output_fp16, o0);
 
         left_fp16 += 4;

--- a/onnxruntime/core/mlas/lib/eltwise_kernel_neon_fp16.cpp
+++ b/onnxruntime/core/mlas/lib/eltwise_kernel_neon_fp16.cpp
@@ -1,0 +1,118 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    eltwise_kernel_neon_fp16.cpp
+
+Abstract:
+
+    This module implements the fp16 eltwise kernels for ARM NEON.
+
+--*/
+#include <arm_neon.h>
+#include <cassert>
+
+#include "fp16_common.h"
+#include "eltwise.h"
+#include "eltwise_kernel_neon.h"
+
+namespace eltwise_neon {
+
+void Add_Kernel_Fp16(const MLAS_FP16* left, const MLAS_FP16* right, MLAS_FP16* output, size_t N) {
+    const auto* left_fp16 = reinterpret_cast<const _mlas_fp16_*>(left);
+    const auto* right_fp16 = reinterpret_cast<const _mlas_fp16_*>(right);
+    auto* output_fp16 = reinterpret_cast<_mlas_fp16_*>(output);
+
+    while (N >= 32) {
+        auto l0 = MlasLoadFloat16x8(left_fp16);
+        auto l1 = MlasLoadFloat16x8(left_fp16 + 8);
+        auto l2 = MlasLoadFloat16x8(left_fp16 + 16);
+        auto l3 = MlasLoadFloat16x8(left_fp16 + 24);
+
+        auto r0 = MlasLoadFloat16x8(right_fp16);
+        auto r1 = MlasLoadFloat16x8(right_fp16 + 8);
+        auto r2 = MlasLoadFloat16x8(right_fp16 + 16);
+        auto r3 = MlasLoadFloat16x8(right_fp16 + 24);
+
+        auto o0 = MlasAddFloat16(l0, r0);
+        auto o1 = MlasAddFloat16(l1, r1);
+        auto o2 = MlasAddFloat16(l2, r2);
+        auto o3 = MlasAddFloat16(l3, r3);
+
+        MlasStoreFloat16x8(output_fp16, o0);
+        MlasStoreFloat16x8(output_fp16 + 8, o1);
+        MlasStoreFloat16x8(output_fp16 + 16, o2);
+        MlasStoreFloat16x8(output_fp16 + 24, o3);
+
+        left_fp16 += 32;
+        right_fp16 += 32;
+        output_fp16 += 32;
+        N -= 32;
+    }
+
+    if (N & 16) {
+        auto l0 = MlasLoadFloat16x8(left_fp16);
+        auto l1 = MlasLoadFloat16x8(left_fp16 + 8);
+
+        auto r0 = MlasLoadFloat16x8(right_fp16);
+        auto r1 = MlasLoadFloat16x8(right_fp16 + 8);
+
+        auto o0 = MlasAddFloat16(l0, r0);
+        auto o1 = MlasAddFloat16(l1, r1);
+
+        MlasStoreFloat16x8(output_fp16, o0);
+        MlasStoreFloat16x8(output_fp16 + 8, o1);
+
+        left_fp16 += 16;
+        right_fp16 += 16;
+        output_fp16 += 16;
+        N -= 16;
+    }
+
+    if (N & 8) {
+        auto l0 = MlasLoadFloat16x8(left_fp16);
+        auto r0 = MlasLoadFloat16x8(right_fp16);
+        auto o0 = MlasAddFloat16(l0, r0);
+        MlasStoreFloat16x8(output_fp16, o0);
+
+        left_fp16 += 8;
+        right_fp16 += 8;
+        output_fp16 += 8;
+        N -= 8;
+    }
+
+    if (N & 4) {
+        auto l0 = MlasLoadFloat16x4(left_fp16);
+        auto r0 = MlasLoadFloat16x4(right_fp16);
+        auto o0 = MlasAddFLoat16(l0, r0);
+        MlasStoreFloat16x4(output_fp16, o0);
+
+        left_fp16 += 4;
+        right_fp16 += 4;
+        output_fp16 += 4;
+        N -= 4;
+    }
+
+    if (N == 3) {
+        auto l0 = MlasLoadPartialFloat16x4(left_fp16, 3);
+        auto r0 = MlasLoadPartialFloat16x4(right_fp16, 3);
+        auto o0 = MlasAddFloat16(l0, r0);
+        MlasStorePartialFloat16x4(output_fp16, o0, 3);
+    } else if (N == 2) {
+        auto l0 = MlasLoadPartialFloat16x4(left_fp16, 2);
+        auto r0 = MlasLoadPartialFloat16x4(right_fp16, 2);
+        auto o0 = MlasAddFloat16(l0, r0);
+        MlasStorePartialFloat16x4(output_fp16, o0, 2);
+    } else if (N == 1) {
+        auto l0 = MlasLoadPartialFloat16x4(left_fp16, 1);
+        auto r0 = MlasLoadPartialFloat16x4(right_fp16, 1);
+        auto o0 = MlasAddFloat16(l0, r0);
+        MlasStorePartialFloat16x4(output_fp16, o0, 1);
+    }
+}
+
+}  // namespace eltwise_neon

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -1070,6 +1070,10 @@ extern const MLAS_HGEMM_DISPATCH MlasHGemmDispatchNeon;
 struct MLAS_SOFTMAX_DISPATCH;
 extern const MLAS_SOFTMAX_DISPATCH MlasSoftmaxDispatchNeon;
 
+// eltwise dispatch structure
+struct MLAS_ELTWISE_DISPATCH;
+extern const MLAS_ELTWISE_DISPATCH MlasEltwiseDispatchNeon;
+
 //
 // Quantized depthwise convolution kernels.
 //
@@ -1233,6 +1237,7 @@ struct MLAS_PLATFORM {
     const MLAS_ROPE_DISPATCH* RopeDispatch{nullptr};
     const MLAS_HGEMM_DISPATCH* HGemmDispatch{nullptr};
     const MLAS_SOFTMAX_DISPATCH* SoftmaxDispatch{nullptr};
+    const MLAS_ELTWISE_DISPATCH* EltwiseDispatch{nullptr};
 };
 
 inline

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -547,6 +547,7 @@ Return Value:
     this->RopeDispatch = &MlasRopeDispatchNeon;
     this->HGemmDispatch = &MlasHGemmDispatchNeon;
     this->SoftmaxDispatch = &MlasSoftmaxDispatchNeon;
+    this->EltwiseDispatch = &MlasEltwiseDispatchNeon;
 
     //
     // Check if the processor supports ASIMD dot product instructions.

--- a/onnxruntime/test/mlas/unittest/test_eltwise.cpp
+++ b/onnxruntime/test/mlas/unittest/test_eltwise.cpp
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "test_util.h"
+#include "core/mlas/lib/mlasi.h"
+#include "core/mlas/lib/eltwise.h"
+
+class MlasEltwiseAddTest : public MlasTestBase {
+ private:
+  MatrixGuardBuffer<float> BufferInputLeft;
+  MatrixGuardBuffer<float> BufferInputRight;
+  MatrixGuardBuffer<float> BufferOutput;
+  MatrixGuardBuffer<float> BufferOutputReference;
+  MatrixGuardBuffer<MLAS_FP16> BufferInputLeftFp16;
+  MatrixGuardBuffer<MLAS_FP16> BufferInputRightFp16;
+  MatrixGuardBuffer<MLAS_FP16> BufferOutputFp16;
+
+  void Test(size_t N, float MinimumValue, float MaximumValue) {
+    float* InputLeft = BufferInputLeft.GetBuffer(N);
+    float* InputRight = BufferInputRight.GetBuffer(N);
+    float* Output = BufferOutput.GetBuffer(N);
+    float* OutputReference = BufferOutputReference.GetBuffer(N);
+
+    std::default_random_engine generator(static_cast<unsigned>(N));
+    std::uniform_real_distribution<float> distribution(MinimumValue, MaximumValue);
+
+    for (size_t n = 0; n < N; n++) {
+      InputLeft[n] = distribution(generator);
+      InputRight[n] = distribution(generator);
+    }
+
+    for (size_t n = 0; n < N; n++) {
+      OutputReference[n] = InputLeft[n] + InputRight[n];
+    }
+
+    MlasEltwiseAdd(InputLeft, InputRight, Output, N);
+
+    constexpr float AbsoluteTolerance = 1e-6f;
+    constexpr float RelativeTolerance = 1e-6f;
+
+    for (size_t n = 0; n < N; n++) {
+      float diff = std::fabs(Output[n] - OutputReference[n]);
+      ASSERT_TRUE(diff <= AbsoluteTolerance || diff <= std::fabs(OutputReference[n]) * RelativeTolerance)
+          << " @" << n << " of " << N << ", got: " << Output[n] << ", expecting: " << OutputReference[n];
+    }
+  }
+
+#if defined(MLAS_F16VEC_INTRINSICS_SUPPORTED) && defined(MLAS_TARGET_ARM64)
+
+  void TestFp16(size_t N, float MinimumValue, float MaximumValue) {
+    MLAS_FP16* InputLeft = BufferInputLeftFp16.GetBuffer(N);
+    MLAS_FP16* InputRight = BufferInputRightFp16.GetBuffer(N);
+    MLAS_FP16* Output = BufferOutputFp16.GetBuffer(N);
+
+    std::default_random_engine generator(static_cast<unsigned>(N));
+    std::uniform_real_distribution<float> distribution(MinimumValue, MaximumValue);
+
+    for (size_t n = 0; n < N; n++) {
+      InputLeft[n] = MLAS_FP16(distribution(generator));
+      InputRight[n] = MLAS_FP16(distribution(generator));
+    }
+
+    MlasEltwiseAdd(InputLeft, InputRight, Output, N);
+
+    constexpr float AbsoluteTolerance = 5e-4f;
+    constexpr float RelativeTolerance = 1e-3f;
+
+    for (size_t n = 0; n < N; n++) {
+      float inLeft = InputLeft[n].ToFloat();
+      float inRight = InputRight[n].ToFloat();
+      float ref = inLeft + inRight;
+      float out = Output[n].ToFloat();
+      float diff = std::fabs(out - ref);
+      ASSERT_TRUE(diff <= AbsoluteTolerance || diff <= std::fabs(ref) * RelativeTolerance)
+          << " @ " << inLeft << ", " << inRight << ", got: " << out << ", expecting: " << ref
+          << ", r-diff: " << diff / std::fabs(ref);
+    }
+  }
+
+#endif  // defined(MLAS_F16VEC_INTRINSICS_SUPPORTED) && defined(MLAS_TARGET_ARM64)
+
+ public:
+  static const char* GetTestSuiteName() {
+    static const std::string suite_name("Eltwise_Add");
+    return suite_name.c_str();
+  }
+
+  void ExecuteShort(void) override {
+    for (size_t n = 1; n < 128; n++) {
+      Test(n, -10.f, 10.f);
+#if defined(MLAS_F16VEC_INTRINSICS_SUPPORTED) && defined(MLAS_TARGET_ARM64)
+      TestFp16(n, -17.f, 11.f);
+#endif  // defined(MLAS_F16VEC_INTRINSICS_SUPPORTED) && defined(MLAS_TARGET_ARM64)
+    }
+  }
+};
+
+static UNUSED_VARIABLE bool added_to_main = AddTestRegister([](bool is_short_execute) {
+  size_t count = 0;
+  if (is_short_execute) {
+    count += MlasDirectShortExecuteTests<MlasEltwiseAddTest>::RegisterShortExecute();
+  }
+  return count;
+});


### PR DESCRIPTION
### Description

- Added support for custom position ids and attention masks to the GQA CPU operator (fp32 and fp16)
- Added MLAS eltwise add kernel for mask application for FP32 and FP16
- Added unit tests for the added eltwise add MLAS kernel
- Modified python tests to test the new GQA inputs


### Motivation and Context
Custom position ids and attention mask are required in order to implement speculative decoding in PhiSilica


