### PR TITLE
[test] add retry to onnx node test data download

### DIFF
--- a/js/scripts/prepare-onnx-node-tests.ts
+++ b/js/scripts/prepare-onnx-node-tests.ts
@@ -32,6 +32,9 @@ const JS_TEST_ROOT = path.join(JS_ROOT, 'test');
 const JS_TEST_DATA_ROOT = path.join(JS_TEST_ROOT, 'data');
 const JS_TEST_DATA_NODE_ROOT = path.join(JS_TEST_DATA_ROOT, 'node');
 
+// Configuration for download retries
+const MAX_DOWNLOAD_RETRY_TIMES = 3;
+
 const main = async () => {
   log.info('PrepareTestData', 'Preparing node tests ...');
 
@@ -49,7 +52,7 @@ const main = async () => {
 
     const folderPrefix = `onnx-rel-${onnxVersion}/onnx/backend/test/data/node`;
 
-    const buffer = await downloadZip(resourceUri);
+    const buffer = await downloadZip(resourceUri, MAX_DOWNLOAD_RETRY_TIMES);
     const zip = await jszip.loadAsync(buffer);
     const entries = zip.filter((relativePath) => relativePath.startsWith(folderPrefix));
 


### PR DESCRIPTION
### Description


Add retry to node tests data downloading. this should help to fix the random pipeline failure because of download failures.
