### PR TITLE
Fix link to Java API documentation

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -6,7 +6,7 @@ Java Native Interface (JNI) is used to allow for seamless calls to ONNX runtime 
 ## Usage
 
 This document pertains to developing, building, running, and testing the API itself in your local environment.
-For general purpose usage of the publicly distributed API, please see the [general Java API documentation](https://www.onnxruntime.ai/docs/reference/api/java-api.html).
+For general purpose usage of the publicly distributed API, please see the [general Java API documentation](https://onnxruntime.ai/docs/api/java/index.html).
 
 ### Building
 


### PR DESCRIPTION
### Description
Update the link in the Java README to the current URL of the Java API documentation.



### Motivation and Context
The link in the Java README to the general Java API documentation is currently broken.


