### PR TITLE
Update packaging pipeline for Nodejs binding

### DIFF
--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -147,6 +147,29 @@ extends:
         SpecificArtifact: ${{ parameters.SpecificArtifact }}
         BuildId: ${{ parameters.BuildId }}
 
+    - template: stages/nodejs-win-packaging-stage.yml
+      parameters:
+        IsReleaseBuild: ${{ parameters.IsReleaseBuild }}
+        ArtifactName: 'drop-onnxruntime-nodejs-win-x64'
+        StageName: 'Windows_Nodejs_Packaging_x64'
+        BuildCommand: --skip_submodule_sync --build_shared_lib --enable_onnx_tests --enable_wcos --use_telemetry --use_dml --use_webgpu --build_nodejs --cmake_generator "Visual Studio 17 2022"
+        BuildArch: 'x64'
+        EnvSetupScript: 'setup_env.bat'
+        sln_platform: 'x64'
+        DoEsrp: ${{ parameters.DoEsrp }}
+        PublishWebGpuBuildTools: true
+
+    - template: stages/nodejs-win-packaging-stage.yml
+      parameters:
+        IsReleaseBuild: ${{ parameters.IsReleaseBuild }}
+        ArtifactName: 'drop-onnxruntime-nodejs-win-arm64'
+        StageName: 'Windows_Nodejs_Packaging_arm64'
+        BuildCommand: --arm64 --skip_submodule_sync --build_shared_lib --enable_onnx_tests --enable_wcos --use_telemetry --use_dml --use_webgpu --build_nodejs --cmake_generator "Visual Studio 17 2022"
+        BuildArch: 'x64'
+        EnvSetupScript: 'setup_env.bat'
+        sln_platform: 'arm64'
+        DoEsrp: ${{ parameters.DoEsrp }}
+        DependsOnStageName: Windows_Nodejs_Packaging_x64
 
     - template: nuget/templates/dml-vs-2022.yml
       parameters:

--- a/tools/ci_build/github/azure-pipelines/stages/nodejs-linux-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nodejs-linux-packaging-stage.yml
@@ -1,0 +1,57 @@
+parameters:
+- name: CudaVersion
+  type: string
+  default: '12.2'
+
+stages:
+- stage: Linux_Nodejs_Packaging_x64
+  dependsOn: []
+  jobs:
+  - job: Linux_Nodejs_Packaging_x64
+    dependsOn: []
+    workspace:
+      clean: all
+    timeoutInMinutes: 180
+    pool:
+      name: 'onnxruntime-Ubuntu2204-AMD-CPU'
+      os: linux
+    variables:
+    - template: ../templates/common-variables.yml
+    - name: CUDA_VERSION_MAJOR
+      ${{ if eq(parameters.CudaVersion, '11.8') }}:
+        value: '11'
+      ${{ if eq(parameters.CudaVersion, '12.2') }}:
+        value: '12'
+    - name: CUDA_VERSION
+      value: ${{ parameters.CudaVersion }}
+    - name: linux_trt_version
+      ${{ if eq(parameters.CudaVersion, '11.8') }}:
+        value: ${{ variables.linux_trt_version_cuda11 }}
+      ${{ if eq(parameters.CudaVersion, '12.2') }}:
+        value: ${{ variables.linux_trt_version_cuda12 }}
+    steps:
+    - checkout: self
+      clean: true
+      submodules: recursive
+    - template: ../templates/get-docker-image-steps.yml
+      parameters:
+        Dockerfile: tools/ci_build/github/linux/docker/inference/x86_64/default/cuda${{ variables.CUDA_VERSION_MAJOR }}/Dockerfile
+        Context: tools/ci_build/github/linux/docker/inference/x86_64/default/cuda${{ variables.CUDA_VERSION_MAJOR }}
+        DockerBuildArgs: "
+          --build-arg TRT_VERSION=${{ variables.linux_trt_version }}
+          --build-arg BUILD_UID=$( id -u )
+          "
+        Repository: onnxruntimecuda${{ variables.CUDA_VERSION_MAJOR }}xtrt86build
+    - template: ../templates/set-version-number-variables-step.yml
+
+    - script: $(Build.SourcesDirectory)/tools/ci_build/github/linux/build_nodejs_package.sh
+      workingDirectory: $(Build.SourcesDirectory)
+      displayName: 'Build Node.js binding Package'
+
+    - template: ../templates/nodejs-artifacts-package-and-publish-steps-posix.yml
+      parameters:
+        arch: 'x64'
+        os: 'linux'
+        artifactName: 'drop-onnxruntime-nodejs-linux-x64'
+
+    - template: ../templates/clean-agent-build-directory-step.yml

