### PR TITLE
Add API for precompiled model compatibility check using just the compat info

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -33,6 +33,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include "onnxruntime_common_enums.h"
 
 /** \brief The API version defined in this header
  *
@@ -6480,6 +6481,20 @@ struct OrtApi {
    * \since Version 1.23.
    */
   ORT_API2_STATUS(Graph_GetModelMetadata, _In_ const OrtGraph* graph, _Outptr_ OrtModelMetadata** out);
+
+  /** \brief Validate a compiled model's compatibility information for a specific EP device.
+   *
+   * \param[in] ep_device The EP device to validate against (e.g., from GetEpDevices
+   * \param[in] compatibility_info The compatibility info string produced when the model was compiled.
+   * \param[out] out_status The resulting compatibility status for the EP device.
+   *
+   * \snippet{doc} snippets.dox OrtStatus Return Value
+   *
+   * \since Version 1.23.
+   */
+  ORT_API2_STATUS(GetEpCompatibilityForDevice, _In_ const OrtEpDevice* ep_device,
+                  _In_ const char* compatibility_info,
+                  _Out_ OrtCompiledModelCompatibility* out_status);
 };
 
 /*

--- a/include/onnxruntime/core/session/onnxruntime_common_enums.h
+++ b/include/onnxruntime/core/session/onnxruntime_common_enums.h
@@ -1,0 +1,18 @@
+// Shared public enums used by both onnxruntime_c_api.h and onnxruntime_ep_c_api.h
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Compatibility state of a compiled model relative to an execution provider.
+typedef enum OrtCompiledModelCompatibility {
+    OrtCompiledModelCompatibility_EP_NOT_APPLICABLE = 0,
+    OrtCompiledModelCompatibility_EP_SUPPORTED_OPTIMAL,
+    OrtCompiledModelCompatibility_EP_SUPPORTED_PREFER_RECOMPILATION,
+    OrtCompiledModelCompatibility_EP_UNSUPPORTED,
+  } OrtCompiledModelCompatibility;
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 // Do not include this file directly. Please include "onnxruntime_c_api.h" instead.
+#include "onnxruntime_common_enums.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -481,18 +482,6 @@ typedef enum OrtEpDataLayout {
 
   OrtEpDataLayout_Default = OrtEpDataLayout_NCHW,
 } OrtEpDataLayout;
-
-/**
- * \brief Enumeration describing the compatibility state of a compiled model relative to an execution provider.
- *
- * \since Version 1.23.
- */
-typedef enum OrtCompiledModelCompatibility {
-  OrtCompiledModelCompatibility_EP_NOT_APPLICABLE = 0,
-  OrtCompiledModelCompatibility_EP_SUPPORTED_OPTIMAL,
-  OrtCompiledModelCompatibility_EP_SUPPORTED_PREFER_RECOMPILATION,
-  OrtCompiledModelCompatibility_EP_UNSUPPORTED,
-} OrtCompiledModelCompatibility;
 
 /**
  * \brief The OrtEp struct provides functions to implement for an execution provider.

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -636,6 +636,11 @@ ORT_API_STATUS_IMPL(ValueInfo_IsFromOuterScope, _In_ const OrtValueInfo* value_i
 // OrtGraph
 ORT_API_STATUS_IMPL(Graph_GetName, _In_ const OrtGraph* graph, _Outptr_ const char** graph_name);
 ORT_API_STATUS_IMPL(Graph_GetModelMetadata, _In_ const OrtGraph* graph, _Outptr_ OrtModelMetadata** out);
+
+// EP Compatibility Info APIs
+ORT_API_STATUS_IMPL(GetEpCompatibilityForDevice, _In_ const OrtEpDevice* ep_device,
+                    _In_ const char* compatibility_info,
+                    _Out_ OrtCompiledModelCompatibility* out_status);
 ORT_API_STATUS_IMPL(Graph_GetModelPath, _In_ const OrtGraph* graph, _Outptr_ const ORTCHAR_T** model_path);
 ORT_API_STATUS_IMPL(Graph_GetOnnxIRVersion, _In_ const OrtGraph* graph, _Out_ int64_t* onnx_ir_version);
 ORT_API_STATUS_IMPL(Graph_GetNumOperatorSets, _In_ const OrtGraph* graph, _Out_ size_t* num_operator_sets);

--- a/onnxruntime/test/framework/ep_compatibility_test.cc
+++ b/onnxruntime/test/framework/ep_compatibility_test.cc
@@ -408,3 +408,91 @@ TEST_F(EpCompatibilityTest, TestSessionOptionConfiguration) {
   EXPECT_TRUE(has_config);
   EXPECT_EQ(config_value, "0");
 }
+
+// -----------------------------
+// C API unit tests
+// -----------------------------
+
+namespace {
+
+// Helper to create an OrtEnv and fetch a CPU EP device pointer via the C API.
+// Returns a pair of (env, cpu_device). Caller releases env via api->ReleaseEnv.
+static std::pair<OrtEnv*, const OrtEpDevice*> CreateEnvAndGetCpuEpDevice(const OrtApi* api) {
+  OrtEnv* env = nullptr;
+  EXPECT_EQ(nullptr, api->CreateEnv(ORT_LOGGING_LEVEL_WARNING, "EpCompatCapiTest", &env));
+  EXPECT_NE(env, nullptr);
+
+  const OrtEpDevice* const* devices = nullptr;
+  size_t num_devices = 0;
+  EXPECT_EQ(nullptr, api->GetEpDevices(env, &devices, &num_devices));
+  EXPECT_GT(num_devices, 0u);
+
+  const OrtEpDevice* cpu_device = nullptr;
+  for (size_t i = 0; i < num_devices; ++i) {
+    const char* name = api->EpDevice_EpName(devices[i]);
+    if (name && std::string(name) == "CPUExecutionProvider") {
+      cpu_device = devices[i];
+      break;
+    }
+  }
+
+  // Fallback: just pick the first device if CPU wasn't found (environment-dependent builds).
+  if (!cpu_device && num_devices > 0) {
+    cpu_device = devices[0];
+  }
+
+  EXPECT_NE(cpu_device, nullptr);
+  return {env, cpu_device};
+}
+
+}  // namespace
+
+TEST(EpCompatibilityCapiTest, InvalidArguments) {
+  const OrtApi* api = OrtGetApiBase()->GetApi(ORT_API_VERSION);
+  ASSERT_NE(api, nullptr);
+
+  OrtCompiledModelCompatibility out_status = OrtCompiledModelCompatibility_EP_NOT_APPLICABLE;
+
+  // ep_device == nullptr
+  OrtStatus* st = api->GetEpCompatibilityForDevice(nullptr, "info", &out_status);
+  ASSERT_NE(st, nullptr);
+  EXPECT_EQ(api->GetErrorCode(st), ORT_INVALID_ARGUMENT);
+  api->ReleaseStatus(st);
+
+  // Prepare a valid device
+  auto [env, device] = CreateEnvAndGetCpuEpDevice(api);
+  ASSERT_NE(env, nullptr);
+  ASSERT_NE(device, nullptr);
+
+  // compatibility_info == nullptr
+  st = api->GetEpCompatibilityForDevice(device, nullptr, &out_status);
+  ASSERT_NE(st, nullptr);
+  EXPECT_EQ(api->GetErrorCode(st), ORT_INVALID_ARGUMENT);
+  api->ReleaseStatus(st);
+
+  // out_status == nullptr
+  st = api->GetEpCompatibilityForDevice(device, "some-info", nullptr);
+  ASSERT_NE(st, nullptr);
+  EXPECT_EQ(api->GetErrorCode(st), ORT_INVALID_ARGUMENT);
+  api->ReleaseStatus(st);
+
+  api->ReleaseEnv(env);
+}
+
+TEST(EpCompatibilityCapiTest, CpuEpReturnsNotApplicableIfNoValidation) {
+  const OrtApi* api = OrtGetApiBase()->GetApi(ORT_API_VERSION);
+  ASSERT_NE(api, nullptr);
+
+  auto [env, device] = CreateEnvAndGetCpuEpDevice(api);
+  ASSERT_NE(env, nullptr);
+  ASSERT_NE(device, nullptr);
+
+  OrtCompiledModelCompatibility out_status = static_cast<OrtCompiledModelCompatibility>(-1);
+  OrtStatus* st = api->GetEpCompatibilityForDevice(device, "arbitrary-compat-string", &out_status);
+  ASSERT_EQ(st, nullptr) << (st ? api->GetErrorMessage(st) : "");
+
+  // For providers that don't implement validation, API should return EP_NOT_APPLICABLE.
+  EXPECT_EQ(out_status, OrtCompiledModelCompatibility_EP_NOT_APPLICABLE);
+
+  api->ReleaseEnv(env);
+}


### PR DESCRIPTION
### Description
This PR adds a new API that applications can use to verify compatibility of a precompiled model with the underlying system, using only the compatibility info string from the model's metadata. 

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- This is a feature to enable apps to check compatibility of a precompiled model without necessarily having the model locally on the device. This enables precompiled models to be stored remotely and downloaded once the application has been able to confirm the validity of a given model with EPs on the device. 


