### PR TITLE
Remove Unnecessary List Conversions in Input Validation

### DIFF
--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -266,7 +266,7 @@ class Session:
 
             sess.run([output_name], {input_name: x})
         """
-        self._validate_input(list(input_feed.keys()))
+        self._validate_input(input_feed.keys())
         if not output_names:
             output_names = [output.name for output in self._outputs_meta]
         try:
@@ -306,7 +306,7 @@ class Session:
 
             sess.run_async([output_name], {input_name: x}, callback)
         """
-        self._validate_input(list(input_feed.keys()))
+        self._validate_input(input_feed.keys())
         if not output_names:
             output_names = [output.name for output in self._outputs_meta]
         return self._sess.run_async(output_names, input_feed, callback, user_data, run_options)
@@ -337,7 +337,7 @@ class Session:
             ort_values = [OrtValue(v) for v in result]
             return ort_values
 
-        self._validate_input(list(input_dict_ort_values.keys()))
+        self._validate_input(input_dict_ort_values.keys())
         if not output_names:
             output_names = [output.name for output in self._outputs_meta]
         try:


### PR DESCRIPTION
### Description
This PR simplifies the code by removing unnecessary `list()` calls around `.keys()` in the `_validate_input` method calls. The dict_keys views are already iterable and support membership testing, so converting them to a list and then searching within that list in the function is not needed. This change makes the code cleaner and provides a small optimization by avoiding the list conversion.

Changes:

- Updated three calls to `_validate_input` to pass `input_feed.keys()` and `input_dict_ort_values.keys()` directly instead of wrapping them with `list()`.


### Motivation and Context

This cleans up the code and avoids an extra step that doesn’t add value. It’s a small improvement, not tied to fixing a specific issue, just making the code simpler and slightly more efficient.

No open issues are linked—this is just a minor cleanup.

