### PR TITLE
[webgpu] Fix batch-norm for ort-web-tests

### DIFF
--- a/onnxruntime/core/providers/webgpu/nn/batch_norm.cc
+++ b/onnxruntime/core/providers/webgpu/nn/batch_norm.cc
@@ -51,8 +51,7 @@ Status BatchNormalizationProgram::GenerateShaderCode(ShaderHelper& shader) const
   const ShaderVariableHelper& output = shader.AddOutput("output", ShaderUsage::UseUniform | ShaderUsage::UseIndicesTypeAlias);
 
   shader.MainFunctionBody() << shader.GuardAgainstOutOfBoundsWorkgroupSizes("uniforms.output_size")
-                            << "  let idx = global_idx * " << components_ << ";\n"
-                            << "  var outputIndices = " << output.OffsetToIndices("idx") << ";\n";
+                            << "  var outputIndices = " << output.OffsetToIndices("global_idx") << ";\n";
   if (spatial_) {
     if (input_tensor.Rank() == 1) {
       shader.MainFunctionBody() << "  let cOffset = 0u;\n";

--- a/onnxruntime/core/providers/webgpu/nn/batch_norm.cc
+++ b/onnxruntime/core/providers/webgpu/nn/batch_norm.cc
@@ -57,7 +57,7 @@ Status BatchNormalizationProgram::GenerateShaderCode(ShaderHelper& shader) const
       shader.MainFunctionBody() << "  let cOffset = 0u;\n";
     } else {
       if (format_ == DataLayout::NHWC) {
-        shader.MainFunctionBody() << "  let cOffset = outputIndices[" << input_tensor.Rank() - 1 << "] / " << components_ << ";\n";
+        shader.MainFunctionBody() << "  let cOffset = outputIndices[" << input_tensor.Rank() - 1 << "];\n";
       } else {
         shader.MainFunctionBody() << "  let cOffset = outputIndices[1];\n";
       }
@@ -121,7 +121,7 @@ Status BatchNormalization<is_nhwc>::ComputeInternal(ComputeContext& context) con
 
   ORT_RETURN_IF_ERROR(BatchNormHelper::ValidateInputs(input_tensor, scale, B, input_mean, input_var, spatial_ == 1, format_ == DataLayout::NHWC));
 
-  BatchNormalizationProgram program{epsilon_, spatial_, format_, static_cast<int64_t>(components)};
+  BatchNormalizationProgram program{epsilon_, spatial_, format_};
   program
       .CacheHint(epsilon_, spatial_, format_, components)
       .AddInputs({{input_tensor, ProgramTensorMetadataDependency::TypeAndRank, components},

--- a/onnxruntime/core/providers/webgpu/nn/batch_norm.h
+++ b/onnxruntime/core/providers/webgpu/nn/batch_norm.h
@@ -11,11 +11,8 @@ namespace webgpu {
 
 class BatchNormalizationProgram final : public Program<BatchNormalizationProgram> {
  public:
-  BatchNormalizationProgram(float epsilon, int64_t spatial, DataLayout format, int64_t components) : Program{"BatchNormalization"},
-                                                                                                     epsilon_{epsilon},
-                                                                                                     spatial_{spatial},
-                                                                                                     format_{format},
-                                                                                                     components_{components} {}
+  BatchNormalizationProgram(float epsilon, int64_t spatial, DataLayout format)
+      : Program{"BatchNormalization"}, epsilon_{epsilon}, spatial_{spatial}, format_{format} {}
 
   Status GenerateShaderCode(ShaderHelper& sh) const override;
 
@@ -25,7 +22,6 @@ class BatchNormalizationProgram final : public Program<BatchNormalizationProgram
   float epsilon_;
   int64_t spatial_;
   DataLayout format_;
-  int64_t components_;
 };
 
 template <bool is_nhwc>


### PR DESCRIPTION
'global_idx' should be used to calculate the output indices.