### PR TITLE
Update semver.h to fix compilation error under linux

### DIFF
--- a/onnxruntime/core/common/semver.h
+++ b/onnxruntime/core/common/semver.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <optional>
 #include <string_view>
 


### PR DESCRIPTION
### Description
Added the header `<cstdint>` to `semver.h`.


### Motivation and Context
Correcting compilation under linux systems, to prevent the error:
```
/xxx/onnxruntime/core/common/semver.h:18:3: error: »uint32_t« does not name a type
   18 |   uint32_t major{};
   19 |   uint32_t minor{};
   20 |   uint32_t patch{};
```

