### PR TITLE
Exclude EPContext Op from Common Subexpression Elimination graph optimization

### DIFF
--- a/onnxruntime/core/optimizer/common_subexpression_elimination.cc
+++ b/onnxruntime/core/optimizer/common_subexpression_elimination.cc
@@ -421,7 +421,13 @@ Status CommonSubexpressionElimination::ApplyImpl(Graph& graph, bool& modified, i
 
   for (NodeIndex node_index : node_topology_list) {
     Node* node = graph.GetNode(node_index);
-    if (node == nullptr)
+
+    // In the context of a model containing EPContext nodes, it's highly unlikely that two EPContext nodes will
+    // procude the same results.
+    // Furthermore, the EquivalenceClass constructor includes the node and all its attributes in the hash calculation,
+    // which can be particularly time-consuming when the "ep_cache_context" attribute contains a large binary blob.
+    // Therefore, EPContext nodes are excluded from this process.
+    if (node == nullptr || node->OpType() == "EPContext")
       continue;
 
     ORT_RETURN_IF_ERROR(Recurse(*node, modified, graph_level, logger));
@@ -470,8 +476,14 @@ Status CommonSubexpressionElimination::ApplyImpl(Graph& graph, bool& modified, i
   graph_outputs.insert(graph_viewer.GetOutputs().begin(), graph_viewer.GetOutputs().end());
 
   for (NodeIndex node_index : node_topology_list) {
+
     Node* node = graph.GetNode(node_index);
-    if (node == nullptr)
+    // In the context of a model containing EPContext nodes, it's highly unlikely that two EPContext nodes will
+    // procude the same results.
+    // Furthermore, the EquivalenceClass constructor includes the node and all its attributes in the hash calculation,
+    // which can be particularly time-consuming when the "ep_cache_context" attribute contains a large binary blob.
+    // Therefore, EPContext nodes are excluded from this process.
+    if (node == nullptr || node->OpType() == "EPContext")
       continue;
 
     bool node_output_replaced = false;

--- a/onnxruntime/core/optimizer/common_subexpression_elimination.cc
+++ b/onnxruntime/core/optimizer/common_subexpression_elimination.cc
@@ -423,7 +423,7 @@ Status CommonSubexpressionElimination::ApplyImpl(Graph& graph, bool& modified, i
     Node* node = graph.GetNode(node_index);
 
     // In the context of a model containing EPContext nodes, it's highly unlikely that two EPContext nodes will
-    // procude the same results.
+    // produce the same results.
     // Furthermore, the EquivalenceClass constructor includes the node and all its attributes in the hash calculation,
     // which can be particularly time-consuming when the "ep_cache_context" attribute contains a large binary blob.
     // Therefore, EPContext nodes are excluded from this process.
@@ -479,7 +479,7 @@ Status CommonSubexpressionElimination::ApplyImpl(Graph& graph, bool& modified, i
 
     Node* node = graph.GetNode(node_index);
     // In the context of a model containing EPContext nodes, it's highly unlikely that two EPContext nodes will
-    // procude the same results.
+    // produce the same results.
     // Furthermore, the EquivalenceClass constructor includes the node and all its attributes in the hash calculation,
     // which can be particularly time-consuming when the "ep_cache_context" attribute contains a large binary blob.
     // Therefore, EPContext nodes are excluded from this process.


### PR DESCRIPTION
In the context of a model containing EPContext nodes, it's highly unlikely that two EPContext nodes will produce the same results.
Furthermore, the EquivalenceClass constructor includes the node and all its attributes in the hash calculation, which can be particularly time-consuming when the "ep_cache_context" attribute contains a large binary blob.

Therefore, we exclude EPContext op from CSE.


