### PR TITLE
Fix compile issue in Azure EP unit test

### DIFF
--- a/onnxruntime/test/providers/azure/azure_basic_test.cc
+++ b/onnxruntime/test/providers/azure/azure_basic_test.cc
@@ -25,9 +25,9 @@ TEST(AzureEP, TestSessionCreation) {
 
   // Use canonical EP name 'AzureExecutionProvider'
   Ort::SessionOptions session_options2;
-  session_options.AddConfigEntry("azure.endpoint_type", "triton");
-  session_options.AppendExecutionProvider(kAzureExecutionProvider, options);
-  EXPECT_NO_THROW((Ort::Session{*ort_env, ort_model_path, session_options}));
+  session_options2.AddConfigEntry("azure.endpoint_type", "triton");
+  session_options2.AppendExecutionProvider(kAzureExecutionProvider, options);
+  EXPECT_NO_THROW((Ort::Session{*ort_env, ort_model_path, session_options2}));
 }
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
### Description
Fix compilation issue (undeclared identifier) in Azure EP unit test.



### Motivation and Context
A previous PR caused a compilation issue in the Azure EP unit test: https://github.com/microsoft/onnxruntime/pull/24433

Our PR CI pipelines did not catch it. It was caught by our post-merge packaging pipelines.

```shell
D:\a\_work\1\s\onnxruntime\test\providers\azure\azure_basic_test.cc(28,3): error C2065: 'session_options': undeclared identifier [D:\a\_work\1\b\RelWithDebInfo\onnxruntime_test_all.vcxproj]
D:\a\_work\1\s\onnxruntime\test\providers\azure\azure_basic_test.cc(29,3): error C2065: 'session_options': undeclared identifier [D:\a\_work\1\b\RelWithDebInfo\onnxruntime_test_all.vcxproj]
D:\a\_work\1\s\onnxruntime\test\providers\azure\azure_basic_test.cc(30,3): error C2065: 'session_options': undeclared identifier [D:\a\_work\1\b\RelWithDebInfo\onnxruntime_test_all.vcxproj]
```