### PR TITLE
Enable tests that pass locally; remove duplicates

### DIFF
--- a/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
+++ b/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
@@ -31,12 +31,10 @@
     "current_failing_tests": [
         "^test_adagrad",
         "^test_adagrad_multiple",
-        "^test_batchnorm_epsilon_old",
         "^test_batchnorm_epsilon_training_mode",
         "^test_batchnorm_example_old",
         "^test_batchnorm_example_training_mode",
         "^test_col2im_pads",  // still one wrong value coming from the backtest example
-        "^test_gathernd_example_int32_batch_dim1",
         "^test_max_int16",
         "^test_max_int8",
         "^test_max_uint16",
@@ -52,8 +50,6 @@
         "^test_pow_types_float32_uint64",
         "^test_gradient_of_add_and_mul",
         "^test_gradient_of_add",
-        "^test_batchnorm_example_training_mode",
-        "^test_batchnorm_epsilon_training_mode",
         "^test_MaxPool2d_stride_padding_dilation_cpu", // result approximation error; need to be updated in ONNX
         "^test_maxunpool_export_with_output_shape", // result mismatch
         "^test_resize_downsample_scales_cubic_align_corners", // results mismatch with onnx tests

--- a/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
+++ b/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
@@ -32,7 +32,6 @@
         "^test_adagrad",
         "^test_adagrad_multiple",
         "^test_batchnorm_epsilon_training_mode",
-        "^test_batchnorm_example_old",
         "^test_batchnorm_example_training_mode",
         "^test_col2im_pads",  // still one wrong value coming from the backtest example
         "^test_max_int16",


### PR DESCRIPTION
There are 2 tests that appear twice in the same list, so I removed the duplicates:
- `^test_batchnorm_example_training_mode`
- `^test_batchnorm_epsilon_training_mode`

The other 3 tests passed locally, so I am enabling them to see if they also pass on the pipelines:
- `test_batchnorm_epsilon_old`
- `test_batchnorm_example_old`
- `test_gathernd_example_int32_batch_dim1`

Sample run:
```
> .\build\Windows\Debug\Debug\onnx_test_runner.exe "C:\work\onnxruntime\build\Windows\Debug\_deps\onnx-src\onnx\backend\test\data\node\test_gathernd_example_int32_batch_dim1"
Load Test Case: gathernd_example_int32_batch_dim1 in C:\work\onnxruntime\build\Windows\Debug\_deps\onnx-src\onnx\backend\test\data\node\test_gathernd_example_int32_batch_dim1
result:
        Models: 1
        Total test cases: 1
                Succeeded: 1
                Not implemented: 0
                Failed: 0
        Stats by Operator type:
                Not implemented(0):
                Failed:
```