### PR TITLE
Add support for selection policy delegate

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
@@ -353,6 +353,7 @@ namespace Microsoft.ML.OnnxRuntime
 
         public IntPtr SessionOptionsAppendExecutionProvider_V2;
         public IntPtr SessionOptionsSetEpSelectionPolicy;
+        public IntPtr SessionOptionsSetEpSelectionPolicyDelegate;
 
         public IntPtr HardwareDevice_Type;
         public IntPtr HardwareDevice_VendorId;
@@ -692,6 +693,11 @@ namespace Microsoft.ML.OnnxRuntime
                 (DSessionOptionsSetEpSelectionPolicy)Marshal.GetDelegateForFunctionPointer(
                     api_.SessionOptionsSetEpSelectionPolicy,
                     typeof(DSessionOptionsSetEpSelectionPolicy));
+
+            OrtSessionOptionsSetEpSelectionPolicyDelegate =
+                (DSessionOptionsSetEpSelectionPolicyDelegate)Marshal.GetDelegateForFunctionPointer(
+                    api_.SessionOptionsSetEpSelectionPolicyDelegate,
+                    typeof(DSessionOptionsSetEpSelectionPolicyDelegate));
         }
 
         internal class NativeLib
@@ -2278,28 +2284,49 @@ namespace Microsoft.ML.OnnxRuntime
 #region Auto EP API related
         //
         // OrtKeyValuePairs
+
+        /// <summary>
+        /// Create an OrtKeyValuePairs instance.
+        /// </summary>
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         public delegate void DOrtCreateKeyValuePairs(out IntPtr /* OrtKeyValuePairs** */ kvps);
 
+        /// <summary>
+        /// Add/replace a key-value pair in the OrtKeyValuePairs instance.
+        /// </summary>
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         public delegate void DOrtAddKeyValuePair(IntPtr /* OrtKeyValuePairs* */ kvps,
                                                  byte[] /* const char* */ key,
                                                  byte[] /* const char* */ value);
 
+        /// <summary>
+        /// Get the value for the provided key. 
+        /// </summary>
+        /// <returns>Value. Returns IntPtr.Zero if key was not found.</returns>
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         public delegate IntPtr /* const char* */ DOrtGetKeyValue(IntPtr /* const OrtKeyValuePairs* */ kvps,
                                                                  byte[] /* const char* */ key);
 
+        /// <summary>
+        /// Get all the key-value pairs in the OrtKeyValuePairs instance.
+        /// </summary>
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         public delegate void DOrtGetKeyValuePairs(IntPtr /* const OrtKeyValuePairs* */ kvps,
                                                   out IntPtr /* const char* const** */ keys,
                                                   out IntPtr /* const char* const** */ values,
                                                   out UIntPtr /* size_t* */ numEntries);
 
+        /// <summary>
+        /// Remove a key-value pair from the OrtKeyValuePairs instance.
+        /// Ignores keys that are not present.
+        /// </summary>
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         public delegate void DOrtRemoveKeyValuePair(IntPtr /* OrtKeyValuePairs* */ kvps,
                                                     byte[] /* const char* */ key);
 
+        /// <summary>
+        /// Release the OrtKeyValuePairs instance.
+        /// </summary>
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         public delegate void DOrtReleaseKeyValuePairs(IntPtr /* OrtKeyValuePairs* */ kvps);
 
@@ -2370,12 +2397,27 @@ namespace Microsoft.ML.OnnxRuntime
 
         //
         // Auto Selection EP registration and selection customization
+
+        /// <summary>
+        /// Register an execution provider library. 
+        /// The library must implement CreateEpFactories and ReleaseEpFactory.
+        /// </summary>
+        /// <param name="env">Environment to add the EP library to.</param>
+        /// <param name="registration_name">Name to register the library under.</param>
+        /// <param name="path">Absolute path to the library.</param>
+        /// <returns>OrtStatus*</returns>
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         public delegate IntPtr /* OrtStatus* */ DOrtRegisterExecutionProviderLibrary(
             IntPtr /* OrtEnv* */ env,
             byte[] /* const char* */ registration_name,
             byte[] /* const ORTCHAR_T* */ path);
 
