### PR TITLE
Enable Inference Results Saving in onnx-test-runner

### DIFF
--- a/onnxruntime/test/onnx/README.txt
+++ b/onnxruntime/test/onnx/README.txt
@@ -2,6 +2,7 @@ onnx_test_runner [options...] <data_root>
 Options:
         -j [models]: Specifies the number of models to run simultaneously.
         -c [runs]: Specifies the number of Session::Run() to invoke simultaneously for each model.
+        -I [inference_mode]: Use inference mode. Save the inference result and skip the output value comparison.
         -n [test_case_name]: Specifies a single test case to run.
         -p [PLANNER_TYPE]: PLANNER_TYPE could be 'seq' or 'simple'. Default: 'simple'.
         -e [EXECUTION_PROVIDER]: EXECUTION_PROVIDER could be 'cpu', 'cuda', 'dnnl', 'tensorrt' or 'acl'. Default: 'cpu'.
@@ -33,3 +34,15 @@ How to run model tests:
    onnx_test_runner <test_data_dir>
    e.g.
 	 onnx_test_runner C:\testdata
+
+3. If running with inference_mode (-I), onnx_test_runner will save output in pb format.
+   - The value comparison will be skipped
+   - The actual_output_<output_id>.pb will be saved in the corresponding test_data_set_<test_case_id> directory.
+   - Example:
+      C:\workspace\resnet18-v1-7
+      │   resnet18-v1-7.onnx
+      │
+      └───test_data_set_0
+            actual_output_0.pb (produced by onnx_test_runner.exe)
+            input_0.pb
+            output_0.pb

--- a/onnxruntime/test/onnx/TestCase.cc
+++ b/onnxruntime/test/onnx/TestCase.cc
@@ -306,6 +306,10 @@ class OnnxTestCase : public ITestCase {
                        bool is_input, size_t i,
                        std::unordered_map<std::string, Ort::Value>& out) const;
 
