### PR TITLE
Upgrade onnxruntime-Ubuntu2204-AMD-CPU machine pool to 24.04

### DIFF
--- a/tools/ci_build/github/azure-pipelines/build-perf-test-binaries-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/build-perf-test-binaries-pipeline.yml
@@ -20,13 +20,17 @@ stages:
         artifactName: 'onnxruntime-android-full-aar'
         job_name_suffix: 'Full'
         publish_executables: '1'
-        pool_name: 'onnxruntime-Ubuntu2204-AMD-CPU'
+        pool_name: 'onnxruntime-Ubuntu2404-AMD-CPU'
         enable_code_sign: false
 
 # build Python packages
 # Linux GPU only
 - ${{ if parameters.BuildPythonPackages }}:
-  - template: stages/py-gpu-packaging-stage.yml
+  - template: stages/py-linux-gpu-stage.yml
     parameters:
-      enable_linux_cuda: true
-      cuda_version: 12.2
+        arch: 'x86_64'
+        machine_pool: 'onnxruntime-Ubuntu2404-AMD-CPU'
+        extra_build_arg: ''
+        cmake_build_type: Release
+        cuda_version: 12.2
+        docker_base_image: onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntime/build/cuda12_x64_almalinux8_gcc12:20250714.2

--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-test-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-test-pipelines.yml
@@ -75,6 +75,16 @@ stages:
       artifactName: 'onnxruntime-android-full-aar'
       ReleaseVersionSuffix: $(ReleaseVersionSuffix)
 
+- stage: Final_AAR_Testing_Android_QNN
+  dependsOn: Setup
+  jobs:
+  - template: templates/android-java-api-aar-test.yml
+    parameters:
+      artifactName: 'onnxruntime-android-qnn-aar'
+      packageName: 'onnxruntime-android-qnn'
+      #TODO: get this information from the setup stage
+      QnnSDKVersion: '2.36.1.250708'
+
 - template: nuget/templates/test_win.yml
   parameters:
     AgentPool: 'onnxruntime-Win-CPU-2022'

--- a/tools/ci_build/github/azure-pipelines/dml-nuget-packaging.yml
+++ b/tools/ci_build/github/azure-pipelines/dml-nuget-packaging.yml
@@ -68,7 +68,6 @@ extends:
         ArtifactName: 'drop-nuget-dml'
         StageName: 'Windows_CI_GPU_DML_Dev'
         BuildCommand: --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --enable_onnx_tests --enable_wcos --use_telemetry --use_dml --enable_generic_interface --build_nodejs --cmake_generator "Visual Studio 17 2022" --use_vcpkg --use_vcpkg_ms_internal_asset_cache
-        BuildArch: 'x64'
         msbuildArchitecture: 'amd64'
         EnvSetupScript: 'setup_env.bat'
         sln_platform: 'x64'
@@ -88,7 +87,6 @@ extends:
         ArtifactName: 'drop-win-dml-arm64-zip'
         StageName: 'Windows_CI_GPU_DML_Dev_arm64'
         BuildCommand: --build_dir $(Build.BinariesDirectory) --arm64 --skip_submodule_sync --build_shared_lib --enable_onnx_tests --enable_wcos --use_telemetry --use_dml --enable_generic_interface --build_nodejs --cmake_generator "Visual Studio 17 2022" --use_vcpkg --use_vcpkg_ms_internal_asset_cache
-        BuildArch: 'x64'
         EnvSetupScript: 'setup_env.bat'
         sln_platform: 'arm64'
         DoDebugBuild: 'false'

--- a/tools/ci_build/github/azure-pipelines/mac-react-native-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-react-native-ci-pipeline.yml
@@ -55,5 +55,5 @@ stages:
   parameters:
     NpmPackagingMode: ${{ variables.NpmPackagingMode }}
     BuildConfig: 'Release'
-    PoolName: 'onnxruntime-Ubuntu2204-AMD-CPU'
+    PoolName: 'onnxruntime-Ubuntu2404-AMD-CPU'
     enable_code_sign: false

