### PR TITLE
Fix the is_leaf check in TreeEnsemble

### DIFF
--- a/onnxruntime/core/providers/cpu/ml/tree_ensemble_attribute.h
+++ b/onnxruntime/core/providers/cpu/ml/tree_ensemble_attribute.h
@@ -308,9 +308,10 @@ struct TreeEnsembleAttributesV5 {
     int64_t curr_treeid = 0;
     for (const int64_t& tree_root : tree_roots) {
       size_t tree_root_size_t = onnxruntime::narrow<size_t>(tree_root);
+      bool is_leaf = (nodes_falsenodeids[tree_root_size_t] == nodes_truenodeids[tree_root_size_t] &&
+                      nodes_falseleafs[tree_root_size_t] && nodes_trueleafs[tree_root_size_t]);
       transformInputOneTree(tree_root_size_t, curr_treeid, 0, 0U,
-                            nodes_falsenodeids[tree_root_size_t] == nodes_truenodeids[tree_root_size_t],
-                            membership_values_by_id, output);
+                            is_leaf, membership_values_by_id, output);
       curr_treeid++;
     }
   }


### PR DESCRIPTION
### Description
Fixes #24679.

### Motivation and Context
The original check for a leaf node was insufficient because a branch child and a leaf child could have the same index. The bug described in issue #24679 is not a rare occasion; in fact, it is something likely to be faced in estimators with small and balanced trees. I encountered it myself in a unit test.

The corrected check ensures that for a node to be considered a leaf, both of its children must be leaves and share the same index.


