### PR TITLE
Update the min GCC version

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -256,16 +256,10 @@ option(onnxruntime_USE_VITISAI_INTERFACE "Build ONNXRuntime shared lib which is 
 option(onnxruntime_USE_QNN_INTERFACE "Build ONNXRuntime shared lib which is compatible with QNN EP interface" OFF)
 
 
-if (onnxruntime_USE_CUDA)
-  # CUDA 11 does not support GCC version >=12. The following code will be removed when all CUDA 11's pipelines are removed.
-  if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 11)
-    message(FATAL_ERROR  "GCC version must be greater than or equal to 11")
-  endif()
-else()
-  if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 12)
-    message(FATAL_ERROR  "GCC version must be greater than or equal to 12")
-  endif()
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 11)
+  message(FATAL_ERROR  "GCC version must be greater than or equal to 11")
 endif()
+
 # ENABLE_TRAINING includes all training functionality
 # The following 2 entry points
 # 1. ORTModule

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -256,8 +256,8 @@ option(onnxruntime_USE_VITISAI_INTERFACE "Build ONNXRuntime shared lib which is 
 option(onnxruntime_USE_QNN_INTERFACE "Build ONNXRuntime shared lib which is compatible with QNN EP interface" OFF)
 
 
-if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 11)
-  message(FATAL_ERROR  "GCC version must be greater than or equal to 11")
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 11.1)
+  message(FATAL_ERROR  "GCC version must be greater than or equal to 11.1")
 endif()
 
 # ENABLE_TRAINING includes all training functionality

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -55,10 +55,6 @@ if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Choose build type: Debug Release RelWithDebInfo MinSizeRel." FORCE)
 endif()
 
-if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 9)
-  message(FATAL_ERROR  "GCC version must be greater than or equal to 9")
-endif()
-
 # Options
 option(onnxruntime_USE_VCPKG "Build with the vcpkg package manager" OFF)
 option(onnxruntime_RUN_ONNX_TESTS "Enable ONNX Compatibility Testing" OFF)
@@ -259,6 +255,17 @@ option(onnxruntime_USE_OPENVINO_INTERFACE "Build ONNXRuntime shared lib which is
 option(onnxruntime_USE_VITISAI_INTERFACE "Build ONNXRuntime shared lib which is compatible with Vitis-AI EP interface" OFF)
 option(onnxruntime_USE_QNN_INTERFACE "Build ONNXRuntime shared lib which is compatible with QNN EP interface" OFF)
 
+
+if (onnxruntime_USE_CUDA)
+  # CUDA 11 does not support GCC version >=12. The following code will be removed when all CUDA 11's pipelines are removed.
+  if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 11)
+    message(FATAL_ERROR  "GCC version must be greater than or equal to 11")
+  endif()
+else()
+  if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 12)
+    message(FATAL_ERROR  "GCC version must be greater than or equal to 12")
+  endif()
+endif()
 # ENABLE_TRAINING includes all training functionality
 # The following 2 entry points
 # 1. ORTModule


### PR DESCRIPTION
### Description
Update the min supported GCC version to 11.1. 


### Motivation and Context
In order to utilize new CPU instructions, we need to use new compilers. For example, our MLAS code needs bfloat16 support for arm, which requires GCC version >=10.  And some other code requires GCC version >=11.1. 
Also, our CI pipelines only tests the code with GCC 11,12 and 14. Therefore this PR increase the min GCC version to 11.1.  Will update it to 12 once we deprecate CUDA 11 pipelines



