### PR TITLE
[build] disable CodeQL for NPM Packaging Pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/npm-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/npm-packaging-pipeline.yml
@@ -50,6 +50,11 @@ extends:
       sourceAnalysisPool:
         name: onnxruntime-Win-CPU-2022
         os: windows
+      codeql:
+        compiled:
+          enabled: false
+          justificationForDisabling: 'CodeQL causes the React Native Android tests to fail when trying to load Linux x64 .so'
+
     stages:
     - template: templates/web-ci.yml
       parameters:


### PR DESCRIPTION
### Description

disable CodeQL for NPM Packaging Pipeline

```
AAPT2 aapt2-7.4.2-8841542-linux Daemon #0: Unexpected error output: ERROR: ld.so: object '/mnt/vss/_work/_temp/codeql3000/distribution/codeql/tools/linux64/${LIB}_${PLATFORM}_trace.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
AAPT2 aapt2-7.4.2-8841542-linux Daemon #1: Unexpected error output: ERROR: ld.so: object '/mnt/vss/_work/_temp/codeql3000/distribution/codeql/tools/linux64/${LIB}_${PLATFORM}_trace.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.

```