### PR TITLE
MLAS: use vmlaq_f32 for ARMv7 targets

### DIFF
--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -2305,8 +2305,8 @@ MLAS_FLOAT32X4
 MlasMultiplyAddFloat32x4(MLAS_FLOAT32X4 Vector1, MLAS_FLOAT32X4 Vector2, MLAS_FLOAT32X4 Vector3)
 {
 #if defined(MLAS_NEON_INTRINSICS)
-#if defined(__ANDROID__) && defined(MLAS_TARGET_ARM)
-    // Android armeabi-v7a ABI doesn't have vfmaq_f32()
+#if defined(MLAS_TARGET_ARM)
+    // ARMv7 NEON doesn’t have vfmaq_f32()
     return vmlaq_f32(Vector3, Vector1, Vector2);
 #else
     return vfmaq_f32(Vector3, Vector1, Vector2);

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -2306,7 +2306,7 @@ MlasMultiplyAddFloat32x4(MLAS_FLOAT32X4 Vector1, MLAS_FLOAT32X4 Vector2, MLAS_FL
 {
 #if defined(MLAS_NEON_INTRINSICS)
 #if defined(MLAS_TARGET_ARM)
-    // ARMv7 NEON doesn’t have vfmaq_f32()
+    // ARMv7 NEON doesn't have vfmaq_f32()
     return vmlaq_f32(Vector3, Vector1, Vector2);
 #else
     return vfmaq_f32(Vector3, Vector1, Vector2);


### PR DESCRIPTION
Use vmlaq_f32 on MLAS_TARGET_ARM (armv7) so builds on Linux/Android arm32 don't attempt to use the armv8 (aarch64) vfmaq_f32 intrinsic.

Fixes build failures referencing vfmaq_f32 in arm_neon.h.

### Description
On ARMv7 targets (32-bit ARM with NEON) the vfmaq_f32 intrinsic is unavailable and causes build failures like:
target specific option mismatch 1728 | vfmaq_f32 (float32x4_t __a, float32x4_t __b, float32x4_t __c).
The previous code only fell back to vmlaq_f32 when __ANDROID__ was defined, which fixes Android but not Linux ARM32 builds.

### Motivation and Context
The proposal is to change:
if defined(__ANDROID__) && defined(MLAS_TARGET_ARM)
to:
if defined(MLAS_TARGET_ARM)

This change ensures 32-bit ARM builds (Linux and Android) use vmlaq_f32 while 64-bit ARM uses vfmaq_f32.

This pr is related to issue #25949 which was opened also by me.