### PR TITLE
[QNN EP] Add support for int64 shape input of Expand Op

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/expand_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/expand_op_builder.cc
@@ -110,6 +110,12 @@ Status ExpandOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
         FillShapeInputData(shape_data, shape_size, static_cast<float>(1.0));
         break;
       }
+      case QNN_DATATYPE_INT_64: {
+        // QNN-EP doesn't support INT64 shape input.
+        qnn_data_type = QNN_DATATYPE_INT_32;
+        FillShapeInputData(shape_data, shape_size, static_cast<int32_t>(1));
+        break;
+      }
       case QNN_DATATYPE_INT_32: {
         FillShapeInputData(shape_data, shape_size, static_cast<int32_t>(1));
         break;

--- a/onnxruntime/test/providers/qnn/reshape_expand_op_test.cc
+++ b/onnxruntime/test/providers/qnn/reshape_expand_op_test.cc
@@ -268,6 +268,16 @@ TEST_F(QnnHTPBackendTests, Expand_HTP_int32) {
                                      19);  // Opset
 }
 
+// Test that int64 Expand runs on HTP backend.
+TEST_F(QnnHTPBackendTests, Expand_HTP_int64) {
+  RunReshapeExpandTestOnHTP<int64_t>("Expand",
+                                     TestInputDef<int64_t>({1}, false, {1}),
+                                     TestInputDef<int64_t>({3}, true, {1, 2, 3}),
+                                     {},  // Attributes
+                                     ExpectedEPNodeAssignment::All,
+                                     19);  // Opset
+}
+
 // Test QDQ Expand
 TEST_F(QnnHTPBackendTests, Expand_4D) {
   RunQDQReshapeExpandTestOnHTP<uint8_t>("Expand",


### PR DESCRIPTION
### Description
1. Transform INT64 shape of Expand Op to INT32 shape.
2. Add Unit test to check INT64 Shape conversion to INT32 by QNN EP.


### Motivation and Context
QNN doesn't support INT64 shape for Expand Op. This commit delegates the Expand Ops
with INT64 shape on QNN EP. This improves the inference time.


