### PR TITLE
ADD emsdk env vars to VCPKG_KEEP_ENV_VARS

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1952,7 +1952,7 @@ def generate_build_tree(
             ]
         env = {}
         if args.use_vcpkg:
-            env["VCPKG_KEEP_ENV_VARS"] = "TRT_UPLOAD_AUTH_TOKEN"
+            env["VCPKG_KEEP_ENV_VARS"] = "TRT_UPLOAD_AUTH_TOKEN;EMSDK;EMSDK_NODE;EMSDK_PYTHON"
             if args.build_wasm:
                 env["EMSDK"] = emsdk_dir
 


### PR DESCRIPTION
### Description
The vars are set by  cmake\external\emsdk\emsdk_env.bat


### Motivation and Context
By default they are filtered by vcpkg to make build reproducible. However, emscripten's cmake toolchain file needs this information. emcc.bat has the following code:
```
@set EM_PY=%EMSDK_PYTHON%
@if "%EM_PY%"=="" (
  set EM_PY=python
)
```
Actually, it doesn't work as expected. the line 
```
set EM_PY=python
``` 
should be changed to 
```
set EM_PY=python.exe
```

We haven't hit this issue because usually the var EM_PY is set.


