### PR TITLE
Move macOS build jobs to a dedicated pool

### DIFF
--- a/tools/ci_build/build_args.py
+++ b/tools/ci_build/build_args.py
@@ -186,6 +186,7 @@ def add_cmake_build_config_args(parser: argparse.ArgumentParser) -> None:
         "--use_vcpkg_ms_internal_asset_cache", action="store_true", help="[MS Internal] Use internal vcpkg asset cache."
     )
     parser.add_argument("--skip_submodule_sync", action="store_true", help="Skip 'git submodule update'.")
+    parser.add_argument("--skip_pip_install", action="store_true", help="Skip 'pip install'.")
 
 
 def add_testing_args(parser: argparse.ArgumentParser) -> None:

--- a/tools/ci_build/github/azure-pipelines/mac-ios-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-ios-packaging-pipeline.yml
@@ -55,9 +55,10 @@ extends:
   parameters:
     # Update the pool with your team's 1ES hosted pool.
     pool:
-      name: "Azure Pipelines"
-      image: "macOS-14"
-      os: macOS
+     name: AcesShared
+     os: macOS
+     demands:
+     - ImageOverride -equals ACES_VM_SharedPool_Sequoia
     sdl:
       sourceAnalysisPool:
         name: onnxruntime-Win-CPU-VS2022-Latest

--- a/tools/ci_build/github/azure-pipelines/mac-ios-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-ios-packaging-pipeline.yml
@@ -55,10 +55,9 @@ extends:
   parameters:
     # Update the pool with your team's 1ES hosted pool.
     pool:
-     name: AcesShared
-     os: macOS
-     demands:
-     - ImageOverride -equals ACES_VM_SharedPool_Sequoia
+      name: "Azure Pipelines"
+      image: "macOS-14"
+      os: macOS
     sdl:
       sourceAnalysisPool:
         name: onnxruntime-Win-CPU-VS2022-Latest

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -138,7 +138,6 @@ stages:
 
     - script: |
         python3 tools/ci_build/github/apple/test_apple_packages.py \
-          --fail_if_cocoapods_missing \
           --framework_info_file "$(Build.BinariesDirectory)/ios_framework/xcframework_info.json" \
           --c_framework_dir "$(Build.BinariesDirectory)/ios_framework/framework_out" \
           --skip_macos_test \

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -116,12 +116,6 @@ stages:
     steps:
     - template: set-version-number-variables-step.yml
 
-    - task: JavaToolInstaller@0
-      inputs:
-        versionSpec: "17"
-        jdkArchitectureOption: "x64"
-        jdkSourceOption: 'PreInstalled'
-
     - template: use-xcode-version.yml
       parameters:
         xcodeVersion: 16.4

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -210,13 +210,6 @@ stages:
       - input: pipelineArtifact
         artifactName: drop-onnxruntime-java-linux-aarch64
         targetPath: '$(Build.BinariesDirectory)\java-artifact\onnxruntime-java-linux-aarch64'
-
-      - input: pipelineArtifact
-        artifactName: drop-onnxruntime-java-osx-x86_64
-        targetPath: '$(Build.BinariesDirectory)\java-artifact\onnxruntime-java-osx-x86_64'
-      - input: pipelineArtifact
-        artifactName: drop-onnxruntime-java-osx-arm64
-        targetPath: '$(Build.BinariesDirectory)\java-artifact\onnxruntime-java-osx-arm64'
       outputs:
       - output: pipelineArtifact
         targetPath: $(Build.BinariesDirectory)\java-artifact\onnxruntime-java-win-x64

--- a/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packaging-pipeline.yml
@@ -26,13 +26,6 @@ stages:
   jobs:
   - template: mac-cpu-packing-jobs.yml
     parameters:
-      MacosArch: 'x86_64'
-      AllowReleasedOpsetOnly: ${{ parameters.AllowReleasedOpsetOnly }}
-      AdditionalBuildFlags: ${{ parameters.AdditionalBuildFlags }}
-
-  - template: mac-cpu-packing-jobs.yml
-    parameters:
-      MacosArch: 'arm64'
       AllowReleasedOpsetOnly: ${{ parameters.AllowReleasedOpsetOnly }}
       AdditionalBuildFlags: ${{ parameters.AdditionalBuildFlags }}
 
