### PR TITLE
Enable mapping of buffers allocated on CPU in the NPU address space

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -1861,5 +1861,17 @@ Status QnnBackendManager::GetOrRegisterContextMemHandle(Qnn_ContextHandle_t cont
   return Status::OK();
 }
 
+Status QnnBackendManager::UnregisterContextMemHandle(Qnn_ContextHandle_t context_handle, void* memory_address) {
+  const auto context_handle_record_it = context_map_.find(context_handle);
+  ORT_RETURN_IF_NOT(context_handle_record_it != context_map_.end(), "QNN context not found: ", context_handle);
+
+  auto& context_handle_record = context_handle_record_it->second;
+  auto& context_mem_handle_manager = context_handle_record->mem_handles;
+
+  ORT_RETURN_IF_ERROR(context_mem_handle_manager->Unregister(memory_address));
+
+  return Status::OK();
+}
+
 }  // namespace qnn
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -1807,7 +1807,7 @@ Status QnnBackendManager::GetOrRegisterContextMemHandle(Qnn_ContextHandle_t cont
                                                         void* memory_address,
                                                         const Qnn_Tensor_t& qnn_tensor,
                                                         Qnn_MemHandle_t& mem_handle,
-                                                        const bool uses_shared_mem_alloc) {
+                                                        bool uses_shared_mem_allocator) {
   // Multi-threading situations to consider:
   // 1) Memory allocation is being freed in another thread while we are processing `memory_address`.
   //    This implies incorrect usage as the memory is being freed while it is still in use. Let's assume this won't
@@ -1824,10 +1824,10 @@ Status QnnBackendManager::GetOrRegisterContextMemHandle(Qnn_ContextHandle_t cont
   auto& context_mem_handle_manager = context_handle_record->mem_handles;
 
   bool did_register{};
-  ORT_RETURN_IF_ERROR(context_mem_handle_manager->GetOrRegister(memory_address, uses_shared_mem_alloc, qnn_tensor,
+  ORT_RETURN_IF_ERROR(context_mem_handle_manager->GetOrRegister(memory_address, uses_shared_mem_allocator, qnn_tensor,
                                                                 mem_handle, did_register));
 
-  if (did_register && uses_shared_mem_alloc) {
+  if (did_register && uses_shared_mem_allocator) {
     HtpSharedMemoryAllocator::AllocationCleanUpFn unregister_mem_handle =
         [&logger = *logger_,
          weak_backend_manager = weak_from_this(),

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -138,7 +138,7 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
   Status GetOrRegisterContextMemHandle(Qnn_ContextHandle_t context, void* memory_address,
                                        const Qnn_Tensor_t& qnn_tensor,
                                        Qnn_MemHandle_t& mem_handle,
-                                       const bool uses_shared_mem_alloc);
+                                       bool uses_shared_mem_allocator);
 
   // Unregisters a QNN mem handle if one exists for the given context and memory address
   Status UnregisterContextMemHandle(Qnn_ContextHandle_t context, void* memory_address);

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -135,9 +135,10 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
 
   // Gets an existing QNN mem handle or registers a new one.
   // `mem_handle` is set to the QNN mem handle.
-  Status GetOrRegisterContextMemHandle(Qnn_ContextHandle_t context, void* shared_memory_address,
+  Status GetOrRegisterContextMemHandle(Qnn_ContextHandle_t context, void* memory_address,
                                        const Qnn_Tensor_t& qnn_tensor,
-                                       Qnn_MemHandle_t& mem_handle);
+                                       Qnn_MemHandle_t& mem_handle,
+                                       const bool uses_shared_mem_alloc);
 
   Status ParseLoraConfig(std::string lora_config);
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -140,6 +140,9 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
                                        Qnn_MemHandle_t& mem_handle,
                                        const bool uses_shared_mem_alloc);
 
+  // Unregisters a QNN mem handle if one exists for the given context and memory address
+  Status UnregisterContextMemHandle(Qnn_ContextHandle_t context, void* memory_address);
+
   Status ParseLoraConfig(std::string lora_config);
 
  private:

--- a/onnxruntime/core/providers/qnn/builder/qnn_context_mem_handle_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_context_mem_handle_manager.h
@@ -10,6 +10,7 @@
 #include "QnnInterface.h"
 
 #include "core/providers/qnn/ort_api.h"
+#include "core/providers/qnn/rpcmem_library.h"
 
 namespace onnxruntime::qnn {
 
@@ -27,7 +28,7 @@ class QnnContextMemHandleManager {
 
   // Gets an existing QNN mem handle or registers a new one.
   // `qnn_mem_handle` is set to the QNN mem handle and `did_register` is true if `qnn_mem_handle` was newly registered.
-  Status GetOrRegister(void* memory_address, const bool uses_shared_mem_alloc, const Qnn_Tensor_t& qnn_tensor,
+  Status GetOrRegister(void* memory_address, bool uses_shared_mem_allocator, const Qnn_Tensor_t& qnn_tensor,
                        Qnn_MemHandle_t& qnn_mem_handle, bool& did_register);
 
   Status Unregister(void* memory_address);
@@ -38,6 +39,7 @@ class QnnContextMemHandleManager {
   const QNN_INTERFACE_VER_TYPE& qnn_interface_;
   Qnn_ContextHandle_t context_;
   const logging::Logger& logger_;
+  const qnn::RpcMemLibrary rpc_lib_;
 
   // assume Qnn_MemHandle_t is a pointer and able to be wrapped with std::unique_ptr
   static_assert(std::is_pointer_v<Qnn_MemHandle_t>);
@@ -50,7 +52,7 @@ class QnnContextMemHandleManager {
     UniqueQnnMemHandle mem_handle;
   };
 
-  // shared memory address -> associated mem handle record
+  // memory address -> associated mem handle record
   InlinedHashMap<const void*, MemHandleRecord> mem_handles_;
   std::mutex mem_handles_mutex_;  // synchronize access to mem_handles_
 };

--- a/onnxruntime/core/providers/qnn/builder/qnn_context_mem_handle_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_context_mem_handle_manager.h
@@ -27,10 +27,10 @@ class QnnContextMemHandleManager {
 
   // Gets an existing QNN mem handle or registers a new one.
   // `qnn_mem_handle` is set to the QNN mem handle and `did_register` is true if `qnn_mem_handle` was newly registered.
-  Status GetOrRegister(void* shared_memory_address, const Qnn_Tensor_t& qnn_tensor,
+  Status GetOrRegister(void* memory_address, const bool uses_shared_mem_alloc, const Qnn_Tensor_t& qnn_tensor,
                        Qnn_MemHandle_t& qnn_mem_handle, bool& did_register);
 
-  Status Unregister(void* shared_memory_address);
+  Status Unregister(void* memory_address);
 
   void Clear();
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_context_mem_handle_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_context_mem_handle_manager.h
@@ -39,7 +39,7 @@ class QnnContextMemHandleManager {
   const QNN_INTERFACE_VER_TYPE& qnn_interface_;
   Qnn_ContextHandle_t context_;
   const logging::Logger& logger_;
-  const qnn::RpcMemLibrary rpc_lib_;
+  std::unique_ptr<qnn::RpcMemLibrary> rpc_lib_;
 
   // assume Qnn_MemHandle_t is a pointer and able to be wrapped with std::unique_ptr
   static_assert(std::is_pointer_v<Qnn_MemHandle_t>);

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.cc
@@ -193,26 +193,30 @@ Status QnnModel::SetupQnnInputOutput(const logging::Logger& logger) {
   return Status::OK();
 }
 
+#include "HTP\QnnHtpMem.h"
+#define BUFF_ALIGNMENT 4096
+
 static Status BindQnnTensorMemoryToOrtValueMemory(const logging::Logger& logger,
                                                   QnnBackendManager& qnn_backend_manager,
                                                   const OrtMemoryInfo& ort_value_memory_info,
                                                   void* ort_value_data, uint32_t ort_value_data_size,
                                                   Qnn_ContextHandle_t qnn_context,
                                                   Qnn_Tensor_t& qnn_tensor) {
-  // either set qnn_tensor memHandle or clientBuf
-  const bool uses_shared_memory = ort_value_memory_info == HtpSharedMemoryAllocator::AssociatedMemoryInfo();
+  const bool uses_shared_mem_alloc = ort_value_memory_info == HtpSharedMemoryAllocator::AssociatedMemoryInfo();
+  const bool buffer_aligned = ((uintptr_t)ort_value_data % BUFF_ALIGNMENT) == 0 && ort_value_data_size % BUFF_ALIGNMENT == 0;
+  const bool htp_backend = qnn_backend_manager.GetQnnBackendType() == QnnBackendType::HTP;
 
-  if (!uses_shared_memory) {
+  if (uses_shared_mem_alloc || (htp_backend && buffer_aligned)) {
+    Qnn_MemHandle_t qnn_mem_handle;
+    ORT_RETURN_IF_ERROR(qnn_backend_manager.GetOrRegisterContextMemHandle(qnn_context, ort_value_data, qnn_tensor,
+                                                                          qnn_mem_handle, uses_shared_mem_alloc));
+    SetQnnTensorMemType(qnn_tensor, QNN_TENSORMEMTYPE_MEMHANDLE);
+    SetQnnTensorMemHandle(qnn_tensor, qnn_mem_handle);
+
+  } else {
     LOGS(logger, VERBOSE) << "Setting Qnn_Tensor_t clientBuf to ORT tensor memory.";
     SetQnnTensorMemType(qnn_tensor, QNN_TENSORMEMTYPE_RAW);
     SetQnnTensorClientBuf(qnn_tensor, ort_value_data, ort_value_data_size);
-  } else {
-    LOGS(logger, VERBOSE) << "Setting Qnn_Tensor_t memHandle to ORT tensor shared memory.";
-    Qnn_MemHandle_t qnn_mem_handle{};
-    ORT_RETURN_IF_ERROR(qnn_backend_manager.GetOrRegisterContextMemHandle(qnn_context, ort_value_data, qnn_tensor,
-                                                                          qnn_mem_handle));
-    SetQnnTensorMemType(qnn_tensor, QNN_TENSORMEMTYPE_MEMHANDLE);
-    SetQnnTensorMemHandle(qnn_tensor, qnn_mem_handle);
   }
 
   return Status::OK();

--- a/onnxruntime/core/providers/qnn/rpcmem_library.cc
+++ b/onnxruntime/core/providers/qnn/rpcmem_library.cc
@@ -165,6 +165,8 @@ RpcMemApi CreateApi(void* library_handle) {
 
   ORT_THROW_IF_ERROR(env.GetSymbolFromLibrary(library_handle, "rpcmem_to_fd", (void**)&api.to_fd));
 
+  ORT_THROW_IF_ERROR(env.GetSymbolFromLibrary(library_handle, "remote_register_buf_attr", (void**)&api.register_buff_attr));
+
   return api;
 }
 

--- a/onnxruntime/core/providers/qnn/rpcmem_library.h
+++ b/onnxruntime/core/providers/qnn/rpcmem_library.h
@@ -30,7 +30,7 @@ constexpr int FASTRPC_ATTR_IMPORT_BUFFER = 256;
 // FastRPC invalid client handle
 constexpr int INVALID_CLIENT_HANDLE = -1;
 
-  // RPCMEM alignment is in 4KB blocks
+// RPCMEM alignment is in 4KB blocks
 constexpr const size_t BUFFER_ALIGNMENT_BLOCK_SIZE = 4096;
  
  /**
@@ -55,7 +55,7 @@ using FreeFnPtr = void (*)(void* po);
  */
 using ToFdFnPtr = int (*)(void* po);
 
-using RemoteRegisterBufAttr = void (*)(void *po, int size, int fd, int attr);
+using RemoteRegisterBufAttrFnPtr = void (*)(void *po, int size, int fd, int attr);
 }  // namespace rpcmem
 
 // RPCMEM API function pointers.
@@ -63,7 +63,7 @@ struct RpcMemApi {
   rpcmem::AllocFnPtr alloc;
   rpcmem::FreeFnPtr free;
   rpcmem::ToFdFnPtr to_fd;
-  rpcmem::RemoteRegisterBufAttr register_buff_attr;
+  rpcmem::RemoteRegisterBufAttrFnPtr register_buff_attr;
 };
 
 // Loads and provides access to the RPCMEM API functions from a dynamically loaded library.

--- a/onnxruntime/core/providers/qnn/rpcmem_library.h
+++ b/onnxruntime/core/providers/qnn/rpcmem_library.h
@@ -24,7 +24,13 @@ constexpr uint32_t RPCMEM_DEFAULT_FLAGS = 1;
 
 constexpr int RPCMEM_HEAP_ID_SYSTEM = 25;
 
-/**
+// External flag passed to fastrpc_register_buf_attr that specifies that a buffer should be imported
+constexpr int FASTRPC_ATTR_IMPORT_BUFFER = 256;
+
+// FastRPC invalid client handle
+constexpr int INVALID_CLIENT_HANDLE = -1;
+ 
+ /**
  * Allocate a zero-copy buffer for size upto 2 GB with the FastRPC framework.
  * Buffers larger than 2 GB must be allocated with rpcmem_alloc2
  * @param[in] heapid  Heap ID to use for memory allocation.
@@ -46,6 +52,7 @@ using FreeFnPtr = void (*)(void* po);
  */
 using ToFdFnPtr = int (*)(void* po);
 
+using RemoteRegisterBufAttr = void (*)(void *po, int size, int fd, int attr);
 }  // namespace rpcmem
 
 // RPCMEM API function pointers.
@@ -53,6 +60,7 @@ struct RpcMemApi {
   rpcmem::AllocFnPtr alloc;
   rpcmem::FreeFnPtr free;
   rpcmem::ToFdFnPtr to_fd;
+  rpcmem::RemoteRegisterBufAttr register_buff_attr;
 };
 
 // Loads and provides access to the RPCMEM API functions from a dynamically loaded library.

--- a/onnxruntime/core/providers/qnn/rpcmem_library.h
+++ b/onnxruntime/core/providers/qnn/rpcmem_library.h
@@ -24,11 +24,14 @@ constexpr uint32_t RPCMEM_DEFAULT_FLAGS = 1;
 
 constexpr int RPCMEM_HEAP_ID_SYSTEM = 25;
 
-// External flag passed to fastrpc_register_buf_attr that specifies that a buffer should be imported
+// External flag passed to fastrpc_register_buf_attr that specifies that a buffer should be copied to RPCMEM space
 constexpr int FASTRPC_ATTR_IMPORT_BUFFER = 256;
 
 // FastRPC invalid client handle
 constexpr int INVALID_CLIENT_HANDLE = -1;
+
+  // RPCMEM alignment is in 4KB blocks
+constexpr const size_t BUFFER_ALIGNMENT_BLOCK_SIZE = 4096;
  
  /**
  * Allocate a zero-copy buffer for size upto 2 GB with the FastRPC framework.


### PR DESCRIPTION
### Description
Enable mapping of buffers allocated on CPU in the NPU address space to avoid copying of buffers.
- Check if data is using shared memory allocator or is buffer aligned & using HTP backend before QNN registration
- During QNN registration, if memory is not allocated via shared mem allocator, map to FastRPC via remote_register_buffer_attr
- Retrieve fd after mapping and create the ShareBufferConfig
- Add FastRPC dergistration in mem_handles_ destructor lambda

Limitations:
Buffers should be 4k aligned.

### Motivation and Context
(https://github.com/microsoft/onnxruntime/issues/23457)


