### PR TITLE
Mitigate crash on logging after LoggingManager destruction

### DIFF
--- a/onnxruntime/core/common/logging/logging.cc
+++ b/onnxruntime/core/common/logging/logging.cc
@@ -161,10 +161,18 @@ std::unique_ptr<Logger> LoggingManager::CreateLogger(const std::string& logger_i
 }
 
 void LoggingManager::Log(const std::string& logger_id, const Capture& message) const {
+  // Ensure the LoggingManager instance is valid before logging
+  if (owns_default_logger_ && !DefaultLoggerManagerInstance().load()) {
+    return;
+  }
   sink_->Send(GetTimestamp(), logger_id, message);
 }
 
 void LoggingManager::SendProfileEvent(profiling::EventRecord& eventRecord) const {
+  // Ensure the LoggingManager instance is valid before sending profile events
+  if (owns_default_logger_ && !DefaultLoggerManagerInstance().load()) {
+    return;
+  }
   sink_->SendProfileEvent(eventRecord);
 }
 


### PR DESCRIPTION
### Description
Ensures that logging and profiling events are only sent if a valid LoggingManager instance exists.
Prevents potential crashes by throwing an exception when attempting to log without a valid instance.

### Motivation and Context

Crash instances are observed where Logger object is still alive and trying to log after the LoggingManager has been destroyed. 

```
# Child-SP          RetAddr               Call Site
00 00000053`35cfd880 00007ffe`29c83e04     0x00007ffe`29f4a5d8
01 00000053`35cfd880 00007ffe`29b65d58     ntdll!RtlpExecuteHandlerForException(void)+0x14 [minkernel\ntos\rtl\arm64\xcptmisc.asm @ 142] 
02 00000053`35cfd8a0 00007ffe`29c83c60     ntdll!RtlDispatchException(struct _EXCEPTION_RECORD * ExceptionRecord = 0x00000053`35cfe290, struct _CONTEXT * ContextRecord = 0x00000053`35cfdee0)+0x2e8 [minkernel\ntos\rtl\arm64\exdsptch.c @ 725] 
03 00000053`35cfdee0 00007ffe`29f4a058     ntdll!KiUserExceptionDispatcher(void)+0x40 [minkernel\ntos\rtl\arm64\trampoln.asm @ 766] 
04 00000053`35cfe350 00007ffd`a717cc78     0x00007ffe`29f4a058
05 00000053`35cfe350 00007ffd`a7170100     ps_onnxruntime!onnxruntime::logging::LoggingManager::Log(class std::basic_string<char,std::char_traits<char>,std::allocator<char> > * logger_id = 0x00000210`0dba64c8, class onnxruntime::logging::Capture * message = 0x00000053`35cfe470)+0x140 [D:\a\_work\1\s\onnxruntime\onnxruntime\core\common\logging\logging.cc @ 164] 
06 (Inline Function) --------`--------     ps_onnxruntime!onnxruntime::logging::Logger::Log(void)+0x10 [D:\a\_work\1\s\onnxruntime\include\onnxruntime\core\common\logging\logging.h @ 344] 
07 00000053`35cfe3a0 00007ffd`a6aa5244     ps_onnxruntime!onnxruntime::logging::Capture::~Capture(void)+0x30 [D:\a\_work\1\s\onnxruntime\onnxruntime\core\common\logging\capture.cc @ 63] 
08 00000053`35cfe3d0 00007ffd`a69ffa10     ps_onnxruntime!<lambda_163dae3642b3c0c78c9bd287d4c102d5>::operator()(void * raw_context_handle = <Value unavailable error>)+0x1dc [D:\a\_work\1\s\onnxruntime\onnxruntime\core\providers\qnn\builder\qnn_backend_manager.cc @ 1720] 
09 (Inline Function) --------`--------     ps_onnxruntime!std::_Func_class<void,unsigned __int64 *>::operator()(unsigned int64 * <_Args_0> = 0x00000000`00000004)+0x2c [C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.42.34433\include\functional @ 920] 
0a 00000053`35cfe600 00007ffd`a6ab3584     ps_onnxruntime!std::unique_ptr<unsigned __int64,std::function<void __cdecl(void)+0x60 [C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.42.34433\include\memory @ 3414] 
0b 00000053`35cfe650 00007ffd`a6a04abc     ps_onnxruntime!std::_Ref_count_obj2<onnxruntime::qnn::QnnBackendManager::QnnContextHandleRecord>::_Destroy(void)+0x44 [C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.42.34433\include\memory @ 2113] 
0c 00000053`35cfe670 00007ffd`a6ab40b4     ps_onnxruntime!std::_Ref_count_base::_Decref(void)+0x4c [C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.42.34433\include\memory @ 1164] 
0d (Inline Function) --------`--------    


0:002> dx Debugger.Sessions[0].Processes[113460].Threads[113216].Stack.Frames[5].SwitchTo();dv /t /v
Debugger.Sessions[0].Processes[113460].Threads[113216].Stack.Frames[5].SwitchTo()
_<unavailable>     class onnxruntime::logging::LoggingManager * this = <value unavailable>_
@x23              class std::basic_string<char,std::char_traits<char>,std::allocator<char> > * logger_id = 0x00000210`0dba64c8
@x22              class onnxruntime::logging::Capture * message = 0x00000053`35cfe470


