### PR TITLE
[EP ABI] Update OrtGraph to use new OrtValues stored in internal Graph

### DIFF
--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -817,15 +817,18 @@ class Graph {  // NOLINT(clang-analyzer-optin.performance.Padding): preserve exi
 
   /// <summary>
   /// Returns the initializer's TensorProto if 'name' is an initializer (either constant or overridable).
-  /// If the initializer is not found, a nullptr is returned. An output parameter is set to true if the initializer
-  /// is constant.
+  /// If the initializer is not found, a nullptr is returned. Also returns, via output parameters, the
+  /// OrtValue that holds the actual data (if any) and a boolean that indicates if the initializer is constant.
   /// </summary>
   /// <param name="name">The initializer's name.</param>
-  /// <param name="check_outer_scope">Checks outer scope if set to true and the graph is a subgraph.</param>
+  /// <param name="value">Output OrtValue that is populated if the initializer tensor proto has been configured
+  ///                     to use external data that points to an OrtValue. Is set to an unallocated OrtValue for
+  ///                     a tensor proto that holds the weight data (e.g., small initializers).</param>
   /// <param name="is_constant">Output parameter set to true if the initializer is a constant.</param>
+  /// <param name="check_outer_scope">Checks outer scope if set to true and the graph is a subgraph.</param>
   /// <returns>The initializer's TensorProto or nullptr.</returns>
-  const ONNX_NAMESPACE::TensorProto* GetInitializer(const std::string& name, bool check_outer_scope,
-                                                    bool& is_constant) const;
+  const ONNX_NAMESPACE::TensorProto* GetInitializer(const std::string& name, OrtValue& value,
+                                                    bool& is_constant, bool check_outer_scope = false) const;
 
   /** Gets the Graph inputs excluding initializers.
   These are the required inputs to the Graph as the initializers can be optionally overridden via graph inputs.

--- a/onnxruntime/core/graph/ep_api_types.cc
+++ b/onnxruntime/core/graph/ep_api_types.cc
@@ -544,9 +544,9 @@ Status EpGraph::Create(const GraphViewer& graph_viewer, /*out*/ std::unique_ptr<
 
       EpValueInfo* outer_value_info = value_info_iter->second.get();
       bool is_constant = false;
-      auto initializer_value = std::make_unique<OrtValue>();
+      auto outer_initializer_value = std::make_unique<OrtValue>();
       const ONNX_NAMESPACE::TensorProto* outer_initializer = parent_graph->GetInitializer(implicit_name,
-                                                                                          *initializer_value,
+                                                                                          *outer_initializer_value,
                                                                                           is_constant,
                                                                                           /*check_outer_scope*/ true);
       outer_value_info->SetFlag(EpValueInfo::kIsOuterScope);
@@ -557,14 +557,14 @@ Status EpGraph::Create(const GraphViewer& graph_viewer, /*out*/ std::unique_ptr<
 
       // Add the OrtValue if this is an initializer.
       if (outer_initializer != nullptr) {
-        if (!initializer_value->IsAllocated()) {
+        if (!outer_initializer_value->IsAllocated()) {
           // onnxruntime::Graph does not have an OrtValue for this initializer, so create one from the TensorProto.
           // This should only happen for small initializers that are needed for ONNX shape inferencing.
           ORT_RETURN_IF_ERROR(utils::TensorProtoToOrtValue(Env::Default(), parent_graph->ModelPath(),
                                                            *outer_initializer, initializer_allocator,
-                                                           *initializer_value));
+                                                           *outer_initializer_value));
         }
-        outer_scope_initializer_values.emplace(outer_value_info->GetName(), std::move(initializer_value));
+        outer_scope_initializer_values.emplace(outer_value_info->GetName(), std::move(outer_initializer_value));
       }
     }
   }

