### PR TITLE
fix compilation with gcc-15

### DIFF
--- a/onnxruntime/core/optimizer/transpose_optimization/optimizer_api.h
+++ b/onnxruntime/core/optimizer/transpose_optimization/optimizer_api.h
@@ -10,6 +10,7 @@
 #include <string_view>
 #include <unordered_map>
 #include <unordered_set>
+#include <cstdint>
 #include <vector>
 
 namespace onnx_transpose_optimization {


### PR DESCRIPTION
With GCC-15, some libstdc++ headers stopped including <stdint.h>: https://github.com/gcc-mirror/gcc/commit/3a817a4a5a6d94da9127af3be9f84a74e3076ee2

So we need to include it ourselves, in places where we relied on the standard headers doing it.