### PR TITLE
Fix(build): Correct maybe-uninitialized and range-loop-construct warnings

### DIFF
--- a/onnxruntime/core/optimizer/nchwc_transformer.cc
+++ b/onnxruntime/core/optimizer/nchwc_transformer.cc
@@ -609,6 +609,10 @@ void NchwcTransformerImpl::TransformBinary(Node& node, bool add_node) {
     nchwc_inputs.push_back(nchwc_input);
   }
 
+  if (nchwc_inputs.empty()) {
+    return;
+  }
+
   auto* nchwc_input_0 = nchwc_inputs[0];
   const int64_t channels = nchwc_inputs[0]->channels_;
 

--- a/onnxruntime/core/optimizer/transformer_memcpy.cc
+++ b/onnxruntime/core/optimizer/transformer_memcpy.cc
@@ -16,7 +16,7 @@ namespace onnxruntime {
 static ProviderTypeToProviderMap GetProvidersByType(
     const InlinedVector<gsl::not_null<const IExecutionProvider*>>& providers) {
   ProviderTypeToProviderMap providers_by_type{};
-  for (const auto provider : providers) {
+  for (const auto& provider : providers) {
     providers_by_type.emplace(provider->Type(), provider);
   }
   return providers_by_type;
@@ -100,7 +100,7 @@ static const onnx::TensorProto* GetInitializer(const Graph& graph, const std::st
 // and mainly provides the subgraph recursion functionality
 Status MemcpyTransformer::ApplyImpl(Graph& graph, bool& modified, int graph_level,
                                     const logging::Logger& logger) const {
-  for (const auto provider : providers_) {
+  for (const auto& provider : providers_) {
     const auto& provider_type = provider->Type();
     if (!utils::ProviderIsCpuBased(*provider)) {
       TransformerMemcpyImpl copy_impl(graph, *provider, providers_by_type_);


### PR DESCRIPTION
This pull request addresses two build warnings that were treated as errors:

1.  **`maybe-uninitialized` warning in `nchwc_transformer.cc`**:
    A `maybe-uninitialized` warning was triggered when accessing `nchwc_inputs[0]` without checking if `nchwc_inputs` was empty. This could lead to a crash if a binary node had no inputs. The fix adds a check to ensure the vector is not empty before accessing the first element.

2.  **`range-loop-construct` warnings in `transformer_memcpy.cc`**:
    The compiler warned about creating copies of objects in range-based for loops. This was resolved by using references (`const auto&`) instead of copies (`const auto`) for the loop variables, which is more efficient.

This fix was provided by an AI bot.