### PR TITLE
Update xcode and iphoneSimulatorVersion after MacOS-14

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   iOS_CI_on_Mac:
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -60,5 +60,5 @@ jobs:
 
     timeout-minutes: 150
     env:
-      XCODE_VERSION: 14.3.1
-      IOS_SIMULATOR_RUNTIME_VERSION: 16.4
+      XCODE_VERSION: 15.3.0
+      IOS_SIMULATOR_RUNTIME_VERSION: 17.4

--- a/tools/ci_build/github/azure-pipelines/templates/stages/mac-ios-packaging-build-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/stages/mac-ios-packaging-build-stage.yml
@@ -23,8 +23,8 @@ stages:
       # Note: Keep the Xcode version and iOS simulator version compatible.
       # Check the table here to see what iOS simulator versions are supported by a particular Xcode version:
       # https://developer.apple.com/support/xcode/
-      xcodeVersion: "14.3.1"
-      iosSimulatorRuntimeVersion: "16.4"
+      xcodeVersion: "15.3.0"
+      iosSimulatorRuntimeVersion: "17.4"
       ${{ if eq(parameters.packageVariant, 'Full') }}:
         buildSettingsFile: "tools/ci_build/github/apple/default_full_apple_framework_build_settings.json"
         cPodName: onnxruntime-c


### PR DESCRIPTION
### Description
Update xcode and iphoneSimulatorVersion after MacOS-14



### Motivation and Context
iOS packaging pipeline and Github Action were still using the old xcode version after https://github.com/microsoft/onnxruntime/pull/23293

