### PR TITLE
[CUDA] Update GroupQueryAttention to support quantized KV cache

### DIFF
--- a/onnxruntime/contrib_ops/cpu/bert/attention_common.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_common.h
@@ -59,6 +59,13 @@ enum class QKOutputType : int {
   AFTER_SOFTMAX = 2
 };
 
+// Enum to define quantization granularity.
+enum class KVQuantizationType : int {
+  NONE = 0,
+  PER_TENSOR = 1,
+  PER_CHANNEL = 2,
+};
+
 constexpr bool LAYOUT_BSNH = false;
 constexpr bool LAYOUT_BNSH = true;
 

--- a/onnxruntime/contrib_ops/cpu/bert/attention_parameters.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_parameters.h
@@ -96,6 +96,11 @@ struct GroupQueryAttentionParameters : AttentionParameters {
   AttentionQkvFormat past_kv_format;
   int zeros_count;
   int* zero_ptr;
+
+  // Quantization parameters for KV cache
+  KVQuantizationType k_quant_type = KVQuantizationType::NONE;
+  KVQuantizationType v_quant_type = KVQuantizationType::NONE;
+  int kv_cache_bit_width = 0;
 };
 
 // Parameters deduced from node attributes and inputs/outputs.

--- a/onnxruntime/contrib_ops/cuda/bert/attention_data.h
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_data.h
@@ -158,6 +158,9 @@ struct GroupQueryAttentionData {
   const T* sin_cache = nullptr;
   const T* head_sink = nullptr;
 
+  const T* k_scale = nullptr;
+  const T* v_scale = nullptr;
+
   // Flash buffers
   T* softmax_lse = nullptr;
   T* softmax_lse_accum = nullptr;

--- a/onnxruntime/contrib_ops/cuda/bert/flash_attention/dequantize.h
+++ b/onnxruntime/contrib_ops/cuda/bert/flash_attention/dequantize.h
@@ -1,0 +1,230 @@
+#pragma once
+
+#include "contrib_ops/cuda/bert/flash_attention/utils.h"
+#include <cute/tensor.hpp>
+#include <cutlass/cutlass.h>
+#include <cutlass/numeric_types.h>
+
+// Set to 1 to enable debug prints for this kernel
+#define DEQUANT_DEBUG 0
+
+namespace onnxruntime {
+namespace flash {
+
+using namespace cute;
+
+// ============================================================================
+// KV Cache Dequantization Utilities for Flash Attention
+// ============================================================================
+//
+// This file implements on-the-fly dequantization of quantized KV cache for
+// Flash Attention kernels. It supports INT4 and INT8 quantization with both
+// per-tensor and per-channel quantization modes.
+//
+// QUANTIZATION SCHEME:
+// -------------------
+// INT4: Symmetric signed quantization, range [-8, 7]
+//   - Quantization:   q = clamp(round(x / scale), -8, 7)
+//   - Storage:        packed = (q + 8) & 0x0F  [converts to unsigned 0-15]
+//   - Packing:        2 values per byte (nibbles)
+//   - Dequantization: x = ((packed & 0x0F) - 8) * scale
+//
+// INT8: Symmetric signed quantization, range [-128, 127]
+//   - Quantization:   q = clamp(round(x / scale), -128, 127)
+//   - Dequantization: x = q * scale
+//
+// SCALE TENSOR FORMAT:
+// -------------------
+// Scale tensors are always FP16/BF16 (type T), even when cache is INT4/INT8.
+//
+// PER_TENSOR mode (QUANT_TYPE=1):
+//   - Single scale for entire tensor
+//   - Shape: [1] or broadcastable to cache shape
+//   - Access: scale[0]
+//
+// PER_CHANNEL mode (QUANT_TYPE=2):
+//   - One scale per head element (channel)
+//   - Shape: [num_heads_k, head_size] or broadcastable
+//   - Access: scale[h_k_idx * head_size + coord_k]
+//   - Where h_k_idx = head index, coord_k = element index within head
+//
+// BIT PACKING (INT4 only):
+// -----------------------
+// Each byte stores 2 values:
+//   - Low nibble (bits 0-3):  even-indexed element (coord_k % 2 == 0)
+//   - High nibble (bits 4-7): odd-indexed element (coord_k % 2 == 1)
+//
+// For odd head_size, the last nibble is padded with 0 (which represents -8+8=0 after bias).
+//
+// TEMPLATE PARAMETERS:
+// -------------------
+// QUANT_TYPE: 0 = none, 1 = PER_TENSOR, 2 = PER_CHANNEL
+// BIT_WIDTH:  4 or 8
+// ScaleType:  FP16 (half) or BF16 (bfloat16)
+// ============================================================================
+
+template <
+    bool Is_even_MN = true, bool Is_even_K = true, int QUANT_TYPE = 0, int BIT_WIDTH = 0,
+    typename TiledCopy, typename SrcTensor, typename DstTensor,
+    typename CoordTensor, typename PredTensor, typename ScaleType>
+__noinline__ __device__ void copy_and_dequantize(
+    TiledCopy const& tiled_copy,
+    SrcTensor const& gmem_src,       // Thread-local view of quantized source tensor in gmem
+    DstTensor& smem_dst,             // Thread-local view of dequantized destination tensor in smem
+    CoordTensor const& identity_MN,  // Thread-local view of an identity tensor for global coordinates
+    PredTensor const& predicate_K,   // Predicate for the K dimension
+    const int max_MN,
+    const ScaleType* scale,
+    const int d,
+    const int h_k_idx) {
+#if DEQUANT_DEBUG
+  if (threadIdx.x == 0 && blockIdx.x == 0 && blockIdx.y == 0 && blockIdx.z == 0) {
+    printf("[DEQUANT_DEBUG] Enter copy_and_dequantize\n");
+    printf("  gmem_ptr: %p, smem_ptr: %p, scale_ptr: %p\n", raw_pointer_cast(gmem_src.data()), raw_pointer_cast(smem_dst.data()), scale);
+    printf("  d: %d, h_k_idx: %d, max_MN: %d, BIT_WIDTH: %d, QUANT_TYPE: %d\n", d, h_k_idx, max_MN, BIT_WIDTH, QUANT_TYPE);
+  }
+#endif
+
+  using DQuantType = typename DstTensor::value_type;  // The dequantized type (e.g., half)
+  using QType = typename SrcTensor::value_type;       // The quantized type (e.g., int8_t or uint8_t for int4)
+
+  constexpr int R = SrcTensor::layout_type::rank;
+  constexpr int K_Tiles = []() {
+    if constexpr (R >= 3) {
+      using ShapeType = decltype(std::declval<typename SrcTensor::layout_type>().shape());
+      return size<2>(ShapeType{});
+    } else {
+      return 1;
+    }
+  }();
+
+#pragma unroll
+  for (int m = 0; m < size<1>(gmem_src); ++m) {
+    if (Is_even_MN || get<0>(identity_MN(0, m, 0)) < max_MN) {
+#pragma unroll
+      for (int k = 0; k < K_Tiles; ++k) {
+        if (Is_even_K || predicate_K(k)) {
+          // Define a lambda to handle the core dequantization logic for a given slice
+          auto process_slice = [&](auto gmem_slice, auto smem_slice, auto identity_slice) {
+            // Step 1 & 2: Load raw quantized data from GMEM to registers.
+            Tensor tRrQ_raw = make_tensor<QType>(shape(gmem_slice));
+
+            if constexpr (Is_even_MN) {
+              copy(tiled_copy, gmem_slice, tRrQ_raw);
+            } else {
+              if constexpr (BIT_WIDTH == 4) {
+                fill(tRrQ_raw, static_cast<QType>(0x88));
+              } else {
+                clear(tRrQ_raw);
+              }
+              // Create a predicate tensor for valid MN coordinates
+              auto tPred = make_tensor<bool>(shape(gmem_slice));
+#pragma unroll
+              for (int i = 0; i < size(tPred); ++i) {
+                tPred(i) = get<1>(identity_slice(i)) < max_MN;
+              }
+              copy_if(tiled_copy, tPred, gmem_slice, tRrQ_raw);
+            }
+
+            // Step 3: Dequantize the data now residing in registers.
+            Tensor tRsK = make_tensor<DQuantType>(shape(smem_slice));
+
+            if constexpr (BIT_WIDTH == 8) {
+              auto const* tRrQ_quant = reinterpret_cast<int8_t const*>(&tRrQ_raw(0));
+
+#pragma unroll 1
+              for (int i = 0; i < size(tRsK); ++i) {
+                float val = static_cast<float>(tRrQ_quant[i]);
+                float current_scale = 1.0f;
+                int coord_k = get<1>(identity_slice(i));
+
+                if constexpr (QUANT_TYPE == 1) {  // PER_TENSOR
+                  current_scale = static_cast<float>(scale[0]);
+                } else if constexpr (QUANT_TYPE == 2) {  // PER_CHANNEL
+                  if (coord_k < d) {
+                    int scale_idx = h_k_idx * d + coord_k;
+#if DEQUANT_DEBUG
+                    if (blockIdx.x == 0 && blockIdx.y == 0 && blockIdx.z == 0 && m == 0 && k == 0 && i == 0) {
+                      printf("[FlashDequant-8bit] Thread=%d CoordK=%d ScaleIdx=%d Raw=%f Scale=%f Result=%f\n",
+                             threadIdx.x, coord_k, scale_idx, val, current_scale, val * current_scale);
+                    }
+#endif
+                    current_scale = static_cast<float>(scale[scale_idx]);
+                  }
+                }
+                tRsK(i) = static_cast<DQuantType>(val * current_scale);
+              }
+            } else if constexpr (BIT_WIDTH == 4) {
+              auto const* tRrQ_packed = reinterpret_cast<uint8_t const*>(&tRrQ_raw(0));
+
+#pragma unroll 1
+              for (int i = 0; i < size(tRsK); ++i) {
+                // With Duplicate Layout in kernel, we load bytes as [B0, B0, B1, B1...].
+                // So for i=0, we want B0. index 0.
+                // For i=1, we want B0. index 1.
+                // For i=2, we want B1. index 2.
+                int coord_k = get<1>(identity_slice(i));
+#if DEQUANT_DEBUG
+                if (threadIdx.x == 0 && blockIdx.x == 0 && blockIdx.y == 0 && i == 0) {
+                  printf("[DequantDebug] BIT_WIDTH=%d QUANT_TYPE=%d i=%d coord_k=%d d=%d packed=0x%x\n",
+                         BIT_WIDTH, QUANT_TYPE, i, coord_k, d, (int)tRrQ_packed[i]);
+                }
+#endif
+                uint8_t packed_val = tRrQ_packed[i];
+                // Unpack INT4 values from nibbles and remove +8 bias applied during quantization.
+                // Even elements are in low nibble (bits 0-3), odd elements in high nibble (bits 4-7).
+                // The -8 bias restores the original signed range [-8, 7].
+                int8_t unpacked_val = (coord_k % 2 == 0)
+                                          ? static_cast<int8_t>((packed_val & 0x0F) - 8)
+                                          : static_cast<int8_t>((packed_val >> 4) - 8);
+
+                float val = static_cast<float>(unpacked_val);
+                float current_scale = 1.0f;
+
+                if constexpr (QUANT_TYPE == 1) {  // PER_TENSOR
+                  current_scale = static_cast<float>(scale[0]);
+                } else if constexpr (QUANT_TYPE == 2) {  // PER_CHANNEL
+                  if (coord_k < d) {
+                    int scale_idx = h_k_idx * d + coord_k;
+                    current_scale = static_cast<float>(scale[scale_idx]);
+#if DEQUANT_DEBUG
+                    if (threadIdx.x == 0 && i < 4) {
+                      printf("[FlashDequant-4bit] B=(%d,%d,%d) T=%d i=%d CK=%d SIdx=%d Pkd=0x%x Unp=%d Sc=%f Res=%f\n",
+                             blockIdx.x, blockIdx.y, blockIdx.z, threadIdx.x, i, coord_k, scale_idx, packed_val, unpacked_val, current_scale, val * current_scale);
+                    }
+#endif
+                  }
+                }
+                tRsK(i) = static_cast<DQuantType>(val * current_scale);
+              }
+            }
+            // Step 4: Perform an efficient copy from registers to shared memory.
+            copy(tRsK, smem_slice);
+          };
+
+          if constexpr (R >= 3) {
+            process_slice(gmem_src(_, m, k), smem_dst(_, m, k), identity_MN(_, m, k));
+          } else {
+            process_slice(gmem_src(_, m), smem_dst(_, m), identity_MN(_, m));
+          }
+
+        } else {
+          if constexpr (R >= 3) {
+            clear(smem_dst(_, m, k));
+          } else {
+            clear(smem_dst(_, m));
+          }
+        }
+      }
+    } else {
+      if constexpr (R >= 3) {
+        clear(smem_dst(_, m, _));
+      } else {
+        clear(smem_dst(_, m));
+      }
+    }
+  }
+}
+
+}  // namespace flash
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/bert/flash_attention/flash.h
+++ b/onnxruntime/contrib_ops/cuda/bert/flash_attention/flash.h
@@ -12,7 +12,7 @@ namespace flash {
 constexpr int TOTAL_DIM = 0;
 constexpr int H_DIM = 1;
 constexpr int D_DIM = 2;
-
+constexpr bool ENABLE_FLASH_ATTENTION_4_BIT = true;
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 struct Qkv_params {
@@ -133,14 +133,31 @@ struct Flash_fwd_params : public Qkv_params {
 
   bool unpadded_lse = false;
   const cudaDeviceProp* dprops = nullptr;
+
+  // Quantization params
+  void* __restrict__ k_scale_ptr = nullptr;
+  void* __restrict__ v_scale_ptr = nullptr;
+
+  // 0: NONE, 1: PER_TENSOR, 2: PER_CHANNEL
+  int k_quant_type = 0;
+  int v_quant_type = 0;
+
+  int kv_cache_bit_width = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <typename T, int Headdim>
 void run_mha_fwd_(Flash_fwd_params& params, cudaStream_t stream);
+
 template <typename T, int Headdim>
 void run_mha_fwd_splitkv_dispatch(Flash_fwd_params& params, cudaStream_t stream);
+
+template <typename T, int Headdim>
+void run_mha_fwd_splitkv_dispatch_quant_8bit(Flash_fwd_params& params, cudaStream_t stream);
+
+template <typename T, int Headdim>
+void run_mha_fwd_splitkv_dispatch_quant_4bit(Flash_fwd_params& params, cudaStream_t stream);
 
 }  // namespace flash
 }  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/bert/flash_attention/flash_api.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/flash_attention/flash_api.cc
@@ -173,10 +173,24 @@ size_t get_out_accum_size(size_t num_splits, size_t batch_size, size_t num_heads
 void run_mha_fwd(Flash_fwd_params& params, cudaStream_t stream, bool force_split_kernel = false) {
   FP16_SWITCH(!params.is_bf16, [&] {
     HEADDIM_SWITCH(params.d, [&] {
-      if (params.num_splits <= 1 && !force_split_kernel) {  // If we don't set it num_splits == 0
+      if (params.num_splits <= 1 && !force_split_kernel && params.k_quant_type == 0) {  // If we don't set it num_splits == 0
         run_mha_fwd_<elem_type, kHeadDim>(params, stream);
       } else {
-        run_mha_fwd_splitkv_dispatch<elem_type, kHeadDim>(params, stream);
+        if (params.k_quant_type != 0) {
+          if constexpr (kHeadDim == 128) {
+            if (params.kv_cache_bit_width == 8) {
+              run_mha_fwd_splitkv_dispatch_quant_8bit<elem_type, kHeadDim>(params, stream);
+            } else if (params.kv_cache_bit_width == 4) {
+              run_mha_fwd_splitkv_dispatch_quant_4bit<elem_type, kHeadDim>(params, stream);
+            }
+          } else {
+            // This path should be unreachable if is_supported_quantization() works correctly.
+            // Fallback to standard kernel to satisfy compiler/linker.
+            run_mha_fwd_splitkv_dispatch<elem_type, kHeadDim>(params, stream);
+          }
+        } else {
+          run_mha_fwd_splitkv_dispatch<elem_type, kHeadDim>(params, stream);
+        }
       }
     });
   });
@@ -436,6 +450,18 @@ bool is_supported(const cudaDeviceProp& dprops, size_t head_size, size_t num_hea
   return (dprops.major >= 8) && (head_size % 8 == 0) && (head_size <= 256) && (num_heads % num_heads_k == 0);
 }
 
+bool is_supported_quantization(bool is_causal, size_t head_size, int k_quant_type, int v_quant_type, int kv_cache_bit_width) {
+  if constexpr (ENABLE_FLASH_ATTENTION_4_BIT) {
+    return (k_quant_type == 0 && v_quant_type == 0) ||  // no quantization supported for all head sizes
+           (is_causal && head_size == 128 &&
+            ((k_quant_type == 1 && v_quant_type == 1 && kv_cache_bit_width == 8) ||
+             (k_quant_type == 2 && v_quant_type == 2 && kv_cache_bit_width == 4)));
+  } else {
+    return (k_quant_type == 0 && v_quant_type == 0) ||  // no quantization supported for all head sizes
+           (is_causal && head_size == 128 && k_quant_type == 1 && v_quant_type == 1 && kv_cache_bit_width == 8);
+  }
+}
+
 // This API is used when past key and value are present... since cached, these are assumed to have sequence length
 // of max_sequence_length, so seqlen_k == max_sequence_length. The actual past sequence length is held in seqlens_k_.
 Status mha_fwd_kvcache(const cudaDeviceProp& dprops,
@@ -473,7 +499,12 @@ Status mha_fwd_kvcache(const cudaDeviceProp& dprops,
                        bool is_rotary_interleaved,
                        bool is_packed_qkv,
                        int max_num_blocks_per_seq,
-                       int page_block_size) {
+                       int page_block_size,
+                       void* k_scale,
+                       void* v_scale,
+                       int k_quant_type,
+                       int v_quant_type,
+                       int kv_cache_bit_width) {
   auto round_multiple = [](int x, int m) { return (x + m - 1) / m * m; };
   const int head_size_rounded = head_size <= 192 ? round_multiple(head_size, 32) : 256;
   const int seqlen_q_rounded = round_multiple(seqlen_q, 128);
@@ -504,6 +535,18 @@ Status mha_fwd_kvcache(const cudaDeviceProp& dprops,
                    is_causal ? 0 : -1);
   params.dprops = &dprops;
 
+  if constexpr (ENABLE_FLASH_ATTENTION_4_BIT) {
+    if (kv_cache_bit_width == 4) {
+      // Adjust strides for packed Int4 (2 elements per byte)
+      params.k_batch_stride /= 2;
+      params.v_batch_stride /= 2;
+      params.k_row_stride /= 2;
+      params.v_row_stride /= 2;
+      params.k_head_stride /= 2;
+      params.v_head_stride /= 2;
+    }
+  }
+
   if (k_new != nullptr && v_new != nullptr) {
     params.seqlen_knew = seqlen_k_new;
     params.knew_ptr = k_new;
@@ -516,6 +559,10 @@ Status mha_fwd_kvcache(const cudaDeviceProp& dprops,
       params.vnew_batch_stride = (seqlen_q * num_heads * head_size) + (2 * seqlen_k_new * num_heads_k * head_size);
       params.knew_row_stride = (num_heads * head_size) + (2 * num_heads_k * head_size);
       params.vnew_row_stride = (num_heads * head_size) + (2 * num_heads_k * head_size);
+
+      // Disable kernel append for packed GQA
+      params.knew_ptr = nullptr;
+      params.vnew_ptr = nullptr;
     } else {
       params.knew_batch_stride = seqlen_k_new * num_heads_k * head_size;
       params.vnew_batch_stride = seqlen_k_new * num_heads_k * head_size;
@@ -524,6 +571,44 @@ Status mha_fwd_kvcache(const cudaDeviceProp& dprops,
     }
     params.knew_head_stride = head_size;
     params.vnew_head_stride = head_size;
+  } else if (is_packed_qkv) {
+    // Handle Packed QKV where K/V are part of Q
+    // q_ptr points to the start of the packed buffer (Batch, Seq, (H + 2*Hk)*D)
+
+    params.seqlen_knew = seqlen_q;  // For packed, new K len is same as Q len
+
+    // Strides for Packed QKV
+    // layout: [batch, seq, (h + 2*hk), d]
+    int64_t row_stride = (num_heads + 2 * num_heads_k) * head_size;
+    params.q_batch_stride = seqlen_q * row_stride;
+    params.knew_batch_stride = seqlen_q * row_stride;
+    params.vnew_batch_stride = seqlen_q * row_stride;
+
+    params.q_row_stride = row_stride;
+    params.knew_row_stride = row_stride;
+    params.vnew_row_stride = row_stride;
+
+    params.q_head_stride = head_size;
+    params.knew_head_stride = head_size;
+    params.vnew_head_stride = head_size;
+
+    // Calculate pointers based on offsets
+    // Q is at offset 0
+    // K is at offset num_heads * head_size
+    // V is at offset (num_heads + num_heads_k) * head_size
+    char* q_base = static_cast<char*>(q);
+    params.knew_ptr = static_cast<void*>(q_base + num_heads * head_size * sizeof(half));  // Assuming half/bf16 type size handled by stride?
+    // WAIT: flash_fwd_params uses void*, but strides are in elements.
+    // The kernel does `reinterpret_cast<Element*>(params.knew_ptr) + ...`
+    // So we must pass the pointer adjusted by ELEMENT count if we cast to Element* inside.
+    // However, we don't know the Element type here (it's void*).
+    // FORTUNATELY, we can just pass `q` and handle the offset via `head_idx` logic OR adjust the pointer bytes.
+    // Adjusting pointer bytes is safer given the kernel implementation.
+
+    // We explicitly disable internal append for Packed QKV because of stride issues.
+    // ORT handles append externally via LaunchConcatNewToPastKV.
+    params.knew_ptr = nullptr;
+    params.vnew_ptr = nullptr;
   } else {
     params.seqlen_knew = 0;
     params.knew_ptr = nullptr;
@@ -572,8 +657,17 @@ Status mha_fwd_kvcache(const cudaDeviceProp& dprops,
     params.page_block_size = 1;
   }
 
-  // Only split kernel supports appending to KV cache
-  run_mha_fwd(params, stream, /*force_split_kernel=*/k_new != nullptr);
+  params.k_scale_ptr = k_scale;
+  params.v_scale_ptr = v_scale;
+  params.k_quant_type = k_quant_type;
+  params.v_quant_type = v_quant_type;
+  params.kv_cache_bit_width = kv_cache_bit_width;
+
+  // Force split kernel if quantization is active (k_quant_type != 0)
+  // because only the split kernel instantiation supports dequantization logic.
+  bool force_split = (k_new != nullptr) || is_packed_qkv || (k_quant_type != 0);
+
+  run_mha_fwd(params, stream, force_split);
 
   return Status::OK();
 }

--- a/onnxruntime/contrib_ops/cuda/bert/flash_attention/flash_api.h
+++ b/onnxruntime/contrib_ops/cuda/bert/flash_attention/flash_api.h
@@ -121,7 +121,12 @@ Status mha_fwd_kvcache(const cudaDeviceProp& dprops,
                        bool is_rotary_interleaved = false,
                        bool is_packed_qkv = false,
                        int max_num_blocks_per_seq = 0,
-                       int page_block_size = 1);
+                       int page_block_size = 1,
+                       void* k_scale = nullptr,
+                       void* v_scale = nullptr,
+                       int k_quant_type = 0,
+                       int v_quant_type = 0,
+                       int kv_cache_bit_width = 0);
 
 size_t get_softmax_lse_size(size_t max_seqlen_q, size_t batch_size, size_t num_heads);
 size_t get_softmax_lse_size(size_t token_count, size_t num_heads);
@@ -130,6 +135,8 @@ std::tuple<size_t, size_t, size_t> get_num_splits_and_buffer_sizes(size_t batch_
                                                                    size_t head_size, size_t num_SMs);
 
 bool is_supported(const cudaDeviceProp& dprops, size_t head_size, size_t num_heads, size_t num_heads_k);
+
+bool is_supported_quantization(bool is_causal, size_t head_size, int k_quant_type, int v_quant_type, int kv_cache_bit_width);
 
 }  // namespace flash
 }  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/bert/flash_attention/flash_fwd_split_hdim128_bf16_sm80_quant_4bit.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/flash_attention/flash_fwd_split_hdim128_bf16_sm80_quant_4bit.cu
@@ -1,0 +1,16 @@
+// Copyright (c) 2023, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+
+#if USE_FLASH_ATTENTION
+
+#include "contrib_ops/cuda/bert/flash_attention/flash_fwd_launch_template.h"
+
+namespace onnxruntime {
+namespace flash {
+
+// Explicitly instantiate ONLY the 4-bit quantized dispatcher
+template void run_mha_fwd_splitkv_dispatch_quant_4bit<cutlass::bfloat16_t, 128>(Flash_fwd_params& params, cudaStream_t stream);
+
+}  // namespace flash
+}  // namespace onnxruntime
+#endif

--- a/onnxruntime/contrib_ops/cuda/bert/flash_attention/flash_fwd_split_hdim128_bf16_sm80_quant_8bit.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/flash_attention/flash_fwd_split_hdim128_bf16_sm80_quant_8bit.cu
@@ -1,0 +1,16 @@
+// Copyright (c) 2023, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+
+#if USE_FLASH_ATTENTION
+
+#include "contrib_ops/cuda/bert/flash_attention/flash_fwd_launch_template.h"
+
+namespace onnxruntime {
+namespace flash {
+
+// Explicitly instantiate ONLY the 8-bit quantized dispatcher
+template void run_mha_fwd_splitkv_dispatch_quant_8bit<cutlass::bfloat16_t, 128>(Flash_fwd_params& params, cudaStream_t stream);
+
+}  // namespace flash
+}  // namespace onnxruntime
+#endif

--- a/onnxruntime/contrib_ops/cuda/bert/flash_attention/flash_fwd_split_hdim128_fp16_sm80_quant_4bit.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/flash_attention/flash_fwd_split_hdim128_fp16_sm80_quant_4bit.cu
@@ -1,0 +1,16 @@
+// Copyright (c) 2023, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+
+#if USE_FLASH_ATTENTION
+
+#include "contrib_ops/cuda/bert/flash_attention/flash_fwd_launch_template.h"
+
+namespace onnxruntime {
+namespace flash {
+
+// Explicitly instantiate ONLY the 4-bit quantized dispatcher
+template void run_mha_fwd_splitkv_dispatch_quant_4bit<cutlass::half_t, 128>(Flash_fwd_params& params, cudaStream_t stream);
+
+}  // namespace flash
+}  // namespace onnxruntime
+#endif

--- a/onnxruntime/contrib_ops/cuda/bert/flash_attention/flash_fwd_split_hdim128_fp16_sm80_quant_8bit.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/flash_attention/flash_fwd_split_hdim128_fp16_sm80_quant_8bit.cu
@@ -1,0 +1,16 @@
+// Copyright (c) 2023, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+
+#if USE_FLASH_ATTENTION
+
+#include "contrib_ops/cuda/bert/flash_attention/flash_fwd_launch_template.h"
+
+namespace onnxruntime {
+namespace flash {
+
+// Explicitly instantiate ONLY the 8-bit quantized dispatcher
+template void run_mha_fwd_splitkv_dispatch_quant_8bit<cutlass::half_t, 128>(Flash_fwd_params& params, cudaStream_t stream);
+
+}  // namespace flash
+}  // namespace onnxruntime
+#endif

--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention.cc
@@ -8,6 +8,8 @@
 #include "contrib_ops/cpu/bert/group_query_attention_helper.h"
 #include "contrib_ops/cuda/bert/cutlass_fmha/memory_efficient_attention.h"
 #include "contrib_ops/cuda/bert/flash_attention/flash_api.h"
+#include "contrib_ops/cuda/utils/dump_cuda_tensor.h"
+#include "contrib_ops/cpu/utils/debug_macros.h"
 
 using namespace onnxruntime::cuda;
 using namespace ::onnxruntime::common;
@@ -17,22 +19,201 @@ namespace onnxruntime {
 namespace contrib {
 namespace cuda {
 
-#define REGISTER_KERNEL_TYPED(T)                                         \
-  ONNX_OPERATOR_TYPED_KERNEL_EX(                                         \
-      GroupQueryAttention,                                               \
-      kMSDomain,                                                         \
-      1,                                                                 \
-      T,                                                                 \
-      kCudaExecutionProvider,                                            \
-      (*KernelDefBuilder::Create())                                      \
-          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>())         \
-          .TypeConstraint("M", {DataTypeImpl::GetTensorType<int32_t>()}) \
-          .MayInplace(3, 1)                                              \
-          .MayInplace(4, 2)                                              \
-          .InputMemoryType(OrtMemTypeCPUInput, 6),                       \
+namespace {
+// Map string attribute to quantization type enum
+KVQuantizationType StringToKVQuantizationType(const std::string& s) {
+  if (s == "NONE") {
+    return KVQuantizationType::NONE;
+  }
+  if (s == "PER_TENSOR") {
+    return KVQuantizationType::PER_TENSOR;
+  }
+  if (s == "PER_CHANNEL") {
+    return KVQuantizationType::PER_CHANNEL;
+  }
+  return KVQuantizationType::NONE;
+}
+
+// Helper struct to manage buffers and pointers for quantization
+template <typename T>
+struct QuantizationData {
+  using CudaT = typename ToCudaType<T>::MappedType;
+
+  IAllocatorUniquePtr<T> dequantized_past_key_buffer;
+  IAllocatorUniquePtr<T> dequantized_past_value_buffer;
+  IAllocatorUniquePtr<T> dequantized_present_key_buffer;
+  IAllocatorUniquePtr<T> dequantized_present_value_buffer;
+
+  const CudaT* k_scale_ptr = nullptr;
+  const CudaT* v_scale_ptr = nullptr;
+
+  bool is_k_quantized = false;
+  bool is_v_quantized = false;
+};
+
+// Helper function to handle dequantization of past_key and past_value
+template <typename T>
+Status HandleDequantization(
+    const GroupQueryAttention<T>* kernel,
+    OpKernelContext* context,
+    const GroupQueryAttentionParameters& params,
+    GroupQueryAttentionData<typename ToCudaType<T>::MappedType>& data,
+    QuantizationData<T>& quant_data) {
+  using CudaT = typename ToCudaType<T>::MappedType;
+
+  const Tensor* past_key = context->Input<Tensor>(3);
+  const Tensor* past_value = context->Input<Tensor>(4);
+  Tensor* present_key = context->Output<Tensor>(1);
+  Tensor* present_value = context->Output<Tensor>(2);
+  const Tensor* k_scale = context->Input<Tensor>(12);
+  const Tensor* v_scale = context->Input<Tensor>(13);
+
+  auto stream = static_cast<cudaStream_t>(context->GetComputeStream()->GetHandle());
+  size_t past_kv_size = static_cast<size_t>(params.batch_size) * params.kv_num_heads * params.seqlen_past_kv_cache * params.head_size;
+  size_t present_kv_size = static_cast<size_t>(params.batch_size) * params.kv_num_heads * params.seqlen_present_kv_cache * params.head_size;
+
+  quant_data.is_k_quantized = params.k_quant_type != KVQuantizationType::NONE;
+  if (quant_data.is_k_quantized) {
+    ORT_ENFORCE(past_key != nullptr && k_scale != nullptr, "past_key and k_scale must be provided for quantized KV cache.");
+    quant_data.k_scale_ptr = reinterpret_cast<const CudaT*>(k_scale->Data<T>());
+
+    quant_data.dequantized_past_key_buffer = kernel->template GetScratchBuffer<T>(past_kv_size, context->GetComputeStream());
+    data.past_key = reinterpret_cast<const CudaT*>(quant_data.dequantized_past_key_buffer.get());
+
+    Status status;
+    if (params.kv_cache_bit_width == 8) {
+      status = LaunchDequantizeKV<CudaT, int8_t, CudaT>(
+          stream, reinterpret_cast<CudaT*>(quant_data.dequantized_past_key_buffer.get()),
+          past_key->Data<int8_t>(), quant_data.k_scale_ptr, data.seqlens_k,
+          params.batch_size, params.kv_num_heads, params.seqlen_past_kv_cache, params.sequence_length, params.head_size,
+          true /*is_past*/, params.kv_cache_bit_width, params.k_quant_type);
+    } else if (params.kv_cache_bit_width == 4) {
+      status = LaunchDequantizeKV<CudaT, uint8_t, CudaT>(
+          stream, reinterpret_cast<CudaT*>(quant_data.dequantized_past_key_buffer.get()),
+          past_key->Data<uint8_t>(), quant_data.k_scale_ptr, data.seqlens_k,
+          params.batch_size, params.kv_num_heads, params.seqlen_past_kv_cache, params.sequence_length, params.head_size,
+          true /*is_past*/, params.kv_cache_bit_width, params.k_quant_type);
+    } else {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Quantized KV cache requires kv_cache_bit_width to be 4 or 8.");
+    }
+    ORT_RETURN_IF_ERROR(status);
+
+    quant_data.dequantized_present_key_buffer = kernel->template GetScratchBuffer<T>(present_kv_size, context->GetComputeStream());
+    data.present_key = reinterpret_cast<CudaT*>(quant_data.dequantized_present_key_buffer.get());
+  } else {
+    data.past_key = (nullptr == past_key) ? nullptr : reinterpret_cast<const CudaT*>(past_key->Data<T>());
+    data.present_key = (nullptr == present_key) ? nullptr : reinterpret_cast<CudaT*>(present_key->MutableData<T>());
+  }
+
+  quant_data.is_v_quantized = params.v_quant_type != KVQuantizationType::NONE;
+  if (quant_data.is_v_quantized) {
+    ORT_ENFORCE(past_value != nullptr && v_scale != nullptr, "past_value and v_scale must be provided for quantized KV cache.");
+    quant_data.v_scale_ptr = reinterpret_cast<const CudaT*>(v_scale->Data<T>());
+
+    quant_data.dequantized_past_value_buffer = kernel->template GetScratchBuffer<T>(past_kv_size, context->GetComputeStream());
+    data.past_value = reinterpret_cast<const CudaT*>(quant_data.dequantized_past_value_buffer.get());
+
+    Status status;
+    if (params.kv_cache_bit_width == 8) {
+      status = LaunchDequantizeKV<CudaT, int8_t, CudaT>(
+          stream, reinterpret_cast<CudaT*>(quant_data.dequantized_past_value_buffer.get()),
+          past_value->Data<int8_t>(), quant_data.v_scale_ptr, data.seqlens_k,
+          params.batch_size, params.kv_num_heads, params.seqlen_past_kv_cache, params.sequence_length, params.head_size,
+          true /*is_past*/, params.kv_cache_bit_width, params.v_quant_type);
+    } else if (params.kv_cache_bit_width == 4) {
+      status = LaunchDequantizeKV<CudaT, uint8_t, CudaT>(
+          stream, reinterpret_cast<CudaT*>(quant_data.dequantized_past_value_buffer.get()),
+          past_value->Data<uint8_t>(), quant_data.v_scale_ptr, data.seqlens_k,
+          params.batch_size, params.kv_num_heads, params.seqlen_past_kv_cache, params.sequence_length, params.head_size,
+          true /*is_past*/, params.kv_cache_bit_width, params.v_quant_type);
+    } else {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Quantized KV cache requires kv_cache_bit_width to be 4 or 8.");
+    }
+    ORT_RETURN_IF_ERROR(status);
+
+    quant_data.dequantized_present_value_buffer = kernel->template GetScratchBuffer<T>(present_kv_size, context->GetComputeStream());
+    data.present_value = reinterpret_cast<CudaT*>(quant_data.dequantized_present_value_buffer.get());
+  } else {
+    data.past_value = (nullptr == past_value) ? nullptr : reinterpret_cast<const CudaT*>(past_value->Data<T>());
+    data.present_value = (nullptr == present_value) ? nullptr : reinterpret_cast<CudaT*>(present_value->MutableData<T>());
+  }
+
+  return Status::OK();
+}
+
+// Helper function to handle requantization of present_key and present_value
+template <typename T>
+Status HandleRequantization(
+    OpKernelContext* context,
+    const GroupQueryAttentionParameters& params,
+    const GroupQueryAttentionData<typename ToCudaType<T>::MappedType>& data,
+    const QuantizationData<T>& quant_data) {
+  using CudaT = typename ToCudaType<T>::MappedType;
+
+  Tensor* present_key = context->Output<Tensor>(1);
+  Tensor* present_value = context->Output<Tensor>(2);
+  auto stream = static_cast<cudaStream_t>(context->GetComputeStream()->GetHandle());
+
+  if (quant_data.is_k_quantized) {
+    Status status;
+    if (params.kv_cache_bit_width == 8) {
+      status = LaunchQuantizeKV<CudaT, int8_t, CudaT>(
+          stream, present_key->MutableData<int8_t>(), data.present_key, quant_data.k_scale_ptr, data.seqlens_k,
+          params.batch_size, params.kv_num_heads, params.seqlen_present_kv_cache, params.head_size,
+          params.kv_cache_bit_width, params.k_quant_type);
+    } else if (params.kv_cache_bit_width == 4) {
+      status = LaunchQuantizeKV<CudaT, uint8_t, CudaT>(
+          stream, present_key->MutableData<uint8_t>(), data.present_key, quant_data.k_scale_ptr, data.seqlens_k,
+          params.batch_size, params.kv_num_heads, params.seqlen_present_kv_cache, params.head_size,
+          params.kv_cache_bit_width, params.k_quant_type);
+    } else {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Quantized KV cache requires kv_cache_bit_width to be 4 or 8.");
+    }
+    ORT_RETURN_IF_ERROR(status);
+  }
+
+  if (quant_data.is_v_quantized) {
+    Status status;
+    if (params.kv_cache_bit_width == 8) {
+      status = LaunchQuantizeKV<CudaT, int8_t, CudaT>(
+          stream, present_value->MutableData<int8_t>(), data.present_value, quant_data.v_scale_ptr, data.seqlens_k,
+          params.batch_size, params.kv_num_heads, params.seqlen_present_kv_cache, params.head_size,
+          params.kv_cache_bit_width, params.v_quant_type);
+    } else if (params.kv_cache_bit_width == 4) {
+      status = LaunchQuantizeKV<CudaT, uint8_t, CudaT>(
+          stream, present_value->MutableData<uint8_t>(), data.present_value, quant_data.v_scale_ptr, data.seqlens_k,
+          params.batch_size, params.kv_num_heads, params.seqlen_present_kv_cache, params.head_size,
+          params.kv_cache_bit_width, params.v_quant_type);
+    } else {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Quantized KV cache requires kv_cache_bit_width to be 4 or 8.");
+    }
+    ORT_RETURN_IF_ERROR(status);
+  }
+
+  return Status::OK();
+}
+
+}  // namespace
+
+#define REGISTER_KERNEL_TYPED(T)                                                      \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                                      \
+      GroupQueryAttention,                                                            \
+      kMSDomain,                                                                      \
+      1,                                                                              \
+      T,                                                                              \
+      kCudaExecutionProvider,                                                         \
+      (*KernelDefBuilder::Create())                                                   \
+          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>())                      \
+          .TypeConstraint("T_CACHE",                                                  \
+                          {DataTypeImpl::GetTensorType<T>(),                          \
+                           DataTypeImpl::GetTensorType<int8_t>(),                     \
+                           DataTypeImpl::GetTensorType<uint8_t>()})                   \
+          .TypeConstraint("M", {DataTypeImpl::GetTensorType<int32_t>()})              \
+          .MayInplace(3, 1)                        /* past_key and present_key */     \
+          .MayInplace(4, 2)                        /* past_value and present_value */ \
+          .InputMemoryType(OrtMemTypeCPUInput, 6), /* total_sequence_length */        \
       GroupQueryAttention<T>);
 
-// REGISTER_KERNEL_TYPED(float)
 REGISTER_KERNEL_TYPED(MLFloat16)
 REGISTER_KERNEL_TYPED(BFloat16)
 
@@ -53,6 +234,12 @@ GroupQueryAttention<T>::GroupQueryAttention(const OpKernelInfo& info)
   scale_ = info.GetAttrOrDefault<float>("scale", 0.0f);
   softcap_ = info.GetAttrOrDefault<float>("softcap", 0.0f);
   use_smooth_softmax_ = info.GetAttrOrDefault<int64_t>("smooth_softmax", 0) == 1;
+
+  k_quant_type_ = StringToKVQuantizationType(info.GetAttrOrDefault<std::string>("k_quant_type", "NONE"));
+  v_quant_type_ = StringToKVQuantizationType(info.GetAttrOrDefault<std::string>("v_quant_type", "NONE"));
+  kv_cache_bit_width_ = static_cast<int>(info.GetAttrOrDefault<int64_t>("kv_cache_bit_width", 0));
+  ORT_ENFORCE(kv_cache_bit_width_ == 0 || kv_cache_bit_width_ == 4 || kv_cache_bit_width_ == 8,
+              "kv_cache_bit_width must be 0 (no quantization), 4 or 8.");
 
   kernel_options_ = this->GetAttentionKernelOptions();
 
@@ -81,6 +268,8 @@ Status GroupQueryAttention<T>::ComputeInternal(OpKernelContext* context) const {
   const Tensor* position_ids = context->Input<Tensor>(9);
   const Tensor* attention_bias = context->Input<Tensor>(10);
   const Tensor* head_sink = context->Input<Tensor>(11);
+  const Tensor* k_scale = context->Input<Tensor>(12);
+  const Tensor* v_scale = context->Input<Tensor>(13);
 
   if (position_ids != nullptr || attention_bias != nullptr) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
@@ -106,6 +295,7 @@ Status GroupQueryAttention<T>::ComputeInternal(OpKernelContext* context) const {
                                                                 total_seqlen,
                                                                 scale_,
                                                                 softcap_,
+                                                                kv_cache_bit_width_,
                                                                 device_prop.maxThreadsPerBlock));
 
   ORT_RETURN_IF_ERROR(group_query_attention_helper::CheckCustomAttentionInputs(position_ids,
@@ -117,8 +307,9 @@ Status GroupQueryAttention<T>::ComputeInternal(OpKernelContext* context) const {
   parameters.use_smooth_softmax = use_smooth_softmax_ || head_sink != nullptr;
   parameters.zeros_count = kZerosCount;
   parameters.zero_ptr = zeros_.get();
-
-  int sequence_length = parameters.sequence_length;
+  parameters.k_quant_type = k_quant_type_;
+  parameters.v_quant_type = v_quant_type_;
+  parameters.kv_cache_bit_width = kv_cache_bit_width_;
   parameters.do_rotary = do_rotary_;
   parameters.rotary_interleaved = rotary_interleaved_;
 
@@ -133,89 +324,229 @@ Status GroupQueryAttention<T>::ComputeInternal(OpKernelContext* context) const {
                            "cos_cache and sin_cache must be passed to GroupQueryAttention when do_rotary = 1");
   }
 
+  // ========================================================================
+  // Input Validation for Quantized KV Cache
+  // ========================================================================
+
+  // Validate INT4 quantization requires even head_size
+  if (kv_cache_bit_width_ == 4) {
+    if (parameters.head_size % 2 != 0) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "INT4 quantized KV cache requires head_size to be even. Got head_size=",
+                             parameters.head_size,
+                             ". INT4 packs 2 values per byte, so odd head_size is not supported.");
+    }
+  }
+
+  // Validate quantized cache requires scale tensors
+  bool has_quantized_k = (k_quant_type_ != KVQuantizationType::NONE);
+  bool has_quantized_v = (v_quant_type_ != KVQuantizationType::NONE);
+
+  if (has_quantized_k || has_quantized_v) {
+    // If using quantization, kv_cache_bit_width must be set
+    if (kv_cache_bit_width_ == 0) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "When k_quant_type or v_quant_type is not NONE, kv_cache_bit_width must be 4 or 8.");
+    }
+
+    // If using quantized K cache, k_scale must be provided when past_key exists
+    if (has_quantized_k && past_key != nullptr && k_scale == nullptr) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "k_scale must be provided when past_key is quantized (k_quant_type is not NONE).");
+    }
+
+    // If using quantized V cache, v_scale must be provided when past_value exists
+    if (has_quantized_v && past_value != nullptr && v_scale == nullptr) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "v_scale must be provided when past_value is quantized (v_quant_type is not NONE).");
+    }
+  }
+
+  // Validate scale tensors are only provided when quantization is enabled
+  if (k_scale != nullptr && !has_quantized_k) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "k_scale is provided but k_quant_type is NONE. Set k_quant_type to enable quantization.");
+  }
+
+  if (v_scale != nullptr && !has_quantized_v) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "v_scale is provided but v_quant_type is NONE. Set v_quant_type to enable quantization.");
+  }
+
+  // ========================================================================
+
   TensorShapeVector output_shape(3);
   output_shape[0] = static_cast<int64_t>(parameters.batch_size);
