### PR TITLE
[WebGPU] allow async shader compilation

### DIFF
--- a/onnxruntime/core/providers/webgpu/program_manager.h
+++ b/onnxruntime/core/providers/webgpu/program_manager.h
@@ -16,6 +16,7 @@ namespace onnxruntime {
 class Tensor;
 
 namespace webgpu {
+class WebGpuContext;
 
 class ProgramArtifact {
  public:
@@ -34,7 +35,7 @@ class ProgramArtifact {
 
 class ProgramManager {
  public:
-  ProgramManager(const wgpu::Device& device, const wgpu::Limits& limits) : device_(device), limits_(limits) {}
+  ProgramManager(WebGpuContext& webgpu_context) : webgpu_context_(webgpu_context) {}
 
   Status NormalizeDispatchGroupSize(uint32_t& x, uint32_t& y, uint32_t& z) const;
 
@@ -53,8 +54,7 @@ class ProgramManager {
 
  private:
   std::unordered_map<std::string, ProgramArtifact> programs_;
-  const wgpu::Device& device_;
-  const wgpu::Limits& limits_;
+  WebGpuContext& webgpu_context_;
 };
 
 }  // namespace webgpu

--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -169,7 +169,7 @@ void WebGpuContext::Initialize(const WebGpuBufferCacheConfig& buffer_cache_confi
                                                            BufferCacheMode::Disabled);
 
     // create program manager
-    program_mgr_ = std::make_unique<ProgramManager>(Device(), DeviceLimits());
+    program_mgr_ = std::make_unique<ProgramManager>(*this);
 
     // set query type
 #if !defined(__wasm__)


### PR DESCRIPTION
### Description

Reduce the time blocked waiting for the shader to be compiled.

### Motivation and Context

Try to optimize the responsiveness of the application when running ort-web in main thread. See #25882