### PR TITLE
[VitisAI] Update the order of deregister op

### DIFF
--- a/onnxruntime/core/providers/vitisai/imp/global_api.cc
+++ b/onnxruntime/core/providers/vitisai/imp/global_api.cc
@@ -268,10 +268,10 @@ void initialize_vitisai_ep() {
 }
 
 void deinitialize_vitisai_ep() {
+  vaip::deregister_xir_ops(s_domains_vitisaiep);
   if (s_library_vitisaiep.deinitialize_onnxruntime_vitisai_ep) {
     s_library_vitisaiep.deinitialize_onnxruntime_vitisai_ep();
   }
-  vaip::deregister_xir_ops(s_domains_vitisaiep);
   // kernel registry would be repopulated, no need to delete kernel registry
   s_domains_vitisaiep.clear();
 

--- a/onnxruntime/core/providers/vitisai/include/vaip/vaip_ort_api.h
+++ b/onnxruntime/core/providers/vitisai/include/vaip/vaip_ort_api.h
@@ -13,7 +13,7 @@ struct OrtApi;
 
 namespace vaip_core {
 
-#define VAIP_ORT_API_MAJOR (16u)
+#define VAIP_ORT_API_MAJOR (17u)
 #define VAIP_ORT_API_MINOR (0u)
 #define VAIP_ORT_API_PATCH (0u)
 struct OrtApiForVaip {


### PR DESCRIPTION
### Description
after deinitialize_onnxruntime_vitisai_ep, s_domains_vitisaiep will be incorrect, which may cause an exception



### Motivation and Context
Put deregister_xir_ops() before deinitialize_onnxruntime_vitisai_ep() to avoid dangling pointers


