### PR TITLE
Fix attention QK linkage error

### DIFF
--- a/onnxruntime/contrib_ops/cuda/bert/attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_impl.cu
@@ -762,12 +762,8 @@ Status UnfusedAttention(
   } else {  // no mask
     if (nullptr != data.output_qk) {
       int64_t qk_size = (int64_t)batch_size * num_heads * sequence_length * total_sequence_length;
-      if (std::is_same<T, QK>::value) {
-        cudaMemcpyAsync(data.output_qk, data.scratch, qk_size * sizeof(QK), cudaMemcpyDeviceToDevice, stream);
-      } else {
-        ORT_RETURN_IF_ERROR(
-          (CopyQK<T, QK>(stream, static_cast<int>(qk_size), data.scratch, reinterpret_cast<QK*>(data.output_qk))));
-      }
+      ORT_RETURN_IF_ERROR(
+        (CopyQK<T, QK>(stream, static_cast<int>(qk_size), data.scratch, reinterpret_cast<QK*>(data.output_qk))));
     }
     ORT_RETURN_IF_ERROR(
         ComputeSoftmax<T>(

--- a/onnxruntime/contrib_ops/cuda/bert/attention_qk.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_qk.cu
@@ -38,7 +38,7 @@ Status CopyQK(cudaStream_t stream,
               const T* input,
               QK* output) {
   if constexpr (std::is_same<T, QK>::value) {
-    cudaMemcpyAsync(output, input, qk_size * sizeof(QK), cudaMemcpyDeviceToDevice, stream);
+    CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(output, input, qk_size * sizeof(QK), cudaMemcpyDeviceToDevice, stream));
     return Status::OK();
   }
   const bool half2float = std::is_same<T, half>::value && std::is_same<QK, float>::value;

--- a/onnxruntime/contrib_ops/cuda/bert/attention_qk.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_qk.cu
@@ -24,6 +24,14 @@ __global__ void ConvertAndCopyQK(const int count, const half* input, float* outp
   }
 }
 
+template <typename T>
+__global__ void ConvertAndCopyQK(const int count, const T* input, T* output) {
+  int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  if (idx < count) {
+    output[idx] = input[idx];
+  }
+}
+
 template <typename T, typename QK>
 Status CopyQK(cudaStream_t stream,
               const int qk_size,

--- a/onnxruntime/contrib_ops/cuda/bert/attention_qk.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_qk.cu
@@ -29,6 +29,10 @@ Status CopyQK(cudaStream_t stream,
               const int qk_size,
               const T* input,
               QK* output) {
+  if constexpr (std::is_same<T, QK>::value) {
+    cudaMemcpyAsync(output, input, qk_size * sizeof(QK), cudaMemcpyDeviceToDevice, stream);
+    return Status::OK();
+  }
   const bool half2float = std::is_same<T, half>::value && std::is_same<QK, float>::value;
   const bool float2half = std::is_same<T, float>::value && std::is_same<QK, half>::value;
   ORT_ENFORCE(half2float || float2half);
@@ -40,6 +44,11 @@ Status CopyQK(cudaStream_t stream,
   return CUDA_CALL(cudaGetLastError());
 }
 
+template Status CopyQK<float, float>(cudaStream_t stream,
+                                     const int qk_size,
+                                     const float* input,
+                                     float* output);
+
 template Status CopyQK<float, half>(cudaStream_t stream,
                                     const int qk_size,
                                     const float* input,
@@ -49,6 +58,11 @@ template Status CopyQK<half, float>(cudaStream_t stream,
                                     const int qk_size,
                                     const half* input,
                                     float* output);
+
+template Status CopyQK<half, half>(cudaStream_t stream,
+                                   const int qk_size,
+                                   const half* input,
+                                   half* output);
 
 }  // namespace cuda
 }  // namespace contrib


### PR DESCRIPTION
### Description
This PR moves the CUDA memcpy for the QK output when type `T` is equal to type `QK` from `attention_impl.cu` into `attention_qk.cu`.

### Motivation and Context
This PR fixes a linkage error when type `T` and type `QK` are the same in `attention_qk.cu`.


