### PR TITLE
Add ability to disable Model Editor API

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -255,6 +255,9 @@ option(onnxruntime_USE_OPENVINO_INTERFACE "Build ONNXRuntime shared lib which is
 option(onnxruntime_USE_VITISAI_INTERFACE "Build ONNXRuntime shared lib which is compatible with Vitis-AI EP interface" OFF)
 option(onnxruntime_USE_QNN_INTERFACE "Build ONNXRuntime shared lib which is compatible with QNN EP interface" OFF)
 
+# model editing api. by default disabled in minimal build. also disabled by winml due to a clash between their OrtModel
+# type the the ORT OrtModel type (which is also used in the EP API).
+option(onnxruntime_ENABLE_MODEL_EDITOR_API "Enable model editing API" ON)
 
 if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 11.1)
   message(FATAL_ERROR  "GCC version must be greater than or equal to 11.1")
@@ -598,6 +601,14 @@ endif()
 # 'extended' implies minimal.
 if (onnxruntime_EXTENDED_MINIMAL_BUILD AND NOT onnxruntime_MINIMAL_BUILD)
   set(onnxruntime_MINIMAL_BUILD ON)
+endif()
+
+if (onnxruntime_MINIMAL_BUILD)
+  if (onnxruntime_ENABLE_MODEL_EDITOR_API)
+    # STATUS as the user most likely did not explicitly enable this
+    message(STATUS "onnxruntime_ENABLE_MODEL_EDITOR_API is not supported in minimal build.")
+  endif()
+  set(onnxruntime_ENABLE_MODEL_EDITOR_API OFF)
 endif()
 
 set(REPO_ROOT ${PROJECT_SOURCE_DIR}/..)
@@ -963,11 +974,10 @@ if (onnxruntime_USE_JSEP)
     list(APPEND ONNXRUNTIME_PROVIDER_NAMES js)
 endif()
 if (onnxruntime_USE_QNN OR onnxruntime_USE_QNN_INTERFACE)
-    
     if(onnxruntime_USE_QNN)
         list(APPEND ORT_PROVIDER_FLAGS -DUSE_QNN=1)
     else()
-        list(APPEND ORT_EXTRA_INTERFACE_FLAGS -DUSE_QNN=1) 
+        list(APPEND ORT_EXTRA_INTERFACE_FLAGS -DUSE_QNN=1)
     endif()
 
     list(APPEND ONNXRUNTIME_PROVIDER_NAMES qnn)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -611,6 +611,11 @@ if (onnxruntime_MINIMAL_BUILD)
   set(onnxruntime_ENABLE_MODEL_EDITOR_API OFF)
 endif()
 
+if (onnxruntime_USE_WINML AND onnxruntime_ENABLE_MODEL_EDITOR_API)
+  message(WARNING "onnxruntime_ENABLE_MODEL_EDITOR_API is not supported in WinML build.")
+  set(onnxruntime_ENABLE_MODEL_EDITOR_API OFF)
+endif()
+
 set(REPO_ROOT ${PROJECT_SOURCE_DIR}/..)
 set(ONNXRUNTIME_ROOT ${PROJECT_SOURCE_DIR}/../onnxruntime)
 set(ORTTRAINING_ROOT ${PROJECT_SOURCE_DIR}/../orttraining)

--- a/cmake/adjust_global_compile_flags.cmake
+++ b/cmake/adjust_global_compile_flags.cmake
@@ -357,3 +357,7 @@ endif()
 if (onnxruntime_USE_EXTENSIONS)
     include_directories(${REPO_ROOT}/include/onnxruntime/core/session)
 endif()
+
+if (NOT onnxruntime_ENABLE_MODEL_EDITOR_API)
+    add_compile_definitions(DISABLE_MODEL_EDITOR_API)
+endif()

--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -1438,6 +1438,7 @@ class Graph {  // NOLINT(clang-analyzer-optin.performance.Padding): preserve exi
                                   const OrtFormatLoadOptions& load_options,
                                   const logging::Logger& logger, std::unique_ptr<Graph>& graph);
 
