### PR TITLE
[QNN EP] Add qnn_version to build_and_package_info.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ rocm_version = None
 is_migraphx = False
 is_openvino = False
 is_qnn = False
+qnn_version = None
 # The following arguments are mutually exclusive
 if wheel_name_suffix == "gpu":
     # TODO: how to support multiple CUDA versions?
@@ -88,6 +89,7 @@ elif parse_arg_remove_boolean(sys.argv, "--use_azure"):
 elif parse_arg_remove_boolean(sys.argv, "--use_qnn"):
     is_qnn = True
     package_name = "onnxruntime-qnn"
+    qnn_version = parse_arg_remove_string(sys.argv, "--qnn_version=")
 elif is_migraphx:
     package_name = "onnxruntime-migraphx" if not nightly_build else "ort-migraphx-nightly"
 
@@ -734,7 +736,7 @@ with open(requirements_path) as f:
     install_requires = f.read().splitlines()
 
 
-def save_build_and_package_info(package_name, version_number, cuda_version, rocm_version):
+def save_build_and_package_info(package_name, version_number, cuda_version, rocm_version, qnn_version):
     sys.path.append(path.join(path.dirname(__file__), "onnxruntime", "python"))
     from onnxruntime_collect_build_info import find_cudart_versions
 
@@ -763,9 +765,11 @@ def save_build_and_package_info(package_name, version_number, cuda_version, rocm
                     )
         elif rocm_version:
             f.write(f"rocm_version = '{rocm_version}'\n")
+        elif qnn_version:
+            f.write(f"qnn_version = '{qnn_version}'\n")
 
 
-save_build_and_package_info(package_name, version_number, cuda_version, rocm_version)
+save_build_and_package_info(package_name, version_number, cuda_version, rocm_version, qnn_version)
 
 extras_require = {}
 if package_name == "onnxruntime-gpu" and is_cuda_version_12:

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -40,6 +40,7 @@ from util import (  # noqa: E402
     is_linux,
     is_macOS,
     is_windows,
+    parse_qnn_version_from_sdk_yaml,
     run,
 )
 
@@ -1883,6 +1884,7 @@ def build_python_wheel(
     use_cann,
     use_azure,
     use_qnn,
+    qnn_home,
     wheel_name_suffix,
     enable_training,
     nightly_build=False,
@@ -1940,6 +1942,9 @@ def build_python_wheel(
             args.append("--use_cann")
         elif use_qnn:
             args.append("--use_qnn")
+            qnn_version = parse_qnn_version_from_sdk_yaml(qnn_home)
+            if qnn_version:
+                args.append(f"--qnn_version={qnn_version}")
         elif use_azure:
             args.append("--use_azure")
 
@@ -2560,6 +2565,7 @@ def main():
                 args.use_cann,
                 args.use_azure,
                 args.use_qnn,
+                args.qnn_home,
                 args.wheel_name_suffix,
                 args.enable_training,
                 nightly_build=nightly_build,

--- a/tools/ci_build/github/android/build_aar_package.py
+++ b/tools/ci_build/github/android/build_aar_package.py
@@ -16,7 +16,7 @@ BUILD_PY = os.path.join(REPO_DIR, "tools", "ci_build", "build.py")
 JAVA_ROOT = os.path.join(REPO_DIR, "java")
 
 sys.path.insert(0, os.path.join(REPO_DIR, "tools", "python"))
-from util import is_windows  # noqa: E402
+from util import is_windows, parse_qnn_version_from_sdk_yaml  # noqa: E402
 
 # We by default will build all 4 ABIs
 DEFAULT_BUILD_ABIS = ["armeabi-v7a", "arm64-v8a", "x86", "x86_64"]
@@ -102,14 +102,7 @@ def _build_aar(args):
 
     if qnn_android_build:
         qnn_home = args.qnn_path
-        sdk_file = os.path.join(qnn_home, "sdk.yaml")
-        qnn_sdk_version = None
-        with open(sdk_file) as f:
-            for line in f:
-                if line.strip().startswith("version:"):
-                    # yaml file has simple key: value format with version as key
-                    qnn_sdk_version = line.split(":", 1)[1].strip()
-                    break
+        qnn_sdk_version = parse_qnn_version_from_sdk_yaml(qnn_home)
 
         # Note: The QNN package version does not follow Semantic Versioning (SemVer) format.
         # only use major.minor.patch version for qnn sdk version and truncate the build_id info if any

--- a/tools/python/util/__init__.py
+++ b/tools/python/util/__init__.py
@@ -4,6 +4,7 @@
 from .get_azcopy import get_azcopy  # noqa: F401
 from .logger import get_logger
 from .platform_helpers import is_linux, is_macOS, is_windows  # noqa: F401
+from .qnn_helpers import parse_qnn_version_from_sdk_yaml  # noqa: F401
 from .run import run  # noqa: F401
 from .vcpkg_helpers import (  # noqa: F401
     generate_android_triplets,

--- a/tools/python/util/qnn_helpers.py
+++ b/tools/python/util/qnn_helpers.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import os
+
+
+def parse_qnn_version_from_sdk_yaml(qnn_home):
+    sdk_file = os.path.join(qnn_home, "sdk.yaml")
+    with open(sdk_file) as f:
+        for line in f:
+            if line.strip().startswith("version:"):
+                # yaml file has simple key: value format with version as key
+                return line.split(":", 1)[1].strip()
+    return None


### PR DESCRIPTION
### Description

This makes the QAIRT/QNN version available in the Python client as `onnxruntime.capi.build_and_package_info.qnn_version`, similar to how it's already done for `cuda_version` and `rcom_version`.


### Motivation and Context

Users in some situations need to bring their own QAIRT/QNN SDK. In these cases, it is important to know the correct version to supply to ensure compatibility.

