### PR TITLE
Remove deprecated onnx.mapping usage

### DIFF
--- a/onnxruntime/python/tools/transformers/fusion_utils.py
+++ b/onnxruntime/python/tools/transformers/fusion_utils.py
@@ -309,11 +309,9 @@ class NumpyHelper:
         # When weights are in external data format but not presented, we can still test the optimizer with two changes:
         # (1) set fill_zeros = True  (2) change load_external_data=False in optimizer.py
         if fill_zeros:
-            from onnx import mapping
-
             return ndarray(
                 shape=tensor.dims,
-                dtype=mapping.TENSOR_TYPE_TO_NP_TYPE[tensor.data_type],
+                dtype=helper.tensor_dtype_to_np_dtype(tensor.data_type),
             )
 
         return numpy_helper.to_array(tensor)

--- a/onnxruntime/test/onnx/gen_test_models.py
+++ b/onnxruntime/test/onnx/gen_test_models.py
@@ -94,7 +94,7 @@ def generate_size_op_test(type, X, test_folder):
 
 
 def generate_reducesum_op_test(X, test_folder):
-    type = onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[X.dtype]
+    type = helper.np_dtype_to_tensor_dtype(X.dtype)
     data_dir = os.path.join(test_folder, "test_data_0")
     os.makedirs(data_dir, exist_ok=True)
     # Create one output (ValueInfoProto)

--- a/onnxruntime/test/python/contrib_ops/onnx_contrib_ops_helper.py
+++ b/onnxruntime/test/python/contrib_ops/onnx_contrib_ops_helper.py
@@ -23,7 +23,7 @@ def prepare_dir(path):
 def _extract_value_info(arr, name, ele_type=None):
     return onnx.helper.make_tensor_value_info(
         name=name,
-        elem_type=ele_type if ele_type else onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[arr.dtype],
+        elem_type=ele_type if ele_type else onnx.helper.np_dtype_to_tensor_dtype(arr.dtype),
         shape=arr.shape,
     )
 

--- a/onnxruntime/test/python/onnxruntime_test_python_iobinding.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_iobinding.py
@@ -9,7 +9,6 @@ from helper import get_name
 from numpy.testing import assert_almost_equal
 from onnx import TensorProto, helper
 from onnx.defs import onnx_opset_version
-from onnx.mapping import TENSOR_TYPE_MAP
 
 import onnxruntime as onnxrt
 from onnxruntime.capi._pybind_state import OrtDevice as C_OrtDevice  # pylint: disable=E0611
@@ -168,8 +167,7 @@ class TestIOBinding(unittest.TestCase):
                 TensorProto.UINT64,
             ]:
                 with self.subTest(onnx_dtype=onnx_dtype, inner_device=str(inner_device)):
-                    assert onnx_dtype in TENSOR_TYPE_MAP
-                    np_dtype = TENSOR_TYPE_MAP[onnx_dtype].np_dtype
+                    np_dtype = helper.tensor_dtype_to_np_dtype(onnx_dtype)
                     x = np.arange(8).reshape((-1, 2)).astype(np_dtype)
 
                     # create onnx graph

--- a/tools/python/ort_test_dir_utils.py
+++ b/tools/python/ort_test_dir_utils.py
@@ -10,7 +10,7 @@ from onnx import TensorProto, numpy_helper
 import onnxruntime as ort
 
 
-def _get_numpy_type(model_info, name):
+def _get_numpy_type(model_info, name) -> np.dtype:
     for i in model_info:
         if i.name == name:
             type_name = i.type.WhichOneof("value")

--- a/tools/python/ort_test_dir_utils.py
+++ b/tools/python/ort_test_dir_utils.py
@@ -15,7 +15,7 @@ def _get_numpy_type(model_info, name):
         if i.name == name:
             type_name = i.type.WhichOneof("value")
             if type_name == "tensor_type":
-                return onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[i.type.tensor_type.elem_type]
+                return onnx.helper.tensor_dtype_to_np_dtype(i.type.tensor_type.elem_type)
             else:
                 raise ValueError(f"Type is not handled: {type_name}")
 
@@ -65,7 +65,7 @@ def _create_missing_input_data(model_inputs, name_input_map, symbolic_dim_values
         if onnx_type not in [TensorProto.FLOAT, TensorProto.BFLOAT16, TensorProto.DOUBLE, TensorProto.FLOAT16]:
             data *= 256
 
-        np_type = onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[onnx_type]
+        np_type = onnx.helper.tensor_dtype_to_np_dtype(onnx_type)
         data = data.astype(np_type)
 
         name_input_map[input.name] = data


### PR DESCRIPTION
`onnx.mapping` was deprecated and is being removed. This PR updates removes deprecated usage.

@MaanavD would be good if this can make it into 1.22.0 for forward ONNX release (1.19+) compatibility.