### PR TITLE
[EP ABI] Check if nodes specified in GetCapability() have already been assigned

### DIFF
--- a/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
+++ b/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
@@ -213,6 +213,14 @@ PluginExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_vie
   // Create ComputeCapability instances from OrtEpGraphSupportInfo::NodeGrouping instances.
   for (const OrtEpGraphSupportInfo::NodeGrouping& node_grouping : api_graph_support_info.node_groupings) {
     if (node_grouping.kind == OrtEpGraphSupportInfo::NodeGroupingKind::kSingleAssignedNode) {
+      if (node_grouping.nodes.empty()) {
+        // The EpGraphSupportInfo_AddSingleNode() C API should already return an error if the EP tries to provide
+        // an invalid node. However, we check here too just in case this changes.
+        LOGS(logger, ERROR) << "OrtEp::GetCapability() for " << Type() << " did not specify a valid node "
+                            << "when specifying a supported node.";
+        return {};
+      }
+
       auto indexed_sub_graph = std::make_unique<IndexedSubGraph>();
 
       indexed_sub_graph->nodes.push_back(node_grouping.nodes[0]->GetInternalNode().Index());

--- a/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
+++ b/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
@@ -6,7 +6,6 @@
 #include <gsl/gsl>
 #include <memory>
 #include <string>
-#include <sstream>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -172,20 +171,6 @@ PluginExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_vie
   ORT_UNUSED_PARAMETER(kernel_lookup);             // TODO: Add support? Not used by prioritized EPs, so probably not needed?
 
   const logging::Logger& logger = GetLogger() != nullptr ? *GetLogger() : logging::LoggingManager::DefaultLogger();
-  auto log_unsupported_node_info = [&ep_type = Type(), &logger](gsl::span<const EpNode* const> ep_nodes) {
-    std::ostringstream oss;
-    oss << "OrtEp::GetCapability() specified nodes that cannot be assigned to " << ep_type << ". ";
-
-    if (const Node* node_for_other_ep = FindFirstNodeAssignedToOtherEP(ep_type, ep_nodes);
-        node_for_other_ep != nullptr) {
-      oss << "Found one or more nodes that were already assigned to a different EP named '"
-          << node_for_other_ep->GetExecutionProviderType() << "'. Ex: "
-          << node_for_other_ep->OpType() << " node with name '"
-          << node_for_other_ep->Name() << "'.";
-    }
-
-    LOGS(logger, WARNING) << oss.str();
-  };
 
   std::unique_ptr<EpGraph> ep_graph = nullptr;
   if (Status status = EpGraph::Create(graph_viewer, ep_graph); !status.IsOK()) {

--- a/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
+++ b/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
@@ -124,7 +124,8 @@ static const Node* FindFirstNodeAssignedToOtherEP(const std::string& ep_type,
                                                   gsl::span<const EpNode* const> ep_nodes) {
   auto node_iter = std::find_if(ep_nodes.begin(), ep_nodes.end(),
                                 [&ep_type](const EpNode* node) -> bool {
-                                  return node->GetInternalNode().GetExecutionProviderType() != ep_type;
+                                  const auto& node_ep_type = node->GetInternalNode().GetExecutionProviderType();
+                                  return !node_ep_type.empty() && node_ep_type != ep_type;
                                 });
 
   return node_iter != ep_nodes.end() ? &(*node_iter)->GetInternalNode() : nullptr;

--- a/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
+++ b/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
@@ -4,7 +4,6 @@
 #include "core/session/plugin_ep/ep_plugin_provider_interfaces.h"
 
 #include <gsl/gsl>
-#include <algorithm>
 #include <memory>
 #include <string>
 #include <sstream>
@@ -227,7 +226,7 @@ PluginExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_vie
       // Check that single node was not already assigned to another EP.
       if (!node_ep.empty() && node_ep != Type()) {
         log_unsupported_node_info(node_grouping.nodes);
-        return {};
+        continue;
       }
 
       auto indexed_sub_graph = std::make_unique<IndexedSubGraph>();
@@ -238,8 +237,8 @@ PluginExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_vie
       if (node_grouping.nodes.empty()) {
         // The EpGraphSupportInfo_AddNodesToFuse() C API should already return an error if the EP tries to provide
         // an empty array of nodes from OrtEp::GetCapability(). However, we check here too just in case this changes.
-        LOGS(logger, WARNING) << "OrtEp::GetCapability() for " << Type() << " set an empty array of nodes "
-                              << "when specifying supported nodes.";
+        LOGS(logger, ERROR) << "OrtEp::GetCapability() for " << Type() << " set an empty array of nodes "
+                            << "when specifying supported nodes.";
         return {};
       }
 
@@ -266,7 +265,7 @@ PluginExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_vie
       // Happens if nodes have already been assigned to another EP.
       if (capabilities.empty()) {
         log_unsupported_node_info(node_grouping.nodes);
-        return {};
+        continue;
       }
 
       if (capabilities.size() > 1) {

--- a/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
+++ b/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
@@ -3,6 +3,8 @@
 
 #include "core/session/plugin_ep/ep_plugin_provider_interfaces.h"
 
+#include <gsl/gsl>
+#include <algorithm>
 #include <memory>
 #include <string>
 #include <sstream>
@@ -170,8 +172,7 @@ PluginExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_vie
   ORT_UNUSED_PARAMETER(kernel_lookup);             // TODO: Add support? Not used by prioritized EPs, so probably not needed?
 
   const logging::Logger& logger = GetLogger() != nullptr ? *GetLogger() : logging::LoggingManager::DefaultLogger();
-
-  auto log_unsupported_node_info = [ep_type = Type(), &logger](gsl::span<const EpNode* const> ep_nodes) {
+  auto log_unsupported_node_info = [&ep_type = Type(), &logger](gsl::span<const EpNode* const> ep_nodes) {
     std::ostringstream oss;
     oss << "OrtEp::GetCapability() specified nodes that cannot be assigned to " << ep_type << ". ";
 

--- a/onnxruntime/test/framework/ep_plugin_provider_test.cc
+++ b/onnxruntime/test/framework/ep_plugin_provider_test.cc
@@ -427,7 +427,7 @@ TEST(PluginExecutionProviderTest, GetCapability_ClaimSomeNodesAssignedToOtherEP)
   }
 
   // Call IExecutionProvider::GetCapability. The underlying OrtEp will try to take all nodes.
-  // Should not crash and should return an empty result.
+  // Should not crash and should return a single compute capability with 2 out of the 3 nodes.
   {
     logging::LoggingManager log_manager{std::make_unique<logging::FileSink>(log_file, false, false),
                                         logging::Severity::kWARNING, false,

--- a/onnxruntime/test/framework/ep_plugin_provider_test.cc
+++ b/onnxruntime/test/framework/ep_plugin_provider_test.cc
@@ -334,8 +334,8 @@ TEST(PluginExecutionProviderTest, InferOrtDeviceFromDeviceMemoryInfo) {
 #endif  // !defined(ORT_NO_EXCEPTIONS)
 }
 
-static OrtStatus* GetCapabilityTakeAllNodes(OrtEp* this_ptr, const OrtGraph* graph,
-                                            OrtEpGraphSupportInfo* graph_support_info) noexcept {
+static OrtStatus* ORT_API_CALL GetCapabilityTakeAllNodes(OrtEp* this_ptr, const OrtGraph* graph,
+                                                         OrtEpGraphSupportInfo* graph_support_info) noexcept {
   auto* this_ep = static_cast<test_plugin_ep::TestOrtEp*>(this_ptr);
 
   size_t num_nodes = 0;

--- a/onnxruntime/test/framework/ep_plugin_provider_test.cc
+++ b/onnxruntime/test/framework/ep_plugin_provider_test.cc
@@ -451,7 +451,7 @@ TEST(PluginExecutionProviderTest, GetCapability_ClaimNodesAssignedToOtherEP) {
   run_test(nodes_for_other_ep, nodes_for_this_ep,
            "Found one or more nodes that were already assigned to a different EP named 'OtherEp'");
 
-  // Load a model and forcibly assign the first two nodes to the another Ep name 'OtherEp'.
+  // Load a model and forcibly assign the first two nodes to another EP named 'OtherEp'.
   // The last Add node should be taken by the test plugin EP.
   nodes_for_other_ep = std::unordered_set<std::string>{"add_0", "mul_0"};
   nodes_for_this_ep = std::unordered_set<std::string>{"add_1"};


### PR DESCRIPTION
### Description
Fixes segfault in `PluginExecutionProvider::GetCapability()` when the underlying `OrtEp` tries to claim nodes that have already been assigned to another EP.


### Motivation and Context
Should log a warning (instead of crashing or throwing an exception) when a plugin EP tries to claim a node that is already assigned to another EP.


