### PR TITLE
Improve Windows ETW callback registration and fix issues

### DIFF
--- a/onnxruntime/core/framework/execution_provider.cc
+++ b/onnxruntime/core/framework/execution_provider.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #include "core/framework/execution_provider.h"
+#include "core/framework/execution_providers.h"
 
 #include "core/graph/graph_viewer.h"
 #include "core/framework/compute_capability.h"
@@ -8,6 +9,8 @@
 #include "core/framework/kernel_registry_manager.h"
 #include "core/framework/murmurhash3.h"
 #include "core/framework/op_kernel.h"
+
+#include <stdint.h>
 
 namespace onnxruntime {
 
@@ -37,4 +40,99 @@ common::Status IExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>&
 }
 
 #endif
+
+ExecutionProviders::ExecutionProviders() {
+#ifdef _WIN32
+  // Register callback for ETW capture state (rundown)
+  etw_callback_key_ = "ExecutionProviders_rundown_";
+  etw_callback_key_.append(std::to_string(reinterpret_cast<uintptr_t>(this)));
+  WindowsTelemetry::RegisterInternalCallback(
+      etw_callback_key_,
+      [this](LPCGUID SourceId,
+             ULONG IsEnabled,
+             UCHAR Level,
+             ULONGLONG MatchAnyKeyword,
+             ULONGLONG MatchAllKeyword,
+             PEVENT_FILTER_DESCRIPTOR FilterData,
+             PVOID CallbackContext) { this->EtwProvidersCallback(SourceId, IsEnabled, Level,
+                                                                 MatchAnyKeyword, MatchAllKeyword,
+                                                                 FilterData, CallbackContext); });
+#endif
+}
+
+ExecutionProviders::~ExecutionProviders() {
+#ifdef _WIN32
+  WindowsTelemetry ::UnregisterInternalCallback(etw_callback_key_);
+#endif
+}
+
+common::Status ExecutionProviders::Add(const std::string& provider_id,
+                                       const std::shared_ptr<IExecutionProvider>& p_exec_provider) {
+  // make sure there are no issues before we change any internal data structures
+  if (provider_idx_map_.find(provider_id) != provider_idx_map_.end()) {
+    auto status = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Provider ", provider_id, " has already been registered.");
+    LOGS_DEFAULT(ERROR) << status.ErrorMessage();
+    return status;
+  }
+
+  // index that provider will have after insertion
+  auto new_provider_idx = exec_providers_.size();
+
+  ORT_IGNORE_RETURN_VALUE(provider_idx_map_.insert({provider_id, new_provider_idx}));
+
+  // update execution provider options
+  auto providerOptions = p_exec_provider->GetProviderOptions();
+  exec_provider_options_[provider_id] = providerOptions;
+
+#ifdef _WIN32
+  LogProviderOptions(provider_id, providerOptions, false);
+#endif
+
+  exec_provider_ids_.push_back(provider_id);
+  exec_providers_.push_back(p_exec_provider);
+  return Status::OK();
+}
+
+#ifdef _WIN32
+void ExecutionProviders::EtwProvidersCallback(LPCGUID /* SourceId */,
+                                              ULONG IsEnabled,
+                                              UCHAR /* Level */,
+                                              ULONGLONG MatchAnyKeyword,
+                                              ULONGLONG /* MatchAllKeyword */,
+                                              PEVENT_FILTER_DESCRIPTOR /* FilterData */,
+                                              PVOID /* CallbackContext */) {
+  // Check if this callback is for capturing state
+  if ((IsEnabled == EVENT_CONTROL_CODE_CAPTURE_STATE) &&
+      ((MatchAnyKeyword & static_cast<ULONGLONG>(onnxruntime::logging::ORTTraceLoggingKeyword::Session)) != 0)) {
+    for (size_t i = 0; i < exec_providers_.size(); ++i) {
+      const auto& provider_id = exec_provider_ids_[i];
+
+      auto it = exec_provider_options_.find(provider_id);
+      if (it != exec_provider_options_.end()) {
+        const auto& options = it->second;
+
+        LogProviderOptions(provider_id, options, true);
+      }
+    }
+  }
+}
+
+void ExecutionProviders::LogProviderOptions(const std::string& provider_id,
+                                            const ProviderOptions& providerOptions,
+                                            bool captureState) {
+  for (const auto& config_pair : providerOptions) {
+    TraceLoggingWrite(
+        telemetry_provider_handle,
+        "ProviderOptions",
+        TraceLoggingKeyword(static_cast<uint64_t>(onnxruntime::logging::ORTTraceLoggingKeyword::Session)),
+        TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+        TraceLoggingString(provider_id.c_str(), "ProviderId"),
+        TraceLoggingString(config_pair.first.c_str(), "Key"),
+        TraceLoggingString(config_pair.second.c_str(), "Value"),
+        TraceLoggingBool(captureState, "isCaptureState"));
+  }
+}
+
+#endif
+
 }  // namespace onnxruntime

