### PR TITLE
Add check for ARM64 SME to MlasDynamicQGemmBatch() unit tests.

### DIFF
--- a/onnxruntime/test/mlas/unittest/test_dynamic_qgemm.cpp
+++ b/onnxruntime/test/mlas/unittest/test_dynamic_qgemm.cpp
@@ -18,6 +18,11 @@ class MlasDynamicQgemmTest {
 
  public:
   void Test(size_t M, size_t N, size_t K, size_t BatchSize) {
+    // Currently, MlasDynamicQGemmBatch() and associated functions require SME or else they are no-ops.
+    if (!MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME()) {
+      GTEST_SKIP() << "MlasDynamicQGemmBatch() requires ARM64 SME but it was not detected. Skipping test.";
+    }
+
     // Setup buffers for holding various data
 
     float* A = buffer_a.GetBuffer(M * K * BatchSize);

--- a/onnxruntime/test/mlas/unittest/test_dynamic_qgemm.cpp
+++ b/onnxruntime/test/mlas/unittest/test_dynamic_qgemm.cpp
@@ -4,9 +4,11 @@
 // SPDX-License-Identifier: MIT
 //
 
-#include "test_util.h"
 // Currently this test only applies to KleidiAI Guard against it running in any other situation
 #if defined(USE_KLEIDIAI) && !defined(_MSC_VER)
+
+#include "test_util.h"
+#include "core/mlas/lib/mlasi.h"  // for MLAS_CPUIDINFO
 
 class MlasDynamicQgemmTest {
  private:


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Add check for ARM64 SME to MlasDynamicQGemmBatch() unit tests. Now, ARM64 SME is required or else MlasDynamicQGemmBatch() is a no-op.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix unit test failures.