### PR TITLE
[CANN] Fix CANN build error

### DIFF
--- a/onnxruntime/core/providers/cann/cann_kernel.h
+++ b/onnxruntime/core/providers/cann/cann_kernel.h
@@ -45,7 +45,7 @@ class CannKernel : public OpKernel {
   template <typename T>
   inline IAllocatorUniquePtr<T> GetScratchBuffer(size_t count_or_bytes, onnxruntime::Stream* stream) const {
     if (count_or_bytes == 0) return nullptr;
-    return IAllocator::MakeUniquePtr<T>(Info().GetAllocator(OrtMemTypeDefault), count_or_bytes, false, stream, WaitCannNotificationOnDevice);
+    return IAllocator::MakeUniquePtr<T>(Info().GetAllocator(OrtMemTypeDefault), count_or_bytes, false, stream);
   }
 
   template <typename T>


### PR DESCRIPTION
### Description

This error points to the most recent PR (https://github.com/microsoft/onnxruntime/pull/25465)

**Error info**
```
/home/dou/code/onnxruntime/onnxruntime/core/providers/cann/cann_kernel.h:48:40: error: no matching function for call to ‘onnxruntime::IAllocator::MakeUniquePtr<void>(onnxruntime::AllocatorPtr, size_t&, bool, onnxruntime::Stream*&, void (&)(onnxruntime::Stream*, onnxruntime::synchronize::Notification&))’
   48 |     return IAllocator::MakeUniquePtr<T>(Info().GetAllocator(OrtMemTypeDefault), count_or_bytes, false, stream, WaitCannNotificationOnDevice);
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/dou/code/onnxruntime/onnxruntime/core/providers/shared_library/provider_api.h:29,
                 from /home/dou/code/onnxruntime/onnxruntime/core/providers/cann/math/binary_elementwise_ops.cc:5:
/home/dou/code/onnxruntime/include/onnxruntime/core/framework/allocator.h:233:33: note: candidate: ‘static onnxruntime::IAllocatorUniquePtr<T> onnxruntime::IAllocator::MakeUniquePtr(std::shared_ptr<onnxruntime::IAllocator>, size_t, bool, onnxruntime::Stream*) [with T = void; onnxruntime::IAllocatorUniquePtr<T> = std::unique_ptr<void, std::function<void(void*)> >; size_t = long unsigned int]’
  233 |   static IAllocatorUniquePtr<T> MakeUniquePtr(std::shared_ptr<IAllocator> allocator, size_t count_or_bytes,
      |                                 ^~~~~~~~~~~~~
/home/dou/code/onnxruntime/include/onnxruntime/core/framework/allocator.h:233:33: note:   candidate expects 4 arguments, 5 provided
In file included from /home/dou/code/onnxruntime/onnxruntime/core/providers/cann/nn/dropout.h:8,
                 from /home/dou/code/onnxruntime/onnxruntime/core/providers/cann/nn/dropout.cc:5:
/home/dou/code/onnxruntime/onnxruntime/core/providers/cann/cann_kernel.h: In instantiation of ‘onnxruntime::IAllocatorUniquePtr<T> onnxruntime::cann::CannKernel::GetScratchBuffer(size_t, onnxruntime::Stream*) const [with T = void; onnxruntime::IAllocatorUniquePtr<T> = std::unique_ptr<void, std::function<void(void*)> >; size_t = long unsigned int]’:
/home/dou/code/onnxruntime/onnxruntime/core/providers/cann/nn/dropout.cc:56:61:   required from ‘onnxruntime::common::Status onnxruntime::cann::Dropout<T1, T2>::ComputeInternal(onnxruntime::OpKernelContext*) const [with T1 = float; T2 = float]’
/home/dou/code/onnxruntime/onnxruntime/core/providers/cann/nn/dropout.cc:29:8:   required from here
/home/dou/code/onnxruntime/onnxruntime/core/providers/cann/cann_kernel.h:48:40: error: no matching function for call to ‘onnxruntime::IAllocator::MakeUniquePtr<void>(onnxruntime::AllocatorPtr, size_t&, bool, onnxruntime::Stream*&, void (&)(onnxruntime::Stream*, onnxruntime::synchronize::Notification&))’
   48 |     return IAllocator::MakeUniquePtr<T>(Info().GetAllocator(OrtMemTypeDefault), count_or_bytes, false, stream, WaitCannNotificationOnDevice);
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/dou/code/onnxruntime/onnxruntime/core/providers/shared_library/provider_api.h:29,
                 from /home/dou/code/onnxruntime/onnxruntime/core/providers/cann/cann_execution_provider.h:12,
```


