### PR TITLE
Avoid traversing entire arrays when extracting shape from objects in java

### DIFF
--- a/java/src/main/java/ai/onnxruntime/TensorInfo.java
+++ b/java/src/main/java/ai/onnxruntime/TensorInfo.java
@@ -506,8 +506,13 @@ public class TensorInfo implements ValueInfo {
         throw new OrtException(
             "Supplied array is ragged, expected " + shape[curDim] + ", found " + curLength);
       }
-      for (int i = 0; i < curLength; i++) {
-        extractShape(shape, curDim + 1, Array.get(obj, i));
+      int nextDim = curDim + 1;
+      // Avoid traversing the entire array (autoboxing its values) when the next dimension is equal
+      // to the shape's length
+      if (shape.length != nextDim) {
+        for (int i = 0; i < curLength; i++) {
+          extractShape(shape, nextDim, Array.get(obj, i));
+        }
       }
     }
   }

--- a/java/src/test/java/ai/onnxruntime/TensorInfoTest.java
+++ b/java/src/test/java/ai/onnxruntime/TensorInfoTest.java
@@ -1,0 +1,56 @@
+package ai.onnxruntime;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TensorInfoTest {
+  @Test
+  public void testConstructFromJavaArray_UnexpectedType() {
+    Object obj = new Object();
+    Throwable t = Assertions.assertThrows(OrtException.class, () -> TensorInfo.constructFromJavaArray(obj));
+    Assertions.assertEquals("Cannot convert class java.lang.Object to a OnnxTensor.", t.getMessage());
+  }
+
+  @Test
+  public void testConstructFromJavaArray_ScalarType() throws OrtException {
+    float obj = 1.0f;
+    TensorInfo tensorInfo = TensorInfo.constructFromJavaArray(obj);
+    Assertions.assertArrayEquals(new long[0], tensorInfo.shape);
+    Assertions.assertEquals(OnnxJavaType.FLOAT, tensorInfo.type);
+    Assertions.assertEquals(TensorInfo.OnnxTensorType.ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, tensorInfo.onnxType);
+  }
+
+  @Test
+  public void testConstructFromJavaArray_1DArrayOfNonPrimitiveNorString() {
+    Object[] obj = new Object[] {new Object(), new Object()};
+    Throwable t = Assertions.assertThrows(OrtException.class, () -> TensorInfo.constructFromJavaArray(obj));
+    Assertions.assertEquals("Cannot create an OnnxTensor from a base type of class java.lang.Object", t.getMessage());
+  }
+
+  @Test
+  public void testConstructFromJavaArray_NineDimensions() {
+    float[][][][][][][][][] obj = new float[1][1][1][1][1][1][1][1][1];
+    Throwable t = Assertions.assertThrows(OrtException.class, () -> TensorInfo.constructFromJavaArray(obj));
+    Assertions.assertEquals("Cannot create an OnnxTensor with more than 8 dimensions. Found 9 dimensions.", t.getMessage());
+  }
+
+  @Test
+  public void testConstructFromJavaArray_RaggedArray() {
+    float[][] obj = new float[][]{
+        new float[1],
+        new float[2]
+    };
+    Throwable t = Assertions.assertThrows(OrtException.class, () -> TensorInfo.constructFromJavaArray(obj));
+    Assertions.assertEquals("Supplied array is ragged, expected 1, found 2", t.getMessage());
+  }
+
+  @Test
+  public void testConstructFromJavaArray_ExtractRecursive() throws OrtException {
+    float[][][] obj = new float[3][2][3];
+    TensorInfo tensorInfo = TensorInfo.constructFromJavaArray(obj);
+
+    Assertions.assertArrayEquals(new long[] {3,2,3}, tensorInfo.shape);
+    Assertions.assertEquals(OnnxJavaType.FLOAT, tensorInfo.type);
+    Assertions.assertEquals(TensorInfo.OnnxTensorType.ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, tensorInfo.onnxType);
+  }
+}


