### PR TITLE
Normalize to positive axis for comparison on GEMM

### DIFF
--- a/onnxruntime/core/optimizer/qdq_transformer/weight_bias_quantization.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/weight_bias_quantization.cc
@@ -128,8 +128,15 @@ Status WeightBiasQuantization::ApplyImpl(Graph& graph, bool& modified, int graph
 
       int64_t axis = 1;
       if (auto axis_iter = dq_attrs.find("axis"); axis_iter != dq_attrs.end()) {
+        axis = axis_iter->second.i();
         const ONNX_NAMESPACE::TensorShapeProto* weight_shape = weight_arg->Shape();
-        axis = HandleNegativeAxis(axis_iter->second.i(), weight_shape->dim_size());
+        if (!weight_shape && dq_1 && dq_1->InputDefs()[0]) {
+          weight_shape = dq_1->InputDefs()[0]->Shape();
+        }
+        if (axis < 0 && !weight_shape) {
+          continue;
+        }
+        axis = HandleNegativeAxis(axis, weight_shape->dim_size());
       }
 
       int64_t expected_axis = 0;

--- a/onnxruntime/core/optimizer/qdq_transformer/weight_bias_quantization.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/weight_bias_quantization.cc
@@ -129,8 +129,7 @@ Status WeightBiasQuantization::ApplyImpl(Graph& graph, bool& modified, int graph
       int64_t axis = 1;
       if (auto axis_iter = dq_attrs.find("axis"); axis_iter != dq_attrs.end()) {
         const ONNX_NAMESPACE::TensorShapeProto* weight_shape = weight_arg->Shape();
-        int64_t weight_rank = weight_shape->dim_size();
-        axis = HandleNegativeAxis(axis_iter->second.i(), weight_rank);
+        axis = HandleNegativeAxis(axis_iter->second.i(), weight_shape->dim_size());
       }
 
       int64_t expected_axis = 0;

--- a/onnxruntime/core/optimizer/qdq_transformer/weight_bias_quantization.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/weight_bias_quantization.cc
@@ -138,6 +138,7 @@ Status WeightBiasQuantization::ApplyImpl(Graph& graph, bool& modified, int graph
           transB = trans_b_iter->second.i();
         }
         expected_axis = transB == 0 ? 1 : 0;
+        axis = (axis == -1) ? 1 : axis;  // normalize for comparison
       }
 
       if (axis != expected_axis) {

--- a/onnxruntime/core/optimizer/qdq_transformer/weight_bias_quantization.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/weight_bias_quantization.cc
@@ -130,7 +130,7 @@ Status WeightBiasQuantization::ApplyImpl(Graph& graph, bool& modified, int graph
       if (auto axis_iter = dq_attrs.find("axis"); axis_iter != dq_attrs.end()) {
         axis = axis_iter->second.i();
         const ONNX_NAMESPACE::TensorShapeProto* weight_shape = weight_arg->Shape();
-        if (!weight_shape && dq_1 && dq_1->InputDefs()[0]) {
+        if (!weight_shape && dq_1->InputDefs()[0]) {
           weight_shape = dq_1->InputDefs()[0]->Shape();
         }
         if (axis < 0 && !weight_shape) {

--- a/onnxruntime/core/optimizer/qdq_transformer/weight_bias_quantization.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/weight_bias_quantization.cc
@@ -129,7 +129,7 @@ Status WeightBiasQuantization::ApplyImpl(Graph& graph, bool& modified, int graph
       int64_t axis = 1;
       if (auto axis_iter = dq_attrs.find("axis"); axis_iter != dq_attrs.end()) {
         const ONNX_NAMESPACE::TensorShapeProto* weight_shape = weight_arg->Shape();
-        int64_t weight_rank = narrow<int64_t>(weight_shape->dim_size());
+        int64_t weight_rank = weight_shape->dim_size();
         axis = HandleNegativeAxis(axis_iter->second.i(), weight_rank);
       }
 


### PR DESCRIPTION
GEMM has 2D input, when given `axis=-1` in DequantizeLinear node attributes. The check `axis == expected_axis` would fail. However, it sematically the same (-1 and 1 for 2D GEMM's input). Normalize the check so we can still perform the quantization for this case. 