@@ -48,9 +41,6 @@ stages:
     templateContext:
       inputs:
       - input: pipelineArtifact
-        artifactName: onnxruntime-osx-x86_64 # The files in this artifact are not signed
-        targetPath: $(Build.ArtifactStagingDirectory)
-      - input: pipelineArtifact
         artifactName: onnxruntime-osx-arm64 # The files in this artifact are not signed
         targetPath: $(Build.ArtifactStagingDirectory)
       outputs:
@@ -65,12 +55,16 @@ stages:
         versionSpec: '3.13'
         addToPath: true
 
-    - task: PythonScript@0
-      displayName: 'Prepare, Create Universal Binary, and Zip with Python'
-      inputs:
-        scriptSource: 'filePath'
-        scriptPath: 'tools/ci_build/prepare_macos_package.py'
-        arguments: '--staging_dir $(Build.ArtifactStagingDirectory)'
+    - script: |
+        set -ex
+        cd $(Build.ArtifactStagingDirectory)
+        # Find and extract the arm64 tarball
+        find . -name 'onnxruntime-osx-arm64*.tgz' -exec tar -xzf {} \;
+        # Remove _manifest directories if they exist
+        find . -type d -name '_manifest' -exec rm -rf {} + || true
+        # Find the extracted directory and zip it
+        find . -maxdepth 1 -type d -name 'onnxruntime-osx-arm64*' -exec zip -FSr --symlinks {}.zip {} \;
+      displayName: 'Prepare ARM64 Package for Signing'
 
     - template: mac-esrp-dylib.yml
       parameters:

--- a/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packaging-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packaging-steps.yml
@@ -54,14 +54,6 @@ steps:
     targetPath: '$(Build.ArtifactStagingDirectory)'
     artifactName: 'onnxruntime-osx-${{ parameters.MacosArch }}'
 
-- template: java-api-artifacts-package-and-publish-steps-posix.yml
-  parameters:
-    arch: 'osx-${{ parameters.MacosArch }}'
-    buildConfig: 'Release'
-    artifactName: 'onnxruntime-java-osx-${{ parameters.MacosArch }}'
-    libraryName: 'libonnxruntime.dylib'
-    nativeLibraryName: 'libonnxruntime4j_jni.dylib'
-
 - template: nodejs-artifacts-package-and-publish-steps-posix.yml
   parameters:
       ${{ if eq(parameters.MacosArch, 'x86_64') }}:

--- a/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packaging-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packaging-steps.yml
@@ -1,9 +1,7 @@
 parameters:
 - name: MacosArch
   type: string
-  values:
-  - 'x86_64'
-  - 'arm64'
+  default: 'arm64'
 
 - name: AdditionalBuildFlags
   displayName: Additional build flags for build.py
@@ -21,11 +19,6 @@ steps:
       make install DESTDIR=$(Build.BinariesDirectory)/installed
   displayName: 'Build ${{ parameters.MacosArch }}'
 
-- ${{ if eq(parameters.MacosArch, 'x86_64') }}:
-  - script: |
-      python3 $(Build.SourcesDirectory)/tools/ci_build/build.py --test  ${{ parameters.AdditionalBuildFlags }} --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --parallel --use_binskim_compliant_compile_flags --build_shared_lib --config Release --use_vcpkg --use_vcpkg_ms_internal_asset_cache
-    displayName: 'Running Tests'
-
 - task: ShellScript@2
   displayName: 'Copy build artifacts for zipping'
   inputs:
@@ -42,13 +35,6 @@ steps:
     archiveFile: '$(Build.ArtifactStagingDirectory)/onnxruntime-osx-${{ parameters.MacosArch }}-$(OnnxRuntimeVersion).tgz'
     replaceExistingArchive: true
 
