### PR TITLE
[TRT RTX EP] EP context changes

### DIFF
--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -35,8 +35,8 @@ microsoft_wil;https://github.com/microsoft/wil/archive/refs/tags/v1.0.230629.1.z
 mimalloc;https://github.com/microsoft/mimalloc/archive/refs/tags/v2.1.1.zip;d5ee7d34223d0567892db5179849939c8769dc41
 mp11;https://github.com/boostorg/mp11/archive/refs/tags/boost-1.82.0.zip;9bc9e01dffb64d9e0773b2e44d2f22c51aace063
 onnx;https://github.com/onnx/onnx/archive/refs/tags/v1.18.0.zip;f156d032a3af91b66d554e11158b33ca77bbb1f2
-# Use the latest commit of 10.9-GA
-onnx_tensorrt;https://github.com/onnx/onnx-tensorrt/archive/d5dce67db7c2e64b07e055571f5ec06f7f254de2.zip;01114d3b67650857281fa50faa2e412130a63b69
+# Side branch
+onnx_tensorrt;https://github.com/gedoensmax/onnx-tensorrt/archive/1ff5201c5eb209a4a58330b9e8cae97f153c93a4.zip;60af1687b0e03c2c920197f4e059cb666aefdd9c
 protobuf;https://github.com/protocolbuffers/protobuf/archive/refs/tags/v21.12.zip;7cf2733949036c7d52fda017badcab093fe73bfa
 protoc_win64;https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-win64.zip;b4521f7ada5b260380f94c4bd7f1b7684c76969a
 protoc_win32;https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-win32.zip;3688010318192c46ce73213cdfb6b3e5656da874

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -35,8 +35,8 @@ microsoft_wil;https://github.com/microsoft/wil/archive/refs/tags/v1.0.230629.1.z
 mimalloc;https://github.com/microsoft/mimalloc/archive/refs/tags/v2.1.1.zip;d5ee7d34223d0567892db5179849939c8769dc41
 mp11;https://github.com/boostorg/mp11/archive/refs/tags/boost-1.82.0.zip;9bc9e01dffb64d9e0773b2e44d2f22c51aace063
 onnx;https://github.com/onnx/onnx/archive/refs/tags/v1.18.0.zip;f156d032a3af91b66d554e11158b33ca77bbb1f2
-# Side branch
-onnx_tensorrt;https://github.com/gedoensmax/onnx-tensorrt/archive/1ff5201c5eb209a4a58330b9e8cae97f153c93a4.zip;60af1687b0e03c2c920197f4e059cb666aefdd9c
+# Use the latest commit of 10.9-GA
+onnx_tensorrt;https://github.com/onnx/onnx-tensorrt/archive/d5dce67db7c2e64b07e055571f5ec06f7f254de2.zip;01114d3b67650857281fa50faa2e412130a63b69
 protobuf;https://github.com/protocolbuffers/protobuf/archive/refs/tags/v21.12.zip;7cf2733949036c7d52fda017badcab093fe73bfa
 protoc_win64;https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-win64.zip;b4521f7ada5b260380f94c4bd7f1b7684c76969a
 protoc_win32;https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-win32.zip;3688010318192c46ce73213cdfb6b3e5656da874

--- a/include/onnxruntime/core/providers/nv_tensorrt_rtx/nv_provider_options.h
+++ b/include/onnxruntime/core/providers/nv_tensorrt_rtx/nv_provider_options.h
@@ -32,12 +32,8 @@ constexpr const char* kProfilesMinShapes = "nv_profile_min_shapes";
 constexpr const char* kProfilesMaxShapes = "nv_profile_max_shapes";
 constexpr const char* kProfilesOptShapes = "nv_profile_opt_shapes";
 constexpr const char* kCudaGraphEnable = "nv_cuda_graph_enable";
-constexpr const char* kONNXBytestream = "nv_onnx_bytestream";
-constexpr const char* kONNXBytestreamSize = "nv_onnx_bytestream_size";
 constexpr const char* kMultiProfileEnable = "nv_multi_profile_enable";
 constexpr const char* kUseExternalDataInitializer = "nv_use_external_data_initializer";
-constexpr const char* kExternalDataBytestream = "nv_external_data_bytestream";
-constexpr const char* kExternalDataBytestreamSize = "nv_external_data_bytestream_size";
 
 }  // namespace provider_option_names
 namespace run_option_names {

--- a/include/onnxruntime/core/providers/nv_tensorrt_rtx/nv_provider_options.h
+++ b/include/onnxruntime/core/providers/nv_tensorrt_rtx/nv_provider_options.h
@@ -35,6 +35,8 @@ constexpr const char* kCudaGraphEnable = "nv_cuda_graph_enable";
 constexpr const char* kONNXBytestream = "nv_onnx_bytestream";
 constexpr const char* kONNXBytestreamSize = "nv_onnx_bytestream_size";
 constexpr const char* kMultiProfileEnable = "nv_multi_profile_enable";
+constexpr const char* kExternalDataBytestream = "nv_external_data_bytestream";
+constexpr const char* kExternalDataBytestreamSize = "nv_external_data_bytestream_size";
 
 }  // namespace provider_option_names
 namespace run_option_names {

--- a/include/onnxruntime/core/providers/nv_tensorrt_rtx/nv_provider_options.h
+++ b/include/onnxruntime/core/providers/nv_tensorrt_rtx/nv_provider_options.h
@@ -35,6 +35,7 @@ constexpr const char* kCudaGraphEnable = "nv_cuda_graph_enable";
 constexpr const char* kONNXBytestream = "nv_onnx_bytestream";
 constexpr const char* kONNXBytestreamSize = "nv_onnx_bytestream_size";
 constexpr const char* kMultiProfileEnable = "nv_multi_profile_enable";
+constexpr const char* kUseExternalDataInitializer = "nv_use_external_data_initializer";
 constexpr const char* kExternalDataBytestream = "nv_external_data_bytestream";
 constexpr const char* kExternalDataBytestreamSize = "nv_external_data_bytestream_size";
 

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
@@ -836,9 +836,9 @@ NvExecutionProvider::NvExecutionProvider(const NvExecutionProviderInfo& info)
 
   cudaDeviceProp prop;
   CUDA_CALL_THROW(cudaGetDeviceProperties(&prop, device_id_));
-  if (prop.major < 8 || prop.major == 9 || prop.major == 10) {
+  if (prop.major < 8 || (prop.major == 8 && prop.minor < 6) || prop.major == 9 || prop.major == 10) {
     ORT_THROW_IF_ERROR(ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                                       "[NvTensorRTRTX EP] The execution provider only supports RTX devices with compute capabilities =< 80."));
+                                       "[NvTensorRTRTX EP] The execution provider only supports RTX devices with compute capabilities >= 86."));
   }
   compute_capability_ = GetComputeCapability(prop);
   if (info.has_user_compute_stream) {

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
@@ -2441,14 +2441,14 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
       std::string compute_capability_hw_compat = compute_capability_ + "+";
 
       ep_context_models_.push_back(CreateCtxNode(graph_body_viewer,
-                                    ep_cache_context_attr_,
-                                    reinterpret_cast<char*>(serialized_engine->data()),
-                                    serialized_engine->size(),
-                                    ep_context_embed_mode_,
-                                    compute_capability_hw_compat,
-                                    model_path_,
-                                    GetLogger(),
-                                    fused_node.Name()));
+                                                 ep_cache_context_attr_,
+                                                 reinterpret_cast<char*>(serialized_engine->data()),
+                                                 serialized_engine->size(),
+                                                 ep_context_embed_mode_,
+                                                 compute_capability_hw_compat,
+                                                 model_path_,
+                                                 GetLogger(),
+                                                 fused_node.Name()));
     }
   }
 

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
@@ -2429,16 +2429,16 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
         ep_cache_context_attr_ = std::filesystem::path(engine_cache_relative_path_to_context_model_dir).append(cache_file_name.string()).string();
       }
       std::string compute_capability_hw_compat = compute_capability_ + "+";