--- a/tools/ci_build/github/azure-pipelines/stages/nodejs-win-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nodejs-win-packaging-stage.yml
@@ -1,0 +1,192 @@
+parameters:
+  BuildCommand: ''
+  StageName: 'Windows_Nodejs_Packaging'
+  ArtifactName: 'drop-onnxruntime-nodejs-win'
+  DoEsrp: 'false'
+  BuildArch: 'x64' # Optional. Options: x86, x64
+  sln_platform: 'x64' # Options: Win32, x64, arm, arm64
+  AgentDemands: []
+  BuildConfigurations: ['RelWithDebInfo'] # Options: Debug, RelWithDebInfo
+  EnableLto: true
+  # Controls whether unreleased onnx opsets are allowed. Default is set to 1
+  AllowReleasedOpsetOnly: '0'
+  IsReleaseBuild: false
+  PublishWebGpuBuildTools: false
+  WebGpuBuildToolsArtifactName: 'Windows_WebGPU_BuildTools_x64'
+  DependsOnStageName: ''
+
+stages:
+- stage: ${{ parameters.StageName }}
+  dependsOn:
+  - Setup
+  - ${{ if ne(parameters.DependsOnStageName, '') }}:
+    - ${{ parameters.DependsOnStageName }}
+
+  jobs:
+  - job: ${{ parameters.StageName }}
+    timeoutInMinutes: 200
+    strategy:
+      maxParallel: 2
+      matrix:
+        ${{ each BuildConfiguration in parameters.BuildConfigurations }}:
+          ${{ BuildConfiguration }}:
+            BuildConfig: ${{ BuildConfiguration }}
+    workspace:
+      clean: all
+    pool:
+      name: onnxruntime-Win-CPU-2022
+      demands: ${{ parameters.AgentDemands }}
+    variables:
+      buildDirectory: '$(Build.BinariesDirectory)'
+      OnnxRuntimeBuildDirectory: '$(Build.BinariesDirectory)'
+      runCodesignValidationInjection: ${{ parameters. DoEsrp}} #For the others, code sign is in a separated job
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+      ALLOW_RELEASED_ONNX_OPSET_ONLY: ${{ parameters.AllowReleasedOpsetOnly }}
+      BuildDate : $[stageDependencies.Setup.Set_Variables.outputs['Set_Build_Date.BuildDate']]
+      BuildTime : $[stageDependencies.Setup.Set_Variables.outputs['Set_Build_Time.BuildTime']]
+      BuildCommandExtra: ''
+      ${{ if eq(parameters.EnableLto, true) }}:
+        build_py_lto_flag: --enable_lto
+
+    steps:
+      - checkout: self
+        clean: true
+        submodules: none
+
+      - powershell: |
+          if($env:TELEMETRYGUID)
+          {
+            $length = $env:TELEMETRYGUID.length
+            $fileContent = "#define TraceLoggingOptionMicrosoftTelemetry() \
+              TraceLoggingOptionGroup("+$env:TELEMETRYGUID.substring(1, $length-2)+")"
+            New-Item -Path "$(Build.SourcesDirectory)\include\onnxruntime\core\platform\windows\TraceLoggingConfigPrivate.h" -ItemType "file" -Value "$fileContent" -Force
+            Write-Output "Enabling TELEMETRY"
+          }
+        displayName: 'Create TraceLoggingConfigPrivate.h For WinML Telemetry'
+        env:
+          TELEMETRYGUID: $(TELEMETRYGUID)
+
+      - task: NodeTool@0
+        inputs:
+          versionSpec: '20.x'
+
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: '3.12'
+          addToPath: true
+          architecture: ${{ parameters.BuildArch }}
+
+      # need to set PROCESSOR_ARCHITECTURE so the x86 SDK is installed correctly
+      - task: UseDotNet@2
+        inputs:
+          version: 8.x
+        env:
+          PROCESSOR_ARCHITECTURE: ${{ parameters.BuildArch }}
+
+      - task: BatchScript@1
+        displayName: 'Setup VS2022 env vars'
+        inputs:
+          filename: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat'
+          arguments: ${{ parameters.BuildArch }}
+          modifyEnvironment: true
+
+      - ${{ if and(ne(parameters.WebGpuBuildToolsArtifactName, ''), eq(parameters.sln_platform, 'arm64')) }}:
+        - task: DownloadPipelineArtifact@2
+          displayName: 'Download WebGPU build tools from x64 build'
+          inputs:
+            artifactName: '${{ parameters.WebGpuBuildToolsArtifactName }}'
+            targetPath: '$(Build.BinariesDirectory)\${{ parameters.WebGpuBuildToolsArtifactName }}'
+        - script: |
+            @echo ##vso[task.setvariable variable=LLVM_TABLEGEN_PATH]$(Build.BinariesDirectory)\${{ parameters.WebGpuBuildToolsArtifactName }}\llvm-tblgen.exe
+            @echo ##vso[task.setvariable variable=CLANG_TABLEGEN_PATH]$(Build.BinariesDirectory)\${{ parameters.WebGpuBuildToolsArtifactName }}\clang-tblgen.exe
+          displayName: 'Set tablegen paths'
+        - powershell: |
+            Write-Host "Using LLVM_TABLEGEN_PATH: $(LLVM_TABLEGEN_PATH)"
+            Write-Host "Using CLANG_TABLEGEN_PATH: $(CLANG_TABLEGEN_PATH)"
+            Write-Host "##vso[task.setvariable variable=BuildCommandExtra]--cmake_extra_defines LLVM_TABLEGEN=$(LLVM_TABLEGEN_PATH) CLANG_TABLEGEN=$(CLANG_TABLEGEN_PATH)"
+          displayName: 'Set build flags for WebGPU cross-compilation'
+
+      - powershell: |
+          python tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) ${{ parameters.BuildCommand }} $(BuildCommandExtra) --use_binskim_compliant_compile_flags --parallel --build --update --config $(BuildConfig) --msbuild_extra_options IncludeMobileTargets=false ${{ variables.build_py_lto_flag }}
+
+      - ${{ if notIn(parameters['sln_platform'], 'Win32', 'x64') }}:
+        # Use cross-compiled protoc
+        - script: |
+           @echo ##vso[task.setvariable variable=ProtocDirectory]$(Build.BinariesDirectory)\installed\bin
+
+      # The Configuration variable is required to build C#
+      - script: |
+         @echo ##vso[task.setvariable variable=Configuration]$(BuildConfig)
+        displayName: 'Set Configuration variable'
+
+      # Node.js Publish
+      - task: BatchScript@1
+        displayName: 'Setup VS env vars'
+        inputs:
+          filename: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat'
+          arguments: ${{ parameters.BuildArch }}
+          modifyEnvironment: true
+      - task: CopyFiles@2
+        displayName: 'Copy DirectML binaries to: $(Build.SourcesDirectory)\js\node\bin\napi-v3\win32\${{ parameters.sln_platform }}'
+        inputs:
+          SourceFolder: '$(Build.BinariesDirectory)\$(BuildConfig)\$(BuildConfig)'
+          Contents: 'DirectML.dll'
+          TargetFolder: '$(Build.SourcesDirectory)\js\node\bin\napi-v3\win32\${{ parameters.sln_platform }}'
+      - powershell: |
+          $dxcZipUrl = "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.8.2502/dxc_2025_02_20.zip"
+          $dxcZipPath = "$(Build.BinariesDirectory)\dxc.zip"
+          $dxcExtractPath = "$(Build.BinariesDirectory)\dxc_extracted"
+          $targetArch = "${{ parameters.sln_platform }}"
+
+          # Download the DXC package
+          Write-Host "Downloading DXC release from $dxcZipUrl"
+          Invoke-WebRequest -Uri $dxcZipUrl -OutFile $dxcZipPath
+
+          # Create extraction directory
+          if (-not (Test-Path $dxcExtractPath)) {
+            New-Item -Path $dxcExtractPath -ItemType Directory -Force
+          }
+
+          # Extract the zip file
+          Write-Host "Extracting DXC package to $dxcExtractPath"
+          Expand-Archive -Path $dxcZipPath -DestinationPath $dxcExtractPath -Force
+
+          # Copy the necessary DLLs to the target directory
+          $sourcePath = Join-Path $dxcExtractPath "bin\$targetArch"
+          $targetPath = "$(Build.SourcesDirectory)\js\node\bin\napi-v3\win32\$targetArch"
+
+          Write-Host "Copying dxil.dll and dxcompiler.dll from $sourcePath to $targetPath"
+          Copy-Item -Path "$sourcePath\dxil.dll" -Destination $targetPath -Force
+          Copy-Item -Path "$sourcePath\dxcompiler.dll" -Destination $targetPath -Force
+
+          Write-Host "DXC DLLs successfully copied to the target directory"
+        displayName: 'Download and Copy DXC Binaries'
+      - template: ../templates/win-esrp-dll.yml
+        parameters:
+          FolderPath: '$(Build.SourcesDirectory)\js\node\bin\napi-v3\win32\${{ parameters.sln_platform }}'
+          DisplayName: 'ESRP - Sign Node.js binding binaries'
+          DoEsrp: ${{ parameters.DoEsrp }}
+          Pattern: '*.dll,*.node'
+
+      - script: |
+          del /Q $(Build.SourcesDirectory)\js\node\bin\napi-v3\win32\${{ parameters.sln_platform }}\CodeSignSummary-*.*
+          call npm pack
+          copy $(Build.SourcesDirectory)\js\node\onnxruntime-*.tgz $(Build.ArtifactStagingDirectory)
+        workingDirectory: '$(Build.SourcesDirectory)\js\node'
+        displayName: 'Create NPM Package'
+
+      - task: 1ES.PublishPipelineArtifact@1
+        inputs:
+          targetPath: '$(Build.SourcesDirectory)\js\node\bin\napi-v3\win32\${{ parameters.sln_platform }}'
+          artifactName: ${{ parameters.ArtifactName }}
+
+      - ${{ if and(eq(parameters.PublishWebGpuBuildTools, true), eq(parameters.sln_platform, 'x64')) }}:
+        - script: |
+            mkdir $(Build.ArtifactStagingDirectory)\${{ parameters.WebGpuBuildToolsArtifactName }}
+            copy $(Build.BinariesDirectory)\$(BuildConfig)\_deps\dawn-build\third_party\dxc\RelWithDebInfo\bin\llvm-tblgen.exe $(Build.ArtifactStagingDirectory)\${{ parameters.WebGpuBuildToolsArtifactName }}
+            copy $(Build.BinariesDirectory)\$(BuildConfig)\_deps\dawn-build\third_party\dxc\RelWithDebInfo\bin\clang-tblgen.exe $(Build.ArtifactStagingDirectory)\${{ parameters.WebGpuBuildToolsArtifactName }}
+          displayName: 'Copy WebGPU build tools'
+        - task: 1ES.PublishPipelineArtifact@1
+          inputs:
+            targetPath: '$(Build.ArtifactStagingDirectory)\${{ parameters.WebGpuBuildToolsArtifactName }}'
+            artifactName: ${{ parameters.WebGpuBuildToolsArtifactName }}

