### PR TITLE
Cast Nodes Fusion

### DIFF
--- a/include/onnxruntime/core/optimizer/graph_transformer_utils.h
+++ b/include/onnxruntime/core/optimizer/graph_transformer_utils.h
@@ -46,7 +46,8 @@ std::string GenerateRuleBasedTransformerName(TransformerLevel level);
 std::unique_ptr<RuleBasedGraphTransformer> GenerateRuleBasedGraphTransformer(
     TransformerLevel level,
     const InlinedHashSet<std::string>& rules_to_disable,
-    const InlinedHashSet<std::string_view>& compatible_execution_providers);
+    const InlinedHashSet<std::string_view>& compatible_execution_providers,
+    const SessionOptions& session_options);
 
 /** Generates all predefined (both rule-based and non-rule-based) transformers for this level.
     Any transformers or rewrite rules named in rules_and_transformers_to_disable will be excluded. */

--- a/include/onnxruntime/core/optimizer/graph_transformer_utils.h
+++ b/include/onnxruntime/core/optimizer/graph_transformer_utils.h
@@ -47,7 +47,7 @@ std::unique_ptr<RuleBasedGraphTransformer> GenerateRuleBasedGraphTransformer(
     TransformerLevel level,
     const InlinedHashSet<std::string>& rules_to_disable,
     const InlinedHashSet<std::string_view>& compatible_execution_providers,
-    const SessionOptions& session_options);
+    const bool enable_cast_chain_elimination = false);
 
 /** Generates all predefined (both rule-based and non-rule-based) transformers for this level.
     Any transformers or rewrite rules named in rules_and_transformers_to_disable will be excluded. */

--- a/include/onnxruntime/core/optimizer/graph_transformer_utils.h
+++ b/include/onnxruntime/core/optimizer/graph_transformer_utils.h
@@ -36,7 +36,8 @@ namespace optimizer_utils {
    TODO: This is visible for testing at the moment, but we should rather make it private. */
 InlinedVector<std::unique_ptr<RewriteRule>> GenerateRewriteRules(
     TransformerLevel level,
-    const InlinedHashSet<std::string>& rules_to_disable = {});
+    const InlinedHashSet<std::string>& rules_to_disable = {},
+    const bool enable_cast_chain_elimination = false);
 
 /** Given a TransformerLevel, this method generates a name for the rule-based graph transformer of that level. */
 std::string GenerateRuleBasedTransformerName(TransformerLevel level);

--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -67,6 +67,10 @@ static const char* const kOrtSessionOptionsEnableQuantQDQCleanup = "session.enab
 // GeluApproximation has side effects which may change the inference results. It is disabled by default due to this.
 static const char* const kOrtSessionOptionsEnableGeluApproximation = "optimization.enable_gelu_approximation";
 
+// Enable or disable Cast chain elimination in graph optimization. "0": disable; "1": enable. The default is "0".
+// CastElimination with chain elimination has side effects which may change the inference results. It is disabled by default due to this.
+static const char* const kOrtSessionOptionsEnableCastChainElimination = "optimization.enable_cast_chain_elimination";
+
 // This setting controls whether to enable AheadOfTime function inlining.
 // AOT function inlining examines the graph and attempts to inline as many locally defined functions in the model
 // as possible with the help of enabled execution providers.

--- a/onnxruntime/core/graph/graph_utils.cc
+++ b/onnxruntime/core/graph/graph_utils.cc
@@ -610,6 +610,11 @@ bool IsGraphInput(const Graph& graph, const NodeArg* input) {
   return std::find(graph_inputs.begin(), graph_inputs.end(), input) != graph_inputs.end();
 }
 
