### PR TITLE
[webgpu] Enable graph capture

### DIFF
--- a/include/onnxruntime/core/framework/execution_provider.h
+++ b/include/onnxruntime/core/framework/execution_provider.h
@@ -264,7 +264,7 @@ class IExecutionProvider {
      This provides an opportunity for execution providers to optionally synchronize and
      clean up its temporary resources to reduce memory and ensure the first run is fast.
   */
-  virtual common::Status OnSessionInitializationEnd() { return Status::OK(); }
+  virtual common::Status OnSessionInitializationEnd(uint32_t /*session_id*/) { return Status::OK(); }
 
   struct FusedNodeAndGraph {
     const std::reference_wrapper<onnxruntime::Node> fused_node;

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.h
@@ -293,7 +293,7 @@ namespace Dml
                 const onnxruntime::GraphOptimizerRegistry& /* graph_optimizer_registry */,
                 onnxruntime::IResourceAccountant* resource_accountant) const final override;
 
-        onnxruntime::common::Status OnSessionInitializationEnd() override
+        onnxruntime::common::Status OnSessionInitializationEnd(uint32_t) override
         {
             return m_impl->OnSessionInitializationEnd();
         }

--- a/onnxruntime/core/providers/webgpu/buffer_manager.cc
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.cc
@@ -250,6 +250,7 @@ class BucketCacheManager : public IBufferCacheManager {
           wgpuBufferRelease(buffer);
         }
       } else {
+        // TODO: Reuse the captured buffers for storage buffer to reduce peak memory.
         auto it = captured_buffers_.find(session_id);
         if (it == captured_buffers_.end()) {
           captured_buffers_.emplace(session_id, std::vector<WGPUBuffer>());

--- a/onnxruntime/core/providers/webgpu/buffer_manager.h
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.h
@@ -14,6 +14,13 @@ namespace webgpu {
 
 class WebGpuContext;
 
+// For command capture and replay
+enum class SStatus {
+  Default,
+  Capturing,
+  Replaying
+};
+
 enum class BufferCacheMode {
   Disabled,
   LazyRelease,
@@ -48,8 +55,11 @@ class IBufferCacheManager {
   // release a buffer
   virtual void ReleaseBuffer(WGPUBuffer buffer) = 0;
 
+  // release captured buffers
+  virtual void ReleaseCapturedBuffers(uint32_t session_id) = 0;
+
   // when a stream refresh is requested
-  virtual void OnRefresh() = 0;
+  virtual void OnRefresh(SStatus session_status, uint32_t session_id) = 0;
 };
 
 //
@@ -67,7 +77,8 @@ class BufferManager {
                                                               wgpu::BufferUsage::CopyDst);
   void Release(WGPUBuffer buffer);
   void Download(WGPUBuffer src, void* dst, size_t size);
-  void RefreshPendingBuffers();
+  void RefreshPendingBuffers(SStatus session_status, uint32_t session_id);
+  void ReleaseCapturedBuffers(uint32_t session_id);
 
  private:
   IBufferCacheManager& GetCacheManager(wgpu::BufferUsage usage) const;

--- a/onnxruntime/core/providers/webgpu/webgpu_context.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.h
@@ -116,6 +116,11 @@ class WebGpuContext final {
     }
   }
 
+  void CaptureBegin(uint32_t session_id);
+  void CaptureEnd();
+  void Replay(uint32_t session_id);
+  void OnReleaseSession(uint32_t session_id);
+
   void Flush();
 
   webgpu::BufferManager& BufferManager() const { return *buffer_mgr_; }
@@ -237,6 +242,21 @@ class WebGpuContext final {
   uint64_t gpu_timestamp_offset_ = 0;
   bool is_profiling_ = false;
   bool preserve_device_;
+
+  SStatus session_status_{SStatus::Default};
+
+  struct CapturedCommandInfo {
+    wgpu::ComputePipeline compute_pipeline;
+    wgpu::BindGroup bind_group;
+    std::array<uint32_t, 3> dispatch_group;
+  };
+  // A session_id to a vector of corresponding commands map for replay
+  std::unordered_map<uint32_t, std::vector<CapturedCommandInfo>> captured_commands_map_;
+
+  // A session_id to a vector of corresponding kernel info map for profiling during replay
+  std::unordered_map<uint32_t, std::vector<PendingKernelInfo>> captured_kernels_map_;
+
+  uint32_t session_id_ = 0;
 
 #if defined(ENABLE_PIX_FOR_WEBGPU_EP)
   std::unique_ptr<WebGpuPIXFrameGenerator> pix_frame_generator_ = nullptr;

--- a/onnxruntime/core/providers/webgpu/webgpu_context.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.h
@@ -253,9 +253,6 @@ class WebGpuContext final {
   // A session_id to a vector of corresponding commands map for replay
   std::unordered_map<uint32_t, std::vector<CapturedCommandInfo>> captured_commands_map_;
 
-  // A session_id to a vector of corresponding kernel info map for profiling during replay
-  std::unordered_map<uint32_t, std::vector<PendingKernelInfo>> captured_kernels_map_;
-
   uint32_t session_id_ = 0;
 
 #if defined(ENABLE_PIX_FOR_WEBGPU_EP)

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.h
@@ -64,7 +64,7 @@ class WebGpuExecutionProvider : public IExecutionProvider {
   bool ConcurrentRunSupported() const override { return false; }
 
   std::vector<AllocatorPtr> CreatePreferredAllocators() override;
-  Status OnSessionInitializationEnd() override;
+  Status OnSessionInitializationEnd(uint32_t session_id) override;
 
   Status OnRunStart(const onnxruntime::RunOptions& run_options) override;
   Status OnRunEnd(bool sync_stream, const onnxruntime::RunOptions& run_options) override;
@@ -91,6 +91,7 @@ class WebGpuExecutionProvider : public IExecutionProvider {
   int regular_run_count_before_graph_capture_ = 0;
   const int min_num_runs_before_cuda_graph_capture_ = 1;  // required min regular runs before graph capture for the necessary memory allocations.
   webgpu::GpuBufferAllocator* allocator_ = nullptr;
+  uint32_t session_id_;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -2291,7 +2291,7 @@ common::Status InferenceSession::Initialize() {
 
   if (status.IsOK()) {
     for (auto& xp : execution_providers_) {
-      auto end_status = xp->OnSessionInitializationEnd();
+      auto end_status = xp->OnSessionInitializationEnd(session_id_);
       if (status.IsOK()) {
         status = end_status;
       }

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -216,7 +216,7 @@ static void CreateMatMulModel(std::unique_ptr<onnxruntime::Model>& p_model, Prov
   if (provider_type == kCpuExecutionProvider) {
     node.SetExecutionProviderType(provider_type);
   } else {
-#if defined(USE_CUDA) || defined(USE_ROCM)
+#if defined(USE_CUDA) || defined(USE_ROCM) || defined(USE_WEBGPU)
     node.SetExecutionProviderType(provider_type);
 #endif
   }
@@ -285,46 +285,74 @@ void RunModelWithBindingMatMul(InferenceSession& session_object,
                                bool is_preallocate_output_vec,
                                ProviderType allocation_provider,
                                IExecutionProvider* gpu_provider,
-                               OrtDevice* output_device) {
+                               OrtDevice* output_device,
+                               bool enable_graph_capture) {
   std::unique_ptr<IOBinding> io_binding;
   Status st = session_object.NewIOBinding(&io_binding);
   ASSERT_TRUE(st.IsOK());
-  auto input_allocator = io_binding->GetCPUAllocator(bind_provider_type);
 
   // bind a value to A with input that will produce invalid output in order to test replacement of a feed
   std::vector<float> values_mul_x_tmp = {12.f, 11.f, 10.f, 9.f, 8.f, 7.f, 6.f, 5.f, 4.f, 3.f, 2.f, 1.f};
   std::vector<int64_t> dims_mul_x_A_tmp = {3, 4};
-  OrtValue input_tmp;
-  CreateMLValue<float>(input_allocator, dims_mul_x_A_tmp, values_mul_x_tmp, &input_tmp);
-  ASSERT_STATUS_OK(io_binding->BindInput("A", input_tmp));
-  const void* tmp_A = io_binding->GetInputs()[0].Get<Tensor>().DataRaw();  // location of data post binding
-
-  // prepare inputs
   std::vector<float> values_mul_x = {0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f, 11.0f};
-
-  /*
-      0 1 2 3     0 1 2
-      4 5 6 7     3 4 5
-      8 9 10 11   6 7 8
-      9 10 11
-      */
-  // bind one input to cpu allocator from bind_provider_type, and another on user provided CPU memory
-  // so both code pathes are covered
-  OrtValue input_ml_value_A;
   std::vector<int64_t> dims_mul_x_A = {3, 4};
-  CreateMLValue<float>(input_allocator, dims_mul_x_A, values_mul_x, &input_ml_value_A);
-
-  OrtValue input_ml_value_B;
   std::vector<int64_t> dims_mul_x_B = {4, 3};
-  CreateMLValue<float>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0], dims_mul_x_B, values_mul_x,
-                       &input_ml_value_B);
 
-  ASSERT_STATUS_OK(io_binding->BindInput("A", input_ml_value_A));
-  ASSERT_STATUS_OK(io_binding->BindInput("B", input_ml_value_B));
+  if (enable_graph_capture) {
+    // For graph capture, all inputs/outputs should be in preallocated gpu memory.
+    ASSERT_TRUE(is_preallocate_output_vec);
+    OrtValue input_ml_value_A_cpu;
+    CreateMLValue<float>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0], dims_mul_x_A, values_mul_x, &input_ml_value_A_cpu);
+    auto& cpu_tensor_a = input_ml_value_A_cpu.Get<Tensor>();
+    Tensor gpu_tensor_a(cpu_tensor_a.DataType(), cpu_tensor_a.Shape(),
+                        gpu_provider->CreatePreferredAllocators()[0]);
+    st = gpu_provider->GetDataTransfer()->CopyTensor(cpu_tensor_a, gpu_tensor_a);
+    ASSERT_TRUE(st.IsOK());
+    OrtValue input_ml_value_A;
+    Tensor::InitOrtValue(std::move(gpu_tensor_a), input_ml_value_A);
 
-  // check location of 'A' post-binding has changed to validate that the previous value was replaced
-  ASSERT_TRUE(io_binding->GetInputs()[0].Get<Tensor>().DataRaw() != tmp_A);
+    OrtValue input_ml_value_B_cpu;
+    CreateMLValue<float>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0], dims_mul_x_B, values_mul_x,
+                         &input_ml_value_B_cpu);
+    auto& cpu_tensor_b = input_ml_value_B_cpu.Get<Tensor>();
+    Tensor gpu_tensor_b(cpu_tensor_b.DataType(), cpu_tensor_b.Shape(),
+                        gpu_provider->CreatePreferredAllocators()[0]);
+    st = gpu_provider->GetDataTransfer()->CopyTensor(cpu_tensor_b, gpu_tensor_b);
+    ASSERT_TRUE(st.IsOK());
+    OrtValue input_ml_value_B;
+    Tensor::InitOrtValue(std::move(gpu_tensor_b), input_ml_value_B);
 
+    ASSERT_STATUS_OK(io_binding->BindInput("A", input_ml_value_A));
+    ASSERT_STATUS_OK(io_binding->BindInput("B", input_ml_value_B));
+  } else {
+    auto input_allocator = io_binding->GetCPUAllocator(bind_provider_type);
+    OrtValue input_tmp;
+    CreateMLValue<float>(input_allocator, dims_mul_x_A_tmp, values_mul_x_tmp, &input_tmp);
+    ASSERT_STATUS_OK(io_binding->BindInput("A", input_tmp));
+    const void* tmp_A = io_binding->GetInputs()[0].Get<Tensor>().DataRaw();  // location of data post binding
+
+    // prepare inputs
+    /*
+        0 1 2 3     0 1 2
+        4 5 6 7     3 4 5
+        8 9 10 11   6 7 8
+        9 10 11
+        */
+    // bind one input to cpu allocator from bind_provider_type, and another on user provided CPU memory
+    // so both code pathes are covered
+    OrtValue input_ml_value_A;
+    CreateMLValue<float>(input_allocator, dims_mul_x_A, values_mul_x, &input_ml_value_A);
+
+    OrtValue input_ml_value_B;
+    CreateMLValue<float>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0], dims_mul_x_B, values_mul_x,
+                         &input_ml_value_B);
+
+    ASSERT_STATUS_OK(io_binding->BindInput("A", input_ml_value_A));
+    ASSERT_STATUS_OK(io_binding->BindInput("B", input_ml_value_B));
+
+    // check location of 'A' post-binding has changed to validate that the previous value was replaced
+    ASSERT_TRUE(io_binding->GetInputs()[0].Get<Tensor>().DataRaw() != tmp_A);
+  }
   // prepare outputs
   std::vector<int64_t> expected_output_dims = {3, 3};
   OrtValue output_ml_value;
@@ -332,7 +360,7 @@ void RunModelWithBindingMatMul(InferenceSession& session_object,
     if (allocation_provider == kCpuExecutionProvider) {
       AllocateMLValue<float>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0], expected_output_dims,
                              &output_ml_value);
-    } else if (allocation_provider == kCudaExecutionProvider || allocation_provider == kRocmExecutionProvider) {
+    } else if (allocation_provider == kCudaExecutionProvider || allocation_provider == kRocmExecutionProvider || allocation_provider == kWebGpuExecutionProvider) {
       AllocateMLValue<float>(gpu_provider->CreatePreferredAllocators()[0], expected_output_dims, &output_ml_value);
     } else {
       ORT_THROW("Unsupported provider");
@@ -350,6 +378,7 @@ void RunModelWithBindingMatMul(InferenceSession& session_object,
 
   // prepare expected inputs and outputs
   std::vector<float> expected_values_mul_y = {42, 48, 54, 114, 136, 158, 186, 224, 262};
+  std::vector<float> expected_values_mul_y_2 = {174, 216, 258, 102, 128, 154, 30, 40, 50};
 
   // Now run
   st = session_object.Run(run_options, *io_binding.get());
@@ -357,9 +386,9 @@ void RunModelWithBindingMatMul(InferenceSession& session_object,
   std::cout << "Run returned status: " << st.ErrorMessage() << std::endl;
   ASSERT_TRUE(st.IsOK());
 
-  if ((is_preallocate_output_vec && (allocation_provider == kCudaExecutionProvider || allocation_provider == kRocmExecutionProvider)) ||
+  if ((is_preallocate_output_vec && (allocation_provider == kCudaExecutionProvider || allocation_provider == kRocmExecutionProvider || allocation_provider == kWebGpuExecutionProvider)) ||
       (output_device && output_device->Type() == OrtDevice::GPU)) {
-#if defined(USE_CUDA) || defined(USE_ROCM)
+#if defined(USE_CUDA) || defined(USE_ROCM) || defined(USE_WEBGPU)
     // in this case we need to copy the tensor from cuda to cpu
     std::vector<OrtValue>& outputs = io_binding->GetOutputs();
     ASSERT_EQ(1u, outputs.size());
@@ -376,6 +405,9 @@ void RunModelWithBindingMatMul(InferenceSession& session_object,
 #ifdef USE_ROCM
     st = GetProviderInfo_ROCM().CreateGPUDataTransfer()->CopyTensor(rtensor, *cpu_tensor.get());
 #endif
+#ifdef USE_WEBGPU
+    st = gpu_provider->GetDataTransfer()->CopyTensor(rtensor, *cpu_tensor.get());
+#endif
     ASSERT_TRUE(st.IsOK());
     OrtValue ml_value;
     ml_value.Init(cpu_tensor.release(),
@@ -384,10 +416,42 @@ void RunModelWithBindingMatMul(InferenceSession& session_object,
     VerifyOutputs({ml_value}, expected_output_dims, expected_values_mul_y);
 #endif
   } else {
-    if (allocation_provider == kCudaExecutionProvider || allocation_provider == kRocmExecutionProvider) {
+    if (allocation_provider == kCudaExecutionProvider || allocation_provider == kRocmExecutionProvider || allocation_provider == kWebGpuExecutionProvider) {
       ASSERT_STATUS_OK(gpu_provider->Sync());
     }
     VerifyOutputs(io_binding->GetOutputs(), expected_output_dims, expected_values_mul_y);
+  }
+
+  if (enable_graph_capture) {
+    // Update input_a's value. Run again. Replay the captured graph
+    OrtValue input_a2;
+    CreateMLValue<float>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0], dims_mul_x_A_tmp, values_mul_x_tmp, &input_a2);
+    auto& cpu_tensor_a2 = input_a2.Get<Tensor>();
+    st = gpu_provider->GetDataTransfer()->CopyTensor(cpu_tensor_a2, const_cast<Tensor&>(io_binding->GetInputs()[0].Get<Tensor>()));
+    ASSERT_TRUE(st.IsOK());
+
+    st = session_object.Run(run_options, *io_binding.get());
+
+    std::cout << "Run returned status: " << st.ErrorMessage() << std::endl;
+    ASSERT_TRUE(st.IsOK());
+
+    // Copy the tensor from gpu to cpu
+    std::vector<OrtValue>& outputs = io_binding->GetOutputs();
+    ASSERT_EQ(1u, outputs.size());
+    auto& rtensor = outputs.front().Get<Tensor>();
+    auto element_type = rtensor.DataType();
+    auto& shape = rtensor.Shape();
+    auto cpu_allocator = TestCPUExecutionProvider()->CreatePreferredAllocators()[0];
+    std::unique_ptr<Tensor> cpu_tensor = std::make_unique<Tensor>(element_type,
+                                                                  shape,
+                                                                  cpu_allocator);
+    st = gpu_provider->GetDataTransfer()->CopyTensor(rtensor, *cpu_tensor.get());
+    ASSERT_TRUE(st.IsOK());
+    OrtValue ml_value;
+    ml_value.Init(cpu_tensor.release(),
+                  DataTypeImpl::GetType<Tensor>(),
+                  DataTypeImpl::GetType<Tensor>()->GetDeleteFunc());
+    VerifyOutputs({ml_value}, expected_output_dims, expected_values_mul_y_2);
   }
 }
 
@@ -1058,16 +1122,16 @@ static void TestBindHelper(const std::string& log_str,
                            ProviderType run_provider_type,
                            bool preallocate_output,
                            ProviderType allocation_provider = kCpuExecutionProvider,
-                           OrtDevice* output_device = nullptr) {
+                           OrtDevice* output_device = nullptr,
+                           bool enable_graph_capture = false) {
   SessionOptions so;
 
   so.session_logid = "InferenceSessionTests." + log_str;
   so.session_log_verbosity_level = 1;  // change to 1 for detailed logging
-
   InferenceSession session_object{so, GetEnvironment()};
   IExecutionProvider* gpu_provider{};
 
-  if (bind_provider_type == kCudaExecutionProvider || bind_provider_type == kRocmExecutionProvider) {
+  if (bind_provider_type == kCudaExecutionProvider || bind_provider_type == kRocmExecutionProvider || bind_provider_type == kWebGpuExecutionProvider) {
 #ifdef USE_CUDA
     auto provider = DefaultCudaExecutionProvider();
     gpu_provider = provider.get();
@@ -1075,6 +1139,15 @@ static void TestBindHelper(const std::string& log_str,
 #endif
 #ifdef USE_ROCM
     auto provider = DefaultRocmExecutionProvider();
+    gpu_provider = provider.get();
+    ASSERT_STATUS_OK(session_object.RegisterExecutionProvider(std::move(provider)));
+#endif
+#ifdef USE_WEBGPU
+    ConfigOptions config_options{};
+    ORT_ENFORCE(config_options.AddConfigEntry(webgpu::options::kEnableGraphCapture,
+                                              enable_graph_capture ? webgpu::options::kEnableGraphCapture_ON : webgpu::options::kEnableGraphCapture_OFF)
+                    .IsOK());
+    auto provider = WebGpuExecutionProviderWithOptions(config_options);
     gpu_provider = provider.get();
     ASSERT_STATUS_OK(session_object.RegisterExecutionProvider(std::move(provider)));
 #endif
@@ -1099,7 +1172,8 @@ static void TestBindHelper(const std::string& log_str,
                             preallocate_output,
                             allocation_provider,
                             gpu_provider,
-                            output_device);
+                            output_device,
+                            enable_graph_capture);
 }
 
 TEST(InferenceSessionTests, TestBindCpu) {
@@ -1186,12 +1260,15 @@ TEST(InferenceSessionTests, InvalidInputTypeOfTensorElement) {
   ASSERT_TRUE(!st.IsOK());
 }
 
-#if defined(USE_CUDA) || defined(USE_ROCM)
+#if defined(USE_CUDA) || defined(USE_ROCM) || defined(USE_WEBGPU)
 #if USE_CUDA
 constexpr const char* kGpuExecutionProvider = kCudaExecutionProvider;
 #elif USE_ROCM
 constexpr const char* kGpuExecutionProvider = kRocmExecutionProvider;
+#elif USE_WEBGPU
+constexpr const char* kGpuExecutionProvider = kWebGpuExecutionProvider;
 #endif
+
 TEST(InferenceSessionTests, TestBindCuda) {
   TestBindHelper("TestBindCuda",
                  kGpuExecutionProvider,
@@ -1222,7 +1299,7 @@ TEST(InferenceSessionTests, TestBindCudaPreallocateOutputOnCpu2) {
                  true /* preallocate output on CPU */,
                  kCpuExecutionProvider);
 }
-
+#ifndef USE_WEBGPU
 TEST(InferenceSessionTests, TestBindCudaSpecifyOutputDeviceOnCuda) {
   OrtDevice device(OrtDevice::GPU, OrtDevice::MemType::DEFAULT, 0);
 
@@ -1233,7 +1310,17 @@ TEST(InferenceSessionTests, TestBindCudaSpecifyOutputDeviceOnCuda) {
                  kGpuExecutionProvider,
                  &device /* specify output device */);
 }
-
+#else
+TEST(InferenceSessionTests, TestGraphCapture) {
+  TestBindHelper("TestGraphCapture",
+                 kGpuExecutionProvider,
+                 kGpuExecutionProvider,
+                 true /* preallocate output on GPU */,
+                 kGpuExecutionProvider,
+                 nullptr,
+                 true /* enable graph capture*/);
+}
+#endif  // !USE_WEBGPU
 #endif
 
 TEST(InferenceSessionTests, ModelWithoutOpset) {

--- a/onnxruntime/test/util/default_providers.cc
+++ b/onnxruntime/test/util/default_providers.cc
@@ -317,6 +317,14 @@ std::unique_ptr<IExecutionProvider> DefaultWebGpuExecutionProvider() {
 #endif
 }
 
+std::unique_ptr<IExecutionProvider> WebGpuExecutionProviderWithOptions(const ConfigOptions& config_options) {
+#ifdef USE_WEBGPU
+  return WebGpuProviderFactoryCreator::Create(config_options)->CreateProvider();
+#else
+  return nullptr;
+#endif
+}
+
 std::unique_ptr<IExecutionProvider> DefaultCannExecutionProvider() {
 #ifdef USE_CANN
   OrtCANNProviderOptions provider_options{};

--- a/onnxruntime/test/util/include/default_providers.h
+++ b/onnxruntime/test/util/include/default_providers.h
@@ -64,6 +64,7 @@ std::unique_ptr<IExecutionProvider> QnnExecutionProviderWithOptions(const Provid
                                                                     const SessionOptions* session_options = nullptr);
 std::unique_ptr<IExecutionProvider> DefaultXnnpackExecutionProvider();
 std::unique_ptr<IExecutionProvider> DefaultWebGpuExecutionProvider();
+std::unique_ptr<IExecutionProvider> WebGpuExecutionProviderWithOptions(const ConfigOptions& config_options);
 std::unique_ptr<IExecutionProvider> DefaultCannExecutionProvider();
 std::unique_ptr<IExecutionProvider> DefaultDmlExecutionProvider();
 


### PR DESCRIPTION

This PR enables graph capture capabilities in the WebGPU provider, which is similar with jsep one #18989. 

All limitations are similar with JS/CUDA EP:
1. Models with control-flow ops (i.e. If, Loop and Scan ops) are not supported.
2. Usage of graph capture is limited to models where-in all ops in the model can be partitioned to the WebGPU EP or CPU EP and no memory copy between them.
3. Shapes of inputs/outputs cannot change across inference calls.
4. IOBinding is required. And all inputs/outputs are pre-allocated gpu buffers.