### PR TITLE
[webgpu-ep] Fix test_batchnorm_example

### DIFF
--- a/onnxruntime/core/providers/webgpu/nn/batch_norm.cc
+++ b/onnxruntime/core/providers/webgpu/nn/batch_norm.cc
@@ -124,6 +124,7 @@ Status BatchNormalization<is_nhwc>::ComputeInternal(ComputeContext& context) con
 
   BatchNormalizationProgram program{epsilon_, spatial_, format_, static_cast<int64_t>(components)};
   program
+      .CacheHint(epsilon_, spatial_, format_, components)
       .AddInputs({{input_tensor, ProgramTensorMetadataDependency::TypeAndRank, components},
                   {scale, ProgramTensorMetadataDependency::TypeAndRank, c_components},
                   {B, ProgramTensorMetadataDependency::TypeAndRank, c_components},

--- a/onnxruntime/core/providers/webgpu/nn/batch_norm.cc
+++ b/onnxruntime/core/providers/webgpu/nn/batch_norm.cc
@@ -104,6 +104,7 @@ Status BatchNormalization<is_nhwc>::ComputeInternal(ComputeContext& context) con
   const TensorShape& input_shape = input_tensor->Shape();
   size_t input_rank = input_shape.NumDimensions();
   const int components = spatial_ ? ((input_shape[input_rank - 1] % 4 == 0) ? 4 : ((input_shape[input_rank - 1] % 2 == 0) ? 2 : 1)) : 1;
+  const int c_components = is_nhwc && input_rank > 1 ? components : 1;
 
   auto output_dims = input_shape.AsShapeVector();
   TensorShape output_shape(output_dims);
@@ -123,12 +124,12 @@ Status BatchNormalization<is_nhwc>::ComputeInternal(ComputeContext& context) con
 
   BatchNormalizationProgram program{epsilon_, spatial_, format_, static_cast<int64_t>(components)};
   program
-      .AddInputs({{input_tensor, ProgramTensorMetadataDependency::TypeAndRank},
-                  {scale, ProgramTensorMetadataDependency::TypeAndRank},
-                  {B, ProgramTensorMetadataDependency::TypeAndRank},
-                  {input_mean, ProgramTensorMetadataDependency::TypeAndRank},
-                  {input_var, ProgramTensorMetadataDependency::TypeAndRank}})
-      .AddOutputs({output_tensor})
+      .AddInputs({{input_tensor, ProgramTensorMetadataDependency::TypeAndRank, components},
+                  {scale, ProgramTensorMetadataDependency::TypeAndRank, c_components},
+                  {B, ProgramTensorMetadataDependency::TypeAndRank, c_components},
+                  {input_mean, ProgramTensorMetadataDependency::TypeAndRank, c_components},
+                  {input_var, ProgramTensorMetadataDependency::TypeAndRank, c_components}})
+      .AddOutputs({{output_tensor, ProgramTensorMetadataDependency::TypeAndRank, components}})
       .SetDispatchGroupSize((output_size + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE)
       .AddUniformVariables({{static_cast<uint32_t>(output_size)}});
   return context.RunProgram(program);


### PR DESCRIPTION
This fixes the missing component handling for the input and output variables in BatchNorm operator.
