### PR TITLE
Fix default value for Whisper's buffer sharing

### DIFF
--- a/onnxruntime/python/tools/transformers/models/whisper/whisper_helper.py
+++ b/onnxruntime/python/tools/transformers/models/whisper/whisper_helper.py
@@ -596,7 +596,7 @@ class WhisperHelper:
                 "no_repeat_ngram_size": 0,
                 "num_beams": 1,
                 "num_return_sequences": 1,
-                "past_present_share_buffer": True,
+                "past_present_share_buffer": provider == "cuda",  # Required for DMMHA CUDA kernel. Otherwise must be false for beam search to work in ORT GenAI.
                 "repetition_penalty": 1.0,
                 "temperature": 1.0,
                 "top_k": 1,


### PR DESCRIPTION
### Description

This PR updates the default value for `past_present_share_buffer` in the GenAI config for Whisper.

### Motivation and Context

ONNX Runtime GenAI does not currently support buffer sharing during beam search. Whisper is often used for beam search so this should be set to false by default. However, the CUDA model is an exception as the `DecoderMaskedMultiHeadAttention` kernel inside `MultiHeadAttention` requires buffer sharing and manages beam search through its `cache_indirection`.