### PR TITLE
A temporary fix for layout opt level to unblock react native android CI

### DIFF
--- a/js/react_native/android/src/main/java/ai/onnxruntime/reactnative/OnnxruntimeModule.java
+++ b/js/react_native/android/src/main/java/ai/onnxruntime/reactnative/OnnxruntimeModule.java
@@ -326,7 +326,7 @@ public class OnnxruntimeModule extends ReactContextBaseJavaModule implements Lif
               {"disabled", SessionOptions.OptLevel.NO_OPT},
               {"basic", SessionOptions.OptLevel.BASIC_OPT},
               {"extended", SessionOptions.OptLevel.EXTENDED_OPT},
-              {"layout", SessionOptions.OptLevel.LAYOUT_OPT},
+              // {"layout", SessionOptions.OptLevel.LAYOUT_OPT},
               {"all", SessionOptions.OptLevel.ALL_OPT},
           })
           .collect(Collectors.toMap(p -> (String)p[0], p -> (SessionOptions.OptLevel)p[1]));


### PR DESCRIPTION
### Description

A temporary fix to unblock react native android CI.

### Motivation and Context

After https://github.com/microsoft/onnxruntime/pull/24726 is merged to main, react native android CI starts failing with error like 

```
/mnt/vss/_work/1/s/js/react_native/e2e/node_modules/onnxruntime-react-native/android/src/main/java/ai/onnxruntime/reactnative/OnnxruntimeModule.java:329: error: cannot find symbol
              {"layout", SessionOptions.OptLevel.LAYOUT_OPT},
                                                ^
  symbol:   variable LAYOUT_OPT
  location: class OptLevel
```

The LAYOUT_OPT is defined in https://github.com/microsoft/onnxruntime/blob/8b3326e53249edb610cfe1648aff5c88f28b65f4/java/src/main/java/ai/onnxruntime/OrtSession.java#L656.

The root cause of the build error is unknown. Since the layout level is just added, so it is not used by users. It is safe to comment the line to unblock the pipeline.