### PR TITLE
[EP ABI] Update to use Node_GetEpName

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -6028,7 +6028,7 @@ struct OrtApi {
 
   /** \brief Returns the execution provider name that this node is assigned to run on.
    *         Returns NULL if the node has not been assigned to any execution provider yet.
-   *         For plugin execution providers, the name is the one registered via RegisterExecutionProviderLibrary.
+   *         For plugin execution providers, the name is the one returned by OrtEp::GetName.
    *
    * \param[in] node The OrtNode instance.
    * \param[out] out Output execution provider type and can be NULL if node has not been assigned.

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -6026,8 +6026,9 @@ struct OrtApi {
    */
   ORT_API2_STATUS(Node_GetGraph, _In_ const OrtNode* node, _Outptr_result_maybenull_ const OrtGraph** graph);
 
-  /** \brief Returns the execution provider type (name) that this node is assigned to run on.
+  /** \brief Returns the execution provider name that this node is assigned to run on.
    *         Returns NULL if the node has not been assigned to any execution provider yet.
+   *         For plugin execution providers, the name is the one registered via RegisterExecutionProviderLibrary.
    *
    * \param[in] node The OrtNode instance.
    * \param[out] out Output execution provider type and can be NULL if node has not been assigned.
@@ -6036,7 +6037,7 @@ struct OrtApi {
    *
    * \since Version 1.23.
    */
-  ORT_API2_STATUS(Node_GetEpType, _In_ const OrtNode* node, _Outptr_result_maybenull_ const char** out);
+  ORT_API2_STATUS(Node_GetEpName, _In_ const OrtNode* node, _Outptr_result_maybenull_ const char** out);
 
   /// @}
 

--- a/onnxruntime/core/graph/ep_api_types.cc
+++ b/onnxruntime/core/graph/ep_api_types.cc
@@ -276,7 +276,7 @@ const OrtOpAttr* EpNode::GetAttribute(const std::string& name) const {
   }
 }
 
-const std::string& EpNode::GetEpType() const {
+const std::string& EpNode::GetEpName() const {
   return node_.GetExecutionProviderType();
 }
 

--- a/onnxruntime/core/graph/ep_api_types.h
+++ b/onnxruntime/core/graph/ep_api_types.h
@@ -208,8 +208,8 @@ struct EpNode : public OrtNode {
   // Helper that gets the node's attributes by name.
   const OrtOpAttr* GetAttribute(const std::string& name) const;
 
-  // Helper that gets the execution provider that this node is assigned to run on.
-  const std::string& GetEpType() const;
+  // Helper that gets the execution provider name that this node is assigned to run on.
+  const std::string& GetEpName() const;
 
  private:
   // Back pointer to containing graph. Useful when traversing through nested subgraphs.

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -3052,7 +3052,7 @@ ORT_API_STATUS_IMPL(OrtApis::Node_GetGraph, _In_ const OrtNode* node,
   API_IMPL_END
 }
 
-ORT_API_STATUS_IMPL(OrtApis::Node_GetEpType, _In_ const OrtNode* node,
+ORT_API_STATUS_IMPL(OrtApis::Node_GetEpName, _In_ const OrtNode* node,
                     _Outptr_result_maybenull_ const char** out) {
   API_IMPL_BEGIN
   if (out == nullptr) {
@@ -3061,10 +3061,10 @@ ORT_API_STATUS_IMPL(OrtApis::Node_GetEpType, _In_ const OrtNode* node,
 
   const EpNode* ep_node = EpNode::ToInternal(node);
   if (ep_node == nullptr) {
-    return OrtApis::CreateStatus(OrtErrorCode::ORT_INVALID_ARGUMENT, "node is a ModelEditorNode which doesn't support Node_GetEpType.");
+    return OrtApis::CreateStatus(OrtErrorCode::ORT_INVALID_ARGUMENT, "node is a ModelEditorNode which doesn't support Node_GetEpName.");
   }
 
-  *out = ep_node->GetEpType().c_str();
+  *out = ep_node->GetEpName().c_str();
   return nullptr;
   API_IMPL_END
 }

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -3751,7 +3751,7 @@ static constexpr OrtApi ort_api_1_to_23 = {
     &OrtApis::Node_GetNumSubgraphs,
     &OrtApis::Node_GetSubgraphs,
     &OrtApis::Node_GetGraph,
-    &OrtApis::Node_GetEpType,
+    &OrtApis::Node_GetEpName,
 
     &OrtApis::GetRunConfigEntry,
 

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -680,7 +680,7 @@ ORT_API_STATUS_IMPL(Node_GetSubgraphs, _In_ const OrtNode* node,
                     _Out_writes_(num_subgraphs) const OrtGraph** subgraphs, _In_ size_t num_subgraphs,
                     _Out_writes_opt_(num_subgraphs) const char** attribute_names);
 ORT_API_STATUS_IMPL(Node_GetGraph, _In_ const OrtNode* node, _Outptr_result_maybenull_ const OrtGraph** graph);
-ORT_API_STATUS_IMPL(Node_GetEpType, _In_ const OrtNode* node, _Outptr_result_maybenull_ const char** out);
+ORT_API_STATUS_IMPL(Node_GetEpName, _In_ const OrtNode* node, _Outptr_result_maybenull_ const char** out);
 
 ORT_API_STATUS_IMPL(GetRunConfigEntry, _In_ const OrtRunOptions* options,
                     _In_z_ const char* config_key, _Outptr_result_maybenull_z_ const char** config_value);

--- a/onnxruntime/test/autoep/library/ep.cc
+++ b/onnxruntime/test/autoep/library/ep.cc
@@ -328,9 +328,9 @@ OrtStatus* ORT_API_CALL ExampleEp::CompileImpl(_In_ OrtEp* this_ptr, _In_ const 
   RETURN_IF_ERROR(ort_api.GetValueInfoName(node_inputs[0], &node_input_names[0]));
   RETURN_IF_ERROR(ort_api.GetValueInfoName(node_inputs[1], &node_input_names[1]));
 
-  const char* ep_type = nullptr;
-  RETURN_IF_ERROR(ort_api.Node_GetEpType(fused_nodes[0], &ep_type));
-  if (std::strncmp(ep_type, "example_ep", 11) != 0) {
+  const char* ep_name = nullptr;
+  RETURN_IF_ERROR(ort_api.Node_GetEpName(fused_nodes[0], &ep_name));
+  if (std::strncmp(ep_name, "example_ep", 11) != 0) {
     return ort_api.CreateStatus(ORT_EP_FAIL, "The fused node is expected to assigned to this EP to run on");
   }
 


### PR DESCRIPTION
Change to use `Node_GetEpName` API name to avoid confusion.
For plugin EPs, the EP factory can use whatever name that registered with ORT, so make the API name `Node_GetEpName` to align with `OrtEpFactory.GetName.`


