### PR TITLE
FIX c++17 compatibility in backend_utils.h

### DIFF
--- a/onnxruntime/core/providers/openvino/backend_utils.h
+++ b/onnxruntime/core/providers/openvino/backend_utils.h
@@ -27,7 +27,7 @@
 
 namespace onnxruntime {
 namespace openvino_ep {
-constexpr std::string log_tag = "[OpenVINO-EP] ";
+inline const std::string log_tag = "[OpenVINO-EP] ";
 
 struct ParameterShape {
   using ort_shape_t = std::vector<int64_t>;


### PR DESCRIPTION
backward compatible `std::string log_tag` definition

This allows compiling with c++17, tested in Debug and Release on Windows

