### PR TITLE
Publish symbols to MSDL

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
@@ -34,7 +34,7 @@ steps:
     - ${{if or(eq(variables['Build.SourceBranch'], 'refs/heads/snnn/symbol'), startsWith(variables['Build.SourceBranch'], 'refs/heads/rel-'))}}:
       - template: publish-symbolrequestprod-api.yml
         parameters:
-          ${{if eq(variables['Build.SourceBranch'], 'refs/heads/main')}}:
+          ${{if eq(variables['Build.SourceBranch'], 'refs/heads/snnn/symbol')}}:
             symbolExpiryTime: 60
           includePublicSymbolServer: true
           symbolsFolder: '$(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\'

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
@@ -31,7 +31,7 @@ parameters:
   default: true
 
 steps:
-    - ${{if or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/rel-'))}}:
+    - ${{if or(eq(variables['Build.SourceBranch'], 'refs/heads/symbol'), startsWith(variables['Build.SourceBranch'], 'refs/heads/rel-'))}}:
       - template: publish-symbolrequestprod-api.yml
         parameters:
           ${{if eq(variables['Build.SourceBranch'], 'refs/heads/main')}}:

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
@@ -31,7 +31,7 @@ parameters:
   default: true
 
 steps:
-    - ${{if or(eq(variables['Build.SourceBranch'], 'refs/heads/symbol'), startsWith(variables['Build.SourceBranch'], 'refs/heads/rel-'))}}:
+    - ${{if or(eq(variables['Build.SourceBranch'], 'refs/heads/snnn/symbol'), startsWith(variables['Build.SourceBranch'], 'refs/heads/rel-'))}}:
       - template: publish-symbolrequestprod-api.yml
         parameters:
           ${{if eq(variables['Build.SourceBranch'], 'refs/heads/main')}}:

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
@@ -34,10 +34,10 @@ steps:
     - ${{if or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/rel-'))}}:
       - template: publish-symbolrequestprod-api.yml
         parameters:
+          ${{if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}：
+            symbolExpiryTime: 60
           includePublicSymbolServer: true
           symbolsFolder: '$(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\'
-          ${{if eq(variables['Build.SourceBranch'], 'refs/heads/main')}}
-            symbolExpiryTime: 60
           symbolsArtifactName: ${{parameters.artifactNameNoVersionString}}
           symbolsVersion: $(Build.BuildId)
           symbolProject: 'ONNX Runtime'         

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
@@ -34,7 +34,7 @@ steps:
     - ${{if or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/rel-'))}}:
       - template: publish-symbolrequestprod-api.yml
         parameters:
-          ${{if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}：
+          ${{if eq(variables['Build.SourceBranch'], 'refs/heads/main')}}:
             symbolExpiryTime: 60
           includePublicSymbolServer: true
           symbolsFolder: '$(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\'

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
@@ -31,10 +31,10 @@ parameters:
   default: true
 
 steps:
-    - ${{if or(eq(variables['Build.SourceBranch'], 'refs/heads/snnn/symbol'), startsWith(variables['Build.SourceBranch'], 'refs/heads/rel-'))}}:
+    - ${{if or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/rel-'))}}:
       - template: publish-symbolrequestprod-api.yml
         parameters:
-          ${{if eq(variables['Build.SourceBranch'], 'refs/heads/snnn/symbol')}}:
+          ${{if eq(variables['Build.SourceBranch'], 'refs/heads/main')}}:
             symbolExpiryTime: 60
           includePublicSymbolServer: true
           symbolsFolder: '$(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\'

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
@@ -31,19 +31,16 @@ parameters:
   default: true
 
 steps:
-    - task: PublishSymbols@2
-      displayName: 'Publish Build Debug Symbols'
-      condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/rel-')))
-      inputs:
-        SymbolsFolder: '$(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\'
-        SearchPattern: '*.pdb'
-        IndexSources: true
-        PublishSymbols: true
-        SymbolServerType: 'TeamServices'
-        SymbolExpirationInDays: '36530'
-        IndexableFileFormats: 'Default'
-        DetailedLog: true
-        SymbolsArtifactName: 'Symbols_${{parameters.artifactNameNoVersionString}}_$(Build.BuildId)'
+    - ${{if or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/rel-'))}}:
+      - template: publish-symbolrequestprod-api.yml
+        parameters:
+          includePublicSymbolServer: true
+          symbolsFolder: '$(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\'
+          ${{if eq(variables['Build.SourceBranch'], 'refs/heads/main')}}
+            symbolExpiryTime: 60
+          symbolsArtifactName: ${{parameters.artifactNameNoVersionString}}
+          symbolsVersion: $(Build.BuildId)
+          symbolProject: 'ONNX Runtime'         
 
     - task: CmdLine@2
       displayName: 'Copy build artifacts for zipping'

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
@@ -40,7 +40,8 @@ steps:
           symbolsFolder: '$(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\'
           symbolsArtifactName: ${{parameters.artifactNameNoVersionString}}
           symbolsVersion: $(Build.BuildId)
-          symbolProject: 'ONNX Runtime'         
+          symbolProject: 'ONNX Runtime'
+          subscription: 'OnnxrunTimeCodeSign_20240611'          
 
     - task: CmdLine@2
       displayName: 'Copy build artifacts for zipping'

--- a/tools/ci_build/github/azure-pipelines/templates/publish-symbolrequestprod-api.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/publish-symbolrequestprod-api.yml
@@ -1,0 +1,90 @@
+# This file was copied from https://github.com/microsoft/devhome/blob/main/build/templates/publish-symbolrequestprod-api.yml#L71
+parameters:
+  - name: includePublicSymbolServer
+    type: boolean
+    default: false
+  - name: symbolsFolder
+    type: string
+    default: '$(Build.SourcesDirectory)/bin'
+  - name: searchPattern
+    type: string
+    default: '**/*.pdb'
+  - name: jobName
+    type: string
+    default: PublishSymbols
+  - name: indexSources
+    type: boolean
+    default: true
+  - name: symbolExpiryTime
+    type: string
+    default: 36530 # This is the default from PublishSymbols@2
+  - name: symbolsArtifactName
+    type: string
+    default: ''
+  - name: symbolsVersion
+    type: string
+    default: ''
+  - name: symbolProject
+    type: string
+  - name: subscription
+    type: string
+
+steps:
+  - powershell: |-
+      Get-PackageProvider -Name NuGet -ForceBootstrap
+      Install-Module -Verbose -AllowClobber -Force Az.Accounts, Az.Storage, Az.Network, Az.Resources, Az.Compute
+    displayName: Install Azure Module Dependencies
+
+  # Transit the Azure token from the Service Connection into a secret variable for the rest of the pipeline to use.
+  - task: AzurePowerShell@5
+    displayName: Generate an Azure Token
+    inputs:
+      azureSubscription: ${{ parameters.subscription }}
+      azurePowerShellVersion: LatestVersion
+      pwsh: true
+      ScriptType: InlineScript
+      Inline: |-
+        $AzToken = (Get-AzAccessToken -ResourceUrl api://30471ccf-0966-45b9-a979-065dbedb24c1).Token
+        Write-Host "##vso[task.setvariable variable=SymbolAccessToken;issecret=true]$AzToken"
+
+  - task: PublishSymbols@2
+    displayName: Publish Symbols (to current Azure DevOps tenant)
+    continueOnError: True
+    inputs:
+      SearchPattern: ${{ parameters.searchPattern }}
+      IndexSources: ${{ parameters.indexSources }}
+      DetailedLog: true
+      SymbolsMaximumWaitTime: 30
+      SymbolServerType: 'TeamServices'
+      SymbolsProduct: 'onnxruntime'
+      SymbolsVersion: ${{ parameters.symbolsVersion }}
+      SymbolsArtifactName: '${{ parameters.symbolsArtifactName }}_${{ parameters.symbolsVersion }}'
+      SymbolExpirationInDays: ${{ parameters.symbolExpiryTime }}
+    env:
+      LIB: $(Build.SourcesDirectory)
+
+  - pwsh: |-
+      # Prepare the defaults for IRM
+      $PSDefaultParameterValues['Invoke-RestMethod:Headers'] = @{ Authorization = "Bearer $(SymbolAccessToken)" }
+      $PSDefaultParameterValues['Invoke-RestMethod:ContentType'] = "application/json"
+      $PSDefaultParameterValues['Invoke-RestMethod:Method'] = "POST"
+
+      $BaseUri = "https://symbolrequestprod.trafficmanager.net/projects/${{ parameters.symbolProject }}/requests"
+
+      # Prepare the request
+      $expiration = (Get-Date).Add([TimeSpan]::FromDays(${{ parameters.symbolExpiryTime }}))
+      $createRequestBody = @{
+        requestName = "${{ parameters.symbolsArtifactName }}_${{ parameters.symbolsVersion }}";
+        expirationTime = $expiration.ToString();
+      }
+      Write-Host "##[debug]Starting request $($createRequestBody.requestName) with expiration date of $($createRequestBody.expirationTime)"
+      Invoke-RestMethod -Uri "$BaseUri" -Body ($createRequestBody | ConvertTo-Json -Compress) -Verbose
+
+      # Request symbol publication
+      $publishRequestBody = @{
+        publishToInternalServer = $true;
+        publishToPublicServer = $${{ parameters.includePublicSymbolServer }};
+      }
+      Write-Host "##[debug]Submitting request $($createRequestBody.requestName) ($($publishRequestBody | ConvertTo-Json -Compress))"
+      Invoke-RestMethod -Uri "$BaseUri/$($createRequestBody.requestName)" -Body ($publishRequestBody | ConvertTo-Json -Compress) -Verbose
+    displayName: Publish Symbols using internal REST API

--- a/tools/ci_build/github/azure-pipelines/templates/publish-symbolrequestprod-api.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/publish-symbolrequestprod-api.yml
@@ -69,7 +69,7 @@ steps:
       $PSDefaultParameterValues['Invoke-RestMethod:ContentType'] = "application/json"
       $PSDefaultParameterValues['Invoke-RestMethod:Method'] = "POST"
 
-      $BaseUri = "https://symbolrequestprod.trafficmanager.net/projects/${{ parameters.symbolProject }}/requests"
+      $BaseUri = "https://symbolrequestppe.trafficmanager.net/projects/${{ parameters.symbolProject }}/requests"
 
       # Prepare the request
       $expiration = (Get-Date).Add([TimeSpan]::FromDays(${{ parameters.symbolExpiryTime }}))

--- a/tools/ci_build/github/azure-pipelines/templates/publish-symbolrequestprod-api.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/publish-symbolrequestprod-api.yml
@@ -69,7 +69,7 @@ steps:
       $PSDefaultParameterValues['Invoke-RestMethod:ContentType'] = "application/json"
       $PSDefaultParameterValues['Invoke-RestMethod:Method'] = "POST"
 
-      $BaseUri = "https://symbolrequestppe.trafficmanager.net/projects/${{ parameters.symbolProject }}/requests"
+      $BaseUri = "https://symbolrequestprod.trafficmanager.net/projects/${{ parameters.symbolProject }}/requests"
 
       # Prepare the request
       $expiration = (Get-Date).Add([TimeSpan]::FromDays(${{ parameters.symbolExpiryTime }}))


### PR DESCRIPTION
### Description
Publish Windows debug symbols to not only Azure DevOps but also msdl.microsoft.com . See https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/symbol-path for how to consume it. 

### Motivation and Context