### PR TITLE
[QNN EP] Add Support for Reciprocal Op in QNN EP

### DIFF
--- a/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selectors.h
+++ b/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selectors.h
@@ -198,6 +198,21 @@ class EinsumNodeGroupSelector : public NodeGroupSelector {
   bool allow_4bit_;
 };
 
+class ReciprocalNodeGroupSelector : public NodeGroupSelector {
+ public:
+  explicit ReciprocalNodeGroupSelector(bool allow_int8 = true, bool allow_16bit = true, bool allow_4bit = true)
+      : allow_int8_(allow_int8), allow_16bit_(allow_16bit), allow_4bit_(allow_4bit) {}
+
+ private:
+  bool Check(const GraphViewer& graph_viewer,
+             const Node& node, const Node* redundant_clip_node,
+             const std::vector<const Node*>& dq_nodes,
+             const std::vector<const Node*>& q_nodes) const override;
+  bool allow_int8_;
+  bool allow_16bit_;
+  bool allow_4bit_;
+};
+
 // 2 DQ nodes for input -> node -> optional Q if QLinearMatMul, MatMulIntegerToFloat if not
 // The lack of a trailing Q isn't really a QDQ node group, so we default support for that to off.
 class MatMulNodeGroupSelector : public NodeGroupSelector {

--- a/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/shared/utils.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/shared/utils.cc
@@ -116,6 +116,11 @@ static const OpVersionsAndSelector::OpVersionsMap GetConvTransposeOpVersionsMap(
 static const OpVersionsAndSelector::OpVersionsMap GetEinsumOpVersionsMap() {
   return {{"Einsum", {}}};
 }
+
+static const OpVersionsAndSelector::OpVersionsMap GetReciprocalOpVersionsMap() {
+  return {{"Reciprocal", {}}};
+}
+
 static const OpVersionsAndSelector::OpVersionsMap GetMatMulOpVersionsMap() {
   return {{"MatMul", {}}};
 }
@@ -215,6 +220,13 @@ void RegisterEinsumSelector(Selectors& qdq_selectors) {
                                  std::move(selector));
 }
 
+void RegisterReciprocalSelector(Selectors& qdq_selectors) {
+  /* register selector for Reciprocal op */
+  std::unique_ptr<NodeGroupSelector> selector = std::make_unique<ReciprocalNodeGroupSelector>();
+  qdq_selectors.RegisterSelector(GetReciprocalOpVersionsMap(),
+                                 std::move(selector));
+}
+
 void RegisterMatMulSelector(Selectors& qdq_selectors) {
   /* register selector for matmul op */
   std::unique_ptr<NodeGroupSelector> selector = std::make_unique<MatMulNodeGroupSelector>();
@@ -288,6 +300,7 @@ void SelectorManager::CreateSelectors() {
   RegisterConvSelector(qdq_selectors_);
   RegisterConvTransposeSelector(qdq_selectors_);
   RegisterEinsumSelector(qdq_selectors_);
+  RegisterReciprocalSelector(qdq_selectors_);
   RegisterMatMulSelector(qdq_selectors_);
   RegisterGemmSelector(qdq_selectors_);
   RegisterInstanceAndLayerNormalizationSelector(qdq_selectors_);

--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
@@ -167,6 +167,10 @@ OpBuilderRegistrations::OpBuilderRegistrations() {
   }
 
   {
+    CreateReciprocalOpBuilder("Reciprocal", *this);
+  }
+
+  {
     CreatePadOpBuilder("Pad", *this);
   }
 

--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
@@ -93,6 +93,8 @@ void CreateLRNOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_r
 
 void CreateTransposeOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 
+void CreateReciprocalOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+
 void CreatePadOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 
 void CreateExpandOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/reciprocal_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/reciprocal_op_builder.cc
@@ -1,0 +1,94 @@
+// Copyright (c) Qualcomm. All rights reserved.
+// Licensed under the MIT License.
+
+#include <algorithm>
+#include <array>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
+#include "core/providers/qnn/builder/op_builder_factory.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+class ReciprocalOpBuilder : public BaseOpBuilder {
+ public:
+  ReciprocalOpBuilder() : BaseOpBuilder("ReciprocalOpBuilder") {}
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(ReciprocalOpBuilder);
+
+ protected:
+  Status ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper, const NodeUnit& node_unit,
+                                     std::vector<std::string>&& input_names, const logging::Logger& logger,
+                                     bool do_op_validation) const override ORT_MUST_USE_RESULT;
+};
+
+Status ReciprocalOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                                        const NodeUnit& node_unit,
+                                                        std::vector<std::string>&& input_names,
+                                                        const logging::Logger& logger,
+                                                        bool do_op_validation) const {
+  ORT_UNUSED_PARAMETER(logger);
+  ORT_UNUSED_PARAMETER(do_op_validation);
+
+  const auto& input = node_unit.Inputs()[0];
+  const auto& output = node_unit.Outputs()[0];
+
+  TensorInfo reciprocal_input_info = {};
+  ORT_RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(input, reciprocal_input_info));
+
+  // Create constant tensor with value 1.0
+  float one_value = 1.0f;
+  std::vector<uint32_t> scalar_shape = {1};
+  std::vector<uint8_t> one_data(sizeof(float));
+  memcpy(one_data.data(), &one_value, sizeof(float));
+
+  const std::string one_tensor_name = input_names[0] + "_ort_qnn_ep_one";
+
+  QnnTensorWrapper one_tensor(one_tensor_name, QNN_TENSOR_TYPE_STATIC, reciprocal_input_info.qnn_data_type,
+                              reciprocal_input_info.quant_param.Copy(), std::move(scalar_shape), std::move(one_data));
+
+  ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(one_tensor)),
+                    "Failed to add constant tensor wrapper for reciprocal numerator.");
+
+  // Get output shape
+  std::vector<uint32_t> output_shape;
+  ORT_RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(output.node_arg, output_shape),
+                    "Failed to get output shape.");
+
+  const std::string output_name = output.node_arg.Name();
+
+  TensorInfo reciprocal_output_info = {};
+  ORT_RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(output, reciprocal_output_info));
+  Qnn_TensorType_t output_tensor_type = qnn_model_wrapper.IsGraphOutput(output_name)
+                                            ? QNN_TENSOR_TYPE_APP_READ
+                                            : QNN_TENSOR_TYPE_NATIVE;
+
+  QnnTensorWrapper output_tensor(output_name, output_tensor_type, reciprocal_output_info.qnn_data_type,
+                                 reciprocal_output_info.quant_param.Copy(), std::move(output_shape));
+
+  ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensor)),
+                    "Failed to add output tensor wrapper for reciprocal.");
+
+  // Create Div node: 1 / input
+  ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(output_name + "_div",
+                                                    QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                    QNN_OP_ELEMENT_WISE_DIVIDE,
+                                                    {one_tensor_name, input_names[0]},
+                                                    {output_name},
+                                                    {},
+                                                    do_op_validation),
+                    "Failed to create Reciprocal_Div node.");
+
+  return Status::OK();
+}
+
+void CreateReciprocalOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
+  op_registrations.AddOpBuilder(op_type, std::make_unique<ReciprocalOpBuilder>());
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/reciprocal_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/reciprocal_op_builder.cc
@@ -19,7 +19,6 @@ class ReciprocalOpBuilder : public BaseOpBuilder {
                        const logging::Logger& logger) const override final ORT_MUST_USE_RESULT;
 
  protected:
