### PR TITLE
[web] revise flag `ort.env.wasm.simd`

### DIFF
--- a/js/common/lib/env.ts
+++ b/js/common/lib/env.ts
@@ -45,8 +45,8 @@ export declare namespace Env {
      *
      * ONNX Runtime will perform feature detection based on the value of this property. Specifically, when the value is
      * set to:
-     * - `undefined` or `true`: will check availability of Fixed-width SIMD.
-     * - `relaxed`: will check availability of Relaxed SIMD.
+     * - `undefined`, `true` or `"fixed"`: will check availability of Fixed-width SIMD.
+     * - `"relaxed"`: will check availability of Relaxed SIMD.
      * - `false`: will not perform SIMD feature checking.
      *
      * Setting this property does not make ONNX Runtime to switch to the corresponding runtime automatically. User need
@@ -56,7 +56,7 @@ export declare namespace Env {
      *
      * @defaultValue `true`
      */
-    simd?: boolean | 'relaxed';
+    simd?: boolean | 'fixed' | 'relaxed';
 
     /**
      * set or get a boolean value indicating whether to enable trace.

--- a/js/common/lib/env.ts
+++ b/js/common/lib/env.ts
@@ -41,16 +41,22 @@ export declare namespace Env {
     numThreads?: number;
 
     /**
-     * set or get a boolean value indicating whether to enable SIMD. If set to false, SIMD will be forcely disabled.
+     * set a value indicating whether to enable SIMD.
+     *
+     * ONNX Runtime will perform feature detection based on the value of this property. Specifically, when the value is
+     * set to:
+     * - `undefined` or `true`: will check availability of Fixed-width SIMD.
+     * - `relaxed`: will check availability of Relaxed SIMD.
+     * - `false`: will not perform SIMD feature checking.
+     *
+     * Setting this property does not make ONNX Runtime to switch to the corresponding runtime automatically. User need
+     * to set `wasmPaths` or `wasmBinary` property to load the corresponding runtime.
      *
      * This setting is available only when WebAssembly SIMD feature is available in current context.
      *
      * @defaultValue `true`
-     *
-     * @deprecated This property is deprecated. Since SIMD is supported by all major JavaScript engines, non-SIMD
-     * build is no longer provided. This property will be removed in future release.
      */
-    simd?: boolean;
+    simd?: boolean | 'relaxed';
 
     /**
      * set or get a boolean value indicating whether to enable trace.

--- a/js/web/lib/backend-wasm.ts
+++ b/js/web/lib/backend-wasm.ts
@@ -17,12 +17,13 @@ export const initializeFlags = (): void => {
     env.wasm.initTimeout = 0;
   }
 
-  if (env.wasm.simd === false) {
+  const simd = env.wasm.simd;
+  if (typeof simd !== 'boolean' && simd !== undefined && simd !== 'relaxed') {
     // eslint-disable-next-line no-console
     console.warn(
-      'Deprecated property "env.wasm.simd" is set to false. ' +
-        'non-SIMD build is no longer provided, and this setting will be ignored.',
+      `Property "env.wasm.simd" is set to unknown value "${simd}". Reset it to \`false\` and ignore SIMD feature checking.`,
     );
+    env.wasm.simd = false;
   }
 
   if (typeof env.wasm.proxy !== 'boolean') {

--- a/js/web/lib/backend-wasm.ts
+++ b/js/web/lib/backend-wasm.ts
@@ -18,7 +18,7 @@ export const initializeFlags = (): void => {
   }
 
   const simd = env.wasm.simd;
-  if (typeof simd !== 'boolean' && simd !== undefined && simd !== 'relaxed') {
+  if (typeof simd !== 'boolean' && simd !== undefined && simd !== 'fixed' && simd !== 'relaxed') {
     // eslint-disable-next-line no-console
     console.warn(
       `Property "env.wasm.simd" is set to unknown value "${simd}". Reset it to \`false\` and ignore SIMD feature checking.`,


### PR DESCRIPTION
### Description

This PR revised the flag `ort.env.wasm.simd` to enhance its usage so that more use scenarios are covered.
- Allow setting to `false` explicitly to disable SIMD checking. resolves #24292 (@Eldow)
- Allow setting to `'relaxed'` to enable Relaxed SIMD checking. Relaxed SIMD is introduced first in #22794 (@jing-bao)
- Behavior is not changed when not setting (ie. `undefined`) or setting to `true`
- Added a warning message when setting to unknown value, and reset to `false` in this case
