### PR TITLE
Remove non-constant input check from ConvActivationFusion

### DIFF
--- a/onnxruntime/core/optimizer/conv_activation_fusion.cc
+++ b/onnxruntime/core/optimizer/conv_activation_fusion.cc
@@ -74,16 +74,8 @@ class ConvActivationSelector : public NodeSelector {
   std::optional<NodesToOptimizeIndices> Select(const GraphViewer& graph_viewer, const Node& node) const override {
     const std::string_view node_ep = node.GetExecutionProviderType();
     const auto* next_node = GetLoneConsumerNode(graph_viewer, node);
-    if (!next_node) {
-      return std::nullopt;
-    }
-
-    // Don't fuse with `next_node` if it has more than one input edge.
-    if (next_node->GetInputEdgesCount() != 1) {
-      return std::nullopt;
-    }
-
-    if (next_node->GetExecutionProviderType() != node_ep) {
+    if (!next_node ||
+        next_node->GetExecutionProviderType() != node_ep) {
       return std::nullopt;
     }
 

--- a/onnxruntime/core/optimizer/utils.h
+++ b/onnxruntime/core/optimizer/utils.h
@@ -163,10 +163,12 @@ bool GetScalarInitializerValue(const onnxruntime::Graph& graph, const onnxruntim
 */
 bool GetClipConstantMinMax(const Graph& graph, const Node& node, float& min, float& max);
 
-/** Check whether node's output edges count is expected.
-@remarks graph output is not included in output edges, and this node shall not have graph output.
-        A node with graph output cannot be fused unless the graph output also exists in outputs of fused node.
-@returns false when the node has graph output, or number of output edges are not expected.
+/** Check whether `node` has expected outputs.
+@remarks Graph outputs are not included in output edges, and this node should not have a graph output.
+         A node with a graph output cannot be fused unless the graph output also exists in outputs of the fused node.
+         Output edges to implicit inputs are also disallowed as we don't want to fuse with part of a subgraph.
+@returns False when `node` has a graph output or an output edge to an implicit input, or when the number of `node`'s
+         output edges is not `expected_output_edges`.
 */
 bool CheckOutputEdges(const Graph& graph, const Node& node, size_t expected_output_edges);
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

An additional check for non-constant inputs was added to ConvActivationFusion in #20282. This was to avoid fusing an Add in a Conv+Add+Relu that has another non-constant input.

https://github.com/microsoft/onnxruntime/blob/6c8cb6a6d1993f84fcf4008f468a071c0b73aad3/onnxruntime/core/optimizer/conv_activation_fusion.cc#L26-L39

However, this check fails to account for implicit inputs and will read past the end of a node's explicit input defs if any implicit inputs are present.

Moreover, this check is no longer necessary after #19470 removed Conv+Add+Relu fusion from ConvActivationFusion.

This change removes the check and some other unused code.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix #24473.