### PR TITLE
Update nv_basic_test.cc

### DIFF
--- a/onnxruntime/test/providers/nv_tensorrt_rtx/nv_basic_test.cc
+++ b/onnxruntime/test/providers/nv_tensorrt_rtx/nv_basic_test.cc
@@ -35,9 +35,9 @@ class NvExecutionProviderTest : public ::testing::Test {
     } else if constexpr (std::is_same<T, float>::value) {
       dtype_name = "fp32";
     } else if constexpr (std::is_same<T, BFloat16>::value) {
-      dtype_name = "fp16";
-    } else if constexpr (std::is_same<T, MLFloat16>::value) {
       dtype_name = "bf16";
+    } else if constexpr (std::is_same<T, MLFloat16>::value) {
+      dtype_name = "fp16";
     } else if constexpr (std::is_same<T, int8_t>::value) {
       dtype_name = "int8";
     } else if constexpr (std::is_same<T, uint8_t>::value) {


### PR DESCRIPTION
### Description
Corrected dtype_name for the respective float16 implementations, previously MLFloat16 would return bf16 rather than fp16, and vice-versa.


### Motivation and Context
It looked wrong but passed the tests, I don't fully comprehend what the test suite is doing to try and improve it. I'd be willing to implement any pointers. 


