### PR TITLE
[VITISAI] pass all session configs to vitisai ep for `Ort::CompileModel` flow

### DIFF
--- a/onnxruntime/core/providers/vitisai/vitisai_provider_factory.cc
+++ b/onnxruntime/core/providers/vitisai/vitisai_provider_factory.cc
@@ -84,7 +84,7 @@ struct VitisAI_Provider : Provider {
     }
   };
   // Get provider specific custom op domain list. Provider has the resposibility to release OrtCustomOpDomain instances it creates.
-  void GetCustomOpDomainList(IExecutionProviderFactory*, std::vector<OrtCustomOpDomain*>&) override{};
+  void GetCustomOpDomainList(IExecutionProviderFactory*, std::vector<OrtCustomOpDomain*>&) override {};
   // Called right after loading the shared library, if this throws any errors Shutdown() will be called and the library unloaded
   void Initialize() override { initialize_vitisai_ep(); }
   // Called right before unloading the shared library

--- a/onnxruntime/core/providers/vitisai/vitisai_provider_factory.cc
+++ b/onnxruntime/core/providers/vitisai/vitisai_provider_factory.cc
@@ -52,6 +52,8 @@ std::unique_ptr<IExecutionProvider> VitisAIProviderFactory::CreateProvider(const
   for (const auto& [key, value] : config_options_map) {
     if (key.rfind(key_prefix, 0) == 0) {
       provider_options[key.substr(key_prefix.size())] = value;
+    } else {
+      provider_options["ort_session_config." + key] = value;
     }
   }
 
@@ -82,7 +84,7 @@ struct VitisAI_Provider : Provider {
     }
   };
   // Get provider specific custom op domain list. Provider has the resposibility to release OrtCustomOpDomain instances it creates.
-  void GetCustomOpDomainList(IExecutionProviderFactory*, std::vector<OrtCustomOpDomain*>&) override {};
+  void GetCustomOpDomainList(IExecutionProviderFactory*, std::vector<OrtCustomOpDomain*>&) override{};
   // Called right after loading the shared library, if this throws any errors Shutdown() will be called and the library unloaded
   void Initialize() override { initialize_vitisai_ep(); }
   // Called right before unloading the shared library


### PR DESCRIPTION
### Description

convert all session configs, i.e. key-value pairs into provider options, the key prefixed with `ort_session_config.`


### Motivation and Context

#24445 has a bug when `Ort::CompileModel`  is used, not all session config are passed to VITISAI EP backend.
It is because that the `session_option` which holds a reference to `VitisiAIExectuionProviderFactory` is not as same as the `session_option` used for `Ort::CompileModel`. `Ort::CompileModel` create another `session_option` behind scene.

The symptom of this bug is that only the session configs in the first `SessionOptions` object is passed to  `VitisiAIExectuionProviderFactory` and session configs in the second `SessionOptions` are not, so that  VITISAI EP backend sometimes assumes that ep.cache_context is not enabled, and then ep context cache model is not created properly.



