### PR TITLE
[webgpu] Optimize MatMul Op

### DIFF
--- a/onnxruntime/core/providers/webgpu/math/matmul.cc
+++ b/onnxruntime/core/providers/webgpu/math/matmul.cc
@@ -101,6 +101,14 @@ Status MatMulNaiveProgram::GenerateShaderCode(ShaderHelper& shader) const {
   return Status::OK();
 }
 
+Status MatMulTiledSubgroupProgram::GenerateShaderCode(ShaderHelper& shader) const {
+  shader.AddInput("a", ShaderUsage::UseValueTypeAlias | ShaderUsage::UseElementTypeAlias);
+  shader.AddInput("b", ShaderUsage::UseValueTypeAlias | ShaderUsage::UseElementTypeAlias);
+  shader.AddOutput("output", ShaderUsage::UseValueTypeAlias | ShaderUsage::UseElementTypeAlias);
+
+  return WGSL_TEMPLATE_APPLY(shader, "math/matmul_tiled_subgroup.wgsl.template");
+}
+
 Status MatMul::ComputeInternal(ComputeContext& context) const {
   // calculate output shape
   MatMulComputeHelper helper;
@@ -152,6 +160,63 @@ Status MatMul::ComputeInternal(ComputeContext& context) const {
         .AddUniformVariables({{output_size}, {m}, {n}, {k}});
 
     return context.RunProgram(program);
+  }
+
+  {
+    auto a_shape = a->Shape();
+    auto b_shape = b->Shape();
+    bool are_matrices = a_shape.NumDimensions() >= 2 && b_shape.NumDimensions() >= 2;
+
+    TensorShape batch_dims_a = a_shape.NumDimensions() > 2
+                                   ? a_shape.Slice(0, a_shape.NumDimensions() - 2)
+                                   : TensorShape({});
+    TensorShape batch_dims_b = b_shape.NumDimensions() > 2
+                                   ? b_shape.Slice(0, b_shape.NumDimensions() - 2)
+                                   : TensorShape({});
+
+    const bool is_vec4 = helper.K() % 4 == 0 && helper.N() % 4 == 0;
+
+    // TODO: Implement broadcasting for batch dimensions.
+    if (are_matrices && batch_dims_a == batch_dims_b && is_vec4) {
+      const uint32_t m = narrow<uint32_t>(helper.M());  // left matrix first dimension
+      const uint32_t n = narrow<uint32_t>(helper.N());  // right matrix second dimension
+      const uint32_t k = narrow<uint32_t>(helper.K());  // right matrix first dimension
+
+      auto output_shape = output_tensor->Shape();
+
+      TensorShape batch_dims = output_shape.NumDimensions() > 2
+                                   ? output_shape.Slice(0, output_shape.NumDimensions() - 2)
+                                   : TensorShape({});
+      const uint32_t batch_size = narrow<uint32_t>(batch_dims.Size());
+
+      const uint32_t kTileM = 64;
+      const uint32_t kTileN = 64;
+      const uint32_t kMTiles = (m + kTileM - 1) / kTileM;
+      const uint32_t kNTiles = (n + kTileM - 1) / kTileN;
+
+      MatMulTiledSubgroupProgram program;
+      program.SetWorkgroupSize(64, 1, 1);
+      program.SetDispatchGroupSize(kNTiles, kMTiles, batch_size);
+
+      program.AddInput({a,
+                        ProgramTensorMetadataDependency::TypeAndRank,
+                        4});
+      program.AddInput({b,
+                        ProgramTensorMetadataDependency::TypeAndRank,
+                        4});
+      program.AddOutput({output_tensor,
+                         ProgramTensorMetadataDependency::TypeAndRank,
+                         4});
+      program.AddUniformVariables({{narrow<uint32_t>(batch_size)},
+                                   {m},
+                                   {k},
+                                   {k / 4},
+                                   {n / 4},
+                                   {kMTiles},
+                                   {kNTiles}});
+
+      return context.RunProgram(program);
+    }
   }
 
   std::vector<const Tensor*> inputs(has_bias ? 3 : 2);

--- a/onnxruntime/core/providers/webgpu/math/matmul.h
+++ b/onnxruntime/core/providers/webgpu/math/matmul.h
@@ -49,5 +49,20 @@ class MatMulNaiveProgram final : public Program<MatMulNaiveProgram> {
   const bool is_channels_last_;
 };
 
+class MatMulTiledSubgroupProgram final : public Program<MatMulTiledSubgroupProgram> {
+ public:
+  MatMulTiledSubgroupProgram() : Program{"MatMulTiledSubgroup"} {}
+
+  Status GenerateShaderCode(ShaderHelper& sh) const override;
+
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES({"Batch", ProgramUniformVariableDataType::Uint32},
+                                          {"M", ProgramUniformVariableDataType::Uint32},
+                                          {"K", ProgramUniformVariableDataType::Uint32},
+                                          {"k_of_a", ProgramUniformVariableDataType::Uint32},
+                                          {"n_div_4", ProgramUniformVariableDataType::Uint32},
+                                          {"M_tiles", ProgramUniformVariableDataType::Uint32},
+                                          {"N_tiles", ProgramUniformVariableDataType::Uint32}, );
+};
+
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/math/matmul_tiled_subgroup.wgsl.template
+++ b/onnxruntime/core/providers/webgpu/math/matmul_tiled_subgroup.wgsl.template
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+fn load_a(batch : u32, m : u32, k_idx : u32) -> a_value_t {
+  if (batch < uniforms.Batch && m < uniforms.M && k_idx < uniforms.k_of_a) {
+    let offset = batch * uniforms.M * uniforms.k_of_a + m * uniforms.k_of_a + k_idx;
+    return a[offset];
+  }
+  return a_value_t();
+}
+
+fn load_b(batch : u32, k : u32, n_idx : u32) -> b_value_t {
+  if (batch < uniforms.Batch && k < uniforms.K && n_idx < uniforms.n_div_4) {
+    let offset = batch * uniforms.K * uniforms.n_div_4 + k * uniforms.n_div_4 + n_idx;
+    return b[offset];
+  }
+  return b_value_t();
+}
+
+fn write_output(batch : u32, m : u32, n_idx : u32, value : output_value_t) {
+  if (batch < uniforms.Batch && m < uniforms.M && n_idx < uniforms.n_div_4) {
+    let offset = batch * uniforms.M * uniforms.n_div_4 + m * uniforms.n_div_4 + n_idx;
+    output[offset] = value;
+  }
+}
+
+var<workgroup> b_cache : array<b_value_t, 64>;
+
+$MAIN {
+  let batch = workgroup_idx / (uniforms.M_tiles * uniforms.N_tiles);
+  let m_base = ((workgroup_idx / uniforms.N_tiles) % uniforms.M_tiles) * 64;
+  let n_base = (workgroup_idx % uniforms.N_tiles) * 64;
+
+  var results : array<output_element_t, 64>;
+  for (var k_idx = 0u; k_idx < uniforms.k_of_a; k_idx++) {
+    let a_data = load_a(batch, m_base + local_idx, k_idx);
+
+    // Loads and transposes a 4x16 block of matrix B into the workgroup cache.
+    let b_local_k = local_idx / 16;
+    let b_local_n_idx = local_idx % 16;
+    let b_data = load_b(batch, 4 * k_idx + b_local_k, n_base / 4 + b_local_n_idx);
+    b_cache[4 * b_local_n_idx][b_local_k] = b_data[0];
+    b_cache[4 * b_local_n_idx + 1u][b_local_k] = b_data[1];
+    b_cache[4 * b_local_n_idx + 2u][b_local_k] = b_data[2];
+    b_cache[4 * b_local_n_idx + 3u][b_local_k] = b_data[3];
+    workgroupBarrier();
+
+    if (sg_size == 32u) {
+      var b_data = b_cache[sg_id];
+      for (var n = 0u; n < 32u; n++) {
+        results[n] += dot(a_data, subgroupShuffle(b_data, n));
+      }
+      b_data = b_cache[sg_id + 32u];
+      for (var n = 0u; n < 32u; n++) {
+        results[n + 32u] += dot(a_data, subgroupShuffle(b_data, n));
+      }
+    } else {
+      for (var n = 0; n < 64; n++) {
+        results[n] += dot(a_data, b_cache[n]);
+      }
+    }
+    workgroupBarrier();
+  }
+
+  for (var n_idx = 0u; n_idx < 16u; n_idx++) {
+    let output = output_value_t(results[4 * n_idx],
+                                results[4 * n_idx + 1u],
+                                results[4 * n_idx + 2u],
+                                results[4 * n_idx + 3u]);
+
+    write_output(batch, m_base + local_idx, n_base / 4 + n_idx, output);
+  }
+}  // MAIN


### PR DESCRIPTION
### Description
This PR optimizes the `MatMul` operation by implementing a new compute shader. The shader uses a workgroup size of 64 and a tile size of 64x64. One optimization is transposing a tile of the B matrix within workgroup memory to enable efficient dot product computations. Additionally, `subgroupShuffle` is utilized to accelerate data transfer and access patterns within subgroups.

### Motivation and Context
See above.
