### PR TITLE
update test case for test_convtranspose_autopad_same

### DIFF
--- a/js/web/test/suite-test-list.jsonc
+++ b/js/web/test/suite-test-list.jsonc
@@ -453,7 +453,7 @@
       // // "test_convinteger_without_padding",
       "test_convtranspose_1d",
       // // "test_convtranspose_3d",
-      "test_convtranspose_autopad_same",
+      "!(opset14)/test_convtranspose_autopad_same",
       "test_convtranspose_dilations",
       "test_convtranspose_kernel_shape",
       "opset{9,17}/test_convtranspose_output_shape",

--- a/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
+++ b/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
@@ -109,7 +109,6 @@
         //GPU failures
         "^test_batchnorm_epsilon_training_mode_cuda",
         "^test_batchnorm_example_training_mode_cuda",
-        "^test_convtranspose_autopad_same_cpu",
         "^test_sub_uint8_cuda",
         "^test_simple_rnn_batchwise_cuda",
         "^test_mul_uint8_cuda",
@@ -873,7 +872,9 @@
     "failing_permanently_nodejs_binding": [
         // those test cases are no longer available in later opset version
         ["opset10", "^test_mod_float_mixed_sign_example"],
-        ["opset11", "^test_unique_not_sorted_without_axis"]
+        ["opset11", "^test_unique_not_sorted_without_axis"],
+        // those test cases are generated incorrectly
+        ["opset14", "^test_convtranspose_autopad_same"]
     ],
     "test_with_types_disabled_due_to_binary_size_concerns": [
         "^test_bitshift_right_uint16",


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

It looks like the test case `test_convtranspose_autopad_same` in ONNX opset14(v1.9) is generated incorrectly: https://github.com/onnx/onnx/pull/3440

The problem is already fixed in opset15+(v1.10).

So, this PR fixes 2 problems:
- disable the test case for opset14 in onnxruntime-web tests ( still run the same test for opset15 and opset17 )
- re-enable the test case by removing if from "current_failing_tests" in onnxruntime\test\testdata\onnx_backend_test_series_filters.jsonc (which should have been done when upgrading to onnx v1.10)

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


