### PR TITLE
Extend OrtAllocator API to get Allocator statistics

### DIFF
--- a/include/onnxruntime/core/framework/allocator.h
+++ b/include/onnxruntime/core/framework/allocator.h
@@ -102,7 +102,7 @@ class IAllocator {
 
   // Each implementation of IAllocator can override and provide their own implementation
   virtual void GetStats(AllocatorStats* /*stats*/) {
-    ORT_NOT_IMPLEMENTED(__FUNCTION__, " is not implemented");
+    ORT_NOT_IMPLEMENTED(__FUNCTION__, " is not supported by this allocator");
   }
 
   static bool CalcMemSizeForArray(size_t nmemb, size_t size, size_t* out) noexcept {

--- a/include/onnxruntime/core/framework/allocator.h
+++ b/include/onnxruntime/core/framework/allocator.h
@@ -102,7 +102,7 @@ class IAllocator {
 
   // Each implementation of IAllocator can override and provide their own implementation
   virtual void GetStats(AllocatorStats* stats) {
-    stats->Clear();
+    *stats = {};
   }
 
   static bool CalcMemSizeForArray(size_t nmemb, size_t size, size_t* out) noexcept {

--- a/include/onnxruntime/core/framework/allocator.h
+++ b/include/onnxruntime/core/framework/allocator.h
@@ -101,7 +101,9 @@ class IAllocator {
   const OrtMemoryInfo& Info() const { return memory_info_; };
 
   // Each implementation of IAllocator can override and provide their own implementation
-  virtual void GetStats(AllocatorStats* /*stats*/) { return; }
+  virtual void GetStats(AllocatorStats* /*stats*/) {
+    ORT_NOT_IMPLEMENTED(__FUNCTION__, " is not implemented");
+  }
 
   static bool CalcMemSizeForArray(size_t nmemb, size_t size, size_t* out) noexcept {
     return CalcMemSizeForArrayWithAlignment(nmemb, size, 0, out);

--- a/include/onnxruntime/core/framework/allocator.h
+++ b/include/onnxruntime/core/framework/allocator.h
@@ -102,7 +102,11 @@ class IAllocator {
 
   // Each implementation of IAllocator can override and provide their own implementation
   virtual void GetStats(AllocatorStats* /*stats*/) {
+#ifdef ORT_NO_RTTI
     ORT_NOT_IMPLEMENTED(__FUNCTION__, " is not supported by this allocator");
+#else
+    ORT_NOT_IMPLEMENTED(__FUNCTION__, " is not supported by allocator of type ", typeid(*this).name());
+#endif
   }
 
   static bool CalcMemSizeForArray(size_t nmemb, size_t size, size_t* out) noexcept {

--- a/include/onnxruntime/core/framework/allocator.h
+++ b/include/onnxruntime/core/framework/allocator.h
@@ -101,12 +101,8 @@ class IAllocator {
   const OrtMemoryInfo& Info() const { return memory_info_; };
 
   // Each implementation of IAllocator can override and provide their own implementation
-  virtual void GetStats(AllocatorStats* /*stats*/) {
-#ifdef ORT_NO_RTTI
-    ORT_NOT_IMPLEMENTED(__FUNCTION__, " is not supported by this allocator");
-#else
-    ORT_NOT_IMPLEMENTED(__FUNCTION__, " is not supported by allocator of type ", typeid(*this).name());
-#endif
+  virtual void GetStats(AllocatorStats* stats) {
+    stats->Clear();
   }
 
   static bool CalcMemSizeForArray(size_t nmemb, size_t size, size_t* out) noexcept {

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -357,10 +357,10 @@ typedef struct OrtAllocator {
    * - MaxAllocSize: The max single allocation seen.
    *
    * Note that not all allocators support this function. If the allocator does not support this function,
-   * it will throw onnxruntime::NotImplementedException exception.
+   * it returns ORT_NOT_IMPLEMENTED.
    */
-  void(ORT_API_CALL* GetStats)(const struct OrtAllocator* this_, _Inout_ struct OrtAllocator* allocator,
-                               _Outptr_ char** stats);
+  ORT_API2_STATUS(GetStats, _In_ const struct OrtAllocator* this_, _Inout_ struct OrtAllocator* allocator,
+                 _Outptr_ char** stats);
 } OrtAllocator;
 
 typedef void(ORT_API_CALL* OrtLoggingFunction)(

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -360,7 +360,7 @@ typedef struct OrtAllocator {
    * it returns ORT_NOT_IMPLEMENTED.
    */
   ORT_API2_STATUS(GetStats, _In_ const struct OrtAllocator* this_, _Inout_ struct OrtAllocator* allocator,
-                 _Outptr_ char** stats);
+                  _Outptr_ char** stats);
 } OrtAllocator;
 
 typedef void(ORT_API_CALL* OrtLoggingFunction)(

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -340,6 +340,11 @@ typedef struct OrtAllocator {
    * those made during session initialization. This allows for separate memory management strategies for these allocations.
    */
   void*(ORT_API_CALL* Reserve)(struct OrtAllocator* this_, size_t size);  ///< Returns a pointer to an allocated block of `size` bytes
+
+  /**
+   * @brief Function used to get the statistics of the allocator.
+   */
+  void(ORT_API_CALL* GetStats)(const struct OrtAllocator* this_, _Inout_ struct OrtAllocator* allocator, _Outptr_ char** stats);
 } OrtAllocator;
 
 typedef void(ORT_API_CALL* OrtLoggingFunction)(
@@ -5266,6 +5271,12 @@ struct OrtApi {
    * \since Version 1.23
    */
   ORT_API2_STATUS(GetTensorSizeInBytes, _In_ const OrtValue* ort_value, _Out_ size_t* size);
+
+  /** \brief Calls OrtAllocator::GetStats function
+   *
+   * \since Version 1.23.
+   */
+  ORT_API2_STATUS(AllocatorGetStats, _In_ const OrtAllocator* ort_allocator, _Inout_ OrtAllocator* allocator, _Outptr_ char** out);
 };
 
 /*

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -344,7 +344,8 @@ typedef struct OrtAllocator {
   /**
    * @brief Function used to get the statistics of the allocator.
    */
-  void(ORT_API_CALL* GetStats)(const struct OrtAllocator* this_, _Inout_ struct OrtAllocator* allocator, _Outptr_ char** stats);
+  void(ORT_API_CALL* GetStats)(const struct OrtAllocator* this_, _Inout_ struct OrtAllocator* allocator,
+                               _Outptr_ char** stats);
 } OrtAllocator;
 
 typedef void(ORT_API_CALL* OrtLoggingFunction)(
@@ -5276,7 +5277,8 @@ struct OrtApi {
    *
    * \since Version 1.23.
    */
-  ORT_API2_STATUS(AllocatorGetStats, _In_ const OrtAllocator* ort_allocator, _Inout_ OrtAllocator* allocator, _Outptr_ char** out);
+  ORT_API2_STATUS(AllocatorGetStats, _In_ const OrtAllocator* ort_allocator, _Inout_ OrtAllocator* allocator,
+                  _Outptr_ char** out);
 };
 
 /*

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -356,7 +356,7 @@ typedef struct OrtAllocator {
    * - NumArenaShrinkages: Number of arena shrinkages (Relevant only for arena based allocators)
    * - MaxAllocSize: The max single allocation seen.
    *
-   * Note that if the allocator does not implement this function, it will return an empty OrtKeyValuePairs.
+   * NOTE: If the allocator does not implement this function, the OrtKeyValuePairs instance will be empty.
    */
   ORT_API2_STATUS(GetStats, _In_ const struct OrtAllocator* this_, _Outptr_ OrtKeyValuePairs** out);
 } OrtAllocator;
@@ -5288,10 +5288,9 @@ struct OrtApi {
 
   /** \brief Calls OrtAllocator::GetStats function
    *
-   * Return a stats string that contains statistics collected by the allocator. The string is
-   * formatted as 'key:value' pairs separated by commas.
+   * Return a pointer to the OrtKeyValuePairs structure that contains the statistics of the allocator.
    *
-   * Note that if the allocator does not implement this function, it will return an empty OrtKeyValuePairs.
+   * NOTE: If the allocator does not implement this function, the OrtKeyValuePairs instance will be empty.
    *
    * \param[in] ort_allocator The allocator to get stats from
    * \param[out] out A pointer to the OrtKeyValuePairs instance that contains the stats

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -343,6 +343,21 @@ typedef struct OrtAllocator {
 
   /**
    * @brief Function used to get the statistics of the allocator.
+   *
+   * Return a stats string that is formatted as 'key:value' pairs separated by commas.
+   * Supported keys are:
+   * - Limit: Bytes limit of the allocator. -1 if no limit is set.
+   * - InUse: Number of bytes in use.
+   * - TotalAllocated: The total number of allocated bytes by the allocator.
+   * - MaxInUse: The maximum bytes in use.
+   * - NumAllocs: Number of allocations.
+   * - NumReserves: Number of reserves. (Number of calls to Reserve() in arena-based allocators)
+   * - NumArenaExtensions: Number of arena extensions (Relevant only for arena based allocators)
+   * - NumArenaShrinkages: Number of arena shrinkages (Relevant only for arena based allocators)
+   * - MaxAllocSize: The max single allocation seen.
+   *
+   * Note that not all allocators support this function. If the allocator does not support this function,
+   * it will throw onnxruntime::NotImplementedException exception.
    */
   void(ORT_API_CALL* GetStats)(const struct OrtAllocator* this_, _Inout_ struct OrtAllocator* allocator,
                                _Outptr_ char** stats);
@@ -5274,6 +5289,18 @@ struct OrtApi {
   ORT_API2_STATUS(GetTensorSizeInBytes, _In_ const OrtValue* ort_value, _Out_ size_t* size);
 
   /** \brief Calls OrtAllocator::GetStats function
+   *
+   * Return a stats string that contains statistics collected by the allocator. The string is
+   * formatted as 'key:value' pairs separated by commas.
+   *
+   * Note that not all allocators support this function. If the allocator does not support this function,
+   * it returns ORT_NOT_IMPLEMENTED.
+   *
+   * \param[in] ort_allocator The allocator to get stats from
+   * \param[in] allocator The allocator to allocate the stats string
+   * \param[out] out The stats string
+   *
+   * \snippet{doc} snippets.dox OrtStatus Return Value
    *
    * \since Version 1.23.
    */

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -344,7 +344,7 @@ typedef struct OrtAllocator {
   /**
    * @brief Function used to get the statistics of the allocator.
    *
-   * Return a stats string that is formatted as 'key:value' pairs separated by commas.
+   * Return a pointer to the OrtKeyValuePairs structure that contains the statistics of the allocator.
    * Supported keys are:
    * - Limit: Bytes limit of the allocator. -1 if no limit is set.
    * - InUse: Number of bytes in use.
@@ -359,8 +359,7 @@ typedef struct OrtAllocator {
    * Note that not all allocators support this function. If the allocator does not support this function,
    * it returns ORT_NOT_IMPLEMENTED.
    */
-  ORT_API2_STATUS(GetStats, _In_ const struct OrtAllocator* this_, _Inout_ struct OrtAllocator* allocator,
-                  _Outptr_ char** stats);
+  ORT_API2_STATUS(GetStats, _In_ const struct OrtAllocator* this_, _Outptr_ OrtKeyValuePairs** out);
 } OrtAllocator;
 
 typedef void(ORT_API_CALL* OrtLoggingFunction)(
@@ -5297,15 +5296,13 @@ struct OrtApi {
    * it returns ORT_NOT_IMPLEMENTED.
    *
    * \param[in] ort_allocator The allocator to get stats from
-   * \param[in] allocator The allocator to allocate the stats string
-   * \param[out] out The stats string
+   * \param[out] out A pointer to the OrtKeyValuePairs instance that contains the stats
    *
    * \snippet{doc} snippets.dox OrtStatus Return Value
    *
    * \since Version 1.23.
    */
-  ORT_API2_STATUS(AllocatorGetStats, _In_ const OrtAllocator* ort_allocator, _Inout_ OrtAllocator* allocator,
-                  _Outptr_ char** out);
+  ORT_API2_STATUS(AllocatorGetStats, _In_ const OrtAllocator* ort_allocator, _Outptr_ OrtKeyValuePairs** out);
 };
 
 /*

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -356,8 +356,7 @@ typedef struct OrtAllocator {
    * - NumArenaShrinkages: Number of arena shrinkages (Relevant only for arena based allocators)
    * - MaxAllocSize: The max single allocation seen.
    *
-   * Note that not all allocators support this function. If the allocator does not support this function,
-   * it returns ORT_NOT_IMPLEMENTED.
+   * Note that if the allocator does not implement this function, it will return an empty OrtKeyValuePairs.
    */
   ORT_API2_STATUS(GetStats, _In_ const struct OrtAllocator* this_, _Outptr_ OrtKeyValuePairs** out);
 } OrtAllocator;
@@ -5292,8 +5291,7 @@ struct OrtApi {
    * Return a stats string that contains statistics collected by the allocator. The string is
    * formatted as 'key:value' pairs separated by commas.
    *
-   * Note that not all allocators support this function. If the allocator does not support this function,
-   * it returns ORT_NOT_IMPLEMENTED.
+   * Note that if the allocator does not implement this function, it will return an empty OrtKeyValuePairs.
    *
    * \param[in] ort_allocator The allocator to get stats from
    * \param[out] out A pointer to the OrtKeyValuePairs instance that contains the stats

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -344,7 +344,8 @@ typedef struct OrtAllocator {
   /**
    * @brief Function used to get the statistics of the allocator.
    *
-   * Return a pointer to the OrtKeyValuePairs structure that contains the statistics of the allocator.
+   * Return a pointer to the OrtKeyValuePairs structure that contains the statistics of the allocator
+   * and the user should call OrtApi::ReleaseKeyValuePairs.
    * Supported keys are:
    * - Limit: Bytes limit of the allocator. -1 if no limit is set.
    * - InUse: Number of bytes in use.
@@ -5288,7 +5289,8 @@ struct OrtApi {
 
   /** \brief Calls OrtAllocator::GetStats function
    *
-   * Return a pointer to the OrtKeyValuePairs structure that contains the statistics of the allocator.
+   * Return a pointer to the OrtKeyValuePairs structure that contains the statistics of the allocator
+   * and the user should call OrtApi::ReleaseKeyValuePairs.
    *
    * NOTE: If the allocator does not implement this function, the OrtKeyValuePairs instance will be empty.
    *

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -2157,10 +2157,10 @@ struct AllocatorImpl : Base<T> {
 
   /** \brief Function that returns the statistics of the allocator.
    *
-   * \param[out] stats: A pointer to a ConstKeyValuePairs object that will be filled with the allocator statistics.
+   * \param[out] stats: A pointer to a KeyValuePairs object that will be filled with the allocator statistics.
    * \return A Status indicating success or failure.
    */
-  Status GetStats(ConstKeyValuePairs* stats) const;
+  Status GetStats(KeyValuePairs* stats) const;
 };
 
 }  // namespace detail

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -2154,6 +2154,7 @@ struct AllocatorImpl : Base<T> {
   MemoryAllocation GetAllocation(size_t size);
   void Free(void* p);
   ConstMemoryInfo GetInfo() const;
+  std::unordered_map<std::string, std::string> GetStats() const;
 };
 
 }  // namespace detail

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -2157,10 +2157,10 @@ struct AllocatorImpl : Base<T> {
 
   /** \brief Function that returns the statistics of the allocator.
    *
-   * \param stats: A map to store the allocator statistics.
+   * \param stats: A Ort::ConstKeyValuePairs to store the allocator statistics.
    * \return A Status indicating success or failure.
    */
-  Status GetStats(std::unordered_map<std::string, std::string>& stats) const;
+  Status GetStats(ConstKeyValuePairs* stats) const;
 };
 
 }  // namespace detail

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -2157,10 +2157,9 @@ struct AllocatorImpl : Base<T> {
 
   /** \brief Function that returns the statistics of the allocator.
    *
-   * \param[out] stats: A pointer to a KeyValuePairs object that will be filled with the allocator statistics.
-   * \return A Status indicating success or failure.
+   * \return A pointer to a KeyValuePairs object that will be filled with the allocator statistics.
    */
-  Status GetStats(KeyValuePairs* stats) const;
+  KeyValuePairs GetStats() const;
 };
 
 }  // namespace detail

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -2154,7 +2154,13 @@ struct AllocatorImpl : Base<T> {
   MemoryAllocation GetAllocation(size_t size);
   void Free(void* p);
   ConstMemoryInfo GetInfo() const;
-  std::unordered_map<std::string, std::string> GetStats() const;
+
+  /** \brief Function that returns the statistics of the allocator.
+   *
+   * \param stats: A map to store the allocator statistics.
+   * \return A Status indicating success or failure.
+   */
+  Status GetStats(std::unordered_map<std::string, std::string>& stats) const;
 };
 
 }  // namespace detail

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -2157,7 +2157,7 @@ struct AllocatorImpl : Base<T> {
 
   /** \brief Function that returns the statistics of the allocator.
    *
-   * \param stats: A Ort::ConstKeyValuePairs to store the allocator statistics.
+   * \param[out] stats: A pointer to a ConstKeyValuePairs object that will be filled with the allocator statistics.
    * \return A Status indicating success or failure.
    */
   Status GetStats(ConstKeyValuePairs* stats) const;

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -244,7 +244,7 @@ inline ConstMemoryInfo AllocatorImpl<T>::GetInfo() const {
 }
 
 template <typename T>
-inline Status AllocatorImpl<T>::GetStats(KeyValuePairs* stats) const {
+inline KeyValuePairs AllocatorImpl<T>::GetStats() const {
   OrtKeyValuePairs* out;
   ThrowOnError(GetApi().AllocatorGetStats(this->p_, &out));
   return KeyValuePairs(out);

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -253,6 +253,10 @@ inline std::unordered_map<std::string, std::string> AllocatorImpl<T>::GetStats()
   if (raw_stats == nullptr) {
     return stats;
   }
+
+  auto free_fn = detail::AllocatedFree(allocator);
+  std::unique_ptr<void, decltype(free_fn)> raw_stats_g(raw_stats, free_fn);
+
   std::istringstream iss(raw_stats);
   std::string line;
   while (std::getline(iss, line, ',')) {
@@ -262,9 +266,8 @@ inline std::unordered_map<std::string, std::string> AllocatorImpl<T>::GetStats()
     }
     std::string key = line.substr(0, pos);
     std::string value = line.substr(pos + 1);
-    stats[key] = value;
+    stats.insert_or_assign(key, value);
   }
-  allocator.Free(raw_stats);
   return stats;
 }
 }  // namespace detail

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -262,7 +262,12 @@ inline Status AllocatorImpl<T>::GetStats(std::unordered_map<std::string, std::st
     }
     std::string key = line.substr(0, pos);
     std::string value = line.substr(pos + 1);
+    // insert_or_assign is C++17 and later
+  #if __cplusplus >= 201703L || defined(_MSVC_LANG) && (_MSVC_LANG >= 201703L)
     stats.insert_or_assign(std::move(key), std::move(value));
+  #else
+    stats[key] = std::move(value);
+  #endif
   }
   return Ort::Status();
 }

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -246,9 +246,8 @@ inline ConstMemoryInfo AllocatorImpl<T>::GetInfo() const {
 template <typename T>
 inline Status AllocatorImpl<T>::GetStats(KeyValuePairs* stats) const {
   OrtKeyValuePairs* out;
-  ORT_CXX_RETURN_ON_API_FAIL(GetApi().AllocatorGetStats(this->p_, &out));
-  *stats = KeyValuePairs(out);
-  return Ort::Status();
+  ThrowOnError(GetApi().AllocatorGetStats(this->p_, &out));
+  return KeyValuePairs(out);
 }
 }  // namespace detail
 

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -244,10 +244,10 @@ inline ConstMemoryInfo AllocatorImpl<T>::GetInfo() const {
 }
 
 template <typename T>
-inline Status AllocatorImpl<T>::GetStats(ConstKeyValuePairs* stats) const {
+inline Status AllocatorImpl<T>::GetStats(KeyValuePairs* stats) const {
   OrtKeyValuePairs* out;
   ORT_CXX_RETURN_ON_API_FAIL(GetApi().AllocatorGetStats(this->p_, &out));
-  *stats = ConstKeyValuePairs(out);
+  *stats = KeyValuePairs(out);
   return Ort::Status();
 }
 }  // namespace detail

--- a/onnxruntime/core/framework/allocator_stats.h
+++ b/onnxruntime/core/framework/allocator_stats.h
@@ -37,6 +37,20 @@ struct AllocatorStats {
     this->total_allocated_bytes = 0;
   }
 
+  std::string ToString() const {
+    std::ostringstream ss;
+    ss << "bytes_limit:" << this->bytes_limit << ","
+       << "bytes_in_use:" << this->bytes_in_use << ","
+       << "total_allocated_bytes:" << this->total_allocated_bytes << ","
+       << "max_bytes_in_use:" << this->max_bytes_in_use << ","
+       << "num_allocs:" << this->num_allocs << ","
+       << "num_reserves:" << this->num_reserves << ","
+       << "num_arena_extensions:" << this->num_arena_extensions << ","
+       << "num_arena_shrinkages:" << this->num_arena_shrinkages << ","
+       << "max_alloc_size:" << this->max_alloc_size;
+    return ss.str();
+  }
+
   std::string DebugString() const {
     std::ostringstream ss;
     ss << "Limit:                    " << this->bytes_limit << "\n"

--- a/onnxruntime/core/framework/allocator_stats.h
+++ b/onnxruntime/core/framework/allocator_stats.h
@@ -37,20 +37,6 @@ struct AllocatorStats {
     this->total_allocated_bytes = 0;
   }
 
-  std::string ToString() const {
-    std::ostringstream ss;
-    ss << "bytes_limit:" << this->bytes_limit << ","
-       << "bytes_in_use:" << this->bytes_in_use << ","
-       << "total_allocated_bytes:" << this->total_allocated_bytes << ","
-       << "max_bytes_in_use:" << this->max_bytes_in_use << ","
-       << "num_allocs:" << this->num_allocs << ","
-       << "num_reserves:" << this->num_reserves << ","
-       << "num_arena_extensions:" << this->num_arena_extensions << ","
-       << "num_arena_shrinkages:" << this->num_arena_shrinkages << ","
-       << "max_alloc_size:" << this->max_alloc_size;
-    return ss.str();
-  }
-
   std::string DebugString() const {
     std::ostringstream ss;
     ss << "Limit:                    " << this->bytes_limit << "\n"

--- a/onnxruntime/core/session/allocator_adapters.cc
+++ b/onnxruntime/core/session/allocator_adapters.cc
@@ -31,11 +31,6 @@ OrtAllocatorImplWrappingIAllocator::OrtAllocatorImplWrappingIAllocator(onnxrunti
     OrtAllocator::GetStats =
         [](const OrtAllocator* this_, OrtAllocator* allocator, char** stats) {
           auto str = static_cast<const OrtAllocatorImplWrappingIAllocator*>(this_)->Stats();
-          if (str.empty()) {
-            *stats = nullptr;
-            return;
-          }
-
           char* stats_string = reinterpret_cast<char*>(allocator->Alloc(allocator, str.size() + 1));
           memcpy(stats_string, str.c_str(), str.size());
           stats_string[str.size()] = '\0';
@@ -62,14 +57,7 @@ const OrtMemoryInfo* OrtAllocatorImplWrappingIAllocator::Info() const {
 
 std::string OrtAllocatorImplWrappingIAllocator::Stats() const {
   AllocatorStats stats{};
-
-  ORT_TRY {
-    i_allocator_->GetStats(&stats);
-  }
-  ORT_CATCH(const NotImplementedException& /*e*/) {
-    return {};
-  }
-
+  i_allocator_->GetStats(&stats);
   auto stats_str = stats.DebugString();
 
   // Process the debug string to a comma-separated format and remove redundant spaces
@@ -82,7 +70,6 @@ std::string OrtAllocatorImplWrappingIAllocator::Stats() const {
   pos = 0;
   while ((pos = stats_str.find(' ', pos)) != std::string::npos) {
     stats_str.replace(pos, 1, "");
-    pos += 1;
   }
 
   return stats_str;

--- a/onnxruntime/core/session/allocator_adapters.cc
+++ b/onnxruntime/core/session/allocator_adapters.cc
@@ -32,6 +32,7 @@ OrtAllocatorImplWrappingIAllocator::OrtAllocatorImplWrappingIAllocator(onnxrunti
         [](const OrtAllocator* this_, OrtAllocator* allocator, char** stats) noexcept -> OrtStatusPtr {
       API_IMPL_BEGIN
 #ifdef ORT_NO_RTTI
+      // When exception is disabled, we should directly return an error status to avoid aborting the program.
       ORT_UNUSED_PARAMETER(this_);
       ORT_UNUSED_PARAMETER(allocator);
       ORT_UNUSED_PARAMETER(stats);

--- a/onnxruntime/core/session/allocator_adapters.cc
+++ b/onnxruntime/core/session/allocator_adapters.cc
@@ -30,15 +30,15 @@ OrtAllocatorImplWrappingIAllocator::OrtAllocatorImplWrappingIAllocator(onnxrunti
   if (OrtAllocator::version >= kOrtAllocatorStatsMinVersion) {
     OrtAllocator::GetStats =
         [](const OrtAllocator* this_, OrtAllocator* allocator, char** stats) noexcept -> OrtStatusPtr {
-          API_IMPL_BEGIN
-          auto str = static_cast<const OrtAllocatorImplWrappingIAllocator*>(this_)->Stats();
-          char* stats_string = reinterpret_cast<char*>(allocator->Alloc(allocator, str.size() + 1));
-          memcpy(stats_string, str.c_str(), str.size());
-          stats_string[str.size()] = '\0';
-          *stats = stats_string;
-          return nullptr;
-          API_IMPL_END
-        };
+      API_IMPL_BEGIN
+      auto str = static_cast<const OrtAllocatorImplWrappingIAllocator*>(this_)->Stats();
+      char* stats_string = reinterpret_cast<char*>(allocator->Alloc(allocator, str.size() + 1));
+      memcpy(stats_string, str.c_str(), str.size());
+      stats_string[str.size()] = '\0';
+      *stats = stats_string;
+      return nullptr;
+      API_IMPL_END
+    };
   }
 }
 

--- a/onnxruntime/core/session/allocator_adapters.cc
+++ b/onnxruntime/core/session/allocator_adapters.cc
@@ -57,7 +57,13 @@ const OrtMemoryInfo* OrtAllocatorImplWrappingIAllocator::Info() const {
 
 std::string OrtAllocatorImplWrappingIAllocator::Stats() const {
   AllocatorStats stats{};
-  i_allocator_->GetStats(&stats);
+
+  try {
+    i_allocator_->GetStats(&stats);
+  } catch (const std::exception& e) {
+    return {};
+  }
+
   auto stats_str = stats.DebugString();
 
   // Process the debug string to a comma-separated format and remove redundant spaces

--- a/onnxruntime/core/session/allocator_adapters.cc
+++ b/onnxruntime/core/session/allocator_adapters.cc
@@ -31,12 +31,19 @@ OrtAllocatorImplWrappingIAllocator::OrtAllocatorImplWrappingIAllocator(onnxrunti
     OrtAllocator::GetStats =
         [](const OrtAllocator* this_, OrtAllocator* allocator, char** stats) noexcept -> OrtStatusPtr {
       API_IMPL_BEGIN
+#ifdef ORT_NO_RTTI
+      ORT_UNUSED_PARAMETER(this_);
+      ORT_UNUSED_PARAMETER(allocator);
+      ORT_UNUSED_PARAMETER(stats);
+      return OrtApis::CreateStatus(ORT_NOT_IMPLEMENTED, "This API is not supported in a NO_RTTI build.");
+#else
       auto str = static_cast<const OrtAllocatorImplWrappingIAllocator*>(this_)->Stats();
       char* stats_string = reinterpret_cast<char*>(allocator->Alloc(allocator, str.size() + 1));
       memcpy(stats_string, str.c_str(), str.size());
       stats_string[str.size()] = '\0';
       *stats = stats_string;
       return nullptr;
+#endif
       API_IMPL_END
     };
   }

--- a/onnxruntime/core/session/allocator_adapters.cc
+++ b/onnxruntime/core/session/allocator_adapters.cc
@@ -56,9 +56,24 @@ const OrtMemoryInfo* OrtAllocatorImplWrappingIAllocator::Info() const {
 }
 
 std::string OrtAllocatorImplWrappingIAllocator::Stats() const {
-  AllocatorStats stats;
+  AllocatorStats stats{};
   i_allocator_->GetStats(&stats);
-  return stats.ToString();
+  auto stats_str = stats.DebugString();
+
+  // Process the debug string to a comma-separated format and remove redundant spaces
+  std::string::size_type pos = 0;
+  while ((pos = stats_str.find('\n', pos)) != std::string::npos) {
+    stats_str.replace(pos, 1, ",");
+    pos += 1;
+  }
+
+  pos = 0;
+  while ((pos = stats_str.find(' ', pos)) != std::string::npos) {
+    stats_str.replace(pos, 1, "");
+    pos += 1;
+  }
+
+  return stats_str;
 }
 
 onnxruntime::AllocatorPtr OrtAllocatorImplWrappingIAllocator::GetWrappedIAllocator() {

--- a/onnxruntime/core/session/allocator_adapters.cc
+++ b/onnxruntime/core/session/allocator_adapters.cc
@@ -29,12 +29,15 @@ OrtAllocatorImplWrappingIAllocator::OrtAllocatorImplWrappingIAllocator(onnxrunti
   }
   if (OrtAllocator::version >= kOrtAllocatorStatsMinVersion) {
     OrtAllocator::GetStats =
-        [](const OrtAllocator* this_, OrtAllocator* allocator, char** stats) {
+        [](const OrtAllocator* this_, OrtAllocator* allocator, char** stats) noexcept -> OrtStatusPtr {
+          API_IMPL_BEGIN
           auto str = static_cast<const OrtAllocatorImplWrappingIAllocator*>(this_)->Stats();
           char* stats_string = reinterpret_cast<char*>(allocator->Alloc(allocator, str.size() + 1));
           memcpy(stats_string, str.c_str(), str.size());
           stats_string[str.size()] = '\0';
           *stats = stats_string;
+          return nullptr;
+          API_IMPL_END
         };
   }
 }

--- a/onnxruntime/core/session/allocator_adapters.cc
+++ b/onnxruntime/core/session/allocator_adapters.cc
@@ -12,7 +12,6 @@ namespace onnxruntime {
 
 namespace {
 constexpr uint32_t kOrtAllocatorReserveMinVersion = 18;
-constexpr uint32_t kOrtAllocatorStatsMinVersion = 23;
 }  // namespace
 
 OrtAllocatorImplWrappingIAllocator::OrtAllocatorImplWrappingIAllocator(onnxruntime::AllocatorPtr&& i_allocator)
@@ -28,18 +27,16 @@ OrtAllocatorImplWrappingIAllocator::OrtAllocatorImplWrappingIAllocator(onnxrunti
     OrtAllocator::Reserve =
         [](OrtAllocator* this_, size_t size) { return static_cast<OrtAllocatorImplWrappingIAllocator*>(this_)->Reserve(size); };
   }
-  if (OrtAllocator::version >= kOrtAllocatorStatsMinVersion) {
-    OrtAllocator::GetStats =
-        [](const OrtAllocator* this_, OrtKeyValuePairs** stats) noexcept -> OrtStatusPtr {
-      API_IMPL_BEGIN
-      auto kvp = std::make_unique<OrtKeyValuePairs>();
-      auto stats_map = static_cast<const OrtAllocatorImplWrappingIAllocator*>(this_)->Stats();
-      kvp->Copy(stats_map);
-      *stats = reinterpret_cast<OrtKeyValuePairs*>(kvp.release());
-      return nullptr;
-      API_IMPL_END
-    };
-  }
+  OrtAllocator::GetStats =
+      [](const OrtAllocator* this_, OrtKeyValuePairs** stats) noexcept -> OrtStatusPtr {
+    API_IMPL_BEGIN
+    auto kvp = std::make_unique<OrtKeyValuePairs>();
+    auto stats_map = static_cast<const OrtAllocatorImplWrappingIAllocator*>(this_)->Stats();
+    kvp->Copy(stats_map);
+    *stats = reinterpret_cast<OrtKeyValuePairs*>(kvp.release());
+    return nullptr;
+    API_IMPL_END
+  };
 }
 
 void* OrtAllocatorImplWrappingIAllocator::Alloc(size_t size) {

--- a/onnxruntime/core/session/allocator_adapters.h
+++ b/onnxruntime/core/session/allocator_adapters.h
@@ -6,6 +6,8 @@
 #include "core/framework/allocator.h"
 #include "core/session/onnxruntime_cxx_api.h"
 
+#include <string>
+
 namespace onnxruntime {
 
 // Since all allocators are of type 'OrtAllocator' and there is a single
@@ -28,6 +30,8 @@ struct OrtAllocatorImplWrappingIAllocator final : public OrtAllocatorImpl {
 
   const OrtMemoryInfo* Info() const;
   void* Reserve(size_t size);
+
+  std::string Stats() const;
 
   ORT_DISALLOW_COPY_AND_ASSIGNMENT(OrtAllocatorImplWrappingIAllocator);
 

--- a/onnxruntime/core/session/allocator_adapters.h
+++ b/onnxruntime/core/session/allocator_adapters.h
@@ -31,7 +31,7 @@ struct OrtAllocatorImplWrappingIAllocator final : public OrtAllocatorImpl {
   const OrtMemoryInfo* Info() const;
   void* Reserve(size_t size);
 
-  std::string Stats() const;
+  std::unordered_map<std::string, std::string> Stats() const;
 
   ORT_DISALLOW_COPY_AND_ASSIGNMENT(OrtAllocatorImplWrappingIAllocator);
 

--- a/onnxruntime/core/session/default_cpu_allocator_c_api.cc
+++ b/onnxruntime/core/session/default_cpu_allocator_c_api.cc
@@ -17,6 +17,12 @@ struct OrtDefaultCpuAllocator : onnxruntime::OrtAllocatorImpl {
         [](OrtAllocator* this_, void* p) { static_cast<OrtDefaultCpuAllocator*>(this_)->Free(p); };
     OrtAllocator::Info =
         [](const OrtAllocator* this_) { return static_cast<const OrtDefaultCpuAllocator*>(this_)->Info(); };
+    OrtAllocator::Reserve =
+        [](OrtAllocator* this_, size_t size) { return static_cast<OrtDefaultCpuAllocator*>(this_)->Alloc(size); };
+    OrtAllocator::GetStats =
+        [](const OrtAllocator* /*this_*/, OrtAllocator* /*allocator*/, char** /*stats*/) noexcept -> OrtStatusPtr {
+      return OrtApis::CreateStatus(ORT_NOT_IMPLEMENTED, "This API is not supported by the allocator");
+    };
     Ort::ThrowOnError(OrtApis::CreateCpuMemoryInfo(OrtDeviceAllocator, OrtMemTypeDefault, &cpu_memory_info));
   }
 

--- a/onnxruntime/core/session/default_cpu_allocator_c_api.cc
+++ b/onnxruntime/core/session/default_cpu_allocator_c_api.cc
@@ -20,7 +20,7 @@ struct OrtDefaultCpuAllocator : onnxruntime::OrtAllocatorImpl {
     OrtAllocator::Reserve =
         [](OrtAllocator* this_, size_t size) { return static_cast<OrtDefaultCpuAllocator*>(this_)->Alloc(size); };
     OrtAllocator::GetStats =
-        [](const OrtAllocator* /*this_*/, OrtAllocator* /*allocator*/, char** /*stats*/) noexcept -> OrtStatusPtr {
+        [](const OrtAllocator* /*this_*/, OrtKeyValuePairs** /*stats*/) noexcept -> OrtStatusPtr {
       return OrtApis::CreateStatus(ORT_NOT_IMPLEMENTED, "This API is not supported by the allocator");
     };
     Ort::ThrowOnError(OrtApis::CreateCpuMemoryInfo(OrtDeviceAllocator, OrtMemTypeDefault, &cpu_memory_info));

--- a/onnxruntime/core/session/default_cpu_allocator_c_api.cc
+++ b/onnxruntime/core/session/default_cpu_allocator_c_api.cc
@@ -22,6 +22,7 @@ struct OrtDefaultCpuAllocator : onnxruntime::OrtAllocatorImpl {
         [](OrtAllocator* this_, size_t size) { return static_cast<OrtDefaultCpuAllocator*>(this_)->Alloc(size); };
     OrtAllocator::GetStats =
         [](const OrtAllocator* /*this_*/, OrtKeyValuePairs** stats) noexcept -> OrtStatusPtr {
+      // Default allocator does not support stats, return an empty OrtKeyValuePairs.
       auto kvp = std::make_unique<OrtKeyValuePairs>();
       *stats = reinterpret_cast<OrtKeyValuePairs*>(kvp.release());
       return nullptr;

--- a/onnxruntime/core/session/default_cpu_allocator_c_api.cc
+++ b/onnxruntime/core/session/default_cpu_allocator_c_api.cc
@@ -3,6 +3,7 @@
 
 #include "core/framework/utils.h"
 #include "core/framework/allocator.h"
+#include "core/session/abi_key_value_pairs.h"
 #include "core/session/allocator_adapters.h"
 #include "core/session/onnxruntime_cxx_api.h"
 #include "core/session/ort_apis.h"
@@ -20,8 +21,10 @@ struct OrtDefaultCpuAllocator : onnxruntime::OrtAllocatorImpl {
     OrtAllocator::Reserve =
         [](OrtAllocator* this_, size_t size) { return static_cast<OrtDefaultCpuAllocator*>(this_)->Alloc(size); };
     OrtAllocator::GetStats =
-        [](const OrtAllocator* /*this_*/, OrtKeyValuePairs** /*stats*/) noexcept -> OrtStatusPtr {
-      return OrtApis::CreateStatus(ORT_NOT_IMPLEMENTED, "This API is not supported by the allocator");
+        [](const OrtAllocator* /*this_*/, OrtKeyValuePairs** stats) noexcept -> OrtStatusPtr {
+      auto kvp = std::make_unique<OrtKeyValuePairs>();
+      *stats = reinterpret_cast<OrtKeyValuePairs*>(kvp.release());
+      return nullptr;
     };
     Ort::ThrowOnError(OrtApis::CreateCpuMemoryInfo(OrtDeviceAllocator, OrtMemTypeDefault, &cpu_memory_info));
   }

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -1567,6 +1567,17 @@ ORT_API_STATUS_IMPL(OrtApis::AllocatorGetInfo, _In_ const OrtAllocator* ptr, _Ou
   API_IMPL_END
 }
 
+ORT_API_STATUS_IMPL(OrtApis::AllocatorGetStats, _In_ const OrtAllocator* ptr, _Inout_ OrtAllocator* allocator, _Outptr_ char** out) {
+  API_IMPL_BEGIN
+  if (ptr->GetStats != nullptr) {
+    ptr->GetStats(ptr, allocator, out);
+  } else {
+    out = nullptr;
+  }
+  return nullptr;
+  API_IMPL_END
+}
+
 template <typename T>
 ORT_STATUS_PTR OrtGetNumSequenceElements(const OrtValue* p_ml_value, size_t* out) {
   auto& data = p_ml_value->Get<T>();
@@ -3024,6 +3035,7 @@ static constexpr OrtApi ort_api_1_to_23 = {
     &OrtApis::GetEpApi,
     // End of Version 22 - DO NOT MODIFY ABOVE (see above text for more information)
     &OrtApis::GetTensorSizeInBytes,
+    &OrtApis::AllocatorGetStats,
 };
 
 // OrtApiBase can never change as there is no way to know what version of OrtApiBase is returned by OrtGetApiBase.

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -1570,6 +1570,9 @@ ORT_API_STATUS_IMPL(OrtApis::AllocatorGetInfo, _In_ const OrtAllocator* ptr, _Ou
 ORT_API_STATUS_IMPL(OrtApis::AllocatorGetStats, _In_ const OrtAllocator* ptr, _Inout_ OrtAllocator* allocator, _Outptr_ char** out) {
   API_IMPL_BEGIN
 #ifdef ORT_NO_RTTI
+  ORT_UNUSED_PARAMETER(ptr);
+  ORT_UNUSED_PARAMETER(allocator);
+  ORT_UNUSED_PARAMETER(out);
   return OrtApis::CreateStatus(ORT_NOT_IMPLEMENTED, "This API is not supported in a NO_RTTI build.");
 #else
   return ptr->GetStats(ptr, allocator, out);

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -1569,14 +1569,7 @@ ORT_API_STATUS_IMPL(OrtApis::AllocatorGetInfo, _In_ const OrtAllocator* ptr, _Ou
 
 ORT_API_STATUS_IMPL(OrtApis::AllocatorGetStats, _In_ const OrtAllocator* ptr, _Inout_ OrtAllocator* allocator, _Outptr_ char** out) {
   API_IMPL_BEGIN
-#ifdef ORT_NO_RTTI
-  ORT_UNUSED_PARAMETER(ptr);
-  ORT_UNUSED_PARAMETER(allocator);
-  ORT_UNUSED_PARAMETER(out);
-  return OrtApis::CreateStatus(ORT_NOT_IMPLEMENTED, "This API is not supported in a NO_RTTI build.");
-#else
   return ptr->GetStats(ptr, allocator, out);
-#endif
   API_IMPL_END
 }
 

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -1567,16 +1567,15 @@ ORT_API_STATUS_IMPL(OrtApis::AllocatorGetInfo, _In_ const OrtAllocator* ptr, _Ou
   API_IMPL_END
 }
 
-ORT_API_STATUS_IMPL(OrtApis::AllocatorGetStats, _In_ const OrtAllocator* ptr, _Inout_ OrtAllocator* allocator, _Outptr_ char** out) {
+ORT_API_STATUS_IMPL(OrtApis::AllocatorGetStats, _In_ const OrtAllocator* ptr, _Outptr_ OrtKeyValuePairs** out) {
   API_IMPL_BEGIN
 #ifdef ORT_NO_RTTI
   // When exception is disabled, we should directly return an error status to avoid aborting the program.
   ORT_UNUSED_PARAMETER(ptr);
-  ORT_UNUSED_PARAMETER(allocator);
   ORT_UNUSED_PARAMETER(out);
   return OrtApis::CreateStatus(ORT_NOT_IMPLEMENTED, "This API is not supported in a NO_RTTI build.");
 #else
-  return ptr->GetStats(ptr, allocator, out);
+  return ptr->GetStats(ptr, out);
 #endif
   API_IMPL_END
 }

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -1570,6 +1570,7 @@ ORT_API_STATUS_IMPL(OrtApis::AllocatorGetInfo, _In_ const OrtAllocator* ptr, _Ou
 ORT_API_STATUS_IMPL(OrtApis::AllocatorGetStats, _In_ const OrtAllocator* ptr, _Inout_ OrtAllocator* allocator, _Outptr_ char** out) {
   API_IMPL_BEGIN
 #ifdef ORT_NO_RTTI
+  // When exception is disabled, we should directly return an error status to avoid aborting the program.
   ORT_UNUSED_PARAMETER(ptr);
   ORT_UNUSED_PARAMETER(allocator);
   ORT_UNUSED_PARAMETER(out);

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -1569,7 +1569,14 @@ ORT_API_STATUS_IMPL(OrtApis::AllocatorGetInfo, _In_ const OrtAllocator* ptr, _Ou
 
 ORT_API_STATUS_IMPL(OrtApis::AllocatorGetStats, _In_ const OrtAllocator* ptr, _Inout_ OrtAllocator* allocator, _Outptr_ char** out) {
   API_IMPL_BEGIN
+#ifdef ORT_NO_RTTI
+  ORT_UNUSED_PARAMETER(ptr);
+  ORT_UNUSED_PARAMETER(allocator);
+  ORT_UNUSED_PARAMETER(out);
+  return OrtApis::CreateStatus(ORT_NOT_IMPLEMENTED, "This API is not supported in a NO_RTTI build.");
+#else
   return ptr->GetStats(ptr, allocator, out);
+#endif
   API_IMPL_END
 }
 

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -1573,9 +1573,7 @@ ORT_API_STATUS_IMPL(OrtApis::AllocatorGetStats, _In_ const OrtAllocator* ptr, _I
     out = nullptr;
     return OrtApis::CreateStatus(ORT_NOT_IMPLEMENTED, "This API is not supported by the allocator");
   }
-
-  ptr->GetStats(ptr, allocator, out);
-  return nullptr;
+  return ptr->GetStats(ptr, allocator, out);
   API_IMPL_END
 }
 

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -1569,10 +1569,6 @@ ORT_API_STATUS_IMPL(OrtApis::AllocatorGetInfo, _In_ const OrtAllocator* ptr, _Ou
 
 ORT_API_STATUS_IMPL(OrtApis::AllocatorGetStats, _In_ const OrtAllocator* ptr, _Inout_ OrtAllocator* allocator, _Outptr_ char** out) {
   API_IMPL_BEGIN
-  if (ptr->GetStats == nullptr) {
-    out = nullptr;
-    return OrtApis::CreateStatus(ORT_NOT_IMPLEMENTED, "This API is not supported by the allocator");
-  }
   return ptr->GetStats(ptr, allocator, out);
   API_IMPL_END
 }

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -1569,14 +1569,7 @@ ORT_API_STATUS_IMPL(OrtApis::AllocatorGetInfo, _In_ const OrtAllocator* ptr, _Ou
 
 ORT_API_STATUS_IMPL(OrtApis::AllocatorGetStats, _In_ const OrtAllocator* ptr, _Outptr_ OrtKeyValuePairs** out) {
   API_IMPL_BEGIN
-#ifdef ORT_NO_RTTI
-  // When exception is disabled, we should directly return an error status to avoid aborting the program.
-  ORT_UNUSED_PARAMETER(ptr);
-  ORT_UNUSED_PARAMETER(out);
-  return OrtApis::CreateStatus(ORT_NOT_IMPLEMENTED, "This API is not supported in a NO_RTTI build.");
-#else
   return ptr->GetStats(ptr, out);
-#endif
   API_IMPL_END
 }
 

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -1569,7 +1569,11 @@ ORT_API_STATUS_IMPL(OrtApis::AllocatorGetInfo, _In_ const OrtAllocator* ptr, _Ou
 
 ORT_API_STATUS_IMPL(OrtApis::AllocatorGetStats, _In_ const OrtAllocator* ptr, _Inout_ OrtAllocator* allocator, _Outptr_ char** out) {
   API_IMPL_BEGIN
+#ifdef ORT_NO_RTTI
+  return OrtApis::CreateStatus(ORT_NOT_IMPLEMENTED, "This API is not supported in a NO_RTTI build.");
+#else
   return ptr->GetStats(ptr, allocator, out);
+#endif
   API_IMPL_END
 }
 

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -1569,11 +1569,12 @@ ORT_API_STATUS_IMPL(OrtApis::AllocatorGetInfo, _In_ const OrtAllocator* ptr, _Ou
 
 ORT_API_STATUS_IMPL(OrtApis::AllocatorGetStats, _In_ const OrtAllocator* ptr, _Inout_ OrtAllocator* allocator, _Outptr_ char** out) {
   API_IMPL_BEGIN
-  if (ptr->GetStats != nullptr) {
-    ptr->GetStats(ptr, allocator, out);
-  } else {
+  if (ptr->GetStats == nullptr) {
     out = nullptr;
+    return OrtApis::CreateStatus(ORT_NOT_IMPLEMENTED, "This API is not supported by the allocator");
   }
+
+  ptr->GetStats(ptr, allocator, out);
   return nullptr;
   API_IMPL_END
 }

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -601,5 +601,5 @@ ORT_API(const OrtEpApi*, GetEpApi);
 
 ORT_API_STATUS_IMPL(GetTensorSizeInBytes, _In_ const OrtValue* ort_value, _Out_ size_t* size);
 
-ORT_API_STATUS_IMPL(AllocatorGetStats, _In_ const OrtAllocator* ptr, _Inout_ OrtAllocator* allocator, _Outptr_ char** out);
+ORT_API_STATUS_IMPL(AllocatorGetStats, _In_ const OrtAllocator* ptr, _Outptr_ OrtKeyValuePairs** out);
 }  // namespace OrtApis

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -601,4 +601,5 @@ ORT_API(const OrtEpApi*, GetEpApi);
 
 ORT_API_STATUS_IMPL(GetTensorSizeInBytes, _In_ const OrtValue* ort_value, _Out_ size_t* size);
 
+ORT_API_STATUS_IMPL(AllocatorGetStats, _In_ const OrtAllocator* ptr, _Inout_ OrtAllocator* allocator, _Outptr_ char** out);
 }  // namespace OrtApis

--- a/onnxruntime/test/shared_lib/test_allocator.cc
+++ b/onnxruntime/test/shared_lib/test_allocator.cc
@@ -32,9 +32,9 @@ TEST(CApiTest, DefaultAllocator) {
   ASSERT_NE(allocation.get(), nullptr);
   memset(allocation.get(), 0, 100U);
 
-  // Default Allocator does not support GetStats
+  // Default Allocator does not implement GetStats and return empty kvp
   Ort::ConstKeyValuePairs stats{};
   auto status = default_allocator.GetStats(&stats);
-  ASSERT_FALSE(status.IsOK());
-  ASSERT_EQ(ORT_NOT_IMPLEMENTED, status.GetErrorCode());
+  ASSERT_TRUE(status.IsOK());
+  ASSERT_EQ(0, stats.GetKeyValuePairs().size());
 }

--- a/onnxruntime/test/shared_lib/test_allocator.cc
+++ b/onnxruntime/test/shared_lib/test_allocator.cc
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include <unordered_map>
-
 #include "core/session/onnxruntime_cxx_api.h"
 #include "core/providers/cpu/cpu_provider_factory.h"
 #include <gtest/gtest.h>
@@ -35,8 +33,8 @@ TEST(CApiTest, DefaultAllocator) {
   memset(allocation.get(), 0, 100U);
 
   // Default Allocator does not support GetStats
-  std::unordered_map<std::string, std::string> stats;
-  auto status = default_allocator.GetStats(stats);
+  Ort::ConstKeyValuePairs stats{};
+  auto status = default_allocator.GetStats(&stats);
   ASSERT_FALSE(status.IsOK());
   ASSERT_EQ(ORT_NOT_IMPLEMENTED, status.GetErrorCode());
 }

--- a/onnxruntime/test/shared_lib/test_allocator.cc
+++ b/onnxruntime/test/shared_lib/test_allocator.cc
@@ -33,7 +33,7 @@ TEST(CApiTest, DefaultAllocator) {
   memset(allocation.get(), 0, 100U);
 
   // Default Allocator does not implement GetStats, we expect the stats to be empty.
-  Ort::ConstKeyValuePairs stats{};
+  Ort::KeyValuePairs stats{};
   auto status = default_allocator.GetStats(&stats);
   ASSERT_TRUE(status.IsOK());
   ASSERT_EQ(0, stats.GetKeyValuePairs().size());

--- a/onnxruntime/test/shared_lib/test_allocator.cc
+++ b/onnxruntime/test/shared_lib/test_allocator.cc
@@ -34,7 +34,7 @@ TEST(CApiTest, DefaultAllocator) {
   ASSERT_NE(allocation.get(), nullptr);
   memset(allocation.get(), 0, 100U);
 
-  // Default Allocator has no stats to report
+  // Default Allocator does not support GetStats
   std::unordered_map<std::string, std::string> stats;
   auto status = default_allocator.GetStats(stats);
   ASSERT_FALSE(status.IsOK());

--- a/onnxruntime/test/shared_lib/test_allocator.cc
+++ b/onnxruntime/test/shared_lib/test_allocator.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <unordered_map>
+
 #include "core/session/onnxruntime_cxx_api.h"
 #include "core/providers/cpu/cpu_provider_factory.h"
 #include <gtest/gtest.h>
@@ -33,6 +35,8 @@ TEST(CApiTest, DefaultAllocator) {
   memset(allocation.get(), 0, 100U);
 
   // Default Allocator has no stats to report
-  auto stats = default_allocator.GetStats();
-  ASSERT_EQ(stats.size(), 0U);
+  std::unordered_map<std::string, std::string> stats;
+  auto status = default_allocator.GetStats(stats);
+  ASSERT_FALSE(status.IsOK());
+  ASSERT_EQ(ORT_NOT_IMPLEMENTED, status.GetErrorCode());
 }

--- a/onnxruntime/test/shared_lib/test_allocator.cc
+++ b/onnxruntime/test/shared_lib/test_allocator.cc
@@ -31,4 +31,8 @@ TEST(CApiTest, DefaultAllocator) {
   ASSERT_EQ(allocation.size(), 100U);
   ASSERT_NE(allocation.get(), nullptr);
   memset(allocation.get(), 0, 100U);
+
+  // Default Allocator has no stats to report
+  auto stats = default_allocator.GetStats();
+  ASSERT_EQ(stats.size(), 0U);
 }

--- a/onnxruntime/test/shared_lib/test_allocator.cc
+++ b/onnxruntime/test/shared_lib/test_allocator.cc
@@ -33,8 +33,6 @@ TEST(CApiTest, DefaultAllocator) {
   memset(allocation.get(), 0, 100U);
 
   // Default Allocator does not implement GetStats, we expect the stats to be empty.
-  Ort::KeyValuePairs stats{};
-  auto status = default_allocator.GetStats(&stats);
-  ASSERT_TRUE(status.IsOK());
+  Ort::KeyValuePairs stats = default_allocator.GetStats();
   ASSERT_EQ(0, stats.GetKeyValuePairs().size());
 }

--- a/onnxruntime/test/shared_lib/test_allocator.cc
+++ b/onnxruntime/test/shared_lib/test_allocator.cc
@@ -32,7 +32,7 @@ TEST(CApiTest, DefaultAllocator) {
   ASSERT_NE(allocation.get(), nullptr);
   memset(allocation.get(), 0, 100U);
 
-  // Default Allocator does not implement GetStats and return empty kvp
+  // Default Allocator does not implement GetStats, we expect the stats to be empty.
   Ort::ConstKeyValuePairs stats{};
   auto status = default_allocator.GetStats(&stats);
   ASSERT_TRUE(status.IsOK());

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -1993,14 +1993,11 @@ TEST(CApiTest, get_allocator_cpu) {
   ASSERT_NE(nullptr, mem_allocation.get());
   ASSERT_EQ(1024U, mem_allocation.size());
 
-  Ort::KeyValuePairs stats;
-  auto status = cpu_allocator.GetStats(&stats);
+  Ort::KeyValuePairs stats = cpu_allocator.GetStats();
 
   // CPU allocator may not support arena usage.
   // See func DoesCpuAllocatorSupportArenaUsage() in allocator_utils.cc.
   if (allocator_info.GetAllocatorType() == OrtAllocatorType::OrtArenaAllocator) {
-    ASSERT_TRUE(status.IsOK());
-
     ASSERT_EQ("-1", std::string(stats.GetValue("Limit")));
     ASSERT_EQ("1024", std::string(stats.GetValue("InUse")));
     ASSERT_EQ("1024", std::string(stats.GetValue("MaxInUse")));
@@ -2014,7 +2011,6 @@ TEST(CApiTest, get_allocator_cpu) {
     ASSERT_NE(nullptr, stats.GetValue("NumArenaShrinkages"));
   } else {
     // If the allocator is not an arena allocator, we expect the stats to be empty.
-    ASSERT_TRUE(status.IsOK());
     ASSERT_EQ(0, stats.GetKeyValuePairs().size());
   }
 }
@@ -2040,9 +2036,7 @@ TEST(CApiTest, get_allocator_cuda) {
   ASSERT_NE(nullptr, mem_allocation.get());
   ASSERT_EQ(1024U, mem_allocation.size());
 
-  Ort::KeyValuePairs stats;
-  auto status = cuda_allocator.GetStats(&stats);
-  ASSERT_TRUE(status.IsOK());
+  Ort::KeyValuePairs stats = cuda_allocator.GetStats();
 
   ASSERT_EQ("-1", std::string(stats.GetValue("Limit")));
   ASSERT_EQ("1024", std::string(stats.GetValue("InUse")));

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -2045,7 +2045,7 @@ TEST(CApiTest, get_allocator_cuda) {
   ASSERT_EQ(1024U, mem_allocation.size());
 
   Ort::ConstKeyValuePairs stats;
-  auto status = cuda_allocator.GetStats(stats);
+  auto status = cuda_allocator.GetStats(&stats);
   ASSERT_TRUE(status.IsOK());
 
   ASSERT_EQ("-1", std::string(stats.GetValue("Limit")));

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -1992,6 +1992,26 @@ TEST(CApiTest, get_allocator_cpu) {
   auto mem_allocation = cpu_allocator.GetAllocation(1024);
   ASSERT_NE(nullptr, mem_allocation.get());
   ASSERT_EQ(1024U, mem_allocation.size());
+
+  auto stats = cpu_allocator.GetStats();
+  // The following check is fail in some CI builds
+  // ASSERT_EQ(1024, std::stoi(stats["bytes_in_use"]));
+
+  std::vector<std::string> expected_stats_keys = {
+      "bytes_in_use",
+      "bytes_limit",
+      "num_allocs",
+      "num_reserves",
+      "num_arena_extensions",
+      "num_arena_shrinkages",
+      "total_allocated_bytes",
+      "max_bytes_in_use",
+      "max_alloc_size",
+  };
+
+  for (const auto& key : expected_stats_keys) {
+    ASSERT_TRUE(stats.find(key) != stats.end()) << "Missing key: " << key;
+  }
 }
 
 #ifdef USE_CUDA
@@ -2014,6 +2034,25 @@ TEST(CApiTest, get_allocator_cuda) {
   auto mem_allocation = cuda_allocator.GetAllocation(1024);
   ASSERT_NE(nullptr, mem_allocation.get());
   ASSERT_EQ(1024U, mem_allocation.size());
+
+  auto stats = cuda_allocator.GetStats();
+  ASSERT_EQ(1024, std::stoi(stats["bytes_in_use"]));
+
+  std::vector<std::string> expected_stats_keys = {
+      "bytes_in_use",
+      "bytes_limit",
+      "num_allocs",
+      "num_reserves",
+      "num_arena_extensions",
+      "num_arena_shrinkages",
+      "total_allocated_bytes",
+      "max_bytes_in_use",
+      "max_alloc_size",
+  };
+
+  for (const auto& key : expected_stats_keys) {
+    ASSERT_TRUE(stats.find(key) != stats.end()) << "Missing key: " << key;
+  }
 }
 #endif
 

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -1998,7 +1998,7 @@ TEST(CApiTest, get_allocator_cpu) {
   auto status = cpu_allocator.GetStats(stats);
 
   // TODO: Investigate why it fails in some CI builds.
-  EXPECT_TRUE(status.IsOK());
+  EXPECT_TRUE(status.IsOK()) << status.GetErrorMessage();
 }
 
 #ifdef USE_CUDA

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -1997,15 +1997,23 @@ TEST(CApiTest, get_allocator_cpu) {
   std::unordered_map<std::string, std::string> stats;
   auto status = cpu_allocator.GetStats(stats);
 
+  // CPU allocator may not support arena usage.
+  // See func DoesCpuAllocatorSupportArenaUsage() in allocator_utils.cc.
   if (allocator_info.GetAllocatorType() == OrtAllocatorType::OrtArenaAllocator) {
     ASSERT_TRUE(status.IsOK());
+
+    ASSERT_EQ("-1", stats["Limit"]);
     ASSERT_EQ("1024", stats["InUse"]);
     ASSERT_EQ("1024", stats["MaxInUse"]);
     ASSERT_EQ("1024", stats["MaxAllocSize"]);
     ASSERT_EQ("2", stats["NumAllocs"]);
     ASSERT_EQ("0", stats["NumReserves"]);
+
+    // We don't check values of the following stats keys
+    ASSERT_TRUE(stats.find("TotalAllocated") != stats.end());
+    ASSERT_TRUE(stats.find("NumArenaExtensions") != stats.end());
+    ASSERT_TRUE(stats.find("NumArenaShrinkages") != stats.end());
   } else {
-    // Device allocator does not support GetStats API
     ASSERT_FALSE(status.IsOK());
     ASSERT_EQ(ORT_NOT_IMPLEMENTED, status.GetErrorCode());
   }
@@ -2035,11 +2043,18 @@ TEST(CApiTest, get_allocator_cuda) {
   std::unordered_map<std::string, std::string> stats;
   auto status = cuda_allocator.GetStats(stats);
   ASSERT_TRUE(status.IsOK());
+
+  ASSERT_EQ("-1", stats["Limit"]);
   ASSERT_EQ("1024", stats["InUse"]);
   ASSERT_EQ("1024", stats["MaxInUse"]);
   ASSERT_EQ("1024", stats["MaxAllocSize"]);
   ASSERT_EQ("2", stats["NumAllocs"]);
   ASSERT_EQ("0", stats["NumReserves"]);
+
+  // We don't check values of the following stats keys
+  ASSERT_TRUE(stats.find("TotalAllocated") != stats.end());
+  ASSERT_TRUE(stats.find("NumArenaExtensions") != stats.end());
+  ASSERT_TRUE(stats.find("NumArenaShrinkages") != stats.end());
 }
 #endif
 

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -1993,7 +1993,7 @@ TEST(CApiTest, get_allocator_cpu) {
   ASSERT_NE(nullptr, mem_allocation.get());
   ASSERT_EQ(1024U, mem_allocation.size());
 
-  Ort::ConstKeyValuePairs stats;
+  Ort::KeyValuePairs stats;
   auto status = cpu_allocator.GetStats(&stats);
 
   // CPU allocator may not support arena usage.
@@ -2040,7 +2040,7 @@ TEST(CApiTest, get_allocator_cuda) {
   ASSERT_NE(nullptr, mem_allocation.get());
   ASSERT_EQ(1024U, mem_allocation.size());
 
-  Ort::ConstKeyValuePairs stats;
+  Ort::KeyValuePairs stats;
   auto status = cuda_allocator.GetStats(&stats);
   ASSERT_TRUE(status.IsOK());
 

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -1996,10 +1996,6 @@ TEST(CApiTest, get_allocator_cpu) {
   Ort::ConstKeyValuePairs stats;
   auto status = cpu_allocator.GetStats(&stats);
 
-#ifdef ORT_NO_RTTI
-  ASSERT_FALSE(status.IsOK());
-  ASSERT_EQ(ORT_NOT_IMPLEMENTED, status.GetErrorCode());
-#else
   // CPU allocator may not support arena usage.
   // See func DoesCpuAllocatorSupportArenaUsage() in allocator_utils.cc.
   if (allocator_info.GetAllocatorType() == OrtAllocatorType::OrtArenaAllocator) {
@@ -2017,10 +2013,10 @@ TEST(CApiTest, get_allocator_cpu) {
     ASSERT_NE(nullptr, stats.GetValue("NumArenaExtensions"));
     ASSERT_NE(nullptr, stats.GetValue("NumArenaShrinkages"));
   } else {
-    ASSERT_FALSE(status.IsOK());
-    ASSERT_EQ(ORT_NOT_IMPLEMENTED, status.GetErrorCode());
+    // If the allocator is not an arena allocator, we expect the stats to be empty.
+    ASSERT_TRUE(status.IsOK());
+    ASSERT_EQ(0, stats.GetKeyValuePairs().size());
   }
-#endif
 }
 
 #ifdef USE_CUDA

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -10,6 +10,7 @@
 #include <mutex>
 #include <sstream>
 #include <thread>
+#include <unordered_map>
 #include <vector>
 
 #include <absl/base/config.h>
@@ -1992,6 +1993,12 @@ TEST(CApiTest, get_allocator_cpu) {
   auto mem_allocation = cpu_allocator.GetAllocation(1024);
   ASSERT_NE(nullptr, mem_allocation.get());
   ASSERT_EQ(1024U, mem_allocation.size());
+
+  std::unordered_map<std::string, std::string> stats;
+  auto status = cpu_allocator.GetStats(stats);
+
+  // TODO: Investigate why it fails in some CI builds.
+  EXPECT_TRUE(status.IsOK());
 }
 
 #ifdef USE_CUDA
@@ -2015,7 +2022,9 @@ TEST(CApiTest, get_allocator_cuda) {
   ASSERT_NE(nullptr, mem_allocation.get());
   ASSERT_EQ(1024U, mem_allocation.size());
 
-  auto stats = cuda_allocator.GetStats();
+  std::unordered_map<std::string, std::string> stats;
+  auto status = cuda_allocator.GetStats(stats);
+  EXPECT_TRUE(status.IsOK());
   ASSERT_EQ(1024, std::stoi(stats["InUse"]));
 
   std::vector<std::string> expected_stats_keys = {

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -2033,7 +2033,7 @@ TEST(CApiTest, get_allocator_cuda) {
   ASSERT_EQ(1024U, mem_allocation.size());
 
   auto stats = cuda_allocator.GetStats();
-  ASSERT_EQ(1024, std::stoi(stats["bytes_in_use"]));
+  ASSERT_EQ(1024, std::stoi(stats["InUse"]));
 
   std::vector<std::string> expected_stats_keys = {
       "Limit",

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -1992,23 +1992,6 @@ TEST(CApiTest, get_allocator_cpu) {
   auto mem_allocation = cpu_allocator.GetAllocation(1024);
   ASSERT_NE(nullptr, mem_allocation.get());
   ASSERT_EQ(1024U, mem_allocation.size());
-
-  auto stats = cpu_allocator.GetStats();
-  std::vector<std::string> expected_stats_keys = {
-      "Limit",
-      "InUse",
-      "TotalAllocated",
-      "MaxInUse",
-      "NumAllocs",
-      "NumReserves",
-      "NumArenaExtensions",
-      "NumArenaShrinkages",
-      "MaxAllocSize",
-  };
-
-  for (const auto& key : expected_stats_keys) {
-    ASSERT_TRUE(stats.find(key) != stats.end()) << "Missing key: " << key;
-  }
 }
 
 #ifdef USE_CUDA

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -1997,6 +1997,10 @@ TEST(CApiTest, get_allocator_cpu) {
   std::unordered_map<std::string, std::string> stats;
   auto status = cpu_allocator.GetStats(stats);
 
+#ifdef ORT_NO_RTTI
+  ASSERT_FALSE(status.IsOK());
+  ASSERT_EQ(ORT_NOT_IMPLEMENTED, status.GetErrorCode());
+#else
   // CPU allocator may not support arena usage.
   // See func DoesCpuAllocatorSupportArenaUsage() in allocator_utils.cc.
   if (allocator_info.GetAllocatorType() == OrtAllocatorType::OrtArenaAllocator) {
@@ -2017,6 +2021,7 @@ TEST(CApiTest, get_allocator_cpu) {
     ASSERT_FALSE(status.IsOK());
     ASSERT_EQ(ORT_NOT_IMPLEMENTED, status.GetErrorCode());
   }
+#endif
 }
 
 #ifdef USE_CUDA

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -10,7 +10,6 @@
 #include <mutex>
 #include <sstream>
 #include <thread>
-#include <unordered_map>
 #include <vector>
 
 #include <absl/base/config.h>
@@ -1994,8 +1993,8 @@ TEST(CApiTest, get_allocator_cpu) {
   ASSERT_NE(nullptr, mem_allocation.get());
   ASSERT_EQ(1024U, mem_allocation.size());
 
-  std::unordered_map<std::string, std::string> stats;
-  auto status = cpu_allocator.GetStats(stats);
+  Ort::ConstKeyValuePairs stats;
+  auto status = cpu_allocator.GetStats(&stats);
 
 #ifdef ORT_NO_RTTI
   ASSERT_FALSE(status.IsOK());
@@ -2006,17 +2005,17 @@ TEST(CApiTest, get_allocator_cpu) {
   if (allocator_info.GetAllocatorType() == OrtAllocatorType::OrtArenaAllocator) {
     ASSERT_TRUE(status.IsOK());
 
-    ASSERT_EQ("-1", stats["Limit"]);
-    ASSERT_EQ("1024", stats["InUse"]);
-    ASSERT_EQ("1024", stats["MaxInUse"]);
-    ASSERT_EQ("1024", stats["MaxAllocSize"]);
-    ASSERT_EQ("2", stats["NumAllocs"]);
-    ASSERT_EQ("0", stats["NumReserves"]);
+    ASSERT_EQ("-1", std::string(stats.GetValue("Limit")));
+    ASSERT_EQ("1024", std::string(stats.GetValue("InUse")));
+    ASSERT_EQ("1024", std::string(stats.GetValue("MaxInUse")));
+    ASSERT_EQ("1024", std::string(stats.GetValue("MaxAllocSize")));
+    ASSERT_EQ("2", std::string(stats.GetValue("NumAllocs")));
+    ASSERT_EQ("0", std::string(stats.GetValue("NumReserves")));
 
-    // We don't check values of the following stats keys
-    ASSERT_TRUE(stats.find("TotalAllocated") != stats.end());
-    ASSERT_TRUE(stats.find("NumArenaExtensions") != stats.end());
-    ASSERT_TRUE(stats.find("NumArenaShrinkages") != stats.end());
+    // We don't check values of the following stats
+    ASSERT_NE(nullptr, stats.GetValue("TotalAllocated"));
+    ASSERT_NE(nullptr, stats.GetValue("NumArenaExtensions"));
+    ASSERT_NE(nullptr, stats.GetValue("NumArenaShrinkages"));
   } else {
     ASSERT_FALSE(status.IsOK());
     ASSERT_EQ(ORT_NOT_IMPLEMENTED, status.GetErrorCode());
@@ -2045,21 +2044,21 @@ TEST(CApiTest, get_allocator_cuda) {
   ASSERT_NE(nullptr, mem_allocation.get());
   ASSERT_EQ(1024U, mem_allocation.size());
 
-  std::unordered_map<std::string, std::string> stats;
+  Ort::ConstKeyValuePairs stats;
   auto status = cuda_allocator.GetStats(stats);
   ASSERT_TRUE(status.IsOK());
 
-  ASSERT_EQ("-1", stats["Limit"]);
-  ASSERT_EQ("1024", stats["InUse"]);
-  ASSERT_EQ("1024", stats["MaxInUse"]);
-  ASSERT_EQ("1024", stats["MaxAllocSize"]);
-  ASSERT_EQ("2", stats["NumAllocs"]);
-  ASSERT_EQ("0", stats["NumReserves"]);
+  ASSERT_EQ("-1", std::string(stats.GetValue("Limit")));
+  ASSERT_EQ("1024", std::string(stats.GetValue("InUse")));
+  ASSERT_EQ("1024", std::string(stats.GetValue("MaxInUse")));
+  ASSERT_EQ("1024", std::string(stats.GetValue("MaxAllocSize")));
+  ASSERT_EQ("2", std::string(stats.GetValue("NumAllocs")));
+  ASSERT_EQ("0", std::string(stats.GetValue("NumReserves")));
 
-  // We don't check values of the following stats keys
-  ASSERT_TRUE(stats.find("TotalAllocated") != stats.end());
-  ASSERT_TRUE(stats.find("NumArenaExtensions") != stats.end());
-  ASSERT_TRUE(stats.find("NumArenaShrinkages") != stats.end());
+  // We don't check values of the following stats
+  ASSERT_NE(nullptr, stats.GetValue("TotalAllocated"));
+  ASSERT_NE(nullptr, stats.GetValue("NumArenaExtensions"));
+  ASSERT_NE(nullptr, stats.GetValue("NumArenaShrinkages"));
 }
 #endif
 

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -1994,19 +1994,16 @@ TEST(CApiTest, get_allocator_cpu) {
   ASSERT_EQ(1024U, mem_allocation.size());
 
   auto stats = cpu_allocator.GetStats();
-  // The following check is fail in some CI builds
-  // ASSERT_EQ(1024, std::stoi(stats["bytes_in_use"]));
-
   std::vector<std::string> expected_stats_keys = {
-      "bytes_in_use",
-      "bytes_limit",
-      "num_allocs",
-      "num_reserves",
-      "num_arena_extensions",
-      "num_arena_shrinkages",
-      "total_allocated_bytes",
-      "max_bytes_in_use",
-      "max_alloc_size",
+      "Limit",
+      "InUse",
+      "TotalAllocated",
+      "MaxInUse",
+      "NumAllocs",
+      "NumReserves",
+      "NumArenaExtensions",
+      "NumArenaShrinkages",
+      "MaxAllocSize",
   };
 
   for (const auto& key : expected_stats_keys) {
@@ -2039,15 +2036,15 @@ TEST(CApiTest, get_allocator_cuda) {
   ASSERT_EQ(1024, std::stoi(stats["bytes_in_use"]));
 
   std::vector<std::string> expected_stats_keys = {
-      "bytes_in_use",
-      "bytes_limit",
-      "num_allocs",
-      "num_reserves",
-      "num_arena_extensions",
-      "num_arena_shrinkages",
-      "total_allocated_bytes",
-      "max_bytes_in_use",
-      "max_alloc_size",
+      "Limit",
+      "InUse",
+      "TotalAllocated",
+      "MaxInUse",
+      "NumAllocs",
+      "NumReserves",
+      "NumArenaExtensions",
+      "NumArenaShrinkages",
+      "MaxAllocSize",
   };
 
   for (const auto& key : expected_stats_keys) {


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Extend IAllocator to get Allocator statistics:
- Add `OrtAllocator::GetStats` and `AllocatorGetStats` C-API.
- Add `Ort::Allocator::GetStats` Cxx API to parse the string and return as map.
- Add UT.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Our system integrates multiple models for inference, each with varying memory demands. Providing a mechanism to retrieve detailed memory statistics would be useful for analyzing memory usage across models and devices more effectively.

