### PR TITLE
Adding support for Turing Arch

### DIFF
--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
@@ -2294,8 +2294,12 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
   if (max_workspace_size_ > 0) {
     trt_config->setMemoryPoolLimit(nvinfer1::MemoryPoolType::kWORKSPACE, max_workspace_size_);
   }
-  trt_config->setNbComputeCapabilities(1);
-  trt_config->setComputeCapability(nvinfer1::ComputeCapability::kCURRENT, 0);
+  // Only set default compute capabilities if user hasn't explicitly configured them
+  constexpr int kDefaultNumComputeCapabilities = 1;  // Default number of compute capabilities for Turing support
+  if (trt_config->getNbComputeCapabilities() == 0) {
+    trt_config->setNbComputeCapabilities(kDefaultNumComputeCapabilities);
+    trt_config->setComputeCapability(nvinfer1::ComputeCapability::kCURRENT, 0);
+  }
 
   int num_inputs = trt_network->getNbInputs();
   int num_outputs = trt_network->getNbOutputs();


### PR DESCRIPTION
Added support for Turing Arch

The changes are to make the ORT NV TensorRT RTX EP use the --computeCapabilities=1 flag by default so they can support the engine build for Turing Arch as well.
