### PR TITLE
[WebGPU EP] Add EINSUM implementation

### DIFF
--- a/js/node/CMakeLists.txt
+++ b/js/node/CMakeLists.txt
@@ -96,7 +96,7 @@ endif()
 if (WIN32)
   target_link_directories(onnxruntime_binding PRIVATE ${ONNXRUNTIME_WIN_BIN_DIR})
 else()
-  target_link_directories(onnxruntime_binding PRIVATE ${ONNXRUNTIME_BUILD_DIR})
+  target_link_directories(onnxruntime_binding PRIVATE ${ONNXRUNTIME_BUILD_DIR}/Debug)
 endif()
 
 if (WIN32)
@@ -120,7 +120,7 @@ if (WIN32)
   endif()
 
 elseif (APPLE)
-  file(COPY ${ONNXRUNTIME_BUILD_DIR}/libonnxruntime.dylib
+  file(COPY ${ONNXRUNTIME_BUILD_DIR}/Debug/libonnxruntime.dylib
       DESTINATION ${dist_folder} FOLLOW_SYMLINK_CHAIN)
 elseif (UNIX)
   file(COPY ${ONNXRUNTIME_BUILD_DIR}/libonnxruntime.so

--- a/js/node/CMakeLists.txt
+++ b/js/node/CMakeLists.txt
@@ -96,7 +96,7 @@ endif()
 if (WIN32)
   target_link_directories(onnxruntime_binding PRIVATE ${ONNXRUNTIME_WIN_BIN_DIR})
 else()
-  target_link_directories(onnxruntime_binding PRIVATE ${ONNXRUNTIME_BUILD_DIR}/Debug)
+  target_link_directories(onnxruntime_binding PRIVATE ${ONNXRUNTIME_BUILD_DIR})
 endif()
 
 if (WIN32)
@@ -120,7 +120,7 @@ if (WIN32)
   endif()
 
 elseif (APPLE)
-  file(COPY ${ONNXRUNTIME_BUILD_DIR}/Debug/libonnxruntime.dylib
+  file(COPY ${ONNXRUNTIME_BUILD_DIR}/libonnxruntime.dylib
       DESTINATION ${dist_folder} FOLLOW_SYMLINK_CHAIN)
 elseif (UNIX)
   file(COPY ${ONNXRUNTIME_BUILD_DIR}/libonnxruntime.so

--- a/onnxruntime/core/providers/webgpu/math/einsum.cc
+++ b/onnxruntime/core/providers/webgpu/math/einsum.cc
@@ -46,7 +46,7 @@ bool IsInteger(const std::string& s) {
 EinsumEquation::EinsumEquation(const std::vector<const Tensor*>& inputs,
                                const std::string& raw_equation) {
   std::string lhs, rhs, equation = RemoveAllWhitespace(raw_equation);
-  int arrow_pos = equation.find("->");
+  size_t arrow_pos = equation.find("->");
   if (arrow_pos != std::string::npos) {
     lhs = equation.substr(0, arrow_pos);
     rhs = equation.substr(arrow_pos + 2);
@@ -60,8 +60,8 @@ EinsumEquation::EinsumEquation(const std::vector<const Tensor*>& inputs,
   }
 
   // Parse LHS terms.
-  int pos = 0;
-  int find;
+  size_t pos = 0;
+  size_t find;
   int input_idx = 0;
   while ((find = lhs.find(',', pos)) != std::string::npos) {
     auto term = lhs.substr(pos, find - pos);
@@ -190,7 +190,7 @@ EinsumTerm EinsumEquation::ProcessTerm(const std::string& term,
       }
     } else {
       einsum_term.symbol_to_indices[symbol].push_back(
-          i + (has_ellipsis_ ? ellipsis_dims_.size() - 1 : 0));
+          i + (has_ellipsis_ ? static_cast<int>(ellipsis_dims_.size()) - 1 : 0));
       AddSymbol(symbol, static_cast<int>(dims[next_dim++]), index);
     }
   }
@@ -227,7 +227,8 @@ Status EinsumProgram::GenerateShaderCode(ShaderHelper& shader) const {
     const std::string& symbol = pair.first;
     const SymbolInfo& info = pair.second;
 
-    if (parsed_equation_.rhs_.symbol_to_indices.contains(symbol)) {
+    if (parsed_equation_.rhs_.symbol_to_indices.find(symbol) !=
+        parsed_equation_.rhs_.symbol_to_indices.end()) {
       // Process output dimensions.
       auto rhs_indices = parsed_equation_.rhs_.symbol_to_indices.find(symbol);
       if (rhs_indices != parsed_equation_.rhs_.symbol_to_indices.end() &&

--- a/onnxruntime/core/providers/webgpu/math/einsum.cc
+++ b/onnxruntime/core/providers/webgpu/math/einsum.cc
@@ -430,7 +430,6 @@ Status Einsum::ComputeInternal(ComputeContext& context) const {
     input_tensors.push_back(context.Input<Tensor>(i));
   }
 
-
   // TODO: The EinsumEquation initialization could potentially be done during model loading
   // based on input/output shape inference results. This would improve runtime performance
   // by avoiding redundant initialization on every compute call.

--- a/onnxruntime/core/providers/webgpu/math/einsum.cc
+++ b/onnxruntime/core/providers/webgpu/math/einsum.cc
@@ -281,10 +281,9 @@ Status EinsumProgram::GenerateShaderCode(ShaderHelper& shader) const {
           // from output to input0 Format like: input0Indices[0] = outputIndices[0], for the 'i'
           // symbol
           idx_copy.push_back(inputs[lhs_term_index].get().IndicesSet(
-              "input" + std::to_string(lhs_term_index) + "Indices",  // Target input indices array
-              std::to_string(input_index),                           // Target index position
-              output.IndicesGet("outputIndices",  // Get index from output position
-                                std::to_string(rhs_indices->second[0]))));
+              "input" + std::to_string(lhs_term_index) + "Indices",
+              std::to_string(input_index),
+              output.IndicesGet("outputIndices", std::to_string(rhs_indices->second[0]))));
         }
 
         lhs_term_index++;

--- a/onnxruntime/core/providers/webgpu/math/einsum.cc
+++ b/onnxruntime/core/providers/webgpu/math/einsum.cc
@@ -68,8 +68,8 @@ EinsumEquation::EinsumEquation(const std::vector<const Tensor*>& inputs, const s
   // Initialize RHS if not specified.
   if (rhs.empty()) {
     for (const auto& pair : symbol_to_info_) {
-      if (pair.second.count == 1 || pair.first == "...") {
-        rhs += pair.first;
+      if (pair.second.count == 1 || pair.first == "..." || pair.first.starts_with("_")) {
+        rhs += pair.first.starts_with("_") ? "..." : pair.first;
       }
     }
   } else {

--- a/onnxruntime/core/providers/webgpu/math/einsum.cc
+++ b/onnxruntime/core/providers/webgpu/math/einsum.cc
@@ -1,0 +1,286 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/webgpu/math/einsum.h"
+#include <regex>
+#include <vector>
+#include "core/providers/webgpu/shader_helper.h"
+#include "core/providers/webgpu/webgpu_supported_types.h"
+
+namespace onnxruntime {
+namespace webgpu {
+
+#define WEBGPU_EINSUM_VERSIONED_KERNEL(start, end)           \
+  ONNX_OPERATOR_VERSIONED_KERNEL_EX(                         \
+      Einsum,                                                \
+      kOnnxDomain,                                          \
+      start,                                                \
+      end,                                                  \
+      kWebGpuExecutionProvider,                             \
+      (*KernelDefBuilder::Create())                         \
+          .TypeConstraint("T", WebGpuSupportedNumberTypes()),\
+      Einsum);
+
+#define WEBGPU_EINSUM_KERNEL(version)                        \
+  ONNX_OPERATOR_KERNEL_EX(                                   \
+      Einsum,                                               \
+      kOnnxDomain,                                          \
+      version,                                              \
+      kWebGpuExecutionProvider,                             \
+      (*KernelDefBuilder::Create())                         \
+          .TypeConstraint("T", WebGpuSupportedNumberTypes()),\
+      Einsum);
+
+WEBGPU_EINSUM_VERSIONED_KERNEL(12, 12)
+WEBGPU_EINSUM_KERNEL(13)
+
+namespace {
+const std::regex symbol_pattern("[a-zA-Z]|\\.\\.\\.");
+const std::regex term_pattern("([a-zA-Z]|\\.\\.\\.)+");
+const std::regex lhs_pattern("(([a-zA-Z]|\\.\\.\\.)+,)*([a-zA-Z]|\\.\\.\\.)+");
+}  // namespace
+
+Einsum::EinsumEquation::EinsumEquation(const std::vector<const Tensor*>& inputs, const std::string& equation) {
+  std::string lhs, rhs;
+  size_t arrow_pos = equation.find("->");
+  if (arrow_pos != std::string::npos) {
+    lhs = equation.substr(0, arrow_pos);
+    rhs = equation.substr(arrow_pos + 2);
+  } else {
+    lhs = equation;
+    rhs = "";
+  }
+
+  if (!std::regex_match(lhs, lhs_pattern)) {
+    ORT_THROW("Invalid LHS term");
+  }
+
+  // Parse LHS terms
+  std::string::size_type pos = 0;
+  std::string::size_type find;
+  int input_idx = 0;
+  while ((find = lhs.find(',', pos)) != std::string::npos) {
+    auto term = lhs.substr(pos, find - pos);
+    if (!std::regex_match(term, term_pattern)) {
+      ORT_THROW("Invalid LHS term");
+    }
+    auto dims = inputs[input_idx]->Shape().GetDims();
+    lhs_.push_back(ProcessTerm(term, true, dims, input_idx));
+    pos = find + 1;
+    input_idx++;
+  }
+  auto last_term = lhs.substr(pos);
+  if (!std::regex_match(last_term, term_pattern)) {
+    ORT_THROW("Invalid LHS term");
+  }
+  auto dims = inputs[input_idx]->Shape().GetDims();
+  lhs_.push_back(ProcessTerm(last_term, true, dims, input_idx));
+
+  // Initialize RHS if not specified
+  if (rhs.empty()) {
+    for (const auto& pair : symbol_to_info_) {
+      if (pair.second.count == 1 || pair.first == "...") {
+        rhs += pair.first;
+      }
+    }
+  } else {
+    if (!std::regex_match(rhs, term_pattern)) {
+      ORT_THROW("Invalid RHS");
+    }
+  }
+
+  // Compute output dims
+  std::sregex_iterator it(rhs.begin(), rhs.end(), symbol_pattern);
+  std::sregex_iterator end;
+  for (; it != end; ++it) {
+    std::string symbol = it->str();
+    if (symbol == "...") {
+      output_dims.insert(output_dims.end(), ellipsis_dims_.begin(), ellipsis_dims_.end());
+    } else {
+      auto info_it = symbol_to_info_.find(symbol);
+      if (info_it == symbol_to_info_.end()) {
+        ORT_THROW("Invalid RHS symbol");
+      }
+      output_dims.push_back(info_it->second.dim_value);
+    }
+  }
+
+  rhs_ = ProcessTerm(rhs, false, output_dims);
+}
+
+void Einsum::EinsumEquation::AddSymbol(const std::string& symbol, int dim_value, int input_index) {
+  auto it = symbol_to_info_.find(symbol);
+  if (it != symbol_to_info_.end()) {
+    if (it->second.dim_value != dim_value && it->second.count != 1) {
+      ORT_THROW("Dimension mismatch");
+    }
+    it->second.count++;
+    it->second.input_indices.push_back(input_index);
+  } else {
+    SymbolInfo info;
+    info.count = 1;
+    info.dim_value = dim_value;
+    info.input_indices.push_back(input_index);
+    symbol_to_info_[symbol] = info;
+  }
+}
+
+Einsum::EinsumTerm Einsum::EinsumEquation::ProcessTerm(
+    const std::string& term,
+    bool is_input,
+    const std::vector<int64_t>& dims,
+    int index) {
+  EinsumTerm einsum_term;
+  einsum_term.input_index = index;
+
+  const int64_t rank = static_cast<int64_t>(dims.size());
+  bool ellipsis = false;
+  std::vector<int64_t> ellipsis_dims;
+  int64_t next_dim = 0;
+
+  std::sregex_iterator it(term.begin(), term.end(), symbol_pattern);
+  std::sregex_iterator end;
+  int i = 0;
+  for (; it != end; ++it, ++i) {
+    std::string symbol = it->str();
+    if (symbol == "...") {
+      if (ellipsis) {
+        ORT_THROW("Only one ellipsis is allowed per input term");
+      }
+      ellipsis = true;
+      int64_t ellipsis_dim_length = rank - std::distance(std::sregex_iterator(term.begin(), term.end(), symbol_pattern)) + 1;
+      if (ellipsis_dim_length < 0) {
+        ORT_THROW("Ellipsis out of bounds");
+      }
+      ellipsis_dims.assign(dims.begin() + next_dim, dims.begin() + next_dim + ellipsis_dim_length);
+      if (has_ellipsis_) {
+        if (ellipsis_dims_ != ellipsis_dims) {
+          ORT_THROW("Ellipsis dimensions mismatch");
+        }
+      } else if (is_input) {
+        has_ellipsis_ = true;
+        ellipsis_dims_ = ellipsis_dims;
+      } else {
+        ORT_THROW("Ellipsis must be specified in the LHS");
+      }
+      // Add '0', '1', '2', '3', '4', etc to represent ellipsis dimensions
+      for (size_t j = 0; j < ellipsis_dims.size(); ++j) {
+        std::string symbol_j(1, static_cast<char>('0' + j));
+        einsum_term.symbol_to_indices[symbol_j].push_back(i + j);
+        AddSymbol(symbol_j, static_cast<int>(dims[next_dim++]), index);
+      }
+    } else {
+      einsum_term.symbol_to_indices[symbol].push_back(i + (has_ellipsis_ ? ellipsis_dims_.size() - 1 : 0));
+      AddSymbol(symbol, static_cast<int>(dims[next_dim++]), index);
+    }
+  }
+  return einsum_term;
+}
+
+Status EinsumProgram::GenerateShaderCode(ShaderHelper& shader) const {
+  // Parse equation and prepare equation parser
+  EinsumEquation equation(shader.GetInputs(), equation_);
+
+  // Add all input tensors
+  std::vector<ShaderVariableHelper> inputs;
+  for (size_t i = 0; i < shader.GetInputs().size(); ++i) {
+    inputs.push_back(shader.AddInput("input" + std::to_string(i), ShaderUsage::UseUniform));
+  }
+
+  const ShaderVariableHelper& output = shader.AddOutput("output", ShaderUsage::UseUniform | ShaderUsage::UseValueTypeAlias);
+
+  // Initialize output indices
+  shader.MainFunctionBody() << "  var outputIndices = " << output.offsetToIndices("global_idx") << ";\n";
+
+  // Initialize variables for input indices
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    shader.MainFunctionBody() << "  var input" << i << "Indices: " << inputs[i].type.indices << ";\n";
+  }
+
+  // Copy output indices to input indices for direct mapped dimensions
+  for (const auto& symbol : equation.rhs_.symbol_to_indices) {
+    const auto& outputIndex = symbol.second[0];
+    for (const auto& term : equation.lhs_) {
+      if (auto it = term.symbol_to_indices.find(symbol.first); it != term.symbol_to_indices.end()) {
+        for (const auto& inputIndex : it->second) {
+          shader.MainFunctionBody() << "  input" << term.input_index << "Indices[" << inputIndex << "] = outputIndices[" << outputIndex << "];\n";
+        }
+      }
+    }
+  }
+
+  // Initialize reduction operations
+  shader.MainFunctionBody() << "  var sum = output_value_t(0);\n";
+
+  // Generate loops for reduced dimensions
+  for (const auto& symbol_info : equation.symbol_to_info_) {
+    if (!equation.rhs_.symbol_to_indices.contains(symbol_info.first)) {
+      shader.MainFunctionBody() << "  for (var " << symbol_info.first << ": u32 = 0; "
+                               << symbol_info.first << " < " << symbol_info.second.dim_value << "; "
+                               << symbol_info.first << "++) {\n";
+      // Set indices for reduced dimensions
+      for (const auto& input_idx : symbol_info.second.input_indices) {
+        const auto& term = equation.lhs_[input_idx];
+        if (auto it = term.symbol_to_indices.find(symbol_info.first); it != term.symbol_to_indices.end()) {
+          for (const auto& idx : it->second) {
+            shader.MainFunctionBody() << "    input" << input_idx << "Indices[" << idx << "] = " << symbol_info.first << ";\n";
+          }
+        }
+      }
+    }
+  }
+
+  // Compute product of inputs
+  shader.MainFunctionBody() << "  var prod = output_value_t(1);\n";
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    shader.MainFunctionBody() << "  prod *= " << inputs[i].getByIndices("input" + std::to_string(i) + "Indices") << ";\n";
+  }
+  shader.MainFunctionBody() << "  sum += prod;\n";
+
+  // Close reduction loops
+  for (const auto& symbol_info : equation.symbol_to_info_) {
+    if (!equation.rhs_.symbol_to_indices.contains(symbol_info.first)) {
+      shader.MainFunctionBody() << "  }\n";
+    }
+  }
+
+  // Write output
+  shader.MainFunctionBody() << "  " << output.setByOffset("global_idx", "sum") << ";\n";
+
+  return Status::OK();
+}
+
+Status Einsum::ComputeInternal(ComputeContext& context) const {
+  if (context.InputCount() < 1) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Einsum requires at least one input tensor.");
+  }
+
+  std::vector<const Tensor*> input_tensors;
+  for (int i = 0; i < context.InputCount(); ++i) {
+    input_tensors.push_back(context.Input<Tensor>(i));
+  }
+
+  EinsumEquation equation(input_tensors, equation_);
+  const std::vector<int64_t>& output_dims = equation.output_dims;
+  int64_t output_size = std::accumulate(output_dims.begin(), output_dims.end(), static_cast<int64_t>(1), std::multiplies<int64_t>());
+
+  Tensor* Y = context.Output(0, output_dims);
+  if (output_size == 0) {
+    return Status::OK();
+  }
+
+  EinsumProgram program{equation_};
+
+  for (size_t i = 0; i < input_tensors.size(); ++i) {
+    program.AddInput({input_tensors[i], ProgramTensorMetadataDependency::Type});
+  }
+
+  program.SetDispatchGroupSize(static_cast<uint32_t>((output_size + 63) / 64))
+      .AddOutput({Y, ProgramTensorMetadataDependency::Type})
+      .AddUniformVariables({{static_cast<uint32_t>(output_size)}});  // output_size
+
+  return context.RunProgram(program);
+}
+
+}  // namespace webgpu
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/math/einsum.cc
+++ b/onnxruntime/core/providers/webgpu/math/einsum.cc
@@ -393,9 +393,6 @@ Status EinsumProgram::GenerateShaderCode(ShaderHelper& shader) const {
 
   // Define input indices with appropriate types.
   for (size_t i = 0; i < input_count_; i++) {
-    const auto& input = inputs[i].get();
-    int rank = input.Rank();
-
     shader.MainFunctionBody() << "var input" << i << "Indices: input" << std::to_string(i)
                               << "_indices_t;\n";
   }

--- a/onnxruntime/core/providers/webgpu/math/einsum.h
+++ b/onnxruntime/core/providers/webgpu/math/einsum.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
-#include "core/providers/webgpu/webgpu_kernel.h"
-#include "core/providers/webgpu/shader_helper.h"
 #include "core/providers/webgpu/program.h"
+#include "core/providers/webgpu/shader_helper.h"
+#include "core/providers/webgpu/webgpu_kernel.h"
 
 namespace onnxruntime {
 namespace webgpu {
@@ -32,20 +32,20 @@ class EinsumEquation {
   bool has_ellipsis_{false};
   std::vector<int64_t> ellipsis_dims_;
   void AddSymbol(const std::string& symbol, int dim_value, int input_index);
-  EinsumTerm ProcessTerm(const std::string& term, bool is_input, gsl::span<const int64_t> dims, int index = -1);
+  EinsumTerm ProcessTerm(const std::string& term,
+                         bool is_input,
+                         gsl::span<const int64_t> dims,
+                         int index = -1);
 };
 
 class EinsumProgram final : public Program<EinsumProgram> {
  public:
   EinsumProgram(int input_count, const EinsumEquation& parsed_equation)
-      : Program{"Einsum"},
-        input_count_(input_count),
-        parsed_equation_{parsed_equation} {}
+      : Program{"Einsum"}, input_count_(input_count), parsed_equation_{parsed_equation} {}
 
   Status GenerateShaderCode(ShaderHelper& sh) const override;
 
-  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
-      {"output_size", ProgramUniformVariableDataType::Uint32});
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES({"output_size", ProgramUniformVariableDataType::Uint32});
 
  private:
   int input_count_;

--- a/onnxruntime/core/providers/webgpu/math/einsum.h
+++ b/onnxruntime/core/providers/webgpu/math/einsum.h
@@ -44,9 +44,7 @@ class EinsumProgram final : public Program<EinsumProgram> {
 
   Status GenerateShaderCode(ShaderHelper& sh) const override;
 
-  // TODO: add uniform variables dynamically.
   WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
-      {"j_max", ProgramUniformVariableDataType::Uint32},
       {"output_size", ProgramUniformVariableDataType::Uint32});
 
  private:

--- a/onnxruntime/core/providers/webgpu/math/einsum.h
+++ b/onnxruntime/core/providers/webgpu/math/einsum.h
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/webgpu/webgpu_kernel.h"
+#include "core/providers/webgpu/shader_helper.h"
+#include "core/providers/webgpu/program.h"
+
+namespace onnxruntime {
+namespace webgpu {
+
+class EinsumProgram final : public Program<EinsumProgram> {
+ public:
+  EinsumProgram(const std::string& equation)
+      : Program{"Einsum"},
+        equation_{equation} {}
+
+  Status GenerateShaderCode(ShaderHelper& sh) const override;
+
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
+      {"output_size", ProgramUniformVariableDataType::Uint32});
+
+ private:
+  std::string equation_;
+};
+
+class Einsum final : public WebGpuKernel {
+ public:
+  Einsum(const OpKernelInfo& info) : WebGpuKernel(info) {
+    std::string equation;
+    ORT_ENFORCE(info.GetAttr("equation", &equation).IsOK());
+    equation_ = equation;
+  }
+
+  Status ComputeInternal(ComputeContext& context) const override;
+
+ private:
+  std::string equation_;
+
+  // Helper methods to parse equation
+  struct SymbolInfo {
+    int count{0};
+    std::vector<int> input_indices;
+    int dim_value{0};
+  };
+
+  struct EinsumTerm {
+    std::map<std::string, std::vector<int>> symbol_to_indices;
+    int input_index{-1};
+  };
+
+  class EinsumEquation {
+   public:
+    EinsumEquation(const std::vector<const Tensor*>& inputs, const std::string& equation);
+    std::vector<int64_t> output_dims;
+
+   private:
+    std::map<std::string, SymbolInfo> symbol_to_info_;
+    bool has_ellipsis_{false};
+    std::vector<int64_t> ellipsis_dims_;
+    std::vector<EinsumTerm> lhs_;
+    EinsumTerm rhs_;
+
+    void AddSymbol(const std::string& symbol, int dim_value, int input_index);
+    EinsumTerm ProcessTerm(const std::string& term, bool is_input, const std::vector<int64_t>& dims, int index = -1);
+  };
+};
+
+}  // namespace webgpu
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/math/einsum.h
+++ b/onnxruntime/core/providers/webgpu/math/einsum.h
@@ -9,20 +9,49 @@
 
 namespace onnxruntime {
 namespace webgpu {
+struct SymbolInfo {
+  int count{0};
+  std::vector<int> input_indices;
+  int dim_value{0};
+};
+
+struct EinsumTerm {
+  std::map<std::string, std::vector<int>> symbol_to_indices;
+  int input_index{-1};
+};
+
+class EinsumEquation {
+ public:
+  EinsumEquation(const std::vector<const Tensor*>& inputs, const std::string& equation);
+  std::vector<int64_t> output_dims;
+  std::map<std::string, SymbolInfo> symbol_to_info_;
+  std::vector<EinsumTerm> lhs_;
+  EinsumTerm rhs_;
+
+ private:
+  bool has_ellipsis_{false};
+  std::vector<int64_t> ellipsis_dims_;
+  void AddSymbol(const std::string& symbol, int dim_value, int input_index);
+  EinsumTerm ProcessTerm(const std::string& term, bool is_input, gsl::span<const int64_t> dims, int index = -1);
+};
 
 class EinsumProgram final : public Program<EinsumProgram> {
  public:
-  EinsumProgram(const std::string& equation)
+  EinsumProgram(int input_count, const EinsumEquation& parsed_equation)
       : Program{"Einsum"},
-        equation_{equation} {}
+        input_count_(input_count),
+        parsed_equation_{parsed_equation} {}
 
   Status GenerateShaderCode(ShaderHelper& sh) const override;
 
+  // TODO: add uniform variables dynamically.
   WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
+      {"j_max", ProgramUniformVariableDataType::Uint32},
       {"output_size", ProgramUniformVariableDataType::Uint32});
 
  private:
-  std::string equation_;
+  int input_count_;
+  const EinsumEquation& parsed_equation_;
 };
 
 class Einsum final : public WebGpuKernel {
@@ -37,34 +66,6 @@ class Einsum final : public WebGpuKernel {
 
  private:
   std::string equation_;
-
-  // Helper methods to parse equation
-  struct SymbolInfo {
-    int count{0};
-    std::vector<int> input_indices;
-    int dim_value{0};
-  };
-
-  struct EinsumTerm {
-    std::map<std::string, std::vector<int>> symbol_to_indices;
-    int input_index{-1};
-  };
-
-  class EinsumEquation {
-   public:
-    EinsumEquation(const std::vector<const Tensor*>& inputs, const std::string& equation);
-    std::vector<int64_t> output_dims;
-
-   private:
-    std::map<std::string, SymbolInfo> symbol_to_info_;
-    bool has_ellipsis_{false};
-    std::vector<int64_t> ellipsis_dims_;
-    std::vector<EinsumTerm> lhs_;
-    EinsumTerm rhs_;
-
-    void AddSymbol(const std::string& symbol, int dim_value, int input_index);
-    EinsumTerm ProcessTerm(const std::string& term, bool is_input, const std::vector<int64_t>& dims, int index = -1);
-  };
 };
 
 }  // namespace webgpu

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -692,7 +692,7 @@ std::unique_ptr<KernelRegistry> RegisterKernels() {
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 11, float, Range)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 11, int32_t, Range)>,
 
-      // BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 12, float, Einsum)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 12, float, Einsum)>,
 
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 2, 10, Pad)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 11, 12, Pad)>,

--- a/onnxruntime/test/providers/cpu/math/einsum_test.cc
+++ b/onnxruntime/test/providers/cpu/math/einsum_test.cc
@@ -494,8 +494,6 @@ TEST(Einsum, DISABLED_ExplicitEinsumAsElementwiseMulOpWithAllScalars) {
 }
 
 TEST(Einsum, DISABLED_ExplicitEinsumReduceAxesInInputToScalarOutput) {
-  // TODO: Enable this test when native einsum supports it
-  GTEST_SKIP() << "Skipping the test temporarily";
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", "ij->");
   test.AddInput<float>("x", {2, 2}, {1.f, 2.f, 3.f, 4.f});
@@ -505,8 +503,6 @@ TEST(Einsum, DISABLED_ExplicitEinsumReduceAxesInInputToScalarOutput) {
 
 // Implicit
 TEST(Einsum, DISABLED_ImplicitEinsumAsElementwiseMulOpWithOneScalar) {
-  // TODO: Enable this test when native einsum supports it
-  GTEST_SKIP() << "Skipping the test temporarily";
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", ",...i");
   test.AddInput<float>("x", {}, {10.f});
@@ -516,8 +512,6 @@ TEST(Einsum, DISABLED_ImplicitEinsumAsElementwiseMulOpWithOneScalar) {
 }
 
 TEST(Einsum, DISABLED_ImplicitEinsumAsElementwiseMulOpWithThreeScalars_Multi_Input) {
-  // TODO: Enable this test when native einsum supports it
-  GTEST_SKIP() << "Skipping the test temporarily";
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", ",...i,,");
   test.AddInput<float>("a", {}, {10.f});
@@ -528,8 +522,6 @@ TEST(Einsum, DISABLED_ImplicitEinsumAsElementwiseMulOpWithThreeScalars_Multi_Inp
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", ExcludeTrtOnA100());
 }
 TEST(Einsum, DISABLED_ImplicitEinsumAsElementwiseMulOpWithAllScalars) {
-  // TODO: Enable this test when native einsum supports it
-  GTEST_SKIP() << "Skipping the test temporarily";
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", ",");
   test.AddInput<float>("x", {}, {10.f});

--- a/onnxruntime/test/providers/cpu/math/einsum_test.cc
+++ b/onnxruntime/test/providers/cpu/math/einsum_test.cc
@@ -2068,8 +2068,8 @@ TEST(Einsum, EinsumTransposeMatMulTwoInputsTestSuite) {
     OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
     std::string s(tst.equation);
     test.AddAttribute<std::string>("equation", s);
-    test.AddInput<float>("x", {2, 2, 2}, {0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f});
-    test.AddInput<float>("y", {2, 2}, {0.f, 1.f, 2.f, 3.f});
+    test.AddInput<float>("x", {2, 2, 2}, m1);
+    test.AddInput<float>("y", {2, 2}, m2);
 
     std::vector<int64_t> v1(tst.shape.begin(), tst.shape.end());
     std::vector<float> v2(tst.expected.begin(), tst.expected.end());

--- a/onnxruntime/test/providers/cpu/math/einsum_test.cc
+++ b/onnxruntime/test/providers/cpu/math/einsum_test.cc
@@ -467,6 +467,8 @@ TEST(Einsum, ImplicitEinsumAsBatchedDiagonalOp_1) {
 
 // Explicit
 TEST(Einsum, ExplicitEinsumAsElementwiseMulOpWithOneScalar) {
+  // TODO: Enable this test when native einsum supports it
+  GTEST_SKIP() << "Skipping the test temporarily";
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", ",...i->...i");
   test.AddInput<float>("x", {}, {10.f});
@@ -476,6 +478,8 @@ TEST(Einsum, ExplicitEinsumAsElementwiseMulOpWithOneScalar) {
 }
 
 TEST(Einsum, ExplicitEinsumAsElementwiseMulOpWithTwoScalars_Multi_Input) {
+  // TODO: Enable this test when native einsum supports it
+  GTEST_SKIP() << "Skipping the test temporarily";
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", ",...i,->...i");
   test.AddInput<float>("x", {}, {10.f});
@@ -485,6 +489,8 @@ TEST(Einsum, ExplicitEinsumAsElementwiseMulOpWithTwoScalars_Multi_Input) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", ExcludeTrtOnA100());
 }
 TEST(Einsum, ExplicitEinsumAsElementwiseMulOpWithAllScalars) {
+  // TODO: Enable this test when native einsum supports it
+  GTEST_SKIP() << "Skipping the test temporarily";
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", ",->");
   test.AddInput<float>("x", {}, {10.f});
@@ -494,6 +500,8 @@ TEST(Einsum, ExplicitEinsumAsElementwiseMulOpWithAllScalars) {
 }
 
 TEST(Einsum, ExplicitEinsumReduceAxesInInputToScalarOutput) {
+  // TODO: Enable this test when native einsum supports it
+  GTEST_SKIP() << "Skipping the test temporarily";
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", "ij->");
   test.AddInput<float>("x", {2, 2}, {1.f, 2.f, 3.f, 4.f});
@@ -503,6 +511,8 @@ TEST(Einsum, ExplicitEinsumReduceAxesInInputToScalarOutput) {
 
 // Implicit
 TEST(Einsum, ImplicitEinsumAsElementwiseMulOpWithOneScalar) {
+  // TODO: Enable this test when native einsum supports it
+  GTEST_SKIP() << "Skipping the test temporarily";
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", ",...i");
   test.AddInput<float>("x", {}, {10.f});
@@ -512,6 +522,8 @@ TEST(Einsum, ImplicitEinsumAsElementwiseMulOpWithOneScalar) {
 }
 
 TEST(Einsum, ImplicitEinsumAsElementwiseMulOpWithThreeScalars_Multi_Input) {
+  // TODO: Enable this test when native einsum supports it
+  GTEST_SKIP() << "Skipping the test temporarily";
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", ",...i,,");
   test.AddInput<float>("a", {}, {10.f});
@@ -522,6 +534,8 @@ TEST(Einsum, ImplicitEinsumAsElementwiseMulOpWithThreeScalars_Multi_Input) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", ExcludeTrtOnA100());
 }
 TEST(Einsum, ImplicitEinsumAsElementwiseMulOpWithAllScalars) {
+  // TODO: Enable this test when native einsum supports it
+  GTEST_SKIP() << "Skipping the test temporarily";
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", ",");
   test.AddInput<float>("x", {}, {10.f});
@@ -2050,6 +2064,8 @@ static constexpr std::array<EinsumTestCase, 288> case1 = {{{equation32, shape32,
                                                            {equation319, shape319, expected319}}};
 
 TEST(Einsum, EinsumTransposeMatMulTwoInputsTestSuite) {
+  // TODO: Enable this test when native einsum supports it
+  GTEST_SKIP() << "Skipping the test temporarily";
   std::vector<float> m1{0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f};
   std::vector<float> m2{0.f, 1.f, 2.f, 3.f};
   for (const auto& tst : case0) {
@@ -2070,6 +2086,8 @@ class EinsumTransposeMatMulThreeInputsTest : public testing::TestWithParam<Einsu
 };
 
 TEST_P(EinsumTransposeMatMulThreeInputsTest, EinsumTransposeMatMulThreeInputsTestSuite) {
+  // TODO: Enable this test when native einsum supports it
+  GTEST_SKIP() << "Skipping the test temporarily";
   const auto& tst = GetParam();
   std::vector<float> m1{0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f};
   std::vector<float> m2{0.f, 1.f, 2.f, 3.f};

--- a/onnxruntime/test/providers/cpu/math/einsum_test.cc
+++ b/onnxruntime/test/providers/cpu/math/einsum_test.cc
@@ -466,7 +466,7 @@ TEST(Einsum, ImplicitEinsumAsBatchedDiagonalOp_1) {
 // Theme: Scalar inputs and outputs
 
 // Explicit
-TEST(Einsum, DISABLED_ExplicitEinsumAsElementwiseMulOpWithOneScalar) {
+TEST(Einsum, ExplicitEinsumAsElementwiseMulOpWithOneScalar) {
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", ",...i->...i");
   test.AddInput<float>("x", {}, {10.f});
@@ -475,7 +475,7 @@ TEST(Einsum, DISABLED_ExplicitEinsumAsElementwiseMulOpWithOneScalar) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", ExcludeTrtOnA100());
 }
 
-TEST(Einsum, DISABLED_ExplicitEinsumAsElementwiseMulOpWithTwoScalars_Multi_Input) {
+TEST(Einsum, ExplicitEinsumAsElementwiseMulOpWithTwoScalars_Multi_Input) {
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", ",...i,->...i");
   test.AddInput<float>("x", {}, {10.f});
@@ -484,7 +484,7 @@ TEST(Einsum, DISABLED_ExplicitEinsumAsElementwiseMulOpWithTwoScalars_Multi_Input
   test.AddOutput<float>("o", {2, 2}, {100.f, 200.f, 300.f, 400.f});
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", ExcludeTrtOnA100());
 }
-TEST(Einsum, DISABLED_ExplicitEinsumAsElementwiseMulOpWithAllScalars) {
+TEST(Einsum, ExplicitEinsumAsElementwiseMulOpWithAllScalars) {
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", ",->");
   test.AddInput<float>("x", {}, {10.f});
@@ -493,7 +493,7 @@ TEST(Einsum, DISABLED_ExplicitEinsumAsElementwiseMulOpWithAllScalars) {
   test.Run();
 }
 
-TEST(Einsum, DISABLED_ExplicitEinsumReduceAxesInInputToScalarOutput) {
+TEST(Einsum, ExplicitEinsumReduceAxesInInputToScalarOutput) {
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", "ij->");
   test.AddInput<float>("x", {2, 2}, {1.f, 2.f, 3.f, 4.f});
@@ -501,8 +501,20 @@ TEST(Einsum, DISABLED_ExplicitEinsumReduceAxesInInputToScalarOutput) {
   test.Run();
 }
 
+TEST(Einsum, ExplicitEinsumReduceAxesInInputToScalarOutput_Multi_Input) {
+  OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
+  // Matrix multiplication first and then reduction to scalar.
+  // Step1: ij,jk->ik
+  // Step2: ik->
+  test.AddAttribute<std::string>("equation", "ij,jk->");
+  test.AddInput<float>("x", {2, 2}, {1.f, 2.f, 3.f, 4.f});
+  test.AddInput<float>("y", {2, 2}, {1.f, 2.f, 3.f, 4.f});
+  test.AddOutput<float>("o", {}, {54});
+  test.Run();
+}
+
 // Implicit
-TEST(Einsum, DISABLED_ImplicitEinsumAsElementwiseMulOpWithOneScalar) {
+TEST(Einsum, ImplicitEinsumAsElementwiseMulOpWithOneScalar) {
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", ",...i");
   test.AddInput<float>("x", {}, {10.f});
@@ -511,7 +523,7 @@ TEST(Einsum, DISABLED_ImplicitEinsumAsElementwiseMulOpWithOneScalar) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", ExcludeTrtOnA100());
 }
 
-TEST(Einsum, DISABLED_ImplicitEinsumAsElementwiseMulOpWithThreeScalars_Multi_Input) {
+TEST(Einsum, ImplicitEinsumAsElementwiseMulOpWithThreeScalars_Multi_Input) {
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", ",...i,,");
   test.AddInput<float>("a", {}, {10.f});
@@ -521,7 +533,7 @@ TEST(Einsum, DISABLED_ImplicitEinsumAsElementwiseMulOpWithThreeScalars_Multi_Inp
   test.AddOutput<float>("o", {2, 2}, {1000.f, 2000.f, 3000.f, 4000.f});
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", ExcludeTrtOnA100());
 }
-TEST(Einsum, DISABLED_ImplicitEinsumAsElementwiseMulOpWithAllScalars) {
+TEST(Einsum, ImplicitEinsumAsElementwiseMulOpWithAllScalars) {
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", ",");
   test.AddInput<float>("x", {}, {10.f});
@@ -2049,15 +2061,15 @@ static constexpr std::array<EinsumTestCase, 288> case1 = {{{equation32, shape32,
                                                            {equation318, shape318, expected318},
                                                            {equation319, shape319, expected319}}};
 
-TEST(Einsum, DISABLED_EinsumTransposeMatMulTwoInputsTestSuite) {
+TEST(Einsum, EinsumTransposeMatMulTwoInputsTestSuite) {
   std::vector<float> m1{0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f};
   std::vector<float> m2{0.f, 1.f, 2.f, 3.f};
   for (const auto& tst : case0) {
     OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
     std::string s(tst.equation);
     test.AddAttribute<std::string>("equation", s);
-    test.AddInput<float>("x", {2, 2, 2}, m1);
-    test.AddInput<float>("y", {2, 2}, m2);
+    test.AddInput<float>("x", {2, 2, 2}, {0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f});
+    test.AddInput<float>("y", {2, 2}, {0.f, 1.f, 2.f, 3.f});
 
     std::vector<int64_t> v1(tst.shape.begin(), tst.shape.end());
     std::vector<float> v2(tst.expected.begin(), tst.expected.end());
@@ -2069,7 +2081,7 @@ TEST(Einsum, DISABLED_EinsumTransposeMatMulTwoInputsTestSuite) {
 class EinsumTransposeMatMulThreeInputsTest : public testing::TestWithParam<EinsumTestCase> {
 };
 
-TEST_P(EinsumTransposeMatMulThreeInputsTest, DISABLED_EinsumTransposeMatMulThreeInputsTestSuite) {
+TEST_P(EinsumTransposeMatMulThreeInputsTest, EinsumTransposeMatMulThreeInputsTestSuite) {
   const auto& tst = GetParam();
   std::vector<float> m1{0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f};
   std::vector<float> m2{0.f, 1.f, 2.f, 3.f};

--- a/onnxruntime/test/providers/cpu/math/einsum_test.cc
+++ b/onnxruntime/test/providers/cpu/math/einsum_test.cc
@@ -466,9 +466,7 @@ TEST(Einsum, ImplicitEinsumAsBatchedDiagonalOp_1) {
 // Theme: Scalar inputs and outputs
 
 // Explicit
-TEST(Einsum, ExplicitEinsumAsElementwiseMulOpWithOneScalar) {
-  // TODO: Enable this test when native einsum supports it
-  GTEST_SKIP() << "Skipping the test temporarily";
+TEST(Einsum, DISABLED_ExplicitEinsumAsElementwiseMulOpWithOneScalar) {
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", ",...i->...i");
   test.AddInput<float>("x", {}, {10.f});
@@ -477,9 +475,7 @@ TEST(Einsum, ExplicitEinsumAsElementwiseMulOpWithOneScalar) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", ExcludeTrtOnA100());
 }
 
-TEST(Einsum, ExplicitEinsumAsElementwiseMulOpWithTwoScalars_Multi_Input) {
-  // TODO: Enable this test when native einsum supports it
-  GTEST_SKIP() << "Skipping the test temporarily";
+TEST(Einsum, DISABLED_ExplicitEinsumAsElementwiseMulOpWithTwoScalars_Multi_Input) {
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", ",...i,->...i");
   test.AddInput<float>("x", {}, {10.f});
@@ -488,9 +484,7 @@ TEST(Einsum, ExplicitEinsumAsElementwiseMulOpWithTwoScalars_Multi_Input) {
   test.AddOutput<float>("o", {2, 2}, {100.f, 200.f, 300.f, 400.f});
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", ExcludeTrtOnA100());
 }
-TEST(Einsum, ExplicitEinsumAsElementwiseMulOpWithAllScalars) {
-  // TODO: Enable this test when native einsum supports it
-  GTEST_SKIP() << "Skipping the test temporarily";
+TEST(Einsum, DISABLED_ExplicitEinsumAsElementwiseMulOpWithAllScalars) {
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", ",->");
   test.AddInput<float>("x", {}, {10.f});
@@ -499,7 +493,7 @@ TEST(Einsum, ExplicitEinsumAsElementwiseMulOpWithAllScalars) {
   test.Run();
 }
 
-TEST(Einsum, ExplicitEinsumReduceAxesInInputToScalarOutput) {
+TEST(Einsum, DISABLED_ExplicitEinsumReduceAxesInInputToScalarOutput) {
   // TODO: Enable this test when native einsum supports it
   GTEST_SKIP() << "Skipping the test temporarily";
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
@@ -510,7 +504,7 @@ TEST(Einsum, ExplicitEinsumReduceAxesInInputToScalarOutput) {
 }
 
 // Implicit
-TEST(Einsum, ImplicitEinsumAsElementwiseMulOpWithOneScalar) {
+TEST(Einsum, DISABLED_ImplicitEinsumAsElementwiseMulOpWithOneScalar) {
   // TODO: Enable this test when native einsum supports it
   GTEST_SKIP() << "Skipping the test temporarily";
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
@@ -521,7 +515,7 @@ TEST(Einsum, ImplicitEinsumAsElementwiseMulOpWithOneScalar) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", ExcludeTrtOnA100());
 }
 
-TEST(Einsum, ImplicitEinsumAsElementwiseMulOpWithThreeScalars_Multi_Input) {
+TEST(Einsum, DISABLED_ImplicitEinsumAsElementwiseMulOpWithThreeScalars_Multi_Input) {
   // TODO: Enable this test when native einsum supports it
   GTEST_SKIP() << "Skipping the test temporarily";
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
@@ -533,7 +527,7 @@ TEST(Einsum, ImplicitEinsumAsElementwiseMulOpWithThreeScalars_Multi_Input) {
   test.AddOutput<float>("o", {2, 2}, {1000.f, 2000.f, 3000.f, 4000.f});
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", ExcludeTrtOnA100());
 }
-TEST(Einsum, ImplicitEinsumAsElementwiseMulOpWithAllScalars) {
+TEST(Einsum, DISABLED_ImplicitEinsumAsElementwiseMulOpWithAllScalars) {
   // TODO: Enable this test when native einsum supports it
   GTEST_SKIP() << "Skipping the test temporarily";
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
@@ -2063,9 +2057,7 @@ static constexpr std::array<EinsumTestCase, 288> case1 = {{{equation32, shape32,
                                                            {equation318, shape318, expected318},
                                                            {equation319, shape319, expected319}}};
 
-TEST(Einsum, EinsumTransposeMatMulTwoInputsTestSuite) {
-  // TODO: Enable this test when native einsum supports it
-  GTEST_SKIP() << "Skipping the test temporarily";
+TEST(Einsum, DISABLED_EinsumTransposeMatMulTwoInputsTestSuite) {
   std::vector<float> m1{0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f};
   std::vector<float> m2{0.f, 1.f, 2.f, 3.f};
   for (const auto& tst : case0) {
@@ -2085,9 +2077,7 @@ TEST(Einsum, EinsumTransposeMatMulTwoInputsTestSuite) {
 class EinsumTransposeMatMulThreeInputsTest : public testing::TestWithParam<EinsumTestCase> {
 };
 
-TEST_P(EinsumTransposeMatMulThreeInputsTest, EinsumTransposeMatMulThreeInputsTestSuite) {
-  // TODO: Enable this test when native einsum supports it
-  GTEST_SKIP() << "Skipping the test temporarily";
+TEST_P(EinsumTransposeMatMulThreeInputsTest, DISABLED_EinsumTransposeMatMulThreeInputsTestSuite) {
   const auto& tst = GetParam();
   std::vector<float> m1{0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f};
   std::vector<float> m2{0.f, 1.f, 2.f, 3.f};


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
This PR added the native implementation of einsum operator, based and expanded on existing einsum.ts. All the test cases in einsum_test.cc have been passed.

The equation attribute value of einsum op is a string which consists of left hand side (LHS) and optionally right hand side (RHS) separated by '->'. Ex.

- "ij->ji" matrix transpose
- "ii->i" diagonal elements of a square matrix
- "ij->" sum over all elements of a matrix
- "ij,jk->ik" explicit matrix multiplication
- "ij,jk" implicit matrix multiplication
- "ij,jk->" matrix multiplication and sum over all elements
- "ij,jk,kl->il" three matrix multiplication
- "...ij,...jk->...ik" batched matmul with broadcasting
- ",...i->...i" matrix element multiplication with one scalar
- "abc,cd->abc" keep the original abc matrix shape but matmul and sum over along d

LHS consists of a sequence of terms separated by commas. Each term corresponds to an input variable.
Each symbol corresponds to a dimension in the input variable. The symbol can be either a letter, 'a' to 'z' or 'A' to
'Z' or '...' to represent arbitrary dimensions or empty to represent a scalar.

Empty RHS are handleed differently for implicit vs explicit modes.
- Implicit mode - arrow is not in the equation where the equation "ij,jk" equals to "ij,jk->ik" which is actually a matrix multiplication.
- Explicit mode - arrow is in the equation where the equation "ij,jk->" contains two steps, first step is a matrix multiplication just like the implicit mode, and the second step is to sum up the matrix produced by the first step to a scalar.

For all the test cases, pls refer to einsum_test.cc



