### PR TITLE
Remove restrictions for ceil() in AveragePool

### DIFF
--- a/js/web/lib/onnxjs/backends/webgl/ops/pool.ts
+++ b/js/web/lib/onnxjs/backends/webgl/ops/pool.ts
@@ -47,11 +47,6 @@ export const parseAveragePoolAttributes: OperatorInitialization<AveragePoolAttri
   const strides = node.attributes.getInts('strides', []);
   const pads = node.attributes.getInts('pads', []);
 
-  // TODO: support attribute 'ceil_mode'
-  if (ceilMode !== 0) {
-    throw new Error('using ceil() in shape computation is not yet supported for AveragePool');
-  }
-
   return createAttributeWithCacheKey({ autoPad, ceilMode, countIncludePad, kernelShape, strides, pads });
 };
 

--- a/js/web/lib/wasm/jsep/webgpu/ops/pool.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/pool.ts
@@ -391,10 +391,6 @@ export const parseAveragePoolAttributes = (attributes: Record<string, unknown>):
   const countIncludePad = (attributes.count_include_pad as number) === 0 ? false : true;
 
   const attr = parsePoolCommonAttributes(attributes);
-  // TODO: support attribute 'ceil_mode'
-  if (attr.ceilMode !== 0) {
-    throw new Error('using ceil() in shape computation is not yet supported for AveragePool');
-  }
   const averagePoolAttributes = { countIncludePad, ...attr, cacheKey: '' };
   return { ...averagePoolAttributes, cacheKey: createAveragePoolShaderKeyFromAttributes(averagePoolAttributes) };
 };


### PR DESCRIPTION
### Description
This is a follow-up to #24270 , which seems to wrap up the work. Thanks @prathikr and @fs-eire !

This merely removes the remaining restrictions, allowing the implementation from #24270 to be used.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fixes #21206
