### PR TITLE
Fix swapped count and value arguments to `std::vector` constructor.

### DIFF
--- a/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
+++ b/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
@@ -685,7 +685,7 @@ TEST(TensorrtExecutionProviderTest, TRTPluginsCustomOpTest) {
   auto cuda_provider = DefaultCudaExecutionProvider();
   auto cpu_allocator = cuda_provider->CreatePreferredAllocators()[1];
   std::vector<int64_t> dims_op_x = {12, 256, 256};
-  std::vector<float> values_op_x(1.0f, 786432);  // 786432=12*256*256
+  std::vector<float> values_op_x(786432, 1.0f);  // 786432=12*256*256
   OrtValue ml_value_x;
   CreateMLValue<float>(cpu_allocator, dims_op_x, values_op_x, &ml_value_x);
   OrtValue ml_value_y;


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Fix swapped value and count arguments to `std::vector` constructor.

The `std::vector` constructor signature is:
`vector( size_type count, const T& value, const Allocator& alloc = Allocator() );`

https://en.cppreference.com/w/cpp/container/vector/vector.html

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix issue discovered after enabling warning.

```
Error: E:\_work\onnxruntime\onnxruntime\onnxruntime\test\providers\tensorrt\tensorrt_basic_test.cc(688,34): error C2220: the following warning is treated as an error [E:\_work\_temp\build\RelWithDebInfo\onnxruntime_provider_test.vcxproj]
Warning: E:\_work\onnxruntime\onnxruntime\onnxruntime\test\providers\tensorrt\tensorrt_basic_test.cc(688,34): warning C4244: 'argument': conversion from 'float' to 'const unsigned __int64', possible loss of data [E:\_work\_temp\build\RelWithDebInfo\onnxruntime_provider_test.vcxproj]
```