### PR TITLE
revert qnn sdk version

### DIFF
--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -60,7 +60,7 @@ parameters:
 - name: QnnSdk
   displayName: QNN SDK Version
   type: string
-  default: 2.36.1.250708
+  default: 2.36.0.250627
 
 resources:
   repositories:

--- a/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar-test.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar-test.yml
@@ -19,7 +19,7 @@ parameters:
 - name: QnnSDKVersion
   displayName: QNN SDK Version
   type: string
-  default: '2.36.1.250708'
+  default: '2.36.0.250627'
 
 - name: enableWebGpu
   displayName: Enable WebGPU test

--- a/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar.yml
@@ -53,7 +53,7 @@ parameters:
 - name: QnnSDKVersion
   displayName: QNN SDK Version
   type: string
-  default: '2.36.1.250708'
+  default: '2.36.0.250627'
 
 - name: is1ES
   displayName: Is 1ES pipeline

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -47,7 +47,7 @@ parameters:
 - name: QnnSDKVersion
   displayName: QNN SDK Version
   type: string
-  default: 2.36.1.250708
+  default: 2.36.0.250627
 
 - name: is1ES
   displayName: Is 1ES pipeline


### PR DESCRIPTION
Fixes Error:

Could not find com.qualcomm.qti:qnn-runtime:2.36.1
The nuget packaging pipeline fails with 
Could not find com.qualcomm.qti:qnn-runtime:2.36.1

https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=866702&view=results
 