### PR TITLE
[QNN-EP] Minor fix: compare different types

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/softmax_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/softmax_op_builder.cc
@@ -39,12 +39,12 @@ constexpr int32_t GetDefaultAxisAttribute(int opset_version) {
   return opset_version < 13 ? 1 : -1;
 }
 
-std::vector<uint32_t> FlattenShapeFromAxis(std::vector<uint32_t>& input_shape, int32_t axis) {
+std::vector<uint32_t> FlattenShapeFromAxis(const std::vector<uint32_t>& input_shape, int32_t axis) {
   /*
   Return the shape with all dimensions multiplied onward from the specified axis. If axis is 0, the returned shape
   will include an additional batch of size 1 as the first dimension.
   */
-  assert(axis >= 0 && axis < input_shape.size());
+  assert(axis >= 0 && static_cast<size_t>(axis) < input_shape.size());
   std::vector<uint32_t> output_shape(input_shape.begin(), input_shape.begin() + axis);
 
   if (axis == 0) {


### PR DESCRIPTION
Fix: ```/local/mnt/workspace/onnxruntime-qnn-ep/onnxruntime/core/providers/qnn/builder/opbuilder/softmax_op_builder.cc: In function ‘std::vector<unsigned int> onnxruntime::qnn::FlattenShapeFromAxis(std::vector<unsigned int>&, int32_t)’:
/local/mnt/workspace/onnxruntime-qnn-ep/onnxruntime/core/providers/qnn/builder/opbuilder/softmax_op_builder.cc:47:28: error: comparison of integer expressions of different signedness: ‘int32_t’ {aka ‘int’} and ‘std::vector<unsigned int>::size_type’ {aka ‘long unsigned int’} [-Werror=sign-compare]
   47 |   assert(axis >= 0 && axis < input_shape.size());
      |```