### PR TITLE
Fix segfault when re-loading an EP library

### DIFF
--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -1794,6 +1794,7 @@ void ProviderLibrary::Unload() {
       }
     }
 
+    initialized_ = false;
     handle_ = nullptr;
     provider_ = nullptr;
   }


### PR DESCRIPTION
### Description
Fixes a segfault that occurs when an EP library is re-loaded in the same process.


### Motivation and Context
A recent [PR ](https://github.com/microsoft/onnxruntime/pull/24430) updated the Environment to unload all EP libraries on destruction of `OrtEnv`. We forgot to properly update the state to mark the EP library as unloaded. Therefore, this caused a segfault when the EP library was re-loaded.


