### PR TITLE
Add opset imports for internal domains to Model Editor model

### DIFF
--- a/onnxruntime/core/graph/model.cc
+++ b/onnxruntime/core/graph/model.cc
@@ -825,13 +825,17 @@ common::Status Model::LoadFromModelEditorApiModel(const OrtModel& model_editor_a
   }
 
   // convert kOnnxDomainAlias to kOnnxDomain if needed and remove the alias entry
-  auto onnx_alias_iter = domain_to_version.find(kOnnxDomainAlias);
-  if (onnx_alias_iter != domain_to_version.end()) {
+  if (auto onnx_alias_iter = domain_to_version.find(kOnnxDomainAlias); onnx_alias_iter != domain_to_version.end()) {
     if (domain_to_version.find(kOnnxDomain) == domain_to_version.end()) {
       domain_to_version[kOnnxDomain] = onnx_alias_iter->second;
     }
 
     domain_to_version.erase(onnx_alias_iter);
+  }
+
+  if (auto onnx_iter = domain_to_version.find(kOnnxDomain); onnx_iter == domain_to_version.end()) {
+    // ONNX domain must be explicitly specified as we can't simply default to the latest opset ORT knows about.
+    return Status(ONNXRUNTIME, INVALID_ARGUMENT, "The opset for the ONNX domain must be explicitly specified.");
   }
 
   // special-case the internal NHWC domain as it must match the ONNX opset if not explicitly imported

--- a/onnxruntime/test/shared_lib/test_model_builder_api.cc
+++ b/onnxruntime/test/shared_lib/test_model_builder_api.cc
@@ -317,15 +317,10 @@ TEST(ModelEditorAPITest, Basic_CApi) {
 
     std::ifstream file(saved_model_path, std::ios::binary);
     ASSERT_TRUE(file.read(buffer.data(), buffer.size()));
-    auto end_data = buffer.data() + buffer.size();
-    ASSERT_NE(std::search(buffer.data(), end_data,
-                          onnxruntime::kMSInternalNHWCDomain,
-                          onnxruntime::kMSInternalNHWCDomain + strlen(onnxruntime::kMSInternalNHWCDomain)),
-              end_data);
-    ASSERT_NE(std::search(buffer.data(), end_data,
-                          onnxruntime::kMSNchwcDomain,
-                          onnxruntime::kMSNchwcDomain + strlen(onnxruntime::kMSNchwcDomain)),
-              end_data);
+
+    std::string_view buffer_view(buffer.data(), buffer.size());
+    ASSERT_NE(buffer_view.find(onnxruntime::kMSInternalNHWCDomain), std::string_view::npos);
+    ASSERT_NE(buffer_view.find(onnxruntime::kMSNchwcDomain), std::string_view::npos);
   };
 
   run_test(false);
@@ -548,7 +543,7 @@ TEST(ModelEditorAPITest, CreateInvalidModel_NoOpsets) {
     auto session = CreateSession(*ort_env, model);
     FAIL();
   } catch (const Ort::Exception& e) {
-    ASSERT_THAT(e.what(), ::testing::HasSubstr("Error No opset import for domain"));
+    ASSERT_THAT(e.what(), ::testing::HasSubstr("The opset for the ONNX domain must be explicitly specified"));
   }
 }
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Add opset imports for internal domains when creating a model via Model Editor API. This is consistent with the behavior when loading an ONNX model (see [here](https://github.com/microsoft/onnxruntime/blob/0b96cbef8da027adec09ebabc9d0a260334c1493/onnxruntime/core/graph/model.cc#L224-L255)).

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Required to make the ONNX file valid if the model is saved after optimization.

#25914

