### PR TITLE
AMD RyzenAI Light CPU-based EP (RyzenAILightExecutionProvider)

### DIFF
--- a/include/onnxruntime/core/graph/constants.h
+++ b/include/onnxruntime/core/graph/constants.h
@@ -55,6 +55,7 @@ constexpr const char* kWebGpuExecutionProvider = "WebGpuExecutionProvider";
 constexpr const char* kCannExecutionProvider = "CANNExecutionProvider";
 constexpr const char* kAzureExecutionProvider = "AzureExecutionProvider";
 constexpr const char* kVSINPUExecutionProvider = "VSINPUExecutionProvider";
+constexpr const char* kRyzenAILightExecutionProvider = "RyzenAILightExecutionProvider";
 
 constexpr const char* kExecutionProviderSharedLibraryPath = "shared_lib_path";
 constexpr const char* kExecutionProviderSharedLibraryEntry = "provider_factory_entry_point";

--- a/onnxruntime/core/framework/utils.cc
+++ b/onnxruntime/core/framework/utils.cc
@@ -61,6 +61,7 @@ bool ProviderIsCpuBased(const std::string& provider_type) {
          provider_type == onnxruntime::kQnnExecutionProvider ||
          provider_type == onnxruntime::kXnnpackExecutionProvider ||
          provider_type == onnxruntime::kAzureExecutionProvider ||
+         provider_type == onnxruntime::kRyzenAILightExecutionProvider ||
          provider_type == onnxruntime::utils::kInternalTestingExecutionProvider;
 }
 


### PR DESCRIPTION
### Description
Added a constant for RyzenAI Light Execution Provider.
Updated the ProviderIsCpuBased utility so that it treats the RyzenAI Light EP as a CPU‑based provider.

### Motivation and Context
I am an AMD RyzenAI Group engineer. 
We are working on a very lightweight shared_library-based EP that is going to be used to run various preprocessed Hybrid models. 
For performance reasons, we would like ORT to treat our new EP as a CPU-based EP. 
