### PR TITLE
Move call to MLAS_CPUIDINFO::GetCPUIDInfo() out of MlasSQNBitGemmDispatchNeon initialization.

### DIFF
--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -1043,9 +1043,10 @@ extern const MLAS_FPQ4GEMM_DISPATCH MlasFpQ4GemmDispatchAvx512;
 
 struct MLAS_QNBIT_GEMM_DISPATCH;
 
-extern const MLAS_QNBIT_GEMM_DISPATCH MlasSQNBitGemmDispatchNeon;
-
-extern const MLAS_QNBIT_GEMM_DISPATCH MlasSQNBitGemmDispatchNeonDot;
+const MLAS_QNBIT_GEMM_DISPATCH&
+GetMlasQNBitGemmDispatchNeon(
+    bool InitializeWithDotSupport
+);
 
 extern const MLAS_QNBIT_GEMM_DISPATCH MlasSQNBitGemmDispatchAvx2;
 

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -1045,6 +1045,8 @@ struct MLAS_QNBIT_GEMM_DISPATCH;
 
 extern const MLAS_QNBIT_GEMM_DISPATCH MlasSQNBitGemmDispatchNeon;
 
+extern const MLAS_QNBIT_GEMM_DISPATCH MlasSQNBitGemmDispatchNeonDot;
+
 extern const MLAS_QNBIT_GEMM_DISPATCH MlasSQNBitGemmDispatchAvx2;
 
 extern const MLAS_QNBIT_GEMM_DISPATCH MlasSQNBitGemmDispatchAvx2vnni;

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -543,7 +543,6 @@ Return Value:
     this->SymmQgemmDispatch = &MlasSymmQgemmS8DispatchNeon;
     this->ConvSymU8S8Dispatch = &MlasConvSymU8DispatchNeon;
     this->ConvSymS8S8Dispatch = &MlasConvSymS8DispatchNeon;
-    this->QNBitGemmDispatch = &MlasSQNBitGemmDispatchNeon;
     this->RopeDispatch = &MlasRopeDispatchNeon;
     this->HGemmDispatch = &MlasHGemmDispatchNeon;
     this->SoftmaxDispatch = &MlasSoftmaxDispatchNeon;
@@ -570,8 +569,9 @@ Return Value:
         this->SymmQgemmDispatch = &MlasSymmQgemmS8DispatchSdot;
         this->ConvSymU8S8Dispatch = &MlasConvSymU8DispatchDot;
         this->ConvSymS8S8Dispatch = &MlasConvSymS8DispatchDot;
-        this->QNBitGemmDispatch = &MlasSQNBitGemmDispatchNeonDot;
     }
+
+    this->QNBitGemmDispatch = &GetMlasQNBitGemmDispatchNeon(HasDotProductInstructions);
 
 #if defined(__linux__)
     //

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -576,6 +576,7 @@ Return Value:
         this->SymmQgemmDispatch = &MlasSymmQgemmS8DispatchSdot;
         this->ConvSymU8S8Dispatch = &MlasConvSymU8DispatchDot;
         this->ConvSymS8S8Dispatch = &MlasConvSymS8DispatchDot;
+        this->QNBitGemmDispatch = &MlasSQNBitGemmDispatchNeonDot;
     }
 
 #if defined(__linux__)

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -552,22 +552,16 @@ Return Value:
     // Check if the processor supports ASIMD dot product instructions.
     //
 
-    bool HasDotProductInstructions;
-
-#if defined(_WIN32)
-    HasDotProductInstructions = (IsProcessorFeaturePresent(PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE) != 0);
-#else
-    // Use the cpuinfo value which is read from sysctl and has some additional special cases.
-    // https://github.com/pytorch/cpuinfo/blob/959002f82d7962a473d8bf301845f2af720e0aa4/src/arm/mach/init.c#L369-L379
+    // Note:
     // Do NOT use ID_AA64ISAR0_EL1. It causes illegal instruction errors on Mac M1 and ARMv8-A chips
     // as well as failing on other ARM chips as it is an EL1 level register that requires extra
     // privileges to read.
     //
     // uint64_t isar0_el1;
     // asm("mrs %[reg], ID_AA64ISAR0_EL1\n" : [reg] "=r"(isar0_el1) : :);
