### PR TITLE
[webgpu] fix program variable data type and revise ProgramInput

### DIFF
--- a/onnxruntime/core/providers/webgpu/program.cc
+++ b/onnxruntime/core/providers/webgpu/program.cc
@@ -105,7 +105,10 @@ constexpr std::string_view ProgramVariableDataTypeName[] = {
     "i8x4",    // Int8x4
     "i8x8",    // Int8x8
     "i8x16",   // Int8x16
+    "u4x8",    // Uint4x8
+    "i4x8",    // Int4x8
 };
+
 std::ostream& operator<<(std::ostream& os, ProgramVariableDataType type) {
   os << ProgramVariableDataTypeName[std::underlying_type<decltype(type)>::type(type)];
   return os;
@@ -135,8 +138,12 @@ int NumberOfComponents(ProgramVariableDataType type) {
     case ProgramVariableDataType::Int8x4:
       return 4;
     case ProgramVariableDataType::Uint8x8:
+    case ProgramVariableDataType::Int8x8:
+    case ProgramVariableDataType::Uint4x8:
+    case ProgramVariableDataType::Int4x8:
       return 8;
     case ProgramVariableDataType::Uint8x16:
+    case ProgramVariableDataType::Int8x16:
       return 16;
     default:
       return -1;
@@ -146,10 +153,6 @@ int NumberOfComponents(ProgramVariableDataType type) {
 ProgramVariableDataType ToProgramVariableDataType(int32_t element_type, int component /* = 1 */) {
   if (component == 1) {
     switch (element_type) {
-      case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
-        return ProgramVariableDataType::Uint8x4;  // shader needs to be aware that only 1 value is valid
-      case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
-        return ProgramVariableDataType::Int8x4;  // shader needs to be aware that only 1 value is valid
       case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:
         return ProgramVariableDataType::Float32;
       case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
@@ -201,6 +204,10 @@ ProgramVariableDataType ToProgramVariableDataType(int32_t element_type, int comp
     switch (element_type) {
       case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
         return ProgramVariableDataType::Uint8x8;
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4:
+        return ProgramVariableDataType::Uint4x8;
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4:
+        return ProgramVariableDataType::Int4x8;
       default:
         return ProgramVariableDataType::InvalidType;
     }
@@ -257,6 +264,15 @@ ProgramInput::ProgramInput(const Tensor* tensor, ProgramTensorMetadataDependency
   if (use_override_shape) {
     override_shape = GetReducedShape(tensor->Shape(), component);
   }
+}
+
+ProgramInput::ProgramInput(const Tensor* tensor, ProgramTensorMetadataDependency dependency, ProgramInput::FlattenTag, int component)
+    : tensor{tensor},
+      dependency{dependency},
+      var_type{ToProgramVariableDataType(tensor->GetElementType(), component)},
+      use_override_shape{true},
+      override_shape{} {
+  override_shape = {(tensor->Shape().Size() + component - 1) / component};
 }
 
 ProgramInput::ProgramInput(const Tensor* tensor, ProgramTensorMetadataDependency dependency, const TensorShape& override_shape, int component)

--- a/onnxruntime/core/providers/webgpu/program.h
+++ b/onnxruntime/core/providers/webgpu/program.h
@@ -201,6 +201,9 @@ enum class ProgramVariableDataType {
   Int8x4,
   Int8x8,
   Int8x16,
+  Uint4x8,
+  Int4x8,
+  // if you add a new type here, you also need to update ProgramVariableDataTypeName
 };
 #ifndef NDEBUG
 std::ostream& operator<<(std::ostream& os, ProgramVariableDataType);
@@ -211,8 +214,15 @@ int NumberOfComponents(ProgramVariableDataType type);
 ProgramVariableDataType ToProgramVariableDataType(int32_t element_type, int component = 1);
 
 struct ProgramInput {
+ private:
+  struct FlattenTag {};
+
+ public:
+  constexpr static const FlattenTag Flatten{};
+
   ProgramInput(const Tensor* tensor);
   ProgramInput(const Tensor* tensor, ProgramTensorMetadataDependency dependency, int component = 1);
+  ProgramInput(const Tensor* tensor, ProgramTensorMetadataDependency dependency, FlattenTag, int component = 1);
   ProgramInput(const Tensor* tensor, ProgramTensorMetadataDependency dependency, const TensorShape& override_shape, int component);
 
   const Tensor* tensor;

--- a/onnxruntime/core/providers/webgpu/quantization/quantize_linear.cc
+++ b/onnxruntime/core/providers/webgpu/quantization/quantize_linear.cc
@@ -148,7 +148,7 @@ Status DequantizeLinear::ComputeInternal(ComputeContext& context) const {
   program
       .AddInputs({{x, ProgramTensorMetadataDependency::TypeAndRank, ProgramInput::Flatten, packed ? 4 : input_component}})
       .AddInputs({{x_scale, ProgramTensorMetadataDependency::TypeAndRank}})
-      .AddOutput({output_tensor, ProgramTensorMetadataDependency::None, components})
+      .AddOutput({output_tensor, ProgramTensorMetadataDependency::Rank, components})
       .SetDispatchGroupSize((x_size / components + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE)
       .AddUniformVariables({{static_cast<uint32_t>(axis)}})
       .AddUniformVariables({{static_cast<uint32_t>(block_size_)}})

--- a/onnxruntime/core/providers/webgpu/quantization/quantize_linear.cc
+++ b/onnxruntime/core/providers/webgpu/quantization/quantize_linear.cc
@@ -121,8 +121,11 @@ Status DequantizeLinear::ComputeInternal(ComputeContext& context) const {
   auto* output_tensor = context.Output(0, x_shape);
   int64_t x_scale_rank = x_scale->Shape().NumDimensions();
 
-  bool packed = x->GetElementType() == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8 || x->GetElementType() == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8;
-  bool is_signed = x->GetElementType() == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8;
+  // Currently only INT8, UINT8, and INT32 are registered.
+  auto x_type = x->GetElementType();
+
+  bool packed = x_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8 || x_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8;
+  bool is_signed = x_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8;
   int64_t axis = (axis_ >= 0) ? axis_ : axis_ + x_shape.NumDimensions();
 
   int max_components = GetMaxComponents(x_size);
@@ -138,12 +141,12 @@ Status DequantizeLinear::ComputeInternal(ComputeContext& context) const {
 
   bool use_components = per_layer && (!packed || max_components == 4);
   int components = use_components ? max_components : 1;
-  int input_component = use_components && !packed ? max_components : 1;
+  int input_component = use_components ? max_components : 1;
 
   DequantizeLinearProgram program{packed, is_signed, per_layer, per_axis, x_zeropoint != nullptr};
 
   program
-      .AddInputs({{x, ProgramTensorMetadataDependency::TypeAndRank, input_component}})
+      .AddInputs({{x, ProgramTensorMetadataDependency::TypeAndRank, ProgramInput::Flatten, packed ? 4 : input_component}})
       .AddInputs({{x_scale, ProgramTensorMetadataDependency::TypeAndRank}})
       .AddOutput({output_tensor, ProgramTensorMetadataDependency::None, components})
       .SetDispatchGroupSize((x_size / components + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE)
@@ -153,7 +156,7 @@ Status DequantizeLinear::ComputeInternal(ComputeContext& context) const {
       .CacheHint(std::to_string(axis), std::to_string(is_signed), std::to_string(per_layer), std::to_string(per_axis), std::to_string(block_size_));
 
   if (x_zeropoint != nullptr) {
-    program.AddInputs({{x_zeropoint, ProgramTensorMetadataDependency::TypeAndRank}});
+    program.AddInputs({{x_zeropoint, ProgramTensorMetadataDependency::None, ProgramInput::Flatten, packed ? 4 : 1}});
   }
 
   return context.RunProgram(program);

--- a/onnxruntime/core/providers/webgpu/shader_helper.cc
+++ b/onnxruntime/core/providers/webgpu/shader_helper.cc
@@ -174,6 +174,14 @@ Status ValidateVariableDataType(int32_t element_type, ProgramVariableDataType va
                             var_type == ProgramVariableDataType::Int8x16,
                         "Unexpected program variable type ", int(var_type), " for int8 tensor");
       break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4:
+      ORT_RETURN_IF_NOT(var_type == ProgramVariableDataType::Int4x8,
+                        "Unexpected program variable type ", int(var_type), " for int4 tensor");
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4:
+      ORT_RETURN_IF_NOT(var_type == ProgramVariableDataType::Uint4x8,
+                        "Unexpected program variable type ", int(var_type), " for uint4 tensor");
+      break;
     default:
       ORT_RETURN_IF(true, "Unsupported data type: ", element_type);
       // todo: add int4/uint4

--- a/onnxruntime/core/providers/webgpu/shader_variable.cc
+++ b/onnxruntime/core/providers/webgpu/shader_variable.cc
@@ -33,6 +33,10 @@ constexpr static const std::string_view STORAGE_TYPE_ARRAY[] = {
     "vec2<u32>",  // Uint8x8
     "vec4<u32>",  // Uint8x16
     "u32",        // Int8x4
+    "vec2<u32>",  // Int8x8
+    "vec4<u32>",  // Int8x16
+    "u32",        // Uint4x8
+    "u32",        // Int4x8
 };
 constexpr static const auto STORAGE_TYPE = details::_to_std_array(STORAGE_TYPE_ARRAY);
 
@@ -55,7 +59,11 @@ constexpr static const std::string_view VALUE_TYPE_ARRAY[] = {
     "u32",         // Uint8x4 (u32 as 4 elements of uint8)
     "vec2<u32>",   // Uint8x8 (vec2<u32> as 2x4 elements of uint8)
     "vec4<u32>",   // Uint8x16 (vec4<u32> as 4x4 elements of uint8)
-    "i32",         // Int8x4
+    "u32",         // Int8x4 (u32 as 4 elements of int8)
+    "vec2<u32>",   // Int8x8 (vec2<i32> as 2x4 elements of int8)
+    "vec4<u32>",   // Int8x16 (vec4<i32> as 4x4 elements of int8)
+    "u32",         // Uint4x8
+    "u32",         // Int4x8
 };
 constexpr static const auto VALUE_TYPE = details::_to_std_array(VALUE_TYPE_ARRAY);
 
@@ -81,6 +89,8 @@ constexpr static const std::string_view ELEMENT_TYPE_ARRAY[] = {
     "i32",   // Int8x4
     "i32",   // Int8x8
     "i32",   // Int8x16
+    "u32",   // Uint4x8
+    "i32",   // Int4x8
 };
 constexpr static const auto ELEMENT_TYPE = details::_to_std_array(ELEMENT_TYPE_ARRAY);
 


### PR DESCRIPTION
### Description

This PR fixes the program variable data type and revise ProgramInput:
- add support for int4/uint4
- fix inconsistency of dealing with number of components for int8/uint8 in ToProgramVariableDataType
- add a constructor for `ProgramInput` to allow "flatten" the shape easily.
- fix dequantize linear

