### PR TITLE
[web CI] fixes shader key validation failure

### DIFF
--- a/.github/actions/webgpu-validate-shader-key/parse-chromium-debug-log.js
+++ b/.github/actions/webgpu-validate-shader-key/parse-chromium-debug-log.js
@@ -16,7 +16,7 @@ async function processChromiumDebugLog() {
 
   for await (const line of rl) {
     const result =
-      /^\[.+INFO:CONSOLE\(\d+\)]\ "(?<raw_log_data>.+)",\ source:\ [^"]+?\(\d+\)$/.exec(
+      /^\[.+INFO:CONSOLE.+?]\ "(?<raw_log_data>.+)",\ source:\ [^"]+?\(\d+\)$/.exec(
         line
       );
     if (!result) {


### PR DESCRIPTION
### Description

loose the regex for the log prefix. this fixes the shader key validation failure and makes it less sensitive to future log format change.



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

with chrome update, the chrome_debug logging format changed a little bit.
