### PR TITLE
add test cases for webgpu ep in web

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
@@ -139,17 +139,19 @@ jobs:
 
   - ${{ if eq(parameters.SkipPublish, false) }}:
     - script: |
-        cp $(Build.BinariesDirectory)/wasm_inferencing/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.wasm $(Build.ArtifactStagingDirectory)/wasm
-        cp $(Build.BinariesDirectory)/wasm_inferencing/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.mjs $(Build.ArtifactStagingDirectory)/wasm
+        mkdir -p $(Build.ArtifactStagingDirectory)/wasm/
+        cp $(Build.BinariesDirectory)/wasm_inferencing/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.wasm $(Build.ArtifactStagingDirectory)/wasm/
+        cp $(Build.BinariesDirectory)/wasm_inferencing/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.mjs $(Build.ArtifactStagingDirectory)/wasm/
         if [ -d $(Build.BinariesDirectory)/wasm_inferencing_jsep ]; then
-          cp $(Build.BinariesDirectory)/wasm_inferencing_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.jsep.wasm $(Build.ArtifactStagingDirectory)/wasm
-          cp $(Build.BinariesDirectory)/wasm_inferencing_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.jsep.mjs $(Build.ArtifactStagingDirectory)/wasm
+          cp $(Build.BinariesDirectory)/wasm_inferencing_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.jsep.wasm $(Build.ArtifactStagingDirectory)/wasm/
+          cp $(Build.BinariesDirectory)/wasm_inferencing_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.jsep.mjs $(Build.ArtifactStagingDirectory)/wasm/
         fi
       displayName: 'Create Artifacts'
     - ${{ if eq(parameters.BuildWebGPU, true) }}:
       - script: |
-          cp $(Build.BinariesDirectory)/wasm_inferencing_webgpu/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.jsep.wasm $(Build.ArtifactStagingDirectory)/wasm_webgpu
-          cp $(Build.BinariesDirectory)/wasm_inferencing_webgpu/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.jsep.mjs $(Build.ArtifactStagingDirectory)/wasm_webgpu
+          mkdir -p $(Build.ArtifactStagingDirectory)/wasm_webgpu/
+          cp $(Build.BinariesDirectory)/wasm_inferencing_webgpu/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.jsep.wasm $(Build.ArtifactStagingDirectory)/wasm_webgpu/
+          cp $(Build.BinariesDirectory)/wasm_inferencing_webgpu/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.jsep.mjs $(Build.ArtifactStagingDirectory)/wasm_webgpu/
         displayName: 'Create Artifacts (WebGPU EP)'
     - ${{ if eq(parameters.is1ES, false) }}:
       - task: PublishPipelineArtifact@1

--- a/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
@@ -125,11 +125,6 @@ jobs:
         WithCache: ${{ parameters.WithCache }}
 
   - ${{ if eq(parameters.BuildWebGPU, true) }}:
-    # This step only verifies whether the build is successful.
-    # currently, we uses EMSDK 3.1.59, which is not compatible with Dawn's changes in its Emscripten fork. Closure compiler will not work for WebGPU build.
-    # Only enables in DEBUG build.
-    #
-    # TODO: when upgrading to a newer Emscripten version, we should fix this step.
     - template: build-linux-wasm-step.yml
       parameters:
         Today: $(Today)
@@ -138,31 +133,48 @@ jobs:
         ${{ else }}:
           AdditionalKey: wasm_inferencing_webgpu_exp | ${{ parameters.BuildConfig }}
         CacheDir: $(ORT_CACHE_DIR)/wasm_inferencing_webgpu
-        Arguments: '$(CommonBuildArgs) --build_dir $(Build.BinariesDirectory)/wasm_inferencing_webgpu --use_webgpu --target onnxruntime_webassembly --skip_tests'
+        Arguments: '$(CommonBuildArgs) --build_dir $(Build.BinariesDirectory)/wasm_inferencing_webgpu --use_webgpu --use_jsep --use_webnn --target onnxruntime_webassembly --skip_tests'
         DisplayName: 'Build (simd + threads + WebGPU experimental)'
         WithCache: ${{ parameters.WithCache }}
 
   - ${{ if eq(parameters.SkipPublish, false) }}:
     - script: |
