### PR TITLE
[build] do not use separated artifacts for wasm build

### DIFF
--- a/.github/workflows/linux-wasm-ci-build-and-test-workflow.yml
+++ b/.github/workflows/linux-wasm-ci-build-and-test-workflow.yml
@@ -107,13 +107,10 @@ jobs:
             cp ${{ github.workspace }}/build/wasm_inferencing_jsep/${{ inputs.build_config }}/ort-wasm-simd-threaded.jsep.wasm ${{ github.workspace }}/artifacts/wasm/
             cp ${{ github.workspace }}/build/wasm_inferencing_jsep/${{ inputs.build_config }}/ort-wasm-simd-threaded.jsep.mjs ${{ github.workspace }}/artifacts/wasm/
           fi
-
-      - name: Create WebGPU Artifacts
-        if: ${{ inputs.skip_publish != true && inputs.build_webgpu == true }}
-        run: |
-          mkdir -p ${{ github.workspace }}/artifacts/wasm_webgpu/
-          cp ${{ github.workspace }}/build/wasm_inferencing_webgpu/${{ inputs.build_config }}/ort-wasm-simd-threaded.asyncify.wasm ${{ github.workspace }}/artifacts/wasm_webgpu/
-          cp ${{ github.workspace }}/build/wasm_inferencing_webgpu/${{ inputs.build_config }}/ort-wasm-simd-threaded.asyncify.mjs ${{ github.workspace }}/artifacts/wasm_webgpu/
+          if [ -d ${{ github.workspace }}/build/wasm_inferencing_webgpu ]; then
+            cp ${{ github.workspace }}/build/wasm_inferencing_webgpu/${{ inputs.build_config }}/ort-wasm-simd-threaded.asyncify.wasm ${{ github.workspace }}/artifacts/wasm/
+            cp ${{ github.workspace }}/build/wasm_inferencing_webgpu/${{ inputs.build_config }}/ort-wasm-simd-threaded.asyncify.mjs ${{ github.workspace }}/artifacts/wasm/
+          fi
 
       - name: Upload WASM artifacts
         if: ${{ inputs.skip_publish != true }}
@@ -121,13 +118,6 @@ jobs:
         with:
           name: ${{ inputs.build_config }}_wasm
           path: ${{ github.workspace }}/artifacts/wasm
-
-      - name: Upload WebGPU artifacts
-        if: ${{ inputs.skip_publish != true && inputs.build_webgpu == true }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ inputs.build_config }}_wasm_webgpu
-          path: ${{ github.workspace }}/artifacts/wasm_webgpu
 
       - name: Test (Node.js) (simd + threads)
         # onnxruntime_test_all is currently only supported in Debug build because it requires exception, which is disabled in Release build.

--- a/.github/workflows/windows-web-ci-workflow.yml
+++ b/.github/workflows/windows-web-ci-workflow.yml
@@ -83,22 +83,6 @@ jobs:
         run: |
           copy ${{ github.workspace }}\artifacts_wasm\ort-*.mjs ${{ github.workspace }}\js\web\dist\
 
-      - name: Download WebAssembly WebGPU artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ inputs.build_config }}_wasm_webgpu
-          path: ${{ github.workspace }}/artifacts_wasm_webgpu
-
-      - name: Binplace dist files (.wasm) for WebGPU
-        shell: cmd
-        run: |
-          copy ${{ github.workspace }}\artifacts_wasm_webgpu\ort-*.wasm ${{ github.workspace }}\js\web\dist\
-
-      - name: Binplace dist files (.mjs) for WebGPU
-        shell: cmd
-        run: |
-          copy ${{ github.workspace }}\artifacts_wasm_webgpu\ort-*.mjs ${{ github.workspace }}\js\web\dist\
-
       - name: npm ci for /js/
         run: npm ci
         working-directory: ${{ github.workspace }}/js

--- a/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
@@ -146,37 +146,23 @@ jobs:
           cp $(Build.BinariesDirectory)/wasm_inferencing_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.jsep.wasm $(Build.ArtifactStagingDirectory)/wasm/
           cp $(Build.BinariesDirectory)/wasm_inferencing_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.jsep.mjs $(Build.ArtifactStagingDirectory)/wasm/
         fi
