### PR TITLE
fix: add missing thread header include to TRT-RTX provider

### DIFF
--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
@@ -31,6 +31,7 @@
 #include <map>
 #include <memory>
 #include <filesystem>
+#include <thread>
 // TODO: find a better way to share this
 #include "core/providers/cuda/cuda_stream_handle.h"
 


### PR DESCRIPTION
This adds a missing thread header include to satisfy the std::thread access.

### Description
As outlined in #25874, a thread header import seems necessary with the standard set of libs installed and the standard compiler on Ubuntu 22.04.

Fixes #25874
