### PR TITLE
Use version check instead has include to prevent build fail

### DIFF
--- a/onnxruntime/core/providers/coreml/model/model.mm
+++ b/onnxruntime/core/providers/coreml/model/model.mm
@@ -363,7 +363,9 @@ void ProfileComputePlan(NSURL* compileUrl, MLModelConfiguration* config) {
 #endif
 }
 
-#if __has_include(<CoreML/MLOptimizationHints.h>)
+#if (defined(__TVOS_18_0) && __TV_OS_VERSION_MAX_ALLOWED >= __TVOS_18_0) || \
+    (defined(__IPHONE_18_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_18_0) || \
+    (defined(__MAC_15_0) && __MAC_OS_VERSION_MAX_ALLOWED >= __MAC_15_0)
 #define HAS_COREMLOPTIMIZATIONHINT 1
 #else
 #define HAS_COREMLOPTIMIZATIONHINT 0


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Fix build fail.

iOS 17.4 already has `CoreML/MLOptimizationHints.h` but no `specializationStrategy`, that will cause build fail

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