-
   Status ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
                                      const NodeUnit& node_unit,
                                      std::vector<std::string>&& input_names,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/reciprocal_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/reciprocal_op_builder.cc
@@ -1,4 +1,4 @@
-// Copyright (c) Qualcomm. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 #include "core/providers/qnn/builder/opbuilder/base_op_builder.h"

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/reciprocal_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/reciprocal_op_builder.cc
@@ -43,9 +43,6 @@ Status ReciprocalOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
   const auto& outputs = node_unit.Outputs();
   ORT_RETURN_IF_NOT(outputs.size() == 1, "Reciprocal operator must have exactly 1 output.");
 
-  // Check input type is float for CPU. Can't use QNN Op validation API since it's before layout transformation
-  ORT_RETURN_IF_ERROR(DataTypeCheckForCpuBackend(qnn_model_wrapper, inputs[0].node_arg.Type()));
-
   return Status::OK();
 }
 

--- a/onnxruntime/test/providers/qnn/simple_op_htp_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_htp_test.cc
@@ -1002,7 +1002,7 @@ TEST_F(QnnHTPBackendTests, Reciprocal_Basic_FLOAT) {
 
 TEST_F(QnnHTPBackendTests, Reciprocal_QU8) {
   RunQDQOpTest<uint8_t>("Reciprocal",
-                        {TestInputDef<float>({2, 2}, false, GetFloatDataInRange(0.1f, 10.0f, 4))},
+                        {TestInputDef<float>({2, 2}, false, GetFloatDataInRange(1.0f, 5.0f, 4))},
                         {},  // No attributes
                         13,
                         ExpectedEPNodeAssignment::All);

--- a/onnxruntime/test/providers/qnn/simple_op_htp_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_htp_test.cc
@@ -991,6 +991,23 @@ TEST_F(QnnHTPBackendTests, BinaryOp_And4D) {
                   ExpectedEPNodeAssignment::All);
 }
 
+// Test Reciprocal on HTP
+TEST_F(QnnHTPBackendTests, Reciprocal_Basic_FLOAT) {
+  RunOpTest<float>("Reciprocal",
+                   {TestInputDef<float>({2, 2}, false, {1.0f, 2.0f, 0.5f, 4.0f})},
+                   {},  // No attributes
+                   13,
+                   ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, Reciprocal_QU8) {
+  RunQDQOpTest<uint8_t>("Reciprocal",
+                        {TestInputDef<float>({2, 2}, false, GetFloatDataInRange(0.1f, 10.0f, 4))},
+                        {},  // No attributes
+                        13,
+                        ExpectedEPNodeAssignment::All);
+}
+
 // Test ScatterND op on HTP
 TEST_F(QnnHTPBackendTests, ScatterND_int64_int64) {
   std::vector<int64_t> data = {0, 1, 2, 3};


### PR DESCRIPTION
- Implemented ReciprocalOpBuilder to support ONNX Reciprocal Op in QNN EP.
- Decomposed Reciprocal into a Div Op.
- Added unit tests to run Reciprocal Op on HTP

### Description
Adds support for the ONNX Reciprocal operator in QNN EP via Div decomposition.



### Motivation and Context
Enables execution of models using Reciprocal on QNN backend, improving Op support.


