### PR TITLE
Remove unused tensor dumper functions

### DIFF
--- a/onnxruntime/contrib_ops/cpu/utils/console_dumper.h
+++ b/onnxruntime/contrib_ops/cpu/utils/console_dumper.h
@@ -18,11 +18,8 @@ class IConsoleDumper {
   void Disable() { is_enabled_ = false; }
   bool IsEnabled() const { return is_enabled_; }
 
-  virtual void Print(const char* name, const size_t* tensor, int dim0, int dim1) const = 0;
   virtual void Print(const char* name, const Tensor& value) const = 0;
   virtual void Print(const char* name, const OrtValue& value) const = 0;
-  virtual void Print(const char* name, int index, bool end_line) const = 0;
-  virtual void Print(const char* name, const std::string& value, bool end_line) const = 0;
   virtual void Print(const std::string& value) const = 0;
 
 #define TENSOR_DUMPER_PRINT_TYPE(dtype)                                                                        \

--- a/onnxruntime/contrib_ops/cpu/utils/dump_tensor.cc
+++ b/onnxruntime/contrib_ops/cpu/utils/dump_tensor.cc
@@ -224,7 +224,6 @@ void CpuTensorConsoleDumper::Print(const char* name, const OrtValue& value) cons
   Print(name, tensor);
 }
 
