### PR TITLE
Add ONNX RMSNormalization(23)

### DIFF
--- a/onnxruntime/core/providers/cpu/cpu_execution_provider.cc
+++ b/onnxruntime/core/providers/cpu/cpu_execution_provider.cc
@@ -1329,6 +1329,7 @@ class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 23, Tr
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 23, Unsqueeze);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 23, Scan);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 23, Size);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 23, RMSNormalization);
 
 // !!PLEASE READ BELOW!! Following that, add new entries above this comment
 

--- a/onnxruntime/core/providers/cpu/nn/rms_norm.cc
+++ b/onnxruntime/core/providers/cpu/nn/rms_norm.cc
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "rms_norm.h"
+
+#include "core/providers/common.h"
+
+namespace onnxruntime {
+#define REGISTER_ONNX_KERNEL_TYPED(T)                                                            \
+  ONNX_CPU_OPERATOR_TYPED_KERNEL(RMSNormalization, 23, T,                                        \
+                                 KernelDefBuilder()                                              \
+                                     .TypeConstraint("T", DataTypeImpl::GetTensorType<T>())      \
+                                     .TypeConstraint("U", DataTypeImpl::GetTensorType<float>()), \
+                                 RMSNorm);
+
+REGISTER_ONNX_KERNEL_TYPED(float)
+REGISTER_ONNX_KERNEL_TYPED(double)
+REGISTER_ONNX_KERNEL_TYPED(MLFloat16)
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cpu/nn/rms_norm.h
+++ b/onnxruntime/core/providers/cpu/nn/rms_norm.h
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "layer_norm_impl.h"
+
+namespace onnxruntime {
+
+class RMSNorm final : public LayerNormImpl {
+ public:
+  RMSNorm(const OpKernelInfo& op_kernel_info)
+      : LayerNormImpl(op_kernel_info, /* simplified */ true) {}
+};
+
+}  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/nn/rms_norm_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/rms_norm_op_test.cc
@@ -1,0 +1,72 @@
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+using namespace std;
+
+namespace onnxruntime {
+namespace test {
+
+template <typename T>
+class RMSNormalizationOpTest : public ::testing::Test {
+};
+using RMSNormalizationOpTestTypes = ::testing::Types<float, MLFloat16>;
+TYPED_TEST_SUITE(RMSNormalizationOpTest, RMSNormalizationOpTestTypes);
+
+TYPED_TEST(RMSNormalizationOpTest, RMSNorm) {
+// prevents test from running on non-BF16-supporting hardware
+#ifdef USE_CUDA
+  int min_cuda_architecture = 530;
+  if (!HasCudaEnvironment(min_cuda_architecture)) {
+    LOGS_DEFAULT(WARNING) << "Hardware NOT support BFP16";
+    return;
+  }
+#endif
+  OpTester test("RMSNormalization", 23);
+  test.AddAttribute<float>("epsilon", 1e-05f);
+
+  vector<float> input = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+  std::vector<int64_t> input_dims{1, 2, 3};
+  test.AddInput<TypeParam>("X", input_dims, GetTypedArray<TypeParam>(input));
+
+  vector<float> scale = {1.F, 1.F, 1.F, 1.F, 1.F, 1.F};
+  vector<int64_t> scale_dims = {6};
+  test.AddInput<TypeParam>("scale", scale_dims, GetTypedArray<TypeParam>(scale), true);
+
+  vector<float> expected_output = {0.4629f, 0.9258f, 1.3887f, 0.7895f, 0.9869f, 1.1843f};
+  test.AddOutput<TypeParam>("Y", input_dims, GetTypedArray<TypeParam>(expected_output));
+  // TRT, DNNL, OpenVINO and NNAPI, CoreML don't support this combination of datatypes
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kTensorrtExecutionProvider, kDnnlExecutionProvider, kOpenVINOExecutionProvider,
+            kNnapiExecutionProvider, kQnnExecutionProvider});
+}
+
+TYPED_TEST(RMSNormalizationOpTest, RMSNorm_Scale) {
+// prevents test from running on non-BF16-supporting hardware
+#ifdef USE_CUDA
+  int min_cuda_architecture = 530;
+  if (!HasCudaEnvironment(min_cuda_architecture)) {
+    LOGS_DEFAULT(WARNING) << "Hardware NOT support BFP16";
+    return;
+  }
+#endif
+  OpTester test("RMSNormalization", 23);
+  test.AddAttribute<float>("epsilon", 1e-05f);
+
+  vector<float> input = {-10.264f, 8.6453f, 43.1561f, -0.641239f, -8.2164f, 0.11412f, 41.3156f, 3.0458f};
+  std::vector<int64_t> input_dims{2, 2, 2};
+  test.AddInput<TypeParam>("X", input_dims, GetTypedArray<TypeParam>(input));
+
+  vector<float> scale = {-0.6953f, 5.1824f};
+  vector<int64_t> scale_dims = {2};
+  test.AddInput<TypeParam>("scale", scale_dims, GetTypedArray<TypeParam>(scale), true);
+
+  vector<float> expected_output = {0.7521f, 4.7215f, -0.9832f, -0.1089f, 0.9832f, 0.1018f, -0.9806f, 0.5388f};
+  test.AddOutput<TypeParam>("Y", input_dims, GetTypedArray<TypeParam>(expected_output));
+  // TRT, DNNL, OpenVINO and NNAPI, CoreML don't support this combination of datatypes
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kTensorrtExecutionProvider, kDnnlExecutionProvider, kOpenVINOExecutionProvider,
+            kNnapiExecutionProvider, kQnnExecutionProvider});
+}
+
+}  // namespace test
+}  // namespace onnxruntime


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Support opset 23 RMSNormalization with CPU kernel.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix #24555 
