### PR TITLE
Added pow support for datatypes

### DIFF
--- a/docs/OperatorKernels.md
+++ b/docs/OperatorKernels.md
@@ -287,7 +287,7 @@ Do not modify directly.*
 |||[11, 12]|**T** = tensor(double), tensor(float), tensor(int32), tensor(int64), tensor(int8), tensor(uint32), tensor(uint64), tensor(uint8)|
 |||[2, 10]|**T** = tensor(double), tensor(float)|
 |ParametricSoftplus|*in* X:**T**<br> *out* Y:**T**|1+|**T** = tensor(float)|
-|Pow|*in* X:**T**<br> *in* Y:**T**<br> *out* Z:**T**<br><br>or<br><br>*in* X:**T**<br> *in* Y:**T1**<br> *out* Z:**T**|15+|**T** = tensor(double), tensor(float), tensor(int32), tensor(int64)<br/> **T1** = tensor(double), tensor(float), tensor(int32), tensor(int64)|
+|Pow|*in* X:**T**<br> *in* Y:**T**<br> *out* Z:**T**<br><br>or<br><br>*in* X:**T**<br> *in* Y:**T1**<br> *out* Z:**T**|15+|**T** = tensor(double), tensor(float), tensor(int32), tensor(int64)<br/> **T1** = tensor(double), tensor(float), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64)|
 |||[13, 14]|**T** = tensor(double), tensor(float), tensor(int32), tensor(int64)<br/> **T1** = tensor(double), tensor(float), tensor(int32), tensor(int64)|
 |||12|**T** = tensor(double), tensor(float), tensor(int32), tensor(int64)<br/> **T1** = tensor(double), tensor(float), tensor(int32), tensor(int64)|
 |||[7, 11]|**T** = tensor(double), tensor(float)|

--- a/onnxruntime/core/providers/cpu/math/element_wise_ops.cc
+++ b/onnxruntime/core/providers/cpu/math/element_wise_ops.cc
@@ -699,11 +699,29 @@ Status DispatchOnBase(OpKernelContext& context, const Tensor& Y) {
   namespace on = ONNX_NAMESPACE;
   Status s;
   switch (Y.GetElementType()) {
+    case on::TensorProto_DataType_INT8:
+      PowImpl<B, int8_t>(context);
+      break;
+    case on::TensorProto_DataType_UINT8:
+      PowImpl<B, uint8_t>(context);
+      break;
+    case on::TensorProto_DataType_INT16:
+      PowImpl<B, int16_t>(context);
+      break;
+    case on::TensorProto_DataType_UINT16:
+      PowImpl<B, uint16_t>(context);
+      break;
     case on::TensorProto_DataType_INT32:
       PowImpl<B, int32_t>(context);
       break;
+    case on::TensorProto_DataType_UINT32:
+      PowImpl<B, uint32_t>(context);
+      break;
     case on::TensorProto_DataType_INT64:
       PowImpl<B, int64_t>(context);
+      break;
+    case on::TensorProto_DataType_UINT64:
+      PowImpl<B, uint64_t>(context);
       break;
     case on::TensorProto_DataType_FLOAT:
       PowImpl<B, float>(context);

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -1423,6 +1423,60 @@ TEST(MathOpTest, Pow_double_int64) {
   test.Run();
 }
 
+TEST(MathOpTest, Pow_double_uint64) {
+  OpTester test("Pow", 12);
+  std::vector<int64_t> dims{3};
+  test.AddInput<double>("X", dims, {1., 2., 3.});
+  test.AddInput<uint64_t>("Y", dims, {4, uint64_t(1) << 63, 6});
+  test.AddOutput<double>("Z", dims, {1., std::pow(2., uint64_t(1) << 63), 729.});
+  test.Run();
+}
+
+TEST(MathOpTest, Pow_double_uint32) {
+  OpTester test("Pow", 12);
+  std::vector<int64_t> dims{3};
+  test.AddInput<double>("X", dims, {1., 2., 3.});
+  test.AddInput<uint32_t>("Y", dims, {4, uint32_t(1) << 31, 6});
+  test.AddOutput<double>("Z", dims, {1., std::pow(2., uint32_t(1) << 31), 729.});
+  test.Run();
+}
+
+TEST(MathOpTest, Pow_double_uint16) {
+  OpTester test("Pow", 12);
+  std::vector<int64_t> dims{3};
+  test.AddInput<double>("X", dims, {1., 2., 3.});
+  test.AddInput<uint16_t>("Y", dims, {4, uint16_t(1) << 15, 6});
+  test.AddOutput<double>("Z", dims, {1., std::pow(2., uint16_t(1) << 15), 729.});
+  test.Run();
+}
+
+TEST(MathOpTest, Pow_double_int16) {
+  OpTester test("Pow", 12);
+  std::vector<int64_t> dims{3};
+  test.AddInput<double>("X", dims, {1., 2., 3.});
+  test.AddInput<int16_t>("Y", dims, {4, int16_t(1) << 14, 6});
+  test.AddOutput<double>("Z", dims, {1., std::pow(2., int16_t(1) << 14), 729.});
+  test.Run();
+}
+
+TEST(MathOpTest, Pow_double_uint8) {
+  OpTester test("Pow", 12);
+  std::vector<int64_t> dims{3};
+  test.AddInput<double>("X", dims, {1., 2., 3.});
+  test.AddInput<uint8_t>("Y", dims, {4, uint8_t(1) << 7, 6});
+  test.AddOutput<double>("Z", dims, {1., std::pow(2., uint8_t(1) << 7), 729.});
+  test.Run();
+}
+
+TEST(MathOpTest, Pow_double_int8) {
+  OpTester test("Pow", 12);
+  std::vector<int64_t> dims{3};
+  test.AddInput<double>("X", dims, {1., 2., 3.});
+  test.AddInput<int8_t>("Y", dims, {4, int8_t(1) << 6, 6});
+  test.AddOutput<double>("Z", dims, {1., std::pow(2., int8_t(1) << 6), 729.});
+  test.Run();
+}
+
 TEST(MathOpTest, Pow_float16_float16) {
   std::vector<int64_t> dims{4};
   TestBinaryFloat16("Pow", dims, {2.0f, 2.0f, std::sqrt(2.0f), 1.0f}, dims, {0.0f, 8.0f, 2.0f, 9.0f},


### PR DESCRIPTION
### Description
I added support for the datatypes ``uint8``, ``int8``, ``uint16``, ``int16``, ``uint32``, ``uint64`` for the ``Y`` argument of the cpu kernel of the ``pow`` operator.



### Motivation and Context
We need especially ``uint64`` to be supported for [ndonnx](https://github.com/Quantco/ndonnx). Nowadays, ``ndonnx`` supports ``pow`` for ``uint64`` via a lossy cast to ``int64``.


