### PR TITLE
[TRT RTX EP] Add support for user provided external initializers with new TRT APIs

### DIFF
--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -35,8 +35,8 @@ microsoft_wil;https://github.com/microsoft/wil/archive/refs/tags/v1.0.230629.1.z
 mimalloc;https://github.com/microsoft/mimalloc/archive/refs/tags/v2.1.1.zip;d5ee7d34223d0567892db5179849939c8769dc41
 mp11;https://github.com/boostorg/mp11/archive/refs/tags/boost-1.82.0.zip;9bc9e01dffb64d9e0773b2e44d2f22c51aace063
 onnx;https://github.com/onnx/onnx/archive/refs/tags/v1.18.0.zip;f156d032a3af91b66d554e11158b33ca77bbb1f2
-# Use the latest commit of 10.9-GA
-onnx_tensorrt;https://github.com/onnx/onnx-tensorrt/archive/d5dce67db7c2e64b07e055571f5ec06f7f254de2.zip;01114d3b67650857281fa50faa2e412130a63b69
+# Side branch
+onnx_tensorrt;https://github.com/gedoensmax/onnx-tensorrt/archive/1ff5201c5eb209a4a58330b9e8cae97f153c93a4.zip;60af1687b0e03c2c920197f4e059cb666aefdd9c
 protobuf;https://github.com/protocolbuffers/protobuf/archive/refs/tags/v21.12.zip;7cf2733949036c7d52fda017badcab093fe73bfa
 protoc_win64;https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-win64.zip;b4521f7ada5b260380f94c4bd7f1b7684c76969a
 protoc_win32;https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-win32.zip;3688010318192c46ce73213cdfb6b3e5656da874

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -35,8 +35,8 @@ microsoft_wil;https://github.com/microsoft/wil/archive/refs/tags/v1.0.230629.1.z
 mimalloc;https://github.com/microsoft/mimalloc/archive/refs/tags/v2.1.1.zip;d5ee7d34223d0567892db5179849939c8769dc41
 mp11;https://github.com/boostorg/mp11/archive/refs/tags/boost-1.82.0.zip;9bc9e01dffb64d9e0773b2e44d2f22c51aace063
 onnx;https://github.com/onnx/onnx/archive/refs/tags/v1.18.0.zip;f156d032a3af91b66d554e11158b33ca77bbb1f2
-# Side branch
-onnx_tensorrt;https://github.com/gedoensmax/onnx-tensorrt/archive/1ff5201c5eb209a4a58330b9e8cae97f153c93a4.zip;60af1687b0e03c2c920197f4e059cb666aefdd9c
+# Use the latest commit of 10.9-GA
+onnx_tensorrt;https://github.com/onnx/onnx-tensorrt/archive/d5dce67db7c2e64b07e055571f5ec06f7f254de2.zip;01114d3b67650857281fa50faa2e412130a63b69
 protobuf;https://github.com/protocolbuffers/protobuf/archive/refs/tags/v21.12.zip;7cf2733949036c7d52fda017badcab093fe73bfa
 protoc_win64;https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-win64.zip;b4521f7ada5b260380f94c4bd7f1b7684c76969a
 protoc_win32;https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-win32.zip;3688010318192c46ce73213cdfb6b3e5656da874

--- a/include/onnxruntime/core/providers/nv_tensorrt_rtx/nv_provider_options.h
+++ b/include/onnxruntime/core/providers/nv_tensorrt_rtx/nv_provider_options.h
@@ -35,6 +35,8 @@ constexpr const char* kCudaGraphEnable = "nv_cuda_graph_enable";
 constexpr const char* kONNXBytestream = "nv_onnx_bytestream";
 constexpr const char* kONNXBytestreamSize = "nv_onnx_bytestream_size";
 constexpr const char* kMultiProfileEnable = "nv_multi_profile_enable";
+constexpr const char* kExternalDataBytestream = "nv_external_data_bytestream";
+constexpr const char* kExternalDataBytestreamSize = "nv_external_data_bytestream_size";
 
 }  // namespace provider_option_names
 namespace run_option_names {

--- a/include/onnxruntime/core/providers/nv_tensorrt_rtx/nv_provider_options.h
+++ b/include/onnxruntime/core/providers/nv_tensorrt_rtx/nv_provider_options.h
@@ -35,6 +35,7 @@ constexpr const char* kCudaGraphEnable = "nv_cuda_graph_enable";
 constexpr const char* kONNXBytestream = "nv_onnx_bytestream";
 constexpr const char* kONNXBytestreamSize = "nv_onnx_bytestream_size";
 constexpr const char* kMultiProfileEnable = "nv_multi_profile_enable";
+constexpr const char* kUseExternalDataInitializer = "nv_use_external_data_initializer";
 constexpr const char* kExternalDataBytestream = "nv_external_data_bytestream";
 constexpr const char* kExternalDataBytestreamSize = "nv_external_data_bytestream_size";
 

--- a/onnxruntime/core/graph/graph_proto_serializer.cc
+++ b/onnxruntime/core/graph/graph_proto_serializer.cc
@@ -95,7 +95,7 @@ void GraphViewerToProto(const GraphViewer& graph_view,
       auto* p_initializer = graph_proto.add_initializer();
 
       // Do not save raw into the graph, only the metadata
-      if (!include_initializer_data && init->has_raw_data()) {
+      if (!include_initializer_data && (init->has_raw_data() || utils::HasExternalDataInMemory(*init))) {
         // Set datatype
         if (init->has_data_type()) {
           p_initializer->set_data_type(init->data_type());

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
@@ -1069,6 +1069,14 @@ NvExecutionProvider::NvExecutionProvider(const NvExecutionProviderInfo& info)
                                        "When providing either 'trt_onnx_bytestream_size' or "
                                        "'trt_onnx_bytestream' both have to be provided"));
   }
+  onnx_external_data_bytestream_ = info.external_data_bytestream;
+  onnx_external_data_bytestream_size_ = info.external_data_bytestream_size;
+  if ((onnx_external_data_bytestream_ != nullptr && onnx_external_data_bytestream_size_ == 0) ||
+      (onnx_external_data_bytestream_ == nullptr && onnx_external_data_bytestream_size_ != 0)) {
+    ORT_THROW_IF_ERROR(ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
+                                        "When providing either 'trt_external_data_bytestream_size' or "
+                                        "'trt_external_data_bytestream' both have to be provided"));
+  }
   detailed_build_log_ = info.detailed_build_log;
   dump_ep_context_model_ = info.dump_ep_context_model;
   ep_context_file_path_ = info.ep_context_file_path;
@@ -1234,6 +1242,7 @@ NvExecutionProvider::NvExecutionProvider(const NvExecutionProviderInfo& info)
                         << ", nv_ep_context_embed_mode: " << ep_context_embed_mode_
                         << ", nv_cache_prefix: " << cache_prefix_
                         << ", nv_onnx_model_bytestream_size_: " << onnx_model_bytestream_size_
+                        << ", nv_onnx_external_bytestream_size_: " << onnx_external_data_bytestream_size_
                         << ", nv_op_types_to_exclude: " << op_types_to_exclude_;
 }
 