+        /// <summary>
+        /// Unregister an execution provider library.
+        /// </summary>
+        /// <param name="env">The environment to unregister the library from.</param>
+        /// <param name="registration_name">The name the library was registered under.</param>
+        /// <returns>OrtStatus*</returns>
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         public delegate IntPtr /* OrtStatus* */ DOrtUnregisterExecutionProviderLibrary(
             IntPtr /* OrtEnv* */ env,
@@ -2384,6 +2426,11 @@ namespace Microsoft.ML.OnnxRuntime
         public static DOrtRegisterExecutionProviderLibrary OrtRegisterExecutionProviderLibrary;
         public static DOrtUnregisterExecutionProviderLibrary OrtUnregisterExecutionProviderLibrary;
 
+        /// <summary>
+        /// Get the OrtEpDevices that are available.
+        /// These are all the possible execution provider and device pairs.
+        /// </summary>
+        /// <returns>OrtStatus*</returns>
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         public delegate IntPtr /* OrtStatus* */ DOrtGetEpDevices(
             IntPtr /* const OrtEnv* */ env,
@@ -2392,6 +2439,20 @@ namespace Microsoft.ML.OnnxRuntime
 
         public static DOrtGetEpDevices OrtGetEpDevices;
 
+        /// <summary>
+        /// Add execution provider devices to the session options.
+        /// Highest priority execution provider and device pairs should be added first.
+        /// All OrtEpDevice instances in ep_devices must be for the same execution provider.
+        /// e.g. selecting OpenVINO for GPU and NPU would have an OrtEpDevice for GPU and NPU.
+        /// </summary>
+        /// <param name="sess_options">SessionOptions to add to.</param>
+        /// <param name="env">Environment that the OrtEpDevice instances came from by calling GetEpDevices</param>
+        /// <param name="ep_devices">One or more OrtEpDevice instances.</param>
+        /// <param name="num_ep_devices">Number of OrtEpDevice instances.</param>
+        /// <param name="ep_option_keys">User overrides for execution provider options. May be IntPtr.Zero.</param>
+        /// <param name="ep_option_vals">User overrides for execution provider options. May be IntPtr.Zero.</param>
+        /// <param name="num_ep_options">Number of user overrides for execution provider options.</param>
+        /// <returns></returns>
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         public delegate IntPtr /* OrtStatus* */ DOrtSessionOptionsAppendExecutionProvider_V2(
             IntPtr /* OrtSessionOptions* */ sess_options,
@@ -2404,6 +2465,18 @@ namespace Microsoft.ML.OnnxRuntime
 
         public static DOrtSessionOptionsAppendExecutionProvider_V2 OrtSessionOptionsAppendExecutionProvider_V2;
 
+        /// <summary>
+        /// Delegate to do custom execution provider selection.
+        /// </summary>
+        /// <param name="epDevices">Available OrtEpDevices to select from.</param>
+        /// <param name="numDevices">Number of OrtEpDevices.</param>
+        /// <param name="modelMetadata">Metadata from the ONNX model.</param>
+        /// <param name="runtimeMetadata">Runtime metadata. May be IntPtr.Zero.</param>
+        /// <param name="selected">OrtEpDevices that were selected. Pre-allocated array for delegate to update.</param>
+        /// <param name="maxSelected">Maximum number of OrtEpDevices that can be selected.</param>
+        /// <param name="numSelected">Number of OrtEpDevices that were selected.</param>
+        /// <param name="state">State that was provided in when the delegate was registered.</param>
+        /// <returns>OrtStatus*</returns>
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         public delegate IntPtr DOrtEpSelectionDelegate(
             IntPtr /* OrtEpDevice** */ epDevices,
@@ -2412,15 +2485,35 @@ namespace Microsoft.ML.OnnxRuntime
             IntPtr /* OrtKeyValuePairs* */ runtimeMetadata,
             IntPtr /* OrtEpDevice** */ selected,
             uint maxSelected,
-            out UIntPtr numSelected
+            out UIntPtr numSelected,
+            IntPtr /* void* */ state
         );
 
+        /// <summary>
+        /// Set the execution provider selection policy.
+        /// </summary>
+        /// <param name="session_options">SessionOptions to set the policy for.</param>
+        /// <param name="policy">Selection policy.</param>
+        /// <returns>OrtStatus*</returns>
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         public delegate IntPtr /* OrtStatus* */ DSessionOptionsSetEpSelectionPolicy(
             IntPtr /* OrtSessionOptions* */ session_options,
-            int /* OrtExecutionProviderDevicePolicy */ policy,
-            IntPtr /* DOrtEpSelectionDelegate* */ selection_delegate);
+            int /* OrtExecutionProviderDevicePolicy */ policy);
         public static DSessionOptionsSetEpSelectionPolicy OrtSessionOptionsSetEpSelectionPolicy;
+
+        /// <summary>
+        /// Set the execution provider selection policy delegate.
+        /// </summary>
+        /// <param name="session_options">SessionOptions to set the policy for.</param>
+        /// <param name="selection_delegate">Selection policy delegate.</param>
+        /// <param name="state">State that is passed through to the selection delegate.</param>
+        /// <returns>OrtStatus*</returns>
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate IntPtr /* OrtStatus* */ DSessionOptionsSetEpSelectionPolicyDelegate(
+            IntPtr /* OrtSessionOptions* */ session_options,
+            IntPtr /* DOrtEpSelectionDelegate* */ selection_delegate,
+            IntPtr /* void* */ state);
+        public static DSessionOptionsSetEpSelectionPolicyDelegate OrtSessionOptionsSetEpSelectionPolicyDelegate;
 
 
         #endregion

--- a/csharp/src/Microsoft.ML.OnnxRuntime/OrtEpDevice.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OrtEpDevice.shared.cs
@@ -10,18 +10,18 @@ namespace Microsoft.ML.OnnxRuntime
     /// Represents the combination of an execution provider and a hardware device 
     /// that the execution provider can utilize.
     /// </summary>
-    public class OrtEpDevice : SafeHandle
+    public class OrtEpDevice
     {
         /// <summary>
         /// Construct an OrtEpDevice from an existing native OrtEpDevice instance.
         /// </summary>
         /// <param name="epDeviceHandle">Native OrtEpDevice handle.</param>
         internal OrtEpDevice(IntPtr epDeviceHandle)
-            : base(epDeviceHandle, ownsHandle: false)
         {
+            _handle = epDeviceHandle;
         }
 
-        internal IntPtr Handle => handle;
+        internal IntPtr Handle => _handle;
 
         /// <summary>
         /// The name of the execution provider.
@@ -30,7 +30,7 @@ namespace Microsoft.ML.OnnxRuntime
         {
             get
             {
-                IntPtr namePtr = NativeMethods.OrtEpDevice_EpName(handle);
+                IntPtr namePtr = NativeMethods.OrtEpDevice_EpName(_handle);
                 return NativeOnnxValueHelper.StringFromNativeUtf8(namePtr);
             }
         }
@@ -42,7 +42,7 @@ namespace Microsoft.ML.OnnxRuntime
         {
             get
             {
-                IntPtr vendorPtr = NativeMethods.OrtEpDevice_EpVendor(handle);
+                IntPtr vendorPtr = NativeMethods.OrtEpDevice_EpVendor(_handle);
                 return NativeOnnxValueHelper.StringFromNativeUtf8(vendorPtr);
             }
         }
@@ -54,7 +54,7 @@ namespace Microsoft.ML.OnnxRuntime
         {
             get
             {
-                return new OrtKeyValuePairs(NativeMethods.OrtEpDevice_EpMetadata(handle));
+                return new OrtKeyValuePairs(NativeMethods.OrtEpDevice_EpMetadata(_handle));
             }
         }
 
@@ -65,7 +65,7 @@ namespace Microsoft.ML.OnnxRuntime
         {
             get
             {
-                return new OrtKeyValuePairs(NativeMethods.OrtEpDevice_EpOptions(handle));
+                return new OrtKeyValuePairs(NativeMethods.OrtEpDevice_EpOptions(_handle));
             }
         }
 
@@ -76,23 +76,11 @@ namespace Microsoft.ML.OnnxRuntime
         {
             get
             {
-                IntPtr devicePtr = NativeMethods.OrtEpDevice_Device(handle);
+                IntPtr devicePtr = NativeMethods.OrtEpDevice_Device(_handle);
                 return new OrtHardwareDevice(devicePtr);
             }
         }
 
-        /// <summary>
-        /// Indicates whether the native handle is invalid.
-        /// </summary>
-        public override bool IsInvalid => handle == IntPtr.Zero;
-
-        /// <summary>
-        /// No-op. OrtEpDevice is always read-only as the instance is owned by native ORT.
-        /// </summary>
-        /// <returns>True</returns>
-        protected override bool ReleaseHandle()
-        {
-            return true;
-        }
+        private readonly IntPtr _handle;
     }
 }

--- a/csharp/src/Microsoft.ML.OnnxRuntime/OrtHardwareDevice.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OrtHardwareDevice.shared.cs
@@ -21,16 +21,16 @@ namespace Microsoft.ML.OnnxRuntime
     /// <summary>
     /// Represents a hardware device that is available on the current system.
     /// </summary>
-    public class OrtHardwareDevice : SafeHandle
+    public class OrtHardwareDevice
     {
 
         /// <summary>
         /// Construct an OrtHardwareDevice for a native OrtHardwareDevice instance.
         /// </summary>
         /// <param name="deviceHandle">Native OrtHardwareDevice handle.</param>
-        internal OrtHardwareDevice(IntPtr deviceHandle)
-            : base(deviceHandle, ownsHandle: false)
+        internal OrtHardwareDevice(IntPtr deviceHandle)            
         {
+            _handle = deviceHandle;
         }
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace Microsoft.ML.OnnxRuntime
         {
             get
             {
-                return (OrtHardwareDeviceType)NativeMethods.OrtHardwareDevice_Type(handle);
+                return (OrtHardwareDeviceType)NativeMethods.OrtHardwareDevice_Type(_handle);
             }
         }
 
@@ -54,7 +54,7 @@ namespace Microsoft.ML.OnnxRuntime
         {
             get
             {
-                return NativeMethods.OrtHardwareDevice_VendorId(handle);
+                return NativeMethods.OrtHardwareDevice_VendorId(_handle);
             }
         }
 
@@ -65,7 +65,7 @@ namespace Microsoft.ML.OnnxRuntime
         {
             get
             {
-                IntPtr vendorPtr = NativeMethods.OrtHardwareDevice_Vendor(handle);
+                IntPtr vendorPtr = NativeMethods.OrtHardwareDevice_Vendor(_handle);
                 return NativeOnnxValueHelper.StringFromNativeUtf8(vendorPtr);
             }
         }
@@ -82,7 +82,7 @@ namespace Microsoft.ML.OnnxRuntime
         {
             get
             {
-                return NativeMethods.OrtHardwareDevice_DeviceId(handle);
+                return NativeMethods.OrtHardwareDevice_DeviceId(_handle);
             }
         }
 
@@ -95,22 +95,10 @@ namespace Microsoft.ML.OnnxRuntime
         {
             get
             {
-                return new OrtKeyValuePairs(NativeMethods.OrtHardwareDevice_Metadata(handle));
+                return new OrtKeyValuePairs(NativeMethods.OrtHardwareDevice_Metadata(_handle));
             }
         }
 
-        /// <summary>
-        /// Indicates whether the native handle is invalid.
-        /// </summary>
-        public override bool IsInvalid => handle == IntPtr.Zero;
-
-        /// <summary>
-        /// No-op. OrtHardwareDevice is always read-only as the instance is owned by native ORT.
-        /// </summary>
-        /// <returns>True</returns>
-        protected override bool ReleaseHandle()
-        {
-            return true;
-        }
+        private readonly IntPtr _handle;
     }
 }