--- a/tools/ci_build/github/azure-pipelines/stages/nuget-combine-cuda-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nuget-combine-cuda-stage.yml
@@ -39,6 +39,11 @@ stages:
     buildJava: ${{ parameters.buildJava }}
     buildNodejs: ${{ parameters.buildNodejs }}
 
+- ${{ if eq(parameters.buildNodejs, 'true') }}:
+  - template: nodejs-linux-packaging-stage.yml
+    parameters:
+      CudaVersion: ${{ parameters.CudaVersion }}
+
 - template: nuget-win-cuda-packaging-stage.yml
   parameters:
     RunOnnxRuntimeTests: ${{ parameters.RunOnnxRuntimeTests }}

--- a/tools/ci_build/github/azure-pipelines/stages/nuget-linux-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nuget-linux-cuda-packaging-stage.yml
@@ -32,9 +32,7 @@ stages:
       parameters:
         Dockerfile: tools/ci_build/github/linux/docker/inference/x86_64/default/cuda${{ variables.CUDA_VERSION_MAJOR }}/Dockerfile
         Context: tools/ci_build/github/linux/docker/inference/x86_64/default/cuda${{ variables.CUDA_VERSION_MAJOR }}
-        DockerBuildArgs: "
-        --build-arg BUILD_UID=$( id -u )
-        "
+        DockerBuildArgs: " --build-arg BUILD_UID=$( id -u )"
         Repository: onnxruntimecuda${{ variables.CUDA_VERSION_MAJOR }}build
 
     - script: $(Build.SourcesDirectory)/tools/ci_build/github/linux/build_cuda_c_api_package.sh
