### PR TITLE
[QNN-EP] Enable largest attr and remove sorted check for topk.

### DIFF
--- a/onnxruntime/test/providers/qnn/topk_op_test.cc
+++ b/onnxruntime/test/providers/qnn/topk_op_test.cc
@@ -41,7 +41,8 @@ static void RunTopKTestOnCPU(const TestInputDef<DataType>& input_def,
                              const TestInputDef<int64_t>& k_def,
                              const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
                              ExpectedEPNodeAssignment expected_ep_assignment,
-                             int opset = 19) {
+                             int opset = 19,
+                             bool verify_outputs = true) {
   ProviderOptions provider_options;
 
   provider_options["backend_type"] = "cpu";
@@ -49,7 +50,10 @@ static void RunTopKTestOnCPU(const TestInputDef<DataType>& input_def,
   RunQnnModelTest(BuildTopKTestCase<DataType>(input_def, k_def, attrs),
                   provider_options,
                   opset,
-                  expected_ep_assignment);
+                  expected_ep_assignment,
+                  /*fp32_abs_err*/ 1e-5f,
+                  /*log_severity*/ logging::Severity::kERROR,
+                  /*verify_outputs*/ verify_outputs);
 }
 
 //
@@ -72,12 +76,13 @@ TEST_F(QnnCPUBackendTests, TopK_NonLastAxis) {
                           ExpectedEPNodeAssignment::All);
 }
 
-// Test that TopK that returns the top k minimum values is not supported by QNN EP.
-TEST_F(QnnCPUBackendTests, TopK_MinValues_Unsupported) {
+// Test that TopK with an axis attribute that is not the last dimension. Set largest to 0.
+TEST_F(QnnCPUBackendTests, TopK_NonLastAxis_Largest_0) {
   RunTopKTestOnCPU<float>(TestInputDef<float>({1, 3, 4, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 48)),
                           TestInputDef<int64_t>({1}, true /* is_initializer */, {2}),
-                          {utils::MakeAttribute("largest", static_cast<int64_t>(0))},
-                          ExpectedEPNodeAssignment::None);  // Should not be assigned to QNN EP.
+                          {utils::MakeAttribute("axis", static_cast<int64_t>(1)),
+                           utils::MakeAttribute("largest", static_cast<int64_t>(0))},
+                          ExpectedEPNodeAssignment::All);
 }
 
 // Test TopK on CPU backend: top 2 largest floats from last axis
@@ -88,6 +93,25 @@ TEST_F(QnnCPUBackendTests, TopK_LargestFloats_LastAxis) {
                           ExpectedEPNodeAssignment::All);
 }
 
+// Test TopK on CPU backend: top 2 largest floats from last axis. Largest to 0.
+TEST_F(QnnCPUBackendTests, TopK_LargestFloats_LastAxis_Largest_0) {
+  RunTopKTestOnCPU<float>(TestInputDef<float>({1, 3, 4, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 48)),
+                          TestInputDef<int64_t>({1}, true /* is_initializer */, {2}),
+                          {utils::MakeAttribute("largest", static_cast<int64_t>(0))},  // Attributes
+                          ExpectedEPNodeAssignment::All);
+}
+
+// Test TopK on CPU backend: top 2 largest floats from last axis. Set largest to 0. Set sorted to false.
+TEST_F(QnnCPUBackendTests, TopK_LargestFloats_LastAxis_Largest_0_Sorted) {
+  RunTopKTestOnCPU<float>(TestInputDef<float>({1, 3, 4, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 48)),
+                          TestInputDef<int64_t>({1}, true /* is_initializer */, {2}),
+                          {utils::MakeAttribute("largest", static_cast<int64_t>(0)),
+                           utils::MakeAttribute("sorted", static_cast<int64_t>(0))},  // Attributes
+                          ExpectedEPNodeAssignment::All,
+                          /*opset*/ 19,
+                          /*verify_outputs*/ false);  // Disable verify output. Unsorted doesn't guarantee output sequence
+}
+
 // Test TopK on CPU backend: top 2 largest int32s from last axis
 TEST_F(QnnCPUBackendTests, TopK_LargestInt32s_LastAxis) {
   std::vector<int32_t> input_data = {-6, -5, -4, -3, -2, 0, 1, 2, 3, 4, 5, 6};
@@ -95,6 +119,27 @@ TEST_F(QnnCPUBackendTests, TopK_LargestInt32s_LastAxis) {
                             TestInputDef<int64_t>({1}, true /* is_initializer */, {2}),
                             {},  // Attributes
                             ExpectedEPNodeAssignment::All);
+}
+
+// Test TopK on CPU backend: top 2 largest int32s from last axis. Set largest to 0.
+TEST_F(QnnCPUBackendTests, TopK_LargestInt32s_LastAxis_Largest_0) {
+  std::vector<int32_t> input_data = {-6, -5, -4, -3, -2, 0, 1, 2, 3, 4, 5, 6};
+  RunTopKTestOnCPU<int32_t>(TestInputDef<int32_t>({1, 2, 2, 3}, false, input_data),
+                            TestInputDef<int64_t>({1}, true /* is_initializer */, {2}),
+                            {utils::MakeAttribute("largest", static_cast<int64_t>(0))},  // Attributes
+                            ExpectedEPNodeAssignment::All);
+}
+
+// Test TopK on CPU backend: top 2 largest int32s from last axis. Set largest to 0. Set sorted to false.
+TEST_F(QnnCPUBackendTests, TopK_LargestInt32s_LastAxis_Largest_0_Sorted) {
+  std::vector<int32_t> input_data = {-6, -5, -4, -3, -2, 0, 1, 2, 3, 4, 5, 6};
+  RunTopKTestOnCPU<int32_t>(TestInputDef<int32_t>({1, 2, 2, 3}, false, input_data),
+                            TestInputDef<int64_t>({1}, true /* is_initializer */, {2}),
+                            {utils::MakeAttribute("largest", static_cast<int64_t>(0)),
+                             utils::MakeAttribute("sorted", static_cast<int64_t>(0))},  // Attributes
+                            ExpectedEPNodeAssignment::All,
+                            /*opset*/ 19,
+                            /*verify_outputs*/ false);  // Disable verify output. Unsorted doesn't guarantee output sequence
 }
 
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
@@ -166,6 +211,14 @@ TEST_F(QnnHTPBackendTests, TopK_LargestFloats_U8_LastAxis) {
                                ExpectedEPNodeAssignment::All);
 }
 
