### PR TITLE
[jsep-webgpu] Add kernel profiling start time in logging

### DIFF
--- a/js/web/lib/wasm/jsep/backend-webgpu.ts
+++ b/js/web/lib/wasm/jsep/backend-webgpu.ts
@@ -428,7 +428,7 @@ export class WebGpuBackend {
             console.log(
               `[profiling] kernel "${kernelId}|${kernelType}|${kernelName}|${programName}" ${inputShapes}${
                 outputShapes
-              }execution time: ${endTime - startTime} ns`,
+              }start time: ${startTime} ns, execution time: ${endTime - startTime} ns`,
             );
           }
           TRACE('GPU', `${programName}::${startTimeU64}::${endTimeU64}`);


### PR DESCRIPTION
### Description
Adds the start time of WebGPU kernel profiling to the logging output.



### Motivation and Context
To aid in performance analysis, this change includes the kernel profiling start time in addition to the existing execution time. This allows for a more detailed understanding of kernel performance and scheduling.


