### PR TITLE
[WebNN] Always execute decomposed *SimplifiedLayerNormalization in FP32

### DIFF
--- a/onnxruntime/core/providers/webnn/builders/impl/normalization_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/normalization_op_builder.cc
@@ -115,17 +115,20 @@ Status NormalizationOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder
       emscripten::val common_options = emscripten::val::object();
 
       if (input_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT16) {
-        // Decomposed *SimplifiedLayerNormalization may lose precision if its data type is float16,
-        // cast all inputs to float32 to ensure precision.
+        // Decomposed *SimplifiedLayerNormalization may lose precision if its data type is float16.
+        // So cast all inputs to float32 to ensure precision.
         common_options.set("label", node.Name() + "_cast_input_to_fp32");
-        input = model_builder.GetBuilder().call<emscripten::val>("cast", input, emscripten::val("float32"));
+        input = model_builder.GetBuilder().call<emscripten::val>("cast", input,
+                                                                 emscripten::val("float32"), common_options);
 
         common_options.set("label", node.Name() + "_cast_scale_to_fp32");
-        scale = model_builder.GetBuilder().call<emscripten::val>("cast", scale, emscripten::val("float32"));
+        scale = model_builder.GetBuilder().call<emscripten::val>("cast", scale,
+                                                                 emscripten::val("float32"), common_options);
 
         if (!bias.isUndefined()) {
           common_options.set("label", node.Name() + "_cast_bias_to_fp32");
-          bias = model_builder.GetBuilder().call<emscripten::val>("cast", bias, emscripten::val("float32"));
+          bias = model_builder.GetBuilder().call<emscripten::val>("cast", bias,
+                                                                  emscripten::val("float32"), common_options);
         }
       }
 
@@ -135,7 +138,8 @@ Status NormalizationOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder
         if (input_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT16) {
           // Cast skip to float32
           common_options.set("label", node.Name() + "_cast_skip_to_fp32");
-          skip = model_builder.GetBuilder().call<emscripten::val>("cast", skip, emscripten::val("float32"));
+          skip = model_builder.GetBuilder().call<emscripten::val>("cast", skip,
+                                                                  emscripten::val("float32"), common_options);
         }
         common_options.set("label", node.Name() + "_add_skip");
         input = model_builder.GetBuilder().call<emscripten::val>("add", input, skip, common_options);
@@ -152,7 +156,8 @@ Status NormalizationOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder
             // Cast input_skip_bias_sum back to float16.
             common_options.set("label", node.Name() + "_cast_input_skip_bias_sum_to_fp16");
             input_skip_bias_sum = model_builder.GetBuilder().call<emscripten::val>("cast", input_skip_bias_sum,
-                                                                                   emscripten::val("float16"));
+                                                                                   emscripten::val("float16"),
+                                                                                   common_options);
           }
           model_builder.AddOperand(output_defs[3]->Name(), input_skip_bias_sum);
         }
