### PR TITLE
Check for non-empty ep_nodes before resizing index_to_ep_node in EpGraph::CreateImpl().

### DIFF
--- a/onnxruntime/core/graph/ep_api_types.cc
+++ b/onnxruntime/core/graph/ep_api_types.cc
@@ -680,9 +680,11 @@ Status EpGraph::CreateImpl(std::unique_ptr<EpGraph> ep_graph, const GraphViewer&
   }
 
   // Iterate through nodes again and update the map of NodeIndex to EpNode*
-  index_to_ep_node.Resize(min_node_index, max_node_index);
-  for (std::unique_ptr<EpNode>& ep_node : ep_nodes) {
-    index_to_ep_node.SetEpNode(ep_node->GetInternalNode().Index(), ep_node.get());
+  if (!ep_nodes.empty()) {
+    index_to_ep_node.Resize(min_node_index, max_node_index);
+    for (std::unique_ptr<EpNode>& ep_node : ep_nodes) {
+      index_to_ep_node.SetEpNode(ep_node->GetInternalNode().Index(), ep_node.get());
+    }
   }
 
   // If this is a subgraph, add the OrtValueInfo and OrtValue objects that come from the outer scope.


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Check for non-empty `ep_nodes` before resizing `index_to_ep_node` in `EpGraph::CreateImpl()`.

In this code:
https://github.com/microsoft/onnxruntime/blob/502416772611825f2e80fb14a865ebf72670689d/onnxruntime/core/graph/ep_api_types.cc#L663-L683

If there are no nodes to process, the values of `min_node_index` and `max_node_index` will not be updated and this assertion in `IndexToEpNodeMap::Resize()` will fail.
https://github.com/microsoft/onnxruntime/blob/502416772611825f2e80fb14a865ebf72670689d/onnxruntime/core/graph/ep_api_types.cc#L538

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix debug assertion failure in [`If.ConditionalBranchesOnlyContainConstantNodes_ThenBranchExecution`](https://github.com/microsoft/onnxruntime/blob/502416772611825f2e80fb14a865ebf72670689d/onnxruntime/test/providers/cpu/controlflow/if_test.cc#L406-L411) when running unit test with a plugin EP (see #25689).