### PR TITLE
[QNN-EP] Fix data type check to skip optional I/Os

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
@@ -8,6 +8,13 @@
 namespace onnxruntime {
 namespace qnn {
 
+namespace {
+bool IsOptionalNodeUnitIODef(const NodeUnitIODef& node_io_def) {
+  const NodeArg& arg = node_io_def.node_arg;
+  return !arg.Exists() || arg.Name().empty();
+}
+}  // namespace
+
 std::string BaseOpBuilder::GetOpBuilderType() const {
   return op_builder_type_;
 }
@@ -46,12 +53,18 @@ Status BaseOpBuilder::ProcessDataTypes(QnnModelWrapper& qnn_model_wrapper,
   const auto& inputs = node_unit.Inputs();
   const auto& outputs = node_unit.Outputs();
   for (auto input : inputs) {
+    if (IsOptionalNodeUnitIODef(input)) {
+      continue;
+    }
     TensorInfo tensor_info = {};
     ORT_RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(input, tensor_info));
     Qnn_DataType_t qnn_data_type = tensor_info.qnn_data_type;
     input_qnn_dtypes.push_back(qnn_data_type);
   }
   for (auto output : outputs) {
+    if (IsOptionalNodeUnitIODef(output)) {
+      continue;
+    }
     TensorInfo tensor_info = {};
     ORT_RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(output, tensor_info));
     Qnn_DataType_t qnn_data_type = tensor_info.qnn_data_type;


### PR DESCRIPTION
### Motivation and Context
Fix data type check to skip optional I/Os.

Optional inputs/outputs would have empty name, and it's valid ONNX syntax. Without this fix, any model with optional inputs/outputs would fail the check due to missing protobuf fields. 


Without this fix, we'd hit error fetching `elem_type` from protobuf.
```
2025-07-22 11:14:40.117740035 [I:onnxruntime:, qnn_execution_provider.cc:740 GetSupportedNodes] Validation FAILED for 1 nodes in NodeUnit (Pad) :
	Operator type: Pad Node name: /blocks.4/Pad Node index: 176
	REASON : The tensor doesn't have elem_type.
```
