### PR TITLE
[QNN EP] Add QNN Execution Provider Tool to Samples

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -88,6 +88,7 @@ option(onnxruntime_USE_RKNPU "Build with RKNPU support" OFF)
 option(onnxruntime_USE_DNNL "Build with DNNL support" OFF)
 option(onnxruntime_USE_JSEP "Build with JavaScript implemented kernels support" OFF)
 option(onnxruntime_BUILD_UNIT_TESTS "Build ONNXRuntime unit tests" ON)
+option(onnxruntime_BUILD_QNN_EP_TOOL "Build ONNXRuntime qnn-ep-tool" OFF)
 option(onnxruntime_BUILD_CSHARP "Build C# library" OFF)
 option(onnxruntime_BUILD_OBJC "Build Objective-C library" OFF)
 option(onnxruntime_USE_PREINSTALLED_EIGEN "Use pre-installed EIGEN. Need to provide eigen_SOURCE_PATH if turn this on." OFF)
@@ -1840,6 +1841,10 @@ endif()
 
 if (onnxruntime_BUILD_UNIT_TESTS)
   list(APPEND ONNXRUNTIME_CMAKE_FILES onnxruntime_unittests)
+endif()
+
+if (onnxruntime_BUILD_QNN_EP_TOOL)
+  list(APPEND ONNXRUNTIME_CMAKE_FILES onnxruntime_qnn_ep_tool)
 endif()
 
 if (onnxruntime_BUILD_WINML_TESTS)

--- a/cmake/onnxruntime_qnn_ep_tool.cmake
+++ b/cmake/onnxruntime_qnn_ep_tool.cmake
@@ -1,0 +1,12 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+set(QNN_EP_TOOL_SRC_DIR ${REPO_ROOT}/samples/qnn_ep_tool)
+onnxruntime_add_executable(
+    qnn_ep_tool
+    ${QNN_EP_TOOL_SRC_DIR}/main.cpp
+    ${QNN_EP_TOOL_SRC_DIR}/utils.cpp
+    ${QNN_EP_TOOL_SRC_DIR}/model_info.cpp
+)
+include_directories(${QNN_EP_TOOL_SRC_DIR})
+target_link_libraries(qnn_ep_tool onnxruntime onnx)

--- a/samples/qnn_ep_tool/README.md
+++ b/samples/qnn_ep_tool/README.md
@@ -1,0 +1,46 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License. -->
+
+# Onnxruntime Qualcomm Neural Network Executaion Provider Tool (QNN EP Tool)
+- The tool runs onnxruntime session inference with QNN Executaion Provider on inputs and save the outputs.
+- The inputs/outputs can be .pb or .raw format.
+
+## Model and Inputs Data Directory Structure
+The tool expects the onnx model and inputs data to be arranged in the following directory structure:
+```bash
+resnet18-v1-7
+├── resnet18-v1-7.onnx
+├── test_data_set_0   
+│   └── input_0.pb (or input_0.raw)
+└── test_data_set_1   
+    └── input_0.pb (or input_0.raw)
+```
+In each test_data_set_X/
+1. If only .pb input data provided, the tool will use .pb as input
+2. If only .raw input data provided, the tool will use .raw as input
+3. If both are provided (not recommended), the tool will prioritize .pb
+
+## Build
+The tool can be built with the flag "--build_qnn_ep_tool" set.
+```cmd
+.\build.bat --config RelWithDebInfo --build_shared_lib --parallel --compile_no_warning_as_error --cmake_generator "Visual Studio 17 2022" --use_qnn --qnn_home <path-to-qnn-sdk> --build_qnn_ep_tool
+```
+
+## Command Line Usage
+1. The following command serves as an example to run the tool
+    ```ps1
+    # qnn_ep_tools.exe <model_dir> <backend_path>
+    .\qnn_ep_tools.exe resnet18-v1-7 QnnCpu.dll
+    ```
+
+2. The tool will produce .pb / .raw under the corresponding directory
+    ```bash
+    resnet18-v1-7
+    ├── resnet18-v1-7.onnx
+    ├── test_data_set_0   
+    │   ├── input_0.pb (input_0.raw)
+    │   └── out_0.pb (out_0.raw)
+    └── test_data_set_1   
+        ├── input_0.pb (input_0.raw)
+        └── out_0.pb (out_0.raw)
+    ```

