### PR TITLE
Exclude onnxruntime-inference-examples directory from Component Gover…

### DIFF
--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -92,6 +92,8 @@ extends:
         enabled: true
         analyzeTargetGlob: $(Build.ArtifactStagingDirectory)/**.dll
       sourceAnalysisPool: "Onnxruntime-Win-CPU-2022"
+      componentgovernance:
+        ignoreDirectories: $(Build.SourcesDirectory)/onnxruntime-inference-examples
       sourceRepositoriesToScan:
         exclude:
         - repository: onnxruntime-inference-examples

--- a/tools/ci_build/github/azure-pipelines/cuda-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/cuda-packaging-pipeline.yml
@@ -91,6 +91,8 @@ extends:
       sourceAnalysisPool:
         name: onnxruntime-Win-CPU-2022
         os: windows
+      componentgovernance:
+        ignoreDirectories: $(Build.SourcesDirectory)/onnxruntime-inference-examples
       sourceRepositoriesToScan:
         exclude:
         - repository: onnxruntime-inference-examples


### PR DESCRIPTION
…nance

### Description
Exclude onnxruntime-inference-examples directory from Component Governance


### Motivation and Context
onnxruntime-inference-examples is a extneral repos


