### PR TITLE
Add `ShouldConvertDataLayoutForOp()` API to allow EPs to customize layout sensitive ops

### DIFF
--- a/include/onnxruntime/core/framework/execution_provider.h
+++ b/include/onnxruntime/core/framework/execution_provider.h
@@ -5,6 +5,7 @@
 
 #ifndef SHARED_PROVIDER
 #include <memory>
+#include <optional>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -326,6 +327,16 @@ class IExecutionProvider {
     // NCHW is the default ONNX standard data layout. So default to it.
     // EPs which prefer a different layout should override to return their preferred layout.
     return DataLayout::NCHW;
+  }
+
+  /**
+    Determine whether a node with `domain` and `op_type` should have its layout converted to NHWC.
+    This function is called during layout transformation.
+    A return value of `std::nullopt` indicates that this decision is left to ORT.
+  */
+  virtual std::optional<bool> ShouldConvertNodeLayoutToNhwc(std::string_view /*node_domain*/,
+                                                            std::string_view /*node_op_type*/) const {
+    return std::nullopt;
   }
 
   virtual void RegisterStreamHandlers(IStreamCommandHandleRegistry& /*stream_handle_registry*/, AllocatorMap&) const {}

--- a/include/onnxruntime/core/framework/execution_provider.h
+++ b/include/onnxruntime/core/framework/execution_provider.h
@@ -330,15 +330,15 @@ class IExecutionProvider {
   }
 
   /**
-    Determine whether a node with `node_domain` and `node_op_type` requires its data layout to be converted to
-    `target_data_layout`.
+    Given an op with domain `domain` and type `op_type`, determine whether an associated node's data layout should be
+    converted to `target_data_layout`.
     If the EP prefers a non-default data layout (see `GetPreferredLayout()`), this function will be called during
     layout transformation with `target_data_layout` set to the EP's preferred data layout.
     A return value of `std::nullopt` indicates that this decision is left to ORT.
   */
