### PR TITLE
Qnn weight sharing improvement

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -3674,9 +3674,6 @@ struct OrtApi {
    *   Enable the float32 model to be inferenced with fp16 precision. Otherwise, it will be fp32 precision.
    *     - "0": With fp32 precision.
    *     - "1": Default. With fp16 precision.
-   *   "enable_htp_weight_sharing": Enable QNN weight sharing feature while compiling multiple graphs into one QNN context.
-   *     - "0": Default. Disabled.
-   *     - "1": Enabled.
    *   "offload_graph_io_quantization": Offload graph input quantization and graph output dequantization to another
    *   execution provider (typically CPU EP).
    *     - "0": Disabled. QNN EP will handle quantization and dequantization of graph I/O.

--- a/onnxruntime/core/providers/qnn/builder/onnx_ctx_model_helper.h
+++ b/onnxruntime/core/providers/qnn/builder/onnx_ctx_model_helper.h
@@ -65,6 +65,8 @@ Status CreateEPContextNodes(Model* model,
                             const onnxruntime::PathString& context_model_path,
                             bool qnn_context_embed_mode,
                             uint64_t max_spill_fill_buffer_size,
-                            const logging::Logger& logger);
+                            const logging::Logger& logger,
+                            bool share_ep_contexts,
+                            bool stop_share_ep_contexts);
 }  // namespace qnn
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -867,14 +867,13 @@ Status QnnBackendManager::SetupBackend(const logging::Logger& logger,
   }
 
   bool enable_htp_weight_sharing = false;
-  // weight sharing only available with offline generation on x64 platform, not available on the real device
-#if defined(__aarch64__) || defined(_M_ARM64)
-  ORT_UNUSED_PARAMETER(share_ep_contexts);
-#else
   if (share_ep_contexts && !load_from_cached_context) {
+#if defined(__aarch64__) || defined(_M_ARM64)
+    LOGS(logger, WARNING) << "Weight sharing only available with offline generation on x64 platform, not work on real device.";
+#else
     enable_htp_weight_sharing = true;
-  }
 #endif
+  }
 
   if (!load_from_cached_context) {
     if (status.IsOK()) {

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -43,7 +43,6 @@ struct QnnBackendManagerConfig {
   uint32_t device_id;
   QnnHtpDevice_Arch_t htp_arch;
   uint32_t soc_model;
-  bool enable_htp_weight_sharing;
 };
 
 class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager> {
@@ -67,8 +66,7 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
         qnn_saver_path_(config.qnn_saver_path),
         device_id_(config.device_id),
         htp_arch_(config.htp_arch),
-        soc_model_(config.soc_model),
-        enable_htp_weight_sharing_(config.enable_htp_weight_sharing) {
+        soc_model_(config.soc_model) {
   }
 
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(QnnBackendManager);
@@ -84,7 +82,8 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
 
   // Initializes handles to QNN resources (device, logger, etc.).
   // NOTE: This function locks the internal `logger_recursive_mutex_`.
-  Status SetupBackend(const logging::Logger& logger, bool load_from_cached_context, bool need_load_system_lib);
+  Status SetupBackend(const logging::Logger& logger, bool load_from_cached_context,
+                      bool need_load_system_lib, bool share_ep_contexts);
 
   Status CreateHtpPowerCfgId(uint32_t deviceId, uint32_t coreId, uint32_t& htp_power_config_id);
 
@@ -155,7 +154,7 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
 
   Status ReleaseProfilehandle();
 
-  Status CreateContext();
+  Status CreateContext(bool enable_htp_weight_sharing);
 
   Status ReleaseContext();
 
@@ -298,7 +297,6 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
   uint32_t device_id_ = 0;
   QnnHtpDevice_Arch_t htp_arch_ = QNN_HTP_DEVICE_ARCH_NONE;
   uint32_t soc_model_ = QNN_SOC_MODEL_UNKNOWN;
-  bool enable_htp_weight_sharing_ = false;
 };
 
 }  // namespace qnn

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -337,22 +337,7 @@ QNNExecutionProvider::QNNExecutionProvider(const ProviderOptions& provider_optio
     LOGS_DEFAULT(VERBOSE) << "User specified enable_htp_fp16_precision: " << enable_HTP_FP16_precision_;
   }
 
-  bool enable_htp_weight_sharing = false;
-  static const std::string QNN_HTP_WEIGHT_SHARING_ENABLED = "enable_htp_weight_sharing";
-  auto htp_weight_sharing_enabled_pos = provider_options_map.find(QNN_HTP_WEIGHT_SHARING_ENABLED);
-  if (htp_weight_sharing_enabled_pos != provider_options_map.end()) {
-    if ("1" == htp_weight_sharing_enabled_pos->second) {
-      enable_htp_weight_sharing = true;
-    } else if ("0" == htp_weight_sharing_enabled_pos->second) {
-      enable_htp_weight_sharing = false;
-    } else {
-      LOGS_DEFAULT(VERBOSE) << "Invalid enable_htp_weight_sharing: " << enable_htp_weight_sharing
-                            << " only 0 or 1 allowed. Set to 0.";
-    }
-    LOGS_DEFAULT(VERBOSE) << "User specified enable_htp_weight_sharing: " << enable_htp_weight_sharing;
-  }
-
-  if (qnn_context_embed_mode_ && enable_htp_weight_sharing) {
+  if (qnn_context_embed_mode_ && share_ep_contexts_) {
     LOGS_DEFAULT(ERROR) << "[EP context generation:] Weight sharing enabled conflict with EP context embed mode. Inference will not work as expected!";
   }
 
@@ -410,8 +395,7 @@ QNNExecutionProvider::QNNExecutionProvider(const ProviderOptions& provider_optio
                                      qnn_saver_path,
                                      device_id_,
                                      htp_arch,
-                                     soc_model,
-                                     enable_htp_weight_sharing});
+                                     soc_model});
   }
 
 #if defined(_WIN32)
