### PR TITLE
[WebNN] Fallback unsupported integer input and output of a WebNN graph to int32

### DIFF
--- a/js/web/lib/wasm/jsep/webnn/tensor-manager.ts
+++ b/js/web/lib/wasm/jsep/webnn/tensor-manager.ts
@@ -10,6 +10,22 @@ import { LOG_DEBUG } from '../log';
 // https://github.com/webmachinelearning/webnn/issues/677
 /// <reference path="webnn.d.ts" />
 
+/**
+ * Map from MLOperandDataType to size in bits. Using bits instead of bytes to avoid possible precision loss on int4 and uint4.
+ */
+const webnnDataTypeToSize = new Map<MLOperandDataType, number>([
+  ['float32', 32],
+  ['float16', 16],
+  ['int32', 32],
+  ['uint32', 32],
+  ['int64', 64],
+  ['uint64', 64],
+  ['int8', 8],
+  ['uint8', 8],
+  ['int4', 4],
+  ['uint4', 4],
+]);
+
 // Convert integer data to an Int32Array buffer.
 // Supports conversion from int64, uint64, uint32, int8 and uint8 to int32.
 export const convertDataToInt32 = (data: Uint8Array, dataType: MLOperandDataType): Uint8Array => {
@@ -165,22 +181,6 @@ export interface TensorManager {
 
 let tensorGuid = 1;
 const createNewTensorId = (): TensorId => tensorGuid++;
-
-/**
- * Map from MLOperandDataType to size in bits. Using bits instead of bytes to avoid possible precision loss on int4 and uint4.
- */
-const webnnDataTypeToSize = new Map<MLOperandDataType, number>([
-  ['float32', 32],
-  ['float16', 16],
-  ['int32', 32],
-  ['uint32', 32],
-  ['int64', 64],
-  ['uint64', 64],
-  ['int8', 8],
-  ['uint8', 8],
-  ['int4', 4],
-  ['uint4', 4],
-]);
 
 /**
  * Map from data type to fallback data type.

--- a/js/web/lib/wasm/jsep/webnn/tensor-manager.ts
+++ b/js/web/lib/wasm/jsep/webnn/tensor-manager.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { WebNNBackend } from '../backend-webnn';
+import { tensorTypeToTypedArrayConstructor } from '../../wasm-common';
 import { LOG_DEBUG } from '../log';
 
 // WebNN API currently does not have a TypeScript definition file. This file is a workaround with types generated from
@@ -9,38 +10,70 @@ import { LOG_DEBUG } from '../log';
 // https://github.com/webmachinelearning/webnn/issues/677
 /// <reference path="webnn.d.ts" />
 
-// Convert BigInt64Array buffer data to Int32Array buffer data.
-export const convertInt64ToInt32 = (data: Uint8Array, returnUint8 = true): Uint8Array | Int32Array => {
-  // Make sure it is a multiple of 8 bytes (BigInt64Array).
-  if (data.byteLength % 8 !== 0) {
-    throw new Error('Invalid Uint8Array length - must be a multiple of 8 (BigInt).');
+// Convert integer data to an Int32Array buffer.
+// Supports conversion from int64, uint64, uint32, int8 and uint8 to int32.
+export const convertDataToInt32 = (data: Uint8Array, dataType: MLOperandDataType): Uint8Array => {
+  if (dataType === 'int32') {
+    return data;
   }
 
-  // Convert Uint8Array to BigInt64Array.
-  const numElements = data.byteLength / 8;
-  const bigInt64Array = new BigInt64Array(data.buffer, data.byteOffset, numElements);
+  const size = webnnDataTypeToSize.get(dataType);
+  if (!size) {
+    throw new Error('Unsupported data type.');
+  }
+  // Make sure the data length is a multiple of the data type size.
+  if (data.byteLength % (size / 8) !== 0) {
+    throw new Error(`Invalid Uint8Array length - must be a multiple of ${size / 8}.`);
+  }
 
-  // Convert BigInt64Array to Int32Array (same number of elements).
-  const int32Array = new Int32Array(numElements);
+  // Convert Uint8Array to original typed array.
+  const numElements = data.byteLength / (size / 8);
+  const originalArray = new (tensorTypeToTypedArrayConstructor(dataType))(data.buffer, data.byteOffset, numElements);
 
-  for (let i = 0; i < numElements; i++) {
-    const value = bigInt64Array[i];
+  switch (dataType) {
+    case 'int64':
+    case 'uint64': {
+      // Convert original typed array to Int32Array.
+      const int32Array = new Int32Array(numElements);
+      for (let i = 0; i < numElements; i++) {
+        const value = originalArray[i];
 
-    // Check for overflow.
-    if (value > 2147483647n || value < -2147483648n) {
-      throw new Error(`Overflow occurred when converting BigInt to Int32 at index ${i}: ${value}`);
+        // Check for overflow.
+        if (value > 2147483647n || value < -2147483648n) {
+          throw new Error(`Overflow occurred when converting BigInt to Int32 at index ${i}: ${value}`);
+        }
+
+        int32Array[i] = Number(value);
+      }
+
+      return new Uint8Array(int32Array.buffer);
     }
-
-    int32Array[i] = Number(value);
+    case 'int8':
+    case 'uint8':
+    case 'uint32': {
+      // Check for overflow.
+      if (dataType === 'uint32') {
+        if (originalArray.some((value) => value > 2147483647)) {
+          throw new Error('Can not convert uint32 data to int32, value out of range.');
+        }
+      }
+      // Convert original typed array to Int32Array.
+      const int32Array = Int32Array.from(originalArray, Number);
+      return new Uint8Array(int32Array.buffer);
+    }
+    default:
+      throw new Error(`Unsupported data convertion from ${dataType} to 'int32'`);
   }
-
-  // Return based on the requested format.
-  return returnUint8 ? new Uint8Array(int32Array.buffer) : int32Array;
 };
 
-// Convert Int32Array buffer data to BigInt64Array buffer data.
-const convertInt32ToInt64 = (data: Uint8Array, returnUint8 = true): Uint8Array | BigInt64Array => {
-  // Make sure it is a multiple of 4 bytes (Int32Array).
+// Convert Int32Array data to original integer data buffer.
+// Supports conversion from int32 to int64, uint64, uint32, int8 and uint8.
+export const convertInt32ToData = (data: Uint8Array, dataType: MLOperandDataType): Uint8Array => {
+  if (dataType === 'int32') {
+    return data;
+  }
+
+  // Make sure the data length is a multiple of 4 bytes (Int32Array).
   if (data.byteLength % 4 !== 0) {
     throw new Error('Invalid Uint8Array length - must be a multiple of 4 (Int32).');
   }
@@ -49,11 +82,46 @@ const convertInt32ToInt64 = (data: Uint8Array, returnUint8 = true): Uint8Array |
   const numElements = data.byteLength / 4;
   const int32Array = new Int32Array(data.buffer, data.byteOffset, numElements);
 
-  // Convert Int32Array to BigInt64Array (same number of elements).
-  const bigInt64Array = BigInt64Array.from(int32Array, BigInt);
-
-  // Return based on the requested format.
-  return returnUint8 ? new Uint8Array(bigInt64Array.buffer) : bigInt64Array;
+  switch (dataType) {
+    case 'int64': {
+      // Convert Int32Array to BigInt64Array.
+      const bigInt64Array = BigInt64Array.from(int32Array, BigInt);
+      return new Uint8Array(bigInt64Array.buffer);
+    }
+    case 'uint64': {
+      if (int32Array.some((value) => value < 0)) {
+        throw new Error('Can not convert int32 data to uin64, negative value found.');
+      }
+      // Convert Int32Array to BigUInt64Array.
+      const bigUint64Array = BigUint64Array.from(int32Array, BigInt);
+      return new Uint8Array(bigUint64Array.buffer);
+    }
+    case 'int8': {
+      if (int32Array.some((value) => value < -128 || value > 127)) {
+        throw new Error('Can not convert int32 data to int8, value out of range.');
+      }
+      // Convert Int32Array to Int8Array.
+      const int8Array = Int8Array.from(int32Array, Number);
+      return new Uint8Array(int8Array.buffer);
+    }
+    case 'uint8': {
+      if (int32Array.some((value) => value < 0 || value > 255)) {
+        throw new Error('Can not convert int32 data to uint8, value out of range.');
+      }
+      // Convert Int32Array to Uint8Array.
+      return Uint8Array.from(int32Array, Number);
+    }
+    case 'uint32': {
+      if (int32Array.some((value) => value < 0)) {
+        throw new Error('Can not convert int32 data to uint32, negative value found.');
+      }
+      // Convert Int32Array to Uint32Array.
+      const uint32Array = Uint32Array.from(int32Array, Number);
+      return new Uint8Array(uint32Array.buffer);
+    }
+    default:
+      throw new Error(`Unsupported data convertion from 'int32' to ${dataType}`);
+  }
 };
 
 export type TensorId = number;
@@ -119,6 +187,18 @@ const webnnDataTypeToSize = new Map<MLOperandDataType, number>([
 ]);
 
 /**
+ * Map from data type to fallback data type.
+ * When the context does not support the original data type, use fallback data type as workaround.
+ * Note: Currently, we only support fallback to int32 for certain integer data types.
+ */
+const webnnDataTypeToFallback = new Map<MLOperandDataType, MLOperandDataType>([
+  ['int8', 'int32'],
+  ['uint8', 'int32'],
+  ['uint32', 'int32'],
+  ['int64', 'int32'],
+]);
+
+/**
  * Calculate the byte length of a tensor with the given data type and shape.
  */
 const calculateByteLength = (dataType: MLOperandDataType, shape: readonly number[]): number => {
@@ -135,13 +215,14 @@ const calculateByteLength = (dataType: MLOperandDataType, shape: readonly number
 class TensorWrapper {
   // The id of the last session that used this tensor.
   public sessionId: number;
-  // This flag is used to indicate whether we should convert data from int64 to int32.
-  public shouldConvertInt64toInt32 = false;
-  public isInt64ToInt32Converted = false;
+  // This flag is used to indicate whether the data has been converted to fallback data type.
+  public isDataConverted = false;
 
   private mlContext: MLContext;
   private mlTensor: MLTensor;
   private dataType: MLOperandDataType;
+  // Fallback data type to use when the context does not support the original data type,
+  private fallbackDataType: MLOperandDataType | undefined;
   private tensorShape: readonly number[];
 
   constructor(descriptor: {
@@ -150,15 +231,15 @@ class TensorWrapper {
     tensor: MLTensor;
     dataType: MLOperandDataType;
     shape: readonly number[];
-    shouldConvertInt64toInt32?: boolean;
+    fallbackDataType?: MLOperandDataType;
   }) {
-    const { sessionId, context, tensor, dataType, shape, shouldConvertInt64toInt32 = false } = descriptor;
+    const { sessionId, context, tensor, dataType, shape, fallbackDataType } = descriptor;
     this.sessionId = sessionId;
     this.mlContext = context;
     this.mlTensor = tensor;
     this.dataType = dataType;
     this.tensorShape = shape;
-    this.shouldConvertInt64toInt32 = shouldConvertInt64toInt32;
+    this.fallbackDataType = fallbackDataType;
   }
 
   public get tensor(): MLTensor {
@@ -167,6 +248,10 @@ class TensorWrapper {
 
   public get type(): MLOperandDataType {
     return this.dataType;
+  }
+
+  public get fallbackType(): MLOperandDataType | undefined {
+    return this.fallbackDataType;
   }
 
   public get shape(): readonly number[] {
@@ -186,29 +271,23 @@ class TensorWrapper {
     this.mlContext.writeTensor(this.mlTensor, data);
   }
 
-  public async read(shouldConvertInt32ToInt64?: boolean): Promise<ArrayBuffer>;
-  public async read(
-    shouldConvertInt32ToInt64?: boolean,
-    dstBuffer?: ArrayBufferView | ArrayBuffer,
-  ): Promise<ArrayBuffer | undefined>;
-  public async read(
-    shouldConvertInt32ToInt64?: boolean,
-    dstBuffer?: ArrayBufferView | ArrayBuffer,
-  ): Promise<ArrayBuffer | undefined> {
-    if (shouldConvertInt32ToInt64) {
-      // This was an int64 data as saved as int32 as workaround, we need to read it as int64.
+  public async read(): Promise<ArrayBuffer>;
+  public async read(dstBuffer?: ArrayBufferView | ArrayBuffer): Promise<ArrayBuffer | undefined>;
+  public async read(dstBuffer?: ArrayBufferView | ArrayBuffer): Promise<ArrayBuffer | undefined> {
+    if (this.fallbackDataType) {
+      // This tensor has been fallback to int32 as workaround, we need to read it as its original integer data type.
       const data = await this.mlContext.readTensor(this.mlTensor);
-      const int64Data = convertInt32ToInt64(new Uint8Array(data)) as Uint8Array;
+      const originalData = convertInt32ToData(new Uint8Array(data), this.dataType);
 
       if (dstBuffer) {
         const targetBuffer =
           dstBuffer instanceof ArrayBuffer
             ? new Uint8Array(dstBuffer)
             : new Uint8Array(dstBuffer.buffer, dstBuffer.byteOffset, dstBuffer.byteLength);
-        targetBuffer.set(int64Data);
+        targetBuffer.set(originalData);
         return undefined;
       } else {
-        return int64Data.buffer;
+        return originalData.buffer;
       }
     } else {
       return dstBuffer ? this.mlContext.readTensor(this.mlTensor, dstBuffer) : this.mlContext.readTensor(this.mlTensor);
@@ -224,8 +303,8 @@ class TensorWrapper {
     );
   }
 
-  public setIsInt64ToInt32Converted(isConverted: boolean): void {
-    this.isInt64ToInt32Converted = isConverted;
+  public setIsDataConverted(isConverted: boolean): void {
+    this.isDataConverted = isConverted;
   }
 }
 
@@ -260,22 +339,26 @@ class TensorIdTracker {
     shape: readonly number[],
     copyOld: boolean,
   ): Promise<MLTensor> {
-    let newDataType = dataType;
     const context = this.tensorManager.getMLContext(sessionId);
-    // If the data type is int64 and the context does not support int64, we need to convert it to int32.
-    const shouldConvertInt64toInt32 =
-      newDataType === 'int64' && !context.opSupportLimits().input.dataTypes.includes('int64');
-    if (shouldConvertInt64toInt32) {
-      newDataType = 'int32';
-      LOG_DEBUG('verbose', () => `[WebNN] TensorIdTracker.ensureTensor: convert dataType from int64 to int32`);
+    let fallbackDataType: MLOperandDataType | undefined;
+    // Check if the context supports the data type, if no, try to use the fallback data type.
+    if (!context.opSupportLimits().input.dataTypes.includes(dataType)) {
+      fallbackDataType = webnnDataTypeToFallback.get(dataType);
+      if (!fallbackDataType || !context.opSupportLimits().input.dataTypes.includes(fallbackDataType)) {
+        throw new Error(`Unsupported data type: ${dataType}`);
+      }
+      LOG_DEBUG(
+        'verbose',
+        () => `[WebNN] TensorIdTracker.ensureTensor: fallback dataType from ${dataType} to ${fallbackDataType}`,
+      );
     }
 
     if (this.wrapper) {
-      if (this.wrapper.canReuseTensor(context, newDataType, shape)) {
+      if (this.wrapper.canReuseTensor(context, dataType, shape)) {
         return this.wrapper.tensor;
       } else {
         if (copyOld) {
-          if (this.wrapper.byteLength !== calculateByteLength(newDataType, shape)) {
+          if (this.wrapper.byteLength !== calculateByteLength(dataType, shape)) {
             throw new Error('Unable to copy data to tensor with different size.');
           }
           this.activeUpload = new Uint8Array(await this.wrapper.read());
@@ -288,16 +371,16 @@ class TensorIdTracker {
     const usage = typeof MLTensorUsage == 'undefined' ? undefined : MLTensorUsage.READ | MLTensorUsage.WRITE;
     this.wrapper = await this.tensorManager.getCachedTensor(
       sessionId,
-      newDataType,
+      dataType,
       shape,
       usage,
       true,
       true,
-      shouldConvertInt64toInt32,
+      fallbackDataType,
     );
 
     if (copyOld && this.activeUpload) {
-      // We don't need to convert the old int64 data to int32,
+      // We don't need to convert the original integer data to int32,
       // because it has been converted when it was uploaded.
       this.wrapper.write(this.activeUpload);
       this.activeUpload = undefined;
@@ -309,12 +392,19 @@ class TensorIdTracker {
   public upload(data: Uint8Array): void {
     let newData = data;
     if (this.wrapper) {
-      if (this.wrapper.shouldConvertInt64toInt32) {
-        // Convert int64 to int32.
-        newData = convertInt64ToInt32(data, true) as Uint8Array;
-        this.wrapper.setIsInt64ToInt32Converted(true);
+      if (this.wrapper.fallbackType) {
+        if (this.wrapper.fallbackType === 'int32') {
+          // Convert original integer data to int32.
+          newData = convertDataToInt32(data, this.wrapper.type);
+          this.wrapper.setIsDataConverted(true);
+        } else {
+          throw new Error(`Unsupported fallback data type: ${this.wrapper.fallbackType}`);
+        }
       }
-      if (newData.byteLength === this.wrapper.byteLength) {
+
+      // Check if the data size matches the tensor size.
+      if (data.byteLength === this.wrapper.byteLength) {
+        // Write the newData to the tensor.
         this.wrapper.write(newData);
         return;
       } else {
@@ -332,9 +422,9 @@ class TensorIdTracker {
 
   public async download(dstBuffer?: ArrayBufferView | ArrayBuffer): Promise<ArrayBuffer | undefined> {
     if (this.activeUpload) {
-      // If this.activeUpload has been converted to int32, we need to convert it back to int64 data.
-      const dstData = this.wrapper?.isInt64ToInt32Converted
-        ? (convertInt32ToInt64(this.activeUpload) as Uint8Array)
+      // If this.activeUpload has been converted to int32, we need to convert it back to original integer data type.
+      const dstData = this.wrapper?.isDataConverted
+        ? convertInt32ToData(this.activeUpload, this.wrapper?.type)
         : this.activeUpload;
 
       if (dstBuffer) {
@@ -353,9 +443,9 @@ class TensorIdTracker {
     }
 
     if (!dstBuffer) {
-      return this.wrapper.read(this.wrapper?.shouldConvertInt64toInt32);
+      return this.wrapper.read();
     }
-    return this.wrapper.read(this.wrapper?.shouldConvertInt64toInt32, dstBuffer);
+    return this.wrapper.read(dstBuffer);
   }
 }
 
@@ -475,27 +565,39 @@ class TensorManagerImpl implements TensorManager {
     usage: MLTensorUsageFlags | undefined,
     writable: boolean,
     readable: boolean,
-    shouldConvertInt64toInt32 = false,
+    fallbackDataType?: MLOperandDataType,
   ): Promise<TensorWrapper> {
     const context = this.getMLContext(sessionId);
     for (const [index, tensor] of this.freeTensors.entries()) {
       if (tensor.canReuseTensor(context, dataType, shape)) {
-        LOG_DEBUG('verbose', () => `[WebNN] Reusing tensor {dataType: ${dataType}, shape: ${shape}}`);
+        LOG_DEBUG(
+          'verbose',
+          () =>
+            `[WebNN] Reusing tensor {dataType: ${dataType}, ${
+              fallbackDataType ? `fallbackDataType: ${fallbackDataType}, ` : ''
+            }shape: ${shape}`,
+        );
         const wrapper = this.freeTensors.splice(index, 1)[0];
         wrapper.sessionId = sessionId;
         return wrapper;
       }
     }
-    LOG_DEBUG('verbose', () => `[WebNN] MLContext.createTensor {dataType: ${dataType}, shape: ${shape}}`);
+    LOG_DEBUG(
+      'verbose',
+      () =>
+        `[WebNN] MLContext.createTensor {dataType: ${dataType}, ${
+          fallbackDataType ? `fallbackDataType: ${fallbackDataType}, ` : ''
+        }shape: ${shape}}`,
+    );
     const tensor = await context.createTensor({
-      dataType,
+      dataType: fallbackDataType ? fallbackDataType : dataType, // If fallback data type is provided, use it.
       shape,
       dimensions: shape,
       usage,
       writable,
       readable,
     });
-    return new TensorWrapper({ sessionId, context, tensor, dataType, shape, shouldConvertInt64toInt32 });
+    return new TensorWrapper({ sessionId, context, tensor, dataType, shape, fallbackDataType });
   }
 
   /**

--- a/js/web/lib/wasm/jsep/webnn/webnn.d.ts
+++ b/js/web/lib/wasm/jsep/webnn/webnn.d.ts
@@ -420,6 +420,7 @@ interface MLContext {
 
 interface MLOpSupportLimits {
   input: MLSupportLimits;
+  output: MLSupportLimits;
 }
 
 interface MLSupportLimits {

--- a/js/web/lib/wasm/wasm-core-impl.ts
+++ b/js/web/lib/wasm/wasm-core-impl.ts
@@ -942,17 +942,17 @@ export const run = async (
             }
           } else if (preferredLocation === 'ml-tensor' && size > 0) {
             const ensureTensor = wasm.webnnEnsureTensor;
-            const isInt64Supported = wasm.webnnIsInt64Supported;
-            if (!ensureTensor || !isInt64Supported) {
+            const isGraphInputOutputTypeSupported = wasm.webnnIsGraphInputOutputTypeSupported;
+            if (!ensureTensor || !isGraphInputOutputTypeSupported) {
               throw new Error('preferredLocation "ml-tensor" is not supported without using WebNN.');
             }
             const tensorSize = calculateTensorSizeInBytes(dataType, size);
             if (tensorSize === undefined || !isMLTensorSupportedType(type)) {
               throw new Error(`Unsupported data type: ${type}`);
             }
-            if (type === 'int64' && !isInt64Supported(sessionId)) {
+            if (!isGraphInputOutputTypeSupported(sessionId, type, false)) {
               throw new Error(
-                `preferredLocation "ml-tensor" for int64 output is not supported by current WebNN Context.`,
+                `preferredLocation "ml-tensor" for ${type} output is not supported by current WebNN Context.`,
               );
             }
 

--- a/js/web/lib/wasm/wasm-types.ts
+++ b/js/web/lib/wasm/wasm-types.ts
@@ -309,11 +309,14 @@ export declare namespace JSEP {
      */
     webnnCreateTemporaryTensor: (sessionId: number, dataType: DataType, shape: readonly number[]) => Promise<number>;
     /**
-     * [exported from pre-jsep.js] Check if a session's associated WebNN Context supports int64.
+     * [exported from pre-jsep.js] Check if a session's associated WebNN Context supports given data type as its graph
+     * input/output.
      * @param sessionId - specify the session ID.
-     * @returns whether the WebNN Context supports int64.
+     * @param type - specify the graph input/output data type.
+     * @param isInput - specify whether the data type is for graph input.
+     * @returns whether the graph input/output of WebNN Context supports the given data type.
      */
-    webnnIsInt64Supported: (sessionId: number) => boolean;
+    webnnIsGraphInputOutputTypeSupported: (sessionId: number, type: Tensor.Type, isInput: boolean) => boolean;
   }
 }
 

--- a/onnxruntime/core/providers/webnn/builders/helper.h
+++ b/onnxruntime/core/providers/webnn/builders/helper.h
@@ -164,7 +164,7 @@ inline bool ReadScalarTensorData(const onnx::TensorProto& tensor, emscripten::va
       scalar = emscripten::val{*reinterpret_cast<uint64_t*>(unpacked_tensor.data())};
       break;
     default:
-      LOGS(logger, ERROR) << "Unsupported data type : " << tensor.data_type();
+      LOGS(logger, ERROR) << "WebNN backend does not support data type: " << tensor.data_type();
       return false;
       break;
   }

--- a/onnxruntime/core/providers/webnn/builders/helper.h
+++ b/onnxruntime/core/providers/webnn/builders/helper.h
@@ -364,6 +364,15 @@ const std::map<ONNX_NAMESPACE::TensorProto_DataType, std::string_view> onnx_to_w
     {ONNX_NAMESPACE::TensorProto_DataType_UINT64, "uint64"},
 };
 
+// This array contains the input/output data types of a WebNN graph that are allowed to be fallback to int32.
+constexpr std::array<ONNX_NAMESPACE::TensorProto_DataType, 5> supported_fallback_integer_data_types = {
+    ONNX_NAMESPACE::TensorProto_DataType_BOOL,
+    ONNX_NAMESPACE::TensorProto_DataType_INT8,
+    ONNX_NAMESPACE::TensorProto_DataType_UINT8,
+    ONNX_NAMESPACE::TensorProto_DataType_UINT32,
+    ONNX_NAMESPACE::TensorProto_DataType_INT64,
+};
+
 bool AreDataTypesSame(const std::string_view op_type,
                       gsl::span<const int32_t> input_types,
                       const logging::Logger& logger);

--- a/onnxruntime/core/providers/webnn/builders/impl/rotaryEmbedding_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/rotaryEmbedding_op_builder.cc
@@ -174,7 +174,8 @@ Status RotaryEmbeddingOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_build
     emscripten::val position_ids_range_desc = emscripten::val::object();
     position_ids_range_desc.set("shape", emscripten::val::array(position_ids_range_shape));
     position_ids_range_desc.set("dimensions", emscripten::val::array(position_ids_range_shape));
-    ORT_RETURN_IF_NOT(SetWebnnDataType(position_ids_range_desc, position_ids_data_type), "Unsupported data type");
+    ORT_RETURN_IF_NOT(SetWebnnDataType(position_ids_range_desc, position_ids_data_type),
+                      "WebNN backend does not support data type: ", position_ids_data_type);
     emscripten::val position_ids_range = wnn_builder.call<emscripten::val>(
         "constant", position_ids_range_desc, position_ids_range_buffer);
     // Add the offset to the sequence.
@@ -221,7 +222,8 @@ Status RotaryEmbeddingOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_build
   emscripten::val sign_constant_desc = emscripten::val::object();
   sign_constant_desc.set("shape", emscripten::val::array(sign_shape));
   sign_constant_desc.set("dimensions", emscripten::val::array(sign_shape));
-  ORT_RETURN_IF_NOT(SetWebnnDataType(sign_constant_desc, input_data_type), "Unsupported data type");
+  ORT_RETURN_IF_NOT(SetWebnnDataType(sign_constant_desc, input_data_type),
+                    "WebNN backend does not support data type: ", input_data_type);
   if (input_data_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {
     sign_buffer = emscripten::val::global("Float32Array").new_(2);
     sign_buffer.set(0, -1.0f);

--- a/onnxruntime/core/providers/webnn/builders/impl/shape_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/shape_op_builder.cc
@@ -40,7 +40,7 @@ Status ShapeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
     data_type = ONNX_NAMESPACE::TensorProto_DataType_INT32;
     typed_array_name = "Int32Array";
   }
-  ORT_RETURN_IF_NOT(SetWebnnDataType(desc, data_type), "Unsupported data type");
+  ORT_RETURN_IF_NOT(SetWebnnDataType(desc, data_type), "WebNN backend does not support data type: ", data_type);
   emscripten::val shape_buffer =
       emscripten::val::global(typed_array_name.c_str()).new_(emscripten::val::array(input_shape));
   emscripten::val shape_constant = model_builder.GetBuilder().call<emscripten::val>("constant", desc, shape_buffer);

--- a/onnxruntime/core/providers/webnn/builders/model_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/model_builder.cc
@@ -33,7 +33,7 @@ ModelBuilder::ModelBuilder(const GraphViewer& graph_viewer, const logging::Logge
   if (!wnn_builder_.as<bool>()) {
     ORT_THROW("Failed to create WebNN builder.");
   }
-  if (wnn_limits["input"]["dataTypes"].call<emscripten::val>("includes", emscripten::val("int64")).as<bool>()) {
+  if (wnn_limits["constant"]["dataTypes"].call<emscripten::val>("includes", emscripten::val("int64")).as<bool>()) {
     is_int64_supported_ = true;
   }
 }
@@ -100,7 +100,7 @@ Status ModelBuilder::RegisterConstant(const onnx::TensorProto& tensor, emscripte
   emscripten::val wnn_builder = GetBuilder();
   const auto data_type = tensor.data_type();
 
-  // A flag to indicate if we should convert int64 to int32.
+  // A flag to indicate if we should convert int64 constant to int32.
   const bool should_convert_int64_to_int32 = !IsInt64Supported() &&
                                              data_type == ONNX_NAMESPACE::TensorProto_DataType_INT64;
 
@@ -291,15 +291,54 @@ Status ModelBuilder::RegisterModelInputOutput(const NodeArg& node_arg, bool is_i
     ORT_RETURN_IF_NOT(SetWebnnDataType(desc, data_type), "Unsupported data type");
   }
 
+  emscripten::val wnn_data_type = desc["dataType"];
+  bool cast_required = false;
+
+  // Some WebNN backends support limited data types for the input and output of a WebNN graph. However,
+  // they can support more data types for intermediate nodes. To address this limitation, we implement a
+  // data type fallback mechanism. (Note: Currently, we only support fallback to int32 for certain integer data types.)
+  // If a data type is not supported for a graph's input or output but is supported for intermediate nodes, we will:
+  //
+  // 1. Save the input MLTensor as 'int32' data type,
+  // 2. Convert the input data from ORT to int32 (handled in tensor-manager.ts),
+  // 3. Insert a cast operation to WebNN graph to convert the input back to its original data type,
+  // 4. Insert a cast operation to WebNN graph to convert the output back to 'int32',
+  // 5. Convert the output data from int32 to its original data type (handled in tensor-manager.ts).
+  if (!wnn_limits_[input_output_type]["dataTypes"].call<emscripten::val>("includes", desc["dataType"]).as<bool>() &&
+      wnn_limits_["constant"]["dataTypes"].call<emscripten::val>("includes", desc["dataType"]).as<bool>() &&
+      std::find(supported_fallback_integer_data_types.cbegin(),
+                supported_fallback_integer_data_types.cend(),
+                data_type) != supported_fallback_integer_data_types.cend()) {
+    LOGS(logger_, VERBOSE) << "The data type " << wnn_data_type.as<std::string>()
+                           << " of the graph " << input_output_type << " [" << name
+                           << "] is not supported. Fallback to int32.";
+    cast_required = true;
+  }
+
   if (is_input) {
-    if (data_type == ONNX_NAMESPACE::TensorProto_DataType_INT64 && !is_int64_supported_) {
-      // Int64 is not supported by current context, use int32 instead.
+    // Another case is that if the 'int64' data type is totally not supported by the WebNN backend.
+    // We will convert the initializers to int32 as well, thereforce, the WebNN graph will only produce
+    // int32 data and we don't need to insert additional cast operation.
+    if (cast_required || (data_type == ONNX_NAMESPACE::TensorProto_DataType_INT64 && !is_int64_supported_)) {
+      // Fallback the input data type to int32.
       desc.set("dataType", emscripten::val("int32"));
     }
-    wnn_operands_.insert(std::make_pair(name, wnn_builder_.call<emscripten::val>("input", name, desc)));
+
+    emscripten::val wnn_input = wnn_builder_.call<emscripten::val>("input", name, desc);
+
+    if (cast_required) {
+      // Insert cast to convert the input data type to the original data type.
+      emscripten::val cast_options = emscripten::val::object();
+      cast_options.set("label", name + "_cast_input_to_original_data_type");
+      wnn_input = wnn_builder_.call<emscripten::val>("cast", wnn_input, wnn_data_type, cast_options);
+    }
+    wnn_operands_.insert(std::make_pair(name, wnn_input));
     emscripten::val::module_property("webnnRegisterGraphInput")(name);
     input_names_.push_back(name);
   } else {
+    if (cast_required) {
+      cast_required_output_names_.push_back(name);
+    }
     emscripten::val::module_property("webnnRegisterGraphOutput")(name);
     output_names_.push_back(name);
   }
@@ -408,7 +447,17 @@ Status ModelBuilder::Compile(std::unique_ptr<Model>& model) {
   ORT_RETURN_IF_ERROR(Initialize());
   emscripten::val named_operands = emscripten::val::object();
   for (auto& name : output_names_) {
-    named_operands.set(name, wnn_operands_.at(name));
+    emscripten::val wnn_output = wnn_operands_.at(name);
+
+    // If the output name is in cast_required_output_names_, cast it to int32.
+    if (std::find(cast_required_output_names_.cbegin(),
+                  cast_required_output_names_.cend(),
+                  name) != cast_required_output_names_.cend()) {
+      emscripten::val cast_options = emscripten::val::object();
+      cast_options.set("label", name + "_cast_output_to_int32");
+      wnn_output = wnn_builder_.call<emscripten::val>("cast", wnn_output, emscripten::val("int32"), cast_options);
+    }
+    named_operands.set(name, wnn_output);
   }
 
   emscripten::val wnn_graph = wnn_builder_.call<emscripten::val>("build", named_operands).await();

--- a/onnxruntime/core/providers/webnn/builders/model_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/model_builder.cc
@@ -230,7 +230,7 @@ Status ModelBuilder::RegisterInitializers() {
     const auto data_type = tensor.data_type();
     emscripten::val operand = emscripten::val::object();
     if (IsSupportedDataType(data_type, wnn_limits_["constant"]["dataTypes"])) {
-      ORT_RETURN_IF_NOT(SetWebnnDataType(desc, data_type), "Unsupported data type");
+      ORT_RETURN_IF_NOT(SetWebnnDataType(desc, data_type), "WebNN backend does not support data type: ", data_type);
       ORT_RETURN_IF_ERROR(RegisterConstant(tensor, operand, desc, logger_));
     } else {
       // TODO: support other type.
@@ -288,7 +288,7 @@ Status ModelBuilder::RegisterModelInputOutput(const NodeArg& node_arg, bool is_i
     }
 
     data_type = type_proto->tensor_type().elem_type();
-    ORT_RETURN_IF_NOT(SetWebnnDataType(desc, data_type), "Unsupported data type");
+    ORT_RETURN_IF_NOT(SetWebnnDataType(desc, data_type), "WebNN backend does not support data type: ", data_type);
   }
 
   emscripten::val wnn_data_type = desc["dataType"];
@@ -316,9 +316,9 @@ Status ModelBuilder::RegisterModelInputOutput(const NodeArg& node_arg, bool is_i
   }
 
   if (is_input) {
-    // Another case is that if the 'int64' data type is totally not supported by the WebNN backend.
-    // We will convert the initializers to int32 as well, thereforce, the WebNN graph will only produce
-    // int32 data and we don't need to insert additional cast operation.
+    // Another case is that if the 'int64' data type is totally unsupported by the WebNN backend.
+    // We will convert the initializers to int32 as well, therefore, the WebNN graph will only produce
+    // int32 data, and we don't need to insert additional cast operation.
     if (cast_required || (data_type == ONNX_NAMESPACE::TensorProto_DataType_INT64 && !is_int64_supported_)) {
       // Fallback the input data type to int32.
       desc.set("dataType", emscripten::val("int32"));
@@ -383,7 +383,7 @@ Status ModelBuilder::AddOperandFromPersistMemoryBuffer(
   memcpy(dest, buffer, size);
   emscripten::val view = emscripten::val::undefined();
   emscripten::val desc = emscripten::val::object();
-  ORT_RETURN_IF_NOT(SetWebnnDataType(desc, data_type), "Unsupported data type");
+  ORT_RETURN_IF_NOT(SetWebnnDataType(desc, data_type), "WebNN backend does not support data type: ", data_type);
   switch (data_type) {
     case ONNX_NAMESPACE::TensorProto_DataType_BOOL:
     case ONNX_NAMESPACE::TensorProto_DataType_UINT8:

--- a/onnxruntime/core/providers/webnn/builders/model_builder.h
+++ b/onnxruntime/core/providers/webnn/builders/model_builder.h
@@ -160,7 +160,7 @@ const emscripten::val& ModelBuilder::CreateOrGetConstant(const int32_t& data_typ
     desc.set("dimensions", dims);
     emscripten::val buffer = emscripten::val::undefined();
     if (!SetWebnnDataType(desc, data_type)) {
-      ORT_THROW("Unsupported data type: " + std::to_string(data_type));
+      ORT_THROW("WebNN backend does not support data type: ", data_type);
     }
     auto num_elements = Product(shape);
     switch (data_type) {
@@ -253,7 +253,7 @@ const emscripten::val& ModelBuilder::CreateOrGetConstant(const int32_t& data_typ
     desc.set("dimensions", dims);
     emscripten::val buffer = emscripten::val::undefined();
     if (!SetWebnnDataType(desc, data_type)) {
-      ORT_THROW("Unsupported data type: " + std::to_string(data_type));
+      ORT_THROW("WebNN backend does not support data type: ", data_type);
     }
     switch (data_type) {
       case ONNX_NAMESPACE::TensorProto_DataType_BOOL:

--- a/onnxruntime/core/providers/webnn/builders/model_builder.h
+++ b/onnxruntime/core/providers/webnn/builders/model_builder.h
@@ -89,6 +89,9 @@ class ModelBuilder {
   InlinedHashMap<std::string, emscripten::val> wnn_operands_;
   std::vector<std::string> input_names_;
   std::vector<std::string> output_names_;
+  // The output names which need to be casted to int32.
+  std::vector<std::string> cast_required_output_names_;
+  std::vector<std::vector<uint8_t>> unpacked_tensors_;
 
   InlinedHashMap<std::string, OnnxTensorInfo> input_output_info_;
 

--- a/onnxruntime/wasm/pre-jsep.js
+++ b/onnxruntime/wasm/pre-jsep.js
@@ -157,6 +157,6 @@ Module["jsepInit"] = (name, params) => {
 
     Module["webnnCreateTemporaryTensor"] =
       backend["createTemporaryTensor"].bind(backend);
-    Module["webnnIsInt64Supported"] = backend["isInt64Supported"].bind(backend);
+    Module["webnnIsGraphInputOutputTypeSupported"] = backend["isGraphInputOutputTypeSupported"].bind(backend);
   }
 };


### PR DESCRIPTION
Some WebNN backends support limited data types for the input and output of a WebNN graph. However, they can support more data types for intermediate nodes. To address this limitation, we implement a data type fallback mechanism. (Note: Currently, we only support fallback to int32 for certain integer data types.)

If a data type is not supported for a graph's input or output but is supported for intermediate nodes, we will:
1. Save the input MLTensor as 'int32' data type,
2. Convert the input data from ORT to int32,
3. Insert a cast operation to WebNN graph to convert the input back to its original data type,
4. Insert a cast operation to WebNN graph to convert the output back to 'int32',
5. Convert the output data from int32 to its original data type.