-- script: |
-    set -e -x
-    mkdir -p $(Build.ArtifactStagingDirectory)/testdata
-    cp $(Build.BinariesDirectory)/Release/libcustom_op_library.dylib $(Build.ArtifactStagingDirectory)/testdata
-  displayName: 'Copy libcustom_op_library.dylib to ArtifactStagingDirectory'
-  condition: and(succeeded(), eq('${{ parameters.MacosArch }}', 'x86_64'))
-
 - task: 1ES.PublishPipelineArtifact@1
   inputs:
     targetPath: '$(Build.ArtifactStagingDirectory)'
@@ -56,9 +42,6 @@ steps:
 
 - template: nodejs-artifacts-package-and-publish-steps-posix.yml
   parameters:
-      ${{ if eq(parameters.MacosArch, 'x86_64') }}:
-          arch: x64
-      ${{ if eq(parameters.MacosArch, 'arm64') }}:
-          arch: arm64
+      arch: arm64
       os: 'darwin'
       artifactName: 'drop-onnxruntime-nodejs-osx-${{ parameters.MacosArch }}'

--- a/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packing-jobs.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packing-jobs.yml
@@ -37,22 +37,6 @@ jobs:
     clean: true
     submodules: none
 
-
-  - script: |
-      uname -m
-
-  - task: JavaToolInstaller@1
-    inputs:
-      versionSpec: '17'
-      jdkArchitectureOption: 'arm64'
-      jdkSourceOption: AzureStorage
-      azureResourceManagerEndpoint: AIInfraBuildOnnxRuntimeOSS
-      azureStorageAccountName: lotus
-      azureContainerName: java
-      azureCommonVirtualFile: 'OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.16_8.tar.gz'
-      jdkDestinationDirectory: '$(agent.toolsDirectory)/jdk17'
-      cleanDestinationDirectory: false
-
   - template: use-xcode-version.yml
     parameters:
       xcodeVersion: 16.4
@@ -73,10 +57,10 @@ jobs:
     - template: mac-cpu-packaging-steps.yml
       parameters:
         MacosArch: ${{ parameters.MacosArch }}
-        AdditionalBuildFlags: ${{ parameters.AdditionalBuildFlags }} --build_nodejs --build_java --use_coreml --use_webgpu --cmake_extra_defines CMAKE_OSX_ARCHITECTURES=arm64
+        AdditionalBuildFlags: ${{ parameters.AdditionalBuildFlags }} --build_nodejs --use_coreml --use_webgpu --cmake_extra_defines CMAKE_OSX_ARCHITECTURES=arm64
 
   - ${{ if eq(parameters.MacosArch, 'x86_64') }}:
     - template: mac-cpu-packaging-steps.yml
       parameters:
         MacosArch: ${{ parameters.MacosArch }}
-        AdditionalBuildFlags: ${{ parameters.AdditionalBuildFlags }} --build_nodejs --build_java --use_coreml --use_webgpu --cmake_extra_defines CMAKE_OSX_ARCHITECTURES=x86_64
+        AdditionalBuildFlags: ${{ parameters.AdditionalBuildFlags }} --build_nodejs --use_coreml --use_webgpu --cmake_extra_defines CMAKE_OSX_ARCHITECTURES=x86_64

--- a/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packing-jobs.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packing-jobs.yml
@@ -41,11 +41,17 @@ jobs:
   - script: |
       uname -m
 
-  - task: JavaToolInstaller@0
+  - task: JavaToolInstaller@1
     inputs:
-      versionSpec: "17"
-      jdkArchitectureOption: "x64"
-      jdkSourceOption: 'PreInstalled'
+      versionSpec: '17'
+      jdkArchitectureOption: 'arm64'
+      jdkSourceOption: AzureStorage
+      azureResourceManagerEndpoint: AIInfraBuildOnnxRuntimeOSS
+      azureStorageAccountName: lotusscus
+      azureContainerName: models
+      azureCommonVirtualFile: 'OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.16_8.tar.gz'
+      jdkDestinationDirectory: '$(agent.toolsDirectory)/jdk17'
+      cleanDestinationDirectory: false
 
   - template: use-xcode-version.yml
     parameters:

--- a/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packing-jobs.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packing-jobs.yml
@@ -37,6 +37,10 @@ jobs:
     clean: true
     submodules: none
 
