### PR TITLE
[QNN EP] Add Case-2 LPBQ pattern support for Gemm and Matmul nodes

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/lpbqgemm_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/lpbqgemm_fusion.cc
@@ -16,12 +16,12 @@ namespace onnxruntime {
 namespace qnn {
 
 static Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
-                                    const NodeUnit& scale_dql_node_unit,
-                                    const NodeUnit& w_ql_node_unit,
-                                    const NodeUnit& w_dql_node_unit,
-                                    const NodeUnit& act_dql_node_unit,
-                                    const NodeUnit& gemm_node_unit,
-                                    const NodeUnit& output_ql_node_unit,
+                                    const NodeUnit* scale_dql_node_unit,
+                                    const NodeUnit* w_ql_node_unit,
+                                    const NodeUnit* w_dql_node_unit,
+                                    const NodeUnit* act_dql_node_unit,
+                                    const NodeUnit* gemm_node_unit,
+                                    const NodeUnit* output_ql_node_unit,
                                     bool validate);
 
 std::unique_ptr<IQnnNodeGroup> LowPowerBlockQuantizedGemmFusion::TryFusion(
@@ -67,24 +67,41 @@ std::unique_ptr<IQnnNodeGroup> LowPowerBlockQuantizedGemmFusion::TryFusion(
                                                      w_dql_parent_types,
                                                      node_to_node_unit,
                                                      node_unit_to_qnn_node_group);
-  if (p_w_ql_node_unit == nullptr) {
-    return nullptr;
+  if (p_w_ql_node_unit != nullptr) {
+    // Check if input of QuantizeLinear is constant initializer
+    if (!qnn_model_wrapper.IsConstantInput(p_w_ql_node_unit->Inputs()[0].node_arg.Name())) {
+      return nullptr;
+    }
+  } else {
+    // Check if input of DequantizeLinear is constant initializer
+    if (!qnn_model_wrapper.IsConstantInput(p_w_dql_node_unit->Inputs()[0].node_arg.Name())) {
+      return nullptr;
+    }
   }
 
-  // Check if input of QuantizeLinear is constant initializer
-  if (!qnn_model_wrapper.IsConstantInput(p_w_ql_node_unit->Inputs()[0].node_arg.Name())) {
-    return nullptr;
-  }
-
-  // Get DequantizeLinear contains per-block int scales and per-channel float scales
-  const std::array<std::string_view, 1> w_ql_parent_types = {"DequantizeLinear"};
-  const NodeUnit* p_scale_dql_node_unit = GetParentOfType(graph_viewer,
-                                                          *p_w_ql_node_unit,
-                                                          w_ql_parent_types,
-                                                          node_to_node_unit,
-                                                          node_unit_to_qnn_node_group);
-  if (p_scale_dql_node_unit == nullptr) {
-    return nullptr;
+  const NodeUnit* p_scale_dql_node_unit = nullptr;
+  if (p_w_ql_node_unit != nullptr) {
+    const std::array<std::string_view, 1> w_ql_parent_types = {"DequantizeLinear"};
+    p_scale_dql_node_unit = GetParentOfType(graph_viewer,
+                                            *p_w_ql_node_unit,
+                                            w_ql_parent_types,
+                                            node_to_node_unit,
+                                            node_unit_to_qnn_node_group);
+    if (p_scale_dql_node_unit == nullptr) {
+      return nullptr;
+    }
+  } else {
+    // Get DequantizeLinear contains per-block int scales and per-channel float scales
+    // DequantizeLinear connects to scale (input 1) of DequantizeLinear node
+    const std::string& scale_name = (p_w_dql_node_unit->Inputs()[0]).quant_param->scale.Name();
+    p_scale_dql_node_unit = GetParentOfInputByName(graph_viewer,
+                                                   *p_w_dql_node_unit,
+                                                   scale_name,
+                                                   node_to_node_unit,
+                                                   node_unit_to_qnn_node_group);
+    if (p_scale_dql_node_unit == nullptr || p_scale_dql_node_unit->OpType() != "DequantizeLinear") {
+      return nullptr;
+    }
   }
 
   TensorInfo pc_scales_tensor_info = {};
@@ -109,51 +126,61 @@ std::unique_ptr<IQnnNodeGroup> LowPowerBlockQuantizedGemmFusion::TryFusion(
   }
 
   if (Status status = CreateOrValidateOnQnn(qnn_model_wrapper,
-                                            *p_scale_dql_node_unit,
-                                            *p_w_ql_node_unit,
-                                            *p_w_dql_node_unit,
-                                            *p_act_dql_node_unit,
-                                            gemm_node_unit,
-                                            *p_output_ql_node_unit,
+                                            p_scale_dql_node_unit,
+                                            p_w_ql_node_unit,
+                                            p_w_dql_node_unit,
+                                            p_act_dql_node_unit,
+                                            &gemm_node_unit,
+                                            p_output_ql_node_unit,
                                             true);
       !status.IsOK()) {
     return nullptr;
   }
 
-  return std::make_unique<LowPowerBlockQuantizedGemmFusion>(*p_scale_dql_node_unit,
-                                                            *p_w_ql_node_unit,
-                                                            *p_w_dql_node_unit,
-                                                            *p_act_dql_node_unit,
-                                                            gemm_node_unit,
-                                                            *p_output_ql_node_unit);
+  return std::make_unique<LowPowerBlockQuantizedGemmFusion>(p_scale_dql_node_unit,
+                                                            p_w_ql_node_unit,
+                                                            p_w_dql_node_unit,
+                                                            p_act_dql_node_unit,
+                                                            &gemm_node_unit,
+                                                            p_output_ql_node_unit);
 }
 
-LowPowerBlockQuantizedGemmFusion::LowPowerBlockQuantizedGemmFusion(const NodeUnit& Scale_DQL_node_unit,
-                                                                   const NodeUnit& W_QL_node_unit,
-                                                                   const NodeUnit& W_DQL_node_unit,
-                                                                   const NodeUnit& Act_DQL_node_unit,
-                                                                   const NodeUnit& Gemm_node_unit,
-                                                                   const NodeUnit& Output_QL_node_unit)
-    : node_units_{&Scale_DQL_node_unit,
-                  &W_QL_node_unit,
-                  &W_DQL_node_unit,
-                  &Act_DQL_node_unit,
-                  &Gemm_node_unit,
-                  &Output_QL_node_unit} {
+LowPowerBlockQuantizedGemmFusion::LowPowerBlockQuantizedGemmFusion(const NodeUnit* Scale_DQL_node_unit,
+                                                                   const NodeUnit* W_QL_node_unit,
+                                                                   const NodeUnit* W_DQL_node_unit,
+                                                                   const NodeUnit* Act_DQL_node_unit,
+                                                                   const NodeUnit* Gemm_node_unit,
+                                                                   const NodeUnit* Output_QL_node_unit)
+    : node_units_{Scale_DQL_node_unit,
+                  W_QL_node_unit,
+                  W_DQL_node_unit,
+                  Act_DQL_node_unit,
+                  Gemm_node_unit,
+                  Output_QL_node_unit} {
 }
 
 Status LowPowerBlockQuantizedGemmFusion::IsSupported(QnnModelWrapper& qmw, const logging::Logger& logger) const {
   ORT_UNUSED_PARAMETER(logger);
-  return CreateOrValidateOnQnn(qmw, *node_units_[0], *node_units_[1], *node_units_[2], *node_units_[3], *node_units_[4], *node_units_[5], true);
+  return CreateOrValidateOnQnn(qmw, node_units_[0], node_units_[1], node_units_[2], node_units_[3], node_units_[4], node_units_[5], true);
 }
 
 Status LowPowerBlockQuantizedGemmFusion::AddToModelBuilder(QnnModelWrapper& qmw, const logging::Logger& logger) const {
   ORT_UNUSED_PARAMETER(logger);
-  return CreateOrValidateOnQnn(qmw, *node_units_[0], *node_units_[1], *node_units_[2], *node_units_[3], *node_units_[4], *node_units_[5], false);
+  return CreateOrValidateOnQnn(qmw, node_units_[0], node_units_[1], node_units_[2], node_units_[3], node_units_[4], node_units_[5], false);
 }
 
 gsl::span<const NodeUnit* const> LowPowerBlockQuantizedGemmFusion::GetNodeUnits() const {
-  return node_units_;
+  static std::vector<const NodeUnit*> filtered_units;
+  filtered_units.clear();
+
+  // Add only non-nullptr node units
+  for (size_t i = 0; i < node_units_.size(); ++i) {
+    if (node_units_[i] != nullptr) {
+      filtered_units.push_back(node_units_[i]);
+    }
+  }
+
+  return gsl::make_span(filtered_units);
 }
 
 const NodeUnit* LowPowerBlockQuantizedGemmFusion::GetTargetNodeUnit() const {
@@ -178,15 +205,19 @@ Status UnpackWeightTensorData(const QnnModelWrapper& qnn_model_wrapper,
 }
 
 Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
-                             const NodeUnit& scale_dql_node_unit,
-                             const NodeUnit& w_ql_node_unit,
-                             const NodeUnit& w_dql_node_unit,
-                             const NodeUnit& act_dql_node_unit,
-                             const NodeUnit& gemm_node_unit,
-                             const NodeUnit& output_ql_node_unit,
+                             const NodeUnit* p_scale_dql_node_unit,
+                             const NodeUnit* p_w_ql_node_unit,
+                             const NodeUnit* p_w_dql_node_unit,
+                             const NodeUnit* p_act_dql_node_unit,
+                             const NodeUnit* p_gemm_node_unit,
+                             const NodeUnit* p_output_ql_node_unit,
                              bool validate) {
+  const NodeUnit& scale_dql_node_unit = *p_scale_dql_node_unit;
+  const NodeUnit& w_dql_node_unit = *p_w_dql_node_unit;
+  const NodeUnit& act_dql_node_unit = *p_act_dql_node_unit;
+  const NodeUnit& gemm_node_unit = *p_gemm_node_unit;
+  const NodeUnit& output_ql_node_unit = *p_output_ql_node_unit;
   assert(scale_dql_node_unit.OpType() == "DequantizeLinear" &&
-         w_ql_node_unit.OpType() == "QuantizeLinear" &&
          w_dql_node_unit.OpType() == "DequantizeLinear" &&
          act_dql_node_unit.OpType() == "DequantizeLinear" &&
          gemm_node_unit.OpType() == "Gemm" &&
@@ -194,7 +225,6 @@ Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
   const auto& node_name = utils::GetUniqueName(gemm_node_unit);
   const NodeUnitIODef& act_dql_input_1_def = act_dql_node_unit.Inputs()[0];
   const NodeUnitIODef& w_dql_input_1_def = w_dql_node_unit.Inputs()[0];
-  const NodeUnitIODef& w_ql_input_1_def = w_ql_node_unit.Inputs()[0];
   const NodeUnitIODef& output_def = output_ql_node_unit.Outputs()[0];
 
   // prepare input tensor
@@ -224,7 +254,8 @@ Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
   std::vector<int32_t> weight_offset(per_channel_float_scale.size(), 0);
   std::vector<uint32_t> block_scales_shape;
   ORT_RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(per_block_int_def.node_arg, block_scales_shape), "Failed to get block_scales shape");
-  // Get attributes like axis, block_size from QuantizeLinear
+
+  // Get attributes like axis from DequantizeLinear
   NodeAttrHelper scales_node_helper(scale_dql_node_unit.GetNode());
   auto block_scales_axis = scales_node_helper.Get("axis", static_cast<int64_t>(0));
 
@@ -238,11 +269,10 @@ Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
   }
 
   std::vector<uint32_t> weight_shape;
-  std::string weight_tensor_name = w_ql_input_1_def.node_arg.Name();
-  ORT_RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(w_ql_input_1_def.node_arg, weight_shape), "Failed to get weight shape");
+  ORT_RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(w_dql_input_1_def.node_arg, weight_shape), "Failed to get weight shape");
 
-  // Get attributes like axis, block_size from QuantizeLinear
-  NodeAttrHelper helper(w_ql_node_unit.GetNode());
+  // Get attributes like axis, block_size from DequantizeLinear
+  NodeAttrHelper helper(w_dql_node_unit.GetNode());
   auto input_channel_axis = helper.Get("axis", static_cast<int64_t>(0));
   if (input_channel_axis < 0) {
     input_channel_axis = weight_shape.size() + input_channel_axis;
@@ -252,35 +282,52 @@ Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
   size_t output_channel_axis = 0;  // Current LowPowerBlockQuantize() support output_channel_axis at index=0;
   weight_qparams = QnnQuantParamsWrapper(per_channel_float_scale, per_block_int_scale, weight_offset, output_channel_axis, block_size, is_int4_type);
 
-  std::vector<uint8_t> unpacked_tensor;
   Qnn_DataType_t weight_data_type = is_int4_type ? QNN_DATATYPE_SFIXED_POINT_4 : QNN_DATATYPE_SFIXED_POINT_8;
-  const auto& weight_tensor_proto = qnn_model_wrapper.GetConstantTensor(weight_tensor_name);
-  ORT_RETURN_IF_ERROR(UnpackWeightTensorData(qnn_model_wrapper, weight_tensor_proto, weight_shape, input_channel_axis, unpacked_tensor));
+  QnnTensorWrapper weight_tensor;
+  std::string weight_tensor_name;
+  if (p_w_ql_node_unit) {
+    std::vector<uint8_t> unpacked_tensor;
+    const NodeUnitIODef& w_ql_input_1_def = p_w_ql_node_unit->Inputs()[0];
+    weight_tensor_name = w_ql_input_1_def.node_arg.Name();
+    const auto& weight_tensor_proto = qnn_model_wrapper.GetConstantTensor(weight_tensor_name);
+    ORT_RETURN_IF_ERROR(UnpackWeightTensorData(qnn_model_wrapper, weight_tensor_proto, weight_shape, input_channel_axis, unpacked_tensor));
 
-  // Quantize weight tensor
-  size_t weight_elements = unpacked_tensor.size() / sizeof(float);
-  auto float_data = gsl::make_span<const float>(reinterpret_cast<const float*>(unpacked_tensor.data()), weight_elements);
-  std::vector<uint8_t> quant_data(weight_elements);
+    // Quantize weight tensor
+    size_t weight_elements = unpacked_tensor.size() / sizeof(float);
+    auto float_data = gsl::make_span<const float>(reinterpret_cast<const float*>(unpacked_tensor.data()), weight_elements);
+    std::vector<uint8_t> quant_data(weight_elements);
 
-  // scale = per_channel_float_scale * per_block_int_scale
-  // weight_data_type = 4 but store in int8 buffer
-  ORT_RETURN_IF_ERROR(qnn::utils::LowPowerBlockQuantizeData(float_data,
-                                                            weight_shape,
-                                                            per_channel_float_scale,
-                                                            per_block_int_scale,
-                                                            weight_offset,
-                                                            quant_data,
-                                                            weight_data_type,
-                                                            output_channel_axis,
-                                                            block_scales_axis,
-                                                            block_size,
-                                                            block_scales_shape));
+    // scale = per_channel_float_scale * per_block_int_scale
+    // weight_data_type = 4 but store in int8 buffer
+    ORT_RETURN_IF_ERROR(qnn::utils::LowPowerBlockQuantizeData(float_data,
+                                                              weight_shape,
+                                                              per_channel_float_scale,
+                                                              per_block_int_scale,
+                                                              weight_offset,
+                                                              quant_data,
+                                                              weight_data_type,
+                                                              output_channel_axis,
+                                                              block_scales_axis,
+                                                              block_size,
+                                                              block_scales_shape));
 
-  // Get weight tensor type from input of w_dql_tensor or output_dql_tensor
-  Qnn_TensorType_t weight_tensor_type = qnn_model_wrapper.GetTensorType(weight_tensor_name);
-  QnnTensorWrapper weight_tensor(weight_tensor_name, weight_tensor_type, QNN_DATATYPE_SFIXED_POINT_8,
-                                 std::move(weight_qparams), std::move(weight_shape),
-                                 std::move(quant_data));
+    // Get weight tensor type from input of w_dql_tensor or output_dql_tensor
+    Qnn_TensorType_t weight_tensor_type = qnn_model_wrapper.GetTensorType(weight_tensor_name);
+    weight_tensor = QnnTensorWrapper(weight_tensor_name, weight_tensor_type, QNN_DATATYPE_SFIXED_POINT_8,
+                                     std::move(weight_qparams), std::move(weight_shape),
+                                     std::move(quant_data));
+  } else {
+    std::vector<uint8_t> unpacked_tensor;
+    weight_tensor_name = w_dql_input_1_def.node_arg.Name();
+    const auto& weight_tensor_proto = qnn_model_wrapper.GetConstantTensor(weight_tensor_name);
+    ORT_RETURN_IF_ERROR(UnpackWeightTensorData(qnn_model_wrapper, weight_tensor_proto, weight_shape, input_channel_axis, unpacked_tensor));
+
+    // Get weight tensor type from input of w_dql_tensor or output_dql_tensor
+    Qnn_TensorType_t weight_tensor_type = qnn_model_wrapper.GetTensorType(weight_tensor_name);
+    weight_tensor = QnnTensorWrapper(weight_tensor_name, weight_tensor_type, QNN_DATATYPE_SFIXED_POINT_8,
+                                     std::move(weight_qparams), std::move(weight_shape),
+                                     std::move(unpacked_tensor));
+  }
 
   // Prepare Bias tensor;
   // Bias tensor is in FP32 and need to quantize to datatype of input 0 of Gemm

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/lpbqgemm_fusion.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/lpbqgemm_fusion.h
@@ -23,12 +23,12 @@ class QnnModelWrapper;
 
 class LowPowerBlockQuantizedGemmFusion : public IQnnNodeGroup {
  public:
-  LowPowerBlockQuantizedGemmFusion(const NodeUnit& Scale_DQL_node_unit,
-                                   const NodeUnit& W_QL_node_unit,
-                                   const NodeUnit& W_DQL_node_unit,
-                                   const NodeUnit& Act_DQL_node_unit,
-                                   const NodeUnit& Gemm_node_unit,
-                                   const NodeUnit& Output_QL_node_unit);
+  LowPowerBlockQuantizedGemmFusion(const NodeUnit* Scale_DQL_node_unit,
+                                   const NodeUnit* W_QL_node_unit,
+                                   const NodeUnit* W_DQL_node_unit,
+                                   const NodeUnit* Act_DQL_node_unit,
+                                   const NodeUnit* Gemm_node_unit,
+                                   const NodeUnit* Output_QL_node_unit);
   ORT_DISALLOW_COPY_AND_ASSIGNMENT(LowPowerBlockQuantizedGemmFusion);
 
   Status IsSupported(QnnModelWrapper& qmw, const logging::Logger& logger) const override;

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/lpbqmatmul_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/lpbqmatmul_fusion.cc
@@ -16,9 +16,9 @@ namespace onnxruntime {
 namespace qnn {
 
 static Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
-                                    const NodeUnit& scale_dql_node_unit,
-                                    const NodeUnit& w_ql_node_unit,
-                                    const NodeUnit& matmul_node_unit,
+                                    const NodeUnit* scale_dql_node_unit,
+                                    const NodeUnit* w_ql_node_unit,
+                                    const NodeUnit* matmul_node_unit,
                                     const logging::Logger& logger,
                                     bool validate);
 
@@ -44,24 +44,43 @@ std::unique_ptr<IQnnNodeGroup> LowPowerBlockQuantizedMatMulFusion::TryFusion(
                                                       matmul_node_unit.Inputs()[1],
                                                       node_to_node_unit,
                                                       node_unit_to_qnn_node_group);
-  if (p_w_ql_node_unit == nullptr || p_w_ql_node_unit->OpType() != "QuantizeLinear") {
-    return nullptr;
+  if (p_w_ql_node_unit != nullptr) {
+    // Check if input of QuantizeLinear is constant initializer
+    if (p_w_ql_node_unit->OpType() != "QuantizeLinear" ||
+        !qnn_model_wrapper.IsConstantInput(p_w_ql_node_unit->Inputs()[0].node_arg.Name())) {
+      return nullptr;
+    }
+  } else {
+    // Check if input 1 of MatMul is constant initializer
+    if (!qnn_model_wrapper.IsConstantInput(matmul_node_unit.Inputs()[1].node_arg.Name())) {
+      return nullptr;
+    }
   }
 
-  // Check if input of QuantizeLinear is constant initializer
-  if (!qnn_model_wrapper.IsConstantInput(p_w_ql_node_unit->Inputs()[0].node_arg.Name())) {
-    return nullptr;
-  }
-
-  // Get DequantizeLinear node unit contains per-block int scales and per-channel float scales
-  const std::array<std::string_view, 1> w_ql_parent_types = {"DequantizeLinear"};
-  const NodeUnit* p_scale_dql_node_unit = GetParentOfType(graph_viewer,
-                                                          *p_w_ql_node_unit,
-                                                          w_ql_parent_types,
-                                                          node_to_node_unit,
-                                                          node_unit_to_qnn_node_group);
-  if (p_scale_dql_node_unit == nullptr) {
-    return nullptr;
+  const NodeUnit* p_scale_dql_node_unit = nullptr;
+  if (p_w_ql_node_unit != nullptr) {
+    // Get DequantizeLinear node unit contains per-block int scales and per-channel float scales
+    const std::array<std::string_view, 1> w_ql_parent_types = {"DequantizeLinear"};
+    p_scale_dql_node_unit = GetParentOfType(graph_viewer,
+                                            *p_w_ql_node_unit,
+                                            w_ql_parent_types,
+                                            node_to_node_unit,
+                                            node_unit_to_qnn_node_group);
+    if (p_scale_dql_node_unit == nullptr) {
+      return nullptr;
+    }
+  } else {
+    // Get DequantizeLinear contains per-block int scales and per-channel float scales
+    // DequantizeLinear connects to scale (input 1) of DequantizeLinear node
+    const std::string& scale_name = (matmul_node_unit.Inputs()[1]).quant_param->scale.Name();
+    p_scale_dql_node_unit = GetParentOfInputByName(graph_viewer,
+                                                   matmul_node_unit,
+                                                   scale_name,
+                                                   node_to_node_unit,
+                                                   node_unit_to_qnn_node_group);
+    if (p_scale_dql_node_unit == nullptr || p_scale_dql_node_unit->OpType() != "DequantizeLinear") {
+      return nullptr;
+    }
   }
 
   TensorInfo pc_scales_tensor_info = {};
@@ -75,38 +94,48 @@ std::unique_ptr<IQnnNodeGroup> LowPowerBlockQuantizedMatMulFusion::TryFusion(
   }
 
   if (Status status = CreateOrValidateOnQnn(qnn_model_wrapper,
-                                            *p_scale_dql_node_unit,
-                                            *p_w_ql_node_unit,
-                                            matmul_node_unit,
+                                            p_scale_dql_node_unit,
+                                            p_w_ql_node_unit,
+                                            &matmul_node_unit,
                                             logger,
                                             true);
       !status.IsOK()) {
     return nullptr;
   }
 
-  return std::make_unique<LowPowerBlockQuantizedMatMulFusion>(*p_scale_dql_node_unit,
-                                                              *p_w_ql_node_unit,
-                                                              matmul_node_unit);
+  return std::make_unique<LowPowerBlockQuantizedMatMulFusion>(p_scale_dql_node_unit,
+                                                              p_w_ql_node_unit,
+                                                              &matmul_node_unit);
 }
 
-LowPowerBlockQuantizedMatMulFusion::LowPowerBlockQuantizedMatMulFusion(const NodeUnit& Scale_DQL_node_unit,
-                                                                       const NodeUnit& W_QL_node_unit,
-                                                                       const NodeUnit& MatMul_node_unit)
-    : node_units_{&Scale_DQL_node_unit,
-                  &W_QL_node_unit,
-                  &MatMul_node_unit} {
+LowPowerBlockQuantizedMatMulFusion::LowPowerBlockQuantizedMatMulFusion(const NodeUnit* Scale_DQL_node_unit,
+                                                                       const NodeUnit* W_QL_node_unit,
+                                                                       const NodeUnit* MatMul_node_unit)
+    : node_units_{Scale_DQL_node_unit,
+                  W_QL_node_unit,
+                  MatMul_node_unit} {
 }
 
 Status LowPowerBlockQuantizedMatMulFusion::IsSupported(QnnModelWrapper& qmw, const logging::Logger& logger) const {
-  return CreateOrValidateOnQnn(qmw, *node_units_[0], *node_units_[1], *node_units_[2], logger, true);
+  return CreateOrValidateOnQnn(qmw, node_units_[0], node_units_[1], node_units_[2], logger, true);
 }
 
 Status LowPowerBlockQuantizedMatMulFusion::AddToModelBuilder(QnnModelWrapper& qmw, const logging::Logger& logger) const {
-  return CreateOrValidateOnQnn(qmw, *node_units_[0], *node_units_[1], *node_units_[2], logger, false);
+  return CreateOrValidateOnQnn(qmw, node_units_[0], node_units_[1], node_units_[2], logger, false);
 }
 
 gsl::span<const NodeUnit* const> LowPowerBlockQuantizedMatMulFusion::GetNodeUnits() const {
-  return node_units_;
+  static std::vector<const NodeUnit*> filtered_units;
+  filtered_units.clear();
+
+  // Add only non-nullptr node units
+  for (size_t i = 0; i < node_units_.size(); ++i) {
+    if (node_units_[i] != nullptr) {
+      filtered_units.push_back(node_units_[i]);
+    }
+  }
+
+  return gsl::make_span(filtered_units);
 }
 
 const NodeUnit* LowPowerBlockQuantizedMatMulFusion::GetTargetNodeUnit() const {
@@ -215,31 +244,30 @@ Status TwoDimensionTranspose(std::vector<uint8_t>& data,
 
 // Process LPBQWeight for ONNX MatMul that can be translated to either a QNN MatMul.
 Status ProcessLPBQWeight(QnnModelWrapper& qnn_model_wrapper,
-                         const NodeUnit& scale_dql_node_unit,
-                         const NodeUnit& w_ql_node_unit,
-                         const NodeUnit& matmul_node_unit,
+                         const NodeUnit* scale_dql_node_unit,
+                         const NodeUnit* w_ql_node_unit,
+                         const NodeUnit* matmul_node_unit,
                          std::vector<std::string>& input_names,
                          const logging::Logger& logger) {
   ORT_UNUSED_PARAMETER(logger);
-  const NodeUnitIODef& mm_input_1_def = matmul_node_unit.Inputs()[1];
-  const NodeUnitIODef& w_ql_input_1_def = w_ql_node_unit.Inputs()[0];
+  const NodeUnitIODef& mm_input_1_def = matmul_node_unit->Inputs()[1];
 
   // get per_channel_float_scale value from Quant param of input[0] of DequantizeLinear
   std::vector<float> per_channel_float_scale;
-  const NodeUnitIODef& per_channel_float_def = scale_dql_node_unit.Inputs()[0];
+  const NodeUnitIODef& per_channel_float_def = scale_dql_node_unit->Inputs()[0];
   const std::optional<NodeUnitIODef::QuantParam>& scale_dql_quant_param = per_channel_float_def.quant_param;
   ORT_RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales(scale_dql_quant_param->scale.Name(), per_channel_float_scale));
 
   // get per_block_int_scale value from input[0] of DequantizeLinear
   std::vector<uint8_t> per_block_int_scale;
-  const NodeUnitIODef& per_block_int_def = scale_dql_node_unit.Inputs()[0];
+  const NodeUnitIODef& per_block_int_def = scale_dql_node_unit->Inputs()[0];
   ORT_RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales<uint8_t>(per_block_int_def.node_arg.Name(), per_block_int_scale));
   std::vector<int32_t> weight_offset(per_channel_float_scale.size(), 0);
   std::vector<uint32_t> block_scales_shape;
   ORT_RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(per_block_int_def.node_arg, block_scales_shape), "Failed to get block_scales shape");
 
   // Read axis of channels in per-block-int-scales data
-  NodeAttrHelper scales_node_helper(scale_dql_node_unit.GetNode());
+  NodeAttrHelper scales_node_helper(scale_dql_node_unit->GetNode());
   auto block_scales_axis = scales_node_helper.Get("axis", static_cast<int64_t>(0));
 
   // Transpose per-block-int-scales to keep channels at index-0 (QNN LPBQ format requires shape [axis_size][blocks-per-axis])
@@ -259,59 +287,122 @@ Status ProcessLPBQWeight(QnnModelWrapper& qnn_model_wrapper,
   }
 
   std::vector<uint32_t> weight_shape;
-  std::string weight_tensor_name = w_ql_input_1_def.node_arg.Name();
-  ORT_RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(w_ql_input_1_def.node_arg, weight_shape), "Failed to get weight shape");
+  std::string weight_tensor_name;
+  QnnTensorWrapper weight_tensor;
 
-  // Get attributes like weight data axis, block_size from QuantizeLinear
-  NodeAttrHelper helper(w_ql_node_unit.GetNode());
-  auto input_channel_axis = helper.Get("axis", static_cast<int64_t>(0));
-  if (input_channel_axis < 0) {
-    input_channel_axis = weight_shape.size() + input_channel_axis;  // QNN requires positive axis value
+  if (w_ql_node_unit) {
+    const NodeUnitIODef* w_ql_input_1_def_ptr = &w_ql_node_unit->Inputs()[0];
+    ORT_RETURN_IF_NOT(w_ql_input_1_def_ptr, "Failed to get Weight input");
+    weight_tensor_name = w_ql_input_1_def_ptr->node_arg.Name();
+    ORT_RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(w_ql_input_1_def_ptr->node_arg, weight_shape), "Failed to get weight shape");
+
+    // Get attributes like weight data axis, block_size from QuantizeLinear
+    NodeAttrHelper helper(w_ql_node_unit->GetNode());
+    auto input_channel_axis = helper.Get("axis", static_cast<int64_t>(0));
+    if (input_channel_axis < 0) {
+      input_channel_axis = weight_shape.size() + input_channel_axis;  // QNN requires positive axis value
+    }
+    auto block_size = helper.Get("block_size", static_cast<int64_t>(0));
+
+    std::vector<uint8_t> unpacked_tensor;
+    const auto& weight_tensor_proto = qnn_model_wrapper.GetConstantTensor(weight_tensor_name);
+    // if input_channel_axis = 0, UnpackWeightTensorData will transpose and keep output_channel at 0
+    ORT_RETURN_IF_ERROR(UnpackWeightTensorData(qnn_model_wrapper, weight_tensor_proto, weight_shape, input_channel_axis, unpacked_tensor));
+
+    // Quantize weight tensor
+    size_t weight_elements = unpacked_tensor.size() / sizeof(float);
+    auto float_data = gsl::make_span<const float>(reinterpret_cast<const float*>(unpacked_tensor.data()), weight_elements);
+    std::vector<uint8_t> quant_data(weight_elements);
+
+    // weight_data_type = 4 but store in int8 buffer
+    size_t output_channel_axis = 0;  // MatMul requires axis to be rank-1
+    Qnn_DataType_t weight_data_type = is_int4_type ? QNN_DATATYPE_SFIXED_POINT_4 : QNN_DATATYPE_SFIXED_POINT_8;
+    ORT_RETURN_IF_ERROR(qnn::utils::LowPowerBlockQuantizeData(float_data,
+                                                              weight_shape,
+                                                              per_channel_float_scale,
+                                                              per_block_int_scale,
+                                                              weight_offset,
+                                                              quant_data,
+                                                              weight_data_type,
+                                                              output_channel_axis,
+                                                              block_scales_axis,
+                                                              block_size,
+                                                              block_scales_shape));
+
+    // MatMul w/ LPBQ requies MatMul(MxK, KxN) and axis = rank-1 (out channels)
+    // Transpose Weight to KxN, output_channel_axis is modified to rank-1;
+    if (input_channel_axis == 1) {
+      ORT_RETURN_IF_ERROR(TwoDimensionTranspose(quant_data, weight_shape, QNN_DATATYPE_SFIXED_POINT_8));
+      input_channel_axis = 0;
+      output_channel_axis = weight_shape.size() - 1;
+    }
+
+    // Construct Quant params for Weight
+    QnnQuantParamsWrapper weight_qparams;
+    weight_qparams = QnnQuantParamsWrapper(per_channel_float_scale, per_block_int_scale, weight_offset, output_channel_axis, block_size, is_int4_type);
+
+    // Get weight tensor type from input of w_dql_tensor or output_dql_tensor
+    Qnn_TensorType_t weight_tensor_type = qnn_model_wrapper.GetTensorType(weight_tensor_name);
+    weight_tensor = QnnTensorWrapper(weight_tensor_name, weight_tensor_type, QNN_DATATYPE_SFIXED_POINT_8,
+                                     std::move(weight_qparams), std::move(weight_shape),
+                                     std::move(quant_data));
+  } else {
+    weight_tensor_name = mm_input_1_def.node_arg.Name();
+    ORT_RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(mm_input_1_def.node_arg, weight_shape), "Failed to get weight shape");
+
+    // Get DequantizeLinear node on Weight in MatMul node unit
+    const Node* p_w_dql_node = nullptr;
+
+    for (auto node : matmul_node_unit->GetAllNodesInGroup()) {
+      for (auto node_input : node->InputDefs()) {
+        if (node_input->Name() == weight_tensor_name) {
+          p_w_dql_node = node;
+          break;
+        }
+
+        if (p_w_dql_node != nullptr) {
+          break;
+        }
+      }
+    }
+    ORT_RETURN_IF_NOT((p_w_dql_node != nullptr), "Failed to get Dequantize node on Weight");
+
+    // Get attributes like weight data axis, block_size from DequantizeLinear
+    NodeAttrHelper helper(*p_w_dql_node);
+    auto input_channel_axis = helper.Get("axis", static_cast<int64_t>(0));
+    if (input_channel_axis < 0) {
+      input_channel_axis = weight_shape.size() + input_channel_axis;  // QNN requires positive axis value
+    }
+    auto block_size = helper.Get("block_size", static_cast<int64_t>(0));
+
+    // Check if the weight is a constant initializer
+    ORT_RETURN_IF_NOT(qnn_model_wrapper.IsConstantInput(weight_tensor_name), "Weight must be a constant initializer");
+
+    std::vector<uint8_t> quant_data;
+    const auto& weight_tensor_proto = qnn_model_wrapper.GetConstantTensor(weight_tensor_name);
+    // if input_channel_axis = 0, UnpackWeightTensorData will transpose and keep output_channel at 0
+    ORT_RETURN_IF_ERROR(UnpackWeightTensorData(qnn_model_wrapper, weight_tensor_proto, weight_shape, input_channel_axis, quant_data));
+
+    size_t output_channel_axis = 0;  // MatMul requires axis to be rank-1
+
+    // MatMul w/ LPBQ requies MatMul(MxK, KxN) and axis = rank-1 (out channels)
+    // Transpose Weight to KxN, output_channel_axis is modified to rank-1;
+    if (input_channel_axis == 1) {
+      ORT_RETURN_IF_ERROR(TwoDimensionTranspose(quant_data, weight_shape, QNN_DATATYPE_SFIXED_POINT_8));
+      input_channel_axis = 0;
+      output_channel_axis = weight_shape.size() - 1;
+    }
+
+    // Construct Quant params for Weight
+    QnnQuantParamsWrapper weight_qparams;
+    weight_qparams = QnnQuantParamsWrapper(per_channel_float_scale, per_block_int_scale, weight_offset, output_channel_axis, block_size, is_int4_type);
+
+    // Get weight tensor type from input of w_dql_tensor or output_dql_tensor
+    Qnn_TensorType_t weight_tensor_type = qnn_model_wrapper.GetTensorType(weight_tensor_name);
+    weight_tensor = QnnTensorWrapper(weight_tensor_name, weight_tensor_type, QNN_DATATYPE_SFIXED_POINT_8,
+                                     std::move(weight_qparams), std::move(weight_shape),
+                                     std::move(quant_data));
   }
-  auto block_size = helper.Get("block_size", static_cast<int64_t>(0));
-
-  std::vector<uint8_t> unpacked_tensor;
-  const auto& weight_tensor_proto = qnn_model_wrapper.GetConstantTensor(weight_tensor_name);
-  // if input_channel_axis = 0, UnpackWeightTensorData will transpose and keep output_channel at 0
-  ORT_RETURN_IF_ERROR(UnpackWeightTensorData(qnn_model_wrapper, weight_tensor_proto, weight_shape, input_channel_axis, unpacked_tensor));
-
-  // Quantize weight tensor
-  size_t weight_elements = unpacked_tensor.size() / sizeof(float);
-  auto float_data = gsl::make_span<const float>(reinterpret_cast<const float*>(unpacked_tensor.data()), weight_elements);
-  std::vector<uint8_t> quant_data(weight_elements);
-
-  // weight_data_type = 4 but store in int8 buffer
-  size_t output_channel_axis = 0;  // MatMul requires axis to be rank-1
-  Qnn_DataType_t weight_data_type = is_int4_type ? QNN_DATATYPE_SFIXED_POINT_4 : QNN_DATATYPE_SFIXED_POINT_8;
-  ORT_RETURN_IF_ERROR(qnn::utils::LowPowerBlockQuantizeData(float_data,
-                                                            weight_shape,
-                                                            per_channel_float_scale,
-                                                            per_block_int_scale,
-                                                            weight_offset,
-                                                            quant_data,
-                                                            weight_data_type,
-                                                            output_channel_axis,
-                                                            block_scales_axis,
-                                                            block_size,
-                                                            block_scales_shape));
-
-  // MatMul w/ LPBQ requies MatMul(MxK, KxN) and axis = rank-1 (out channels)
-  // Transpose Weight to KxN, output_channel_axis is modified to rank-1;
-  if (input_channel_axis == 1) {
-    ORT_RETURN_IF_ERROR(TwoDimensionTranspose(quant_data, weight_shape, QNN_DATATYPE_SFIXED_POINT_8));
-    input_channel_axis = 0;
-    output_channel_axis = weight_shape.size() - 1;
-  }
-
-  // Construct Quant params for Weight
-  QnnQuantParamsWrapper weight_qparams;
-  weight_qparams = QnnQuantParamsWrapper(per_channel_float_scale, per_block_int_scale, weight_offset, output_channel_axis, block_size, is_int4_type);
-
-  // Get weight tensor type from input of w_dql_tensor or output_dql_tensor
-  Qnn_TensorType_t weight_tensor_type = qnn_model_wrapper.GetTensorType(weight_tensor_name);
-  QnnTensorWrapper weight_tensor(weight_tensor_name, weight_tensor_type, QNN_DATATYPE_SFIXED_POINT_8,
-                                 std::move(weight_qparams), std::move(weight_shape),
-                                 std::move(quant_data));
 
   ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(weight_tensor)), "Failed to add weight");
   input_names.emplace_back(weight_tensor_name);
@@ -320,21 +411,22 @@ Status ProcessLPBQWeight(QnnModelWrapper& qnn_model_wrapper,
 }  // namespace
 
 Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
-                             const NodeUnit& scale_dql_node_unit,
-                             const NodeUnit& w_ql_node_unit,
-                             const NodeUnit& matmul_node_unit,
+                             const NodeUnit* scale_dql_node_unit,
+                             const NodeUnit* w_ql_node_unit,
+                             const NodeUnit* matmul_node_unit,
                              const logging::Logger& logger,
                              bool validate) {
-  assert(scale_dql_node_unit.OpType() == "DequantizeLinear" &&
-         w_ql_node_unit.OpType() == "QuantizeLinear" &&
-         matmul_node_unit.OpType() == "MatMul");
+  ORT_RETURN_IF_NOT((scale_dql_node_unit && scale_dql_node_unit->OpType() == "DequantizeLinear") &&
+                        (!w_ql_node_unit || w_ql_node_unit->OpType() == "QuantizeLinear") &&
+                        (matmul_node_unit && matmul_node_unit->OpType() == "MatMul"),
+                    "Invalid Matmul LPBQ pattern identified");
 
-  const auto& node_name = utils::GetUniqueName(matmul_node_unit);
+  const auto& node_name = utils::GetUniqueName(*matmul_node_unit);
 
   std::vector<std::string> input_names;
 
   // prepare input tensor
-  const NodeUnitIODef& input_def = matmul_node_unit.Inputs()[0];
+  const NodeUnitIODef& input_def = matmul_node_unit->Inputs()[0];
   const std::string& input_tensor_name = input_def.node_arg.Name();
   ORT_RETURN_IF_ERROR(ProcessInput0(qnn_model_wrapper, input_def, input_tensor_name, input_names,
                                     logger, validate));
@@ -344,7 +436,7 @@ Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
                                         matmul_node_unit, input_names, logger));
 
   // Prepare Output
-  const NodeUnitIODef& output_def = matmul_node_unit.Outputs()[0];
+  const NodeUnitIODef& output_def = matmul_node_unit->Outputs()[0];
   const std::string& op_output_name = output_def.node_arg.Name();
   QnnTensorWrapper output_tensor;
   ORT_RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(output_def, output_tensor));

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/lpbqmatmul_fusion.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/lpbqmatmul_fusion.h
@@ -23,9 +23,9 @@ class QnnModelWrapper;
 
 class LowPowerBlockQuantizedMatMulFusion : public IQnnNodeGroup {
  public:
-  LowPowerBlockQuantizedMatMulFusion(const NodeUnit& Scale_DQL_node_unit,
-                                     const NodeUnit& W_QL_node_unit,
-                                     const NodeUnit& MatMul_node_unit);
+  LowPowerBlockQuantizedMatMulFusion(const NodeUnit* Scale_DQL_node_unit,
+                                     const NodeUnit* W_QL_node_unit,
+                                     const NodeUnit* MatMul_node_unit);
   ORT_DISALLOW_COPY_AND_ASSIGNMENT(LowPowerBlockQuantizedMatMulFusion);
 
   Status IsSupported(QnnModelWrapper& qmw, const logging::Logger& logger) const override;

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/utils.cc
@@ -236,5 +236,69 @@ const NodeUnit* GetParentOfInput(const GraphViewer& graph_viewer,
   return nullptr;
 }
 
+const NodeUnit* GetParentOfInputByName(const GraphViewer& graph_viewer,
+                                       const NodeUnit& node_unit,
+                                       const std::string& input_name,
+                                       const std::unordered_map<const Node*, const NodeUnit*>& node_unit_map,
+                                       const std::unordered_map<const NodeUnit*, const IQnnNodeGroup*>& qnn_node_group_map) {
+  const Node* p_child_node = nullptr;
+
+  for (auto node : node_unit.GetAllNodesInGroup()) {
+    for (auto node_input : node->InputDefs()) {
+      if (node_input->Name() == input_name) {
+        p_child_node = node;
+        break;
+      }
+
+      if (p_child_node != nullptr) {
+        break;
+      }
+    }
+  }
+
+  if (p_child_node == nullptr) {
+    return nullptr;
+  }
+
+  const Node& child_node = *p_child_node;
+
+  for (auto edge = child_node.InputEdgesBegin(); edge != child_node.InputEdgesEnd(); ++edge) {
+    const Node& parent_node = edge->GetNode();
+    if (parent_node.OutputDefs()[0]->Name() != input_name) {
+      continue;
+    }
+
+    if (graph_viewer.GetNode(parent_node.Index()) == nullptr) {
+      // Node is not in this GraphViewer
+      return nullptr;
+    }
+
+    if (graph_viewer.NodeProducesGraphOutput(parent_node)) {
+      // Node is producing a graph output
+      return nullptr;
+    }
+
+    const auto parent_node_unit_it = node_unit_map.find(&parent_node);
+    if (parent_node_unit_it == node_unit_map.end()) {
+      return nullptr;
+    }
+    const NodeUnit* p_parent_node_unit = parent_node_unit_it->second;
+
+    // Check if parent node has already been handled. Should not be the case if the calling
+    // fusion function has been called in topological order, but check to be safe.
+    if (qnn_node_group_map.count(p_parent_node_unit) != 0) {
+      return nullptr;
+    }
+
+    // parent must not already be part of a QDQ NodeUnit (i.e., be standalone).
+    if (p_parent_node_unit->UnitType() != NodeUnit::Type::SingleNode) {
+      return nullptr;
+    }
+
+    return p_parent_node_unit;
+  }
+  return nullptr;
+}
+
 }  // namespace qnn
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/utils.h
@@ -51,5 +51,11 @@ const NodeUnit* GetParentOfInput(const GraphViewer& graph_viewer,
                                  const std::unordered_map<const Node*, const NodeUnit*>& node_unit_map,
                                  const std::unordered_map<const NodeUnit*, const IQnnNodeGroup*>& qnn_node_group_map);
 
