### PR TITLE
support more data types in tensor dumper

### DIFF
--- a/onnxruntime/contrib_ops/cpu/utils/console_dumper.h
+++ b/onnxruntime/contrib_ops/cpu/utils/console_dumper.h
@@ -17,33 +17,30 @@ class IConsoleDumper {
   virtual ~IConsoleDumper() {}
   void Disable() { is_enabled_ = false; }
   bool IsEnabled() const { return is_enabled_; }
-  virtual void Print(const char* name, const float* tensor, int dim0, int dim1) const = 0;
-  virtual void Print(const char* name, const MLFloat16* tensor, int dim0, int dim1) const = 0;
+
   virtual void Print(const char* name, const size_t* tensor, int dim0, int dim1) const = 0;
-  virtual void Print(const char* name, const int64_t* tensor, int dim0, int dim1) const = 0;
-  virtual void Print(const char* name, const int32_t* tensor, int dim0, int dim1) const = 0;
-
-  virtual void Print(const char* name, const float* tensor, int dim0, int dim1, int dim2) const = 0;
-  virtual void Print(const char* name, const MLFloat16* tensor, int dim0, int dim1, int dim2) const = 0;
-  virtual void Print(const char* name, const int64_t* tensor, int dim0, int dim1, int dim2) const = 0;
-  virtual void Print(const char* name, const int32_t* tensor, int dim0, int dim1, int dim2) const = 0;
-
-  virtual void Print(const char* name, const float* tensor, int dim0, int dim1, int dim2, int dim3) const = 0;
-  virtual void Print(const char* name, const MLFloat16* tensor, int dim0, int dim1, int dim2, int dim3) const = 0;
-  virtual void Print(const char* name, const int64_t* tensor, int dim0, int dim1, int dim2, int dim3) const = 0;
-  virtual void Print(const char* name, const int32_t* tensor, int dim0, int dim1, int dim2, int dim3) const = 0;
-
-  virtual void Print(const char* name, const int32_t* tensor, gsl::span<const int64_t>& dims) const = 0;
-  virtual void Print(const char* name, const int64_t* tensor, gsl::span<const int64_t>& dims) const = 0;
-  virtual void Print(const char* name, const float* tensor, gsl::span<const int64_t>& dims) const = 0;
-  virtual void Print(const char* name, const MLFloat16* tensor, gsl::span<const int64_t>& dims) const = 0;
-
   virtual void Print(const char* name, const Tensor& value) const = 0;
   virtual void Print(const char* name, const OrtValue& value) const = 0;
   virtual void Print(const char* name, int index, bool end_line) const = 0;
   virtual void Print(const char* name, const std::string& value, bool end_line) const = 0;
-
   virtual void Print(const std::string& value) const = 0;
+
+#define TENSOR_DUMPER_PRINT_TYPE(dtype)                                                                        \
+  virtual void Print(const char* name, const dtype* tensor, int dim0, int dim1) const = 0;                     \
+  virtual void Print(const char* name, const dtype* tensor, int dim0, int dim1, int dim2) const = 0;           \
+  virtual void Print(const char* name, const dtype* tensor, int dim0, int dim1, int dim2, int dim3) const = 0; \
+  virtual void Print(const char* name, const dtype* tensor, gsl::span<const int64_t>& dims) const = 0;
+
+  TENSOR_DUMPER_PRINT_TYPE(int8_t)
+  TENSOR_DUMPER_PRINT_TYPE(uint8_t)
+  TENSOR_DUMPER_PRINT_TYPE(int32_t)
+  TENSOR_DUMPER_PRINT_TYPE(int64_t)
+  TENSOR_DUMPER_PRINT_TYPE(float)
+  TENSOR_DUMPER_PRINT_TYPE(MLFloat16)
+  TENSOR_DUMPER_PRINT_TYPE(BFloat16)
+  TENSOR_DUMPER_PRINT_TYPE(UInt4x2)
+  TENSOR_DUMPER_PRINT_TYPE(Int4x2)
+#undef TENSOR_DUMPER_PRINT_TYPE
 
  protected:
   bool is_enabled_;

--- a/onnxruntime/contrib_ops/cpu/utils/dump_tensor.cc
+++ b/onnxruntime/contrib_ops/cpu/utils/dump_tensor.cc
@@ -62,6 +62,54 @@ void DumpCpuTensor(const char* name, const T* tensor, int dim0, int dim1, int di
   }
 }
 
