### PR TITLE
[WebGPU-EP] Disable SubgroupMatrix uniformity checks

### DIFF
--- a/onnxruntime/core/providers/webgpu/shader_helper.cc
+++ b/onnxruntime/core/providers/webgpu/shader_helper.cc
@@ -379,6 +379,7 @@ Status ShaderHelper::GenerateSourceCode(std::string& code, std::vector<int>& sha
 #if !defined(__wasm__)
   if (device_.HasFeature(wgpu::FeatureName::ChromiumExperimentalSubgroupMatrix)) {
     ss << "enable chromium_experimental_subgroup_matrix;\n";
+    ss << "diagnostic (off, chromium.subgroup_matrix_uniformity);\n";
   }
 #endif
 


### PR DESCRIPTION
This disables the uniformity checks for SubgroupMatrix in the WebGPU EP.