### PR TITLE
fixed matmul broadcasting

### DIFF
--- a/onnxruntime/core/providers/cpu/math/matmul_helper.h
+++ b/onnxruntime/core/providers/cpu/math/matmul_helper.h
@@ -137,7 +137,11 @@ class MatMulComputeHelper {
 
     // broadcasting for all output dims except last two
     for (size_t idx_dim = 0; idx_dim < num_dims_with_pad - 2; ++idx_dim) {
-      output_dims[idx_dim] = std::max(left_padded_dims_[idx_dim], right_padded_dims_[idx_dim]);
+      if (left_padded_dims_[idx_dim] == 0 || right_padded_dims_[idx_dim] == 0) {
+        output_dims[idx_dim] = 0;
+      } else {
+        output_dims[idx_dim] = std::max(left_padded_dims_[idx_dim], right_padded_dims_[idx_dim]);
+      }
       if (left_padded_dims_[idx_dim] != output_dims[idx_dim])
         ORT_RETURN_IF_NOT(left_padded_dims_[idx_dim] == 1, "left operand cannot broadcast on dim ", idx_dim);
       if (right_padded_dims_[idx_dim] != output_dims[idx_dim])

--- a/onnxruntime/test/providers/cpu/math/matmul_fastmath_test.cc
+++ b/onnxruntime/test/providers/cpu/math/matmul_fastmath_test.cc
@@ -96,6 +96,13 @@ std::vector<MatMulTestData<T>> GenerateTestCases() {
        }});
 
   test_cases.push_back(
+      {"test 3D batch with empty batch dim",
+       {0, 1, 1},
+       {1, 1, 1},
+       {0, 1, 1},
+       real_expected_vals({})});
+
+  test_cases.push_back(
       {"test 4D batch",
        {2, 2, 1, 20},
        {2, 2, 20, 2},

--- a/onnxruntime/test/providers/cpu/math/matmul_test.cc
+++ b/onnxruntime/test/providers/cpu/math/matmul_test.cc
@@ -152,6 +152,13 @@ std::vector<MatMulTestData<T>> GenerateTestCases() {
        })});
 
   test_cases.push_back(
+      {"test 3D batch with empty batch dim",
+       {0, 1, 1},
+       {1, 1, 1},
+       {0, 1, 1},
+       real_expected_vals({})});
+
+  test_cases.push_back(
       {"test 4D batch",
        {2, 2, 1, 3},
        {2, 2, 3, 2},


### PR DESCRIPTION
### Description
currently, the broadcasting of the ``MatMul`` operator does not correctly handle zero-sized batch dimensions. By the numpy standard, when one matrix has length 0 in one batch dimension and the other matrix has length 1 in that dimension, it should be broadcasted to length 0. Instead, onnxruntime currently raises an error in that case.
I modified the computation of ``output_dims`` to fix that error.



### Motivation and Context
We came across this problem when testing the onnxruntime via [onnx-tests](https://github.com/cbourjau/onnx-tests).


