### PR TITLE
[Not-For-Review] support enableGraphCapture in tests

### DIFF
--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -785,6 +785,11 @@ void WebGpuContext::Replay(const std::vector<webgpu::CapturedCommandInfo>& captu
   Flush(buffer_manager);
 
   graph_capture_state_ = GraphCaptureState::Default;
+
+  // This wait roughly compensates for the output buffer readback.
+  auto status = Wait(device_queue_.OnSubmittedWorkDone(
+    wgpu::CallbackMode::WaitAnyOnly, [](wgpu::QueueWorkDoneStatus, wgpu::StringView) {}));
+  ORT_ENFORCE(status == Status::OK(), "Replay failed.");
 }
 
 void WebGpuContext::CaptureEnd() {


### PR DESCRIPTION
To evaluate perf impact of the feature, Run onnxruntime_perf_test with the command line options below:
`-e webgpu -i "enableGraphCapture|1"`