--- a/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.shared.cs
@@ -636,9 +636,32 @@ namespace Microsoft.ML.OnnxRuntime
         public void SetEpSelectionPolicy(ExecutionProviderDevicePolicy policy)
         {
             NativeApiStatus.VerifySuccess(
-                NativeMethods.OrtSessionOptionsSetEpSelectionPolicy(handle, (int)policy, IntPtr.Zero));
+                NativeMethods.OrtSessionOptionsSetEpSelectionPolicy(handle, (int)policy));
         }
 
+        /// <summary>
+        /// Set the execution provider selection policy if using automatic execution provider selection.
+        /// Execution providers must be registered with the OrtEnv to be available for selection.
+        /// </summary>
+        /// <param name="selectionDelegate">Delegate that implements the custom selection policy.</param>
+        public void SetEpSelectionPolicyDelegate(EpSelectionDelegate selectionDelegate = null)
+        {
+            _epSelectionPolicyConnector = new EpSelectionPolicyConnector(selectionDelegate);
+            _epSelectionPolicyDelegate = new NativeMethods.DOrtEpSelectionDelegate(
+                EpSelectionPolicyConnector.EpSelectionPolicyWrapper);
+
+            // make sure these stay alive. not sure if this is necessary when they're class members though
+            _epSelectionPolicyConnectorHandle = GCHandle.Alloc(_epSelectionPolicyConnector);
+            _epSelectionPolicyDelegateHandle = GCHandle.Alloc(_epSelectionPolicyDelegate);
+
+            IntPtr funcPtr = Marshal.GetFunctionPointerForDelegate(_epSelectionPolicyDelegate);
+
+            NativeApiStatus.VerifySuccess(
+                NativeMethods.OrtSessionOptionsSetEpSelectionPolicyDelegate(
+                    handle, 
+                    funcPtr,
+                    GCHandle.ToIntPtr(_epSelectionPolicyConnectorHandle)));
+        }
         #endregion
 
         internal IntPtr Handle
