### PR TITLE
Enable BrowserStack testing stage 

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.BrowserStack.Android/browserstack.yml
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.BrowserStack.Android/browserstack.yml
@@ -3,11 +3,11 @@ platforms:
   - platformName: android
     deviceName: Samsung Galaxy S22 Ultra
     platformVersion: 12.0
-browserstackLocal: true
+browserstackLocal: false
 buildName: ORT android test
 buildIdentifier: ${BUILD_NUMBER}
 projectName: ORT-UITests
 debug: true
 networkLogs: false
 testContextOptions:
-    skipSessionStatus: true   
+    skipSessionStatus: true

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_android.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_android.yml
@@ -49,6 +49,15 @@ stages:
             dotnet publish -c Release --property:UsePrebuiltNativePackage=true --property:CurrentOnnxRuntimeVersion=$(NuGetPackageVersionNumber) -f net8.0-android
           workingDirectory: '$(Build.SourcesDirectory)\csharp\test\Microsoft.ML.OnnxRuntime.Tests.MAUI'
 
+      - task: BrowserStackConfig@0
+        inputs:
+          BrowserStackServiceEndPoint: 'OnnxRuntimeBrowserStackConnection'
+
+      - task: BrowserStackAppUploader@0
+        inputs:
+          appPath: '$(Build.SourcesDirectory)\csharp\test\Microsoft.ML.OnnxRuntime.Tests.MAUI\bin\Release\net8.0-android\publish\ORT.CSharp.Tests.MAUI-Signed.apk'
+          appCustomId: 'Appium-Android-CI'
+
       - task: PowerShell@2
         displayName: Run BrowserStack test
         inputs:


### PR DESCRIPTION
### Description
Tests previously not running in ADO pipelines correctly -- instead would time out