@@ -1701,7 +1710,34 @@ SubGraphCollection_t NvExecutionProvider::GetSupportedList(SubGraphCollection_t 
         // When creating model proto from graph viewer, let ORT use priority-based topological sort based on node index.
         // The reason is, in some cases, for example ResNet50, using default topological sort will end up with generating
         // the model proto that has different node ordering compared to original onnx model.
-        graph_viewer->ToProto(*model_proto->mutable_graph(), true, true, 1 /*priority-based topological sort*/);
+        // graph_viewer->ToProto(*model_proto->mutable_graph(), true, true, 1 /*priority-based topological sort*/);
+
+        // Set export initializers to false so that we can succesfully serialize.
+        std::vector<const char*> names;
+        std::vector<const char*> bytes;
+        std::vector<int64_t> sizes;
+
+        auto allInitializers = graph_viewer->GetAllInitializedTensors();
+
+        for (auto entry : allInitializers) {
+          auto name = entry.first;
+          auto* tp = entry.second;
+
+          // std::cout << "ORT: Saving initializers in mem: " << tp->name() << ", has raw data? " << tp->has_raw_data() << std::endl;
+
+          // TODO: Handle non-raw-data?
+          if (tp->has_raw_data()) {
+            names.push_back(tp->name().c_str());
+            bytes.push_back(tp->raw_data().c_str());
+            sizes.push_back(tp->raw_data().size());
+          }
+          // else {
+          //   std::cout << "ORT: Tensor has no raw data: " << tp->name() << std::endl;
+          // }
+        }
+        graph_viewer->ToProto(*model_proto->mutable_graph(), true, true, 1 /*priority-based topological sort*/, false);
+
+
         model_proto->set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
 
         std::string string_buf;
@@ -1724,7 +1760,19 @@ SubGraphCollection_t NvExecutionProvider::GetSupportedList(SubGraphCollection_t 
         {
           auto trt_parser = tensorrt_ptr::unique_pointer<nvonnxparser::IParser>(nvonnxparser::createParser(*trt_network, trt_logger));
 
-          auto is_model_supported = trt_parser->supportsModelV2(string_buf.data(), string_buf.size(), model_path_);
+          // auto is_model_supported = trt_parser->supportsModelV2(string_buf.data(), string_buf.size(), model_path_);
+
+        bool loadSuccess = trt_parser->loadModelProto(string_buf.data(), string_buf.size(), model_path_);
+
+        bool loadInit = true;
+        for (int i=0; i<names.size(); i++){
+          loadInit &= trt_parser->loadInitializer(names[i], bytes[i], sizes[i]);
+        }
+        if (!(loadSuccess && loadInit)) {
+          ORT_THROW_IF_ERROR(ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "TRT Parser load failed"));
+        }
+        // auto is_model_supported = trt_parser->supportsModelV3();
+        bool is_model_supported = trt_parser->parseModelProto();
 
           // Note: Calling getNbSubgraphs or getSubgraphNodes before calling supportsModelV2 results in undefined behavior.
           auto num_subgraphs = trt_parser->getNbSubgraphs();
@@ -2135,9 +2183,12 @@ common::Status NvExecutionProvider::RefitEngine(std::string onnx_model_filename,
                                                 bool path_check,
                                                 const void* onnx_model_bytestream,
                                                 size_t onnx_model_bytestream_size,
+                                                const void* onnx_external_data_bytestream,
+                                                size_t onnx_external_data_bytestream_size,
                                                 nvinfer1::ICudaEngine* trt_engine,
                                                 bool serialize_refitted_engine,
-                                                bool detailed_build_log) {
+                                                bool detailed_build_log,
+                                                const GraphViewer* graph_body_viewer) {
   bool refit_from_file = onnx_model_bytestream == nullptr && onnx_model_bytestream_size == 0;
   std::filesystem::path onnx_model_path{onnx_model_folder_path};
   if (refit_from_file) {
@@ -2181,18 +2232,157 @@ common::Status NvExecutionProvider::RefitEngine(std::string onnx_model_filename,
       return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
                              "Nv EP's IParserRefitter could not refit deserialized weight-stripped engine with weights contained in: " + onnx_model_path.string());
     }
+    if (refitter->refitCudaEngine()) {
+      LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Successfully refitted the weight-stripped engine.";
+    } else {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
+                             "TensorRT EP's IRefitter could not refit deserialized weight-stripped engine with weights contained in: " + onnx_model_path.string());
+    }
   } else {
+    int required_weights = refitter->getAllWeights(0, nullptr);
+    std::vector<char const*> refit_names(required_weights);
+    refitter->getAllWeights(required_weights, refit_names.data());
+
     LOGS_DEFAULT(VERBOSE) << "[NvTensorRTRTX EP] Refitting from byte array";
-    if (!parser_refitter->refitFromBytes(onnx_model_bytestream, onnx_model_bytestream_size)) {
+    // if (!parser_refitter->refitFromBytes(onnx_model_bytestream, onnx_model_bytestream_size)) {
+    LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Weights required for a full refit " << required_weights;
+
+    // predeclare variables here to keep them alive for the refitter
+    std::vector<const char*> names;
+    names.reserve(required_weights);
+    std::vector<const char*> bytes;
+    bytes.reserve(required_weights);
+    std::vector<std::string> bytes_copy;
+    bytes_copy.reserve(required_weights);
+    std::vector<int64_t> sizes;
+    sizes.reserve(required_weights);
+    auto onnx_model = ModelProto::Create();
+    TensorProtos* allInitializers_byte_stream;
+    const InitializedTensorSet* allInitializers_graph_body;
+
+    // load graph structure
+    bool refitloadSuccess = parser_refitter->loadModelProto(onnx_model_bytestream, onnx_model_bytestream_size, nullptr);
+    if (!refitloadSuccess) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
                              "Nv EP's IParserRefitter could not refit deserialized weight-stripped engine with weights contained in the provided bytestraem");
     }
-  }
-  if (refitter->refitCudaEngine()) {
-    LOGS_DEFAULT(VERBOSE) << "[NvTensorRTRTX EP] Successfully refitted the weight-stripped engine.";
-  } else {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                           "Nv EP's IRefitter could not refit deserialized weight-stripped engine with weights contained in: " + onnx_model_path.string());
+  // }
+  // if (refitter->refitCudaEngine()) {
+  //   LOGS_DEFAULT(VERBOSE) << "[NvTensorRTRTX EP] Successfully refitted the weight-stripped engine.";
+  // } else {
+  //   return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
+  //                          "Nv EP's IRefitter could not refit deserialized weight-stripped engine with weights contained in: " + onnx_model_path.string());
+
+  // conditional branch loading additional initializers if needed
+    if (onnx_external_data_bytestream_size) {
+      // This code path is leveraged when loading a context file as byte array
+      // and providing the corresponding ONNX as byte array through provider options
+
+      const auto onnx_model_view = std::string((const char*)onnx_model_bytestream,
+                                               onnx_model_bytestream_size);
+      if (!onnx_model->ParseFromString(onnx_model_view)) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
+                               "The provided ONNX bytestream to refit could not be parsed.");
+      }
+
+
+
+      auto const& graph = onnx_model->mutable_graph();
+      allInitializers_byte_stream = graph->mutable_initializer();
+      LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Initializers that were found " << allInitializers_byte_stream->size();
+      struct DataInfo {
+        int64_t offset;
+        size_t length;
+      };
+      for (int initializer_idx = 0; initializer_idx < allInitializers_byte_stream->size(); ++initializer_idx) {
+        auto& proto = allInitializers_byte_stream->at(initializer_idx);
+        auto& proto_name = proto.name();
+        bool weight_is_refittable = std::find(refit_names.begin(), refit_names.end(), proto_name) != refit_names.end();
+        if (weight_is_refittable) {
+          if (proto.has_data_location()) {
+            if (proto.data_location() == TensorProto_DataLocation_EXTERNAL) {
+              DataInfo external_data_info = {};
+              auto external_data = proto.mutable_external_data();
+              const std::string kOffset = "offset", kLength = "length";
+              for (int entry_idx = 0; entry_idx < external_data->size(); ++entry_idx) {
+                auto current_key = external_data->at(entry_idx).mutable_key();
+                auto current_value = external_data->at(entry_idx).mutable_value();
+                if (*current_key == kOffset && !current_value->empty()) {
+                  external_data_info.offset = std::stoll(*current_value);
+                } else if (*current_key == kLength && !current_value->empty()) {
+                  external_data_info.length = std::stoul(*current_value);
+                }
+              }
+              names.push_back(proto.name().c_str());
+              bytes.push_back(static_cast<const char*>(onnx_external_data_bytestream) + external_data_info.offset);
+              sizes.push_back(external_data_info.length);
+            } else {
+              return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
+                                     "[TensorRT EP] Proto: " + proto_name + " has default as data locationn which is not supported");
+            }
+          } else {
+            if (!proto.has_raw_data()) {
+              return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
+                                     "[TensorRT EP] Proto: " + proto_name + " has no raw data");
+            }
+            auto& raw_data = proto.raw_data();
+
+            names.push_back(proto.name().c_str());
+            bytes.push_back(raw_data.c_str());
+            sizes.push_back(raw_data.size());
+          }
+        } else {
+          LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Initializer with name: " << proto_name << " cannot be refitted";
+        }
+      }
+    } else if (graph_body_viewer) {
+      // This path will only be used if
+      // 1. An ONNX was provided as byte array including initializers
+      // 2. An ONNX was provided as byte array and it's initializers were provided using AddExternalInitializers* API
+      LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Refitting using initializers of the current graph in memory";
+
+      allInitializers_graph_body = &graph_body_viewer->GetAllInitializedTensors();
+
+      for (auto& entry : *allInitializers_graph_body) {
+        auto* tp = entry.second;
+        auto& proto_name = tp->name();
+        // TODO: Handle non-raw-data?
+        bool weight_is_refittable = std::find(refit_names.begin(), refit_names.end(), proto_name) != refit_names.end();
+        if (tp->has_raw_data() && weight_is_refittable) {
+          names.push_back(proto_name.c_str());
+          bytes.push_back(tp->raw_data().c_str());
+          sizes.push_back(tp->raw_data().size());
+        }
+      }
+    } else {
+      LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] No external initializers are present";
+    }
+    // provide dedicated initializers if ONNX serialization is not complete
+    if (!names.empty()) {
+      LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Number of initializers submitted to refitter " << names.size();
+      bool refloadInit = true;
+      for(int i=0; i<names.size(); i++) {
+        refloadInit &= parser_refitter->loadInitializer(names[i], bytes[i], sizes[i]);
+      }
+
+      // bool refloadInit = parser_refitter->loadInitializer(names.data(), bytes.data(), sizes.data(), names.size());
+      if (!refloadInit) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
+                               "TensorRT EP's IParserRefitter could not refit deserialized weight-stripped engine with weights contained in the provided bytestraem");
+      }
+    }
+
+    bool refparseModelProto = parser_refitter->refitModelProto();
+    if (!refparseModelProto) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
+                             "TensorRT EP's IParserRefitter could not refit deserialized weight-stripped engine with weights contained in the provided bytestraem");
+    }
+    if (refitter->refitCudaEngine()) {
+      LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Successfully refitted the weight-stripped engine.";
+    } else {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
+                             "TensorRT EP's IRefitter could not refit deserialized weight-stripped engine with weights contained in: " + onnx_model_path.string());
+    }
   }
 
   // serialize the refitted engine to disk
@@ -2252,12 +2442,31 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
   // Reconstruct graph proto from fused node's function body
   auto model = graph_body_viewer.CreateModel(*GetLogger());
   auto model_proto = model->ToProto();
+  // Set export initializers to false so that we can succesfully serialize.
+
+  std::vector<const char*> names;
+  std::vector<const char*> bytes;
+  std::vector<int64_t> sizes;
+
+  auto allInitializers = graph_body_viewer.GetAllInitializedTensors();
+
+  for (auto entry : allInitializers) {
+    auto name = entry.first;
+    auto* tp = entry.second;
+    // TODO: Handle non-raw-data?
+    if (tp->has_raw_data()) {
+      names.push_back(tp->name().c_str());
+      bytes.push_back(tp->raw_data().c_str());
+      sizes.push_back(tp->raw_data().size());
+    }
+  }
+
 
   // ORT's default topological sort is using reversed DFS.
   // When creating model proto from graph viewer, let ORT use priority-based topological sort based on node index.
   // The reason is, in some cases, for example ResNet50, using default topological sort will end up with generating
   // the model proto that has different node ordering compared to original onnx model.
-  graph_body_viewer.ToProto(*model_proto->mutable_graph(), true, true, 1 /*priority-based topological sort*/);
+  graph_body_viewer.ToProto(*model_proto->mutable_graph(), true, true, 1 /*priority-based topological sort*/, false);
   model_proto->set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
   std::string string_buf;
   model_proto->SerializeToString(string_buf);
@@ -2274,7 +2483,21 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
   auto trt_network = std::unique_ptr<nvinfer1::INetworkDefinition>(trt_builder->createNetworkV2(network_flags));
   auto trt_config = std::unique_ptr<nvinfer1::IBuilderConfig>(trt_builder->createBuilderConfig());
   auto trt_parser = tensorrt_ptr::unique_pointer<nvonnxparser::IParser>(nvonnxparser::createParser(*trt_network, trt_logger));
-  trt_parser->parse(string_buf.data(), string_buf.size(), model_path_);
+  // trt_parser->parse(string_buf.data(), string_buf.size(), model_path_);
+  bool loadSuccess = trt_parser->loadModelProto(string_buf.data(), string_buf.size(), model_path_);
+  // bool loadInit = trt_parser->loadInitializer(names.data(), bytes.data(), sizes.data(), names.size());
+  bool loadInit = true;
+  for (int i=0; i<names.size(); i++){
+    loadInit &= trt_parser->loadInitializer(names[i], bytes[i], sizes[i]);
+  }
+  if (!(loadSuccess && loadInit)) {
+    ORT_THROW_IF_ERROR(ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "TRT Parser load failed"));
+  }
+  bool parseModelProto = trt_parser->parseModelProto();
+  if (!parseModelProto) {
+    ORT_THROW_IF_ERROR(ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "TRT Parser failed"));
+  }
+
   if (max_workspace_size_ > 0) {
     trt_config->setMemoryPoolLimit(nvinfer1::MemoryPoolType::kWORKSPACE, max_workspace_size_);
   }
@@ -2563,9 +2786,12 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
                               false /* path check for security */,
                               onnx,
                               onnx_size,
+                              onnx_external_data_bytestream_,
+                              onnx_external_data_bytestream_size_,
                               trt_engine.get(),
                               false /* serialize refitted engine to disk */,
-                              detailed_build_log_);
+                              detailed_build_log_,
+                              &graph_body_viewer);
     if (status != Status::OK()) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL, status.ErrorMessage());
     }
@@ -2631,6 +2857,7 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
   // Create function state
   // TODO: remove default capture
   NodeComputeInfo compute_info;
+  auto* graph_body_viewer_ptr = &graph_body_viewer;
   compute_info.create_state_func = [=](ComputeContext* context, FunctionState* state) {
     std::unique_ptr<TensorrtFuncState> p = std::make_unique<TensorrtFuncState>();
     *p = {context->allocate_func, context->release_func, context->allocator_handle, context->node_name, builder_.get(),
@@ -2642,7 +2869,7 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
           context_memory_sharing_enable_, &max_ctx_mem_size_,
           engine_decryption_enable_, engine_decryption_, engine_encryption_,
           detailed_build_log_, sparsity_enable_,
-          auxiliary_streams_, cuda_graph_enable_, cache_prefix_, cache_suffix};
+          auxiliary_streams_, cuda_graph_enable_, cache_prefix_, cache_suffix, graph_body_viewer_ptr};
     *state = p.release();
     return 0;
   };
@@ -2747,9 +2974,12 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
                                 false /* path check for security */,
                                 onnx_model_bytestream_,
                                 onnx_model_bytestream_size_,
+                                onnx_external_data_bytestream_,
+                                onnx_external_data_bytestream_size_,
                                 trt_engine,
                                 false /* serialize refitted engine to disk */,
-                                detailed_build_log_);
+                                detailed_build_log_,
+                                trt_state->graph_viewer);
       if (status != Status::OK()) {
         return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL, status.ErrorMessage());
       }
