### PR TITLE
[EP ABI] support `Graph_GetModelMetadata`

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -5644,14 +5644,21 @@ struct OrtApi {
    */
   ORT_API2_STATUS(Graph_GetName, _In_ const OrtGraph* graph, _Outptr_ const char** graph_name);
 
-  /** \brief Get the filepath to the model from which an OrtGraph is constructed.
+  /** \brief Get ::OrtModelMetadata from an ::OrtGraph
    *
-   * \note The model's filepath is empty if the filepath is unknown, such as when the model is loaded from bytes
-   * via CreateSessionFromArray.
+   * \param[in] graph
+   * \param[out] out Newly created ::OrtModelMetadata. Must be freed using OrtApi::ReleaseModelMetadata
+   *
+   * \snippet{doc} snippets.dox OrtStatus Return Value
+   *
+   * \since Version 1.23.
+   */
+  ORT_API2_STATUS(Graph_GetModelMetadata, _In_ const OrtGraph* graph, _Outptr_ OrtModelMetadata** out);
+
+  /** \brief Returns the ONNX IR version.
    *
    * \param[in] graph The OrtGraph instance.
-   * \param[out] model_path Output parameter set to the model's null-terminated filepath.
-   *                        Set to an empty path string if unknown.
+   * \param[out] onnx_ir_version Output parameter set to the ONNX IR version.
    *
    * \snippet{doc} snippets.dox OrtStatus Return Value
    *

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -5644,17 +5644,6 @@ struct OrtApi {
    */
   ORT_API2_STATUS(Graph_GetName, _In_ const OrtGraph* graph, _Outptr_ const char** graph_name);
 
-  /** \brief Get ::OrtModelMetadata from an ::OrtGraph
-   *
-   * \param[in] graph
-   * \param[out] out Newly created ::OrtModelMetadata. Must be freed using OrtApi::ReleaseModelMetadata
-   *
-   * \snippet{doc} snippets.dox OrtStatus Return Value
-   *
-   * \since Version 1.23.
-   */
-  ORT_API2_STATUS(Graph_GetModelMetadata, _In_ const OrtGraph* graph, _Outptr_ OrtModelMetadata** out);
-
   /** \brief Returns the ONNX IR version.
    *
    * \param[in] graph The OrtGraph instance.
@@ -6476,6 +6465,17 @@ struct OrtApi {
                   _In_reads_(num_tensors) OrtValue* const* dst_tensors,
                   _In_opt_ OrtSyncStream* stream,
                   _In_ size_t num_tensors);
+
+  /** \brief Get ::OrtModelMetadata from an ::OrtGraph
+   *
+   * \param[in] graph
+   * \param[out] out Newly created ::OrtModelMetadata. Must be freed using OrtApi::ReleaseModelMetadata
+   *
+   * \snippet{doc} snippets.dox OrtStatus Return Value
+   *
+   * \since Version 1.23.
+   */
+  ORT_API2_STATUS(Graph_GetModelMetadata, _In_ const OrtGraph* graph, _Outptr_ OrtModelMetadata** out);
 };
 
 /*

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -5644,10 +5644,14 @@ struct OrtApi {
    */
   ORT_API2_STATUS(Graph_GetName, _In_ const OrtGraph* graph, _Outptr_ const char** graph_name);
 
