### PR TITLE
[WIP] [WebGPU] allow WGSL template generation

### DIFF
--- a/cmake/onnxruntime_providers_webgpu.cmake
+++ b/cmake/onnxruntime_providers_webgpu.cmake
@@ -9,6 +9,9 @@
   if (onnxruntime_ENABLE_WEBASSEMBLY_THREADS)
     add_definitions(-DENABLE_WEBASSEMBLY_THREADS=1)
   endif()
+  if (onnxruntime_USE_WGSL_TEMPLATE)
+    add_definitions(-DORT_USE_WGSL_TEMPLATE=1)
+  endif()
   file(GLOB_RECURSE onnxruntime_providers_webgpu_cc_srcs CONFIGURE_DEPENDS
     "${ONNXRUNTIME_ROOT}/core/providers/webgpu/*.h"
     "${ONNXRUNTIME_ROOT}/core/providers/webgpu/*.cc"
@@ -20,6 +23,7 @@
 
   source_group(TREE ${REPO_ROOT} FILES ${onnxruntime_providers_webgpu_cc_srcs})
   onnxruntime_add_static_library(onnxruntime_providers_webgpu ${onnxruntime_providers_webgpu_cc_srcs})
+  target_compile_features(onnxruntime_providers_webgpu PRIVATE cxx_std_20)
   onnxruntime_add_include_to_target(onnxruntime_providers_webgpu
     onnxruntime_common onnx onnx_proto flatbuffers::flatbuffers Boost::mp11 safeint_interface)
 
@@ -117,4 +121,54 @@
   endif()
 
   add_dependencies(onnxruntime_providers_webgpu ${onnxruntime_EXTERNAL_DEPENDENCIES})
+
+  if (onnxruntime_USE_WGSL_TEMPLATE)
+    # Define the WGSL templates directory and output directory
+    set(WGSL_TEMPLATES_DIR "${ONNXRUNTIME_ROOT}/core/providers/webgpu/wgsl_templates")
+    set(WGSL_GENERATED_ROOT "${CMAKE_CURRENT_BINARY_DIR}/wgsl_generated")
+    set(WGSL_GENERATED_DIR "${WGSL_GENERATED_ROOT}/wgsl_template_gen")
+
+    # Ensure the output directory exists
+    file(MAKE_DIRECTORY ${WGSL_GENERATED_DIR})
+
+    # Find npm and node executables
+    find_program(NPM_EXECUTABLE "npm.cmd" "npm" REQUIRED)
+    if(NOT NPM_EXECUTABLE)
+      message(FATAL_ERROR "npm is required for WGSL template generation but was not found")
+    endif()
+    find_program(NODE_EXECUTABLE "node" REQUIRED)
+    if (NOT NODE_EXECUTABLE)
+      message(FATAL_ERROR "Node is required for WGSL template generation but was not found")
+    endif()
+
+    # Install npm dependencies
+    add_custom_command(
+      OUTPUT "${WGSL_TEMPLATES_DIR}/node_modules/.install_complete"
+      COMMAND ${NPM_EXECUTABLE} ci
+      COMMAND ${CMAKE_COMMAND} -E touch "${WGSL_TEMPLATES_DIR}/node_modules/.install_complete"
+      DEPENDS "${WGSL_TEMPLATES_DIR}/package.json" "${WGSL_TEMPLATES_DIR}/package-lock.json"
+      WORKING_DIRECTORY ${WGSL_TEMPLATES_DIR}
+      COMMENT "Installing npm dependencies for WGSL template generation"
+      VERBATIM
+    )
+      # Find all WGSL template input files
+    file(GLOB_RECURSE WGSL_TEMPLATE_FILES "${ONNXRUNTIME_ROOT}/core/providers/webgpu/*.wgsl.template")
+
+    # Generate WGSL templates
+    add_custom_target(onnxruntime_webgpu_wgsl_generation
+      COMMAND ${NPM_EXECUTABLE} run gen -- -i ../ -o ${WGSL_GENERATED_DIR} -I wgsl_template_gen/ --generator static-cpp --clean --debug
+      DEPENDS "${WGSL_TEMPLATES_DIR}/node_modules/.install_complete" ${WGSL_TEMPLATE_FILES}
+      WORKING_DIRECTORY ${WGSL_TEMPLATES_DIR}
+      COMMENT "Generating WGSL templates from *.wgsl.template files"
+      VERBATIM
+      SOURCES ${WGSL_TEMPLATE_FILES}
+    )
+
+    # Add the generated directory to include paths
+    target_include_directories(onnxruntime_providers_webgpu PRIVATE ${WGSL_GENERATED_ROOT})
+
+    # Make sure generation happens before building the provider
+    add_dependencies(onnxruntime_providers_webgpu onnxruntime_webgpu_wgsl_generation)
+  endif()
+
   set_target_properties(onnxruntime_providers_webgpu PROPERTIES FOLDER "ONNXRuntime")

--- a/onnxruntime/core/providers/webgpu/shader_helper.h
+++ b/onnxruntime/core/providers/webgpu/shader_helper.h
@@ -13,6 +13,10 @@
 #include "core/providers/webgpu/shader_variable.h"
 #include "core/providers/webgpu/string_utils.h"
 
+#if defined(ORT_USE_WGSL_TEMPLATE)
+#include "core/providers/webgpu/wgsl_gen.h"
+#endif
+
 namespace onnxruntime {
 namespace webgpu {
 
@@ -72,6 +76,17 @@ class ShaderHelper final {
                uint32_t dispatch_group_size_z);
 
   Status Init();
+
+#if defined(ORT_USE_WGSL_TEMPLATE)
+  // Apply the WGSL template to the shader helper.
+  //
+  // \param TemplateFilepath The filepath of the WGSL template to apply.
+  // \return Status indicating success or failure.
+  template <wgsl_gen::string_template_filepath TemplateFilepath, typename TemplateParameterType = wgsl_gen::TemplateParameter<TemplateFilepath>::type>
+  Status ApplyTemplate(TemplateParameterType parameter) {
+    return wgsl_gen::ApplyTemplate<TemplateFilepath>(*this, parameter);
+  }
+#endif
 
   // Add an input variable to the shader.
   //

--- a/onnxruntime/core/providers/webgpu/tensor/pad.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/pad.cc
@@ -19,6 +19,12 @@ Status PadProgram::GenerateShaderCode(ShaderHelper& shader) const {
   }
   const auto& output = shader.AddOutput("output", ShaderUsage::UseUniform | ShaderUsage::UseShapeAndStride | ShaderUsage::UseValueTypeAlias);
 
+#if defined(ORT_USE_WGSL_TEMPLATE)
+  return shader.ApplyTemplate<"tensor/pad.wgsl.template">({.param_dim_value_zero = static_cast<int>(dim_value_zero_),
+                                                            .param_is_float16 = static_cast<int>(is_float16_),
+                                                            .param_pad_mode = static_cast<int>(mode_),
+                                                            .var_output = &output});
+#else
   shader.MainFunctionBody() << shader.GuardAgainstOutOfBoundsWorkgroupSizes("uniforms.output_size");
   std::string constant_value_str = std::string("let constant_value = ") +
                                    (is_float16_ ? "bitcast<vec2<f16>>(uniforms.constant_value)[0];\n" : "bitcast<output_value_t>(uniforms.constant_value);\n");
@@ -86,6 +92,7 @@ Status PadProgram::GenerateShaderCode(ShaderHelper& shader) const {
                             << "  " << output.SetByOffset("global_idx", "select(data[input_index], constant_value, use_pad_value)");
 
   return Status::OK();
+#endif
 }
 
 Status Pad::ComputeInternal(ComputeContext& context) const {

--- a/onnxruntime/core/providers/webgpu/tensor/pad.wgsl.template
+++ b/onnxruntime/core/providers/webgpu/tensor/pad.wgsl.template
@@ -1,0 +1,74 @@
+#define PAD_MODE_CONSTANT 0
+#define PAD_MODE_REFLECT 1
+#define PAD_MODE_EDGE 2
+#define PAD_MODE_WRAP 3
+
+#use guardAgainstOutOfBoundsWorkgroupSizes
+#use getElementAt
+#use .offsetToIndices .setByOffset .rank
+
+#param dim_value_zero
+#param is_float16
+#param pad_mode
+
+$MAIN {
+  guardAgainstOutOfBoundsWorkgroupSizes(uniforms.output_size);
+
+  let constant_value =
+#if is_float16
+      bitcast<vec2<f16>>(uniforms.constant_value)[0];
+#else
+      bitcast<output_value_t>(uniforms.constant_value);
+#endif
+
+#if dim_value_zero
+  output[global_idx] = constant_value;
+#else
+  let output_indices = output.offsetToIndices(global_idx);
+  var input_index = u32(0);
+  var use_pad_value = false;
+  var in_coord = i32(0);
+
+  for (var dim = 0; dim < output.rank && !use_pad_value; dim++) {
+    let output_index = i32(getElementAt(output_indices, dim, output.rank));
+    let lower_pads = getElementAt(uniforms.lower_pads, dim, output.rank);
+    let data_shape = i32(getElementAt(uniforms.data_shape, dim, output.rank));
+#if pad_mode == PAD_MODE_CONSTANT
+    if (output_index < lower_pads || output_index >= data_shape + lower_pads) {
+        use_pad_value = true;
+#elif pad_mode == PAD_MODE_EDGE
+    if (output_index < lower_pads) {
+      in_coord = 0;
+    } else if (output_index >= data_shape + lower_pads) {
+      in_coord = data_shape - 1;
+#elif pad_mode == PAD_MODE_REFLECT
+    if (output_index < lower_pads || output_index >= data_shape + lower_pads) {
+      in_coord = output_index - lower_pads;
+      if (in_coord < 0) {
+        in_coord = -in_coord;
+      }
+      let _2n_1 = 2 * (data_shape - 1);
+      in_coord = in_coord % _2n_1;
+      if (in_coord >= data_shape) {
+        in_coord = _2n_1 - in_coord;
+      }
+#else // PAD_MODE_WRAP
+    if (output_index < lower_pads) {
+      in_coord = data_shape + output_index - lower_pads;
+    } else if (output_index >= data_shape + lower_pads) {
+      in_coord = output_index - data_shape - lower_pads;
+#endif // pad_mode
+    } else {
+        in_coord = output_index - lower_pads;
+    }
+
+    input_index += select(u32(in_coord)
+#if output.rank > 1
+        * getElementAt(uniforms.data_stride, dim, output.rank - 1)
+#endif
+        , u32(in_coord), dim == output.rank - 1);
+  }
+
+  output.setByOffset(global_idx, select(data[input_index], constant_value, use_pad_value));
+#endif
+} // MAIN

--- a/onnxruntime/core/providers/webgpu/wgsl_gen.cc
+++ b/onnxruntime/core/providers/webgpu/wgsl_gen.cc
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if defined(ORT_USE_WGSL_TEMPLATE)
+
+#include <string>
+
+#include "core/providers/webgpu/wgsl_gen.h"
+
+#include "core/providers/webgpu/shader_helper.h"
+#include "core/providers/webgpu/shader_variable.h"
+#include "core/providers/webgpu/webgpu_utils.h"
+
+namespace onnxruntime {
+namespace webgpu {
+namespace wgsl_gen {
+
+#if defined(INCLUDED_BY_WGSL_GEN_IMPL)
+#error "macro INCLUDED_BY_WGSL_GEN_IMPL should not be defined yet."
+#endif
+
+#define INCLUDED_BY_WGSL_GEN_IMPL
+#include "wgsl_template_gen/index_impl.h"
+#undef INCLUDED_BY_WGSL_GEN_IMPL
+
+}  // namespace wgsl_gen
+}  // namespace webgpu
+}  // namespace onnxruntime
+
+#endif

--- a/onnxruntime/core/providers/webgpu/wgsl_gen.h
+++ b/onnxruntime/core/providers/webgpu/wgsl_gen.h
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <array>
+#include <string_view>
+
+#include "core/common/common.h"
+
+//
+// Forward declarations
+//
+namespace onnxruntime {
+namespace webgpu {
+
+class ShaderHelper;
+class ShaderVariableHelper;
+
+}  // namespace webgpu
+}  // namespace onnxruntime
+
+namespace onnxruntime {
+namespace webgpu {
+namespace wgsl_gen {
+
+// A helper struct to enable using a string literal as a NTTP (non-type template parameter).
+template <size_t N>
+struct string_template_filepath {
+  std::array<char, N> data{};  // N is the number of characters, excluding null terminator
+
+  consteval string_template_filepath(const char (&str)[N + 1]) {  // N+1 to account for null terminator in string literal
+    for (size_t i = 0; i < N; ++i) {
+      data[i] = str[i];
+    }
+  }
+
+  // Convert to std::string_view
+  constexpr std::string_view to_string_view() const {
+    return {data.data(), N};
+  }
+
+  // Equality comparison (optional, as we'll convert to string_view for map lookup)
+  consteval bool operator==(const string_template_filepath& other) const {
+    return data == other.data;
+  }
+};
+
+template <size_t StrLenWithNull>
+string_template_filepath(const char (&str)[StrLenWithNull]) -> string_template_filepath<StrLenWithNull - 1>;
+
+// Allow template specialization based on the string literal to define different template parameters.
+template <string_template_filepath TemplateName>
+struct TemplateParameter;
+
+// Allow specialization for specific templates.
+template <string_template_filepath TemplateName, typename TemplateParameterType = TemplateParameter<TemplateName>::type>
+onnxruntime::common::Status ApplyTemplate(ShaderHelper& shader_helper, TemplateParameterType parameter);
+
+#if defined(INCLUDED_BY_WGSL_GEN_HEADER)
+#error "macro INCLUDED_BY_WGSL_GEN_HEADER should not be defined yet."
+#endif
+
+#define INCLUDED_BY_WGSL_GEN_HEADER
+#include "wgsl_template_gen/index.h"
+#undef INCLUDED_BY_WGSL_GEN_HEADER
+
+}  // namespace wgsl_gen
+}  // namespace webgpu
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/wgsl_templates/.gitignore
+++ b/onnxruntime/core/providers/webgpu/wgsl_templates/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/onnxruntime/core/providers/webgpu/wgsl_templates/README.md
+++ b/onnxruntime/core/providers/webgpu/wgsl_templates/README.md
@@ -1,0 +1,21 @@
+## WebGPU WGSL template
+
+The current folder is used in ONNX Runtime WebGPU EP to build the WGSL template files into a set of generated C++ header files.
+
+For more information, check [wgsl-template](https://github.com/fs-eire/wgsl-template).
+
+### Build steps
+
+Just append `--use_wgsl_template` to the ORT build script:
+
+```sh
+./build.sh --use_webgpu --use_wgsl_template
+```
+
+
+The following build steps are only for when you just want to build/debug the template generation.
+
+(in current folder)
+
+1. run `npm ci`
+2. run `npm run gen -- -i ../ -o {output_dir} --generator static-cpp --clean --debug`

--- a/onnxruntime/core/providers/webgpu/wgsl_templates/package-lock.json
+++ b/onnxruntime/core/providers/webgpu/wgsl_templates/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "ort_wgsl_template_gen",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ort_wgsl_template_gen",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@fs-eire/wgsl-template": "^0.1.3"
+      }
+    },
+    "node_modules/@fs-eire/wgsl-template": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@fs-eire/wgsl-template/-/wgsl-template-0.1.3.tgz",
+      "integrity": "sha512-f0jyqNJfcnc+6/4fXNN/Pg81g6TX0h7DZFmnHOVgw+lVYUqxfxz3IHV//BH/+DtYF7nHgLyg0jJRYRzUjLe6FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.8"
+      },
+      "bin": {
+        "wgsl-gen": "dist/bin/cli.js"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    }
+  }
+}

--- a/onnxruntime/core/providers/webgpu/wgsl_templates/package.json
+++ b/onnxruntime/core/providers/webgpu/wgsl_templates/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "ort_wgsl_template_gen",
+  "version": "1.0.0",
+  "private": true,
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "gen": "wgsl-gen"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@fs-eire/wgsl-template": "^0.1.3"
+  }
+}

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -477,6 +477,7 @@ def generate_build_tree(
         "-Donnxruntime_USE_JSEP=" + ("ON" if args.use_jsep else "OFF"),
         "-Donnxruntime_USE_WEBGPU=" + ("ON" if args.use_webgpu else "OFF"),
         "-Donnxruntime_USE_EXTERNAL_DAWN=" + ("ON" if args.use_external_dawn else "OFF"),
+        "-Donnxruntime_USE_WGSL_TEMPLATE=" + ("ON" if args.use_wgsl_template else "OFF"),
         # Training related flags
         "-Donnxruntime_ENABLE_NVTX_PROFILE=" + ("ON" if args.enable_nvtx_profile else "OFF"),
         "-Donnxruntime_ENABLE_TRAINING=" + ("ON" if args.enable_training else "OFF"),

--- a/tools/ci_build/build_args.py
+++ b/tools/ci_build/build_args.py
@@ -746,6 +746,7 @@ def add_execution_provider_args(parser: argparse.ArgumentParser) -> None:
     webgpu_group.add_argument(
         "--use_external_dawn", action="store_true", help="Use external Dawn dependency for WebGPU."
     )
+    webgpu_group.add_argument("--use_wgsl_template", action="store_true", help="Enable WebGPU WGSL template generation.")
 
     # --- XNNPACK ---
     xnn_group = parser.add_argument_group("XNNPACK Execution Provider")


### PR DESCRIPTION
### Description

This PR introduces the [WGSL-Template](https://github.com/fs-eire/wgsl-template) into WebGPU EP to enable the capability of template based WGSL source generation.

The purpose of this change is to improve the readability of the WGSL source code and reduce the future maintenance cost due to the difficulty of understanding the current WGSL code generation logic.

Currently, this is still WIP and a lot of things are subject to change.

### Explanation

- build
  append flag `--use_wgsl_template`

- the template files use extension `.wgsl.template` and are located in `core/providers/webgpu/` folder.

- the corresponding C++ file should use `shader_helper.ApplyTemplate<...>()` to apply the template. (check pad.cc for example)

- for documentation - https://github.com/fs-eire/wgsl-template
