### PR TITLE
[QNN EP] Enhance unique name generator for node and tensor names

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
@@ -202,7 +202,7 @@ Status BaseOpBuilder::ProcessInt64Tensors(QnnModelWrapper& qnn_model_wrapper,
     // Insert cast to int32 if input dtype is int64
     if (input_tensorwrapper.GetTensorDataType() == QNN_DATATYPE_INT_64) {
       const Qnn_TensorType_t tensor_type = QNN_TENSOR_TYPE_NATIVE;
-      const std::string cast_output_name = input_names[i] + "_cast_int32";
+      const std::string cast_output_name = utils::GetUniqueName(input_names[i], "_cast_int32");
       if (!qnn_model_wrapper.IsQnnTensorWrapperExist(cast_output_name)) {
         Qnn_DataType_t qnn_data_type = QNN_DATATYPE_INT_32;
         const auto& input_i = node_unit.Inputs()[i];
@@ -295,8 +295,8 @@ Status BaseOpBuilder::ProcessOutputs(QnnModelWrapper& qnn_model_wrapper,
     }
 
     if (needs_int64_cast) {
-      std::string cast_node_name = output_name + "_cast_int64";
-      std::string cast_input_name = output_name + "_cast_int64_aux";
+      const std::string cast_node_name = utils::GetUniqueName(node_unit, "_cast_int64");
+      const std::string cast_input_name = utils::GetUniqueName(output_name, "_cast_int64");
       QnnQuantParamsWrapper quant_params = output_info.quant_param.Copy();
       std::vector<uint32_t> cast_output_shape = output_info.shape;
 
@@ -309,10 +309,10 @@ Status BaseOpBuilder::ProcessOutputs(QnnModelWrapper& qnn_model_wrapper,
       ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(cast_input_tensorwrapper)), "Failed to add tensor.");
       output_names.push_back(cast_input_name);
       // Store the cast node information for later addition
-      cast_node_info_vec.push_back({cast_node_name, cast_input_name, output_name});
+      cast_node_info_vec.emplace_back(CastNodeInfo{cast_node_name, cast_input_name, output_name});
     } else if (supported_qnn_data_type != output_info.qnn_data_type && is_graph_output && !do_op_validation) {
-      std::string cast_node_name = output_name + "_ort_qnn_ep_cast";
-      std::string cast_input_name = output_name + "_ort_qnn_ep_aux";
+      const std::string cast_node_name = utils::GetUniqueName(node_unit, "_cast");
+      const std::string cast_input_name = utils::GetUniqueName(output_name, "_cast");
       std::vector<uint32_t> cast_output_shape = output_info.shape;
       QnnTensorWrapper cast_input_tensorwrapper(cast_input_name,
                                                 QNN_TENSOR_TYPE_NATIVE,
@@ -322,7 +322,7 @@ Status BaseOpBuilder::ProcessOutputs(QnnModelWrapper& qnn_model_wrapper,
                                                 mem_type);
       ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(cast_input_tensorwrapper)), "Failed to add tensor.");
       output_names.push_back(cast_input_name);
-      cast_node_info_vec.push_back({cast_node_name, cast_input_name, output_name});
+      cast_node_info_vec.emplace_back(CastNodeInfo{cast_node_name, cast_input_name, output_name});
     } else {
       output_info.qnn_data_type = supported_qnn_data_type;
       output_names.push_back(output_name);
@@ -336,9 +336,9 @@ Status BaseOpBuilder::ProcessOutputs(QnnModelWrapper& qnn_model_wrapper,
     ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)), "Failed to add tensor.");
   }
 
-  ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetNodeName(node_unit),
+  ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit),
                                                     QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                                    qnn_op_type,  // Typically GetQnnOpType(), but can be overridden.
+                                                    qnn_op_type,
                                                     std::move(input_names),
                                                     std::move(output_names),
                                                     std::move(param_tensor_names),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc
@@ -68,7 +68,7 @@ Status CastOpBuilder::ProcessExtraInputForNotEqual(QnnModelWrapper& qnn_model_wr
   }
 
   // Build additional static input with value 0.
-  const std::string& input_name = utils::GetNodeName(node_unit) + "_notequal_zero";
+  const std::string& input_name = utils::GetUniqueName(node_unit, "_notequal_zero");
 
   Qnn_DataType_t qnn_data_type = QNN_DATATYPE_UNDEFINED;
   const auto* type_proto = input.node_arg.TypeAsProto();
@@ -84,7 +84,7 @@ Status CastOpBuilder::ProcessExtraInputForNotEqual(QnnModelWrapper& qnn_model_wr
                     "Failed to add additional input tensor for QNN Cast node that will be replaced by NotEqual.");
   input_names.push_back(input_name);
 
-  LOGS(logger, VERBOSE) << "FP-to-Bool Cast node " << utils::GetNodeName(node_unit) << " is replaced by NotEqual.";
+  LOGS(logger, VERBOSE) << "FP-to-Bool Cast node " << node_unit.Name() << " is replaced by NotEqual.";
   return Status::OK();
 }
 
@@ -177,7 +177,7 @@ Status CastOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
   const std::string qnn_op_type = IsFpToBoolCast(node_unit)
                                       ? QNN_OP_ELEMENT_WISE_NOT_EQUAL
                                       : GetQnnOpType(node_unit.OpType());
-  ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetNodeName(node_unit),
+  ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit),
                                                     QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                     qnn_op_type,
                                                     std::move(input_names),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/einsum_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/einsum_op_builder.cc
