### PR TITLE
[QNN EP] Add support for Int64 tensors

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
@@ -31,10 +31,9 @@ Status BaseOpBuilder::AddToModelBuilder(QnnModelWrapper& qnn_model_wrapper,
   // Inputs & output handling mostly same for most of the Ops, just node attributes are different
   ORT_RETURN_IF_ERROR(ProcessInputs(qnn_model_wrapper, node_unit, logger,
                                     input_names, do_op_validation));
-
+  ORT_RETURN_IF_ERROR(ProcessInt64Tensors(qnn_model_wrapper, node_unit, input_names));
   ORT_RETURN_IF_ERROR(ProcessAttributesAndOutputs(qnn_model_wrapper, node_unit, std::move(input_names),
                                                   logger, do_op_validation));
-
   return Status::OK();
 }
 
@@ -132,6 +131,48 @@ Status BaseOpBuilder::AddZeroBiasInput(QnnModelWrapper& qnn_model_wrapper,
   return Status::OK();
 }
 
+Status BaseOpBuilder::ProcessInt64Tensors(QnnModelWrapper& qnn_model_wrapper,
+                                          const NodeUnit& node_unit,
+                                          std::vector<std::string>& input_names) const {
+  if (input_names.size() < 1) {
+    return Status::OK();
+  }
+  for (size_t i = 0; i < input_names.size(); i++) {
+    auto& input_tensorwrapper = qnn_model_wrapper.GetQnnTensorWrapper(input_names[i]);
+    // Insert cast to int32 if input dtype is int64
+    if (input_tensorwrapper.GetTensorDataType() == QNN_DATATYPE_INT_64) {
+      const Qnn_TensorType_t tensor_type = QNN_TENSOR_TYPE_NATIVE;
+      const std::string cast_output_name = input_names[i] + "_cast_int32";
+      if (!qnn_model_wrapper.IsQnnTensorWrapperExist(cast_output_name)) {
+        Qnn_DataType_t qnn_data_type = QNN_DATATYPE_INT_32;
+        const auto& input_i = node_unit.Inputs()[i];
+        std::vector<uint32_t> output_shape;
+        ORT_RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(input_i.node_arg, output_shape),
+                          "QNN EP: Cannot get input shape for ", input_i.node_arg.Name().c_str());
+        QnnTensorWrapper output_tensorwrapper(cast_output_name,
+                                              tensor_type,
+                                              qnn_data_type,
+                                              QnnQuantParamsWrapper(),
+                                              std::move(output_shape));
+        ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)),
+                          "Failed to add output tensor for QNN Cast node.");
+
+        ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(cast_output_name,
+                                                          QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                          QNN_OP_CAST,
+                                                          {input_names[i]},
+                                                          {cast_output_name},
+                                                          {},
+                                                          false),
+                          "Failed to create QNN Cast node.");
+      }
+
+      input_names[i] = cast_output_name;
+    }
+  }
+  return Status::OK();
+}
+
 Status BaseOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
                                                   const NodeUnit& node_unit,
                                                   std::vector<std::string>&& input_names,
@@ -140,7 +181,6 @@ Status BaseOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
   if (input_names.size() < 1) {
     return Status::OK();
   }
-
   ORT_RETURN_IF_ERROR(ProcessOutputs(qnn_model_wrapper, node_unit, std::move(input_names), {},
                                      logger, do_op_validation, GetQnnOpType(node_unit.OpType())));
   return Status::OK();
