### PR TITLE
workaround linux CI pipeline: pin triton to v3.2.0

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
@@ -10,4 +10,4 @@ sympy==1.12 ; python_version < '3.9'
 sympy==1.13 ; python_version >= '3.9'
 flatbuffers
 neural-compressor>=2.2.1
-triton
+triton==3.2.0


### PR DESCRIPTION
### Description

pin triton to v3.2.0

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


