### PR TITLE
[web] fix support for subgroup

### DIFF
--- a/cmake/onnxruntime_webassembly.cmake
+++ b/cmake/onnxruntime_webassembly.cmake
@@ -101,6 +101,9 @@ if (NOT onnxruntime_USE_VCPKG)
   target_compile_options(onnx PRIVATE -Wno-unused-parameter -Wno-unused-variable)
 endif()
 
+# Include the Node.js helper for finding and validating Node.js and NPM
+include(node_helper.cmake)
+
 if (onnxruntime_BUILD_WEBASSEMBLY_STATIC_LIB)
     bundle_static_library(onnxruntime_webassembly
       ${PROTOBUF_LIB}
@@ -147,11 +150,6 @@ if (onnxruntime_BUILD_WEBASSEMBLY_STATIC_LIB)
         onnxruntime_webassembly
         GTest::gtest
       )
-
-      find_program(NODE_EXECUTABLE node required)
-      if (NOT NODE_EXECUTABLE)
-        message(FATAL_ERROR "Node is required for a test")
-      endif()
 
       add_test(NAME onnxruntime_webassembly_test
         COMMAND ${NODE_EXECUTABLE} onnxruntime_webassembly_test.js
@@ -343,6 +341,19 @@ else()
     )
   endif()
 
+  #
+  # Apply post-processing script for the generated JavaScript file
+  #
+  list(APPEND onnxruntime_webassembly_script_deps "${ONNXRUNTIME_ROOT}/wasm/wasm_post_build.js")
+  add_custom_command(
+    TARGET onnxruntime_webassembly
+    POST_BUILD
+    # Backup file at $<TARGET_FILE_NAME:onnxruntime_webassembly>.bak
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE_NAME:onnxruntime_webassembly>" "$<TARGET_FILE_NAME:onnxruntime_webassembly>.bak"
+    COMMAND ${CMAKE_COMMAND} -E echo "Performing post-process for $<TARGET_FILE_NAME:onnxruntime_webassembly>"
+    COMMAND ${NODE_EXECUTABLE} "${ONNXRUNTIME_ROOT}/wasm/wasm_post_build.js" "$<TARGET_FILE_NAME:onnxruntime_webassembly>"
+  )
+
   set_target_properties(onnxruntime_webassembly PROPERTIES LINK_DEPENDS "${onnxruntime_webassembly_script_deps}")
 
   set(target_name_list ort)
@@ -373,61 +384,4 @@ else()
   endif()
 
   set_target_properties(onnxruntime_webassembly PROPERTIES OUTPUT_NAME ${target_name} SUFFIX ".mjs")
-
-  if (onnxruntime_ENABLE_WEBASSEMBLY_THREADS)
-    #
-    # The following POST_BUILD script is a workaround for enabling:
-    # - using onnxruntime-web with Multi-threading enabled when import from CDN
-    # - using onnxruntime-web when consumed in some frameworks like Vite
-    #
-    # In the use case mentioned above, the file name of the script may be changed. So we need to replace the line:
-    # `new Worker(new URL("ort-wasm-*.mjs", import.meta.url),`
-    # with
-    # `new Worker(new URL(import.meta.url),`
-    #
-    # This behavior is introduced in https://github.com/emscripten-core/emscripten/pull/22165. Since it's unlikely to be
-    # reverted, and there is no config to disable this behavior, we have to use a post-build script to workaround it.
-    #
-
-    # Generate a script to do the post-build work
-    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/wasm_post_build.js "
-      const fs = require('fs');
-      const path = require('path');
-
-      // node wasm_post_build.js <mjsFilePath>
-      const mjsFilePath = process.argv[2];
-      let contents = fs.readFileSync(mjsFilePath).toString();
-
-      const regex = 'new Worker\\\\(new URL\\\\(\".+?\", ?import\\\\.meta\\\\.url\\\\),';
-      const matches = [...contents.matchAll(new RegExp(regex, 'g'))];
-      if (matches.length !== 1) {
-        throw new Error(
-          `Unexpected number of matches for \"\${regex}\" in \"\${mjsFilePath}\": \${matches.length}.`,
-        );
-      }
-
-      // Replace the only occurrence.
-      contents = contents.replace(
-        new RegExp(regex),
-        `new Worker(new URL(import.meta.url),`,
-      );
-
-      fs.writeFileSync(mjsFilePath, contents);
-    "
-    )
-
-    find_program(NODE_EXECUTABLE node required)
-    if (NOT NODE_EXECUTABLE)
-      message(FATAL_ERROR "Node is required to run the post-build script")
-    endif()
-
-    add_custom_command(
-      TARGET onnxruntime_webassembly
-      POST_BUILD
-      # Backup file at $<TARGET_FILE_NAME:onnxruntime_webassembly>.bak
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE_NAME:onnxruntime_webassembly>" "$<TARGET_FILE_NAME:onnxruntime_webassembly>.bak"
-      COMMAND ${CMAKE_COMMAND} -E echo "Performing post-process for $<TARGET_FILE_NAME:onnxruntime_webassembly>"
-      COMMAND ${NODE_EXECUTABLE} "${CMAKE_CURRENT_BINARY_DIR}/wasm_post_build.js" "$<TARGET_FILE_NAME:onnxruntime_webassembly>"
-    )
-  endif()
 endif()

