### PR TITLE
Linux device discovery for TRT-RTX Ep

### DIFF
--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_provider_factory.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_provider_factory.cc
@@ -584,6 +584,7 @@ struct NvTensorRtRtxEpFactory : OrtEpFactory {
    * @return True if the device is a supported NVIDIA GPU, false otherwise.
    */
   bool IsOrtHardwareDeviceSupported(const OrtHardwareDevice& device) {
+#if _WIN32
     const auto& metadata_entries = device.metadata.Entries();
     const auto it = metadata_entries.find("LUID");
     if (it == metadata_entries.end()) {
@@ -625,6 +626,25 @@ struct NvTensorRtRtxEpFactory : OrtEpFactory {
     }
 
     return false;
+#else
+    const auto& metadata_entries = device.metadata.Entries();
+    const auto it = metadata_entries.find("pci_bus_id");
+    if (it == metadata_entries.end()) {
+      return false;
+    }
+    auto& target_id = it->second;
+    int cuda_device_idx = 0;
+    if (cudaDeviceGetByPCIBusId(&cuda_device_idx, target_id.c_str()) != cudaSuccess) {
+      return false;
+    }
+
+    cudaDeviceProp prop;
+    if (cudaGetDeviceProperties(&prop, cuda_device_idx) != cudaSuccess) {
+      return false;
+    }
+    // Ampere architecture or newer is required.
+    return prop.major >= 8;
+#endif
   }
 
   // Creates and returns OrtEpDevice instances for all OrtHardwareDevices that this factory supports.

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/version_script.lds
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/version_script.lds
@@ -2,6 +2,8 @@
 VERS_1.0 {
   global:
     GetProvider;    
+    CreateEpFactories;
+    ReleaseEpFactory;
 
   # Hide everything else.
   local:

--- a/onnxruntime/test/providers/nv_tensorrt_rtx/nv_basic_test.cc
+++ b/onnxruntime/test/providers/nv_tensorrt_rtx/nv_basic_test.cc
@@ -278,7 +278,6 @@ INSTANTIATE_TEST_SUITE_P(NvExecutionProviderTest, TypeTests,
                                            ),
                          [](const testing::TestParamInfo<TypeTests::ParamType>& info) { return getTypeAsName(info.param); });
 
-#ifdef _WIN32
 static bool SessionHasEp(Ort::Session& session, const char* ep_name) {
   // Access the underlying InferenceSession.
   const OrtSession* ort_session = session;
@@ -295,7 +294,6 @@ static bool SessionHasEp(Ort::Session& session, const char* ep_name) {
 }
 
 // Tests autoEP feature to automatically select an EP that supports the GPU.
-// Currently only works on Windows.
 TEST(NvExecutionProviderTest, AutoEp_PreferGpu) {
   PathString model_name = ORT_TSTR("nv_execution_provider_auto_ep.onnx");
   std::string graph_name = "test";
@@ -305,7 +303,11 @@ TEST(NvExecutionProviderTest, AutoEp_PreferGpu) {
   CreateBaseModel(model_name, graph_name, dims);
 
   {
+#if _WIN32
     ort_env->RegisterExecutionProviderLibrary(kNvTensorRTRTXExecutionProvider, ORT_TSTR("onnxruntime_providers_nv_tensorrt_rtx.dll"));
+#else
+    ort_env->RegisterExecutionProviderLibrary(kNvTensorRTRTXExecutionProvider, ORT_TSTR("libonnxruntime_providers_nv_tensorrt_rtx.so"));
+#endif
 
     Ort::SessionOptions so;
     so.SetEpSelectionPolicy(OrtExecutionProviderDevicePolicy_PREFER_GPU);
@@ -601,8 +603,6 @@ TEST(NvExecutionProviderTest, FP4CustomOpModel) {
 
   LOGS_DEFAULT(INFO) << "[NvExecutionProviderTest] TRT FP4 dynamic quantize model run completed successfully";
 }
-
-#endif
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/nv_tensorrt_rtx/nv_ep_context_test.cc
+++ b/onnxruntime/test/providers/nv_tensorrt_rtx/nv_ep_context_test.cc
@@ -14,7 +14,6 @@ namespace test {
 
 RegisteredEpDeviceUniquePtr AppendTrtEtxEP(Ort::SessionOptions& session_options, std::unordered_map<std::string, std::string>& option_map) {
   RegisteredEpDeviceUniquePtr nv_tensorrt_rtx_ep;
-#ifdef _WIN32
   /// Since this test runs after other tests that use registration interface this test has to use it as well
   /// windows as otherwise the kernel registry inside the EP will not be populated. The legacy APis ony call the initialize once.
   Utils::RegisterAndGetNvTensorRtRtxEp(*ort_env, nv_tensorrt_rtx_ep);
@@ -26,9 +25,6 @@ RegisteredEpDeviceUniquePtr AppendTrtEtxEP(Ort::SessionOptions& session_options,
     }
   }
   session_options.AppendExecutionProvider_V2(*ort_env, {selected_device}, option_map);
-#else
-  session_options.AppendExecutionProvider(onnxruntime::kNvTensorRTRTXExecutionProvider, option_map);
-#endif
   return nv_tensorrt_rtx_ep;
 }
 

--- a/onnxruntime/test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.cc
+++ b/onnxruntime/test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.cc
@@ -24,7 +24,6 @@
 
 namespace onnxruntime {
 namespace test {
-#ifdef _WIN32
 
 Utils::NvTensorRtRtxEpInfo Utils::nv_tensorrt_rtx_ep_info;
 
@@ -61,7 +60,6 @@ void Utils::RegisterAndGetNvTensorRtRtxEp(Ort::Env& env, RegisteredEpDeviceUniqu
     c_api.UnregisterExecutionProviderLibrary(env, nv_tensorrt_rtx_ep_info.registration_name.c_str());
   });
 }
-#endif  // _WIN32
 
 void CreateBaseModel(const PathString& model_name,
                      std::string graph_name,


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

This change adds vendor id and PCIe bus_id to the properties detected during Linux device discovery. 

Those properties are used to enable device discovery on Linux for the TRT-RTX execution provider.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
I want to use device discovery for TRT-EP also on Linux.


This changes have already been tested with the newly added inference samples https://github.com/microsoft/onnxruntime-inference-examples/pull/529 . Some further testing is required to see whether this repo's CI passes (therefore setting draft for now)

@gedoensmax for visibilty

