### PR TITLE
add c# interface for onnxruntime

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
@@ -417,7 +417,7 @@ namespace Microsoft.ML.OnnxRuntime
             OrtCreateEnvWithGlobalThreadPools = (DOrtCreateEnvWithGlobalThreadPools)Marshal.GetDelegateForFunctionPointer(api_.CreateEnvWithGlobalThreadPools, typeof(DOrtCreateEnvWithGlobalThreadPools));
             OrtCreateEnvWithCustomLoggerAndGlobalThreadPools = (DOrtCreateEnvWithCustomLoggerAndGlobalThreadPools)Marshal.GetDelegateForFunctionPointer(api_.CreateEnvWithCustomLoggerAndGlobalThreadPools, typeof(DOrtCreateEnvWithCustomLoggerAndGlobalThreadPools));
             OrtReleaseEnv = (DOrtReleaseEnv)Marshal.GetDelegateForFunctionPointer(api_.ReleaseEnv, typeof(DOrtReleaseEnv));
-            
+
             OrtEnableTelemetryEvents = (DOrtEnableTelemetryEvents)Marshal.GetDelegateForFunctionPointer(api_.EnableTelemetryEvents, typeof(DOrtEnableTelemetryEvents));
             OrtDisableTelemetryEvents = (DOrtDisableTelemetryEvents)Marshal.GetDelegateForFunctionPointer(api_.DisableTelemetryEvents, typeof(DOrtDisableTelemetryEvents));
 
@@ -597,6 +597,8 @@ namespace Microsoft.ML.OnnxRuntime
                 api_.SessionOptionsAppendExecutionProvider_CUDA, typeof(DSessionOptionsAppendExecutionProvider_CUDA));
             SessionOptionsAppendExecutionProvider_CUDA_V2 = (DSessionOptionsAppendExecutionProvider_CUDA_V2)Marshal.GetDelegateForFunctionPointer(
                 api_.SessionOptionsAppendExecutionProvider_CUDA_V2, typeof(DSessionOptionsAppendExecutionProvider_CUDA_V2));
+            SessionOptionsAppendExecutionProvider_VitisAI = (DSessionOptionsAppendExecutionProvider_VitisAI)Marshal.GetDelegateForFunctionPointer(
+                api_.SessionOptionsAppendExecutionProvider_VitisAI, typeof(DSessionOptionsAppendExecutionProvider_VitisAI));
             OrtCreateCUDAProviderOptions = (DOrtCreateCUDAProviderOptions)Marshal.GetDelegateForFunctionPointer(api_.CreateCUDAProviderOptions, typeof(DOrtCreateCUDAProviderOptions));
             OrtUpdateCUDAProviderOptions = (DOrtUpdateCUDAProviderOptions)Marshal.GetDelegateForFunctionPointer(api_.UpdateCUDAProviderOptions, typeof(DOrtUpdateCUDAProviderOptions));
             OrtGetCUDAProviderOptionsAsString = (DOrtGetCUDAProviderOptionsAsString)Marshal.GetDelegateForFunctionPointer(api_.GetCUDAProviderOptionsAsString, typeof(DOrtGetCUDAProviderOptionsAsString));
@@ -676,12 +678,12 @@ namespace Microsoft.ML.OnnxRuntime
             OrtEpDevice_Device = (DOrtEpDevice_Device)Marshal.GetDelegateForFunctionPointer(
                 api_.EpDevice_Device, typeof(DOrtEpDevice_Device));
 
-            OrtRegisterExecutionProviderLibrary = 
+            OrtRegisterExecutionProviderLibrary =
                 (DOrtRegisterExecutionProviderLibrary)Marshal.GetDelegateForFunctionPointer(
                     api_.RegisterExecutionProviderLibrary,
                     typeof(DOrtRegisterExecutionProviderLibrary));
 
-            OrtUnregisterExecutionProviderLibrary = 
+            OrtUnregisterExecutionProviderLibrary =
                 (DOrtUnregisterExecutionProviderLibrary)Marshal.GetDelegateForFunctionPointer(
                     api_.UnregisterExecutionProviderLibrary,
                     typeof(DOrtUnregisterExecutionProviderLibrary));
@@ -690,12 +692,12 @@ namespace Microsoft.ML.OnnxRuntime
                 api_.GetEpDevices,
                 typeof(DOrtGetEpDevices));
 
