### PR TITLE
Support plugin EPs with original SessionOptionsAppendExecutionProvider API

### DIFF
--- a/onnxruntime/core/session/ort_env.cc
+++ b/onnxruntime/core/session/ort_env.cc
@@ -46,6 +46,16 @@ OrtEnv::~OrtEnv() {
 #endif
 }
 
+/*static*/
+OrtEnv::UniquePtr OrtEnv::GetInstanceIfExists() {
+  std::lock_guard<std::mutex> lock(m_);
+  if (p_instance_) {
+    ++ref_count_;
+  }
+
+  return OrtEnv::UniquePtr(p_instance_, OrtEnv::Release);
+}
+
 OrtEnv* OrtEnv::GetInstance(const OrtEnv::LoggingManagerConstructionInfo& lm_info,
                             onnxruntime::common::Status& status,
                             const OrtThreadingOptions* tp_options) {

--- a/onnxruntime/core/session/ort_env.h
+++ b/onnxruntime/core/session/ort_env.h
@@ -35,6 +35,9 @@ struct OrtEnv {
                              onnxruntime::common::Status& status,
                              const OrtThreadingOptions* tp_options = nullptr);
 
+  using UniquePtr = std::unique_ptr<OrtEnv, void (*)(OrtEnv*)>;
+  static UniquePtr GetInstanceIfExists();
+
   static void Release(OrtEnv* env_ptr);
 
   const onnxruntime::Environment& GetEnvironment() const {

--- a/onnxruntime/test/autoep/library/ep.cc
+++ b/onnxruntime/test/autoep/library/ep.cc
@@ -233,7 +233,7 @@ OrtStatus* ORT_API_CALL ExampleEp::GetCapabilityImpl(OrtEp* this_ptr, const OrtG
     for (const auto& node : nodes) {
       auto op_type = node.GetOperatorType();
 
-      if (op_type != "Mul") {
+      if (op_type == "Mul") {
         // Check that Mul has inputs/output of type float
         std::vector<Ort::ConstValueInfo> inputs = node.GetInputs();
         std::vector<Ort::ConstValueInfo> outputs = node.GetOutputs();


### PR DESCRIPTION
### Description
Draft only. May not be merged.

Allows an application to use `SessionOptionsAppendExecutionProvider` with a plugin EP from a library registered with ORT. The `SessionOptionsAppendExecutionProvider` implementation first tries to use an EP built with ORT. If not found, it looks for a plugin EP with the matching name. If a plugin EP exists, an EP factory with all `OrtEpDevice` instances it supports is added to the session options.

```c++
 const OrtApi& c_api = Ort::GetApi();
  ASSERT_ORTSTATUS_OK(c_api.RegisterExecutionProviderLibrary(*ort_env,
                                                             Utils::example_ep_info.registration_name.c_str(),
                                                             Utils::example_ep_info.library_path.c_str()));
  const std::string& plugin_ep_name = Utils::example_ep_info.registration_name;

  {
    Ort::SessionOptions session_options;
    std::unordered_map<std::string, std::string> ep_options;
    session_options.AppendExecutionProvider(plugin_ep_name, ep_options);  // Support added by this PR

    Ort::ModelCompilationOptions compile_options(*ort_env, session_options);
    compile_options.SetFlags(OrtCompileApiFlags::OrtCompileApiFlags_ERROR_IF_NO_NODES_COMPILED);
    compile_options.SetInputModelPath(input_model_file);
    compile_options.SetOutputModelPath(output_model_file);

    Ort::Status status = Ort::CompileModel(*ort_env, compile_options);
  }

  ASSERT_ORTSTATUS_OK(c_api.UnregisterExecutionProviderLibrary(*ort_env,
                                                               Utils::example_ep_info.registration_name.c_str()));

```



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


