### PR TITLE
Extend ORT perf test to report submit vs inference time

### DIFF
--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -238,6 +238,18 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
 #endif
   } else if (provider_name_ == onnxruntime::kNvTensorRTRTXExecutionProvider) {
 #ifdef USE_NV
+#ifdef _MSC_VER
+    std::string ov_string = ToUTF8String(performance_test_config.run_config.ep_runtime_config_string);
+#else
+    std::string ov_string = performance_test_config.run_config.ep_runtime_config_string;
+#endif
+    ParseSessionConfigs(ov_string, provider_options);
+    if (!provider_options.empty()) {
+      std::cout << "Setting NV TensorRT RTX provider options to:\n";
+      for (const auto& provider_option : provider_options) {
+        std::cout << "\t" << provider_option.first << ":" << provider_option.second << "\n";
+      }
+    }
     session_options.AppendExecutionProvider("NvTensorRtRtx", provider_options);
     if (performance_test_config.run_config.enable_cuda_io_binding) {
       device_memory_name_ = CUDA;

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -58,7 +58,8 @@ RunTiming OnnxRuntimeTestSession::Run() {
     for (auto& name : output_names_) {
       io_binding.BindOutput(name.c_str(), mem_info);
     }
-
+    // do not time IO binding creation
+    start = std::chrono::high_resolution_clock::now();
     session_.Run(run_options, io_binding);
     timing.submit_timing = std::chrono::high_resolution_clock::now() - start;
     io_binding.SynchronizeOutputs();

--- a/onnxruntime/test/perftest/ort_test_session.h
+++ b/onnxruntime/test/perftest/ort_test_session.h
@@ -29,7 +29,7 @@ class OnnxRuntimeTestSession : public TestSession {
 
   ~OnnxRuntimeTestSession() = default;
 
-  std::chrono::duration<double> Run() override;
+  RunTiming Run() override;
 
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(OnnxRuntimeTestSession);
 

--- a/onnxruntime/test/perftest/ort_test_session.h
+++ b/onnxruntime/test/perftest/ort_test_session.h
@@ -6,6 +6,11 @@
 #include <random>
 #include "test_configuration.h"
 #include "test_session.h"
+
+#if defined(USE_CUDA) || defined(USE_TENSORRT) || defined(USE_NV)
+#include <cuda_runtime.h>
+#endif
+
 class TestModelInfo;
 namespace onnxruntime {
 namespace perftest {
@@ -27,7 +32,7 @@ class OnnxRuntimeTestSession : public TestSession {
 
   bool PopulateGeneratedInputTestData(int32_t seed);
 
-  ~OnnxRuntimeTestSession() = default;
+  ~OnnxRuntimeTestSession();
 
   RunTiming Run() override;
 
@@ -51,6 +56,9 @@ class OnnxRuntimeTestSession : public TestSession {
   const int input_length_;
   std::string provider_name_;
   std::string device_memory_name_;  // Device memory type name to use from the list in allocator.h
+#if defined(USE_CUDA) || defined(USE_TENSORRT) || defined(USE_NV)
+  cudaStream_t stream_;  // Device stream if required by IO bindings
+#endif
 };
 
 }  // namespace perftest

--- a/onnxruntime/test/perftest/performance_runner.cc
+++ b/onnxruntime/test/perftest/performance_runner.cc
@@ -69,19 +69,19 @@ void PerformanceResult::DumpToFile(const std::basic_string<ORTCHAR_T>& path, boo
   }
 
   if (have_file) {
-    for (size_t runs = 0; runs < time_costs.size(); runs++) {
-      outfile << model_name << "," << time_costs[runs] << "," << peak_workingset_size << ","
+    for (size_t runs = 0; runs < time_costs_submission.size(); runs++) {
+      outfile << model_name << "," << time_costs_submission[runs] << "," << peak_workingset_size << ","
               << average_CPU_usage << "," << runs << std::endl;
     }
   } else {
     // match formatting of the initial output from PerformanceRunner::Run
     std::cout << "Avg CPU usage:" << average_CPU_usage
               << "\nPeak working set size:" << peak_workingset_size
-              << "\nRuns:" << time_costs.size() << std::endl;
+              << "\nRuns:" << time_costs_submission.size() << std::endl;
   }
 
-  if (!time_costs.empty() && f_include_statistics) {
-    std::vector<double> sorted_time = time_costs;
+  if (!time_costs_submission.empty() && f_include_statistics) {
+    std::vector<double> sorted_time = time_costs_submission;
 
     size_t total = sorted_time.size();
     size_t n50 = static_cast<size_t>(total * 0.5);
@@ -152,15 +152,21 @@ Status PerformanceRunner::Run() {
   auto first_inference_duration =
       std::chrono::duration_cast<std::chrono::milliseconds>(initial_inference_result_.end - initial_inference_result_.start).count();
   std::chrono::duration<double> inference_duration = performance_result_.end - performance_result_.start;
-
+  auto iterations = performance_result_.time_costs_submission.size();
+  double avg_cpu_time_ms = std::accumulate(performance_result_.time_costs_submission.begin(), performance_result_.time_costs_submission.end(), 0.0) / static_cast<double>(iterations) * 1000;
+  double avg_total_time_ms = std::accumulate(performance_result_.time_costs_total.begin(), performance_result_.time_costs_total.end(), 0.0) / static_cast<double>(iterations) * 1000;
+  std::string avg_time_string = "Average inference time cost total: " + std::to_string(avg_total_time_ms) + " ms\n";
+  if (performance_test_config_.run_config.enable_cuda_io_binding) {
+    avg_time_string += "Average inference time cost submission: " + std::to_string(avg_cpu_time_ms) + " ms\n";
+  }
   std::cout << "Session creation time cost: " << session_create_duration.count() << " s\n"
             << "First inference time cost: " << first_inference_duration << " ms\n"
             << "Total inference time cost: " << performance_result_.total_time_cost << " s\n"  // sum of time taken by each request
-            << "Total inference requests: " << performance_result_.time_costs.size() << "\n"
-            << "Average inference time cost: " << performance_result_.total_time_cost / performance_result_.time_costs.size() * 1000 << " ms\n"
+            << "Total inference requests: " << iterations << "\n"
+            << avg_time_string
             // Time between start and end of run. Less than Total time cost when running requests in parallel.
             << "Total inference run time: " << inference_duration.count() << " s\n"
-            << "Number of inferences per second: " << performance_result_.time_costs.size() / inference_duration.count() << " \n"
+            << "Number of inferences per second: " << iterations / inference_duration.count() << " \n"
             << "Avg CPU usage: " << performance_result_.average_CPU_usage << " %\n"
             << "Peak working set size: " << performance_result_.peak_workingset_size << " bytes"
             << std::endl;

--- a/onnxruntime/test/perftest/test_session.h
+++ b/onnxruntime/test/perftest/test_session.h
@@ -8,9 +8,15 @@
 
 namespace onnxruntime {
 namespace perftest {
+
+struct RunTiming {
+  std::chrono::duration<double> submit_timing = std::chrono::seconds(0);
+  std::chrono::duration<double> total_timing = std::chrono::seconds(0);
+};
+
 class TestSession {
  public:
-  virtual std::chrono::duration<double> Run() = 0;
+  virtual RunTiming Run() = 0;
   // TODO: implement it
   // This function won't return duration, because it may vary largely.
   // Please measure the perf at a higher level.

--- a/onnxruntime/test/perftest/tf_test_session.h
+++ b/onnxruntime/test/perftest/tf_test_session.h
@@ -205,7 +205,7 @@ class TensorflowTestSession : public TestSession {
     assert(t != nullptr);
     feed_tensors_[test_data_id][input_id] = t;
   }
-  std::chrono::duration<double> Run() override {
+  RunTiming Run() override {
     // Randomly pick one OrtValueArray from feed_tensors_. (NOT ThreadSafe)
     const std::uniform_int_distribution<int>::param_type p(0, static_cast<int>(feed_tensors_.size() - 1));
     const size_t id = static_cast<size_t>(dist_(rand_engine_, p));
@@ -222,7 +222,10 @@ class TensorflowTestSession : public TestSession {
       TF_DeleteTensor(f);
     }
     TF_DeleteStatus(s);
-    return end - start;
+    RunTiming timing;
+    timing.cpu_time = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+    timing.total_timing = timing.submit_timing;
+    return timing;
   }
 
   ~TensorflowTestSession() override {


### PR DESCRIPTION
This PR adds:
- ORT perf test dynamic option parsing for TRT RTX EP
- ORT perf test can now report submit vs inference time for device bindings

@chilo-ms can you help merge this ? 