### PR TITLE
[webgpu]: optimize pool operators

### DIFF
--- a/onnxruntime/core/providers/webgpu/nn/pool.h
+++ b/onnxruntime/core/providers/webgpu/nn/pool.h
@@ -14,13 +14,14 @@ namespace webgpu {
 class PoolProgram final : public Program<PoolProgram> {
  public:
   PoolProgram(bool is_max_pool, bool is_nhwc, const TensorShapeVector& kernel_shape, bool is_float16,
-              bool count_include_pad)
+              bool count_include_pad, bool are_small_output_big_kernel)
       : Program{"Pool"},
         is_max_pool_{is_max_pool},
         is_nhwc_{is_nhwc},
         kernel_shape_{kernel_shape},
         is_float16_{is_float16},
-        count_include_pad_{count_include_pad} {}
+        count_include_pad_{count_include_pad},
+        are_small_output_big_kernel_{are_small_output_big_kernel} {}
 
   Status GenerateShaderCode(ShaderHelper& sh) const override;
 
@@ -39,6 +40,7 @@ class PoolProgram final : public Program<PoolProgram> {
   const TensorShapeVector kernel_shape_;
   const bool is_float16_;
   const bool count_include_pad_;
+  const bool are_small_output_big_kernel_;
 };
 
 template <typename PoolType, bool is_nhwc>


### PR DESCRIPTION
The patch optimizes pool operators when output size is small and kernel size is big

### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