@@ -179,7 +219,35 @@ Status BaseOpBuilder::ProcessOutputs(QnnModelWrapper& qnn_model_wrapper,
 
     Qnn_DataType_t supported_qnn_data_type = GetSupportedOutputDataType(output_i, output_info.qnn_data_type);
     bool is_graph_output = qnn_model_wrapper.IsGraphOutput(output_name);
-    if (supported_qnn_data_type != output_info.qnn_data_type && is_graph_output && !do_op_validation) {
+
+    // Check if we need to add a cast node for int64
+    bool needs_int64_cast = false;
+    if (is_graph_output) {
+      for (const auto& input_name : input_names) {
+        if (input_name.find("_cast_int32") != std::string::npos) {
+          needs_int64_cast = true;
+          break;
+        }
+      }
+    }
+
+    if (needs_int64_cast) {
+      std::string cast_node_name = output_name + "_cast_int64";
+      std::string cast_input_name = output_name + "_cast_int64_aux";
+      QnnQuantParamsWrapper quant_params = output_info.quant_param.Copy();
+      std::vector<uint32_t> cast_output_shape = output_info.shape;
+
+      // Create the cast input tensor wrapper
+      QnnTensorWrapper cast_input_tensorwrapper(cast_input_name,
+                                                QNN_TENSOR_TYPE_NATIVE,
+                                                supported_qnn_data_type,
+                                                output_info.quant_param.Copy(),
+                                                std::move(cast_output_shape));
+      ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(cast_input_tensorwrapper)), "Failed to add tensor.");
+      output_names.push_back(cast_input_name);
+      // Store the cast node information for later addition
+      cast_node_info_vec.push_back({cast_node_name, cast_input_name, output_name});
+    } else if (supported_qnn_data_type != output_info.qnn_data_type && is_graph_output && !do_op_validation) {
       std::string cast_node_name = output_name + "_ort_qnn_ep_cast";
       std::string cast_input_name = output_name + "_ort_qnn_ep_aux";
       std::vector<uint32_t> cast_output_shape = output_info.shape;

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
@@ -76,6 +76,10 @@ class BaseOpBuilder : public IOpBuilder {
                                std::vector<std::string>& input_names,
                                bool do_op_validation = false) const ORT_MUST_USE_RESULT;
 
+  Status ProcessInt64Tensors(QnnModelWrapper& qnn_model_wrapper,
+                             const NodeUnit& node_unit,
+                             std::vector<std::string>& input_names) const ORT_MUST_USE_RESULT;
+
   virtual Status ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
                                              const NodeUnit& node_unit,
                                              std::vector<std::string>&& input_names,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc
@@ -102,6 +102,9 @@ Status CastOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
   const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(output_name);
 
   const Qnn_TensorType_t tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
+  if (qnn_data_type == QNN_DATATYPE_INT_64 && tensor_type == QNN_TENSOR_TYPE_NATIVE) {
+    qnn_data_type = QNN_DATATYPE_INT_32;
+  }
   QnnTensorWrapper output_tensorwrapper(output_name,
                                         tensor_type,
                                         qnn_data_type,

--- a/onnxruntime/core/providers/qnn/builder/qnn_def.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_def.h
@@ -155,6 +155,24 @@ class QnnTensorWrapper {
                                                                            dimensions_(std::move(shape)),
                                                                            client_buf_(std::move(client_buf)),
                                                                            quant_params_(quantize_params) {
+    if (data_type == QNN_DATATYPE_INT_64) {
+      // QNN doesn't support int64_t, so we cast to int32_t.
+      if (tensor_type == QNN_TENSOR_TYPE_NATIVE) {
+        data_type = QNN_DATATYPE_INT_32;
+      }
+      if (client_buf_.size()) {
+        const size_t num_elems = client_buf_.size() / sizeof(int64_t);
+        std::vector<uint8_t> cast_data;
+        cast_data.resize(num_elems * sizeof(int32_t));
+        gsl::span<int64_t> origin_values{reinterpret_cast<int64_t*>(client_buf_.data()), num_elems};
+        gsl::span<int32_t> new_values(reinterpret_cast<int32_t*>(cast_data.data()), num_elems);
+        for (size_t i = 0; i < num_elems; i++) {
+          new_values[i] = static_cast<int32_t>(origin_values[i]);
+        }
+        data_type = QNN_DATATYPE_INT_32;
+        client_buf_ = std::move(cast_data);
+      }
+    }
     SetQnnTensorType(qnn_tensor_, tensor_type);
     SetQnnTensorName(qnn_tensor_, tensor_name_.c_str());
     SetQnnTensorDataType(qnn_tensor_, data_type);

--- a/onnxruntime/test/providers/qnn/reshape_expand_op_test.cc
+++ b/onnxruntime/test/providers/qnn/reshape_expand_op_test.cc
@@ -238,6 +238,17 @@ TEST_F(QnnHTPBackendTests, Reshape_4D_int32) {
                                      19);  // Opset
 }
 
+// Test that int64 Reshape runs on HTP backend.
+TEST_F(QnnHTPBackendTests, Reshape_4D_int64) {
+  std::vector<int64_t> input_data = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+  RunReshapeExpandTestOnHTP<int64_t>("Reshape",
+                                     TestInputDef<int64_t>({1, 3, 2, 2}, false, input_data),
+                                     TestInputDef<int64_t>({3}, true, {1, 1, 12}),
+                                     {},  // Attributes
+                                     ExpectedEPNodeAssignment::All,
+                                     19);  // Opset
+}
+
 // Test QDQ Reshape with a shape value of 0 (copy dimension from input)
 TEST_F(QnnHTPBackendTests, Reshape_4D_0MeansCopy) {
   RunQDQReshapeExpandTestOnHTP<uint8_t>("Reshape",


### PR DESCRIPTION
1. Added 'ProcessInt64Tensors' method in BaseOpBuilder to handle common input processing to the graph.
2. Added logic in ProcessOutputs to handle common Cast addition at output.
3. Adds Cast Op at the input to convert to int32 for graph input.
4. Initializers and activation inputs are handled by casting int64_t data to int32_t for QNN compatibility by resizing and copying data.
5. Modified `TransposeOpBuilder` and `GatherOpBuilder`to handle processing outputs.
6. Added unit test for a Reshape op to run with int64 inputs

### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


