### PR TITLE
Fix: delay CUDADriverWrapper instantiation to avoid uncaught exception

### DIFF
--- a/onnxruntime/contrib_ops/cuda/bert/tensorrt_fused_multihead_attention/cudaDriverWrapper.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/tensorrt_fused_multihead_attention/cudaDriverWrapper.cc
@@ -136,10 +136,8 @@ CUresult CUDADriverWrapper::cuLaunchKernel(
       f, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY, blockDimZ, sharedMemBytes, hStream, kernelParams, extra);
 }
 
-// Initialize the singleton instance
-CUDADriverWrapper CUDADriverWrapper::instance;
-
 const CUDADriverWrapper* CUDADriverWrapper::GetInstance() {
+  static CUDADriverWrapper instance;
   return &instance;
 }
 

--- a/onnxruntime/contrib_ops/cuda/bert/tensorrt_fused_multihead_attention/cudaDriverWrapper.h
+++ b/onnxruntime/contrib_ops/cuda/bert/tensorrt_fused_multihead_attention/cudaDriverWrapper.h
@@ -100,8 +100,6 @@ class CUDADriverWrapper {
       CUfunction f, uint32_t gridDimX, uint32_t gridDimY, uint32_t gridDimZ,
       uint32_t blockDimX, uint32_t blockDimY, uint32_t blockDimZ, uint32_t sharedMemBytes, CUstream hStream,
       void** kernelParams, void** extra);
-
-  static CUDADriverWrapper instance;
 };
 
 inline void cuErrCheck_(CUresult stat, const CUDADriverWrapper& wrap, const char* file, int line) {


### PR DESCRIPTION
Fix: delay CUDADriverWrapper instantiation to avoid uncaught exceptions when CUDA is unavailable

### Description

This PR moves the static instantiation of CUDADriverWrapper from a class-level static field to a function-local static inside CUDADriverWrapper::GetInstance(). This change ensures that the CUDA driver is only loaded when the instance is actually needed, rather than at static initialization time. It preserves the singleton behavior while deferring instantiation to runtime.

### Motivation and Context

When libcuda.so.1 is not available on the system, the constructor of CUDADriverWrapper throws an exception. Previously, this exception was triggered during static initialization, leading to an uncatchable std::terminate() and process termination. By moving the instance into GetInstance() as a function-local static, the exception can now be caught by client code (e.g., in try/catch), allowing graceful fallback when CUDA is unavailable.

