### PR TITLE
upgrade emsdk to 4.0.9

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,4 +7,4 @@
 [submodule "cmake/external/emsdk"]
 	path = cmake/external/emsdk
 	url = https://github.com/emscripten-core/emsdk.git
-	branch = 4.0.8
+	branch = 4.0.9

--- a/tools/ci_build/build_args.py
+++ b/tools/ci_build/build_args.py
@@ -342,7 +342,7 @@ def add_webassembly_args(parser: argparse.ArgumentParser) -> None:
     """Adds arguments for WebAssembly (WASM) platform builds."""
     parser.add_argument("--build_wasm", action="store_true", help="Build for WebAssembly.")
     parser.add_argument("--build_wasm_static_lib", action="store_true", help="Build WebAssembly static library.")
-    parser.add_argument("--emsdk_version", default="4.0.8", help="Specify version of emsdk.")
+    parser.add_argument("--emsdk_version", default="4.0.9", help="Specify version of emsdk.")
     parser.add_argument("--enable_wasm_simd", action="store_true", help="Enable WebAssembly SIMD.")
     parser.add_argument("--enable_wasm_relaxed_simd", action="store_true", help="Enable WebAssembly Relaxed SIMD.")
     parser.add_argument("--enable_wasm_threads", action="store_true", help="Enable WebAssembly multi-threading.")

--- a/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
@@ -88,15 +88,15 @@ jobs:
     - script: |
         set -ex
         cd '$(Build.SourcesDirectory)/cmake/external/emsdk'
-        ./emsdk install 4.0.8 ccache-git-emscripten-64bit
-        ./emsdk activate 4.0.8 ccache-git-emscripten-64bit
+        ./emsdk install 4.0.9 ccache-git-emscripten-64bit
+        ./emsdk activate 4.0.9 ccache-git-emscripten-64bit
       displayName: 'emsdk install and activate ccache for emscripten'
   - ${{if eq(parameters.WithCache, false)}}:
     - script: |
         set -ex
         cd '$(Build.SourcesDirectory)/cmake/external/emsdk'
-        ./emsdk install 4.0.8
-        ./emsdk activate 4.0.8
+        ./emsdk install 4.0.9
+        ./emsdk activate 4.0.9
       displayName: 'emsdk install and activate ccache for emscripten'
 
   - template: build-linux-wasm-step.yml


### PR DESCRIPTION
### Description

upgrade emsdk to 4.0.9

### Motivation and Context

A bug in emscan-deps blocks the build when using Ninja. The bug is fixed in upstream at https://github.com/emscripten-core/emscripten/pull/24506. The fix is included in emsdk v4.0.9

Why not upgrade to latest (4.0.11 at the moment):

- later version introduced a breaking change in https://github.com/emscripten-core/emscripten/pull/24384. ORT-web need to make some changes to work with it, and it takes more time. For now, upgrading to 4.0.9 should be enough to unblock the build.

Why the CI is not affected:

- The build issue seems to occur when building using Ninja. CI is using Linux with default CMake generator. For WebAssembly build, the default CMake generator is:
  - Ninja (Windows)
  - Makefile (UNIX)