### PR TITLE
[WebGPU EP] Exclude zero-dim input test case for WebGPU EP.

### DIFF
--- a/onnxruntime/test/providers/cpu/nn/conv_fp16_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/conv_fp16_test.cc
@@ -968,7 +968,7 @@ TEST(ConvFp16Test, ConvDimWithZero) {
       vector<int64_t>{1, 1},        // kernel_shape
       vector<int64_t>{0, 0, 0, 0},  // pads
       vector<int64_t>{1, 1},        // strides
-      {}                            // excluded EPs
+      {kWebGpuExecutionProvider}    // excluded EPs
   };
 
   vector<MLFloat16> X;


### PR DESCRIPTION
### Description
Exclude zero-dim input testcase for WebGPU EP.



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


