### PR TITLE
Add a new operator attribute type `ORT_OP_ATTR_BYTES` to the ORT C API

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -272,6 +272,7 @@ typedef enum OrtOpAttrType {
   ORT_OP_ATTR_FLOATS,
   ORT_OP_ATTR_STRING,
   ORT_OP_ATTR_STRINGS,
+  ORT_OP_ATTR_BYTES,
 } OrtOpAttrType;
 
 //! @}

--- a/onnxruntime/core/session/custom_ops.cc
+++ b/onnxruntime/core/session/custom_ops.cc
@@ -453,7 +453,7 @@ ORT_API_STATUS_IMPL(OrtApis::ReadOpAttr, _In_ const OrtOpAttr* op_attr, _In_ Ort
         const auto& s = attr->s();
         if (len < s.size()) {
           ret = OrtApis::CreateStatus(OrtErrorCode::ORT_INVALID_ARGUMENT,
-                                      "Size of data not large enough to hold the string.");
+                                      "Size of data not large enough to hold the byte sequence.");
         } else {
           char* output_c = reinterpret_cast<char*>(data);
           memcpy(output_c, s.data(), s.size());

--- a/onnxruntime/core/session/custom_ops.cc
+++ b/onnxruntime/core/session/custom_ops.cc
@@ -456,9 +456,7 @@ ORT_API_STATUS_IMPL(OrtApis::ReadOpAttr, _In_ const OrtOpAttr* op_attr, _In_ Ort
                                       "Size of data not large enough to hold the string.");
         } else {
           char* output_c = reinterpret_cast<char*>(data);
-          for (char c : s) {
-            *output_c++ = c;
-          }
+          memcpy(output_c, s.data(), s.size());
         }
         *out = s.size();
         break;

--- a/onnxruntime/core/session/custom_ops.cc
+++ b/onnxruntime/core/session/custom_ops.cc
@@ -449,6 +449,20 @@ ORT_API_STATUS_IMPL(OrtApis::ReadOpAttr, _In_ const OrtOpAttr* op_attr, _In_ Ort
         *out = s.size() + 1;
         break;
       }
+      case OrtOpAttrType::ORT_OP_ATTR_BYTES: {
+        const auto& s = attr->s();
+        if (len < s.size()) {
+          ret = OrtApis::CreateStatus(OrtErrorCode::ORT_INVALID_ARGUMENT,
+                                      "Size of data not large enough to hold the string.");
+        } else {
+          char* output_c = reinterpret_cast<char*>(data);
+          for (char c : s) {
+            *output_c++ = c;
+          }
+        }
+        *out = s.size();
+        break;
+      }
       case OrtOpAttrType::ORT_OP_ATTR_STRINGS: {
         const auto& ss = attr->strings();
         size_t num_bytes = 0;

--- a/onnxruntime/core/session/standalone_op_invoker.cc
+++ b/onnxruntime/core/session/standalone_op_invoker.cc
@@ -348,6 +348,10 @@ onnxruntime::Status CreateOpAttr(const char* name, const void* data, int len, Or
       attr->set_s(std::string{str});
       attr->set_type(ONNX_NAMESPACE::AttributeProto_AttributeType::AttributeProto_AttributeType_STRING);
       break;
+    case OrtOpAttrType::ORT_OP_ATTR_BYTES:
+      attr->set_s(std::string{str, str + len});
+      attr->set_type(ONNX_NAMESPACE::AttributeProto_AttributeType::AttributeProto_AttributeType_STRING);
+      break;
     case OrtOpAttrType::ORT_OP_ATTR_STRINGS:
       for (int j = 0; j < len; ++j) {
         attr->add_strings(std::string{strs[j]});


### PR DESCRIPTION
### Description

Add a new operator attribute type `ORT_OP_ATTR_BYTES` to the ONNX
Runtime C API.

### Motivation and Context

PR #24887 allows plugin-EPs to interface with ORT using a binary stable interface.

It is an important feature for a plugin EP to generate an EP context model as specified by
https://onnxruntime.ai/docs/execution-providers/EP-Context-Design.html

The EP needs to read and write the `ep_cache_context` attribute of type `ORT_OP_ATTR_STRING` as specified by
https://github.com/microsoft/onnxruntime/blob/5fdd4e4f2a2b6705a9a49a378a3b3496805067ee/onnxruntime/core/graph/contrib_ops/contrib_defs.cc#L3301-L3305

The current implemention of `ReadOpAttr` regards an attribute of type `ORT_OP_ATTR_STRING` as a null terminated string.
https://github.com/microsoft/onnxruntime/blob/5fdd4e4f2a2b6705a9a49a378a3b3496805067ee/onnxruntime/core/session/custom_ops.cc#L437-L447

It is very common that `ep_cache_context` is a sequence of bytes, as specificed by ONNX
https://github.com/ankane/onnxruntime-1/blob/95843a5dbc3100062be88bcb0d06fd36877f3f77/onnxruntime/core/protobuf/onnx-ml.proto#L140

This commit adds a new operator attribute type `ORT_OP_ATTR_BYTES` to the ONNX Runtime C API, which allows plugin EPs to read and write `ep_cache_context` as a sequence of bytes.