### PR TITLE
[QNN EP] Enable MaxPool Op with "auto_pad" param set as VALID.

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/pool_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/pool_op_builder.cc
@@ -81,7 +81,7 @@ Status PoolOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
 
   if (op_type == "MaxPool" || op_type == "AveragePool") {
     auto auto_pad = node_helper.Get("auto_pad", std::string("NOTSET"));
-    ORT_RETURN_IF(auto_pad != "NOTSET" && auto_pad != "SAME_LOWER" && auto_pad != "SAME_UPPER",
+    ORT_RETURN_IF(auto_pad != "NOTSET" && auto_pad != "SAME_LOWER" && auto_pad != "SAME_UPPER" && auto_pad != "VALID",
                   "QNN Pool operators do not support 'auto_pad' value: ", auto_pad.c_str());
   }
 
@@ -102,7 +102,7 @@ Status PoolOpBuilder::SetCommonPoolParams(const NodeAttrHelper& node_helper,
 
   pad_amount = node_helper.Get("pads", std::vector<uint32_t>{0, 0, 0, 0});
   auto auto_pad = node_helper.Get("auto_pad", std::string("NOTSET"));
-  ORT_RETURN_IF(auto_pad != "NOTSET" && auto_pad != "SAME_LOWER" && auto_pad != "SAME_UPPER",
+  ORT_RETURN_IF(auto_pad != "NOTSET" && auto_pad != "SAME_LOWER" && auto_pad != "SAME_UPPER" && auto_pad != "VALID",
                 "QNN Pool operators do not support 'auto_pad' value: ", auto_pad.c_str());
 
   if (auto_pad.compare("NOTSET") != 0) {

--- a/onnxruntime/test/providers/qnn/pool_op_test.cpp
+++ b/onnxruntime/test/providers/qnn/pool_op_test.cpp
@@ -219,6 +219,19 @@ TEST_F(QnnHTPBackendTests, DISABLED_MaxPool_Large_Input2_Ceil_HTP_u8) {
                             ExpectedEPNodeAssignment::All);
 }
 
+TEST_F(QnnHTPBackendTests, MaxPool_Large_Input3_AutoPadValid_HTP_u8) {
+  RunQDQPoolOpTest<uint8_t>("MaxPool",
+                            TestInputDef<float>({1, 160, 14, 20}, false, -10.0f, 10.0f),  // Dynamic input with range [-10, 10]
+                            {utils::MakeAttribute("kernel_shape", std::vector<int64_t>{2, 2}),
+                             utils::MakeAttribute("strides", std::vector<int64_t>{2, 2}),
+                             utils::MakeAttribute("pads", std::vector<int64_t>{0, 0, 0, 0}),
+                             utils::MakeAttribute("dilations", std::vector<int64_t>{1, 1}),
+                             utils::MakeAttribute("ceil_mode", static_cast<int64_t>(0)),
+                             utils::MakeAttribute("storage_order", static_cast<int64_t>(0)),
+                             utils::MakeAttribute("auto_pad", "VALID")},
+                            ExpectedEPNodeAssignment::All);
+}
+
 // QNN v2.13: Certain large input sizes cause the QNN graph to fail to finalize with error 1002 (QNN_COMMON_ERROR_MEM_ALLOC).
 // Fixed in QNN v2.14.1.
 TEST_F(QnnHTPBackendTests, MaxPool_LargeInput_1Pads_u8) {


### PR DESCRIPTION
Enable MaxPool Op with "auto_pad" param set as VALID.
VALID runs with all pad values set to 0.

### Description
Remove the assert from QNN_EP for MaxPool Op with "auto_pad" as VALID since the Op with this config is supported on QNN backend. 



### Motivation and Context
QNN_EP rejects MaxPool Op with "auto_pad" as VALID with message the QNN Pool does not support this config.
QNN Pool Op supports auto_pad=VALID and all the pad values are set to 0.


