### PR TITLE
[CPU] Add 8bit support to matmulnbits quantizer 

### DIFF
--- a/onnxruntime/core/mlas/inc/mlas_q4.h
+++ b/onnxruntime/core/mlas/inc/mlas_q4.h
@@ -266,7 +266,7 @@ MlasBlockwiseQuantizedShape(
 /**
  * @brief Compute the sizes of the quantized data and quantization parameter buffers.
  *
- * @param qbits                             The bit width of each quantized value.
+ * @tparam qbits                            The bit width of each quantized value.
  * @param block_size                        The number of quantized values in a block.
  * @param columnwise                        Whether a block contains values from a matrix column (true) or row (false).
  * @param rows                              Number of matrix rows.
@@ -277,9 +277,9 @@ MlasBlockwiseQuantizedShape(
  *
  * If the qbits or block_size values are unsupported the output sizes will be zero.
  */
+template <int qbits>
 void MLASCALL
 MlasBlockwiseQuantizedBufferSizes(
-    int qbits,
     int block_size,
     bool columnwise,
     int rows,

--- a/onnxruntime/core/mlas/lib/q4_dq.cpp
+++ b/onnxruntime/core/mlas/lib/q4_dq.cpp
@@ -387,12 +387,13 @@ range2scale(float min, float max, ScaleT& scale)
 
 
 /**
- * @brief Blockwise quantization methods
+ * @brief Blockwise quantization methods. Source is row major. Dest, scale and zp are column major.
+ *        Always quantize to unsigned int.
  * @tparam ElementT       source data type, e.g. fp32/fp16
  * @tparam block_size     number of elemenets quantized together
  * @tparam qbits          number of bits in each quantized element
- * @tparam Columnwise     true:  elements in a block come from one single column
- *                        false: elements in a block come from one single row
+ * @tparam Columnwise     true:  quantize along src column, pack along src column.
+ *                        false: quantize along src row, pack along src column.
  */
 template <
     typename ElementT,
@@ -402,7 +403,7 @@ template <
 struct BlockwiseQuantizer {
     // To support other qbits, need to add bit packing code for
     // storing to dst and zero points
-    static_assert(qbits == 4 || qbits == 8, "Only 4b and 8b block quantization is supported!");
+    static_assert(qbits == 2 || qbits == 4 || qbits == 8, "Only 2b, 4b and 8b block quantization is supported!");
 
     using QuantBlk = std::conditional_t<Columnwise, Shape2D<block_size, 1>, Shape2D<1, block_size>>;
     using ThreadBlk = Shape2D<QuantBlk::kRow * BitsTraits<qbits, false>::kPackSize, QuantBlk::kColumn>;
@@ -422,15 +423,9 @@ struct BlockwiseQuantizer {
         int meta_cols;
         quantizeMetaShape(rows, columns, meta_rows, meta_cols);
 
-        if constexpr (Columnwise) {
-            // quantized matrix is stored in column major, packed by column
-            q_rows = (meta_rows * QuantBlk::kRow * qbits + 7) / 8;
-            q_cols = meta_cols * QuantBlk::kColumn;
-        } else {
-            // quantized matrix is stored in row major, packed by row
-            q_rows = meta_rows * QuantBlk::kRow;
-            q_cols = (meta_cols * QuantBlk::kColumn * qbits + 7) / 8;
-        }
+        // quantized matrix is stored in column major, packed by column
+        q_rows = (meta_rows * QuantBlk::kRow * qbits + 7) / 8;
+        q_cols = meta_cols * QuantBlk::kColumn;
     }
 
     static MLAS_FORCEINLINE void quantizedBufferSizes(
@@ -447,17 +442,13 @@ struct BlockwiseQuantizer {
 
         if (zero_point_bytes) {
             // this works for qbits == 4 or 8 but may need to be updated for other qbits values
-            if constexpr (Columnwise) {
-                *zero_point_bytes = ((meta_rows * qbits + 7) / 8) * meta_cols;
-            } else {
-                *zero_point_bytes = ((meta_cols * qbits + 7) / 8) * meta_rows;
-            }
+            *zero_point_bytes = ((meta_rows * qbits + 7) / 8) * meta_cols;
         }
     }
 
     /**
      * @brief Quantized a Matrix shape [rows, columns], resulting quantized
-     *        and packed data are stored in column major (transposed)
+     *        and packed data are stored in column major (transposed).
      * @param[out] dst           pointer to the quantized weights, column major: [columns, rows]
      * @param[out] scale         pointer to the scales, column major: [columns/QuantBlk::kColumn, rows/QuantBlk::kRow]
      * @param[out] zero_points   pointer to the zero points, same shape as scale
@@ -485,12 +476,12 @@ struct BlockwiseQuantizer {
 
         int q_rows, q_cols;
         quantizedShape(rows, columns, q_rows, q_cols);
+        constexpr int kPackSize = BitsTraits<qbits, false>::kPackSize;
 
         MlasTryBatchParallel(
             thread_pool, total_thrd_blks,
             [&](ptrdiff_t block_idx) {
-                uint8_t zp_bytes[BitsTraits<qbits, false>::kPackSize];
-                std::fill_n(zp_bytes, BitsTraits<qbits, false>::kPackSize, (uint8_t)8);
+                uint8_t zp_bytes[kPackSize] = {(uint8_t)BitsTraits<qbits, false>::kMid}, vi[kPackSize] = {0};
 
                 const int32_t r_blk_idx = static_cast<int32_t>(block_idx / thrd_col_blks);
                 const int32_t c_blk_idx = static_cast<int32_t>(block_idx % thrd_col_blks);
@@ -505,7 +496,7 @@ struct BlockwiseQuantizer {
                 const int meta_col = c / QuantBlk::kColumn;
 
                 // compute scale and zero point
-                for (int kpack = 0; kpack < BitsTraits<qbits, false>::kPackSize; kpack++) {
+                for (int kpack = 0; kpack < kPackSize; kpack++) {
 
                     // scan a single block to extract range [min, max]
                     float min = std::numeric_limits<float>::max();
@@ -531,40 +522,44 @@ struct BlockwiseQuantizer {
                     }
                 }
 
-                // !! 4b specific code as we need to pack 2 4b numbers into one byte
                 if (zero_points != nullptr) {
-                    const int32_t meta_idx = meta_col * ((row_blks + 1) / 2) + meta_row / 2;
-                    zero_points[meta_idx] = (zp_bytes[0] & 0xf) | (zp_bytes[1] << 4);
+                    const int32_t meta_idx = meta_col * ((row_blks + kPackSize - 1) / kPackSize) + meta_row / kPackSize;
+                    if constexpr (qbits == 8) {
+                        zero_points[meta_idx] = zp_bytes[0];
+                    } else if constexpr (qbits == 4) {
+                        zero_points[meta_idx] = (zp_bytes[0] & 0xf) | (zp_bytes[1] << 4);
+                    } else if constexpr (qbits == 2) {
+                        zero_points[meta_idx] = (zp_bytes[0] & 0x3) | (zp_bytes[1] << 2) | (zp_bytes[2] << 4) | (zp_bytes[3] << 6);
+                    } else {
+                        MLAS_THROW_EX(std::runtime_error, "Unsupported qbits");
+                    }
                 }
 
                 for (int32_t j = c; j < c_end; ++j) {
                     const int32_t meta_c = j / QuantBlk::kColumn;
-                    for (int32_t i = r; i < r_end; i += 2) {
-                        const int32_t meta_r = i / QuantBlk::kRow;
-                        const float scale = static_cast<float>(scales[meta_c * row_blks + meta_r]);
-                        const float reciprocal_scale = scale ? 1.0f / scale : 0.0f;
-                        const int8_t zp = zp_bytes[meta_r & 1];
-                        const int8_t zp1 = zp_bytes[((i + 1) / QuantBlk::kRow) & 1];
+                    for (int32_t i = r; i < r_end; i += kPackSize) {
+                        for (int l = 0; l < kPackSize; l++) {
+                            if (i + l < r_end) {
+                                const int32_t meta_r = (i + l) / QuantBlk::kRow;
+                                const float scale = static_cast<float>(scales[meta_c * row_blks + meta_r]);
+                                const float reciprocal_scale = scale ? 1.0f / scale : 0.0f;
+                                const int8_t zp = zp_bytes[meta_r % kPackSize];
 
-                        const float v0 = static_cast<float>(src[i * leadingDimension + j]);
-                        const uint8_t vi0 = (uint8_t)std::clamp(roundf(v0 * reciprocal_scale + zp),
-                                                                0.0f, BitsTraits<qbits, false>::kMaxFp);
-
-                        uint8_t vi1 = (uint8_t)zp;
-                        if (i + 1 < r_end) {
-                            float reciprocal_scale1 = reciprocal_scale;
-                            if constexpr (QuantBlk::kRow == 1) {
-                                const float scale1 =
-                                    static_cast<float>(scales[meta_c * row_blks + meta_r + 1]);
-                                reciprocal_scale1 = scale1 ? 1.0f / scale1 : 0.0f;
+                                const float v = static_cast<float>(src[(i + l) * leadingDimension + j]);
+                                vi[l] = (uint8_t)std::clamp(roundf(v * reciprocal_scale + zp),
+                                                            0.0f, BitsTraits<qbits, false>::kMaxFp);
                             }
-                            const float v1 = static_cast<float>(src[(i + 1) * leadingDimension + j]);
-                            vi1 = (uint8_t)std::clamp(roundf(v1 * reciprocal_scale1 + zp1), 0.0f,
-                                                      BitsTraits<qbits, false>::kMaxFp);
                         }
 
-                        // !! 4b specific code
-                        dst[j * q_rows + i / 2] = (vi0 & 0xf) | (vi1 << 4);
+                        if constexpr (qbits == 8) {
+                            dst[j * q_rows + i / kPackSize] = vi[0];
+                        } else if constexpr (qbits == 4) {
+                            dst[j * q_rows + i / kPackSize] = (vi[0] & 0xf) | (vi[1] << 4);
+                        } else if constexpr (qbits == 2) {
+                            dst[j * q_rows + i / kPackSize] = (vi[0] & 0x3) | (vi[1] << 2) | (vi[2] << 4) | (vi[3] << 6);
+                        } else {
+                            MLAS_THROW_EX(std::runtime_error, "Unsupported qbits");
+                        }
                     }
                 }
             });

--- a/onnxruntime/core/mlas/lib/q4_dq.cpp
+++ b/onnxruntime/core/mlas/lib/q4_dq.cpp
@@ -488,7 +488,9 @@ struct BlockwiseQuantizer {
         MlasTryBatchParallel(
             thread_pool, total_thrd_blks,
             [&](ptrdiff_t block_idx) {
-                uint8_t zp_bytes[kPackSize] = {(uint8_t)BitsTraits<qbits, false>::kMid}, vi[kPackSize] = {0};
+                uint8_t zp_bytes[kPackSize], vi[kPackSize];
+                std::fill_n(zp_bytes, kPackSize, (uint8_t)BitsTraits<qbits, false>::kMid);
+                std::fill_n(vi, kPackSize, 0);
 
                 const int32_t r_blk_idx = static_cast<int32_t>(block_idx / thrd_col_blks);
                 const int32_t c_blk_idx = static_cast<int32_t>(block_idx % thrd_col_blks);

--- a/onnxruntime/core/mlas/lib/q4_dq.cpp
+++ b/onnxruntime/core/mlas/lib/q4_dq.cpp
@@ -328,7 +328,7 @@ struct BitsTraits {
     static constexpr float halfRange = static_cast<float>(kMid - kMin);
 
     // number of qbit elements to pack into whole bytes
-    static constexpr int kPackSize = (qbits == 8) ? 1 : (qbits == 4) ? 2 : (qbits == 2) ? 4 : 0;
+    static constexpr int kPackSize = (qbits == 8) ? 1 : ((qbits == 4) ? 2 : ((qbits == 2) ? 4 : 0));
     static_assert(kPackSize != 0, "Packing to whole bytes not supported for this qbits!");
 };
 
@@ -634,7 +634,6 @@ struct BlockwiseQuantizer {
                         const int vi = GetElem(vi_pair, i % kPackSize);
                         const float v = (vi - zp) * scale;
                         dst[j * rows + i] = ElementT(v);
-
                     }
                 }
             });

--- a/onnxruntime/core/mlas/lib/q4_dq.cpp
+++ b/onnxruntime/core/mlas/lib/q4_dq.cpp
@@ -387,6 +387,7 @@ range2scale(float min, float max, ScaleT& scale)
 
 
 /**
+ * TODO(fajin): use int4/8 for symmetric quantization so the (vq - zp) operation in MatMulNBits can be saved.
  * @brief Blockwise quantization methods. Source is row major. Dest, scale and zp are column major.
  *        Always quantize to unsigned int.
  * @tparam ElementT       source data type, e.g. fp32/fp16

--- a/onnxruntime/core/mlas/lib/q4_dq.cpp
+++ b/onnxruntime/core/mlas/lib/q4_dq.cpp
@@ -483,11 +483,11 @@ struct BlockwiseQuantizer {
 
         int q_rows, q_cols;
         quantizedShape(rows, columns, q_rows, q_cols);
-        constexpr int kPackSize = BitsTraits<qbits, false>::kPackSize;
 
         MlasTryBatchParallel(
             thread_pool, total_thrd_blks,
             [&](ptrdiff_t block_idx) {
+                constexpr int kPackSize = BitsTraits<qbits, false>::kPackSize;
                 uint8_t zp_bytes[kPackSize], vi[kPackSize];
                 std::fill_n(zp_bytes, kPackSize, (uint8_t)BitsTraits<qbits, false>::kMid);
                 std::fill_n(vi, kPackSize, 0);
@@ -551,7 +551,7 @@ struct BlockwiseQuantizer {
                             const int32_t meta_r = (i + l) / QuantBlk::kRow;
                             const float scale = static_cast<float>(scales[meta_c * row_blks + meta_r]);
                             const float reciprocal_scale = scale ? 1.0f / scale : 0.0f;
-                            const int8_t zp = zp_bytes[meta_r % kPackSize];
+                            const int32_t zp = zp_bytes[meta_r % kPackSize];
 
                             const float v = static_cast<float>(src[(i + l) * leadingDimension + j]);
                             vi[l] = (uint8_t)std::clamp(roundf(v * reciprocal_scale + zp),

--- a/onnxruntime/python/onnxruntime_pybind_quant.cc
+++ b/onnxruntime/python/onnxruntime_pybind_quant.cc
@@ -34,8 +34,8 @@ namespace python {
 namespace py = pybind11;
 using namespace onnxruntime;
 
-template <typename T>
-void QuantizeMatMul4BitsBlockwise(
+template <typename T, int qbits>
+void QuantizeMatMulNBitsBlockwise(
     py::array_t<uint8_t> dst,          // shape: [ N, block_per_K, block_blob_size ]
     py::array_t<T> src,                // shape: [K, N]
     py::array_t<T> scale,              // shape: [N, block_per_K]
@@ -53,7 +53,7 @@ void QuantizeMatMul4BitsBlockwise(
   py::buffer_info scale_buf = scale.request();
   py::buffer_info zp_buf = zero_points.request();
 
-  MlasQuantizeBlockwise<T, 4>(
+  MlasQuantizeBlockwise<T, qbits>(
       reinterpret_cast<uint8_t*>(dst_buf.ptr),
       reinterpret_cast<T*>(scale_buf.ptr),
       is_symmetric ? nullptr : reinterpret_cast<uint8_t*>(zp_buf.ptr),
@@ -126,8 +126,10 @@ void QuantizeMatMulBnb4Blockwise(
 }
 
 void CreateQuantPybindModule(py::module& m) {
-  m.def("quantize_matmul_4bits", &QuantizeMatMul4BitsBlockwise<float>);
-  m.def("quantize_matmul_4bits", &QuantizeMatMul4BitsBlockwise<MLFloat16>);
+  m.def("quantize_matmul_4bits", &QuantizeMatMulNBitsBlockwise<float, 4>);
+  m.def("quantize_matmul_4bits", &QuantizeMatMulNBitsBlockwise<MLFloat16, 4>);
+  m.def("quantize_matmul_8bits", &QuantizeMatMulNBitsBlockwise<float, 8>);
+  m.def("quantize_matmul_8bits", &QuantizeMatMulNBitsBlockwise<MLFloat16, 8>);
   m.def("quantize_matmul_bnb4", &QuantizeMatMulBnb4Blockwise<float>);
   m.def("quantize_matmul_bnb4", &QuantizeMatMulBnb4Blockwise<MLFloat16>);
   m.def("quantize_qdq_matmul_4bits", &QuantizeQDQMatMul4BitsBlockwise<float>);

--- a/onnxruntime/python/tools/quantization/matmul_4bits_quantizer.py
+++ b/onnxruntime/python/tools/quantization/matmul_4bits_quantizer.py
@@ -18,7 +18,7 @@ import onnx
 from onnx.onnx_pb import GraphProto, ModelProto, NodeProto, TensorProto
 from packaging import version
 
-from onnxruntime.capi._pybind_state import quantize_matmul_4bits, quantize_qdq_matmul_4bits
+from onnxruntime.capi._pybind_state import quantize_matmul_4bits, quantize_qdq_matmul_4bits, quantize_matmul_8bits
 
 from .calibrate import CalibrationDataReader
 from .onnx_model import ONNXModel

--- a/onnxruntime/python/tools/quantization/matmul_4bits_quantizer.py
+++ b/onnxruntime/python/tools/quantization/matmul_4bits_quantizer.py
@@ -191,6 +191,7 @@ class DefaultWeightOnlyQuantConfig(WeightOnlyQuantConfig):
         quant_format=QuantFormat.QOperator,
         op_types_to_quantize: tuple[str, ...] | None = None,
         quant_axes: tuple[tuple[str, int], ...] | None = None,
+        bits: int = 4,
     ):
         """
         This is a class for weight only affine quantization configuration.
@@ -221,7 +222,7 @@ class DefaultWeightOnlyQuantConfig(WeightOnlyQuantConfig):
         )
         self.block_size = block_size
         self.is_symmetric = is_symmetric
-        self.bits = 4
+        self.bits = bits
         self.accuracy_level = accuracy_level
 
 
@@ -721,9 +722,11 @@ class DefaultWeightOnlyQuantizer:
     def __init__(self, config: DefaultWeightOnlyQuantConfig):
         self.config = config
 
-    def int4_block_quant(self, fp32weight: npt.ArrayLike) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-        """4b quantize fp32 weight to int4 using C++ kernels."""
+    def qbits_block_quant(self, fp32weight: npt.ArrayLike) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """4b/8b quantize fp32 weight to int4 using C++ kernels."""
 
+        qbits = self.config.bits
+        kPack = 8 // qbits
         if len(fp32weight.shape) != 2:
             raise ValueError("Current int4 block quantization only supports 2D tensors!")
         rows, cols = fp32weight.shape
@@ -732,7 +735,7 @@ class DefaultWeightOnlyQuantizer:
         k_blocks = (rows + block_size - 1) // block_size
 
         if self.config.quant_format == QuantFormat.QOperator:
-            blob_size = block_size // 2
+            blob_size = (block_size + kPack - 1) // kPack
             padded_rows = k_blocks * block_size
             pad_len = padded_rows - rows
             if pad_len > 0:
@@ -740,12 +743,18 @@ class DefaultWeightOnlyQuantizer:
 
             # block wise quantization, each block comes from a single column
             packed = np.zeros((cols, k_blocks, blob_size), dtype="uint8")
-            zero_point = np.zeros(cols * ((k_blocks + 1) // 2), dtype="uint8")
+            zero_point = np.zeros(cols * ((k_blocks + kPack - 1) // kPack), dtype="uint8")
             scales = np.zeros((cols * k_blocks), dtype=fp32weight.dtype)
-            quantize_matmul_4bits(
-                packed, fp32weight, scales, zero_point, block_size, cols, rows, self.config.is_symmetric
-            )
+            if qbits == 8:
+                quantize_matmul_8bits(
+                    packed, fp32weight, scales, zero_point, block_size, cols, rows, self.config.is_symmetric
+                )
+            else:
+                quantize_matmul_4bits(
+                    packed, fp32weight, scales, zero_point, block_size, cols, rows, self.config.is_symmetric
+                )
         else:
+            # QDQ format only support 4 bits quantization
             packed = np.zeros((rows * cols + 1) // 2, dtype="uint8")
             zero_point = np.zeros((cols * k_blocks + 1) // 2, dtype="uint8")
             scales = np.zeros((k_blocks, cols), dtype=fp32weight.dtype)
@@ -757,10 +766,14 @@ class DefaultWeightOnlyQuantizer:
 
     def quantize_matmul(self, node: NodeProto, graph_stack: list[GraphProto]) -> list[NodeProto]:
         """
-        Quantize weight B of MatMul node to int4.
+        Quantize weight B of MatMul node to int4 or int8.
         Currently only support 2D constant matrix and axis 0 blockwise quantization.
         """
-        qtype = TensorProto.INT4 if self.config.is_symmetric else TensorProto.UINT4
+        bits = self.config.bits
+        if bits == 8:
+            qtype = TensorProto.INT8 if self.config.is_symmetric else TensorProto.UINT8
+        else:
+            qtype = TensorProto.INT4 if self.config.is_symmetric else TensorProto.UINT4
         input_b = node.input[1]
         b_tensor, b_graph = get_initializer(input_b, graph_stack)
         if b_tensor is None:
@@ -772,13 +785,17 @@ class DefaultWeightOnlyQuantizer:
             logger.info("MatMul weight is not 2D. Skip to quantize")
             return [node]  # can only process 2-D matrix
 
-        packed, scales, zero_points = self.int4_block_quant(b_ndarray)
+        packed, scales, zero_points = self.qbits_block_quant(b_ndarray)
 
         if self.config.quant_format == QuantFormat.QOperator:
-            b_quant = onnx.numpy_helper.from_array(packed, b_tensor.name + "_Q4")
+            b_quant = onnx.numpy_helper.from_array(packed, b_tensor.name + f"_Q{bits}")
             scales_tensor = onnx.numpy_helper.from_array(scales, b_tensor.name + "_scales")
         else:
-            b_quant = onnx.helper.make_tensor(b_tensor.name + "_DQ_Q4", qtype, b_ndarray.shape, packed.tobytes(), True)
+            b_quant = onnx.helper.make_tensor(b_tensor.name + f"_DQ_Q{bits}",
+                                              qtype,
+                                              b_ndarray.shape,
+                                              packed.tobytes(),
+                                              True)
             scales_tensor = onnx.numpy_helper.from_array(scales, b_tensor.name + "_DQ_scales")
 
         for input in b_graph.input:
@@ -800,21 +817,21 @@ class DefaultWeightOnlyQuantizer:
             rows, cols = b_ndarray.shape
             kwargs["K"] = rows
             kwargs["N"] = cols
-            kwargs["bits"] = 4
+            kwargs["bits"] = bits
             kwargs["block_size"] = self.config.block_size
             if self.config.accuracy_level is not None:
                 kwargs["accuracy_level"] = self.config.accuracy_level
 
-            matmul_q4_node = onnx.helper.make_node(
+            matmul_qbit_node = onnx.helper.make_node(
                 "MatMulNBits",
                 inputs=input_names,
                 outputs=[node.output[0]],
-                name=node.name + "_Q4" if node.name else "",
+                name=node.name + f"_Q{bits}" if node.name else "",
                 domain="com.microsoft",
                 **kwargs,
             )
 
-            output_nodes.append(matmul_q4_node)
+            output_nodes.append(matmul_qbit_node)
         else:
             dq_input_names = [b_quant.name, scales_tensor.name]
             dq_output_names = [b_quant.name + "_output"]
@@ -831,14 +848,14 @@ class DefaultWeightOnlyQuantizer:
                 "DequantizeLinear",
                 inputs=dq_input_names,
                 outputs=dq_output_names,
-                name=node.name + "_DQ_Q4" if node.name else "",
+                name=node.name + f"_DQ_Q{bits}" if node.name else "",
                 **dq_kwargs,
             )
             matmul_node = onnx.helper.make_node(
                 "MatMul",
                 inputs=matmul_input_names,
                 outputs=matmul_output_names,
-                name=node.name + "_matmul_Q4" if node.name else "",
+                name=node.name + f"_matmul_Q{bits}" if node.name else "",
             )
             output_nodes.extend([dq_node, matmul_node])
 
@@ -1010,16 +1027,23 @@ class DefaultWeightOnlyQuantizer:
         """
         logger.info(f"start to quantize {node.name} ...")
 
+        bits = self.config.bits
         if node.op_type == "MatMul":
+            if bits == 8 and self.config.quant_format == QuantFormat.QDQ:
+                logger.error("MatMul only supports QOperator format for 8 bits quantization.")
+                return [node]
             results = self.quantize_matmul(node, graph_stack)
         elif node.op_type == "Gather":
+            if self.config.bits != 4:
+                logger.error("Gather only supports 4 bits quantization.")
+                return [node]
+
             results = self.quantize_gather(node, graph_stack)
         else:
             logger.error(f"Unsupported operator {node.op_type} for weight only quantization. Skip quantization.")
-            results = [node]
+            return [node]
 
-        logger.info(f"complete quantization of {node.name} ...")
-
+        logger.info(f"complete quantization of {node.name} with {self.config.bits} bits ...")
         return results
 
 
@@ -1446,6 +1470,7 @@ if __name__ == "__main__":
             quant_format=quant_format,
             op_types_to_quantize=op_types_to_quantize,
             quant_axes=quant_axes,
+            bits=args.bits,
         )
     elif args.quant_method == "rtn":
         quant_config = RTNWeightOnlyQuantConfig(op_types_to_quantize=op_types_to_quantize)

--- a/onnxruntime/test/contrib_ops/matmul_4bits_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_4bits_test.cc
@@ -127,8 +127,8 @@ void RunTest(const TestOptions& opts,
 
   size_t q_data_size_in_bytes, q_scale_size, q_zp_size_in_bytes;
   MlasBlockwiseQuantizedBufferSizes<QBits>(static_cast<int>(opts.block_size), /* columnwise */ true,
-                                    static_cast<int>(K), static_cast<int>(N),
-                                    q_data_size_in_bytes, q_scale_size, &q_zp_size_in_bytes);
+                                           static_cast<int>(K), static_cast<int>(N),
+                                           q_data_size_in_bytes, q_scale_size, &q_zp_size_in_bytes);
 
   std::vector<uint8_t> input1_vals(q_data_size_in_bytes);
   std::vector<float> scales(q_scale_size);

--- a/onnxruntime/test/contrib_ops/matmul_4bits_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_4bits_test.cc
@@ -126,7 +126,7 @@ void RunTest(const TestOptions& opts,
                                             q_rows, q_cols);
 
   size_t q_data_size_in_bytes, q_scale_size, q_zp_size_in_bytes;
-  MlasBlockwiseQuantizedBufferSizes(QBits, static_cast<int>(opts.block_size), /* columnwise */ true,
+  MlasBlockwiseQuantizedBufferSizes<QBits>(static_cast<int>(opts.block_size), /* columnwise */ true,
                                     static_cast<int>(K), static_cast<int>(N),
                                     q_data_size_in_bytes, q_scale_size, &q_zp_size_in_bytes);
 

--- a/onnxruntime/test/mlas/bench/bench_qnbitgemm.cpp
+++ b/onnxruntime/test/mlas/bench/bench_qnbitgemm.cpp
@@ -31,8 +31,8 @@ void RunQNBitGemmBenchmark(size_t BlkLen,
   }
 
   size_t QuantBDataSizeInBytes, QuantBScaleSize, QuantBZeroPointSizeInBytes;
-  MlasBlockwiseQuantizedBufferSizes(
-      BlkBitWidth, static_cast<int>(BlkLen), /* columnwise */ true,
+  MlasBlockwiseQuantizedBufferSizes<BlkBitWidth>(
+      static_cast<int>(BlkLen), /* columnwise */ true,
       static_cast<int>(K), static_cast<int>(N),
       QuantBDataSizeInBytes, QuantBScaleSize, &QuantBZeroPointSizeInBytes);
 

--- a/onnxruntime/test/mlas/unittest/test_blockq4.cpp
+++ b/onnxruntime/test/mlas/unittest/test_blockq4.cpp
@@ -53,7 +53,7 @@ class MlasBlockwiseQdqTest : public MlasTestBase {
     MlasBlockwiseQuantizedShape<float, 4>(block_size, columnwise, rows, columns, q_rows, q_cols);
 
     size_t q_data_size_in_bytes, q_scale_size, q_zp_size_in_bytes;
-    MlasBlockwiseQuantizedBufferSizes(4, block_size, columnwise, rows, columns,
+    MlasBlockwiseQuantizedBufferSizes<4>(block_size, columnwise, rows, columns,
                                       q_data_size_in_bytes, q_scale_size, &q_zp_size_in_bytes);
 
     uint8_t* elements = InputElements.GetBuffer(q_data_size_in_bytes, true);

--- a/onnxruntime/test/mlas/unittest/test_blockq4.cpp
+++ b/onnxruntime/test/mlas/unittest/test_blockq4.cpp
@@ -51,8 +51,10 @@ class MlasBlockwiseQdqTest : public MlasTestBase {
   MatrixGuardBuffer<uint8_t> QDQTransposedOutputElements;
   MatrixGuardBuffer<T> QDQTransposedOutputScales;
   MatrixGuardBuffer<uint8_t> QDQTransposedOutputOffsets;
-  constexpr static float err_ = qbits == 8 ? 1e-2f : qbits == 4 ? 6e-2f : 2e-1f;
-  constexpr static float rel_ = qbits == 8 ? 5e-2f : qbits == 4 ? 2e-1f : 5e-1f;
+  constexpr static float err_ = qbits == 8 ? 1e-2f : qbits == 4 ? 6e-2f
+                                                                : 2e-1f;
+  constexpr static float rel_ = qbits == 8 ? 5e-2f : qbits == 4 ? 2e-1f
+                                                                : 5e-1f;
 
   bool FloatEqual(T a, T b, float err = err_, float rel = rel_) {
     float va = static_cast<float>(a);
@@ -83,9 +85,9 @@ class MlasBlockwiseQdqTest : public MlasTestBase {
 
     size_t q_data_size_in_bytes, q_scale_size, q_zp_size_in_bytes;
     MlasBlockwiseQuantizedBufferSizes<qbits>(block_size, columnwise, rows, columns,
-                                      q_data_size_in_bytes, q_scale_size, &q_zp_size_in_bytes);
+                                             q_data_size_in_bytes, q_scale_size, &q_zp_size_in_bytes);
 
-    uint8_t* elements = InputElements.GetBuffer(q_data_size_in_bytes, true); // after quantize
+    uint8_t* elements = InputElements.GetBuffer(q_data_size_in_bytes, true);  // after quantize
     uint8_t* qdq_weights;
     uint8_t* qdq_weights_T;
     if constexpr (qbits == 4) {

--- a/onnxruntime/test/mlas/unittest/test_sqnbitgemm.cpp
+++ b/onnxruntime/test/mlas/unittest/test_sqnbitgemm.cpp
@@ -246,7 +246,7 @@ class MlasSQNBitGemmTest : public MlasTestBase {
     uint8_t* QuantBZeroPoint = nullptr;
     {
       size_t QuantBDataSizeInBytes, QuantBScaleSize, QuantBZeroPointSizeInBytes;
-      MlasBlockwiseQuantizedBufferSizes(BlkBitWidth, BlkLen, /* columnwise */ true,
+      MlasBlockwiseQuantizedBufferSizes<BlkBitWidth>(BlkLen, /* columnwise */ true,
                                         static_cast<int>(K), static_cast<int>(N),
                                         QuantBDataSizeInBytes, QuantBScaleSize, &QuantBZeroPointSizeInBytes);
 

--- a/onnxruntime/test/mlas/unittest/test_sqnbitgemm.cpp
+++ b/onnxruntime/test/mlas/unittest/test_sqnbitgemm.cpp
@@ -247,8 +247,8 @@ class MlasSQNBitGemmTest : public MlasTestBase {
     {
       size_t QuantBDataSizeInBytes, QuantBScaleSize, QuantBZeroPointSizeInBytes;
       MlasBlockwiseQuantizedBufferSizes<BlkBitWidth>(BlkLen, /* columnwise */ true,
-                                        static_cast<int>(K), static_cast<int>(N),
-                                        QuantBDataSizeInBytes, QuantBScaleSize, &QuantBZeroPointSizeInBytes);
+                                                     static_cast<int>(K), static_cast<int>(N),
+                                                     QuantBDataSizeInBytes, QuantBScaleSize, &QuantBZeroPointSizeInBytes);
 
       QuantBData = BufferQuantBData.GetBuffer(QuantBDataSizeInBytes);
       QuantBScale = BufferQuantBScale.GetBuffer(QuantBScaleSize);

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -8090,8 +8090,8 @@ TEST_F(GraphTransformationTests, MatMulNBitsBiasFusion) {
 
       size_t q_data_size_in_bytes, q_scale_size, q_zp_size_in_bytes;
       MlasBlockwiseQuantizedBufferSizes<qbits>(block_size, /* columnwise */ true,
-                                        K, N,
-                                        q_data_size_in_bytes, q_scale_size, &q_zp_size_in_bytes);
+                                               K, N,
+                                               q_data_size_in_bytes, q_scale_size, &q_zp_size_in_bytes);
 
       auto* A = builder.MakeInput<float>(std::vector{M, K}, "A");
 

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -8089,7 +8089,7 @@ TEST_F(GraphTransformationTests, MatMulNBitsBiasFusion) {
                                                 q_rows, q_cols);
 
       size_t q_data_size_in_bytes, q_scale_size, q_zp_size_in_bytes;
-      MlasBlockwiseQuantizedBufferSizes(qbits, block_size, /* columnwise */ true,
+      MlasBlockwiseQuantizedBufferSizes<qbits>(block_size, /* columnwise */ true,
                                         K, N,
                                         q_data_size_in_bytes, q_scale_size, &q_zp_size_in_bytes);
 

--- a/onnxruntime/test/python/quantization/test_op_matmul_4bits.py
+++ b/onnxruntime/test/python/quantization/test_op_matmul_4bits.py
@@ -390,3 +390,4 @@ class TestOpMatMul4Bits(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+    # TODO(fajin): add 8bit quantization test after enabling kenrels


### PR DESCRIPTION
### Description
Add 8bit support to matmulnbits quantizer. matmul_4bits_quantizer now can quantize a const B in a MatMul to 8bits initializer.

### Motivation and Context
MatMul4Bits has accuracy issue for phi-4 model used for foundry local.
The early prototype showed >= 6bits can fix the issue.
To mitigate the issue as soon as possible, add 8bit support to MatMulNBits.