@@ -914,7 +937,77 @@ namespace Microsoft.ML.OnnxRuntime
         {
             NativeApiStatus.VerifySuccess(NativeMethods.OrtSessionOptionsSetLoadCancellationFlag(handle, value));
         }
+        #endregion
 
+        #region Selection Policy Delegate helpers
+        public delegate List<OrtEpDevice> EpSelectionDelegate(IReadOnlyList<OrtEpDevice> epDevices,
+                                                              OrtKeyValuePairs modelMetadata,
+                                                              OrtKeyValuePairs runtimeMetadata,
+                                                              uint maxSelections);
+
+        /// <summary>
+        /// Class to bridge the C# and native worlds for the EP selection policy delegate
+        /// </summary>
+        internal class EpSelectionPolicyConnector
+        {
+            private readonly EpSelectionDelegate _csharpDelegate;
+
+            internal EpSelectionPolicyConnector(EpSelectionDelegate selectionDelegate)
+            {
+                _csharpDelegate = selectionDelegate;
+            }
+
+            // convert between C and C# types
+            public static IntPtr EpSelectionPolicyWrapper(IntPtr /* OrtEpDevice** */ epDevicesIn,
+                                                          uint numDevices,
+                                                          IntPtr /* OrtKeyValuePairs* */ modelMetadataIn,
+                                                          IntPtr /* OrtKeyValuePairs* */ runtimeMetadataIn,
+                                                          IntPtr /* OrtEpDevice** */ selectedOut,
+                                                          uint maxSelected,
+                                                          out UIntPtr numSelected,
+                                                          IntPtr state)
+            {
+                Span<IntPtr> epDevicesIntPtrs;
+                Span<IntPtr> selectedDevicesIntPtrs;
+                EpSelectionPolicyConnector connector = (EpSelectionPolicyConnector)GCHandle.FromIntPtr(state).Target;
+
+                unsafe
+                {
+                    void* ptr = epDevicesIn.ToPointer();
+                    epDevicesIntPtrs = new Span<IntPtr>(ptr, checked((int)numDevices));
+
+                }
+
+                List<OrtEpDevice> epDevices = new List<OrtEpDevice>();
+                for (int i = 0; i < numDevices; i++)
+                {
+
+                    epDevices.Add(new OrtEpDevice(epDevicesIntPtrs[i]));
+                }
+
+                OrtKeyValuePairs modelMetadata = new OrtKeyValuePairs(modelMetadataIn);
+                OrtKeyValuePairs runtimeMetadata = new OrtKeyValuePairs(runtimeMetadataIn);
+
+                var selected = connector._csharpDelegate(epDevices, modelMetadata, runtimeMetadata, maxSelected);
+
+                numSelected = (UIntPtr)selected.Count;
+
+                unsafe
+                {
+                    void* ptr = selectedOut.ToPointer();
+                    selectedDevicesIntPtrs = new Span<IntPtr>(ptr, (int)maxSelected);
+                }
+
+                int idx = 0;
+                foreach (var epDevice in selected)
+                {
+                    selectedDevicesIntPtrs[idx] = epDevice.Handle;
+                    idx++;
+                }
+
+                return IntPtr.Zero;
+            }
+        }
         #endregion
 
         #region Private Methods
