### PR TITLE
Update mac.yml iphone_simulator job to use Xcode version 16.4.

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: macos-15
 
     env:
-      xcode_version: 16
+      xcode_version: 16.4
 
     strategy:
       matrix:


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Update mac.yml iphone_simulator job to use Xcode version 16.4.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix CI build failure.

Following the recommendation here: https://github.com/actions/runner-images/issues/12758#issuecomment-3187480561
