### PR TITLE
feat(tensorrt): add per-session use_tf32 provider option (#26029)

### DIFF
--- a/include/onnxruntime/core/providers/tensorrt/tensorrt_provider_options.h
+++ b/include/onnxruntime/core/providers/tensorrt/tensorrt_provider_options.h
@@ -52,6 +52,7 @@ struct OrtTensorRTProviderOptionsV2 {
   int trt_cuda_graph_enable{0};                          // Enable CUDA graph in ORT TRT
   const char* trt_preview_features{nullptr};             // Specify the preview features to be enabled, features should be separated by comma
                                                          // available keys: "ALIASED_PLUGIN_IO_10_03"
+  int trt_use_tf32{1};                                   // Enable TF32 in TensorRT builder for FP32 compute. Default 1 = true
 
   /*
    * Please note that there are rules for using following context model related provider options:

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -1368,6 +1368,8 @@ TensorrtExecutionProvider::TensorrtExecutionProvider(const TensorrtExecutionProv
     min_subgraph_size_ = info.min_subgraph_size;
     max_workspace_size_ = info.max_workspace_size;
     fp16_enable_ = info.fp16_enable;
+    // TF32 per-session toggle (default true)
+    use_tf32_ = info.use_tf32;
     bf16_enable_ = info.bf16_enable;
     // BF16 support is primarily available on NVIDIA GPUs with the Ampere and later architectures with compute capability of 8.0 or higher.
     if (bf16_enable_ && prop.major < 8) {
@@ -3360,6 +3362,21 @@ Status TensorrtExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphView
 #endif
   // Set precision flags
   std::string trt_node_name_with_precision = fused_node.Name();
+  // apply TF32 builder flag if supported by TensorRT
+#if defined(NV_TENSORRT_MAJOR) && (NV_TENSORRT_MAJOR >= 8)
+  if (use_tf32_) {
+    trt_config->setFlag(nvinfer1::BuilderFlag::kTF32);
+    trt_node_name_with_precision += "_tf32";
+  } else {
+    // clear if available in this TensorRT version
+    trt_config->clearFlag(nvinfer1::BuilderFlag::kTF32);
+    trt_node_name_with_precision += "_notf32";
+  }
+#else
+  if (!use_tf32_) {
+    LOGS_DEFAULT(WARNING) << "[TensorRT EP] use_tf32 unsupported on this TensorRT version; ignoring.";
+  }
+#endif
   if (fp16_enable_) {
     trt_config->setFlag(nvinfer1::BuilderFlag::kFP16);
     trt_node_name_with_precision += "_fp16";
@@ -4003,6 +4020,14 @@ Status TensorrtExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphView
         trt_config->setFlag(nvinfer1::BuilderFlag::kINT8);
         LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] INT8 mode is enabled";
       }
+      // apply TF32 builder flag for this build path as well
+#if defined(NV_TENSORRT_MAJOR) && (NV_TENSORRT_MAJOR >= 8)
+      if (use_tf32_) {
+        trt_config->setFlag(nvinfer1::BuilderFlag::kTF32);
+      } else {
+        trt_config->clearFlag(nvinfer1::BuilderFlag::kTF32);
+      }
+#endif
       if (trt_state->fp16_enable) {
         trt_config->setFlag(nvinfer1::BuilderFlag::kFP16);
         LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] FP16 mode is enabled";

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
@@ -323,6 +323,7 @@ class TensorrtExecutionProvider : public IExecutionProvider {
   int max_partition_iterations_ = 1000;
   size_t min_subgraph_size_ = 1;
   size_t max_workspace_size_ = 0;
+  bool use_tf32_ = true;
   bool fp16_enable_ = false;
   bool bf16_enable_ = false;
   bool int8_enable_ = false;

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_info.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_info.cc
@@ -62,6 +62,7 @@ constexpr const char* kExternalDataBytestreamSize = "trt_external_data_bytestrea
 constexpr const char* kOpTypesToExclude = "trt_op_types_to_exclude";
 constexpr const char* kPreviewFeatures = "trt_preview_features";
 constexpr const char* kGraphIncludeInitializer = "trt_load_user_initializer";
+constexpr const char* kUseTF32 = "use_tf32";
 
 }  // namespace provider_option_names
 }  // namespace tensorrt
@@ -154,6 +155,7 @@ TensorrtExecutionProviderInfo TensorrtExecutionProviderInfo::FromProviderOptions
           .AddAssignmentToReference(tensorrt::provider_option_names::kOpTypesToExclude, info.op_types_to_exclude)
           .AddAssignmentToReference(tensorrt::provider_option_names::kPreviewFeatures, info.preview_features)
           .AddAssignmentToReference(tensorrt::provider_option_names::kGraphIncludeInitializer, info.load_user_initializer)
+          .AddAssignmentToReference(tensorrt::provider_option_names::kUseTF32, info.use_tf32)
           .Parse(options));  // add new provider option here.
 
   info.user_compute_stream = user_compute_stream;
@@ -215,6 +217,7 @@ ProviderOptions TensorrtExecutionProviderInfo::ToProviderOptions(const TensorrtE
       {tensorrt::provider_option_names::kOpTypesToExclude, MakeStringWithClassicLocale(info.op_types_to_exclude)},
       {tensorrt::provider_option_names::kPreviewFeatures, MakeStringWithClassicLocale(info.preview_features)},
       {tensorrt::provider_option_names::kGraphIncludeInitializer, MakeStringWithClassicLocale(info.load_user_initializer)},
+      {tensorrt::provider_option_names::kUseTF32, MakeStringWithClassicLocale(info.use_tf32)},
   };
   return options;
 }
@@ -284,6 +287,7 @@ ProviderOptions TensorrtExecutionProviderInfo::ToProviderOptions(const OrtTensor
       {tensorrt::provider_option_names::kExternalDataBytestreamSize, MakeStringWithClassicLocale(info.trt_external_data_bytestream_size)},
       {tensorrt::provider_option_names::kOpTypesToExclude, kOpTypesToExclude_},
       {tensorrt::provider_option_names::kGraphIncludeInitializer, MakeStringWithClassicLocale(info.trt_load_user_initializer)},
+      {tensorrt::provider_option_names::kUseTF32, MakeStringWithClassicLocale(info.trt_use_tf32)},
   };
   return options;
 }
@@ -394,5 +398,6 @@ void TensorrtExecutionProviderInfo::UpdateProviderOptions(void* provider_options
   trt_provider_options_v2.trt_op_types_to_exclude = copy_string_if_needed(internal_options.op_types_to_exclude);
   trt_provider_options_v2.trt_preview_features = copy_string_if_needed(internal_options.preview_features);
   trt_provider_options_v2.trt_load_user_initializer = internal_options.load_user_initializer;
+  trt_provider_options_v2.trt_use_tf32 = internal_options.use_tf32;
 }
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_info.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_info.h
@@ -23,6 +23,8 @@ struct TensorrtExecutionProviderInfo {
   int max_partition_iterations{1000};
   int min_subgraph_size{1};
   size_t max_workspace_size{0};
+  // By default, enable TF32 for FP32 compute when available
+  bool use_tf32{true};
   bool fp16_enable{false};
   bool bf16_enable{false};
   bool int8_enable{false};

--- a/onnxruntime/core/providers/tensorrt/tensorrt_provider_factory.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_provider_factory.cc
@@ -81,6 +81,7 @@ struct Tensorrt_Provider : Provider {
     info.max_partition_iterations = options.trt_max_partition_iterations;
     info.min_subgraph_size = options.trt_min_subgraph_size;
     info.max_workspace_size = options.trt_max_workspace_size;
+    info.use_tf32 = options.trt_use_tf32 != 0;
     info.fp16_enable = options.trt_fp16_enable != 0;
     info.bf16_enable = options.trt_bf16_enable != 0;
     info.int8_enable = options.trt_int8_enable != 0;

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -748,6 +748,14 @@ static std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory
             } else {
               ORT_THROW("[ERROR] [TensorRT] The value for the key 'trt_weight_stripped_engine_enable' should be 'True' or 'False'. Default value is 'False'.\n");
             }
+          } else if (option.first == "use_tf32") {
+            if (option.second == "True" || option.second == "true" || option.second == "1") {
+              params.trt_use_tf32 = 1;
+            } else if (option.second == "False" || option.second == "false" || option.second == "0") {
+              params.trt_use_tf32 = 0;
+            } else {
+              ORT_THROW("[ERROR] [TensorRT] The value for the key 'use_tf32' should be 'True'/'False' or '1'/'0'. Default is 'True'.\n");
+            }
           } else if (option.first == "trt_onnx_model_folder_path") {
             if (!option.second.empty()) {
               onnx_model_folder_path = option.second;


### PR DESCRIPTION
## Description
- Adds a per-session TensorRT EP option `use_tf32` (default: enabled) to allow/deny TF32 tensor-core math for FP32 compute when building TensorRT engines.  
- Mirrors CUDA EP’s `use_tf32` behavior; enables side-by-side sessions with differing TF32 settings without relying on the global `NVIDIA_TF32_OVERRIDE` env var.  
- Separates engine caches by suffixing names with `_tf32` or `_notf32` to avoid collisions when toggling the option.  

## Motivation & Context
- [Issue #26029](https://github.com/microsoft/onnxruntime/issues/26029) requested parity with CUDA EP’s `use_tf32` to avoid depending on `NVIDIA_TF32_OVERRIDE` and to run concurrent sessions with different TF32 policies.  
- TF32 can impact performance and numeric behavior; fine-grained per-session control improves reproducibility and profiling workflows.  

## Key Changes
### Provider option plumbing
- Add `use_tf32` key (default true) to TensorRT EP provider options.  
  - `onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_info.cc:65, 158, 220, 290, 401`  
  - `onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_info.h:26`  
- Extend C API V2 struct with `trt_use_tf32` (default 1).  
  - `include/onnxruntime/core/providers/tensorrt/tensorrt_provider_options.h:55`  
- Map V2 struct ↔ internal info in factory.  
  - `onnxruntime/core/providers/tensorrt/tensorrt_provider_factory.cc:84`  

### EP behavior
- Add EP member `use_tf32_` and initialize from provider info.  
  - `onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h:326`  
  - `onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc:1372`  
- Apply TensorRT builder flags to enable/disable TF32 per engine build (TRT ≥ 8):  
  - `setFlag/clearFlag(nvinfer1::BuilderFlag::kTF32)`  
  - `onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc:3367, 3372, 4025, 4028`  
- Engine cache separation via name suffix `_tf32` / `_notf32`.  
  - `onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc:3369, 3373`  

### Python binding
- Accept provider options dict key `"use_tf32"` → `params.trt_use_tf32`.  
  - `onnxruntime/python/onnxruntime_pybind_state.cc:753`  

### Tests
- Provider options roundtrip (no GPU required):  
  - `onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc:28, 34`  
- Runtime TF32 engine cache separation test (skips if TRT < 8):  
  - `onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc (UseTF32EngineCacheSeparation)`  

## API Surface
- New provider option (string map): `"use_tf32"` → `"0"/"1"`.  
- New C API V2 field: `OrtTensorRTProviderOptionsV2.trt_use_tf32` (int).  
- Defaults: enabled (`true`/`1`), matching CUDA EP.  

## Usage Example
**Python:**
```python
providers=[("TensorrtExecutionProvider", {"use_tf32": "0"})]


