### PR TITLE
Fix native module loading and improve React Native package

### DIFF
--- a/js/react_native/android/build.gradle
+++ b/js/react_native/android/build.gradle
@@ -1,17 +1,5 @@
 import java.nio.file.Paths
 
-buildscript {
-  repositories {
-    google()
-    mavenCentral()
-  }
-
-  dependencies {
-    classpath 'com.android.tools.build:gradle:7.4.2'
-    // noinspection DifferentKotlinGradleVersion
-  }
-}
-
 apply plugin: 'com.android.library'
 
 def getExtOrDefault(name) {

--- a/js/react_native/package.json
+++ b/js/react_native/package.json
@@ -1,5 +1,5 @@
 {
-  "react-native": "lib/index",
+  "react-native": "dist/commonjs/index",
   "module": "dist/module/index",
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
- The buildscript block was removed from js/react_native/android/build.gradle to avoid conflicts with Expo prebuild. 
- The react-native entry in js/react_native/package.json was updated to dist/commonjs/index, allowing Expo/Metro to import compiled JavaScript.
- Improved the bindings to prevent crashes


