### PR TITLE
Fix: Replace macOS-13 with macOS-15 in workflows

### DIFF
--- a/.github/workflows/macos-ci-build-and-test-workflow.yml
+++ b/.github/workflows/macos-ci-build-and-test-workflow.yml
@@ -48,9 +48,9 @@ jobs:
         #
         include: ${{ fromJSON(inputs.matrix_include) }}
 
-    # "macos-13" is a x86_64 image, and "macos-15" is an arm64 image.
+    # macos-15 supports both x86_64 and arm64
     # see also: https://github.com/actions/runner-images/blob/main/README.md
-    runs-on: ${{ matrix.machine == 'x86_64' && 'macos-13' || 'macos-15' }}
+    runs-on: macos-15
     env:
       build_flags: >
         --build_dir ./build


### PR DESCRIPTION
GH's doc says: "The macOS 13 hosted runner image is closing down, following our [N-1 OS support policy](https://github.com/actions/runner-images?tab=readme-ov-file#software-and-image-support). This process will begin October 1, 2025, and the image will be fully retired on December 4, 2025. We recommend updating workflows to use macos-14 or macos-15."
