### PR TITLE
[CUDA] Update sm check for flash attention

### DIFF
--- a/onnxruntime/contrib_ops/cuda/bert/cudnn_fmha/cudnn_flash_attention.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/cudnn_fmha/cudnn_flash_attention.cu
@@ -100,9 +100,7 @@ bool is_supported(const cudaDeviceProp& dprops,
                   int sequence_length_q,
                   int sequence_length_kv,
                   bool is_causal) {
-  bool is_sm8x = dprops.major == 8 && dprops.minor >= 0;
-  bool is_sm90 = dprops.major == 9 && dprops.minor == 0;
-  return (is_sm8x || is_sm90) &&
+  return (dprops.major >= 8) &&
          (head_size_qk % 8 == 0) && (head_size_qk <= 256) &&
          (head_size_v % 8 == 0) && (head_size_v <= 256) &&
          (num_heads_q % num_heads_kv == 0) &&

--- a/onnxruntime/contrib_ops/cuda/bert/flash_attention/flash_api.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/flash_attention/flash_api.cc
@@ -411,9 +411,7 @@ Status mha_varlen_fwd(const cudaDeviceProp& dprops,
 }
 
 bool is_supported(const cudaDeviceProp& dprops, size_t head_size, size_t num_heads, size_t num_heads_k) {
-  bool is_sm8x = dprops.major == 8 && dprops.minor >= 0;
-  bool is_sm90 = dprops.major == 9 && dprops.minor == 0;
-  return (is_sm8x || is_sm90) && (head_size % 8 == 0) && (head_size <= 256) && (num_heads % num_heads_k == 0);
+  return (dprops.major >= 8) && (head_size % 8 == 0) && (head_size <= 256) && (num_heads % num_heads_k == 0);
 }
 
 // This API is used when past key and value are present... since cached, these are assumed to have sequence length


### PR DESCRIPTION
### Description

Currently, flash attention is only enabled for sm8x and sm90. That means blackwell GPU will not be able to use flash attention. This is enable flash attention for sm > 90.

Note that the flash attention implementation is not optimized for blackwell, but shall be able to run in blackwell GPU. 

Future works:
* Integrate flash attn for hopper: https://github.com/Dao-AILab/flash-attention/tree/main/hopper
* Integrate fmha for blackwell: https://github.com/NVIDIA/cutlass/tree/main/examples/77_blackwell_fmha

### Motivation and Context
ORT GENAI is slow in RTX 5090


