### PR TITLE
'QnnEpFactory' should provide a fully-qualified path to the backend

### DIFF
--- a/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
+++ b/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
@@ -7,6 +7,35 @@
 #include "core/providers/qnn/qnn_execution_provider.h"
 #include "core/providers/qnn/builder/qnn_utils.h"
 
+/// @brief Gets the path of directory containing the dynamic library that contains the address.
+/// @param address An address of a function or variable in the dynamic library.
+/// @return The path of the directory containing the dynamic library, or an empty string if the path cannot be determined.
+static onnxruntime::PathString GetDynamicLibraryLocationByAddress(const void* address) {
+#ifdef _WIN32
+  HMODULE moduleHandle;
+  if (!::GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                            reinterpret_cast<LPCWSTR>(address), &moduleHandle)) {
+    return {};
+  }
+  std::wstring buffer;
+  for (std::uint32_t size{70}; size < 4096; size *= 2) {
+    buffer.resize(size, L'\0');
+    const std::uint32_t requiredSize = ::GetModuleFileNameW(moduleHandle, buffer.data(), size);
+    if (requiredSize == 0) {
+      break;
+    }
+    if (requiredSize == size) {
+      continue;
+    }
+    buffer.resize(requiredSize);
+    return {std::move(buffer)};
+  }
+#else
+  std::ignore = address;
+#endif
+  return {};
+}
+
 namespace onnxruntime {
 struct QNNProviderFactory : IExecutionProviderFactory {
   QNNProviderFactory(const ProviderOptions& provider_options_map, const ConfigOptions* config_options)
@@ -123,9 +152,8 @@ struct QnnEpFactory : OrtEpFactory {
   QnnEpFactory(const OrtApi& ort_api_in,
                const char* ep_name,
                OrtHardwareDeviceType hw_type,
-               const char* qnn_backend_type)
-      : ort_api{ort_api_in}, ep_name{ep_name}, ort_hw_device_type{hw_type}, qnn_backend_type{qnn_backend_type} {
-    ort_version_supported = ORT_API_VERSION;
+               std::string qnn_backend_path)
+      : ort_api{ort_api_in}, ep_name{ep_name}, ort_hw_device_type{hw_type}, qnn_backend_path{std::move(qnn_backend_path)} {
     GetName = GetNameImpl;
     GetVendor = GetVendorImpl;
     GetVendorId = GetVendorIdImpl;
@@ -177,7 +205,7 @@ struct QnnEpFactory : OrtEpFactory {
           factory->ort_api.HardwareDevice_VendorId(&device) == factory->vendor_id) {
         OrtKeyValuePairs* ep_options = nullptr;
         factory->ort_api.CreateKeyValuePairs(&ep_options);
-        factory->ort_api.AddKeyValuePair(ep_options, "backend_type", factory->qnn_backend_type.c_str());
+        factory->ort_api.AddKeyValuePair(ep_options, "backend_path", factory->qnn_backend_path.c_str());
         ORT_API_RETURN_IF_ERROR(
             factory->ort_api.GetEpApi()->CreateEpDevice(factory, &device, nullptr, ep_options,
                                                         &ep_devices[num_ep_devices++]));
@@ -209,7 +237,7 @@ struct QnnEpFactory : OrtEpFactory {
   // Qualcomm vendor ID. Refer to the ACPI ID registry (search Qualcomm): https://uefi.org/ACPI_ID_List
   const uint32_t vendor_id{'Q' | ('C' << 8) | ('O' << 16) | ('M' << 24)};
   const OrtHardwareDeviceType ort_hw_device_type;  // Supported OrtHardwareDevice
-  const std::string qnn_backend_type;              // QNN backend type for OrtHardwareDevice
+  const std::string qnn_backend_path;              // QNN backend path for OrtHardwareDevice
 };
 
 extern "C" {
@@ -221,9 +249,23 @@ OrtStatus* CreateEpFactories(const char* /*registration_name*/, const OrtApiBase
   const OrtApi* ort_api = ort_api_base->GetApi(ORT_API_VERSION);
 
   // Factory could use registration_name or define its own EP name.
+#if defined(_WIN32)
+  std::string backend_path = "QnnHtp.dll";
+#else
+  std::string backend_path = "libQnnHtp.so";
+#endif
+
+  // Identify the path of the current dynamic library, and expect that backend_path is in the same directory.
+  onnxruntime::PathString current_path = GetDynamicLibraryLocationByAddress(CreateEpFactories);
+  if (!current_path.empty()) {
+    const std::filesystem::path parent_path = std::filesystem::path{std::move(current_path)}.parent_path();
+    backend_path = (parent_path / backend_path).string();
+  }
+
   auto factory_npu = std::make_unique<QnnEpFactory>(*ort_api,
                                                     onnxruntime::kQnnExecutionProvider,
-                                                    OrtHardwareDeviceType_NPU, "htp");
+                                                    OrtHardwareDeviceType_NPU,
+                                                    std::move(backend_path));
 
   // If want to support GPU, create a new factory instance because QNN EP is not currently setup to partition a single model
   // among heterogeneous devices.


### PR DESCRIPTION
### Description
The `QnnEpFactory` implementation currently initializes the underlying provider by passing the `backend_type` configuration as `htp`, causing the provider to find the appropriate backend-library, and load it relative to the OnnxRuntime library. But if EP's are distributed separately from the OnnxRuntime library - a major benefit of the EP ABI - then the backend-library may-well not be relative to the OnnxRuntime. Having the `QnnEpFactory` implementation look for its associated runtime relative to _itself_ would allow the implementation to bring its own runtime - and that's what this PR enables.

If the `QnnEpFactory` implementation is co-located with the OnnxRuntime library, then this is consistent with the existing behavior, but an `QnnEpFactory` implementation that is shipped 'out-of-band' will use a backend-relative to itself.

### Motivation and Context
To support out-of-band distribution of EP's - enabled by the EP ABI work - then EP's should accommodate finding dependencies relative to the EP library, and not the OnnxRuntime library.