### PR TITLE
Add build.py `--targets` option to specify multiple targets. Update existing list-valued options to use argparse "extend" action.

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -203,10 +203,6 @@ def add_default_definition(definition_list, key, default_value):
     definition_list.append(key + "=" + default_value)
 
 
-def normalize_arg_list(nested_list):
-    return [i for j in nested_list for i in j] if nested_list else []
-
-
 def number_of_parallel_jobs(args):
     return os.cpu_count() if args.parallel == 0 else args.parallel
 
@@ -986,7 +982,7 @@ def generate_build_tree(
             ]
 
         # add default emscripten settings
-        emscripten_settings = normalize_arg_list(args.emscripten_settings)
+        emscripten_settings = list(args.emscripten_settings)
 
         # set -s MALLOC
         if args.wasm_malloc is not None:
@@ -1330,13 +1326,14 @@ def clean_targets(cmake_path, build_dir, configs):
         run_subprocess(cmd_args)
 
 
-def build_targets(args, cmake_path, build_dir, configs, num_parallel_jobs, target=None):
+def build_targets(args, cmake_path, build_dir, configs, num_parallel_jobs, targets: list[str] | None):
     for config in configs:
         log.info("Building targets for %s configuration", config)
         build_dir2 = get_config_build_dir(build_dir, config)
         cmd_args = [cmake_path, "--build", build_dir2, "--config", config]
-        if target:
-            cmd_args.extend(["--target", target])
+        if targets:
+            log.info(f"Building specified targets: {targets}")
+            cmd_args.extend(["--target", *targets])
 
         build_tool_args = []
         if num_parallel_jobs != 1:
@@ -2060,12 +2057,12 @@ def build_nuget_package(
             # use the sln that include the mobile targets
             sln = "OnnxRuntime.CSharp.sln"
 
-    # explicitly exclude mobile targets in this case
-    if sln != "OnnxRuntime.CSharp.sln" and have_exclude_mobile_targets_option is False:
-        msbuild_extra_options.append("IncludeMobileTargets=false")
-
     # expand extra_options to add prefix
     extra_options = ["/p:" + option for option in msbuild_extra_options]
+
+    # explicitly exclude mobile targets in this case
+    if sln != "OnnxRuntime.CSharp.sln" and have_exclude_mobile_targets_option is False:
+        extra_options.append("/p:IncludeMobileTargets=false")
 
     # we have to use msbuild directly if including Xamarin targets as dotnet only supports MAUI (.net6)
     use_dotnet = sln != "OnnxRuntime.CSharp.sln"
@@ -2281,7 +2278,7 @@ def main():
                     "Running as root is not allowed. If you really want to do that, use '--allow_running_as_root'."
                 )
 
-    cmake_extra_defines = normalize_arg_list(args.cmake_extra_defines)
+    cmake_extra_defines = list(args.cmake_extra_defines)
 
     if args.use_tensorrt:
         args.use_cuda = True
@@ -2560,7 +2557,7 @@ def main():
         if args.parallel < 0:
             raise BuildError(f"Invalid parallel job count: {args.parallel}")
         num_parallel_jobs = number_of_parallel_jobs(args)
-        build_targets(args, cmake_path, build_dir, configs, num_parallel_jobs, args.target)
+        build_targets(args, cmake_path, build_dir, configs, num_parallel_jobs, args.targets)
 
     if args.test:
         if args.enable_onnx_tests:
@@ -2629,7 +2626,7 @@ def main():
                 getattr(args, "use_dml", False),
                 args.use_migraphx,
                 args.enable_training_apis,
-                normalize_arg_list(args.msbuild_extra_options),
+                args.msbuild_extra_options,
             )
 
     if args.test and args.build_nuget:
@@ -2642,7 +2639,7 @@ def main():
             args.use_dnnl,
             args.enable_training_apis,
             configs,
-            normalize_arg_list(args.msbuild_extra_options),
+            args.msbuild_extra_options,
         )
 
     if args.gen_doc:

--- a/tools/ci_build/build_args.py
+++ b/tools/ci_build/build_args.py
@@ -122,7 +122,21 @@ def add_core_build_args(parser: argparse.ArgumentParser) -> None:
         type=int,
         help="Use parallel build. Optional value specifies max jobs (0=num CPUs).",
     )
-    parser.add_argument("--target", help="Build a specific CMake target (e.g., winml_dll).")
+    parser.add_argument(
+        "--target",
+        nargs=1,
+        action="extend",
+        metavar="TARGET",
+        dest="targets",
+        help="Build a specific CMake target (e.g., winml_dll).",
+    )
+    parser.add_argument(
+        "--targets",
+        nargs="+",
+        action="extend",
+        default=[],
+        help="Build one or more specific CMake targets.",
+    )
     parser.add_argument(
         "--compile_no_warning_as_error",
         action="store_true",
@@ -146,7 +160,8 @@ def add_cmake_build_config_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--cmake_extra_defines",
         nargs="+",
-        action="append",
+        action="extend",
+        default=[],
         help="Extra CMake definitions (-D<key>=<value>). Provide as <key>=<value>.",
     )
     parser.add_argument("--cmake_path", default="cmake", help="Path to the CMake executable.")
@@ -366,7 +381,8 @@ def add_webassembly_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--emscripten_settings",
         nargs="+",
-        action="append",
+        action="extend",
+        default=[],
         help="Extra emscripten settings (-s <key>=<value>). Provide as <key>=<value>.",
     )
 
@@ -562,7 +578,8 @@ def add_csharp_binding_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--msbuild_extra_options",
         nargs="+",
-        action="append",
+        action="extend",
+        default=[],
         help="Extra MSBuild properties (/p:key=value). Provide as key=value.",
     )
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

- Add build.py `--targets` option to specify multiple targets.
- Update existing list-valued options to use argparse "extend" action. Unlike "append", "extend" won't create nested lists.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Allow multiple targets to be specified. Use newer argparse feature to simplify option handling.