-            OrtSessionOptionsAppendExecutionProvider_V2 = 
+            OrtSessionOptionsAppendExecutionProvider_V2 =
                 (DOrtSessionOptionsAppendExecutionProvider_V2)Marshal.GetDelegateForFunctionPointer(
                     api_.SessionOptionsAppendExecutionProvider_V2,
                     typeof(DOrtSessionOptionsAppendExecutionProvider_V2));
 
-            OrtSessionOptionsSetEpSelectionPolicy = 
+            OrtSessionOptionsSetEpSelectionPolicy =
                 (DSessionOptionsSetEpSelectionPolicy)Marshal.GetDelegateForFunctionPointer(
                     api_.SessionOptionsSetEpSelectionPolicy,
                     typeof(DSessionOptionsSetEpSelectionPolicy));
@@ -941,7 +943,7 @@ namespace Microsoft.ML.OnnxRuntime
 #region InferenceSession API
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         public delegate IntPtr /* OrtStatus* */ DOrtCreateStatus(
-            uint /* OrtErrorCode */ code, 
+            uint /* OrtErrorCode */ code,
             byte[] /* const char* */ msg);
         public static DOrtCreateStatus OrtCreateStatus;
 
@@ -1311,6 +1313,20 @@ namespace Microsoft.ML.OnnxRuntime
             IntPtr /*(const OrtTensorRTProviderOptionsV2*)*/ trtProviderOptions);
 
         public static DSessionOptionsAppendExecutionProvider_TensorRT_V2 SessionOptionsAppendExecutionProvider_TensorRT_V2;
+
+        /// <summary>
+        /// Append a VitisAI EP instance (configured based on given provider options) to the native OrtSessionOptions instance
+        /// </summary>
+        /// <param name="options">Native OrtSessionOptions instance</param>
+        /// <param name="keys">Native keys instance</param>
+        /// <param name="values">Native values instance</param>
+        /// <param name="numEntries">Native numEntries instance</param>
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate IntPtr /*(OrtStatus*)*/ DSessionOptionsAppendExecutionProvider_VitisAI(
+            IntPtr /*(OrtSessionOptions*)*/ options,
+            IntPtr keys, IntPtr values, UIntPtr numEntries);
+
+        public static DSessionOptionsAppendExecutionProvider_VitisAI SessionOptionsAppendExecutionProvider_VitisAI;
 
         /// <summary>
         /// Append a CUDA EP instance (configured based on given provider options) to the native OrtSessionOptions instance
@@ -2317,7 +2333,7 @@ namespace Microsoft.ML.OnnxRuntime
                                                  byte[] /* const char* */ value);
 
         /// <summary>
-        /// Get the value for the provided key. 
+        /// Get the value for the provided key.
         /// </summary>
         /// <returns>Value. Returns IntPtr.Zero if key was not found.</returns>
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
@@ -2416,7 +2432,7 @@ namespace Microsoft.ML.OnnxRuntime
         // Auto Selection EP registration and selection customization
 
         /// <summary>
-        /// Register an execution provider library. 
+        /// Register an execution provider library.
         /// The library must implement CreateEpFactories and ReleaseEpFactory.
         /// </summary>
         /// <param name="env">Environment to add the EP library to.</param>

--- a/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.shared.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Linq;
 
 namespace Microsoft.ML.OnnxRuntime
 {
@@ -258,6 +259,58 @@ namespace Microsoft.ML.OnnxRuntime
         }
 
         /// <summary>
