### PR TITLE
[QNN-EP] Add BQ and LPBQ support in QNN EP

### DIFF
--- a/onnxruntime/core/framework/node_unit.h
+++ b/onnxruntime/core/framework/node_unit.h
@@ -49,6 +49,7 @@ struct NodeUnitIODef {
     const NodeArg& scale;
     const NodeArg* zero_point{nullptr};
     std::optional<int64_t> axis{std::nullopt};
+    std::optional<int64_t> block_size{std::nullopt};
   };
 
   const NodeArg& node_arg;

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
@@ -118,7 +118,8 @@ Status GemmOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
 
     std::string input_tensor_name = input_name;
     if (1 == input_trans_flag.at(input_i) && !is_constant_input) {
-      ORT_RETURN_IF(quantize_param.IsPerChannel(), "Non-constant Gemm inputs only support per-tensor quantization");
+      ORT_RETURN_IF(quantize_param.IsPerChannel() || quantize_param.IsBlockwise(),
+                    "Non-constant Gemm inputs only support per-tensor quantization");
 
       // Add Transpose node
       std::vector<uint32_t> old_input_shape(input_shape);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/instance_norm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/instance_norm_op_builder.cc
@@ -114,7 +114,7 @@ Status InstanceNormOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
     };
 
     if (!input0_info.is_initializer) {
-      ORT_RETURN_IF(input0_info.quant_param.IsPerChannel(),
+      ORT_RETURN_IF(input0_info.quant_param.IsPerChannel() || input0_info.quant_param.IsBlockwise(),
                     "Non-constant InstanceNormalization inputs only support per-tensor quantization");
 
       // Add Reshape node to transform 1D input to 2D (i.e., set height to 1).

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -69,6 +69,12 @@ Status SimpleOpBuilder::ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper,
     ORT_RETURN_IF_ERROR(qnn_model_wrapper.IsPerChannelQuantized(node_unit.Inputs()[0], is_per_chan_quant, quant_axis));
     ORT_RETURN_IF(is_per_chan_quant, "QNN EP does not support a standalone DQ op with per-channel quantization");
 
+    bool is_block_quant = false;
+    int64_t quant_block_axis = 0;
+    int64_t quant_block_size = 0;
+    ORT_RETURN_IF_ERROR(qnn_model_wrapper.IsBlockwiseQuantized(node_unit.Inputs()[0], is_block_quant, quant_block_axis, quant_block_size));
+    ORT_RETURN_IF(is_block_quant, "QNN EP does not support a standalone DQ op with blockwise quantization");
+
     if (qnn_model_wrapper.GetModelSettings().offload_graph_io_quantization) {
       ORT_RETURN_IF(qnn_model_wrapper.IsGraphOutput(node_unit.Outputs()[0].node_arg.Name()),
                     "QNN EP is configured to not take DQ nodes that generate a graph output.");
@@ -80,6 +86,12 @@ Status SimpleOpBuilder::ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper,
     int64_t quant_axis = 0;
     ORT_RETURN_IF_ERROR(qnn_model_wrapper.IsPerChannelQuantized(node_unit.Outputs()[0], is_per_chan_quant, quant_axis));
     ORT_RETURN_IF(is_per_chan_quant, "QNN EP does not support a standalone Q op with per-channel quantization");
+
+    bool is_block_quant = false;
+    int64_t quant_block_axis = 0;
+    int64_t quant_block_size = 0;
+    ORT_RETURN_IF_ERROR(qnn_model_wrapper.IsBlockwiseQuantized(node_unit.Outputs()[0], is_block_quant, quant_block_axis, quant_block_size));
+    ORT_RETURN_IF(is_block_quant, "QNN EP does not support a standalone Q op with blockwise quantization");
 
     if (qnn_model_wrapper.GetModelSettings().offload_graph_io_quantization) {
       ORT_RETURN_IF(qnn_model_wrapper.IsGraphInput(node_unit.Inputs()[0].node_arg.Name()),

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
@@ -272,6 +272,12 @@ class QnnModelWrapper {
                                /*out*/ bool& is_per_channel,
                                /*out*/ int64_t& axis) const;
 
+  // Checks if a tensor in the ONNX graph is blockwise quantized.
+  Status IsBlockwiseQuantized(const onnxruntime::NodeUnitIODef& io_def,
+                              /*out*/ bool& is_blockwise,
+                              /*out*/ int64_t& axis,
+                              /*out*/ int64_t& block_size) const;
+
  private:
   bool CreateQnnInputOutputTensors(const std::string& qnn_node_name,
                                    const std::vector<std::string>& names,

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -265,6 +265,12 @@ std::ostream& operator<<(std::ostream& out, const Qnn_QuantizationEncoding_t& en
     case QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET:
       out << "QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET";
       break;
+    case QNN_QUANTIZATION_ENCODING_BLOCK:
+      out << "QNN_QUANTIZATION_ENCODING_BLOCK";
+      break;
+    case QNN_QUANTIZATION_ENCODING_BLOCKWISE_EXPANSION:
+      out << "QNN_QUANTIZATION_ENCODING_BLOCKWISE_EXPANSION";
+      break;
     case QNN_QUANTIZATION_ENCODING_UNDEFINED:
       out << "QNN_QUANTIZATION_ENCODING_UNDEFINED";
       break;
@@ -315,6 +321,53 @@ std::ostream& operator<<(std::ostream& out, const Qnn_QuantizeParams_t& quantize
         out << quantize_params.bwAxisScaleOffsetEncoding.offsets[i] << (i == num_elems - 1 ? "" : " ");
       }
       out << (truncate ? "...)" : ")");
+    } else if (quantize_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BLOCK) {
+      out << " blockSize=" << quantize_params.blockEncoding.blockSize;
+      size_t num_elems = sizeof(quantize_params.blockEncoding.scaleOffset);
+      bool truncate = num_elems > 20;
+      num_elems = truncate ? 20 : num_elems;
+      out << " scales=(";
+      for (size_t i = 0; i < num_elems; i++) {
+        out << quantize_params.blockEncoding.scaleOffset[i].scale << (i == num_elems - 1 ? "" : " ");
+      }
+      out << ") offsets=(";
+      for (size_t i = 0; i < num_elems; i++) {
+        out << quantize_params.blockEncoding.scaleOffset[i].offset << (i == num_elems - 1 ? "" : " ");
+      }
+      out << (truncate ? "...)" : ")");
+    } else if (quantize_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BLOCKWISE_EXPANSION) {
+      out << " axis=" << quantize_params.blockwiseExpansion->axis;
+      uint32_t num_blocks_per_axis = quantize_params.blockwiseExpansion->numBlocksPerAxis;
+      out << " numBlocksPerAxis=" << num_blocks_per_axis;
+      out << " blockScaleBitwidth=" << quantize_params.blockwiseExpansion->blockScaleBitwidth;
+      size_t num_elems = sizeof(quantize_params.blockwiseExpansion->scaleOffsets);
+      bool truncate = num_elems > 20;
+      num_elems = truncate ? 20 : num_elems;
+      out << " scales=(";
+      for (size_t i = 0; i < num_elems; i++) {
+        out << quantize_params.blockwiseExpansion->scaleOffsets[i].scale << (i == num_elems - 1 ? "" : " ");
+      }
+      out << ") offsets=(";
+      for (size_t i = 0; i < num_elems; i++) {
+        out << quantize_params.blockwiseExpansion->scaleOffsets[i].offset << (i == num_elems - 1 ? "" : " ");
+      }
+      out << (truncate ? "...)" : ")");
+      size_t num_block_scales = num_elems * num_blocks_per_axis;
+      if (quantize_params.blockwiseExpansion->blocksScale8 != nullptr) {
+        out << " blocksScale8=(";
+        for (size_t i = 0; i < num_block_scales; i++) {
+          out << quantize_params.blockwiseExpansion->blocksScale8[i] << (i == num_block_scales - 1 ? "" : " ");
+        }
+        out << ")";
+      } else if (quantize_params.blockwiseExpansion->blocksScale16 != nullptr) {
+        out << " blocksScale16=(";
+        for (size_t i = 0; i < num_block_scales; i++) {
+          out << quantize_params.blockwiseExpansion->blocksScale16[i] << (i == num_block_scales - 1 ? "" : " ");
+        }
+        out << ")";
+      } else {
+        out << " Unsupported LPBQ scale.";
+      }
     } else {
       out << " encoding not supported.";
     }

--- a/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
+++ b/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
@@ -946,6 +946,7 @@ struct NodeUnitIODef final {
     const NodeArg& scale;
     const NodeArg* zero_point{nullptr};
     std::optional<int64_t> axis{std::nullopt};
+    std::optional<int64_t> block_size{std::nullopt};
   };
 
   const NodeArg& node_arg;


### PR DESCRIPTION
### Description

1. Add a new attribute block_size to QuantParam.
2. Add a function to check if a tensor in the ONNX graph is blockwise quantized in QnnModelWrapper.
3. Add definition and translation of BQ (Blockwise Quantization) and LPBQ (Low Power Blockwise Quantization) when initializing QnnQuantParamsWrapper.
4. Add checks for blockwise quantization in several op builders.

### Motivation and Context

1. QNN-EP currently does not support block quantization coding. Since the finer granularity provided by block quantization generally leads to better quantization accuracy, we'd like to add support for BQ and LPBQ in QNN-EP.