### PR TITLE
[webgpu] Enable matmul8bits for dp4/subgroupMatrix path

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/quantization/dp4a_matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/webgpu/quantization/dp4a_matmul_nbits.cc
@@ -9,7 +9,9 @@ namespace contrib {
 namespace webgpu {
 namespace {
 
-constexpr std::string_view commonFunctions = R"ADDNL_FN(
+std::string commonFunctions(uint32_t nbits) {
+  if (nbits == 4) {
+    return R"ADDNL_FN(
         fn DequantizedFrom4BitsTo8Bits(in: vec2<u32>) -> vec4<u32>
         {
             var out = vec4<u32>(0);
@@ -38,6 +40,37 @@ constexpr std::string_view commonFunctions = R"ADDNL_FN(
             return output_element_t(local_sum) * scale;
         }
   )ADDNL_FN";
+  } else {
+    ORT_ENFORCE(nbits == 8, "Only 4/8 bits are supported for webgpu matmulnbits");
+    // For 8bits, in case data overflow when converting from int32 (output of dot4I8Packed) to f16, we force it convert to f32.
+    // Then do the scale. Finally, convert to output element type.
+    return R"ADDNL_FN(
+        fn AlignWithZeroPoint(in: vec4<u32>) -> vec4<u32>
+        {
+            var out = vec4<u32>(0);
+            out[0] = pack4xI8(vec4<i32>(unpack4xU8(in[0])) - vec4<i32>(128));
+            out[1] = pack4xI8(vec4<i32>(unpack4xU8(in[1])) - vec4<i32>(128));
+            out[2] = pack4xI8(vec4<i32>(unpack4xU8(in[2])) - vec4<i32>(128));
+            out[3] = pack4xI8(vec4<i32>(unpack4xU8(in[3])) - vec4<i32>(128));
+            return out;
+        }
+
+        // Scaled dot product of 8 packed unsigned integers.
+        fn SDP8AI(a1:vec4<u32>, b1:vec4<u32>, a2:vec4<u32>, b2:vec4<u32>, scale:output_element_t) -> output_element_t
+        {
+            var local_sum = dot4I8Packed(a1[0], b1[0]);
+            local_sum += dot4I8Packed(a1[1], b1[1]);
+            local_sum += dot4I8Packed(a1[2], b1[2]);
+            local_sum += dot4I8Packed(a1[3], b1[3]);
+            local_sum += dot4I8Packed(a2[0], b2[0]);
+            local_sum += dot4I8Packed(a2[1], b2[1]);
+            local_sum += dot4I8Packed(a2[2], b2[2]);
+            local_sum += dot4I8Packed(a2[3], b2[3]);
+            return output_element_t(f32(local_sum) * f32(scale));
+        }
+  )ADDNL_FN";
+  }
+}
 
 }  // namespace
 
@@ -98,7 +131,7 @@ Status DP4AMatMulNBitsProgram::GenerateShaderCode(ShaderHelper& shader) const {
   // this shader require A to be int8 quantized with block size 64. B is regular
   // matmulnbits input with block size 32.
 
-  shader.AdditionalImplementation() << commonFunctions
+  shader.AdditionalImplementation() << commonFunctions(nbits_)
                                     << "  const block_size = " << block_size_ << ";";
 
   shader.AdditionalImplementation() << R"ADDNL_FN(
@@ -129,7 +162,9 @@ Status DP4AMatMulNBitsProgram::GenerateShaderCode(ShaderHelper& shader) const {
                 scale_A[row] = scales_a[a_global*(uniforms.K/128) + kidx_v/8];
             }
         }
-
+    )ADDNL_FN";
+  if (nbits_ == 4) {
+    shader.AdditionalImplementation() << R"ADDNL_FN(
         fn loadSHMB(b_global_base:u32, kidx_v:u32, row: u32, col: u32)
         {
             let b_global = b_global_base + row;
@@ -147,6 +182,27 @@ Status DP4AMatMulNBitsProgram::GenerateShaderCode(ShaderHelper& shader) const {
             }
         }
     )ADDNL_FN";
