### PR TITLE
Add custom ops library_path to EP metadata

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_ep_device_ep_metadata_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_ep_device_ep_metadata_keys.h
@@ -9,7 +9,11 @@
 // Key for the execution provider version string. This should be available for all plugin EPs.
 static const char* const kOrtEpDevice_EpMetadataKey_Version = "version";
 
+
 // Prefix for execution provider compatibility information stored in model metadata.
 // Used when generating EP context models to store compatibility strings for each EP.
 // Full key format: "ep_compatibility_info.<EP_TYPE>"
 static const char* const kOrtModelMetadata_EpCompatibilityInfoPrefix = "ep_compatibility_info.";
+
+// Key for the execution provider library path (for dynamically loaded EPs)
+static const char* const kOrtEpDevice_EpMetadataKey_LibraryPath = "library_path";

--- a/include/onnxruntime/core/session/onnxruntime_ep_device_ep_metadata_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_ep_device_ep_metadata_keys.h
@@ -9,7 +9,6 @@
 // Key for the execution provider version string. This should be available for all plugin EPs.
 static const char* const kOrtEpDevice_EpMetadataKey_Version = "version";
 
-
 // Prefix for execution provider compatibility information stored in model metadata.
 // Used when generating EP context models to store compatibility strings for each EP.
 // Full key format: "ep_compatibility_info.<EP_TYPE>"

--- a/onnxruntime/core/session/plugin_ep/ep_factory_provider_bridge.cc
+++ b/onnxruntime/core/session/plugin_ep/ep_factory_provider_bridge.cc
@@ -4,6 +4,8 @@
 #include "core/session/plugin_ep/ep_factory_provider_bridge.h"
 
 #include "core/providers/shared_library/provider_host_api.h"
