### PR TITLE
Set CMAKE_POLICY_DEFAULT_CMP0069 to NEW to ensure that IPO flags are added for dependencies.

### DIFF
--- a/cmake/adjust_global_compile_flags.cmake
+++ b/cmake/adjust_global_compile_flags.cmake
@@ -99,10 +99,21 @@ if (onnxruntime_ENABLE_LTO)
     include(CheckIPOSupported)
     check_ipo_supported(RESULT ipo_enabled OUTPUT ipo_output)
     if (NOT ipo_enabled)
-      message(WARNING "IPO is not supported by this compiler")
+      message(WARNING "Interprocedural optimization (IPO) is not supported by this compiler. ${ipo_output}")
       set(onnxruntime_ENABLE_LTO OFF)
     else()
       set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+
+      # See https://cmake.org/cmake/help/latest/policy/CMP0069.html.
+      #
+      # "The OLD behavior for this policy is to add IPO flags only for Intel compiler on Linux.
+      # The NEW behavior for this policy is to add IPO flags for the current compiler or produce an error if CMake does
+      # not know the flags."
+      #
+      # CMake versions 3.8 and lower use the OLD behavior. This project requires CMake version > 3.8.
+      # However, some dependencies may specify a lower required CMake version and default to the OLD behavior.
+      # Ensure that CMake also uses the NEW behavior for such dependencies.
+      set(CMAKE_POLICY_DEFAULT_CMP0069 NEW)
     endif()
 endif()
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Set CMAKE_POLICY_DEFAULT_CMP0069 to NEW to ensure that interprocedural optimization (IPO) flags are added for dependencies.
If the OLD behavior is used, the IPO flags are only added for the Intel compiler on Linux.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Address some warnings:
```
CMake Warning (dev) at onnxruntime_build/MinSizeRel/_deps/protobuf-src/cmake/libprotobuf-lite.cmake:89 (add_library):
  Policy CMP0069 is not set: INTERPROCEDURAL_OPTIMIZATION is enforced when
  enabled.  Run "cmake --help-policy CMP0069" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  INTERPROCEDURAL_OPTIMIZATION property will be ignored for target
  'libprotobuf-lite'.
Call Stack (most recent call first):
  onnxruntime_build/MinSizeRel/_deps/protobuf-src/CMakeLists.txt:304 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at onnxruntime_build/MinSizeRel/_deps/protobuf-src/cmake/libprotobuf.cmake:102 (add_library):
  Policy CMP0069 is not set: INTERPROCEDURAL_OPTIMIZATION is enforced when
  enabled.  Run "cmake --help-policy CMP0069" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  INTERPROCEDURAL_OPTIMIZATION property will be ignored for target
  'libprotobuf'.
Call Stack (most recent call first):
  onnxruntime_build/MinSizeRel/_deps/protobuf-src/CMakeLists.txt:305 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at onnxruntime_build/MinSizeRel/_deps/pytorch_cpuinfo-src/CMakeLists.txt:254 (ADD_LIBRARY):
  Policy CMP0069 is not set: INTERPROCEDURAL_OPTIMIZATION is enforced when
  enabled.  Run "cmake --help-policy CMP0069" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  INTERPROCEDURAL_OPTIMIZATION property will be ignored for target 'cpuinfo'.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at onnxruntime_build/MinSizeRel/_deps/pytorch_cpuinfo-src/CMakeLists.txt:262 (ADD_LIBRARY):
  Policy CMP0069 is not set: INTERPROCEDURAL_OPTIMIZATION is enforced when
  enabled.  Run "cmake --help-policy CMP0069" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  INTERPROCEDURAL_OPTIMIZATION property will be ignored for target
  'cpuinfo_internals'.
This warning is for project developers.  Use -Wno-dev to suppress it.
```