### PR TITLE
[QNN EP] Add Support for MaxPool rank-3 input QNN EP

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/pool_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/pool_op_builder.cc
@@ -59,8 +59,30 @@ Status PoolOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
 
   std::vector<uint32_t> input_shape;
   ORT_RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(inputs[0].node_arg, input_shape), "Cannot get shape");
-  if (input_shape.size() != 4) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "QNN Pool2D only support 2D!");
+
+  bool is1d = (input_shape.size() == 3);
+  if (!is1d && input_shape.size() != 4) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "QNN Pool only supports rank 3 or 4!");
+  }
+
+  NodeAttrHelper node_helper(node_unit);
+
+  if (is1d) {
+    auto kernel_shape = node_helper.Get("kernel_shape", std::vector<int32_t>{});
+    ORT_RETURN_IF_NOT(kernel_shape.size() == 1, "QNN Pool1D: kernel_shape must have length 1!");
+
+    auto pads = node_helper.Get("pads", std::vector<int32_t>{});
+    ORT_RETURN_IF_NOT(pads.size() == 2, "QNN Pool1D: pads must have length 2!");
+
+    auto strides = node_helper.Get("strides", std::vector<int32_t>{});
+    ORT_RETURN_IF_NOT(strides.empty() || strides.size() == 1, "QNN Pool1D: strides must have length 1 or omitted!");
+
+    auto dilations = node_helper.Get("dilations", std::vector<int32_t>{1});
+    ORT_RETURN_IF_NOT(dilations.size() == 1, "QNN Pool1D: dilations must have length 1 or omitted!");
+  }
+  else {
+    auto dilations = node_helper.Get("dilations", std::vector<int32_t>{1, 1});
+    ORT_RETURN_IF_NOT(dilations.size() == 2, "QNN Pool2D: dilations must have length 2 or omitted!");
   }
 
   if (node_unit.Outputs().size() > 1) {
@@ -71,12 +93,6 @@ Status PoolOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
   // Onnx GlobalMaxPool doesn't have any attributes
   if (op_type == "GlobalMaxPool") {
     return Status::OK();
-  }
-
-  NodeAttrHelper node_helper(node_unit);
-  auto dilation_values = node_helper.Get("dilations", std::vector<int32_t>{1, 1});
-  if (dilation_values != std::vector<int32_t>{1, 1}) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "QNN does not support Dilation attribute");
   }
 
   if (op_type == "MaxPool" || op_type == "AveragePool") {
@@ -94,19 +110,49 @@ Status PoolOpBuilder::SetCommonPoolParams(const NodeAttrHelper& node_helper,
                                           int32_t& ceil_mode,
                                           std::vector<uint32_t>&& input_shape,
                                           std::vector<uint32_t>&& output_shape) const {
-  filter_size = node_helper.Get("kernel_shape", std::vector<uint32_t>{1, 1});
-  ORT_RETURN_IF_NOT(filter_size.size() == 2, "QNN only support kernel_shape with shape[2].");
+  {
+    auto raw_filter_size = node_helper.Get("kernel_shape", std::vector<uint32_t>{1, 1});
+    if (raw_filter_size.size() == 1) {
+      filter_size = {1, raw_filter_size[0]};
+    } else {
+      filter_size = raw_filter_size;
+    }
+  }
+  ORT_RETURN_IF_NOT(filter_size.size() == 2,
+                    "QNN only support kernel_shape with shape[2].");
 
-  strides = node_helper.Get("strides", std::vector<uint32_t>{1, 1});
-  ORT_RETURN_IF_NOT(strides.size() == 2, "QNN only support strides with shape[2].");
+  {
+    auto raw_strides = node_helper.Get("strides", std::vector<uint32_t>{1, 1});
+    if (raw_strides.size() == 1) {
+      strides = {1, raw_strides[0]};
+    } else {
+      strides = raw_strides;
+    }
+  }
+  ORT_RETURN_IF_NOT(strides.size() == 2,
+                    "QNN only support strides with shape[2].");
 
-  pad_amount = node_helper.Get("pads", std::vector<uint32_t>{0, 0, 0, 0});
+  {
+    auto raw_pad_amount = node_helper.Get("pads", std::vector<uint32_t>{0, 0, 0, 0});
+    if (raw_pad_amount.size() == 2) {
+      pad_amount = {0, raw_pad_amount[0], 0, raw_pad_amount[1]};
+    } else {
+      pad_amount = raw_pad_amount;
+    }
+  }
+
   auto auto_pad = node_helper.Get("auto_pad", std::string("NOTSET"));
   ORT_RETURN_IF(auto_pad != "NOTSET" && auto_pad != "SAME_LOWER" && auto_pad != "SAME_UPPER",
                 "QNN Pool operators do not support 'auto_pad' value: ", auto_pad.c_str());
 
   if (auto_pad.compare("NOTSET") != 0) {
-    std::vector<uint32_t> dilations = node_helper.Get("dilations", std::vector<uint32_t>{1, 1});
+    std::vector<uint32_t> dilations;
+    auto raw_dilations = node_helper.Get("dilations", std::vector<uint32_t>{1, 1});
+    if (raw_dilations.size() == 1) {
+      dilations = {1, raw_dilations[0]};
+    } else {
+      dilations = raw_dilations;
+    }
 
     auto total_pads_0 = (output_shape[1] - 1) * strides[0] + (filter_size[0] - 1) * dilations[0] + 1 - input_shape[1];
     auto total_pads_1 = (output_shape[2] - 1) * strides[1] + (filter_size[1] - 1) * dilations[1] + 1 - input_shape[2];
@@ -144,6 +190,36 @@ void SetPoolParam(const NodeUnit& node_unit,
   qnn_model_wrapper.AddParamWrapper(std::move(qnn_param));
 }
 
+std::vector<uint32_t> ComputePoolOutputShape(
+    const std::vector<uint32_t>& input_shape,   // {N, H, W, C}
+    const std::vector<uint32_t>& kernel_shape,  // {k_h, k_w}
+    const std::vector<uint32_t>& strides,       // {s_h, s_w}
+    const std::vector<uint32_t>& pads) {
+  assert(input_shape.size() == 4 &&
+         kernel_shape.size() == 2 &&
+         strides.size() == 2 &&
+         pads.size() == 4);
+
+  const uint32_t N = input_shape[0];
+  const uint32_t H = input_shape[1];
+  const uint32_t W = input_shape[2];
+  const uint32_t C = input_shape[3];
+
+  // pad the spatial dims
+  uint32_t padded_H = H + pads[0] + pads[2];
+  uint32_t padded_W = W + pads[1] + pads[3];
+
+  // floor-mode on NHWC
+  uint32_t out_H = (padded_H < kernel_shape[0])
+                       ? 0
+                       : (padded_H - kernel_shape[0]) / strides[0] + 1;
+  uint32_t out_W = (padded_W < kernel_shape[1])
+                       ? 0
+                       : (padded_W - kernel_shape[1]) / strides[1] + 1;
+
+  return {N, out_H, out_W, C};
+}
+
 Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
                                                   const NodeUnit& node_unit,
                                                   std::vector<std::string>&& input_names,
@@ -154,7 +230,45 @@ Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
   const auto& inputs = node_unit.Inputs();
   std::vector<uint32_t> input_shape;
   ORT_RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(inputs[0].node_arg, input_shape), "Cannot get shape");
-  ORT_RETURN_IF_NOT(input_shape.size() == 4, "Input should have 4 dimension NCHW.");
+
+  const auto& reshape_input = node_unit.Inputs()[0];
+  TensorInfo reshape_input_info = {};
+  ORT_RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(reshape_input, reshape_input_info));
+
+  bool needs_reshape = false;
+  const std::string reshape4d = input_names[0] + "_pre_reshape";
+  if (input_shape.size() == 3) {
+    needs_reshape = true;
+    // build new_shape = {N, 1, C, L}
+    std::vector<uint32_t> new_shape = {
+        input_shape[0],
+        1,
+        input_shape[1],
+        input_shape[2]};
+
+    const std::string reshape_node_name = "pre_reshape";
+    QnnTensorWrapper rw(
+        reshape4d,
+        QNN_TENSOR_TYPE_NATIVE,
+        reshape_input_info.qnn_data_type,
+        reshape_input_info.quant_param.Copy(),
+        std::move(new_shape));
+    ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(rw)),
+                      "Failed to add reshape-4d tensor.");
+    ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
+                          reshape_node_name,
+                          QNN_OP_PACKAGE_NAME_QTI_AISW,
+                          "Reshape",
+                          {input_names[0]},
+                          {reshape4d},
+                          {},
+                          do_op_validation),
+                      "Failed to create reshape-4d node.");
+    input_names[0] = reshape4d;
+    input_shape = {input_shape[0], 1, input_shape[1], input_shape[2]};
+  }
+
+  ORT_RETURN_IF_NOT(input_shape.size() == 4, "Input should have 4 dims NCHW or 3 dims for 1D pooling.");
   // Default value for GlobalAveragePool
   // Pool use filter & stride with shape [filter_height, filter_width]
   // With layout transformer, the input has shape  [batch, height, width, channel],
