### PR TITLE
[MIGraphX EP][ROCm EP] Update build args to include rocm_gfx_arch input for ROCM/MIGraphX EP builds 

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -731,6 +731,7 @@ def generate_build_tree(
     if args.use_rocm:
         cmake_args.append("-Donnxruntime_ROCM_HOME=" + rocm_home)
         cmake_args.append("-Donnxruntime_ROCM_VERSION=" + args.rocm_version)
+        cmake_args.append("-DCMAKE_HIP_ARCHITECTURES=" + args.rocm_gfx_arch)
     if args.use_tensorrt or args.use_nv_tensorrt_rtx:
         cmake_args.append("-Donnxruntime_TENSORRT_HOME=" + tensorrt_home)
 

--- a/tools/ci_build/build_args.py
+++ b/tools/ci_build/build_args.py
@@ -609,6 +609,8 @@ def add_execution_provider_args(parser: argparse.ArgumentParser) -> None:
     rocm_group.add_argument("--use_rocm", action="store_true", help="Enable ROCm EP.")
     rocm_group.add_argument("--rocm_version", help="ROCm stack version.")
     rocm_group.add_argument("--rocm_home", help="Path to ROCm installation directory.")
+    rocm_group.add_argument("--rocm_gfx_arch", help='Provide gfx arch. Example --rocm_gfx_arch gfx942' 
+            ' or --rocm_gfx_arch "gfx90a;gfx942"')
     # ROCm-specific profiling
     rocm_group.add_argument(
         "--enable_rocm_profiling",


### PR DESCRIPTION

### Description
<!-- Describe your changes. -->
Allow for us to select GFX targets for build


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Used by our QA but also can be leveraged by third parties to try builds for specific gfx targets and architectures 

Already in our rocm7.0 testing branch via : https://github.com/ROCm/onnxruntime/pull/126
