### PR TITLE
[MIGRAPHX EP] Workaround for reducing GPU memory allocations

### DIFF
--- a/onnxruntime/core/framework/memory_info.cc
+++ b/onnxruntime/core/framework/memory_info.cc
@@ -47,7 +47,6 @@ void MemoryInfo::Init(const SequentialExecutionPlan* execution_plan,
     tensor_alloc_info_map_[value_idx] = std::move(mem_info);
     tensors_memory_info_map_[mem_info.location];
   }
-  return;
 }
 
 // Record the planned memory information
@@ -77,6 +76,12 @@ void MemoryInfo::RecordPatternInfo(const MemoryPatternGroup& mem_patterns, const
 // Record the actual allocated tensor in the device
 void MemoryInfo::RecordTensorDeviceAllocInfo(const OrtValueIndex idx, const OrtValue& value, const MapType& type) {
   if (tensor_alloc_info_map_.find(idx) == tensor_alloc_info_map_.end()) return;
+#ifdef USE_MIGRAPHX
+  if (!value.IsAllocated()) {
+    tensors_memory_info_map_.at(AllocPlan(idx)->location)[type].AddAllocMemory(idx, {0, 0});
+    return;
+  }
+#endif
   ORT_ENFORCE(value.IsTensor(), "Memory profiler only supports tensor type.");
   auto& tensor = value.Get<Tensor>();
   auto tensor_size_in_bytes = tensor.SizeInBytes();

--- a/onnxruntime/core/framework/memory_info.h
+++ b/onnxruntime/core/framework/memory_info.h
@@ -27,16 +27,15 @@ struct MemoryInfoPerTensor {
 };
 
 struct MemoryInfoMap {
-  using MemoryInfoMapT = std::unordered_map<onnxruntime::OrtValueIndex, onnxruntime::MemoryInfoPerTensor>;
+  using MemoryInfoMapT = std::unordered_map<OrtValueIndex, MemoryInfoPerTensor>;
 
- public:
   MemoryInfoMap() = default;
 
   void AddPlannedMemory(const OrtValueIndex& idx, const MemoryBlock& mb) {
     map_[idx].planned_block = mb;
   }
 
-  void AddAllocMemory(const OrtValueIndex& idx, MemoryBlock& mb) {
+  void AddAllocMemory(const OrtValueIndex& idx, const MemoryBlock& mb) {
     map_[idx].allocated_block = mb;
     if (ptr_offset == 0 || (ptr_offset > mb.offset_ && mb.offset_ != 0)) {
       ptr_offset = mb.offset_;

--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -469,7 +469,13 @@ Status SessionState::PrepackConstantInitializedTensors(
 
               if (constant_initialized_tensors.count(ort_value_idx)) {
                 bool is_packed = false;
-                const Tensor& const_initialized_tensor = constant_initialized_tensors[ort_value_idx].Get<Tensor>();
+                const auto ort_value = constant_initialized_tensors[ort_value_idx];
+#ifdef USE_MIGRAPHX
+                if (!ort_value.IsAllocated()) {
+                  break;
+                }
+#endif
+                const Tensor& const_initialized_tensor = ort_value.Get<Tensor>();
 
                 auto iter = initializers_to_share_map.find(input_name);
                 bool is_shared_initializer = (iter != initializers_to_share_map.end());

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -223,7 +223,6 @@ MIGraphXExecutionProvider::MIGraphXExecutionProvider(const MIGraphXExecutionProv
   }
 
   // Print configured options for the session.
-
   LOGS_DEFAULT(VERBOSE) << "[MIGraphX EP] MIGraphX provider Session Options:"
                         << "\n " << migraphx_provider_option::kDeviceId << ": " << device_id_
                         << "\n " << migraphx_provider_option::kFp16Enable << ": " << fp16_enable_
@@ -1417,6 +1416,8 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
           auto& name = it.first;
           auto& index = it.second;
           auto input_tensor = ctx.GetInput(index);
+          if (!input_tensor.HasValue())
+            continue;
           auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
           const auto tensor_shape = tensor_info.GetShape();
           std::vector<std::size_t> ort_lens(tensor_shape.begin(), tensor_shape.end());
@@ -1434,6 +1435,8 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
           for (auto&& name : param_shapes.names()) {
             if (map_input_name_index.count(name) > 0) {
               auto input_tensor = ctx.GetInput(map_input_name_index[name]);
+              if (!input_tensor.HasValue())
+                continue;
               auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
               const auto tensor_shape = tensor_info.GetShape();
               std::vector<std::size_t> ort_lens(tensor_shape.begin(), tensor_shape.end());
@@ -1480,6 +1483,8 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
             for (auto&& name : local_param_shapes.names()) {
               if (map_input_name_index.count(name) > 0) {
                 auto input_tensor = ctx.GetInput(map_input_name_index[name]);
+                if (!input_tensor.HasValue())
+                  continue;
                 auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
                 const auto tensor_shape = tensor_info.GetShape();
                 const auto tensor_type = tensor_info.GetElementType();
@@ -1514,6 +1519,8 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
           if (map_input_name_index.count(name) > 0) {
             LOGS_DEFAULT(VERBOSE) << "Setting parameters for:" << name;
             auto input_tensor = ctx.GetInput(map_input_name_index[name]);
+            if (!input_tensor.HasValue())
+              continue;
             auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
             const auto tensor_shape = tensor_info.GetShape();
             const auto tensor_type = tensor_info.GetElementType();

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -127,7 +127,7 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
   bool exhaustive_tune_ = false;
   mutable std::filesystem::path model_path_{};
   size_t mem_limit_{std::numeric_limits<size_t>::max()};
-  ArenaExtendStrategy arena_extend_strategy_{ArenaExtendStrategy::kNextPowerOfTwo};
+  ArenaExtendStrategy arena_extend_strategy_{ArenaExtendStrategy::kSameAsRequested};
 
   std::unordered_map<std::string, migraphx::program> map_progs_;
   std::unordered_map<std::string, std::string> map_onnx_string_;

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.h
@@ -52,7 +52,7 @@ struct MIGraphXExecutionProviderInfo {
   bool exhaustive_tune{false};
 
   size_t mem_limit{std::numeric_limits<size_t>::max()};
-  ArenaExtendStrategy arena_extend_strategy{ArenaExtendStrategy::kNextPowerOfTwo};
+  ArenaExtendStrategy arena_extend_strategy{ArenaExtendStrategy::kSameAsRequested};
 
   OrtArenaCfg* default_memory_arena_cfg{nullptr};
 


### PR DESCRIPTION
### Description
The current design of the MIGraphX graph compiler, which we use for the MIGraphX Execution Provider, requires managing GPU allocations independently from ONNXRuntime. With this PR, we implement a workaround to prevent ONNXRuntime from allocating initializers for MIGraphX EP. For all constant initializer tensors located in an AMD GPU device, the function responsible for allocating memory returns status OK without performing any actual allocation or data read from disk. Otherwise, those are double allocated and consume more memory than required. In the ONNXRuntime memory profiler, we are registering those kinds of allocations as empty blocks for further analysis.

### Motivation and Context
To reduce the memory allocations on the GPU when used with MIGraphX EP.

