### PR TITLE
[nodejs] upgrade N-API version to 6

### DIFF
--- a/js/node/CMakeLists.txt
+++ b/js/node/CMakeLists.txt
@@ -12,7 +12,7 @@ execute_process(COMMAND node -e "console.log(process.platform)"
                 OUTPUT_VARIABLE node_platform OUTPUT_STRIP_TRAILING_WHITESPACE)
 file(READ ${CMAKE_SOURCE_DIR}/../../VERSION_NUMBER ort_version)
 string(STRIP "${ort_version}" ort_version)
-set(dist_folder "${CMAKE_SOURCE_DIR}/bin/napi-v3/${node_platform}/${NODE_ARCH}/")
+set(dist_folder "${CMAKE_SOURCE_DIR}/bin/napi-v6/${node_platform}/${NODE_ARCH}/")
 
 # onnxruntime.dll dir
 if(NOT ONNXRUNTIME_BUILD_DIR)

--- a/js/node/lib/binding.ts
+++ b/js/node/lib/binding.ts
@@ -53,7 +53,7 @@ export declare namespace Binding {
 // export native binding
 export const binding =
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-  require(`../bin/napi-v3/${process.platform}/${process.arch}/onnxruntime_binding.node`) as {
+  require(`../bin/napi-v6/${process.platform}/${process.arch}/onnxruntime_binding.node`) as {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     InferenceSession: Binding.InferenceSessionConstructor;
     listSupportedBackends: () => Binding.SupportedBackend[];

--- a/js/node/package.json
+++ b/js/node/package.json
@@ -6,6 +6,11 @@
     "type": "git"
   },
   "author": "fs-eire",
+  "binary": {
+    "napi_versions": [
+      6
+    ]
+  },
   "version": "1.22.0",
   "dependencies": {
     "adm-zip": "^0.5.16",

--- a/js/node/script/install.js
+++ b/js/node/script/install.js
@@ -92,7 +92,7 @@ if (typeof INSTALL_FLAG === 'string') {
   INSTALL_MANIFEST_NAMES = installations;
 }
 
-const BIN_FOLDER = path.join(__dirname, '..', 'bin/napi-v3', PLATFORM);
+const BIN_FOLDER = path.join(__dirname, '..', 'bin/napi-v6', PLATFORM);
 const INSTALL_MANIFESTS = [];
 
 const PACKAGES = new Set();

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/dml-vs-2022.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/dml-vs-2022.yml
@@ -75,7 +75,7 @@ stages:
         inputs:
           versionSpec: '3.12'
           addToPath: true
-          architecture: ${{ parameters.BuildArch }}   
+          architecture: ${{ parameters.BuildArch }}
 
       # need to set PROCESSOR_ARCHITECTURE so the x86 SDK is installed correctly
       - task: UseDotNet@2
@@ -168,13 +168,13 @@ stages:
             modifyEnvironment: true
         - template: ../../templates/win-esrp-dll.yml
           parameters:
-            FolderPath: '$(Build.SourcesDirectory)\js\node\bin\napi-v3\win32\x64'
+            FolderPath: '$(Build.SourcesDirectory)\js\node\bin\napi-v6\win32\x64'
             DisplayName: 'ESRP - Sign Node.js binding binaries'
             DoEsrp: ${{ parameters.DoEsrp }}
             Pattern: '*.dll,*.node'
 
         - script: |
-           del /Q $(Build.SourcesDirectory)\js\node\bin\napi-v3\win32\x64\CodeSignSummary-*.*
+           del /Q $(Build.SourcesDirectory)\js\node\bin\napi-v6\win32\x64\CodeSignSummary-*.*
            call npm pack
            copy $(Build.SourcesDirectory)\js\node\onnxruntime-*.tgz $(Build.ArtifactStagingDirectory)
            xcopy /E /I $(Build.SourcesDirectory)\js\node\prebuilds $(Build.ArtifactStagingDirectory)\prebuilds
@@ -196,18 +196,18 @@ stages:
 
       - ${{ if eq(parameters.BuildNodejs, 'true') }}:
         - task: CopyFiles@2
-          displayName: 'Copy DirectML binaries to: $(Build.SourcesDirectory)\js\node\bin\napi-v3\win32\${{ parameters.sln_platform }}'
+          displayName: 'Copy DirectML binaries to: $(Build.SourcesDirectory)\js\node\bin\napi-v6\win32\${{ parameters.sln_platform }}'
           inputs:
             SourceFolder: '$(Build.BinariesDirectory)\$(BuildConfig)\$(BuildConfig)'
             Contents: 'DirectML.dll'
-            TargetFolder: '$(Build.SourcesDirectory)\js\node\bin\napi-v3\win32\${{ parameters.sln_platform }}'
+            TargetFolder: '$(Build.SourcesDirectory)\js\node\bin\napi-v6\win32\${{ parameters.sln_platform }}'
         - template: ../../templates/win-esrp-dll.yml
           parameters:
-            FolderPath: '$(Build.SourcesDirectory)\js\node\bin\napi-v3\win32\${{ parameters.sln_platform }}'
+            FolderPath: '$(Build.SourcesDirectory)\js\node\bin\napi-v6\win32\${{ parameters.sln_platform }}'
             DisplayName: 'ESRP - Sign Node.js binding binaries'
             DoEsrp: ${{ parameters.DoEsrp }}
             Pattern: '*.node'
         - task: 1ES.PublishPipelineArtifact@1
           inputs:
-            targetPath: '$(Build.SourcesDirectory)\js\node\bin\napi-v3\win32\${{ parameters.sln_platform }}'
+            targetPath: '$(Build.SourcesDirectory)\js\node\bin\napi-v6\win32\${{ parameters.sln_platform }}'
             artifactName: 'drop-onnxruntime-nodejs-win-${{ parameters.sln_platform }}-dml'

--- a/tools/ci_build/github/azure-pipelines/stages/nodejs-win-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nodejs-win-packaging-stage.yml
@@ -127,11 +127,11 @@ stages:
           arguments: ${{ parameters.BuildArch }}
           modifyEnvironment: true
       - task: CopyFiles@2
-        displayName: 'Copy DirectML binaries to: $(Build.SourcesDirectory)\js\node\bin\napi-v3\win32\${{ parameters.sln_platform }}'
+        displayName: 'Copy DirectML binaries to: $(Build.SourcesDirectory)\js\node\bin\napi-v6\win32\${{ parameters.sln_platform }}'
         inputs:
           SourceFolder: '$(Build.BinariesDirectory)\$(BuildConfig)\$(BuildConfig)'
           Contents: 'DirectML.dll'
-          TargetFolder: '$(Build.SourcesDirectory)\js\node\bin\napi-v3\win32\${{ parameters.sln_platform }}'
+          TargetFolder: '$(Build.SourcesDirectory)\js\node\bin\napi-v6\win32\${{ parameters.sln_platform }}'
       - powershell: |
           $dxcZipUrl = "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.8.2502/dxc_2025_02_20.zip"
           $dxcZipPath = "$(Build.BinariesDirectory)\dxc.zip"
@@ -153,7 +153,7 @@ stages:
 
           # Copy the necessary DLLs to the target directory
           $sourcePath = Join-Path $dxcExtractPath "bin\$targetArch"
-          $targetPath = "$(Build.SourcesDirectory)\js\node\bin\napi-v3\win32\$targetArch"
+          $targetPath = "$(Build.SourcesDirectory)\js\node\bin\napi-v6\win32\$targetArch"
 
           Write-Host "Copying dxil.dll and dxcompiler.dll from $sourcePath to $targetPath"
           Copy-Item -Path "$sourcePath\dxil.dll" -Destination $targetPath -Force
@@ -163,13 +163,13 @@ stages:
         displayName: 'Download and Copy DXC Binaries'
       - template: ../templates/win-esrp-dll.yml
         parameters:
-          FolderPath: '$(Build.SourcesDirectory)\js\node\bin\napi-v3\win32\${{ parameters.sln_platform }}'
+          FolderPath: '$(Build.SourcesDirectory)\js\node\bin\napi-v6\win32\${{ parameters.sln_platform }}'
           DisplayName: 'ESRP - Sign Node.js binding binaries'
           DoEsrp: ${{ parameters.DoEsrp }}
           Pattern: '*.dll,*.node'
 
       - script: |
-          del /Q $(Build.SourcesDirectory)\js\node\bin\napi-v3\win32\${{ parameters.sln_platform }}\CodeSignSummary-*.*
+          del /Q $(Build.SourcesDirectory)\js\node\bin\napi-v6\win32\${{ parameters.sln_platform }}\CodeSignSummary-*.*
           call npm pack
           copy $(Build.SourcesDirectory)\js\node\onnxruntime-*.tgz $(Build.ArtifactStagingDirectory)
         workingDirectory: '$(Build.SourcesDirectory)\js\node'
@@ -177,7 +177,7 @@ stages:
 
       - task: 1ES.PublishPipelineArtifact@1
         inputs:
-          targetPath: '$(Build.SourcesDirectory)\js\node\bin\napi-v3\win32\${{ parameters.sln_platform }}'
+          targetPath: '$(Build.SourcesDirectory)\js\node\bin\napi-v6\win32\${{ parameters.sln_platform }}'
           artifactName: ${{ parameters.ArtifactName }}
 
       - ${{ if and(eq(parameters.PublishWebGpuBuildTools, true), eq(parameters.sln_platform, 'x64')) }}:

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -599,7 +599,7 @@ stages:
     #  - linux/x64/libonnxruntime_providers_cuda.so
     #
     # Rest binary artifacts will eventually be put into folder before packaging 'onnxruntime-node':
-    #  $(Build.SourcesDirectory)\js\node\bin\napi-v3\{os}\{cpu_arch}\
+    #  $(Build.SourcesDirectory)\js\node\bin\napi-v6\{os}\{cpu_arch}\
     #
     # {os} is one of 'win32', 'darwin', 'linux' and {cpu_arch} is one of 'x64', 'arm64'.
 
@@ -659,63 +659,63 @@ stages:
 
     # Node.js binding win32/x64
     - task: CopyFiles@2
-      displayName: 'Copy binaries to: $(Build.SourcesDirectory)\js\node\bin\napi-v3\win32\x64\'
+      displayName: 'Copy binaries to: $(Build.SourcesDirectory)\js\node\bin\napi-v6\win32\x64\'
       inputs:
         SourceFolder: '$(Build.BinariesDirectory)\nodejs-artifacts\win32\x64'
         Contents: |
           *.dll
           *.node
-        TargetFolder: '$(Build.SourcesDirectory)\js\node\bin\napi-v3\win32\x64'
+        TargetFolder: '$(Build.SourcesDirectory)\js\node\bin\napi-v6\win32\x64'
 
     # Node.js binding win32/arm64
     - task: CopyFiles@2
-      displayName: 'Copy binaries to: $(Build.SourcesDirectory)\js\node\bin\napi-v3\win32\arm64\'
+      displayName: 'Copy binaries to: $(Build.SourcesDirectory)\js\node\bin\napi-v6\win32\arm64\'
       inputs:
         SourceFolder: '$(Build.BinariesDirectory)\nodejs-artifacts\win32\arm64'
         Contents: |
           *.dll
           *.node
-        TargetFolder: '$(Build.SourcesDirectory)\js\node\bin\napi-v3\win32\arm64'
+        TargetFolder: '$(Build.SourcesDirectory)\js\node\bin\napi-v6\win32\arm64'
 
     # Node.js binding linux/x64
     - task: CopyFiles@2
-      displayName: 'Copy nodejs binaries to: $(Build.SourcesDirectory)\js\node\bin\napi-v3\linux\x64\'
+      displayName: 'Copy nodejs binaries to: $(Build.SourcesDirectory)\js\node\bin\napi-v6\linux\x64\'
       inputs:
         SourceFolder: '$(Build.BinariesDirectory)\nodejs-artifacts\linux\x64'
         Contents: |
           libonnxruntime.so.1
           *.node
-        TargetFolder: '$(Build.SourcesDirectory)\js\node\bin\napi-v3\linux\x64'
+        TargetFolder: '$(Build.SourcesDirectory)\js\node\bin\napi-v6\linux\x64'
 
     # Node.js binding linux/arm64
     - task: CopyFiles@2
-      displayName: 'Copy nodejs binaries to: $(Build.SourcesDirectory)\js\node\bin\napi-v3\linux\arm64\'
+      displayName: 'Copy nodejs binaries to: $(Build.SourcesDirectory)\js\node\bin\napi-v6\linux\arm64\'
       inputs:
         SourceFolder: '$(Build.BinariesDirectory)\nodejs-artifacts\linux\arm64'
         Contents: |
           libonnxruntime.so.1
           *.node
-        TargetFolder: '$(Build.SourcesDirectory)\js\node\bin\napi-v3\linux\arm64'
+        TargetFolder: '$(Build.SourcesDirectory)\js\node\bin\napi-v6\linux\arm64'
 
     # Node.js binding darwin/x64
     - task: CopyFiles@2
-      displayName: 'Copy nodejs binaries to: $(Build.SourcesDirectory)\js\node\bin\napi-v3\darwin\x64\'
+      displayName: 'Copy nodejs binaries to: $(Build.SourcesDirectory)\js\node\bin\napi-v6\darwin\x64\'
       inputs:
         SourceFolder: '$(Build.BinariesDirectory)\nodejs-artifacts\darwin\x64'
         Contents: |
           libonnxruntime.*.dylib
           *.node
-        TargetFolder: '$(Build.SourcesDirectory)\js\node\bin\napi-v3\darwin\x64'
+        TargetFolder: '$(Build.SourcesDirectory)\js\node\bin\napi-v6\darwin\x64'
 
     # Node.js binding darwin/arm64
     - task: CopyFiles@2
-      displayName: 'Copy nodejs binaries to: $(Build.SourcesDirectory)\js\node\bin\napi-v3\darwin\arm64\'
+      displayName: 'Copy nodejs binaries to: $(Build.SourcesDirectory)\js\node\bin\napi-v6\darwin\arm64\'
       inputs:
         SourceFolder: '$(Build.BinariesDirectory)\nodejs-artifacts\darwin\arm64'
         Contents: |
           libonnxruntime.*.dylib
           *.node
-        TargetFolder: '$(Build.SourcesDirectory)\js\node\bin\napi-v3\darwin\arm64'
+        TargetFolder: '$(Build.SourcesDirectory)\js\node\bin\napi-v6\darwin\arm64'
 
     - task: PowerShell@2
       inputs:

--- a/tools/ci_build/github/azure-pipelines/templates/nodejs-artifacts-package-and-publish-steps-posix.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/nodejs-artifacts-package-and-publish-steps-posix.yml
@@ -8,9 +8,9 @@ parameters:
 - name: artifactName
   type: string
   default: ''
-  
+
 steps:
     - task: 1ES.PublishPipelineArtifact@1
       inputs:
-        targetPath: '$(Build.SourcesDirectory)/js/node/bin/napi-v3/${{ parameters.os }}/${{ parameters.arch }}'
+        targetPath: '$(Build.SourcesDirectory)/js/node/bin/napi-v6/${{ parameters.os }}/${{ parameters.arch }}'
         artifactName: '${{parameters.artifactName}}'

--- a/tools/ci_build/github/azure-pipelines/templates/nodejs-artifacts-package-and-publish-steps-windows.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/nodejs-artifacts-package-and-publish-steps-windows.yml
@@ -8,21 +8,21 @@ parameters:
   displayName: Run code sign tasks? Must be true if you are doing an Onnx Runtime release.
   type: boolean
   default: true
-  
+
 - name: artifactName
   type: string
   default: ''
-  
+
 steps:
   - ${{ if eq(parameters.DoEsrp, true) }}:
     - template: win-esrp-dll.yml
       parameters:
-        FolderPath: '$(Build.SourcesDirectory)\js\node\bin\napi-v3\win32\${{ parameters.arch }}'
+        FolderPath: '$(Build.SourcesDirectory)\js\node\bin\napi-v6\win32\${{ parameters.arch }}'
         DisplayName: 'ESRP - Sign Node.js binding binaries'
         DoEsrp: ${{parameters.DoEsrp}}
         Pattern: '*.node'
 
   - task: 1ES.PublishPipelineArtifact@1
     inputs:
-      targetPath: '$(Build.SourcesDirectory)\js\node\bin\napi-v3\win32\${{ parameters.arch }}'
+      targetPath: '$(Build.SourcesDirectory)\js\node\bin\napi-v6\win32\${{ parameters.arch }}'
       artifactName: '${{parameters.artifactName}}'


### PR DESCRIPTION
### Description

Update N-API version to 6.

- NAPI v6 is required for `napi_set_instance_data` and `napi_get_instance_data`, as used by #24366
- Adding the "binary" field in package.json for CMake-js to work correctly. (was unintentially removed in #24418)

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


