### PR TITLE
Expose and test GetTensorSizeInBytes in C# and Python

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
@@ -366,6 +366,8 @@ namespace Microsoft.ML.OnnxRuntime
         public IntPtr EpDevice_EpMetadata;
         public IntPtr EpDevice_EpOptions;
         public IntPtr EpDevice_Device;
+        public IntPtr GetEpApi;
+        public IntPtr GetTensorSizeInBytes;
     }
 
     internal static class NativeMethods
@@ -539,6 +541,7 @@ namespace Microsoft.ML.OnnxRuntime
             OrtValueIsTensor = (DOrtValueIsTensor)Marshal.GetDelegateForFunctionPointer(api_.IsTensor, typeof(DOrtValueIsTensor));
             OrtValueIsSparseTensor = (DOrtValueIsSparseTensor)Marshal.GetDelegateForFunctionPointer(api_.IsSparseTensor, typeof(DOrtValueIsSparseTensor));
             OrtGetTensorMutableData = (DOrtGetTensorMutableData)Marshal.GetDelegateForFunctionPointer(api_.GetTensorMutableData, typeof(DOrtGetTensorMutableData));
+            OrtGetTensorSizeInBytes = (DOrtGetTensorSizeInBytes)Marshal.GetDelegateForFunctionPointer(api_.GetTensorSizeInBytes, typeof(DOrtGetTensorSizeInBytes));
             OrtFillStringTensor = (DOrtFillStringTensor)Marshal.GetDelegateForFunctionPointer(api_.FillStringTensor, typeof(DOrtFillStringTensor));
             OrtGetResizedStringTensorElementBuffer = (DOrtGetResizedStringTensorElementBuffer)Marshal.GetDelegateForFunctionPointer(api_.GetResizedStringTensorElementBuffer, typeof(DOrtGetResizedStringTensorElementBuffer));
             OrtGetStringTensorContent = (DOrtGetStringTensorContent)Marshal.GetDelegateForFunctionPointer(api_.GetStringTensorContent, typeof(DOrtGetStringTensorContent));
@@ -2094,6 +2097,12 @@ namespace Microsoft.ML.OnnxRuntime
         public delegate IntPtr /*(OrtStatus*)*/ DOrtGetTensorMutableData(IntPtr /*(OrtValue*)*/ value, out IntPtr /* (void**)*/ dataBufferHandle);
 
         public static DOrtGetTensorMutableData OrtGetTensorMutableData;
+
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate IntPtr /*(OrtStatus*)*/ DOrtGetTensorSizeInBytes(IntPtr /* const struct OrtValue*/ ortValue,
+                                  out UIntPtr /* size_t* */ tensorSizeInBytes);
+
+        public static DOrtGetTensorSizeInBytes OrtGetTensorSizeInBytes;
 
         /// \param value A tensor created from OrtCreateTensor... function.
         /// \param len total data length, not including the trailing '\0' chars.

--- a/csharp/src/Microsoft.ML.OnnxRuntime/OrtValue.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OrtValue.shared.cs
@@ -313,6 +313,17 @@ namespace Microsoft.ML.OnnxRuntime
 #endif
 
         /// <summary>
+        /// This API computes and returns the size of the tensor data in bytes.
+        /// </summary>
+        /// <returns>size of the tensor data in bytes</returns>
+        public long GetTensorSizeInBytes()
+        {
+            // The native API verifies that this is a non-string tensor
+            NativeApiStatus.VerifySuccess(NativeMethods.OrtGetTensorSizeInBytes(Handle, out UIntPtr size));
+            return (long)size;
+        }
+
+        /// <summary>
         /// Fetch string tensor element buffer pointer at the specified index,
         /// convert/copy to UTF-16 char[] and return a ReadOnlyMemory{char} instance.
         ///

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/OrtValueTests.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/OrtValueTests.cs
@@ -153,6 +153,8 @@ namespace Microsoft.ML.OnnxRuntime.Tests
 
             // Verify contained data
             Assert.Equal(originalData.ToArray(), tensor.GetTensorDataAsSpan<T>().ToArray());
+            var byteData = tensor.GetTensorMutableRawData();
+            Assert.Equal(byteData.Length, tensor.GetTensorSizeInBytes());
         }
 
         [Fact(DisplayName = "CreateTensorOverManagedBuffer")]
@@ -278,7 +280,8 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             // Must return always 2 for map since we have two ort values
             Assert.Equal(2, map.GetValueCount());
 
-            map.ProcessMap((keys, values) => {
+            map.ProcessMap((keys, values) =>
+            {
                 Assert.Equal(OnnxValueType.ONNX_TYPE_TENSOR, keys.OnnxType);
                 Assert.Equal(OnnxValueType.ONNX_TYPE_TENSOR, values.OnnxType);
                 Assert.Equal(ml_data_1, keys.GetTensorDataAsSpan<long>().ToArray());

--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -1006,6 +1006,13 @@ class OrtValue:
         """
         return self._ortvalue.element_type()
 
+    def tensor_size_in_bytes(self) -> int:
+        """
+        Returns the size of the data in the OrtValue in bytes
+        if the OrtValue is a tensor.
+        """
+        return self._ortvalue.tensor_size_in_bytes()
+
     def has_value(self) -> bool:
         """
         Returns True if the OrtValue corresponding to an

--- a/onnxruntime/python/onnxruntime_pybind_ortvalue.cc
+++ b/onnxruntime/python/onnxruntime_pybind_ortvalue.cc
@@ -327,6 +327,9 @@ void addOrtValueMethods(pybind11::module& m) {
            "This integer is one type defined by ONNX TensorProto_DataType "
            "(such as onnx.TensorProto.FLOAT)."
            "Raises an exception in any other case.")
+      .def("tensor_size_in_bytes", [](const OrtValue* ort_value) -> size_t {
+        ORT_ENFORCE(ort_value->IsTensor(), "Only OrtValues that are Tensors are currently supported");
+        return ort_value->Get<Tensor>().SizeInBytes(); }, "Returns tensor size in bytes.")
       .def("has_value", [](const OrtValue* ort_value) -> bool { return ort_value->IsAllocated(); })
       .def("is_tensor", [](const OrtValue* ort_value) -> bool { return ort_value->IsTensor(); })
       .def("is_sparse_tensor", [](const OrtValue* ort_value) -> bool { return ort_value->IsSparseTensor(); })

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -1382,6 +1382,8 @@ class TestInferenceSession(unittest.TestCase):
         self.assertEqual(ortvalue1.shape(), [3, 2])
         self.assertEqual(ortvalue1.data_type(), "tensor(float)")
         self.assertEqual(ortvalue1.is_tensor(), True)
+        # Assumes float32 and shape {3, 2} as above
+        self.assertEqual(ortvalue1.tensor_size_in_bytes(), 4 * 2 * 3)
         self.assertTrue(np.array_equal(ortvalue1.numpy(), numpy_arr_input))
 
         # Pass in the constructed OrtValue to a session via Run() and check results


### PR DESCRIPTION
### Description
Expose and test GetTensorSizeInBytes in C# and Python

### Motivation and Context

https://github.com/microsoft/onnxruntime/issues/24680