@@ -112,13 +110,6 @@ stages:
           libraryName: 'libonnxruntime.so'
           nativeLibraryName: 'libonnxruntime4j_jni.so'
           is1ES: true
-
-    - ${{ if eq(parameters.buildNodejs, 'true') }}:
-      - template: ../templates/nodejs-artifacts-package-and-publish-steps-posix.yml
-        parameters:
-          arch: 'x64'
-          os: 'linux'
-          artifactName: 'drop-onnxruntime-nodejs-linux-x64-tensorrt'
 
     - template: ../templates/c-api-artifacts-package-and-publish-steps-posix.yml
       parameters:

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -182,10 +182,10 @@ stages:
     buildArch: x64
     msbuildPlatform: arm64
     packageName: arm64
-    buildparameter: --build_nodejs --arm64 ${{ parameters.AdditionalBuildFlags }}  ${{ parameters.AdditionalWinBuildFlags}}
+    buildparameter: --arm64 ${{ parameters.AdditionalBuildFlags }}  ${{ parameters.AdditionalWinBuildFlags}}
     runTests: false
     buildJava: false
-    buildNodejs: true
+    buildNodejs: false
 
 - template: win-ci.yml
   parameters:
@@ -194,10 +194,10 @@ stages:
     buildArch: x64
     msbuildPlatform: x64
     packageName: x64
