### PR TITLE
GatherBlockQuantized supports zero points and 8 bits for uint8 dtype

### DIFF
--- a/docs/ContribOperators.md
+++ b/docs/ContribOperators.md
@@ -2053,6 +2053,8 @@ This version of the operator has been available since version 1 of the 'com.micr
 #### Attributes
 
 <dl>
+<dt><tt>bits</tt> : int</dt>
+<dd>Number of bits used for weight quantization. Must be either 4 or 8. </dd>
 <dt><tt>block_size</tt> : int</dt>
 <dd>(Optional) block size used for weight quantization. It needs to be a power of 2 and not smaller than 16.</dd>
 <dt><tt>gather_axis</tt> : int</dt>

--- a/js/web/test/data/ops/gather-block-quantized.jsonc
+++ b/js/web/test/data/ops/gather-block-quantized.jsonc
@@ -21,6 +21,11 @@
         "name": "quantize_axis",
         "data": 2,
         "type": "int"
+      },
+      {
+        "name": "bits",
+        "data": 4,
+        "type": "int"
       }
     ],
     "cases": [

--- a/onnxruntime/contrib_ops/cpu/quantization/gather_block_quantized.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/gather_block_quantized.cc
@@ -18,17 +18,18 @@ namespace contrib {
 
 namespace {
 template <typename T1>
-int32_t GetDataElement(const T1* data_ptr, int64_t data_idx) {
+int32_t Get4BitElement(const T1* data_ptr, int64_t data_idx) {
   return static_cast<int32_t>(data_ptr[data_idx >> 1].GetElem(narrow<size_t>(data_idx & 1)));
 }
 
 template <>
-int32_t GetDataElement<uint8_t>(const uint8_t* data_ptr, int64_t data_idx) {
+int32_t Get4BitElement<uint8_t>(const uint8_t* data_ptr, int64_t data_idx) {
   const uint8_t data_val_u8 = data_ptr[data_idx >> 1];
   // Weights are stored as (nibble2)(nibble1) in uint8_t.
   auto data_val = static_cast<int32_t>((data_idx & 1) ? ((data_val_u8 >> 4) & 0x0F) : (data_val_u8 & 0x0F));
   return data_val;
 }
+
 }  // namespace
 
 template <typename T1, typename Tind>
@@ -46,6 +47,13 @@ class GatherBlockQuantized : public OpKernel {
     if (!info.GetAttr<int64_t>("block_size", &block_size_).IsOK()) {
       block_size_ = 128;
     }
+
+    ORT_ENFORCE(block_size_ >= 16 && ((block_size_ - 1) & block_size_) == 0,
+                "'block_size' must be a power of 2 and not less than 16.");
+
+    constexpr int64_t default_bits = 4;
+    info.GetAttrOrDefault("bits", &bits_, default_bits);
+    ORT_ENFORCE(bits_ == 4 || bits_ == 8, "GatherBlockQuantized only support bits==4 or 8");
 
     ORT_ENFORCE(block_size_ >= 16 && ((block_size_ - 1) & block_size_) == 0,
                 "'block_size' must be 2's power and not less than 16.");
@@ -84,6 +92,7 @@ class GatherBlockQuantized : public OpKernel {
   int64_t gather_axis_;
   int64_t quantize_axis_;
   int64_t block_size_;
+  int64_t bits_;
 };
 
 template <typename T1, typename Tind>
@@ -94,13 +103,21 @@ Status GatherBlockQuantized<T1, Tind>::PrepareForCompute(OpKernelContext* contex
   p.zero_points_tensor = context->Input<Tensor>(3);
 
   const auto& data_shape = p.data_tensor->Shape();
-  const auto& indices_shape = p.indices_tensor->Shape();
   const auto data_rank = data_shape.NumDimensions();
   p.gather_axis = HandleNegativeAxis(gather_axis_, narrow<int64_t>(data_rank));
+
   p.quantize_axis = HandleNegativeAxis(quantize_axis_, narrow<int64_t>(data_rank));
+  if constexpr (std::is_same_v<T1, uint8_t>) {
+    ORT_RETURN_IF_NOT(p.gather_axis == 0, "For uint8_t data, gather_axis must be 0.");
+    ORT_RETURN_IF_NOT(p.quantize_axis == static_cast<int64_t>(data_rank) - 1, "For uint8_t data, quantize_axis must be the last dimension.");
+    ORT_RETURN_IF_NOT(p.gather_axis != p.quantize_axis, "gather_axis and quantize_axis must not be the same.");
+  }
+
+  const auto& indices_shape = p.indices_tensor->Shape();
+  const auto indices_rank = indices_shape.NumDimensions();
 
   std::vector<int64_t> shape;
-  shape.reserve(data_rank - 1 + indices_shape.NumDimensions());
+  shape.reserve(data_rank - 1 + indices_rank);
 
   // get output tensor
   // replace the dimension for p.gather_axis with the shape from the indices
@@ -113,12 +130,21 @@ Status GatherBlockQuantized<T1, Tind>::PrepareForCompute(OpKernelContext* contex
   for (int64_t i = p.gather_axis + 1; i < static_cast<int64_t>(data_rank); ++i)
     shape.push_back(data_shape[narrow<size_t>(i)]);
 
-  // When data is stored as uint8_t, each element has two int4 values.
+  // When bits==4 and data is stored as uint8_t, each element has two int4 values.
   // The shape in the onnx model reflects that by having the last dimension be half the number of values.
-  // Ex: For a true data size of 2000x3072, the onnx model would have data of shape 2000x1536.
+  // Example: For a true data size of 2000x3072, the packed uint8 tensor has shape 2000x1536.
   // However the outputs still need to be of size 2000x3072. Therefore we x2 the last dimension here.
-  uint32_t components = (std::is_same_v<T1, uint8_t>) ? 2 : 1;
-  shape[shape.size() - 1] = shape.back() * components;
+  uint32_t components = 1;
+  if constexpr (std::is_same_v<T1, uint8_t>) {
+    components = 8 / static_cast<int>(bits_);
+    if (components > 1) {
+      // To handle quantize_axis that is not the last dimension:
+      //  shape[(p.quantize_axis < p.gather_axis) ? p.quantize_axis : p.quantize_axis + indices_rank - 1] *= components;
+      // Since we constraint the last dimension to be the quantize_axis, we can simplify it to:
+      shape.back() *= components;
+    }
+  }
+
   p.output_tensor = context->Output(0, TensorShape(std::move(shape)));
 
   // validate quantization parameters
@@ -137,8 +163,14 @@ Status GatherBlockQuantized<T1, Tind>::PrepareForCompute(OpKernelContext* contex
     ORT_RETURN_IF_NOT(scales_shape.NumDimensions() == zero_points_shape.NumDimensions(),
                       "scales and zero_points must have the same rank.");
     for (size_t i = 0; i < scales_shape.NumDimensions(); ++i) {
-      ORT_RETURN_IF_NOT(scales_shape[i] == zero_points_shape[i],
-                        "scales and zero_points must have the same shape.");
+      if (components > 1 && i == static_cast<size_t>(p.quantize_axis)) {
+        // For uint8_t with bits=4, zero points is stored as 2 components per byte.
+        ORT_RETURN_IF_NOT((scales_shape[i] + components - 1) / components == zero_points_shape[i],
+                          "scales and zero_points shape does not match.");
+      } else {
+        ORT_RETURN_IF_NOT(scales_shape[i] == zero_points_shape[i],
+                          "scales and zero_points must have the same shape.");
+      }
     }
   }
 
@@ -186,7 +218,16 @@ Status GatherBlockQuantized<T1, Tind>::CopyDataAndDequantize(const T1* data_ptr,
     int64_t output_idx = output_idx_base;
     int64_t data_idx = data_idx_base;
     for (int64_t i = 0; i < gather_block; ++i, ++output_idx, ++data_idx) {
-      auto data_val = GetDataElement(data_ptr, data_idx);
+      int32_t data_val;
+      if constexpr (!std::is_same_v<T1, uint8_t>) {
+        data_val = Get4BitElement(data_ptr, data_idx);
+      } else {  // unit8_t
+        if (bits_ == 4) {
+          data_val = Get4BitElement(data_ptr, data_idx);
+        } else {  // buts_ == 8
+          data_val = static_cast<int32_t>(data_ptr[data_idx]);
+        }
+      }
 
       int64_t x = data_idx / quantize_full_block;
       int64_t y = data_idx % quantize_full_block / quantize_N;
@@ -194,13 +235,27 @@ Status GatherBlockQuantized<T1, Tind>::CopyDataAndDequantize(const T1* data_ptr,
       int64_t scale_idx = x * scale_full_block + y / block_size_ * quantize_N + z;
       auto scale_val = static_cast<float>(scales_ptr[scale_idx]);
       int32_t zp_val;
+
       if constexpr (std::is_same_v<T1, uint8_t>) {
-        // The default zero point for uint8 weights as stored by MatMulNBits op is 8.
-        zp_val = 8;
+        if (zero_points_ptr) {
+          if (bits_ == 4) {
+            uint8_t packed = zero_points_ptr[scale_idx >> 1];
+            if (scale_idx & 1) {
+              zp_val = static_cast<int32_t>((packed >> 4) & 0x0F);
+            } else {
+              zp_val = static_cast<int32_t>(packed & 0x0F);
+            }
+          } else {  // bits_ == 8
+            zp_val = static_cast<int32_t>(zero_points_ptr[scale_idx]);
+          }
+        } else {
+          const int32_t default_zero_point = bits_ == 4 ? 8 : 128;
+          zp_val = default_zero_point;
+        }
       } else {
-        zp_val = static_cast<int32_t>(zero_points_ptr
-                                          ? zero_points_ptr[scale_idx >> 1].GetElem(narrow<size_t>(scale_idx & 1))
-                                          : 0);
+        zp_val = zero_points_ptr
+                     ? static_cast<int32_t>(zero_points_ptr[scale_idx >> 1].GetElem(narrow<size_t>(scale_idx & 1)))
+                     : 0;
       }
 
       output_ptr[output_idx] = static_cast<T2>(static_cast<float>(data_val - zp_val) * scale_val);
@@ -232,7 +287,7 @@ template <typename T1, typename Tind>
 Status GatherBlockQuantized<T1, Tind>::Compute(OpKernelContext* context) const {
   Prepare p;
   ORT_RETURN_IF_ERROR(PrepareForCompute(context, p));
-  auto components = (std::is_same_v<T1, uint8_t>) ? 2 : 1;
+  int64_t components = std::is_same_v<T1, uint8_t> ? (8 / static_cast<int>(bits_)) : 1;
   const auto& data_shape = p.data_tensor->Shape();
   // re-shape the data tensor to [gather_M, gather_axis_dim, gather_block]
   // re-shape the indices tensor to [gather_N]

--- a/onnxruntime/contrib_ops/js/quantization/gather_block_quantized.h
+++ b/onnxruntime/contrib_ops/js/quantization/gather_block_quantized.h
@@ -28,8 +28,14 @@ class GatherBlockQuantized : public JsKernel {
       block_size = 128;
     }
 
+    int64_t bits;
+    constexpr int64_t default_bits = 4;
+    info.GetAttrOrDefault("bits", &bits, default_bits);
+    ORT_ENFORCE(bits == 4, "GatherBlockQuantized JS kernel only support bits==4");
+
     ORT_ENFORCE(block_size >= 16 && ((block_size - 1) & block_size) == 0,
                 "'block_size' must be 2's power and not less than 16.");
+
     JSEP_INIT_KERNEL_ATTRIBUTE(GatherBlockQuantized, ({
                                  "gatherAxis" : $1,
                                  "quantizeAxis" : $2,

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -3599,6 +3599,10 @@ GatherBlockQuantized is a Gather with data quantized. It is similar to Gather (h
             "(Optional) block size used for weight quantization. It needs to be a power of 2 and not smaller than 16.",
             AttributeProto::INT,
             static_cast<int64_t>(128))
+      .Attr("bits",
+            "Number of bits used for weight quantization. Must be either 4 or 8. ",
+            AttributeProto::INT,
+            static_cast<int64_t>(4))
       .Input(0, "data", "Tensor of rank r >= 1. Block-wise quantized.", "T1")
       .Input(1,
              "indices",
@@ -3614,22 +3618,25 @@ GatherBlockQuantized is a Gather with data quantized. It is similar to Gather (h
       .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
         // Type inference
         propagateElemTypeFromInputToOutput(ctx, 2, 0);
-        // Shape inference
+
+        // The first 3 inputs must have shape.
         if (!hasNInputShapes(ctx, 3)) {
           return;
         }
         const TensorShapeProto& data_shape = ctx.getInputType(0)->tensor_type().shape();
         const TensorShapeProto& indices_shape = ctx.getInputType(1)->tensor_type().shape();
         const TensorShapeProto& scales_shape = ctx.getInputType(2)->tensor_type().shape();
-        int r = data_shape.dim_size();
 
-        if (r < 1) {
-          fail_shape_inference("data tensor must have rank >= 1");
+        int r = data_shape.dim_size();
+        if (r <= 1) {
+          fail_shape_inference("data tensor must have rank > 1");
         }
 
         int gather_axis = static_cast<int>(getAttribute(ctx, "gather_axis", 0));
         int quantize_axis = static_cast<int>(getAttribute(ctx, "quantize_axis", 1));
+        int bits = static_cast<int>(getAttribute(ctx, "bits", 4));
         auto block_size = getAttribute(ctx, "block_size", 128);
+
         if (gather_axis < -r || gather_axis >= r) {
           fail_shape_inference("gather_axis must be in [-r, r-1]");
         }
@@ -3643,15 +3650,19 @@ GatherBlockQuantized is a Gather with data quantized. It is similar to Gather (h
         gather_axis = (gather_axis + r) % r;
         quantize_axis = (quantize_axis + r) % r;
 
-        if ((ctx.getInputType(0)->tensor_type().elem_type() == onnx::TensorProto_DataType_UINT8) && gather_axis != 0) {
-          fail_shape_inference("gather_axis must be 0, for uint8 data");
+        if (ctx.getInputType(0)->tensor_type().elem_type() == onnx::TensorProto_DataType_UINT8) {
+          if (gather_axis != 0) {
+            fail_shape_inference("gather_axis must be 0, for uint8 data");
+          }
+          // CPU implementation requires quantize_axis to be the last dimension right now.
+          // we are relaxing it in the spec and shape inference since other EP might not have such restriction.
         }
 
         if (scales_shape.dim_size() != r) {
           fail_shape_inference("scales must have the same rank as data");
         }
 
-        uint32_t components = ctx.getInputType(0)->tensor_type().elem_type() == onnx::TensorProto_DataType_UINT8 ? 2 : 1;
+        uint32_t components = (ctx.getInputType(0)->tensor_type().elem_type() == onnx::TensorProto_DataType_UINT8) ? (8 / bits) : 1;
         for (int i = 0; i < r; ++i) {
           if (!data_shape.dim(i).has_dim_value() ||
               !scales_shape.dim(i).has_dim_value() ||
@@ -3663,10 +3674,6 @@ GatherBlockQuantized is a Gather with data quantized. It is similar to Gather (h
 
         // validate zero point shape
         if (ctx.hasInput(3)) {
-          if (ctx.getInputType(0)->tensor_type().elem_type() == onnx::TensorProto_DataType_UINT8) {
-            fail_type_inference("zero_points are not supported for uint8_t data type");
-          }
-
           if (!hasInputShape(ctx, 3)) {
             fail_shape_inference("zero_points shape must be known");
           }
@@ -3679,6 +3686,12 @@ GatherBlockQuantized is a Gather with data quantized. It is similar to Gather (h
           for (int i = 0; i < r; ++i) {
             if (!zp_shape.dim(i).has_dim_value() ||
                 zp_shape.dim(i).dim_value() != scales_shape.dim(i).dim_value()) {
+              if (ctx.getInputType(0)->tensor_type().elem_type() == onnx::TensorProto_DataType_UINT8 &&
+                  bits == 4 &&
+                  i == quantize_axis &&
+                  zp_shape.dim(i).dim_value() == (scales_shape.dim(i).dim_value() + 1) / 2) {
+                continue;
+              }
               fail_shape_inference("zero points shape and scales shape do not match");
             }
           }
@@ -3686,19 +3699,27 @@ GatherBlockQuantized is a Gather with data quantized. It is similar to Gather (h
 
         int q = indices_shape.dim_size();
         int out_rank = q + r - 1;
-        if (out_rank == 0) {
-          ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
+        auto* output_shape = ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
+        output_shape->clear_dim();
+        for (int i = 0; i < gather_axis; ++i) {
+          *output_shape->add_dim() = data_shape.dim(i);
         }
-        for (int i = 0; i < out_rank; ++i) {
-          // For uint8_t data type the last dimension needs to be expanded back to actual dimension,
-          // because the data 2 int4s are stored packed in a single uint8_t.
-          auto last_dimension_components = (i == out_rank - 1) ? components : 1;
-          *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim() =
-              (i < gather_axis)
-                  ? data_shape.dim(i)
-              : (i >= gather_axis && i < gather_axis + q)
-                  ? indices_shape.dim(i - gather_axis)
-                  : data_shape.dim(i - q + 1) * last_dimension_components;
+        for (int i = 0; i < q; ++i) {
+          *output_shape->add_dim() = indices_shape.dim(i);
+        }
+        for (int i = gather_axis + 1; i < r; ++i) {
+          *output_shape->add_dim() = data_shape.dim(i);
+        }
+
+        // Find the correct dimension to expand and multiply it by components
+        if (components > 1) {
+          int quantize_output_dim_idx = (quantize_axis < gather_axis) ? quantize_axis : quantize_axis + q - 1;
+          if (quantize_output_dim_idx < out_rank) {
+            auto* dim_to_update = output_shape->mutable_dim(quantize_output_dim_idx);
+            if (dim_to_update->has_dim_value()) {
+              dim_to_update->set_dim_value(dim_to_update->dim_value() * components);
+            }
+          }
         }
       });
 

--- a/onnxruntime/test/contrib_ops/gather_block_quantized_op_test.cc
+++ b/onnxruntime/test/contrib_ops/gather_block_quantized_op_test.cc
@@ -1,10 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <cstdint>
 #include <vector>
 #include <type_traits>
 #include <memory>
 #include <utility>
+#include <sstream>
 
 #include "core/common/common.h"
 #include "core/framework/execution_provider.h"
@@ -20,20 +22,67 @@ namespace test {
 // compensates for that by adding 8 to the data values, so that the outputs match the results that
 // we be seen with non uint8_t data types.
 template <typename T1>
-void PackDataForUint8TypeIfNecessary(std::vector<int>& data, std::vector<int64_t>& data_shape) {
+void PackDataForUint8TypeIfNecessary(std::vector<int>& data, std::vector<int64_t>& data_shape, int bits = 4) {
   if (!std::is_same_v<T1, uint8_t>) {
     return;
   }
-  // For uint8_t, we need to pack each pair of values (after adding 8) into a single uint8_t
-  std::vector<int> packed_data;
-  for (size_t i = 0; i < data.size(); i += 2) {
-    int low_nibble = (data[i] + 8) & 0xF;
-    int high_nibble = ((i + 1) < data.size()) ? ((data[i + 1] + 8) & 0xF) : 0;
-    int packed = (high_nibble << 4) | low_nibble;
-    packed_data.push_back(packed);
+
+  if (bits == 8) {
+    return;  // No packing needed for 8 bits
   }
+  ORT_ENFORCE(bits == 4);
+
+  int64_t total_elements = 1;
+  for (const auto& dim : data_shape) {
+    total_elements *= dim;
+  }
+  int64_t input_columns = data_shape.back();
+  int64_t total_rows = total_elements / input_columns;
+
+  // For uint8_t, we need to pack each pair of 4 bits (after adding 8) into a single uint8_t
+  std::vector<int> packed_data;
+  int64_t output_columns = (input_columns + 1) / 2;
+  packed_data.reserve(total_rows * output_columns);
+  for (int64_t row = 0; row < total_rows; ++row) {
+    for (int64_t col = 0; col < input_columns; col += 2) {
+      int low_nibble = (data[row * input_columns + col] + 8) & 0xF;
+      int high_nibble = ((col + 1) < input_columns) ? ((data[row * input_columns + col + 1] + 8) & 0xF) : 0;
+      int packed = (high_nibble << 4) | low_nibble;
+      packed_data.push_back(packed);
+    }
+  }
+
   data = packed_data;
-  data_shape[data_shape.size() - 1] = (data_shape[data_shape.size() - 1] + 1) / 2;
+  data_shape.back() = output_columns;
+}
+
+template <typename T>
+std::string VectorToString(const std::vector<T>& vec) {
+  std::ostringstream oss;
+  for (size_t i = 0; i < vec.size(); ++i) {
+    oss << vec[i];
+    if (i != vec.size() - 1) {
+      oss << ",";
+    }
+  }
+  return oss.str();
+}
+
+template <typename T>
+void CheckDataAndShape(const std::vector<T>& data, const std::vector<int64_t>& shape, std::string name = "") {
+  int64_t total_elements = 1;
+  for (const auto& dim : shape) {
+    total_elements *= dim;
+  }
+
+  // UInt4x2 and Int4x2 uses global packing instead of per-row packing.
+  if constexpr (std::is_same<T, UInt4x2>::value || std::is_same<T, Int4x2>::value) {
+    total_elements = (total_elements + 1) / 2;
+  }
+
+  ORT_ENFORCE(static_cast<int64_t>(data.size()) == total_elements, "Data size does not match the shape",
+              "Data size: ", data.size(), ", Expected size: ", total_elements,
+              ", Shape: ", VectorToString(shape), " Name:", name, " Type:", typeid(T).name());
 }
 
 // Combinations: types, gather_axis, quantize_axis, block_size, indices, scale shape vs data shape
@@ -45,24 +94,35 @@ void RunGatherBlockQuantized(const std::vector<T1>& data,
                              const std::vector<T2>& scales,
                              const std::vector<int64_t>& scales_shape,
                              const std::vector<T1>& zero_points,
+                             const std::vector<int64_t>& zero_points_shape,
                              const int64_t gather_axis,
                              const int64_t quantize_axis,
                              const int64_t block_size,
+                             const int64_t bits,
                              const std::vector<T2>& output,
                              const std::vector<int64_t>& output_shape,
                              OpTester::ExpectResult expect_result = OpTester::ExpectResult::kExpectSuccess) {
+  CheckDataAndShape<T1>(data, data_shape, "data in RunGatherBlockQuantized");
+  CheckDataAndShape<Tind>(indices, indices_shape, "indices in RunGatherBlockQuantized");
+  CheckDataAndShape<T2>(scales, scales_shape, "scales in RunGatherBlockQuantized");
+  if (!zero_points_shape.empty()) {
+    CheckDataAndShape<T1>(zero_points, zero_points_shape, "zero_points in RunGatherBlockQuantized");
+  }
+  CheckDataAndShape<T2>(output, output_shape, "output in RunGatherBlockQuantized");
+
   auto run_test = [&](bool indices_is_initializer) {
     OpTester test("GatherBlockQuantized", 1, kMSDomain);
 
     test.AddAttribute<int64_t>("gather_axis", gather_axis);
     test.AddAttribute<int64_t>("quantize_axis", quantize_axis);
     test.AddAttribute<int64_t>("block_size", block_size);
+    test.AddAttribute<int64_t>("bits", bits);
 
     test.AddInput<T1>("data", data_shape, data);
     test.AddInput<Tind>("indices", indices_shape, indices, indices_is_initializer);
     test.AddInput<T2>("scales", scales_shape, scales);
     if (!zero_points.empty()) {
-      test.AddInput<T1>("zero_points", scales_shape, zero_points);
+      test.AddInput<T1>("zero_points", zero_points_shape, zero_points);
     }
 
     test.AddOutput<T2>("output", output_shape, output);
@@ -93,23 +153,97 @@ ToType(const std::vector<T2>& vec) {
 template <typename T>
 typename std::enable_if<boost::mp11::mp_contains<TypeList<UInt4x2, Int4x2>, T>::value, std::vector<T>>::type
 ToType(const std::vector<int>& vec) {
-  std::vector<T> result;
+  // UInt4x2 and Int4x2 uses global packing instead of per-row packing.
   size_t i = 0;
   constexpr int offset = std::is_same<T, Int4x2>::value ? 0 : 8;
+  std::vector<T> result;
   for (i = 0; i + 1 < vec.size(); i += 2) {
     result.push_back(T(vec[i] + offset, vec[i + 1] + offset));
   }
   if (i < vec.size()) {
     result.push_back(T(vec[i] + offset, 0 + offset));
   }
-
   return result;
+}
+
+// The data and zero_points are not packed
+template <typename T1, typename T2, typename Tind>
+void RunUnpackedData(
+    const std::vector<int>& unpacked_data,
+    const std::vector<int64_t>& unpacked_data_shape,
+    const std::vector<int>& indices,
+    const std::vector<int64_t>& indices_shape,
+    const std::vector<float>& scales,
+    const std::vector<int64_t>& scales_shape,
+    std::vector<int>& zero_points,
+    const int64_t gather_axis,
+    const int64_t quantize_axis,
+    const int64_t block_size,
+    const int64_t bits,
+    const std::vector<float>& output,
+    const std::vector<int64_t>& output_shape,
+    bool expect_success) {
+  CheckDataAndShape<int>(unpacked_data, unpacked_data_shape, "unpacked_data");
+  CheckDataAndShape<int>(indices, indices_shape, "indices");
+  CheckDataAndShape<float>(scales, scales_shape, "scales");
+  if (!zero_points.empty()) {
+    CheckDataAndShape<int>(zero_points, scales_shape, "zero_points");
+  }
+  CheckDataAndShape<float>(output, output_shape, "output");
+
+  // Make a copy to avoid modifying the original unpacked data.
+  std::vector<int> packed_data = unpacked_data;
+  std::vector<int64_t> packed_data_shape = unpacked_data_shape;
+  PackDataForUint8TypeIfNecessary<T1>(packed_data, packed_data_shape, static_cast<int>(bits));
+
+  auto expect_result = expect_success ? OpTester::ExpectResult::kExpectSuccess : OpTester::ExpectResult::kExpectFailure;
+  if (zero_points.empty()) {
+    // If no zero points are provided, we can skip packing them.
+    RunGatherBlockQuantized(ToType<T1>(packed_data),
+                            packed_data_shape,
+                            ToType<Tind>(indices),
+                            indices_shape,
+                            ToType<T2>(scales),
+                            scales_shape,
+                            {},
+                            {},
+                            gather_axis,
+                            quantize_axis,
+                            block_size,
+                            bits,
+                            ToType<T2>(output),
+                            output_shape,
+                            expect_result);
+    return;
+  }
+
+  // Make a copy to avoid modifying the original unpacked data.
+  std::vector<int> packed_zero_point = zero_points;
+  std::vector<int64_t> packed_zero_point_shape = scales_shape;
+  PackDataForUint8TypeIfNecessary<T1>(packed_zero_point, packed_zero_point_shape, static_cast<int>(bits));
+
+  RunGatherBlockQuantized(ToType<T1>(packed_data),
+                          packed_data_shape,
+                          ToType<Tind>(indices),
+                          indices_shape,
+                          ToType<T2>(scales),
+                          scales_shape,
+                          ToType<T1>(packed_zero_point),
+                          packed_zero_point_shape,
+                          gather_axis,
+                          quantize_axis,
+                          block_size,
+                          bits,
+                          ToType<T2>(output),
+                          output_shape,
+                          expect_result);
 }
 
 template <typename T1, typename T2, typename Tind>
 void Test_Fail_WithZeroPoints(int64_t gather_axis,
                               int64_t quantize_axis,
-                              int64_t block_size) {
+                              int64_t block_size,
+                              int64_t bits = 4) {
   std::vector<int> data = {-8, -7, -6, -5,
                            -4, -3, -2, -1,
                            0, 1, 2, 3,
@@ -117,7 +251,6 @@ void Test_Fail_WithZeroPoints(int64_t gather_axis,
                            4, 5, 6, 7,
                            -4, -3, -2, -1};
   std::vector<int64_t> data_shape = {2, 3, 4};
-  PackDataForUint8TypeIfNecessary<T1>(data, data_shape);
   std::vector<int> indices = {1};
   std::vector<int64_t> indices_shape = {1};
   std::vector<float> scales = {1.0f, 2.0f, 1.0f, 2.0f, 1.0f, 2.0f};
@@ -128,19 +261,8 @@ void Test_Fail_WithZeroPoints(int64_t gather_axis,
                                -6.f, -4.f, -2.f, 0.f};
   std::vector<int64_t> output_shape = {1, 3, 4};
 
-  RunGatherBlockQuantized(ToType<T1>(data),
-                          data_shape,
-                          ToType<Tind>(indices),
-                          indices_shape,
-                          ToType<T2>(scales),
-                          scales_shape,
-                          ToType<T1>(zero_points),
-                          gather_axis,
-                          quantize_axis,
-                          block_size,
-                          ToType<T2>(output),
-                          output_shape,
-                          OpTester::ExpectResult::kExpectFailure);
+  RunUnpackedData<T1, T2, Tind>(data, data_shape, indices, indices_shape, scales, scales_shape, zero_points,
+                                gather_axis, quantize_axis, block_size, bits, output, output_shape, false);
 }
 
 TEST(GatherBlockQuantizedOpTest, UnsupportedTypes) {
@@ -161,7 +283,8 @@ TEST(GatherBlockQuantizedOpTest, UnsupportedTypes) {
 template <typename T1, typename T2, typename Tind>
 void Test_Fail_WithoutZeroPoints(int64_t gather_axis,
                                  int64_t quantize_axis,
-                                 int64_t block_size) {
+                                 int64_t block_size,
+                                 int64_t bits = 4) {
   std::vector<int> data = {-8, -7, -6, -5,
                            -4, -3, -2, -1,
                            0, 1, 2, 3,
@@ -169,35 +292,22 @@ void Test_Fail_WithoutZeroPoints(int64_t gather_axis,
                            4, 5, 6, 7,
                            -4, -3, -2, -1};
   std::vector<int64_t> data_shape = {2, 3, 4};
-  PackDataForUint8TypeIfNecessary<T1>(data, data_shape);
+
   std::vector<int> indices = {1};
   std::vector<int64_t> indices_shape = {1};
   std::vector<float> scales = {1.0f, 2.0f, 1.0f, 2.0f, 1.0f, 2.0f};
   std::vector<int64_t> scales_shape = {2, 3, 1};
+  std::vector<int> zero_points = {};
   std::vector<float> output = {8.f, 10.f, 12.f, 14.f,
                                3.f, 4.f, 5.f, 6.f,
                                -6.f, -4.f, -2.f, 0.f};
   std::vector<int64_t> output_shape = {1, 3, 4};
 
-  RunGatherBlockQuantized(ToType<T1>(data),
-                          data_shape,
-                          ToType<Tind>(indices),
-                          indices_shape,
-                          ToType<T2>(scales),
-                          scales_shape,
-                          {},
-                          gather_axis,
-                          quantize_axis,
-                          block_size,
-                          ToType<T2>(output),
-                          output_shape,
-                          OpTester::ExpectResult::kExpectFailure);
+  RunUnpackedData<T1, T2, Tind>(data, data_shape, indices, indices_shape, scales, scales_shape, zero_points,
+                                gather_axis, quantize_axis, block_size, bits, output, output_shape, false);
 }
 
 TEST(GatherBlockQuantizedOpTest, UnsupportedUInt8DataType) {
-  // T1 uint8_t with zero points is not yet supported.
-  Test_Fail_WithZeroPoints<uint8_t, float, int32_t>(0, 2, 16);
-  Test_Fail_WithZeroPoints<uint8_t, float, int16_t>(0, 2, 16);
   // Gather on axis other than 0 is not supported with uint8_t
   Test_Fail_WithoutZeroPoints<uint8_t, float, int32_t>(1, 2, 16);
   Test_Fail_WithoutZeroPoints<uint8_t, float, int16_t>(1, 2, 16);
@@ -221,6 +331,15 @@ TEST(GatherBlockQuantizedOpTest, InvalidQuantizeAxis) {
   Test_Fail_WithZeroPoints<uint8_t, float, int32_t>(0, -4, 16);
 }
 
+TEST(GatherBlockQuantizedOpTest, NotSupportedBits) {
+  Test_Fail_WithZeroPoints<UInt4x2, float, int32_t>(0, 2, 16, 1);
+  Test_Fail_WithZeroPoints<UInt4x2, float, int32_t>(0, 2, 16, 2);
+  Test_Fail_WithZeroPoints<UInt4x2, float, int32_t>(0, 2, 16, 3);
+  Test_Fail_WithZeroPoints<UInt4x2, float, int32_t>(0, 2, 16, 5);
+  Test_Fail_WithZeroPoints<UInt4x2, float, int32_t>(0, 2, 16, 6);
+  Test_Fail_WithZeroPoints<UInt4x2, float, int32_t>(0, 2, 16, 7);
+}
+
 template <typename T1, typename T2, typename Tind>
 void Test_ShapeMismatch_WithZeroPoints() {
   std::vector<int> data = {-8, -7, -6, -5,
@@ -230,7 +349,6 @@ void Test_ShapeMismatch_WithZeroPoints() {
                            4, 5, 6, 7,
                            -4, -3, -2, -1};
   std::vector<int64_t> data_shape = {2, 3, 4};
-  PackDataForUint8TypeIfNecessary<T1>(data, data_shape);
   std::vector<int> indices = {1};
   std::vector<int64_t> indices_shape = {1};
   std::vector<float> scales = {1.0f, 2.0f, 1.0f, 2.0f};
@@ -241,19 +359,12 @@ void Test_ShapeMismatch_WithZeroPoints() {
                                -6.f, -4.f, -2.f, 0.f};
   std::vector<int64_t> output_shape = {1, 3, 4};
 
-  RunGatherBlockQuantized(ToType<T1>(data),
-                          data_shape,
-                          ToType<Tind>(indices),
-                          indices_shape,
-                          ToType<T2>(scales),
-                          scales_shape,
-                          ToType<T1>(zero_points),
-                          0,
-                          2,
-                          16,
-                          ToType<T2>(output),
-                          output_shape,
-                          OpTester::ExpectResult::kExpectFailure);
+  constexpr int64_t gather_axis = 0;
+  constexpr int64_t quantize_axis = 2;
+  constexpr int64_t block_size = 16;
+  constexpr int64_t bits = 4;
+  RunUnpackedData<T1, T2, Tind>(data, data_shape, indices, indices_shape, scales, scales_shape, zero_points,
+                                gather_axis, quantize_axis, block_size, bits, output, output_shape, false);
 }
 
 TEST(GatherBlockQuantizedOpTest, ShapeMismatch) {
@@ -271,7 +382,6 @@ void Test_InvalidIndices_WithZeroPoints() {
                            4, 5, 6, 7,
                            -4, -3, -2, -1};
   std::vector<int64_t> data_shape = {2, 3, 4};
-  PackDataForUint8TypeIfNecessary<T1>(data, data_shape);
   std::vector<int> indices = {2};
   std::vector<int64_t> indices_shape = {1};
   std::vector<float> scales = {1.0f, 2.0f, 1.0f, 2.0f, 1.0f, 2.0f};
@@ -282,19 +392,12 @@ void Test_InvalidIndices_WithZeroPoints() {
                                -6.f, -4.f, -2.f, 0.f};
   std::vector<int64_t> output_shape = {1, 3, 4};
 
-  RunGatherBlockQuantized(ToType<T1>(data),
-                          data_shape,
-                          ToType<Tind>(indices),
-                          indices_shape,
-                          ToType<T2>(scales),
-                          scales_shape,
-                          ToType<T1>(zero_points),
-                          0,
-                          2,
-                          16,
-                          ToType<T2>(output),
-                          output_shape,
-                          OpTester::ExpectResult::kExpectFailure);
+  constexpr int64_t gather_axis = 0;
+  constexpr int64_t quantize_axis = 2;
+  constexpr int64_t block_size = 16;
+  constexpr int64_t bits = 4;
+  RunUnpackedData<T1, T2, Tind>(data, data_shape, indices, indices_shape, scales, scales_shape, zero_points,
+                                gather_axis, quantize_axis, block_size, bits, output, output_shape, false);
 }
 
 TEST(GatherBlockQuantizedOpTest, InvalidIndices) {
@@ -304,7 +407,7 @@ TEST(GatherBlockQuantizedOpTest, InvalidIndices) {
 }
 
 template <typename T1, typename T2, typename Tind>
-void Test_GatherAxis0_WithZeroPoints() {
+void Test_GatherAxis0_WithZeroPoints(int bits = 4) {
   std::vector<int> data = {-8, -7, -6, -5, -8, -7, -6, -5, -8, -7, -6, -5, -8, -7, -6, -5, -8,
                            -4, -3, -2, -1, -4, -3, -2, -1, -4, -3, -2, -1, -4, -3, -2, -1, -4,
                            0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0,
@@ -324,32 +427,14 @@ void Test_GatherAxis0_WithZeroPoints() {
                                -6, -4, -2, 0, -6, -4, -2, 0, -6, -4, -2, 0, -6, -4, -2, 0, -5};
   std::vector<int64_t> output_shape = {1, 3, 17};
 
-  RunGatherBlockQuantized(ToType<T1>(data),
-                          data_shape,
-                          ToType<Tind>(indices),
-                          indices_shape,
-                          ToType<T2>(scales),
-                          scales_shape,
-                          ToType<T1>(zero_points),
-                          0,
-                          2,
-                          16,
-                          ToType<T2>(output),
-                          output_shape,
-                          OpTester::ExpectResult::kExpectSuccess);
-  RunGatherBlockQuantized(ToType<T1>(data),
-                          data_shape,
-                          ToType<Tind>(indices),
-                          indices_shape,
-                          ToType<T2>(scales),
-                          scales_shape,
-                          ToType<T1>(zero_points),
-                          -3,
-                          -1,
-                          16,
-                          ToType<T2>(output),
-                          output_shape,
-                          OpTester::ExpectResult::kExpectSuccess);
+  constexpr int64_t gather_axis = 0;
+  constexpr int64_t quantize_axis = 2;
+  constexpr int64_t block_size = 16;
+  RunUnpackedData<T1, T2, Tind>(data, data_shape, indices, indices_shape, scales, scales_shape, zero_points,
+                                gather_axis, quantize_axis, block_size, bits, output, output_shape, true);
+
+  RunUnpackedData<T1, T2, Tind>(data, data_shape, indices, indices_shape, scales, scales_shape, zero_points,
+                                -3, -1, block_size, bits, output, output_shape, true);
 }
 
 TEST(GatherBlockQuantizedOpTest, GatherAxis0WithZeroPoints) {
@@ -364,7 +449,49 @@ TEST(GatherBlockQuantizedOpTest, GatherAxis0WithZeroPoints) {
 }
 
 template <typename T1, typename T2, typename Tind>
-void Test_GatherAxis0_NoZeroPoints() {
+void Test_GatherAxis0_WithZeroPoints_Uint8(int bits = 4) {
+  std::vector<int> data = {-8, -7, -6, -5, -8, -7, -6, -5, -8, -7, -6, -5, -8, -7, -6, -5, -8, 0,
+                           -4, -3, -2, -1, -4, -3, -2, -1, -4, -3, -2, -1, -4, -3, -2, -1, -4, 0,
+                           0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 0,
+                           4, 5, 6, 7, 4, 5, 6, 7, 4, 5, 6, 7, 4, 5, 6, 7, 4, 0,
+                           4, 5, 6, 7, 4, 5, 6, 7, 4, 5, 6, 7, 4, 5, 6, 7, 4, 0,
+                           -4, -3, -2, -1, -4, -3, -2, -1, -4, -3, -2, -1, -4, -3, -2, -1, -4, 0};
+  std::vector<int64_t> data_shape = {2, 3, 18};
+  std::vector<int> indices = {1};
+  std::vector<int64_t> indices_shape = {1};
+  std::vector<float> scales = {1.0f, 2.0f, 1.0f, 2.0f, 1.0f, 2.0f,
+                               2.0f, 2.0f, 1.0f, 1.0f, 2.0f, 1.0f};
+  std::vector<int64_t> scales_shape = {2, 3, 2};
+  std::vector<int> zero_points = {-1, 1, 0, 0, 1, -1,
+                                  1, -1, 1, 0, -1, 1};
+  // 4 bits output
+  std::vector<float> output = {6, 8, 10, 12, 6, 8, 10, 12, 6, 8, 10, 12, 6, 8, 10, 12, 10, 2,
+                               3, 4, 5, 6, 3, 4, 5, 6, 3, 4, 5, 6, 3, 4, 5, 6, 4, 0,
+                               -6, -4, -2, 0, -6, -4, -2, 0, -6, -4, -2, 0, -6, -4, -2, 0, -5, -1};
+  std::vector<int64_t> output_shape = {1, 3, 18};
+
+  constexpr int64_t gather_axis = 0;
+  constexpr int64_t quantize_axis = 2;
+  constexpr int64_t block_size = 16;
+  RunUnpackedData<T1, T2, Tind>(data, data_shape, indices, indices_shape, scales, scales_shape, zero_points,
+                                gather_axis, quantize_axis, block_size, bits, output, output_shape, true);
+
+  RunUnpackedData<T1, T2, Tind>(data, data_shape, indices, indices_shape, scales, scales_shape, zero_points,
+                                -3, -1, block_size, bits, output, output_shape, true);
+}
+
+TEST(GatherBlockQuantizedOpTest, GatherAxis0WithZeroPoints_4Bits) {
+  Test_GatherAxis0_WithZeroPoints_Uint8<uint8_t, float, int32_t>();
+  Test_GatherAxis0_WithZeroPoints_Uint8<uint8_t, MLFloat16, int64_t>();
+}
+
+TEST(GatherBlockQuantizedOpTest, GatherAxis0WithZeroPoints_8Bits) {
+  Test_GatherAxis0_WithZeroPoints_Uint8<uint8_t, float, int32_t>(8);
+  Test_GatherAxis0_WithZeroPoints_Uint8<uint8_t, MLFloat16, int64_t>(8);
+}
+
+template <typename T1, typename T2, typename Tind>
+void Test_GatherAxis0_NoZeroPoints(int bits = 4) {
   std::vector<int> data = {-8, -7, -6, -5,
                            -4, -3, -2, -1,
                            0, 1, 2, 3,
@@ -372,42 +499,28 @@ void Test_GatherAxis0_NoZeroPoints() {
                            4, 5, 6, 7,
                            -4, -3, -2, -1};
   std::vector<int64_t> data_shape = {2, 3, 4};
-  PackDataForUint8TypeIfNecessary<T1>(data, data_shape);
+
   std::vector<int> indices = {1};
   std::vector<int64_t> indices_shape = {1};
   std::vector<float> scales = {1.0f, 2.0f, 1.0f, 2.0f, 1.0f, 2.0f};
   std::vector<int64_t> scales_shape = {2, 3, 1};
+
+  // 4 bits output
   std::vector<float> output = {8.f, 10.f, 12.f, 14.f,
                                4.f, 5.f, 6.f, 7.f,
                                -8.f, -6.f, -4.f, -2.f};
+
   std::vector<int64_t> output_shape = {1, 3, 4};
 
-  RunGatherBlockQuantized(ToType<T1>(data),
-                          data_shape,
-                          ToType<Tind>(indices),
-                          indices_shape,
-                          ToType<T2>(scales),
-                          scales_shape,
-                          {},
-                          0,
-                          2,
-                          16,
-                          ToType<T2>(output),
-                          output_shape,
-                          OpTester::ExpectResult::kExpectSuccess);
-  RunGatherBlockQuantized(ToType<T1>(data),
-                          data_shape,
-                          ToType<Tind>(indices),
-                          indices_shape,
-                          ToType<T2>(scales),
-                          scales_shape,
-                          {},
-                          -3,
-                          -1,
-                          16,
-                          ToType<T2>(output),
-                          output_shape,
-                          OpTester::ExpectResult::kExpectSuccess);
+  std::vector<int> zero_points = {};
+  constexpr int64_t gather_axis = 0;
+  constexpr int64_t quantize_axis = 2;
+  constexpr int64_t block_size = 16;
+  RunUnpackedData<T1, T2, Tind>(data, data_shape, indices, indices_shape, scales, scales_shape, zero_points,
+                                gather_axis, quantize_axis, block_size, bits, output, output_shape, true);
+
+  RunUnpackedData<T1, T2, Tind>(data, data_shape, indices, indices_shape, scales, scales_shape, zero_points,
+                                -3, -1, block_size, bits, output, output_shape, true);
 }
 
 TEST(GatherBlockQuantizedOpTest, GatherAxis0NoZeroPoints) {
@@ -415,10 +528,18 @@ TEST(GatherBlockQuantizedOpTest, GatherAxis0NoZeroPoints) {
   Test_GatherAxis0_NoZeroPoints<Int4x2, MLFloat16, int32_t>();
   Test_GatherAxis0_NoZeroPoints<Int4x2, float, int64_t>();
   Test_GatherAxis0_NoZeroPoints<Int4x2, MLFloat16, int64_t>();
+}
+
+TEST(GatherBlockQuantizedOpTest, GatherAxis0NoZeroPoints_4Bits) {
   Test_GatherAxis0_NoZeroPoints<uint8_t, float, int32_t>();
   Test_GatherAxis0_NoZeroPoints<uint8_t, MLFloat16, int32_t>();
   Test_GatherAxis0_NoZeroPoints<uint8_t, float, int64_t>();
   Test_GatherAxis0_NoZeroPoints<uint8_t, MLFloat16, int64_t>();
+}
+
+TEST(GatherBlockQuantizedOpTest, GatherAxis0NoZeroPoints_8Bits) {
+  Test_GatherAxis0_NoZeroPoints<uint8_t, float, int64_t>(8);
+  Test_GatherAxis0_NoZeroPoints<uint8_t, MLFloat16, int64_t>(8);
 }
 
 template <typename T1, typename T2, typename Tind>
@@ -443,32 +564,15 @@ void Test_GatherAxis1_WithZeroPoints() {
                                -5.f, -4.f, -2.f, -2.f};
   std::vector<int64_t> output_shape = {2, 1, 3, 4};
 
-  RunGatherBlockQuantized(ToType<T1>(data),
-                          data_shape,
-                          ToType<Tind>(indices),
-                          indices_shape,
-                          ToType<T2>(scales),
-                          scales_shape,
-                          ToType<T1>(zero_points),
-                          1,
-                          1,
-                          16,
-                          ToType<T2>(output),
-                          output_shape,
-                          OpTester::ExpectResult::kExpectSuccess);
-  RunGatherBlockQuantized(ToType<T1>(data),
-                          data_shape,
-                          ToType<Tind>(indices),
-                          indices_shape,
-                          ToType<T2>(scales),
-                          scales_shape,
-                          ToType<T1>(zero_points),
-                          -2,
-                          -2,
-                          16,
-                          ToType<T2>(output),
-                          output_shape,
-                          OpTester::ExpectResult::kExpectSuccess);
+  constexpr int64_t gather_axis = 1;
+  constexpr int64_t quantize_axis = 1;
+  constexpr int64_t block_size = 16;
+  constexpr int64_t bits = 4;
+  RunUnpackedData<T1, T2, Tind>(data, data_shape, indices, indices_shape, scales, scales_shape, zero_points,
+                                gather_axis, quantize_axis, block_size, bits, output, output_shape, true);
+
+  RunUnpackedData<T1, T2, Tind>(data, data_shape, indices, indices_shape, scales, scales_shape, zero_points,
+                                -2, -2, block_size, bits, output, output_shape, true);
 }
 
 TEST(GatherBlockQuantizedOpTest, GatherAxis1) {
@@ -504,32 +608,15 @@ void Test_GatherAxis2_WithZeroPoints() {
                                6.f, 5.f, 6.f, 3.f, -3.f, -4.f};
   std::vector<int64_t> output_shape = {2, 3, 2, 1};
 
-  RunGatherBlockQuantized(ToType<T1>(data),
-                          data_shape,
-                          ToType<Tind>(indices),
-                          indices_shape,
-                          ToType<T2>(scales),
-                          scales_shape,
-                          ToType<T1>(zero_points),
-                          2,
-                          0,
-                          16,
-                          ToType<T2>(output),
-                          output_shape,
-                          OpTester::ExpectResult::kExpectSuccess);
-  RunGatherBlockQuantized(ToType<T1>(data),
-                          data_shape,
-                          ToType<Tind>(indices),
-                          indices_shape,
-                          ToType<T2>(scales),
-                          scales_shape,
-                          ToType<T1>(zero_points),
-                          -1,
-                          -3,
-                          16,
-                          ToType<T2>(output),
-                          output_shape,
-                          OpTester::ExpectResult::kExpectSuccess);
+  constexpr int64_t gather_axis = 2;
+  constexpr int64_t quantize_axis = 0;
+  constexpr int64_t block_size = 16;
+  constexpr int64_t bits = 4;
+  RunUnpackedData<T1, T2, Tind>(data, data_shape, indices, indices_shape, scales, scales_shape, zero_points,
+                                gather_axis, quantize_axis, block_size, bits, output, output_shape, true);
+
+  RunUnpackedData<T1, T2, Tind>(data, data_shape, indices, indices_shape, scales, scales_shape, zero_points,
+                                -1, -3, block_size, bits, output, output_shape, true);
 }
 
 TEST(GatherBlockQuantizedOpTest, GatherAxis2) {


### PR DESCRIPTION
Add support for unit8 GatherBlockQuantized for the following two areas:
* Allow zero points.
* Add bits attribute and support bits=8.

Major change is to update shape inference; and update unit tests to cover these.

Note that only CPU implementation, and CUDA implementation will be added later in another PR.

### Motivation and Context

Previously, zero points are not supported when dtype is uint8. Only 4 bit quantization without zero points were supported.
This change is to  share weights of lm_head with 8 bit quantization between GatherBlockQuantized and MatMulNBits.
 
For example, when K is multiple of `block_size`, typical input and output shapes are like the following:
 * data has shape (N, K) for 8 bits, or (N, K / 2) for 4 bits.
 * scales has shape (N, k_blocks), where k_blocks = (K / block_size).
 * zero_points has shape (N, k_blocks) for 8 bits, (N, (k_blocks + 1) / 2) for 4 bits.
 * output will have shape (..., K), where ... is the shape of `indices`.