### PR TITLE
Add CMake option to enable saturation checker for ConvSymKernelAvx2

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -65,7 +65,7 @@ option(onnxruntime_REDIRECT_STATIC_ANALYSIS_OUTPUTS_TO_FILE "Use a custom SDL Ru
 option(onnxruntime_ENABLE_PYTHON "Enable python buildings" OFF)
 # Enable it may cause LNK1169 error
 option(onnxruntime_ENABLE_MEMLEAK_CHECKER "Experimental: Enable memory leak checker in Windows debug build" OFF)
-option(onnxruntime_ENABLE_AVX2_SATURATION_CHECKER "Experimental: Enable avx2 saturation checker in build" OFF)
+option(onnxruntime_ENABLE_CONVSYMKERNELAVX2_SAT_CHECKER "Experimental: Enable ConvSymKernelAvx2 assembly saturation checker in build" OFF)
 option(onnxruntime_USE_CUDA "Build with CUDA support" OFF)
 # Enable ONNX Runtime CUDA EP's internal unit tests that directly access the EP's internal functions instead of through
 # OpKernels. When the option is ON, we will have two copies of GTest library in the same process. It is not a typical

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -65,6 +65,7 @@ option(onnxruntime_REDIRECT_STATIC_ANALYSIS_OUTPUTS_TO_FILE "Use a custom SDL Ru
 option(onnxruntime_ENABLE_PYTHON "Enable python buildings" OFF)
 # Enable it may cause LNK1169 error
 option(onnxruntime_ENABLE_MEMLEAK_CHECKER "Experimental: Enable memory leak checker in Windows debug build" OFF)
+option(onnxruntime_ENABLE_AVX2_SATURATION_CHECKER "Experimental: Enable avx2 saturation checker in build" OFF)
 option(onnxruntime_USE_CUDA "Build with CUDA support" OFF)
 # Enable ONNX Runtime CUDA EP's internal unit tests that directly access the EP's internal functions instead of through
 # OpKernels. When the option is ON, we will have two copies of GTest library in the same process. It is not a typical

--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -193,6 +193,7 @@ function(setup_mlas_source_for_windows)
       ${MLAS_SRC_DIR}/rotary_embedding_kernel_avx2.h
       ${MLAS_SRC_DIR}/rotary_embedding_kernel_avx2.cpp
       ${MLAS_SRC_DIR}/rotary_embedding_kernel_avx2.cpp
+      ${MLAS_SRC_DIR}/saturation_check.cpp
       ${MLAS_SRC_DIR}/qgemm_kernel_amx.cpp
       ${MLAS_SRC_DIR}/qgemm_kernel_avx2.cpp
       ${MLAS_SRC_DIR}/qgemm_kernel_sse.cpp
@@ -238,6 +239,10 @@ function(setup_mlas_source_for_windows)
       ${MLAS_SRC_DIR}/amd64/TanhKernelFma3.asm
       ${MLAS_SRC_DIR}/amd64/ErfKernelFma3.asm
     )
+
+    if(onnxruntime_ENABLE_CONVSYMKERNELAVX2_SAT_CHECKER)
+      set_source_files_properties(${MLAS_SRC_DIR}/amd64/ConvSymKernelAvx2.asm PROPERTIES COMPILE_FLAGS "-DENABLE_CONVSYMKERNELAVX2_SAT_CHECKER")
+    endif()
 
     if(MSVC_VERSION GREATER_EQUAL 1933)
       target_sources(onnxruntime_mlas PRIVATE

--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -641,6 +641,7 @@ else()
           ${MLAS_SRC_DIR}/rotary_embedding_kernel_avx2.h
           ${MLAS_SRC_DIR}/rotary_embedding_kernel_avx2.cpp
           ${MLAS_SRC_DIR}/rotary_embedding_kernel_avx2.cpp
+          ${MLAS_SRC_DIR}/saturation_check.cpp
         )
         if(CMAKE_CXX_COMPILER_VERSION GREATER_EQUAL 13.1 AND NOT(APPLE))
           set(mlas_platform_srcs_avx2

--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -717,8 +717,8 @@ endif()
           set_source_files_properties(${MLAS_SRC_DIR}/x86_64/QgemmU8S8KernelAmx.S PROPERTIES COMPILE_FLAGS "-mavx2 -mavx512bw -mavx512dq -mavx512vl -mavx512f")
         endif()
 
-        if(onnxruntime_ENABLE_AVX2_SATURATION_CHECKER)
-          set_source_files_properties(${MLAS_SRC_DIR}/x86_64/ConvSymKernelAvx2.S PROPERTIES COMPILE_FLAGS "-mavx2 -mfma -mf16c -DENABLE_AVX2_SATURATION_CHECKER")      
+        if(onnxruntime_ENABLE_CONVSYMKERNELAVX2_SAT_CHECKER)
+          set_source_files_properties(${MLAS_SRC_DIR}/x86_64/ConvSymKernelAvx2.S PROPERTIES COMPILE_FLAGS "-mavx2 -mfma -mf16c -DENABLE_CONVSYMKERNELAVX2_SAT_CHECKER")
         endif()
 
         if(ONNXRUNTIME_MLAS_MULTI_ARCH)

--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -717,6 +717,10 @@ endif()
           set_source_files_properties(${MLAS_SRC_DIR}/x86_64/QgemmU8S8KernelAmx.S PROPERTIES COMPILE_FLAGS "-mavx2 -mavx512bw -mavx512dq -mavx512vl -mavx512f")
         endif()
 
+        if(onnxruntime_ENABLE_AVX2_SATURATION_CHECKER)
+          set_source_files_properties(${MLAS_SRC_DIR}/x86_64/ConvSymKernelAvx2.S PROPERTIES COMPILE_FLAGS "-mavx2 -mfma -mf16c -DENABLE_AVX2_SATURATION_CHECKER")      
+        endif()
+
         if(ONNXRUNTIME_MLAS_MULTI_ARCH)
           onnxruntime_add_static_library(onnxruntime_mlas_x86_64 ${mlas_platform_srcs})
           set_target_properties(onnxruntime_mlas_x86_64 PROPERTIES OSX_ARCHITECTURES "x86_64")

--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -46,6 +46,7 @@ onnxruntime_add_static_library(onnxruntime_mlas
   ${MLAS_SRC_DIR}/rotary_embedding.h
   ${MLAS_SRC_DIR}/rotary_embedding.cpp
   ${MLAS_SRC_DIR}/softmax.h
+  ${MLAS_SRC_DIR}/saturation_check.cpp
 )
 
 target_sources(onnxruntime_mlas PRIVATE
@@ -193,7 +194,6 @@ function(setup_mlas_source_for_windows)
       ${MLAS_SRC_DIR}/rotary_embedding_kernel_avx2.h
       ${MLAS_SRC_DIR}/rotary_embedding_kernel_avx2.cpp
       ${MLAS_SRC_DIR}/rotary_embedding_kernel_avx2.cpp
-      ${MLAS_SRC_DIR}/saturation_check.cpp
       ${MLAS_SRC_DIR}/qgemm_kernel_amx.cpp
       ${MLAS_SRC_DIR}/qgemm_kernel_avx2.cpp
       ${MLAS_SRC_DIR}/qgemm_kernel_sse.cpp
@@ -642,11 +642,11 @@ else()
           ${MLAS_SRC_DIR}/x86_64/ErfKernelFma3.S
           ${MLAS_SRC_DIR}/intrinsics/avx2/qladd_avx2.cpp
           ${MLAS_SRC_DIR}/intrinsics/avx2/qdwconv_avx2.cpp
+          ${MLAS_SRC_DIR}/intrinsics/avx2/saturation_check_avx2.cpp
           ${MLAS_SRC_DIR}/sqnbitgemm_kernel_avx2.cpp
           ${MLAS_SRC_DIR}/rotary_embedding_kernel_avx2.h
           ${MLAS_SRC_DIR}/rotary_embedding_kernel_avx2.cpp
           ${MLAS_SRC_DIR}/rotary_embedding_kernel_avx2.cpp
-          ${MLAS_SRC_DIR}/saturation_check.cpp
         )
         if(CMAKE_CXX_COMPILER_VERSION GREATER_EQUAL 13.1 AND NOT(APPLE))
           set(mlas_platform_srcs_avx2

--- a/onnxruntime/core/mlas/lib/intrinsics/avx2/saturation_check_avx2.cpp
+++ b/onnxruntime/core/mlas/lib/intrinsics/avx2/saturation_check_avx2.cpp
@@ -1,0 +1,62 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    saturation_check_avx2.cpp
+
+Abstract:
+
+    This module implements logic to check saturation of the VPMADDUBSW
+    instruction.
+
+--*/
+
+#include <immintrin.h>
+
+#include <atomic>
+#include <iostream>
+
+namespace onnxruntime
+{
+extern std::atomic<int> saturation_count;
+}
+
+extern "C" void
+CheckSaturationForVPMADDUBSW(const __m256i* unsigned_ptr, const __m256i* signed_ptr)
+{
+    // Load data from memory (unaligned load)
+    __m256i unsigned_data = _mm256_loadu_si256(unsigned_ptr);
+    __m256i signed_data = _mm256_loadu_si256(signed_ptr);
+
+    alignas(32) uint8_t unsigned_bytes[32];  // Unsigned input values
+    alignas(32) int8_t signed_bytes[32];     // Signed input values
+
+    // Store the data into the byte arrays
+    _mm256_store_si256(reinterpret_cast<__m256i*>(unsigned_bytes), unsigned_data);
+    _mm256_store_si256(reinterpret_cast<__m256i*>(signed_bytes), signed_data);
+
+    bool saturation_detected = false;
+
+    // Iterate through the 16 pairs of 8-bit unsigned and signed values
+    for (int i = 0; i < 16; ++i) {
+        // Perform the VPMADDUBSW operation in higher precision (int32_t)
+        int32_t computed_value =
+            static_cast<int32_t>(signed_bytes[2 * i]) * static_cast<int32_t>(static_cast<uint32_t>(unsigned_bytes[2 * i])) +
+            static_cast<int32_t>(signed_bytes[2 * i + 1]) * static_cast<int32_t>(static_cast<uint32_t>(unsigned_bytes[2 * i + 1]));
+
+        // If the computed value exceeds the 16-bit signed integer range, saturation occurred
+        if (computed_value > INT16_MAX || computed_value < INT16_MIN) {
+            saturation_detected = true;
+            break;
+        }
+    }
+
+    // If saturation is detected, log a warning (only log once based on the atomic count)
+    if (saturation_detected && ++onnxruntime::saturation_count < 2) {
+        std::cerr << "Warning: saturation detected in VPMADDUBSW instruction." << std::endl;
+    }
+}

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -18,6 +18,7 @@ Abstract:
 #pragma once
 
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <functional>
 #include <limits>

--- a/onnxruntime/core/mlas/lib/saturation_check.cpp
+++ b/onnxruntime/core/mlas/lib/saturation_check.cpp
@@ -1,0 +1,127 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    platform.cpp
+
+Abstract:
+
+    This module implements logic to select the best configuration for the
+    this platform.
+
+--*/
+
+#include <immintrin.h>
+#include <stdint.h>
+#include <iostream>
+
+void print_m256i_16(const char* label, __m256i reg) {
+    alignas(32) int16_t values[16];  // __m256i has 16x int16_t elements
+    _mm256_store_si256(reinterpret_cast<__m256i*>(values), reg);
+
+    std::cout << label << ": ";
+    for (int i = 0; i < 16; ++i) {
+        std::cout << std::hex << values[i] << " ";
+    }
+    std::cout << std::endl;
+}
+
+void print_m256i_8(const char* label, __m256i reg) {
+    alignas(32) int8_t values[32];  // __m256i has 16x int16_t elements
+    _mm256_store_si256(reinterpret_cast<__m256i*>(values), reg);
+
+    std::cout << label << ": ";
+    for (int i = 0; i < 32; ++i) {
+        std::cout << std::dec << static_cast<uint32_t>(values[i]) << " ";
+    }
+    std::cout << std::endl;
+}
+
+#if 0
+//#ifdef SATURATION_DETECTION_ENABLED
+extern "C" void CheckForSaturationBeforeMul(const __m256i* unsigned_ptr, const __m256i* signed_ptr) {
+    static  int counter = 0;
+
+    __m256i unsigned_data = _mm256_loadu_si256(unsigned_ptr);
+    __m256i signed_data = _mm256_loadu_si256(signed_ptr);
+
+    __m256i result = _mm256_maddubs_epi16(unsigned_data, signed_data);
+
+    alignas(32) uint16_t unsigned_bytes[16];  // __m256i has 16x int16_t elements
+    _mm256_store_si256(reinterpret_cast<__m256i*>(unsigned_bytes), unsigned_data);
+    alignas(32) int16_t signed_bytes[16];  // __m256i has 16x int16_t elements
+    _mm256_store_si256(reinterpret_cast<__m256i*>(signed_bytes), signed_data);
+
+    //(void)input;  // Suppress unused variable warning
+    //(void)multiplier;  // Suppress unused variable warning
+
+    // Example saturation check: print values
+    if (counter < 10) {
+        print_m256i_8("unsigned_data:\t", unsigned_data);
+        print_m256i_8("signed_data:\t", signed_data);
+        print_m256i_16("result:\t", result);
+        counter++;
+        int32_t dest =
+            static_cast<int32_t>(signed_bytes[0]) * static_cast<int32_t>(static_cast<uint32_t>(unsigned_bytes[0])) +
+            static_cast<int32_t>(signed_bytes[1]) * static_cast<int32_t>(static_cast<uint32_t>(unsigned_bytes[1]));
+        std::cout << "Checking for saturation..." << std::hex << "0x" << dest << std::endl;
+    }
+    
+    return;  // Modify this to return true if saturation is detected
+}
+//#endif  // SATURATION_DETECTION_ENABLED
+#endif
+
+#if 1
+extern "C" void CheckForSaturationBeforeMul(const __m256i* unsigned_ptr, const __m256i* signed_ptr) {
+    static int counter = 0;
+
+    // Load data from memory
+    __m256i unsigned_data = _mm256_loadu_si256(unsigned_ptr);
+    __m256i signed_data = _mm256_loadu_si256(signed_ptr);
+
+    // Perform multiplication with saturation detection
+    __m256i result = _mm256_maddubs_epi16(unsigned_data, signed_data);  // Multiply and add adjacent bytes
+
+    // Extract original values
+    alignas(32) uint8_t unsigned_bytes[32];  // Unsigned input values
+    alignas(32) int8_t signed_bytes[32];     // Signed input values
+    alignas(32) int16_t result_values[16];   // 16-bit results from _mm256_maddubs_epi16
+
+    _mm256_store_si256(reinterpret_cast<__m256i*>(unsigned_bytes), unsigned_data);
+    _mm256_store_si256(reinterpret_cast<__m256i*>(signed_bytes), signed_data);
+    _mm256_store_si256(reinterpret_cast<__m256i*>(result_values), result);
+
+    //constexpr int16_t INT16_MAX = 32767;
+    //constexpr int16_t INT16_MIN = -32768;
+    bool saturation_detected = false;
+
+    // Compute in higher precision (int32_t) and compare with 16-bit limits
+    //std::cout << "computed_value: ";
+    for (int i = 0; i < 16; ++i) {
+        int32_t computed_value =
+            static_cast<int32_t>(signed_bytes[2 * i]) * static_cast<int32_t>(static_cast<uint32_t>(unsigned_bytes[2 * i])) +
+            static_cast<int32_t>(signed_bytes[2 * i + 1]) * static_cast<int32_t>(static_cast<uint32_t>(unsigned_bytes[2 * i + 1]));
+
+        //std::cout << std::hex << "0x" << computed_value << " ";
+
+        // If the computed value exceeds the 16-bit range, saturation occurred
+        if (computed_value > INT16_MAX || computed_value < INT16_MIN) {
+            saturation_detected = true;
+            break;
+        }
+    }
+    //std::cout << std::endl;
+
+    // Log a warning if saturation is detected
+    if (saturation_detected && counter < 5) {
+        std::cerr << "[WARNING] Saturation detected in _mm256_maddubs_epi16 operation!" << std::endl;
+        counter++;
+    }
+
+}
+#endif

--- a/onnxruntime/core/mlas/lib/saturation_check.cpp
+++ b/onnxruntime/core/mlas/lib/saturation_check.cpp
@@ -6,68 +6,59 @@ Licensed under the MIT License.
 
 Module Name:
 
-    platform.cpp
+    saturation_check.cpp
 
 Abstract:
 
-    This module implements logic to select the best configuration for the
-    this platform.
+    This module implements logic to check saturation of the VPMADDUBSW
+    instruction.
 
 --*/
 
-#include <atomic>
 #include <immintrin.h>
-#include <stdint.h>
+
+#include <atomic>
 #include <iostream>
 
-namespace onnxruntime {
+namespace onnxruntime
+{
 
 std::atomic<int> saturation_count{0};
 
 }
 
-extern "C" void CheckForSaturationBeforeMul(const __m256i* unsigned_ptr, const __m256i* signed_ptr) {
-
-    // Load data from memory
+extern "C" void
+CheckSaturationForVPMADDUBSW(const __m256i* unsigned_ptr, const __m256i* signed_ptr)
+{
+    // Load data from memory (unaligned load)
     __m256i unsigned_data = _mm256_loadu_si256(unsigned_ptr);
     __m256i signed_data = _mm256_loadu_si256(signed_ptr);
 
-    // Perform multiplication with saturation detection
-    __m256i result = _mm256_maddubs_epi16(unsigned_data, signed_data);  // Multiply and add adjacent bytes
-
-    // Extract original values
     alignas(32) uint8_t unsigned_bytes[32];  // Unsigned input values
     alignas(32) int8_t signed_bytes[32];     // Signed input values
-    alignas(32) int16_t result_values[16];   // 16-bit results from _mm256_maddubs_epi16
 
+    // Store the data into the byte arrays
     _mm256_store_si256(reinterpret_cast<__m256i*>(unsigned_bytes), unsigned_data);
     _mm256_store_si256(reinterpret_cast<__m256i*>(signed_bytes), signed_data);
-    _mm256_store_si256(reinterpret_cast<__m256i*>(result_values), result);
 
-    //constexpr int16_t INT16_MAX = 32767;
-    //constexpr int16_t INT16_MIN = -32768;
     bool saturation_detected = false;
 
-    // Compute in higher precision (int32_t) and compare with 16-bit limits
-    //std::cout << "computed_value: ";
+    // Iterate through the 16 pairs of 8-bit unsigned and signed values
     for (int i = 0; i < 16; ++i) {
+        // Perform the VPMADDUBSW operation in higher precision (int32_t)
         int32_t computed_value =
             static_cast<int32_t>(signed_bytes[2 * i]) * static_cast<int32_t>(static_cast<uint32_t>(unsigned_bytes[2 * i])) +
             static_cast<int32_t>(signed_bytes[2 * i + 1]) * static_cast<int32_t>(static_cast<uint32_t>(unsigned_bytes[2 * i + 1]));
 
-        //std::cout << std::hex << "0x" << computed_value << " ";
-
-        // If the computed value exceeds the 16-bit range, saturation occurred
+        // If the computed value exceeds the 16-bit signed integer range, saturation occurred
         if (computed_value > INT16_MAX || computed_value < INT16_MIN) {
             saturation_detected = true;
             break;
         }
     }
-    //std::cout << std::endl;
 
-    // Log a warning if saturation is detected
+    // If saturation is detected, log a warning (only log once based on the atomic count)
     if (saturation_detected && ++onnxruntime::saturation_count < 2) {
-        std::cerr << "[WARNING] Saturation detected in VPMADDUBSW instruction!" << std::endl;
+        std::cerr << "Warning: saturation detected in VPMADDUBSW instruction." << std::endl;
     }
-
 }

--- a/onnxruntime/core/mlas/lib/saturation_check.cpp
+++ b/onnxruntime/core/mlas/lib/saturation_check.cpp
@@ -15,70 +15,16 @@ Abstract:
 
 --*/
 
+#include <atomic>
 #include <immintrin.h>
 #include <stdint.h>
 #include <iostream>
 
-void print_m256i_16(const char* label, __m256i reg) {
-    alignas(32) int16_t values[16];  // __m256i has 16x int16_t elements
-    _mm256_store_si256(reinterpret_cast<__m256i*>(values), reg);
+namespace onnxruntime {
 
-    std::cout << label << ": ";
-    for (int i = 0; i < 16; ++i) {
-        std::cout << std::hex << values[i] << " ";
-    }
-    std::cout << std::endl;
+std::atomic<int> saturation_count{0};
+
 }
-
-void print_m256i_8(const char* label, __m256i reg) {
-    alignas(32) int8_t values[32];  // __m256i has 16x int16_t elements
-    _mm256_store_si256(reinterpret_cast<__m256i*>(values), reg);
-
-    std::cout << label << ": ";
-    for (int i = 0; i < 32; ++i) {
-        std::cout << std::dec << static_cast<uint32_t>(values[i]) << " ";
-    }
-    std::cout << std::endl;
-}
-
-#if 0
-//#ifdef SATURATION_DETECTION_ENABLED
-extern "C" void CheckForSaturationBeforeMul(const __m256i* unsigned_ptr, const __m256i* signed_ptr) {
-    static  int counter = 0;
-
-    __m256i unsigned_data = _mm256_loadu_si256(unsigned_ptr);
-    __m256i signed_data = _mm256_loadu_si256(signed_ptr);
-
-    __m256i result = _mm256_maddubs_epi16(unsigned_data, signed_data);
-
-    alignas(32) uint16_t unsigned_bytes[16];  // __m256i has 16x int16_t elements
-    _mm256_store_si256(reinterpret_cast<__m256i*>(unsigned_bytes), unsigned_data);
-    alignas(32) int16_t signed_bytes[16];  // __m256i has 16x int16_t elements
-    _mm256_store_si256(reinterpret_cast<__m256i*>(signed_bytes), signed_data);
-
-    //(void)input;  // Suppress unused variable warning
-    //(void)multiplier;  // Suppress unused variable warning
-
-    // Example saturation check: print values
-    if (counter < 10) {
-        print_m256i_8("unsigned_data:\t", unsigned_data);
-        print_m256i_8("signed_data:\t", signed_data);
-        print_m256i_16("result:\t", result);
-        counter++;
-        int32_t dest =
-            static_cast<int32_t>(signed_bytes[0]) * static_cast<int32_t>(static_cast<uint32_t>(unsigned_bytes[0])) +
-            static_cast<int32_t>(signed_bytes[1]) * static_cast<int32_t>(static_cast<uint32_t>(unsigned_bytes[1]));
-        std::cout << "Checking for saturation..." << std::hex << "0x" << dest << std::endl;
-    }
-    
-    return;  // Modify this to return true if saturation is detected
-}
-//#endif  // SATURATION_DETECTION_ENABLED
-#endif
-
-#if 1
-
-int saturate_counter = 0;
 
 extern "C" void CheckForSaturationBeforeMul(const __m256i* unsigned_ptr, const __m256i* signed_ptr) {
 
@@ -120,10 +66,8 @@ extern "C" void CheckForSaturationBeforeMul(const __m256i* unsigned_ptr, const _
     //std::cout << std::endl;
 
     // Log a warning if saturation is detected
-    if (saturation_detected && saturate_counter < 2) {
-        std::cerr << "[WARNING] Saturation detected in _mm256_maddubs_epi16 operation!" << std::endl;
-        saturate_counter++;
+    if (saturation_detected && ++onnxruntime::saturation_count < 2) {
+        std::cerr << "[WARNING] Saturation detected in VPMADDUBSW instruction!" << std::endl;
     }
 
 }
-#endif

--- a/onnxruntime/core/mlas/lib/saturation_check.cpp
+++ b/onnxruntime/core/mlas/lib/saturation_check.cpp
@@ -25,6 +25,12 @@ namespace onnxruntime
 
 std::atomic<int> saturation_count{0};
 
+void
+reset_saturation_count()
+{
+    saturation_count = 0;
+}
+
 }
 
 extern "C" void

--- a/onnxruntime/core/mlas/lib/saturation_check.cpp
+++ b/onnxruntime/core/mlas/lib/saturation_check.cpp
@@ -77,8 +77,10 @@ extern "C" void CheckForSaturationBeforeMul(const __m256i* unsigned_ptr, const _
 #endif
 
 #if 1
+
+int saturate_counter = 0;
+
 extern "C" void CheckForSaturationBeforeMul(const __m256i* unsigned_ptr, const __m256i* signed_ptr) {
-    static int counter = 0;
 
     // Load data from memory
     __m256i unsigned_data = _mm256_loadu_si256(unsigned_ptr);
@@ -118,9 +120,9 @@ extern "C" void CheckForSaturationBeforeMul(const __m256i* unsigned_ptr, const _
     //std::cout << std::endl;
 
     // Log a warning if saturation is detected
-    if (saturation_detected && counter < 5) {
+    if (saturation_detected && saturate_counter < 2) {
         std::cerr << "[WARNING] Saturation detected in _mm256_maddubs_epi16 operation!" << std::endl;
-        counter++;
+        saturate_counter++;
     }
 
 }

--- a/onnxruntime/core/mlas/lib/saturation_check.cpp
+++ b/onnxruntime/core/mlas/lib/saturation_check.cpp
@@ -15,10 +15,6 @@ Abstract:
 
 --*/
 
-//#include <immintrin.h>
-
-//#include <atomic>
-
 #include "mlasi.h"
 
 namespace onnxruntime

--- a/onnxruntime/core/mlas/lib/x86_64/ConvSymKernelAvx2.S
+++ b/onnxruntime/core/mlas/lib/x86_64/ConvSymKernelAvx2.S
@@ -27,7 +27,10 @@ Abstract:
 
         .macro CheckSaturation VecReg1Num, VecReg2Num
 
-        # Save all caller-saved registers (RAX, RCX, RDX, RSI, RDI, R8, R9, R10, R11)
+//
+// Save all caller-saved registers (RAX, RCX, RDX, RSI, RDI, R8, R9, R10, R11)
+//
+
         push    rax
         push    rcx
         push    rdx
@@ -38,9 +41,12 @@ Abstract:
         push    r10
         push    r11
 
-        sub     rsp, 512                        # Reserve space for 16 YMM registers (32 bytes)
+        sub     rsp, 512                        # reserve space for 16 YMM registers (32 bytes)
 
-        # Save YMM registers (YMM0 to YMM15)
+//
+// Save YMM registers (YMM0 to YMM15)
+//
+
         vmovdqu  [rsp], ymm0
         vmovdqu  [rsp+32], ymm1
         vmovdqu  [rsp+64], ymm2
@@ -63,7 +69,10 @@ Abstract:
 
         call    CheckSaturationForVPMADDUBSW
 
-        # Restore YMM registers
+//
+// Restore YMM registers
+//
+
         vmovdqu  ymm0, [rsp]
         vmovdqu  ymm1, [rsp+32]
         vmovdqu  ymm2, [rsp+64]
@@ -81,9 +90,12 @@ Abstract:
         vmovdqu  ymm14, [rsp+448]
         vmovdqu  ymm15, [rsp+480]
 
-        add     rsp, 512                        # Clean up the reserved stack space
+        add     rsp, 512                        # clean up the reserved stack space
 
-        # Restore all caller-saved registers (RAX, RCX, RDX, RSI, RDI, R8, R9, R10, R11)
+//
+// Restore all caller-saved registers (RAX, RCX, RDX, RSI, RDI, R8, R9, R10, R11)
+//
+
         pop     r11
         pop     r10
         pop     r9

--- a/onnxruntime/core/mlas/lib/x86_64/ConvSymKernelAvx2.S
+++ b/onnxruntime/core/mlas/lib/x86_64/ConvSymKernelAvx2.S
@@ -23,6 +23,79 @@ Abstract:
 
         .intel_syntax noprefix
 
+        .extern CheckForSaturationBeforeMul  # Declare external function
+
+        .macro CheckSaturation
+
+    # Save all caller-saved registers (RAX, RCX, RDX, RSI, RDI, R8, R9, R10, R11)
+    push    rax
+    push    rcx
+    push    rdx
+    push    rsi
+    push    rdi
+    push    r8
+    push    r9
+    push    r10
+    push    r11
+
+    sub     rsp, 512            # Reserve space for 16 registers (32 bytes for YMM registers)
+
+    # Save XMM registers (YMM0 to YMM15)
+    vmovdqu  [rsp], ymm0
+    vmovdqu  [rsp+32], ymm1
+    vmovdqu  [rsp+64], ymm2
+    vmovdqu  [rsp+96], ymm3
+    vmovdqu  [rsp+128], ymm4
+    vmovdqu  [rsp+160], ymm5
+    vmovdqu  [rsp+192], ymm6
+    vmovdqu  [rsp+224], ymm7
+    vmovdqu  [rsp+256], ymm8
+    vmovdqu  [rsp+288], ymm9
+    vmovdqu  [rsp+320], ymm10
+    vmovdqu  [rsp+352], ymm11
+    vmovdqu  [rsp+384], ymm12
+    vmovdqu  [rsp+416], ymm13
+    vmovdqu  [rsp+448], ymm14
+    vmovdqu  [rsp+480], ymm15
+
+    lea rdi, [rsp+64]
+    lea rsi, [rsp]
+
+    call    CheckForSaturationBeforeMul  # Call the C++ function
+
+    # Restore XMM registers
+    vmovdqu  ymm0, [rsp]
+    vmovdqu  ymm1, [rsp+32]
+    vmovdqu  ymm2, [rsp+64]
+    vmovdqu  ymm3, [rsp+96]
+    vmovdqu  ymm4, [rsp+128]
+    vmovdqu  ymm5, [rsp+160]
+    vmovdqu  ymm6, [rsp+192]
+    vmovdqu  ymm7, [rsp+224]
+    vmovdqu  ymm8, [rsp+256]
+    vmovdqu  ymm9, [rsp+288]
+    vmovdqu  ymm10, [rsp+320]
+    vmovdqu  ymm11, [rsp+352]
+    vmovdqu  ymm12, [rsp+384]
+    vmovdqu  ymm13, [rsp+416]
+    vmovdqu  ymm14, [rsp+448]
+    vmovdqu  ymm15, [rsp+480]
+
+    add     rsp, 512              # Clean up the reserved stack space
+
+    # Restore all caller-saved registers (RAX, RCX, RDX, RSI, RDI, R8, R9, R10, R11)
+    pop     r11
+    pop     r10
+    pop     r9
+    pop     r8
+    pop     rdi
+    pop     rsi
+    pop     rdx
+    pop     rcx
+    pop     rax
+
+        .endm
+
 /*++
 
 Macro Description:
@@ -50,148 +123,17 @@ Implicit Arguments:
 
 --*/
 
-        .extern CheckForSaturationBeforeMul  # Declare external function
-
         .macro MultiplyAccumulateRowAvx2 Vec1Reg, Vec2Reg
 
-    # Save all caller-saved registers (RAX, RCX, RDX, RSI, RDI, R8, R9, R10, R11)
-    push    rax
-    push    rcx
-    push    rdx
-    push    rsi
-    push    rdi
-    push    r8
-    push    r9
-    push    r10
-    push    r11
-
-    sub     rsp, 512            # Reserve space for 16 registers (32 bytes for YMM registers)
-
-    # Save XMM registers (YMM0 to YMM15)
-    vmovdqu  [rsp], ymm0
-    vmovdqu  [rsp+32], ymm1
-    vmovdqu  [rsp+64], ymm2
-    vmovdqu  [rsp+96], ymm3
-    vmovdqu  [rsp+128], ymm4
-    vmovdqu  [rsp+160], ymm5
-    vmovdqu  [rsp+192], ymm6
-    vmovdqu  [rsp+224], ymm7
-    vmovdqu  [rsp+256], ymm8
-    vmovdqu  [rsp+288], ymm9
-    vmovdqu  [rsp+320], ymm10
-    vmovdqu  [rsp+352], ymm11
-    vmovdqu  [rsp+384], ymm12
-    vmovdqu  [rsp+416], ymm13
-    vmovdqu  [rsp+448], ymm14
-    vmovdqu  [rsp+480], ymm15
-
-    lea rdi, [rsp+64]
-    lea rsi, [rsp]
-
-    call    CheckForSaturationBeforeMul  # Call the C++ function
-
-    # Restore XMM registers
-    vmovdqu  ymm0, [rsp]
-    vmovdqu  ymm1, [rsp+32]
-    vmovdqu  ymm2, [rsp+64]
-    vmovdqu  ymm3, [rsp+96]
-    vmovdqu  ymm4, [rsp+128]
-    vmovdqu  ymm5, [rsp+160]
-    vmovdqu  ymm6, [rsp+192]
-    vmovdqu  ymm7, [rsp+224]
-    vmovdqu  ymm8, [rsp+256]
-    vmovdqu  ymm9, [rsp+288]
-    vmovdqu  ymm10, [rsp+320]
-    vmovdqu  ymm11, [rsp+352]
-    vmovdqu  ymm12, [rsp+384]
-    vmovdqu  ymm13, [rsp+416]
-    vmovdqu  ymm14, [rsp+448]
-    vmovdqu  ymm15, [rsp+480]
-
-    add     rsp, 512              # Clean up the reserved stack space
-
-    # Restore all caller-saved registers (RAX, RCX, RDX, RSI, RDI, R8, R9, R10, R11)
-    pop     r11
-    pop     r10
-    pop     r9
-    pop     r8
-    pop     rdi
-    pop     rsi
-    pop     rdx
-    pop     rcx
-    pop     rax
-
+#if defined(ENABLE_AVX2_SATURATION_CHECKER)
+        CheckSaturation
+#endif
         vpmaddubsw ymm3,ymm2,ymm0
         vpmaddwd ymm3,ymm3,ymm12
         vpaddd \Vec1Reg\(),\Vec1Reg\(),ymm3
-
-    # Save all caller-saved registers (RAX, RCX, RDX, RSI, RDI, R8, R9, R10, R11)
-    push    rax
-    push    rcx
-    push    rdx
-    push    rsi
-    push    rdi
-    push    r8
-    push    r9
-    push    r10
-    push    r11
-
-    sub     rsp, 512            # Reserve space for 16 registers (32 bytes for YMM registers)
-
-    # Save XMM registers (YMM0 to YMM15)
-    vmovdqu  [rsp], ymm0
-    vmovdqu  [rsp+32], ymm1
-    vmovdqu  [rsp+64], ymm2
-    vmovdqu  [rsp+96], ymm3
-    vmovdqu  [rsp+128], ymm4
-    vmovdqu  [rsp+160], ymm5
-    vmovdqu  [rsp+192], ymm6
-    vmovdqu  [rsp+224], ymm7
-    vmovdqu  [rsp+256], ymm8
-    vmovdqu  [rsp+288], ymm9
-    vmovdqu  [rsp+320], ymm10
-    vmovdqu  [rsp+352], ymm11
-    vmovdqu  [rsp+384], ymm12
-    vmovdqu  [rsp+416], ymm13
-    vmovdqu  [rsp+448], ymm14
-    vmovdqu  [rsp+480], ymm15
-
-    lea rdi, [rsp+64]
-    lea rsi, [rsp]
-
-    call    CheckForSaturationBeforeMul  # Call the C++ function
-
-    # Restore XMM registers
-    vmovdqu  ymm0, [rsp]
-    vmovdqu  ymm1, [rsp+32]
-    vmovdqu  ymm2, [rsp+64]
-    vmovdqu  ymm3, [rsp+96]
-    vmovdqu  ymm4, [rsp+128]
-    vmovdqu  ymm5, [rsp+160]
-    vmovdqu  ymm6, [rsp+192]
-    vmovdqu  ymm7, [rsp+224]
-    vmovdqu  ymm8, [rsp+256]
-    vmovdqu  ymm9, [rsp+288]
-    vmovdqu  ymm10, [rsp+320]
-    vmovdqu  ymm11, [rsp+352]
-    vmovdqu  ymm12, [rsp+384]
-    vmovdqu  ymm13, [rsp+416]
-    vmovdqu  ymm14, [rsp+448]
-    vmovdqu  ymm15, [rsp+480]
-
-    add     rsp, 512              # Clean up the reserved stack space
-
-    # Restore all caller-saved registers (RAX, RCX, RDX, RSI, RDI, R8, R9, R10, R11)
-    pop     r11
-    pop     r10
-    pop     r9
-    pop     r8
-    pop     rdi
-    pop     rsi
-    pop     rdx
-    pop     rcx
-    pop     rax
-
+#if defined(ENABLE_AVX2_SATURATION_CHECKER)
+        CheckSaturation
+#endif
         vpmaddubsw ymm2,ymm2,ymm1
         vpmaddwd ymm2,ymm2,ymm12
         vpaddd \Vec2Reg\(),\Vec2Reg\(),ymm2

--- a/onnxruntime/core/mlas/lib/x86_64/ConvSymKernelAvx2.S
+++ b/onnxruntime/core/mlas/lib/x86_64/ConvSymKernelAvx2.S
@@ -125,13 +125,13 @@ Implicit Arguments:
 
         .macro MultiplyAccumulateRowAvx2 Vec1Reg, Vec2Reg
 
-#if defined(ENABLE_AVX2_SATURATION_CHECKER)
+#if defined(ENABLE_CONVSYMKERNELAVX2_SAT_CHECKER)
         CheckSaturation
 #endif
         vpmaddubsw ymm3,ymm2,ymm0
         vpmaddwd ymm3,ymm3,ymm12
         vpaddd \Vec1Reg\(),\Vec1Reg\(),ymm3
-#if defined(ENABLE_AVX2_SATURATION_CHECKER)
+#if defined(ENABLE_CONVSYMKERNELAVX2_SAT_CHECKER)
         CheckSaturation
 #endif
         vpmaddubsw ymm2,ymm2,ymm1

--- a/onnxruntime/core/mlas/lib/x86_64/ConvSymKernelAvx2.S
+++ b/onnxruntime/core/mlas/lib/x86_64/ConvSymKernelAvx2.S
@@ -61,7 +61,7 @@ Abstract:
         lea rdi, [rsp+64]
         lea rsi, [rsp]
 
-        call    CheckSaturationForVPMADDUBSW  # Call the C++ function
+        call    CheckSaturationForVPMADDUBSW
 
         # Restore YMM registers
         vmovdqu  ymm0, [rsp]

--- a/onnxruntime/core/mlas/lib/x86_64/ConvSymKernelAvx2.S
+++ b/onnxruntime/core/mlas/lib/x86_64/ConvSymKernelAvx2.S
@@ -27,72 +27,72 @@ Abstract:
 
         .macro CheckSaturation
 
-    # Save all caller-saved registers (RAX, RCX, RDX, RSI, RDI, R8, R9, R10, R11)
-    push    rax
-    push    rcx
-    push    rdx
-    push    rsi
-    push    rdi
-    push    r8
-    push    r9
-    push    r10
-    push    r11
+        # Save all caller-saved registers (RAX, RCX, RDX, RSI, RDI, R8, R9, R10, R11)
+        push    rax
+        push    rcx
+        push    rdx
+        push    rsi
+        push    rdi
+        push    r8
+        push    r9
+        push    r10
+        push    r11
 
-    sub     rsp, 512            # Reserve space for 16 registers (32 bytes for YMM registers)
+        sub     rsp, 512            # Reserve space for 16 YMM registers (32 bytes)
 
-    # Save XMM registers (YMM0 to YMM15)
-    vmovdqu  [rsp], ymm0
-    vmovdqu  [rsp+32], ymm1
-    vmovdqu  [rsp+64], ymm2
-    vmovdqu  [rsp+96], ymm3
-    vmovdqu  [rsp+128], ymm4
-    vmovdqu  [rsp+160], ymm5
-    vmovdqu  [rsp+192], ymm6
-    vmovdqu  [rsp+224], ymm7
-    vmovdqu  [rsp+256], ymm8
-    vmovdqu  [rsp+288], ymm9
-    vmovdqu  [rsp+320], ymm10
-    vmovdqu  [rsp+352], ymm11
-    vmovdqu  [rsp+384], ymm12
-    vmovdqu  [rsp+416], ymm13
-    vmovdqu  [rsp+448], ymm14
-    vmovdqu  [rsp+480], ymm15
+        # Save YMM registers (YMM0 to YMM15)
+        vmovdqu  [rsp], ymm0
+        vmovdqu  [rsp+32], ymm1
+        vmovdqu  [rsp+64], ymm2
+        vmovdqu  [rsp+96], ymm3
+        vmovdqu  [rsp+128], ymm4
+        vmovdqu  [rsp+160], ymm5
+        vmovdqu  [rsp+192], ymm6
+        vmovdqu  [rsp+224], ymm7
+        vmovdqu  [rsp+256], ymm8
+        vmovdqu  [rsp+288], ymm9
+        vmovdqu  [rsp+320], ymm10
+        vmovdqu  [rsp+352], ymm11
+        vmovdqu  [rsp+384], ymm12
+        vmovdqu  [rsp+416], ymm13
+        vmovdqu  [rsp+448], ymm14
+        vmovdqu  [rsp+480], ymm15
 
-    lea rdi, [rsp+64]
-    lea rsi, [rsp]
+        lea rdi, [rsp+64]
+        lea rsi, [rsp]
 
-    call    CheckSaturationForVPMADDUBSW  # Call the C++ function
+        call    CheckSaturationForVPMADDUBSW  # Call the C++ function
 
-    # Restore XMM registers
-    vmovdqu  ymm0, [rsp]
-    vmovdqu  ymm1, [rsp+32]
-    vmovdqu  ymm2, [rsp+64]
-    vmovdqu  ymm3, [rsp+96]
-    vmovdqu  ymm4, [rsp+128]
-    vmovdqu  ymm5, [rsp+160]
-    vmovdqu  ymm6, [rsp+192]
-    vmovdqu  ymm7, [rsp+224]
-    vmovdqu  ymm8, [rsp+256]
-    vmovdqu  ymm9, [rsp+288]
-    vmovdqu  ymm10, [rsp+320]
-    vmovdqu  ymm11, [rsp+352]
-    vmovdqu  ymm12, [rsp+384]
-    vmovdqu  ymm13, [rsp+416]
-    vmovdqu  ymm14, [rsp+448]
-    vmovdqu  ymm15, [rsp+480]
+        # Restore YMM registers
+        vmovdqu  ymm0, [rsp]
+        vmovdqu  ymm1, [rsp+32]
+        vmovdqu  ymm2, [rsp+64]
+        vmovdqu  ymm3, [rsp+96]
+        vmovdqu  ymm4, [rsp+128]
+        vmovdqu  ymm5, [rsp+160]
+        vmovdqu  ymm6, [rsp+192]
+        vmovdqu  ymm7, [rsp+224]
+        vmovdqu  ymm8, [rsp+256]
+        vmovdqu  ymm9, [rsp+288]
+        vmovdqu  ymm10, [rsp+320]
+        vmovdqu  ymm11, [rsp+352]
+        vmovdqu  ymm12, [rsp+384]
+        vmovdqu  ymm13, [rsp+416]
+        vmovdqu  ymm14, [rsp+448]
+        vmovdqu  ymm15, [rsp+480]
 
-    add     rsp, 512              # Clean up the reserved stack space
+        add     rsp, 512              # Clean up the reserved stack space
 
-    # Restore all caller-saved registers (RAX, RCX, RDX, RSI, RDI, R8, R9, R10, R11)
-    pop     r11
-    pop     r10
-    pop     r9
-    pop     r8
-    pop     rdi
-    pop     rsi
-    pop     rdx
-    pop     rcx
-    pop     rax
+        # Restore all caller-saved registers (RAX, RCX, RDX, RSI, RDI, R8, R9, R10, R11)
+        pop     r11
+        pop     r10
+        pop     r9
+        pop     r8
+        pop     rdi
+        pop     rsi
+        pop     rdx
+        pop     rcx
+        pop     rax
 
         .endm
 

--- a/onnxruntime/core/mlas/lib/x86_64/ConvSymKernelAvx2.S
+++ b/onnxruntime/core/mlas/lib/x86_64/ConvSymKernelAvx2.S
@@ -25,7 +25,7 @@ Abstract:
 
         .extern CheckSaturationForVPMADDUBSW
 
-        .macro CheckSaturation
+        .macro CheckSaturation VecReg1Num, VecReg2Num
 
         # Save all caller-saved registers (RAX, RCX, RDX, RSI, RDI, R8, R9, R10, R11)
         push    rax
@@ -38,7 +38,7 @@ Abstract:
         push    r10
         push    r11
 
-        sub     rsp, 512            # Reserve space for 16 YMM registers (32 bytes)
+        sub     rsp, 512                        # Reserve space for 16 YMM registers (32 bytes)
 
         # Save YMM registers (YMM0 to YMM15)
         vmovdqu  [rsp], ymm0
@@ -58,8 +58,8 @@ Abstract:
         vmovdqu  [rsp+448], ymm14
         vmovdqu  [rsp+480], ymm15
 
-        lea rdi, [rsp+64]
-        lea rsi, [rsp]
+        lea rdi, [rsp+32*\VecReg1Num\()]        # first operand (unsigned)
+        lea rsi, [rsp+32*\VecReg2Num\()]        # second operand (signed)
 
         call    CheckSaturationForVPMADDUBSW
 
@@ -81,7 +81,7 @@ Abstract:
         vmovdqu  ymm14, [rsp+448]
         vmovdqu  ymm15, [rsp+480]
 
-        add     rsp, 512              # Clean up the reserved stack space
+        add     rsp, 512                        # Clean up the reserved stack space
 
         # Restore all caller-saved registers (RAX, RCX, RDX, RSI, RDI, R8, R9, R10, R11)
         pop     r11
@@ -126,13 +126,13 @@ Implicit Arguments:
         .macro MultiplyAccumulateRowAvx2 Vec1Reg, Vec2Reg
 
 #if defined(ENABLE_CONVSYMKERNELAVX2_SAT_CHECKER)
-        CheckSaturation
+        CheckSaturation 2,0
 #endif
         vpmaddubsw ymm3,ymm2,ymm0
         vpmaddwd ymm3,ymm3,ymm12
         vpaddd \Vec1Reg\(),\Vec1Reg\(),ymm3
 #if defined(ENABLE_CONVSYMKERNELAVX2_SAT_CHECKER)
-        CheckSaturation
+        CheckSaturation 2,1
 #endif
         vpmaddubsw ymm2,ymm2,ymm1
         vpmaddwd ymm2,ymm2,ymm12

--- a/onnxruntime/core/mlas/lib/x86_64/ConvSymKernelAvx2.S
+++ b/onnxruntime/core/mlas/lib/x86_64/ConvSymKernelAvx2.S
@@ -23,7 +23,7 @@ Abstract:
 
         .intel_syntax noprefix
 
-        .extern CheckForSaturationBeforeMul  # Declare external function
+        .extern CheckSaturationForVPMADDUBSW
 
         .macro CheckSaturation
 
@@ -61,7 +61,7 @@ Abstract:
     lea rdi, [rsp+64]
     lea rsi, [rsp]
 
-    call    CheckForSaturationBeforeMul  # Call the C++ function
+    call    CheckSaturationForVPMADDUBSW  # Call the C++ function
 
     # Restore XMM registers
     vmovdqu  ymm0, [rsp]

--- a/onnxruntime/core/mlas/lib/x86_64/ConvSymKernelAvx2.S
+++ b/onnxruntime/core/mlas/lib/x86_64/ConvSymKernelAvx2.S
@@ -50,11 +50,148 @@ Implicit Arguments:
 
 --*/
 
+        .extern CheckForSaturationBeforeMul  # Declare external function
+
         .macro MultiplyAccumulateRowAvx2 Vec1Reg, Vec2Reg
+
+    # Save all caller-saved registers (RAX, RCX, RDX, RSI, RDI, R8, R9, R10, R11)
+    push    rax
+    push    rcx
+    push    rdx
+    push    rsi
+    push    rdi
+    push    r8
+    push    r9
+    push    r10
+    push    r11
+
+    sub     rsp, 512            # Reserve space for 16 registers (32 bytes for YMM registers)
+
+    # Save XMM registers (YMM0 to YMM15)
+    vmovdqu  [rsp], ymm0
+    vmovdqu  [rsp+32], ymm1
+    vmovdqu  [rsp+64], ymm2
+    vmovdqu  [rsp+96], ymm3
+    vmovdqu  [rsp+128], ymm4
+    vmovdqu  [rsp+160], ymm5
+    vmovdqu  [rsp+192], ymm6
+    vmovdqu  [rsp+224], ymm7
+    vmovdqu  [rsp+256], ymm8
+    vmovdqu  [rsp+288], ymm9
+    vmovdqu  [rsp+320], ymm10
+    vmovdqu  [rsp+352], ymm11
+    vmovdqu  [rsp+384], ymm12
+    vmovdqu  [rsp+416], ymm13
+    vmovdqu  [rsp+448], ymm14
+    vmovdqu  [rsp+480], ymm15
+
+    lea rdi, [rsp+64]
+    lea rsi, [rsp]
+
+    call    CheckForSaturationBeforeMul  # Call the C++ function
+
+    # Restore XMM registers
+    vmovdqu  ymm0, [rsp]
+    vmovdqu  ymm1, [rsp+32]
+    vmovdqu  ymm2, [rsp+64]
+    vmovdqu  ymm3, [rsp+96]
+    vmovdqu  ymm4, [rsp+128]
+    vmovdqu  ymm5, [rsp+160]
+    vmovdqu  ymm6, [rsp+192]
+    vmovdqu  ymm7, [rsp+224]
+    vmovdqu  ymm8, [rsp+256]
+    vmovdqu  ymm9, [rsp+288]
+    vmovdqu  ymm10, [rsp+320]
+    vmovdqu  ymm11, [rsp+352]
+    vmovdqu  ymm12, [rsp+384]
+    vmovdqu  ymm13, [rsp+416]
+    vmovdqu  ymm14, [rsp+448]
+    vmovdqu  ymm15, [rsp+480]
+
+    add     rsp, 512              # Clean up the reserved stack space
+
+    # Restore all caller-saved registers (RAX, RCX, RDX, RSI, RDI, R8, R9, R10, R11)
+    pop     r11
+    pop     r10
+    pop     r9
+    pop     r8
+    pop     rdi
+    pop     rsi
+    pop     rdx
+    pop     rcx
+    pop     rax
 
         vpmaddubsw ymm3,ymm2,ymm0
         vpmaddwd ymm3,ymm3,ymm12
         vpaddd \Vec1Reg\(),\Vec1Reg\(),ymm3
+
+    # Save all caller-saved registers (RAX, RCX, RDX, RSI, RDI, R8, R9, R10, R11)
+    push    rax
+    push    rcx
+    push    rdx
+    push    rsi
+    push    rdi
+    push    r8
+    push    r9
+    push    r10
+    push    r11
+
+    sub     rsp, 512            # Reserve space for 16 registers (32 bytes for YMM registers)
+
+    # Save XMM registers (YMM0 to YMM15)
+    vmovdqu  [rsp], ymm0
+    vmovdqu  [rsp+32], ymm1
+    vmovdqu  [rsp+64], ymm2
+    vmovdqu  [rsp+96], ymm3
+    vmovdqu  [rsp+128], ymm4
+    vmovdqu  [rsp+160], ymm5
+    vmovdqu  [rsp+192], ymm6
+    vmovdqu  [rsp+224], ymm7
+    vmovdqu  [rsp+256], ymm8
+    vmovdqu  [rsp+288], ymm9
+    vmovdqu  [rsp+320], ymm10
+    vmovdqu  [rsp+352], ymm11
+    vmovdqu  [rsp+384], ymm12
+    vmovdqu  [rsp+416], ymm13
+    vmovdqu  [rsp+448], ymm14
+    vmovdqu  [rsp+480], ymm15
+
+    lea rdi, [rsp+64]
+    lea rsi, [rsp]
+
+    call    CheckForSaturationBeforeMul  # Call the C++ function
+
+    # Restore XMM registers
+    vmovdqu  ymm0, [rsp]
+    vmovdqu  ymm1, [rsp+32]
+    vmovdqu  ymm2, [rsp+64]
+    vmovdqu  ymm3, [rsp+96]
+    vmovdqu  ymm4, [rsp+128]
+    vmovdqu  ymm5, [rsp+160]
+    vmovdqu  ymm6, [rsp+192]
+    vmovdqu  ymm7, [rsp+224]
+    vmovdqu  ymm8, [rsp+256]
+    vmovdqu  ymm9, [rsp+288]
+    vmovdqu  ymm10, [rsp+320]
+    vmovdqu  ymm11, [rsp+352]
+    vmovdqu  ymm12, [rsp+384]
+    vmovdqu  ymm13, [rsp+416]
+    vmovdqu  ymm14, [rsp+448]
+    vmovdqu  ymm15, [rsp+480]
+
+    add     rsp, 512              # Clean up the reserved stack space
+
+    # Restore all caller-saved registers (RAX, RCX, RDX, RSI, RDI, R8, R9, R10, R11)
+    pop     r11
+    pop     r10
+    pop     r9
+    pop     r8
+    pop     rdi
+    pop     rsi
+    pop     rdx
+    pop     rcx
+    pop     rax
+
         vpmaddubsw ymm2,ymm2,ymm1
         vpmaddwd ymm2,ymm2,ymm12
         vpaddd \Vec2Reg\(),\Vec2Reg\(),ymm2

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -96,8 +96,6 @@
 using namespace ONNX_NAMESPACE;
 using namespace onnxruntime::common;
 
-extern int saturate_counter;
-
 namespace onnxruntime {
 namespace {
 template <typename T>
@@ -251,6 +249,8 @@ Status GetMinimalBuildOptimizationHandling(
 #endif  // !defined(ORT_MINIMAL_BUILD)
 
 }  // namespace
+
+extern std::atomic<int> saturation_count;
 
 std::atomic<uint32_t> InferenceSession::global_session_id_{1};
 std::map<uint32_t, InferenceSession*> InferenceSession::active_sessions_;
@@ -2863,7 +2863,7 @@ Status InferenceSession::Run(const RunOptions& run_options,
   }
 #endif
 
-  saturate_counter = 0;
+  saturation_count = 0;
 
   // As N+1 inference runs (N for memory allocation and 1 for graph capturing)
   // are needed before replaying the captured graph, here run N inference runs recursively until graph captured,

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -2863,7 +2863,7 @@ Status InferenceSession::Run(const RunOptions& run_options,
   }
 #endif
 
-  saturation_count = 0;
+  reset_saturation_count();
 
   // As N+1 inference runs (N for memory allocation and 1 for graph capturing)
   // are needed before replaying the captured graph, here run N inference runs recursively until graph captured,

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -96,6 +96,8 @@
 using namespace ONNX_NAMESPACE;
 using namespace onnxruntime::common;
 
+extern int saturate_counter;
+
 namespace onnxruntime {
 namespace {
 template <typename T>
@@ -2860,6 +2862,8 @@ Status InferenceSession::Run(const RunOptions& run_options,
     node_stats_recorder_->ResetPerRunNameDeduper();
   }
 #endif
+
+  saturate_counter = 0;
 
   // As N+1 inference runs (N for memory allocation and 1 for graph capturing)
   // are needed before replaying the captured graph, here run N inference runs recursively until graph captured,

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -250,8 +250,6 @@ Status GetMinimalBuildOptimizationHandling(
 
 }  // namespace
 
-extern std::atomic<int> saturation_count;
-
 std::atomic<uint32_t> InferenceSession::global_session_id_{1};
 std::map<uint32_t, InferenceSession*> InferenceSession::active_sessions_;
 #ifdef _WIN32

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -58,6 +58,8 @@ class IExecutionProvider;
 class IOBinding;
 struct Notification;
 
+void reset_saturation_count();
+
 #ifdef ENABLE_TRAINING
 struct PartialGraphExecutionState;
 using OrtValueCache = InlinedHashMap<std::string, OrtValue>;


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

This PR adds a new CMake option: onnxruntime_ENABLE_CONVSYMKERNELAVX2_SAT_CHECKER. When enabled, this option activates a saturation checker for the VPMADDUBSW instruction used in the ConvSymKernelAvx2 path.

The checker works by calling a helper function before each VPMADDUBSW instruction. This function simulates the computation using C++ and intrinsics with higher-precision types (int32_t) to detect whether the result exceeds the bounds of int16_t (i.e., greater than INT16_MAX or less than INT16_MIN).

By default, the checker logs a warning only once per inference session. However, the logic can be easily extended to print more frequently if needed. Developers can also reuse this pattern to implement similar saturation checks for other instructions.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

On some models running with AVX2 (instead of AVX-VNNI), we've observed accuracy degradation due to saturation in vectorized instructions. This saturation checker provides a way to debug and detect those cases by reporting potential overflow in intermediate computations.