@@ -705,7 +689,9 @@ QNNExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_viewer
   // It will load the QnnSystem lib if is_qnn_ctx_model=true, and
   // delay the Qnn context creation to Compile() using the cached context binary
   // or generate context cache enable, need to use use QnnSystem lib to parse the binary to get the max spill fill buffer size
-  auto rt = qnn_backend_manager_->SetupBackend(logger, is_qnn_ctx_model, context_cache_enabled_ && enable_spill_fill_buffer_);
+  auto rt = qnn_backend_manager_->SetupBackend(logger, is_qnn_ctx_model,
+                                               context_cache_enabled_ && enable_spill_fill_buffer_,
+                                               share_ep_contexts_);
   if (Status::OK() != rt) {
     LOGS(logger, ERROR) << "QNN SetupBackend failed " << rt.ErrorMessage();
     return result;

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -352,6 +352,10 @@ QNNExecutionProvider::QNNExecutionProvider(const ProviderOptions& provider_optio
     LOGS_DEFAULT(VERBOSE) << "User specified enable_htp_weight_sharing: " << enable_htp_weight_sharing;
   }
 
+  if (qnn_context_embed_mode_ && enable_htp_weight_sharing) {
+    LOGS_DEFAULT(ERROR) << "[EP context generation:] Weight sharing enabled conflict with EP context embed mode. Inference will not work as expected!";
+  }
+
   // Add this option because this feature requires QnnSystem lib and it's no supported for Windows x86_64 platform
   enable_spill_fill_buffer_ = ParseBoolOption("enable_htp_spill_fill_buffer", false, provider_options_map);
 
@@ -1051,7 +1055,9 @@ Status QNNExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& fused
                                                   context_model_path,
                                                   qnn_context_embed_mode_,
                                                   max_spill_fill_buffer_size,
-                                                  logger));
+                                                  logger,
+                                                  share_ep_contexts_,
+                                                  stop_share_ep_contexts_));
 
     if (share_ep_contexts_ && !stop_share_ep_contexts_ &&
         nullptr == SharedContext::GetInstance().GetSharedQnnBackendManager()) {

--- a/onnxruntime/core/providers/qnn/shared_context.h
+++ b/onnxruntime/core/providers/qnn/shared_context.h
@@ -84,6 +84,21 @@ class SharedContext {
     qnn_backend_manager_.reset();
   }
 
+  void SetSharedCtxBinFileName(std::string& shared_ctx_bin_file_name) {
+    const std::lock_guard<std::mutex> lock(mtx_);
+    shared_ctx_bin_file_name_ = shared_ctx_bin_file_name;
+  }
+
+  const std::string& GetSharedCtxBinFileName() {
+    const std::lock_guard<std::mutex> lock(mtx_);
+    return shared_ctx_bin_file_name_;
+  }
+
+  void ResetSharedCtxBinFileName() {
+    const std::lock_guard<std::mutex> lock(mtx_);
+    shared_ctx_bin_file_name_.clear();
+  }
+
  private:
   SharedContext() = default;
   ~SharedContext() = default;
@@ -94,6 +109,9 @@ class SharedContext {
   std::vector<std::unique_ptr<qnn::QnnModel>> shared_qnn_models_;
   // Used for compiling multiple models into same QNN context binary
   std::shared_ptr<qnn::QnnBackendManager> qnn_backend_manager_;
+  // Track the shared ctx binary .bin file name, all _ctx.onnx point to this .bin file
+  // only the last session generate the .bin file since it contains all graphs from all sessions.
+  std::string shared_ctx_bin_file_name_;
   // Producer sessions can be in parallel
   // Consumer sessions have to be after producer sessions initialized
   std::mutex mtx_;

--- a/onnxruntime/test/ep_weight_sharing_ctx_gen/command_args_parser.cc
+++ b/onnxruntime/test/ep_weight_sharing_ctx_gen/command_args_parser.cc
@@ -48,7 +48,6 @@ namespace qnnctxgen {
       "\t    [QNN only] [htp_arch]: The minimum HTP architecture. The driver will use ops compatible with this architecture. eg: '0', '68', '69', '73', '75'. Defaults to '0' (none). \n"
       "\t    [QNN only] [enable_htp_fp16_precision]: Enable the HTP_FP16 precision so that the float32 model will be inferenced with fp16 precision. \n"
       "\t    Otherwise, it will be fp32 precision. Works for float32 model for HTP backend. Defaults to '1' (with FP16 precision.). \n"
-      "\t    [QNN only] [enable_htp_weight_sharing]: Allows common weights across graphs to be shared and stored in a single context binary. Defaults to '1' (enabled).\n"
       "\t    [QNN only] [offload_graph_io_quantization]: Offload graph input quantization and graph output dequantization to another EP (typically CPU EP). \n"
       "\t    Defaults to '1' (QNN EP handles the graph I/O quantization and dequantization). \n"
       "\t    [QNN only] [enable_htp_spill_fill_buffer]: Enable HTP spill file buffer, used while generating QNN context binary."
@@ -161,8 +160,8 @@ static bool ParseSessionConfigs(const std::string& configs_string,
               std::string str = str_stream.str();
               ORT_THROW("Wrong value for htp_graph_finalization_optimization_mode. select from: " + str);
             }
-          } else if (key == "enable_htp_fp16_precision" || key == "enable_htp_weight_sharing" ||
-                     key == "offload_graph_io_quantization" || key == "enable_htp_spill_fill_buffer") {
+          } else if (key == "enable_htp_fp16_precision" || key == "offload_graph_io_quantization" ||
+                     key == "enable_htp_spill_fill_buffer") {
             std::unordered_set<std::string> supported_options = {"0", "1"};
             if (supported_options.find(value) == supported_options.end()) {
               std::ostringstream str_stream;
@@ -173,7 +172,7 @@ static bool ParseSessionConfigs(const std::string& configs_string,
             }
           } else {
             ORT_THROW(R"(Wrong key type entered. Choose from options: ['backend_path', 'vtcm_mb', 'htp_performance_mode',
- 'htp_graph_finalization_optimization_mode', 'soc_model', 'htp_arch', 'enable_htp_fp16_precision', 'enable_htp_weight_sharing',
+ 'htp_graph_finalization_optimization_mode', 'soc_model', 'htp_arch', 'enable_htp_fp16_precision',
  'offload_graph_io_quantization', 'enable_htp_spill_fill_buffer'])");
           }
 

--- a/onnxruntime/test/ep_weight_sharing_ctx_gen/main.cc
+++ b/onnxruntime/test/ep_weight_sharing_ctx_gen/main.cc
@@ -144,11 +144,6 @@ int real_main(int argc, char* argv[]) {
         provider_options["backend_path"] = "libQnnHtp.so";
 #endif
 
-        // set default QNN EP option to enable weight sharing if not set by user
-        const std::string enable_htp_weight_sharing = "enable_htp_weight_sharing";
-        if (provider_options.find(enable_htp_weight_sharing) == provider_options.end()) {
-          provider_options[enable_htp_weight_sharing] = "1";
-        }
         so.AppendExecutionProvider("QNN", provider_options);
 #else
         ORT_THROW("QNN is not supported in this build\n");
@@ -173,8 +168,8 @@ int real_main(int argc, char* argv[]) {
     // so that the inference session can be created with any order of the ctx.onnx models
     // otherwise, user can also skip this step, but they need to create the inference session from the last generated ctx.onnx model
     // since only the last ctx.onnx has EPContext nodes has the correct max_size covers graphs for all sessions
-    const std::string enable_htp_weight_sharing = "enable_htp_spill_fill_buffer";
-    auto pos = provider_options.find(enable_htp_weight_sharing);
+    const std::string enable_htp_spill_fill_buffer = "enable_htp_spill_fill_buffer";
+    auto pos = provider_options.find(enable_htp_spill_fill_buffer);
     if (pos != provider_options.end() && pos->second == "1") {
       std::cout << "Start to update the generated Onnx model to reflect the max_size." << std::endl;
 

--- a/onnxruntime/test/ep_weight_sharing_ctx_gen/main.cc
+++ b/onnxruntime/test/ep_weight_sharing_ctx_gen/main.cc
@@ -17,8 +17,8 @@ using ProviderOptions = std::unordered_map<std::string, std::string>;
 
 // from the last context cache Onnx model, find the EPContext node with main_context=1,
 // get the max spill fill buffer size
-static void GetLastContextBinaryFileName(const std::basic_string<ORTCHAR_T> last_onnx_ctx_file,
-                                         int64_t& max_size) {
+static void GetEpContextInfoFromLastContextModel(const std::basic_string<ORTCHAR_T> last_onnx_ctx_file,
+                                                 int64_t& max_size) {
   max_size = 0;
 
   onnx::ModelProto model;
@@ -182,9 +182,9 @@ int real_main(int argc, char* argv[]) {
       std::vector<std::basic_string<ORTCHAR_T>> ep_ctx_files;
       ep_ctx_files.reserve(test_config.model_file_paths.size());
       for (auto model_path : test_config.model_file_paths) {
-        auto pos = model_path.find_last_of(ORT_TSTR("."));
-        if (pos != std::string::npos) {
-          model_path = model_path.substr(0, pos) + ORT_TSTR("_ctx.onnx");
+        auto dot_pos = model_path.find_last_of(ORT_TSTR("."));
+        if (dot_pos != std::string::npos) {
+          model_path = model_path.substr(0, dot_pos) + ORT_TSTR("_ctx.onnx");
         } else {
           model_path = model_path + ORT_TSTR("_ctx.onnx");
         }
@@ -192,7 +192,7 @@ int real_main(int argc, char* argv[]) {
       }
 
       int64_t max_size = 0;
-      GetLastContextBinaryFileName(ep_ctx_files.back(), max_size);
+      GetEpContextInfoFromLastContextModel(ep_ctx_files.back(), max_size);
       ep_ctx_files.pop_back();
 
       UpdateEpContextModel(ep_ctx_files, max_size);

--- a/onnxruntime/test/ep_weight_sharing_ctx_gen/main.cc
+++ b/onnxruntime/test/ep_weight_sharing_ctx_gen/main.cc
@@ -168,12 +168,13 @@ int real_main(int argc, char* argv[]) {
       }
     }
 
+    // Only with enable_htp_spill_fill_buffer enabled:
     // Update generated context cache Onnx model to have the same max_size (align with the last generated model)
     // so that the inference session can be created with any order of the ctx.onnx models
     // otherwise, user can also skip this step, but they need to create the inference session from the last generated ctx.onnx model
-    // since only the last ctx.onnx has EPContext nodes with correct max_size
+    // since only the last ctx.onnx has EPContext nodes has the correct max_size covers graphs for all sessions
     const std::string enable_htp_weight_sharing = "enable_htp_spill_fill_buffer";
-    if (provider_options.find(enable_htp_weight_sharing) == provider_options.end()) {
+    if (provider_options.find(enable_htp_weight_sharing) != provider_options.end()) {
       std::cout << "Start to update the generated Onnx model to reflect the max_size." << std::endl;
 
       // The steps below only used for spill fill buffer enabled

--- a/onnxruntime/test/ep_weight_sharing_ctx_gen/main.cc
+++ b/onnxruntime/test/ep_weight_sharing_ctx_gen/main.cc
@@ -166,8 +166,6 @@ int real_main(int argc, char* argv[]) {
     // Only with enable_htp_spill_fill_buffer enabled:
     // Update generated context cache Onnx model to have the same max_size (align with the last generated model)
     // so that the inference session can be created with any order of the ctx.onnx models
-    // otherwise, user can also skip this step, but they need to create the inference session from the last generated ctx.onnx model
-    // since only the last ctx.onnx has EPContext nodes has the correct max_size covers graphs for all sessions
     const std::string enable_htp_spill_fill_buffer = "enable_htp_spill_fill_buffer";
     auto pos = provider_options.find(enable_htp_spill_fill_buffer);
     if (pos != provider_options.end() && pos->second == "1") {

--- a/onnxruntime/test/ep_weight_sharing_ctx_gen/main.cc
+++ b/onnxruntime/test/ep_weight_sharing_ctx_gen/main.cc
@@ -174,7 +174,8 @@ int real_main(int argc, char* argv[]) {
     // otherwise, user can also skip this step, but they need to create the inference session from the last generated ctx.onnx model
     // since only the last ctx.onnx has EPContext nodes has the correct max_size covers graphs for all sessions
     const std::string enable_htp_weight_sharing = "enable_htp_spill_fill_buffer";
-    if (provider_options.find(enable_htp_weight_sharing) != provider_options.end()) {
+    auto pos = provider_options.find(enable_htp_weight_sharing);
+    if (pos != provider_options.end() && pos->second == "1") {
       std::cout << "Start to update the generated Onnx model to reflect the max_size." << std::endl;
 
       // The steps below only used for spill fill buffer enabled

--- a/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
@@ -1236,7 +1236,7 @@ TEST_F(QnnHTPBackendTests, QnnContextShareAcrossSessions) {
 
   auto ort_outputs1 = session1.Run(Ort::RunOptions{}, input_names_c.data(), ort_inputs.data(), ort_inputs.size(),
                                    output_names_c.data(), 1);
-  #endif
+#endif
 
   for (auto model_path : onnx_model_paths) {
     std::remove(model_path.c_str());
@@ -1246,7 +1246,6 @@ TEST_F(QnnHTPBackendTests, QnnContextShareAcrossSessions) {
   }
   std::remove(qnn_ctx_binary_file_name1.c_str());
 }
-
 
 // For Ort sessions to generate the context binary, with session option ep.share_ep_contexts enabled
 // Ort sessions will share the QnnBackendManager, so that all graphs from all models compile into the same Qnn context

--- a/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
@@ -1104,7 +1104,6 @@ static void DumpModelWithSharedCtx(ProviderOptions provider_options,
 #endif  // !_M_ARM64
 #endif  // !__aarch64__
 
-
   so.AppendExecutionProvider("QNN", provider_options);
 
   // Create 2 sessions to generate context binary models, the 1st session will share the QnnBackendManager
@@ -1384,23 +1383,13 @@ TEST_F(QnnHTPBackendTests, QnnContextGenWeightSharingSessionAPI) {
     std::remove(ctx_model_path.c_str());
   }
 
-  Ort::SessionOptions so;
-  so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
-  so.AddConfigEntry(kOrtSessionOptionEpContextEmbedMode, "0");
-  // enable ep.share_ep_contexts so that QNNEP share the QnnBackendManager across sessions
-  so.AddConfigEntry(kOrtSessionOptionShareEpContexts, "1");
+  DumpModelWithSharedCtx(provider_options, onnx_model_paths[0], onnx_model_paths[1]);
 
-  so.AppendExecutionProvider("QNN", provider_options);
-
-  Ort::Session session1(*ort_env, ToPathString(onnx_model_paths[0]).c_str(), so);
   std::string qnn_ctx_binary_file_name1;
   GetContextBinaryFileName(ctx_model_paths[0], qnn_ctx_binary_file_name1,
                            DefaultLoggingManager().DefaultLogger());
   EXPECT_TRUE(!qnn_ctx_binary_file_name1.empty());
 
-  // Tell the EP stop share the QnnBackendManager from this session then on
-  so.AddConfigEntry(kOrtSessionOptionStopShareEpContexts, "1");
-  Ort::Session session2(*ort_env, ToPathString(onnx_model_paths[1]).c_str(), so);
   std::string qnn_ctx_binary_file_name2;
   GetContextBinaryFileName(ctx_model_paths[1], qnn_ctx_binary_file_name2,
                            DefaultLoggingManager().DefaultLogger());

--- a/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
@@ -1088,7 +1088,7 @@ static void CreateQdqModel(const std::string& model_file_name, const Logger& log
   ASSERT_STATUS_OK(onnxruntime::Model::Save(model, ToPathString(model_file_name)));
 }
 
-static void DumpModelWithSharedCtx(const ProviderOptions& provider_options,
+static void DumpModelWithSharedCtx(ProviderOptions provider_options,
                                    const std::string& onnx_model_path1,
                                    const std::string& onnx_model_path2) {
   Ort::SessionOptions so;
@@ -1096,6 +1096,14 @@ static void DumpModelWithSharedCtx(const ProviderOptions& provider_options,
   so.AddConfigEntry(kOrtSessionOptionEpContextEmbedMode, "0");
   // enable ep.share_ep_contexts so that QNNEP share the QnnBackendManager across sessions
   so.AddConfigEntry(kOrtSessionOptionShareEpContexts, "1");
+
+#ifndef __aarch64__
+#ifndef _M_ARM64
+  // weight sharing only available for v73 and higher
+  provider_options["soc_model"] = "60";
+#endif  // !_M_ARM64
+#endif  // !__aarch64__
+
 
   so.AppendExecutionProvider("QNN", provider_options);
 

--- a/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
@@ -1399,7 +1399,7 @@ TEST_F(QnnHTPBackendTests, QnnContextGenWeightSharingSessionAPI) {
   EXPECT_TRUE(!qnn_ctx_binary_file_name2.empty());
 
   // 2 *_ctx.onn point to same .bin file
-  EXPECT_TRUE(qnn_ctx_binary_file_name1  == qnn_ctx_binary_file_name2);
+  EXPECT_TRUE(qnn_ctx_binary_file_name1 == qnn_ctx_binary_file_name2);
 
   // clean up
   for (auto model_path : onnx_model_paths) {

--- a/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
@@ -1114,6 +1114,7 @@ static void DumpModelWithSharedCtx(ProviderOptions provider_options,
   Ort::Session session2(*ort_env, ToPathString(onnx_model_path2).c_str(), so);
 }
 
+#if defined(__aarch64__) || defined(_M_ARM64)
 static void GetModelInputNames(const std::string& model_path,
                                std::vector<std::string>& input_names,
                                std::vector<std::string>& output_names,
@@ -1133,6 +1134,7 @@ static void GetModelInputNames(const std::string& model_path,
     output_names.push_back(output->Name());
   }
 }
+#endif
 
 // 1. Create 2 QDQ models
 // 2. Initialize 2 Ort sessions which share the same QNN EP from these 2 QDQ models


### PR DESCRIPTION
### Description
Qnn weight sharing improvement so that only the last session (the session that has both share_ep_contexts and stop_share_ep_contexts enabled) generates the .bin file. The .bin file name is decided from the 1st session. And all generated *_ctx.onnx models point to this single .bin to avoid post-processing work.
Previously each session generates a _ctx.onnx model with a .bin file. So it requires post-processing work to go through generated *_ctx.onnx models to get the last generated *_ctx.bin file and update all *_ctx.onnx to point to the same .bin file and remove the .bin files not used.