### PR TITLE
[QNN EP] Add LowPowerBlockQuantization support for Gemm node

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
@@ -430,29 +430,6 @@ Status QnnModelWrapper::UnpackZeroPoints(const std::string& initializer_name,
   return Status::OK();
 }
 
-Status QnnModelWrapper::UnpackScales(const std::string& initializer_name, std::vector<float>& scales) const {
-  const auto& graph_initializers = GetInitializerTensors();
-  auto iter = graph_initializers.find(initializer_name);
-  ORT_RETURN_IF(iter == graph_initializers.end(), "Unable to find initializer for scale(s): ",
-                initializer_name.c_str());
-  gsl::not_null<const onnx::TensorProto*> scale_tensor_proto = iter->second;
-
-  ORT_RETURN_IF_NOT(scale_tensor_proto->has_data_type(), "Expected scale initializer ", initializer_name.c_str(),
-                    " to have a proto data type.");
-  ORT_RETURN_IF_NOT(scale_tensor_proto->data_type() == ONNX_NAMESPACE::TensorProto_DataType_FLOAT,
-                    "Expected scale initializer to be of type FLOAT");
-
-  std::vector<uint8_t> initializer_bytes;
-
-  ORT_RETURN_IF_ERROR(UnpackInitializerData(*scale_tensor_proto, initializer_bytes));
-
-  gsl::span<const float> src = gsl::make_span(reinterpret_cast<const float*>(initializer_bytes.data()),
-                                              initializer_bytes.size() / sizeof(float));
-
-  scales.insert(scales.end(), src.begin(), src.end());
-  return Status::OK();
-}
-
 // Checks if a tensor in the ONNX graph is per-channel quantized.
 Status QnnModelWrapper::IsPerChannelQuantized(const onnxruntime::NodeUnitIODef& io_def,
                                               /*out*/ bool& is_per_channel,

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
@@ -261,8 +261,44 @@ class QnnModelWrapper {
 
   const GraphViewer& GetGraphViewer() const { return graph_viewer_; }
 
-  // Unpack float scales from initializer (1 scale for per-tensor, > 1 for per-axis).
-  Status UnpackScales(const std::string& initializer_name, std::vector<float>& scales) const;
+  // Unpack scales from initializer (1 scale for per-tensor, > 1 for per-axis or per-block).
+  // Template parameter T allows handling both float and uint8_t scale types.
+  template <typename T = float>
+  Status UnpackScales(const std::string& initializer_name, std::vector<T>& scales) const {
+    const auto& graph_initializers = GetInitializerTensors();
+    auto iter = graph_initializers.find(initializer_name);
+    ORT_RETURN_IF(iter == graph_initializers.end(), "Unable to find initializer for scale(s): ",
+                  initializer_name.c_str());
+    gsl::not_null<const onnx::TensorProto*> scale_tensor_proto = iter->second;
+
+    ORT_RETURN_IF_NOT(scale_tensor_proto->has_data_type(), "Expected scale initializer ", initializer_name.c_str(),
+                      " to have a proto data type.");
+
+    // Handle float scales
+    if constexpr (std::is_same_v<T, float>) {
+      // Verify data type for float scales
+      ORT_RETURN_IF_NOT(scale_tensor_proto->data_type() == ONNX_NAMESPACE::TensorProto_DataType_FLOAT,
+                        "Expected float scale initializer to be of type FLOAT");
+
+      std::vector<uint8_t> initializer_bytes;
+      ORT_RETURN_IF_ERROR(UnpackInitializerData(*scale_tensor_proto, initializer_bytes));
+      gsl::span<const float> src = gsl::make_span(reinterpret_cast<const float*>(initializer_bytes.data()),
+                                                  initializer_bytes.size() / sizeof(float));
+      scales.insert(scales.end(), src.begin(), src.end());
+    }
+    // Handle uint8_t scales (for block quantization)
+    else if constexpr (std::is_same_v<T, uint8_t>) {
+      // Verify data type for uint8_t scales
+      ORT_RETURN_IF_NOT(scale_tensor_proto->data_type() == ONNX_NAMESPACE::TensorProto_DataType_UINT8,
+                        "Expected uint8_t scale initializer to be of type UINT8");
+
+      ORT_RETURN_IF_ERROR(UnpackInitializerData(*scale_tensor_proto, scales));
+    } else {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Scale ONNX data type `", typeid(T).name(),
+                             "` is not supported for unpacking.");
+    }
+    return Status::OK();
+  }
 
   // Unpack zero-points from initializer and convert to int32_t (1 zero-point for per-tensor, > 1 for per-channel).
   Status UnpackZeroPoints(const std::string& initializer_name,

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/lpbqgemm_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/lpbqgemm_fusion.cc
@@ -1,0 +1,357 @@
+#include <gsl/gsl>
+#include <algorithm>
+#include <cassert>
+#include <limits>
+#include <optional>
+#include <utility>
+
+#include "core/providers/qnn/ort_api.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+#include "core/providers/qnn/builder/op_builder_factory.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_node_group/utils.h"
+#include "core/providers/qnn/builder/qnn_node_group/lpbqgemm_fusion.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+static Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
+                                    const NodeUnit& scale_dql_node_unit,
+                                    const NodeUnit& w_ql_node_unit,
+                                    const NodeUnit& w_dql_node_unit,
+                                    const NodeUnit& act_dql_node_unit,
+                                    const NodeUnit& gemm_node_unit,
+                                    const NodeUnit& output_ql_node_unit,
+                                    bool validate);
+
+std::unique_ptr<IQnnNodeGroup> LowPowerBlockQuantizedGemmFusion::TryFusion(
+    QnnModelWrapper& qnn_model_wrapper,
+    const NodeUnit& gemm_node_unit,
+    const std::unordered_map<const Node*, const NodeUnit*>& node_to_node_unit,
+    const std::unordered_map<const NodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
+    const logging::Logger& logger) {
+  ORT_UNUSED_PARAMETER(logger);
+
+  // Looking for a Gemm to start search for Gemm w/ LPBQ encodings pattern.
+  if (gemm_node_unit.OpType() != "Gemm") {
+    return nullptr;
+  }
+
+  const GraphViewer& graph_viewer = qnn_model_wrapper.GetGraphViewer();
+
+  // Get DequantizeLinear on Activation (input 0) of Gemm node
+  const NodeUnit* p_act_dql_node_unit = GetParentOfInput(graph_viewer,
+                                                         gemm_node_unit,
+                                                         gemm_node_unit.Inputs()[0],
+                                                         node_to_node_unit,
+                                                         node_unit_to_qnn_node_group);
+  if (p_act_dql_node_unit == nullptr || p_act_dql_node_unit->OpType() != "DequantizeLinear") {
+    return nullptr;
+  }
+
+  // Get DequantizeLinear on Weight (input 1) of Gemm node
+  const NodeUnit* p_w_dql_node_unit = GetParentOfInput(graph_viewer,
+                                                       gemm_node_unit,
+                                                       gemm_node_unit.Inputs()[1],
+                                                       node_to_node_unit,
+                                                       node_unit_to_qnn_node_group);
+  if (p_w_dql_node_unit == nullptr || p_w_dql_node_unit->OpType() != "DequantizeLinear") {
+    return nullptr;
+  }
+
+  // Get QuantizeLinear on Weight (input 1) of Gemm node (optional)
+  const std::array<std::string_view, 1> w_dql_parent_types = {"QuantizeLinear"};
+  const NodeUnit* p_w_ql_node_unit = GetParentOfType(graph_viewer,
+                                                     *p_w_dql_node_unit,
+                                                     w_dql_parent_types,
+                                                     node_to_node_unit,
+                                                     node_unit_to_qnn_node_group);
+  if (p_w_ql_node_unit == nullptr) {
+    return nullptr;
+  }
+
+  // Check if input of QuantizeLinear is constant initializer
+  if (!qnn_model_wrapper.IsConstantInput(p_w_ql_node_unit->Inputs()[0].node_arg.Name())) {
+    return nullptr;
+  }
+
+  // Get DequantizeLinear contains per-block int scales and per-channel float scales
+  const std::array<std::string_view, 1> w_ql_parent_types = {"DequantizeLinear"};
+  const NodeUnit* p_scale_dql_node_unit = GetParentOfType(graph_viewer,
+                                                          *p_w_ql_node_unit,
+                                                          w_ql_parent_types,
+                                                          node_to_node_unit,
+                                                          node_unit_to_qnn_node_group);
+  if (p_scale_dql_node_unit == nullptr) {
+    return nullptr;
+  }
+
+  TensorInfo pc_scales_tensor_info = {};
+  if (Status status = qnn_model_wrapper.GetTensorInfo(p_scale_dql_node_unit->Inputs()[0], pc_scales_tensor_info);
+      !status.IsOK()) {
+    return nullptr;
+  }
+  // Check if input 0 of DequantizeLinear is constant initializer and has per-channel float scales
+  if (!pc_scales_tensor_info.is_initializer || !pc_scales_tensor_info.quant_param.IsPerChannel()) {
+    return nullptr;
+  }
+
+  // Get QuantizeLinear NodeUnit at Gemm output
+  const std::array<std::string_view, 1> gemm_child_types = {"QuantizeLinear"};
+  const NodeUnit* p_output_ql_node_unit = GetOnlyChildOfType(graph_viewer,
+                                                             gemm_node_unit,
+                                                             gemm_child_types,
+                                                             node_to_node_unit,
+                                                             node_unit_to_qnn_node_group);
+  if (p_output_ql_node_unit == nullptr) {
+    return nullptr;
+  }
+
+  if (Status status = CreateOrValidateOnQnn(qnn_model_wrapper,
+                                            *p_scale_dql_node_unit,
+                                            *p_w_ql_node_unit,
+                                            *p_w_dql_node_unit,
+                                            *p_act_dql_node_unit,
+                                            gemm_node_unit,
+                                            *p_output_ql_node_unit,
+                                            true);
+      !status.IsOK()) {
+    return nullptr;
+  }
+
+  return std::make_unique<LowPowerBlockQuantizedGemmFusion>(*p_scale_dql_node_unit,
+                                                            *p_w_ql_node_unit,
+                                                            *p_w_dql_node_unit,
+                                                            *p_act_dql_node_unit,
+                                                            gemm_node_unit,
+                                                            *p_output_ql_node_unit);
+}
+
+LowPowerBlockQuantizedGemmFusion::LowPowerBlockQuantizedGemmFusion(const NodeUnit& Scale_DQL_node_unit,
+                                                                   const NodeUnit& W_QL_node_unit,
+                                                                   const NodeUnit& W_DQL_node_unit,
+                                                                   const NodeUnit& Act_DQL_node_unit,
+                                                                   const NodeUnit& Gemm_node_unit,
+                                                                   const NodeUnit& Output_QL_node_unit)
+    : node_units_{&Scale_DQL_node_unit,
+                  &W_QL_node_unit,
+                  &W_DQL_node_unit,
+                  &Act_DQL_node_unit,
+                  &Gemm_node_unit,
+                  &Output_QL_node_unit} {
+}
+
+Status LowPowerBlockQuantizedGemmFusion::IsSupported(QnnModelWrapper& qmw, const logging::Logger& logger) const {
+  ORT_UNUSED_PARAMETER(logger);
+  return CreateOrValidateOnQnn(qmw, *node_units_[0], *node_units_[1], *node_units_[2], *node_units_[3], *node_units_[4], *node_units_[5], true);
+}
+
+Status LowPowerBlockQuantizedGemmFusion::AddToModelBuilder(QnnModelWrapper& qmw, const logging::Logger& logger) const {
+  ORT_UNUSED_PARAMETER(logger);
+  return CreateOrValidateOnQnn(qmw, *node_units_[0], *node_units_[1], *node_units_[2], *node_units_[3], *node_units_[4], *node_units_[5], false);
+}
+
+gsl::span<const NodeUnit* const> LowPowerBlockQuantizedGemmFusion::GetNodeUnits() const {
+  return node_units_;
+}
+
+const NodeUnit* LowPowerBlockQuantizedGemmFusion::GetTargetNodeUnit() const {
+  return node_units_[4];
+}
+
+Status UnpackWeightTensorData(const QnnModelWrapper& qnn_model_wrapper,
+                              const onnx::TensorProto* weight_tensor_proto,
+                              std::vector<uint32_t>& weight_shape,
+                              int64_t input_channel_axis,
+                              std::vector<uint8_t>& unpacked_tensor) {
+  ORT_RETURN_IF_NOT(weight_tensor_proto != nullptr, "Weight tensor proto is null");
+
+  if (input_channel_axis == 0) {
+    // Transpose to keep output_channel at index 0;
+    // This is needed for proper LPBQ encoding where output channels must be at dimension 0
+    return utils::TwoDimensionTranspose(qnn_model_wrapper, weight_shape, *weight_tensor_proto, unpacked_tensor);
+  } else {
+    // No transpose needed, just unpack the initializer data
+    return qnn_model_wrapper.UnpackInitializerData(*weight_tensor_proto, unpacked_tensor);
+  }
+}
+
+Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
+                             const NodeUnit& scale_dql_node_unit,
+                             const NodeUnit& w_ql_node_unit,
+                             const NodeUnit& w_dql_node_unit,
+                             const NodeUnit& act_dql_node_unit,
+                             const NodeUnit& gemm_node_unit,
+                             const NodeUnit& output_ql_node_unit,
+                             bool validate) {
+  assert(scale_dql_node_unit.OpType() == "DequantizeLinear" &&
+         w_ql_node_unit.OpType() == "QuantizeLinear" &&
+         w_dql_node_unit.OpType() == "DequantizeLinear" &&
+         act_dql_node_unit.OpType() == "DequantizeLinear" &&
+         gemm_node_unit.OpType() == "Gemm" &&
+         output_ql_node_unit.OpType() == "QuantizeLinear");
+  const auto& node_name = utils::GetNodeName(gemm_node_unit);
+  const NodeUnitIODef& act_dql_input_1_def = act_dql_node_unit.Inputs()[0];
+  const NodeUnitIODef& w_dql_input_1_def = w_dql_node_unit.Inputs()[0];
+  const NodeUnitIODef& w_ql_input_1_def = w_ql_node_unit.Inputs()[0];
+  const NodeUnitIODef& output_def = output_ql_node_unit.Outputs()[0];
+
+  // prepare input tensor
+  std::string input_tensor_name = act_dql_input_1_def.node_arg.Name();
+  QnnTensorWrapper input_tensor;
+  ORT_RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(act_dql_input_1_def, input_tensor));
+  // get input_scale value from input[1] of DequantizeLinear
+  std::vector<float> input_scales;
+  const std::optional<NodeUnitIODef::QuantParam>& act_dql_quant_param = act_dql_input_1_def.quant_param;
+  ORT_RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales(act_dql_quant_param->scale.Name(), input_scales));
+  ORT_RETURN_IF_NOT(input_scales.size() == 1,
+                    "Got unexpected size of scales on Gemm Input0. Expected per-tensor scales");
+
+  // Prepare LowPowerBlockQuantized(LPBQ) Weight
+  QnnQuantParamsWrapper weight_qparams;
+
+  // get per_channel_float_scale value from input[1] of DequantizeLinear
+  std::vector<float> per_channel_float_scale;
+  const NodeUnitIODef& per_channel_float_def = scale_dql_node_unit.Inputs()[0];
+  const std::optional<NodeUnitIODef::QuantParam>& scale_dql_quant_param = per_channel_float_def.quant_param;
+  ORT_RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales(scale_dql_quant_param->scale.Name(), per_channel_float_scale));
+
+  // get per_block_int_scale value from input[0] of DequantizeLinear
+  std::vector<uint8_t> per_block_int_scale;
+  const NodeUnitIODef& per_block_int_def = scale_dql_node_unit.Inputs()[0];
+  ORT_RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales<uint8_t>(per_block_int_def.node_arg.Name(), per_block_int_scale));
+  std::vector<int32_t> weight_offset(per_channel_float_scale.size(), 0);
+  std::vector<uint32_t> block_scales_shape;
+  ORT_RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(per_block_int_def.node_arg, block_scales_shape), "Failed to get block_scales shape");
+  // Get attributes like axis, block_size from QuantizeLinear
+  NodeAttrHelper scales_node_helper(scale_dql_node_unit.GetNode());
+  auto block_scales_axis = scales_node_helper.Get("axis", static_cast<int64_t>(0));
+
+  const std::optional<NodeUnitIODef::QuantParam>& w_dql_quant_param = w_dql_input_1_def.quant_param;
+  bool is_int4_type = false;
+  if (w_dql_quant_param->zero_point != nullptr) {
+    int32_t elem_data_type = 0;
+    ORT_RETURN_IF_ERROR(utils::GetOnnxTensorElemDataType(*w_dql_quant_param->zero_point, elem_data_type));
+    is_int4_type = (elem_data_type == ONNX_NAMESPACE::TensorProto_DataType_INT4) ||
+                   (elem_data_type == ONNX_NAMESPACE::TensorProto_DataType_UINT4);
+  }
+
+  // Get attributes like axis, block_size from QuantizeLinear
+  NodeAttrHelper helper(w_ql_node_unit.GetNode());
+  auto input_channel_axis = helper.Get("axis", static_cast<int64_t>(0));
+  auto block_size = helper.Get("block_size", static_cast<int64_t>(0));
+
+  size_t output_channel_axis = 0;  // Current LowPowerBlockQuantize() support output_channel_axis at index=0;
+  weight_qparams = QnnQuantParamsWrapper(per_channel_float_scale, per_block_int_scale, weight_offset, output_channel_axis, block_size, is_int4_type);
+
+  std::vector<uint32_t> weight_shape;
+  std::vector<uint8_t> unpacked_tensor;
+  std::string weight_tensor_name = w_ql_input_1_def.node_arg.Name();
+  ORT_RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(w_ql_input_1_def.node_arg, weight_shape), "Failed to get weight shape");
+  Qnn_DataType_t weight_data_type = is_int4_type ? QNN_DATATYPE_SFIXED_POINT_4 : QNN_DATATYPE_SFIXED_POINT_8;
+  const auto& weight_tensor_proto = qnn_model_wrapper.GetConstantTensor(weight_tensor_name);
+  ORT_RETURN_IF_ERROR(UnpackWeightTensorData(qnn_model_wrapper, weight_tensor_proto, weight_shape, input_channel_axis, unpacked_tensor));
+
+  // Quantize weight tensor
+  size_t weight_elements = unpacked_tensor.size() / sizeof(float);
+  auto float_data = gsl::make_span<const float>(reinterpret_cast<const float*>(unpacked_tensor.data()), weight_elements);
+  std::vector<uint8_t> quant_data(weight_elements);
+
+  // scale = per_channel_float_scale * per_block_int_scale
+  // weight_data_type = 4 but store in int8 buffer
+  ORT_RETURN_IF_ERROR(qnn::utils::LowPowerBlockQuantizeData(float_data,
+                                                            weight_shape,
+                                                            per_channel_float_scale,
+                                                            per_block_int_scale,
+                                                            weight_offset,
+                                                            quant_data,
+                                                            weight_data_type,
+                                                            output_channel_axis,
+                                                            block_scales_axis,
+                                                            block_size,
+                                                            block_scales_shape));
+
+  // Get weight tensor type from input of w_dql_tensor or output_dql_tensor
+  Qnn_TensorType_t weight_tensor_type = qnn_model_wrapper.GetTensorType(weight_tensor_name);
+  QnnTensorWrapper weight_tensor(weight_tensor_name, weight_tensor_type, QNN_DATATYPE_SFIXED_POINT_8,
+                                 std::move(weight_qparams), std::move(weight_shape),
+                                 std::move(quant_data));
+
+  // Prepare Bias tensor;
+  // Bias tensor is in FP32 and need to quantize to datatype of input 0 of Gemm
+  QnnTensorWrapper bias_tensor;
+  const NodeUnitIODef* bias_def_ptr = nullptr;
+  bool has_bias = gemm_node_unit.Inputs().size() == 3 && gemm_node_unit.Inputs()[2].node_arg.Exists();
+  if (has_bias) {
+    bias_def_ptr = &gemm_node_unit.Inputs()[2];
+    std::vector<uint32_t> bias_shape;
+    std::string bias_tensor_name = bias_def_ptr->node_arg.Name();
+    ORT_RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(bias_def_ptr->node_arg, bias_shape), "Failed to get bias shape");
+    Qnn_DataType_t bias_data_type = QNN_DATATYPE_SFIXED_POINT_32;
+    Qnn_TensorType_t bias_tensor_type = qnn_model_wrapper.GetTensorType(bias_tensor_name);
+    const auto& bias_tensor_proto = qnn_model_wrapper.GetConstantTensor(bias_tensor_name);
+
+    // Prepare scale for bias as input scale * per_channel_float_scales;
+    std::vector<float> bias_scales(per_channel_float_scale.size());
+    std::transform(per_channel_float_scale.begin(), per_channel_float_scale.end(), bias_scales.begin(),
+                   [input_scales](float x) { return x * input_scales[0]; });
+
+    // bias_offset = vector of zero's
+    std::vector<int32_t> bias_offsets(bias_scales.size(), 0);
+
+    // Read bias tensor buffer
+    std::vector<uint8_t> unpacked_bias_tensor;
+    ORT_RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(*bias_tensor_proto, unpacked_bias_tensor));
+
+    // Quantize bias tensor
+    size_t bias_elements = unpacked_bias_tensor.size() / sizeof(float);
+    auto bias_float_data = gsl::make_span<const float>(reinterpret_cast<const float*>(unpacked_bias_tensor.data()), bias_elements);
+    std::vector<uint8_t> bias_quant_data(bias_elements * qnn::utils::GetElementSizeByType(bias_data_type));
+
+    ORT_RETURN_IF_ERROR(qnn::utils::QuantizeData(bias_float_data, bias_shape, bias_scales, bias_offsets, bias_quant_data, bias_data_type, /*axis*/ 0));
+    QnnQuantParamsWrapper bias_qparams(bias_scales, bias_offsets, /*axis*/ 0, /*is_int4*/ 0);
+
+    bias_tensor = QnnTensorWrapper(bias_tensor_name, bias_tensor_type, bias_data_type,
+                                   std::move(bias_qparams), std::move(bias_shape),
+                                   std::move(bias_quant_data));
+  }
+
+  // Prepare Output
+  QnnTensorWrapper output_tensor;
+  ORT_RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(output_def, output_tensor));
+
+  if (validate) {
+    std::vector<Qnn_Tensor_t> input_tensors = {input_tensor.GetQnnTensor(), weight_tensor.GetQnnTensor()};
+    if (has_bias) {
+      input_tensors.emplace_back(bias_tensor.GetQnnTensor());
+    }
+
+    ORT_RETURN_IF_ERROR(qnn_model_wrapper.ValidateQnnNode(node_name,
+                                                          QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                          QNN_OP_FULLY_CONNECTED,
+                                                          std::move(input_tensors),
+                                                          {output_tensor.GetQnnTensor()},
+                                                          {}));
+  } else {
+    ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(input_tensor)), "Failed to add input");
+    ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(weight_tensor)), "Failed to add weight");
+    if (has_bias) {
+      ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bias_tensor)), "Failed to add bias");
+    }
+
+    ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensor)), "Failed to add output");
+    std::vector<std::string> input_names = {input_tensor_name, weight_tensor_name};
+    ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(node_name,
+                                                      QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                      QNN_OP_MAT_MUL,
+                                                      std::move(input_names),
+                                                      {output_def.node_arg.Name()},
+                                                      {},
+                                                      validate),
+                      "Failed to Fuse Gemm w/ LPBQ Sequence into MatMul w/ LPBQ encodings.");
+  }
+
+  return Status();
+}
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/lpbqgemm_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/lpbqgemm_fusion.cc
@@ -343,7 +343,7 @@ Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
     std::vector<std::string> input_names = {input_tensor_name, weight_tensor_name};
     ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(node_name,
                                                       QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                                      QNN_OP_MAT_MUL,
+                                                      QNN_OP_FULLY_CONNECTED,
                                                       std::move(input_names),
                                                       {output_def.node_arg.Name()},
                                                       {},

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/lpbqgemm_fusion.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/lpbqgemm_fusion.h
@@ -1,0 +1,52 @@
+// Copyright (c) Qualcomm. All rights reserved.
+// Licensed under the MIT License
+
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include "core/providers/qnn/ort_api.h"
+#include "core/providers/qnn/builder/qnn_node_group/qnn_node_group.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+class QnnModelWrapper;
+
+/// <summary>
+/// Represents a fusion of a {DQ, DQ->Q->DQ} -> Gemm -> DQ sequence.
+/// This is translated into a QNN's FC w/ LPBQ encodings.
+/// The contained NodeUnits are of type SingleNode since they are not part of a QDQ node unit.
+/// </summary>
+
+class LowPowerBlockQuantizedGemmFusion : public IQnnNodeGroup {
+ public:
+  LowPowerBlockQuantizedGemmFusion(const NodeUnit& Scale_DQL_node_unit,
+                                   const NodeUnit& W_QL_node_unit,
+                                   const NodeUnit& W_DQL_node_unit,
+                                   const NodeUnit& Act_DQL_node_unit,
+                                   const NodeUnit& Gemm_node_unit,
+                                   const NodeUnit& Output_QL_node_unit);
+  ORT_DISALLOW_COPY_AND_ASSIGNMENT(LowPowerBlockQuantizedGemmFusion);
+
+  Status IsSupported(QnnModelWrapper& qmw, const logging::Logger& logger) const override;
+  Status AddToModelBuilder(QnnModelWrapper& qmw, const logging::Logger& logger) const override;
+  gsl::span<const NodeUnit* const> GetNodeUnits() const override;
+  const NodeUnit* GetTargetNodeUnit() const override;
+  std::string_view Type() const override { return "LowPowerBlockQuantizedGemmFusion"; }
+
+  static std::unique_ptr<IQnnNodeGroup> TryFusion(
+      QnnModelWrapper& qnn_model_wrapper,
+      const NodeUnit& scale_dql_node_unit,
+      const std::unordered_map<const Node*, const NodeUnit*>& node_to_node_unit,
+      const std::unordered_map<const NodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
+      const logging::Logger& logger);
+
+ private:
+  std::array<const NodeUnit*, 6> node_units_;
+};
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
@@ -94,7 +94,7 @@ void registerUDO(const std::string& node_type, const std::string& op_package) {
                                 /*node_to_node_unit=*/std::placeholders::_3,
                                 /*node_unit_to_qnn_node_group=*/std::placeholders::_4,
                                 /*logger=*/std::placeholders::_5);
-  fusions[node_type] = boundFunction;
+  fusions[node_type] = {boundFunction};
 }
 /// <summary>
 /// Given a starting NodeUnit, this function tries all possible fusions that start with that NodeUnit.

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
@@ -18,6 +18,7 @@
 #include "core/providers/qnn/builder/qnn_node_group/scale_softmax_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/channel_shuffle_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/udo_fusion.h"
