### PR TITLE
[QNN EP] ARM64EC python package remove --vcpkg in build

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/py-win-arm64ec-qnn.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-win-arm64ec-qnn.yml
@@ -91,7 +91,7 @@ jobs:
         --use_qnn
         --qnn_home $(QnnSDKRootDir)
         --enable_pybind
-        --parallel --use_vcpkg --use_vcpkg_ms_internal_asset_cache --update --arm64ec
+        --parallel --update --arm64ec
         $(TelemetryOption) ${{ parameters.BUILD_PY_PARAMETERS }}
       workingDirectory: '$(Build.BinariesDirectory)'
 


### PR DESCRIPTION
--use_vcpkg option seems to be causing problems for --arm64ec python packages (onnxruntime-qnn)
session creation crashes for packages built with --use_vcpkg.
the released onnxruntime-qnn 1.21.0 python wheel for x64 (arm64ec) has this issue. 
removing --use_vcpkg while the issue is debugged in parallel. 
we plan to release a 1.21.1 onnxruntime-qnn x64 python wheel without --use_vcpkg to address the crash. 

https://github.com/microsoft/onnxruntime/issues/24082
