### PR TITLE
[OVEP] Fix debug build

### DIFF
--- a/onnxruntime/core/providers/openvino/backend_utils.h
+++ b/onnxruntime/core/providers/openvino/backend_utils.h
@@ -27,7 +27,7 @@
 
 namespace onnxruntime {
 namespace openvino_ep {
-constexpr std::string log_tag = "[OpenVINO-EP] ";
+static const std::string log_tag = "[OpenVINO-EP] ";
 
 struct ParameterShape {
   using ort_shape_t = std::vector<int64_t>;

--- a/onnxruntime/core/providers/openvino/ov_interface.cc
+++ b/onnxruntime/core/providers/openvino/ov_interface.cc
@@ -49,12 +49,12 @@ void printDebugInfo(const ov::CompiledModel& obj) {
             std::cout << "    " << item2.first << ": " << item2.second.as<std::string>() << std::endl;
           }
         }
-        else {
-          std::cout << "  " << cfg << ": " << prop.as<std::string>() << std::endl;
-        }
+      } else {
+        std::cout << "  " << cfg << ": " << prop.as<std::string>() << std::endl;
       }
     }
   }
+}
 #endif
 
   // Function to check if a given OV property is enabled


### PR DESCRIPTION
### Description
Fix build issues in debug code under #ifndef NDEBUG check.
Switch constexpr std::string to static const

### Motivation and Context
MSVC fails to compile constexpr std::string under _DEBUG