### PR TITLE
[CI] upgrade x86_64 image for macOS CI

### DIFF
--- a/.github/workflows/macos-ci-build-and-test-workflow.yml
+++ b/.github/workflows/macos-ci-build-and-test-workflow.yml
@@ -39,7 +39,7 @@ jobs:
         build_config: ["Debug", "Release"]
         exclude: ${{ fromJSON(inputs.matrix_exclude) }}
 
-    runs-on: ${{ matrix.platform_machine == 'x86_64' && 'macos-13' || 'macos-15' }}
+    runs-on: ${{ matrix.platform_machine == 'x86_64' && 'macos-15-large' || 'macos-15' }}
     env:
       build_flags: >
         --build_dir ./build

--- a/.github/workflows/macos-ci-build-and-test-workflow.yml
+++ b/.github/workflows/macos-ci-build-and-test-workflow.yml
@@ -56,7 +56,7 @@ jobs:
         ${{ inputs.use_coreml && '--use_coreml' || '' }}
         --use_vcpkg --use_vcpkg_ms_internal_asset_cache
         --config ${{ matrix.build_config }}
-      xcode_version: ${{ matrix.platform_machine == 'x86_64' && '14.3.1' || '16' }}
+      xcode_version: 16
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
### Description

Upgrade the x86_64 image for macOS CI from `macos-13` to `macos-15-large` to improve build performance.

See: https://github.com/actions/runner-images/blob/main/README.md#available-images
