### PR TITLE
Fixes for DynamicQuantizeMatMul and Attention3D tests

### DIFF
--- a/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_matmul.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_matmul.cc
@@ -206,10 +206,10 @@ class DynamicQuantizeMatMul final : public MatMulIntegerToFloatBase {
         const float* bs_data = b_scale_tensor->Data<float>();
         const size_t bs_size = static_cast<size_t>(b_scale_tensor->Shape().Size());
         for (size_t i = 0; i < bs_size; ++i) {
-            const float s = bs_data[i];
-            if (!std::isfinite(s) || s <= 0.0f) {
-                can_use_dynamic_quant_mlas_ = false;
-                break;
+          const float s = bs_data[i];
+          if (!std::isfinite(s) || s <= 0.0f) {
+            can_use_dynamic_quant_mlas_ = false;
+            break;
           }
         }
       }
@@ -406,8 +406,9 @@ Status DynamicQuantizeMatMul::Compute(OpKernelContext* ctx) const {
     std::vector<MLAS_GEMM_DYN_QUANT_DATA_PARAMS> gemm_data_vec(num_gemms);
 
     for (size_t gemm_idx = 0; gemm_idx < num_gemms; gemm_idx++) {
+
       auto& params = gemm_data_vec[gemm_idx];
-      params.A = reinterpret_cast<const float*>(a_data + helper.LeftOffsets()[gemm_idx]);
+      params.A = reinterpret_cast<const float*>(a_data) + helper.LeftOffsets()[gemm_idx];
       params.lda = gemm_shape.K;
       params.PackedB = packed_b_.get();
       params.C = y_data + helper.OutputOffsets()[gemm_idx];

--- a/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_matmul.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_matmul.cc
@@ -203,14 +203,13 @@ class DynamicQuantizeMatMul final : public MatMulIntegerToFloatBase {
       // Kleidi dynamic path requires strictly positive, finite scales.
       // Disable if any invalid scale is detected.
       if (can_use_dynamic_quant_mlas_) {
-        const float* bs_data = b_scale_tensor->Data<float>();
-        const size_t bs_size = static_cast<size_t>(b_scale_tensor->Shape().Size());
-        for (size_t i = 0; i < bs_size; ++i) {
-          const float s = bs_data[i];
-          if (!std::isfinite(s) || s <= 0.0f) {
-            can_use_dynamic_quant_mlas_ = false;
-            break;
-          }
+        const auto bs = b_scale_tensor->DataAsSpan<float>();
+        const bool has_invalid =
+            std::any_of(bs.begin(), bs.end(),
+                        [](float s) { return !std::isfinite(s) || s <= 0.0f; });
+
+        if (has_invalid) {
+          can_use_dynamic_quant_mlas_ = false;
         }
       }
 
@@ -393,7 +392,7 @@ Status DynamicQuantizeMatMul::Compute(OpKernelContext* ctx) const {
     if (y->Shape().Size() == 0)
       return Status::OK();
 
-    auto a_data = static_cast<const uint8_t*>(ctx->Input<Tensor>(IN_A)->DataRaw());
+    const float* a_data = ctx->Input<Tensor>(IN_A)->Data<float>();
     auto* y_data = y->MutableData<float>();
 
     // batch gemm
@@ -406,9 +405,8 @@ Status DynamicQuantizeMatMul::Compute(OpKernelContext* ctx) const {
     std::vector<MLAS_GEMM_DYN_QUANT_DATA_PARAMS> gemm_data_vec(num_gemms);
 
     for (size_t gemm_idx = 0; gemm_idx < num_gemms; gemm_idx++) {
-
       auto& params = gemm_data_vec[gemm_idx];
-      params.A = reinterpret_cast<const float*>(a_data) + helper.LeftOffsets()[gemm_idx];
+      params.A = a_data + helper.LeftOffsets()[gemm_idx];
       params.lda = gemm_shape.K;
       params.PackedB = packed_b_.get();
       params.C = y_data + helper.OutputOffsets()[gemm_idx];

--- a/onnxruntime/core/mlas/lib/kleidiai/sgemm_kleidiai.cpp
+++ b/onnxruntime/core/mlas/lib/kleidiai/sgemm_kleidiai.cpp
@@ -321,7 +321,7 @@ ArmKleidiAI::MlasGemmBatch(
 
             if (can_memcpy) {
                 std::memcpy(dst_tile, temp_tile, TileSizeM * TileSizeN * sizeof(float));
-                return true;
+                return;
             }
 
             float alpha = Data[BIdx].alpha;
@@ -347,7 +347,7 @@ ArmKleidiAI::MlasGemmBatch(
                     }
                 }
             }
-            return true;
+            return;
         });
         return true;
     }

--- a/onnxruntime/core/mlas/lib/kleidiai/sgemm_kleidiai.cpp
+++ b/onnxruntime/core/mlas/lib/kleidiai/sgemm_kleidiai.cpp
@@ -157,7 +157,7 @@ ArmKleidiAI::MlasGemmBatch(
         return true;
     }
 
-    if (Data->alpha == 0.0f) {
+    if (Data->alpha == 0.0f || K == 0) {
         if (Data->beta == 0.0f) {
             for (size_t i = 0; i < M; ++i) {
                 std::fill_n(Data->C + i * Data->ldc, N, 0.0f);
@@ -171,22 +171,6 @@ ArmKleidiAI::MlasGemmBatch(
         }
         return true;
     }
-
-    if (K == 0) {
-        if (Data->beta == 0.0f) {
-            for (size_t i = 0; i < M; ++i) {
-                std::fill_n(Data->C + i * Data->ldc, N, 0.0f);
-            }
-        } else if (Data->beta != 1.0f) {
-            for (size_t i = 0; i < M; ++i) {
-                for (size_t j = 0; j < N; ++j) {
-                    Data->C[i * Data->ldc + j] *= Data->beta;
-                }
-            }
-        }
-        return true;
-    }
-
 
     if (TransA == CblasNoTrans) {
         const size_t mr = kai_get_mr_matmul_clamp_f32_f32p2vlx1_f32p2vlx1biasf32_sme2_mopa();
@@ -196,7 +180,7 @@ ArmKleidiAI::MlasGemmBatch(
         auto m_step = kai_get_m_step_matmul_clamp_f32_f32p2vlx1_f32p2vlx1biasf32_sme2_mopa();
         auto n_step = kai_get_n_step_matmul_clamp_f32_f32p2vlx1_f32p2vlx1biasf32_sme2_mopa();
 
-        if ((M < m_step && N < n_step) && !Data->BIsPacked) {
+        if (M < m_step && N < n_step && !Data->BIsPacked) {
             // Fallback to MLAS
             return false;
         }


### PR DESCRIPTION
### Description
This change fixes correctness issues in two areas that were causing failures in onnxruntime_test_all:

- DynamicQuantizeMatMul.WithConstantBInputs
- AttentionTest.Attention3DDefault
- AttentionTest.Attention3DWithPastAndPresentQkMatmul

What was wrong and how it’s fixed
1) DynamicQuantizeMatMul.WithConstantBInputs
- Root cause: The Kleidi dynamic quantization GEMM path could be selected even when the B scales contained values such as (zero, negative, or non-finite). That violates kernel assumptions and can lead to incorrect results.
- Fix: In `onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_matmul.cc`, we now explicitly validate that all B scales are finite and strictly positive before enabling the Kleidi/MLAS dynamic path. If any scale is invalid, we disable that path.

2) Attention tests (Attention3DDefault, Attention3DWithPastAndPresentQkMatmul)
- Root causes in `onnxruntime/core/mlas/lib/kleidiai/sgemm_kleidiai.cpp`:
  - Incorrect handling of GEMM corner cases for alpha/beta and K==0 (e.g., not respecting C = beta*C when alpha==0 or K==0).
  - Unnecessary or premature fallbacks for small shapes.
- Fixes:
  - Add early-outs for degenerate sizes: if M==0 or N==0, return handled.
  - Correctly implement alpha/beta semantics:
