### PR TITLE
Enable 2bit CPU matmul fallback 

### DIFF
--- a/onnxruntime/contrib_ops/cpu/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/matmul_nbits.cc
@@ -458,7 +458,7 @@ Status MatMulNBits<float>::ComputeBUnpacked(const Tensor* a,
   auto tmp_b_data_ptr = IAllocator::MakeUniquePtr<float>(allocator, SafeInt<size_t>(K_) * N_, true);
 
   if ((reorder_idx_data == nullptr) && (!zero_points || !zero_points->IsDataType<float>())) {
-    // dequantize b, only 2 and 4b quantization is supported for now
+    // dequantize b, only 2b, 4b, and 8b quantization is supported for now
     if (this->nbits_ == 2) {
       MlasDequantizeBlockwise<float, 2>(
           tmp_b_data_ptr.get(),                           // dequantized output

--- a/onnxruntime/contrib_ops/cpu/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/matmul_nbits.cc
@@ -112,8 +112,8 @@ class MatMulNBits final : public OpKernel {
       has_unquantized_zero_point_ = type != ONNX_NAMESPACE::TensorProto_DataType_UINT8;
     }
 
-    ORT_ENFORCE(nbits_ == 4 || nbits_ == 8,
-                "Only 4b and 8b quantization is supported for MatMulNBits op, additional bits support is planned.");
+    ORT_ENFORCE(nbits_ == 2 || nbits_ == 4 || nbits_ == 8,
+                "Only 2b, 4b and 8b quantization is supported for MatMulNBits op, additional bits support is planned.");
     const Tensor* tensor_zero_point = nullptr;
     has_zp_input_ = info.TryGetConstantInput(InputIndex::zero_points, &tensor_zero_point);
   }
@@ -458,7 +458,19 @@ Status MatMulNBits<float>::ComputeBUnpacked(const Tensor* a,
   auto tmp_b_data_ptr = IAllocator::MakeUniquePtr<float>(allocator, SafeInt<size_t>(K_) * N_, true);
 
   if ((reorder_idx_data == nullptr) && (!zero_points || !zero_points->IsDataType<float>())) {
-    if (nbits_ == 4) {
+    // dequantize b, only 2 and 4b quantization is supported for now
+    if (this->nbits_ == 2) {
+      MlasDequantizeBlockwise<float, 2>(
+          tmp_b_data_ptr.get(),                           // dequantized output
+          b_data,                                         // quantized input
+          scales_data,                                    // quantization scales
+          static_cast<const uint8_t*>(zero_points_data),  // quantization zero points
+          static_cast<int32_t>(block_size_),              // quantization block size
+          column_wise_quant_,                             // columnwise quantization or row-wise
+          static_cast<int32_t>(K_),                       // number of rows in quantized input
+          static_cast<int32_t>(N_),                       // number of columns in quantized input
+          thread_pool);
+    } else if (this->nbits_ == 4) {
       MlasDequantizeBlockwise<float, 4>(
           tmp_b_data_ptr.get(),                           // dequantized output
           b_data,                                         // quantized input

--- a/onnxruntime/contrib_ops/cpu/quantization/matmul_nbits_helper.h
+++ b/onnxruntime/contrib_ops/cpu/quantization/matmul_nbits_helper.h
@@ -31,7 +31,7 @@ Status CheckInputs(const T* /*activation*/,
   // group_index          : (K) or (k_blocks * block_size), or null
   // bias                 : (N), or null
   // Note that scales and zero_points can be 1D for backward compatibility.
-  if (bits != 4 && bits != 8) {
+  if (bits != 2 && bits != 4 && bits != 8) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "bits should be 4 or 8, got ", bits);
   }
 

--- a/onnxruntime/contrib_ops/cpu/quantization/matmul_nbits_helper.h
+++ b/onnxruntime/contrib_ops/cpu/quantization/matmul_nbits_helper.h
@@ -32,7 +32,7 @@ Status CheckInputs(const T* /*activation*/,
   // bias                 : (N), or null
   // Note that scales and zero_points can be 1D for backward compatibility.
   if (bits != 2 && bits != 4 && bits != 8) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "bits should be 4 or 8, got ", bits);
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "bits should be 2, 4 or 8, got ", bits);
   }
 
   if (block_size < 16 || (block_size & (block_size - 1)) != 0) {

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -1240,8 +1240,8 @@ Graph::Graph(const Model& owning_model,
                                                             use_tensor_buffer_true);
       assert(ort_value.IsAllocated());
       auto ins_result = ortvalue_initializers_.insert_or_assign(tensor_proto_to_add.name(), std::move(ort_value));
-      ORT_ENFORCE(ins_result.second, "Unexpected duplicate insert or assign OrtValue for tensor: ", tensor_proto_to_add.name(),
-                  " in the initializer list.");
+      // ORT_ENFORCE(ins_result.second, "Unexpected duplicate insert or assign OrtValue for tensor: ", tensor_proto_to_add.name(),
+      //             " in the initializer list.");
       tensor_proto = std::move(tensor_proto_to_add);
     }
   };

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -1240,8 +1240,8 @@ Graph::Graph(const Model& owning_model,
                                                             use_tensor_buffer_true);
       assert(ort_value.IsAllocated());
       auto ins_result = ortvalue_initializers_.insert_or_assign(tensor_proto_to_add.name(), std::move(ort_value));
-      // ORT_ENFORCE(ins_result.second, "Unexpected duplicate insert or assign OrtValue for tensor: ", tensor_proto_to_add.name(),
-      //             " in the initializer list.");
+      ORT_ENFORCE(ins_result.second, "Unexpected duplicate insert or assign OrtValue for tensor: ", tensor_proto_to_add.name(),
+                  " in the initializer list.");
       tensor_proto = std::move(tensor_proto_to_add);
     }
   };

--- a/onnxruntime/core/mlas/inc/mlas_q4.h
+++ b/onnxruntime/core/mlas/inc/mlas_q4.h
@@ -277,7 +277,7 @@ MlasBlockwiseQuantizedShape(
  *
  * If the qbits or block_size values are unsupported the output sizes will be zero.
  */
-template <int qbits>
+template<int qbits>
 void MLASCALL
 MlasBlockwiseQuantizedBufferSizes(
     int block_size,

--- a/onnxruntime/python/onnxruntime_pybind_quant.cc
+++ b/onnxruntime/python/onnxruntime_pybind_quant.cc
@@ -128,6 +128,8 @@ void QuantizeMatMulBnb4Blockwise(
 void CreateQuantPybindModule(py::module& m) {
   m.def("quantize_matmul_4bits", &QuantizeMatMulNBitsBlockwise<float, 4>);
   m.def("quantize_matmul_4bits", &QuantizeMatMulNBitsBlockwise<MLFloat16, 4>);
+  m.def("quantize_matmul_nbits", &QuantizeMatMulNBitsBlockwise<MLFloat16, 4>);
+  m.def("quantize_matmul_nbits", &QuantizeMatMulNBitsBlockwise<float, 4>);
   m.def("quantize_matmul_8bits", &QuantizeMatMulNBitsBlockwise<float, 8>);
   m.def("quantize_matmul_8bits", &QuantizeMatMulNBitsBlockwise<MLFloat16, 8>);
   m.def("quantize_matmul_bnb4", &QuantizeMatMulBnb4Blockwise<float>);

--- a/onnxruntime/python/onnxruntime_pybind_quant.cc
+++ b/onnxruntime/python/onnxruntime_pybind_quant.cc
@@ -126,10 +126,10 @@ void QuantizeMatMulBnb4Blockwise(
 }
 
 void CreateQuantPybindModule(py::module& m) {
+  m.def("quantize_matmul_2bits", &QuantizeMatMulNBitsBlockwise<float, 2>);
+  m.def("quantize_matmul_2bits", &QuantizeMatMulNBitsBlockwise<MLFloat16, 2>);
   m.def("quantize_matmul_4bits", &QuantizeMatMulNBitsBlockwise<float, 4>);
   m.def("quantize_matmul_4bits", &QuantizeMatMulNBitsBlockwise<MLFloat16, 4>);
-  m.def("quantize_matmul_nbits", &QuantizeMatMulNBitsBlockwise<MLFloat16, 4>);
-  m.def("quantize_matmul_nbits", &QuantizeMatMulNBitsBlockwise<float, 4>);
   m.def("quantize_matmul_8bits", &QuantizeMatMulNBitsBlockwise<float, 8>);
   m.def("quantize_matmul_8bits", &QuantizeMatMulNBitsBlockwise<MLFloat16, 8>);
   m.def("quantize_matmul_bnb4", &QuantizeMatMulBnb4Blockwise<float>);

--- a/onnxruntime/python/tools/quantization/matmul_nbits_quantizer.py
+++ b/onnxruntime/python/tools/quantization/matmul_nbits_quantizer.py
@@ -16,7 +16,12 @@ import numpy.typing as npt
 import onnx
 from onnx.onnx_pb import GraphProto, ModelProto, NodeProto, TensorProto
 
-from onnxruntime.capi._pybind_state import quantize_matmul_nbits, quantize_matmul_4bits, quantize_matmul_8bits, quantize_qdq_matmul_4bits
+from onnxruntime.capi._pybind_state import (
+    quantize_matmul_4bits,
+    quantize_matmul_8bits,
+    quantize_matmul_nbits,
+    quantize_qdq_matmul_4bits,
+)
 
 from .calibrate import CalibrationDataReader
 from .neural_compressor import gptq_quantize, rtn_quantize
@@ -820,7 +825,15 @@ class DefaultWeightOnlyQuantizer:
             scales = np.zeros((cols * k_blocks), dtype=fp32weight.dtype)
             if qbits == 2:
                 quantize_matmul_nbits(
-                    packed, fp32weight, self.config.bits, scales, zero_point, block_size, cols, rows, self.config.is_symmetric
+                    packed,
+                    fp32weight,
+                    self.config.bits,
+                    scales,
+                    zero_point,
+                    block_size,
+                    cols,
+                    rows,
+                    self.config.is_symmetric,
                 )
             elif qbits == 8:
                 quantize_matmul_8bits(
@@ -1254,7 +1267,6 @@ class MatMulNBitsQuantizer:
 
         if algo_config is None:
             algo_config = DefaultWeightOnlyQuantConfig(
-                bits=bits,
                 block_size=block_size,
                 is_symmetric=is_symmetric,
                 accuracy_level=accuracy_level,
@@ -1577,7 +1589,6 @@ if __name__ == "__main__":
         )
     elif args.quant_method == "default":
         quant_config = DefaultWeightOnlyQuantConfig(
-            bits=args.bits,
             block_size=args.block_size,
             is_symmetric=args.symmetric,
             accuracy_level=args.accuracy_level,

--- a/onnxruntime/python/tools/quantization/matmul_nbits_quantizer.py
+++ b/onnxruntime/python/tools/quantization/matmul_nbits_quantizer.py
@@ -17,9 +17,9 @@ import onnx
 from onnx.onnx_pb import GraphProto, ModelProto, NodeProto, TensorProto
 
 from onnxruntime.capi._pybind_state import (
+    quantize_matmul_2bits,
     quantize_matmul_4bits,
     quantize_matmul_8bits,
-    quantize_matmul_nbits,
     quantize_qdq_matmul_4bits,
 )
 
@@ -824,7 +824,7 @@ class DefaultWeightOnlyQuantizer:
             zero_point = np.zeros(cols * ((k_blocks + kpack - 1) // kpack), dtype="uint8")
             scales = np.zeros((cols * k_blocks), dtype=fp32weight.dtype)
             if qbits == 2:
-                quantize_matmul_nbits(
+                quantize_matmul_2bits(
                     packed,
                     fp32weight,
                     self.config.bits,

--- a/onnxruntime/python/tools/transformers/models/llama/convert_to_onnx.py
+++ b/onnxruntime/python/tools/transformers/models/llama/convert_to_onnx.py
@@ -670,6 +670,8 @@ def get_args():
 
     blockwise_group = parser.add_argument_group("blockwise (4-bit quantization)")
 
+    parser.add_argument("--bits", default=4, type=int, help="the target bits to represent weight")
+
     blockwise_group.add_argument(
         "--block_size",
         required=False,
@@ -988,6 +990,7 @@ def main():
                         model = onnx.load_model(fp_path, load_external_data=True)
                         quant = MatMulNBitsQuantizer(
                             model=model,
+                            bits=args.bits,
                             block_size=args.block_size,
                             is_symmetric=True,
                             accuracy_level=args.int4_accuracy_level,

--- a/onnxruntime/python/tools/transformers/models/phi2/convert_to_onnx.py
+++ b/onnxruntime/python/tools/transformers/models/phi2/convert_to_onnx.py
@@ -168,6 +168,7 @@ class ConvertPhi2ToONNX:
             assert self.precision == Precision.INT4
             quant = MatMulNBitsQuantizer(
                 model=optimizer.model,
+                bits=4,
                 block_size=self.block_size,
                 is_symmetric=True,
                 accuracy_level=self.accuracy_level,

--- a/onnxruntime/test/contrib_ops/matmul_2bits_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_2bits_test.cc
@@ -244,13 +244,21 @@ void TestMatMul2BitsTyped(float abs_error = 0.1f, float rel_error = 0.02f) {
 
 }  // namespace
 
-TEST(MatMulNBits, Float32_2Bits) {
+TEST(MatMulNBits, Float32_2Bits_Accuracy0) {
+  // Currently, only fallback option enabled for 2bit datatypes
+  // where the 2bits are dequantized to fp32
   TestMatMul2BitsTyped<float, 1, 1, 16, 16, 0>();
   TestMatMul2BitsTyped<float, 1, 2, 16, 16, 0>();
   TestMatMul2BitsTyped<float, 1, 32, 16, 16, 0>();
   TestMatMul2BitsTyped<float, 1, 32, 32, 16, 0>();
   TestMatMul2BitsTyped<float, 1, 32, 16, 128, 0>();
   TestMatMul2BitsTyped<float, 1, 288, 16, 16, 0>();
+  TestMatMul2BitsTyped<float, 1, 1, 16, 16, 0>();
+  TestMatMul2BitsTyped<float, 4, 2, 16, 16, 0>();
+  TestMatMul2BitsTyped<float, 4, 32, 16, 16, 0>();
+  TestMatMul2BitsTyped<float, 4, 32, 32, 16, 0>();
+  TestMatMul2BitsTyped<float, 4, 32, 16, 128, 0>();
+  TestMatMul2BitsTyped<float, 4, 288, 16, 16, 0>();
 }
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/contrib_ops/matmul_2bits_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_2bits_test.cc
@@ -1,0 +1,298 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef ORT_MINIMAL_BUILD
+
+#include <optional>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "core/common/narrow.h"
+#include "core/common/span_utils.h"
+#include "core/framework/tensor.h"
+#include "core/mlas/inc/mlas_qnbit.h"
+#include "core/mlas/inc/mlas_q4.h"
+#include "core/mlas/inc/mlas.h"
+#include "core/session/inference_session.h"
+#include "test/common/cuda_op_test_utils.h"
+#include "test/common/tensor_op_test_utils.h"
+#include "test/framework/test_utils.h"
+#include "test/optimizer/graph_transform_test_builder.h"
+#include "test/providers/provider_test_utils.h"
+#include "test/util/include/default_providers.h"
+#include "test/util/include/scoped_env_vars.h"
+#include "core/session/onnxruntime_cxx_api.h"
+#include "core/session/ort_env.h"
+#include "core/util/qmath.h"
+
+extern std::unique_ptr<Ort::Env> ort_env;
+
+namespace onnxruntime {
+
+namespace test {
+
+namespace {
+
+constexpr int QBits = 2;
+
+// TODO: determine if this is necessary for 2bit unpacked B val??
+void QuantizeDequantize(std::vector<float>& raw_vals,
+                        std::vector<uint8_t>& quant_vals,
+                        std::vector<float>& scales,
+                        std::vector<uint8_t>* zp,
+                        int32_t N,
+                        int32_t K,
+                        int32_t block_size) {
+  auto& ortenv = **ort_env.get();
+  onnxruntime::concurrency::ThreadPool* tp = ortenv.GetEnvironment().GetIntraOpThreadPool();
+
+  MlasQuantizeBlockwise<float, QBits>(
+      quant_vals.data(),
+      scales.data(),
+      zp != nullptr ? zp->data() : nullptr,
+      raw_vals.data(),
+      block_size,
+      true,
+      K,
+      N,
+      N,
+      tp);
+
+  // Note that raw_vals is NxK after dequant
+  MlasDequantizeBlockwise<float, QBits>(
+      raw_vals.data(),                       // dequantized output
+      quant_vals.data(),                     // quantized input
+      scales.data(),                         // quantization scales
+      zp != nullptr ? zp->data() : nullptr,  // quantization zero points
+      block_size,                            // quantization block size
+      true,                                  // columnwise quantization
+      K,                                     // number of rows
+      N,                                     // number of columns
+      tp);
+}
+
+// define test options
+// define run test (reference TestMatMul8BitsTyped)
+// it calls RunTest8Bits
+
+struct TestOptions2Bits {
+    int64_t M{1};
+    int64_t N{1};
+    int64_t K{1};
+    int64_t block_size{32};
+    int64_t accuracy_level{0};
+
+    bool has_zero_point{false};
+    bool has_g_idx{false};
+    bool has_bias{false};
+
+    std::optional<float> output_abs_error{};
+    std::optional<float> output_rel_error{};
+};
+
+[[maybe_unused]] std::ostream& operator<<(std::ostream& os, const TestOptions2Bits& opts) {
+  return os << "M:" << opts.M << ", N:" << opts.N << ", K:" << opts.K
+            << ", block_size:" << opts.block_size
+            << ", accuracy_level:" << opts.accuracy_level
+            << ", has_zero_point:" << opts.has_zero_point
+            << ", has_g_idx:" << opts.has_g_idx
+            << ", has_bias:" << opts.has_bias;
+}
+
+template <typename T1>
+void RunTest2Bits(const TestOptions2Bits& opts) {
+  SCOPED_TRACE(opts);
+
+  const int64_t M = opts.M,
+                K = opts.K,
+                N = opts.N;
+
+  RandomValueGenerator random{1234};
+  std::vector<float> input0_fp32_vals(random.Gaussian<float>(AsSpan({M, K}), 0.0f, 0.25f));
+  std::vector<float> input1_fp32_vals(random.Gaussian<float>(AsSpan({K, N}), 0.0f, 0.25f));
+
+  int q_rows, q_cols;
+  MlasBlockwiseQuantizedShape<float, QBits>(static_cast<int>(opts.block_size), /* columnwise */ true,
+                                            static_cast<int>(K), static_cast<int>(N),
+                                            q_rows, q_cols);
+
+  size_t q_data_size_in_bytes, q_scale_size, q_zp_size_in_bytes;
+  MlasBlockwiseQuantizedBufferSizes<QBits>(static_cast<int>(opts.block_size), /* columnwise */ true,
+                                           static_cast<int>(K), static_cast<int>(N),
+                                           q_data_size_in_bytes, q_scale_size, &q_zp_size_in_bytes);
+
+  std::vector<uint8_t> input1_vals(q_data_size_in_bytes);
+  std::vector<float> scales(q_scale_size);
+  std::vector<uint8_t> zp(q_zp_size_in_bytes);
+
+  auto& ortenv = **ort_env.get();
+  onnxruntime::concurrency::ThreadPool* tp = ortenv.GetEnvironment().GetIntraOpThreadPool();
+
+  MlasQuantizeBlockwise<float, QBits>(
+      input1_vals.data(),
+      scales.data(),
+      opts.has_zero_point ? zp.data() : nullptr,
+      input1_fp32_vals.data(),
+      static_cast<int32_t>(opts.block_size),
+      true,
+      static_cast<int32_t>(K),
+      static_cast<int32_t>(N),
+      static_cast<int32_t>(N),
+      tp);
+
+  // Note that raw_vals is NxK after dequant
+  MlasDequantizeBlockwise<float, QBits>(
+      input1_fp32_vals.data(),
+      input1_vals.data(),
+      scales.data(),
+      opts.has_zero_point ? zp.data() : nullptr,
+      static_cast<int32_t>(opts.block_size),
+      true,
+      static_cast<int32_t>(K),
+      static_cast<int32_t>(N),
+      tp);
+
+      const std::vector<int64_t> bias_shape = {N};
+  const auto bias = [&]() -> std::optional<std::vector<float>> {
+    if (opts.has_bias) {
+      return random.Uniform(bias_shape, 1.0f, 5.0f);
+    }
+    return std::nullopt;
+  }();
+
+  std::vector<float> expected_vals(M * N);
+  for (int64_t m = 0; m < M; m++) {
+    for (int64_t n = 0; n < N; n++) {
+      float sum = 0.0f;
+      for (int64_t k = 0; k < K; k++) {
+        sum += input0_fp32_vals[m * K + k] * input1_fp32_vals[n * K + k];
+      }
+      expected_vals[m * N + n] = sum + (bias.has_value() ? (*bias)[n] : 0.0f);
+    }
+  }
+
+  OpTester test("MatMulNBits", 1, kMSDomain);
+    test.AddAttribute<int64_t>("K", K);
+    test.AddAttribute<int64_t>("N", N);
+    test.AddAttribute<int64_t>("block_size", opts.block_size);
+    test.AddAttribute<int64_t>("bits", QBits);
+    test.AddAttribute<int64_t>("accuracy_level", opts.accuracy_level);
+
+    if constexpr (std::is_same<T1, float>::value) {
+    test.AddInput<T1>("A", {M, K}, input0_fp32_vals, false);
+  } else if constexpr (std::is_same<T1, MLFloat16>::value) {
+    test.AddInput<T1>("A", {M, K}, FloatsToMLFloat16s(input0_fp32_vals), false);
+  } else if constexpr (std::is_same<T1, BFloat16>::value) {
+    test.AddInput<T1>("A", {M, K}, FloatsToBFloat16s(input0_fp32_vals), false);
+  }
+
+  int64_t k_blocks = (K + opts.block_size - 1) / opts.block_size;
+  test.AddInput<uint8_t>("B", {q_cols, k_blocks, q_rows / k_blocks}, input1_vals, true);
+
+  if constexpr (std::is_same<T1, float>::value) {
+    test.AddInput<T1>("scales", {N, static_cast<int64_t>(q_scale_size) / N}, scales, true);
+  } else if constexpr (std::is_same<T1, MLFloat16>::value) {
+    test.AddInput<T1>("scales", {N, static_cast<int64_t>(q_scale_size) / N}, FloatsToMLFloat16s(scales), true);
+  } else if constexpr (std::is_same<T1, BFloat16>::value) {
+    test.AddInput<T1>("scales", {N, static_cast<int64_t>(q_scale_size) / N}, FloatsToBFloat16s(scales), true);
+  }
+
+  if (opts.has_zero_point) {
+    test.AddInput<uint8_t>("zero_points", {N, static_cast<int64_t>(q_zp_size_in_bytes) / N}, zp, true);
+  } else {
+    test.AddOptionalInputEdge<uint8_t>();
+  }
+
+  // Account for deprecated "g_idx" input
+  test.AddOptionalInputEdge<int32_t>();
+
+  if (bias.has_value()) {
+    if constexpr (std::is_same<T1, float>::value) {
+      test.AddInput<T1>("bias", bias_shape, *bias, true);
+    } else if constexpr (std::is_same<T1, MLFloat16>::value) {
+      test.AddInput<T1>("bias", bias_shape, FloatsToMLFloat16s(*bias), true);
+    } else if constexpr (std::is_same<T1, BFloat16>::value) {
+      test.AddInput<T1>("bias", bias_shape, FloatsToBFloat16s(*bias), true);
+    }
+  } else {
+    test.AddOptionalInputEdge<T1>();
+  }
+
+  if constexpr (std::is_same<T1, float>::value) {
+    test.AddOutput<T1>("Y", {M, N}, expected_vals);
+  } else if constexpr (std::is_same<T1, MLFloat16>::value) {
+    test.AddOutput<T1>("Y", {M, N}, FloatsToMLFloat16s(expected_vals));
+  } else if constexpr (std::is_same<T1, BFloat16>::value) {
+    test.AddOutput<T1>("Y", {M, N}, FloatsToBFloat16s(expected_vals));
+  }
+
+  if (opts.output_abs_error.has_value()) {
+    test.SetOutputAbsErr("Y", *opts.output_abs_error);
+  }
+
+  if (opts.output_rel_error.has_value()) {
+    test.SetOutputRelErr("Y", *opts.output_rel_error);
+  }
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  if constexpr (std::is_same<T1, float>::value) {
+      execution_providers.emplace_back(DefaultCpuExecutionProvider());
+      test.ConfigEps(std::move(execution_providers));
+      test.RunWithConfig();
+  }
+}
+
+template <typename AType, int M, int N, int K, int block_size, int accuracy_level = 0>
+void TestMatMul2BitsTyped(float abs_error = 0.1f, float rel_error = 0.02f) {
+  TestOptions2Bits base_opts{};
+  base_opts.M = M, base_opts.N = N, base_opts.K = K;
+  base_opts.block_size = block_size;
+  base_opts.accuracy_level = accuracy_level;
+
+  base_opts.output_abs_error = abs_error;
+  base_opts.output_rel_error = rel_error;
+
+  {
+    TestOptions2Bits opts = base_opts;
+    opts.has_zero_point = false;
+    opts.has_bias = false;
+    RunTest2Bits<AType>(opts);
+  }
+
+  {
+    TestOptions2Bits opts = base_opts;
+    opts.has_zero_point = true;
+    opts.has_bias = false;
+    RunTest2Bits<AType>(opts);
+  }
+
+  {
+    TestOptions2Bits opts = base_opts;
+    opts.has_zero_point = false;
+    opts.has_bias = true;
+    RunTest2Bits<AType>(opts);
+  }
+
+  {
+    TestOptions2Bits opts = base_opts;
+    opts.has_zero_point = true;
+    opts.has_bias = true;
+    RunTest2Bits<AType>(opts);
+  }
+}
+
+} // namespace
+
+TEST(MatMulNBits, Float32_2Bits) {
+  TestMatMul2BitsTyped<float, 1, 1, 16, 16, 0>();
+  TestMatMul2BitsTyped<float, 1, 2, 16, 16, 0>();
+  TestMatMul2BitsTyped<float, 1, 32, 16, 16, 0>();
+  TestMatMul2BitsTyped<float, 1, 32, 32, 16, 0>();
+  TestMatMul2BitsTyped<float, 1, 32, 16, 128, 0>();
+  TestMatMul2BitsTyped<float, 1, 288, 16, 16, 0>();
+}
+} // namespace test
+} // namespace onnxruntime
+
+#endif // ORT_MINIMAL_BUILD

--- a/onnxruntime/test/python/quantization/test_op_matmul_2bits.py
+++ b/onnxruntime/test/python/quantization/test_op_matmul_2bits.py
@@ -306,53 +306,6 @@ class TestOpMatMul2Bits(unittest.TestCase):
         # cover rounding error - 2-bit quantization has higher error than 4-bit
         self.quant_test(model_fp32_path, data_reader, 32, False, op_types_to_quantize=("Gather",), rtol=0.3, atol=0.8)
 
-    @unittest.skipIf(
-        find_spec("onnxruntime.training"), "Skip because training package doesn't has quantize_matmul_2bits"
-    )
-    def test_quantize_matmul_int2_symmetric_qdq(self):
-        np.random.seed(13)
-
-        model_fp32_path = str(Path(self._tmp_model_dir.name).joinpath("matmul_fp32_symmetric.onnx").absolute())
-        self.construct_model_matmul(model_fp32_path, symmetric=True)
-        data_reader = self.input_feeds(1, {"input": (100, 52)})
-        self.quant_test(model_fp32_path, data_reader, 32, True, quant_utils.QuantFormat.QDQ, rtol=0.02, atol=0.1)
-
-    @unittest.skipIf(
-        find_spec("onnxruntime.training"), "Skip because training package doesn't has quantize_matmul_2bits"
-    )
-    def test_quantize_matmul_int2_offsets_qdq(self):
-        model_fp32_path = str(Path(self._tmp_model_dir.name).joinpath("matmul_fp32_offset.onnx").absolute())
-        self.construct_model_matmul(model_fp32_path, symmetric=False)
-        data_reader = self.input_feeds(1, {"input": (100, 52)})
-        self.quant_test(model_fp32_path, data_reader, 32, False, quant_utils.QuantFormat.QDQ, rtol=0.02, atol=0.1)
-
-    @unittest.skipIf(
-        find_spec("onnxruntime.training"), "Skip because training package doesn't has quantize_matmul_2bits"
-    )
-    def test_quantize_matmul_2bits(self):
-        np.random.seed(13)
-        for k in [32, 40, 256, 512, 1024, 1040]:
-            for n in [8, 256]:
-                model_fp32_path = str(
-                    Path(self._tmp_model_dir.name).joinpath(f"matmul_fp32_k_{k}_n_{n}.onnx").absolute()
-                )
-                self.construct_model_matmul(model_fp32_path, symmetric=True, k=k, n=n)
-                for m in [1, 2]:
-                    data_reader = self.input_feeds(m, {"input": (m, k)})
-                    for config in ["default", "hqq"]:
-                        for block_size in [16, 128, 256]:
-                            if block_size <= k:
-                                self.quant_test(
-                                    model_fp32_path,
-                                    data_reader,
-                                    block_size,
-                                    True,
-                                    atol=0.1,
-                                    rtol=0.02,
-                                    config=config,
-                                    suffix=f"_m_{m}_n_{n}_k_{k}",
-                                )
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/onnxruntime/test/python/quantization/test_op_matmul_2bits.py
+++ b/onnxruntime/test/python/quantization/test_op_matmul_2bits.py
@@ -225,5 +225,6 @@ class TestOpMatMul2Bits(unittest.TestCase):
         data_reader = self.input_feeds(1, {"input": (100, 52)})
         self.quant_test(model_fp32_path, data_reader, 32, False, rtol=0.02, atol=0.1)
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/onnxruntime/test/python/quantization/test_op_matmul_4bits.py
+++ b/onnxruntime/test/python/quantization/test_op_matmul_4bits.py
@@ -274,6 +274,7 @@ class TestOpMatMul4Bits(unittest.TestCase):
             algo_config = matmul_nbits_quantizer.HQQWeightOnlyQuantConfig(block_size=block_size)
 
         model = quant_utils.load_model_with_shape_infer(Path(model_fp32_path))
+        bits = 4
         quant = matmul_nbits_quantizer.MatMulNBitsQuantizer(
             model, bits, block_size, is_symmetric, algo_config=algo_config
         )

--- a/onnxruntime/test/python/quantization/test_op_matmul_8bits.py
+++ b/onnxruntime/test/python/quantization/test_op_matmul_8bits.py
@@ -141,7 +141,7 @@ class TestOpMatMul8Bits(unittest.TestCase):
                 quant_axes=quant_axes,
             )
 
-        quant = matmul_nbits_quantizer.MatMulNBitsQuantizer(model, algo_config=quant_config)
+        quant = matmul_nbits_quantizer.MatMulNBitsQuantizer(model, bits=8, algo_config=quant_config)
         quant.process()
         quant.model.save_model_to_file(model_int8_path, False)
 


### PR DESCRIPTION
### Description
- enable 2bit matmulnbits
- falls back to ComputeBUnpacked (dequants to fp32)
- Also adapting quantize script to enable 2 bits
- adds 2bit unit tests
    - [blockwise quantize for 2bits already implemented ](https://github.com/microsoft/onnxruntime/blob/b9575476e94daa9c6578aba92d8f04324dd15815/onnxruntime/core/mlas/lib/q4_dq.cpp#L407)

### Motivation and Context
- working on enabling bitnet + lowbit LLM's


