### PR TITLE
Pin wheel version to 0.45.1

### DIFF
--- a/tools/ci_build/requirements/pybind/requirements.txt
+++ b/tools/ci_build/requirements/pybind/requirements.txt
@@ -1,6 +1,6 @@
 setuptools
 flatbuffers
-wheel
+wheel=0.45.1
 pytest
 numpy>=1.19.0
 sympy>=1.10

--- a/tools/ci_build/requirements/pybind/requirements.txt
+++ b/tools/ci_build/requirements/pybind/requirements.txt
@@ -1,6 +1,6 @@
 setuptools
 flatbuffers
-wheel=0.45.1
+wheel==0.45.1
 pytest
 numpy>=1.19.0
 sympy>=1.10


### PR DESCRIPTION
There is an issue with the 0.46.0 `wheel` version as reported in https://github.com/pypa/wheel/issues/660. We are currently seeing this on the Python packaging pipelines, for example in [this run](https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=740997&view=logs&j=4864752d-f1c3-57c0-06eb-25cee39385a7&s=3fc0883b-27ef-5aa3-1052-0a269c26624c&t=fa95d49e-17f6-501e-c36c-b2949c11fc4a&l=13).