### PR TITLE
Fix ORT default logger for non ANSI strings

### DIFF
--- a/onnxruntime/core/common/logging/sinks/ostream_sink.h
+++ b/onnxruntime/core/common/logging/sinks/ostream_sink.h
@@ -39,6 +39,8 @@ class WOStreamSink : public ISink {
  protected:
   WOStreamSink(std::wostream& stream, bool flush)
       : stream_{&stream}, flush_{flush} {
+    // Set the locale to UTF-8 to ensure proper handling of wide characters
+    stream.imbue(std::locale(".UTF-8", std::locale::ctype));
   }
 
  public:


### PR DESCRIPTION
### Description

The current ORT default logger does not handle non-ANSI strings properly. If any wide characters are present in the log message, the underlying `st::wclog` will be in failure status and no longer output further logs after that.


### Motivation and Context

When running onnxruntime_test_all with verbose logging, the standard error no longer output anything after running `TunableOp` test case. After debug, I found out that the following verbose logging failed the `std::wcerr` and since the stream is on a failed status it no longer output anything further.


https://github.com/microsoft/onnxruntime/blob/19d8d69c6692f43ed6e03bfa177aeb6548db5008/onnxruntime/core/framework/tunable.h#L266

This change sets the code page to UTF-8 so that those characters can be properly handled by the wide stream.