### PR TITLE
fix checks for metal when running under wasm

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/quantization/dp4a_matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/webgpu/quantization/dp4a_matmul_nbits.cc
@@ -513,8 +513,9 @@ bool CanApplyDP4AMatrixMatMulNBits(onnxruntime::webgpu::ComputeContext& context,
                                    bool has_zero_points) {
   // macOS - Avoid using dp4a on Metal, as it does not appear to have native dp4a support.
   // https://github.com/gpuweb/gpuweb/issues/2677#issuecomment-1713292226
+  // Use 'vendor' to check for metal; 'backend' is always WEBGPU when running under wasm.
   bool use_dp4a = context.HasFeature(wgpu::FeatureName::Subgroups) &&
-                  context.AdapterInfo().backendType != wgpu::BackendType::Metal;
+                  context.AdapterInfo().vendor != std::string_view{"apple"};
   return (accuracy_level == 4 && block_size % 32 == 0 &&
           batch_count == 1 && components_k == 4 && K % 128 == 0 && N % 16 == 0 &&
           !has_zero_points && use_dp4a);

--- a/onnxruntime/contrib_ops/webgpu/quantization/subgroup_matrix_matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/webgpu/quantization/subgroup_matrix_matmul_nbits.cc
@@ -248,8 +248,8 @@ bool CanApplySubgroupMatrixMatMulNBits(onnxruntime::webgpu::ComputeContext& cont
   // some precision issues with subgroupMatrixMultiplyAccumulate. It is possible to support higher accuracy
   // by setting compute_precision to Fp32, but that will be slower. For 1K token prefill FP16 Phi 3.5 is around 5s,
   // FP322 is around 7s.
-  return context.AdapterInfo().backendType == wgpu::BackendType::Metal &&
-         has_subgroup_matrix &&
+  return has_subgroup_matrix &&
+         context.AdapterInfo().vendor == std::string_view{"apple"} &&
          accuracy_level == 4 &&
          block_size == 32 &&
          batch_count == 1 &&


### PR DESCRIPTION
When under wasm we can't check for metal by looking at backend because it will always be WEBGPU.
Because of this we'll take the DP4A path on metal that results in sub-optimal performance.
Use vendor to check for metal instead.
