### PR TITLE
[WebGPU] Fix potential dangling reference in MatMul

### DIFF
--- a/onnxruntime/core/providers/webgpu/math/matmul.h
+++ b/onnxruntime/core/providers/webgpu/math/matmul.h
@@ -42,7 +42,7 @@ class MatMulNaiveProgram final : public Program<MatMulNaiveProgram> {
                                           {"K", ProgramUniformVariableDataType::Uint32});
 
  private:
-  const Activation& activation_;
+  const Activation activation_;
   const size_t output_rank_;
   const int64_t output_number_;
   const bool has_bias_;

--- a/onnxruntime/core/providers/webgpu/math/matmul_packed.h
+++ b/onnxruntime/core/providers/webgpu/math/matmul_packed.h
@@ -26,7 +26,7 @@ class MatMulProgram final : public Program<MatMulProgram> {
                                           {"dim_inner", ProgramUniformVariableDataType::Uint32});
 
  private:
-  const Activation& activation_;
+  const Activation activation_;
   const bool has_bias_;
   const bool is_vec4_;
   const InlinedVector<int64_t> elements_per_thread_;


### PR DESCRIPTION
## Description

`MatMul` in the WebGPU EP contains a const& member initialized with a temporary object (`Activation()`). This introduces a dangling reference issue.

## Motivation and Context

While working on another PR, I accidentally discovered this potential problem. Although no errors have been observed in the current code, a dangling reference leads to undefined behavior and could cause potential issues in the future.