### PR TITLE
Add arena that uses EP API so that an EP library can be self-sufficient.

### DIFF
--- a/include/onnxruntime/core/framework/allocator.h
+++ b/include/onnxruntime/core/framework/allocator.h
@@ -86,8 +86,11 @@ class Stream;
 namespace synchronize {
 class Notification;
 }
+
 using WaitNotificationFn = std::function<void(Stream*, synchronize::Notification&)>;
-void* AllocateBufferWithOptions(IAllocator& allocator, size_t size, bool use_reserve, Stream* stream, WaitNotificationFn wait_fn);
+void* AllocateBufferWithOptions(IAllocator& allocator, size_t size, bool use_reserve, Stream* stream,
+                                // wait fn is for backwards compat with provider bridge
+                                WaitNotificationFn ignored = nullptr);
 
 template <typename T>
 using IAllocatorUniquePtr = std::unique_ptr<T, std::function<void(T*)>>;
@@ -104,6 +107,9 @@ class IAllocator {
    * @remarks Use SafeInt when calculating the size of memory to allocate using Alloc.
    */
   virtual void* Alloc(size_t size) = 0;
+
+  virtual bool IsStreamAware() const { return false; }
+  virtual void* AllocOnStream(size_t size, Stream* /*stream*/) { return Alloc(size); }
 
   /**
    * Free memory at p.
@@ -192,7 +198,7 @@ class IAllocator {
   template <typename T>
   static IAllocatorUniquePtr<T> MakeUniquePtr(std::shared_ptr<IAllocator> allocator, size_t count_or_bytes,
                                               bool use_reserve = false,
-                                              Stream* stream = nullptr, WaitNotificationFn wait_fn = nullptr) {
+                                              Stream* stream = nullptr) {
     ValidateAllocator(allocator);
 
     // for now limit to fundamental types. we could support others, but to do so either we or the caller
@@ -210,7 +216,7 @@ class IAllocator {
     }
 
     // allocate
-    T* p = static_cast<T*>(AllocateBufferWithOptions(*allocator, alloc_size, use_reserve, stream, std::move(wait_fn)));
+    T* p = static_cast<T*>(AllocateBufferWithOptions(*allocator, alloc_size, use_reserve, stream, nullptr));
     ValidateAllocation(p, alloc_size);
 
     return IAllocatorUniquePtr<T>{p,

--- a/include/onnxruntime/core/framework/stream_handles.h
+++ b/include/onnxruntime/core/framework/stream_handles.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 
+#include <atomic>
 #include <functional>
 #include <optional>
 #include <unordered_map>
@@ -21,9 +22,9 @@ namespace synchronize {
 class Notification;
 }
 
-// a stream abstraction which hold an opaque handle, and a reference to which OrtDevice instance this stream belong to.
-// it need to be OrtDevice instance as we might have different stream on different OrtDevice with same type.
-// i.e. different cuda stream on different GPU.
+/// <summary>
+/// Class to represent a stream on the OrtDevice.
+/// </summary>
 class Stream {
  public:
   Stream(StreamHandle h, const OrtDevice& d)
@@ -31,123 +32,117 @@ class Stream {
   }
 
   virtual ~Stream() = default;
+
   virtual std::unique_ptr<synchronize::Notification> CreateNotification(size_t /*num_consumers*/) {
     return {};
   };
+
   // block the host thread until all the tasks in the stream finished.
   virtual void Flush() {};
+
   // The framework may reuse the stream instance for multiple iterations.
   // This is the API that provide a chance to let the device stream cleanup
   // resource at the end of a iteration.
   virtual Status CleanUpOnRunEnd() { return Status::OK(); };
 
+  // Get the native stream handle. nullptr if the OrtDevice doesn't support streams.
   StreamHandle GetHandle() const { return handle_; }
 
   const OrtDevice& GetDevice() const { return device_; }
 
-  // We use the timestamp based vector clocks to optimize the resource sharing
-  // between different streams.
-  // Each stream maintain following data structure:
-  // 1. Current timestamp
-  // 2. A lookup table that for a given stream, what is its timestamp when the
-  //    last synchronization happened with current stream.
-  // 3. When a notification is activated, it take a snapshot of current stream's
-  //    lookup table.
-  // 4. When synchronization happened (current stream wait on a notification),
-  //    update its lookup table with the table snapshot in notification.
-  // The memory reusing strategy is:
-  // A kernel in current stream is safe to reuse another stream's memory chunk
-  // as long as the reused chunk's timestamp is less than the last synchronized
-  // timestamp recorded in the lookup table.
+  // Get the current synchronization ID.
+  // The value is 0 until this stream records an event.
+  // The sync id is incremented before each new event that is recorded in our stream via Notification::Activate.
+  uint64_t GetSyncId() const { return sync_id_; }
 
