### PR TITLE
Moyo/pch

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1792,10 +1792,10 @@ else()
 endif()
 
 if(onnxruntime_BUILD_UNIT_TESTS)
-  include(Q:/src/onnxruntime/cmake/onnxruntime_test_pch.cmake)
+  include("${CMAKE_CURRENT_SOURCE_DIR}/onnxruntime_test_pch.cmake")
 endif()
 
 # Include precompiled header configuration for providers
 if(TARGET onnxruntime_providers)
-  include(Q:/src/onnxruntime/cmake/onnxruntime_providers_pch.cmake)
+  include("${CMAKE_CURRENT_SOURCE_DIR}/onnxruntime_providers_pch.cmake")
 endif()

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1790,3 +1790,12 @@ else()
     include("${CMAKE_CURRENT_SOURCE_DIR}/arm64x.cmake")
   endif()
 endif()
+
+if(onnxruntime_BUILD_UNIT_TESTS)
+  include(Q:/src/onnxruntime/cmake/onnxruntime_test_pch.cmake)
+endif()
+
+# Include precompiled header configuration for providers
+if(TARGET onnxruntime_providers)
+  include(Q:/src/onnxruntime/cmake/onnxruntime_providers_pch.cmake)
+endif()

--- a/cmake/onnxruntime_providers_pch.cmake
+++ b/cmake/onnxruntime_providers_pch.cmake
@@ -1,0 +1,25 @@
+# Precompiled header configuration for onnxruntime_providers
+target_include_directories(onnxruntime_providers PRIVATE
+  "Q:/src/onnxruntime/include/onnxruntime"
+  "Q:/src/onnxruntime/build/Windows/RelWithDebInfo/_deps/onnx-src"
+  "Q:/src/onnxruntime/onnxruntime"
+)
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+  # Visual Studio PCH
+  target_precompile_headers(onnxruntime_providers PRIVATE
+    "Q:/src/onnxruntime/cmake/providers_pch.h"
+  )
+endif()
+
+# Exclude certain files that might conflict with PCH
+set(PROVIDERS_PCH_EXCLUDE_FILES
+  # Add any problematic source files here if needed
+  # Example: Q:/src/onnxruntime/onnxruntime/core/providers/cpu/some_problematic_file.cc
+)
+
+foreach(file ${PROVIDERS_PCH_EXCLUDE_FILES})
+  set_source_files_properties(${file} PROPERTIES
+    SKIP_PRECOMPILE_HEADERS ON
+  )
+endforeach()

--- a/cmake/onnxruntime_providers_pch.cmake
+++ b/cmake/onnxruntime_providers_pch.cmake
@@ -1,25 +1,8 @@
 # Precompiled header configuration for onnxruntime_providers
-target_include_directories(onnxruntime_providers PRIVATE
-  "Q:/src/onnxruntime/include/onnxruntime"
-  "Q:/src/onnxruntime/build/Windows/RelWithDebInfo/_deps/onnx-src"
-  "Q:/src/onnxruntime/onnxruntime"
-)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   # Visual Studio PCH
   target_precompile_headers(onnxruntime_providers PRIVATE
-    "Q:/src/onnxruntime/cmake/providers_pch.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/providers_pch.h"
   )
 endif()
-
-# Exclude certain files that might conflict with PCH
-set(PROVIDERS_PCH_EXCLUDE_FILES
-  # Add any problematic source files here if needed
-  # Example: Q:/src/onnxruntime/onnxruntime/core/providers/cpu/some_problematic_file.cc
-)
-
-foreach(file ${PROVIDERS_PCH_EXCLUDE_FILES})
-  set_source_files_properties(${file} PROPERTIES
-    SKIP_PRECOMPILE_HEADERS ON
-  )
-endforeach()

--- a/cmake/onnxruntime_test_pch.cmake
+++ b/cmake/onnxruntime_test_pch.cmake
@@ -1,22 +1,16 @@
 # Precompiled header configuration for onnxruntime_test_all
-target_include_directories(onnxruntime_test_all PRIVATE
-  "Q:/src/onnxruntime/onnxruntime/test"
-  "Q:/src/onnxruntime/build/Windows/RelWithDebInfo/_deps/googletest-src/googletest/include"
-  "Q:/src/onnxruntime/include/onnxruntime"
-  "Q:/src/onnxruntime/build/Windows/RelWithDebInfo/_deps/onnx-src"
-  "Q:/src/onnxruntime/build/Windows/RelWithDebInfo/_deps/googletest-src/googletest/include/gtest/internal"
-)
+
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   # Visual Studio PCH
   target_precompile_headers(onnxruntime_test_all PRIVATE
-    "Q:/src/onnxruntime/onnxruntime/cmake/test_pch.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/test_pch.h"
   )
   endif()
 
 # Exclude certain files that might conflict with PCH
 set(PCH_EXCLUDE_FILES
   # Add any problematic source files here
-  Q:/src/onnxruntime/onnxruntime/test/framework/tensor_shape_test.cc
+  "${TEST_SRC_DIR}/framework/tensor_shape_test.cc"
 )
 
 foreach(file ${PCH_EXCLUDE_FILES})