@@ -2951,6 +3181,8 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromPrecompiledEngine(const Gra
                                                            onnx_model_folder_path_,
                                                            onnx_model_bytestream_,
                                                            onnx_model_bytestream_size_,
+                                                           onnx_external_data_bytestream_,
+                                                           onnx_external_data_bytestream_size_,
                                                            detailed_build_log_);
   auto status = trt_cache_model_handler.GetEpContextFromGraph(graph_body_viewer);
   if (status != Status::OK()) {

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
@@ -1074,8 +1074,8 @@ NvExecutionProvider::NvExecutionProvider(const NvExecutionProviderInfo& info)
   if ((onnx_external_data_bytestream_ != nullptr && onnx_external_data_bytestream_size_ == 0) ||
       (onnx_external_data_bytestream_ == nullptr && onnx_external_data_bytestream_size_ != 0)) {
     ORT_THROW_IF_ERROR(ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                                        "When providing either 'trt_external_data_bytestream_size' or "
-                                        "'trt_external_data_bytestream' both have to be provided"));
+                                        "When providing either 'onnx_external_data_bytestream_size' or "
+                                        "'onnx_external_data_bytestream' both have to be provided"));
   }
   detailed_build_log_ = info.detailed_build_log;
   dump_ep_context_model_ = info.dump_ep_context_model;
@@ -1710,32 +1710,19 @@ SubGraphCollection_t NvExecutionProvider::GetSupportedList(SubGraphCollection_t 
         // When creating model proto from graph viewer, let ORT use priority-based topological sort based on node index.
         // The reason is, in some cases, for example ResNet50, using default topological sort will end up with generating
         // the model proto that has different node ordering compared to original onnx model.
-        // graph_viewer->ToProto(*model_proto->mutable_graph(), true, true, 1 /*priority-based topological sort*/);
 
-        // Set export initializers to false so that we can succesfully serialize.
-        std::vector<const char*> names;
-        std::vector<const char*> bytes;
-        std::vector<int64_t> sizes;
+        // get initializer data
+        std::vector<TensorrtUserWeights> userWeights;
 
         auto allInitializers = graph_viewer->GetAllInitializedTensors();
-
-        for (auto entry : allInitializers) {
-          auto name = entry.first;
-          auto* tp = entry.second;
-
-          // std::cout << "ORT: Saving initializers in mem: " << tp->name() << ", has raw data? " << tp->has_raw_data() << std::endl;
-
-          // TODO: Handle non-raw-data?
-          if (tp->has_raw_data()) {
-            names.push_back(tp->name().c_str());
-            bytes.push_back(tp->raw_data().c_str());
-            sizes.push_back(tp->raw_data().size());
-          }
-          // else {
-          //   std::cout << "ORT: Tensor has no raw data: " << tp->name() << std::endl;
-          // }
+        for (auto entry : allInitializers){
+            auto* tp = entry.second;
+            if (tp->has_raw_data()){
+              userWeights.push_back(
+                TensorrtUserWeights{tp->name(), tp->raw_data(), (int64_t)tp->raw_data().size()});
+            }
         }
-        graph_viewer->ToProto(*model_proto->mutable_graph(), true, true, 1 /*priority-based topological sort*/, false);
+        graph_viewer->ToProto(*model_proto->mutable_graph(), true, true, 1 /*priority-based topological sort*/, false /*include raw initializers*/);
 
 
         model_proto->set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
@@ -1756,23 +1743,18 @@ SubGraphCollection_t NvExecutionProvider::GetSupportedList(SubGraphCollection_t 
         auto network_flags = 1U << static_cast<uint32_t>(nvinfer1::NetworkDefinitionCreationFlag::kSTRONGLY_TYPED);
         auto trt_network = std::unique_ptr<nvinfer1::INetworkDefinition>(trt_builder->createNetworkV2(network_flags));
 
+        bool is_model_supported = false;
+
         // limit the scope of trt_parser so that model gets unloaded from memory asap
         {
           auto trt_parser = tensorrt_ptr::unique_pointer<nvonnxparser::IParser>(nvonnxparser::createParser(*trt_network, trt_logger));
 
-          // auto is_model_supported = trt_parser->supportsModelV2(string_buf.data(), string_buf.size(), model_path_);
+          trt_parser->loadModelProto(string_buf.data(), string_buf.size(), model_path_);
 
-        bool loadSuccess = trt_parser->loadModelProto(string_buf.data(), string_buf.size(), model_path_);
-
-        bool loadInit = true;
-        for (int i=0; i<names.size(); i++){
-          loadInit &= trt_parser->loadInitializer(names[i], bytes[i], sizes[i]);
-        }
-        if (!(loadSuccess && loadInit)) {
-          ORT_THROW_IF_ERROR(ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "TRT Parser load failed"));
-        }
-        // auto is_model_supported = trt_parser->supportsModelV3();
-        bool is_model_supported = trt_parser->parseModelProto();
+          for (auto const& userWeight : userWeights){
+            trt_parser->loadInitializer(userWeight.name.c_str(), static_cast<void const*>(userWeight.data.c_str()), userWeight.size);
+          }
+          is_model_supported = trt_parser->parseModelProto();
 
           // Note: Calling getNbSubgraphs or getSubgraphNodes before calling supportsModelV2 results in undefined behavior.
           auto num_subgraphs = trt_parser->getNbSubgraphs();
@@ -2190,6 +2172,7 @@ common::Status NvExecutionProvider::RefitEngine(std::string onnx_model_filename,
                                                 bool detailed_build_log,
                                                 const GraphViewer* graph_body_viewer) {
   bool refit_from_file = onnx_model_bytestream == nullptr && onnx_model_bytestream_size == 0;
+  bool refit_complete = false;
   std::filesystem::path onnx_model_path{onnx_model_folder_path};
   if (refit_from_file) {
     if (!onnx_model_filename.empty()) {
@@ -2212,7 +2195,6 @@ common::Status NvExecutionProvider::RefitEngine(std::string onnx_model_filename,
                                "The ONNX model path has '..'. For security purpose, it's not "
                                "allowed to point outside the directory.");
       }
-
       if (!(std::filesystem::exists(onnx_model_path) && std::filesystem::is_regular_file(onnx_model_path))) {
         return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
                                "The ONNX model " + onnx_model_path.string() +
@@ -2220,80 +2202,67 @@ common::Status NvExecutionProvider::RefitEngine(std::string onnx_model_filename,
       }
     }
   }
-
   // weight-stripped engine refit logic
   TensorrtLogger& trt_logger = GetTensorrtLogger(detailed_build_log);
   auto refitter = std::unique_ptr<nvinfer1::IRefitter>(nvinfer1::createInferRefitter(*trt_engine, trt_logger));
   auto parser_refitter = std::unique_ptr<nvonnxparser::IParserRefitter>(
       nvonnxparser::createParserRefitter(*refitter, trt_logger));
-  if (refit_from_file) {
-    LOGS_DEFAULT(VERBOSE) << "[NvTensorRTRTX EP] Refitting from file on disk: " << onnx_model_path.string();
-    if (!parser_refitter->refitFromFile(onnx_model_path.string().c_str())) {
+
+  bool refit_with_external_data = onnx_external_data_bytestream != nullptr && onnx_external_data_bytestream_size != 0;
+
+  // New refit APIs
+  if (refit_with_external_data || graph_body_viewer) {
+    if (refit_from_file) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                             "Nv EP's IParserRefitter could not refit deserialized weight-stripped engine with weights contained in: " + onnx_model_path.string());
+        "TensorRT EP's refit with external data must be called with a valid ONNX model bytestream");
     }
-    if (refitter->refitCudaEngine()) {
-      LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Successfully refitted the weight-stripped engine.";
-    } else {
+
+    if (!parser_refitter->loadModelProto(onnx_model_bytestream, onnx_model_bytestream_size, nullptr)){
       return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                             "TensorRT EP's IRefitter could not refit deserialized weight-stripped engine with weights contained in: " + onnx_model_path.string());
+                             "TensorRT EP's IParserRefitter could not load model from provided onnx_model_bytestream");
     }
-  } else {
+
+    // Extract weight information from the Refitter
     int required_weights = refitter->getAllWeights(0, nullptr);
     std::vector<char const*> refit_names(required_weights);
     refitter->getAllWeights(required_weights, refit_names.data());
 
-    LOGS_DEFAULT(VERBOSE) << "[NvTensorRTRTX EP] Refitting from byte array";
-    // if (!parser_refitter->refitFromBytes(onnx_model_bytestream, onnx_model_bytestream_size)) {
-    LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Weights required for a full refit " << required_weights;
-
-    // predeclare variables here to keep them alive for the refitter
+    // Vectors to keep track of data pointers
     std::vector<const char*> names;
     names.reserve(required_weights);
     std::vector<const char*> bytes;
     bytes.reserve(required_weights);
-    std::vector<std::string> bytes_copy;
-    bytes_copy.reserve(required_weights);
     std::vector<int64_t> sizes;
     sizes.reserve(required_weights);
-    auto onnx_model = ModelProto::Create();
-    TensorProtos* allInitializers_byte_stream;
-    const InitializedTensorSet* allInitializers_graph_body;
 
-    // load graph structure
-    bool refitloadSuccess = parser_refitter->loadModelProto(onnx_model_bytestream, onnx_model_bytestream_size, nullptr);
-    if (!refitloadSuccess) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                             "Nv EP's IParserRefitter could not refit deserialized weight-stripped engine with weights contained in the provided bytestraem");
+    /*
+    TODO: Instead of passing in a single pointer and reconstructing the entire ONNX model, is it better to pre-partition the weights?
+    This function will now have parameters void ** data, const char ** names, int64_t * sizes, int64_t num_weights
+    for (int i = 0; i < num_weights; i++)
+    {
+        parser_refitter->loadInitializer(data[i], names[i], sizes[i]);
     }
-  // }
-  // if (refitter->refitCudaEngine()) {
-  //   LOGS_DEFAULT(VERBOSE) << "[NvTensorRTRTX EP] Successfully refitted the weight-stripped engine.";
-  // } else {
-  //   return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-  //                          "Nv EP's IRefitter could not refit deserialized weight-stripped engine with weights contained in: " + onnx_model_path.string());
+    */
 
-  // conditional branch loading additional initializers if needed
-    if (onnx_external_data_bytestream_size) {
-      // This code path is leveraged when loading a context file as byte array
-      // and providing the corresponding ONNX as byte array through provider options
+    if (refit_with_external_data)
+    {
+      auto onnx_model = ModelProto::Create();
+      TensorProtos* allInitializers_byte_stream;
 
+      // Reconstruct onnx model view.
       const auto onnx_model_view = std::string((const char*)onnx_model_bytestream,
-                                               onnx_model_bytestream_size);
+                                                onnx_model_bytestream_size);
       if (!onnx_model->ParseFromString(onnx_model_view)) {
         return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                               "The provided ONNX bytestream to refit could not be parsed.");
+                                "The provided ONNX bytestream to refit could not be parsed.");
       }
 
-
-
+      // Extract graph and initializer information.
       auto const& graph = onnx_model->mutable_graph();
       allInitializers_byte_stream = graph->mutable_initializer();
       LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Initializers that were found " << allInitializers_byte_stream->size();
-      struct DataInfo {
-        int64_t offset;
-        size_t length;
-      };
+
+      // Loop through all initializers
       for (int initializer_idx = 0; initializer_idx < allInitializers_byte_stream->size(); ++initializer_idx) {
         auto& proto = allInitializers_byte_stream->at(initializer_idx);
         auto& proto_name = proto.name();
@@ -2301,52 +2270,53 @@ common::Status NvExecutionProvider::RefitEngine(std::string onnx_model_filename,
         if (weight_is_refittable) {
           if (proto.has_data_location()) {
             if (proto.data_location() == TensorProto_DataLocation_EXTERNAL) {
-              DataInfo external_data_info = {};
+              // Default values for reading into external_data blob.
+              int64_t offset = 0;
+              size_t length = 0;
               auto external_data = proto.mutable_external_data();
               const std::string kOffset = "offset", kLength = "length";
               for (int entry_idx = 0; entry_idx < external_data->size(); ++entry_idx) {
                 auto current_key = external_data->at(entry_idx).mutable_key();
                 auto current_value = external_data->at(entry_idx).mutable_value();
                 if (*current_key == kOffset && !current_value->empty()) {
-                  external_data_info.offset = std::stoll(*current_value);
+                  offset = std::stoll(*current_value);
                 } else if (*current_key == kLength && !current_value->empty()) {
-                  external_data_info.length = std::stoul(*current_value);
+                  length = std::stoul(*current_value);
                 }
               }
               names.push_back(proto.name().c_str());
-              bytes.push_back(static_cast<const char*>(onnx_external_data_bytestream) + external_data_info.offset);
-              sizes.push_back(external_data_info.length);
+              bytes.push_back(static_cast<const char*>(onnx_external_data_bytestream) + offset);
+              sizes.push_back(length);
             } else {
               return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                                     "[TensorRT EP] Proto: " + proto_name + " has default as data locationn which is not supported");
+                                      "[TensorRT EP] Proto: " + proto_name + " has default as data location which is not supported");
             }
           } else {
             if (!proto.has_raw_data()) {
               return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                                     "[TensorRT EP] Proto: " + proto_name + " has no raw data");
+                                      "[TensorRT EP] Proto: " + proto_name + " has no raw data");
             }
             auto& raw_data = proto.raw_data();
-
             names.push_back(proto.name().c_str());
             bytes.push_back(raw_data.c_str());
             sizes.push_back(raw_data.size());
           }
         } else {
-          LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Initializer with name: " << proto_name << " cannot be refitted";
+          LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Initializer with name: " << proto_name << " was not marked as refittable";
         }
       }
