### PR TITLE
[QNN EP] Add Infrastructure to check datatypes

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
@@ -70,6 +70,18 @@ class BaseOpBuilder : public IOpBuilder {
     return Status::OK();
   }
 
+  Status ProcessDataTypes(QnnModelWrapper& qnn_model_wrapper,
+                          const NodeUnit& node_unit) const ORT_MUST_USE_RESULT;
+
+  virtual Status CheckCpuDataTypes(const std::vector<Qnn_DataType_t>,
+                                   const std::vector<Qnn_DataType_t>) const ORT_MUST_USE_RESULT;
+
+  virtual Status CheckHtpDataTypes(const std::vector<Qnn_DataType_t>,
+                                   const std::vector<Qnn_DataType_t>) const ORT_MUST_USE_RESULT;
+
+  virtual Status CheckGpuDataTypes(const std::vector<Qnn_DataType_t>,
+                                   const std::vector<Qnn_DataType_t>) const ORT_MUST_USE_RESULT;
+
   virtual Status ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
                                const NodeUnit& node_unit,
                                const logging::Logger& logger,


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Add BaseOpBuilder::ProcessDataTypes
- Add CheckCpuDataTypes, CheckHtpDataTypes and CheckGpuDataTypes
- Check if datatypes are supported on QnnCpu and QnnHtp for BatchNorm
- Add corresponding unit test for BatchNorm on QnnCpu and QnnHtp

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- Due to varying datatype support for each op on various backends (QnnCpu, QnnHtp, QnnGpu), we need an infrastructure to check datatypes according to the document
https://docs.qualcomm.com/bundle/publicresource/topics/80-63442-50/operations.html#backend-supplements