-        cp $(Build.BinariesDirectory)/wasm_inferencing/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.wasm $(Build.ArtifactStagingDirectory)
-        cp $(Build.BinariesDirectory)/wasm_inferencing/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.mjs $(Build.ArtifactStagingDirectory)
+        cp $(Build.BinariesDirectory)/wasm_inferencing/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.wasm $(Build.ArtifactStagingDirectory)/wasm
+        cp $(Build.BinariesDirectory)/wasm_inferencing/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.mjs $(Build.ArtifactStagingDirectory)/wasm
         if [ -d $(Build.BinariesDirectory)/wasm_inferencing_jsep ]; then
-          cp $(Build.BinariesDirectory)/wasm_inferencing_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.jsep.wasm $(Build.ArtifactStagingDirectory)
-          cp $(Build.BinariesDirectory)/wasm_inferencing_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.jsep.mjs $(Build.ArtifactStagingDirectory)
+          cp $(Build.BinariesDirectory)/wasm_inferencing_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.jsep.wasm $(Build.ArtifactStagingDirectory)/wasm
+          cp $(Build.BinariesDirectory)/wasm_inferencing_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.jsep.mjs $(Build.ArtifactStagingDirectory)/wasm
         fi
       displayName: 'Create Artifacts'
+    - ${{ if eq(parameters.BuildWebGPU, true) }}:
+      - script: |
+          cp $(Build.BinariesDirectory)/wasm_inferencing_webgpu/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.jsep.wasm $(Build.ArtifactStagingDirectory)/wasm_webgpu
+          cp $(Build.BinariesDirectory)/wasm_inferencing_webgpu/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.jsep.mjs $(Build.ArtifactStagingDirectory)/wasm_webgpu
+        displayName: 'Create Artifacts (WebGPU EP)'
     - ${{ if eq(parameters.is1ES, false) }}:
       - task: PublishPipelineArtifact@1
         displayName: 'Publish Pipeline Artifact'
         inputs:
           artifactName: '${{ parameters.BuildConfig }}_wasm'
-          targetPath: '$(Build.ArtifactStagingDirectory)'
+          targetPath: '$(Build.ArtifactStagingDirectory)/wasm'
+      - ${{ if eq(parameters.BuildWebGPU, true) }}:
+        - task: PublishPipelineArtifact@1
+          displayName: 'Publish Pipeline Artifact (WebGPU EP)'
+          inputs:
+            artifactName: '${{ parameters.BuildConfig }}_wasm_webgpu'
+            targetPath: '$(Build.ArtifactStagingDirectory)/wasm_webgpu'
     - ${{ if eq(parameters.is1ES, true) }}:
       - task: 1ES.PublishPipelineArtifact@1
         displayName: 'Publish Pipeline Artifact'
         inputs:
           artifactName: '${{ parameters.BuildConfig }}_wasm'
-          targetPath: '$(Build.ArtifactStagingDirectory)'
+          targetPath: '$(Build.ArtifactStagingDirectory)/wasm'
+      - ${{ if eq(parameters.BuildWebGPU, true) }}:
+        - task: 1ES.PublishPipelineArtifact@1
+          displayName: 'Publish Pipeline Artifact (WebGPU EP)'
+          inputs:
+            artifactName: '${{ parameters.BuildConfig }}_wasm_webgpu'
+            targetPath: '$(Build.ArtifactStagingDirectory)/wasm_webgpu'
   - task: PublishTestResults@2
     displayName: 'Publish unit test results'
     inputs:

--- a/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
@@ -147,7 +147,7 @@ stages:
       ExtraBuildArgs: '--target onnxruntime_webassembly --skip_tests --enable_wasm_api_exception_catching --disable_rtti ${{ parameters.ExtraBuildArgs }}'
       PoolName: ${{ parameters.PoolName }}
       BuildJsep: ${{ parameters.BuildJsep }}
-      BuildWebGPU: false
+      BuildWebGPU: ${{ parameters.BuildWebGPU }}
       WithCache: ${{ parameters.WithCache }}
       is1ES: ${{ parameters.is1ES }}
 

--- a/tools/ci_build/github/azure-pipelines/templates/win-web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-web-ci.yml
@@ -222,6 +222,17 @@ jobs:
     displayName: 'Run ort-web tests - WebAssembly: proxy'
     condition: and(succeeded(), eq('${{ parameters.BuildConfig }}', 'Release'))
   - script: |
