### PR TITLE
Limit telemetry script to Windows agents

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/telemetry-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/telemetry-steps.yml
@@ -5,6 +5,7 @@ steps:
   # TELEMETRYGUID is a runtime variable that is stored on the pipeline in an old-fashioned way. So it cannot be used in
   # template expressions. We access it through env variables.
   - task: PowerShell@2
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
     displayName: 'Set TelemetryOption variable and optionally create TraceLoggingConfigPrivate.h for WinML Telemetry'
     inputs:
       targetType: filePath


### PR DESCRIPTION
This pull request modifies the telemetry script in the Azure Pipelines configuration to ensure it only runs on Windows agents.

The `telemetry-steps.yml` file has been updated to include a condition for the PowerShell task that sets the `TelemetryOption` variable and creates `TraceLoggingConfigPrivate.h`. The new condition, `and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))`, ensures that this task is only executed when the build is running on a Windows agent and all previous steps have completed successfully.

This change prevents the telemetry script from running on non-Windows agents, where it is not applicable.