### PR TITLE
[build] do not disable 4244/4267 warning when building Tint

### DIFF
--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -738,7 +738,13 @@ if (onnxruntime_USE_WEBGPU)
           #   Dawn disabled f16 support for NVIDIA Vulkan by default because of crashes in f16 CTS tests (crbug.com/tint/2164).
           #   Since the crashes are limited to specific GPU models, we patched Dawn to remove the restriction.
           #
-          ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/dawn/dawn_force_enable_f16_nvidia_vulkan.patch)
+          ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/dawn/dawn_force_enable_f16_nvidia_vulkan.patch &&
+
+          # The dawn_binskim.patch contains the following changes:
+          #
+          # - (private) Fulfill the BinSkim requirements
+          #   Some build warnings are not allowed to be disabled in project level.
+          ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/dawn/dawn_binskim.patch)
 
       onnxruntime_fetchcontent_declare(
         dawn

--- a/cmake/patches/dawn/dawn_binskim.patch
+++ b/cmake/patches/dawn/dawn_binskim.patch
@@ -1,0 +1,13 @@
+diff --git a/src/tint/CMakeLists.txt b/src/tint/CMakeLists.txt
+index 0d5f52a358..90764d21b5 100644
+--- a/src/tint/CMakeLists.txt
++++ b/src/tint/CMakeLists.txt
+@@ -143,8 +143,6 @@ function(tint_default_compile_options TARGET)
+       /W4
+       /wd4068 # unknown pragma
+       /wd4127 # conditional expression is constant
+-      /wd4244 # 'conversion' conversion from 'type1' to 'type2', possible loss of data
+-      /wd4267 # 'var' : conversion from 'size_t' to 'type', possible loss of data
+       /wd4324 # 'struct_name' : structure was padded due to __declspec(align())
+       /wd4459 # declaration of 'identifier' hides global declaration
+       /wd4458 # declaration of 'identifier' hides class member


### PR DESCRIPTION
### Description

Per Windows team's CyberEO requirement, do not disable the warnings in project level.

