### PR TITLE
[Clean up] Fix ep_name vs ep_registration_name usage in autoEP Python unit tests

### DIFF
--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -1801,7 +1801,7 @@ void addGlobalMethods(py::module& m) {
 
 #if !defined(ORT_MINIMAL_BUILD)
 /**
- * Calls the user's Python EP selection function and coverts the results to a format that can be used
+ * Calls the user's Python EP selection function and converts the results to a format that can be used
  * by ORT to select OrtEpDevice instances. The user's function is set by calling
  * SessionOptions.set_provider_selection_policy_delegate() on the Python side. The result of this wrapper
  * function is used in core/session/provider_policy_context.cc.

--- a/onnxruntime/test/python/onnxruntime_test_python_autoep.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_autoep.py
@@ -28,15 +28,15 @@ class TestAutoEP(AutoEpTestCase):
         Test registration of CUDA EP, adding its OrtDevice to the SessionOptions, and running inference.
         """
         ep_lib_path = "onnxruntime_providers_cuda.dll"
-        ep_registration_name = "CUDAExecutionProvider"
+        ep_name = "CUDAExecutionProvider"
 
         if sys.platform != "win32":
             self.skipTest("Skipping test because device discovery is only supported on Windows")
 
-        if ep_registration_name not in available_providers:
+        if ep_name not in available_providers:
             self.skipTest("Skipping test because it needs to run on CUDA EP")
 
-        self.register_execution_provider_library(ep_registration_name, ep_lib_path)
+        self.register_execution_provider_library(ep_name, ep_lib_path)
 
         ep_devices = onnxrt.get_ep_devices()
         has_cpu_ep = False
@@ -45,7 +45,7 @@ class TestAutoEP(AutoEpTestCase):
             ep_name = ep_device.ep_name
             if ep_name == "CPUExecutionProvider":
                 has_cpu_ep = True
-            if ep_name == ep_registration_name:
+            if ep_name == ep_name:
                 cuda_ep_device = ep_device
 
         self.assertTrue(has_cpu_ep)
@@ -70,22 +70,22 @@ class TestAutoEP(AutoEpTestCase):
         np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
         del sess  # Delete session before unregistering library
-        self.unregister_execution_provider_library(ep_registration_name)
+        self.unregister_execution_provider_library(ep_name)
 
     def test_cuda_prefer_gpu_and_inference(self):
         """
         Test selecting CUDA EP via the PREFER_GPU policy and running inference.
         """
         ep_lib_path = "onnxruntime_providers_cuda.dll"
-        ep_registration_name = "CUDAExecutionProvider"
+        ep_name = "CUDAExecutionProvider"
 
         if sys.platform != "win32":
             self.skipTest("Skipping test because device discovery is only supported on Windows")
 
-        if ep_registration_name not in available_providers:
+        if ep_name not in available_providers:
             self.skipTest("Skipping test because it needs to run on CUDA EP")
 
-        self.register_execution_provider_library(ep_registration_name, ep_lib_path)
+        self.register_execution_provider_library(ep_name, ep_lib_path)
 
         # Set a policy to prefer GPU. Cuda should be selected.
         sess_options = onnxrt.SessionOptions()
@@ -102,22 +102,22 @@ class TestAutoEP(AutoEpTestCase):
         np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
         del sess  # Delete session before unregistering library
-        self.unregister_execution_provider_library(ep_registration_name)
+        self.unregister_execution_provider_library(ep_name)
 
     def test_cuda_ep_selection_delegate_and_inference(self):
         """
         Test selecting CUDA EP via the custom EP selection delegate function and then run inference.
         """
         ep_lib_path = "onnxruntime_providers_cuda.dll"
-        ep_registration_name = "CUDAExecutionProvider"
+        ep_name = "CUDAExecutionProvider"
 
         if sys.platform != "win32":
             self.skipTest("Skipping test because device discovery is only supported on Windows")
 
-        if ep_registration_name not in available_providers:
+        if ep_name not in available_providers:
             self.skipTest("Skipping test because it needs to run on CUDA EP")
 
-        self.register_execution_provider_library(ep_registration_name, ep_lib_path)
+        self.register_execution_provider_library(ep_name, ep_lib_path)
 
         # User's custom EP selection function.
         def my_delegate(
@@ -130,7 +130,7 @@ class TestAutoEP(AutoEpTestCase):
             self.assertGreaterEqual(len(ep_devices), 2)
             self.assertGreaterEqual(max_selections, 2)
 
-            cuda_ep_device = next((d for d in ep_devices if d.ep_name == ep_registration_name), None)
+            cuda_ep_device = next((d for d in ep_devices if d.ep_name == ep_name), None)
             self.assertIsNotNone(cuda_ep_device)
 
             # Select the CUDA device and the ORT CPU EP device (should always be last)
@@ -150,7 +150,7 @@ class TestAutoEP(AutoEpTestCase):
         np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
         del sess  # Delete session before unregistering library
-        self.unregister_execution_provider_library(ep_registration_name)
+        self.unregister_execution_provider_library(ep_name)
 
     def test_custom_ep_selection_delegate_that_raises_error(self):
         """
@@ -192,8 +192,8 @@ class TestAutoEP(AutoEpTestCase):
         except FileNotFoundError:
             self.skipTest(f"Skipping test because EP library '{ep_lib_path}' cannot be found")
 
-        ep_registration_name = "example_ep"
-        self.register_execution_provider_library(ep_registration_name, os.path.realpath(ep_lib_path))
+        ep_name = "example_ep"
+        self.register_execution_provider_library(ep_name, os.path.realpath(ep_lib_path))
 
         ep_devices = onnxrt.get_ep_devices()
         has_cpu_ep = False
@@ -203,7 +203,7 @@ class TestAutoEP(AutoEpTestCase):
 
             if ep_name == "CPUExecutionProvider":
                 has_cpu_ep = True
-            if ep_name == ep_registration_name:
+            if ep_name == ep_name:
                 test_ep_device = ep_device
 
         self.assertTrue(has_cpu_ep)
@@ -236,7 +236,7 @@ class TestAutoEP(AutoEpTestCase):
             sess_options.add_provider_for_devices([test_ep_device], {"opt1": "val1"})
         self.assertIn("EP is not currently supported", str(context.exception))
 
-        self.unregister_execution_provider_library(ep_registration_name)
+        self.unregister_execution_provider_library(ep_name)
 
 
 if __name__ == "__main__":

--- a/onnxruntime/test/python/onnxruntime_test_python_autoep.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_autoep.py
@@ -42,10 +42,9 @@ class TestAutoEP(AutoEpTestCase):
         has_cpu_ep = False
         cuda_ep_device = None
         for ep_device in ep_devices:
-            ep_name = ep_device.ep_name
-            if ep_name == "CPUExecutionProvider":
+            if ep_device.ep_name == "CPUExecutionProvider":
                 has_cpu_ep = True
-            if ep_name == ep_name:
+            if ep_device.ep_name == ep_name:
                 cuda_ep_device = ep_device
 
         self.assertTrue(has_cpu_ep)
@@ -199,11 +198,9 @@ class TestAutoEP(AutoEpTestCase):
         has_cpu_ep = False
         test_ep_device = None
         for ep_device in ep_devices:
-            ep_name = ep_device.ep_name
-
-            if ep_name == "CPUExecutionProvider":
+            if ep_device.ep_name == "CPUExecutionProvider":
                 has_cpu_ep = True
-            if ep_name == ep_name:
+            if ep_device.ep_name == ep_name:
                 test_ep_device = ep_device
 
         self.assertTrue(has_cpu_ep)

--- a/onnxruntime/test/python/onnxruntime_test_python_compile_api.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_compile_api.py
@@ -34,8 +34,8 @@ class TestCompileApi(AutoEpTestCase):
             self.skipTest("Skipping test because provider selection policies are only supported on Windows")
 
         ep_lib_path = "onnxruntime_providers_qnn.dll"
-        ep_registration_name = "QNNExecutionProvider"
-        self.register_execution_provider_library(ep_registration_name, ep_lib_path)
+        ep_name = "QNNExecutionProvider"
+        self.register_execution_provider_library(ep_name, ep_lib_path)
 
         input_model_path = get_name("nhwc_resize_scales_opset18.onnx")
         output_model_path = os.path.join(self._tmp_dir_path, "model.compiled0.onnx")
@@ -51,7 +51,7 @@ class TestCompileApi(AutoEpTestCase):
         )
         model_compiler.compile_to_file(output_model_path)
         self.assertTrue(os.path.exists(output_model_path))
-        self.unregister_execution_provider_library(ep_registration_name)
+        self.unregister_execution_provider_library(ep_name)
 
     def test_compile_with_ep_selection_delegate(self):
         """


### PR DESCRIPTION
### Description
Cleans up the usage of `ep_name` and `ep_registration_name` in the autoEP Python unit tests.



### Motivation and Context
Addresses comments from a previous PR: https://github.com/microsoft/onnxruntime/pull/24634
> nit: the registration name and EP names don't need to match. could we call this 'ep_name' to avoid potentially creating an assumption that they always do?


