### PR TITLE
More error checking for user provided C# policy selection delegate

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
@@ -405,7 +405,6 @@ namespace Microsoft.ML.OnnxRuntime
 #else
             // TODO: Make this save the pointer, and not copy the whole structure across
             api_ = (OrtApi)OrtGetApi(ORT_API_VERSION);
-
             OrtGetVersionString = (DOrtGetVersionString)Marshal.GetDelegateForFunctionPointer(OrtGetApiBase().GetVersionString, typeof(DOrtGetVersionString));
 #endif
             OrtCreateStatus = (DOrtCreateStatus)Marshal.GetDelegateForFunctionPointer(
@@ -934,7 +933,7 @@ namespace Microsoft.ML.OnnxRuntime
         public delegate void DOrtReleaseStatus(IntPtr /*(OrtStatus*)*/ statusPtr);
         public static DOrtReleaseStatus OrtReleaseStatus;
 
-        #endregion Status API
+#endregion Status API
 
 #region InferenceSession API
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
@@ -405,14 +405,18 @@ namespace Microsoft.ML.OnnxRuntime
 #else
             // TODO: Make this save the pointer, and not copy the whole structure across
             api_ = (OrtApi)OrtGetApi(ORT_API_VERSION);
+
             OrtGetVersionString = (DOrtGetVersionString)Marshal.GetDelegateForFunctionPointer(OrtGetApiBase().GetVersionString, typeof(DOrtGetVersionString));
 #endif
+            OrtCreateStatus = (DOrtCreateStatus)Marshal.GetDelegateForFunctionPointer(
+                api_.CreateStatus, typeof(DOrtCreateStatus));
 
             OrtCreateEnv = (DOrtCreateEnv)Marshal.GetDelegateForFunctionPointer(api_.CreateEnv, typeof(DOrtCreateEnv));
             OrtCreateEnvWithCustomLogger = (DOrtCreateEnvWithCustomLogger)Marshal.GetDelegateForFunctionPointer(api_.CreateEnvWithCustomLogger, typeof(DOrtCreateEnvWithCustomLogger));
             OrtCreateEnvWithGlobalThreadPools = (DOrtCreateEnvWithGlobalThreadPools)Marshal.GetDelegateForFunctionPointer(api_.CreateEnvWithGlobalThreadPools, typeof(DOrtCreateEnvWithGlobalThreadPools));
             OrtCreateEnvWithCustomLoggerAndGlobalThreadPools = (DOrtCreateEnvWithCustomLoggerAndGlobalThreadPools)Marshal.GetDelegateForFunctionPointer(api_.CreateEnvWithCustomLoggerAndGlobalThreadPools, typeof(DOrtCreateEnvWithCustomLoggerAndGlobalThreadPools));
             OrtReleaseEnv = (DOrtReleaseEnv)Marshal.GetDelegateForFunctionPointer(api_.ReleaseEnv, typeof(DOrtReleaseEnv));
+            
             OrtEnableTelemetryEvents = (DOrtEnableTelemetryEvents)Marshal.GetDelegateForFunctionPointer(api_.EnableTelemetryEvents, typeof(DOrtEnableTelemetryEvents));
             OrtDisableTelemetryEvents = (DOrtDisableTelemetryEvents)Marshal.GetDelegateForFunctionPointer(api_.DisableTelemetryEvents, typeof(DOrtDisableTelemetryEvents));
 
@@ -930,9 +934,14 @@ namespace Microsoft.ML.OnnxRuntime
         public delegate void DOrtReleaseStatus(IntPtr /*(OrtStatus*)*/ statusPtr);
         public static DOrtReleaseStatus OrtReleaseStatus;
 
-#endregion Status API
+        #endregion Status API
 
 #region InferenceSession API
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate IntPtr /* OrtStatus* */ DOrtCreateStatus(
+            uint /* OrtErrorCode */ code, 
+            byte[] /* const char* */ msg);
+        public static DOrtCreateStatus OrtCreateStatus;
 
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         public delegate IntPtr /* OrtStatus* */ DOrtCreateSession(

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/OrtAutoEpTests.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/OrtAutoEpTests.cs
@@ -198,5 +198,89 @@ public class OrtAutoEpTests
             Assert.NotNull(session);
         }
     }
+
+    // select max + 1, starting with all devices
+    private static List<OrtEpDevice> SelectionPolicyDelegateTooMany(IReadOnlyList<OrtEpDevice> epDevices,
+                                                                    OrtKeyValuePairs modelMetadata,
+                                                                    OrtKeyValuePairs runtimeMetadata,
+                                                                    uint maxSelections)
+    {
+        Assert.NotEmpty(modelMetadata.Entries);
+        Assert.True(epDevices.Count > 0);
+        var selected = new List<OrtEpDevice>(epDevices);
+
+        while (selected.Count < (maxSelections + 1))
+        {
+            selected.Add(epDevices.Last());
+        }
+
+        return selected;
+    }
+
+    [Fact]
+    public void SetEpSelectionPolicyDelegateTooMany()
+    {
+        using SessionOptions sessionOptions = new SessionOptions();
+        sessionOptions.LogSeverityLevel = OrtLoggingLevel.ORT_LOGGING_LEVEL_VERBOSE;
+
+        var epDevices = ortEnvInstance.GetEpDevices();
+        Assert.NotEmpty(epDevices);
+
+        // select too many devices
+        sessionOptions.SetEpSelectionPolicyDelegate(SelectionPolicyDelegateTooMany);
+
+        var model = TestDataLoader.LoadModelFromEmbeddedResource("squeezenet.onnx");
+
+        // session should fail
+        try
+        {
+            using var session = new InferenceSession(model, sessionOptions);
+            Assert.Fail("Should have thrown an exception");
+        }
+        catch (OnnxRuntimeException ex)
+        {
+            // Current C++ max is 8. We copy all devices and keep adding until we exceed that.
+            const int max = 8;
+            var numSelected = epDevices.Count > max ? epDevices.Count : (max + 1);
+            var expected = "[ErrorCode:Fail] EP selection delegate failed: The number of selected devices " +
+                          $"({numSelected}) returned by the C# selection delegate exceeds the maximum ({max})";
+            Assert.Contains(expected, ex.Message);
+        }
+    }
+
+    // throw exception in user provided delegate
+    private static List<OrtEpDevice> SelectionPolicyDelegateThrows(IReadOnlyList<OrtEpDevice> epDevices,
+                                                                    OrtKeyValuePairs modelMetadata,
+                                                                    OrtKeyValuePairs runtimeMetadata,
+                                                                    uint maxSelections)
+    {
+        throw new ArgumentException("Test exception");
+    }
+
+    [Fact]
+    public void SetEpSelectionPolicyDelegateThrows()
+    {
+        using SessionOptions sessionOptions = new SessionOptions();
+        sessionOptions.LogSeverityLevel = OrtLoggingLevel.ORT_LOGGING_LEVEL_VERBOSE;
+
+        var epDevices = ortEnvInstance.GetEpDevices();
+        Assert.NotEmpty(epDevices);
+
+        sessionOptions.SetEpSelectionPolicyDelegate(SelectionPolicyDelegateThrows);
+
+        var model = TestDataLoader.LoadModelFromEmbeddedResource("squeezenet.onnx");
+
+        try
+        {
+            using var session = new InferenceSession(model, sessionOptions);
+            Assert.Fail("Should have thrown an exception");
+        }
+        catch (OnnxRuntimeException ex)
+        {
+            var expected = "[ErrorCode:Fail] EP selection delegate failed: " +
+                           "The C# selection delegate threw an exception: Test exception";
+            Assert.Contains(expected, ex.Message);
+        }
+    }
 }
 #endif


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Handle user selection policy delegate throwing or returning too many selections in C# code and create error message.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


