### PR TITLE
[QNN-EP] Apply Softmax layout transformation for GPU

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/softmax_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/softmax_op_builder.cc
@@ -61,7 +61,7 @@ Status SoftmaxOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
                                        const logging::Logger& logger,
                                        std::vector<std::string>& input_names,
                                        bool do_op_validation) const {
-  const bool is_npu_backend = IsNpuBackend(qnn_model_wrapper.GetQnnBackendType());
+  const bool is_qpu_backend = IsQpuBackend(qnn_model_wrapper.GetQnnBackendType());
   const auto& inputs = node_unit.Inputs();
   const std::string& input_name = inputs[0].node_arg.Name();
   assert(inputs.size() == 1);
@@ -108,9 +108,9 @@ Status SoftmaxOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
                                                          is_graph_input,
                                                          false));
     input_names.push_back(reshape_output_name);
-  } else if (is_npu_backend && axis != static_cast<int32_t>(input_rank) - 1) {
+  } else if (is_qpu_backend && axis != static_cast<int32_t>(input_rank) - 1) {
     /*
-    For Onnx Softmax with opset >= 13, the QNN HTP backend only supports the axis attribute that refers to the last
+    For Onnx Softmax with opset >= 13, the QNN HTP and GPU backends only supports the axis attribute that refers to the last
     input dimension.
     QNN EP is able to support arbitrary axis attribute by wrapping transposes around the operator.
     */


### PR DESCRIPTION
### Description
- Transposes are inserted for Softmax with axis != output_rank-1 for the HTP backend.
- The GPU backend also has this requirement on the axis param, so this change enables the layout transformation for the GPU as well.

### Motivation and Context
- Enables more models with GPU backend.
