### PR TITLE
Fix webgpu_pix_frame_generator by adding missing present mode attribute

### DIFF
--- a/onnxruntime/core/providers/webgpu/webgpu_pix_frame_generator.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_pix_frame_generator.cc
@@ -36,6 +36,7 @@ WebGpuPIXFrameGenerator::WebGpuPIXFrameGenerator(wgpu::Instance instance, wgpu::
   format = capabilities.formats[0];
 
   wgpu::SurfaceConfiguration config;
+  config.presentMode = capabilities.presentModes[0];
   config.device = device;
   config.format = format;
   config.width = kWidth;


### PR DESCRIPTION
This PR fixed webgpu_fix_frame_generator by adding present mode to the surface configuration. This new attribute is required by laste Dawn to rendering frames.


