### PR TITLE
[build] fix build with delay load hook

### DIFF
--- a/onnxruntime/core/dll/delay_load_hook.cc
+++ b/onnxruntime/core/dll/delay_load_hook.cc
@@ -45,7 +45,7 @@
 
 namespace {
 
-#define DEFINE_KNOWN_DLL(name) {#name ".dll", L#name L".dll"}
+#define DEFINE_KNOWN_DLL(name) {#name ".dll", L## #name L".dll"}
 
 constexpr struct {
   const char* str;


### PR DESCRIPTION
### Description

Fix build when at least one delay load DLL is needed for onnxruntime.dll

The old code contains non standard macro definition which is considered as build error in latest VC++