### PR TITLE
[WebGPU] upgrade wgsl-template to 0.1.14

### DIFF
--- a/onnxruntime/core/providers/webgpu/wgsl_templates/package-lock.json
+++ b/onnxruntime/core/providers/webgpu/wgsl_templates/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@fs-eire/wgsl-template": "^0.1.13"
+        "@fs-eire/wgsl-template": "^0.1.14"
       }
     },
     "node_modules/@fs-eire/wgsl-template": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/@fs-eire/wgsl-template/-/wgsl-template-0.1.13.tgz",
-      "integrity": "sha512-SOQjVCQCUmXb9qYr2E3CKNs88/FzINuhFJiobBEkSAsyKtJby9oFWGZnrEO+hIl/oDTLA01LbjiDxuf6TGHE/w==",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/@fs-eire/wgsl-template/-/wgsl-template-0.1.14.tgz",
+      "integrity": "sha512-tEECRz7gAWH+NWGRWGNk9IIs4LRpYN9wsy9jzJklopvDcHpg3If8XY3tphggnpr9Otq4jUiqCLZCfQIBg515Mg==",
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.8"

--- a/onnxruntime/core/providers/webgpu/wgsl_templates/package.json
+++ b/onnxruntime/core/providers/webgpu/wgsl_templates/package.json
@@ -10,6 +10,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@fs-eire/wgsl-template": "^0.1.13"
+    "@fs-eire/wgsl-template": "^0.1.14"
   }
 }


### PR DESCRIPTION
### Description

Upgrade wgsl-template to 0.1.14.

Includes the following changes:
- show original file/line if different
- allow duplicated params
- [bugfix] show source lines correctly for generation errors
