### PR TITLE
Add missing einsum kernels

### DIFF
--- a/onnxruntime/core/providers/cpu/math/einsum.cc
+++ b/onnxruntime/core/providers/cpu/math/einsum.cc
@@ -107,6 +107,84 @@ Status Einsum::DeviceCompute(OpKernelContext* context, const std::vector<const T
                                               EinsumOp::DeviceHelpers::CpuDeviceHelpers::DataCopy);
 
     return einsum_compute_processor.Run();
+  } else if (inputs[0]->IsDataType<uint32_t>()) {
+    auto einsum_compute_processor = EinsumTypedComputeProcessor<uint32_t>(context,
+                                                                          allocator,
+                                                                          tp,
+                                                                          einsum_compute_preprocessor,
+                                                                          nullptr);
+
+    einsum_compute_processor.SetDeviceHelpers(EinsumOp::DeviceHelpers::CpuDeviceHelpers::Transpose,
+                                              EinsumOp::DeviceHelpers::CpuDeviceHelpers::MatMul<uint32_t>,
+                                              EinsumOp::DeviceHelpers::CpuDeviceHelpers::ReduceSum<uint32_t>,
+                                              EinsumOp::DeviceHelpers::CpuDeviceHelpers::DataCopy);
+
+    return einsum_compute_processor.Run();
+  } else if (inputs[0]->IsDataType<uint64_t>()) {
+    auto einsum_compute_processor = EinsumTypedComputeProcessor<uint64_t>(context,
+                                                                          allocator,
+                                                                          tp,
+                                                                          einsum_compute_preprocessor,
+                                                                          nullptr);
+
+    einsum_compute_processor.SetDeviceHelpers(EinsumOp::DeviceHelpers::CpuDeviceHelpers::Transpose,
+                                              EinsumOp::DeviceHelpers::CpuDeviceHelpers::MatMul<uint64_t>,
+                                              EinsumOp::DeviceHelpers::CpuDeviceHelpers::ReduceSum<uint64_t>,
+                                              EinsumOp::DeviceHelpers::CpuDeviceHelpers::DataCopy);
+
+    return einsum_compute_processor.Run();
+  } else if (inputs[0]->IsDataType<int16_t>()) {
+    auto einsum_compute_processor = EinsumTypedComputeProcessor<int16_t>(context,
+                                                                         allocator,
+                                                                         tp,
+                                                                         einsum_compute_preprocessor,
+                                                                         nullptr);
+
+    einsum_compute_processor.SetDeviceHelpers(EinsumOp::DeviceHelpers::CpuDeviceHelpers::Transpose,
+                                              EinsumOp::DeviceHelpers::CpuDeviceHelpers::MatMul<int16_t>,
+                                              EinsumOp::DeviceHelpers::CpuDeviceHelpers::ReduceSum<int16_t>,
+                                              EinsumOp::DeviceHelpers::CpuDeviceHelpers::DataCopy);
+
+    return einsum_compute_processor.Run();
+  } else if (inputs[0]->IsDataType<uint16_t>()) {
+    auto einsum_compute_processor = EinsumTypedComputeProcessor<uint16_t>(context,
+                                                                          allocator,
+                                                                          tp,
+                                                                          einsum_compute_preprocessor,
+                                                                          nullptr);
+
+    einsum_compute_processor.SetDeviceHelpers(EinsumOp::DeviceHelpers::CpuDeviceHelpers::Transpose,
+                                              EinsumOp::DeviceHelpers::CpuDeviceHelpers::MatMul<uint16_t>,
+                                              EinsumOp::DeviceHelpers::CpuDeviceHelpers::ReduceSum<uint16_t>,
+                                              EinsumOp::DeviceHelpers::CpuDeviceHelpers::DataCopy);
+
+    return einsum_compute_processor.Run();
+  } else if (inputs[0]->IsDataType<int8_t>()) {
+    auto einsum_compute_processor = EinsumTypedComputeProcessor<int8_t>(context,
+                                                                        allocator,
+                                                                        tp,
+                                                                        einsum_compute_preprocessor,
+                                                                        nullptr);
+
+    einsum_compute_processor.SetDeviceHelpers(EinsumOp::DeviceHelpers::CpuDeviceHelpers::Transpose,
+                                              EinsumOp::DeviceHelpers::CpuDeviceHelpers::MatMul<int8_t>,
+                                              EinsumOp::DeviceHelpers::CpuDeviceHelpers::ReduceSum<int8_t>,
+                                              EinsumOp::DeviceHelpers::CpuDeviceHelpers::DataCopy);
+
+    return einsum_compute_processor.Run();
+  } else if (inputs[0]->IsDataType<uint8_t>()) {
+    auto einsum_compute_processor = EinsumTypedComputeProcessor<uint8_t>(context,
+                                                                         allocator,
+                                                                         tp,
+                                                                         einsum_compute_preprocessor,
+                                                                         nullptr);
+
+    einsum_compute_processor.SetDeviceHelpers(EinsumOp::DeviceHelpers::CpuDeviceHelpers::Transpose,
+                                              EinsumOp::DeviceHelpers::CpuDeviceHelpers::MatMul<uint8_t>,
+                                              EinsumOp::DeviceHelpers::CpuDeviceHelpers::ReduceSum<uint8_t>,
+                                              EinsumOp::DeviceHelpers::CpuDeviceHelpers::DataCopy);
+
+    return einsum_compute_processor.Run();
   }
 
   return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED,