--- a/onnxruntime/wasm/wasm_post_build.js
+++ b/onnxruntime/wasm/wasm_post_build.js
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+//
+// Post-process the mjs file.
+//
+
+//
+// USAGE: node wasm_post_build.js <mjsFilePath>
+//
+
+const mjsFilePath = process.argv[2];
+let contents = fs.readFileSync(mjsFilePath).toString();
+
+// STEP.1 - Apply workaround for spawning workers using `import.meta.url`.
+
+// This script is a workaround for enabling:
+// - using onnxruntime-web with Multi-threading enabled when import from CDN
+// - using onnxruntime-web when consumed in some frameworks like Vite
+//
+// In the use case mentioned above, the file name of the script may be changed. So we need to replace the line:
+// `new Worker(new URL("ort-wasm-*.mjs", import.meta.url),`
+// with
+// `new Worker(new URL(import.meta.url),`
+//
+// This behavior is introduced in https://github.com/emscripten-core/emscripten/pull/22165. Since it's unlikely to be
+// reverted, and there is no config to disable this behavior, we have to use a post-build script to workaround it.
+
+// This step should only be applied for multithreading builds
+if (path.basename(mjsFilePath).includes('-threaded')) {
+    const regex = 'new Worker\\(new URL\\(".+?", ?import\\.meta\\.url\\),';
+    const matches = [...contents.matchAll(new RegExp(regex, 'g'))];
+    if (matches.length !== 1) {
+        throw new Error(
+            `Unexpected number of matches for "${regex}" in "${mjsFilePath}": ${matches.length}.`,
+        );
+    }
+
+    // Replace the only occurrence.
+    contents = contents.replace(
+        new RegExp(regex),
+        `new Worker(new URL(import.meta.url),`,
+    );
+}
+
+// STEP.2 - Workaround the issue referred in https://issues.chromium.org/issues/435879324
+
+// Closure compiler will minimize the key of object `FeatureNameString2Enum`, turning `subgroup` into something else.
+
+// This workaround is to replace the generated code as following:
+//
+// (for debug build)
+//
+// > subgroups: "17",
+// --- change to -->
+// > "subgroups": "17",
+//
+// (for release build)
+//
+// > Pe:"17",
+// --- change to -->
+// > "subgroups":"17",
+//
+
+// This step should only be applied for WebGPU EP builds
+if (path.basename(mjsFilePath).includes('.async')) {
+    const regexDebug = 'subgroups: "17"';
+    const regexRelease = '[a-zA-Z_$][a-zA-Z0-9_$]*:"17"';
+
+    const matchesDebug = [...contents.matchAll(new RegExp(regexDebug, 'g'))];
+    const matchesRelease = [...contents.matchAll(new RegExp(regexRelease, 'g'))];
+
+    if (matchesDebug.length === 1 && matchesRelease.length === 0) {
+        contents = contents.replace(
+            new RegExp(regexDebug),
+            '"subgroups": "17"',
+        );
+    } else if (matchesDebug.length === 0 && matchesRelease.length === 1) {
+        contents = contents.replace(
+            new RegExp(regexRelease),
+            '"subgroups":"17"',
+        );
+    } else {
+        throw new Error(
+            `Unexpected number of matches for "${regexDebug}" and "${regexRelease}" in "${mjsFilePath}": Debug=${matchesDebug.length}, Release=${matchesRelease.length}.`,
+        );
+    }
+}
+
+
+fs.writeFileSync(mjsFilePath, contents);


### PR DESCRIPTION
### Description

Currently the subgroup feature is not working correctly for WebGPU EP on web.

See #25595.

Before the bug is fixed in upstream (https://issues.chromium.org/issues/435879324), use this workaround to enable subgroup support.