### PR TITLE
[QNN EP] Fix inconsistent inputs for graph

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_model.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.cc
@@ -331,7 +331,7 @@ Status QnnModel::SetupTensors(std::vector<QnnTensorInfo>& qnn_tensor_infos,
                               bool is_input) {
   if (is_input) {
     // Reserve qnn_tensor_infos according to the number of graph inputs.
-    auto input_count = GetGraphInputNumber();
+    auto input_count = GetGraphInputCount();
     ORT_RETURN_IF(0 == input_count, "Zero input number!");
     qnn_tensor_infos.resize(input_count);
   } else {
@@ -362,13 +362,10 @@ Status QnnModel::SetupTensors(std::vector<QnnTensorInfo>& qnn_tensor_infos,
   //   a discrepancy in the input quantities.
   // If not all inputs are used, erase the empty allocations in qnn_tensor_infos.
   if (is_input) {
-    for (auto iter = qnn_tensor_infos.begin(); iter != qnn_tensor_infos.end();) {
-      if ((*iter).tensor_wrapper == nullptr) {
-        iter = qnn_tensor_infos.erase(iter);
-      } else {
-        ++iter;
-      }
-    }
+    qnn_tensor_infos.erase(std::remove_if(qnn_tensor_infos.begin(),
+                                          qnn_tensor_infos.end(),
+                                          [](QnnTensorInfo qnn_tensor_info) { return qnn_tensor_info.tensor_wrapper == nullptr; }),
+                           qnn_tensor_infos.end());
   }
   return Status::OK();
 }

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.cc
@@ -329,14 +329,15 @@ Status QnnModel::ExecuteGraph(const Ort::KernelContext& context,
 Status QnnModel::SetupTensors(std::vector<QnnTensorInfo>& qnn_tensor_infos,
                               const std::vector<QnnTensorWrapper>& tensor_wrappers,
                               bool is_input) {
+  size_t tensor_count = tensor_wrappers.size();
+  ORT_RETURN_IF(0 == tensor_count, "Zero tensor size!");
   if (is_input) {
-    // Reserve qnn_tensor_infos according to the number of graph inputs.
+    // Resize qnn_tensor_infos according to the number of graph inputs.
     auto input_count = GetGraphInputCount();
-    ORT_RETURN_IF(0 == input_count, "Zero input number!");
+    ORT_RETURN_IF(input_count < tensor_count,
+                  "The count of graph inputs should be at least the count of tensor_wrapper!");
     qnn_tensor_infos.resize(input_count);
   } else {
-    size_t tensor_count = tensor_wrappers.size();
-    ORT_RETURN_IF(0 == tensor_count, "Zero tensor size!");
     qnn_tensor_infos.resize(tensor_count);
   }
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.h
@@ -77,6 +77,11 @@ class QnnModel {
     return it->second;
   }
 
+  // Return the number of graph inputs
+  size_t GetGraphInputNumber() const {
+    return model_input_index_map_.size();
+  }
+
   size_t GetOutputIndex(const std::string& name) const {
     return GetInputOutputIndex(name, outputs_info_);
   }

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.h
@@ -78,7 +78,7 @@ class QnnModel {
   }
 
   // Return the number of graph inputs
-  size_t GetGraphInputNumber() const {
+  size_t GetGraphInputCount() const {
     return model_input_index_map_.size();
   }
 

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -1294,13 +1294,9 @@ TEST_F(QnnHTPBackendTests, AutoEp_PreferNpu) {
 //   to tensor wrappers.
 // - However, these remaining inputs still appear in the graph inputs,
 //   resulting in a discrepancy in the input quantities.
-TEST_F(QnnHTPBackendTests, TestMismatchedGraphInput) {
+TEST_F(QnnHTPBackendTests, TestMismatchedGraphInputAndTensorWrapperCount) {
   onnxruntime::ProviderOptions provider_options;
-#if defined(_WIN32)
-  provider_options["backend_path"] = "QnnHtp.dll";
-#else
-  provider_options["backend_path"] = "libQnnHtp.so";
-#endif
+  provider_options["backend_type"] = "htp";
 
   auto input_defs = {TestInputDef<float>({1, 3, 10, 10}, false, -10.0f, 10.0f),
                      TestInputDef<float>({0}, false, {}),

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -6,6 +6,7 @@
 #include <thread>
 
 #include "core/graph/constants.h"
+#include "core/graph/node_attr_utils.h"
 #include "core/providers/cpu/cpu_provider_factory.h"  // For OrtSessionOptionsAppendExecutionProvider_CPU
 #if BUILD_QNN_EP_STATIC_LIB
 #include "core/providers/qnn/qnn_allocator.h"  // Used by QnnHTPBackendTests.UseHtpSharedMemoryAllocatorForInputs
@@ -1285,6 +1286,38 @@ TEST_F(QnnHTPBackendTests, AutoEp_PreferNpu) {
   ASSERT_ORTSTATUS_OK(Ort::GetApi().UnregisterExecutionProviderLibrary(*ort_env, kQnnExecutionProvider));
 }
 #endif  // defined(WIN32) && !BUILD_QNN_EP_STATIC_LIB
+
+// Test whether QNN EP can handle the case where the number of graph inputs and
+// the number of tensor wrappers do not match.
+// Take Resize op as an example.
+// - Qnn only cares about the 1st input, so the rest of the inputs are not converted
+//   to tensor wrappers.
+// - However, these remaining inputs still appear in the graph inputs,
+//   resulting in a discrepancy in the input quantities.
+TEST_F(QnnHTPBackendTests, TestMismatchedGraphInput) {
+  onnxruntime::ProviderOptions provider_options;
+#if defined(_WIN32)
+  provider_options["backend_path"] = "QnnHtp.dll";
+#else
+  provider_options["backend_path"] = "libQnnHtp.so";
+#endif
+
+  auto input_defs = {TestInputDef<float>({1, 3, 10, 10}, false, -10.0f, 10.0f),
+                     TestInputDef<float>({0}, false, {}),
+                     TestInputDef<float>({4}, true, {1.0f, 1.0f, 2.0f, 2.0f})};
+  auto attrs = {utils::MakeAttribute("mode", "nearest"),
+                utils::MakeAttribute("coordinate_transformation_mode", "asymmetric"),
+                utils::MakeAttribute("nearest_mode", "floor")};
+  RunQnnModelTest(BuildOpTestCase<float>("Resize",
+                                         input_defs,
+                                         {},
+                                         attrs,
+                                         kOnnxDomain),
+                  provider_options,
+                  11,
+                  ExpectedEPNodeAssignment::All,
+                  0.008f);
+}
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 #endif  // !defined(ORT_MINIMAL_BUILD)


### PR DESCRIPTION
### Description

- Match the graph input correctly
- Add GetGraphInputNumber function

### Motivation and Context

- The number of graph inputs and the number of tensor wrappers may not match.
- For example, for ResizeNearestNeighbor op, Qnn only cares about the 1st input, so the rest of the inputs are not converted to tensor wrappers. However, these remaining inputs still appear in the graph inputs, resulting in a discrepancy in the input quantities.