### PR TITLE
[build] fix build on mac

### DIFF
--- a/onnxruntime/test/framework/function_test.cc
+++ b/onnxruntime/test/framework/function_test.cc
@@ -3,6 +3,7 @@
 
 #include "gtest/gtest.h"
 
+#include "core/graph/onnx_protobuf.h"
 #include "onnx/defs/parser.h"
 
 #include "core/common/span_utils.h"

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -9,6 +9,9 @@
 
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
+
+#include "core/graph/onnx_protobuf.h"
+
 #include "onnx/defs/parser.h"
 #include "onnx/defs/printer.h"
 
@@ -18,7 +21,6 @@
 #include "core/graph/graph_utils.h"
 #include "core/graph/graph_viewer.h"
 #include "core/graph/model.h"
-#include "core/graph/onnx_protobuf.h"
 #include "core/mlas/inc/mlas_q4.h"
 #include "core/optimizer/attention_fusion.h"
 #include "core/optimizer/bias_dropout_fusion.h"

--- a/onnxruntime/test/optimizer/layout_transformation_potentially_added_ops_test.cc
+++ b/onnxruntime/test/optimizer/layout_transformation_potentially_added_ops_test.cc
@@ -5,7 +5,7 @@
 
 #include "gtest/gtest.h"
 
-#include "onnx/defs/schema.h"
+#include "core/graph/onnx_protobuf.h"
 
 #include "core/graph/constants.h"
 


### PR DESCRIPTION
### Description

Fixes build on macOS.

always include `"core/graph/onnx_protobuf.h"` before including other onnx/protobuf headers.

```
.../build/MacOS/Debug/_deps/protobuf-src/src/google/protobuf/parse_context.h:328:47: error: implicit conversion loses integer precision: 'long' to 'int' [-Werror,-Wshorten-64-to-32]
  328 |     int chunk_size = buffer_end_ + kSlopBytes - ptr;
      |         ~~~~~~~~~~   ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
```