+
+  - script: |
+      uname -m
+
   - task: JavaToolInstaller@0
     inputs:
       versionSpec: "17"

--- a/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packing-jobs.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packing-jobs.yml
@@ -27,9 +27,10 @@ jobs:
     MACOSX_DEPLOYMENT_TARGET: '14.0'
     ALLOW_RELEASED_ONNX_OPSET_ONLY: ${{ parameters.AllowReleasedOpsetOnly }}
   pool:
-    name: "Azure Pipelines"
-    image: 'macOS-15'
-    os: macOS
+   name: AcesShared
+   os: macOS
+   demands:
+   - ImageOverride -equals ACES_VM_SharedPool_Sequoia
   timeoutInMinutes: 300
   steps:
   - checkout: self

--- a/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packing-jobs.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packing-jobs.yml
@@ -1,10 +1,4 @@
 parameters:
-- name: MacosArch
-  type: string
-  values:
-  - 'x86_64'
-  - 'arm64'
-
 - name: AdditionalBuildFlags
   displayName: Additional build flags for build.py
   type: string
@@ -20,7 +14,7 @@ parameters:
   - 0
 
 jobs:
-- job: MacOS_C_API_Packaging_CPU_${{ parameters.MacosArch }}
+- job: MacOS_C_API_Packaging_CPU_arm64
   workspace:
     clean: all
   variables:
@@ -43,7 +37,7 @@ jobs:
 
   - template: setup-build-tools.yml
     parameters:
-      host_cpu_arch: ${{ parameters.MacosArch }}
+      host_cpu_arch: arm64
 
   - template: set-version-number-variables-step.yml
 
@@ -53,14 +47,7 @@ jobs:
       export CMAKE_ARGS="-DONNX_GEN_PB_TYPE_STUBS=ON -DONNX_WERROR=OFF"
       python3 -m pip install -r '$(Build.SourcesDirectory)/tools/ci_build/github/linux/docker/scripts/requirements.txt'    
 
-  - ${{ if eq(parameters.MacosArch, 'arm64') }}:
-    - template: mac-cpu-packaging-steps.yml
-      parameters:
-        MacosArch: ${{ parameters.MacosArch }}
-        AdditionalBuildFlags: ${{ parameters.AdditionalBuildFlags }} --build_nodejs --use_coreml --use_webgpu --cmake_extra_defines CMAKE_OSX_ARCHITECTURES=arm64
-
-  - ${{ if eq(parameters.MacosArch, 'x86_64') }}:
-    - template: mac-cpu-packaging-steps.yml
-      parameters:
-        MacosArch: ${{ parameters.MacosArch }}
-        AdditionalBuildFlags: ${{ parameters.AdditionalBuildFlags }} --build_nodejs --use_coreml --use_webgpu --cmake_extra_defines CMAKE_OSX_ARCHITECTURES=x86_64
+  - template: mac-cpu-packaging-steps.yml
+    parameters:
+      MacosArch: arm64
+      AdditionalBuildFlags: ${{ parameters.AdditionalBuildFlags }} --build_nodejs --use_coreml --use_webgpu --cmake_extra_defines CMAKE_OSX_ARCHITECTURES=arm64

--- a/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packing-jobs.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packing-jobs.yml
@@ -47,8 +47,8 @@ jobs:
       jdkArchitectureOption: 'arm64'
       jdkSourceOption: AzureStorage
       azureResourceManagerEndpoint: AIInfraBuildOnnxRuntimeOSS
-      azureStorageAccountName: lotusscus
-      azureContainerName: models
+      azureStorageAccountName: lotus
+      azureContainerName: java
       azureCommonVirtualFile: 'OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.16_8.tar.gz'
       jdkDestinationDirectory: '$(agent.toolsDirectory)/jdk17'
       cleanDestinationDirectory: false

--- a/tools/ci_build/github/azure-pipelines/templates/py-macos.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-macos.yml
@@ -45,7 +45,7 @@ jobs:
 
   - template: use-xcode-version.yml
     parameters:
-      xcodeVersion: '16.4.0'
+      xcodeVersion: '16.4'
 
 
   - template: setup-build-tools.yml

