### PR TITLE
Revert "Publish debug symbols for windows (#24643) (#24651)"

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
@@ -31,20 +31,6 @@ parameters:
   default: true
 
 steps:
-    - task: PublishSymbols@2
-      displayName: 'Publish Build Debug Symbols'
-      condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/rel-')))
-      inputs:
-        SymbolsFolder: '$(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\'
-        SearchPattern: '*.pdb'
-        IndexSources: true
-        PublishSymbols: true
-        SymbolServerType: 'TeamServices'
-        SymbolExpirationInDays: '36530'
-        IndexableFileFormats: 'Default'
-        DetailedLog: true
-        SymbolsArtifactName: 'Symbols_${{parameters.buildConfig}}'
-
     - task: CmdLine@2
       displayName: 'Copy build artifacts for zipping'
       inputs:


### PR DESCRIPTION
This reverts commit 8fbc5d7880707bc0c9decc5001f67881ee885f43 which results in packaging pipeline failures 



