### PR TITLE
[WebGPU EP] move transpose output_size check to computeinternal

### DIFF
--- a/onnxruntime/core/providers/webgpu/tensor/transpose.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/transpose.cc
@@ -165,7 +165,7 @@ Status Transpose::ComputeInternal(ComputeContext& context) const {
   TensorShape output_shape(output_dims);
   auto* output_tensor = context.Output(0, output_shape);
 
-  uint32_t output_size = output_shape.Size();
+  int64_t output_size = output_shape.Size();
   if (output_size == 0) {
     return Status::OK();
   }

--- a/onnxruntime/core/providers/webgpu/tensor/transpose.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/transpose.cc
@@ -104,10 +104,6 @@ Status Transpose::DoTranspose(onnxruntime::webgpu::ComputeContext& context,
                               gsl::span<const size_t> permutations,
                               const Tensor& input, Tensor& output) {
   const auto& input_shape = input.Shape();
-  uint32_t output_size = onnxruntime::narrow<int32_t>(input_shape.Size());
-  if (output_size == 0) {
-    return Status::OK();
-  }
   const auto& input_dims = input_shape.GetDims();
   int32_t rank = static_cast<int32_t>(input_shape.NumDimensions());
 
@@ -134,6 +130,8 @@ Status Transpose::DoTranspose(onnxruntime::webgpu::ComputeContext& context,
                           : new_shape;
     new_output_shape = TensorShape({new_input_shape[1], new_input_shape[0]});
   }
+
+  uint32_t output_size = onnxruntime::narrow<int32_t>(input_shape.Size());
   TransposeProgram program{permutations, use_shared};
 
   if (use_shared) {
@@ -159,6 +157,11 @@ Status Transpose::ComputeInternal(ComputeContext& context) const {
   const auto* input_tensor = context.Input(0);
   const TensorShape& input_shape = input_tensor->Shape();
   int32_t rank = static_cast<int32_t>(input_shape.NumDimensions());
+
+  uint32_t output_size = onnxruntime::narrow<int32_t>(input_shape.Size());
+  if (output_size == 0) {
+    return Status::OK();
+  }
 
   TensorShapeVector output_dims(rank);
   InlinedVector<size_t> default_perm(rank);

--- a/onnxruntime/core/providers/webgpu/tensor/transpose.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/transpose.cc
@@ -158,17 +158,17 @@ Status Transpose::ComputeInternal(ComputeContext& context) const {
   const TensorShape& input_shape = input_tensor->Shape();
   int32_t rank = static_cast<int32_t>(input_shape.NumDimensions());
 
-  uint32_t output_size = onnxruntime::narrow<int32_t>(input_shape.Size());
-  if (output_size == 0) {
-    return Status::OK();
-  }
-
   TensorShapeVector output_dims(rank);
   InlinedVector<size_t> default_perm(rank);
   const InlinedVector<size_t>* p_perm = nullptr;
   ORT_RETURN_IF_ERROR(ComputeOutputShape(*input_tensor, output_dims, default_perm, p_perm));
   TensorShape output_shape(output_dims);
   auto* output_tensor = context.Output(0, output_shape);
+
+  uint32_t output_size = output_shape.Size();
+  if (output_size == 0) {
+    return Status::OK();
+  }
 
   return DoTranspose(context, *p_perm, *input_tensor, *output_tensor);
 }


### PR DESCRIPTION
Adjust fix for https://github.com/microsoft/onnxruntime/pull/24746