### PR TITLE
Add basic detection of whether a GPU is discrete on Linux

### DIFF
--- a/onnxruntime/core/platform/linux/device_discovery.cc
+++ b/onnxruntime/core/platform/linux/device_discovery.cc
@@ -6,6 +6,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iterator>
+#include <optional>
 #include <string_view>
 
 #include "core/common/common.h"
@@ -105,8 +106,8 @@ std::optional<bool> IsGpuDiscrete(uint16_t vendor_id, uint16_t device_id) {
 
   // Currently, we only assume that all Nvidia GPUs are discrete.
 
-  constexpr auto nvidia_pci_id = 0x10de;
-  if (vendor_id == nvidia_pci_id) {
+  constexpr auto kNvidiaPciId = 0x10de;
+  if (vendor_id == kNvidiaPciId) {
     return true;
   }
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Update Linux device discovery to add rudimentary detection of whether a GPU is discrete and include that in the device metadata.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Include more potentially useful metadata.