### PR TITLE
Fix #24130 by adding an empty dependency group to the code that generates Microsoft.ML.OnnxRuntime.nuspec

### DIFF
--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -268,6 +268,7 @@ def generate_dependencies(xml_text, package_name, version):
             xml_text.append(dml_dependency)
         xml_text.append("</group>")
         if package_name == "Microsoft.ML.OnnxRuntime":
+            xml_text.append('<group targetFramework="native" />')
             # Support net8.0-android
             xml_text.append('<group targetFramework="net8.0-android31.0">')
             xml_text.append('<dependency id="Microsoft.ML.OnnxRuntime.Managed"' + ' version="' + version + '"/>')


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

As detailed in the issue (#24130), the Microsoft.ML.OnnxRuntime nuspec needs an additional dependency group for the `native` TFM, to allow it to be referenced via `PackageReference` in vcxproj projects.

I took a peek at the code after filing the issue, since it seemed like it ought to be a simple fix. It looks like the nuspec file for the `Microsoft.ML.OnnxRuntime` package is generated by the python code in `generate_nuspec_for_native_nuget.py`, so I just added a line of code there.

However I'm not sure how the build system invokes this generator so I haven't been able to test it in situ. Let me know if this isn't the right fix!


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

See detailed description in #24130

