### PR TITLE
Fuse Initializers Graph Transform

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.shared.cs
@@ -17,6 +17,7 @@ namespace Microsoft.ML.OnnxRuntime
         ORT_DISABLE_ALL = 0,
         ORT_ENABLE_BASIC = 1,
         ORT_ENABLE_EXTENDED = 2,
+        ORT_ENABLE_LAYOUT = 3,
         ORT_ENABLE_ALL = 99
     }
 

--- a/include/onnxruntime/core/optimizer/graph_transformer_level.h
+++ b/include/onnxruntime/core/optimizer/graph_transformer_level.h
@@ -12,8 +12,9 @@ enum class TransformerLevel : int {
   Level1,       // basic optimizations
   Level2,       // extended optimizations
   Level3,       // layout optimizations
+  Level4,       // unsupported datatypes optimizations
   // The max level should always be same as the last level.
-  MaxLevel = Level3
+  MaxLevel = Level4
 };
 
 }  // namespace onnxruntime

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -348,6 +348,7 @@ typedef enum GraphOptimizationLevel {
   ORT_DISABLE_ALL = 0,
   ORT_ENABLE_BASIC = 1,
   ORT_ENABLE_EXTENDED = 2,
+  ORT_ENABLE_LAYOUT = 3,
   ORT_ENABLE_ALL = 99
 } GraphOptimizationLevel;
 

