### PR TITLE
[CUDA] Add fallback to bfloat16 for cuda 11.8 build

### DIFF
--- a/cmake/external/cuda_configuration.cmake
+++ b/cmake/external/cuda_configuration.cmake
@@ -54,7 +54,7 @@ macro(setup_cuda_compiler)
     message(FATAL_ERROR "No CUDA compiler found")
   endif()
 
-  set(CUDA_REQUIRED_VERSION "11.4")
+  set(CUDA_REQUIRED_VERSION "11.8")
   if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS CUDA_REQUIRED_VERSION)
     message(FATAL_ERROR "CUDA version ${CMAKE_CUDA_COMPILER_VERSION} must be at least ${CUDA_REQUIRED_VERSION}")
   endif()

--- a/onnxruntime/contrib_ops/cuda/bert/cutlass_fmha/fmha_launch_template.h
+++ b/onnxruntime/contrib_ops/cuda/bert/cutlass_fmha/fmha_launch_template.h
@@ -9,6 +9,13 @@
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #endif
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4100)  // Ignore warning C4100: unreferenced format parameter.
+#pragma warning(disable : 4310)  // Ignore warning C4310: cast truncates constant value.
+#pragma warning(disable : 4459)  // Ignore warning C4100: declaration of '_' hides global declaration.
+#endif
+
 #include "contrib_ops/cuda/bert/cutlass_fmha/memory_efficient_attention.h"
 #include "contrib_ops/cuda/bert/cutlass_fmha/kernel_forward.h"
 