--- a/tools/ci_build/github/azure-pipelines/nodejs/templates/test.yml
+++ b/tools/ci_build/github/azure-pipelines/nodejs/templates/test.yml
@@ -1,10 +1,12 @@
 steps:
 - checkout: none
-- task: DownloadPipelineArtifact@0
-  displayName: 'Download NPM packages'
-  inputs:
-    artifactName: NPM_packages
-    targetPath: '$(Build.BinariesDirectory)/nodejs-artifact'
+- download: build
+  displayName: 'Download NPM_packages'
+  artifact: 'NPM_packages'
+
+- script: |
+    mv $(Pipeline.Workspace)/build/NPM_packages '$(Build.BinariesDirectory)/nodejs-artifact'
+
 - script: mkdir e2e_test
   workingDirectory: '$(Build.BinariesDirectory)'
 
@@ -32,5 +34,3 @@ steps:
     npm install $(NpmPackageFilesForTest) --onnxruntime-node-install-cuda=skip
     node -p "require('onnxruntime-node')"
   workingDirectory: '$(Build.BinariesDirectory)/e2e_test'
-
-- template: ../../templates/clean-agent-build-directory-step.yml

--- a/tools/ci_build/github/azure-pipelines/nodejs/templates/test_linux.yml
+++ b/tools/ci_build/github/azure-pipelines/nodejs/templates/test_linux.yml
@@ -13,7 +13,6 @@ stages:
     timeoutInMinutes: 120
     pool:
       name: ${{ parameters.AgentPool }}
-      os: 'linux'
 
     variables:
     - name: OnnxRuntimeBuildDirectory

--- a/tools/ci_build/github/azure-pipelines/nodejs/templates/test_macos.yml
+++ b/tools/ci_build/github/azure-pipelines/nodejs/templates/test_macos.yml
@@ -12,7 +12,7 @@ stages:
     timeoutInMinutes:  120
     pool:
       name: 'Azure Pipelines'
-      image: 'macOS-14'
+      image: 'macOS-15'
       os: 'macOS'
 
     variables:

--- a/tools/ci_build/github/azure-pipelines/npm-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/npm-packaging-pipeline.yml
@@ -55,7 +55,7 @@ extends:
       parameters:
         NpmPackagingMode: ${{ variables.NpmPackagingMode }}
         IsReleasePipeline: true
-        PoolName: 'onnxruntime-Ubuntu2204-AMD-CPU'
+        PoolName: 'onnxruntime-Ubuntu2404-AMD-CPU'
         PackageName: 'onnxruntime-web'
         ExtraBuildArgs: ''
         UseWebPoolName: true
@@ -69,7 +69,7 @@ extends:
       parameters:
         NpmPackagingMode: ${{ variables.NpmPackagingMode }}
         BuildConfig: 'Release'
-        PoolName: 'onnxruntime-Ubuntu2204-AMD-CPU'
+        PoolName: 'onnxruntime-Ubuntu2404-AMD-CPU'
         PackageName: 'onnxruntime-react-native'
         InitialStageDependsOn: 'Precheck_and_extract_commit'
         enable_code_sign: false

--- a/tools/ci_build/github/azure-pipelines/nuget-windows-ai.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget-windows-ai.yml
@@ -100,7 +100,7 @@ extends:
           - output: pipelineArtifact
             path: '$(Build.ArtifactStagingDirectory)/merged'
             artifact: drop_Windows_Build_NuGet_Packaging
