### PR TITLE
Change type len from int to size_t

### DIFF
--- a/onnxruntime/core/framework/model_metadef_id_generator.cc
+++ b/onnxruntime/core/framework/model_metadef_id_generator.cc
@@ -28,7 +28,7 @@ int ModelMetadefIdGenerator::GenerateId(const onnxruntime::GraphViewer& graph_vi
   // hash the bytes in the Graph instance. we can't just use the address as a new Graph instance may use
   // the same memory (unit tests prove this can occur). the raw bytes of the Graph instance should be a unique
   // fingerprint for the instance that can use used as the key to the hash of the model path/contents.
-  MurmurHash3::x86_128(&main_graph, gsl::narrow_cast<int32_t>(sizeof(Graph)), instance_hash[0], &instance_hash);
+  MurmurHash3::x86_128(&main_graph, sizeof(Graph), instance_hash[0], &instance_hash);
   HashValue graph_instance_hash = instance_hash[0] | (uint64_t(instance_hash[1]) << 32);
 
   // if we've already hashed this main graph instance use the cached value
@@ -42,10 +42,10 @@ int ModelMetadefIdGenerator::GenerateId(const onnxruntime::GraphViewer& graph_vi
     // this may not be available if the model was loaded from a stream or in-memory bytes
     const auto model_path_str = main_graph.ModelPath().string();
     if (!model_path_str.empty()) {
-      MurmurHash3::x86_128(model_path_str.data(), gsl::narrow_cast<int32_t>(model_path_str.size()), hash[0], &hash);
+      MurmurHash3::x86_128(model_path_str.data(), model_path_str.size(), hash[0], &hash);
     } else {
       auto hash_str = [&hash](const std::string& str) {
-        MurmurHash3::x86_128(str.data(), gsl::narrow_cast<int32_t>(str.size()), hash[0], &hash);
+        MurmurHash3::x86_128(str.data(), str.size(), hash[0], &hash);
       };
 
       // fingerprint the main graph by hashing graph inputs and the ordered outputs from each node

--- a/onnxruntime/core/framework/murmurhash3.cc
+++ b/onnxruntime/core/framework/murmurhash3.cc
@@ -59,7 +59,7 @@ inline uint64_t rotl64(uint64_t x, int8_t r) {
 //
 // Changes to support big-endian from https://github.com/explosion/murmurhash/pull/27/
 // were manually applied to original murmurhash3 source code.
-ORT_FORCEINLINE uint32_t getblock32(const uint32_t* p, int i) {
+ORT_FORCEINLINE uint32_t getblock32(const uint32_t* p, ptrdiff_t i) {
   if constexpr (onnxruntime::endian::native == onnxruntime::endian::little) {
     return p[i];
   } else {
@@ -71,7 +71,7 @@ ORT_FORCEINLINE uint32_t getblock32(const uint32_t* p, int i) {
   }
 }
 
-ORT_FORCEINLINE uint64_t getblock64(const uint64_t* p, int i) {
+ORT_FORCEINLINE uint64_t getblock64(const uint64_t* p, ptrdiff_t i) {
   if constexpr (onnxruntime::endian::native == onnxruntime::endian::little) {
     return p[i];
   } else {
@@ -115,10 +115,10 @@ ORT_FORCEINLINE constexpr uint64_t fmix64(uint64_t k) {
 //-----------------------------------------------------------------------------
 
 namespace onnxruntime {
-void MurmurHash3::x86_32(const void* key, int len,
+void MurmurHash3::x86_32(const void* key, size_t len,
                          uint32_t seed, void* out) {
   const uint8_t* data = (const uint8_t*)key;
-  const int nblocks = len / 4;
+  const auto nblocks = static_cast<ptrdiff_t>(len / 4U);
 
   uint32_t h1 = seed;
 
@@ -128,9 +128,9 @@ void MurmurHash3::x86_32(const void* key, int len,
   //----------
   // body
 
-  const uint32_t* blocks = (const uint32_t*)(data + static_cast<ptrdiff_t>(nblocks) * 4);
+  const uint32_t* blocks = (const uint32_t*)(data + nblocks * 4);
 
-  for (int i = -nblocks; i; i++) {
+  for (auto i = -nblocks; i; i++) {
     uint32_t k1 = getblock32(blocks, i);
 
     k1 *= c1;
@@ -145,7 +145,7 @@ void MurmurHash3::x86_32(const void* key, int len,
   //----------
   // tail
 
-  const uint8_t* tail = (const uint8_t*)(data + static_cast<ptrdiff_t>(nblocks) * 4);
+  const uint8_t* tail = (const uint8_t*)(data + nblocks * 4);
 
   uint32_t k1 = 0;
 
@@ -176,9 +176,9 @@ void MurmurHash3::x86_32(const void* key, int len,
 
 //-----------------------------------------------------------------------------
 
-void MurmurHash3::x86_128(const void* key, int len, uint32_t seed, void* out) {
+void MurmurHash3::x86_128(const void* key, size_t len, uint32_t seed, void* out) {
   const uint8_t* data = (const uint8_t*)key;
-  const int nblocks = len / 16;
+  const auto nblocks = static_cast<ptrdiff_t>(len / 16U);
 
   uint32_t h1 = seed;
   uint32_t h2 = seed;
@@ -193,9 +193,9 @@ void MurmurHash3::x86_128(const void* key, int len, uint32_t seed, void* out) {
   //----------
   // body
 
-  const uint32_t* blocks = (const uint32_t*)(data + static_cast<ptrdiff_t>(nblocks) * 16);
+  const uint32_t* blocks = (const uint32_t*)(data + nblocks * 16);
 
-  for (int i = -nblocks; i; i++) {
+  for (auto i = -nblocks; i; i++) {
     uint32_t k1 = getblock32(blocks, i * 4 + 0);
     uint32_t k2 = getblock32(blocks, i * 4 + 1);
     uint32_t k3 = getblock32(blocks, i * 4 + 2);
@@ -241,7 +241,7 @@ void MurmurHash3::x86_128(const void* key, int len, uint32_t seed, void* out) {
   //----------
   // tail
 
-  const uint8_t* tail = (const uint8_t*)(data + static_cast<ptrdiff_t>(nblocks) * 16);
+  const uint8_t* tail = (const uint8_t*)(data + nblocks * 16);
 
   uint32_t k1 = 0;
   uint32_t k2 = 0;

--- a/onnxruntime/core/framework/murmurhash3.h
+++ b/onnxruntime/core/framework/murmurhash3.h
@@ -4,13 +4,14 @@
 #pragma once
 
 #include <cstdint>
+#include <cstddef>
 
 namespace onnxruntime {
 struct MurmurHash3 {
   // generate 32-bit hash from input and write to 'out'
-  static void x86_32(const void* key, int len, uint32_t seed, void* out);
+  static void x86_32(const void* key, size_t len, uint32_t seed, void* out);
 
   // generate 128-bit hash from input and write to 'out'.
-  static void x86_128(const void* key, int len, uint32_t seed, void* out);
+  static void x86_128(const void* key, size_t len, uint32_t seed, void* out);
 };
 }  // namespace onnxruntime

--- a/onnxruntime/core/framework/prepacked_weights.cc
+++ b/onnxruntime/core/framework/prepacked_weights.cc
@@ -11,14 +11,14 @@ HashValue PrePackedWeights::GetHash() const {
 
   uint32_t hash[4] = {0, 0, 0, 0};
 
-  auto hash_int8_t_buffer = [&hash](void* data, int len) { MurmurHash3::x86_128(data, len, hash[0], &hash); };
+  auto hash_int8_t_buffer = [&hash](void* data, size_t len) { MurmurHash3::x86_128(data, len, hash[0], &hash); };
 
   ORT_ENFORCE(buffers_.size() == buffer_sizes_.size());
   for (size_t iter = 0; iter < buffers_.size(); ++iter) {
     // some pre-packed buffers may be null if they were just "place-holders" occupying an index
     // in the "buffers_" vector
     if (buffers_[iter].get() != nullptr) {
-      hash_int8_t_buffer(buffers_[iter].get(), static_cast<int>(buffer_sizes_[iter]));
+      hash_int8_t_buffer(buffers_[iter].get(), buffer_sizes_[iter]);
     }
   }
 

--- a/onnxruntime/core/framework/resource_accountant.cc
+++ b/onnxruntime/core/framework/resource_accountant.cc
@@ -204,7 +204,7 @@ std::string IResourceAccountant::MakeUniqueNodeName(const Node& node) {
 
   uint32_t hash[4] = {0, 0, 0, 0};
   auto hash_str = [&hash](const std::string& str) {
-    MurmurHash3::x86_128(str.data(), narrow<int32_t>(str.size()), hash[0], &hash);
+    MurmurHash3::x86_128(str.data(), str.size(), hash[0], &hash);
   };
 
   const auto& node_name = (node.Name().empty()) ? node.OpType() : node.Name();

--- a/onnxruntime/core/providers/cann/cann_utils.cc
+++ b/onnxruntime/core/providers/cann/cann_utils.cc
@@ -220,7 +220,7 @@ bool FileExist(const std::string& file_name) {
 
 void GenerateHashValue(const std::string string, HashValue& hash_value) {
   uint32_t hash[4] = {0, 0, 0, 0};
-  MurmurHash3::x86_128(string.data(), gsl::narrow_cast<int32_t>(string.size()), hash[0], &hash);
+  MurmurHash3::x86_128(string.data(), string.size(), hash[0], &hash);
   hash_value = hash[0] | (uint64_t(hash[1]) << 32);
 }
 

--- a/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
+++ b/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
@@ -775,7 +775,7 @@ std::unique_ptr<Model> CreateModel(const GraphViewer& graph_viewer, const loggin
 }  // namespace cann
 #endif
 
-void MurmurHash3::x86_128(const void* key, int len, uint32_t seed, void* out) {
+void MurmurHash3::x86_128(const void* key, size_t len, uint32_t seed, void* out) {
   return g_host->MurmurHash3__x86_128(key, len, seed, out);
 }
 

--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -1288,7 +1288,7 @@ struct ProviderHost {
   virtual std::unique_ptr<Model> cann__CreateModel(const GraphViewer& graph_viewer, const logging::Logger& logger) = 0;
 #endif
 
-  virtual void MurmurHash3__x86_128(const void* key, int len, uint32_t seed, void* out) = 0;
+  virtual void MurmurHash3__x86_128(const void* key, size_t len, uint32_t seed, void* out) = 0;
 
 #ifdef _WIN32
   virtual std::string ToUTF8String(const std::wstring& s) = 0;

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_helper.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_helper.cc
@@ -15,7 +15,7 @@ std::string GetUniqueGraphName(const Graph& graph) {
   uint32_t hash[4] = {0, 0, 0, 0};
 
   auto hash_str = [&hash](const std::string& str) {
-    MurmurHash3::x86_128(str.data(), gsl::narrow_cast<int32_t>(str.size()), hash[0], &hash);
+    MurmurHash3::x86_128(str.data(), str.size(), hash[0], &hash);
   };
 
   // Hash all nodes' name

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_utils.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_utils.h
@@ -533,7 +533,7 @@ HashValue TRTGenerateId(const GraphViewer& graph_viewer, std::string trt_version
   uint32_t hash[4] = {0, 0, 0, 0};
 
   auto hash_str = [&hash](const std::string& str) {
-    MurmurHash3::x86_128(str.data(), gsl::narrow_cast<int32_t>(str.size()), hash[0], &hash);
+    MurmurHash3::x86_128(str.data(), str.size(), hash[0], &hash);
   };
 
   // Use the model's file name instead of the entire path to avoid cache regeneration if path changes

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -1636,7 +1636,7 @@ struct ProviderHostImpl : ProviderHost {
   }
 #endif
 
-  void MurmurHash3__x86_128(const void* key, int len, uint32_t seed, void* out) override {
+  void MurmurHash3__x86_128(const void* key, size_t len, uint32_t seed, void* out) override {
     MurmurHash3::x86_128(key, len, seed, out);
   }
 


### PR DESCRIPTION
### Description
As titled.



### Motivation and Context
We have the last MatMul in phi-4-mini onnx which is b_shape = {3072, 200064} 
packed_b_size = MlasGemmPackBSize(N, K);
 it is 3072*200064*sizeof(float)=2458386432
This is larger than 2,147,483,647, it is out of the int boundary on a 32-bit system. Then len is negative.
So we change the type to size_t, and the model can be loaded successfully after the change.


