### PR TITLE
Update number of mel bins for whisper model

### DIFF
--- a/onnxruntime/python/tools/transformers/models/whisper/whisper_helper.py
+++ b/onnxruntime/python/tools/transformers/models/whisper/whisper_helper.py
@@ -93,8 +93,7 @@ class WhisperHelper:
         if separate_encoder_and_decoder_init:
             return
 
-        audio_processor_json = textwrap.dedent("""\
-        {
+        audio_processor_cfg = {
             "feature_extraction": {
                 "sequence": [
                     {
@@ -524,14 +523,15 @@ class WhisperHelper:
                                 "chunk_size": 30,
                                 "hop_length": 160,
                                 "n_fft": 400,
-                                "n_mel": 80
+                                "n_mel": config.num_mel_bins
                             }
                         }
                     }
                 ]
             }
         }
-        """)
+        audio_processor_json = json.dumps(audio_processor_cfg, indent=4)
+
         with open(os.path.join(output_dir, "audio_processor_config.json"), "w") as f:
             f.write(audio_processor_json)
 

--- a/onnxruntime/python/tools/transformers/models/whisper/whisper_helper.py
+++ b/onnxruntime/python/tools/transformers/models/whisper/whisper_helper.py
@@ -6,7 +6,6 @@
 import json
 import logging
 import os
-import textwrap
 from pathlib import Path
 
 import numpy as np

--- a/onnxruntime/python/tools/transformers/models/whisper/whisper_helper.py
+++ b/onnxruntime/python/tools/transformers/models/whisper/whisper_helper.py
@@ -96,12 +96,7 @@ class WhisperHelper:
         audio_processor_cfg = {
             "feature_extraction": {
                 "sequence": [
-                    {
-                        "operation": {
-                            "name": "audio_decoder",
-                            "type": "AudioDecoder"
-                        }
-                    },
+                    {"operation": {"name": "audio_decoder", "type": "AudioDecoder"}},
                     {
                         "operation": {
                             "name": "STFT",
@@ -510,23 +505,18 @@ class WhisperHelper:
                                     0.000986635684967041,
                                     0.0005550682544708252,
                                     0.0002467334270477295,
-                                    0.0000616908073425293
-                                ]
-                            }
+                                    0.0000616908073425293,
+                                ],
+                            },
                         }
                     },
                     {
                         "operation": {
                             "name": "log_mel_spectrogram",
                             "type": "LogMelSpectrum",
-                            "attrs": {
-                                "chunk_size": 30,
-                                "hop_length": 160,
-                                "n_fft": 400,
-                                "n_mel": config.num_mel_bins
-                            }
+                            "attrs": {"chunk_size": 30, "hop_length": 160, "n_fft": 400, "n_mel": config.num_mel_bins},
                         }
-                    }
+                    },
                 ]
             }
         }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Update number of mel bins for whisper model as it differs based on the Whisper model version. Otherwise I am unable to run Whisper v3 models as the num_mel_bins is 128 for that.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Currently unable to run Whisper v3 models as the num_mel_bins is 128 and it is fixed to 80 right now and causes issue during preprocessing.


