### PR TITLE
Fix EP context name for cache file name with two dots

### DIFF
--- a/onnxruntime/core/providers/openvino/backend_manager.cc
+++ b/onnxruntime/core/providers/openvino/backend_manager.cc
@@ -228,8 +228,7 @@ Status BackendManager::ExportCompiledBlobAsEPCtxNode(const onnxruntime::GraphVie
     if (blob_filename.empty()) {
       blob_filename = session_context_.onnx_model_path_name;
     }
-    blob_filename = blob_filename.parent_path() / name;
-    blob_filename.replace_extension("blob");
+    blob_filename = blob_filename.parent_path() / (name + ".blob");
     std::ofstream blob_file(blob_filename,
                             std::ios::out | std::ios::trunc | std::ios::binary);
     if (!blob_file) {


### PR DESCRIPTION
As `name` is already derived from stem (of cache file name), ff cache file name contains two dots then blob file name is incorrect. This enables cache file name with two dots.

### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


