### PR TITLE
Add void to empty parameter list to fix -Werror=strict-prototypes error

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -5108,7 +5108,7 @@ struct OrtApi {
    *
    * \since Version 1.22.
    */
-  const OrtModelEditorApi*(ORT_API_CALL* GetModelEditorApi)();
+  const OrtModelEditorApi*(ORT_API_CALL* GetModelEditorApi)(void);
 
   /** \brief Create an OrtValue for a Tensor that uses pre-existing memory.
    *
@@ -5166,7 +5166,7 @@ struct OrtApi {
    *
    * \since Version 1.22.
    */
-  const OrtCompileApi*(ORT_API_CALL* GetCompileApi)();
+  const OrtCompileApi*(ORT_API_CALL* GetCompileApi)(void);
 
   //
   // OrtKeyValuePairs
@@ -5434,7 +5434,7 @@ struct OrtApi {
    *
    * \since Version 1.22.
    */
-  const OrtEpApi*(ORT_API_CALL* GetEpApi)();
+  const OrtEpApi*(ORT_API_CALL* GetEpApi)(void);
 
   /** \brief Compute total size in bytes of the tensor data contained in an OrtValue.
    *


### PR DESCRIPTION
Compiling C application dependent on onnxruntime with flag -Werror=strict-prototypes results in an error because the function declarations without parameters are considered to have an implicit int parameter list, which is not allowed in strict prototype mode. To fix this, we need to explicitly specify void in the parameter list of functions that do not take any arguments.

### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

When compiling a C program that depends on ONNX Runtime with the `-Werror=strict-prototypes` flag enabled, the build fails due to function declarations in `onnxruntime_c_api.h` that are not strict prototypes. For example, in the **onnxruntime-inference-examples** project, the following errors are reported:

```
~/install/onnxruntime/include/onnxruntime_c_api.h:4929:3: error: function declaration isn't a prototype [-Werror=strict-prototypes]
  const OrtModelEditorApi*(ORT_API_CALL* GetModelEditorApi)();
  ^~~~~
~/install/onnxruntime/include/onnxruntime_c_api.h:4987:3: error: function declaration isn't a prototype [-Werror=strict-prototypes]
  const OrtCompileApi*(ORT_API_CALL* GetCompileApi)();
  ^~~~~
~/install/onnxruntime/include/onnxruntime_c_api.h:5253:3: error: function declaration isn't a prototype [-Werror=strict-prototypes]
  const OrtEpApi*(ORT_API_CALL* GetEpApi)();
  ^~~~~
```
This occurs because function declarations with empty parentheses are not considered proper prototypes in C, and strict prototype checking treats this as an error.

Our project uses ONNX Runtime and enforces -Werror=strict-prototypes in our build system. It would be very helpful if these declarations in ONNX Runtime could be updated to use (void) for functions that take no arguments, so that strict prototype builds succeed without errors.