### PR TITLE
[VitisAI] Remove 4k alignment from preferred allocator

### DIFF
--- a/onnxruntime/core/providers/vitisai/vitisai_execution_provider.cc
+++ b/onnxruntime/core/providers/vitisai/vitisai_execution_provider.cc
@@ -29,7 +29,7 @@ VitisAIExecutionProvider::VitisAIExecutionProvider(
     : IExecutionProvider{onnxruntime::kVitisAIExecutionProvider,
                          OrtDevice(OrtDevice::CPU, OrtDevice::MemType::DEFAULT, OrtDevice::VendorIds::NONE,
                                    DEFAULT_CPU_ALLOCATOR_DEVICE_ID)},
-      info_(info) { // Removed 4k alignment for now, need better fix
+      info_(info) {  // Removed 4k alignment for now, need better fix
   auto it = info_.find("ep_context_enable");
   ep_ctx_enabled_ = it != info_.end() && it->second == "1";
   it = info_.find("ep_context_embed_mode");
@@ -155,7 +155,7 @@ std::vector<AllocatorPtr> VitisAIExecutionProvider::CreatePreferredAllocators() 
             OrtMemoryInfo(
                 onnxruntime::CPU_ALIGNED_4K, OrtAllocatorType::OrtDeviceAllocator,
                 OrtDevice(OrtDevice::CPU, OrtDevice::MemType::DEFAULT, OrtDevice::VendorIds::NONE,
-                          device_id))); // Removed 4k alignment for now, need better fix
+                          device_id)));  // Removed 4k alignment for now, need better fix
       },
       DEFAULT_CPU_ALLOCATOR_DEVICE_ID, use_arena_false};
 

--- a/onnxruntime/core/providers/vitisai/vitisai_execution_provider.cc
+++ b/onnxruntime/core/providers/vitisai/vitisai_execution_provider.cc
@@ -28,9 +28,8 @@ VitisAIExecutionProvider::VitisAIExecutionProvider(
     const ProviderOptions& info)
     : IExecutionProvider{onnxruntime::kVitisAIExecutionProvider,
                          OrtDevice(OrtDevice::CPU, OrtDevice::MemType::DEFAULT, OrtDevice::VendorIds::NONE,
-                                   DEFAULT_CPU_ALLOCATOR_DEVICE_ID,
-                                   kAlloc4KAlignment)},
-      info_(info) {
+                                   DEFAULT_CPU_ALLOCATOR_DEVICE_ID)},
+      info_(info) { // Removed 4k alignment for now, need better fix
   auto it = info_.find("ep_context_enable");
   ep_ctx_enabled_ = it != info_.end() && it->second == "1";
   it = info_.find("ep_context_embed_mode");
@@ -156,8 +155,7 @@ std::vector<AllocatorPtr> VitisAIExecutionProvider::CreatePreferredAllocators() 
             OrtMemoryInfo(
                 onnxruntime::CPU_ALIGNED_4K, OrtAllocatorType::OrtDeviceAllocator,
                 OrtDevice(OrtDevice::CPU, OrtDevice::MemType::DEFAULT, OrtDevice::VendorIds::NONE,
-                          device_id,
-                          kAlloc4KAlignment)));
+                          device_id))); // Removed 4k alignment for now, need better fix
       },
       DEFAULT_CPU_ALLOCATOR_DEVICE_ID, use_arena_false};
 

--- a/onnxruntime/core/providers/vitisai/vitisai_execution_provider.cc
+++ b/onnxruntime/core/providers/vitisai/vitisai_execution_provider.cc
@@ -150,7 +150,7 @@ std::vector<AllocatorPtr> VitisAIExecutionProvider::CreatePreferredAllocators() 
   // We do not want arena for 4k alignment, as it would not respect alignment.
   // For CPU, use arena
   // Removed 4k alignment for now, need better fix
-  constexpr const bool use_arena = true;
+  constexpr const bool use_arena_true = true;
   AllocatorCreationInfo device_info_cpu{
       [](OrtDevice::DeviceId device_id) {
         return std::make_unique<CPUAllocator>(
@@ -159,7 +159,7 @@ std::vector<AllocatorPtr> VitisAIExecutionProvider::CreatePreferredAllocators() 
                 OrtDevice(OrtDevice::CPU, OrtDevice::MemType::DEFAULT, OrtDevice::VendorIds::NONE,
                           device_id)));
       },
-      DEFAULT_CPU_ALLOCATOR_DEVICE_ID, use_arena};
+      DEFAULT_CPU_ALLOCATOR_DEVICE_ID, use_arena_true};
 
   result.push_back(CreateAllocator(device_info_cpu));
   return result;

--- a/onnxruntime/core/providers/vitisai/vitisai_execution_provider.cc
+++ b/onnxruntime/core/providers/vitisai/vitisai_execution_provider.cc
@@ -147,19 +147,21 @@ std::unique_ptr<profiling::EpProfiler> VitisAIExecutionProvider::GetProfiler() {
 
 std::vector<AllocatorPtr> VitisAIExecutionProvider::CreatePreferredAllocators() {
   std::vector<AllocatorPtr> result;
-  // We do not want arena for this, as it would not respect alignment.
-  constexpr const bool use_arena_false = false;
-  AllocatorCreationInfo device_info_cpu_aligned_4k{
+  // We do not want arena for 4k alignment, as it would not respect alignment.
+  // For CPU, use arena
+  // Removed 4k alignment for now, need better fix
+  constexpr const bool use_arena = true;
+  AllocatorCreationInfo device_info_cpu{
       [](OrtDevice::DeviceId device_id) {
         return std::make_unique<CPUAllocator>(
             OrtMemoryInfo(
-                onnxruntime::CPU_ALIGNED_4K, OrtAllocatorType::OrtDeviceAllocator,
+                onnxruntime::CPU, OrtAllocatorType::OrtDeviceAllocator,
                 OrtDevice(OrtDevice::CPU, OrtDevice::MemType::DEFAULT, OrtDevice::VendorIds::NONE,
-                          device_id)));  // Removed 4k alignment for now, need better fix
+                          device_id)));
       },
-      DEFAULT_CPU_ALLOCATOR_DEVICE_ID, use_arena_false};
+      DEFAULT_CPU_ALLOCATOR_DEVICE_ID, use_arena};
 
-  result.push_back(CreateAllocator(device_info_cpu_aligned_4k));
+  result.push_back(CreateAllocator(device_info_cpu));
   return result;
 }
 


### PR DESCRIPTION
Short term solution for IO binding issue with `update_inplace` method of `OrtValue`.

### Description
With ORT 1.23 (main), there seem to be an issue with IOBind feature with 4k aligned preferred allocator.
Remove the 4k alignment requirement for now for a temp fix.

### Motivation and Context
- Fixes issues with IO Binding for few critical models.
- Will bring back 4k alignment when we have a appropriate fix in.


