### PR TITLE
fetch latest version from web

### DIFF
--- a/rust/onnxruntime-sys/Cargo.toml
+++ b/rust/onnxruntime-sys/Cargo.toml
@@ -19,6 +19,7 @@ libloading = "0.7"
 
 [build-dependencies]
 bindgen = "0.63"
+serde_json = "1"
 cmake = "0.1"
 anyhow = "1.0"
 

--- a/rust/onnxruntime/src/lib.rs
+++ b/rust/onnxruntime/src/lib.rs
@@ -333,8 +333,6 @@ pub enum GraphOptimizationLevel {
     Basic = sys::GraphOptimizationLevel::ORT_ENABLE_BASIC as OnnxEnumInt,
     /// Extended optimization
     Extended = sys::GraphOptimizationLevel::ORT_ENABLE_EXTENDED as OnnxEnumInt,
-    /// Layout optimization
-    Layout = sys::GraphOptimizationLevel::ORT_ENABLE_LAYOUT as OnnxEnumInt,
     /// Add optimization
     All = sys::GraphOptimizationLevel::ORT_ENABLE_ALL as OnnxEnumInt,
 }
@@ -346,7 +344,6 @@ impl From<GraphOptimizationLevel> for sys::GraphOptimizationLevel {
             DisableAll => sys::GraphOptimizationLevel::ORT_DISABLE_ALL,
             Basic => sys::GraphOptimizationLevel::ORT_ENABLE_BASIC,
             Extended => sys::GraphOptimizationLevel::ORT_ENABLE_EXTENDED,
-            Layout => sys::GraphOptimizationLevel::ORT_ENABLE_LAYOUT,
             All => sys::GraphOptimizationLevel::ORT_ENABLE_ALL,
         }
     }

--- a/rust/onnxruntime/src/tensor/ort_output_tensor.rs
+++ b/rust/onnxruntime/src/tensor/ort_output_tensor.rs
@@ -325,6 +325,8 @@ impl<'a> TryFrom<OrtOutputTensor> for OrtOutput<'a> {
                 }
                 // Unimplemented output tensor data types
                 sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX64
+                | sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4
+                | sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4
                 | sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED
                 | sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL
                 | sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16


### PR DESCRIPTION
### Description
```toml
[patch.crates-io]
onnxruntime-sys = { git = "https://github.com/microsoft/onnxruntime/" }
onnxruntime = { git = "https://github.com/microsoft/onnxruntime/" }
```
was broken


### Motivation and Context
- official crates.io release doesnt support arm64 downloads


