### PR TITLE
Add a new ORT API `GetSessionOptionConfigEntries`

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -6074,6 +6074,16 @@ struct OrtApi {
    * \since Version 1.23
    */
   ORT_API2_STATUS(GetTensorData, _In_ const OrtValue* value, _Outptr_ const void** out);
+
+  /** \brief Get Session configuration entries.
+   *
+   * \param[in] options The session options.
+   * \return An OrtKeyValuePairs instance containing the all session config enties.
+   *         Note: the user should call OrtApi::ReleaseKeyValuePairs.
+   *
+   * \since Version 1.22.
+   */
+  OrtKeyValuePairs*(ORT_API_CALL* GetSessionOptionConfigEntries)(_In_ const OrtSessionOptions* options);
 };
 
 /*

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -6085,7 +6085,7 @@ struct OrtApi {
    *
    * \since Version 1.23.
    */
-  ORT_API2_STATUS(GetSessionOptionConfigEntries, _In_ const OrtSessionOptions* options, _Outptr_ OrtKeyValuePairs** out);
+  ORT_API2_STATUS(GetSessionOptionsConfigEntries, _In_ const OrtSessionOptions* options, _Outptr_ OrtKeyValuePairs** out);
 };
 
 /*

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -6078,12 +6078,14 @@ struct OrtApi {
   /** \brief Get Session configuration entries.
    *
    * \param[in] options The session options.
-   * \return An OrtKeyValuePairs instance containing all session configuration entries.
-   *         Note: the user should call OrtApi::ReleaseKeyValuePairs.
+   * \param[out] out A pointer to a newly created OrtKeyValuePairs instance.
+   *
+   *  An OrtKeyValuePairs instance containing all session configuration entries.
+   *  Note: the user should call OrtApi::ReleaseKeyValuePairs.
    *
    * \since Version 1.23.
    */
