### PR TITLE
Run Matmul 8 bit tests on CPU builds

### DIFF
--- a/onnxruntime/test/contrib_ops/matmul_8bits_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_8bits_test.cc
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 
 #ifndef ORT_MINIMAL_BUILD
-#if (defined(MLAS_TARGET_AMD64_IX86) && !defined(USE_DML) && !defined(USE_WEBGPU) && !defined(USE_COREML)) || defined(USE_CUDA) || defined(USE_WEBGPU)
-
 #include <optional>
 
 #include "gtest/gtest.h"
@@ -25,6 +23,8 @@
 #include "core/session/onnxruntime_cxx_api.h"
 #include "core/session/ort_env.h"
 #include "core/util/qmath.h"
+
+#if (defined(MLAS_TARGET_AMD64_IX86) && !defined(USE_DML) && !defined(USE_WEBGPU) && !defined(USE_COREML)) || defined(USE_CUDA) || defined(USE_WEBGPU)
 
 extern std::unique_ptr<Ort::Env> ort_env;
 


### PR DESCRIPTION
### Description

It seems like https://github.com/microsoft/onnxruntime/pull/24509 added a guard for the 8 bit Matmul tests that depends on an MLAS macro being set to compile and run on CPUs but that guard itself was preventing the inclusion of the MLAS header where the macro would have been set and so Matmul 8 bit tests were not being compiled and run on CPU builds.

### Motivation and Context
Improve test coverage for CPU builds 


