### PR TITLE
Support 8 bit weights unpacked mode compute in MatmulNBits kernel

### DIFF
--- a/onnxruntime/contrib_ops/cpu/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/matmul_nbits.cc
@@ -752,9 +752,11 @@ Status MatMulNBits<T1>::Compute(OpKernelContext* ctx) const {
   }
 
   // TODO(hasesh): Should this logging level be warning ?
-  LOGS(ctx->Logger(), INFO) << MakeString("Using unpacked compute mode for the Matmul operation ",
+  LOGS(ctx->Logger(), INFO) << MakeString("Falling back to using unpacked compute mode for the Matmul operation ",
                                           "(i.e.) the weights will be de-quantized to fp32 before invoking "
-                                          "the fp32 Matmul operation");
+                                          "the fp32 Matmul kernel."
+                                          "This is because MLAS doesn't have an optimized quantized kernel "
+                                          "for the requested compute configuration.");
 
   return ComputeBUnpacked(a, b, scales, zero_points, reorder_idx, bias, y, allocator, thread_pool, helper);
 }

--- a/onnxruntime/contrib_ops/cpu/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/matmul_nbits.cc
@@ -7,6 +7,7 @@
 #include <type_traits>
 
 #include "core/common/common.h"
+#include "core/common/make_string.h"
 #include "core/common/narrow.h"
 #include "core/common/safeint.h"
 #include "core/framework/op_kernel.h"