+const NodeUnit* GetParentOfInputByName(const GraphViewer& graph_viewer,
+                                       const NodeUnit& node_unit,
+                                       const std::string& input_name,
+                                       const std::unordered_map<const Node*, const NodeUnit*>& node_unit_map,
+                                       const std::unordered_map<const NodeUnit*, const IQnnNodeGroup*>& qnn_node_group_map);
+
 }  // namespace qnn
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/qnn/qnn_node_group/lpbqgemm_fusion_without_ql_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/lpbqgemm_fusion_without_ql_test.cc
@@ -1,0 +1,135 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <string>
+#include <vector>
+#include <cmath>
+#include <optional>
+#include <utility>
+#include <array>
+#include <memory>
+#include <unordered_map>
+
+#include "core/graph/graph.h"
+#include "core/graph/node_attr_utils.h"
+#include "test/optimizer/qdq_test_utils.h"
+#include "test/providers/qnn/qnn_test_utils.h"
+#include "gtest/gtest.h"
+
+namespace onnxruntime {
+namespace test {
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+
+namespace {
+
+GetQDQTestCaseFn BuildLPBQGemmWithoutQLTestCase() {
+  return [](ModelTestBuilder& builder) -> void {
+    // Define the test case for LPBQGemm fusion without QuantizeLinear node
+    const int64_t input_channels = 16;
+    const int64_t output_channels = 16;
+    const int64_t blocks_per_axis = 4;
+    const std::vector<int64_t> input_shape{1, input_channels};
+    auto input_def = TestInputDef<float>(input_shape, false, -0.5f, 0.5f);
+    NodeArg* input = MakeTestInput<float>(builder, input_def);
+
+    // QuantizeLinear for Activation
+    NodeArg* act_ql_output = builder.MakeIntermediate();
+    NodeArg* act_ql_scale = builder.MakeScalarInitializer<float>(0.00005509183756657876f);
+    NodeArg* act_ql_zero_point = builder.MakeScalarInitializer<uint16_t>(23715);
+    builder.AddNode("QuantizeLinear", {input, act_ql_scale, act_ql_zero_point}, {act_ql_output});
+
+    // DequantizeLinear for Activation
+    NodeArg* act_dql_output = builder.MakeIntermediate();
+    NodeArg* act_dql_scale = builder.MakeScalarInitializer<float>(0.00005509183756657876f);
+    NodeArg* act_dql_zero_point = builder.MakeScalarInitializer<uint16_t>(23715);
+    builder.AddNode("DequantizeLinear", {act_ql_output, act_dql_scale, act_dql_zero_point}, {act_dql_output});
+
+    // DequantizeLinear for Scale
+    NodeArg* scale_dql_input = builder.MakeInitializer<uint8_t>({blocks_per_axis, output_channels}, 1, 15);
+    NodeArg* scale_dql_scale = builder.MakeInitializer<float>({output_channels}, 0.01f, 0.02f);
+    std::vector<uint8_t> dql_zero_points_data = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    NodeArg* scale_dql_zero_point = builder.Make1DInitializer<uint8_t>(dql_zero_points_data);
+    NodeArg* scale_dql_output = builder.MakeIntermediate();
+    Node& scale_dql = builder.AddNode("DequantizeLinear", {scale_dql_input, scale_dql_scale, scale_dql_zero_point}, {scale_dql_output});
+    scale_dql.AddAttribute("axis", static_cast<int64_t>(1));
+
+    // Create quantized weight directly (skip QuantizeLinear)
+    // We're creating a pre-quantized weight tensor that would normally be the output of QuantizeLinear
+    std::vector<Int4x2> quantized_weight_data;
+    size_t num_storage_elems = input_channels * output_channels;
+    quantized_weight_data.resize(Int4x2::CalcNumInt4Pairs(num_storage_elems));
+    for (size_t i = 0; i < num_storage_elems / 2; ++i) {
+      // Set some pattern in the quantized weights
+      quantized_weight_data[i].SetElem(0, i % 16);
+      quantized_weight_data[i].SetElem(1, (i + 8) % 16);
+    }
+    NodeArg* w_quantized = builder.MakeInitializer<Int4x2>({input_channels, output_channels}, quantized_weight_data);
+
+    // DequantizeLinear for Weight (directly using the quantized weight)
+    std::vector<Int4x2> zero_points_data;
+    size_t num_zp_elems = blocks_per_axis * output_channels;
+    zero_points_data.resize(Int4x2::CalcNumInt4Pairs(num_zp_elems));
+    for (size_t i = 0; i < num_zp_elems; ++i) {
+      size_t r = i >> 1;
+      size_t c = i & 0x1;
+      zero_points_data[r].SetElem(c, 0);
+    }
+    NodeArg* w_dql_zero_point = builder.MakeInitializer<Int4x2>({blocks_per_axis, output_channels}, zero_points_data);
+    NodeArg* w_dql_output = builder.MakeIntermediate();
+    Node& w_dql = builder.AddNode("DequantizeLinear", {w_quantized, scale_dql_output, w_dql_zero_point}, {w_dql_output});
+    w_dql.AddAttribute("axis", static_cast<int64_t>(0));
+    w_dql.AddAttribute("block_size", static_cast<int64_t>(4));
+
+    // Gemm
+    NodeArg* gemm_bias = builder.MakeInitializer<float>({output_channels}, -1.0f, 1.0f);
+    NodeArg* gemm_output = builder.MakeIntermediate();
+    builder.AddNode("Gemm", {act_dql_output, w_dql_output, gemm_bias}, {gemm_output});
+
+    // QuantizeLinear for Output
+    NodeArg* output_ql_scale = builder.MakeScalarInitializer<float>(0.00019595865160226822f);
+    NodeArg* output_ql_zero_point = builder.MakeScalarInitializer<uint16_t>(31693);
+    NodeArg* output_ql_output = builder.MakeIntermediate();
+    builder.AddNode("QuantizeLinear", {gemm_output, output_ql_scale, output_ql_zero_point}, {output_ql_output});
+
+    // DequantizeLinear for Output
+    NodeArg* output_dql_scale = builder.MakeScalarInitializer<float>(0.00019595865160226822f);
+    NodeArg* output_dql_zero_point = builder.MakeScalarInitializer<uint16_t>(31693);
+    NodeArg* output_dql_output = builder.MakeOutput();
+    builder.AddNode("DequantizeLinear", {output_ql_output, output_dql_scale, output_dql_zero_point}, {output_dql_output});
+  };
+}
+
+ProviderOptions GetProviderOptions() {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  return provider_options;
+}
+
+}  // namespace
+
+#if defined(_WIN32)
+// Graph fails to compose on ARM64 Windows since QNN 2.37.0
+TEST_F(QnnHTPBackendTests, DISABLED_LPBQGemmFusionWithoutQL) {
+#else
+TEST_F(QnnHTPBackendTests, LPBQGemmFusionWithoutQL) {
+#endif
+  ProviderOptions provider_options = GetProviderOptions();
+  RunQnnModelTest(BuildLPBQGemmWithoutQLTestCase(),
+                  provider_options,
+                  /*opset_version=*/21,
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::Some,
+                  /*fp32_abs_err=*/1e-2f,
+                  /*log_severity =*/logging::Severity::kERROR,
+                  /*verify_outputs=*/false);
+}
+
+#endif  // defined(__aarch64__) || defined(_M_ARM64)
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/test/providers/qnn/qnn_node_group/lpbqmatmul_fusion_without_ql_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/lpbqmatmul_fusion_without_ql_test.cc
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <string>
+#include <vector>
+#include <cmath>
+#include <optional>
+#include <utility>
+#include <array>
+#include <memory>
+#include <unordered_map>
+
+#include "core/graph/graph.h"
+#include "core/graph/node_attr_utils.h"
+#include "test/optimizer/qdq_test_utils.h"
+#include "test/providers/qnn/qnn_test_utils.h"
+#include "gtest/gtest.h"
+
+namespace onnxruntime {
+namespace test {
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+
+namespace {
+
+GetQDQTestCaseFn BuildLPBQMatMulWithoutQLTestCase() {
+  return [](ModelTestBuilder& builder) -> void {
+    // Define the test case for LPBQMatMul fusion without QuantizeLinear node
+    const int64_t input_channels = 16;
+    const int64_t output_channels = 16;
+    const int64_t blocks_per_axis = 4;
+    const std::vector<int64_t> input_shape{1, input_channels};
+    auto input_def = TestInputDef<float>(input_shape, false, -0.5f, 0.5f);
+    NodeArg* input = MakeTestInput<float>(builder, input_def);
+
+    // QuantizeLinear for Activation
+    NodeArg* act_ql_output = builder.MakeIntermediate();
+    NodeArg* act_ql_scale = builder.MakeScalarInitializer<float>(0.00005509183756657876f);
+    NodeArg* act_ql_zero_point = builder.MakeScalarInitializer<uint16_t>(23715);
+    builder.AddNode("QuantizeLinear", {input, act_ql_scale, act_ql_zero_point}, {act_ql_output});
+
+    // DequantizeLinear for Activation
+    NodeArg* act_dql_output = builder.MakeIntermediate();
+    NodeArg* act_dql_scale = builder.MakeScalarInitializer<float>(0.00005509183756657876f);
+    NodeArg* act_dql_zero_point = builder.MakeScalarInitializer<uint16_t>(23715);
+    builder.AddNode("DequantizeLinear", {act_ql_output, act_dql_scale, act_dql_zero_point}, {act_dql_output});
+
+    // DequantizeLinear for Scale
+    NodeArg* scale_dql_input = builder.MakeInitializer<uint8_t>({blocks_per_axis, output_channels}, 1, 15);
+    NodeArg* scale_dql_scale = builder.MakeInitializer<float>({output_channels}, 0.01f, 0.02f);
+    std::vector<uint8_t> dql_zero_points_data = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    NodeArg* scale_dql_zero_point = builder.Make1DInitializer<uint8_t>(dql_zero_points_data);
+    NodeArg* scale_dql_output = builder.MakeIntermediate();
+    Node& scale_dql = builder.AddNode("DequantizeLinear", {scale_dql_input, scale_dql_scale, scale_dql_zero_point}, {scale_dql_output});
+    scale_dql.AddAttribute("axis", static_cast<int64_t>(1));
+
+    // Create quantized weight directly (skip QuantizeLinear)
+    // We're creating a pre-quantized weight tensor that would normally be the output of QuantizeLinear
+    std::vector<Int4x2> quantized_weight_data;
+    size_t num_storage_elems = input_channels * output_channels;
+    quantized_weight_data.resize(Int4x2::CalcNumInt4Pairs(num_storage_elems));
+    for (size_t i = 0; i < num_storage_elems / 2; ++i) {
+      // Set some pattern in the quantized weights
+      quantized_weight_data[i].SetElem(0, i % 16);
+      quantized_weight_data[i].SetElem(1, (i + 8) % 16);
+    }
+    NodeArg* w_quantized = builder.MakeInitializer<Int4x2>({input_channels, output_channels}, quantized_weight_data);
+
+    // DequantizeLinear for Weight
+    std::vector<Int4x2> zero_points_data;
+    size_t num_zp_elems = blocks_per_axis * output_channels;
+    zero_points_data.resize(Int4x2::CalcNumInt4Pairs(num_zp_elems));
+    for (size_t i = 0; i < num_zp_elems; ++i) {
+      size_t r = i >> 1;
+      size_t c = i & 0x1;
+      zero_points_data[r].SetElem(c, 0);
+    }
+    NodeArg* w_dql_zero_point = builder.MakeInitializer<Int4x2>({blocks_per_axis, output_channels}, zero_points_data);
+    NodeArg* w_dql_output = builder.MakeIntermediate();
+    Node& w_dql = builder.AddNode("DequantizeLinear", {w_quantized, scale_dql_output, w_dql_zero_point}, {w_dql_output});
+    w_dql.AddAttribute("axis", static_cast<int64_t>(0));
+    w_dql.AddAttribute("block_size", static_cast<int64_t>(4));
+
+    // MatMul
+    NodeArg* matmul_output = builder.MakeIntermediate();
+    builder.AddNode("MatMul", {act_dql_output, w_dql_output}, {matmul_output});
+
+    // QuantizeLinear for Output
+    NodeArg* output_ql_scale = builder.MakeScalarInitializer<float>(0.00019595865160226822f);
+    NodeArg* output_ql_zero_point = builder.MakeScalarInitializer<uint16_t>(31693);
+    NodeArg* output_ql_output = builder.MakeIntermediate();
+    builder.AddNode("QuantizeLinear", {matmul_output, output_ql_scale, output_ql_zero_point}, {output_ql_output});
+
+    // DequantizeLinear for Output
+    NodeArg* output_dql_scale = builder.MakeScalarInitializer<float>(0.00019595865160226822f);
+    NodeArg* output_dql_zero_point = builder.MakeScalarInitializer<uint16_t>(31693);
+    NodeArg* output_dql_output = builder.MakeOutput();
+    builder.AddNode("DequantizeLinear", {output_ql_output, output_dql_scale, output_dql_zero_point}, {output_dql_output});
+  };
+}
+
+ProviderOptions GetProviderOptions() {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  return provider_options;
+}
+
+}  // namespace
+
+#if defined(_WIN32)
+// Graph fails to compose on ARM64 Windows since QNN 2.37.0
+TEST_F(QnnHTPBackendTests, DISABLED_LPBQMatMulFusionWithoutQL) {
+#else
+TEST_F(QnnHTPBackendTests, LPBQMatMulFusionWithoutQL) {
+#endif
+  ProviderOptions provider_options = GetProviderOptions();
+  RunQnnModelTest(BuildLPBQMatMulWithoutQLTestCase(),
+                  provider_options,
+                  /*opset_version=*/21,
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::Some,
+                  /*fp32_abs_err=*/1e-2f,
+                  /*log_severity =*/logging::Severity::kERROR,
+                  /*verify_outputs=*/false);
+}
+
+#endif  // defined(__aarch64__) || defined(_M_ARM64)
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)


### PR DESCRIPTION
### Description

 - Case-2 LPBQ pattern omits QuantizeLinear node in LPBQ packing pattern
 - Modify LPBQ fusion logic in QNN EP implemented for Gemma and MatMul nodes to gracefully handle the optional QuantizeLinear node in LPBQ packing pattern.
 - Add unit tests to verify Case-2 LPBQ pattern fusion for Gemm and MatMul nodes.



### Motivation and Context
- QuantizeLinear node in LowPowerBlockQuantization encoding packing pattern can be optional as it helps to keep the weights in INT datatype and further helps to reduce the size of model.