--- a/samples/qnn_ep_tool/include/model_info.hpp
+++ b/samples/qnn_ep_tool/include/model_info.hpp
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <onnxruntime_cxx_api.h>
+
+#include <vector>
+
+class OnnxModelInfo {
+    public:
+        OnnxModelInfo(const OrtApi* g_ort, const OrtSession* session, OrtAllocator* allocator);
+        size_t get_num_in_tensors();
+        std::vector<char*> get_in_tensor_names();
+        std::vector<std::vector<int64_t>> get_in_tensor_dims();
+        std::vector<ONNXTensorElementDataType> get_in_tensor_element_types();
+        std::vector<int64_t> get_in_tensor_element_nums();
+        std::vector<OrtValue*>& get_in_tensors();
+
+        size_t get_num_out_tensors();
+        std::vector<char*> get_out_tensor_names();
+        std::vector<std::vector<int64_t>> get_out_tensor_dims();
+        std::vector<ONNXTensorElementDataType> get_out_tensor_element_types();
+        std::vector<int64_t> get_out_tensor_element_nums();
+        std::vector<OrtValue*>& get_out_tensors();
+
+        void release_ort_values(const OrtApi* g_ort);
+        void PrintOnnxModelInfo();
+    private:
+        size_t num_in_tensors;
+        std::vector<char*> in_tensor_names;
+        std::vector<std::vector<int64_t>> in_tensor_dims;
+        std::vector<ONNXTensorElementDataType> in_tensor_element_types;
+        std::vector<int64_t> in_tensor_element_nums;
+        std::vector<OrtValue*> in_tensors;
+
+        size_t num_out_tensors;
+        std::vector<char*> out_tensor_names;
+        std::vector<std::vector<int64_t>> out_tensor_dims;
+        std::vector<ONNXTensorElementDataType> out_tensor_element_types;
+        std::vector<int64_t> out_tensor_element_nums;
+        std::vector<OrtValue*> out_tensors;
+};
+
+size_t GetONNXTypeSize(ONNXTensorElementDataType dtype);
+int onnx_element_type_to_tensorproto_dtype(ONNXTensorElementDataType dtype);

--- a/samples/qnn_ep_tool/include/utils.hpp
+++ b/samples/qnn_ep_tool/include/utils.hpp
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <onnxruntime_cxx_api.h>
+
+#include <filesystem> //NOLINT
+#include <string>
+#include <vector>
+
+#include "core/platform/path_lib.h"
+
+#include "include/model_info.hpp"
+
+std::basic_string<PATH_CHAR_TYPE> find_model_path(std::string model_dir);
+
+std::vector<std::basic_string<PATH_CHAR_TYPE>> find_test_data_sets(std::string model_dir);
+
+std::string check_data_format(const std::filesystem::path test_data_set_dir);
+
+void load_input_tensors_from_raws(
+  std::filesystem::path inp_dir,
+  const OrtApi* g_ort,
+  OnnxModelInfo* model_info,
+  std::vector<std::vector<float>>* input_data
+);
+
+void dump_output_tensors_to_raws(
+  std::filesystem::path out_dir,
+  const OrtApi* g_ort,
+  OnnxModelInfo* model_info
+);
+
+void load_input_tensors_from_pbs(
+  std::filesystem::path inp_dir,
+  const OrtApi* g_ort,
+  OnnxModelInfo* model_info,
+  std::vector<std::vector<float>>* input_data
+);
+
+void dump_output_tensors_to_pbs(
+  std::filesystem::path out_dir,
+  const OrtApi* g_ort,
+  OnnxModelInfo* model_info
+);

