### PR TITLE
Update NDK to 28

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Android NDK
         uses: ./.github/actions/setup-android-ndk
         with:
-          ndk-version: 27.2.12479018
+          ndk-version: 28.0.13004108
 
       - name: Export GitHub Actions cache environment variables
         uses: actions/github-script@v7
@@ -101,7 +101,7 @@ jobs:
       - name: Setup Android NDK
         uses: ./.github/actions/setup-android-ndk
         with:
-          ndk-version: 27.2.12479018
+          ndk-version: 28.0.13004108
 
       - name: Export GitHub Actions cache environment variables
         uses: actions/github-script@v7

--- a/tools/android_custom_build/Dockerfile
+++ b/tools/android_custom_build/Dockerfile
@@ -55,7 +55,7 @@ WORKDIR /workspace
 
 # install Android SDK and tools
 ENV ANDROID_HOME=~/android-sdk
-ENV NDK_VERSION=27.2.12479018
+ENV NDK_VERSION=28.0.13004108
 ENV ANDROID_NDK_HOME=${ANDROID_HOME}/ndk/${NDK_VERSION}
 
 RUN aria2c -q -d /tmp -o cmdline-tools.zip \

--- a/tools/ci_build/github/azure-pipelines/templates/use-android-ndk.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/use-android-ndk.yml
@@ -3,7 +3,7 @@
   parameters:
   - name: AndroidNdkVersion
     type: string
-    default: "27.2.12479018"  # LTS version
+    default: "28.0.13004108"  # LTS version
 
   steps:
   - bash: |


### PR DESCRIPTION
### Description
Similar to #23280


### Motivation and Context
CMake 4.0 dropped the support for NDK 27.

