### PR TITLE
[WebNN] Fix the op support limit for batchNormalization

### DIFF
--- a/onnxruntime/core/providers/webnn/builders/map_info.h
+++ b/onnxruntime/core/providers/webnn/builders/map_info.h
@@ -200,7 +200,7 @@ const std::unordered_map<std::string_view, WebnnOpInfo> op_inputs_map = {
     {"DequantizeLinear", {"dequantizeLinear", {{0, "input"}, {1, "scale"}, {2, "zeroPoint"}}}},
     {"InstanceNormalization", {"instanceNormalization", {{0, "input"}, {1, "scale"}, {2, "bias"}}}},
     {"GRU", {"gru", {{0, "input"}, {1, "weight"}, {2, "recurrentWeight"}, {3, "bias"}, {5, "initialHiddenState"}}}},
-    {"BatchNormalization", {"batchNormalization", {{0, "input"}, {1, "scale"}, {2, "bias"}, {3, "input_mean"}, {4, "input_var"}}}},
+    {"BatchNormalization", {"batchNormalization", {{0, "input"}, {1, "scale"}, {2, "bias"}, {3, "mean"}, {4, "variance"}}}},
     {"LSTM", {"lstm", {{0, "input"}, {1, "weight"}, {2, "recurrentWeight"}, {3, "bias"}, {5, "initialHiddenState"}, {6, "initialCellState"}, {7, "peepholeWeight"}}}},
 };
 }  // namespace webnn


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
According to the [WebNN spec](https://www.w3.org/TR/webnn/#api-mlgraphbuilder-batchnorm), the batchNorm should have input names "mean" and "variance" instead of "input_mean" and "input_var".


### Motivation and Context
This issue causes any BatchNorm with mean/variance inputs to fall back to wasm.

