### PR TITLE
Pass mem_info into CPUAllocator constructor (#25212)

### DIFF
--- a/onnxruntime/core/session/environment.cc
+++ b/onnxruntime/core/session/environment.cc
@@ -226,7 +226,7 @@ Status Environment::CreateAndRegisterAllocator(const OrtMemoryInfo& mem_info, co
         l_arena_cfg};
     allocator_ptr = CreateAllocator(alloc_creation_info);
   } else {
-    AllocatorCreationInfo alloc_creation_info{[](int) { return std::make_unique<CPUAllocator>(); },
+    AllocatorCreationInfo alloc_creation_info{[mem_info](int) { return std::make_unique<CPUAllocator>(mem_info); },
                                               0, create_arena};
     allocator_ptr = CreateAllocator(alloc_creation_info);
   }


### PR DESCRIPTION
### Description
Added missing "mem_info" parameter into CPUAllocator constructor


### Motivation and Context
Without the correct mem_info, CudaPinned allocator is mapped with wrong (default) "Cpu" memory_info.