### PR TITLE
Fix static mutex destruction order issues causing crashes at program termination

### DIFF
--- a/onnxruntime/core/common/logging/logging.cc
+++ b/onnxruntime/core/common/logging/logging.cc
@@ -65,8 +65,11 @@ LoggingManager* LoggingManager::GetDefaultInstance() {
 #endif
 
 static std::mutex& DefaultLoggerMutex() noexcept {
-  static std::mutex mutex;
-  return mutex;
+  // Fix for static destruction order issue:
+  // Use a heap-allocated mutex that we intentionally leak to avoid
+  // destruction order problems during program termination
+  static std::mutex* mutex = new std::mutex();
+  return *mutex;
 }
 
 Logger* LoggingManager::s_default_logger_ = nullptr;

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -136,7 +136,7 @@ class InferenceSession {
   using InputOutputDefMetaMap = InlinedHashMap<std::string_view, InputOutputDefMetaData>;
   static std::map<uint32_t, InferenceSession*> active_sessions_;
 #ifdef _WIN32
-  static std::mutex active_sessions_mutex_;  // Protects access to active_sessions_
+  // Mutex is now accessed through GetActiveSessionsMutex() function to avoid static destruction issues
   static onnxruntime::WindowsTelemetry::EtwInternalCallback callback_ML_ORT_provider_;
   onnxruntime::logging::EtwRegistrationManager::EtwInternalCallback callback_ETWSink_provider_;
 #endif

--- a/onnxruntime/core/session/ort_env.h
+++ b/onnxruntime/core/session/ort_env.h
@@ -62,7 +62,7 @@ struct OrtEnv {
   // tracking active users. It is set to nullptr when the last reference is released
   // (and not shutting down).
   static OrtEnv* p_instance_;
-  static std::mutex m_;
+  // Mutex is now accessed through GetOrtEnvMutex() function
   static int ref_count_;
 
   std::unique_ptr<onnxruntime::Environment> value_;


### PR DESCRIPTION
## Description
  This PR fixes crashes that occur during program termination due to static mutex destruction order issues. When static
  mutexes are destroyed while other static objects still reference them, it causes undefined behavior and crashes.

  ## Motivation and Context
  Static destruction order in C++ is undefined across translation units. This causes crashes when:
  - Logging infrastructure attempts to use mutexes during cleanup
  - Multiple static objects have interdependencies
  - Cleanup order varies between platforms/configurations

  ## Changes
  The fix uses heap-allocated mutexes (intentionally leaked) for critical static mutexes to ensure they remain valid
  throughout program lifetime:

  1. `DefaultLoggerMutex()` in `logging.cc` - Used by logging infrastructure
  2. `GetOrtEnvMutex()` in `ort_env.cc` - Used by ORT environment management
  3. `GetActiveSessionsMutex()` in `inference_session.cc` - Windows-specific session tracking

  ## Technical Details
  - Uses `new std::mutex()` without corresponding `delete` (intentional leak)
  - The leaked memory is negligible (24-40 bytes per mutex)
  - This is a common C++ pattern for avoiding static destruction issues
  - Similar approach used in many production systems (LLVM, Chrome, etc.)

  ## Testing
  - Tested on macOS (ARM64)
  - Existing test suite passes
  - Additional testing on Windows and Linux would be appreciated

  ## Note
  This issue was discovered while working on the Rust-based TTS library which uses ONNX Runtime. The crashes were occurring during cleanup when the library was unloaded.