### PR TITLE
Add dynamic bucket cache mode to improve peak and avg gpu buffer memory usage

### DIFF
--- a/onnxruntime/core/providers/webgpu/buffer_manager.cc
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.cc
@@ -278,20 +278,20 @@ class DynamicBucketCacheManager : public IBufferCacheManager {
   }
 
   size_t CalculateBufferSize(size_t request_size) override {
-    request_size = NormalizeBufferSize(request_size);
+    size_t normalized_request_size = NormalizeBufferSize(request_size);
 
     // Track usage for the current run
-    current_run_usage_[request_size]++;
+    current_run_usage_[normalized_request_size]++;
 
     // Check if we already have a bucket for this size. If not, create a new bucket so that it can cache buffers of
     // this size in the current session run if the buffer is quickly released in the same session.
-    if (buckets_.find(request_size) == buckets_.end()) {
-      buckets_.emplace(request_size, std::vector<WGPUBuffer>());
-      buckets_keys_.push_back(request_size);
+    if (buckets_.find(normalized_request_size) == buckets_.end()) {
+      buckets_.emplace(normalized_request_size, std::vector<WGPUBuffer>());
+      buckets_keys_.push_back(normalized_request_size);
       std::sort(buckets_keys_.begin(), buckets_keys_.end());
     }
 
-    return request_size;
+    return normalized_request_size;
   }
 
   WGPUBuffer TryAcquireCachedBuffer(size_t buffer_size) override {

--- a/onnxruntime/core/providers/webgpu/buffer_manager.cc
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.cc
@@ -276,9 +276,11 @@ class DynamicBucketCacheManager : public IBufferCacheManager {
     // Adjust buckets based on the collected memory patterns every 2 runs.
     // The reason for this is to allow the cache to adapt to the memory usage patterns
     // of previous runs of last completed token generation session.
-    if ((session_id_ + 1) % 2 == 0) {
+    static size_t run_id = 0;
+    if ((run_id + 1) % 2 == 0) {
       AdjustBuckets();
     }
+    ++run_id;
   }
 
   size_t CalculateBufferSize(size_t request_size) override {

--- a/onnxruntime/core/providers/webgpu/buffer_manager.cc
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.cc
@@ -304,7 +304,7 @@ class DynamicBucketCacheManager : public IBufferCacheManager {
     return nullptr;
   }
 
-  void RegisterBuffer(WGPUBuffer buffer, size_t request_size) override {
+  void RegisterBuffer(WGPUBuffer /*buffer*/, size_t /*request_size*/) override {
     // no-op
   }
 

--- a/onnxruntime/core/providers/webgpu/buffer_manager.cc
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.cc
@@ -383,6 +383,8 @@ std::unique_ptr<IBufferCacheManager> CreateBufferCacheManager(BufferCacheMode ca
       return std::make_unique<SimpleCacheManager>();
     case BufferCacheMode::Bucket:
       return std::make_unique<BucketCacheManager>();
+    case BufferCacheMode::DynamicBucket:
+      return std::make_unique<DynamicBucketCacheManager>();
     default:
       ORT_NOT_IMPLEMENTED("Unsupported buffer cache mode");
   }
@@ -401,6 +403,9 @@ std::ostream& operator<<(std::ostream& os, BufferCacheMode mode) {
       break;
     case BufferCacheMode::Bucket:
       os << "Bucket";
+      break;
+    case BufferCacheMode::DynamicBucket:
+      os << "DynamicBucket";
       break;
     default:
       os << "Unknown(" << static_cast<int>(mode) << ")";

--- a/onnxruntime/core/providers/webgpu/buffer_manager.cc
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.cc
@@ -3,17 +3,11 @@
 
 #include "core/providers/webgpu/buffer_manager.h"
 #include "core/providers/webgpu/webgpu_context.h"
-#include <chrono>
-#include <ctime>
-#include <fstream>
-#include <iomanip>
 
 namespace onnxruntime {
 namespace webgpu {
 
 namespace {
-constexpr const char* METRICS_FILE = "memory_result_inter_session_optimization_with_early_release_and_without_default_bucket_limits.csv";
-constexpr const char* METRICS_HEADER = "Timestamp,TotalMemory(MB),PeakMemory(MB),ActiveBuffers,TotalBuffers,TimeoutMs\n";
 
 constexpr size_t NormalizeBufferSize(size_t size) {
   return (size + 15) / 16 * 16;

--- a/onnxruntime/core/providers/webgpu/buffer_manager.cc
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.cc
@@ -273,8 +273,12 @@ class DynamicBucketCacheManager : public IBufferCacheManager {
       pattern.frequency = usage.second;
     }
 
-    // Adjust buckets based on the collected memory patterns.
-    AdjustBuckets();
+    // Adjust buckets based on the collected memory patterns every 2 runs.
+    // The reason for this is to allow the cache to adapt to the memory usage patterns
+    // of previous runs of last completed token generation session.
+    if ((session_id_ + 1) % 2 == 0) {
+      AdjustBuckets();
+    }
   }
 
   size_t CalculateBufferSize(size_t request_size) override {

--- a/onnxruntime/core/providers/webgpu/buffer_manager.h
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.h
@@ -52,10 +52,10 @@ class IBufferCacheManager {
   // when a stream refresh is requested
   virtual void OnRefresh() = 0;
 
-  // Track start of inference run
+  // Track start of session run
   virtual void OnRunStart() {}
 
-  // Track end of inference run and update memory patterns
+  // Track end of session run and update memory patterns
   virtual void OnRunEnd() {}
 };
 
@@ -76,7 +76,6 @@ class BufferManager {
   void Download(WGPUBuffer src, void* dst, size_t size);
   void RefreshPendingBuffers();
 
-  // Track inference run memory patterns
   void OnRunStart() {
     if (storage_cache_) storage_cache_->OnRunStart();
     if (uniform_cache_) uniform_cache_->OnRunStart();

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -881,7 +881,7 @@ Status WebGpuExecutionProvider::OnRunStart(const onnxruntime::RunOptions& /*run_
     context_.StartProfiling();
   }
 
-  // Start tracking memory usage for this run
+  // Start tracking memory usage for this session run.
   context_.BufferManager().OnRunStart();
 
   if (IsGraphCaptureEnabled() && IsGraphCaptureAllowed() && !IsGraphCaptured(0)) {
@@ -906,7 +906,7 @@ Status WebGpuExecutionProvider::OnRunEnd(bool /* sync_stream */, const onnxrunti
     context_.CollectProfilingData(profiler_->Events());
   }
 
-  // Update memory patterns from this run
+  // Update memory patterns from this session run.
   context_.BufferManager().OnRunEnd();
 
   context_.OnRunEnd();

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -881,6 +881,9 @@ Status WebGpuExecutionProvider::OnRunStart(const onnxruntime::RunOptions& /*run_
     context_.StartProfiling();
   }
 
+  // Start tracking memory usage for this run
+  context_.BufferManager().OnRunStart();
+
   if (IsGraphCaptureEnabled() && IsGraphCaptureAllowed() && !IsGraphCaptured(0)) {
     ORT_NOT_IMPLEMENTED("graph capture not implemented");
   }
@@ -902,6 +905,9 @@ Status WebGpuExecutionProvider::OnRunEnd(bool /* sync_stream */, const onnxrunti
   if (profiler_->Enabled()) {
     context_.CollectProfilingData(profiler_->Events());
   }
+
+  // Update memory patterns from this run
+  context_.BufferManager().OnRunEnd();
 
   context_.OnRunEnd();
 

--- a/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
@@ -210,6 +210,8 @@ std::shared_ptr<IExecutionProviderFactory> WebGpuProviderFactoryCreator::Create(
         return webgpu::BufferCacheMode::Simple;
       } else if (buffer_cache_mode_str == kBufferCacheMode_Bucket) {
         return webgpu::BufferCacheMode::Bucket;
+      } else if (buffer_cache_mode_str == kBufferCacheMode_DynamicBucket) {
+        return webgpu::BufferCacheMode::DynamicBucket;
       } else {
         ORT_THROW("Invalid buffer cache mode: ", config_entry_str);
       }

--- a/onnxruntime/core/providers/webgpu/webgpu_provider_options.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_provider_options.h
@@ -53,6 +53,7 @@ constexpr const char* kBufferCacheMode_Disabled = "disabled";
 constexpr const char* kBufferCacheMode_LazyRelease = "lazyRelease";
 constexpr const char* kBufferCacheMode_Simple = "simple";
 constexpr const char* kBufferCacheMode_Bucket = "bucket";
+constexpr const char* kBufferCacheMode_DynamicBucket = "dynamicBucket";
 
 constexpr const char* kValidationMode_Disabled = "disabled";
 constexpr const char* kValidationMode_wgpuOnly = "wgpuOnly";


### PR DESCRIPTION
### Description
Add a dynamic bucket cache mode to improve the GPU buffer memory usage, including reducing the peak memory and average memory usage without any other performance regressions.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Default buckets solution uses default buckets with coarse-grained bucket keys to cache buffers and don’t update the bucket keys over the runs while dynamic buckets solution uses dynamic buckets with fine-grained bucket keys to cache buffers and update the bucket keys over the runs. Dynamic buckets solution will overall request less buffers than default buckets solution but keeps the similar cache missed buffer bytes. We summarized the optimization solution details in this doc https://microsoftapc-my.sharepoint.com/:w:/g/personal/feich_microsoft_com/Eb1nPP2LyDZNq9bpG-jXp64BbEVcbbMzYeOPJHc3ITUu-w?e=tQLJVo.

A experimental result shows that dynamic buckets solution can reduce the **peak memory** usage by **16.9%** aginst Edge build-in AI Phi3 model with GenAI tool command: python benchmark/python/benchmark_e2e.py -i /Users/feich/models/phi3 -l 1000 -o perf_result.csv

**Open questions**: if this solution works well, is it possible to replace current default bucket solution?

### Test Device 
- Windows with NVIDIA GeForce RTX 5080 chip 
- Mac Mini with Apple M2 Pro chip 

### Model Memory and Perf Analysis
The peak/avg memory calculation is based on this commit https://github.com/microsoft/onnxruntime/commit/61cdfb9bfdf5baca7013f1e4f8c39c848b5f8359

The token gen latency and tokens/sec are from the output file of benchmark_e2e.py script
Token Gen Latency -> prompt_processing_latency_ms
Tokens/sec -> token_generation_throughput_tps

**Phi3-Windows**
Optimization Strategy | Peak Memory (MB) | Avg Memory (MB) | Token Gen Latency (ms) | Tokens/sec
-- | -- | -- | -- | --
Default Bucket | 3603.83 | 3127.05 | 7.17 | 139.50
Dynamic Bucket | **2994.94 (+16.90%)** | 2510.18 (+19.73%) | 7.15 (+0.24%) | 139.84 (+0.24%)

**DeepSeek-R1-Windows**
Optimization Strategy | Peak Memory (MB) | Avg Memory (MB) | Token Gen Latency (ms) | Tokens/sec
-- | -- | -- | -- | --
Default Bucket | 2089.03 | 1716.15 | 6.07 | 164.67
Dynamic Bucket | **1752.53 (+16.11%)** | 1345.29 (+21.61%) | 6.10 (-0.43%) | 163.97 (-0.42%)

**LLAMA3.2-1B-Windows**
Optimization Strategy | Peak Memory (MB) | Avg Memory (MB) | Token Gen Latency (ms) | Tokens/sec
-- | -- | -- | -- | --
Default Bucket | 1736.03 | 1424.64 | 3.37 | 296.53
Dynamic Bucket | **1550.81 (+10.67%)** | 1222.38 (+14.20%) | 3.37 (+0.06%) | 296.71 (+0.06%)

**Phi3-Mac**
Optimization Strategy | Peak Memory (MB) | Avg Memory (MB) | Token Gen Latency (ms) | Tokens/sec
-- | -- | -- | -- | --
Default Bucket | 3603.83 | 3121.60 | 7.17 | 139.50
Dynamic Bucket | **2994.94 (+16.90%)** | 2508.87 (+19.63%) | 7.15 (+0.24%) | 139.84 (+0.24%)

**DeepSeek-R1-Mac**
Optimization Strategy | Peak Memory (MB) | Avg Memory (MB) | Token Gen Latency (ms) | Tokens/sec
-- | -- | -- | -- | --
Default Bucket | 2065.88 | 1697.92 | 11.23 | 89.01
Dynamic Bucket | **1739.98 (+15.78%)** | 1344.08 (+20.84%) | 11.22 (+0.11%) | 89.10 (+0.11%)

**LLAMA3.2-1B-Mac**
Optimization Strategy | Peak Memory (MB) | Avg Memory (MB) | Token Gen Latency (ms) | Tokens/sec
-- | -- | -- | -- | --
Default Bucket | 1652.87 | 1361.16 | 8.52 | 117.32
Dynamic Bucket | **1535.11 (+7.12%)** | 1220.86 (+10.31%) | 8.53 (-0.02%) | 117.30 (-0.02%)