### PR TITLE
[web] allow NPM tests to run nodejs binding for webgpu

### DIFF
--- a/js/web/script/test-runner-cli-args.ts
+++ b/js/web/script/test-runner-cli-args.ts
@@ -405,7 +405,7 @@ export function parseTestRunnerCliArgs(cmdlineArgs: string[]): TestRunnerCliArgs
   //       and ChromeCanary is not in CI.
 
   const defaultBrowserBackends = ['webgl', 'webgpu', 'wasm' /*, 'webnn'*/];
-  const nodejsBackends = ['cpu', 'wasm'];
+  const nodejsBackends = ['cpu', 'wasm', 'webgpu'];
   const backendArgs = args.backend || args.b;
   const backend =
     typeof backendArgs !== 'string'

--- a/js/web/test/test-main.ts
+++ b/js/web/test/test-main.ts
@@ -13,7 +13,16 @@ import { Logger } from '../lib/onnxjs/instrument';
 
 import { Test } from './test-types';
 
-if (ORT_WEB_TEST_CONFIG.model.some((testGroup) => testGroup.tests.some((test) => test.backend === 'cpu'))) {
+if (
+  // when NPM test is launched with `-e=node` and (`-b=cpu` or `-b=webgpu`), load ONNXRuntime Node.js binding.
+  platform.name === 'Node.js' &&
+  (ORT_WEB_TEST_CONFIG.model.some((testGroup) =>
+    testGroup.tests.some((test) => test.backend === 'cpu' || test.backend === 'webgpu'),
+  ) ||
+    ORT_WEB_TEST_CONFIG.op.some((testGroup) =>
+      testGroup.tests.some((test) => test.backend === 'cpu' || test.backend === 'webgpu'),
+    ))
+) {
   // require onnxruntime-node
   require('../../node');
 }


### PR DESCRIPTION
### Description

This change allows NPM tests to run the nodejs binding for webgpu. This helps to debug test failures much easier because WebAssembly is generally very difficult to debug.

Steps to debug:

0. build
   - {ORT_ROOT}> build --config Debug --use_webgpu --build_nodejs
   - {ORT_ROOT}\js\web> npm ci
   - {ORT_ROOT}\js\web> npm run pull:wasm
2. run `npm test -- <args> -b=webgpu -e=node` once. ( this command generates necessary .js files and `testdata-config.json`.)
3. use native debugger to debug:
   ```
   C:\Program Files\nodejs\node.exe {ORT_ROOT}\js\node_modules\mocha\bin\_mocha --timeout 999999 --colors -r {ORT_ROOT}\js/web/dist/ort.node.min.js {ORT_ROOT}\js/web/test/test-main   
   ```