-    buildparameter: --build_java --build_nodejs ${{ parameters.AdditionalBuildFlags }}  ${{ parameters.AdditionalWinBuildFlags}}
+    buildparameter: --build_java ${{ parameters.AdditionalBuildFlags }}  ${{ parameters.AdditionalWinBuildFlags}}
     runTests: ${{ parameters.RunOnnxRuntimeTests }}
     buildJava: true
-    buildNodejs: true
+    buildNodejs: false
 
 - stage: Jar_Packaging
   dependsOn:
@@ -506,14 +506,11 @@ stages:
 
 - stage: Nodejs_Packaging
   dependsOn:
-  - Windows_CI_GPU_DML_Dev
-  - Windows_CI_GPU_DML_Dev_arm64
+  - Windows_Nodejs_Packaging_x64
+  - Windows_Nodejs_Packaging_arm64
+  - Linux_Nodejs_Packaging_x64
   - Linux_C_API_Packaging_CPU
-  - Linux_C_API_Packaging_GPU
   - MacOS_C_API_Package_Publish
-  - Windows_Packaging_CPU_x86_${{ parameters.BuildVariant }}
-  - Windows_Packaging_CPU_x64_${{ parameters.BuildVariant }}
-  - Windows_Packaging_CPU_arm64_${{ parameters.BuildVariant }}
   condition: succeeded()
   jobs:
   - job: Nodejs_Packaging
@@ -544,74 +541,78 @@ stages:
     # Node.js binding artifacts preparation
     #
     # This stage prepares Node.js binding artifacts for publishing. The artifacts support the following platforms:
-    #  - Windows x64 with DML support
-    #  - Windows arm64 with DML support
-    #  - Linux x64 with TensorRT support
+    #  - Windows x64 (CPU, DML, WebGPU)
+    #  - Windows arm64 (CPU, DML, WebGPU)
+    #  - Linux x64 (CPU, CUDA, TensorRT, WebGPU)
     #  - Linux arm64 (CPU only)
-    #  - macOS x64 (CPU only)
-    #  - macOS arm64 (CPU only)
+    #  - macOS x64 (CPU, CoreML, WebGPU)
+    #  - macOS arm64 (CPU, CoreML, WebGPU)
     #
-    # ORT Node.js binding artifacts contain 2 parts:
-    #  1. ONNX Runtime native shared libraries and their dependencies
-    #     - Windows (x64, arm64):
-    #       - onnxruntime.dll
-    #       - DirectML.dll
-    #     - Linux (x64, arm64):
-    #       - libonnxruntime.so{.version}
-    #       - libonnxruntime_providers_shared.so
-    #       - libonnxruntime_providers_{provider}.so
-    #     - macOS (x64, arm64):
-    #       - libonnxruntime.dylib
-    #  2. ONNX Runtime Node.js binding
-    #     - onnxruntime_binding.node
+    # File manifest:
+    #  - Windows x64 (CPU, DML, WebGPU):
+    #    dependency: Windows_Nodejs_Packaging_x64 (drop-onnxruntime-nodejs-win-x64)
+    #    files:
+    #      - onnxruntime_binding.node
+    #      - onnxruntime.dll
+    #      - DirectML.dll
+    #      - dxil.dll
+    #      - dxcompiler.dll
     #
