### PR TITLE
Update mac.yml iphone_simulator job - use Xcode 16.4 and simulator runtime version 18.5.

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -53,7 +53,8 @@ jobs:
     runs-on: macos-15
 
     env:
-      xcode_version: 16
+      xcode_version: 16.4
+      simulator_runtime_version: 18.5
 
     strategy:
       matrix:
@@ -90,6 +91,8 @@ jobs:
             --apple_deploy_target=15.1 \
             --apple_sysroot=iphonesimulator \
             --osx_arch=${{ matrix.target_arch }}
+        env:
+          ORT_GET_SIMULATOR_DEVICE_INFO_REQUESTED_RUNTIME_VERSION: ${{ env.simulator_runtime_version }}
 
   Objective-C-StaticAnalysis:
     runs-on: macos-14


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Update mac.yml iphone_simulator job - use Xcode 16.4 and simulator runtime version 18.5.

Changes from these PRs:
#25752
#25794

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix CI build failure.