### PR TITLE
Align hardware ID parsing with DXCore representation

### DIFF
--- a/onnxruntime/core/platform/windows/device_discovery.cc
+++ b/onnxruntime/core/platform/windows/device_discovery.cc
@@ -120,7 +120,7 @@ std::unordered_map<uint64_t, DeviceInfo> GetDeviceInfoSetupApi(const std::unorde
                                             (PBYTE)buffer, sizeof(buffer), &size)) {
         uint32_t vendor_id = 0;
         uint32_t device_id = 0;
-                                      
+
         // PCI\VEN_xxxx&DEV_yyyy&...
         // ACPI\VEN_xxxx&DEV_yyyy&... if we're lucky.
         // ACPI values seem to be very inconsistent, so we check fairly carefully and always require a device id.

--- a/onnxruntime/core/platform/windows/device_discovery.cc
+++ b/onnxruntime/core/platform/windows/device_discovery.cc
@@ -68,6 +68,20 @@ uint64_t GetLuidKey(LUID luid) {
   return (uint64_t(luid.HighPart) << 32) | luid.LowPart;
 }
 
+// Converts a wide string (up to 4 characters) representing a hardware ID component (e.g., "ABCD" from "VEN_ABCD")
+// into a uint32_t. The conversion is done in a little-endian manner, meaning the first character
+// of the string becomes the least significant byte of the integer, and the fourth character
+// becomes the most significant byte.
+uint32_t WStringToUint32Id(const std::wstring& vendor_name) {
+  uint32_t vendor_id = 0;
+  for (size_t i = 0; i < 4 && i < vendor_name.size(); ++i) {
+    // For little-endian, place each character at the appropriate byte position
+    // First character goes into lowest byte, last character into highest byte
+    vendor_id |= static_cast<unsigned char>(vendor_name[i] & 0xFF) << (i * 8);
+  }
+  return vendor_id;
+}
+
 // returns info for display and processor entries. key is (vendor_id << 32 | device_id)
 // npus: (vendor_id << 32 | device_id) for devices we think are NPUs from DXCORE
 std::unordered_map<uint64_t, DeviceInfo> GetDeviceInfoSetupApi(const std::unordered_set<uint64_t>& npus) {
@@ -110,8 +124,9 @@ std::unordered_map<uint64_t, DeviceInfo> GetDeviceInfoSetupApi(const std::unorde
         const auto get_id = [](const std::wstring& hardware_id, const std::wstring& prefix) -> uint32_t {
           if (auto idx = hardware_id.find(prefix); idx != std::wstring::npos) {
             auto id = hardware_id.substr(idx + prefix.size(), 4);
-            if (std::all_of(id.begin(), id.end(), iswxdigit)) {
-              return std::stoul(id, nullptr, 16);
+            if (id.size() == 4) {
+              // DXCore reports vendor and device IDs as 32-bit integer representations of the ASCII string.
+              return WStringToUint32Id(id);
             }
           }
 


### PR DESCRIPTION
### Description
Modified the `get_id` lambda to parse 4-character hardware ID components (e.g., from VEN_xxxx or DEV_yyyy) by converting the ASCII string representation directly to a uint32_t using `WStringToUint32Id`.

This replaces the previous hexadecimal string-to-integer conversion and aligns with how DXCore reports these vendor and device IDs, ensuring consistent ID interpretation.

### Motivation and Context
Before this change, we were assuming the hardware ID components were hexadecimal strings and converting them to integers. This assumption is incorrect and was leading to incorrect interpretations of the vendor and device IDs.

Down the line when we compare the vendor and device id with the ids we receive from DXCORE, there are no matches, and we fail to copy the information collected in `GetDeviceInfoSetupApi`.

### Testing
Tested with all the sample apps and stepped through the code to verify the Vendor and Device IDs match the IDs from DXCORE on both Qualcomm and AMD.