--- a/tools/ci_build/github/azure-pipelines/templates/py-macos.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-macos.yml
@@ -24,9 +24,10 @@ jobs:
   workspace:
     clean: all
   pool:
-    name: "Azure Pipelines"
-    image: "macOS-15"
+    name: AcesShared
     os: macOS
+    demands:
+    - ImageOverride -equals ACES_VM_SharedPool_Sequoia
   templateContext:
     outputs:
     - output: pipelineArtifact

--- a/tools/ci_build/github/azure-pipelines/templates/setup-build-tools.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/setup-build-tools.yml
@@ -16,13 +16,12 @@ parameters:
 steps:
 - template: telemetry-steps.yml
 
-# Currently all ADO macOS machines are x64 machines
 - task: UsePythonVersion@0
   displayName: 'Use Python ${{ parameters.host_cpu_arch }} (macOS)'
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
   inputs:
     versionSpec: ${{ parameters.python_version }}    
-    architecture: 'x64'
+    architecture: ${{ parameters.host_cpu_arch }}
     
 - task: UsePythonVersion@0
   displayName: 'Use Python ${{ parameters.host_cpu_arch }} (non-macOS)'

--- a/tools/ci_build/github/azure-pipelines/templates/stages/mac-ios-packaging-build-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/stages/mac-ios-packaging-build-stage.yml
@@ -17,8 +17,8 @@ stages:
       # Note: Keep the Xcode version and iOS simulator version compatible.
       # Check the table here to see what iOS simulator versions are supported by a particular Xcode version:
       # https://developer.apple.com/support/xcode/
-      xcodeVersion: "15.3.0"
-      iosSimulatorRuntimeVersion: "17.4"
+      xcodeVersion: "16.4"
+      iosSimulatorRuntimeVersion: "18.5"
       buildSettingsFile: "tools/ci_build/github/apple/default_full_apple_framework_build_settings.json"
       cPodName: onnxruntime-c
       objcPodName: onnxruntime-objc

--- a/tools/ci_build/github/windows/jar_packaging.py
+++ b/tools/ci_build/github/windows/jar_packaging.py
@@ -33,7 +33,12 @@ def find_7z_executable():
     if seven_zip_exe:
         return seven_zip_exe
 
-    # 2. Check the default installation directory under Program Files
+    # 2. Check if '7za' is in the PATH (common on Linux systems)
+    seven_zip_exe = shutil.which("7za")
+    if seven_zip_exe:
+        return seven_zip_exe
+
+    # 3. Check the default installation directory under Program Files
     program_files = os.environ.get("ProgramFiles")  # noqa: SIM112
     if program_files:
         default_path = Path(program_files) / "7-Zip" / "7z.exe"