### PR DESCRIPTION
### Description
Avoids calling [`TensorInfo#extractShape`](https://github.com/microsoft/onnxruntime/blob/main/java/src/main/java/ai/onnxruntime/TensorInfo.java#L495) recursively when `curDim + 1 == shape.length`.
Thus enhancing the performance by avoiding traversing the entire array to return on the last DFS iteration, as well as unnecessary object [autoboxing](https://docs.oracle.com/javase/tutorial/java/data/autoboxing.html) and method calls.

### Motivation and Context
Our Java rest API makes predictions using 100 floats for each tensor, and processing hundreds of tensors for each request, resulting in creating hundreds of thousands of `OnnxTensor` objects being created per second.

We noticed while profiling the app that about 35% of the cpu sampling was spent in `TensorInfo#extractShape` method, particularly in the [`Arrays.get(obj, i)`](https://github.com/microsoft/onnxruntime/blob/main/java/src/main/java/ai/onnxruntime/TensorInfo.java#L510) method call, which is called for each element in the array.

Also, the `Arrays.get(obj, i)` method returns an `Object`, making `float`s (or any other native type) get autoboxed to `Float` objects, and they were subject to garbage collection.

A benchmark using a `float[1][100]`:

| Benchmark             | Mode  | Threads | Samples |        Score | Score Error (99.9%) | Unit   |
|-----------------------|-------|---------|---------|-------------:|--------------------:|--------|
| currentImplementation | thrpt | 1       | 10      |   106.992317 |            0.598410 | ops/ms |
| proposedImplementation     | thrpt | 1       | 10      | 11938.071770 |          143.899310 | ops/ms |


<details>

<summary>Benchmark code</summary>

```java
@BenchmarkMode(Mode.Throughput)
@OutputTimeUnit(TimeUnit.MILLISECONDS)
@State(Scope.Benchmark)
@Fork(value = 1, jvmArgs = {"-Xms4G", "-Xmx4G", "-Dcom.sun.management.jmxremote", "-Dcom.sun.management.jmxremote.port=9010", "-Dcom.sun.management.jmxremote.authenticate=false",
    "-Dcom.sun.management.jmxremote.ssl=false", "-Djava.rmi.server.hostname=127.0.0.1",
    "-XX:+UseG1GC"})
@Measurement(iterations = 10)
public class ShapeBenchmark {
  float[][] embeddings;


  @Param({"1"})
  int dims;

  @Param({"100"})
  int embeddingsSize;

  @Setup(Level.Trial)
  public void setup() {
    embeddings = new float[dims][embeddingsSize];
    for (int i = 0; i < embeddings.length; i++) {
      for (int j = 0; j < embeddings[i].length; j++) {
        embeddings[i][j] = (float) Math.random();
      }
    }
  }

  @Benchmark
  public long[] currentImplementation() throws OrtException {
    int dimensions = getDimensions(embeddings);
    long[] shape = new long[dimensions];
    extractShape(shape, 0, embeddings);
    return shape;
  }

  @Benchmark
  public long[] proposedImplementation() throws OrtException {
    int dimensions = getDimensions(embeddings);
    long[] shape = new long[dimensions];
    newExtractShape(shape, 0, embeddings);
    return shape;
  }

  // Helper method to get the dimensions of the given array. Copied from TensorInfo#constructFromJavaArray
  public static int getDimensions(Object o) {
    Class<?> objClass = o.getClass();
    int dimensions = 0;
    while (objClass.isArray()) {
      objClass = objClass.getComponentType();
      dimensions++;
    }
    return dimensions;
  }

  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
  // Copied from TensorInfo#extractShape
  public static void extractShape(long[] shape, int curDim, Object obj) throws OrtException {
    if (shape.length != curDim) {
      int curLength = Array.getLength(obj);
      if (curLength == 0) {
        throw new OrtException(
            "Supplied array has a zero dimension at "
                + curDim
                + ", all dimensions must be positive");
      } else if (shape[curDim] == 0L) {
        shape[curDim] = curLength;
      } else if (shape[curDim] != curLength) {
        throw new OrtException(
            "Supplied array is ragged, expected " + shape[curDim] + ", found " + curLength);
      }
      for (int i = 0; i < curLength; i++) {
        extractShape(shape, curDim + 1, Array.get(obj, i));
      }
    }
  }

  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
  public static void newExtractShape(long[] shape, int curDim, Object obj) throws OrtException {
    if (shape.length != curDim) {
      int curLength = Array.getLength(obj);
      if (curLength == 0) {
        throw new OrtException(
            "Supplied array has a zero dimension at "
                + curDim
                + ", all dimensions must be positive");
      } else if (shape[curDim] == 0L) {
        shape[curDim] = curLength;
      } else if (shape[curDim] != curLength) {
        throw new OrtException(
            "Supplied array is ragged, expected " + shape[curDim] + ", found " + curLength);
      }
      int nextDim = curDim + 1;
      if (shape.length != nextDim) {
        for (int i = 0; i < curLength; i++) {
          newExtractShape(shape, nextDim, Array.get(obj, i));
        }
      }
    }
  }

}
```

</details>

Disclaimer: I wasn't able to build onnx locally to run all the test suite for inference in my M3 because im having issues with some dependencies, but added tests for [`TensorInfo.constructFromJavaArray(obj)`](https://github.com/microsoft/onnxruntime/blob/main/java/src/main/java/ai/onnxruntime/TensorInfo.java#L375) and they pass for `main` branch as well.