### PR TITLE
increase timeout for nuget-test-android pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_android.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_android.yml
@@ -10,6 +10,7 @@ stages:
   - job:  NuGet_Test_Android
     workspace:
       clean: all
+    timeoutInMinutes: 120
     pool: "${{ parameters.AgentPool }}"
 
     variables:


### PR DESCRIPTION
Pipeline has been timing out after 1hr for the past several runs on [zip-nuget-pipeline](https://aiinfra.visualstudio.com/Lotus/_build?definitionId=940&_a=summary). Increasing from 1hr to 2hr in accordance with linux-test-pipeline