### PR TITLE
[webgpu] Fix build break in matmul_nbits.cc

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.cc
@@ -92,7 +92,6 @@ Status MatMulNBitsProgram::GenerateShaderCode(ShaderHelper& shader) const {
                              WGSL_TEMPLATE_PARAMETER(tile_size, tile_size_),
                              WGSL_TEMPLATE_PARAMETER(tile_size_k, tile_size_k),
                              WGSL_TEMPLATE_PARAMETER(tile_size_k_vec, tile_size_k_vec));
-  return Status::OK();
 }
 
 Status MatMulNBits::ComputeInternal(onnxruntime::webgpu::ComputeContext& context) const {


### PR DESCRIPTION
### Description

Fix build break caused by warning C4702: unreachable code.

```
onnxruntime\contrib_ops\webgpu\quantization\matmul_nbits.cc(95,1): error C2220: the following warning is treated
 as an error [C:\code\o3\build_main\Debug\onnxruntime_providers_webgpu.vcxproj]
onnxruntime\contrib_ops\webgpu\quantization\matmul_nbits.cc(95,1): warning C4702: unreachable code [C:\code\o3\b
uild_main\Debug\onnxruntime_providers_webgpu.vcxproj]
```

Seems the CI pipeline does not catch this.