### PR TITLE
[webgpu] allow overloads to Program::AddIndices

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
@@ -97,7 +97,7 @@ Status CopyKVCache(onnxruntime::webgpu::ComputeContext& context, const WebgpuAtt
   }
   program.AddOutputs({{present_key, ProgramTensorMetadataDependency::Rank, components},
                       {present_value, ProgramTensorMetadataDependency::Rank, components}})
-      .AddIndices(valid_present_shape);
+      .AddIndices(std::move(valid_present_shape));
   program.SetDispatchGroupSize(onnxruntime::narrow<uint32_t>(valid_kv_size + 63 / 64))
       .SetWorkgroupSize(64)
       .CacheHint(has_past, parameters.qkv_format_, parameters.past_present_share_buffer_)

--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
@@ -190,9 +190,9 @@ Status BinaryElementwise::ComputeInternal(ComputeContext& context) const {
     // Mode Vectorize broadcast
     // cache hint: "V{a_rank};{b_rank};{output_rank}"
     program
-        .AddIndices(reshaped_output_shape)
-        .AddIndices(reshaped_lhs_shape)
-        .AddIndices(reshaped_rhs_shape)
+        .AddIndices(std::move(reshaped_output_shape))
+        .AddIndices(std::move(reshaped_lhs_shape))
+        .AddIndices(std::move(reshaped_rhs_shape))
         .CacheHint("V");
   } else {
     // Mode Broadcast

--- a/onnxruntime/core/providers/webgpu/program.cc
+++ b/onnxruntime/core/providers/webgpu/program.cc
@@ -289,7 +289,7 @@ ProgramBase::ProgramBase(std::string_view name, ProgramMetadata&& metadata)
 }
 
 ProgramBase& ProgramBase::AddInput(ProgramInput&& input) {
-  inputs_.emplace_back(input);
+  inputs_.emplace_back(std::move(input));
   return *this;
 }
 
@@ -299,7 +299,7 @@ ProgramBase& ProgramBase::AddInputs(std::initializer_list<ProgramInput> inputs) 
 }
 
 ProgramBase& ProgramBase::AddOutput(ProgramOutput&& output) {
-  outputs_.emplace_back(output);
+  outputs_.emplace_back(std::move(output));
   return *this;
 }
 

--- a/onnxruntime/core/providers/webgpu/program.cc
+++ b/onnxruntime/core/providers/webgpu/program.cc
@@ -308,16 +308,6 @@ ProgramBase& ProgramBase::AddOutputs(std::initializer_list<ProgramOutput> output
   return *this;
 }
 
-ProgramBase& ProgramBase::AddIndices(const TensorShape& shape) {
-  indices_.emplace_back(shape);
-  return *this;
-}
-
-ProgramBase& ProgramBase::AddIndices(TensorShape&& shape) {
-  indices_.emplace_back(shape);
-  return *this;
-}
-
 ProgramBase& ProgramBase::SetDispatchGroupSize(uint32_t x) {
   return SetDispatchGroupSize(x, 1, 1);
 }

--- a/onnxruntime/core/providers/webgpu/program.h
+++ b/onnxruntime/core/providers/webgpu/program.h
@@ -271,9 +271,11 @@ class ProgramBase {
   // add multiple program outputs
   ProgramBase& AddOutputs(std::initializer_list<ProgramOutput> outputs);
   // add a program variable for indices
-  ProgramBase& AddIndices(const TensorShape& shape);
-  // add a program variable for indices
-  ProgramBase& AddIndices(TensorShape&& shape);
+  template <typename... Args>
+  ProgramBase& AddIndices(Args&&... args) {
+    indices_.emplace_back(std::forward<Args>(args)...);
+    return *this;
+  }
 
   // set the size of dispatch groups. Y and Z are 1 if not specified.
   ProgramBase& SetDispatchGroupSize(uint32_t x);

--- a/onnxruntime/core/providers/webgpu/tensor/expand.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/expand.cc
@@ -53,7 +53,7 @@ Status Expand::ComputeInternal(ComputeContext& context) const {
           {data_size},
       });
   if (components_i != components_o) {
-    program.AddIndices(output_shape);
+    program.AddIndices(std::move(output_shape));
   }
   return context.RunProgram(program);
 }


### PR DESCRIPTION
### Description
This change allows more overloads for the `Program::AddIndices` method, and makes use of r-value references for parameters when possible.

Also fixed the implementation of the `AddInputs` and `AddOutputs` methods to use r-value references for the parameters