### PR TITLE
Update updateStaleIssues.yml: remove the reopen issue logic

### DIFF
--- a/.github/policies/updateStaleIssues.yml
+++ b/.github/policies/updateStaleIssues.yml
@@ -52,14 +52,4 @@ configuration:
         then:
           - removeLabel:
               label: stale
-      - description: Re-open stale issue if closed stale issue is commented on
-        if:
-          - payloadType: Issue_Comment
-          - and:
-              - not:
-                  isOpen
-              - hasLabel:
-                  label: stale
-        then:
-          - reopenIssue
       


### PR DESCRIPTION
If someone closed an issue that had a "stale" label and the person did not remove the label when closing the issue, this workflow will reopen it, which is not desired. Therefore this PR removes the reopening issue logic.




