### PR TITLE
[Web] Avoid unnecessary data copy for pre-allocated tensors

### DIFF
--- a/js/web/lib/wasm/wasm-core-impl.ts
+++ b/js/web/lib/wasm/wasm-core-impl.ts
@@ -725,6 +725,7 @@ export const run = async (
   const inputTensorHandles: number[] = [];
   const outputTensorHandles: number[] = [];
   const inputOutputAllocs: number[] = [];
+  const preAllocatedOutputs: number[] = [];
 
   const beforeRunStack = wasm.stackSave();
   const inputValuesOffset = wasm.stackAlloc(inputCount * ptrSize);
@@ -797,7 +798,8 @@ export const run = async (
         const location = outputTensors[i]?.[3]; // undefined means output is not pre-allocated.
 
         if (location) {
-          // output is pre-allocated. bind the tensor.
+          // output is pre-allocated, store and bind the tensor.
+          preAllocatedOutputs.push(outputTensorHandles[i]);
           const errorCode = wasm._OrtBindOutput(handle, outputNamesUTF8Encoded[index], outputTensorHandles[i], 0);
           if (errorCode !== 0) {
             checkLastError(`Can't bind pre-allocated output[${i}] for session=${sessionId}.`);
@@ -861,7 +863,10 @@ export const run = async (
     TRACE_EVENT_BEGIN('wasm ProcessOutputTensor');
     for (let i = 0; i < outputCount; i++) {
       const tensor = Number(wasm.getValue(outputValuesOffset + i * ptrSize, '*'));
-      if (tensor === outputTensorHandles[i]) {
+      // Certain pre-allocated tensors may already be bound in the IO binding. e.g. the WebNN backend
+      // always binds its tensor to 'ml-tensor'. In such cases, the tensor ID might change after binding,
+      // but copying data for these tensors should still be avoided.
+      if (tensor === outputTensorHandles[i] || preAllocatedOutputs.includes(outputTensorHandles[i])) {
         // output tensor is pre-allocated. no need to copy data.
         output.push(outputTensors[i]!);
         continue;

--- a/js/web/lib/wasm/wasm-core-impl.ts
+++ b/js/web/lib/wasm/wasm-core-impl.ts
@@ -869,6 +869,12 @@ export const run = async (
       if (tensor === outputTensorHandles[i] || preAllocatedOutputs.includes(outputTensorHandles[i])) {
         // output tensor is pre-allocated. no need to copy data.
         output.push(outputTensors[i]!);
+        if (tensor !== outputTensorHandles[i]) {
+          // release redundant tensor earlier.
+          if (wasm._OrtReleaseTensor(tensor) !== 0) {
+            checkLastError("Can't release tensor.");
+          }
+        }
         continue;
       }
 

--- a/js/web/lib/wasm/wasm-core-impl.ts
+++ b/js/web/lib/wasm/wasm-core-impl.ts
@@ -863,6 +863,8 @@ export const run = async (
     TRACE_EVENT_BEGIN('wasm ProcessOutputTensor');
     for (let i = 0; i < outputCount; i++) {
       const tensor = Number(wasm.getValue(outputValuesOffset + i * ptrSize, '*'));
+      // TODO: revisit this part to ensure it works for WebGPU when both pre-allocated outputs and
+      // preferred location are specified.
       // Certain pre-allocated tensors may already be bound in the IO binding. e.g. the WebNN backend
       // always binds its tensor to 'ml-tensor'. In such cases, the tensor ID might change after binding,
       // but copying data for these tensors should still be avoided.


### PR DESCRIPTION
### Description
Ensure all pre-allocated tensors do not trigger unnecessary data copying. e.g. the WebNN EP always binds its tensor to 'ml-tensor'. In such cases, the tensor ID might change after binding, but copying data for these tensors should still be avoided.

### Motivation and Context
This improves efficiency and avoids redundant operations.


