### PR TITLE
Add static quantization runner

### DIFF
--- a/onnxruntime/python/tools/quantization/README.md
+++ b/onnxruntime/python/tools/quantization/README.md
@@ -1,2 +1,84 @@
 # Quantization Tool
-This tool can be used to quantize select ONNX models. Support is based on operators in the model. Please refer to https://onnxruntime.ai/docs/performance/quantization.html for usage details and https://github.com/microsoft/onnxruntime-inference-examples/tree/main/quantization for examples.
+This tool can be used to quantize selected ONNX models. Support is based on operators in the model. Please refer to https://onnxruntime.ai/docs/performance/quantization.html for usage details and https://github.com/microsoft/onnxruntime-inference-examples/tree/main/quantization for examples.
+
+## Static Quantization Tool
+
+### Build
+Please add `--enable_pybind` and `--build_wheel` to the build command to acquire the python tools.
+
+```bash
+cd onnxruntime
+.\build.bat --config RelWithDebInfo --build_shared_lib --parallel --cmake_generator "Visual Studio 17 2022" --enable_pybind --build_wheel
+```
+
+### Model and Data
+The static quantization tool expects the directory structure of model and data.
+
+```ps1
+work_dir\resnet18-v1-7
+├───model.onnx
+├───test_data_set_0
+├───test_data_set_1
+├───test_data_set_2
+├───test_data_set_3
+├───test_data_set_4
+├───test_data_set_5
+├───test_data_set_6
+├───test_data_set_7
+├───test_data_set_8
+└───test_data_set_9
+```
+
+### Usage
+Install the python tools built in onnxruntime
+```ps1
+cd work_dir
+python -m venv ort_env
+ort_env\Scripts\activate
+python -m pip install <path-to-built-folder>\RelWithDebInfo\RelWithDebInfo\dist\<name-of-the-wheel>.whl
+
+# The following command yields model_quant.onnx under the same directory "resnet18-v1-7"
+python -m onnxruntime.quantization.static_quantize_runner -i resnet18-v1-7\model.onnx -o resnet18-v1-7\model_quant.onnx
+
+work_dir\resnet18-v1-7
+├───model.onnx
+├───model_quant.onnx
+├───test_data_set_0
+│   ...
+└───test_data_set_9
+```
+
+### Quantization Arguments
+Please refer to `static_quantize_runner.py` for more detailed arguments.
+
+```ps1
+python -m onnxruntime.quantization.static_quantize_runner -i resnet18-v1-7\model.onnx -o resnet18-v1-7\model_quant.onnx --activation_type qint8 --weight_type qint16
+python -m onnxruntime.quantization.static_quantize_runner -i resnet18-v1-7\model.onnx -o resnet18-v1-7\model_quant.onnx --activation_type qint16 --weight_type qint16 --quantize_bias
+python -m onnxruntime.quantization.static_quantize_runner -i resnet18-v1-7\model.onnx -o resnet18-v1-7\model_quant.onnx --activation_type qint16 --weight_type qint8 --per_channel
+```
+
+### Tensor Quant Overrides Json Format
+With `--tensor_quant_overrides`, the tool can consume the json file with quantization override information.
+```ps1
+python -m onnxruntime.quantization.static_quantize_runner -i resnet18-v1-7\model.onnx -o resnet18-v1-7\model_quant.onnx --tensor_quant_overrides <path-to-json>\encoding.json
+```
+
+The tool expects the encoding.json with the format:
+```json
+{
+    "conv1_1": [
+        {
+            "scale": 0.005,
+            "zero_point": 12
+        }
+    ]
+}
+```
+- Each key is the name of a tensor in the onnx model.
+    - e.g. "conv1_1"
+- For each tensor, a list of dictionary should be provided
+    - For per-tensor quantization, the list contains a single dictionary.
+    - For per-channel quantization, the list contains a dictionary for each channel in the tensor.
+    - Each dictionary contain the information required for quantization including:
+        - scale (float)
+        - zero_point (int)

