### PR TITLE
[QNN EP] Fix Weight Bias Quantization implementation

### DIFF
--- a/onnxruntime/core/optimizer/qdq_transformer/weight_bias_quantization.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/weight_bias_quantization.cc
@@ -89,7 +89,9 @@ Status WeightBiasQuantization::ApplyImpl(Graph& graph, bool& modified, int graph
       }
 
       const auto& dq_attrs = dq_1->GetAttributes();
-      if (dq_attrs.find("block_size") != dq_attrs.end()) {
+      auto attr_it = dq_attrs.find("block_size");
+      // Default value of block_size=0 has no significance. Don't skip weight_bias_quantization.
+      if (attr_it != dq_attrs.end() && attr_it->second.i() != 0) {
         continue;
       }
 


### PR DESCRIPTION
 - ORT is populating all node attributes in GetAttributes() API call with keeping default values for unspecified attributes in NodeProto.
 - Check the possibility of default values and don't skip weight_bias_quantization on Conv operator if the weight has DeQuantize node with attribute block_size=0 is read.

### Description
GetAttributes() API call is populating all attributes in node definition with assigning default values for unspecified attributes in the model. Weight Bias Quantization is being skipped when block_size attribute present in the DequantizeLinear node producing the weight for a Conv operator. Gracefully handle the default value of block_size i.e., 0 and apply the Weight Bias Quantization as the default value '0' has no significance.


### Motivation and Context
Applying Weight Bias Quantization on Conv operator enables ORT QDQ transformer to fold the DQ-->Conv-->Q pattern into Conv operator. This improves inference time for some QDQ ONNX models.