@@ -1000,8 +1093,43 @@ namespace Microsoft.ML.OnnxRuntime
         {
             NativeMethods.OrtReleaseSessionOptions(handle);
             handle = IntPtr.Zero;
+
+            if (_epSelectionPolicyConnectorHandle.IsAllocated)
+            {
+                _epSelectionPolicyConnectorHandle.Free();
+                _epSelectionPolicyConnector = null;
+            }
+
+            if (_epSelectionPolicyDelegateHandle.IsAllocated)
+            {
+                _epSelectionPolicyDelegateHandle.Free();
+                _epSelectionPolicyDelegate = null;
+            }
+
+
             return true;
         }
         #endregion
+
+        /// <summary>
+        /// Helper class to connect C and C# usage of the EP selection policy delegate.
+        /// </summary>
+        EpSelectionPolicyConnector _epSelectionPolicyConnector = null;
+
+        /// <summary>
+        /// Handle to the EP selection policy connector that is passed to the C API as state for the 
+        /// EP selection policy delegate.
+        /// </summary>
+        GCHandle _epSelectionPolicyConnectorHandle = default;
+
+        /// <summary>
+        /// Delegate instance that is provided to the C API.
+        /// </summary>
+        NativeMethods.DOrtEpSelectionDelegate _epSelectionPolicyDelegate = null;
+
+        /// <summary>
+        /// Handle to the EP selection policy delegate that is passed to the C API.
+        /// </summary>
+        GCHandle _epSelectionPolicyDelegateHandle = default;
     }
 }

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -438,18 +438,20 @@ typedef enum OrtExecutionProviderDevicePolicy {
  * \param max_ep_devices The maximum number of devices that can be selected in the pre-allocated array.
                          Currently the maximum is 8.
  * \param num_ep_devices The number of selected devices.
+ * \param state Opaque pointer. Required to use the delegate from other languages like C# and python.
  *
  * \return OrtStatus* Selection status. Return nullptr on success.
  *                    Use CreateStatus to provide error info. Use ORT_FAIL as the error code.
  *                    ORT will release the OrtStatus* if not null.
  */
-typedef OrtStatus* (*EpSelectionDelegate)(_In_ const OrtEpDevice** ep_devices,
-                                          _In_ size_t num_devices,
-                                          _In_ const OrtKeyValuePairs* model_metadata,
-                                          _In_opt_ const OrtKeyValuePairs* runtime_metadata,
-                                          _Inout_ const OrtEpDevice** selected,
-                                          _In_ size_t max_selected,
-                                          _Out_ size_t* num_selected);
+typedef OrtStatus*(ORT_API_CALL* EpSelectionDelegate)(_In_ const OrtEpDevice** ep_devices,
+                                                      _In_ size_t num_devices,
+                                                      _In_ const OrtKeyValuePairs* model_metadata,
+                                                      _In_opt_ const OrtKeyValuePairs* runtime_metadata,
+                                                      _Inout_ const OrtEpDevice** selected,
+                                                      _In_ size_t max_selected,
+                                                      _Out_ size_t* num_selected,
+                                                      _In_ void* state);
 
 /** \brief Algorithm to use for cuDNN Convolution Op
  */
@@ -5127,18 +5129,30 @@ struct OrtApi {
 
   /** \brief Set the execution provider selection policy for the session.
    *
-   * Allows users to specify a device selection policy for automatic execution provider (EP) selection,
-   * or provide a delegate callback for custom selection logic.
+   * Allows users to specify a device selection policy for automatic execution provider (EP) selection.
+   * If custom selection is required please use SessionOptionsSetEpSelectionPolicyDelegate instead.
    *
    * \param[in] session_options The OrtSessionOptions instance.
    * \param[in] policy The device selection policy to use (see OrtExecutionProviderDevicePolicy).
-   * \param[in] delegate Optional delegate callback for custom selection. Pass nullptr to use the built-in policy.
    *
    * \since Version 1.22
    */
   ORT_API2_STATUS(SessionOptionsSetEpSelectionPolicy, _In_ OrtSessionOptions* session_options,
-                  _In_ OrtExecutionProviderDevicePolicy policy,
-                  _In_opt_ EpSelectionDelegate* delegate);
+                  _In_ OrtExecutionProviderDevicePolicy policy);
+
+  /** \brief Set the execution provider selection policy delegate for the session.
+   *
+   * Allows users to provide a custom device selection policy for automatic execution provider (EP) selection.
+   *
+   * \param[in] session_options The OrtSessionOptions instance.
+   * \param[in] delegate Delegate callback for custom selection.
+   * \param[in] delegate_state Optional state that will be passed to the delegate callback. nullptr if not required.
+   *
+   * \since Version 1.22
+   */
+  ORT_API2_STATUS(SessionOptionsSetEpSelectionPolicyDelegate, _In_ OrtSessionOptions* session_options,
+                  _In_ EpSelectionDelegate delegate,
+                  _In_opt_ void* delegate_state);
 
   /** \brief Get the hardware device type.
    *

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -1103,8 +1103,10 @@ struct SessionOptionsImpl : ConstSessionOptionsImpl<T> {
                                                  const std::unordered_map<std::string, std::string>& ep_options);
 
   /// Wraps OrtApi::SessionOptionsSetEpSelectionPolicy
-  SessionOptionsImpl& SetEpSelectionPolicy(OrtExecutionProviderDevicePolicy policy,
-                                           EpSelectionDelegate* delegate = nullptr);
+  SessionOptionsImpl& SetEpSelectionPolicy(OrtExecutionProviderDevicePolicy policy);
+
+  /// Wraps OrtApi::SessionOptionsSetEpSelectionPolicyDelegate
+  SessionOptionsImpl& SetEpSelectionPolicy(EpSelectionDelegate delegate, void* state = nullptr);
 
   SessionOptionsImpl& SetCustomCreateThreadFn(OrtCustomCreateThreadFn ort_custom_create_thread_fn);  ///< Wraps OrtApi::SessionOptionsSetCustomCreateThreadFn
   SessionOptionsImpl& SetCustomThreadCreationOptions(void* ort_custom_thread_creation_options);      ///< Wraps OrtApi::SessionOptionsSetCustomThreadCreationOptions

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -1150,9 +1150,14 @@ inline SessionOptionsImpl<T>& SessionOptionsImpl<T>::AppendExecutionProvider_V2(
 }
 
 template <typename T>
-inline SessionOptionsImpl<T>& SessionOptionsImpl<T>::SetEpSelectionPolicy(OrtExecutionProviderDevicePolicy policy,
-                                                                          EpSelectionDelegate* delegate) {
-  ThrowOnError(GetApi().SessionOptionsSetEpSelectionPolicy(this->p_, policy, delegate));
+inline SessionOptionsImpl<T>& SessionOptionsImpl<T>::SetEpSelectionPolicy(OrtExecutionProviderDevicePolicy policy) {
+  ThrowOnError(GetApi().SessionOptionsSetEpSelectionPolicy(this->p_, policy));
+  return *this;
+}
+
+template <typename T>
+inline SessionOptionsImpl<T>& SessionOptionsImpl<T>::SetEpSelectionPolicy(EpSelectionDelegate delegate, void* state) {
+  ThrowOnError(GetApi().SessionOptionsSetEpSelectionPolicyDelegate(this->p_, delegate, state));
   return *this;
 }
 

--- a/onnxruntime/core/framework/session_options.h
+++ b/onnxruntime/core/framework/session_options.h
@@ -96,7 +96,8 @@ struct EpSelectionPolicy {
   // and no selection policy was explicitly provided.
   bool enable{false};
   OrtExecutionProviderDevicePolicy policy = OrtExecutionProviderDevicePolicy_DEFAULT;
-  EpSelectionDelegate* delegate{};
+  EpSelectionDelegate delegate{};
+  void* state{nullptr};  // state for the delegate
 };
 
 /**

--- a/onnxruntime/core/session/abi_session_options.cc
+++ b/onnxruntime/core/session/abi_session_options.cc
@@ -367,12 +367,24 @@ ORT_API_STATUS_IMPL(OrtApis::SetDeterministicCompute, _Inout_ OrtSessionOptions*
 }
 
 ORT_API_STATUS_IMPL(OrtApis::SessionOptionsSetEpSelectionPolicy, _In_ OrtSessionOptions* options,
-                    _In_ OrtExecutionProviderDevicePolicy policy,
-                    _In_opt_ EpSelectionDelegate* delegate) {
+                    _In_ OrtExecutionProviderDevicePolicy policy) {
   API_IMPL_BEGIN
   options->value.ep_selection_policy.enable = true;
   options->value.ep_selection_policy.policy = policy;
+  options->value.ep_selection_policy.delegate = nullptr;
+  options->value.ep_selection_policy.state = nullptr;
+  return nullptr;
+  API_IMPL_END
+}
+
+ORT_API_STATUS_IMPL(OrtApis::SessionOptionsSetEpSelectionPolicyDelegate, _In_ OrtSessionOptions* options,
+                    _In_opt_ EpSelectionDelegate delegate,
+                    _In_opt_ void* state) {
+  API_IMPL_BEGIN
+  options->value.ep_selection_policy.enable = true;
+  options->value.ep_selection_policy.policy = OrtExecutionProviderDevicePolicy_DEFAULT;
   options->value.ep_selection_policy.delegate = delegate;
+  options->value.ep_selection_policy.state = state;
   return nullptr;
   API_IMPL_END
 }

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -248,6 +248,37 @@ Status GetMinimalBuildOptimizationHandling(
 
 #endif  // !defined(ORT_MINIMAL_BUILD)
 
+// read model metadata from ModelProto
+void ReadModelMetadata(const ONNX_NAMESPACE::ModelProto& model_proto, ModelMetadata& metadata) {
+  metadata.producer_name = model_proto.has_producer_name() ? model_proto.producer_name() : "";
+  metadata.producer_version = model_proto.has_producer_version() ? model_proto.producer_version() : "";
+  metadata.description = model_proto.has_doc_string() ? model_proto.doc_string() : "";
+  metadata.domain = model_proto.has_domain() ? model_proto.domain() : "";
+  metadata.version = model_proto.has_ir_version() ? model_proto.ir_version() : int64_t(0);
+  if (model_proto.has_graph()) {
+    metadata.graph_name = model_proto.graph().has_name() ? model_proto.graph().name() : "";
+    metadata.graph_description = model_proto.graph().has_doc_string() ? model_proto.graph().doc_string() : "";
+  } else {
+    metadata.graph_name = "";
+    metadata.graph_description = "";
+  }
+
+  for (const auto& entry : model_proto.metadata_props()) {
+    metadata.custom_metadata_map[entry.key()] = entry.value();
+  }
+}
+
+// read model metadata from Model.
+void ReadModelMetadata(const Model& model, ModelMetadata& metadata) {
+  metadata.producer_name = model.ProducerName();
+  metadata.producer_version = model.ProducerVersion();
+  metadata.description = model.DocString();
+  metadata.domain = model.Domain();
+  metadata.version = model.ModelVersion();
+  metadata.graph_name = model.MainGraph().Name();
+  metadata.graph_description = model.GraphDocString();
+  metadata.custom_metadata_map = model.MetaData();
+}
 }  // namespace
 
 std::atomic<uint32_t> InferenceSession::global_session_id_{1};
@@ -370,6 +401,10 @@ void InferenceSession::ConstructorCommon(const SessionOptions& session_options,
   auto status = FinalizeSessionOptions(session_options, model_proto_, is_model_proto_parsed_, session_options_);
   ORT_ENFORCE(status.IsOK(), "Could not finalize session options while constructing the inference session. Error Message: ",
               status.ErrorMessage());
+
+  if (is_model_proto_parsed_) {
+    ReadModelMetadata(model_proto_, model_metadata_);
+  }
 
   // a monotonically increasing session id for use in telemetry
   session_id_ = global_session_id_.fetch_add(1);
@@ -3015,7 +3050,9 @@ common::Status InferenceSession::Run(const RunOptions& run_options, const NameML
 std::pair<common::Status, const ModelMetadata*> InferenceSession::GetModelMetadata() const {
   {
     std::lock_guard<std::mutex> l(session_mutex_);
-    if (!is_model_loaded_) {
+    // we can populate the model metadata in the InferenceSession ctor (is_model_proto_parsed_ == true) or
+    // during InferenceSession::Load (is_model_loaded_ == true).
+    if (!is_model_proto_parsed_ && !is_model_loaded_) {
       LOGS(*session_logger_, ERROR) << "Model was not loaded";
       return std::make_pair(common::Status(common::ONNXRUNTIME, common::FAIL, "Model was not loaded."), nullptr);
     }
@@ -3265,13 +3302,7 @@ common::Status InferenceSession::SaveModelMetadata(const onnxruntime::Model& mod
   const onnxruntime::Graph& graph = model.MainGraph();
 
   // save model metadata
-  model_metadata_.producer_name = model.ProducerName();
-  model_metadata_.description = model.DocString();
-  model_metadata_.graph_description = model.GraphDocString();
-  model_metadata_.domain = model.Domain();
-  model_metadata_.version = model.ModelVersion();
-  model_metadata_.custom_metadata_map = model.MetaData();
-  model_metadata_.graph_name = graph.Name();
+  ReadModelMetadata(model, model_metadata_);
 
   auto add_inputs_outputs = [](const InputDefList& inputs_outputs, InputOutputDefMetaMap& map) {
     map.reserve(inputs_outputs.size());

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -80,6 +80,7 @@ struct ModelMetadata {
   ModelMetadata& operator=(const ModelMetadata&) = delete;
 
   std::string producer_name;
+  std::string producer_version;
   std::string graph_name;
   std::string domain;
   std::string description;

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -3013,6 +3013,7 @@ static constexpr OrtApi ort_api_1_to_23 = {
     &OrtApis::GetEpDevices,
     &OrtApis::SessionOptionsAppendExecutionProvider_V2,
     &OrtApis::SessionOptionsSetEpSelectionPolicy,
+    &OrtApis::SessionOptionsSetEpSelectionPolicyDelegate,
 
     &OrtApis::HardwareDevice_Type,
     &OrtApis::HardwareDevice_VendorId,
@@ -3062,7 +3063,7 @@ static_assert(offsetof(OrtApi, AddExternalInitializersFromFilesInMemory) / sizeo
 // no additions in version 19, 20, and 21
 static_assert(offsetof(OrtApi, SetEpDynamicOptions) / sizeof(void*) == 284, "Size of version 20 API cannot change");
 
-static_assert(offsetof(OrtApi, GetEpApi) / sizeof(void*) == 316, "Size of version 22 API cannot change");
+static_assert(offsetof(OrtApi, GetEpApi) / sizeof(void*) == 317, "Size of version 22 API cannot change");
 
 // So that nobody forgets to finish an API version, this check will serve as a reminder:
 static_assert(std::string_view(ORT_VERSION) == "1.23.0",

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -577,8 +577,11 @@ ORT_API_STATUS_IMPL(SessionOptionsAppendExecutionProvider_V2, _In_ OrtSessionOpt
                     size_t num_ep_options);
 
 ORT_API_STATUS_IMPL(SessionOptionsSetEpSelectionPolicy, _In_ OrtSessionOptions* sess_options,
-                    _In_ OrtExecutionProviderDevicePolicy policy,
-                    _In_opt_ EpSelectionDelegate* delegate);
+                    _In_ OrtExecutionProviderDevicePolicy policy);
+
+ORT_API_STATUS_IMPL(SessionOptionsSetEpSelectionPolicyDelegate, _In_ OrtSessionOptions* sess_options,
+                    _In_ EpSelectionDelegate delegate,
+                    _In_opt_ void* state);
 
 // OrtHardwareDevice accessors.
 ORT_API(OrtHardwareDeviceType, HardwareDevice_Type, _In_ const OrtHardwareDevice* device);


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Add support for selection policy delegate
- split API function into one for the policy enum and one for the delegate
- add `void*` for user state
  - required to wire up using the delegate in other languages.

Add C# support for specifying the selection policy delegate.

Address comments from initial C# autoep support PR.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


