### PR TITLE
[QNN EP] Add fixing dynamic input shapes in qnn.preprocess

### DIFF
--- a/onnxruntime/python/tools/qnn/preprocess.py
+++ b/onnxruntime/python/tools/qnn/preprocess.py
@@ -69,6 +69,16 @@ def _parse_arguments():
         help="List of graph output names to be transposed into channel-last.",
     )
 
+    # Fix dynamic input shapes.
+    parser.add_argument(
+        "--dynamic_input_shapes",
+        nargs=2,
+        action="append",
+        type=str,
+        default=None,
+        help="Model input name and desired static shape in comma seprated format, for example: 'input' 1,3,256,256",
+    )
+
     return parser.parse_args()
 
 
@@ -83,6 +93,7 @@ def qnn_preprocess_model(
     external_data_convert_attribute: bool = False,
     inputs_to_make_channel_last: list[str] | None = None,
     outputs_to_make_channel_last: list[str] | None = None,
+    dynamic_input_shapes: list[tuple[str, str]] | None = None,
 ) -> bool:
     """Preprocess ONNX model for QNN.
 
@@ -105,6 +116,8 @@ def qnn_preprocess_model(
             Defaults to None.
         outputs_to_make_channel_last: A list of strs specifying graph output names to be transposed into channel-last.
             Defaults to None.
+        dynamic_input_shapes: A list of tuples specifying model input name to and its static shape in comma seprated
+            format, for example: [('input', '1,3,256,256')]. Defaults to None.
 
     Returns:
         A bool indicating whether the model is modified.
@@ -120,6 +133,7 @@ def qnn_preprocess_model(
         external_data_convert_attribute=external_data_convert_attribute,
         inputs_to_make_channel_last=inputs_to_make_channel_last,
         outputs_to_make_channel_last=outputs_to_make_channel_last,
+        dynamic_input_shapes=dynamic_input_shapes,
     )
 
 
@@ -136,4 +150,5 @@ if __name__ == "__main__":
         external_data_convert_attribute=args.external_data_convert_attribute,
         inputs_to_make_channel_last=args.inputs_to_make_channel_last,
         outputs_to_make_channel_last=args.outputs_to_make_channel_last,
+        dynamic_input_shapes=args.dynamic_input_shapes,
     )

--- a/onnxruntime/python/tools/quantization/execution_providers/qnn/preprocess.py
+++ b/onnxruntime/python/tools/quantization/execution_providers/qnn/preprocess.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import onnx
 
+from .......tools.python.util.onnx_model_utils import fix_output_shapes, make_input_shape_fixed
 from ...fusions import FusionGelu, FusionLayerNormalization
 from ...onnx_model import ONNXModel
 from ...quant_utils import save_and_reload_model_with_shape_infer
@@ -28,6 +29,7 @@ def qnn_preprocess_model(
     external_data_convert_attribute: bool = False,
     inputs_to_make_channel_last: list[str] | None = None,
     outputs_to_make_channel_last: list[str] | None = None,
+    dynamic_input_shapes: list[tuple[str, str]] | None = None,
 ) -> bool:
     """
     If necessary, this method creates a new "pre-processed" model in preparation for
@@ -82,6 +84,8 @@ def qnn_preprocess_model(
             This can potentially improve inference latency for QDQ models running on QNN EP because the
             additional transpose node may allow other transpose nodes inserted during ORT layout transformation
             to cancel out.
+        dynamic_input_shapes: A list of tuples specifying model input name to and its static shape in comma seprated
+            format, for example: [('input', '1,3,256,256')]. Defaults to None.
     """
     modified = False
     model = model_input if isinstance(model_input, onnx.ModelProto) else onnx.load_model(model_input)
@@ -118,6 +122,14 @@ def qnn_preprocess_model(
             fusion_layernorm = FusionLayerNormalization(onnx_model)
             if fusion_layernorm.apply():
                 modified = True
+
+    # Optionally, fix the dynamic input shapes.
+    if dynamic_input_shapes:
+        for input_name, input_shape_str in dynamic_input_shapes:
+            input_shape = [int(i) for i in input_shape_str.split(",")]
+            make_input_shape_fixed(onnx_model.graph(), input_name, input_shape)
+        fix_output_shapes(onnx_model.model)
+        modified = True
 
     # Optionally, transpose inputs and/or outputs to make them "channel-last".
     if inputs_to_make_channel_last or outputs_to_make_channel_last:


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

- Add argument "--dynamic_input_shapes" to fix dynamic input shapes in qnn.preprocess

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

- Because QNN-EP doesn't support dynamic shape, add this argument to support model with dynamic input dims but static input shape after qnn.preprocess.