### PR TITLE
python: make print_debug_info robust when LD_LIBRARY_PATH is unset on Linux

### DIFF
--- a/onnxruntime/__init__.py
+++ b/onnxruntime/__init__.py
@@ -217,7 +217,7 @@ def print_debug_info():
     if platform.system() == "Windows":
         print(f"\nEnvironment variable:\nPATH={os.environ['PATH']}")
     elif platform.system() == "Linux":
-        print(f"\nEnvironment variable:\nLD_LIBRARY_PATH={os.environ['LD_LIBRARY_PATH']}")
+        print(f"\nEnvironment variable:\nLD_LIBRARY_PATH={os.environ.get('LD_LIBRARY_PATH', '(unset)')}")
 
     if importlib.util.find_spec("psutil"):
 

--- a/onnxruntime/__init__.py
+++ b/onnxruntime/__init__.py
@@ -215,7 +215,7 @@ def print_debug_info():
                 print(f"{package} not installed")
 
     if platform.system() == "Windows":
-        print(f"\nEnvironment variable:\nPATH={os.environ['PATH']}")
+        print(f"\nEnvironment variable:\nPATH={os.environ.get('PATH', '(unset)')}")
     elif platform.system() == "Linux":
         print(f"\nEnvironment variable:\nLD_LIBRARY_PATH={os.environ.get('LD_LIBRARY_PATH', '(unset)')}")
 


### PR DESCRIPTION
### Description

fixes #25700