--- a/onnxruntime/python/tools/quantization/static_quantize_runner.py
+++ b/onnxruntime/python/tools/quantization/static_quantize_runner.py
@@ -1,0 +1,256 @@
+import argparse
+import json
+import os
+
+import numpy as np
+import onnx
+
+import onnxruntime
+from onnxruntime.quantization import QuantFormat, QuantType, StaticQuantConfig, quantize
+from onnxruntime.quantization.calibrate import CalibrationDataReader, CalibrationMethod
+
+
+class OnnxModelCalibrationDataReader(CalibrationDataReader):
+    def __init__(self, model_path):
+        self.model_dir = os.path.dirname(model_path)
+        data_dirs = [
+            os.path.join(self.model_dir, a) for a in os.listdir(self.model_dir) if a.startswith("test_data_set_")
+        ]
+        model_inputs = onnxruntime.InferenceSession(model_path).get_inputs()
+        name2tensors = []
+        for data_dir in data_dirs:
+            name2tensor = {}
+            data_paths = [os.path.join(data_dir, a) for a in sorted(os.listdir(data_dir))]
+            data_ndarrays = [self.read_onnx_pb_data(data_path) for data_path in data_paths]
+            for model_input, data_ndarray in zip(model_inputs, data_ndarrays, strict=False):
+                name2tensor[model_input.name] = data_ndarray
+            name2tensors.append(name2tensor)
+        assert len(name2tensors) == len(data_dirs)
+        assert len(name2tensors[0]) == len(model_inputs)
+
+        self.calibration_data = iter(name2tensors)
+
+    def get_next(self) -> dict:
+        """generate the input data dict for ONNXinferenceSession run"""
+        return next(self.calibration_data, None)
+
+    def read_onnx_pb_data(self, file_pb):
+        tensor = onnx.TensorProto()
+        with open(file_pb, "rb") as f:
+            tensor.ParseFromString(f.read())
+        ret = onnx.numpy_helper.to_array(tensor)
+        return ret
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="The arguments for static quantization")
+    parser.add_argument("-i", "--input_model_path", required=True, help="Path to the input onnx model")
+    parser.add_argument(
+        "-o", "--output_quantized_model_path", required=True, help="Path to the output quantized onnx model"
+    )
+    parser.add_argument(
+        "--activation_type",
+        choices=["qint8", "quint8", "qint16", "quint16", "qint4", "quint4", "qfloat8e4m3fn"],
+        default="quint8",
+        help="Activation quantization type used",
+    )
+    parser.add_argument(
+        "--weight_type",
+        choices=["qint8", "quint8", "qint16", "quint16", "qint4", "quint4", "qfloat8e4m3fn"],
+        default="qint8",
+        help="Weight quantization type used",
+    )
+    parser.add_argument("--enable_subgraph", action="store_true", help="If set, subgraph will be quantized.")
+    parser.add_argument(
+        "--force_quantize_no_input_check",
+        action="store_true",
+        help="By default, some latent operators like maxpool, transpose, do not quantize if their input is not"
+        " quantized already. Setting to True to force such operator always quantize input and so generate"
+        " quantized output. Also the True behavior could be disabled per node using the nodes_to_exclude.",
+    )
+    parser.add_argument(
+        "--matmul_const_b_only",
+        action="store_true",
+        help="If set, only MatMul with const B will be quantized.",
+    )
+    parser.add_argument(
+        "--add_qdq_pair_to_weight",
+        action="store_true",
+        help="If set, it remains floating-point weight and inserts both QuantizeLinear/DeQuantizeLinear"
+        " nodes to weight.",
+    )
+    parser.add_argument(
+        "--dedicated_qdq_pair",
+        action="store_true",
+        help="If set, it will create identical and dedicated QDQ pair for each node.",
+    )
+    parser.add_argument(
+        "--op_types_to_exclude_output_quantization",
+        nargs="+",
+        default=[],
+        help="If any op type is specified, it won't quantize the output of ops with this specific op types.",
+    )
+    parser.add_argument(
+        "--calibration_method",
+        default="minmax",
+        choices=["minmax", "entropy", "percentile", "distribution"],
+        help="Calibration method used",
+    )
+    parser.add_argument("--quant_format", default="qdq", choices=["qdq", "qoperator"], help="Quantization format used")
+    parser.add_argument(
+        "--calib_tensor_range_symmetric",
+        action="store_true",
+        help="If enabled, the final range of tensor during calibration will be explicitly"
+        " set to symmetric to central point 0",
+    )
+    # TODO: --calib_strided_minmax"
+    # TODO: --calib_moving_average_constant"
+    # TODO: --calib_max_intermediate_outputs"
+    parser.add_argument(
+        "--calib_moving_average",
+        action="store_true",
+        help="If enabled, the moving average of"
+        " the minimum and maximum values will be computed when the calibration method selected is MinMax.",
+    )
+    parser.add_argument(
+        "--disable_quantize_bias",
+        action="store_true",
+        help="Whether to quantize floating-point biases by solely inserting a DeQuantizeLinear node"
+        " If not set, it remains floating-point bias and does not insert any quantization nodes"
+        " associated with biases.",
+    )
+
+    # TODO: Add arguments related to Smooth Quant
+
+    parser.add_argument(
+        "--use_qdq_contrib_ops",
+        action="store_true",
+        help="If set, the inserted QuantizeLinear and DequantizeLinear ops will have the com.microsoft domain,"
+        " which forces use of ONNX Runtime's QuantizeLinear and DequantizeLinear contrib op implementations.",
+    )
+    parser.add_argument(
+        "--minimum_real_range",
+        type=float,
+        default=0.0001,
+        help="If set to a floating-point value, the calculation of the quantization parameters"
+        " (i.e., scale and zero point) will enforce a minimum range between rmin and rmax. If (rmax-rmin)"
+        " is less than the specified minimum range, rmax will be set to rmin + MinimumRealRange. This is"
+        " necessary for EPs like QNN that require a minimum floating-point range when determining "
+        " quantization parameters.",
+    )
+    parser.add_argument(
+        "--qdq_keep_removable_activations",
+        action="store_true",
+        help="If set, removable activations (e.g., Clip or Relu) will not be removed,"
+        " and will be explicitly represented in the QDQ model.",
+    )
+    parser.add_argument(
+        "--qdq_disable_weight_adjust_for_int32_bias",
+        action="store_true",
+        help="If set, QDQ quantizer will not adjust the weight's scale when the bias"
+        " has a scale (input_scale * weight_scale) that is too small.",
+    )
+    parser.add_argument("--per_channel", action="store_true", help="Whether using per-channel quantization")
+    parser.add_argument(
+        "--nodes_to_quantize",
+        nargs="+",
+        default=None,
+        help="List of nodes names to quantize. When this list is not None only the nodes in this list are quantized.",
+    )
+    parser.add_argument(
+        "--nodes_to_exclude",
+        nargs="+",
+        default=None,
+        help="List of nodes names to exclude. The nodes in this list will be excluded from quantization when it is not None.",
+    )
+    parser.add_argument(
+        "--op_per_channel_axis",
+        nargs=2,
+        action="append",
+        metavar=("OP_TYPE", "PER_CHANNEL_AXIS"),
+        default=[],
+        help="Set channel axis for specific op type, for example: --op_per_channel_axis MatMul 1, and it's"
+        " effective only when per channel quantization is supported and per_channel is True. If specific"
+        " op type supports per channel quantization but not explicitly specified with channel axis,"
+        " default channel axis will be used.",
+    )
+    parser.add_argument("--tensor_quant_overrides", help="Set the json file for tensor quantization overrides.")
+    return parser.parse_args()
+
+
+def get_tensor_quant_overrides(file):
+    # TODO: Enhance the function to handle more real cases of json file
+    if not file:
+        return {}
+    with open(file) as f:
+        quant_override_dict = json.load(f)
+    for tensor in quant_override_dict:
+        for enc_dict in quant_override_dict[tensor]:
+            enc_dict["scale"] = np.array(enc_dict["scale"], dtype=np.float32)
+            enc_dict["zero_point"] = np.array(enc_dict["zero_point"])
+    return quant_override_dict
+
+
+def main():
+    args = parse_arguments()
+    data_reader = OnnxModelCalibrationDataReader(model_path=args.input_model_path)
+    arg2quant_type = {
+        "qint8": QuantType.QInt8,
+        "quint8": QuantType.QUInt8,
+        "qint16": QuantType.QInt16,
+        "quint16": QuantType.QUInt16,
+        "qint4": QuantType.QInt4,
+        "quint4": QuantType.QUInt4,
+        "qfloat8e4m3fn": QuantType.QFLOAT8E4M3FN,
+    }
+    activation_type = arg2quant_type[args.activation_type]
+    weight_type = arg2quant_type[args.weight_type]
+    qdq_op_type_per_channel_support_to_axis = dict(args.op_per_channel_axis)
+    extra_options = {
+        "EnableSubgraph": args.enable_subgraph,
+        "ForceQuantizeNoInputCheck": args.force_quantize_no_input_check,
+        "MatMulConstBOnly": args.matmul_const_b_only,
+        "AddQDQPairToWeight": args.add_qdq_pair_to_weight,
+        "OpTypesToExcludeOutputQuantization": args.op_types_to_exclude_output_quantization,
+        "DedicatedQDQPair": args.dedicated_qdq_pair,
+        "QDQOpTypePerChannelSupportToAxis": qdq_op_type_per_channel_support_to_axis,
+        "CalibTensorRangeSymmetric": args.calib_tensor_range_symmetric,
+        "CalibMovingAverage": args.calib_moving_average,
+        "QuantizeBias": not args.disable_quantize_bias,
+        "UseQDQContribOps": args.use_qdq_contrib_ops,
+        "MinimumRealRange": args.minimum_real_range,
+        "QDQKeepRemovableActivations": args.qdq_keep_removable_activations,
+        "QDQDisableWeightAdjustForInt32Bias": args.qdq_disable_weight_adjust_for_int32_bias,
+        # Load json file for encoding override
+        "TensorQuantOverrides": get_tensor_quant_overrides(args.tensor_quant_overrides),
+    }
+    arg2calib_method = {
+        "minmax": CalibrationMethod.MinMax,
+        "entropy": CalibrationMethod.Entropy,
+        "percentile": CalibrationMethod.Percentile,
+        "distribution": CalibrationMethod.Distribution,
+    }
+    arg2quant_format = {
+        "qdq": QuantFormat.QDQ,
+        "qoperator": QuantFormat.QOperator,
+    }
+    sqc = StaticQuantConfig(
+        calibration_data_reader=data_reader,
+        calibrate_method=arg2calib_method[args.calibration_method],
+        quant_format=arg2quant_format[args.quant_format],
+        activation_type=activation_type,
+        weight_type=weight_type,
+        op_types_to_quantize=None,
+        nodes_to_quantize=args.nodes_to_quantize,
+        nodes_to_exclude=args.nodes_to_exclude,
+        per_channel=args.per_channel,
+        reduce_range=False,
+        use_external_data_format=False,
+        calibration_providers=None,  # Use CPUExecutionProvider
+        extra_options=extra_options,
+    )
+    quantize(model_input=args.input_model_path, model_output=args.output_quantized_model_path, quant_config=sqc)
+
+
+if __name__ == "__main__":
+    main()

