### PR TITLE
Proper Error Message when fp16 model is used for Beam Search in CPU

### DIFF
--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search.cc
@@ -68,7 +68,9 @@ REGISTER_KERNEL_TYPED(float)
 
 namespace transformers {
 
-constexpr const char* kBeamSearchNotSupportFp16InCpu = "BeamSearch does not support float16 model on CPU execution provider. Use float32 model or CUDA execution provider instead.";
+constexpr const char* kBeamSearchNotSupportFp16InCpu =
+    "BeamSearch does not support float16 model on CPU execution provider. "
+    "Use float32 model or CUDA execution provider instead.";
 
 void BeamSearch::Init(const OpKernelInfo& info) {
   parameters_->ParseFromAttributes(info);

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search.cc
@@ -68,6 +68,8 @@ REGISTER_KERNEL_TYPED(float)
 
 namespace transformers {
 
+constexpr const char* kBeamSearchNotSupportFp16InCpu = "BeamSearch does not support float16 model on CPU execution provider. Use float32 model or CUDA execution provider instead.";
+
 void BeamSearch::Init(const OpKernelInfo& info) {
   parameters_->ParseFromAttributes(info);
 
@@ -215,6 +217,8 @@ Status BeamSearch::Compute(OpKernelContext* ctx) const {
   // Make a copy of parameters since we will update it based on inputs later
   BeamSearchParameters parameters = *parameters_;
 
+  const bool is_cpu_provider = ctx->GetComputeStream() == nullptr;
+
   if (parameters.model_type == IGenerationParameters::kModelTypeGpt) {
     if (!gpt_subgraph_->IsOutputFloat16()) {  // Output float32
       BeamSearchGpt<float> impl{
@@ -240,6 +244,10 @@ Status BeamSearch::Compute(OpKernelContext* ctx) const {
 
       return impl.Execute(init_run_decoder_feeds_fetches_manager_, *decoder_feeds_fetches_manager_);
     } else {  // Output float16
+      if (is_cpu_provider) {
+        ORT_THROW(kBeamSearchNotSupportFp16InCpu);
+      }
+
       BeamSearchGpt<MLFloat16> impl{
           *ctx_internal,
           has_init_decoder_ ? init_run_decoder_session_state : nullptr,
@@ -256,6 +264,7 @@ Status BeamSearch::Compute(OpKernelContext* ctx) const {
           device_copy_int32_func_,
           update_gpt_feeds_fp16_func_,
           create_beam_scorer_func_};
+
 #ifdef USE_CUDA
       ORT_RETURN_IF_ERROR(impl.InitializeCuda(reorder_past_state_func_, cuda_device_prop_, cuda_device_arch_));
 #endif
@@ -294,6 +303,10 @@ Status BeamSearch::Compute(OpKernelContext* ctx) const {
 
       return impl.Execute(*encoder_feeds_fetches_manager_, *decoder_feeds_fetches_manager_);
     } else {
+      if (is_cpu_provider) {
+        ORT_THROW(kBeamSearchNotSupportFp16InCpu);
+      }
+
       BeamSearchT5<MLFloat16> impl{
           *ctx_internal, *encoder_session_state, *decoder_session_state, *t5_encoder_subgraph_,
           *t5_decoder_subgraph_, thread_pool, ctx->GetComputeStream(), dumper_, parameters,
@@ -309,6 +322,7 @@ Status BeamSearch::Compute(OpKernelContext* ctx) const {
           expand_buffer_float_func_,
           expand_buffer_float16_func_,
           create_beam_scorer_func_};
+
 #ifdef USE_CUDA
       ORT_RETURN_IF_ERROR(impl.InitializeCuda(reorder_past_state_func_, init_cache_indir_func_, cuda_device_prop_, cuda_device_arch_));
 #endif
@@ -346,6 +360,10 @@ Status BeamSearch::Compute(OpKernelContext* ctx) const {
 
       return impl.Execute(*encoder_feeds_fetches_manager_, *decoder_feeds_fetches_manager_);
     } else {
+      if (is_cpu_provider) {
+        ORT_THROW(kBeamSearchNotSupportFp16InCpu);
+      }
+
       BeamSearchWhisper<MLFloat16> impl{
           *ctx_internal, *encoder_session_state, *decoder_session_state, *whisper_encoder_subgraph_,
           *whisper_decoder_subgraph_, thread_pool, ctx->GetComputeStream(), dumper_, parameters,


### PR DESCRIPTION
### Description
Show proper error message when fp16 model is used for Beam Search in CPU.

Before:
```
2025-02-15 20:15:02.999160115 [E:onnxruntime:, sequential_executor.cc:516 ExecuteKernel] Non-zero status code returned while running BeamSearch node. Name:'beam_search' Status Message: bad_function_call
```

After:
```
onnxruntime.capi.onnxruntime_pybind11_state.RuntimeException: [ONNXRuntimeError] : 6 : RUNTIME_EXCEPTION : Non-zero status code returned while running BeamSearch node. Name:'beam_search' Status Message: onnxruntime/onnxruntime/contrib_ops/cpu/transformers/beam_search.cc:309 virtual onnxruntime::common::Status onnxruntime::contrib::transformers::BeamSearch::Compute(onnxruntime::OpKernelContext*) const BeamSearch does not support float16 model on CPU execution provider. Use float32 model or CUDA execution provider instead.
```

### Motivation and Context
https://github.com/microsoft/onnxruntime/issues/23728