+      powershell "Get-WmiObject Win32_Process -Filter \"name = 'chrome.exe'\" | Format-List CommandLine"
+    displayName: 'Check active Chrome processes (before test)'
+    condition: and(succeeded(), eq(variables['Agent.Diagnostic'], 'true'))
+  - script: |
+      mkdir $(Agent.TempDirectory)\web\test\07
+      dir $(Agent.TempDirectory)\web\test\07
+      npm test --webgpu-ep -- -b=webgpu -e=chrome --user-data-dir=$(Agent.TempDirectory)\web\test\07 --chromium-flags=--enable-logging --chromium-flags=--v=1
+    workingDirectory: '$(Build.SourcesDirectory)\js\web'
+    displayName: 'Run ort-web tests - WebAssembly: proxy'
+    condition: and(succeeded(), eq('${{ parameters.BuildConfig }}', 'Release'))
+  - script: |
       npm run test:e2e -- --browser=Chrome_default
     workingDirectory: '$(Build.SourcesDirectory)\js\web'
     displayName: 'E2E package consuming test'

--- a/tools/ci_build/github/azure-pipelines/templates/win-web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-web-ci.yml
@@ -237,6 +237,7 @@ jobs:
           **\ort-*.wasm
         targetFolder: $(Build.SourcesDirectory)\js\web\dist
         flattenFolders: true
+        overWrite: true
       displayName: 'Binplace dist files (.wasm)'
     - task: CopyFiles@2
       inputs:
@@ -245,6 +246,7 @@ jobs:
           **\ort-*.mjs
         targetFolder: $(Build.SourcesDirectory)\js\web\dist
         flattenFolders: true
+        overWrite: true
       displayName: 'Binplace dist files (.mjs)'
     - script: |
         powershell "Get-WmiObject Win32_Process -Filter \"name = 'chrome.exe'\" | Format-List CommandLine"

--- a/tools/ci_build/github/azure-pipelines/templates/win-web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-web-ci.yml
@@ -81,12 +81,12 @@ jobs:
       versionSpec: '20.x'
   - task: DownloadPipelineArtifact@2
     inputs:
-      patterns: '${{ parameters.BuildConfig }}_*/**/*'
-      path: $(Pipeline.Workspace)\artifacts
+      patterns: '${{ parameters.BuildConfig }}_wasm/**/*'
+      path: $(Pipeline.Workspace)\artifacts_wasm
     displayName: 'Download WebAssembly artifacts'
   - task: CopyFiles@2
     inputs:
-      sourceFolder: $(Pipeline.Workspace)\artifacts
+      sourceFolder: $(Pipeline.Workspace)\artifacts_wasm
       contents: |
         **\ort-*.wasm
       targetFolder: $(Build.SourcesDirectory)\js\web\dist
@@ -94,7 +94,7 @@ jobs:
     displayName: 'Binplace dist files (.wasm)'
   - task: CopyFiles@2
     inputs:
-      sourceFolder: $(Pipeline.Workspace)\artifacts
+      sourceFolder: $(Pipeline.Workspace)\artifacts_wasm
       contents: |
         **\ort-*.mjs
       targetFolder: $(Build.SourcesDirectory)\js\web\dist
@@ -221,17 +221,45 @@ jobs:
     workingDirectory: '$(Build.SourcesDirectory)\js\web'
     displayName: 'Run ort-web tests - WebAssembly: proxy'
     condition: and(succeeded(), eq('${{ parameters.BuildConfig }}', 'Release'))