+  } else {
+    ORT_ENFORCE(nbits_ == 8, "Only 4/8 bits are supported for webgpu matmulnbits");
+    shader.AdditionalImplementation() << R"ADDNL_FN(
+        fn loadSHMB(b_global_base:u32, kidx_v:u32, row: u32, col: u32)
+        {
+            let b_global = b_global_base + row;
+            if (b_global >= uniforms.N)
+            {
+                return;
+            }
+
+            let b_value = input_b[b_global*uniforms.K16+kidx_v+col];
+            tile_B[col][row] = AlignWithZeroPoint(b_value);
+            if (col == 0)
+            {
+                // kidx_v - each kidx_v covers 16 values of k
+                scale_B[row] = scales_b[b_global*(uniforms.K/block_size) + kidx_v/(block_size/16)];
+            }
+        }
+    )ADDNL_FN";
+  }
 
   shader.MainFunctionBody() << R"MAIN_FN(
         // During the load phase we use all 256 threads to load 64 rows of A/B.
@@ -289,18 +345,19 @@ Status DP4AMatMulNBitsSmallMProgram::GenerateShaderCode(ShaderHelper& shader) co
   //    - Stores intermediate results in shared memory (inter_results)
   //    - Iterates through columns accumulating results in inter_results
   //    - Performs final reduction sum in inter_results for output
-  shader.AdditionalImplementation() << "const tile_size = " << tile_size_ << "u;\n"
-                                    << "const tile_size_k_vec = " << tile_size_k_vec << "u;\n"
-                                    // sub_tile_size is the number of concurrent b rows processed by the workgroup.
-                                    << "const sub_tile_size = " << WorkgroupSizeX() / tile_size_k_vec << "u;\n";
-  shader.AdditionalImplementation() << commonFunctions
+  shader.AdditionalImplementation() << "  const tile_size = " << tile_size_ << "u;\n"
+                                    << "  const tile_size_k_vec = " << tile_size_k_vec << "u;\n"
+                                    << "  const double_tile_size_k_vec = " << 2 * tile_size_k_vec << "u;\n"
+                                    // sub_tile_count is the number of concurrent b rows processed by the workgroup.
+                                    << "  const sub_tile_count = " << WorkgroupSizeX() / tile_size_k_vec << "u;\n"
+                                    << "  var<workgroup> inter_results: array<array<output_element_t, tile_size_k_vec>, tile_size>;\n";
+
+  shader.AdditionalImplementation() << commonFunctions(nbits_)
                                     << R"ADDNL_FN(
-    // Shared memory
     // Need 2 * tile_size_k_vec (32) to store a tile_A since b is quantized as 4 bits and a is quantized as 8 bits.
     var<workgroup> tile_A : array<vec4<u32>, 32>;
     // Need 4 scales value since each tile_A includes 512 (4x4x32) scalars and the block_size is 128.
     var<workgroup> scale_A : array<output_element_t, 4>;