@@ -200,7 +205,8 @@ Status NormalizationOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder
       if (input_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT16) {
         // Cast output back to float16.
         common_options.set("label", node.Name() + "_cast_output_to_fp16");
-        output = model_builder.GetBuilder().call<emscripten::val>("cast", output, emscripten::val("float16"));
+        output = model_builder.GetBuilder().call<emscripten::val>("cast", output,
+                                                                  emscripten::val("float16"), common_options);
       }
     }
   } else if (op_type == "InstanceNormalization") {

--- a/onnxruntime/core/providers/webnn/builders/impl/normalization_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/normalization_op_builder.cc
@@ -114,9 +114,29 @@ Status NormalizationOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder
       ORT_RETURN_IF_NOT(GetType(*input_defs[0], input_type, logger), "Cannot get input type");
       emscripten::val common_options = emscripten::val::object();
 
+      if (input_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT16) {
+        // Decomposed *SimplifiedLayerNormalization may lose precision if its data type is float16,
+        // cast all inputs to float32 to ensure precision.
+        common_options.set("label", node.Name() + "_cast_input_to_fp32");
+        input = model_builder.GetBuilder().call<emscripten::val>("cast", input, emscripten::val("float32"));
+
+        common_options.set("label", node.Name() + "_cast_scale_to_fp32");
+        scale = model_builder.GetBuilder().call<emscripten::val>("cast", scale, emscripten::val("float32"));
+
+        if (!bias.isUndefined()) {
+          common_options.set("label", node.Name() + "_cast_bias_to_fp32");
+          bias = model_builder.GetBuilder().call<emscripten::val>("cast", bias, emscripten::val("float32"));
+        }
+      }
+
       // If it is SkipSimplifiedLayerNormalization, add the skip and bias (if it exists) to the input.
       if (op_type == "SkipSimplifiedLayerNormalization") {
         emscripten::val skip = model_builder.GetOperand(input_defs[1]->Name());
+        if (input_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT16) {
+          // Cast skip to float32
+          common_options.set("label", node.Name() + "_cast_skip_to_fp32");
+          skip = model_builder.GetBuilder().call<emscripten::val>("cast", skip, emscripten::val("float32"));
+        }
         common_options.set("label", node.Name() + "_add_skip");
         input = model_builder.GetBuilder().call<emscripten::val>("add", input, skip, common_options);
         if (!bias.isUndefined()) {
@@ -127,12 +147,20 @@ Status NormalizationOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder
         // Add SkipSimplifiedLayerNormalization's output input_skip_bias_sum if it exists.
         // Now input equals to input_skip_bias_sum.
         if (TensorExists(output_defs, 3)) {
-          model_builder.AddOperand(output_defs[3]->Name(), input);
+          emscripten::val input_skip_bias_sum = input;
+          if (input_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT16) {
+            // Cast input_skip_bias_sum back to float16.
+            common_options.set("label", node.Name() + "_cast_input_skip_bias_sum_to_fp16");
+            input_skip_bias_sum = model_builder.GetBuilder().call<emscripten::val>("cast", input_skip_bias_sum,
+                                                                                   emscripten::val("float16"));
+          }
+          model_builder.AddOperand(output_defs[3]->Name(), input_skip_bias_sum);
         }
       }
 
       // Pow
-      emscripten::val pow_constant = model_builder.CreateOrGetConstant<float>(input_type, 2);
+      emscripten::val pow_constant =
+          model_builder.CreateOrGetConstant<float>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT, 2);
       common_options.set("label", node.Name() + "_pow");
       emscripten::val pow =
           model_builder.GetBuilder().call<emscripten::val>("pow", input, pow_constant, common_options);
@@ -145,7 +173,8 @@ Status NormalizationOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder
       emscripten::val reduce_mean = model_builder.GetBuilder().call<emscripten::val>("reduceMean", pow, reduce_options);
 
       // Add
-      emscripten::val add_constant = model_builder.CreateOrGetConstant<float>(input_type, epsilon);
+      emscripten::val add_constant =
+          model_builder.CreateOrGetConstant<float>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT, epsilon);
       common_options.set("label", node.Name() + "_add");
       emscripten::val add =
           model_builder.GetBuilder().call<emscripten::val>("add", reduce_mean, add_constant, common_options);
@@ -166,6 +195,12 @@ Status NormalizationOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder
       if (!bias.isUndefined()) {
         common_options.set("label", node.Name() + "_add_bias");
         output = model_builder.GetBuilder().call<emscripten::val>("add", output, bias, common_options);
+      }
+
+      if (input_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT16) {
+        // Cast output back to float16.
+        common_options.set("label", node.Name() + "_cast_output_to_fp16");
+        output = model_builder.GetBuilder().call<emscripten::val>("cast", output, emscripten::val("float16"));
       }
     }
   } else if (op_type == "InstanceNormalization") {


### PR DESCRIPTION
Decomposed [Skip]SimplifiedLayerNormalization will lose precision in FP16, we'd like to add cast (to: fp32) ops around it in WebNN EP to ensure its precision rather than manually add cast nodes in each model file.