### PR TITLE
Enable tests that pass on the scoreboard

### DIFF
--- a/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
+++ b/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
@@ -86,10 +86,6 @@
         "^test_identity_sequence_cpu",
         "^test_lstm_batchwise_cpu",
         "^test_simple_rnn_batchwise_cpu",
-        "^test_sub_uint8_cpu",
-        "^test_mul_uint8_cpu",
-        "^test_add_uint8_cpu",
-        "^test_div_uint8_cpu",
         // Optional operators are supported in ORT but the ONNX backend test runner
         // doesn't yet have capability to deal with optional type test data.
         // These tests have been validated using the in-house onnx_test_runner.
@@ -145,13 +141,9 @@
         "^test_shufflenet",
         "^test_squeezenet",
         "^test_averagepool_3d_dilations_large_count_include_pad_is_1_ceil_mode_is_True_cpu",
-        "^test_averagepool_3d_dilations_large_count_include_pad_is_1_ceil_mode_is_False_cpu",
-        "^test_averagepool_3d_dilations_large_count_include_pad_is_0_ceil_mode_is_True_cpu",
-        "^test_averagepool_3d_dilations_large_count_include_pad_is_0_ceil_mode_is_False_cpu",
         "^test_averagepool_3d_dilations_large_count_include_pad_is_1_ceil_mode_is_True_cuda",
         "^test_averagepool_3d_dilations_large_count_include_pad_is_1_ceil_mode_is_False_cuda",
         "^test_averagepool_2d_dilations_cpu",
-        "^test_averagepool_3d_dilations_small_cpu",
         "^test_constant_pad_axes*",
         "^test_constant_pad*",
         "^test_edge_pad*",
@@ -248,14 +240,7 @@
         "^test_reduce_sum_empty_set_cuda",
         "^test_reduce_sum_square_empty_set_cuda",
         "^test_reduce_sum_square_empty_set_expanded_cuda",
-        // ONNX 1.16.0 fixed a maxpool output size bug and added this test.
-        // Enable this test when ORT PR is merged: https://github.com/microsoft/onnxruntime/pull/18377
-        // See original ONNX 1.16.0 fix: https://github.com/onnx/onnx/pull/5741
-        "^test_maxpool_2d_ceil_output_size_reduce_by_one",
         // ai.onnx.ml.TreeEnsemble from ONNX 1.16.0 is not implemented in ORT yet.
-        "^test_ai_onnx_ml_tree_ensemble_set_membership_cpu",
-        "^test_ai_onnx_ml_tree_ensemble_set_membership_cpu",
-        "^test_ai_onnx_ml_tree_ensemble_single_tree_cpu",
         "^test_ai_onnx_ml_tree_ensemble_set_membership_cuda",
         "^test_ai_onnx_ml_tree_ensemble_single_tree_cuda",
         // ORT Cast(21) implementation doesn't support int4 yet
@@ -284,12 +269,8 @@
         // QLinearMatMul(21) from ONNX 1.16.0 is not implemented in ORT yet.
         "^test_qlinearmatmul_2D_int8_float16_cpu",
         "^test_qlinearmatmul_2D_int8_float32_cpu",
-        "^test_qlinearmatmul_2D_uint8_float16_cpu",
-        "^test_qlinearmatmul_2D_uint8_float32_cpu",
         "^test_qlinearmatmul_3D_int8_float16_cpu",
         "^test_qlinearmatmul_3D_int8_float32_cpu",
-        "^test_qlinearmatmul_3D_uint8_float16_cpu",
-        "^test_qlinearmatmul_3D_uint8_float32_cpu",
         "^test_qlinearmatmul_2D_int8_float16_cuda",
         "^test_qlinearmatmul_2D_int8_float32_cuda",
         "^test_qlinearmatmul_2D_uint8_float16_cuda",


### PR DESCRIPTION
Ran the https://github.com/onnx/backend-scoreboard with this change: https://github.com/onnx/backend-scoreboard/pull/64 and noticed that some of tests that are in the `current_failing_tests` list are passing when using `onnxruntime` 1.21.0. So I would like to remove those from the list.