### PR TITLE
[WebNN] Handle in-memory external data

### DIFF
--- a/onnxruntime/core/providers/webnn/builders/helper.h
+++ b/onnxruntime/core/providers/webnn/builders/helper.h
@@ -15,6 +15,7 @@
 #include <emscripten.h>
 #include <emscripten/val.h>
 
+using onnxruntime::common::Status;
 namespace onnxruntime {
 
 class GraphViewer;
@@ -92,14 +93,33 @@ inline std::vector<T> GetNarrowedIntfromInt64(gsl::span<const int64_t> int64_vec
   return vec;
 }
 
-template <typename T>
-bool ReadIntArrayFrom1DTensor(const onnx::TensorProto& tensor, std::vector<T>& array, const logging::Logger& logger) {
-  std::vector<uint8_t> unpacked_tensor;
-  auto status = onnxruntime::utils::UnpackInitializerData(tensor, unpacked_tensor);
+bool inline UnpackInitializerData(const ONNX_NAMESPACE::TensorProto& initializer,
+                                  std::vector<uint8_t>& unpacked_tensor,
+                                  const GraphViewer& graph_viewer,
+                                  const logging::Logger& logger) {
+  Status status = Status::OK();
+  if (utils::HasExternalData(initializer)) {
+    status = onnxruntime::utils::UnpackInitializerData(initializer, graph_viewer.ModelPath(), unpacked_tensor);
+  } else {
+    status = onnxruntime::utils::UnpackInitializerData(initializer, unpacked_tensor);
+  }
+
   if (!status.IsOK()) {
-    LOGS(logger, ERROR) << "Error while unpacking shape: " << status.ErrorMessage();
+    LOGS(logger, ERROR) << "Error while unpacking initializer data: " << status.ErrorMessage();
     return false;
   }
+
+  return true;
+}
+
+template <typename T>
+bool ReadIntArrayFrom1DTensor(const onnx::TensorProto& tensor, std::vector<T>& array,
+                              const GraphViewer& graph_viewer, const logging::Logger& logger) {
+  std::vector<uint8_t> unpacked_tensor;
+  if (!UnpackInitializerData(tensor, unpacked_tensor, graph_viewer, logger)) {
+    return false;
+  }
+
   const auto& dims = tensor.dims();
   if (dims.size() != 1) {
     LOGS(logger, VERBOSE) << "The tensor must be 1D.";
@@ -130,13 +150,13 @@ bool ReadIntArrayFrom1DTensor(const onnx::TensorProto& tensor, std::vector<T>& a
   return true;
 }
 
-inline bool ReadScalarTensorData(const onnx::TensorProto& tensor, emscripten::val& scalar, const logging::Logger& logger) {
+inline bool ReadScalarTensorData(const onnx::TensorProto& tensor, emscripten::val& scalar,
+                                 const GraphViewer& graph_viewer, const logging::Logger& logger) {
   std::vector<uint8_t> unpacked_tensor;
-  auto status = onnxruntime::utils::UnpackInitializerData(tensor, unpacked_tensor);
-  if (!status.IsOK()) {
-    LOGS(logger, ERROR) << "Error while unpacking tensor: " << status.ErrorMessage();
+  if (!UnpackInitializerData(tensor, unpacked_tensor, graph_viewer, logger)) {
     return false;
   }
+
   switch (tensor.data_type()) {
     case ONNX_NAMESPACE::TensorProto_DataType_BOOL:
     case ONNX_NAMESPACE::TensorProto_DataType_UINT8:

--- a/onnxruntime/core/providers/webnn/builders/impl/cumsum_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/cumsum_op_builder.cc
@@ -50,7 +50,8 @@ Status CumSumOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const
   const std::string axis_name = GetTensorName(input_defs, 1);
   const auto axis_tensor = *initializers.at(axis_name);
   emscripten::val axis = emscripten::val::undefined();
-  ORT_RETURN_IF_NOT(ReadScalarTensorData(axis_tensor, axis, logger), "Cannot get axis value");
+  ORT_RETURN_IF_NOT(ReadScalarTensorData(axis_tensor, axis, model_builder.GetGraphViewer(), logger),
+                    "Cannot get axis value");
   int64_t webnn_axis = HandleNegativeAxis(axis.as<int64_t>(), input_rank);
 
   NodeAttrHelper helper(node);

--- a/onnxruntime/core/providers/webnn/builders/impl/expand_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/expand_op_builder.cc
@@ -44,7 +44,8 @@ Status ExpandOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
   const auto& initializers(model_builder.GetInitializerTensors());
   const auto& shape_tensor = *initializers.at(input_defs[1]->Name());
   std::vector<int64_t> new_shape;
-  ORT_RETURN_IF_NOT(ReadIntArrayFrom1DTensor(shape_tensor, new_shape, logger), "Cannot get shape.");
+  ORT_RETURN_IF_NOT(ReadIntArrayFrom1DTensor(shape_tensor, new_shape, model_builder.GetGraphViewer(), logger),
+                    "Cannot get shape.");
   emscripten::val input = model_builder.GetOperand(input_defs[0]->Name());
   std::vector<int64_t> input_shape;
   ORT_RETURN_IF_NOT(GetShape(*input_defs[0], input_shape, logger), "Cannot get input's shape.");
@@ -84,8 +85,7 @@ bool ExpandOpBuilder::IsOpSupportedImpl(const GraphViewer& graph_viewer,
   }
 
   std::vector<int64_t> new_shape;
-  if (!ReadIntArrayFrom1DTensor(shape_tensor, new_shape, logger)) {
-    LOGS(logger, VERBOSE) << "Cannot get shape.";
+  if (!ReadIntArrayFrom1DTensor(shape_tensor, new_shape, graph_viewer, logger)) {
     return false;
   }
   if (std::any_of(new_shape.begin(), new_shape.end(), [](int64_t dimension) { return dimension == 0; })) {

--- a/onnxruntime/core/providers/webnn/builders/impl/gqa_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/gqa_op_builder.cc
@@ -392,7 +392,7 @@ bool GroupQueryAttentionOpBuilder::IsOpSupportedImpl(const GraphViewer& graph_vi
 
   const auto total_sequence_length_tensor = *total_sequence_length_initializer;
   emscripten::val total_sequence_length = emscripten::val::undefined();
-  if (!ReadScalarTensorData(total_sequence_length_tensor, total_sequence_length, logger)) {
+  if (!ReadScalarTensorData(total_sequence_length_tensor, total_sequence_length, graph_viewer, logger)) {
     return false;
   }
 

--- a/onnxruntime/core/providers/webnn/builders/impl/gru_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/gru_op_builder.cc
@@ -143,8 +143,7 @@ bool GruOpBuilder::IsOpSupportedImpl(const GraphViewer& graph_viewer, const Node
 
     const auto& sequence_lens_tensor = *seq_initializer;
     std::vector<int32_t> sequence_lens;
-    if (!ReadIntArrayFrom1DTensor(sequence_lens_tensor, sequence_lens, logger)) {
-      LOGS(logger, ERROR) << "Cannot read sequence lens tensor";
+    if (!ReadIntArrayFrom1DTensor(sequence_lens_tensor, sequence_lens, graph_viewer, logger)) {
       return false;
     }
     if (!std::all_of(sequence_lens.begin(), sequence_lens.end(),

--- a/onnxruntime/core/providers/webnn/builders/impl/lstm_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/lstm_op_builder.cc
@@ -149,8 +149,7 @@ bool LstmOpBuilder::IsOpSupportedImpl(const GraphViewer& graph_viewer, const Nod
 
     const auto& sequence_lens_tensor = *sequence_lens_init;
     std::vector<int32_t> sequence_lens;
-    if (!ReadIntArrayFrom1DTensor(sequence_lens_tensor, sequence_lens, logger)) {
-      LOGS(logger, ERROR) << "Cannot read sequence lens tensor";
+    if (!ReadIntArrayFrom1DTensor(sequence_lens_tensor, sequence_lens, graph_viewer, logger)) {
       return false;
     }
     if (std::any_of(sequence_lens.begin(), sequence_lens.end(),

--- a/onnxruntime/core/providers/webnn/builders/impl/pad_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/pad_op_builder.cc
@@ -83,16 +83,18 @@ Status PadOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
   const auto opset = node.SinceVersion();
   // From opset 11, pads, constant value and axes are inputs.
   if (opset >= 11) {
+    const auto& graph_viewer = model_builder.GetGraphViewer();
     ORT_RETURN_IF(input_defs.size() < 2, "Pads is required at opset ", opset);
     std::vector<int64_t> pads;
     const auto& pads_tensor = *initializers.at(input_defs[1]->Name());
-    ORT_RETURN_IF_NOT(ReadIntArrayFrom1DTensor(pads_tensor, pads, logger), "Error while read pads tensor");
+    ORT_RETURN_IF_NOT(ReadIntArrayFrom1DTensor(pads_tensor, pads, graph_viewer, logger),
+                      "Error while read pads tensor");
 
     // Constant value and axes are optional. Make sure they are not empty.
     if (!GetTensorName(input_defs, 2).empty()) {
       const auto value_tensor = *initializers.at(input_defs[2]->Name());
       emscripten::val value = emscripten::val::object();
-      ORT_RETURN_IF_NOT(ReadScalarTensorData(value_tensor, value, logger), "Cannot read constant value");
+      ORT_RETURN_IF_NOT(ReadScalarTensorData(value_tensor, value, graph_viewer, logger), "Cannot read constant value");
       options.set("value", value);
     }
 
@@ -100,7 +102,8 @@ Status PadOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
       const auto input_rank = input_shape.size();
       std::vector<int64_t> axes;
       const auto& axes_tensor = *initializers.at(input_defs[3]->Name());
-      ORT_RETURN_IF_NOT(ReadIntArrayFrom1DTensor(axes_tensor, axes, logger), "Error while read axes tensor");
+      ORT_RETURN_IF_NOT(ReadIntArrayFrom1DTensor(axes_tensor, axes, graph_viewer, logger),
+                        "Error while read axes tensor");
       std::vector<size_t> axes_index;
       std::transform(
           axes.begin(), axes.end(), std::back_inserter(axes_index),

--- a/onnxruntime/core/providers/webnn/builders/impl/reshape_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/reshape_op_builder.cc
@@ -93,9 +93,7 @@ bool ReshapeOpBuilder::IsOpSupportedImpl(const GraphViewer& graph_viewer,
 
   const auto& perm_tensor = *perm_init;
   std::vector<uint8_t> unpacked_tensor;
-  auto status = onnxruntime::utils::UnpackInitializerData(perm_tensor, unpacked_tensor);
-  if (!status.IsOK()) {
-    LOGS(logger, ERROR) << "Error while unpacking perm_tensor: " << status.ErrorMessage();
+  if (!UnpackInitializerData(perm_tensor, unpacked_tensor, graph_viewer, logger)) {
     return false;
   }
 

--- a/onnxruntime/core/providers/webnn/builders/impl/resize_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/resize_op_builder.cc
@@ -69,11 +69,9 @@ bool GetResizeScalesAndAxes(const GraphViewer& graph_viewer,
   }
 
   std::vector<uint8_t> unpacked_tensor;
-  auto status = onnxruntime::utils::UnpackInitializerData(scales_tensor, unpacked_tensor);
-  if (!status.IsOK()) {
-    LOGS(logger, ERROR) << "Error while unpacking scales_tensor: " << status.ErrorMessage();
+  if (!UnpackInitializerData(scales_tensor, unpacked_tensor, graph_viewer, logger)) {
     return false;
-  }
+  };
   const float* scales_data = reinterpret_cast<const float*>(unpacked_tensor.data());
 
   if (has_axes) {
@@ -137,9 +135,7 @@ bool GetResizeSizesAndAxes(const GraphViewer& graph_viewer,
   }
 
   std::vector<uint8_t> unpacked_tensor;
-  auto status = onnxruntime::utils::UnpackInitializerData(sizes_tensor, unpacked_tensor);
-  if (!status.IsOK()) {
-    LOGS(logger, ERROR) << "Error while unpacking sizes_tensor: " << status.ErrorMessage();
+  if (!UnpackInitializerData(sizes_tensor, unpacked_tensor, graph_viewer, logger)) {
     return false;
   }
   const int64_t* sizes_data = reinterpret_cast<const int64_t*>(unpacked_tensor.data());

--- a/onnxruntime/core/providers/webnn/builders/impl/split_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/split_op_builder.cc
@@ -66,7 +66,8 @@ Status SplitOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
   } else if (GetTensorName(input_defs, 1).size()) {
     const auto& initializers(model_builder.GetInitializerTensors());
     const auto& split_tensor = *initializers.at(input_defs[1]->Name());
-    ORT_RETURN_IF_NOT(ReadIntArrayFrom1DTensor(split_tensor, splits, logger), "Cannot get input for split.");
+    ORT_RETURN_IF_NOT(ReadIntArrayFrom1DTensor(split_tensor, splits, model_builder.GetGraphViewer(), logger),
+                      "Cannot get input for split.");
   } else if (!helper.HasAttr("split")) {
     split_count = node.OutputDefs().size();
   }
@@ -125,8 +126,7 @@ bool SplitOpBuilder::IsOpSupportedImpl(const GraphViewer& graph_viewer,
       LOGS(logger, VERBOSE) << "The type of tensor's element data must be INT64.";
       return false;
     }
-    if (!ReadIntArrayFrom1DTensor(split_tensor, split, logger)) {
-      LOGS(logger, VERBOSE) << "Cannot get split.";
+    if (!ReadIntArrayFrom1DTensor(split_tensor, split, graph_viewer, logger)) {
       return false;
     }
   } else {

--- a/onnxruntime/core/providers/webnn/builders/impl/triangular_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/triangular_op_builder.cc
@@ -57,7 +57,9 @@ Status TriangularOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
     const auto diagonal_tensor = *initializers.at(diagonal_name);
 
     std::vector<uint8_t> unpacked_tensor;
-    ORT_RETURN_IF_ERROR(onnxruntime::utils::UnpackInitializerData(diagonal_tensor, unpacked_tensor));
+    ORT_RETURN_IF_NOT(UnpackInitializerData(diagonal_tensor, unpacked_tensor,
+                                            model_builder.GetGraphViewer(), logger),
+                      "Failed to unpack diagonal tensor data");
     const auto diagonal = *reinterpret_cast<int64_t*>(unpacked_tensor.data());
     options.set("diagonal", SafeInt<int32_t>(diagonal).Ref());
   }


### PR DESCRIPTION
### Description
Some initializers are stored as in-memory external data, WebNN EP should support these initializers.

### Motivation and Context
This PR:
- Added `HasExternalDataInMemory` check for external data to avoid unexpected error.
- Wrapped the `UnpackInitializerData` to make it compatible with external data.

Fixed #25078