### PR TITLE
'LoadPluginOrProviderBridge' should load the library_path as absolute

### DIFF
--- a/onnxruntime/core/session/ep_library_plugin.h
+++ b/onnxruntime/core/session/ep_library_plugin.h
@@ -16,9 +16,9 @@ namespace onnxruntime {
 /// </summary>
 class EpLibraryPlugin : public EpLibrary {
  public:
-  EpLibraryPlugin(const std::string& registration_name, const ORTCHAR_T* library_path)
+  EpLibraryPlugin(const std::string& registration_name, std::filesystem::path library_path)
       : registration_name_{registration_name},
-        library_path_{library_path} {
+        library_path_{std::move(library_path)} {
   }
 
   const char* RegistrationName() const override {

--- a/onnxruntime/core/session/provider_bridge_library.h
+++ b/onnxruntime/core/session/provider_bridge_library.h
@@ -9,8 +9,14 @@
 namespace onnxruntime {
 struct Provider;
 
+enum class ProviderLibraryPathType
+{
+  Default,
+  Absolute,
+};
+
 struct ProviderLibrary {
-  ProviderLibrary(const ORTCHAR_T* filename, bool unload = true);
+  ProviderLibrary(const ORTCHAR_T* filename, bool unload = true, ProviderLibraryPathType pathType = ProviderLibraryPathType::Default);
   ~ProviderLibrary();
 
   Status Load();
@@ -19,8 +25,9 @@ struct ProviderLibrary {
 
  private:
   std::mutex mutex_;
-  const ORTCHAR_T* filename_;
+  const ORTCHAR_T* const filename_;
   bool unload_;
+  const bool absolute_;
   bool initialized_{};
   Provider* provider_{};
   void* handle_{};

--- a/onnxruntime/core/session/provider_bridge_library.h
+++ b/onnxruntime/core/session/provider_bridge_library.h
@@ -9,8 +9,7 @@
 namespace onnxruntime {
 struct Provider;
 
-enum class ProviderLibraryPathType
-{
+enum class ProviderLibraryPathType {
   Default,
   Absolute,
 };

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -1727,8 +1727,8 @@ bool InitProvidersSharedLibrary() try {
   return false;
 }
 
-ProviderLibrary::ProviderLibrary(const ORTCHAR_T* filename, bool unload)
-    : filename_{filename}, unload_{unload} {
+ProviderLibrary::ProviderLibrary(const ORTCHAR_T* filename, bool unload, ProviderLibraryPathType pathType)
+    : filename_{filename}, unload_{unload}, absolute_{pathType == ProviderLibraryPathType::Absolute} {
 }
 
 ProviderLibrary::~ProviderLibrary() {
@@ -1744,8 +1744,16 @@ Status ProviderLibrary::Load() {
     std::lock_guard<std::mutex> lock{mutex_};
     s_library_shared.Ensure();
 
-    auto full_path = Env::Default().GetRuntimePath() + filename_;
-    ORT_RETURN_IF_ERROR(Env::Default().LoadDynamicLibrary(full_path, false, &handle_));
+    if (absolute_) {
+      // If filename_ is not absolute it should not be loaded.
+      if (!std::filesystem::path{filename_}.is_absolute()) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "An absolute path must be specified.");
+      }
+      ORT_RETURN_IF_ERROR(Env::Default().LoadDynamicLibrary(filename_, false, &handle_));
+    } else {
+      auto full_path = Env::Default().GetRuntimePath() + filename_;
+      ORT_RETURN_IF_ERROR(Env::Default().LoadDynamicLibrary(full_path, false, &handle_));
+    }
 
     Provider* (*PGetProvider)();
     ORT_RETURN_IF_ERROR(Env::Default().GetSymbolFromLibrary(handle_, "GetProvider", (void**)&PGetProvider));


### PR DESCRIPTION
### Description
`LoadPluginOrProviderBridge` is called when attempting to load a Plugin. It uses the passed `library_path` to attempt to load the Plugin as a `Provider` - using `ProviderLibrary` - to see if it can be treated as a 'ProviderBridge'. `ProviderLibrary` attempts to load the Provider by prefixing the path to the onnxruntime.dll. Plugins needn't be redistributed with OnnxRuntime, so the path to the Plugin _may_ be an absolute path, and if so `ProviderLibrary` fails. At the same time - however - `LoadPluginOrProviderBridge` needs to support OnnxRuntime-relative paths: As 'Providers' are migrated to 'Plugins', existing Providers should be usable as Plugins. To accommodate both scenarios, this PR:

1. Adds support to `ProviderLibrary` to be created with an absolute path.
2. Validates the path passed to `LoadPluginOrProviderBridge`;
    1. if it is absolute, the same absolute path is passed to `ProviderLibrary` and `EpLibraryPlugin`.
    2. if the path is not absolute, it is converted to an absolute path by prefixing the OnnxRuntime location, and the same path is passed to `ProviderLibrary` and `EpLibraryPlugin`.

### Motivation and Context
This PR enables `LoadPluginOrProviderBridge` to be called with an absolute path to the Plugin, allowing it to be used as a 'ProviderBridge', or with an OnnxRuntime-relative path to the Plugin.