+#include "core/providers/qnn/builder/qnn_node_group/lpbqgemm_fusion.h"
 
 #include "core/providers/qnn/builder/qnn_utils.h"
 #include "core/providers/qnn/ort_api.h"
@@ -72,12 +73,12 @@ using FusionFunc = std::function<std::unique_ptr<IQnnNodeGroup>(QnnModelWrapper&
                                                                 const logging::Logger& logger)>;
 
 // Maps a starting operator type to the fusion function.
-static std::unordered_map<std::string, FusionFunc> fusions = {
-    {"DequantizeLinear", DQQFusion::TryFusion},
-    {"HardSigmoid", HardSigmoidMulFusion::TryFusion},
-    {"Gemm", ReshapeGemmFusion::TryFusion},
-    {"Mul", ScaleSoftmaxFusion::TryFusion},
-    {"Transpose", ChannelShuffleFusion::TryFusion}};
+static std::unordered_map<std::string, std::vector<FusionFunc>> fusions = {
+    {"DequantizeLinear", {DQQFusion::TryFusion}},
+    {"HardSigmoid", {HardSigmoidMulFusion::TryFusion}},
+    {"Gemm", {LowPowerBlockQuantizedGemmFusion::TryFusion, ReshapeGemmFusion::TryFusion}},
+    {"Mul", {ScaleSoftmaxFusion::TryFusion}},
+    {"Transpose", {ChannelShuffleFusion::TryFusion}}};
 
 void registerUDO(const std::string& node_type, const std::string& op_package) {
   std::function<std::unique_ptr<IQnnNodeGroup>(QnnModelWrapper & qnn_model_wrapper,
@@ -119,9 +120,13 @@ static std::unique_ptr<IQnnNodeGroup> TryQnnFusions(
 
   auto iter = fusions.find(starting_node_unit.OpType());
   if (iter != fusions.end()) {
-    FusionFunc fusion_func = iter->second;
-    return fusion_func(qnn_model_wrapper, starting_node_unit, node_to_node_unit,
-                       node_unit_to_qnn_node_group, logger);
+    for (auto& fusion_func : iter->second) {
+      std::unique_ptr<IQnnNodeGroup> fused_node_group = fusion_func(qnn_model_wrapper, starting_node_unit, node_to_node_unit,
+                                                                    node_unit_to_qnn_node_group, logger);
+      if (fused_node_group) {
+        return fused_node_group;
+      }
+    }
   }
   return nullptr;
 }

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/utils.cc
@@ -61,5 +61,161 @@ const NodeUnit* GetOnlyChildOfType(const GraphViewer& graph_viewer,
   return child_node_unit;
 }
 
+const NodeUnit* GetChildOfType(const GraphViewer& graph_viewer,
+                               const NodeUnit& parent_node_unit,
+                               gsl::span<const std::string_view> child_op_types,
+                               const std::unordered_map<const Node*, const NodeUnit*>& node_unit_map,
+                               const std::unordered_map<const NodeUnit*, const IQnnNodeGroup*>& qnn_node_group_map) {
+  const Node& parent_node = parent_node_unit.GetNode();
+
+  // Parent must not produce a graph output.
+  // This check ensures we don't try to fuse with nodes that produce graph outputs
+  if (graph_viewer.NodeProducesGraphOutput(parent_node)) {
+    return nullptr;
+  }
+
+  // Child must be of a valid type.
+  for (auto edge = parent_node.OutputEdgesBegin(); edge != parent_node.OutputEdgesEnd(); ++edge) {
+    const Node& child_node = edge->GetNode();
+    if (graph_viewer.GetNode(child_node.Index()) == nullptr) {
+      return nullptr;  // Node is not in this GraphViewer
+    }
+    const std::string& child_type = child_node.OpType();
+    bool is_valid_child_type = false;
+
+    for (const auto& valid_op_type : child_op_types) {
+      if (valid_op_type == child_type) {
+        is_valid_child_type = true;
+        break;
+      }
+    }
+
+    if (!is_valid_child_type) {
+      continue;
+    }
+
+    const auto child_node_unit_it = node_unit_map.find(&child_node);
+    if (child_node_unit_it == node_unit_map.end()) {
+      return nullptr;
+    }
+    const NodeUnit* child_node_unit = child_node_unit_it->second;
+
+    // Check if child node has already been handled. Should not be the case if the calling
+    // fusion function has been called in topological order, but check to be safe.
+    if (qnn_node_group_map.count(child_node_unit) != 0) {
+      return nullptr;
+    }
+
+    // child must not already be part of a QDQ NodeUnit (i.e., be standalone).
+    if (child_node_unit->UnitType() != NodeUnit::Type::SingleNode) {
+      return nullptr;
+    }
+
+    return child_node_unit;
+  }
+
+  return nullptr;
+}
+
+const NodeUnit* GetParentOfType(const GraphViewer& graph_viewer,
+                                const NodeUnit& child_node_unit,
+                                gsl::span<const std::string_view> parent_op_types,
+                                const std::unordered_map<const Node*, const NodeUnit*>& node_unit_map,
+                                const std::unordered_map<const NodeUnit*, const IQnnNodeGroup*>& qnn_node_group_map) {
+  const Node& child_node = child_node_unit.GetNode();
+
+  for (auto edge = child_node.InputEdgesBegin(); edge != child_node.InputEdgesEnd(); ++edge) {
+    const Node& parent_node = edge->GetNode();
+    if (graph_viewer.GetNode(parent_node.Index()) == nullptr) {
+      // Node is not in this GraphViewer
+      return nullptr;
+    }
+
+    if (graph_viewer.NodeProducesGraphOutput(parent_node)) {
+      // Node is producing a graph output
+      return nullptr;
+    }
+
+    const std::string& parent_type = parent_node.OpType();
+    bool is_valid_parent_type = false;
+
+    for (const auto& valid_op_type : parent_op_types) {
+      if (valid_op_type == parent_type) {
+        is_valid_parent_type = true;
+        break;
+      }
+    }
+
+    if (!is_valid_parent_type) {
+      continue;
+    }
+
+    const auto parent_node_unit_it = node_unit_map.find(&parent_node);
+    if (parent_node_unit_it == node_unit_map.end()) {
+      return nullptr;
+    }
+    const NodeUnit* p_parent_node_unit = parent_node_unit_it->second;
+
+    // Check if parent node has already been handled. Should not be the case if the calling
+    // fusion function has been called in topological order, but check to be safe.
+    if (qnn_node_group_map.count(p_parent_node_unit) != 0) {
+      return nullptr;
+    }
+
+    // parent must not already be part of a QDQ NodeUnit (i.e., be standalone).
+    if (p_parent_node_unit->UnitType() != NodeUnit::Type::SingleNode) {
+      return nullptr;
+    }
+
+    return p_parent_node_unit;
+  }
+  return nullptr;
+}
+
+const NodeUnit* GetParentOfInput(const GraphViewer& graph_viewer,
+                                 const NodeUnit& node_unit,
+                                 const NodeUnitIODef& input,
+                                 const std::unordered_map<const Node*, const NodeUnit*>& node_unit_map,
+                                 const std::unordered_map<const NodeUnit*, const IQnnNodeGroup*>& qnn_node_group_map) {
+  const Node& child_node = node_unit.GetNode();
+
+  for (auto edge = child_node.InputEdgesBegin(); edge != child_node.InputEdgesEnd(); ++edge) {
+    const Node& parent_node = edge->GetNode();
+    if (parent_node.OutputDefs()[0]->Name() != input.node_arg.Name()) {
+      continue;
+    }
+
+    if (graph_viewer.GetNode(parent_node.Index()) == nullptr) {
+      // Node is not in this GraphViewer
+      return nullptr;
+    }
+
+    if (graph_viewer.NodeProducesGraphOutput(parent_node)) {
+      // Node is producing a graph output
+      return nullptr;
+    }
+
+    const auto parent_node_unit_it = node_unit_map.find(&parent_node);
+    if (parent_node_unit_it == node_unit_map.end()) {
+      return nullptr;
+    }
+    const NodeUnit* p_parent_node_unit = parent_node_unit_it->second;
+
+    // Check if parent node has already been handled. Should not be the case if the calling
+    // fusion function has been called in topological order, but check to be safe.
+    if (qnn_node_group_map.count(p_parent_node_unit) != 0) {
+      return nullptr;
+    }
+
+    // parent must not already be part of a QDQ NodeUnit (i.e., be standalone).
+    if (p_parent_node_unit->UnitType() != NodeUnit::Type::SingleNode) {
+      return nullptr;
+    }
+
+    return p_parent_node_unit;
+  }
+  return nullptr;
+}
+
 }  // namespace qnn
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/utils.h
@@ -34,6 +34,22 @@ const NodeUnit* GetOnlyChildOfType(const GraphViewer& graph_viewer,
                                    gsl::span<const std::string_view> child_op_types,
                                    const std::unordered_map<const Node*, const NodeUnit*>& node_unit_map,
                                    const std::unordered_map<const NodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group);
+const NodeUnit* GetChildOfType(const GraphViewer& graph_viewer,
+                               const NodeUnit& parent_node_unit,
+                               gsl::span<const std::string_view> child_op_types,
+                               const std::unordered_map<const Node*, const NodeUnit*>& node_unit_map,
+                               const std::unordered_map<const NodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group);
+const NodeUnit* GetParentOfType(const GraphViewer& graph_viewer,
+                                const NodeUnit& child_node_unit,
+                                gsl::span<const std::string_view> parent_op_types,
+                                const std::unordered_map<const Node*, const NodeUnit*>& node_unit_map,
+                                const std::unordered_map<const NodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group);
+
+const NodeUnit* GetParentOfInput(const GraphViewer& graph_viewer,
+                                 const NodeUnit& node_unit,
+                                 const NodeUnitIODef& input,
+                                 const std::unordered_map<const Node*, const NodeUnit*>& node_unit_map,
+                                 const std::unordered_map<const NodeUnit*, const IQnnNodeGroup*>& qnn_node_group_map);
 
 }  // namespace qnn
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.h
@@ -30,11 +30,15 @@ class QnnQuantParamsWrapper {
   // Construct a per-channel quantization param.
   QnnQuantParamsWrapper(gsl::span<const float> scales, gsl::span<const int32_t> offsets, int32_t axis, bool is_int4);
 
+  // Construct a LPBQ quantization param.
+  QnnQuantParamsWrapper(gsl::span<const float> per_channel_float_scales, gsl::span<const uint8_t> per_block_int_scales,
+                        gsl::span<const int32_t> offsets, int64_t axis, int64_t block_size, bool is_int4);
+
   Qnn_QuantizeParams_t& Get() { return params_; }
   const Qnn_QuantizeParams_t& Get() const { return params_; }
 
   // Initialize this object from a raw Qnn_QuantizeParam_t object.
-  Status Init(const Qnn_QuantizeParams_t& params);
+  Status Init(const Qnn_QuantizeParams_t& params, const size_t lpbq_num_scaleoffsets = 0);
 
   // Initialize this object from a (potentially) quantized ONNX tensor.
   // QnnModelWrapper provides utilities for unpacking scale and zero-point ONNX initializers.
@@ -56,6 +60,11 @@ class QnnQuantParamsWrapper {
     return params_.encodingDefinition == QNN_DEFINITION_DEFINED &&
            (params_.quantizationEncoding == QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET ||
             (params_.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET));
+  }
+
+  bool IsLPBQ() const {
+    return params_.encodingDefinition == QNN_DEFINITION_DEFINED &&
+           (params_.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BLOCKWISE_EXPANSION);
   }
 
   // Get a copy of scales. Works for both per-tensor and per-channel.
@@ -148,6 +157,12 @@ class QnnQuantParamsWrapper {
   // - QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET: array of scale/zp pairs [{scale0, zp0}, {scale1, zp1}, ...]
   // - QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET: parallel arrays for scales and zps [scale0, ...] [zp0, zp1, ...]
   std::unique_ptr<char[]> per_channel_data_;
+
+  // Stores LowPowerBlockQuant encodings meta like number of per_channel_scales, per-block scales,
+  // and blockwise_expansion_data
+  uint32_t per_channel_scales_size_;
+  std::unique_ptr<uint8_t[]> block_scales_data_;
+  std::unique_ptr<char[]> blockwise_expansion_data_;
 };
 
 }  // namespace qnn

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -1037,6 +1037,99 @@ Status QuantizeData(gsl::span<const float> data, gsl::span<const uint32_t> shape
   return Status::OK();
 }
 
