### PR TITLE
Improve Shape Inference for GQA

### DIFF
--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -314,7 +314,7 @@ void BaseGroupQueryAttentionTypeAndShapeInference(ONNX_NAMESPACE::InferenceConte
         }
       } else if (use_max_past_present_buffer == -1) {
         const auto* total_sequence_length_data = ctx.getInputData(6);
-        if (total_sequence_length_data != nullptr) {
+        if (total_sequence_length_data != nullptr && past_dims[2].has_dim_value()) {
           int64_t total_sequence_length_value = 0;
           const auto& data = ParseData<int32_t>(total_sequence_length_data);
           total_sequence_length_value = static_cast<int64_t>(data[0]);

--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -312,6 +312,29 @@ void BaseGroupQueryAttentionTypeAndShapeInference(ONNX_NAMESPACE::InferenceConte
           updateOutputShape(ctx, 1, present_shape);
           updateOutputShape(ctx, 2, present_shape);
         }
+      } else if (use_max_past_present_buffer == -1) {
+        const auto* total_sequence_length_data = ctx.getInputData(6);
+        if (total_sequence_length_data != nullptr) {
+          int64_t total_sequence_length_value = 0;
+          const auto& data = ParseData<int32_t>(total_sequence_length_data);
+          total_sequence_length_value = static_cast<int64_t>(data[0]);
+
+          // present_sequence_length = max(past_sequence_length, total_sequence_length)
+          int64_t present_sequence_length = total_sequence_length_value > past_dims[2].dim_value()
+                                                ? total_sequence_length_value
+                                                : past_dims[2].dim_value();
+
+          ONNX_NAMESPACE::TensorShapeProto present_shape;
+          for (auto& dim : past_dims) {
+            *present_shape.add_dim() = dim;
+          }
+
+          // shape of present key/value is (batch_size, kv_num_heads, present_sequence_length, head_size)
+          present_shape.mutable_dim(2)->set_dim_value(present_sequence_length);
+
+          updateOutputShape(ctx, 1, present_shape);
+          updateOutputShape(ctx, 2, present_shape);
+        }
       }
     }
   }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
For GroupQueryAttention op, if the input total_sequence_length is a constant, we can infer the shape of output present_key/present_value `(batch_size, kv_num_heads, present_sequence_length, head_size)`.

https://github.com/microsoft/onnxruntime/blob/5ed900e9712ce2f02e40c15b945d18453d1960d8/onnxruntime/contrib_ops/cpu/bert/group_query_attention_helper.h#L185

We know that from CPU EP, `present_sequence_length = max(past_sequence_length, total_sequence_length)`, and `batch_size, kv_num_heads, head_size` are the same as past_key/past_value.

This inference is very important for WebNN EP, because WebNN only supports GQA for `present_sequence_length == past_sequence_length` and requires static shape for graph compilation.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


