### PR TITLE
[CORE]Fix windows warning with CUDA fp4 header inclusion

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_common.h
+++ b/onnxruntime/core/providers/cuda/cuda_common.h
@@ -10,7 +10,19 @@
 #endif
 
 #if defined(ENABLE_FP4) && !defined(DISABLE_FLOAT4_TYPES)
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+// 'fp4_interpretation' : unreferenced parameter
+#pragma warning(disable : 4100)
+#endif
+
 #include <cuda_fp4.h>
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
 #endif
 
 #include "core/providers/shared_library/provider_api.h"

--- a/onnxruntime/core/providers/cuda/cuda_type_conversion.h
+++ b/onnxruntime/core/providers/cuda/cuda_type_conversion.h
@@ -9,7 +9,19 @@
 #include <cuda_fp8.h>
 #endif
 #if defined(ENABLE_FP4) && !defined(DISABLE_FLOAT4_TYPES)
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+// 'fp4_interpretation' : unreferenced parameter
+#pragma warning(disable : 4100)
+#endif
+
 #include <cuda_fp4.h>
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
 #endif
 #include <type_traits>
 #include <cstdint>


### PR DESCRIPTION
### Description
As title

### Motivation and Context
Fix Windows CUDA 12.8+ builds wrt to fp4 type usage


