### PR TITLE
Use vmlaq_f32 in MlasMultipleAddFloat32x4 for Android armeabi-v7a.

### DIFF
--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -2280,7 +2280,8 @@ MLAS_FLOAT32X4
 MlasMultiplyAddFloat32x4(MLAS_FLOAT32X4 Vector1, MLAS_FLOAT32X4 Vector2, MLAS_FLOAT32X4 Vector3)
 {
 #if defined(MLAS_NEON_INTRINSICS)
-#if defined(MLAS_TARGET_ARM)
+#if defined(__ANDROID__) && defined(MLAS_TARGET_ARM)
+    // Android armeabi-v7a ABI doesn't have vfmaq_f32()
     return vmlaq_f32(Vector3, Vector1, Vector2);
 #else
     return vfmaq_f32(Vector3, Vector1, Vector2);


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Use vmlaq_f32 in MlasMultiplyAddFloat32x4 for Android armeabi-v7a.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix Android armeabi-v7a build where vfmaq_f32 is not available.

Fix #25949
