### PR TITLE
[QNN-EP] Add GPU to QNN EP factory

### DIFF
--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -1436,6 +1436,20 @@ TEST_F(QnnHTPBackendTests, AutoEp_PreferNpu) {
 
   ASSERT_ORTSTATUS_OK(Ort::GetApi().UnregisterExecutionProviderLibrary(*ort_env, kQnnExecutionProvider));
 }
+
+TEST_F(QnnGPUBackendTests, AutoEp_PreferGpu) {
+  ASSERT_ORTSTATUS_OK(Ort::GetApi().RegisterExecutionProviderLibrary(*ort_env, kQnnExecutionProvider,
+                                                                     ORT_TSTR("onnxruntime_providers_qnn.dll")));
+
+  Ort::SessionOptions so;
+  so.SetEpSelectionPolicy(OrtExecutionProviderDevicePolicy_PREFER_GPU);
+
+  const ORTCHAR_T* ort_model_path = ORT_MODEL_FOLDER "nhwc_resize_sizes_opset18.onnx";
+  Ort::Session session(*ort_env, ort_model_path, so);
+  EXPECT_TRUE(SessionHasEp(session, kQnnExecutionProvider));
+
+  ASSERT_ORTSTATUS_OK(Ort::GetApi().UnregisterExecutionProviderLibrary(*ort_env, kQnnExecutionProvider));
+}
 #endif  // defined(WIN32) && !BUILD_QNN_EP_STATIC_LIB
 
 // Test whether QNN EP can handle the case where the number of graph inputs and


### PR DESCRIPTION
## Description

Make the GPU backend visible to users of the WinML API.

The V2 EP selection mechanism will now expose the GPU device for QNN. The GPU can be picked when:

* The device list contains only GPU
* The execution policy is set to PREFER_GPU

If multiple devices (e.g. HTP and GPU) are provided to `AppendExecutionProviders_V2`, whichever device was provided last in the list will be used.

## Motivation and Context
Required to enable WinML usage with the QNN GPU backend

