### PR TITLE
Enable JAVA API build for LoongArch64

### DIFF
--- a/cmake/onnxruntime_java.cmake
+++ b/cmake/onnxruntime_java.cmake
@@ -110,6 +110,8 @@ elseif (X86_64)
   set(JNI_ARCH x64)
 elseif (POWER)
   set(JNI_ARCH ppc64)
+elseif (LOONGARCH64)
+  set(JNI_ARCH loongarch64)
 else()
   # Now mirror the checks used with MSVC
   if(MSVC)

--- a/java/src/main/java/ai/onnxruntime/OnnxRuntime.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxRuntime.java
@@ -140,6 +140,8 @@ final class OnnxRuntime {
       detectedArch = "aarch64";
     } else if (arch.startsWith("ppc64")) {
       detectedArch = "ppc64";
+    } else if (arch.startsWith("loongarch64")) {
+      detectedArch = "loongarch64";
     } else if (isAndroid()) {
       detectedArch = arch;
     } else {


### PR DESCRIPTION
### Description
- Trivial changes to support LoongArch Java API build



### Motivation and Context
- ONNX Runtime already supports LoongArch, but the Java API requires some trivial changes to enable it.