--- a/samples/qnn_ep_tool/main.cpp
+++ b/samples/qnn_ep_tool/main.cpp
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <onnxruntime_cxx_api.h>
+
+#include <filesystem> // NOLINT
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "core/platform/path_lib.h"
+#include "include/utils.hpp"
+
+int main(int, char* argv[]) {
+  std::string model_dir(argv[1]);
+  std::cout << model_dir << std::endl;
+  std::basic_string<PATH_CHAR_TYPE> model_path = find_model_path(model_dir);
+  if (model_path.size() <= 0) {
+    std::cout << ".onnx model should be provided" << std::endl;
+    exit(0);
+  }
+
+  // model
+  std::cout << "[Successfully Load Model] " << std::endl;
+  const OrtApi* g_ort = OrtGetApiBase()->GetApi(ORT_API_VERSION);
+  std::cout << "[ORT_API_VERSION] " << ORT_API_VERSION << std::endl;
+  OrtEnv* env;
+  g_ort->CreateEnv(ORT_LOGGING_LEVEL_VERBOSE, "test", &env);
+  OrtSessionOptions* session_options;
+  g_ort->CreateSessionOptions(&session_options);
+  g_ort->SetIntraOpNumThreads(session_options, 1);
+  g_ort->SetSessionGraphOptimizationLevel(session_options, ORT_ENABLE_BASIC);
+
+  std::string backend_path(argv[2]);
+  if (!std::filesystem::exists(std::filesystem::path(backend_path))) {
+    std::cout << "Not Found:" << backend_path << std::endl;
+    exit(0);
+  }
+  std::vector<const char*> options_keys = {"backend_path"};
+  std::vector<const char*> options_values = {backend_path.c_str()};
+
+  g_ort->SessionOptionsAppendExecutionProvider(
+    session_options, "QNN",
+    options_keys.data(), options_values.data(), options_keys.size()
+  );
+
+  OrtSession* session;
+  g_ort->CreateSession(env, model_path.c_str(), session_options, &session);
+  std::cout << "[Successfully CreateSession]" << std::endl;
+
+  OrtAllocator* allocator;
+  g_ort->GetAllocatorWithDefaultOptions(&allocator);
+
+  OnnxModelInfo model_info(g_ort, session, allocator);
+  model_info.PrintOnnxModelInfo();
+
+  // Multiple test_data_set_X
+  std::vector<std::basic_string<PATH_CHAR_TYPE>> test_data_sets = find_test_data_sets(model_dir);
+  std::cout << "test_data_sets.size() " << test_data_sets.size() << std::endl;
+  for (size_t idx = 0; idx < test_data_sets.size(); idx++) {
+    std::cout << "---- test_data_set_" << idx << " ----" << std::endl;
+    std::vector<std::vector<float>> input_data;
+    auto test_data_set_dir = std::filesystem::path(test_data_sets[idx]);
+    auto data_format = check_data_format(test_data_set_dir);
+    if (data_format == "pb") {
+      std::cout << "[test_data_sets_" << idx << "] " << "Loading .pb" << std::endl;
+      load_input_tensors_from_pbs(
+        test_data_set_dir,
+        g_ort,
+        &model_info,
+        &input_data
+      );
+    } else if (data_format == "raw") {
+      std::cout << "[test_data_sets_" << idx << "] " << "Loading .raw" << std::endl;
+      load_input_tensors_from_raws(
+        test_data_set_dir,
+        g_ort,
+        &model_info,
+        &input_data
+      );
+    }
+    std::cout << "[test_data_sets_" << idx << "] " << "Successfully Load Inputs" << std::endl;
+    g_ort->Run(
+      session,
+      nullptr,
+      model_info.get_in_tensor_names().data(),
+      (const OrtValue* const*)model_info.get_in_tensors().data(),
+      model_info.get_in_tensors().size(),
+      model_info.get_out_tensor_names().data(),
+      model_info.get_out_tensor_names().size(),
+      model_info.get_out_tensors().data()
+    );
+    std::cout << "[test_data_sets_" << idx << "] " << "Successfully Inference" << std::endl;
+    if (data_format == "pb") {
+      std::cout << "[test_data_sets_" << idx << "] " << "Dumping .pb" << std::endl;
+      dump_output_tensors_to_pbs(
+        test_data_set_dir,
+        g_ort,
+        &model_info
+      );
+    } else if (data_format == "raw") {
+      std::cout << "[test_data_sets_" << idx << "] " << "Dumping .raw" << std::endl;
+      dump_output_tensors_to_raws(
+        test_data_set_dir,
+        g_ort,
+        &model_info
+      );
+    }
+    std::cout << "[test_data_sets_" << idx << "] " << "Successfully Save Outputs" << std::endl;
+    model_info.release_ort_values(g_ort);
+    std::cout << "[test_data_sets_" << idx << "] " << "Successfully Release OrtValue" << std::endl;
+  }
+  return 0;
+}