+// Test 8-bit QDQ TopK on HTP backend: top 2 largest floats from last axis. Set largest to 0.
+TEST_F(QnnHTPBackendTests, TopK_LargestFloats_U8_LastAxis_Largest_0) {
+  RunQDQTopKTestOnHTP<uint8_t>(TestInputDef<float>({1, 3, 4, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 48)),
+                               TestInputDef<int64_t>({1}, true /* is_initializer */, {2}),
+                               {utils::MakeAttribute("largest", static_cast<int64_t>(0))},  // Attributes
+                               ExpectedEPNodeAssignment::All);
+}
+
 // Test 8-bit QDQ TopK on HTP backend: non-last axis
 TEST_F(QnnHTPBackendTests, TopK_U8_NonLastAxis) {
   RunQDQTopKTestOnHTP<uint8_t>(TestInputDef<float>({1, 3, 4, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 48)),
@@ -174,11 +227,29 @@ TEST_F(QnnHTPBackendTests, TopK_U8_NonLastAxis) {
                                ExpectedEPNodeAssignment::All);
 }
 
+// Test 8-bit QDQ TopK on HTP backend: non-last axis. Set largest to 0.
+TEST_F(QnnHTPBackendTests, TopK_U8_NonLastAxis_Largest_0) {
+  RunQDQTopKTestOnHTP<uint8_t>(TestInputDef<float>({1, 3, 4, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 48)),
+                               TestInputDef<int64_t>({1}, true /* is_initializer */, {2}),
+                               {utils::MakeAttribute("axis", static_cast<int64_t>(1)),
+                                utils::MakeAttribute("largest", static_cast<int64_t>(0))},  // Attributes
+                               ExpectedEPNodeAssignment::All);
+}
+
 // Test 16-bit QDQ TopK on HTP backend: top 2 largest floats from last axis
 TEST_F(QnnHTPBackendTests, TopK_LargestFloats_U16_LastAxis) {
   RunQDQTopKTestOnHTP<uint16_t>(TestInputDef<float>({1, 3, 4, 4}, false, GetFloatDataInRange(-20.0f, 20.0f, 48)),
                                 TestInputDef<int64_t>({1}, true /* is_initializer */, {2}),
                                 {},  // Attributes
+                                ExpectedEPNodeAssignment::All,
+                                21);  // opset
+}
+
+// Test 16-bit QDQ TopK on HTP backend: top 2 largest floats from last axis. Set largest to 0.
+TEST_F(QnnHTPBackendTests, TopK_LargestFloats_U16_LastAxis_Largest_0) {
+  RunQDQTopKTestOnHTP<uint16_t>(TestInputDef<float>({1, 3, 4, 4}, false, GetFloatDataInRange(-20.0f, 20.0f, 48)),
+                                TestInputDef<int64_t>({1}, true /* is_initializer */, {2}),
+                                {utils::MakeAttribute("largest", static_cast<int64_t>(0))},  // Attributes
                                 ExpectedEPNodeAssignment::All,
                                 21);  // opset
 }
@@ -192,6 +263,15 @@ TEST_F(QnnHTPBackendTests, TopK_U16_NonLastAxis) {
                                 21);  // opset
 }
 
+// Test 16-bit QDQ TopK on HTP backend: non-last axis. Set largest to 0.
+TEST_F(QnnHTPBackendTests, TopK_U16_NonLastAxis_Largest_0) {
+  RunQDQTopKTestOnHTP<uint16_t>(TestInputDef<float>({1, 3, 4, 4}, false, GetFloatDataInRange(-20.0f, 20.0f, 48)),
+                                TestInputDef<int64_t>({1}, true /* is_initializer */, {2}),
+                                {utils::MakeAttribute("axis", static_cast<int64_t>(1)),
+                                 utils::MakeAttribute("largest", static_cast<int64_t>(0))},  // Attributes
+                                ExpectedEPNodeAssignment::All,
+                                21);  // opset
+}
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Enable largest attr and remove sorted check for QNN topk op builder.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


