### PR TITLE
Replace gsl::narrow with narrow in xnnpack code

### DIFF
--- a/onnxruntime/core/providers/xnnpack/math/softmax.cc
+++ b/onnxruntime/core/providers/xnnpack/math/softmax.cc
@@ -160,7 +160,7 @@ Softmax::Softmax(const OpKernelInfo& info) : XnnpackKernel{info} {
   // we have checked it in GetCapability
   const auto* x_shape = input_defs[0]->Shape();
   size_t rank = x_shape->dim_size();
-  axis_ = gsl::narrow<int>(HandleNegativeAxis(axis_, int64_t(rank)));
+  axis_ = narrow<int>(HandleNegativeAxis(axis_, int64_t(rank)));
 
   auto input_shape = utils::GetTensorShapeFromTensorShapeProto(*x_shape);
   int64_t channels = opset_ < 13 ? input_shape.SizeFromDimension(axis_) : input_shape[axis_];

--- a/onnxruntime/core/providers/xnnpack/nn/average_pool.cc
+++ b/onnxruntime/core/providers/xnnpack/nn/average_pool.cc
@@ -19,15 +19,15 @@ Status CreateXnnpackKernel(const PoolAttributes& pool_attrs,
                            struct xnn_operator*& p,
                            const OpQuantParam& quant_param,
                            OpComputeType avgpool_type) {
-  uint32_t input_padding_top = gsl::narrow<uint32_t>(pool_attrs.pads[0]);
-  uint32_t input_padding_left = gsl::narrow<uint32_t>(pool_attrs.pads[1]);
-  uint32_t input_padding_bottom = gsl::narrow<uint32_t>(pool_attrs.pads[2]);
-  uint32_t input_padding_right = gsl::narrow<uint32_t>(pool_attrs.pads[3]);
+  uint32_t input_padding_top = narrow<uint32_t>(pool_attrs.pads[0]);
+  uint32_t input_padding_left = narrow<uint32_t>(pool_attrs.pads[1]);
+  uint32_t input_padding_bottom = narrow<uint32_t>(pool_attrs.pads[2]);
+  uint32_t input_padding_right = narrow<uint32_t>(pool_attrs.pads[3]);
 
-  uint32_t pooling_height = gsl::narrow<uint32_t>(pool_attrs.kernel_shape[0]);
-  uint32_t pooling_width = gsl::narrow<uint32_t>(pool_attrs.kernel_shape[1]);
-  uint32_t stride_height = gsl::narrow<uint32_t>(pool_attrs.strides[0]);
-  uint32_t stride_width = gsl::narrow<uint32_t>(pool_attrs.strides[1]);
+  uint32_t pooling_height = narrow<uint32_t>(pool_attrs.kernel_shape[0]);
+  uint32_t pooling_width = narrow<uint32_t>(pool_attrs.kernel_shape[1]);
+  uint32_t stride_height = narrow<uint32_t>(pool_attrs.strides[0]);
+  uint32_t stride_width = narrow<uint32_t>(pool_attrs.strides[1]);
 
   uint32_t flags = 0;
   if (pool_attrs.auto_pad == AutoPadType::SAME_UPPER) {

--- a/onnxruntime/core/providers/xnnpack/nn/conv_base.cc
+++ b/onnxruntime/core/providers/xnnpack/nn/conv_base.cc
@@ -34,18 +34,18 @@ Status CreateXnnpackKernel(const ConvAttributes& conv_attrs,
   // if this is 1D input, we fake all the height related dims being 1 to make it 2D. so {W} -> {1, W}
   const auto is_1D = kernel_shape.size() == 1;
 
-  const uint32_t kernel_height = is_1D ? 1 : gsl::narrow<uint32_t>(kernel_shape[0]);
-  const uint32_t kernel_width = gsl::narrow<uint32_t>(kernel_shape[is_1D ? 0 : 1]);
+  const uint32_t kernel_height = is_1D ? 1 : narrow<uint32_t>(kernel_shape[0]);
+  const uint32_t kernel_width = narrow<uint32_t>(kernel_shape[is_1D ? 0 : 1]);
 
-  const uint32_t input_padding_top = is_1D ? 0 : gsl::narrow<uint32_t>(conv_attrs.pads[0]);
-  const uint32_t input_padding_left = gsl::narrow<uint32_t>(conv_attrs.pads[is_1D ? 0 : 1]);
-  const uint32_t input_padding_bottom = is_1D ? 0 : gsl::narrow<uint32_t>(conv_attrs.pads[2]);
-  const uint32_t input_padding_right = gsl::narrow<uint32_t>(conv_attrs.pads[is_1D ? 1 : 3]);
+  const uint32_t input_padding_top = is_1D ? 0 : narrow<uint32_t>(conv_attrs.pads[0]);
+  const uint32_t input_padding_left = narrow<uint32_t>(conv_attrs.pads[is_1D ? 0 : 1]);
+  const uint32_t input_padding_bottom = is_1D ? 0 : narrow<uint32_t>(conv_attrs.pads[2]);
+  const uint32_t input_padding_right = narrow<uint32_t>(conv_attrs.pads[is_1D ? 1 : 3]);
 
-  const uint32_t subsampling_height = is_1D ? 1 : gsl::narrow<uint32_t>(conv_attrs.strides[0]);
-  const uint32_t subsampling_width = gsl::narrow<uint32_t>(conv_attrs.strides[is_1D ? 0 : 1]);
-  const uint32_t dilation_height = is_1D ? 1 : gsl::narrow<uint32_t>(conv_attrs.dilations[0]);
-  const uint32_t dilation_width = gsl::narrow<uint32_t>(conv_attrs.dilations[is_1D ? 0 : 1]);
+  const uint32_t subsampling_height = is_1D ? 1 : narrow<uint32_t>(conv_attrs.strides[0]);
+  const uint32_t subsampling_width = narrow<uint32_t>(conv_attrs.strides[is_1D ? 0 : 1]);
+  const uint32_t dilation_height = is_1D ? 1 : narrow<uint32_t>(conv_attrs.dilations[0]);
+  const uint32_t dilation_width = narrow<uint32_t>(conv_attrs.dilations[is_1D ? 0 : 1]);
 
   uint32_t flags = 0;
   if (conv_attrs.auto_pad == AutoPadType::SAME_UPPER) {
@@ -62,9 +62,9 @@ Status CreateXnnpackKernel(const ConvAttributes& conv_attrs,
   // also, in the case of DepthWiseConv, group_count = C, IC is 1 constantly, OC is what DPconv require.
   // So we can unify it with IC and OC.
   // group is either 1 (for regular conv) or C (for depth-wise conv), and hence M % group == 0 so M/group is safe
-  uint32_t group_count = gsl::narrow<uint32_t>(conv_attrs.group);
-  size_t group_input_channels = gsl::narrow<size_t>(C / group_count);   // either C or 1
-  size_t group_output_channels = gsl::narrow<size_t>(M / group_count);  // either M or M/C
+  uint32_t group_count = narrow<uint32_t>(conv_attrs.group);
+  size_t group_input_channels = narrow<size_t>(C / group_count);   // either C or 1
+  size_t group_output_channels = narrow<size_t>(M / group_count);  // either M or M/C
   if (conv_type == OpComputeType::op_compute_type_fp32) {
     auto* B_data = Bias ? Bias->Data<float>() : nullptr;
     auto create_func = is_transpose ? xnn_create_deconvolution2d_nhwc_f32

--- a/onnxruntime/core/providers/xnnpack/nn/max_pool.cc
+++ b/onnxruntime/core/providers/xnnpack/nn/max_pool.cc
@@ -115,17 +115,17 @@ bool MaxPool::IsOnnxNodeSupported(const NodeUnit& node_unit,
 MaxPool::MaxPool(const OpKernelInfo& info)
     : XnnpackKernel(info),
       pool_attrs_{info, "MaxPool", info.node().SinceVersion()} {
-  uint32_t input_padding_top = gsl::narrow<uint32_t>(pool_attrs_.pads[0]);
-  uint32_t input_padding_left = gsl::narrow<uint32_t>(pool_attrs_.pads[1]);
-  uint32_t input_padding_bottom = gsl::narrow<uint32_t>(pool_attrs_.pads[2]);
-  uint32_t input_padding_right = gsl::narrow<uint32_t>(pool_attrs_.pads[3]);
+  uint32_t input_padding_top = narrow<uint32_t>(pool_attrs_.pads[0]);
+  uint32_t input_padding_left = narrow<uint32_t>(pool_attrs_.pads[1]);
+  uint32_t input_padding_bottom = narrow<uint32_t>(pool_attrs_.pads[2]);
+  uint32_t input_padding_right = narrow<uint32_t>(pool_attrs_.pads[3]);
 
-  uint32_t pooling_height = gsl::narrow<uint32_t>(pool_attrs_.kernel_shape[0]);
-  uint32_t pooling_width = gsl::narrow<uint32_t>(pool_attrs_.kernel_shape[1]);
-  uint32_t stride_height = gsl::narrow<uint32_t>(pool_attrs_.strides[0]);
-  uint32_t stride_width = gsl::narrow<uint32_t>(pool_attrs_.strides[1]);
-  uint32_t dilation_height = gsl::narrow<uint32_t>(pool_attrs_.dilations[0]);
-  uint32_t dilation_width = gsl::narrow<uint32_t>(pool_attrs_.dilations[1]);
+  uint32_t pooling_height = narrow<uint32_t>(pool_attrs_.kernel_shape[0]);
+  uint32_t pooling_width = narrow<uint32_t>(pool_attrs_.kernel_shape[1]);
+  uint32_t stride_height = narrow<uint32_t>(pool_attrs_.strides[0]);
+  uint32_t stride_width = narrow<uint32_t>(pool_attrs_.strides[1]);
+  uint32_t dilation_height = narrow<uint32_t>(pool_attrs_.dilations[0]);
+  uint32_t dilation_width = narrow<uint32_t>(pool_attrs_.dilations[1]);
 
   // get values from any fusion with an activation
   if (std::string activation; info.GetAttr<std::string>("activation", &activation).IsOK()) {


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Replace use of gsl::narrow with narrow to build for xnnpack with exceptions disabled @snnn 


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Address issue https://github.com/microsoft/onnxruntime/issues/24383

