### PR TITLE
[webgpu] Use DoTranspose directly in Conv Op

### DIFF
--- a/onnxruntime/core/providers/webgpu/nn/conv.cc
+++ b/onnxruntime/core/providers/webgpu/nn/conv.cc
@@ -21,7 +21,8 @@ Status TransposeKernel(ComputeContext& context, const Tensor* kernel, const Tens
   }
   TensorShape transposed_kernel_shape(transposed_kernel_shape_vector);
   *transposed_kernel = context.CreateGPUTensor(kernel->DataType(), transposed_kernel_shape);
-  return Transpose::DoTranspose(context, perm, *kernel, *transposed_kernel, &kernel_shape, &transposed_kernel_shape);
+  const Tensor reshaped_kernel(kernel->DataType(), kernel_shape, const_cast<void*>(kernel->DataRaw()), kernel->Location());
+  return Transpose::DoTranspose(context, perm, reshaped_kernel, *transposed_kernel);
 }
 
 template <bool is_channels_last, bool is_fused>

--- a/onnxruntime/core/providers/webgpu/tensor/transpose.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/transpose.cc
@@ -110,22 +110,15 @@ Status TransposeProgram::GenerateShaderCode(ShaderHelper& shader) const {
 
 Status Transpose::DoTranspose(onnxruntime::webgpu::ComputeContext& context,
                               gsl::span<const size_t> permutations,
-                              const Tensor& input, Tensor& output, const TensorShape* input_shape_ptr, TensorShape* output_shape_ptr) {
-  const auto& input_shape = input_shape_ptr ? *input_shape_ptr : input.Shape();
+                              const Tensor& input, Tensor& output) {
+  const auto& input_shape = input.Shape();
   const auto& input_dims = input_shape.GetDims();
   int32_t rank = static_cast<int32_t>(input_shape.NumDimensions());
 
   TensorShapeVector output_dims(rank);
 
-  if (output_shape_ptr) {
-    auto dims = output_shape_ptr->GetDims();
-    for (int32_t i = 0; i < rank; ++i) {
-      output_dims[i] = dims[i];
-    }
-  } else {
-    for (int32_t i = 0; i < rank; i++) {
-      output_dims[i] = input_dims[permutations[i]];
-    }
+  for (int32_t i = 0; i < rank; i++) {
+    output_dims[i] = input_dims[permutations[i]];
   }
 
   TensorShapeVector new_shape{};

--- a/onnxruntime/core/providers/webgpu/tensor/transpose.h
+++ b/onnxruntime/core/providers/webgpu/tensor/transpose.h
@@ -16,7 +16,7 @@ class Transpose final : public WebGpuKernel, public TransposeBase {
   Transpose(const OpKernelInfo& info) : WebGpuKernel{info}, TransposeBase{info} {
   }
   Status ComputeInternal(ComputeContext& context) const override;
-  static Status DoTranspose(onnxruntime::webgpu::ComputeContext& context, gsl::span<const size_t> permutations, const Tensor& input, Tensor& output, const TensorShape* input_shape_ptr = nullptr, TensorShape* output_shape_ptr = nullptr);
+  static Status DoTranspose(onnxruntime::webgpu::ComputeContext& context, gsl::span<const size_t> permutations, const Tensor& input, Tensor& output);
 
   constexpr static uint32_t TILE_SIZE = 16;
 };


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

This refactors the `TransposeKernel` to call `Transpose::DoTranspose` directly.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

See above.
