### PR TITLE
set fp16 abs_error for WebGPU EP in InstanceNorm test

### DIFF
--- a/onnxruntime/core/providers/webgpu/nn/instance_norm.cc
+++ b/onnxruntime/core/providers/webgpu/nn/instance_norm.cc
@@ -76,7 +76,8 @@ Status ComputeChannelScaleAndShift(ComputeContext& context, const Tensor* input,
                   {scale, ProgramTensorMetadataDependency::TypeAndRank},
                   {bias, ProgramTensorMetadataDependency::TypeAndRank}})
       .AddOutputs({{output, ProgramTensorMetadataDependency::TypeAndRank, reduced_output_shape, 2}})
-      .SetDispatchGroupSize(static_cast<uint32_t>(units_of_work));
+      .SetDispatchGroupSize(static_cast<uint32_t>(units_of_work))
+      .SetWorkgroupSize(workgroup_size);
   return context.RunProgram(program);
 }
 

--- a/onnxruntime/test/providers/cpu/nn/instance_norm_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/instance_norm_op_test.cc
@@ -3,6 +3,7 @@
 
 #include "gtest/gtest.h"
 #include "test/providers/provider_test_utils.h"
+#include "test/util/include/default_providers.h"
 #include "test/common/tensor_op_test_utils.h"
 
 using namespace std;

--- a/onnxruntime/test/providers/cpu/nn/instance_norm_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/instance_norm_op_test.cc
@@ -50,11 +50,11 @@ TYPED_TEST(InstanceNormalizationOpTest, InstanceNorm) {
                                      -0.14644464F, -0.82262872F, -0.66852817F, 1.63760153F,
                                      -1.65898662F, 0.27618144F, 0.64840618F, 0.734399F};
     test.AddOutput<TypeParam>("Y", input_dims, GetTypedArray<TypeParam>(expected_output));
-#ifdef USE_WEBGPU
-    if constexpr (std::is_same<TypeParam, MLFloat16>::value) {
-      test.SetOutputTolerance(0.005F, 0.005F);
+    if (DefaultWebGpuExecutionProvider().get() != nullptr) {
+      if constexpr (std::is_same<TypeParam, MLFloat16>::value) {
+        test.SetOutputTolerance(0.005F, 0.005F);
+      }
     }
-#endif
     test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
   };
   run_test(false);
@@ -84,11 +84,11 @@ TYPED_TEST(InstanceNormalizationOpTest, InstanceNormBatch1) {
                                      1.46688162F, -0.98600774F, -0.79911913F, 0.31824524F,
                                      0.57370438F, 0.42193634F, 0.6525492F, -1.64818992F};
     test.AddOutput<TypeParam>("Y", input_dims, GetTypedArray<TypeParam>(expected_output));
-#ifdef USE_WEBGPU
-    if constexpr (std::is_same<TypeParam, MLFloat16>::value) {
-      test.SetOutputTolerance(0.005F, 0.005F);
+    if (DefaultWebGpuExecutionProvider().get() != nullptr) {
+      if constexpr (std::is_same<TypeParam, MLFloat16>::value) {
+        test.SetOutputTolerance(0.005F, 0.005F);
+      }
     }
-#endif
     test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
   };
   run_test(false);
@@ -130,7 +130,7 @@ TEST(InstanceNormalizationOpTest, InstanceNormBatch2) {
 }
 
 // Only CUDA and ROCm kernels have float 16 support
-#if defined(USE_CUDA) || defined(USE_ROCM) || defined(USE_COREML)
+#if defined(USE_CUDA) || defined(USE_ROCM) || defined(USE_COREML) || defined(USE_WEBGPU)
 
 TEST(InstanceNormalizationOpTest, InstanceNormBatch1_fp16) {
   OpTester test("InstanceNormalization");
@@ -168,6 +168,9 @@ TEST(InstanceNormalizationOpTest, InstanceNormBatch1_fp16) {
   test.AddInput<MLFloat16>("B", {3}, B_fp16);
   test.AddOutput<MLFloat16>("Y", input_dims, expected_output_fp16);
 
+  if (DefaultWebGpuExecutionProvider().get() != nullptr) {
+    test.SetOutputTolerance(0.005F, 0.005F);
+  }
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 }
 
@@ -215,6 +218,9 @@ TEST(InstanceNormalizationOpTest, InstanceNormBatch2_fp16) {
   test.AddInput<MLFloat16>("B", {3}, B_fp16);
   test.AddOutput<MLFloat16>("Y", input_dims, expected_output_fp16);
 
+  if (DefaultWebGpuExecutionProvider().get() != nullptr) {
+    test.SetOutputTolerance(0.005F, 0.005F);
+  }
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 }
 


### PR DESCRIPTION
### Description
set fp16 abs_error for WebGPU EP in InstanceNorm test

Prefer to use `DefaultWebGpuExecutionProvider().get() != nullptr` as condition

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


