### PR TITLE
Add ort api for CustomOp compute events.

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -6480,6 +6480,14 @@ struct OrtApi {
    * \since Version 1.23.
    */
   ORT_API2_STATUS(Graph_GetModelMetadata, _In_ const OrtGraph* graph, _Outptr_ OrtModelMetadata** out);
+
+  /** \brief Push Custom Op Compute profiling events back to Onnxruntime Profiler Events.
+   *
+   * \param[in] context OrtKernelContext instance
+   * \param[in] CustomOp Kernel Compute profiling events vector.
+   *
+   */
+  ORT_API2_STATUS(KernelContext_RecordCustomEventsToProfiler, _In_ const OrtKernelContext* context, _In_ void* events);
 };
 
 /*

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -2543,6 +2543,7 @@ struct KernelContext {
   OrtAllocator* GetAllocator(const OrtMemoryInfo& memory_info) const;
   OrtKernelContext* GetOrtKernelContext() const { return ctx_; }
   void ParallelFor(void (*fn)(void*, size_t), size_t total, size_t num_batch, void* usr_data) const;
+  void* RecordCustomEventsToProfiler(void* events) const;
 
  private:
   OrtKernelContext* ctx_;

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -2455,6 +2455,12 @@ inline void KernelContext::ParallelFor(void (*fn)(void*, size_t), size_t total, 
   ThrowOnError(GetApi().KernelContext_ParallelFor(ctx_, fn, total, num_batch, usr_data));
 }
 
+inline void* KernelContext::RecordCustomEventsToProfiler(void* events) const {
+  void* out = nullptr;
+  ThrowOnError(GetApi().KernelContext_RecordCustomEventsToProfiler(ctx_, events));
+  return out;
+}
+
 inline OpAttr::OpAttr(const char* name, const void* data, int len, OrtOpAttrType type) {
   Ort::ThrowOnError(GetApi().CreateOpAttr(name, data, len, type, &p_));
 }

--- a/onnxruntime/core/common/profiler.h
+++ b/onnxruntime/core/common/profiler.h
@@ -119,6 +119,13 @@ class Profiler {
     }
   }
 
+  void RecordCustomEvents(Events& events) noexcept {
+    for (auto& e : events) {
+      e.ts = e.ts - std::chrono::duration_cast<std::chrono::microseconds>(profiling_start_time_.time_since_epoch()).count();
+      events_.emplace_back(e);
+    }
+  };
+
  private:
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(Profiler);
 

--- a/onnxruntime/core/framework/op_kernel_context_internal.h
+++ b/onnxruntime/core/framework/op_kernel_context_internal.h
@@ -104,6 +104,8 @@ class OpKernelContextInternal : public OpKernelContext {
 
   const bool& GetTerminateFlag() const noexcept { return terminate_flag_; }
 
+  void RecordCustomEventsToProfiler(profiling::Events& events) const noexcept { session_state_.Profiler().RecordCustomEvents(events); }
+
  private:
 #if !defined(ORT_MINIMAL_BUILD)
   class AccountingAllocator : public IAllocator {

--- a/onnxruntime/core/session/custom_ops.cc
+++ b/onnxruntime/core/session/custom_ops.cc
@@ -761,6 +761,14 @@ ORT_API_STATUS_IMPL(OrtApis::KernelContext_GetScratchBuffer, _In_ const OrtKerne
   return nullptr;
 };
 
+ORT_API_STATUS_IMPL(OrtApis::KernelContext_RecordCustomEventsToProfiler, _In_ const OrtKernelContext* context,
+                    _In_ void* events) {
+  return ExecuteIfKernelContextApiEnabled([&]() -> OrtStatusPtr {
+    reinterpret_cast<const onnxruntime::OpKernelContextInternal*>(context)->RecordCustomEventsToProfiler(*(reinterpret_cast<onnxruntime::profiling::Events*>(events)));
+    return nullptr;
+  });
+};
+
 #if ENABLE_CUSTOM_OP_API
 #include "core/framework/customregistry.h"
 namespace onnxruntime {

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -4108,6 +4108,7 @@ static constexpr OrtApi ort_api_1_to_23 = {
     &OrtApis::CopyTensors,
 
     &OrtApis::Graph_GetModelMetadata,
+    &OrtApis::KernelContext_RecordCustomEventsToProfiler,
 };
 
 // OrtApiBase can never change as there is no way to know what version of OrtApiBase is returned by OrtGetApiBase.

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -741,4 +741,6 @@ ORT_API_STATUS_IMPL(CopyTensors, _In_ const OrtEnv* env,
                     _In_reads_(num_tensors) OrtValue* const* dst_tensors,
                     _In_opt_ OrtSyncStream* stream,
                     _In_ size_t num_tensors);
+
+ORT_API_STATUS_IMPL(KernelContext_RecordCustomEventsToProfiler, _In_ const OrtKernelContext* context, _In_ void* events);
 }  // namespace OrtApis


### PR DESCRIPTION
CustomOp compute can return events to onnxruntime Profiler Events, when onnxruntime enables "-p" option, generating events timeline in json file.

### Description
Add Ort Api for custom op.



### Motivation and Context
Custom Op compute profiling events can be return to onnxruntime Profiler Events,
generating custom op events timeline in more detail