--- a/cmake/onnxruntime_test_pch.cmake
+++ b/cmake/onnxruntime_test_pch.cmake
@@ -1,0 +1,26 @@
+# Precompiled header configuration for onnxruntime_test_all
+target_include_directories(onnxruntime_test_all PRIVATE
+  "Q:/src/onnxruntime/onnxruntime/test"
+  "Q:/src/onnxruntime/build/Windows/RelWithDebInfo/_deps/googletest-src/googletest/include"
+  "Q:/src/onnxruntime/include/onnxruntime"
+  "Q:/src/onnxruntime/build/Windows/RelWithDebInfo/_deps/onnx-src"
+  "Q:/src/onnxruntime/build/Windows/RelWithDebInfo/_deps/googletest-src/googletest/include/gtest/internal"
+)
+if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+  # Visual Studio PCH
+  target_precompile_headers(onnxruntime_test_all PRIVATE
+    "Q:/src/onnxruntime/onnxruntime/cmake/test_pch.h"
+  )
+  endif()
+
+# Exclude certain files that might conflict with PCH
+set(PCH_EXCLUDE_FILES
+  # Add any problematic source files here
+  Q:/src/onnxruntime/onnxruntime/test/framework/tensor_shape_test.cc
+)
+
+foreach(file ${PCH_EXCLUDE_FILES})
+  set_source_files_properties(${file} PROPERTIES
+    SKIP_PRECOMPILE_HEADERS ON
+  )
+endforeach()

--- a/cmake/providers_pch.h
+++ b/cmake/providers_pch.h
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+// Core framework headers (highest compilation time impact)
+#include "core/framework/op_kernel.h"
+#include "core/framework/op_kernel_info.h"
+#include "core/framework/execution_provider.h"
+#include "core/framework/op_node_proto_helper.h"
+#include "core/framework/data_types.h"
+#include "core/framework/tensor.h"
+
+// Graph-related headers
+#include "core/graph/graph_viewer.h"
+#include "core/graph/graph.h"
+#include "core/graph/onnx_protobuf.h"
+
+// ONNX schema definitions
+#include "onnx/defs/schema.h"
+
+// Windows-specific headers (if applicable)
+#ifdef _WIN32
+#include <windows.h>
+#endif

--- a/cmake/test_pch.h
+++ b/cmake/test_pch.h
@@ -24,8 +24,3 @@
 #ifdef _WIN32
 #include <windows.h>
 #endif
-
-// Commonly used ONNX Runtime namespaces
-using namespace onnxruntime;
-using namespace onnxruntime::test;
-using namespace ONNX_NAMESPACE;

--- a/cmake/test_pch.h
+++ b/cmake/test_pch.h
@@ -7,11 +7,11 @@
 #include "gtest/gtest.h"
 #include "gtest/gtest-assertion-result.h"
 #include "gtest/gtest-message.h"
-#include "gtest-port.h"
+#include "gtest/internal/gtest-port.h"
 
 // Core test utilities (most frequently used in tests)
-#include "providers/provider_test_utils.h"
-#include "providers/checkers.h"
+#include "test/providers/provider_test_utils.h"
+#include "test/providers/checkers.h"
 
 // ONNX and Protocol Buffer headers
 #include "core/graph/onnx_protobuf.h"

--- a/onnxruntime/cmake/test_pch.h
+++ b/onnxruntime/cmake/test_pch.h
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+// Test framework headers (highest compilation time impact)
+#include "gtest/gtest.h"
+#include "gtest/gtest-assertion-result.h"
+#include "gtest/gtest-message.h"
+#include "gtest-port.h"
+
+// Core test utilities (most frequently used in tests)
+#include "providers/provider_test_utils.h"
+#include "providers/checkers.h"
+
+// ONNX and Protocol Buffer headers
+#include "core/graph/onnx_protobuf.h"
+#include "onnx/defs/schema.h"
+
+// Data types and framework headers
+#include "core/framework/data_types.h"
+
+// Windows-specific headers (if applicable)
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+// Commonly used ONNX Runtime namespaces
+using namespace onnxruntime;
+using namespace onnxruntime::test;
+using namespace ONNX_NAMESPACE;


### PR DESCRIPTION
### Description

This PR introduces precompiled header (PCH) support for ONNX Runtime targets that exhibited the longest build times when built with the MSVC toolset. By analyzing build performance, I identified a subset of targets with significant compilation overhead due to repeated header processing. Enabling PCH for these targets reduces redundant parsing, improving incremental and full build performance.

Changes include:

Added PCH configuration to selected CMake targets with the highest build cost in MSVC builds.

Ensured PCH setup is compatible with the existing build configurations.

Verified successful compilation and linkage with PCH enabled under MSVC.

Impact:

~30% reduction in build time for the affected targets with the MSVC toolset.