--- a/onnxruntime/test/python/quantization/test_static_quantize_runner.py
+++ b/onnxruntime/test/python/quantization/test_static_quantize_runner.py
@@ -1,0 +1,568 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import contextlib
+import json
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+import numpy as np
+import onnx
+
+from onnxruntime.quantization import static_quantize_runner
+
+
+class StaticQuantizeRunnerTestBase:
+    def setUp(self):
+        self._tmp_model_dir = tempfile.TemporaryDirectory(prefix="ort.static_quant_runner_")
+        self._tmp_dir_path = self._tmp_model_dir.name
+        self.rand_seed = 0
+        np.random.seed(self.rand_seed)
+
+    def run_static_quantize_runner(self, script_args: list, override_dict=None) -> onnx.ModelProto:
+        model = self.onnx_model()
+        test_data_sets = self.get_test_data_set(model)
+        for idx, test_data_set in enumerate(test_data_sets):
+            test_data_set_dir = os.path.join(self._tmp_dir_path, f"test_data_set_{idx}")
+            os.makedirs(test_data_set_dir, exist_ok=True)
+            for data_idx, test_data in enumerate(test_data_set):
+                data_path = os.path.join(test_data_set_dir, f"input_{data_idx}.pb")
+                with open(data_path, "wb") as f:
+                    tensor_proto = onnx.numpy_helper.from_array(test_data)
+                    f.write(tensor_proto.SerializeToString())
+
+        in_model_path = os.path.join(self._tmp_dir_path, "model.onnx")
+        onnx.save_model(model, in_model_path)  # Save input test model to disk
+
+        out_model_path = os.path.join(self._tmp_dir_path, "model_quant.onnx")
+
+        # Call script's main() with custom command-line args.
+        script = ["static_quantize_runner.py", "-i", in_model_path, "-o", out_model_path]
+        if override_dict:
+            quant_override_path = os.path.join(self._tmp_dir_path, "quant_override.json")
+            with open(quant_override_path, "w") as f:
+                json.dump(override_dict, f)
+            script += ["--tensor_quant_overrides", quant_override_path]
+
+        with mock.patch("sys.argv", script + script_args):
+            static_quantize_runner.main()
+
+        # check that output qdq model was generated
+        self.assertTrue(os.path.exists(out_model_path))
+        return onnx.load_model(out_model_path)
+
+    def onnx_model(self) -> onnx.ModelProto:
+        pass
+
+    def get_test_data_set(self, model):
+        inp_shapes = [[d.dim_value for d in inp.type.tensor_type.shape.dim] for inp in model.graph.input]
+        inp_dtypes = [onnx.helper.tensor_dtype_to_np_dtype(inp.type.tensor_type.elem_type) for inp in model.graph.input]
+        test_data_sets = [
+            [
+                np.random.rand(*inp_shape).astype(inp_dtype)
+                for inp_shape, inp_dtype in zip(inp_shapes, inp_dtypes, strict=False)
+            ]
+        ]
+        return test_data_sets
+
+    def test_activation_weight_type(self):
+        script_args_set = [
+            (["--activation_type", "quint8", "--weight_type", "quint8"], True),
+            (["--activation_type", "quint8", "--weight_type", "qint8"], True),
+            (["--activation_type", "qint8", "--weight_type", "quint8"], False),
+            (["--activation_type", "qint8", "--weight_type", "qint8"], True),
+        ]
+        for script_args, success in script_args_set:
+            with (
+                self.subTest(script_args=script_args),
+                contextlib.nullcontext() if success else self.assertRaises(Exception),
+            ):
+                self.run_static_quantize_runner(script_args)
+
+    def test_quant_format(self):
+        script_args_set = [(["--quant_format", "qdq"], True), (["--quant_format", "qoperator"], True)]
+        for script_args, success in script_args_set:
+            with (
+                self.subTest(script_args=script_args),
+                contextlib.nullcontext() if success else self.assertRaises(Exception),
+            ):
+                self.run_static_quantize_runner(script_args)
+
+    def test_calibration_method(self):
+        script_args_set = [
+            (["--calibration_method", "minmax"], True),
+            (["--calibration_method", "entropy"], True),
+            (["--calibration_method", "percentile"], True),
+            (["--calibration_method", "distribution"], True),
+        ]
+        for script_args, success in script_args_set:
+            with (
+                self.subTest(script_args=script_args),
+                contextlib.nullcontext() if success else self.assertRaises(Exception),
+            ):
+                self.run_static_quantize_runner(script_args)
+
+    def test_calib_tensor_range_symmetric(self):
+        # TODO: Check whether the calibrated tensor value is symmetric
+        script_args_set = [
+            (["--activation_type", "quint8", "--calib_tensor_range_symmetric"], True),
+            (["--activation_type", "qint8", "--calib_tensor_range_symmetric"], True),
+        ]
+        for script_args, success in script_args_set:
+            with (
+                self.subTest(script_args=script_args, success=success),
+                contextlib.nullcontext() if success else self.assertRaises(Exception),
+            ):
+                self.run_static_quantize_runner(script_args)
+
+    def test_calib_moving_average(self):
+        script_args_set = [
+            (["--calib_moving_average"], True),
+        ]
+        for script_args, success in script_args_set:
+            with (
+                self.subTest(script_args=script_args, success=success),
+                contextlib.nullcontext() if success else self.assertRaises(Exception),
+            ):
+                self.run_static_quantize_runner(script_args)
+
+    def test_minimum_real_range(self):
+        # TODO: Check whether the (rmin-rmax) follows the minimum range
+        script_args_set = [
+            (["--minimum_real_range", "0.001"], True),
+        ]
+        for script_args, success in script_args_set:
+            with (
+                self.subTest(script_args=script_args, success=success),
+                contextlib.nullcontext() if success else self.assertRaises(Exception),
+            ):
+                self.run_static_quantize_runner(script_args)
+
+    def test_use_qdq_contrib_ops(self):
+        script_args_set = [
+            (["--use_qdq_contrib_ops"], True),
+        ]
+        for script_args, success in script_args_set:
+            with (
+                self.subTest(script_args=script_args, success=success),
+                contextlib.nullcontext() if success else self.assertRaises(Exception),
+            ):
+                quant_model = self.run_static_quantize_runner(script_args)
+                for node in quant_model.graph.node:
+                    if node.op_type in ["QuantizeLinear", "DeQuantizeLinear"]:
+                        assert node.domain == "com.microsoft"
+
+    def test_qdq_disable_weight_adjust_for_int32_bias(self):
+        # TODO: Check whether the weight's scale is adjusted
+        script_args_set = [
+            (["--qdq_disable_weight_adjust_for_int32_bias"], True),
+        ]
+        for script_args, success in script_args_set:
+            with (
+                self.subTest(script_args=script_args, success=success),
+                contextlib.nullcontext() if success else self.assertRaises(Exception),
+            ):
+                self.run_static_quantize_runner(script_args)
+
+
+class TestAdd(StaticQuantizeRunnerTestBase, unittest.TestCase):
+    def onnx_model(self, inp_shape=(4, 3, 32, 32)) -> onnx.ModelProto:
+        graph_inputs = [
+            onnx.helper.make_tensor_value_info("input_0", onnx.TensorProto.FLOAT, inp_shape),
+            onnx.helper.make_tensor_value_info("input_1", onnx.TensorProto.FLOAT, inp_shape),
+        ]
+        graph_outputs = [onnx.helper.make_tensor_value_info("output_0", onnx.TensorProto.FLOAT, inp_shape)]
+        initializers = []
+
+        add_node = onnx.helper.make_node("Add", ["input_0", "input_1"], ["output_0"], name="Add0")
+        graph = onnx.helper.make_graph(
+            [add_node],
+            "AddGraph",
+            graph_inputs,
+            graph_outputs,
+            initializer=initializers,
+        )
+        opset_imports = [onnx.helper.make_opsetid("", 21)]
+        model = onnx.helper.make_model(graph, opset_imports=opset_imports)
+        model = onnx.shape_inference.infer_shapes(model)
+        onnx.checker.check_model(model, True)
+        return model
+
+    def test_tensor_quant_overrides(self):
+        override_dict = {"input_0": [{"scale": 0.005, "zero_point": 2}]}
+        quant_model = self.run_static_quantize_runner(script_args=[], override_dict=override_dict)
+        assert quant_model.graph.initializer[0].name == "input_0_zero_point"
+        assert np.allclose(quant_model.graph.initializer[0].int32_data, 2)
+        assert quant_model.graph.initializer[1].name == "input_0_scale"
+        assert np.allclose(quant_model.graph.initializer[1].float_data, 0.005)
+
+
+class TestMatMulConstB(StaticQuantizeRunnerTestBase, unittest.TestCase):
+    def onnx_model(self, inp_shape=(4, 3, 5, 7), weight_shape=(4, 3, 7, 9), out_shape=(4, 3, 5, 9)) -> onnx.ModelProto:
+        graph_inputs = [
+            onnx.helper.make_tensor_value_info("input_0", onnx.TensorProto.FLOAT, inp_shape),
+        ]
+        graph_outputs = [onnx.helper.make_tensor_value_info("output_0", onnx.TensorProto.FLOAT, out_shape)]
+        initializers = [
+            onnx.helper.make_tensor(
+                "weight_0", onnx.TensorProto.FLOAT, dims=weight_shape, vals=np.random.rand(*weight_shape)
+            )
+        ]
+        matmul_input_names = ["input_0", "weight_0"]
+
+        matmul_node = onnx.helper.make_node("MatMul", matmul_input_names, ["output_0"], name="MatMul0")
+        graph = onnx.helper.make_graph(
+            [matmul_node],
+            "MatMulGraph",
+            graph_inputs,
+            graph_outputs,
+            initializer=initializers,
+        )
+        opset_imports = [onnx.helper.make_opsetid("", 21)]
+        model = onnx.helper.make_model(graph, opset_imports=opset_imports)
+        model = onnx.shape_inference.infer_shapes(model)
+        onnx.checker.check_model(model, True)
+        return model
+
+    def test_per_channel_quant(self):
+        # TODO: Fix the str and int issue on the axis and enable the following subtests
+        script_args_set = [
+            (["--per_channel"], 3),
+            # (["--per_channel", "--op_per_channel_axis", "MatMul", "0"], 4),
+            # (["--per_channel", "--op_per_channel_axis", "MatMul", "1"], 3),
+            # (["--per_channel", "--op_per_channel_axis", "MatMul", "2"], 7),
+            # (["--per_channel", "--op_per_channel_axis", "MatMul", "3"], 9),
+        ]
+        for script_args, n_channels in script_args_set:
+            with self.subTest(script_args=script_args):
+                quant_model = self.run_static_quantize_runner(script_args)
+                assert quant_model.graph.initializer[0].name == "input_0_zero_point"
+                assert len(quant_model.graph.initializer[0].dims) == 0
+                assert quant_model.graph.initializer[1].name == "input_0_scale"
+                assert len(quant_model.graph.initializer[1].dims) == 0
+                assert quant_model.graph.initializer[2].name == "weight_0_zero_point"
+                assert quant_model.graph.initializer[2].dims[0] == n_channels
+                assert quant_model.graph.initializer[3].name == "weight_0_scale"
+                assert quant_model.graph.initializer[3].dims[0] == n_channels
+
+    def test_add_qdq_pair_to_weight(self):
+        script_args_set = [
+            (["--add_qdq_pair_to_weight"], 7),
+            ([], 6),
+        ]
+        for script_args, expect_num_nodes in script_args_set:
+            with self.subTest(script_args=script_args, expect_num_nodes=expect_num_nodes):
+                quant_model = self.run_static_quantize_runner(script_args)
+                assert len(quant_model.graph.node) == expect_num_nodes
+
+    def test_exlude_output_quantization(self):
+        script_args_set = [
+            (["--op_types_to_exclude_output_quantization", "MatMul"], 4),
+            ([], 6),
+        ]
+        for script_args, expect_num_nodes in script_args_set:
+            with self.subTest(script_args=script_args, expect_num_nodes=expect_num_nodes):
+                quant_model = self.run_static_quantize_runner(script_args)
+                assert len(quant_model.graph.node) == expect_num_nodes
+
+
+class TestMatMul(StaticQuantizeRunnerTestBase, unittest.TestCase):
+    def onnx_model(self, inp_shape1=(4, 3, 5, 7), inp_shape2=(4, 3, 7, 9), out_shape=(4, 3, 5, 9)) -> onnx.ModelProto:
+        graph_inputs = [
+            onnx.helper.make_tensor_value_info("input_0", onnx.TensorProto.FLOAT, inp_shape1),
+            onnx.helper.make_tensor_value_info("input_1", onnx.TensorProto.FLOAT, inp_shape2),
+        ]
+        graph_outputs = [onnx.helper.make_tensor_value_info("output_0", onnx.TensorProto.FLOAT, out_shape)]
+        matmul_input_names = ["input_0", "input_1"]
+
+        matmul_node = onnx.helper.make_node("MatMul", matmul_input_names, ["output_0"], name="MatMul0")
+        graph = onnx.helper.make_graph([matmul_node], "MatMulGraph", graph_inputs, graph_outputs)
+        opset_imports = [onnx.helper.make_opsetid("", 21)]
+        model = onnx.helper.make_model(graph, opset_imports=opset_imports)
+        model = onnx.shape_inference.infer_shapes(model)
+        onnx.checker.check_model(model, True)
+        return model
+
+    def test_matmul_const_b_only(self):
+        # TODO: Support --matmul_const_b_only on qdq quant_format and refine the testcase
+        script_args_set = [
+            (["--quant_format", "qoperator", "--matmul_const_b_only"], 1),
+            (["--quant_format", "qoperator"], 4),
+        ]
+        for script_args, expect_num_nodes in script_args_set:
+            with self.subTest(script_args=script_args, expect_num_nodes=expect_num_nodes):
+                quant_model = self.run_static_quantize_runner(script_args)
+                assert len(quant_model.graph.node) == expect_num_nodes
+
+
+class TestAddSideBySide(StaticQuantizeRunnerTestBase, unittest.TestCase):
+    def onnx_model(self, inp_shape=(4, 3, 32, 32)) -> onnx.ModelProto:
+        graph_inputs = [
+            onnx.helper.make_tensor_value_info("input_0", onnx.TensorProto.FLOAT, inp_shape),
+            onnx.helper.make_tensor_value_info("input_1", onnx.TensorProto.FLOAT, inp_shape),
+            onnx.helper.make_tensor_value_info("input_2", onnx.TensorProto.FLOAT, inp_shape),
+        ]
+        graph_outputs = [
+            onnx.helper.make_tensor_value_info("output_0", onnx.TensorProto.FLOAT, inp_shape),
+            onnx.helper.make_tensor_value_info("output_1", onnx.TensorProto.FLOAT, inp_shape),
+        ]
+        add_node0 = onnx.helper.make_node("Add", ["input_0", "input_1"], ["output_0"], name="Add0")
+        add_node1 = onnx.helper.make_node("Add", ["input_1", "input_2"], ["output_1"], name="Add1")
+        graph = onnx.helper.make_graph(
+            [add_node0, add_node1],
+            "AddGraph",
+            graph_inputs,
+            graph_outputs,
+            initializer=[],
+        )
+        opset_imports = [onnx.helper.make_opsetid("", 21)]
+        model = onnx.helper.make_model(graph, opset_imports=opset_imports)
+        model = onnx.shape_inference.infer_shapes(model)
+        onnx.checker.check_model(model, True)
+        return model
+
+    def test_dedicated_qdq_pair(self):
+        # TODO: Support --matmul_const_b_only on qdq quant_format and refine the testcase
+        script_args_set = [([], 12), (["--dedicated_qdq_pair"], 14)]
+        for script_args, expect_num_nodes in script_args_set:
+            with self.subTest(script_args=script_args, expect_num_nodes=expect_num_nodes):
+                quant_model = self.run_static_quantize_runner(script_args)
+                assert len(quant_model.graph.node) == expect_num_nodes
+
+    def test_nodes_to_quantize(self):
+        script_args_set = [
+            (["--nodes_to_quantize", "Add0"], 8),
+            (["--nodes_to_quantize", "Add1"], 8),
+            (["--nodes_to_quantize", "Add0", "Add1"], 12),
+        ]
+        for script_args, expect_num_nodes in script_args_set:
+            with self.subTest(script_args=script_args, expect_num_nodes=expect_num_nodes):
+                quant_model = self.run_static_quantize_runner(script_args)
+                assert len(quant_model.graph.node) == expect_num_nodes
+
+    def test_nodes_to_exclude(self):
+        script_args_set = [
+            (["--nodes_to_exclude", "Add0"], 8),
+            (["--nodes_to_exclude", "Add1"], 8),
+            (["--nodes_to_exclude", "Add0", "Add1"], 2),
+        ]
+        for script_args, expect_num_nodes in script_args_set:
+            with self.subTest(script_args=script_args, expect_num_nodes=expect_num_nodes):
+                quant_model = self.run_static_quantize_runner(script_args)
+                assert len(quant_model.graph.node) == expect_num_nodes
+
+
+class TestConv(StaticQuantizeRunnerTestBase, unittest.TestCase):
+    def onnx_model(
+        self, inp_shape=(4, 3, 32, 32), weight_shape=(8, 3, 5, 5), bias_shape=(8,), out_shape=(4, 8, 28, 28)
+    ) -> onnx.ModelProto:
+        graph_inputs = [
+            onnx.helper.make_tensor_value_info("input_0", onnx.TensorProto.FLOAT, inp_shape),
+        ]
+        graph_outputs = [onnx.helper.make_tensor_value_info("output_0", onnx.TensorProto.FLOAT, out_shape)]
+        initializers = [
+            onnx.helper.make_tensor(
+                "weight_0", onnx.TensorProto.FLOAT, dims=weight_shape, vals=np.random.rand(*weight_shape)
+            ),
+            onnx.helper.make_tensor(
+                "bias_0", onnx.TensorProto.FLOAT, dims=bias_shape, vals=np.random.rand(*bias_shape)
+            ),
+        ]
+
+        conv_node = onnx.helper.make_node(
+            "Conv",
+            ["input_0", "weight_0", "bias_0"],
+            ["output_0"],
+            name="Conv0",
+            kernel_shape=[5, 5],
+        )
+        graph = onnx.helper.make_graph(
+            [conv_node],
+            "ConvGraph",
+            graph_inputs,
+            graph_outputs,
+            initializer=initializers,
+        )
+        opset_imports = [onnx.helper.make_opsetid("", 21)]
+        model = onnx.helper.make_model(graph, opset_imports=opset_imports)
+        model = onnx.shape_inference.infer_shapes(model)
+        onnx.checker.check_model(model, True)
+        return model
+
+    def test_disable_quantize_bias(self):
+        script_args_set = [
+            ([], 7),
+            (["--disable_quantize_bias"], 6),
+        ]
+        for script_args, expect_num_nodes in script_args_set:
+            with self.subTest(script_args=script_args, expect_num_nodes=expect_num_nodes):
+                quant_model = self.run_static_quantize_runner(script_args)
+                assert len(quant_model.graph.node) == expect_num_nodes
+
+
+class TestConvRelu(StaticQuantizeRunnerTestBase, unittest.TestCase):
+    def onnx_model(
+        self, inp_shape=(4, 3, 32, 32), weight_shape=(8, 3, 5, 5), bias_shape=(8,), out_shape=(4, 8, 28, 28)
+    ) -> onnx.ModelProto:
+        graph_inputs = [
+            onnx.helper.make_tensor_value_info("input_0", onnx.TensorProto.FLOAT, inp_shape),
+        ]
+        graph_outputs = [onnx.helper.make_tensor_value_info("output_0", onnx.TensorProto.FLOAT, out_shape)]
+        initializers = [
+            onnx.helper.make_tensor(
+                "weight_0", onnx.TensorProto.FLOAT, dims=weight_shape, vals=np.random.rand(*weight_shape)
+            ),
+            onnx.helper.make_tensor(
+                "bias_0", onnx.TensorProto.FLOAT, dims=bias_shape, vals=np.random.rand(*bias_shape)
+            ),
+        ]
+
+        conv_node = onnx.helper.make_node(
+            "Conv",
+            ["input_0", "weight_0", "bias_0"],
+            ["conv_output_0"],
+            name="Conv0",
+            kernel_shape=[5, 5],
+        )
+
+        relu_node = onnx.helper.make_node(
+            "Relu",
+            ["conv_output_0"],
+            ["output_0"],
+            name="Relu0",
+        )
+        graph = onnx.helper.make_graph(
+            [conv_node, relu_node],
+            "ConvReluGraph",
+            graph_inputs,
+            graph_outputs,
+            initializer=initializers,
+        )
+        opset_imports = [onnx.helper.make_opsetid("", 21)]
+        model = onnx.helper.make_model(graph, opset_imports=opset_imports)
+        model = onnx.shape_inference.infer_shapes(model)
+        onnx.checker.check_model(model, True)
+        return model
+
+    def test_qdq_keep_removable_activations(self):
+        script_args_set = [([], 7), (["--qdq_keep_removable_activations"], 10)]
+        for script_args, expect_num_nodes in script_args_set:
+            with self.subTest(script_args=script_args, expect_num_nodes=expect_num_nodes):
+                quant_model = self.run_static_quantize_runner(script_args)
+                assert len(quant_model.graph.node) == expect_num_nodes
+
+
+class TestIfGraph(StaticQuantizeRunnerTestBase, unittest.TestCase):
+    def onnx_model(self) -> onnx.ModelProto:
+        cond = onnx.helper.make_tensor_value_info("cond", onnx.TensorProto.BOOL, [1])
+        input_0 = onnx.helper.make_tensor_value_info("input_0", onnx.TensorProto.FLOAT, [4, 3, 32, 32])
+        input_1 = onnx.helper.make_tensor_value_info("input_1", onnx.TensorProto.FLOAT, [4, 3, 32, 32])
+        output_0 = onnx.helper.make_tensor_value_info("output_0", onnx.TensorProto.FLOAT, [4, 3, 32, 32])
+
+        then_graph = onnx.helper.make_graph(
+            nodes=[onnx.helper.make_node("Add", ["input_0", "input_1"], ["output_0"], name="Add0")],
+            name="AddGraph",
+            inputs=[],
+            outputs=[output_0],
+            initializer=[],
+        )
+        else_graph = onnx.helper.make_graph(
+            nodes=[onnx.helper.make_node("Mul", ["input_0", "input_1"], ["output_0"], name="Mul0")],
+            name="MulGraph",
+            inputs=[],
+            outputs=[output_0],
+            initializer=[],
+        )
+        if_node = onnx.helper.make_node(
+            "If", inputs=["cond"], outputs=["output_0"], then_branch=then_graph, else_branch=else_graph
+        )
+        graph = onnx.helper.make_graph(
+            nodes=[if_node], name="main_graph", inputs=[cond, input_0, input_1], outputs=[output_0]
+        )
+        opset_imports = [onnx.helper.make_opsetid("", 21)]
+        model = onnx.helper.make_model(graph, opset_imports=opset_imports)
+        model = onnx.shape_inference.infer_shapes(model)
+        onnx.checker.check_model(model, True)
+        return model
+
+    def test_enable_subgraph(self):
+        # TODO: Investigate the reason of failure on --enable_subgraph
+        script_args_set = [(["--enable_subgraph", "--quant_format", "qoperator"], False)]
+        for script_args, success in script_args_set:
+            with (
+                self.subTest(script_args=script_args),
+                contextlib.nullcontext() if success else self.assertRaises(Exception),
+            ):
+                self.run_static_quantize_runner(script_args)
+
+    def test_calibration_method(self):
+        # TODO: Investigate the reason of failure on calibration methods
+        script_args_set = [
+            (["--calibration_method", "minmax"], True),
+            (["--calibration_method", "entropy"], False),
+            (["--calibration_method", "percentile"], False),
+            (["--calibration_method", "distribution"], False),
+        ]
+        for script_args, success in script_args_set:
+            with (
+                self.subTest(script_args=script_args),
+                contextlib.nullcontext() if success else self.assertRaises(Exception),
+            ):
+                self.run_static_quantize_runner(script_args)
+
+
+class TestWhere(StaticQuantizeRunnerTestBase, unittest.TestCase):
+    def onnx_model(self, inp_shape=(4, 3, 32, 32)) -> onnx.ModelProto:
+        graph_inputs = [
+            onnx.helper.make_tensor_value_info("cond", onnx.TensorProto.BOOL, inp_shape),
+            onnx.helper.make_tensor_value_info("input_0", onnx.TensorProto.FLOAT, inp_shape),
+            onnx.helper.make_tensor_value_info("input_1", onnx.TensorProto.FLOAT, inp_shape),
+        ]
+        graph_outputs = [onnx.helper.make_tensor_value_info("output_0", onnx.TensorProto.FLOAT, inp_shape)]
+
+        add_node = onnx.helper.make_node("Add", ["input_0", "input_1"], ["Add_output_0"], name="Add0")
+        mul_node = onnx.helper.make_node("Mul", ["input_0", "input_1"], ["Mul_output_0"], name="Mul0")
+        where_node = onnx.helper.make_node(
+            "Where", ["cond", "Add_output_0", "Mul_output_0"], ["output_0"], name="Where0"
+        )
+        graph = onnx.helper.make_graph(
+            [add_node, mul_node, where_node],
+            "WhereGraph",
+            graph_inputs,
+            graph_outputs,
+            initializer=[],
+        )
+        opset_imports = [onnx.helper.make_opsetid("", 21)]
+        model = onnx.helper.make_model(graph, opset_imports=opset_imports)
+        model = onnx.shape_inference.infer_shapes(model)
+        onnx.checker.check_model(model, True)
+        return model
+
+    def test_quant_format(self):
+        # TODO: Investigate the failure on --quant_format qoperator
+        script_args_set = [(["--quant_format", "qdq"], True), (["--quant_format", "qoperator"], False)]
+        for script_args, success in script_args_set:
+            with (
+                self.subTest(script_args=script_args),
+                contextlib.nullcontext() if success else self.assertRaises(Exception),
+            ):
+                self.run_static_quantize_runner(script_args)
+
+    def test_force_quantize_no_input_check(self):
+        script_args_set = [
+            (["--nodes_to_exclude", "Add0", "Mul0"], 3),
+            (["--nodes_to_exclude", "Add0", "Mul0", "--force_quantize_no_input_check"], 9),
+        ]
+        for script_args, expect_num_node in script_args_set:
+            with self.subTest(script_args=script_args):
+                quant_model = self.run_static_quantize_runner(script_args)
+                assert len(quant_model.graph.node) == expect_num_node
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Add a general command-line tool for static quantization
- Support loading TensorQuantOverride from json file
- Add the corresponding README

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- Currently, developers are able to use preprocess tool from command line
    - https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html#pre-processing
    - `python -m onnxruntime.quantization.preprocess --help`
- The PR aims to provide similar usage for static quantization.
    - `python -m onnxruntime.quantization.static_quantize_runner --help`
- Existing command-line examples in onnxruntime-inference-example are not general for arbitrary ONNX models.