-    // HasDotProductInstructions = ((isar0_el1 >> 44) & 0xfu) == 0x1u;
-    HasDotProductInstructions = MLAS_CPUIDINFO::GetCPUIDInfo().HasArmNeonDot();
-#endif
+    // const bool HasDotProductInstructions = ((isar0_el1 >> 44) & 0xfu) == 0x1u;
+
+    const bool HasDotProductInstructions = MLAS_CPUIDINFO::GetCPUIDInfo().HasArmNeonDot();
 
     if (HasDotProductInstructions) {
         this->GemmU8U8Dispatch = &MlasGemmU8X8DispatchUdot;

--- a/onnxruntime/core/mlas/lib/qnbitgemm_kernel_neon.cpp
+++ b/onnxruntime/core/mlas/lib/qnbitgemm_kernel_neon.cpp
@@ -173,43 +173,41 @@ Q4BitGemmPerGemmWorkspaceAlignment(
 }  // namespace sqnbitgemm_neon
 
 //
-// Kernel dispatch structures.
+// Kernel dispatch structure accessor.
 //
 
-namespace
-{
-
-MLAS_QNBIT_GEMM_DISPATCH
-MakeDispatch(
-    bool HasDotSupport
+const MLAS_QNBIT_GEMM_DISPATCH&
+GetMlasQNBitGemmDispatchNeon(
+    bool InitializeWithDotSupport
 )
 {
-    MLAS_QNBIT_GEMM_DISPATCH d;
+    // Note: The InitializeWithX parameters are only used in the invocation of this method that initializes the static
+    // MLAS_QNBIT_GEMM_DISPATCH instance.
 
-    d.Q4BitGemmPackQuantBDataSize = sqnbitgemm_neon::Q4BitGemmPackQuantBDataSize;
-    d.SQ4BitGemmPackQuantBData = sqnbitgemm_neon::SQ4BitGemmPackQuantBData;
+    static const MLAS_QNBIT_GEMM_DISPATCH MlasQNBitGemmDispatchNeon = [&]() {
+        MLAS_QNBIT_GEMM_DISPATCH d;
 
-    d.Q4BitGemmPerGemmWorkspaceSize = sqnbitgemm_neon::Q4BitGemmPerGemmWorkspaceSize;
-    d.Q4BitGemmPerGemmWorkspaceAlignment = sqnbitgemm_neon::Q4BitGemmPerGemmWorkspaceAlignment;
+        d.Q4BitGemmPackQuantBDataSize = sqnbitgemm_neon::Q4BitGemmPackQuantBDataSize;
+        d.SQ4BitGemmPackQuantBData = sqnbitgemm_neon::SQ4BitGemmPackQuantBData;
 
-    d.SQ4BitGemmM1Kernel_CompFp32 = sqnbitgemm_neon::SQ4BitGemmM1Kernel_CompFp32;
-    d.SQ4BitBlkDequantBForSgemm_CompFp32 = sqnbitgemm_neon::SQ4BitBlkDequantBForSgemm_CompFp32;
-    if (HasDotSupport) {
-        d.SQ4BitGemmKernel_CompInt8 = sqnbitgemm_neon::SQ4BitGemmKernel_CompInt8;
-    }
-    d.QuantizeARow_CompInt8 = sqnbitgemm_neon::QuantizeARow_CompInt8;
+        d.Q4BitGemmPerGemmWorkspaceSize = sqnbitgemm_neon::Q4BitGemmPerGemmWorkspaceSize;
+        d.Q4BitGemmPerGemmWorkspaceAlignment = sqnbitgemm_neon::Q4BitGemmPerGemmWorkspaceAlignment;
+
+        d.SQ4BitGemmM1Kernel_CompFp32 = sqnbitgemm_neon::SQ4BitGemmM1Kernel_CompFp32;
+        d.SQ4BitBlkDequantBForSgemm_CompFp32 = sqnbitgemm_neon::SQ4BitBlkDequantBForSgemm_CompFp32;
+        if (InitializeWithDotSupport) {
+            d.SQ4BitGemmKernel_CompInt8 = sqnbitgemm_neon::SQ4BitGemmKernel_CompInt8;
+        }
+        d.QuantizeARow_CompInt8 = sqnbitgemm_neon::QuantizeARow_CompInt8;
 
 #if defined(MLAS_F16VEC_INTRINSICS_SUPPORTED) && defined(MLAS_TARGET_ARM64)
-    d.HQ4BitGemmPackQuantBData = sqnbitgemm_neon::HQ4BitGemmPackQuantBData_CompFp16;
-    d.HQ4BitBlkDequantBForHgemm_CompFp16 = sqnbitgemm_neon::HQ4BitBlkDequantBForHgemm_CompFp16;
-    d.HQ4BitGemmKernel_CompFp16 = sqnbitgemm_neon::HQ4BitGemmKernel_CompFp16;
+        d.HQ4BitGemmPackQuantBData = sqnbitgemm_neon::HQ4BitGemmPackQuantBData_CompFp16;
+        d.HQ4BitBlkDequantBForHgemm_CompFp16 = sqnbitgemm_neon::HQ4BitBlkDequantBForHgemm_CompFp16;
+        d.HQ4BitGemmKernel_CompFp16 = sqnbitgemm_neon::HQ4BitGemmKernel_CompFp16;
 #endif  // MLAS_F16VEC_INTRINSICS_SUPPORTED && MLAS_TARGET_ARM64
 
-    return d;
+        return d;
+    }();
+
+    return MlasQNBitGemmDispatchNeon;
 }
-
-}  // namespace
-
-const MLAS_QNBIT_GEMM_DISPATCH MlasSQNBitGemmDispatchNeon = MakeDispatch(/* HasDotSupport */ false);
-
-const MLAS_QNBIT_GEMM_DISPATCH MlasSQNBitGemmDispatchNeonDot = MakeDispatch(/* HasDotSupport */ true);

--- a/onnxruntime/core/mlas/lib/qnbitgemm_kernel_neon.h
+++ b/onnxruntime/core/mlas/lib/qnbitgemm_kernel_neon.h
@@ -25,6 +25,8 @@ Abstract:
 
 #include "mlasi.h"
 
+#include "mlas_qnbit.h"
+
 namespace sqnbitgemm_neon
 {
 

--- a/onnxruntime/core/mlas/lib/qnbitgemm_kernel_neon.h
+++ b/onnxruntime/core/mlas/lib/qnbitgemm_kernel_neon.h
@@ -23,9 +23,8 @@ Abstract:
 #include <cstddef>
 #include <utility>
 
-#include "mlasi.h"
-
 #include "mlas_qnbit.h"
+#include "mlasi.h"
 
 namespace sqnbitgemm_neon
 {


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Move call to `MLAS_CPUIDINFO::GetCPUIDInfo()` out of `MlasSQNBitGemmDispatchNeon` initialization.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Reduce binary size when MatMulNBits op is not included in the build.

I believe the side effect of `MLAS_CPUIDINFO::GetCPUIDInfo()` (e.g., initializing a static object) prevents the linker from discarding the code in a build where the associated MLAS functions are unused.

bloaty diff output of Android minimal build with no ops:

baseline: 06482c2644, updated: 8f5d213829

```
$ bloaty -d compileunits ${UPDATED_DIR}/libonnxruntime.stripped.so --debug-file=${UPDATED_DIR}/libonnxruntime.so -- ${BASELINE_DIR}/libonnxruntime.stripped.so --debug-file=${BASELINE_DIR}/libonnxruntime.so
    FILE SIZE        VM SIZE
 --------------  --------------
  +0.1%     +85  +0.1%     +85    [section .rodata]
   +12%     +60   +12%     +60    D:/source/onnxruntime_2/build/android.minimal_baseline/MinSizeRel/_deps/pytorch_cpuinfo-src/src/linux/multiline.c
  +3.5%     +44  +3.5%     +44    D:/source/onnxruntime_2/build/android.minimal_baseline/MinSizeRel/_deps/pytorch_cpuinfo-src/src/arm/linux/aarch64-isa.c
  -0.8%     -24  -0.8%     -24    [section .dynsym]
 -33.3%     -32 -33.3%     -32    [section .gnu.version_r]
  -0.1%     -53  -0.1%     -53    D:/source/onnxruntime_2/onnxruntime/core/session/onnxruntime_c_api.cc
 -100.1%     -96 -100.1%     -88    [11 Others]
  -4.9%     -96  -4.9%     -96    [section .got]
  -3.8%    -104  -3.8%    -104    D:/source/onnxruntime_2/build/android.minimal_baseline/MinSizeRel/_deps/protobuf-src/src/google/protobuf/arena.cc
  [DEL]    -224  [DEL]    -224    D:/source/onnxruntime_2/onnxruntime/core/mlas/lib/threading.cpp
  -0.6%    -244  -0.6%    -244    [section .eh_frame]
  [ = ]       0 -65.4%    -257    [section .tbss]
  -1.4%    -360  -1.4%    -360    [section .data.rel.ro]
  [ = ]       0 -25.8%    -456    [section .relro_padding]
  [DEL]    -876  [DEL]    -988    D:/source/onnxruntime_2/onnxruntime/core/mlas/lib/qnbitgemm_kernel_neon.cpp
  -1.6% -1.08Ki  -1.6% -1.08Ki    [section .rela.dyn]
  -0.8% -1.71Ki  -0.8% -1.71Ki    [section .text]
 -15.6% -2.62Ki -15.6% -2.62Ki    D:/source/onnxruntime_2/onnxruntime/core/common/threadpool.cc
  [DEL] -6.97Ki  [DEL] -6.97Ki    D:/source/onnxruntime_2/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_neon_fp32.cpp
  [DEL] -7.18Ki  [DEL] -7.18Ki    D:/source/onnxruntime_2/onnxruntime/core/mlas/lib/hqnbitgemm_kernel_neon_fp16.cpp
  [DEL] -10.1Ki  [DEL] -10.1Ki    D:/source/onnxruntime_2/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_neon_int8.cpp
  -2.6% -31.6Ki  -2.6% -32.4Ki    TOTAL
```