### PR TITLE
Fix QNN SDK download problem

### DIFF
--- a/tools/ci_build/github/azure-pipelines/android-arm64-v8a-QNN-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-arm64-v8a-QNN-crosscompile-ci-pipeline.yml
@@ -52,7 +52,7 @@ jobs:
   - script: sudo chmod go+rw /dev/kvm
     displayName: Update permissions to KVM
 
-  - template: templates/jobs/download_linux_qnn_sdk.yml
+  - template: templates/jobs/init_linux_qnn_sdk_x64.yml
     parameters:
       QnnSDKVersion: ${{ parameters.QnnSdk }}
 

--- a/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar.yml
@@ -103,7 +103,7 @@ jobs:
   - template: use-android-ndk.yml
 
   - ${{ if contains(parameters.packageName, 'qnn') }}:
-    - template: jobs/download_linux_qnn_sdk.yml
+    - template: jobs/init_linux_qnn_sdk_x64.yml
       parameters:
         QnnSDKVersion: '${{parameters.QnnSDKVersion}}'
 

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/download_linux_qnn_sdk.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/download_linux_qnn_sdk.yml
@@ -35,9 +35,7 @@ steps:
       fi
     displayName: "Sanity Check: QnnSDKVersion vs sdk.yaml version"
 
-  - script: |
-      cp '/data/qnnsdk/Qualcomm AI Hub Proprietary License.pdf' $(QnnSDKRootDir)
-    displayName: 'Download Qualcomm AI Hub license'
+
 
   - script: |
       ls -al $(QnnSDKRootDir)

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/download_linux_qnn_sdk.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/download_linux_qnn_sdk.yml
@@ -4,12 +4,8 @@ parameters:
     default: '2.36.1.250708'
 
 steps:
-  - script: |
-      azcopy cp --recursive https://lotusscus.blob.core.windows.net/models/qnnsdk/qnn-v${{ parameters.QnnSDKVersion }} $(Agent.TempDirectory)
-    displayName: 'Download QNN SDK v${{ parameters.QnnSDKVersion }}'
-
   - bash: |
-      echo "##vso[task.setvariable variable=QnnSDKRootDir]$(Agent.TempDirectory)/qnn-v${{ parameters.QnnSDKVersion }}"
+      echo "##vso[task.setvariable variable=QnnSDKRootDir]/data/qnnsdk/qnn-v${{ parameters.QnnSDKVersion }}"
     displayName: Set QnnSDKRootDir
 
   - script: |
@@ -40,7 +36,7 @@ steps:
     displayName: "Sanity Check: QnnSDKVersion vs sdk.yaml version"
 
   - script: |
-      azcopy cp --recursive 'https://lotusscus.blob.core.windows.net/models/qnnsdk/Qualcomm AI Hub Proprietary License.pdf' $(QnnSDKRootDir)
+      cp '/data/qnnsdk/Qualcomm AI Hub Proprietary License.pdf' $(QnnSDKRootDir)
     displayName: 'Download Qualcomm AI Hub license'
 
   - script: |

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/init_linux_qnn_sdk_x64.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/init_linux_qnn_sdk_x64.yml
@@ -4,12 +4,8 @@ parameters:
     default: '2.36.1.250708'
 
 steps:
-  - script: |
-      azcopy cp --recursive https://lotusscus.blob.core.windows.net/models/qnnsdk/qnn-v${{ parameters.QnnSDKVersion }} $(Agent.TempDirectory)
-    displayName: 'Download QNN SDK v${{ parameters.QnnSDKVersion }}'
-
   - bash: |
-      echo "##vso[task.setvariable variable=QnnSDKRootDir]$(Agent.TempDirectory)/qnn-v${{ parameters.QnnSDKVersion }}"
+      echo "##vso[task.setvariable variable=QnnSDKRootDir]/data/qnnsdk/qnn-v${{ parameters.QnnSDKVersion }}"
     displayName: Set QnnSDKRootDir
 
   - script: |
@@ -39,9 +35,7 @@ steps:
       fi
     displayName: "Sanity Check: QnnSDKVersion vs sdk.yaml version"
 
-  - script: |
-      azcopy cp --recursive 'https://lotusscus.blob.core.windows.net/models/qnnsdk/Qualcomm AI Hub Proprietary License.pdf' $(QnnSDKRootDir)
-    displayName: 'Download Qualcomm AI Hub license'
+
 
   - script: |
       ls -al $(QnnSDKRootDir)

--- a/tools/ci_build/github/azure-pipelines/templates/py-linux-qnn.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-linux-qnn.yml
@@ -58,7 +58,7 @@ jobs:
     clean: true
     submodules: none
 
-  - template: jobs/download_linux_qnn_sdk.yml
+  - template: jobs/init_linux_qnn_sdk_x64.yml
     parameters:
       QnnSDKVersion: ${{ parameters.QnnSdk }}
 


### PR DESCRIPTION
Previously the machine pool had a User-assigned managed identity (UMI) which was used for accessing the blob storage. Now the UMI was removed. to improve security. Therefore we baked the data into the VM image instead. 