### PR TITLE
[VitisAI] bugfix: add empty CreateDataTransferImpl

### DIFF
--- a/onnxruntime/core/providers/vitisai/vitisai_provider_factory.cc
+++ b/onnxruntime/core/providers/vitisai/vitisai_provider_factory.cc
@@ -109,6 +109,7 @@ struct VitisAIEpFactory : OrtEpFactory {
     GetVendorId = GetVendorIdImpl;
     GetVersion = GetVersionImpl;
     GetSupportedDevices = GetSupportedDevicesImpl;
+    CreateDataTransfer = CreateDataTransferImpl;
     CreateEp = CreateEpImpl;
     ReleaseEp = ReleaseEpImpl;
 
@@ -166,6 +167,12 @@ struct VitisAIEpFactory : OrtEpFactory {
       }
     }
     return nullptr;
+  }
+
+  static OrtStatus* CreateDataTransferImpl(
+      OrtEpFactory* /*this_ptr*/,
+      OrtDataTransferImpl** /*data_transfer*/) noexcept {
+    return nullptr;  // TODO: Implement data transfer if needed
   }
 
   static OrtStatus* CreateEpImpl(OrtEpFactory* /*this_ptr*/,


### PR DESCRIPTION
### Description

bugfix segfault when when registering VitisAI EP.

```python
import onnxruntime as ort
ort.register_execution_provider_library("VitisAIExecutionProvider", "./onnxruntime_providers_vitisai.dll")
```
it crashes at here 

https://github.com/microsoft/onnxruntime/blob/7e59947dcf8f489f02e1d9dfb7ca0f3de0d677d0/onnxruntime/core/session/environment.cc#L515

It is related to #25254

### Implementation

and an empty implementation for `CreateDataTransferImpl`
