### PR TITLE
Consistent with the configuration in the packaged cmake

### DIFF
--- a/tools/ci_build/github/linux/copy_strip_binary.sh
+++ b/tools/ci_build/github/linux/copy_strip_binary.sh
@@ -18,8 +18,6 @@ EXIT_CODE=1
 uname -a
 cd "$BINARY_DIR"
 mv installed/usr/local $ARTIFACT_NAME
-mv $ARTIFACT_NAME/include/onnxruntime/* $ARTIFACT_NAME/include
-rmdir $ARTIFACT_NAME/include/onnxruntime
 # Do not ship onnx_test_runner
 rm -rf $ARTIFACT_NAME/bin
 echo "Copy debug symbols in a separate file and strip the original binary."
@@ -29,9 +27,6 @@ then
     strip -S $BINARY_DIR/$ARTIFACT_NAME/lib/$LIB_NAME
     # copy the CoreML EP header for macOS build (libs with .dylib ext)
     cp $SOURCE_DIR/include/onnxruntime/core/providers/coreml/coreml_provider_factory.h  $BINARY_DIR/$ARTIFACT_NAME/include
-else
-   # Linux
-   mv $ARTIFACT_NAME/lib64 $ARTIFACT_NAME/lib
 fi
 
 # copy the README, licence and TPN


### PR DESCRIPTION
Shared library path and include path are not   same  in release file `onnxruntime-linux-x64-gpu-1.22.0.tgz` .

1. The library file named libonnxruntime.so.1.22.0 in `onnxruntimeTargets-release.cmake`  is at `lib64/libonnxruntime.so.1.22.0`, but file in `lib` path. 
2.  The include path in `onnxruntimeTargets.cmake`  is in `${_IMPORT_PREFIX}/include/onnxruntime`, but path in `include` path.

### Description
<!-- Describe your changes. -->
1. 
<img width="799" height="87" alt="image" src="https://github.com/user-attachments/assets/d870d4d2-c91c-4ba4-99cc-1eaefd9ca541" />

`  IMPORTED_LOCATION_RELEASE "${_IMPORT_PREFIX}/lib64/libonnxruntime.so.1.22.0"`


2. 
<img width="1093" height="559" alt="image" src="https://github.com/user-attachments/assets/195b9362-ebc5-46e5-9a3f-278efc2bf5b2" />
`  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include/onnxruntime"`

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


https://github.com/microsoft/onnxruntime/issues/24003#issue-2913355372