### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/actions/linux-web-init-and-check/action.yml
+++ b/.github/actions/linux-web-init-and-check/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v5
       with:
         node-version: "22.x"
 

--- a/.github/actions/macos-ci-setup/action.yml
+++ b/.github/actions/macos-ci-setup/action.yml
@@ -30,7 +30,7 @@ runs:
   using: "composite"
   steps:
     - name: Use Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python_version }}
 
@@ -42,7 +42,7 @@ runs:
         assert platform.machine().lower() == "${{ inputs.platform_machine}}", "This job expects to be run on an ${{ inputs.platform_machine}} machine."
 
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ inputs.node_version }}
 
@@ -51,7 +51,7 @@ runs:
       run: brew install coreutils ninja
 
     - name: Install Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: "temurin"
         java-version: ${{ inputs.java_version }}
@@ -61,7 +61,7 @@ runs:
       run: |
         XCODE_DEVELOPER_DIR="/Applications/Xcode_${{ inputs.xcode_version }}.app/Contents/Developer"
         sudo xcode-select --switch "${XCODE_DEVELOPER_DIR}"
-    
+
     - name: Install python dependencies
       shell: bash
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,7 +61,7 @@ jobs:
           distribution: 'microsoft'
 
       - if: ${{ matrix.language == 'javascript' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -87,7 +87,7 @@ jobs:
     name: Optional Lint C++
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v5
       - name: Update PATH
         run: |
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
@@ -117,7 +117,7 @@ jobs:
     runs-on: ["self-hosted", "1ES.Pool=onnxruntime-github-Ubuntu2204-AMD-CPU"]
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
       - uses: reviewdog/action-eslint@v1

--- a/.github/workflows/linux-wasm-ci-build-and-test-workflow.yml
+++ b/.github/workflows/linux-wasm-ci-build-and-test-workflow.yml
@@ -46,7 +46,7 @@ jobs:
           submodules: recursive
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
 

--- a/.github/workflows/linux_minimal_build.yml
+++ b/.github/workflows/linux_minimal_build.yml
@@ -12,8 +12,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref
-    || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: true
 
 env:
@@ -33,7 +32,7 @@ jobs:
         with:
           submodules: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
 
@@ -69,7 +68,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
 
@@ -87,8 +86,7 @@ jobs:
       - name: Run Build 2 (Update)
         uses: microsoft/onnxruntime-github-actions/run-build-script-in-docker@v0.0.8
         with:
-          docker_image: ${{ steps.build_docker_image_step.outputs.full-image-name
-            }}
+          docker_image: ${{ steps.build_docker_image_step.outputs.full-image-name }}
           build_config: Debug # From original --config Debug
           mode: 'update' # CMake configure step
           extra_build_flags: >-
@@ -102,8 +100,7 @@ jobs:
       - name: Run Build 2 (Build)
         uses: microsoft/onnxruntime-github-actions/run-build-script-in-docker@v0.0.8
         with:
-          docker_image: ${{ steps.build_docker_image_step.outputs.full-image-name
-            }}
+          docker_image: ${{ steps.build_docker_image_step.outputs.full-image-name }}
           build_config: Debug # From original --config Debug
           mode: 'build' # Actual build step
           extra_build_flags: >-
@@ -128,10 +125,10 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
-    
+
       - uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.8
         with:
           vcpkg-version: '2025.06.13'
@@ -162,7 +159,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
 
@@ -194,7 +191,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
 
@@ -228,7 +225,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
 
@@ -247,8 +244,7 @@ jobs:
       - name: Run Build 5 (Update)
         uses: microsoft/onnxruntime-github-actions/run-build-script-in-docker@v0.0.8
         with:
-          docker_image: ${{ steps.build_docker_image_step.outputs.full-image-name
-            }}
+          docker_image: ${{ steps.build_docker_image_step.outputs.full-image-name }}
           build_config: Debug
           mode: 'update'
           extra_build_flags: >-
@@ -260,8 +256,7 @@ jobs:
       - name: Run Build 5 (Build)
         uses: microsoft/onnxruntime-github-actions/run-build-script-in-docker@v0.0.8
         with:
-          docker_image: ${{ steps.build_docker_image_step.outputs.full-image-name
-            }}
+          docker_image: ${{ steps.build_docker_image_step.outputs.full-image-name }}
           build_config: Debug
           mode: 'build'
           extra_build_flags: >-
@@ -272,8 +267,7 @@ jobs:
       - name: Run Build 5 (Test)
         uses: microsoft/onnxruntime-github-actions/run-build-script-in-docker@v0.0.8
         with:
-          docker_image: ${{ steps.build_docker_image_step.outputs.full-image-name
-            }}
+          docker_image: ${{ steps.build_docker_image_step.outputs.full-image-name }}
           build_config: Debug
           mode: 'test'
           extra_build_flags: >-
@@ -316,8 +310,7 @@ jobs:
       - name: Run Build 6a (Update)
         uses: microsoft/onnxruntime-github-actions/run-build-script-in-docker@v0.0.8
         with:
-          docker_image: ${{ steps.build_docker_image_step.outputs.full-image-name
-            }}
+          docker_image: ${{ steps.build_docker_image_step.outputs.full-image-name }}
           build_config: MinSizeRel
           mode: 'update'
           extra_build_flags: >-
@@ -332,8 +325,7 @@ jobs:
       - name: Run Build 6a (Build)
         uses: microsoft/onnxruntime-github-actions/run-build-script-in-docker@v0.0.8
         with:
-          docker_image: ${{ steps.build_docker_image_step.outputs.full-image-name
-            }}
+          docker_image: ${{ steps.build_docker_image_step.outputs.full-image-name }}
           build_config: MinSizeRel
           mode: 'build'
           extra_build_flags: >-
@@ -349,8 +341,7 @@ jobs:
       - name: Run Build 6a (Test)
         uses: microsoft/onnxruntime-github-actions/run-build-script-in-docker@v0.0.8
         with:
-          docker_image: ${{ steps.build_docker_image_step.outputs.full-image-name
-            }}
+          docker_image: ${{ steps.build_docker_image_step.outputs.full-image-name }}
           build_config: MinSizeRel
           mode: 'test'
           extra_build_flags: >-
@@ -396,8 +387,7 @@ jobs:
       - name: Run Build 6b (Update)
         uses: microsoft/onnxruntime-github-actions/run-build-script-in-docker@v0.0.8
         with:
-          docker_image: ${{ steps.build_docker_image_step.outputs.full-image-name
-            }}
+          docker_image: ${{ steps.build_docker_image_step.outputs.full-image-name }}
           build_config: MinSizeRel # From original --config MinSizeRel
           mode: 'update'
           extra_build_flags: >-
@@ -415,8 +405,7 @@ jobs:
       - name: Run Build 6b (Build)
         uses: microsoft/onnxruntime-github-actions/run-build-script-in-docker@v0.0.8
         with:
-          docker_image: ${{ steps.build_docker_image_step.outputs.full-image-name
-            }}
+          docker_image: ${{ steps.build_docker_image_step.outputs.full-image-name }}
           build_config: MinSizeRel # From original --config MinSizeRel
           mode: 'build'
           extra_build_flags: >-
@@ -471,8 +460,7 @@ jobs:
       - name: Run Build 6c (Update)
         uses: microsoft/onnxruntime-github-actions/run-build-script-in-docker@v0.0.8
         with:
-          docker_image: ${{ steps.build_docker_image_step.outputs.full-image-name
-            }}
+          docker_image: ${{ steps.build_docker_image_step.outputs.full-image-name }}
           build_config: MinSizeRel # From original --config MinSizeRel
           mode: 'update'
           extra_build_flags: >-
@@ -490,8 +478,7 @@ jobs:
       - name: Run Build 6c (Build)
         uses: microsoft/onnxruntime-github-actions/run-build-script-in-docker@v0.0.8
         with:
-          docker_image: ${{ steps.build_docker_image_step.outputs.full-image-name
-            }}
+          docker_image: ${{ steps.build_docker_image_step.outputs.full-image-name }}
           build_config: MinSizeRel # From original --config MinSizeRel
           mode: 'build'
           extra_build_flags: >-
@@ -521,7 +508,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
       - name: Download Test Data Artifact

--- a/.github/workflows/publish-js-apidocs.yml
+++ b/.github/workflows/publish-js-apidocs.yml
@@ -25,10 +25,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 18
-      - name: Generate JS docs 
+      - name: Generate JS docs
         run: |
           cd js/
           npm ci

--- a/.github/workflows/windows-web-ci-workflow.yml
+++ b/.github/workflows/windows-web-ci-workflow.yml
@@ -62,7 +62,7 @@ jobs:
           git checkout -- .gitattributes
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20.x"
 

--- a/.github/workflows/windows_cuda.yml
+++ b/.github/workflows/windows_cuda.yml
@@ -56,7 +56,7 @@ jobs:
           Add-Content -Path $env:GITHUB_PATH -Value "$env:RUNNER_TEMP\v12.2\bin"
           Add-Content -Path $env:GITHUB_PATH -Value "$env:RUNNER_TEMP\v12.2\extras\CUPTI\lib64"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20.x'
 
@@ -82,7 +82,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         shell: cmd
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         env:
           PROCESSOR_ARCHITECTURE: x64
         with:
@@ -168,7 +168,7 @@ jobs:
           python-version: '3.12'
           architecture: x64
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20.x'
 
@@ -221,12 +221,12 @@ jobs:
           if ($lastExitCode -ne 0) {
             exit $lastExitCode
           }
-          
+
           python.exe ${{ github.workspace }}\tools\python\update_ctest_path.py   "${{ runner.temp }}\build\RelWithDebInfo\CTestTestfile.cmake" "${{ runner.temp }}\build\RelWithDebInfo"
           if ($lastExitCode -ne 0) {
             exit $lastExitCode
           }
-          
+
           python.exe ${{ github.workspace }}\tools\ci_build\build.py --test --config RelWithDebInfo --build_dir build --skip_submodule_sync --build_csharp --parallel --use_binskim_compliant_compile_flags --cmake_generator "Visual Studio 17 2022" --build_shared_lib --build_wheel --build_java --use_cuda --cuda_home="$env:RUNNER_TEMP\v12.2" --enable_cuda_profiling --use_vcpkg --use_vcpkg_ms_internal_asset_cache --enable_transformers_tool_test --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=86  --cmake_extra_defines onnxruntime_ENABLE_CUDA_EP_INTERNAL_TESTS=ON
           if ($lastExitCode -ne 0) {
             exit $lastExitCode

--- a/.github/workflows/windows_dml.yml
+++ b/.github/workflows/windows_dml.yml
@@ -47,7 +47,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         shell: cmd
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20.x'
 
@@ -67,7 +67,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         shell: cmd
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         env:
           PROCESSOR_ARCHITECTURE: x64
         with:

--- a/.github/workflows/windows_tensorrt.yml
+++ b/.github/workflows/windows_tensorrt.yml
@@ -61,7 +61,7 @@ jobs:
           Add-Content -Path $env:GITHUB_PATH -Value "$env:RUNNER_TEMP\v12.2\extras\CUPTI\lib64"
           Add-Content -Path $env:GITHUB_PATH -Value "$env:RUNNER_TEMP\TensorRT-10.9.0.34.Windows10.x86_64.cuda-12.8\lib"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20.x'
 
@@ -87,7 +87,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         shell: cmd
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         env:
           PROCESSOR_ARCHITECTURE: x64
         with:
@@ -173,7 +173,7 @@ jobs:
           python-version: '3.12'
           architecture: x64
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20.x'
 
@@ -231,12 +231,12 @@ jobs:
           if ($lastExitCode -ne 0) {
             exit $lastExitCode
           }
-          
+
           python.exe ${{ github.workspace }}\tools\python\update_ctest_path.py   "${{ runner.temp }}\build\RelWithDebInfo\CTestTestfile.cmake" "${{ runner.temp }}\build\RelWithDebInfo"
           if ($lastExitCode -ne 0) {
             exit $lastExitCode
           }
-          
+
           python ${{ github.workspace }}\tools\ci_build\build.py --config RelWithDebInfo --parallel --use_binskim_compliant_compile_flags             --build_dir build --skip_submodule_sync --build_shared_lib --test --cmake_generator "Visual Studio 17 2022" --build_wheel --enable_onnx_tests             --use_tensorrt --tensorrt_home="${{ runner.temp }}\TensorRT-10.9.0.34.Windows10.x86_64.cuda-12.8"             --cuda_home="${{ runner.temp }}\v12.2" --use_vcpkg --use_vcpkg_ms_internal_asset_cache --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=86
           if ($lastExitCode -ne 0) {
             exit $lastExitCode

--- a/.github/workflows/windows_webgpu.yml
+++ b/.github/workflows/windows_webgpu.yml
@@ -56,7 +56,7 @@ jobs:
         working-directory: ${{ github.workspace }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20.x"
 
@@ -78,7 +78,7 @@ jobs:
         working-directory: ${{ github.workspace }}
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         env:
           PROCESSOR_ARCHITECTURE: x64
         with:
@@ -230,7 +230,7 @@ jobs:
         working-directory: ${{ github.workspace }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20.x"
 
@@ -252,7 +252,7 @@ jobs:
         working-directory: ${{ github.workspace }}
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         env:
           PROCESSOR_ARCHITECTURE: x64
         with:

--- a/.github/workflows/windows_x64_debug_build_x64_debug.yml
+++ b/.github/workflows/windows_x64_debug_build_x64_debug.yml
@@ -38,7 +38,7 @@ jobs:
         run: python -m pip install -r "${{ github.workspace }}\tools\ci_build\github\windows\python\requirements.txt"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20.x'
 
@@ -60,7 +60,7 @@ jobs:
         working-directory: ${{ github.workspace }}
 
       - name: Use .NET 8.x
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.x'
         env:

--- a/.github/workflows/windows_x64_release_build_x64_release.yml
+++ b/.github/workflows/windows_x64_release_build_x64_release.yml
@@ -38,7 +38,7 @@ jobs:
         run: python -m pip install -r "${{ github.workspace }}\tools\ci_build\github\windows\python\requirements.txt"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20.x'
 
@@ -60,7 +60,7 @@ jobs:
         working-directory: ${{ github.workspace }}
 
       - name: Use .NET 8.x
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.x'
         env:

--- a/.github/workflows/windows_x64_release_ep_generic_interface_build_x64_release_ep_generic_interface.yml
+++ b/.github/workflows/windows_x64_release_ep_generic_interface_build_x64_release_ep_generic_interface.yml
@@ -38,7 +38,7 @@ jobs:
         run: python -m pip install -r "${{ github.workspace }}\tools\ci_build\github\windows\python\requirements.txt"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20.x'
 
@@ -60,7 +60,7 @@ jobs:
         working-directory: ${{ github.workspace }}
 
       - name: Use .NET 8.x
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.x'
         env:

--- a/.github/workflows/windows_x64_release_vitisai_build_x64_release.yml
+++ b/.github/workflows/windows_x64_release_vitisai_build_x64_release.yml
@@ -38,7 +38,7 @@ jobs:
         run: python -m pip install -r "${{ github.workspace }}\tools\ci_build\github\windows\python\requirements.txt"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20.x'
 
@@ -60,7 +60,7 @@ jobs:
         working-directory: ${{ github.workspace }}
 
       - name: Use .NET 8.x
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.x'
         env:

--- a/.github/workflows/windows_x64_release_xnnpack.yml
+++ b/.github/workflows/windows_x64_release_xnnpack.yml
@@ -38,7 +38,7 @@ jobs:
         run: python -m pip install -r "${{ github.workspace }}\tools\ci_build\github\windows\python\requirements.txt"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20.x'
 
@@ -60,7 +60,7 @@ jobs:
         working-directory: ${{ github.workspace }}
 
       - name: Use .NET 8.x
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.x'
         env:

--- a/.github/workflows/windows_x86.yml
+++ b/.github/workflows/windows_x86.yml
@@ -38,7 +38,7 @@ jobs:
         run: python -m pip install -r "${{ github.workspace }}\tools\ci_build\github\windows\python\requirements.txt"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20.x'
           architecture: x86 #Add architecture
@@ -61,7 +61,7 @@ jobs:
         working-directory: ${{ github.workspace }}
 
       - name: Use .NET 8.x
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.x'
         env:


### PR DESCRIPTION
This pull request updates the following GitHub Actions to their latest versions:

- `actions/checkout` to `v5`
- `actions/setup-python` to `v6`
- `actions/setup-node` to `v5`
- `actions/setup-java` to `v5`
- `actions/setup-dotnet` to `v5`

These updates were performed by a script that parsed all YAML workflow files and updated the `uses` statements.