@@ -287,8 +287,8 @@ Status CreateMatMulTransposeAll(
   std::vector<uint32_t> input_shape1(input_info1.shape);
   std::swap(input_shape0[1], input_shape0[2]);
   std::swap(input_shape1[1], input_shape1[2]);
-  const std::string input_transpos0 = input_names[0] + "_t0";
-  const std::string input_transpos1 = input_names[1] + "_t1";
+  const std::string input_transpos0 = onnxruntime::qnn::utils::GetUniqueName(input_names[0], "_transpose");
+  const std::string input_transpos1 = onnxruntime::qnn::utils::GetUniqueName(input_names[1], "_transpose");
   const std::vector<uint32_t> transpose_perm{0, 2, 1, 3};
   ORT_RETURN_IF_ERROR(qnn_model_wrapper->AddTransposeNode(
       /*node_index=*/node_unit.Index(),
@@ -315,7 +315,7 @@ Status CreateMatMulTransposeAll(
   onnxruntime::qnn::TensorInfo matmul_output_info{};
   const auto& output = node_unit.Outputs()[0];
   ORT_RETURN_IF_ERROR(qnn_model_wrapper->GetTensorInfo(output, matmul_output_info));
-  const std::string matmul_output_name = onnxruntime::qnn::utils::GetNodeName(node_unit) + "_matmul";
+  const std::string matmul_output_name = onnxruntime::qnn::utils::GetUniqueName(node_unit, "_matmul");
   std::vector<uint32_t> matmul_output_shape(matmul_output_info.shape);
   std::swap(matmul_output_shape[1], matmul_output_shape[2]);
   onnxruntime::qnn::QnnTensorWrapper matmul_output_wrapper(
@@ -325,7 +325,7 @@ Status CreateMatMulTransposeAll(
                     node_unit.OpType() + " failed to add tensor.");
   std::vector<std::string> param_tensor_names = SetMatMulParamTensorNames(
       qnn_model_wrapper, node_unit, /*transpose_in0=*/false, /*transpose_in1=*/false);
-  ORT_RETURN_IF_NOT(qnn_model_wrapper->CreateQnnNode(/*qnn_node_name=*/onnxruntime::qnn::utils::GetNodeName(node_unit),
+  ORT_RETURN_IF_NOT(qnn_model_wrapper->CreateQnnNode(/*qnn_node_name=*/onnxruntime::qnn::utils::GetUniqueName(node_unit, QNN_OP_MAT_MUL),
                                                      /*package_name=*/QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                      /*qnn_node_type=*/QNN_OP_MAT_MUL,
                                                      /*input_names=*/{input_transpos1, input_transpos0},
@@ -373,7 +373,7 @@ Status CreateReduceSumMulBroadcastX(
   ORT_RETURN_IF_NOT(shape_in0.size() == 4, "CreateReduceSumMulBroadcastX expects input 0 to be rank 4");
   ORT_RETURN_IF_NOT(shape_in1.size() == 3, "CreateReduceSumMulBroadcastX expects input 1 to be rank 3");
   const std::vector<uint32_t> new_shape_in0{shape_in0[0], shape_in0[1], shape_in0[2], 1, shape_in0[3]};
-  const std::string reshape_out_name = input_names[0] + "_reshaped";
+  const std::string reshape_out_name = onnxruntime::qnn::utils::GetUniqueName(input_names[0], "_reshape");
   ORT_RETURN_IF_ERROR(qnn_model_wrapper->AddReshapeNode(
       /*input_name=*/input_names[0],
       /*output_name=*/reshape_out_name,
@@ -387,7 +387,7 @@ Status CreateReduceSumMulBroadcastX(
   // Multiply: reshaped in0 * in1
   // The output shape of the multiplication is determined by broadcasting the reshaped in0 of
   // (b, h, w, 1, c) and in1 (w, k, c) along the matching axes, resulting in (b, h, w, k, c).
-  const std::string mul_out_name = onnxruntime::qnn::utils::GetNodeName(node_unit) + "_mul";
+  const std::string mul_out_name = onnxruntime::qnn::utils::GetUniqueName(node_unit, "_mul");
   std::vector<uint32_t> shape_out_mul{new_shape_in0[0], new_shape_in0[1], new_shape_in0[2], shape_in1[1], new_shape_in0[4]};
   onnxruntime::qnn::QnnTensorWrapper tensor_wrapper_mul(mul_out_name,
                                                         QNN_TENSOR_TYPE_NATIVE,
@@ -397,7 +397,7 @@ Status CreateReduceSumMulBroadcastX(
   ORT_RETURN_IF_NOT(qnn_model_wrapper->AddTensorWrapper(std::move(tensor_wrapper_mul)),
                     "CreateReduceSumMulBroadcastX: failed to AddTensorWrapper");
   ORT_RETURN_IF_NOT(qnn_model_wrapper->CreateQnnNode(
-                        /*qnn_node_name=*/mul_out_name,
+                        /*qnn_node_name=*/onnxruntime::qnn::utils::GetUniqueName(node_unit, QNN_OP_ELEMENT_WISE_MULTIPLY),
                         /*package_name=*/QNN_OP_PACKAGE_NAME_QTI_AISW,
                         /*qnn_node_type=*/QNN_OP_ELEMENT_WISE_MULTIPLY,
                         /*input_names=*/{reshape_out_name, input_names[1]},
@@ -444,7 +444,7 @@ Status CreateReduceSumMulBroadcastX(
                     "CreateReduceSumMulBroadcastX: failed to AddTensorWrapper");
 
   ORT_RETURN_IF_NOT(qnn_model_wrapper->CreateQnnNode(
-                        /*qnn_node_name=*/out_name,
+                        /*qnn_node_name=*/onnxruntime::qnn::utils::GetUniqueName(node_unit, QNN_OP_REDUCE_SUM),
                         /*package_name=*/QNN_OP_PACKAGE_NAME_QTI_AISW,
                         /*qnn_node_type=*/QNN_OP_REDUCE_SUM,
                         /*input_names=*/{mul_out_name},

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/expand_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/expand_op_builder.cc
@@ -138,7 +138,7 @@ Status ExpandOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
   }  // if-else
 
   const std::string& output_name = node_unit.Outputs()[0].node_arg.Name();
-  std::string shape_input_name(input_name + "_" + output_name);
+  std::string shape_input_name = utils::GetUniqueName(input_name, output_name);
   QnnTensorWrapper input_tensorwrapper(shape_input_name, QNN_TENSOR_TYPE_STATIC, qnn_data_type,
                                        std::move(quantize_param), std::move(input_shape),
                                        std::move(shape_data));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/instance_norm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/instance_norm_op_builder.cc
@@ -103,7 +103,7 @@ Status InstanceNormOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
       input0_info.shape.size() == 3 && input0_info.shape[0] != 1) {
     const std::string& orig_input0_name = inputs[0].node_arg.Name();
     const std::string op_input0_name = input0_info.is_initializer ? orig_input0_name
-                                                                  : orig_input0_name + "_ort_qnn_ep_reshape";
+                                                                  : utils::GetUniqueName(orig_input0_name, "_reshape");
     input_names.push_back(op_input0_name);
 
     std::vector<uint8_t> initializer_data;
@@ -170,7 +170,7 @@ Status InstanceNormOpBuilder::ProcessScale(QnnModelWrapper& qnn_model_wrapper,
     const Qnn_QuantizeParams_t& quant_param = tensor_info.quant_param.Get();
     if (tensor_info.qnn_data_type == QNN_DATATYPE_SFIXED_POINT_8) {
       std::string convert_input_name = input_names.back();
-      std::string convert_output_name = convert_input_name + "_convert_s8_to_u8";
+      std::string convert_output_name = utils::GetUniqueName(convert_input_name, "_convert_s8_to_u8");
       Status status = utils::InsertConvertOp(
           qnn_model_wrapper,
           convert_input_name,
@@ -231,7 +231,7 @@ Status InstanceNormOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
   //
 
   const std::string& orig_output_name = outputs[0].node_arg.Name();
-  std::string op_output_name = orig_output_name + "_ort_qnn_ep_reshape";
+  std::string op_output_name = utils::GetUniqueName(orig_output_name, "_reshape");
 
   std::vector<uint32_t> op_output_shape = {
       output_info.shape[0],  // N
@@ -243,7 +243,7 @@ Status InstanceNormOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
   QnnTensorWrapper output_tensorwrapper(op_output_name, QNN_TENSOR_TYPE_NATIVE, output_info.qnn_data_type,
                                         output_info.quant_param.Copy(), std::vector<uint32_t>(op_output_shape));
   ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)), "Failed to add tensor.");
-  ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetNodeName(node_unit),
+  ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit),
                                                     QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                     GetQnnOpType(node_unit.OpType()),
                                                     std::move(input_names),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/layer_norm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/layer_norm_op_builder.cc
@@ -92,7 +92,7 @@ Status LayerNormOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
     ORT_RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[SCALE_IDX], scale_input_info));
 
     if (x_input_info.quant_param.IsPerTensor(/*include_bw*/ true) && scale_input_info.quant_param.IsQuantized()) {
-      const std::string bias_name = qnn::utils::GetNodeName(node_unit) + "_implicit_bias_ort_qnn_ep";
+      const std::string bias_name = qnn::utils::GetUniqueName(node_unit, "_implicit_bias");
       std::vector<uint32_t> bias_shape = scale_input_info.shape;
       ORT_RETURN_IF_ERROR(AddZeroBiasInput(qnn_model_wrapper, x_input_info.quant_param, scale_input_info.quant_param,
                                            std::move(bias_shape), bias_name, logger, input_names));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/lstm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/lstm_op_builder.cc
@@ -197,7 +197,7 @@ Status LSTMOpBuilder::AddStridedSliceOrReshape(QnnModelWrapper& qnn_model_wrappe
                       "Failed to add input tensor for inserted StridedSlice or Reshape.");
 
     // params
-    const std::string& node_name = output_name;
+    const std::string node_name = utils::GetUniqueName(node_unit, QNN_OP_STRIDED_SLICE);
 
     // ranges
     std::vector<uint32_t> ranges_data;
@@ -314,7 +314,7 @@ Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrapper,
       ORT_RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(onnx_inputs[i], input_tensor_infos[i]));
     }
   }
-  // becuase QNN LSTM three outputs are mandatory, we should provide them tensor info
+  // because QNN LSTM three outputs are mandatory, we should provide them tensor info
   std::vector<TensorInfo> output_tensor_infos(3);
   for (size_t i = 0; i < 3; i++) {
     if (onnx_outputs.size() > i && onnx_outputs[i].node_arg.Exists()) {
@@ -389,10 +389,10 @@ Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrapper,
     std::vector<uint32_t> qnn_input_indices = {1, 2, 3, 16};
     std::vector<int32_t> begins = {2, 3, 1, 0};
     std::vector<std::string> qnn_lstm_weight_name = {
-        input_names[1] + "_input_to_forget_gate_weight_" + direction,
-        input_names[1] + "_input_to_cell_gate_weight_" + direction,
-        input_names[1] + "_input_to_output_gate_weight_" + direction,
-        input_names[1] + "_input_to_input_gate_weight_" + direction,
+        utils::GetUniqueName(input_names[1], "_input_to_forget_gate_weight_" + direction),
+        utils::GetUniqueName(input_names[1], "_input_to_cell_gate_weight_" + direction),
+        utils::GetUniqueName(input_names[1], "_input_to_output_gate_weight_" + direction),
+        utils::GetUniqueName(input_names[1], "_input_to_input_gate_weight_" + direction),
     };
     for (size_t i = 0; i < 4; i++) {
       std::vector<std::vector<int32_t>> ranges = {{direction_idx, direction_idx + 1, 1},
@@ -432,10 +432,10 @@ Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrapper,
     std::vector<uint32_t> qnn_input_indices = {4, 5, 6, 17};
     std::vector<int32_t> begins = {2, 3, 1, 0};
     std::vector<std::string> qnn_lstm_weight_name = {
-        input_names[2] + "_recurrent_to_forget_gate_weight_" + direction,
-        input_names[2] + "_recurrent_to_cell_gate_weight_" + direction,
-        input_names[2] + "_recurrent_to_output_gate_weight_" + direction,
-        input_names[2] + "_recurrent_to_input_gate_weight_" + direction};
+        utils::GetUniqueName(input_names[2], "_recurrent_to_forget_gate_weight_" + direction),
+        utils::GetUniqueName(input_names[2], "_recurrent_to_cell_gate_weight_" + direction),
+        utils::GetUniqueName(input_names[2], "_recurrent_to_output_gate_weight_" + direction),
+        utils::GetUniqueName(input_names[2], "_recurrent_to_input_gate_weight_" + direction)};
     for (size_t i = 0; i < 4; i++) {
       std::vector<std::vector<int32_t>> ranges = {{direction_idx, direction_idx + 1, 1},
                                                   {begins[i] * hidden_size_sign, (begins[i] + 1) * hidden_size_sign, 1},
@@ -473,22 +473,22 @@ Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrapper,
     uint32_t new_axes_mask = 0b00U;
     std::vector<uint32_t> output_shape = {hidden_size};
     std::vector<std::string> qnn_lstm_bias_name = {
-        node_name + "_forget_gate_bias_" + direction,
-        node_name + "_cell_gate_bias_" + direction,
-        node_name + "_output_gate_bias_" + direction,
-        node_name + "_input_gate_bias_" + direction};
+        utils::GetUniqueName(node_unit, "_forget_gate_bias_" + direction),
+        utils::GetUniqueName(node_unit, "_cell_gate_bias_" + direction),
+        utils::GetUniqueName(node_unit, "_output_gate_bias_" + direction),
+        utils::GetUniqueName(node_unit, "_input_gate_bias_" + direction)};
     std::vector<uint32_t> qnn_input_indices = {7, 8, 9, 21};
     if (onnx_inputs.size() > 3 && onnx_inputs[3].node_arg.Exists()) {
       std::vector<int32_t> begins = {2, 3, 1, 0, 6, 7, 5, 4};
       std::vector<std::string> onnx_lstm_bias_name = {
-          input_names[3] + "_input_to_forget_gate_bias_" + direction,
-          input_names[3] + "_input_to_cell_gate_bias_" + direction,
-          input_names[3] + "_input_to_output_gate_bias_" + direction,
-          input_names[3] + "_input_to_input_gate_bias_" + direction,
-          input_names[3] + "_recurrent_to_forget_gate_bias_" + direction,
-          input_names[3] + "_recurrent_to_cell_gate_bias_" + direction,
-          input_names[3] + "_recurrent_to_output_gate_bias_" + direction,
-          input_names[3] + "_recurrent_to_input_gate_bias_" + direction};
+          utils::GetUniqueName(input_names[3], "_input_to_forget_gate_bias_" + direction),
+          utils::GetUniqueName(input_names[3], "_input_to_cell_gate_bias_" + direction),
+          utils::GetUniqueName(input_names[3], "_input_to_output_gate_bias_" + direction),
+          utils::GetUniqueName(input_names[3], "_input_to_input_gate_bias_" + direction),
+          utils::GetUniqueName(input_names[3], "_recurrent_to_forget_gate_bias_" + direction),
+          utils::GetUniqueName(input_names[3], "_recurrent_to_cell_gate_bias_" + direction),
+          utils::GetUniqueName(input_names[3], "_recurrent_to_output_gate_bias_" + direction),
+          utils::GetUniqueName(input_names[3], "_recurrent_to_input_gate_bias_" + direction)};
       for (size_t i = 0; i < 8; i++) {
         std::vector<std::vector<int32_t>> ranges = {{direction_idx, direction_idx + 1, 1},
                                                     {begins[i] * hidden_size_sign, (begins[i] + 1) * hidden_size_sign, 1}};
@@ -516,14 +516,14 @@ Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrapper,
                                                   input_tensor_infos[3].quant_param.Copy(), std::vector<uint32_t>(output_shape));
         ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(add_output_tensorwrapper)),
                           "QNN EP: Failed to add output tensor for inserted ElementWiseAdd node.");
-        ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(node_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_ELEMENT_WISE_ADD,
+        ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit, QNN_OP_ELEMENT_WISE_ADD), QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_ELEMENT_WISE_ADD,
                                                           std::move(add_input_names), {qnn_lstm_bias_name[i]}, {}, do_op_validation),
                           "Failed to create manually inserted ElementWiseAdd node.");
         qnn_lstm_input_names[qnn_input_indices[i]] = qnn_lstm_bias_name[i];
       }
     } else {
       // prepare zero bias
-      std::string zero_bias_name = node_name + "_zero_bias";
+      std::string zero_bias_name = utils::GetUniqueName(node_unit, "_zero_bias");
       QnnTensorWrapper zero_bias_tensor_wrapper(zero_bias_name,
                                                 QNN_TENSOR_TYPE_STATIC,
                                                 input_tensor_infos[0].qnn_data_type,
@@ -551,9 +551,9 @@ Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrapper,
     std::vector<uint32_t> qnn_input_indices = {18, 19, 20};
     std::vector<int32_t> begins = {0, 2, 1};
     std::vector<std::string> qnn_lstm_weight_name = {
-        input_names[7] + "_cell_to_input_gate_weight_" + direction,
-        input_names[7] + "_cell_to_forget_gate_weight_" + direction,
-        input_names[7] + "_cell_to_output_gate_weight_" + direction};
+        utils::GetUniqueName(input_names[7], "_cell_to_input_gate_weight_" + direction),
+        utils::GetUniqueName(input_names[7], "_cell_to_forget_gate_weight_" + direction),
+        utils::GetUniqueName(input_names[7], "_cell_to_output_gate_weight_" + direction)};
     for (size_t i = 0; i < 3; i++) {
       std::vector<std::vector<int32_t>> ranges = {
           {direction_idx, direction_idx + 1, 1},
@@ -595,7 +595,7 @@ Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrapper,
     std::vector<uint32_t> output_shape = {batch_size, hidden_size};
     for (size_t i = 0; i < 2; i++) {
       if (onnx_inputs.size() > src_indices[i] && onnx_inputs[src_indices[i]].node_arg.Exists()) {
-        std::string qnn_lstm_input_name = input_names[src_indices[i]] + "_" + direction;
+        const std::string qnn_lstm_input_name = utils::GetUniqueName(input_names[src_indices[i]], direction);
         ORT_RETURN_IF_ERROR(AddStridedSliceOrReshape(/*qnn_model_wrapper=*/qnn_model_wrapper,
                                                      /*node_unit=*/node_unit,
                                                      /*input_name=*/input_names[src_indices[i]],
@@ -615,7 +615,7 @@ Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrapper,
         qnn_lstm_input_names[qnn_input_indices[i]] = qnn_lstm_input_name;
       } else {
         // prepare zero initial values
-        std::string zero_initial_values_name = node_name + "_LSTM_initial_values_" + (i == 0 ? "h" : "c");
+        std::string zero_initial_values_name = utils::GetUniqueName(node_name, std::string("_LSTM_initial_values_") + (i == 0 ? "h" : "c"));
         QnnTensorWrapper zero_bias_tensor_wrapper(zero_initial_values_name,
                                                   QNN_TENSOR_TYPE_STATIC,
                                                   input_tensor_infos[0].qnn_data_type,
@@ -648,7 +648,7 @@ Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrapper,
       std::vector<std::vector<int32_t>> ranges = {{SafeInt<int32_t>(sequence_idx), SafeInt<int32_t>(sequence_idx + 1), 1},
                                                   {0, SafeInt<int32_t>(batch_size), 1},
                                                   {0, SafeInt<int32_t>(input_size), 1}};
-      std::string qnn_lstm_input_name = input_names[0] + "_cell_" + std::to_string(sequence_idx) + "_input";
+      std::string qnn_lstm_input_name = utils::GetUniqueName(input_names[0], "_cell_" + std::to_string(sequence_idx) + "_input");
       std::vector<uint32_t> output_shape = {batch_size, input_size};
       ORT_RETURN_IF_ERROR(AddStridedSliceOrReshape(/*qnn_model_wrapper=*/qnn_model_wrapper,
                                                    /*node_unit=*/node_unit,
@@ -673,9 +673,9 @@ Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrapper,
     std::vector<uint32_t> qnn_lstm_output_shape = {batch_size, hidden_size};
 
     std::vector<std::string> qnn_lstm_output_names = {
-        node_name + "_QNN_LSTM_output_all_hidden_state_" + std::to_string(sequence_idx) + "_" + direction,
-        node_name + "_QNN_LSTM_output_cell_state_" + std::to_string(sequence_idx) + "_" + direction,
-        node_name + "_QNN_LSTM_output_hidden_state_" + std::to_string(sequence_idx) + "_" + direction};
+        utils::GetUniqueName(node_unit, "_QNN_LSTM_output_all_hidden_state_" + std::to_string(sequence_idx) + "_" + direction),
+        utils::GetUniqueName(node_unit, "_QNN_LSTM_output_cell_state_" + std::to_string(sequence_idx) + "_" + direction),
+        utils::GetUniqueName(node_unit, "_QNN_LSTM_output_hidden_state_" + std::to_string(sequence_idx) + "_" + direction)};
     qnn_lstm_input_names[10] = qnn_lstm_output_names[2];  // update initial_h
     qnn_lstm_input_names[11] = qnn_lstm_output_names[1];  // update initial_c
     qnn_all_hidden_state_names[sequence_idx] = qnn_lstm_output_names[2];
@@ -689,7 +689,7 @@ Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrapper,
       ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)),
                         "QNN EP: Failed to add %ldth output tensor for QNN LSTM.", j);
     }
-    std::string lstm_node_name = node_name + "_cell_" + std::to_string(sequence_idx) + "_" + direction;
+    const std::string lstm_node_name = utils::GetUniqueName(node_unit, "_cell" + std::to_string(sequence_idx) + "_" + direction);
     ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(lstm_node_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_LSTM,
                                                       std::move(qnn_lstm_input_names_i), std::move(qnn_lstm_output_names),
                                                       std::vector<std::string>(param_names), do_op_validation),
@@ -697,7 +697,7 @@ Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrapper,
   }
 
   // pack all timestamp outputs together for onnx output[0]
-  std::string qnn_pack_output_name = node_name + "_QNN_LSTM_output_hidden_state_all_" + direction;
+  const std::string qnn_pack_output_name = utils::GetUniqueName(node_unit, "_QNN_LSTM_output_hidden_state_all_" + direction);
 
   // add pack for output[0]
   std::vector<std::string> pack_param_names;
@@ -731,7 +731,7 @@ Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrapper,
       {1, batch_size, hidden_size}};
   for (size_t i = 0; i < 3; i++) {
     if (onnx_outputs.size() > i && onnx_outputs[i].node_arg.Exists()) {
-      const std::string reshape_output_name = is_bidirection ? qnn_reshape_input_names[i] + "_unsqueeze_" + direction : onnx_outputs[i].node_arg.Name();
+      const std::string reshape_output_name = is_bidirection ? utils::GetUniqueName(qnn_reshape_input_names[i], "_unsqueeze_" + direction) : onnx_outputs[i].node_arg.Name();
       ORT_RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(/*input_name=*/qnn_reshape_input_names[i],
                                                            /*output_name=*/reshape_output_name,
                                                            /*input_shape=*/qnn_lstm_output_shapes[i],
@@ -786,7 +786,7 @@ Status LSTMOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
                                                      std::vector<uint32_t>(output_info.shape));
         ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(concat_output_tensorwrapper)),
                           "QNN EP: Failed to add output tensor for QNN Concat.");
-        ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(node_unit.Name(), QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_CONCAT,
+        ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit, QNN_OP_CONCAT), QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_CONCAT,
                                                           {uni_lstm_output_names_forward[i], uni_lstm_output_names_reverse[i]}, {onnx_output_name},
                                                           std::move(concat_param_names), do_op_validation),
                           "QNN EP: Failed to create Qnn Concat node.");

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/mean_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/mean_op_builder.cc
@@ -50,13 +50,12 @@ Status MeanOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
     ORT_RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(output.node_arg, output_shape), "Failed to get output shape.");
     std::vector<uint8_t> unpackage_data(sizeof(float));
 
-    const std::string add_output = sum_output + "_ort_qnn_ep_add_" + std::to_string(i);
+    const std::string add_output = utils::GetUniqueName(sum_output, "_add" + std::to_string(i));
     QnnTensorWrapper add_tensor(add_output, QNN_TENSOR_TYPE_NATIVE, input_info.qnn_data_type,
                                 QnnQuantParamsWrapper(), std::move(output_shape));
     ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(add_tensor)),
                       "Failed to add Add tensor wrapper.");
-    const std::string add_op_name = "Mean_Add_" + std::to_string(i);
-    ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(add_op_name,
+    ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit, QNN_OP_ELEMENT_WISE_ADD),
                                                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                       QNN_OP_ELEMENT_WISE_ADD,
                                                       {sum_output, input_names[i]},
@@ -74,7 +73,7 @@ Status MeanOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
   std::vector<uint8_t> divisor_data(sizeof(float));
   memcpy(divisor_data.data(), &divisor, sizeof(float));
 
-  const std::string divisor_name = sum_output + "_ort_qnn_ep_divisor";
+  const std::string divisor_name = utils::GetUniqueName(sum_output, "_divisor");
 
   QnnTensorWrapper divisor_tensor(divisor_name, QNN_TENSOR_TYPE_STATIC, input_info.qnn_data_type,
                                   QnnQuantParamsWrapper(), std::move(scalar_shape), std::move(divisor_data));
@@ -94,8 +93,7 @@ Status MeanOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
   ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensor)),
                     "Failed to add output tensor wrapper.");
   std::vector<std::string> div_inputs = {sum_output, divisor_name};
-  const std::string div_node_name = output_name + "_div";
-  ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(div_node_name,
+  ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit, QNN_OP_ELEMENT_WISE_DIVIDE),
                                                     QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                     QNN_OP_ELEMENT_WISE_DIVIDE,
                                                     {sum_output, divisor_name},

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/pool_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/pool_op_builder.cc
@@ -235,7 +235,7 @@ Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
   ORT_RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(reshape_input, reshape_input_info));
 
   bool needs_reshape = false;
-  const std::string reshape_prior_out = input_names[0] + "_prior_reshape";
+  const std::string reshape_prior_out = utils::GetUniqueName(input_names[0], "_reshape");
   if (input_shape.size() == 3) {
     needs_reshape = true;
     // build new_shape = {N, 1, C, L}
@@ -254,7 +254,7 @@ Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
     ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(reshape_prior_tensor)),
                       "Failed to add reshape prior tensor.");
     ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                          utils::GetNodeName(node_unit) + "_reshape_prior",
+                          utils::GetUniqueName(node_unit, QNN_OP_RESHAPE),
                           QNN_OP_PACKAGE_NAME_QTI_AISW,
                           QNN_OP_RESHAPE,
                           {input_names[0]},
@@ -445,8 +445,7 @@ Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
   }
   const auto& outputs = node_unit.Outputs();
   const std::string real_out = outputs[0].node_arg.Name();
-  const std::string pool_out = real_out + "_reshape_after";
-  const std::string qnn_op = GetQnnOpType(op_type);
+  const std::string pool_out = utils::GetUniqueName(real_out, "_reshape_after");
   TensorInfo output_info{};
   ORT_RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Outputs()[0], output_info));
   bool is_graph_output = qnn_model_wrapper.IsGraphOutput(real_out);
@@ -463,9 +462,9 @@ Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
       "Failed to add tensor for pool_out");
 
   ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                        utils::GetNodeName(node_unit) + "_pool2d",
+                        utils::GetUniqueName(node_unit, op_type),
                         QNN_OP_PACKAGE_NAME_QTI_AISW,
-                        qnn_op,
+                        GetQnnOpType(op_type),
                         {reshape_prior_out},
                         {pool_out},
                         std::move(param_tensor_names),
@@ -483,7 +482,7 @@ Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
   ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(reshape_after_tensor)),
                     "Failed to add reshape after tensor.");
   ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                        utils::GetNodeName(node_unit) + "_reshape_after",
