### PR TITLE
Add `python_version < "3.13"` for onnxscript dependency.

### DIFF
--- a/tools/ci_build/github/linux/python/requirements.txt
+++ b/tools/ci_build/github/linux/python/requirements.txt
@@ -8,4 +8,4 @@ protobuf==4.21.12
 sympy==1.12
 flatbuffers
 psutil
-onnxscript==0.2.3
+onnxscript==0.2.3 ; python_version < '3.13'


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Add `python_version < "3.13"` for `onnxscript` dependency in tools/ci_build/github/linux/python/requirements.txt.

`onnxscript` has `onnx` as a dependency. Building the `onnx` wheel fails with Python 3.13.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix pipeline build failures.