### PR TITLE
Fix a typo in ORT_API_CALL macro (_stdcall)

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -87,7 +87,7 @@ extern "C" {
 #else
 #define ORT_EXPORT
 #endif
-#define ORT_API_CALL _stdcall
+#define ORT_API_CALL __stdcall
 #define ORT_MUST_USE_RESULT
 #define ORTCHAR_T wchar_t
 #else


### PR DESCRIPTION
### Description
Fixed the macro `ORT_API_CALL` by replacing `_stdcall` with `__stdcall`



### Motivation and Context
Recently, I found an issue that prevents ONNX Runtime from being built using the MinGW toolchain on Windows.

After investigating, I discovered that the ONNX Runtime C API header contains a typo in the `ORT_API_CALL` preprocessor macro.
It is incorrectly defined as `_stdcall` instead of the correct `__stdcall` (with two leading underscores).
This causes build failures on compilers like MinGW that are strict about this syntax.


