### PR TITLE
Upgrade com.diffplug.spotless to 7.2.1 in Java build

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -3,7 +3,7 @@ plugins {
 	id 'maven-publish'
 	id 'signing'
 	id 'jacoco'
-	id "com.diffplug.spotless" version "6.25.0"
+	id "com.diffplug.spotless" version "7.2.1"
 }
 
 allprojects {


### PR DESCRIPTION
This PR upgrades the com.diffplug.spotless Gradle plugin to version 7.2.1 in the java/build.gradle file. This brings in the latest features and bug fixes from the Spotless code formatter.