### PR TITLE
Update bigmodels-ci-pipeline.yml for Azure Pipelines

### DIFF
--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -309,14 +309,13 @@ stages:
         "
         Repository: onnxruntimeubi8packagestest_torch
         UseImageCacheContainerRegistry: false
-
     - task: DownloadPackage@1
-      displayName: 'Download Meta Llama2 model'
       inputs:
-        packageType: upack
-        feed: '/7424c8e4-5c62-490e-95c4-79446f31017c'
-        version: 1.0.0
-        definition: '6fe0c4ed-9d0e-4d66-94cc-fb6a111d02a5'
+        packageType: 'upack'
+        feed: '2692857e-05ef-43b4-ba9c-ccf1c22c437c/8fc55c18-5239-4843-a0df-c7a8b1b36be7'
+        view: 'bdf2fe57-11ef-4a86-a145-7857a0405755'
+        definition: '2a6a4112-e5b6-48cb-ab68-ddfb83533702'
+        version: '1.0.0'
         downloadPath: $(Agent.TempDirectory)/meta_llama2_7b_hf
 
     - script: |
@@ -421,17 +420,17 @@ stages:
         ScriptName: tools/ci_build/get_docker_image.py
         DockerBuildArgs: '--build-arg BUILD_UID=$( id -u )'
         Repository: onnxruntimepackagestest_ompffmpeg
-
     - task: DownloadPackage@1
       # The model data in artifact is downloaded from openai/whisper-large-v3 in huggingface model hub
       # In order to save size, removed .git directory and pickled files, and keep the safetensors model files
       displayName: 'Download Whisper Model'
       inputs:
-        packageType: upack
-        feed: '/7424c8e4-5c62-490e-95c4-79446f31017c'
-        version: 1.0.0
-        definition: 'b583ce7c-1a8f-4099-ae28-5d5f56c478b1'
-        downloadPath: $(Agent.TempDirectory)/whisper_large_v3
+        packageType: 'upack'
+        feed: '2692857e-05ef-43b4-ba9c-ccf1c22c437c/8fc55c18-5239-4843-a0df-c7a8b1b36be7'
+        view: 'bdf2fe57-11ef-4a86-a145-7857a0405755'
+        definition: 'c78cdb16-4022-4baa-84d4-8bccbe935762'
+        version: '1.0.1'
+        downloadPath: $(Agent.TempDirectory)/whisper_large_v3\
 
     - script: |
         docker run -e SYSTEM_COLLECTIONURI --rm --gpus all -v $(Build.SourcesDirectory):/workspace \

--- a/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/bigmodels-ci-pipeline.yml
@@ -430,7 +430,7 @@ stages:
         view: 'bdf2fe57-11ef-4a86-a145-7857a0405755'
         definition: 'c78cdb16-4022-4baa-84d4-8bccbe935762'
         version: '1.0.1'
-        downloadPath: $(Agent.TempDirectory)/whisper_large_v3\
+        downloadPath: $(Agent.TempDirectory)/whisper_large_v3
 
     - script: |
         docker run -e SYSTEM_COLLECTIONURI --rm --gpus all -v $(Build.SourcesDirectory):/workspace \


### PR DESCRIPTION
Update the feed information because we have moved the models to a new feed.