### PR TITLE
[QNN EP] Reverting a recent logging change for QNN GPU only, 

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -371,8 +371,16 @@ Status QnnBackendManager::InitializeQnnLog(const logging::Logger& logger) {
 QnnLog_Level_t QnnBackendManager::MapOrtSeverityToQNNLogLevel(logging::Severity ort_log_level) {
   // Map ORT log severity to Qnn log level
   switch (ort_log_level) {
-    case logging::Severity::kVERBOSE:
-      return QNN_LOG_LEVEL_VERBOSE;
+    case logging::Severity::kVERBOSE: {
+      switch ((GetQnnBackendType())) {
+        case QnnBackendType::GPU:
+          // Currently GPU needs this log level to work.
+          // This switch will be removed once this is resolved.
+          return QNN_LOG_LEVEL_DEBUG;
+        default:
+          return QNN_LOG_LEVEL_VERBOSE;
+      }
+    }
     case logging::Severity::kINFO:
       return QNN_LOG_LEVEL_INFO;
     case logging::Severity::kWARNING:


### PR DESCRIPTION

### Description
Mapping ORT verbose logging back to QnnGpu Debug logging.

### Motivation and Context
Why is this change required? What problem does it solve?
As of now this change is required for the QnnGpu backend to run models correctly.
It's necessity is mentioned in this commit
https://github.com/microsoft/onnxruntime/commit/b4b5a798371f79ef18587bea24ef348bd94d7e6c
It is temporarily reverting this commit. for the GPU case only, due to loss of functionality
https://github.com/microsoft/onnxruntime/commit/9d45b9ae27014112342f1b50e5e4941ba8ec3ffe