+#if !defined(DISABLE_MODEL_EDITOR_API)
   static Status LoadFromModelEditorApiModel(const OrtGraph& api_graph,
                                             const Model& owning_model,
                                             const std::unordered_map<std::string, int>& domain_to_version,
@@ -1447,6 +1448,7 @@ class Graph {  // NOLINT(clang-analyzer-optin.performance.Padding): preserve exi
                                             std::unique_ptr<Graph>& graph);
 
   Status UpdateUsingModelEditorApiModel(const OrtModel& api_model);
+#endif
 
 #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
   const RuntimeOptimizationRecordContainer& RuntimeOptimizations() const {

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -4837,33 +4837,33 @@ struct OrtApi {
   ORT_CLASS_RELEASE(ValueInfo);
 
   /** \brief Release an OrtNode if it was not added to an OrtGraph.
-   * \since Version 1.21.
+   * \since Version 1.22.
    */
   ORT_CLASS_RELEASE(Node);
 
   /** \brief Release an OrtGraph.
    * \snippet{doc} snippets.dox OrtStatus Return Value
-   * \since Version 1.21.
+   * \since Version 1.22.
    */
   ORT_CLASS_RELEASE(Graph);
 
   /** \brief Release an OrtModel.
    * \snippet{doc} snippets.dox OrtStatus Return Value
-   * \since Version 1.21.
+   * \since Version 1.22.
    */
   ORT_CLASS_RELEASE(Model);
 
   /** \brief Get the value name from an OrtValueInfo instance.
    * \param[in] value_info The OrtValueInfo instance.
    * \snippet{doc} snippets.dox OrtStatus Return Value
-   * \since Version 1.21.
+   * \since Version 1.22.
    */
   ORT_API2_STATUS(GetValueInfoName, _In_ const OrtValueInfo* value_info, _Out_ const char** name);
 
   /** \brief Get the type information from an OrtValueInfo instance.
    * \param[in] value_info The OrtValueInfo instance.
    * \snippet{doc} snippets.dox OrtStatus Return Value
-   * \since Version 1.21.
+   * \since Version 1.22.
    */
   ORT_API2_STATUS(GetValueInfoTypeInfo, _In_ const OrtValueInfo* value_info, _Outptr_ const OrtTypeInfo** type_info);
 
@@ -4873,7 +4873,7 @@ struct OrtApi {
    *
    * \return Model Editor API struct
    *
-   * \since Version 1.21.
+   * \since Version 1.22.
    */
   const OrtModelEditorApi*(ORT_API_CALL* GetModelEditorApi)();
 
@@ -4892,7 +4892,7 @@ struct OrtApi {
    *
    * \snippet{doc} snippets.dox OrtStatus Return Value
    *
-   * \since Version 1.21.
+   * \since Version 1.22.
    */
   ORT_API2_STATUS(CreateTensorWithDataAndDeleterAsOrtValue, _In_ OrtAllocator* deleter,
                   _In_ void* p_data, size_t p_data_len,
@@ -4914,6 +4914,7 @@ struct OrtApi {
    *
    * \snippet{doc} snippets.dox OrtStatus
    *
+   * \since Version 1.22.
    */
   ORT_API2_STATUS(SessionOptionsSetLoadCancellationFlag, _Inout_ OrtSessionOptions* options,
                   _In_ bool cancel);

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -1229,7 +1229,7 @@ struct Session : detail::SessionImpl<OrtSession> {
   Session(const Env& env, const void* model_data, size_t model_data_length, const SessionOptions& options,
           OrtPrepackedWeightsContainer* prepacked_weights_container);
 
-#if !defined(ORT_MINIMAL_BUILD)
+#if !defined(DISABLE_MODEL_EDITOR_API)
   /// Wraps OrtModelEditorApi::CreateSessionFromModel
   Session(const Env& env, const Model& model, const SessionOptions& options);
 
@@ -1239,7 +1239,7 @@ struct Session : detail::SessionImpl<OrtSession> {
   /// Wraps OrtModelEditorApi::CreateModelEditorSession
   static Session CreateModelEditorSession(const Env& env, const void* model_data, size_t model_data_length,
                                           const SessionOptions& options);
-#endif  // !defined(ORT_MINIMAL_BUILD)
+#endif  // !defined(DISABLE_MODEL_EDITOR_API)
 
   ConstSession GetConst() const { return ConstSession{this->p_}; }
   UnownedSession GetUnowned() const { return UnownedSession{this->p_}; }
@@ -1420,13 +1420,13 @@ struct TypeInfo : detail::TypeInfoImpl<OrtTypeInfo> {
   explicit TypeInfo(std::nullptr_t) {}
   explicit TypeInfo(OrtTypeInfo* p) : TypeInfoImpl<OrtTypeInfo>{p} {}  ///< C API Interop
 
-#if !defined(ORT_MINIMAL_BUILD)
+#if !defined(DISABLE_MODEL_EDITOR_API)
   static TypeInfo CreateTensorInfo(ConstTensorTypeAndShapeInfo tensor_info);
   static TypeInfo CreateSparseTensorInfo(ConstTensorTypeAndShapeInfo sparse_tensor_info);
   static TypeInfo CreateSequenceTypeInfo(ConstTypeInfo sequence_type);
   static TypeInfo CreateMapTypeInfo(ONNXTensorElementDataType key_type, ConstTypeInfo value_type);
   static TypeInfo CreateOptionalTypeInfo(ConstTypeInfo contained_type);
-#endif  // !defined(ORT_MINIMAL_BUILD)
+#endif  // !defined(DISABLE_MODEL_EDITOR_API)
 
   ConstTypeInfo GetConst() const { return ConstTypeInfo{this->p_}; }
 };
@@ -2602,7 +2602,7 @@ struct Node : detail::NodeImpl<OrtNode> {
   explicit Node(std::nullptr_t) {}                     ///< No instance is created
   explicit Node(OrtNode* p) : NodeImpl<OrtNode>{p} {}  ///< Take ownership of a pointer created by C API
 
-#if !defined(ORT_MINIMAL_BUILD)
+#if !defined(DISABLE_MODEL_EDITOR_API)
   Node(const std::string& operator_name, const std::string& operator_domain,
        const std::string& node_name,
        const std::vector<std::string>& input_names,
@@ -2624,7 +2624,7 @@ struct Node : detail::NodeImpl<OrtNode> {
                    const std::vector<std::string>& output_names,
                    std::vector<OpAttr>& attributes,
                    OrtNode*& node);
-#endif  // !defined(ORT_MINIMAL_BUILD)
+#endif  // !defined(DISABLE_MODEL_EDITOR_API)
 };
 
 namespace detail {
@@ -2633,12 +2633,13 @@ struct GraphImpl : Ort::detail::Base<T> {
   using B = Ort::detail::Base<T>;
   using B::B;
 
-#if !defined(ORT_MINIMAL_BUILD)
+#if !defined(DISABLE_MODEL_EDITOR_API)
   void SetInputs(std::vector<ValueInfo>& inputs);
   void SetOutputs(std::vector<ValueInfo>& outputs);
   void AddInitializer(const std::string& name, Value& initializer, bool data_is_external);  // Graph takes ownership of Value
   void AddNode(Node& node);                                                                 // Graph takes ownership of Node
-#endif                                                                                      // !defined(ORT_MINIMAL_BUILD)
+
+#endif  // !defined(DISABLE_MODEL_EDITOR_API)
 };
 }  // namespace detail
 
@@ -2648,7 +2649,7 @@ struct GraphImpl : Ort::detail::Base<T> {
 struct Graph : detail::GraphImpl<OrtGraph> {
   explicit Graph(std::nullptr_t) {}                        ///< No instance is created
   explicit Graph(OrtGraph* p) : GraphImpl<OrtGraph>{p} {}  ///< Take ownership of a pointer created by C API
-#if !defined(ORT_MINIMAL_BUILD)
+#if !defined(DISABLE_MODEL_EDITOR_API)
   Graph();
 #endif
 };
@@ -2659,7 +2660,7 @@ struct ModelImpl : Ort::detail::Base<T> {
   using B = Ort::detail::Base<T>;
   using B::B;
 
-#if !defined(ORT_MINIMAL_BUILD)
+#if !defined(DISABLE_MODEL_EDITOR_API)
   void AddGraph(Graph& graph);
 #endif
 };
@@ -2677,7 +2678,7 @@ struct Model : detail::ModelImpl<OrtModel> {
   explicit Model(std::nullptr_t) {}                        ///< No instance is created
   explicit Model(OrtModel* p) : ModelImpl<OrtModel>{p} {}  ///< Take ownership of a pointer created by C API
 
-#if !defined(ORT_MINIMAL_BUILD)
+#if !defined(DISABLE_MODEL_EDITOR_API)
   explicit Model(const std::vector<DomainOpsetPair>& opsets);
 #endif
 

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -1112,14 +1112,14 @@ inline TypeInfo ConstSessionImpl<T>::GetOverridableInitializerTypeInfo(size_t in
   return TypeInfo{out};
 }
 
-#if !defined(ORT_MINIMAL_BUILD)
+#if !defined(DISABLE_MODEL_EDITOR_API)
 template <typename T>
 inline int ConstSessionImpl<T>::GetOpset(const std::string& domain) const {
   int opset;
   ThrowOnError(GetModelEditorApi().SessionGetOpsetForDomain(this->p_, domain.c_str(), &opset));
   return opset;
 }
-#endif  // !defined(ORT_MINIMAL_BUILD)
+#endif  // !defined(DISABLE_MODEL_EDITOR_API)
 
 template <typename T>
 std::vector<ValueInfo> ConstSessionImpl<T>::GetInputs() const {
@@ -1198,14 +1198,14 @@ inline void SessionImpl<T>::SetEpDynamicOptions(const char* const* keys, const c
   ThrowOnError(GetApi().SetEpDynamicOptions(this->p_, keys, values, kv_len));
 }
 
-#if !defined(ORT_MINIMAL_BUILD)
+#if !defined(DISABLE_MODEL_EDITOR_API)
 template <typename T>
 inline void SessionImpl<T>::FinalizeModelEditorSession(const Model& model, const SessionOptions& options,
                                                        OrtPrepackedWeightsContainer* prepacked_weights_container) {
   ThrowOnError(GetModelEditorApi().ApplyModelToModelEditorSession(this->p_, model));
   ThrowOnError(GetModelEditorApi().FinalizeModelEditorSession(this->p_, options, prepacked_weights_container));
 }
-#endif  // #if !defined(ORT_MINIMAL_BUILD)
+#endif  // #if !defined(DISABLE_MODEL_EDITOR_API)
 
 }  // namespace detail
 
@@ -1253,7 +1253,7 @@ inline Session::Session(const Env& env, const void* model_data, size_t model_dat
                                                                             prepacked_weights_container, &this->p_));
 }
 
-#if !defined(ORT_MINIMAL_BUILD)
+#if !defined(DISABLE_MODEL_EDITOR_API)
 inline Session::Session(const Env& env, const Model& model, const SessionOptions& options) {
   ThrowOnError(GetModelEditorApi().CreateSessionFromModel(env, model.GetConst(), options, &this->p_));
 }
@@ -1277,7 +1277,7 @@ inline Session Session::CreateModelEditorSession(const Env& env, const void* mod
 
 void FinalizeModelEditorSession(const Model& model, const SessionOptions& options,
                                 OrtPrepackedWeightsContainer* prepacked_weights_container);
-#endif  // #if !defined(ORT_MINIMAL_BUILD)
+#endif  // #if !defined(DISABLE_MODEL_EDITOR_API)
 
 inline AllocatedStringPtr ModelMetadata::GetProducerNameAllocated(OrtAllocator* allocator) const {
   char* out;
@@ -1362,7 +1362,7 @@ inline TensorTypeAndShapeInfo::TensorTypeAndShapeInfo(ONNXTensorElementDataType 
   }
 }
 
-#if !defined(ORT_MINIMAL_BUILD)
+#if !defined(DISABLE_MODEL_EDITOR_API)
 // static
 inline TypeInfo TypeInfo::CreateTensorInfo(ConstTensorTypeAndShapeInfo tensor_type_and_shape_info) {
   OrtTypeInfo* output = nullptr;
@@ -1397,7 +1397,7 @@ inline TypeInfo TypeInfo::CreateOptionalTypeInfo(ConstTypeInfo contained_type) {
   ThrowOnError(GetModelEditorApi().CreateOptionalTypeInfo(contained_type, &output));
   return TypeInfo{output};
 }
-#endif  // #if !defined(ORT_MINIMAL_BUILD)
+#endif  // #if !defined(DISABLE_MODEL_EDITOR_API)
 
 namespace detail {
 
@@ -2386,7 +2386,7 @@ inline std::vector<const char*> StringsToCharPtrs(const std::vector<std::string>
 }
 }  // namespace detail
 
-#if !defined(ORT_MINIMAL_BUILD)
+#if !defined(DISABLE_MODEL_EDITOR_API)
 // static
 inline void Node::Init(const std::string& operator_name, const std::string& operator_domain,
                        const std::string& node_name,
@@ -2449,7 +2449,7 @@ inline Model::Model(const std::vector<DomainOpsetPair>& opsets) {
 inline ValueInfo::ValueInfo(const std::string& name, const ConstTypeInfo& type_info) {
   ThrowOnError(GetModelEditorApi().CreateValueInfo(name.c_str(), type_info, &p_));
 }
-#endif  // !defined(ORT_MINIMAL_BUILD)
+#endif  // !defined(DISABLE_MODEL_EDITOR_API)
 
 namespace detail {
 template <>
@@ -2466,7 +2466,7 @@ inline ConstTypeInfo ValueInfoImpl<OrtValueInfo>::TypeInfo() const {
   return ConstTypeInfo{type_info};
 }
 
-#if !defined(ORT_MINIMAL_BUILD)
+#if !defined(DISABLE_MODEL_EDITOR_API)
 template <>
 inline void GraphImpl<OrtGraph>::SetInputs(std::vector<ValueInfo>& inputs) {
   std::vector<OrtValueInfo*> inputs_ptrs;
@@ -2510,7 +2510,7 @@ inline void ModelImpl<OrtModel>::AddGraph(Graph& graph) {
   // Model takes ownership of `graph`
   ThrowOnError(GetModelEditorApi().AddGraphToModel(p_, graph.release()));
 }
-#endif  // !defined(ORT_MINIMAL_BUILD)
+#endif  // !defined(DISABLE_MODEL_EDITOR_API)
 
 }  // namespace detail
 }  // namespace Ort

--- a/onnxruntime/core/framework/onnxruntime_typeinfo.cc
+++ b/onnxruntime/core/framework/onnxruntime_typeinfo.cc
@@ -95,7 +95,7 @@ ORT_API_STATUS_IMPL(OrtApis::GetDenotationFromTypeInfo, _In_ const OrtTypeInfo* 
   API_IMPL_END
 }
 
-#if !defined(ORT_MINIMAL_BUILD)
+#if !defined(DISABLE_MODEL_EDITOR_API)
 ORT_API_STATUS_IMPL(OrtModelEditorAPI::CreateTensorTypeInfo, _In_ const OrtTensorTypeAndShapeInfo* tensor_info,
                     _Out_ OrtTypeInfo** type_info) {
   API_IMPL_BEGIN
@@ -148,7 +148,7 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::CreateOptionalTypeInfo, _In_ const OrtTyp
   return nullptr;
   API_IMPL_END
 }
-#endif  // !defined(ORT_MINIMAL_BUILD)
+#endif  // !defined(DISABLE_MODEL_EDITOR_API)
 
 ORT_API(void, OrtApis::ReleaseTypeInfo, _Frees_ptr_opt_ OrtTypeInfo* ptr) {
   std::unique_ptr<OrtTypeInfo> p(ptr);

--- a/onnxruntime/core/framework/tensor_type_and_shape.cc
+++ b/onnxruntime/core/framework/tensor_type_and_shape.cc
@@ -226,8 +226,6 @@ std::unique_ptr<OrtTensorTypeAndShapeInfo> OrtTensorTypeAndShapeInfo::GetTensorS
   if (dim_params != nullptr) {
     type_and_shape->dim_params = *dim_params;
   } else {
-    // we expect to be being called with a concrete shape so validate that
-    assert(type_and_shape->shape.Size() >= 0);
     type_and_shape->dim_params.resize(type_and_shape->shape.NumDimensions(), "");
   }
 

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -5744,7 +5744,7 @@ common::Status Graph::LoadFromOrtFormat(const onnxruntime::fbs::Graph& fbs_graph
   return Status::OK();
 }
 
-#if !defined(ORT_MINIMAL_BUILD)
+#if !defined(DISABLE_MODEL_EDITOR_API)
 namespace {
 ValueInfoProto OrtValueInfoToOnnx(const OrtValueInfo& vi) {
   // the model builder API checks that the OrtValueInfo has a complete and valid OrtTypeInfo instance and that the
@@ -5946,5 +5946,5 @@ Status Graph::UpdateUsingModelEditorApiModel(const OrtModel& api_model) {
   return LoadFromModelEditorApiModel(*api_model.graph, /*updating_existing_graph*/ true);
 }
 
-#endif  // !defined(ORT_MINIMAL_BUILD)
+#endif  // !defined(DISABLE_MODEL_EDITOR_API)
 }  // namespace onnxruntime

--- a/onnxruntime/core/graph/model.cc
+++ b/onnxruntime/core/graph/model.cc
@@ -753,7 +753,9 @@ Status Model::Load(int fd, const PathString& model_path, std::shared_ptr<Model>&
 
   return Status::OK();
 }
+#endif  // !defined(ORT_MINIMAL_BUILD)
 
+#if !defined(DISABLE_MODEL_EDITOR_API)
 // static
 common::Status Model::LoadFromModelEditorApiModel(const OrtModel& model_editor_api_model,
                                                   const IOnnxRuntimeOpSchemaRegistryList* local_registries,
@@ -783,7 +785,9 @@ common::Status Model::LoadFromModelEditorApiModel(const OrtModel& model_editor_a
 
   return Status::OK();
 }
+#endif  // !defined(DISABLE_MODEL_EDITOR_API)
 
+#if !defined(ORT_MINIMAL_BUILD)
 Status Model::Save(Model& model, int p_fd) {
   if (p_fd < 0) {
     return Status(ONNXRUNTIME, INVALID_ARGUMENT, "<p_fd> is less than 0.");

--- a/onnxruntime/core/graph/model.h
+++ b/onnxruntime/core/graph/model.h
@@ -294,12 +294,6 @@ class Model {
                              const logging::Logger& logger,
                              const ModelOptions& options = {});
 
-  static common::Status LoadFromModelEditorApiModel(const OrtModel& graph_api_model,
-                                                    const IOnnxRuntimeOpSchemaRegistryList* local_registries,
-                                                    const ModelOptions& options,
-                                                    const logging::Logger& logger,
-                                                    std::unique_ptr<Model>& model);
-
   common::Status SaveToOrtFormat(flatbuffers::FlatBufferBuilder& builder,
                                  flatbuffers::Offset<onnxruntime::fbs::Model>& model) const;
 
@@ -311,6 +305,14 @@ class Model {
   void RemoveLocalFunctionsProtos(const InlinedHashSet<std::string>& retained);
 
 #endif  // !defined(ORT_MINIMAL_BUILD)
+
+#if !defined(DISABLE_MODEL_EDITOR_API)
+  static common::Status LoadFromModelEditorApiModel(const OrtModel& graph_api_model,
+                                                    const IOnnxRuntimeOpSchemaRegistryList* local_registries,
+                                                    const ModelOptions& options,
+                                                    const logging::Logger& logger,
+                                                    std::unique_ptr<Model>& model);
+#endif
 
   static common::Status LoadFromOrtFormat(const onnxruntime::fbs::Model& fbs_model,
 #if !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/core/graph/model_editor_api_types.h
+++ b/onnxruntime/core/graph/model_editor_api_types.h
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#pragma once
+
 #include "core/common/inlined_containers_fwd.h"
 #include "core/framework/ort_value.h"
 #include "core/framework/onnxruntime_typeinfo.h"
@@ -9,11 +11,13 @@
 // ORT C interface types for OrtGraphApi can't be in a namespace.
 // We need to define them here so onnxruntime::Model can be created from OrtModel.
 
+// OrtValueInfo isn't model editing specific so can be used if Model Editor API is disabled.
 struct OrtValueInfo {
   std::string name;
   std::unique_ptr<OrtTypeInfo> type_info;
 };
 
+#if !defined(DISABLE_MODEL_EDITOR_API)
 struct OrtOpAttr {
   ONNX_NAMESPACE::AttributeProto attr_proto;
 };
@@ -45,3 +49,5 @@ struct OrtModel {
   std::unique_ptr<OrtGraph> graph;
   std::unordered_map<std::string, int> domain_to_version;
 };
+
+#endif  // !defined(DISABLE_MODEL_EDITOR_API)

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -323,7 +323,9 @@ class InferenceSession {
    * @return OK if success.
    */
   [[nodiscard]] common::Status Load();
+#endif
 
+#if !defined(DISABLE_MODEL_EDITOR_API)
   /**
    * Load an OrtModel that was dynamically constructed via OrtModelEditorApi.
    *
@@ -343,8 +345,7 @@ class InferenceSession {
    * @return OK if success.
    */
   [[nodiscard]] common::Status ApplyUpdates(const OrtModel& graph_api_model);
-
-#endif  // !defined(ORT_MINIMAL_BUILD)
+#endif  // !defined(DISABLE_MODEL_EDITOR_API)
 
   /**
    * Initializes a previously loaded ONNX model. Initialization includes but is not

--- a/onnxruntime/core/session/model_editor_api.h
+++ b/onnxruntime/core/session/model_editor_api.h
@@ -1,3 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#if !defined(DISABLE_MODEL_EDITOR_API)
+
 namespace OrtModelEditorAPI {
 
 // implementation that returns the API struct
@@ -63,3 +70,5 @@ ORT_API_STATUS_IMPL(FinalizeModelEditorSession, _In_ OrtSession* session, _In_ c
                     _Inout_ OrtPrepackedWeightsContainer* prepacked_weights_container);
 
 }  // namespace OrtModelEditorAPI
+
+#endif  // !defined(DISABLE_MODEL_EDITOR_API)

--- a/onnxruntime/core/session/model_editor_c_api.cc
+++ b/onnxruntime/core/session/model_editor_c_api.cc
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#if !defined(ORT_MINIMAL_BUILD)
+#if !defined(DISABLE_MODEL_EDITOR_API)
 
 #include <variant>
 

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2336,6 +2336,7 @@ ORT_API(void, OrtApis::ReleaseValueInfo, _Frees_ptr_opt_ OrtValueInfo* value_inf
   delete value_info;
 }
 
+#if !defined(DISABLE_MODEL_EDITOR_API)
 ORT_API(void, OrtApis::ReleaseNode, _Frees_ptr_opt_ OrtNode* node) {
   delete node;
 }
@@ -2347,6 +2348,21 @@ ORT_API(void, OrtApis::ReleaseGraph, _Frees_ptr_opt_ OrtGraph* graph) {
 ORT_API(void, OrtApis::ReleaseModel, _Frees_ptr_opt_ OrtModel* model) {
   delete model;
 }
+#else
+// it shouldn't be possible to create these if the model editor api is disabled,
+// and if you can't create them you can't release them.
+ORT_API(void, OrtApis::ReleaseNode, _Frees_ptr_opt_ OrtNode* /*node*/) {
+  assert(false);
+}
+
+ORT_API(void, OrtApis::ReleaseGraph, _Frees_ptr_opt_ OrtGraph* /*graph*/) {
+  assert(false);
+}
+
+ORT_API(void, OrtApis::ReleaseModel, _Frees_ptr_opt_ OrtModel* /*model*/) {
+  assert(false);
+}
+#endif
 
 ORT_API_STATUS_IMPL(OrtApis::GetValueInfoName, _In_ const OrtValueInfo* value_info,
                     _Out_ const char** name) {

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2381,10 +2381,10 @@ ORT_API(const OrtTrainingApi*, OrtApis::GetTrainingApi, uint32_t version) {
 }
 
 ORT_API(const OrtModelEditorApi*, OrtApis::GetModelEditorApi) {
-#if !defined(ORT_MINIMAL_BUILD)
+#if !defined(DISABLE_MODEL_EDITOR_API)
   return OrtModelEditorAPI::GetModelEditorApi();
 #else
-  fprintf(stderr, "The Model Editor API is not supported in a minimal build.\n");
+  fprintf(stderr, "The Model Editor API is not supported in this build.\n");
   return nullptr;
 #endif
 }

--- a/onnxruntime/test/shared_lib/test_model_builder_api.cc
+++ b/onnxruntime/test/shared_lib/test_model_builder_api.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#if !defined(DISABLE_MODEL_EDITOR_API)
+
 #include <gsl/gsl>
 
 #include "gtest/gtest.h"
@@ -699,3 +701,5 @@ TEST(ModelEditorAPITest, CreateTypeInfo) {
 
   api.ReleaseTypeInfo(base_tensor_type_info);
 }
+
+#endif  // defined(DISABLE_MODEL_EDITOR_API)

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -387,6 +387,9 @@ def generate_build_tree(
 
         if args.use_winml:
             cmake_args.append("-Donnxruntime_BUILD_WINML_TESTS=" + ("OFF" if args.skip_winml_tests else "ON"))
+            # Model Editor API has an OrtModel which clashes with the WinML OrtModel.
+            # Disable Model Editor API to avoid this issue.
+            cmake_args.append("-Donnxruntime_ENABLE_MODEL_EDITOR_API=OFF")
         if args.dml_path:
             cmake_args += [
                 "-Donnxruntime_USE_CUSTOM_DIRECTML=ON",


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
The OrtModel clashes with a type in the winml public API leading to issues as the linker gets confused. 
As winml doesn't need any model editing capabilities the cleanest solution is to make it easy to exclude Model Editor API.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Resolve type confusion leading to runtime crash in winml