-    } else if (graph_body_viewer) {
+    }
+    else { // graph_body_viewer path.
       // This path will only be used if
       // 1. An ONNX was provided as byte array including initializers
       // 2. An ONNX was provided as byte array and it's initializers were provided using AddExternalInitializers* API
       LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Refitting using initializers of the current graph in memory";
 
-      allInitializers_graph_body = &graph_body_viewer->GetAllInitializedTensors();
+      auto allInitializers_graph_body = &graph_body_viewer->GetAllInitializedTensors();
 
       for (auto& entry : *allInitializers_graph_body) {
         auto* tp = entry.second;
         auto& proto_name = tp->name();
-        // TODO: Handle non-raw-data?
         bool weight_is_refittable = std::find(refit_names.begin(), refit_names.end(), proto_name) != refit_names.end();
         if (tp->has_raw_data() && weight_is_refittable) {
           names.push_back(proto_name.c_str());
@@ -2354,35 +2324,50 @@ common::Status NvExecutionProvider::RefitEngine(std::string onnx_model_filename,
           sizes.push_back(tp->raw_data().size());
         }
       }
-    } else {
-      LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] No external initializers are present";
     }
-    // provide dedicated initializers if ONNX serialization is not complete
+
+    // Load extracted initializers into the parser
     if (!names.empty()) {
       LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Number of initializers submitted to refitter " << names.size();
-      bool refloadInit = true;
-      for(int i=0; i<names.size(); i++) {
-        refloadInit &= parser_refitter->loadInitializer(names[i], bytes[i], sizes[i]);
+      for (size_t i = 0; i < names.size(); i++)
+      {
+        bool refloadInit = parser_refitter->loadInitializer(names[i], bytes[i], sizes[i]);
+        if (!refloadInit) {
+          return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
+                                "TensorRT EP's IParserRefitter could not refit deserialized weight-stripped engine with weights contained in the provided bytestraem");
+        }
       }
+    }
+    // Perform refit.
+    if(!parser_refitter->refitModelProto())
+    {
+       return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
+                              "TensorRT EP's IParserRefitter refitModelProto() failed with the provided external data bytestream.");
+    }
+    refit_complete = true;
 
-      // bool refloadInit = parser_refitter->loadInitializer(names.data(), bytes.data(), sizes.data(), names.size());
-      if (!refloadInit) {
+  }
+  // If new refit flow was not completed, then fallback to refit_from_file.
+  if (!refit_complete){
+    if (refit_from_file) {
+      LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Refitting from file on disk: " << onnx_model_path.string();
+      if (!parser_refitter->refitFromFile(onnx_model_path.string().c_str())) {
         return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                               "TensorRT EP's IParserRefitter could not refit deserialized weight-stripped engine with weights contained in the provided bytestraem");
+                              "TensorRT EP's IParserRefitter could not refit deserialized weight-stripped engine with weights contained in: " + onnx_model_path.string());
+      }
+    }else {
+      LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Refitting from byte array";
+      if (!parser_refitter->refitFromBytes(onnx_model_bytestream, onnx_model_bytestream_size)) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
+                              "TensorRT EP's IParserRefitter could not refit deserialized weight-stripped engine with weights contained in the provided bytestream");
       }
     }
-
-    bool refparseModelProto = parser_refitter->refitModelProto();
-    if (!refparseModelProto) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                             "TensorRT EP's IParserRefitter could not refit deserialized weight-stripped engine with weights contained in the provided bytestraem");
-    }
-    if (refitter->refitCudaEngine()) {
-      LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Successfully refitted the weight-stripped engine.";
-    } else {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                             "TensorRT EP's IRefitter could not refit deserialized weight-stripped engine with weights contained in: " + onnx_model_path.string());
-    }
+  }
+  if (refitter->refitCudaEngine()) {
+    LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Successfully refitted the weight-stripped engine.";
+  } else {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
+                            "TensorRT EP's IRefitter could not refit deserialized weight-stripped engine with weights contained in: " + onnx_model_path.string());
   }
 
   // serialize the refitted engine to disk
@@ -2442,25 +2427,19 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
   // Reconstruct graph proto from fused node's function body
   auto model = graph_body_viewer.CreateModel(*GetLogger());
   auto model_proto = model->ToProto();
-  // Set export initializers to false so that we can succesfully serialize.
 
-  std::vector<const char*> names;
-  std::vector<const char*> bytes;
-  std::vector<int64_t> sizes;
+  // exclude weights if external
+  auto userWeights = std::make_unique<std::vector<TensorrtUserWeights>>();
 
   auto allInitializers = graph_body_viewer.GetAllInitializedTensors();
-
-  for (auto entry : allInitializers) {
-    auto name = entry.first;
-    auto* tp = entry.second;
-    // TODO: Handle non-raw-data?
-    if (tp->has_raw_data()) {
-      names.push_back(tp->name().c_str());
-      bytes.push_back(tp->raw_data().c_str());
-      sizes.push_back(tp->raw_data().size());
-    }
+  for (auto entry : allInitializers){
+      auto name = entry.first;
+      auto* tp = entry.second;
+      if (tp->has_raw_data()){
+          userWeights->push_back(
+            TensorrtUserWeights{tp->name(), tp->raw_data(), (int64_t)tp->raw_data().size()});
+      }
   }
-
 
   // ORT's default topological sort is using reversed DFS.
   // When creating model proto from graph viewer, let ORT use priority-based topological sort based on node index.
@@ -2483,20 +2462,11 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
   auto trt_network = std::unique_ptr<nvinfer1::INetworkDefinition>(trt_builder->createNetworkV2(network_flags));
   auto trt_config = std::unique_ptr<nvinfer1::IBuilderConfig>(trt_builder->createBuilderConfig());
   auto trt_parser = tensorrt_ptr::unique_pointer<nvonnxparser::IParser>(nvonnxparser::createParser(*trt_network, trt_logger));
-  // trt_parser->parse(string_buf.data(), string_buf.size(), model_path_);
-  bool loadSuccess = trt_parser->loadModelProto(string_buf.data(), string_buf.size(), model_path_);
-  // bool loadInit = trt_parser->loadInitializer(names.data(), bytes.data(), sizes.data(), names.size());
-  bool loadInit = true;
-  for (int i=0; i<names.size(); i++){
-    loadInit &= trt_parser->loadInitializer(names[i], bytes[i], sizes[i]);
+  trt_parser->loadModelProto(string_buf.data(), string_buf.size(), model_path_);
+  for (auto const& userWeight : *userWeights){
+    trt_parser->loadInitializer(userWeight.name.c_str(), static_cast<void const*>(userWeight.data.c_str()), userWeight.size);
   }
-  if (!(loadSuccess && loadInit)) {
-    ORT_THROW_IF_ERROR(ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "TRT Parser load failed"));
-  }
-  bool parseModelProto = trt_parser->parseModelProto();
-  if (!parseModelProto) {
-    ORT_THROW_IF_ERROR(ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "TRT Parser failed"));
-  }
+  trt_parser->parseModelProto();
 
   if (max_workspace_size_ > 0) {
     trt_config->setMemoryPoolLimit(nvinfer1::MemoryPoolType::kWORKSPACE, max_workspace_size_);
@@ -2790,8 +2760,7 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
                               onnx_external_data_bytestream_size_,
                               trt_engine.get(),
                               false /* serialize refitted engine to disk */,
-                              detailed_build_log_,
-                              &graph_body_viewer);
+                              detailed_build_log_);
     if (status != Status::OK()) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL, status.ErrorMessage());
     }
@@ -2848,6 +2817,7 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
   engines_.emplace(fused_node.Name(), std::move(trt_engine));
   contexts_.emplace(fused_node.Name(), std::move(trt_context));
   networks_.emplace(fused_node.Name(), std::move(trt_network));
+  weights_.emplace(fused_node.Name(), std::move(userWeights));
   input_info_[fused_node.Name()].push_back(input_indexes);
   output_info_[fused_node.Name()].push_back(output_indexes);
   output_info_[fused_node.Name()].push_back(output_types);
@@ -2857,7 +2827,6 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
   // Create function state
   // TODO: remove default capture
   NodeComputeInfo compute_info;
-  auto* graph_body_viewer_ptr = &graph_body_viewer;
   compute_info.create_state_func = [=](ComputeContext* context, FunctionState* state) {
     std::unique_ptr<TensorrtFuncState> p = std::make_unique<TensorrtFuncState>();
     *p = {context->allocate_func, context->release_func, context->allocator_handle, context->node_name, builder_.get(),
@@ -2869,7 +2838,7 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
           context_memory_sharing_enable_, &max_ctx_mem_size_,
           engine_decryption_enable_, engine_decryption_, engine_encryption_,
           detailed_build_log_, sparsity_enable_,
-          auxiliary_streams_, cuda_graph_enable_, cache_prefix_, cache_suffix, graph_body_viewer_ptr};
+          auxiliary_streams_, cuda_graph_enable_, cache_prefix_, cache_suffix, &weights_[context->node_name]};
     *state = p.release();
     return 0;
   };
@@ -2978,8 +2947,7 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
                                 onnx_external_data_bytestream_size_,
                                 trt_engine,
                                 false /* serialize refitted engine to disk */,
-                                detailed_build_log_,
-                                trt_state->graph_viewer);
+                                detailed_build_log_);
       if (status != Status::OK()) {
         return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL, status.ErrorMessage());
       }

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
@@ -1069,6 +1069,7 @@ NvExecutionProvider::NvExecutionProvider(const NvExecutionProviderInfo& info)
                                        "When providing either 'trt_onnx_bytestream_size' or "
                                        "'trt_onnx_bytestream' both have to be provided"));
   }