--- a/samples/qnn_ep_tool/model_info.cpp
+++ b/samples/qnn_ep_tool/model_info.cpp
@@ -1,0 +1,204 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <onnxruntime_cxx_api.h>
+
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+#include "include/model_info.hpp"
+#include "onnx/onnx_pb.h"
+
+OnnxModelInfo::OnnxModelInfo(const OrtApi* g_ort, const OrtSession* session, OrtAllocator* allocator) {
+  g_ort->SessionGetInputCount(session, &num_in_tensors);
+  g_ort->SessionGetOutputCount(session, &num_out_tensors);
+
+  in_tensor_names.resize(num_in_tensors);
+  in_tensor_dims.resize(num_in_tensors);
+  in_tensor_element_types.resize(num_in_tensors);
+  in_tensor_element_nums.resize(num_in_tensors);
+  in_tensors.resize(num_in_tensors);
+  for (size_t i = 0; i < num_in_tensors; i++) {
+    // Get tensor name, tensor info
+    g_ort->SessionGetInputName(session, i, allocator, &in_tensor_names[i]);
+
+    OrtTypeInfo* type_info;
+    const OrtTensorTypeAndShapeInfo* tensor_info;
+    g_ort->SessionGetInputTypeInfo(session, i, &type_info);
+    g_ort->CastTypeInfoToTensorInfo(type_info, &tensor_info);
+    g_ort->GetTensorElementType(tensor_info, &in_tensor_element_types[i]);
+
+    // Get tensor shapes/dims/bytes
+    size_t num_dims;
+    g_ort->GetDimensionsCount(tensor_info, &num_dims);
+    in_tensor_dims[i].resize(num_dims);
+    g_ort->GetDimensions(tensor_info, in_tensor_dims[i].data(), num_dims);
+    in_tensor_element_nums[i] = 1;
+    for (size_t j = 0; j < in_tensor_dims[i].size(); ++j) {
+      // If onnx model has dynamic dimension on tensors, e.g. [N, 3, 224, 224]
+      // g_ort->GetDimensions yields [-1, 3, 224, 224]. We need to handle it with abs().
+      in_tensor_dims[i][j] = abs(in_tensor_dims[i][j]);
+      in_tensor_element_nums[i] *= in_tensor_dims[i][j];
+    }
+
+    if (type_info) g_ort->ReleaseTypeInfo(type_info);
+  }
+  out_tensor_names.resize(num_out_tensors);
+  out_tensor_dims.resize(num_out_tensors);
+  out_tensor_element_types.resize(num_out_tensors);
+  out_tensor_element_nums.resize(num_out_tensors);
+  out_tensors.resize(num_out_tensors);
+  for (size_t i = 0; i < num_out_tensors; i++) {
+    g_ort->SessionGetOutputName(session, i, allocator, &out_tensor_names[i]);
+    OrtTypeInfo* type_info;
+    const OrtTensorTypeAndShapeInfo* tensor_info;
+    g_ort->SessionGetOutputTypeInfo(session, i, &type_info);
+    g_ort->CastTypeInfoToTensorInfo(type_info, &tensor_info);
+    g_ort->GetTensorElementType(tensor_info, &out_tensor_element_types[i]);
+
+    // Get tensor shapes/dims/bytes
+    size_t num_dims;
+    g_ort->GetDimensionsCount(tensor_info, &num_dims);
+    out_tensor_dims[i].resize(num_dims);
+    g_ort->GetDimensions(tensor_info, out_tensor_dims[i].data(), num_dims);
+    out_tensor_element_nums[i] = 1;
+    for (size_t j = 0; j < out_tensor_dims[i].size(); ++j) {
+      // If onnx model has dynamic dimension on tensors, e.g. [N, 3, 224, 224]
+      // g_ort->GetDimensions yields [-1, 3, 224, 224]. We need to handle it with abs().
+      out_tensor_dims[i][j] = abs(out_tensor_dims[i][j]);
+      out_tensor_element_nums[i] *= out_tensor_dims[i][j];
+    }
+
+    if (type_info) g_ort->ReleaseTypeInfo(type_info);
+  }
+}
+size_t OnnxModelInfo::get_num_in_tensors() { return num_in_tensors; }
+std::vector<char*> OnnxModelInfo::get_in_tensor_names() { return in_tensor_names; }
+std::vector<std::vector<int64_t>> OnnxModelInfo::get_in_tensor_dims() { return in_tensor_dims; }
+std::vector<ONNXTensorElementDataType> OnnxModelInfo::get_in_tensor_element_types() { return in_tensor_element_types; }
+std::vector<int64_t> OnnxModelInfo::get_in_tensor_element_nums() { return in_tensor_element_nums; }
+std::vector<OrtValue*>& OnnxModelInfo::get_in_tensors() { return in_tensors; }
+
+size_t OnnxModelInfo::get_num_out_tensors() { return num_out_tensors; }
+std::vector<char*> OnnxModelInfo::get_out_tensor_names() { return out_tensor_names; }
+std::vector<std::vector<int64_t>> OnnxModelInfo::get_out_tensor_dims() { return out_tensor_dims; }
+std::vector<ONNXTensorElementDataType> OnnxModelInfo::get_out_tensor_element_types() { return out_tensor_element_types; }
+std::vector<int64_t> OnnxModelInfo::get_out_tensor_element_nums() { return out_tensor_element_nums; }
+std::vector<OrtValue*>& OnnxModelInfo::get_out_tensors() { return out_tensors; }
+
+void OnnxModelInfo::release_ort_values(const OrtApi* g_ort) {
+  for (size_t i = 0; i < num_in_tensors; i++) {
+    if (in_tensors[i]) {
+      g_ort->ReleaseValue(in_tensors[i]);
+      in_tensors[i] = nullptr;
+    }
+  }
+  for (size_t i = 0; i < num_out_tensors; i++) {
+    if (out_tensors[i]) {
+      g_ort->ReleaseValue(out_tensors[i]);
+      out_tensors[i] = nullptr;
+    }
+  }
+}
+
+void OnnxModelInfo::PrintOnnxModelInfo() {
+  std::cout << "num_in_tensors: " << num_in_tensors << std::endl;
+  std::cout << "num_out_tensors: " << num_out_tensors << std::endl;
+  for (size_t i = 0; i < num_in_tensors; i++) {
+    std::cout << "in_tensor_dims " << i << ": [";
+    for (size_t j = 0; j < in_tensor_dims[i].size(); ++j) {
+      std::cout << ' ' << in_tensor_dims[i][j];
+    }
+    std::cout << " ]" << std::endl;
+    std::cout << "InTensorElementType " << in_tensor_element_types[i] << std::endl;
+    std::cout << "InElementSize " << GetONNXTypeSize(in_tensor_element_types[i]) << std::endl;
+    std::cout << "InTensorElementNums " << in_tensor_element_nums[i] << std::endl;
+  }
+  for (size_t i = 0; i < num_out_tensors; i++) {
+    std::cout << "out_tensor_dims " << i << ": [";
+    for (size_t j = 0; j < out_tensor_dims[i].size(); ++j) {
+      std::cout << ' ' << out_tensor_dims[i][j];
+    }
+    std::cout << " ]" << std::endl;
+    std::cout << "OutTensorElementType " << out_tensor_element_types[i] << std::endl;
+    std::cout << "OutElementSize " << GetONNXTypeSize(out_tensor_element_types[i]) << std::endl;
+    std::cout << "OutTensorElementNums " << out_tensor_element_nums[i] << std::endl;
+  }
+}
+
+size_t GetONNXTypeSize(ONNXTensorElementDataType dtype) {
+  switch (dtype) {
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
+      return 2;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:
+      return sizeof(float);
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:
+      return sizeof(double);
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
+      return sizeof(uint8_t);
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:
+      return sizeof(uint16_t);
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32:
+      return sizeof(uint32_t);
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64:
+      return sizeof(uint64_t);
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
+      return sizeof(int8_t);
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16:
+      return sizeof(int16_t);
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:
+      return sizeof(int32_t);
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:
+      return sizeof(int64_t);
+    default:
+      throw std::runtime_error("Unsupported ONNX data type");
+  }
+}
+
+int onnx_element_type_to_tensorproto_dtype(ONNXTensorElementDataType dtype) {
+  switch (dtype) {
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:
+      return ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_BFLOAT16;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
+      return ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_FLOAT16;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:
+      return ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_FLOAT;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:
+      return ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_DOUBLE;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4:
+      return ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_UINT4;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
+      return ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_UINT8;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:
+      return ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_UINT16;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32:
+      return ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_UINT32;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64:
+      return ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_UINT64;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4:
+      return ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_INT4;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
+      return ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_FLOAT;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16:
+      return ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_INT16;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:
+      return ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_INT32;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:
+      return ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_INT64;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FN:
+      return ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_FLOAT8E4M3FN;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FNUZ:
+      return ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_FLOAT8E4M3FNUZ;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2:
+      return ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_FLOAT8E5M2;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2FNUZ:
+      return ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_FLOAT8E5M2FNUZ;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING:
+      return ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_STRING;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL:
+      return ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_BOOL;
+    default:
+      throw std::runtime_error("Unsupported ONNX data type");
+  }
+}

