### PR TITLE
Fix CUDA 12.8+ build issues with regards to fp4 type

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_common.h
+++ b/onnxruntime/core/providers/cuda/cuda_common.h
@@ -106,7 +106,7 @@ class ToCudaType<Float8E5M2FNUZ> {
 #if defined(ENABLE_FP4) && !defined(DISABLE_FLOAT4_TYPES)
 // ENABLE_FP4 is only set if CUDA SDK version is >= 12.8
 // Just in case - statically assert the same
-static_assert(CUDA_VERSION >= 12080, 
+static_assert(CUDA_VERSION >= 12080,
               "CUDA_VERSION should be >= 12.8 if ENABLE_FP4 is set");
 template <>
 class ToCudaType<Float4E2M1x2> {

--- a/onnxruntime/core/providers/cuda/cuda_common.h
+++ b/onnxruntime/core/providers/cuda/cuda_common.h
@@ -106,7 +106,7 @@ class ToCudaType<Float8E5M2FNUZ> {
 #if defined(ENABLE_FP4) && !defined(DISABLE_FLOAT4_TYPES)
 // ENABLE_FP4 is only set if CUDA SDK version is >= 12.8
 // Just in case - statically assert the same
-static_assert(defined(CUDA_VERSION) && CUDA_VERSION >= 12080, 
+static_assert(CUDA_VERSION >= 12080, 
               "CUDA_VERSION should be >= 12.8 if ENABLE_FP4 is set");
 template <>
 class ToCudaType<Float4E2M1x2> {

--- a/onnxruntime/core/providers/cuda/cuda_common.h
+++ b/onnxruntime/core/providers/cuda/cuda_common.h
@@ -9,8 +9,9 @@
 #include <ciso646>
 #endif
 
-// Needed for CUDA_VERSION
-#include <cuda.h>
+#if defined(ENABLE_FP4) && !defined(DISABLE_FLOAT4_TYPES)
+#include <cuda_fp4.h>
+#endif
 
 #include "core/providers/shared_library/provider_api.h"
 #include "core/common/status.h"
@@ -104,14 +105,10 @@ class ToCudaType<Float8E5M2FNUZ> {
 #endif
 
 #if defined(ENABLE_FP4) && !defined(DISABLE_FLOAT4_TYPES)
-// ENABLE_FP4 is only set if CUDA SDK version is >= 12.8
-// Just in case - statically assert the same
-static_assert(CUDA_VERSION >= 12080,
-              "CUDA_VERSION should be >= 12.8 if ENABLE_FP4 is set");
 template <>
 class ToCudaType<Float4E2M1x2> {
  public:
-  typedef Float4E2M1x2::PackedCudaType MappedType;
+  typedef __nv_fp4x2_e2m1 MappedType;
 };
 #endif
 

--- a/onnxruntime/core/providers/cuda/cuda_common.h
+++ b/onnxruntime/core/providers/cuda/cuda_common.h
@@ -105,6 +105,10 @@ class ToCudaType<Float8E5M2FNUZ> {
 
 #if defined(ENABLE_FP4) && !defined(DISABLE_FLOAT4_TYPES)
 // ENABLE_FP4 is only set if CUDA SDK version is >= 12.8
+// Just in case - statically assert the same
+#if !defined(CUDA_VERSION) || CUDA_VERSION < 12080
+static_assert(false, "CUDA_VERSION should be >= 12.8 if ENABLE_FP4 is set");
+#endif
 template <>
 class ToCudaType<Float4E2M1x2> {
  public:

--- a/onnxruntime/core/providers/cuda/cuda_common.h
+++ b/onnxruntime/core/providers/cuda/cuda_common.h
@@ -9,6 +9,9 @@
 #include <ciso646>
 #endif
 
+// Needed for CUDA_VERSION
+#include <cuda.h>
+
 #include "core/providers/shared_library/provider_api.h"
 #include "core/common/status.h"
 #include "core/framework/float8.h"

--- a/onnxruntime/core/providers/cuda/cuda_common.h
+++ b/onnxruntime/core/providers/cuda/cuda_common.h
@@ -107,7 +107,7 @@ class ToCudaType<Float8E5M2FNUZ> {
 // ENABLE_FP4 is only set if CUDA SDK version is >= 12.8
 // Just in case - statically assert the same
 #if !defined(CUDA_VERSION) || CUDA_VERSION < 12080
-static_assert(false, "CUDA_VERSION should be >= 12.8 if ENABLE_FP4 is set");
+static_assert(CUDA_VERSION >= 12080, "CUDA_VERSION should be >= 12.8 if ENABLE_FP4 is set");
 #endif
 template <>
 class ToCudaType<Float4E2M1x2> {

--- a/onnxruntime/core/providers/cuda/cuda_common.h
+++ b/onnxruntime/core/providers/cuda/cuda_common.h
@@ -106,9 +106,8 @@ class ToCudaType<Float8E5M2FNUZ> {
 #if defined(ENABLE_FP4) && !defined(DISABLE_FLOAT4_TYPES)
 // ENABLE_FP4 is only set if CUDA SDK version is >= 12.8
 // Just in case - statically assert the same
-#if !defined(CUDA_VERSION) || CUDA_VERSION < 12080
-static_assert(CUDA_VERSION >= 12080, "CUDA_VERSION should be >= 12.8 if ENABLE_FP4 is set");
-#endif
+static_assert(defined(CUDA_VERSION) && CUDA_VERSION >= 12080, 
+              "CUDA_VERSION should be >= 12.8 if ENABLE_FP4 is set");
 template <>
 class ToCudaType<Float4E2M1x2> {
  public:

--- a/onnxruntime/core/providers/cuda/cuda_type_conversion.h
+++ b/onnxruntime/core/providers/cuda/cuda_type_conversion.h
@@ -3,6 +3,9 @@
 
 #pragma once
 
+// Needed for CUDA_VERSION
+#include <cuda.h>
+
 #include <cuda_fp16.h>
 #include <cuda_bf16.h>
 #if defined(ENABLE_FP8) && !defined(DISABLE_FLOAT8_TYPES)

--- a/onnxruntime/core/providers/cuda/cuda_type_conversion.h
+++ b/onnxruntime/core/providers/cuda/cuda_type_conversion.h
@@ -98,7 +98,8 @@ struct OrtToCudaType<Float8E5M2FNUZ> {
 #if defined(ENABLE_FP4) && !defined(DISABLE_FLOAT4_TYPES)
 // ENABLE_FP4 is only set if CUDA SDK version is >= 12.8
 // Just in case - statically assert the same
-static_assert(defined(CUDA_VERSION) && CUDA_VERSION >= 12080, "CUDA_VERSION should be >= 12.8 if ENABLE_FP4 is set");
+static_assert(defined(CUDA_VERSION) && CUDA_VERSION >= 12080, 
+              "CUDA_VERSION should be >= 12.8 if ENABLE_FP4 is set");
 template <>
 struct OrtToCudaType<Float4E2M1x2> {
   using type = Float4E2M1x2::PackedCudaType;

--- a/onnxruntime/core/providers/cuda/cuda_type_conversion.h
+++ b/onnxruntime/core/providers/cuda/cuda_type_conversion.h
@@ -98,7 +98,7 @@ struct OrtToCudaType<Float8E5M2FNUZ> {
 #if defined(ENABLE_FP4) && !defined(DISABLE_FLOAT4_TYPES)
 // ENABLE_FP4 is only set if CUDA SDK version is >= 12.8
 // Just in case - statically assert the same
-static_assert(defined(CUDA_VERSION) && CUDA_VERSION >= 12080, 
+static_assert(CUDA_VERSION >= 12080, 
               "CUDA_VERSION should be >= 12.8 if ENABLE_FP4 is set");
 template <>
 struct OrtToCudaType<Float4E2M1x2> {

--- a/onnxruntime/core/providers/cuda/cuda_type_conversion.h
+++ b/onnxruntime/core/providers/cuda/cuda_type_conversion.h
@@ -98,9 +98,7 @@ struct OrtToCudaType<Float8E5M2FNUZ> {
 #if defined(ENABLE_FP4) && !defined(DISABLE_FLOAT4_TYPES)
 // ENABLE_FP4 is only set if CUDA SDK version is >= 12.8
 // Just in case - statically assert the same
-#if !defined(CUDA_VERSION) || CUDA_VERSION < 12080
-static_assert(false, "CUDA_VERSION should be >= 12.8 if ENABLE_FP4 is set");
-#endif
+static_assert(defined(CUDA_VERSION) && CUDA_VERSION >= 12080, "CUDA_VERSION should be >= 12.8 if ENABLE_FP4 is set");
 template <>
 struct OrtToCudaType<Float4E2M1x2> {
   using type = Float4E2M1x2::PackedCudaType;

--- a/onnxruntime/core/providers/cuda/cuda_type_conversion.h
+++ b/onnxruntime/core/providers/cuda/cuda_type_conversion.h
@@ -96,6 +96,11 @@ struct OrtToCudaType<Float8E5M2FNUZ> {
 #endif
 
 #if defined(ENABLE_FP4) && !defined(DISABLE_FLOAT4_TYPES)
+// ENABLE_FP4 is only set if CUDA SDK version is >= 12.8
+// Just in case - statically assert the same
+#if !defined(CUDA_VERSION) || CUDA_VERSION < 12080
+static_assert(false, "CUDA_VERSION should be >= 12.8 if ENABLE_FP4 is set");
+#endif
 template <>
 struct OrtToCudaType<Float4E2M1x2> {
   using type = Float4E2M1x2::PackedCudaType;

--- a/onnxruntime/core/providers/cuda/cuda_type_conversion.h
+++ b/onnxruntime/core/providers/cuda/cuda_type_conversion.h
@@ -3,9 +3,6 @@
 
 #pragma once
 
-// Needed for CUDA_VERSION
-#include <cuda.h>
-
 #include <cuda_fp16.h>
 #include <cuda_bf16.h>
 #if defined(ENABLE_FP8) && !defined(DISABLE_FLOAT8_TYPES)
@@ -96,13 +93,9 @@ struct OrtToCudaType<Float8E5M2FNUZ> {
 #endif
 
 #if defined(ENABLE_FP4) && !defined(DISABLE_FLOAT4_TYPES)
-// ENABLE_FP4 is only set if CUDA SDK version is >= 12.8
-// Just in case - statically assert the same
-static_assert(CUDA_VERSION >= 12080,
-              "CUDA_VERSION should be >= 12.8 if ENABLE_FP4 is set");
 template <>
 struct OrtToCudaType<Float4E2M1x2> {
-  using type = Float4E2M1x2::PackedCudaType;
+  using type = __nv_fp4x2_e2m1;
 };
 #endif
 

--- a/onnxruntime/core/providers/cuda/cuda_type_conversion.h
+++ b/onnxruntime/core/providers/cuda/cuda_type_conversion.h
@@ -98,7 +98,7 @@ struct OrtToCudaType<Float8E5M2FNUZ> {
 #if defined(ENABLE_FP4) && !defined(DISABLE_FLOAT4_TYPES)
 // ENABLE_FP4 is only set if CUDA SDK version is >= 12.8
 // Just in case - statically assert the same
-static_assert(CUDA_VERSION >= 12080, 
+static_assert(CUDA_VERSION >= 12080,
               "CUDA_VERSION should be >= 12.8 if ENABLE_FP4 is set");
 template <>
 struct OrtToCudaType<Float4E2M1x2> {


### PR DESCRIPTION
### Description
Fix CUDA 12.8+ build issues with regards to fp4 type

### Motivation and Context
Fix CUDA 12.8+ build issues with regards to fp4 type