-  // Get the current timestamp
-  uint64_t GetCurrentTimestamp() const { return timestamp_; }
-
-  // return the timestamp when the last synchronization happened between target stream and current stream.
-  // return 0 if no synchronization happened.
-  // if target_stream is nullptr, it means it is a sequence running on device doesn't support Stream (i.e. CPU)
-  // we can safely return 0 in that case to save a lookup.
-  uint64_t GetLastSyncTimestampWithTargetStream(Stream* target_stream) const {
-    if (!target_stream)
-      return 0;
-    auto it = other_stream_clock_.find(target_stream);
-    return it == other_stream_clock_.end() ? 0 : it->second;
+  // Return the sync id from when the last synchronization happened between producer_stream and this stream.
+  // i.e. the id for the event that the producer stream recorded and we waited on
+  //
+  // Returns 0 if the streams have not previously been synchronized.
+  uint64_t GetSyncIdForLastWaitOnStream(const Stream& producer_stream) const {
+    auto it = producer_stream_sync_info_.find(&producer_stream);
+    return it == producer_stream_sync_info_.end() ? 0 : it->second;
   }
 
-  // make a copy of the current stream lookup table.
-  // this is used to create a snapshot of the stream lookup table in notification.
-  void CloneCurrentStreamSyncTable(std::unordered_map<Stream*, uint64_t>& output) const {
-    output.reserve(other_stream_clock_.size());
-    output.insert(other_stream_clock_.begin(), other_stream_clock_.end());
+  // Get the sync information that is added to a notification when it is activated.
+  // This contains sync ids for all streams we have waited on, and the new sync id for our stream.
+  std::unordered_map<const Stream*, uint64_t> OnNotificationActivation() {
+    // copy our sync info so the notification can pass it on to any waiting streams
+    auto sync_info = producer_stream_sync_info_;
+    // and add our info to the copy, incrementing the sync_id
+    sync_info[this] = ++sync_id_;
+
+    return sync_info;
   }
 
-  // bump the current timestamp
-  // When a notification get activated, bump the snapshot in its owner.
-  // Stream is not shared across threads, BumpTimeStampAndReturn will only be invoked on the current thread
-  // where the stream is executed on, so there is no race condition.
-  uint64_t BumpTimeStampAndReturn() {
-    return ++timestamp_;
-  }
+  // Record information from a Notification we waited on.
+  //   - copies the producer stream info from the notification.
+  void UpdateWithAwaitedNotification(const synchronize::Notification& notification);
 
-  // update the stream lookup table with the snapshot saved in notification.
-  void UpdateStreamClock(const std::unordered_map<Stream*, uint64_t>& clock) {
-    for (const auto& kv : clock) {
-      auto ret = other_stream_clock_.insert(kv);
-      if (!ret.second) {
-        ret.first->second = std::max(ret.first->second, kv.second);
-      }
-    }
-  }
-
+  // used in custom ops. doesn't really belong here.
   virtual void* GetResource(int /*version*/, int /*id*/) const {
     return nullptr;
   }
 
-  virtual WaitNotificationFn GetWaitNotificationFn() const { return nullptr; }
-
  private:
   StreamHandle handle_;
   const OrtDevice& device_;
-  uint64_t timestamp_{0};
+
+  // current sync id. equivalent to a counter for the number of events we have recorded in the underlying stream.
+  // 0 == no events recorded. sync_id_ is updated prior to recording a new event.
+  std::atomic<uint64_t> sync_id_{0};
+
+  // This is a map to track synchronization points between streams. When we wait on another stream (the producer)
+  // we add an entry to the map for that stream.
+  // The entry has the sync id from the producer stream for the event we waited on.
+  //
   // TODO: use inline container.
   // currently this class is header only, but abseil doesn't compile with nvcc
   // we need to add new symbol to provider_bridge and hide abseil from the header.
-  std::unordered_map<Stream*, uint64_t> other_stream_clock_{};
+  std::unordered_map<const Stream*, uint64_t> producer_stream_sync_info_{};
 
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(Stream);
 };
 
 namespace synchronize {
-// An abstraction used for synchronization between streams. See its concrete subclass (CudaNotification, etc.) how the activate
-// and wait works for a specific stream
+// An abstraction used for synchronization between streams.
+// See derived classes (CudaNotification, etc.) for implementation examples.
 class Notification {
  public:
   explicit Notification(Stream& s) : stream_(s) {}
   virtual ~Notification() = default;
 
-  // this api will perform three operations:
-  // 1. activate the notification on device, for example, record an event on GPU.
-  // 2. take a snapshot of the timestamp lookup table in current stream.
-  // 3. bump the timestamp for current stream.
+  // Activate the notification. This records an event in the Stream that created the Notification that other streams can wait on.
   void ActivateAndUpdate() {
     Activate();
-    stream_.CloneCurrentStreamSyncTable(stream_clock_);
-    stream_clock_[&stream_] = stream_.BumpTimeStampAndReturn();
+
+    // copy the sync info. this includes an entry for stream_ with the next sync id.
+    stream_sync_info_ = stream_.OnNotificationActivation();
   }
 
-  // return the timestamp lookup table saved in the notification.
-  const std::unordered_map<Stream*, uint64_t>& GetStreamSyncTable() {
-    return stream_clock_;
+  // Get the sync history for the producer stream that created this Notification.
+  // The notification must have be activated previously.
+  const std::unordered_map<const Stream*, uint64_t>& GetStreamSyncInfo() const {
+    return stream_sync_info_;
   }
 
  protected:
   virtual void Activate() = 0;
-  // which stream create this notification.
+
+  Stream& GetStream() {
+    return stream_;
+  }
+
+ private:
+  // Stream that created the notification (producer stream).
   Stream& stream_;
+
+  // This is a snapshot of the sync history for the stream that created the Notification.
+  //
   // TODO: use inline container.
   // currently this class is header only, but abseil doesn't compile with nvcc
   // we need to add new symbol to provider_bridge and hide abseil from the header.
-  std::unordered_map<Stream*, uint64_t> stream_clock_{};
+  std::unordered_map<const Stream*, uint64_t> stream_sync_info_{};
 };
 }  // namespace synchronize
 

--- a/include/onnxruntime/core/session/environment.h
+++ b/include/onnxruntime/core/session/environment.h
@@ -137,8 +137,7 @@ class Environment {
     return execution_devices_;
   }
 
-  Status CreateSharedAllocator(const OrtEpDevice& ep_device,
-                               OrtDeviceMemoryType mem_type, OrtAllocatorType allocator_type,
+  Status CreateSharedAllocator(const OrtEpDevice& ep_device, OrtDeviceMemoryType mem_type,
                                const OrtKeyValuePairs* allocator_options, OrtAllocator** allocator);
   Status ReleaseSharedAllocator(const OrtEpDevice& ep_device, OrtDeviceMemoryType mem_type);
 
@@ -161,8 +160,7 @@ class Environment {
 
   Status RegisterAllocatorImpl(AllocatorPtr allocator);
   Status UnregisterAllocatorImpl(const OrtMemoryInfo& mem_info, bool error_if_not_found = true);
-  Status CreateSharedAllocatorImpl(const OrtEpDevice& ep_device,
-                                   const OrtMemoryInfo& memory_info, OrtAllocatorType allocator_type,
+  Status CreateSharedAllocatorImpl(const OrtEpDevice& ep_device, const OrtMemoryInfo& memory_info,
                                    const OrtKeyValuePairs* allocator_options, OrtAllocator** allocator,
                                    bool replace_existing);
 

--- a/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
@@ -367,7 +367,8 @@ struct OrtEpApi {
    *
    * \param[in] value The OrtValue instance to get the memory device from.
    * \param[out] device The OrtMemoryDevice associated with the OrtValue instance.
-   * \return Status Success if OrtValue contains a Tensor. Otherwise, an error status is returned.
+   *
+   * \snippet{doc} snippets.dox OrtStatus Return Value
    *
    * \since Version 1.23.
    */
@@ -425,6 +426,41 @@ struct OrtEpApi {
    * \since Version 1.23.
    */
   ORT_API_T(uint32_t, MemoryDevice_GetDeviceId, _In_ const OrtMemoryDevice* memory_device);
+
+  /** \brief Get the OrtSyncStreamImpl associated with an OrtSyncStream instance.
+   *
+   * This allows an the plugin library to connect its OrtSyncStreamImpl instance with an OrtSyncStream if needed.
+   *
+   * \param[in] impl The OrtSyncStream instance to find an OrtSyncStreamImpl for.
+   * \return The associated OrtSyncStreamImpl if found. nullptr otherwise.
+   *
+   * \since Version 1.23.
+   *
+   * \remarks There should always be an OrtSyncStreamImpl associated with an OrtSyncStream instance that the EP gets.
+   */
+  ORT_API_T(const OrtSyncStreamImpl*, SyncStream_GetImpl, _In_ const OrtSyncStream* impl);
+
+  /** \brief Get the current sync ID for a stream.
+   *
+   * \param[in] stream The OrtSyncStream to get the sync ID for.
+   * \return Current sync ID.
+   *
+   * \since Version 1.23.
+   */
+  ORT_API_T(uint64_t, SyncStream_GetSyncId, _In_ const OrtSyncStream* stream);
+
+  /** \brief Get the sync ID for the last time the consumer_stream waited on the producer_stream.
+   *
+   * When two streams are synchronized, the sync id represents the event used in that synchronization.
+   *
+   * \param[in] producer_stream The OrtSyncStream that produced the data.
+   * \param[in] consumer_stream The OrtSyncStream that waited on the producer_stream.
+   * \return ID for last sync. 0 if no sync has occurred between the two streams.
+   *
+   * \since Version 1.23.
+   */
+  ORT_API_T(uint64_t, GetSyncIdForLastWaitOnSyncStream,
+            _In_ const OrtSyncStream* producer_stream, _In_ const OrtSyncStream* consumer_stream);
 };
 
 /**

--- a/onnxruntime/contrib_ops/cuda/bert/cudnn_fmha/cudnn_flash_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/cudnn_fmha/cudnn_flash_attention.cc
@@ -391,8 +391,7 @@ void run(
   // Allocate workspace.
   auto bytes = mha_graph->get_workspace_size();
 
-  IAllocatorUniquePtr<void> buffer = IAllocator::MakeUniquePtr<void>(
-      allocator, bytes, false, stream, WaitCudaNotificationOnDevice);
+  IAllocatorUniquePtr<void> buffer = IAllocator::MakeUniquePtr<void>(allocator, bytes, false, stream);
 
   CUDNN_FE_CALL_THROW(mha_graph->execute(handle, variant_pack, buffer.get()));
 }

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.cc
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.cc
@@ -232,7 +232,7 @@ Status AddToFeeds(Stream* ort_stream,
     }
   }
   if (!buffer) {
-    buffer = IAllocator::MakeUniquePtr<char>(device_allocator, total_bytes, false, ort_stream, WaitCudaNotificationOnDevice);
+    buffer = IAllocator::MakeUniquePtr<char>(device_allocator, total_bytes, false, ort_stream);
   }
   char* gpu_data = buffer.get();
   CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(gpu_data, pinned_data, total_bytes, cudaMemcpyHostToDevice, stream));

--- a/onnxruntime/core/framework/allocator_utils.cc
+++ b/onnxruntime/core/framework/allocator_utils.cc
@@ -54,7 +54,6 @@ AllocatorPtr CreateAllocator(const AllocatorCreationInfo& info) {
       return AllocatorPtr(
           std::make_unique<StreamAwareArena>(std::move(device_allocator),
                                              max_mem,
-                                             info.enable_cross_stream_reusing,
                                              arena_extend_str,
                                              initial_chunk_size_bytes,
                                              max_dead_bytes_per_chunk,

--- a/onnxruntime/core/framework/allocator_utils.h
+++ b/onnxruntime/core/framework/allocator_utils.h
@@ -19,14 +19,12 @@ struct AllocatorCreationInfo {
                         OrtDevice::DeviceId device_id = 0,
                         bool use_arena = true,
                         OrtArenaCfg arena_cfg = {0, -1, -1, -1, -1, -1L},
-                        bool stream_aware_arena = false,
-                        bool cross_stream_reusing = false)
+                        bool stream_aware_arena = false)
       : device_alloc_factory(device_alloc_factory),
         device_id(device_id),
         use_arena(use_arena),
         arena_cfg(arena_cfg),
-        use_stream_aware_arena(stream_aware_arena),
-        enable_cross_stream_reusing(cross_stream_reusing) {
+        use_stream_aware_arena(stream_aware_arena) {
   }
 
   AllocatorFactory device_alloc_factory;
@@ -34,7 +32,6 @@ struct AllocatorCreationInfo {
   bool use_arena;
   OrtArenaCfg arena_cfg;
   bool use_stream_aware_arena;
-  bool enable_cross_stream_reusing;
 };
 
 // Returns an allocator (an instance of IAllocator) based on the creation info provided.

--- a/onnxruntime/core/framework/bfc_arena.cc
+++ b/onnxruntime/core/framework/bfc_arena.cc
@@ -224,6 +224,7 @@ Status BFCArena::Extend(size_t rounded_bytes) {
   c->next = kInvalidChunkHandle;
   // assign the new created chunk to default stream, so it can be pick up by any stream
   c->stream = nullptr;
+  c->stream_sync_id = 0;
 
   region_manager_.set_handle(c->ptr, h);
 
@@ -253,7 +254,7 @@ void BFCArena::DeallocateChunk(ChunkHandle h) {
   Chunk* c = ChunkFromHandle(h);
   // clean the stream / timestamp when deallocate chunk
   c->stream = nullptr;
-  c->stream_timestamp = 0;
+  c->stream_sync_id = 0;
   c->next = free_chunks_list_;
   free_chunks_list_ = h;
 }
@@ -268,7 +269,7 @@ size_t BFCArena::RoundedBytes(size_t bytes) {
 }
 
 void* BFCArena::Alloc(size_t size) {
-  return AllocateRawInternal(size, false, nullptr, false, nullptr);
+  return AllocateRawInternal(size, false, nullptr);
 }
 
 void* BFCArena::Reserve(size_t size) {
@@ -309,13 +310,11 @@ size_t BFCArena::AllocatedSize(const void* ptr) {
 
 void* BFCArena::AllocateRawInternal(size_t num_bytes,
                                     bool dump_log_on_failure,
-                                    Stream* stream,
-                                    bool enable_cross_stream_reusing,
-                                    WaitNotificationFn wait_fn) {
+                                    Stream* stream) {
   if (num_bytes == 0) {
-    LOGS_DEFAULT(VERBOSE) << "tried to allocate 0 bytes";
     return nullptr;
   }
+
   // First, always allocate memory of at least kMinAllocationSize
   // bytes, and always allocate multiples of kMinAllocationSize bytes
   // so all memory addresses are nicely byte aligned.
@@ -326,20 +325,9 @@ void* BFCArena::AllocateRawInternal(size_t num_bytes,
 
   std::lock_guard<std::mutex> lock(lock_);
   // search for a valid chunk
-  auto* chunk = FindChunkPtr(bin_num,
-                             rounded_bytes,
-                             num_bytes,
-                             stream,
-                             enable_cross_stream_reusing,
-                             wait_fn);
+  auto* chunk = FindChunkPtr(bin_num, rounded_bytes, num_bytes, stream);
 
   if (chunk != nullptr) {
-    // if it is on default stream (the new allocate chunk), assign to current stream
-    if (chunk->stream == nullptr) {
-      chunk->stream = stream;
-      if (stream)
-        chunk->stream_timestamp = stream->GetCurrentTimestamp();
-    }
     return chunk->ptr;
   }
 
@@ -349,12 +337,8 @@ void* BFCArena::AllocateRawInternal(size_t num_bytes,
   // Try to extend
   auto status = Extend(rounded_bytes);
   if (status.IsOK()) {
-    chunk = FindChunkPtr(bin_num, rounded_bytes, num_bytes, stream, false);
+    chunk = FindChunkPtr(bin_num, rounded_bytes, num_bytes, stream);
     if (chunk != nullptr) {
-      // if it is on default stream (the new allocate chunk), assign to current stream
-      if (chunk->stream == nullptr && stream) {
-        chunk->stream = stream;
-      }
       return chunk->ptr;
     } else {
       status = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
@@ -413,11 +397,8 @@ BFCArena::Chunk* BFCArena::SplitFreeChunkFromBin(BFCArena::Bin::FreeChunkSet* fr
 }
 
 BFCArena::Chunk* BFCArena::FindChunkPtr(BinNum bin_num, size_t rounded_bytes,
-                                        size_t num_bytes, Stream* stream,
-                                        bool allow_chunk_from_different_stream,
-                                        WaitNotificationFn wait_fn) {
-  BFCArena::Chunk* other_stream_candidate = nullptr;
-  // First identify the first bin that could satisfy rounded_bytes.
+                                        size_t num_bytes, Stream* stream) {
+  //  First identify the first bin that could satisfy rounded_bytes.
   for (; bin_num < kNumBins; bin_num++) {
     // Start searching from the first bin for the smallest chunk that fits
     // rounded_bytes.
@@ -427,29 +408,27 @@ BFCArena::Chunk* BFCArena::FindChunkPtr(BinNum bin_num, size_t rounded_bytes,
       BFCArena::Chunk* chunk = ChunkFromHandle(h);
       ORT_ENFORCE(!chunk->in_use());
       if (chunk->size >= rounded_bytes) {
-        // We found an existing chunk that fits us that wasn't in use, now check the stream
+        // We found an existing chunk that fits us that wasn't in use, now check the stream.
         bool safe_to_use = chunk->stream == stream ||
                            !chunk->stream ||
                            (stream && chunk->stream &&
-                            chunk->stream_timestamp < stream->GetLastSyncTimestampWithTargetStream(chunk->stream));
+                            chunk->stream_sync_id < stream->GetSyncIdForLastWaitOnStream(*chunk->stream));
         if (safe_to_use) {
           // the chunk with same stream has higher priority.
-          return SplitFreeChunkFromBin(&b->free_chunks, citer, rounded_bytes, num_bytes);
-        } else if (allow_chunk_from_different_stream && !other_stream_candidate) {
-          other_stream_candidate = chunk;
+          chunk = SplitFreeChunkFromBin(&b->free_chunks, citer, rounded_bytes, num_bytes);
+
+          if (stream) {
+            chunk->stream = stream;
+            chunk->stream_sync_id = stream->GetSyncId();
+          }
+
+          return chunk;
         }
       }
     }
   }
-  // if trying to use an unsafe chunk from other streams, secure it.
-  if (other_stream_candidate) {
-    SecureTheChunk(other_stream_candidate->stream, stream, wait_fn);
-    // if find some available chunk, make sure mark it as "being used" before return
-    other_stream_candidate->allocation_id = next_allocation_id_++;
-    other_stream_candidate->bin_num = kInvalidBinNum;
-  }
 
-  return other_stream_candidate;
+  return nullptr;
 }
 
 void BFCArena::SplitChunk(BFCArena::ChunkHandle h, size_t num_bytes) {
@@ -463,7 +442,7 @@ void BFCArena::SplitChunk(BFCArena::ChunkHandle h, size_t num_bytes) {
   BFCArena::Chunk* new_chunk = ChunkFromHandle(h_new_chunk);
   // set the new chunk's stream and timestamp
   new_chunk->stream = c->stream;
-  new_chunk->stream_timestamp = c->stream_timestamp;
+  new_chunk->stream_sync_id = c->stream_sync_id;
 
   new_chunk->ptr = static_cast<void*>(static_cast<char*>(c->ptr) + num_bytes);
   region_manager_.set_handle(new_chunk->ptr, h_new_chunk);
@@ -608,7 +587,7 @@ void BFCArena::Merge(BFCArena::ChunkHandle h1,
 
   // Set the new size
   c1->size += c2->size;
-  c1->stream_timestamp = std::max(c1->stream_timestamp, c2->stream_timestamp);
+  c1->stream_sync_id = std::max(c1->stream_sync_id, c2->stream_sync_id);
 
   DeleteChunk(h2);
 }
@@ -815,7 +794,7 @@ void BFCArena::ResetChunkOnTargetStream(Stream* target_stream, bool coalesce_fla
       Chunk* c = ChunkFromHandle(h);
       if (c->stream == target_stream) {
         c->stream = nullptr;
-        c->stream_timestamp = 0;
+        c->stream_sync_id = 0;
       }
       h = c->next;
     }
@@ -850,24 +829,23 @@ void BFCArena::ResetChunkOnTargetStream(Stream* target_stream, bool coalesce_fla
 
 StreamAwareArena::StreamAwareArena(std::unique_ptr<IAllocator> resource_allocator,
                                    size_t total_memory,
-                                   bool enable_cross_stream_sharing,
                                    ArenaExtendStrategy arena_extend_strategy,
                                    int initial_chunk_size_bytes,
                                    int max_dead_bytes_per_chunk,
                                    int initial_growth_chunk_size_bytes,
-                                   int64_t max_power_of_two_extend_bytes) : BFCArena(std::move(resource_allocator),
-                                                                                     total_memory,
-                                                                                     arena_extend_strategy,
-                                                                                     initial_chunk_size_bytes,
-                                                                                     max_dead_bytes_per_chunk,
-                                                                                     initial_growth_chunk_size_bytes,
-                                                                                     max_power_of_two_extend_bytes),
-                                                                            enable_cross_stream_reusing_(enable_cross_stream_sharing) {
+                                   int64_t max_power_of_two_extend_bytes)
+    : BFCArena(std::move(resource_allocator),
+               total_memory,
+               arena_extend_strategy,
+               initial_chunk_size_bytes,
+               max_dead_bytes_per_chunk,
+               initial_growth_chunk_size_bytes,
+               max_power_of_two_extend_bytes) {
   arena_type_ = ArenaType::StreamAwareArena;
 }
 
-void* StreamAwareArena::AllocOnStream(size_t size, Stream* current_stream, WaitNotificationFn wait_fn) {
-  return AllocateRawInternal(size, false, current_stream, enable_cross_stream_reusing_, wait_fn);
+void* StreamAwareArena::AllocOnStream(size_t size, Stream* current_stream) {
+  return AllocateRawInternal(size, false, current_stream);
 }
 
 void StreamAwareArena::ReleaseStreamBuffers(Stream* stream) {
@@ -875,17 +853,5 @@ void StreamAwareArena::ReleaseStreamBuffers(Stream* stream) {
   ResetChunkOnTargetStream(stream, true);
 }
 
-void StreamAwareArena::SecureTheChunk(Stream* chunk_stream, Stream* target_stream, WaitNotificationFn wait_fn) const {
-  if (chunk_stream && target_stream && chunk_stream != target_stream) {
-    auto notification = chunk_stream->CreateNotification(1);
-    notification->ActivateAndUpdate();
-    if (wait_fn) {
-      wait_fn(target_stream, *notification);
-    }
-
-    target_stream->UpdateStreamClock(notification->GetStreamSyncTable());
-    // it should be ok to release the notification now, as the wait is already launch to stream.
-  }
-}
 #endif
 }  // namespace onnxruntime

--- a/onnxruntime/core/framework/execution_steps.cc
+++ b/onnxruntime/core/framework/execution_steps.cc
@@ -23,25 +23,25 @@ std::string BarrierStep::ToString() const {
   return MakeString("Barrier - BarrierId: ", barrier_id_, ", Count: ", 2);
 }
 
-WaitOnEPStep::WaitOnEPStep(WaitNotificationFn handle,
-                           NotificationIndex idx, NodeIndex node_index) : SequentialExecutionPlan::ExecutionStep(node_index),
-                                                                          wait_handle_(handle),
-                                                                          notification_idx_(idx) {}
+WaitOnEPStep::WaitOnEPStep(WaitNotificationFn handle, NotificationIndex idx, NodeIndex node_index)
+    : SequentialExecutionPlan::ExecutionStep(node_index),
+      wait_fn_(handle),
+      notification_idx_(idx) {}
 
 Status WaitOnEPStep::Execute(StreamExecutionContext& ctx,
                              size_t stream_idx,
                              SessionScope& /*session_scope*/,
                              const bool& /*terminate_flag*/,
                              bool& continue_flag) {
-  ORT_ENFORCE(wait_handle_, "WaitOnEPStep.wait_handle is null");
+  ORT_ENFORCE(wait_fn_, "WaitOnEPStep.wait_handle is null");
 
   auto* stream = ctx.GetDeviceStream(stream_idx);
   auto& notification = *ctx.GetNotification(notification_idx_);
-  wait_handle_(stream, notification);
+  wait_fn_(stream, notification);
 
   // update the stream's clock status
   if (stream != nullptr) {
-    stream->UpdateStreamClock(notification.GetStreamSyncTable());
+    stream->UpdateWithAwaitedNotification(notification);
   }
 
   LOGS(ctx.GetLogger(), VERBOSE) << "stream " << stream_idx << " wait on Notification with id: " << notification_idx_;

--- a/onnxruntime/core/framework/execution_steps.h
+++ b/onnxruntime/core/framework/execution_steps.h
@@ -38,7 +38,7 @@ class WaitOnEPStep : public SequentialExecutionPlan::ExecutionStep {
   std::string ToString() const override;
 
  private:
-  WaitNotificationFn wait_handle_;
+  WaitNotificationFn wait_fn_;
   NotificationIndex notification_idx_;
 };
 

--- a/onnxruntime/core/framework/plugin_ep_stream.h
+++ b/onnxruntime/core/framework/plugin_ep_stream.h
@@ -87,8 +87,8 @@ class Stream : public onnxruntime::Stream {
     return ToStatusAndRelease(ort_status);
   }
 
-  WaitNotificationFn GetWaitNotificationFn() const override {
-    return Notification::WaitNotificationOnDevice;
+  const OrtSyncStreamImpl& GetImpl() const {
+    return impl_;
   }
 
   ~Stream() override {

--- a/onnxruntime/core/framework/stream_handles.cc
+++ b/onnxruntime/core/framework/stream_handles.cc
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/framework/stream_handles.h"
+
+namespace onnxruntime {
+
+void Stream::UpdateWithAwaitedNotification(const synchronize::Notification& notification) {
+  const std::unordered_map<const Stream*, uint64_t>& stream_sync_info = notification.GetStreamSyncInfo();
+  for (const auto& kv : stream_sync_info) {
+    auto ret = producer_stream_sync_info_.insert(kv);
+    if (!ret.second) {
+      // we already have an entry. use the highest value for the producer stream.
+      ret.first->second = std::max(ret.first->second, kv.second);
+    }
+  }
+}
+}  // namespace onnxruntime

--- a/onnxruntime/core/framework/tensor_allocator_with_mem_pattern.h
+++ b/onnxruntime/core/framework/tensor_allocator_with_mem_pattern.h
@@ -39,14 +39,8 @@ class TensorAllocatorWithMemPattern : public ITensorAllocator {
       }
 
       const auto peak_size = mem_patterns_.patterns[i].PeakSize();
-      void* buffer;
-      if (alloc->Info().alloc_type == OrtArenaAllocator) {
-        // Arena has a specific way to store static memory.
-        // Arena does not reuse static memory allocated by Reserve.
-        buffer = static_cast<BFCArena*>(alloc.get())->Reserve(peak_size);
-      } else {
-        buffer = alloc->Alloc(peak_size);
-      }
+      // use Reserve for initializers so they don't affect arena growth patterns if an arena is involved.
+      void* buffer = alloc->Reserve(peak_size);
 
       auto buffer_ptr = BufferUniquePtr(buffer, BufferDeleter(std::move(alloc)));
       auto kvp = buffers_.insert(std::make_pair(location, buffer));

--- a/onnxruntime/core/framework/utils.cc
+++ b/onnxruntime/core/framework/utils.cc
@@ -74,28 +74,17 @@ static common::Status AllocateHelper(const AllocatorPtr& allocator,
 
   if (source_mlvalue.IsTensor()) {
     const Tensor& source_tensor = source_mlvalue.Get<Tensor>();
-    if (allocator->Info().alloc_type == OrtArenaAllocator) {
-      void* p_data = nullptr;
-#ifdef ORT_ENABLE_STREAM
-      BFCArena* arena_ptr = static_cast<BFCArena*>(allocator.get());
-      auto* stream_aware_alloc = StreamAwareArena::FromBFCArena(*arena_ptr);
-      if (stream_aware_alloc && target_stream) {
-        size_t len = Tensor::CalculateTensorStorageSize(source_tensor.DataType(), source_tensor.Shape());
-        p_data = stream_aware_alloc->AllocOnStream(len, target_stream, nullptr);
-      }
-#else
-      ORT_UNUSED_PARAMETER(target_stream);
-#endif  // ORT_ENABLE_STREAM
+    if (target_stream && allocator->IsStreamAware()) {
+      size_t len = Tensor::CalculateTensorStorageSize(source_tensor.DataType(), source_tensor.Shape());
+      void* p_data = allocator->AllocOnStream(len, target_stream);
       if (p_data == nullptr) {
-        Tensor::InitOrtValue(source_tensor.DataType(),
-                             source_tensor.Shape(),
-                             allocator, target_mlvalue);
-      } else {
-        Tensor::InitOrtValue(source_tensor.DataType(),
-                             source_tensor.Shape(),
-                             p_data,
-                             allocator, target_mlvalue);
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Allocation failed.");
       }
+
+      Tensor::InitOrtValue(source_tensor.DataType(),
+                           source_tensor.Shape(),
+                           p_data,
+                           allocator, target_mlvalue);
     } else {
       Tensor::InitOrtValue(source_tensor.DataType(),
                            source_tensor.Shape(),

--- a/onnxruntime/core/providers/cann/cann_execution_provider.cc
+++ b/onnxruntime/core/providers/cann/cann_execution_provider.cc
@@ -1488,8 +1488,7 @@ AllocatorPtr CANNExecutionProvider::CreateCannAllocator(OrtDevice::DeviceId devi
                                               -1,
                                               -1,
                                               -1L)},
-      true,
-      false);
+      true);
 
   return CreateAllocator(default_memory_info);
 }

--- a/onnxruntime/core/providers/cann/cann_stream_handle.cc
+++ b/onnxruntime/core/providers/cann/cann_stream_handle.cc
@@ -18,7 +18,7 @@ struct CannNotification : public synchronize::Notification {
   }
 
   void Activate() override {
-    CANN_CALL_THROW(aclrtRecordEvent(event_, static_cast<aclrtStream>(stream_.GetHandle())));
+    CANN_CALL_THROW(aclrtRecordEvent(event_, static_cast<aclrtStream>(GetStream().GetHandle())));
   }
 
   void wait_on_device(Stream& device_stream) {

--- a/onnxruntime/core/providers/cann/cann_stream_handle.h
+++ b/onnxruntime/core/providers/cann/cann_stream_handle.h
@@ -24,8 +24,6 @@ struct CannStream : Stream {
   void Flush() override;
 
   bool own_stream_{true};
-
-  WaitNotificationFn GetWaitNotificationFn() const override { return WaitCannNotificationOnDevice; }
 };
 
 void RegisterCannStreamHandles(IStreamCommandHandleRegistry& stream_handle_registry,

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -161,9 +161,7 @@ AllocatorPtr CUDAExecutionProvider::CreateCudaAllocator(OrtDevice::DeviceId devi
         {default_memory_arena_cfg ? *default_memory_arena_cfg
                                   : OrtArenaCfg(gpu_mem_limit, static_cast<int>(arena_extend_strategy), -1, -1, -1, -1L)},
         // make it stream aware
-        true,
-        // enable cross stream sharing?
-        false);
+        true);
 
     // CUDA malloc/free is expensive so always use an arena
     return CreateAllocator(default_memory_info);

--- a/onnxruntime/core/providers/cuda/cuda_kernel.h
+++ b/onnxruntime/core/providers/cuda/cuda_kernel.h
@@ -41,8 +41,12 @@ class CudaKernel : public OpKernel {
 
   template <typename T>
   inline IAllocatorUniquePtr<T> GetScratchBuffer(size_t count_or_bytes, onnxruntime::Stream* stream) const {
-    if (count_or_bytes == 0) return nullptr;
-    return IAllocator::MakeUniquePtr<T>(Info().GetAllocator(OrtMemType::OrtMemTypeDefault), count_or_bytes, false, stream, WaitCudaNotificationOnDevice);
+    if (count_or_bytes == 0) {
+      return nullptr;
+    }
+
+    return IAllocator::MakeUniquePtr<T>(Info().GetAllocator(OrtMemType::OrtMemTypeDefault), count_or_bytes, false,
+                                        stream);
   }
 
   // Different from GetScratchBuffer which use IAllocator::Alloc() to allocate memory,

--- a/onnxruntime/core/providers/cuda/cuda_provider_factory.cc
+++ b/onnxruntime/core/providers/cuda/cuda_provider_factory.cc
@@ -355,8 +355,9 @@ struct CudaOrtAllocator : OrtAllocator {
     Alloc = AllocImpl;
     Free = FreeImpl;
     Info = InfoImpl;
-    Reserve = AllocImpl;  // no special behavior for Reserve so use AllocImpl
-    GetStats = nullptr;   // GetStatsImpl. The CUDA allocators don't have stats currently so we can skip.
+    Reserve = AllocImpl;      // no special behavior for Reserve so use AllocImpl
+    GetStats = nullptr;       // GetStatsImpl. The CUDA allocators don't have stats currently so we can skip.
+    AllocOnStream = nullptr;  // TODO. Plugin EP arena to provide this.
 
     const OrtEpApi& ep_api = *api.GetEpApi();
     const OrtMemoryDevice* mem_device = ep_api.MemoryInfo_GetMemoryDevice(mem_info);

--- a/onnxruntime/core/providers/cuda/cuda_stream_handle.cc
+++ b/onnxruntime/core/providers/cuda/cuda_stream_handle.cc
@@ -38,7 +38,7 @@ struct CudaNotification : public synchronize::Notification {
 
   void Activate() override {
     // record event with cudaEventBlockingSync so we can support sync on host without busy wait.
-    CUDA_CALL_THROW(cudaEventRecord(event_, static_cast<cudaStream_t>(stream_.GetHandle())));
+    CUDA_CALL_THROW(cudaEventRecord(event_, static_cast<cudaStream_t>(GetStream().GetHandle())));
   }
 
   void wait_on_device(Stream& device_stream) {

--- a/onnxruntime/core/providers/cuda/cuda_stream_handle.h
+++ b/onnxruntime/core/providers/cuda/cuda_stream_handle.h
@@ -48,8 +48,6 @@ struct CudaStream : Stream {
 
   onnxruntime::IAllocator* GetCpuAllocator() const { return cpu_allocator_.get(); }
 
-  WaitNotificationFn GetWaitNotificationFn() const override { return WaitCudaNotificationOnDevice; }
-
  private:
   std::vector<void*> deferred_cpu_buffers_;
   AllocatorPtr cpu_allocator_;

--- a/onnxruntime/core/providers/cuda/tunable/cuda_tuning_context.cc
+++ b/onnxruntime/core/providers/cuda/tunable/cuda_tuning_context.cc
@@ -120,7 +120,7 @@ IAllocatorUniquePtr<void> CudaTuningContext::GetScratchBuffer(
     return nullptr;
   }
 
-  return IAllocator::MakeUniquePtr<void>(it->second, num_bytes, false, stream, WaitCudaNotificationOnDevice);
+  return IAllocator::MakeUniquePtr<void>(it->second, num_bytes, false, stream);
 }
 
 }  // namespace tunable

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -323,9 +323,7 @@ AllocatorPtr MIGraphXExecutionProvider::CreateMIGraphXAllocator(OrtDevice::Devic
                                   : OrtArenaCfg(migx_mem_limit, static_cast<int>(arena_extend_strategy),
                                                 -1, -1, -1, -1L)},
         // make it stream aware
-        true,
-        // enable cross stream sharing?
-        false);
+        true);
 
     // ROCM malloc/free is expensive so always use an arena
     return CreateAllocator(default_memory_info);

--- a/onnxruntime/core/providers/migraphx/migraphx_stream_handle.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_stream_handle.cc
@@ -18,11 +18,12 @@ struct MIGraphXNotification : public synchronize::Notification {
 
   void Activate() override {
     // record event with hipEventBlockingSync so we can support sync on host without busy wait.
-    HIP_CALL_THROW(hipEventRecord(event_, static_cast<hipStream_t>(stream_.GetHandle())));
+    HIP_CALL_THROW(hipEventRecord(event_, static_cast<hipStream_t>(GetStream().GetHandle())));
   }
 
   void wait_on_device(Stream& device_stream) {
-    ORT_ENFORCE(device_stream.GetDevice().Type() == OrtDevice::GPU, "Unexpected device:", device_stream.GetDevice().ToString());
+    ORT_ENFORCE(device_stream.GetDevice().Type() == OrtDevice::GPU, "Unexpected device:",
+                device_stream.GetDevice().ToString());
     // launch a wait command to the migraphx stream
     HIP_CALL_THROW(hipStreamWaitEvent(static_cast<hipStream_t>(device_stream.GetHandle()), event_, 0));
   };

--- a/onnxruntime/core/providers/migraphx/migraphx_stream_handle.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_stream_handle.h
@@ -29,8 +29,6 @@ struct MIGraphXStream : Stream {
 
   virtual void* GetResource(int version, int id) const;
 
-  virtual WaitNotificationFn GetWaitNotificationFn() const { return WaitMIGraphXNotificationOnDevice; }
-
  private:
   std::vector<void*> deferred_cpu_buffers_;
   AllocatorPtr cpu_allocator_;

--- a/onnxruntime/core/session/allocator_adapters.cc
+++ b/onnxruntime/core/session/allocator_adapters.cc
@@ -3,6 +3,7 @@
 
 #include "allocator_adapters.h"
 #include "core/framework/error_code_helper.h"
+#include "core/framework/plugin_ep_stream.h"
 #include "core/session/abi_devices.h"
 #include "core/session/abi_key_value_pairs.h"
 #include "core/session/environment.h"
@@ -21,24 +22,33 @@ namespace {
 // `IAllocatorImplWrappingOrtAllocator` to ensure compatibility.
 constexpr uint32_t kOrtAllocatorReserveMinVersion = 18;
 constexpr uint32_t kOrtAllocatorStatsMinVersion = 23;
+constexpr uint32_t kOrtAllocatorAllocOnStreamMinVersion = 23;
 }  // namespace
 
 OrtAllocatorImplWrappingIAllocator::OrtAllocatorImplWrappingIAllocator(onnxruntime::AllocatorPtr&& i_allocator)
     : i_allocator_(std::move(i_allocator)) {
   OrtAllocator::version = ORT_API_VERSION;
-  OrtAllocator::Alloc =
-      [](OrtAllocator* this_, size_t size) { return static_cast<OrtAllocatorImplWrappingIAllocator*>(this_)->Alloc(size); };
-  OrtAllocator::Free =
-      [](OrtAllocator* this_, void* p) { static_cast<OrtAllocatorImplWrappingIAllocator*>(this_)->Free(p); };
-  OrtAllocator::Info =
-      [](const OrtAllocator* this_) { return static_cast<const OrtAllocatorImplWrappingIAllocator*>(this_)->Info(); };
+
+  OrtAllocator::Alloc = [](OrtAllocator* this_, size_t size) {
+    return static_cast<OrtAllocatorImplWrappingIAllocator*>(this_)->Alloc(size);
+  };
+
+  OrtAllocator::Free = [](OrtAllocator* this_, void* p) {
+    static_cast<OrtAllocatorImplWrappingIAllocator*>(this_)->Free(p);
+  };
+
+  OrtAllocator::Info = [](const OrtAllocator* this_) {
+    return static_cast<const OrtAllocatorImplWrappingIAllocator*>(this_)->Info();
+  };
+
   if (OrtAllocator::version >= kOrtAllocatorReserveMinVersion) {
-    OrtAllocator::Reserve =
-        [](OrtAllocator* this_, size_t size) { return static_cast<OrtAllocatorImplWrappingIAllocator*>(this_)->Reserve(size); };
+    OrtAllocator::Reserve = [](OrtAllocator* this_, size_t size) {
+      return static_cast<OrtAllocatorImplWrappingIAllocator*>(this_)->Reserve(size);
+    };
   }
+
   if (OrtAllocator::version >= kOrtAllocatorStatsMinVersion) {
-    OrtAllocator::GetStats =
-        [](const OrtAllocator* this_, OrtKeyValuePairs** stats) noexcept -> OrtStatusPtr {
+    OrtAllocator::GetStats = [](const OrtAllocator* this_, OrtKeyValuePairs** stats) noexcept -> OrtStatusPtr {
       API_IMPL_BEGIN
       auto kvp = std::make_unique<OrtKeyValuePairs>();
       const auto& stats_map = static_cast<const OrtAllocatorImplWrappingIAllocator*>(this_)->Stats();
@@ -48,10 +58,20 @@ OrtAllocatorImplWrappingIAllocator::OrtAllocatorImplWrappingIAllocator(onnxrunti
       API_IMPL_END
     };
   }
+
+  if (OrtAllocator::version >= kOrtAllocatorAllocOnStreamMinVersion) {
+    OrtAllocator::AllocOnStream = [](OrtAllocator* this_, size_t size, OrtSyncStream* stream) {
+      return static_cast<OrtAllocatorImplWrappingIAllocator*>(this_)->AllocOnStream(size, stream);
+    };
+  }
 }
 
 void* OrtAllocatorImplWrappingIAllocator::Alloc(size_t size) {
   return i_allocator_->Alloc(size);
+}
+
+void* OrtAllocatorImplWrappingIAllocator::AllocOnStream(size_t size, OrtSyncStream* stream) {
+  return i_allocator_->AllocOnStream(size, static_cast<Stream*>(stream));
 }
 
 void* OrtAllocatorImplWrappingIAllocator::Reserve(size_t size) {
@@ -102,6 +122,18 @@ IAllocatorImplWrappingOrtAllocator::IAllocatorImplWrappingOrtAllocator(OrtAlloca
 }
 
 void* IAllocatorImplWrappingOrtAllocator::Alloc(size_t size) {
+  return ort_allocator_->Alloc(ort_allocator_.get(), size);
+}
+
+bool IAllocatorImplWrappingOrtAllocator::IsStreamAware() const {
+  return ort_allocator_->version >= kOrtAllocatorAllocOnStreamMinVersion && ort_allocator_->AllocOnStream != nullptr;
+}
+
+void* IAllocatorImplWrappingOrtAllocator::AllocOnStream(size_t size, Stream* stream) {
+  if (ort_allocator_->version >= kOrtAllocatorAllocOnStreamMinVersion && ort_allocator_->AllocOnStream) {
+    return ort_allocator_->AllocOnStream(ort_allocator_.get(), size, static_cast<OrtSyncStream*>(stream));
+  }
+
   return ort_allocator_->Alloc(ort_allocator_.get(), size);
 }
 
@@ -297,7 +329,6 @@ ORT_API_STATUS_IMPL(OrtApis::CreateSharedAllocator,
                     [[maybe_unused]] _In_ OrtEnv* ort_env,
                     [[maybe_unused]] _In_ const OrtEpDevice* ep_device,
                     [[maybe_unused]] _In_ OrtDeviceMemoryType mem_type,
-                    [[maybe_unused]] _In_ OrtAllocatorType allocator_type,
                     [[maybe_unused]] _In_opt_ const OrtKeyValuePairs* allocator_options,
                     _Outptr_opt_ OrtAllocator** allocator) {
 #if !defined(ORT_MINIMAL_BUILD)
@@ -307,7 +338,7 @@ ORT_API_STATUS_IMPL(OrtApis::CreateSharedAllocator,
   }
 
   auto& env = ort_env->GetEnvironment();
-  ORT_API_RETURN_IF_STATUS_NOT_OK(env.CreateSharedAllocator(*ep_device, mem_type, allocator_type, allocator_options,
+  ORT_API_RETURN_IF_STATUS_NOT_OK(env.CreateSharedAllocator(*ep_device, mem_type, allocator_options,
                                                             allocator));
 
   return nullptr;

--- a/onnxruntime/core/session/allocator_adapters.h
+++ b/onnxruntime/core/session/allocator_adapters.h
@@ -25,6 +25,7 @@ struct OrtAllocatorImplWrappingIAllocator final : public OrtAllocatorImpl {
   ~OrtAllocatorImplWrappingIAllocator() override = default;
 
   void* Alloc(size_t size);
+  void* AllocOnStream(size_t size, OrtSyncStream* stream);
   void Free(void* p);
   void* Reserve(size_t size);
 
@@ -55,6 +56,9 @@ class IAllocatorImplWrappingOrtAllocator final : public IAllocator {
   void* Alloc(size_t size) override;
   void Free(void* p) override;
   void* Reserve(size_t size) override;
+
+  bool IsStreamAware() const override;
+  void* AllocOnStream(size_t size, Stream* stream) override;
 
   const OrtAllocator* GetWrappedOrtAllocator() const {
     return ort_allocator_.get();

--- a/onnxruntime/core/session/custom_ops.cc
+++ b/onnxruntime/core/session/custom_ops.cc
@@ -757,7 +757,7 @@ ORT_API_STATUS_IMPL(OrtApis::KernelContext_GetScratchBuffer, _In_ const OrtKerne
     return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "No requested allocator available");
   }
   onnxruntime::Stream* stream = reinterpret_cast<const onnxruntime::OpKernelContext*>(context)->GetComputeStream();
-  *out = AllocateBufferWithOptions(*allocator, count_or_bytes, false, stream, stream->GetWaitNotificationFn());
+  *out = AllocateBufferWithOptions(*allocator, count_or_bytes, false, stream);
   return nullptr;
 };
 

--- a/onnxruntime/core/session/ep_api.cc
+++ b/onnxruntime/core/session/ep_api.cc
@@ -179,6 +179,31 @@ ORT_API(uint32_t, MemoryDevice_GetDeviceId, _In_ const OrtMemoryDevice* memory_d
   return memory_device->Id();
 }
 
+ORT_API(const OrtSyncStreamImpl*, SyncStream_GetImpl, _In_ const OrtSyncStream* impl) {
+  // the EP API should only ever see plugin_ep::Stream instances
+  const auto& stream = *reinterpret_cast<const plugin_ep::Stream*>(impl);
+  return &stream.GetImpl();
+}
+
+ORT_API(uint64_t, SyncStream_GetSyncId, _In_ const OrtSyncStream* stream) {
+  return static_cast<const Stream*>(stream)->GetSyncId();
+}
+
+ORT_API(uint64_t, GetSyncIdForLastWaitOnSyncStream, _In_ const OrtSyncStream* producer_stream,
+        _In_ const OrtSyncStream* consumer_stream) {
+  uint64_t id{0};
+  if (producer_stream && consumer_stream) {
+    const auto& producer = *static_cast<const Stream*>(producer_stream);
+    const auto& consumer = *static_cast<const Stream*>(consumer_stream);
+
+    // If both streams are valid, we can return the sync id for the last wait on the consumer stream.
+    // This is useful for synchronizing operations between different streams.
+    id = consumer.GetSyncIdForLastWaitOnStream(producer);
+  }
+
+  return id;
+}
+
 static constexpr OrtEpApi ort_ep_api = {
     // NOTE: ABI compatibility depends on the order within this struct so all additions must be at the end,
     // and no functions can be removed (the implementation needs to change to return an error).
@@ -200,6 +225,10 @@ static constexpr OrtEpApi ort_ep_api = {
     &OrtExecutionProviderApi::MemoryDevice_GetMemoryType,
     &OrtExecutionProviderApi::MemoryDevice_GetVendorId,
     &OrtExecutionProviderApi::MemoryDevice_GetDeviceId,
+
+    &OrtExecutionProviderApi::SyncStream_GetImpl,
+    &OrtExecutionProviderApi::SyncStream_GetSyncId,
+    &OrtExecutionProviderApi::GetSyncIdForLastWaitOnSyncStream,
 };
 
 // checks that we don't violate the rule that the functions must remain in the slots they were originally assigned

--- a/onnxruntime/core/session/ep_api.h
+++ b/onnxruntime/core/session/ep_api.h
@@ -35,4 +35,9 @@ ORT_API(OrtMemoryInfoDeviceType, MemoryDevice_GetDeviceType, _In_ const OrtMemor
 ORT_API(OrtDeviceMemoryType, MemoryDevice_GetMemoryType, _In_ const OrtMemoryDevice* memory_device);
 ORT_API(uint32_t, MemoryDevice_GetVendorId, _In_ const OrtMemoryDevice* memory_device);
 ORT_API(uint32_t, MemoryDevice_GetDeviceId, _In_ const OrtMemoryDevice* memory_device);
+
+ORT_API(const OrtSyncStreamImpl*, SyncStream_GetImpl, _In_ const OrtSyncStream* impl);
+ORT_API(uint64_t, SyncStream_GetSyncId, _In_ const OrtSyncStream* stream);
+ORT_API(uint64_t, GetSyncIdForLastWaitOnSyncStream, _In_ const OrtSyncStream* producer_stream,
+        _In_ const OrtSyncStream* consumer_stream);
 }  // namespace OrtExecutionProviderApi

--- a/onnxruntime/core/session/ep_plugin_provider_interfaces.cc
+++ b/onnxruntime/core/session/ep_plugin_provider_interfaces.cc
@@ -575,6 +575,13 @@ std::vector<AllocatorPtr> PluginExecutionProvider::CreatePreferredAllocators() {
       ORT_THROW("Error creating allocator: ", ToStatusAndRelease(ort_status).ToString());
     }
 
+    if (ort_allocator_ptr->Info(ort_allocator_ptr)->alloc_type == OrtAllocatorType::OrtArenaAllocator) {
+      ORT_THROW(
+          "OrtEpFactory returned an allocator with OrtAllocatorType of OrtArenaAllocator. "
+          "This type is reserved for ONNX Runtime internal usage only, as any arena usage by the "
+          "EP library should be opaque to ORT");
+    }
+
     auto ort_allocator = OrtAllocatorUniquePtr(
         ort_allocator_ptr,
         [this](OrtAllocator* allocator) {

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -3571,7 +3571,7 @@ common::Status InferenceSession::ValidateAndParseShrinkArenaString(const std::st
       ++iter;
     }
 
-    // Shrink if it is an arena based allocator
+    // Shrink if it is a BFCArena allocator
     // Iterate through the registered allocators as we could have multiple allocators for the device+type
     // if they differ by vendor_id.
     for (const auto& [device, allocator_ptr] : session_state_->GetAllocators()) {

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -692,8 +692,7 @@ ORT_API(const OrtMemoryInfo*, EpDevice_MemoryInfo, _In_ const OrtEpDevice* ep_de
         _In_ OrtDeviceMemoryType memory_type);
 
 ORT_API_STATUS_IMPL(CreateSharedAllocator, _In_ OrtEnv* env, _In_ const OrtEpDevice* ep_device,
-                    _In_ OrtDeviceMemoryType mem_type, _In_ OrtAllocatorType allocator_type,
-                    _In_opt_ const OrtKeyValuePairs* allocator_options,
+                    _In_ OrtDeviceMemoryType mem_type, _In_opt_ const OrtKeyValuePairs* allocator_options,
                     _Outptr_opt_ OrtAllocator** allocator);
 ORT_API_STATUS_IMPL(GetSharedAllocator, _In_ OrtEnv* env, _In_ const OrtMemoryInfo* mem_info,
                     _Outptr_result_maybenull_ OrtAllocator** allocator);
@@ -730,4 +729,7 @@ ORT_API_STATUS_IMPL(CopyTensors, _In_ const OrtEnv* env,
                     _In_reads_(num_tensors) OrtValue* const* dst_tensors,
                     _In_opt_ OrtSyncStream* stream,
                     _In_ size_t num_tensors);
+
+ORT_API_STATUS_IMPL(GetSessionOptionsConfigEntries, _In_ const OrtSessionOptions* options,
+                    _Outptr_ OrtKeyValuePairs** out);
 }  // namespace OrtApis

--- a/onnxruntime/test/autoep/library/ep_allocator.h
+++ b/onnxruntime/test/autoep/library/ep_allocator.h
@@ -5,17 +5,50 @@
 
 #include "example_plugin_ep_utils.h"
 
+#include <sstream>
+
 // from onnxruntime/core/framework/allocator_stats.h
+// copied from onnxruntime::AllocatorStats
 struct AllocatorStats {
   int64_t num_allocs;             // Number of allocations.
   int64_t num_reserves;           // Number of reserves. (Number of calls to Reserve() in arena-based allocators)
+  int64_t num_arena_extensions;   // Number of arena extensions (Relevant only for arena based allocators)
+  int64_t num_arena_shrinkages;   // Number of arena shrinkages (Relevant only for arena based allocators)
   int64_t bytes_in_use;           // Number of bytes in use.
   int64_t total_allocated_bytes;  // The total number of allocated bytes by the allocator.
   int64_t max_bytes_in_use;       // The maximum bytes in use.
   int64_t max_alloc_size;         // The max single allocation seen.
-  int64_t bytes_limit;            // The upper limit what the allocator can allocate, if such a limit
-                                  // is known. Certain allocator may return 0 to indicate the limit is
-                                  // unknown.
+                                  // The upper limit what the allocator can allocate, if such a limit
+                                  // is known. Certain allocator may return 0 to indicate the limit is unknown.
+  int64_t bytes_limit;
+
+  void ToKeyValuePairs(const OrtApi& api, OrtKeyValuePairs* kvps) const {
+    if (num_allocs > 0 || bytes_limit != 0) {
+      api.AddKeyValuePair(kvps, "Limit", std::to_string(bytes_limit).c_str());
+      api.AddKeyValuePair(kvps, "InUse", std::to_string(bytes_in_use).c_str());
+      api.AddKeyValuePair(kvps, "TotalAllocated", std::to_string(total_allocated_bytes).c_str());
+      api.AddKeyValuePair(kvps, "MaxInUse", std::to_string(max_bytes_in_use).c_str());
+      api.AddKeyValuePair(kvps, "NumAllocs", std::to_string(num_allocs).c_str());
+      api.AddKeyValuePair(kvps, "NumReserves", std::to_string(num_reserves).c_str());
+      api.AddKeyValuePair(kvps, "NumArenaExtensions", std::to_string(num_arena_extensions).c_str());
+      api.AddKeyValuePair(kvps, "NumArenaShrinkages", std::to_string(num_arena_shrinkages).c_str());
+      api.AddKeyValuePair(kvps, "MaxAllocSize", std::to_string(max_alloc_size).c_str());
+    }
+  }
+
+  std::string DebugString() const {
+    std::ostringstream ss;
+    ss << "Limit:                    " << this->bytes_limit << "\n"
+       << "InUse:                    " << this->bytes_in_use << "\n"
+       << "TotalAllocated:           " << this->total_allocated_bytes << "\n"
+       << "MaxInUse:                 " << this->max_bytes_in_use << "\n"
+       << "NumAllocs:                " << this->num_allocs << "\n"
+       << "NumReserves:              " << this->num_reserves << "\n"
+       << "NumArenaExtensions:       " << this->num_arena_extensions << "\n"
+       << "NumArenaShrinkages:       " << this->num_arena_shrinkages << "\n"
+       << "MaxAllocSize:             " << this->max_alloc_size << "\n";
+    return ss.str();
+  }
 };
 
 struct CustomAllocator : OrtAllocator {
@@ -27,6 +60,7 @@ struct CustomAllocator : OrtAllocator {
     Info = InfoImpl;
     Reserve = AllocImpl;      // no special reserve logic and most likely unnecessary unless you have your own arena
     GetStats = GetStatsImpl;  // this can be set to nullptr if you don't want to implement it
+    AllocOnStream = nullptr;
   }
 
   static void* ORT_API_CALL AllocImpl(struct OrtAllocator* this_, size_t size) {

--- a/onnxruntime/test/autoep/library/ep_arena.cc
+++ b/onnxruntime/test/autoep/library/ep_arena.cc
@@ -1,0 +1,778 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "ep_arena.h"
+
+#include <cassert>
+#include <map>
+
+namespace {
+std::string GetAllocatorName(const OrtApi& api, OrtAllocator& allocator) {
+  const OrtMemoryInfo* mem_info = allocator.Info(&allocator);
+  const char* allocator_name;
+  auto* status = api.MemoryInfoGetName(mem_info, &allocator_name);  // never fails
+  static_cast<void>(status);
+  return allocator_name;
+}
+}  // namespace
+
+ArenaImpl::ArenaImpl(AllocatorUniquePtr allocator, const ArenaConfig& config, const OrtApi& api,
+                     const OrtLogger& logger)
+    : device_allocator_{std::move(allocator)},
+      allocator_name_{GetAllocatorName(api, *device_allocator_)},
+      config_{config},
+      next_allocation_id_(1),
+      free_chunks_list_(kInvalidChunkHandle),
+      api_{api},
+      ep_api_{*api_.GetEpApi()},
+      logger_{logger} {
+  LOG(INFO, "Creating ArenaImpl for "
+                << allocator_name_
+                << " with following configs: initial_chunk_size_bytes: " << config_.initial_chunk_size_bytes
+                << " max_dead_bytes_per_chunk: " << config_.max_dead_bytes_per_chunk
+                << " initial_growth_chunk_size_bytes: " << config_.initial_growth_chunk_size_bytes
+                << " max_power_of_two_extend_bytes: " << config_.max_power_of_two_extend_bytes
+                << " memory limit: " << config_.max_mem
+                << " arena_extend_strategy: " << config_.arena_extend_strategy);
+
+  curr_region_allocation_bytes_ = RoundedBytes(
+      std::min(config_.max_mem, static_cast<size_t>(config_.initial_chunk_size_bytes)));
+
+  stats_.bytes_limit = static_cast<int64_t>(config.max_mem);
+
+  // Create a bunch of bins of various good sizes.
+
+  // We create bins to fit all possible ranges that cover the
+  // config_.max_mem starting from allocations up to 256 bytes to
+  // allocations up to (and including) the memory limit.
+  LOG(VERBOSE, "Creating " << kNumBins << " bins of max chunk size "
+                           << BinNumToSize(0) << " to " << BinNumToSize(kNumBins - 1));
+
+  for (BinNum b = 0; b < kNumBins; b++) {
+    size_t bin_size = BinNumToSize(b);
+    new (BinFromIndex(b)) Bin(this, bin_size);
+    EP_ENFORCE((BinForSize(bin_size) == BinFromIndex(b) &&
+                BinForSize(bin_size + 255) == BinFromIndex(b) &&
+                BinForSize(bin_size * 2 - 1) == BinFromIndex(b)),
+               "Invalid bin size for bin " << b);
+
+    if (b + 1 < kNumBins) {
+      EP_ENFORCE(BinForSize(bin_size * 2) != BinFromIndex(b), "Invalid bin size for " << b);
+    }
+  }
+}
+
+ArenaImpl::~ArenaImpl() {
+  for (const auto& region : region_manager_.regions()) {
+    device_allocator_->Free(device_allocator_.get(), region.ptr());
+  }
+
+  for (const auto& reserve_chunk : reserved_chunks_) {
+    device_allocator_->Free(device_allocator_.get(), reserve_chunk.first);
+  }
+
+  for (BinNum b = 0; b < kNumBins; b++) {
+    BinFromIndex(b)->~Bin();
+  }
+}
+
+ArenaImpl::Chunk* ArenaImpl::ChunkFromHandle(ChunkHandle h) {
+  EP_ENFORCE(h < chunks_.size(), "ChunkFromHandle");
+  return &(chunks_[h]);
+}
+
+OrtStatus* ArenaImpl::Extend(size_t rounded_bytes) {
+  size_t available_bytes = config_.max_mem - static_cast<size_t>(stats_.total_allocated_bytes);
+  // Rounds available_bytes down to the nearest multiple of kMinAllocationSize.
+  available_bytes = (available_bytes / kMinAllocationSize) * kMinAllocationSize;
+
+  // Do we have enough space to handle the client's request?
+  // If not, fail immediately.
+  if (rounded_bytes > available_bytes) {
+    RETURN_ERROR(ORT_EP_FAIL, "Available memory of " << available_bytes << " is smaller than requested bytes of "
+                                                     << rounded_bytes);
+  }
+
+  auto safe_alloc = [this](size_t alloc_bytes) {
+    void* new_mem = nullptr;
+    try {
+      new_mem = device_allocator_->Alloc(device_allocator_.get(), alloc_bytes);
+    } catch (const std::bad_alloc&) {
+      // attempted allocation can throw std::bad_alloc. we want to treat this the same as if it returned nullptr
+      // so swallow the exception
+    }
+    // catch (const MyException& exception) {
+    //   if your implementation threw, consider swallowing the exception to enable attempting a smaller allocation
+    //   if possible
+    //}
+    return new_mem;
+  };
+
+  auto get_extend_bytes = [this, available_bytes](const size_t bytes, size_t& extend_bytes) -> OrtStatus* {
+    extend_bytes = 0;
+    if (config_.arena_extend_strategy == ArenaExtendStrategy::kNextPowerOfTwo) {
+      // If curr_region_allocation_bytes_ is not enough to satisfy the
+      // allocation, keep multiplying by a power of two until that is
+      // sufficient.
+      bool increased_allocation = false;
+      while (bytes > curr_region_allocation_bytes_) {
+        curr_region_allocation_bytes_ *= 2;
+        increased_allocation = true;
+      }
+
+      extend_bytes = std::min(static_cast<size_t>(curr_region_allocation_bytes_), available_bytes);
+
+      // we allocated the same number of bytes as the current region
+      // the 2x is to double the minimum size of the next amount we'll allocate
+      if (!increased_allocation) {
+        if (config_.arena_extend_strategy == ArenaExtendStrategy::kNextPowerOfTwo &&
+            static_cast<int64_t>(curr_region_allocation_bytes_) * 2 < config_.max_power_of_two_extend_bytes) {
+          curr_region_allocation_bytes_ *= 2;
+        } else {
+          curr_region_allocation_bytes_ = config_.max_power_of_two_extend_bytes;
+        }
+      }
+    } else if (config_.arena_extend_strategy == ArenaExtendStrategy::kSameAsRequested) {
+      // BFC Arena could cause internal and external fragmentation. But, running training with
+      // big batch size will be very sensitive to fragmentation. So, to avoid fragmentation,
+      // just extend arena with actual requested size.
+      extend_bytes = bytes;
+    } else {
+      RETURN_ERROR(ORT_INVALID_ARGUMENT, "Invalid arena extend strategy." << config_.arena_extend_strategy);
+    }
+
+    return nullptr;
+  };
+
+  size_t bytes;
+  RETURN_IF_ERROR(get_extend_bytes(rounded_bytes, bytes));
+
+  // Try allocating.
+  void* mem_addr = safe_alloc(bytes);
+
+  static constexpr float kBackpedalFactor = 0.9f;
+  // Try allocating less memory.
+  while (mem_addr == nullptr) {
+    // kBackpedalFactor is float, bytes is size_t. The result of bytes * kBackpedalFactor is float. When we cast it to
+    // size_t, which is a smaller type, it could loss data. This is what C4244 complains. The "static_cast<size_t>" here
+    // is to suppress the warning. C26451 suggest we may change kBackpedalFactor to double to get better accuary. But if
+    // we do that, AMD GPU CI build pipeline will have an "out-of-memory" error. So I choose to keep this piece of code
+    // untouched and disable the warning first.
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(push)
+#pragma warning(disable : 26451)
+#endif
+    bytes = RoundedBytes(static_cast<size_t>(bytes * kBackpedalFactor));
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(pop)
+#endif
+    // give up if we can't satisfy the requested size, or we're attempting an allocation of less than 8K.
+    //
+    // the latter protects against an infinite loop that occurs when bytes is less than 2560. at that point the 10%
+    // reduction to 2304 bytes is undone by rounding to a 256 boundary in RoundedBytes, leading to an infinite loop.
+    // the 8K value is just to give up a little earlier vs. getting all the way down to 2560 bytes.
+    // If we can't allocate 8K, we're pretty much dead.
+    if (bytes < rounded_bytes || bytes < 8 * 1024)
+      break;
+
+    mem_addr = safe_alloc(bytes);
+  }
+
+  if (mem_addr == nullptr) {
+    RETURN_ERROR(ORT_EP_FAIL, "Failed to allocate memory for requested buffer of size " << rounded_bytes);
+  }
+
+  LOG(INFO, "Extended allocation by " << bytes << " bytes.");
+
+  stats_.total_allocated_bytes += bytes;
+  LOG(INFO, "Total allocated bytes: " << stats_.total_allocated_bytes);
+
+  LOG(INFO, "Allocated memory at " << mem_addr << " to " << static_cast<void*>(static_cast<char*>(mem_addr) + bytes));
+
+  region_manager_.AddAllocationRegion(mem_addr, bytes, stats_.num_arena_extensions);
+  stats_.num_arena_extensions += 1;
+
+  // Create one large chunk for the whole memory space that will
+  // be chunked later.
+  ChunkHandle h = AllocateChunk();
+  ArenaImpl::Chunk* c = ChunkFromHandle(h);
+  c->ptr = mem_addr;
+  c->size = bytes;
+  c->allocation_id = -1;
+  c->prev = kInvalidChunkHandle;
+  c->next = kInvalidChunkHandle;
+  // assign the new created chunk to default stream, so it can be pick up by any stream
+  c->stream = nullptr;
+
+  region_manager_.set_handle(c->ptr, h);
+
+  // TODO(vrv): Try to merge this new region with an existing region,
+  // if the address space is contiguous, to avoid fragmentation
+  // across regions.
+
+  // Insert the chunk into the right bin.
+  InsertFreeChunkIntoBin(h);
+
+  return nullptr;
+}
+
+ArenaImpl::ChunkHandle
+ArenaImpl::AllocateChunk() {
+  if (free_chunks_list_ != kInvalidChunkHandle) {
+    ChunkHandle h = free_chunks_list_;
+    Chunk* c = ChunkFromHandle(h);
+    free_chunks_list_ = c->next;
+    return h;
+  }
+  ChunkHandle h = chunks_.size();
+  chunks_.resize(h + 1);
+  return h;
+}
+
+void ArenaImpl::DeallocateChunk(ChunkHandle h) {
+  Chunk* c = ChunkFromHandle(h);
+
+  if (c->stream) {
+    if (auto it = stream_to_chunks_.find(c->stream); it != stream_to_chunks_.end()) {
+      size_t result = it->second.erase(h);
+      static_cast<void>(result);  // should always be found
+
+      if (it->second.empty()) {
+        stream_to_chunks_.erase(it);
+        impl_to_stream_.erase(ep_api_.SyncStream_GetImpl(c->stream));
+      }
+    }
+
+    c->stream = nullptr;
+    c->stream_sync_id = 0;
+  }
+
+  c->next = free_chunks_list_;
+  free_chunks_list_ = h;
+}
+
+// static
+size_t ArenaImpl::RoundedBytes(size_t bytes) {
+  return (kMinAllocationSize * ((bytes + kMinAllocationSize - 1) / kMinAllocationSize));
+}
+
+void* ArenaImpl::Alloc(size_t size) {
+  return AllocateRawInternal(size, nullptr, false);
+}
+
+void* ArenaImpl::AllocOnStream(size_t size, OrtSyncStream* stream) {
+  return AllocateRawInternal(size, stream, false);
+}
+
+void* ArenaImpl::Reserve(size_t size) {
+  if (size == 0)
+    return nullptr;
+
+  std::lock_guard<std::mutex> lock(lock_);
+
+  LOG(INFO, "Reserving memory in ArenaImpl for " << allocator_name_ << " size: " << size);
+
+  void* ptr = device_allocator_->Alloc(device_allocator_.get(), size);
+  EP_ENFORCE(reserved_chunks_.find(ptr) == reserved_chunks_.end(), __FUNCTION__);
+  reserved_chunks_.insert(std::pair<void*, size_t>(ptr, size));
+  stats_.bytes_in_use += size;
+  stats_.num_reserves += 1;
+  stats_.num_allocs += 1;
+  stats_.max_alloc_size = std::max<size_t>(static_cast<size_t>(stats_.max_alloc_size), size);
+  stats_.max_bytes_in_use = std::max<int64_t>(static_cast<int64_t>(stats_.max_bytes_in_use), stats_.bytes_in_use);
+  stats_.total_allocated_bytes += size;
+  return ptr;
+}
+
+size_t ArenaImpl::RequestedSize(const void* ptr) {
+  std::lock_guard<std::mutex> lock(lock_);
+  ArenaImpl::ChunkHandle h = region_manager_.get_handle(ptr);
+  EP_ENFORCE(h != kInvalidChunkHandle, __FUNCTION__);
+  ArenaImpl::Chunk* c = ChunkFromHandle(h);
+  return c->requested_size;
+}
+
+size_t ArenaImpl::AllocatedSize(const void* ptr) {
+  std::lock_guard<std::mutex> lock(lock_);
+  ArenaImpl::ChunkHandle h = region_manager_.get_handle(ptr);
+  EP_ENFORCE(h != kInvalidChunkHandle, __FUNCTION__);
+  ArenaImpl::Chunk* c = ChunkFromHandle(h);
+  return c->size;
+}
+
+void* ArenaImpl::AllocateRawInternal(size_t num_bytes, OrtSyncStream* stream, bool dump_log_on_failure) {
+  if (num_bytes == 0) {
+    return nullptr;
+  }
+
+  // Round to multiple of kMinAllocationSize
+  size_t rounded_bytes = RoundedBytes(num_bytes);
+
+  // The BFC allocator tries to find the best fit first.
+  BinNum bin_num = BinNumForSize(rounded_bytes);
+
+  std::lock_guard<std::mutex> lock(lock_);
+
+  if (stream && stream_to_chunks_.find(stream) == stream_to_chunks_.end()) {
+    stream_to_chunks_.insert({stream, std::set<size_t>{}});
+    const OrtSyncStreamImpl* stream_impl = ep_api_.SyncStream_GetImpl(stream);
+    assert(stream_impl);
+    impl_to_stream_.insert({stream_impl, stream});
+  }
+
+  // search for a valid chunk
+  auto* chunk = FindChunkPtr(bin_num, rounded_bytes, num_bytes, stream);
+
+  if (chunk != nullptr) {
+    return chunk->ptr;
+  }
+
+  LOG(INFO, "Extending arena for " << allocator_name_
+                                   << ". bin_num:" << bin_num << " (requested) num_bytes: " << num_bytes
+                                   << " (actual) rounded_bytes:" << rounded_bytes);
+
+  // Try to extend
+  auto status = Extend(rounded_bytes);
+  if (status == nullptr) {
+    chunk = FindChunkPtr(bin_num, rounded_bytes, num_bytes, stream);
+    if (chunk != nullptr) {
+      return chunk->ptr;
+    } else {
+      status = api_.CreateStatus(ORT_EP_FAIL,
+                                 ("Failed to find a free memory block despite calling Extend. rounded_bytes=" +
+                                  std::to_string(rounded_bytes))
+                                     .c_str());
+    }
+  }
+
+  // We searched all bins for an existing free chunk to use and couldn't find one. Dump the memory log for analysis.
+  if (dump_log_on_failure) {
+    LOG(ERROR, "BFC Arena ran out of memory trying to allocate " << num_bytes);
+    DumpMemoryLog(rounded_bytes);
+  }
+
+  throw new std::runtime_error(api_.GetErrorMessage(status));
+}
+
+OrtStatus* ArenaImpl::GetStats(OrtKeyValuePairs** stats) {
+  std::lock_guard<std::mutex> lock(lock_);
+
+  api_.CreateKeyValuePairs(stats);
+  stats_.ToKeyValuePairs(api_, *stats);
+
+  return nullptr;
+}
+
+ArenaImpl::Chunk* ArenaImpl::SplitFreeChunkFromBin(ArenaImpl::Bin::FreeChunkSet* free_chunks,
+                                                   const ArenaImpl::Bin::FreeChunkSet::iterator& citer,
+                                                   size_t rounded_bytes,
+                                                   size_t num_bytes) {
+  const ArenaImpl::ChunkHandle h = (*citer);
+  RemoveFreeChunkIterFromBin(free_chunks, citer);
+  ArenaImpl::Chunk* chunk = ChunkFromHandle(h);
+
+  // If we can break the size of the chunk into two reasonably large pieces, do so.
+  // In any case don't waste more than max_dead_bytes_per_chunk bytes on padding this alloc.
+  if (chunk->size >= rounded_bytes * 2 ||
+      static_cast<int64_t>(chunk->size - rounded_bytes) >= config_.max_dead_bytes_per_chunk) {
+    SplitChunk(h, rounded_bytes);
+    chunk = ChunkFromHandle(h);  // Update chunk pointer in case it moved
+  }
+
+  // The requested size of the returned chunk is what the user has allocated.
+  chunk->requested_size = num_bytes;
+  // Assign a unique id and increment the id counter, marking the chunk as being in use.
+  chunk->allocation_id = next_allocation_id_++;
+
+  ++stats_.num_allocs;
+  stats_.bytes_in_use += chunk->size;
+  stats_.max_bytes_in_use = std::max(stats_.max_bytes_in_use, stats_.bytes_in_use);
+  stats_.max_alloc_size = std::max<int64_t>(stats_.max_alloc_size, static_cast<int64_t>(chunk->size));
+
+  return chunk;
+}
+
+ArenaImpl::Chunk* ArenaImpl::FindChunkPtr(BinNum bin_num, size_t rounded_bytes, size_t num_bytes,
+                                          OrtSyncStream* stream) {
+  // First identify the first bin that could satisfy rounded_bytes.
+  for (; bin_num < kNumBins; bin_num++) {
+    // Start searching from the first bin for the smallest chunk that fits rounded_bytes.
+    Bin* b = BinFromIndex(bin_num);
+    for (auto citer = b->free_chunks.begin(); citer != b->free_chunks.end(); ++citer) {
+      const ArenaImpl::ChunkHandle h = (*citer);
+      ArenaImpl::Chunk* chunk = ChunkFromHandle(h);
+      EP_ENFORCE(!chunk->in_use(), __FUNCTION__);
+
+      if (chunk->size >= rounded_bytes) {
+        // We found an existing chunk that fits us that wasn't in use.
+        // If it's assigned to another stream, and we have synchronized with that stream more recently than it
+        // was assigned, we can take the chunk.
+        bool safe_to_use = chunk->stream == stream ||
+                           !chunk->stream ||
+                           (stream && chunk->stream &&
+                            chunk->stream_sync_id < ep_api_.GetSyncIdForLastWaitOnSyncStream(chunk->stream, stream));
+
+        if (safe_to_use) {
+          chunk = SplitFreeChunkFromBin(&b->free_chunks, citer, rounded_bytes, num_bytes);
+
+          if (stream) {
+            chunk->stream = stream;
+            chunk->stream_sync_id = ep_api_.SyncStream_GetSyncId(stream);
+            stream_to_chunks_[stream].insert(h);
+          }
+
+          return chunk;
+        }
+      }
+    }
+  }
+
+  return nullptr;
+}
+
+void ArenaImpl::SplitChunk(ArenaImpl::ChunkHandle h, size_t num_bytes) {
+  // Allocate the new chunk before we do any ChunkFromHandle
+  ChunkHandle h_new_chunk = AllocateChunk();
+
+  Chunk* c = ChunkFromHandle(h);
+  EP_ENFORCE(!c->in_use() && (c->bin_num == kInvalidBinNum), __FUNCTION__);
+
+  // Create a new chunk starting num_bytes after c
+  ArenaImpl::Chunk* new_chunk = ChunkFromHandle(h_new_chunk);
+  new_chunk->stream = c->stream;
+  new_chunk->stream_sync_id = c->stream_sync_id;
+
+  new_chunk->ptr = static_cast<void*>(static_cast<char*>(c->ptr) + num_bytes);
+  region_manager_.set_handle(new_chunk->ptr, h_new_chunk);
+
+  // Set the new sizes of the chunks.
+  new_chunk->size = c->size - num_bytes;
+  c->size = num_bytes;
+
+  // The new chunk is not in use.
+  new_chunk->allocation_id = -1;
+
+  // Maintain the pointers.
+  // c <-> c_neighbor becomes
+  // c <-> new_chunk <-> c_neighbor
+  ArenaImpl::ChunkHandle h_neighbor = c->next;
+  new_chunk->prev = h;
+  new_chunk->next = h_neighbor;
+  c->next = h_new_chunk;
+  if (h_neighbor != kInvalidChunkHandle) {
+    Chunk* c_neighbor = ChunkFromHandle(h_neighbor);
+    c_neighbor->prev = h_new_chunk;
+  }
+
+  // Add the newly free chunk to the free bin.
+  InsertFreeChunkIntoBin(h_new_chunk);
+}
+
+void ArenaImpl::Free(void* p) {
+  if (p == nullptr) {
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(lock_);
+  auto it = reserved_chunks_.find(p);
+  if (it != reserved_chunks_.end()) {
+    device_allocator_->Free(device_allocator_.get(), it->first);
+    stats_.bytes_in_use -= it->second;
+    stats_.total_allocated_bytes -= it->second;
+    reserved_chunks_.erase(it);
+  } else {
+    DeallocateRawInternal(p);
+  }
+}
+
+void ArenaImpl::DeallocateRawInternal(void* ptr) {
+  // Find the chunk from the ptr.
+  ArenaImpl::ChunkHandle h = region_manager_.get_handle(ptr);
+  EP_ENFORCE(h != kInvalidChunkHandle, __FUNCTION__);
+
+  // Consider coalescing it.
+  FreeAndMaybeCoalesce(h);
+}
+
+// Merges Chunk(h2) into Chunk(h1) when Chunk(h1)->next is h2 and Chunk(h2)->prev is h1.
+void ArenaImpl::Merge(ArenaImpl::ChunkHandle h1,
+                      ArenaImpl::ChunkHandle h2) {
+  Chunk* c1 = ChunkFromHandle(h1);
+  Chunk* c2 = ChunkFromHandle(h2);
+  // We can only merge chunks that are not in use.
+  EP_ENFORCE(!c1->in_use() && !c2->in_use() && c1->stream == c2->stream, __FUNCTION__);
+
+  // c1's prev doesn't change, still points to the same ptr, and is
+  // still not in use.
+
+  // Fix up neighbor pointers
+  //
+  // c1 <-> c2 <-> c3 should become
+  // c1 <-> c3
+
+  ArenaImpl::ChunkHandle h3 = c2->next;
+  c1->next = h3;
+  EP_ENFORCE(c2->prev == h1, __FUNCTION__);
+  if (h3 != kInvalidChunkHandle) {
+    ArenaImpl::Chunk* c3 = ChunkFromHandle(h3);
+    c3->prev = h1;
+  }
+
+  // Set the new size
+  c1->size += c2->size;
+
+  // we only merge chunks that have the same stream
+  assert(c1->stream == c2->stream);
+  c1->stream_sync_id = std::max(c1->stream_sync_id, c2->stream_sync_id);
+
+  DeleteChunk(h2);
+}
+
+void ArenaImpl::DeleteChunk(ChunkHandle h) {
+  // Delete h and cleanup all state
+  Chunk* c = ChunkFromHandle(h);
+  region_manager_.erase(c->ptr);
+  DeallocateChunk(h);
+}
+
+void ArenaImpl::InsertFreeChunkIntoBin(ArenaImpl::ChunkHandle h) {
+  Chunk* c = ChunkFromHandle(h);
+  EP_ENFORCE(!c->in_use() && (c->bin_num == kInvalidBinNum), __FUNCTION__);
+  BinNum bin_num = BinNumForSize(c->size);
+  Bin* new_bin = BinFromIndex(bin_num);
+  c->bin_num = bin_num;
+  new_bin->free_chunks.insert(h);
+}
+
+void ArenaImpl::RemoveFreeChunkIterFromBin(ArenaImpl::Bin::FreeChunkSet* free_chunks,
+                                           const ArenaImpl::Bin::FreeChunkSet::iterator& citer) {
+  ChunkHandle h = *citer;
+  Chunk* c = ChunkFromHandle(h);
+  EP_ENFORCE(!c->in_use() && (c->bin_num != kInvalidBinNum), __FUNCTION__);
+  free_chunks->erase(citer);
+  c->bin_num = kInvalidBinNum;
+}
+
+void ArenaImpl::RemoveFreeChunkFromBin(ArenaImpl::ChunkHandle h) {
+  Chunk* c = ChunkFromHandle(h);
+  EP_ENFORCE(!c->in_use() && (c->bin_num != kInvalidBinNum), __FUNCTION__);
+  EP_ENFORCE(BinFromIndex(c->bin_num)->free_chunks.erase(h) > 0, "Could not find chunk in bin");
+  c->bin_num = kInvalidBinNum;
+}
+
+void ArenaImpl::FreeAndMaybeCoalesce(ArenaImpl::ChunkHandle h) {
+  Chunk* c = ChunkFromHandle(h);
+  EP_ENFORCE(c->in_use() && (c->bin_num == kInvalidBinNum), __FUNCTION__);
+
+  // Mark the chunk as no longer in use
+  c->allocation_id = -1;
+
+  // Updates the stats.
+  stats_.bytes_in_use -= c->size;
+
+  // This chunk is no longer in-use, consider coalescing the chunk
+  // with adjacent chunks.
+  ChunkHandle chunk_to_reassign = Coalesce(h);
+  InsertFreeChunkIntoBin(chunk_to_reassign);
+}
+
+ArenaImpl::ChunkHandle ArenaImpl::Coalesce(ChunkHandle h) {
+  Chunk* c = ChunkFromHandle(h);
+  EP_ENFORCE(!c->in_use(), __FUNCTION__);
+
+  // This chunk is no longer in-use, consider coalescing the chunk with adjacent chunks.
+  ChunkHandle chunk_to_reassign = h;
+
+  // If the next chunk is free, coalesce the two
+  if (c->next != kInvalidChunkHandle) {
+    Chunk* cnext = ChunkFromHandle(c->next);
+    // only merge the chunks belong to the same stream
+    if (!cnext->in_use() && cnext->stream == c->stream) {
+      chunk_to_reassign = h;
+
+      // Deletes c->next
+      RemoveFreeChunkFromBin(c->next);
+      Merge(h, ChunkFromHandle(h)->next);
+    }
+  }
+
+  // If the previous chunk is free, coalesce the two
+  c = ChunkFromHandle(h);
+  if (c->prev != kInvalidChunkHandle) {
+    Chunk* cprev = ChunkFromHandle(c->prev);
+    // only merge the chunks belong to the same stream
+    if (!cprev->in_use() && cprev->stream == c->stream) {
+      chunk_to_reassign = c->prev;
+
+      RemoveFreeChunkFromBin(c->prev);  // this deletes c
+      Merge(ChunkFromHandle(h)->prev, h);
+    }
+  }
+
+  return chunk_to_reassign;
+}
+
+std::array<ArenaImpl::BinDebugInfo, ArenaImpl::kNumBins> ArenaImpl::GetBinDebugInfo() {
+  std::array<BinDebugInfo, kNumBins> bin_infos;
+
+  for (const auto& region : region_manager_.regions()) {
+    ChunkHandle h = region_manager_.get_handle(region.ptr());
+    while (h != kInvalidChunkHandle) {
+      const Chunk* c = ChunkFromHandle(h);
+      BinNum bin_num = BinNumForSize(c->size);
+      BinDebugInfo& bin_info = bin_infos[bin_num];
+      bin_info.total_bytes_in_bin += c->size;
+      bin_info.total_chunks_in_bin++;
+
+      if (c->in_use()) {
+        bin_info.total_bytes_in_use += c->size;
+        bin_info.total_requested_bytes_in_use += c->requested_size;
+        bin_info.total_chunks_in_use++;
+      } else {
+        Bin* bin = BinFromIndex(bin_num);
+        EP_ENFORCE(bin->free_chunks.count(h) == 1 && c->bin_num == bin_num, __FUNCTION__);
+      }
+
+      h = c->next;
+    }
+  }
+  return bin_infos;
+}
+
+void ArenaImpl::DumpMemoryLog(size_t num_bytes) {
+  const std::array<BinDebugInfo, kNumBins> bin_infos = GetBinDebugInfo();
+  LOG(INFO, "Allocator:" << allocator_name_);
+  LOG(INFO, "Bin size: Chunks in_use/total (if not zero). Allocated bytes in_use/total. Requested bytes.");
+
+  size_t waste = 0;
+  for (BinNum bin_num = 0; bin_num < kNumBins; bin_num++) {
+    Bin* b = BinFromIndex(bin_num);
+    const BinDebugInfo& bin_info = bin_infos[bin_num];
+    EP_ENFORCE(b->free_chunks.size() == bin_info.total_chunks_in_bin - bin_info.total_chunks_in_use, __FUNCTION__);
+
+    if (bin_info.total_chunks_in_bin > 0) {
+      LOG(INFO, b->bin_size
+                    << ": Chunks " << bin_info.total_chunks_in_use << "/" << bin_info.total_chunks_in_bin
+                    << ". Bytes "
+                    << bin_info.total_bytes_in_use << "/" << bin_info.total_bytes_in_bin << ". "
+                    << "Requested " << bin_info.total_requested_bytes_in_use << ".");
+
+      waste += bin_info.total_bytes_in_use - bin_info.total_requested_bytes_in_use;
+    }
+  }
+
+  if (waste > 0) {
+    LOG(INFO, "Diff between in-use and requested bytes is " << waste);
+  }
+
+  // Find the bin that we would have liked to allocate in, so we can get some further analysis about fragmentation.
+  Bin* b = BinForSize(num_bytes);
+
+  LOG(INFO, "Bin for " << num_bytes
+                       << " bytes has max bytes of " << b->bin_size
+                       << ", Chunk State: ");
+
+  for (ChunkHandle h : b->free_chunks) {
+    Chunk* c = ChunkFromHandle(h);
+    LOG(INFO, "  " << c->DebugString(this, true));
+  }
+
+  // Next show the chunks that are in use, and also summarize their number by size.
+  LOG(INFO, "Overall chunks summary:");
+  std::map<size_t, int> in_use_by_size;
+  for (const auto& region : region_manager_.regions()) {
+    ChunkHandle h = region_manager_.get_handle(region.ptr());
+    while (h != kInvalidChunkHandle) {
+      const Chunk* c = ChunkFromHandle(h);
+      if (c->in_use()) {
+        in_use_by_size[c->size]++;
+      }
+      LOG(INFO, (c->in_use() ? "  Chunk" : "  Free ") << " at " << c->ptr
+                                                      << " of size " << c->size);
+      h = c->next;
+    }
+  }
+
+  LOG(INFO, "Summary of in-use chunks by size: ");
+  size_t total_bytes = 0;
+  for (auto& it : in_use_by_size) {
+    LOG(INFO, "  " << it.second << " chunks of size " << it.first
+                   << ". Total " << it.first * it.second);
+    total_bytes += (it.first * it.second);
+  }
+
+  LOG(INFO, "Sum Total of in-use chunks: " << total_bytes);
+  LOG(INFO, "Stats: \n"
+                << stats_.DebugString());
+}
+
+OrtStatus* ArenaImpl::ResetChunksUsingStream(const OrtSyncStreamImpl* stream_impl) {
+  std::lock_guard<std::mutex> lock(lock_);
+
+  auto impl_it = impl_to_stream_.find(stream_impl);
+  if (impl_it == impl_to_stream_.end()) {
+    return nullptr;  // stream hasn't been used with this arena
+  }
+
+  const OrtSyncStream* stream = impl_it->second;
+
+  auto it = stream_to_chunks_.find(stream);
+  if (it != stream_to_chunks_.end()) {
+    const auto& chunk_handles = it->second;
+    for (size_t handle : chunk_handles) {
+      Chunk* c = ChunkFromHandle(handle);
+      assert(c->stream == stream);  // something is out of sync if this is not the case
+      c->stream = nullptr;
+    }
+
+    stream_to_chunks_.erase(it);
+    impl_to_stream_.erase(stream_impl);
+  }
+
+  // It's also possible to find the chunks this way, but that requires iterating every single in-use allocation.
+  // We also repeat this for every single stream used in a session.
+  // OTOH there's a cost to create/update keep streams_to_chunks_.
+  // Using streams_to_chunks_ for now. It also simplifies debugging to have that info. If you're unsure about this
+  // choice feel free to perf test the two approaches.
+  //
+  // for (const auto& region : region_manager_.regions()) {
+  //   ChunkHandle region_begin_chunk = region_manager_.get_handle(region.ptr());
+  //   ChunkHandle h = region_begin_chunk;
+  //   while (h != kInvalidChunkHandle) {
+  //     Chunk* c = ChunkFromHandle(h);
+  //     if (c->stream == target_stream) {
+  //       c->stream = nullptr;
+  //       c->stream_sync_id = 0;
+  //     }
+  //     h = c->next;
+  //   }
+  // }
+
+  // coalesce
+  for (const auto& region : region_manager_.regions()) {
+    ChunkHandle region_begin_chunk = region_manager_.get_handle(region.ptr());
+    ChunkHandle h = region_begin_chunk;
+    while (h != kInvalidChunkHandle) {
+      Chunk* c = ChunkFromHandle(h);
+      if (!c->in_use()) {
+        RemoveFreeChunkFromBin(h);
+        ChunkHandle h_next = c->next;
+        Chunk* c_next = h_next != kInvalidChunkHandle ? ChunkFromHandle(h_next) : nullptr;
+
+        // merge until next chunk is different stream
+        while (c_next && !c_next->in_use() && c_next->stream == c->stream) {
+          Coalesce(h);
+          h_next = c->next;
+          c_next = h_next != kInvalidChunkHandle ? ChunkFromHandle(h_next) : nullptr;
+        }
+
+        if (c->bin_num == kInvalidBinNum) {
+          InsertFreeChunkIntoBin(h);
+        }
+      }
+      h = c->next;
+    }
+  }
+
+  return nullptr;
+}

--- a/onnxruntime/test/autoep/library/ep_arena.h
+++ b/onnxruntime/test/autoep/library/ep_arena.h
@@ -1,0 +1,629 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+// Portions Copyright (c) Microsoft Corporation
+
+#pragma once
+#include <array>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <set>
+
+#include "onnxruntime_cxx_api.h"
+#include "ep_allocator.h"
+#include "example_plugin_ep_utils.h"
+
+#if defined(PLATFORM_WINDOWS)
+#include <intrin.h>
+#endif
+
+enum ArenaExtendStrategy {
+  kDefault = -1,
+  kNextPowerOfTwo = 0,
+  kSameAsRequested = 1,
+};
+
+// copied from onnxruntime::OrtArenaCfg so the values and config key names match
+struct ArenaConfig {
+  static const ArenaExtendStrategy DEFAULT_ARENA_EXTEND_STRATEGY = ArenaExtendStrategy::kNextPowerOfTwo;
+  static const int DEFAULT_INITIAL_CHUNK_SIZE_BYTES = 1 * 1024 * 1024;
+  static const int DEFAULT_MAX_DEAD_BYTES_PER_CHUNK = 128 * 1024 * 1024;
+  static const int DEFAULT_INITIAL_GROWTH_CHUNK_SIZE_BYTES = 2 * 1024 * 1024;
+  static const int64_t DEFAULT_MAX_POWER_OF_TWO_EXTEND_BYTES = 1024 * 1024 * 1024;  // 1GB
+  static const size_t DEFAULT_MAX_MEM = std::numeric_limits<size_t>::max();
+
+  ArenaConfig(size_t max_mem = std::numeric_limits<size_t>::max(),
+              ArenaExtendStrategy arena_extend_strategy = DEFAULT_ARENA_EXTEND_STRATEGY,
+              int initial_chunk_size_bytes = DEFAULT_INITIAL_CHUNK_SIZE_BYTES,
+              int max_dead_bytes_per_chunk = DEFAULT_MAX_DEAD_BYTES_PER_CHUNK,
+              int initial_growth_chunk_size_bytes = DEFAULT_INITIAL_GROWTH_CHUNK_SIZE_BYTES,
+              int64_t max_power_of_two_extend_bytes = DEFAULT_MAX_POWER_OF_TWO_EXTEND_BYTES)
+      : max_mem(max_mem),
+        arena_extend_strategy(arena_extend_strategy),
+        initial_chunk_size_bytes(initial_chunk_size_bytes),
+        max_dead_bytes_per_chunk(max_dead_bytes_per_chunk),
+        initial_growth_chunk_size_bytes(initial_growth_chunk_size_bytes),
+        max_power_of_two_extend_bytes(max_power_of_two_extend_bytes) {
+    if (arena_extend_strategy == ArenaExtendStrategy::kDefault) {
+      arena_extend_strategy = ArenaExtendStrategy::kNextPowerOfTwo;
+    }
+  }
+
+  size_t max_mem;
+  ArenaExtendStrategy arena_extend_strategy;
+  int initial_chunk_size_bytes;
+  int max_dead_bytes_per_chunk;
+  int initial_growth_chunk_size_bytes;
+  int64_t max_power_of_two_extend_bytes;
+
+  bool IsValid() {
+    return initial_chunk_size_bytes > 0 &&
+           max_dead_bytes_per_chunk > 0 &&
+           initial_growth_chunk_size_bytes > 0 &&
+           max_power_of_two_extend_bytes > 0;
+  }
+
+  // config key names that we parse in FromKeyValuePairs
+  struct ConfigKeyNames {
+    static constexpr const char* ArenaExtendStrategy = "arena.extend_strategy";
+    static constexpr const char* InitialChunkSizeBytes = "arena.initial_chunk_size_bytes";
+    static constexpr const char* MaxDeadBytesPerChunk = "arena.max_dead_bytes_per_chunk";
+    static constexpr const char* InitialGrowthChunkSizeBytes = "arena.initial_growth_chunk_size_bytes";
+    static constexpr const char* MaxPowerOfTwoExtendBytes = "arena.max_power_of_two_extend_bytes";
+    static constexpr const char* MaxMem = "arena.max_mem";
+  };
+
+  static ArenaConfig FromKeyValuePairs(const OrtApi& api, const OrtKeyValuePairs& kvps) {
+    ArenaConfig config{};
+    const char* value = nullptr;
+
+    if (value = api.GetKeyValue(&kvps, ConfigKeyNames::ArenaExtendStrategy); value) {
+      config.arena_extend_strategy = std::string(value) == "1" ? kSameAsRequested : kNextPowerOfTwo;
+    }
+
+    if (value = api.GetKeyValue(&kvps, ConfigKeyNames::InitialChunkSizeBytes); value) {
+      config.initial_chunk_size_bytes = std::stoi(std::string(value));
+    }
+
+    if (value = api.GetKeyValue(&kvps, ConfigKeyNames::MaxDeadBytesPerChunk); value) {
+      config.max_dead_bytes_per_chunk = std::stoi(std::string(value));
+    }
+
+    if (value = api.GetKeyValue(&kvps, ConfigKeyNames::InitialGrowthChunkSizeBytes); value) {
+      config.initial_growth_chunk_size_bytes = std::stoi(std::string(value));
+    }
+
+    if (value = api.GetKeyValue(&kvps, ConfigKeyNames::MaxPowerOfTwoExtendBytes); value) {
+      config.max_power_of_two_extend_bytes = std::stoll(value);
+    }
+
+    if (value = api.GetKeyValue(&kvps, ConfigKeyNames::MaxMem); value) {
+      config.max_mem = static_cast<size_t>(std::stoull(std::string(value)));
+    }
+
+    return config;
+  }
+};
+
+// A memory allocator that implements a 'best-fit with coalescing' algorithm.
+// This is essentially a very simple version of Doug Lea's malloc (dlmalloc).
+//
+// The goal of this allocator is to support defragmentation via coalescing.
+// One assumption we make is that the process using this allocator owns pretty much all of the memory, and that nearly
+// all requests to allocate memory go through this interface.
+class ArenaImpl {
+ public:
+  static const ArenaExtendStrategy DEFAULT_ARENA_EXTEND_STRATEGY = ArenaExtendStrategy::kNextPowerOfTwo;
+  static const int DEFAULT_INITIAL_CHUNK_SIZE_BYTES = 1 * 1024 * 1024;
+  static const int DEFAULT_MAX_DEAD_BYTES_PER_CHUNK = 128 * 1024 * 1024;
+  static const int DEFAULT_INITIAL_GROWTH_CHUNK_SIZE_BYTES = 2 * 1024 * 1024;
+  static const int64_t DEFAULT_MAX_POWER_OF_TWO_EXTEND_BYTES = 1024 * 1024 * 1024;  // 1GB
+  static const size_t DEFAULT_MAX_MEM = std::numeric_limits<size_t>::max();
+
+  ArenaImpl(AllocatorUniquePtr allocator, const ArenaConfig& config, const OrtApi& api,
+            const OrtLogger& logger);
+
+  ~ArenaImpl();
+
+  void* Alloc(size_t size);
+  void* AllocOnStream(size_t size, OrtSyncStream* stream);
+  void Free(void* p);
+
+  // allocate memory directly. this is used for initializers so they don't affect the arena growth patterns
+  void* Reserve(size_t size);
+
+  OrtStatus* GetStats(OrtKeyValuePairs** stats);
+
+  size_t RequestedSize(const void* ptr);
+  size_t AllocatedSize(const void* ptr);
+
+  // Un-assign chunks that are currently assigned to the stream.
+  //
+  // This should be called from OrtSyncStreamImpl::OnSessionRunEnd.
+  // A stream is used in one session at a time. When called from OnSessionRunEnd we know that the stream is done and
+  // will not be performing any more operations on the data.
+  //
+  // We don't have a better way to know when it's safe to re-use a chunk in another stream given the actual memory
+  // usage is asynchronous on the GPU side, and the code assigning memory is running on CPU prior to that.
+  OrtStatus* ResetChunksUsingStream(const OrtSyncStreamImpl* stream_impl);
+
+ private:
+  void* AllocateRawInternal(size_t num_bytes, OrtSyncStream* stream, bool dump_log_on_failure);
+  void DeallocateRawInternal(void* ptr);
+
+  // A ChunkHandle is an index into the chunks_ vector in BFCAllocator
+  // kInvalidChunkHandle means an invalid chunk
+  using ChunkHandle = size_t;
+  static const size_t kInvalidChunkHandle = static_cast<size_t>(-1);
+
+  using BinNum = int;
+  static const int kInvalidBinNum = -1;
+  static const int kNumBins = 21;
+
+  // Chunks point to memory.  Their prev/next pointers form a
+  // doubly-linked list of addresses sorted by base address that
+  // must be contiguous.  Chunks contain information about whether
+  // they are in use or whether they are free, and contain a pointer
+  // to the bin they are in.
+  struct Chunk {
+    size_t size = 0;  // Full size of buffer.
+
+    // We sometimes give chunks that are larger than needed to reduce
+    // fragmentation.  requested_size keeps track of what the client
+    // actually wanted so we can understand whether our splitting
+    // strategy is efficient.
+    size_t requested_size = 0;
+
+    // allocation_id is set to -1 when the chunk is not in use. It is assigned a
+    // value greater than zero before the chunk is returned from
+    // AllocateRaw, and this value is unique among values assigned by
+    // the parent allocator.
+    int64_t allocation_id = -1;
+    void* ptr = nullptr;  // pointer to granted subbuffer.
+
+    // If not kInvalidChunkHandle, the memory referred to by 'prev' is directly
+    // preceding the memory used by this chunk.  E.g., It should start
+    // at 'ptr - prev->size'
+    ChunkHandle prev = kInvalidChunkHandle;
+
+    // If not kInvalidChunkHandle, the memory referred to by 'next' is directly
+    // following the memory used by this chunk.  E.g., It should be at
+    // 'ptr + next->size'
+    ChunkHandle next = kInvalidChunkHandle;
+
+    // What bin are we in?
+    BinNum bin_num = kInvalidBinNum;
+
+    OrtSyncStream* stream = nullptr;
+    // Current sync id of `stream` when it was assigned the Chunk.
+    // If the chunk is assigned to a stream and is free, and another Stream wants to use it, that Stream must have
+    // synchronized with `stream` at a sync id > to stream_sync_id.
+    // stream_sync_id is set when the chunk is first assigned to `stream`.
+    // The sync id is incremented at the start of sync, so any chunk with a previous sync id is safe to re-assign.
+    uint64_t stream_sync_id = 0;
+
+    bool in_use() const { return allocation_id != -1; }
+
+    std::string DebugString(ArenaImpl* a, bool recurse) {
+      std::ostringstream ss;
+      ss << "  Size: " << size << " | Requested Size: " << requested_size << " | in_use: " << in_use();
+      if (recurse && prev != ArenaImpl::kInvalidChunkHandle) {
+        Chunk* p = a->ChunkFromHandle(prev);
+        ss << ", prev: " << p->DebugString(a, false);
+      }
+
+      if (recurse && next != ArenaImpl::kInvalidChunkHandle) {
+        Chunk* n = a->ChunkFromHandle(next);
+        ss << ", next: " << n->DebugString(a, false);
+      }
+      return ss.str();
+    }
+  };
+
+  // A Bin is a collection of similar-sized free chunks.
+  struct Bin {
+    // All chunks in this bin have >= bin_size memory.
+    size_t bin_size = 0;
+
+    struct ChunkComparator {
+      explicit ChunkComparator(ArenaImpl* allocator)
+          : allocator_(allocator) {}
+
+      // Sort first by size and then use pointer address as a tie breaker.
+      bool operator()(const ChunkHandle ha,
+                      const ChunkHandle hb) const {
+        const Chunk* a = allocator_->ChunkFromHandle(ha);
+        const Chunk* b = allocator_->ChunkFromHandle(hb);
+        if (a->size != b->size) {
+          return a->size < b->size;
+        }
+        return a->ptr < b->ptr;
+      }
+
+     private:
+      ArenaImpl* allocator_;  // The parent allocator
+    };
+
+    typedef std::set<ChunkHandle, ChunkComparator> FreeChunkSet;
+    // List of free chunks within the bin, sorted by chunk size.
+    // Chunk * not owned.
+    FreeChunkSet free_chunks;
+    Bin(ArenaImpl* allocator, size_t bs)
+        : bin_size(bs), free_chunks(ChunkComparator(allocator)) {}
+  };
+
+  static const size_t kMinAllocationBits = 8;
+  static const size_t kMinAllocationSize = 1 << kMinAllocationBits;
+
+  // AllocationRegion maps pointers to ChunkHandles for a single
+  // contiguous memory region.
+  //
+  // This class is thread-compatible.
+  class AllocationRegion {
+   public:
+    AllocationRegion(void* ptr, size_t memory_size, int64_t id)
+        : ptr_(ptr),
+          memory_size_(memory_size),
+          end_ptr_(static_cast<void*>(static_cast<char*>(ptr_) + memory_size_)),
+          id_(id) {
+      EP_ENFORCE(0 == memory_size % kMinAllocationSize, "AllocationRegion ctor");
+
+      const size_t n_handles = (memory_size + kMinAllocationSize - 1) / kMinAllocationSize;
+      handles_ = std::make_unique<ChunkHandle[]>(n_handles);
+      for (size_t i = 0; i < n_handles; i++) {
+        handles_[i] = kInvalidChunkHandle;
+      }
+    }
+
+    AllocationRegion(AllocationRegion&& other) noexcept { Swap(other); }
+    AllocationRegion() = default;
+    ~AllocationRegion() = default;
+
+    AllocationRegion& operator=(AllocationRegion&& other) noexcept {
+      Swap(other);
+      return *this;
+    }
+
+    void* ptr() const { return ptr_; }
+    void* end_ptr() const { return end_ptr_; }
+    size_t memory_size() const { return memory_size_; }
+    int64_t id() const { return id_; }
+
+    ChunkHandle get_handle(const void* p) const {
+      return handles_[IndexFor(p)];
+    }
+
+    void set_handle(const void* p, ChunkHandle h) {
+      handles_[IndexFor(p)] = h;
+    }
+
+    void erase(const void* p) {
+      set_handle(p, kInvalidChunkHandle);
+    }
+
+   private:
+    void Swap(AllocationRegion& other) {
+      std::swap(ptr_, other.ptr_);
+      std::swap(memory_size_, other.memory_size_);
+      std::swap(end_ptr_, other.end_ptr_);
+      std::swap(id_, other.id_);
+      std::swap(handles_, other.handles_);
+    }
+
+    int IndexFor(const void* p) const {
+      std::uintptr_t p_int = reinterpret_cast<std::uintptr_t>(p);
+      std::uintptr_t base_int = reinterpret_cast<std::uintptr_t>(ptr_);
+      EP_ENFORCE(p_int >= base_int, "AllocationRegion::IndexFor");
+      EP_ENFORCE(p_int < base_int + memory_size_, "AllocationRegion::IndexFor");
+      return static_cast<int>(((p_int - base_int) >> kMinAllocationBits));
+    }
+
+    // metadata about the allocation region.
+    void* ptr_ = nullptr;
+    size_t memory_size_ = 0;
+    void* end_ptr_ = nullptr;
+    // A unique identifier for this allocation region
+    // (May be used by the client to track which allocation region was allocated first, second, and so on)
+    int64_t id_ = -1;
+
+    // Array of size "memory_size / kMinAllocationSize".  It is
+    // indexed by (p-base) / kMinAllocationSize, contains ChunkHandle
+    // for the memory allocation represented by "p"
+    std::unique_ptr<ChunkHandle[]> handles_;
+
+    AllocationRegion& operator=(const AllocationRegion&) = delete;
+  };
+
+  // RegionManager aggregates one or more "AllocationRegions" and provides
+  // a layer of indirection from pointers to the underlying ChunkHandle,
+  // allowing allocation across multiple discontiguous memory regions.
+  //
+  // This class is thread-compatible.
+  class RegionManager {
+   public:
+    RegionManager() = default;
+    ~RegionManager() = default;
+
+    void AddAllocationRegion(void* ptr, size_t memory_size, int64_t id) {
+      // Insert sorted by end_ptr
+      auto entry = std::upper_bound(regions_.begin(), regions_.end(), ptr, &Comparator);
+      regions_.insert(entry, AllocationRegion(ptr, memory_size, id));
+    }
+
+    void RemoveAllocationRegion(void* ptr) {
+      auto entry = std::upper_bound(regions_.begin(), regions_.end(), ptr, &Comparator);
+      EP_ENFORCE(entry != regions_.end(), "RegionManager::RemoveAllocationRegion Could not find Region for: " << ptr);
+      regions_.erase(entry);
+    }
+
+    ChunkHandle get_handle(const void* p) const {
+      return RegionFor(p)->get_handle(p);
+    }
+
+    void set_handle(const void* p, ChunkHandle h) {
+      return MutableRegionFor(p)->set_handle(p, h);
+    }
+    void erase(const void* p) { return MutableRegionFor(p)->erase(p); }
+
+    const std::vector<AllocationRegion>& regions() const { return regions_; }
+
+   private:
+    RegionManager(const RegionManager&) = delete;
+    RegionManager& operator=(const RegionManager&) = delete;
+    RegionManager(RegionManager&&) = delete;
+    RegionManager& operator=(RegionManager&&) = delete;
+
+    static bool Comparator(const void* ptr, const AllocationRegion& other) {
+      return ptr < other.end_ptr();
+    }
+
+    AllocationRegion* MutableRegionFor(const void* p) {
+      return const_cast<AllocationRegion*>(RegionFor(p));
+    }
+
+    const AllocationRegion* RegionFor(const void* p) const {
+      auto entry = std::upper_bound(regions_.begin(), regions_.end(), p, &Comparator);
+
+      if (entry != regions_.end()) {
+        return &(*entry);
+      }
+
+      EP_ENFORCE(entry != regions_.end(), "RegionManager::RegionFor Could not find Region for: " << p);
+      return nullptr;
+    }
+
+   private:
+    std::vector<AllocationRegion> regions_;
+  };
+
+  // Returns 'bytes' rounded up to the next highest kMinAllocationSize.
+  size_t RoundedBytes(size_t bytes);
+
+  // Try to add a new memory region that can satisfy an allocation of
+  // 'rounded_bytes' bytes.
+  OrtStatus* Extend(size_t rounded_bytes);
+
+  // Returns an underlying allocated chunk of size
+  // 'rounded_bytes'.
+  ArenaImpl::Chunk* FindChunkPtr(BinNum bin_num, size_t rounded_bytes, size_t num_bytes, OrtSyncStream* stream);
+
+  // Splits the chunk specified by 'h' into two chunks, one at least
+  // of size 'num_bytes'.
+  void SplitChunk(ChunkHandle h, size_t num_bytes);
+
+  // Merges the two chunk handles.  Requires that the chunks are
+  // contiguous in their allocation.
+  void Merge(ChunkHandle h, ChunkHandle h2);
+
+  // Frees the memory represented by 'h', coalescing the chunk if
+  // possible.
+  void FreeAndMaybeCoalesce(ChunkHandle h);
+
+  ArenaImpl::ChunkHandle Coalesce(ChunkHandle h);
+
+  // Adds the chunk 'h' to the proper free bin.
+  void InsertFreeChunkIntoBin(ChunkHandle h);
+
+  // Removes the free chunk pointed to by 'c' from the set free_chunks.
+  void RemoveFreeChunkIterFromBin(Bin::FreeChunkSet* free_chunks,
+                                  const Bin::FreeChunkSet::iterator& c);
+
+  // Removes a free chunk from the bin.
+  void RemoveFreeChunkFromBin(ChunkHandle h);
+
+  ArenaImpl::Chunk* SplitFreeChunkFromBin(ArenaImpl::Bin::FreeChunkSet* free_chunks,
+                                          const ArenaImpl::Bin::FreeChunkSet::iterator& citer,
+                                          size_t rounded_bytes,
+                                          size_t num_bytes);
+
+  // Removes the chunk metadata represented by 'h'.
+  void DeleteChunk(ChunkHandle h);
+
+  void DumpMemoryLog(size_t num_bytes);
+
+  ChunkHandle AllocateChunk();
+  void DeallocateChunk(ChunkHandle h);
+
+  Chunk* ChunkFromHandle(ChunkHandle h);
+
+  // Information about a Bin that is useful for debugging.
+  struct BinDebugInfo {
+    size_t total_bytes_in_use = 0;
+    size_t total_bytes_in_bin = 0;
+    size_t total_requested_bytes_in_use = 0;
+    size_t total_chunks_in_use = 0;
+    size_t total_chunks_in_bin = 0;
+  };
+
+  // Computes and returns a BinDebugInfo for each Bin.
+  std::array<BinDebugInfo, kNumBins> GetBinDebugInfo();
+
+  int Log2FloorNonZeroSlow(uint64_t n) {
+    int r = 0;
+    while (n > 0) {
+      r++;
+      n >>= 1;
+    }
+    return r - 1;
+  }
+
+  // Returns floor(log2(n)).
+  int Log2FloorNonZero(uint64_t n) {
+#if defined(__GNUC__)
+    return 63 ^ __builtin_clzll(n);
+#elif defined(PLATFORM_WINDOWS)
+    unsigned long index;
+#if defined(_WIN64)
+    _BitScanReverse64(&index, n);
+#else
+    auto high = static_cast<unsigned long>(n >> 32);
+    if (_BitScanReverse(&index, high) > 0) {
+      index += 32;
+    } else {
+      auto low = static_cast<unsigned long>((n << 32) >> 32);
+      _BitScanReverse(&index, low);
+    }
+#endif
+    return index;
+#else
+    return Log2FloorNonZeroSlow(n);
+#endif
+  }
+
+  // Map from bin size to Bin
+  Bin* BinFromIndex(BinNum index) {
+    return reinterpret_cast<Bin*>(&(bins_space_[index * sizeof(Bin)]));
+  }
+
+  size_t BinNumToSize(BinNum index) {
+    return static_cast<size_t>(256) << index;
+  }
+
+  BinNum BinNumForSize(size_t bytes) {
+    uint64_t v = std::max<size_t>(bytes, 256) >> kMinAllocationBits;
+    int b = std::min(kNumBins - 1, Log2FloorNonZero(v));
+    return b;
+  }
+
+  Bin* BinForSize(size_t bytes) {
+    return BinFromIndex(BinNumForSize(bytes));
+  }
+
+  alignas(Bin) char bins_space_[sizeof(Bin) * kNumBins];
+
+  mutable std::mutex lock_;
+
+  AllocatorUniquePtr device_allocator_;
+  const std::string allocator_name_;
+  const ArenaConfig config_;
+
+  RegionManager region_manager_;
+  size_t curr_region_allocation_bytes_;
+
+  // Counter containing the next unique identifier to assign to a newly-created chunk.
+  int64_t next_allocation_id_;
+
+  std::vector<Chunk> chunks_;
+  ChunkHandle free_chunks_list_;  // Pointer to head of linked list of free Chunks
+  std::unordered_map<void*, size_t> reserved_chunks_;
+
+  // chunks being used by a stream
+  std::unordered_map<const OrtSyncStream*, std::set<ChunkHandle>> stream_to_chunks_;
+
+  // map to connect the OrtSyncStreamImpl the EP library creates to the OrtSyncStream that ORT uses.
+  // we don't know that it's safe to re-use a chunk until the stream is done with, which is via the call to
+  // OrtSyncStreamImpl::OnSessionRunEnd. the allocations see OrtSyncStream, so we need to connect things up to
+  // un-assign chunks when StreamImpl::OnSessionRunEnd is called.
+  std::unordered_map<const OrtSyncStreamImpl*, const OrtSyncStream*> impl_to_stream_;
+
+  AllocatorStats stats_;
+
+  const OrtApi& api_;
+  const OrtEpApi& ep_api_;
+  const OrtLogger& logger_;
+
+  ArenaImpl(const ArenaImpl&) = delete;
+  ArenaImpl& operator=(const ArenaImpl&) = delete;
+  ArenaImpl(ArenaImpl&&) = delete;
+  ArenaImpl& operator=(ArenaImpl&&) = delete;
+};
+
+struct ArenaAllocator : OrtAllocator {
+  static OrtStatus* CreateOrtArenaAllocator(AllocatorUniquePtr allocator,
+                                            const OrtKeyValuePairs* options,
+                                            const OrtApi& api,
+                                            const OrtLogger& logger,
+                                            std::unique_ptr<ArenaAllocator>& arena_allocator) {
+    ArenaConfig config = options ? ArenaConfig::FromKeyValuePairs(api, *options) : ArenaConfig{};
+    const OrtMemoryInfo* mem_info = allocator->Info(allocator.get());
+    auto impl = std::make_unique<ArenaImpl>(std::move(allocator), config, api, logger);
+
+    arena_allocator = std::make_unique<ArenaAllocator>(std::move(impl), *mem_info);
+
+    return nullptr;
+  }
+
+  ArenaAllocator(std::unique_ptr<ArenaImpl> implementation, const OrtMemoryInfo& memory_info)
+      : impl_{std::move(implementation)},
+        memory_info_{memory_info} {
+    version = ORT_API_VERSION;
+    Alloc = AllocImpl;
+    Reserve = ReserveImpl;
+    Free = FreeImpl;
+    Info = InfoImpl;
+    GetStats = GetStatsImpl;
+    AllocOnStream = AllocOnStreamImpl;
+  }
+
+  // remove the OrtSyncStream* from any chunks that were using the stream
+  OrtStatus* ResetChunksUsingStream(const OrtSyncStreamImpl* stream_impl) {
+    impl_->ResetChunksUsingStream(stream_impl);
+    return nullptr;
+  }
+
+  static void* ORT_API_CALL AllocImpl(struct OrtAllocator* this_, size_t size) {
+    auto& arena = *static_cast<ArenaAllocator*>(this_);
+    return arena.impl_->Alloc(size);
+  }
+
+  static void* ORT_API_CALL AllocOnStreamImpl(struct OrtAllocator* this_, size_t size, OrtSyncStream* stream) {
+    auto& arena = *static_cast<ArenaAllocator*>(this_);
+    return arena.impl_->AllocOnStream(size, stream);
+  }
+
+  static void* ORT_API_CALL ReserveImpl(struct OrtAllocator* this_, size_t size) {
+    auto& arena = *static_cast<ArenaAllocator*>(this_);
+    return arena.impl_->Reserve(size);
+  }
+
+  static void ORT_API_CALL FreeImpl(struct OrtAllocator* this_, void* p) {
+    auto& arena = *static_cast<ArenaAllocator*>(this_);
+    arena.impl_->Free(p);
+  }
+
+  static const OrtMemoryInfo* ORT_API_CALL InfoImpl(const struct OrtAllocator* this_) {
+    const auto& arena = *static_cast<const ArenaAllocator*>(this_);
+    return &arena.memory_info_;
+  }
+
+  static OrtStatus* ORT_API_CALL GetStatsImpl(const struct OrtAllocator* this_, OrtKeyValuePairs** out) noexcept {
+    const auto& arena = *static_cast<const ArenaAllocator*>(this_);
+    return arena.impl_->GetStats(out);
+  };
+
+ private:
+  std::unique_ptr<ArenaImpl> impl_;
+  const OrtMemoryInfo& memory_info_;
+};

--- a/onnxruntime/test/autoep/library/ep_factory.cc
+++ b/onnxruntime/test/autoep/library/ep_factory.cc
@@ -7,6 +7,7 @@
 
 #include "ep.h"
 #include "ep_allocator.h"
+#include "ep_arena.h"
 #include "ep_data_transfer.h"
 #include "ep_stream_support.h"
 
@@ -38,6 +39,8 @@ ExampleEpFactory::ExampleEpFactory(const char* ep_name, ApiPtrs apis, const OrtL
                                              /*vendor*/ 0xBE57, /* device_id */ 0,
                                              OrtDeviceMemoryType_DEFAULT,
                                              /*alignment*/ 0,
+                                             // it is invalid to use OrtArenaAllocator as that is reserved for the
+                                             // internal ORT Arena implementation
                                              OrtAllocatorType::OrtDeviceAllocator,
                                              &mem_info);
   assert(status == nullptr);  // should never fail.
@@ -195,7 +198,7 @@ void ORT_API_CALL ExampleEpFactory::ReleaseEpImpl(OrtEpFactory* /*this_ptr*/, Or
 /*static*/
 OrtStatus* ORT_API_CALL ExampleEpFactory::CreateAllocatorImpl(OrtEpFactory* this_ptr,
                                                               const OrtMemoryInfo* memory_info,
-                                                              const OrtKeyValuePairs* /*allocator_options*/,
+                                                              const OrtKeyValuePairs* allocator_options,
                                                               OrtAllocator** allocator) noexcept {
   auto& factory = *static_cast<ExampleEpFactory*>(this_ptr);
   *allocator = nullptr;
@@ -206,17 +209,62 @@ OrtStatus* ORT_API_CALL ExampleEpFactory::CreateAllocatorImpl(OrtEpFactory* this
                                         "Value did not come directly from an OrtEpDevice returned by this factory.");
   }
 
+  OrtDeviceMemoryType mem_type;
+  RETURN_IF_ERROR(factory.ort_api.MemoryInfoGetDeviceMemType(memory_info, &mem_type));
+
+  if (mem_type != OrtDeviceMemoryType_DEFAULT) {
+    // we only registered default memory with EpDevice_AddAllocatorInfo so this should never happen
+    return factory.ort_api.CreateStatus(ORT_INVALID_ARGUMENT, "Unexpected OrtDeviceMemoryType.");
+  }
+
   // NOTE: The factory implementation is free to return a shared OrtAllocator* instance instead of creating a new
   //       allocator on each call. To do this have an allocator instance as an OrtEpFactory class member and make
   //       ReleaseAllocatorImpl a no-op.
-  auto cpu_allocator = std::make_unique<CustomAllocator>(memory_info, factory);
-  *allocator = cpu_allocator.release();
+  //
+  // NOTE: EP should implement it's own arena logic. ep_arena.cc/h is provided as a reference and we use it here for
+  //       device memory. `allocator_options` can be used for arena configuration and there is a helper in ep_arena.h
+  //       to convert from OrtKeyValuePairs to the same arena config settings that ORT uses.
+  //       You are of course free to have completely different settings.
+  //
+  // create/use the shared arena based allocator
+  std::lock_guard<std::mutex> lock{factory.mutex_};
+
+  if (!factory.arena_allocator_) {
+    std::unique_ptr<OrtAllocator> ep_allocator = std::make_unique<CustomAllocator>(memory_info, factory);
+
+    // initial shared allocator in environment does not have allocator options.
+    // if the user calls CreateSharedAllocator they can provide options to configure the arena differently.
+    factory.arena_allocator_using_default_settings_ = allocator_options == nullptr;
+    RETURN_IF_ERROR(ArenaAllocator::CreateOrtArenaAllocator(std::move(ep_allocator), allocator_options,
+                                                            factory.ort_api,
+                                                            factory.default_logger_, factory.arena_allocator_));
+
+  } else {
+    if (factory.arena_allocator_using_default_settings_ && allocator_options) {
+      // potential change in arena settings. up to EP author to determine how to handle this.
+      // we should not get here if replacing the shared allocator in the environment, as we free the existing one
+      // before replacing it. i.e. ReleaseAllocatorImpl should have been called, and arena_allocator_ should be null.
+    }
+  }
+
+  ++factory.num_arena_users_;
+  *allocator = factory.arena_allocator_.get();
+
   return nullptr;
 }
 
 /*static*/
-void ORT_API_CALL ExampleEpFactory::ReleaseAllocatorImpl(OrtEpFactory* /*this*/, OrtAllocator* allocator) noexcept {
-  delete static_cast<CustomAllocator*>(allocator);
+void ORT_API_CALL ExampleEpFactory::ReleaseAllocatorImpl(OrtEpFactory* this_ptr, OrtAllocator* allocator) noexcept {
+  auto& factory = *static_cast<ExampleEpFactory*>(this_ptr);
+  std::lock_guard<std::mutex> lock{factory.mutex_};
+
+  if (allocator == factory.arena_allocator_.get()) {
+    if (--factory.num_arena_users_ == 0) {
+      factory.arena_allocator_ = nullptr;
+    }
+  } else {
+    delete static_cast<CustomAllocator*>(allocator);
+  }
 }
 
 /*static*/
@@ -238,7 +286,7 @@ OrtStatus* ORT_API_CALL ExampleEpFactory::CreateSyncStreamForDeviceImpl(OrtEpFac
                                                                         const OrtMemoryDevice* memory_device,
                                                                         const OrtKeyValuePairs* stream_options,
                                                                         OrtSyncStreamImpl** stream) noexcept {
-  auto& factory = *static_cast<const ExampleEpFactory*>(this_ptr);
+  auto& factory = *static_cast<ExampleEpFactory*>(this_ptr);
   *stream = nullptr;
 
   // we only need stream synchronization on the device stream

--- a/onnxruntime/test/autoep/library/ep_stream_support.cc
+++ b/onnxruntime/test/autoep/library/ep_stream_support.cc
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #include "ep_stream_support.h"
-
+#include "ep_factory.h"
 //
 // StreamImpl implementation
 //
@@ -27,7 +27,13 @@ OrtStatus* ORT_API_CALL StreamImpl::FlushImpl(_In_ OrtSyncStreamImpl* /*this_ptr
 }
 
 /*static*/
-OrtStatus* ORT_API_CALL StreamImpl::OnSessionRunEndImpl(_In_ OrtSyncStreamImpl* /*this_ptr*/) noexcept {
+OrtStatus* ORT_API_CALL StreamImpl::OnSessionRunEndImpl(_In_ OrtSyncStreamImpl* this_ptr) noexcept {
+  auto& impl = *static_cast<StreamImpl*>(this_ptr);
+  auto* arena = impl.factory_->GetArenaAllocator();
+  if (arena) {
+    arena->ResetChunksUsingStream(this_ptr);
+  }
+
   return nullptr;
 }
 

--- a/onnxruntime/test/autoep/library/ep_stream_support.h
+++ b/onnxruntime/test/autoep/library/ep_stream_support.h
@@ -4,15 +4,18 @@
 #pragma once
 
 #include "onnxruntime_c_api.h"
+#include "ep_factory.h"
 #include "example_plugin_ep_utils.h"
+
+class ExampleEpFactory;
 
 //
 // Class implementing Stream support for synchronization.
 //
 class StreamImpl : public OrtSyncStreamImpl, public ApiPtrs {
  public:
-  StreamImpl(ApiPtrs apis, const OrtEp* ep, const OrtKeyValuePairs* /*stream_options*/)
-      : ApiPtrs(apis), ep_{ep} {
+  StreamImpl(ExampleEpFactory& factory, const OrtEp* ep, const OrtKeyValuePairs* /*stream_options*/)
+      : ApiPtrs(factory), ep_{ep}, factory_{&factory} {
     ort_version_supported = ORT_API_VERSION;
     CreateNotification = CreateNotificationImpl;
     GetHandle = GetHandleImpl;
@@ -34,6 +37,7 @@ class StreamImpl : public OrtSyncStreamImpl, public ApiPtrs {
   // EP instance if the stream is being created internally for inferencing.
   // nullptr when the stream is created outside of an inference session for data copies.
   const OrtEp* ep_;
+  ExampleEpFactory* factory_{nullptr};
 };
 
 //

--- a/onnxruntime/test/autoep/library/example_plugin_ep_utils.h
+++ b/onnxruntime/test/autoep/library/example_plugin_ep_utils.h
@@ -25,11 +25,52 @@
     }                                                    \
   } while (0)
 
+// see ORT_ENFORCE for implementations that also capture a stack trace and work in builds with exceptions disabled
+// NOTE: In this simplistic implementation you must provide an argument, even it if's an empty string
+#define EP_ENFORCE(condition, ...)                       \
+  do {                                                   \
+    if (!(condition)) {                                  \
+      std::ostringstream oss;                            \
+      oss << "EP_ENFORCE failed: " << #condition << " "; \
+      oss << __VA_ARGS__;                                \
+      throw std::runtime_error(oss.str());               \
+    }                                                    \
+  } while (false)
+
+#ifdef _WIN32
+#define EP_WSTR(x) L##x
+#define EP_FILE_INTERNAL(x) EP_WSTR(x)
+#define EP_FILE EP_FILE_INTERNAL(__FILE__)
+#else
+#define EP_FILE __FILE__
+#endif
+
+#define LOG(level, ...)                                                                                             \
+  do {                                                                                                              \
+    std::ostringstream ss;                                                                                          \
+    ss << __VA_ARGS__;                                                                                              \
+    api_.Logger_LogMessage(&logger_, ORT_LOGGING_LEVEL_##level, ss.str().c_str(), EP_FILE, __LINE__, __FUNCTION__); \
+  } while (false)
+
+#define RETURN_ERROR(code, ...)                       \
+  do {                                                \
+    std::ostringstream ss;                            \
+    ss << __VA_ARGS__;                                \
+    return api_.CreateStatus(code, ss.str().c_str()); \
+  } while (false)
+
+#define THROW(...)       \
+  std::ostringstream ss; \
+  ss << __VA_ARGS__;     \
+  throw new std::runtime_error(ss.str().c_str())
+
 struct ApiPtrs {
   const OrtApi& ort_api;
   const OrtEpApi& ep_api;
   const OrtModelEditorApi& model_editor_api;
 };
+
+using AllocatorUniquePtr = std::unique_ptr<OrtAllocator, std::function<void(OrtAllocator*)>>;
 
 // Helper to release Ort one or more objects obtained from the public C API at the end of their scope.
 template <typename T>

--- a/onnxruntime/test/autoep/test_allocators.cc
+++ b/onnxruntime/test/autoep/test_allocators.cc
@@ -30,8 +30,9 @@ struct DummyAllocator : OrtAllocator {
     Alloc = AllocImpl;
     Free = FreeImpl;
     Info = InfoImpl;
-    Reserve = AllocImpl;  // no special reserve logic and most likely unnecessary unless you have your own arena
-    GetStats = nullptr;   // this can be set to nullptr if not implemented
+    Reserve = AllocImpl;      // no special reserve logic and most likely unnecessary unless you have your own arena
+    GetStats = nullptr;       // this can be set to nullptr if not implemented
+    AllocOnStream = nullptr;  // optional
   }
 
   static void* ORT_API_CALL AllocImpl(struct OrtAllocator* this_, size_t size) {
@@ -75,9 +76,8 @@ TEST(SharedAllocators, AddArenaToSharedAllocator) {
   auto initial_chunk_size = "25600";  // arena allocates in 256 byte amounts
   allocator_options.Add(OrtArenaCfg::ConfigKeyNames::InitialChunkSizeBytes, initial_chunk_size);
 
-  ASSERT_ORTSTATUS_OK(c_api.CreateSharedAllocator(*ort_env, example_ep.get(),
-                                                  OrtDeviceMemoryType_DEFAULT, OrtArenaAllocator, &allocator_options,
-                                                  &allocator));
+  ASSERT_ORTSTATUS_OK(c_api.CreateSharedAllocator(*ort_env, example_ep.get(), OrtDeviceMemoryType_DEFAULT,
+                                                  &allocator_options, &allocator));
 
   // first allocation should init the arena to the initial chunk size
   void* mem = allocator->Alloc(allocator, 16);

--- a/onnxruntime/test/framework/bfc_arena_test.cc
+++ b/onnxruntime/test/framework/bfc_arena_test.cc
@@ -339,80 +339,81 @@ struct StreamMock : public Stream {
 
 #ifdef ORT_ENABLE_STREAM
 TEST(StreamAwareArenaTest, TwoStreamAllocation) {
-  StreamAwareArena a(std::unique_ptr<IAllocator>(new CPUAllocator()), 1 << 30, false);
+  StreamAwareArena a(std::unique_ptr<IAllocator>(new CPUAllocator()), 1 << 30);
   CheckStats(&a, 0, 0, 0, 0);
 
   OrtDevice tmp;
 
   StreamMock stream1(tmp), stream2(tmp);
 
-  auto* stream1_chunk_a = a.AllocOnStream(4096, &stream1, nullptr);
-  auto* stream2_chunk_a = a.AllocOnStream(4096, &stream2, nullptr);
-  a.Free(stream1_chunk_a);
-  auto* stream2_chunk_b = a.AllocOnStream(4096, &stream2, nullptr);
+  auto* stream1_chunk_a = a.AllocOnStream(4096, &stream1);  // 4K chunk on stream 1
+  auto* stream2_chunk_a = a.AllocOnStream(4096, &stream2);  // 4K chunk on stream 2
+  a.Free(stream1_chunk_a);                                  // free but assigned to stream1
+
   // stream2 can't reuse stream1's chunk
+  auto* stream2_chunk_b = a.AllocOnStream(4096, &stream2);  // 4K chunk on stream 2
   EXPECT_NE(stream2_chunk_b, stream1_chunk_a);
-  a.Free(stream2_chunk_a);
-  auto* stream1_chunk_c = a.AllocOnStream(4096, &stream1, nullptr);
-  // it should pick the first chunk
+
+  a.Free(stream2_chunk_a);  // free but assigned to stream2
+
+  // it should pick the first chunk.
+  auto* stream1_chunk_c = a.AllocOnStream(4096, &stream1);
   EXPECT_EQ(stream1_chunk_c, stream1_chunk_a);
 
-  auto* stream1_chunk_d = a.AllocOnStream(4096, &stream1, nullptr);
-  // it shouldn't pick stream2_chunk_a's buffer
+  // it shouldn't stream2_chunk_a due to stream mismatch
+  auto* stream1_chunk_d = a.AllocOnStream(4096, &stream1);
   EXPECT_NE(stream1_chunk_d, stream2_chunk_a);
-  a.Free(stream2_chunk_b);
+
+  a.Free(stream2_chunk_b);  // still assigned to stream 2. should coalesce with stream1_chunk_a to create 8K buffer
+
   // test clean stream2
-  a.ReleaseStreamBuffers(&stream2);
-  auto stream1_chunk_e = a.AllocOnStream(8192, &stream1, nullptr);
-  // now it should pick the stream2_chunk_a's buffer
-  EXPECT_EQ(stream1_chunk_e, stream2_chunk_a);
+  a.ReleaseStreamBuffers(&stream2);  // all stream 2 buffers are now available
+
+  // now it should pick stream2_chunk_a as it is no longer assigned to stream 2
+  auto stream1_chunk_e = a.AllocOnStream(8192, &stream1);
+  EXPECT_EQ(stream1_chunk_e, stream2_chunk_a);  // stream1_chunk_e and stream2_chunk_a are assigned to stream1
+
   a.Free(stream1_chunk_c);
   a.Free(stream1_chunk_d);
-  // add stream2 to stream 1 depenency
+
+  // stream 2 wait on stream 1
   auto stream1_notification_a = stream1.CreateNotification(1);
-  stream1_notification_a->ActivateAndUpdate();
-  stream2.UpdateStreamClock(stream1_notification_a->GetStreamSyncTable());
-  auto* stream2_chunk_c = a.AllocOnStream(4096, &stream2, nullptr);
-  // it should pick the first chunk
-  EXPECT_EQ(stream2_chunk_c, stream1_chunk_c);
-  auto* stream2_chunk_d = a.AllocOnStream(4096, &stream2, nullptr);
-  // it should pick the third slot
-  EXPECT_EQ(stream2_chunk_d, stream1_chunk_d);
-  // continue allocate on stream1
-  auto* stream1_chunk_f = a.AllocOnStream(4096, &stream1, nullptr);
+  stream1_notification_a->ActivateAndUpdate();                     // stream 1 sync id 0 -> 1
+  stream2.UpdateWithAwaitedNotification(*stream1_notification_a);  // stream 2 now has sync id info of stream1:1
+
+  // stream 2 can now take stream 1 buffers with sync id of 0
+  auto* stream2_chunk_c = a.AllocOnStream(4096, &stream2);
+  EXPECT_EQ(stream2_chunk_c, stream1_chunk_c);  // stream2 took a buffer from stream1 with sync id 0
+
+  // stream 2 can take the remaining free buffer from stream 1 with sync id of 0
+  auto* stream2_chunk_d = a.AllocOnStream(4096, &stream2);
+  EXPECT_EQ(stream2_chunk_d, stream1_chunk_d);  // stream2 took the other buffer from stream 1
+
+  // new buffer required
+  auto* stream1_chunk_f = a.AllocOnStream(4096, &stream1);  // new buffer on stream 1. sync id = 1
   a.Free(stream1_chunk_f);
-  auto* stream2_chunk_e = a.AllocOnStream(4096, &stream2, nullptr);
+
+  // new buffer required
+  auto* stream2_chunk_e = a.AllocOnStream(4096, &stream2);  // new buffer on stream 2
   EXPECT_NE(stream2_chunk_e, stream1_chunk_f);
+
+  // free 8K buffer on stream 1
   a.Free(stream1_chunk_e);
-  // test clean stream1
-  a.ReleaseStreamBuffers(&stream1);
-  auto* stream2_chunk_f = a.AllocOnStream(8192, &stream2, nullptr);
-  // now it should pick stream1_chunk_e
+
+  // can use 8K stream1_chunk_e as it has sync id = 0 and stream 2 has sync id of 1 for stream 1
+  auto* stream2_chunk_f = a.AllocOnStream(8192, &stream2);
   EXPECT_EQ(stream2_chunk_f, stream1_chunk_e);
+
+  // remove assignment to stream 1 for free buffers. stream1_chunk_f will become available to stream 2
+  a.ReleaseStreamBuffers(&stream1);  // stream1 buffers are new available
+
+  auto* stream2_chunk_g = a.AllocOnStream(4096, &stream2);
+  EXPECT_EQ(stream2_chunk_g, stream1_chunk_f);
 
   // cleanup
   a.Free(stream2_chunk_d);
   a.Free(stream2_chunk_e);
   a.Free(stream2_chunk_f);
-}
-
-TEST(StreamAwareArenaTest, TestSecureTheChunk) {
-  StreamAwareArena a(std::unique_ptr<IAllocator>(new CPUAllocator()), 1 << 30, true);
-  OrtDevice tmp;
-  StreamMock stream1(tmp), stream2(tmp);
-
-  void* p1 = a.AllocOnStream(BFCArena::DEFAULT_INITIAL_CHUNK_SIZE_BYTES, &stream1, nullptr);
-  a.Free(p1);
-
-  bool waitFunctionInvoked = false;
-  void* p2 = a.AllocOnStream(BFCArena::DEFAULT_INITIAL_CHUNK_SIZE_BYTES, &stream2,
-                             [&waitFunctionInvoked](Stream*, synchronize::Notification&) { waitFunctionInvoked = true; });
-
-  std::unordered_map<Stream*, uint64_t> syncTable;
-  stream2.CloneCurrentStreamSyncTable(syncTable);
-  EXPECT_EQ(syncTable.size(), 1u) << "stream2 has been updated with stream1's nofitication on the clock";
-  EXPECT_TRUE(waitFunctionInvoked) << "wait function should be invoked";
-  a.Free(p2);
 }
 #endif
 

--- a/onnxruntime/test/shared_lib/test_model_builder_api.cc
+++ b/onnxruntime/test/shared_lib/test_model_builder_api.cc
@@ -118,6 +118,9 @@ struct TestAllocator : public OrtAllocator {
     Reserve = [](struct OrtAllocator* /*this*/, size_t /*size*/) -> void* {
       throw std::runtime_error("This should not be used");
     };
+
+    GetStats = nullptr;
+    AllocOnStream = nullptr;
   }
 
   // initializers that are used directly by the model. as there's no copy they must remain valid.


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Add arena that uses EP API so that an EP library can be self-sufficient.
Remove cross stream sharing from BFCArena. Nothing is using it and it creates a dependency on synchronizing streams inside the arena implementation.
Tried to simplify the Stream/Notification usage. 

Current setup adds an AllocOnStream to OrtAllocator. There's no stream aware Free at this point as ORT does not attach the Stream to the memory usage so can't pass it in to the Free call. 

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
If ORT adds BFCArena to an OrtAllocator from the EP we have OrtAllocator -> IAllocator wrapper -> BFCArena IAllocator [-> OrtAllocator wrapper for external usage].

The EP managing its own arena is much simpler.
