### PR TITLE
Upgrade wheel to 0.45.1

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/requirements.txt
@@ -3,7 +3,7 @@ numpy==2.2.6
 mypy
 pytest
 setuptools==78.1.1
-wheel==0.42.0
+wheel==0.45.1
 onnx==1.18.0
 argparse
 sympy==1.14


### PR DESCRIPTION
Currently our macOS wheels use Metadata-Version  2.1
Currently our Windows and Linux wheels use Metadata-Version  2.4
Because they use different versions of the ["wheel"](https://pypi.org/project/wheel/#history)  package that is used for generating the wheel files. 

When publishing the macOS wheels to Azure DevOps feed, I got the following error:
```
ERROR: Failed to upload onnxruntime-1.23.0.dev20250903002-cp310-cp310-macosx_13_0_universal2.whl.
Return code: 1
STDOUT:
Uploading distributions to 
https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi
/upload
ERROR    InvalidDistribution: Invalid distribution metadata: dynamic introduced 
         in metadata version 2.2, not 2.1            
```

This PR makes them consistent. 