-  /** \brief Returns the ONNX IR version.
+  /** \brief Get the filepath to the model from which an OrtGraph is constructed.
+   *
+   * \note The model's filepath is empty if the filepath is unknown, such as when the model is loaded from bytes
+   * via CreateSessionFromArray.
    *
    * \param[in] graph The OrtGraph instance.
-   * \param[out] onnx_ir_version Output parameter set to the ONNX IR version.
+   * \param[out] model_path Output parameter set to the model's null-terminated filepath.
+   *                        Set to an empty path string if unknown.
    *
    * \snippet{doc} snippets.dox OrtStatus Return Value
    *
@@ -6468,8 +6472,8 @@ struct OrtApi {
 
   /** \brief Get ::OrtModelMetadata from an ::OrtGraph
    *
-   * \param[in] graph
-   * \param[out] out Newly created ::OrtModelMetadata. Must be freed using OrtApi::ReleaseModelMetadata
+   * \param[in] graph The OrtGraph instance.
+   * \param[out] out Newly created ::OrtModelMetadata. Must be freed using OrtApi::ReleaseModelMetadata.
    *
    * \snippet{doc} snippets.dox OrtStatus Return Value
    *

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -2834,6 +2834,7 @@ struct GraphImpl : Ort::detail::Base<T> {
   void SetOutputs(std::vector<ValueInfo>& outputs);
   void AddInitializer(const std::string& name, Value& initializer, bool data_is_external);  // Graph takes ownership of Value
   void AddNode(Node& node);                                                                 // Graph takes ownership of Node
+  ModelMetadata GetModelMetadata() const;                                                   ///< Wraps OrtApi::Graph_GetModelMetadata
 #endif                                                                                      // !defined(ORT_MINIMAL_BUILD)
 };
 }  // namespace detail
@@ -2848,6 +2849,7 @@ struct Graph : detail::GraphImpl<OrtGraph> {
   Graph();
 #endif
 };
+using ConstGraph = detail::GraphImpl<Ort::detail::Unowned<const OrtGraph>>;
 
 namespace detail {
 template <typename T>

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -2798,6 +2798,13 @@ inline void GraphImpl<OrtGraph>::AddNode(Node& node) {
   ThrowOnError(GetModelEditorApi().AddNodeToGraph(p_, node.release()));
 }
 
+template <typename T>
+inline ModelMetadata GraphImpl<T>::GetModelMetadata() const {
+  OrtModelMetadata* out;
+  ThrowOnError(GetApi().Graph_GetModelMetadata(this->p_, &out));
+  return ModelMetadata{out};
+}
+
 template <>
 inline void ModelImpl<OrtModel>::AddGraph(Graph& graph) {
   // Model takes ownership of `graph`

--- a/onnxruntime/core/graph/abi_graph_types.h
+++ b/onnxruntime/core/graph/abi_graph_types.h
@@ -11,6 +11,7 @@
 #include "core/framework/onnxruntime_typeinfo.h"
 #include "core/graph/onnx_protobuf.h"
 #include "core/session/inference_session.h"
+
 #define DEFINE_ORT_GRAPH_IR_TO_EXTERNAL_INTERNAL_FUNCS(external_type, internal_type, internal_api) \
   external_type* ToExternal() { return static_cast<external_type*>(this); }                        \
   const external_type* ToExternal() const { return static_cast<const external_type*>(this); }      \

--- a/onnxruntime/core/graph/abi_graph_types.h
+++ b/onnxruntime/core/graph/abi_graph_types.h
@@ -302,6 +302,11 @@ struct OrtGraph {
   virtual const std::string& GetName() const = 0;
 
   /// <summary>
+  /// Returns the model's metadata.
+  /// </summary>
+  /// <returns>The model metadata.</returns>
+  virtual OrtModelMetadata* GetModelMetadata() const = 0;
+  /// <summary>
   /// Returns the model's path, which is empty if unknown.
   /// </summary>
   /// <returns>The model path.</returns>

--- a/onnxruntime/core/graph/abi_graph_types.h
+++ b/onnxruntime/core/graph/abi_graph_types.h
@@ -10,7 +10,7 @@
 #include "core/framework/tensor_external_data_info.h"
 #include "core/framework/onnxruntime_typeinfo.h"
 #include "core/graph/onnx_protobuf.h"
-
+#include "core/session/inference_session.h"
 #define DEFINE_ORT_GRAPH_IR_TO_EXTERNAL_INTERNAL_FUNCS(external_type, internal_type, internal_api) \
   external_type* ToExternal() { return static_cast<external_type*>(this); }                        \
   const external_type* ToExternal() const { return static_cast<const external_type*>(this); }      \
@@ -305,7 +305,7 @@ struct OrtGraph {
   /// Returns the model's metadata.
   /// </summary>
   /// <returns>The model metadata.</returns>
-  virtual OrtModelMetadata* GetModelMetadata() const = 0;
+  virtual std::unique_ptr<onnxruntime::ModelMetadata> GetModelMetadata() const = 0;
   /// <summary>
   /// Returns the model's path, which is empty if unknown.
   /// </summary>

--- a/onnxruntime/core/graph/ep_api_types.cc
+++ b/onnxruntime/core/graph/ep_api_types.cc
@@ -20,6 +20,8 @@
 #include "core/framework/onnxruntime_typeinfo.h"
 #include "core/graph/graph_viewer.h"
 #include "core/graph/graph.h"
+#include "core/graph/model.h"
+#include "core/session/inference_session.h"
 
 namespace onnxruntime {
 
@@ -768,6 +770,23 @@ Status EpGraph::CreateImpl(std::unique_ptr<EpGraph> ep_graph, const GraphViewer&
 }
 
 const std::string& EpGraph::GetName() const { return graph_viewer_.Name(); }
+
+OrtModelMetadata* EpGraph::GetModelMetadata() const {
+  const auto& model = graph_viewer_.GetGraph().GetModel();
+  const auto& graph = graph_viewer_.GetGraph();
+  auto model_metadata = std::make_unique<ModelMetadata>();
+
+  model_metadata->producer_name = model.ProducerName();
+  model_metadata->producer_version = model.ProducerVersion();
+  model_metadata->description = model.DocString();
+  model_metadata->graph_description = model.GraphDocString();
+  model_metadata->domain = model.Domain();
+  model_metadata->version = model.ModelVersion();
+  model_metadata->custom_metadata_map = model.MetaData();
+  model_metadata->graph_name = graph.Name();
+
+  return reinterpret_cast<OrtModelMetadata*>(model_metadata.release());
+}
 
 const ORTCHAR_T* EpGraph::GetModelPath() const {
   return graph_viewer_.ModelPath().c_str();

--- a/onnxruntime/core/graph/ep_api_types.cc
+++ b/onnxruntime/core/graph/ep_api_types.cc
@@ -21,7 +21,6 @@
 #include "core/graph/graph_viewer.h"
 #include "core/graph/graph.h"
 #include "core/graph/model.h"
-#include "core/session/inference_session.h"
 
 namespace onnxruntime {
 
@@ -771,7 +770,7 @@ Status EpGraph::CreateImpl(std::unique_ptr<EpGraph> ep_graph, const GraphViewer&
 
 const std::string& EpGraph::GetName() const { return graph_viewer_.Name(); }
 
-OrtModelMetadata* EpGraph::GetModelMetadata() const {
+std::unique_ptr<ModelMetadata> EpGraph::GetModelMetadata() const {
   const auto& model = graph_viewer_.GetGraph().GetModel();
   const auto& graph = graph_viewer_.GetGraph();
   auto model_metadata = std::make_unique<ModelMetadata>();
@@ -785,7 +784,7 @@ OrtModelMetadata* EpGraph::GetModelMetadata() const {
   model_metadata->custom_metadata_map = model.MetaData();
   model_metadata->graph_name = graph.Name();
 
-  return reinterpret_cast<OrtModelMetadata*>(model_metadata.release());
+  return model_metadata;
 }
 
 const ORTCHAR_T* EpGraph::GetModelPath() const {

--- a/onnxruntime/core/graph/ep_api_types.cc
+++ b/onnxruntime/core/graph/ep_api_types.cc
@@ -785,8 +785,8 @@ std::unique_ptr<ModelMetadata> EpGraph::GetModelMetadata() const {
   model_metadata->graph_name = model.MainGraph().Name();
   return model_metadata;
 #else
-  return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED,
-                         "Getting the model metadata is not supported in this build");
+  ORT_NOT_IMPLEMENTED("Getting the model metadata is not supported in this build");
+  return nullptr;
 #endif
 }
 

--- a/onnxruntime/core/graph/ep_api_types.cc
+++ b/onnxruntime/core/graph/ep_api_types.cc
@@ -785,7 +785,6 @@ std::unique_ptr<ModelMetadata> EpGraph::GetModelMetadata() const {
   model_metadata->graph_name = model.MainGraph().Name();
   return model_metadata;
 #else
-  ORT_NOT_IMPLEMENTED("Getting the model metadata is not supported in this build");
   return nullptr;
 #endif
 }

--- a/onnxruntime/core/graph/ep_api_types.cc
+++ b/onnxruntime/core/graph/ep_api_types.cc
@@ -771,6 +771,7 @@ Status EpGraph::CreateImpl(std::unique_ptr<EpGraph> ep_graph, const GraphViewer&
 const std::string& EpGraph::GetName() const { return graph_viewer_.Name(); }
 
 std::unique_ptr<ModelMetadata> EpGraph::GetModelMetadata() const {
+#if !defined(ORT_MINIMAL_BUILD)
   const auto& model = graph_viewer_.GetGraph().GetModel();
   auto model_metadata = std::make_unique<ModelMetadata>();
 
@@ -782,8 +783,11 @@ std::unique_ptr<ModelMetadata> EpGraph::GetModelMetadata() const {
   model_metadata->version = model.ModelVersion();
   model_metadata->custom_metadata_map = model.MetaData();
   model_metadata->graph_name = model.MainGraph().Name();
-
   return model_metadata;
+#else
+  return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED,
+                         "Getting the model metadata is not supported in this build");
+#endif
 }
 
 const ORTCHAR_T* EpGraph::GetModelPath() const {

--- a/onnxruntime/core/graph/ep_api_types.cc
+++ b/onnxruntime/core/graph/ep_api_types.cc
@@ -772,7 +772,6 @@ const std::string& EpGraph::GetName() const { return graph_viewer_.Name(); }
 
 std::unique_ptr<ModelMetadata> EpGraph::GetModelMetadata() const {
   const auto& model = graph_viewer_.GetGraph().GetModel();
-  const auto& graph = graph_viewer_.GetGraph();
   auto model_metadata = std::make_unique<ModelMetadata>();
 
   model_metadata->producer_name = model.ProducerName();
@@ -782,7 +781,7 @@ std::unique_ptr<ModelMetadata> EpGraph::GetModelMetadata() const {
   model_metadata->domain = model.Domain();
   model_metadata->version = model.ModelVersion();
   model_metadata->custom_metadata_map = model.MetaData();
-  model_metadata->graph_name = graph.Name();
+  model_metadata->graph_name = model.MainGraph().Name();
 
   return model_metadata;
 }

--- a/onnxruntime/core/graph/ep_api_types.h
+++ b/onnxruntime/core/graph/ep_api_types.h
@@ -298,6 +298,9 @@ struct EpGraph : public OrtGraph {
   // Returns the graph's name.
   const std::string& GetName() const override;
 
+  // Returns the graph's metadata
+  OrtModelMetadata* GetModelMetadata() const override;
+
   // Returns the model path.
   const ORTCHAR_T* GetModelPath() const override;
 

--- a/onnxruntime/core/graph/ep_api_types.h
+++ b/onnxruntime/core/graph/ep_api_types.h
@@ -299,7 +299,7 @@ struct EpGraph : public OrtGraph {
   const std::string& GetName() const override;
 
   // Returns the graph's metadata
-  OrtModelMetadata* GetModelMetadata() const override;
+  std::unique_ptr<ModelMetadata> GetModelMetadata() const override;
 
   // Returns the model path.
   const ORTCHAR_T* GetModelPath() const override;

--- a/onnxruntime/core/graph/model_editor_api_types.h
+++ b/onnxruntime/core/graph/model_editor_api_types.h
@@ -14,6 +14,7 @@
 #include "core/graph/abi_graph_types.h"
 #include "core/graph/onnx_protobuf.h"
 #include "core/session/inference_session.h"
+
 namespace onnxruntime {
 
 /// <summary>

--- a/onnxruntime/core/graph/model_editor_api_types.h
+++ b/onnxruntime/core/graph/model_editor_api_types.h
@@ -184,8 +184,8 @@ struct ModelEditorGraph : public OrtGraph {
 
   const std::string& GetName() const override { return name; }
 
-  OrtModelMetadata* GetModelMetadata() const override {
-    return reinterpret_cast<OrtModelMetadata*>(std::make_unique<ModelMetadata>(model_metadata).release());
+  std::unique_ptr<ModelMetadata> GetModelMetadata() const override {
+    return std::make_unique<ModelMetadata>(model_metadata);
   }
   const ORTCHAR_T* GetModelPath() const override { return model_path.c_str(); }
 

--- a/onnxruntime/core/graph/model_editor_api_types.h
+++ b/onnxruntime/core/graph/model_editor_api_types.h
@@ -13,7 +13,7 @@
 #include "core/framework/ort_value.h"
 #include "core/graph/abi_graph_types.h"
 #include "core/graph/onnx_protobuf.h"
-
+#include "core/session/inference_session.h"
 namespace onnxruntime {
 
 /// <summary>
@@ -184,6 +184,9 @@ struct ModelEditorGraph : public OrtGraph {
 
   const std::string& GetName() const override { return name; }
 
+  OrtModelMetadata* GetModelMetadata() const override {
+    return reinterpret_cast<OrtModelMetadata*>(std::make_unique<ModelMetadata>(model_metadata).release());
+  }
   const ORTCHAR_T* GetModelPath() const override { return model_path.c_str(); }
 
   int64_t GetOnnxIRVersion() const override {
@@ -241,6 +244,7 @@ struct ModelEditorGraph : public OrtGraph {
   std::vector<std::unique_ptr<onnxruntime::ModelEditorNode>> nodes;
   std::string name = "ModelEditorGraph";
   std::filesystem::path model_path;
+  ModelMetadata model_metadata;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2626,6 +2626,17 @@ ORT_API_STATUS_IMPL(OrtApis::Graph_GetName, _In_ const OrtGraph* graph, _Outptr_
   API_IMPL_END
 }
 
+ORT_API_STATUS_IMPL(OrtApis::Graph_GetModelMetadata, _In_ const OrtGraph* graph, _Outptr_ OrtModelMetadata** out) {
+  API_IMPL_BEGIN
+  if (out == nullptr) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "'out' argument is NULL");
+  }
+  *out = graph->GetModelMetadata();
+  //
+  return nullptr;
+  API_IMPL_END
+}
+
 ORT_API_STATUS_IMPL(OrtApis::Graph_GetModelPath, _In_ const OrtGraph* graph, _Outptr_ const ORTCHAR_T** model_path) {
   API_IMPL_BEGIN
   if (model_path == nullptr) {
@@ -4034,6 +4045,7 @@ static constexpr OrtApi ort_api_1_to_23 = {
     &OrtApis::ValueInfo_IsConstantInitializer,
     &OrtApis::ValueInfo_IsFromOuterScope,
     &OrtApis::Graph_GetName,
+    &OrtApis::Graph_GetModelMetadata,
     &OrtApis::Graph_GetModelPath,
     &OrtApis::Graph_GetOnnxIRVersion,
     &OrtApis::Graph_GetNumOperatorSets,

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -4044,7 +4044,6 @@ static constexpr OrtApi ort_api_1_to_23 = {
     &OrtApis::ValueInfo_IsConstantInitializer,
     &OrtApis::ValueInfo_IsFromOuterScope,
     &OrtApis::Graph_GetName,
-    &OrtApis::Graph_GetModelMetadata,
     &OrtApis::Graph_GetModelPath,
     &OrtApis::Graph_GetOnnxIRVersion,
     &OrtApis::Graph_GetNumOperatorSets,
@@ -4106,6 +4105,8 @@ static constexpr OrtApi ort_api_1_to_23 = {
     &OrtApis::ReleaseSyncStream,
 
     &OrtApis::CopyTensors,
+
+    &OrtApis::Graph_GetModelMetadata,
 };
 
 // OrtApiBase can never change as there is no way to know what version of OrtApiBase is returned by OrtGetApiBase.

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2631,7 +2631,7 @@ ORT_API_STATUS_IMPL(OrtApis::Graph_GetModelMetadata, _In_ const OrtGraph* graph,
   if (out == nullptr) {
     return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "'out' argument is NULL");
   }
-  *out = graph->GetModelMetadata();
+  *out = reinterpret_cast<OrtModelMetadata*>(graph->GetModelMetadata().release());
   //
   return nullptr;
   API_IMPL_END

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2632,7 +2632,6 @@ ORT_API_STATUS_IMPL(OrtApis::Graph_GetModelMetadata, _In_ const OrtGraph* graph,
     return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "'out' argument is NULL");
   }
   *out = reinterpret_cast<OrtModelMetadata*>(graph->GetModelMetadata().release());
-  //
   return nullptr;
   API_IMPL_END
 }

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -635,6 +635,7 @@ ORT_API_STATUS_IMPL(ValueInfo_IsFromOuterScope, _In_ const OrtValueInfo* value_i
 
 // OrtGraph
 ORT_API_STATUS_IMPL(Graph_GetName, _In_ const OrtGraph* graph, _Outptr_ const char** graph_name);
+ORT_API_STATUS_IMPL(Graph_GetModelMetadata, _In_ const OrtGraph* graph, _Outptr_ OrtModelMetadata** out);
 ORT_API_STATUS_IMPL(Graph_GetModelPath, _In_ const OrtGraph* graph, _Outptr_ const ORTCHAR_T** model_path);
 ORT_API_STATUS_IMPL(Graph_GetOnnxIRVersion, _In_ const OrtGraph* graph, _Out_ int64_t* onnx_ir_version);
 ORT_API_STATUS_IMPL(Graph_GetNumOperatorSets, _In_ const OrtGraph* graph, _Out_ size_t* num_operator_sets);

--- a/onnxruntime/test/ep_graph/test_ep_graph.cc
+++ b/onnxruntime/test/ep_graph/test_ep_graph.cc
@@ -917,10 +917,7 @@ static void CheckGraphCApi(const GraphViewer& graph_viewer, const OrtGraph& api_
   // Check the model metadata
   Ort::AllocatorWithDefaultOptions default_allocator;
   auto ort_cxx_graph = Ort::ConstGraph(&api_graph);
-  auto api_model_metadata = ort_cxx_graph.GetModelMetadata();
-  OrtModelMetadata* ort_model_metadata;
-  ASSERT_ORTSTATUS_OK(ort_api.Graph_GetModelMetadata(&api_graph, &ort_model_metadata));
-  auto ort_cxx_model_metadat = Ort::ModelMetadata(ort_model_metadata);
+  auto ort_cxx_model_metadat = ort_cxx_graph.GetModelMetadata();
   auto& model = graph_viewer.GetGraph().GetModel();
   ASSERT_EQ(std::strcmp(ort_cxx_model_metadat.GetProducerNameAllocated(default_allocator).get(), model.ProducerName().c_str()), 0);
   ASSERT_EQ(std::strcmp(ort_cxx_model_metadat.GetGraphNameAllocated(default_allocator).get(), model.MainGraph().Name().c_str()), 0);


### PR DESCRIPTION
### Description

Add a new API `Graph_GetModelMetadata`

### Motivation and Context

VitisAI EP would convert ONNX IR to another IR which is suitable for AMD AI compilers.
The metadata in a OrtModel contains many important infomation produced by other tools, e.g. Olive.

This API potentially used by many other execution providers which need to access the same information.