### PR TITLE
[QNN-EP] Fix int64 graph output issue

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
@@ -286,11 +286,10 @@ Status BaseOpBuilder::ProcessOutputs(QnnModelWrapper& qnn_model_wrapper,
     // Check if we need to add a cast node for int64
     bool needs_int64_cast = false;
     if (is_graph_output) {
-      for (const auto& input_name : input_names) {
-        if (input_name.find("_cast_int32") != std::string::npos) {
-          needs_int64_cast = true;
-          break;
-        }
+      if (supported_qnn_data_type == output_info.qnn_data_type &&
+          (output_info.qnn_data_type == QNN_DATATYPE_INT_64 || output_info.qnn_data_type == QNN_DATATYPE_UINT_64)) {
+        supported_qnn_data_type = supported_qnn_data_type == QNN_DATATYPE_INT_64 ? QNN_DATATYPE_INT_32 : QNN_DATATYPE_UINT_32;
+        needs_int64_cast = true;
       }
     }
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

- Change the output data type of the last node from int64/uint64 to int32/uint32, then a Cast op is added to convert the output tensor from int32/uint32 to int64/uint64.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

- Currently we only add the cast op (int32->int64) when the input name contains "_cast_int32", but the input name may not have this string because it can follow the data type of the previous node. In this case, the input data type of the op is int32, and the output data type of the op is int64, causing an error.

- Unit test -https://github.com/microsoft/onnxruntime/blob/4b1838b29608f5a19c0997971fd83bee6732ee56/onnxruntime/test/providers/qnn/reshape_expand_op_test.cc#L242

