### PR TITLE
Update AnyChart library to version 8.13.0 in perf_view HTML

### DIFF
--- a/tools/perf_view/ort_perf_view.html
+++ b/tools/perf_view/ort_perf_view.html
@@ -3,9 +3,9 @@
   <head>
     <title id="filename">Onnxruntime Perf View</title>
     <script type="text/javascript" src="https://cdn.anychart.com/releases/v8/js/anychart-core.min.js"></script>
-    <script src="https://cdn.anychart.com/releases/8.11.0/js/anychart-ui.min.js"></script>
+    <script src="https://cdn.anychart.com/releases/8.13.0/js/anychart-ui.min.js"></script>
     <script type="text/javascript" src="https://cdn.anychart.com/releases/v8/js/anychart-treemap.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://cdn.anychart.com/releases/8.11.1/css/anychart-ui.min.css"/>
+    <link rel="stylesheet" type="text/css" href="https://cdn.anychart.com/releases/8.13.0/css/anychart-ui.min.css"/>
     <style>
       html, body {
         width: 100%;


### PR DESCRIPTION
### Description
The perf view uses outdated any chart version, which results in perf_view not showing any summary. 

Previously happened: https://github.com/microsoft/onnxruntime/issues/16873



