### PR TITLE
Python binding for listing custom operators. 

### DIFF
--- a/include/onnxruntime/core/graph/schema_registry.h
+++ b/include/onnxruntime/core/graph/schema_registry.h
@@ -92,6 +92,12 @@ class OnnxRuntimeOpSchemaRegistry : public IOnnxRuntimeOpSchemaCollection {
                            const ONNX_NAMESPACE::OpSchema** latest_schema,
                            int* earliest_opset_where_unchanged) const override;
 
+  std::vector<ONNX_NAMESPACE::OpSchema> get_all_schemas_with_history();
+
+
+
+
+
   bool empty() const {
     return map_.empty();
   }

--- a/onnxruntime/core/graph/schema_registry.cc
+++ b/onnxruntime/core/graph/schema_registry.cc
@@ -104,6 +104,23 @@ common::Status OnnxRuntimeOpSchemaRegistry::RegisterOpSchemaInternal(ONNX_NAMESP
   return common::Status::OK();
 }
 
+
+
+// list all schemas
+std::vector<ONNX_NAMESPACE::OpSchema> OnnxRuntimeOpSchemaRegistry::get_all_schemas_with_history(){
+    std::vector<ONNX_NAMESPACE::OpSchema> r;
+
+    for (auto& x : map_) {
+      for (auto& y : x.second) {
+        for (auto& z : y.second) {
+          r.emplace_back(z.second);
+        }
+      }
+    }
+    return r;
+
+  }
+
 // Return the schema with biggest version, which is not greater than specified
 // <op_set_version> in specified domain. The value of earliest_opset_where_unchanged
 // is also set to the earliest version preceding op_set_version where the operator


### PR DESCRIPTION
Lists the OpSchemas of custom operators introduce when installing custom libraries on a Session.
This is done in response to the issue, see issue https://github.com/microsoft/onnxruntime/issues/25494. Where i asked for the possibility of listing the OpSchemas of custom operators.

### Description
I used the already existing custom registry for custom ops and add a new function for SessionOptions, given a session options it is possible to list the OpSchemas installed by custom libraries. The implementation is quite easy, when the function is created a CustomRegistry is created and the function CreateCustomRegistry is used with the custom_ops_domains variable of SessionOptions. Then the GetOpschemaRegistry is taken a listed all its Schemas. For listing the schemas, a new function was added to OnnxRuntimeOpSchemaRegistry listing the operators.



### Motivation and Context
The main reason this change is important is a lot of information about custom operators is not accessible when for predefined operators it is already an option with the functions "from onnxruntime.capi.onnxruntime_pybind11_state import get_all_operator_schema". The information given by OpSchemas helps with creating graphical user interfaces for viewing or editing ONNX models. For example, Nvidia Nsight DL has no compatibility with custom operators as the information about types, descriptions, input and outputs is not directly accessible by onnxruntime.

In my case, I am developing a program to extract metadata given Onnx models and expressing the information in RDF. I was using the function to list operators to expresses in the ontology a lot of information about the operators. It was not compatible with custom operators, this function helps solve that issue.

Best Regards


