### PR TITLE
[build] do not use x86 mac machines anymore

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -35,7 +35,7 @@ jobs:
       use_coreml: true
       matrix_include: >-
         [
-          {"machine": "x86_64", "target": "x86_64", "build_config": "Release"},
+          {"machine": "arm64", "target": "x86_64", "build_config": "Release"},
           {"machine": "arm64", "target": "arm64", "build_config": "Debug"},
           {"machine": "arm64", "target": "arm64", "build_config": "Release"}
         ]


### PR DESCRIPTION
### Description

as x86_64 Mac machines are retiring, move jobs to arm64.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


