### PR TITLE
[QNN EP] Add support for RandomUniformLike Op in QNN EP

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
@@ -201,6 +201,10 @@ OpBuilderRegistrations::OpBuilderRegistrations() {
   }
 
   {
+    CreateRandomUniformLikeOpBuilder("RandomUniformLike", *this);
+  }
+
+  {
     CreateGatherNDOpBuilder("GatherND", *this);
   }
 

--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
@@ -111,6 +111,8 @@ void CreateLSTMOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_
 
 void CreateCumSumOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 
+void CreateRandomUniformLikeOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+
 void CreateMeanOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 
 void CreateGatherNDOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/random_uniform_like_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/random_uniform_like_op_builder.cc
@@ -1,0 +1,215 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/op_builder_factory.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+class RandomUniformLikeOpBuilder : public BaseOpBuilder {
+ public:
+  RandomUniformLikeOpBuilder() : BaseOpBuilder("RandomUniformLikeOpBuilder") {}
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(RandomUniformLikeOpBuilder);
+
+ protected:
+  Status ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
+                       const NodeUnit& node_unit,
+                       const logging::Logger& logger,
+                       std::vector<std::string>& input_names,
+                       bool do_op_validation) const override;
+
+  Status ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                     const NodeUnit& node_unit,
+                                     std::vector<std::string>&& input_names,
+                                     const logging::Logger& logger,
+                                     bool do_op_validation) const override;
+};
+
+Status RandomUniformLikeOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
+                                                 const NodeUnit& node_unit,
+                                                 const logging::Logger& logger,
+                                                 std::vector<std::string>& input_names,
+                                                 bool do_op_validation) const {
+  ORT_UNUSED_PARAMETER(do_op_validation);
+  ORT_UNUSED_PARAMETER(logger);
+  NodeAttrHelper node_helper(node_unit);
+  const auto& inputs = node_unit.Inputs();
+  const auto& input_tensor = inputs[0];
+  const std::string& input_tensor_name = input_tensor.node_arg.Name();
+
+  std::vector<uint32_t> input_shape;
+  ORT_RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(input_tensor.node_arg, input_shape),
+                    "Failed to get shape for input tensor: ", input_tensor_name);
+
+  const std::string shape_tensor_name = utils::GetUniqueName(input_tensor_name, "_shape");
+  std::vector<uint8_t> shape_data(input_shape.size() * sizeof(uint32_t));
+  memcpy(shape_data.data(), input_shape.data(), shape_data.size());
+  std::vector<uint32_t> shape_tensor_shape = {static_cast<uint32_t>(input_shape.size())};
+
+  QnnTensorWrapper shape_tensor_wrapper(shape_tensor_name,
+                                        QNN_TENSOR_TYPE_STATIC,
+                                        QNN_DATATYPE_UINT_32,
+                                        QnnQuantParamsWrapper(),
+                                        std::move(shape_tensor_shape),
+                                        std::move(shape_data));
+
+  ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(shape_tensor_wrapper)),
+                    "Failed to add shape tensor.");
+
+  input_names.push_back(shape_tensor_name);
+
+  // --- If seed attribute is present, add it as second input ---
+  if (node_helper.HasAttr("seed")) {
+    auto seed_value = node_helper.GetFloat("seed");
+
+    std::vector<uint32_t> scalar_shape = {1};
+    std::vector<uint8_t> seed_data(sizeof(float));
+    memcpy(seed_data.data(), &seed_value, sizeof(float));
+
+    const std::string seed_tensor_name = utils::GetUniqueName(input_tensor_name, "_ort_qnn_ep_seed");
+
+    QnnTensorWrapper seed_tensor(seed_tensor_name, QNN_TENSOR_TYPE_STATIC, QNN_DATATYPE_FLOAT_32,
+                                 QnnQuantParamsWrapper(), std::move(scalar_shape), std::move(seed_data));
+
+    ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(seed_tensor)),
+                      "Failed to add seed tensor");
+
+    input_names.push_back(seed_tensor_name);  // Seed is always second
+  }
+  return Status::OK();
+}
+
+Status RandomUniformLikeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                                               const NodeUnit& node_unit,
+                                                               std::vector<std::string>&& input_names,
+                                                               const logging::Logger& logger,
+                                                               bool do_op_validation) const {
+  ORT_UNUSED_PARAMETER(logger);
+  NodeAttrHelper node_helper(node_unit);
+  std::vector<std::string> param_names;
+
+  // Extract 'low' attribute
+  float low = node_helper.Get("low", 0.0f);
+  Qnn_Scalar_t low_param = QNN_SCALAR_INIT;
+  low_param.dataType = QNN_DATATYPE_FLOAT_32;
+  low_param.floatValue = low;
+  QnnParamWrapper low_param_wrapper(node_unit.Index(),
+                                    node_unit.Name(),
+                                    QNN_OP_RANDOM_UNIFORM_LIKE_PARAM_LOW,
+                                    low_param);
+
+  param_names.push_back(low_param_wrapper.GetParamTensorName());
+  qnn_model_wrapper.AddParamWrapper(std::move(low_param_wrapper));
+
+  // Extract 'high' attribute
+  float high = node_helper.Get("high", 1.0f);
+  Qnn_Scalar_t high_param = QNN_SCALAR_INIT;
+  high_param.dataType = QNN_DATATYPE_FLOAT_32;
+  high_param.floatValue = high;
+  QnnParamWrapper high_param_wrapper(node_unit.Index(),
+                                     node_unit.Name(),
+                                     QNN_OP_RANDOM_UNIFORM_LIKE_PARAM_HIGH,
+                                     high_param);
+
+  param_names.push_back(high_param_wrapper.GetParamTensorName());
+  qnn_model_wrapper.AddParamWrapper(std::move(high_param_wrapper));
+
+  const auto& outputs = node_unit.Outputs();
+  const std::string& output_name = outputs[0].node_arg.Name();
+
+  bool is_graph_output = qnn_model_wrapper.IsGraphOutput(output_name);
+  Qnn_TensorType_t tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
+
+  // Get output info
+  TensorInfo output_info{};
+  ORT_RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(outputs[0], output_info));
+
+  // Determine if we need to use UFIXED_POINT_8 and add a dequantize node
+  bool is_npu_backend = IsNpuBackend(qnn_model_wrapper.GetQnnBackendType());
+  bool need_dequantize = is_npu_backend;
+
+  if (need_dequantize) {
+    // Create an intermediate tensor with UFIXED_POINT_8 data type
+    const std::string intermediate_output_name = utils::GetUniqueName(output_name, "_uint8");
+
+    // Calculate quantization parameters based on low and high values
+    QnnQuantParamsWrapper quantize_param;
+    float scale = 0.0f;
+    int32_t zero_point = 0;
+    ORT_RETURN_IF_ERROR(utils::GetQuantParams(low, high, QNN_DATATYPE_UFIXED_POINT_8, scale, zero_point));
+    quantize_param = QnnQuantParamsWrapper(scale, zero_point);
+    QnnTensorWrapper intermediate_output_wrapper(intermediate_output_name,
+                                                 QNN_TENSOR_TYPE_NATIVE,
+                                                 QNN_DATATYPE_UFIXED_POINT_8,
+                                                 std::move(quantize_param),
+                                                 std::vector<uint32_t>(output_info.shape));
+
+    ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(intermediate_output_wrapper)),
+                      "Failed to add intermediate output tensor.");
+
+    // Create the RandomUniformLike node with uint8 output
+    ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
+                          utils::GetUniqueName(node_unit),
+                          QNN_OP_PACKAGE_NAME_QTI_AISW,
+                          QNN_OP_RANDOM_UNIFORM_LIKE,
+                          std::move(input_names),
+                          {intermediate_output_name},
+                          std::move(param_names),
+                          do_op_validation),
+                      "Failed to create RandomUniformLike node.");
+
+    // Create the final output tensor with the original data type
+    QnnTensorWrapper output_wrapper(output_name,
+                                    tensor_type,
+                                    output_info.qnn_data_type,
+                                    output_info.quant_param.Copy(),
+                                    std::vector<uint32_t>(output_info.shape));
+
+    ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_wrapper)),
+                      "Failed to add output tensor.");
+
+    // Create a Dequantize node to convert from uint8 to float32
+    ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
+                          utils::GetUniqueName(node_unit, "_dequantize"),
+                          QNN_OP_PACKAGE_NAME_QTI_AISW,
+                          QNN_OP_DEQUANTIZE,
+                          {intermediate_output_name},
+                          {output_name},
+                          {},
+                          do_op_validation),
+                      "Failed to create Dequantize node.");
+  } else {
+    // For non-NPU backends, use the original data type directly
+    QnnTensorWrapper output_wrapper(output_name,
+                                    tensor_type,
+                                    output_info.qnn_data_type,
+                                    output_info.quant_param.Copy(),
+                                    std::vector<uint32_t>(output_info.shape));
+
+    ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_wrapper)),
+                      "Failed to add output tensor.");
+
+    // Create the RandomUniformLike node with the original data type output
+    ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
+                          utils::GetUniqueName(node_unit),
+                          QNN_OP_PACKAGE_NAME_QTI_AISW,
+                          QNN_OP_RANDOM_UNIFORM_LIKE,
+                          std::move(input_names),
+                          {output_name},
+                          std::move(param_names),
+                          do_op_validation),
+                      "Failed to create RandomUniformLike node.");
+  }
+
+  return Status::OK();
+}
+
+void CreateRandomUniformLikeOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
+  op_registrations.AddOpBuilder(op_type, std::make_unique<RandomUniformLikeOpBuilder>());
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.cc
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.cc
@@ -130,6 +130,75 @@ void RunQnnModelTest(const GetTestModelFn& build_test_case, ProviderOptions prov
                             {}, verify_outputs);
 }
 
