### PR TITLE
[EP ABI] Signatures for compatibility info methods

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
@@ -336,6 +336,18 @@ typedef enum OrtEpDataLayout {
 } OrtEpDataLayout;
 
 /**
+ * \brief Enumeration describing the compatibility state of a compiled model relative to an execution provider.
+ *
+ * \since Version 1.23.
+ */
+typedef enum OrtCompiledModelCompatibility {
+  OrtCompiledModelCompatibility_EP_NOT_APPLICABLE = 0,
+  OrtCompiledModelCompatibility_EP_SUPPORTED_OPTIMAL,
+  OrtCompiledModelCompatibility_EP_SUPPORTED_PREFER_RECOMPILATION,
+  OrtCompiledModelCompatibility_EP_UNSUPPORTED,
+} OrtCompiledModelCompatibility;
+
+/**
  * \brief The OrtEp struct provides functions to implement for an execution provider.
  * \since Version 1.22.
  */
@@ -522,6 +534,24 @@ struct OrtEp {
    * \since Version 1.23.
    */
   ORT_API2_STATUS(OnRunEnd, _In_ OrtEp* this_ptr, _In_ const OrtRunOptions* run_options, _In_ bool sync_stream);
+
+  /** \brief Get a string with details about the EP stack used to produce a compiled model.
+   *
+   * This function gets a compatibility information string that contains details about the execution provider
+   * used to compile a given model. This string can later be used with ValidateCompiledModelCompatibilityInfo
+   * to determine if a compiled model is compatible with the EP.
+   *
+   * The returned string should be a null-terminated, UTF-8 encoded string. ORT will copy it.
+   *
+   * \param[in] this_ptr The OrtEp instance.
+   * \param[in] graph The OrtGraph instance for which to generate compatibility information.
+   *
+   * \snippet{doc} snippets.dox OrtStatus Return Value
+   *
+   * \since Version 1.23.
+   */
+  const char*(ORT_API_CALL* GetCompiledModelCompatibilityInfo)(_In_ OrtEp* this_ptr,
+                                                               _In_ const OrtGraph* graph);
 };
 
 /** \brief The function signature that ORT will call to create OrtEpFactory instances.
@@ -682,6 +712,23 @@ struct OrtEpFactory {
    * \since Version 1.23.
    */
   ORT_API_T(const char*, GetVersion, _In_ const OrtEpFactory* this_ptr);
+
+  /** \brief Validate the compatibility of a compiled model with the execution provider.
+   *
+   * This function validates if a model produced with the supplied compatibility info string is supported by the underlying EP.
+   * The EP should check if a compiled model is compatible with the EP and set the model_compatibility parameter accordingly.
+   *
+   * \param[in] this_ptr The OrtEpFactory instance.
+   * \param[in] compatibility_info The compatibility information string that will be used
+   * \param[out] model_compatibility OrtCompiledModelCompatibility enum value describing the compatibility of the model with the EP.
+   *
+   * \snippet{doc} snippets.dox OrtStatus Return Value
+   *
+   * \since Version 1.23.
+   */
+  OrtStatus*(ORT_API_CALL* ValidateCompiledModelCompatibilityInfo)(_In_ OrtEpFactory* this_ptr,
+                                                                   _In_ const char* compatibility_info,
+                                                                   _Out_ OrtCompiledModelCompatibility* model_compatibility);
 
   /** \brief Create an OrtAllocator for the given OrtMemoryInfo.
    *


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
This PR proposes two new ABI methods to better support precompiled models. We introduce the concept of a compatibility information string, which is a piece of data produced by an EP implementor to describe the stack that may have been used to compile a model. The `GetCompiledModelCompatibilityInfo` function on the `OrtEp` interface creates this string.

ORT will get the compatibility information string when precompiling a model and will store the output in the model's metadata. When creating sessions against any precompiled models, ORT will use the `ValidateCompiledModelCompatibilityInfo` function to confirm that the model is still compatible. The EP implementor decides how compatibility is defined for their stack and communicates this via the possible states in the enum. 

The validation API is stored on the `OrtEpFactory` to allow for cases where a model may not be present on the device yet (e.g., perhaps an application is trying to decide on a pre-compiled model to download based on the state of the system). 

### Motivation and Context
The APIs proposed in this PR address two requirements:

1. Apps that have an already pre-compiled model on device need a way to determine if the pre-compiled app is still valid (given the EPs / drivers / etc. on the system). 
2. Apps may have many different pre-compiled versions of a model stored on a remote server, and want to figure out which of those models they should download for the device where they are running.
