### PR TITLE
[QNN EP] Disable tests broken by QNN 2.37

### DIFF
--- a/onnxruntime/test/providers/qnn/qnn_node_group/lpbqgemm_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/lpbqgemm_fusion_test.cc
@@ -107,7 +107,12 @@ ProviderOptions GetProviderOptions() {
 
 }  // namespace
 
+#if defined(_WIN32)
+// Graph fails to compose on ARM64 Windows since QNN 2.37.0
+TEST_F(QnnHTPBackendTests, DISABLED_LPBQGemmFusion) {
+#else
 TEST_F(QnnHTPBackendTests, LPBQGemmFusion) {
+#endif
   ProviderOptions provider_options = GetProviderOptions();
   RunQnnModelTest(BuildLPBQGemmTestCase(),
                   provider_options,

--- a/onnxruntime/test/providers/qnn/qnn_node_group/lpbqmatmul_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/lpbqmatmul_fusion_test.cc
@@ -106,7 +106,12 @@ ProviderOptions GetProviderOptions() {
 
 }  // namespace
 
+#if defined(_WIN32)
+// Graph fails to compose on ARM64 Windows since QNN 2.37.0
+TEST_F(QnnHTPBackendTests, DISABLED_LPBQMatMulFusion) {
+#else
 TEST_F(QnnHTPBackendTests, LPBQMatMulFusion) {
+#endif
   ProviderOptions provider_options = GetProviderOptions();
   RunQnnModelTest(BuildLPBQMatMulTestCase(),
                   provider_options,


### PR DESCRIPTION
### Description

Disable two tests that were broken on X Elite by upgrading to QNN 2.37.0


