### PR TITLE
Add kleidiai to onnxruntime_EXTERNAL_LIBRARIES in setup_kleidiai().

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -281,6 +281,9 @@ function(setup_kleidiai)
     ${MLAS_SRC_DIR}/kai_ukernel_interface.cpp
   )
   target_link_libraries(onnxruntime_mlas PRIVATE kleidiai)
+
+  list(APPEND onnxruntime_EXTERNAL_LIBRARIES kleidiai)
+  set(onnxruntime_EXTERNAL_LIBRARIES ${onnxruntime_EXTERNAL_LIBRARIES} PARENT_SCOPE)
 endfunction()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Emscripten")


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Add `kleidiai` to `onnxruntime_EXTERNAL_LIBRARIES` in `setup_kleidiai()`.

This is important when building an Apple static framework.
If `kleidiai` is not in `onnxruntime_EXTERNAL_LIBRARIES`, we may encounter link errors when using the static framework, e.g., when building an iOS app targeting ARM64 iphoneos.

It happened to work in the iOS packages built by the packaging pipeline because those are built with the XNNPACK EP enabled. In that case, `kleidiai` is added to `onnxruntime_EXTERNAL_LIBRARIES` elsewhere.
https://github.com/microsoft/onnxruntime/blob/0aaccafd41eca1580ec409d4ccd32cd1288c7e05/cmake/external/xnnpack.cmake#L95
https://github.com/microsoft/onnxruntime/blob/0aaccafd41eca1580ec409d4ccd32cd1288c7e05/cmake/external/onnxruntime_external_deps.cmake#L569-L572

`onnxruntime_EXTERNAL_LIBRARIES` should tolerate duplicate values. But `kleidiai` needs to be included at least once if we use it.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix Apple static framework build with KleidiAI when the XNNPACK EP is not enabled.