### PR TITLE
Fix deps.txt issue when building onnxruntime on arm64 devices

### DIFF
--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -22,7 +22,7 @@ dlpack;https://github.com/dmlc/dlpack/archive/5c210da409e7f1e51ddf445134a4376fdb
 # it contains changes on top of 3.4.0 which are required to fix build issues.
 # Until the 3.4.1 release this is the best option we have.
 # Issue link: https://gitlab.com/libeigen/eigen/-/issues/2744
-eigen;https://gitlab.com/libeigen/eigen/-/archive/1d8b82b0740839c0de7f1242a3585e3390ff5f33/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip;5ea4d05e62d7f954a46b3213f9b2535bdd866803
+eigen;https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.zip;ef24286b7ece8737c99fa831b02941843546c081
 flatbuffers;https://github.com/google/flatbuffers/archive/refs/tags/v23.5.26.zip;59422c3b5e573dd192fead2834d25951f1c1670c
 fp16;https://github.com/Maratyszcza/FP16/archive/0a92994d729ff76a58f692d3028ca1b64b145d91.zip;b985f6985a05a1c03ff1bb71190f66d8f98a1494
 fxdiv;https://github.com/Maratyszcza/FXdiv/archive/63058eff77e11aa15bf531df5dd34395ec3017c8.zip;a5658f4036402dbca7cebee32be57fb8149811e1


### PR DESCRIPTION
### Description
This PR fixes a build error that occurred on arm64 devices due to incorrect handling of `deps.txt` in the onnxruntime build process.

### Problem
When attempting to build onnxruntime on arm64 as shown below, the build would fall into error that caused by non-existing/broken eigen version specified in the old `deps.txt`.
Build command:
```
./build.sh --config Release --update --build --parallel --build_wheel \
--use_tensorrt --cuda_home /usr/local/cuda --cudnn_home /usr/lib/aarch64-linux-gnu \
--tensorrt_home /usr/lib/aarch64-linux-gnu
```

###Fix
The eigen info in deps.txt has been replaced with the current tag and sha1 hash value.


### Motivation and Context
This update prevents CMake-related build errors on arm64 devices when compiling ONNXRuntime.


###Encountered Error Output
[ 11%] Creating directories for 'eigen3-populate'
[ 22%] Performing download step (download, verify and extract) for 'eigen3-populate'
-- Downloading...
   dst='/home/cezeri/onnxruntime/build/Linux/Release/_deps/eigen3-subbuild/eigen3-populate-prefix/src/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip'
   timeout='none'
   inactivity timeout='none'
-- Using src='https://gitlab.com/libeigen/eigen/-/archive/1d8b82b0740839c0de7f1242a3585e3390ff5f33/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip'
-- verifying file...
       file='/home/cezeri/onnxruntime/build/Linux/Release/_deps/eigen3-subbuild/eigen3-populate-prefix/src/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip'
-- SHA1 hash of
    /home/cezeri/onnxruntime/build/Linux/Release/_deps/eigen3-subbuild/eigen3-populate-prefix/src/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip
  does not match expected value
    expected: '5ea4d05e62d7f954a46b3213f9b2535bdd866803'
      actual: '51982be81bbe52572b54180454df11a3ece9a934'
-- Hash mismatch, removing...
-- Using src='https://gitlab.com/libeigen/eigen/-/archive/1d8b82b0740839c0de7f1242a3585e3390ff5f33/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip'
-- verifying file...
       file='/home/cezeri/onnxruntime/build/Linux/Release/_deps/eigen3-subbuild/eigen3-populate-prefix/src/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip'
-- SHA1 hash of
    /home/cezeri/onnxruntime/build/Linux/Release/_deps/eigen3-subbuild/eigen3-populate-prefix/src/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip
  does not match expected value
    expected: '5ea4d05e62d7f954a46b3213f9b2535bdd866803'
      actual: '51982be81bbe52572b54180454df11a3ece9a934'
