### PR TITLE
[QNN-EP] Fix ONNX context model helper.

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/qnn/builder/onnx_ctx_model_helper.cc
@@ -77,6 +77,7 @@ Status CreateNodeArgs(const std::vector<std::string>& names,
     const OnnxTensorInfo& tensor_info = tensor_info_table.at(name);
     std::unique_ptr<ONNX_NAMESPACE::TypeProto> tensor_type = Factory<ONNX_NAMESPACE::TypeProto>::Create();
     tensor_type->mutable_tensor_type()->set_elem_type(tensor_info.data_type_);
+    tensor_type->mutable_tensor_type()->mutable_shape();
     for (size_t j = 0; j < tensor_info.shape_.size(); ++j) {
       tensor_type->mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(tensor_info.shape_[j]);
     }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Fix the bug where the QNN EP generates an ONNX model with EP Context and fails to run.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
When generating an ONNX model with QNN EP context where the input is scalar, the shape is not set, resulting in a null pointer and causing the subsequent run to fail.