-    # For windows platform, the artifact is named as 'onnxruntime-nodejs-win-x64-dml' for x64, and
-    # 'onnxruntime-nodejs-win-arm64-dml' for arm64. Each artifact contains both (1) and (2).
+    #  - Windows arm64 (CPU, DML, WebGPU):
+    #    dependency: Windows_Nodejs_Packaging_arm64 (drop-onnxruntime-nodejs-win-arm64)
+    #    files:
+    #      - onnxruntime_binding.node
+    #      - onnxruntime.dll
+    #      - DirectML.dll
+    #      - dxil.dll
+    #      - dxcompiler.dll
     #
-    # For Linux and macOS platforms, (1) and (2) are packed into separate artifacts.
-    # The following artifacts contain (1):
-    #  - onnxruntime-osx
-    #  - onnxruntime-linux-x64-tensorrt
-    #  - onnxruntime-linux-aarch64
-    # The following artifacts contain (2):
-    #  - drop-onnxruntime-nodejs-linux-x64-tensorrt
-    #  - drop-onnxruntime-nodejs-linux-aarch64
-    #  - drop-onnxruntime-nodejs-osx-x86_64
-    #  - drop-onnxruntime-nodejs-osx-arm64
+    #  - Linux x64 (CPU, CUDA, TensorRT, WebGPU):
+    #    dependency: Linux_Nodejs_Packaging_x64 (drop-onnxruntime-nodejs-linux-x64)
+    #    files:
+    #      - onnxruntime_binding.node
+    #      - libonnxruntime.so.1
+    #      - libonnxruntime_providers_shared.so
+    #      - libonnxruntime_providers_cuda.so
+    #      - libonnxruntime_providers_tensorrt.so
     #
-    # All binary artifacts will eventually be put into folder before packaging 'onnxruntime-node':
+    #  - Linux arm64 (CPU only):
+    #    dependency: Linux_C_API_Packaging_CPU_aarch64 (drop-onnxruntime-nodejs-linux-aarch64)
+    #    files:
+    #      - onnxruntime_binding.node
+    #      - libonnxruntime.so.1
+    #
+    #  - macOS x64 (CPU, CoreML, WebGPU):
+    #    dependency: MacOS_C_API_Packaging_CPU_x86_64 (drop-onnxruntime-nodejs-osx-x86_64)
+    #    files:
+    #      - onnxruntime_binding.node
+    #      - libonnxruntime.{version}.dylib
+    #
+    #  - macOS arm64 (CPU, CoreML, WebGPU):
+    #    dependency: MacOS_C_API_Packaging_CPU_arm64 (drop-onnxruntime-nodejs-osx-arm64)
+    #    files:
+    #      - onnxruntime_binding.node
+    #      - libonnxruntime.{version}.dylib
+    #
+    # The following files will be excluded from the further packaging because they are too large to be included in the
+    # NPM package:
+    #  - linux/x64/libonnxruntime_providers_cuda.so
+    #
+    # Rest binary artifacts will eventually be put into folder before packaging 'onnxruntime-node':
     #  $(Build.SourcesDirectory)\js\node\bin\napi-v3\{os}\{cpu_arch}\
     #
     # {os} is one of 'win32', 'darwin', 'linux' and {cpu_arch} is one of 'x64', 'arm64'.
 
     - task: DownloadPipelineArtifact@0
-      displayName: 'Download Pipeline Artifact - NuGet (OSX)'
-      inputs:
-        artifactName: 'onnxruntime-osx'
-        targetPath: '$(Build.BinariesDirectory)/nuget-artifact'
-
-    - task: DownloadPipelineArtifact@0
-      displayName: 'Download Pipeline Artifact - NuGet (Linux x64)'
-      inputs:
-        artifactName: 'onnxruntime-linux-x64-tensorrt'
-        targetPath: '$(Build.BinariesDirectory)/nuget-artifact'
-
-    - task: DownloadPipelineArtifact@0
-      displayName: 'Download Pipeline Artifact - NuGet (Linux aarch64)'
-      inputs:
-        artifactName: 'onnxruntime-linux-aarch64'
-        targetPath: '$(Build.BinariesDirectory)/nuget-artifact'
-
-    - task: DownloadPipelineArtifact@0
       displayName: 'Download Pipeline Artifact - Nodejs (Win x64)'
       inputs:
-        artifactName: 'drop-onnxruntime-nodejs-win-x64-dml'
+        artifactName: 'drop-onnxruntime-nodejs-win-x64'
         targetPath: '$(Build.BinariesDirectory)/nodejs-artifacts/win32/x64/'
 
     - task: DownloadPipelineArtifact@0
       displayName: 'Download Pipeline Artifact - Nodejs (Win ARM64)'
       inputs:
-        artifactName: 'drop-onnxruntime-nodejs-win-arm64-dml'
+        artifactName: 'drop-onnxruntime-nodejs-win-arm64'
         targetPath: '$(Build.BinariesDirectory)/nodejs-artifacts/win32/arm64/'
 
     - task: DownloadPipelineArtifact@0
@@ -629,7 +630,7 @@ stages:
     - task: DownloadPipelineArtifact@0
       displayName: 'Download Pipeline Artifact - Nodejs (Linux x64)'
       inputs:
-        artifactName: 'drop-onnxruntime-nodejs-linux-x64-tensorrt'
+        artifactName: 'drop-onnxruntime-nodejs-linux-x64'
         targetPath: '$(Build.BinariesDirectory)/nodejs-artifacts/linux/x64/'
 
     - task: DownloadPipelineArtifact@0
@@ -638,15 +639,9 @@ stages:
         artifactName: 'drop-onnxruntime-nodejs-linux-aarch64'
         targetPath: '$(Build.BinariesDirectory)/nodejs-artifacts/linux/arm64/'
 
-    - task: PowerShell@2
-      displayName: 'PowerShell Script'
-      inputs:
-        targetType: filePath
-        filePath: $(Build.SourcesDirectory)\tools\ci_build\github\windows\extract_nuget_files.ps1
-
     - script: |
-        dir
-      workingDirectory: '$(Build.BinariesDirectory)/nuget-artifact'
+        dir /S
+      workingDirectory: '$(Build.BinariesDirectory)/nodejs-artifacts'
       displayName: 'List artifacts'
 
     - script: |
@@ -684,60 +679,42 @@ stages:
 
     # Node.js binding linux/x64
     - task: CopyFiles@2
-      displayName: 'Copy nuget binaries to: $(Build.SourcesDirectory)\js\node\bin\napi-v3\linux\x64\'
-      inputs:
-        SourceFolder: '$(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\nuget-artifacts\onnxruntime-linux-x64-tensorrt\lib'
-        Contents: |
-          libonnxruntime.so.1
-          libonnxruntime_providers_shared.so
-        TargetFolder: '$(Build.SourcesDirectory)\js\node\bin\napi-v3\linux\x64'
-    - task: CopyFiles@2
       displayName: 'Copy nodejs binaries to: $(Build.SourcesDirectory)\js\node\bin\napi-v3\linux\x64\'
       inputs:
         SourceFolder: '$(Build.BinariesDirectory)\nodejs-artifacts\linux\x64'
-        Contents: '*.node'
+        Contents: |
+          libonnxruntime.so.1
+          *.node
         TargetFolder: '$(Build.SourcesDirectory)\js\node\bin\napi-v3\linux\x64'
 
     # Node.js binding linux/arm64
     - task: CopyFiles@2
-      displayName: 'Copy nuget binaries to: $(Build.SourcesDirectory)\js\node\bin\napi-v3\linux\arm64\'
-      inputs:
-        SourceFolder: '$(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\nuget-artifacts\onnxruntime-linux-aarch64\lib'
-        Contents: 'libonnxruntime.so.1'
-        TargetFolder: '$(Build.SourcesDirectory)\js\node\bin\napi-v3\linux\arm64'
-    - task: CopyFiles@2
       displayName: 'Copy nodejs binaries to: $(Build.SourcesDirectory)\js\node\bin\napi-v3\linux\arm64\'
       inputs:
         SourceFolder: '$(Build.BinariesDirectory)\nodejs-artifacts\linux\arm64'
-        Contents: '*.node'
+        Contents: |
+          libonnxruntime.so.1
+          *.node
         TargetFolder: '$(Build.SourcesDirectory)\js\node\bin\napi-v3\linux\arm64'
 
     # Node.js binding darwin/x64
     - task: CopyFiles@2