@@ -191,6 +305,22 @@ Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
     ORT_RETURN_IF_ERROR(SetCommonPoolParams(node_helper, filter_size, pad_amount, stride, ceil_mode,
                                             std::move(input_shape), std::move(output_shape)));
   }
+
+  std::vector<uint32_t> onnx_in_shape;
+  ORT_RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(inputs[0].node_arg, onnx_in_shape), "Cannot get shape");
+  // Reshaped input rank-4 for MaxPool
+  if (onnx_in_shape.size() == 3) {
+    onnx_in_shape = {onnx_in_shape[0],
+                     1,
+                     onnx_in_shape[1],
+                     onnx_in_shape[2]};
+  }
+
+  // Calculate MaxPool output for rank-4 when input is rank 3
+  auto pooled_shape = ComputePoolOutputShape(onnx_in_shape,
+                                             filter_size,
+                                             stride,
+                                             pad_amount);
 
   SetPoolParam(node_unit, QNN_OP_POOL_MAX_2D_PARAM_FILTER_SIZE, std::move(filter_size_dim), std::move(filter_size), param_tensor_names, qnn_model_wrapper);
   SetPoolParam(node_unit, QNN_OP_POOL_MAX_2D_PARAM_PAD_AMOUNT, std::move(pad_amount_dim), std::move(pad_amount), param_tensor_names, qnn_model_wrapper);
