### PR TITLE
Disable CoreML EP for test case GemmTransA_int32_128x128x128

### DIFF
--- a/onnxruntime/test/providers/cpu/math/gemm_test.cc
+++ b/onnxruntime/test/providers/cpu/math/gemm_test.cc
@@ -1599,7 +1599,7 @@ TEST(GemmOpTest, GemmTransA_int32_128x128x128) {
   test.AddInput<int32_t>("C", {M, N}, C_data);
   test.AddOutput<int32_t>("Y", {M, N}, Y_data);
 
-  test.ConfigExcludeEps({kQnnExecutionProvider, kCpuExecutionProvider})
+  test.ConfigExcludeEps({kQnnExecutionProvider, kCpuExecutionProvider, kCoreMLExecutionProvider})
       .Config(run_with_tunable_op)
       .RunWithConfig();
 }


### PR DESCRIPTION
### Description

Fix test failure.

```
1: [ RUN      ] GemmOpTest.GemmTransA_int32_128x128x128
1: /Users/runner/work/1/s/onnxruntime/test/providers/base_tester.cc:317: Failure
1: Expected equality of these values:
1:   expect_result
1:     Which is: 4-byte object <00-00 00-00>
1:   ExpectResult::kExpectFailure
1:     Which is: 4-byte object <01-00 00-00>
1: Initialize failed but expected success: Could not find an implementation for Gemm(13) node with name 'node1'
1: Google Test trace:
1: /Users/runner/work/1/s/onnxruntime/test/providers/base_tester.cc:849: registered execution providers: CoreMLExecutionProvider
1: 
1: /Users/runner/work/1/s/onnxruntime/test/providers/base_tester.cc:317: Failure
1: Expected equality of these values:
1:   expect_result
1:     Which is: 4-byte object <00-00 00-00>
1:   ExpectResult::kExpectFailure
1:     Which is: 4-byte object <01-00 00-00>
1: Initialize failed but expected success: Could not find an implementation for Gemm(13) node with name 'node1'
```
