### PR TITLE
vitisai/imp/graph.cc: fix graph_save() for models with external data

### DIFF
--- a/onnxruntime/core/providers/vitisai/imp/graph.cc
+++ b/onnxruntime/core/providers/vitisai/imp/graph.cc
@@ -177,7 +177,9 @@ void graph_save(const Graph& graph, const std::string& filename, const std::stri
   auto graph_proto_subgraph = graph.ToGraphProto();
   *model_proto->mutable_graph() = *graph_proto_subgraph;
   auto& logger = logging::LoggingManager::DefaultLogger();
-  auto model = Model::Create(std::move(*model_proto), ToPathString(filename), nullptr, logger);
+  // Reading initializer data from an external data file below will access the data file based on the directory of the model_path
+  // parameter. Thus, the path to the original model must be used here to make reading initializer data from an external file work.
+  auto model = Model::Create(std::move(*model_proto), graph.ModelPath(), nullptr, logger);
   auto status = model->MainGraph().Resolve();
   vai_assert(status.IsOK(), "graph resolve error:" + status.ErrorMessage());
   if (initializer_size_threshold == std::numeric_limits<size_t>::max()) {


### PR DESCRIPTION
### Description

This fixes the export of a model to disk (e.g. for debugging) in case the original model uses an external data file.
Before, the external data file was not found if the model is exporter to a different directory than the original model.

### Motivation and Context

Reading initializer data from an external data file happens on demand and uses the name of the model file to determine the directory containing the data file.
Thus, when creating a new Model object in memory for the export to disk, it is important to use the path to the original model file in that object instead of the path to the model file to be exported to disk. This ensures that the original data file can still be found for reading the initializer data during the export.
