### PR TITLE
Increase timeout to 90min for ARM64-Xcode16-targeting-iphonesimulator

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -164,7 +164,7 @@ jobs:
       matrix:
         target_arch: [x86_64, arm64]
 
-    timeout-minutes: 75
+    timeout-minutes: 90
 
     steps:
     - uses: actions/setup-python@v5


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

There are still some timeout for the pipeline. further extend the timeout to 90 minutes for ARM64-Xcode16-targeting-iphonesimulator.

It takes quite a while if all build cache is missing.

### Motivation and Context

The pipeline sometimes failed because of timeout. There is a previous PR #24030 to increase the timeout from 60min to 75 min but it looks like not enough.
