### PR TITLE
Add docs for QNN EP `backend_type` provider option

### DIFF
--- a/docs/execution-providers/QNN-ExecutionProvider.md
+++ b/docs/execution-providers/QNN-ExecutionProvider.md
@@ -55,7 +55,9 @@ The QNN Execution Provider supports a number of configuration options. These pro
 |`"backend_type"`|Description|
 |---|-----|
 |'cpu'|Enable CPU backend. Useful for integration testing. The CPU backend is a reference implementation of QNN operators.|
+|'gpu'|Enable GPU backend.|
 |'htp'|Enable HTP backend. Offloads compute to NPU. Default.|
+|'saver'|Enable Saver backend.|
 
 |`"backend_path"`|Description|
 |---|-----|

--- a/docs/execution-providers/QNN-ExecutionProvider.md
+++ b/docs/execution-providers/QNN-ExecutionProvider.md
@@ -62,7 +62,7 @@ The QNN Execution Provider supports a number of configuration options. These pro
 |`"backend_path"`|Description|
 |---|-----|
 |'libQnnCpu.so' or 'QnnCpu.dll'|Enable CPU backend. See `backend_type` 'cpu'.|
-|'libQnnHtp.so' or 'QnnHtp.dll'|Enable HTP backend. See `backend_type` 'npu'.|
+|'libQnnHtp.so' or 'QnnHtp.dll'|Enable HTP backend. See `backend_type` 'htp'.|
 
 **Note:** `backend_path` is an alternative to `backend_type`. At most one of the two should be specified.
 `backend_path` requires a platform-specific path (e.g., `libQnnCpu.so` vs. `QnnCpu.dll`) but also allows one to specify an arbitrary path.

--- a/docs/execution-providers/QNN-ExecutionProvider.md
+++ b/docs/execution-providers/QNN-ExecutionProvider.md
@@ -52,10 +52,18 @@ OnnxRuntime QNN Execution Provider is a supported runtime in [Qualcomm AI Hub](h
 ## Configuration Options
 The QNN Execution Provider supports a number of configuration options. These provider options are specified as key-value string pairs.
 
+|`"backend_type"`|Description|
+|---|-----|
+|'cpu'|Enable CPU backend. Useful for integration testing. The CPU backend is a reference implementation of QNN operators.|
+|'htp'|Enable HTP backend. Offloads compute to NPU. Default.|
+
 |`"backend_path"`|Description|
 |---|-----|
-|'libQnnCpu.so' or 'QnnCpu.dll'|Enable CPU backend. Useful for integration testing. CPU backend is a reference implementation of QNN operators|
-|'libQnnHtp.so' or 'QnnHtp.dll'|Enable HTP backend. Offloads compute to NPU.|
+|'libQnnCpu.so' or 'QnnCpu.dll'|Enable CPU backend. See `backend_type` 'cpu'.|
+|'libQnnHtp.so' or 'QnnHtp.dll'|Enable HTP backend. See `backend_type` 'npu'.|
+
+**Note:** `backend_path` is an alternative to `backend_type`. At most one of the two should be specified.
+`backend_path` requires a platform-specific path (e.g., `libQnnCpu.so` vs. `QnnCpu.dll`) but also allows one to specify an arbitrary path.
 
 |`"profiling_level"`|Description|
 |---|---|


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Add docs for QNN EP `backend_type` provider option.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Document QNN EP option added in #24235.
