### PR TITLE
[QNN EP] Remove workaround for syntax error macro

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -56,12 +56,6 @@ static const char* DlError() {
 #endif
 }
 
-// Workaround for a missing comma in QNN_IR_GRAPH_CUSTOM_CONFIG_INIT.
-static QnnIrGraph_CustomConfig_t EmptyIrGraphConfig() {
-  return {
-      QNN_IR_GRAPH_CONFIG_OPTION_SERIALIZATION, {QNN_IR_GRAPH_SERIALIZATION_TYPE_FLAT_BUFFER, ""}};
-}
-
 class QnnIrConfig : public QnnSerializerConfig {
  public:
   QnnIrConfig(std::string backend_path, std::string dlc_dir)
@@ -97,7 +91,7 @@ class QnnIrConfig : public QnnSerializerConfig {
 
  private:
   static QnnConfigsBuilder<QnnGraph_Config_t, QnnIrGraph_CustomConfig_t> MakeConfigsBuilder() {
-    return QnnConfigsBuilder<QnnGraph_Config_t, QnnIrGraph_CustomConfig_t>(QNN_GRAPH_CONFIG_INIT, EmptyIrGraphConfig());
+    return QnnConfigsBuilder<QnnGraph_Config_t, QnnIrGraph_CustomConfig_t>(QNN_GRAPH_CONFIG_INIT, QNN_IR_GRAPH_CUSTOM_CONFIG_INIT);
   }
 
   std::filesystem::path dlc_dir_;


### PR DESCRIPTION
### Description

Until QAIRT 2.37.0, `QNN_IR_GRAPH_SERIALIZATION_OPTION_INIT` was unusable due to a missing semicolon. Now that it's been fixed, revert the workaround.