+  use_external_data_initializer_ = info.use_external_data_initializer;
   onnx_external_data_bytestream_ = info.external_data_bytestream;
   onnx_external_data_bytestream_size_ = info.external_data_bytestream_size;
   if ((onnx_external_data_bytestream_ != nullptr && onnx_external_data_bytestream_size_ == 0) ||
@@ -1243,6 +1244,7 @@ NvExecutionProvider::NvExecutionProvider(const NvExecutionProviderInfo& info)
                         << ", nv_cache_prefix: " << cache_prefix_
                         << ", nv_onnx_model_bytestream_size_: " << onnx_model_bytestream_size_
                         << ", nv_onnx_external_bytestream_size_: " << onnx_external_data_bytestream_size_
+                        << ", nv_use_external_data_initializer_: " << use_external_data_initializer_
                         << ", nv_op_types_to_exclude: " << op_types_to_exclude_;
 }
 
@@ -1711,18 +1713,25 @@ SubGraphCollection_t NvExecutionProvider::GetSupportedList(SubGraphCollection_t 
         // The reason is, in some cases, for example ResNet50, using default topological sort will end up with generating
         // the model proto that has different node ordering compared to original onnx model.
 
-        // get initializer data
+        // save user provided external data in memory instead of writing to ModelProto
+        // needed for models > 2GB
         std::vector<TensorrtUserWeights> userWeights;
 
-        auto allInitializers = graph_viewer->GetAllInitializedTensors();
-        for (auto entry : allInitializers){
+        if(use_external_data_initializer_) {
+          auto allInitializers = graph_viewer->GetAllInitializedTensors();
+          for (auto &entry : allInitializers) {
             auto* tp = entry.second;
-            if (tp->has_raw_data()){
-              userWeights.push_back(
-                TensorrtUserWeights{tp->name(), tp->raw_data(), (int64_t)tp->raw_data().size()});
+            if (tp->has_raw_data()) {
+              userWeights.emplace_back(tp->name(), tp->raw_data());
+            } else if (utils::HasExternalDataInMemory(*tp)) {
+              std::unique_ptr<ONNX_NAMESPACE::TensorProto> full_init;
+              ORT_THROW_IF_ERROR(utils::GetTensorProtoWithDataIfInMemory(*tp, full_init));
+              userWeights.emplace_back(full_init->name(), full_init->raw_data());
             }
+          }
         }
-        graph_viewer->ToProto(*model_proto->mutable_graph(), true, true, 1 /*priority-based topological sort*/, false /*include raw initializers*/);
+
+        graph_viewer->ToProto(*model_proto->mutable_graph(), true, true, 1 /*priority-based topological sort*/, !use_external_data_initializer_ /*include raw initializers*/);
 
 
         model_proto->set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
@@ -1749,12 +1758,16 @@ SubGraphCollection_t NvExecutionProvider::GetSupportedList(SubGraphCollection_t 
         {
           auto trt_parser = tensorrt_ptr::unique_pointer<nvonnxparser::IParser>(nvonnxparser::createParser(*trt_network, trt_logger));
 
-          trt_parser->loadModelProto(string_buf.data(), string_buf.size(), model_path_);
-
-          for (auto const& userWeight : userWeights){
-            trt_parser->loadInitializer(userWeight.name.c_str(), static_cast<void const*>(userWeight.data.c_str()), userWeight.size);
+          if (use_external_data_initializer_) {
+            trt_parser->loadModelProto(string_buf.data(), string_buf.size(), model_path_);
+            for (auto const& userWeight : userWeights){
+              trt_parser->loadInitializer(userWeight.Name(), userWeight.Data(), userWeight.Size());
+            }
+            is_model_supported = trt_parser->parseModelProto();
           }
-          is_model_supported = trt_parser->parseModelProto();
+          else {
+            is_model_supported = trt_parser->supportsModelV2(string_buf.data(), string_buf.size(), model_path_);
+          }
 
           // Note: Calling getNbSubgraphs or getSubgraphNodes before calling supportsModelV2 results in undefined behavior.
           auto num_subgraphs = trt_parser->getNbSubgraphs();
@@ -2169,9 +2182,10 @@ common::Status NvExecutionProvider::RefitEngine(std::string onnx_model_filename,
                                                 size_t onnx_external_data_bytestream_size,
                                                 nvinfer1::ICudaEngine* trt_engine,
                                                 bool serialize_refitted_engine,
-                                                bool detailed_build_log,
-                                                const GraphViewer* graph_body_viewer) {
+                                                bool detailed_build_log) {
+
   bool refit_from_file = onnx_model_bytestream == nullptr && onnx_model_bytestream_size == 0;
+  bool refit_with_external_data = onnx_external_data_bytestream != nullptr && onnx_external_data_bytestream_size != 0;
   bool refit_complete = false;
   std::filesystem::path onnx_model_path{onnx_model_folder_path};
   if (refit_from_file) {
@@ -2195,6 +2209,7 @@ common::Status NvExecutionProvider::RefitEngine(std::string onnx_model_filename,
                                "The ONNX model path has '..'. For security purpose, it's not "
                                "allowed to point outside the directory.");
       }
+
       if (!(std::filesystem::exists(onnx_model_path) && std::filesystem::is_regular_file(onnx_model_path))) {
         return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
                                "The ONNX model " + onnx_model_path.string() +
@@ -2202,164 +2217,136 @@ common::Status NvExecutionProvider::RefitEngine(std::string onnx_model_filename,
       }
     }
   }
+
   // weight-stripped engine refit logic
   TensorrtLogger& trt_logger = GetTensorrtLogger(detailed_build_log);
   auto refitter = std::unique_ptr<nvinfer1::IRefitter>(nvinfer1::createInferRefitter(*trt_engine, trt_logger));
   auto parser_refitter = std::unique_ptr<nvonnxparser::IParserRefitter>(
       nvonnxparser::createParserRefitter(*refitter, trt_logger));
 
-  bool refit_with_external_data = onnx_external_data_bytestream != nullptr && onnx_external_data_bytestream_size != 0;
-
   // New refit APIs
-  if (refit_with_external_data || graph_body_viewer) {
+  if (refit_with_external_data) {
+    // A valid model bytestream must be passed.
     if (refit_from_file) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-        "TensorRT EP's refit with external data must be called with a valid ONNX model bytestream");
+                             "TensorRT EP's refit with external data must be called with a valid ONNX model bytestream");
     }
 
-    if (!parser_refitter->loadModelProto(onnx_model_bytestream, onnx_model_bytestream_size, nullptr)){
+    if (!parser_refitter->loadModelProto(onnx_model_bytestream, onnx_model_bytestream_size, nullptr)) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
                              "TensorRT EP's IParserRefitter could not load model from provided onnx_model_bytestream");
     }
 
-    // Extract weight information from the Refitter
+    // Extract weight information from the Refitter.
     int required_weights = refitter->getAllWeights(0, nullptr);
     std::vector<char const*> refit_names(required_weights);
     refitter->getAllWeights(required_weights, refit_names.data());
+    LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Refitter requires " << required_weights << " weights";
 
-    // Vectors to keep track of data pointers
-    std::vector<const char*> names;
+    // Vectors to keep track of data pointers.
+    std::vector<std::string> names;
     names.reserve(required_weights);
     std::vector<const char*> bytes;
     bytes.reserve(required_weights);
     std::vector<int64_t> sizes;
     sizes.reserve(required_weights);
 
-    /*
-    TODO: Instead of passing in a single pointer and reconstructing the entire ONNX model, is it better to pre-partition the weights?
-    This function will now have parameters void ** data, const char ** names, int64_t * sizes, int64_t num_weights
-    for (int i = 0; i < num_weights; i++)
-    {
-        parser_refitter->loadInitializer(data[i], names[i], sizes[i]);
+    auto onnx_model = ModelProto::Create();
+    TensorProtos* allInitializers_byte_stream;
+
+    // Reconstruct onnx model view.
+    const auto onnx_model_view = std::string((const char*)onnx_model_bytestream,
+                                             onnx_model_bytestream_size);
+    if (!onnx_model->ParseFromString(onnx_model_view)) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
+                             "The provided ONNX bytestream to refit could not be parsed.");
     }
-    */
 
-    if (refit_with_external_data)
-    {
-      auto onnx_model = ModelProto::Create();
-      TensorProtos* allInitializers_byte_stream;
+    // Extract graph and initializer information.
+    auto const& graph = onnx_model->mutable_graph();
+    allInitializers_byte_stream = graph->mutable_initializer();
+    LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Initializers that were found " << allInitializers_byte_stream->size();
 
-      // Reconstruct onnx model view.
-      const auto onnx_model_view = std::string((const char*)onnx_model_bytestream,
-                                                onnx_model_bytestream_size);
-      if (!onnx_model->ParseFromString(onnx_model_view)) {
-        return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                                "The provided ONNX bytestream to refit could not be parsed.");
-      }
-
-      // Extract graph and initializer information.
-      auto const& graph = onnx_model->mutable_graph();
-      allInitializers_byte_stream = graph->mutable_initializer();
-      LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Initializers that were found " << allInitializers_byte_stream->size();
-
-      // Loop through all initializers
-      for (int initializer_idx = 0; initializer_idx < allInitializers_byte_stream->size(); ++initializer_idx) {
-        auto& proto = allInitializers_byte_stream->at(initializer_idx);
-        auto& proto_name = proto.name();
-        bool weight_is_refittable = std::find(refit_names.begin(), refit_names.end(), proto_name) != refit_names.end();
-        if (weight_is_refittable) {
-          if (proto.has_data_location()) {
-            if (proto.data_location() == TensorProto_DataLocation_EXTERNAL) {
-              // Default values for reading into external_data blob.
-              int64_t offset = 0;
-              size_t length = 0;
-              auto external_data = proto.mutable_external_data();
-              const std::string kOffset = "offset", kLength = "length";
-              for (int entry_idx = 0; entry_idx < external_data->size(); ++entry_idx) {
-                auto current_key = external_data->at(entry_idx).mutable_key();
-                auto current_value = external_data->at(entry_idx).mutable_value();
-                if (*current_key == kOffset && !current_value->empty()) {
-                  offset = std::stoll(*current_value);
-                } else if (*current_key == kLength && !current_value->empty()) {
-                  length = std::stoul(*current_value);
-                }
+    // Loop through all initializers
+    int missing_initializer_data = 0;
+    for (int initializer_idx = 0; initializer_idx < allInitializers_byte_stream->size(); ++initializer_idx) {
+      auto& proto = allInitializers_byte_stream->at(initializer_idx);
+      auto& proto_name = proto.name();
+      bool weight_is_refittable = std::find(refit_names.begin(), refit_names.end(), proto_name) != refit_names.end();
+      if (weight_is_refittable) {
+        if (proto.has_data_location()) {
+          if (proto.data_location() == TensorProto_DataLocation_EXTERNAL) {
+            // Default values for reading into external_data blob.
+            int64_t offset = 0;
+            size_t length = 0;
+            auto external_data = proto.mutable_external_data();
+            const std::string kOffset = "offset", kLength = "length";
+            for (int entry_idx = 0; entry_idx < external_data->size(); ++entry_idx) {
+              auto current_key = external_data->at(entry_idx).mutable_key();
+              auto current_value = external_data->at(entry_idx).mutable_value();
+              if (*current_key == kOffset && !current_value->empty()) {
+                offset = std::stoll(*current_value);
+              } else if (*current_key == kLength && !current_value->empty()) {
+                length = std::stoul(*current_value);
               }
-              names.push_back(proto.name().c_str());
-              bytes.push_back(static_cast<const char*>(onnx_external_data_bytestream) + offset);
-              sizes.push_back(length);
-            } else {
-              return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                                      "[TensorRT EP] Proto: " + proto_name + " has default as data location which is not supported");
             }
+            names.push_back(proto.name());
+            bytes.push_back(static_cast<const char*>(onnx_external_data_bytestream) + offset);
+            sizes.push_back(length);
           } else {
-            if (!proto.has_raw_data()) {
-              return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                                      "[TensorRT EP] Proto: " + proto_name + " has no raw data");
-            }
-            auto& raw_data = proto.raw_data();
-            names.push_back(proto.name().c_str());
-            bytes.push_back(raw_data.c_str());
-            sizes.push_back(raw_data.size());
+            return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
+                                   "[TensorRT EP] Proto: " + proto_name + " expected to have external datalocation, but default datalocation was provided instead.");
           }
+        } else if (proto.has_raw_data()) {
+          auto& raw_data = proto.raw_data();
+          names.push_back(proto.name());
+          bytes.push_back(raw_data.c_str());
+          sizes.push_back(raw_data.size());
         } else {
-          LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Initializer with name: " << proto_name << " was not marked as refittable";
+          LOGS_DEFAULT(WARNING) << "[TensorRT EP] Proto: " + proto_name + " has no raw nor external data.";
+          ++missing_initializer_data;
         }
+      } else {
+        LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Initializer with name: " << proto_name << " was not marked as refittable";
       }
     }
-    else { // graph_body_viewer path.
-      // This path will only be used if
-      // 1. An ONNX was provided as byte array including initializers
-      // 2. An ONNX was provided as byte array and it's initializers were provided using AddExternalInitializers* API
-      LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Refitting using initializers of the current graph in memory";
-
-      auto allInitializers_graph_body = &graph_body_viewer->GetAllInitializedTensors();
-
-      for (auto& entry : *allInitializers_graph_body) {
-        auto* tp = entry.second;
-        auto& proto_name = tp->name();
-        bool weight_is_refittable = std::find(refit_names.begin(), refit_names.end(), proto_name) != refit_names.end();
-        if (tp->has_raw_data() && weight_is_refittable) {
-          names.push_back(proto_name.c_str());
-          bytes.push_back(tp->raw_data().c_str());
-          sizes.push_back(tp->raw_data().size());
-        }
-      }
+    if (missing_initializer_data) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
+                             "[TensorRT EP] RefitEngine is missing " + std::to_string(missing_initializer_data) + " initializers.");
     }
 
     // Load extracted initializers into the parser
     if (!names.empty()) {
       LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Number of initializers submitted to refitter " << names.size();
-      for (size_t i = 0; i < names.size(); i++)
-      {
-        bool refloadInit = parser_refitter->loadInitializer(names[i], bytes[i], sizes[i]);
+      for (size_t i = 0; i < names.size(); i++) {
+        bool refloadInit = parser_refitter->loadInitializer(names[i].c_str(), bytes[i], sizes[i]);
         if (!refloadInit) {
           return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                                "TensorRT EP's IParserRefitter could not refit deserialized weight-stripped engine with weights contained in the provided bytestraem");
+                                 "TensorRT EP's IParserRefitter could not refit deserialized weight-stripped engine with weights contained in the provided bytestream");
         }
       }
     }
     // Perform refit.
-    if(!parser_refitter->refitModelProto())
-    {
-       return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                              "TensorRT EP's IParserRefitter refitModelProto() failed with the provided external data bytestream.");
+    if (!parser_refitter->refitModelProto()) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
+                             "TensorRT EP's IParserRefitter refitModelProto() failed with the provided external data bytestream.");
     }
     refit_complete = true;
-
   }
+
   // If new refit flow was not completed, then fallback to refit_from_file.
-  if (!refit_complete){
+  if (!refit_complete) {
     if (refit_from_file) {
       LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Refitting from file on disk: " << onnx_model_path.string();
       if (!parser_refitter->refitFromFile(onnx_model_path.string().c_str())) {
         return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                              "TensorRT EP's IParserRefitter could not refit deserialized weight-stripped engine with weights contained in: " + onnx_model_path.string());
+                               "TensorRT EP's IParserRefitter could not refit deserialized weight-stripped engine with weights contained in: " + onnx_model_path.string());
       }
-    }else {
+    } else {
       LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Refitting from byte array";
       if (!parser_refitter->refitFromBytes(onnx_model_bytestream, onnx_model_bytestream_size)) {
         return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                              "TensorRT EP's IParserRefitter could not refit deserialized weight-stripped engine with weights contained in the provided bytestream");
+                               "TensorRT EP's IParserRefitter could not refit deserialized weight-stripped engine with weights contained in the provided bytestream");
       }
     }
   }