-  - script: |
-      powershell "Get-WmiObject Win32_Process -Filter \"name = 'chrome.exe'\" | Format-List CommandLine"
-    displayName: 'Check active Chrome processes (before test)'
-    condition: and(succeeded(), eq(variables['Agent.Diagnostic'], 'true'))
-  - script: |
-      mkdir $(Agent.TempDirectory)\web\test\07
-      dir $(Agent.TempDirectory)\web\test\07
-      npm test --webgpu-ep -- -b=webgpu -e=chrome --user-data-dir=$(Agent.TempDirectory)\web\test\07 --chromium-flags=--enable-logging --chromium-flags=--v=1
-    workingDirectory: '$(Build.SourcesDirectory)\js\web'
-    displayName: 'Run ort-web tests - WebAssembly: proxy'
-    condition: and(succeeded(), eq('${{ parameters.BuildConfig }}', 'Release'))
+
+  # === Start of experimental WebGPU EP tests ===
+
+  - ${{ if eq(parameters.RunWebGpuTests, true) }}:
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        patterns: '${{ parameters.BuildConfig }}_wasm_webgpu/**/*'
+        path: $(Pipeline.Workspace)\artifacts_wasm_webgpu
+      displayName: 'Download WebAssembly artifacts'
+    - task: CopyFiles@2
+      inputs:
+        sourceFolder: $(Pipeline.Workspace)\artifacts_wasm_webgpu
+        contents: |
+          **\ort-*.wasm
+        targetFolder: $(Build.SourcesDirectory)\js\web\dist
+        flattenFolders: true
+      displayName: 'Binplace dist files (.wasm)'
+    - task: CopyFiles@2
+      inputs:
+        sourceFolder: $(Pipeline.Workspace)\artifacts_wasm_webgpu
+        contents: |
+          **\ort-*.mjs
+        targetFolder: $(Build.SourcesDirectory)\js\web\dist
+        flattenFolders: true
+      displayName: 'Binplace dist files (.mjs)'
+    - script: |
+        powershell "Get-WmiObject Win32_Process -Filter \"name = 'chrome.exe'\" | Format-List CommandLine"
+      displayName: 'Check active Chrome processes (before test)'
+      condition: and(succeeded(), eq(variables['Agent.Diagnostic'], 'true'))
+    - script: |
+        mkdir $(Agent.TempDirectory)\web\test\07
+        dir $(Agent.TempDirectory)\web\test\07
+        npm test --webgpu-ep -- -b=webgpu -e=chrome --user-data-dir=$(Agent.TempDirectory)\web\test\07 --chromium-flags=--enable-logging --chromium-flags=--v=1
+      workingDirectory: '$(Build.SourcesDirectory)\js\web'
+      displayName: 'Run ort-web tests - WebGPU EP'
+      continueOnError: true # we allow WebGPU EP tests to fail for now
+
+  # === End of experimental WebGPU EP tests ===
+
   - script: |
       npm run test:e2e -- --browser=Chrome_default
     workingDirectory: '$(Build.SourcesDirectory)\js\web'
@@ -267,12 +295,13 @@ jobs:
       displayName: 'Publish Pipeline Artifact'
       condition: and(succeeded(), eq('${{ parameters.BuildConfig }}', 'Release'))
   - script: |
-      if exist 01 (echo ------------------- BEGIN 01 -------------------&&type 01\chrome_debug.log&&echo ------------------- END 01 ------------------- )
-      if exist 02 (echo ------------------- BEGIN 02 -------------------&&type 02\chrome_debug.log&&echo ------------------- END 02 ------------------- )
-      if exist 03 (echo ------------------- BEGIN 03 -------------------&&type 03\chrome_debug.log&&echo ------------------- END 03 ------------------- )
-      if exist 04 (echo ------------------- BEGIN 04 -------------------&&type 04\chrome_debug.log&&echo ------------------- END 04 ------------------- )
-      if exist 05 (echo ------------------- BEGIN 05 -------------------&&type 05\chrome_debug.log&&echo ------------------- END 05 ------------------- )
-      if exist 06 (echo ------------------- BEGIN 06 -------------------&&type 06\chrome_debug.log&&echo ------------------- END 06 ------------------- )
+      for %%i in (01 02 03 04 05 06 07) do (
+        if exist %%i (
+          echo ------------------- BEGIN %%i -------------------
+          type %%i\chrome_debug.log
+          echo ------------------- END %%i -------------------
+        )
+      )
     displayName: 'Log Chrome processes (after test)'
     workingDirectory: '$(Agent.TempDirectory)\web\test'
     condition: always()

--- a/tools/ci_build/github/azure-pipelines/templates/win-web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-web-ci.yml
@@ -255,7 +255,7 @@ jobs:
     - script: |
         mkdir $(Agent.TempDirectory)\web\test\07
         dir $(Agent.TempDirectory)\web\test\07
-        npm test --webgpu-ep -- -b=webgpu -e=chrome --user-data-dir=$(Agent.TempDirectory)\web\test\07 --chromium-flags=--enable-logging --chromium-flags=--v=1
+        npm test --webgpu-ep -- -b=webgpu -e=chrome $(webgpuCommandlineExtraFlags) --user-data-dir=$(Agent.TempDirectory)\web\test\07 --chromium-flags=--enable-logging --chromium-flags=--v=1
       workingDirectory: '$(Build.SourcesDirectory)\js\web'
       displayName: 'Run ort-web tests - WebGPU EP'
       continueOnError: true # we allow WebGPU EP tests to fail for now


### PR DESCRIPTION
### Description

This PR enables web tests (NPM suite tests) for WebGPU EP.

There are some test failures expected, so the specific job is marked as "continueOnError".

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


