### PR TITLE
Correct generated cmake syntax

### DIFF
--- a/tools/python/util/vcpkg_helpers.py
+++ b/tools/python/util/vcpkg_helpers.py
@@ -139,11 +139,11 @@ def generate_triplet_for_android(
         # Valid options are dynamic and static. Libraries can ignore this setting if they do not support the preferred linkage type. In our case, we prefer to use static libs.
         f.write("set(VCPKG_LIBRARY_LINKAGE static)\n")
         if not enable_rtti:
-            f.write("set(CMAKE_ANDROID_RTTI OFF)")
+            f.write("set(CMAKE_ANDROID_RTTI OFF)\n")
         if not enable_exception:
-            f.write("set(CMAKE_ANDROID_EXCEPTIONS OFF)")
+            f.write("set(CMAKE_ANDROID_EXCEPTIONS OFF)\n")
         if use_cpp_shared:
-            f.write("set(ANDROID_STL c++_shared)")
+            f.write("set(ANDROID_STL c++_shared)\n")
 
         ldflags = []
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

As title.

Previously will got
CMake Error at  build/Android/intermediates/armeabi-v7a/vcpkg/buildtrees/0.vcpkg_dep_info.cmake:15:
  Parse error.  Expected a newline, got identifier with text "set".


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


