### PR TITLE
[QNN EP] Revert workarounds for QNN <= 2.35

### DIFF
--- a/onnxruntime/test/onnx/TestCase.cc
+++ b/onnxruntime/test/onnx/TestCase.cc
@@ -1396,11 +1396,7 @@ std::unique_ptr<std::set<BrokenTest>> GetBrokenTests(const std::string& provider
     broken_tests->insert({"resize_downsample_scales_linear", "result differs"});
     broken_tests->insert({"gridsample_volumetric_nearest_align_corners_0", "unknown version"});
     broken_tests->insert({"gridsample_volumetric_nearest_align_corners_1", "unknown version"});
-    broken_tests->insert({"rotary_embedding", "unknown version"});
-    broken_tests->insert({"rotary_embedding_no_position_ids", "unknown version"});
-    broken_tests->insert({"rotary_embedding_interleaved", "unknown version"});
     broken_tests->insert({"rotary_embedding_no_position_ids_expanded", "unknown version"});
-    broken_tests->insert({"rotary_embedding_no_position_ids_interleaved", "unknown version"});
     broken_tests->insert({"rotary_embedding_no_position_ids_interleaved_expanded", "unknown version"});
     // Fails since QNN SDK 2.17.0:
     // expected 7.70947 (40f6b3f3), got 7.84096 (40fae920), diff: 0.131491, tol=0.00870947 idx=419. 100 of 1715 differ
@@ -1410,7 +1406,6 @@ std::unique_ptr<std::set<BrokenTest>> GetBrokenTests(const std::string& provider
     broken_tests->insert({"gemm_default_vector_bias", "result differs with 2.34"});
     // expected 0.0505495 (3d4f0d00), got 0.0506369 (3d4f68ae), diff: 8.74326e-05, tol=6.05495e-05 idx=448
     broken_tests->insert({"mobilenetv2-1.0", "result differs with 2.34"});
-    broken_tests->insert({"facedetection_op8", "segfault with CPU backend, will be fixed by QNN 2.36"});
 
     // These next 3 Resize tests fail on CPU backend with QNN SDK 2.22.0 due to inaccuracy.
     // output=Y:expected 1 (3f800000), got 3 (40400000), diff: 2, tol=0.002 idx=24. 8 of 56 differ
@@ -1424,8 +1419,6 @@ std::unique_ptr<std::set<BrokenTest>> GetBrokenTests(const std::string& provider
     // Fails with QNN 2.31 on Windows x64 for CPU
     broken_tests->insert({"gelu_tanh_2", "y:expected -0.0131778 (bc57e7d5), got -0.0136333 (bc5f5e38), diff: 0.000455472, tol=2.31778e-05."});
     broken_tests->insert({"averagepool_2d_ceil", "result differs. expected 13.5 (41580000), got 0 (0)"});
-    // Fails with QNN 2.32
-    broken_tests->insert({"resize_upsample_scales_linear", "expected 1 (3f800000), got 0.25 (3e800000)"});
   }
 
 #ifdef DISABLE_CONTRIB_OPS

--- a/onnxruntime/test/providers/qnn/layer_norm_test.cc
+++ b/onnxruntime/test/providers/qnn/layer_norm_test.cc
@@ -204,7 +204,7 @@ TEST_F(QnnHTPBackendTests, LayerNorm1D_LastAxis_StaticScale_AU16_WU8) {
 
 // Test accuracy of 8-bit QDQ LayerNorm with a dynamic scale input.
 //
-// TODO(adrianlizarraga): Fails to finalize with QNN SDK 2.22. Still fails on QNN SDK 2.35.0.
+// TODO(adrianlizarraga): Fails to finalize with QNN SDK 2.22. Still fails on QNN SDK 2.36.1.
 // Verbose logs:
 // Starting stage: Graph Transformations and Optimizations
 // C:\...\QNN\HTP\HTP\src\hexagon\prepare\graph_prepare.cc:203:ERROR:could not create op: q::flat_to_vtcm

--- a/onnxruntime/test/providers/qnn/lrn_op_test.cc
+++ b/onnxruntime/test/providers/qnn/lrn_op_test.cc
@@ -131,9 +131,7 @@ TEST_F(QnnHTPBackendTests, LRNSize3) {
                            0.0001f,  // alpha
                            0.75f,    // beta
                            1.0f,     // bias
-                           13,       // opset
-                           // Need to use tolerance of 0.8% of output range after QNN SDK 2.22
-                           QDQTolerance(0.008f));
+                           13);      // opset
 }
 
 TEST_F(QnnHTPBackendTests, LRNSize5) {
@@ -143,9 +141,7 @@ TEST_F(QnnHTPBackendTests, LRNSize5) {
                            0.0001f,  // alpha
                            0.75f,    // beta
                            1.0f,     // bias
-                           13,       // opset
-                           // Need to use tolerance of 0.8% of output range after QNN SDK 2.22
-                           QDQTolerance(0.008f));
+                           13);      // opset
 }
 
 TEST_F(QnnHTPBackendTests, LRN_size_larger_than_channel) {

--- a/onnxruntime/test/providers/qnn/resize_test.cc
+++ b/onnxruntime/test/providers/qnn/resize_test.cc
@@ -259,20 +259,14 @@ TEST_F(QnnCPUBackendTests, ResizeDownsampleNearestAlignCorners_rpf) {
 // Cpu tests that use the "linear" mode.
 //
 
-// accuracy issue since QNN 2.31
-// Expected: contains 240 values, where each value and its corresponding value in 16-byte object <F0-00 00-00 00-00 00-00 40-01 57-DD 45-01 00-00> are an almost-equal pair
-// Actual: 16-byte object <F0-00 00-00 00-00 00-00 40-01 39-DD 45-01 00-00>, where the value pair (-10, -10.5084743) at index #0 don't match, which is -0.508474 from -10
-TEST_F(QnnCPUBackendTests, DISABLED_Resize2xLinearHalfPixel) {
+TEST_F(QnnCPUBackendTests, Resize2xLinearHalfPixel) {
   std::vector<float> input_data = GetFloatDataInRange(-10.0f, 10.0f, 60);
   RunCPUResizeOpTest(TestInputDef<float>({1, 3, 4, 5}, false, input_data),
                      {1, 3, 8, 10}, "linear", "half_pixel", "",
                      ExpectedEPNodeAssignment::All);
 }
 
-// accuracy issue since QNN 2.31
-// Expected: contains 240 values, where each value and its corresponding value in 16-byte object <F0-00 00-00 00-00 00-00 40-01 57-4B C9-02 00-00> are an almost-equal pair
-// Actual: 16-byte object <F0-00 00-00 00-00 00-00 40-01 39-4B C9-02 00-00>, where the value pair (-10, -10.5084743) at index #0 don't match, which is -0.508474 from -10
-TEST_F(QnnCPUBackendTests, DISABLED_Resize2xLinearHalfPixel_scales) {
+TEST_F(QnnCPUBackendTests, Resize2xLinearHalfPixel_scales) {
   std::vector<float> input_data = GetFloatDataInRange(-10.0f, 10.0f, 60);
   RunCPUResizeOpTestWithScales(TestInputDef<float>({1, 3, 4, 5}, false, input_data),
                                {1.0f, 1.0f, 2.0f, 2.0f}, "linear", "half_pixel", "",


### PR DESCRIPTION
### Description

Re-enable tests and remove workarounds that were introduced as part of a QNN <= 2.35.0 upgrade but are no longer necessary.

### Motivation and Context

QNN/QAIRT releases about once a month. As ONNX Runtime adopts these new versions, some number of tests are often found to be impacted. Consequently, tests are skipped and tolerances are loosened. This change reverts as many of those workarounds as possible that were made for QNN upgrades between 2.17 and 2.35, inclusive. 