+bool IsGraphOutput(const Graph& graph, const NodeArg* output) {
+  const std::vector<const NodeArg*>& graph_outputs = graph.GetOutputs();
+  return std::find(graph_outputs.begin(), graph_outputs.end(), output) != graph_outputs.end();
+}
+
 bool IsInitializer(const Graph& graph, const std::string& name, bool check_outer_scope) {
   bool is_initializer = false;
   const ONNX_NAMESPACE::TensorProto* initializer = nullptr;

--- a/onnxruntime/core/graph/graph_utils.cc
+++ b/onnxruntime/core/graph/graph_utils.cc
@@ -611,7 +611,7 @@ bool IsGraphInput(const Graph& graph, const NodeArg* input) {
 }
 
 bool IsGraphOutput(const Graph& graph, const NodeArg* output) {
-  const std::vector<const NodeArg*>& graph_outputs = graph.GetOutputs();
+  const auto& graph_outputs = graph.GetOutputs();
   return std::find(graph_outputs.begin(), graph_outputs.end(), output) != graph_outputs.end();
 }
 

--- a/onnxruntime/core/graph/graph_utils.h
+++ b/onnxruntime/core/graph/graph_utils.h
@@ -132,6 +132,9 @@ bool IsOutputUsed(const Node& node, int index);
 /** Returns true if the graph has the given input.*/
 bool IsGraphInput(const Graph& graph, const NodeArg* input);
 
+/** Returns true if the graph has the given output.*/
+bool IsGraphOutput(const Graph& graph, const NodeArg* output);
+
 /** returns true if 'name' is an initializer in 'graph', or an ancestor graph if check_outer_scope is true.
 @param check_outer_scope If true and 'graph' is a subgraph, check ancestor graph/s for 'name' if not found in 'graph'.
 */

--- a/onnxruntime/core/optimizer/cast_chain_elimination.cc
+++ b/onnxruntime/core/optimizer/cast_chain_elimination.cc
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/common/logging/logging.h"
+#include "core/optimizer/cast_chain_elimination.h"
+#include "core/optimizer/utils.h"
+#include "core/graph/graph.h"
+#include "core/graph/graph_utils.h"
+
+namespace onnxruntime {
+
+Status CastChainElimination::ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const {
+  GraphViewer graph_viewer(graph);
+  const auto& node_topology_list = graph_viewer.GetNodesInTopologicalOrder();
+
+  for (auto node_index : node_topology_list) {
+    auto* node_ptr = graph.GetNode(node_index);
+    if (node_ptr == nullptr)
+      continue;  // we removed the node as part of an earlier fusion
+
+    Node& node = *node_ptr;
+
+    ORT_RETURN_IF_ERROR(Recurse(node, modified, graph_level, logger));
+
+    if (!graph_utils::CanRemoveNode(graph, node, logger)) {
+      continue;
+    }
+
+    if (node.OpType() != "Cast") {
+      continue;
+    }
+
+    const auto* input_type = node.InputDefs()[0]->TypeAsProto();
+    if (input_type == nullptr || !input_type->tensor_type().has_elem_type()) {
+      continue;
+    }
+
+    // If not, find the longest chain that casts to the input type, if it exists.
+    Node* current = &node;
+    Node* final_non_cast_node = &node;
+    int matching_elem_type = input_type->tensor_type().elem_type();
+
+    while (current->OpType() == "Cast") {
+      const auto& to_attr = current->GetAttributes().at("to");
+
+      // A rare case when the Cast node output is branching out.
+      // We don't really want to deal with this complexity, hence we will skip it.
+      if (current->GetOutputEdgesCount() > 1) {
+        return Status::OK();
+      }
+
+      auto it = current->OutputNodesBegin();
+      if (it == current->OutputNodesEnd()) {
+        break;
+      }
+      current = const_cast<Node*>(&(*it));
+
+      // We found the repeating pattern.
+      if (to_attr.i() == matching_elem_type) {
+        final_non_cast_node = current;
+      }
+    }
+
+    // No repeating pattern was found.
+    if (node.Index() == final_non_cast_node->Index()) {
+      continue;
+    }
+
+    std::vector<Node*> to_remove;
+    current = &node;
+
+    // Collect nodes for removal.
+    while (current != final_non_cast_node && current->OpType() == "Cast") {
+      to_remove.push_back(current);
+      auto it = current->OutputNodesBegin();
+      if (it == current->OutputNodesEnd())
+        break;
+      current = const_cast<Node*>(&*it);
+    }
+
+    // First remove all outbound edges.
+    for (Node* n : to_remove) {
+      graph_utils::RemoveNodeOutputEdges(graph, *n);
+    }
+
+    NodeArg* last_node_output_def = to_remove.back()->MutableOutputDefs()[0];
+    const std::string& last_node_output_tensor_name = last_node_output_def->Name();
+
+    // Find the matching def slot, so we can wire the final node to the input of the first removeable node.
+    int slot = -1;
+    auto& inputs = final_non_cast_node->MutableInputDefs();
+    for (int i = 0, n = static_cast<int>(inputs.size()); i < n; ++i) {
+      if (inputs[i]->Name() == last_node_output_tensor_name) {
+        slot = i;
+        break;
+      }
+    }
+
+    final_non_cast_node->MutableInputDefs()[slot] = to_remove[0]->MutableInputDefs()[0];
+
+    graph_utils::MoveAllNodeInputEdges(graph, *to_remove[0], *final_non_cast_node);
+
+    // Finally, remove the nodes itself.
+    for (Node* n : to_remove) {
+      graph.RemoveNode(n->Index());
+    }
+
+    modified = true;
+  }
+
+  return Status::OK();
+}
+}  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/cast_chain_elimination.cc
+++ b/onnxruntime/core/optimizer/cast_chain_elimination.cc
@@ -12,13 +12,7 @@ namespace onnxruntime {
 
 Status CastChainElimination::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_effect, const logging::Logger&) const {
   auto nextNodeIt = node.OutputNodesBegin();
-
   Node* next = graph.GetNode(nextNodeIt->Index());
-
-  // Skip if the next node is not of type Cast.
-  if (next->OpType() != "Cast") {
-    return Status::OK();
-  }
 
   // We can remove the current node.
   graph_utils::RemoveNodeOutputEdges(graph, node);
@@ -28,6 +22,7 @@ Status CastChainElimination::Apply(Graph& graph, Node& node, RewriteRuleEffect& 
 
   // Find the matching def slot, so we can wire the final node to the input of the removeable node.
   int slot = -1;
+
   auto& inputs = next->MutableInputDefs();
   for (int i = 0, n = static_cast<int>(inputs.size()); i < n; ++i) {
     if (inputs[i]->Name() == last_node_output_tensor_name) {
@@ -48,10 +43,6 @@ Status CastChainElimination::Apply(Graph& graph, Node& node, RewriteRuleEffect& 
 }
 
 bool CastChainElimination::SatisfyCondition(const Graph& graph, const Node& node, const logging::Logger& logger) const {
-  if (graph_utils::IsGraphOutput(graph, node.OutputDefs()[0])) {
-    return false;
-  }
-
   const auto* input_type = node.InputDefs()[0]->TypeAsProto();
   if (input_type == nullptr || !input_type->tensor_type().has_elem_type()) {
     return false;
@@ -63,6 +54,15 @@ bool CastChainElimination::SatisfyCondition(const Graph& graph, const Node& node
 
   // Skip nodes that don't have 1 output edge.
   if (node.GetOutputEdgesCount() != 1) {
+    return false;
+  }
+
+  const auto nextNodeIt = node.OutputNodesBegin();
+
+  const Node* next = graph.GetNode(nextNodeIt->Index());
+
+  // Skip if the next node is not of type Cast.
+  if (next->OpType() != "Cast") {
     return false;
   }
 

--- a/onnxruntime/core/optimizer/cast_chain_elimination.cc
+++ b/onnxruntime/core/optimizer/cast_chain_elimination.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "core/common/logging/logging.h"
+#include "core/optimizer/rewrite_rule.h"
 #include "core/optimizer/cast_chain_elimination.h"
 #include "core/optimizer/utils.h"
 #include "core/graph/graph.h"
@@ -9,75 +10,62 @@
 
 namespace onnxruntime {
 
-Status CastChainElimination::ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const {
-  GraphViewer graph_viewer(graph);
-  const auto& node_topology_list = graph_viewer.GetNodesInTopologicalOrder();
+Status CastChainElimination::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_effect, const logging::Logger&) const {
+  auto nextNodeIt = node.OutputNodesBegin();
 
-  for (auto node_index : node_topology_list) {
-    auto* node_ptr = graph.GetNode(node_index);
-    if (node_ptr == nullptr)
-      continue;  // we removed the node as part of an earlier fusion
+  Node* next = graph.GetNode(nextNodeIt->Index());
 
-    Node& node = *node_ptr;
-
-    if (node.OpType() != "Cast") {
-      continue;
-    }
-
-    ORT_RETURN_IF_ERROR(Recurse(node, modified, graph_level, logger));
-
-    if (graph_utils::IsGraphOutput(graph, node.OutputDefs()[0])) {
-      continue;
-    }
-
-    const auto* input_type = node.InputDefs()[0]->TypeAsProto();
-    if (input_type == nullptr || !input_type->tensor_type().has_elem_type()) {
-      continue;
-    }
-
-    if (!graph_utils::CanRemoveNode(graph, node, logger)) {
-      continue;
-    }
-
-    // Skip nodes that don't have 1 output edge.
-    if (node.GetOutputEdgesCount() != 1) {
-      continue;
-    }
-
-    auto nextNodeIt = node.OutputNodesBegin();
-
-    Node* next = graph.GetNode(nextNodeIt->Index());
-
-    // Skip if the next node is not of type Cast.
-    if (next->OpType() != "Cast") {
-      continue;
-    }
-
-    // We can remove the current node.
-    graph_utils::RemoveNodeOutputEdges(graph, node);
-
-    NodeArg* last_node_output_def = node.MutableOutputDefs()[0];
-    const std::string& last_node_output_tensor_name = last_node_output_def->Name();
-
-    // Find the matching def slot, so we can wire the final node to the input of the removeable node.
-    int slot = -1;
-    auto& inputs = next->MutableInputDefs();
-    for (int i = 0, n = static_cast<int>(inputs.size()); i < n; ++i) {
-      if (inputs[i]->Name() == last_node_output_tensor_name) {
-        slot = i;
-        break;
-      }
-    }
-
-    next->MutableInputDefs()[slot] = node.MutableInputDefs()[0];
-
-    graph_utils::MoveAllNodeInputEdges(graph, node, *next);
-
-    graph.RemoveNode(node.Index());
-
-    modified = true;
+  // Skip if the next node is not of type Cast.
+  if (next->OpType() != "Cast") {
+    return Status::OK();
   }
 
+  // We can remove the current node.
+  graph_utils::RemoveNodeOutputEdges(graph, node);
+
+  NodeArg* last_node_output_def = node.MutableOutputDefs()[0];
+  const std::string& last_node_output_tensor_name = last_node_output_def->Name();
+
+  // Find the matching def slot, so we can wire the final node to the input of the removeable node.
+  int slot = -1;
+  auto& inputs = next->MutableInputDefs();
+  for (int i = 0, n = static_cast<int>(inputs.size()); i < n; ++i) {
+    if (inputs[i]->Name() == last_node_output_tensor_name) {
+      slot = i;
+      break;
+    }
+  }
+
+  next->MutableInputDefs()[slot] = node.MutableInputDefs()[0];
+
+  graph_utils::MoveAllNodeInputEdges(graph, node, *next);
+
+  graph.RemoveNode(node.Index());
+
+  rule_effect = RewriteRuleEffect::kRemovedCurrentNode;
+
   return Status::OK();
+}
+
+bool CastChainElimination::SatisfyCondition(const Graph& graph, const Node& node, const logging::Logger& logger) const {
+  if (graph_utils::IsGraphOutput(graph, node.OutputDefs()[0])) {
+    return false;
+  }
+
+  const auto* input_type = node.InputDefs()[0]->TypeAsProto();
+  if (input_type == nullptr || !input_type->tensor_type().has_elem_type()) {
+    return false;
+  }
+
+  if (!graph_utils::CanRemoveNode(graph, node, logger)) {
+    return false;
+  }
+
+  // Skip nodes that don't have 1 output edge.
+  if (node.GetOutputEdgesCount() != 1) {
+    return false;
+  }
+
+  return true;
 }
 }  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/cast_chain_elimination.cc
+++ b/onnxruntime/core/optimizer/cast_chain_elimination.cc
@@ -43,11 +43,6 @@ Status CastChainElimination::Apply(Graph& graph, Node& node, RewriteRuleEffect& 
 }
 
 bool CastChainElimination::SatisfyCondition(const Graph& graph, const Node& node, const logging::Logger& logger) const {
-  const auto* input_type = node.InputDefs()[0]->TypeAsProto();
-  if (input_type == nullptr || !input_type->tensor_type().has_elem_type()) {
-    return false;
-  }
-
   if (!graph_utils::CanRemoveNode(graph, node, logger)) {
     return false;
   }

--- a/onnxruntime/core/optimizer/cast_chain_elimination.h
+++ b/onnxruntime/core/optimizer/cast_chain_elimination.h
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/optimizer/graph_transformer.h"
+
+namespace onnxruntime {
+
+/**
+@Class CastElimination
+The transform that will try to find the longest chain of the type Cast where the 'to' attribute has the same data type as the input of the first Cast node in the chain.
+E.g.
+A ('float32') -> Cast (to='float16') ->  Cast (to='int4') ->  Cast (to='float32') -> Cast (to='float16') -> B
+will reduce to
+ A ('float32') -> Cast (to='float16') -> B
+
+All the Cast nodes throughout the path need to have one input and one output to be considered for the fusion.
+*/
+class CastChainElimination : public GraphTransformer {
+ public:
+  explicit CastChainElimination(const InlinedHashSet<std::string_view>& compatible_execution_providers = {}) noexcept
+      : GraphTransformer("CastChainElimination", compatible_execution_providers) {
+  }
+
+ private:
+  Status ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const override;
+};
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/cast_chain_elimination.h
+++ b/onnxruntime/core/optimizer/cast_chain_elimination.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "core/optimizer/graph_transformer.h"
+#include "core/optimizer/rewrite_rule.h"
 
 namespace onnxruntime {
 
@@ -17,14 +17,18 @@ will reduce to
 
 All the Cast nodes throughout the path need to have one input and one output to be considered for the fusion.
 */
-class CastChainElimination : public GraphTransformer {
+class CastChainElimination : public RewriteRule {
  public:
-  explicit CastChainElimination(const InlinedHashSet<std::string_view>& compatible_execution_providers = {}) noexcept
-      : GraphTransformer("CastChainElimination", compatible_execution_providers) {
+  CastChainElimination() noexcept : RewriteRule("CastChainElimination") {}
+
+  std::vector<std::string> TargetOpTypes() const noexcept override {
+    return {"Cast"};
   }
 
  private:
-  Status ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const override;
+  bool SatisfyCondition(const Graph& graph, const Node& node, const logging::Logger& logger) const override;
+
+  Status Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_effect, const logging::Logger& logger) const override;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/cast_elimination.cc
+++ b/onnxruntime/core/optimizer/cast_elimination.cc
@@ -32,17 +32,17 @@ Status CastElimination::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_
   while (current->OpType() == "Cast") {
     const auto& to_attr = current->GetAttributes().at("to");
 
-    auto it = current->OutputNodesBegin();
-    if (it == current->OutputNodesEnd()) {
-      break;
-    }
-    current = const_cast<Node*>(&(*it));
-
     // Special case when Cast is branching out into multiple outputs.
     // Possible to detect different chains, but much harder and out of scope for this fusion.
     if (current->GetOutputEdgesCount() > 1) {
       return Status::OK();
     }
+
+    auto it = current->OutputNodesBegin();
+    if (it == current->OutputNodesEnd()) {
+      break;
+    }
+    current = const_cast<Node*>(&(*it));
 
     // We found we are repeating the conversion.
     if (to_attr.i() == matching_elem_type) {

--- a/onnxruntime/core/optimizer/cast_elimination.cc
+++ b/onnxruntime/core/optimizer/cast_elimination.cc
@@ -44,8 +44,17 @@ Status CastElimination::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_
     }
   }
 
+  // No repeating pattern was found.
+  if (current == final_non_cast_node) {
+    return Status::OK();
+  }
+
+  rule_effect = RewriteRuleEffect::kRemovedCurrentNode;
+
   std::vector<Node*> to_remove;
   current = &node;
+
+  // Collect the nodes to remove.
   while (current != final_non_cast_node && current->OpType() == "Cast") {
     to_remove.push_back(current);
     auto it = current->OutputNodesBegin();
@@ -54,26 +63,8 @@ Status CastElimination::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_
     current = const_cast<Node*>(&*it);
   }
 
-  // No repeating pattern was found.
-  if (to_remove.empty()) {
-    return Status::OK();
-  }
-
-  std::cout << "to remove size " << to_remove.size() << std::endl;
-
-  for (Node* n : to_remove) {
-    std::cout << "el is" << std::endl;
-    std::cout << n->Name() << " " << n->Index() << std::endl;
-  }
-
-  std::cout << "Explicit args count" << to_remove[0]->MutableInputArgsCount() << std::endl;
-  std::cout << "Explicit args count2 " << to_remove[0]->GetInputEdgesCount() << std::endl;
-
-  rule_effect = RewriteRuleEffect::kRemovedCurrentNode;
-
   // First remove all outbound edges.
   for (Node* n : to_remove) {
-    std::cout << n->Name() << std::endl;
     graph_utils::RemoveNodeOutputEdges(graph, *n);
   }
 

--- a/onnxruntime/core/optimizer/cast_elimination.cc
+++ b/onnxruntime/core/optimizer/cast_elimination.cc
@@ -44,16 +44,13 @@ Status CastElimination::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_
     }
   }
 
-  if (current == final_non_cast_node) {
+  if (node.Index() == final_non_cast_node->Index()) {
     return Status::OK();
   }
-
-  rule_effect = RewriteRuleEffect::kRemovedCurrentNode;
 
   std::vector<Node*> to_remove;
   current = &node;
 
-  // Collect the nodes to remove.
   while (current != final_non_cast_node && current->OpType() == "Cast") {
     to_remove.push_back(current);
     auto it = current->OutputNodesBegin();
@@ -62,10 +59,7 @@ Status CastElimination::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_
     current = const_cast<Node*>(&*it);
   }
 
-  // No nodes to remove.
-  if (to_remove.empty()) {
-    return Status::OK();
-  }
+  rule_effect = RewriteRuleEffect::kRemovedCurrentNode;
 
   // First remove all outbound edges.
   for (Node* n : to_remove) {

--- a/onnxruntime/core/optimizer/cast_elimination.cc
+++ b/onnxruntime/core/optimizer/cast_elimination.cc
@@ -44,7 +44,6 @@ Status CastElimination::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_
     }
   }
 
-  // No repeating pattern was found.
   if (current == final_non_cast_node) {
     return Status::OK();
   }
@@ -61,6 +60,11 @@ Status CastElimination::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_
     if (it == current->OutputNodesEnd())
       break;
     current = const_cast<Node*>(&*it);
+  }
+
+  // No nodes to remove.
+  if (to_remove.empty()) {
+    return Status::OK();
   }
 
   // First remove all outbound edges.

--- a/onnxruntime/core/optimizer/cast_elimination.cc
+++ b/onnxruntime/core/optimizer/cast_elimination.cc
@@ -11,8 +11,72 @@
 namespace onnxruntime {
 
 Status CastElimination::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_effect, const logging::Logger&) const {
-  if (graph_utils::RemoveNode(graph, node)) {
-    rule_effect = RewriteRuleEffect::kRemovedCurrentNode;
+  const auto* input_type = node.InputDefs()[0]->TypeAsProto();
+  if (input_type == nullptr || !input_type->tensor_type().has_elem_type()) {
+    return Status::OK();
+  }
+
+  Node* current = &node;
+  Node* final_non_cast_node = &node;
+  int matching_elem_type = input_type->tensor_type().elem_type();
+
+  while (current->OpType() == "Cast") {
+    const auto& to_attr = current->GetAttributes().at("to");
+
+    auto it = current->OutputNodesBegin();
+    if (it == current->OutputNodesEnd()) {
+      break;
+    }
+    current = const_cast<Node*>(&(*it));
+
+    // We found we are repeating the conversion.
+    if (to_attr.i() == matching_elem_type) {
+      final_non_cast_node = current;
+    }
+  }
+
+  std::vector<Node*> to_remove;
+  current = &node;
+  while (current != final_non_cast_node && current->OpType() == "Cast") {
+    to_remove.push_back(current);
+    auto it = current->OutputNodesBegin();
+    if (it == current->OutputNodesEnd())
+      break;
+    current = const_cast<Node*>(&*it);
+  }
+
+  // The existing Cast nodes are all valid.
+  if (to_remove.empty()) {
+    return Status::OK();
+  }
+
+  rule_effect = RewriteRuleEffect::kRemovedCurrentNode;
+
+  // First remove all outbound edges.
+  for (Node* n : to_remove) {
+    graph_utils::RemoveNodeOutputEdges(graph, *n);
+  }
+
+  NodeArg* last_node_output_def = to_remove.back()->MutableOutputDefs()[0];
+  const std::string& last_node_output_tensor_name = last_node_output_def->Name();
+
+  // Find the matching def slot, so we can wire the final node to the input of the first removeable node.
+  int slot = -1;
+  auto& inputs = final_non_cast_node->MutableInputDefs();
+  for (int i = 0, n = static_cast<int>(inputs.size()); i < n; ++i) {
+    if (inputs[i]->Name() == last_node_output_tensor_name) {
+      slot = i;
+      break;
+    }
+  }
+
+  final_non_cast_node->MutableInputDefs()[slot] = to_remove[0]->MutableInputDefs()[0];
+
+  graph_utils::MoveAllNodeInputEdges(graph, *to_remove[0], *final_non_cast_node);
+
+  // Finally, remove the nodes itself.
+  for (Node* n : to_remove) {
+    graph.RemoveNode(n->Index());
   }
 
   return Status::OK();
@@ -22,13 +86,7 @@ bool CastElimination::SatisfyCondition(const Graph& graph, const Node& node, con
   if (!graph_utils::CanRemoveNode(graph, node, logger)) {
     return false;
   }
-
-  const auto* input_type = node.InputDefs()[0]->TypeAsProto();
-  if (input_type == nullptr || !input_type->tensor_type().has_elem_type()) {
-    return false;
-  }
-
-  return optimizer_utils::IsAttributeWithExpectedValue(node, "to", static_cast<int64_t>(input_type->tensor_type().elem_type()));
+  return true;
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/cast_elimination.cc
+++ b/onnxruntime/core/optimizer/cast_elimination.cc
@@ -38,6 +38,12 @@ Status CastElimination::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_
     }
     current = const_cast<Node*>(&(*it));
 
+    // Special case when Cast is branching out into multiple outputs.
+    // Possible to detect different chains, but much harder and out of scope for this fusion.
+    if (current->GetOutputEdgesCount() > 1) {
+      return Status::OK();
+    }
+
     // We found we are repeating the conversion.
     if (to_attr.i() == matching_elem_type) {
       final_non_cast_node = current;

--- a/onnxruntime/core/optimizer/cast_elimination.h
+++ b/onnxruntime/core/optimizer/cast_elimination.h
@@ -12,7 +12,7 @@ namespace onnxruntime {
 
 Rewrite rule that eliminates Cast nodes if 'to' attribute has same data type as input tensor data type.
 Additionally, it will try to find the longest chain where the 'to' attribute has the same data type as the input of the first Cast node in the chain.
-E.g. 
+E.g.
 A ('float32') -> Cast (to='float16') ->  Cast (to='int4') ->  Cast (to='float32') -> Cast (to='float16') -> B
 will reduce to
  A ('float32') -> Cast (to='float16') -> B

--- a/onnxruntime/core/optimizer/cast_elimination.h
+++ b/onnxruntime/core/optimizer/cast_elimination.h
@@ -11,13 +11,6 @@ namespace onnxruntime {
 @Class CastElimination
 
 Rewrite rule that eliminates Cast nodes if 'to' attribute has same data type as input tensor data type.
-Additionally, it will try to find the longest chain where the 'to' attribute has the same data type as the input of the first Cast node in the chain.
-E.g.
-A ('float32') -> Cast (to='float16') ->  Cast (to='int4') ->  Cast (to='float32') -> Cast (to='float16') -> B
-will reduce to
- A ('float32') -> Cast (to='float16') -> B
-
-All the Cast nodes throughout the path need to have one input and one output to be considered for the fusion.
 
 It is attempted to be triggered only on nodes with op type "Cast".
 */

--- a/onnxruntime/core/optimizer/cast_elimination.h
+++ b/onnxruntime/core/optimizer/cast_elimination.h
@@ -11,6 +11,13 @@ namespace onnxruntime {
 @Class CastElimination
 
 Rewrite rule that eliminates Cast nodes if 'to' attribute has same data type as input tensor data type.
+Additionally, it will try to find the longest chain where the 'to' attribute has the same data type as the input of the first Cast node in the chain.
+E.g. 
+A ('float32') -> Cast (to='float16') ->  Cast (to='int4') ->  Cast (to='float32') -> Cast (to='float16') -> B
+will reduce to
+ A ('float32') -> Cast (to='float16') -> B
+
+All the Cast nodes throughout the path need to have one input and one output to be considered for the fusion.
 
 It is attempted to be triggered only on nodes with op type "Cast".
 */

--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -178,9 +178,7 @@ std::unique_ptr<RuleBasedGraphTransformer> GenerateRuleBasedGraphTransformer(
     TransformerLevel level,
     const InlinedHashSet<std::string>& rules_to_disable,
     const InlinedHashSet<std::string_view>& compatible_execution_providers,
-    const SessionOptions& session_options) {
-  const bool enable_cast_chain_elimination =
-      session_options.config_options.GetConfigOrDefault(kOrtSessionOptionsEnableCastChainElimination, "0") == "1";
+    const bool enable_cast_chain_elimination) {
   auto rewrite_rules_to_register = GenerateRewriteRules(level, rules_to_disable, enable_cast_chain_elimination);
   if (rewrite_rules_to_register.empty()) {
     return nullptr;
@@ -207,6 +205,8 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
   InlinedVector<std::unique_ptr<GraphTransformer>> transformers;
   const bool disable_quant_qdq =
       session_options.config_options.GetConfigOrDefault(kOrtSessionOptionsDisableQuantQDQ, "0") == "1";
+  const bool enable_cast_chain_elimination =
+      session_options.config_options.GetConfigOrDefault(kOrtSessionOptionsEnableCastChainElimination, "0") == "1";
 #ifndef DISABLE_CONTRIB_OPS
   const InlinedHashSet<std::string_view> cpu_ep = {onnxruntime::kCpuExecutionProvider};
   const InlinedHashSet<std::string_view> cpu_acl_eps = {onnxruntime::kCpuExecutionProvider,
@@ -220,7 +220,7 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
       // RewriteRule optimizations are the simplest (they generally remove unnecessary nodes and are cheap to run)
       // so run them first so there is potentially less for the more intensive optimizations like ConstantFolding,
       // CommonSubexpressionElimination and TransposeOptimizer to do.
-      auto rule_transformer = GenerateRuleBasedGraphTransformer(level, rules_and_transformers_to_disable, {}, session_options);
+      auto rule_transformer = GenerateRuleBasedGraphTransformer(level, rules_and_transformers_to_disable, {}, enable_cast_chain_elimination);
       if (rule_transformer != nullptr) {
         transformers.emplace_back(std::move(rule_transformer));
       }
@@ -274,7 +274,7 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
     } break;
 
     case TransformerLevel::Level2: {
-      auto rule_transformer = GenerateRuleBasedGraphTransformer(level, rules_and_transformers_to_disable, {}, session_options);
+      auto rule_transformer = GenerateRuleBasedGraphTransformer(level, rules_and_transformers_to_disable, {}, enable_cast_chain_elimination);
       if (rule_transformer != nullptr) {
         transformers.emplace_back(std::move(rule_transformer));
       }

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -4397,7 +4397,7 @@ TEST_F(GraphTransformationTests, CastChainEliminationRepeatedPattern) {
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   op_to_count = CountOpsInGraph(graph);
-  ASSERT_TRUE(op_to_count["Cast"] == 1);
+  ASSERT_TRUE(op_to_count["Cast"] == 3);
 }
 
 TEST_F(GraphTransformationTests, PreShapeNodeElimination) {

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -4387,14 +4387,14 @@ TEST_F(GraphTransformationTests, CastChainEliminationRepeatedPattern) {
   std::shared_ptr<Model> model;
   ASSERT_TRUE(Model::Load(model_uri, model, nullptr, *logger_).IsOK());
   Graph& graph = model->MainGraph();
-
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Cast"] == 7);
 
-  onnxruntime::GraphTransformerManager graph_transformation_mgr{3};
-  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<CastChainElimination>(), TransformerLevel::Level2));
+  auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformer1");
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<CastChainElimination>()));
+  onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
-  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Cast"] == 3);

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -4362,7 +4362,7 @@ TEST_F(GraphTransformationTests, ExpandElimination) {
   ASSERT_TRUE(op_to_count["Expand"] == 3);
 }
 
-TEST_F(GraphTransformationTests, CastElimination) {
+TEST_F(GraphTransformationTests, CastEliminationSimple) {
   constexpr const ORTCHAR_T* model_uri = MODEL_FOLDER "cast_elimination.onnx";
   std::shared_ptr<Model> model;
   ASSERT_TRUE(Model::Load(model_uri, model, nullptr, *logger_).IsOK());
@@ -4378,6 +4378,25 @@ TEST_F(GraphTransformationTests, CastElimination) {
 
   op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Cast"] == 4);
+}
+
+TEST_F(GraphTransformationTests, CastEliminationRepeatedPattern) {
+  constexpr const ORTCHAR_T* model_uri = MODEL_FOLDER "cast_elimination_complex.onnx";
+
+  std::shared_ptr<Model> model;
+  ASSERT_TRUE(Model::Load(model_uri, model, nullptr, *logger_).IsOK());
+  Graph& graph = model->MainGraph();
+  std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
+  ASSERT_TRUE(op_to_count["Cast"] == 7);
+
+  auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformer1");
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<CastElimination>()));
+  onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
+
+  op_to_count = CountOpsInGraph(graph);
+  ASSERT_TRUE(op_to_count["Cast"] == 1);
 }
 
 TEST_F(GraphTransformationTests, PreShapeNodeElimination) {

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -25,6 +25,7 @@
 #include "core/optimizer/bias_gelu_fusion.h"
 #include "core/optimizer/bias_softmax_fusion.h"
 #include "core/optimizer/cast_elimination.h"
+#include "core/optimizer/cast_chain_elimination.h"
 #include "core/optimizer/common_subexpression_elimination.h"
 #include "core/optimizer/concat_slice_elimination.h"
 #include "core/optimizer/constant_folding.h"
@@ -4380,20 +4381,20 @@ TEST_F(GraphTransformationTests, CastEliminationSimple) {
   ASSERT_TRUE(op_to_count["Cast"] == 4);
 }
 
-TEST_F(GraphTransformationTests, CastEliminationRepeatedPattern) {
+TEST_F(GraphTransformationTests, CastChainEliminationRepeatedPattern) {
   constexpr const ORTCHAR_T* model_uri = MODEL_FOLDER "cast_elimination_complex.onnx";
 
   std::shared_ptr<Model> model;
   ASSERT_TRUE(Model::Load(model_uri, model, nullptr, *logger_).IsOK());
   Graph& graph = model->MainGraph();
+
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Cast"] == 7);
 
-  auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformer1");
-  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<CastElimination>()));
-  onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
+  onnxruntime::GraphTransformerManager graph_transformation_mgr{3};
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<CastChainElimination>(), TransformerLevel::Level2));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Cast"] == 1);

--- a/onnxruntime/test/testdata/transform/cast_elimination_complex.onnx
+++ b/onnxruntime/test/testdata/transform/cast_elimination_complex.onnx
@@ -1,0 +1,40 @@
+cast_chain_generator:Ô
+,
+XX_fp16Cast_X_to_fp16"Cast*	
+to
+ 
+1
+X_fp16X_fp32Cast_X_to_fp32"Cast*	
+to 
+,
+YY_fp32Cast_Y_to_fp32"Cast*	
+to 
+"
+X_fp32
+Y_fp32t0_sumAdd"Add
+*
+t0_sumt1_castCast_1"Cast*	
+to
+ 
++
+t1_castt2_castCast_2"Cast*	
+to 
++
+t2_castt3_castCast_3"Cast*	
+to 
++
+t3_castt4_castCast_4"Cast*	
+to
+ 
+&
+t4_castZOutputIdentity"IdentityCastChainGraphZ
+X
+	
+NZ
+Y
+	
+Nb
+Z
+	
+
+NB


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
We might have a case where multiple Cast nodes in the chain cast back to the original type. This fusion will remove extra nodes.
E.g.
`A ('float32') -> Cast (to='float16') ->  Cast (to='int4') ->  Cast (to='float32') -> Cast (to='float16') -> B
`
will reduce to
` A ('float32') -> Cast (to='float16') -> B
`
All the Cast nodes throughout the path need to have one input and one output to be considered for the fusion.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Gemma3 ONNX models used to have double casting, and many new models created by the model builder might have as well. Extra Casts might reduce accuracy and increase inference time.


