### PR TITLE
Fix source name in CUDA publishing pipeline configuration

### DIFF
--- a/tools/ci_build/github/azure-pipelines/py-cuda-publishing-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/py-cuda-publishing-pipeline.yml
@@ -1,7 +1,7 @@
 resources:
   pipelines:
   - pipeline: build
-    source: 'Python CUDA12 Package Test Pipeline'
+    source: 'Python CUDA Package Test Pipeline'
     trigger:
       branches:
         include:


### PR DESCRIPTION
### Description
Python Cuda Publishing pipeline references old test pipeline


