### PR TITLE
Update unknown provider error message with current providers

### DIFF
--- a/onnxruntime/core/session/provider_registration.cc
+++ b/onnxruntime/core/session/provider_registration.cc
@@ -169,7 +169,7 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider,
   } else {
     ORT_UNUSED_PARAMETER(options);
     status = OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
-                                   "Unknown provider name. Currently supported values are 'OPENVINO', 'SNPE', 'XNNPACK', 'QNN', 'WEBNN' ,'CoreML', and 'AZURE'");
+                                   "Unknown provider name. Currently supported values are 'DML', 'QNN', 'OpenVINO', 'SNPE', 'XNNPACK', 'WEBNN', 'WebGPU', 'AZURE', 'JS', 'VitisAI', and 'CoreML'");
   }
 
   return status;


### PR DESCRIPTION
### Description
WebGPU, VitisAI, and DML are missing from the list.

### Motivation and Context
If users misspell a provider name this error should be showing them the full possibilities. Leaving one out will lead to confusion.

I noticed it when testing new providers in GenAI that the error message was not up to date.