@@ -2367,7 +2354,7 @@ common::Status NvExecutionProvider::RefitEngine(std::string onnx_model_filename,
     LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Successfully refitted the weight-stripped engine.";
   } else {
     return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                            "TensorRT EP's IRefitter could not refit deserialized weight-stripped engine with weights contained in: " + onnx_model_path.string());
+                           "TensorRT EP's IRefitter could not refit deserialized weight-stripped engine with weights contained in: " + onnx_model_path.string());
   }
 
   // serialize the refitted engine to disk
@@ -2376,10 +2363,11 @@ common::Status NvExecutionProvider::RefitEngine(std::string onnx_model_filename,
     nvinfer1::IHostMemory* serialized_engine = trt_engine->serialize();
     std::ofstream engine_file(refitted_engine_cache, std::ios::binary | std::ios::out);
     engine_file.write(reinterpret_cast<const char*>(serialized_engine->data()), serialized_engine->size());
-    LOGS_DEFAULT(VERBOSE) << "[NvTensorRTRTX EP] Serialize the refitted engine to " << refitted_engine_cache;
+    LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Serialize the refitted engine to " << refitted_engine_cache;
   }
   return Status::OK();
 }
+
 
 common::Status NvExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& fused_nodes_and_graphs,
                                             std::vector<NodeComputeInfo>& node_compute_funcs) {
@@ -2431,21 +2419,25 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
   // exclude weights if external
   auto userWeights = std::make_unique<std::vector<TensorrtUserWeights>>();
 
-  auto allInitializers = graph_body_viewer.GetAllInitializedTensors();
-  for (auto entry : allInitializers){
-      auto name = entry.first;
+  if (use_external_data_initializer_) {
+    auto allInitializers = graph_body_viewer.GetAllInitializedTensors();
+    for (auto& entry : allInitializers){
       auto* tp = entry.second;
       if (tp->has_raw_data()){
-          userWeights->push_back(
-            TensorrtUserWeights{tp->name(), tp->raw_data(), (int64_t)tp->raw_data().size()});
+        userWeights->emplace_back(TensorrtUserWeights(tp->name(), tp->raw_data()));
+      } else if (utils::HasExternalDataInMemory(*tp)) {
+        std::unique_ptr<ONNX_NAMESPACE::TensorProto> full_init;
+        ORT_THROW_IF_ERROR(utils::GetTensorProtoWithDataIfInMemory(*tp, full_init));
+        userWeights->emplace_back(TensorrtUserWeights(full_init->name(), full_init->raw_data()));
       }
+    }
   }
 
   // ORT's default topological sort is using reversed DFS.
   // When creating model proto from graph viewer, let ORT use priority-based topological sort based on node index.
   // The reason is, in some cases, for example ResNet50, using default topological sort will end up with generating
   // the model proto that has different node ordering compared to original onnx model.
-  graph_body_viewer.ToProto(*model_proto->mutable_graph(), true, true, 1 /*priority-based topological sort*/, false);
+  graph_body_viewer.ToProto(*model_proto->mutable_graph(), true, true, 1 /*priority-based topological sort*/, !use_external_data_initializer_ /*include raw initializers*/);
   model_proto->set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
   std::string string_buf;
   model_proto->SerializeToString(string_buf);
@@ -2462,11 +2454,17 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
   auto trt_network = std::unique_ptr<nvinfer1::INetworkDefinition>(trt_builder->createNetworkV2(network_flags));
   auto trt_config = std::unique_ptr<nvinfer1::IBuilderConfig>(trt_builder->createBuilderConfig());
   auto trt_parser = tensorrt_ptr::unique_pointer<nvonnxparser::IParser>(nvonnxparser::createParser(*trt_network, trt_logger));
-  trt_parser->loadModelProto(string_buf.data(), string_buf.size(), model_path_);
-  for (auto const& userWeight : *userWeights){
-    trt_parser->loadInitializer(userWeight.name.c_str(), static_cast<void const*>(userWeight.data.c_str()), userWeight.size);
+
+  if (use_external_data_initializer_) {
+    trt_parser->loadModelProto(string_buf.data(), string_buf.size(), model_path_);
+    for (auto const& userWeight : *userWeights){
+      trt_parser->loadInitializer(userWeight.Name(), userWeight.Data(), userWeight.Size());
+    }
+    trt_parser->parseModelProto();
   }
-  trt_parser->parseModelProto();
+  else {
+    trt_parser->parse(string_buf.data(), string_buf.size(), model_path_);
+  }
 
   if (max_workspace_size_ > 0) {
     trt_config->setMemoryPoolLimit(nvinfer1::MemoryPoolType::kWORKSPACE, max_workspace_size_);
@@ -2748,14 +2746,12 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
 
   if (weight_stripped_engine_refit_) {
     LOGS_DEFAULT(VERBOSE) << "[NvTensorRTRTX EP] Refit engine from main ONNX file after engine build";
-    char* onnx = string_buf.data();
-    size_t onnx_size = string_buf.size();
     auto status = RefitEngine(model_path_,
                               onnx_model_folder_path_,
                               engine_cache_path,
                               false /* path check for security */,
-                              onnx,
-                              onnx_size,
+                              onnx_model_bytestream_,
+                              onnx_model_bytestream_size_,
                               onnx_external_data_bytestream_,
                               onnx_external_data_bytestream_size_,
                               trt_engine.get(),

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
@@ -668,7 +668,7 @@ Status BindContextInput(Ort::KernelContext& ctx,
         if (!trt_context->setTensorAddress(input_name, &shape_tensor_values[input_name][0])) {
           std::string error_input_name = input_name;
           std::string error_msg =
-              "Nv EP failed to call nvinfer1::IExecutionContext::setTensorAddress() for shape input '" +
+              "NvTensorRTRTX EP failed to call nvinfer1::IExecutionContext::setTensorAddress() for shape input '" +
               error_input_name + "'";
           ORT_THROW_IF_ERROR(ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL, error_msg));
         }
@@ -691,7 +691,7 @@ Status BindContextInput(Ort::KernelContext& ctx,
         if (!trt_context->setTensorAddress(input_name, &shape_tensor_values_int64[input_name][0])) {
           std::string error_input_name = input_name;
           std::string error_msg =
-              "Nv EP failed to call nvinfer1::IExecutionContext::setTensorAddress() for shape input '" +
+              "NvTensorRTRTX EP failed to call nvinfer1::IExecutionContext::setTensorAddress() for shape input '" +
               error_input_name + "'";
           ORT_THROW_IF_ERROR(ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL, error_msg));
         }
@@ -713,7 +713,7 @@ Status BindContextInput(Ort::KernelContext& ctx,
     if (!trt_context->setInputShape(input_name, dims)) {
       std::string error_input_name = input_name;
       ORT_THROW_IF_ERROR(ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                                         "Nv EP failed to call nvinfer1::IExecutionContext::setInputShape() for input '" + error_input_name + "'"));
+                                         "NvTensorRTRTX EP failed to call nvinfer1::IExecutionContext::setInputShape() for input '" + error_input_name + "'"));
     }
 
     // Bind "execution tensor" input buffer
@@ -734,7 +734,7 @@ Status BindContextInput(Ort::KernelContext& ctx,
       CASE_GET_CAST_INPUT_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE, double, float)
       default: {
         return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                               "Nv EP input onnx tensor data type: " + std::to_string(tensor_type) + " not supported.");
+                               "NvTensorRTRTX EP input onnx tensor data type: " + std::to_string(tensor_type) + " not supported.");
       }
     }
     trt_context->setTensorAddress(input_name, data);
@@ -821,7 +821,7 @@ Status BindContextOutput(Ort::KernelContext& ctx,
       CASE_GET_CAST_OUTPUT_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE, double, float)
       default: {
         return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                               "Nv EP output tensor data type: " + std::to_string(output_type) + " not supported.");
+                               "NvTensorRTRTX EP output tensor data type: " + std::to_string(output_type) + " not supported.");
       }
     }
     trt_context->setTensorAddress(output_name, buffers[output_name]);
