### PR TITLE
[ROCm EP]Add ROCm execution provider to excluded EP for test with Cuda EP

### DIFF
--- a/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
@@ -2381,7 +2381,7 @@ TEST(ResizeOpTest, NoAntialias_AlignCorners_Cubic_Floor_NHWC) {
     23.0000f, 24.0000f,
   };
   // clang-format on
-  InlinedVector<std::string_view> excluded_eps = {kCudaExecutionProvider};
+  InlinedVector<std::string_view> excluded_eps = {kCudaExecutionProvider, kRocmExecutionProvider};
   TestAntialiasing(
       {{"antialias", "0"},
        {"coordinate_transformation_mode", "align_corners"},


### PR DESCRIPTION
Need this since ROCm EP just hipifies the CUDA kernel's used for this. Will give false failures when in fact CUDA EP is doing the same thing

### Description
<!-- Describe your changes. -->
Adds ROCmExecutionprovider as additional exclude on test that CudaExecutionProvider is failing on. 


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Since ROCm EP performs a HIPIFY on the CUDA EP kernels to use the equivalent functionality in ROCm to achieve inference, any errors or gaps we find in the CUDA ep will translate accordingly to the ROCm EP. Need to add the exclude here to this newly added test
