### PR TITLE
[WebNN] Support ConvInteger op

### DIFF
--- a/js/web/docs/webnn-operators.md
+++ b/js/web/docs/webnn-operators.md
@@ -25,6 +25,7 @@ platforms. Check the [WebNN status](https://webmachinelearning.github.io/webnn-s
 | Clip | ai.onnx(7-10, 11, 12, 13+) | clamp | |
 | Concat | ai.onnx(7-10, 11-12, 13+) | concat | |
 | Conv | ai.onnx(7-10, 11+) | conv2d | Only supports 3-D or 4-D input and 'W' (weight) |
+| ConvInteger | ai.onnx(10+) | cast, conv2d, dequantizeLinear | Only supports 3-D or 4-D input and 'W' (weight) |
 | ConvTranspose | ai.onnx(7-10, 11+) | convTranspose2d | Only supports 3-D or 4-D input and 'W' (weight) |
 | Cos | ai.onnx(7+) | cos | |
 | CumSum | ai.onnx(11-13, 14+) | cumulativeSum | 'axis' input should be a constant |

--- a/onnxruntime/core/optimizer/transpose_optimization/onnx_transpose_optimization.cc
+++ b/onnxruntime/core/optimizer/transpose_optimization/onnx_transpose_optimization.cc
@@ -3308,7 +3308,7 @@ const std::unordered_set<std::string_view>& GetLayoutSensitiveOps() {
       "BatchNormalization", "InstanceNormalization",
 
       // convolutions
-      "Conv", "QLinearConv", "ConvTranspose",
+      "Conv", "ConvInteger", "QLinearConv", "ConvTranspose",
 
       // pooling
       "AveragePool", "LpPool", "MaxPool", "MaxUnpool",

--- a/onnxruntime/core/providers/webnn/builders/helper.h
+++ b/onnxruntime/core/providers/webnn/builders/helper.h
@@ -203,6 +203,7 @@ std::unordered_set<const Node*> GetSupportedNodes(const GraphViewer& graph_viewe
 
 // Some ONNX ops are supported by decomposed WebNN ops.
 const std::map<std::string_view, std::vector<std::string_view>> decomposed_op_map = {
+    {"ConvInteger", {"cast", "conv2d", "dequantizeLinear"}},
     {"GroupQueryAttention",
      {"add", "cast", "concat", "constant", "cumulativeSum", "div", "expand", "lesser", "matmul", "reshape", "scatterND",
       "softmax", "transpose", "where"}},
@@ -228,7 +229,6 @@ const std::map<std::string_view, std::string_view> op_map = {
     {"Clip", "clamp"},
     {"Concat", "concat"},
     {"Conv", "conv2d"},
-    {"ConvInteger", "conv2dInteger"},
     {"ConvTranspose", "convTranspose2d"},
     {"Cos", "cos"},
     {"CumSum", "cumulativeSum"},

--- a/onnxruntime/core/providers/webnn/builders/impl/conv_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/conv_op_builder.cc
@@ -30,6 +30,8 @@ class ConvOpBuilder : public BaseOpBuilder {
                          const WebnnDeviceType device_type, const logging::Logger& logger) const override;
   bool HasSupportedInputsImpl(const GraphViewer&, const Node& node,
                               const emscripten::val& wnn_limits, const logging::Logger& logger) const override;
+  bool HasSupportedOutputsImpl(const Node& node, const emscripten::val& wnn_limits,
+                               const logging::Logger& logger) const override;
 };
 
 void ConvOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) const {
@@ -52,18 +54,19 @@ common::Status SetConvBaseOptions(ModelBuilder& model_builder,
                                   const logging::Logger& logger) {
   NodeAttrHelper helper(node);
   const auto& input_defs = node.InputDefs();
+  const auto& op_type = node.OpType();
 
   // Add Padding.
   AutoPadType auto_pad_type = StringToAutoPadType(helper.Get("auto_pad", "NOTSET"));
   std::vector<int64_t> pads_out;
-  if (node.OpType() == "Conv" || node.OpType() == "ConvInteger") {
+  if (op_type == "Conv" || op_type == "ConvInteger") {
     // Calculate explicit padding for autoPad.
     if (AutoPadType::SAME_UPPER == auto_pad_type || AutoPadType::SAME_LOWER == auto_pad_type) {
       ORT_RETURN_IF_ERROR(HandleAutoPad(input_shape, weight_shape[2], weight_shape[3],
                                         pads, strides, dilations, auto_pad_type, pads_out, !is_nhwc));
       pads = pads_out;
     }
-  } else if (node.OpType() == "ConvTranspose") {
+  } else if (op_type == "ConvTranspose") {
     std::vector<int64_t> output_shape = helper.Get("output_shape", std::vector<int64_t>{-1, -1});
     // Appending 1's if it is ConvTranspose 1d and output shape is provided.
     if (output_shape.size() == 1 && is_conv1d && output_shape[0] != -1) {
@@ -103,7 +106,7 @@ common::Status SetConvBaseOptions(ModelBuilder& model_builder,
   options.set("padding", emscripten::val::array(GetNarrowedIntfromInt64<uint32_t>(padding)));
 
   // Add bias if present.
-  if (input_defs.size() > 2) {
+  if (input_defs.size() > 2 && op_type != "ConvInteger") {
     options.set("bias", model_builder.GetOperand(input_defs[2]->Name()));
   }
 
@@ -219,6 +222,8 @@ Status ConvOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const N
   const bool is_nhwc = model_builder.GetPreferredLayout() == DataLayout::NHWC;
   const bool is_conv1d = input_shape.size() == 3 && weight_shape.size() == 3;
   const bool is_constant_weight = Contains(initializers, weight_name);
+
+  emscripten::val common_options = emscripten::val::object();
   // Support conv1d by prepending a 1 or 2 size dimensions.
   if (is_conv1d) {
     // Reshape input.
@@ -230,7 +235,9 @@ Status ConvOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const N
       input_shape.push_back(1);
     }
     std::vector<uint32_t> new_shape = GetNarrowedIntfromInt64<uint32_t>(input_shape);
-    input = model_builder.GetBuilder().call<emscripten::val>("reshape", input, emscripten::val::array(new_shape));
+    common_options.set("label", node.Name() + "_reshape_input");
+    input = model_builder.GetBuilder().call<emscripten::val>("reshape", input,
+                                                             emscripten::val::array(new_shape), common_options);
 
     weight_shape.resize(4, 1);  // Ensure 4D by appending 1's if needed.
     strides.resize(2, 1);       // Ensure 2D by appending 1's if needed.
@@ -277,16 +284,14 @@ Status ConvOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const N
     if (!is_nhwc || !is_constant_weight) {
       // The weight_shape has been appended 1's, reshape weight operand.
       std::vector<uint32_t> new_shape = GetNarrowedIntfromInt64<uint32_t>(weight_shape);
-      emscripten::val reshape_options = emscripten::val::object();
-      reshape_options.set("label", node.Name() + "_reshape_filter");
+      common_options.set("label", node.Name() + "_reshape_filter");
       filter = model_builder.GetBuilder().call<emscripten::val>("reshape",
                                                                 filter,
                                                                 emscripten::val::array(new_shape),
-                                                                reshape_options);
+                                                                common_options);
     }
   }
 
-  emscripten::val transpose_options = emscripten::val::object();
   if (is_nhwc && !is_constant_weight) {
     // For NHWC preferred layout, if the weight is input:
     // - Transpose it from iohw -> ohwi for convTranspose.
@@ -298,6 +303,7 @@ Status ConvOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const N
     } else {
       perm = {0, 2, 3, 1};  // L_0231
     }
+    emscripten::val transpose_options = emscripten::val::object();
     transpose_options.set("permutation", emscripten::val::array(perm));
     transpose_options.set("label", node.Name() + "_transpose_filter");
     filter = model_builder.GetBuilder().call<emscripten::val>("transpose", filter, transpose_options);
@@ -306,20 +312,48 @@ Status ConvOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const N
   if (op_type == "Conv") {
     output = model_builder.GetBuilder().call<emscripten::val>("conv2d", input, filter, options);
   } else if (op_type == "ConvInteger") {
-    emscripten::val x_zero_point = emscripten::val::null();
-    emscripten::val w_zero_point = emscripten::val::null();
-    if (input_defs.size() >= 3) {
+    // WebNN doesn't provide a dedicated op for ConvInteger, it can be simply decomposed by
+    // DequantizeLinear x, w -> Conv -> Cast (to int32)
+    int32_t x_type;
+    ORT_RETURN_IF_NOT(GetType(*input_defs[0], x_type, logger), "Cannot get data type of input x");
+
+    emscripten::val x_zero_point, w_zero_point, x_scale, w_scale;
+    if (TensorExists(input_defs, 2)) {
       x_zero_point = model_builder.GetOperand(node.InputDefs()[2]->Name());
     } else {
-      x_zero_point = model_builder.CreateOrGetConstant<uint8_t>(ONNX_NAMESPACE::TensorProto_DataType_UINT8, 0);
+      x_zero_point = model_builder.CreateOrGetConstant<uint8_t>(x_type, 0);
     }
-    if (input_defs.size() >= 4) {
+
+    // Scale is not used by ConvInteger but required by DequantizeLinear. So set it to deafult value 1.0f.
+    // The x_zero_point must be a scalar and the scale input should have the same shape as the zero point input.
+    // So the x_scale must be a scalar too.
+    x_scale = model_builder.CreateOrGetConstant<float>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT, 1.0f);
+    // Dequantize x to Float32
+    common_options.set("label", node.Name() + "_dequantized_x");
+    input = model_builder.GetBuilder().call<emscripten::val>("dequantizeLinear", input, x_scale, x_zero_point,
+                                                             common_options);
+
+    if (TensorExists(input_defs, 3)) {
       w_zero_point = model_builder.GetOperand(node.InputDefs()[3]->Name());
+      std::vector<int64_t> w_zero_point_shape;
+      ORT_RETURN_IF_NOT(GetShape(*input_defs[3], w_zero_point_shape, logger), "Cannot get shape of w_zero_point");
+      w_scale = model_builder.CreateOrGetConstant<float>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT, 1.0f,
+                                                         GetNarrowedIntfromInt64<uint32_t>(w_zero_point_shape));
     } else {
-      w_zero_point = model_builder.CreateOrGetConstant<uint8_t>(ONNX_NAMESPACE::TensorProto_DataType_UINT8, 0);
+      w_zero_point = model_builder.CreateOrGetConstant<uint8_t>(x_type, 0);
+      w_scale = x_scale;
     }
-    output = model_builder.GetBuilder().call<emscripten::val>("conv2dInteger",
-                                                              input, x_zero_point, filter, w_zero_point, options);
+    // Dequantize w to Float32
+    common_options.set("label", node.Name() + "_dequantized_w");
+    filter = model_builder.GetBuilder().call<emscripten::val>("dequantizeLinear", filter, w_scale, w_zero_point,
+                                                              common_options);
+    // Conv with dequantized x and w
+    options.set("label", node.Name() + "_conv_dequantized_inputs");
+    output = model_builder.GetBuilder().call<emscripten::val>("conv2d", input, filter, options);
+
+    // Cast the result to int32
+    common_options.set("label", node.Name() + "_cast_output");
+    output = model_builder.GetBuilder().call<emscripten::val>("cast", output, emscripten::val("int32"), common_options);
   } else {
     output = model_builder.GetBuilder().call<emscripten::val>("convTranspose2d", input, filter, options);
   }
@@ -330,12 +364,11 @@ Status ConvOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const N
     std::vector<int64_t> output_shape;
     ORT_RETURN_IF_NOT(GetShape(*output_defs[0], output_shape, logger), "Cannot get output shape");
     std::vector<uint32_t> new_shape = GetNarrowedIntfromInt64<uint32_t>(output_shape);
-    emscripten::val reshape_options = emscripten::val::object();
-    reshape_options.set("label", node.Name() + "_reshape_output");
+    common_options.set("label", node.Name() + "_reshape_output");
     output = model_builder.GetBuilder().call<emscripten::val>("reshape",
                                                               output,
                                                               emscripten::val::array(new_shape),
-                                                              reshape_options);
+                                                              common_options);
   }
 
   model_builder.AddOperand(node.OutputDefs()[0]->Name(), std::move(output));
@@ -410,7 +443,31 @@ bool ConvOpBuilder::HasSupportedInputsImpl(const GraphViewer&, const Node& node,
     return false;
   }
 
-  return IsDataTypeSupportedByOp(op_type, input0_type, wnn_limits, "input", "X", logger);
+  if (op_type == "ConvInteger") {
+    // The first decomposed op of ConvInteger is DequantizeLinear, and so
+    // we only need to ensure it supports the input0_type.
+    return IsDataTypeSupportedByOp("DequantizeLinear", input0_type, wnn_limits, "input", "x", logger);
+  } else {
+    return IsDataTypeSupportedByOp(op_type, input0_type, wnn_limits, "input", "X", logger);
+  }
+}
+
+bool ConvOpBuilder::HasSupportedOutputsImpl(const Node& node, const emscripten::val& wnn_limits,
+                                            const logging::Logger& logger) const {
+  const auto& output = *node.OutputDefs()[0];
+  const std::string_view op_type = node.OpType();
+  int32_t output_type;
+  if (!GetType(output, output_type, logger)) {
+    return false;
+  }
+
+  if (op_type == "ConvInteger") {
+    // The last decomposed op of ConvInteger is Cast, and so
+    // we only need to ensure it supports the output_type.
+    return IsDataTypeSupportedByOp("Cast", output_type, wnn_limits, "output", "Output", logger);
+  } else {
+    return IsDataTypeSupportedByOp(op_type, output_type, wnn_limits, "output", "Output", logger);
+  }
 }
 
 void CreateConvOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {


### PR DESCRIPTION
WebNN doesn't provide a dedicated op for `ConvInteger`, this PR supports `ConvInteger` op by decomposing it into `DequantizeLinear x, w -> Conv -> Cast (to int32)`.

BTW, adds `ConvInteger` to layout sensitive op list for layout transformation when the preferred layout is NHWC.