### PR TITLE
[webgpu] allows atomic type for output

### DIFF
--- a/onnxruntime/core/providers/webgpu/program.cc
+++ b/onnxruntime/core/providers/webgpu/program.cc
@@ -289,6 +289,7 @@ ProgramOutput::ProgramOutput(Tensor* tensor, ProgramTensorMetadataDependency dep
     : tensor{tensor},
       dependency{dependency},
       var_type{ToProgramVariableDataType(tensor->GetElementType(), component)},
+      is_atomic{false},
       use_override_shape{component > 1},
       override_shape{} {
   if (use_override_shape) {
@@ -296,10 +297,19 @@ ProgramOutput::ProgramOutput(Tensor* tensor, ProgramTensorMetadataDependency dep
   }
 }
 
+ProgramOutput::ProgramOutput(Tensor* tensor, ProgramTensorMetadataDependency dependency, ProgramOutput::AtomicTag)
+    : tensor{tensor},
+      dependency{dependency},
+      var_type{ToProgramVariableDataType(tensor->GetElementType())},
+      is_atomic{true},
+      use_override_shape{false},
+      override_shape{} {}
+
 ProgramOutput::ProgramOutput(Tensor* tensor, ProgramTensorMetadataDependency dependency, const TensorShape& override_shape, int component)
     : tensor{tensor},
       dependency{dependency},
       var_type{ToProgramVariableDataType(tensor->GetElementType(), component)},
+      is_atomic{false},
       use_override_shape{true},
       override_shape{override_shape} {}
 

--- a/onnxruntime/core/providers/webgpu/program.h
+++ b/onnxruntime/core/providers/webgpu/program.h
@@ -233,13 +233,21 @@ struct ProgramInput {
 };
 
 struct ProgramOutput {
+ private:
+  struct AtomicTag {};
+
+ public:
+  constexpr static const AtomicTag Atomic{};
+
   ProgramOutput(Tensor* tensor);
   ProgramOutput(Tensor* tensor, ProgramTensorMetadataDependency dependency, int component = 1);
+  ProgramOutput(Tensor* tensor, ProgramTensorMetadataDependency dependency, AtomicTag);
   ProgramOutput(Tensor* tensor, ProgramTensorMetadataDependency dependency, const TensorShape& override_shape, int component);
 
   Tensor* tensor;
   ProgramTensorMetadataDependency dependency;
   ProgramVariableDataType var_type;
+  bool is_atomic;
   bool use_override_shape;
   TensorShape override_shape;
 };

--- a/onnxruntime/core/providers/webgpu/shader_helper.cc
+++ b/onnxruntime/core/providers/webgpu/shader_helper.cc
@@ -250,7 +250,7 @@ Status ShaderHelper::ValidateVariable(const ProgramInput& input, const ShaderVar
   return Status::OK();
 }
 Status ShaderHelper::ValidateVariable(const ProgramOutput& output, const ShaderVariableHelper& var) const {
-  ORT_RETURN_IF_ERROR(ValidateVariableDataType(output.tensor->GetElementType(), var.type_));
+  ORT_RETURN_IF_ERROR(ValidateVariableDataType(output.tensor->GetElementType(), var.type_, output.is_atomic));
   ORT_RETURN_IF_ERROR(ValidateVariableShape(output.tensor->Shape(),
                                             output.use_override_shape,
                                             output.use_override_shape ? output.override_shape : output.tensor->Shape(),

--- a/onnxruntime/core/providers/webgpu/shader_helper.cc
+++ b/onnxruntime/core/providers/webgpu/shader_helper.cc
@@ -420,7 +420,7 @@ Status ShaderHelper::GenerateSourceCode(std::string& code, std::vector<int>& sha
   for (size_t i = 0; i < output_vars_.size(); ++i) {
     const auto& output = output_vars_[i];
     bool is_atomic = program_.Outputs()[i].is_atomic;
-    ss << "@group(0) @binding(" << i << ") var<storage, read_write> " << output->name_ << ": array<";
+    ss << "@group(0) @binding(" << input_vars_.size() + i << ") var<storage, read_write> " << output->name_ << ": array<";
     if (is_atomic) {
       ss << "atomic<";
     }


### PR DESCRIPTION
### Description

This PR adds support for atomic types for program output. Applying atomic type on program output can be done in the following way:
```c++
program.AddOutput({output_tensor, ProgramTensorMetadataDependency::TypeAndRank, ProgramOutput::Atomic});
```
The last
```

The support for atomic type is minimal. According to [spec](https://www.w3.org/TR/WGSL/#atomic-types), the only valid operations on atomic objects are the [atomic builtin functions](https://www.w3.org/TR/WGSL/#atomic-builtin-functions). This means atomic types cannot be accessed (get/set) using the normal way. Get* and Set* functions will not be working on atomic types for indices helper. Use the WGSL builtin functions directly. OffsetToIndices and IndicesToOffset functions still work.