### PR TITLE
Update LLM export to use PyTorch 2.7

### DIFF
--- a/onnxruntime/python/tools/transformers/models/llama/convert_to_onnx.py
+++ b/onnxruntime/python/tools/transformers/models/llama/convert_to_onnx.py
@@ -25,7 +25,7 @@ from llama_torch import setup_torch_model
 
 # to patch transformers before exporting for transformers >= 4.45
 from models.torch_export_patches import bypass_export_some_errors
-from models.torch_export_patches.patch_inputs import convert_dynamic_axes_into_dynamic_shapes, replace_dynamic_shapes
+from models.torch_export_patches.patch_inputs import convert_dynamic_axes_into_dynamic_shapes
 from onnx_model import OnnxModel
 from optimizer import optimize_model
 from packaging import version

--- a/onnxruntime/python/tools/transformers/models/llama/convert_to_onnx.py
+++ b/onnxruntime/python/tools/transformers/models/llama/convert_to_onnx.py
@@ -165,61 +165,17 @@ def run_dynamo_export(
         llama, args=model_args, dynamic_axes=dynamic_axes, prefix_mapping={"present": "past_key_values"}
     )
 
-    if version.Version(torch.__version__) < version.Version("2.7"):
-        # This section is only needed for torch==2.6. The workaround implemented here
-        # to fix bugs is not necessary with torch>=2.7.
-        # - strings are not allowed with torch 2.6, so we replace them by DYNAMIC
-        # - TypePromotion was fixed in torch==2.7
-        from onnxscript import opset18 as op
-
-        dynamic_shapes = replace_dynamic_shapes(
-            dynamic_shapes,
-            dict(batch_size=torch.export.Dim("batch_size")),
-            default_value=torch.export.Dim.DYNAMIC,
+    with bypass_export_some_errors(patch_transformers=True):
+        torch.onnx.export(
+            llama,
+            (),
+            temp_path,
+            kwargs=model_kwargs,
+            dynamic_shapes=dynamic_shapes,
+            dynamo=True,
+            verbose=args.verbose,
+            optimize=True,
         )
-
-        # TypePromotion cannot fix a type issue after the conversion.
-        # We insert an additional CastLike when the exporter
-        def custom_aten_ge(self, other):
-            if isinstance(other, (int, float)):
-                return op.GreaterOrEqual(self, op.CastLike(other, self))
-            return op.GreaterOrEqual(self, other)
-
-        with bypass_export_some_errors(patch_transformers=True):
-            # ONNX pass TypePromotion crashes for torch 2.6.
-            # It can be bypassed by exporting first into an exported program.
-            # We then need to apply run_decompositions() before onnx conversion starts.
-            ep = torch.export.export(
-                llama,
-                (),
-                kwargs=model_kwargs,
-                dynamic_shapes=dynamic_shapes,
-                strict=False,
-            )
-            ep = ep.run_decompositions()
-            torch.onnx.export(
-                ep,
-                (),
-                temp_path,
-                kwargs=model_kwargs,
-                dynamic_shapes=dynamic_shapes,
-                dynamo=True,
-                verbose=args.verbose,
-                optimize=True,
-                custom_translation_table={torch.ops.aten.ge.Scalar: custom_aten_ge},
-            )
-    else:
-        with bypass_export_some_errors(patch_transformers=True):
-            torch.onnx.export(
-                llama,
-                (),
-                temp_path,
-                kwargs=model_kwargs,
-                dynamic_shapes=dynamic_shapes,
-                dynamo=True,
-                verbose=args.verbose,
-                optimize=True,
-            )
 
     # Check decoder_with_past_model.onnx and save all external data to one file
     onnx.checker.check_model(temp_path)

--- a/onnxruntime/python/tools/transformers/models/llama/llama_parity.py
+++ b/onnxruntime/python/tools/transformers/models/llama/llama_parity.py
@@ -25,7 +25,7 @@ from llama_inputs import (
 )
 from llama_torch import setup_torch_model
 from models.torch_export_patches.cache_helper import make_dynamic_cache
-from transformers import AutoConfig
+from transformers import __version__ as transformers_version, AutoConfig
 from transformers.cache_utils import DynamicCache
 
 import onnxruntime as ort
@@ -117,7 +117,7 @@ def verify_parity(
 
     inputs = get_inputs(args, config)
 
-    if "past_key_values" in inputs and pv.Version(transformers.__version__) >= pv.Version("4.45"):
+    if "past_key_values" in inputs and pv.Version(transformers_version) >= pv.Version("4.45"):
         # Using DynamicCache
         inputs["past_key_values"] = make_dynamic_cache(inputs["past_key_values"])
 

--- a/onnxruntime/python/tools/transformers/models/llama/llama_parity.py
+++ b/onnxruntime/python/tools/transformers/models/llama/llama_parity.py
@@ -13,7 +13,6 @@ import time
 import numpy as np
 import packaging.version as pv
 import torch
-import transformers
 from benchmark_helper import setup_logger
 from dist_settings import get_rank, get_size
 from llama_inputs import (
@@ -26,7 +25,7 @@ from llama_inputs import (
 )
 from llama_torch import setup_torch_model
 from models.torch_export_patches.cache_helper import make_dynamic_cache
-from transformers import AutoConfig
+from transformers import __version__ as transformers_version, AutoConfig
 from transformers.cache_utils import DynamicCache
 
 import onnxruntime as ort
@@ -105,7 +104,7 @@ def verify_parity(
     pytorch_model: None | torch.nn.Module = None,
     config: None | AutoConfig = None,
 ):
-    # If it's running in a machine which GPU memory < 36GB, it should unload the llama in GPU in time and free the GPU memory for ORT.
+    # If it's running in a machine where GPU memory < 36GB, it should unload the model in GPU in time and free the GPU memory for ORT.
     py_model = pytorch_model
     if py_model is None:
         config, py_model = setup_torch_model(
@@ -123,13 +122,14 @@ def verify_parity(
         inputs["past_key_values"] = make_dynamic_cache(inputs["past_key_values"])
 
     # Run inference with PyTorch
+    inputs_after_deepcopy = torch_deepcopy(inputs)
     if args.execution_provider != "cpu":
         torch.cuda.synchronize()
     start_time = time.time()
-    # If there is a cache in the inputs, we need to make a copy as the model modify them inplace.
+    # If there is a cache in the inputs, we need to make a copy as the model modifies them inplace.
     # DynamicCache inherits from torch.nn.Module in some version of transformers.
     # We need to make the copy manually.
-    pt_outputs = py_model(**torch_deepcopy(inputs)).logits.detach().cpu().numpy()
+    pt_outputs = py_model(**inputs_after_deepcopy).logits.detach().cpu().numpy()
     if args.execution_provider != "cpu":
         torch.cuda.synchronize()
     end_time = time.time()

--- a/onnxruntime/python/tools/transformers/models/llama/llama_parity.py
+++ b/onnxruntime/python/tools/transformers/models/llama/llama_parity.py
@@ -25,7 +25,7 @@ from llama_inputs import (
 )
 from llama_torch import setup_torch_model
 from models.torch_export_patches.cache_helper import make_dynamic_cache
-from transformers import __version__ as transformers_version, AutoConfig
+from transformers import AutoConfig
 from transformers.cache_utils import DynamicCache
 
 import onnxruntime as ort

--- a/onnxruntime/python/tools/transformers/models/llama/llama_parity.py
+++ b/onnxruntime/python/tools/transformers/models/llama/llama_parity.py
@@ -25,7 +25,8 @@ from llama_inputs import (
 )
 from llama_torch import setup_torch_model
 from models.torch_export_patches.cache_helper import make_dynamic_cache
-from transformers import __version__ as transformers_version, AutoConfig
+from transformers import AutoConfig
+from transformers import __version__ as transformers_version
 from transformers.cache_utils import DynamicCache
 
 import onnxruntime as ort

--- a/onnxruntime/python/tools/transformers/models/llama/requirements.txt
+++ b/onnxruntime/python/tools/transformers/models/llama/requirements.txt
@@ -1,8 +1,7 @@
 onnxscript>=0.2.3
 optimum>=1.14.1
-optree  # this is still needed when pytorch==2.6 is used
 transformers==4.48.0
-torch>=2.2.0
+torch>=2.7.0
 onnx==1.17.0
 datasets>=2.8.0
 protobuf==3.20.2

--- a/onnxruntime/python/tools/transformers/models/llama/requirements.txt
+++ b/onnxruntime/python/tools/transformers/models/llama/requirements.txt
@@ -1,5 +1,6 @@
 onnxscript>=0.2.3
 optimum>=1.14.1
+optree
 transformers==4.48.0
 torch>=2.7.0
 onnx==1.17.0

--- a/onnxruntime/python/tools/transformers/models/torch_export_patches/__init__.py
+++ b/onnxruntime/python/tools/transformers/models/torch_export_patches/__init__.py
@@ -4,13 +4,14 @@ from typing import Any
 import numpy as np
 import packaging.version as pv
 import torch
+from transformers import __version__ as transformers_version
+from transformers.cache_utils import DynamicCache, EncoderDecoderCache
 
 from .onnx_export_errors import (
     bypass_export_some_errors,
     register_additional_serialization_functions,
 )
-from transformers import __version__ as transformers_version
-from transformers.cache_utils import DynamicCache, EncoderDecoderCache
+
 
 def is_torchdynamo_exporting() -> bool:
     """Tells if torch is exporting a model."""
@@ -459,6 +460,4 @@ def make_encoder_decoder_cache(
     cross_attention_cache: DynamicCache,
 ) -> EncoderDecoderCache:
     "Creates an EncoderDecoderCache."
-    return EncoderDecoderCache(
-        self_attention_cache=self_attention_cache, cross_attention_cache=cross_attention_cache
-    )
+    return EncoderDecoderCache(self_attention_cache=self_attention_cache, cross_attention_cache=cross_attention_cache)

--- a/onnxruntime/python/tools/transformers/models/torch_export_patches/__init__.py
+++ b/onnxruntime/python/tools/transformers/models/torch_export_patches/__init__.py
@@ -4,13 +4,13 @@ from typing import Any
 import numpy as np
 import packaging.version as pv
 import torch
-import transformers
 
 from .onnx_export_errors import (
     bypass_export_some_errors,
     register_additional_serialization_functions,
 )
-
+from transformers import __version__ as transformers_version
+from transformers.cache_utils import DynamicCache, EncoderDecoderCache
 
 def is_torchdynamo_exporting() -> bool:
     """Tells if torch is exporting a model."""
@@ -422,43 +422,43 @@ def string_type(
     raise AssertionError(f"Unsupported type {type(obj).__name__!r} - {type(obj)}")
 
 
-if pv.Version(transformers.__version__) > pv.Version("4.49.99999"):
+if pv.Version(transformers_version) > pv.Version("4.49.99999"):
 
     def make_dynamic_cache(
         key_value_pairs: list[tuple[torch.Tensor, torch.Tensor]],
-    ) -> transformers.cache_utils.DynamicCache:
+    ) -> DynamicCache:
         """
-        Creates an instance of :class:`transformers.cache_utils.DynamicCache`.
+        Creates an instance of :class:`DynamicCache`.
         This version is valid for ``transformers >= 4.50``.
 
         :param key_value_pairs: list of pairs of (key, values)
-        :return: :class:`transformers.cache_utils.DynamicCache`
+        :return: :class:`DynamicCache`
         """
-        return transformers.cache_utils.DynamicCache(key_value_pairs)
+        return DynamicCache(key_value_pairs)
 
 else:
 
     def make_dynamic_cache(
         key_value_pairs: list[tuple[torch.Tensor, torch.Tensor]],
-    ) -> transformers.cache_utils.DynamicCache:
+    ) -> DynamicCache:
         """
-        Creates an instance of :class:`transformers.cache_utils.DynamicCache`.
+        Creates an instance of :class:`DynamicCache`.
         This version is valid for ``transformers < 4.50``.
 
         :param key_value_pairs: list of pairs of (key, values)
-        :return: :class:`transformers.cache_utils.DynamicCache`
+        :return: :class:`DynamicCache`
         """
-        cache = transformers.cache_utils.DynamicCache(len(key_value_pairs))
+        cache = DynamicCache(len(key_value_pairs))
         for i, (key, value) in enumerate(key_value_pairs):
             cache.update(key, value, i)
         return cache
 
 
 def make_encoder_decoder_cache(
-    self_attention_cache: transformers.cache_utils.DynamicCache,
-    cross_attention_cache: transformers.cache_utils.DynamicCache,
-) -> transformers.cache_utils.EncoderDecoderCache:
+    self_attention_cache: DynamicCache,
+    cross_attention_cache: DynamicCache,
+) -> EncoderDecoderCache:
     "Creates an EncoderDecoderCache."
-    return transformers.cache_utils.EncoderDecoderCache(
+    return EncoderDecoderCache(
         self_attention_cache=self_attention_cache, cross_attention_cache=cross_attention_cache
     )

--- a/onnxruntime/python/tools/transformers/models/torch_export_patches/cache_helper.py
+++ b/onnxruntime/python/tools/transformers/models/torch_export_patches/cache_helper.py
@@ -1,6 +1,5 @@
 import packaging.version as pv
 import torch
-
 from transformers import __version__ as transformers_version
 from transformers.cache_utils import DynamicCache, EncoderDecoderCache
 
@@ -70,6 +69,4 @@ def make_encoder_decoder_cache(
     """
     Creates an EncoderDecoderCache.
     """
-    return EncoderDecoderCache(
-        self_attention_cache=self_attention_cache, cross_attention_cache=cross_attention_cache
-    )
+    return EncoderDecoderCache(self_attention_cache=self_attention_cache, cross_attention_cache=cross_attention_cache)

--- a/onnxruntime/python/tools/transformers/models/torch_export_patches/cache_helper.py
+++ b/onnxruntime/python/tools/transformers/models/torch_export_patches/cache_helper.py
@@ -1,12 +1,13 @@
 import packaging.version as pv
 import torch
-import transformers
-import transformers.cache_utils
+
+from transformers import __version__ as transformers_version
+from transformers.cache_utils import DynamicCache, EncoderDecoderCache
 
 
 def is_cache_dynamic_registered(fast: bool = False) -> bool:
     """
-    Tells class :class:`transformers.cache_utils.DynamicCache` can be
+    Tells class :class:`DynamicCache` can be
     serialized and deserialized. Only then, :func:`torch.export.export`
     can export a model.
 
@@ -14,7 +15,7 @@ def is_cache_dynamic_registered(fast: bool = False) -> bool:
     :return: result
     """
     if fast:
-        return transformers.cache_utils.DynamicCache in torch.utils._pytree.SUPPORTED_NODES
+        return DynamicCache in torch.utils._pytree.SUPPORTED_NODES
     bsize, nheads, slen, dim = 2, 4, 3, 7
     cache = make_dynamic_cache(
         [
@@ -30,45 +31,45 @@ def is_cache_dynamic_registered(fast: bool = False) -> bool:
     return len(cache2.key_cache) == len(cache.value_cache)
 
 
-if pv.Version(transformers.__version__) > pv.Version("4.49.99999"):
+if pv.Version(transformers_version) > pv.Version("4.49.99999"):
 
     def make_dynamic_cache(
         key_value_pairs: list[tuple[torch.Tensor, torch.Tensor]],
-    ) -> transformers.cache_utils.DynamicCache:
+    ) -> DynamicCache:
         """
-        Creates an instance of :class:`transformers.cache_utils.DynamicCache`.
+        Creates an instance of :class:`DynamicCache`.
         This version is valid for ``transformers >= 4.50``.
 
         :param key_value_pairs: list of pairs of (key, values)
-        :return: :class:`transformers.cache_utils.DynamicCache`
+        :return: :class:`DynamicCache`
         """
-        return transformers.cache_utils.DynamicCache(key_value_pairs)
+        return DynamicCache(key_value_pairs)
 
 else:
 
     def make_dynamic_cache(
         key_value_pairs: list[tuple[torch.Tensor, torch.Tensor]],
-    ) -> transformers.cache_utils.DynamicCache:
+    ) -> DynamicCache:
         """
-        Creates an instance of :class:`transformers.cache_utils.DynamicCache`.
+        Creates an instance of :class:`DynamicCache`.
         This version is valid for ``transformers < 4.50``.
 
         :param key_value_pairs: list of pairs of (key, values)
-        :return: :class:`transformers.cache_utils.DynamicCache`
+        :return: :class:`DynamicCache`
         """
-        cache = transformers.cache_utils.DynamicCache(len(key_value_pairs))
+        cache = DynamicCache(len(key_value_pairs))
         for i, (key, value) in enumerate(key_value_pairs):
             cache.update(key, value, i)
         return cache
 
 
 def make_encoder_decoder_cache(
-    self_attention_cache: transformers.cache_utils.DynamicCache,
-    cross_attention_cache: transformers.cache_utils.DynamicCache,
-) -> transformers.cache_utils.EncoderDecoderCache:
+    self_attention_cache: DynamicCache,
+    cross_attention_cache: DynamicCache,
+) -> EncoderDecoderCache:
     """
     Creates an EncoderDecoderCache.
     """
-    return transformers.cache_utils.EncoderDecoderCache(
+    return EncoderDecoderCache(
         self_attention_cache=self_attention_cache, cross_attention_cache=cross_attention_cache
     )

--- a/onnxruntime/python/tools/transformers/models/torch_export_patches/onnx_export_errors.py
+++ b/onnxruntime/python/tools/transformers/models/torch_export_patches/onnx_export_errors.py
@@ -71,7 +71,6 @@ def _register_cache_serialization(verbose: int = 0) -> dict[str, bool]:
     # Cache serialization: to be moved into appropriate packages
     import packaging.version as pv
     import torch
-    from transformers import __version__ as transformers_version
 
     try:
         from transformers.cache_utils import DynamicCache

--- a/onnxruntime/python/tools/transformers/models/torch_export_patches/onnx_export_errors.py
+++ b/onnxruntime/python/tools/transformers/models/torch_export_patches/onnx_export_errors.py
@@ -71,7 +71,7 @@ def _register_cache_serialization(verbose: int = 0) -> dict[str, bool]:
     # Cache serialization: to be moved into appropriate packages
     import packaging.version as pv
     import torch
-    import transformers
+    from transformers import __version__ as transformers_version
 
     try:
         from transformers.cache_utils import DynamicCache
@@ -110,7 +110,7 @@ def _register_cache_serialization(verbose: int = 0) -> dict[str, bool]:
     # torch.fx._pytree.register_pytree_flatten_spec(
     #           DynamicCache, _flatten_dynamic_cache_for_fx)
     # so we remove it anyway
-    if DynamicCache in torch.fx._pytree.SUPPORTED_NODES and pv.Version(transformers.__version__) >= pv.Version("2.7"):
+    if DynamicCache in torch.fx._pytree.SUPPORTED_NODES and pv.Version(torch.__version__) >= pv.Version("2.7"):
         if verbose:
             print("[_register_cache_serialization] DynamicCache is unregistered first.")
         _unregister(DynamicCache)

--- a/onnxruntime/python/tools/transformers/models/torch_export_patches/onnx_export_serialization.py
+++ b/onnxruntime/python/tools/transformers/models/torch_export_patches/onnx_export_serialization.py
@@ -1,7 +1,8 @@
 from typing import Any
 
 import torch
-import transformers
+
+from transformers.cache_utils import DynamicCache, MambaCache
 
 ############
 # MambaCache
@@ -25,9 +26,9 @@ import transformers
 #     dtype=dtype,
 # )
 def flatten_mamba_cache(
-    mamba_cache: transformers.cache_utils.MambaCache,
+    mamba_cache: MambaCache,
 ) -> tuple[list[Any], torch.utils._pytree.Context]:
-    """Serializes a :class:`transformers.cache_utils.MambaCache` with python objects."""
+    """Serializes a :class:`MambaCache` with python objects."""
     flat = [
         (k, getattr(mamba_cache, k))
         for k in [
@@ -47,8 +48,8 @@ def unflatten_mamba_cache(
     values: list[Any],
     context: torch.utils._pytree.Context,
     output_type=None,
-) -> transformers.cache_utils.MambaCache:
-    """Restores a :class:`transformers.cache_utils.MambaCache` from python objects."""
+) -> MambaCache:
+    """Restores a :class:`MambaCache` from python objects."""
     conv_states, ssm_states = values
 
     class _config:
@@ -63,8 +64,6 @@ def unflatten_mamba_cache(
                 self.state_size = ssm_states.shape[3]
                 self.conv_kernel = conv_states.shape[3]
                 self.num_hidden_layers = conv_states.shape[0]
-
-    from transformers.cache_utils import MambaCache
 
     cache = MambaCache(
         _config(),
@@ -84,9 +83,7 @@ def flatten_with_keys_mamba_cache(
     list[tuple[torch.utils._pytree.KeyEntry, Any]],
     torch.utils._pytree.Context,
 ]:
-    """Serializes a :class:`transformers.cache_utils.MambaCache` with python objects."""
-    import torch
-
+    """Serializes a :class:`MambaCache` with python objects."""
     values, context = flatten_mamba_cache(d)
     return [(torch.utils._pytree.MappingKey(k), v) for k, v in zip(context, values, strict=False)], context
 
@@ -97,9 +94,9 @@ def flatten_with_keys_mamba_cache(
 
 
 def flatten_dynamic_cache(
-    dynamic_cache: transformers.cache_utils.DynamicCache,
+    dynamic_cache: DynamicCache,
 ) -> tuple[list[Any], torch.utils._pytree.Context]:
-    """Serializes a :class:`transformers.cache_utils.DynamicCache` with python objects."""
+    """Serializes a :class:`DynamicCache` with python objects."""
     flat = [(k, getattr(dynamic_cache, k)) for k in ["key_cache", "value_cache"] if hasattr(dynamic_cache, k)]
     return [f[1] for f in flat], [f[0] for f in flat]
 
@@ -110,9 +107,7 @@ def flatten_with_keys_dynamic_cache(
     list[tuple[torch.utils._pytree.KeyEntry, Any]],
     torch.utils._pytree.Context,
 ]:
-    """Serializes a :class:`transformers.cache_utils.DynamicCache` with python objects."""
-    import torch
-
+    """Serializes a :class:`DynamicCache` with python objects."""
     values, context = flatten_dynamic_cache(d)
     return [(torch.utils._pytree.MappingKey(k), v) for k, v in zip(context, values, strict=False)], context
 
@@ -121,10 +116,8 @@ def unflatten_dynamic_cache(
     values: list[Any],
     context: torch.utils._pytree.Context,
     output_type=None,
-) -> transformers.cache_utils.DynamicCache:
-    """Restores a :class:`transformers.cache_utils.DynamicCache` from python objects."""
-    from transformers.cache_utils import DynamicCache
-
+) -> DynamicCache:
+    """Restores a :class:`DynamicCache` from python objects."""
     cache = DynamicCache()
     values = dict(zip(context, values, strict=False))
     for k, v in values.items():

--- a/onnxruntime/python/tools/transformers/models/torch_export_patches/onnx_export_serialization.py
+++ b/onnxruntime/python/tools/transformers/models/torch_export_patches/onnx_export_serialization.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 import torch
-
 from transformers.cache_utils import DynamicCache, MambaCache
 
 ############

--- a/onnxruntime/python/tools/transformers/models/torch_export_patches/patch_inputs.py
+++ b/onnxruntime/python/tools/transformers/models/torch_export_patches/patch_inputs.py
@@ -2,10 +2,10 @@ import inspect
 from typing import Any
 
 import torch
+from transformers.cache_utils import DynamicCache
 
 from . import string_type
 from .cache_helper import make_dynamic_cache
-from transformers.cache_utils import DynamicCache
 
 
 def _process_cache(k: str, v):

--- a/onnxruntime/python/tools/transformers/models/torch_export_patches/patch_inputs.py
+++ b/onnxruntime/python/tools/transformers/models/torch_export_patches/patch_inputs.py
@@ -2,10 +2,10 @@ import inspect
 from typing import Any
 
 import torch
-import transformers
 
 from . import string_type
 from .cache_helper import make_dynamic_cache
+from transformers.cache_utils import DynamicCache
 
 
 def _process_cache(k: str, v):
@@ -22,7 +22,7 @@ def _process_cache(k: str, v):
 
 
 def _make_shape(subset: dict, cls: type, value: Any) -> Any:
-    if cls is transformers.cache_utils.DynamicCache:
+    if cls is DynamicCache:
         assert subset, "DynamicCache cannot be empty"
         values = set(map(str, subset.values()))
         assert len(values) == 1, (

--- a/onnxruntime/python/tools/transformers/models/torch_export_patches/patches/patch_transformers.py
+++ b/onnxruntime/python/tools/transformers/models/torch_export_patches/patches/patch_transformers.py
@@ -4,9 +4,9 @@ from dataclasses import dataclass
 from typing import Any
 
 import torch
-import transformers
-import transformers.modeling_attn_mask_utils
 from transformers.cache_utils import Cache, DynamicCache, StaticCache
+from transformers.generation.utils import GenerationMixin
+from transformers.modeling_attn_mask_utils import AttentionMaskConverter
 
 
 def _patch_make_causal_mask(
@@ -50,11 +50,11 @@ if sys.version_info[:2] <= (3, 11):
     class patched_AttentionMaskConverter:
         """
         Patches
-        ``transformers.modeling_attn_mask_utils.AttentionMaskConverter._make_causal_mask``.
+        ``AttentionMaskConverter._make_causal_mask``.
         """
 
         _PATCHES_ = ["_make_causal_mask"]
-        _PATCHED_CLASS_ = transformers.modeling_attn_mask_utils.AttentionMaskConverter
+        _PATCHED_CLASS_ = AttentionMaskConverter
 
         @staticmethod
         def _make_causal_mask(
@@ -73,11 +73,11 @@ else:
     class patched_AttentionMaskConverter:
         """
         Patches
-        ``transformers.modeling_attn_mask_utils.AttentionMaskConverter._make_causal_mask``.
+        ``AttentionMaskConverter._make_causal_mask``.
         """
 
         _PATCHES_ = ["_make_causal_mask"]
-        _PATCHED_CLASS_ = transformers.modeling_attn_mask_utils.AttentionMaskConverter
+        _PATCHED_CLASS_ = AttentionMaskConverter
 
         @staticmethod
         def _make_causal_mask(
@@ -99,7 +99,7 @@ class patched_DynamicCache:
     """
 
     _PATCHES_ = ["reorder_cache", "update", "crop", "from_batch_splits", "get_seq_length"]
-    _PATCHED_CLASS_ = transformers.cache_utils.DynamicCache
+    _PATCHED_CLASS_ = DynamicCache
 
     def get_seq_length(self, layer_idx: int | None = 0) -> int:
         """Returns the sequence length of the cached states.
@@ -217,7 +217,7 @@ class patched_GenerationMixin:
         "_cache_dependant_input_preparation_exporting",
         "prepare_inputs_for_generation",
     ]
-    _PATCHED_CLASS_ = transformers.generation.utils.GenerationMixin
+    _PATCHED_CLASS_ = GenerationMixin
 
     def _cache_dependant_input_preparation(
         self,


### PR DESCRIPTION
### Description
This PR updates ONNX Runtime's LLM conversion tools to use [PyTorch 2.7](https://pytorch.org/blog/pytorch-2-7/) and reduces memory usage during export.

### Motivation and Context
Importing the `transformers` package with `import transformers` will take a long time because of the many namespaces it has at the top level. It is more efficient to only import the desired class names. Additionally, the benchmarking of the PyTorch model includes the deep copy of the inputs when it does not need to. The deep copy can be performed before measuring latency.
