### PR TITLE
[webgpu][dawn API optimization] workgroup dispatch

### DIFF
--- a/onnxruntime/core/providers/webgpu/webgpu_context.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.h
@@ -156,6 +156,11 @@ class WebGpuContext final {
       : instance_{instance}, device_{device}, validation_mode_{validation_mode}, query_type_{TimestampQueryType::None}, preserve_device_{preserve_device} {}
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(WebGpuContext);
 
+  void LaunchComputePipeline(const wgpu::ComputePassEncoder& compute_pass_encoder,
+                             const std::vector<WGPUBuffer>& bind_buffers,
+                             const ProgramArtifact& program_artifact,
+                             uint32_t x, uint32_t y, uint32_t z);
+
   std::vector<const char*> GetEnabledAdapterToggles() const;
   std::vector<const char*> GetEnabledDeviceToggles() const;
   std::vector<const char*> GetDisabledDeviceToggles() const;


### PR DESCRIPTION
### Description

This PR is one of a series of changes for optimization of Dawn API usage. See https://github.com/microsoft/onnxruntime/pull/24281

Optimize the code for workgroup dispatch in the `WebGpuContext` class.

The updated code prefers using the C-API instead of the C++ API for WebGPU. This is because the C++ API uses class `wgpu::Buffer`, which causes significant amount of calls to `wgpuBufferAddRef` and `wgpuBufferRelease` to ensure the lifecycle of the buffer is managed correctly. For this specific use case in ONNX Runtime (launch a compute shader program), using the C-API is more efficient.
