### PR TITLE
Increase timeout for ARM64-Xcode16-targeting-iphonesimulator

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -164,7 +164,7 @@ jobs:
       matrix:
         target_arch: [x86_64, arm64]
 
-    timeout-minutes: 60
+    timeout-minutes: 75
 
     steps:
     - uses: actions/setup-python@v5


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Increase timeout for ARM64-Xcode16-targeting-iphonesimulator GHA job.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

The ARM64-Xcode16-targeting-iphonesimulator (arm64) job was sometimes timing out and failing.