### PR TITLE
[build] fix macOS x86_64 cross-compile warning

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -558,6 +558,7 @@ else()
   check_cxx_compiler_flag(-Wambiguous-reversed-operator HAS_AMBIGUOUS_REVERSED_OPERATOR)
   # -Winterference-size was added in GCC 13
   check_cxx_compiler_flag(-Winterference-size HAS_INTERFERENCE_SIZE)
+  check_cxx_compiler_flag(-Warray-bounds HAS_ARRAY_BOUNDS)
   check_cxx_compiler_flag(-Wbitwise-instead-of-logical HAS_BITWISE_INSTEAD_OF_LOGICAL)
   check_cxx_compiler_flag(-Wcast-function-type HAS_CAST_FUNCTION_TYPE)
   check_cxx_compiler_flag(-Wcatch-value HAS_CATCH_VALUE)

--- a/cmake/onnxruntime_config.h.in
+++ b/cmake/onnxruntime_config.h.in
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#cmakedefine HAS_ARRAY_BOUNDS
 #cmakedefine HAS_BITWISE_INSTEAD_OF_LOGICAL
 #cmakedefine HAS_CAST_FUNCTION_TYPE
 #cmakedefine HAS_CATCH_VALUE


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->


This pull request introduces a new compiler flag check for `-Warray-bounds` and addresses a Clang-specific warning in the `MlasQ4Int8TileGemmKernelBlkLen32Avx2` function.

The warning is generated in unreachable code, however it is still triggered the warning. Anyway add the change to make Clang happy.

Fixes #23180