### PR TITLE
[QNN EP] Transform SFIXED to UFIXED on InstanceNorm scale

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/instance_norm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/instance_norm_op_builder.cc
@@ -25,6 +25,11 @@ class InstanceNormOpBuilder : public BaseOpBuilder {
                        std::vector<std::string>& input_names,
                        bool do_op_validation) const override ORT_MUST_USE_RESULT;
 
+  Status ProcessScale(QnnModelWrapper& qnn_model_wrapper,
+                      const NodeUnitIODef& input,
+                      const logging::Logger& logger,
+                      std::vector<std::string>& input_names) const;
+
   Status ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
                                      const NodeUnit& node_unit,
                                      std::vector<std::string>&& input_names,
@@ -143,8 +148,45 @@ Status InstanceNormOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
     ORT_RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[0], logger, input_names));  // Input 0
   }
 
-  ORT_RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[1], logger, input_names));  // Scale
+  ORT_RETURN_IF_ERROR(ProcessScale(qnn_model_wrapper, inputs[1], logger, input_names));  // Scale
   ORT_RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[2], logger, input_names));  // Bias
+
+  return Status::OK();
+}
+
+Status InstanceNormOpBuilder::ProcessScale(QnnModelWrapper& qnn_model_wrapper,
+                                           const NodeUnitIODef& input,
+                                           const logging::Logger& logger,
+                                           std::vector<std::string>& input_names) const {
+  ORT_RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, input, logger, input_names));
+
+  // Turn SFIXED scale of InstanceNorm into UFIXED when it is constant
+  const auto& input_name = input.node_arg.Name();
+  bool is_const = qnn_model_wrapper.IsConstantInput(input_name);
+  bool is_npu = IsNpuBackend(qnn_model_wrapper.GetQnnBackendType());
+  if (is_npu && is_const) {
+    TensorInfo tensor_info = {};
+    ORT_RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(input, tensor_info));
+    const Qnn_QuantizeParams_t& quant_param = tensor_info.quant_param.Get();
+    if (tensor_info.qnn_data_type == QNN_DATATYPE_SFIXED_POINT_8) {
+      std::string convert_input_name = input_names.back();
+      std::string convert_output_name = convert_input_name + "_convert_s8_to_u8";
+      Status status = utils::InsertConvertOp(
+          qnn_model_wrapper,
+          convert_input_name,
+          convert_output_name,
+          QNN_DATATYPE_SFIXED_POINT_8,
+          QNN_DATATYPE_UFIXED_POINT_8,
+          quant_param.scaleOffsetEncoding.offset,
+          quant_param.scaleOffsetEncoding.scale,
+          tensor_info.shape,
+          false,  // asymmetric
+          false   // do_op_validation
+      );
+      input_names.pop_back();
+      input_names.push_back(convert_output_name);
+    }
+  }
 
   return Status::OK();
 }