-
 #define TENSOR_DUMPER_PRINT_TYPE(dtype)                                                                                     \
   void CpuTensorConsoleDumper::Print(const char* name, const dtype* tensor, int dim0, int dim1) const {                     \
     if (is_enabled_)                                                                                                        \
@@ -266,7 +265,6 @@ void CpuTensorConsoleDumper::Print(const char*, const Tensor&) const {
 
 void CpuTensorConsoleDumper::Print(const char*, const OrtValue&) const {
 }
-
 
 #define TENSOR_DUMPER_PRINT_TYPE(dtype)                                                            \
   void CpuTensorConsoleDumper::Print(const char*, const dtype*, int, int) const {                  \

--- a/onnxruntime/contrib_ops/cpu/utils/dump_tensor.cc
+++ b/onnxruntime/contrib_ops/cpu/utils/dump_tensor.cc
@@ -224,35 +224,6 @@ void CpuTensorConsoleDumper::Print(const char* name, const OrtValue& value) cons
   Print(name, tensor);
 }
 
-void CpuTensorConsoleDumper::Print(const char* name, int index, bool end_line) const {
-  if (!is_enabled_)
-    return;
-
-  std::unique_lock<std::mutex> lock(s_mutex);
-  std::cout << std::string(name) << "[" << index << "]";
-
-  if (end_line) {
-    std::cout << std::endl;
-  }
-}
-
-void CpuTensorConsoleDumper::Print(const char* name, const std::string& value, bool end_line) const {
-  if (!is_enabled_)
-    return;
-
-  std::unique_lock<std::mutex> lock(s_mutex);
-  std::cout << std::string(name) << "=" << value;
-
-  if (end_line) {
-    std::cout << std::endl;
-  }
-}
-
-void CpuTensorConsoleDumper::Print(const char* name, const size_t* tensor, int dim0, int dim1) const {
-  if (!is_enabled_)
-    return;
-  DumpCpuTensor<size_t>(name, tensor, dim0, dim1);
-}
 
 #define TENSOR_DUMPER_PRINT_TYPE(dtype)                                                                                     \
   void CpuTensorConsoleDumper::Print(const char* name, const dtype* tensor, int dim0, int dim1) const {                     \
@@ -296,14 +267,6 @@ void CpuTensorConsoleDumper::Print(const char*, const Tensor&) const {
 void CpuTensorConsoleDumper::Print(const char*, const OrtValue&) const {
 }
 
-void CpuTensorConsoleDumper::Print(const char*, int, bool) const {
-}
-
-void CpuTensorConsoleDumper::Print(const char*, const std::string&, bool) const {
-}
-
-void CpuTensorConsoleDumper::Print(const char*, const size_t*, int, int) const {
-}
 
 #define TENSOR_DUMPER_PRINT_TYPE(dtype)                                                            \
   void CpuTensorConsoleDumper::Print(const char*, const dtype*, int, int) const {                  \

--- a/onnxruntime/contrib_ops/cpu/utils/dump_tensor.h
+++ b/onnxruntime/contrib_ops/cpu/utils/dump_tensor.h
@@ -15,12 +15,8 @@ class CpuTensorConsoleDumper : public IConsoleDumper {
   CpuTensorConsoleDumper();
   virtual ~CpuTensorConsoleDumper() {}
 
-  void Print(const char* name, const size_t* tensor, int dim0, int dim1) const override;
-
   void Print(const char* name, const Tensor& value) const override;
   void Print(const char* name, const OrtValue& value) const override;
-  void Print(const char* name, int index, bool end_line) const override;
-  void Print(const char* name, const std::string& value, bool end_line) const override;
 
   void Print(const std::string& value) const override;
 

--- a/onnxruntime/contrib_ops/cuda/utils/dump_cuda_tensor.cc
+++ b/onnxruntime/contrib_ops/cuda/utils/dump_cuda_tensor.cc
@@ -272,10 +272,6 @@ void CudaTensorConsoleDumper::Print(const std::string& value) const {
   std::cout << value << std::endl;
 }
 
-void CudaTensorConsoleDumper::Print(const char* name, const size_t* tensor, int dim0, int dim1) const {
-  if (is_enabled_)
-    DumpGpuTensor<size_t>(name, tensor, dim0, dim1, true);
-}
 
 void CudaTensorConsoleDumper::Print(const char* name, const Tensor& tensor) const {
   if (is_enabled_)
@@ -287,25 +283,6 @@ void CudaTensorConsoleDumper::Print(const char* name, const OrtValue& value) con
   Print(name, tensor);
 }
 
-void CudaTensorConsoleDumper::Print(const char* name, int index, bool end_line) const {
-  if (!is_enabled_)
-    return;
-
-  std::cout << std::string(name) << "[" << index << "]";
-  if (end_line) {
-    std::cout << std::endl;
-  }
-}
-
-void CudaTensorConsoleDumper::Print(const char* name, const std::string& value, bool end_line) const {
-  if (!is_enabled_)
-    return;
-
-  std::cout << std::string(name) << "=" << value;
-  if (end_line) {
-    std::cout << std::endl;
-  }
-}
 
 #define CUDA_DUMPER_PRINT_TYPE(dtype, dtype2)                                                                                \
   void CudaTensorConsoleDumper::Print(const char* name, const dtype* tensor, int dim0, int dim1) const {                     \
@@ -344,8 +321,6 @@ CudaTensorConsoleDumper::CudaTensorConsoleDumper() {
 void CudaTensorConsoleDumper::Print(const std::string&) const {
 }
 
-void CudaTensorConsoleDumper::Print(const char*, const size_t*, int, int) const {
-}
 
 void CudaTensorConsoleDumper::Print(const char*, const Tensor&) const {
 }
@@ -353,11 +328,6 @@ void CudaTensorConsoleDumper::Print(const char*, const Tensor&) const {
 void CudaTensorConsoleDumper::Print(const char*, const OrtValue&) const {
 }
 
-void CudaTensorConsoleDumper::Print(const char*, int, bool) const {
-}
-
-void CudaTensorConsoleDumper::Print(const char*, const std::string&, bool) const {
-}
 
 #define CUDA_DUMPER_PRINT_TYPE(dtype)                                                               \
   void CudaTensorConsoleDumper::Print(const char*, const dtype*, int, int) const {                  \

--- a/onnxruntime/contrib_ops/cuda/utils/dump_cuda_tensor.cc
+++ b/onnxruntime/contrib_ops/cuda/utils/dump_cuda_tensor.cc
@@ -272,7 +272,6 @@ void CudaTensorConsoleDumper::Print(const std::string& value) const {
   std::cout << value << std::endl;
 }
 
-
 void CudaTensorConsoleDumper::Print(const char* name, const Tensor& tensor) const {
   if (is_enabled_)
     DumpGpuTensor(name, tensor);
@@ -282,7 +281,6 @@ void CudaTensorConsoleDumper::Print(const char* name, const OrtValue& value) con
   const Tensor& tensor = value.Get<Tensor>();
   Print(name, tensor);
 }
-
 
 #define CUDA_DUMPER_PRINT_TYPE(dtype, dtype2)                                                                                \
   void CudaTensorConsoleDumper::Print(const char* name, const dtype* tensor, int dim0, int dim1) const {                     \
@@ -321,13 +319,11 @@ CudaTensorConsoleDumper::CudaTensorConsoleDumper() {
 void CudaTensorConsoleDumper::Print(const std::string&) const {
 }
 
-
 void CudaTensorConsoleDumper::Print(const char*, const Tensor&) const {
 }
 
 void CudaTensorConsoleDumper::Print(const char*, const OrtValue&) const {
 }
-
 
 #define CUDA_DUMPER_PRINT_TYPE(dtype)                                                               \
   void CudaTensorConsoleDumper::Print(const char*, const dtype*, int, int) const {                  \

--- a/onnxruntime/contrib_ops/cuda/utils/dump_cuda_tensor.h
+++ b/onnxruntime/contrib_ops/cuda/utils/dump_cuda_tensor.h
@@ -16,11 +16,8 @@ class CudaTensorConsoleDumper : public onnxruntime::contrib::IConsoleDumper {
   CudaTensorConsoleDumper();
   virtual ~CudaTensorConsoleDumper() {}
 
-  void Print(const char* name, const size_t* tensor, int dim0, int dim1) const override;
   void Print(const char* name, const Tensor& value) const override;
   void Print(const char* name, const OrtValue& value) const override;
-  void Print(const char* name, int index, bool end_line) const override;
-  void Print(const char* name, const std::string& value, bool end_line) const override;
   void Print(const std::string& value) const override;
 
 #define CUDA_DUMPER_PRINT_TYPE(dtype)                                                              \


### PR DESCRIPTION
### Description
Remove unused tensor dumper functions. 

Those functions are not needed any more since it is easy to make a string with `::onnxruntime::MakeString` like in `DUMP_CPU_STRING` macros.

### Motivation and Context
Follow up with https://github.com/microsoft/onnxruntime/pull/24813#discussion_r2096803842.

Some functions were added, but not used any more. Remove them to avoid maintenance cost.
