### PR TITLE
Use appropriate macros for model compatibility API declarations

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
@@ -695,8 +695,8 @@ struct OrtEp {
    *
    * \since Version 1.23.
    */
-  const char*(ORT_API_CALL* GetCompiledModelCompatibilityInfo)(_In_ OrtEp* this_ptr,
-                                                               _In_ const OrtGraph* graph);
+  ORT_API_T(const char*, GetCompiledModelCompatibilityInfo, _In_ OrtEp* this_ptr,
+                                                            _In_ const OrtGraph* graph);
 };
 
 /** \brief The function signature that ORT will call to create OrtEpFactory instances.
@@ -873,9 +873,9 @@ struct OrtEpFactory {
    *
    * \since Version 1.23.
    */
-  OrtStatus*(ORT_API_CALL* ValidateCompiledModelCompatibilityInfo)(_In_ OrtEpFactory* this_ptr,
-                                                                   _In_ const char* compatibility_info,
-                                                                   _Out_ OrtCompiledModelCompatibility* model_compatibility);
+  ORT_API2_STATUS(ValidateCompiledModelCompatibilityInfo, _In_ OrtEpFactory* this_ptr,
+                                                          _In_ const char* compatibility_info,
+                                                          _Out_ OrtCompiledModelCompatibility* model_compatibility);
 
   /** \brief Create an OrtAllocator that can be shared across sessions for the given OrtMemoryInfo.
    *

--- a/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
@@ -696,7 +696,7 @@ struct OrtEp {
    * \since Version 1.23.
    */
   ORT_API_T(const char*, GetCompiledModelCompatibilityInfo, _In_ OrtEp* this_ptr,
-                                                            _In_ const OrtGraph* graph);
+            _In_ const OrtGraph* graph);
 };
 
 /** \brief The function signature that ORT will call to create OrtEpFactory instances.

--- a/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
@@ -874,8 +874,8 @@ struct OrtEpFactory {
    * \since Version 1.23.
    */
   ORT_API2_STATUS(ValidateCompiledModelCompatibilityInfo, _In_ OrtEpFactory* this_ptr,
-                                                          _In_ const char* compatibility_info,
-                                                          _Out_ OrtCompiledModelCompatibility* model_compatibility);
+                  _In_ const char* compatibility_info,
+                  _Out_ OrtCompiledModelCompatibility* model_compatibility);
 
   /** \brief Create an OrtAllocator that can be shared across sessions for the given OrtMemoryInfo.
    *


### PR DESCRIPTION
### Description
This change corrects the signatures on the new precompiled model compatibility APIs to use the recommended macros.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
This fix addresses PR feedback from #25454 . 


