### PR TITLE
Add telemetry for logging GPU and NPU driver information in ONNX Runtime

### DIFF
--- a/onnxruntime/core/platform/telemetry.cc
+++ b/onnxruntime/core/platform/telemetry.cc
@@ -89,4 +89,12 @@ void Telemetry::LogExecutionProviderEvent(LUID* adapterLuid) const {
   ORT_UNUSED_PARAMETER(adapterLuid);
 }
 
+void Telemetry::LogDriverInfoEvent(const std::string_view device_class,
+                                   const std::wstring_view& driver_names,
+                                   const std::wstring_view& driver_versions) const {
+  ORT_UNUSED_PARAMETER(device_class);
+  ORT_UNUSED_PARAMETER(driver_names);
+  ORT_UNUSED_PARAMETER(driver_versions);
+}
+
 }  // namespace onnxruntime

--- a/onnxruntime/core/platform/telemetry.h
+++ b/onnxruntime/core/platform/telemetry.h
@@ -69,6 +69,10 @@ class Telemetry {
 
   virtual void LogExecutionProviderEvent(LUID* adapterLuid) const;
 
+  virtual void LogDriverInfoEvent(const std::string_view device_class,
+                                  const std::wstring_view& driver_names,
+                                  const std::wstring_view& driver_versions) const;
+
  private:
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(Telemetry);
 };

--- a/onnxruntime/core/platform/windows/device_discovery.cc
+++ b/onnxruntime/core/platform/windows/device_discovery.cc
@@ -279,7 +279,7 @@ std::unordered_map<uint64_t, DeviceInfo> GetDeviceInfoSetupApi(const std::unorde
                              nullptr, &type,
                              reinterpret_cast<LPBYTE>(driver_version),
                              &str_size) == ERROR_SUCCESS &&
-                             type == REG_SZ) {
+            type == REG_SZ) {
           // Ensure proper null termination of a string retrieved from the Windows Registry API.
           driver_version[(str_size / sizeof(wchar_t)) - 1] = 0;
           driver_version_str = driver_version;

--- a/onnxruntime/core/platform/windows/telemetry.cc
+++ b/onnxruntime/core/platform/windows/telemetry.cc
@@ -385,4 +385,21 @@ void WindowsTelemetry::LogExecutionProviderEvent(LUID* adapterLuid) const {
                     TraceLoggingUInt32(adapterLuid->HighPart, "adapterLuidHighPart"));
 }
 
+void WindowsTelemetry::LogDriverInfoEvent(const std::string_view device_class, const std::wstring_view& driver_names, const std::wstring_view& driver_versions) const {
+  if (global_register_count_ == 0 || enabled_ == false)
+    return;
+
+  TraceLoggingWrite(telemetry_provider_handle,
+                    "DriverInfo",
+                    TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
+                    TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+                    TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+                    TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+                    // Telemetry info
+                    TraceLoggingUInt8(0, "schemaVersion"),
+                    TraceLoggingString(device_class.data(), "deviceClass"),
+                    TraceLoggingWideString(driver_names.data(), "driverNames"),
+                    TraceLoggingWideString(driver_versions.data(), "driverVersions"));
+}
+
 }  // namespace onnxruntime

--- a/onnxruntime/core/platform/windows/telemetry.h
+++ b/onnxruntime/core/platform/windows/telemetry.h
@@ -60,6 +60,10 @@ class WindowsTelemetry : public Telemetry {
 
   void LogExecutionProviderEvent(LUID* adapterLuid) const override;
 
+  void LogDriverInfoEvent(const std::string_view device_class,
+                          const std::wstring_view& driver_names,
+                          const std::wstring_view& driver_versions) const override;
+
   using EtwInternalCallback = std::function<void(LPCGUID SourceId, ULONG IsEnabled, UCHAR Level,
                                                  ULONGLONG MatchAnyKeyword, ULONGLONG MatchAllKeyword,
                                                  PEVENT_FILTER_DESCRIPTOR FilterData, PVOID CallbackContext)>;


### PR DESCRIPTION
### Description
This feature enhances telemetry by gathering and logging driver information for GPU and NPU devices detected on Windows systems. The implementation includes:

- **Driver Information Collection**:
  - Introduced a `device_version_info` map to categorize driver information by device type (GPU or NPU).
  - For each detected device:
    - Queries the Windows Registry for driver version information using `RegQueryValueExW`.
    - Collects driver names (device descriptions) and versions into the appropriate device type category.

- **Telemetry Logging**:
  - Calls `LogDriverInfoEvent` with the following parameters:
    - `device_class`: Indicates the device type ("GPU" or "NPU").
    - `driver_names`: Comma-separated list of driver names as wide strings.
    - `driver_versions`: Comma-separated list of driver versions as wide strings.

### Motivation and Context
Having telemetry for GPU and NPU driver information is essential for monitoring and diagnosing performance issues related between driver versions.


### Performance and Testing
This change was tested on Windows with a variety of sample apps along with onnxruntime_test_all
and onnxruntime_perf_test
The code adds an additional 25-30 microseconds for NPU/GPU that is enumerated.