-- Hash mismatch, removing...
-- Using src='https://gitlab.com/libeigen/eigen/-/archive/1d8b82b0740839c0de7f1242a3585e3390ff5f33/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip'
-- verifying file...
       file='/home/cezeri/onnxruntime/build/Linux/Release/_deps/eigen3-subbuild/eigen3-populate-prefix/src/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip'
-- SHA1 hash of
    /home/cezeri/onnxruntime/build/Linux/Release/_deps/eigen3-subbuild/eigen3-populate-prefix/src/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip
  does not match expected value
    expected: '5ea4d05e62d7f954a46b3213f9b2535bdd866803'
      actual: '51982be81bbe52572b54180454df11a3ece9a934'
-- Hash mismatch, removing...
-- Using src='https://gitlab.com/libeigen/eigen/-/archive/1d8b82b0740839c0de7f1242a3585e3390ff5f33/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip'
-- verifying file...
       file='/home/cezeri/onnxruntime/build/Linux/Release/_deps/eigen3-subbuild/eigen3-populate-prefix/src/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip'
-- SHA1 hash of
    /home/cezeri/onnxruntime/build/Linux/Release/_deps/eigen3-subbuild/eigen3-populate-prefix/src/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip
  does not match expected value
    expected: '5ea4d05e62d7f954a46b3213f9b2535bdd866803'
      actual: '51982be81bbe52572b54180454df11a3ece9a934'
-- Hash mismatch, removing...
-- Using src='https://gitlab.com/libeigen/eigen/-/archive/1d8b82b0740839c0de7f1242a3585e3390ff5f33/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip'
-- verifying file...
       file='/home/cezeri/onnxruntime/build/Linux/Release/_deps/eigen3-subbuild/eigen3-populate-prefix/src/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip'
-- SHA1 hash of
    /home/cezeri/onnxruntime/build/Linux/Release/_deps/eigen3-subbuild/eigen3-populate-prefix/src/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip
  does not match expected value
    expected: '5ea4d05e62d7f954a46b3213f9b2535bdd866803'
      actual: '51982be81bbe52572b54180454df11a3ece9a934'
-- Hash mismatch, removing...
-- Using src='https://gitlab.com/libeigen/eigen/-/archive/1d8b82b0740839c0de7f1242a3585e3390ff5f33/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip'
-- verifying file...
       file='/home/cezeri/onnxruntime/build/Linux/Release/_deps/eigen3-subbuild/eigen3-populate-prefix/src/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip'
-- SHA1 hash of
    /home/cezeri/onnxruntime/build/Linux/Release/_deps/eigen3-subbuild/eigen3-populate-prefix/src/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip
  does not match expected value
    expected: '5ea4d05e62d7f954a46b3213f9b2535bdd866803'
      actual: '51982be81bbe52572b54180454df11a3ece9a934'
-- Hash mismatch, removing...
CMake Error at eigen3-subbuild/eigen3-populate-prefix/src/eigen3-populate-stamp/download-eigen3-populate.cmake:163 (message):
  Each download failed!

   
   


gmake[2]: *** [CMakeFiles/eigen3-populate.dir/build.make:100: eigen3-populate-prefix/src/eigen3-populate-stamp/eigen3-populate-download] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:87: CMakeFiles/eigen3-populate.dir/all] Error 2
gmake: *** [Makefile:91: all] Error 2

CMake Error at /usr/share/cmake-4.0/Modules/FetchContent.cmake:1918 (message):
  Build step for eigen3 failed: 2
Call Stack (most recent call first):
  /usr/share/cmake-4.0/Modules/FetchContent.cmake:1609 (__FetchContent_populateSubbuild)
  /usr/share/cmake-4.0/Modules/FetchContent.cmake:2145:EVAL:2 (__FetchContent_doPopulation)
  /usr/share/cmake-4.0/Modules/FetchContent.cmake:2145 (cmake_language)
  /usr/share/cmake-4.0/Modules/FetchContent.cmake:2384 (__FetchContent_Populate)
  external/helper_functions.cmake:22 (FetchContent_MakeAvailable)
  external/eigen.cmake:15 (onnxruntime_fetchcontent_makeavailable)
  external/onnxruntime_external_deps.cmake:542 (include)
  CMakeLists.txt:699 (include)

