### PR TITLE
Add default constructor to Ort::Status.

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -728,6 +728,7 @@ struct Status : detail::Base<OrtStatus> {
   using Base = detail::Base<OrtStatus>;
   using Base::Base;
 
+  Status() = default;
   explicit Status(std::nullptr_t) noexcept {}      ///< Create an empty object, must be assigned a valid one to be used
   explicit Status(OrtStatus* status) noexcept;     ///< Takes ownership of OrtStatus instance returned from the C API.
   explicit Status(const Exception&);               ///< Creates status instance out of exception

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -823,7 +823,7 @@ inline Status Env::CopyTensors(const std::vector<Value>& src_tensors,
     return Status("Source and destination tensor vectors must have the same size", ORT_INVALID_ARGUMENT);
   }
   if (src_tensors.empty()) {
-    return Status();
+    return Status(nullptr);
   }
 
   const OrtValue* const* src_tensors_ptr = reinterpret_cast<const OrtValue* const*>(src_tensors.data());


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Fix packaging pipelines


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
  During CIs and local builds Ort::Status() gets inherited from the base due to using directives,
  however, that does not work for packaging pipelines.
  Having default ctor is important for storing Status in containers if needed.