--- a/onnxruntime/core/framework/execution_providers.h
+++ b/onnxruntime/core/framework/execution_providers.h
@@ -26,91 +26,24 @@ Class for managing lookup of the execution providers in a session.
 */
 class ExecutionProviders {
  public:
-  ExecutionProviders() {
-#ifdef _WIN32
-    // Register callback for ETW capture state (rundown)
-    etw_callback_ = onnxruntime::WindowsTelemetry::EtwInternalCallback(
-        [this](
-            LPCGUID SourceId,
-            ULONG IsEnabled,
-            UCHAR Level,
-            ULONGLONG MatchAnyKeyword,
-            ULONGLONG MatchAllKeyword,
-            PEVENT_FILTER_DESCRIPTOR FilterData,
-            PVOID CallbackContext) {
-          (void)SourceId;
-          (void)Level;
-          (void)MatchAnyKeyword;
-          (void)MatchAllKeyword;
-          (void)FilterData;
-          (void)CallbackContext;
+  ExecutionProviders();
 
-          // Check if this callback is for capturing state
-          if ((IsEnabled == EVENT_CONTROL_CODE_CAPTURE_STATE) &&
-              ((MatchAnyKeyword & static_cast<ULONGLONG>(onnxruntime::logging::ORTTraceLoggingKeyword::Session)) != 0)) {
-            for (size_t i = 0; i < exec_providers_.size(); ++i) {
-              const auto& provider_id = exec_provider_ids_[i];
+  ~ExecutionProviders();
 
-              auto it = exec_provider_options_.find(provider_id);
-              if (it != exec_provider_options_.end()) {
-                const auto& options = it->second;
-
-                LogProviderOptions(provider_id, options, true);
-              }
-            }
-          }
-        });
-    WindowsTelemetry::RegisterInternalCallback(etw_callback_);
-#endif
-  }
-
-  ~ExecutionProviders() {
-#ifdef _WIN32
-    WindowsTelemetry ::UnregisterInternalCallback(etw_callback_);
-#endif
-  }
-
-  common::Status
-  Add(const std::string& provider_id, const std::shared_ptr<IExecutionProvider>& p_exec_provider) {
-    // make sure there are no issues before we change any internal data structures
-    if (provider_idx_map_.find(provider_id) != provider_idx_map_.end()) {
-      auto status = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Provider ", provider_id, " has already been registered.");
-      LOGS_DEFAULT(ERROR) << status.ErrorMessage();
-      return status;
-    }
-
-    // index that provider will have after insertion
-    auto new_provider_idx = exec_providers_.size();
-
-    ORT_IGNORE_RETURN_VALUE(provider_idx_map_.insert({provider_id, new_provider_idx}));
-
-    // update execution provider options
-    auto providerOptions = p_exec_provider->GetProviderOptions();
-    exec_provider_options_[provider_id] = providerOptions;
+  common::Status Add(const std::string& provider_id, const std::shared_ptr<IExecutionProvider>& p_exec_provider);
 
 #ifdef _WIN32
-    LogProviderOptions(provider_id, providerOptions, false);
-#endif
 
-    exec_provider_ids_.push_back(provider_id);
-    exec_providers_.push_back(p_exec_provider);
-    return Status::OK();
-  }
+  void EtwProvidersCallback(LPCGUID SourceId,
+                            ULONG IsEnabled,
+                            UCHAR Level,
+                            ULONGLONG MatchAnyKeyword,
+                            ULONGLONG MatchAllKeyword,
+                            PEVENT_FILTER_DESCRIPTOR FilterData,
+                            PVOID CallbackContext);
 
-#ifdef _WIN32
-  void LogProviderOptions(const std::string& provider_id, const ProviderOptions& providerOptions, bool captureState) {
-    for (const auto& config_pair : providerOptions) {
-      TraceLoggingWrite(
-          telemetry_provider_handle,
-          "ProviderOptions",
-          TraceLoggingKeyword(static_cast<uint64_t>(onnxruntime::logging::ORTTraceLoggingKeyword::Session)),
-          TraceLoggingLevel(WINEVENT_LEVEL_INFO),
-          TraceLoggingString(provider_id.c_str(), "ProviderId"),
-          TraceLoggingString(config_pair.first.c_str(), "Key"),
-          TraceLoggingString(config_pair.second.c_str(), "Value"),
-          TraceLoggingBool(captureState, "isCaptureState"));
-    }
-  }
+  void LogProviderOptions(const std::string& provider_id, const ProviderOptions& providerOptions,
+                          bool captureState);
 #endif
 
   const IExecutionProvider* Get(const onnxruntime::Node& node) const {
@@ -169,7 +102,7 @@ class ExecutionProviders {
   bool cpu_execution_provider_was_implicitly_added_ = false;
 
 #ifdef _WIN32
-  WindowsTelemetry::EtwInternalCallback etw_callback_;
+  std::string etw_callback_key_;
 #endif
 };
 }  // namespace onnxruntime

--- a/onnxruntime/core/platform/windows/logging/etw_sink.cc
+++ b/onnxruntime/core/platform/windows/logging/etw_sink.cc
@@ -60,7 +60,6 @@ TRACELOGGING_DEFINE_PROVIDER(etw_provider_handle, "ONNXRuntimeTraceLoggingProvid
 
 EtwRegistrationManager& EtwRegistrationManager::Instance() {
   static EtwRegistrationManager instance;
-  instance.LazyInitialize();
   return instance;
 }
 
@@ -106,18 +105,15 @@ HRESULT EtwRegistrationManager::Status() const {
   return etw_status_;
 }
 
-void EtwRegistrationManager::RegisterInternalCallback(const EtwInternalCallback& callback) {
+void EtwRegistrationManager::RegisterInternalCallback(const std::string& cb_key, EtwInternalCallback callback) {
   std::lock_guard<std::mutex> lock(callbacks_mutex_);
-  callbacks_.push_back(&callback);
+  [[maybe_unused]] auto result = callbacks_.emplace(cb_key, std::move(callback));
+  assert(result.second);
 }
 
-void EtwRegistrationManager::UnregisterInternalCallback(const EtwInternalCallback& callback) {
+void EtwRegistrationManager::UnregisterInternalCallback(const std::string& cb_key) {
   std::lock_guard<std::mutex> lock(callbacks_mutex_);
-  auto new_end = std::remove_if(callbacks_.begin(), callbacks_.end(),
-                                [&callback](const EtwInternalCallback* ptr) {
-                                  return ptr == &callback;
-                                });
-  callbacks_.erase(new_end, callbacks_.end());
+  callbacks_.erase(cb_key);
 }
 
 void NTAPI EtwRegistrationManager::ORT_TL_EtwEnableCallback(
@@ -139,37 +135,24 @@ void NTAPI EtwRegistrationManager::ORT_TL_EtwEnableCallback(
 }
 
 EtwRegistrationManager::~EtwRegistrationManager() {
-  std::lock_guard<std::mutex> lock(callbacks_mutex_);
-  callbacks_.clear();
-  if (initialization_status_ == InitializationStatus::Initialized ||
-      initialization_status_ == InitializationStatus::Initializing) {
-    std::lock_guard<std::mutex> init_lock(init_mutex_);
-    assert(initialization_status_ != InitializationStatus::Initializing);
-    if (initialization_status_ == InitializationStatus::Initialized) {
-      ::TraceLoggingUnregister(etw_provider_handle);
-      initialization_status_ = InitializationStatus::NotInitialized;
-    }
+  if (initialization_status_ == InitializationStatus::Initialized) {
+    ::TraceLoggingUnregister(etw_provider_handle);
+    initialization_status_ = InitializationStatus::NotInitialized;
   }
 }
 
-EtwRegistrationManager::EtwRegistrationManager() {
-}
-
-void EtwRegistrationManager::LazyInitialize() {
-  if (initialization_status_ == InitializationStatus::NotInitialized) {
-    std::lock_guard<std::mutex> lock(init_mutex_);
-    if (initialization_status_ == InitializationStatus::NotInitialized) {  // Double-check locking pattern
-      initialization_status_ = InitializationStatus::Initializing;
-      etw_status_ = ::TraceLoggingRegisterEx(etw_provider_handle, ORT_TL_EtwEnableCallback, nullptr);
-      if (FAILED(etw_status_)) {
-        // Registration can fail when running under Low Integrity process, and should be non-fatal
-        initialization_status_ = InitializationStatus::Failed;
-        // Injection of ETW logger can happen very early if ETW provider was already listening.
-        // Don't use LOGS_DEFAULT here or can get "Attempt to use DefaultLogger but none has been registered"
-        std::cerr << "Error in ETW registration: " << std::to_string(etw_status_) << std::endl;
-      }
-      initialization_status_ = InitializationStatus::Initialized;
-    }
+EtwRegistrationManager::EtwRegistrationManager()
+    : initialization_status_(InitializationStatus::NotInitialized),
+      is_enabled_(false),
+      level_(),
+      keyword_(0) {
+  etw_status_ = ::TraceLoggingRegisterEx(etw_provider_handle, ORT_TL_EtwEnableCallback, nullptr);
+  if (FAILED(etw_status_)) {
+    // Registration can fail when running under Low Integrity process, and should be non-fatal
+    initialization_status_ = InitializationStatus::Failed;
+    LOGS_DEFAULT(WARNING) << "Error in ETW registration: " << std::to_string(etw_status_);
+  } else {
+    initialization_status_ = InitializationStatus::Initialized;
   }
 }
 
@@ -182,10 +165,9 @@ void EtwRegistrationManager::InvokeCallbacks(LPCGUID SourceId, ULONG IsEnabled, 
   }
 
   std::lock_guard<std::mutex> lock(callbacks_mutex_);
-  for (const auto& callback : callbacks_) {
-    if (callback != nullptr) {
-      (*callback)(SourceId, IsEnabled, Level, MatchAnyKeyword, MatchAllKeyword, FilterData, CallbackContext);
-    }
+  for (const auto& entry : callbacks_) {
+    const auto& cb = entry.second;
+    cb(SourceId, IsEnabled, Level, MatchAnyKeyword, MatchAllKeyword, FilterData, CallbackContext);
   }
 }
 

--- a/onnxruntime/core/platform/windows/logging/etw_sink.h
+++ b/onnxruntime/core/platform/windows/logging/etw_sink.h
@@ -20,6 +20,7 @@
 #include <atomic>
 #include <iostream>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "core/common/logging/capture.h"
@@ -77,14 +78,13 @@ class EtwRegistrationManager {
   // Get the ETW registration status
   HRESULT Status() const;
 
-  void RegisterInternalCallback(const EtwInternalCallback& callback);
+  void RegisterInternalCallback(const std::string& cb_key, EtwInternalCallback callback);
 
-  void UnregisterInternalCallback(const EtwInternalCallback& callback);
+  void UnregisterInternalCallback(const std::string& cb_key);
 
  private:
   EtwRegistrationManager();
   ~EtwRegistrationManager();
-  void LazyInitialize();
 
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(EtwRegistrationManager);
 
@@ -100,10 +100,9 @@ class EtwRegistrationManager {
       _In_opt_ PEVENT_FILTER_DESCRIPTOR FilterData,
       _In_opt_ PVOID CallbackContext);
 
-  std::vector<const EtwInternalCallback*> callbacks_;
+  std::unordered_map<std::string, EtwInternalCallback> callbacks_;
   std::mutex callbacks_mutex_;
   mutable std::mutex provider_change_mutex_;
-  std::mutex init_mutex_;
   InitializationStatus initialization_status_ = InitializationStatus::NotInitialized;
   bool is_enabled_;
   UCHAR level_;
@@ -133,8 +132,8 @@ class EtwRegistrationManager {
   Severity MapLevelToSeverity() { return Severity::kFATAL; }
   uint64_t Keyword() const { return 0; }
   HRESULT Status() const { return 0; }
-  void RegisterInternalCallback(const EtwInternalCallback& callback) {}
-  void UnregisterInternalCallback(const EtwInternalCallback& callback) {}
+  void RegisterInternalCallback(const std::string& cb_key, EtwInternalCallback callback) {}
+  void UnregisterInternalCallback(const std::string& cb_key) {}
 
  private:
   EtwRegistrationManager() = default;

--- a/onnxruntime/core/platform/windows/logging/etw_sink.h
+++ b/onnxruntime/core/platform/windows/logging/etw_sink.h
@@ -85,6 +85,7 @@ class EtwRegistrationManager {
  private:
   EtwRegistrationManager();
   ~EtwRegistrationManager();
+  void LazyInitialize();
 
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(EtwRegistrationManager);
 
@@ -100,10 +101,11 @@ class EtwRegistrationManager {
       _In_opt_ PEVENT_FILTER_DESCRIPTOR FilterData,
       _In_opt_ PVOID CallbackContext);
 
+  std::mutex init_mutex_;
+  std::atomic<InitializationStatus> initialization_status_ = InitializationStatus::NotInitialized;
   std::unordered_map<std::string, EtwInternalCallback> callbacks_;
   std::mutex callbacks_mutex_;
   mutable std::mutex provider_change_mutex_;
-  InitializationStatus initialization_status_ = InitializationStatus::NotInitialized;
   bool is_enabled_;
   UCHAR level_;
   ULONGLONG keyword_;

--- a/onnxruntime/core/platform/windows/telemetry.h
+++ b/onnxruntime/core/platform/windows/telemetry.h
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 #pragma once
+
 #include <atomic>
+#include <unordered_map>
 #include <vector>
 
 #include "core/platform/telemetry.h"
@@ -68,9 +70,9 @@ class WindowsTelemetry : public Telemetry {
                                                  ULONGLONG MatchAnyKeyword, ULONGLONG MatchAllKeyword,
                                                  PEVENT_FILTER_DESCRIPTOR FilterData, PVOID CallbackContext)>;
 
-  static void RegisterInternalCallback(const EtwInternalCallback& callback);
+  static void RegisterInternalCallback(const std::string& callback_key, EtwInternalCallback callback);
 
-  static void UnregisterInternalCallback(const EtwInternalCallback& callback);
+  static void UnregisterInternalCallback(const std::string& callback_key);
 
  private:
   static std::mutex mutex_;
@@ -78,7 +80,7 @@ class WindowsTelemetry : public Telemetry {
   static bool enabled_;
   static uint32_t projection_;
 
-  static std::vector<const EtwInternalCallback*> callbacks_;
+  static std::unordered_map<std::string, EtwInternalCallback> callbacks_;
   static std::mutex callbacks_mutex_;
   static std::mutex provider_change_mutex_;
   static UCHAR level_;

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -96,7 +96,7 @@ class QNNExecutionProvider : public IExecutionProvider {
   bool stop_share_ep_contexts_ = false;
   bool enable_spill_fill_buffer_ = false;
 #if defined(_WIN32)
-  onnxruntime::logging::EtwRegistrationManager::EtwInternalCallback callback_ETWSink_provider_ = nullptr;
+  std::string callback_ETWSink_key_;
 #endif
   qnn::ModelSettings model_settings_ = {};
   bool dump_json_qnn_graph_ = false;

--- a/onnxruntime/core/providers/qnn/qnn_telemetry.h
+++ b/onnxruntime/core/providers/qnn/qnn_telemetry.h
@@ -12,6 +12,7 @@
 #include <functional>
 #include <mutex>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "core/providers/qnn/ort_api.h"
@@ -58,9 +59,9 @@ class QnnTelemetry {
                                                  ULONGLONG MatchAnyKeyword, ULONGLONG MatchAllKeyword,
                                                  PEVENT_FILTER_DESCRIPTOR FilterData, PVOID CallbackContext)>;
 
-  static void RegisterInternalCallback(const EtwInternalCallback& callback);
+  static void RegisterInternalCallback(const std::string& cb_key, EtwInternalCallback callback);
 
-  static void UnregisterInternalCallback(const EtwInternalCallback& callback);
+  static void UnregisterInternalCallback(const std::string& cb_key);
 
  private:
   QnnTelemetry();
@@ -72,7 +73,7 @@ class QnnTelemetry {
   static uint32_t global_register_count_;
   static bool enabled_;
 
-  static std::vector<const EtwInternalCallback*> callbacks_;
+  static std::unordered_map<std::string, EtwInternalCallback> callbacks_;
   static std::mutex callbacks_mutex_;
   static std::mutex provider_change_mutex_;
   static UCHAR level_;

--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -314,10 +314,11 @@ struct ProviderHost {
   virtual logging::Severity logging__EtwRegistrationManager__MapLevelToSeverity(logging::EtwRegistrationManager* p) = 0;
   virtual void logging__EtwRegistrationManager__RegisterInternalCallback(
       logging::EtwRegistrationManager* p,
-      const logging::EtwRegistrationManager_EtwInternalCallback& callback) = 0;
+      const std::string& cb_key,
+      logging::EtwRegistrationManager_EtwInternalCallback callback) = 0;
   virtual void logging__EtwRegistrationManager__UnregisterInternalCallback(
       logging::EtwRegistrationManager* p,
-      const logging::EtwRegistrationManager_EtwInternalCallback& callback) = 0;
+      const std::string& cb_key) = 0;
 #endif  // defined(_WIN32)
 
   // Env

--- a/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
+++ b/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
@@ -58,11 +58,11 @@ struct EtwRegistrationManager final {
   static EtwRegistrationManager& Instance() { return g_host->logging__EtwRegistrationManager__Instance(); }
   static bool SupportsETW() { return g_host->logging__EtwRegistrationManager__SupportsETW(); }
   Severity MapLevelToSeverity() { return g_host->logging__EtwRegistrationManager__MapLevelToSeverity(this); }
-  void RegisterInternalCallback(const EtwInternalCallback& callback) {
-    g_host->logging__EtwRegistrationManager__RegisterInternalCallback(this, callback);
+  void RegisterInternalCallback(const std::string& cb_key, EtwInternalCallback callback) {
+    g_host->logging__EtwRegistrationManager__RegisterInternalCallback(this, cb_key, std::move(callback));
   }
-  void UnregisterInternalCallback(const EtwInternalCallback& callback) {
-    g_host->logging__EtwRegistrationManager__UnregisterInternalCallback(this, callback);
+  void UnregisterInternalCallback(const std::string& cb_key) {
+    g_host->logging__EtwRegistrationManager__UnregisterInternalCallback(this, cb_key);
   }
 };
 #endif  // defined(_WIN32)

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -251,9 +251,10 @@ Status GetMinimalBuildOptimizationHandling(
 }  // namespace
 
 std::atomic<uint32_t> InferenceSession::global_session_id_{1};
-std::map<uint32_t, InferenceSession*> InferenceSession::active_sessions_;
 #ifdef _WIN32
 std::mutex InferenceSession::active_sessions_mutex_;  // Protects access to active_sessions_
+std::map<uint32_t, InferenceSession*> InferenceSession::active_sessions_;
+const std::string InferenceSession::callback_ML_ORT_provider_key_{"InferenceSessionML_ORT_provider"};
 onnxruntime::WindowsTelemetry::EtwInternalCallback InferenceSession::callback_ML_ORT_provider_;
 #endif
 
@@ -375,7 +376,6 @@ void InferenceSession::ConstructorCommon(const SessionOptions& session_options,
   session_id_ = global_session_id_.fetch_add(1);
 
   SetLoggingManager(session_options, session_env);
-
   // The call to InitLogger depends on the final state of session_options_. Hence it should be invoked
   // after the invocation of FinalizeSessionOptions.
   InitLogger(logging_manager_);  // this sets session_logger_ so that it can be used for logging after this point.
@@ -508,87 +508,45 @@ void InferenceSession::ConstructorCommon(const SessionOptions& session_options,
   telemetry_ = {};
 
 #ifdef _WIN32
-  std::lock_guard<std::mutex> lock(active_sessions_mutex_);
-  active_sessions_[session_id_] = this;
+  {
+    std::lock_guard<std::mutex> lock(active_sessions_mutex_);
+    auto result = active_sessions_.insert_or_assign(session_id_, this);
+    ORT_ENFORCE(result.second, "active_sessions has not been cleanup for session_id", session_id_);
+    // Register callback for ETW capture state (rundown) for Microsoft.ML.ONNXRuntime provider
+    // one for all sessions
+    if (active_sessions_.size() == 1) {
+      WindowsTelemetry::RegisterInternalCallback(callback_ML_ORT_provider_key_, ML_Ort_Provider_Etw_Callback);
+    }
+  }
 
-  // Register callback for ETW capture state (rundown) for Microsoft.ML.ONNXRuntime provider
-  callback_ML_ORT_provider_ = onnxruntime::WindowsTelemetry::EtwInternalCallback(
-      [](LPCGUID SourceId,
-         ULONG IsEnabled,
-         UCHAR Level,
-         ULONGLONG MatchAnyKeyword,
-         ULONGLONG MatchAllKeyword,
-         PEVENT_FILTER_DESCRIPTOR FilterData,
-         PVOID CallbackContext) {
-        (void)SourceId;
-        (void)Level;
-        (void)MatchAnyKeyword;
-        (void)MatchAllKeyword;
-        (void)FilterData;
-        (void)CallbackContext;
-        ORT_UNUSED_PARAMETER(SourceId);
-        ORT_UNUSED_PARAMETER(Level);
-        ORT_UNUSED_PARAMETER(MatchAnyKeyword);
-        ORT_UNUSED_PARAMETER(MatchAllKeyword);
-        ORT_UNUSED_PARAMETER(FilterData);
-        ORT_UNUSED_PARAMETER(CallbackContext);
-
-        // Check if this callback is for capturing state
-        if ((IsEnabled == EVENT_CONTROL_CODE_CAPTURE_STATE) &&
-            ((MatchAnyKeyword & static_cast<ULONGLONG>(onnxruntime::logging::ORTTraceLoggingKeyword::Session)) != 0)) {
-          InferenceSession::LogAllSessions();
-        }
-      });
-  WindowsTelemetry::RegisterInternalCallback(callback_ML_ORT_provider_);
+  // If the __ctor does not finish for some reason, make sure that we still unregister
+  // whatever has been registered.
+  etw_deregistrar_.emplace([this]() { UnregisterETWCallbacks(); });
 
   // Register callback for ETW start / stop so that LOGS tracing can be adjusted dynamically after session start
+  callback_ETWSink_provider_key_ = "InferenceSession_Start_Stop_";
+  callback_ETWSink_provider_key_.append(std::to_string(session_id_));
   auto& etwRegistrationManager = logging::EtwRegistrationManager::Instance();
-  callback_ETWSink_provider_ = onnxruntime::logging::EtwRegistrationManager::EtwInternalCallback(
-      [&etwRegistrationManager, this](LPCGUID SourceId,
-                                      ULONG IsEnabled,
-                                      UCHAR Level,
-                                      ULONGLONG MatchAnyKeyword,
-                                      ULONGLONG MatchAllKeyword,
-                                      PEVENT_FILTER_DESCRIPTOR FilterData,
-                                      PVOID CallbackContext) {
-        ORT_UNUSED_PARAMETER(SourceId);
-        ORT_UNUSED_PARAMETER(Level);
-        ORT_UNUSED_PARAMETER(MatchAnyKeyword);
-        ORT_UNUSED_PARAMETER(MatchAllKeyword);
-        ORT_UNUSED_PARAMETER(FilterData);
-        ORT_UNUSED_PARAMETER(CallbackContext);
-
-        if (logging_manager_ != nullptr) {
-          auto ortETWSeverity = etwRegistrationManager.MapLevelToSeverity();
-
-          if ((MatchAnyKeyword & static_cast<ULONGLONG>(onnxruntime::logging::ORTTraceLoggingKeyword::Logs)) != 0 &&
-              IsEnabled == EVENT_CONTROL_CODE_ENABLE_PROVIDER) {
-            LOGS(*session_logger_, VERBOSE) << "Adding ETW Sink to logger with severity level: " << (ULONG)ortETWSeverity;
-            logging_manager_->AddSinkOfType(
-                onnxruntime::logging::SinkType::EtwSink,
-                []() -> std::unique_ptr<onnxruntime::logging::ISink> { return std::make_unique<onnxruntime::logging::EtwSink>(); },
-                ortETWSeverity);
-            onnxruntime::logging::LoggingManager::GetDefaultInstance()->AddSinkOfType(
-                onnxruntime::logging::SinkType::EtwSink,
-                []() -> std::unique_ptr<onnxruntime::logging::ISink> { return std::make_unique<onnxruntime::logging::EtwSink>(); },
-                ortETWSeverity);
-            LOGS(*session_logger_, INFO) << "Done Adding ETW Sink to logger with severity level: " << (ULONG)ortETWSeverity;
-          }
-          if (IsEnabled == EVENT_CONTROL_CODE_DISABLE_PROVIDER) {
-            LOGS(*session_logger_, INFO) << "Removing ETW Sink from logger";
-            logging_manager_->RemoveSink(onnxruntime::logging::SinkType::EtwSink);
-            LOGS(*session_logger_, VERBOSE) << "Done Removing ETW Sink from logger";
-          }
-        }
-      });
 
   // Register callback for ETW capture state (rundown)
-  etwRegistrationManager.RegisterInternalCallback(callback_ETWSink_provider_);
-
+  etwRegistrationManager.RegisterInternalCallback(callback_ETWSink_provider_key_,
+                                                  [&etwRegistrationManager, this](
+                                                      LPCGUID SourceId,
+                                                      ULONG IsEnabled,
+                                                      UCHAR Level,
+                                                      ULONGLONG MatchAnyKeyword,
+                                                      ULONGLONG MatchAllKeyword,
+                                                      PEVENT_FILTER_DESCRIPTOR FilterData,
+                                                      PVOID CallbackContext) {
+                                                    ETWSink_provider(etwRegistrationManager, SourceId, IsEnabled, Level,
+                                                                     MatchAnyKeyword, MatchAllKeyword, FilterData,
+                                                                     CallbackContext);
+                                                  });
 #endif
 }
 
-void InferenceSession::TraceSessionOptions(const SessionOptions& session_options, bool captureState, const logging::Logger& logger) {
+void InferenceSession::TraceSessionOptions(const SessionOptions& session_options, bool captureState,
+                                           const logging::Logger& logger) {
   ORT_UNUSED_PARAMETER(captureState);  // Otherwise Linux build error
 
   LOGS(logger, INFO) << session_options;
@@ -736,18 +694,6 @@ InferenceSession::~InferenceSession() {
       LOGS(*session_logger_, ERROR) << "Unknown error during EndProfiling()";
     }
   }
-
-  // Unregister the session and ETW callbacks
-#ifdef _WIN32
-  std::lock_guard<std::mutex> lock(active_sessions_mutex_);
-  if (callback_ML_ORT_provider_ != nullptr) {
-    WindowsTelemetry::UnregisterInternalCallback(callback_ML_ORT_provider_);
-  }
-  if (callback_ETWSink_provider_ != nullptr) {
-    logging::EtwRegistrationManager::Instance().UnregisterInternalCallback(callback_ETWSink_provider_);
-  }
-#endif
-  active_sessions_.erase(session_id_);
 
 #ifdef ONNXRUNTIME_ENABLE_INSTRUMENT
   if (session_activity_started_)
@@ -2453,7 +2399,6 @@ common::Status InferenceSession::ValidateInputsOutputs(gsl::span<const std::stri
       }
     } else if (input_output_ml_value.IsSparseTensor()) {
 #if !defined(DISABLE_SPARSE_TENSORS)
-
       const SparseTensor& sparse_tensor = input_output_ml_value.Get<SparseTensor>();
       if (expected_type->IsSparseTensorType()) {
         auto expected_element_type = expected_type->AsSparseTensorType()->GetElementType();
@@ -3456,6 +3401,34 @@ IOBinding* SessionIOBinding::Get() {
 }
 
 #ifdef _WIN32
+
+void InferenceSession::UnregisterETWCallbacks() {
+  if (!callback_ETWSink_provider_key_.empty()) {
+    logging::EtwRegistrationManager::Instance().UnregisterInternalCallback(callback_ETWSink_provider_key_);
+  }
+  {
+    std::lock_guard<std::mutex> lock(active_sessions_mutex_);
+    active_sessions_.erase(session_id_);
+    if (active_sessions_.empty()) {
+      WindowsTelemetry::UnregisterInternalCallback(callback_ML_ORT_provider_key_);
+    }
+  }
+}
+
+void InferenceSession::ML_Ort_Provider_Etw_Callback(LPCGUID /* SourceId */,
+                                                    ULONG IsEnabled,
+                                                    UCHAR /* Level */,
+                                                    ULONGLONG MatchAnyKeyword,
+                                                    ULONGLONG /* MatchAllKeyword */,
+                                                    PEVENT_FILTER_DESCRIPTOR /* FilterData */,
+                                                    PVOID /* CallbackContext */) {
+  // Check if this callback is for capturing state
+  if ((IsEnabled == EVENT_CONTROL_CODE_CAPTURE_STATE) &&
+      ((MatchAnyKeyword & static_cast<ULONGLONG>(onnxruntime::logging::ORTTraceLoggingKeyword::Session)) != 0)) {
+    InferenceSession::LogAllSessions();
+  }
+}
+
 void InferenceSession::LogAllSessions() {
   const Env& env = Env::Default();
 
@@ -3469,8 +3442,8 @@ void InferenceSession::LogAllSessions() {
 
     auto model = session->model_;
     if (nullptr != model) {
-      onnxruntime::Graph& graph = model->MainGraph();
-      bool model_has_fp16_inputs = ModelHasFP16Inputs(graph);
+      const onnxruntime::Graph& graph = model->MainGraph();
+      const bool model_has_fp16_inputs = ModelHasFP16Inputs(graph);
       env.GetTelemetryProvider().LogSessionCreation(
           session->session_id_, model->IrVersion(), model->ProducerName(), model->ProducerVersion(), model->Domain(),
           graph.DomainToVersionMap(), graph.Name(), model->MetaData(),
@@ -3480,6 +3453,34 @@ void InferenceSession::LogAllSessions() {
     InferenceSession::TraceSessionOptions(session->session_options_, true, *session->session_logger_);
   }
 }
+
+void InferenceSession::ETWSink_provider(logging::EtwRegistrationManager& etwRegistrationManager,
+                                        LPCGUID, ULONG IsEnabled, UCHAR, ULONGLONG MatchAnyKeyword,
+                                        ULONGLONG, PEVENT_FILTER_DESCRIPTOR, PVOID) {
+  if (logging_manager_ != nullptr) {
+    auto ortETWSeverity = etwRegistrationManager.MapLevelToSeverity();
+
+    if ((MatchAnyKeyword & static_cast<ULONGLONG>(onnxruntime::logging::ORTTraceLoggingKeyword::Logs)) != 0 &&
+        IsEnabled == EVENT_CONTROL_CODE_ENABLE_PROVIDER) {
+      LOGS(*session_logger_, VERBOSE) << "Adding ETW Sink to logger with severity level: " << (ULONG)ortETWSeverity;
+      logging_manager_->AddSinkOfType(
+          onnxruntime::logging::SinkType::EtwSink,
+          []() -> std::unique_ptr<onnxruntime::logging::ISink> { return std::make_unique<onnxruntime::logging::EtwSink>(); },
+          ortETWSeverity);
+      onnxruntime::logging::LoggingManager::GetDefaultInstance()->AddSinkOfType(
+          onnxruntime::logging::SinkType::EtwSink,
+          []() -> std::unique_ptr<onnxruntime::logging::ISink> { return std::make_unique<onnxruntime::logging::EtwSink>(); },
+          ortETWSeverity);
+      LOGS(*session_logger_, INFO) << "Done Adding ETW Sink to logger with severity level: " << (ULONG)ortETWSeverity;
+    }
+    if (IsEnabled == EVENT_CONTROL_CODE_DISABLE_PROVIDER) {
+      LOGS(*session_logger_, INFO) << "Removing ETW Sink from logger";
+      logging_manager_->RemoveSink(onnxruntime::logging::SinkType::EtwSink);
+      LOGS(*session_logger_, VERBOSE) << "Done Removing ETW Sink from logger";
+    }
+  }
+}
+
 #endif
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -462,13 +462,14 @@ struct ProviderHostImpl : ProviderHost {
   }
   void logging__EtwRegistrationManager__RegisterInternalCallback(
       logging::EtwRegistrationManager* p,
-      const logging::EtwRegistrationManager_EtwInternalCallback& callback) override {
-    p->RegisterInternalCallback(callback);
+      const std::string& cb_key,
+      logging::EtwRegistrationManager_EtwInternalCallback callback) override {
+    p->RegisterInternalCallback(cb_key, std::move(callback));
   }
   void logging__EtwRegistrationManager__UnregisterInternalCallback(
       logging::EtwRegistrationManager* p,
-      const logging::EtwRegistrationManager_EtwInternalCallback& callback) override {
-    p->UnregisterInternalCallback(callback);
+      const std::string& cb_key) override {
+    p->UnregisterInternalCallback(cb_key);
   }
 #endif  // defined(_WIN32)
 


### PR DESCRIPTION
### Description

- `EtwRegistrationManager`. Make sure all fields initialized by a constructor
- Register `ML_Ort_Provider_Etw_Callback` once for all the sessions. The first session registers, the last one to go aware removes the callback to Log all sessions.
- Register a callback object instead of a pointer to it. Store it in the map with a session unique key.
- Create a registration guard to remove callbacks in case `InferenceSession` constructor does not finish.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
This PR is inspired by https://github.com/microsoft/onnxruntime/issues/24773?reload=1.

Current code exhibits multiple issues.
- `EtwRegistrationManager` constructor does not initialize all of the fields including the `InitializationStatus`.
- Global callback object is registered and re-created by every session. Customers sometimes run thousands of models in the same sessions which results in a quadratic ETW costs. The callback object is destroyed and recreated every time a session is created.
- There is a chance that InferenceSession constructor does not finish, and the callback would remain registered. This may result in intermittent hard to diagnose bugs.


