### PR TITLE
Skip `_tpause` call for `_M_ARM64EC` in spin_pause.cc.

### DIFF
--- a/onnxruntime/core/common/spin_pause.cc
+++ b/onnxruntime/core/common/spin_pause.cc
@@ -25,6 +25,7 @@ namespace concurrency {
 // Intrinsic to use in spin-loops
 void SpinPause() {
 #if (defined(_M_AMD64) || defined(__x86_64__)) && \
+    !defined(_M_ARM64EC) &&                       \
     !defined(__ANDROID__) &&                      \
     !defined(__APPLE__)
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Skip `_tpause` call for `_M_ARM64EC` in spin_pause.cc.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix link error on ARM64EC for `_tpause` unresolved external symbol.