-  output_shape[1] = static_cast<int64_t>(sequence_length);
+  output_shape[1] = static_cast<int64_t>(parameters.sequence_length);
   output_shape[2] = static_cast<int64_t>(parameters.hidden_size);
   Tensor* output = context->Output(0, output_shape);
+
+  // Set up present KV output shapes
+  std::vector<int64_t> present_dims = {
+      parameters.batch_size, parameters.kv_num_heads, parameters.seqlen_present_kv_cache, parameters.head_size};
+
+  // Update present shape when kv cache has quantization.
+  if (kv_cache_bit_width_ == 4) {
+    present_dims[3] = (present_dims[3] + 1) / 2;
+  }
+
+  TensorShape present_shape(present_dims);
+
+  context->Output(1, present_shape);  // present_key
+  context->Output(2, present_shape);  // present_value
+
+  QuantizationData<T> quant_data;
+  IAllocatorUniquePtr<void> k_buffer;
+  IAllocatorUniquePtr<void> v_buffer;
+  IAllocatorUniquePtr<void> rotary_buffer;
+  IAllocatorUniquePtr<void> fmha_buffer;
+  IAllocatorUniquePtr<void> unpacked_qkv_buffer;
+
+  // Flash Attention buffers
+  IAllocatorUniquePtr<void> softmax_lse_buffer;
+  IAllocatorUniquePtr<void> softmax_lse_accum_buffer;
+  IAllocatorUniquePtr<void> out_accum_buffer;
+
+  // Allocate seqlens_k_buffer here so it is available for both paths
+  auto seqlens_k_buffer = GetScratchBuffer<void>(sizeof(int) * parameters.batch_size, context->GetComputeStream());
+  data.seqlens_k_buff = reinterpret_cast<int*>(seqlens_k_buffer.get());
 
 #if USE_FLASH_ATTENTION
   bool use_flash_attention = !disable_flash_attention_ &&
                              onnxruntime::flash::is_supported(device_prop,
                                                               parameters.head_size,
                                                               parameters.num_heads,
-                                                              parameters.kv_num_heads);
-  // Allocate buffers
-  size_t softmax_lse_bytes = 0;
-  size_t softmax_lse_accum_bytes = 0;
-  size_t out_accum_bytes = 0;
+                                                              parameters.kv_num_heads) &&
+                             onnxruntime::flash::is_supported_quantization(true /*is_causal*/,
+                                                                           parameters.head_size,
+                                                                           static_cast<int>(k_quant_type_),
+                                                                           static_cast<int>(v_quant_type_),
+                                                                           kv_cache_bit_width_);
+#else
+  constexpr bool use_flash_attention = false;
+#endif
+
   if (use_flash_attention) {
-    // softmax buffer
-    softmax_lse_bytes = onnxruntime::flash::get_softmax_lse_size(parameters.sequence_length, parameters.batch_size, parameters.num_heads);
-    // split kv buffer
-    using namespace std;
-    auto [num_splits, slse_accum_bytes, o_accum_bytes] = onnxruntime::flash::get_num_splits_and_buffer_sizes(
+    // --- FLASH ATTENTION PATH ---
+
+    data.query = reinterpret_cast<const CudaT*>(query->Data<T>());
+    data.key = key == nullptr ? nullptr : reinterpret_cast<const CudaT*>(key->Data<T>());
+    data.value = value == nullptr ? nullptr : reinterpret_cast<const CudaT*>(value->Data<T>());
+    data.seqlens_k = const_cast<int*>(seqlens_k->Data<int>());
+
+    data.k_scale = k_scale == nullptr ? nullptr : reinterpret_cast<const CudaT*>(k_scale->Data<T>());
+    data.v_scale = v_scale == nullptr ? nullptr : reinterpret_cast<const CudaT*>(v_scale->Data<T>());
+
+    // Handle Past/Present pointers handling quantization types
+    if (k_quant_type_ != KVQuantizationType::NONE && past_key != nullptr) {
+      if (kv_cache_bit_width_ == 8) {
+        data.past_key = reinterpret_cast<const CudaT*>(past_key->Data<int8_t>());
+        data.present_key = reinterpret_cast<CudaT*>(context->Output<Tensor>(1)->MutableData<int8_t>());
+      } else {
+        data.past_key = reinterpret_cast<const CudaT*>(past_key->Data<uint8_t>());
+        data.present_key = reinterpret_cast<CudaT*>(context->Output<Tensor>(1)->MutableData<uint8_t>());
+      }
+    } else {
+      data.past_key = (past_key == nullptr) ? nullptr : reinterpret_cast<const CudaT*>(past_key->Data<T>());
+      data.present_key = reinterpret_cast<CudaT*>(context->Output<Tensor>(1)->MutableData<T>());
+    }
+
+    if (v_quant_type_ != KVQuantizationType::NONE && past_value != nullptr) {
+      if (kv_cache_bit_width_ == 8) {
+        data.past_value = reinterpret_cast<const CudaT*>(past_value->Data<int8_t>());
+        data.present_value = reinterpret_cast<CudaT*>(context->Output<Tensor>(2)->MutableData<int8_t>());
+      } else {
+        data.past_value = reinterpret_cast<const CudaT*>(past_value->Data<uint8_t>());
+        data.present_value = reinterpret_cast<CudaT*>(context->Output<Tensor>(2)->MutableData<uint8_t>());
+      }
+    } else {
+      data.past_value = (past_value == nullptr) ? nullptr : reinterpret_cast<const CudaT*>(past_value->Data<T>());
+      data.present_value = reinterpret_cast<CudaT*>(context->Output<Tensor>(2)->MutableData<T>());
+    }
+
+    data.use_flash_attention = true;
+    data.use_memory_efficient_attention = false;
+
+    // Allocate Flash specific buffers (Softmax LSE, Accum)
+    size_t softmax_lse_bytes = onnxruntime::flash::get_softmax_lse_size(parameters.sequence_length, parameters.batch_size, parameters.num_heads);
+    auto [num_splits, softmax_lse_accum_bytes, out_accum_bytes] = onnxruntime::flash::get_num_splits_and_buffer_sizes(
         parameters.batch_size, parameters.sequence_length, parameters.total_sequence_length, parameters.num_heads,
         parameters.head_size, device_prop.multiProcessorCount);
     parameters.num_splits = static_cast<int>(num_splits);
-    softmax_lse_accum_bytes = slse_accum_bytes;
-    out_accum_bytes = o_accum_bytes;
-  }
-  auto softmax_lse_buffer = GetScratchBuffer<void>(softmax_lse_bytes, context->GetComputeStream());
-  auto softmax_lse_accum_buffer = GetScratchBuffer<void>(softmax_lse_accum_bytes, context->GetComputeStream());
-  auto out_accum_buffer = GetScratchBuffer<void>(out_accum_bytes, context->GetComputeStream());
-#else
-  constexpr bool use_flash_attention = false;
-  auto softmax_lse_buffer = GetScratchBuffer<void>(0, context->GetComputeStream());        // nullptr
-  auto softmax_lse_accum_buffer = GetScratchBuffer<void>(0, context->GetComputeStream());  // nullptr
-  auto out_accum_buffer = GetScratchBuffer<void>(0, context->GetComputeStream());          // nullptr
-#endif
+
+    softmax_lse_buffer = GetScratchBuffer<void>(softmax_lse_bytes, context->GetComputeStream());
+    softmax_lse_accum_buffer = GetScratchBuffer<void>(softmax_lse_accum_bytes, context->GetComputeStream());
+    out_accum_buffer = GetScratchBuffer<void>(out_accum_bytes, context->GetComputeStream());
+
+    data.softmax_lse = reinterpret_cast<CudaT*>(softmax_lse_buffer.get());
+    data.softmax_lse_accum = reinterpret_cast<CudaT*>(softmax_lse_accum_buffer.get());
+    data.out_accum = reinterpret_cast<CudaT*>(out_accum_buffer.get());
+
+    size_t unpacked_qkv_bytes = parameters.is_packed_qkv && (parameters.num_heads != parameters.kv_num_heads)
+                                    ? (static_cast<size_t>(parameters.batch_size) * parameters.sequence_length * (parameters.num_heads + 2 * parameters.kv_num_heads) * parameters.head_size * sizeof(T))
+                                    : 0;
+    if (unpacked_qkv_bytes > 0) {
+      unpacked_qkv_buffer = GetScratchBuffer<void>(unpacked_qkv_bytes, context->GetComputeStream());
+      data.unpacked_qkv_buffer = reinterpret_cast<CudaT*>(unpacked_qkv_buffer.get());
+    } else {
+      data.unpacked_qkv_buffer = nullptr;
+    }
+
+  } else {
+    // --- FALLBACK PATH ---
 
 #if USE_MEMORY_EFFICIENT_ATTENTION
-  int sm = (device_prop.major * 10) + device_prop.minor;
-  bool use_memory_efficient_attention =
-      !use_flash_attention &&
-      !disable_memory_efficient_attention_ &&
-      has_memory_efficient_attention(sm, sizeof(T) == 2, parameters.head_size, parameters.head_size);
+    int sm = (device_prop.major * 10) + device_prop.minor;
+    bool use_memory_efficient_attention =
+        !use_flash_attention &&
+        !disable_memory_efficient_attention_ &&
+        has_memory_efficient_attention(sm, sizeof(T) == 2, parameters.head_size, parameters.head_size);
 
-  // allocate buffers
-  size_t kv_buffer_bytes = 0;
-  // need a buffer if we must ungroup kv
-  const bool needs_buff = (parameters.num_heads != parameters.kv_num_heads);
-  if (use_memory_efficient_attention && needs_buff) {
-    kv_buffer_bytes = (sizeof(T) * parameters.batch_size * parameters.num_heads * parameters.seqlen_present_kv_cache * parameters.head_size);
-  }
-  size_t rotary_buffer_bytes = 0;
-  if (use_memory_efficient_attention && do_rotary_) {
-    rotary_buffer_bytes = 2 * sizeof(T) * parameters.batch_size * parameters.num_heads * parameters.sequence_length * parameters.head_size;
-    rotary_buffer_bytes += sizeof(int64_t) * parameters.batch_size * parameters.sequence_length;
-  }
-  size_t fmha_buffer_bytes = 0;
-  if (use_memory_efficient_attention && MemoryEfficientAttentionParams::need_workspace(parameters.head_size, sizeof(T) == sizeof(float))) {
-    fmha_buffer_bytes = (parameters.batch_size * parameters.sequence_length * parameters.num_heads * parameters.head_size * sizeof(float));
-  }
-  size_t unpacked_qkv_bytes = 0;
-  if (use_memory_efficient_attention && parameters.is_packed_qkv) {
-    unpacked_qkv_bytes = (parameters.batch_size * parameters.sequence_length * (parameters.num_heads + 2 * parameters.kv_num_heads) * parameters.head_size * sizeof(T));
-  }
-  auto k_buffer = GetScratchBuffer<void>(kv_buffer_bytes, context->GetComputeStream());
-  auto v_buffer = GetScratchBuffer<void>(kv_buffer_bytes, context->GetComputeStream());
-  auto rotary_buffer = GetScratchBuffer<void>(rotary_buffer_bytes, context->GetComputeStream());
-  auto fmha_buffer = GetScratchBuffer<void>(fmha_buffer_bytes, context->GetComputeStream());
-  auto unpacked_qkv_buffer = GetScratchBuffer<void>(unpacked_qkv_bytes, context->GetComputeStream());
+    size_t kv_buffer_bytes = (use_memory_efficient_attention && (parameters.num_heads != parameters.kv_num_heads))
+                                 ? (sizeof(T) * parameters.batch_size * parameters.num_heads * parameters.seqlen_present_kv_cache * parameters.head_size)
+                                 : 0;
+    size_t rotary_buffer_bytes = use_memory_efficient_attention && do_rotary_
+                                     ? (2 * sizeof(T) * parameters.batch_size * parameters.num_heads * parameters.sequence_length * parameters.head_size +
+                                        sizeof(int64_t) * parameters.batch_size * parameters.sequence_length)
+                                     : 0;
+    size_t fmha_buffer_bytes = (use_memory_efficient_attention && MemoryEfficientAttentionParams::need_workspace(parameters.head_size, sizeof(T) == sizeof(float)))
+                                   ? (static_cast<size_t>(parameters.batch_size) * parameters.sequence_length * parameters.num_heads * parameters.head_size * sizeof(float))
+                                   : 0;
+    size_t unpacked_qkv_bytes = use_memory_efficient_attention && parameters.is_packed_qkv
+                                    ? (static_cast<size_t>(parameters.batch_size) * parameters.sequence_length * (parameters.num_heads + 2 * parameters.kv_num_heads) * parameters.head_size * sizeof(T))
+                                    : 0;
+    k_buffer = GetScratchBuffer<void>(kv_buffer_bytes, context->GetComputeStream());
+    v_buffer = GetScratchBuffer<void>(kv_buffer_bytes, context->GetComputeStream());
+    rotary_buffer = GetScratchBuffer<void>(rotary_buffer_bytes, context->GetComputeStream());
+    fmha_buffer = GetScratchBuffer<void>(fmha_buffer_bytes, context->GetComputeStream());
+    unpacked_qkv_buffer = GetScratchBuffer<void>(unpacked_qkv_bytes, context->GetComputeStream());
 #else
-  constexpr bool use_memory_efficient_attention = false;
-  auto k_buffer = GetScratchBuffer<void>(0, context->GetComputeStream());
-  auto v_buffer = GetScratchBuffer<void>(0, context->GetComputeStream());
-  auto rotary_buffer = GetScratchBuffer<void>(0, context->GetComputeStream());
-  auto fmha_buffer = GetScratchBuffer<void>(0, context->GetComputeStream());
-  auto unpacked_qkv_buffer = GetScratchBuffer<void>(0, context->GetComputeStream());
+    bool use_memory_efficient_attention = false;
 #endif
+    data.use_memory_efficient_attention = use_memory_efficient_attention;
+    data.use_flash_attention = false;
+
+    data.query = reinterpret_cast<const CudaT*>(query->Data<T>());
+    data.key = key == nullptr ? nullptr : reinterpret_cast<const CudaT*>(key->Data<T>());
+    data.value = value == nullptr ? nullptr : reinterpret_cast<const CudaT*>(value->Data<T>());
+    data.seqlens_k = const_cast<int*>(seqlens_k->Data<int>());
+
+    data.k_scale = k_scale == nullptr ? nullptr : reinterpret_cast<const CudaT*>(k_scale->Data<T>());
+    data.v_scale = v_scale == nullptr ? nullptr : reinterpret_cast<const CudaT*>(v_scale->Data<T>());
+
+    ORT_RETURN_IF_ERROR(HandleDequantization(this, context, parameters, data, quant_data));
+
+    data.k = reinterpret_cast<CudaT*>(k_buffer.get());
+    data.v = reinterpret_cast<CudaT*>(v_buffer.get());
+    data.fmha_buffer = reinterpret_cast<CudaT*>(fmha_buffer.get());
+    data.unpacked_qkv_buffer = reinterpret_cast<CudaT*>(unpacked_qkv_buffer.get());
+    data.rotary_buffer = reinterpret_cast<CudaT*>(rotary_buffer.get());
+  }
 
   if (kernel_options_->AllowDebugInfo()) {
     AttentionKernelDebugInfo debug_info;
     debug_info.use_flash_attention = use_flash_attention;
-    debug_info.use_efficient_attention = use_memory_efficient_attention;
+    debug_info.use_efficient_attention = data.use_memory_efficient_attention;
 
     debug_info.Print("GroupQueryAttention",
                      this->Node().Name(),
@@ -223,67 +554,13 @@ Status GroupQueryAttention<T>::ComputeInternal(OpKernelContext* context) const {
                      std::is_same<T, BFloat16>::value);
   }
 
-  // seqlens_k buffer
-  size_t seqlens_k_bytes = 0;
-  seqlens_k_bytes = sizeof(int) * parameters.batch_size;
-  auto seqlens_k_buffer = GetScratchBuffer<void>(seqlens_k_bytes, context->GetComputeStream());
-
-  std::vector<int64_t> present_dims;
-  if (parameters.past_kv_format == AttentionQkvFormat::Q_K_V_BSNH) {
-    present_dims = {
-        parameters.batch_size, parameters.seqlen_present_kv_cache, parameters.kv_num_heads, parameters.head_size};
-  } else {  // BNSH
-    present_dims = {
-        parameters.batch_size, parameters.kv_num_heads, parameters.seqlen_present_kv_cache, parameters.head_size};
-  }
-  TensorShape present_shape(present_dims);
-  Tensor* present_key = context->Output(1, present_shape);
-  Tensor* present_value = context->Output(2, present_shape);
-
-  data.query = reinterpret_cast<const CudaT*>(query->Data<T>());
-  data.key = key == nullptr ? nullptr : reinterpret_cast<const CudaT*>(key->Data<T>());
-  data.value = value == nullptr ? nullptr : reinterpret_cast<const CudaT*>(value->Data<T>());
-  data.past_key = (nullptr == past_key) ? nullptr : reinterpret_cast<const CudaT*>(past_key->Data<T>());
-  data.past_value = (nullptr == past_value) ? nullptr : reinterpret_cast<const CudaT*>(past_value->Data<T>());
-  data.output = reinterpret_cast<CudaT*>(output->MutableData<T>());
-  data.present_key = (nullptr == present_key) ? nullptr : reinterpret_cast<CudaT*>(present_key->MutableData<T>());
-  data.present_value = (nullptr == present_value) ? nullptr : reinterpret_cast<CudaT*>(present_value->MutableData<T>());
-  data.seqlens_k = const_cast<int*>(seqlens_k->Data<int>());
-  data.use_flash_attention = use_flash_attention;
-  data.use_memory_efficient_attention = use_memory_efficient_attention;
   if (data.past_key == data.present_key) {
     parameters.kv_share_buffer = true;
   } else {
     parameters.kv_share_buffer = false;
   }
-  // Flash Buffers
-  if (softmax_lse_buffer != nullptr) {
-    data.softmax_lse = reinterpret_cast<CudaT*>(softmax_lse_buffer.get());
-  }
-  if (softmax_lse_accum_buffer != nullptr) {
-    data.softmax_lse_accum = reinterpret_cast<CudaT*>(softmax_lse_accum_buffer.get());
-  }
-  if (out_accum_buffer != nullptr) {
-    data.out_accum = reinterpret_cast<CudaT*>(out_accum_buffer.get());
-  }
-  if (seqlens_k_buffer != nullptr) {
-    data.seqlens_k_buff = reinterpret_cast<int*>(seqlens_k_buffer.get());
-  }
-  // Memory Efficient Buffers
-  if (k_buffer != nullptr) {
-    data.k = reinterpret_cast<CudaT*>(k_buffer.get());
-    data.v = reinterpret_cast<CudaT*>(v_buffer.get());
-  }
-  if (fmha_buffer != nullptr) {
-    data.fmha_buffer = reinterpret_cast<CudaT*>(fmha_buffer.get());
-  }
-  if (unpacked_qkv_buffer != nullptr) {
-    data.unpacked_qkv_buffer = reinterpret_cast<CudaT*>(unpacked_qkv_buffer.get());
-  }
-  if (rotary_buffer != nullptr) {
-    data.rotary_buffer = reinterpret_cast<CudaT*>(rotary_buffer.get());
-  }
-  // Rotary Embedding
+  data.output = reinterpret_cast<CudaT*>(output->MutableData<T>());
+
   if (parameters.do_rotary) {
     data.cos_cache = reinterpret_cast<const CudaT*>(cos_cache->Data<T>());
     data.sin_cache = reinterpret_cast<const CudaT*>(sin_cache->Data<T>());
@@ -293,10 +570,36 @@ Status GroupQueryAttention<T>::ComputeInternal(OpKernelContext* context) const {
     data.head_sink = reinterpret_cast<const CudaT*>(head_sink->Data<T>());
   }
 
-  cublasHandle_t cublas = GetCublasHandle(context);
+#if DUMP_TENSOR_LEVEL > 0
+  DUMP_TENSOR_INIT();
+  // Dump Scales
+  if (data.k_scale) {
+    // Assuming scalar or small vector, dump first few elements
+    DUMP_TENSOR("k_scale", data.k_scale, 1, 1, 1, 1);
+  }
 
-  return QkvToContext<CudaT>(
-      device_prop, cublas, context->GetComputeStream(), parameters, data);
+  // Dump Present Key (should contain past + new)
+  // Note: Dimensions might need adjustment for int4 to avoid dump crash if size mismatch
+  if (parameters.k_quant_type != KVQuantizationType::NONE) {
+    // Just dump raw bytes
+    if (parameters.kv_cache_bit_width == 4) {
+      DUMP_TENSOR("present_key_quant_packed", reinterpret_cast<const int8_t*>(data.present_key),
+                  parameters.batch_size, parameters.kv_num_heads, parameters.seqlen_present_kv_cache, parameters.head_size / 2);
+    } else {
+      DUMP_TENSOR("present_key_quant", reinterpret_cast<const int8_t*>(data.present_key),
+                  parameters.batch_size, parameters.kv_num_heads, parameters.seqlen_present_kv_cache, parameters.head_size);
+    }
+  }
+#endif
+
+  cublasHandle_t cublas = GetCublasHandle(context);
+  ORT_RETURN_IF_ERROR(QkvToContext<CudaT>(device_prop, cublas, context->GetComputeStream(), parameters, data));
+
+  if (!use_flash_attention) {
+    ORT_RETURN_IF_ERROR(HandleRequantization(context, parameters, data, quant_data));
+  }
+
+  return Status::OK();
 }
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention.h
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention.h
@@ -7,6 +7,7 @@
 #include "core/providers/cuda/cuda_kernel.h"
 #include "contrib_ops/cuda/bert/group_query_attention_impl.h"
 #include "contrib_ops/cuda/bert/attention_kernel_options.h"
+#include "contrib_ops/cpu/bert/attention_common.h"
 
 namespace onnxruntime {
 namespace contrib {
@@ -33,6 +34,11 @@ class GroupQueryAttention final : public CudaKernel {
   float softcap_;
   bool disable_flash_attention_;
   bool disable_memory_efficient_attention_;
+
+  KVQuantizationType k_quant_type_;
+  KVQuantizationType v_quant_type_;
+  int kv_cache_bit_width_;
+
   static constexpr int kZerosCount = 256;  // In prompt case we create a zero buffer of size 256 for seqlen (assume batch_size <= 256)
   IAllocatorUniquePtr<int> zeros_;
   const AttentionKernelOptions* kernel_options_;

--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention_impl.cu
@@ -25,25 +25,29 @@ limitations under the License.
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include <cassert>
+#include <cublas_v2.h>
 #include <cuda_fp16.h>
+
+#include <cassert>
 #include <cub/cub.cuh>
-#include "core/providers/cuda/cu_inc/common.cuh"
-#include "core/providers/cuda/cuda_common.h"
-#include "core/providers/cuda/shared_inc/fpgeneric.h"
-#include "contrib_ops/cuda/bert/attention_softmax.h"
-#include "contrib_ops/cuda/bert/transformer_common.h"
+
+// #include "contrib_ops/cpu/bert/attention_base.h"
+#include "contrib_ops/cpu/utils/debug_macros.h"
 #include "contrib_ops/cuda/bert/add_bias_transpose.h"
-#include "contrib_ops/cpu/bert/attention_base.h"
+#include "contrib_ops/cuda/bert/attention_impl.h"
+#include "contrib_ops/cuda/bert/attention_softmax.h"
 #include "contrib_ops/cuda/bert/bert_padding.h"
-#include "contrib_ops/cuda/utils/dump_cuda_tensor.h"
 #include "contrib_ops/cuda/bert/cutlass_fmha/memory_efficient_attention.h"
 #include "contrib_ops/cuda/bert/flash_attention/flash_api.h"
 #include "contrib_ops/cuda/bert/group_query_attention_impl.h"
-#include "contrib_ops/cuda/bert/attention_impl.h"
-#include "core/providers/cuda/shared_inc/cuda_call.h"
+#include "contrib_ops/cuda/bert/group_query_attention_qdq.cuh"
 #include "contrib_ops/cuda/bert/rotary_embedding_impl.h"
-#include <cublas_v2.h>
+#include "contrib_ops/cuda/bert/transformer_common.h"
+#include "contrib_ops/cuda/utils/dump_cuda_tensor.h"
+#include "core/providers/cuda/cu_inc/common.cuh"
+#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/shared_inc/cuda_call.h"
+#include "core/providers/cuda/shared_inc/fpgeneric.h"
 
 using namespace onnxruntime::cuda;
 
@@ -57,6 +61,26 @@ namespace cuda {
 __global__ void repeat_seqlen(int32_t* seqlens_k, int32_t seqlen, int batch_size) {
   int id = blockDim.x * blockIdx.x + threadIdx.x;
   if (id < batch_size) seqlens_k[id] = seqlen;
+}
+
+__global__ void GetPastSeqLens(const int32_t* total_seqlens,
+                               int32_t* past_seqlens, const int batch_size,
+                               const int sequence_length) {
+  int tid = blockDim.x * blockIdx.x + threadIdx.x;
+  if (tid < batch_size) {
+    past_seqlens[tid] = total_seqlens[tid] + 1 - sequence_length;
+  }
+}
+
+Status LaunchGetPastSeqLens(const int32_t* total_seqlens, int32_t* past_seqlens,
+                            const int batch_size, const int sequence_length,
+                            cudaStream_t stream,
+                            const int max_threads_per_block) {
+  const int threads = std::min(batch_size, max_threads_per_block);
+  const int blocks = (batch_size + threads - 1) / threads;
+  GetPastSeqLens<<<blocks, threads, 0, stream>>>(total_seqlens, past_seqlens,
+                                                 batch_size, sequence_length);
+  return CUDA_CALL(cudaGetLastError());
 }
 
 // Concat new to past in present. Supports past BSNH or past BNSH
@@ -274,7 +298,7 @@ Status LaunchGetSeqlensInteractive(const int32_t* seqlens_k, int32_t* seqlens_k_
                                    const int batch_size, const int sequence_length, cudaStream_t stream,
                                    const int max_threads_per_block) {
   const int threads = std::min(batch_size, max_threads_per_block);
-  const int blocks = (threads / max_threads_per_block) + 1;
+  const int blocks = (batch_size + threads - 1) / threads;
   GetSeqlensInteractive<<<blocks, threads, 0, stream>>>(seqlens_k, seqlens_k_buff, batch_size,
                                                         sequence_length);
   return CUDA_CALL(cudaGetLastError());
@@ -296,7 +320,7 @@ __global__ void UnpackQKV(const T* packed_qkv, T* unpacked_q, T* unpacked_k, T* 
     int offset = tid % d;
     if (output_bnsh) {  // output BNSH
       int head_count = kv_num_heads;
-      T* unpacked;
+      T* unpacked = nullptr;
       if (offset < q_hidden) {
         unpacked = unpacked_q;
         head_count = num_heads;
@@ -307,23 +331,32 @@ __global__ void UnpackQKV(const T* packed_qkv, T* unpacked_q, T* unpacked_k, T* 
         unpacked = unpacked_v;
         offset -= (q_hidden + k_hidden);
       }
-      int n = offset / head_size;
-      int h = offset % head_size;
 
-      int unpacked_i = INDEX_4D(head_count, sequence_length, head_size, b, n, s, h);
-      unpacked[unpacked_i] = packed_qkv[tid];
+      if (unpacked != nullptr) {
+        int n = offset / head_size;
+        int h = offset % head_size;
+
+        int unpacked_i = INDEX_4D(head_count, sequence_length, head_size, b, n, s, h);
+        unpacked[unpacked_i] = packed_qkv[tid];
+      }
     } else {  // output BSNH
       if (offset < q_hidden) {
-        int unpacked_i = b * sequence_length * num_heads * head_size + s * num_heads * head_size + offset;
-        unpacked_q[unpacked_i] = packed_qkv[tid];
+        if (unpacked_q != nullptr) {
+          int unpacked_i = b * sequence_length * num_heads * head_size + s * num_heads * head_size + offset;
+          unpacked_q[unpacked_i] = packed_qkv[tid];
+        }
       } else if (offset < q_hidden + k_hidden) {
-        int unpacked_i = b * sequence_length * kv_num_heads * head_size +
-                         s * kv_num_heads * head_size + (offset - q_hidden);
-        unpacked_k[unpacked_i] = packed_qkv[tid];
+        if (unpacked_k != nullptr) {
+          int unpacked_i = b * sequence_length * kv_num_heads * head_size +
+                           s * kv_num_heads * head_size + (offset - q_hidden);
+          unpacked_k[unpacked_i] = packed_qkv[tid];
+        }
       } else {
-        int unpacked_i = b * sequence_length * kv_num_heads * head_size +
-                         s * kv_num_heads * head_size + (offset - q_hidden - k_hidden);
-        unpacked_v[unpacked_i] = packed_qkv[tid];
+        if (unpacked_v != nullptr) {
+          int unpacked_i = b * sequence_length * kv_num_heads * head_size +
+                           s * kv_num_heads * head_size + (offset - q_hidden - k_hidden);
+          unpacked_v[unpacked_i] = packed_qkv[tid];
+        }
       }
     }
   }
@@ -432,28 +465,99 @@ Status FlashAttention(
   }
 
   void* seqlens_k = reinterpret_cast<void*>(data.seqlens_k);
-  if (parameters.is_subsequent_prompt) {
-    ORT_RETURN_IF_ERROR(LaunchGetSeqlensInteractive(reinterpret_cast<const int32_t*>(data.seqlens_k),
-                                                    reinterpret_cast<int32_t*>(data.seqlens_k_buff), batch_size,
-                                                    sequence_length, stream, max_threads_per_block));
+  if (parameters.is_first_prompt) {
+    constexpr int thr_per_blk = 256;
+    int blk_in_grid = (batch_size + thr_per_blk - 1) / thr_per_blk;
+    repeat_seqlen<<<blk_in_grid, thr_per_blk, 0, stream>>>(
+        data.seqlens_k_buff, sequence_length, batch_size);
     seqlens_k = reinterpret_cast<void*>(data.seqlens_k_buff);
-  } else if (parameters.is_first_prompt) {
-    // set seqlens_k to zeros... flash api uses seqlens_k to indicate where to append key and value
-    // user should use seqlens_k to index into output to get new tokens
-    if (batch_size <= parameters.zeros_count) {
-      seqlens_k = parameters.zero_ptr;
+  } else {
+    // If using manual quantization (Append_KV=false in kernel), we must pass Total Length to kernel.
+    bool manual_append_quant = parameters.k_quant_type != KVQuantizationType::NONE && !parameters.is_packed_qkv;
+
+    if (manual_append_quant) {
+      ORT_RETURN_IF_ERROR(LaunchGetSeqlensTotal(data.seqlens_k, data.seqlens_k_buff, batch_size, stream, max_threads_per_block));
+
+#if DUMP_TENSOR_LEVEL > 0
+      int32_t cpu_seqlen = 0;
+      cudaMemcpyAsync(&cpu_seqlen, data.seqlens_k_buff, sizeof(int32_t), cudaMemcpyDeviceToHost, stream);
+      cudaStreamSynchronize(stream);  // Force wait to print
+      printf("[GQA Impl] Batch0 Total SeqLen used for Append: %d (New Token Appended)\n", cpu_seqlen);
+#endif
+
     } else {
-      // Launch kernel to create larger seqlen tensor when batch_size > 256
-      constexpr int thr_per_blk = 256;
-      int blk_in_grid = (batch_size + thr_per_blk - 1) / thr_per_blk;
-      repeat_seqlen<<<blk_in_grid, thr_per_blk, 0, stream>>>(data.seqlens_k_buff, 0, batch_size);
-      seqlens_k = reinterpret_cast<void*>(data.seqlens_k_buff);
+      ORT_RETURN_IF_ERROR(LaunchGetSeqlensInteractive(
+          reinterpret_cast<const int32_t*>(data.seqlens_k),
+          reinterpret_cast<int32_t*>(data.seqlens_k_buff), batch_size,
+          sequence_length, stream, max_threads_per_block));
     }
+    seqlens_k = reinterpret_cast<void*>(data.seqlens_k_buff);
   }
 
-  if (!parameters.kv_share_buffer || parameters.is_first_prompt) {  // copy past kv to present kv
-    ORT_RETURN_IF_ERROR(LaunchConcatNewToPastKV(parameters, data, nullptr, nullptr, stream, max_threads_per_block,
-                                                true));
+  bool is_quantized = parameters.k_quant_type != KVQuantizationType::NONE;
+
+#if DUMP_TENSOR_LEVEL > 0
+  printf("[GQA Impl] is_quantized: %d, is_packed_qkv: %d, is_first_prompt: %d, kv_share_buffer: %d\n",
+         static_cast<int>(is_quantized),
+         static_cast<int>(parameters.is_packed_qkv),
+         static_cast<int>(parameters.is_first_prompt),
+         static_cast<int>(parameters.kv_share_buffer));
+#endif
+
+  if (is_quantized) {
+    // [Manual Append Logic]
+    if (!parameters.kv_share_buffer || parameters.is_first_prompt) {
+      size_t past_sz = static_cast<size_t>(batch_size) * kv_num_heads * parameters.seqlen_past_kv_cache * head_size;
+      if (parameters.kv_cache_bit_width == 4) past_sz = (past_sz + 1) / 2;
+      CUDA_CALL_THROW(cudaMemcpyAsync(data.present_key, data.past_key, past_sz, cudaMemcpyDeviceToDevice, stream));
+      CUDA_CALL_THROW(cudaMemcpyAsync(data.present_value, data.past_value, past_sz, cudaMemcpyDeviceToDevice, stream));
+    }
+
+    if (!parameters.is_packed_qkv) {
+      auto LaunchQuantAppend = [&](void* dst, const T* src, const T* scale, KVQuantizationType q_type) {
+        if (parameters.kv_cache_bit_width == 8) {
+          return LaunchQuantizeAppendKV<T, int8_t, T>(
+              stream, reinterpret_cast<int8_t*>(dst), src, scale,
+              data.seqlens_k, batch_size, kv_num_heads,
+              parameters.seqlen_present_kv_cache, head_size, 8, sequence_length, q_type);
+        } else {
+          return LaunchQuantizeAppendKV<T, uint8_t, T>(
+              stream, reinterpret_cast<uint8_t*>(dst), src, scale,
+              data.seqlens_k, batch_size, kv_num_heads,
+              parameters.seqlen_present_kv_cache, head_size, 4, sequence_length, q_type);
+        }
+      };
+      ORT_RETURN_IF_ERROR(LaunchQuantAppend(data.present_key, reinterpret_cast<const T*>(key), data.k_scale, parameters.k_quant_type));
+      ORT_RETURN_IF_ERROR(LaunchQuantAppend(data.present_value, reinterpret_cast<const T*>(value), data.v_scale, parameters.v_quant_type));
+    }
+  } else {
+    // [Standard FP16 Append Logic]
+    if (parameters.is_packed_qkv) {
+      // Unpack K and V from Packed QKV into temporary buffer
+      T* unpacked_buffer = reinterpret_cast<T*>(data.unpacked_qkv_buffer);
+      if (unpacked_buffer != nullptr) {
+        size_t q_size = static_cast<size_t>(batch_size) * sequence_length * num_heads * head_size;
+        T* unpacked_k = unpacked_buffer + q_size;
+        size_t k_size = static_cast<size_t>(batch_size) * sequence_length * kv_num_heads * head_size;
+        T* unpacked_v = unpacked_k + k_size;
+
+        // Always unpack to BSNH as LaunchConcatNewToPastKV expects contiguous BSNH input
+        ORT_RETURN_IF_ERROR((LaunchUnpackQKV<T, false>(reinterpret_cast<const T*>(data.query), nullptr, unpacked_k, unpacked_v, num_heads, kv_num_heads, head_size, sequence_length, batch_size, stream, max_threads_per_block)));
+
+        // Update key/value to point to unpacked headers
+        key = unpacked_k;
+        value = unpacked_v;
+      }
+    }
+
+    if (parameters.kv_share_buffer && !parameters.is_first_prompt) {
+      constexpr bool is_new_kv_bnsh_format = false;
+      ORT_RETURN_IF_ERROR(LaunchConcatKVInPlace(parameters, data, key, value, is_new_kv_bnsh_format, stream, max_threads_per_block));
+    } else {
+      // ORT MUST perform the append (using unpacked data for packed case)
+      bool skip_new_append = false;
+      ORT_RETURN_IF_ERROR(LaunchConcatNewToPastKV(parameters, data, key, value, stream, max_threads_per_block, skip_new_append));
+    }
   }
 
   void* present_key = reinterpret_cast<void*>(const_cast<T*>(data.present_key));
@@ -462,25 +566,37 @@ Status FlashAttention(
   void* sin_cache = reinterpret_cast<void*>(const_cast<T*>(data.sin_cache));
   void* head_sink = reinterpret_cast<void*>(const_cast<T*>(data.head_sink));
 
+  void* k_scale =
+      const_cast<void*>(reinterpret_cast<const void*>(data.k_scale));
+  void* v_scale =
+      const_cast<void*>(reinterpret_cast<const void*>(data.v_scale));
+
   bool past_bsnh = past_kv_format == AttentionQkvFormat::Q_K_V_BSNH;
 
   DUMP_TENSOR_INIT();
   DUMP_TENSOR("Q", reinterpret_cast<T*>(query), batch_size, sequence_length, num_heads, head_size);
-  DUMP_TENSOR("K", reinterpret_cast<T*>(present_key), batch_size, parameters.seqlen_present_kv_cache, kv_num_heads, head_size);
-  DUMP_TENSOR("V", reinterpret_cast<T*>(present_value), batch_size, parameters.seqlen_present_kv_cache, kv_num_heads, head_size);
+  // Only dump K/V if NOT quantized due to data type (T* vs int8*)
+  if (!is_quantized) {
+    DUMP_TENSOR("K", reinterpret_cast<T*>(present_key), batch_size, parameters.seqlen_present_kv_cache, kv_num_heads, head_size);
+    DUMP_TENSOR("V", reinterpret_cast<T*>(present_value), batch_size, parameters.seqlen_present_kv_cache, kv_num_heads, head_size);
+  }
 
+  // We have already appended (and quantized if needed) the new tokens into present_key/value.
+  // Pass nullptr for new_k/new_v to disable the kernel's internal Append_KV logic.
   ORT_RETURN_IF_ERROR(onnxruntime::flash::mha_fwd_kvcache(
-      device_prop, stream, query, present_key, present_value, key, value, data.output,
-      reinterpret_cast<void*>(data.softmax_lse), seqlens_k, cos_cache, sin_cache, head_sink, /*block_table*/ nullptr,
-      batch_size, num_heads, kv_num_heads, head_size, sequence_length,
-      parameters.seqlen_present_kv_cache, kv_sequence_length, parameters.rotary_dim,
-      scale, parameters.softcap, is_causal, is_bf16, parameters.use_smooth_softmax, past_bsnh, parameters.num_splits,
-      reinterpret_cast<void*>(data.softmax_lse_accum), reinterpret_cast<void*>(data.out_accum),
-      parameters.local_window_size - 1, parameters.rotary_interleaved, parameters.is_packed_qkv));
-
-  // if (parameters.left_padding && parameters.is_first_prompt) {
-  //   ORT_RETURN_IF_ERROR(LaunchLeftPadLast(parameters, data, stream, device_prop.maxThreadsPerBlock));
-  // }
+      device_prop, stream, query, present_key, present_value, nullptr, nullptr,
+      data.output, reinterpret_cast<void*>(data.softmax_lse), seqlens_k,
+      cos_cache, sin_cache, head_sink, /*block_table*/ nullptr, batch_size,
+      num_heads, kv_num_heads, head_size, sequence_length,
+      parameters.seqlen_present_kv_cache, kv_sequence_length,
+      parameters.rotary_dim, scale, parameters.softcap, is_causal, is_bf16,
+      parameters.use_smooth_softmax, past_bsnh, parameters.num_splits,
+      reinterpret_cast<void*>(data.softmax_lse_accum),
+      reinterpret_cast<void*>(data.out_accum), parameters.local_window_size - 1,
+      parameters.rotary_interleaved, parameters.is_packed_qkv, 0, 1, k_scale,
+      v_scale, static_cast<int>(parameters.k_quant_type),
+      static_cast<int>(parameters.v_quant_type),
+      parameters.kv_cache_bit_width));
 
   DUMP_TENSOR("flash attention output", data.output, batch_size, sequence_length, num_heads, head_size);
 
@@ -708,6 +824,3 @@ template Status LaunchUnpackQKV<BFloat16, LAYOUT_BNSH>(
 }  // namespace cuda
 }  // namespace contrib
 }  // namespace onnxruntime
-
-#undef OFFSET_BNSH
-#undef OFFSET_BSNH

--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention_impl.h
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention_impl.h
@@ -28,6 +28,21 @@ Status LaunchUnpackQKV(const T* packed_qkv, T* unpacked_q, T* unpacked_k, T* unp
                        const int kv_num_heads, const int head_size, const int sequence_length, const int batch_size,
                        cudaStream_t stream, const int max_threads_per_block);
 
+template <typename T, typename T_QUANT, typename T_SCALE>
+Status LaunchDequantizeKV(cudaStream_t stream, T* dequantized_data,
+                          const T_QUANT* quantized_data, const T_SCALE* scale,
+                          const int* seqlens, int batch_size, int num_heads,
+                          int past_sequence_length, int sequence_length,
+                          int head_size, bool is_past, int bit_width,
+                          KVQuantizationType quant_type);
+
+template <typename T, typename T_QUANT, typename T_SCALE>
+Status LaunchQuantizeKV(cudaStream_t stream, T_QUANT* quantized_data,
+                        const T* dequantized_data, const T_SCALE* scale,
+                        const int* seqlens, int batch_size, int num_heads,
+                        int sequence_length, int head_size, int bit_width,
+                        KVQuantizationType quant_type);
+
 }  // namespace cuda
 }  // namespace contrib
 }  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention_qdq.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention_qdq.cuh
@@ -1,0 +1,425 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+// #include <cstdio> // Added for printf
+#include <cuda_fp16.h>
+
+#include "contrib_ops/cuda/bert/group_query_attention_impl.h"
+#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/shared_inc/cuda_call.h"
+
+using namespace onnxruntime::cuda;
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+
+// ============================================================================
+// KV Cache Quantization/Dequantization Kernels
+// ============================================================================
+//
+// This file implements symmetric quantization for KV cache in GroupQueryAttention.
+// Supports INT4 and INT8 with PER_TENSOR and PER_CHANNEL quantization modes.
+//
+// QUANTIZATION SCHEME:
+// -------------------
+// INT4: Symmetric signed quantization
+//   - Range: [-8, 7] (signed 4-bit)
+//   - Formula: q = clamp(round(x / scale), -8, 7)
+//   - Rounding: Round-to-nearest (rintf)
+//   - Saturation: Clamp to [-8, 7]
+//
+// INT8: Symmetric signed quantization
+//   - Range: [-128, 127] (signed 8-bit)
+//   - Formula: q = clamp(round(x / scale), -128, 127)
+//   - Rounding: Round-to-nearest (rintf)
+//   - Saturation: Clamp to [-128, 127]
+//
+// BIT PACKING (INT4 only):
+// -----------------------
+// Storage format: uint8_t, 2 values per byte
+//   packed_byte = ((q0 + 8) & 0x0F) | (((q1 + 8) & 0x0F) << 4)
+//
+// Where:
+//   - q0 (even element) → low nibble (bits 0-3)
+//   - q1 (odd element) → high nibble (bits 4-7)
+//   - +8 bias converts signed [-8, 7] to unsigned [0, 15]
+//
+// For odd head_size, last element q0 is paired with q1 = 0.
+//
+// SCALE TENSOR FORMAT:
+// -------------------
+// Scales are always FP16/BF16 (type T), never quantized.
+//
+// PER_TENSOR: scale[0] - single scale for entire cache
+// PER_CHANNEL: scale[head_idx * head_size + elem_idx] - one scale per channel
+//
+// MEMORY LAYOUT:
+// -------------
+// Cache: BNSH (batch, num_heads, sequence_length, head_size)
+// INT4: (head_size + 1) / 2 bytes per head
+// INT8: head_size bytes per head
+// ============================================================================
+
+// Dequantization Kernel for KV cache.
+template <typename T, typename T_QUANT, typename T_SCALE>
+__global__ void DequantizeKernel(T* dequantized_data,
+                                 const T_QUANT* quantized_data,
+                                 const T_SCALE* scale, const int* seqlens,
+                                 int batch_size, int num_heads,
+                                 int cache_sequence_length, int sequence_length,
+                                 int head_size, bool is_past, int bit_width,
+                                 KVQuantizationType quant_type) {
+  int S = cache_sequence_length;
+  int total_elements = batch_size * num_heads * S * head_size;
+
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < total_elements;
+       i += blockDim.x * gridDim.x) {
+    int h = i % head_size;
+    int s = (i / head_size) % S;
+    int n = (i / (head_size * S)) % num_heads;
+    int b = i / (num_heads * head_size * S);
+
+    // Correctly identify padding in the past_kv cache.
+    // In the decoding case, `seqlens` contains `past_len + new_len - 1`.
+    // We need the actual past_len to mask the padding correctly.
+    if (is_past && seqlens != nullptr) {
+      // For a given batch entry `b`, the actual length of the past sequence is `seqlens[b] + 1 - sequence_length`.
+      // If `s` (the current sequence index) is beyond this length, it's padding and should be zeroed.
+      int past_len_b = seqlens[b] + 1 - sequence_length;
+      if (s >= past_len_b) {
+        dequantized_data[i] = static_cast<T>(0.0f);
+        continue;
+      }
+    }
+
+    float scale_val = 1.0f;
+    if (quant_type == KVQuantizationType::PER_TENSOR) {
+      scale_val = static_cast<float>(scale[0]);
+    } else {  // PER_CHANNEL
+      int scale_idx = n * head_size + h;
+      scale_val = static_cast<float>(scale[scale_idx]);
+    }
+
+    float quantized_float;
+    if (bit_width == 8) {
+      quantized_float = static_cast<float>(
+          reinterpret_cast<const int8_t*>(quantized_data)[i]);
+    } else {  // 4
+      const uint8_t packed_val =
+          reinterpret_cast<const uint8_t*>(quantized_data)[i / 2];
+      quantized_float = (i % 2 == 0)
+                            ? static_cast<float>((packed_val & 0x0F) - 8)
+                            : static_cast<float>((packed_val >> 4) - 8);
+    }
+
+    dequantized_data[i] = static_cast<T>(quantized_float * scale_val);
+  }
+}
+
+template <typename T, typename T_QUANT, typename T_SCALE>
+Status LaunchDequantizeKV(cudaStream_t stream, T* dequantized_data,
+                          const T_QUANT* quantized_data, const T_SCALE* scale,
+                          const int* seqlens, int batch_size, int num_heads,
+                          int cache_sequence_length, int sequence_length,
+                          int head_size, bool is_past, int bit_width,
+                          KVQuantizationType quant_type) {
+  int S = cache_sequence_length;
+  if (S == 0) return Status::OK();
+
+  int total_elements = batch_size * num_heads * S * head_size;
+  const int threads_per_block = 256;
+  const int blocks =
+      (total_elements + threads_per_block - 1) / threads_per_block;
+
+  DequantizeKernel<T, T_QUANT, T_SCALE><<<blocks, threads_per_block, 0, stream>>>(
+      dequantized_data, quantized_data, scale, seqlens, batch_size, num_heads,
+      cache_sequence_length, sequence_length, head_size, is_past, bit_width,
+      quant_type);
+
+  return CUDA_CALL(cudaGetLastError());
+}
+
+// Quantization Kernel for KV cache.
+template <typename T, typename T_QUANT, typename T_SCALE>
+__global__ void QuantizeKernel(T_QUANT* quantized_data,
+                               const T* dequantized_data, const T_SCALE* scale,
+                               const int* seqlens, int total_packed_elements,
+                               int cache_sequence_length, int num_heads, int head_size,
+                               int bit_width, KVQuantizationType quant_type) {
+  int elements_per_head_packed = (bit_width == 4) ? (head_size + 1) / 2 : head_size;
+
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < total_packed_elements;
+       i += blockDim.x * gridDim.x) {
+    int h_packed = i % elements_per_head_packed;
+    int s = (i / elements_per_head_packed) % cache_sequence_length;
+    int n = (i / (elements_per_head_packed * cache_sequence_length)) % num_heads;
+    int b = i / (num_heads * elements_per_head_packed * cache_sequence_length);
+
+    // Zero out padding in the present_kv cache.
+    // `seqlens` (seqlens_k) provides the total valid sequence length for each batch item.
+    // If the current sequence index `s` is in the padded region, write zero.
+    int total_valid_len_b = seqlens[b] + 1;
+    if (s >= total_valid_len_b) {
+      if (bit_width == 8) {
+        reinterpret_cast<int8_t*>(quantized_data)[i] = 0;
+      } else {  // 4
+        // With packed iteration, each thread handles one byte (2 values).
+        // Since we are in the padding region, write a zero byte.
+        reinterpret_cast<uint8_t*>(quantized_data)[i] = (0 + 8) | ((0 + 8) << 4);
+      }
+      continue;
+    }
+
+    if (bit_width == 8) {
+      int h = h_packed;
+      float scale_val = 1.0f;
+      if (quant_type == KVQuantizationType::PER_TENSOR) {
+        scale_val = static_cast<float>(scale[0]);
+      } else {  // PER_CHANNEL
+        int scale_idx = n * head_size + h;
+        scale_val = static_cast<float>(scale[scale_idx]);
+      }
+
+      float inv_scale = (scale_val == 0.0f) ? 0.0f : 1.0f / scale_val;
+      int64_t flattened_input_idx = (int64_t)b * num_heads * cache_sequence_length * head_size +
+                                    (int64_t)n * cache_sequence_length * head_size +
+                                    (int64_t)s * head_size +
+                                    h;
+      float val_float = static_cast<float>(dequantized_data[flattened_input_idx]) * inv_scale;
+
+      int32_t val_int32 = static_cast<int32_t>(rintf(val_float));
+      reinterpret_cast<int8_t*>(quantized_data)[i] =
+          static_cast<int8_t>(max(-128, min(127, val_int32)));
+    } else {  // 4
+      int h0 = h_packed * 2;
+      int h1 = h0 + 1;
+
+      // Compute first nibble
+      float scale0 = 1.0f;
+      if (quant_type == KVQuantizationType::PER_TENSOR) {
+        scale0 = static_cast<float>(scale[0]);
+      } else {
+        scale0 = static_cast<float>(scale[n * head_size + h0]);
+      }
+      float inv_scale0 = (scale0 == 0.0f) ? 0.0f : 1.0f / scale0;
+
+      int64_t input_idx0 = (int64_t)b * num_heads * cache_sequence_length * head_size +
+                           (int64_t)n * cache_sequence_length * head_size +
+                           (int64_t)s * head_size +
+                           h0;
+      float val0 = static_cast<float>(dequantized_data[input_idx0]) * inv_scale0;
+      int8_t q0 = static_cast<int8_t>(max(-8.0f, min(7.0f, rintf(val0))));
+
+      // Compute second nibble if within head_size
+      int8_t q1 = 0;  // Default to 0 (value 0) if padded
+      if (h1 < head_size) {
+        float scale1 = 1.0f;
+        if (quant_type == KVQuantizationType::PER_TENSOR) {
+          scale1 = static_cast<float>(scale[0]);
+        } else {
+          scale1 = static_cast<float>(scale[n * head_size + h1]);
+        }
+        float inv_scale1 = (scale1 == 0.0f) ? 0.0f : 1.0f / scale1;
+
+        int64_t input_idx1 = (int64_t)b * num_heads * cache_sequence_length * head_size +
+                             (int64_t)n * cache_sequence_length * head_size +
+                             (int64_t)s * head_size +
+                             h1;
+        float val1 = static_cast<float>(dequantized_data[input_idx1]) * inv_scale1;
+        q1 = static_cast<int8_t>(max(-8.0f, min(7.0f, rintf(val1))));
+      } else {
+        // Padding for odd head_size
+        q1 = 0;
+      }
+
+      // Pack two 4-bit values into one byte with +8 bias to convert to unsigned [0,15]
+      // Low nibble: q0 (even element), High nibble: q1 (odd element)
+      uint8_t packed = ((q0 + 8) & 0x0F) | (((q1 + 8) & 0x0F) << 4);
+      reinterpret_cast<uint8_t*>(quantized_data)[i] = packed;
+    }
+  }
+}
+
+// Append kernel for dynamic offset quantization
+template <typename T, typename T_QUANT, typename T_SCALE>
+__global__ void QuantizeAppendKernel(T_QUANT* cache_data,
+                                     const T* new_data,
+                                     const T_SCALE* scale,
+                                     const int* total_seqlens,
+                                     int max_seq_len,
+                                     int num_heads,
+                                     int head_size,
+                                     int bit_width,
+                                     int new_seq_len,
+                                     KVQuantizationType quant_type,
+                                     int batch_size) {
+  int elements_per_head_packed = (bit_width == 4) ? (head_size + 1) / 2 : head_size;
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int total_elements = batch_size * num_heads * new_seq_len * elements_per_head_packed;
+
+  if (idx >= total_elements) return;
+
+  int h_packed = idx % elements_per_head_packed;
+  int tmp = idx / elements_per_head_packed;
+  int s = tmp % new_seq_len;
+  tmp = tmp / new_seq_len;
+  int n = tmp % num_heads;
+  int b = tmp / num_heads;
+
+  if (b >= batch_size) return;
+
+  int past_len = 0;
+  if (total_seqlens != nullptr) {
+    past_len = total_seqlens[b] - new_seq_len;
+  }
+  // For safety, ensure past_len >= 0. In prompt phase, it's 0.
+  if (past_len < 0) past_len = 0;
+
+  int64_t cache_offset = (int64_t)b * num_heads * max_seq_len * elements_per_head_packed +
+                         (int64_t)n * max_seq_len * elements_per_head_packed +
+                         (int64_t)(past_len + s) * elements_per_head_packed +
+                         h_packed;
+
+  if (bit_width == 8) {
+    int h = h_packed;
+    int64_t src_idx = (int64_t)b * num_heads * new_seq_len * head_size +
+                      (int64_t)n * new_seq_len * head_size +
+                      (int64_t)s * head_size +
+                      h;
+    float val = static_cast<float>(new_data[src_idx]);
+
+    float s_scale = 1.0f;
+    if (quant_type == KVQuantizationType::PER_TENSOR)
+      s_scale = (float)scale[0];
+    else if (quant_type == KVQuantizationType::PER_CHANNEL)
+      s_scale = (float)scale[n * head_size + h];
+
+    float inv_s = (s_scale == 0.0f) ? 0.0f : 1.0f / s_scale;
+    int8_t q_val = static_cast<int8_t>(max(-128.0f, min(127.0f, rintf(val * inv_s))));
+    reinterpret_cast<int8_t*>(cache_data)[cache_offset] = q_val;
+
+  } else {  // Int4
+    int h0 = h_packed * 2;
+    int h1 = h0 + 1;
+
+    int64_t src_idx0 = (int64_t)b * num_heads * new_seq_len * head_size +
+                       (int64_t)n * new_seq_len * head_size +
+                       (int64_t)s * head_size +
+                       h0;
+    float val0 = static_cast<float>(new_data[src_idx0]);
+
+    float val1 = 0.0f;
+    if (h1 < head_size) {
+      int64_t src_idx1 = (int64_t)b * num_heads * new_seq_len * head_size +
+                         (int64_t)n * new_seq_len * head_size +
+                         (int64_t)s * head_size +
+                         h1;
+      val1 = static_cast<float>(new_data[src_idx1]);
+    }
+
+    float s0 = 1.0f;
+    float s1 = 1.0f;
+    if (quant_type == KVQuantizationType::PER_TENSOR) {
+      s0 = (float)scale[0];
+      s1 = (float)scale[0];
+    } else {
+      s0 = (float)scale[n * head_size + h0];
+      if (h1 < head_size) s1 = (float)scale[n * head_size + h1];
+    }
+
+    int8_t q0 = static_cast<int8_t>(max(-8.0f, min(7.0f, rintf(val0 * (s0 == 0 ? 0 : 1.0f / s0)))));
+    int8_t q1 = static_cast<int8_t>(max(-8.0f, min(7.0f, rintf(val1 * (s1 == 0 ? 0 : 1.0f / s1)))));
+
+    uint8_t packed = ((q0 + 8) & 0x0F) | (((q1 + 8) & 0x0F) << 4);
+    reinterpret_cast<uint8_t*>(cache_data)[cache_offset] = packed;
+  }
+}
+
+template <typename T, typename T_QUANT, typename T_SCALE>
+Status LaunchQuantizeKV(cudaStream_t stream, T_QUANT* quantized_data,
+                        const T* dequantized_data, const T_SCALE* scale,
+                        const int* seqlens, int batch_size, int num_heads,
+                        int cache_sequence_length, int head_size, int bit_width,
+                        KVQuantizationType quant_type) {
+  if (cache_sequence_length == 0) return Status::OK();
+
+  int elements_per_head_packed = (bit_width == 4) ? (head_size + 1) / 2 : head_size;
+  int total_packed_elements = batch_size * num_heads * cache_sequence_length * elements_per_head_packed;
+
+  const int threads_per_block = 256;
+  int blocks = (total_packed_elements + threads_per_block - 1) / threads_per_block;
+
+  QuantizeKernel<T, T_QUANT, T_SCALE><<<blocks, threads_per_block, 0, stream>>>(
+      quantized_data, dequantized_data, scale, seqlens, total_packed_elements,
+      cache_sequence_length, num_heads, head_size, bit_width, quant_type);
+
+  return CUDA_CALL(cudaGetLastError());
+}
+
+template <typename T, typename T_QUANT, typename T_SCALE>
+Status LaunchQuantizeAppendKV(cudaStream_t stream, T_QUANT* cache_data,
+                              const T* new_data, const T_SCALE* scale,
+                              const int* past_seqlens, int batch_size, int num_heads,
+                              int max_seq_len, int head_size, int bit_width,
+                              int new_seq_len,
+                              KVQuantizationType quant_type) {
+  int elements_per_head_packed = (bit_width == 4) ? (head_size + 1) / 2 : head_size;
+  int total_threads = batch_size * num_heads * new_seq_len * elements_per_head_packed;
+  const int threads_per_block = 256;
+  int blocks = (total_threads + threads_per_block - 1) / threads_per_block;
+
+  QuantizeAppendKernel<T, T_QUANT, T_SCALE><<<blocks, threads_per_block, 0, stream>>>(
+      cache_data, new_data, scale, past_seqlens, max_seq_len, num_heads, head_size, bit_width, new_seq_len, quant_type, batch_size);
+
+  return CUDA_CALL(cudaGetLastError());
+}
+
+// Explicit instantiations for launchers
+template Status LaunchDequantizeKV<half, int8_t, half>(cudaStream_t, half*,
+                                                       const int8_t*, const half*,
+                                                       const int*, int, int, int, int,
+                                                       int, bool, int,
+                                                       KVQuantizationType);
+template Status LaunchDequantizeKV<half, uint8_t, half>(cudaStream_t, half*,
+                                                        const uint8_t*, const half*,
+                                                        const int*, int, int, int,
+                                                        int, int, bool, int,
+                                                        KVQuantizationType);
+template Status LaunchDequantizeKV<BFloat16, int8_t, BFloat16>(
+    cudaStream_t, BFloat16*, const int8_t*, const BFloat16*, const int*, int, int,
+    int, int, int, bool, int, KVQuantizationType);
+template Status LaunchDequantizeKV<BFloat16, uint8_t, BFloat16>(
+    cudaStream_t, BFloat16*, const uint8_t*, const BFloat16*, const int*, int, int,
+    int, int, int, bool, int, KVQuantizationType);
+
+template Status LaunchQuantizeKV<half, int8_t, half>(
+    cudaStream_t, int8_t*, const half*, const half*, const int*, int, int, int, int,
+    int, KVQuantizationType);
+template Status LaunchQuantizeKV<half, uint8_t, half>(
+    cudaStream_t, uint8_t*, const half*, const half*, const int*, int, int, int, int,
+    int, KVQuantizationType);
+template Status LaunchQuantizeKV<BFloat16, int8_t, BFloat16>(
+    cudaStream_t, int8_t*, const BFloat16*, const BFloat16*, const int*, int, int, int,
+    int, int, KVQuantizationType);
+template Status LaunchQuantizeKV<BFloat16, uint8_t, BFloat16>(
+    cudaStream_t, uint8_t*, const BFloat16*, const BFloat16*, const int*, int, int, int,
+    int, int, KVQuantizationType);
+
+template Status LaunchQuantizeAppendKV<half, int8_t, half>(
+    cudaStream_t, int8_t*, const half*, const half*, const int*, int, int, int, int,
+    int, int, KVQuantizationType);
+template Status LaunchQuantizeAppendKV<half, uint8_t, half>(
+    cudaStream_t, uint8_t*, const half*, const half*, const int*, int, int, int, int,
+    int, int, KVQuantizationType);
+template Status LaunchQuantizeAppendKV<BFloat16, int8_t, BFloat16>(
+    cudaStream_t, int8_t*, const BFloat16*, const BFloat16*, const int*, int, int, int,
+    int, int, int, KVQuantizationType);
+template Status LaunchQuantizeAppendKV<BFloat16, uint8_t, BFloat16>(
+    cudaStream_t, uint8_t*, const BFloat16*, const BFloat16*, const int*, int, int, int,
+    int, int, int, KVQuantizationType);
+
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/test/python/transformers/test_gqa.py
+++ b/onnxruntime/test/python/transformers/test_gqa.py
@@ -14,14 +14,17 @@ import os
 import platform
 import random
 import unittest
+from copy import deepcopy
 from dataclasses import dataclass
 
 import numpy
 import torch
 from einops import rearrange, repeat
 from onnx import TensorProto, helper
+from packaging import version
 from parameterized import parameterized
 
+import onnxruntime
 from onnxruntime import InferenceSession, OrtValue, SessionOptions, get_available_providers
 
 # Set seed for reproducibility
@@ -31,9 +34,39 @@ random.seed(69)
 # Reduces number of tests to run for faster pipeline checks
 pipeline_mode = os.getenv("PIPELINE_MODE", "1") == "1"
 
+# Number of values per parameter (compared to pipeline mode)
+param_count = int(os.getenv("PARAM_COUNT", "2")) if not pipeline_mode else 1
+
 # #################################################################################################
 #  Configuration and Helper Classes
 # #################################################################################################
+
+
+# --- ONNX and Torch/Numpy Dtype Mappings ---
+ONNX_TENSOR_TYPE_MAP = {
+    "float32": TensorProto.FLOAT,
+    "float16": TensorProto.FLOAT16,
+    "bfloat16": TensorProto.BFLOAT16,
+    "int32": TensorProto.INT32,
+    "int8": TensorProto.INT8,
+    "int4": TensorProto.UINT8,
+}
+
+TORCH_DTYPE_MAP = {
+    "float32": torch.float32,
+    "float16": torch.float16,
+    "bfloat16": torch.bfloat16,
+    "int8": torch.int8,
+    "int4": torch.uint8,
+}
+
+NUMPY_DTYPE_MAP = {
+    "float32": numpy.float32,
+    "float16": numpy.float16,
+    "bfloat16": numpy.uint16,
+    "int8": numpy.int8,
+    "int4": numpy.uint8,
+}
 
 
 @dataclass
@@ -57,6 +90,97 @@ class GQAConfig:
     has_position_ids: bool = False
     has_attention_bias: bool = False
     has_head_sink: bool = False
+    # Quantization parameters
+    k_quant_type: str = "NONE"
+    v_quant_type: str = "NONE"
+    kv_cache_type: str = "float16"
+    kv_cache_bit_width: int = 0
+
+
+# #################################################################################################
+#  Quantization Helpers
+# #################################################################################################
+
+
+def get_q_range(q_type_str):
+    if q_type_str == "int8":
+        return -128, 127
+    if q_type_str == "int4":
+        return -8, 7
+    raise ValueError(f"Unsupported quantization type for range: {q_type_str}")
+
+
+def pack_int4(tensor_int8):
+    assert tensor_int8.shape[-1] % 2 == 0
+    t_low = tensor_int8[..., 0::2] + 8
+    t_high = tensor_int8[..., 1::2] + 8
+    packed = (t_low & 0x0F) | (t_high << 4)
+    return packed.to(torch.uint8)
+
+
+def unpack_int4(packed_tensor_uint8):
+    t_low = (packed_tensor_uint8 & 0x0F) - 8
+    t_high = (packed_tensor_uint8 >> 4) - 8
+    unpacked = torch.empty(
+        (*packed_tensor_uint8.shape[:-1], packed_tensor_uint8.shape[-1] * 2),
+        dtype=torch.int8,
+        device=packed_tensor_uint8.device,
+    )
+    unpacked[..., 0::2] = t_low
+    unpacked[..., 1::2] = t_high
+    return unpacked
+
+
+def compute_scale(tensor_float, quant_type, q_type_str):
+    if quant_type == "NONE":
+        return None
+
+    qmin, qmax = get_q_range(q_type_str)
+
+    if quant_type == "PER_TENSOR":
+        t_max = torch.max(torch.abs(tensor_float))
+        scale = t_max / qmax if t_max > 1e-6 else torch.tensor(1.0, device=tensor_float.device, dtype=torch.float32)
+        return scale.unsqueeze(0).to(torch.float32)
+
+    if quant_type == "PER_CHANNEL":
+        # Per-channel scale is computed independently for each channel across the batch and sequence length dimensions.
+        t_max = torch.max(torch.abs(tensor_float), dim=2, keepdim=True)[0]
+        t_max = torch.max(t_max, dim=0, keepdim=True)[0]
+        scale = t_max / qmax
+        scale[scale < 1e-6] = 1.0
+        return scale.to(torch.float32)
+
+    raise ValueError(f"Unsupported quant_type: {quant_type}")
+
+
+def dequantize_tensor(quantized_tensor, scale, quant_type, q_type_str):
+    if quant_type == "NONE":
+        return quantized_tensor
+
+    # Ensure scale is on the same device as quantized_tensor
+    if isinstance(scale, torch.Tensor):
+        scale = scale.to(quantized_tensor.device)
+
+    unpacked_tensor = quantized_tensor
+    if q_type_str == "int4":
+        unpacked_tensor = unpack_int4(quantized_tensor)
+
+    return unpacked_tensor.to(torch.float32) * scale
+
+
+def quantize_tensor_with_scale(tensor_float, scale, quant_type, q_type_str):
+    """Quantizes a tensor using a provided scale."""
+    if quant_type == "NONE":
+        return tensor_float
+
+    qmin, qmax = get_q_range(q_type_str)
+    quantized = torch.clamp(torch.round(tensor_float / scale), qmin, qmax)
+
+    if q_type_str == "int4":
+        quantized = pack_int4(quantized.to(torch.int8))
+    else:
+        quantized = quantized.to(TORCH_DTYPE_MAP[q_type_str])
+    return quantized
 
 
 # #################################################################################################
@@ -149,45 +273,91 @@ def apply_rotary_embedding(x, cos, sin, pos, interleaved, device="cpu"):
 # #################################################################################################
 
 
-def create_group_query_attention_graph_prompt(
+def create_gqa_node_and_io(
     config: GQAConfig,
     ort_type,
     share_buffer=True,
+    is_past=False,
+    output_qk: int = 0,  # CUDA does not support output_qk for GQA
 ):
-    assert not (config.has_head_sink and config.use_smooth_softmax)
-    past_kv_seqlen = config.buffer_sequence_length if share_buffer else 0
-    present_kv_seqlen = config.buffer_sequence_length if share_buffer else config.kv_sequence_length
+    if is_past:
+        if share_buffer:
+            past_kv_seqlen = config.buffer_sequence_length
+            present_kv_seqlen = config.buffer_sequence_length
+        else:
+            past_kv_seqlen = config.past_kv_sequence_length
+            present_kv_seqlen = config.past_kv_sequence_length + config.kv_sequence_length
+    else:  # Prompt
+        past_kv_seqlen = config.buffer_sequence_length if share_buffer else 0
+        present_kv_seqlen = config.buffer_sequence_length if share_buffer else config.kv_sequence_length
 
-    nodes = [
-        helper.make_node(
-            op_type="GroupQueryAttention",
-            inputs=[
-                "query",
-                "key" if not config.packed else "",
-                "value" if not config.packed else "",
-                "past_key" if share_buffer else "",
-                "past_value" if share_buffer else "",
-                "seqlens_k",
-                "total_sequence_length",
-                "cos_cache" if config.rotary else "",
-                "sin_cache" if config.rotary else "",
-                "position_ids" if config.has_position_ids else "",
-                "attention_bias" if config.has_attention_bias else "",
-                "head_sink" if config.has_head_sink else "",
-            ],
-            outputs=["output", "present_key", "present_value"],
-            name="GroupQueryAttention_0",
-            num_heads=config.num_heads,
-            kv_num_heads=config.kv_num_heads,
-            local_window_size=config.local_window_size,
-            do_rotary=config.rotary,
-            rotary_interleaved=config.rotary_interleaved,
-            softcap=config.softcap,
-            smooth_softmax=1 if config.use_smooth_softmax else 0,
-            domain="com.microsoft",
-        ),
+    # --- Node Definition ---
+    outputs = [
+        "output",
+        "present_key",
+        "present_value",
     ]
 
+    if output_qk > 0:
+        outputs.append("output_qk")
+
+    # Ensure kv_cache_bit_width is set correctly based on cache type if not provided
+    bit_width = config.kv_cache_bit_width
+    if bit_width == 0:
+        if config.kv_cache_type == "int4":
+            bit_width = 4
+        elif config.kv_cache_type == "int8":
+            bit_width = 8
+
+    inputs = [
+        "query",
+        "key" if not config.packed else "",
+        "value" if not config.packed else "",
+        "past_key" if is_past or share_buffer else "",
+        "past_value" if is_past or share_buffer else "",
+        "seqlens_k",
+        "total_sequence_length",
+        "cos_cache" if config.rotary else "",
+        "sin_cache" if config.rotary else "",
+        "position_ids" if config.has_position_ids else "",
+        "attention_bias" if config.has_attention_bias else "",
+        "head_sink" if config.has_head_sink else "",
+        "k_scale" if config.k_quant_type != "NONE" and (is_past or share_buffer) else "",
+        "v_scale" if config.v_quant_type != "NONE" and (is_past or share_buffer) else "",
+    ]
+
+    # Remove trailing empty strings
+    while inputs and inputs[-1] == "":
+        inputs.pop()
+
+    quantization_attributes = (
+        {
+            "k_quant_type": config.k_quant_type,
+            "v_quant_type": config.v_quant_type,
+            "kv_cache_bit_width": bit_width,
+        }
+        if config.k_quant_type != "NONE"
+        else {}
+    )
+
+    node = helper.make_node(
+        op_type="GroupQueryAttention",
+        inputs=inputs,
+        outputs=outputs,
+        name="GroupQueryAttention_0",
+        num_heads=config.num_heads,
+        kv_num_heads=config.kv_num_heads,
+        local_window_size=config.local_window_size,
+        do_rotary=config.rotary,
+        rotary_interleaved=config.rotary_interleaved,
+        softcap=config.softcap,
+        smooth_softmax=1 if config.use_smooth_softmax else 0,
+        qk_output=output_qk,
+        **quantization_attributes,
+        domain="com.microsoft",
+    )
+
+    # --- Graph Inputs ---
     q_hidden_size = (
         (config.num_heads * config.head_size)
         if not config.packed
@@ -198,6 +368,8 @@ def create_group_query_attention_graph_prompt(
         helper.make_tensor_value_info("seqlens_k", TensorProto.INT32, [config.batch_size]),
         helper.make_tensor_value_info("total_sequence_length", TensorProto.INT32, [1]),
     ]
+
+    cache_ort_type = ONNX_TENSOR_TYPE_MAP[config.kv_cache_type]
 
     if not config.packed:
         graph_input.extend(
@@ -214,25 +386,32 @@ def create_group_query_attention_graph_prompt(
                 ),
             ]
         )
-    if share_buffer:
-        # Shape is (batch_size, kv_num_heads, sequence_length, head_size)
+
+    if is_past or share_buffer:
         k_shape = [config.batch_size, config.kv_num_heads, past_kv_seqlen, config.head_size]
-        v_shape = k_shape
+        if config.kv_cache_type == "int4":
+            k_shape[-1] //= 2
         graph_input.extend(
             [
-                helper.make_tensor_value_info("past_key", ort_type, k_shape),
-                helper.make_tensor_value_info("past_value", ort_type, v_shape),
+                helper.make_tensor_value_info("past_key", cache_ort_type, k_shape),
+                helper.make_tensor_value_info("past_value", cache_ort_type, k_shape),
             ]
         )
+        if config.k_quant_type != "NONE":
+            graph_input.append(helper.make_tensor_value_info("k_scale", ort_type, None))
+        if config.v_quant_type != "NONE":
+            graph_input.append(helper.make_tensor_value_info("v_scale", ort_type, None))
+
     if config.rotary:
         rotary_dim = (math.floor(config.head_size / 16) * 16) // 2
-        cache_seq_len = config.buffer_sequence_length if share_buffer else config.kv_sequence_length
+        cache_seq_len = config.buffer_sequence_length
         graph_input.extend(
             [
                 helper.make_tensor_value_info("cos_cache", ort_type, [cache_seq_len, rotary_dim]),
                 helper.make_tensor_value_info("sin_cache", ort_type, [cache_seq_len, rotary_dim]),
             ]
         )
+
     if config.has_position_ids:
         graph_input.append(
             helper.make_tensor_value_info(
@@ -240,147 +419,50 @@ def create_group_query_attention_graph_prompt(
             )
         )
     if config.has_attention_bias:
+        bias_len = present_kv_seqlen if is_past else config.kv_sequence_length
         graph_input.append(
             helper.make_tensor_value_info(
-                "attention_bias", ort_type, [config.batch_size, 1, config.q_sequence_length, config.kv_sequence_length]
+                "attention_bias", ort_type, [config.batch_size, 1, config.q_sequence_length, bias_len]
             )
         )
     if config.has_head_sink:
         graph_input.append(helper.make_tensor_value_info("head_sink", ort_type, [config.num_heads]))
 
-    # Shape is (batch_size, kv_num_heads, sequence_length, head_size)
+    # --- Graph Outputs ---
     output_k_shape = [config.batch_size, config.kv_num_heads, present_kv_seqlen, config.head_size]
-    output_v_shape = output_k_shape
+    if config.kv_cache_type == "int4":
+        output_k_shape[-1] //= 2
 
     graph_output = [
         helper.make_tensor_value_info(
             "output", ort_type, [config.batch_size, config.q_sequence_length, config.num_heads * config.head_size]
         ),
-        helper.make_tensor_value_info("present_key", ort_type, output_k_shape),
-        helper.make_tensor_value_info("present_value", ort_type, output_v_shape),
+        helper.make_tensor_value_info("present_key", cache_ort_type, output_k_shape),
+        helper.make_tensor_value_info("present_value", cache_ort_type, output_k_shape),
     ]
 
-    graph = helper.make_graph(nodes, "GroupQueryAttention_Graph", graph_input, graph_output)
+    if output_qk > 0:
+        graph_output.append(
+            helper.make_tensor_value_info(
+                "output_qk",
+                ort_type,
+                [config.batch_size, config.num_heads, config.q_sequence_length, present_kv_seqlen],
+            )
+        )
+
+    return node, graph_input, graph_output
+
+
+def create_group_query_attention_graph_prompt(config: GQAConfig, ort_type, share_buffer=True):
+    node, graph_input, graph_output = create_gqa_node_and_io(config, ort_type, share_buffer, is_past=False)
+    graph = helper.make_graph([node], "GroupQueryAttention_Graph", graph_input, graph_output)
     model = helper.make_model(graph)
     return model.SerializeToString()
 
 
-def create_group_query_attention_graph_past(
-    config: GQAConfig,
-    ort_type,
-    share_buffer=True,
-):
-    assert not (config.has_head_sink and config.use_smooth_softmax)
-
-    if share_buffer:
-        past_kv_seqlen = config.buffer_sequence_length
-        present_kv_seqlen = config.buffer_sequence_length
-    else:
-        past_kv_seqlen = config.past_kv_sequence_length
-        present_kv_seqlen = config.past_kv_sequence_length + config.kv_sequence_length
-
-    nodes = [
-        helper.make_node(
-            "GroupQueryAttention",
-            [
-                "query",
-                "key" if not config.packed else "",
-                "value" if not config.packed else "",
-                "past_key",
-                "past_value",
-                "seqlens_k",
-                "total_sequence_length",
-                "cos_cache" if config.rotary else "",
-                "sin_cache" if config.rotary else "",
-                "position_ids" if config.has_position_ids else "",
-                "attention_bias" if config.has_attention_bias else "",
-                "head_sink" if config.has_head_sink else "",
-            ],
-            ["output", "present_key", "present_value"],
-            "GroupQueryAttention_0",
-            num_heads=config.num_heads,
-            kv_num_heads=config.kv_num_heads,
-            local_window_size=config.local_window_size,
-            do_rotary=config.rotary,
-            rotary_interleaved=config.rotary_interleaved,
-            softcap=config.softcap,
-            smooth_softmax=1 if config.use_smooth_softmax else 0,
-            domain="com.microsoft",
-        ),
-    ]
-
-    q_hidden_size = (
-        (config.num_heads * config.head_size)
-        if not config.packed
-        else (config.num_heads * config.head_size + 2 * config.kv_num_heads * config.head_size)
-    )
-    # Shape is (batch_size, kv_num_heads, sequence_length, head_size)
-    past_k_shape = [config.batch_size, config.kv_num_heads, past_kv_seqlen, config.head_size]
-    graph_input = [
-        helper.make_tensor_value_info("query", ort_type, [config.batch_size, config.q_sequence_length, q_hidden_size]),
-        helper.make_tensor_value_info("past_key", ort_type, past_k_shape),
-        helper.make_tensor_value_info("past_value", ort_type, past_k_shape),
-        helper.make_tensor_value_info("seqlens_k", TensorProto.INT32, [config.batch_size]),
-        helper.make_tensor_value_info("total_sequence_length", TensorProto.INT32, [1]),
-    ]
-
-    if not config.packed:
-        graph_input.extend(
-            [
-                helper.make_tensor_value_info(
-                    "key",
-                    ort_type,
-                    [config.batch_size, config.q_sequence_length, config.kv_num_heads * config.head_size],
-                ),
-                helper.make_tensor_value_info(
-                    "value",
-                    ort_type,
-                    [config.batch_size, config.q_sequence_length, config.kv_num_heads * config.head_size],
-                ),
-            ]
-        )
-
-    if config.rotary:
-        rotary_dim = (math.floor(config.head_size / 16) * 16) // 2
-        cache_len = config.buffer_sequence_length
-        graph_input.extend(
-            [
-                helper.make_tensor_value_info("cos_cache", ort_type, [cache_len, rotary_dim]),
-                helper.make_tensor_value_info("sin_cache", ort_type, [cache_len, rotary_dim]),
-            ]
-        )
-
-    if config.has_position_ids:
-        graph_input.append(
-            helper.make_tensor_value_info(
-                "position_ids", TensorProto.INT64, [config.batch_size, config.q_sequence_length]
-            )
-        )
-    if config.has_attention_bias:
-        graph_input.append(
-            helper.make_tensor_value_info(
-                "attention_bias", ort_type, [config.batch_size, 1, config.q_sequence_length, present_kv_seqlen]
-            )
-        )
-    if config.has_head_sink:
-        graph_input.append(helper.make_tensor_value_info("head_sink", ort_type, [config.num_heads]))
-
-    output_k_shape = [
-        config.batch_size,
-        config.kv_num_heads,
-        present_kv_seqlen,
-        config.head_size,
-    ]
-
-    graph_output = [
-        helper.make_tensor_value_info(
-            "output", ort_type, [config.batch_size, config.q_sequence_length, config.num_heads * config.head_size]
-        ),
-        helper.make_tensor_value_info("present_key", ort_type, output_k_shape),
-        helper.make_tensor_value_info("present_value", ort_type, output_k_shape),
-    ]
-
-    graph = helper.make_graph(nodes, "GroupQueryAttention_Graph", graph_input, graph_output)
+def create_group_query_attention_graph_past(config: GQAConfig, ort_type, share_buffer=True):
+    node, graph_input, graph_output = create_gqa_node_and_io(config, ort_type, share_buffer, is_past=True)
+    graph = helper.make_graph([node], "GroupQueryAttention_Graph", graph_input, graph_output)
     model = helper.make_model(graph)
     return model.SerializeToString()
 
@@ -403,6 +485,8 @@ def gqa_prompt_func(
     position_ids,
     attention_bias,
     head_sink,
+    k_scale,
+    v_scale,
     ep,
     device,
     share_buffer=True,
@@ -425,53 +509,59 @@ def gqa_prompt_func(
     io_binding = ort_session.io_binding()
 
     # Common inputs
+    seqlens_k_ort = OrtValue.ortvalue_from_numpy(seqlens_k.detach().cpu().numpy().astype(numpy.int32), device, 0)
+    io_binding.bind_ortvalue_input("seqlens_k", seqlens_k_ort)
     ort_inputs = {
         "query": q.detach().cpu().numpy(),
-        "seqlens_k": seqlens_k.detach().cpu().numpy().astype(numpy.int32),
         "total_sequence_length": torch.tensor([config.q_sequence_length], dtype=torch.int32).detach().cpu().numpy(),
     }
     io_binding.bind_cpu_input("query", ort_inputs["query"])
-    io_binding.bind_cpu_input("seqlens_k", ort_inputs["seqlens_k"])
     io_binding.bind_cpu_input("total_sequence_length", ort_inputs["total_sequence_length"])
 
     if new_k is not None:
-        ort_inputs["key"] = new_k.detach().cpu().numpy()
-        ort_inputs["value"] = new_v.detach().cpu().numpy()
-        io_binding.bind_cpu_input("key", ort_inputs["key"])
-        io_binding.bind_cpu_input("value", ort_inputs["value"])
+        io_binding.bind_cpu_input("key", new_k.detach().cpu().numpy())
+        io_binding.bind_cpu_input("value", new_v.detach().cpu().numpy())
     if cos is not None:
-        ort_inputs["cos_cache"] = cos.detach().cpu().numpy()
-        ort_inputs["sin_cache"] = sin.detach().cpu().numpy()
-        io_binding.bind_cpu_input("cos_cache", ort_inputs["cos_cache"])
-        io_binding.bind_cpu_input("sin_cache", ort_inputs["sin_cache"])
+        io_binding.bind_cpu_input("cos_cache", cos.detach().cpu().numpy())
+        io_binding.bind_cpu_input("sin_cache", sin.detach().cpu().numpy())
 
     # CPU-specific inputs
     if config.has_position_ids:
-        ort_inputs["position_ids"] = position_ids.detach().cpu().numpy()
-        io_binding.bind_cpu_input("position_ids", ort_inputs["position_ids"])
+        io_binding.bind_cpu_input("position_ids", position_ids.detach().cpu().numpy())
     if config.has_attention_bias:
-        ort_inputs["attention_bias"] = attention_bias.detach().cpu().numpy()
-        io_binding.bind_cpu_input("attention_bias", ort_inputs["attention_bias"])
+        io_binding.bind_cpu_input("attention_bias", attention_bias.detach().cpu().numpy())
     if config.has_head_sink:
-        ort_inputs["head_sink"] = head_sink.detach().cpu().numpy()
-        io_binding.bind_cpu_input("head_sink", ort_inputs["head_sink"])
+        io_binding.bind_cpu_input("head_sink", head_sink.detach().cpu().numpy())
+
+    # Quantization inputs
+    if k_scale is not None:
+        io_binding.bind_cpu_input("k_scale", k_scale.detach().cpu().numpy().astype(numpy_type))
+    if v_scale is not None:
+        io_binding.bind_cpu_input("v_scale", v_scale.detach().cpu().numpy().astype(numpy_type))
+
+    # Outputs
+    io_binding.bind_output("output")
 
     if share_buffer:
+        cache_numpy_type = NUMPY_DTYPE_MAP[config.kv_cache_type]
         past_k_ort = OrtValue.ortvalue_from_numpy(k.detach().cpu().numpy(), device, 0)
         past_v_ort = OrtValue.ortvalue_from_numpy(v.detach().cpu().numpy(), device, 0)
-        io_binding.bind_input("past_key", device, 0, numpy_type, past_k_ort.shape(), past_k_ort.data_ptr())
-        io_binding.bind_input("past_value", device, 0, numpy_type, past_v_ort.shape(), past_v_ort.data_ptr())
-        io_binding.bind_output("output")
+        io_binding.bind_input("past_key", device, 0, cache_numpy_type, past_k_ort.shape(), past_k_ort.data_ptr())
+        io_binding.bind_input("past_value", device, 0, cache_numpy_type, past_v_ort.shape(), past_v_ort.data_ptr())
         io_binding.bind_ortvalue_output("present_key", past_k_ort)
         io_binding.bind_ortvalue_output("present_value", past_v_ort)
+
     else:
-        io_binding.bind_output("output")
         io_binding.bind_output("present_key")
         io_binding.bind_output("present_value")
 
     ort_session.run_with_iobinding(io_binding)
     ort_output, present_k, present_v = io_binding.copy_outputs_to_cpu()
-    return torch.tensor(ort_output), present_k, present_v
+    return (
+        torch.tensor(ort_output),
+        present_k,
+        present_v,
+    )
 
 
 def gqa_past_func(
@@ -487,6 +577,8 @@ def gqa_past_func(
     position_ids,
     attention_bias,
     head_sink,
+    k_scale,
+    v_scale,
     ep,
     device,
     share_buffer=True,
@@ -509,61 +601,63 @@ def gqa_past_func(
     io_binding = ort_session.io_binding()
 
     # Common inputs
-    total_seq_len = (
-        config.past_kv_sequence_length if share_buffer else config.past_kv_sequence_length + config.q_sequence_length
-    )
+    total_seq_len = config.past_kv_sequence_length + config.q_sequence_length
+    seqlens_k_ort = OrtValue.ortvalue_from_numpy(seqlens_k.detach().cpu().numpy().astype(numpy.int32), device, 0)
+    io_binding.bind_ortvalue_input("seqlens_k", seqlens_k_ort)
     ort_inputs = {
         "query": q.detach().cpu().numpy(),
-        "seqlens_k": seqlens_k.detach().cpu().numpy().astype(numpy.int32),
         "total_sequence_length": torch.tensor([total_seq_len], dtype=torch.int32).detach().cpu().numpy(),
     }
     io_binding.bind_cpu_input("query", ort_inputs["query"])
-    io_binding.bind_cpu_input("seqlens_k", ort_inputs["seqlens_k"])
     io_binding.bind_cpu_input("total_sequence_length", ort_inputs["total_sequence_length"])
 
     if new_k is not None:
-        ort_inputs["key"] = new_k.detach().cpu().numpy()
-        ort_inputs["value"] = new_v.detach().cpu().numpy()
-        io_binding.bind_cpu_input("key", ort_inputs["key"])
-        io_binding.bind_cpu_input("value", ort_inputs["value"])
+        io_binding.bind_cpu_input("key", new_k.detach().cpu().numpy())
+        io_binding.bind_cpu_input("value", new_v.detach().cpu().numpy())
     if cos is not None:
-        ort_inputs["cos_cache"] = cos.detach().cpu().numpy()
-        ort_inputs["sin_cache"] = sin.detach().cpu().numpy()
-        io_binding.bind_cpu_input("cos_cache", ort_inputs["cos_cache"])
-        io_binding.bind_cpu_input("sin_cache", ort_inputs["sin_cache"])
+        io_binding.bind_cpu_input("cos_cache", cos.detach().cpu().numpy())
+        io_binding.bind_cpu_input("sin_cache", sin.detach().cpu().numpy())
 
     # CPU-specific inputs
     if config.has_position_ids:
-        ort_inputs["position_ids"] = position_ids.detach().cpu().numpy()
-        io_binding.bind_cpu_input("position_ids", ort_inputs["position_ids"])
+        io_binding.bind_cpu_input("position_ids", position_ids.detach().cpu().numpy())
     if config.has_attention_bias:
-        ort_inputs["attention_bias"] = attention_bias.detach().cpu().numpy()
-        io_binding.bind_cpu_input("attention_bias", ort_inputs["attention_bias"])
+        io_binding.bind_cpu_input("attention_bias", attention_bias.detach().cpu().numpy())
     if config.has_head_sink:
-        ort_inputs["head_sink"] = head_sink.detach().cpu().numpy()
-        io_binding.bind_cpu_input("head_sink", ort_inputs["head_sink"])
+        io_binding.bind_cpu_input("head_sink", head_sink.detach().cpu().numpy())
 
-    # Binding past and present KV
+    # Quantization inputs
+    if k_scale is not None:
+        io_binding.bind_cpu_input("k_scale", k_scale.detach().cpu().numpy().astype(numpy_type))
+    if v_scale is not None:
+        io_binding.bind_cpu_input("v_scale", v_scale.detach().cpu().numpy().astype(numpy_type))
+
+    # Outputs
+    io_binding.bind_output("output")
+
+    cache_numpy_type = NUMPY_DTYPE_MAP[config.kv_cache_type]
+
     if share_buffer:
         past_k_ort = OrtValue.ortvalue_from_numpy(k.detach().cpu().numpy(), device, 0)
         past_v_ort = OrtValue.ortvalue_from_numpy(v.detach().cpu().numpy(), device, 0)
-        io_binding.bind_input("past_key", device, 0, numpy_type, past_k_ort.shape(), past_k_ort.data_ptr())
-        io_binding.bind_input("past_value", device, 0, numpy_type, past_v_ort.shape(), past_v_ort.data_ptr())
-        io_binding.bind_output("output")
+        io_binding.bind_input("past_key", device, 0, cache_numpy_type, past_k_ort.shape(), past_k_ort.data_ptr())
+        io_binding.bind_input("past_value", device, 0, cache_numpy_type, past_v_ort.shape(), past_v_ort.data_ptr())
         io_binding.bind_ortvalue_output("present_key", past_k_ort)
         io_binding.bind_ortvalue_output("present_value", past_v_ort)
+
     else:
-        ort_inputs["past_key"] = k.detach().cpu().numpy()
-        ort_inputs["past_value"] = v.detach().cpu().numpy()
-        io_binding.bind_cpu_input("past_key", ort_inputs["past_key"])
-        io_binding.bind_cpu_input("past_value", ort_inputs["past_value"])
-        io_binding.bind_output("output")
+        io_binding.bind_cpu_input("past_key", k.detach().cpu().numpy())
+        io_binding.bind_cpu_input("past_value", v.detach().cpu().numpy())
         io_binding.bind_output("present_key")
         io_binding.bind_output("present_value")
 
     ort_session.run_with_iobinding(io_binding)
     ort_output, present_k, present_v = io_binding.copy_outputs_to_cpu()
-    return torch.tensor(ort_output), present_k, present_v
+    return (
+        torch.tensor(ort_output),
+        present_k,
+        present_v,
+    )
 
 
 # #################################################################################################
@@ -587,7 +681,7 @@ def construct_local_mask(seqlen_q, seqlen_k, window_size, query_padding_mask, ke
 
 
 def smooth_softmax_ref(x, head_sink):
-    b, n, s, t = x.shape
+    b, n, s, _ = x.shape
     if head_sink is not None:
         sink = head_sink.reshape(1, n, 1, 1).expand(b, -1, s, -1)
     else:
@@ -668,6 +762,26 @@ def attention_ref(
 # #################################################################################################
 # Parity Check (Core Test Logic)
 # #################################################################################################
+def get_static_scale(config: GQAConfig, device, torch_type, std):
+    """Generates calibration data and computes the static quantization scale."""
+    calibration_batch_size = 1
+    calibration_sequence_length = 1024
+    calibration_data_k = (
+        torch.randn(
+            calibration_batch_size,
+            config.kv_num_heads,
+            calibration_sequence_length,
+            config.head_size,
+            device=device,
+            dtype=torch_type,
+        )
+        * std
+    )
+    calibration_data_v = torch.randn_like(calibration_data_k) * std
+
+    k_scale = compute_scale(calibration_data_k, config.k_quant_type, config.kv_cache_type)
+    v_scale = compute_scale(calibration_data_v, config.v_quant_type, config.kv_cache_type)
+    return k_scale, v_scale
 
 
 def parity_check_gqa_prompt(
@@ -681,11 +795,8 @@ def parity_check_gqa_prompt(
     rtol,
     atol,
 ):
-    # Q/K/V have normal distribution with mean = 0 and standard deviation = 0.02.
-    # If we use standard deviation = 1, numerical stability issues may occur.
+    torch.manual_seed(0)
     std = 0.02
-
-    # --- Test Data Generation ---
     q = (
         torch.randn(
             config.batch_size,
@@ -698,9 +809,9 @@ def parity_check_gqa_prompt(
         * std
     )
 
-    # k and v are the cache buffers, created in BNSH format
+    # Initialize the KV cache to zeros since no past context in prompt testing.
     k = (
-        torch.randn(
+        torch.zeros(
             config.batch_size,
             config.kv_num_heads,
             config.buffer_sequence_length,
@@ -710,7 +821,7 @@ def parity_check_gqa_prompt(
         )
         * std
     )
-    v = torch.randn_like(k)
+    v = torch.zeros_like(k)
 
     new_k = (
         torch.randn(
@@ -725,8 +836,13 @@ def parity_check_gqa_prompt(
     )
     new_v = torch.randn_like(new_k) * std
 
-    head_sink = torch.rand(config.num_heads, dtype=torch_type, device=device) if config.has_head_sink else None
+    k_scale, v_scale = get_static_scale(config, device, torch_type, std)
+    if k_scale is not None:
+        k_scale = k_scale.to(torch_type)
+    if v_scale is not None:
+        v_scale = v_scale.to(torch_type)
 
+    head_sink = torch.rand(config.num_heads, dtype=torch_type, device=device) if config.has_head_sink else None
     window_size = (-1, -1)
     if config.local_window_size > 0:
         window_size = (config.local_window_size, 0)
@@ -734,10 +850,20 @@ def parity_check_gqa_prompt(
         window_size = (-1, 0)
 
     # --- PyTorch Reference Path ---
-    # Transpose BNSH cache to BSNH format for reference implementation
-    k_cache_ref = k.clone().transpose(1, 2)
-    v_cache_ref = v.clone().transpose(1, 2)
-
+    k_ref_dequant = dequantize_tensor(
+        quantize_tensor_with_scale(k, k_scale, config.k_quant_type, config.kv_cache_type),
+        k_scale,
+        config.k_quant_type,
+        config.kv_cache_type,
+    )
+    v_ref_dequant = dequantize_tensor(
+        quantize_tensor_with_scale(v, v_scale, config.v_quant_type, config.kv_cache_type),
+        v_scale,
+        config.v_quant_type,
+        config.kv_cache_type,
+    )
+    k_cache_ref = k_ref_dequant.clone().transpose(1, 2)
+    v_cache_ref = v_ref_dequant.clone().transpose(1, 2)
     cache_seqlens = torch.full((config.batch_size,), config.kv_sequence_length, device=device, dtype=torch.int32)
     rotary_seqlens = torch.zeros(config.batch_size, device=device, dtype=torch.long)
 
@@ -750,8 +876,7 @@ def parity_check_gqa_prompt(
         q_ro = apply_rotary_embedding(q.clone(), cos, sin, rotary_seqlens, config.rotary_interleaved, device)
         k_ro = apply_rotary_embedding(new_k.clone(), cos, sin, rotary_seqlens, config.rotary_interleaved, device)
 
-    position_ids = None
-    attention_bias = None
+    position_ids, attention_bias = None, None
     if ep == "CPUExecutionProvider":
         if config.has_position_ids:
             position_ids = (
@@ -771,15 +896,19 @@ def parity_check_gqa_prompt(
     kv_seqlens_expanded = rearrange(cache_seqlens, "b -> b 1")
     update_mask = arange < kv_seqlens_expanded
 
-    k_cache_ref[update_mask] = rearrange(k_ro, "b s ... -> (b s) ...").to(dtype=torch_type)
-    v_cache_ref[update_mask] = rearrange(new_v, "b s ... -> (b s) ...").to(dtype=torch_type)
+    # Explicitly cast the source tensor to the destination's dtype before assignment.
+    source_k = rearrange(k_ro, "b s ... -> (b s) ...")
+    k_cache_ref[update_mask] = source_k.to(k_cache_ref.dtype)
+
+    source_v = rearrange(new_v, "b s ... -> (b s) ...")
+    v_cache_ref[update_mask] = source_v.to(v_cache_ref.dtype)
+
     key_padding_mask = arange < kv_seqlens_expanded
 
     out_ref, _ = attention_ref(
         q=q_ro,
         k=k_cache_ref,
         v=v_cache_ref,
-        query_padding_mask=None,
         key_padding_mask=key_padding_mask,
         attention_bias=attention_bias,
         causal=True,
@@ -790,22 +919,20 @@ def parity_check_gqa_prompt(
     )
     out_ref_np = out_ref.detach().cpu().numpy()
 
-    # Transpose reference cache back to BNSH for comparison
-    k_cache_ref_np = k_cache_ref.transpose(1, 2).detach().cpu().numpy()
-    v_cache_ref_np = v_cache_ref.transpose(1, 2).detach().cpu().numpy()
-
     # --- ONNX Runtime Path ---
-    q_ort, k_ort, v_ort, new_k_ort, new_v_ort = q, k, v, new_k, new_v
+    q_ort, new_k_ort, new_v_ort = q, new_k, new_v
     if config.packed:
         q_ort = torch.cat([q, new_k, new_v], dim=2)
         new_k_ort, new_v_ort = None, None
 
-    # seqlens_k for GQA op is past_seq_len + seq_len - 1
+    k_quant = quantize_tensor_with_scale(k, k_scale, config.k_quant_type, config.kv_cache_type)
+    v_quant = quantize_tensor_with_scale(v, v_scale, config.v_quant_type, config.kv_cache_type)
+
     ort_seqlens = cache_seqlens - 1
     out, present_k, present_v = gqa_prompt_func(
         q=q_ort,
-        k=k_ort,
-        v=v_ort,
+        k=k_quant,
+        v=v_quant,
         config=config,
         new_k=new_k_ort,
         new_v=new_v_ort,
@@ -815,6 +942,8 @@ def parity_check_gqa_prompt(
         position_ids=position_ids,
         attention_bias=attention_bias,
         head_sink=head_sink,
+        k_scale=k_scale,
+        v_scale=v_scale,
         ep=ep,
         device=device,
         share_buffer=True,
@@ -825,9 +954,64 @@ def parity_check_gqa_prompt(
     out_np = out.detach().cpu().numpy()
 
     # --- Comparison ---
-    numpy.testing.assert_allclose(present_k, k_cache_ref_np, rtol=rtol, atol=atol)
-    numpy.testing.assert_allclose(present_v, v_cache_ref_np, rtol=rtol, atol=atol)
     numpy.testing.assert_allclose(out_np, out_ref_np, rtol=rtol, atol=atol)
+
+    # Compare quantized cache with proper masking per batch
+    if config.k_quant_type != "NONE":
+        # Convert numpy array to torch tensor with correct dtype
+        if config.kv_cache_type == "int4":
+            # For int4, present_k is uint8 packed data
+            present_k_torch = torch.from_numpy(present_k).to(device)
+        elif config.kv_cache_type == "int8":
+            # For int8, present_k is int8 data
+            present_k_torch = torch.from_numpy(present_k.astype(numpy.int8)).to(device)
+        else:
+            present_k_torch = torch.from_numpy(present_k).to(device)
+
+        present_k_dequant = (
+            dequantize_tensor(present_k_torch, k_scale, config.k_quant_type, config.kv_cache_type).cpu().numpy()
+        )
+
+        # Mask the reference cache to only valid regions
+        k_cache_ref_masked = k_cache_ref.transpose(1, 2).clone()
+        arange = torch.arange(config.buffer_sequence_length, device=device).unsqueeze(0).unsqueeze(0).unsqueeze(-1)
+        cache_seqlens_expanded = cache_seqlens.unsqueeze(1).unsqueeze(1).unsqueeze(-1)
+        mask = arange >= cache_seqlens_expanded
+        k_cache_ref_masked[mask.expand_as(k_cache_ref_masked)] = 0
+        k_cache_ref_dequant = k_cache_ref_masked.cpu().numpy()
+
+        for b in range(config.batch_size):
+            valid_len = cache_seqlens[b].item()
+            numpy.testing.assert_allclose(
+                present_k_dequant[b, :, :valid_len, :], k_cache_ref_dequant[b, :, :valid_len, :], rtol=rtol, atol=atol
+            )
+
+    if config.v_quant_type != "NONE":
+        # Convert numpy array to torch tensor with correct dtype
+        if config.kv_cache_type == "int4":
+            present_v_torch = torch.from_numpy(present_v).to(device)
+        elif config.kv_cache_type == "int8":
+            present_v_torch = torch.from_numpy(present_v.astype(numpy.int8)).to(device)
+        else:
+            present_v_torch = torch.from_numpy(present_v).to(device)
+
+        present_v_dequant = (
+            dequantize_tensor(present_v_torch, v_scale, config.v_quant_type, config.kv_cache_type).cpu().numpy()
+        )
+
+        # Mask the reference cache to only valid regions
+        v_cache_ref_masked = v_cache_ref.transpose(1, 2).clone()
+        arange = torch.arange(config.buffer_sequence_length, device=device).unsqueeze(0).unsqueeze(0).unsqueeze(-1)
+        cache_seqlens_expanded = cache_seqlens.unsqueeze(1).unsqueeze(1).unsqueeze(-1)
+        mask = arange >= cache_seqlens_expanded
+        v_cache_ref_masked[mask.expand_as(v_cache_ref_masked)] = 0
+        v_cache_ref_dequant = v_cache_ref_masked.cpu().numpy()
+
+        for b in range(config.batch_size):
+            valid_len = cache_seqlens[b].item()
+            numpy.testing.assert_allclose(
+                present_v_dequant[b, :, :valid_len, :], v_cache_ref_dequant[b, :, :valid_len, :], rtol=rtol, atol=atol
+            )
 
 
 def parity_check_gqa_past(
@@ -841,46 +1025,38 @@ def parity_check_gqa_past(
     rtol,
     atol,
 ):
+    torch.manual_seed(0)
+    std = 0.02
     # --- Test Data Generation ---
-    q = torch.randn(
-        config.batch_size,
-        config.q_sequence_length,
-        config.num_heads,
-        config.head_size,
-        device=device,
-        dtype=torch_type,
+    q = (
+        torch.randn(
+            config.batch_size,
+            config.q_sequence_length,
+            config.num_heads,
+            config.head_size,
+            device=device,
+            dtype=torch_type,
+        )
+        * std
     )
-    # k and v are the cache buffers, created in BNSH format
-    k = torch.randn(
-        config.batch_size,
-        config.kv_num_heads,
-        config.buffer_sequence_length,
-        config.head_size,
-        device=device,
-        dtype=torch_type,
+    k = (
+        torch.randn(
+            config.batch_size,
+            config.kv_num_heads,
+            config.buffer_sequence_length,
+            config.head_size,
+            device=device,
+            dtype=torch_type,
+        )
+        * std
     )
-    v = torch.randn_like(k)
-    new_k = torch.randn(
-        config.batch_size,
-        config.q_sequence_length,
-        config.kv_num_heads,
-        config.head_size,
-        device=device,
-        dtype=torch_type,
-    )
-    new_v = torch.randn_like(new_k)
+    v = torch.randn_like(k) * std
 
-    head_sink = torch.rand(config.num_heads, dtype=torch_type, device=device) if config.has_head_sink else None
-    window_size = (-1, -1)
-    if config.local_window_size > 0:
-        window_size = (config.local_window_size, 0)
-    elif causal:
-        window_size = (-1, 0)
-
-    # --- PyTorch Reference Path ---
-    # Transpose BNSH cache to BSNH format for reference implementation
-    k_cache_ref = k.clone().transpose(1, 2)
-    v_cache_ref = v.clone().transpose(1, 2)
+    k_scale, v_scale = get_static_scale(config, device, torch_type, std)
+    if k_scale is not None:
+        k_scale = k_scale.to(torch_type)
+    if v_scale is not None:
+        v_scale = v_scale.to(torch_type)
 
     cache_seqlens = torch.randint(
         0,
@@ -889,6 +1065,46 @@ def parity_check_gqa_past(
         device=device,
         dtype=torch.long,
     )
+
+    for i in range(config.batch_size):
+        past_len = cache_seqlens[i].item()
+        k[i, :, past_len:, :] = 0
+        v[i, :, past_len:, :] = 0
+
+    new_k = (
+        torch.randn(
+            config.batch_size,
+            config.q_sequence_length,
+            config.kv_num_heads,
+            config.head_size,
+            device=device,
+            dtype=torch_type,
+        )
+        * std
+    )
+    new_v = torch.randn_like(new_k) * std
+    head_sink = torch.rand(config.num_heads, dtype=torch_type, device=device) if config.has_head_sink else None
+    window_size = (-1, -1)
+    if config.local_window_size > 0:
+        window_size = (config.local_window_size, 0)
+    elif causal:
+        window_size = (-1, 0)
+
+    # --- PyTorch Reference Path ---
+    k_ref_dequant = dequantize_tensor(
+        quantize_tensor_with_scale(k, k_scale, config.k_quant_type, config.kv_cache_type),
+        k_scale,
+        config.k_quant_type,
+        config.kv_cache_type,
+    )
+    v_ref_dequant = dequantize_tensor(
+        quantize_tensor_with_scale(v, v_scale, config.v_quant_type, config.kv_cache_type),
+        v_scale,
+        config.v_quant_type,
+        config.kv_cache_type,
+    )
+    k_cache_ref = k_ref_dequant.clone().transpose(1, 2)
+    v_cache_ref = v_ref_dequant.clone().transpose(1, 2)
 
     cos, sin, q_ro, k_ro = None, None, q, new_k
     if config.rotary:
@@ -899,9 +1115,8 @@ def parity_check_gqa_past(
         q_ro = apply_rotary_embedding(q.clone(), cos, sin, cache_seqlens, config.rotary_interleaved, device)
         k_ro = apply_rotary_embedding(new_k.clone(), cos, sin, cache_seqlens, config.rotary_interleaved, device)
 
-    position_ids = None
-    attention_bias = None
-    total_seq_len = config.past_kv_sequence_length
+    position_ids, attention_bias = None, None
+    total_seq_len = config.past_kv_sequence_length + config.q_sequence_length
     if ep == "CPUExecutionProvider":
         if config.has_position_ids:
             position_ids = (cache_seqlens.unsqueeze(1) + torch.arange(config.q_sequence_length, device=device)).long()
@@ -918,15 +1133,14 @@ def parity_check_gqa_past(
     update_mask = torch.logical_and(
         cache_seqlens_expanded <= arange, arange < cache_seqlens_expanded + config.q_sequence_length
     )
-    k_cache_ref[update_mask] = rearrange(k_ro, "b s ... -> (b s) ...").to(dtype=torch_type)
-    v_cache_ref[update_mask] = rearrange(new_v, "b s ... -> (b s) ...").to(dtype=torch_type)
+    k_cache_ref[update_mask] = rearrange(k_ro, "b s ... -> (b s) ...").to(k_cache_ref.dtype)
+    v_cache_ref[update_mask] = rearrange(new_v, "b s ... -> (b s) ...").to(v_cache_ref.dtype)
     key_padding_mask = arange < cache_seqlens_expanded + config.q_sequence_length
 
     out_ref, _ = attention_ref(
         q=q_ro,
         k=k_cache_ref,
         v=v_cache_ref,
-        query_padding_mask=None,
         key_padding_mask=key_padding_mask,
         attention_bias=attention_bias,
         causal=True,
@@ -937,21 +1151,20 @@ def parity_check_gqa_past(
     )
     out_ref_np = out_ref.detach().cpu().numpy()
 
-    # Transpose reference cache back to BNSH for comparison
-    k_cache_ref_np = k_cache_ref.transpose(1, 2).detach().cpu().numpy()
-    v_cache_ref_np = v_cache_ref.transpose(1, 2).detach().cpu().numpy()
-
     # --- ONNX Runtime Path ---
-    q_ort, k_ort, v_ort, new_k_ort, new_v_ort = q, k, v, new_k, new_v
+    q_ort, new_k_ort, new_v_ort = q, new_k, new_v
     if config.packed:
         q_ort = torch.cat([q, new_k, new_v], dim=2)
         new_k_ort, new_v_ort = None, None
 
+    k_quant = quantize_tensor_with_scale(k, k_scale, config.k_quant_type, config.kv_cache_type)
+    v_quant = quantize_tensor_with_scale(v, v_scale, config.v_quant_type, config.kv_cache_type)
+
     ort_seqlens = cache_seqlens + config.q_sequence_length - 1
     out, present_k, present_v = gqa_past_func(
         q=q_ort,
-        k=k_ort,
-        v=v_ort,
+        k=k_quant,
+        v=v_quant,
         config=config,
         new_k=new_k_ort,
         new_v=new_v_ort,
@@ -961,6 +1174,8 @@ def parity_check_gqa_past(
         position_ids=position_ids,
         attention_bias=attention_bias,
         head_sink=head_sink,
+        k_scale=k_scale,
+        v_scale=v_scale,
         ep=ep,
         device=device,
         share_buffer=True,
@@ -970,9 +1185,69 @@ def parity_check_gqa_past(
     out = torch.reshape(out, (config.batch_size, config.q_sequence_length, config.num_heads, config.head_size))
     out_np = out.detach().cpu().numpy()
 
-    numpy.testing.assert_allclose(present_k, k_cache_ref_np, rtol=rtol, atol=atol)
-    numpy.testing.assert_allclose(present_v, v_cache_ref_np, rtol=rtol, atol=atol)
+    # --- Comparison ---
     numpy.testing.assert_allclose(out_np, out_ref_np, rtol=rtol, atol=atol)
+
+    # Compare quantized cache with proper masking per batch
+    if config.k_quant_type != "NONE":
+        if config.kv_cache_type == "int4":
+            present_k_torch = torch.from_numpy(present_k).to(device)
+        elif config.kv_cache_type == "int8":
+            present_k_torch = torch.from_numpy(present_k.astype(numpy.int8)).to(device)
+        else:
+            present_k_torch = torch.from_numpy(present_k).to(device)
+
+        present_k_dequant = (
+            dequantize_tensor(present_k_torch, k_scale, config.k_quant_type, config.kv_cache_type).cpu().numpy()
+        )
+
+        # Mask the reference cache to only valid regions
+        k_cache_ref_masked = k_cache_ref.transpose(1, 2).clone()
+        total_seqlens = cache_seqlens + config.q_sequence_length
+        arange = torch.arange(config.buffer_sequence_length, device=device).unsqueeze(0).unsqueeze(0).unsqueeze(-1)
+        total_seqlens_expanded = total_seqlens.unsqueeze(1).unsqueeze(1).unsqueeze(-1)
+        mask = arange >= total_seqlens_expanded
+        k_cache_ref_masked[mask.expand_as(k_cache_ref_masked)] = 0
+        k_cache_ref_dequant = k_cache_ref_masked.cpu().numpy()
+
+        for b in range(config.batch_size):
+            valid_len = (cache_seqlens[b] + config.q_sequence_length).item()
+            numpy.testing.assert_allclose(
+                present_k_dequant[b, :, :valid_len, :],
+                k_cache_ref_dequant[b, :, :valid_len, :],
+                rtol=rtol,
+                atol=atol,
+            )
+
+    if config.v_quant_type != "NONE":
+        if config.kv_cache_type == "int4":
+            present_v_torch = torch.from_numpy(present_v).to(device)
+        elif config.kv_cache_type == "int8":
+            present_v_torch = torch.from_numpy(present_v.astype(numpy.int8)).to(device)
+        else:
+            present_v_torch = torch.from_numpy(present_v).to(device)
+
+        present_v_dequant = (
+            dequantize_tensor(present_v_torch, v_scale, config.v_quant_type, config.kv_cache_type).cpu().numpy()
+        )
+
+        # Mask the reference cache to only valid regions
+        v_cache_ref_masked = v_cache_ref.transpose(1, 2).clone()
+        total_seqlens = cache_seqlens + config.q_sequence_length
+        arange = torch.arange(config.buffer_sequence_length, device=device).unsqueeze(0).unsqueeze(0).unsqueeze(-1)
+        total_seqlens_expanded = total_seqlens.unsqueeze(1).unsqueeze(1).unsqueeze(-1)
+        mask = arange >= total_seqlens_expanded
+        v_cache_ref_masked[mask.expand_as(v_cache_ref_masked)] = 0
+        v_cache_ref_dequant = v_cache_ref_masked.cpu().numpy()
+
+        for b in range(config.batch_size):
+            valid_len = (cache_seqlens[b] + config.q_sequence_length).item()
+            numpy.testing.assert_allclose(
+                present_v_dequant[b, :, :valid_len, :],
+                v_cache_ref_dequant[b, :, :valid_len, :],
+                rtol=rtol,
+                atol=atol,
+            )
 
 
 # #################################################################################################
@@ -981,7 +1256,8 @@ def parity_check_gqa_past(
 
 
 def get_cuda_rotary_options():
-    return [(False, False)] if pipeline_mode else [(True, False), (True, True), (False, False)]
+    options = [(False, False), (True, False), (True, True)]
+    return options[:param_count]
 
 
 def get_cpu_rotary_options():
@@ -989,21 +1265,21 @@ def get_cpu_rotary_options():
 
 
 def get_softmax_options(allow_head_sink: bool = True):
-    head_sink_option = (False, True) if allow_head_sink else (False, False)
-    return [(False, False), head_sink_option] if pipeline_mode else [(False, False), (False, True), (True, False)]
+    options = [(False, False), (False, True), (True, False)]
+    return options[:2] if pipeline_mode else options[:param_count]
 
 
 def gqa_cuda_prompt_test_cases(allow_head_sink: bool = True):
-    batches = [3] if pipeline_mode else [1, 3, 5]
-    seqs = [(35, 35)] if pipeline_mode else [(35, 35), (127, 127), (240, 240), (2000, 2000)]
-    num_h = [(6, 3)] if pipeline_mode else [(6, 3), (9, 9), (32, 8)]
-    h_sizes = [32] if pipeline_mode else [32, 64, 128, 256]
+    batches = [3, 1, 5]
+    seqs = [(35, 35), (127, 127), (240, 240), (2000, 2000)]
+    heads = [(6, 3), (9, 9), (32, 8)]
+    h_sizes = [128, 32, 64, 256]
     smmoth_softmax__head_sink = get_softmax_options(allow_head_sink)
 
-    for b in batches:
-        for sq, skv in seqs:
-            for n, n2 in num_h:
-                for h in h_sizes:
+    for b in batches[:param_count]:
+        for sq, skv in seqs[:param_count]:
+            for n, n2 in heads[:param_count]:
+                for h in h_sizes[:param_count]:
                     for lws in [-1, random.randint(1, skv)]:
                         for rotary, rotary_interleaved in get_cuda_rotary_options():
                             for packed in [False, True]:
@@ -1035,17 +1311,18 @@ def gqa_cuda_prompt_test_cases(allow_head_sink: bool = True):
 
 
 def gqa_cuda_past_test_cases(allow_head_sink: bool = True):
-    batches = [5] if pipeline_mode else [1, 3, 5]
+    batches = [2, 1, 3]
     # s: new sequence length, s2: past sequence length
-    seqs = [(1, 1024)] if pipeline_mode else [(1, 128), (1, 1024), (1, 2048), (1, 5000)]
-    num_h = [(32, 8)] if pipeline_mode else [(6, 3), (9, 9), (32, 8)]
-    h_sizes = [256] if pipeline_mode else [64, 128, 256]
+    seqs = [(1, 128), (1, 1024), (1, 2048), (1, 5000)]
+    heads = [(32, 8), (6, 3), (9, 9)]
+    # We test 128 in pipeline since quantized kv cache is only enabled for head_size=128 in flash attention.
+    h_sizes = [128, 64, 256]
     smmoth_softmax__head_sink = get_softmax_options(allow_head_sink)
 
-    for b in batches:
-        for s, s2 in seqs:
-            for n, n2 in num_h:
-                for h in h_sizes:
+    for b in batches[:param_count]:
+        for s, s2 in seqs[:param_count]:
+            for n, n2 in heads[:param_count]:
+                for h in h_sizes[:param_count]:
                     for lws in [-1, random.randint(1, s2)]:
                         for rotary, rotary_interleaved in get_cuda_rotary_options():
                             for packed in [False, True]:
@@ -1074,6 +1351,27 @@ def gqa_cuda_past_test_cases(allow_head_sink: bool = True):
                                         yield name, config
 
 
+def gqa_cuda_quantized_test_cases(is_past):
+    base_cases = gqa_cuda_past_test_cases() if is_past else gqa_cuda_prompt_test_cases()
+    for name, config in base_cases:
+        if config.packed:  # Quantization is not supported with packed QKV yet
+            continue
+        for kv_type in ["int8", "int4"]:
+            for quant_mode in ["PER_TENSOR", "PER_CHANNEL"]:
+                q_config = deepcopy(config)
+                q_config.k_quant_type = quant_mode
+                q_config.v_quant_type = quant_mode
+                q_config.kv_cache_type = kv_type
+                if kv_type == "int4":
+                    if q_config.head_size % 2 != 0:
+                        continue
+                    q_config.kv_cache_bit_width = 4
+                elif kv_type == "int8":
+                    q_config.kv_cache_bit_width = 8
+                q_name = f"{name}_quant_{kv_type}_{quant_mode}"
+                yield q_name, q_config
+
+
 # #################################################################################################
 #  Unit Test Classes
 # #################################################################################################
@@ -1095,6 +1393,10 @@ def has_memory_efficient():
         return False
     major, _ = torch.cuda.get_device_capability()
     return major >= 5
+
+
+def has_quantized_kv_cache():
+    return version.parse(onnxruntime.__version__) >= version.parse("1.24.0")
 
 
 @unittest.skipIf(not has_flash_attention(), "Flash Attention is not available, skipping tests.")
@@ -1143,8 +1445,8 @@ class TestMemoryEfficientGQA(unittest.TestCase):
             numpy_type=numpy.float16,
             ort_type=TensorProto.FLOAT16,
             causal=True,
-            rtol=5e-3,
-            atol=5e-3,
+            rtol=2e-2,
+            atol=2e-2,
         )
 
     @parameterized.expand(gqa_cuda_past_test_cases(allow_head_sink=False))
@@ -1159,7 +1461,41 @@ class TestMemoryEfficientGQA(unittest.TestCase):
             ort_type=TensorProto.FLOAT16,
             causal=True,
             rtol=5e-3,
-            atol=5e-3,
+            atol=2e-2,
+        )
+
+
+@unittest.skipIf(not has_flash_attention(), "Flash Attention is not available, skipping tests.")
+@unittest.skipIf(not has_quantized_kv_cache(), "Quantized KV Cache is not available, skipping tests.")
+class TestQuantizedGQA(unittest.TestCase):
+    @parameterized.expand(gqa_cuda_quantized_test_cases(is_past=False))
+    def test_gqa_quantized_prompt(self, name, config):
+        os.environ["ORT_DISABLE_FLASH_ATTENTION"] = "0"
+        parity_check_gqa_prompt(
+            config=config,
+            ep="CUDAExecutionProvider",
+            device="cuda",
+            torch_type=torch.float16,
+            numpy_type=numpy.float16,
+            ort_type=TensorProto.FLOAT16,
+            causal=True,
+            rtol=5e-2,
+            atol=0.15,
+        )
+
+    @parameterized.expand(gqa_cuda_quantized_test_cases(is_past=True))
+    def test_gqa_quantized_past(self, name, config):
+        os.environ["ORT_DISABLE_FLASH_ATTENTION"] = "0"
+        parity_check_gqa_past(
+            config=config,
+            ep="CUDAExecutionProvider",
+            device="cuda",
+            torch_type=torch.float16,
+            numpy_type=numpy.float16,
+            ort_type=TensorProto.FLOAT16,
+            causal=True,
+            rtol=5e-2,
+            atol=0.15,
         )
 
 


### PR DESCRIPTION
This updates GroupQueryAttention operator to suppport KV cache quantization. The KV cache can store in data types of float8, int8 or uint8  (for 4 bits).

### Background

A center piece of LLM inference is the Key-Value (KV) cache, a critical optimization that accelerates text generation by removing computational redundancy. However, this introduces a new, formidable bottleneck related to memory. 

#### Related Research
(1) Early work on quantized KV cache uses **per-tensor** post-training quantization.

(2) KIVI: Asymmetric Per-Channel/Per-Token Quantization. The core observation behind KIVI is that the distribution of outliers in the Key and Value caches is fundamentally different. So it uses asymmetric quantization strategy:
 * Key Cache: Quantized on a per-channel basis. This allows each channel to have its own unique scale and zero-point, effectively isolating the high-magnitude outlier channels and preventing them from skewing the quantization range for the other, smaller-valued channels.
 * Value Cache: Quantized on a per-token basis, which was found to be more effective for its data distribution.
 * <1% accuracy drop on average at 2-bit.
 
(3) NQKV: Normal Distribution Quantile Quantization. The observation when grouped into blocks along the token dimension, elements of kv cache closely approximate a normal distribution. It divides each token into smaller blocks and quantizes each block in 4-bits independently.

(4) KVQuant: It uses Pre-RoPE Per-Channel Key Quantization. It also uses per-vector Dense-and-Sparse Quantization.

#### Related Implementation
* Huggingface Transformers follow the idea of KIVI. To improve performance, it retains a fixed size (like 128) residual cache to store keys and values in their original precision. When the residual cache reaches its maximum capacity the stored keys and values are quantized and the cache content is discarded. See https://huggingface.co/blog/kv-cache-quantization for detail.
* TensorRT-LLM supports INT8 and FP8 KV cache implementations. It shows up to a 1.45x throughput improvement over FP16 baseline.

Based on the related work, quantized kv cache is better to support per-tensor (like TensorRT-LLM) and KIVI style (per-channel quantization for key, and per token dynamic quantization for value).

In this pull request, we will focus on per-tensor and per-channel static quantization.

The following are not supportted, but can be extended in the future if needed:
 * per token dynamic quantization: This is complicated since it need integration with genai.
 * 2-bit quantization: Current design can be easily extended to 2-bit. It is not implemented in this PR.
 * zero-points:  Assume that symmetric quantization is enough, zero-point support is lower priority.
 * block-quantization: seems not very popular since per-channel can have better accuracy.
 * per-head quantization: seems not very popular since per-channel can have better accuracy.
 * fp4: lower priority than 2-bit support.
 * Two other float8 data types: right now only supports float8 data types having better match with CUDA.

Note: int2 data type is not supported by onnx (see https://github.com/onnx/onnx/pull/7163) right now.

### Acknowledgment

This work started from a draft proposal from Nachiket Khasbag (Nvidia) and Gaurav Garg (Nvidia) about supporting Quantized GQA.