-      displayName: 'Copy nuget binaries to: $(Build.SourcesDirectory)\js\node\bin\napi-v3\darwin\x64\'
-      inputs:
-        SourceFolder: '$(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\nuget-artifacts\onnxruntime-osx-x86_64\lib'
-        Contents: 'libonnxruntime.*.dylib'
-        TargetFolder: '$(Build.SourcesDirectory)\js\node\bin\napi-v3\darwin\x64'
-    - task: CopyFiles@2
       displayName: 'Copy nodejs binaries to: $(Build.SourcesDirectory)\js\node\bin\napi-v3\darwin\x64\'
       inputs:
         SourceFolder: '$(Build.BinariesDirectory)\nodejs-artifacts\darwin\x64'
-        Contents: '*.node'
+        Contents: |
+          libonnxruntime.*.dylib
+          *.node
         TargetFolder: '$(Build.SourcesDirectory)\js\node\bin\napi-v3\darwin\x64'
 
     # Node.js binding darwin/arm64
     - task: CopyFiles@2
-      displayName: 'Copy nuget binaries to: $(Build.SourcesDirectory)\js\node\bin\napi-v3\darwin\arm64\'
-      inputs:
-        SourceFolder: '$(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\nuget-artifacts\onnxruntime-osx-arm64\lib'
-        Contents: 'libonnxruntime.*.dylib'
-        TargetFolder: '$(Build.SourcesDirectory)\js\node\bin\napi-v3\darwin\arm64'
-    - task: CopyFiles@2
       displayName: 'Copy nodejs binaries to: $(Build.SourcesDirectory)\js\node\bin\napi-v3\darwin\arm64\'
       inputs:
         SourceFolder: '$(Build.BinariesDirectory)\nodejs-artifacts\darwin\arm64'
-        Contents: '*.node'
+        Contents: |
+          libonnxruntime.*.dylib
+          *.node
         TargetFolder: '$(Build.SourcesDirectory)\js\node\bin\napi-v3\darwin\arm64'
 
     - task: PowerShell@2

--- a/tools/ci_build/github/azure-pipelines/templates/linux-cpu-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-cpu-packaging-pipeline.yml
@@ -34,7 +34,7 @@ stages:
       PoolName: 'onnxruntime-Ubuntu2204-AMD-CPU'
       ArtifactNamePrefix: ${{ parameters.ArtifactNamePrefix }}
       PackageJava: ${{ parameters.PackageJava }}
-      PackageNodeJS: ${{ parameters.PackageNodeJS }}
+      PackageNodeJS: false
 
   - template: c-api-linux-cpu.yml
     parameters:

--- a/tools/ci_build/github/linux/build_nodejs_package.sh
+++ b/tools/ci_build/github/linux/build_nodejs_package.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e -x
+mkdir -p $HOME/.onnx
+docker run -e SYSTEM_COLLECTIONURI --rm --volume /data/onnx:/data/onnx:ro --volume $BUILD_SOURCESDIRECTORY:/onnxruntime_src --volume $BUILD_BINARIESDIRECTORY:/build \
+--volume /data/models:/build/models:ro --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimecuda${CUDA_VERSION_MAJOR}xtrt86build \
+/bin/bash -c "/usr/bin/python3 /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config Release --skip_tests --skip_submodule_sync --parallel --use_binskim_compliant_compile_flags --build_shared_lib --build_nodejs --use_webgpu --use_tensorrt --cuda_version=$CUDA_VERSION --cuda_home=/usr/local/cuda-$CUDA_VERSION --cudnn_home=/usr --tensorrt_home=/usr --cmake_extra_defines 'CMAKE_CUDA_ARCHITECTURES=60-real;70-real;75-real;80-real;90' --use_vcpkg --use_vcpkg_ms_internal_asset_cache && cd /build/Release && make install DESTDIR=/build/installed"


### PR DESCRIPTION
### Description

Update packaging pipeline for Nodejs binding.

This change updates the pipeline to perform all Node.js binding builds, including:
- Windows x64 ( CPU, DML, WebGPU )
- Windows arm64 ( CPU, DML, WebGPU )
- Linux x64 ( CPU, CUDA, TensorRT, WebGPU )
- Linux arm64 ( CPU )
- MacOS x64 ( CPU, CoreML, WebGPU )
- MacOS arm64 ( CPU, CoreML, WebGPU )

#### Dependencies

The Node.js binding depends on the Nuget package from the same build.

Because NPM has a size limit so we cannot fit libonnxruntime_provider_cuda.so into it. The Node.js binding works in a way that an installation script will try to download the Nuget package of the corresponding version.

