### PR TITLE
[NV TensorRT RTX EP] Package CUDA Runtime and TRT RTX with NV TensorRT RTX EP python wheel

### DIFF
--- a/cmake/onnxruntime_python.cmake
+++ b/cmake/onnxruntime_python.cmake
@@ -962,13 +962,31 @@ if (onnxruntime_USE_TENSORRT)
 endif()
 
 if (onnxruntime_USE_NV)
+  if ( OR ${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+      file(GLOB NV_LIB_FILES LIST_DIRECTORIES false "${TENSORRT_RTX_ROOT}/lib/tensorrt_*.dll"
+                                             "${TENSORRT_RTX_ROOT}/lib/libtensorrt_*.so.*")
+    message(STATUS "NV lib files: " ${NV_LIB_FILES})
+  endif()
   add_custom_command(
     TARGET onnxruntime_pybind11_state POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy
+        ${NV_LIB_FILES}
         $<TARGET_FILE:onnxruntime_providers_nv_tensorrt_rtx>
         $<TARGET_FILE:onnxruntime_providers_shared>
         $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/capi/
   )
+  if (EXISTS "${TENSORRT_RTX_ROOT}/doc/LICENSE.txt")
+    add_custom_command(
+      TARGET onnxruntime_pybind11_state POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy "${TENSORRT_RTX_ROOT}/doc/LICENSE.txt" $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/TRT_RTX_LICENSE.txt
+    )
+  endif()
+  if (EXISTS "${TENSORRT_RTX_ROOT}/doc/Acknowledgements.txt")
+    add_custom_command(
+      TARGET onnxruntime_pybind11_state POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy "${TENSORRT_RTX_ROOT}/doc/Acknowledgements.txt" $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/TRT_RTX_Acknowledgements.txt
+    )
+  endif()
 endif()
 
 if (onnxruntime_USE_MIGRAPHX)

--- a/setup.py
+++ b/setup.py
@@ -374,6 +374,12 @@ if platform.system() == "Linux" or platform.system() == "AIX":
         "libHtpPrepare.so",
     ]
     dl_libs.extend(qnn_deps)
+    #NV TensorRT RTX
+    nv_tensorrt_rtx_deps = [
+        "libtensorrt_rtx.so.*",
+        "libtensorrt_onnxparser_rtx.so.*"
+    ]
+    dl_libs.extend(nv_tensorrt_rtx_deps)
     if nightly_build:
         libs.extend(["libonnxruntime_pywrapper.so"])
 elif platform.system() == "Darwin":
@@ -454,6 +460,12 @@ else:
         "migraphx_tf.dll",
     ]
     libs.extend(migraphx_deps)
+    #NV TensorRT RTX Libs
+    nv_tensorrt_rtx_deps = [
+        "tensorrt_onnxparser_rtx_*.dll",
+        "tensorrt_rtx_*.dll"
+    ]
+    libs.extend(nv_tensorrt_rtx_deps)
 
 if is_manylinux:
     if is_openvino:
@@ -496,8 +508,8 @@ else:
 examples_names = ["mul_1.onnx", "logreg_iris.onnx", "sigmoid.onnx"]
 examples = [path.join("datasets", x) for x in examples_names]
 
-# Extra files such as EULA and ThirdPartyNotices (and Qualcomm License, only for QNN release packages)
-extra = ["LICENSE", "ThirdPartyNotices.txt", "Privacy.md", "Qualcomm_LICENSE.pdf"]
+# Extra files such as EULA and ThirdPartyNotices (and Qualcomm License, only for QNN release packages)(TRT RTX and CUDA License for NV TRT RTX EP release packages)
+extra = ["LICENSE", "ThirdPartyNotices.txt", "Privacy.md", "Qualcomm_LICENSE.pdf", "TRT_RTX_LICENSE.txt", "TRT_RTX_Acknowledgements.txt"]
 
 # Description
 readme_file = "docs/python/ReadMeOV.rst" if is_openvino else "docs/python/README.rst"
@@ -764,6 +776,10 @@ if not path.exists(requirements_path):
 with open(requirements_path) as f:
     install_requires = f.read().splitlines()
 
+#Adding CUDA Runtime as dependency for NV TensorRT RTX python wheel
+if package_name == "onnxruntime-trt-rtx":
+    install_requires.append("nvidia-cuda-runtime-cu12~=12.0")
+    cuda_version = parse_arg_remove_string(sys.argv, "--cuda_version=")
 
 def save_build_and_package_info(package_name, version_number, cuda_version, rocm_version, qnn_version):
     sys.path.append(path.join(path.dirname(__file__), "onnxruntime", "python"))

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1992,6 +1992,10 @@ def build_python_wheel(
                 args.append(f"--qnn_version={qnn_version}")
         elif use_azure:
             args.append("--use_azure")
+        elif wheel_name_suffix == "trt-rtx":
+            cuda_version = cuda_version or parse_cuda_version_from_json(cuda_home)
+            if cuda_version:
+                args.append(f"--cuda_version={cuda_version}")
 
         run_subprocess(args, cwd=cwd)
 


### PR DESCRIPTION
### Description
- CUDA Runtime added as a dependency for NV EP python wheel
- TRT RTX dlls and license copied to wheel as public wheels for TRT RTX are currently unavailable
-  Use onnxruntime.preload_dlls() to load CUDA Runtime DLL


### Motivation and Context
Enables out-of-the-box usage for the NV TensorRT RTX EP python wheel


