### PR TITLE
Remove incorrect function calls

### DIFF
--- a/docs/genai/howto/migrate.md
+++ b/docs/genai/howto/migrate.md
@@ -70,7 +70,6 @@ Note: chat mode and system prompt caching are only supported for batch size 1. F
    auto sequences = OgaSequences::Create();
    tokenizer->Encode(system_prompt.c_str(), *sequences);
    generator->AppendTokenSequences(*sequences);
-   generator.append_tokens(system_tokens)
    ```
 
 ### Add chat mode to your C++ application


### PR DESCRIPTION
### Description
Removes an incorrect function call within the C++ migration instructions.



### Motivation and Context
The line `generator.append_tokens(system_tokens)` appears to be an mistaken copy from python instructions.


