### PR TITLE
Allow TransposeOptimizer handle layout agonistic GeLU

### DIFF
--- a/onnxruntime/core/optimizer/layout_transformation/layout_transformation_dev_notes.md
+++ b/onnxruntime/core/optimizer/layout_transformation/layout_transformation_dev_notes.md
@@ -13,7 +13,7 @@ Foreach
   1. call GetCapability
   2. IF EP.DesiredFormat == NHWC
     2.1. Invoke Layout Transformer
-    2.2 If graph is modified -> call GetCapability (layout transformer can add new nodes to the graph)
+    2.2. If graph is modified -> call GetCapability (layout transformer can add new nodes to the graph)
   3 Compile
 ```
 

--- a/onnxruntime/core/optimizer/transpose_optimization/onnx_transpose_optimization.cc
+++ b/onnxruntime/core/optimizer/transpose_optimization/onnx_transpose_optimization.cc
@@ -2487,6 +2487,7 @@ constexpr HandlerInfo reshape_handler = {&FirstInput, &HandleReshape, /*transpos
 static const std::unordered_map<std::string_view, const HandlerInfo&> handler_map{
     {"Cast", simple_node_handler},
     {"Exp", simple_node_handler},
+    {"Gelu", simple_node_handler},
     {"Identity", simple_node_handler},
     {"LeakyRelu", simple_node_handler},
     {"Log", simple_node_handler},

--- a/onnxruntime/test/perftest/strings_helper.cc
+++ b/onnxruntime/test/perftest/strings_helper.cc
@@ -41,7 +41,7 @@ void ParseSessionConfigs(const std::string& configs_string,
         available_keys_str += ", ";
       }
       ORT_THROW("[ERROR] wrong key type entered : `", key,
-                "`. The following runtime key options are avaible: [", available_keys_str, "]");
+                "`. The following runtime key options are available: [", available_keys_str, "]");
     }
 
     auto it = session_configs.find(key);


### PR DESCRIPTION
For NHWC EP, this GeLU op missing from handler would result in extra transpose wraps around GeLU ops. This fix address this issue and improves performance. 