--- a/onnxruntime/core/graph/ep_api_types.cc
+++ b/onnxruntime/core/graph/ep_api_types.cc
@@ -485,12 +485,18 @@ Status EpGraph::Create(const GraphViewer& graph_viewer, /*out*/ std::unique_ptr<
 
     initializer_value_infos.push_back(value_info);
 
-    // Temporary: Copy onnx::TensorProto into OrtValue objects owned by this EpGraph.
-    // TODO: Remove this logic once a separate PR that updates onnxruntime::Graph to store initializers as
-    // OrtValue instances is merged.
+    // Initialize OrtValue for the initializer.
     auto initializer_value = std::make_unique<OrtValue>();
-    ORT_RETURN_IF_ERROR(utils::TensorProtoToOrtValue(Env::Default(), graph_viewer.ModelPath(), *tensor_proto,
-                                                     initializer_allocator, *initializer_value));
+    bool graph_has_ortvalue = graph_viewer.GetGraph().GetOrtValueInitializer(initializer_name, *initializer_value,
+                                                                             /*check_outer_scope*/ false);
+
+    if (!graph_has_ortvalue) {
+      // onnxruntime::Graph does not have an OrtValue for this initializer, so create one from the TensorProto.
+      // This should only happen for small initializers that are needed for ONNX shape inferencing.
+      ORT_RETURN_IF_ERROR(utils::TensorProtoToOrtValue(Env::Default(), graph_viewer.ModelPath(), *tensor_proto,
+                                                       initializer_allocator, *initializer_value));
+    }
+
     initializer_values.emplace(value_info->GetName(), std::move(initializer_value));
   }
 
@@ -538,23 +544,26 @@ Status EpGraph::Create(const GraphViewer& graph_viewer, /*out*/ std::unique_ptr<
 
       EpValueInfo* outer_value_info = value_info_iter->second.get();
       bool is_constant = false;
+      auto initializer_value = std::make_unique<OrtValue>();
       const ONNX_NAMESPACE::TensorProto* outer_initializer = parent_graph->GetInitializer(implicit_name,
-                                                                                          /*check_outer_scope*/ true,
-                                                                                          is_constant);
+                                                                                          *initializer_value,
+                                                                                          is_constant,
+                                                                                          /*check_outer_scope*/ true);
       outer_value_info->SetFlag(EpValueInfo::kIsOuterScope);
 
       if (outer_initializer != nullptr) {
         outer_value_info->SetFlag(is_constant ? EpValueInfo::kIsConstantInitializer : EpValueInfo::kIsOptionalGraphInput);
       }
 
-      // Temporary: Copy onnx::TensorProto into OrtValue objects owned by this EpGraph.
-      // TODO: Remove this logic once a separate PR that updates onnxruntime::Graph to store initializers as
-      // OrtValue instances is merged.
+      // Add the OrtValue if this is an initializer.
       if (outer_initializer != nullptr) {
-        auto initializer_value = std::make_unique<OrtValue>();
-        ORT_RETURN_IF_ERROR(utils::TensorProtoToOrtValue(Env::Default(), parent_graph->ModelPath(),
-                                                         *outer_initializer, initializer_allocator,
-                                                         *initializer_value));
+        if (!initializer_value->IsAllocated()) {
+          // onnxruntime::Graph does not have an OrtValue for this initializer, so create one from the TensorProto.
+          // This should only happen for small initializers that are needed for ONNX shape inferencing.
+          ORT_RETURN_IF_ERROR(utils::TensorProtoToOrtValue(Env::Default(), parent_graph->ModelPath(),
+                                                           *outer_initializer, initializer_allocator,
+                                                           *initializer_value));
+        }
         outer_scope_initializer_values.emplace(outer_value_info->GetName(), std::move(initializer_value));
       }
     }

--- a/onnxruntime/core/graph/ep_api_types.cc
+++ b/onnxruntime/core/graph/ep_api_types.cc
@@ -453,12 +453,12 @@ Status EpGraph::Create(const GraphViewer& graph_viewer, /*out*/ std::unique_ptr<
                               graph_output_value_infos,
                               [](EpValueInfo* v) { v->SetFlag(EpValueInfo::Flags::kIsGraphOutput); });
 
-  std::unordered_map<std::string_view, OrtValue> outer_scope_initializer_values;
+  std::unordered_map<std::string_view, std::unique_ptr<OrtValue>> outer_scope_initializer_values;
 
   // Create OrtValueInfo and OrtValue instances for each initializer.
   const InitializedTensorSet initializers = graph_viewer.GetAllInitializedTensors();
   std::vector<EpValueInfo*> initializer_value_infos;
-  std::unordered_map<std::string_view, OrtValue> initializer_values;
+  std::unordered_map<std::string_view, std::unique_ptr<OrtValue>> initializer_values;
 
   initializer_value_infos.reserve(initializers.size());
   initializer_values.reserve(initializers.size());
