### PR TITLE
[WebNN] Rename outputs for gru and lstm

### DIFF
--- a/onnxruntime/core/providers/webnn/builders/impl/gru_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/gru_op_builder.cc
@@ -237,15 +237,15 @@ bool GruOpBuilder::HasSupportedOutputsImpl(const Node& node,
   bool Y_h_supported = has_Y_h && GetType(*output_defs[1], Y_h_type, logger);
 
   if (Y_supported && !Y_h_supported) {
-    return IsDataTypeSupportedByOp(op_type, Y_type, wnn_limits, "outputs", "Y", logger);
+    return IsDataTypeSupportedByOp(op_type, Y_type, wnn_limits, "output1", "Y", logger);
   } else if (!Y_supported && Y_h_supported) {
-    return IsDataTypeSupportedByOp(op_type, Y_h_type, wnn_limits, "outputs", "Y_h", logger);
+    return IsDataTypeSupportedByOp(op_type, Y_h_type, wnn_limits, "output0", "Y_h", logger);
   } else if (Y_supported && Y_h_supported) {
     if (Y_type != Y_h_type) {
       LOGS(logger, VERBOSE) << "[GRU] Output data types must be the same.";
       return false;
     }
-    return IsDataTypeSupportedByOp(op_type, Y_type, wnn_limits, "outputs", "Y", logger);
+    return IsDataTypeSupportedByOp(op_type, Y_type, wnn_limits, "output1", "Y", logger);
   } else {
     LOGS(logger, VERBOSE) << "[GRU] No output found.";
     return false;

--- a/onnxruntime/core/providers/webnn/builders/impl/lstm_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/lstm_op_builder.cc
@@ -259,13 +259,13 @@ bool LstmOpBuilder::HasSupportedOutputsImpl(const Node& node,
   bool has_Y_c = TensorExists(output_defs, 2);
 
   if (has_Y && GetType(*output_defs[0], Y_type, logger)) {
-    return IsDataTypeSupportedByOp(op_type, Y_type, wnn_limits, "outputs", "Y", logger);
+    return IsDataTypeSupportedByOp(op_type, Y_type, wnn_limits, "output2", "Y", logger);
   }
   if (has_Y_h && GetType(*output_defs[1], Y_h_type, logger)) {
-    return IsDataTypeSupportedByOp(op_type, Y_h_type, wnn_limits, "outputs", "Y_h", logger);
+    return IsDataTypeSupportedByOp(op_type, Y_h_type, wnn_limits, "output0", "Y_h", logger);
   }
   if (has_Y_c && GetType(*output_defs[2], Y_c_type, logger)) {
-    return IsDataTypeSupportedByOp(op_type, Y_c_type, wnn_limits, "outputs", "Y_c", logger);
+    return IsDataTypeSupportedByOp(op_type, Y_c_type, wnn_limits, "output1", "Y_c", logger);
   }
 
   return false;


### PR DESCRIPTION
WebNN spec changed the output names of `gru` and `lstm` for `OpSupportLimits` in https://github.com/webmachinelearning/webnn/pull/857, renamed them in WebNN EP as well.