### PR TITLE
add check in NPM packaging pipeline for @dev package version

### DIFF
--- a/tools/ci_build/github/js/validate-npm-packages.py
+++ b/tools/ci_build/github/js/validate-npm-packages.py
@@ -129,6 +129,16 @@ if RELEASE_NODE and RELEASE_REACT_NATIVE and ort_node_ver != ort_react_native_ve
 if RELEASE_WEB and RELEASE_REACT_NATIVE and ort_web_ver != ort_react_native_ver:
     raise Exception("version number is different for onnxruntime-web and onnxruntime-react-native")
 
+# @dev build has to match the following pattern:
+# "x.y.z-dev.*"
+if tag == "dev":
+    if RELEASE_NODE and "-dev" not in ort_node_ver:
+        raise Exception(f'@dev build version should contain "-dev". ort_node_ver={ort_node_ver}')
+    if RELEASE_WEB and "-dev" not in ort_web_ver:
+        raise Exception(f'@dev build version should contain "-dev". ort_web_ver={ort_web_ver}')
+    if RELEASE_REACT_NATIVE and "-dev" not in ort_react_native_ver:
+        raise Exception(f'@dev build version should contain "-dev". ort_react_native_ver={ort_react_native_ver}')
+
 print("====== validated versions ======")
 print(f"source_branch={source_branch}")
 print(f"tag={tag}")


### PR DESCRIPTION
### Description

This PR adds a check for the package version for dev channel.

This PR should be able to help avoid publishing packages like "-rc.*" to dev channel automatically.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


