### PR TITLE
[webgpu] move comments out from WGSL in FlashAttention impl

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
@@ -353,30 +353,31 @@ Status FlashAttentionProgram::GenerateShaderCode(ShaderHelper& shader) const {
       qk_4[2] = select(min_value, qk_4[2], k_start+14 < seq_causal_length);
       qk_4[3] = select(min_value, qk_4[3], k_start+15 < seq_causal_length);
     }
-
-    //
-    // Compute SoftMax as per Flash Attention technique.
-    //
-    // Crux of Flash Attention is here, that allows for partial softmax computation,
-    // direct update of output and merging with previous results.
-    // https://courses.cs.washington.edu/courses/cse599m/23sp/notes/flashattn.pdf
-    // Where b is the block size of the tile. Xi is storing QKtranspose for the ith tile.
-    // mi_local is the max of Xi. Note: _ in this notation means what follows is a
-    // subscript. max_j=1:b (Xi[j]) is the max of Xi[j] for j=1 to b.
-    //
-    // for i = 1, #tiles do
-    //  Xi = Q[k,:] Kt[:, (i-1) b : i b]
-    //  mi_local= max_j=1:b (Xi[j])
-    //  Mi = max(M_(i-1), mi_local)
-    //  d'_i = d'_(i-1) * e^(M_(i-1)-M_i) + Σ_j=1:b e^(Xi[j]-Mi)
-    //  o'_i = o'_(i-1) * d'_(i-1) * e^(M_(i-1)-M_i) / d'_i + Σ_j=1:b (e^(Xi[j]-Mi) / d'_i) V[j + (i - 1)b,:]
-    // end
-    //
-    // In the code below:
-    // dleft is the first term of d'_i expression above : d'_(i-1) * e^(M_(i-1)-M_i).
-    // sum is the second term of the same expression    : Σ_j=1:b e^(Xi[j]-Mi)
-    // o_ratio is the part of the first term of o'_i expression above : d'_(i-1) * e^(M_(i-1)-M_i) / d'_i
-    //
+)MAIN_FN";
+  //
+  // Compute SoftMax as per Flash Attention technique.
+  //
+  // Crux of Flash Attention is here, that allows for partial softmax computation,
+  // direct update of output and merging with previous results.
+  // https://courses.cs.washington.edu/courses/cse599m/23sp/notes/flashattn.pdf
+  // Where b is the block size of the tile. Xi is storing QKtranspose for the ith tile.
+  // mi_local is the max of Xi. Note: _ in this notation means what follows is a
+  // subscript. max_j=1:b (Xi[j]) is the max of Xi[j] for j=1 to b.
+  //
+  // for i = 1, #tiles do
+  //  Xi = Q[k,:] Kt[:, (i-1) b : i b]
+  //  mi_local= max_j=1:b (Xi[j])
+  //  Mi = max(M_(i-1), mi_local)
+  //  d'_i = d'_(i-1) * e^(M_(i-1)-M_i) + Σ_j=1:b e^(Xi[j]-Mi)
+  //  o'_i = o'_(i-1) * d'_(i-1) * e^(M_(i-1)-M_i) / d'_i + Σ_j=1:b (e^(Xi[j]-Mi) / d'_i) V[j + (i - 1)b,:]
+  // end
+  //
+  // In the code below:
+  // dleft is the first term of d'_i expression above : d'_(i-1) * e^(M_(i-1)-M_i).
+  // sum is the second term of the same expression    : Σ_j=1:b e^(Xi[j]-Mi)
+  // o_ratio is the part of the first term of o'_i expression above : d'_(i-1) * e^(M_(i-1)-M_i) / d'_i
+  //
+  shader.MainFunctionBody() << R"MAIN_FN(
     var local_max_temp = max(qk_1, qk_2);
     if (sg_size > 8)
     {


### PR DESCRIPTION
### Description

There are 2 benefits to this change:
- the comments contain "Σ", a unicode char causing `std::wclog` failed and no longer output future logs on Windows native app, if not enabled UTF-8 explicitly by `std::wclog.imbue(std::locale(".UTF-8"));`. Moving it out resolves the problem.
- makes the WGSL code slightly shorter.
