### PR TITLE
Pin VCPKG version

### DIFF
--- a/.github/actions/locate-vcvarsall-and-setup-env/action.yml
+++ b/.github/actions/locate-vcvarsall-and-setup-env/action.yml
@@ -12,7 +12,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Download ORT Actions Asset (v0.0.3) # <-- Adjust version as needed
+    - name: Download ORT Actions Asset (v0.0.3)
       uses: dsaltares/fetch-gh-release-asset@1.1.0 # Action to download assets
       with:
         repo: 'microsoft/onnxruntime-github-actions'    # The repo containing the actions
@@ -20,7 +20,6 @@ runs:
         file: 'onnxruntime-actions-v0.0.3.zip'           # The asset filename (matches release workflow output)
         target: 'onnxruntime-actions.zip'                # Local filename to save as
       env:
-        # Use default token for public repos, provide PAT for private if necessary
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Unzip ORT Actions (Windows)

--- a/.github/actions/locate-vcvarsall-and-setup-env/action.yml
+++ b/.github/actions/locate-vcvarsall-and-setup-env/action.yml
@@ -34,7 +34,7 @@ runs:
         # List the contents recursively (Windows equivalent of ls -lR)
         Get-ChildItem -Path '.\.github\_downloaded_actions' -Recurse
 
-    - name: Build Docker Image (${{ inputs.architecture }} / ${{ inputs.build_config }})
+    - name: Setup VCPKG
       uses: ./.github/_downloaded_actions/setup-vcpkg
       with:
         vcpkg-version: '2025.03.19'

--- a/.github/actions/locate-vcvarsall-and-setup-env/action.yml
+++ b/.github/actions/locate-vcvarsall-and-setup-env/action.yml
@@ -12,6 +12,34 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Download ORT Actions Asset (v0.0.3) # <-- Adjust version as needed
+      uses: dsaltares/fetch-gh-release-asset@1.1.0 # Action to download assets
+      with:
+        repo: 'microsoft/onnxruntime-github-actions'    # The repo containing the actions
+        version: 'tags/v0.0.3'                           # The specific tag/version to use
+        file: 'onnxruntime-actions-v0.0.3.zip'           # The asset filename (matches release workflow output)
+        target: 'onnxruntime-actions.zip'                # Local filename to save as
+      env:
+        # Use default token for public repos, provide PAT for private if necessary
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Unzip ORT Actions (Windows)
+      shell: pwsh
+      run: |
+        # Create a directory to hold them (-Force acts like -p, creates parents if needed)
+        New-Item -Path '.\.github\_downloaded_actions' -ItemType Directory -Force
+        # Unzip the archive to the target directory
+        Expand-Archive -Path '.\onnxruntime-actions.zip' -DestinationPath '.\.github\_downloaded_actions' -Force
+        Write-Host "Unzipped contents:"
+        # List the contents recursively (Windows equivalent of ls -lR)
+        Get-ChildItem -Path '.\.github\_downloaded_actions' -Recurse
+
+    - name: Build Docker Image (${{ inputs.architecture }} / ${{ inputs.build_config }})
+      uses: ./.github/_downloaded_actions/setup-vcpkg
+      with:
+        vcpkg-version: '2025.03.19'
+        vcpkg-hash: '17e96169cd3f266c4716fcdc1bb728e6a64f103941ece463a2834d50694eba4fb48f30135503fd466402afa139abc847ef630733c442595d1c34979f261b0114'
+
     - name: Find vcvarsall.bat
       id: find-vcvarsall
       shell: python  # Use Python shell

--- a/.github/actions/locate-vcvarsall-and-setup-env/action.yml
+++ b/.github/actions/locate-vcvarsall-and-setup-env/action.yml
@@ -19,8 +19,6 @@ runs:
         version: 'tags/v0.0.3'                           # The specific tag/version to use
         file: 'onnxruntime-actions-v0.0.3.zip'           # The asset filename (matches release workflow output)
         target: 'onnxruntime-actions.zip'                # Local filename to save as
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Unzip ORT Actions (Windows)
       shell: pwsh

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Android NDK
         uses: ./.github/actions/setup-android-ndk
         with:
-          ndk-version: 27.2.12479018
+          ndk-version: 28.0.13004108
 
       - name: Export GitHub Actions cache environment variables
         uses: actions/github-script@v7
@@ -101,7 +101,7 @@ jobs:
       - name: Setup Android NDK
         uses: ./.github/actions/setup-android-ndk
         with:
-          ndk-version: 27.2.12479018
+          ndk-version: 28.0.13004108
 
       - name: Export GitHub Actions cache environment variables
         uses: actions/github-script@v7

--- a/tools/android_custom_build/Dockerfile
+++ b/tools/android_custom_build/Dockerfile
@@ -55,7 +55,7 @@ WORKDIR /workspace
 
 # install Android SDK and tools
 ENV ANDROID_HOME=~/android-sdk
-ENV NDK_VERSION=27.2.12479018
+ENV NDK_VERSION=28.0.13004108
 ENV ANDROID_NDK_HOME=${ANDROID_HOME}/ndk/${NDK_VERSION}
 
 RUN aria2c -q -d /tmp -o cmdline-tools.zip \

--- a/tools/ci_build/github/azure-pipelines/templates/use-android-ndk.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/use-android-ndk.yml
@@ -3,7 +3,7 @@
   parameters:
   - name: AndroidNdkVersion
     type: string
-    default: "27.2.12479018"  # LTS version
+    default: "28.0.13004108"  # LTS version
 
   steps:
   - bash: |


### PR DESCRIPTION
### Description
1. Pin VCPKG version
2. Update NDK to 28 because cmake 4.0 dropped the support for NDK 27.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


