### PR TITLE
Fix Windows non-CUDA build break

### DIFF
--- a/onnxruntime/test/providers/cpu/nn/conv_fp16_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/conv_fp16_test.cc
@@ -273,14 +273,13 @@ TEST(ConvFp16Test, Conv1D_Bias) {
 }
 
 TEST(ConvBF16Test, Conv2D_1) {
-#ifdef USE_CUDA
+#ifndef USE_CUDA
+  GTEST_SKIP() << "BFloat16 tests are only enabled on CUDA builds";
+#else
   if (!CudaHasBF16Support()) {
     LOGS_DEFAULT(WARNING) << "Hardware does NOT support BF16";
     return;
   }
-#else
-  GTEST_SKIP() << "BFloat16 tests are only enabled on CUDA builds";
-#endif
 
   OpTester test("Conv", 22);
 
@@ -332,6 +331,7 @@ TEST(ConvBF16Test, Conv2D_1) {
   test.AddOutput<BFloat16>("Y", Y_shape, expected_vals, /*no sort*/ false, 0.002f, 0.0f);
 
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kCudaExecutionProvider});
+#endif
 }
 
 TEST(ConvFp16Test, Conv2D_1) {

--- a/onnxruntime/test/providers/cpu/nn/conv_fp16_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/conv_fp16_test.cc
@@ -279,10 +279,9 @@ TEST(ConvBF16Test, Conv2D_1) {
     return;
   }
 #else
-  return;
+  GTEST_SKIP() << "BFloat16 tests are only enabled on CUDA builds";
 #endif
 
-#ifdef USE_CUDA
   OpTester test("Conv", 22);
 
   ConvOpAndTestAttributes attributes = {
@@ -333,7 +332,6 @@ TEST(ConvBF16Test, Conv2D_1) {
   test.AddOutput<BFloat16>("Y", Y_shape, expected_vals, /*no sort*/ false, 0.002f, 0.0f);
 
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kCudaExecutionProvider});
-#endif
 }
 
 TEST(ConvFp16Test, Conv2D_1) {

--- a/onnxruntime/test/providers/cpu/nn/conv_fp16_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/conv_fp16_test.cc
@@ -282,6 +282,7 @@ TEST(ConvBF16Test, Conv2D_1) {
   return;
 #endif
 
+#ifdef USE_CUDA
   OpTester test("Conv", 22);
 
   ConvOpAndTestAttributes attributes = {
@@ -332,6 +333,7 @@ TEST(ConvBF16Test, Conv2D_1) {
   test.AddOutput<BFloat16>("Y", Y_shape, expected_vals, /*no sort*/ false, 0.002f, 0.0f);
 
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kCudaExecutionProvider});
+#endif
 }
 
 TEST(ConvFp16Test, Conv2D_1) {

--- a/onnxruntime/test/providers/cpu/nn/pool_fp16_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/pool_fp16_op_test.cc
@@ -323,15 +323,13 @@ TEST(PoolTest, MaxPool_DilationPadding_3d) {
 }
 
 TEST(PoolBF16Test, AveragePool) {
-#ifdef USE_CUDA
+#ifndef USE_CUDA
+  GTEST_SKIP() << "BFloat16 tests are only enabled on CUDA builds";
+#else
   if (!CudaHasBF16Support()) {
     LOGS_DEFAULT(WARNING) << "Hardware does NOT support BF16";
     return;
   }
-#else
-  GTEST_SKIP() << "BFloat16 tests are only enabled on CUDA builds";
-#endif
-
   OpTester test("AveragePool", 22);
 
   test.AddAttribute("auto_pad", "");
@@ -411,6 +409,7 @@ TEST(PoolBF16Test, AveragePool) {
   test.AddInput<BFloat16>("X", x_dims, x_vals);
   test.AddOutput<BFloat16>("Y", expected_dims, expected_vals);
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kCudaExecutionProvider});
+#endif
 }
 
 TEST(PoolFp16Test, AveragePool) {

--- a/onnxruntime/test/providers/cpu/nn/pool_fp16_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/pool_fp16_op_test.cc
@@ -332,6 +332,7 @@ TEST(PoolBF16Test, AveragePool) {
   return;
 #endif
 
+#ifdef USE_CUDA
   OpTester test("AveragePool", 22);
 
   test.AddAttribute("auto_pad", "");
@@ -411,6 +412,7 @@ TEST(PoolBF16Test, AveragePool) {
   test.AddInput<BFloat16>("X", x_dims, x_vals);
   test.AddOutput<BFloat16>("Y", expected_dims, expected_vals);
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kCudaExecutionProvider});
+#endif
 }
 
 TEST(PoolFp16Test, AveragePool) {

--- a/onnxruntime/test/providers/cpu/nn/pool_fp16_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/pool_fp16_op_test.cc
@@ -329,10 +329,9 @@ TEST(PoolBF16Test, AveragePool) {
     return;
   }
 #else
-  return;
+  GTEST_SKIP() << "BFloat16 tests are only enabled on CUDA builds";
 #endif
 
-#ifdef USE_CUDA
   OpTester test("AveragePool", 22);
 
   test.AddAttribute("auto_pad", "");
@@ -412,7 +411,6 @@ TEST(PoolBF16Test, AveragePool) {
   test.AddInput<BFloat16>("X", x_dims, x_vals);
   test.AddOutput<BFloat16>("Y", expected_dims, expected_vals);
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kCudaExecutionProvider});
-#endif
 }
 
 TEST(PoolFp16Test, AveragePool) {


### PR DESCRIPTION
### Description
Fix warnings in non-CUDA EP Windows builds


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
 
Minor fix from https://github.com/microsoft/onnxruntime/pull/26102


