### PR TITLE
Update the customer op API ReadOpAttr for string type to avoid adding '\0' to the end

### DIFF
--- a/onnxruntime/core/session/custom_ops.cc
+++ b/onnxruntime/core/session/custom_ops.cc
@@ -436,23 +436,20 @@ ORT_API_STATUS_IMPL(OrtApis::ReadOpAttr, _In_ const OrtOpAttr* op_attr, _In_ Ort
       }
       case OrtOpAttrType::ORT_OP_ATTR_STRING: {
         const auto& s = attr->s();
-        if (len < s.size() + 1) {
+        if (len < s.size()) {
           ret = OrtApis::CreateStatus(OrtErrorCode::ORT_INVALID_ARGUMENT,
                                       "Size of data not large enough to hold the string.");
         } else {
           char* output_c = reinterpret_cast<char*>(data);
-          for (char c : s) {
-            *output_c++ = c;
-          }
-          *output_c = '\0';
+          memcpy(output_c, s.data(), s.size());
         }
-        *out = s.size() + 1;
+        *out = s.size();
         break;
       }
       case OrtOpAttrType::ORT_OP_ATTR_STRINGS: {
         const auto& ss = attr->strings();
         size_t num_bytes = 0;
-        for_each(ss.begin(), ss.end(), [&num_bytes](const std::string& s) { num_bytes += s.size() + 1; });
+        for_each(ss.begin(), ss.end(), [&num_bytes](const std::string& s) { num_bytes += s.size(); });
 
         if (len < num_bytes) {
           ret = OrtApis::CreateStatus(OrtErrorCode::ORT_INVALID_ARGUMENT,
@@ -460,10 +457,7 @@ ORT_API_STATUS_IMPL(OrtApis::ReadOpAttr, _In_ const OrtOpAttr* op_attr, _In_ Ort
         } else {
           char* output_c = reinterpret_cast<char*>(data);
           for (const auto& s : ss) {
-            for (char c : s) {
-              *output_c++ = c;
-            }
-            *output_c++ = '\0';
+            memcpy(output_c, s.data(), s.size());
           }
         }
         *out = num_bytes;


### PR DESCRIPTION
Update the customer op API ReadOpAttr for string type to avoid adding '\0' at the end.


