### PR TITLE
[QNN EP] Add multiple Op support in QNN EP

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
@@ -65,6 +65,11 @@ OpBuilderRegistrations::OpBuilderRegistrations() {
     CreateSimpleOpBuilder("GridSample", *this);
 
     CreateSimpleOpBuilder("LpNormalization", *this);
+
+    CreateSimpleOpBuilder("Softplus", *this);
+    CreateSimpleOpBuilder("IsNaN", *this);
+    CreateSimpleOpBuilder("NonZero", *this);
+    CreateSimpleOpBuilder("Xor", *this);
   }
 
   {
@@ -184,6 +189,10 @@ OpBuilderRegistrations::OpBuilderRegistrations() {
 
   {
     CreateLSTMOpBuilder("LSTM", *this);
+  }
+
+  {
+    CreateModOpBuilder("Mod", *this);
   }
 }
 

--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
@@ -104,5 +104,7 @@ void CreateMatMulOpBuilder(const std::string& op_type, OpBuilderRegistrations& o
 void CreateEinsumOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 
 void CreateLSTMOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+
+void CreateModOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 }  // namespace qnn
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
@@ -244,6 +244,14 @@ class BaseOpBuilder : public IOpBuilder {
         {"LRN", QNN_OP_LRN},
 
         {"Pad", QNN_OP_PAD},
+        {"Softplus", QNN_OP_ELEMENT_WISE_NEURON},
+        {"IsNaN", QNN_OP_ELEMENT_WISE_NOT_EQUAL},
+        {"NonZero", QNN_OP_NON_ZERO},
+        {"Xor", QNN_OP_ELEMENT_WISE_XOR},
+
+        // Note: Mod is handled separately inside ModOpBuilder
+        // {"Mod", QNN_OP_ELEMENT_WISE_MOD},
+        // {"Mod", QNN_OP_ELEMENT_WISE_FMOD},
 
         {"Expand", QNN_OP_ELEMENT_WISE_MULTIPLY}};
     auto it = onnx_op_type_to_qnn_op_type.find(onnx_op_type);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/mod_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/mod_op_builder.cc
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/op_builder_factory.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+
+namespace onnxruntime {
+namespace qnn {
+class ModOpBuilder : public BaseOpBuilder {
+ public:
+  ModOpBuilder() : BaseOpBuilder("ModOpBuilder") {}
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(ModOpBuilder);
+
+ protected:
+  Status ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                     const NodeUnit& node_unit,
+                                     std::vector<std::string>&& input_names,
+                                     const logging::Logger& logger,
+                                     bool do_op_validation) const override ORT_MUST_USE_RESULT;
+};
+
+Status ModOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                                 const NodeUnit& node_unit,
+                                                 std::vector<std::string>&& input_names,
+                                                 const logging::Logger& logger,
+                                                 bool do_op_validation) const {
+  NodeAttrHelper node_helper(node_unit);
+  auto fmod = node_helper.Get("fmod", (int32_t)0);
+
+  // QNN has separate operators for Interger Mod and FMod
+  const std::string op_type = fmod == 1 ? QNN_OP_ELEMENT_WISE_FMOD : QNN_OP_ELEMENT_WISE_MOD;
+
+  ORT_RETURN_IF_ERROR(ProcessOutputs(qnn_model_wrapper, node_unit,
+                                     std::move(input_names), {},
+                                     logger, do_op_validation, op_type));
+
+  return Status::OK();
+}
+
+void CreateModOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
+  op_registrations.AddOpBuilder(op_type, std::make_unique<ModOpBuilder>());
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -379,6 +379,18 @@ Status SimpleOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_w
     qnn_model_wrapper.AddParamWrapper(std::move(operation_param));
   }
 