-  virtual std::optional<bool> ShouldConvertNodeLayout(DataLayout /*target_data_layout*/,
-                                                      std::string_view /*node_domain*/,
-                                                      std::string_view /*node_op_type*/) const {
+  virtual std::optional<bool> ShouldConvertDataLayoutForOp(std::string_view /*domain*/,
+                                                           std::string_view /*op_type*/,
+                                                           DataLayout /*target_data_layout*/) const {
     return std::nullopt;
   }
 

--- a/include/onnxruntime/core/framework/execution_provider.h
+++ b/include/onnxruntime/core/framework/execution_provider.h
@@ -6,6 +6,7 @@
 #ifndef SHARED_PROVIDER
 #include <memory>
 #include <optional>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 

--- a/include/onnxruntime/core/framework/execution_provider.h
+++ b/include/onnxruntime/core/framework/execution_provider.h
@@ -330,13 +330,15 @@ class IExecutionProvider {
   }
 
   /**
-    Determine whether a node with `domain` and `op_type` requires its data layout to be converted to NHWC.
-    If the EP prefers NHWC data layout (see `GetPreferredLayout()`), this function will be called during layout
-    transformation.
+    Determine whether a node with `node_domain` and `node_op_type` requires its data layout to be converted to
+    `target_data_layout`.
+    If the EP prefers a non-default data layout (see `GetPreferredLayout()`), this function will be called during
+    layout transformation with `target_data_layout` set to the EP's preferred data layout.
     A return value of `std::nullopt` indicates that this decision is left to ORT.
   */
-  virtual std::optional<bool> ShouldConvertNodeLayoutToNhwc(std::string_view /*node_domain*/,
-                                                            std::string_view /*node_op_type*/) const {
+  virtual std::optional<bool> ShouldConvertNodeLayout(DataLayout /*target_data_layout*/,
+                                                      std::string_view /*node_domain*/,
+                                                      std::string_view /*node_op_type*/) const {
     return std::nullopt;
   }
 

--- a/include/onnxruntime/core/framework/execution_provider.h
+++ b/include/onnxruntime/core/framework/execution_provider.h
@@ -331,7 +331,8 @@ class IExecutionProvider {
 
   /**
     Determine whether a node with `domain` and `op_type` requires its data layout to be converted to NHWC.
-    This function is called during layout transformation.
+    If the EP prefers NHWC data layout (see `GetPreferredLayout()`), this function will be called during layout
+    transformation.
     A return value of `std::nullopt` indicates that this decision is left to ORT.
   */
   virtual std::optional<bool> ShouldConvertNodeLayoutToNhwc(std::string_view /*node_domain*/,

--- a/include/onnxruntime/core/framework/execution_provider.h
+++ b/include/onnxruntime/core/framework/execution_provider.h
@@ -330,7 +330,7 @@ class IExecutionProvider {
   }
 
   /**
-    Determine whether a node with `domain` and `op_type` should have its layout converted to NHWC.
+    Determine whether a node with `domain` and `op_type` requires its data layout to be converted to NHWC.
     This function is called during layout transformation.
     A return value of `std::nullopt` indicates that this decision is left to ORT.
   */

--- a/include/onnxruntime/core/framework/execution_provider.h
+++ b/include/onnxruntime/core/framework/execution_provider.h
@@ -64,6 +64,9 @@ using RunOptions = ::OrtRunOptions;
 enum class DataLayout {
   NCHW,
   NHWC,
+
+  // NCHW is the default ONNX standard data layout. So default to it.
+  Default = NCHW,
 };
 
 class IExecutionProvider {
@@ -324,9 +327,8 @@ class IExecutionProvider {
   }
 
   virtual DataLayout GetPreferredLayout() const {
-    // NCHW is the default ONNX standard data layout. So default to it.
     // EPs which prefer a different layout should override to return their preferred layout.
-    return DataLayout::NCHW;
+    return DataLayout::Default;
   }
 
   /**

--- a/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
@@ -257,6 +257,31 @@ struct OrtEp {
   OrtStatus*(ORT_API_CALL* GetPreferredDataLayout)(_In_ OrtEp* this_ptr,
                                                    _Out_ OrtEpDataLayout* preferred_data_layout);
 
+  /** \brief Determine whether a node with `domain` and `op_type` requires its data layout to be converted to NHWC.
+   *         If the EP prefers NHWC data layout (see `GetPreferredDataLayout()`), this function will be called during
+   *         layout transformation.
+   *
+   * \note Implementation of this function is optional.
+   *       If an EP prefers NHWC data layout, it may implement this to customize the specific NHWC op preferences at a
+   *       finer granularity.
+   *
+   * \param[in] this_ptr The OrtEp instance.
+   * \param[in] node_domain The node's op domain. An empty string means the ONNX domain.
+   * \param[in] node_op_type The node's op type.
+   * \param[out] should_convert Indicates whether the node's layout should be converted to NHWC.
+   *                            If greater than 0, convert.
+   *                            If 0, don't convert.
+   *                            Otherwise, if less than 0, leave the decision to ORT.
+   *
+   * \snippet{doc} snippets.dox OrtStatus Return Value
+   *
+   * \since Version 1.23.
+   */
+  OrtStatus*(ORT_API_CALL* ShouldConvertNodeLayoutToNhwc)(_In_ OrtEp* this_ptr,
+                                                          _In_z_ const char* node_domain,
+                                                          _In_z_ const char* node_op_type,
+                                                          _Outptr_ int* should_convert);
+
   /** \brief Set dynamic options on this EP.
    *
    * Dynamic options can be set by the user at any time after session creation with `OrtApi::SetEpDynamicOptions()`.

--- a/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
@@ -263,8 +263,8 @@ struct OrtEp {
   OrtStatus*(ORT_API_CALL* GetPreferredDataLayout)(_In_ OrtEp* this_ptr,
                                                    _Out_ OrtEpDataLayout* preferred_data_layout);
 
-  /** \brief Determine whether a node with `node_domain` and `node_op_type` requires its data layout to be converted to
-   *         `target_data_layout`.
+  /** \brief Given an op with domain `domain` and type `op_type`, determine whether an associated node's data layout
+   *         should be converted to `target_data_layout`.
    *         If the EP prefers a non-default data layout (see `GetPreferredDataLayout()`), this function will be called
    *         during layout transformation with `target_data_layout` set to the EP's preferred data layout.
    *
@@ -273,10 +273,10 @@ struct OrtEp {
    *       preferences at a finer granularity.
    *
    * \param[in] this_ptr The OrtEp instance.
+   * \param[in] domain The op domain. An empty string means the ONNX domain.
+   * \param[in] op_type The op type.
    * \param[in] target_data_layout The target data layout.
-   * \param[in] node_domain The node's op domain. An empty string means the ONNX domain.
-   * \param[in] node_op_type The node's op type.
-   * \param[out] should_convert Indicates whether the node's layout should be converted to `target_data_layout`.
+   * \param[out] should_convert Whether the associated node's data layout should be converted to `target_data_layout`.
    *                            If greater than 0, convert.
    *                            If 0, don't convert.
    *                            Otherwise, if less than 0, leave the decision to ORT.
@@ -285,11 +285,11 @@ struct OrtEp {
    *
    * \since Version 1.23.
    */
-  OrtStatus*(ORT_API_CALL* ShouldConvertNodeLayout)(_In_ OrtEp* this_ptr,
-                                                    _In_ OrtEpDataLayout target_data_layout,
-                                                    _In_z_ const char* node_domain,
-                                                    _In_z_ const char* node_op_type,
-                                                    _Outptr_ int* should_convert);
+  OrtStatus*(ORT_API_CALL* ShouldConvertDataLayoutForOp)(_In_ OrtEp* this_ptr,
+                                                         _In_z_ const char* domain,
+                                                         _In_z_ const char* op_type,
+                                                         _In_ OrtEpDataLayout target_data_layout,
+                                                         _Outptr_ int* should_convert);
 
   /** \brief Set dynamic options on this EP.
    *

--- a/onnxruntime/core/optimizer/layout_transformation/layout_transformation.cc
+++ b/onnxruntime/core/optimizer/layout_transformation/layout_transformation.cc
@@ -45,7 +45,7 @@ bool ShouldConvertNodeLayoutToNhwc(const IExecutionProvider& execution_provider,
   }
 
   const auto op_type = node.OpType();
-  if (auto should_convert_from_ep = execution_provider.ShouldConvertNodeLayout(DataLayout::NHWC, domain, op_type);
+  if (auto should_convert_from_ep = execution_provider.ShouldConvertDataLayoutForOp(domain, op_type, DataLayout::NHWC);
       should_convert_from_ep.has_value()) {
     return *should_convert_from_ep;
   }

--- a/onnxruntime/core/optimizer/layout_transformation/layout_transformation.cc
+++ b/onnxruntime/core/optimizer/layout_transformation/layout_transformation.cc
@@ -84,15 +84,6 @@ bool ShouldConvertNodeLayoutToNhwc(const IExecutionProvider& execution_provider,
 
   // handle special cases
 
-// NHWC for Resize operator is not implemented on kWebGpuExecutionProvider
-#if defined(USE_WEBGPU)
-  if (node.GetExecutionProviderType() == kWebGpuExecutionProvider) {
-    if (node.OpType() == "Resize") {
-      return false;
-    }
-  }
-#endif
-
 // TODO: We don't need to check USE_CUDA || USE_CUDA_PROVIDER_INTERFACE in this function because we're already
 // checking if the node is assigned to the desired EP (e.g., CUDA EP). We should only need to check
 // ENABLE_CUDA_NHWC_OPS.

--- a/onnxruntime/core/optimizer/layout_transformation/layout_transformation.cc
+++ b/onnxruntime/core/optimizer/layout_transformation/layout_transformation.cc
@@ -68,6 +68,7 @@ const std::unordered_set<std::string_view>& GetORTLayoutSensitiveOps() {
     // Define a static local string array so we can refer to the elements with string_views.
     static const std::string layout_sensitive_contrib_ops[]{
         MakeORTLayoutSensitiveOpId(kMSDomain, "FusedConv"),
+        MakeORTLayoutSensitiveOpId(kMSDomain, "GridSample"),
         MakeORTLayoutSensitiveOpId(kMSDomain, "QLinearAveragePool"),
         MakeORTLayoutSensitiveOpId(kMSDomain, "QLinearGlobalAveragePool"),
     };

--- a/onnxruntime/core/optimizer/layout_transformation/layout_transformation.cc
+++ b/onnxruntime/core/optimizer/layout_transformation/layout_transformation.cc
@@ -45,7 +45,7 @@ bool ShouldConvertNodeLayoutToNhwc(const IExecutionProvider& execution_provider,
   }
 
   const auto op_type = node.OpType();
-  if (auto should_convert_from_ep = execution_provider.ShouldConvertNodeLayoutToNhwc(domain, op_type);
+  if (auto should_convert_from_ep = execution_provider.ShouldConvertNodeLayout(DataLayout::NHWC, domain, op_type);
       should_convert_from_ep.has_value()) {
     return *should_convert_from_ep;
   }

--- a/onnxruntime/core/optimizer/layout_transformation/layout_transformation.cc
+++ b/onnxruntime/core/optimizer/layout_transformation/layout_transformation.cc
@@ -83,16 +83,6 @@ bool ShouldConvertNodeLayoutToNhwc(const IExecutionProvider& execution_provider,
 #if 0
 
   // handle special cases
-#if defined(USE_JSEP)
-  // TODO(fs-eire): Remove special case handing of JSEP once NHWC Resize implementation is fixed
-  if (node.GetExecutionProviderType() == kJsExecutionProvider) {
-    if (node.OpType() == "Resize") {
-      // leave Resize as-is pending bugfix for NHWC implementation. this means the node will remain in the ONNX domain
-      // with the original input layout.
-      return false;
-    }
-  }
-#endif
 
 // NHWC for Resize operator is not implemented on kWebGpuExecutionProvider
 #if defined(USE_WEBGPU)

--- a/onnxruntime/core/optimizer/layout_transformation/layout_transformation.h
+++ b/onnxruntime/core/optimizer/layout_transformation/layout_transformation.h
@@ -68,11 +68,18 @@ bool IsSupportedOpset(const Graph& graph);
 /// Gets a list of layout sensitive ops for ORT. This list contains ONNX standard defined
 /// layout sensitive ops + contrib ops + ops which are not layout sensitive but are treated as
 /// layout sensitive by ORT EPs (example Resize).
-/// The format of the returned ops is "<op type>" for ops in the ONNX domain and
-/// "<domain>:<op type>" for ops in other domains.
+///
+/// Note: The format of the returned op identifiers is "<op type>" for ops in the ONNX domain and
+/// "<domain>:<op type>" for ops in other domains. `MakeORTLayoutSensitiveOpId()` can be used to
+/// create an op identifier with this format.
 /// </summary>
-/// <returns>unordered set of op_types which are layout sensitive</returns>
+/// <returns>set of op identifiers which are layout sensitive</returns>
 const std::unordered_set<std::string_view>& GetORTLayoutSensitiveOps();
+
+/// <summary>
+/// Creates an op identifier compatible with `GetORTLayoutSensitiveOps()`.
+/// </summary>
+std::string MakeORTLayoutSensitiveOpId(std::string_view domain, std::string_view op_type);
 
 /// <summary>
 /// Inserts transposes around op inputs/outputs. Alternatively transposes initializers or uses existing Transpose

--- a/onnxruntime/core/optimizer/layout_transformation/layout_transformation.h
+++ b/onnxruntime/core/optimizer/layout_transformation/layout_transformation.h
@@ -68,6 +68,8 @@ bool IsSupportedOpset(const Graph& graph);
 /// Gets a list of layout sensitive ops for ORT. This list contains ONNX standard defined
 /// layout sensitive ops + contrib ops + ops which are not layout sensitive but are treated as
 /// layout sensitive by ORT EPs (example Resize).
+/// The format of the returned ops is "<op type>" for ops in the ONNX domain and
+/// "<domain>:<op type>" for ops in other domains.
 /// </summary>
 /// <returns>unordered set of op_types which are layout sensitive</returns>
 const std::unordered_set<std::string_view>& GetORTLayoutSensitiveOps();

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -342,7 +342,8 @@ std::optional<bool> CUDAExecutionProvider::ShouldConvertNodeLayoutToNhwc(std::st
       "LRN",
   };
 
-  return node_domain == kOnnxDomain && cuda_nhwc_onnx_ops.find(node_op_type) != cuda_nhwc_onnx_ops.end();
+  return (node_domain == kOnnxDomain && cuda_nhwc_onnx_ops.find(node_op_type) != cuda_nhwc_onnx_ops.end()) ||
+         (node_domain == kMSDomain && node_op_type == "GridSample");
 
 #else  // defined(ENABLE_CUDA_NHWC_OPS)
   return std::nullopt;

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -323,9 +323,13 @@ DataLayout CUDAExecutionProvider::GetPreferredLayout() const {
   return this->IsNHWCPreferred() ? DataLayout::NHWC : DataLayout::NCHW;
 }
 
-std::optional<bool> CUDAExecutionProvider::ShouldConvertNodeLayoutToNhwc(std::string_view node_domain,
-                                                                         std::string_view node_op_type) const {
+std::optional<bool> CUDAExecutionProvider::ShouldConvertNodeLayout(DataLayout target_data_layout,
+                                                                   std::string_view node_domain,
+                                                                   std::string_view node_op_type) const {
 #if defined(ENABLE_CUDA_NHWC_OPS)
+  if (target_data_layout != DataLayout::NHWC) {
+    return std::nullopt;
+  }
 
   // TODO(mtavenrath) generate list from registered kernels using nhwc domain
   static const std::unordered_set<std::string_view> cuda_nhwc_onnx_ops{

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -323,9 +323,9 @@ DataLayout CUDAExecutionProvider::GetPreferredLayout() const {
   return this->IsNHWCPreferred() ? DataLayout::NHWC : DataLayout::NCHW;
 }
 
-std::optional<bool> CUDAExecutionProvider::ShouldConvertNodeLayout(DataLayout target_data_layout,
-                                                                   std::string_view node_domain,
-                                                                   std::string_view node_op_type) const {
+std::optional<bool> CUDAExecutionProvider::ShouldConvertDataLayoutForOp(std::string_view node_domain,
+                                                                        std::string_view node_op_type,
+                                                                        DataLayout target_data_layout) const {
 #if defined(ENABLE_CUDA_NHWC_OPS)
   if (target_data_layout != DataLayout::NHWC) {
     return std::nullopt;

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.h
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.h
@@ -39,6 +39,9 @@ class CUDAExecutionProvider : public IExecutionProvider {
 
   DataLayout GetPreferredLayout() const override;
 
+  std::optional<bool> ShouldConvertNodeLayoutToNhwc(std::string_view node_domain,
+                                                    std::string_view node_op_type) const override;
+
   const void* GetExecutionHandle() const noexcept override {
     // The CUDA interface does not return anything interesting.
     return nullptr;

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.h
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.h
@@ -39,8 +39,9 @@ class CUDAExecutionProvider : public IExecutionProvider {
 
   DataLayout GetPreferredLayout() const override;
 
-  std::optional<bool> ShouldConvertNodeLayoutToNhwc(std::string_view node_domain,
-                                                    std::string_view node_op_type) const override;
+  std::optional<bool> ShouldConvertNodeLayout(DataLayout target_data_layout,
+                                              std::string_view node_domain,
+                                              std::string_view node_op_type) const override;
 
   const void* GetExecutionHandle() const noexcept override {
     // The CUDA interface does not return anything interesting.

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.h
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.h
@@ -39,9 +39,9 @@ class CUDAExecutionProvider : public IExecutionProvider {
 
   DataLayout GetPreferredLayout() const override;
 
-  std::optional<bool> ShouldConvertNodeLayout(DataLayout target_data_layout,
-                                              std::string_view node_domain,
-                                              std::string_view node_op_type) const override;
+  std::optional<bool> ShouldConvertDataLayoutForOp(std::string_view node_domain,
+                                                   std::string_view node_op_type,
+                                                   DataLayout target_data_layout) const override;
 
   const void* GetExecutionHandle() const noexcept override {
     // The CUDA interface does not return anything interesting.

--- a/onnxruntime/core/providers/cuda/cuda_nhwc_kernels.cc
+++ b/onnxruntime/core/providers/cuda/cuda_nhwc_kernels.cc
@@ -24,8 +24,8 @@
 
 namespace onnxruntime::cuda {
 
-// When adding new supported NHWC operations make sure to also integrate them into: ShouldConvertNodeLayoutToNhwc
-// in onnxruntime/core/optimizer/layout_transformation/layout_transformation.cc
+// When adding new supported NHWC operations make sure to also integrate them into
+// CUDAExecutionProvider::ShouldConvertNodeLayout()
 
 class CUDA_NHWC_OP_VERSIONED_TYPED_CLASS_NAME(7, 8, float, BatchNormalization);
 class CUDA_NHWC_OP_VERSIONED_TYPED_CLASS_NAME(7, 8, double, BatchNormalization);

--- a/onnxruntime/core/providers/cuda/cuda_nhwc_kernels.cc
+++ b/onnxruntime/core/providers/cuda/cuda_nhwc_kernels.cc
@@ -24,7 +24,7 @@
 
 namespace onnxruntime::cuda {
 
-// When adding new supported NHWC operations make sure to also integrate them into: ConvertNodeLayout
+// When adding new supported NHWC operations make sure to also integrate them into: ShouldConvertNodeLayoutToNhwc
 // in onnxruntime/core/optimizer/layout_transformation/layout_transformation.cc
 
 class CUDA_NHWC_OP_VERSIONED_TYPED_CLASS_NAME(7, 8, float, BatchNormalization);

--- a/onnxruntime/core/providers/cuda/cuda_nhwc_kernels.cc
+++ b/onnxruntime/core/providers/cuda/cuda_nhwc_kernels.cc
@@ -25,7 +25,7 @@
 namespace onnxruntime::cuda {
 
 // When adding new supported NHWC operations make sure to also integrate them into
-// CUDAExecutionProvider::ShouldConvertNodeLayout()
+// CUDAExecutionProvider::ShouldConvertDataLayoutForOp()
 
 class CUDA_NHWC_OP_VERSIONED_TYPED_CLASS_NAME(7, 8, float, BatchNormalization);
 class CUDA_NHWC_OP_VERSIONED_TYPED_CLASS_NAME(7, 8, double, BatchNormalization);

--- a/onnxruntime/core/providers/js/js_execution_provider.cc
+++ b/onnxruntime/core/providers/js/js_execution_provider.cc
@@ -849,6 +849,18 @@ std::unique_ptr<onnxruntime::IExternalDataLoader> JsExecutionProvider::GetExtern
   return std::make_unique<js::ExternalDataLoader>();
 }
 
+std::optional<bool> JsExecutionProvider::ShouldConvertNodeLayoutToNhwc(std::string_view node_domain,
+                                                                       std::string_view node_op_type) const {
+  // TODO(fs-eire): Remove special case handing of JSEP once NHWC Resize implementation is fixed
+  if (node_domain == kOnnxDomain && node_op_type == "Resize") {
+    // leave Resize as-is pending bugfix for NHWC implementation. this means the node will remain in the ONNX domain
+    // with the original input layout.
+    return false;
+  }
+
+  return std::nullopt;
+}
+
 JsExecutionProvider::~JsExecutionProvider() {
 }
 

--- a/onnxruntime/core/providers/js/js_execution_provider.cc
+++ b/onnxruntime/core/providers/js/js_execution_provider.cc
@@ -849,9 +849,9 @@ std::unique_ptr<onnxruntime::IExternalDataLoader> JsExecutionProvider::GetExtern
   return std::make_unique<js::ExternalDataLoader>();
 }
 
-std::optional<bool> JsExecutionProvider::ShouldConvertNodeLayout(DataLayout target_data_layout,
-                                                                 std::string_view node_domain,
-                                                                 std::string_view node_op_type) const {
+std::optional<bool> JsExecutionProvider::ShouldConvertDataLayoutForOp(std::string_view node_domain,
+                                                                      std::string_view node_op_type,
+                                                                      DataLayout target_data_layout) const {
   if (target_data_layout != DataLayout::NHWC) {
     return std::nullopt;
   }

--- a/onnxruntime/core/providers/js/js_execution_provider.cc
+++ b/onnxruntime/core/providers/js/js_execution_provider.cc
@@ -849,8 +849,13 @@ std::unique_ptr<onnxruntime::IExternalDataLoader> JsExecutionProvider::GetExtern
   return std::make_unique<js::ExternalDataLoader>();
 }
 
-std::optional<bool> JsExecutionProvider::ShouldConvertNodeLayoutToNhwc(std::string_view node_domain,
-                                                                       std::string_view node_op_type) const {
+std::optional<bool> JsExecutionProvider::ShouldConvertNodeLayout(DataLayout target_data_layout,
+                                                                 std::string_view node_domain,
+                                                                 std::string_view node_op_type) const {
+  if (target_data_layout != DataLayout::NHWC) {
+    return std::nullopt;
+  }
+
   // TODO(fs-eire): Remove special case handing of JSEP once NHWC Resize implementation is fixed
   if (node_domain == kOnnxDomain && node_op_type == "Resize") {
     // leave Resize as-is pending bugfix for NHWC implementation. this means the node will remain in the ONNX domain

--- a/onnxruntime/core/providers/js/js_execution_provider.h
+++ b/onnxruntime/core/providers/js/js_execution_provider.h
@@ -54,8 +54,9 @@ class JsExecutionProvider : public IExecutionProvider {
 
   DataLayout GetPreferredLayout() const override { return preferred_data_layout_; }
 
-  std::optional<bool> ShouldConvertNodeLayoutToNhwc(std::string_view node_domain,
-                                                    std::string_view node_op_type) const override;
+  std::optional<bool> ShouldConvertNodeLayout(DataLayout target_data_layout,
+                                              std::string_view node_domain,
+                                              std::string_view node_op_type) const override;
 
   FusionStyle GetFusionStyle() const override { return FusionStyle::FilteredGraphViewer; }
 

--- a/onnxruntime/core/providers/js/js_execution_provider.h
+++ b/onnxruntime/core/providers/js/js_execution_provider.h
@@ -54,9 +54,9 @@ class JsExecutionProvider : public IExecutionProvider {
 
   DataLayout GetPreferredLayout() const override { return preferred_data_layout_; }
 
-  std::optional<bool> ShouldConvertNodeLayout(DataLayout target_data_layout,
-                                              std::string_view node_domain,
-                                              std::string_view node_op_type) const override;
+  std::optional<bool> ShouldConvertDataLayoutForOp(std::string_view node_domain,
+                                                   std::string_view node_op_type,
+                                                   DataLayout target_data_layout) const override;
 
   FusionStyle GetFusionStyle() const override { return FusionStyle::FilteredGraphViewer; }
 

--- a/onnxruntime/core/providers/js/js_execution_provider.h
+++ b/onnxruntime/core/providers/js/js_execution_provider.h
@@ -54,6 +54,9 @@ class JsExecutionProvider : public IExecutionProvider {
 
   DataLayout GetPreferredLayout() const override { return preferred_data_layout_; }
 
+  std::optional<bool> ShouldConvertNodeLayoutToNhwc(std::string_view node_domain,
+                                                    std::string_view node_op_type) const override;
+
   FusionStyle GetFusionStyle() const override { return FusionStyle::FilteredGraphViewer; }
 
   // JSEP disallow concurrent run because actual implementation (eg. WebGPU backend) relies on global states to work,

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -1066,9 +1066,9 @@ DataLayout QNNExecutionProvider::GetPreferredLayout() const {
   return DataLayout::NHWC;
 }
 
-std::optional<bool> QNNExecutionProvider::ShouldConvertNodeLayout(DataLayout target_data_layout,
-                                                                  std::string_view node_domain,
-                                                                  std::string_view node_op_type) const {
+std::optional<bool> QNNExecutionProvider::ShouldConvertDataLayoutForOp(std::string_view node_domain,
+                                                                       std::string_view node_op_type,
+                                                                       DataLayout target_data_layout) const {
   if (target_data_layout != DataLayout::NHWC) {
     return std::nullopt;
   }

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -1069,6 +1069,10 @@ DataLayout QNNExecutionProvider::GetPreferredLayout() const {
 std::optional<bool> QNNExecutionProvider::ShouldConvertNodeLayout(DataLayout target_data_layout,
                                                                   std::string_view node_domain,
                                                                   std::string_view node_op_type) const {
+  if (target_data_layout != DataLayout::NHWC) {
+    return std::nullopt;
+  }
+
   if (node_domain == kOnnxDomain && node_op_type == "Upsample") {
     // Upsample is translated to QNN's Resize, which requires the NHWC layout for processing.
     return true;

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -1066,8 +1066,9 @@ DataLayout QNNExecutionProvider::GetPreferredLayout() const {
   return DataLayout::NHWC;
 }
 
-std::optional<bool> QNNExecutionProvider::ShouldConvertNodeLayoutToNhwc(std::string_view node_domain,
-                                                                        std::string_view node_op_type) const {
+std::optional<bool> QNNExecutionProvider::ShouldConvertNodeLayout(DataLayout target_data_layout,
+                                                                  std::string_view node_domain,
+                                                                  std::string_view node_op_type) const {
   if (node_domain == kOnnxDomain && node_op_type == "Upsample") {
     // Upsample is translated to QNN's Resize, which requires the NHWC layout for processing.
     return true;

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -929,6 +929,16 @@ DataLayout QNNExecutionProvider::GetPreferredLayout() const {
   return DataLayout::NHWC;
 }
 
+std::optional<bool> QNNExecutionProvider::ShouldConvertNodeLayoutToNhwc(std::string_view node_domain,
+                                                                        std::string_view node_op_type) const {
+  if (node_domain == kOnnxDomain && node_op_type == "Upsample") {
+    // Upsample is translated to QNN's Resize, which requires the NHWC layout for processing.
+    return true;
+  }
+
+  return std::nullopt;
+}
+
 Status QNNExecutionProvider::CreateComputeFunc(std::vector<NodeComputeInfo>& node_compute_funcs,
                                                const logging::Logger& logger) {
   NodeComputeInfo compute_info;

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -43,6 +43,9 @@ class QNNExecutionProvider : public IExecutionProvider {
 
   DataLayout GetPreferredLayout() const override;
 
+  std::optional<bool> ShouldConvertNodeLayoutToNhwc(std::string_view node_domain,
+                                                    std::string_view node_op_type) const override;
+
   const InlinedVector<const Node*> GetEpContextNodes() const override;
 
   Status OnRunStart(const onnxruntime::RunOptions& run_options) override;

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -43,8 +43,9 @@ class QNNExecutionProvider : public IExecutionProvider {
 
   DataLayout GetPreferredLayout() const override;
 
-  std::optional<bool> ShouldConvertNodeLayoutToNhwc(std::string_view node_domain,
-                                                    std::string_view node_op_type) const override;
+  std::optional<bool> ShouldConvertNodeLayout(DataLayout target_data_layout,
+                                              std::string_view node_domain,
+                                              std::string_view node_op_type) const override;
 
   const InlinedVector<const Node*> GetEpContextNodes() const override;
 

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -43,9 +43,9 @@ class QNNExecutionProvider : public IExecutionProvider {
 
   DataLayout GetPreferredLayout() const override;
 
-  std::optional<bool> ShouldConvertNodeLayout(DataLayout target_data_layout,
-                                              std::string_view node_domain,
-                                              std::string_view node_op_type) const override;
+  std::optional<bool> ShouldConvertDataLayoutForOp(std::string_view node_domain,
+                                                   std::string_view node_op_type,
+                                                   DataLayout target_data_layout) const override;
 
   const InlinedVector<const Node*> GetEpContextNodes() const override;
 

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -855,9 +855,9 @@ std::unique_ptr<onnxruntime::IExternalDataLoader> WebGpuExecutionProvider::GetEx
 }
 #endif
 
-std::optional<bool> WebGpuExecutionProvider::ShouldConvertNodeLayout(DataLayout target_data_layout,
-                                                                     std::string_view node_domain,
-                                                                     std::string_view node_op_type) const {
+std::optional<bool> WebGpuExecutionProvider::ShouldConvertDataLayoutForOp(std::string_view node_domain,
+                                                                          std::string_view node_op_type,
+                                                                          DataLayout target_data_layout) const {
   if (target_data_layout != DataLayout::NHWC) {
     return std::nullopt;
   }

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -855,8 +855,13 @@ std::unique_ptr<onnxruntime::IExternalDataLoader> WebGpuExecutionProvider::GetEx
 }
 #endif
 
-std::optional<bool> WebGpuExecutionProvider::ShouldConvertNodeLayoutToNhwc(std::string_view node_domain,
-                                                                           std::string_view node_op_type) const {
+std::optional<bool> WebGpuExecutionProvider::ShouldConvertNodeLayout(DataLayout target_data_layout,
+                                                                     std::string_view node_domain,
+                                                                     std::string_view node_op_type) const {
+  if (target_data_layout != DataLayout::NHWC) {
+    return std::nullopt;
+  }
+
   // NHWC for Resize operator is not implemented on kWebGpuExecutionProvider
   if (node_domain == kOnnxDomain && node_op_type == "Resize") {
     return false;

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -855,6 +855,16 @@ std::unique_ptr<onnxruntime::IExternalDataLoader> WebGpuExecutionProvider::GetEx
 }
 #endif
 
+std::optional<bool> WebGpuExecutionProvider::ShouldConvertNodeLayoutToNhwc(std::string_view node_domain,
+                                                                           std::string_view node_op_type) const {
+  // NHWC for Resize operator is not implemented on kWebGpuExecutionProvider
+  if (node_domain == kOnnxDomain && node_op_type == "Resize") {
+    return false;
+  }
+
+  return std::nullopt;
+}
+
 WebGpuExecutionProvider::~WebGpuExecutionProvider() {
   WebGpuContextFactory::ReleaseContext(context_id_);
 }

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.h
@@ -57,8 +57,9 @@ class WebGpuExecutionProvider : public IExecutionProvider {
 
   DataLayout GetPreferredLayout() const override { return preferred_data_layout_; }
 
-  std::optional<bool> ShouldConvertNodeLayoutToNhwc(std::string_view node_domain,
-                                                    std::string_view node_op_type) const override;
+  std::optional<bool> ShouldConvertNodeLayout(DataLayout target_data_layout,
+                                              std::string_view node_domain,
+                                              std::string_view node_op_type) const override;
 
   FusionStyle GetFusionStyle() const override { return FusionStyle::FilteredGraphViewer; }
 

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.h
@@ -57,9 +57,9 @@ class WebGpuExecutionProvider : public IExecutionProvider {
 
   DataLayout GetPreferredLayout() const override { return preferred_data_layout_; }
 
-  std::optional<bool> ShouldConvertNodeLayout(DataLayout target_data_layout,
-                                              std::string_view node_domain,
-                                              std::string_view node_op_type) const override;
+  std::optional<bool> ShouldConvertDataLayoutForOp(std::string_view node_domain,
+                                                   std::string_view node_op_type,
+                                                   DataLayout target_data_layout) const override;
 
   FusionStyle GetFusionStyle() const override { return FusionStyle::FilteredGraphViewer; }
 

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.h
@@ -57,6 +57,9 @@ class WebGpuExecutionProvider : public IExecutionProvider {
 
   DataLayout GetPreferredLayout() const override { return preferred_data_layout_; }
 
+  std::optional<bool> ShouldConvertNodeLayoutToNhwc(std::string_view node_domain,
+                                                    std::string_view node_op_type) const override;
+
   FusionStyle GetFusionStyle() const override { return FusionStyle::FilteredGraphViewer; }
 
   // WebGPU EP disallow concurrent run because actual implementation (eg. WebGPU backend) relies on global states to

--- a/onnxruntime/core/session/ep_plugin_provider_interfaces.cc
+++ b/onnxruntime/core/session/ep_plugin_provider_interfaces.cc
@@ -390,6 +390,21 @@ const InlinedVector<const Node*> PluginExecutionProvider::GetEpContextNodes() co
   return result;
 }
 
+namespace {
+
+struct DataLayoutMapping {
+  DataLayout data_layout;
+  OrtEpDataLayout api_data_layout;
+};
+
+// Maps enum values between `onnxruntime::DataLayout` and `OrtEpDataLayout`.
+constexpr std::array kDataLayoutMappings{
+    DataLayoutMapping{DataLayout::NCHW, OrtEpDataLayout::OrtEpDataLayout_NCHW},
+    DataLayoutMapping{DataLayout::NHWC, OrtEpDataLayout::OrtEpDataLayout_NHWC},
+};
+
+}  // namespace
+
 DataLayout PluginExecutionProvider::GetPreferredLayout() const {
   if (ort_ep_->GetPreferredDataLayout == nullptr) {
     return Base::GetPreferredLayout();
@@ -399,32 +414,40 @@ DataLayout PluginExecutionProvider::GetPreferredLayout() const {
 
   ORT_THROW_IF_ERROR(ToStatusAndRelease(ort_ep_->GetPreferredDataLayout(ort_ep_.get(), &api_data_layout)));
 
-  switch (api_data_layout) {
-    case OrtEpDataLayout::OrtEpDataLayout_NCHW:
-      return DataLayout::NCHW;
+  const auto data_layout_mapping = std::find_if(kDataLayoutMappings.begin(), kDataLayoutMappings.end(),
+                                                [api_data_layout](const DataLayoutMapping& mapping) {
+                                                  return mapping.api_data_layout == api_data_layout;
+                                                });
 
-    case OrtEpDataLayout::OrtEpDataLayout_NHWC:
-      return DataLayout::NHWC;
+  ORT_ENFORCE(data_layout_mapping != kDataLayoutMappings.end(),
+              "OrtEp::GetPreferredDataLayout() returned an invalid data layout: ", static_cast<int>(api_data_layout));
 
-    default:
-      ORT_THROW("OrtEp::GetPreferredDataLayout() returned an invalid data layout: ",
-                static_cast<int>(api_data_layout));
-  }
+  return data_layout_mapping->data_layout;
 }
 
-std::optional<bool> PluginExecutionProvider::ShouldConvertNodeLayoutToNhwc(std::string_view node_domain,
-                                                                           std::string_view node_op_type) const {
-  if (ort_ep_->ShouldConvertNodeLayoutToNhwc == nullptr) {
-    return Base::ShouldConvertNodeLayoutToNhwc(node_domain, node_op_type);
+std::optional<bool> PluginExecutionProvider::ShouldConvertNodeLayout(DataLayout target_data_layout,
+                                                                     std::string_view node_domain,
+                                                                     std::string_view node_op_type) const {
+  if (ort_ep_->ShouldConvertNodeLayout == nullptr) {
+    return Base::ShouldConvertNodeLayout(target_data_layout, node_domain, node_op_type);
   }
+
+  const auto data_layout_mapping = std::find_if(kDataLayoutMappings.begin(), kDataLayoutMappings.end(),
+                                                [target_data_layout](const DataLayoutMapping& mapping) {
+                                                  return mapping.data_layout = target_data_layout;
+                                                });
+
+  ORT_ENFORCE(data_layout_mapping != kDataLayoutMappings.end(),
+              "Unable to map target_data_layout (", static_cast<int>(target_data_layout), ") to OrtEpDataLayout.");
 
   // Ensure domain and op type strings are null-terminated.
   const std::string node_domain_str{node_domain}, node_op_type_str{node_op_type};
   int should_convert = -1;
 
   ORT_THROW_IF_ERROR(ToStatusAndRelease(
-      ort_ep_->ShouldConvertNodeLayoutToNhwc(ort_ep_.get(), node_domain_str.c_str(), node_op_type_str.c_str(),
-                                             &should_convert)));
+      ort_ep_->ShouldConvertNodeLayout(ort_ep_.get(), data_layout_mapping->api_data_layout,
+                                       node_op_domain_str.c_str(), node_op_type_str.c_str(),
+                                       &should_convert)));
 
   if (should_convert > 0) {
     return true;

--- a/onnxruntime/core/session/ep_plugin_provider_interfaces.cc
+++ b/onnxruntime/core/session/ep_plugin_provider_interfaces.cc
@@ -419,11 +419,12 @@ std::optional<bool> PluginExecutionProvider::ShouldConvertNodeLayoutToNhwc(std::
   }
 
   // Ensure domain and op type strings are null-terminated.
-  const std::string node_domain_str = node_domain, node_op_type_str = node_op_type;
+  const std::string node_domain_str{node_domain}, node_op_type_str{node_op_type};
   int should_convert = -1;
 
   ORT_THROW_IF_ERROR(ToStatusAndRelease(
-      ort_ep_->ShouldConvertNodeLayoutToNhwc(ort_ep_.get(), node_domain_str, node_op_type_str, &should_convert)));
+      ort_ep_->ShouldConvertNodeLayoutToNhwc(ort_ep_.get(), node_domain_str.c_str(), node_op_type_str.c_str(),
+                                             &should_convert)));
 
   if (should_convert > 0) {
     return true;

--- a/onnxruntime/core/session/ep_plugin_provider_interfaces.cc
+++ b/onnxruntime/core/session/ep_plugin_provider_interfaces.cc
@@ -425,11 +425,11 @@ DataLayout PluginExecutionProvider::GetPreferredLayout() const {
   return data_layout_mapping->data_layout;
 }
 
-std::optional<bool> PluginExecutionProvider::ShouldConvertNodeLayout(DataLayout target_data_layout,
-                                                                     std::string_view node_domain,
-                                                                     std::string_view node_op_type) const {
-  if (ort_ep_->ShouldConvertNodeLayout == nullptr) {
-    return Base::ShouldConvertNodeLayout(target_data_layout, node_domain, node_op_type);
+std::optional<bool> PluginExecutionProvider::ShouldConvertDataLayoutForOp(std::string_view node_domain,
+                                                                          std::string_view node_op_type,
+                                                                          DataLayout target_data_layout) const {
+  if (ort_ep_->ShouldConvertDataLayoutForOp == nullptr) {
+    return Base::ShouldConvertDataLayoutForOp(node_domain, node_op_type, target_data_layout);
   }
 
   const auto data_layout_mapping = std::find_if(kDataLayoutMappings.begin(), kDataLayoutMappings.end(),
@@ -445,9 +445,10 @@ std::optional<bool> PluginExecutionProvider::ShouldConvertNodeLayout(DataLayout 
   int should_convert = -1;
 
   ORT_THROW_IF_ERROR(ToStatusAndRelease(
-      ort_ep_->ShouldConvertNodeLayout(ort_ep_.get(), data_layout_mapping->api_data_layout,
-                                       node_domain_str.c_str(), node_op_type_str.c_str(),
-                                       &should_convert)));
+      ort_ep_->ShouldConvertDataLayoutForOp(ort_ep_.get(),
+                                            node_domain_str.c_str(), node_op_type_str.c_str(),
+                                            data_layout_mapping->api_data_layout,
+                                            &should_convert)));
 
   if (should_convert > 0) {
     return true;

--- a/onnxruntime/core/session/ep_plugin_provider_interfaces.cc
+++ b/onnxruntime/core/session/ep_plugin_provider_interfaces.cc
@@ -434,7 +434,7 @@ std::optional<bool> PluginExecutionProvider::ShouldConvertNodeLayout(DataLayout 
 
   const auto data_layout_mapping = std::find_if(kDataLayoutMappings.begin(), kDataLayoutMappings.end(),
                                                 [target_data_layout](const DataLayoutMapping& mapping) {
-                                                  return mapping.data_layout = target_data_layout;
+                                                  return mapping.data_layout == target_data_layout;
                                                 });
 
   ORT_ENFORCE(data_layout_mapping != kDataLayoutMappings.end(),
@@ -446,7 +446,7 @@ std::optional<bool> PluginExecutionProvider::ShouldConvertNodeLayout(DataLayout 
 
   ORT_THROW_IF_ERROR(ToStatusAndRelease(
       ort_ep_->ShouldConvertNodeLayout(ort_ep_.get(), data_layout_mapping->api_data_layout,
-                                       node_op_domain_str.c_str(), node_op_type_str.c_str(),
+                                       node_domain_str.c_str(), node_op_type_str.c_str(),
                                        &should_convert)));
 
   if (should_convert > 0) {

--- a/onnxruntime/core/session/ep_plugin_provider_interfaces.cc
+++ b/onnxruntime/core/session/ep_plugin_provider_interfaces.cc
@@ -412,6 +412,26 @@ DataLayout PluginExecutionProvider::GetPreferredLayout() const {
   }
 }
 
+std::optional<bool> PluginExecutionProvider::ShouldConvertNodeLayoutToNhwc(std::string_view node_domain,
+                                                                           std::string_view node_op_type) const {
+  if (ort_ep_->ShouldConvertNodeLayoutToNhwc == nullptr) {
+    return Base::ShouldConvertNodeLayoutToNhwc(node_domain, node_op_type);
+  }
+
+  int should_convert = -1;
+
+  ORT_THROW_IF_ERROR(ToStatusAndRelease(
+    ort_ep_->ShouldConvertNodeLayoutToNhwc(ort_ep_.get(), node_domain.data(), node_op_type.data(), &should_convert)));
+
+  if (should_convert > 0) {
+    return true;
+  } else if (should_convert == 0) {
+    return false;
+  } else {
+    return std::nullopt;
+  }
+}
+
 Status PluginExecutionProvider::OnRunStart(const RunOptions& run_options) {
   if (ort_ep_->OnRunStart == nullptr) {
     return Base::OnRunStart(run_options);

--- a/onnxruntime/core/session/ep_plugin_provider_interfaces.cc
+++ b/onnxruntime/core/session/ep_plugin_provider_interfaces.cc
@@ -418,10 +418,12 @@ std::optional<bool> PluginExecutionProvider::ShouldConvertNodeLayoutToNhwc(std::
     return Base::ShouldConvertNodeLayoutToNhwc(node_domain, node_op_type);
   }
 
+  // Ensure domain and op type strings are null-terminated.
+  const std::string node_domain_str = node_domain, node_op_type_str = node_op_type;
   int should_convert = -1;
 
   ORT_THROW_IF_ERROR(ToStatusAndRelease(
-    ort_ep_->ShouldConvertNodeLayoutToNhwc(ort_ep_.get(), node_domain.data(), node_op_type.data(), &should_convert)));
+      ort_ep_->ShouldConvertNodeLayoutToNhwc(ort_ep_.get(), node_domain_str, node_op_type_str, &should_convert)));
 
   if (should_convert > 0) {
     return true;

--- a/onnxruntime/core/session/ep_plugin_provider_interfaces.h
+++ b/onnxruntime/core/session/ep_plugin_provider_interfaces.h
@@ -77,8 +77,9 @@ class PluginExecutionProvider : public IExecutionProvider {
 
   DataLayout GetPreferredLayout() const override;
 
-  std::optional<bool> ShouldConvertNodeLayoutToNhwc(std::string_view node_domain,
-                                                    std::string_view node_op_type) const override;
+  std::optional<bool> ShouldConvertNodeLayout(DataLayout target_data_layout,
+                                              std::string_view node_domain,
+                                              std::string_view node_op_type) const override;
 
   Status OnRunStart(const RunOptions& run_options) override;
 

--- a/onnxruntime/core/session/ep_plugin_provider_interfaces.h
+++ b/onnxruntime/core/session/ep_plugin_provider_interfaces.h
@@ -77,6 +77,9 @@ class PluginExecutionProvider : public IExecutionProvider {
 
   DataLayout GetPreferredLayout() const override;
 
+  std::optional<bool> ShouldConvertNodeLayoutToNhwc(std::string_view node_domain,
+                                                    std::string_view node_op_type) const override;
+
   Status OnRunStart(const RunOptions& run_options) override;
 
   Status OnRunEnd(bool sync_stream, const RunOptions& run_options) override;

--- a/onnxruntime/core/session/ep_plugin_provider_interfaces.h
+++ b/onnxruntime/core/session/ep_plugin_provider_interfaces.h
@@ -77,9 +77,9 @@ class PluginExecutionProvider : public IExecutionProvider {
 
   DataLayout GetPreferredLayout() const override;
 
-  std::optional<bool> ShouldConvertNodeLayout(DataLayout target_data_layout,
-                                              std::string_view node_domain,
-                                              std::string_view node_op_type) const override;
+  std::optional<bool> ShouldConvertDataLayoutForOp(std::string_view node_domain,
+                                                   std::string_view node_op_type,
+                                                   DataLayout target_data_layout) const override;
 
   Status OnRunStart(const RunOptions& run_options) override;
 

--- a/onnxruntime/test/framework/ep_plugin_provider_test.cc
+++ b/onnxruntime/test/framework/ep_plugin_provider_test.cc
@@ -122,11 +122,11 @@ TEST(PluginExecutionProviderTest, ShouldConvertNodeLayout) {
 
   {
     auto custom_nhwc_op_determination_fn = [](OrtEp* /*this_ptr*/,
-                                           OrtEpDataLayout target_data_layout,
-                                           const char* /*node_domain*/,
-                                           const char* node_op_type,
-                                           int* should_convert) -> ::OrtStatus* {
-      ASSERT_EQ(target_data_layout, OrtEpDataLayout::OrtEpDataLayout_NHWC);
+                                              OrtEpDataLayout target_data_layout,
+                                              const char* /*node_domain*/,
+                                              const char* node_op_type,
+                                              int* should_convert) -> ::OrtStatus* {
+      EXPECT_EQ(target_data_layout, OrtEpDataLayout::OrtEpDataLayout_NHWC);
 
       if (node_op_type == std::string_view{"Conv"}) {
         *should_convert = 1;


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Add `IExecutionProvider::ShouldConvertDataLayoutForOp()` to allow EPs to customize layout sensitive ops. Move existing hardcoded EP-specific logic out of layout transformer code.

Add `OrtEp::ShouldConvertDataLayoutForOp` to ABI EP API to allow similar customization by plugin EPs.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Enable layout sensitive op customization through internal EP interface and the ABI EP API.