### PR TITLE
Do not add LD_LIBRARY_PATH to search path when not defined

### DIFF
--- a/cmake/onnxruntime_providers_acl.cmake
+++ b/cmake/onnxruntime_providers_acl.cmake
@@ -13,7 +13,9 @@
     onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers Boost::mp11 safeint_interface
   )
 
-  target_link_libraries(onnxruntime_providers_acl -L$ENV{LD_LIBRARY_PATH})
+  if (DEFINED ENV{LD_LIBRARY_PATH})
+    target_link_libraries(onnxruntime_providers_acl -L$ENV{LD_LIBRARY_PATH})
+  endif()
   add_dependencies(onnxruntime_providers_acl ${onnxruntime_EXTERNAL_DEPENDENCIES})
   set_target_properties(onnxruntime_providers_acl PROPERTIES FOLDER "ONNXRuntime")
   target_include_directories(onnxruntime_providers_acl


### PR DESCRIPTION
If LD_LIBRARY_PATH is not defined a blank "-L" is added to the link command. This causes the next object to be linked to get treated as if it was a search path and causes link failure.

