### PR TITLE
add branch name to artifact "validation-scripts"

### DIFF
--- a/tools/ci_build/github/azure-pipelines/npm-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/npm-packaging-pipeline.yml
@@ -114,6 +114,12 @@ extends:
             targetFolder: $(Build.ArtifactStagingDirectory)\validation-scripts
           displayName: 'Copy validation scripts'
 
+        - script: |
+            echo "== Source Branch =="
+            echo "$(Build.SourceBranch)"
+            echo "$(Build.SourceBranch)" > $(Build.ArtifactStagingDirectory)\node-artifacts\_branch.txt
+          displayName: 'Extract Source Branch'
+
         - task: 1ES.PublishPipelineArtifact@1
           inputs:
             artifactName: 'validation_scripts'


### PR DESCRIPTION
### Description

This fix allows the JS Release Pipeline to have the info of the source branch name.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