@@ -486,15 +486,15 @@ Status EpGraph::Create(const GraphViewer& graph_viewer, /*out*/ std::unique_ptr<
     initializer_value_infos.push_back(value_info);
 
     // Initialize OrtValue for the initializer.
-    OrtValue initializer_value;
-    bool graph_has_ortvalue = graph_viewer.GetGraph().GetOrtValueInitializer(initializer_name, initializer_value,
+    auto initializer_value = std::make_unique<OrtValue>();
+    bool graph_has_ortvalue = graph_viewer.GetGraph().GetOrtValueInitializer(initializer_name, *initializer_value,
                                                                              /*check_outer_scope*/ false);
 
     if (!graph_has_ortvalue) {
       // onnxruntime::Graph does not have an OrtValue for this initializer, so create one from the TensorProto.
       // This should only happen for small initializers that are needed for ONNX shape inferencing.
       ORT_RETURN_IF_ERROR(utils::TensorProtoToOrtValue(Env::Default(), graph_viewer.ModelPath(), *tensor_proto,
-                                                       initializer_allocator, initializer_value));
+                                                       initializer_allocator, *initializer_value));
     }
 
     initializer_values.emplace(value_info->GetName(), std::move(initializer_value));
@@ -544,9 +544,9 @@ Status EpGraph::Create(const GraphViewer& graph_viewer, /*out*/ std::unique_ptr<
 
       EpValueInfo* outer_value_info = value_info_iter->second.get();
       bool is_constant = false;
-      OrtValue outer_initializer_value;
+      auto outer_initializer_value = std::make_unique<OrtValue>();
       const ONNX_NAMESPACE::TensorProto* outer_initializer = parent_graph->GetInitializer(implicit_name,
-                                                                                          outer_initializer_value,
+                                                                                          *outer_initializer_value,
                                                                                           is_constant,
                                                                                           /*check_outer_scope*/ true);
       outer_value_info->SetFlag(EpValueInfo::kIsOuterScope);
@@ -557,12 +557,12 @@ Status EpGraph::Create(const GraphViewer& graph_viewer, /*out*/ std::unique_ptr<
 
       // Add the OrtValue if this is an initializer.
       if (outer_initializer != nullptr) {
-        if (!outer_initializer_value.IsAllocated()) {
+        if (!outer_initializer_value->IsAllocated()) {
           // onnxruntime::Graph does not have an OrtValue for this initializer, so create one from the TensorProto.
           // This should only happen for small initializers that are needed for ONNX shape inferencing.
           ORT_RETURN_IF_ERROR(utils::TensorProtoToOrtValue(Env::Default(), parent_graph->ModelPath(),
                                                            *outer_initializer, initializer_allocator,
-                                                           outer_initializer_value));
+                                                           *outer_initializer_value));
         }
         outer_scope_initializer_values.emplace(outer_value_info->GetName(), std::move(outer_initializer_value));
       }
@@ -648,14 +648,14 @@ const OrtValue* EpGraph::GetInitializerValue(std::string_view name) const {
   // Check for initializer value in the graph's scope.
   if (auto iter = initializer_values_.find(name);
       iter != initializer_values_.end()) {
-    return &iter->second;
+    return iter->second.get();
   }
 
   // Check for the initializer value in an outer scope.
   // Only finds a value if the outer initializer value is used within this graph.
   if (auto iter = outer_scope_initializer_values_.find(name);
       iter != outer_scope_initializer_values_.end()) {
-    return &iter->second;
+    return iter->second.get();
   }
 
   return nullptr;

--- a/onnxruntime/core/graph/ep_api_types.h
+++ b/onnxruntime/core/graph/ep_api_types.h
@@ -296,8 +296,11 @@ struct EpGraph : public OrtGraph {
   std::unordered_map<std::string, std::unique_ptr<EpValueInfo>> value_infos_;  // All value infos in the graph
 
   std::vector<EpValueInfo*> initializer_value_infos_;
-  std::unordered_map<std::string_view, std::unique_ptr<OrtValue>> initializer_values_;
-  std::unordered_map<std::string_view, std::unique_ptr<OrtValue>> outer_scope_initializer_values_;
+
+  // Note: we return pointers to these OrtValue elements, which could be invalidated if the
+  // map is reallocated. This is not an issue now because OrtGraph is essentially readonly.
+  std::unordered_map<std::string_view, OrtValue> initializer_values_;
+  std::unordered_map<std::string_view, OrtValue> outer_scope_initializer_values_;
 
   InlinedVector<EpValueInfo*> inputs_;
   InlinedVector<EpValueInfo*> outputs_;

--- a/onnxruntime/core/graph/ep_api_types.h
+++ b/onnxruntime/core/graph/ep_api_types.h
@@ -297,8 +297,9 @@ struct EpGraph : public OrtGraph {
 
   std::vector<EpValueInfo*> initializer_value_infos_;
 
-  // Note: we return pointers to these OrtValue elements, which could be invalidated if the
-  // map is reallocated. This is not an issue now because OrtGraph is essentially readonly.
+  // Note: We return pointers to these OrtValue elements to users of the C API. These pointers would be invalidated
+  // if the maps were reallocated. However, this is not an issue now because OrtGraph is essentially readonly after
+  // initialization.
   std::unordered_map<std::string_view, OrtValue> initializer_values_;
   std::unordered_map<std::string_view, OrtValue> outer_scope_initializer_values_;
 

--- a/onnxruntime/core/graph/ep_api_types.h
+++ b/onnxruntime/core/graph/ep_api_types.h
@@ -296,12 +296,8 @@ struct EpGraph : public OrtGraph {
   std::unordered_map<std::string, std::unique_ptr<EpValueInfo>> value_infos_;  // All value infos in the graph
 
   std::vector<EpValueInfo*> initializer_value_infos_;
-
-  // Note: We return pointers to these OrtValue elements to users of the C API. These pointers would be invalidated
-  // if the maps were reallocated. However, this is not an issue now because OrtGraph is essentially readonly after
-  // initialization.
-  std::unordered_map<std::string_view, OrtValue> initializer_values_;
-  std::unordered_map<std::string_view, OrtValue> outer_scope_initializer_values_;
+  std::unordered_map<std::string_view, std::unique_ptr<OrtValue>> initializer_values_;
+  std::unordered_map<std::string_view, std::unique_ptr<OrtValue>> outer_scope_initializer_values_;
 
   InlinedVector<EpValueInfo*> inputs_;
   InlinedVector<EpValueInfo*> outputs_;

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -3831,8 +3831,8 @@ const ONNX_NAMESPACE::TensorProto* Graph::GetInitializer(const std::string& init
   return initializer;
 }
 
-const ONNX_NAMESPACE::TensorProto* Graph::GetInitializer(const std::string& initializer_name, bool check_outer_scope,
-                                                         bool& is_constant) const {
+const ONNX_NAMESPACE::TensorProto* Graph::GetInitializer(const std::string& initializer_name, OrtValue& value,
+                                                         bool& is_constant, bool check_outer_scope) const {
   const ONNX_NAMESPACE::TensorProto* initializer = nullptr;
   if (GetInitializedTensor(initializer_name, initializer)) {
     if (CanOverrideInitializer()) {
@@ -3844,10 +3844,13 @@ const ONNX_NAMESPACE::TensorProto* Graph::GetInitializer(const std::string& init
     } else {
       is_constant = true;
     }
+
+    auto it = ortvalue_initializers_.find(initializer_name);
+    value = (it != ortvalue_initializers_.end()) ? it->second : OrtValue();
   } else if (check_outer_scope && IsSubgraph()) {
     // make sure there's not a local value with the same name. if there is it shadows any initializer in outer scope.
     if (IsOuterScopeValue(initializer_name)) {
-      initializer = parent_graph_->GetInitializer(initializer_name, check_outer_scope, is_constant);
+      initializer = parent_graph_->GetInitializer(initializer_name, value, is_constant, check_outer_scope);
     }
   }
 

--- a/onnxruntime/test/ep_graph/test_ep_graph.cc
+++ b/onnxruntime/test/ep_graph/test_ep_graph.cc
@@ -287,8 +287,11 @@ static void CheckValueInfosCApi(const GraphViewer& graph_viewer, gsl::span<const
                                            return node_arg->Name() == graph_output->Name();
                                          });
       bool is_const_initializer = false;
-      const ONNX_NAMESPACE::TensorProto* initializer = graph_viewer.GetGraph().GetInitializer(value_name, true,
-                                                                                              is_const_initializer);
+      OrtValue initializer_value;
+      const ONNX_NAMESPACE::TensorProto* initializer = graph_viewer.GetGraph().GetInitializer(value_name,
+                                                                                              initializer_value,
+                                                                                              is_const_initializer,
+                                                                                              /*check_outer_scope*/ true);
       bool can_override_initializer = graph_viewer.CanOverrideInitializer();
 
       bool api_is_req_graph_input = false;


### PR DESCRIPTION
### Description
Updates the `OrtGraph` implementation to take advantage of the work done in PR https://github.com/microsoft/onnxruntime/pull/23979, which sets the infrastructure to store initializers as `OrtValue` instances in the `onnxruntime::Graph`.

There still needs to be second part to the [aforementioned PR](https://github.com/microsoft/onnxruntime/pull/23979) to ensure that all initializers are stored as `OrtValue`s in the Graph.



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