-          - ${{if and(eq(parameters.IsReleaseBuild, false), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/users/snnn/')))}}:
+          - ${{if and(eq(parameters.IsReleaseBuild, false), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/rel-')))}}:
             - output: nuget
               useDotNetTask: false # The default is false to use the NuGetCommand task. Set to true to use the DotNetCoreCLI task to publish packages.
               packagesToPush: '$(Build.ArtifactStagingDirectory)/merged/*.nupkg;!$(Build.ArtifactStagingDirectory)/merged/*.symbols.nupkg'

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/dml-vs-2022.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/dml-vs-2022.yml
@@ -6,11 +6,8 @@ parameters:
   DoNugetPack:  'false'
   NuPackScript : ''
   ArtifactName: 'drop-nuget'
-  DoNodejsPack: 'false'
-  BuildNodejs: 'true'
   DoEsrp: 'false'
   DoTestCoverage: 'false'
-  BuildArch: 'x64' # Optional. Options: x86, x64
   sln_platform: 'x64' # Options: Win32, x64, arm, arm64
   EnvSetupScript: 'setup_env.bat'
   AgentDemands: []
@@ -40,7 +37,6 @@ stages:
     variables:
       buildDirectory: '$(Build.BinariesDirectory)'
       OnnxRuntimeBuildDirectory: '$(Build.BinariesDirectory)'
-      runCodesignValidationInjection: and(${{ parameters.DoNodejsPack }},${{ parameters. DoEsrp}}) #For the others, code sign is in a separated job
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
       ALLOW_RELEASED_ONNX_OPSET_ONLY: ${{ parameters.AllowReleasedOpsetOnly }}
       BuildDate : $[stageDependencies.Setup.Set_Variables.outputs['Set_Build_Date.BuildDate']]
@@ -63,7 +59,7 @@ stages:
         inputs:
           versionSpec: '3.12'
           addToPath: true
-          architecture: ${{ parameters.BuildArch }}
+          architecture: x64
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
@@ -74,13 +70,13 @@ stages:
         inputs:
           version: 8.x
         env:
-          PROCESSOR_ARCHITECTURE: ${{ parameters.BuildArch }}
+          PROCESSOR_ARCHITECTURE: x64
 
       - task: BatchScript@1
         displayName: 'Setup VS2022 env vars'
         inputs:
           filename: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat'
-          arguments: ${{ parameters.BuildArch }}
+          arguments: x64
           modifyEnvironment: true
 
       - ${{ if notIn(parameters['sln_platform'], 'Win32', 'x64') }}:
@@ -114,7 +110,7 @@ stages:
           inputs:
             version: 6.x
           env:
-            PROCESSOR_ARCHITECTURE: ${{ parameters.BuildArch }}
+            PROCESSOR_ARCHITECTURE: x64
 
         - template: ../../templates/win-esrp-dll.yml
           parameters:
@@ -148,64 +144,10 @@ stages:
               ${{if eq(variables['Build.SourceBranch'], 'refs/heads/main')}}:
                 symbolExpiryTime: 60
               includePublicSymbolServer: true
-              symbolsArtifactName: onnxruntime-dml-nuget-${{ parameters.BuildArch }}
+              symbolsArtifactName: onnxruntime-dml-nuget-${{ parameters.sln_platform }}
               symbolsVersion: $(Build.BuildId)
               symbolProject: 'ONNX Runtime'
               subscription: 'OnnxrunTimeCodeSign_20240611'
               searchPattern: |
                 $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\onnxruntime.pdb
                 $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\onnxruntime_providers_*.pdb
-
-      # Node.js Publish
-      - ${{ if eq(parameters['DoNodejsPack'], 'true') }}:
-        - task: BatchScript@1
-          displayName: 'Setup VS env vars'
-          inputs:
-            filename: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat'
-            arguments: ${{ parameters.BuildArch }}
-            modifyEnvironment: true
-        - template: ../../templates/win-esrp-dll.yml
-          parameters:
-            FolderPath: '$(Build.SourcesDirectory)\js\node\bin\napi-v6\win32\x64'
-            DisplayName: 'ESRP - Sign Node.js binding binaries'
-            DoEsrp: ${{ parameters.DoEsrp }}
-            Pattern: '*.dll,*.node'
-
-        - script: |
-           del /Q $(Build.SourcesDirectory)\js\node\bin\napi-v6\win32\x64\CodeSignSummary-*.*
-           call npm pack
-           copy $(Build.SourcesDirectory)\js\node\onnxruntime-*.tgz $(Build.ArtifactStagingDirectory)
-           xcopy /E /I $(Build.SourcesDirectory)\js\node\prebuilds $(Build.ArtifactStagingDirectory)\prebuilds
-          workingDirectory: '$(Build.SourcesDirectory)\js\node'
-          displayName: 'Create NPM Package'
-
-        - task: 1ES.PublishPipelineArtifact@1
-          displayName: 'Publish Pipeline Artifact: ${{ parameters.ArtifactName }}'
-          inputs:
-            artifactName: ${{ parameters.ArtifactName }}
-            targetPath: '$(Build.ArtifactStagingDirectory)'
-
-        # Put an unzipped version there to check if all the binaries are signed.
-        - script: |
-           7z x $(Build.ArtifactStagingDirectory)\prebuilds\onnxruntime-*.tar.gz
-           7z x $(Build.ArtifactStagingDirectory)\onnxruntime-*.tar
-          displayName: 'Unzip package to test'
-          workingDirectory: '$(Build.ArtifactStagingDirectory)'
-
-      - ${{ if eq(parameters.BuildNodejs, 'true') }}:
-        - task: CopyFiles@2
-          displayName: 'Copy DirectML binaries to: $(Build.SourcesDirectory)\js\node\bin\napi-v6\win32\${{ parameters.sln_platform }}'
-          inputs:
-            SourceFolder: '$(Build.BinariesDirectory)\$(BuildConfig)\$(BuildConfig)'
-            Contents: 'DirectML.dll'
-            TargetFolder: '$(Build.SourcesDirectory)\js\node\bin\napi-v6\win32\${{ parameters.sln_platform }}'
-        - template: ../../templates/win-esrp-dll.yml
-          parameters:
-            FolderPath: '$(Build.SourcesDirectory)\js\node\bin\napi-v6\win32\${{ parameters.sln_platform }}'
-            DisplayName: 'ESRP - Sign Node.js binding binaries'
-            DoEsrp: ${{ parameters.DoEsrp }}
-            Pattern: '*.node'
-        - task: 1ES.PublishPipelineArtifact@1
-          inputs:
-            targetPath: '$(Build.SourcesDirectory)\js\node\bin\napi-v6\win32\${{ parameters.sln_platform }}'
-            artifactName: 'drop-onnxruntime-nodejs-win-${{ parameters.sln_platform }}-dml'

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_android.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_android.yml
@@ -24,17 +24,13 @@ stages:
         inputs:
           versionSpec: 6.10.x
 
-      - template: ../../templates/flex-downloadPipelineArtifact.yml
-        parameters:
-          StepName: 'Download Pipeline Artifact'
-          ArtifactName: drop-signed-nuget-${{ parameters.ArtifactSuffix }}
-          TargetPath: '$(Build.BinariesDirectory)\nuget-artifact'
-          SpecificArtifact: ${{ parameters.SpecificArtifact }}
-          BuildId: ${{ parameters.BuildId }}
+      - download: build
+        displayName: 'Download Nuget'
+        artifact: 'drop-signed-nuget-${{ parameters.ArtifactSuffix }}'
 
       - template: get-nuget-package-version-as-variable.yml
         parameters:
-          packageFolder: '$(Build.BinariesDirectory)\nuget-artifact'
+          packageFolder: '$(Pipeline.Workspace)/build/drop-signed-nuget-${{ parameters.ArtifactSuffix }}'
 
       - task: PowerShell@2
         displayName: Install MAUI workloads
@@ -49,7 +45,7 @@ stages:
         inputs:
           targetType: 'inline'
           script: |
-            dotnet nuget add source $(Build.BinariesDirectory)\nuget-artifact --name local-nuget
+            dotnet nuget add source $(Pipeline.Workspace)/build/drop-signed-nuget-${{ parameters.ArtifactSuffix }} --name local-nuget
             dotnet publish -c Release --property:UsePrebuiltNativePackage=true --property:CurrentOnnxRuntimeVersion=$(NuGetPackageVersionNumber) -f net8.0-android
           workingDirectory: '$(Build.SourcesDirectory)\csharp\test\Microsoft.ML.OnnxRuntime.Tests.MAUI'
 

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_linux.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_linux.yml
@@ -1,5 +1,5 @@
 parameters:
-  AgentPool: 'onnxruntime-Ubuntu2204-AMD-CPU'
+  AgentPool: 'onnxruntime-Ubuntu2404-AMD-CPU'
   ArtifactSuffix: ''
   NugetPackageName: ''
   StageSuffix: 'CPU'
@@ -30,21 +30,18 @@ stages:
       value: '$(Build.BinariesDirectory)'
 
     steps:
-    - template: ../../templates/flex-downloadPipelineArtifact.yml
-      parameters:
-        StepName: 'Download Signed NuGet'
-        ArtifactName: drop-signed-nuget-${{ parameters.ArtifactSuffix }}
-        TargetPath: '$(Build.BinariesDirectory)/nuget-artifact'
-        SpecificArtifact: ${{ parameters.SpecificArtifact }}
-        BuildId: ${{ parameters.BuildId }}
+    - download: build
+      displayName: 'Download Nuget'
+      artifact: 'drop-signed-nuget-${{ parameters.ArtifactSuffix }}'
+    - download: build
+      displayName: 'Download Linux CustomOp TestData'
+      artifact: ${{ parameters.CustomOpArtifactName }}
 
-    - template: ../../templates/flex-downloadPipelineArtifact.yml
-      parameters:
-        StepName: 'Download Linux CustomOp TestData'
-        ArtifactName: ${{ parameters.CustomOpArtifactName }}
-        TargetPath: '$(Build.BinariesDirectory)/testdata'
-        SpecificArtifact: ${{ parameters.specificArtifact }}
-        BuildId: ${{ parameters.BuildId }}
+
+    - script: |
+        mv $(Pipeline.Workspace)/build/drop-signed-nuget-${{ parameters.ArtifactSuffix }} $(Build.BinariesDirectory)/nuget-artifact
+        mv $(Pipeline.Workspace)/build/${{ parameters.CustomOpArtifactName }} $(Build.BinariesDirectory)/testdata
+   
 
     - template: get-nuget-package-version-as-variable.yml
       parameters:
@@ -111,5 +108,3 @@ stages:
           DisableMlOps: $(DisableMlOps)
           IsReleaseBuild: $(IsReleaseBuild)
           PACKAGENAME: ${{ parameters.NugetPackageName }}
-
-    - template: ../../templates/clean-agent-build-directory-step.yml

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_macos.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_macos.yml
@@ -21,23 +21,19 @@ stages:
       displayName: 'Download Nuget'
       artifact: 'drop-signed-nuget-${{ parameters.ArtifactSuffix }}'
 
+    - download: build
+      displayName: 'Download Nuget'
+      artifact: 'onnxruntime-osx'
 
     - script: |
         mv $(Pipeline.Workspace)/build/drop-signed-nuget-${{ parameters.ArtifactSuffix }} $(Build.BinariesDirectory)/nuget-artifact
-  
-
-    - task: DownloadPipelineArtifact@0
-      displayName: 'Download OsX CustomOp test data'
-      inputs:
-        artifactName: 'onnxruntime-osx'
-        targetPath: '$(Build.BinariesDirectory)/testdata'
+        mv $(Pipeline.Workspace)/build/onnxruntime-osx $(Build.BinariesDirectory)/testdata
 
     - template: get-nuget-package-version-as-variable.yml
       parameters:
         packageFolder: '$(Build.BinariesDirectory)/nuget-artifact'
 
     - script: |
-       echo "TODO: Enable this test once fix this nuget test issue"
        $(Build.SourcesDirectory)/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh \
                  $(Build.BinariesDirectory)/nuget-artifact \
                  $(NuGetPackageVersionNumber) \
@@ -53,5 +49,3 @@ stages:
           DisableContribOps: $(DisableContribOps)
           DisableMlOps: $(DisableMlOps)
           IsReleaseBuild: $(IsReleaseBuild)
-
-    - template: ../../templates/clean-agent-build-directory-step.yml

--- a/tools/ci_build/github/azure-pipelines/post-merge-jobs.yml
+++ b/tools/ci_build/github/azure-pipelines/post-merge-jobs.yml
@@ -19,7 +19,7 @@ stages:
   parameters:
     NpmPackagingMode: 'dev'
     IsReleasePipeline: true
-    PoolName: 'onnxruntime-Ubuntu2204-AMD-CPU'
+    PoolName: 'onnxruntime-Ubuntu2404-AMD-CPU'
     BuildStaticLib: true
     ExtraBuildArgs: ''
     UseWebPoolName: true
@@ -340,7 +340,7 @@ stages:
     timeoutInMinutes: 150
     variables:
       skipComponentGovernanceDetection: true
-    pool: 'onnxruntime-Ubuntu2204-AMD-CPU'
+    pool: 'onnxruntime-Ubuntu2404-AMD-CPU'
     steps:
     - template: templates/set-version-number-variables-step.yml
 
@@ -383,7 +383,7 @@ stages:
   - job: AndroidCustomBuildScript
     workspace:
       clean: all
-    pool: 'onnxruntime-Ubuntu2204-AMD-CPU'
+    pool: 'onnxruntime-Ubuntu2404-AMD-CPU'
     variables:
       dockerImageTag: onnxruntime-android-custom-build
     steps:

--- a/tools/ci_build/github/azure-pipelines/py-cuda-package-test-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/py-cuda-package-test-pipeline.yml
@@ -25,7 +25,7 @@ stages:
     dependsOn:
     jobs:
     - job: Python_Publishing_GPU
-      pool: 'onnxruntime-Ubuntu2204-AMD-CPU'
+      pool: 'onnxruntime-Ubuntu2404-AMD-CPU'
       steps:
       - checkout: none
       - download: build

--- a/tools/ci_build/github/azure-pipelines/py-package-test-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/py-package-test-pipeline.yml
@@ -11,7 +11,7 @@ stages:
   - template: templates/py-packaging-linux-test-cpu.yml
     parameters:
       arch: 'x86_64'
-      machine_pool: 'onnxruntime-Ubuntu2204-AMD-CPU'
+      machine_pool: 'onnxruntime-Ubuntu2404-AMD-CPU'
 
 
 - stage: Linux_Test_CPU_aarch64_stage
@@ -38,7 +38,7 @@ stages:
         itemPattern: '*/*manylinux*x86_64.whl'
         arch: 'x86_64'
         machine_pool:
-          name: 'onnxruntime-Ubuntu2204-AMD-CPU'
+          name: 'onnxruntime-Ubuntu2404-AMD-CPU'
 
 # ****The following Stage depend on all previous tags. ***
 

--- a/tools/ci_build/github/azure-pipelines/stages/c-api-linux-cpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/c-api-linux-cpu-stage.yml
@@ -6,6 +6,6 @@ stages:
     parameters:
       OnnxruntimeArch: 'x64'
       OnnxruntimeNodejsBindingArch: 'x64'
-      PoolName: 'onnxruntime-Ubuntu2204-AMD-CPU'
+      PoolName: 'onnxruntime-Ubuntu2404-AMD-CPU'
       PackageJava: false
       PackageNodeJS: false

--- a/tools/ci_build/github/azure-pipelines/stages/download-java-tools-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/download-java-tools-stage.yml
@@ -4,7 +4,7 @@ stages:
   jobs:
   - job: Download_Java_Tools
     pool:
-      name: 'onnxruntime-Ubuntu2204-AMD-CPU'
+      name: 'onnxruntime-Ubuntu2404-AMD-CPU'
       os: linux
     steps:
     - checkout: none

--- a/tools/ci_build/github/azure-pipelines/stages/nodejs-linux-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nodejs-linux-packaging-stage.yml
@@ -13,7 +13,7 @@ stages:
       clean: all
     timeoutInMinutes: 180
     pool:
-      name: 'onnxruntime-Ubuntu2204-AMD-CPU'
+      name: 'onnxruntime-Ubuntu2404-AMD-CPU'
       os: linux
     variables:
     - template: ../templates/common-variables.yml

--- a/tools/ci_build/github/azure-pipelines/stages/nuget-linux-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nuget-linux-cuda-packaging-stage.yml
@@ -16,7 +16,7 @@ stages:
       clean: all
     timeoutInMinutes: 150
     pool:
-      name: 'onnxruntime-Ubuntu2204-AMD-CPU'
+      name: 'onnxruntime-Ubuntu2404-AMD-CPU'
       os: linux
     variables:
     - name: CUDA_VERSION_MAJOR
@@ -65,7 +65,7 @@ stages:
       clean: all
     timeoutInMinutes: 180
     pool:
-      name: 'onnxruntime-Ubuntu2204-AMD-CPU'
+      name: 'onnxruntime-Ubuntu2404-AMD-CPU'
       os: linux
     variables:
     - template: ../templates/common-variables.yml

--- a/tools/ci_build/github/azure-pipelines/stages/nuget_dml_packaging_stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nuget_dml_packaging_stage.yml
@@ -29,7 +29,7 @@ stages:
         artifactName: drop-win-dml-arm64-zip
         targetPath: '$(Build.BinariesDirectory)/nuget-artifact-dml'
       outputs:
-        - ${{if and(eq(parameters.IsReleaseBuild, false), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/users/snnn/')))}}:
+        - ${{if and(eq(parameters.IsReleaseBuild, false), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/rel-')))}}:
           - output: nuget
             useDotNetTask: false # The default is false to use the NuGetCommand task. Set to true to use the DotNetCoreCLI task to publish packages.
             packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'

--- a/tools/ci_build/github/azure-pipelines/stages/py-cpu-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/py-cpu-packaging-stage.yml
@@ -302,7 +302,7 @@ stages:
     - template: ../templates/py-linux.yml
       parameters:
         arch: 'x86_64'
-        machine_pool: 'onnxruntime-Ubuntu2204-AMD-CPU-Large'
+        machine_pool: 'onnxruntime-Ubuntu2404-AMD-CPU'
         extra_build_arg: ${{ parameters.build_py_parameters }}
         cmake_build_type: ${{ parameters.cmake_build_type }}
         is1ES: true
@@ -346,7 +346,7 @@ stages:
     jobs:
     - template: ../templates/py-linux-qnn.yml
       parameters:
-        machine_pool: 'onnxruntime-Ubuntu2204-AMD-CPU'
+        machine_pool: 'onnxruntime-Ubuntu2404-AMD-CPU'
         extra_build_arg: ${{ parameters.build_py_parameters }}
         cmake_build_type: ${{ parameters.cmake_build_type }}
         is1ES: true

--- a/tools/ci_build/github/azure-pipelines/stages/py-cuda-publishing-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/py-cuda-publishing-stage.yml
@@ -8,7 +8,7 @@ stages:
   jobs:
   - job: Python_Publishing_GPU
     pool:
-      name: 'onnxruntime-Ubuntu2204-AMD-CPU'
+      name: 'onnxruntime-Ubuntu2404-AMD-CPU'
       os: linux
     steps:
     - checkout: none

--- a/tools/ci_build/github/azure-pipelines/stages/py-gpu-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/py-gpu-packaging-stage.yml
@@ -45,7 +45,7 @@ stages:
     - template: py-linux-gpu-stage.yml
       parameters:
           arch: 'x86_64'
-          machine_pool: 'onnxruntime-Ubuntu2204-AMD-CPU-Large'
+          machine_pool: 'onnxruntime-Ubuntu2404-AMD-CPU'
           extra_build_arg: ${{ parameters.build_py_parameters }}
           cmake_build_type: ${{ parameters.cmake_build_type }}
           cuda_version: ${{ parameters.cuda_version }}

--- a/tools/ci_build/github/azure-pipelines/stages/set_packaging_variables_stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/set_packaging_variables_stage.yml
@@ -24,7 +24,7 @@ stages:
   jobs:
   - job: Set_Variables
     pool:
-      name: 'onnxruntime-Ubuntu2204-AMD-CPU'
+      name: 'onnxruntime-Ubuntu2404-AMD-CPU'
       os: 'linux'
     templateContext:
       sdl:

--- a/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar-test.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar-test.yml
@@ -29,7 +29,7 @@ parameters:
 jobs:
 - job: Final_AAR_Testing_Android
   pool:
-    name: 'onnxruntime-Ubuntu2204-AMD-CPU'
+    name: 'onnxruntime-Ubuntu2404-AMD-CPU'
     os: linux
   workspace:
     clean: all

--- a/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar.yml
@@ -33,7 +33,7 @@ parameters:
 - name: pool_name
   displayName: Pool name
   type: string
-  default: 'onnxruntime-Ubuntu2204-AMD-CPU'
+  default: 'onnxruntime-Ubuntu2404-AMD-CPU'
 
 - name: packageName
   displayName: Package Name

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -100,15 +100,6 @@ stages:
       QnnSDKVersion: ${{ parameters.QnnSDKVersion }}
       is1ES: ${{ parameters.is1ES }}
 
-- stage: Final_AAR_Testing_Android_QNN
-  dependsOn: Android_Java_API_AAR_Packaging_QNN
-  jobs:
-  - template: android-java-api-aar-test.yml
-    parameters:
-      artifactName: 'onnxruntime-android-qnn-aar'
-      packageName: 'onnxruntime-android-qnn'
-      QnnSDKVersion: ${{ parameters.QnnSDKVersion }}
-
 - stage: iOS_Full_xcframework
   dependsOn: []
   jobs:

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -16,7 +16,7 @@ parameters:
 
 - name: PoolName
   type: string
-  default: 'onnxruntime-Ubuntu2204-AMD-CPU'
+  default: 'onnxruntime-Ubuntu2404-AMD-CPU'
 
 - name: ArtifactNamePrefix
   type: string

--- a/tools/ci_build/github/azure-pipelines/templates/linux-cpu-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-cpu-packaging-pipeline.yml
@@ -31,7 +31,7 @@ stages:
       AdditionalBuildFlags: ${{ parameters.AdditionalBuildFlags }}
       OnnxruntimeArch: 'x64'
       OnnxruntimeNodejsBindingArch: 'x64'
-      PoolName: 'onnxruntime-Ubuntu2204-AMD-CPU'
+      PoolName: 'onnxruntime-Ubuntu2404-AMD-CPU'
       ArtifactNamePrefix: ${{ parameters.ArtifactNamePrefix }}
       PackageJava: ${{ parameters.PackageJava }}
       PackageNodeJS: false

--- a/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
@@ -13,7 +13,7 @@ parameters:
 
 - name: PoolName
   type: string
-  default: 'onnxruntime-Ubuntu2204-AMD-CPU'
+  default: 'onnxruntime-Ubuntu2404-AMD-CPU'
 
 - name: SkipPublish
   type: boolean

--- a/tools/ci_build/github/azure-pipelines/templates/qnn-ep-win.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/qnn-ep-win.yml
@@ -29,7 +29,7 @@ stages:
           enabled: true
           scanOutputDirectoryOnly: true
       outputs:
-      - ${{if and(and(eq(parameters.PublishNugetToFeed, true), eq(parameters.IsReleaseBuild, false)), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/users/snnn/')))}}:
+      - ${{if and(and(eq(parameters.PublishNugetToFeed, true), eq(parameters.IsReleaseBuild, false)), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/rel-')))}}:
         - output: nuget
           # condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main')) # Optional condition
           useDotNetTask: false # The default is false to use the NuGetCommand task. Set to true to use the DotNetCoreCLI task to publish packages.

--- a/tools/ci_build/github/azure-pipelines/web-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/web-ci-pipeline.yml
@@ -54,7 +54,7 @@ stages:
   parameters:
     NpmPackagingMode: ${{ variables.NpmPackagingMode }}
     IsReleasePipeline: false
-    PoolName: 'onnxruntime-Ubuntu2204-AMD-CPU'
+    PoolName: 'onnxruntime-Ubuntu2404-AMD-CPU'
     BuildStaticLib: true
     ExtraBuildArgs: $(ExtraBuildArgs)
     WASMTemplate: linux-wasm-ci.yml


### PR DESCRIPTION
### Description
1. Upgrade onnxruntime-Ubuntu2204-AMD-CPU machine pool to Ubuntu 24.04, which can fix some vulnerability management issues.
2. Fix some packaging pipeline issues and remove some unused code blocks from dml-vs-2022.yml



