### PR TITLE
Fix inference unable to run due to JS WASM runtime not being bundled into `onnxruntime-web/wasm` build

### DIFF
--- a/js/web/script/build.ts
+++ b/js/web/script/build.ts
@@ -644,7 +644,7 @@ async function main() {
       isProduction: true,
       outputName: 'ort.wasm.bundle',
       format: 'esm',
-      define: { ...DEFAULT_DEFINE, 'BUILD_DEFS.DISABLE_JSEP': 'true', 'BUILD_DEFS.DISABLE_WEBGL': 'true' },
+      define: { ...DEFAULT_DEFINE, 'BUILD_DEFS.DISABLE_JSEP': 'true', 'BUILD_DEFS.DISABLE_WEBGL': 'true', 'BUILD_DEFS.ENABLE_BUNDLE_WASM_JS': 'true' },
     });
     // ort.webgl[.min].[m]js
     await addAllWebBuildTasks({


### PR DESCRIPTION
### Description
Fixes inference error from `ort-wasm-simd-threaded.mjs` not being bundled into `ort.wasm.bundle.min.mjs` as it is for other `bundle.min.mjs` builds.

### Motivation and Context
To decrease my app's bundle size, I followed the [conditional importing guide](https://github.com/microsoft/onnxruntime-inference-examples/tree/main/js/importing_onnxruntime-web#conditional-importing) and imported the WASM-only build:
```diff
- import * as ort from 'onnxruntime-web';
+ import * as ort from 'onnxruntime-web/wasm';
```
After this change, creating an inference session would result in: `TypeError: Failed to resolve module specifier './ort-wasm-simd-threaded.mjs'`.

This was because `ort-wasm-simd-threaded.mjs` was not bundled into the build at `onnxruntime-web/wasm`, which points to `ort.wasm.bundle.min.mjs`, despite how its name suggests. In other builds with `bundle` in their name, the module is bundled, yet it was not done so in the WASM one. This PR bundles the Javascript WASM runtime in to match the other builds, fixing the error.