--- a/onnxruntime/test/providers/qnn/instance_norm_htp_test.cc
+++ b/onnxruntime/test/providers/qnn/instance_norm_htp_test.cc
@@ -17,24 +17,24 @@ namespace test {
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 // Function that builds a QDQ model with an InstanceNormalization operator.
-template <typename QuantType>
-static GetTestQDQModelFn<QuantType> BuildQDQInstanceNormTestCase(const TestInputDef<float>& input_def,
-                                                                 const TestInputDef<float>& scale_def,
-                                                                 const TestInputDef<float>& bias_def,
-                                                                 const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
-                                                                 bool use_contrib_qdq = false) {
+template <typename ActivationQType, typename ScaleQType>
+static GetTestQDQModelFn<ActivationQType> BuildQDQInstanceNormTestCase(const TestInputDef<float>& input_def,
+                                                                       const TestInputDef<float>& scale_def,
+                                                                       const TestInputDef<float>& bias_def,
+                                                                       const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
+                                                                       bool use_contrib_qdq = false) {
   return [input_def, scale_def, bias_def, attrs,
           use_contrib_qdq](ModelTestBuilder& builder,
-                           std::vector<QuantParams<QuantType>>& output_qparams) {
+                           std::vector<QuantParams<ActivationQType>>& output_qparams) {
     // input => Q => DQ =>
     NodeArg* input = MakeTestInput(builder, input_def);
-    QuantParams<QuantType> input_qparams = GetTestInputQuantParams<QuantType>(input_def);
+    QuantParams<ActivationQType> input_qparams = GetTestInputQuantParams<ActivationQType>(input_def);
     NodeArg* input_qdq = AddQDQNodePair(builder, input, input_qparams.scale, input_qparams.zero_point,
                                         use_contrib_qdq);
 
     // scale => Q => DQ =>
     NodeArg* scale = MakeTestInput(builder, scale_def);
-    QuantParams<QuantType> scale_qparams = GetTestInputQuantParams<QuantType>(scale_def);
+    QuantParams<ScaleQType> scale_qparams = GetTestInputQuantParams<ScaleQType>(scale_def);
     NodeArg* scale_qdq = AddQDQNodePair(builder, scale, scale_qparams.scale, scale_qparams.zero_point,
                                         use_contrib_qdq);
 
@@ -51,8 +51,8 @@ static GetTestQDQModelFn<QuantType> BuildQDQInstanceNormTestCase(const TestInput
     }
 
     // Add instance_norm_output -> Q -> output_u8
-    AddQDQNodePairWithOutputAsGraphOutput<QuantType>(builder, instance_norm_output, output_qparams[0].scale,
-                                                     output_qparams[0].zero_point, use_contrib_qdq);
+    AddQDQNodePairWithOutputAsGraphOutput<ActivationQType>(builder, instance_norm_output, output_qparams[0].scale,
+                                                           output_qparams[0].zero_point, use_contrib_qdq);
   };
 }
 
@@ -66,7 +66,7 @@ static GetTestQDQModelFn<QuantType> BuildQDQInstanceNormTestCase(const TestInput
  * \param attrs The node's attributes. The only valid attribute for InstanceNormalization is 'epsilon'.
  * \param expected_ep_assignment How many nodes are expected to be assigned to QNN (All, Some, or None).
  */
-template <typename QuantType = uint8_t>
+template <typename ActivationQType = uint8_t, typename ScaleQType = uint8_t>
 static void RunInstanceNormQDQTest(const TestInputDef<float>& input_def,
                                    const TestInputDef<float>& scale_def,
                                    const TestInputDef<float>& bias_def,
@@ -79,7 +79,7 @@ static void RunInstanceNormQDQTest(const TestInputDef<float>& input_def,
 
   // Runs model with DQ-> InstanceNorm -> Q and compares the outputs of the CPU and QNN EPs.
   TestQDQModelAccuracy(BuildOpTestCase<float>("InstanceNormalization", {input_def, scale_def, bias_def}, {}, attrs),
-                       BuildQDQInstanceNormTestCase<QuantType>(input_def, scale_def, bias_def, attrs, use_contrib_qdq),
+                       BuildQDQInstanceNormTestCase<ActivationQType, ScaleQType>(input_def, scale_def, bias_def, attrs, use_contrib_qdq),
                        provider_options,
                        18,
                        expected_ep_assignment);
@@ -87,7 +87,7 @@ static void RunInstanceNormQDQTest(const TestInputDef<float>& input_def,
 
 // Check that QNN compiles DQ -> InstanceNormalization -> Q as a single unit.
 // Use an input of rank 4.
-TEST_F(QnnHTPBackendTests, InstanceNormU8) {
+TEST_F(QnnHTPBackendTests, InstanceNormU8U8) {
   // fails with QNN 2.15.1 with the following fixed input.
   std::vector<float> input_data = {3.21289f, -5.9981f, -1.72799f, 6.27263f, 3.36205f, -1.93515f, -5.40113f, 3.75648f, 6.15357f,
                                    -5.25769f, 2.73637f, -0.901382f, -6.55612f, 1.99497f, -4.79228f, 2.69813f, 8.3064f, 0.0362501f};
@@ -100,22 +100,35 @@ TEST_F(QnnHTPBackendTests, InstanceNormU8) {
                          ExpectedEPNodeAssignment::All);
 }
 
-TEST_F(QnnHTPBackendTests, InstanceNormU16) {
+TEST_F(QnnHTPBackendTests, InstanceNormU8S8) {
+  // Check SFIXED scale
   std::vector<float> input_data = {3.21289f, -5.9981f, -1.72799f, 6.27263f, 3.36205f, -1.93515f, -5.40113f, 3.75648f, 6.15357f,
                                    -5.25769f, 2.73637f, -0.901382f, -6.55612f, 1.99497f, -4.79228f, 2.69813f, 8.3064f, 0.0362501f};
   std::vector<float> scale_data = {-0.148738f, -1.45158f};
   std::vector<float> bias_data = {-2.2785083772f, 2.3338717017f};
-  RunInstanceNormQDQTest<uint16_t>(TestInputDef<float>({1, 2, 3, 3}, false, input_data).OverrideValueRange(-10.0f, 10.0f),
-                                   TestInputDef<float>({2}, true, scale_data).OverrideValueRange(-2.0f, 2.0f),
-                                   TestInputDef<float>({2}, true, bias_data).OverrideValueRange(-3.0f, 3.0f),
-                                   {},
-                                   ExpectedEPNodeAssignment::All,
-                                   true);  // Use contrib Q/DQ ops for 16bit support.
+  RunInstanceNormQDQTest<uint8_t, int8_t>(TestInputDef<float>({1, 2, 3, 3}, false, input_data).OverrideValueRange(-10.0f, 10.0f),
+                                          TestInputDef<float>({2}, true, scale_data).OverrideValueRange(-2.0f, 2.0f),
+                                          TestInputDef<float>({2}, true, bias_data).OverrideValueRange(-3.0f, 3.0f),
+                                          {},
+                                          ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, InstanceNormU16U8) {
+  std::vector<float> input_data = {3.21289f, -5.9981f, -1.72799f, 6.27263f, 3.36205f, -1.93515f, -5.40113f, 3.75648f, 6.15357f,
+                                   -5.25769f, 2.73637f, -0.901382f, -6.55612f, 1.99497f, -4.79228f, 2.69813f, 8.3064f, 0.0362501f};
+  std::vector<float> scale_data = {-0.148738f, -1.45158f};
+  std::vector<float> bias_data = {-2.2785083772f, 2.3338717017f};
+  RunInstanceNormQDQTest<uint16_t, uint8_t>(TestInputDef<float>({1, 2, 3, 3}, false, input_data).OverrideValueRange(-10.0f, 10.0f),
+                                            TestInputDef<float>({2}, true, scale_data).OverrideValueRange(-2.0f, 2.0f),
+                                            TestInputDef<float>({2}, true, bias_data).OverrideValueRange(-3.0f, 3.0f),
+                                            {},
+                                            ExpectedEPNodeAssignment::All,
+                                            true);  // Use contrib Q/DQ ops for 16bit support.
 }
 
 // Check that QNN compiles DQ -> InstanceNormalization -> Q as a single unit.
 // Use an input of rank 3.
-TEST_F(QnnHTPBackendTests, InstanceNormU8Rank3) {
+TEST_F(QnnHTPBackendTests, InstanceNormU8U8Rank3) {
   RunInstanceNormQDQTest(TestInputDef<float>({1, 2, 3}, false, {6.0f, 4.0f, 2.0f, 6.0f, 8.0f, 2.0f}),
                          TestInputDef<float>({2}, true, {1.0f, 2.0f}),
                          TestInputDef<float>({2}, true, {1.0f, 3.0f}),
@@ -125,7 +138,7 @@ TEST_F(QnnHTPBackendTests, InstanceNormU8Rank3) {
 
 // Test 8-bit QDQ InstanceNormalization with an input of rank 3 with N != 1,
 // which requires wrapping the QNN InstanceNorm op with reshapes.
-TEST_F(QnnHTPBackendTests, InstanceNormU8Rank3_BatchSizeNot1) {
+TEST_F(QnnHTPBackendTests, InstanceNormU8U8Rank3_BatchSizeNot1) {
   std::vector<float> input_data = {6.0f, 4.0f, 2.0f, 6.0f, 8.0f, 2.0f,
                                    -8.0f, -6.0f, 0.0f, 1.0f, 3.0f, 6.0f};
   RunInstanceNormQDQTest(TestInputDef<float>({2, 2, 3}, false, input_data),
@@ -137,21 +150,21 @@ TEST_F(QnnHTPBackendTests, InstanceNormU8Rank3_BatchSizeNot1) {
 
 // Test 16-bit QDQ InstanceNormalization with an input of rank 3 with N != 1,
 // which requires wrapping the QNN InstanceNorm op with reshapes.
-TEST_F(QnnHTPBackendTests, InstanceNormU16Rank3_BatchSizeNot1) {
+TEST_F(QnnHTPBackendTests, InstanceNormU16U8Rank3_BatchSizeNot1) {
   std::vector<float> input_data = {6.0f, 4.0f, 2.0f, 6.0f, 8.0f, 2.0f,
                                    -8.0f, -6.0f, 0.0f, 1.0f, 3.0f, 6.0f};
-  RunInstanceNormQDQTest<uint16_t>(TestInputDef<float>({2, 2, 3}, false, input_data),
-                                   TestInputDef<float>({2}, true, {1.0f, 2.0f}),
-                                   TestInputDef<float>({2}, true, {1.0f, 3.0f}),
-                                   {},
-                                   ExpectedEPNodeAssignment::All,
-                                   true);  // Use contrib Q/DQ ops for 16bit support.
+  RunInstanceNormQDQTest<uint16_t, uint8_t>(TestInputDef<float>({2, 2, 3}, false, input_data),
+                                            TestInputDef<float>({2}, true, {1.0f, 2.0f}),
+                                            TestInputDef<float>({2}, true, {1.0f, 3.0f}),
+                                            {},
+                                            ExpectedEPNodeAssignment::All,
+                                            true);  // Use contrib Q/DQ ops for 16bit support.
 }
 
 // Test 8-bit QDQ InstanceNormalization with an input of rank 3 with N != 1,
 // which requires wrapping the QNN InstanceNorm op with reshapes.
 // Input 0 is an initializer.
-TEST_F(QnnHTPBackendTests, InstanceNormU8Rank3_BatchSizeNot1_Initializer) {
+TEST_F(QnnHTPBackendTests, InstanceNormU8U8Rank3_BatchSizeNot1_Initializer) {
   std::vector<float> input_data = {6.0f, 4.0f, 2.0f, 6.0f, 8.0f, 2.0f,
                                    -8.0f, -6.0f, 0.0f, 1.0f, 3.0f, 6.0f};
   RunInstanceNormQDQTest(TestInputDef<float>({2, 2, 3}, true, input_data),
@@ -164,19 +177,19 @@ TEST_F(QnnHTPBackendTests, InstanceNormU8Rank3_BatchSizeNot1_Initializer) {
 // Test 16-bit QDQ InstanceNormalization with an input of rank 3 with N != 1,
 // which requires wrapping the QNN InstanceNorm op with reshapes.
 // Input 0 is an initializer.
-TEST_F(QnnHTPBackendTests, InstanceNormU16Rank3_BatchSizeNot1_Initializer) {
+TEST_F(QnnHTPBackendTests, InstanceNormU16U8Rank3_BatchSizeNot1_Initializer) {
   std::vector<float> input_data = {6.0f, 4.0f, 2.0f, 6.0f, 8.0f, 2.0f,
                                    -8.0f, -6.0f, 0.0f, 1.0f, 3.0f, 6.0f};
-  RunInstanceNormQDQTest<uint16_t>(TestInputDef<float>({2, 2, 3}, true, input_data),
-                                   TestInputDef<float>({2}, true, {1.0f, 2.0f}),
-                                   TestInputDef<float>({2}, false, {1.0f, 3.0f}),
-                                   {},
-                                   ExpectedEPNodeAssignment::All,
-                                   true);  // Use contrib Q/DQ ops for 16-bit support.
+  RunInstanceNormQDQTest<uint16_t, uint8_t>(TestInputDef<float>({2, 2, 3}, true, input_data),
+                                            TestInputDef<float>({2}, true, {1.0f, 2.0f}),
+                                            TestInputDef<float>({2}, false, {1.0f, 3.0f}),
+                                            {},
+                                            ExpectedEPNodeAssignment::All,
+                                            true);  // Use contrib Q/DQ ops for 16-bit support.
 }
 
 // Check that QNN InstanceNorm operator does not handle inputs with rank > 4.
-TEST_F(QnnHTPBackendTests, InstanceNormU8Rank5) {
+TEST_F(QnnHTPBackendTests, InstanceNormU8U8Rank5) {
   RunInstanceNormQDQTest(TestInputDef<float>({1, 2, 3, 3, 3}, false, -10.0f, 10.0f),
                          TestInputDef<float>({2}, true, -2.0f, 2.0f),
                          TestInputDef<float>({2}, true, -3.0f, 3.0f),


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- In the InstanceNormOpBuilder, when inputs[1] (scale) is constant and running on NPU backend, transform S8 scale into U8 scale since Qnn Htp does not support SFIXED InstanceNorm scale.
- Allow RunInstanceNormQDQTest to specify different data types for inputs[0] (data) and inputs[1] (scale)
- Add corresponding unit test QnnHTPBackendTests.InstanceNormU8S8


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- Prevent InstanceNormOp from fallback to CPU on SFIXED scale