--- a/onnxruntime/core/providers/cpu/math/einsum_utils/einsum_auxiliary_ops.cc
+++ b/onnxruntime/core/providers/cpu/math/einsum_utils/einsum_auxiliary_ops.cc
@@ -453,6 +453,156 @@ template std::unique_ptr<Tensor> ReduceSum<int64_t>(
     gsl::span<const int64_t> reduce_axes, AllocatorPtr allocator,
     concurrency::ThreadPool* tp, void* einsum_cuda_assets, const DeviceHelpers::ReduceSum<int64_t>& reduce_sum_func);
 
+// uint32_t
+template Status DeviceHelpers::CpuDeviceHelpers::MatMul<uint32_t>(
+    const uint32_t* input_1_data, const uint32_t* input_2_data, uint32_t* output_data,
+    size_t left_stride, size_t right_stride, size_t output_stride,
+    size_t num_batches, size_t M, size_t K, size_t N, concurrency::ThreadPool* tp,
+    void* einsum_cuda_assets);
+
+template std::unique_ptr<Tensor> MatMul<uint32_t>(
+    const Tensor& input_1, const gsl::span<const int64_t>& input_shape_1_override,
+    const Tensor& input_2, const gsl::span<const int64_t>& input_shape_2_override,
+    AllocatorPtr allocator, concurrency::ThreadPool* tp, void* einsum_cuda_assets,
+    const DeviceHelpers::MatMul<uint32_t>& device_matmul_func);
+
+template std::unique_ptr<Tensor> DeviceHelpers::CpuDeviceHelpers::ReduceSum<uint32_t>(
+    const Tensor& input, gsl::span<const int64_t> reduce_axes,
+    bool keep_dims, AllocatorPtr allocator,
+    const TensorShape* input_shape_override,
+    concurrency::ThreadPool* tp, void* einsum_cuda_assets);
+
+template std::unique_ptr<Tensor> ReduceSum<uint32_t>(
+    const Tensor& input, const TensorShape& input_shape_override,
+    gsl::span<const int64_t> reduce_axes, AllocatorPtr allocator,
+    concurrency::ThreadPool* tp, void* einsum_cuda_assets,
+    const DeviceHelpers::ReduceSum<uint32_t>& device_reduce_sum_func);
+
+// uint64_t
+template Status DeviceHelpers::CpuDeviceHelpers::MatMul<uint64_t>(
+    const uint64_t* input_1_data, const uint64_t* input_2_data, uint64_t* output_data,
+    size_t left_stride, size_t right_stride, size_t output_stride,
+    size_t num_batches, size_t M, size_t K, size_t N, concurrency::ThreadPool* tp,
+    void* einsum_cuda_assets);
+
+template std::unique_ptr<Tensor> MatMul<uint64_t>(
+    const Tensor& input_1, const gsl::span<const int64_t>& input_shape_1_override,
+    const Tensor& input_2, const gsl::span<const int64_t>& input_shape_2_override,
+    AllocatorPtr allocator, concurrency::ThreadPool* tp, void* einsum_cuda_assets,
+    const DeviceHelpers::MatMul<uint64_t>& device_matmul_func);
+
+template std::unique_ptr<Tensor> DeviceHelpers::CpuDeviceHelpers::ReduceSum<uint64_t>(
+    const Tensor& input, gsl::span<const int64_t> reduce_axes,
+    bool keep_dims, AllocatorPtr allocator,
+    const TensorShape* input_shape_override,
+    concurrency::ThreadPool* tp, void* einsum_cuda_assets);
+
+template std::unique_ptr<Tensor> ReduceSum<uint64_t>(
+    const Tensor& input, const TensorShape& input_shape_override,
+    gsl::span<const int64_t> reduce_axes, AllocatorPtr allocator,
+    concurrency::ThreadPool* tp, void* einsum_cuda_assets,
+    const DeviceHelpers::ReduceSum<uint64_t>& device_reduce_sum_func);
+
+// uint16_t
+template Status DeviceHelpers::CpuDeviceHelpers::MatMul<uint16_t>(
+    const uint16_t* input_1_data, const uint16_t* input_2_data, uint16_t* output_data,
+    size_t left_stride, size_t right_stride, size_t output_stride,
+    size_t num_batches, size_t M, size_t K, size_t N, concurrency::ThreadPool* tp,
+    void* einsum_cuda_assets);
+
+template std::unique_ptr<Tensor> MatMul<uint16_t>(
+    const Tensor& input_1, const gsl::span<const int64_t>& input_shape_1_override,
+    const Tensor& input_2, const gsl::span<const int64_t>& input_shape_2_override,
+    AllocatorPtr allocator, concurrency::ThreadPool* tp, void* einsum_cuda_assets,
+    const DeviceHelpers::MatMul<uint16_t>& device_matmul_func);
+
+template std::unique_ptr<Tensor> DeviceHelpers::CpuDeviceHelpers::ReduceSum<uint16_t>(
+    const Tensor& input, gsl::span<const int64_t> reduce_axes,
+    bool keep_dims, AllocatorPtr allocator,
+    const TensorShape* input_shape_override,
+    concurrency::ThreadPool* tp, void* einsum_cuda_assets);
+
+template std::unique_ptr<Tensor> ReduceSum<uint16_t>(
+    const Tensor& input, const TensorShape& input_shape_override,
+    gsl::span<const int64_t> reduce_axes, AllocatorPtr allocator,
+    concurrency::ThreadPool* tp, void* einsum_cuda_assets,
+    const DeviceHelpers::ReduceSum<uint16_t>& device_reduce_sum_func);
+
+// int16_t
+template Status DeviceHelpers::CpuDeviceHelpers::MatMul<int16_t>(
+    const int16_t* input_1_data, const int16_t* input_2_data, int16_t* output_data,
+    size_t left_stride, size_t right_stride, size_t output_stride,
+    size_t num_batches, size_t M, size_t K, size_t N, concurrency::ThreadPool* tp,
+    void* einsum_cuda_assets);
+
+template std::unique_ptr<Tensor> MatMul<int16_t>(
+    const Tensor& input_1, const gsl::span<const int64_t>& input_shape_1_override,
+    const Tensor& input_2, const gsl::span<const int64_t>& input_shape_2_override,
+    AllocatorPtr allocator, concurrency::ThreadPool* tp, void* einsum_cuda_assets,
+    const DeviceHelpers::MatMul<int16_t>& device_matmul_func);
+
+template std::unique_ptr<Tensor> DeviceHelpers::CpuDeviceHelpers::ReduceSum<int16_t>(
+    const Tensor& input, gsl::span<const int64_t> reduce_axes,
+    bool keep_dims, AllocatorPtr allocator,
+    const TensorShape* input_shape_override,
+    concurrency::ThreadPool* tp, void* einsum_cuda_assets);
+
+template std::unique_ptr<Tensor> ReduceSum<int16_t>(
+    const Tensor& input, const TensorShape& input_shape_override,
+    gsl::span<const int64_t> reduce_axes, AllocatorPtr allocator,
+    concurrency::ThreadPool* tp, void* einsum_cuda_assets,
+    const DeviceHelpers::ReduceSum<int16_t>& device_reduce_sum_func);
+
+// uint8_t
+template Status DeviceHelpers::CpuDeviceHelpers::MatMul<uint8_t>(
+    const uint8_t* input_1_data, const uint8_t* input_2_data, uint8_t* output_data,
+    size_t left_stride, size_t right_stride, size_t output_stride,
+    size_t num_batches, size_t M, size_t K, size_t N, concurrency::ThreadPool* tp,
+    void* einsum_cuda_assets);
+
+template std::unique_ptr<Tensor> MatMul<uint8_t>(
+    const Tensor& input_1, const gsl::span<const int64_t>& input_shape_1_override,
+    const Tensor& input_2, const gsl::span<const int64_t>& input_shape_2_override,
+    AllocatorPtr allocator, concurrency::ThreadPool* tp, void* einsum_cuda_assets,
+    const DeviceHelpers::MatMul<uint8_t>& device_matmul_func);
+
+template std::unique_ptr<Tensor> DeviceHelpers::CpuDeviceHelpers::ReduceSum<uint8_t>(
+    const Tensor& input, gsl::span<const int64_t> reduce_axes,
+    bool keep_dims, AllocatorPtr allocator,
+    const TensorShape* input_shape_override,
+    concurrency::ThreadPool* tp, void* einsum_cuda_assets);
+
+template std::unique_ptr<Tensor> ReduceSum<uint8_t>(
+    const Tensor& input, const TensorShape& input_shape_override,
+    gsl::span<const int64_t> reduce_axes, AllocatorPtr allocator,
+    concurrency::ThreadPool* tp, void* einsum_cuda_assets,
+    const DeviceHelpers::ReduceSum<uint8_t>& device_reduce_sum_func);
+
+// int8_t
+template Status DeviceHelpers::CpuDeviceHelpers::MatMul<int8_t>(
+    const int8_t* input_1_data, const int8_t* input_2_data, int8_t* output_data,
+    size_t left_stride, size_t right_stride, size_t output_stride,
+    size_t num_batches, size_t M, size_t K, size_t N, concurrency::ThreadPool* tp,
+    void* einsum_cuda_assets);
+
+template std::unique_ptr<Tensor> MatMul<int8_t>(
+    const Tensor& input_1, const gsl::span<const int64_t>& input_shape_1_override,
+    const Tensor& input_2, const gsl::span<const int64_t>& input_shape_2_override,
+    AllocatorPtr allocator, concurrency::ThreadPool* tp, void* einsum_cuda_assets,
+    const DeviceHelpers::MatMul<int8_t>& device_matmul_func);
+
+template std::unique_ptr<Tensor> DeviceHelpers::CpuDeviceHelpers::ReduceSum<int8_t>(
+    const Tensor& input, gsl::span<const int64_t> reduce_axes,
+    bool keep_dims, AllocatorPtr allocator,
+    const TensorShape* input_shape_override,
+    concurrency::ThreadPool* tp, void* einsum_cuda_assets);
+
+template std::unique_ptr<Tensor> ReduceSum<int8_t>(
+    const Tensor& input, const TensorShape& input_shape_override,
+    gsl::span<const int64_t> reduce_axes, AllocatorPtr allocator,
+    concurrency::ThreadPool* tp, void* einsum_cuda_assets,
+    const DeviceHelpers::ReduceSum<int8_t>& device_reduce_sum_func);
+
 // MLFloat16
 template std::unique_ptr<Tensor> MatMul<MLFloat16>(
     const Tensor& input_1, const gsl::span<const int64_t>& input_shape_1_override,

--- a/onnxruntime/core/providers/cpu/math/einsum_utils/einsum_typed_compute_processor.cc
+++ b/onnxruntime/core/providers/cpu/math/einsum_utils/einsum_typed_compute_processor.cc
@@ -431,5 +431,11 @@ template class EinsumTypedComputeProcessor<int32_t>;
 template class EinsumTypedComputeProcessor<double>;
 template class EinsumTypedComputeProcessor<int64_t>;
 template class EinsumTypedComputeProcessor<MLFloat16>;
+template class EinsumTypedComputeProcessor<uint8_t>;
+template class EinsumTypedComputeProcessor<int8_t>;
+template class EinsumTypedComputeProcessor<uint16_t>;
+template class EinsumTypedComputeProcessor<int16_t>;
+template class EinsumTypedComputeProcessor<uint32_t>;
+template class EinsumTypedComputeProcessor<uint64_t>;
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cpu/reduction/reduction_ops.cc
+++ b/onnxruntime/core/providers/cpu/reduction/reduction_ops.cc
@@ -1156,6 +1156,12 @@ template class ReduceSum<float>;
 template class ReduceSum<int32_t>;
 template class ReduceSum<double>;
 template class ReduceSum<int64_t>;
+template class ReduceSum<uint64_t>;
+template class ReduceSum<uint32_t>;
+template class ReduceSum<int8_t>;
+template class ReduceSum<uint8_t>;
+template class ReduceSum<int16_t>;
+template class ReduceSum<uint16_t>;
 
 template void CommonReduce1Loop<ReduceAggregatorSum<float>>(OpKernelContext* ctx,
                                                             const gsl::span<const int64_t>& axes_, int64_t keepdims_,

--- a/onnxruntime/core/util/math_cpu.cc
+++ b/onnxruntime/core/util/math_cpu.cc
@@ -49,6 +49,10 @@ EIGEN_MATMUL_FUNCTION(int32_t)
 EIGEN_MATMUL_FUNCTION(uint32_t)
 EIGEN_MATMUL_FUNCTION(int64_t)
 EIGEN_MATMUL_FUNCTION(uint64_t)
+EIGEN_MATMUL_FUNCTION(int16_t)
+EIGEN_MATMUL_FUNCTION(uint16_t)
+EIGEN_MATMUL_FUNCTION(int8_t)
+EIGEN_MATMUL_FUNCTION(uint8_t)
 
 ////////////////////////////////////////////////////////////////////////////////
 // BLAS alternatives.

--- a/onnxruntime/test/providers/cpu/math/einsum_test.cc
+++ b/onnxruntime/test/providers/cpu/math/einsum_test.cc
@@ -542,6 +542,60 @@ TEST(Einsum, ImplicitEinsumAsElementwiseMulOpWithAllScalars) {
   test.Run();
 }
 
+TEST(Einsum, TestUint64Einsum) {
+  OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
+  test.AddAttribute<std::string>("equation", "i,j->");
+  test.AddInput<uint64_t>("x", {2}, {uint64_t(1) << 62, 1});
+  test.AddInput<uint64_t>("y", {2}, {1, 1});
+  test.AddOutput<uint64_t>("o", {}, {(uint64_t(1) << 62) + 1});
+  test.Run();
+}
+
+TEST(Einsum, TestUint32Einsum) {
+  OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
+  test.AddAttribute<std::string>("equation", "i,j->");
+  test.AddInput<uint32_t>("x", {2}, {uint32_t(1) << 30, 1});
+  test.AddInput<uint32_t>("y", {2}, {1, 1});
+  test.AddOutput<uint32_t>("o", {}, {(uint32_t(1) << 30) + 1});
+  test.Run();
+}
+
+TEST(Einsum, TestUint16Einsum) {
+  OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
+  test.AddAttribute<std::string>("equation", "i,j->");
+  test.AddInput<uint16_t>("x", {2}, {uint16_t(1) << 14, 1});
+  test.AddInput<uint16_t>("y", {2}, {1, 1});
+  test.AddOutput<uint16_t>("o", {}, {(uint16_t(1) << 14) + 1});
+  test.Run();
+}
+
+TEST(Einsum, TestUint8Einsum) {
+  OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
+  test.AddAttribute<std::string>("equation", "i,j->");
+  test.AddInput<uint8_t>("x", {2}, {uint8_t(1) << 6, 1});
+  test.AddInput<uint8_t>("y", {2}, {1, 1});
+  test.AddOutput<uint8_t>("o", {}, {(uint8_t(1) << 6) + 1});
+  test.Run();
+}
+
+TEST(Einsum, TestInt16Einsum) {
+  OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
+  test.AddAttribute<std::string>("equation", "i,j->");
+  test.AddInput<int16_t>("x", {2}, {int16_t(1) << 13, 1});
+  test.AddInput<int16_t>("y", {2}, {1, 1});
+  test.AddOutput<int16_t>("o", {}, {(int16_t(1) << 13) + 1});
+  test.Run();
+}
+
+TEST(Einsum, TestInt8Einsum) {
+  OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
+  test.AddAttribute<std::string>("equation", "i,j->");
+  test.AddInput<int8_t>("x", {2}, {int8_t(1) << 5, 1});
+  test.AddInput<int8_t>("y", {2}, {1, 1});
+  test.AddOutput<int8_t>("o", {}, {(int8_t(1) << 5) + 1});
+  test.Run();
+}
+
 // Tensor Contraction
 
 // Explicit


### PR DESCRIPTION
### Description
I added the missing kernels ``uint64``, ``uint32``, ``uint16``, ``int16``, ``uint8``, ``int8`` that are specified in the onnx standard.


### Motivation and Context
We need especially ``uint64`` to be supported for [ndonnx](https://github.com/Quantco/ndonnx). Nowadays, ``ndonnx`` supports ``einsum`` for ``uint64`` via a lossy cast to ``int64``.


