### PR TITLE
Make test `CApiTest.RequestLoadCancellation` deterministic

### DIFF
--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -4674,27 +4674,14 @@ TEST(CApiTest, RequestLoadCancellation) {
   constexpr const ORTCHAR_T* model_path = ORT_TSTR("testdata/transformers/tiny_gpt2_beamsearch.onnx");
   Ort::Env env(ORT_LOGGING_LEVEL_WARNING);
   Ort::SessionOptions session_options;
+  session_options.SetLoadCancellationFlag(true);
 
-  auto terminator = [&session_options]() {
-    session_options.SetLoadCancellationFlag(true);
-    return;
-  };
-
-  std::packaged_task<void()> task{terminator};
-  std::future<void> terminator_result = task.get_future();
-  std::thread terminator_thread{std::move(task)};
   bool terminated = false;
   try {
     Ort::Session session(env, model_path, session_options);
   } catch (const Ort::Exception& ex) {
     terminated = OrtErrorCode::ORT_MODEL_LOAD_CANCELED == ex.GetOrtErrorCode();
   }
-  // done with the thread
-  terminator_thread.join();
-
-  // call get to propagate any exception
-  terminator_result.get();
-
   ASSERT_TRUE(terminated);
 }
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Make test `CApiTest.RequestLoadCancellation` deterministic by removing the `terminator` thread.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
The test contributes to CI failures