-      std::unique_ptr<ONNX_NAMESPACE::ModelProto> model_proto{CreateCtxModel(graph_body_viewer,
-                                                                             ep_cache_context_attr_,
-                                                                             reinterpret_cast<char*>(serialized_engine->data()),
-                                                                             serialized_engine->size(),
-                                                                             ep_context_embed_mode_,
-                                                                             compute_capability_hw_compat,
-                                                                             model_path_,
-                                                                             GetLogger(),
-                                                                             ep_context_models_, fused_node.Name())};
-      // DumpCtxsModel(model_proto.get(), ctx_model_path_);
+
+      ep_context_models_.push_back(CreateCtxNode(graph_body_viewer,
+                                    ep_cache_context_attr_,
+                                    reinterpret_cast<char*>(serialized_engine->data()),
+                                    serialized_engine->size(),
+                                    ep_context_embed_mode_,
+                                    compute_capability_hw_compat,
+                                    model_path_,
+                                    GetLogger(),
+                                    fused_node.Name()));
     }
   }
 

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
@@ -1785,10 +1785,6 @@ NvExecutionProvider::GetCapability(const GraphViewer& graph,
     if (exclude_ops_set.find(node->OpType()) != exclude_ops_set.end()) {
       supported_node = false;
     }
-    // Exclude contrib ops
-    if (node->Domain() == kMSDomain) {
-      supported_node = false;
-    }
 
     if (supported_node) {
       if (new_subgraph) {

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
@@ -2611,8 +2611,6 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
         cache_path = GetCachePath(cache_path_, fused_node.Name()) + ".engine";
         ;
       }
-      auto cache_file_name = std::filesystem::path(cache_path).filename();
-      cache_path = std::filesystem::path(engine_cache_relative_path_to_context_model_dir).append(cache_file_name.string()).string();
       // NV TRT EP per default generates hardware compatible engines for any RTX device with compute capability > 80
       std::string compute_capability_hw_compat = "80+";
       if (!ep_context_model_) {

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
@@ -2066,7 +2066,7 @@ common::Status NvExecutionProvider::RefitEngine(std::string onnx_model_filename,
     refitter->getAllWeights(required_weights, refit_names_prealocated.data());
     LOGS_DEFAULT(VERBOSE) << "[NvTensorRTRTX EP] Refitter requires " << required_weights << " weights";
     std::unordered_set<std::string> refit_names(std::make_move_iterator(refit_names_prealocated.begin()),
-                                      std::make_move_iterator(refit_names_prealocated.end()));
+                                                std::make_move_iterator(refit_names_prealocated.end()));
 
     // Vectors to keep track of data pointers.
     std::vector<std::string> names;

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
@@ -2688,7 +2688,6 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
   engines_.emplace(fused_node.Name(), std::move(trt_engine));
   contexts_.emplace(fused_node.Name(), std::move(trt_context));
   networks_.emplace(fused_node.Name(), std::move(trt_network));
-  weights_.emplace(fused_node.Name(), std::move(userWeights));
   input_info_[fused_node.Name()].push_back(input_indexes);
   output_info_[fused_node.Name()].push_back(output_indexes);
   output_info_[fused_node.Name()].push_back(output_types);
@@ -2708,7 +2707,7 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
           runtime_.get(), profiles_[context->node_name],
           engine_decryption_enable_, engine_decryption_, engine_encryption_,
           detailed_build_log_, sparsity_enable_,
-          auxiliary_streams_, cuda_graph_enable_, is_dynamic_shape_context, cache_prefix_, &weights_[context->node_name]};
+          auxiliary_streams_, cuda_graph_enable_, is_dynamic_shape_context, cache_prefix_};
     *state = p.release();
     return 0;
   };

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
@@ -2141,7 +2141,7 @@ static bool IsIOBindingRequired(TRTState* const trt_state, const Ort::KernelCont
 
 const InlinedVector<const Node*> NvExecutionProvider::GetEpContextNodes() const {
   InlinedVector<const Node*> ep_context_nodes;
-  for (auto& model : ep_context_nodes_) {
+  for (auto& model : ep_context_models_) {
     auto& graph = model->MainGraph();
     for (int i = 0; i < graph.MaxNodeIndex(); i++) {
       auto node = graph.GetNode(i);
@@ -2441,7 +2441,7 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
                                                                              compute_capability_hw_compat,
                                                                              model_path_,
                                                                              GetLogger(),
-                                                                             ep_context_nodes_, fused_node.Name())};
+                                                                             ep_context_models_, fused_node.Name())};
       // DumpCtxsModel(model_proto.get(), ctx_model_path_);
     }
   }

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
@@ -1708,21 +1708,32 @@ NvExecutionProvider::GetCapability(const GraphViewer& graph,
 #endif
   model_path_[sizeof(model_path_) - 1] = '\0';
 
-  // If the model consists of only a single "EPContext" contrib op, it means TRT EP can fetch the precompiled engine info from the node and
-  // load the engine directly without having to go through the processes of graph proto reconstruction, calling TRT parser and engine compilation.
-  // So, simply return the ComputeCapability here.
-  if (graph.NumberOfNodes() == 1 && GraphHasCtxNode(graph)) {
-    SubGraph_t supported_node_vector = {{0}, true};
-    std::unique_ptr<IndexedSubGraph> sub_graph = GetSubGraph(supported_node_vector, graph, TRTGenerateId(graph, std::to_string(trt_version_), std::to_string(cuda_version_)), 0);
-    result.push_back(ComputeCapability::Create(std::move(sub_graph)));
-    return result;
-  }
+  const int number_of_ort_nodes = graph.NumberOfNodes();
+  const std::vector<NodeIndex>& node_index = graph.GetNodesInTopologicalOrder(1 /*priority-based topological sort*/);
 
   // Generate unique kernel name for TRT graph
   HashValue model_hash = TRTGenerateId(graph, std::to_string(trt_version_), std::to_string(cuda_version_));
 
-  // Get supported node list from TensorRT parser
-  const int number_of_ort_nodes = graph.NumberOfNodes();
+  // If there are "EPContext" contrib op nodes, it means TRT EP can fetch the precompiled engine info from the node and
+  // load the engine directly without having to go through the processes of graph proto reconstruction, calling TRT
+  // parser and engine compilation. So, simply return subgraphs consists of single ep context nodes here.
+  if (GraphHasCtxNode(graph)) {
+    int subgraph_idx = 0;
+    for (size_t i = 0; i < static_cast<size_t>(number_of_ort_nodes); i++) {
+      const auto& node = graph.GetNode(node_index[i]);
+      const bool is_context_node = node && !node->OpType().empty() && node->OpType() == "EPContext";
+      if (is_context_node) {
+        SubGraph_t supported_node_vector(std::make_pair(std::vector<size_t>{i}, true));
+        std::unique_ptr<IndexedSubGraph> sub_graph = GetSubGraph(supported_node_vector, graph, model_hash, subgraph_idx++);
+
+        result.push_back(ComputeCapability::Create(std::move(sub_graph)));
+      }
+    }
+    return result;
+  }
+
+  // For regular ONNX nodes, get supported node list from TensorRT parser
+
   std::vector<size_t> nodes_vector(number_of_ort_nodes);
   std::iota(std::begin(nodes_vector), std::end(nodes_vector), 0);
 
@@ -1741,7 +1752,6 @@ NvExecutionProvider::GetCapability(const GraphViewer& graph,
   auto exclude_ops_set = get_exclude_ops_set(op_types_to_exclude_);
 
   SubGraphCollection_t parser_nodes_vector, supported_nodes_vector;
-  const std::vector<NodeIndex>& node_index = graph.GetNodesInTopologicalOrder(1 /*priority-based topological sort*/);
   bool new_subgraph = true;
 
   /* Iterate all the nodes and exclude the node if:

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
@@ -836,9 +836,10 @@ NvExecutionProvider::NvExecutionProvider(const NvExecutionProviderInfo& info)
 
   cudaDeviceProp prop;
   CUDA_CALL_THROW(cudaGetDeviceProperties(&prop, device_id_));
-  if (prop.major < 8 || (prop.major == 8 && prop.minor < 6) || prop.major == 9 || prop.major == 10) {
+  auto cc = prop.major * 10 + prop.minor;
+  if (!(cc == 86 || cc == 89 || cc >= 120)) {
     ORT_THROW_IF_ERROR(ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
-                                       "[NvTensorRTRTX EP] The execution provider only supports RTX devices with compute capabilities >= 86."));
+                                       "[NvTensorRTRTX EP] The execution provider only supports RTX devices with compute capabilities 86, 89, 120 and above"));
   }
   compute_capability_ = GetComputeCapability(prop);
   if (info.has_user_compute_stream) {

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.h
@@ -397,7 +397,6 @@ class NvExecutionProvider : public IExecutionProvider {
   std::unordered_map<std::string, ShapeRangesMap> input_shape_ranges_;  // The profile shape ranges that the engine is built with
   std::unordered_map<std::string, std::vector<nvinfer1::IOptimizationProfile*>> profiles_;
   std::unordered_map<std::string, DDSOutputAllocatorMap> dds_output_allocator_maps_;
-  std::unordered_map<std::string, std::unique_ptr<std::vector<TensorrtUserWeights>>> weights_;  // User provided weights
 
   // for external stream, we need to create its cudnn/cublass handle before cuda EP enable cuda graph capture
   cudnnHandle_t external_cudnn_handle_ = nullptr;

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.h
@@ -153,6 +153,13 @@ struct TensorParams {
   }
 };
 
+// Struct to hold user weights when ModelProtos are serialized with external data
+struct TensorrtUserWeights {
+  std::string name{};
+  std::string data{};
+  int64_t size{};
+};
+
 // Information to construct kernel function state.
 struct TensorrtFuncState {
   AllocateFunc test_allocate_func = nullptr;
@@ -190,6 +197,7 @@ struct TensorrtFuncState {
   bool skip_io_binding_allowed = false;  // Indicates if input/output binding can be skipped
   IAllocatorUniquePtr<void> context_memory = nullptr;
   size_t context_memory_size = 0;
+  std::unique_ptr<std::vector<TensorrtUserWeights>> *userWeights = nullptr;
 };
 
 // Minimum information to construct kernel function state for direct engine load code path
@@ -364,6 +372,7 @@ class NvExecutionProvider : public IExecutionProvider {
   std::unordered_map<std::string, ShapeRangesMap> input_shape_ranges_;  // The profile shape ranges that the engine is built with
   std::unordered_map<std::string, std::vector<nvinfer1::IOptimizationProfile*>> profiles_;
   std::unordered_map<std::string, DDSOutputAllocatorMap> dds_output_allocator_maps_;
+  std::unordered_map<std::string, std::unique_ptr<std::vector<TensorrtUserWeights>>> weights_; // User provided weights
 
   // for external stream, we need to create its cudnn/cublass handle before cuda EP enable cuda graph capture
   cudnnHandle_t external_cudnn_handle_ = nullptr;

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.h
@@ -156,23 +156,36 @@ struct TensorParams {
 // Data structure to hold user weights when ModelProtos are serialized with external data
 class TensorrtUserWeights {
  public:
-  TensorrtUserWeights(const std::string& name, const std::string& data) : name_(name), data_(data) {};
+  TensorrtUserWeights(const std::string& name, const std::string& data) : name_(name),
+                                                                          data_cpy_(data) {
+                                                                          };
+
+  TensorrtUserWeights(const std::string& name, const void* data, size_t size) : name_(name), data_(data), size_(size) {
+                                                                                };
 
   const char* Name() const {
     return name_.c_str();
   };
 
   const void* Data() const {
-    return static_cast<void const*>(data_.data());
+    if (!data_cpy_.empty()) {
+      return data_cpy_.data();
+    }
+    return data_;
   }
 
   int64_t Size() const {
-    return static_cast<int64_t>(data_.size());
+    if (!data_cpy_.empty()) {
+      return static_cast<int64_t>(data_cpy_.size());
+    }
+    return static_cast<int64_t>(size_);
   }
 
  private:
   std::string name_{};
-  std::string data_{};
+  std::string data_cpy_{};
+  void const* data_;
+  size_t size_;
 };
 
 // Information to construct kernel function state.

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.h
@@ -283,6 +283,8 @@ class NvExecutionProvider : public IExecutionProvider {
                                     bool serialize_refitted_engine,
                                     bool detailed_build_log);
 
+  const InlinedVector<const Node*> GetEpContextNodes() const override;
+
  private:
   mutable NvExecutionProviderInfo info_;
   bool external_stream_ = false;
@@ -317,6 +319,7 @@ class NvExecutionProvider : public IExecutionProvider {
   std::string cache_prefix_;
   std::string op_types_to_exclude_;
   int nv_profile_index_ = 0;
+  std::vector<std::unique_ptr<onnxruntime::Model>> ep_context_nodes_;
 
   // The format is as for TENSORRT_VERSION: (MAJOR * 100 + MINOR) * 100 + PATCH
   int32_t trt_version_;

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.h
@@ -153,11 +153,26 @@ struct TensorParams {
   }
 };
 
-// Struct to hold user weights when ModelProtos are serialized with external data
-struct TensorrtUserWeights {
-  std::string name{};
-  std::string data{};
-  int64_t size{};
+// Data structure to hold user weights when ModelProtos are serialized with external data
+class TensorrtUserWeights {
+ public:
+  TensorrtUserWeights(const std::string& name, const std::string& data) : name_(name), data_(data) {};
+
+  const char* Name() const {
+    return name_.c_str();
+  };
+
+  const void* Data() const {
+    return static_cast<void const*>(data_.data());
+  }
+
+  const int64_t Size() const {
+    return static_cast<int64_t>(data_.size());
+  }
+
+ private:
+  std::string name_{};
+  std::string data_{};
 };
 
 // Information to construct kernel function state.
@@ -291,8 +306,7 @@ class NvExecutionProvider : public IExecutionProvider {
                                     size_t onnx_external_data_bytestream_size,
                                     nvinfer1::ICudaEngine* trt_engine,
                                     bool serialize_refitted_engine,
-                                    bool detailed_build_log,
-                                    const GraphViewer* graph_body_viewer = nullptr);
+                                    bool detailed_build_log);
 
   const InlinedVector<const Node*> GetEpContextNodes() const override;
 
@@ -312,6 +326,7 @@ class NvExecutionProvider : public IExecutionProvider {
   std::string onnx_model_folder_path_;
   const void* onnx_model_bytestream_;
   size_t onnx_model_bytestream_size_;
+  bool use_external_data_initializer_ = false;
   const void* onnx_external_data_bytestream_ = nullptr;
   size_t onnx_external_data_bytestream_size_ = 0;
   bool sparsity_enable_ = false;

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.h
@@ -204,6 +204,7 @@ struct TensorrtFuncState {
   bool is_dynamic_shape = false;
   std::string cache_prefix;
   std::string cache_suffix;
+  // runtime parameters
   std::vector<IAllocatorUniquePtr<void>> scratch_buffers;
   std::vector<TensorParams> input_tensors;
   std::vector<TensorParams> output_tensors;
@@ -211,7 +212,6 @@ struct TensorrtFuncState {
   bool skip_io_binding_allowed = false;  // Indicates if input/output binding can be skipped
   IAllocatorUniquePtr<void> context_memory = nullptr;
   size_t context_memory_size = 0;
-  std::unique_ptr<std::vector<TensorrtUserWeights>> *userWeights = nullptr;
 };
 
 // Minimum information to construct kernel function state for direct engine load code path
@@ -226,6 +226,7 @@ struct TensorrtShortFuncState {
   std::vector<std::unordered_map<std::string, size_t>> output_info;
   std::mutex* tensorrt_mu_ptr = nullptr;
   bool is_dynamic_shape = false;
+  // runtime parameters
   std::vector<IAllocatorUniquePtr<void>> scratch_buffers;
   std::vector<TensorParams> input_tensors;
   std::vector<TensorParams> output_tensors;

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.h
@@ -319,7 +319,7 @@ class NvExecutionProvider : public IExecutionProvider {
   std::string cache_prefix_;
   std::string op_types_to_exclude_;
   int nv_profile_index_ = 0;
-  std::vector<std::unique_ptr<onnxruntime::Model>> ep_context_nodes_;
+  std::vector<std::unique_ptr<onnxruntime::Model>> ep_context_models_;
 
   // The format is as for TENSORRT_VERSION: (MAJOR * 100 + MINOR) * 100 + PATCH
   int32_t trt_version_;

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.h
@@ -279,9 +279,12 @@ class NvExecutionProvider : public IExecutionProvider {
                                     bool path_check,
                                     const void* onnx_model_bytestream,
                                     size_t onnx_model_bytestream_size,
+                                    const void* onnx_external_data_bytestream,
+                                    size_t onnx_external_data_bytestream_size,
                                     nvinfer1::ICudaEngine* trt_engine,
                                     bool serialize_refitted_engine,
-                                    bool detailed_build_log);
+                                    bool detailed_build_log,
+                                    const GraphViewer* graph_body_viewer = nullptr);
 
   const InlinedVector<const Node*> GetEpContextNodes() const override;
 
@@ -301,6 +304,8 @@ class NvExecutionProvider : public IExecutionProvider {
   std::string onnx_model_folder_path_;
   const void* onnx_model_bytestream_;
   size_t onnx_model_bytestream_size_;
+  const void* onnx_external_data_bytestream_ = nullptr;
+  size_t onnx_external_data_bytestream_size_ = 0;
   bool sparsity_enable_ = false;
   int auxiliary_streams_ = -1;
   std::string cache_path_, engine_decryption_lib_path_;

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_info.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_info.cc
@@ -85,7 +85,8 @@ NvExecutionProviderInfo NvExecutionProviderInfo::FromProviderOptions(const Provi
     info.dump_ep_context_model = false;
   } else if (ep_context_enable == "1") {
     info.dump_ep_context_model = true;
-    info.weight_stripped_engine_enable = true;
+    // We want to reenable weightless engines as soon constant initializers are supported as inputs
+    info.weight_stripped_engine_enable = false;
   } else {
     ORT_THROW("Invalid ", kOrtSessionOptionEpContextEnable, " must 0 or 1");
   }

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_info.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_info.cc
@@ -51,24 +51,6 @@ NvExecutionProviderInfo NvExecutionProviderInfo::FromProviderOptions(const Provi
           .AddAssignmentToReference(nv::provider_option_names::kCudaGraphEnable, info.cuda_graph_enable)
           .AddAssignmentToReference(nv::provider_option_names::kUseExternalDataInitializer, info.use_external_data_initializer)
           .AddAssignmentToReference(nv::provider_option_names::kMultiProfileEnable, info.multi_profile_enable)
-          .AddValueParser(
-              nv::provider_option_names::kONNXBytestream,
-              [&onnx_bytestream](const std::string& value_str) -> Status {
-                size_t address;
-                ORT_RETURN_IF_ERROR(ParseStringWithClassicLocale(value_str, address));
-                onnx_bytestream = reinterpret_cast<void*>(address);
-                return Status::OK();
-              })
-          .AddAssignmentToReference(nv::provider_option_names::kONNXBytestreamSize, info.onnx_bytestream_size)
-          .AddValueParser(
-              nv::provider_option_names::kExternalDataBytestream,
-              [&external_data_bytestream](const std::string& value_str) -> Status {
-                size_t address;
-                ORT_RETURN_IF_ERROR(ParseStringWithClassicLocale(value_str, address));
-                external_data_bytestream = reinterpret_cast<void*>(address);
-                return Status::OK();
-              })
-          .AddAssignmentToReference(nv::provider_option_names::kExternalDataBytestreamSize, info.external_data_bytestream_size)
           .Parse(options));  // add new provider option here.
 
   info.user_compute_stream = user_compute_stream;
@@ -123,11 +105,7 @@ ProviderOptions NvExecutionProviderInfo::ToProviderOptions(const NvExecutionProv
       {nv::provider_option_names::kProfilesMaxShapes, MakeStringWithClassicLocale(info.profile_max_shapes)},
       {nv::provider_option_names::kProfilesOptShapes, MakeStringWithClassicLocale(info.profile_opt_shapes)},
       {nv::provider_option_names::kCudaGraphEnable, MakeStringWithClassicLocale(info.cuda_graph_enable)},
-      {nv::provider_option_names::kONNXBytestream, MakeStringWithClassicLocale(info.onnx_bytestream)},
-      {nv::provider_option_names::kONNXBytestreamSize, MakeStringWithClassicLocale(info.onnx_bytestream_size)},
-      {nv::provider_option_names::kUseExternalDataInitializer, MakeStringWithClassicLocale(info.use_external_data_initializer)},
-      {nv::provider_option_names::kExternalDataBytestream, MakeStringWithClassicLocale(info.external_data_bytestream)},
-      {nv::provider_option_names::kExternalDataBytestreamSize, MakeStringWithClassicLocale(info.external_data_bytestream_size)},
+      {nv::provider_option_names::kUseExternalDataInitializer, MakeStringWithClassicLocale(info.use_external_data_initializer)}
   };
   return options;
 }

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_info.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_info.cc
@@ -49,6 +49,7 @@ NvExecutionProviderInfo NvExecutionProviderInfo::FromProviderOptions(const Provi
           .AddAssignmentToReference(nv::provider_option_names::kProfilesMaxShapes, info.profile_max_shapes)
           .AddAssignmentToReference(nv::provider_option_names::kProfilesOptShapes, info.profile_opt_shapes)
           .AddAssignmentToReference(nv::provider_option_names::kCudaGraphEnable, info.cuda_graph_enable)
+          .AddAssignmentToReference(nv::provider_option_names::kUseExternalDataInitializer, info.use_external_data_initializer)
           .AddAssignmentToReference(nv::provider_option_names::kMultiProfileEnable, info.multi_profile_enable)
           .AddValueParser(
               nv::provider_option_names::kONNXBytestream,
@@ -105,6 +106,8 @@ NvExecutionProviderInfo NvExecutionProviderInfo::FromProviderOptions(const Provi
     ORT_THROW("Invalid ", kOrtSessionOptionEpContextEmbedMode, " must 0 or 1");
   }
 
+  // info.use_external_data_initializer = true;
+
   return info;
 }
 
@@ -123,6 +126,7 @@ ProviderOptions NvExecutionProviderInfo::ToProviderOptions(const NvExecutionProv
       {nv::provider_option_names::kCudaGraphEnable, MakeStringWithClassicLocale(info.cuda_graph_enable)},
       {nv::provider_option_names::kONNXBytestream, MakeStringWithClassicLocale(info.onnx_bytestream)},
       {nv::provider_option_names::kONNXBytestreamSize, MakeStringWithClassicLocale(info.onnx_bytestream_size)},
+      {nv::provider_option_names::kUseExternalDataInitializer, MakeStringWithClassicLocale(info.use_external_data_initializer)},
       {nv::provider_option_names::kExternalDataBytestream, MakeStringWithClassicLocale(info.external_data_bytestream)},
       {nv::provider_option_names::kExternalDataBytestreamSize, MakeStringWithClassicLocale(info.external_data_bytestream_size)},
   };

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_info.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_info.cc
@@ -105,8 +105,7 @@ ProviderOptions NvExecutionProviderInfo::ToProviderOptions(const NvExecutionProv
       {nv::provider_option_names::kProfilesMaxShapes, MakeStringWithClassicLocale(info.profile_max_shapes)},
       {nv::provider_option_names::kProfilesOptShapes, MakeStringWithClassicLocale(info.profile_opt_shapes)},
       {nv::provider_option_names::kCudaGraphEnable, MakeStringWithClassicLocale(info.cuda_graph_enable)},
-      {nv::provider_option_names::kUseExternalDataInitializer, MakeStringWithClassicLocale(info.use_external_data_initializer)}
-  };
+      {nv::provider_option_names::kUseExternalDataInitializer, MakeStringWithClassicLocale(info.use_external_data_initializer)}};
   return options;
 }
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_info.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_info.cc
@@ -106,8 +106,6 @@ NvExecutionProviderInfo NvExecutionProviderInfo::FromProviderOptions(const Provi
     ORT_THROW("Invalid ", kOrtSessionOptionEpContextEmbedMode, " must 0 or 1");
   }
 
-  // info.use_external_data_initializer = true;
-
   return info;
 }
 

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_info.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_info.h
@@ -31,6 +31,7 @@ struct NvExecutionProviderInfo {
   std::string onnx_model_folder_path{""};
   const void* onnx_bytestream{nullptr};
   size_t onnx_bytestream_size{0};
+  bool use_external_data_initializer{false};
   const void* external_data_bytestream{nullptr};
   size_t external_data_bytestream_size{0};
   bool engine_decryption_enable{false};

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_info.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_info.h
@@ -31,6 +31,8 @@ struct NvExecutionProviderInfo {
   std::string onnx_model_folder_path{""};
   const void* onnx_bytestream{nullptr};
   size_t onnx_bytestream_size{0};
+  const void* external_data_bytestream{nullptr};
+  size_t external_data_bytestream_size{0};
   bool engine_decryption_enable{false};
   std::string engine_decryption_lib_path{""};
   bool force_sequential_engine_build{false};

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_utils.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_utils.h
@@ -386,20 +386,9 @@ std::string GetCachePath(const std::string& root, const std::string& name) {
  * Get compute capability
  *
  */
-std::string GetComputeCapacity(const cudaDeviceProp& prop) {
+std::string GetComputeCapability(const cudaDeviceProp& prop) {
   const std::string compute_capability = std::to_string(prop.major * 10 + prop.minor);
   return compute_capability;
-}
-
-/*
- * Get Timing by compute capability
- *
- */
-std::string GetTimingCachePath(const std::string& root, std::string& compute_cap) {
-  // append compute capability of the GPU as this invalidates the cache and TRT will throw when loading the cache
-  const std::string timing_cache_name = "NvExecutionProvider_cache_sm" +
-                                        compute_cap + ".timing";
-  return GetCachePath(root, timing_cache_name);
 }
 
 /*

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.cc
@@ -66,14 +66,14 @@ void UpdateCtxNodeModelEngineContext(ONNX_NAMESPACE::ModelProto* model_proto,
  * Create EP context node where engine information is embedded
  */
 std::unique_ptr<onnxruntime::Model> CreateCtxNode(const GraphViewer& graph_viewer,
-                                           const std::string engine_cache_path,
-                                           char* engine_data,
-                                           size_t size,
-                                           const int64_t embed_mode,
-                                           const std::string compute_capability,
-                                           const std::string onnx_model_path,
-                                           const logging::Logger* logger,
-                                           const std::string& ep_context_node_name) {
+                                                  const std::string engine_cache_path,
+                                                  char* engine_data,
+                                                  size_t size,
+                                                  const int64_t embed_mode,
+                                                  const std::string compute_capability,
+                                                  const std::string onnx_model_path,
+                                                  const logging::Logger* logger,
+                                                  const std::string& ep_context_node_name) {
   auto model_build = Model::Create("nv_trt_rtx_ep_context_model", false, *logger);
   auto& graph_build = model_build->MainGraph();
 

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.cc
@@ -110,8 +110,6 @@ Status CreateCtxNode(const GraphViewer& graph_viewer,
       engine_data_str.assign(engine_data, size);
     }
     attr_ep_cache_context->set_s(engine_data_str);
-    // TODO(maximilianm) we might want to disable this warning as we only support weightless engines that are really small
-    //                   the reason we had this was that the field will be hashed and storing a large bytestream has significant overhead
   } else {
     attr_ep_cache_context->set_s(engine_cache_path);
     std::fstream engine_cache_file(engine_cache_path, std::ios::binary | std::ios::out);

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.cc
@@ -294,6 +294,8 @@ Status TensorRTCacheModelHandler::GetEpContextFromGraph(const GraphViewer& graph
                                                      make_secure_path_checks,
                                                      onnx_model_bytestream_,
                                                      onnx_model_bytestream_size_,
+                                                     onnx_external_data_bytestream_,
+                                                     onnx_external_data_bytestream_size_,
                                                      (*trt_engine_).get(),
                                                      false /* serialize refitted engine to disk */,
                                                      detailed_build_log_);
@@ -363,6 +365,8 @@ Status TensorRTCacheModelHandler::GetEpContextFromGraph(const GraphViewer& graph
                                                      make_secure_path_checks,
                                                      onnx_model_bytestream_,
                                                      onnx_model_bytestream_size_,
+                                                     onnx_external_data_bytestream_,
+                                                     onnx_external_data_bytestream_size_,
                                                      (*trt_engine_).get(),
                                                      true /* serialize refitted engine to disk */,
                                                      detailed_build_log_);

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.cc
@@ -111,7 +111,8 @@ Status CreateCtxNode(const GraphViewer& graph_viewer,
     }
     attr_ep_cache_context->set_s(engine_data_str);
   } else {
-    attr_ep_cache_context->set_s(engine_cache_path);
+    std::string engine_cache_filename = std::filesystem::path(engine_cache_path).filename().string();
+    attr_ep_cache_context->set_s(engine_cache_filename);
     std::fstream engine_cache_file(engine_cache_path, std::ios::binary | std::ios::out);
     if (engine_cache_file.is_open()) {
       engine_cache_file.write(engine_data, size);

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.h
@@ -20,9 +20,7 @@ static const std::string COMPUTE_CAPABILITY = "hardware_architecture";
 static const std::string ONNX_MODEL_FILENAME = "onnx_model_filename";
 static const std::string EPCONTEXT_OP_DOMAIN = "com.microsoft";
 static const std::string EPCONTEXT_WARNING =
-    "It's suggested to set the ORT graph optimization level to 0 and  \
-                                              make \"embed_mode\" to 0 (\"ep_cache_context\" is the cache path)\
-                                              for the best model loading time";
+    "It's suggested to set the ORT graph optimization level to 0 for the best performance";
 
 bool GraphHasCtxNode(const GraphViewer& graph_viewer);
 const std::filesystem::path& GetModelPath(const GraphViewer& graph_viewer);

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.h
@@ -27,7 +27,7 @@ static const std::string EPCONTEXT_WARNING =
 bool GraphHasCtxNode(const GraphViewer& graph_viewer);
 const std::filesystem::path& GetModelPath(const GraphViewer& graph_viewer);
 std::filesystem::path GetPathOrParentPathOfCtxModel(const std::string& ep_context_file_path);
-ONNX_NAMESPACE::ModelProto* CreateCtxModel(const GraphViewer& graph_viewer,
+std::unique_ptr<onnxruntime::Model> CreateCtxNode(const GraphViewer& graph_viewer,
                                            const std::string engine_cache_path,
                                            char* engine_data,
                                            size_t size,
@@ -35,7 +35,7 @@ ONNX_NAMESPACE::ModelProto* CreateCtxModel(const GraphViewer& graph_viewer,
                                            const std::string compute_capability,
                                            const std::string onnx_model_path,
                                            const logging::Logger* logger,
-                                           std::vector<std::unique_ptr<onnxruntime::Model>>& ep_context_models, const std::string& ep_context_node_name);
+                                           const std::string& ep_context_node_name);
 std::string GetCtxModelPath(const std::string& ep_context_file_path,
                             const std::string& original_model_path);
 bool IsAbsolutePath(const std::string& path_string);

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.h
@@ -54,6 +54,8 @@ class TensorRTCacheModelHandler {
                             std::string onnx_model_folder_path,
                             const void* onnx_model_bytestream,
                             size_t onnx_model_bytestream_size,
+                            const void* onnx_external_data_bytestream,
+                            size_t onnx_external_data_bytestream_size,
                             bool detailed_build_log)
       : trt_engine_(trt_engine),
         trt_runtime_(trt_runtime),
@@ -63,6 +65,8 @@ class TensorRTCacheModelHandler {
         onnx_model_folder_path_(onnx_model_folder_path),
         onnx_model_bytestream_(onnx_model_bytestream),
         onnx_model_bytestream_size_(onnx_model_bytestream_size),
+        onnx_external_data_bytestream_(onnx_external_data_bytestream),
+        onnx_external_data_bytestream_size_(onnx_external_data_bytestream_size),
         detailed_build_log_(detailed_build_log) {
   }
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(TensorRTCacheModelHandler);
@@ -80,6 +84,8 @@ class TensorRTCacheModelHandler {
   std::string onnx_model_folder_path_;
   const void* onnx_model_bytestream_;
   size_t onnx_model_bytestream_size_;
+  const void* onnx_external_data_bytestream_;
+  size_t onnx_external_data_bytestream_size_;
   bool detailed_build_log_;
 };  // TRTCacheModelHandler
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.h
@@ -34,7 +34,8 @@ ONNX_NAMESPACE::ModelProto* CreateCtxModel(const GraphViewer& graph_viewer,
                                            const int64_t embed_mode,
                                            const std::string compute_capability,
                                            const std::string onnx_model_path,
-                                           const logging::Logger* logger);
+                                           const logging::Logger* logger,
+                                           std::vector<std::unique_ptr<onnxruntime::Model>>& ep_context_nodes, const std::string& node_name);
 std::string GetCtxModelPath(const std::string& ep_context_file_path,
                             const std::string& original_model_path);
 bool IsAbsolutePath(const std::string& path_string);

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.h
@@ -26,14 +26,14 @@ bool GraphHasCtxNode(const GraphViewer& graph_viewer);
 const std::filesystem::path& GetModelPath(const GraphViewer& graph_viewer);
 std::filesystem::path GetPathOrParentPathOfCtxModel(const std::string& ep_context_file_path);
 std::unique_ptr<onnxruntime::Model> CreateCtxNode(const GraphViewer& graph_viewer,
-                                           const std::string engine_cache_path,
-                                           char* engine_data,
-                                           size_t size,
-                                           const int64_t embed_mode,
-                                           const std::string compute_capability,
-                                           const std::string onnx_model_path,
-                                           const logging::Logger* logger,
-                                           const std::string& ep_context_node_name);
+                                                  const std::string engine_cache_path,
+                                                  char* engine_data,
+                                                  size_t size,
+                                                  const int64_t embed_mode,
+                                                  const std::string compute_capability,
+                                                  const std::string onnx_model_path,
+                                                  const logging::Logger* logger,
+                                                  const std::string& ep_context_node_name);
 std::string GetCtxModelPath(const std::string& ep_context_file_path,
                             const std::string& original_model_path);
 bool IsAbsolutePath(const std::string& path_string);

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.h
@@ -35,7 +35,7 @@ ONNX_NAMESPACE::ModelProto* CreateCtxModel(const GraphViewer& graph_viewer,
                                            const std::string compute_capability,
                                            const std::string onnx_model_path,
                                            const logging::Logger* logger,
-                                           std::vector<std::unique_ptr<onnxruntime::Model>>& ep_context_nodes, const std::string& node_name);
+                                           std::vector<std::unique_ptr<onnxruntime::Model>>& ep_context_models, const std::string& ep_context_node_name);
 std::string GetCtxModelPath(const std::string& ep_context_file_path,
                             const std::string& original_model_path);
 bool IsAbsolutePath(const std::string& path_string);

--- a/onnxruntime/test/providers/nv_tensorrt_rtx/nv_basic_test.cc
+++ b/onnxruntime/test/providers/nv_tensorrt_rtx/nv_basic_test.cc
@@ -31,11 +31,6 @@ TEST(NvExecutionProviderTest, ContextEmbedAndReload) {
   std::vector<int> dims = {1, 3, 2};
 
   CreateBaseModel(model_name, graph_name, dims);
-
-  auto env = Ort::Env();
-  auto logging_level = OrtLoggingLevel::ORT_LOGGING_LEVEL_WARNING;
-  env.UpdateEnvWithCustomLogLevel(logging_level);
-
   // AOT time
   {
     auto start = std::chrono::high_resolution_clock::now();
@@ -44,7 +39,7 @@ TEST(NvExecutionProviderTest, ContextEmbedAndReload) {
     so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
     so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, model_name_ctx_str.c_str());
     so.AppendExecutionProvider(kNvTensorRTRTXExecutionProvider, {});
-    Ort::Session session_object(env, model_name.c_str(), so);
+    Ort::Session session_object(*ort_env, model_name.c_str(), so);
     auto stop = std::chrono::high_resolution_clock::now();
     std::cout << "Session creation AOT: " << std::chrono::duration_cast<std::chrono::milliseconds>((stop - start)).count() << " ms" << std::endl;
 
@@ -59,7 +54,7 @@ TEST(NvExecutionProviderTest, ContextEmbedAndReload) {
     Ort::RunOptions run_options;
     so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
     so.AppendExecutionProvider(kNvTensorRTRTXExecutionProvider, {});
-    Ort::Session session_object(env, model_name_ctx.c_str(), so);
+    Ort::Session session_object(*ort_env, model_name_ctx.c_str(), so);
     auto stop = std::chrono::high_resolution_clock::now();
     std::cout << "Session creation JIT: " << std::chrono::duration_cast<std::chrono::milliseconds>((stop - start)).count() << " ms" << std::endl;
 
@@ -78,10 +73,6 @@ TEST(NvExecutionProviderTest, ContextEmbedAndReloadDynamic) {
 
   CreateBaseModel(model_name, graph_name, dims);
 
-  auto env = Ort::Env();
-  auto logging_level = OrtLoggingLevel::ORT_LOGGING_LEVEL_WARNING;
-  env.UpdateEnvWithCustomLogLevel(logging_level);
-
   // AOT time
   {
     auto start = std::chrono::high_resolution_clock::now();
@@ -90,7 +81,7 @@ TEST(NvExecutionProviderTest, ContextEmbedAndReloadDynamic) {
     so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
     so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, model_name_ctx_str.c_str());
     so.AppendExecutionProvider(kNvTensorRTRTXExecutionProvider, {});
-    Ort::Session session_object(env, model_name.c_str(), so);
+    Ort::Session session_object(*ort_env, model_name.c_str(), so);
     auto stop = std::chrono::high_resolution_clock::now();
     std::cout << "Session creation AOT: " << std::chrono::duration_cast<std::chrono::milliseconds>((stop - start)).count() << " ms" << std::endl;
 
@@ -105,7 +96,7 @@ TEST(NvExecutionProviderTest, ContextEmbedAndReloadDynamic) {
     Ort::RunOptions run_options;
     so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
     so.AppendExecutionProvider(kNvTensorRTRTXExecutionProvider, {});
-    Ort::Session session_object(env, model_name_ctx.c_str(), so);
+    Ort::Session session_object(*ort_env, model_name_ctx.c_str(), so);
     auto stop = std::chrono::high_resolution_clock::now();
     std::cout << "Session creation JIT: " << std::chrono::duration_cast<std::chrono::milliseconds>((stop - start)).count() << " ms" << std::endl;
 
@@ -127,10 +118,6 @@ TEST(NvExecutionProviderTest, ContextEmbedAndReloadDataDynamic) {
 
   CreateBaseModel(model_name, graph_name, dims);
 
-  auto env = Ort::Env();
-  auto logging_level = OrtLoggingLevel::ORT_LOGGING_LEVEL_WARNING;
-  env.UpdateEnvWithCustomLogLevel(logging_level);
-
   // AOT time
   {
     auto start = std::chrono::high_resolution_clock::now();
@@ -139,7 +126,7 @@ TEST(NvExecutionProviderTest, ContextEmbedAndReloadDataDynamic) {
     so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
     so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, model_name_ctx_str.c_str());
     so.AppendExecutionProvider(kNvTensorRTRTXExecutionProvider, {});
-    Ort::Session session_object(env, model_name.c_str(), so);
+    Ort::Session session_object(*ort_env, model_name.c_str(), so);
     auto stop = std::chrono::high_resolution_clock::now();
     std::cout << "Session creation AOT: " << std::chrono::duration_cast<std::chrono::milliseconds>((stop - start)).count() << " ms" << std::endl;
 
@@ -154,7 +141,7 @@ TEST(NvExecutionProviderTest, ContextEmbedAndReloadDataDynamic) {
     Ort::RunOptions run_options;
     so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
     so.AppendExecutionProvider(kNvTensorRTRTXExecutionProvider, {});
-    Ort::Session session_object(env, model_name_ctx.c_str(), so);
+    Ort::Session session_object(*ort_env, model_name_ctx.c_str(), so);
     auto stop = std::chrono::high_resolution_clock::now();
     std::cout << "Session creation JIT: " << std::chrono::duration_cast<std::chrono::milliseconds>((stop - start)).count() << " ms" << std::endl;
 
@@ -196,25 +183,21 @@ class TypeTests : public ::testing::TestWithParam<ONNX_NAMESPACE::TensorProto_Da
 };
 
 TEST_P(TypeTests, IOTypes) {
-  std::string dtype_name = getTypeAsName(GetParam());
+  const std::string dtype_name = getTypeAsName(GetParam());
   ASSERT_FALSE(dtype_name.empty());
   const std::string model_name_str = "nv_execution_provider_" + dtype_name + ".onnx";
   const PathString model_name = ToPathString(model_name_str);
-  std::string graph_name = "test" + dtype_name;
-  std::vector<int> dims = {1, -1, -1};
+  const std::string graph_name = "test" + dtype_name;
+  const std::vector<int> dims = {1, 5, 10};
 
   CreateBaseModel(model_name, graph_name, dims, false, GetParam());
-
-  auto env = Ort::Env();
-  auto logging_level = OrtLoggingLevel::ORT_LOGGING_LEVEL_WARNING;
-  env.UpdateEnvWithCustomLogLevel(logging_level);
 
   // AOT time
   {
     Ort::SessionOptions so;
     Ort::RunOptions run_options;
     so.AppendExecutionProvider(kNvTensorRTRTXExecutionProvider, {});
-    Ort::Session session_object(env, model_name.c_str(), so);
+    Ort::Session session_object(*ort_env, model_name.c_str(), so);
 
     auto io_binding = generate_io_binding(session_object);
     session_object.Run(run_options, io_binding);
@@ -260,20 +243,16 @@ TEST(NvExecutionProviderTest, AutoEp_PreferGpu) {
 
   CreateBaseModel(model_name, graph_name, dims);
 
-  auto env = Ort::Env();
-  auto logging_level = OrtLoggingLevel::ORT_LOGGING_LEVEL_WARNING;
-  env.UpdateEnvWithCustomLogLevel(logging_level);
-
   {
-    env.RegisterExecutionProviderLibrary(kNvTensorRTRTXExecutionProvider, ORT_TSTR("onnxruntime_providers_nv_tensorrt_rtx.dll"));
+    ort_env->RegisterExecutionProviderLibrary(kNvTensorRTRTXExecutionProvider, ORT_TSTR("onnxruntime_providers_nv_tensorrt_rtx.dll"));
 
     Ort::SessionOptions so;
     so.SetEpSelectionPolicy(OrtExecutionProviderDevicePolicy_PREFER_GPU);
-    Ort::Session session_object(env, model_name.c_str(), so);
+    Ort::Session session_object(*ort_env, model_name.c_str(), so);
     EXPECT_TRUE(SessionHasEp(session_object, kNvTensorRTRTXExecutionProvider));
   }
 
-  env.UnregisterExecutionProviderLibrary(kNvTensorRTRTXExecutionProvider);
+  ort_env->UnregisterExecutionProviderLibrary(kNvTensorRTRTXExecutionProvider);
 }
 
 TEST(NvExecutionProviderTest, GetSharedAllocator) {

--- a/onnxruntime/test/providers/nv_tensorrt_rtx/nv_basic_test.cc
+++ b/onnxruntime/test/providers/nv_tensorrt_rtx/nv_basic_test.cc
@@ -1,4 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // Licensed under the MIT License.
 #include "core/graph/onnx_protobuf.h"
@@ -217,7 +216,7 @@ INSTANTIATE_TEST_SUITE_P(NvExecutionProviderTest, TypeTests,
                                            ),
                          [](const testing::TestParamInfo<TypeTests::ParamType>& info) { return getTypeAsName(info.param); });
 
-#if defined(WIN32)
+#ifdef _WIN32
 static bool SessionHasEp(Ort::Session& session, const char* ep_name) {
   // Access the underlying InferenceSession.
   const OrtSession* ort_session = session;
@@ -399,7 +398,7 @@ TEST(NvExecutionProviderTest, DataTransfer) {
   device_tensor = Ort::Value();
 }
 
-#endif  // defined(WIN32)
+#endif
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/nv_tensorrt_rtx/nv_basic_test.cc
+++ b/onnxruntime/test/providers/nv_tensorrt_rtx/nv_basic_test.cc
@@ -5,21 +5,13 @@
 #include "core/session/inference_session.h"
 #include "test/providers/provider_test_utils.h"
 #include "test/framework/test_utils.h"
-#include "gtest/gtest.h"
+
 #include "test/util/include/scoped_env_vars.h"
 #include "test/common/trt_op_test_utils.h"
 #include "test/common/random_generator.h"
 #include "test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.h"
 
-#include "test/util/include/api_asserts.h"
-#include "test/util/include/asserts.h"
-#include <onnxruntime_cxx_api.h>
-#include <onnxruntime_ep_device_ep_metadata_keys.h>
-#include <onnxruntime_run_options_config_keys.h>
-#include <onnxruntime_session_options_config_keys.h>
-#include <string>
 #include <thread>
-#include <filesystem>
 #include <chrono>
 
 using namespace std;
@@ -59,170 +51,6 @@ class NvExecutionProviderTest : public ::testing::Test {
 using NvExecutionProviderTestTypes = ::testing::Types<double, float, MLFloat16, BFloat16, uint8_t, int8_t, int32_t, int64_t>;  // double,
 TYPED_TEST_SUITE(NvExecutionProviderTest, NvExecutionProviderTestTypes);
 
-std::string PathToUTF8(const PathString& path) {
-#ifdef WIN32
-  std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
-  return converter.to_bytes(path);
-#else
-  return path.c_str();
-#endif
-}
-
-void clearFileIfExists(PathString path) {
-  if (std::filesystem::exists(path)) {
-    std::filesystem::remove(path);
-  }
-}
-
-template <typename T>
-void VerifyOutputs(const std::vector<OrtValue>& fetches, const std::vector<int64_t>& expected_dims,
-                   const std::vector<T>& expected_values) {
-  ASSERT_EQ(1, fetches.size());
-  auto& rtensor = fetches.front().Get<Tensor>();
-  TensorShape expected_shape(expected_dims);
-  ASSERT_EQ(expected_shape, rtensor.Shape());
-  const std::vector<T> found(rtensor.Data<T>(), rtensor.Data<T>() + expected_values.size());
-  ASSERT_EQ(expected_values, found);
-}
-
-/**
- * Create a simple model with dynamic or non-dynamic input shape.
- * \param model_name - model name
- * \param graph_name - graph name
- * \param dims - input dimensions
- * \param add_fast_gelu - add FastGelu node which makes the whole model partition into TRT EP and CUDA EP subgraphs.
- *
- * input: "X", "Y" and "Z"
- *        you can specify input dimensions, for example (1, 3, 2), (1, 2) or (1, -1, -1)). Note: -1 means the dimension is dynamic.
- *        All three inputs have the same dimensions.
- * output: "M"
- *
- *      "X"  "Y"
- *        \  /
- *    "Z"  Add
- *      \  /
- *       Add
- *       /
- *       Add (+ float scalar "S")
- *       /
- *     "O"
- *
- *     or
- *
- *      "X"  "Y"
- *        \  /
- *    "Z"  Add
- *      \  /
- *       Add
- *       /
- *    FastGelu (This node will be placed on CUDA EP)
- *     /
- *     *       Add (+ float scalar "S")
- *    /
- *   "O"
- */
-static void CreateBaseModel(const PathString& model_name,
-                            std::string graph_name,
-                            std::vector<int> dims,
-                            bool add_fast_gelu = false,
-                            ONNX_NAMESPACE::TensorProto_DataType dtype = ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {
-  onnxruntime::Model model(graph_name, false, DefaultLoggingManager().DefaultLogger());
-  auto& graph = model.MainGraph();
-  std::vector<onnxruntime::NodeArg*> inputs;
-  std::vector<onnxruntime::NodeArg*> outputs;
-
-  // FLOAT tensor
-  ONNX_NAMESPACE::TypeProto float_tensor;
-  float_tensor.mutable_tensor_type()->set_elem_type(dtype);
-
-  for (auto dim : dims) {
-    float_tensor.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(dim);
-  }
-  ONNX_NAMESPACE::TypeProto dyn_float_tensor;
-  dyn_float_tensor.mutable_tensor_type()->set_elem_type(dtype);
-
-  auto& input_arg_1 = graph.GetOrCreateNodeArg("X", &float_tensor);
-  auto& input_arg_2 = graph.GetOrCreateNodeArg("Y", &float_tensor);
-  inputs.push_back(&input_arg_1);
-  inputs.push_back(&input_arg_2);
-  auto& output_arg = graph.GetOrCreateNodeArg("node_1_out_1", &float_tensor);
-  outputs.push_back(&output_arg);
-  graph.AddNode("node_1", "Add", "node 1.", inputs, outputs);
-
-  auto& input_arg_3 = graph.GetOrCreateNodeArg("Z", &float_tensor);
-  inputs.clear();
-  inputs.push_back(&output_arg);
-  inputs.push_back(&input_arg_3);
-
-  auto& output_arg_2 = graph.GetOrCreateNodeArg("node_2_out_1", &float_tensor);
-  outputs.clear();
-  outputs.push_back(&output_arg_2);
-  graph.AddNode("node_2", "Add", "node 2.", inputs, outputs);
-
-  inputs.clear();
-  inputs.push_back(&output_arg_2);
-
-  if (add_fast_gelu) {
-    auto& output_arg_3 = graph.GetOrCreateNodeArg("node_3_out_1", &dyn_float_tensor);
-    outputs.clear();
-    outputs.push_back(&output_arg_3);
-
-    graph.AddNode("node_3", "FastGelu", "node 3.", inputs, outputs,
-                  /* attributes */ nullptr, kMSDomain);
-
-    inputs.clear();
-    inputs.push_back(&output_arg_3);
-  }
-
-  ONNX_NAMESPACE::TypeProto float_scalar;
-  float_scalar.mutable_tensor_type()->set_elem_type(dtype);
-  float_scalar.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
-  auto& input_scalar = graph.GetOrCreateNodeArg("S", &float_scalar);
-  inputs.push_back(&input_scalar);
-
-  auto& output_arg_4 = graph.GetOrCreateNodeArg("O", &dyn_float_tensor);
-
-  outputs.clear();
-  outputs.push_back(&output_arg_4);
-  graph.AddNode("node_5", "Add", "node 5.", inputs, outputs);
-
-  auto status = graph.Resolve();
-  ASSERT_TRUE(status.IsOK());
-  status = onnxruntime::Model::Save(model, model_name);
-  ASSERT_TRUE(status.IsOK());
-}
-
-static Ort::IoBinding generate_io_binding(Ort::Session& session, std::map<std::string, std::vector<int64_t>> shape_overwrites = {}) {
-  Ort::IoBinding binding(session);
-  auto allocator = Ort::AllocatorWithDefaultOptions();
-  for (int input_idx = 0; input_idx < int(session.GetInputCount()); ++input_idx) {
-    auto input_name = session.GetInputNameAllocated(input_idx, Ort::AllocatorWithDefaultOptions());
-    auto full_tensor_info = session.GetInputTypeInfo(input_idx);
-    auto tensor_info = full_tensor_info.GetTensorTypeAndShapeInfo();
-    auto shape = tensor_info.GetShape();
-    auto type = tensor_info.GetElementType();
-    if (shape_overwrites.find(input_name.get()) == shape_overwrites.end()) {
-      for (auto& v : shape) {
-        if (v == -1) {
-          v = 1;
-        }
-      }
-    } else {
-      shape = shape_overwrites[input_name.get()];
-    }
-    auto input_value = Ort::Value::CreateTensor(allocator,
-                                                shape.data(),
-                                                shape.size(),
-                                                type);
-    binding.BindInput(input_name.get(), input_value);
-  }
-
-  for (int output_idx = 0; output_idx < int(session.GetOutputCount()); ++output_idx) {
-    auto output_name = session.GetOutputNameAllocated(output_idx, Ort::AllocatorWithDefaultOptions());
-    binding.BindOutput(output_name.get(), allocator.GetInfo());
-  }
-  return binding;
-}
 
 TEST(NvExecutionProviderTest, ContextEmbedAndReload) {
   PathString model_name = ORT_TSTR("nv_execution_provider_test.onnx");

--- a/onnxruntime/test/providers/nv_tensorrt_rtx/nv_ep_context_test.cc
+++ b/onnxruntime/test/providers/nv_tensorrt_rtx/nv_ep_context_test.cc
@@ -56,16 +56,17 @@ class CompileApiTest
   }
 };
 
-TEST_P(CompileApiTest, EmbedMode) {
-  const auto& test_param = GetCompileParam();
-  const std::string test_name = test_param.to_string();
+void SmallModelTest(CompileParam test_param, bool fully_supported_model) {
+  std::string test_name = test_param.to_string();
+  if (!fully_supported_model)
+    test_name += "_fast_gelu";
   PathString model_name = path_utils::MakePathString("nv_execution_provider_compile_" + test_name + ".onnx");
   PathString model_name_ctx = path_utils::MakePathString("nv_execution_provider_compile_" + test_name + "_ctx.onnx");
   clearFileIfExists(model_name_ctx);
   std::string graph_name = "test";
   std::vector<int> dims = {1, 3, 2};
 
-  CreateBaseModel(model_name, graph_name, dims, true);
+  CreateBaseModel(model_name, graph_name, dims, !fully_supported_model);
 
   Ort::SessionOptions session_options;
 #ifdef _WIN32
@@ -97,11 +98,7 @@ TEST_P(CompileApiTest, EmbedMode) {
     model_compile_options.SetOutputModelPath(model_name_ctx.c_str());
   }
   // AOT time
-  auto status = Ort::CompileModel(*ort_env, model_compile_options);
-  if (!status.IsOK()) {
-    std::cerr << status.GetErrorMessage() << std::endl;
-  }
-  ASSERT_TRUE(status.IsOK());
+  ASSERT_TRUE(Ort::CompileModel(*ort_env, model_compile_options).IsOK());
 
   // JIT time
   Ort::Session session_object{nullptr};
@@ -115,6 +112,103 @@ TEST_P(CompileApiTest, EmbedMode) {
   session_object.Run(run_options, io_binding);
 }
 
+TEST_P(CompileApiTest, SmallModel) {
+  const auto& test_param = GetCompileParam();
+  SmallModelTest(test_param, true);
+}
+
+TEST_P(CompileApiTest, SmallSplitModel) {
+  const auto& test_param = GetCompileParam();
+  SmallModelTest(test_param, false);
+}
+
+TEST_P(CompileApiTest, LargeModel) {
+  const auto& test_param = GetCompileParam();
+  PathString model_name = path_utils::MakePathString("nv_execution_provider_compile_large.onnx");
+  PathString external_data_name = path_utils::MakePathString("nv_execution_provider_compile_large.onnx_data");
+  PathString model_name_ctx = path_utils::MakePathString("nv_execution_provider_compile_large_ctx.onnx");
+  PathString model_name_ctx_data = path_utils::MakePathString("nv_execution_provider_compile_large_ctx.onnx_data");
+  clearFileIfExists(model_name_ctx);
+  std::string graph_name = "test";
+  std::vector<int> dims = {1, 3, 2};
+  if (!std::filesystem::exists(model_name) || !std::filesystem::exists(external_data_name)) {
+    CreateLargeLLMModel(model_name, external_data_name);
+  }
+
+  Ort::SessionOptions session_options;
+  std::vector<const char*> option_keys;
+  std::vector<const char*> option_values;
+  if (test_param.bytestream_io) {
+    option_keys = {onnxruntime::nv::provider_option_names::kUseExternalDataInitializer};
+    option_values = {"0"};
+  }
+  ASSERT_EQ(option_keys.size(), option_values.size());
+#ifdef _WIN32
+  /// Since this test runs after other tests that use registration interface this test has to use it as well
+  /// windows as otherwise the kernel registry inside the EP will not be populated. The legacy APis ony call the initialize once.
+  RegisteredEpDeviceUniquePtr nv_tensorrt_rtx_ep;
+  Utils::RegisterAndGetNvTensorRtRtxEp(*ort_env, nv_tensorrt_rtx_ep);
+  const OrtEpDevice* const* ep_devices = nullptr;
+  const OrtEpDevice* const* selected_device = nullptr;
+  size_t num_devices = 0;
+  ASSERT_ORTSTATUS_OK(Ort::GetApi().GetEpDevices(*ort_env, &ep_devices, &num_devices));
+  for (int i = 0; i < num_devices; i++) {
+    if (ep_devices[i]->ep_name == kNvTensorRTRTXExecutionProvider) {
+      selected_device = &ep_devices[i];
+    }
+  }
+  ASSERT_ORTSTATUS_OK(Ort::GetApi().SessionOptionsAppendExecutionProvider_V2(session_options, *ort_env, selected_device, 1,
+                                                                             option_keys.data(), option_values.data(), option_keys.size()));
+#else
+  std::unordered_map<std::string, std::string> option_map;
+  for (size_t i = 0; i < option_keys.size(); ++i) {
+    option_map[option_keys[i]] = option_values[i];
+  }
+  session_options.AppendExecutionProvider(onnxruntime::kNvTensorRTRTXExecutionProvider, option_map);
+#endif
+
+  Ort::ModelCompilationOptions model_compile_options(*ort_env, session_options);
+  // with embed mode == 1 the resulting file will be over the 2GB proto limit
+  model_compile_options.SetEpContextEmbedMode(0);
+
+  void* output_context = nullptr;
+  size_t output_context_size = 0;
+  std::vector<char> input_onnx, input_data;
+  std::vector<PathString> file_names;
+  std::vector<char*> file_buffers;
+  std::vector<size_t> lengths;
+  if (test_param.bytestream_io) {
+    input_onnx = readBinaryFile(model_name);
+    input_data = readBinaryFile(external_data_name);
+    file_names = {external_data_name};
+    file_buffers = {input_data.data()};
+    lengths = {input_data.size()};
+    session_options.AddExternalInitializersFromFilesInMemory(file_names, file_buffers, lengths);
+
+    model_compile_options.SetInputModelFromBuffer(input_onnx.data(), input_onnx.size());
+    model_compile_options.SetOutputModelBuffer(Ort::AllocatorWithDefaultOptions(), &output_context, &output_context_size);
+  } else {
+    model_compile_options.SetInputModelPath(model_name.c_str());
+    model_compile_options.SetOutputModelPath(model_name_ctx.c_str());
+    model_compile_options.SetOutputModelExternalInitializersFile(model_name_ctx_data.c_str(), 1024);
+  }
+
+  // AOT time
+  ASSERT_TRUE(Ort::CompileModel(*ort_env, model_compile_options).IsOK());
+
+  // JIT time
+  std::unique_ptr<Ort::Session> session;
+  if (test_param.bytestream_io) {
+    session = std::make_unique<Ort::Session>(*ort_env, output_context, output_context_size, session_options);
+  } else {
+    session = std::make_unique<Ort::Session>(*ort_env, model_name_ctx.c_str(), session_options);
+  }
+
+  auto io_binding = generate_io_binding(*session);
+  Ort::RunOptions run_options;
+  session->Run(run_options, io_binding);
+}
+
 INSTANTIATE_TEST_SUITE_P(
     NvExecutionProviderTest, CompileApiTest,
     ::testing::Values(
@@ -125,7 +219,6 @@ INSTANTIATE_TEST_SUITE_P(
     [](const testing::TestParamInfo<CompileApiTest::ParamType>& info) {
       return info.param.to_string();
     });
-
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/nv_tensorrt_rtx/nv_ep_context_test.cc
+++ b/onnxruntime/test/providers/nv_tensorrt_rtx/nv_ep_context_test.cc
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Licensed under the MIT License.
+#include "core/common/path_utils.h"
+#include "core/graph/onnx_protobuf.h"
+#include "core/session/inference_session.h"
+#include "test/providers/provider_test_utils.h"
+#include "test/framework/test_utils.h"
+
+#include "test/util/include/scoped_env_vars.h"
+#include "test/common/trt_op_test_utils.h"
+#include "test/common/random_generator.h"
+#include "test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.h"
+
+#include <thread>
+#include <chrono>
+
+using namespace std;
+using namespace ONNX_NAMESPACE;
+using namespace ::onnxruntime::logging;
+extern std::unique_ptr<Ort::Env> ort_env;
+namespace onnxruntime {
+
+namespace test {
+
+std::vector<char> readBinaryFile(const PathString& filename) {
+  std::ifstream file(filename, std::ios::binary);
+  if (!file.is_open()) {
+    throw std::runtime_error("Could not open file: " + PathToUTF8String(filename));
+  }
+
+  file.seekg(0, std::ios::end);
+  std::streamsize filesize = file.tellg();
+  file.seekg(0, std::ios::beg);
+
+  std::vector<char> buffer(filesize);
+  if (!file.read(reinterpret_cast<char*>(buffer.data()), filesize)) {
+    throw std::runtime_error("Could not read file: " + PathToUTF8String(filename));
+  }
+
+  return buffer;
+}
+
+struct CompileParam {
+  bool embed_mode;
+  bool bytestream_io;
+  const std::string to_string() const {
+    return "embed_mode_" + std::to_string(embed_mode) + "_bytestream_io_" + std::to_string(bytestream_io);
+  }
+};
+class CompileApiTest
+    : public testing::TestWithParam<CompileParam> {
+ public:
+  const CompileParam& GetCompileParam() const {
+    return GetParam();
+  }
+};
+
+TEST_P(CompileApiTest, EmbedMode) {
+  const auto& test_param = GetCompileParam();
+  const std::string test_name = test_param.to_string();
+  PathString model_name = path_utils::MakePathString("nv_execution_provider_compile_" + test_name + ".onnx");
+  PathString model_name_ctx = path_utils::MakePathString("nv_execution_provider_compile_" + test_name + "_ctx.onnx");
+  clearFileIfExists(model_name_ctx);
+  std::string graph_name = "test";
+  std::vector<int> dims = {1, 3, 2};
+
+  CreateBaseModel(model_name, graph_name, dims, true);
+
+  Ort::SessionOptions session_options;
+#ifdef _WIN32
+  /// Since this test runs after other tests that use registration interface this test has to use it as well
+  /// windows as otherwise the kernel registry inside the EP will not be populated. The legacy APis ony call the initialize once.
+  RegisteredEpDeviceUniquePtr nv_tensorrt_rtx_ep;
+  Utils::RegisterAndGetNvTensorRtRtxEp(*ort_env, nv_tensorrt_rtx_ep);
+  const OrtEpDevice* const* ep_devices = nullptr;
+  size_t num_devices = 0;
+  ASSERT_ORTSTATUS_OK(Ort::GetApi().GetEpDevices(*ort_env, &ep_devices, &num_devices));
+  ASSERT_ORTSTATUS_OK(Ort::GetApi().SessionOptionsAppendExecutionProvider_V2(session_options, *ort_env,
+                                                                             ep_devices, 1, nullptr, nullptr, 0));
+#else
+  session_options.AppendExecutionProvider(kNvTensorRTRTXExecutionProvider, {});
+#endif
+
+  Ort::ModelCompilationOptions model_compile_options(*ort_env, session_options);
+  model_compile_options.SetEpContextEmbedMode(test_param.embed_mode);
+
+  void* output_context = nullptr;
+  size_t output_context_size = 0;
+  std::vector<char> input_onnx;
+  if (test_param.bytestream_io) {
+    input_onnx = readBinaryFile(model_name);
+    model_compile_options.SetInputModelFromBuffer(input_onnx.data(), input_onnx.size());
+    model_compile_options.SetOutputModelBuffer(Ort::AllocatorWithDefaultOptions(), &output_context, &output_context_size);
+  } else {
+    model_compile_options.SetInputModelPath(model_name.c_str());
+    model_compile_options.SetOutputModelPath(model_name_ctx.c_str());
+  }
+  // AOT time
+  auto status = Ort::CompileModel(*ort_env, model_compile_options);
+  if (!status.IsOK()) {
+    std::cerr << status.GetErrorMessage() << std::endl;
+  }
+  ASSERT_TRUE(status.IsOK());
+
+  // JIT time
+  Ort::Session session_object{nullptr};
+  if (test_param.bytestream_io) {
+    session_object = Ort::Session(*ort_env, output_context, output_context_size, session_options);
+  } else {
+    session_object = Ort::Session(*ort_env, model_name_ctx.c_str(), session_options);
+  }
+  auto io_binding = generate_io_binding(session_object);
+  Ort::RunOptions run_options;
+  session_object.Run(run_options, io_binding);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    NvExecutionProviderTest, CompileApiTest,
+    ::testing::Values(
+        CompileParam{true, false},
+        CompileParam{false, false},
+        CompileParam{true, true},
+        CompileParam{false, true}),
+    [](const testing::TestParamInfo<CompileApiTest::ParamType>& info) {
+      return info.param.to_string();
+    });
+
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.cc
+++ b/onnxruntime/test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.cc
@@ -20,6 +20,7 @@
 
 namespace onnxruntime {
 namespace test {
+#ifdef _WIN32
 
 Utils::NvTensorRtRtxEpInfo Utils::nv_tensorrt_rtx_ep_info;
 
@@ -56,6 +57,7 @@ void Utils::RegisterAndGetNvTensorRtRtxEp(Ort::Env& env, RegisteredEpDeviceUniqu
     c_api.UnregisterExecutionProviderLibrary(env, nv_tensorrt_rtx_ep_info.registration_name.c_str());
   });
 }
+#endif  // _WIN32
 
 void CreateBaseModel(const PathString& model_name,
                      std::string graph_name,

--- a/onnxruntime/test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.cc
+++ b/onnxruntime/test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.cc
@@ -12,6 +12,11 @@
 
 #include "core/session/onnxruntime_cxx_api.h"
 #include "test/util/include/api_asserts.h"
+#include "core/graph/onnx_protobuf.h"
+#include "test/util/include/scoped_env_vars.h"
+#include "test/common/trt_op_test_utils.h"
+#include "test/providers/provider_test_utils.h"
+#include "test/framework/test_utils.h"
 
 namespace onnxruntime {
 namespace test {
@@ -50,6 +55,119 @@ void Utils::RegisterAndGetNvTensorRtRtxEp(Ort::Env& env, RegisteredEpDeviceUniqu
   registered_ep = RegisteredEpDeviceUniquePtr(nv_tensorrt_rtx_ep, [&env, c_api](const OrtEpDevice* /*ep*/) {
     c_api.UnregisterExecutionProviderLibrary(env, nv_tensorrt_rtx_ep_info.registration_name.c_str());
   });
+}
+
+void CreateBaseModel(const PathString& model_name,
+                     std::string graph_name,
+                     std::vector<int> dims,
+                     bool add_fast_gelu,
+                     ONNX_NAMESPACE::TensorProto_DataType dtype) {
+  onnxruntime::Model model(graph_name, false, DefaultLoggingManager().DefaultLogger());
+  auto& graph = model.MainGraph();
+  std::vector<onnxruntime::NodeArg*> inputs;
+  std::vector<onnxruntime::NodeArg*> outputs;
+
+  // FLOAT tensor
+  ONNX_NAMESPACE::TypeProto float_tensor;
+  float_tensor.mutable_tensor_type()->set_elem_type(dtype);
+
+  for (auto dim : dims) {
+    float_tensor.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(dim);
+  }
+  ONNX_NAMESPACE::TypeProto dyn_float_tensor;
+  dyn_float_tensor.mutable_tensor_type()->set_elem_type(dtype);
+
+  auto& input_arg_1 = graph.GetOrCreateNodeArg("X", &float_tensor);
+  auto& input_arg_2 = graph.GetOrCreateNodeArg("Y", &float_tensor);
+  inputs.push_back(&input_arg_1);
+  inputs.push_back(&input_arg_2);
+  auto& output_arg = graph.GetOrCreateNodeArg("node_1_out_1", &float_tensor);
+  outputs.push_back(&output_arg);
+  graph.AddNode("node_1", "Add", "node 1.", inputs, outputs);
+
+  auto& input_arg_3 = graph.GetOrCreateNodeArg("Z", &float_tensor);
+  inputs.clear();
+  inputs.push_back(&output_arg);
+  inputs.push_back(&input_arg_3);
+
+  auto& output_arg_2 = graph.GetOrCreateNodeArg("node_2_out_1", &float_tensor);
+  outputs.clear();
+  outputs.push_back(&output_arg_2);
+  graph.AddNode("node_2", "Add", "node 2.", inputs, outputs);
+
+  inputs.clear();
+  inputs.push_back(&output_arg_2);
+
+  if (add_fast_gelu) {
+    auto& output_arg_3 = graph.GetOrCreateNodeArg("node_3_out_1", &dyn_float_tensor);
+    outputs.clear();
+    outputs.push_back(&output_arg_3);
+
+    graph.AddNode("node_3", "FastGelu", "node 3.", inputs, outputs,
+                  /* attributes */ nullptr, kMSDomain);
+
+    inputs.clear();
+    inputs.push_back(&output_arg_3);
+  }
+
+  ONNX_NAMESPACE::TypeProto float_scalar;
+  float_scalar.mutable_tensor_type()->set_elem_type(dtype);
+  float_scalar.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+  auto& input_scalar = graph.GetOrCreateNodeArg("S", &float_scalar);
+  inputs.push_back(&input_scalar);
+
+  auto& output_arg_4 = graph.GetOrCreateNodeArg("O", &dyn_float_tensor);
+
+  outputs.clear();
+  outputs.push_back(&output_arg_4);
+  graph.AddNode("node_5", "Add", "node 5.", inputs, outputs);
+
+  auto status = graph.Resolve();
+  ASSERT_TRUE(status.IsOK());
+  status = onnxruntime::Model::Save(model, model_name);
+  ASSERT_TRUE(status.IsOK());
+}
+
+Ort::IoBinding generate_io_binding(
+    Ort::Session& session,
+    std::map<std::string, std::vector<int64_t>> shape_overwrites,
+    OrtAllocator* allocator) {
+  Ort::IoBinding binding(session);
+  auto default_allocator = Ort::AllocatorWithDefaultOptions();
+  if (allocator == nullptr) {
+    allocator = default_allocator;
+  }
+  const OrtMemoryInfo* info;
+  Ort::ThrowOnError(Ort::GetApi().AllocatorGetInfo(allocator, &info));
+  Ort::MemoryInfo mem_info(info->name, info->alloc_type, info->device.Id(), info->mem_type);
+
+  for (int input_idx = 0; input_idx < int(session.GetInputCount()); ++input_idx) {
+    auto input_name = session.GetInputNameAllocated(input_idx, Ort::AllocatorWithDefaultOptions());
+    auto full_tensor_info = session.GetInputTypeInfo(input_idx);
+    auto tensor_info = full_tensor_info.GetTensorTypeAndShapeInfo();
+    auto shape = tensor_info.GetShape();
+    auto type = tensor_info.GetElementType();
+    if (shape_overwrites.find(input_name.get()) == shape_overwrites.end()) {
+      for (auto& v : shape) {
+        if (v == -1) {
+          v = 1;
+        }
+      }
+    } else {
+      shape = shape_overwrites[input_name.get()];
+    }
+    auto input_value = Ort::Value::CreateTensor(allocator,
+                                                shape.data(),
+                                                shape.size(),
+                                                type);
+    binding.BindInput(input_name.get(), input_value);
+  }
+
+  for (int output_idx = 0; output_idx < int(session.GetOutputCount()); ++output_idx) {
+    auto output_name = session.GetOutputNameAllocated(output_idx, Ort::AllocatorWithDefaultOptions());
+    binding.BindOutput(output_name.get(), mem_info);
+  }
+  return binding;
 }
 
 }  // namespace test

--- a/onnxruntime/test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.cc
+++ b/onnxruntime/test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.cc
@@ -7,10 +7,12 @@
 #include "test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.h"
 
 #include <algorithm>
+#include <random>
 #include <gtest/gtest.h>
 
 #include "core/session/onnxruntime_cxx_api.h"
 #include "test/util/include/api_asserts.h"
+#include "core/graph/basic_types.h"
 #include "core/graph/onnx_protobuf.h"
 #include "core/graph/model_saving_options.h"
 #include "test/util/include/scoped_env_vars.h"
@@ -134,6 +136,290 @@ void CreateBaseModel(const PathString& model_name,
     status = Model::Save(model, model_name);
   }
   ASSERT_TRUE(status.IsOK());
+}
+
+// Helper to create large initializers
+ONNX_NAMESPACE::TensorProto CreateLargeWeight(
+    const std::string& name,
+    ONNX_NAMESPACE::TensorProto_DataType dtype,
+    const std::vector<int64_t>& shape,
+    float scale = 0.02f) {
+  ONNX_NAMESPACE::TensorProto tensor;
+  tensor.set_name(name);
+  tensor.set_data_type(dtype);
+  for (auto d : shape) tensor.add_dims(d);
+  // Here we fill with random floats, but for real data, use your trained weights.
+  size_t total_size = 1;
+  for (int64_t d : shape) total_size *= d;
+  if (dtype == ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {
+    std::vector<float> data(total_size);
+    std::default_random_engine rng;
+    std::normal_distribution<float> dist(0.0f, scale);
+    for (auto& v : data) v = dist(rng);
+    tensor.set_raw_data(data.data(), total_size * sizeof(float));
+  } else if (dtype == ONNX_NAMESPACE::TensorProto_DataType_FLOAT16) {
+    std::vector<MLFloat16> data(total_size);
+    std::default_random_engine rng;
+    std::normal_distribution<float> dist(0.0f, scale);
+    for (auto& v : data) v = MLFloat16(dist(rng));
+    tensor.set_raw_data(data.data(), total_size * sizeof(MLFloat16));
+  } else {
+    throw std::runtime_error("Unsupported data type for large weight");
+  }
+  return tensor;
+}
+
+// Helper to add a GroupQueryAttention node
+onnxruntime::NodeArg& AddGroupQueryAttention(
+    onnxruntime::Graph& graph,
+    onnxruntime::NodeArg& query,
+    onnxruntime::NodeArg& key,
+    onnxruntime::NodeArg& value,
+    int batch_size,
+    int head_dim,
+    int seq_len,
+    int num_heads,
+    int kv_num_heads,
+    float scale,
+    ONNX_NAMESPACE::TensorProto_DataType dtype,
+    const std::string& node_name) {
+  // KV cache
+  ONNX_NAMESPACE::TypeProto key_type;
+  key_type.mutable_tensor_type()->set_elem_type(dtype);
+  key_type.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(batch_size);
+  key_type.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(kv_num_heads);
+  key_type.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(seq_len);
+  key_type.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(head_dim);
+  auto& past_key = graph.GetOrCreateNodeArg(node_name + "_past_key", &key_type);
+
+  ONNX_NAMESPACE::TypeProto value_type;
+  value_type.mutable_tensor_type()->set_elem_type(dtype);
+  value_type.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(batch_size);
+  value_type.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(kv_num_heads);
+  value_type.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(seq_len);
+  value_type.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(head_dim);
+  auto& past_value = graph.GetOrCreateNodeArg(node_name + "_past_value", &value_type);
+
+  // Output
+  auto& output = graph.GetOrCreateNodeArg(node_name + "_output", nullptr);
+
+  // Create required initializers for GroupQueryAttention
+  ONNX_NAMESPACE::TensorProto seqlens_k_tensor;
+  seqlens_k_tensor.set_name(node_name + "_seqlens_k");
+  seqlens_k_tensor.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_INT32);
+  seqlens_k_tensor.add_dims(2);
+  seqlens_k_tensor.set_dims(0, batch_size);
+  seqlens_k_tensor.set_dims(0, 1);
+  seqlens_k_tensor.add_int32_data(seq_len - 1);  // seqlens_k = total_sequence_length - 1
+  graph.AddInitializedTensor(seqlens_k_tensor);
+
+  ONNX_NAMESPACE::TensorProto total_seq_len_tensor;
+  total_seq_len_tensor.set_name(node_name + "_total_sequence_length");
+  total_seq_len_tensor.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_INT32);
+  total_seq_len_tensor.add_int32_data(seq_len);
+  graph.AddInitializedTensor(total_seq_len_tensor);
+
+  // Get the initializers that were created for this node
+  auto* seqlens_k = graph.GetNodeArg(node_name + "_seqlens_k");
+  auto* total_sequence_length = graph.GetNodeArg(node_name + "_total_sequence_length");
+
+  auto& present_value = graph.GetOrCreateNodeArg(node_name + "_present_value", nullptr);
+  auto& present_key = graph.GetOrCreateNodeArg(node_name + "_present_key", nullptr);
+
+  // Inputs - GroupQueryAttention requires at least 7 inputs (query, key, value, past_key, past_value, seqlens_k, total_sequence_length)
+  std::vector<onnxruntime::NodeArg*> inputs = {
+      &query,                 // 0: query
+      &key,                   // 1: key
+      &value,                 // 2: value
+      &past_key,              // 3: past_key (optional)
+      &past_value,            // 4: past_value (optional)
+      seqlens_k,              // 5: seqlens_k (required)
+      total_sequence_length,  // 6: total_sequence_length (required)
+                              // nullptr,                   // 7: cos_cache (optional)
+                              // nullptr,                   // 8: sin_cache (optional)
+                              // nullptr,                   // 9: position_ids (optional)
+                              // nullptr,                   // 10: attention_bias (optional)
+                              // nullptr                    // 11: head_sink (optional)
+  };
+
+  // Attributes
+  NodeAttributes attrs;
+  ONNX_NAMESPACE::AttributeProto attr_heads;
+  attr_heads.set_name("num_heads");
+  attr_heads.set_type(onnx::AttributeProto_AttributeType_INT);
+  attr_heads.set_i(num_heads);
+  attrs["num_heads"] = attr_heads;
+  ONNX_NAMESPACE::AttributeProto attr_kv_num_heads;
+  attr_kv_num_heads.set_name("kv_num_heads");
+  attr_kv_num_heads.set_type(onnx::AttributeProto_AttributeType_INT);
+  attr_kv_num_heads.set_i(kv_num_heads);
+  attrs["kv_num_heads"] = attr_kv_num_heads;
+  ONNX_NAMESPACE::AttributeProto attr_scale;
+  attr_scale.set_name("scale");
+  attr_scale.set_type(onnx::AttributeProto_AttributeType_FLOAT);
+  attr_scale.set_f(scale);
+  attrs["scale"] = attr_scale;
+
+  // Register node
+  graph.AddNode(
+      node_name,
+      "GroupQueryAttention",
+      "GroupQueryAttention Node",
+      inputs,
+      {&output, &present_key, &present_value},
+      &attrs,
+      "com.microsoft");
+
+  return output;
+}
+
+void CreateLargeLLMModel(const PathString& model_path, const PathString& external_data_path) {
+  // Model parameters (example: 24 layers, 4096 hidden dim, 32 attention heads, 8 kv heads => GQA)
+  int batch_size = 1;
+  int num_layers = 32;
+  int hidden_dim = 2048;
+  int q_num_heads = 8;
+  int kv_num_heads = 1;  // GQA: q_num_heads > kv_num_heads, and divisible.
+  int seq_length = 128;  // Short, for demonstration.
+  int vocab_size = 32000;
+  auto dtype = ONNX_NAMESPACE::TensorProto_DataType_FLOAT16;
+
+  // Set up model/graph
+  onnxruntime::Model model("LLM_With_GQA", false, DefaultLoggingManager().DefaultLogger());
+  auto& graph = model.MainGraph();
+
+  // Input
+  ONNX_NAMESPACE::TypeProto input_type;
+  input_type.mutable_tensor_type()->set_elem_type(dtype);
+  input_type.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(batch_size);
+  input_type.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(seq_length);
+  input_type.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(hidden_dim);
+  auto& input = graph.GetOrCreateNodeArg("input", &input_type);
+
+  auto* current_arg = &input;
+
+  // Repeated layers: [Attention + MLP]
+  for (int l = 0; l < num_layers; ++l) {
+    // KV cache - initialize with zeros for the first forward pass
+    int head_dim = hidden_dim / q_num_heads;
+
+    // Split Q, K, V
+    auto& q_split = graph.GetOrCreateNodeArg("q_split_" + std::to_string(l), nullptr);
+    auto& k_split = graph.GetOrCreateNodeArg("k_split_" + std::to_string(l), nullptr);
+    auto& v_split = graph.GetOrCreateNodeArg("v_split_" + std::to_string(l), nullptr);
+    constexpr bool split = false;
+    if constexpr (split) {
+      // Attention weights (Q, K, V projections)
+      auto wqkv = CreateLargeWeight("wqkv_" + std::to_string(l),
+                                    dtype, {hidden_dim, hidden_dim * 3});
+      graph.AddInitializedTensor(wqkv);
+
+      // Q = input @ wq, K = input @ wk, V = input @ wv
+      auto& qkv_arg = graph.GetOrCreateNodeArg("qkv_" + std::to_string(l), nullptr);
+      graph.AddNode("QKV_Linear_" + std::to_string(l), "MatMul", "", {current_arg, graph.GetNodeArg(wqkv.name())}, {&qkv_arg});
+
+      NodeAttributes attrs_split;
+      ONNX_NAMESPACE::AttributeProto attr_split_axis;
+      attr_split_axis.set_name("axis");
+      attr_split_axis.set_type(onnx::AttributeProto_AttributeType_INT);
+      attr_split_axis.set_i(-1);
+      attrs_split["axis"] = attr_split_axis;
+      ONNX_NAMESPACE::AttributeProto attr_split_num_outputs;
+      attr_split_num_outputs.set_name("num_outputs");
+      attr_split_num_outputs.set_type(onnx::AttributeProto_AttributeType_INT);
+      attr_split_num_outputs.set_i(3);
+      attrs_split["num_outputs"] = attr_split_num_outputs;
+      graph.AddNode("Q_Split_" + std::to_string(l), "Split", "", {&qkv_arg}, {&q_split, &k_split, &v_split}, &attrs_split);
+    } else {
+      // Attention weights (Q, K, V projections)
+      auto wq = CreateLargeWeight("wq_" + std::to_string(l),
+                                  dtype, {hidden_dim, hidden_dim});
+      graph.AddInitializedTensor(wq);
+      auto wk = CreateLargeWeight("wk_" + std::to_string(l),
+                                  dtype, {hidden_dim, head_dim * kv_num_heads});
+      graph.AddInitializedTensor(wk);
+      auto wv = CreateLargeWeight("wv_" + std::to_string(l),
+                                  dtype, {hidden_dim, head_dim * kv_num_heads});
+      graph.AddInitializedTensor(wv);
+
+      // Q = input @ wq, K = input @ wk, V = input @ wv
+      graph.AddNode("Q_Linear_" + std::to_string(l), "MatMul", "", {current_arg, graph.GetNodeArg(wq.name())}, {&q_split});
+      graph.AddNode("K_Linear_" + std::to_string(l), "MatMul", "", {current_arg, graph.GetNodeArg(wk.name())}, {&k_split});
+      graph.AddNode("V_Linear_" + std::to_string(l), "MatMul", "", {current_arg, graph.GetNodeArg(wv.name())}, {&v_split});
+    }
+    // Reshape Q, K, V
+    auto& q_reshaped = graph.GetOrCreateNodeArg("q_reshaped_" + std::to_string(l), nullptr);
+    auto& k_reshaped = graph.GetOrCreateNodeArg("k_reshaped_" + std::to_string(l), nullptr);
+    auto& v_reshaped = graph.GetOrCreateNodeArg("v_reshaped_" + std::to_string(l), nullptr);
+
+    ONNX_NAMESPACE::TensorProto q_shape_tensor;
+    q_shape_tensor.set_name("q_shape_" + std::to_string(l));
+    q_shape_tensor.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_INT64);
+    q_shape_tensor.add_dims(3);
+    q_shape_tensor.add_int64_data(batch_size);
+    q_shape_tensor.add_int64_data(seq_length);
+    q_shape_tensor.add_int64_data(head_dim * q_num_heads);
+    graph.AddInitializedTensor(q_shape_tensor);
+
+    ONNX_NAMESPACE::TensorProto k_shape_tensor;
+    k_shape_tensor.set_name("k_shape_" + std::to_string(l));
+    k_shape_tensor.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_INT64);
+    k_shape_tensor.add_dims(3);
+    k_shape_tensor.add_int64_data(batch_size);
+    k_shape_tensor.add_int64_data(seq_length);
+    k_shape_tensor.add_int64_data(head_dim * kv_num_heads);
+    graph.AddInitializedTensor(k_shape_tensor);
+
+    ONNX_NAMESPACE::TensorProto v_shape_tensor;
+    v_shape_tensor.set_name("v_shape_" + std::to_string(l));
+    v_shape_tensor.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_INT64);
+    v_shape_tensor.add_dims(3);
+    v_shape_tensor.add_int64_data(batch_size);
+    v_shape_tensor.add_int64_data(seq_length);
+    v_shape_tensor.add_int64_data(head_dim * kv_num_heads);
+    graph.AddInitializedTensor(v_shape_tensor);
+
+    graph.AddNode("Q_Reshape_" + std::to_string(l), "Reshape", "", {&q_split, graph.GetNodeArg(q_shape_tensor.name())}, {&q_reshaped});
+    graph.AddNode("K_Reshape_" + std::to_string(l), "Reshape", "", {&k_split, graph.GetNodeArg(k_shape_tensor.name())}, {&k_reshaped});
+    graph.AddNode("V_Reshape_" + std::to_string(l), "Reshape", "", {&v_split, graph.GetNodeArg(v_shape_tensor.name())}, {&v_reshaped});
+
+    // Replace standard attention with GQA
+    auto& attn_out = AddGroupQueryAttention(
+        graph, q_reshaped, k_reshaped, v_reshaped,
+        batch_size, head_dim, seq_length, q_num_heads, kv_num_heads,
+        1.0f, dtype,
+        "GQA_" + std::to_string(l));
+
+    // Add an MLP block: (Linear + Activation + Linear)
+    auto w1 = CreateLargeWeight("mlp_w1_" + std::to_string(l), dtype, {hidden_dim, hidden_dim * 4});
+    auto w2 = CreateLargeWeight("mlp_w2_" + std::to_string(l), dtype, {hidden_dim * 4, hidden_dim});
+    graph.AddInitializedTensor(w1);
+    graph.AddInitializedTensor(w2);
+
+    auto& mlp_hidden = graph.GetOrCreateNodeArg("mlp_hidden_" + std::to_string(l), nullptr);
+    graph.AddNode("MLP_1_" + std::to_string(l), "MatMul", "", {&attn_out, graph.GetNodeArg(w1.name())}, {&mlp_hidden});
+    auto& relu_out = graph.GetOrCreateNodeArg("relu_" + std::to_string(l), nullptr);
+    graph.AddNode("Relu_" + std::to_string(l), "Relu", "", {&mlp_hidden}, {&relu_out});
+    auto& mlp_out = graph.GetOrCreateNodeArg("mlp_out_" + std::to_string(l), nullptr);
+    graph.AddNode("MLP_2_" + std::to_string(l), "MatMul", "", {&relu_out, graph.GetNodeArg(w2.name())}, {&mlp_out});
+    current_arg = &mlp_out;  // For next layer.
+  }
+
+  // Final projection to vocab
+  auto w_logits = CreateLargeWeight("w_logits",
+                                    dtype, {hidden_dim, vocab_size});
+  graph.AddInitializedTensor(w_logits);
+  auto& output = graph.GetOrCreateNodeArg("logits", nullptr);
+  graph.AddNode("Output_Linear", "MatMul", "", {current_arg, graph.GetNodeArg(w_logits.name())}, {&output});
+
+  // Validate, Write as large model with external data
+  auto status = graph.Resolve();
+  if (!status.IsOK()) throw std::runtime_error(status.ErrorMessage());
+
+  onnxruntime::ModelSavingOptions save_options(128);
+  status = onnxruntime::Model::SaveWithExternalInitializers(
+      model, model_path, external_data_path, save_options);
+  if (!status.IsOK()) throw std::runtime_error(status.ErrorMessage());
 }
 
 Ort::IoBinding generate_io_binding(

--- a/onnxruntime/test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.cc
+++ b/onnxruntime/test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.cc
@@ -151,15 +151,15 @@ ONNX_NAMESPACE::TensorProto CreateLargeWeight(
   // Here we fill with random floats, but for real data, use your trained weights.
   size_t total_size = 1;
   for (int64_t d : shape) total_size *= d;
+  std::random_device rd;
+  std::default_random_engine rng(rd());
   if (dtype == ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {
     std::vector<float> data(total_size);
-    std::default_random_engine rng;
     std::normal_distribution<float> dist(0.0f, scale);
     for (auto& v : data) v = dist(rng);
     tensor.set_raw_data(data.data(), total_size * sizeof(float));
   } else if (dtype == ONNX_NAMESPACE::TensorProto_DataType_FLOAT16) {
     std::vector<MLFloat16> data(total_size);
-    std::default_random_engine rng;
     std::normal_distribution<float> dist(0.0f, scale);
     for (auto& v : data) v = MLFloat16(dist(rng));
     tensor.set_raw_data(data.data(), total_size * sizeof(MLFloat16));

--- a/onnxruntime/test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.h
+++ b/onnxruntime/test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.h
@@ -29,7 +29,7 @@ using RegisteredEpDeviceUniquePtr = std::unique_ptr<const OrtEpDevice, std::func
 struct Utils {
   struct NvTensorRtRtxEpInfo {
     const std::filesystem::path library_path =
-#if _WIN32
+#ifdef _WIN32
         "onnxruntime_providers_nv_tensorrt_rtx.dll";
 #else
         "libonnxruntime_providers_nv_tensorrt_rtx.so";
@@ -48,7 +48,7 @@ struct Utils {
 };
 
 [[maybe_unused]] static std::string PathToUTF8(const PathString& path) {
-#ifdef WIN32
+#ifdef _WIN32
   std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
   return converter.to_bytes(path);
 #else

--- a/onnxruntime/test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.h
+++ b/onnxruntime/test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.h
@@ -13,6 +13,7 @@
 #include <onnxruntime_ep_device_ep_metadata_keys.h>
 #include <onnxruntime_run_options_config_keys.h>
 #include <onnxruntime_session_options_config_keys.h>
+#include <core/providers/nv_tensorrt_rtx/nv_provider_options.h>
 
 #include "core/graph/constants.h"
 #include "core/common/path_string.h"
@@ -63,7 +64,7 @@ struct Utils {
 
 template <typename T>
 static void VerifyOutputs(const std::vector<OrtValue>& fetches, const std::vector<int64_t>& expected_dims,
-                   const std::vector<T>& expected_values) {
+                          const std::vector<T>& expected_values) {
   ASSERT_EQ(1, fetches.size());
   auto& rtensor = fetches.front().Get<Tensor>();
   TensorShape expected_shape(expected_dims);
@@ -78,6 +79,7 @@ static void VerifyOutputs(const std::vector<OrtValue>& fetches, const std::vecto
  * \param graph_name - graph name
  * \param dims - input dimensions
  * \param add_fast_gelu - add FastGelu node which makes the whole model partition into TRT EP and CUDA EP subgraphs.
+ * \param external_initializer_file - file name to save external initializers to
  *
  * input: "X", "Y" and "Z"
  *        you can specify input dimensions, for example (1, 3, 2), (1, 2) or (1, -1, -1)). Note: -1 means the dimension is dynamic.
@@ -112,7 +114,8 @@ void CreateBaseModel(const PathString& model_name,
                      std::string graph_name,
                      std::vector<int> dims,
                      bool add_fast_gelu = false,
-                     ONNX_NAMESPACE::TensorProto_DataType dtype = ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+                     ONNX_NAMESPACE::TensorProto_DataType dtype = ONNX_NAMESPACE::TensorProto_DataType_FLOAT,
+                     const PathString& external_initializer_file = {});
 
 Ort::IoBinding generate_io_binding(
     Ort::Session& session,

--- a/onnxruntime/test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.h
+++ b/onnxruntime/test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.h
@@ -5,9 +5,19 @@
 
 #include <filesystem>
 #include <string>
+#include <map>
+#include <codecvt>
 
-#include "core/session/onnxruntime_cxx_api.h"
+#include <gtest/gtest.h>
+#include <onnxruntime_cxx_api.h>
+#include <onnxruntime_ep_device_ep_metadata_keys.h>
+#include <onnxruntime_run_options_config_keys.h>
+#include <onnxruntime_session_options_config_keys.h>
+
 #include "core/graph/constants.h"
+#include "core/common/path_string.h"
+#include "core/framework/tensor.h"
+#include "test/util/include/api_asserts.h"
 
 namespace onnxruntime {
 namespace test {
@@ -34,5 +44,79 @@ struct Utils {
   // automatically unregister the EP library.
   static void RegisterAndGetNvTensorRtRtxEp(Ort::Env& env, RegisteredEpDeviceUniquePtr& nv_tensorrt_rtx_ep);
 };
+
+static std::string PathToUTF8(const PathString& path) {
+#ifdef WIN32
+  std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
+  return converter.to_bytes(path);
+#else
+  return path.c_str();
+#endif
+}
+
+static void clearFileIfExists(PathString path) {
+  if (std::filesystem::exists(path)) {
+    std::filesystem::remove(path);
+  }
+}
+
+template <typename T>
+static void VerifyOutputs(const std::vector<OrtValue>& fetches, const std::vector<int64_t>& expected_dims,
+                   const std::vector<T>& expected_values) {
+  ASSERT_EQ(1, fetches.size());
+  auto& rtensor = fetches.front().Get<Tensor>();
+  TensorShape expected_shape(expected_dims);
+  ASSERT_EQ(expected_shape, rtensor.Shape());
+  const std::vector<T> found(rtensor.Data<T>(), rtensor.Data<T>() + expected_values.size());
+  ASSERT_EQ(expected_values, found);
+}
+
+/**
+ * Create a simple model with dynamic or non-dynamic input shape.
+ * \param model_name - model name
+ * \param graph_name - graph name
+ * \param dims - input dimensions
+ * \param add_fast_gelu - add FastGelu node which makes the whole model partition into TRT EP and CUDA EP subgraphs.
+ *
+ * input: "X", "Y" and "Z"
+ *        you can specify input dimensions, for example (1, 3, 2), (1, 2) or (1, -1, -1)). Note: -1 means the dimension is dynamic.
+ *        All three inputs have the same dimensions.
+ * output: "M"
+ *
+ *      "X"  "Y"
+ *        \  /
+ *    "Z"  Add
+ *      \  /
+ *       Add
+ *       /
+ *       Add (+ float scalar "S")
+ *       /
+ *     "O"
+ *
+ *     or
+ *
+ *      "X"  "Y"
+ *        \  /
+ *    "Z"  Add
+ *      \  /
+ *       Add
+ *       /
+ *    FastGelu (This node will be placed on CUDA EP)
+ *     /
+ *     *       Add (+ float scalar "S")
+ *    /
+ *   "O"
+ */
+void CreateBaseModel(const PathString& model_name,
+                     std::string graph_name,
+                     std::vector<int> dims,
+                     bool add_fast_gelu = false,
+                     ONNX_NAMESPACE::TensorProto_DataType dtype = ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+
+Ort::IoBinding generate_io_binding(
+    Ort::Session& session,
+    std::map<std::string, std::vector<int64_t>> shape_overwrites = {},
+    OrtAllocator* allocator = nullptr);
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.h
+++ b/onnxruntime/test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.h
@@ -117,6 +117,8 @@ void CreateBaseModel(const PathString& model_name,
                      ONNX_NAMESPACE::TensorProto_DataType dtype = ONNX_NAMESPACE::TensorProto_DataType_FLOAT,
                      const PathString& external_initializer_file = {});
 
+void CreateLargeLLMModel(const PathString& model_path, const PathString& external_data_path);
+
 Ort::IoBinding generate_io_binding(
     Ort::Session& session,
     std::map<std::string, std::vector<int64_t>> shape_overwrites = {},

--- a/onnxruntime/test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.h
+++ b/onnxruntime/test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.h
@@ -17,6 +17,7 @@
 #include "core/graph/constants.h"
 #include "core/common/path_string.h"
 #include "core/framework/tensor.h"
+#include "core/framework/ort_value.h"
 #include "test/util/include/api_asserts.h"
 
 namespace onnxruntime {
@@ -45,7 +46,7 @@ struct Utils {
   static void RegisterAndGetNvTensorRtRtxEp(Ort::Env& env, RegisteredEpDeviceUniquePtr& nv_tensorrt_rtx_ep);
 };
 
-static std::string PathToUTF8(const PathString& path) {
+[[maybe_unused]] static std::string PathToUTF8(const PathString& path) {
 #ifdef WIN32
   std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
   return converter.to_bytes(path);
@@ -54,7 +55,7 @@ static std::string PathToUTF8(const PathString& path) {
 #endif
 }
 
-static void clearFileIfExists(PathString path) {
+[[maybe_unused]] static void clearFileIfExists(PathString path) {
   if (std::filesystem::exists(path)) {
     std::filesystem::remove(path);
   }

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1708,8 +1708,10 @@ def run_onnxruntime_tests(args, source_dir, ctest_path, build_dir, configs):
             run_ios_tests(args, source_dir, config, cwd)
             continue
         dll_path_list = []
-        if args.use_tensorrt or args.use_nv_tensorrt_rtx:
+        if args.use_tensorrt:
             dll_path_list.append(os.path.join(args.tensorrt_home, "lib"))
+        if args.use_nv_tensorrt_rtx:
+            dll_path_list.append(os.path.join(args.tensorrt_rtx_home, "lib"))
 
         dll_path = None
         if len(dll_path_list) > 0:


### PR DESCRIPTION
* Implements `GetEPContextNodes()`
* Enables usage of `AddExternalInitializersFromFilesInMemory` for models that have to be communicated as byte stream but are larger than 2GB
* Add EP context unit tests for file, bytestreams and both embed modes

NOTE: For large models > 2GB, `embed_mode=0` must be used. `embed_mode=1` fails due to protobuf limitations