### PR TITLE
Add ability for EP to get vendor ID and device ID from OrtMemoryDevice

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
@@ -296,6 +296,28 @@ struct OrtEpApi {
    * \since Version 1.23.
    */
   ORT_API_T(OrtDeviceMemoryType, MemoryDevice_GetMemoryType, _In_ const OrtMemoryDevice* memory_device);
+
+  /** \brief Get the vendor ID from an OrtMemoryDevice instance.
+   *
+   * The vendor ID is used to identify the vendor of the device, and is typically set to the PCI vendor ID.
+   *
+   * If the device is not vendor specific (e.g. CPU memory) the vendor ID is set to 0.
+   *
+   * \param[in] memory_device OrtMemoryDevice instance.
+   * \return The vendor ID value.
+   *
+   * \since Version 1.23.
+   */
+  ORT_API_T(uint32_t, MemoryDevice_GetVendorId, _In_ const OrtMemoryDevice* memory_device);
+
+  /** \brief Get the device ID from an OrtMemoryDevice instance.
+   *
+   * \param[in] memory_device OrtMemoryDevice instance.
+   * \return The device ID.
+   *
+   * \since Version 1.23.
+   */
+  ORT_API_T(uint32_t, MemoryDevice_GetDeviceId, _In_ const OrtMemoryDevice* memory_device);
 };
 
 /**

--- a/onnxruntime/core/session/ep_api.cc
+++ b/onnxruntime/core/session/ep_api.cc
@@ -152,6 +152,14 @@ ORT_API(OrtDeviceMemoryType, MemoryDevice_GetMemoryType, _In_ const OrtMemoryDev
                                                                  : OrtDeviceMemoryType_HOST_ACCESSIBLE;
 }
 
+ORT_API(uint32_t, MemoryDevice_GetVendorId, _In_ const OrtMemoryDevice* memory_device) {
+  return memory_device->Vendor();
+}
+
+ORT_API(uint32_t, MemoryDevice_GetDeviceId, _In_ const OrtMemoryDevice* memory_device) {
+  return memory_device->Id();
+}
+
 static constexpr OrtEpApi ort_ep_api = {
     // NOTE: ABI compatibility depends on the order within this struct so all additions must be at the end,
     // and no functions can be removed (the implementation needs to change to return an error).
@@ -171,6 +179,8 @@ static constexpr OrtEpApi ort_ep_api = {
     &OrtExecutionProviderApi::MemoryDevice_AreEqual,
     &OrtExecutionProviderApi::MemoryDevice_GetDeviceType,
     &OrtExecutionProviderApi::MemoryDevice_GetMemoryType,
+    &OrtExecutionProviderApi::MemoryDevice_GetVendorId,
+    &OrtExecutionProviderApi::MemoryDevice_GetDeviceId,
 };
 
 // checks that we don't violate the rule that the functions must remain in the slots they were originally assigned

--- a/onnxruntime/core/session/ep_api.h
+++ b/onnxruntime/core/session/ep_api.h
@@ -33,4 +33,6 @@ ORT_API_STATUS_IMPL(Value_GetMemoryDevice, _In_ const OrtValue* value, _Out_ con
 ORT_API(bool, MemoryDevice_AreEqual, _In_ const OrtMemoryDevice* a, _In_ const OrtMemoryDevice* b);
 ORT_API(OrtMemoryInfoDeviceType, MemoryDevice_GetDeviceType, _In_ const OrtMemoryDevice* memory_device);
 ORT_API(OrtDeviceMemoryType, MemoryDevice_GetMemoryType, _In_ const OrtMemoryDevice* memory_device);
+ORT_API(uint32_t, MemoryDevice_GetVendorId, _In_ const OrtMemoryDevice* memory_device);
+ORT_API(uint32_t, MemoryDevice_GetDeviceId, _In_ const OrtMemoryDevice* memory_device);
 }  // namespace OrtExecutionProviderApi

--- a/onnxruntime/test/autoep/library/ep_data_transfer.cc
+++ b/onnxruntime/test/autoep/library/ep_data_transfer.cc
@@ -10,11 +10,38 @@
 bool ORT_API_CALL ExampleDataTransfer::CanCopyImpl(void* this_ptr,
                                                    const OrtMemoryDevice* src_memory_device,
                                                    const OrtMemoryDevice* dst_memory_device) noexcept {
+  static constexpr uint32_t VendorId = 0xBE57;  // Example vendor ID for demonstration purposes.
+
   auto& impl = *static_cast<ExampleDataTransfer*>(this_ptr);
   bool src_is_our_device = impl.ep_api.MemoryDevice_AreEqual(src_memory_device, impl.device_mem_info);
   bool dst_is_our_device = impl.ep_api.MemoryDevice_AreEqual(dst_memory_device, impl.device_mem_info);
 
-  return src_is_our_device || dst_is_our_device;
+  if (src_is_our_device && dst_is_our_device) {
+    return true;
+  }
+
+  // implementation should check if the copy is possible, which may require checking the device type, the memory type
+  // and the vendor and device IDs as needed.
+  OrtMemoryInfoDeviceType src_device_type = impl.ep_api.MemoryDevice_GetDeviceType(src_memory_device);
+  OrtMemoryInfoDeviceType dst_device_type = impl.ep_api.MemoryDevice_GetDeviceType(dst_memory_device);
+  // OrtDeviceMemoryType src_mem_type = impl.ep_api.MemoryDevice_GetMemoryType(src_memory_device);
+  // OrtDeviceMemoryType dst_mem_type = impl.ep_api.MemoryDevice_GetMemoryType(dst_memory_device);
+  // uint32_t src_device_vendor_id = impl.ep_api.MemoryDevice_GetVendorId(src_memory_device);
+  // uint32_t dst_device_vendor_id = impl.ep_api.MemoryDevice_GetVendorId(dst_memory_device);
+  // uint32_t src_device_device_id = impl.ep_api.MemoryDevice_GetDeviceId(src_memory_device);
+  // uint32_t dst_device_device_id = impl.ep_api.MemoryDevice_GetDeviceId(dst_memory_device);
+
+  if (src_is_our_device) {
+    // check device type and vendor to see if compatible
+    return (dst_device_type == OrtMemoryInfoDeviceType_CPU);
+  }
+
+  if (dst_is_our_device) {
+    // check device type and vendor to see if compatible
+    return (src_device_type == OrtMemoryInfoDeviceType_CPU);
+  }
+
+  return false;
 }
 
 // function to copy one or more tensors.
@@ -41,6 +68,7 @@ OrtStatus* ORT_API_CALL ExampleDataTransfer::CopyTensorsImpl(void* this_ptr,
 
     OrtMemoryInfoDeviceType src_device_type = impl.ep_api.MemoryDevice_GetDeviceType(src_device);
     OrtMemoryInfoDeviceType dst_device_type = impl.ep_api.MemoryDevice_GetDeviceType(dst_device);
+
     //  OrtDeviceMemoryType src_mem_type = impl.ep_api.MemoryDevice_GetMemoryType(src_device);
     //  OrtDeviceMemoryType dst_mem_type = impl.ep_api.MemoryDevice_GetMemoryType(dst_device);
     //   bool copy_involves_pinned_memory = src_mem_type == OrtDeviceMemoryType_HOST_ACCESSIBLE ||


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
EP implementations need to be able to read vendor id and device id to implement OrtDataTransferImpl::CanCopy correctly.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