+                        utils::GetUniqueName(node_unit, QNN_OP_RESHAPE),
                         QNN_OP_PACKAGE_NAME_QTI_AISW,
                         QNN_OP_RESHAPE,
                         {pool_out},

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/reciprocal_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/reciprocal_op_builder.cc
@@ -51,7 +51,7 @@ Status ReciprocalOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mod
   ORT_UNUSED_PARAMETER(logger);
 
   // Create a constant tensor for the divisor (1.0)
-  std::string divisor_name = node_unit.Name() + "_divisor";
+  std::string divisor_name = utils::GetUniqueName(node_unit, "_divisor");
   std::vector<uint32_t> divisor_shape{1};
   std::vector<uint8_t> divisor_data;
 
@@ -94,7 +94,7 @@ Status ReciprocalOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mod
   ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)), "Failed to add output tensor.");
 
   ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                        utils::GetNodeName(node_unit),
+                        utils::GetUniqueName(node_unit),
                         QNN_OP_PACKAGE_NAME_QTI_AISW,
                         QNN_OP_ELEMENT_WISE_DIVIDE,
                         {divisor_name, input_names[0]},

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/topk.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/topk.cc
@@ -96,7 +96,7 @@ Status TopKOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
   }
 
   // Add Transpose to permute axis to the last.
