### PR TITLE
Make local mirror of cmake dependencies configurable

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -426,6 +426,7 @@ if (onnxruntime_EXTENDED_MINIMAL_BUILD AND NOT onnxruntime_MINIMAL_BUILD)
 endif()
 
 set(REPO_ROOT ${PROJECT_SOURCE_DIR}/..)
+set(CMAKE_DEPS_MIRROR_DIR ${REPO_ROOT}/mirror CACHE PATH "Path to the local mirror of cmake dependencies")
 set(ONNXRUNTIME_ROOT ${PROJECT_SOURCE_DIR}/../onnxruntime)
 set(ORTTRAINING_ROOT ${PROJECT_SOURCE_DIR}/../orttraining)
 set(ORTTRAINING_SOURCE_DIR ${ORTTRAINING_ROOT}/orttraining)

--- a/cmake/external/helper_functions.cmake
+++ b/cmake/external/helper_functions.cmake
@@ -4,11 +4,11 @@
 # 2. Set the cmake property COMPILE_WARNING_AS_ERROR to OFF for these external projects.
 
 function(onnxruntime_fetchcontent_declare contentName)
+    cmake_parse_arguments(PARSE_ARGV 1 ARG "" "URL;URL_HASH;SOURCE_SUBDIR" "")
+    message(STATUS "Fetch ${contentName} from ${ARG_URL}")
     FetchContent_Declare(${ARGV})
     string(TOLOWER ${contentName} contentNameLower)
-    list(FIND ARGN SOURCE_SUBDIR index_SOURCE_SUBDIR)
-    if(index_SOURCE_SUBDIR GREATER_EQUAL 0)
-      cmake_parse_arguments(PARSE_ARGV 1 ARG "" "SOURCE_SUBDIR" "") 
+    if(NOT "${ARG_SOURCE_SUBDIR}" STREQUAL "")
       set(onnxruntime_${contentNameLower}_cmake_src_dir "${ARG_SOURCE_SUBDIR}" PARENT_SCOPE)
     endif()
 endfunction()

--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -20,7 +20,7 @@ foreach(ONNXRUNTIME_DEP IN LISTS ONNXRUNTIME_DEPS_LIST)
 
     if(ONNXRUNTIME_DEP_URL MATCHES "^https://")
       # Search a local mirror folder
-      string(REGEX REPLACE "^https://" "${REPO_ROOT}/mirror/" LOCAL_URL "${ONNXRUNTIME_DEP_URL}")
+      string(REGEX REPLACE "^https://" "${CMAKE_DEPS_MIRROR_DIR}/" LOCAL_URL "${ONNXRUNTIME_DEP_URL}")
 
       if(EXISTS "${LOCAL_URL}")
         cmake_path(ABSOLUTE_PATH LOCAL_URL)

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1023,6 +1023,9 @@ def generate_build_tree(
     if path_to_protoc_exe:
         cmake_args += [f"-DONNX_CUSTOM_PROTOC_EXECUTABLE={path_to_protoc_exe}"]
 
+    if args.cmake_deps_mirror_dir:
+        cmake_args += [f"-DCMAKE_DEPS_MIRROR_DIR={args.cmake_deps_mirror_dir}"]
+
     if args.fuzz_testing:
         if not (
             args.build_shared_lib

--- a/tools/ci_build/build_args.py
+++ b/tools/ci_build/build_args.py
@@ -203,6 +203,7 @@ def add_testing_args(parser: argparse.ArgumentParser) -> None:
         help="Run onnx_test_runner against test data. Only used in ONNX Runtime's CI pipelines",
     )
     parser.add_argument("--path_to_protoc_exe", help="Path to protoc executable.")
+    parser.add_argument("--cmake_deps_mirror_dir", help="Path to the local mirror of cmake dependencies.")
     parser.add_argument("--fuzz_testing", action="store_true", help="Enable Fuzz testing.")
     parser.add_argument(
         "--enable_symbolic_shape_infer_tests",


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Added support for the `--cmake_deps_mirror_dir` option to allow users to specify a custom local directory for CMake dependencies.
- Improved logging to show the source of `FetchContent` in CMake.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- Previously, ONNX Runtime searched for CMake dependencies only in the default `<repo_root>/mirror` directory.
- This change enables users to configure an alternative location for storing CMake dependencies, offering greater flexibility in build environments.