### PR TITLE
Support CUDA pinned allocator in Environment::CreateAndRegisterAllocatorV2

### DIFF
--- a/onnxruntime/core/session/environment.cc
+++ b/onnxruntime/core/session/environment.cc
@@ -397,15 +397,21 @@ Status Environment::CreateAndRegisterAllocatorV2(const std::string& provider_typ
 
 #if defined(USE_CUDA) || defined(USE_CUDA_PROVIDER_INTERFACE)
   if (provider_type == onnxruntime::kCudaExecutionProvider) {
-    CUDAExecutionProviderInfo cuda_ep_info;
-    GetProviderInfo_CUDA().CUDAExecutionProviderInfo__FromProviderOptions(options, cuda_ep_info);
-    CUDAExecutionProviderExternalAllocatorInfo external_info = cuda_ep_info.external_allocator_info;
-    AllocatorPtr allocator_ptr = GetProviderInfo_CUDA().CreateCudaAllocator(
-        static_cast<int16_t>(mem_info.device.Id()),
-        arena_cfg->max_mem,
-        static_cast<ArenaExtendStrategy>(arena_cfg->arena_extend_strategy),
-        external_info, arena_cfg);
-    return RegisterAllocatorImpl(allocator_ptr);
+    if (mem_info.device.MemType() == OrtDevice::MemType::HOST_ACCESSIBLE) {
+      AllocatorPtr allocator_ptr = GetProviderInfo_CUDA().CreateCUDAPinnedAllocator(onnxruntime::CUDA_PINNED);
+      return RegisterAllocatorImpl(allocator_ptr);
+    }
+    else {
+      CUDAExecutionProviderInfo cuda_ep_info;
+      GetProviderInfo_CUDA().CUDAExecutionProviderInfo__FromProviderOptions(options, cuda_ep_info);
+      CUDAExecutionProviderExternalAllocatorInfo external_info = cuda_ep_info.external_allocator_info;
+      AllocatorPtr allocator_ptr = GetProviderInfo_CUDA().CreateCudaAllocator(
+          static_cast<int16_t>(mem_info.device.Id()),
+          arena_cfg->max_mem,
+          static_cast<ArenaExtendStrategy>(arena_cfg->arena_extend_strategy),
+          external_info, arena_cfg);
+      return RegisterAllocatorImpl(allocator_ptr);
+    }
   }
 #endif
 

--- a/onnxruntime/core/session/environment.cc
+++ b/onnxruntime/core/session/environment.cc
@@ -400,8 +400,7 @@ Status Environment::CreateAndRegisterAllocatorV2(const std::string& provider_typ
     if (mem_info.device.MemType() == OrtDevice::MemType::HOST_ACCESSIBLE) {
       AllocatorPtr allocator_ptr = GetProviderInfo_CUDA().CreateCUDAPinnedAllocator(onnxruntime::CUDA_PINNED);
       return RegisterAllocatorImpl(allocator_ptr);
-    }
-    else {
+    } else {
       CUDAExecutionProviderInfo cuda_ep_info;
       GetProviderInfo_CUDA().CUDAExecutionProviderInfo__FromProviderOptions(options, cuda_ep_info);
       CUDAExecutionProviderExternalAllocatorInfo external_info = cuda_ep_info.external_allocator_info;


### PR DESCRIPTION
### Description
Distinguish between the memory types when creating a shared environment allocator for CUDAExecutionProvider

### Motivation and Context
Fixed #25211

