### PR TITLE
Fix improper iterator usage

### DIFF
--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
@@ -2021,10 +2021,12 @@ NvExecutionProvider::GetCapability(const GraphViewer& graph,
   }
 
   // Remove subgraphs if its size is less than the predefined minimal size
-  for (auto it = supported_nodes_vector.begin(); it != supported_nodes_vector.end(); ++it) {
+  for (auto it = supported_nodes_vector.begin(); it != supported_nodes_vector.end();) {
     const size_t subgraph_size = it->first.size();
     if (subgraph_size < min_subgraph_size_) {
-      supported_nodes_vector.erase(it--);
+      it = supported_nodes_vector.erase(it);
+    } else {
+      ++it;
     }
   }
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
This pull request includes a minor but important fix to the iteration logic in the `NvExecutionProvider::GetCapability` method to ensure correctness and avoid potential undefined behavior when removing elements from a container during iteration.

### Iteration logic fix:
* In `onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc`, the loop for removing subgraphs smaller than the minimal size was updated to use `it = supported_nodes_vector.erase(it)` instead of `erase(it--)`. This ensures the iterator remains valid and avoids decrementing it unnecessarily, improving code safety and readability.

### Motivation and Context
Prevent possible memory corruption.
Similar code was addressed in tensorrt EP.

