### PR TITLE
Add PackageVersion parameter to NuGet packaging stage

### DIFF
--- a/tools/ci_build/github/azure-pipelines/stages/nuget-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nuget-cuda-packaging-stage.yml
@@ -72,7 +72,7 @@ stages:
         SpecificArtifact: ${{ parameters.SpecificArtifact }}
         BuildId: ${{ parameters.BuildId }}
 
-    - template: set-version-number-variables-step.yml
+    - template: ../templates/set-version-number-variables-step.yml
 
     # Reconstruct the build dir
     - task: PowerShell@2


### PR DESCRIPTION
Fix: `Microsoft.ML.OnnxRuntime.Managed.nupkg` artifact from GPU pipeline does not have package version.

![image](https://github.com/user-attachments/assets/4a6135ab-4774-4aa6-aeb1-d5b06948ba8f)
