### PR TITLE
[DRAFT PR] Disable ORT_RUN_EXTERNAL_ONNX_TESTS to test CI impact

### DIFF
--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -593,7 +593,7 @@ if(NOT (onnx_FOUND OR ONNX_FOUND)) # building ONNX from source
 endif()
 
 if (onnxruntime_RUN_ONNX_TESTS)
-  add_definitions(-DORT_RUN_EXTERNAL_ONNX_TESTS)
+  # add_definitions(-DORT_RUN_EXTERNAL_ONNX_TESTS)
 endif()
 
 if(onnxruntime_ENABLE_DLPACK)


### PR DESCRIPTION
## Description
This draft PR disables the `ORT_RUN_EXTERNAL_ONNX_TESTS` macro to test the CI impact of removing private model dependencies.

## Changes
- Commented out `add_definitions(-DORT_RUN_EXTERNAL_ONNX_TESTS)` in `cmake/external/onnxruntime_external_deps.cmake` (line 601)

## Purpose
Testing how CI pipelines react to disabling external model tests that depend on private models not available to external partners.

## Context
Part of the initiative to ensure all ONNX Runtime test models are publicly accessible for external EP partners (NVIDIA, Intel, Qualcomm, AMD).

### Verification Results
- 49.2% of current test models have verified public checksums matching ONNX Model Zoo
- 50.8% are private/modified versions that cannot be shared
- This change disables tests for the private models