+template <typename T>
+void DumpCpuTensor(const char* name, const T* tensor, int dim0, int dim1, int dim2, int dim3) {
+  std::unique_lock<std::mutex> lock(s_mutex);
+
+  if (s_output_thread_id)
+    std::cout << "Thread ID:" << std::this_thread::get_id() << std::endl;
+
+  if (nullptr != name) {
+    std::cout << std::string(name) << std::endl;
+  }
+
+  if (onnxruntime::utils::kDefaultSnippetThreshold < static_cast<int64_t>(dim0 * dim1 * dim2 * dim3)) {
+    for (int i = 0; i < dim0; i++) {
+      std::cout << "[" << i << "]:" << std::endl;
+      onnxruntime::utils::PrintCpuTensorSnippet<T>(tensor + i * dim1 * dim2 * dim3, dim1, dim2, dim3,
+                                                   onnxruntime::utils::kDefaultSnippetEdgeItems);
+    }
+  } else {
+    for (int i = 0; i < dim0; i++) {
+      std::cout << "[" << i << "]:" << std::endl;
+      onnxruntime::utils::PrintCpuTensorFull<T>(tensor + i * dim1 * dim2 * dim3, dim1, dim2, dim3);
+    }
+  }
+}
+
+void DumpCpuTensor(const char* name, const Tensor& tensor, int dim0, int dim1, int dim2, int dim3) {
+  MLDataType dataType = tensor.DataType();
+  if (dataType == DataTypeImpl::GetType<float>()) {
+    DumpCpuTensor<float>(name, tensor.Data<float>(), dim0, dim1, dim2, dim3);
+  } else if (dataType == DataTypeImpl::GetType<MLFloat16>()) {
+    DumpCpuTensor<MLFloat16>(name, tensor.Data<MLFloat16>(), dim0, dim1, dim2, dim3);
+  } else if (dataType == DataTypeImpl::GetType<int32_t>()) {
+    DumpCpuTensor<int32_t>(name, tensor.Data<int32_t>(), dim0, dim1, dim2, dim3);
+  } else if (dataType == DataTypeImpl::GetType<int64_t>()) {
+    DumpCpuTensor<int64_t>(name, tensor.Data<int64_t>(), dim0, dim1, dim2, dim3);
+  } else if (dataType == DataTypeImpl::GetType<int8_t>()) {
+    DumpCpuTensor<int8_t>(name, tensor.Data<int8_t>(), dim0, dim1, dim2, dim3);
+  } else if (dataType == DataTypeImpl::GetType<uint8_t>()) {
+    DumpCpuTensor<uint8_t>(name, tensor.Data<uint8_t>(), dim0, dim1, dim2, dim3);
+  } else if (dataType == DataTypeImpl::GetType<UInt4x2>()) {
+    DumpCpuTensor<UInt4x2>(name, tensor.Data<UInt4x2>(), dim0, dim1, dim2, dim3);
+  } else if (dataType == DataTypeImpl::GetType<Int4x2>()) {
+    DumpCpuTensor<Int4x2>(name, tensor.Data<Int4x2>(), dim0, dim1, dim2, dim3);
+  } else {
+    assert(0);
+  }
+}
+
 void DumpCpuTensor(const char* name, const Tensor& tensor, int dim0, int dim1, int dim2) {
   MLDataType dataType = tensor.DataType();
   if (dataType == DataTypeImpl::GetType<float>()) {
@@ -72,6 +120,14 @@ void DumpCpuTensor(const char* name, const Tensor& tensor, int dim0, int dim1, i
     DumpCpuTensor<int32_t>(name, tensor.Data<int32_t>(), dim0, dim1, dim2);
   } else if (dataType == DataTypeImpl::GetType<int64_t>()) {
     DumpCpuTensor<int64_t>(name, tensor.Data<int64_t>(), dim0, dim1, dim2);
+  } else if (dataType == DataTypeImpl::GetType<int8_t>()) {
+    DumpCpuTensor<int8_t>(name, tensor.Data<int8_t>(), dim0, dim1, dim2);
+  } else if (dataType == DataTypeImpl::GetType<uint8_t>()) {
+    DumpCpuTensor<uint8_t>(name, tensor.Data<uint8_t>(), dim0, dim1, dim2);
+  } else if (dataType == DataTypeImpl::GetType<UInt4x2>()) {
+    DumpCpuTensor<UInt4x2>(name, tensor.Data<UInt4x2>(), dim0, dim1, dim2);
+  } else if (dataType == DataTypeImpl::GetType<Int4x2>()) {
+    DumpCpuTensor<Int4x2>(name, tensor.Data<Int4x2>(), dim0, dim1, dim2);
   } else {
     assert(0);
   }
@@ -87,9 +143,21 @@ void DumpCpuTensor(const char* name, const Tensor& tensor, int dim0, int dim1) {
     DumpCpuTensor<int32_t>(name, tensor.Data<int32_t>(), dim0, dim1);
   } else if (dataType == DataTypeImpl::GetType<int64_t>()) {
     DumpCpuTensor<int64_t>(name, tensor.Data<int64_t>(), dim0, dim1);
+  } else if (dataType == DataTypeImpl::GetType<int8_t>()) {
+    DumpCpuTensor<int8_t>(name, tensor.Data<int8_t>(), dim0, dim1);
+  } else if (dataType == DataTypeImpl::GetType<uint8_t>()) {
+    DumpCpuTensor<uint8_t>(name, tensor.Data<uint8_t>(), dim0, dim1);
+  } else if (dataType == DataTypeImpl::GetType<UInt4x2>()) {
+    DumpCpuTensor<UInt4x2>(name, tensor.Data<UInt4x2>(), dim0, dim1);
+  } else if (dataType == DataTypeImpl::GetType<Int4x2>()) {
+    DumpCpuTensor<Int4x2>(name, tensor.Data<Int4x2>(), dim0, dim1);
   } else {
     assert(0);
   }
+}
+
+void DumpCpuTensor(const char* name, const Tensor& tensor, int dim0) {
+  DumpCpuTensor(name, tensor, 1, dim0);
 }
 
 void DumpCpuTensor(const char* name, const Tensor& tensor) {
@@ -101,21 +169,33 @@ void DumpCpuTensor(const char* name, const Tensor& tensor) {
   std::cout << "Shape:" << shape << std::endl;
 
   size_t num_dims = shape.NumDimensions();
-  if (num_dims >= 3) {
-    int dim0 = static_cast<int>(shape.SizeToDimension(num_dims - 2));
-    int dim1 = static_cast<int>(shape[num_dims - 2]);
-    int dim2 = static_cast<int>(shape[num_dims - 1]);
+  if (num_dims >= 4) {
+    int dim0 = static_cast<int>(shape.SizeToDimension(num_dims - 4));
+    int dim1 = static_cast<int>(shape[num_dims - 3]);
+    int dim2 = static_cast<int>(shape[num_dims - 2]);
+    int dim3 = static_cast<int>(shape[num_dims - 1]);
+    DumpCpuTensor(nullptr, tensor, dim0, dim1, dim2, dim3);
+    return;
+  }
+
+  if (num_dims == 3) {
+    int dim0 = static_cast<int>(shape[0]);
+    int dim1 = static_cast<int>(shape[1]);
+    int dim2 = static_cast<int>(shape[2]);
     DumpCpuTensor(nullptr, tensor, dim0, dim1, dim2);
     return;
   }
 
-  auto num_items = shape.Size();
-  size_t num_rows = 1;
-  if (num_dims > 1) {
-    num_rows = static_cast<size_t>(shape[0]);
+  if (num_dims == 2) {
+    int dim0 = static_cast<int>(shape[0]);
+    int dim1 = static_cast<int>(shape[1]);
+    DumpCpuTensor(nullptr, tensor, dim0, dim1);
+    return;
   }
-  size_t row_size = num_items / num_rows;
-  DumpCpuTensor(nullptr, tensor, static_cast<int>(num_rows), static_cast<int>(row_size));
+
+  if (num_dims == 1) {
+    DumpCpuTensor(nullptr, tensor, static_cast<int>(shape[0]));
+  }
 }
 
 CpuTensorConsoleDumper::CpuTensorConsoleDumper() {
@@ -131,84 +211,6 @@ void CpuTensorConsoleDumper::Print(const std::string& value) const {
   if (s_output_thread_id)
     std::cout << "Thread ID:" << std::this_thread::get_id() << std::endl;
   std::cout << value << std::endl;
-}
-
-void CpuTensorConsoleDumper::Print(const char* name, const float* tensor, int dim0, int dim1) const {
-  if (!is_enabled_)
-    return;
-  DumpCpuTensor<float>(name, tensor, dim0, dim1);
-}
-
-void CpuTensorConsoleDumper::Print(const char* name, const MLFloat16* tensor, int dim0, int dim1) const {
-  if (!is_enabled_)
-    return;
-  DumpCpuTensor<MLFloat16>(name, tensor, dim0, dim1);
-}
-
-void CpuTensorConsoleDumper::Print(const char* name, const size_t* tensor, int dim0, int dim1) const {
-  if (!is_enabled_)
-    return;
-  DumpCpuTensor<size_t>(name, tensor, dim0, dim1);
-}
-
-void CpuTensorConsoleDumper::Print(const char* name, const int64_t* tensor, int dim0, int dim1) const {
-  if (!is_enabled_)
-    return;
-  DumpCpuTensor<int64_t>(name, tensor, dim0, dim1);
-}
-
-void CpuTensorConsoleDumper::Print(const char* name, const int32_t* tensor, int dim0, int dim1) const {
-  if (!is_enabled_)
-    return;
-  DumpCpuTensor<int32_t>(name, tensor, dim0, dim1);
-}
-
-void CpuTensorConsoleDumper::Print(const char* name, const float* tensor, int dim0, int dim1, int dim2) const {
-  if (!is_enabled_)
-    return;
-  DumpCpuTensor<float>(name, tensor, dim0, dim1, dim2);
-}
-
-void CpuTensorConsoleDumper::Print(const char* name, const MLFloat16* tensor, int dim0, int dim1, int dim2) const {
-  if (!is_enabled_)
-    return;
-  DumpCpuTensor<MLFloat16>(name, tensor, dim0, dim1, dim2);
-}
-
-void CpuTensorConsoleDumper::Print(const char* name, const int64_t* tensor, int dim0, int dim1, int dim2) const {
-  if (!is_enabled_)
-    return;
-  DumpCpuTensor<int64_t>(name, tensor, dim0, dim1, dim2);
-}
-
-void CpuTensorConsoleDumper::Print(const char* name, const int32_t* tensor, int dim0, int dim1, int dim2) const {
-  if (!is_enabled_)
-    return;
-  DumpCpuTensor<int32_t>(name, tensor, dim0, dim1, dim2);
-}
-
-void CpuTensorConsoleDumper::Print(const char* name, const float* tensor, int dim0, int dim1, int dim2, int dim3) const {
-  if (!is_enabled_)
-    return;
-  DumpCpuTensor<float>(name, tensor, dim0 * dim1, dim2, dim3);
-}
-
-void CpuTensorConsoleDumper::Print(const char* name, const MLFloat16* tensor, int dim0, int dim1, int dim2, int dim3) const {
-  if (!is_enabled_)
-    return;
-  DumpCpuTensor<MLFloat16>(name, tensor, dim0 * dim1, dim2, dim3);
-}
-
-void CpuTensorConsoleDumper::Print(const char* name, const int64_t* tensor, int dim0, int dim1, int dim2, int dim3) const {
-  if (!is_enabled_)
-    return;
-  DumpCpuTensor<int64_t>(name, tensor, dim0 * dim1, dim2, dim3);
-}
-
-void CpuTensorConsoleDumper::Print(const char* name, const int32_t* tensor, int dim0, int dim1, int dim2, int dim3) const {
-  if (!is_enabled_)
-    return;
-  DumpCpuTensor<int32_t>(name, tensor, dim0 * dim1, dim2, dim3);
 }
 
 void CpuTensorConsoleDumper::Print(const char* name, const Tensor& tensor) const {
@@ -246,21 +248,39 @@ void CpuTensorConsoleDumper::Print(const char* name, const std::string& value, b
   }
 }
 
-void CpuTensorConsoleDumper::Print(const char* name, const int32_t* tensor, gsl::span<const int64_t>& dims) const {
-  PrintTensorByDims<CpuTensorConsoleDumper, int32_t>(this, name, tensor, dims);
+void CpuTensorConsoleDumper::Print(const char* name, const size_t* tensor, int dim0, int dim1) const {
+  if (!is_enabled_)
+    return;
+  DumpCpuTensor<size_t>(name, tensor, dim0, dim1);
 }
 
-void CpuTensorConsoleDumper::Print(const char* name, const int64_t* tensor, gsl::span<const int64_t>& dims) const {
-  PrintTensorByDims<CpuTensorConsoleDumper, int64_t>(this, name, tensor, dims);
-}
+#define TENSOR_DUMPER_PRINT_TYPE(dtype)                                                                                     \
+  void CpuTensorConsoleDumper::Print(const char* name, const dtype* tensor, int dim0, int dim1) const {                     \
+    if (is_enabled_)                                                                                                        \
+      DumpCpuTensor<dtype>(name, tensor, dim0, dim1);                                                                       \
+  }                                                                                                                         \
+  void CpuTensorConsoleDumper::Print(const char* name, const dtype* tensor, int dim0, int dim1, int dim2) const {           \
+    if (is_enabled_)                                                                                                        \
+      DumpCpuTensor<dtype>(name, tensor, dim0, dim1, dim2);                                                                 \
+  }                                                                                                                         \
+  void CpuTensorConsoleDumper::Print(const char* name, const dtype* tensor, int dim0, int dim1, int dim2, int dim3) const { \
+    if (is_enabled_)                                                                                                        \
+      DumpCpuTensor<dtype>(name, tensor, dim0, dim1, dim2, dim3);                                                           \
+  }                                                                                                                         \
+  void CpuTensorConsoleDumper::Print(const char* name, const dtype* tensor, gsl::span<const int64_t>& dims) const {         \
+    PrintTensorByDims<CpuTensorConsoleDumper, dtype>(this, name, tensor, dims);                                             \
+  }
 
-void CpuTensorConsoleDumper::Print(const char* name, const float* tensor, gsl::span<const int64_t>& dims) const {
-  PrintTensorByDims<CpuTensorConsoleDumper, float>(this, name, tensor, dims);
-}
-
-void CpuTensorConsoleDumper::Print(const char* name, const MLFloat16* tensor, gsl::span<const int64_t>& dims) const {
-  PrintTensorByDims<CpuTensorConsoleDumper, MLFloat16>(this, name, tensor, dims);
-}
+TENSOR_DUMPER_PRINT_TYPE(int8_t)
+TENSOR_DUMPER_PRINT_TYPE(uint8_t)
+TENSOR_DUMPER_PRINT_TYPE(int32_t)
+TENSOR_DUMPER_PRINT_TYPE(int64_t)
+TENSOR_DUMPER_PRINT_TYPE(float)
+TENSOR_DUMPER_PRINT_TYPE(MLFloat16)
+TENSOR_DUMPER_PRINT_TYPE(BFloat16)
+TENSOR_DUMPER_PRINT_TYPE(UInt4x2)
+TENSOR_DUMPER_PRINT_TYPE(Int4x2)
+#undef TENSOR_DUMPER_PRINT_TYPE
 
 #else
 
@@ -268,45 +288,6 @@ CpuTensorConsoleDumper::CpuTensorConsoleDumper() {
 }
 
 void CpuTensorConsoleDumper::Print(const std::string&) const {
-}
-
-void CpuTensorConsoleDumper::Print(const char*, const float*, int, int) const {
-}
-
-void CpuTensorConsoleDumper::Print(const char*, const MLFloat16*, int, int) const {
-}
-
-void CpuTensorConsoleDumper::Print(const char*, const size_t*, int, int) const {
-}
-
-void CpuTensorConsoleDumper::Print(const char*, const int64_t*, int, int) const {
-}
-
-void CpuTensorConsoleDumper::Print(const char*, const int32_t*, int, int) const {
-}
-
-void CpuTensorConsoleDumper::Print(const char*, const float*, int, int, int) const {
-}
-
-void CpuTensorConsoleDumper::Print(const char*, const MLFloat16*, int, int, int) const {
-}
-
-void CpuTensorConsoleDumper::Print(const char*, const int64_t*, int, int, int) const {
-}
-
-void CpuTensorConsoleDumper::Print(const char*, const int32_t*, int, int, int) const {
-}
-
-void CpuTensorConsoleDumper::Print(const char*, const float*, int, int, int, int) const {
-}
-
-void CpuTensorConsoleDumper::Print(const char*, const MLFloat16*, int, int, int, int) const {
-}
-
-void CpuTensorConsoleDumper::Print(const char*, const int64_t*, int, int, int, int) const {
-}
-
-void CpuTensorConsoleDumper::Print(const char*, const int32_t*, int, int, int, int) const {
 }
 
 void CpuTensorConsoleDumper::Print(const char*, const Tensor&) const {
@@ -321,17 +302,30 @@ void CpuTensorConsoleDumper::Print(const char*, int, bool) const {
 void CpuTensorConsoleDumper::Print(const char*, const std::string&, bool) const {
 }
 
-void CpuTensorConsoleDumper::Print(const char*, const int32_t*, gsl::span<const int64_t>&) const {
+void CpuTensorConsoleDumper::Print(const char*, const size_t*, int, int) const {
 }
 
-void CpuTensorConsoleDumper::Print(const char*, const int64_t*, gsl::span<const int64_t>&) const {
-}
+#define TENSOR_DUMPER_PRINT_TYPE(dtype)                                                            \
+  void CpuTensorConsoleDumper::Print(const char*, const dtype*, int, int) const {                  \
+  }                                                                                                \
+  void CpuTensorConsoleDumper::Print(const char*, const dtype*, int, int, int) const {             \
+  }                                                                                                \
+  void CpuTensorConsoleDumper::Print(const char*, const dtype*, int, int, int, int) const {        \
+  }                                                                                                \
+  void CpuTensorConsoleDumper::Print(const char*, const dtype*, gsl::span<const int64_t>&) const { \
+  }
 
-void CpuTensorConsoleDumper::Print(const char*, const float*, gsl::span<const int64_t>&) const {
-}
+TENSOR_DUMPER_PRINT_TYPE(int8_t)
+TENSOR_DUMPER_PRINT_TYPE(uint8_t)
+TENSOR_DUMPER_PRINT_TYPE(int32_t)
+TENSOR_DUMPER_PRINT_TYPE(int64_t)
+TENSOR_DUMPER_PRINT_TYPE(float)
+TENSOR_DUMPER_PRINT_TYPE(MLFloat16)
+TENSOR_DUMPER_PRINT_TYPE(BFloat16)
+TENSOR_DUMPER_PRINT_TYPE(UInt4x2)
+TENSOR_DUMPER_PRINT_TYPE(Int4x2)
+#undef TENSOR_DUMPER_PRINT_TYPE
 
-void CpuTensorConsoleDumper::Print(const char*, const MLFloat16*, gsl::span<const int64_t>&) const {
-}
 #endif
 
 }  // namespace contrib

--- a/onnxruntime/contrib_ops/cpu/utils/dump_tensor.h
+++ b/onnxruntime/contrib_ops/cpu/utils/dump_tensor.h
@@ -14,26 +14,8 @@ class CpuTensorConsoleDumper : public IConsoleDumper {
  public:
   CpuTensorConsoleDumper();
   virtual ~CpuTensorConsoleDumper() {}
-  void Print(const char* name, const float* tensor, int dim0, int dim1) const override;
-  void Print(const char* name, const MLFloat16* tensor, int dim0, int dim1) const override;
+
   void Print(const char* name, const size_t* tensor, int dim0, int dim1) const override;
-  void Print(const char* name, const int64_t* tensor, int dim0, int dim1) const override;
-  void Print(const char* name, const int32_t* tensor, int dim0, int dim1) const override;
-
-  void Print(const char* name, const float* tensor, int dim0, int dim1, int dim2) const override;
-  void Print(const char* name, const MLFloat16* tensor, int dim0, int dim1, int dim2) const override;
-  void Print(const char* name, const int64_t* tensor, int dim0, int dim1, int dim2) const override;
-  void Print(const char* name, const int32_t* tensor, int dim0, int dim1, int dim2) const override;
-
-  void Print(const char* name, const float* tensor, int dim0, int dim1, int dim2, int dim3) const override;
-  void Print(const char* name, const MLFloat16* tensor, int dim0, int dim1, int dim2, int dim3) const override;
-  void Print(const char* name, const int64_t* tensor, int dim0, int dim1, int dim2, int dim3) const override;
-  void Print(const char* name, const int32_t* tensor, int dim0, int dim1, int dim2, int dim3) const override;
-
-  void Print(const char* name, const int32_t* tensor, gsl::span<const int64_t>& dims) const override;
-  void Print(const char* name, const int64_t* tensor, gsl::span<const int64_t>& dims) const override;
-  void Print(const char* name, const float* tensor, gsl::span<const int64_t>& dims) const override;
-  void Print(const char* name, const MLFloat16* tensor, gsl::span<const int64_t>& dims) const override;
 
   void Print(const char* name, const Tensor& value) const override;
   void Print(const char* name, const OrtValue& value) const override;
@@ -47,6 +29,23 @@ class CpuTensorConsoleDumper : public IConsoleDumper {
   void Print(const char* name, const std::vector<T>& vec, size_t max_count = 0) const {
     this->Print(name, vec.data(), 1, static_cast<int>(std::min(max_count, vec.size())));
   }
+
+#define TENSOR_DUMPER_PRINT_TYPE(dtype)                                                                     \
+  void Print(const char* name, const dtype* tensor, int dim0, int dim1) const override;                     \
+  void Print(const char* name, const dtype* tensor, int dim0, int dim1, int dim2) const override;           \
+  void Print(const char* name, const dtype* tensor, int dim0, int dim1, int dim2, int dim3) const override; \
+  void Print(const char* name, const dtype* tensor, gsl::span<const int64_t>& dims) const override;
+
+  TENSOR_DUMPER_PRINT_TYPE(int8_t)
+  TENSOR_DUMPER_PRINT_TYPE(uint8_t)
+  TENSOR_DUMPER_PRINT_TYPE(int32_t)
+  TENSOR_DUMPER_PRINT_TYPE(int64_t)
+  TENSOR_DUMPER_PRINT_TYPE(float)
+  TENSOR_DUMPER_PRINT_TYPE(MLFloat16)
+  TENSOR_DUMPER_PRINT_TYPE(BFloat16)
+  TENSOR_DUMPER_PRINT_TYPE(UInt4x2)
+  TENSOR_DUMPER_PRINT_TYPE(Int4x2)
+#undef TENSOR_DUMPER_PRINT_TYPE
 };
 
 }  // namespace contrib

--- a/onnxruntime/contrib_ops/cuda/utils/dump_cuda_tensor.cc
+++ b/onnxruntime/contrib_ops/cuda/utils/dump_cuda_tensor.cc
@@ -146,6 +146,31 @@ void DumpGpuTensor(const char* name, const T* tensor, int dim0, int dim1, int di
   }
 }
 
+void DumpGpuTensor(const char* name, const Tensor& tensor, int dim0, int dim1, int dim2, int dim3) {
+  MLDataType dataType = tensor.DataType();
+  bool is_gpu_tensor = (tensor.Location().device.Type() == OrtDevice::GPU);
+  if (dataType == DataTypeImpl::GetType<float>()) {
+    DumpGpuTensor<float>(name, tensor.Data<float>(), dim0, dim1, dim2, dim3, is_gpu_tensor);
+  } else if (dataType == DataTypeImpl::GetType<MLFloat16>()) {
+    DumpGpuTensor<MLFloat16>(name, tensor.Data<MLFloat16>(), dim0, dim1, dim2, dim3, is_gpu_tensor);
+  } else if (dataType == DataTypeImpl::GetType<int32_t>()) {
+    DumpGpuTensor<int32_t>(name, tensor.Data<int32_t>(), dim0, dim1, dim2, dim3, is_gpu_tensor);
+  } else if (dataType == DataTypeImpl::GetType<int64_t>()) {
+    DumpGpuTensor<int64_t>(name, tensor.Data<int64_t>(), dim0, dim1, dim2, dim3, is_gpu_tensor);
+  } else if (dataType == DataTypeImpl::GetType<int8_t>()) {
+    DumpGpuTensor<int8_t>(name, tensor.Data<int8_t>(), dim0, dim1, dim2, dim3, is_gpu_tensor);
+  } else if (dataType == DataTypeImpl::GetType<uint8_t>()) {
+    DumpGpuTensor<uint8_t>(name, tensor.Data<uint8_t>(), dim0, dim1, dim2, dim3, is_gpu_tensor);
+  } else if (dataType == DataTypeImpl::GetType<UInt4x2>()) {
+    DumpGpuTensor<UInt4x2>(name, tensor.Data<UInt4x2>(), dim0, dim1, dim2, dim3, is_gpu_tensor);
+  } else if (dataType == DataTypeImpl::GetType<Int4x2>()) {
+    DumpGpuTensor<Int4x2>(name, tensor.Data<Int4x2>(), dim0, dim1, dim2, dim3, is_gpu_tensor);
+  } else {
+    std::cout << std::string(name) << std::endl;
+    std::cout << "The data type is not supported in DumpGpuTensor" << std::endl;
+  }
+}
+
 void DumpGpuTensor(const char* name, const Tensor& tensor, int dim0, int dim1, int dim2) {
   MLDataType dataType = tensor.DataType();
   bool is_gpu_tensor = (tensor.Location().device.Type() == OrtDevice::GPU);
@@ -157,8 +182,17 @@ void DumpGpuTensor(const char* name, const Tensor& tensor, int dim0, int dim1, i
     DumpGpuTensor<int32_t>(name, tensor.Data<int32_t>(), dim0, dim1, dim2, is_gpu_tensor);
   } else if (dataType == DataTypeImpl::GetType<int64_t>()) {
     DumpGpuTensor<int64_t>(name, tensor.Data<int64_t>(), dim0, dim1, dim2, is_gpu_tensor);
+  } else if (dataType == DataTypeImpl::GetType<int8_t>()) {
+    DumpGpuTensor<int8_t>(name, tensor.Data<int8_t>(), dim0, dim1, dim2, is_gpu_tensor);
+  } else if (dataType == DataTypeImpl::GetType<uint8_t>()) {
+    DumpGpuTensor<uint8_t>(name, tensor.Data<uint8_t>(), dim0, dim1, dim2, is_gpu_tensor);
+  } else if (dataType == DataTypeImpl::GetType<UInt4x2>()) {
+    DumpGpuTensor<UInt4x2>(name, tensor.Data<UInt4x2>(), dim0, dim1, dim2, is_gpu_tensor);
+  } else if (dataType == DataTypeImpl::GetType<Int4x2>()) {
+    DumpGpuTensor<Int4x2>(name, tensor.Data<Int4x2>(), dim0, dim1, dim2, is_gpu_tensor);
   } else {
-    assert(0);
+    std::cout << std::string(name) << std::endl;
+    std::cout << "The data type is not supported in DumpGpuTensor" << std::endl;
   }
 }
 
@@ -173,9 +207,22 @@ void DumpGpuTensor(const char* name, const Tensor& tensor, int dim0, int dim1) {
     DumpGpuTensor<int32_t>(name, tensor.Data<int32_t>(), dim0, dim1, is_gpu_tensor);
   } else if (dataType == DataTypeImpl::GetType<int64_t>()) {
     DumpGpuTensor<int64_t>(name, tensor.Data<int64_t>(), dim0, dim1, is_gpu_tensor);
+  } else if (dataType == DataTypeImpl::GetType<int8_t>()) {
+    DumpGpuTensor<int8_t>(name, tensor.Data<int8_t>(), dim0, dim1, is_gpu_tensor);
+  } else if (dataType == DataTypeImpl::GetType<uint8_t>()) {
+    DumpGpuTensor<uint8_t>(name, tensor.Data<uint8_t>(), dim0, dim1, is_gpu_tensor);
+  } else if (dataType == DataTypeImpl::GetType<UInt4x2>()) {
+    DumpGpuTensor<UInt4x2>(name, tensor.Data<UInt4x2>(), dim0, dim1, is_gpu_tensor);
+  } else if (dataType == DataTypeImpl::GetType<Int4x2>()) {
+    DumpGpuTensor<Int4x2>(name, tensor.Data<Int4x2>(), dim0, dim1, is_gpu_tensor);
   } else {
-    assert(0);
+    std::cout << std::string(name) << std::endl;
+    std::cout << "The data type is not supported in DumpGpuTensor" << std::endl;
   }
+}
+
+void DumpGpuTensor(const char* name, const Tensor& tensor, int dim0) {
+  DumpGpuTensor(name, tensor, 1, dim0);
 }
 
 void DumpGpuTensor(const char* name, const Tensor& tensor) {
@@ -188,21 +235,33 @@ void DumpGpuTensor(const char* name, const Tensor& tensor) {
   std::cout << tensor.Location().ToString() << std::endl;
 
   size_t num_dims = shape.NumDimensions();
-  if (num_dims >= 3) {
-    int dim0 = static_cast<int>(shape.SizeToDimension(num_dims - 2));
-    int dim1 = static_cast<int>(shape[num_dims - 2]);
-    int dim2 = static_cast<int>(shape[num_dims - 1]);
+  if (num_dims >= 4) {
+    int dim0 = static_cast<int>(shape.SizeToDimension(num_dims - 4));
+    int dim1 = static_cast<int>(shape[num_dims - 3]);
+    int dim2 = static_cast<int>(shape[num_dims - 2]);
+    int dim3 = static_cast<int>(shape[num_dims - 1]);
+    DumpGpuTensor(nullptr, tensor, dim0, dim1, dim2, dim3);
+    return;
+  }
+
+  if (num_dims == 3) {
+    int dim0 = static_cast<int>(shape[0]);
+    int dim1 = static_cast<int>(shape[1]);
+    int dim2 = static_cast<int>(shape[2]);
     DumpGpuTensor(nullptr, tensor, dim0, dim1, dim2);
     return;
   }
 
-  auto num_items = shape.Size();
-  size_t num_rows = 1;
-  if (num_dims > 1) {
-    num_rows = static_cast<size_t>(shape[0]);
+  if (num_dims == 2) {
+    int dim0 = static_cast<int>(shape[0]);
+    int dim1 = static_cast<int>(shape[1]);
+    DumpGpuTensor(nullptr, tensor, dim0, dim1);
+    return;
   }
-  size_t row_size = num_items / num_rows;
-  DumpGpuTensor(nullptr, tensor, static_cast<int>(num_rows), static_cast<int>(row_size));
+
+  if (num_dims == 1) {
+    DumpGpuTensor(nullptr, tensor, static_cast<int>(shape[0]));
+  }
 }
 
 CudaTensorConsoleDumper::CudaTensorConsoleDumper() {
@@ -216,93 +275,6 @@ void CudaTensorConsoleDumper::Print(const std::string& value) const {
 void CudaTensorConsoleDumper::Print(const char* name, const size_t* tensor, int dim0, int dim1) const {
   if (is_enabled_)
     DumpGpuTensor<size_t>(name, tensor, dim0, dim1, true);
-}
-
-void CudaTensorConsoleDumper::Print(const char* name, const int32_t* tensor, int dim0, int dim1) const {
-  if (is_enabled_)
-    DumpGpuTensor<int32_t>(name, tensor, dim0, dim1, true);
-}
-
-void CudaTensorConsoleDumper::Print(const char* name, const int32_t* tensor, int dim0, int dim1, int dim2) const {
-  if (is_enabled_)
-    DumpGpuTensor<int32_t>(name, tensor, dim0, dim1, dim2, true);
-}
-
-void CudaTensorConsoleDumper::Print(const char* name, const int32_t* tensor, int dim0, int dim1, int dim2, int dim3) const {
-  if (is_enabled_)
-    DumpGpuTensor<int32_t>(name, tensor, dim0, dim1, dim2, dim3, true);
-}
-
-void CudaTensorConsoleDumper::Print(const char* name, const int64_t* tensor, int dim0, int dim1) const {
-  if (is_enabled_)
-    DumpGpuTensor<int64_t>(name, tensor, dim0, dim1, true);
-}
-
-void CudaTensorConsoleDumper::Print(const char* name, const int64_t* tensor, int dim0, int dim1, int dim2) const {
-  if (is_enabled_)
-    DumpGpuTensor<int64_t>(name, tensor, dim0, dim1, dim2, true);
-}
-
-void CudaTensorConsoleDumper::Print(const char* name, const int64_t* tensor, int dim0, int dim1, int dim2, int dim3) const {
-  if (is_enabled_)
-    DumpGpuTensor<int64_t>(name, tensor, dim0, dim1, dim2, dim3, true);
-}
-
-void CudaTensorConsoleDumper::Print(const char* name, const float* tensor, int dim0, int dim1) const {
-  if (is_enabled_)
-    DumpGpuTensor<float>(name, tensor, dim0, dim1, true);
-}
-
-void CudaTensorConsoleDumper::Print(const char* name, const float* tensor, int dim0, int dim1, int dim2) const {
-  if (is_enabled_)
-    DumpGpuTensor<float>(name, tensor, dim0, dim1, dim2, true);
-}
-
-void CudaTensorConsoleDumper::Print(const char* name, const float* tensor, int dim0, int dim1, int dim2, int dim3) const {
-  if (is_enabled_)
-    DumpGpuTensor<float>(name, tensor, dim0, dim1, dim2, dim3, true);
-}
-
-void CudaTensorConsoleDumper::Print(const char* name, const MLFloat16* tensor, int dim0, int dim1) const {
-  if (is_enabled_)
-    DumpGpuTensor<MLFloat16>(name, tensor, dim0, dim1, true);
-}
-
-void CudaTensorConsoleDumper::Print(const char* name, const MLFloat16* tensor, int dim0, int dim1, int dim2) const {
-  if (is_enabled_)
-    DumpGpuTensor<MLFloat16>(name, tensor, dim0, dim1, dim2, true);
-}
-
-void CudaTensorConsoleDumper::Print(const char* name, const MLFloat16* tensor, int dim0, int dim1, int dim2, int dim3) const {
-  if (is_enabled_)
-    DumpGpuTensor<MLFloat16>(name, tensor, dim0, dim1, dim2, dim3, true);
-}
-
-void CudaTensorConsoleDumper::Print(const char* name, const BFloat16* tensor, int dim0, int dim1) const {
-  if (is_enabled_)
-    DumpGpuTensor<BFloat16>(name, tensor, dim0, dim1, true);
-}
-
-void CudaTensorConsoleDumper::Print(const char* name, const BFloat16* tensor, int dim0, int dim1, int dim2) const {
-  if (is_enabled_)
-    DumpGpuTensor<BFloat16>(name, tensor, dim0, dim1, dim2, true);
-}
-
-void CudaTensorConsoleDumper::Print(const char* name, const BFloat16* tensor, int dim0, int dim1, int dim2, int dim3) const {
-  if (is_enabled_)
-    DumpGpuTensor<BFloat16>(name, tensor, dim0, dim1, dim2, dim3, true);
-}
-
-void CudaTensorConsoleDumper::Print(const char* name, const half* tensor, int dim0, int dim1) const {
-  Print(name, reinterpret_cast<const MLFloat16*>(tensor), dim0, dim1);
-}
-
-void CudaTensorConsoleDumper::Print(const char* name, const half* tensor, int dim0, int dim1, int dim2) const {
-  Print(name, reinterpret_cast<const MLFloat16*>(tensor), dim0, dim1, dim2);
-}
-
-void CudaTensorConsoleDumper::Print(const char* name, const half* tensor, int dim0, int dim1, int dim2, int dim3) const {
-  Print(name, reinterpret_cast<const MLFloat16*>(tensor), dim0, dim1, dim2, dim3);
 }
 
 void CudaTensorConsoleDumper::Print(const char* name, const Tensor& tensor) const {
@@ -335,28 +307,35 @@ void CudaTensorConsoleDumper::Print(const char* name, const std::string& value, 
   }
 }
 
-void CudaTensorConsoleDumper::Print(const char* name, const int32_t* tensor, gsl::span<const int64_t>& dims) const {
-  PrintTensorByDims<CudaTensorConsoleDumper, int32_t>(this, name, tensor, dims);
-}
-void CudaTensorConsoleDumper::Print(const char* name, const int64_t* tensor, gsl::span<const int64_t>& dims) const {
-  PrintTensorByDims<CudaTensorConsoleDumper, int64_t>(this, name, tensor, dims);
-}
+#define CUDA_DUMPER_PRINT_TYPE(dtype, dtype2)                                                                                \
+  void CudaTensorConsoleDumper::Print(const char* name, const dtype* tensor, int dim0, int dim1) const {                     \
+    if (is_enabled_)                                                                                                         \
+      DumpGpuTensor<dtype2>(name, reinterpret_cast<const dtype2*>(tensor), dim0, dim1, true);                                \
+  }                                                                                                                          \
+  void CudaTensorConsoleDumper::Print(const char* name, const dtype* tensor, int dim0, int dim1, int dim2) const {           \
+    if (is_enabled_)                                                                                                         \
+      DumpGpuTensor<dtype2>(name, reinterpret_cast<const dtype2*>(tensor), dim0, dim1, dim2, true);                          \
+  }                                                                                                                          \
+  void CudaTensorConsoleDumper::Print(const char* name, const dtype* tensor, int dim0, int dim1, int dim2, int dim3) const { \
+    if (is_enabled_)                                                                                                         \
+      DumpGpuTensor<dtype2>(name, reinterpret_cast<const dtype2*>(tensor), dim0, dim1, dim2, dim3, true);                    \
+  }                                                                                                                          \
+  void CudaTensorConsoleDumper::Print(const char* name, const dtype* tensor, gsl::span<const int64_t>& dims) const {         \
+    PrintTensorByDims<CudaTensorConsoleDumper, dtype2>(this, name, reinterpret_cast<const dtype2*>(tensor), dims);           \
+  }
 
-void CudaTensorConsoleDumper::Print(const char* name, const float* tensor, gsl::span<const int64_t>& dims) const {
-  PrintTensorByDims<CudaTensorConsoleDumper, float>(this, name, tensor, dims);
-}
+CUDA_DUMPER_PRINT_TYPE(int8_t, int8_t)
+CUDA_DUMPER_PRINT_TYPE(uint8_t, uint8_t)
+CUDA_DUMPER_PRINT_TYPE(int32_t, int32_t)
+CUDA_DUMPER_PRINT_TYPE(int64_t, int64_t)
+CUDA_DUMPER_PRINT_TYPE(float, float)
+CUDA_DUMPER_PRINT_TYPE(MLFloat16, MLFloat16)
+CUDA_DUMPER_PRINT_TYPE(BFloat16, BFloat16)
+CUDA_DUMPER_PRINT_TYPE(UInt4x2, UInt4x2)
+CUDA_DUMPER_PRINT_TYPE(Int4x2, Int4x2)
 
-void CudaTensorConsoleDumper::Print(const char* name, const half* tensor, gsl::span<const int64_t>& dims) const {
-  PrintTensorByDims<CudaTensorConsoleDumper, half>(this, name, tensor, dims);
-}
-
-void CudaTensorConsoleDumper::Print(const char* name, const MLFloat16* tensor, gsl::span<const int64_t>& dims) const {
-  PrintTensorByDims<CudaTensorConsoleDumper, MLFloat16>(this, name, tensor, dims);
-}
-
-void CudaTensorConsoleDumper::Print(const char* name, const BFloat16* tensor, gsl::span<const int64_t>& dims) const {
-  PrintTensorByDims<CudaTensorConsoleDumper, BFloat16>(this, name, tensor, dims);
-}
+CUDA_DUMPER_PRINT_TYPE(half, MLFloat16)
+#undef DUMPER_PRINT_TYPE
 
 #else
 CudaTensorConsoleDumper::CudaTensorConsoleDumper() {
@@ -366,60 +345,6 @@ void CudaTensorConsoleDumper::Print(const std::string&) const {
 }
 
 void CudaTensorConsoleDumper::Print(const char*, const size_t*, int, int) const {
-}
-
-void CudaTensorConsoleDumper::Print(const char*, const int32_t*, int, int) const {
-}
-
-void CudaTensorConsoleDumper::Print(const char*, const int32_t*, int, int, int) const {
-}
-
-void CudaTensorConsoleDumper::Print(const char*, const int32_t*, int, int, int, int) const {
-}
-
-void CudaTensorConsoleDumper::Print(const char*, const int64_t*, int, int) const {
-}
-
-void CudaTensorConsoleDumper::Print(const char*, const int64_t*, int, int, int) const {
-}
-
-void CudaTensorConsoleDumper::Print(const char*, const int64_t*, int, int, int, int) const {
-}
-
-void CudaTensorConsoleDumper::Print(const char*, const float*, int, int) const {
-}
-
-void CudaTensorConsoleDumper::Print(const char*, const float*, int, int, int) const {
-}
-
-void CudaTensorConsoleDumper::Print(const char*, const float*, int, int, int, int) const {
-}
-
-void CudaTensorConsoleDumper::Print(const char*, const MLFloat16*, int, int) const {
-}
-
-void CudaTensorConsoleDumper::Print(const char*, const MLFloat16*, int, int, int) const {
-}
-
-void CudaTensorConsoleDumper::Print(const char*, const MLFloat16*, int, int, int, int) const {
-}
-
-void CudaTensorConsoleDumper::Print(const char*, const BFloat16*, int, int) const {
-}
-
-void CudaTensorConsoleDumper::Print(const char*, const BFloat16*, int, int, int) const {
-}
-
-void CudaTensorConsoleDumper::Print(const char*, const BFloat16*, int, int, int, int) const {
-}
-
-void CudaTensorConsoleDumper::Print(const char*, const half*, int, int) const {
-}
-
-void CudaTensorConsoleDumper::Print(const char*, const half*, int, int, int) const {
-}
-
-void CudaTensorConsoleDumper::Print(const char*, const half*, int, int, int, int) const {
 }
 
 void CudaTensorConsoleDumper::Print(const char*, const Tensor&) const {
@@ -434,23 +359,27 @@ void CudaTensorConsoleDumper::Print(const char*, int, bool) const {
 void CudaTensorConsoleDumper::Print(const char*, const std::string&, bool) const {
 }
 
-void CudaTensorConsoleDumper::Print(const char*, const int32_t*, gsl::span<const int64_t>&) const {
-}
+#define CUDA_DUMPER_PRINT_TYPE(dtype)                                                               \
+  void CudaTensorConsoleDumper::Print(const char*, const dtype*, int, int) const {                  \
+  }                                                                                                 \
+  void CudaTensorConsoleDumper::Print(const char*, const dtype*, int, int, int) const {             \
+  }                                                                                                 \
+  void CudaTensorConsoleDumper::Print(const char*, const dtype*, int, int, int, int) const {        \
+  }                                                                                                 \
+  void CudaTensorConsoleDumper::Print(const char*, const dtype*, gsl::span<const int64_t>&) const { \
+  }
 
-void CudaTensorConsoleDumper::Print(const char*, const int64_t*, gsl::span<const int64_t>&) const {
-}
-
-void CudaTensorConsoleDumper::Print(const char*, const float*, gsl::span<const int64_t>&) const {
-}
-
-void CudaTensorConsoleDumper::Print(const char*, const half*, gsl::span<const int64_t>&) const {
-}
-
-void CudaTensorConsoleDumper::Print(const char*, const MLFloat16*, gsl::span<const int64_t>&) const {
-}
-
-void CudaTensorConsoleDumper::Print(const char*, const BFloat16*, gsl::span<const int64_t>&) const {
-}
+CUDA_DUMPER_PRINT_TYPE(int8_t)
+CUDA_DUMPER_PRINT_TYPE(uint8_t)
+CUDA_DUMPER_PRINT_TYPE(int32_t)
+CUDA_DUMPER_PRINT_TYPE(int64_t)
+CUDA_DUMPER_PRINT_TYPE(float)
+CUDA_DUMPER_PRINT_TYPE(MLFloat16)
+CUDA_DUMPER_PRINT_TYPE(BFloat16)
+CUDA_DUMPER_PRINT_TYPE(UInt4x2)
+CUDA_DUMPER_PRINT_TYPE(Int4x2)
+CUDA_DUMPER_PRINT_TYPE(half)
+#undef DUMPER_PRINT_TYPE
 
 #endif
 

--- a/onnxruntime/contrib_ops/cuda/utils/dump_cuda_tensor.h
+++ b/onnxruntime/contrib_ops/cuda/utils/dump_cuda_tensor.h
@@ -17,43 +17,30 @@ class CudaTensorConsoleDumper : public onnxruntime::contrib::IConsoleDumper {
   virtual ~CudaTensorConsoleDumper() {}
 
   void Print(const char* name, const size_t* tensor, int dim0, int dim1) const override;
-
-  void Print(const char* name, const int32_t* tensor, int dim0, int dim1) const override;
-  void Print(const char* name, const int32_t* tensor, int dim0, int dim1, int dim2) const override;
-  void Print(const char* name, const int32_t* tensor, int dim0, int dim1, int dim2, int dim3) const override;
-  void Print(const char* name, const int32_t* tensor, gsl::span<const int64_t>& dims) const override;
-
-  void Print(const char* name, const int64_t* tensor, int dim0, int dim1) const override;
-  void Print(const char* name, const int64_t* tensor, int dim0, int dim1, int dim2) const override;
-  void Print(const char* name, const int64_t* tensor, int dim0, int dim1, int dim2, int dim3) const override;
-  void Print(const char* name, const int64_t* tensor, gsl::span<const int64_t>& dims) const override;
-
-  void Print(const char* name, const float* tensor, int dim0, int dim1) const override;
-  void Print(const char* name, const float* tensor, int dim0, int dim1, int dim2) const override;
-  void Print(const char* name, const float* tensor, int dim0, int dim1, int dim2, int dim3) const override;
-  void Print(const char* name, const float* tensor, gsl::span<const int64_t>& dims) const override;
-
-  void Print(const char* name, const MLFloat16* tensor, int dim0, int dim1) const override;
-  void Print(const char* name, const MLFloat16* tensor, int dim0, int dim1, int dim2) const override;
-  void Print(const char* name, const MLFloat16* tensor, int dim0, int dim1, int dim2, int dim3) const override;
-  void Print(const char* name, const MLFloat16* tensor, gsl::span<const int64_t>& dims) const override;
-
-  void Print(const char* name, const half* tensor, int dim0, int dim1) const;
-  void Print(const char* name, const half* tensor, int dim0, int dim1, int dim2) const;
-  void Print(const char* name, const half* tensor, int dim0, int dim1, int dim2, int dim3) const;
-  void Print(const char* name, const half* tensor, gsl::span<const int64_t>& dims) const;
-
-  void Print(const char* name, const BFloat16* tensor, int dim0, int dim1) const;
-  void Print(const char* name, const BFloat16* tensor, int dim0, int dim1, int dim2) const;
-  void Print(const char* name, const BFloat16* tensor, int dim0, int dim1, int dim2, int dim3) const;
-  void Print(const char* name, const BFloat16* tensor, gsl::span<const int64_t>& dims) const;
-
   void Print(const char* name, const Tensor& value) const override;
   void Print(const char* name, const OrtValue& value) const override;
   void Print(const char* name, int index, bool end_line) const override;
   void Print(const char* name, const std::string& value, bool end_line) const override;
-
   void Print(const std::string& value) const override;
+
+#define CUDA_DUMPER_PRINT_TYPE(dtype)                                                              \
+  void Print(const char* name, const dtype* tensor, int dim0, int dim1) const;                     \
+  void Print(const char* name, const dtype* tensor, int dim0, int dim1, int dim2) const;           \
+  void Print(const char* name, const dtype* tensor, int dim0, int dim1, int dim2, int dim3) const; \
+  void Print(const char* name, const dtype* tensor, gsl::span<const int64_t>& dims) const;
+
+  CUDA_DUMPER_PRINT_TYPE(int8_t)
+  CUDA_DUMPER_PRINT_TYPE(uint8_t)
+  CUDA_DUMPER_PRINT_TYPE(int32_t)
+  CUDA_DUMPER_PRINT_TYPE(int64_t)
+  CUDA_DUMPER_PRINT_TYPE(float)
+  CUDA_DUMPER_PRINT_TYPE(MLFloat16)
+  CUDA_DUMPER_PRINT_TYPE(BFloat16)
+  CUDA_DUMPER_PRINT_TYPE(UInt4x2)
+  CUDA_DUMPER_PRINT_TYPE(Int4x2)
+  CUDA_DUMPER_PRINT_TYPE(half)
+
+#undef CUDA_DUMPER_PRINT_TYPE
 };
 
 }  // namespace cuda


### PR DESCRIPTION
### Description
support of dumping tensors of int8, uin t8, BFloat16, UInt4x2, and Int4x2 data types in the tensor dumper.

### Motivation and Context
Help debugging of operators using these data types.