### PR TITLE
[QNN EP] fix memory leak in OrtEpFactory::GetSupportedDevices()

### DIFF
--- a/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
+++ b/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
@@ -219,9 +219,11 @@ struct QnnEpFactory : OrtEpFactory {
         OrtKeyValuePairs* ep_options = nullptr;
         factory->ort_api.CreateKeyValuePairs(&ep_options);
         factory->ort_api.AddKeyValuePair(ep_options, "backend_path", factory->qnn_backend_path.c_str());
-        ORT_API_RETURN_IF_ERROR(
-            factory->ort_api.GetEpApi()->CreateEpDevice(factory, &device, nullptr, ep_options,
-                                                        &ep_devices[num_ep_devices++]));
+        OrtStatus* status = factory->ort_api.GetEpApi()->CreateEpDevice(factory, &device, nullptr, ep_options,
+                                                                        &ep_devices[num_ep_devices++]);
+
+        factory->ort_api.ReleaseKeyValuePairs(ep_options);
+        ORT_API_RETURN_IF_ERROR(status);
       }
     }
 


### PR DESCRIPTION
### Description
Fixes memory leak in `OrtEpFactory::GetSupportedDevices()`. The `OrtKeyValuePairs` instance created by the factory was not released.

This memory leak can be reproduced by running the unit test [QnnHTPBackendTests.AutoEp_PreferNpu](https://github.com/microsoft/onnxruntime/blob/4e2699fbf24d96d2a0261b30509864da08b701de/onnxruntime/test/providers/qnn/qnn_basic_test.cc#L1426).

### Motivation and Context
Fix memory leak that one encounters when using automatic EP selection (e.g., PREFER_NPU) with QNN EP.

