### PR TITLE
Allocator and data transfer support for plugin EP API

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -1826,8 +1826,9 @@ endif()
 if (WIN32 AND onnxruntime_BUILD_SHARED_LIB AND
     NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten" AND
     NOT onnxruntime_MINIMAL_BUILD)
-  onnxruntime_add_shared_library_module(example_plugin_ep
-                                        ${TEST_SRC_DIR}/autoep/library/example_plugin_ep.cc)
+  file(GLOB onnxruntime_autoep_test_library_src "${TEST_SRC_DIR}/autoep/library/*.h"
+                                                "${TEST_SRC_DIR}/autoep/library/*.cc")
+  onnxruntime_add_shared_library_module(example_plugin_ep ${onnxruntime_autoep_test_library_src})
   target_include_directories(example_plugin_ep PRIVATE ${REPO_ROOT}/include/onnxruntime/core/session)
   target_link_libraries(example_plugin_ep PRIVATE onnxruntime)
 

--- a/include/onnxruntime/core/framework/allocator.h
+++ b/include/onnxruntime/core/framework/allocator.h
@@ -7,10 +7,17 @@
 
 #include "core/common/common.h"
 #include "core/framework/allocator_stats.h"
+#include "core/session/abi_key_value_pairs.h"
 // some enums are defined in session/onnxruntime_c_api.h but used in ortdevice.h/ortmemory.h
 #include "core/session/onnxruntime_c_api.h"
 #include "core/framework/ortdevice.h"
 #include "core/framework/ortmemoryinfo.h"
+
+namespace onnxruntime {
+namespace common {
+class Status;
+}
+}  // namespace onnxruntime
 
 // This configures the arena based allocator used by ORT
 // See docs/C_API.md for details on what these mean and how to choose these values