@@ -226,9 +231,7 @@ def run_packaging(package_type: str, build_dir: str):
         "cpu": {
             "platforms": [
                 {"path": "onnxruntime-java-linux-x64", "lib": "libcustom_op_library.so", "archive_lib": True},
-                {"path": "onnxruntime-java-osx-x86_64", "lib": "libcustom_op_library.dylib", "archive_lib": True},
                 {"path": "onnxruntime-java-linux-aarch64", "lib": "libcustom_op_library.so", "archive_lib": False},
-                {"path": "onnxruntime-java-osx-arm64", "lib": "libcustom_op_library.dylib", "archive_lib": False},
             ]
         },
         "gpu": {

--- a/tools/ci_build/github/windows/jar_packaging_test.py
+++ b/tools/ci_build/github/windows/jar_packaging_test.py
@@ -31,7 +31,6 @@ def directory_setup_factory(tmp_path):
         java_artifact_dir = tmp_path / "java-artifact"
         win_dir = java_artifact_dir / "onnxruntime-java-win-x64"
         linux_dir = java_artifact_dir / "onnxruntime-java-linux-x64"
-        osx_dir = java_artifact_dir / "onnxruntime-java-osx-x86_64"
 
         # --- Main artifact directory (Windows) ---
         win_dir.mkdir(parents=True, exist_ok=True)
@@ -53,25 +52,13 @@ def directory_setup_factory(tmp_path):
             create_empty_file(linux_native_dir / "libonnxruntime_providers_cuda.so")
         (linux_dir / "_manifest" / "spdx_2.2").mkdir(parents=True, exist_ok=True)
 
-        # --- macOS and other platforms (for CPU test) ---
+        # --- Additional platforms (for CPU test) ---
         if package_type == "cpu":
-            osx_native_dir = osx_dir / "ai" / "onnxruntime" / "native" / "osx-x86_64"
-            osx_native_dir.mkdir(parents=True, exist_ok=True)
-            create_empty_file(osx_dir / "libcustom_op_library.dylib")
-            create_empty_file(osx_native_dir / "libonnxruntime.dylib")
-            create_empty_file(osx_native_dir / "libonnxruntime4j_jni.dylib")
-            (osx_dir / "_manifest" / "spdx_2.2").mkdir(parents=True, exist_ok=True)
-
-            # Add linux-aarch64 and osx-arm64 for CPU test
+            # Add linux-aarch64 for CPU test
             linux_aarch64_dir = java_artifact_dir / "onnxruntime-java-linux-aarch64"
             linux_aarch64_native_dir = linux_aarch64_dir / "ai" / "onnxruntime" / "native" / "linux-aarch64"
             linux_aarch64_native_dir.mkdir(parents=True, exist_ok=True)
             create_empty_file(linux_aarch64_dir / "libcustom_op_library.so")
-
-            osx_arm64_dir = java_artifact_dir / "onnxruntime-java-osx-arm64"
-            osx_arm64_native_dir = osx_arm64_dir / "ai" / "onnxruntime" / "native" / "osx-arm64"
-            osx_arm64_native_dir.mkdir(parents=True, exist_ok=True)
-            create_empty_file(osx_arm64_dir / "libcustom_op_library.dylib")
 
         return tmp_path
 
@@ -134,9 +121,6 @@ def test_cpu_packaging(directory_setup_factory, version_string):
         # Linux libs
         assert "ai/onnxruntime/native/linux-x64/libonnxruntime.so" in jar_contents
         assert "ai/onnxruntime/native/linux-x64/libonnxruntime4j_jni.so" in jar_contents
-        # macOS libs
-        assert "ai/onnxruntime/native/osx-x86_64/libonnxruntime.dylib" in jar_contents
-        assert "ai/onnxruntime/native/osx-x86_64/libonnxruntime4j_jni.dylib" in jar_contents
         # GPU libs should NOT be present
         assert "ai/onnxruntime/native/linux-x64/libonnxruntime_providers_cuda.so" not in jar_contents
 
@@ -144,14 +128,9 @@ def test_cpu_packaging(directory_setup_factory, version_string):
     with zipfile.ZipFile(testing_jar_path, "r") as zf:
         jar_contents = zf.namelist()
         assert "libcustom_op_library.so" in jar_contents
-        assert "libcustom_op_library.dylib" in jar_contents
 
     # 3. Verify the custom op libraries were removed from the source directories
     linux_dir = temp_build_dir / "java-artifact" / "onnxruntime-java-linux-x64"
-    osx_dir = temp_build_dir / "java-artifact" / "onnxruntime-java-osx-x86_64"
     linux_aarch64_dir = temp_build_dir / "java-artifact" / "onnxruntime-java-linux-aarch64"
-    osx_arm64_dir = temp_build_dir / "java-artifact" / "onnxruntime-java-osx-arm64"
     assert not (linux_dir / "libcustom_op_library.so").exists()
-    assert not (osx_dir / "libcustom_op_library.dylib").exists()
     assert not (linux_aarch64_dir / "libcustom_op_library.so").exists()
-    assert not (osx_arm64_dir / "libcustom_op_library.dylib").exists()


### PR DESCRIPTION
### Description
Move packaging pipelines' macOS build jobs to a new machine pool that is much faster, which can reduce the build time by 85%.
However, it has some drawbacks:
1. It does not have Java installed. Also, ADO's JavaToolInstaller task does not support macOS. So I have to remove these things from the pipeline. We will stop providing java binaries for macOS until this issue is resolved.
2. It does not Cocoapod. But Cocoapod itself is being deprecated.  So it is not a big deal. 




