### PR TITLE
Fix improper vector iterator handling and a couple of warnings

### DIFF
--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -369,7 +369,7 @@ common::Status SaveInitializedTensors(
   if (memory_profile_func)
     memory_profile_func(planner);
 
-  for (auto i : planned_initializers_memory_sizes_in_byte) {
+  for (const auto& i : planned_initializers_memory_sizes_in_byte) {
     LOGS(logger, INFO) << "[Memory] SessionStateInitializer statically allocates "
                        << i.second << " bytes for " << i.first.ToString() << std::endl;
   }

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -2587,10 +2587,12 @@ TensorrtExecutionProvider::GetCapability(const GraphViewer& graph,
     supported_nodes_vector.clear();
   }
 
-  for (auto it = supported_nodes_vector.begin(); it != supported_nodes_vector.end(); ++it) {
+  for (auto it = supported_nodes_vector.begin(); it != supported_nodes_vector.end();) {
     const size_t subgraph_size = it->first.size();
     if (subgraph_size < min_subgraph_size_) {
       it = supported_nodes_vector.erase(it);
+    } else {
+      ++it;
     }
   }
 

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -2587,11 +2587,10 @@ TensorrtExecutionProvider::GetCapability(const GraphViewer& graph,
     supported_nodes_vector.clear();
   }
 
-  // Remove subgraphs if its size is less than the predefined minimal size
   for (auto it = supported_nodes_vector.begin(); it != supported_nodes_vector.end(); ++it) {
     const size_t subgraph_size = it->first.size();
     if (subgraph_size < min_subgraph_size_) {
-      supported_nodes_vector.erase(it--);
+      it = supported_nodes_vector.erase(it);
     }
   }
 

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_custom_ops.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_custom_ops.h
@@ -78,7 +78,7 @@ struct TensorRTCustomOp : Ort::CustomOpBase<TensorRTCustomOp, TensorRTCustomKern
  private:
   const char* provider_{onnxruntime::kTensorrtExecutionProvider};
   void* compute_stream_;
-  const char* name_;
+  const char* name_ = nullptr;
   size_t num_inputs_ = 1;   // set to 1 to match with default min_arity for variadic input
   size_t num_outputs_ = 1;  // set to 1 to match with default min_arity for variadic output
 };


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
When erasing elements from a vector while iterating over it, the iterator must be updated to the new position after the erase operation as a return value, otherwise results in decrement of end operator which is undefined behavior.
Fix a couple of warnings as well.

### Motivation and Context
Causes test assert.

