### PR TITLE
[WebGPU] Map UMA buffers for model uploading

### DIFF
--- a/include/onnxruntime/core/framework/allocator.h
+++ b/include/onnxruntime/core/framework/allocator.h
@@ -222,6 +222,14 @@ class IAllocator {
                                   }};
   }
 
+  enum class AllocHint {
+    None = 0,
+    UploadDst = 1,
+  };
+  // Set the allocation hint for the allocator. Once set, the Alloc operations of this allocator will be aware of this
+  // hint.
+  virtual void SetAllocHint(AllocHint hint) { ORT_UNUSED_PARAMETER(hint); }
+
  private:
   //
   // validation functions. split out from methods that are templatized on the data type to minimize binary size.

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -163,7 +163,9 @@ static common::Status DeserializeTensorProto(const Env& env, const std::basic_st
       // 2. load initializer into CPU memory - p_deserialize_tensor,
       //    we will use mmap so no need to allocate memory on CPU in advance
       // 3. copy tensor from CPU to device - p_deserialize_tensor -> p_tensor
+      alloc->SetAllocHint(IAllocator::AllocHint::UploadDst);
       ORT_RETURN_IF_ERROR(AllocateTensor(m, p_tensor, type, tensor_shape, use_device_allocator_for_initializers, alloc));
+      alloc->SetAllocHint(IAllocator::AllocHint::None);
 
       std::unique_ptr<Tensor> p_deserialize_tensor = std::make_unique<Tensor>(type, TensorShape(), default_cpu_alloc);
 
@@ -179,7 +181,9 @@ static common::Status DeserializeTensorProto(const Env& env, const std::basic_st
     }
   } else {
     // for internal initializer, always allocate memory on device - p_tensor
+    alloc->SetAllocHint(IAllocator::AllocHint::UploadDst);
     ORT_RETURN_IF_ERROR(AllocateTensor(m, p_tensor, type, tensor_shape, use_device_allocator_for_initializers, alloc));
+    alloc->SetAllocHint(IAllocator::AllocHint::None);
 
     if (device_type == OrtDevice::CPU) {
       // deserialize directly to CPU tensor

--- a/onnxruntime/core/providers/webgpu/allocator.cc
+++ b/onnxruntime/core/providers/webgpu/allocator.cc
@@ -13,7 +13,13 @@ void* GpuBufferAllocator::Alloc(size_t size) {
     return nullptr;
   }
 
-  auto buffer = context_.BufferManager().Create(size);
+  WGPUBuffer buffer;
+  // Use UMA for upload destination buffers if the device supports it.
+  if (alloc_hint_ == AllocHint::UploadDst && context_.SupportsBufferMapExtendedUsages()) {
+    buffer = context_.BufferManager().CreateUMA(size);
+  } else {
+    buffer = context_.BufferManager().Create(size);
+  }
 
   stats_.num_allocs++;
   return buffer;

--- a/onnxruntime/core/providers/webgpu/allocator.h
+++ b/onnxruntime/core/providers/webgpu/allocator.h
@@ -24,10 +24,14 @@ class GpuBufferAllocator : public IAllocator {
   virtual void* Alloc(size_t size) override;
   virtual void Free(void* p) override;
   void GetStats(AllocatorStats* stats) override;
+  void SetAllocHint(AllocHint hint) override {
+      alloc_hint_ = hint;
+  }
 
  private:
   AllocatorStats stats_;
   const WebGpuContext& context_;
+  AllocHint alloc_hint_ = AllocHint::None;
 };
 
 }  // namespace webgpu

--- a/onnxruntime/core/providers/webgpu/buffer_manager.h
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.h
@@ -62,6 +62,7 @@ class BufferManager {
   void Upload(void* src, WGPUBuffer dst, size_t size);
   void MemCpy(WGPUBuffer src, WGPUBuffer dst, size_t size);
   WGPUBuffer Create(size_t size, wgpu::BufferUsage usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::CopyDst);
+  WGPUBuffer CreateUMA(size_t size, wgpu::BufferUsage usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::CopyDst);
   void Release(WGPUBuffer buffer);
   void Download(WGPUBuffer src, void* dst, size_t size);
   void RefreshPendingBuffers();

--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -143,6 +143,8 @@ void WebGpuContext::Initialize(const WebGpuBufferCacheConfig& buffer_cache_confi
     ORT_ENFORCE(Device().GetLimits(&device_supported_limits));
     device_limits_ = device_supported_limits.limits;
 
+    supports_buffer_map_extended_usages_ = device_.HasFeature(wgpu::FeatureName::BufferMapExtendedUsages);
+
     // create buffer manager
     buffer_mgr_ = BufferManagerFactory::Create(*this,
                                                buffer_cache_config.storage.mode,
@@ -491,7 +493,9 @@ std::vector<wgpu::FeatureName> WebGpuContext::GetAvailableRequiredFeatures(const
 #endif
       wgpu::FeatureName::TimestampQuery,
       wgpu::FeatureName::ShaderF16,
-      wgpu::FeatureName::Subgroups};
+      wgpu::FeatureName::Subgroups,
+      wgpu::FeatureName::BufferMapExtendedUsages,
+  };
   for (auto feature : features) {
     if (adapter.HasFeature(feature)) {
       required_features.push_back(feature);

--- a/onnxruntime/core/providers/webgpu/webgpu_context.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.h
@@ -142,6 +142,7 @@ class WebGpuContext final {
 
   Status Run(ComputeContext& context, const ProgramBase& program);
   void OnRunEnd();
+  bool SupportsBufferMapExtendedUsages() const { return supports_buffer_map_extended_usages_; }
 
  private:
   enum class TimestampQueryType {
@@ -231,6 +232,7 @@ class WebGpuContext final {
 #if defined(ENABLE_PIX_FOR_WEBGPU_EP)
   std::unique_ptr<WebGpuPIXFrameGenerator> pix_frame_generator_ = nullptr;
 #endif  // ENABLE_PIX_FOR_WEBGPU_EP
+ bool supports_buffer_map_extended_usages_ = false;
 };
 
 }  // namespace webgpu


### PR DESCRIPTION
With the Dawn BufferMapExtendedUsages feature available, we can now copy data directly to the GPU buffer for UMA GPUs without the need to use a staging buffer. This PR enables the feature for model uploading during the initialization of the inference session, where ORT reaches the peak memory usage. To achieve this, we need to introduce a new 'SetAllocHint' method in the 'IAllocator', so that the WebGPU allocator can have the buffer manager to handle UMA buffers appropriately.

Credits to @fs-eire for the overall design of implementation.