-  OrtKeyValuePairs*(ORT_API_CALL* GetSessionOptionConfigEntries)(_In_ const OrtSessionOptions* options);
+  ORT_API2_STATUS(GetSessionOptionConfigEntries, _In_ const OrtSessionOptions* options, _Outptr_ OrtKeyValuePairs** out);
 };
 
 /*

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -6081,7 +6081,7 @@ struct OrtApi {
    * \return An OrtKeyValuePairs instance containing all session configuration entries.
    *         Note: the user should call OrtApi::ReleaseKeyValuePairs.
    *
-   * \since Version 1.22.
+   * \since Version 1.23.
    */
   OrtKeyValuePairs*(ORT_API_CALL* GetSessionOptionConfigEntries)(_In_ const OrtSessionOptions* options);
 };

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -6078,7 +6078,7 @@ struct OrtApi {
   /** \brief Get Session configuration entries.
    *
    * \param[in] options The session options.
-   * \return An OrtKeyValuePairs instance containing the all session config enties.
+   * \return An OrtKeyValuePairs instance containing all session configuration entries.
    *         Note: the user should call OrtApi::ReleaseKeyValuePairs.
    *
    * \since Version 1.22.

--- a/onnxruntime/core/session/abi_session_options.cc
+++ b/onnxruntime/core/session/abi_session_options.cc
@@ -278,6 +278,15 @@ ORT_API_STATUS_IMPL(OrtApis::GetSessionConfigEntry, _In_ const OrtSessionOptions
   API_IMPL_END
 }
 
+ORT_API(OrtKeyValuePairs*, OrtApis::GetSessionOptionConfigEntries, _In_ const OrtSessionOptions* options) {
+  auto& config_options = options->value.config_options.GetConfigOptionsMap();
+  auto kvps = std::make_unique<OrtKeyValuePairs>();
+  for (auto& kv : config_options) {
+    kvps->Add(kv.first.c_str(), kv.second.c_str());
+  }
+  return reinterpret_cast<OrtKeyValuePairs*>(kvps.release());
+}
+
 ORT_API_STATUS_IMPL(OrtApis::AddInitializer, _Inout_ OrtSessionOptions* options, _In_z_ const char* name,
                     _In_ const OrtValue* val) {
   API_IMPL_BEGIN

--- a/onnxruntime/core/session/abi_session_options.cc
+++ b/onnxruntime/core/session/abi_session_options.cc
@@ -278,7 +278,7 @@ ORT_API_STATUS_IMPL(OrtApis::GetSessionConfigEntry, _In_ const OrtSessionOptions
   API_IMPL_END
 }
 
-ORT_API_STATUS_IMPL(OrtApis::GetSessionOptionConfigEntries, _In_ const OrtSessionOptions* options, _Outptr_ OrtKeyValuePairs** out) {
+ORT_API_STATUS_IMPL(OrtApis::GetSessionOptionsConfigEntries, _In_ const OrtSessionOptions* options, _Outptr_ OrtKeyValuePairs** out) {
   API_IMPL_BEGIN
   if (options == nullptr) {
     return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "options is nullptr");

--- a/onnxruntime/core/session/abi_session_options.cc
+++ b/onnxruntime/core/session/abi_session_options.cc
@@ -278,16 +278,19 @@ ORT_API_STATUS_IMPL(OrtApis::GetSessionConfigEntry, _In_ const OrtSessionOptions
   API_IMPL_END
 }
 
-ORT_API(OrtKeyValuePairs*, OrtApis::GetSessionOptionConfigEntries, _In_ const OrtSessionOptions* options) {
-  if (!options) {
-    return nullptr; // Return nullptr to indicate invalid input.
+ORT_API_STATUS_IMPL(OrtApis::GetSessionOptionConfigEntries, _In_ const OrtSessionOptions* options, _Outptr_ OrtKeyValuePairs** out) {
+  API_IMPL_BEGIN
+  if (options == nullptr) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "options is nullptr");
   }
   auto& config_options = options->value.config_options.GetConfigOptionsMap();
   auto kvps = std::make_unique<OrtKeyValuePairs>();
   for (auto& kv : config_options) {
     kvps->Add(kv.first.c_str(), kv.second.c_str());
   }
-  return reinterpret_cast<OrtKeyValuePairs*>(kvps.release());
+  *out = reinterpret_cast<OrtKeyValuePairs*>(kvps.release());
+  return nullptr;
+  API_IMPL_END
 }
 
 ORT_API_STATUS_IMPL(OrtApis::AddInitializer, _Inout_ OrtSessionOptions* options, _In_z_ const char* name,

--- a/onnxruntime/core/session/abi_session_options.cc
+++ b/onnxruntime/core/session/abi_session_options.cc
@@ -279,6 +279,9 @@ ORT_API_STATUS_IMPL(OrtApis::GetSessionConfigEntry, _In_ const OrtSessionOptions
 }
 
 ORT_API(OrtKeyValuePairs*, OrtApis::GetSessionOptionConfigEntries, _In_ const OrtSessionOptions* options) {
+  if (!options) {
+    return nullptr; // Return nullptr to indicate invalid input.
+  }
   auto& config_options = options->value.config_options.GetConfigOptionsMap();
   auto kvps = std::make_unique<OrtKeyValuePairs>();
   for (auto& kv : config_options) {

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -3633,7 +3633,7 @@ static constexpr OrtApi ort_api_1_to_23 = {
 
     &OrtApis::GetTensorData,
 
-    &OrtApis::GetSessionOptionConfigEntries,
+    &OrtApis::GetSessionOptionsConfigEntries,
 };
 
 // OrtApiBase can never change as there is no way to know what version of OrtApiBase is returned by OrtGetApiBase.

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -3632,6 +3632,8 @@ static constexpr OrtApi ort_api_1_to_23 = {
     &OrtApis::ReleaseSharedAllocator,
 
     &OrtApis::GetTensorData,
+
+    &OrtApis::GetSessionOptionConfigEntries,
 };
 
 // OrtApiBase can never change as there is no way to know what version of OrtApiBase is returned by OrtGetApiBase.

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -691,5 +691,5 @@ ORT_API_STATUS_IMPL(ReleaseSharedAllocator, _In_ OrtEnv* env, _In_ const OrtEpDe
 
 ORT_API_STATUS_IMPL(GetTensorData, _In_ const OrtValue* value, _Outptr_ const void** out);
 
-ORT_API_STATUS_IMPL(GetSessionOptionConfigEntries, _In_ const OrtSessionOptions* options, _Outptr_ OrtKeyValuePairs** out);
+ORT_API_STATUS_IMPL(GetSessionOptionsConfigEntries, _In_ const OrtSessionOptions* options, _Outptr_ OrtKeyValuePairs** out);
 }  // namespace OrtApis

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -691,5 +691,5 @@ ORT_API_STATUS_IMPL(ReleaseSharedAllocator, _In_ OrtEnv* env, _In_ const OrtEpDe
 
 ORT_API_STATUS_IMPL(GetTensorData, _In_ const OrtValue* value, _Outptr_ const void** out);
 
-ORT_API(OrtKeyValuePairs*, GetSessionOptionConfigEntries, _In_ const OrtSessionOptions* options);
+ORT_API_STATUS_IMPL(GetSessionOptionConfigEntries, _In_ const OrtSessionOptions* options, _Outptr_ OrtKeyValuePairs** out);
 }  // namespace OrtApis

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -690,4 +690,6 @@ ORT_API_STATUS_IMPL(ReleaseSharedAllocator, _In_ OrtEnv* env, _In_ const OrtEpDe
                     _In_ OrtDeviceMemoryType mem_type);
 
 ORT_API_STATUS_IMPL(GetTensorData, _In_ const OrtValue* value, _Outptr_ const void** out);
+
+ORT_API(OrtKeyValuePairs*, GetSessionOptionConfigEntries, _In_ const OrtSessionOptions* options);
 }  // namespace OrtApis


### PR DESCRIPTION
### Description

Add a new ORT API `GetSessionOptionConfigEntries`.

### Motivation and Context

#24887 allows plugin-EPs to interface with ORT using a binary stable interface. #24445 allows an EP to handle the extraction of EP options from the session option configurations.  For an EP like VitisAI EP to comply with the requirements,

it is necessary for a plugin-EPs to access all config entries in a session option.

```c++
    OrtKeyValuePairs * kvps = nullptr;
    auto status = GetSessionOptionConfigEntries(session_option, &kvps);
    if(status) {
        throw status;
    }
    std::unique_ptr<OrtKeyValuePairs, void (*)(OrtKeyValuePairs*)>
        config_entries(kvps,
                       ort_api.ReleaseKeyValuePairs);
    const char* const* keys = nullptr;
    const char* const* values = nullptr;
    size_t num_keys = 0;
    // Get keys and values from the config entries
    Ort::GetApi().GetKeyValuePairs(config_entries.get(), &keys, &values, &num_keys);

    for (size_t i = 0; i < num_keys; ++i) {
        // process keys[i] and values[i]
    }
```

