### PR TITLE
Add React Native namespace back in for iOS

### DIFF
--- a/js/react_native/android/src/main/AndroidManifest.xml
+++ b/js/react_native/android/src/main/AndroidManifest.xml
@@ -1,2 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+           package="ai.onnxruntime.reactnative">
 </manifest>


### PR DESCRIPTION
### Description
- adds react native namespace back in to the androidmanifest.xml

### Motivation and Context
- reverses [this commit](https://github.com/microsoft/onnxruntime/commit/d8ed4da1dfee781919247d9ce001f246489c8f90)
- missed [this comment](https://github.com/microsoft/onnxruntime/blob/2656671064a83564ddf5766f3449c2406259c3ef/js/react_native/android/build.gradle#L141) that explains that androidmanifest.xml is used for iOS while androidmanifestnew.xml is used for android


