### PR TITLE
[webgpu] Restore FP16 math in flash attention generation

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
@@ -574,8 +574,8 @@ Status FlashAttentionDecodeQKTProgram::GenerateShaderCode(ShaderHelper& shader) 
                                     << "const sub_tile_count = " << WorkgroupSizeX() / tile_size_k_vec << "u;\n";
   shader.AdditionalImplementation() << R"ADDNL_FN(
 var<workgroup> tile_q: array<q_value_t, tile_size_k_vec>;
-var<workgroup> inner_qk_values: array<array<f32, tile_size_k_vec>, tile_size>;
-var<workgroup> tile_qk: array<f32, tile_size>;
+var<workgroup> inner_qk_values: array<array<q_element_t, tile_size_k_vec>, tile_size>;
+var<workgroup> tile_qk: array<q_element_t, tile_size>;
 )ADDNL_FN";
 
   if (has_attention_bias_) {
@@ -607,11 +607,11 @@ var<workgroup> tile_qk: array<f32, tile_size>;
         tile_q[local_idx] = q[q_offset + k + local_idx];
       }
       workgroupBarrier();
-      let q_data = vec4<f32>(tile_q[local_col]);
+      let q_data = tile_q[local_col] * q_element_t(uniforms.alpha);
       if (k + local_col < uniforms.head_size_vec) {
         for (var row_offset = 0u; row_offset < tile_size; row_offset += sub_tile_count) {
           if (total_seq_offset + row_offset + local_row < total_sequence_length) {
-            inner_qk_values[row_offset + local_row][local_col] += dot(vec4<f32>(present_key[present_offset + (total_seq_offset + row_offset + local_row) * uniforms.head_size_vec + k + local_col]), q_data);
+            inner_qk_values[row_offset + local_row][local_col] += dot(present_key[present_offset + (total_seq_offset + row_offset + local_row) * uniforms.head_size_vec + k + local_col], q_data);
           }
         }
       }
@@ -619,13 +619,13 @@ var<workgroup> tile_qk: array<f32, tile_size>;
     }
 
     if (local_idx < tile_size && total_seq_offset + local_idx < total_sequence_length && head_idx < uniforms.num_heads) {
-      var sum = f32(0);
+      var sum = q_element_t(0);
       for (var i = 0u; i < tile_size_k_vec; i++) {
         sum += inner_qk_values[local_idx][i];
       }
 
       let output_idx = head_idx * total_sequence_length + total_seq_offset + local_idx;
-      sum = sum * uniforms.alpha + f32(loadAttentionBias(output_idx));
+      sum = sum + loadAttentionBias(output_idx);
       tile_qk[local_idx] = sum;
       output[output_idx] = sum;
     }
@@ -745,7 +745,7 @@ var<workgroup> qkv_values: array<array<present_value_value_t, tile_size_k_vec>, 
       }
 
       if (total_seq_offset + local_idx < total_sequence_length) {
-        tile_qk[local_idx] = present_value_element_t(exp(qk[head_idx * total_sequence_length + total_seq_offset + local_idx] - g_max) / g_sum);
+        tile_qk[local_idx] = present_value_element_t(exp(f32(qk[head_idx * total_sequence_length + total_seq_offset + local_idx]) - g_max) / g_sum);
       }
     }
     for (var k: u32 = 0u; k < uniforms.head_size_vec; k += tile_size_k_vec) {
@@ -926,7 +926,7 @@ Status ApplyFlashAttention(const Tensor* Q, const Tensor* K, const Tensor* V, co
   const TensorShapeVector qk_dims({parameters.batch_size_, parameters.num_heads_,
                                    parameters.sequence_length_, parameters.total_sequence_length_});
   const TensorShape qk_shape(qk_dims);
-  Tensor qk = context.CreateGPUTensor(DataTypeImpl::GetType<float>(), qk_shape);
+  Tensor qk = context.CreateGPUTensor(Q->DataType(), qk_shape);
   constexpr uint32_t tile_size = 64;
   const uint32_t num_total_seq_length_tile = (parameters.total_sequence_length_ + tile_size - 1) / tile_size;
   // The metadata is used to store the max and sum of each tile.


### PR DESCRIPTION
This PR restores FP16 math in flash attention generation shader. It follows the changes in #24953 to use scale to multiply Q first instead of calculating it after QK to avoid data overflow in FP16.


