### PR TITLE
Draft: [NV TRT RTX EP] Fix onnx checker for constants in subgraph

### DIFF
--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -1357,6 +1357,11 @@ Graph::Graph(const Model& owning_model,
       if (is_sparse) {
         sparse_tensor_names_.emplace(tensor.name());
       }
+    } else if (utils::HasExternalDataInMemory(tensor)) {
+      std::unique_ptr<ONNX_NAMESPACE::TensorProto> full_init;
+      ORT_THROW_IF_ERROR(utils::GetTensorProtoWithDataIfInMemory(tensor, full_init));
+      tensor.clear_external_data();
+      tensor.set_raw_data(full_init->raw_data());
     }
 
     auto p = name_to_initial_tensor_.emplace(tensor.name(), &tensor);
@@ -3720,7 +3725,7 @@ Status Graph::InjectExternalInitializedTensors(const InlinedHashMap<std::string,
 Status Graph::InjectExternalInitializersFromFilesInMemory(
     const InlinedHashMap<PathString, std::pair<char*, size_t>>& external_initializer_files) {
   for (const auto& [tensor_name, tensor_proto] : name_to_initial_tensor_) {
-    if (tensor_proto->data_location() == TensorProto_DataLocation_EXTERNAL) {
+    if (tensor_proto->data_location() == TensorProto_DataLocation_EXTERNAL && !utils::HasExternalDataInMemory(*tensor_proto)) {
       std::unique_ptr<ExternalDataInfo> external_data_info;
       ORT_RETURN_IF_ERROR(ExternalDataInfo::Create(tensor_proto->external_data(), external_data_info));
 


### PR DESCRIPTION
### Description

This PR is supposed to fix:
[ ] Loading large models using the `AddExternalInitializersFromFilesInMemory` API
[ ] Fix Phi4 128k instruct parsing 

The first issue is resolved by adding a check in `Graph::InjectExternalInitializersFromFilesInMemory(` from what I can tell. The other issue that parsing of the `If` node fails during `Graph::Resolve` within `NvExecutionProvider::GetSupportedList` [here](https://github.com/gedoensmax/onnxruntime/blob/223a1f7bc00adaa5ae6bd033f1a4631b0f623510/onnxruntime/core/graph/graph.cc#L3212). I tried to fix this by loading the external data in memory to raw data.
This did not resolve the error though:
```
←[1;31m2025-07-29 17:00:31.7917863 [E:onnxruntime:, graph.cc:3212 onnxruntime::Graph::VerifyNodeAndOpMatch] This is an i
nvalid model. In Node, ("/model/rotemb_caches_subgraph/If", If, "", -1) : ("/model/rotemb_caches_subgraph/Greater/output
_0": tensor(bool),) -> ("cos_cache": tensor(float16),"sin_cache": tensor(float16),) , Error Data of TensorProto ( tensor
 name: cos_cache_large) should be stored in */_ORT_MEM_ADDR_/*, but it doesn't exist or is not accessible.←[m
```

@chilo-ms @skottmckay would you be able to help out ? My guess is this has something to do with the ORT Graph wrapping.