### PR TITLE
[WebGPU EP] adjust test case to skip CoreML EP

### DIFF
--- a/onnxruntime/test/providers/cpu/math/softmax_test.cc
+++ b/onnxruntime/test/providers/cpu/math/softmax_test.cc
@@ -60,8 +60,8 @@ TEST(SoftmaxOperator, webgpu_nan) {
   test.AddInput<float>("X", dimensions, x_vals);
   test.AddOutput<float>("Y", dimensions, expected_result);
 
-  // explicitly disable CPU EP for this test since CPU implementation does not handle NaN
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kCpuExecutionProvider});
+  // explicitly disable for EPs that do not handle NaN
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kCpuExecutionProvider, kCoreMLExecutionProvider});
 }
 #endif
 


### PR DESCRIPTION
Fixes pipeline error in MacOS_C_API_Packaging_CPU_x86_64 by disabling softmax NaN test for CoreML EP since it does not handle NaN.