-  std::string transpose_output_name = input_names[0] + "_ort_qnn_ep_transpose";
+  const std::string transpose_output_name = utils::GetUniqueName(input_names[0], "_transpose");
   std::vector<uint32_t> transpose_perm;
   ORT_RETURN_IF_ERROR(utils::GetPermToLastAxis(static_cast<uint32_t>(axis),
                                                static_cast<uint32_t>(input_rank),
@@ -175,7 +175,7 @@ Status TopKOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
     // Since user may not be aware of the additional Transpose, the original output name of TopK node must be used by
     // the additional Transpose node which has the same output as original TopK node.
     const std::string& output_name = output.node_arg.Name();
-    std::string transpose_input_name = output_name + "_ort_qnn_ep_transpose";
+    const std::string transpose_input_name = utils::GetUniqueName(output_name, "_transpose");
     transpose_input_names.push_back(std::move(transpose_input_name));
 
     // Since the input of TopK node is permuted, its output shape must be manually calculated.
@@ -197,7 +197,7 @@ Status TopKOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
   }
 
   // Add TopK node.
-  ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetNodeName(node_unit),
+  ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit),
                                                     QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                     GetQnnOpType(node_unit.OpType()),
                                                     std::move(input_names),
@@ -228,7 +228,7 @@ Status TopKOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
     bool is_cast_required = output_idx == 1 && output_info.qnn_data_type == QNN_DATATYPE_INT_64 && is_graph_output;
     std::string cast_input_name = "";
     if (is_cast_required) {
-      cast_input_name = transpose_output_name + "_ort_qnn_ep_cast";
+      cast_input_name = utils::GetUniqueName(transpose_output_name, "_cast");
       // For the same reason described above, the original output name is now used by this Cast.
       transpose_output_name = cast_input_name;
       // Since additional Cast is added, below Transpose is no longer graph output.
@@ -255,7 +255,7 @@ Status TopKOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
                                                  std::vector<uint32_t>(output_info.shape));
       ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(cast_output_tensorwrapper)),
                         "Failed to add tensor.");
