### PR TITLE
Fix bug for same option provided multiple times in perf test

### DIFF
--- a/onnxruntime/test/perftest/strings_helper.cc
+++ b/onnxruntime/test/perftest/strings_helper.cc
@@ -56,6 +56,34 @@ void ParseSessionConfigs(const std::string& configs_string,
   }
 }
 
+bool ParseDimensionOverride(const std::string& input, std::map<std::string, int64_t>& free_dim_override_map) {
+  std::stringstream ss(input);
+  std::string free_dim_str;
+
+  while (std::getline(ss, free_dim_str, ';')) {
+    if (!free_dim_str.empty()) {
+      size_t delimiter_location = free_dim_str.find(":");
+      if (delimiter_location >= free_dim_str.size() - 1) {
+        return false;
+      }
+      std::string dim_identifier = free_dim_str.substr(0, delimiter_location);
+      std::string override_val_str = free_dim_str.substr(delimiter_location + 1, std::string::npos);
+      ORT_TRY {
+        int64_t override_val = std::stoll(override_val_str.c_str());
+        if (override_val <= 0) {
+          return false;
+        }
+        free_dim_override_map[dim_identifier] = override_val;
+      }
+      ORT_CATCH(...) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
 void ParseEpOptions(const std::string& input, std::vector<std::unordered_map<std::string, std::string>>& result) {
   auto tokens = utils::SplitString(input, ";", true);
 

--- a/onnxruntime/test/perftest/strings_helper.h
+++ b/onnxruntime/test/perftest/strings_helper.h
@@ -14,6 +14,8 @@ void ParseSessionConfigs(const std::string& configs_string,
                          std::unordered_map<std::string, std::string>& session_configs,
                          const std::unordered_set<std::string>& available_keys = {});
 
+bool ParseDimensionOverride(const std::string& input, std::map<std::string, int64_t>& free_dim_override_map);
+
 void ParseEpList(const std::string& input, std::vector<std::string>& result);
 
 void ParseEpOptions(const std::string& input, std::vector<std::unordered_map<std::string, std::string>>& result);


### PR DESCRIPTION
### Description
If an option appears multiple times:
Unlike `getopt` just returns it again in the parsing loop, `Abseil` processes them in order, and the last one wins (overwrites earlier values).

This PR fixes the bug for `-f` free dimension override by name and `-F `free dimension override by denotation. 
see https://github.com/microsoft/onnxruntime/issues/25714