+  if (op_type == "Softplus") {
+    Qnn_Scalar_t neuron_operation = QNN_SCALAR_INIT;
+    neuron_operation.dataType = QNN_DATATYPE_UINT_32;
+    neuron_operation.uint32Value = QNN_OP_ELEMENT_WISE_NEURON_OPERATION_SOFTPLUS;
+
+    QnnParamWrapper operation_param(node_unit.Index(), node_unit.Name(),
+                                    QNN_OP_ELEMENT_WISE_NEURON_PARAM_OPERATION,
+                                    neuron_operation);
+    param_tensor_names.push_back(operation_param.GetParamTensorName());
+    qnn_model_wrapper.AddParamWrapper(std::move(operation_param));
+  }
+
   if (op_type == "DepthToSpace") {
     ORT_RETURN_IF_ERROR(ProcessBlockSizeAttribute(qnn_model_wrapper, node_unit, param_tensor_names));
     ORT_RETURN_IF_ERROR(ProcessModeAttribute(qnn_model_wrapper, node_unit, param_tensor_names));

--- a/onnxruntime/test/providers/qnn/simple_op_htp_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_htp_test.cc
@@ -109,6 +109,27 @@ TEST_F(QnnCPUBackendTests, DISABLED_UnaryOp_Relu) {
                  ExpectedEPNodeAssignment::All);
 }
 
+// Test Mod with fmod = 1
+TEST_F(QnnCPUBackendTests, BinaryOp_Mod_FLOAT) {
+  RunOpTestOnCPU<float>("Mod",
+                        {TestInputDef<float>({6}, false, {-4.3f, 7.2f, 5.0f, 4.3f, -7.2f, 8.0f}),
+                         TestInputDef<float>({6}, false, {2.1f, -3.4f, 8.0f, -2.1f, 3.4f, 5.0f})},
+                        {utils::MakeAttribute("fmod", static_cast<int64_t>(1))},
+                        13,
+                        ExpectedEPNodeAssignment::All);
+}
+
+// Test Mod with fmod = 0
+// TODO: Fix output mismatch between QNN CPU and CPU EP.
+TEST_F(QnnCPUBackendTests, DISABLED_BinaryOp_Mod_INT32) {
+  RunOpTestOnCPU<int32_t>("Mod",
+                          {TestInputDef<int32_t>({6}, false, {-4, 7, 5, 4, -7, 8}),
+                           TestInputDef<int32_t>({6}, false, {2, -3, 8, -2, 3, 5})},
+                          {utils::MakeAttribute("fmod", static_cast<int64_t>(0))},
+                          13,
+                          ExpectedEPNodeAssignment::All);
+}
+
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 // Tests the accuracy of a QDQ model on QNN EP by comparing to CPU EP, which runs both the fp32 model
@@ -331,6 +352,19 @@ TEST_F(QnnHTPBackendTests, UnaryOp_HardSwish_U16) {
                          ExpectedEPNodeAssignment::All,
                          kOnnxDomain,
                          true);
+}
+
+// Test Softplus on HTP
+TEST_F(QnnHTPBackendTests, UnaryOp_Softplus) {
+  const std::vector<float> input_data = {-10.0f, -8.4f, 0.0f, 5.0f, 7.1f, 10.0f};
+  RunOpTest<float>("Softplus",
+                   {TestInputDef<float>({6}, false, input_data)},
+                   {},
+                   14,
+                   ExpectedEPNodeAssignment::All,
+                   kOnnxDomain,
+                   0.01f,
+                   true);
 }
 
 // Check that QNN compiles DQ -> Atan -> Q as a single unit.
@@ -988,6 +1022,16 @@ TEST_F(QnnHTPBackendTests, BinaryOp_And4D) {
                    TestInputDef<bool>({1, 4}, false, {false, true, false, true})},
                   {},
                   17,
+                  ExpectedEPNodeAssignment::All);
+}
+
+// Test Xor
+TEST_F(QnnHTPBackendTests, BinaryOp_Xor4D) {
+  RunOpTest<bool>("Xor",
+                  {TestInputDef<bool>({1, 4}, false, {false, false, true, true}),
+                   TestInputDef<bool>({1, 4}, false, {false, true, false, true})},
+                  {},
+                  7,
                   ExpectedEPNodeAssignment::All);
 }
 


### PR DESCRIPTION
### Description
Add support for below ONNX Operators in QNN-EP
  1. Mod
  2. Xor
  3. NonZero
  4. IsNaN
  5. Softplus


### Motivation and Context
This improves inference time of multiple models contain these operators on Qualcomm SoCs.