@@ -440,8 +441,6 @@ Status MatMulNBits<float>::ComputeBUnpacked(const Tensor* a,
                                             AllocatorPtr& allocator,
                                             concurrency::ThreadPool* thread_pool,
                                             const MatMulComputeHelper& helper) const {
-  ORT_ENFORCE(nbits_ == 4, "Only 4b quantization is supported for unpacked compute.");
-
   const auto* a_data = a->Data<float>();
   const uint8_t* b_data = b->Data<uint8_t>();
   const auto* scales_data = scales->Data<float>();
@@ -460,19 +459,35 @@ Status MatMulNBits<float>::ComputeBUnpacked(const Tensor* a,
   auto tmp_b_data_ptr = IAllocator::MakeUniquePtr<float>(allocator, SafeInt<size_t>(K_) * N_, true);
 
   if ((reorder_idx_data == nullptr) && (!zero_points || !zero_points->IsDataType<float>())) {
-    // dequantize b, only 4b quantization is supported for now
-    MlasDequantizeBlockwise<float, 4>(
-        tmp_b_data_ptr.get(),                           // dequantized output
-        b_data,                                         // quantized input
-        scales_data,                                    // quantization scales
-        static_cast<const uint8_t*>(zero_points_data),  // quantization zero points
-        static_cast<int32_t>(block_size_),              // quantization block size
-        column_wise_quant_,                             // columnwise quantization or row-wise
-        static_cast<int32_t>(K_),                       // number of rows in quantized input
-        static_cast<int32_t>(N_),                       // number of columns in quantized input
-        thread_pool);
+      if (nbits_ == 4) {
+          MlasDequantizeBlockwise<float, 4>(
+              tmp_b_data_ptr.get(),                           // dequantized output
+              b_data,                                         // quantized input
+              scales_data,                                    // quantization scales
+              static_cast<const uint8_t*>(zero_points_data),  // quantization zero points
+              static_cast<int32_t>(block_size_),              // quantization block size
+              column_wise_quant_,                             // columnwise quantization or row-wise
+              static_cast<int32_t>(K_),                       // number of rows in quantized input
+              static_cast<int32_t>(N_),                       // number of columns in quantized input
+              thread_pool);
+      } else {  // If it isn't 4bit, it has to be 8-bit quantization
+        MlasDequantizeBlockwise<float, 8>(
+            tmp_b_data_ptr.get(),                           // dequantized output
+            b_data,                                         // quantized input
+            scales_data,                                    // quantization scales
+            static_cast<const uint8_t*>(zero_points_data),  // quantization zero points
+            static_cast<int32_t>(block_size_),              // quantization block size
+            column_wise_quant_,                             // columnwise quantization or row-wise
+            static_cast<int32_t>(K_),                       // number of rows in quantized input
+            static_cast<int32_t>(N_),                       // number of columns in quantized input
+            thread_pool);
+      } 
   } else {
+    // Hitting any of the below is very rare
     ORT_ENFORCE(column_wise_quant_, "Row-wise quantization is not supported for now");
+    ORT_ENFORCE(nbits_ == 4, "Only 4b quantization is supported for unpacked compute using "
+                             "non-MLAS de-quantization for now");
+
     // !!!!!!!!!!!!!! naive implementation, need to be optimized !!!!!!!!!!!!!!
     if (zero_points && zero_points->IsDataType<float>()) {
       DequantizeBlockwise<float, float>(
@@ -550,7 +565,6 @@ Status MatMulNBits<MLFloat16>::ComputeBUnpacked(const Tensor* a,
                                                 AllocatorPtr& allocator,
                                                 concurrency::ThreadPool* thread_pool,
                                                 const MatMulComputeHelper& helper) const {
-  ORT_ENFORCE(nbits_ == 4, "Only 4b quantization is supported for unpacked compute.");
   const auto* a_data = a->Data<MLFloat16>();
   const uint8_t* b_data = b->Data<uint8_t>();
   const auto* scales_data = scales->Data<MLFloat16>();
@@ -580,19 +594,36 @@ Status MatMulNBits<MLFloat16>::ComputeBUnpacked(const Tensor* a,
   auto tmp_b_data_ptr = IAllocator::MakeUniquePtr<float>(allocator, SafeInt<size_t>(K_) * N_, true);
 
   if ((reorder_idx_data == nullptr) && (!zero_points || !zero_points->IsDataType<MLFloat16>())) {
-    // dequantize b, only 4b quantization is supported for now
-    MlasDequantizeBlockwise<float, 4>(
-        tmp_b_data_ptr.get(),                           // dequantized output
-        b_data,                                         // quantized input
-        scales_ptr,                                     // quantization scales
-        static_cast<const uint8_t*>(zero_points_data),  // quantization zero points
-        static_cast<int32_t>(block_size_),              // quantization block size
-        column_wise_quant_,                             // columnwise quantization or row-wise
-        static_cast<int32_t>(K_),                       // number of rows in quantized input
-        static_cast<int32_t>(N_),                       // number of columns in quantized input
-        thread_pool);
+    if (nbits_ == 4) {
+      MlasDequantizeBlockwise<float, 4>(
+          tmp_b_data_ptr.get(),                           // dequantized output
+          b_data,                                         // quantized input
+          scales_ptr,                                     // quantization scales
+          static_cast<const uint8_t*>(zero_points_data),  // quantization zero points
+          static_cast<int32_t>(block_size_),              // quantization block size
+          column_wise_quant_,                             // columnwise quantization or row-wise
+          static_cast<int32_t>(K_),                       // number of rows in quantized input
+          static_cast<int32_t>(N_),                       // number of columns in quantized input
+          thread_pool);
+    } else {  // If it isn't 4bit, it has to be 8-bit quantization
+      MlasDequantizeBlockwise<float, 8>(
+          tmp_b_data_ptr.get(),                           // dequantized output
+          b_data,                                         // quantized input
+          scales_ptr,                                     // quantization scales
+          static_cast<const uint8_t*>(zero_points_data),  // quantization zero points
+          static_cast<int32_t>(block_size_),              // quantization block size
+          column_wise_quant_,                             // columnwise quantization or row-wise
+          static_cast<int32_t>(K_),                       // number of rows in quantized input
+          static_cast<int32_t>(N_),                       // number of columns in quantized input
+          thread_pool);
+    }
   } else {
+    // Hitting any of the below is very rare
     ORT_ENFORCE(column_wise_quant_, "Row-wise quantization is not supported for now");
+    ORT_ENFORCE(nbits_ == 4,
+                "Only 4b quantization is supported for unpacked compute using "
+                "non-MLAS de-quantization for now");
+
     // !!!!!!!!!!!!!! naive implementation, need to be optimized !!!!!!!!!!!!!!
     if (zero_points && zero_points->IsDataType<MLFloat16>()) {
       DequantizeBlockwise<float, MLFloat16>(
@@ -719,6 +750,11 @@ Status MatMulNBits<T1>::Compute(OpKernelContext* ctx) const {
       return ComputeBPacked(a, scales, zero_points, bias, y, allocator, thread_pool, helper);
     }
   }
+
+  // TODO(hasesh): Should this logging level be warning ?
+  LOGS(ctx->Logger(), INFO) << MakeString("Using unpacked compute mode for the Matmul operation ",
+                                          "(i.e.) the weights will be de-quantized to fp32 before invoking "
+                                          "the fp32 Matmul operation");
 
   return ComputeBUnpacked(a, b, scales, zero_points, reorder_idx, bias, y, allocator, thread_pool, helper);
 }

--- a/onnxruntime/test/contrib_ops/matmul_8bits_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_8bits_test.cc
@@ -159,6 +159,7 @@ void RunTest8Bits(const TestOptions8Bits& opts) {
     test.AddOptionalInputEdge<uint8_t>();
   }
 
+  // Account for deprecated "g_idx" input
   test.AddOptionalInputEdge<int32_t>();
 
   if (bias.has_value()) {
@@ -282,6 +283,45 @@ TEST(MatMulNBits, Float32_8b_AccuracyLevel4) {
   TestMatMul8BitsTyped<float, 100, 288, 93, 128, 4>();
   TestMatMul8BitsTyped<float, 100, 288, 1234, 16, 4>();
   TestMatMul8BitsTyped<float, 2, 5120, 3072, 32, 4>();
+}
+
+TEST(MatMulNBits, Float32_8b_AccuracyLevel1) {
+  // At the time of writing these tests, Fp32 activations + 8 bit weights + Accuracy level 1
+  // do not have MLAS optimized kernels on any platform and hence this will use the "unpacked"
+  // compute mode (i.e.) de-quantize the 8 bit weights to fp32 and invoke vanilla fp32 Gemm
+  // in MLAS. This test helps keep that path tested.
+  TestMatMul8BitsTyped<float, 1, 1, 16, 16, 1>();
+  TestMatMul8BitsTyped<float, 1, 2, 16, 16, 1>();
+  TestMatMul8BitsTyped<float, 1, 32, 16, 16, 1>();
+  TestMatMul8BitsTyped<float, 1, 4, 32, 16, 1>();
+  TestMatMul8BitsTyped<float, 2, 4, 32, 16, 1>();
+  TestMatMul8BitsTyped<float, 1, 4, 64, 16, 1>();
+  TestMatMul8BitsTyped<float, 1, 32, 16, 128, 1>();
+  TestMatMul8BitsTyped<float, 1, 256, 32, 16, 1>();
+  TestMatMul8BitsTyped<float, 1, 288, 16, 16, 1>();
+  TestMatMul8BitsTyped<float, 1, 288, 1024, 16, 1>();
+  TestMatMul8BitsTyped<float, 1, 288, 1024, 128, 1>();
+  TestMatMul8BitsTyped<float, 2, 288, 1024, 128, 1>();
+  TestMatMul8BitsTyped<float, 1, 40, 576, 32, 1>();
+  TestMatMul8BitsTyped<float, 2, 40, 576, 32, 1>();
+  TestMatMul8BitsTyped<float, 1, 288, 93, 32, 1>();
+  TestMatMul8BitsTyped<float, 1, 288, 93, 128, 1>();
+  TestMatMul8BitsTyped<float, 1, 288, 1234, 16, 1>();
+  TestMatMul8BitsTyped<float, 2, 1, 16, 16, 1>();
+  TestMatMul8BitsTyped<float, 2, 2, 16, 16, 1>();
+  TestMatMul8BitsTyped<float, 100, 1, 16, 16, 1>();
+  TestMatMul8BitsTyped<float, 100, 2, 16, 16, 1>();
+  TestMatMul8BitsTyped<float, 100, 32, 16, 16, 1>();
+  TestMatMul8BitsTyped<float, 100, 32, 32, 16, 1>();
+  TestMatMul8BitsTyped<float, 100, 32, 16, 128, 1>();
+  TestMatMul8BitsTyped<float, 100, 288, 16, 16, 1>();
+  TestMatMul8BitsTyped<float, 100, 288, 1024, 16, 1>();
+  TestMatMul8BitsTyped<float, 100, 288, 1024, 128, 1>();
+  TestMatMul8BitsTyped<float, 100, 288, 192, 64, 1>();
+  TestMatMul8BitsTyped<float, 100, 288, 93, 32, 1>();
+  TestMatMul8BitsTyped<float, 100, 288, 93, 128, 1>();
+  TestMatMul8BitsTyped<float, 100, 288, 1234, 16, 1>();
+  TestMatMul8BitsTyped<float, 2, 5120, 3072, 32, 1>();
 }
 
 #if defined(USE_CUDA) || defined(USE_WEBGPU)


### PR DESCRIPTION
### Description

MLAS doesn't have optimzed kernel implementations for 8-bit weights to support all user requested configurations (as allowed per the `MatMulNBits` op kernel spec) For example, only `accuracy_level` of 4 is supported when weights are 8 bits. In this case, provide a "fallback" execution path like the one available for 4 bit weights.

This change: 
 
1. Adds an execution path in the "unpacked compute" mode for 8-bit weights in `MatmulNBits` kernel
 as MlasDequantize already supports 8 bit weights
          1.1 Hitting the non-MLAS de-quantization path which doesn't support 8 bits should be very rare and an enforce is added to guard against hitting that

2. Added logging to alert users that the non-optimal "unpacked compute" mode is being used in the `MatmulNBits` kernel 

### Motivation and Context
Prevent users from hitting errors if MLAS doesn't host optimized kernels for 8 bit weights


