### PR TITLE
[QNN EP] Remove unnecessary std::move to fix warning/error

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc
@@ -78,8 +78,8 @@ Status CastOpBuilder::ProcessExtraInputForNotEqual(QnnModelWrapper& qnn_model_wr
                                         QNN_TENSOR_TYPE_STATIC,
                                         qnn_data_type,
                                         QnnQuantParamsWrapper(),
-                                        std::move(std::vector<uint32_t>{1}),
-                                        std::move(std::vector<uint8_t>(utils::GetElementSizeByType(qnn_data_type), 0)));
+                                        std::vector<uint32_t>{1},
+                                        std::vector<uint8_t>(utils::GetElementSizeByType(qnn_data_type), 0));
   ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(input_tensor_wrapper)),
                     "Failed to add additional input tensor for QNN Cast node that will be replaced by NotEqual.");
   input_names.push_back(input_name);


### PR DESCRIPTION
### Description
Removes unnecessary std::move on an r-value expression. This caused a compiler warning/error in the Linux Android QNN pipeline.



### Motivation and Context
Introduced by PR: https://github.com/microsoft/onnxruntime/pull/24466


