### PR TITLE
[JSEP] Fix outputSize calculation causing duplicate indices.

### DIFF
--- a/js/web/lib/wasm/jsep/webgpu/ops/scatter-nd.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/scatter-nd.ts
@@ -78,46 +78,15 @@ const atomicReductionSnippet = (reduction: string, ptr: string, v: string, type:
   }
 };
 
-const calcDataOffsetSnippet = (dataRank: number, parallel: boolean) =>
-  `${
-    dataRank === 1
-      ? `
-    let element_count_dim = uniforms.output_strides;
-    let dim_value = uniforms.output_shape;`
-      : `
-    let element_count_dim = uniforms.output_strides[${parallel ? 'i - indices_start' : 'i'}];
-    let dim_value = uniforms.output_shape[${parallel ? 'i - indices_start' : 'i'} + uniforms.last_index_dimension];`
-  }
-    
-    if (index >= 0) {
-      if (index >= i32(dim_value)) {
-        index = i32(dim_value - 1);
-      }
-    } else {
-      if (index < -i32(dim_value)) {
-        index = 0;
-      } else {
-        index += i32(dim_value);
-      }
-    }
-    data_offset += u32((u32(index) * element_count_dim));`;
-
-const updateElementsSnippet = (attributes: ScatterNDAttributes, outputTypeValue: ReductionType, parallel: boolean) =>
-  `for (var i = 0u; i < uniforms.num_updates_elements; i++) {
-        let value = updates[uniforms.num_updates_elements * ${parallel ? 'global_idx' : 'idx'} + i];
-        ${atomicReductionSnippet(attributes.reduction, 'output[data_offset + i]', 'value', outputTypeValue)}
-      }`;
-
 const createScatterNDProgramInfo = (inputs: readonly TensorView[], attributes: ScatterNDAttributes): ProgramInfo => {
   const inputShape = inputs[0].dims;
   const indicesShape = inputs[1].dims;
   const outputShape = inputShape;
   // TODO: support bool with components 4.
   const components = 1;
-  const outputSize = Math.ceil(ShapeUtil.size(indicesShape) / components);
+  const outputSize = Math.ceil(ShapeUtil.sizeToDimension(inputShape, indicesShape.length - 1) / components);
   const lastIndexDimension = indicesShape[indicesShape.length - 1];
   const numUpdatesElements = ShapeUtil.sizeFromDimension(inputShape, lastIndexDimension);
-  const numIndicesElements = ShapeUtil.sizeFromDimension(indicesShape, 0) / lastIndexDimension;
 
   const programUniforms: ProgramUniform[] = [
     { type: DataType.uint32, data: outputSize },
@@ -142,48 +111,45 @@ const createScatterNDProgramInfo = (inputs: readonly TensorView[], attributes: S
         .declareVariables(indices, updates, output)}
       ${shaderHelper.mainStart()}
         ${shaderHelper.guardAgainstOutOfBoundsWorkgroupSizes('uniforms.output_size')}
-  var hasDuplicates = false;
-  if (${attributes.reduction === 'none'}) {
-    for (var i = 0; i < ${numIndicesElements}; i = i + 1) {
-      for (var j = i + 1; j < ${numIndicesElements}; j = j + 1) {
-        var index_i = i32(indices[i].x);
-        var index_j = i32(indices[j].x);
-        if (index_i == index_j) {
-          hasDuplicates = true;
-          break;
-        }
-      }
-      if (hasDuplicates) {
-        break;
-      }
-    }
-  }
-
-  if (${attributes.reduction === 'none'} && hasDuplicates) {
-    if (global_idx != 0u) {
-      return;
-    }
-    // Process each index-update pair individually when duplicates exist
-    for (var idx = 0u; idx < ${numIndicesElements}u; idx++) {
-      var data_offset = 0u;
-      for (var i = 0u; i < uniforms.last_index_dimension; i++) {
-        var index = i32(indices[idx * uniforms.last_index_dimension + i].x);
-        ${calcDataOffsetSnippet(inputShape.length, false)}
-      }
-      ${updateElementsSnippet(attributes, output.type.value as ReductionType, false)}
-    }
-    return;
-  }
-
   var data_offset = 0u;
-  var indices_start = uniforms.last_index_dimension * global_idx;
-  var indices_end = indices_start + uniforms.last_index_dimension;
+  let indices_start = uniforms.last_index_dimension * global_idx;
+  let indices_end = indices_start + uniforms.last_index_dimension;
   for (var i = indices_start; i < indices_end; i++) {
     var index = i32(indices[i].x);
-    ${calcDataOffsetSnippet(inputShape.length, true)}
+    ${
+      inputs[0].dims.length === 1
+        ? `
+    let element_count_dim = uniforms.output_strides;
+    let dim_value = uniforms.output_shape;`
+        : `
+    let element_count_dim = uniforms.output_strides[i - indices_start];
+    let dim_value = uniforms.output_shape[i - indices_start];`
+    }
+    if (index >= 0) {
+      if (index >= i32(dim_value)) {
+        index = i32(dim_value - 1);
+      }
+    } else {
+      if (index < -i32(dim_value)) {
+        index = 0;
+      } else {
+        index += i32(dim_value);
+      }
+    }
+    data_offset += u32((u32(index) * element_count_dim));
   }
-  ${updateElementsSnippet(attributes, output.type.value as ReductionType, true)}
-  }`;
+
+  for (var i = 0u; i < uniforms.num_updates_elements; i++) {
+    let value = updates[uniforms.num_updates_elements * global_idx + i];
+    ${atomicReductionSnippet(
+      attributes.reduction,
+      'output[data_offset + i]',
+      'value',
+      output.type.value as ReductionType,
+    )}
+  }
+
+      }`;
   };
   return {
     name: 'ScatterND',

--- a/js/web/lib/wasm/jsep/webgpu/ops/scatter-nd.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/scatter-nd.ts
@@ -84,7 +84,7 @@ const createScatterNDProgramInfo = (inputs: readonly TensorView[], attributes: S
   const outputShape = inputShape;
   // TODO: support bool with components 4.
   const components = 1;
-  const outputSize = Math.ceil(ShapeUtil.sizeToDimension(inputShape, indicesShape.length - 1) / components);
+  const outputSize = Math.ceil(ShapeUtil.sizeToDimension(indicesShape, indicesShape.length - 1) / components);
   const lastIndexDimension = indicesShape[indicesShape.length - 1];
   const numUpdatesElements = ShapeUtil.sizeFromDimension(inputShape, lastIndexDimension);
 


### PR DESCRIPTION
### Description
Fix the outputSize computation causing duplicate indices. The outputSize should be the size of indices tensor without counting the last dimension.



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Fix the issue https://github.com/microsoft/onnxruntime/issues/24070

