### PR TITLE
[Fix] Dependencies find_package pybind11 error

### DIFF
--- a/cmake/external/pybind11.cmake
+++ b/cmake/external/pybind11.cmake
@@ -2,11 +2,10 @@ set(PYBIND11_NOPYTHON ON CACHE BOOL "" FORCE)
 set(PYBIND11_INSTALL OFF CACHE BOOL "" FORCE)
 set(PYBIND11_TEST OFF CACHE BOOL "" FORCE)
 onnxruntime_fetchcontent_declare(
-    pybind11_project
+    pybind11
     URL ${DEP_URL_pybind11}
     URL_HASH SHA1=${DEP_SHA1_pybind11}
     EXCLUDE_FROM_ALL
     FIND_PACKAGE_ARGS 2.13 NAMES pybind11
 )
-onnxruntime_fetchcontent_makeavailable(pybind11_project)
-
+onnxruntime_fetchcontent_makeavailable(pybind11)


### PR DESCRIPTION
### Description
To fix the CMake configuration error when a dependency brought in via FetchContent uses find_package(pybind11 REQUIRED)
Similar with #23939 

Major Changes：
- rename project name from pybind11_project to pybind11

### Motivation and Context

Get the following build error when Dependencies use find_package(pybind11 REQUIRED)
```
Could not find a package configuration file provided by "pybind11" with any
  of the following names:

    pybind11Config.cmake
    pybind11-config.cmake

```
pybind11 project name is "pybind11" (https://github.com/pybind/pybind11/blob/master/CMakeLists.txt#L38-L41)
Config cmake file name is "pybind11Config.cmake" (https://github.com/pybind/pybind11/blob/master/CMakeLists.txt#L323-L325)