@@ -37,6 +44,26 @@ struct OrtArenaCfg {
   int max_dead_bytes_per_chunk;           // use -1 to allow ORT to choose the default
   int initial_growth_chunk_size_bytes;    // use -1 to allow ORT to choose the default
   int64_t max_power_of_two_extend_bytes;  // use -1 to allow ORT to choose the default
+
+  bool IsValid() {
+    return arena_extend_strategy >= -1 && arena_extend_strategy <= 1 &&
+           initial_chunk_size_bytes >= -1 &&
+           max_dead_bytes_per_chunk >= -1 &&
+           initial_growth_chunk_size_bytes >= -1 &&
+           max_power_of_two_extend_bytes >= -1;
+  }
+
+  // config key names that we parse in FromKeyValuePairs
+  struct ConfigKeyNames {
+    static constexpr const char* ArenaExtendStrategy = "arena.extend_strategy";
+    static constexpr const char* InitialChunkSizeBytes = "arena.initial_chunk_size_bytes";
+    static constexpr const char* MaxDeadBytesPerChunk = "arena.max_dead_bytes_per_chunk";
+    static constexpr const char* InitialGrowthChunkSizeBytes = "arena.initial_growth_chunk_size_bytes";
+    static constexpr const char* MaxPowerOfTwoExtendBytes = "arena.max_power_of_two_extend_bytes";
+    static constexpr const char* MaxMem = "arena.max_mem";
+  };
+
+  static onnxruntime::common::Status FromKeyValuePairs(const OrtKeyValuePairs& kvps, OrtArenaCfg& cfg);
 };
 
 namespace onnxruntime {

--- a/include/onnxruntime/core/framework/execution_provider.h
+++ b/include/onnxruntime/core/framework/execution_provider.h
@@ -35,6 +35,7 @@ class GraphOptimizerRegistry;
 #include "core/framework/stream_handles.h"
 #include "core/framework/tuning_context.h"
 
+struct OrtEpDevice;
 struct OrtRunOptions;
 
 namespace onnxruntime {

--- a/onnxruntime/core/framework/data_transfer_manager.cc
+++ b/onnxruntime/core/framework/data_transfer_manager.cc
@@ -16,6 +16,20 @@ Status DataTransferManager::RegisterDataTransfer(std::unique_ptr<IDataTransfer> 
   return Status::OK();
 }
 
+Status DataTransferManager::UnregisterDataTransfer(IDataTransfer* data_transfer) {
+  auto iter = std::find_if(datatransfers_.begin(), datatransfers_.end(),
+                           [&data_transfer](const std::unique_ptr<IDataTransfer>& dt) {
+                             return dt.get() == data_transfer;
+                           });
+
+  if (iter != datatransfers_.end()) {
+    datatransfers_.erase(iter);
+  }
+
+  // ignore if not found
+  return Status::OK();
+}
+
 const IDataTransfer* DataTransferManager::GetDataTransfer(const OrtDevice& src_device, const OrtDevice& dst_device) const {
   for (auto& data_transfer : datatransfers_) {
     if (!data_transfer->CanCopy(src_device, dst_device)) {

--- a/onnxruntime/core/framework/data_transfer_manager.h
+++ b/onnxruntime/core/framework/data_transfer_manager.h
@@ -17,6 +17,7 @@ class DataTransferManager {
   // static DataTransferManager& Instance();
 
   common::Status RegisterDataTransfer(std::unique_ptr<IDataTransfer> data_transfer);
+  common::Status UnregisterDataTransfer(IDataTransfer* data_transfer);
 
   const IDataTransfer* GetDataTransfer(const OrtDevice& src_device, const OrtDevice& dst_device) const;
 

--- a/onnxruntime/core/framework/plugin_data_transfer.cc
+++ b/onnxruntime/core/framework/plugin_data_transfer.cc
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+#include "core/framework/plugin_data_transfer.h"
+
+#include "core/framework/error_code_helper.h"
+
+namespace onnxruntime {
+namespace plugin_ep {
+
+namespace {
+static const std::function<void(void*)> no_op_deleter = [](void*) {};
+static const MLDataType ml_tensor_type = DataTypeImpl::GetType<Tensor>();
+}  // namespace
+
+Status DataTransfer::CopyTensors(const std::vector<SrcDstPair>& src_dst_pairs) const {
+  // need to wrap the src/dst Tensor instances in OrtValue as the ORT API doesn't expose an OrtTensor.
+  // Adding an OrtTensor to the API would also require adding getters for type/shape/data.
+  // Those already exist for OrtValue so in order to minimize the API surface area we pay the price of a
+  // const_cast to convert the `const Tensor*` src to an OrtValue.
+  std::vector<OrtValue> values;
+  values.resize(src_dst_pairs.size() * 2);
+
+  for (size_t i = 0; i < src_dst_pairs.size(); ++i) {
+    const auto& pair = src_dst_pairs[i];
+
+    // we need to remove the const from the src to wrap it in an OrtValue.
+    // it's passed to the impl as a const OrtValue, and the deleter is a no-op so this should be safe.
+    Tensor* src_tensor = const_cast<Tensor*>(&(pair.src.get()));
+    values[i * 2].Init(reinterpret_cast<void*>(src_tensor), ml_tensor_type, no_op_deleter);
+    values[i * 2 + 1].Init(reinterpret_cast<void*>(&pair.dst.get()), ml_tensor_type, no_op_deleter);
+  }
+
+  std::vector<const OrtValue*> src_values;
+  std::vector<OrtValue*> dst_values;
+  std::vector<OrtSyncStream*> streams;
+  src_values.reserve(src_dst_pairs.size());
+  dst_values.reserve(src_dst_pairs.size());
+  streams.reserve(src_dst_pairs.size());
+
+  for (size_t i = 0; i < src_dst_pairs.size(); ++i) {
+    src_values.push_back(&values[i * 2]);
+    dst_values.push_back(&values[i * 2 + 1]);
+    streams.push_back(nullptr);  // static_cast<OrtSyncStream*>(src_dst_pairs[i].src_stream));
+  }
+
+  auto* status = impl_.CopyTensors(&impl_, src_values.data(), dst_values.data(), streams.data(),
+                                   src_dst_pairs.size());
+
+  return status == nullptr ? Status::OK() : ToStatus(status);
+}
+
+// optimized version for a single copy. see comments above in CopyTensors regarding the OrtValue usage and const_cast
+Status DataTransfer::CopyTensorImpl(const Tensor& src_tensor, Tensor& dst_tensor, onnxruntime::Stream* /*stream*/) const {
+  OrtValue src, dst;
+  Tensor* src_tensor_ptr = const_cast<Tensor*>(&src_tensor);
+  src.Init(reinterpret_cast<void*>(src_tensor_ptr), ml_tensor_type, no_op_deleter);
+  dst.Init(reinterpret_cast<void*>(&dst_tensor), ml_tensor_type, no_op_deleter);
+  const OrtValue* src_ptr = &src;
+  OrtValue* dst_ptr = &dst;
+  OrtSyncStream* stream_ptr = nullptr; // static_cast<OrtSyncStream*>(stream);
+  auto* status = impl_.CopyTensors(&impl_, &src_ptr, &dst_ptr, &stream_ptr, 1);
+
+  return status == nullptr ? Status::OK() : ToStatus(status);
+}
+
+}  // namespace plugin_ep
+}  // namespace onnxruntime

--- a/onnxruntime/core/framework/plugin_data_transfer.h
+++ b/onnxruntime/core/framework/plugin_data_transfer.h
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+#include "core/framework/data_transfer.h"
+#include "core/framework/error_code_helper.h"
+#include "core/framework/ort_value.h"
+#include "core/session/onnxruntime_c_api.h"
+#include "core/session/abi_devices.h"
+
+namespace onnxruntime {
+namespace plugin_ep {
+
+class DataTransfer : public IDataTransfer {
+ public:
+  DataTransfer(OrtDataTransferImpl& impl)
+      : impl_{impl} {
+  }
+
+  bool CanCopy(const OrtDevice& src_device, const OrtDevice& dst_device) const override {
+    const OrtMemoryDevice* src_memory_device = static_cast<const OrtMemoryDevice*>(&src_device);
+    const OrtMemoryDevice* dst_memory_device = static_cast<const OrtMemoryDevice*>(&dst_device);
+
+    return impl_.CanCopy(&impl_, src_memory_device, dst_memory_device);
+  }
+
+  Status CopyTensor(const Tensor& src, Tensor& dst) const override {
+    return CopyTensorImpl(src, dst, nullptr);
+  }
+
+  Status CopyTensorAsync(const Tensor& src, Tensor& dst, Stream& stream) const {
+    return CopyTensorImpl(src, dst, &stream);
+  }
+
+  Status CopyTensors(const std::vector<SrcDstPair>& src_dst_pairs) const override;
+
+  ~DataTransfer() override {
+    impl_.Release(&impl_);
+  }
+
+ private:
+  Status CopyTensorImpl(const Tensor& src, Tensor& dst, onnxruntime::Stream* stream = nullptr) const;
+
+  OrtDataTransferImpl& impl_;
+};
+}  // namespace plugin_ep
+}  // namespace onnxruntime

--- a/onnxruntime/core/platform/windows/debug_alloc.cc
+++ b/onnxruntime/core/platform/windows/debug_alloc.cc
@@ -253,7 +253,8 @@ Memory_LeakCheck::~Memory_LeakCheck() {
         string.find("testing::internal::Mutex::ThreadSafeLazyInit") == std::string::npos &&
         string.find("testing::internal::ThreadLocalRegistryImpl::GetThreadLocalsMapLocked") == std::string::npos &&
         string.find("testing::internal::ThreadLocalRegistryImpl::GetValueOnCurrentThread") == std::string::npos &&
-        string.find("PyInit_onnxruntime_pybind11_state") == std::string::npos) {
+        string.find("PyInit_onnxruntime_pybind11_state") == std::string::npos &&
+        string.find("google::protobuf::internal::InitProtobufDefaultsSlow") == std::string::npos) {
       if (leaked_bytes == 0)
         DebugPrint("\n-----Starting Heap Trace-----\n\n");
 

--- a/onnxruntime/core/session/abi_devices.h
+++ b/onnxruntime/core/session/abi_devices.h
@@ -7,8 +7,12 @@
 #include <unordered_map>
 
 #include "core/common/hash_combine.h"
+#include "core/framework/ortdevice.h"
 #include "core/session/abi_key_value_pairs.h"
 #include "core/session/onnxruntime_c_api.h"
+
+// alias API type to internal type
+struct OrtMemoryDevice : OrtDevice {};
 
 struct OrtHardwareDevice {
   OrtHardwareDeviceType type;
@@ -62,4 +66,6 @@ struct OrtEpDevice {
   OrtKeyValuePairs ep_options;
 
   OrtEpFactory* ep_factory;
+  const OrtMemoryInfo* device_memory_info{nullptr};
+  const OrtMemoryInfo* host_accessible_memory_info{nullptr};
 };

--- a/onnxruntime/core/session/environment.cc
+++ b/onnxruntime/core/session/environment.cc
@@ -6,6 +6,7 @@
 #include <array>
 
 #include "core/common/basic_types.h"
+#include "core/framework/allocator.h"
 #include "core/framework/allocator_utils.h"
 #include "core/framework/error_code_helper.h"
 #include "core/graph/constants.h"
@@ -69,39 +70,22 @@ std::once_flag schemaRegistrationOnceFlag;
 ProviderInfo_CUDA& GetProviderInfo_CUDA();
 #endif  // defined(USE_CUDA) || defined(USE_CUDA_PROVIDER_INTERFACE)
 
-Status Environment::Create(std::unique_ptr<logging::LoggingManager> logging_manager,
-                           std::unique_ptr<Environment>& environment,
-                           const OrtThreadingOptions* tp_options,
-                           bool create_global_thread_pools) {
-  environment = std::make_unique<Environment>();
-  auto status = environment->Initialize(std::move(logging_manager), tp_options, create_global_thread_pools);
-  return status;
-}
-
-// Ugly but necessary for instances where we want to check equality of two OrtMemoryInfos
-// without accounting for OrtAllocatorType in the equality checking process.
-// TODO: Should we remove the OrtAllocatorType field from the OrtMemoryInfo struct to
-// avoid such problems and also remove the unintuitive phenomenon of binding an allocator
-// type to OrtMemoryInfo (which loosely is just device info) ?
+namespace {
+// Ignore whether there is an arena wrapping the allocator by excluding OrtMemoryInfo.alloc_type from the comparison
 static bool AreOrtMemoryInfosEquivalent(
     const OrtMemoryInfo& left, const OrtMemoryInfo& right,
-    bool include_allocator_type_for_equivalence_checking = true) {
-  if (include_allocator_type_for_equivalence_checking) {
-    return left == right;
-  } else {
-    return left.mem_type == right.mem_type &&
-           left.device == right.device &&
-           strcmp(left.name, right.name) == 0;
-  }
+    bool match_name = true) {
+  return left.mem_type == right.mem_type &&
+         left.device == right.device &&
+         (!match_name || strcmp(left.name, right.name) == 0);
 }
 
-Status Environment::RegisterAllocator(AllocatorPtr allocator) {
-  const auto& mem_info = allocator->Info();
-
-  // We don't expect millions of allocators getting registered. Hence linear search should be fine.
-  auto ite = std::find_if(std::begin(shared_allocators_),
-                          std::end(shared_allocators_),
-                          [&mem_info](const AllocatorPtr& alloc_ptr) {
+std::vector<AllocatorPtr>::const_iterator FindExistingAllocator(const std::vector<AllocatorPtr>& allocators,
+                                                                const OrtMemoryInfo& mem_info,
+                                                                bool match_name = true) {
+  auto ite = std::find_if(std::begin(allocators),
+                          std::end(allocators),
+                          [&mem_info, match_name](const AllocatorPtr& alloc_ptr) {
                             // We want to do the equality checking of 2 OrtMemoryInfos sans the OrtAllocatorType field.
                             // This is because we want to avoid registering two allocators for the same device that just
                             // differ on OrtAllocatorType.
@@ -111,14 +95,96 @@ Status Environment::RegisterAllocator(AllocatorPtr allocator) {
                             // OrtDeviceAllocator (which is the only accepted value while registering a custom allocator).
                             // If we allowed this, it could potentially cause a lot of confusion as to which shared allocator
                             // to use for that device and we want to avoid having any ugly logic around this.
-                            return AreOrtMemoryInfosEquivalent(alloc_ptr->Info(), mem_info, false);
+                            return AreOrtMemoryInfosEquivalent(alloc_ptr->Info(), mem_info, match_name);
                           });
 
-  if (ite != shared_allocators_.end()) {
-    return Status(ONNXRUNTIME, INVALID_ARGUMENT, "An allocator for this device has already been registered for sharing.");
+  return ite;
+}
+
+std::unordered_set<OrtAllocator*>::const_iterator FindExistingAllocator(const std::unordered_set<OrtAllocator*>& allocators,
+                                                                        const OrtMemoryInfo& mem_info,
+                                                                        bool match_name = true) {
+  return std::find_if(std::begin(allocators),
+                      std::end(allocators),
+                      [&mem_info, match_name](const OrtAllocator* alloc_ptr) {
+                        const auto* alloc_mem_info = alloc_ptr->Info(alloc_ptr);
+                        return AreOrtMemoryInfosEquivalent(*alloc_mem_info, mem_info, match_name);
+                      });
+}
+}  // namespace
+
+Status Environment::Create(std::unique_ptr<logging::LoggingManager> logging_manager,
+                           std::unique_ptr<Environment>& environment,
+                           const OrtThreadingOptions* tp_options,
+                           bool create_global_thread_pools) {
+  environment = std::make_unique<Environment>();
+  auto status = environment->Initialize(std::move(logging_manager), tp_options, create_global_thread_pools);
+  return status;
+}
+
+Status Environment::RegisterAllocator(OrtAllocator* allocator) {
+  std::lock_guard<std::mutex> lock{mutex_};
+
+  auto allocator_ptr = std::make_shared<IAllocatorImplWrappingOrtAllocator>(allocator);
+
+  // for the public API we always want to replace any existing allocator for the device.
+  auto status = RegisterAllocatorImpl(allocator_ptr, /*replace_existing*/ true);
+
+  // update shared_ort_allocators_
+  if (status.IsOK()) {
+    if (auto it = FindExistingAllocator(shared_ort_allocators_, *allocator->Info(allocator), /*match_name*/ true);
+        it != shared_ort_allocators_.end()) {
+      shared_ort_allocators_.erase(it);
+    }
+
+    shared_ort_allocators_.insert(allocator);
   }
 
-  shared_allocators_.insert(ite, allocator);
+  return status;
+}
+
+Status Environment::RegisterAllocatorImpl(AllocatorPtr allocator, bool replace_existing) {
+  const auto& mem_info = allocator->Info();
+
+  const bool match_name = false;
+  if (FindExistingAllocator(shared_allocators_, mem_info, match_name) != shared_allocators_.end()) {
+    if (replace_existing) {
+      ORT_RETURN_IF_ERROR(UnregisterAllocatorImpl(mem_info, match_name));
+    } else {
+      return Status(ONNXRUNTIME, INVALID_ARGUMENT,
+                    "An allocator for this device has already been registered for sharing.");
+    }
+  }
+
+  shared_allocators_.push_back(std::move(allocator));
+
+  return Status::OK();
+}
+Status Environment::UnregisterAllocator(const OrtMemoryInfo& mem_info) {
+  std::lock_guard<std::mutex> lock{mutex_};
+
+  return UnregisterAllocatorImpl(mem_info);
+}
+
+Status Environment::UnregisterAllocatorImpl(const OrtMemoryInfo& mem_info, bool error_if_not_found) {
+  auto it = FindExistingAllocator(shared_allocators_, mem_info);
+
+  if (error_if_not_found && it == shared_allocators_.end()) {
+    return Status(ONNXRUNTIME, INVALID_ARGUMENT, "No allocator for this device has been registered for sharing.");
+  }
+
+  // we need to remove from shared_ort_allocators_ first in case the entry in shared_allocators_ owns the pointer in
+  // shared_ort_allocators_
+  // e.g. a plug-in EP allocator is an IAllocatorImplWrappingOrtAllocator that owns the OrtAllocator* created by the EP
+  // so when we remove that from shared_allocators_ we release the OrtAllocator instance.
+
+  // shared_ort_allocators_ are internal only so never an error if there's no match
+  auto it2 = FindExistingAllocator(shared_ort_allocators_, mem_info);
+  if (it2 != shared_ort_allocators_.end()) {
+    shared_ort_allocators_.erase(it2);
+  }
+
+  shared_allocators_.erase(it);
 
   return Status::OK();
 }
@@ -126,7 +192,8 @@ Status Environment::RegisterAllocator(AllocatorPtr allocator) {
 Status Environment::CreateAndRegisterAllocator(const OrtMemoryInfo& mem_info, const OrtArenaCfg* arena_cfg) {
   // TODO should we allow sharing of non-CPU allocators?
   if (mem_info.device.Type() != OrtDevice::CPU) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Only CPU devices are supported. Please call CreateAndRegisterAllocatorV2() for other device.");
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "Only CPU devices are supported. Please call CreateAndRegisterAllocatorV2() for other device.");
   }
 
   // determine if arena should be used
@@ -148,15 +215,7 @@ Status Environment::CreateAndRegisterAllocator(const OrtMemoryInfo& mem_info, co
     // override with values from the user supplied arena_cfg object
     if (arena_cfg) {
       max_mem = arena_cfg->max_mem;
-
       arena_extend_strategy = arena_cfg->arena_extend_strategy;
-      // validate the value here
-      if (!(arena_extend_strategy == -1 || arena_extend_strategy == 0 || arena_extend_strategy == 1)) {
-        return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                               "Received invalid value for arena extend strategy."
-                               " Valid values can be either 0, 1 or -1.");
-      }
-
       initial_chunk_size_bytes = arena_cfg->initial_chunk_size_bytes;
       max_dead_bytes_per_chunk = arena_cfg->max_dead_bytes_per_chunk;
       initial_growth_chunk_size_bytes = arena_cfg->initial_growth_chunk_size_bytes;
@@ -177,26 +236,8 @@ Status Environment::CreateAndRegisterAllocator(const OrtMemoryInfo& mem_info, co
     allocator_ptr = CreateAllocator(alloc_creation_info);
   }
 
-  return RegisterAllocator(allocator_ptr);
-}
-
-Status Environment::UnregisterAllocator(const OrtMemoryInfo& mem_info) {
-  auto ite = std::find_if(std::begin(shared_allocators_),
-                          std::end(shared_allocators_),
-                          [&mem_info](const AllocatorPtr& alloc_ptr) {
-                            // See comment in RegisterAllocator() as to why we
-                            // use this method of OrtMemoryInfo equality checking
-                            return AreOrtMemoryInfosEquivalent(alloc_ptr->Info(), mem_info, false);
-                          });
-
-  if (ite == shared_allocators_.end()) {
-    return Status(ONNXRUNTIME, INVALID_ARGUMENT,
-                  "No allocator for this device has been registered for sharing.");
-  }
-
-  shared_allocators_.erase(ite);
-
-  return Status::OK();
+  std::lock_guard<std::mutex> lock{mutex_};
+  return RegisterAllocatorImpl(allocator_ptr, /*replace_existing*/ true);
 }
 
 Status Environment::Initialize(std::unique_ptr<logging::LoggingManager> logging_manager,
@@ -329,8 +370,6 @@ Internal copy node
 
 #if !defined(ORT_MINIMAL_BUILD)
     // register internal EPs for autoep selection
-    // TODO: ??? Is there any reason not to do this like an EP allocates a large chunk of memory when created?
-    //       If that is the case the user could register by name with no library path to do registration manually.
     ORT_RETURN_IF_ERROR(CreateAndRegisterInternalEps());
 #endif
   }
@@ -363,7 +402,7 @@ Status Environment::CreateAndRegisterAllocatorV2(const std::string& provider_typ
         arena_cfg->max_mem,
         static_cast<ArenaExtendStrategy>(arena_cfg->arena_extend_strategy),
         external_info, arena_cfg);
-    return RegisterAllocator(allocator_ptr);
+    return RegisterAllocatorImpl(allocator_ptr, /*replace_existing*/ true);
   }
 #endif
 
@@ -392,6 +431,20 @@ Status Environment::RegisterExecutionProviderLibrary(const std::string& registra
     execution_devices_.reserve(execution_devices_.size() + ep_info->execution_devices.size());
     for (const auto& ed : ep_info->execution_devices) {
       execution_devices_.push_back(ed.get());
+
+      // add shared allocators so they're available without an inference session being required.
+      // we don't replace an existing allocator as we just need one to exist for the OrtMemoryInfo and we don't want
+      // to blow away any custom allocators previously added by the user.
+      const auto end_it = shared_ort_allocators_.end();
+      if (ed->device_memory_info != nullptr) {
+        ORT_RETURN_IF_ERROR(CreateSharedAllocatorImpl(*ed, *ed->device_memory_info, OrtDeviceAllocator, nullptr,
+                                                      nullptr, /*replace_existing*/ false));
+      }
+
+      if (ed->host_accessible_memory_info != nullptr) {
+        ORT_RETURN_IF_ERROR(CreateSharedAllocatorImpl(*ed, *ed->host_accessible_memory_info, OrtDeviceAllocator,
+                                                      nullptr, nullptr, /*replace_existing*/ false));
+      }
     }
 
     for (const auto& internal_factory : internal_factories) {
@@ -424,6 +477,8 @@ Status Environment::CreateAndRegisterInternalEps() {
 }
 
 Status Environment::RegisterExecutionProviderLibrary(const std::string& registration_name, const ORTCHAR_T* lib_path) {
+  std::lock_guard<std::mutex> lock{mutex_};
+
   std::vector<EpFactoryInternal*> internal_factories = {};
   std::unique_ptr<EpLibrary> ep_library;
 
@@ -435,6 +490,8 @@ Status Environment::RegisterExecutionProviderLibrary(const std::string& registra
 }
 
 Status Environment::UnregisterExecutionProviderLibrary(const std::string& ep_name) {
+  std::lock_guard<std::mutex> lock{mutex_};
+
   if (ep_libraries_.count(ep_name) == 0) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Execution provider library: ", ep_name, " was not registered.");
   }
@@ -442,9 +499,7 @@ Status Environment::UnregisterExecutionProviderLibrary(const std::string& ep_nam
   auto status = Status::OK();
 
   ORT_TRY {
-    // unload.
     auto ep_info = std::move(ep_libraries_[ep_name]);
-
     // remove from map and global list of OrtEpDevice* before unloading so we don't get a leftover entry if
     // something goes wrong in any of the following steps..
     ep_libraries_.erase(ep_name);
@@ -454,9 +509,21 @@ Status Environment::UnregisterExecutionProviderLibrary(const std::string& ep_nam
     }
 
     for (const auto& ed : ep_info->execution_devices) {
+      // remove from global list of OrtEpDevices
       if (auto it = std::find(execution_devices_.begin(), execution_devices_.end(), ed.get());
           it != execution_devices_.end()) {
         execution_devices_.erase(it);
+      }
+
+      // unregister any shared allocators.
+      // match only the OrtEpDevice allocator in case the user registered a custom allocator with matching info.
+      const bool error_if_not_found = false;
+      if (ed->device_memory_info != nullptr) {
+        ORT_RETURN_IF_ERROR(UnregisterAllocatorImpl(*ed->device_memory_info, error_if_not_found));
+      }
+
+      if (ed->host_accessible_memory_info != nullptr) {
+        ORT_RETURN_IF_ERROR(UnregisterAllocatorImpl(*ed->host_accessible_memory_info, error_if_not_found));
       }
     }
 
@@ -464,9 +531,115 @@ Status Environment::UnregisterExecutionProviderLibrary(const std::string& ep_nam
   }
   ORT_CATCH(const std::exception& ex) {
     ORT_HANDLE_EXCEPTION([&]() {
-      status = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to unregister EP library: ", ep_name, " with error: ", ex.what());
+      status = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to unregister EP library: ", ep_name, " with error: ",
+                               ex.what());
     });
   }
+
+  return status;
+}
+
+Status Environment::CreateSharedAllocator(const OrtEpDevice& ep_device,
+                                          OrtDeviceMemoryType mem_type, OrtAllocatorType allocator_type,
+                                          const OrtKeyValuePairs* allocator_options,
+                                          OrtAllocator** allocator_out) {
+  auto* memory_info = mem_type == OrtMemTypeDefault ? ep_device.device_memory_info
+                                                    : ep_device.host_accessible_memory_info;
+  if (memory_info == nullptr) {
+    return Status(ONNXRUNTIME, ORT_INVALID_ARGUMENT, "Invalid memory type for OrtEpDevice.");
+  }
+
+  std::lock_guard<std::mutex> lock{mutex_};
+  return CreateSharedAllocatorImpl(ep_device, *memory_info, allocator_type, allocator_options, allocator_out,
+                                   /*replace_existing*/ true);
+}
+
+Status Environment::CreateSharedAllocatorImpl(const OrtEpDevice& ep_device,
+                                              const OrtMemoryInfo& memory_info,
+                                              OrtAllocatorType allocator_type,
+                                              const OrtKeyValuePairs* allocator_options,
+                                              OrtAllocator** allocator_out,
+                                              bool replace_existing) {
+  // if we're replacing an existing allocator we don't care who added it
+  if (auto it = FindExistingAllocator(shared_allocators_, memory_info, /*match_name*/ false);
+      it != shared_allocators_.end()) {
+    if (!replace_existing) {
+      return Status::OK();
+    }
+
+    shared_allocators_.erase(it);
+  }
+
+  // clear out any exact match in the internal shared allocators
+  if (auto it = FindExistingAllocator(shared_ort_allocators_, memory_info, /*match_name*/ true);
+      it != shared_ort_allocators_.end()) {
+    shared_ort_allocators_.erase(it);
+  }
+
+  OrtAllocator* allocator = nullptr;
+  auto* ort_status = ep_device.ep_factory->CreateAllocator(ep_device.ep_factory, &memory_info, allocator_options,
+                                                           &allocator);
+  if (ort_status != nullptr) {
+    return ToStatus(ort_status);
+  }
+
+  if (allocator_out != nullptr) {
+    *allocator_out = allocator;
+  }
+
+  auto ort_allocator = OrtAllocatorUniquePtr(allocator,
+                                             [&ep_device](OrtAllocator* allocator) {
+                                               ep_device.ep_factory->ReleaseAllocator(ep_device.ep_factory, allocator);
+                                             });
+
+  AllocatorPtr shared_allocator;
+
+  if (allocator_type == OrtArenaAllocator) {
+    // wrap with arena
+    OrtArenaCfg arena_cfg;
+    if (allocator_options != nullptr) {
+      auto status = OrtArenaCfg::FromKeyValuePairs(*allocator_options, arena_cfg);
+    }
+
+    // pending Stream support being added to plugin EP API in separate PR
+    // ep_device.ep_factory->IsStreamAware(ep_device.ep_factory);
+    bool stream_aware_arena = false;
+
+    AllocatorCreationInfo alloc_creation_info{
+        [&ort_allocator](int) -> std::unique_ptr<IAllocator> {
+          return std::make_unique<IAllocatorImplWrappingOrtAllocator>(std::move(ort_allocator));
+        },
+        /*unused*/ -1,  // arg to the lambda above that is ignored as the device id comes from the allocator
+        /*create_arena*/ true,
+        arena_cfg,
+        stream_aware_arena,
+    };
+
+    shared_allocator = CreateAllocator(alloc_creation_info);
+  } else {
+    shared_allocator = std::make_shared<IAllocatorImplWrappingOrtAllocator>(std::move(ort_allocator));
+  }
+
+  shared_ort_allocators_.insert(allocator);
+  shared_allocators_.push_back(std::move(shared_allocator));
+
+  return Status::OK();
+}
+
+OrtAllocator* Environment::GetSharedAllocator(const OrtMemoryInfo& mem_info) {
+  // doesn't matter whether we match a custom allocator or an EP allocator so match_name is false
+  auto it = FindExistingAllocator(shared_ort_allocators_, mem_info, /*match_name*/ false);
+  return it != shared_ort_allocators_.end() ? *it : nullptr;
+}
+
+Status Environment::ReleaseSharedAllocator(const OrtEpDevice& ep_device, OrtDeviceMemoryType mem_type) {
+  auto* memory_info = mem_type == OrtMemTypeDefault ? ep_device.device_memory_info
+                                                    : ep_device.host_accessible_memory_info;
+  if (memory_info == nullptr) {
+    return Status(ONNXRUNTIME, ORT_INVALID_ARGUMENT, "Invalid memory type for OrtEpDevice.");
+  }
+
+  auto status = UnregisterAllocator(*memory_info);
 
   return status;
 }

--- a/onnxruntime/core/session/ep_api.cc
+++ b/onnxruntime/core/session/ep_api.cc
@@ -4,6 +4,10 @@
 #include "core/session/ep_api.h"
 
 #include "core/framework/error_code_helper.h"
+#include "core/framework/ort_value.h"
+#include "core/framework/ortdevice.h"
+#include "core/framework/ortmemoryinfo.h"
+#include "core/framework/tensor.h"
 #include "core/session/abi_devices.h"
 #include "core/session/ort_apis.h"
 
@@ -38,12 +42,77 @@ ORT_API(void, ReleaseEpDevice, _Frees_ptr_opt_ OrtEpDevice* device) {
   delete device;
 }
 
+ORT_API_STATUS_IMPL(EpDevice_AddAllocatorInfo, _In_ OrtEpDevice* ep_device,
+                    _In_ const OrtMemoryInfo* allocator_memory_info) {
+  const OrtDevice& info = allocator_memory_info->device;
+  if (info.MemType() == OrtDevice::MemType::DEFAULT) {
+    ep_device->device_memory_info = allocator_memory_info;
+  } else {
+    ep_device->host_accessible_memory_info = allocator_memory_info;
+  }
+
+  return nullptr;
+}
+
+ORT_API(const OrtMemoryDevice*, OrtMemoryInfo_GetMemoryDevice, _In_ const OrtMemoryInfo* memory_info) {
+  return static_cast<const OrtMemoryDevice*>(&memory_info->device);
+}
+
+ORT_API_STATUS_IMPL(OrtValue_GetMemoryDevice, _In_ const OrtValue* value, _Out_ const OrtMemoryDevice** device) {
+  *device = nullptr;
+  if (value == nullptr || value->IsTensor() == false) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "OrtValue does not contain an allocated tensor.");
+  }
+
+  auto& tensor = value->Get<Tensor>();
+  *device = static_cast<const OrtMemoryDevice*>(&tensor.Location().device);
+
+  return nullptr;
+}
+
+ORT_API(bool, OrtMemoryDevice_AreEqual, _In_ const OrtMemoryDevice* a, _In_ const OrtMemoryDevice* b) {
+  // don't care if they're both null as you don't need to call this function if they are
+  if (a == nullptr || b == nullptr) {
+    return false;
+  }
+
+  // TODO: Validate this calls OrtDevice::operator== as expected
+  return *a == *b;
+}
+
+ORT_API(OrtMemoryInfoDeviceType, OrtMemoryDevice_GetDeviceType, _In_ const OrtMemoryDevice* memory_device) {
+  switch (memory_device->Type()) {
+    case OrtDevice::GPU:
+      return OrtMemoryInfoDeviceType_GPU;
+    case OrtDevice::NPU:
+      return OrtMemoryInfoDeviceType_NPU;
+    case OrtDevice::FPGA:
+      return OrtMemoryInfoDeviceType_FPGA;
+    case OrtDevice::CPU:
+    default:  // should never happen. means we're out of sync with CreateMemoryInfo_V2
+      return OrtMemoryInfoDeviceType_CPU;
+  }
+}
+
+ORT_API(OrtDeviceMemoryType, OrtMemoryDevice_GetMemoryType, _In_ const OrtMemoryDevice* memory_device) {
+  return memory_device->MemType() == OrtDevice::MemType::DEFAULT ? OrtDeviceMemoryType_DEFAULT
+                                                                 : OrtDeviceMemoryType_HOST_ACCESSIBLE;
+}
+
 static constexpr OrtEpApi ort_ep_api = {
     // NOTE: ABI compatibility depends on the order within this struct so all additions must be at the end,
     // and no functions can be removed (the implementation needs to change to return an error).
 
     &OrtExecutionProviderApi::CreateEpDevice,
     &OrtExecutionProviderApi::ReleaseEpDevice,
+    &OrtExecutionProviderApi::EpDevice_AddAllocatorInfo,
+
+    &OrtExecutionProviderApi::OrtMemoryInfo_GetMemoryDevice,
+    &OrtExecutionProviderApi::OrtValue_GetMemoryDevice,
+
+    &OrtExecutionProviderApi::OrtMemoryDevice_AreEqual,
+    &OrtExecutionProviderApi::OrtMemoryDevice_GetDeviceType,
+    &OrtExecutionProviderApi::OrtMemoryDevice_GetMemoryType,
 };
 
 // checks that we don't violate the rule that the functions must remain in the slots they were originally assigned

--- a/onnxruntime/core/session/ep_api.h
+++ b/onnxruntime/core/session/ep_api.h
@@ -16,4 +16,14 @@ ORT_API_STATUS_IMPL(CreateEpDevice, _In_ OrtEpFactory* ep_factory,
                     _Out_ OrtEpDevice** ep_device);
 
 ORT_API(void, ReleaseEpDevice, _Frees_ptr_opt_ OrtEpDevice* device);
+
+ORT_API_STATUS_IMPL(EpDevice_AddAllocatorInfo, _In_ OrtEpDevice* ep_device,
+                    _In_ const OrtMemoryInfo* allocator_memory_info);
+
+ORT_API(const OrtMemoryDevice*, OrtMemoryInfo_GetMemoryDevice, _In_ const OrtMemoryInfo* memory_info);
+ORT_API_STATUS_IMPL(OrtValue_GetMemoryDevice, _In_ const OrtValue* value, _Out_ const OrtMemoryDevice** device);
+
+ORT_API(bool, OrtMemoryDevice_AreEqual, _In_ const OrtMemoryDevice* a, _In_ const OrtMemoryDevice* b);
+ORT_API(OrtMemoryInfoDeviceType, OrtMemoryDevice_GetDeviceType, _In_ const OrtMemoryDevice* memory_device);
+ORT_API(OrtDeviceMemoryType, OrtMemoryDevice_GetMemoryType, _In_ const OrtMemoryDevice* memory_device);
 }  // namespace OrtExecutionProviderApi

--- a/onnxruntime/core/session/ep_api_utils.h
+++ b/onnxruntime/core/session/ep_api_utils.h
@@ -8,11 +8,11 @@ namespace onnxruntime {
 // used by EpFactoryInternal and EpFactoryProviderBridge.
 template <typename TFactory>
 struct ForwardToFactory {
-  static const char* ORT_API_CALL GetFactoryName(const OrtEpFactory* this_ptr) {
+  static const char* ORT_API_CALL GetFactoryName(const OrtEpFactory* this_ptr) noexcept {
     return static_cast<const TFactory*>(this_ptr)->GetName();
   }
 
-  static const char* ORT_API_CALL GetVendor(const OrtEpFactory* this_ptr) {
+  static const char* ORT_API_CALL GetVendor(const OrtEpFactory* this_ptr) noexcept {
     return static_cast<const TFactory*>(this_ptr)->GetVendor();
   }
 
@@ -21,7 +21,7 @@ struct ForwardToFactory {
                                                      size_t num_devices,
                                                      OrtEpDevice** ep_devices,
                                                      size_t max_ep_devices,
-                                                     size_t* num_ep_devices) {
+                                                     size_t* num_ep_devices) noexcept {
     return static_cast<TFactory*>(this_ptr)->GetSupportedDevices(devices, num_devices, ep_devices,
                                                                  max_ep_devices, num_ep_devices);
   }
@@ -32,12 +32,12 @@ struct ForwardToFactory {
                                           size_t num_devices,
                                           const OrtSessionOptions* session_options,
                                           const OrtLogger* logger,
-                                          OrtEp** ep) {
+                                          OrtEp** ep) noexcept {
     return static_cast<TFactory*>(this_ptr)->CreateEp(devices, ep_metadata_pairs, num_devices,
                                                       session_options, logger, ep);
   }
 
-  static void ORT_API_CALL ReleaseEp(OrtEpFactory* this_ptr, OrtEp* ep) {
+  static void ORT_API_CALL ReleaseEp(OrtEpFactory* this_ptr, OrtEp* ep) noexcept {
     static_cast<TFactory*>(this_ptr)->ReleaseEp(ep);
   }
 };

--- a/onnxruntime/core/session/ep_factory_internal.cc
+++ b/onnxruntime/core/session/ep_factory_internal.cc
@@ -33,7 +33,7 @@ OrtStatus* EpFactoryInternal::GetSupportedDevices(const OrtHardwareDevice* const
                                                   size_t num_devices,
                                                   OrtEpDevice** ep_devices,
                                                   size_t max_ep_devices,
-                                                  size_t* num_ep_devices) {
+                                                  size_t* num_ep_devices) noexcept {
   return get_supported_func_(this, devices, num_devices, ep_devices, max_ep_devices, num_ep_devices);
 }
 
@@ -68,7 +68,7 @@ void EpFactoryInternal::ReleaseEp(OrtEp* /*ep*/) {
 }
 
 InternalExecutionProviderFactory::InternalExecutionProviderFactory(EpFactoryInternal& ep_factory,
-                                                                   const std::vector<const OrtEpDevice*>& ep_devices)
+                                                                   gsl::span<const OrtEpDevice* const> ep_devices)
     : ep_factory_{ep_factory} {
   devices_.reserve(ep_devices.size());
   ep_metadata_.reserve(ep_devices.size());

--- a/onnxruntime/core/session/ep_factory_internal.h
+++ b/onnxruntime/core/session/ep_factory_internal.h
@@ -36,14 +36,14 @@ class EpFactoryInternal : public OrtEpFactory {
                     GetSupportedFunc&& get_supported_func,
                     CreateFunc&& create_func);
 
-  const char* GetName() const { return ep_name_.c_str(); }
-  const char* GetVendor() const { return vendor_.c_str(); }
+  const char* GetName() const noexcept { return ep_name_.c_str(); }
+  const char* GetVendor() const noexcept { return vendor_.c_str(); }
 
   OrtStatus* GetSupportedDevices(_In_reads_(num_devices) const OrtHardwareDevice* const* devices,
                                  _In_ size_t num_devices,
                                  _Inout_ OrtEpDevice** ep_devices,
                                  _In_ size_t max_ep_devices,
-                                 _Out_ size_t* num_ep_devices);
+                                 _Out_ size_t* num_ep_devices) noexcept;
 
   // we don't implement this. CreateIExecutionProvider should be used.
   OrtStatus* CreateEp(_In_reads_(num_devices) const OrtHardwareDevice* const* devices,
@@ -74,7 +74,7 @@ class EpFactoryInternal : public OrtEpFactory {
 // IExecutionProviderFactory for EpFactoryInternal that is required for SessionOptionsAppendExecutionProvider_V2
 struct InternalExecutionProviderFactory : public IExecutionProviderFactory {
  public:
-  InternalExecutionProviderFactory(EpFactoryInternal& ep_factory, const std::vector<const OrtEpDevice*>& ep_devices);
+  InternalExecutionProviderFactory(EpFactoryInternal& ep_factory, gsl::span<const OrtEpDevice* const> ep_devices);
 
   std::unique_ptr<IExecutionProvider> CreateProvider(const OrtSessionOptions& session_options,
                                                      const OrtLogger& session_logger) override;

--- a/onnxruntime/core/session/ep_plugin_provider_interfaces.cc
+++ b/onnxruntime/core/session/ep_plugin_provider_interfaces.cc
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/session/ep_plugin_provider_interfaces.h"
+
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "core/framework/error_code_helper.h"
+#include "core/session/abi_devices.h"
+#include "core/session/abi_logger.h"
+#include "core/session/allocator_adapters.h"
+#include "core/providers/partitioning_utils.h"
+
+namespace onnxruntime {
+
+//
+// PluginExecutionProviderFactory
+//
+
+PluginExecutionProviderFactory::PluginExecutionProviderFactory(OrtEpFactory& ep_factory,
+                                                               gsl::span<const OrtEpDevice* const> ep_devices)
+    : ep_factory_{ep_factory},
+      devices_{ep_devices.begin(), ep_devices.end()} {
+  hardware_devices_.reserve(ep_devices.size());
+  ep_metadata_.reserve(ep_devices.size());
+
+  for (const auto* ep_device : devices_) {
+    hardware_devices_.push_back(ep_device->device);
+    ep_metadata_.push_back(&ep_device->ep_metadata);
+  }
+}
+
+std::unique_ptr<IExecutionProvider>
+PluginExecutionProviderFactory::CreateProvider(const OrtSessionOptions& session_options,
+                                               const OrtLogger& session_logger) {
+  OrtEp* ort_ep = nullptr;
+  OrtStatus* status = ep_factory_.CreateEp(&ep_factory_, hardware_devices_.data(), ep_metadata_.data(),
+                                           devices_.size(), &session_options, &session_logger, &ort_ep);
+  if (status != nullptr) {
+    ORT_THROW("Error creating execution provider: ", ToStatus(status).ToString());
+  }
+
+  auto ep_wrapper = std::make_unique<PluginExecutionProvider>(UniqueOrtEp(ort_ep, OrtEpDeleter(ep_factory_)),
+                                                              ep_factory_,
+                                                              devices_);
+  ep_wrapper->SetLogger(session_logger.ToInternal());
+
+  return ep_wrapper;
+}
+
+//
+// PluginExecutionProvider
+//
+
+PluginExecutionProvider::PluginExecutionProvider(UniqueOrtEp ep, OrtEpFactory& ep_factory,
+                                                 gsl::span<const OrtEpDevice* const> ep_devices)
+    : IExecutionProvider(ep->GetName(ep.get()), OrtDevice()),  // TODO: What to do about OrtDevice for plugins?
+      plugin_ep_(std::move(ep)),
+      ep_factory_{ep_factory},
+      ep_devices_{ep_devices.begin(), ep_devices.end()} {
+  // generally there should only be one OrtEpDevice.
+  // if there are multiple we expect them to come from the same factory.
+  ORT_ENFORCE(std::all_of(ep_devices_.begin(), ep_devices_.end(),
+                          [this](const OrtEpDevice* ep_device) { return ep_device->ep_factory == &ep_factory_; }));
+
+  for (const auto* ep_device : ep_devices_) {
+    if (ep_device->device_memory_info != nullptr) {
+      allocator_mem_infos_.push_back(ep_device->device_memory_info);
+    }
+
+    if (ep_device->host_accessible_memory_info != nullptr) {
+      allocator_mem_infos_.push_back(ep_device->host_accessible_memory_info);
+    }
+  }
+}
+
+std::unique_ptr<onnxruntime::IDataTransfer> PluginExecutionProvider::GetDataTransfer() const {
+  OrtDataTransferImpl* data_transfer_impl = nullptr;
+  OrtStatus* status = ep_factory_.CreateDataTransfer(&ep_factory_, &data_transfer_impl);
+  if (status != nullptr) {
+    ORT_THROW("Error creating data transfer: ", ToStatus(status).ToString());
+  }
+
+  auto dt = std::make_unique<plugin_ep::DataTransfer>(*data_transfer_impl);
+  return dt;
+}
+
+std::vector<AllocatorPtr> PluginExecutionProvider::CreatePreferredAllocators() {
+  std::vector<AllocatorPtr> allocators;
+  allocators.reserve(allocator_mem_infos_.size());
+
+  for (const auto* memory_info : allocator_mem_infos_) {
+    OrtAllocator* ort_allocator_ptr = nullptr;
+    OrtStatus* ort_status = ep_factory_.CreateAllocator(&ep_factory_, memory_info, nullptr, &ort_allocator_ptr);
+
+    // throw or log? start with throw
+    if (ort_status != nullptr) {
+      ORT_THROW("Error creating allocator: ", ToStatus(ort_status).ToString());
+    }
+
+    auto ort_allocator = OrtAllocatorUniquePtr(
+        ort_allocator_ptr,
+        [this](OrtAllocator* allocator) {
+          ep_factory_.ReleaseAllocator(&ep_factory_, allocator);
+        });
+    allocators.push_back(std::make_shared<IAllocatorImplWrappingOrtAllocator>(std::move(ort_allocator)));
+  }
+
+  return allocators;
+}
+
+PluginExecutionProvider::~PluginExecutionProvider() = default;
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/session/ep_plugin_provider_interfaces.h
+++ b/onnxruntime/core/session/ep_plugin_provider_interfaces.h
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <gsl/gsl>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include "core/common/common.h"
+#include "core/framework/execution_provider.h"
+#include "core/framework/plugin_data_transfer.h"
+#include "core/providers/providers.h"
+#include "core/session/onnxruntime_c_api.h"
+
+namespace onnxruntime {
+struct EpNode;
+struct EpValueInfo;
+
+/// <summary>
+/// IExecutionProviderFactory that wraps a OrtEpFactory. Required for SessionOptionsAppendExecutionProvider_V2.
+/// </summary>
+struct PluginExecutionProviderFactory : public IExecutionProviderFactory {
+ public:
+  PluginExecutionProviderFactory(OrtEpFactory& ep_factory, gsl::span<const OrtEpDevice* const> ep_devices);
+
+  std::unique_ptr<IExecutionProvider> CreateProvider(const OrtSessionOptions& session_options,
+                                                     const OrtLogger& session_logger) override;
+
+  std::unique_ptr<IExecutionProvider> CreateProvider() override {
+    ORT_NOT_IMPLEMENTED("CreateProvider without parameters is not supported.");
+  }
+
+ private:
+  OrtEpFactory& ep_factory_;
+  std::vector<const OrtEpDevice*> devices_;
+  std::vector<const OrtHardwareDevice*> hardware_devices_;
+  std::vector<const OrtKeyValuePairs*> ep_metadata_;
+};
+
+/// <summary>
+/// Functor that deletes an instance of OrtEp. Used to create an std::unique_ptr<OrtEp, OrtEpDeleter>.
+/// </summary>
+struct OrtEpDeleter {
+  explicit OrtEpDeleter(OrtEpFactory& ort_ep_factory) : ort_ep_factory_(ort_ep_factory) {}
+  void operator()(OrtEp* ort_ep) {
+    ort_ep_factory_.ReleaseEp(&ort_ep_factory_, ort_ep);
+  }
+  OrtEpFactory& ort_ep_factory_;
+};
+
+/// <summary>
+/// Type that represents a std::unique_ptr for an instance of OrtEp.
+/// </summary>
+using UniqueOrtEp = std::unique_ptr<OrtEp, OrtEpDeleter>;
+
+/// <summary>
+/// IExecutionProvider that wraps an instance of OrtEp.
+/// </summary>
+class PluginExecutionProvider : public IExecutionProvider {
+ public:
+  explicit PluginExecutionProvider(UniqueOrtEp ep, OrtEpFactory& ep_factory,
+                                   gsl::span<const OrtEpDevice* const> ep_devices);
+  ~PluginExecutionProvider();
+
+  std::unique_ptr<IDataTransfer> GetDataTransfer() const override;
+
+  // create per-session allocators
+  // longer term we should prefer shared allocators in Environment and only create per-session allocators as
+  // needed based on matching against allocator_mem_infos_.
+  std::vector<AllocatorPtr> CreatePreferredAllocators() override;
+
+ private:
+  UniqueOrtEp plugin_ep_;
+
+  OrtEpFactory& ep_factory_;
+  std::vector<const OrtEpDevice*> ep_devices_;
+  std::vector<const OrtMemoryInfo*> allocator_mem_infos_;
+};
+}  // namespace onnxruntime

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -111,12 +111,12 @@ using namespace onnxruntime;
 #define TENSOR_READ_API_BEGIN                          \
   API_IMPL_BEGIN                                       \
   auto v = reinterpret_cast<const ::OrtValue*>(value); \
-  auto& tensor = v->Get<onnxruntime::Tensor>();
+  const auto& tensor = v->Get<onnxruntime::Tensor>();
 
 #define TENSOR_READWRITE_API_BEGIN \
   API_IMPL_BEGIN                   \
   auto v = (value);                \
-  auto tensor = v->GetMutable<onnxruntime::Tensor>();
+  auto* tensor = v->GetMutable<onnxruntime::Tensor>();
 
 namespace {
 // Create tensor. Allocates memory. Tensor owns memory. Allocator is wrapped and stored in a shared_ptr in Tensor.
@@ -1083,6 +1083,13 @@ ORT_API_STATUS_IMPL(OrtApis::GetTensorMutableData, _Inout_ OrtValue* value, _Out
   //  return OrtApis::CreateStatus(ORT_NOT_IMPLEMENTED, "this API does not support strings");
   //}
   *output = tensor->MutableDataRaw();
+  return nullptr;
+  API_IMPL_END
+}
+
+ORT_API_STATUS_IMPL(OrtApis::GetTensorData, _Inout_ const OrtValue* value, _Outptr_ const void** output) {
+  TENSOR_READ_API_BEGIN
+  *output = tensor.DataRaw();
   return nullptr;
   API_IMPL_END
 }
@@ -2236,6 +2243,11 @@ ORT_API_STATUS_IMPL(OrtApis::CreateArenaCfg, _In_ size_t max_mem, int arena_exte
   cfg->initial_chunk_size_bytes = initial_chunk_size_bytes;
   cfg->max_dead_bytes_per_chunk = max_dead_bytes_per_chunk;
   cfg->max_dead_bytes_per_chunk = -1L;
+
+  if (!cfg->IsValid()) {
+    return CreateStatus(ORT_INVALID_ARGUMENT, "Invalid configuration value was provided.");
+  }
+
   *out = cfg.release();
   return nullptr;
   API_IMPL_END
@@ -2265,6 +2277,10 @@ ORT_API_STATUS_IMPL(OrtApis::CreateArenaCfgV2, _In_reads_(num_keys) const char* 
 
       return CreateStatus(ORT_INVALID_ARGUMENT, oss.str().c_str());
     }
+  }
+
+  if (!cfg->IsValid()) {
+    return CreateStatus(ORT_INVALID_ARGUMENT, "Invalid configuration value was provided.");
   }
 
   *out = cfg.release();
@@ -2598,6 +2614,10 @@ ORT_API(const OrtKeyValuePairs*, OrtApis::EpDevice_EpOptions, _In_ const OrtEpDe
 
 ORT_API(const OrtHardwareDevice*, OrtApis::EpDevice_Device, _In_ const OrtEpDevice* ep_device) {
   return ep_device->device;
+}
+
+ORT_API(const OrtMemoryInfo*, OrtApis::EpDevice_MemoryInfo, _In_ const OrtEpDevice* ep_device) {
+  return ep_device->device_memory_info;
 }
 
 static constexpr OrtApiBase ort_api_base = {
@@ -3031,7 +3051,15 @@ static constexpr OrtApi ort_api_1_to_23 = {
     // End of Version 22 - DO NOT MODIFY ABOVE (see above text for more information)
     &OrtApis::GetTensorSizeInBytes,
     &OrtApis::AllocatorGetStats,
+
     &OrtApis::CreateMemoryInfo_V2,
+    &OrtApis::EpDevice_MemoryInfo,
+
+    &OrtApis::CreateSharedAllocator,
+    &OrtApis::GetSharedAllocator,
+    &OrtApis::ReleaseSharedAllocator,
+
+    &OrtApis::GetTensorData,
 };
 
 // OrtApiBase can never change as there is no way to know what version of OrtApiBase is returned by OrtGetApiBase.

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -607,4 +607,16 @@ ORT_API_STATUS_IMPL(CreateMemoryInfo_V2, _In_ const char* name, _In_ enum OrtMem
                     _In_ uint32_t vendor_id, _In_ int16_t device_id, _In_ enum OrtDeviceMemoryType mem_type,
                     _In_ size_t alignment, enum OrtAllocatorType allocator_type,
                     _Outptr_ OrtMemoryInfo** out);
+
+ORT_API(const OrtMemoryInfo*, EpDevice_MemoryInfo, _In_ const OrtEpDevice* ep_device);
+
+ORT_API_STATUS_IMPL(CreateSharedAllocator, _In_ OrtEnv* env, _In_ const OrtEpDevice* ep_device,
+                    _In_ OrtDeviceMemoryType mem_type, _In_ OrtAllocatorType allocator_type,
+                    _In_opt_ const OrtKeyValuePairs* allocator_options,
+                    _Outptr_opt_ OrtAllocator** allocator);
+ORT_API(OrtAllocator*, GetSharedAllocator, _In_ OrtEnv* env, _In_ const OrtMemoryInfo* mem_info);
+ORT_API_STATUS_IMPL(ReleaseSharedAllocator, _In_ OrtEnv* env, _In_ const OrtEpDevice* ep_device,
+                    _In_ OrtDeviceMemoryType mem_type);
+
+ORT_API_STATUS_IMPL(GetTensorData, _In_ const OrtValue* value, _Outptr_ const void** out);
 }  // namespace OrtApis

--- a/onnxruntime/core/session/ort_env.cc
+++ b/onnxruntime/core/session/ort_env.cc
@@ -105,10 +105,17 @@ void OrtEnv::Release(OrtEnv* env_ptr) {
         instance_to_delete = p_instance_;  // Point to the instance to be deleted.
         p_instance_ = nullptr;             // Set the static instance pointer to nullptr under the lock.
       } else {
+#if !defined(ONNXRUNTIME_ENABLE_MEMLEAK_CHECK)
         // Process is shutting down, let it leak.
         // p_instance_ remains as is (though ref_count_ is 0), future CreateEnv calls
         // would increment ref_count_ on this "leaked" instance.
         // This behavior matches the requirement to "just let the memory leak out".
+#else
+        // we're tracing for memory leaks so we want to avoid as many leaks as possible and the leaks are considered
+        // as failures for test apps.
+        instance_to_delete = p_instance_;
+        p_instance_ = nullptr;
+#endif
       }
     }
   }  // Mutex m_ is released here when lock_guard goes out of scope.
@@ -124,23 +131,4 @@ onnxruntime::logging::LoggingManager* OrtEnv::GetLoggingManager() const {
 
 void OrtEnv::SetLoggingManager(std::unique_ptr<onnxruntime::logging::LoggingManager> logging_manager) {
   value_->SetLoggingManager(std::move(logging_manager));
-}
-
-onnxruntime::common::Status OrtEnv::RegisterAllocator(AllocatorPtr allocator) {
-  auto status = value_->RegisterAllocator(allocator);
-  return status;
-}
-
-onnxruntime::common::Status OrtEnv::CreateAndRegisterAllocator(const OrtMemoryInfo& mem_info,
-                                                               const OrtArenaCfg* arena_cfg) {
-  auto status = value_->CreateAndRegisterAllocator(mem_info, arena_cfg);
-  return status;
-}
-
-onnxruntime::common::Status OrtEnv::UnregisterAllocator(const OrtMemoryInfo& mem_info) {
-  return value_->UnregisterAllocator(mem_info);
-}
-
-onnxruntime::common::Status OrtEnv::CreateAndRegisterAllocatorV2(const std::string& provider_type, const OrtMemoryInfo& mem_info, const std::unordered_map<std::string, std::string>& options, const OrtArenaCfg* arena_cfg) {
-  return value_->CreateAndRegisterAllocatorV2(provider_type, mem_info, options, arena_cfg);
 }

--- a/onnxruntime/core/session/ort_env.h
+++ b/onnxruntime/core/session/ort_env.h
@@ -48,26 +48,8 @@ struct OrtEnv {
   onnxruntime::logging::LoggingManager* GetLoggingManager() const;
   void SetLoggingManager(std::unique_ptr<onnxruntime::logging::LoggingManager> logging_manager);
 
-  /**
-   * Registers an allocator for sharing between multiple sessions.
-   * Returns an error if an allocator with the same OrtMemoryInfo is already registered.
-   */
-  onnxruntime::common::Status RegisterAllocator(onnxruntime::AllocatorPtr allocator);
-
-  /**
-   * Creates and registers an allocator for sharing between multiple sessions.
-   * Return an error if an allocator with the same OrtMemoryInfo is already registered.
-   */
-  onnxruntime::common::Status CreateAndRegisterAllocator(const OrtMemoryInfo& mem_info,
-                                                         const OrtArenaCfg* arena_cfg = nullptr);
-
-  /**
-   * Removes registered allocator that was previously registered for sharing between multiple sessions.
-   */
-  onnxruntime::common::Status UnregisterAllocator(const OrtMemoryInfo& mem_info);
   OrtEnv(std::unique_ptr<onnxruntime::Environment> value);
   ~OrtEnv();
-  onnxruntime::common::Status CreateAndRegisterAllocatorV2(const std::string& provider_type, const OrtMemoryInfo& mem_info, const std::unordered_map<std::string, std::string>& options, const OrtArenaCfg* arena_cfg = nullptr);
 
  private:
   // p_instance_ holds the single, global instance of OrtEnv.

--- a/onnxruntime/core/session/utils.cc
+++ b/onnxruntime/core/session/utils.cc
@@ -19,6 +19,7 @@
 #include "core/session/ep_factory_internal.h"
 #include "core/session/ep_library_plugin.h"
 #include "core/session/ep_library_provider_bridge.h"
+#include "core/session/ep_plugin_provider_interfaces.h"
 #include "core/session/model_compilation_options.h"
 #include "core/session/provider_policy_context.h"
 #endif  // !defined(ORT_MINIMAL_BUILD)
@@ -348,12 +349,17 @@ Status CreateIExecutionProviderFactoryForEpDevices(const Environment& env,
                            "All OrtEpDevice values in ep_devices must have the same execution provider.");
   }
 
-  EpFactoryInternal* internal_factory = nullptr;
+  std::unique_ptr<IExecutionProviderFactory> provider_factory = nullptr;
+
   for (const OrtEpDevice* ep_device : ep_devices) {
-    // we expect the internal factory to be available for internal and provider bridge EPs, which is all we support.
-    internal_factory = env.GetEpFactoryInternal(ep_device->ep_factory);
-    if (!internal_factory) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "EP is not currently supported by this API");
+    if (provider_factory == nullptr) {
+      EpFactoryInternal* internal_factory = env.GetEpFactoryInternal(ep_device->ep_factory);
+
+      if (internal_factory) {
+        provider_factory = std::make_unique<InternalExecutionProviderFactory>(*internal_factory, ep_devices);
+      } else {
+        provider_factory = std::make_unique<PluginExecutionProviderFactory>(*ep_device->ep_factory, ep_devices);
+      }
     }
 
     // add the options to the session options with the EP prefix.
@@ -373,13 +379,8 @@ Status CreateIExecutionProviderFactoryForEpDevices(const Environment& env,
     }
   }
 
-  if (!internal_factory) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "EP is not currently supported by this API");
-  }
+  out = std::move(provider_factory);
 
-  out = std::make_unique<InternalExecutionProviderFactory>(*internal_factory,
-                                                           std::vector<const OrtEpDevice*>(ep_devices.begin(),
-                                                                                           ep_devices.end()));
   return Status::OK();
 }
 #endif  // !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/test/autoep/library/ep.cc
+++ b/onnxruntime/test/autoep/library/ep.cc
@@ -1,0 +1,26 @@
+#include "ep.h"
+#include "ep_factory.h"
+
+ExampleEp::ExampleEp(ExampleEpFactory& factory, const std::string& name,
+                     const OrtSessionOptions& session_options, const OrtLogger& logger)
+    : ApiPtrs(static_cast<const ApiPtrs&>(factory)),
+      factory_{factory},
+      name_{name},
+      session_options_{session_options},
+      logger_{logger} {
+  // Initialize the execution provider's function table
+  GetName = GetNameImpl;
+
+  auto status = ort_api.Logger_LogMessage(&logger_,
+                                          OrtLoggingLevel::ORT_LOGGING_LEVEL_INFO,
+                                          ("ExampleEp has been created with name " + name_).c_str(),
+                                          ORT_FILE, __LINE__, __FUNCTION__);
+  // ignore status for now
+  (void)status;
+}
+
+/*static*/
+const char* ExampleEp ::GetNameImpl(const OrtEp* this_ptr) noexcept {
+  const auto* ep = static_cast<const ExampleEp*>(this_ptr);
+  return ep->name_.c_str();
+}

--- a/onnxruntime/test/autoep/library/ep.h
+++ b/onnxruntime/test/autoep/library/ep.h
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "onnxruntime_c_api.h"
+#include "utils.h"
+
+class ExampleEpFactory;
+
+class ExampleEp : public OrtEp, public ApiPtrs {
+ public:
+  ExampleEp(ExampleEpFactory& factory, const std::string& name,
+            const OrtSessionOptions& session_options, const OrtLogger& logger);
+
+  ~ExampleEp() = default;
+
+ private:
+  static const char* GetNameImpl(const OrtEp* this_ptr) noexcept;
+
+  ExampleEpFactory& factory_;
+  std::string name_;
+  const OrtSessionOptions& session_options_;
+  const OrtLogger& logger_;
+};

--- a/onnxruntime/test/autoep/library/ep_allocator.h
+++ b/onnxruntime/test/autoep/library/ep_allocator.h
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "onnxruntime_cxx_api.h"
+
+struct CustomAllocator : OrtAllocator {
+  CustomAllocator(const OrtMemoryInfo* mem_info) : memory_info{mem_info} {
+    Alloc = AllocImpl;
+    Free = FreeImpl;
+    Info = InfoImpl;
+    Reserve = AllocImpl;  // no special reserve logic and most likely unnecessary unless you have your own arena
+  }
+
+  static void* ORT_API_CALL AllocImpl(struct OrtAllocator* /*this_*/, size_t size) {
+    // CustomAllocator& impl = *static_cast<CustomAllocator*>(this_);
+    return malloc(size);
+  }
+
+  /// Free a block of memory previously allocated with OrtAllocator::Alloc
+  static void ORT_API_CALL FreeImpl(struct OrtAllocator* /*this_*/, void* p) {
+    return free(p);
+  }
+
+  /// Return a pointer to an ::OrtMemoryInfo that describes this allocator
+  static const struct OrtMemoryInfo* ORT_API_CALL InfoImpl(const struct OrtAllocator* this_) {
+    const CustomAllocator& impl = *static_cast<const CustomAllocator*>(this_);
+    return impl.memory_info;
+  }
+
+ private:
+  const OrtMemoryInfo* memory_info;
+};

--- a/onnxruntime/test/autoep/library/ep_data_transfer.cc
+++ b/onnxruntime/test/autoep/library/ep_data_transfer.cc
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "ep_data_transfer.h"
+
+#include <cassert>
+#include <gsl/span>
+
+/*static*/
+bool ORT_API_CALL ExampleDataTransfer::CanCopyImpl(void* this_ptr,
+                                                   const OrtMemoryDevice* src_memory_device,
+                                                   const OrtMemoryDevice* dst_memory_device) noexcept {
+  auto& impl = *static_cast<ExampleDataTransfer*>(this_ptr);
+  bool src_is_our_device = impl.ep_api.OrtMemoryDevice_AreEqual(src_memory_device, impl.device_mem_info);
+  bool dst_is_our_device = impl.ep_api.OrtMemoryDevice_AreEqual(dst_memory_device, impl.device_mem_info);
+
+  return src_is_our_device || dst_is_our_device;
+}
+
+// function to copy one or more tensors.
+// implementation can optionally use async copy if a stream is available for the input.
+/*static*/
+OrtStatus* ORT_API_CALL ExampleDataTransfer::CopyTensorsImpl(void* this_ptr,
+                                                             const OrtValue** src_tensors_ptr,
+                                                             OrtValue** dst_tensors_ptr,
+                                                             OrtSyncStream** streams_ptr,
+                                                             size_t num_tensors) noexcept {
+  auto& impl = *static_cast<ExampleDataTransfer*>(this_ptr);
+
+  auto src_tensors = gsl::make_span<const OrtValue*>(src_tensors_ptr, num_tensors);
+  auto dst_tensors = gsl::make_span<OrtValue*>(dst_tensors_ptr, num_tensors);
+  auto streams = gsl::make_span<OrtSyncStream*>(streams_ptr, num_tensors);
+
+  for (size_t i = 0; i < num_tensors; ++i) {
+    // NOTE: Stream support will be a separate PR. ignore teh streams_ptr values for now
+
+    const OrtMemoryDevice* src_device = nullptr;
+    const OrtMemoryDevice* dst_device = nullptr;
+    RETURN_IF_ERROR(impl.ep_api.OrtValue_GetMemoryDevice(src_tensors[i], &src_device));
+    RETURN_IF_ERROR(impl.ep_api.OrtValue_GetMemoryDevice(dst_tensors[i], &dst_device));
+
+    OrtMemoryInfoDeviceType src_device_type = impl.ep_api.OrtMemoryDevice_GetDeviceType(src_device);
+    OrtMemoryInfoDeviceType dst_device_type = impl.ep_api.OrtMemoryDevice_GetDeviceType(dst_device);
+    OrtDeviceMemoryType src_mem_type = impl.ep_api.OrtMemoryDevice_GetMemoryType(src_device);
+    OrtDeviceMemoryType dst_mem_type = impl.ep_api.OrtMemoryDevice_GetMemoryType(dst_device);
+
+    const void* src_data = nullptr;
+    void* dst_data = nullptr;
+    RETURN_IF_ERROR(impl.ort_api.GetTensorData(src_tensors[i], &src_data));
+    RETURN_IF_ERROR(impl.ort_api.GetTensorMutableData(dst_tensors[i], &dst_data));
+
+    bool copy_involves_pinned_memory = src_mem_type == OrtDeviceMemoryType_HOST_ACCESSIBLE ||
+                                       dst_mem_type == OrtDeviceMemoryType_HOST_ACCESSIBLE;
+
+    if (dst_device_type == OrtMemoryInfoDeviceType_GPU) {
+      if (src_device_type == OrtMemoryInfoDeviceType_GPU) {
+        // GPU -> GPU
+      } else {
+        // CPU -> GPU
+      }
+    } else if (src_device_type == OrtMemoryInfoDeviceType_GPU) {
+      // GPU -> CPU
+    } else {
+      // CPU -> CPU involves copy to/from pinned memory and a synchronize may be required first
+      assert(copy_involves_pinned_memory);
+    }
+  }
+
+  return nullptr;
+}
+
+/*static*/
+void ORT_API_CALL ExampleDataTransfer::ReleaseImpl(void* this_ptr) noexcept {
+  delete static_cast<ExampleDataTransfer*>(this_ptr);
+}

--- a/onnxruntime/test/autoep/library/ep_data_transfer.h
+++ b/onnxruntime/test/autoep/library/ep_data_transfer.h
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "onnxruntime_c_api.h"
+#include "utils.h"
+
+struct ExampleDataTransfer : OrtDataTransferImpl, ApiPtrs {
+  ExampleDataTransfer(ApiPtrs api_ptrs,
+                      const OrtMemoryDevice* device_mem_info_,
+                      const OrtMemoryDevice* shared_mem_info_ = nullptr)
+      : ApiPtrs(api_ptrs), device_mem_info{device_mem_info_}, shared_mem_info{shared_mem_info_} {
+    CanCopy = CanCopyImpl;
+    CopyTensors = CopyTensorsImpl;
+    Release = ReleaseImpl;
+  }
+
+  static bool ORT_API_CALL CanCopyImpl(void* this_ptr,
+                                       const OrtMemoryDevice* src_memory_device,
+                                       const OrtMemoryDevice* dst_memory_device) noexcept;
+
+  // function to copy one or more tensors.
+  // implementation can optionally use async copy if a stream is available for the input.
+  static OrtStatus* ORT_API_CALL CopyTensorsImpl(void* this_ptr,
+                                                 const OrtValue** src_tensors_ptr,
+                                                 OrtValue** dst_tensors_ptr,
+                                                 OrtSyncStream** streams_ptr,
+                                                 size_t num_tensors) noexcept;
+  static void ORT_API_CALL ReleaseImpl(void* this_ptr) noexcept;
+
+ private:
+  const OrtMemoryDevice* device_mem_info;
+  const OrtMemoryDevice* shared_mem_info;
+};

--- a/onnxruntime/test/autoep/library/ep_factory.cc
+++ b/onnxruntime/test/autoep/library/ep_factory.cc
@@ -1,0 +1,237 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "ep_factory.h"
+
+#include <cassert>
+
+#include "ep.h"
+#include "ep_allocator.h"
+#include "ep_data_transfer.h"
+
+ExampleEpFactory::ExampleEpFactory(const char* ep_name, ApiPtrs apis)
+    : ApiPtrs(apis), ep_name_{ep_name} {
+  ort_version_supported = ORT_API_VERSION;  // set to the ORT version we were compiled with.
+  GetName = GetNameImpl;
+  GetVendor = GetVendorImpl;
+
+  GetSupportedDevices = GetSupportedDevicesImpl;
+
+  CreateEp = CreateEpImpl;
+  ReleaseEp = ReleaseEpImpl;
+
+  CreateAllocator = CreateAllocatorImpl;
+  ReleaseAllocator = ReleaseAllocatorImpl;
+
+  CreateDataTransfer = CreateDataTransferImpl;
+
+  // for the sake of this example we specify a CPU allocator with no arena and 1K alignment (arbitrary)
+  // as well as GPU and GPU shared memory. the actual EP implementation would typically define two at most for a
+  // device (one for device memory and one for shared memory for data transfer between device and CPU)
+
+  // setup the OrtMemoryInfo instances required by the EP.
+  OrtMemoryInfo* mem_info = nullptr;
+  auto* status = ort_api.CreateMemoryInfo_V2("ExampleEP CPU", OrtMemoryInfoDeviceType_CPU,
+                                             /*vendor*/ 0xBE57, /* device_id */ 0,
+                                             OrtDeviceMemoryType_DEFAULT,
+                                             /*alignment*/ 1024,
+                                             OrtAllocatorType::OrtDeviceAllocator,  // no arena
+                                             &mem_info);
+  assert(status == nullptr);  // should never fail.
+
+  cpu_memory_info_ = MemoryInfoUniquePtr(mem_info, ort_api.ReleaseMemoryInfo);
+
+  //
+  // GPU allocator OrtMemoryInfo for example purposes
+  mem_info = nullptr;
+  status = ort_api.CreateMemoryInfo_V2("ExampleEP GPU", OrtMemoryInfoDeviceType_GPU,
+                                       /*vendor*/ 0xBE57, /* device_id */ 0,
+                                       OrtDeviceMemoryType_DEFAULT,
+                                       /*alignment*/ 0,
+                                       OrtAllocatorType::OrtDeviceAllocator,
+                                       &mem_info);
+  assert(status == nullptr);  // should never fail.
+  default_gpu_memory_info_ = MemoryInfoUniquePtr(mem_info, ort_api.ReleaseMemoryInfo);
+
+  mem_info = nullptr;
+  status = ort_api.CreateMemoryInfo_V2("ExampleEP GPU pinned", OrtMemoryInfoDeviceType_CPU,
+                                       /*vendor*/ 0xBE57, /* device_id */ 0,
+                                       OrtDeviceMemoryType_HOST_ACCESSIBLE,
+                                       /*alignment*/ 0,
+                                       OrtAllocatorType::OrtDeviceAllocator,
+                                       &mem_info);
+  assert(status == nullptr);  // should never fail.
+  host_accessible_gpu_memory_info_ = MemoryInfoUniquePtr(mem_info, ort_api.ReleaseMemoryInfo);
+
+  // if we were to use GPU we'd create it like this
+  data_transfer_impl_ = std::make_unique<ExampleDataTransfer>(
+      apis,
+      ep_api.OrtMemoryInfo_GetMemoryDevice(default_gpu_memory_info_.get()),         // device memory
+      ep_api.OrtMemoryInfo_GetMemoryDevice(host_accessible_gpu_memory_info_.get())  // shared memory
+  );
+
+  data_transfer_impl_.reset();  // but we're CPU only so we return nullptr for the IDataTransfer.
+}
+
+/*static*/
+const char* ORT_API_CALL ExampleEpFactory::GetNameImpl(const OrtEpFactory* this_ptr) noexcept {
+  const auto* factory = static_cast<const ExampleEpFactory*>(this_ptr);
+  return factory->ep_name_.c_str();
+}
+
+/*static*/
+const char* ORT_API_CALL ExampleEpFactory::GetVendorImpl(const OrtEpFactory* this_ptr) noexcept {
+  const auto* factory = static_cast<const ExampleEpFactory*>(this_ptr);
+  return factory->vendor_.c_str();
+}
+
+/*static*/
+OrtStatus* ORT_API_CALL ExampleEpFactory::GetSupportedDevicesImpl(OrtEpFactory* this_ptr,
+                                                                  const OrtHardwareDevice* const* devices,
+                                                                  size_t num_devices,
+                                                                  OrtEpDevice** ep_devices,
+                                                                  size_t max_ep_devices,
+                                                                  size_t* p_num_ep_devices) noexcept {
+  size_t& num_ep_devices = *p_num_ep_devices;
+  auto* factory = static_cast<ExampleEpFactory*>(this_ptr);
+
+  for (size_t i = 0; i < num_devices && num_ep_devices < max_ep_devices; ++i) {
+    // C API
+    const OrtHardwareDevice& device = *devices[i];
+    if (factory->ort_api.HardwareDevice_Type(&device) == OrtHardwareDeviceType::OrtHardwareDeviceType_CPU) {
+      // these can be returned as nullptr if you have nothing to add.
+      OrtKeyValuePairs* ep_metadata = nullptr;
+      OrtKeyValuePairs* ep_options = nullptr;
+      factory->ort_api.CreateKeyValuePairs(&ep_metadata);
+      factory->ort_api.CreateKeyValuePairs(&ep_options);
+
+      // random example using made up values
+      factory->ort_api.AddKeyValuePair(ep_metadata, "version", "0.1");
+      factory->ort_api.AddKeyValuePair(ep_options, "run_really_fast", "true");
+
+      // OrtEpDevice copies ep_metadata and ep_options.
+      OrtEpDevice* ep_device = nullptr;
+      auto* status = factory->ort_api.GetEpApi()->CreateEpDevice(factory, &device, ep_metadata, ep_options,
+                                                                 &ep_device);
+
+      factory->ort_api.ReleaseKeyValuePairs(ep_metadata);
+      factory->ort_api.ReleaseKeyValuePairs(ep_options);
+
+      if (status != nullptr) {
+        return status;
+      }
+
+      // register the allocator info required by the EP.
+      // in this example we register CPU info which is unnecessary unless you need to override the default ORT allocator
+      // for a non-CPU EP this would be device info (GPU/NPU) and possible host accessible info.
+      RETURN_IF_ERROR(factory->ep_api.EpDevice_AddAllocatorInfo(ep_device, factory->cpu_memory_info_.get()));
+
+      ep_devices[num_ep_devices++] = ep_device;
+    }
+
+    // C++ API equivalent. Throws on error.
+    //{
+    //  Ort::ConstHardwareDevice device(devices[i]);
+    //  if (device.Type() == OrtHardwareDeviceType::OrtHardwareDeviceType_CPU) {
+    //    Ort::KeyValuePairs ep_metadata;
+    //    Ort::KeyValuePairs ep_options;
+    //    ep_metadata.Add("version", "0.1");
+    //    ep_options.Add("run_really_fast", "true");
+    //    Ort::EpDevice ep_device{*this_ptr, device, ep_metadata.GetConst(), ep_options.GetConst()};
+    //    ep_devices[num_ep_devices++] = ep_device.release();
+    //  }
+    //}
+  }
+
+  return nullptr;
+}
+
+/*static*/
+OrtStatus* ORT_API_CALL ExampleEpFactory::CreateEpImpl(OrtEpFactory* this_ptr,
+                                                       const OrtHardwareDevice* const* /*devices*/,
+                                                       const OrtKeyValuePairs* const* /*ep_metadata*/,
+                                                       size_t num_devices,
+                                                       const OrtSessionOptions* session_options,
+                                                       const OrtLogger* logger,
+                                                       OrtEp** ep) noexcept {
+  auto* factory = static_cast<ExampleEpFactory*>(this_ptr);
+  *ep = nullptr;
+
+  if (num_devices != 1) {
+    // we only registered for CPU and only expected to be selected for one CPU
+    // if you register for multiple devices (e.g. CPU, GPU and maybe NPU) you will get an entry for each device
+    // the EP has been selected for.
+    return factory->ort_api.CreateStatus(ORT_INVALID_ARGUMENT,
+                                         "Example EP only supports selection for one device.");
+  }
+
+  // Create the execution provider
+  RETURN_IF_ERROR(factory->ort_api.Logger_LogMessage(logger,
+                                                     OrtLoggingLevel::ORT_LOGGING_LEVEL_INFO,
+                                                     "Creating Example EP", ORT_FILE, __LINE__, __FUNCTION__));
+
+  // use properties from the device and ep_metadata if needed
+  // const OrtHardwareDevice* device = devices[0];
+  // const OrtKeyValuePairs* ep_metadata = ep_metadata[0];
+
+  auto dummy_ep = std::make_unique<ExampleEp>(*factory, factory->ep_name_, *session_options, *logger);
+
+  *ep = dummy_ep.release();
+  return nullptr;
+}
+
+/*static*/
+void ORT_API_CALL ExampleEpFactory::ReleaseEpImpl(OrtEpFactory* /*this_ptr*/, OrtEp* ep) noexcept {
+  ExampleEp* dummy_ep = static_cast<ExampleEp*>(ep);
+  delete dummy_ep;
+}
+
+/*static*/
+OrtStatus* ORT_API_CALL ExampleEpFactory::CreateAllocatorImpl(OrtEpFactory* this_ptr,
+                                                              const OrtMemoryInfo* memory_info,
+                                                              const OrtKeyValuePairs* /*allocator_options*/,
+                                                              OrtAllocator** allocator) noexcept {
+  auto& factory = *static_cast<ExampleEpFactory*>(this_ptr);
+  *allocator = nullptr;
+
+  // NOTE: The factory implementation can return a shared OrtAllocator* instead of creating a new instance on each call.
+  //       To do this just make ReleaseAllocatorImpl a no-op.
+
+  // NOTE: If OrtMemoryInfo has allocator type (call MemoryInfoGetType) of OrtArenaAllocator, an ORT BFCArena
+  //       will be added to wrap the returned OrtAllocator. The EP is free to implement its own arena, and if it
+  //       wants to do this the OrtMemoryInfo MUST be created with an allocator type of OrtDeviceAllocator.
+
+  // NOTE: The OrtMemoryInfo pointer should only ever be coming straight from an OrtEpDevice, and pointer based
+  // matching should work.
+  if (memory_info == factory.cpu_memory_info_.get()) {
+    // create a CPU allocator. use the basic OrtAllocator for this example.
+    auto cpu_allocator = std::make_unique<CustomAllocator>(memory_info);
+    *allocator = cpu_allocator.release();
+  } else if (memory_info == factory.default_gpu_memory_info_.get()) {
+    // create a GPU allocator
+    return factory.ort_api.CreateStatus(ORT_NOT_IMPLEMENTED, "Example is not implemented.");
+  } else if (memory_info == factory.host_accessible_gpu_memory_info_.get()) {
+    // create a pinned memory allocator
+    return factory.ort_api.CreateStatus(ORT_NOT_IMPLEMENTED, "Example is not implemented.");
+  } else {
+    return factory.ort_api.CreateStatus(ORT_INVALID_ARGUMENT,
+                                        "INTERNAL ERROR! Unknown memory info provided to CreateAllocator. "
+                                        "Value did not come directly from an OrtEpDevice returned by this factory.");
+  }
+
+  return nullptr;
+}
+
+/*static*/
+void ORT_API_CALL ExampleEpFactory::ReleaseAllocatorImpl(OrtEpFactory* /*this*/, OrtAllocator* allocator) noexcept {
+  delete static_cast<CustomAllocator*>(allocator);
+}
+
+/*static*/
+OrtStatus* ORT_API_CALL ExampleEpFactory::CreateDataTransferImpl(OrtEpFactory* this_ptr,
+                                                                 OrtDataTransferImpl** data_transfer) noexcept {
+  auto& factory = *static_cast<ExampleEpFactory*>(this_ptr);
+  *data_transfer = factory.data_transfer_impl_.get();
+
+  return nullptr;
+}

--- a/onnxruntime/test/autoep/library/ep_factory.h
+++ b/onnxruntime/test/autoep/library/ep_factory.h
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "onnxruntime_c_api.h"
+#include "ep_data_transfer.h"
+#include "utils.h"
+
+class ExampleEpFactory : public OrtEpFactory, public ApiPtrs {
+ public:
+  ExampleEpFactory(const char* ep_name, ApiPtrs apis);
+
+  OrtDataTransferImpl* GetDataTransfer() const {
+    return data_transfer_impl_.get();
+  }
+
+ private:
+  static const char* ORT_API_CALL GetNameImpl(const OrtEpFactory* this_ptr) noexcept;
+
+  static const char* ORT_API_CALL GetVendorImpl(const OrtEpFactory* this_ptr) noexcept;
+
+  static OrtStatus* ORT_API_CALL GetSupportedDevicesImpl(OrtEpFactory* this_ptr,
+                                                         const OrtHardwareDevice* const* devices,
+                                                         size_t num_devices,
+                                                         OrtEpDevice** ep_devices,
+                                                         size_t max_ep_devices,
+                                                         size_t* p_num_ep_devices) noexcept;
+
+  static OrtStatus* ORT_API_CALL CreateEpImpl(OrtEpFactory* this_ptr,
+                                              const OrtHardwareDevice* const* /*devices*/,
+                                              const OrtKeyValuePairs* const* /*ep_metadata*/,
+                                              size_t num_devices,
+                                              const OrtSessionOptions* session_options,
+                                              const OrtLogger* logger,
+                                              OrtEp** ep) noexcept;
+
+  static void ORT_API_CALL ReleaseEpImpl(OrtEpFactory* /*this_ptr*/, OrtEp* ep) noexcept;
+
+  static OrtStatus* ORT_API_CALL CreateAllocatorImpl(OrtEpFactory* this_ptr,
+                                                     const OrtMemoryInfo* memory_info,
+                                                     const OrtKeyValuePairs* /*allocator_options*/,
+                                                     OrtAllocator** allocator) noexcept;
+
+  static void ORT_API_CALL ReleaseAllocatorImpl(OrtEpFactory* /*this*/, OrtAllocator* allocator) noexcept;
+
+  static OrtStatus* ORT_API_CALL CreateDataTransferImpl(OrtEpFactory* this_ptr,
+                                                        OrtDataTransferImpl** data_transfer) noexcept;
+
+  const std::string ep_name_;            // EP name
+  const std::string vendor_{"Contoso"};  // EP vendor name
+
+  // CPU allocator so we can control the arena behavior. optional as ORT always provides a CPU allocator if needed.
+  using MemoryInfoUniquePtr = std::unique_ptr<OrtMemoryInfo, std::function<void(OrtMemoryInfo*)>>;
+  MemoryInfoUniquePtr cpu_memory_info_;
+
+  // for example purposes. if the EP used GPU, and pinned/shared memory was required for data transfer, these are the
+  // OrtMemoryInfo instance required for that.
+  MemoryInfoUniquePtr default_gpu_memory_info_;
+  MemoryInfoUniquePtr host_accessible_gpu_memory_info_;
+
+  std::unique_ptr<ExampleDataTransfer> data_transfer_impl_;  // data transfer implementation for this factory
+};

--- a/onnxruntime/test/autoep/library/example_plugin_ep.cc
+++ b/onnxruntime/test/autoep/library/example_plugin_ep.cc
@@ -1,158 +1,7 @@
-#include "onnxruntime_cxx_api.h"
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
-#include <cassert>
-#include <memory>
-#include <string>
-#include <vector>
-
-#define RETURN_IF_ERROR(fn)   \
-  do {                        \
-    OrtStatus* status = (fn); \
-    if (status != nullptr) {  \
-      return status;          \
-    }                         \
-  } while (0)
-
-struct ApiPtrs {
-  const OrtApi& ort_api;
-  // const OrtEpApi& ep_api;  TODO: Add this when we flesh out the EP API.
-};
-
-struct ExampleEp : OrtEp, ApiPtrs {
-  ExampleEp(ApiPtrs apis, const std::string& name, const OrtSessionOptions& session_options, const OrtLogger& logger)
-      : ApiPtrs(apis), name_{name}, session_options_{session_options}, logger_{logger} {
-    // Initialize the execution provider.
-
-    auto status = ort_api.Logger_LogMessage(&logger_,
-                                            OrtLoggingLevel::ORT_LOGGING_LEVEL_INFO,
-                                            ("ExampleEp has been created with name " + name_).c_str(),
-                                            ORT_FILE, __LINE__, __FUNCTION__);
-    // ignore status for now
-    (void)status;
-  }
-
-  ~ExampleEp() {
-    // Clean up the execution provider
-  }
-
-  std::string name_;
-  const OrtSessionOptions& session_options_;
-  const OrtLogger& logger_;
-};
-
-struct ExampleEpFactory : OrtEpFactory, ApiPtrs {
-  ExampleEpFactory(const char* ep_name, ApiPtrs apis) : ApiPtrs(apis), ep_name_{ep_name} {
-    ort_version_supported = ORT_API_VERSION;  // set to the ORT version we were compiled with.
-    GetName = GetNameImpl;
-    GetVendor = GetVendorImpl;
-    GetSupportedDevices = GetSupportedDevicesImpl;
-    CreateEp = CreateEpImpl;
-    ReleaseEp = ReleaseEpImpl;
-  }
-
-  static const char* ORT_API_CALL GetNameImpl(const OrtEpFactory* this_ptr) {
-    const auto* factory = static_cast<const ExampleEpFactory*>(this_ptr);
-    return factory->ep_name_.c_str();
-  }
-
-  static const char* ORT_API_CALL GetVendorImpl(const OrtEpFactory* this_ptr) {
-    const auto* factory = static_cast<const ExampleEpFactory*>(this_ptr);
-    return factory->vendor_.c_str();
-  }
-
-  static OrtStatus* ORT_API_CALL GetSupportedDevicesImpl(OrtEpFactory* this_ptr,
-                                                         const OrtHardwareDevice* const* devices,
-                                                         size_t num_devices,
-                                                         OrtEpDevice** ep_devices,
-                                                         size_t max_ep_devices,
-                                                         size_t* p_num_ep_devices) {
-    size_t& num_ep_devices = *p_num_ep_devices;
-    auto* factory = static_cast<ExampleEpFactory*>(this_ptr);
-
-    for (size_t i = 0; i < num_devices && num_ep_devices < max_ep_devices; ++i) {
-      // C API
-      const OrtHardwareDevice& device = *devices[i];
-      if (factory->ort_api.HardwareDevice_Type(&device) == OrtHardwareDeviceType::OrtHardwareDeviceType_CPU) {
-        // these can be returned as nullptr if you have nothing to add.
-        OrtKeyValuePairs* ep_metadata = nullptr;
-        OrtKeyValuePairs* ep_options = nullptr;
-        factory->ort_api.CreateKeyValuePairs(&ep_metadata);
-        factory->ort_api.CreateKeyValuePairs(&ep_options);
-
-        // random example using made up values
-        factory->ort_api.AddKeyValuePair(ep_metadata, "version", "0.1");
-        factory->ort_api.AddKeyValuePair(ep_options, "run_really_fast", "true");
-
-        // OrtEpDevice copies ep_metadata and ep_options.
-        auto* status = factory->ort_api.GetEpApi()->CreateEpDevice(factory, &device, ep_metadata, ep_options,
-                                                                   &ep_devices[num_ep_devices++]);
-
-        factory->ort_api.ReleaseKeyValuePairs(ep_metadata);
-        factory->ort_api.ReleaseKeyValuePairs(ep_options);
-
-        if (status != nullptr) {
-          return status;
-        }
-      }
-
-      // C++ API equivalent. Throws on error.
-      //{
-      //  Ort::ConstHardwareDevice device(devices[i]);
-      //  if (device.Type() == OrtHardwareDeviceType::OrtHardwareDeviceType_CPU) {
-      //    Ort::KeyValuePairs ep_metadata;
-      //    Ort::KeyValuePairs ep_options;
-      //    ep_metadata.Add("version", "0.1");
-      //    ep_options.Add("run_really_fast", "true");
-      //    Ort::EpDevice ep_device{*this_ptr, device, ep_metadata.GetConst(), ep_options.GetConst()};
-      //    ep_devices[num_ep_devices++] = ep_device.release();
-      //  }
-      //}
-    }
-
-    return nullptr;
-  }
-
-  static OrtStatus* ORT_API_CALL CreateEpImpl(OrtEpFactory* this_ptr,
-                                              _In_reads_(num_devices) const OrtHardwareDevice* const* /*devices*/,
-                                              _In_reads_(num_devices) const OrtKeyValuePairs* const* /*ep_metadata*/,
-                                              _In_ size_t num_devices,
-                                              _In_ const OrtSessionOptions* session_options,
-                                              _In_ const OrtLogger* logger,
-                                              _Out_ OrtEp** ep) {
-    auto* factory = static_cast<ExampleEpFactory*>(this_ptr);
-    *ep = nullptr;
-
-    if (num_devices != 1) {
-      // we only registered for CPU and only expected to be selected for one CPU
-      // if you register for multiple devices (e.g. CPU, GPU and maybe NPU) you will get an entry for each device
-      // the EP has been selected for.
-      return factory->ort_api.CreateStatus(ORT_INVALID_ARGUMENT,
-                                           "Example EP only supports selection for one device.");
-    }
-
-    // Create the execution provider
-    RETURN_IF_ERROR(factory->ort_api.Logger_LogMessage(logger,
-                                                       OrtLoggingLevel::ORT_LOGGING_LEVEL_INFO,
-                                                       "Creating Example EP", ORT_FILE, __LINE__, __FUNCTION__));
-
-    // use properties from the device and ep_metadata if needed
-    // const OrtHardwareDevice* device = devices[0];
-    // const OrtKeyValuePairs* ep_metadata = ep_metadata[0];
-
-    auto dummy_ep = std::make_unique<ExampleEp>(*factory, factory->ep_name_, *session_options, *logger);
-
-    *ep = dummy_ep.release();
-    return nullptr;
-  }
-
-  static void ORT_API_CALL ReleaseEpImpl(OrtEpFactory* /*this_ptr*/, OrtEp* ep) {
-    ExampleEp* dummy_ep = static_cast<ExampleEp*>(ep);
-    delete dummy_ep;
-  }
-
-  const std::string ep_name_;            // EP name
-  const std::string vendor_{"Contoso"};  // EP vendor name
-};
+#include "ep_factory.h"
 
 // To make symbols visible on macOS/iOS
 #ifdef __APPLE__
@@ -168,11 +17,11 @@ extern "C" {
 EXPORT_SYMBOL OrtStatus* CreateEpFactories(const char* registration_name, const OrtApiBase* ort_api_base,
                                            OrtEpFactory** factories, size_t max_factories, size_t* num_factories) {
   const OrtApi* ort_api = ort_api_base->GetApi(ORT_API_VERSION);
-  // const OrtEpApi* ep_api = ort_api->GetEpApi();
+  const OrtEpApi* ep_api = ort_api->GetEpApi();
 
   // Factory could use registration_name or define its own EP name.
   std::unique_ptr<OrtEpFactory> factory = std::make_unique<ExampleEpFactory>(registration_name,
-                                                                             ApiPtrs{*ort_api});
+                                                                             ApiPtrs{*ort_api, *ep_api});
 
   if (max_factories < 1) {
     return ort_api->CreateStatus(ORT_INVALID_ARGUMENT,
@@ -186,7 +35,7 @@ EXPORT_SYMBOL OrtStatus* CreateEpFactories(const char* registration_name, const 
 }
 
 EXPORT_SYMBOL OrtStatus* ReleaseEpFactory(OrtEpFactory* factory) {
-  delete factory;
+  delete static_cast<ExampleEpFactory*>(factory);
   return nullptr;
 }
 

--- a/onnxruntime/test/autoep/library/utils.h
+++ b/onnxruntime/test/autoep/library/utils.h
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "onnxruntime_cxx_api.h"
+
+#define RETURN_IF_ERROR(expr) \
+  do {                        \
+    auto _status = (expr);    \
+    if (_status)              \
+      return _status;         \
+  } while (0)
+
+struct ApiPtrs {
+  const OrtApi& ort_api;
+  const OrtEpApi& ep_api;
+};

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -44,6 +44,7 @@
 #include "core/providers/rocm/rocm_provider_factory.h"
 #include "core/providers/rocm/gpu_data_transfer.h"
 #endif
+#include "core/session/allocator_adapters.h"
 #include "core/session/environment.h"
 #include "core/session/IOBinding.h"
 #include "core/session/inference_session_utils.h"
@@ -2752,30 +2753,40 @@ TEST(InferenceSessionTests, AllocatorSharing_EnsureSessionsUseSameOrtCreatedAllo
       [mem_info](int) { return std::make_unique<CPUAllocator>(mem_info); },
       0, use_arena};
 
-  AllocatorPtr allocator_ptr = CreateAllocator(device_info);
-  st = env->RegisterAllocator(allocator_ptr);
+  // convert to OrtAllocator* to use the public method used to register allocators by the ORT API
+  OrtAllocatorImplWrappingIAllocator ort_allocator(CreateAllocator(device_info));
+  st = env->RegisterAllocator(&ort_allocator);
   ASSERT_STATUS_OK(st);
-  // create sessions to share the allocator
 
-  SessionOptions so1;
-  ASSERT_STATUS_OK(so1.config_options.AddConfigEntry(kOrtSessionOptionsConfigUseEnvAllocators, "1"));
-  InferenceSessionTestSharingAllocator sess1(so1, *env);
-  ASSERT_STATUS_OK(sess1.Load(MODEL_URI));
-  ASSERT_STATUS_OK(sess1.Initialize());
+  {
+    // create sessions to share the allocator
+    SessionOptions so1;
+    ASSERT_STATUS_OK(so1.config_options.AddConfigEntry(kOrtSessionOptionsConfigUseEnvAllocators, "1"));
+    InferenceSessionTestSharingAllocator sess1(so1, *env);
+    ASSERT_STATUS_OK(sess1.Load(MODEL_URI));
+    ASSERT_STATUS_OK(sess1.Initialize());
 
-  SessionOptions so2;
-  ASSERT_STATUS_OK(so2.config_options.AddConfigEntry(kOrtSessionOptionsConfigUseEnvAllocators, "1"));
-  InferenceSessionTestSharingAllocator sess2(so2, *env);
-  ASSERT_STATUS_OK(sess2.Load(MODEL_URI));
-  ASSERT_STATUS_OK(sess2.Initialize());
+    SessionOptions so2;
+    ASSERT_STATUS_OK(so2.config_options.AddConfigEntry(kOrtSessionOptionsConfigUseEnvAllocators, "1"));
+    InferenceSessionTestSharingAllocator sess2(so2, *env);
+    ASSERT_STATUS_OK(sess2.Load(MODEL_URI));
+    ASSERT_STATUS_OK(sess2.Initialize());
 
-  // This line ensures the allocator in the session is the same as that in the env
-  ASSERT_EQ(sess1.GetSessionState().GetAllocator(mem_info).get(),
-            allocator_ptr.get());
+    // Need to undo the wrapping that happens in Environment::RegisterAllocator to be able to compare the pointers
+    const OrtAllocator* session_allocator = reinterpret_cast<IAllocatorImplWrappingOrtAllocator*>(
+                                                sess1.GetSessionState().GetAllocator(mem_info).get())
+                                                ->GetWrappedOrtAllocator();
 
-  // This line ensures the underlying IAllocator* is the same across 2 sessions.
-  ASSERT_EQ(sess1.GetSessionState().GetAllocator(mem_info).get(),
-            sess2.GetSessionState().GetAllocator(mem_info).get());
+    // This line ensures the allocator in the session is the same as that in the env
+    ASSERT_EQ(session_allocator, &ort_allocator);
+
+    // This line ensures the underlying IAllocator* is the same across 2 sessions.
+    ASSERT_EQ(sess1.GetSessionState().GetAllocator(mem_info).get(),
+              sess2.GetSessionState().GetAllocator(mem_info).get());
+  }
+
+  // registered as the allocator will become invalid before the environment is destroyed
+  ASSERT_STATUS_OK(env->UnregisterAllocator(mem_info));
 }
 
 // Ensure sessions don't use the same allocator. It uses ORT created allocator.
@@ -2800,8 +2811,8 @@ TEST(InferenceSessionTests, AllocatorSharing_EnsureSessionsDontUseSameOrtCreated
       [mem_info](int) { return std::make_unique<CPUAllocator>(mem_info); },
       0, use_arena};
 
-  AllocatorPtr allocator_ptr = CreateAllocator(device_info);
-  st = env->RegisterAllocator(allocator_ptr);
+  OrtAllocatorImplWrappingIAllocator ort_allocator(CreateAllocator(device_info));
+  st = env->RegisterAllocator(&ort_allocator);
   ASSERT_STATUS_OK(st);
   // create sessions to share the allocator
 
@@ -2817,9 +2828,13 @@ TEST(InferenceSessionTests, AllocatorSharing_EnsureSessionsDontUseSameOrtCreated
   ASSERT_STATUS_OK(sess2.Load(MODEL_URI));
   ASSERT_STATUS_OK(sess2.Initialize());
 
+  // Need to undo the wrapping that happens in Environment::RegisterAllocator to be able to compare the pointers
+  const OrtAllocator* session_allocator = reinterpret_cast<IAllocatorImplWrappingOrtAllocator*>(
+                                              sess1.GetSessionState().GetAllocator(mem_info).get())
+                                              ->GetWrappedOrtAllocator();
+
   // This line ensures the allocator in the session is the same as that in the env
-  ASSERT_EQ(sess1.GetSessionState().GetAllocator(mem_info).get(),
-            allocator_ptr.get());
+  ASSERT_EQ(session_allocator, &ort_allocator);
 
   // This line ensures the underlying OrtAllocator* is the same across 2 sessions.
   ASSERT_NE(sess1.GetSessionState().GetAllocator(mem_info).get(),

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -3384,11 +3384,11 @@ TEST(CApiTest, TestSharedAllocators) {
     // NOTE: On x86 builds arenas are not supported and will default to using non-arena based allocator
     ASSERT_TRUE(api.CreateAndRegisterAllocator(env_ptr, mem_info, arena_cfg) == nullptr);
 
-    // Test that duplicates are handled
+    // Registration is always a replace operation
     std::unique_ptr<OrtStatus, decltype(api.ReleaseStatus)> status_releaser(
         api.CreateAndRegisterAllocator(env_ptr, mem_info, arena_cfg),
         api.ReleaseStatus);
-    ASSERT_FALSE(status_releaser.get() == nullptr);
+    ASSERT_TRUE(status_releaser.get() == nullptr);
 
     {
       // create session 1
@@ -3427,12 +3427,12 @@ TEST(CApiTest, TestSharedAllocators) {
     MockedOrtAllocator custom_allocator;
     ASSERT_TRUE(api.RegisterAllocator(env_ptr, &custom_allocator) == nullptr);
 
-    // Test that duplicates are handled
+    // Registration is always a replace operation
     std::unique_ptr<OrtStatus, decltype(api.ReleaseStatus)>
         status_releaser(
             api.RegisterAllocator(env_ptr, &custom_allocator),
             api.ReleaseStatus);
-    ASSERT_FALSE(status_releaser.get() == nullptr);
+    ASSERT_TRUE(status_releaser.get() == nullptr);
 
     {
       // Keep this scoped to destroy the underlying sessions after use


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Add allocator and data transfer infrastructure for plugin EP API

Allocators are created via the OrtEpFactory using OrtMemoryInfo that as added to the OrtEpDevice instances the factory returns. This allows allocators to be created outside of an inference session and shared.

When a library is loaded a default instance of each allocator is added to the shared allocators if there is no existing allocator (e.g. user provided custom allocator).
CreateSharedAllocator can be used to replace this default instance with a user configured one. e.g. add an arena or provide other configuration options that are passed through to the OrtEpFactory's CreateAllocator function.
 
Similarly IDataTransfer is supported by the factory implementing OrtDataTransferImpl, which will also enable data transfer outside of a session. That will be added in a future PR as the synchronization requirements need to be figured out and will affect the public API.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