--- a/samples/qnn_ep_tool/utils.cpp
+++ b/samples/qnn_ep_tool/utils.cpp
@@ -1,0 +1,209 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <onnxruntime_cxx_api.h>
+
+#include <filesystem> //NOLINT
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "core/platform/path_lib.h"
+#include "core/session/onnxruntime_c_api.h"
+#include "include/utils.hpp"
+#include "onnx/onnx_pb.h"
+
+std::basic_string<PATH_CHAR_TYPE> find_model_path(std::string model_dir) {
+  std::basic_string<PATH_CHAR_TYPE> ret(ORT_TSTR(""));
+  for (auto const& file_entry : std::filesystem::directory_iterator(model_dir)) {
+    if (file_entry.is_regular_file() && file_entry.path().extension() == ORT_TSTR(".onnx")) {
+      ret = file_entry.path().native();
+    }
+  }
+  return ret;
+}
+
+std::vector<std::basic_string<PATH_CHAR_TYPE>> find_test_data_sets(std::string model_dir) {
+  std::vector<std::basic_string<PATH_CHAR_TYPE>> ret = {};
+  const std::basic_string<PATH_CHAR_TYPE> prefix = ORT_TSTR("test_data_set_");
+  for (auto const& dir_entry : std::filesystem::directory_iterator(model_dir)) {
+    if (dir_entry.is_directory() && dir_entry.path().filename().native().compare(0, prefix.size(), prefix) == 0) {
+      ret.push_back(dir_entry.path().native());
+    }
+  }
+  return ret;
+}
+
+std::string check_data_format(const std::filesystem::path test_data_set_dir) {
+  if (std::filesystem::is_empty(test_data_set_dir)) {
+    std::cout << "input_0.pb or input_0.raw data should be provided" << std::endl;
+    exit(0);
+  }
+  for (auto const& dir_entry : std::filesystem::directory_iterator(test_data_set_dir)) {
+    if (dir_entry.path().extension().native() == ORT_TSTR(".pb")) {
+      return "pb";
+    } else if (dir_entry.path().extension().native() == ORT_TSTR(".raw")) {
+      return "raw";
+    } else {
+      std::cout << "Only .pb or .raw format of data is supported" << std::endl;
+      exit(0);
+    }
+  }
+  return std::string();
+}
+
+void load_input_tensors_from_raws(
+  std::filesystem::path inp_dir,
+  const OrtApi* g_ort,
+  OnnxModelInfo* model_info,
+  std::vector<std::vector<float>>* input_data
+) {
+  // Multiple input .raw in each inp_dir (test_data_set_X)
+  input_data->resize(model_info->get_num_in_tensors());
+  for (size_t in_idx = 0; in_idx < model_info->get_num_in_tensors(); in_idx++) {
+#ifdef _WIN32
+    std::wstring infile_name = std::wstring(L"input_") + std::to_wstring(in_idx) + std::wstring(L".raw");
+#else
+    std::string infile_name = std::string("input_") + std::to_string(in_idx) + std::string(".raw")
+#endif
+    auto infile_path = (inp_dir / infile_name);
+    // input data
+    size_t input_byte_nums = model_info->get_in_tensor_element_nums()[in_idx] *
+                             GetONNXTypeSize(model_info->get_out_tensor_element_types()[in_idx]);
+    (*input_data)[in_idx].resize(input_byte_nums);
+
+    // CreateTensor in Ort using input_data
+    // The input_data should not be released until Inference completes
+    OrtMemoryInfo* memory_info;
+    g_ort->CreateCpuMemoryInfo(OrtArenaAllocator, OrtMemTypeDefault, &memory_info);
+    g_ort->CreateTensorWithDataAsOrtValue(
+      memory_info, reinterpret_cast<void*>((*input_data)[in_idx].data()),
+      input_byte_nums,
+      model_info->get_in_tensor_dims()[in_idx].data(),
+      model_info->get_in_tensor_dims()[in_idx].size(),
+      model_info->get_in_tensor_element_types()[in_idx],
+      &model_info->get_in_tensors()[in_idx]
+    );
+    // Read Input .raw
+    std::ifstream input_raw_file(infile_path, std::ios::binary);
+    input_raw_file.read(
+      reinterpret_cast<char*>(&(*input_data)[in_idx][0]),
+      input_byte_nums
+    );
+    input_raw_file.close();
+  }
+  return;
+}
+
+void load_input_tensors_from_pbs(
+  std::filesystem::path inp_dir,
+  const OrtApi* g_ort,
+  OnnxModelInfo* model_info,
+  std::vector<std::vector<float>>* input_data
+) {
+  // Multiple input .pb in each inp_dir (test_data_set_X)
+  input_data->resize(model_info->get_num_in_tensors());
+  for (size_t in_idx = 0; in_idx < model_info->get_num_in_tensors(); in_idx++) {
+#ifdef _WIN32
+    std::wstring infile_name = std::wstring(L"input_") + std::to_wstring(in_idx) + std::wstring(L".pb");
+#else
+    std::string infile_name = std::string("input_") + std::to_string(in_idx) + std::string(".pb")
+#endif
+    const std::filesystem::path infile_path = (inp_dir / infile_name);
+    std::string buffer;
+    buffer.resize(std::filesystem::file_size(infile_path));
+
+    // input_X.pb -> String
+    std::ifstream file(infile_path, std::ios::binary);
+    file.read(&buffer[0], buffer.size());
+    file.close();
+
+    // String -> TensorProto
+    ONNX_NAMESPACE::TensorProto tensor_proto;
+    tensor_proto.ParseFromString(buffer);
+
+    // TensorProto -> std::vector<float>
+    size_t input_byte_nums = model_info->get_in_tensor_element_nums()[in_idx] *
+                             GetONNXTypeSize(model_info->get_out_tensor_element_types()[in_idx]);
+    assert(input_byte_nums == tensor_proto.raw_data().size());
+    (*input_data)[in_idx].resize(input_byte_nums);
+    std::memcpy(
+      (*input_data)[in_idx].data(),
+      tensor_proto.raw_data().data(), input_byte_nums
+    );
+
+    // Prepare OrtValue
+    OrtMemoryInfo* memory_info;
+    g_ort->CreateCpuMemoryInfo(OrtArenaAllocator, OrtMemTypeDefault, &memory_info);
+    g_ort->CreateTensorWithDataAsOrtValue(
+      memory_info,
+      reinterpret_cast<void*>((*input_data)[in_idx].data()),
+      input_byte_nums,
+      model_info->get_in_tensor_dims()[in_idx].data(),
+      model_info->get_in_tensor_dims()[in_idx].size(),
+      model_info->get_in_tensor_element_types()[in_idx],
+      &model_info->get_in_tensors()[in_idx]
+    );
+  }
+  return;
+}
+
+void dump_output_tensors_to_raws(
+  std::filesystem::path out_dir,
+  const OrtApi* g_ort,
+  OnnxModelInfo* model_info
+) {
+  // Dump output of each out tensor
+  for (size_t out_idx = 0; out_idx < model_info->get_num_out_tensors(); out_idx++) {
+    // output data
+    void* output_buffer;
+    g_ort->GetTensorMutableData(model_info->get_out_tensors()[out_idx], &output_buffer);
+#ifdef _WIN32
+    std::wstring outfile = std::wstring(L"out_") + std::to_wstring(out_idx) + std::wstring(L".raw");
+#else
+    std::string outfile = std::string("out_") + std::to_string(out_idx) + std::string(".raw")
+#endif
+    std::ofstream fout(out_dir / outfile, std::ios::binary);
+    fout.write(
+      reinterpret_cast<const char*>(output_buffer),
+      model_info->get_out_tensor_element_nums()[out_idx] *
+          GetONNXTypeSize(model_info->get_out_tensor_element_types()[out_idx])
+    );
+    fout.close();
+  }
+  return;
+}
+
+void dump_output_tensors_to_pbs(
+  std::filesystem::path out_dir,
+  const OrtApi* g_ort,
+  OnnxModelInfo* model_info
+) {
+  // Dump output of each out tensor
+  for (size_t out_idx = 0; out_idx < model_info->get_num_out_tensors(); out_idx++) {
+    // output data
+    ONNX_NAMESPACE::TensorProto tensor_proto;
+    for (size_t j = 0; j < model_info->get_out_tensor_dims()[out_idx].size(); ++j) {
+      tensor_proto.add_dims(static_cast<int>(model_info->get_out_tensor_dims()[out_idx][j]));
+    }
+    void* output_buffer;
+    g_ort->GetTensorMutableData(model_info->get_out_tensors()[out_idx], &output_buffer);
+#ifdef _WIN32
+    std::wstring outfile = std::wstring(L"out_") + std::to_wstring(out_idx) + std::wstring(L".pb");
+#else
+    std::string outfile = std::string("out_") + std::to_string(out_idx) + std::string(".pb")
+#endif
+    tensor_proto.set_data_type(
+      onnx_element_type_to_tensorproto_dtype(model_info->get_out_tensor_element_types()[out_idx]));
+    tensor_proto.set_raw_data(
+      output_buffer,
+      model_info->get_out_tensor_element_nums()[out_idx] *
+          GetONNXTypeSize(model_info->get_out_tensor_element_types()[out_idx])
+    );
+    std::ofstream fout(out_dir / outfile, std::ios::binary);
+    tensor_proto.SerializeToOstream(&fout);
+    fout.close();
+  }
+  return;
+}

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -259,6 +259,9 @@ def parse_arguments():
 
     parser.add_argument("--gen-api-doc", action="store_true", help="Generate API documentation for PyTorch frontend")
 
