### PR TITLE
[webgpu EP] put GetMaxComponents and SumVector to one place.

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/bert/bias_add.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/bias_add.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "core/providers/webgpu/shader_helper.h"
+#include "core/providers/webgpu/webgpu_utils.h"
 #include "core/providers/webgpu/webgpu_supported_types.h"
 #include "contrib_ops/webgpu/bert/bias_add.h"
 #include "contrib_ops/webgpu/webgpu_contrib_kernels.h"
@@ -32,15 +33,6 @@ Status BiasAddProgram::GenerateShaderCode(ShaderHelper& shader) const {
                             << output.SetByOffset("global_idx", "value");
 
   return Status::OK();
-}
-
-static int64_t GetMaxComponents(int64_t size) {
-  if (size % 4 == 0) {
-    return 4;
-  } else if (size % 2 == 0) {
-    return 2;
-  }
-  return 1;
 }
 
 Status BiasAdd::ComputeInternal(onnxruntime::webgpu::ComputeContext& context) const {

--- a/onnxruntime/contrib_ops/webgpu/bert/skip_layer_norm.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/skip_layer_norm.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "core/providers/webgpu/shader_helper.h"
+#include "core/providers/webgpu/webgpu_utils.h"
 #include "core/providers/webgpu/webgpu_supported_types.h"
 #include "contrib_ops/webgpu/webgpu_contrib_kernels.h"
 #include "contrib_ops/webgpu/bert/skip_layer_norm.h"
@@ -9,28 +10,6 @@
 namespace onnxruntime {
 namespace contrib {
 namespace webgpu {
-
-static uint32_t GetMaxComponents(int size) {
-  if (size % 4 == 0) {
-    return 4;
-  } else if (size % 2 == 0) {
-    return 2;
-  }
-  return 1;
-}
-
-static std::string SumVector(std::string x, int components) {
-  switch (components) {
-    case 1:
-      return x;
-    case 2:
-      return "(" + x + ".x + " + x + ".y" + ")";
-    case 4:
-      return "(" + x + ".x + " + x + ".y + " + x + ".w + " + x + ".z" + ")";
-    default:
-      ORT_THROW("Unsupported number of components: ", components);
-  }
-}
 
 Status SkipLayerNormProgram::GenerateShaderCode(ShaderHelper& shader) const {
   const auto& x = shader.AddInput("x", ShaderUsage::UseUniform | ShaderUsage::UseValueTypeAlias);

--- a/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.cc
@@ -10,23 +10,13 @@
 #include "core/providers/cpu/math/matmul_helper.h"
 #include "core/providers/webgpu/shader_helper.h"
 #include "core/providers/webgpu/webgpu_supported_types.h"
+#include "core/providers/webgpu/webgpu_utils.h"
 
 namespace onnxruntime {
 namespace contrib {
 namespace webgpu {
 
 namespace {
-// Put it to a common place?
-uint32_t GetMaxComponents(uint32_t size) {
-  // we cannot use vec3 type since it has alignment of 16 bytes
-  if (size % 4 == 0) {
-    return 4;
-  } else if (size % 2 == 0) {
-    return 2;
-  }
-
-  return 1;
-}
 
 std::string QuantizedDataType(int components) {
   switch (components) {

--- a/onnxruntime/core/providers/webgpu/math/softmax.cc
+++ b/onnxruntime/core/providers/webgpu/math/softmax.cc
@@ -11,6 +11,7 @@
 #include "core/providers/webgpu/shader_variable.h"
 #include "core/providers/webgpu/shader_helper.h"
 #include "core/providers/webgpu/webgpu_supported_types.h"
+#include "core/providers/webgpu/webgpu_utils.h"
 namespace onnxruntime {
 namespace webgpu {
 
@@ -54,28 +55,6 @@ static std::string MaxVector(const std::string& name, int components) {
     default:
       ORT_THROW("Unsupported number of components: ", components);
   }
-}
-
-static std::string SumVector(const std::string& x, int components) {
-  switch (components) {
-    case 1:
-      return x;
-    case 2:
-      return "(" + x + ".x + " + x + ".y" + ")";
-    case 4:
-      return "(" + x + ".x + " + x + ".y + " + x + ".w + " + x + ".z" + ")";
-    default:
-      ORT_THROW("Unsupported number of components: ", components);
-  }
-}
-
-static int GetMaxComponents(int64_t size) {
-  if (size % 4 == 0) {
-    return 4;
-  } else if (size % 2 == 0) {
-    return 2;
-  }
-  return 1;
 }
 
 Status SoftmaxProgram::GenerateShaderCode(ShaderHelper& shader) const {

--- a/onnxruntime/core/providers/webgpu/nn/layer_norm.cc
+++ b/onnxruntime/core/providers/webgpu/nn/layer_norm.cc
@@ -4,19 +4,11 @@
 
 #include "core/providers/webgpu/shader_helper.h"
 #include "core/providers/webgpu/webgpu_supported_types.h"
+#include "core/providers/webgpu/webgpu_utils.h"
 #include "core/providers/webgpu/nn/layer_norm.h"
 
 namespace onnxruntime {
 namespace webgpu {
-
-static int GetMaxComponents(int64_t size) {
-  if (size % 4 == 0) {
-    return 4;
-  } else if (size % 2 == 0) {
-    return 2;
-  }
-  return 1;
-}
 
 static size_t NormalizeAxis(int64_t axis, size_t tensor_rank) {
   int64_t rank = static_cast<int64_t>(tensor_rank);
@@ -24,19 +16,6 @@ static size_t NormalizeAxis(int64_t axis, size_t tensor_rank) {
     ORT_THROW("invalid axis: ", axis);
   }
   return onnxruntime::narrow<size_t>(axis < 0 ? axis + rank : axis);
-}
-
-static std::string SumVector(std::string x, int components) {
-  switch (components) {
-    case 1:
-      return x;
-    case 2:
-      return "(" + x + ".x + " + x + ".y" + ")";
-    case 4:
-      return "(" + x + ".x + " + x + ".y + " + x + ".w + " + x + ".z" + ")";
-    default:
-      ORT_THROW("Unsupported number of components: ", components);
-  }
 }
 
 Status LayerNormProgram::GenerateShaderCode(ShaderHelper& shader) const {

--- a/onnxruntime/core/providers/webgpu/webgpu_utils.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_utils.h
@@ -7,7 +7,7 @@
 namespace onnxruntime {
 namespace webgpu {
 
-inline int64_t GetMaxComponents(int64_t size) {
+inline int GetMaxComponents(int64_t size) {
   if (size % 4 == 0) {
     return 4;
   } else if (size % 2 == 0) {

--- a/onnxruntime/core/providers/webgpu/webgpu_utils.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_utils.h
@@ -16,5 +16,18 @@ inline int64_t GetMaxComponents(int64_t size) {
   return 1;
 }
 
+inline std::string SumVector(std::string x, int components) {
+  switch (components) {
+    case 1:
+      return x;
+    case 2:
+      return "(" + x + ".x + " + x + ".y" + ")";
+    case 4:
+      return "(" + x + ".x + " + x + ".y + " + x + ".z + " + x + ".w" + ")";
+    default:
+      ORT_THROW("Unsupported number of components: ", components);
+  }
+}
+
 }  // namespace webgpu
 }  // namespace onnxruntime


### PR DESCRIPTION
### Description

put `GetMaxComponents` and `SumVector` to one place.

fix a bug in `SumVector`:

```diff
-      return "(" + x + ".x + " + x + ".y + " + x + ".w + " + x + ".z" + ")";
+      return "(" + x + ".x + " + x + ".y + " + x + ".z + " + x + ".w" + ")";
```

