### PR TITLE
Use model hash from metadata if available

### DIFF
--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -2082,8 +2082,20 @@ common::Status InferenceSession::Initialize() {
       SetWeightDataType(model_weight_type);
 #endif
 #ifdef _WIN32
-      model_graph_hash = ComputeModelGraphHash(graph);
-      model_weight_hash = (model_graph_hash == "0") ? "0" : ComputeModelWeightHash(initializers);
+      // Check if model metadata contains a "model_hash" field
+      const auto& metadata = model_->MetaData();
+      auto model_hash_it = metadata.find("model_hash");
+
+      if (model_hash_it != metadata.end()) {
+        // Use the model_hash from metadata
+        model_graph_hash = model_hash_it->second;
+        model_weight_hash = model_hash_it->second;
+      } else {
+        // Compute hashes
+        model_graph_hash = ComputeModelGraphHash(graph);
+        model_weight_hash = (model_graph_hash == "0") ? "0" : ComputeModelWeightHash(initializers);
+      }
+
       SetGraphHash(model_graph_hash);
       SetWeightHash(model_weight_hash);
 #endif


### PR DESCRIPTION
### Description
This change implements **Metadata-based hash override** optimization to the model hashing logic. Added logic to check for "model_hash" in model metadata before computing hashes. If present, both model_graph_hash and model_weight_hash are set to the metadata value, bypassing computation entirely.

### Motivation and Context
ONNX models generated using the Olive toolchain now have the option to include the model hash as part of the ONNX metadata. For such models, it would be beneficial to use the provided hash instead of computing it from scratch.