--- a/java/src/main/java/ai/onnxruntime/OrtSession.java
+++ b/java/src/main/java/ai/onnxruntime/OrtSession.java
@@ -652,6 +652,11 @@ public class OrtSession implements AutoCloseable {
        * graph.
        */
       EXTENDED_OPT(2),
+      /**
+       * Applies all the layout optimizations like NCHW and NCHWC to the ONNX
+       * graph.
+       */
+      LAYOUT_OPT(3),
       /** Applies all available optimizations to the ONNX graph. */
       ALL_OPT(99);
 

--- a/java/src/main/native/OrtJniUtil.c
+++ b/java/src/main/native/OrtJniUtil.c
@@ -47,6 +47,8 @@ GraphOptimizationLevel convertOptimizationLevel(jint level) {
             return ORT_ENABLE_BASIC;
         case 2:
             return ORT_ENABLE_EXTENDED;
+        case 3:
+            return ORT_ENABLE_LAYOUT;
         case 99:
             return ORT_ENABLE_ALL;
         default:

--- a/js/common/lib/inference-session.ts
+++ b/js/common/lib/inference-session.ts
@@ -81,7 +81,7 @@ export declare namespace InferenceSession {
      *
      * This setting is available only in ONNXRuntime (Node.js binding and react-native) or WebAssembly backend
      */
-    graphOptimizationLevel?: 'disabled' | 'basic' | 'extended' | 'all';
+    graphOptimizationLevel?: 'disabled' | 'basic' | 'extended' | 'layout' | 'all';
 
     /**
      * Whether enable CPU memory arena.

--- a/js/node/src/session_options_helper.cc
+++ b/js/node/src/session_options_helper.cc
@@ -31,6 +31,7 @@ const std::unordered_map<std::string, GraphOptimizationLevel> GRAPH_OPT_LEVEL_NA
     {"disabled", ORT_DISABLE_ALL},
     {"basic", ORT_ENABLE_BASIC},
     {"extended", ORT_ENABLE_EXTENDED},
+    {"layout", ORT_ENABLE_LAYOUT},
     {"all", ORT_ENABLE_ALL}};
 
 const std::unordered_map<std::string, ExecutionMode> EXECUTION_MODE_NAME_TO_ID_MAP = {{"sequential", ORT_SEQUENTIAL},

--- a/js/react_native/android/src/main/java/ai/onnxruntime/reactnative/OnnxruntimeModule.java
+++ b/js/react_native/android/src/main/java/ai/onnxruntime/reactnative/OnnxruntimeModule.java
@@ -326,6 +326,7 @@ public class OnnxruntimeModule extends ReactContextBaseJavaModule implements Lif
               {"disabled", SessionOptions.OptLevel.NO_OPT},
               {"basic", SessionOptions.OptLevel.BASIC_OPT},
               {"extended", SessionOptions.OptLevel.EXTENDED_OPT},
+              {"layout", SessionOptions.OptLevel.LAYOUT_OPT},
               {"all", SessionOptions.OptLevel.ALL_OPT},
           })
           .collect(Collectors.toMap(p -> (String)p[0], p -> (SessionOptions.OptLevel)p[1]));

--- a/js/react_native/ios/OnnxruntimeModule.mm
+++ b/js/react_native/ios/OnnxruntimeModule.mm
@@ -301,6 +301,7 @@ static NSDictionary* graphOptimizationLevelTable = @{
   @"disabled" : @(ORT_DISABLE_ALL),
   @"basic" : @(ORT_ENABLE_BASIC),
   @"extended" : @(ORT_ENABLE_EXTENDED),
+  @"layout" : @(ORT_ENABLE_LAYOUT),
   @"all" : @(ORT_ENABLE_ALL)
 };
 

--- a/js/web/lib/wasm/session-options.ts
+++ b/js/web/lib/wasm/session-options.ts
@@ -14,6 +14,8 @@ const getGraphOptimzationLevel = (graphOptimizationLevel: string | unknown): num
       return 1;
     case 'extended':
       return 2;
+    case 'layout':
+      return 3;
     case 'all':
       return 99;
     default:

--- a/js/web/script/test-runner-cli-args.ts
+++ b/js/web/script/test-runner-cli-args.ts
@@ -58,7 +58,7 @@ Options:
 *** Session Options ***
  -u=<...>, --optimized-model-file-path=<...>        Specify whether to dump the optimized model.
  -o=<...>, --graph-optimization-level=<...>         Specify graph optimization level.
-                                                      Default is 'all'. Valid values are 'disabled', 'basic', 'extended', 'all'.
+                                                      Default is 'all'. Valid values are 'disabled', 'basic', 'extended', 'layout', 'all'.
  -i=<...>, --io-binding=<...>  Specify the IO binding testing type. Should be one of the following:
                                  none            (default)
                                  gpu-tensor      use pre-allocated GPU tensors for inputs and outputs
@@ -195,7 +195,7 @@ export interface TestRunnerCliArgs {
   /**
    * Specify graph optimization level
    */
-  graphOptimizationLevel: 'disabled' | 'basic' | 'extended' | 'all';
+  graphOptimizationLevel: 'disabled' | 'basic' | 'extended' | 'layout' | 'all';
 
   cpuOptions?: InferenceSession.CpuExecutionProviderOption;
   cudaOptions?: InferenceSession.CudaExecutionProviderOption;
@@ -480,7 +480,7 @@ export function parseTestRunnerCliArgs(cmdlineArgs: string[]): TestRunnerCliArgs
   const graphOptimizationLevel = args['graph-optimization-level'] || args.o || 'all';
   if (
     typeof graphOptimizationLevel !== 'string' ||
-    ['disabled', 'basic', 'extended', 'all'].indexOf(graphOptimizationLevel) === -1
+    ['disabled', 'basic', 'extended', 'layout', 'all'].indexOf(graphOptimizationLevel) === -1
   ) {
     throw new Error(`graph optimization level is invalid: ${graphOptimizationLevel}`);
   }

--- a/objectivec/include/ort_enums.h
+++ b/objectivec/include/ort_enums.h
@@ -50,6 +50,7 @@ typedef NS_ENUM(int32_t, ORTGraphOptimizationLevel) {
   ORTGraphOptimizationLevelNone,
   ORTGraphOptimizationLevelBasic,
   ORTGraphOptimizationLevelExtended,
+  ORTGraphOptimizationLevelLayout,
   ORTGraphOptimizationLevelAll,
 };
 

--- a/objectivec/ort_enums.mm
+++ b/objectivec/ort_enums.mm
@@ -68,6 +68,7 @@ constexpr GraphOptimizationLevelInfo kGraphOptimizationLevelInfos[]{
     {ORTGraphOptimizationLevelNone, ORT_DISABLE_ALL},
     {ORTGraphOptimizationLevelBasic, ORT_ENABLE_BASIC},
     {ORTGraphOptimizationLevelExtended, ORT_ENABLE_EXTENDED},
+    {ORTGraphOptimizationLevelLayout, ORT_ENABLE_LAYOUT},
     {ORTGraphOptimizationLevelAll, ORT_ENABLE_ALL},
 };
 

--- a/onnxruntime/core/common/cpuid_info.cc
+++ b/onnxruntime/core/common/cpuid_info.cc
@@ -123,7 +123,9 @@ void CPUIDInfo::X86Init() {
       has_f16c_ = has_avx_ && (data[2] & (1 << 29)) && (data[3] & (1 << 26));
 
       if (num_IDs >= 7) {
-        GetCPUID(7, data);
+        // This change is made to overcome the issue of __get_cpuid returning all zeros, instead use __get_cpuid_count.
+        // Reference: https://stackoverflow.com/questions/46272579/why-does-get-cpuid-return-all-zeros-for-leaf-4
+        GetCPUID(7, 0, data);
         const uint32_t max_SubLeaves = data[0];
         has_amx_bf16_ = (data[3] & (1 << 22));
         has_avx2_ = has_avx_ && (data[1] & (1 << 5));

--- a/onnxruntime/core/framework/session_options.h
+++ b/onnxruntime/core/framework/session_options.h
@@ -124,7 +124,7 @@ struct SessionOptions {
   unsigned max_num_graph_transformation_steps = 10;  // TODO choose a good default here?
 
   // set graph optimization level
-  TransformerLevel graph_optimization_level = TransformerLevel::Level3;
+  TransformerLevel graph_optimization_level = TransformerLevel::MaxLevel;
 
   // controls the size of the thread pool used to parallelize the execution of tasks within individual nodes (ops)
   OrtThreadPoolParams intra_op_param;

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -1450,6 +1450,17 @@ MlasConvertHalfToFloatBuffer(
     size_t Count
 );
 
+#define MLAS_MIN_TENSOR_SIZE_FOR_HALF_TO_FLOAT_CONVERSION_IN_PARALLEL 128000
+
+void
+MLASCALL
+MlasConvertHalfToFloatBufferInParallel(
+    const MLAS_FP16* Source,
+    float* Destination,
+    size_t Count,
+    MLAS_THREADPOOL* ThreadPool
+);
+
 void
 MLASCALL
 MlasConvertFloatToHalfBuffer(

--- a/onnxruntime/core/mlas/lib/cast.cpp
+++ b/onnxruntime/core/mlas/lib/cast.cpp
@@ -33,6 +33,53 @@ MlasConvertHalfToFloatBuffer(
     }
 }
 
+
+void
+MLASCALL
+MlasConvertHalfToFloatBufferInParallel(
+    const MLAS_FP16* Source,
+    float* Destination,
+    size_t Count,
+    MLAS_THREADPOOL* ThreadPool
+)
+{
+    // Check if the Tensor is long enough to use threads.
+    // Check if the Thread Pool is available.
+    // If not, execute single threaded conversion of half to float
+    if (!((Count > MLAS_MIN_TENSOR_SIZE_FOR_HALF_TO_FLOAT_CONVERSION_IN_PARALLEL) && ThreadPool)) {
+        MlasConvertHalfToFloatBuffer(Source, Destination, Count);
+    }
+    else {
+
+        // Calculate the number of compute cycles per implementation
+        size_t num_compute_cycles;
+        if (MLAS_CPUIDINFO::GetCPUIDInfo().HasSSE3()) {
+            num_compute_cycles = Count >> 1;
+        } else if (MLAS_CPUIDINFO::GetCPUIDInfo().HasAVX2()) {
+            num_compute_cycles = Count >> 2;
+        } else {
+            num_compute_cycles = Count * 10;
+        }
+
+        MLAS_THREADPOOL::TryParallelFor(
+            ThreadPool, Count,
+            // Tensor Op Cost
+            {
+                static_cast<double>(Count * sizeof(MLAS_FP16)),  // Size of no. of elements in bytes to be loaded
+                static_cast<double>(Count * sizeof(float)),      // Size of no. of elements in bytes to be stored
+                static_cast<double>(num_compute_cycles),         // No. of compute cycles required for the tensor op
+            },
+            // Lambda function required by TryParallelFor method
+            [Source, Destination](std::ptrdiff_t first_span, std::ptrdiff_t last_span) {
+                MlasConvertHalfToFloatBuffer(
+                    Source + first_span,
+                    Destination + first_span,
+                    static_cast<size_t>(last_span - first_span));
+            }
+        );
+    }
+}
+
 void
 MLASCALL
 MlasConvertFloatToHalfBuffer(

--- a/onnxruntime/core/optimizer/fuse_initializers_transformer.cc
+++ b/onnxruntime/core/optimizer/fuse_initializers_transformer.cc
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) Intel Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include <string>
+#include <set>
+#include <algorithm>
+#include "core/graph/graph_utils.h"
+#include "core/graph/graph_viewer.h"
+#include "core/optimizer/initializer.h"
+#include "core/optimizer/fuse_initializers_transformer.h"
+
+namespace onnxruntime {
+
+/**
+ * @brief   Check if the input node is cast node with no inputs and single output.
+ *
+ * @param   node  Node object
+ *
+ * @return  True, if input node is Cast node with no inputs and single output,
+ *          else, False.
+ */
+static bool IsCastNodeWithConstraints(const Node& node) {
+
+    // Node must be cast node
+    if (!("Cast" == node.OpType())) return false;
+
+    // Node must have no input edges
+    if (!(0 == node.GetInputEdgesCount())) return false;
+
+    // Node must have only one output edge
+    if (!(1 == node.GetOutputEdgesCount())) return false;
+
+    return true;
+}
+
+/**
+ * @brief   Check if for the current node has an initialized tensor of a specific type with specific type output.
+ *
+ * As the node to be checked is a Cast node with zero input, one initializer and one output, the input_defs_index
+ * and the output_defs_index is assumed to be 0 in all cases for all the checks.
+ *
+ * @param graph            Graph object.
+ * @param node             Node object.
+ * @param tensor_type      The type of initialized tensor to be found in the given node.
+ * @param output_type      The type of output for the given node.
+ *
+ * @return  True, if for the given node an initialized tensor of "tensor_type" with specific "output_type" is found,
+ *          else, False.
+ */
+static bool IsNodeValidForFusion(const Graph& graph,
+                                const Node& node,
+                                const onnxruntime::MLDataType tensor_type,
+                                const onnxruntime::MLDataType output_type) {
+
+    // Node must have initialized tensor
+    if (!(graph.IsInitializedTensor(node.InputDefs()[0]->Name()))) return false;
+
+    // Initialzed tensor must be of tensor_type
+    if (!(DataTypeImpl::TypeFromProto(*(node.InputDefs()[0]->TypeAsProto())) == tensor_type)) return false;
+
+    // Node output must be of output_type
+    if (!(DataTypeImpl::TypeFromProto(*(node.OutputDefs()[0]->TypeAsProto())) == output_type)) return false;
+
+    return true;
+}
+
+/**
+ * @brief   Make a new name from the old node arg name.
+ *
+ * It replaces "InsertedPrecisionFreeCast_" prefix in a node name with "FusedBack_" prefix.
+ *
+ * @param   old_node_arg_name Old arg name.
+ *
+ * @return  New arg name.
+ */
+static const std::string NewNodeArgName(const std::string& old_node_arg_name) {
+    static thread_local const std::string pattern_to_be_replaced = "InsertedPrecisionFreeCast_";
+    std::string new_node_arg_name = old_node_arg_name;
+    auto pos = new_node_arg_name.find(pattern_to_be_replaced);
+    if(std::string::npos != pos) new_node_arg_name.replace(pos, pattern_to_be_replaced.size(), "");
+    new_node_arg_name = "FusedBack_" + new_node_arg_name;
+    return new_node_arg_name;
+}
+
+/**
+ * @brief   It fuses the initializer in the current node to its next node / output node, and then
+ *          remove the link/edge between current node and next node / output node.
+ *
+ * The node input_defs_index and output_defs_index is assumed to be always 0, as the node which encapsulates
+ * a single Initializer have just zero input, one initializer and one output.
+ *
+ * @param graph                 Graph object.
+ * @param node                  Current Node to be fused with its next node.
+ * @param next_node_arg_type    The "type" of initializer expected by the next-node to the current node.
+ * @param thread_pool           Thread pool for multi-threaded conversion of the initializer
+ *                              from an unsupported to supported type tensor.
+ */
+static void FuseInitializerWithNode(Graph& graph,
+                                    Node& node,
+                                    const onnxruntime::MLDataType next_node_arg_type,
+                                    onnxruntime::concurrency::ThreadPool* thread_pool) {
+
+    // Get next node
+    Node& next_node = *graph.GetNode(node.OutputNodesBegin()->Index());
+
+    // Get the index in next node at which the initializer must be replaced
+    NodeIndex next_node_arg_index = 0;
+    for (; next_node_arg_index < next_node.InputDefs().size(); ++next_node_arg_index) {
+        if (node.Name() == next_node.InputDefs()[next_node_arg_index]->Name()) {
+            break;
+        }
+    }
+
+    // Get the src initialized tensor at input def index 0
+    auto constant_initializer_tensor = graph_utils::GetConstantInitializer(graph, node.InputDefs()[0]->Name());
+    ONNX_NAMESPACE::TensorProto src_tensor(*constant_initializer_tensor);
+    Initializer src_init{*constant_initializer_tensor, graph.ModelPath()};
+    src_init.ToProto(src_tensor);
+
+    // Convert to dst tensor
+    ONNX_NAMESPACE::TensorProto dst_tensor;
+    if (next_node_arg_type == DataTypeImpl::GetTensorType<float>())
+      dst_tensor = src_init.ToFloat32(graph.GenerateNodeArgName(NewNodeArgName(next_node.InputDefs()[next_node_arg_index]->Name())), thread_pool);
+    else if (next_node_arg_type == DataTypeImpl::GetTensorType<MLFloat16>())
+      dst_tensor = src_init.ToFP16(graph.GenerateNodeArgName(NewNodeArgName(next_node.InputDefs()[next_node_arg_index]->Name())));
+    else if (next_node_arg_type == DataTypeImpl::GetTensorType<BFloat16>())
+      dst_tensor = src_init.ToBFloat16(graph.GenerateNodeArgName(NewNodeArgName(next_node.InputDefs()[next_node_arg_index]->Name())));
+    else
+      return;
+
+    // Remove the edge between the current node output def at index 0 and next node arg at relative arg index.
+    graph.RemoveEdge(node.Index(), next_node.Index(), 0, static_cast<int>(next_node_arg_index));
+
+    // Add the new converted Tensor in next node as initializer
+    graph_utils::ReplaceNodeInput(next_node, static_cast<int>(next_node_arg_index), graph_utils::AddInitializer(graph, dst_tensor));
+}
+
+Status FuseInitializersTransformer::ApplyImpl(Graph& graph, bool& modified, int /*graph_level*/, const logging::Logger& /*logger*/) const {
+
+    // Init
+    std::set<NodeIndex> nodes_to_be_fused_and_removed_from_graph;
+
+    // Get nodes in topological order
+    const GraphViewer graph_viewer(graph);
+    auto nodes_indexes_in_topological_order = graph_viewer.GetNodesInTopologicalOrder();
+
+    // For each Node
+    for (auto node_index : nodes_indexes_in_topological_order) {
+
+        // Get Node
+        auto node = graph.GetNode(node_index);
+
+        // Check if the current node is a Cast node with all constraints and valid for fusion
+        if (node && IsCastNodeWithConstraints(*node) && IsNodeValidForFusion(graph, *node, init_type_, cvt_type_)) {
+
+            // Add node to the set of nodes to be fused and removed
+            nodes_to_be_fused_and_removed_from_graph.insert(node_index);
+        }
+    }
+
+    // Fuse all Cast Node with src type Initializer casted to dst type to Next Node
+    for(auto node_index : nodes_to_be_fused_and_removed_from_graph) {
+        auto node = graph.GetNode(node_index);
+        FuseInitializerWithNode(graph, *node, cvt_type_, thread_pool_);
+    }
+
+    // Remove all nodes considered during fusion
+    for(auto node_index : nodes_to_be_fused_and_removed_from_graph) {
+        graph.RemoveNode(node_index);
+    }
+
+    // set flag to true indicating the graph is changed
+    if(!nodes_to_be_fused_and_removed_from_graph.empty()) modified = true;
+
+    return Status::OK();
+}
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/fuse_initializers_transformer.h
+++ b/onnxruntime/core/optimizer/fuse_initializers_transformer.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Intel Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#pragma once
+
+#include "core/optimizer/graph_transformer.h"
+#include "core/framework/kernel_registry_manager.h"
+#include "core/framework/kernel_registry.h"
+
+namespace onnxruntime {
+
+    /**
+     * @class FuseInitializersTransformer
+     *
+     * A Transformer to fuse cast node that casts from init_type to cvt_type, back to their next/output nodes.
+     * Below is the explanation on how this transforms works. It depends on "InsertCastTransforms" to produce the
+     * intermediate representation from which it fuses the initializers (which are the cast node with zero input,
+     * one initializer, and one output) back to the next/output node. After fusion, the link/edge between such
+     * cast node to next/output node will then be removed.
+     *
+     *
+     * ```
+     *
+     *         "Input Graph"                       "Intermediate Representation"               "Fusion Transforms"
+     *
+     *           --------                   --------        --------        --------                 --------
+     *          | X_Fp16 |                 | X_Fp16 |      | W_Fp16 |      | B_Fp16 |               | X_Fp16 |
+     *           --------                   --------        --------        --------                 --------
+     *              |                          |               |               |                        |
+     *              |                          |               |               |                        |
+     *              |                          V               V               V                        V
+     *              |                       | Cast |        | Cast |        | Cast |                 | Cast |
+     *              |                       | Fp16 |        | Fp16 |        | Fp16 |                 | Fp16 |
+     *              |                       |  To  |        |  To  |        |  To  |                 |  To  |
+     *              |                       | Fp32 |        | Fp32 |        | Fp32 |                 | Fp32 |
+     *              |                          |               |               |                        |
+     *              |                          |               |               |                        |
+     *              V                          V               V               V                        V
+     *  ----------------------------       -----------------------------------------       ----------------------------
+     * |        Conv_Fp16           |     |                                         |     |         Conv_Fp32          |
+     * |        --W_Fp16--          | ==> |                Conv_Fp32                | ==> |         --W_Fp32--         |
+     * |        --B_Fp16--          |     |                                         |     |         --B_Fp32--         |
+     *  ----------------------------       -----------------------------------------       ----------------------------
+     *              |                                          |                                        |
+     *              |                                          |                                        |
+     *              |                                          V                                        V
+     *              |                                       | Cast |                                 | Cast |
+     *              |                                       | Fp32 |                                 | Fp32 |
+     *              |                                       |  To  |                                 |  To  |
+     *              |                                       | Fp16 |                                 | Fp16 |
+     *              |                                          |                                        |
+     *              |                                          |                                        |
+     *              V                                          V                                        V
+     *           --------                                   --------                                 --------
+     *          | Y_Fp16 |                                 | Y_Fp16 |                               | Y_Fp16 |
+     *           --------                                   --------                                 --------
+     *
+     * ```
+     *
+     */
+    class FuseInitializersTransformer : public GraphTransformer {
+
+    public:
+        /**
+         * @brief   Fuses Initializers to child node after conversion to child node kernel type
+         *          to save compute on Cast Op during inference.
+         *
+         * This transforms must be applied after InsertCastTransformer. Currently only FP16 Initializers are fused with
+         * nodes supporting FP32 Initializers, however, the code is designed to apply for any supported conversion/s.
+         *
+         * @param name          Name of the transforms, just for logging purpose.
+         * @param init_type     The unsupported type for which cast nodes are inserted to convert
+         *                      the initializers to supported type initializers expected by next/output nodes.
+         * @param cvt_type      The supported type initializers expected by next/output nodes.
+         * @param thread_pool   A pointer to thread pool to support conversion from init_type to cvt_type
+         *                      with multithreading
+         */
+        FuseInitializersTransformer(const std::string& name,
+                                    const onnxruntime::MLDataType init_type,
+                                    const onnxruntime::MLDataType cvt_type,
+                                    onnxruntime::concurrency::ThreadPool *thread_pool = nullptr) :
+                                    GraphTransformer(name, {}),
+                                    init_type_(init_type),
+                                    cvt_type_(cvt_type),
+                                    thread_pool_(thread_pool) {}
+
+    private:
+
+        const onnxruntime::MLDataType init_type_;
+        const onnxruntime::MLDataType cvt_type_;
+        onnxruntime::concurrency::ThreadPool* thread_pool_;
+        Status ApplyImpl(
+             Graph& graph,
+             bool& modified,
+             int graph_level,
+             const logging::Logger& logger) const override;
+    };
+}  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/graph_transformer_mgr.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_mgr.cc
@@ -21,6 +21,7 @@ common::Status GraphTransformerManager::GetSteps(unsigned& steps) const {
 
 common::Status GraphTransformerManager::ApplyTransformers(Graph& graph, TransformerLevel level,
                                                           const logging::Logger& logger) const {
+  _is_graph_modified = false;
   const auto& transformers = level_to_transformer_map_.find(level);
   if (transformers == level_to_transformer_map_.end()) {
     return Status::OK();
@@ -35,6 +36,7 @@ common::Status GraphTransformerManager::ApplyTransformers(Graph& graph, Transfor
       bool modified = false;
       ORT_RETURN_IF_ERROR(transformer->Apply(graph, modified, logger));
       graph_changed = graph_changed || modified;
+      _is_graph_modified = _is_graph_modified || graph_changed;
     }
     if (!graph_changed) {
       break;
@@ -42,6 +44,10 @@ common::Status GraphTransformerManager::ApplyTransformers(Graph& graph, Transfor
   }
 
   return Status::OK();
+}
+
+bool GraphTransformerManager::IsGraphModified(void) const {
+  return _is_graph_modified;
 }
 
 common::Status GraphTransformerManager::Register(std::unique_ptr<GraphTransformer> transformer,

--- a/onnxruntime/core/optimizer/graph_transformer_mgr.h
+++ b/onnxruntime/core/optimizer/graph_transformer_mgr.h
@@ -30,6 +30,9 @@ class GraphTransformerManager {
   // Apply all transformers registered for the given level on the given graph
   common::Status ApplyTransformers(Graph& graph, TransformerLevel level, const logging::Logger& logger) const;
 
+  // Get status if the graph is modified while applying the registered transformers
+  bool IsGraphModified(void) const;
+
  private:
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(GraphTransformerManager);
 
@@ -38,5 +41,6 @@ class GraphTransformerManager {
 
   InlinedHashMap<TransformerLevel, InlinedVector<std::unique_ptr<GraphTransformer>>> level_to_transformer_map_;
   InlinedHashMap<std::string, GraphTransformer*> transformers_info_;
+  mutable bool _is_graph_modified = false;
 };
 }  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/initializer.cc
+++ b/onnxruntime/core/optimizer/initializer.cc
@@ -10,6 +10,8 @@
 #include "core/framework/tensorprotoutils.h"
 #include "core/framework/tensor_external_data_info.h"
 #include "core/platform/env.h"
+#include "core/mlas/inc/mlas.h"
+#include "core/common/cpuid_info.h"
 
 namespace onnxruntime {
 
@@ -125,6 +127,64 @@ struct TensorToProtoBFloat16 {
   }
 };
 
+template <typename T>
+struct ToFloat32;
+
+template <>
+struct ToFloat32<float> {
+  float operator()(const float& f) const {
+    return f;
+  }
+};
+
+template <>
+struct ToFloat32<double> {
+  float operator()(double d) const {
+    return static_cast<float>(d);
+  }
+};
+
+template <>
+struct ToFloat32<BFloat16> {
+  float operator()(BFloat16 bf) const {
+    return static_cast<float>(bf);
+  }
+};
+
+template <>
+struct ToFloat32<MLFloat16> {
+  float operator()(MLFloat16 hf) const {
+    return static_cast<float>(hf);
+  }
+};
+
+template <typename T>
+struct TensorToProtoFloat32 {
+  void operator()(const Tensor& data, ONNX_NAMESPACE::TensorProto& proto, onnxruntime::concurrency::ThreadPool* /*thread_pool*/) const {
+    auto span = data.DataAsSpan<T>();
+    ToFloat32<T> to_float32;
+    for (const auto& v : span) {
+      proto.add_float_data(to_float32(v));
+    }
+  }
+};
+
+
+template <>
+struct TensorToProtoFloat32<MLFloat16> {
+
+  void operator()(const Tensor& data,
+                  ONNX_NAMESPACE::TensorProto& proto,
+                  onnxruntime::concurrency::ThreadPool* thread_pool) const {
+    auto source = reinterpret_cast<const MLFloat16*>(data.DataRaw());
+    auto count = size_t(data.SizeInBytes() / sizeof(MLFloat16));
+    auto destination_mem = std::make_unique<float[]>(count);
+    auto destination = destination_mem.get();
+    MlasConvertHalfToFloatBufferInParallel(source, destination, count, thread_pool);
+    utils::SetRawDataInTensorProto(proto, destination, count * sizeof(float));
+  }
+};
+
 inline void SetNameDims(const std::string& name,
                         gsl::span<const int64_t> dims,
                         ONNX_NAMESPACE::TensorProto_DataType dt,
@@ -152,6 +212,14 @@ ONNX_NAMESPACE::TensorProto Initializer::ToBFloat16(const std::string& name) con
   SetNameDims(name, data_.Shape().GetDims(), ONNX_NAMESPACE::TensorProto_DataType_BFLOAT16, tensor_proto);
   utils::MLTypeCallDispatcher<BFloat16, float, double> t_disp(data_.GetElementType());
   t_disp.Invoke<TensorToProtoBFloat16>(data_, tensor_proto);
+  return tensor_proto;
+}
+
+ONNX_NAMESPACE::TensorProto Initializer::ToFloat32(const std::string& name, onnxruntime::concurrency::ThreadPool* thread_pool) const {
+  ONNX_NAMESPACE::TensorProto tensor_proto;
+  SetNameDims(name, data_.Shape().GetDims(), ONNX_NAMESPACE::TensorProto_DataType_FLOAT, tensor_proto);
+  utils::MLTypeCallDispatcher<float, double, BFloat16, MLFloat16> t_disp(data_.GetElementType());
+  t_disp.Invoke<TensorToProtoFloat32>(data_, tensor_proto, thread_pool);
   return tensor_proto;
 }
 

--- a/onnxruntime/core/optimizer/initializer.h
+++ b/onnxruntime/core/optimizer/initializer.h
@@ -38,6 +38,8 @@ class Initializer final {
   ONNX_NAMESPACE::TensorProto ToFP16(const std::string& name) const;
 
   ONNX_NAMESPACE::TensorProto ToBFloat16(const std::string& name) const;
+
+  ONNX_NAMESPACE::TensorProto ToFloat32(const std::string& name, onnxruntime::concurrency::ThreadPool* thread_pool = nullptr) const;
 #endif  // ORT_EXTENDED_MINIMAL_BUILD
   int data_type() const {
     return data_.GetElementType();

--- a/onnxruntime/core/providers/cpu/tensor/cast_op.cc
+++ b/onnxruntime/core/providers/cpu/tensor/cast_op.cc
@@ -258,28 +258,7 @@ struct TensorCaster<MLFloat16, float> {
     auto out_data = out.MutableData<float>();
     auto in_data = in.Data<MLFloat16>();
     const size_t shape_size = narrow<size_t>(shape.Size());
-
-    // Check if the tensor is long enough to use threads
-    if (shape_size <= 128000) {
-      MlasConvertHalfToFloatBuffer(in_data, out_data, shape_size);
-      return;
-    }
-    // Calculate the number of compute cyles per implementation
-    auto cpu_info = CPUIDInfo::GetCPUIDInfo();
-    double num_compute_cycles;
-    if (cpu_info.HasSSE3()) {
-      num_compute_cycles = static_cast<double>(shape_size >> 1);
-    } else if (cpu_info.HasAVX2()) {
-      num_compute_cycles = static_cast<double>(shape_size >> 2);
-    } else {
-      num_compute_cycles = static_cast<double>(shape_size * 10);
-    }
-
-    concurrency::ThreadPool::TryParallelFor(ctx.GetOperatorThreadPool(), shape_size,
-                                            {shape_size * 2.f, shape_size * 4.f, num_compute_cycles},
-                                            [in_data, out_data](std::ptrdiff_t first_span, std::ptrdiff_t last_span) {
-                                              MlasConvertHalfToFloatBuffer(in_data + first_span, out_data + first_span, static_cast<size_t>(last_span - first_span));
-                                            });
+    MlasConvertHalfToFloatBufferInParallel(in_data, out_data, shape_size, ctx.GetOperatorThreadPool());
   }
 };
 

--- a/onnxruntime/core/session/abi_session_options.cc
+++ b/onnxruntime/core/session/abi_session_options.cc
@@ -180,6 +180,9 @@ ORT_API_STATUS_IMPL(OrtApis::SetSessionGraphOptimizationLevel, _In_ OrtSessionOp
     case ORT_ENABLE_EXTENDED:
       options->value.graph_optimization_level = onnxruntime::TransformerLevel::Level2;
       break;
+    case ORT_ENABLE_LAYOUT:
+      options->value.graph_optimization_level = onnxruntime::TransformerLevel::Level3;
+      break;
     case ORT_ENABLE_ALL:
       options->value.graph_optimization_level = onnxruntime::TransformerLevel::MaxLevel;
       break;

--- a/onnxruntime/core/session/inference_session_utils.cc
+++ b/onnxruntime/core/session/inference_session_utils.cc
@@ -74,6 +74,11 @@ static Status SetGraphOptimizationLevel(SessionOptions& session_options,
       session_options.graph_optimization_level = TransformerLevel::Level2;
       return Status::OK();
 
+    case ORT_ENABLE_LAYOUT:
+      LOGS(logger, INFO) << "Setting graph_optimization_level to ORT_ENABLE_LAYOUT";
+      session_options.graph_optimization_level = TransformerLevel::Level3;
+      return Status::OK();
+
     case ORT_ENABLE_ALL:
       LOGS(logger, INFO) << "Setting graph_optimization_level to ORT_ENABLE_ALL";
       session_options.graph_optimization_level = TransformerLevel::MaxLevel;

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -1546,6 +1546,7 @@ void addObjectMethods(py::module& m, ExecutionProviderRegistrationFn ep_registra
       .value("ORT_DISABLE_ALL", GraphOptimizationLevel::ORT_DISABLE_ALL)
       .value("ORT_ENABLE_BASIC", GraphOptimizationLevel::ORT_ENABLE_BASIC)
       .value("ORT_ENABLE_EXTENDED", GraphOptimizationLevel::ORT_ENABLE_EXTENDED)
+      .value("ORT_ENABLE_LAYOUT", GraphOptimizationLevel::ORT_ENABLE_LAYOUT)
       .value("ORT_ENABLE_ALL", GraphOptimizationLevel::ORT_ENABLE_ALL);
 
   py::enum_<ExecutionMode>(m, "ExecutionMode")
@@ -1770,6 +1771,9 @@ Applies to session load, initialization, etc. Default is 0.)pbdoc")
                 retval = ORT_ENABLE_EXTENDED;
                 break;
               case onnxruntime::TransformerLevel::Level3:
+                retval = ORT_ENABLE_LAYOUT;
+                break;
+              case onnxruntime::TransformerLevel::MaxLevel:
                 retval = ORT_ENABLE_ALL;
                 break;
               default:
@@ -1791,8 +1795,11 @@ Applies to session load, initialization, etc. Default is 0.)pbdoc")
               case ORT_ENABLE_EXTENDED:
                 options->value.graph_optimization_level = onnxruntime::TransformerLevel::Level2;
                 break;
-              case ORT_ENABLE_ALL:
+              case ORT_ENABLE_LAYOUT:
                 options->value.graph_optimization_level = onnxruntime::TransformerLevel::Level3;
+                break;
+              case ORT_ENABLE_ALL:
+                options->value.graph_optimization_level = onnxruntime::TransformerLevel::MaxLevel;
                 break;
             }
           },

--- a/onnxruntime/python/tools/tensorrt/perf/benchmark.py
+++ b/onnxruntime/python/tools/tensorrt/perf/benchmark.py
@@ -29,6 +29,7 @@ from perf_utils import (
     cuda_fp16,
     disable,
     enable_all,
+    layout,
     extended,
     get_output,
     get_profile_metrics,
@@ -116,6 +117,8 @@ def get_graph_opt_level(enablement):
 
     if enablement == enable_all:
         opt_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_ALL
+    elif enablement == layout:
+        opt_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_LAYOUT
     elif enablement == extended:
         opt_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_EXTENDED
     elif enablement == basic:
@@ -2197,7 +2200,7 @@ def parse_arguments():
         "--graph_enablement",
         required=False,
         default=enable_all,
-        choices=[disable, basic, extended, enable_all],
+        choices=[disable, basic, extended, layout, enable_all],
         help="Choose graph optimization enablement.",
     )
 

--- a/onnxruntime/python/tools/tensorrt/perf/perf_utils.py
+++ b/onnxruntime/python/tools/tensorrt/perf/perf_utils.py
@@ -69,6 +69,7 @@ table_headers = [model_title, *provider_list]
 disable = "disable"
 basic = "basic"
 extended = "extended"
+layout = "layout"
 enable_all = "all"
 
 

--- a/onnxruntime/python/tools/transformers/README.md
+++ b/onnxruntime/python/tools/transformers/README.md
@@ -35,7 +35,7 @@ Models not in the list may only be partially optimized or not optimized at all.
 -  **use_gpu**: (*optional*)
     When opt_level > 1, please set this flag for GPU inference.
 - **opt_level**: (*optional*)
-    Set a proper graph optimization level of OnnxRuntime: 0 - disable all (default), 1 - basic, 2 - extended, 99 - all. If the value is positive, OnnxRuntime will be used to optimize graph first.
+    Set a proper graph optimization level of OnnxRuntime: 0 - disable all (default), 1 - basic, 2 - extended, 3 - layout, 99 - all. If the value is positive, OnnxRuntime will be used to optimize graph first.
 - **verbose**: (*optional*)
     Print verbose information when this flag is specified.
 
@@ -84,4 +84,3 @@ Since past state is used, sequence length in input_ids is 1. For example, s=4 me
 python -m onnxruntime.transformers.models.gpt2.benchmark_gpt2 --use_gpu -m gpt2 -o -v -b 1 8 32 128 -s 4 8 32 128 -p fp32
 python -m onnxruntime.transformers.models.gpt2.benchmark_gpt2 --use_gpu -m gpt2 -o -v -b 1 8 32 128 -s 4 8 32 128 -p fp16
 ```
-

--- a/onnxruntime/python/tools/transformers/bert_perf_test.py
+++ b/onnxruntime/python/tools/transformers/bert_perf_test.py
@@ -113,6 +113,8 @@ def create_session(
         sess_options.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_BASIC
     elif graph_optimization_level == 2:
         sess_options.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_EXTENDED
+    elif graph_optimization_level == 3:
+        sess_options.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_LAYOUT
     elif graph_optimization_level == 99:
         sess_options.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_ALL
     else:
@@ -422,9 +424,9 @@ def parse_arguments():
         "--opt_level",
         required=False,
         type=int,
-        choices=[0, 1, 2, 99],
+        choices=[0, 1, 2, 3, 99],
         default=99,
-        help="onnxruntime optimization level: 0 - disable all, 1 - basic, 2 - extended, 99 - enable all.",
+        help="onnxruntime optimization level: 0 - disable all, 1 - basic, 2 - extended, 3 - layout, 99 - enable all.",
     )
 
     parser.add_argument(

--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -135,6 +135,8 @@ def optimize_by_onnxruntime(
         sess_options.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_BASIC
     elif opt_level == 2:
         sess_options.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_EXTENDED
+    elif opt_level == 3:
+        sess_options.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_LAYOUT
     else:
         sess_options.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_ALL
 
@@ -517,11 +519,11 @@ def _parse_arguments():
         "--opt_level",
         required=False,
         type=int,
-        choices=[0, 1, 2, 99],
+        choices=[0, 1, 2, 3, 99],
         default=None,
         help="onnxruntime optimization level. 0 will disable onnxruntime graph optimization. "
         "The recommended value is 1. When opt_level > 1 is used, optimized model for GPU might not run in CPU. "
-        "Level 2 and 99 are intended for --only_onnxruntime.",
+        "Level 2, Level 3 and 99 are intended for --only_onnxruntime.",
     )
 
     parser.add_argument(

--- a/onnxruntime/test/framework/fuse_initializers_transformer_test.cc
+++ b/onnxruntime/test/framework/fuse_initializers_transformer_test.cc
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) Intel Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "gtest/gtest.h"
+#include "test_utils.h"
+#include "test/test_environment.h"
+#include "test/util/include/default_providers.h"
+#include "test/util/include/asserts.h"
+#include "core/graph/model.h"
+#include "core/graph/graph_utils.h"
+#include "core/graph/graph_viewer.h"
+#include "core/optimizer/insert_cast_transformer.h"
+#include "core/optimizer/fuse_initializers_transformer.h"
+
+namespace onnxruntime {
+
+    namespace test {
+
+        #define MODEL_FOLDER ORT_TSTR("testdata/transform/")
+
+        unsigned int CountNoOfInitializersInGraph(const Graph& graph, const onnxruntime::MLDataType _data_type) {
+
+            //init
+            unsigned int num_initializers = 0;
+
+            // Get nodes in topological order
+            const GraphViewer graph_viewer(graph);
+            auto nodes_indexes_in_topological_order = graph_viewer.GetNodesInTopologicalOrder();
+
+            // For each Node
+            for (auto node_index : nodes_indexes_in_topological_order) {
+
+                // Get Node
+                auto node = graph.GetNode(node_index);
+
+                // Get input defs
+                auto node_input_defs = node->InputDefs();
+
+                // For each Node Args
+                for (NodeIndex node_arg_index = 0; node_arg_index < node_input_defs.size(); ++node_arg_index) {
+
+                    // Continue if the current arg is not an initialized tensor
+                    if (!(graph.IsInitializedTensor(node_input_defs[node_arg_index]->Name()))) continue;
+
+                    // Continue if initialzed tensor is not of specific type
+                    if (!(_data_type == DataTypeImpl::TypeFromProto(*(node_input_defs[node_arg_index]->TypeAsProto())))) continue;
+
+                    // increment
+                    num_initializers += 1;
+                }
+            }
+
+            return num_initializers;
+        }
+
+        unsigned int CountNoOfNodesInGraph(const Graph& graph, const onnxruntime::MLDataType _data_type) {
+
+            //init
+            unsigned int num_nodes = 0;
+            unsigned int num_args_in_a_node = 0;
+
+            // Get nodes in topological order
+            const GraphViewer graph_viewer(graph);
+            auto nodes_indexes_in_topological_order = graph_viewer.GetNodesInTopologicalOrder();
+
+            // For each Node
+            for (auto node_index : nodes_indexes_in_topological_order) {
+
+                // Get Node
+                auto node = graph.GetNode(node_index);
+
+                // Get input defs
+                auto node_input_defs = node->InputDefs();
+
+                // For each Node Args
+                num_args_in_a_node = 0;
+                for (NodeIndex node_arg_index = 0; node_arg_index < node_input_defs.size(); ++node_arg_index) {
+
+                    // Continue if current arg is not of specific type
+                    if (!(_data_type == DataTypeImpl::TypeFromProto(*(node_input_defs[node_arg_index]->TypeAsProto())))) continue;
+
+                    num_args_in_a_node += 1;
+                }
+
+                // increment
+                num_nodes += ((node_input_defs.size() == num_args_in_a_node) ? 1 : 0);
+            }
+
+            return num_nodes;
+        }
+
+        void test_graph_structure_at_init(const Graph& graph) {
+            // Count ops
+            auto op_to_count = CountOpsInGraph(graph);
+            EXPECT_TRUE(0==op_to_count["Cast"]);
+            // Count no. of initializers of FP16 type
+            auto num_initializers_fp16 = CountNoOfInitializersInGraph(graph, DataTypeImpl::GetTensorType<MLFloat16>());
+            EXPECT_TRUE(2==num_initializers_fp16);
+            // Count no. of initializers of FP32 type
+            auto num_initializers_fp32 = CountNoOfInitializersInGraph(graph, DataTypeImpl::GetTensorType<float>());
+            EXPECT_TRUE(0==num_initializers_fp32);
+            // Count no. of FP16 nodes
+            auto num_nodes_fp16 = CountNoOfNodesInGraph(graph, DataTypeImpl::GetTensorType<MLFloat16>());
+            EXPECT_TRUE(1==num_nodes_fp16);
+            // Count no. of FP32 nodes
+            auto num_nodes_fp32 = CountNoOfNodesInGraph(graph, DataTypeImpl::GetTensorType<float>());
+            EXPECT_TRUE(0==num_nodes_fp32);
+            // Check if all conditions are met
+            ASSERT_TRUE((0==op_to_count["Cast"])
+                     && (2==num_initializers_fp16)
+                     && (0==num_initializers_fp32)
+                     && (1==num_nodes_fp16)
+                     && (0==num_nodes_fp32));
+        }
+
+        void test_graph_structure_before_fusion(const Graph& graph) {
+            // Count ops
+            auto op_to_count = CountOpsInGraph(graph);
+            EXPECT_TRUE(4==op_to_count["Cast"]);
+            // Count no. of initializers of FP16 type
+            auto num_initializers_fp16 = CountNoOfInitializersInGraph(graph, DataTypeImpl::GetTensorType<MLFloat16>());
+            EXPECT_TRUE(2==num_initializers_fp16);
+            // Count no. of initializers of FP32 type
+            auto num_initializers_fp32 = CountNoOfInitializersInGraph(graph, DataTypeImpl::GetTensorType<float>());
+            EXPECT_TRUE(0==num_initializers_fp32);
+            // Count no. of FP16 nodes
+            auto num_nodes_fp16 = CountNoOfNodesInGraph(graph, DataTypeImpl::GetTensorType<MLFloat16>());
+            EXPECT_TRUE(3==num_nodes_fp16);
+            // Count no. of FP32 nodes
+            auto num_nodes_fp32 = CountNoOfNodesInGraph(graph, DataTypeImpl::GetTensorType<float>());
+            EXPECT_TRUE(2==num_nodes_fp32);
+            // Check if all conditions are met
+            ASSERT_TRUE((4==op_to_count["Cast"])
+                     && (2==num_initializers_fp16)
+                     && (0==num_initializers_fp32)
+                     && (3==num_nodes_fp16)
+                     && (2==num_nodes_fp32));
+        }
+
+        void test_graph_structure_after_fusion(const Graph& graph) {
+            // Count ops
+            auto op_to_count = CountOpsInGraph(graph);
+            EXPECT_TRUE(2==op_to_count["Cast"]);
+            // Count no. of initializers of FP16 type
+            auto num_initializers_fp16 = CountNoOfInitializersInGraph(graph, DataTypeImpl::GetTensorType<MLFloat16>());
+            EXPECT_TRUE(0==num_initializers_fp16);
+            // Count no. of initializers of FP32 type
+            auto num_initializers_fp32 = CountNoOfInitializersInGraph(graph, DataTypeImpl::GetTensorType<float>());
+            EXPECT_TRUE(2==num_initializers_fp32);
+            // Count no. of FP16 nodes
+            auto num_nodes_fp16 = CountNoOfNodesInGraph(graph, DataTypeImpl::GetTensorType<MLFloat16>());
+            EXPECT_TRUE(1==num_nodes_fp16);
+            // Count no. of FP32 nodes
+            auto num_nodes_fp32 = CountNoOfNodesInGraph(graph, DataTypeImpl::GetTensorType<float>());
+            EXPECT_TRUE(2==num_nodes_fp32);
+            // Check if all conditions are met
+            ASSERT_TRUE((2==op_to_count["Cast"])
+                     && (0==num_initializers_fp16)
+                     && (2==num_initializers_fp32)
+                     && (1==num_nodes_fp16)
+                     && (2==num_nodes_fp32));
+        }
+
+        TEST(TransformerTest, FuseFp16InitializersWithFp32Node) {
+
+            // Init
+            auto test_logger = DefaultLoggingManager().DefaultLogger();
+            auto model_uri = MODEL_FOLDER ORT_TSTR("fuse_fp16_initializers.onnx");
+            std::shared_ptr<Model> model;
+
+            // Load model
+            auto status_at_load = Model::Load(model_uri, model, nullptr, test_logger);
+            ASSERT_TRUE(status_at_load.IsOK()) << status_at_load;
+
+            // Load Graph
+            Graph& graph = model->MainGraph();
+
+            // check graph initial structure
+            test_graph_structure_at_init(graph);
+
+            // apply insert cast transforms
+            InsertCastTransformer insert_cast_transformer("TransformerTest.FusedInitializers",
+                DefaultCpuExecutionProvider()->GetKernelRegistry().get());
+
+            bool graph_modified_by_insert_cast_transforms = false;
+            auto status_insert_cast_transforms = insert_cast_transformer.Apply(graph,
+                                                    graph_modified_by_insert_cast_transforms,
+                                                    test_logger);
+
+            EXPECT_TRUE(status_insert_cast_transforms.IsOK()) << status_insert_cast_transforms;
+            auto status_insert_cast_transforms_resolve = graph.Resolve();
+            EXPECT_TRUE(status_insert_cast_transforms_resolve.IsOK()) << status_insert_cast_transforms_resolve;
+
+            // check graph structure before fusion
+            if(graph_modified_by_insert_cast_transforms) {
+                test_graph_structure_before_fusion(graph);
+            }
+
+            // apply fused initializer transforms
+            FuseInitializersTransformer fused_initializers_transformer("TransformerTest.FusedInitializers",
+                DataTypeImpl::GetTensorType<MLFloat16>(),
+                DataTypeImpl::GetTensorType<float>());
+
+            bool graph_modified_by_fused_initializers_transforms = false;
+            auto status_fused_initializers_transforms = fused_initializers_transformer.Apply(graph,
+                                                            graph_modified_by_fused_initializers_transforms,
+                                                            test_logger);
+
+            EXPECT_TRUE(status_fused_initializers_transforms.IsOK()) << status_fused_initializers_transforms;
+            auto status_fused_initializers_transforms_resolve = graph.Resolve();
+            EXPECT_TRUE(status_fused_initializers_transforms_resolve.IsOK()) << status_fused_initializers_transforms_resolve;
+
+            // If insert cast transforms is applied then FP16 compute is not supported
+            if(graph_modified_by_insert_cast_transforms) {
+
+                // If fp16 compute is not supported, Fusion is performed.
+                // The fp16 node/s is/are transformed to fp32 node/s.
+                // For each fp16 initializer in fp16 node/s, a cast node is created, converting fp16 tensors to fp32
+                // tensors everytime during each inference.
+                // Each of fp16 cast nodes will point to newly created fp32 nodes. Running nodes with fp32 kernel.
+                // From input to next node there will be one FP16 to FP32 cast node. Totaling two FP32 node.
+                // From last node to output there will be one FP32 to FP16 cast node. Totaling one FP16 node.
+                EXPECT_TRUE(graph_modified_by_fused_initializers_transforms) << status_fused_initializers_transforms_resolve;
+
+                // check if graph structure is changed from initial structure
+                test_graph_structure_after_fusion(graph);
+
+            } else {
+
+                // If fp16 compute is supported, Fusion is not performed, keeping the graph as it is.
+                EXPECT_FALSE(graph_modified_by_fused_initializers_transforms) << status_fused_initializers_transforms_resolve;
+
+                // check if graph structure is same as initial structure
+                test_graph_structure_at_init(graph);
+
+            }
+
+        } // FuseFp16InitializersWithFp32Node
+
+    }  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -2361,8 +2361,8 @@ TEST(InferenceSessionTests, LoadModelWithValidOrtConfigJson) {
   ASSERT_TRUE(session_object_1.GetSessionOptions().execution_mode == ExecutionMode::ORT_SEQUENTIAL);
 
   // The default value for graph_optimization_level is Level1
-  // The model requests Level3 - hence that should be used
-  ASSERT_TRUE(session_object_1.GetSessionOptions().graph_optimization_level == TransformerLevel::Level3);
+  // The model requests MaxLevel - hence that should be used
+  ASSERT_TRUE(session_object_1.GetSessionOptions().graph_optimization_level == TransformerLevel::MaxLevel);
 
   // The default value for enable_profiling is false
   // The model requests true - hence that should be used

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -87,7 +87,7 @@ void usage() {
       "\t    [SNPE only] [enable_init_cache]: enable SNPE init caching feature, set to 1 to enabled it. Disabled by default. \n"
       "\t [Usage]: -e <provider_name> -i '<key1>|<value1> <key2>|<value2>' \n\n"
       "\t [Example] [For SNPE EP] -e snpe -i \"runtime|CPU priority|low\" \n\n"
-      "\t-o [optimization level]: Default is 99. Valid values are 0 (disable), 1 (basic), 2 (extended), 99 (all).\n"
+      "\t-o [optimization level]: Default is 99. Valid values are 0 (disable), 1 (basic), 2 (extended), 3 (layout), 99 (all).\n"
       "\t\tPlease see onnxruntime_c_api.h (enum GraphOptimizationLevel) for the full list of all optimization levels. "
       "\t-f: Enable EP context cache generation.\n"
       "\t-b: Disable EP context embed mode.\n"
@@ -342,6 +342,9 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
               break;
             case ORT_ENABLE_EXTENDED:
               graph_optimization_level = ORT_ENABLE_EXTENDED;
+              break;
+            case ORT_ENABLE_LAYOUT:
+              graph_optimization_level = ORT_ENABLE_LAYOUT;
               break;
             case ORT_ENABLE_ALL:
               graph_optimization_level = ORT_ENABLE_ALL;

--- a/onnxruntime/test/perftest/README.md
+++ b/onnxruntime/test/perftest/README.md
@@ -7,39 +7,39 @@ This tool provides the performance results using the ONNX Runtime with the speci
 Options:
 
 	-A: Disable memory arena.
-	
+
 	-M: Disable memory pattern.
-	
+
 	-P: Use parallel executor instead of sequential executor.
-	
+
 	-c: [parallel runs]: Specifies the (max) number of runs to invoke simultaneously. Default:1.
-	
+
 	-e: [cpu|cuda|mkldnn|tensorrt|openvino|acl|vitisai]: Specifies the execution provider 'cpu','cuda','dnnn','tensorrt', 'openvino', 'acl' and 'vitisai'. Default is 'cpu'.
-        
+
 	-m: [test_mode]: Specifies the test mode. Value coulde be 'duration' or 'times'. Provide 'duration' to run the test for a fix duration, and 'times' to repeated for a certain times. Default:'duration'.
-        
-	-o: [optimization level]: Default is 1. Valid values are 0 (disable), 1 (basic), 2 (extended), 99 (all). Please see __onnxruntime_c_api.h__ (enum GraphOptimizationLevel) for the full list of all optimization levels.
-	
+
+	-o: [optimization level]: Default is 1. Valid values are 0 (disable), 1 (basic), 2 (extended), 3 (layout), 99 (all). Please see __onnxruntime_c_api.h__ (enum GraphOptimizationLevel) for the full list of all optimization levels.
+
 	-u: [path to save optimized model]: Default is empty so no optimized model would be saved.
-	
+
 	-p: [profile_file]: Specifies the profile name to enable profiling and dump the profile data to the file.
-	
+
 	-r: [repeated_times]: Specifies the repeated times if running in 'times' test mode.Default:1000.
-        
+
 	-s: Show statistics result, like P75, P90.
 
 	-t: [seconds_to_run]: Specifies the seconds to run for 'duration' mode. Default:600.
-        
+
 	-v: Show verbose information.
-        
+
 	-x: [intra_op_num_threads]: Sets the number of threads used to parallelize the execution within nodes. A value of 0 means the test will auto-select a default. Must >=0.
-	
+
 	-y: [inter_op_num_threads]: Sets the number of threads used to parallelize the execution of the graph (across nodes), A value of 0 means the test will auto-select a default. Must >=0.
 
         -C: [session_config_entries]: Specify session configuration entries as key-value pairs: -C "<key1>|<val1> <key2>|<val2>"
                                       Refer to onnxruntime_session_options_config_keys.h for valid keys and values.
                                       [Example] -C "session.disable_cpu_ep_fallback|1 ep.context_enable|1"
-	
+
 	-h: help.
 
 Model path and input data dependency:
@@ -51,7 +51,7 @@ Model path and input data dependency:
         --test_data_set_2
             --input0.pb
         --model.onnx
-    
+
 The path of model.onnx needs to be provided as `<model_path>` argument.
 
 __Sample output__ from the tool will look something like this:

--- a/onnxruntime/test/perftest/command_args_parser.cc
+++ b/onnxruntime/test/perftest/command_args_parser.cc
@@ -56,7 +56,7 @@ namespace perftest {
       "\t-F [free_dimension_override]: Specifies a free dimension by denotation to override to a specific value for performance optimization. "
       "Syntax is [dimension_denotation:override_value]. override_value must > 0\n"
       "\t-P: Use parallel executor instead of sequential executor.\n"
-      "\t-o [optimization level]: Default is 99 (all). Valid values are 0 (disable), 1 (basic), 2 (extended), 99 (all).\n"
+      "\t-o [optimization level]: Default is 99 (all). Valid values are 0 (disable), 1 (basic), 2 (extended), 3 (layout), 99 (all).\n"
       "\t\tPlease see onnxruntime_c_api.h (enum GraphOptimizationLevel) for the full list of all optimization levels.\n"
       "\t-u [optimized_model_path]: Specify the optimized model path for saving.\n"
       "\t-d [CUDA only][cudnn_conv_algorithm]: Specify CUDNN convolution algorithms: 0(benchmark), 1(heuristic), 2(default). \n"
@@ -324,6 +324,9 @@ static bool ParseDimensionOverride(std::basic_string<ORTCHAR_T>& dim_identifier,
             break;
           case ORT_ENABLE_EXTENDED:
             test_config.run_config.optimization_level = ORT_ENABLE_EXTENDED;
+            break;
+          case ORT_ENABLE_LAYOUT:
+            test_config.run_config.optimization_level = ORT_ENABLE_LAYOUT;
             break;
           case ORT_ENABLE_ALL:
             test_config.run_config.optimization_level = ORT_ENABLE_ALL;

--- a/onnxruntime/test/testdata/transform/fuse_fp16_initializers.onnx
+++ b/onnxruntime/test/testdata/transform/fuse_fp16_initializers.onnx
@@ -1,0 +1,28 @@
+
+:Ÿ
+
+X
+W
+BYconv_1"Conv*
+auto_pad"NOTSET *
+	dilations@@ *
+group *
+kernel_shape@@ *
+pads@@@@ *
+strides@@ !conv_with_initializer_and_padding*!
+*Òs»Tötª\út±cïeåeQBW*
+*£sBBZ
+X
+
+
+
+
+
+b
+Y
+
+
+
+
+
+B

--- a/onnxruntime/wasm/api.h
+++ b/onnxruntime/wasm/api.h
@@ -60,7 +60,7 @@ int EMSCRIPTEN_KEEPALIVE OrtGetLastError(int* error_code, const char** error_mes
  * create an instance of ORT session options.
  * assume that all enum type parameters, such as graph_optimization_level, execution_mode, and log_severity_level,
  * are checked and set properly at JavaScript.
- * @param graph_optimization_level disabled, basic, extended, or enable all
+ * @param graph_optimization_level disabled, basic, extended, layout, or enable all
  * @param enable_cpu_mem_arena enable or disable cpu memory arena
  * @param enable_mem_pattern enable or disable memory pattern
  * @param execution_mode sequential or parallel execution mode

--- a/rust/onnxruntime/src/lib.rs
+++ b/rust/onnxruntime/src/lib.rs
@@ -333,6 +333,8 @@ pub enum GraphOptimizationLevel {
     Basic = sys::GraphOptimizationLevel::ORT_ENABLE_BASIC as OnnxEnumInt,
     /// Extended optimization
     Extended = sys::GraphOptimizationLevel::ORT_ENABLE_EXTENDED as OnnxEnumInt,
+    /// Layout optimization
+    Layout = sys::GraphOptimizationLevel::ORT_ENABLE_LAYOUT as OnnxEnumInt,
     /// Add optimization
     All = sys::GraphOptimizationLevel::ORT_ENABLE_ALL as OnnxEnumInt,
 }
@@ -344,6 +346,7 @@ impl From<GraphOptimizationLevel> for sys::GraphOptimizationLevel {
             DisableAll => sys::GraphOptimizationLevel::ORT_DISABLE_ALL,
             Basic => sys::GraphOptimizationLevel::ORT_ENABLE_BASIC,
             Extended => sys::GraphOptimizationLevel::ORT_ENABLE_EXTENDED,
+            Layout => sys::GraphOptimizationLevel::ORT_ENABLE_LAYOUT,
             All => sys::GraphOptimizationLevel::ORT_ENABLE_ALL,
         }
     }

--- a/tools/python/util/convert_onnx_models_to_ort.py
+++ b/tools/python/util/convert_onnx_models_to_ort.py
@@ -106,12 +106,12 @@ def _convert(
 
     providers = ["CPUExecutionProvider"]
 
-    # if the optimization level is 'all' we manually exclude the NCHWc transformer. It's not applicable to ARM
-    # devices, and creates a device specific model which won't run on all hardware.
+    # if the optimization level is greater than or equal to 'layout' we manually exclude the NCHWc transformer.
+    # It's not applicable to ARM devices, and creates a device specific model which won't run on all hardware.
     # If someone really really really wants to run it they could manually create an optimized onnx model first,
     # or they could comment out this code.
     optimizer_filter = None
-    if optimization_level == ort.GraphOptimizationLevel.ORT_ENABLE_ALL and target_platform != "amd64":
+    if ((optimization_level >= ort.GraphOptimizationLevel.ORT_ENABLE_LAYOUT) and target_platform != "amd64"):
         optimizer_filter = ["NchwcTransformer"]
 
     converted_models = []

--- a/tools/python/util/onnx_model_utils.py
+++ b/tools/python/util/onnx_model_utils.py
@@ -376,6 +376,9 @@ def get_optimization_level(level):
     if level == "extended":
         # Optimizations using custom operators, excluding NCHWc and NHWC layout optimizers
         return ort.GraphOptimizationLevel.ORT_ENABLE_EXTENDED
+    if level == "layout":
+        # NCHWc and NHWC layout optimizers
+        return ort.GraphOptimizationLevel.ORT_ENABLE_LAYOUT
     if level == "all":
         return ort.GraphOptimizationLevel.ORT_ENABLE_ALL
 

--- a/tools/python/util/optimize_onnx_model.py
+++ b/tools/python/util/optimize_onnx_model.py
@@ -22,7 +22,7 @@ def optimize_model_helper():
     parser.add_argument(
         "--opt_level",
         default="basic",
-        choices=["disable", "basic", "extended", "all"],
+        choices=["disable", "basic", "extended", "layout", "all"],
         help="Optimization level to use.",
     )
     parser.add_argument(


### PR DESCRIPTION
### Description

Added a graph transform for mixed precisions graphs when FP16 compute is unavailable. At session creation, this graph transform converts FP16 initializers (_which were changed to FP16 to FP32 cast nodes_) to FP32 initializers and fuses them with their next FP32 nodes.
 

- Behavior before this change:
"fp16 initializers -> cast_from_fp16_to_fp32 -> fp32 node/s"
 
- Behavior after this change:
"fp16 initializers converted to fp32 initializers then fused with fp32 node/s"

### Motivation and Context

This change aims to run the FP16 models without the repetitive casting of FP16 initializers to FP32 initializers, by fusing FP32 initializers with their next nodes, when FP16 compute is not available.

### Two separate commits For this PR

This PR consists of two separate commits.
- The **First commit** adds Fuse Initializers Graph Transforms "FIGT" as the last stage of the graph transforms during session creation.
- The **second commit** adds a new level to Graph Transforms, "Level 4".  We purposed it to be used to support unsupported datatype computes. We added "FIGT" to Level 4 of graph optimization levels, so that it can be turned off whenever required and the Level 1 to Level 3 optimizations remain unaffected.
- We have submitted this PR with two commits so we can track the changes needed for both commits separately. Once approved, we can squash these commits before merging.

### Re-Running Level 1 to Level 3 optimizations after Level 4 / FIGT

The idea behind re-running Level1, Partitioning, Level2, and Level3 graph transforms is that, after the fusion of initializers with their respective nodes, the nodes are now in a format that might be supported by other graph transforms that were previously skipped. Hence, some of the transformations previously unable to be applied are now valid and can be applied to create a more optimal graph for execution.

### Documentation

We have not yet added any details related to Level 4 in the [Graph Optimizations in ONNX Runtime](https://onnxruntime.ai/docs/performance/model-optimizations/graph-optimizations.html) documentation. We might need a little bit of guidance on how to update this documentation, once the PR is accepted.

### Working

Currently, the Fuse Initializers Graph Transform fuses cast nodes that casts from FP16 to FP32, back to their
next/output nodes. Below is an explanation of how this transforms works. It depends on ```InsertCastTransforms```
to produce the intermediate representation from which it fuses the initializers (which are the cast node with
zero input, one initializer, and one output) back to the next/output node. After fusion, the link/edge between such
cast node to the next/output node will then be removed.

```
        "Input Graph"                       "Intermediate Representation"                 "FIGT Transforms"

          --------                   --------        --------        --------                 --------
         | X_Fp16 |                 | X_Fp16 |      | W_Fp16 |      | B_Fp16 |               | X_Fp16 |
          --------                   --------        --------        --------                 --------
             |                          |               |               |                        |
             |                          |               |               |                        |
             |                          V               V               V                        V
             |                       | Cast |        | Cast |        | Cast |                 | Cast |
             |                       | Fp16 |        | Fp16 |        | Fp16 |                 | Fp16 |
             |                       |  To  |        |  To  |        |  To  |                 |  To  |
             |                       | Fp32 |        | Fp32 |        | Fp32 |                 | Fp32 |
             |                          |               |               |                        |
             |                          |               |               |                        |
             V                          V               V               V                        V
 ----------------------------       -----------------------------------------       ----------------------------
|        Conv_Fp16           |     |                                         |     |         Conv_Fp32          |
|        --W_Fp16--          | ==> |                Conv_Fp32                | ==> |         --W_Fp32--         |
|        --B_Fp16--          |     |                                         |     |         --B_Fp32--         |
 ----------------------------       -----------------------------------------       ----------------------------
             |                                          |                                        |
             |                                          |                                        |
             |                                          V                                        V
             |                                       | Cast |                                 | Cast |
             |                                       | Fp32 |                                 | Fp32 |
             |                                       |  To  |                                 |  To  |
             |                                       | Fp16 |                                 | Fp16 |
             |                                          |                                        |
             |                                          |                                        |
             V                                          V                                        V
          --------                                   --------                                 --------
         | Y_Fp16 |                                 | Y_Fp16 |                               | Y_Fp16 |
          --------                                   --------                                 --------
```