### PR TITLE
[WebNN] Fix bug in int64 data type support validation

### DIFF
--- a/onnxruntime/core/providers/webnn/builders/helper.cc
+++ b/onnxruntime/core/providers/webnn/builders/helper.cc
@@ -226,7 +226,9 @@ bool AreDataTypesSame(const std::string_view op_type,
   return true;
 }
 
-bool IsSupportedDataType(const int32_t onnx_data_type, const emscripten::val& webnn_supported_data_types) {
+bool IsSupportedDataType(const int32_t onnx_data_type,
+                         const emscripten::val& webnn_supported_data_types,
+                         const emscripten::val& wnn_limits) {
   auto it = onnx_to_webnn_data_type_map.find(static_cast<ONNX_NAMESPACE::TensorProto_DataType>(onnx_data_type));
   if (it == onnx_to_webnn_data_type_map.end())
     return false;
@@ -240,7 +242,8 @@ bool IsSupportedDataType(const int32_t onnx_data_type, const emscripten::val& we
 
   if (webnn_data_type == "int64" &&
       !is_supported &&
-      webnn_supported_data_types.call<emscripten::val>("includes", emscripten::val("int32")).as<bool>()) {
+      webnn_supported_data_types.call<emscripten::val>("includes", emscripten::val("int32")).as<bool>() &&
+      !wnn_limits["constant"]["dataTypes"].call<emscripten::val>("includes", emscripten::val("int64")).as<bool>()) {
     // Current context doesn't support int64, but int32 is supported.
     // We can use int32 as a workaround.
     is_supported = true;
@@ -280,8 +283,9 @@ bool IsDataTypeSupportedByWebNNOp(const std::string_view onnx_op_type,
                           << webnn_input_output_name << "]";
     return false;
   }
-  if (!IsSupportedDataType(
-          onnx_data_type, wnn_limits[std::string(webnn_op_type)][std::string(webnn_input_output_name)]["dataTypes"])) {
+  if (!IsSupportedDataType(onnx_data_type,
+                           wnn_limits[std::string(webnn_op_type)][std::string(webnn_input_output_name)]["dataTypes"],
+                           wnn_limits)) {
     LOGS(logger, VERBOSE) << "[" << onnx_op_type << "] " << onnx_input_output_name << "'s data type: ["
                           << onnx_data_type << "] is not supported by WebNN op [" << webnn_op_type << "] for now";
     return false;

--- a/onnxruntime/core/providers/webnn/builders/helper.h
+++ b/onnxruntime/core/providers/webnn/builders/helper.h
@@ -268,7 +268,9 @@ inline bool GetWebNNOpInputs(const std::string_view onnx_op_type,
 bool AreDataTypesSame(const std::string_view op_type,
                       gsl::span<const int32_t> input_types,
                       const logging::Logger& logger);
-bool IsSupportedDataType(const int32_t onnx_data_type, const emscripten::val& webnn_supported_data_types);
+bool IsSupportedDataType(const int32_t onnx_data_type,
+                         const emscripten::val& webnn_supported_data_types,
+                         const emscripten::val& wnn_limits);
 bool IsDataTypeSupportedByOp(const std::string_view onnx_op_type,
                              const int32_t onnx_data_type,
                              const emscripten::val& wnn_limits,

--- a/onnxruntime/core/providers/webnn/builders/helper.h
+++ b/onnxruntime/core/providers/webnn/builders/helper.h
@@ -269,8 +269,9 @@ bool AreDataTypesSame(const std::string_view op_type,
                       gsl::span<const int32_t> input_types,
                       const logging::Logger& logger);
 bool IsSupportedDataType(const int32_t onnx_data_type,
-                         const emscripten::val& webnn_supported_data_types,
-                         const emscripten::val& wnn_limits);
+                         const emscripten::val& wnn_limits,
+                         const std::string_view webnn_op_type,
+                         const std::string_view webnn_input_output_name);
 bool IsDataTypeSupportedByOp(const std::string_view onnx_op_type,
                              const int32_t onnx_data_type,
                              const emscripten::val& wnn_limits,

--- a/onnxruntime/core/providers/webnn/builders/model_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/model_builder.cc
@@ -229,7 +229,7 @@ Status ModelBuilder::RegisterInitializers() {
     desc.set("shape", emscripten::val::array(dims));
     const auto data_type = tensor.data_type();
     emscripten::val operand = emscripten::val::object();
-    if (IsSupportedDataType(data_type, wnn_limits_["constant"]["dataTypes"], wnn_limits_)) {
+    if (IsSupportedDataType(data_type, wnn_limits_, "constant", "")) {
       ORT_RETURN_IF_NOT(SetWebnnDataType(desc, data_type), "WebNN backend does not support data type: ", data_type);
       ORT_RETURN_IF_ERROR(RegisterConstant(tensor, operand, desc, logger_));
     } else {

--- a/onnxruntime/core/providers/webnn/builders/model_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/model_builder.cc
@@ -229,7 +229,7 @@ Status ModelBuilder::RegisterInitializers() {
     desc.set("shape", emscripten::val::array(dims));
     const auto data_type = tensor.data_type();
     emscripten::val operand = emscripten::val::object();
-    if (IsSupportedDataType(data_type, wnn_limits_["constant"]["dataTypes"])) {
+    if (IsSupportedDataType(data_type, wnn_limits_["constant"]["dataTypes"], wnn_limits_)) {
       ORT_RETURN_IF_NOT(SetWebnnDataType(desc, data_type), "WebNN backend does not support data type: ", data_type);
       ORT_RETURN_IF_ERROR(RegisterConstant(tensor, operand, desc, logger_));
     } else {


### PR DESCRIPTION
Only allows int64 data type when current WebNN context totally doesn't support int64 but support int32.