### PR TITLE
[VitisAI] Ability to dynamically add kernels to kernel registry

### DIFF
--- a/onnxruntime/core/providers/vitisai/imp/global_api.cc
+++ b/onnxruntime/core/providers/vitisai/imp/global_api.cc
@@ -7,10 +7,6 @@
 #include <iostream>
 #include <codecvt>
 #include <fstream>
-#include "core/framework/op_kernel.h"
-#include "core/framework/provider_options.h"
-#include "core/providers/shared_library/provider_api.h"
-#include "core/providers/shared_library/provider_wrappedtypes.h"
 #include "onnxruntime_c_api.h"
 #ifdef _WIN32
 #include <Windows.h>
@@ -19,6 +15,7 @@
 
 #include "core/common/exceptions.h"
 #include "core/framework/error_code_helper.h"
+#include "core/framework/provider_options.h"
 #include "core/providers/shared/common.h"
 
 #include "vaip/dll_safe.h"

--- a/onnxruntime/core/providers/vitisai/imp/global_api.cc
+++ b/onnxruntime/core/providers/vitisai/imp/global_api.cc
@@ -76,6 +76,7 @@ static onnxruntime::PathString GetDynamicLibraryLocationByAddress(const void* ad
 vaip_core::OrtApiForVaip* create_org_api_hook();
 struct OrtVitisAIEpAPI {
   void (*initialize_onnxruntime_vitisai_ep)(vaip_core::OrtApiForVaip* api, std::vector<OrtCustomOpDomain*>& ret_domain);
+  void (*refresh_vitisai_ep_domains)(std::vector<OrtCustomOpDomain*>& ret_domain);
   void (*vitisai_on_ep_factory_created)(const onnxruntime::ProviderOptions& options);
   std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>* (*compile_onnx_model_with_options)(
       const std::string& model_path, const onnxruntime::Graph& graph, const onnxruntime::ProviderOptions& options);
@@ -134,6 +135,7 @@ struct OrtVitisAIEpAPI {
       ORT_THROW(status2);
     }
     std::ignore = env.GetSymbolFromLibrary(handle_, "vitisai_on_ep_factory_created", (void**)&vitisai_on_ep_factory_created);
+    std::ignore = env.GetSymbolFromLibrary(handle_, "refresh_vitisai_ep_domains", (void**)&refresh_vitisai_ep_domains);
     std::ignore = env.GetSymbolFromLibrary(handle_, "vaip_get_version",
                                            (void**)&vaip_get_version);
     std::ignore = env.GetSymbolFromLibrary(handle_, "profiler_collect", (void**)&profiler_collect);
@@ -326,6 +328,8 @@ static void refresh_kernel_registry(const std::vector<OrtCustomOpDomain*>& domai
 }
 
 void refresh_vitisai_ep_kernels() {
+  if (s_library_vitisaiep.refresh_vitisai_ep_domains)
+    s_library_vitisaiep.refresh_vitisai_ep_domains(s_domains_vitisaiep);
   vaip::register_xir_ops(s_domains_vitisaiep);
   refresh_kernel_registry(s_domains_vitisaiep);
 }

--- a/onnxruntime/core/providers/vitisai/include/vaip/global_api.h
+++ b/onnxruntime/core/providers/vitisai/include/vaip/global_api.h
@@ -13,6 +13,7 @@
 void initialize_vitisai_ep();
 void deinitialize_vitisai_ep();
 void vitisai_on_ep_factory_created(const onnxruntime::ProviderOptions& options);
+void refresh_vitisai_ep_kernels();
 vaip_core::DllSafe<std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>> compile_onnx_model(const onnxruntime::GraphViewer& graph_viewer, const onnxruntime::logging::Logger& logger, const onnxruntime::ProviderOptions& options);
 std::shared_ptr<onnxruntime::KernelRegistry> get_kernel_registry_vitisaiep();
 const std::vector<OrtCustomOpDomain*>& get_domains_vitisaiep();

--- a/onnxruntime/core/providers/vitisai/include/vaip/global_api.h
+++ b/onnxruntime/core/providers/vitisai/include/vaip/global_api.h
@@ -12,6 +12,7 @@
 #include <optional>
 void initialize_vitisai_ep();
 void deinitialize_vitisai_ep();
+void vitisai_on_ep_factory_created(const onnxruntime::ProviderOptions& options);
 vaip_core::DllSafe<std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>> compile_onnx_model(const onnxruntime::GraphViewer& graph_viewer, const onnxruntime::logging::Logger& logger, const onnxruntime::ProviderOptions& options);
 std::shared_ptr<onnxruntime::KernelRegistry> get_kernel_registry_vitisaiep();
 const std::vector<OrtCustomOpDomain*>& get_domains_vitisaiep();

--- a/onnxruntime/core/providers/vitisai/vitisai_provider_factory.cc
+++ b/onnxruntime/core/providers/vitisai/vitisai_provider_factory.cc
@@ -16,7 +16,9 @@ using namespace onnxruntime;
 namespace onnxruntime {
 
 struct VitisAIProviderFactory : IExecutionProviderFactory {
-  VitisAIProviderFactory(const ProviderOptions& info) : info_(info) {}
+  VitisAIProviderFactory(const ProviderOptions& info) : info_(info) {
+    vitisai_on_ep_factory_created(info);
+  }
   ~VitisAIProviderFactory() = default;
 
   std::unique_ptr<IExecutionProvider> CreateProvider() override;

--- a/onnxruntime/core/providers/vitisai/vitisai_provider_factory.cc
+++ b/onnxruntime/core/providers/vitisai/vitisai_provider_factory.cc
@@ -18,6 +18,7 @@ namespace onnxruntime {
 struct VitisAIProviderFactory : IExecutionProviderFactory {
   VitisAIProviderFactory(const ProviderOptions& info) : info_(info) {
     vitisai_on_ep_factory_created(info);
+    refresh_vitisai_ep_kernels();
   }
   ~VitisAIProviderFactory() = default;
 


### PR DESCRIPTION
### Description
This PR adds the ability to add operations into the KernelRegistry after VitisAI EP library initialization. It also currently calls it after EP factory creation.

This PR does:
* a refactoring of the `CreateKernelInfo` creation (puts it into a dedicated function)
* add a `refresh_kernel_registry` function and rename `create_kernel_registry` into `initialize_kernel_registry`,
* maintain a list `s_vitisaiep_registered_ops` of ops known to be in the KernelRegistry, to prevent duplicating already registered ops when `refresh_kernel_registry` is called.

### Motivation and Context
The VitisAI library needs to register ops at multiple points past its initialization. This facility lets it do so, and updates the ops once the EP factory exists (before the EPs are actually created).

Sits on top of #25759.