+    # Build QNN execution provider tool in onnxruntime/samples/
+    parser.add_argument("--build_qnn_ep_tool", action="store_true", help="Build executable tool for inference.")
+
     # CUDA related
     parser.add_argument("--use_cuda", action="store_true", help="Enable CUDA.")
     parser.add_argument(
@@ -1134,6 +1137,7 @@ def generate_build_tree(
         "-Donnxruntime_USE_VCPKG=" + ("ON" if args.use_vcpkg else "OFF"),
         "-Donnxruntime_USE_MIMALLOC=" + ("ON" if args.use_mimalloc else "OFF"),
         "-Donnxruntime_ENABLE_PYTHON=" + ("ON" if args.enable_pybind else "OFF"),
+        "-Donnxruntime_BUILD_QNN_EP_TOOL=" + ("ON" if args.build_qnn_ep_tool else "OFF"),
         "-Donnxruntime_BUILD_CSHARP=" + ("ON" if args.build_csharp else "OFF"),
         "-Donnxruntime_BUILD_JAVA=" + ("ON" if args.build_java else "OFF"),
         "-Donnxruntime_BUILD_NODEJS=" + ("ON" if args.build_nodejs else "OFF"),


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
1. Add qnn_ep_tool to leverage QnnCpu.dll and QnnHtp.dll for inference
2. Add onnxruntime_qnn_ep_tool.cmake to build the qnn_ep_tool
3. Modify CMakeList.txt and tools/ci_build/build.py to build the tool with flag onnxruntime_BUILD_QNN_EP_TOOL=ON
4. The qnn_ep_tool supports .pb and .raw formats for input data and output results.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
1. Currently onnxruntime only includes a sample (tutorial) in Node.js.
2. We would like to add the executable QNNEP tool as a sample in CPP.
3. This allows developers to obtain a native inference-purpose executable by specifying a particular CMake flag in onnxruntime repository, eliminating the need to depend on other examples like onnxruntime-inference-examples.

