### PR TITLE
[DML EP] Support in-memory external data TensorProto

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionHelper.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionHelper.cpp
@@ -117,14 +117,17 @@ namespace DmlGraphFusionHelper
         // The tensor may be stored as raw data or in typed fields.
         if (initializer->data_location() == onnx::TensorProto_DataLocation_EXTERNAL)
         {
-            std::basic_string<ORTCHAR_T> external_file_path;
-            onnxruntime::FileOffsetType file_offset;
-            SafeInt<size_t> tensor_byte_size;
-            THROW_IF_NOT_OK(onnxruntime::utils::GetExternalDataInfo(*initializer,  graph.ModelPath(), external_file_path, file_offset, tensor_byte_size));
-            if (external_file_path == onnxruntime::utils::kTensorProtoMemoryAddressTag) {
-                tensorPtr = reinterpret_cast<std::byte*>(file_offset);
-                tensorByteSize = tensor_byte_size;
-            } else {
+            std::basic_string<ORTCHAR_T> externalFilePath;
+            onnxruntime::FileOffsetType fileOffset;
+            SafeInt<size_t> safeTensorByteSize;
+            THROW_IF_NOT_OK(onnxruntime::utils::GetExternalDataInfo(*initializer,  graph.ModelPath(), /*out*/ externalFilePath, /*out*/ fileOffset, /*out*/ safeTensorByteSize));
+            if (externalFilePath == onnxruntime::utils::kTensorProtoMemoryAddressTag)
+            {
+                tensorPtr = reinterpret_cast<std::byte*>(fileOffset);
+                tensorByteSize = safeTensorByteSize;
+            }
+            else
+            {
                 THROW_IF_NOT_OK(onnxruntime::utils::UnpackInitializerData(*initializer, graph.ModelPath(), unpackedExternalTensor));
                 tensorPtr = reinterpret_cast<std::byte*>(unpackedExternalTensor.data());
                 tensorByteSize = unpackedExternalTensor.size();

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionHelper.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionHelper.cpp
@@ -117,9 +117,18 @@ namespace DmlGraphFusionHelper
         // The tensor may be stored as raw data or in typed fields.
         if (initializer->data_location() == onnx::TensorProto_DataLocation_EXTERNAL)
         {
-            THROW_IF_NOT_OK(onnxruntime::utils::UnpackInitializerData(*initializer, graph.ModelPath(), unpackedExternalTensor));
-            tensorPtr = reinterpret_cast<std::byte*>(unpackedExternalTensor.data());
-            tensorByteSize = unpackedExternalTensor.size();
+            std::basic_string<ORTCHAR_T> external_file_path;
+            onnxruntime::FileOffsetType file_offset;
+            SafeInt<size_t> tensor_byte_size;
+            THROW_IF_NOT_OK(onnxruntime::utils::GetExternalDataInfo(*initializer,  graph.ModelPath(), external_file_path, file_offset, tensor_byte_size));
+            if (external_file_path == onnxruntime::utils::kTensorProtoMemoryAddressTag) {
+                tensorPtr = reinterpret_cast<std::byte*>(file_offset);
+                tensorByteSize = tensor_byte_size;
+            } else {
+                THROW_IF_NOT_OK(onnxruntime::utils::UnpackInitializerData(*initializer, graph.ModelPath(), unpackedExternalTensor));
+                tensorPtr = reinterpret_cast<std::byte*>(unpackedExternalTensor.data());
+                tensorByteSize = unpackedExternalTensor.size();
+            }
         }
         else if (initializer->has_raw_data())
         {

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.cpp
@@ -1576,14 +1576,18 @@ namespace Windows::AI::MachineLearning::Adapter
         // The tensor may be stored as raw data or in typed fields.
         if (impl->data_location() == onnx::TensorProto_DataLocation_EXTERNAL)
         {
-            std::basic_string<ORTCHAR_T> external_file_path;
-            onnxruntime::FileOffsetType file_offset;
-            SafeInt<size_t> tensor_byte_size;
-            THROW_IF_NOT_OK(onnxruntime::utils::GetExternalDataInfo(*impl,  modelPath, external_file_path, file_offset, tensor_byte_size));
-            if (external_file_path == onnxruntime::utils::kTensorProtoMemoryAddressTag) {
-                m_dataPtr = reinterpret_cast<std::byte*>(file_offset);
-                m_tensorByteSize = tensor_byte_size;
-            } else {
+            std::basic_string<ORTCHAR_T> externalFilePath;
+            onnxruntime::FileOffsetType fileOffset;
+            SafeInt<size_t> tensorByteSize;
+            SafeInt<size_t> safeTensorByteSize;
+            THROW_IF_NOT_OK(onnxruntime::utils::GetExternalDataInfo(*impl,  modelPath, /*out*/ externalFilePath, /*out*/ fileOffset, /*out*/ safeTensorByteSize));
+            if (externalFilePath == onnxruntime::utils::kTensorProtoMemoryAddressTag)
+            {
+                m_dataPtr = reinterpret_cast<std::byte*>(fileOffset);
+                m_tensorByteSize = safeTensorByteSize;
+            }
+            else
+            {
                 THROW_IF_NOT_OK(onnxruntime::utils::UnpackInitializerData(*impl, modelPath, m_unpackedExternalTensor));
                 m_dataPtr = reinterpret_cast<std::byte*>(m_unpackedExternalTensor.data());
                 m_tensorByteSize = m_unpackedExternalTensor.size();

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.cpp
@@ -1576,9 +1576,18 @@ namespace Windows::AI::MachineLearning::Adapter
         // The tensor may be stored as raw data or in typed fields.
         if (impl->data_location() == onnx::TensorProto_DataLocation_EXTERNAL)
         {
-            THROW_IF_NOT_OK(onnxruntime::utils::UnpackInitializerData(*impl, modelPath, m_unpackedExternalTensor));
-            m_dataPtr = reinterpret_cast<std::byte*>(m_unpackedExternalTensor.data());
-            m_tensorByteSize = m_unpackedExternalTensor.size();
+            std::basic_string<ORTCHAR_T> external_file_path;
+            onnxruntime::FileOffsetType file_offset;
+            SafeInt<size_t> tensor_byte_size;
+            THROW_IF_NOT_OK(onnxruntime::utils::GetExternalDataInfo(*impl,  modelPath, external_file_path, file_offset, tensor_byte_size));
+            if (external_file_path == onnxruntime::utils::kTensorProtoMemoryAddressTag) {
+                m_dataPtr = reinterpret_cast<std::byte*>(file_offset);
+                m_tensorByteSize = tensor_byte_size;
+            } else {
+                THROW_IF_NOT_OK(onnxruntime::utils::UnpackInitializerData(*impl, modelPath, m_unpackedExternalTensor));
+                m_dataPtr = reinterpret_cast<std::byte*>(m_unpackedExternalTensor.data());
+                m_tensorByteSize = m_unpackedExternalTensor.size();
+            }
         }
         else if (impl->has_raw_data())
         {

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.cpp
@@ -1578,7 +1578,6 @@ namespace Windows::AI::MachineLearning::Adapter
         {
             std::basic_string<ORTCHAR_T> externalFilePath;
             onnxruntime::FileOffsetType fileOffset;
-            SafeInt<size_t> tensorByteSize;
             SafeInt<size_t> safeTensorByteSize;
             THROW_IF_NOT_OK(onnxruntime::utils::GetExternalDataInfo(*impl,  modelPath, /*out*/ externalFilePath, /*out*/ fileOffset, /*out*/ safeTensorByteSize));
             if (externalFilePath == onnxruntime::utils::kTensorProtoMemoryAddressTag)


### PR DESCRIPTION
### Description
TensorProto may have external data in existing memory buffer. For those TensorProto, the 'location' field of the external data info is set to a special marker `*/_ORT_MEM_ADDR_/*`, and the 'offset' field contains the address of the memory buffer.

This PR allows DirectML EP to recognize in-memory external data TensorProto and use the address of existing memory buffer containing the external data.

### Motivation and Context
Applications using ModelEditor API may create initializers with existing buffer to save memory, such as WebNN. This fix allows DirectML EP can be used by those applications.

