### PR TITLE
Update vcpkg.json: remove  optional-lite

### DIFF
--- a/cmake/vcpkg.json
+++ b/cmake/vcpkg.json
@@ -43,7 +43,6 @@
     "ms-gsl",
     "nlohmann-json",
     "onnx",
-    "optional-lite",
     {
       "name": "protobuf",
       "version>=": "3.21.12"


### PR DESCRIPTION
The library is not used. C++ itself already has std::optional.




