### PR TITLE
Add patch for WebGPU on Android to handle fp16 in uniforms

### DIFF
--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -746,6 +746,16 @@ if (onnxruntime_USE_WEBGPU)
           #   Some build warnings are not allowed to be disabled in project level.
           ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/dawn/dawn_binskim.patch)
 
+      if(Android)
+        # Android devices doesn't seem to allow fp16 in uniforms so the WebGPU EP has to manually handle passing an fp32
+        # in the uniform and converting to fp16 before using.
+        set(ONNXRUNTIME_Dawn_PATCH_COMMAND
+            "${ONNXRUNTIME_Dawn_PATCH_COMMAND} &&
+            ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/dawn/uniform_and_storage_buffer_16_bit_access.patch"
+        )
+        add_compile_definitions(ORT_WEBGPU_NO_FP16_IN_UNIFORMS)
+      endif()
+
       onnxruntime_fetchcontent_declare(
         dawn
         URL ${DEP_URL_dawn}

--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -750,8 +750,6 @@ if (onnxruntime_USE_WEBGPU)
           # in the uniform and converting to fp16 before using.
           ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/dawn/uniform_and_storage_buffer_16_bit_access.patch)
 
-      add_compile_definitions(ORT_WEBGPU_NO_FP16_IN_UNIFORMS)
-
       onnxruntime_fetchcontent_declare(
         dawn
         URL ${DEP_URL_dawn}

--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -744,17 +744,13 @@ if (onnxruntime_USE_WEBGPU)
           #
           # - (private) Fulfill the BinSkim requirements
           #   Some build warnings are not allowed to be disabled in project level.
-          ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/dawn/dawn_binskim.patch)
+          ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/dawn/dawn_binskim.patch &&
 
-      if(Android)
-        # Android devices doesn't seem to allow fp16 in uniforms so the WebGPU EP has to manually handle passing an fp32
-        # in the uniform and converting to fp16 before using.
-        set(ONNXRUNTIME_Dawn_PATCH_COMMAND
-            "${ONNXRUNTIME_Dawn_PATCH_COMMAND} &&
-            ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/dawn/uniform_and_storage_buffer_16_bit_access.patch"
-        )
-        add_compile_definitions(ORT_WEBGPU_NO_FP16_IN_UNIFORMS)
-      endif()
+          # Android devices doesn't seem to allow fp16 in uniforms so the WebGPU EP has to manually handle passing an fp32
+          # in the uniform and converting to fp16 before using.
+          ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/dawn/uniform_and_storage_buffer_16_bit_access.patch)
+
+      add_compile_definitions(ORT_WEBGPU_NO_FP16_IN_UNIFORMS)
 
       onnxruntime_fetchcontent_declare(
         dawn

--- a/cmake/patches/dawn/uniform_and_storage_buffer_16_bit_access.patch
+++ b/cmake/patches/dawn/uniform_and_storage_buffer_16_bit_access.patch
@@ -22,10 +22,10 @@ index c01d64e40f..0f1f4beae4 100644
              usedKnobs._16BitStorageFeatures.storageInputOutput16 = VK_TRUE;
          }
 diff --git a/src/dawn/native/vulkan/PhysicalDeviceVk.cpp b/src/dawn/native/vulkan/PhysicalDeviceVk.cpp
-index f9902776c7..8d64da750f 100644
+index a324c101ed..8d64da750f 100644
 --- a/src/dawn/native/vulkan/PhysicalDeviceVk.cpp
 +++ b/src/dawn/native/vulkan/PhysicalDeviceVk.cpp
