### PR TITLE
Add macOS ARM64 pipeline for webgpu

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -154,6 +154,46 @@ jobs:
           --use_xnnpack \
           --use_binskim_compliant_compile_flags
 
+  ARM64-Xcode16-webgpu:
+    runs-on: macos-15
+
+    env:
+      xcode_version: 16
+
+    timeout-minutes: 60
+
+    steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ env.python_version }}
+
+    - name: Verify ARM64 machine
+      shell: python
+      run: |
+        import platform
+        assert platform.machine() == "arm64", "This job expects to be run on an ARM64 machine."
+
+    - name: Use Xcode ${{ env.xcode_version }}
+      shell: bash
+      run: |
+        XCODE_DEVELOPER_DIR="/Applications/Xcode_${{ env.xcode_version }}.app/Contents/Developer"
+        sudo xcode-select --switch "${XCODE_DEVELOPER_DIR}"
+
+    - uses: actions/checkout@v4
+
+    - name: Build and test
+      shell: bash
+      run: |
+        python ./tools/ci_build/build.py \
+          --build_dir ./build \
+          --update \
+          --build --parallel \
+          --test \
+          --build_shared_lib \
+          --build_nodejs \
+          --use_webgpu \
+          --use_binskim_compliant_compile_flags
+
   ARM64-Xcode16-targeting-iphonesimulator:
     runs-on: macos-15
 


### PR DESCRIPTION
### Description

Add macOS ARM64 pipeline for webgpu.

This pipeline is a temporary one. I created this pipeline because the current code already fails on macOS ARM64 for WebGPU EP. Adding this pipeline allows to check the status of the fix, and eventually when the build passes, this pipeline will be merged with the existing macOS arm64 pipeline.
