### PR TITLE
check nchwc_inputs before accessing

### DIFF
--- a/onnxruntime/core/optimizer/nchwc_transformer.cc
+++ b/onnxruntime/core/optimizer/nchwc_transformer.cc
@@ -609,6 +609,11 @@ void NchwcTransformerImpl::TransformBinary(Node& node, bool add_node) {
     nchwc_inputs.push_back(nchwc_input);
   }
 
+  // Bail out if nchwc_inputs is not empty before accessing [0]
+  if (nchwc_inputs.empty()) {
+    return;
+  }
+
   auto* nchwc_input_0 = nchwc_inputs[0];
   const int64_t channels = nchwc_inputs[0]->channels_;
 


### PR DESCRIPTION
### Description
Fixes a build error by checking that `nchwc_inputs` is not empty before accessing its elements in `TransformBinary`.

### Motivation and Context
Compiler flagged a possible uninitialized access to `nchwc_inputs[0]` (when empty), causing the build to fail. This check ensures safe access and avoids undefined behavior. No impact on valid graphs.