### PR TITLE
[webgpu] Manually normalize `Conv-Transpose` dispatch group size for Intel GPUs

### DIFF
--- a/onnxruntime/core/providers/webgpu/nn/conv.cc
+++ b/onnxruntime/core/providers/webgpu/nn/conv.cc
@@ -41,9 +41,9 @@ Status TransposeKernel(ComputeContext& context, const Tensor* kernel, const Tens
   // TODO: Revert this change once the driver issue is fixed.
   if (context.AdapterInfo().vendor == std::string_view{"intel"}) {
     ORT_ENFORCE(rank == static_cast<size_t>(4), "Input tensor must have rank 4.");
-    uint32_t dispatch_x = ceil_div(transposed_kernel_shape_vector[0] * transposed_kernel_shape_vector[1], 2);
-    uint32_t dispatch_y = ceil_div(transposed_kernel_shape_vector[2], 4);
-    uint32_t dispatch_z = ceil_div(transposed_kernel_shape_vector[3], 8);
+    dispatch_x = ceil_div(transposed_kernel_shape_vector[0] * transposed_kernel_shape_vector[1], 2);
+    dispatch_y = ceil_div(transposed_kernel_shape_vector[2], 4);
+    dispatch_z = ceil_div(transposed_kernel_shape_vector[3], 8);
   }
 
   TensorShape transposed_kernel_shape(transposed_kernel_shape_vector);

--- a/onnxruntime/core/providers/webgpu/nn/conv.cc
+++ b/onnxruntime/core/providers/webgpu/nn/conv.cc
@@ -8,6 +8,15 @@
 #include "core/providers/webgpu/nn/grouped_conv.h"
 #include "core/providers/webgpu/webgpu_utils.h"
 #include "core/providers/webgpu/math/matmul.h"
+
+namespace {
+
+inline uint32_t ceil_div(int64_t numerator, int32_t denominator) {
+  return static_cast<uint32_t>((numerator + denominator - 1) / denominator);
+}
+
+}  // namespace
+
 namespace onnxruntime {
 namespace webgpu {
 
@@ -19,6 +28,13 @@ Status TransposeKernel(ComputeContext& context, const Tensor* kernel, const Tens
     transposed_kernel_shape_vector[i] = kernel_shape[perm[i]];
   }
   uint32_t output_size = onnxruntime::narrow<uint32_t>(kernel_shape.Size());
+
+  // Normalize dispatch = ceil_div(output_size, 64)
+  ORT_ENFORCE(rank == static_cast<size_t>(4), "Input tensor must have rank 4.");
+  uint32_t dispatch_x = onnxruntime::narrow<uint32_t>(transposed_kernel_shape_vector[0] * transposed_kernel_shape_vector[1]);
+  uint32_t dispatch_y = ceil_div(transposed_kernel_shape_vector[2], 8);
+  uint32_t dispatch_z = ceil_div(transposed_kernel_shape_vector[3], 8);
+
   TensorShape transposed_kernel_shape(transposed_kernel_shape_vector);
   *transposed_kernel = context.CreateGPUTensor(kernel->DataType(), transposed_kernel_shape);
   bool use_shared = false;
@@ -28,7 +44,8 @@ Status TransposeKernel(ComputeContext& context, const Tensor* kernel, const Tens
       .AddInput({kernel, ProgramTensorMetadataDependency::TypeAndRank, kernel_shape, 1})
       .AddOutput({transposed_kernel, ProgramTensorMetadataDependency::TypeAndRank})
       .AddUniformVariable({output_size})
-      .SetDispatchGroupSize((output_size + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE);
+      .SetWorkgroupSize(64)
+      .SetDispatchGroupSize(dispatch_x, dispatch_y, dispatch_z);
   return context.RunProgram(program);
 }
 

--- a/onnxruntime/core/providers/webgpu/nn/conv.cc
+++ b/onnxruntime/core/providers/webgpu/nn/conv.cc
@@ -34,7 +34,7 @@ Status TransposeKernel(ComputeContext& context, const Tensor* kernel, const Tens
   uint32_t dispatch_z = 1;
 
   // This temporary workaround addresses a significant performance bottleneck
-  // (10x slower) for the shape (3, 3, 2560, 1280) due to an issue with Intel's
+  // (~12x slower) for the shape (3, 3, 2560, 1280) due to an issue with Intel's
   // GPU drivers. We manually normalize the dispatch group size to restore
   // performance.
   //

--- a/onnxruntime/core/providers/webgpu/nn/conv.cc
+++ b/onnxruntime/core/providers/webgpu/nn/conv.cc
@@ -31,8 +31,8 @@ Status TransposeKernel(ComputeContext& context, const Tensor* kernel, const Tens
 
   // Normalize dispatch = ceil_div(output_size, 64)
   ORT_ENFORCE(rank == static_cast<size_t>(4), "Input tensor must have rank 4.");
-  uint32_t dispatch_x = onnxruntime::narrow<uint32_t>(transposed_kernel_shape_vector[0] * transposed_kernel_shape_vector[1]);
-  uint32_t dispatch_y = ceil_div(transposed_kernel_shape_vector[2], 8);
+  uint32_t dispatch_x = ceil_div(transposed_kernel_shape_vector[0] * transposed_kernel_shape_vector[1], 2);
+  uint32_t dispatch_y = ceil_div(transposed_kernel_shape_vector[2], 4);
   uint32_t dispatch_z = ceil_div(transposed_kernel_shape_vector[3], 8);
 
   TensorShape transposed_kernel_shape(transposed_kernel_shape_vector);


### PR DESCRIPTION
### Description
This PR improves the performance of `Conv-Transpose` by ~12x on Lunar Lake.

For a specific shape: (3, 3, 2560, 1280), the default normalization produced a dispatch group size of (679, 679, 1) resulted in extremely slow performance on LNL (likely due to a driver issue). By manually normalize the dispatch group size to (5, 640, 160), we achieve a significant ~12x performance improvement on LNL.

### Motivation and Context
See above.

Co-authored-by: Yang, Wenqin <wenqin.yang@intel.com>
