### PR TITLE
safeint.h: quelch gcc's -Wreturn-type

### DIFF
--- a/onnxruntime/core/common/safeint.h
+++ b/onnxruntime/core/common/safeint.h
@@ -13,11 +13,11 @@ class SafeIntExceptionHandler;
 template <>
 class SafeIntExceptionHandler<onnxruntime::OnnxRuntimeException> {
  public:
-  static void SafeIntOnOverflow() {
+  [[noreturn]] static void SafeIntOnOverflow() {
     ORT_THROW("Integer overflow");
   }
 
-  static void SafeIntOnDivZero() {
+  [[noreturn]] static void SafeIntOnDivZero() {
     ORT_THROW("Divide by zero");
   }
 };


### PR DESCRIPTION
Quoting cppreference.com:
  (the `[[noreturn]]` attribute) Indicates that the function will not
  return control flow to the calling function after it finishes (e.g.
  functions that terminate the application, throw exceptions, loop
  indefinitely, etc.). This attribute applies to the name of the
  function being declared in function declarations only.
  
  If a function previously declared with `[[noreturn]]` is invoked and
  that invocation eventually returns, the behavior is runtime-undefined.

The `SafeIntOn*` member functions immediately throw, so if they are used in a function with non-void return type, g++ 14 issues a warning that there exist control paths in the function where no value is returned.

Fix this by marking the member functions explicitly noreturn.

This is needed so onnxruntime builds correctly with `-Wall -Wextra`.