+void RunQnnModelTestHTPNoVerify(const GetTestModelFn& build_test_case, ProviderOptions provider_options,
+                                int opset_version, ExpectedEPNodeAssignment expected_ep_assignment,
+                                logging::Severity log_severity,
+                                std::function<void(const Graph&)>* ep_graph_checker) {
+  // Add kMSDomain to cover contrib op like Gelu
+  const std::unordered_map<std::string, int> domain_to_version = {{"", opset_version}, {kMSDomain, 1}};
+
+  auto& logging_manager = DefaultLoggingManager();
+  logging_manager.SetDefaultLoggerSeverity(log_severity);
+
+  onnxruntime::Model model("QNN_EP_TestModel", false, ModelMetaData(), PathString(),
+                           IOnnxRuntimeOpSchemaRegistryList(), domain_to_version, {},
+                           logging_manager.DefaultLogger());
+  Graph& graph = model.MainGraph();
+  ModelTestBuilder helper(graph);
+  build_test_case(helper);
+  helper.SetGraphOutputs();
+  ASSERT_STATUS_OK(model.MainGraph().Resolve());
+
+  // Serialize the model to a string.
+  std::string model_data;
+  model.ToProto().SerializeToString(&model_data);
+  TryEnableQNNSaver(provider_options);
+
+  SessionOptions so;
+  so.session_logid = "QNN_EP_TestLogID";
+  RunOptions run_options;
+  run_options.run_tag = so.session_logid;
+
+  InferenceSessionWrapper session_object{so, GetEnvironment()};
+
+  std::string provider_type = kCpuExecutionProvider;
+  auto qnn_ep = QnnExecutionProviderWithOptions(provider_options, &so);
+  provider_type = qnn_ep->Type();
+  ASSERT_STATUS_OK(session_object.RegisterExecutionProvider(std::move(qnn_ep)));
+  ASSERT_STATUS_OK(session_object.Load(model_data.data(), static_cast<int>(model_data.size())));
+  ASSERT_STATUS_OK(session_object.Initialize());
+
+  const auto& graph_from_session = session_object.GetGraph();
+
+  auto ep_nodes = CountAssignedNodes(graph_from_session, provider_type);
+  if (expected_ep_assignment == ExpectedEPNodeAssignment::All) {
+    // Verify the entire graph is assigned to the EP
+    ASSERT_EQ(ep_nodes, graph_from_session.NumberOfNodes()) << "Not all nodes were assigned to " << provider_type;
+  } else if (expected_ep_assignment == ExpectedEPNodeAssignment::None) {
+    ASSERT_EQ(ep_nodes, 0) << "No nodes are supposed to be assigned to " << provider_type;
+  } else {
+    ASSERT_GT(ep_nodes, 0) << "No nodes were assigned to " << provider_type;
+  }
+
+  if (ep_graph_checker) {
+    (*ep_graph_checker)(graph_from_session);
+  }
+
+  // Run the model but don't verify outputs
+  const auto& outputs = graph_from_session.GetOutputs();
+  std::vector<std::string> output_names;
+  std::vector<OrtValue> output_vals;
+
+  output_names.reserve(outputs.size());
+  for (const auto* node_arg : outputs) {
+    if (node_arg->Exists()) {
+      output_names.push_back(node_arg->Name());
+    }
+  }
+
+  ASSERT_STATUS_OK(session_object.Run(run_options, helper.feeds_, output_names, &output_vals));
+}
+
 void InferenceModel(const std::string& model_data, const char* log_id,
                     const ProviderOptions& provider_options,
                     ExpectedEPNodeAssignment expected_ep_assignment, const NameMLValMap& feeds,

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.h
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.h
@@ -1176,6 +1176,23 @@ void RunQnnModelTest(const GetTestModelFn& build_test_case, ProviderOptions prov
                      bool verify_outputs = true,
                      std::function<void(const Graph&)>* ep_graph_checker = nullptr);
 
+/**
+ * Runs a test model on the QNN HTP backend and verifies node assignment to QNN EP without comparing outputs to ORT CPU.
+ * This is useful for operations like RandomUniformLike where outputs are expected to be different between runs.
+ *
+ * \param build_test_case Function that builds a test model.
+ * \param provider_options Provider options for QNN EP.
+ * \param opset_version The opset version.
+ * \param expected_ep_assignment How many nodes are expected to be assigned to QNN (All, Some, or None).
+ * \param log_severity The logger's minimum severity level.
+ * \param ep_graph_checker Function called on the Graph generated for the EP's session. Used to check node
+ *                         EP assignment.
+ */
+void RunQnnModelTestHTPNoVerify(const GetTestModelFn& build_test_case, ProviderOptions provider_options,
+                                int opset_version, ExpectedEPNodeAssignment expected_ep_assignment,
+                                logging::Severity log_severity = logging::Severity::kERROR,
+                                std::function<void(const Graph&)>* ep_graph_checker = nullptr);
+
 enum class BackendSupport {
   SUPPORT_UNKNOWN,
   UNSUPPORTED,

--- a/onnxruntime/test/providers/qnn/simple_op_htp_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_htp_test.cc
@@ -1839,6 +1839,38 @@ TEST_F(QnnHTPBackendTests, HardSigmoidFusedIntoHardSwish_FP16) {
                         ExpectedEPNodeAssignment::All);
 }
 
+// Test RandomUniformLike + Add operation on HTP backend
+TEST_F(QnnHTPBackendTests, RandomUniformLikeAddTest) {
+  // Create a function that builds the test model: input -> RandomUniformLike -> Add -> output
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    // Create input tensor with shape [1, 4, 3] and float32 data
+    std::vector<float> input_data = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f,
+                                     7.0f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f};
+    auto* input = builder.MakeInput<float>({1, 4, 3}, input_data);
+
+    // RandomUniformLike node
+    auto* random_output = builder.MakeIntermediate();
+    Node& random_node = builder.AddNode("RandomUniformLike", {input}, {random_output});
+    random_node.AddAttribute("low", 0.0f);
+    random_node.AddAttribute("high", 10.0f);
+    random_node.AddAttribute("seed", 42.0f);
+
+    // Add node: input + random_output
+    auto* final_output = builder.MakeOutput();
+    builder.AddNode("Add", {input, random_output}, {final_output});
+  };
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+
+  // Run the test - we expect both RandomUniformLike and Add to be assigned to QNN EP
+  // Using the NoVerify version since RandomUniformLike randomness algo differs from ORT CPU
+  RunQnnModelTestHTPNoVerify(build_test_case,
+                             provider_options,
+                             14,
+                             ExpectedEPNodeAssignment::All);
+}
+
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 }  // namespace test


### PR DESCRIPTION
- Added new op builder for RandomUniformLike
- Added unit tests for verification on HTp

### Description
Add support for RandomUniformLike in QNN EP


### Motivation and Context
Enable more ops to run on the NPU


