### PR TITLE
Disable KleidiAI in Python Packaging pipeline MacOS build

### DIFF
--- a/tools/ci_build/github/azure-pipelines/stages/py-cpu-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/py-cpu-packaging-stage.yml
@@ -232,7 +232,20 @@ stages:
           set -e -x
           export _PYTHON_HOST_PLATFORM=macosx-${{variables.MACOSX_DEPLOYMENT_TARGET}}-universal2
           python3 -m pip install -r '$(Build.SourcesDirectory)/tools/ci_build/github/linux/docker/scripts/requirements.txt'
-          python3 $(Build.SourcesDirectory)/tools/ci_build/build.py --build_dir $(Build.BinariesDirectory) --use_coreml --skip_submodule_sync --parallel --use_vcpkg --use_vcpkg_ms_internal_asset_cache --use_binskim_compliant_compile_flags --config Release --build_wheel ${{ parameters.build_py_parameters }} --use_coreml --cmake_extra_defines CMAKE_OSX_ARCHITECTURES="arm64;x86_64" --update --build
+          # Note: There is a build error when we set CMAKE_OSX_ARCHITECTURES="arm64;x86_64" and KleidiAI is enabled.
+          # Disable KleidiAI as a workaround with --no_kleidiai.
+          # TODO Re-enable KleidiAI once https://github.com/microsoft/onnxruntime/issues/24152 is fixed.
+          python3 $(Build.SourcesDirectory)/tools/ci_build/build.py \
+            --build_dir $(Build.BinariesDirectory) \
+            --use_vcpkg --use_vcpkg_ms_internal_asset_cache \
+            --use_binskim_compliant_compile_flags \
+            --config Release \
+            --build_wheel \
+            --use_coreml \
+            --no_kleidiai \
+            ${{ parameters.build_py_parameters }} \
+            --cmake_extra_defines CMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
+            --update --skip_submodule_sync --build --parallel
         displayName: 'Command Line Script'
 
       - script: |


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Disable KleidiAI in Python Packaging pipeline MacOS build. This is a workaround for a build error. See https://github.com/microsoft/onnxruntime/issues/24152.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Address build error.
