### PR TITLE
[JSEP] Fix inputShape index OOB in slice.ts

### DIFF
--- a/js/web/lib/wasm/jsep/webgpu/ops/slice.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/slice.ts
@@ -98,7 +98,7 @@ const calculateInputIndicesImpl = (
   `fn calculateInputIndices(output_indices: ${output.type.indices}) -> ${input.type.indices} {
           var input_indices: ${input.type.indices};
           var carry = 0u;
-          for (var i = ${inputShape.length}; i >= 0; i--) {
+          for (var i = ${inputShape.length - 1}; i >= 0; i--) {
             let input_shape_i = ${getElementAt('uniforms.input_shape', 'i', inputShape.length)};
             let steps_i = ${getElementAt('uniforms.steps', 'i', inputShape.length)};
             let signs_i = ${getElementAt('uniforms.signs', 'i', inputShape.length)};


### PR DESCRIPTION
Use `inputShape.length - 1` instead of `inputShape.length` to avoid out-of-bounds access.