+/**
+ * @brief QuantizeData with LPBQ encodings (per_channel_float_scales, per_block_int_scales)
+ * @pre-condition data should have axis at 0
+ *
+ * @param data float data of Gemm weight
+ * @param data_shape shape of Gemm weight
+ * @param pc_f_scales per-channel float scales
+ * @param pb_i_scales per-block int scales
+ * @param pc_offsets per-channel offsets
+ * @param quantize data (int4 data) stored in uint8
+ * @param data_type data_type of quantized tensor (int4)
+ * @param axis channel dimension (default: 0)
+ * @param block_size size of block in a channel
+ * @param block_scales_shape shape of block scales
+ */
+Status LowPowerBlockQuantizeData(gsl::span<const float> data,
+                                 gsl::span<const uint32_t> data_shape,
+                                 gsl::span<const float> channel_scales,
+                                 gsl::span<const uint8_t> block_scales,
+                                 gsl::span<const int32_t> offsets,
+                                 /*out*/ gsl::span<uint8_t> quant_bytes,
+                                 Qnn_DataType_t data_type,
+                                 int64_t data_axis,
+                                 int64_t block_scales_axis,
+                                 size_t data_block_size,
+                                 gsl::span<const uint32_t> block_scales_shape) {
+  // transpose weight to match [K, N] where K : In Channel and N : Out Channel
+  const size_t num_dims = data_shape.size();
+  const size_t num_elems = ShapeSizeCalc(data_shape, 0, num_dims);
+  ORT_RETURN_IF_NOT(num_elems == data.size(), "Shape mismatch with data to quantize");
+  // LPBQ is currently supported for INT4 and INT8 types. INT4 weight is stored in INT8 buffer.
+  size_t expected_num_quant_bytes = GetElementSizeByType(QNN_DATATYPE_SFIXED_POINT_8) * data.size();
+  ORT_RETURN_IF_NOT(quant_bytes.size() == expected_num_quant_bytes,
+                    "Cannot quantize data because output buffer is not the correct size");
+
+  size_t data_axis_no_neg = data_axis < 0 ? static_cast<size_t>(data_axis) + num_dims : static_cast<size_t>(data_axis);
+
+  size_t block_scales_axis_no_neg = block_scales_axis < 0 ? static_cast<size_t>(block_scales_axis) + num_dims : static_cast<size_t>(block_scales_axis);
+
+  // Assumption: data is of rank-2 with OutChannels at 0-dim
+  ORT_RETURN_IF_NOT(data_axis_no_neg == 0, "BlockQuantize works for Output Channel at axis 0");  // Data is expected in format: OI or OIHW; Output channel at axis-0
+  // Current implementation is expecting block axis at axis-0
+  ORT_RETURN_IF_NOT(data_shape[data_axis_no_neg] == block_scales_shape[block_scales_axis_no_neg], "Incompatible shape of block_scales w.r.t data");
+
+  size_t channel_count = data_shape[data_axis_no_neg];
+  size_t block_count = (block_scales_axis_no_neg == 0) ? block_scales_shape[1] : block_scales_shape[0];
+  size_t data_block_count = ShapeSizeCalc(data_shape, data_axis_no_neg + 1, num_dims) / data_block_size;
+
+  ORT_RETURN_IF_NOT(data_block_count == block_count, "Incompatible LowPowerBlockQuantization encodings.");
+  ORT_RETURN_IF_NOT(channel_scales.size() == channel_count, "Unexpected size of per-channel-float-scales output buffer");
+  ORT_RETURN_IF_NOT(offsets.size() == channel_count, "Unexpected size of offsets output buffer");
+  ORT_RETURN_IF_NOT(block_scales.size() == channel_count * block_count, "Unexpected size of Per-block-int-scales output buffer");
+
+  // Pre-determine the block_scales_index calculation method based on the axis configuration
+  // If block_scales_axis is 0, then the channel dimension comes first in the block scales tensor
+  // Otherwise, the block dimension comes first
+  bool is_channel_first = (block_scales_axis_no_neg == 0);
+
+  size_t i = 0;
+  for (size_t cn = 0; cn < channel_count; ++cn) {
+    for (size_t bn = 0; bn < block_count; ++bn) {
+      auto input_span = gsl::make_span<const float>(&data[i], data_block_size);
+      auto output_span = gsl::make_span<uint8_t>(&quant_bytes[i * sizeof(int8_t)], sizeof(int8_t) * data_block_size);
+
+      // Calculate the index into the block_scales array based on the layout
+      // For channel-first layout: index = cn * block_count + bn
+      // For block-first layout: index = bn * channel_count + cn
+      size_t block_scales_index = is_channel_first ? (cn * block_count + bn) : (bn * channel_count + cn);
+
+      // Combine the per-channel float scale with the per-block int scale
+      const float scale = channel_scales[cn] * static_cast<float>(block_scales[block_scales_index]);
+
+      switch (data_type) {
+        case QNN_DATATYPE_SFIXED_POINT_8: {
+          ORT_RETURN_IF_ERROR(QuantizeData<int8_t>(input_span, scale, offsets[cn], output_span));
+          break;
+        }
+        case QNN_DATATYPE_SFIXED_POINT_4: {
+          ORT_RETURN_IF_ERROR(QuantizeData<Int4QuantTraits>(input_span, scale, offsets[cn], output_span));
+          break;
+        }
+        default:
+          return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Unsupported quantization data type for LowPowerBlockQuantizeData");
+      }
+      i += data_block_size;
+    }
+  }
+
+  ORT_RETURN_IF_NOT(i == data.size(), "Failed to LowPowerBlockQuantize due to mismatch per-channel and per-block scales");
+
+  return Status::OK();
+}
+
 std::string GetQnnErrorMessage(const QNN_INTERFACE_VER_TYPE& qnn_interface, Qnn_ErrorHandle_t qnn_error_handle) {
   const char* error_msg = nullptr;
   if (qnn_interface.errorGetMessage(qnn_error_handle, &error_msg) == QNN_SUCCESS) {

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -1043,13 +1043,13 @@ Status QuantizeData(gsl::span<const float> data, gsl::span<const uint32_t> shape
  *
  * @param data float data of Gemm weight
  * @param data_shape shape of Gemm weight
- * @param pc_f_scales per-channel float scales
- * @param pb_i_scales per-block int scales
- * @param pc_offsets per-channel offsets
- * @param quantize data (int4 data) stored in uint8
+ * @param channel_scales per-channel float scales
+ * @param block_scales per-block int scales
+ * @param offsets per-channel offsets
+ * @param quant_bytes data (int4 data) stored in uint8
  * @param data_type data_type of quantized tensor (int4)
- * @param axis channel dimension (default: 0)
- * @param block_size size of block in a channel
+ * @param data_axis channel dimension (default: 0)
+ * @param block_scales_axis size of block in a channel
  * @param block_scales_shape shape of block scales
  */
 Status LowPowerBlockQuantizeData(gsl::span<const float> data,

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.h
@@ -271,8 +271,8 @@ inline Status QuantizeData<Int4QuantTraits>(gsl::span<const float> data, float s
   const size_t expected_output_bytes = sizeof(int8_t) * num_elems;
   ORT_RETURN_IF_NOT(expected_output_bytes == quant_bytes.size(),
                     "Output buffer is not large enough to hold quantized bytes.");
-  const double clip_min = static_cast<double>(-8.0f);
-  const double clip_max = static_cast<double>(7.0f);
+  const double clip_min = static_cast<double>(Int4QuantTraits::clip_min);
+  const double clip_max = static_cast<double>(Int4QuantTraits::clip_max);
 
   int8_t* output = reinterpret_cast<int8_t*>(quant_bytes.data());
   for (size_t i = 0; i < num_elems; ++i) {

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.h
@@ -207,6 +207,21 @@ Status QuantizeData(gsl::span<const float> data, gsl::span<const uint32_t> shape
                     /*out*/ gsl::span<uint8_t> quant_bytes, Qnn_DataType_t data_type,
                     std::optional<int64_t> axis = std::nullopt);
 
+// Quantizes the given float data using the provided Low Power Block Quantization parameters
+// (float channel_scales, int block_scales and offsets)
+// The provided offsets must use the QNN convention where offset = -zero_point.
+Status LowPowerBlockQuantizeData(gsl::span<const float> data,
+                                 gsl::span<const uint32_t> data_shape,
+                                 gsl::span<const float> channel_scales,
+                                 gsl::span<const uint8_t> block_scales,
+                                 gsl::span<const int32_t> offsets,
+                                 /*out*/ gsl::span<uint8_t> quant_bytes,
+                                 Qnn_DataType_t data_type,
+                                 int64_t data_axis,
+                                 int64_t block_scales_axis,
+                                 size_t channel_block_size,
+                                 gsl::span<const uint32_t> block_scales_shape);
+
 // Quantizes (per-tensor) the given float data using the provided scale and offset.
 // The provided offset must use the QNN convention where offset = -zero_point.
 template <typename QuantType>
@@ -227,6 +242,46 @@ inline Status QuantizeData(gsl::span<const float> data, float scale, int32_t off
     float_val = std::max(float_val, clip_min);
     float_val = std::min(float_val, clip_max);
     output[i] = static_cast<QuantType>(float_val);
+  }
+  return Status::OK();
+}
+
+// Define a specialized struct for Int4 quantization traits
+// This allows us to use template specialization for Int4 quantization while
+// maintaining a consistent interface with other quantization types
+struct Int4QuantTraits {
+  // The storage type used for Int4 values (int8_t is used since QNN expects
+  // Int4 values to be stored in 8-bit containers with the upper 4 bits unused)
+  using StorageType = int8_t;
+
+  // Clipping range for Int4 values:
+  // - For signed Int4, the range is [-8, 7]
+  // - We use these constants to ensure quantized values stay within valid range
+  static constexpr double clip_min = -8.0;
+  static constexpr double clip_max = 7.0;
+};
+
+// Template specialization for Int4 quantization
+// Quantizes (per-tensor) the given float data using the provided scale and offset.
+// The provided offset must use the QNN convention where offset = -zero_point.
+template <>
+inline Status QuantizeData<Int4QuantTraits>(gsl::span<const float> data, float scale, int32_t offset,
+                                            /*out*/ gsl::span<uint8_t> quant_bytes) {
+  const size_t num_elems = data.size();
+  const size_t expected_output_bytes = sizeof(int8_t) * num_elems;
+  ORT_RETURN_IF_NOT(expected_output_bytes == quant_bytes.size(),
+                    "Output buffer is not large enough to hold quantized bytes.");
+  const double clip_min = static_cast<double>(-8.0f);
+  const double clip_max = static_cast<double>(7.0f);
+
+  int8_t* output = reinterpret_cast<int8_t*>(quant_bytes.data());
+  for (size_t i = 0; i < num_elems; ++i) {
+    const double scale_dbl = static_cast<double>(scale);
+    const double offset_dbl = static_cast<double>(offset);
+    double float_val = std::nearbyint(static_cast<double>(data[i]) / scale_dbl) - offset_dbl;
+    float_val = std::max(float_val, clip_min);
+    float_val = std::min(float_val, clip_max);
+    output[i] = static_cast<int8_t>(float_val);
   }
   return Status::OK();
 }


### PR DESCRIPTION
### Description 
- Low Power Block Quantization(LPBQ) is widely used to accelerate accuracy sensitive models via QNN(Qualcomm Neural Network) stack.
 - LPBQ encoding format is Qualcomm's alternative for BlockQuantization technique.
 - The current implementation expects LPBQ encodings packed in a node sequence (DQ -> Q -> DQ)
 - This PR folds LPBQ pattern on Weight of Gemm nodes into a Qnn BlockExpansion encoding structure.
 - This PR adds INT4 Quantization support



### Motivation and Context
- This enables acceleration of accuracy sensitive models that require block quantization kind of encodings via QNN EP
- This avoids fallback of nodes consuming block quantized tensors on CPU EP and further improves inference time.