+        /// Append a VitisAI EP instance (configured based on given provider options) to the native OrtSessionOptions instance
+        /// </summary>
+        /// <param name="options">Native OrtSessionOptions instance</param>
+        /// <param name="keys">Native keys instance</param>
+        /// <param name="values">Native values instance</param>
+        /// <param name="numEntries">Native numEntries instance</param>
+        public void AppendExecutionProvider_VitisAI(Dictionary<string, string> config)
+        {
+#if __MOBILE__
+            throw new NotSupportedException("The VitisAI Execution Provider is not supported in this build");
+#else
+            int count = config.Count;
+            IntPtr[] keyPtrs = new IntPtr[count];
+            IntPtr[] valuePtrs = new IntPtr[count];
+
+            string[] keys = config.Keys.ToArray();
+            string[] values = config.Values.ToArray();
+
+            for (int i = 0; i < count; ++i) {
+                keyPtrs[i] = Marshal.StringToHGlobalAnsi(keys[i]);
+                valuePtrs[i] = Marshal.StringToHGlobalAnsi(values[i]);
+            }
+
+            IntPtr keysNative = Marshal.AllocHGlobal(IntPtr.Size * count);
+            IntPtr valuesNative = Marshal.AllocHGlobal(IntPtr.Size * count);
+
+            Marshal.Copy(keyPtrs, 0, keysNative, count);
+            Marshal.Copy(valuePtrs, 0, valuesNative, count);
+
+            try
+            {
+                UIntPtr numKeys = new UIntPtr((uint)count);
+                NativeApiStatus.VerifySuccess(
+                    NativeMethods.SessionOptionsAppendExecutionProvider_VitisAI(
+                        handle, keysNative, valuesNative, numKeys));
+            }
+            finally
+            {
+            // 释放内存
+                for (int i = 0; i < count; ++i)
+                {
+                    Marshal.FreeHGlobal(keyPtrs[i]);
+                    Marshal.FreeHGlobal(valuePtrs[i]);
+                }
+                Marshal.FreeHGlobal(keysNative);
+                Marshal.FreeHGlobal(valuesNative);
+            }
+#endif
+        }
+
+
+        /// <summary>
         /// Use only if you have the onnxruntime package specific to this Execution Provider.
         /// </summary>
         /// <param name="deviceId">device identification</param>
@@ -426,20 +479,20 @@ namespace Microsoft.ML.OnnxRuntime
         }
 
         /// <summary>
-        /// Select execution providers from the list of available execution providers and devices returned by 
+        /// Select execution providers from the list of available execution providers and devices returned by
         /// GetEpDevices.
-        /// 
-        /// One or more OrtEpDevice instances may be provided in epDevices, but must all be for the same 
+        ///
+        /// One or more OrtEpDevice instances may be provided in epDevices, but must all be for the same
         /// execution provider.
-        /// 
+        ///
         /// Make multiple calls to AppendExecutionProvider if you wish to use multiple execution providers.
-        /// 
-        /// e.g. 
+        ///
+        /// e.g.
         ///   - if execution provider 'A' has an OrtEpDevice for NPU and one for GPU and you wish to use it for
         ///     both devices, pass the two OrtEpDevice instances in the epDevices list in one call.
-        ///   - if you wish to use execution provider 'B' for GPU and execution provider 'C' for CPU, 
+        ///   - if you wish to use execution provider 'B' for GPU and execution provider 'C' for CPU,
         ///     make two calls to AppendExecutionProvider, with one OrtEpDevice in the epDevices list in each call.
-        ///     
+        ///
         /// The priority of the execution providers is set by the order in which they are appended.
         /// Highest priority is first.
         /// </summary>
@@ -449,7 +502,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// <param name="epOptions">Optional options to configure the execution provider. May be null.</param>
         /// <exception cref="ArgumentException">epDevices was empty.</exception>
         /// <see cref="OrtEnv.GetEpDevices" />
-        public void AppendExecutionProvider(OrtEnv env, IReadOnlyList<OrtEpDevice> epDevices, 
+        public void AppendExecutionProvider(OrtEnv env, IReadOnlyList<OrtEpDevice> epDevices,
                                             IReadOnlyDictionary<string, string> epOptions)
         {
             if (epDevices == null || epDevices.Count == 0)
@@ -481,7 +534,7 @@ namespace Microsoft.ML.OnnxRuntime
                         env.Handle,
                         epDevicePtrs,
                         (UIntPtr)epDevices.Count,
-                        epOptionsKeys,  
+                        epOptionsKeys,
                         epOptionsValues,
                         epOptionsCount));
             }
@@ -659,7 +712,7 @@ namespace Microsoft.ML.OnnxRuntime
 
             NativeApiStatus.VerifySuccess(
                 NativeMethods.OrtSessionOptionsSetEpSelectionPolicyDelegate(
-                    handle, 
+                    handle,
                     funcPtr,
                     GCHandle.ToIntPtr(_epSelectionPolicyConnectorHandle)));
         }
@@ -1161,7 +1214,7 @@ namespace Microsoft.ML.OnnxRuntime
         EpSelectionPolicyConnector _epSelectionPolicyConnector = null;
 
         /// <summary>
-        /// Handle to the EP selection policy connector that is passed to the C API as state for the 
+        /// Handle to the EP selection policy connector that is passed to the C API as state for the
         /// EP selection policy delegate.
         /// </summary>
         GCHandle _epSelectionPolicyConnectorHandle = default;


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
add C# interface for VitisAI EP


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- in order to execute VitisAI EP in onnxruntime for C# users, we commit these changes


