### PR TITLE
fix header include in webgpu_context.cc

### DIFF
--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -10,7 +10,9 @@
 #endif
 
 #if !defined(__wasm__)
+#if !defined(BUILD_DAWN_MONOLITHIC_LIBRARY)
 #include "dawn/dawn_proc.h"
+#endif
 #if !defined(USE_EXTERNAL_DAWN)
 #include "dawn/native/DawnNative.h"
 #endif


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

header file "dawn/dawn_proc.h" is only used in a non-monolithic build of dawn.

