### PR TITLE
[WebGPU] Reduce staging buffers for uploading intializers

### DIFF
--- a/onnxruntime/core/providers/webgpu/buffer_manager.cc
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.cc
@@ -243,7 +243,21 @@ BufferManager::BufferManager(WebGpuContext& context, BufferCacheMode storage_buf
       default_cache_{CreateBufferCacheManager(BufferCacheMode::Disabled)} {
 }
 
+Status BufferManager::OnSessionInitializationEnd() {
+  session_initialized_ = true;
+  return Status::OK();
+}
+
 void BufferManager::Upload(void* src, WGPUBuffer dst, size_t size) {
+  if (!session_initialized_ && context_.SupportsBufferMapExtendedUsages()) {
+    wgpu::Buffer dst_buffer = dst;
+    auto mapped_data = dst_buffer.GetMappedRange();
+    ORT_ENFORCE(mapped_data, "Buffer must be mapped at creation for UMA buffer support.");
+    memcpy(mapped_data, src, size);
+    dst_buffer.Unmap();
+    return;
+  }
+
   auto buffer_size = NormalizeBufferSize(size);
 
   wgpu::BufferDescriptor desc{};
@@ -256,13 +270,14 @@ void BufferManager::Upload(void* src, WGPUBuffer dst, size_t size) {
   memcpy(mapped_data, src, size);
   staging_buffer.Unmap();
 
-  auto& command_encoder = context_.GetCommandEncoder();
-  context_.EndComputePass();
+  auto command_encoder = context_.Device().CreateCommandEncoder();
   command_encoder.CopyBufferToBuffer(staging_buffer, 0, dst, 0, buffer_size);
-  pending_staging_buffers_.push_back(staging_buffer);
+  auto command_buffer = command_encoder.Finish();
+  context_.Device().GetQueue().Submit(1, &command_buffer);
 }
 
 void BufferManager::MemCpy(WGPUBuffer src, WGPUBuffer dst, size_t size) {
+  ORT_ENFORCE(session_initialized_, "Session must be initialized before calling MemCpy.");
   ORT_ENFORCE(src != dst, "Source and destination buffers must be different.");
 
   auto buffer_size = NormalizeBufferSize(size);
@@ -279,29 +294,40 @@ WGPUBuffer BufferManager::Create(size_t size, wgpu::BufferUsage usage) {
   auto& cache = GetCacheManager(static_cast<WGPUBufferUsage>(usage));
   auto buffer_size = cache.CalculateBufferSize(size);
 
+  auto CreateBuffer = [this, size, buffer_size, &cache](wgpu::BufferUsage usage, bool map_at_creation) -> WGPUBuffer {
+    wgpu::BufferDescriptor desc{};
+    desc.size = buffer_size;
+    desc.usage = usage;
+    desc.mappedAtCreation = map_at_creation;
+    auto buffer = context_.Device().CreateBuffer(&desc).MoveToCHandle();
+
+    ORT_ENFORCE(buffer, "Failed to create GPU buffer: size=", buffer_size, ", usage=", uint64_t(usage), ".");
+
+    cache.RegisterBuffer(buffer, size);
+    return buffer;
+  };
+
+  if (!session_initialized_ && context_.SupportsBufferMapExtendedUsages()) {
+    ORT_ENFORCE(usage & wgpu::BufferUsage::Storage,
+                "UMA buffer support is only allowed for storage buffers before session initialization.");
+    return CreateBuffer(usage | wgpu::BufferUsage::MapRead | wgpu::BufferUsage::MapWrite, true);
+  }
+
   auto buffer = cache.TryAcquireCachedBuffer(buffer_size);
   if (buffer) {
     return buffer;
   }
 
-  // cache miss, create a new buffer
-  wgpu::BufferDescriptor desc{};
-  desc.size = buffer_size;
-  desc.usage = usage;
-  // desc.label = std::to_string(xx++).c_str();
-  buffer = context_.Device().CreateBuffer(&desc).MoveToCHandle();
-
-  ORT_ENFORCE(buffer, "Failed to create GPU buffer: size=", buffer_size, ", usage=", uint64_t(usage), ".");
-
-  cache.RegisterBuffer(buffer, size);
-  return buffer;
+  return CreateBuffer(usage, false);
 }
 
 void BufferManager::Release(WGPUBuffer buffer) {
+  ORT_ENFORCE(session_initialized_, "Session must be initialized before calling Release.");
   GetCacheManager(buffer).ReleaseBuffer(buffer);
 }
 
 void BufferManager::Download(WGPUBuffer src, void* dst, size_t size) {
+  ORT_ENFORCE(session_initialized_, "Session must be initialized before calling Download.");
   auto buffer_size = NormalizeBufferSize(size);
 
   wgpu::BufferDescriptor desc{};
@@ -325,7 +351,6 @@ void BufferManager::Download(WGPUBuffer src, void* dst, size_t size) {
 }
 
 void BufferManager::RefreshPendingBuffers() {
-  pending_staging_buffers_.clear();
   storage_cache_->OnRefresh();
   uniform_cache_->OnRefresh();
   query_resolve_cache_->OnRefresh();

--- a/onnxruntime/core/providers/webgpu/buffer_manager.h
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.h
@@ -59,6 +59,8 @@ class BufferManager {
  public:
   BufferManager(WebGpuContext& context, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode);
 
+  Status OnSessionInitializationEnd();
+
   void Upload(void* src, WGPUBuffer dst, size_t size);
   void MemCpy(WGPUBuffer src, WGPUBuffer dst, size_t size);
   WGPUBuffer Create(size_t size, wgpu::BufferUsage usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::CopyDst);
@@ -76,7 +78,7 @@ class BufferManager {
   std::unique_ptr<IBufferCacheManager> query_resolve_cache_;
   std::unique_ptr<IBufferCacheManager> default_cache_;
 
-  std::vector<wgpu::Buffer> pending_staging_buffers_;
+  bool session_initialized_ = false;
 };
 
 class BufferManagerFactory {

--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -143,6 +143,8 @@ void WebGpuContext::Initialize(const WebGpuBufferCacheConfig& buffer_cache_confi
     ORT_ENFORCE(Device().GetLimits(&device_supported_limits));
     device_limits_ = device_supported_limits.limits;
 
+    supports_buffer_map_extended_usages_ = device_.HasFeature(wgpu::FeatureName::BufferMapExtendedUsages);
+
     // create buffer manager
     buffer_mgr_ = BufferManagerFactory::Create(*this,
                                                buffer_cache_config.storage.mode,
@@ -491,7 +493,9 @@ std::vector<wgpu::FeatureName> WebGpuContext::GetAvailableRequiredFeatures(const
 #endif
       wgpu::FeatureName::TimestampQuery,
       wgpu::FeatureName::ShaderF16,
-      wgpu::FeatureName::Subgroups};
+      wgpu::FeatureName::Subgroups,
+      wgpu::FeatureName::BufferMapExtendedUsages,
+  };
   for (auto feature : features) {
     if (adapter.HasFeature(feature)) {
       required_features.push_back(feature);
@@ -696,6 +700,10 @@ void WebGpuContext::OnRunEnd() {
     pix_frame_generator_->GeneratePIXFrame();
   }
 #endif  // ENABLE_PIX_FOR_WEBGPU_EP
+}
+
+Status WebGpuContext::OnSessionInitializationEnd() {
+  return buffer_mgr_->OnSessionInitializationEnd();
 }
 
 std::unordered_map<int32_t, WebGpuContextFactory::WebGpuContextInfo> WebGpuContextFactory::contexts_;

--- a/onnxruntime/core/providers/webgpu/webgpu_context.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.h
@@ -143,6 +143,10 @@ class WebGpuContext final {
   Status Run(ComputeContext& context, const ProgramBase& program);
   void OnRunEnd();
 
+  Status OnSessionInitializationEnd();
+
+  bool SupportsBufferMapExtendedUsages() const { return supports_buffer_map_extended_usages_; }
+
  private:
   enum class TimestampQueryType {
     None = 0,
@@ -231,6 +235,7 @@ class WebGpuContext final {
 #if defined(ENABLE_PIX_FOR_WEBGPU_EP)
   std::unique_ptr<WebGpuPIXFrameGenerator> pix_frame_generator_ = nullptr;
 #endif  // ENABLE_PIX_FOR_WEBGPU_EP
+  bool supports_buffer_map_extended_usages_ = false;
 };
 
 }  // namespace webgpu

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -843,6 +843,8 @@ std::unique_ptr<profiling::EpProfiler> WebGpuExecutionProvider::GetProfiler() {
   return profiler;
 }
 
+Status WebGpuExecutionProvider::OnSessionInitializationEnd() { return context_.OnSessionInitializationEnd(); }
+
 Status WebGpuExecutionProvider::OnRunStart(const onnxruntime::RunOptions& /*run_options*/) {
   if (context_.ValidationMode() >= ValidationMode::Basic) {
     context_.PushErrorScope();

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.h
@@ -63,6 +63,7 @@ class WebGpuExecutionProvider : public IExecutionProvider {
   bool ConcurrentRunSupported() const override { return false; }
 
   std::vector<AllocatorPtr> CreatePreferredAllocators() override;
+  Status OnSessionInitializationEnd() override;
 
   Status OnRunStart(const onnxruntime::RunOptions& run_options) override;
   Status OnRunEnd(bool sync_stream, const onnxruntime::RunOptions& run_options) override;


### PR DESCRIPTION
This change reduces the number of staging buffers used for uploading initializers to the GPU. On the one hand, we early release the upload staging buffers. On the other hand, we use the BufferMapExtendedUsages feature of Dawn on UMA GPUs, which allows us to directly write into the dest GPU buffer without the need of a staging buffer. To achieve this, we need to ensure the UMA GPU buffers are mapped at creation. We have BufferManager to be awared of OnSessionInitializationEnd(), so that it can handle buffer Create() and Upload() calls properly.

Credits to @fs-eire for the overall design of implementation.
