### PR TITLE
Inference fallback provider bugfix

### DIFF
--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -516,7 +516,7 @@ class InferenceSession(Session):
                 )
                 and any(
                     provider == "NvTensorRTRTXExecutionProvider"
-                    or (isinstance(provider, tuple) and provider[0] == "NvExecutionProvider")
+                    or (isinstance(provider, tuple) and provider[0] == "NvTensorRTRTXExecutionProvider")
                     for provider in providers
                 )
             ):


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Bugfix(es) in the Inference Session creation flow which otherwise wouldn't set CUDA execution providers for users having TRT or NvRTX.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
the `_create_inference_session` method is unable to set CUDA execution providers even when they're available due to a minor bug in the control flow (`if` statement instead of `elif`) (for TRT) and a typo (for NvRTX). Further context in #25145 

