### PR TITLE
Replace react-native-fs with  @dr.pogodin/react-native-fs

### DIFF
--- a/js/react_native/e2e/package-lock.json
+++ b/js/react_native/e2e/package-lock.json
@@ -8,9 +8,9 @@
       "name": "onnxruntime-reactnative-example",
       "version": "0.5.0",
       "dependencies": {
+        "@dr.pogodin/react-native-fs": "^2.32.1",
         "react": "^18.2.0",
-        "react-native": "^0.73.11",
-        "react-native-fs": "^2.20.0"
+        "react-native": "^0.73.11"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0",
@@ -2267,6 +2267,51 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@dr.pogodin/react-native-fs": {
+      "version": "2.32.1",
+      "resolved": "https://registry.npmjs.org/@dr.pogodin/react-native-fs/-/react-native-fs-2.32.1.tgz",
+      "integrity": "sha512-vNPgyPpw4OGaooIay8RUx0qUaFExas0ce6kmud1oTKjqeohEqwzuFZBa7gJ1bmF2cEkplp8sUzw2BVv4NDPrVA==",
+      "license": "MIT",
+      "workspaces": [
+        "example"
+      ],
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "http-status-codes": "^2.3.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/birdofpreyru"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@dr.pogodin/react-native-fs/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.1",
@@ -4710,9 +4755,6 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "license": "MIT"
-    },
-    "node_modules/base-64": {
-      "version": "0.1.0"
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -7604,6 +7646,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
+      "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
+      "license": "MIT"
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -10775,23 +10823,6 @@
         "react": "18.2.0"
       }
     },
-    "node_modules/react-native-fs": {
-      "version": "2.20.0",
-      "license": "MIT",
-      "dependencies": {
-        "base-64": "^0.1.0",
-        "utf8": "^3.0.0"
-      },
-      "peerDependencies": {
-        "react-native": "*",
-        "react-native-windows": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-windows": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-native/node_modules/@jest/types": {
       "version": "26.6.2",
       "license": "MIT",
@@ -12372,10 +12403,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/utf8": {
-      "version": "3.0.0",
-      "license": "MIT"
     },
     "node_modules/utf8-byte-length": {
       "version": "1.0.4",

--- a/js/react_native/e2e/package.json
+++ b/js/react_native/e2e/package.json
@@ -11,9 +11,9 @@
     "test": "jest"
   },
   "dependencies": {
+    "@dr.pogodin/react-native-fs": "^2.32.1",
     "react": "^18.2.0",
-    "react-native": "^0.73.11",
-    "react-native-fs": "^2.20.0"
+    "react-native": "^0.73.11"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/js/react_native/e2e/src/App.tsx
+++ b/js/react_native/e2e/src/App.tsx
@@ -8,7 +8,7 @@ import { Image, Text, TextInput, View } from 'react-native';
 import { InferenceSession, Tensor } from 'onnxruntime-react-native';
 import MNIST, { MNISTInput, MNISTOutput, MNISTResult, } from './mnist-data-handler';
 import { Buffer } from 'buffer';
-import { readFile } from 'react-native-fs';
+import { readFile } from '@dr.pogodin/react-native-fs';
 
 interface State {
   session:


### PR DESCRIPTION
### Description
This PR replaces the deprecated or less actively maintained react-native-fs package with [@dr.pogodin/react-native-fs](https://github.com/dr.pogodin/react-native-fs), a community-maintained fork that preserves the same API surface while introducing ongoing improvements and better cross-platform support, including enhanced compatibility for React Native Windows.

### Motivation and Context
The original react-native-fs package is no longer actively maintained, which presents risks related to security, such as this [CG work item](https://aiinfra.visualstudio.com/Lotus/_componentGovernance/218239/alert/12564026?typeId=31471371&pipelinesTrackingFilter=0).

