### PR TITLE
Windows: Show more useful DLL load errors to say exactly what DLL is missing

### DIFF
--- a/onnxruntime/core/platform/windows/dll_load_error.cc
+++ b/onnxruntime/core/platform/windows/dll_load_error.cc
@@ -44,7 +44,7 @@ std::wstring DetermineLoadLibraryError(const wchar_t* filename_in, DWORD flags) 
 
     // Iterate through the import descriptors to see which dependent DLL can't load
     filename.clear();
-    flags = 0; // Dependent libraries are relative, and flags like LOAD_WITH_ALTERED_SEARCH_PATH is undefined for those.
+    flags = 0;  // Dependent libraries are relative, and flags like LOAD_WITH_ALTERED_SEARCH_PATH is undefined for those.
     for (; import_desc->Characteristics; import_desc++) {
       const char* dll_name = reinterpret_cast<const char*>(reinterpret_cast<const BYTE*>(hModule.get()) + import_desc->Name);
       // Try to load the dependent DLL, and if it fails, we loop again with this as the DLL and we'll be one step closer to the missing file.

--- a/onnxruntime/core/platform/windows/dll_load_error.cc
+++ b/onnxruntime/core/platform/windows/dll_load_error.cc
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <windows.h>
+#include <dbghelp.h>
+#include <iostream>
+#include <string>
+#pragma comment(lib, "dbghelp.lib")
+
+struct HMODULE_Deleter {
+  typedef HMODULE pointer;
+  void operator()(HMODULE h) { FreeLibrary(h); }
+};
+
+using ModulePtr = std::unique_ptr<HMODULE, HMODULE_Deleter>;
+
+// If a DLL fails to load, this will try loading the DLL and then its dependencies recursively
+// until it finds a missing file, then will report which file is missing and what the dependency
+// chain is.
+std::wstring DetermineLoadLibraryError(const wchar_t* filename_in) {
+  std::wstring error(L"Error loading");
+
+  std::wstring filename{filename_in};
+  while (filename.size()) {
+    error += std::wstring(L" \"") + filename + L"\"";
+
+    ModulePtr hModule = ModulePtr{LoadLibraryExW(filename.c_str(), NULL, DONT_RESOLVE_DLL_REFERENCES)};
+    if (!hModule) {
+      error += L" which is missing.";
+      return error;
+    }
+
+    // Get the address of the Import Directory
+    ULONG size;
+    PIMAGE_IMPORT_DESCRIPTOR importDesc = (PIMAGE_IMPORT_DESCRIPTOR)ImageDirectoryEntryToData(hModule.get(), TRUE, IMAGE_DIRECTORY_ENTRY_IMPORT, &size);
+    if (!importDesc) {
+      error += L" No import directory found.";  // This is unexpected, and I'm not sure how it could happen but we handle it just in case.
+      return error;
+    }
+
+    // Iterate through the import descriptors to see which dependent DLL can't load
+    filename.clear();
+    for (; importDesc->Characteristics; importDesc++) {
+      char* dllName = (char*)((BYTE*)(hModule.get()) + importDesc->Name);
+      ModulePtr hDepModule{LoadLibrary(dllName)};
+      if (!hDepModule) {
+        filename = std::wstring(dllName, dllName + strlen(dllName));
+        error += L" which depends on";
+        break;
+      }
+    }
+  }
+  error += L" But no dependency issue could be determined.";
+  return error;
+}

--- a/onnxruntime/core/platform/windows/dll_load_error.cc
+++ b/onnxruntime/core/platform/windows/dll_load_error.cc
@@ -3,9 +3,11 @@
 
 #include <windows.h>
 #include <dbghelp.h>
-#include <iostream>
-#include <string>
 #pragma comment(lib, "dbghelp.lib")
+#include <iostream>
+#include <memory>
+#include <string>
+#include "dll_load_error.h"
 
 struct HMODULE_Deleter {
   typedef HMODULE pointer;
@@ -17,34 +19,38 @@ using ModulePtr = std::unique_ptr<HMODULE, HMODULE_Deleter>;
 // If a DLL fails to load, this will try loading the DLL and then its dependencies recursively
 // until it finds a missing file, then will report which file is missing and what the dependency
 // chain is.
-std::wstring DetermineLoadLibraryError(const wchar_t* filename_in) {
+std::wstring DetermineLoadLibraryError(const wchar_t* filename_in, DWORD flags) {
   std::wstring error(L"Error loading");
 
   std::wstring filename{filename_in};
   while (filename.size()) {
     error += std::wstring(L" \"") + filename + L"\"";
 
-    ModulePtr hModule = ModulePtr{LoadLibraryExW(filename.c_str(), NULL, DONT_RESOLVE_DLL_REFERENCES)};
+    // We use DONT_RESOLVE_DLL_REFERENCES instead of LOAD_LIBRARY_AS_DATAFILE because the latter will not process the import table
+    // and will result in the IMAGE_IMPORT_DESCRIPTOR table names being uninitialized.
+    ModulePtr hModule = ModulePtr{LoadLibraryExW(filename.c_str(), NULL, flags | DONT_RESOLVE_DLL_REFERENCES)};
     if (!hModule) {
       error += L" which is missing.";
       return error;
     }
 
     // Get the address of the Import Directory
-    ULONG size;
-    PIMAGE_IMPORT_DESCRIPTOR importDesc = (PIMAGE_IMPORT_DESCRIPTOR)ImageDirectoryEntryToData(hModule.get(), TRUE, IMAGE_DIRECTORY_ENTRY_IMPORT, &size);
-    if (!importDesc) {
+    ULONG size{};
+    IMAGE_IMPORT_DESCRIPTOR* import_desc = reinterpret_cast<IMAGE_IMPORT_DESCRIPTOR*>(ImageDirectoryEntryToData(hModule.get(), TRUE, IMAGE_DIRECTORY_ENTRY_IMPORT, &size));
+    if (!import_desc) {
       error += L" No import directory found.";  // This is unexpected, and I'm not sure how it could happen but we handle it just in case.
       return error;
     }
 
     // Iterate through the import descriptors to see which dependent DLL can't load
     filename.clear();
-    for (; importDesc->Characteristics; importDesc++) {
-      char* dllName = (char*)((BYTE*)(hModule.get()) + importDesc->Name);
-      ModulePtr hDepModule{LoadLibrary(dllName)};
+    flags = 0; // Dependent libraries are relative, and flags like LOAD_WITH_ALTERED_SEARCH_PATH is undefined for those.
+    for (; import_desc->Characteristics; import_desc++) {
+      const char* dll_name = reinterpret_cast<const char*>(reinterpret_cast<const BYTE*>(hModule.get()) + import_desc->Name);
+      // Try to load the dependent DLL, and if it fails, we loop again with this as the DLL and we'll be one step closer to the missing file.
+      ModulePtr hDepModule{LoadLibrary(dll_name)};
       if (!hDepModule) {
-        filename = std::wstring(dllName, dllName + strlen(dllName));
+        filename = std::wstring(dll_name, dll_name + strlen(dll_name));
         error += L" which depends on";
         break;
       }

--- a/onnxruntime/core/platform/windows/dll_load_error.h
+++ b/onnxruntime/core/platform/windows/dll_load_error.h
@@ -1,1 +1,1 @@
-std::wstring DetermineLoadLibraryError(const wchar_t* filename);
+std::wstring DetermineLoadLibraryError(const wchar_t* filename, DWORD flags);

--- a/onnxruntime/core/platform/windows/dll_load_error.h
+++ b/onnxruntime/core/platform/windows/dll_load_error.h
@@ -1,0 +1,1 @@
+std::wstring DetermineLoadLibraryError(const wchar_t* filename);

--- a/onnxruntime/core/platform/windows/env.cc
+++ b/onnxruntime/core/platform/windows/env.cc
@@ -39,6 +39,7 @@ limitations under the License.
 #include <wil/Resource.h>
 
 #include "core/platform/path_lib.h"  // for LoopDir()
+#include "dll_load_error.h"
 
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 
@@ -704,17 +705,17 @@ Status WindowsEnv::LoadDynamicLibrary(const PathString& wlibrary_filename, bool 
     static constexpr DWORD bufferLength = 64 * 1024;
     std::wstring s(bufferLength, '\0');
     FormatMessageW(
-        FORMAT_MESSAGE_FROM_SYSTEM |
-            FORMAT_MESSAGE_IGNORE_INSERTS,
+        FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
         NULL,
         error_code,
         MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
         (LPWSTR)s.data(),
-        0, NULL);
+        bufferLength, NULL);
+    s.erase(std::remove(s.begin(), s.end(), L'\r'), s.end());
+    s.erase(std::remove(s.begin(), s.end(), L'\n'), s.end());
     std::wostringstream oss;
-    oss << L"LoadLibrary failed with error " << error_code << L" \"" << s.c_str() << L"\" when trying to load \"" << wlibrary_filename << L"\"";
+    oss << DetermineLoadLibraryError(wlibrary_filename.c_str()) << L" (Error " << error_code << ": \"" << s.c_str() << "\")";
     std::wstring errmsg = oss.str();
-    // TODO: trim the ending '\r' and/or '\n'
     common::Status status(common::ONNXRUNTIME, common::FAIL, ToUTF8String(errmsg));
     return status;
   }

--- a/onnxruntime/core/platform/windows/env.cc
+++ b/onnxruntime/core/platform/windows/env.cc
@@ -39,7 +39,7 @@ limitations under the License.
 #include <wil/Resource.h>
 
 #include "core/platform/path_lib.h"  // for LoopDir()
-#include "dll_load_error.h"
+#include "core/platform/windows/dll_load_error.h"
 
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 
@@ -714,7 +714,8 @@ Status WindowsEnv::LoadDynamicLibrary(const PathString& wlibrary_filename, bool 
     s.erase(std::remove(s.begin(), s.end(), L'\r'), s.end());
     s.erase(std::remove(s.begin(), s.end(), L'\n'), s.end());
     std::wostringstream oss;
-    oss << DetermineLoadLibraryError(wlibrary_filename.c_str()) << L" (Error " << error_code << ": \"" << s.c_str() << "\")";
+    oss << DetermineLoadLibraryError(wlibrary_filename.c_str(), LOAD_WITH_ALTERED_SEARCH_PATH)
+        << L" (Error " << error_code << ": \"" << s.c_str() << "\")";
     std::wstring errmsg = oss.str();
     common::Status status(common::ONNXRUNTIME, common::FAIL, ToUTF8String(errmsg));
     return status;


### PR DESCRIPTION
### Description
When we fail to load a provider shared DLL in windows, the error is not very specific. Users have to figure out if the onnxruntime file is missing, a cuda file, or cudnn is not installed (and perhaps others). And this is just the cuda provider. It would be far more useful if it would say exactly what file is missing so the user can fix the actual problem.

Plus, this will likely result in many fewer github issues regarding this problem, but if they do, they will be much easier to fix.

This fix adds a function that will try loading a dll and its dependencies recursively to figure out which file is missing. It uses the OS dbghelp library to do it and is not very complex.

This also fixes a many year old bug that was introduced in the change to use FormatMessage in env.cc, where the system error would always be an empty string `error 126 ""` due to passing 0 as the format buffer length. We will now see the more useful `The specified module could not be found.` style error messages.

### Motivation and Context

Previously if we fail to load the cuda provider, the error would look like this, which is limited:

`unknown file: error: C++ exception with description " onnxruntime::ProviderLibrary::Get [ONNXRuntimeError] : 1 : FAIL : LoadLibrary failed with error 126 "" when trying to load "C:\Example\Path\To\Library\onnxruntime_providers_cuda.dll"`

Now it will look like this if cudnn is not installed:

`unknown file: error: C++ exception with description onnxruntime::ProviderLibrary::Get [ONNXRuntimeError] : 1 : FAIL : Error loading "C:\Example\Path\To\Library\onnxruntime_providers_cuda.dll" which depends on "cudnn64_9.dll" which is missing. (Error 126: "The specified module could not be found.")`

If cuda is not installed:

`unknown file: error: C++ exception with description onnxruntime::ProviderLibrary::Get [ONNXRuntimeError] : 1 : FAIL : Error loading "C:\Example\Path\To\Library\onnxruntime_providers_cuda.dll" which depends on "cudart64_12.dll" which is missing. (Error 126: "The specified module could not be found.")`

And if onnxruntime_providers_cuda.dll is not installed:

`unknown file: error: C++ exception with description onnxruntime::ProviderLibrary::Get [ONNXRuntimeError] : 1 : FAIL : Error loading "C:\Example\Path\To\Library\onnxruntime_providers_cuda.dll" which is missing. (Error 126: "The specified module could not be found.")
`