@@ -885,7 +885,7 @@ Status BindKernelOutput(Ort::KernelContext& ctx,
     CASE_CAST_TENSOR(ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE, float, double)
     default: {
       return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                             "Nv EP output tensor data type: " + std::to_string(output_type) + " not supported.");
+                             "NvTensorRTRTX EP output tensor data type: " + std::to_string(output_type) + " not supported.");
     }
   }
   return Status::OK();
@@ -1192,13 +1192,13 @@ NvExecutionProvider::NvExecutionProvider(const NvExecutionProviderInfo& info)
     LIBTYPE handle = OPENLIB(engine_decryption_lib_path_.c_str());
     if (handle == nullptr) {
       ORT_THROW_IF_ERROR(ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                                         "Nv EP could not open shared library from " + engine_decryption_lib_path_));
+                                         "NvTensorRTRTX EP could not open shared library from " + engine_decryption_lib_path_));
     }
     engine_decryption_ = (int (*)(const char*, char*, size_t*))LIBFUNC(handle, "decrypt");
     engine_encryption_ = (int (*)(const char*, char*, size_t))LIBFUNC(handle, "encrypt");
     if (engine_decryption_ == nullptr) {
       ORT_THROW_IF_ERROR(ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                                         "Nv EP could not find decryption function in shared library from " + engine_decryption_lib_path_));
+                                         "NvTensorRTRTX EP could not find decryption function in shared library from " + engine_decryption_lib_path_));
     }
   }
 
@@ -2229,19 +2229,19 @@ common::Status NvExecutionProvider::RefitEngine(std::string onnx_model_filename,
     // A valid model bytestream must be passed.
     if (refit_from_file) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                             "TensorRT EP's refit with external data must be called with a valid ONNX model bytestream");
+                             "NvTensorRTRTX EP's refit with external data must be called with a valid ONNX model bytestream");
     }
 
     if (!parser_refitter->loadModelProto(onnx_model_bytestream, onnx_model_bytestream_size, nullptr)) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                             "TensorRT EP's IParserRefitter could not load model from provided onnx_model_bytestream");
+                             "NvTensorRTRTX EP's IParserRefitter could not load model from provided onnx_model_bytestream");
     }
 
     // Extract weight information from the Refitter.
     int required_weights = refitter->getAllWeights(0, nullptr);
     std::vector<char const*> refit_names(required_weights);
     refitter->getAllWeights(required_weights, refit_names.data());
-    LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Refitter requires " << required_weights << " weights";
+    LOGS_DEFAULT(VERBOSE) << "[NvTensorRTRTX EP] Refitter requires " << required_weights << " weights";
 
     // Vectors to keep track of data pointers.
     std::vector<std::string> names;
@@ -2265,7 +2265,7 @@ common::Status NvExecutionProvider::RefitEngine(std::string onnx_model_filename,
     // Extract graph and initializer information.
     auto const& graph = onnx_model->mutable_graph();
     allInitializers_byte_stream = graph->mutable_initializer();
-    LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Initializers that were found " << allInitializers_byte_stream->size();
+    LOGS_DEFAULT(VERBOSE) << "[NvTensorRTRTX EP] Initializers that were found " << allInitializers_byte_stream->size();
 
     // Loop through all initializers
     int missing_initializer_data = 0;
@@ -2295,7 +2295,7 @@ common::Status NvExecutionProvider::RefitEngine(std::string onnx_model_filename,
             sizes.push_back(length);
           } else {
             return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                                   "[TensorRT EP] Proto: " + proto_name + " expected to have external datalocation, but default datalocation was provided instead.");
+                                   "[NvTensorRTRTX EP] Proto: " + proto_name + " expected to have external datalocation, but default datalocation was provided instead.");
           }
         } else if (proto.has_raw_data()) {
           auto& raw_data = proto.raw_data();
@@ -2303,33 +2303,33 @@ common::Status NvExecutionProvider::RefitEngine(std::string onnx_model_filename,
           bytes.push_back(raw_data.c_str());
           sizes.push_back(raw_data.size());
         } else {
-          LOGS_DEFAULT(WARNING) << "[TensorRT EP] Proto: " + proto_name + " has no raw nor external data.";
+          LOGS_DEFAULT(WARNING) << "[NvTensorRTRTX EP] Proto: " + proto_name + " has no raw nor external data.";
           ++missing_initializer_data;
         }
       } else {
-        LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Initializer with name: " << proto_name << " was not marked as refittable";
+        LOGS_DEFAULT(VERBOSE) << "[NvTensorRTRTX EP] Initializer with name: " << proto_name << " was not marked as refittable";
       }
     }
     if (missing_initializer_data) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                             "[TensorRT EP] RefitEngine is missing " + std::to_string(missing_initializer_data) + " initializers.");
+                             "[NvTensorRTRTX EP] RefitEngine is missing " + std::to_string(missing_initializer_data) + " initializers.");
     }
 
     // Load extracted initializers into the parser
     if (!names.empty()) {
-      LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Number of initializers submitted to refitter " << names.size();
+      LOGS_DEFAULT(VERBOSE) << "[NvTensorRTRTX EP] Number of initializers submitted to refitter " << names.size();
       for (size_t i = 0; i < names.size(); i++) {
         bool refloadInit = parser_refitter->loadInitializer(names[i].c_str(), bytes[i], sizes[i]);
         if (!refloadInit) {
           return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                                 "TensorRT EP's IParserRefitter could not refit deserialized weight-stripped engine with weights contained in the provided bytestream");
+                                 "NvTensorRTRTX EP's IParserRefitter could not refit deserialized weight-stripped engine with weights contained in the provided bytestream");
         }
       }
     }
     // Perform refit.
     if (!parser_refitter->refitModelProto()) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                             "TensorRT EP's IParserRefitter refitModelProto() failed with the provided external data bytestream.");
+                             "NvTensorRTRTX EP's IParserRefitter refitModelProto() failed with the provided external data bytestream.");
     }
     refit_complete = true;
   }
@@ -2337,24 +2337,24 @@ common::Status NvExecutionProvider::RefitEngine(std::string onnx_model_filename,
   // If new refit flow was not completed, then fallback to refit_from_file.
   if (!refit_complete) {
     if (refit_from_file) {
-      LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Refitting from file on disk: " << onnx_model_path.string();
+      LOGS_DEFAULT(VERBOSE) << "[NvTensorRTRTX EP] Refitting from file on disk: " << onnx_model_path.string();
       if (!parser_refitter->refitFromFile(onnx_model_path.string().c_str())) {
         return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                               "TensorRT EP's IParserRefitter could not refit deserialized weight-stripped engine with weights contained in: " + onnx_model_path.string());
+                               "NvTensorRTRTX EP's IParserRefitter could not refit deserialized weight-stripped engine with weights contained in: " + onnx_model_path.string());
       }
     } else {
-      LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Refitting from byte array";
+      LOGS_DEFAULT(VERBOSE) << "[NvTensorRTRTX EP] Refitting from byte array";
       if (!parser_refitter->refitFromBytes(onnx_model_bytestream, onnx_model_bytestream_size)) {
         return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                               "TensorRT EP's IParserRefitter could not refit deserialized weight-stripped engine with weights contained in the provided bytestream");
+                               "NvTensorRTRTX EP's IParserRefitter could not refit deserialized weight-stripped engine with weights contained in the provided bytestream");
       }
     }
   }
   if (refitter->refitCudaEngine()) {
-    LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Successfully refitted the weight-stripped engine.";
+    LOGS_DEFAULT(VERBOSE) << "[NvTensorRTRTX EP] Successfully refitted the weight-stripped engine.";
   } else {
     return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                           "TensorRT EP's IRefitter could not refit deserialized weight-stripped engine with weights contained in: " + onnx_model_path.string());
+                           "NvTensorRTRTX EP's IRefitter could not refit deserialized weight-stripped engine with weights contained in: " + onnx_model_path.string());
   }
 
   // serialize the refitted engine to disk
@@ -2363,7 +2363,7 @@ common::Status NvExecutionProvider::RefitEngine(std::string onnx_model_filename,
     nvinfer1::IHostMemory* serialized_engine = trt_engine->serialize();
     std::ofstream engine_file(refitted_engine_cache, std::ios::binary | std::ios::out);
     engine_file.write(reinterpret_cast<const char*>(serialized_engine->data()), serialized_engine->size());
-    LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Serialize the refitted engine to " << refitted_engine_cache;
+    LOGS_DEFAULT(VERBOSE) << "[NvTensorRTRTX EP] Serialize the refitted engine to " << refitted_engine_cache;
   }
   return Status::OK();
 }
@@ -2713,12 +2713,12 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
     std::unique_ptr<nvinfer1::IHostMemory> serialized_engine{trt_builder->buildSerializedNetwork(*trt_network, *trt_config)};
     if (serialized_engine == nullptr) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                             "Nv EP failed to create engine from network for fused node: " + fused_node.Name());
+                             "NvTensorRTRTX EP failed to create engine from network for fused node: " + fused_node.Name());
     }
     trt_engine = std::unique_ptr<nvinfer1::ICudaEngine>(runtime_->deserializeCudaEngine(serialized_engine->data(), serialized_engine->size()));
     if (trt_engine == nullptr) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                             "Nv EP failed to deserialize engine for fused node: " + fused_node.Name());
+                             "NvTensorRTRTX EP failed to deserialize engine for fused node: " + fused_node.Name());
     }
     if (detailed_build_log_) {
       auto engine_build_stop = std::chrono::steady_clock::now();
@@ -2783,7 +2783,7 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
   }
   if (!trt_context) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                           "Nv EP could not build execution context for fused node: " + fused_node.Name());
+                           "NvTensorRTRTX EP could not build execution context for fused node: " + fused_node.Name());
   }
 
   // Create input to index map
@@ -2887,7 +2887,7 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
 
     if (multi_profile_enable_ == true) {
       if (!trt_context->setOptimizationProfileAsync(nv_profile_index_, stream))
-        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Nv EP select an optimization profile for the current context failed");
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "NvTensorRTRTX EP select an optimization profile for the current context failed");
     }
 
     // Name the engine cache based on GPU compute capacity and reduce the chance of loading an incompatible cache
@@ -2928,7 +2928,7 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
       // If there is any input tensor in shape_ranges, it means this input tensor has dynamic shape and its profile shape values have not yet resolved.
       // TRT EP will help determine the min/max/opt profile values based on current input tensor value.
       if (shape_ranges.find(input_name) != shape_ranges.end()) {
-        return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL, "Nv EP failed to parse input tensor and generate optimization profiles.");
+        return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL, "NvTensorRTRTX EP failed to parse input tensor and generate optimization profiles.");
       }
     }
 
@@ -3049,7 +3049,7 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
 
     // Run TRT inference
     if (!trt_context->enqueueV3(stream)) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Nv EP execution context enqueue failed.");
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "NvTensorRTRTX EP execution context enqueue failed.");
     }
 
     /*
@@ -3176,7 +3176,7 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromPrecompiledEngine(const Gra
   }
   if (!trt_context) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                           "Nv EP could not build execution context for fused node: " + fused_node.Name());
+                           "NvTensorRTRTX EP could not build execution context for fused node: " + fused_node.Name());
   }
 
   // Create input/output to index maps
@@ -3366,7 +3366,7 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromPrecompiledEngine(const Gra
 
     // Run TRT inference
     if (!trt_context->enqueueV3(stream)) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Nv EP execution context enqueue failed.");
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "NvTensorRTRTX EP execution context enqueue failed.");
     }
 
     /*

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.h
@@ -110,11 +110,26 @@ class OutputAllocator : public nvinfer1::IOutputAllocator {
  */
 using ShapeRangesMap = std::unordered_map<std::string, std::unordered_map<size_t, std::vector<std::vector<int64_t>>>>;
 