+  void ConvertResult(Ort::Value& out_value,
+                     size_t i,
+                     ONNX_NAMESPACE::TensorProto& result_pb) const;
+
   void ConvertTestData(const ONNX_NAMESPACE::SequenceProto& test_data_pb,
                        onnxruntime::test::HeapBuffer& b,
                        bool is_input, size_t i,
@@ -349,6 +353,7 @@ class OnnxTestCase : public ITestCase {
 
   void LoadTestData(size_t id, onnxruntime::test::HeapBuffer& b, std::unordered_map<std::string, Ort::Value>&,
                     bool is_input) const override;
+  void SaveResult(size_t id, std::vector<Ort::Value>& out_values) const override;
 };
 
 std::unique_ptr<ITestCase> CreateOnnxTestCase(const std::string& test_case_name,
@@ -439,6 +444,21 @@ static void LoadTensor(const PATH_STRING_TYPE& pb_file, ONNX_NAMESPACE::TensorPr
   f.SetCloseOnDelete(true);
   if (!input_pb.ParseFromZeroCopyStream(&f)) {
     ORT_THROW("parse file '", ToUTF8String(pb_file), "' failed");
+  }
+}
+
+// save tensors to disk
+template <typename PATH_STRING_TYPE>
+static void SaveTensor(const PATH_STRING_TYPE& pb_file, ONNX_NAMESPACE::TensorProto& result_pb) {
+  int tensor_fd;
+  auto st = Env::Default().FileOpenWr(pb_file, tensor_fd);
+  if (!st.IsOK()) {
+    ORT_THROW("open file '", ToUTF8String(pb_file), "' failed:", st.ErrorMessage());
+  }
+  google::protobuf::io::FileOutputStream f(tensor_fd, protobuf_block_size_in_bytes);
+  f.SetCloseOnDelete(true);
+  if (!result_pb.SerializeToZeroCopyStream(&f)) {
+    ORT_THROW("serialize file '", ToUTF8String(pb_file), "' failed");
   }
 }
 
@@ -559,6 +579,41 @@ void OnnxTestCase::LoadTestData(size_t id, onnxruntime::test::HeapBuffer& b,
   }
 }
 
+void OnnxTestCase::SaveResult(size_t id, std::vector<Ort::Value>& out_values) const {
+  if (id >= test_data_dirs_.size()) {
+    ORT_THROW("index out of bound");
+  }
+  std::vector<PATH_STRING_TYPE> result_pb_files;
+
+  std::filesystem::path dir_fs_path = test_data_dirs_[id];
+  if (!std::filesystem::exists(dir_fs_path)) return;
+
+  for (size_t idx = 0; idx < out_values.size(); idx++) {
+    auto onnx_type = out_values[idx].GetConst().GetTypeInfo().GetConst().GetONNXType();
+    if (onnx_type == ONNXType::ONNX_TYPE_TENSOR) {
+      ONNX_NAMESPACE::TensorProto result_pb;
+      ConvertResult(out_values[idx], idx, result_pb);
+      std::cout << "[SaveResult] " << result_pb.dims_size() << std::endl;
+#ifdef _WIN32
+      std::wstring actual_output = std::wstring(L"actual_output_") + std::to_wstring(idx) + std::wstring(L".pb");
+#else
+      std::string actual_output = std::string("actual_output_") + std::to_string(idx) + std::string(".pb");
+#endif
+      result_pb_files.push_back(actual_output);
+      SaveTensor(dir_fs_path / result_pb_files[idx], result_pb);
+    } else if (onnx_type == ONNXType::ONNX_TYPE_SEQUENCE) {
+      // TODO: Support SequenceProto
+      ORT_THROW("ONNX_TYPE_SEQUENCE type for the output ", idx, " is not yet supported in test runner SaveResult");
+    } else if (onnx_type == ONNXType::ONNX_TYPE_OPTIONAL) {
+      // TODO: Support OptionalProto
+      ORT_THROW("ONNX_TYPE_OPTIONAL type for the output ", idx, " is not yet supported in test runner SaveResult");
+    } else {
+      ORT_THROW("Unsupported type for the output ", idx, " in test runner SaveResult");
+    }
+  }
+  return;
+}
+
 void OnnxTestCase::ConvertTestData(const ONNX_NAMESPACE::TensorProto& test_data_pb,
                                    onnxruntime::test::HeapBuffer& b,
                                    bool is_input, size_t i,
@@ -587,6 +642,18 @@ void OnnxTestCase::ConvertTestData(const ONNX_NAMESPACE::TensorProto& test_data_
     b.AddDeleter(d);
   }
   out.emplace(name_finalized, std::move(v1));
+}
+
+void OnnxTestCase::ConvertResult(Ort::Value& out_value,
+                                 size_t i,
+                                 ONNX_NAMESPACE::TensorProto& result_pb) const {
+  // Convert output Ort::Value to TensorProto
+  std::string out_name = model_info_->GetOutputName(i);
+  auto status = onnxruntime::test::MLValueToTensorProto(out_value, result_pb);
+  if (!status.IsOK()) {
+    ORT_THROW("Output ", i, " ", out_name, ": ", status.ToString());
+  }
+  return;
 }
 
 void OnnxTestCase::ConvertTestData(const ONNX_NAMESPACE::SequenceProto& test_data_pb,

--- a/onnxruntime/test/onnx/TestCase.h
+++ b/onnxruntime/test/onnx/TestCase.h
@@ -32,6 +32,7 @@ class ITestCase {
   virtual void LoadTestData(size_t id, onnxruntime::test::HeapBuffer& b,
                             std::unordered_map<std::string, Ort::Value>& name_data_map,
                             bool is_input) const = 0;
+  virtual void SaveResult(size_t id, std::vector<Ort::Value>& out_values) const = 0;
   virtual const std::filesystem::path& GetModelUrl() const = 0;
   virtual const std::string& GetNodeName() const = 0;
   virtual const ONNX_NAMESPACE::ValueInfoProto* GetInputInfoFromModel(size_t i) const = 0;

--- a/onnxruntime/test/onnx/dataitem_request.cc
+++ b/onnxruntime/test/onnx/dataitem_request.cc
@@ -19,10 +19,10 @@ namespace onnxruntime {
 namespace test {
 
 std::pair<EXECUTE_RESULT, TIME_SPEC> DataTaskRequestContext::Run(const ITestCase& c, ::Ort::Session& session,
-                                                                 OrtAllocator* allocator, size_t task_id) {
+                                                                 OrtAllocator* allocator, size_t task_id, bool inference_mode) {
   std::pair<EXECUTE_RESULT, TIME_SPEC> result;
   Callback empty_cb;
-  DataTaskRequestContext ctx(empty_cb, c, session, allocator, task_id);
+  DataTaskRequestContext ctx(empty_cb, c, session, allocator, task_id, inference_mode);
   ORT_TRY {
     result = ctx.RunImpl();
   }
@@ -37,9 +37,9 @@ std::pair<EXECUTE_RESULT, TIME_SPEC> DataTaskRequestContext::Run(const ITestCase
 
 void DataTaskRequestContext::Request(const Callback& cb, concurrency::ThreadPool* tp,
                                      const ITestCase& c, Ort::Session& session,
-                                     OrtAllocator* allocator, size_t task_id) {
+                                     OrtAllocator* allocator, size_t task_id, bool inference_mode) {
   assert(cb);
-  std::unique_ptr<DataTaskRequestContext> self = std::make_unique<DataTaskRequestContext>(cb, c, session, allocator, task_id);
+  std::unique_ptr<DataTaskRequestContext> self = std::make_unique<DataTaskRequestContext>(cb, c, session, allocator, task_id, inference_mode);
   CallableFactory<DataTaskRequestContext, void> f(self.get());
   auto runnable = f.GetCallable<&DataTaskRequestContext::RunAsync>();
   onnxruntime::concurrency::ThreadPool::Schedule(tp, [runnable]() { runnable.Invoke(); });
@@ -118,6 +118,10 @@ std::pair<EXECUTE_RESULT, TIME_SPEC> DataTaskRequestContext::RunImpl() {
   test_case_.GetRelativePerSampleTolerance(&relative_per_sample_tolerance);
   test_case_.GetPostProcessing(&post_procesing);
 
+  if (inference_mode_) {
+    test_case_.SaveResult(task_id_, output_values);
+    return std::make_pair(EXECUTE_RESULT::SUCCESS, spent_time_);
+  }
   std::unordered_map<std::string, Ort::Value> expected_output_values;
   test_case_.LoadTestData(task_id_, holder, expected_output_values, false);
 

--- a/onnxruntime/test/onnx/dataitem_request.h
+++ b/onnxruntime/test/onnx/dataitem_request.h
@@ -39,7 +39,7 @@ class DataTaskRequestContext {
   /// <param name="task_id">this task id</param>
   /// <returns>execution result and elapsed time</returns>
   static std::pair<EXECUTE_RESULT, TIME_SPEC> Run(const ITestCase& c, ::Ort::Session& session,
-                                                  OrtAllocator* allocator, size_t task_id);
+                                                  OrtAllocator* allocator, size_t task_id, bool inference_mode = false);
 
   /// <summary>
   /// Schedules a data task to run on a threadpool. The function
@@ -53,7 +53,7 @@ class DataTaskRequestContext {
   /// <param name="task_id">this taks id</param>
   static void Request(const Callback& cb, concurrency::ThreadPool* tp,
                       const ITestCase& c, ::Ort::Session& session,
-                      OrtAllocator* allocator, size_t task_id);
+                      OrtAllocator* allocator, size_t task_id, bool inference_mode = false);
 
   ORT_DISALLOW_COPY_AND_ASSIGNMENT(DataTaskRequestContext);
 
@@ -69,12 +69,13 @@ class DataTaskRequestContext {
 
   DataTaskRequestContext(const Callback& cb,
                          const ITestCase& test_case, ::Ort::Session& session,
-                         OrtAllocator* allocator, size_t task_id)
+                         OrtAllocator* allocator, size_t task_id, bool inference_mode = false)
       : cb_(cb),
         test_case_(test_case),
         session_(session),
         default_allocator_(allocator),
-        task_id_(task_id) {
+        task_id_(task_id),
+        inference_mode_(inference_mode) {
     SetTimeSpecToZero(&spent_time_);
   }
 
@@ -88,6 +89,7 @@ class DataTaskRequestContext {
   OrtAllocator* default_allocator_;
   size_t task_id_;
   TIME_SPEC spent_time_;
+  bool inference_mode_;
 };
 
 }  // namespace test

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -45,6 +45,7 @@ void usage() {
       "\t-M : Disable memory pattern\n"
       "\t-c [runs]: Specifies the number of Session::Run() to invoke simultaneously for each model.\n"
       "\t-r [repeat]: Specifies the number of times to repeat\n"
+      "\t-I [inference_mode]: Use inference mode. Save the inference result and skip the output value comparison.\n"
       "\t-v: verbose\n"
       "\t-n [test_case_name]: Specifies a single test case to run.\n"
       "\t-e [EXECUTION_PROVIDER]: EXECUTION_PROVIDER could be 'cpu', 'cuda', 'dnnl', 'tensorrt', 'vsinpu'"
@@ -202,6 +203,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
   bool enable_cpu_mem_arena = true;
   ExecutionMode execution_mode = ExecutionMode::ORT_SEQUENTIAL;
   int repeat_count = 1;
+  bool inference_mode = false;
   int p_models = GetNumCpuCores();
   bool enable_cuda = false;
   bool enable_dnnl = false;
@@ -239,7 +241,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
   bool pause = false;
   {
     int ch;
-    while ((ch = getopt(argc, argv, ORT_TSTR("Ac:hj:Mn:r:e:t:a:xvo:d:C:i:pzfb"))) != -1) {
+    while ((ch = getopt(argc, argv, ORT_TSTR("Ac:hj:IMn:r:e:t:a:xvo:d:C:i:pzfb"))) != -1) {
       switch (ch) {
         case 'A':
           enable_cpu_mem_arena = false;
@@ -267,6 +269,9 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
             usage();
             return -1;
           }
+          break;
+        case 'I':
+          inference_mode = true;
           break;
         case 'M':
           enable_mem_pattern = false;
@@ -932,7 +937,7 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
               });
 
     auto tp = TestEnv::CreateThreadPool(Env::Default());
-    TestEnv test_env(env, sf, tp.get(), std::move(tests), stat);
+    TestEnv test_env(env, sf, tp.get(), std::move(tests), stat, inference_mode);
     Status st = test_env.Run(p_models, concurrent_session_runs, repeat_count);
     if (!st.IsOK()) {
       fprintf(stderr, "%s\n", st.ErrorMessage().c_str());

--- a/onnxruntime/test/onnx/tensorprotoutils.cc
+++ b/onnxruntime/test/onnx/tensorprotoutils.cc
@@ -586,6 +586,124 @@ Status TensorProtoToMLValue(const onnx::TensorProto& tensor_proto, const MemBuff
   return Status::OK();
 }
 
+Status MLValueToTensorProto(Ort::Value& value, onnx::TensorProto& tensor_proto) {
+  Ort::TensorTypeAndShapeInfo tensor_info = value.GetTensorTypeAndShapeInfo();
+  size_t out_dims = tensor_info.GetDimensionsCount();
+  std::vector<int64_t> out_shape = tensor_info.GetShape();
+  for (size_t j = 0; j != out_dims; ++j) {
+    if (out_shape[j] < 0) return Status(common::ONNXRUNTIME, common::FAIL, "Tensor can't contain negative dims");
+    tensor_proto.add_dims(out_shape[j]);
+  }
+  size_t tensor_size = tensor_info.GetElementCount();
+  if (static_cast<uint64_t>(tensor_size) > SIZE_MAX) {
+    return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT, "Size overflow");
+  }
+
+  ONNXTensorElementDataType tensor_elem_data_type = tensor_info.GetElementType();
+  int tensor_elem_bytes;
+  int tensor_proto_dtype;
+  switch (tensor_elem_data_type) {
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:
+      tensor_proto_dtype = ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_FLOAT;
+      tensor_elem_bytes = sizeof(float);
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
+      tensor_proto_dtype = ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_UINT8;
+      tensor_elem_bytes = sizeof(uint8_t);
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
+      tensor_proto_dtype = ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_INT8;
+      tensor_elem_bytes = sizeof(int8_t);
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:
+      tensor_proto_dtype = ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_UINT16;
+      tensor_elem_bytes = sizeof(uint16_t);
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16:
+      tensor_proto_dtype = ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_INT16;
+      tensor_elem_bytes = sizeof(int16_t);
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:
+      tensor_proto_dtype = ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_INT32;
+      tensor_elem_bytes = sizeof(int32_t);
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:
+      tensor_proto_dtype = ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_INT64;
+      tensor_elem_bytes = sizeof(int64_t);
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL:
+      tensor_proto_dtype = ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_BOOL;
+      tensor_elem_bytes = sizeof(bool);
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
+      tensor_proto_dtype = ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_FLOAT16;
+      tensor_elem_bytes = 2;
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:
+      tensor_proto_dtype = ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_DOUBLE;
+      tensor_elem_bytes = sizeof(double);
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32:
+      tensor_proto_dtype = ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_UINT32;
+      tensor_elem_bytes = sizeof(uint32_t);
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64:
+      tensor_proto_dtype = ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_UINT64;
+      tensor_elem_bytes = sizeof(uint64_t);
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX64:
+      tensor_proto_dtype = ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_COMPLEX64;
+      tensor_elem_bytes = 8;
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX128:
+      tensor_proto_dtype = ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_COMPLEX128;
+      tensor_elem_bytes = 16;
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:
+      tensor_proto_dtype = ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_BFLOAT16;
+      tensor_elem_bytes = 2;
+      break;
+#if !defined(DISABLE_FLOAT8_TYPES)
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FN:
+      tensor_proto_dtype = ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_FLOAT8E4M3FN;
+      tensor_elem_bytes = 1;
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FNUZ:
+      tensor_proto_dtype = ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_FLOAT8E4M3FNUZ;
+      tensor_elem_bytes = 1;
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2:
+      tensor_proto_dtype = ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_FLOAT8E5M2;
+      tensor_elem_bytes = 1;
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2FNUZ:
+      tensor_proto_dtype = ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_FLOAT8E5M2FNUZ;
+      tensor_elem_bytes = 1;
+      break;
+#endif
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4:
+      tensor_proto_dtype = ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_UINT4;
+      tensor_elem_bytes = 1;
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4:
+      tensor_proto_dtype = ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_INT4;
+      tensor_elem_bytes = 1;
+      break;
+    default: {
+      // In this function, we do not support
+      // ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING and ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED
+      std::ostringstream ostr;
+      ostr << "Initialized tensor with unexpected type: " << tensor_elem_data_type;
+      return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT, ostr.str());
+    }
+  }
+  tensor_proto.set_data_type(tensor_proto_dtype);
+  void* output_buffer = value.GetTensorMutableRawData();
+  tensor_proto.set_raw_data(
+      output_buffer, tensor_size * tensor_elem_bytes);
+  return Status::OK();
+}
+
 template Status GetSizeInBytesFromTensorProto<kAllocAlignment>(const onnx::TensorProto& tensor_proto, size_t* out);
 template Status GetSizeInBytesFromTensorProto<0>(const onnx::TensorProto& tensor_proto, size_t* out);
 }  // namespace test

--- a/onnxruntime/test/onnx/tensorprotoutils.h
+++ b/onnxruntime/test/onnx/tensorprotoutils.h
@@ -36,6 +36,8 @@ common::Status GetSizeInBytesFromTensorProto(const onnx::TensorProto& tensor_pro
 common::Status TensorProtoToMLValue(const onnx::TensorProto& input, const MemBuffer& m, /* out */ Ort::Value& value,
                                     OrtCallback& deleter);
 
+common::Status MLValueToTensorProto(Ort::Value& value, /* out */ onnx::TensorProto& tensor_proto);
+
 template <typename T>
 void UnpackTensor(const onnx::TensorProto& tensor, const void* raw_data, size_t raw_data_len,
                   /*out*/ T* p_data, size_t expected_size);

--- a/onnxruntime/test/onnx/testcase_driver.h
+++ b/onnxruntime/test/onnx/testcase_driver.h
@@ -33,7 +33,8 @@ class TestCaseDriver {
   /// <param name="repeat_count">Repeat each data tests this many times (only for non-concurrent execution)</param>
   /// <returns>All tests results</returns>
   static std::vector<std::shared_ptr<TestCaseResult>> Run(const TestEnv& env,
-                                                          size_t concurrent_runs, size_t repeat_count);
+                                                          size_t concurrent_runs, size_t repeat_count,
+                                                          bool inference_mode = false);
 
   /// <summary>
   /// Runs all test cases(models) concurrently but not more than
@@ -44,12 +45,12 @@ class TestCaseDriver {
   /// <param name="concurrent_runs">number of data tests to run concurrently on a specific test case(model)</param>
   /// <returns>All test results</returns>
   static std::vector<std::shared_ptr<TestCaseResult>> RunParallel(const TestEnv& env, size_t parallel_models,
-                                                                  size_t concurrent_runs);
+                                                                  size_t concurrent_runs, bool inference_mode = false);
 
   ORT_DISALLOW_ASSIGNMENT(TestCaseDriver);
 
  private:
-  TestCaseDriver(const TestEnv& env, size_t concurrent_runs);
+  TestCaseDriver(const TestEnv& env, size_t concurrent_runs, bool inference_mode = false);
 
   /// This makes the __Dtor private because the lifespan is managed by the class itself
   ~TestCaseDriver() = default;
@@ -66,6 +67,7 @@ class TestCaseDriver {
 
   const TestEnv& env_;
   size_t concurrent_runs_;
+  bool inference_mode_;
   std::vector<std::shared_ptr<TestCaseResult>> results_;
   TestCaseRequestContext::Callback on_test_case_complete_;
 

--- a/onnxruntime/test/onnx/testcase_request.h
+++ b/onnxruntime/test/onnx/testcase_request.h
@@ -50,7 +50,8 @@ class TestCaseRequestContext {
   static std::shared_ptr<TestCaseResult> Run(PThreadPool tpool,
                                              const ITestCase& c, Ort::Env& env,
                                              const Ort::SessionOptions& sf,
-                                             size_t concurrent_runs, size_t repeat_count);
+                                             size_t concurrent_runs, size_t repeat_count,
+                                             bool inference_mode = false);
 
   /// <summary>
   /// Schedules a TestCase to asynchronously on a TP. The function returns immediately.
@@ -64,7 +65,7 @@ class TestCaseRequestContext {
   /// <param name="concurrent_runs"></param>
   static void Request(const Callback& cb, PThreadPool tpool, const ITestCase& c,
                       Ort::Env& env, const Ort::SessionOptions& sf,
-                      size_t test_case_id, size_t concurrent_runs);
+                      size_t test_case_id, size_t concurrent_runs, bool inference_mode = false);
 
   const TIME_SPEC& GetTimeSpend() const {
     return test_case_time_;
@@ -79,7 +80,7 @@ class TestCaseRequestContext {
   ~TestCaseRequestContext() = default;
 
   TestCaseRequestContext(const Callback& cb, PThreadPool tp, const ITestCase& test_case, Ort::Env& env,
-                         const Ort::SessionOptions& session_opts, size_t test_case_id);
+                         const Ort::SessionOptions& session_opts, size_t test_case_id, bool inference_mode = false);
 
  private:
   bool SetupSession();
@@ -109,6 +110,7 @@ class TestCaseRequestContext {
   MockedOrtAllocator allocator_;
   std::shared_ptr<TestCaseResult> result_;
   TIME_SPEC test_case_time_;
+  bool inference_mode_;
   Callable<void, size_t, EXECUTE_RESULT, const TIME_SPEC&> on_data_task_cb_;
 
   mutable std::atomic_size_t data_tasks_started_;

--- a/onnxruntime/test/onnx/testenv.cc
+++ b/onnxruntime/test/onnx/testenv.cc
@@ -18,9 +18,10 @@ std::unique_ptr<OrtThreadPool> TestEnv::CreateThreadPool(onnxruntime::Env& env) 
 }
 
 TestEnv::TestEnv(Ort::Env& env, Ort::SessionOptions& so, PThreadPool tp,
-                 std::vector<ITestCase*>&& tests, TestResultStat& stat)
+                 std::vector<ITestCase*>&& tests, TestResultStat& stat, bool inference_mode)
     : env_(env),
       so_(so),
+      inference_mode_(inference_mode),
       tp_(tp),
       tests_(std::move(tests)),
       stat_(stat) {
@@ -33,9 +34,9 @@ TestEnv::~TestEnv() {
 Status TestEnv::Run(size_t parallel_models, int concurrent_runs, size_t repeat_count) {
   std::vector<std::shared_ptr<TestCaseResult>> results;
   if (parallel_models > 1U && tests_.size() > 1U) {
-    results = onnxruntime::test::TestCaseDriver::RunParallel(*this, parallel_models, concurrent_runs);
+    results = onnxruntime::test::TestCaseDriver::RunParallel(*this, parallel_models, concurrent_runs, inference_mode_);
   } else {
-    results = onnxruntime::test::TestCaseDriver::Run(*this, concurrent_runs, repeat_count);
+    results = onnxruntime::test::TestCaseDriver::Run(*this, concurrent_runs, repeat_count, inference_mode_);
   }
 
   CalculateStats(results);

--- a/onnxruntime/test/onnx/testenv.h
+++ b/onnxruntime/test/onnx/testenv.h
@@ -34,7 +34,7 @@ using PThreadPool = OrtThreadPool*;
 class TestEnv {
  public:
   TestEnv(Ort::Env& env, Ort::SessionOptions& sf1, PThreadPool tp,
-          std::vector<ITestCase*>&& tests, TestResultStat& stat1);
+          std::vector<ITestCase*>&& tests, TestResultStat& stat1, bool inference_mode = false);
 
   ~TestEnv();
 
@@ -72,6 +72,7 @@ class TestEnv {
 
   Ort::Env& env_;
   const Ort::SessionOptions& so_;
+  bool inference_mode_;
   PThreadPool tp_;
   std::vector<ITestCase*> tests_;
   TestResultStat& stat_;


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Add flag to determine whether to save inference results.
- Implement infrastructure to transform OrtValue into TensorProto
- Update the README with corresponding descriptions.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

- The PR aims to save the inference results of onnx-test-runner for inference purpose.
- Developer can proceed with custom metrics and verifications.