### PR TITLE
[WebGPU EP] Implements ceil mode for Average Pool 

### DIFF
--- a/onnxruntime/core/providers/webgpu/nn/pool.cc
+++ b/onnxruntime/core/providers/webgpu/nn/pool.cc
@@ -169,8 +169,6 @@ Status PoolProgram::GenerateShaderCode(ShaderHelper& shader) const {
 
 template <typename PoolType, bool is_nhwc>
 Status Pool<PoolType, is_nhwc>::ComputeInternal(ComputeContext& context) const {
-  // TODO: support 'ceil' mode.
-  ORT_RETURN_IF_NOT(pool_attrs_.ceil_mode == 0, "Using ceil is not supported yet.");
   // TODO: support 'column major' storage_order.
   ORT_RETURN_IF_NOT(pool_attrs_.storage_order == 0, "Using column major storage_order is not supported yet.");
 

--- a/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
@@ -647,7 +647,7 @@ TEST(PoolTest, MaxPool_10_Dilation_Ceil1_2d) {
 
   // TODO: Enable the case for WebGPU once ceil is supported.
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
-           {kTensorrtExecutionProvider, kAclExecutionProvider, kWebGpuExecutionProvider});
+           {kTensorrtExecutionProvider, kAclExecutionProvider});
 }
 
 TEST(PoolTest, MaxPool_10_DilationPadding_3d) {
@@ -1008,7 +1008,7 @@ TEST(PoolTest, AveragePool_10_ceil1_2d) {
 
   // TODO: Enable the case for WebGPU once ceil is supported.
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
-           {kTensorrtExecutionProvider, kAclExecutionProvider, kWebGpuExecutionProvider});
+           {kTensorrtExecutionProvider, kAclExecutionProvider});
 }
 
 TEST(PoolTest, AveragePool_19_dilation_2d) {

--- a/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
@@ -645,7 +645,6 @@ TEST(PoolTest, MaxPool_10_Dilation_Ceil1_2d) {
   test.AddInput<float>("X", x_dims, x_vals);
   test.AddOutput<float>("Y", expected_dims, expected_vals);
 
-  // TODO: Enable the case for WebGPU once ceil is supported.
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
            {kTensorrtExecutionProvider, kAclExecutionProvider});
 }
@@ -1006,7 +1005,6 @@ TEST(PoolTest, AveragePool_10_ceil1_2d) {
   test.AddInput<float>("X", x_dims, x_vals);
   test.AddOutput<float>("Y", expected_dims, expected_vals);
 
-  // TODO: Enable the case for WebGPU once ceil is supported.
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
            {kTensorrtExecutionProvider, kAclExecutionProvider});
 }


### PR DESCRIPTION
Ceil mode is required for rtdetr model.

The actual ceil mode calculation is already implemented in the PoolAttributes::ComputeOutputSize() method from pool_attributes.h under CPU EP.