### PR TITLE
Create struct for CPUID check to reuse CPUID logic

### DIFF
--- a/onnxruntime/core/platform/windows/hardware_core_enumerator.h
+++ b/onnxruntime/core/platform/windows/hardware_core_enumerator.h
@@ -9,4 +9,9 @@ struct HardwareCoreEnumerator {
   HardwareCoreEnumerator() = delete;
   static uint32_t DefaultIntraOpNumThreads();
 };
+typedef struct {
+  bool isIntel;
+  bool isIntelSpecifiedPlatform;
+} IntelChecks;
+IntelChecks checkIntel();
 }  // namespace onnxruntime


### PR DESCRIPTION
### Description
Currently there's no way to reuse the logic from hardware_core_enumerator to check for GenuineIntel CPU. This logic can be useful when doing CPUID check in ORT.

Motivation and Context
Allows for use of same CPUID check logic across different parts of MLAS. All that's needed is to import "hardware_core_enumerator.h" and the checkIntel function can be used along with the IntelChecks struct to capture if we're running on Intel or not.


