### PR TITLE
Fix unused variable warning in onnxruntime/core/providers/coreml/builders/impl/gather_op_builder.cc.

### DIFF
--- a/onnxruntime/core/providers/coreml/builders/impl/gather_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/gather_op_builder.cc
@@ -30,7 +30,7 @@ int64_t GetAxisAttribute(const Node& node) {
 }  // namespace
 
 Status GatherOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node,
-                                              const logging::Logger& logger) const {
+                                              const logging::Logger& /*logger*/) const {
   if (model_builder.CreateMLProgram()) {
     using CoreML::Specification::MILSpec::Operation;
     std::unique_ptr<Operation> op = model_builder.CreateOperation(node, "gather");


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Fix unused variable warning in onnxruntime/core/providers/coreml/builders/impl/gather_op_builder.cc.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix build.