### PR TITLE
Telemetry field to indicate debugger is attached

### DIFF
--- a/onnxruntime/core/platform/windows/telemetry.cc
+++ b/onnxruntime/core/platform/windows/telemetry.cc
@@ -183,6 +183,7 @@ void WindowsTelemetry::LogProcessInfo() const {
                     // Telemetry info
                     TraceLoggingUInt8(0, "schemaVersion"),
                     TraceLoggingString(ORT_VERSION, "runtimeVersion"),
+                    TraceLoggingBool(IsDebuggerPresent(), "isDebuggerAttached"),
                     TraceLoggingBool(isRedist, "isRedist"));
 
   process_info_logged = true;


### PR DESCRIPTION
### Description
This commit adds a telemetry field to indicate if a debugger is attached to the process.

### Motivation and Context
This is useful for ignoring events coming from processes being debugged.


