### PR TITLE
Write parameters based on output shapes not the amount of names

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1359,7 +1359,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       }
 
       auto prog_output_shapes = prog.get_output_shapes();
-      for (std::size_t i = 0; i < output_names.size(); ++i) {
+      for (std::size_t i = 0; i < prog_output_shapes.size(); ++i) {
         auto out_len = prog_output_shapes[i].lengths();
         options.set_input_parameter_shape(output_names[i], out_len);
       }


### PR DESCRIPTION
Running into a case where the amount of names being larger than inputs from the MIGraphX program causes us to go out of bounds and try to index outputs that don't exist. This leads to undefined/broken behavior (faults)

### Description
<!-- Describe your changes. -->
This fixes an out of bounds condition that occurs when output_names() errornoursly is used to bind size of the amount of inputs used for setting parameters in MIGraphX EP


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Seeing this in some cases for user data
