### PR TITLE
Web/WASM: Copy back results for pre‑allocated CPU outputs (fixes #25786)

### DIFF
--- a/js/web/test/unittests/backends/wasm/test-preallocated-cpu-output.ts
+++ b/js/web/test/unittests/backends/wasm/test-preallocated-cpu-output.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { expect } from 'chai';
+import * as ort from 'onnxruntime-common';
+// A tiny ABS model with static shape [2,4]
+const ONNX_MODEL_TEST_ABS_STATIC = Uint8Array.from([
+  8, 9, 58, 83, 10, 31, 10, 7, 105, 110, 112, 117, 116, 95, 48, 18, 8, 111, 117, 116, 112, 117, 116, 95, 48, 26, 3, 65,
+  98, 115, 34, 3, 65, 98, 115, 58, 0, 18, 3, 97, 98, 115, 90, 25, 10, 7, 105, 110, 112, 117, 116, 95, 48, 18, 14, 10,
+  12, 8, 1, 18, 8, 10, 2, 8, 2, 10, 2, 8, 4, 98, 16, 10, 8, 111, 117, 116, 112, 117, 116, 95, 48, 18, 4, 10, 2, 8, 1,
+  66, 4, 10, 0, 16, 21,
+]);
+describe('#UnitTest# - wasm - preallocated CPU output', () => {
+  it('fills pre-allocated CPU tensor with results', async () => {
+    const session = await ort.InferenceSession.create(ONNX_MODEL_TEST_ABS_STATIC);
+    const dims = [2, 4];
+    const inputData = new Float32Array([-1, 2, -3, 4, -5, 6, -7, 8]);
+    const feeds: Record<string, ort.Tensor> = {
+      input_0: new ort.Tensor('float32', inputData, dims),
+    } as unknown as Record<string, ort.Tensor>;
+    const prealloc = new ort.Tensor('float32', new Float32Array(inputData.length), dims);
+    const results = await session.run(feeds, { output_0: prealloc });
+    // Should return the exact same Tensor instance
+    expect(results.output_0).to.equal(prealloc);
+    const expected = Array.from(inputData, (v) => Math.abs(v));
+    const got = Array.from(prealloc.data as Float32Array);
+    expect(got).to.deep.equal(expected);
+  });
+});

--- a/js/web/test/unittests/index.ts
+++ b/js/web/test/unittests/index.ts
@@ -12,5 +12,6 @@ if (typeof window !== 'undefined') {
 }
 
 require('./backends/wasm/test-model-metadata');
+require('./backends/wasm/test-preallocated-cpu-output');
 
 require('./opset');


### PR DESCRIPTION
# Description

Fix post-run handling for pre-allocated CPU outputs in the WASM core (partially fixes #25786).

- When an output is pre-allocated and its location is `'cpu'`, call `_OrtGetTensorData()` and copy from the WASM heap into the user’s pre-allocated buffer before returning.  
- Supports both numeric and string tensors (string[] updated in place).  
- Preserves zero-copy behavior for `'gpu-buffer'` and `'ml-tensor'` pre-allocs; releases redundant native handles only when the EP swaps them via IO binding.  
- **Add a unit test** that validates the behavior: runs a tiny ABS model and pre-allocates a CPU output; asserts the returned Tensor is the same object and its data equals `abs(input)`.  

**Changed files (high-level):**
- `js/web/lib/wasm/wasm-core-impl.ts`  
- `js/web/test/unittests/backends/wasm/test-preallocated-cpu-output.ts`  
- `js/web/test/unittests/index.ts`  

---

# Motivation and Context

**Why**: Pre-allocated CPU outputs were returned unchanged (often zeros) because the post-run fast-path treated all pre-allocations as “no copy needed”. For CPU tensors, kernels write results into a WASM heap buffer created during preparation, so a copy-back into the user’s `TypedArray`/`string[]` is required.  

**What this fixes**: Ensures pre-allocated CPU outputs are populated with the model results while preserving object identity (the same Tensor instance is returned). This directly addresses [issue #25786](https://github.com/microsoft/onnxruntime/issues/25786).  

**Scope and safety:**
- GPU/ML pre-allocated outputs remain zero-copy (no behavior change).  
- Non-preallocated outputs are unchanged.  
- The copy cost for CPU pre-allocs matches the existing non-prealloc CPU path (a single WASM → JS copy).  

**Tests**:  
- The new unit test exercises the CPU pre-alloc scenario and passes in Node+WASM.  
- Manual testing with a browser repro confirms CPU pre-alloc now matches the baseline output.  



