### PR TITLE
[ort-build] Pass ORT_EXTRA_INTERFACE_FLAGS to onnxruntime_session

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1231,7 +1231,7 @@ function(onnxruntime_set_compile_flags target_name)
       target_compile_definitions(${target_name} PRIVATE ${ORT_FLAG})
     endforeach()
 
-    if("${target_name}" STREQUAL "onnxruntime")
+    if(("${target_name}" STREQUAL "onnxruntime") OR ("${target_name}" STREQUAL "onnxruntime_session"))
         foreach(ORT_EXTRA_FLAG ${ORT_EXTRA_INTERFACE_FLAGS})
           target_compile_definitions(${target_name} PRIVATE ${ORT_EXTRA_FLAG})
         endforeach()


### PR DESCRIPTION
### Description
The onnxruntime v1.21.0 merge broke the 'generic-interface' code. PR https://github.com/microsoft/onnxruntime/pull/23530 cleaned-up the implementation but made a change: it only adds the ORT_EXTRA_INTERFACE_FLAGS preprocessor definitions to the onnxruntime target. But the important part of registration - [onnxruntime/core/session/provider_registration.cc](https://github.com/microsoft/win-onnxruntime/blob/e46c0d86b9cd15fce1dd6d53fdf03a22edce1ff7/onnxruntime/core/session/provider_registration.cc) - isn't compiled by the onnxruntime target, it's compiled by the onnxruntime_session target, which is linked into onnxruntime. This means that the registration doesn't get passed the flags to enable EP 'awareness' and registration fails.

This PR is the most pragmatic fix I can make; I'm not very familiar with the OnnxRuntime build - please let me know if there's a better way to fix this. This is a local fix to unblock Windows development - this should probably be fixed in main, too.

Motivation and Context
QNN EP registration fails in onnxruntime.dll binaries compiled with the --enable_generic_interface parameter.