-      ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(cast_input_name,
+      ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit, QNN_OP_CAST),
                                                         QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                         QNN_OP_CAST,
                                                         {cast_input_name},

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/transpose_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/transpose_op_builder.cc
@@ -111,8 +111,8 @@ Status TransposeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
 
   // If a cast to int64 is needed, add the cast node
   if (needs_int64_cast) {
-    std::string cast_node_name = output_name + "_cast_int64";
-    std::string cast_input_name = output_name + "_cast_int64_aux";
+    std::string cast_node_name = utils::GetUniqueName(node_unit, "_cast_int64");
+    std::string cast_input_name = utils::GetUniqueName(output_name, "_cast_int64");
     std::string cast_output_name = output_name;
 
     // Create the cast input tensor wrapper
@@ -123,7 +123,7 @@ Status TransposeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
                                               std::move(output_shape));
 
     ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(cast_input_tensorwrapper)), "Failed to add tensor.");
-    cast_node_info_vec.push_back({cast_node_name, cast_input_name, cast_output_name});
+    cast_node_info_vec.emplace_back(CastNodeInfo{cast_node_name, cast_input_name, cast_output_name});
   }
 
   // Transpose output uses same data type and quantization parameter with input
@@ -140,7 +140,7 @@ Status TransposeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)), "Failed to add tensor.");
 
   output_names.push_back(output_name);
