### PR TITLE
[webgpu][dawn API optimization] reduce number of calls to wgpuDeviceGetQueue

### DIFF
--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -136,6 +136,8 @@ void WebGpuContext::Initialize(const WebGpuBufferCacheConfig& buffer_cache_confi
 
     LOGS_DEFAULT(VERBOSE) << "WebGPU EP Context is created for: Instance=" << instance_.Get() << ", Device=" << device_.Get() << ".";
 
+    // cache device queue
+    device_queue_ = device_.GetQueue();
     // cache adapter info
     ORT_ENFORCE(Device().GetAdapterInfo(&adapter_info_));
     // cache device limits
@@ -404,7 +406,7 @@ Status WebGpuContext::Run(ComputeContext& context, const ProgramBase& program) {
     }
 
     uniform_buffer = buffer_mgr_->Create(uniform_buffer_total_size, wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
-    device_.GetQueue().WriteBuffer(uniform_buffer, 0, uniform_data_buffer.data(), uniform_buffer_total_size);
+    device_queue_.WriteBuffer(uniform_buffer, 0, uniform_data_buffer.data(), uniform_buffer_total_size);
   }
 
   const auto& compute_pass_encoder = GetComputePassEncoder();
@@ -696,7 +698,7 @@ void WebGpuContext::Flush() {
   }
 
   auto command_buffer = current_command_encoder_.Finish();
-  Device().GetQueue().Submit(1, &command_buffer);
+  device_queue_.Submit(1, &command_buffer);
   BufferManager().RefreshPendingBuffers();
   current_command_encoder_ = nullptr;
   num_pending_dispatches_ = 0;

--- a/onnxruntime/core/providers/webgpu/webgpu_context.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.h
@@ -207,6 +207,7 @@ class WebGpuContext final {
 
   webgpu::ValidationMode validation_mode_;
 
+  wgpu::Queue device_queue_;
   wgpu::AdapterInfo adapter_info_;
   wgpu::Limits device_limits_;
   std::unordered_set<wgpu::FeatureName> device_features_;


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
This PR is one of a series of changes for optimization of Dawn API usage. See #24281

Optimizes the usage of wgpuDeviceGetQueue.
