### PR TITLE
Adding ORT framework side for CUDA graph in Nv TensorRT RTX

### DIFF
--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -2295,6 +2295,7 @@ common::Status InferenceSession::Initialize() {
       //
       std::vector<const char*> graph_support_ep_list = {
           onnxruntime::kTensorrtExecutionProvider,
+          onnxruntime::kNvTensorRTRTXExecutionProvider,
           onnxruntime::kCudaExecutionProvider,
           onnxruntime::kRocmExecutionProvider,
           onnxruntime::kJsExecutionProvider,


### PR DESCRIPTION
CUDA Graph feature for NV TensorRT RTX EP

Adding the ORT Framework side implementation for enabling CUDA graph feature for NV TensorRT RTX EP.
