### PR TITLE
new cmake version installed to match minimum version

### DIFF
--- a/dockerfiles/scripts/install_cmake.sh
+++ b/dockerfiles/scripts/install_cmake.sh
@@ -5,7 +5,7 @@ cd /tmp/src
 
 echo "Installing cmake"
 CPU_ARCH=`uname -m`
-CMAKE_VERSION='3.27.3'
+CMAKE_VERSION='3.28.0'
 curl https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-linux-$CPU_ARCH.tar.gz -sSL --retry 5  -o /tmp/src/cmake.tar.gz
 tar -zxf /tmp/src/cmake.tar.gz --strip=1 -C /usr
 rm -f /tmp/src/cmake.tar.gz


### PR DESCRIPTION
### Description
In cmake/CMakeLists.txt the minimum version of cmake is 3.28, this PR updates the version of CMake installed on the dockers to be 3.28.0.



### Motivation and Context
Fixes microsoft/onnxruntime#24521