+#include "core/session/plugin_ep/ep_library_plugin.h"
+#include "core/session/onnxruntime_ep_device_ep_metadata_keys.h"
 
 namespace onnxruntime {
 OrtStatus* ProviderBridgeEpFactory::GetSupportedDevices(EpFactoryInternal& ep_factory,
@@ -20,6 +22,11 @@ OrtStatus* ProviderBridgeEpFactory::GetSupportedDevices(EpFactoryInternal& ep_fa
     auto* ep_device = ep_devices[i];
     if (ep_device) {
       ep_device->ep_factory = &ep_factory;
+
+      // Add library path to EP metadata if available
+      if (library_path_.has_value()) {
+        ep_device->ep_metadata.Add(kOrtEpDevice_EpMetadataKey_LibraryPath, library_path_->string());
+      }
     }
   }
 

--- a/onnxruntime/core/session/plugin_ep/ep_factory_provider_bridge.h
+++ b/onnxruntime/core/session/plugin_ep/ep_factory_provider_bridge.h
@@ -3,6 +3,9 @@
 
 #pragma once
 
+#include <filesystem>
+#include <optional>
+
 #include "core/framework/error_code_helper.h"
 #include "core/session/abi_devices.h"
 #include "core/session/abi_session_options_impl.h"
@@ -12,12 +15,14 @@
 namespace onnxruntime {
 class ProviderBridgeEpFactory : public EpFactoryInternalImpl {
  public:
-  ProviderBridgeEpFactory(OrtEpFactory& ep_factory, ProviderLibrary& provider_library)
+  ProviderBridgeEpFactory(OrtEpFactory& ep_factory, ProviderLibrary& provider_library,
+                          std::optional<std::filesystem::path> library_path = std::nullopt)
       : EpFactoryInternalImpl(ep_factory.GetName(&ep_factory),
                               ep_factory.GetVendor(&ep_factory),
                               ep_factory.GetVendorId(&ep_factory)),
         ep_factory_{ep_factory},
-        provider_library_{provider_library} {
+        provider_library_{provider_library},
+        library_path_{std::move(library_path)} {
   }
 
  private:
@@ -61,6 +66,7 @@ class ProviderBridgeEpFactory : public EpFactoryInternalImpl {
 
   OrtEpFactory& ep_factory_;           // OrtEpFactory from the provider bridge EP
   ProviderLibrary& provider_library_;  // ProviderLibrary from the provider bridge EP
+  std::optional<std::filesystem::path> library_path_;  // Library path for EP metadata
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/session/plugin_ep/ep_factory_provider_bridge.h
+++ b/onnxruntime/core/session/plugin_ep/ep_factory_provider_bridge.h
@@ -65,9 +65,9 @@ class ProviderBridgeEpFactory : public EpFactoryInternalImpl {
     return ep_factory_.CreateSyncStreamForDevice(&ep_factory_, device, stream_options, stream);
   }
 
-  OrtEpFactory& ep_factory_;           // OrtEpFactory from the provider bridge EP
-  ProviderLibrary& provider_library_;  // ProviderLibrary from the provider bridge EP
-  std::optional<std::filesystem::path> library_path_;  // Library path for EP metadata
+  OrtEpFactory& ep_factory_;
+  ProviderLibrary& provider_library_;
+  std::optional<std::filesystem::path> library_path_;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/session/plugin_ep/ep_factory_provider_bridge.h
+++ b/onnxruntime/core/session/plugin_ep/ep_factory_provider_bridge.h
@@ -5,6 +5,7 @@
 
 #include <filesystem>
 #include <optional>
+#include <utility>
 
 #include "core/framework/error_code_helper.h"
 #include "core/session/abi_devices.h"

--- a/onnxruntime/core/session/plugin_ep/ep_library.h
+++ b/onnxruntime/core/session/plugin_ep/ep_library.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <filesystem>
 #include <string>
 #include "core/common/status.h"
 #include "core/framework/provider_options.h"
@@ -24,9 +23,6 @@ class EpLibrary {
   virtual Status Load() { return Status::OK(); }
   virtual const std::vector<OrtEpFactory*>& GetFactories() = 0;  // valid after Load()
   virtual Status Unload() { return Status::OK(); }
-
-  // Get the library path for this EP library (empty for internal EPs)
-  virtual std::filesystem::path GetLibraryPath() const { return std::filesystem::path{}; }
 
   virtual ~EpLibrary() = default;
 

--- a/onnxruntime/core/session/plugin_ep/ep_library.h
+++ b/onnxruntime/core/session/plugin_ep/ep_library.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <filesystem>
 #include <string>
 #include "core/common/status.h"
 #include "core/framework/provider_options.h"
@@ -23,6 +24,10 @@ class EpLibrary {
   virtual Status Load() { return Status::OK(); }
   virtual const std::vector<OrtEpFactory*>& GetFactories() = 0;  // valid after Load()
   virtual Status Unload() { return Status::OK(); }
+
+  // Get the library path for this EP library (empty for internal EPs)
+  virtual std::filesystem::path GetLibraryPath() const { return std::filesystem::path{}; }
+
   virtual ~EpLibrary() = default;
 
   ORT_DISALLOW_COPY_AND_ASSIGNMENT(EpLibrary);

--- a/onnxruntime/core/session/plugin_ep/ep_library_plugin.h
+++ b/onnxruntime/core/session/plugin_ep/ep_library_plugin.h
@@ -33,11 +33,6 @@ class EpLibraryPlugin : public EpLibrary {
 
   Status Unload() override;
 
-  // Get the library path for this plugin EP
-  std::filesystem::path GetLibraryPath() const override {
-    return library_path_;
-  }
-
   ORT_DISALLOW_COPY_AND_ASSIGNMENT(EpLibraryPlugin);
 
  private:

--- a/onnxruntime/core/session/plugin_ep/ep_library_plugin.h
+++ b/onnxruntime/core/session/plugin_ep/ep_library_plugin.h
@@ -33,6 +33,11 @@ class EpLibraryPlugin : public EpLibrary {
 
   Status Unload() override;
 
+  // Get the library path for this plugin EP
+  std::filesystem::path GetLibraryPath() const override {
+    return library_path_;
+  }
+
   ORT_DISALLOW_COPY_AND_ASSIGNMENT(EpLibraryPlugin);
 
  private:

--- a/onnxruntime/core/session/plugin_ep/ep_library_provider_bridge.cc
+++ b/onnxruntime/core/session/plugin_ep/ep_library_provider_bridge.cc
@@ -4,6 +4,7 @@
 #include "core/session/plugin_ep/ep_library_provider_bridge.h"
 
 #include "core/session/plugin_ep/ep_factory_provider_bridge.h"
+#include "core/session/plugin_ep/ep_library_plugin.h"
 
 namespace onnxruntime {
 Status EpLibraryProviderBridge::Load() {
@@ -26,8 +27,16 @@ Status EpLibraryProviderBridge::Load() {
   // to do this we need to capture `factory` and plug it in to is_supported_fn and create_fn.
   // we also need to update any returned OrtEpDevice instances to swap the wrapper EpFactoryInternal in so that we can
   // call Provider::CreateIExecutionProvider in EpFactoryInternal::CreateIExecutionProvider.
+
+  // Get library path from the EpLibrary using the virtual method
+  auto library_path = ep_library_plugin_->GetLibraryPath();
+  std::optional<std::filesystem::path> library_path_opt;
+  if (!library_path.empty()) {
+    library_path_opt = library_path;
+  }
+
   for (const auto& factory : ep_library_plugin_->GetFactories()) {
-    auto factory_impl = std::make_unique<ProviderBridgeEpFactory>(*factory, *provider_library_);
+    auto factory_impl = std::make_unique<ProviderBridgeEpFactory>(*factory, *provider_library_, library_path_opt);
     auto internal_factory = std::make_unique<EpFactoryInternal>(std::move(factory_impl));
 
     factory_ptrs_.push_back(internal_factory.get());

--- a/onnxruntime/core/session/plugin_ep/ep_library_provider_bridge.cc
+++ b/onnxruntime/core/session/plugin_ep/ep_library_provider_bridge.cc
@@ -28,15 +28,8 @@ Status EpLibraryProviderBridge::Load() {
   // we also need to update any returned OrtEpDevice instances to swap the wrapper EpFactoryInternal in so that we can
   // call Provider::CreateIExecutionProvider in EpFactoryInternal::CreateIExecutionProvider.
 
-  // Get library path from the EpLibrary using the virtual method
-  auto library_path = ep_library_plugin_->GetLibraryPath();
-  std::optional<std::filesystem::path> library_path_opt;
-  if (!library_path.empty()) {
-    library_path_opt = library_path;
-  }
-
   for (const auto& factory : ep_library_plugin_->GetFactories()) {
-    auto factory_impl = std::make_unique<ProviderBridgeEpFactory>(*factory, *provider_library_, library_path_opt);
+    auto factory_impl = std::make_unique<ProviderBridgeEpFactory>(*factory, *provider_library_, library_path_);
     auto internal_factory = std::make_unique<EpFactoryInternal>(std::move(factory_impl));
 
     factory_ptrs_.push_back(internal_factory.get());

--- a/onnxruntime/core/session/plugin_ep/ep_library_provider_bridge.h
+++ b/onnxruntime/core/session/plugin_ep/ep_library_provider_bridge.h
@@ -21,9 +21,11 @@ namespace onnxruntime {
 class EpLibraryProviderBridge : public EpLibrary {
  public:
   EpLibraryProviderBridge(std::unique_ptr<ProviderLibrary> provider_library,
-                          std::unique_ptr<EpLibrary> ep_library_plugin)
+                          std::unique_ptr<EpLibrary> ep_library_plugin,
+                          std::optional<std::filesystem::path> library_path = std::nullopt)
       : provider_library_{std::move(provider_library)},
-        ep_library_plugin_{std::move(ep_library_plugin)} {
+        ep_library_plugin_{std::move(ep_library_plugin)},
+        library_path_{std::move(library_path)} {
   }
 
   const char* RegistrationName() const override {
@@ -39,10 +41,6 @@ class EpLibraryProviderBridge : public EpLibrary {
     return internal_factory_ptrs_;
   }
 
-  std::filesystem::path GetLibraryPath() const override {
-    return ep_library_plugin_->GetLibraryPath();
-  }
-
   Status Load() override;
   Status Unload() override;
 
@@ -56,6 +54,9 @@ class EpLibraryProviderBridge : public EpLibrary {
   // we wrap the OrtEpFactory instances it contains to pass through function calls, and
   // implement EpFactoryInternal::CreateIExecutionProvider by calling Provider::CreateIExecutionProvider.
   std::unique_ptr<EpLibrary> ep_library_plugin_;
+
+  // Library path for EP metadata
+  std::optional<std::filesystem::path> library_path_;
 
   std::vector<std::unique_ptr<EpFactoryInternal>> factories_;
   std::vector<OrtEpFactory*> factory_ptrs_;                // for convenience

--- a/onnxruntime/core/session/plugin_ep/ep_library_provider_bridge.h
+++ b/onnxruntime/core/session/plugin_ep/ep_library_provider_bridge.h
@@ -39,6 +39,10 @@ class EpLibraryProviderBridge : public EpLibrary {
     return internal_factory_ptrs_;
   }
 
+  std::filesystem::path GetLibraryPath() const override {
+    return ep_library_plugin_->GetLibraryPath();
+  }
+
   Status Load() override;
   Status Unload() override;
 

--- a/onnxruntime/core/session/utils.cc
+++ b/onnxruntime/core/session/utils.cc
@@ -421,13 +421,14 @@ Status LoadPluginOrProviderBridge(const std::string& registration_name,
                      << (is_provider_bridge ? " as a provider bridge" : " as a plugin");
 
   // create EpLibraryPlugin to ensure CreateEpFactories and ReleaseEpFactory are available
-  auto ep_library_plugin = std::make_unique<EpLibraryPlugin>(registration_name, std::move(resolved_library_path));
+  auto ep_library_plugin = std::make_unique<EpLibraryPlugin>(registration_name, resolved_library_path);
   ORT_RETURN_IF_ERROR(ep_library_plugin->Load());
 
   if (is_provider_bridge) {
     // wrap the EpLibraryPlugin with EpLibraryProviderBridge to add to directly create an IExecutionProvider
     auto ep_library_provider_bridge = std::make_unique<EpLibraryProviderBridge>(std::move(provider_library),
-                                                                                std::move(ep_library_plugin));
+                                                                                std::move(ep_library_plugin),
+                                                                                resolved_library_path);
     ORT_RETURN_IF_ERROR(ep_library_provider_bridge->Load());
     internal_factories = ep_library_provider_bridge->GetInternalFactories();
     ep_library = std::move(ep_library_provider_bridge);


### PR DESCRIPTION
## Summary
Adds EP metadata library path support to enable custom ops DLL registration with proper path resolution.

## Changes
- Added `library_path` metadata key to EP metadata infrastructure
- Pass resolved library path directly to `EpLibraryProviderBridge` constructor
- Simplified implementation per reviewer feedback (removed virtual method complexity)
- Added `#include <utility>` for std::move compliance

## Purpose
Enables downstream applications (like onnxruntime-genai) to resolve relative custom ops library paths using EP metadata, improving DLL registration reliability.

## Files Modified
- `plugin_ep/ep_factory_provider_bridge.h`
- `plugin_ep/ep_library.h` 
- `plugin_ep/ep_library_plugin.h`
- `plugin_ep/ep_library_provider_bridge.cc`
- `plugin_ep/ep_library_provider_bridge.h`
- `utils.cc`