### PR TITLE
[c++] Eliminate dynamic initialization of static Ort::Global<void>::api_

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -166,7 +166,7 @@ inline const OrtApi* detail::Global::DefaultInit() noexcept {
   // This makes it safe to have a Ort::Env constructed as a static member.
   //
   // This DOES NOT make it safe to _use_ arbitrary ORT C++ APIs when
-  // initializaing static members, however.
+  // initializing static members, however.
   static const OrtApi* api = OrtGetApiBase()->GetApi(ORT_API_VERSION);
   return api;
 }

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -79,8 +79,10 @@ struct Exception : std::exception {
   throw Ort::Exception(string, code)
 #endif
 
-// If macro ORT_API_MANUAL_INIT is defined, no static initialization will be
-// performed. Instead, users must call InitApi() before using ORT.
+#ifdef ORT_API_MANUAL_INIT
+// If the macro ORT_API_MANUAL_INIT is defined, no static initialization
+// will be performed. Instead, users must call InitApi() before using the
+// ORT C++ APIs..
 //
 // InitApi() sets the global API object using the default initialization
 // logic. Users call this to initialize the ORT C++ APIs at a time that
@@ -103,6 +105,7 @@ inline void InitApi() noexcept;
 // }
 //
 inline void InitApi(const OrtApi* api) noexcept;
+#endif
 
 namespace detail {
 // This is used internally by the C++ API. This class holds the global
@@ -138,14 +141,17 @@ struct Global {
   // Has different definitions based on ORT_API_MANUAL_INIT
   static const OrtApi* DefaultInit() noexcept;
 
+#ifdef ORT_API_MANUAL_INIT
   // Public APIs to set the OrtApi* to use.
   friend void ::Ort::InitApi() noexcept;
   friend void ::Ort::InitApi(const OrtApi*) noexcept;
+#endif
 };
 }  // namespace detail
 
 #ifdef ORT_API_MANUAL_INIT
 
+// See comments on declaration above for usage.
 inline void InitApi(const OrtApi* api) noexcept { detail::Global::Api(api); }
 inline void InitApi() noexcept { InitApi(OrtGetApiBase()->GetApi(ORT_API_VERSION)); }
 

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -133,7 +133,7 @@ struct Global {
 inline void InitApi(const OrtApi* api) noexcept { detail::Global::api_ = api; }
 inline void InitApi() noexcept { InitApi(OrtGetApiBase()->GetApi(ORT_API_VERSION)); }
 
-#if defined(__clang__) || defined(_MSC_VER)
+#ifdef _MSC_VER
 // If you get a linker error about a mismatch here, you are trying to
 // link two compilation units that have different definitions for
 // ORT_API_MANUAL_INIT together. All compilation units must agree on the
@@ -149,7 +149,7 @@ inline const OrtApi* detail::Global::DefaultInit() noexcept {
 
 #else  // ORT_API_MANUAL_INIT
 
-#if defined(__clang__) || defined(_MSC_VER)
+#ifdef _MSC_VER
 // If you get a linker error about a mismatch here, you are trying to link
 // two compilation units that have different definitions for
 // ORT_API_MANUAL_INIT together. All compilation units must agree on the

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -127,7 +127,7 @@ struct Global {
     // that is delay loaded or delay loads its dependencies.
     //
     // This DOES NOT make it safe to _use_ arbitrary ORT C++ APIs when
-    // initializaing static members, however.
+    // initializing static members, however.
     static const OrtApi* api = DefaultInit();
 
     if (newValue) {

--- a/js/node/src/inference_session_wrap.cc
+++ b/js/node/src/inference_session_wrap.cc
@@ -15,7 +15,7 @@ Napi::Object InferenceSessionWrap::Init(Napi::Env env, Napi::Object exports) {
   // create ONNX runtime env
   Ort::InitApi();
   ORT_NAPI_THROW_ERROR_IF(
-      Ort::Global<void>::api_ == nullptr, env,
+      &Ort::GetApi() == nullptr, env,
       "Failed to initialize ONNX Runtime API. It could happen when this nodejs binding was built with a higher version "
       "ONNX Runtime but now runs with a lower version ONNX Runtime DLL(or shared library).");
 

--- a/onnxruntime/core/providers/shared_library/provider_ort_api_init.cc
+++ b/onnxruntime/core/providers/shared_library/provider_ort_api_init.cc
@@ -24,7 +24,7 @@ std::once_flag init;
 }  // namespace
 
 void InitProviderOrtApi() {
-  std::call_once(init, []() { Ort::Global<void>::api_ = Provider_GetHost()->OrtGetApiBase()->GetApi(ORT_API_VERSION); });
+  std::call_once(init, []() { Ort::InitApi(Provider_GetHost()->OrtGetApiBase()->GetApi(ORT_API_VERSION)); });
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/vitisai/imp/global_api.cc
+++ b/onnxruntime/core/providers/vitisai/imp/global_api.cc
@@ -332,7 +332,7 @@ vaip_core::OrtApiForVaip* create_org_api_hook() {
   InitProviderOrtApi();
   set_version_info(the_global_api);
   the_global_api.host_ = Provider_GetHost();
-  assert(Ort::Global<void>::api_ != nullptr);
+  assert(&Ort::GetApi() != nullptr);
   the_global_api.ort_api_ = &Ort::GetApi();
   the_global_api.model_load = [](const std::string& filename) -> Model* {
     auto model_proto = ONNX_NAMESPACE::ModelProto::Create();

--- a/onnxruntime/core/providers/vitisai/imp/global_api.cc
+++ b/onnxruntime/core/providers/vitisai/imp/global_api.cc
@@ -229,7 +229,7 @@ int vitisai_ep_set_ep_dynamic_options(
 struct MyCustomOpKernel : OpKernel {
   MyCustomOpKernel(const OpKernelInfo& info, const OrtCustomOp& op) : OpKernel(info), op_(op) {
     op_kernel_ =
-        op_.CreateKernel(&op_, Ort::Global<void>::api_, reinterpret_cast<const OrtKernelInfo*>(&info));
+        op_.CreateKernel(&op_, &Ort::GetApi() _, reinterpret_cast<const OrtKernelInfo*>(&info));
   }
 
   ~MyCustomOpKernel() override { op_.KernelDestroy(op_kernel_); }
@@ -333,7 +333,7 @@ vaip_core::OrtApiForVaip* create_org_api_hook() {
   set_version_info(the_global_api);
   the_global_api.host_ = Provider_GetHost();
   assert(Ort::Global<void>::api_ != nullptr);
-  the_global_api.ort_api_ = Ort::Global<void>::api_;
+  the_global_api.ort_api_ = &Ort::GetApi();
   the_global_api.model_load = [](const std::string& filename) -> Model* {
     auto model_proto = ONNX_NAMESPACE::ModelProto::Create();
     auto& logger = logging::LoggingManager::DefaultLogger();

--- a/onnxruntime/core/providers/vitisai/imp/global_api.cc
+++ b/onnxruntime/core/providers/vitisai/imp/global_api.cc
@@ -229,7 +229,7 @@ int vitisai_ep_set_ep_dynamic_options(
 struct MyCustomOpKernel : OpKernel {
   MyCustomOpKernel(const OpKernelInfo& info, const OrtCustomOp& op) : OpKernel(info), op_(op) {
     op_kernel_ =
-        op_.CreateKernel(&op_, &Ort::GetApi() _, reinterpret_cast<const OrtKernelInfo*>(&info));
+        op_.CreateKernel(&op_, &Ort::GetApi(), reinterpret_cast<const OrtKernelInfo*>(&info));
   }
 
   ~MyCustomOpKernel() override { op_.KernelDestroy(op_kernel_); }

--- a/onnxruntime/test/autoep/library/ep_arena.h
+++ b/onnxruntime/test/autoep/library/ep_arena.h
@@ -21,7 +21,10 @@ limitations under the License.
 #include <mutex>
 #include <set>
 
+#define ORT_API_MANUAL_INIT
 #include "onnxruntime_cxx_api.h"
+#undef ORT_API_MANUAL_INIT
+
 #include "ep_allocator.h"
 #include "example_plugin_ep_utils.h"
 

--- a/onnxruntime/test/testdata/custom_op_library/custom_op_library.cc
+++ b/onnxruntime/test/testdata/custom_op_library/custom_op_library.cc
@@ -26,7 +26,7 @@ static void AddOrtCustomOpDomainToContainer(Ort::CustomOpDomain&& domain) {
 }
 
 OrtStatus* ORT_API_CALL RegisterCustomOps(OrtSessionOptions* options, const OrtApiBase* api) {
-  Ort::Global<void>::api_ = api->GetApi(ORT_API_VERSION);
+  Ort::InitApi(api->GetApi(ORT_API_VERSION));
   OrtStatus* result = nullptr;
 
   ORT_TRY {


### PR DESCRIPTION
### Description

Delay the call to `OrtGetApiBase()` until the first call to `Ort::GetApi()` so that `OrtGetApiBase()` is typically called after dynamic library loading.

### Motivation and Context

When ORT_API_MANUAL_INIT is not defined (which is the default), the static `Ort::Global<void>::api_` has a dynamic initializer that calls `OrtGetApiBase()->GetApi(ORT_API_VERSION)` This dynamic initialization can cause problems when it interacts with other global/static initialization. On Windows in particular, it can also cause deadlocks when used in a dynamic library if OrtGetApiBase()->GetApi() attempts to load any other libraries.

* Replace the templated `Global<void>::api_` with an inline static initialized to nullptr.
* `Ort::GetApi()` now calls `detail::Global::GetApi()` which calls `detail::Global::DefaultInit()` if initialization is needed.
  * When `ORT_API_MANUAL_INIT` is defined, `DefaultInit()` returns nullptr, which will eventually cause the program to crash. The callers have violated the initialization contract by not calling one of the `Ort::InitApi` overloads.
  * When `ORT_API_MANUAL_INIT` is not defined, `DefaultInit()` uses a function-level static to compute the result of `OrtGetApiBase()->GetApi(ORT_API_VERSION)` once and return it.
* `Ort::Global<void>` has been replaced with a non-templated type and moved inside a `detail` namespace. Since the `Global<void>` object was documented as being used internally, it is believed that these changes here are non-breaking, as they do not impact a public API. The public APIs, `Ort::InitApi()` and `Ort::InitApi(const OrtApi*)` remain unchanged.
* Add `#pragma detect_mismatch` to surface issues with compilation units that disagree on how ORT_API_MANUAL_INIT is defined. (MSVC only.)