-// Struct to hold user weights when ModelProtos are serialized with external data
-struct TensorrtUserWeights {
-  std::string name{};
-  std::string data{};
-  int64_t size{};
+// Data structure to hold user weights when ModelProtos are serialized with external data
+class TensorrtUserWeights {
+ public:
+  TensorrtUserWeights(const std::string& name, const std::string& data) : name_(name), data_(data) {};
+
+  const char* Name() const {
+    return name_.c_str();
+  };
+
+  const void* Data() const {
+    return static_cast<void const*>(data_.data());
+  }
+
+  const int64_t Size() const {
+    return static_cast<int64_t>(data_.size());
+  }
+
+ private:
+  std::string name_{};
+  std::string data_{};
 };
 
 // Information to construct kernel function state.
@@ -236,8 +251,7 @@ class NvExecutionProvider : public IExecutionProvider {
                                     size_t onnx_external_data_bytestream_size,
                                     nvinfer1::ICudaEngine* trt_engine,
                                     bool serialize_refitted_engine,
-                                    bool detailed_build_log,
-                                    const GraphViewer* graph_body_viewer = nullptr);
+                                    bool detailed_build_log);
 
  private:
   mutable NvExecutionProviderInfo info_;
@@ -255,6 +269,7 @@ class NvExecutionProvider : public IExecutionProvider {
   std::string onnx_model_folder_path_;
   const void* onnx_model_bytestream_;
   size_t onnx_model_bytestream_size_;
+  bool use_external_data_initializer_ = false;
   const void* onnx_external_data_bytestream_ = nullptr;
   size_t onnx_external_data_bytestream_size_ = 0;
   bool sparsity_enable_ = false;

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.h
@@ -141,6 +141,7 @@ struct TensorrtFuncState {
   bool cuda_graph_enable = 0;
   std::string cache_prefix;
   std::string cache_suffix;
+  const GraphViewer* graph_viewer;
 };
 
 // Minimum information to construct kernel function state for direct engine load code path
@@ -224,9 +225,12 @@ class NvExecutionProvider : public IExecutionProvider {
                                     bool path_check,
                                     const void* onnx_model_bytestream,
                                     size_t onnx_model_bytestream_size,
+                                    const void* onnx_external_data_bytestream,
+                                    size_t onnx_external_data_bytestream_size,
                                     nvinfer1::ICudaEngine* trt_engine,
                                     bool serialize_refitted_engine,
-                                    bool detailed_build_log);
+                                    bool detailed_build_log,
+                                    const GraphViewer* graph_body_viewer = nullptr);
 
  private:
   mutable NvExecutionProviderInfo info_;
@@ -244,6 +248,8 @@ class NvExecutionProvider : public IExecutionProvider {
   std::string onnx_model_folder_path_;
   const void* onnx_model_bytestream_;
   size_t onnx_model_bytestream_size_;
+  const void* onnx_external_data_bytestream_ = nullptr;
+  size_t onnx_external_data_bytestream_size_ = 0;
   bool sparsity_enable_ = false;
   int auxiliary_streams_ = -1;
   std::string cache_path_, engine_decryption_lib_path_;

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.h
@@ -110,6 +110,13 @@ class OutputAllocator : public nvinfer1::IOutputAllocator {
  */
 using ShapeRangesMap = std::unordered_map<std::string, std::unordered_map<size_t, std::vector<std::vector<int64_t>>>>;
 
+// Struct to hold user weights when ModelProtos are serialized with external data
+struct TensorrtUserWeights {
+  std::string name{};
+  std::string data{};
+  int64_t size{};
+};
+
 // Information to construct kernel function state.
 struct TensorrtFuncState {
   AllocateFunc test_allocate_func = nullptr;
@@ -141,7 +148,7 @@ struct TensorrtFuncState {
   bool cuda_graph_enable = 0;
   std::string cache_prefix;
   std::string cache_suffix;
-  const GraphViewer* graph_viewer;
+  std::unique_ptr<std::vector<TensorrtUserWeights>> *userWeights = nullptr;
 };
 
 // Minimum information to construct kernel function state for direct engine load code path
@@ -309,6 +316,7 @@ class NvExecutionProvider : public IExecutionProvider {
   std::unordered_map<std::string, ShapeRangesMap> input_shape_ranges_;  // The profile shape ranges that the engine is built with
   std::unordered_map<std::string, std::vector<nvinfer1::IOptimizationProfile*>> profiles_;
   std::unordered_map<std::string, DDSOutputAllocatorMap> dds_output_allocator_maps_;
+  std::unordered_map<std::string, std::unique_ptr<std::vector<TensorrtUserWeights>>> weights_; // User provided weights
 
   // for external stream, we need to create its cudnn/cublass handle before cuda EP enable cuda graph capture
   cudnnHandle_t external_cudnn_handle_ = nullptr;

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_info.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_info.cc
@@ -49,6 +49,7 @@ NvExecutionProviderInfo NvExecutionProviderInfo::FromProviderOptions(const Provi
           .AddAssignmentToReference(nv::provider_option_names::kProfilesMaxShapes, info.profile_max_shapes)
           .AddAssignmentToReference(nv::provider_option_names::kProfilesOptShapes, info.profile_opt_shapes)
           .AddAssignmentToReference(nv::provider_option_names::kCudaGraphEnable, info.cuda_graph_enable)
+          .AddAssignmentToReference(nv::provider_option_names::kUseExternalDataInitializer, info.use_external_data_initializer)
           .AddAssignmentToReference(nv::provider_option_names::kMultiProfileEnable, info.multi_profile_enable)
           .AddValueParser(
               nv::provider_option_names::kONNXBytestream,
@@ -105,6 +106,8 @@ NvExecutionProviderInfo NvExecutionProviderInfo::FromProviderOptions(const Provi
     ORT_THROW("Invalid ", kOrtSessionOptionEpContextEmbedMode, " must 0 or 1");
   }
 
+  // info.use_external_data_initializer = true;
+
   return info;
 }
 
@@ -123,6 +126,7 @@ ProviderOptions NvExecutionProviderInfo::ToProviderOptions(const NvExecutionProv
       {nv::provider_option_names::kCudaGraphEnable, MakeStringWithClassicLocale(info.cuda_graph_enable)},
       {nv::provider_option_names::kONNXBytestream, MakeStringWithClassicLocale(info.onnx_bytestream)},
       {nv::provider_option_names::kONNXBytestreamSize, MakeStringWithClassicLocale(info.onnx_bytestream_size)},
+      {nv::provider_option_names::kUseExternalDataInitializer, MakeStringWithClassicLocale(info.use_external_data_initializer)},
       {nv::provider_option_names::kExternalDataBytestream, MakeStringWithClassicLocale(info.external_data_bytestream)},
       {nv::provider_option_names::kExternalDataBytestreamSize, MakeStringWithClassicLocale(info.external_data_bytestream_size)},
   };

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_info.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_info.cc
@@ -106,8 +106,6 @@ NvExecutionProviderInfo NvExecutionProviderInfo::FromProviderOptions(const Provi
     ORT_THROW("Invalid ", kOrtSessionOptionEpContextEmbedMode, " must 0 or 1");
   }
 
-  // info.use_external_data_initializer = true;
-
   return info;
 }
 

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_info.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_info.h
@@ -31,6 +31,7 @@ struct NvExecutionProviderInfo {
   std::string onnx_model_folder_path{""};
   const void* onnx_bytestream{nullptr};
   size_t onnx_bytestream_size{0};
+  bool use_external_data_initializer{false};
   const void* external_data_bytestream{nullptr};
   size_t external_data_bytestream_size{0};
   bool engine_decryption_enable{false};

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_info.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_info.h
@@ -31,6 +31,8 @@ struct NvExecutionProviderInfo {
   std::string onnx_model_folder_path{""};
   const void* onnx_bytestream{nullptr};
   size_t onnx_bytestream_size{0};
+  const void* external_data_bytestream{nullptr};
+  size_t external_data_bytestream_size{0};
   bool engine_decryption_enable{false};
   std::string engine_decryption_lib_path{""};
   bool force_sequential_engine_build{false};

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.cc
@@ -301,6 +301,8 @@ Status TensorRTCacheModelHandler::GetEpContextFromGraph(const GraphViewer& graph
                                                      make_secure_path_checks,
                                                      onnx_model_bytestream_,
                                                      onnx_model_bytestream_size_,
+                                                     onnx_external_data_bytestream_,
+                                                     onnx_external_data_bytestream_size_,
                                                      (*trt_engine_).get(),
                                                      false /* serialize refitted engine to disk */,
                                                      detailed_build_log_);
@@ -370,6 +372,8 @@ Status TensorRTCacheModelHandler::GetEpContextFromGraph(const GraphViewer& graph
                                                      make_secure_path_checks,
                                                      onnx_model_bytestream_,
                                                      onnx_model_bytestream_size_,
+                                                     onnx_external_data_bytestream_,
+                                                     onnx_external_data_bytestream_size_,
                                                      (*trt_engine_).get(),
                                                      true /* serialize refitted engine to disk */,
                                                      detailed_build_log_);

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.h
@@ -55,6 +55,8 @@ class TensorRTCacheModelHandler {
                             std::string onnx_model_folder_path,
                             const void* onnx_model_bytestream,
                             size_t onnx_model_bytestream_size,
+                            const void* onnx_external_data_bytestream,
+                            size_t onnx_external_data_bytestream_size,
                             bool detailed_build_log)
       : trt_engine_(trt_engine),
         trt_runtime_(trt_runtime),
@@ -64,6 +66,8 @@ class TensorRTCacheModelHandler {
         onnx_model_folder_path_(onnx_model_folder_path),
         onnx_model_bytestream_(onnx_model_bytestream),
         onnx_model_bytestream_size_(onnx_model_bytestream_size),
+        onnx_external_data_bytestream_(onnx_external_data_bytestream),
+        onnx_external_data_bytestream_size_(onnx_external_data_bytestream_size),
         detailed_build_log_(detailed_build_log) {
   }
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(TensorRTCacheModelHandler);
@@ -81,6 +85,8 @@ class TensorRTCacheModelHandler {
   std::string onnx_model_folder_path_;
   const void* onnx_model_bytestream_;
   size_t onnx_model_bytestream_size_;
+  const void* onnx_external_data_bytestream_;
+  size_t onnx_external_data_bytestream_size_;
   bool detailed_build_log_;
 };  // TRTCacheModelHandler
 }  // namespace onnxruntime

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1679,8 +1679,10 @@ def run_onnxruntime_tests(args, source_dir, ctest_path, build_dir, configs):
             run_ios_tests(args, source_dir, config, cwd)
             continue
         dll_path_list = []
-        if args.use_tensorrt or args.use_nv_tensorrt_rtx:
+        if args.use_tensorrt:
             dll_path_list.append(os.path.join(args.tensorrt_home, "lib"))
+        if args.use_nv_tensorrt_rtx:
+            dll_path_list.append(os.path.join(args.tensorrt_rtx_home, "lib"))
 
         dll_path = None
         if len(dll_path_list) > 0:


### PR DESCRIPTION
This PR adds support for user provided external initializers which are already in memory, instead of loading from disk. 

Adds 3 new EP options:
* `nv_use_external_data_initializer` : when enabled, EP will own the weights in memory, instead of serializing it to ModelProto. This helps to run models >2GB
* `nv_external_data_bytestream` : bytestream for external data
* `nv_external_data_bytestream_size` : bytestream size for external data

These are implemented with new `loadModelProto` and `loadIntializer` APIs available in TRT RTX 1.1 onwards