### PR TITLE
Fix Sign and Clip operation on int64 tensors

### DIFF
--- a/onnxruntime/core/providers/cpu/math/clip.cc
+++ b/onnxruntime/core/providers/cpu/math/clip.cc
@@ -131,7 +131,7 @@ struct Clip::ComputeImpl {
               ConstEigenVectorMap<T>(X->Data<T>() + start, count)
                   .array()
                   .unaryExpr([=](auto x) {
-                    return std::clamp(x, min_val, max_val);
+		    return std::min(max_val, std::max(x, min_val));
                   });
         },
         0);

--- a/onnxruntime/core/providers/cpu/math/clip.cc
+++ b/onnxruntime/core/providers/cpu/math/clip.cc
@@ -129,8 +129,10 @@ struct Clip::ComputeImpl {
 
           EigenVectorMap<T>(Y->MutableData<T>() + start, count) =
               ConstEigenVectorMap<T>(X->Data<T>() + start, count)
-                  .cwiseMax(min_val)
-                  .cwiseMin(max_val);
+                  .array()
+                  .unaryExpr([=](auto x) {
+                    return std::clamp(x, min_val, max_val);
+                  });
         },
         0);
   }

--- a/onnxruntime/core/providers/cpu/math/sign.cc
+++ b/onnxruntime/core/providers/cpu/math/sign.cc
@@ -51,7 +51,9 @@ namespace sign_internal {
 template <class T>
 struct CallSignImpl {
   void operator()(const Tensor* input, Tensor* output) const {
-    EigenMap<T>(*output) = EigenMap<T>(*input).array().cwiseSign();
+    EigenMap<T>(*output) = EigenMap<T>(*input).array().unaryExpr([=](auto x) -> T {
+      return (x > 0) - (x < 0);
+    });
   }
 };
 

--- a/onnxruntime/test/python/test_clip.py
+++ b/onnxruntime/test/python/test_clip.py
@@ -1,0 +1,33 @@
+import numpy as np
+import onnx
+from onnx import TensorProto, helper
+
+import onnxruntime as ort
+
+
+def make_clip_model() -> onnx.ModelProto:
+    max_node = helper.make_node(op_type="Constant", domain="ai.onnx", inputs=[], outputs=["max"], value_int=0)
+    clip_node = helper.make_node(
+        op_type="Clip",
+        domain="ai.onnx",
+        inputs=["x", "", "max"],
+        outputs=["y"],
+    )
+
+    graph = helper.make_graph(
+        nodes=[max_node, clip_node],
+        name="TestClip",
+        inputs=[helper.make_value_info("x", type_proto=helper.make_tensor_type_proto(TensorProto.INT64, [2]))],
+        outputs=[helper.make_value_info("y", type_proto=helper.make_tensor_type_proto(TensorProto.INT64, [2]))],
+    )
+
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
+    return model
+
+
+def test_clip():
+    sess = ort.InferenceSession(make_clip_model().SerializeToString())
+    x = np.asarray([2147483649, 2147483649], np.int64)
+    (res,) = sess.run(None, {"x": x})
+
+    np.testing.assert_array_equal(res, np.clip(x, min=None, max=0))

--- a/onnxruntime/test/python/test_sign.py
+++ b/onnxruntime/test/python/test_sign.py
@@ -1,0 +1,32 @@
+import numpy as np
+import onnx
+from onnx import TensorProto, helper
+
+import onnxruntime as ort
+
+
+def make_sign_model() -> onnx.ModelProto:
+    node = helper.make_node(
+        op_type="Sign",
+        domain="ai.onnx",
+        inputs=["x"],
+        outputs=["y"],
+    )
+
+    graph = helper.make_graph(
+        nodes=[node],
+        name="TestSign",
+        inputs=[helper.make_value_info("x", type_proto=helper.make_tensor_type_proto(TensorProto.INT64, [2]))],
+        outputs=[helper.make_value_info("y", type_proto=helper.make_tensor_type_proto(TensorProto.INT64, [2]))],
+    )
+
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
+    return model
+
+
+def test_sign():
+    sess = ort.InferenceSession(make_sign_model().SerializeToString())
+    x = np.asarray([2147483649, 2147483649], np.int64)
+    (res,) = sess.run(None, {"x": x})
+
+    np.testing.assert_array_equal(res, np.sign(x))


### PR DESCRIPTION
### Description
The Clip and sign operators exhibit buggy behavior for some int64 values on Linux and Windows (see added test cases). Using [Eigen's Array-API](https://eigen.tuxfamily.org/dox/group__TutorialArrayClass.html#title0) appears to mitigate the issue. A failing test case on CI can be found [here](https://github.com/cbourjau/onnxruntime/actions/runs/16053021996/job/45300270472) (uses the conda-forge toolchain). 