-  ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetNodeName(node_unit),
+  ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit),
                                                     QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                     QNN_OP_TRANSPOSE,
                                                     std::move(input_names),

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
@@ -514,7 +514,7 @@ Status QnnModelWrapper::AddReshapeNode(const std::string& input_name, const std:
   ORT_RETURN_IF_NOT(AddTensorWrapper(std::move(output_tensorwrapper)),
                     "QNN EP: Failed to add output tensor for inserted Reshape.");
 
-  ORT_RETURN_IF_NOT(CreateQnnNode(output_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_RESHAPE, {input_name},
+  ORT_RETURN_IF_NOT(CreateQnnNode(utils::GetUniqueName(output_name, QNN_OP_RESHAPE), QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_RESHAPE, {input_name},
                                   {output_name}, {}, do_op_validation),
                     "QNN EP: Failed to create manually inserted Qnn Reshape node.");
 
@@ -564,8 +564,7 @@ Status QnnModelWrapper::AddTransposeNode(NodeIndex node_index,
   uint32_t perm_size = static_cast<uint32_t>(transpose_perm.size());
   std::vector<uint32_t> perm_dim{perm_size};
   std::vector<uint32_t> transpose_perm_copy = transpose_perm;
-  const std::string& node_name = output_name;
-  QnnParamWrapper transpose_param(node_index, node_name, QNN_OP_TRANSPOSE_PARAM_PERM, std::move(perm_dim), std::move(transpose_perm_copy));
+  QnnParamWrapper transpose_param(node_index, output_name, QNN_OP_TRANSPOSE_PARAM_PERM, std::move(perm_dim), std::move(transpose_perm_copy));
   std::string param_tensor_name(transpose_param.GetParamTensorName());
   ORT_RETURN_IF_NOT(AddParamWrapper(std::move(transpose_param)), "Failed to add tensor.");
   Qnn_TensorType_t tensor_type = (false == is_for_output) ? QNN_TENSOR_TYPE_NATIVE : QNN_TENSOR_TYPE_APP_READ;
@@ -576,11 +575,9 @@ Status QnnModelWrapper::AddTransposeNode(NodeIndex node_index,
                                         quantize_param.Copy(),
                                         std::move(output_shape_copy));
   ORT_RETURN_IF_NOT(AddTensorWrapper(std::move(output_tensorwrapper)), "Failed to add tensor.");
-  const static std::string qnn_node_type = "Transpose";
-
-  ORT_RETURN_IF_NOT(CreateQnnNode(output_name,
+  ORT_RETURN_IF_NOT(CreateQnnNode(utils::GetUniqueName(output_name, QNN_OP_TRANSPOSE),
                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                  qnn_node_type,
+                                  QNN_OP_TRANSPOSE,
                                   {input_name},
                                   {output_name},
                                   {param_tensor_name},

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
@@ -186,7 +186,7 @@ class QnnModelWrapper {
                           bool is_for_input = true,
                           bool is_for_output = false);
 
-  // Tranpose NCHW->HWCN for QNN weight
+  // Transpose NCHW->HWCN for QNN weight
   Status AddNchwToHwcnTranspose(NodeIndex node_index,
                                 const std::string& input_name,
                                 const std::string& output_name,

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/channel_shuffle_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/channel_shuffle_fusion.cc
@@ -181,7 +181,7 @@ Status CreateOrValidateOnQnn(
   if (!validate) {
     ORT_RETURN_IF_NOT(qnn_model_wrapper->AddTensorWrapper(std::move(channel_shuffle_input)), "Failed to add input");
     ORT_RETURN_IF_NOT(qnn_model_wrapper->AddTensorWrapper(std::move(channel_shuffle_output)), "Failed to add output");
-    ORT_RETURN_IF_NOT(qnn_model_wrapper->CreateQnnNode(transpose_tail->Name(),
+    ORT_RETURN_IF_NOT(qnn_model_wrapper->CreateQnnNode(onnxruntime::qnn::utils::GetUniqueName(*transpose_tail),
                                                        QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                        QNN_OP_CHANNEL_SHUFFLE,
                                                        {cs_input_def.node_arg.Name()},

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/dq_q_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/dq_q_fusion.cc
@@ -89,7 +89,7 @@ static Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
                                     const NodeUnit& q_node_unit,
                                     bool validate) {
   assert(dq_node_unit.OpType() == DEQUANTIZE_LINEAR && q_node_unit.OpType() == QUANTIZE_LINEAR);
-  const auto& node_name = utils::GetNodeName(dq_node_unit);
+  const auto& node_name = utils::GetUniqueName(dq_node_unit);
   const NodeUnitIODef& input_def = dq_node_unit.Inputs()[0];
   const NodeUnitIODef& output_def = q_node_unit.Outputs()[0];
 
@@ -109,7 +109,7 @@ static Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
   } else {
     ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(input_tensor)), "Failed to add input");
     ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensor)), "Failed to add output");
-    ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetNodeName(q_node_unit),
+    ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(node_name,
                                                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                       QNN_OP_CONVERT,
                                                       {input_def.node_arg.Name()},

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/hardsigmoid_mul_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/hardsigmoid_mul_fusion.cc
@@ -106,7 +106,7 @@ static Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
                                     const NodeUnit& mul_node_unit,
                                     bool validate) {
   assert(hardsigmoid_node_unit.OpType() == "HardSigmoid" && mul_node_unit.OpType() == "Mul");
-  const auto& node_name = utils::GetNodeName(hardsigmoid_node_unit);
+  const auto& node_name = utils::GetUniqueName(hardsigmoid_node_unit);
   const NodeUnitIODef& input_def = hardsigmoid_node_unit.Inputs()[0];
   const NodeUnitIODef& output_def = mul_node_unit.Outputs()[0];
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/lpbqgemm_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/lpbqgemm_fusion.cc
@@ -191,7 +191,7 @@ Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
          act_dql_node_unit.OpType() == "DequantizeLinear" &&
          gemm_node_unit.OpType() == "Gemm" &&
          output_ql_node_unit.OpType() == "QuantizeLinear");
-  const auto& node_name = utils::GetNodeName(gemm_node_unit);
+  const auto& node_name = utils::GetUniqueName(gemm_node_unit);
   const NodeUnitIODef& act_dql_input_1_def = act_dql_node_unit.Inputs()[0];
   const NodeUnitIODef& w_dql_input_1_def = w_dql_node_unit.Inputs()[0];
   const NodeUnitIODef& w_ql_input_1_def = w_ql_node_unit.Inputs()[0];

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/lpbqmatmul_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/lpbqmatmul_fusion.cc
@@ -127,7 +127,7 @@ Status ProcessInput0(QnnModelWrapper& qnn_model_wrapper,
   std::string actual_input_0_name = original_input_0_name;
 
   if (reshape_input_0) {
-    actual_input_0_name = original_input_0_name + "_ort_qnn_ep_reshape";
+    actual_input_0_name = utils::GetUniqueName(original_input_0_name, "_reshape");
     std::vector<uint32_t> shape_2d{1, input_0_info.shape[0]};
     QnnQuantParamsWrapper quant_param_2d = input_0_info.quant_param.Copy();
     ORT_RETURN_IF_ERROR(quant_param_2d.HandleUnsqueeze<uint32_t>(input_0_info.shape, shape_2d));
@@ -329,7 +329,7 @@ Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
          w_ql_node_unit.OpType() == "QuantizeLinear" &&
          matmul_node_unit.OpType() == "MatMul");
 
-  const auto& node_name = utils::GetNodeName(matmul_node_unit);
+  const auto& node_name = utils::GetUniqueName(matmul_node_unit);
 
   std::vector<std::string> input_names;
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.cc
@@ -68,7 +68,7 @@ bool CheckShape(const Node& reshape_node) {
 Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper, const NodeUnit& reshape_node_unit,
                              const NodeUnit& gemm_node_unit, bool validate) {
   assert(reshape_node_unit.OpType() == "Reshape" && gemm_node_unit.OpType() == "Gemm");
-  const auto& node_name = utils::GetNodeName(gemm_node_unit);
+  const auto& node_name = utils::GetUniqueName(gemm_node_unit);
   const NodeUnitIODef& input_def = reshape_node_unit.Inputs()[0];
   const NodeUnitIODef& weight_def = gemm_node_unit.Inputs()[1];
   const NodeUnitIODef* bias_def_ptr = nullptr;

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/scale_softmax_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/scale_softmax_fusion.cc
@@ -152,8 +152,9 @@ Status CreateOrValidateOnQnn(
   ORT_RETURN_IF_ERROR(qnn_model_wrapper->MakeTensorWrapper(mul_input_other, fused_softmax_input));
   ORT_RETURN_IF_ERROR(qnn_model_wrapper->MakeTensorWrapper(softmax_output, fused_softmax_output));
 
+  const std::string node_name = onnxruntime::qnn::utils::GetUniqueName(*softmax);
   if (validate) {
-    ORT_RETURN_IF_ERROR(qnn_model_wrapper->ValidateQnnNode(softmax->Name(),
+    ORT_RETURN_IF_ERROR(qnn_model_wrapper->ValidateQnnNode(node_name,
                                                            QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                            QNN_OP_SOFTMAX,
                                                            {fused_softmax_input.GetQnnTensor()},
@@ -162,7 +163,7 @@ Status CreateOrValidateOnQnn(
   } else {
     ORT_RETURN_IF_NOT(qnn_model_wrapper->AddTensorWrapper(std::move(fused_softmax_input)), "Failed to add input");
     ORT_RETURN_IF_NOT(qnn_model_wrapper->AddTensorWrapper(std::move(fused_softmax_output)), "Failed to add output");
-    ORT_RETURN_IF_NOT(qnn_model_wrapper->CreateQnnNode(softmax->Name(),
+    ORT_RETURN_IF_NOT(qnn_model_wrapper->CreateQnnNode(node_name,
                                                        QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                        QNN_OP_SOFTMAX,
                                                        {mul_input_other.node_arg.Name()},

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/udo_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/udo_fusion.cc
@@ -99,7 +99,7 @@ static Status CreateOrValidateOnQnn(
     const logging::Logger& logger) {
   ORT_UNUSED_PARAMETER(do_op_validation);
 
-  std::string node_name = utils::GetNodeName(node_unit);
+  const std::string node_name = utils::GetUniqueName(node_unit);
 
   // get qnn inputs
   const auto& inputs = node_unit.Inputs();

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -790,13 +790,29 @@ Status GetQnnDataType(const bool is_quantized_tensor, const ONNX_NAMESPACE::Type
   return Status::OK();
 }
 
-const std::string& GetNodeName(const NodeUnit& node_unit) {
-  const std::string& node_name = node_unit.Name();
-  if (node_name.empty()) {
-    return node_unit.Outputs()[0].node_arg.Name();
+std::string GetUniqueName(const std::string& base, std::string_view suffix) {
+  std::string name = base;
+  if (!suffix.empty()) {
+    name += suffix;
   }
+  static std::unordered_map<std::string, int> counter;
+  int& count = counter[name];
+  if (count > 0) {
+    name += "_" + std::to_string(count);
+  }
+  ++count;
+  return name;
+}
 
-  return node_name;
+std::string GetUniqueName(const NodeUnit& node_unit, std::string_view suffix) {
+  // Preserve node name when exist. Otherwise, use op type with index
+  std::string base;
+  if (!node_unit.Name().empty()) {
+    base = node_unit.Name();
+  } else {
+    base = node_unit.OpType() + std::to_string(node_unit.Index());
+  }
+  return GetUniqueName(base, suffix);
 }
 
 bool OnnxDataTypeToQnnDataType(const int32_t onnx_data_type, Qnn_DataType_t& qnn_data_type, bool is_quantized) {
@@ -1380,10 +1396,9 @@ Status InsertConvertOp(QnnModelWrapper& qnn_model_wrapper,
                                                 QnnQuantParamsWrapper(scale, offset),
                                                 std::move(output_shape_copy));
   ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(convert_output_tensorwrapper)), "Failed to add tensor.");
-
-  ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(convert_output_name,
+  ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(convert_output_name, QNN_OP_CONVERT),
                                                     QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                                    "Convert",
+                                                    QNN_OP_CONVERT,
                                                     {convert_input_name},
                                                     {convert_output_name},
                                                     {},

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.h
@@ -90,7 +90,11 @@ std::ostream& operator<<(std::ostream& out, const QnnOpConfigWrapper& op_conf_wr
 Status GetQnnDataType(const bool is_quantized_tensor, const ONNX_NAMESPACE::TypeProto* type_proto,
                       Qnn_DataType_t& tensor_data_type);
 
-const std::string& GetNodeName(const NodeUnit& node_unit);
+// Returns an unique name string based on a base string and an optional suffix.
+std::string GetUniqueName(const std::string& base, std::string_view suffix = {});
+
+// Returns an unique name string from its name or op type and index, plus an optional suffix.
+std::string GetUniqueName(const NodeUnit& node_unit, std::string_view suffix = {});
 
 bool OnnxDataTypeToQnnDataType(const int32_t data_type, Qnn_DataType_t& qnn_data_type, bool is_quantized = false);
 


### PR DESCRIPTION
### Description
Enhance unique name generator for node and tensor names

### Motivation and Context
QNN requires node name to be unique. We've seen many instance of QNN node name conflicts results in failures on QNN graph finalizations. However, currently it's hard-coded and thus error-prone, this change adds utility to generate unique names used in QNN nodes and intermediate I/O tensors. 

