### PR TITLE
Fix AutoEpSelection and OrtEpLibrary tests when using AuthenticAMD

### DIFF
--- a/onnxruntime/core/common/cpuid_info.cc
+++ b/onnxruntime/core/common/cpuid_info.cc
@@ -154,7 +154,7 @@ std::string CPUIDInfo::GetX86Vendor(int32_t* data) {
 
 uint32_t CPUIDInfo::GetVendorId(const std::string& vendor) {
   if (vendor == "GenuineIntel") return 0x8086;
-  if (vendor == "GenuineAMD") return 0x1022;
+  if (vendor == "AuthenticAMD") return 0x1022;
   if (vendor.find("Qualcomm") == 0) return 'Q' | ('C' << 8) | ('O' << 16) | ('M' << 24);
   if (vendor.find("NV") == 0) return 0x10DE;
   return 0;


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Turn GenuineAMD into AuthenticAMD in cpuid_info.cc::CPUIDInfo::GetVendorId

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

- The change is fixing the issue https://github.com/microsoft/onnxruntime/issues/24676