-@@ -252,8 +252,9 @@ void PhysicalDevice::InitializeSupportedFeaturesImpl() {
+@@ -269,8 +269,9 @@ void PhysicalDevice::InitializeSupportedFeaturesImpl() {
      if (mDeviceInfo.HasExt(DeviceExt::ShaderFloat16Int8) &&
          mDeviceInfo.HasExt(DeviceExt::_16BitStorage) &&
          mDeviceInfo.shaderFloat16Int8Features.shaderFloat16 == VK_TRUE &&
@@ -34,6 +34,6 @@ index f9902776c7..8d64da750f 100644
 +        mDeviceInfo._16BitStorageFeatures.storageBuffer16BitAccess == VK_TRUE /*&&
 +        WebGPU EP needs to ensure we don't put fp16 values in uniforms when this patch is applied.
 +        mDeviceInfo._16BitStorageFeatures.uniformAndStorageBuffer16BitAccess == VK_TRUE*/) {
-         // TODO(crbug.com/tint/2164): Investigate crashes in f16 CTS tests to enable on NVIDIA.
-         if (!gpu_info::IsNvidia(GetVendorId())) {
-             EnableFeature(Feature::ShaderF16);
+         // ONNX Runtime Patch: enable shaderF16 on all devices.
+         EnableFeature(Feature::ShaderF16);
+         shaderF16Enabled = true;

--- a/cmake/patches/dawn/uniform_and_storage_buffer_16_bit_access.patch
+++ b/cmake/patches/dawn/uniform_and_storage_buffer_16_bit_access.patch
@@ -1,0 +1,39 @@
+diff --git a/src/dawn/native/vulkan/DeviceVk.cpp b/src/dawn/native/vulkan/DeviceVk.cpp
+index c01d64e40f..0f1f4beae4 100644
+--- a/src/dawn/native/vulkan/DeviceVk.cpp
++++ b/src/dawn/native/vulkan/DeviceVk.cpp
+@@ -464,13 +464,15 @@ ResultOrError<VulkanDeviceKnobs> Device::CreateDevice(VkPhysicalDevice vkPhysica
+         DAWN_ASSERT(usedKnobs.HasExt(DeviceExt::ShaderFloat16Int8) &&
+                     mDeviceInfo.shaderFloat16Int8Features.shaderFloat16 == VK_TRUE &&
+                     usedKnobs.HasExt(DeviceExt::_16BitStorage) &&
+-                    mDeviceInfo._16BitStorageFeatures.storageBuffer16BitAccess == VK_TRUE &&
++                    mDeviceInfo._16BitStorageFeatures.storageBuffer16BitAccess == VK_TRUE /*&&
+                     mDeviceInfo._16BitStorageFeatures.uniformAndStorageBuffer16BitAccess ==
+-                        VK_TRUE);
++                        VK_TRUE*/);
+
+         usedKnobs.shaderFloat16Int8Features.shaderFloat16 = VK_TRUE;
+         usedKnobs._16BitStorageFeatures.storageBuffer16BitAccess = VK_TRUE;
+-        usedKnobs._16BitStorageFeatures.uniformAndStorageBuffer16BitAccess = VK_TRUE;
++        if (mDeviceInfo._16BitStorageFeatures.uniformAndStorageBuffer16BitAccess == VK_TRUE) {
++            usedKnobs._16BitStorageFeatures.uniformAndStorageBuffer16BitAccess = VK_TRUE;
++        }
+         if (mDeviceInfo._16BitStorageFeatures.storageInputOutput16 == VK_TRUE) {
+             usedKnobs._16BitStorageFeatures.storageInputOutput16 = VK_TRUE;
+         }
+diff --git a/src/dawn/native/vulkan/PhysicalDeviceVk.cpp b/src/dawn/native/vulkan/PhysicalDeviceVk.cpp
+index f9902776c7..8d64da750f 100644
+--- a/src/dawn/native/vulkan/PhysicalDeviceVk.cpp
++++ b/src/dawn/native/vulkan/PhysicalDeviceVk.cpp
+@@ -252,8 +252,9 @@ void PhysicalDevice::InitializeSupportedFeaturesImpl() {
+     if (mDeviceInfo.HasExt(DeviceExt::ShaderFloat16Int8) &&
+         mDeviceInfo.HasExt(DeviceExt::_16BitStorage) &&
+         mDeviceInfo.shaderFloat16Int8Features.shaderFloat16 == VK_TRUE &&
+-        mDeviceInfo._16BitStorageFeatures.storageBuffer16BitAccess == VK_TRUE &&
+-        mDeviceInfo._16BitStorageFeatures.uniformAndStorageBuffer16BitAccess == VK_TRUE) {
++        mDeviceInfo._16BitStorageFeatures.storageBuffer16BitAccess == VK_TRUE /*&&
++        WebGPU EP needs to ensure we don't put fp16 values in uniforms when this patch is applied.
++        mDeviceInfo._16BitStorageFeatures.uniformAndStorageBuffer16BitAccess == VK_TRUE*/) {
+         // TODO(crbug.com/tint/2164): Investigate crashes in f16 CTS tests to enable on NVIDIA.
+         if (!gpu_info::IsNvidia(GetVendorId())) {
+             EnableFeature(Feature::ShaderF16);

--- a/tools/ci_build/github/android/default_full_aar_build_settings.json
+++ b/tools/ci_build/github/android/default_full_aar_build_settings.json
@@ -17,6 +17,7 @@
         "--use_nnapi",
         "--use_xnnpack",
         "--use_webgpu",
+        "--cmake_extra_defines=CMAKE_CXX_SCAN_FOR_MODULES=OFF",
         "--skip_tests"
     ]
 }

--- a/tools/ci_build/github/android/default_full_aar_build_settings.json
+++ b/tools/ci_build/github/android/default_full_aar_build_settings.json
@@ -16,6 +16,7 @@
         "--build_shared_lib",
         "--use_nnapi",
         "--use_xnnpack",
+        "--use_webgpu",
         "--skip_tests"
     ]
 }


### PR DESCRIPTION




### Motivation and Context
Android devices (like S24) doesn't seem to allow fp16 in uniforms so the WebGPU EP has to manually handle passing an fp32 in the uniform and converting to fp16 before using.

