### PR TITLE
[NV RTX EP] Set Compute Capability only on Turing architecture

### DIFF
--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
@@ -2281,11 +2281,16 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
   if (max_shared_mem_size_ > 0) {
     trt_config->setMemoryPoolLimit(nvinfer1::MemoryPoolType::kTACTIC_SHARED_MEMORY, max_shared_mem_size_);
   }
-  // Only set default compute capabilities if user hasn't explicitly configured them
-  constexpr int kDefaultNumComputeCapabilities = 1;  // Default number of compute capabilities for Turing support
-  if (trt_config->getNbComputeCapabilities() == 0) {
-    trt_config->setNbComputeCapabilities(kDefaultNumComputeCapabilities);
-    trt_config->setComputeCapability(nvinfer1::ComputeCapability::kCURRENT, 0);
+
+  // Only set compute capability for Turing
+  const std::string kTuringComputeCapability{"75"};
+
+  if (compute_capability_ == kTuringComputeCapability) {
+    constexpr int kDefaultNumComputeCapabilities = 1;
+    if (trt_config->getNbComputeCapabilities() == 0) {
+      trt_config->setNbComputeCapabilities(kDefaultNumComputeCapabilities);
+      trt_config->setComputeCapability(nvinfer1::ComputeCapability::kSM75, 0);
+    }
   }
 
   int num_inputs = trt_network->getNbInputs();


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Set compute capability only on Turing arch


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Setting the native compute capability was causing a regression in performance. 

@gaugarg-nv @ishwar-raut1 @ankan-ban 

