### PR TITLE
[QNN-EP] Add support for Sum operator with 2 inputs

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
@@ -47,6 +47,7 @@ OpBuilderRegistrations::OpBuilderRegistrations() {
     CreateSimpleOpBuilder("Sin", *this);
     CreateSimpleOpBuilder("Sqrt", *this);
     CreateSimpleOpBuilder("Sub", *this);
+    CreateSimpleOpBuilder("Sum", *this);
     CreateSimpleOpBuilder("Tanh", *this);
 
     CreateSimpleOpBuilder("Concat", *this);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
@@ -158,6 +158,7 @@ class BaseOpBuilder : public IOpBuilder {
         {"Softmax", QNN_OP_SOFTMAX},
         {"Sqrt", QNN_OP_ELEMENT_WISE_SQUARE_ROOT},
         {"Sub", QNN_OP_ELEMENT_WISE_SUBTRACT},
+        {"Sum", QNN_OP_ELEMENT_WISE_ADD},
         {"Tanh", QNN_OP_TANH},
         {"Transpose", QNN_OP_TRANSPOSE},
         {"GridSample", QNN_OP_GRID_SAMPLE},

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -56,11 +56,18 @@ Status SimpleOpBuilder::ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper,
                       padding_mode.c_str());
   }
 
-  // ONNX's Min and Max operators accept a variable number of inputs (i.e., variadic).
-  // However, QNN's Min and Max operators must take in exactly two inputs.
+  // ONNX's Min, Max, and Sum operators accept a variable number of inputs (i.e., variadic).
+  // However, QNN's Min, Max, and Add operators must take in exactly two inputs.
   if (op_type == "Min" || op_type == "Max") {
     ORT_RETURN_IF_NOT(node_unit.Inputs().size() == 2,
-                      "QNN EP only supports Min and Max operators with exactly 2 inputs.");
+                      "QNN EP only supports ", op_type.c_str(), " operator with exactly 2 inputs.");
+  }
+
+  if (op_type == "Sum") {
+    size_t inputs_num = node_unit.Inputs().size();
+    ORT_RETURN_IF_NOT(inputs_num == 2,
+                      "QNN EP supports Sum operator with QNN_OP_ELEMENT_WISE_ADD, which takes exactly 2 inputs. Got ONNX's Sum operator with ",
+                      std::to_string(inputs_num).c_str(), " inputs.");
   }
 
   if (op_type == "DequantizeLinear") {


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
* Add Sum to op builder in QNN-EP
* Now we can limit the support to Sum with 2 inputs.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
* Enhance QNN-EP support for Sum with two inputs

