### PR TITLE
`OrtKeyValuePairs` updates

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -5088,6 +5088,8 @@ struct OrtApi {
 
   /** \brief Add a key-value pair to the OrtKeyValuePairs instance.
    *
+   * If a pair with the same key already exists, it is overwritten.
+   *
    * \param[in] kvps OrtKeyValuePairs instance.
    * \param[in] key Key to be added.
    * \param[in] value Value to be added.

--- a/onnxruntime/core/framework/allocator.cc
+++ b/onnxruntime/core/framework/allocator.cc
@@ -31,27 +31,28 @@ Status OrtArenaCfg::FromKeyValuePairs(const OrtKeyValuePairs& kvps, OrtArenaCfg&
     return Status::OK();
   };
 
-  if (auto it = kvps.entries.find(ConfigKeyNames::ArenaExtendStrategy); it != kvps.entries.end()) {
+  const auto& kvps_entries = kvps.Entries();
+  if (auto it = kvps_entries.find(ConfigKeyNames::ArenaExtendStrategy); it != kvps_entries.end()) {
     ORT_RETURN_IF_ERROR(from_string(it->first, it->second, cfg.arena_extend_strategy));
   }
 
-  if (auto it = kvps.entries.find(ConfigKeyNames::InitialChunkSizeBytes); it != kvps.entries.end()) {
+  if (auto it = kvps_entries.find(ConfigKeyNames::InitialChunkSizeBytes); it != kvps_entries.end()) {
     ORT_RETURN_IF_ERROR(from_string(it->first, it->second, cfg.initial_chunk_size_bytes));
   }
 
-  if (auto it = kvps.entries.find(ConfigKeyNames::MaxDeadBytesPerChunk); it != kvps.entries.end()) {
+  if (auto it = kvps_entries.find(ConfigKeyNames::MaxDeadBytesPerChunk); it != kvps_entries.end()) {
     ORT_RETURN_IF_ERROR(from_string(it->first, it->second, cfg.max_dead_bytes_per_chunk));
   }
 
-  if (auto it = kvps.entries.find(ConfigKeyNames::InitialGrowthChunkSizeBytes); it != kvps.entries.end()) {
+  if (auto it = kvps_entries.find(ConfigKeyNames::InitialGrowthChunkSizeBytes); it != kvps_entries.end()) {
     ORT_RETURN_IF_ERROR(from_string(it->first, it->second, cfg.initial_growth_chunk_size_bytes));
   }
 
-  if (auto it = kvps.entries.find(ConfigKeyNames::MaxPowerOfTwoExtendBytes); it != kvps.entries.end()) {
+  if (auto it = kvps_entries.find(ConfigKeyNames::MaxPowerOfTwoExtendBytes); it != kvps_entries.end()) {
     ORT_RETURN_IF_ERROR(from_string(it->first, it->second, cfg.max_power_of_two_extend_bytes));
   }
 
-  if (auto it = kvps.entries.find(ConfigKeyNames::MaxMem); it != kvps.entries.end()) {
+  if (auto it = kvps_entries.find(ConfigKeyNames::MaxMem); it != kvps_entries.end()) {
     ORT_RETURN_IF_ERROR(from_string(it->first, it->second, cfg.max_mem));
   }
 

--- a/onnxruntime/core/platform/windows/device_discovery.cc
+++ b/onnxruntime/core/platform/windows/device_discovery.cc
@@ -581,7 +581,7 @@ std::unordered_set<OrtHardwareDevice> DeviceDiscovery::DiscoverDevicesForPlatfor
         << ", vendor:" << ortdevice.vendor
         << ", type:" << std::dec << static_cast<int>(ortdevice.type)
         << ", metadata: [";
-    for (auto& [key, value] : ortdevice.metadata.entries) {
+    for (auto& [key, value] : ortdevice.metadata.Entries()) {
       oss << key << "=" << value << ", ";
     }
 

--- a/onnxruntime/core/session/abi_devices.h
+++ b/onnxruntime/core/session/abi_devices.h
@@ -26,7 +26,7 @@ struct OrtHardwareDevice {
     onnxruntime::HashCombine(hd.vendor_id, h);
     onnxruntime::HashCombine(hd.vendor, h);
     onnxruntime::HashCombine(hd.type, h);
-    for (const auto& [key, value] : hd.metadata.entries) {
+    for (const auto& [key, value] : hd.metadata.Entries()) {
       onnxruntime::HashCombine(key, h);
       onnxruntime::HashCombine(value, h);
     }
@@ -51,8 +51,7 @@ struct equal_to<OrtHardwareDevice> {
            lhs.vendor_id == rhs.vendor_id &&
            lhs.device_id == rhs.device_id &&
            lhs.vendor == rhs.vendor &&
-           lhs.metadata.keys == rhs.metadata.keys &&
-           lhs.metadata.values == rhs.metadata.values;
+           lhs.metadata.Entries() == rhs.metadata.Entries();
   }
 };
 }  // namespace std

--- a/onnxruntime/core/session/abi_key_value_pairs.h
+++ b/onnxruntime/core/session/abi_key_value_pairs.h
@@ -39,10 +39,6 @@ struct OrtKeyValuePairs {
     Sync();
   }
 
-  void CopyFromMap(const std::unordered_map<std::string, std::string>& src) {
-    CopyFromMap(std::map<std::string, std::string>(src.begin(), src.end()));
-  }
-
   void Add(const char* key, const char* value) {
     // ignore if either are nullptr.
     if (key && value) {
@@ -50,17 +46,16 @@ struct OrtKeyValuePairs {
     }
   }
 
-  void Add(const std::string& key, const std::string& value) {
+  void Add(std::string key, std::string value) {
     if (key.empty()) {  // ignore empty keys
       return;
     }
 
-    auto iter_inserted = entries_.insert({key, value});
-    bool inserted = iter_inserted.second;
+    auto [it, inserted] = entries_.insert_or_assign(std::move(key), std::move(value));
     if (inserted) {
-      const auto& entry = *iter_inserted.first;
-      keys_.push_back(entry.first.c_str());
-      values_.push_back(entry.second.c_str());
+      const auto& [entry_key, entry_value] = *it;
+      keys_.push_back(entry_key.c_str());
+      values_.push_back(entry_value.c_str());
     } else {
       // rebuild is easier and changing an entry is not expected to be a common case.
       Sync();

--- a/onnxruntime/core/session/abi_key_value_pairs.h
+++ b/onnxruntime/core/session/abi_key_value_pairs.h
@@ -4,20 +4,45 @@
 #pragma once
 
 #include <algorithm>
+#include <map>
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <vector>
+
+#include "gsl/gsl"
 
 struct OrtKeyValuePairs {
-  std::unordered_map<std::string, std::string> entries;
-  // members to make returning all key/value entries via the C API easier
-  std::vector<const char*> keys;
-  std::vector<const char*> values;
+  OrtKeyValuePairs() = default;
 
-  void Copy(const std::unordered_map<std::string, std::string>& src) {
-    entries = src;
+  OrtKeyValuePairs(const OrtKeyValuePairs& other) {
+    CopyFromMap(other.entries_);
+  }
+
+  OrtKeyValuePairs(OrtKeyValuePairs&& other) : OrtKeyValuePairs{} {
+    swap(*this, other);
+  }
+
+  OrtKeyValuePairs& operator=(OrtKeyValuePairs other) {  // handles copy and move assignment
+    swap(*this, other);
+    return *this;
+  }
+
+  friend void swap(OrtKeyValuePairs& a, OrtKeyValuePairs& b) {
+    using std::swap;
+    swap(a.entries_, b.entries_);
+    swap(a.keys_, b.keys_);
+    swap(a.values_, b.values_);
+  }
+
+  void CopyFromMap(std::map<std::string, std::string> src) {
+    entries_ = std::move(src);
     Sync();
   }
+
+  void CopyFromMap(const std::unordered_map<std::string, std::string>& src) {
+    CopyFromMap(std::map<std::string, std::string>(src.begin(), src.end()));
+  }
+
   void Add(const char* key, const char* value) {
     // ignore if either are nullptr.
     if (key && value) {
@@ -30,12 +55,12 @@ struct OrtKeyValuePairs {
       return;
     }
 
-    auto iter_inserted = entries.insert({key, value});
+    auto iter_inserted = entries_.insert({key, value});
     bool inserted = iter_inserted.second;
     if (inserted) {
       const auto& entry = *iter_inserted.first;
-      keys.push_back(entry.first.c_str());
-      values.push_back(entry.second.c_str());
+      keys_.push_back(entry.first.c_str());
+      values_.push_back(entry.second.c_str());
     } else {
       // rebuild is easier and changing an entry is not expected to be a common case.
       Sync();
@@ -48,27 +73,47 @@ struct OrtKeyValuePairs {
       return;
     }
 
-    auto iter = entries.find(key);
-    if (iter != entries.end()) {
-      auto key_iter = std::find(keys.begin(), keys.end(), iter->first.c_str());
-      // there should only ever be one matching entry, and keys and values should be in sync
-      if (key_iter != keys.end()) {
-        auto idx = std::distance(keys.begin(), key_iter);
-        keys.erase(key_iter);
-        values.erase(values.begin() + idx);
+    auto iter = entries_.find(key);
+    if (iter != entries_.end()) {
+      auto key_iter = std::find(keys_.begin(), keys_.end(), iter->first.c_str());
+      // there should only ever be one matching entry, and keys_ and values_ should be in sync
+      if (key_iter != keys_.end()) {
+        auto idx = std::distance(keys_.begin(), key_iter);
+        keys_.erase(key_iter);
+        values_.erase(values_.begin() + idx);
       }
 
-      entries.erase(iter);
+      entries_.erase(iter);
     }
+  }
+
+  const std::map<std::string, std::string>& Entries() const {
+    return entries_;
+  }
+
+  gsl::span<const char* const> Keys() const {
+    return keys_;
+  }
+
+  gsl::span<const char* const> Values() const {
+    return values_;
   }
 
  private:
   void Sync() {
-    keys.clear();
-    values.clear();
-    for (const auto& entry : entries) {
-      keys.push_back(entry.first.c_str());
-      values.push_back(entry.second.c_str());
+    keys_.clear();
+    values_.clear();
+    for (const auto& entry : entries_) {
+      keys_.push_back(entry.first.c_str());
+      values_.push_back(entry.second.c_str());
     }
   }
+
+  // Note: Use std::map so that we can iterate through entries in a deterministic order.
+  std::map<std::string, std::string> entries_;
+
+  // members to make returning all key/value entries via the C API easier
+  // Note: The elements point to strings owned by `entries_`.
+  std::vector<const char*> keys_;
+  std::vector<const char*> values_;
 };

--- a/onnxruntime/core/session/allocator_adapters.cc
+++ b/onnxruntime/core/session/allocator_adapters.cc
@@ -42,7 +42,7 @@ OrtAllocatorImplWrappingIAllocator::OrtAllocatorImplWrappingIAllocator(onnxrunti
       API_IMPL_BEGIN
       auto kvp = std::make_unique<OrtKeyValuePairs>();
       auto stats_map = static_cast<const OrtAllocatorImplWrappingIAllocator*>(this_)->Stats();
-      kvp->Copy(stats_map);
+      kvp->CopyFromMap(stats_map);
       *stats = reinterpret_cast<OrtKeyValuePairs*>(kvp.release());
       return nullptr;
       API_IMPL_END
@@ -130,25 +130,27 @@ void IAllocatorImplWrappingOrtAllocator::GetStats(AllocatorStats* stats) {
 
     std::unique_ptr<OrtKeyValuePairs*, decltype(release_fn)> kvp_guard(&kvps, release_fn);
 
-    for (size_t i = 0; i < kvps->keys.size(); ++i) {
-      if (strcmp(kvps->keys[i], "Limit") == 0) {
-        stats->bytes_limit = std::stoll(kvps->values[i]);
-      } else if (strcmp(kvps->keys[i], "InUse") == 0) {
-        stats->bytes_in_use = std::stoll(kvps->values[i]);
-      } else if (strcmp(kvps->keys[i], "TotalAllocated") == 0) {
-        stats->total_allocated_bytes = std::stoll(kvps->values[i]);
-      } else if (strcmp(kvps->keys[i], "MaxInUse") == 0) {
-        stats->max_bytes_in_use = std::stoll(kvps->values[i]);
-      } else if (strcmp(kvps->keys[i], "NumAllocs") == 0) {
-        stats->num_allocs = std::stoll(kvps->values[i]);
-      } else if (strcmp(kvps->keys[i], "NumReserves") == 0) {
-        stats->num_reserves = std::stoll(kvps->values[i]);
-      } else if (strcmp(kvps->keys[i], "NumArenaExtensions") == 0) {
-        stats->num_arena_extensions = std::stoll(kvps->values[i]);
-      } else if (strcmp(kvps->keys[i], "NumArenaShrinkages") == 0) {
-        stats->num_arena_shrinkages = std::stoll(kvps->values[i]);
-      } else if (strcmp(kvps->keys[i], "MaxAllocSize") == 0) {
-        stats->max_alloc_size = std::stoll(kvps->values[i]);
+    const auto keys = kvps->Keys(), values = kvps->Values();
+
+    for (size_t i = 0; i < keys.size(); ++i) {
+      if (strcmp(keys[i], "Limit") == 0) {
+        stats->bytes_limit = std::stoll(values[i]);
+      } else if (strcmp(keys[i], "InUse") == 0) {
+        stats->bytes_in_use = std::stoll(values[i]);
+      } else if (strcmp(keys[i], "TotalAllocated") == 0) {
+        stats->total_allocated_bytes = std::stoll(values[i]);
+      } else if (strcmp(keys[i], "MaxInUse") == 0) {
+        stats->max_bytes_in_use = std::stoll(values[i]);
+      } else if (strcmp(keys[i], "NumAllocs") == 0) {
+        stats->num_allocs = std::stoll(values[i]);
+      } else if (strcmp(keys[i], "NumReserves") == 0) {
+        stats->num_reserves = std::stoll(values[i]);
+      } else if (strcmp(keys[i], "NumArenaExtensions") == 0) {
+        stats->num_arena_extensions = std::stoll(values[i]);
+      } else if (strcmp(keys[i], "NumArenaShrinkages") == 0) {
+        stats->num_arena_shrinkages = std::stoll(values[i]);
+      } else if (strcmp(keys[i], "MaxAllocSize") == 0) {
+        stats->max_alloc_size = std::stoll(values[i]);
       }
     }
   }

--- a/onnxruntime/core/session/allocator_adapters.cc
+++ b/onnxruntime/core/session/allocator_adapters.cc
@@ -41,8 +41,8 @@ OrtAllocatorImplWrappingIAllocator::OrtAllocatorImplWrappingIAllocator(onnxrunti
         [](const OrtAllocator* this_, OrtKeyValuePairs** stats) noexcept -> OrtStatusPtr {
       API_IMPL_BEGIN
       auto kvp = std::make_unique<OrtKeyValuePairs>();
-      auto stats_map = static_cast<const OrtAllocatorImplWrappingIAllocator*>(this_)->Stats();
-      kvp->CopyFromMap(stats_map);
+      const auto& stats_map = static_cast<const OrtAllocatorImplWrappingIAllocator*>(this_)->Stats();
+      kvp->CopyFromMap(std::map<std::string, std::string>(stats_map.begin(), stats_map.end()));
       *stats = reinterpret_cast<OrtKeyValuePairs*>(kvp.release());
       return nullptr;
       API_IMPL_END

--- a/onnxruntime/core/session/ep_library_internal.cc
+++ b/onnxruntime/core/session/ep_library_internal.cc
@@ -83,7 +83,7 @@ std::unique_ptr<EpLibraryInternal> EpLibraryInternal::CreateDmlEp() {
         // TODO: Should we ignore a user provided 'device_id' when they select an OrtEpDevice as that is associated with
         //       a specific device.
         //       How would we know what options should not allow user overrides if set in OrtEpDevice?
-        if (auto it = device.metadata.entries.find("DxgiAdapterNumber"); it != device.metadata.entries.end()) {
+        if (auto it = device.metadata.Entries().find("DxgiAdapterNumber"); it != device.metadata.Entries().end()) {
           ep_options = std::make_unique<OrtKeyValuePairs>();
           ep_options->Add("device_id", it->second.c_str());
         }

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -3019,7 +3019,8 @@ ORT_API(void, OrtApis::AddKeyValuePair, _In_ OrtKeyValuePairs* kvps,
 ORT_API(const char*, OrtApis::GetKeyValue, _In_ const OrtKeyValuePairs* kvps, _In_ const char* key) {
   const char* value = nullptr;
 
-  if (auto entry = kvps->entries.find(key); entry != kvps->entries.end()) {
+  const auto& entries = kvps->Entries();
+  if (auto entry = entries.find(key); entry != entries.end()) {
     value = entry->second.c_str();
   }
 
@@ -3028,9 +3029,9 @@ ORT_API(const char*, OrtApis::GetKeyValue, _In_ const OrtKeyValuePairs* kvps, _I
 
 ORT_API(void, OrtApis::GetKeyValuePairs, _In_ const OrtKeyValuePairs* kvps,
         _Outptr_ const char* const** keys, _Outptr_ const char* const** values, _Out_ size_t* num_entries) {
-  *keys = kvps->keys.data();
-  *values = kvps->values.data();
-  *num_entries = kvps->entries.size();
+  *keys = kvps->Keys().data();
+  *values = kvps->Values().data();
+  *num_entries = kvps->Entries().size();
 }
 
 ORT_API(void, OrtApis::RemoveKeyValuePair, _Frees_ptr_opt_ OrtKeyValuePairs* kvps, _In_ const char* key) {

--- a/onnxruntime/core/session/provider_policy_context.cc
+++ b/onnxruntime/core/session/provider_policy_context.cc
@@ -30,7 +30,7 @@ bool IsDiscreteDevice(const OrtEpDevice* d) {
     return false;
   }
 
-  const auto& entries = d->device->metadata.entries;
+  const auto& entries = d->device->metadata.Entries();
   if (auto it = entries.find("Discrete"); it != entries.end()) {
     return it->second == "1";
   }
@@ -366,7 +366,7 @@ Status ProviderPolicyContext::AddEpDefaultOptionsToSession(InferenceSession& ses
   auto& config_options = sess.GetMutableSessionOptions().config_options;
   for (auto device : devices) {
     const std::string ep_options_prefix = OrtSessionOptions::GetProviderOptionPrefix(device->ep_name.c_str());
-    for (const auto& [key, value] : device->ep_options.entries) {
+    for (const auto& [key, value] : device->ep_options.Entries()) {
       const std::string option_key = ep_options_prefix + key;
       // preserve user-provided options as they override any defaults the EP factory specified earlier
       if (config_options.configurations.find(option_key) == config_options.configurations.end()) {

--- a/onnxruntime/core/session/utils.cc
+++ b/onnxruntime/core/session/utils.cc
@@ -60,7 +60,7 @@ Status TestAutoSelectEPsImpl(const Environment& env, InferenceSession& sess, con
     // add ep_options to SessionOptions with prefix.
     // preserve any user provided values.
     const std::string ep_options_prefix = OrtSessionOptions::GetProviderOptionPrefix(ep_device->ep_name.c_str());
-    for (const auto& [key, value] : ep_device->ep_options.entries) {
+    for (const auto& [key, value] : ep_device->ep_options.Entries()) {
       auto prefixed_key = ep_options_prefix + key;
       if (session_options.config_options.configurations.count(key) == 0) {
         // add the default value with prefix
@@ -353,7 +353,7 @@ Status CreateIExecutionProviderFactoryForEpDevices(const Environment& env,
     // first add the default values with prefix followed by user specified values so those win
     const std::string prefix = OrtSessionOptions::GetProviderOptionPrefix(ep_device->ep_name.c_str());
     auto& config_options = session_options.config_options;
-    for (const auto& [key, value] : ep_device->ep_options.entries) {
+    for (const auto& [key, value] : ep_device->ep_options.Entries()) {
       ORT_RETURN_IF_ERROR(config_options.AddConfigEntry((prefix + key).c_str(), value.c_str()));
     }
 

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -1854,10 +1854,10 @@ static OrtStatus* ORT_API_CALL PyEpSelectionPolicyWrapper(_In_ const OrtEpDevice
                                                           _In_ void* state) {
   PyEpSelectionDelegate* actual_delegate = reinterpret_cast<PyEpSelectionDelegate*>(state);
   std::vector<const OrtEpDevice*> py_ep_devices(ep_devices, ep_devices + num_devices);
-  std::unordered_map<std::string, std::string> py_model_metadata =
-      model_metadata ? model_metadata->entries : std::unordered_map<std::string, std::string>{};
-  std::unordered_map<std::string, std::string> py_runtime_metadata =
-      runtime_metadata ? runtime_metadata->entries : std::unordered_map<std::string, std::string>{};
+  std::map<std::string, std::string> py_model_metadata =
+      model_metadata ? model_metadata->Entries() : std::map<std::string, std::string>{};
+  std::map<std::string, std::string> py_runtime_metadata =
+      runtime_metadata ? runtime_metadata->Entries() : std::map<std::string, std::string>{};
 
   *num_selected = 0;
   std::vector<const OrtEpDevice*> py_selected;
@@ -1986,8 +1986,8 @@ void addObjectMethods(py::module& m, ExecutionProviderRegistrationFn ep_registra
           R"pbdoc(Hardware device's unique identifier.)pbdoc")
       .def_property_readonly(
           "metadata",
-          [](OrtHardwareDevice* hw_device) -> std::unordered_map<std::string, std::string> {
-            return hw_device->metadata.entries;
+          [](OrtHardwareDevice* hw_device) -> std::map<std::string, std::string> {
+            return hw_device->metadata.Entries();
           },
           R"pbdoc(Hardware device's metadata as string key/value pairs.)pbdoc");
 
@@ -2004,14 +2004,14 @@ for model inference.)pbdoc");
           R"pbdoc(The execution provider's vendor name.)pbdoc")
       .def_property_readonly(
           "ep_metadata",
-          [](OrtEpDevice* ep_device) -> std::unordered_map<std::string, std::string> {
-            return ep_device->ep_metadata.entries;
+          [](OrtEpDevice* ep_device) -> std::map<std::string, std::string> {
+            return ep_device->ep_metadata.Entries();
           },
           R"pbdoc(The execution provider's additional metadata for the OrtHardwareDevice.)pbdoc")
       .def_property_readonly(
           "ep_options",
-          [](OrtEpDevice* ep_device) -> std::unordered_map<std::string, std::string> {
-            return ep_device->ep_options.entries;
+          [](OrtEpDevice* ep_device) -> std::map<std::string, std::string> {
+            return ep_device->ep_options.Entries();
           },
           R"pbdoc(The execution provider's options used to configure the provider to use the OrtHardwareDevice.)pbdoc")
       .def_property_readonly(

--- a/onnxruntime/python/onnxruntime_pybind_state_common.h
+++ b/onnxruntime/python/onnxruntime_pybind_state_common.h
@@ -248,10 +248,11 @@ extern OrtDevice::DeviceId cuda_device_id;
 extern size_t gpu_mem_limit;
 
 #if !defined(ORT_MINIMAL_BUILD)
-using PyEpSelectionDelegate = std::function<std::vector<const OrtEpDevice*>(const std::vector<const OrtEpDevice*>& ep_devices,
-                                                                            const std::unordered_map<std::string, std::string>& model_metadata,
-                                                                            const std::unordered_map<std::string, std::string>& runtime_metadata,
-                                                                            size_t max_selections)>;
+using PyEpSelectionDelegate =
+    std::function<std::vector<const OrtEpDevice*>(const std::vector<const OrtEpDevice*>& ep_devices,
+                                                  const std::map<std::string, std::string>& model_metadata,
+                                                  const std::map<std::string, std::string>& runtime_metadata,
+                                                  size_t max_selections)>;
 #endif
 
 // Thin wrapper over internal C OrtSessionOptions to store additional state.

--- a/onnxruntime/test/autoep/test_autoep_selection.cc
+++ b/onnxruntime/test/autoep/test_autoep_selection.cc
@@ -107,7 +107,7 @@ static void TestInference(Ort::Env& env, const std::basic_string<ORTCHAR_T>& mod
     // C API. Test the C++ API because if it works the C API must also work.
     // ASSERT_ORTSTATUS_OK(Ort::GetApi().SessionOptionsAppendExecutionProvider_V2(
     //    session_options, env, devices.data(), devices.size(),
-    //    provider_options.keys.data(), provider_options.values.data(), provider_options.entries.size()));
+    //    provider_options.Keys().data(), provider_options.Values().data(), provider_options.Entries().size()));
     std::vector<Ort::ConstEpDevice> ep_devices;
     ep_devices.reserve(devices.size());
     for (const auto* device : devices) {
@@ -370,7 +370,7 @@ static OrtStatus* ORT_API_CALL PolicyDelegate(_In_ const OrtEpDevice** ep_device
     return Ort::GetApi().CreateStatus(ORT_INVALID_ARGUMENT, "Expected to be able to select 2 devices.");
   }
 
-  if (model_metadata->entries.empty()) {
+  if (model_metadata->Entries().empty()) {
     return Ort::GetApi().CreateStatus(ORT_INVALID_ARGUMENT, "Model metadata was empty.");
   }
 

--- a/onnxruntime/test/framework/key_value_pairs_test.cc
+++ b/onnxruntime/test/framework/key_value_pairs_test.cc
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/session/abi_key_value_pairs.h"
+
+#include <algorithm>
+#include <iterator>
+
+#include "gtest/gtest.h"
+
+namespace onnxruntime::test {
+
+namespace {
+
+// Verify that the OrtKeyValuePairs internal containers are all consistent.
+void CheckConsistency(const OrtKeyValuePairs& kvps) {
+  ASSERT_EQ(kvps.Keys().size(), kvps.Entries().size());
+  ASSERT_EQ(kvps.Values().size(), kvps.Entries().size());
+
+  for (const auto& [k, v] : kvps.Entries()) {
+    auto key_it = std::find(kvps.Keys().begin(), kvps.Keys().end(), k.c_str());
+    ASSERT_NE(key_it, kvps.Keys().end());
+
+    const auto entry_idx = std::distance(kvps.Keys().begin(), key_it);
+    ASSERT_EQ(kvps.Values()[entry_idx], v.c_str());
+  }
+}
+
+}  // namespace
+
+TEST(OrtKeyValuePairsTest, BasicUsage) {
+  const auto kvp_entry_map = std::map<std::string, std::string>{
+      {"a", "1"}, {"b", "2"}, {"c", "3"}};
+
+  OrtKeyValuePairs kvps{};
+  kvps.CopyFromMap(kvp_entry_map);
+  CheckConsistency(kvps);
+  ASSERT_EQ(kvps.Entries(), kvp_entry_map);
+
+  kvps.Add("d", "4");
+  CheckConsistency(kvps);
+  ASSERT_EQ(kvps.Entries().size(), 4);
+
+  kvps.Remove("c");
+  CheckConsistency(kvps);
+  ASSERT_EQ(kvps.Entries().size(), 3);
+}
+
+TEST(OrtKeyValuePairsTest, CopyAndMove) {
+  const auto kvp_entry_map = std::map<std::string, std::string>{
+      {"a", "1"}, {"b", "2"}, {"c", "3"}};
+
+  OrtKeyValuePairs kvps0{};
+  kvps0.CopyFromMap(kvp_entry_map);
+  CheckConsistency(kvps0);
+
+  OrtKeyValuePairs kvps1 = kvps0;
+  CheckConsistency(kvps1);
+  ASSERT_EQ(kvps1.Entries(), kvps0.Entries());
+
+  OrtKeyValuePairs kvps2 = std::move(kvps1);
+  CheckConsistency(kvps1);
+  CheckConsistency(kvps2);
+  ASSERT_TRUE(kvps1.Entries().empty());
+  ASSERT_EQ(kvps2.Entries(), kvps0.Entries());
+}
+
+TEST(OrtKeyValuePairsTest, Overwrite) {
+  OrtKeyValuePairs kvps{};
+
+  kvps.Add("a", "1");
+  CheckConsistency(kvps);
+
+  kvps.Add("a", "2");
+  CheckConsistency(kvps);
+  ASSERT_EQ(kvps.Values().size(), 1);
+  ASSERT_STREQ(kvps.Values()[0], "2");
+}
+
+TEST(OrtKeyValuePairsTest, IgnoredInput) {
+  OrtKeyValuePairs kvps{};
+
+  kvps.Add(nullptr, "1");
+  CheckConsistency(kvps);
+  ASSERT_EQ(kvps.Entries().size(), size_t{0});
+
+  kvps.Add("a", nullptr);
+  CheckConsistency(kvps);
+  ASSERT_EQ(kvps.Entries().size(), size_t{0});
+
+  kvps.Add("", "1");  // empty key is ignored
+  CheckConsistency(kvps);
+  ASSERT_EQ(kvps.Entries().size(), size_t{0});
+}
+
+}  // namespace onnxruntime::test


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

- Change the entries container type from `std::unordered_map` to `std::map`. This enables deterministic iteration order.

- Enforce internal container state consistency. `OrtKeyValuePairs` has several internal containers that must stay consistent. Previously, the internal containers were public. This change makes them private and also fixes the copy/move behavior.

- Add unit tests.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Some fixes and improvements.