### PR TITLE
[WebNN] Fix bug in getting the first input name of a WebNN op

### DIFF
--- a/onnxruntime/core/providers/webnn/builders/helper.h
+++ b/onnxruntime/core/providers/webnn/builders/helper.h
@@ -203,11 +203,11 @@ std::unordered_set<const Node*> GetSupportedNodes(const GraphViewer& graph_viewe
                                                   const emscripten::val& wnn_limits,
                                                   const logging::Logger& logger);
 
-// Retrieve the first input name of a WebNN op used for validating supported input data types.
+// Retrieve the first input name of an ONNX op's corresponding WebNN op used for validating supported input data types.
 // WebNN ops have various first input names such as 'a', 'input', 'inputs', etc.
 // All WebNN op inputs are recorded in op_inputs_map.
-inline std::string_view GetWebNNOpFirstInputName(const std::string_view webnn_op_type) {
-  auto it = op_inputs_map.find(webnn_op_type);
+inline std::string_view GetWebNNOpFirstInputName(const std::string_view op_type) {
+  auto it = op_inputs_map.find(op_type);
   if (it != op_inputs_map.end()) {
     for (const auto& input : it->second.inputs) {
       if (input.index == 0) {

--- a/onnxruntime/core/providers/webnn/builders/impl/base_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/base_op_builder.cc
@@ -66,7 +66,7 @@ bool BaseOpBuilder::HasSupportedInputsImpl(const GraphViewer&, const Node& node,
   if (webnn_op_type.empty())
     return false;
 
-  const std::string_view webnn_input_name = GetWebNNOpFirstInputName(webnn_op_type);
+  const std::string_view webnn_input_name = GetWebNNOpFirstInputName(op_type);
   return IsDataTypeSupportedByWebNNOp(op_type, webnn_op_type, input_type, wnn_limits,
                                       webnn_input_name, "input", logger);
 }

--- a/onnxruntime/core/providers/webnn/builders/impl/lrn_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/lrn_op_builder.cc
@@ -156,9 +156,10 @@ bool LRNOpBuilder::HasSupportedInputsImpl(const GraphViewer&, const Node& node,
   }
 
   // Check if the input data type is supported by each decomposed WebNN op.
-  // Decomposed ops include: "add", "averagePool2d", "div", "mul", "pad", "pow" and "transpose".
-  for (const std::string_view webnn_op_type : decomposed_op_map.at(op_type)) {
-    const std::string_view webnn_input_name = GetWebNNOpFirstInputName(webnn_op_type);
+  // Decomposed ops include: "Add", "AveragePool", "Div", "Mul", "Pad", "Pow" and "Transpose".
+  for (const std::string_view decomposed_op_type : decomposed_op_map.at(op_type)) {
+    const std::string_view webnn_op_type = GetWebNNOpType(decomposed_op_type);
+    const std::string_view webnn_input_name = GetWebNNOpFirstInputName(decomposed_op_type);
     if (!IsDataTypeSupportedByWebNNOp(op_type, webnn_op_type, input_type, wnn_limits, webnn_input_name, "X", logger)) {
       return false;
     }
@@ -178,7 +179,8 @@ bool LRNOpBuilder::HasSupportedOutputsImpl(const Node& node,
   }
 
   // Check if the output data type is supported by every decomposed WebNN op.
-  for (const std::string_view webnn_op_type : decomposed_op_map.at(op_type)) {
+  for (const std::string_view decomposed_op_type : decomposed_op_map.at(op_type)) {
+    const std::string_view webnn_op_type = GetWebNNOpType(decomposed_op_type);
     if (!IsDataTypeSupportedByWebNNOp(op_type, webnn_op_type, output_type, wnn_limits, "output", "Y", logger)) {
       return false;
     }

--- a/onnxruntime/core/providers/webnn/builders/impl/normalization_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/normalization_op_builder.cc
@@ -350,9 +350,10 @@ bool NormalizationOpBuilder::HasSupportedInputsImpl(const GraphViewer&, const No
   if (op_type == "SimplifiedLayerNormalization" || op_type == "SkipSimplifiedLayerNormalization") {
     // SkipSimplifiedLayerNormalization and SimplifiedLayerNormalization are supported by decomposed WebNN ops.
     // Check if the input data type is supported by each decomposed WebNN op.
-    // Decomposed ops include: "add", "div", "mul", "pow", "reduceMean" and "sqrt".
-    for (const std::string_view webnn_op_type : decomposed_op_map.at(op_type)) {
-      const std::string_view webnn_input_name = GetWebNNOpFirstInputName(webnn_op_type);
+    // Decomposed ops include: "Add", "Div", "Mul", "Pow", "ReduceMean" and "Sqrt".
+    for (const std::string_view decomposed_op_type : decomposed_op_map.at(op_type)) {
+      const std::string_view webnn_op_type = GetWebNNOpType(decomposed_op_type);
+      const std::string_view webnn_input_name = GetWebNNOpFirstInputName(decomposed_op_type);
       if (!IsDataTypeSupportedByWebNNOp(
               op_type, webnn_op_type, input0_type, wnn_limits, webnn_input_name, "input", logger)) {
         return false;
@@ -376,7 +377,8 @@ bool NormalizationOpBuilder::HasSupportedOutputsImpl(const Node& node,
 
   if (op_type == "SimplifiedLayerNormalization" || op_type == "SkipSimplifiedLayerNormalization") {
     // Check if the output data type is supported by every decomposed WebNN op.
-    for (const std::string_view webnn_op_type : decomposed_op_map.at(op_type)) {
+    for (const std::string_view decomposed_op_type : decomposed_op_map.at(op_type)) {
+      const std::string_view webnn_op_type = GetWebNNOpType(decomposed_op_type);
       if (!IsDataTypeSupportedByWebNNOp(op_type, webnn_op_type, output_type, wnn_limits, "output", "output", logger)) {
         return false;
       }

--- a/onnxruntime/core/providers/webnn/builders/impl/rotaryEmbedding_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/rotaryEmbedding_op_builder.cc
@@ -436,9 +436,10 @@ bool RotaryEmbeddingOpBuilder::HasSupportedInputsImpl(const GraphViewer&,
   }
 
   // Check if the input data type is supported by each decomposed WebNN op.
-  // Decomposed ops include: "add", "concat", "gather", "mul", "reshape" and "split".
-  for (const std::string_view webnn_op_type : decomposed_op_map.at(op_type)) {
-    const std::string_view webnn_input_name = GetWebNNOpFirstInputName(webnn_op_type);
+  // Decomposed ops include: "Add", "Concat", "Gather", "Mul", "Reshape" and "Split".
+  for (const std::string_view decomposed_op_type : decomposed_op_map.at(op_type)) {
+    const std::string_view webnn_op_type = GetWebNNOpType(decomposed_op_type);
+    const std::string_view webnn_input_name = GetWebNNOpFirstInputName(decomposed_op_type);
     if (!IsDataTypeSupportedByWebNNOp(
             op_type, webnn_op_type, input_type, wnn_limits, webnn_input_name, "input", logger)) {
       return false;
@@ -459,7 +460,8 @@ bool RotaryEmbeddingOpBuilder::HasSupportedOutputsImpl(const Node& node,
   }
 
   // Check if the output data type is supported by every decomposed WebNN op.
-  for (const std::string_view webnn_op_type : decomposed_op_map.at(op_type)) {
+  for (const std::string_view decomposed_op_type : decomposed_op_map.at(op_type)) {
+    const std::string_view webnn_op_type = GetWebNNOpType(decomposed_op_type);
     const std::string_view webnn_output_name = webnn_op_type == "split" ? "outputs" : "output";
     if (!IsDataTypeSupportedByWebNNOp(
             op_type, webnn_op_type, output_type, wnn_limits, webnn_output_name, "output", logger)) {

--- a/onnxruntime/core/providers/webnn/builders/map_info.h
+++ b/onnxruntime/core/providers/webnn/builders/map_info.h
@@ -43,18 +43,20 @@ constexpr std::array<ONNX_NAMESPACE::TensorProto_DataType, 5> supported_fallback
 };
 
 // Some ONNX ops are supported by decomposed WebNN ops.
+// This map defines the relationship between ONNX ops and their corresponding decomposed ONNX ops.
+// Use ONNX-to-ONNX op mapping to improve the search complexity for WebNN ops in the op_inputs_map.
 const std::map<std::string_view, std::vector<std::string_view>> decomposed_op_map = {
-    {"ConvInteger", {"cast", "conv2d", "dequantizeLinear"}},
+    {"ConvInteger", {"Cast", "Conv", "DequantizeLinear"}},
     {"GroupQueryAttention",
-     {"add", "cast", "concat", "constant", "cumulativeSum", "div", "expand", "lesser", "matmul", "reshape", "scatterND",
-      "softmax", "transpose", "where"}},
-    {"LRN", {"add", "averagePool2d", "div", "mul", "pad", "pow", "transpose"}},
-    {"MatMulInteger", {"cast", "dequantizeLinear", "matmul"}},
-    {"MatMulNBits", {"add", "dequantizeLinear", "matmul", "reshape", "transpose"}},
-    {"MultiHeadAttention", {"add", "cast", "concat", "constant", "div", "matmul", "reshape", "softmax", "transpose"}},
-    {"RotaryEmbedding", {"add", "concat", "gather", "mul", "reshape", "slice", "split"}},
-    {"SimplifiedLayerNormalization", {"add", "div", "mul", "pow", "reduceMean", "sqrt"}},
-    {"SkipSimplifiedLayerNormalization", {"add", "div", "mul", "pow", "reduceMean", "sqrt"}},
+     {"Add", "Cast", "Concat", "CumSum", "Div", "Expand", "Less", "MatMul", "Reshape", "ScatterND",
+      "Softmax", "Transpose", "Where"}},
+    {"LRN", {"Add", "AveragePool", "Div", "Mul", "Pad", "Pow", "Transpose"}},
+    {"MatMulInteger", {"Cast", "DequantizeLinear", "MatMul"}},
+    {"MatMulNBits", {"Add", "DequantizeLinear", "MatMul", "Reshape", "Transpose"}},
+    {"MultiHeadAttention", {"Add", "Cast", "Concat", "Div", "MatMul", "Reshape", "Softmax", "Transpose"}},
+    {"RotaryEmbedding", {"Add", "Concat", "Gather", "Mul", "Reshape", "Slice", "Split"}},
+    {"SimplifiedLayerNormalization", {"Add", "Div", "Mul", "Pow", "ReduceMean", "Sqrt"}},
+    {"SkipSimplifiedLayerNormalization", {"Add", "Div", "Mul", "Pow", "ReduceMean", "Sqrt"}},
 };
 
 /**


### PR DESCRIPTION
This util `GetWebNNOpFirstInputName` previously accepted a WebNN op name as parameter, which will always return "input" because the key of `op_inputs_map` is ONNX op type.

This PR fixes the bug by:
- Changing the parameter of `GetWebNNOpFirstInputName` to ONNX op
- Changing the `decomposed_op_map` to ONNX-to-ONNX op mapping, in order to improve the search complexity.