### PR TITLE
[VitisAI EP] Add GetLibraryPath API to expose execution provider plugin library paths

### DIFF
--- a/include/onnxruntime/core/session/environment.h
+++ b/include/onnxruntime/core/session/environment.h
@@ -154,6 +154,11 @@ class Environment {
   const DataTransferManager& GetDataTransferManager() const {
     return data_transfer_mgr_;
   }
+
+  // Get the filesystem path of the library registered for the given EP registration name.
+  // Returns NOT_FOUND/FAIL if the EP is not registered or does not expose a library path.
+  Status GetExecutionProviderLibraryPath(const std::string& registration_name,
+                                         std::filesystem::path& out) const;
 #endif  // !defined(ORT_MINIMAL_BUILD)
 
   // return a shared allocator from a plugin EP or custom allocator added with RegisterAllocator

--- a/onnxruntime/core/session/plugin_ep/ep_library.h
+++ b/onnxruntime/core/session/plugin_ep/ep_library.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <string>
+#include <filesystem>
 #include "core/common/status.h"
 #include "core/framework/provider_options.h"
 #include "core/framework/session_options.h"
@@ -22,6 +23,14 @@ class EpLibrary {
   virtual const char* RegistrationName() const = 0;
   virtual Status Load() { return Status::OK(); }
   virtual const std::vector<OrtEpFactory*>& GetFactories() = 0;  // valid after Load()
+
+  // Return the filesystem path for the underlying library if available. Default implementation returns an
+  // empty path so derived classes that represent a plugin should override this.
+  virtual const std::filesystem::path& GetLibraryPath() const {
+    static const std::filesystem::path empty{};
+    return empty;
+  }
+
   virtual Status Unload() { return Status::OK(); }
   virtual ~EpLibrary() = default;
 

--- a/onnxruntime/core/session/plugin_ep/ep_library_plugin.h
+++ b/onnxruntime/core/session/plugin_ep/ep_library_plugin.h
@@ -31,6 +31,9 @@ class EpLibraryPlugin : public EpLibrary {
     return factories_;
   }
 
+  // Return the actual library path for plugin-based EpLibrary instances.
+  const std::filesystem::path& GetLibraryPath() const override { return library_path_; }
+
   Status Unload() override;
 
   ORT_DISALLOW_COPY_AND_ASSIGNMENT(EpLibraryPlugin);


### PR DESCRIPTION
This PR adds functionality to expose execution provider plugin library filesystem paths through new APIs:

**Changes:**
- Add virtual `GetLibraryPath()` method to `EpLibrary` base class
- Implement `GetLibraryPath()` override in `EpLibraryPlugin` to return `library_path_`
- Add `Environment::GetExecutionProviderLibraryPath()` public API for thread-safe access to EP library paths
- Enable external applications to resolve custom ops libraries relative to EP plugin locations

**Use Case:**
Allows downstream projects (like win-onnxruntime-genai) to intelligently resolve relative custom ops library paths by using the execution provider plugin location as a base directory.

**API Usage:**
```cpp
onnxruntime::Environment& env = GetEnvironment();
std::filesystem::path ep_lib_path;
auto status = env.GetExecutionProviderLibraryPath("QNNExecutionProvider", ep_lib_path);