### PR TITLE
[Native WebGPU] Use some alternate way to calculate Sigmoid

### DIFF
--- a/onnxruntime/core/providers/webgpu/math/unary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/webgpu/math/unary_elementwise_ops.cc
@@ -107,7 +107,7 @@ WEBGPU_ELEMENTWISE_IMPL(Log, "log(a)")
 WEBGPU_ELEMENTWISE_VERSIONED_KERNEL(Log, 6, 12, WebGpuSupportedFloatTypes())
 WEBGPU_ELEMENTWISE_KERNEL(Log, 13, WebGpuSupportedFloatTypes())
 
-WEBGPU_ELEMENTWISE_IMPL(Sigmoid, "select(1.0 / (1.0 + exp(-a)), 1.0 - 1.0 / (1.0 + exp(abs(a))), a < (a - a))")
+WEBGPU_ELEMENTWISE_IMPL(Sigmoid, "select(1.0 / (1.0 + exp(-a)), 1.0 - 1.0 / (1.0 + exp(a)), a < (a - a))")
 WEBGPU_ELEMENTWISE_VERSIONED_KERNEL(Sigmoid, 6, 12, WebGpuSupportedFloatTypes())
 WEBGPU_ELEMENTWISE_KERNEL(Sigmoid, 13, WebGpuSupportedFloatTypes())
 

--- a/onnxruntime/core/providers/webgpu/math/unary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/webgpu/math/unary_elementwise_ops.cc
@@ -107,7 +107,7 @@ WEBGPU_ELEMENTWISE_IMPL(Log, "log(a)")
 WEBGPU_ELEMENTWISE_VERSIONED_KERNEL(Log, 6, 12, WebGpuSupportedFloatTypes())
 WEBGPU_ELEMENTWISE_KERNEL(Log, 13, WebGpuSupportedFloatTypes())
 
-WEBGPU_ELEMENTWISE_IMPL(Sigmoid, "1.0 / (1.0 + exp(-a))")
+WEBGPU_ELEMENTWISE_IMPL(Sigmoid, "select(1.0 / (1.0 + exp(-a)), 1.0 - 1.0 / (1.0 + exp(abs(a))), a < (a - a))")
 WEBGPU_ELEMENTWISE_VERSIONED_KERNEL(Sigmoid, 6, 12, WebGpuSupportedFloatTypes())
 WEBGPU_ELEMENTWISE_KERNEL(Sigmoid, 13, WebGpuSupportedFloatTypes())
 


### PR DESCRIPTION
Compute [1 - Sigmoid(-x)] to calculate Sigmoid(x) if the input is negative because exp(x) for a negative value could cause overflow.

### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Required to get expected result with YOLOv9.

