### PR TITLE
[QNN EP] Add 16x16 Gemm translation

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
@@ -143,6 +143,52 @@ Status GemmOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
     QnnTensorWrapper input_tensorwrapper(input_tensor_name, tensor_type, qnn_data_type, std::move(quantize_param),
                                          std::move(input_shape), std::move(unpacked_tensor));
     ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(input_tensorwrapper)), "Failed to add tensor.");
+
+    if (1 == input_i) {
+      // Workaround that inserts a QNN Convert op before input[1] (converts from quantized uint16 to signed symmetric int16)
+      // to avoid a QNN validation failure.
+      //
+      // QNN graph WITHOUT workaround (fails validation):
+      //     input_0_uint16 ---> FC ---> output_uint16
+      //                         ^
+      //                         |
+      //     input_1_uint16 -----+
+      //
+      // QNN graph WITH workaround (passes validation):
+      //     input_0_uint16 ----------------------> FC ---> output_uint16
+      //                                            ^
+      //                                            |
+      //     input_1_uint16 --> Convert(to int16) --+
+
+      std::string weight_input_name = input_tensor_name;
+      const auto& weight_tensor_wrapper = qnn_model_wrapper.GetQnnTensorWrapper(weight_input_name);
+
+      if (weight_tensor_wrapper.GetTensorDataType() == QNN_DATATYPE_UFIXED_POINT_16) {
+        const auto& quant_param_wrapper = weight_tensor_wrapper.GetQnnQuantParams();
+        const Qnn_QuantizeParams_t& quant_param = quant_param_wrapper.Get();
+        const auto& transformed_input1_shape = weight_tensor_wrapper.GetTensorDims();
+
+        ORT_RETURN_IF_NOT(quant_param_wrapper.IsPerTensor(),
+                          "FC's INT16 weight inputs only support INT16 per-tensor quantization");
+
+        // Pop FC weight. Insert Convert op after Weight
+        input_names.pop_back();
+        const std::string& fc_output_name = node_unit.Outputs()[0].node_arg.Name();
+        std::string convert_output_name = weight_input_name + "_convert_" + fc_output_name;
+
+        ORT_RETURN_IF_ERROR(utils::InsertConvertOp(qnn_model_wrapper,
+                                                   weight_input_name,
+                                                   convert_output_name,
+                                                   QNN_DATATYPE_UFIXED_POINT_16,
+                                                   QNN_DATATYPE_SFIXED_POINT_16,
+                                                   quant_param.scaleOffsetEncoding.offset,
+                                                   quant_param.scaleOffsetEncoding.scale,
+                                                   transformed_input1_shape,
+                                                   true,  // Symmetric
+                                                   do_op_validation));
+        input_names.push_back(convert_output_name);
+      }
+    }
   }
 
   return Status::OK();

--- a/onnxruntime/test/providers/qnn/gemm_op_test.cc
+++ b/onnxruntime/test/providers/qnn/gemm_op_test.cc
@@ -303,6 +303,20 @@ TEST_F(QnnHTPBackendTests, Gemm_Dynamic_A_Static_B_Dynamic_Bias_U8) {
                                         ExpectedEPNodeAssignment::All);
 }
 
+// Test 16-bit QDQ Gemm with dynamic inputs A and Bias. The B input is an initializer.
+TEST_F(QnnHTPBackendTests, Gemm_Dynamic_A_Dynamic_B_Dynamic_Bias_U16) {
+  std::vector<float> input_a_data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  std::vector<float> input_b_data = GetFloatDataInRange(-5.0f, 5.0f, 24);
+  std::vector<float> input_c_data = GetFloatDataInRange(-1.0f, 1.0f, 4);
+  RunQDQGemmTestOnHTP<uint16_t, uint16_t>({TestInputDef<float>({1, 6}, false, input_a_data),
+                                           TestInputDef<float>({6, 4}, false, input_b_data),
+                                           TestInputDef<float>({1, 4}, false, input_c_data)},
+                                          {},
+                                          ExpectedEPNodeAssignment::All,
+                                          13,     // opset
+                                          true);  // Use com.microsoft Q/DQ ops
+}
+
 // Test broadcasting of bias input. All inputs are dynamic.
 TEST_F(QnnHTPBackendTests, Gemm_Broadcast_Bias_DynamicInputs) {
   std::vector<float> input_a_data = {1.0f, 2.0f, 3.0f, 4.0f, -1.0f, -2.0f, -3.0f, -4.0f};


### PR DESCRIPTION
### Description
 - QNN's 16x16 FC doesn't support asymmetric int16 weight
 - Insert Convert Op to convert from asymmetric uint16 weight to symmetric int16 weight
 - Add unit tests to verify 16x16 Gemm translation.


### Motivation and Context
This fix schedules 16x16 Gemm Ops on QNN HTP accelerator.
This improves inference time of Models contain 16x16 Gemm operators