@@ -286,6 +293,10 @@ void DispatchBlockSize(const MemoryEfficientAttentionParams& params) {
 
 #if defined(__GNUC__)
 #pragma GCC diagnostic pop
+#endif
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
 #endif
 
 #endif  // USE_MEMORY_EFFICIENT_ATTENTION

--- a/onnxruntime/contrib_ops/cuda/bert/layer_norm.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/layer_norm.cuh
@@ -19,6 +19,7 @@ limitations under the License.
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 #pragma once
 
 #include "core/providers/cuda/cuda_common.h"
@@ -63,11 +64,15 @@ __device__ inline half2 AddHalf2(const half2 a, const half2 b) {
 
 template <>
 __device__ inline nv_bfloat16 Rsqrt(const nv_bfloat16& x) {
+#if defined(__CUDACC__) && defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800 && (CUDA_VERSION < 12020)
+  return nv_bfloat16(rsqrtf(float(x)));
+#else
   return hrsqrt(x);
+#endif
 }
 
 __device__ inline nv_bfloat162 AddHalf2(const nv_bfloat162 a, const nv_bfloat162 b) {
-  return __hadd2(a, b);
+  return a + b;
 }
 
 struct KeyValuePairSum {
@@ -91,10 +96,14 @@ struct KeyValuePairSum {
 
   __device__ inline cub::KeyValuePair<nv_bfloat16, nv_bfloat16> operator()(const cub::KeyValuePair<nv_bfloat16, nv_bfloat16>& a,
                                                                            const cub::KeyValuePair<nv_bfloat16, nv_bfloat16>& b) {
+#if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800)
     const nv_bfloat162 a2 = __halves2bfloat162(a.key, a.value);
     const nv_bfloat162 b2 = __halves2bfloat162(b.key, b.value);
     const nv_bfloat162 res = AddHalf2(a2, b2);
     return cub::KeyValuePair<nv_bfloat16, nv_bfloat16>(__low2bfloat16(res), __high2bfloat16(res));
+#else
+    return cub::KeyValuePair<nv_bfloat16, nv_bfloat16>(a.key + b.key, a.value + b.value);
+#endif
   }
 };
 
@@ -122,7 +131,7 @@ __device__ inline void LayerNorm(
     const int idx = offset + i;
     const T val = output[idx];
     const T g(gamma[i]);
-    const T b = (nullptr == beta) ? (T)0 : beta[i];
+    const T b = (nullptr == beta) ? static_cast<T>(0.0f) : beta[i];
     output[idx] = g * (val - mu) * rsigma + b;
   }
 }

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.cu
@@ -340,20 +340,18 @@ Status FlashAttention(
 
 template <typename T>
 Status QkvToContext(
-    const cudaDeviceProp& device_prop,
-    cublasHandle_t& /*cublas*/,
-    Stream* ort_stream,
-    contrib::PagedAttentionParameters& parameters,
-    PagedAttentionData<T>& data) {
+    [[maybe_unused]] const cudaDeviceProp& device_prop,
+    [[maybe_unused]] cublasHandle_t& /*cublas*/,
+    [[maybe_unused]] Stream* ort_stream,
+    [[maybe_unused]] contrib::PagedAttentionParameters& parameters,
+    [[maybe_unused]] PagedAttentionData<T>& data) {
+#if USE_FLASH_ATTENTION
   auto stream = static_cast<cudaStream_t>(ort_stream->GetHandle());
   const float scale = parameters.scale == 0.0f ? 1.f / sqrt(static_cast<float>(parameters.head_size)) : parameters.scale;
-
-#if USE_FLASH_ATTENTION
   if (data.use_flash_attention) {
     return FlashAttention(device_prop, stream, parameters, data, scale);
   }
 #endif
-
   return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Unfused Paged Attention not implemented.");
 }
 

--- a/onnxruntime/contrib_ops/cuda/bert/skip_layer_norm_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/skip_layer_norm_impl.cu
@@ -98,7 +98,7 @@ __global__ void SkipLayerNormKernel(
 
   // Reduce sum of x and x^2, and the results are divided by ld.
   KeyValuePairSum pair_sum;
-  cub::KeyValuePair<T, T> thread_data(0, 0);
+  cub::KeyValuePair<T, T> thread_data(0.0f, 0.0f);
 
   for (int i = threadIdx.x; i < ld; i += TPB) {
     const int idx = offset + i;
@@ -187,9 +187,18 @@ __global__ void SkipLayerNormKernelSmall(
 
 template <typename T, bool Simplified>
 void LaunchSkipLayerNormKernel(
-    cudaStream_t stream, T* output, T* sum_output,
-    const T* input, const T* skip, const T* bias, const T* gamma, const T* beta, float epsilon,
-    int ld, int row_count, int skip_size) {
+    [[maybe_unused]] cudaStream_t stream,
+    [[maybe_unused]] T* output,
+    [[maybe_unused]] T* sum_output,
+    [[maybe_unused]] const T* input,
+    [[maybe_unused]] const T* skip,
+    [[maybe_unused]] const T* bias,
+    [[maybe_unused]] const T* gamma,
+    [[maybe_unused]] const T* beta,
+    [[maybe_unused]] float epsilon,
+    [[maybe_unused]] int ld,
+    [[maybe_unused]] int row_count,
+    [[maybe_unused]] int skip_size) {
   const int next_size = NextSize(ld);
   const int grid_size = row_count;
   bool can_unroll_vec4 = CanVectorized(output, sum_output, input,
@@ -271,6 +280,7 @@ SKIPLAYERNORM_IMPL(half, true);
 SKIPLAYERNORM_IMPL(half, false);
 SKIPLAYERNORM_IMPL(nv_bfloat16, true);
 SKIPLAYERNORM_IMPL(nv_bfloat16, false);
+
 }  // namespace cuda
 }  // namespace contrib
 }  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/moe/ft_moe/moe_gemm_kernels_template.h
+++ b/onnxruntime/contrib_ops/cuda/moe/ft_moe/moe_gemm_kernels_template.h
@@ -24,6 +24,8 @@
 #if defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable : 4100)
+#pragma warning(disable : 4310)
+#pragma warning(disable : 4459)
 #endif
 
 #include "cutlass/arch/arch.h"

--- a/onnxruntime/contrib_ops/cuda/quantization/dequantize_blockwise.cuh
+++ b/onnxruntime/contrib_ops/cuda/quantization/dequantize_blockwise.cuh
@@ -130,3 +130,11 @@ Status DequantizeBlockwise8b(
 }  // namespace cuda
 }  // namespace contrib
 }  // namespace onnxruntime
+
+// Macro to reduce repetitive fallback code
+#define DECLARE_DEQUANTIZE_FALLBACK(FuncName, T, ZeroT, MIN_ARCH, TYPENAME)                                      \
+  template <>                                                                                                    \
+  Status FuncName<T, ZeroT>(                                                                                     \
+      T*, const uint8_t*, const T*, const ZeroT*, const int32_t*, int, int, int, cudaStream_t) {                 \
+    return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED, TYPENAME " requires compute capability >= " #MIN_ARCH); \
+  }

--- a/onnxruntime/contrib_ops/cuda/quantization/dequantize_blockwise_8bits.cu
+++ b/onnxruntime/contrib_ops/cuda/quantization/dequantize_blockwise_8bits.cu
@@ -272,6 +272,7 @@ template Status Dequantize8Bits<half, uint8_t>(
     int block_size,
     cudaStream_t stream);
 
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
 template Status Dequantize8Bits<__nv_bfloat16, uint8_t>(
     __nv_bfloat16* output,
     const uint8_t* quant_data,
@@ -282,6 +283,9 @@ template Status Dequantize8Bits<__nv_bfloat16, uint8_t>(
     int n,
     int block_size,
     cudaStream_t stream);
+#else
+DECLARE_DEQUANTIZE_FALLBACK(Dequantize8Bits, __nv_bfloat16, uint8_t, 8.0, "BFloat16")
+#endif
 
 template Status Dequantize8Bits<float, float>(
     float* output,
@@ -305,6 +309,7 @@ template Status Dequantize8Bits<half, half>(
     int block_size,
     cudaStream_t stream);
 
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
 template Status Dequantize8Bits<__nv_bfloat16, __nv_bfloat16>(
     __nv_bfloat16* output,
     const uint8_t* quant_data,
@@ -315,6 +320,10 @@ template Status Dequantize8Bits<__nv_bfloat16, __nv_bfloat16>(
     int n,
     int block_size,
     cudaStream_t stream);
+#else
+DECLARE_DEQUANTIZE_FALLBACK(Dequantize8Bits, __nv_bfloat16, __nv_bfloat16, 8.0, "BFloat16")
+#endif
+#undef DECLARE_DEQUANTIZE_FALLBACK
 
 // Generic dequantization kernel for 8 bits
 template <
@@ -518,6 +527,7 @@ template Status DequantizeBlockwise8b<half>(
     int columns,
     cudaStream_t stream);
 
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
 template Status DequantizeBlockwise8b<__nv_bfloat16>(
     __nv_bfloat16* dst,
     const uint8_t* src,
@@ -528,6 +538,13 @@ template Status DequantizeBlockwise8b<__nv_bfloat16>(
     int rows,
     int columns,
     cudaStream_t stream);
+#else
+template <>
+Status DequantizeBlockwise8b<__nv_bfloat16>(
+    __nv_bfloat16*, const uint8_t*, const __nv_bfloat16*, const uint8_t*, int, bool, int, int, cudaStream_t) {
+  return Status::OK();
+}
+#endif
 
 }  // namespace cuda
 }  // namespace contrib

--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.cc
@@ -8,6 +8,7 @@
 #include "core/common/status.h"
 #include "core/framework/float16.h"
 #include "core/providers/cpu/math/matmul_helper.h"
+#include "core/providers/cuda/cu_inc/common.cuh"
 #include "core/providers/cuda/cuda_type_conversion.h"
 #include "contrib_ops/cuda/utils/dump_cuda_tensor.h"
 #include "contrib_ops/cpu/utils/dump_tensor.h"
@@ -254,12 +255,7 @@ Status MatMulNBits<T>::PrePack_ZeroPoint([[maybe_unused]] const Tensor& tensor,
 
 template <typename T>
 Status MatMulNBits<T>::ComputeInternal(OpKernelContext* ctx) const {
-  if constexpr (std::is_same_v<T, BFloat16>) {
-    if (sm_ < 80) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED,
-                             "BFloat16 MatMulNBits is not supported on cuda device with compute capability < 8.0");
-    }
-  }
+  CHECK_GPU_SUPPORT_DATA_TYPE(T, sm_);
 
   const Tensor* a = ctx->Input<Tensor>(0);
   const Tensor* reorder_idx = ctx->Input<Tensor>(4);

--- a/onnxruntime/contrib_ops/cuda/quantization/moe_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/quantization/moe_quantization.cc
@@ -54,9 +54,8 @@ Status QMoE<T>::QuantizedMoEImpl(OpKernelContext* context,
                                  const Tensor* fc2_scales,
                                  const Tensor* fc3_scales_optional,
                                  const cudaDeviceProp& device_prop) const {
-  auto stream = context->GetComputeStream();
-
   const int sm = device_prop.major * 10 + device_prop.minor;
+  CHECK_GPU_SUPPORT_DATA_TYPE(T, sm);
 
   AllocatorPtr allocator;
   ORT_RETURN_IF_ERROR(context->GetTempSpaceAllocator(&allocator));
@@ -78,6 +77,7 @@ Status QMoE<T>::QuantizedMoEImpl(OpKernelContext* context,
   size_t expanded_source_row_to_expanded_dest_row_size = k_ * moe_params.num_rows * sizeof(int);
   size_t expert_for_source_row_size = k_ * moe_params.num_rows * sizeof(int);
 
+  auto stream = context->GetComputeStream();
   IAllocatorUniquePtr<void> work_space = IAllocator::MakeUniquePtr<void>(allocator, ws_size, false, stream);
   IAllocatorUniquePtr<void> fc2_output = IAllocator::MakeUniquePtr<void>(allocator, fc2_output_size, false, stream);
   IAllocatorUniquePtr<void> expert_scales =


### PR DESCRIPTION
CUDA 11.8 has no definition for bf16 functions for cuda arch < 800. Some recent bf16 kernels causes build error with cuda 11.8. This fixes the build error (see https://github.com/microsoft/onnxruntime/issues/25162)