@@ -229,12 +359,65 @@ Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
     qnn_model_wrapper.AddParamWrapper(std::move(count_pad_for_edges_param));
   }
 
-  ORT_RETURN_IF_ERROR(ProcessOutputs(qnn_model_wrapper, node_unit,
-                                     std::move(input_names),
-                                     std::move(param_tensor_names),
-                                     logger,
-                                     do_op_validation,
-                                     GetQnnOpType(op_type)));
+  if (!needs_reshape) {
+    ORT_RETURN_IF_ERROR(ProcessOutputs(qnn_model_wrapper, node_unit,
+                                       std::move(input_names),
+                                       std::move(param_tensor_names),
+                                       logger,
+                                       do_op_validation,
+                                       GetQnnOpType(op_type)));
+
+    return Status::OK();
+  }
+  const auto& outputs = node_unit.Outputs();
+  const std::string real_out = outputs[0].node_arg.Name();
+  const std::string pool_name = "poolmax2d";
+  const std::string pool_out = real_out + "_post_reshape";
+  const std::string post_reshape_node_name = "post_reshape";
+  const std::string qnn_op = GetQnnOpType(op_type);
+  TensorInfo output_info{};
+  ORT_RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Outputs()[0], output_info));
+  bool is_graph_output = qnn_model_wrapper.IsGraphOutput(real_out);
+  Qnn_TensorType_t tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
+  QnnTensorWrapper pool_tensor(
+      pool_out,
+      QNN_TENSOR_TYPE_NATIVE,
+      reshape_input_info.qnn_data_type,
+      output_info.quant_param.Copy(),
+      std::move(pooled_shape));
+
+  ORT_RETURN_IF_NOT(
+      qnn_model_wrapper.AddTensorWrapper(std::move(pool_tensor)),
+      "Failed to add tensor for pool_out");
+
+  ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
+                        pool_name,
+                        QNN_OP_PACKAGE_NAME_QTI_AISW,
+                        qnn_op,
+                        {reshape4d},
+                        {pool_out},
+                        std::move(param_tensor_names),
+                        do_op_validation),
+                    "Failed to create QNN Pool node for rank-3 input.");
+
+  std::vector<uint32_t> final_shape3d = output_info.shape;
+  QnnTensorWrapper reshape_back_tensor(
+      real_out,
+      tensor_type,
+      output_info.qnn_data_type,
+      output_info.quant_param.Copy(),
+      std::move(final_shape3d));
+
+  ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(reshape_back_tensor)), "Failed to add tensor.");
+  ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
+                        post_reshape_node_name,
+                        QNN_OP_PACKAGE_NAME_QTI_AISW,
+                        "Reshape",
+                        {pool_out},
+                        {real_out},
+                        {},
+                        do_op_validation),
+                    "Failed to create reshape-back node.");
 
   return Status::OK();
 }

--- a/onnxruntime/test/providers/qnn/pool_op_test.cpp
+++ b/onnxruntime/test/providers/qnn/pool_op_test.cpp
@@ -188,6 +188,38 @@ TEST_F(QnnHTPBackendTests, MaxPool_Large_Input_HTP_u8) {
                             QDQTolerance(0.00417f));
 }
 
+// 1-D MaxPool HTP test for rank-3 without ceil
+TEST_F(QnnHTPBackendTests, MaxPool_Rank3_HTP_u8) {
+  RunQDQPoolOpTest<uint8_t>(
+      "MaxPool",
+      TestInputDef<float>({1, 3, 3}, false, -10.0f, 10.0f),
+      // A single 1-D kernel of length 3
+      {utils::MakeAttribute("kernel_shape", std::vector<int64_t>{3}),
+       utils::MakeAttribute("strides", std::vector<int64_t>{3}),
+       // 1-D pad: only two values
+       utils::MakeAttribute("pads", std::vector<int64_t>{0, 0}),
+       utils::MakeAttribute("dilations", std::vector<int64_t>{1}),
+       utils::MakeAttribute("ceil_mode", static_cast<int64_t>(0)),
+       utils::MakeAttribute("storage_order", static_cast<int64_t>(0)),
+       utils::MakeAttribute("auto_pad", "NOTSET")},
+      ExpectedEPNodeAssignment::All);
+}
+
+// 1-D MaxPool HTP test for rank-3 with ceil_mode=1
+TEST_F(QnnHTPBackendTests, MaxPool_Rank3_Ceil_HTP_u8) {
+  RunQDQPoolOpTest<uint8_t>(
+      "MaxPool",
+      TestInputDef<float>({1, 3, 3}, false, -10.0f, 10.0f),
+      {utils::MakeAttribute("kernel_shape", std::vector<int64_t>{3}),
+       utils::MakeAttribute("strides", std::vector<int64_t>{3}),
+       utils::MakeAttribute("pads", std::vector<int64_t>{0, 0}),
+       utils::MakeAttribute("dilations", std::vector<int64_t>{1}),
+       utils::MakeAttribute("ceil_mode", static_cast<int64_t>(1)),
+       utils::MakeAttribute("storage_order", static_cast<int64_t>(0)),
+       utils::MakeAttribute("auto_pad", "NOTSET")},
+      ExpectedEPNodeAssignment::All);
+}
+
 TEST_F(QnnHTPBackendTests, MaxPool_Ceil_HTP_u8) {
   RunQDQPoolOpTest<uint8_t>("MaxPool",
                             TestInputDef<float>({1, 2, 3, 3}, false, -10.0f, 10.0f),  // Dynamic input with range [-10, 10]


### PR DESCRIPTION
- Currently QNN EP only supports MaxPool for rank 4.
- This change adds support for rank 3 input by adding Reshapes before and after the Op to ensure that the MaxPool gets input rank 4.
- Updated all attributes if converting rank 3 input to rank 4 by updating stride, pads, dilations and kernel size.
- Added unit tests which takes input rank 3 to validate MaxPool on NPU.

### Description
This change extends the support of QNN EP's MaxPool operation to handle input tensors of rank 3. To achieve this, Reshape Ops are added before and after the MaxPool Op to ensure that the input to MaxPool is always of rank 4, as required. Additionally, the attributes such as stride, pads, dilations, and kernel size are updated accordingly to accommodate the conversion of rank 3 inputs to rank 4. Unit tests have been added to validate the functionality of MaxPool on NPU with rank 3 inputs.



### Motivation and Context
This change is required to enhance the flexibility and usability of QNN EP's MaxPool operation by supporting a broader range of input tensor ranks. Previously, the operation was limited to only supporting rank 4 inputs, which restricted the support in certain scenarios. By adding support for rank 3 inputs, this change solves the problem of limited compatibility and enhances the overall functionality and makes sure that the MaxPool op offloads to the NPU (QNN HTP Backend)