-    var<workgroup> inter_results: array<array<output_element_t, tile_size_k_vec>, tile_size>;
     fn loadSHMA(a_global: u32, kidx_v: u32, col: u32)
     {
       let k_offset = kidx_v + col;
@@ -320,13 +377,16 @@ Status DP4AMatMulNBitsSmallMProgram::GenerateShaderCode(ShaderHelper& shader) co
   shader.MainFunctionBody() << R"MAIN_FN(
     let a_global = u32(workgroup_idx / uniforms.num_N_tile);
     let b_global_base = (workgroup_idx % uniforms.num_N_tile) * tile_size;
-    // Handle each workgroup threads as a block of [sub_tile_size][tile_size_k_vec]
+    // Handle each workgroup threads as a block of [sub_tile_count][tile_size_k_vec]
     let local_col = local_idx % tile_size_k_vec;
     let local_row = local_idx / tile_size_k_vec;
+  )MAIN_FN";
+  if (nbits_ == 4) {
+    shader.MainFunctionBody() << R"MAIN_FN(
     for (var kidx_v:u32 = 0; kidx_v < uniforms.K32; kidx_v += tile_size_k_vec)
     {
       // Load Phase: Populate shared memory for the workgroup.
-      if (local_idx < 32)
+      if (local_idx < double_tile_size_k_vec)
       {
         loadSHMA(a_global, kidx_v * 2, local_idx);
       }
@@ -338,7 +398,7 @@ Status DP4AMatMulNBitsSmallMProgram::GenerateShaderCode(ShaderHelper& shader) co
       var own_b1 = vec4<u32>(0);
       let k_offset = kidx_v + local_col;
       // calculate intermediate results into inter_results.
-      for (var row_offset = 0u; row_offset < tile_size; row_offset += sub_tile_size) {
+      for (var row_offset = 0u; row_offset < tile_size; row_offset += sub_tile_count) {
         let b_global = b_global_base + row_offset + local_row;
         if (b_global < uniforms.N && k_offset < uniforms.K32)
         {
@@ -354,7 +414,43 @@ Status DP4AMatMulNBitsSmallMProgram::GenerateShaderCode(ShaderHelper& shader) co
       }
       workgroupBarrier();
     }
+  )MAIN_FN";
+  } else {
+    shader.MainFunctionBody() << R"MAIN_FN(
+    for (var kidx_v:u32 = 0; kidx_v < uniforms.K16; kidx_v += double_tile_size_k_vec)
+    {
+      // Load Phase: Populate shared memory for the workgroup.
+      if (local_idx < double_tile_size_k_vec)
+      {
+        loadSHMA(a_global, kidx_v, local_idx);
+      }
+      workgroupBarrier();
+      var own_a: vec4<u32> = tile_A[local_col * 2];
+      var own_a1: vec4<u32> = tile_A[local_col * 2 + 1];
+      var own_scale_a = scale_A[local_col / 4];
+      var own_b = vec4<u32>(0);
+      var own_b1 = vec4<u32>(0);
+      let k_offset = kidx_v + local_col * 2;
+      // calculate intermediate results into inter_results.
+      for (var row_offset = 0u; row_offset < tile_size; row_offset += sub_tile_count) {
+        let b_global = b_global_base + row_offset + local_row;
+        if (b_global < uniforms.N && k_offset < uniforms.K16)
+        {
+          let b_offset = b_global * uniforms.K16 + k_offset;
+          own_b = AlignWithZeroPoint(input_b[b_offset]);
+          own_b1 = AlignWithZeroPoint(input_b[b_offset + 1]);
 
+          // k_offset - covers 16 values of k in input_b
+          let own_scale_b = scales_b[b_global * uniforms.K / uniforms.block_size + k_offset * 16 / uniforms.block_size];
+          inter_results[row_offset + local_row][local_col] += SDP8AI(own_a, own_b, own_a1, own_b1, own_scale_a * own_scale_b);
+        }
+      }
+      workgroupBarrier();
+    }
+  )MAIN_FN";
+  }
+
+  shader.MainFunctionBody() << R"MAIN_FN(
     if (local_idx < tile_size) {
       // Do reduce sum to get final output.
       var output_value = output_element_t(0);
@@ -378,6 +474,7 @@ Status ApplyDP4AMatrixMatMulNBits(const Tensor* a, const Tensor* b, const Tensor
                                   uint32_t K,
                                   uint32_t block_size,
                                   uint32_t min_M_for_tile_optimization,
+                                  uint32_t nbits,
                                   onnxruntime::webgpu::ComputeContext& context,
                                   Tensor* y) {
   constexpr uint32_t kVec4Components = 4;
@@ -399,7 +496,7 @@ Status ApplyDP4AMatrixMatMulNBits(const Tensor* a, const Tensor* b, const Tensor
 
   if (M < min_M_for_tile_optimization) {
     constexpr uint32_t kTileSize = 32;
-    DP4AMatMulNBitsSmallMProgram mul_program{kTileSize};
+    DP4AMatMulNBitsSmallMProgram mul_program{kTileSize, nbits};
     uint32_t num_N_tile = (N + kTileSize - 1) / kTileSize;
     mul_program.SetWorkgroupSize(128);
     mul_program.SetDispatchGroupSize(M * num_N_tile);
@@ -408,7 +505,8 @@ Status ApplyDP4AMatrixMatMulNBits(const Tensor* a, const Tensor* b, const Tensor
                            {b, ProgramTensorMetadataDependency::TypeAndRank, static_cast<int>(kVec4Components * kU32Components)},
                            {scales, ProgramTensorMetadataDependency::TypeAndRank, 1}})
         .AddUniformVariables({M, N, K, K / 16, K / 32, block_size, num_N_tile})
-        .AddOutput({y, ProgramTensorMetadataDependency::TypeAndRank, 1});
+        .AddOutput({y, ProgramTensorMetadataDependency::TypeAndRank, 1})
+        .CacheHint(nbits);
     return context.RunProgram(mul_program);
   }
 
@@ -416,12 +514,12 @@ Status ApplyDP4AMatrixMatMulNBits(const Tensor* a, const Tensor* b, const Tensor
   TensorShape reshaped_y_shape{1, M, N / kVec4Components};
   uint32_t num_M_tile = (M + kTileSize - 1) / kTileSize;
   uint32_t num_N_tile = (N + kTileSize - 1) / kTileSize;
-  DP4AMatMulNBitsProgram mul_program{block_size};
+  DP4AMatMulNBitsProgram mul_program{block_size, nbits};
   mul_program.SetWorkgroupSize(256);
   mul_program.SetDispatchGroupSize(num_M_tile * num_N_tile);
   mul_program.AddInputs({{&a_quant, ProgramTensorMetadataDependency::TypeAndRank, static_cast<int>(kVec4Components)},
                          {&a_scale, ProgramTensorMetadataDependency::TypeAndRank, 1},
-                         {b, ProgramTensorMetadataDependency::TypeAndRank, static_cast<int>(kVec2Components * kU32Components)},
+                         {b, ProgramTensorMetadataDependency::TypeAndRank, static_cast<int>(nbits == 4 ? kVec2Components * kU32Components : kVec4Components * kU32Components)},
                          {scales, ProgramTensorMetadataDependency::TypeAndRank, 1}})
       .AddUniformVariables({{static_cast<uint32_t>(M)},
                             {static_cast<uint32_t>(N)},
@@ -430,7 +528,7 @@ Status ApplyDP4AMatrixMatMulNBits(const Tensor* a, const Tensor* b, const Tensor
                             {static_cast<uint32_t>(K / 16)},
                             {num_N_tile}})
       .AddOutput({y, ProgramTensorMetadataDependency::TypeAndRank, reshaped_y_shape, static_cast<int>(kVec4Components)})
-      .CacheHint("Block" + std::to_string(block_size));
+      .CacheHint("Block" + std::to_string(block_size), nbits);
   return context.RunProgram(mul_program);
 }
 

--- a/onnxruntime/contrib_ops/webgpu/quantization/dp4a_matmul_nbits.h
+++ b/onnxruntime/contrib_ops/webgpu/quantization/dp4a_matmul_nbits.h
@@ -20,7 +20,7 @@ class DP4AMatMulQuantizeProgram final : public Program<DP4AMatMulQuantizeProgram
 
 class DP4AMatMulNBitsProgram final : public Program<DP4AMatMulNBitsProgram> {
  public:
-  DP4AMatMulNBitsProgram(uint32_t block_size) : Program{"DP4AMatMulNBits"}, block_size_(block_size) {}
+  DP4AMatMulNBitsProgram(uint32_t block_size, uint32_t nbits) : Program{"DP4AMatMulNBits"}, block_size_(block_size), nbits_(nbits) {}
   Status GenerateShaderCode(ShaderHelper& sh) const override;
   WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
       {"M", ProgramUniformVariableDataType::Uint32},
@@ -32,11 +32,12 @@ class DP4AMatMulNBitsProgram final : public Program<DP4AMatMulNBitsProgram> {
 
  private:
   uint32_t block_size_;
+  uint32_t nbits_;
 };
 
 class DP4AMatMulNBitsSmallMProgram final : public Program<DP4AMatMulNBitsSmallMProgram> {
  public:
-  DP4AMatMulNBitsSmallMProgram(uint32_t tile_size) : Program{"DP4AMatMulNBitsSmallMProgram"}, tile_size_(tile_size) {}
+  DP4AMatMulNBitsSmallMProgram(uint32_t tile_size, uint32_t nbits) : Program{"DP4AMatMulNBitsSmallMProgram"}, tile_size_(tile_size), nbits_(nbits) {}
   Status GenerateShaderCode(ShaderHelper& sh) const override;
   WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
       {"M", ProgramUniformVariableDataType::Uint32},
@@ -49,6 +50,7 @@ class DP4AMatMulNBitsSmallMProgram final : public Program<DP4AMatMulNBitsSmallMP
 
  private:
   uint32_t tile_size_;
+  uint32_t nbits_;
 };
 
 Status ApplyDP4AMatrixMatMulNBits(const Tensor* a, const Tensor* b, const Tensor* scales,
@@ -57,6 +59,7 @@ Status ApplyDP4AMatrixMatMulNBits(const Tensor* a, const Tensor* b, const Tensor
                                   uint32_t K,
                                   uint32_t block_size,
                                   uint32_t min_M_for_tile_optimization,
+                                  uint32_t nbits,
                                   onnxruntime::webgpu::ComputeContext& context,
                                   Tensor* y);
 

--- a/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.cc
@@ -724,7 +724,7 @@ Status MatMulNBits::ComputeInternal(onnxruntime::webgpu::ComputeContext& context
   }
 
   // On FP32 only GPUs, integer math is faster than FP32 therefore always use DP4A independent of length of M.
-  if ((M >= kMinMForTileOptimization || y->DataType() == DataTypeImpl::GetType<float>() ||
+  if ((M >= kMinMForTileOptimization || y->DataType() == DataTypeImpl::GetType<float>() || nbits == 8 ||
        context.AdapterInfo().vendor == std::string_view{"qualcomm"}) &&
       CanApplyDP4AMatrixMatMulNBits(context, accuracy_level_, block_size, batch_count, N, K, components_a, has_zero_points)) {
     return ApplyDP4AMatrixMatMulNBits(a, b, scales, M, N, K, block_size, kMinMForTileOptimization, nbits, context, y);

--- a/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.cc
@@ -707,7 +707,7 @@ Status MatMulNBits::ComputeInternal(onnxruntime::webgpu::ComputeContext& context
   const uint32_t N = onnxruntime::narrow<uint32_t>(helper.N());
   const uint32_t K = onnxruntime::narrow<uint32_t>(helper.K());
   const uint32_t block_size = onnxruntime::narrow<uint32_t>(block_size_);
-  constexpr uint32_t nbits = 4;
+  const uint32_t nbits = onnxruntime::narrow<uint32_t>(bits_);
 
   const uint32_t n_blocks_per_col = (K + block_size - 1) / block_size;
   const uint32_t blob_size = (block_size / 8) * nbits;
@@ -720,15 +720,18 @@ Status MatMulNBits::ComputeInternal(onnxruntime::webgpu::ComputeContext& context
   // macOS - Experimental dawn support for subgroup matrix matmul on Metal.
   if (M >= kMinMForTileOptimization &&
       CanApplySubgroupMatrixMatMulNBits(context, accuracy_level_, block_size, batch_count, N, K, has_zero_points)) {
-    return ApplySubgroupMatrixMatMulNBits(a, b, scales, M, N, K, context, y);
+    return ApplySubgroupMatrixMatMulNBits(a, b, scales, M, N, K, nbits, context, y);
   }
 
   // On FP32 only GPUs, integer math is faster than FP32 therefore always use DP4A independent of length of M.
   if ((M >= kMinMForTileOptimization || y->DataType() == DataTypeImpl::GetType<float>() ||
        context.AdapterInfo().vendor == std::string_view{"qualcomm"}) &&
       CanApplyDP4AMatrixMatMulNBits(context, accuracy_level_, block_size, batch_count, N, K, components_a, has_zero_points)) {
-    return ApplyDP4AMatrixMatMulNBits(a, b, scales, M, N, K, block_size, kMinMForTileOptimization, context, y);
+    return ApplyDP4AMatrixMatMulNBits(a, b, scales, M, N, K, block_size, kMinMForTileOptimization, nbits, context, y);
   }
+
+  // TODO: Remvoe it once the 8bits is supported for the non-dp4 path.
+  ORT_ENFORCE(nbits == 4, "Only 4 bits are supported for the non-dp4 path for webgpu matmulnbits");
 
   // WideTileProgram
   // This program is optimized for Block32 prefill using Tile16x128.

--- a/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.h
+++ b/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.h
@@ -55,10 +55,10 @@ class MatMulNBits final : public WebGpuKernel {
     K_ = info.GetAttr<int64_t>("K");
     N_ = info.GetAttr<int64_t>("N");
     block_size_ = info.GetAttr<int64_t>("block_size");
-    int64_t bits = info.GetAttr<int64_t>("bits");
+    bits_ = info.GetAttr<int64_t>("bits");
     accuracy_level_ = info.GetAttrOrDefault<int64_t>("accuracy_level", 4);
-    ORT_ENFORCE(bits == 4,
-                "Only 4b quantization is supported for MatMulNBits op, additional bits support is planned.");
+    ORT_ENFORCE(bits_ == 4 || bits_ == 8,
+                "Only 4b/8b quantization is supported for MatMulNBits op, additional bits support is planned.");
   }
 
   Status ComputeInternal(onnxruntime::webgpu::ComputeContext& context) const override;
@@ -68,6 +68,7 @@ class MatMulNBits final : public WebGpuKernel {
   int64_t N_;
   int64_t block_size_;
   int64_t accuracy_level_;
+  int64_t bits_;
 };
 
 }  // namespace webgpu

--- a/onnxruntime/contrib_ops/webgpu/quantization/subgroup_matrix_matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/webgpu/quantization/subgroup_matrix_matmul_nbits.cc
@@ -41,7 +41,9 @@ Status SubgroupMatrixMatMulNBitsProgram::GenerateShaderCode(ShaderHelper& shader
                 tile_A[row * tile_k + col + col_offset] = compute_precision(input_a[a_global*uniforms.K + k_idx + col + col_offset]);
             }
         }
-
+    )ADDNL_FN";
+  if (nbits_ == 4) {
+    shader.AdditionalImplementation() << R"ADDNL_FN(
         fn loadSHMB(tile_base: u32, k_idx: u32, row: u32, c_idx: u32) {
             let b_global = tile_base + row;
             if (b_global >= uniforms.N) {
@@ -69,7 +71,40 @@ Status SubgroupMatrixMatMulNBitsProgram::GenerateShaderCode(ShaderHelper& shader
                 tile_B[tile_b_base + 7] = b_value_upper[3];
             }
         }
-
+    )ADDNL_FN";
+  } else {
+    ORT_ENFORCE(nbits_ == 8, "Only 4/8 bits are supported for webgpu matmulnbits");
+    shader.AdditionalImplementation() << R"ADDNL_FN(
+        fn loadSHMB(tile_base: u32, k_idx: u32, row: u32, c_idx: u32) {
+            let b_global = tile_base + row;
+            if (b_global >= uniforms.N) {
+                return;
+            }
+            // Each call loads 16 columns, starting at col.
+            var col = c_idx * 16;
+            // 128 threads need to load 64 x 32. 2 threads per row or 16 col per thread.
+            // Stored in column major fashion.
+            let b_idx = u32((b_global*uniforms.K + k_idx + col)/8);
+            let scale   = compute_precision(scales_b[(b_global*uniforms.K + k_idx + col)/quantization_block_size]);
+            for (var step:u32 = 0; step < 2; step++)
+            {
+                var b_value = input_b[b_idx+step];
+                var b_value0 = (vec4<compute_precision>(unpack4xU8(b_value[0])) - vec4<compute_precision>(128)) * scale;
+                var b_value1 = (vec4<compute_precision>(unpack4xU8(b_value[1])) - vec4<compute_precision>(128)) * scale;
+                let tile_b_base = row * tile_k + col + step * 8;
+                tile_B[tile_b_base]     = b_value0[0];
+                tile_B[tile_b_base + 1] = b_value0[1];
+                tile_B[tile_b_base + 2] = b_value0[2];
+                tile_B[tile_b_base + 3] = b_value0[3];
+                tile_B[tile_b_base + 4] = b_value1[0];
+                tile_B[tile_b_base + 5] = b_value1[1];
+                tile_B[tile_b_base + 6] = b_value1[2];
+                tile_B[tile_b_base + 7] = b_value1[3];
+            }
+        }
+    )ADDNL_FN";
+  }
+  shader.AdditionalImplementation() << R"ADDNL_FN(
         fn storeOutput(offset:u32, row: u32, col:u32, src_slot:u32, row_limit:i32) {
             if (row_limit > 0 && row < u32(row_limit))
             {
@@ -174,24 +209,26 @@ Status ApplySubgroupMatrixMatMulNBits(const Tensor* a, const Tensor* b, const Te
                                       uint32_t M,
                                       uint32_t N,
                                       uint32_t K,
+                                      uint32_t nbits,
                                       onnxruntime::webgpu::ComputeContext& context,
                                       Tensor* y) {
   constexpr uint32_t kTileSizeA = 32;
   constexpr uint32_t kTileSizeB = 64;
   constexpr uint32_t kU32Components = 4;
   TensorShape y_shape{1, M, N};
-  SubgroupMatrixMatMulNBitsProgram mul_program;
+  SubgroupMatrixMatMulNBitsProgram mul_program{nbits};
   mul_program.SetWorkgroupSize(128);
   mul_program.SetDispatchGroupSize(
       (N + kTileSizeB - 1) / kTileSizeB,
       (M + kTileSizeA - 1) / kTileSizeA, 1);
   mul_program.AddInputs({{a, ProgramTensorMetadataDependency::TypeAndRank, 1},
-                         {b, ProgramTensorMetadataDependency::TypeAndRank, static_cast<int>(kU32Components)},
+                         {b, ProgramTensorMetadataDependency::TypeAndRank, static_cast<int>(nbits == 4 ? kU32Components : 2 * kU32Components)},
                          {scales, ProgramTensorMetadataDependency::TypeAndRank, 1}})
       .AddUniformVariables({{static_cast<uint32_t>(M)},
                             {static_cast<uint32_t>(N)},
                             {static_cast<uint32_t>(K)}})
-      .AddOutput({y, ProgramTensorMetadataDependency::TypeAndRank, y_shape, 1});
+      .AddOutput({y, ProgramTensorMetadataDependency::TypeAndRank, y_shape, 1})
+      .CacheHint(nbits);
   return context.RunProgram(mul_program);
 }
 

--- a/onnxruntime/contrib_ops/webgpu/quantization/subgroup_matrix_matmul_nbits.h
+++ b/onnxruntime/contrib_ops/webgpu/quantization/subgroup_matrix_matmul_nbits.h
@@ -17,18 +17,22 @@ using namespace onnxruntime::webgpu;
 
 class SubgroupMatrixMatMulNBitsProgram final : public Program<SubgroupMatrixMatMulNBitsProgram> {
  public:
-  SubgroupMatrixMatMulNBitsProgram() : Program{"SubgroupMatrixMatMulNBits"} {}
+  SubgroupMatrixMatMulNBitsProgram(uint32_t nbits) : Program{"SubgroupMatrixMatMulNBits"}, nbits_(nbits) {}
   Status GenerateShaderCode(ShaderHelper& sh) const override;
   WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
       {"M", ProgramUniformVariableDataType::Uint32},
       {"N", ProgramUniformVariableDataType::Uint32},
       {"K", ProgramUniformVariableDataType::Uint32});
+
+ private:
+  uint32_t nbits_;
 };
 
 Status ApplySubgroupMatrixMatMulNBits(const Tensor* a, const Tensor* b, const Tensor* scales,
                                       uint32_t M,
                                       uint32_t N,
                                       uint32_t K,
+                                      uint32_t nbits,
                                       onnxruntime::webgpu::ComputeContext& context,
                                       Tensor* y);
 


### PR DESCRIPTION
This PR enables matmul8bits for the dp4/subgroupMatrix path in webgpu.

This PR is separated from #24546 for easier review.