+        if [ -d $(Build.BinariesDirectory)/wasm_inferencing_webgpu ]; then
+          cp $(Build.BinariesDirectory)/wasm_inferencing_webgpu/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.asyncify.wasm $(Build.ArtifactStagingDirectory)/wasm/
+          cp $(Build.BinariesDirectory)/wasm_inferencing_webgpu/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.asyncify.mjs $(Build.ArtifactStagingDirectory)/wasm/
+        fi
       displayName: 'Create Artifacts'
-    - ${{ if eq(parameters.BuildWebGPU, true) }}:
-      - script: |
-          mkdir -p $(Build.ArtifactStagingDirectory)/wasm_webgpu/
-          cp $(Build.BinariesDirectory)/wasm_inferencing_webgpu/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.asyncify.wasm $(Build.ArtifactStagingDirectory)/wasm_webgpu/
-          cp $(Build.BinariesDirectory)/wasm_inferencing_webgpu/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.asyncify.mjs $(Build.ArtifactStagingDirectory)/wasm_webgpu/
-        displayName: 'Create Artifacts (WebGPU EP)'
     - ${{ if eq(parameters.is1ES, false) }}:
       - task: PublishPipelineArtifact@1
         displayName: 'Publish Pipeline Artifact'
         inputs:
           artifactName: '${{ parameters.BuildConfig }}_wasm'
           targetPath: '$(Build.ArtifactStagingDirectory)/wasm'
-      - ${{ if eq(parameters.BuildWebGPU, true) }}:
-        - task: PublishPipelineArtifact@1
-          displayName: 'Publish Pipeline Artifact (WebGPU EP)'
-          inputs:
-            artifactName: '${{ parameters.BuildConfig }}_wasm_webgpu'
-            targetPath: '$(Build.ArtifactStagingDirectory)/wasm_webgpu'
     - ${{ if eq(parameters.is1ES, true) }}:
       - task: 1ES.PublishPipelineArtifact@1
         displayName: 'Publish Pipeline Artifact'
         inputs:
           artifactName: '${{ parameters.BuildConfig }}_wasm'
           targetPath: '$(Build.ArtifactStagingDirectory)/wasm'
-      - ${{ if eq(parameters.BuildWebGPU, true) }}:
-        - task: 1ES.PublishPipelineArtifact@1
-          displayName: 'Publish Pipeline Artifact (WebGPU EP)'
-          inputs:
-            artifactName: '${{ parameters.BuildConfig }}_wasm_webgpu'
-            targetPath: '$(Build.ArtifactStagingDirectory)/wasm_webgpu'
   - task: PublishTestResults@2
     displayName: 'Publish unit test results'
     inputs:

--- a/tools/ci_build/github/azure-pipelines/templates/win-web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-web-ci.yml
@@ -225,29 +225,6 @@ jobs:
   # === Start of experimental WebGPU EP tests ===
 
   - ${{ if eq(parameters.RunWebGpuTests, true) }}:
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        patterns: '${{ parameters.BuildConfig }}_wasm_webgpu/**/*'
-        path: $(Pipeline.Workspace)\artifacts_wasm_webgpu
-      displayName: 'Download WebAssembly artifacts'
-    - task: CopyFiles@2
-      inputs:
-        sourceFolder: $(Pipeline.Workspace)\artifacts_wasm_webgpu
-        contents: |
-          **\ort-*.wasm
-        targetFolder: $(Build.SourcesDirectory)\js\web\dist
-        flattenFolders: true
-        overWrite: true
-      displayName: 'Binplace dist files (.wasm)'
-    - task: CopyFiles@2
-      inputs:
-        sourceFolder: $(Pipeline.Workspace)\artifacts_wasm_webgpu
-        contents: |
-          **\ort-*.mjs
-        targetFolder: $(Build.SourcesDirectory)\js\web\dist
-        flattenFolders: true
-        overWrite: true
-      displayName: 'Binplace dist files (.mjs)'
     - script: |
         powershell "Get-WmiObject Win32_Process -Filter \"name = 'chrome.exe'\" | Format-List CommandLine"
       displayName: 'Check active Chrome processes (before test)'


### PR DESCRIPTION
### Description

Previously we have 2 artifacts:
- `${{ inputs.build_config }}_wasm`
- `${{ inputs.build_config }}_wasm_webgpu`

Now that we use a different file name so that we can simplify this part and make it a single artifact.