### PR TITLE
Split DML nuget packaging jobs to a dedicated pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -103,7 +103,10 @@ extends:
       spotBugs:
         enabled: false
         justificationForDisabling: "Getting ##[error]1. SpotBugs Error gdn.unknownFormatResult - File: spotbugs.xml, which indicates that SpotBugs found one or more errors, which are not handled by the Guardian right now."
-
+      codeql:
+        compiled:
+          enabled: false
+          justificationForDisabling: 'CodeQL is taking nearly 6 hours resulting in timeouts in our production pipelines'
     stages:
     - template: stages/set_packaging_variables_stage.yml
       parameters:
@@ -173,71 +176,3 @@ extends:
         sln_platform: 'arm64'
         DoEsrp: ${{ parameters.DoEsrp }}
         DependsOnStageName: Windows_Nodejs_Packaging_x64
-
-    - template: nuget/templates/dml-vs-2022.yml
-      parameters:
-        IsReleaseBuild: ${{ parameters.IsReleaseBuild }}
-        ArtifactName: 'drop-nuget-dml'
-        StageName: 'Windows_CI_GPU_DML_Dev'
-        BuildCommand: --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --enable_onnx_tests --enable_wcos --use_telemetry --use_dml --enable_generic_interface --build_nodejs --cmake_generator "Visual Studio 17 2022" --use_vcpkg --use_vcpkg_ms_internal_asset_cache
-        BuildArch: 'x64'
-        msbuildArchitecture: 'amd64'
-        EnvSetupScript: 'setup_env.bat'
-        sln_platform: 'x64'
-        DoDebugBuild: 'false'
-        DoNugetPack: 'true'
-        DoEsrp: ${{ parameters.DoEsrp }}
-        NuPackScript: |
-          msbuild $(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.proj /p:Configuration=RelWithDebInfo /t:CreatePackage /p:OrtPackageId=Microsoft.ML.OnnxRuntime.DirectML /p:IsReleaseBuild=${{ parameters.IsReleaseBuild }} /p:CurrentData=$(BuildDate) /p:CurrentTime=$(BuildTime)
-          copy $(Build.SourcesDirectory)\csharp\src\Microsoft.ML.OnnxRuntime\bin\RelWithDebInfo\*.nupkg $(Build.ArtifactStagingDirectory)
-          copy $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\*.nupkg $(Build.ArtifactStagingDirectory)
-          mkdir $(Build.ArtifactStagingDirectory)\testdata
-          copy $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\custom_op_library.* $(Build.ArtifactStagingDirectory)\testdata
-
-    - template: nuget/templates/dml-vs-2022.yml
-      parameters:
-        IsReleaseBuild: ${{ parameters.IsReleaseBuild }}
-        ArtifactName: 'drop-win-dml-x86-zip'
-        StageName: 'Windows_CI_GPU_DML_Dev_x86'
-        BuildCommand: --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --enable_onnx_tests --enable_wcos --use_telemetry --use_dml --enable_generic_interface --cmake_generator "Visual Studio 17 2022" --use_vcpkg --use_vcpkg_ms_internal_asset_cache
-        BuildArch: 'x86'
-        EnvSetupScript: 'setup_env_x86.bat'
-        sln_platform: 'Win32'
-        DoDebugBuild: 'false'
-        DoNugetPack: 'true'
-        DoEsrp: ${{ parameters.DoEsrp }}
-        RunTests: 'false'
-        NuPackScript: |
-          msbuild $(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.proj /p:Configuration=RelWithDebInfo /p:TargetArchitecture=x86 /t:CreatePackage /p:OrtPackageId=Microsoft.ML.OnnxRuntime.DirectML /p:IsReleaseBuild=${{ parameters.IsReleaseBuild }}
-          cd $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\
-          ren Microsoft.ML.OnnxRuntime.DirectML.* win-dml-x86.zip
-          copy $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\win-dml-x86.zip $(Build.ArtifactStagingDirectory)
-          mkdir $(Build.ArtifactStagingDirectory)\testdata
-          copy $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\custom_op_library.* $(Build.ArtifactStagingDirectory)\testdata
-
-    - template: nuget/templates/dml-vs-2022.yml
-      parameters:
-        IsReleaseBuild: ${{ parameters.IsReleaseBuild }}
-        ArtifactName: 'drop-win-dml-arm64-zip'
-        StageName: 'Windows_CI_GPU_DML_Dev_arm64'
-        BuildCommand: --build_dir $(Build.BinariesDirectory) --arm64 --skip_submodule_sync --build_shared_lib --enable_onnx_tests --enable_wcos --use_telemetry --use_dml --enable_generic_interface --build_nodejs --cmake_generator "Visual Studio 17 2022" --use_vcpkg --use_vcpkg_ms_internal_asset_cache
-        BuildArch: 'x64'
-        EnvSetupScript: 'setup_env.bat'
-        sln_platform: 'arm64'
-        DoDebugBuild: 'false'
-        DoNugetPack: 'true'
-        DoEsrp: ${{ parameters.DoEsrp }}
-        RunTests: 'false'
-        NuPackScript: |
-          msbuild $(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.proj /p:Configuration=RelWithDebInfo /p:TargetArchitecture=arm64 /t:CreatePackage /p:OrtPackageId=Microsoft.ML.OnnxRuntime.DirectML /p:IsReleaseBuild=${{ parameters.IsReleaseBuild }}
-          cd $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\
-          ren Microsoft.ML.OnnxRuntime.DirectML.* win-dml-arm64.zip
-          copy $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\win-dml-arm64.zip $(Build.ArtifactStagingDirectory)
-          mkdir $(Build.ArtifactStagingDirectory)\testdata
-          copy $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\custom_op_library.* $(Build.ArtifactStagingDirectory)\testdata
-
-
-
-    - template: stages/nuget_dml_packaging_stage.yml
-      parameters:
-        DoEsrp: ${{ parameters.DoEsrp }}

--- a/tools/ci_build/github/azure-pipelines/dml-nuget-packaging.yml
+++ b/tools/ci_build/github/azure-pipelines/dml-nuget-packaging.yml
@@ -16,6 +16,26 @@ parameters:
   type: boolean
   default: false
 
+- name: IsReleaseBuild
+  displayName: Is a release build? Set it to true if you are doing an ONNX Runtime release.
+  type: boolean
+  default: false
+
+- name: PreReleaseVersionSuffixString
+  displayName: Suffix added to pre-release package version. Only used if IsReleaseBuild is true. Denotes the type of pre-release package.
+  type: string
+  values:
+  - alpha
+  - beta
+  - rc
+  - none
+  default: none
+
+- name: PreReleaseVersionSuffixNumber
+  displayName: Number added to pre-release package version. Only used if IsReleaseBuild is true. Denotes the sequence of a pre-release package.
+  type: number
+  default: 0
+
 extends:
   # The pipeline extends the 1ES PT which will inject different SDL and compliance tasks.
   # For non-production pipelines, use "Unofficial" as defined below.
@@ -40,6 +60,11 @@ extends:
           enabled: false
           justificationForDisabling: 'CodeQL is taking nearly 6 hours resulting in timeouts in our production pipelines'
     stages:
+    - template: stages/set_packaging_variables_stage.yml
+      parameters:
+        IsReleaseBuild: ${{ parameters.IsReleaseBuild }}
+        PreReleaseVersionSuffixString: ${{ parameters.PreReleaseVersionSuffixString }}
+        PreReleaseVersionSuffixNumber: ${{ parameters.PreReleaseVersionSuffixNumber }}
     - template: nuget/templates/dml-vs-2022.yml
       parameters:
         IsReleaseBuild: ${{ parameters.IsReleaseBuild }}

--- a/tools/ci_build/github/azure-pipelines/dml-nuget-packaging.yml
+++ b/tools/ci_build/github/azure-pipelines/dml-nuget-packaging.yml
@@ -1,3 +1,10 @@
+resources:
+  repositories:
+  - repository: 1esPipelines
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
 parameters:
 - name: DoEsrp
   displayName: Run code sign tasks? Must be true if you are doing an ONNX Runtime release

--- a/tools/ci_build/github/azure-pipelines/dml-nuget-packaging.yml
+++ b/tools/ci_build/github/azure-pipelines/dml-nuget-packaging.yml
@@ -1,0 +1,79 @@
+parameters:
+- name: DoEsrp
+  displayName: Run code sign tasks? Must be true if you are doing an ONNX Runtime release
+  type: boolean
+  default: true
+
+- name: IsReleaseBuild
+  displayName: Is a release build? Set it to true if you are doing an ONNX Runtime release.
+  type: boolean
+  default: false
+
+extends:
+  # The pipeline extends the 1ES PT which will inject different SDL and compliance tasks.
+  # For non-production pipelines, use "Unofficial" as defined below.
+  # For productions pipelines, use "Official".
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  parameters:
+    sdl:
+      binskim:
+        enabled: true
+        analyzeTargetGlob: $(Build.ArtifactStagingDirectory)/**.dll
+      sourceAnalysisPool: "Onnxruntime-Win-CPU-2022"
+      componentgovernance:
+        ignoreDirectories: $(Build.SourcesDirectory)/onnxruntime-inference-examples
+      sourceRepositoriesToScan:
+        exclude:
+        - repository: onnxruntime-inference-examples
+      spotBugs:
+        enabled: false
+        justificationForDisabling: "Getting ##[error]1. SpotBugs Error gdn.unknownFormatResult - File: spotbugs.xml, which indicates that SpotBugs found one or more errors, which are not handled by the Guardian right now."
+      codeql:
+        compiled:
+          enabled: false
+          justificationForDisabling: 'CodeQL is taking nearly 6 hours resulting in timeouts in our production pipelines'
+    stages:
+    - template: nuget/templates/dml-vs-2022.yml
+      parameters:
+        IsReleaseBuild: ${{ parameters.IsReleaseBuild }}
+        ArtifactName: 'drop-nuget-dml'
+        StageName: 'Windows_CI_GPU_DML_Dev'
+        BuildCommand: --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --enable_onnx_tests --enable_wcos --use_telemetry --use_dml --enable_generic_interface --build_nodejs --cmake_generator "Visual Studio 17 2022" --use_vcpkg --use_vcpkg_ms_internal_asset_cache
+        BuildArch: 'x64'
+        msbuildArchitecture: 'amd64'
+        EnvSetupScript: 'setup_env.bat'
+        sln_platform: 'x64'
+        DoDebugBuild: 'false'
+        DoNugetPack: 'true'
+        DoEsrp: ${{ parameters.DoEsrp }}
+        NuPackScript: |
+          msbuild $(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.proj /p:Configuration=RelWithDebInfo /t:CreatePackage /p:OrtPackageId=Microsoft.ML.OnnxRuntime.DirectML /p:IsReleaseBuild=${{ parameters.IsReleaseBuild }} /p:CurrentData=$(BuildDate) /p:CurrentTime=$(BuildTime)
+          copy $(Build.SourcesDirectory)\csharp\src\Microsoft.ML.OnnxRuntime\bin\RelWithDebInfo\*.nupkg $(Build.ArtifactStagingDirectory)
+          copy $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\*.nupkg $(Build.ArtifactStagingDirectory)
+          mkdir $(Build.ArtifactStagingDirectory)\testdata
+          copy $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\custom_op_library.* $(Build.ArtifactStagingDirectory)\testdata
+
+    - template: nuget/templates/dml-vs-2022.yml
+      parameters:
+        IsReleaseBuild: ${{ parameters.IsReleaseBuild }}
+        ArtifactName: 'drop-win-dml-arm64-zip'
+        StageName: 'Windows_CI_GPU_DML_Dev_arm64'
+        BuildCommand: --build_dir $(Build.BinariesDirectory) --arm64 --skip_submodule_sync --build_shared_lib --enable_onnx_tests --enable_wcos --use_telemetry --use_dml --enable_generic_interface --build_nodejs --cmake_generator "Visual Studio 17 2022" --use_vcpkg --use_vcpkg_ms_internal_asset_cache
+        BuildArch: 'x64'
+        EnvSetupScript: 'setup_env.bat'
+        sln_platform: 'arm64'
+        DoDebugBuild: 'false'
+        DoNugetPack: 'true'
+        DoEsrp: ${{ parameters.DoEsrp }}
+        RunTests: 'false'
+        NuPackScript: |
+          msbuild $(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.proj /p:Configuration=RelWithDebInfo /p:TargetArchitecture=arm64 /t:CreatePackage /p:OrtPackageId=Microsoft.ML.OnnxRuntime.DirectML /p:IsReleaseBuild=${{ parameters.IsReleaseBuild }}
+          cd $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\
+          ren Microsoft.ML.OnnxRuntime.DirectML.* win-dml-arm64.zip
+          copy $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\win-dml-arm64.zip $(Build.ArtifactStagingDirectory)
+          mkdir $(Build.ArtifactStagingDirectory)\testdata
+          copy $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\custom_op_library.* $(Build.ArtifactStagingDirectory)\testdata
+
+    - template: stages/nuget_dml_packaging_stage.yml
+      parameters:
+        DoEsrp: ${{ parameters.DoEsrp }}

--- a/tools/ci_build/github/azure-pipelines/dml-nuget-packaging.yml
+++ b/tools/ci_build/github/azure-pipelines/dml-nuget-packaging.yml
@@ -16,11 +16,6 @@ parameters:
   type: boolean
   default: false
 
-- name: IsReleaseBuild
-  displayName: Is a release build? Set it to true if you are doing an ONNX Runtime release.
-  type: boolean
-  default: false
-
 - name: PreReleaseVersionSuffixString
   displayName: Suffix added to pre-release package version. Only used if IsReleaseBuild is true. Denotes the type of pre-release package.
   type: string

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/dml-vs-2022.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/dml-vs-2022.yml
@@ -156,7 +156,7 @@ stages:
               ${{if eq(variables['Build.SourceBranch'], 'refs/heads/main')}}:
                 symbolExpiryTime: 60
               includePublicSymbolServer: true
-              symbolsArtifactName: ${{parameters.artifactNameNoVersionString}}
+              symbolsArtifactName: onnxruntime-dml-nuget-${{ parameters.BuildArch }}
               symbolsVersion: $(Build.BuildId)
               symbolProject: 'ONNX Runtime'
               subscription: 'OnnxrunTimeCodeSign_20240611'

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/dml-vs-2022.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/dml-vs-2022.yml
@@ -23,7 +23,6 @@ parameters:
   IsReleaseBuild: false
 stages:
 - stage: ${{ parameters.StageName }}
-  dependsOn: Setup
   jobs:
   - job: ${{ parameters.StageName }}
     timeoutInMinutes: 200

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/dml-vs-2022.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/dml-vs-2022.yml
@@ -23,6 +23,7 @@ parameters:
   IsReleaseBuild: false
 stages:
 - stage: ${{ parameters.StageName }}
+  dependsOn: Setup
   jobs:
   - job: ${{ parameters.StageName }}
     timeoutInMinutes: 200

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
@@ -9,7 +9,6 @@ parameters:
   # For training packages, to differentiate the artifact name we add '-training' suffix. This needs to be passed from
   # the parent pipeline.
   TestDataArtifactSuffix: ''
-  Skipx86Tests: 'false'
   CudaVersion: ''
   SpecificArtifact: false
   BuildId: ''
@@ -89,15 +88,6 @@ stages:
       env:
         PACKAGENAME: ${{ parameters.NugetPackageName }}
 
-    - ${{ if ne(parameters['Skipx86Tests'], 'true') }}:
-        - script: |
-           @echo "Running Runtest.bat"
-           test\Microsoft.ML.OnnxRuntime.EndToEndTests\runtest.bat $(Build.BinariesDirectory)\nuget-artifact net8.0 x86 $(NuGetPackageVersionNumber)
-          workingDirectory: '$(Build.SourcesDirectory)\csharp'
-          displayName: 'Run End to End Test (C#) .Net Core x86'
-          env:
-            PACKAGENAME: ${{ parameters.NugetPackageName }}
-
     # TODO: Add .Net Framework AnyCPU test task
 
     - script: |
@@ -107,15 +97,3 @@ stages:
       displayName: 'Run End to End Test (C#) .NetFramework x64'
       env:
         PACKAGENAME: ${{ parameters.NugetPackageName }}
-
-    - ${{ if ne(parameters['Skipx86Tests'], 'true') }}:
-        - script: |
-           @echo "Running Runtest.bat"
-           test\Microsoft.ML.OnnxRuntime.EndToEndTests\runtest.bat $(Build.BinariesDirectory)\nuget-artifact net462 x86 $(NuGetPackageVersionNumber)
-          workingDirectory: '$(Build.SourcesDirectory)\csharp'
-          displayName: 'Run End to End Test (C#) .NetFramework x86'
-          enabled: false
-          env:
-            PACKAGENAME: ${{ parameters.NugetPackageName }}
-
-    - template: ../../templates/clean-agent-build-directory-step.yml

--- a/tools/ci_build/github/azure-pipelines/py-cuda-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/py-cuda-packaging-pipeline.yml
@@ -49,7 +49,7 @@ extends:
       codeql:
         compiled:
           enabled: false
-          justificationForDisabling: 'CodeQL is taking nearly 4 hours resulting in timeouts in our production pipelines'
+          justificationForDisabling: 'CodeQL is taking nearly 6 hours resulting in timeouts in our production pipelines'
     pool:
       name: 'onnxruntime-Win-CPU-2022'  # Name of your hosted pool
       os: windows  # OS of the image. This value cannot be a variable. Allowed values: windows, linux, macOS

--- a/tools/ci_build/github/azure-pipelines/stages/nuget-combine-cuda-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nuget-combine-cuda-stage.yml
@@ -66,7 +66,6 @@ stages:
     NugetPackageName: 'Microsoft.ML.OnnxRuntime.Gpu'
     ArtifactSuffix: 'GPU'
     StageSuffix: 'GPU'
-    Skipx86Tests: 'true'
     CudaVersion: ${{ parameters.CudaVersion }}
     SpecificArtifact: ${{ parameters.SpecificArtifact }}
     BuildId: ${{ parameters.BuildId }}
@@ -78,7 +77,6 @@ stages:
     ArtifactSuffix: 'GPU'
     StageSuffix: 'GPU'
     MoreSuffix: '_Windows'
-    Skipx86Tests: 'true'
     CudaVersion: ${{ parameters.CudaVersion }}
     SpecificArtifact: ${{ parameters.SpecificArtifact }}
     BuildId: ${{ parameters.BuildId }}

--- a/tools/ci_build/github/azure-pipelines/stages/nuget_dml_packaging_stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nuget_dml_packaging_stage.yml
@@ -7,7 +7,6 @@ stages:
 - stage: NuGet_Packaging_DML
   dependsOn:
   - Windows_CI_GPU_DML_Dev
-  - Windows_CI_GPU_DML_Dev_x86
   - Windows_CI_GPU_DML_Dev_arm64
   condition: succeeded()
   jobs:
@@ -48,15 +47,6 @@ stages:
                 unzip %%~ni.zip -d %%~ni
                 del /Q %%~ni.zip
         
-                unzip win-dml-x86.zip -d win-x86
-                mkdir %%~ni\runtimes\win-x86
-                mkdir %%~ni\runtimes\win-x86\native
-        
-                move win-x86\runtimes\win-x86\native\onnxruntime.dll %%~ni\runtimes\win-x86\native\onnxruntime.dll
-                move win-x86\runtimes\win-x86\native\onnxruntime.lib %%~ni\runtimes\win-x86\native\onnxruntime.lib
-                move win-x86\runtimes\win-x86\native\onnxruntime.pdb %%~ni\runtimes\win-x86\native\onnxruntime.pdb
-                move win-x86\runtimes\win-x86\native\onnxruntime_providers_shared.dll %%~ni\runtimes\win-x86\native\onnxruntime_providers_shared.dll
-        
                 unzip win-dml-arm64.zip -d win-arm64
                 mkdir %%~ni\runtimes\win-arm64
                 mkdir %%~ni\runtimes\win-arm64\native
@@ -88,7 +78,7 @@ stages:
         PackageType: 'nuget'
         PackagePath: '$(Build.ArtifactStagingDirectory)'
         PackageName: 'Microsoft.ML.OnnxRuntime.DirectML*nupkg'
-        PlatformsSupported: 'win-x64,win-x86,win-arm64'
+        PlatformsSupported: 'win-x64,win-arm64'
         VerifyNugetSigning: ${{ parameters.DoEsrp }}
 
     - task: 1ES.PublishPipelineArtifact@1

--- a/tools/ci_build/github/azure-pipelines/stages/py-cpu-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/py-cpu-packaging-stage.yml
@@ -67,7 +67,9 @@ stages:
     dependsOn: []
     jobs:
     - job: Windows_py_Wheels
-      pool: 'onnxruntime-Win-CPU-2022'
+      pool:
+        name: 'onnxruntime-Win-CPU-2022'
+        os: windows
       strategy:
         matrix:
           Python310_x64:

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -163,20 +163,6 @@ stages:
         targetPath: '$(Build.BinariesDirectory)/artifacts'
         artifactName: 'onnxruntime-ios-full-xcframework'
 
-
-
-- template: win-ci.yml
-  parameters:
-    DoEsrp: ${{ parameters.DoEsrp }}
-    stage_name_suffix: CPU_x86_${{ parameters.BuildVariant }}
-    buildArch: x86
-    msbuildPlatform: Win32
-    packageName: x86
-    buildparameter: ${{ parameters.AdditionalBuildFlags }} ${{ parameters.AdditionalWinBuildFlags}}
-    runTests: ${{ parameters.RunOnnxRuntimeTests }}
-    buildJava: false
-    buildNodejs: false
-
 - template: win-ci.yml
   parameters:
     DoEsrp: ${{ parameters.DoEsrp }}
@@ -296,7 +282,6 @@ stages:
   - Setup
   - Linux_C_API_Packaging_CPU
   - MacOS_C_API_Package_Publish
-  - Windows_Packaging_CPU_x86_${{ parameters.BuildVariant }}
   - Windows_Packaging_CPU_x64_${{ parameters.BuildVariant }}
   - Windows_Packaging_CPU_arm64_${{ parameters.BuildVariant }}
   - Android_Java_API_AAR_Packaging_Full
@@ -322,14 +307,6 @@ stages:
       parameters:
         StepName: 'Download Pipeline Artifact - Win x64'
         ArtifactName: 'onnxruntime-win-x64'
-        TargetPath: '$(Build.BinariesDirectory)/nuget-artifact'
-        SpecificArtifact: ${{ parameters.specificArtifact }}
-        BuildId: ${{ parameters.BuildId }}
-
-    - template: flex-downloadPipelineArtifact.yml
-      parameters:
-        StepName: 'Download win-x86 Pipeline Artifact'
-        ArtifactName: 'onnxruntime-win-x86'
         TargetPath: '$(Build.BinariesDirectory)/nuget-artifact'
         SpecificArtifact: ${{ parameters.specificArtifact }}
         BuildId: ${{ parameters.BuildId }}
@@ -484,7 +461,7 @@ stages:
         PackageType: 'nuget'
         PackagePath: '$(Build.ArtifactStagingDirectory)'
         PackageName: 'Microsoft.ML.OnnxRuntime.*nupkg'
-        PlatformsSupported: 'win-x64,win-x86,linux-x64,linux-arm64,osx-x64'
+        PlatformsSupported: 'win-x64,linux-x64,linux-arm64,osx-x64'
         VerifyNugetSigning: false
 
     - task: 1ES.PublishPipelineArtifact@1
@@ -806,7 +783,6 @@ stages:
 - template: ../nuget/templates/test_win.yml
   parameters:
     AgentPool: 'onnxruntime-Win-CPU-2022'
-    Skipx86Tests: false
     NugetPackageName: 'Microsoft.ML.OnnxRuntime'
     ArtifactSuffix: 'CPU'
     SpecificArtifact: ${{ parameters.SpecificArtifact }}

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-prebuild-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-prebuild-steps.yml
@@ -48,20 +48,6 @@ steps:
       @echo ##vso[task.setvariable variable=vcvarsall]%vcvarsall%
     displayName: 'locate vcvarsall via vswhere'
 
-- ${{ if eq(parameters.BuildArch, 'x86') }}:
-  - script: |
-      @echo off
-      set vswherepath="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-      for /f "usebackq delims=" %%i in (`%vswherepath% -latest -property installationPath`) do (
-        if exist "%%i\VC\Auxiliary\Build\vcvars32.bat" (
-          set vcvarsall="%%i\VC\Auxiliary\Build\vcvars32.bat"
-        )
-      )
-
-      @echo %vcvarsall% will be used as the VC compiler
-      @echo ##vso[task.setvariable variable=vcvarsall]%vcvarsall%
-    displayName: 'locate vcvarsall via vswhere'
-
 - task: BatchScript@1
   displayName: 'Setup VC env'
   inputs:

--- a/tools/ci_build/github/azure-pipelines/templates/ondevice-training-cpu-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/ondevice-training-cpu-packaging-pipeline.yml
@@ -301,7 +301,6 @@ stages:
 - template: ../nuget/templates/test_win.yml
   parameters:
     AgentPool : 'onnxruntime-Win-CPU-2022'
-    Skipx86Tests : false
     NugetPackageName : 'Microsoft.ML.OnnxRuntime.Training'
     ArtifactSuffix: 'Training-CPU'
     StageSuffix: 'Training_CPU'

--- a/tools/ci_build/github/azure-pipelines/templates/publish-nuget-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/publish-nuget-steps.yml
@@ -70,7 +70,6 @@ stages:
               7z.exe l -slt %%~ni.zip runtimes\linux-arm64\native\libonnxruntime.so | findstr /R /C:"^Size = [0-9]*" | for /F "tokens=3" %%a  in ('more') do if not "%%a" == "" echo linux,aarch64,default,%%a >> $(Build.BinariesDirectory)\binary_size_data.txt
               7z.exe l -slt %%~ni.zip runtimes\osx-x64\native\libonnxruntime.dylib | findstr /R /C:"^Size = [0-9]*" | for /F "tokens=3" %%a  in ('more') do if not "%%a" == "" echo osx,x64,default,%%a >> $(Build.BinariesDirectory)\binary_size_data.txt
               7z.exe l -slt %%~ni.zip runtimes\win-x64\native\onnxruntime.dll | findstr /R /C:"^Size = [0-9]*" | for /F "tokens=3" %%a  in ('more') do if not "%%a" == "" echo win,x64,default,%%a >> $(Build.BinariesDirectory)\binary_size_data.txt
-              7z.exe l -slt %%~ni.zip runtimes\win-x86\native\onnxruntime.dll | findstr /R /C:"^Size = [0-9]*" | for /F "tokens=3" %%a  in ('more') do if not "%%a" == "" echo win,x86,default,%%a >> $(Build.BinariesDirectory)\binary_size_data.txt
               )
             )
 

--- a/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
@@ -148,10 +148,6 @@ stages:
             ${{ if contains(parameters.buildparameter, 'use_tensorrt') }}:
               DownloadCUDA: true
               DownloadTRT: true
-      - powershell: |
-          Write-Host "##vso[task.prependpath]C:\Program Files (x86)\dotnet"
-        displayName: 'Append dotnet x86  Directory to PATH'
-        condition: and(succeeded(), eq('${{ parameters.buildArch}}', 'x86'))
 
       - template: set-version-number-variables-step.yml
 


### PR DESCRIPTION
### Description
Split DML nuget packaging jobs to a dedicated pipeline
Remove Windows 32-bit packages from nuget pipelines.

### Motivation and Context
To make the "Zip-Nuget-Java-Nodejs Packaging Pipeline" lighter. 


