### PR TITLE
Fix shape inference failure with in-memory external data

### DIFF
--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -2678,7 +2678,6 @@ class InferenceContextImpl : public ONNX_NAMESPACE::InferenceContext {
     // only return data if it's for a constant initializer. checks for outer scope initializers
     // if this is a subgraph and the name isn't found locally.
     const TensorProto* initializer = graph_.GetConstantInitializer(def->Name(), true);
-
     if (initializer != nullptr) {
       // Check if this is in-memory external data (data stored in OrtValue)
       // ONNX shape inference cannot handle external data, so we need to materialize it
@@ -2689,19 +2688,17 @@ class InferenceContextImpl : public ONNX_NAMESPACE::InferenceContext {
           // Create a temporary TensorProto with the actual data from the OrtValue
           // This allows ONNX shape inference to access the data
           const Tensor& tensor = ort_value.Get<Tensor>();
-          auto temp_tensor_proto = std::make_unique<ONNX_NAMESPACE::TensorProto>(
-              utils::TensorToTensorProto(tensor, initializer->name(), /*use_tensor_buffer=*/false));
-
-          const TensorProto* result = temp_tensor_proto.get();
-          // Store the temporary proto so it outlives this call
-          temp_tensor_protos_.push_back(std::move(temp_tensor_proto));
-          return result;
+          auto temp_tensor_proto = utils::TensorToTensorProto(tensor, initializer->name(), /*use_tensor_buffer=*/false);
+          // Store the temporary proto so it outlives this call, maintain pointers steady
+          temp_tensor_protos_.push_back(std::make_unique<ONNX_NAMESPACE::TensorProto>(std::move(temp_tensor_proto)));
+          return temp_tensor_protos_.back().get();
+        } else {
+          // If we can't get the OrtValue, it is a bug
+          ORT_THROW("Initializer ", def->Name(),
+                    " has in-memory external data but cannot get OrtValue during shape inference");
         }
-        // If we can't get the OrtValue, fall through to return the original initializer
-        // This may cause shape inference to fail, but it's better than crashing
       }
     }
-
     return initializer;
   }
 
@@ -2743,7 +2740,9 @@ class InferenceContextImpl : public ONNX_NAMESPACE::InferenceContext {
   const Graph::ResolveOptions& options_;
   // Temporary TensorProtos created for in-memory external data during shape inference
   // These need to outlive the shape inference call, so we store them here
-  mutable std::vector<std::unique_ptr<ONNX_NAMESPACE::TensorProto>> temp_tensor_protos_;
+  // Inference is per node and the instance of this context is on the stack,
+  // so this is safe.
+  mutable InlinedVector<std::unique_ptr<ONNX_NAMESPACE::TensorProto>> temp_tensor_protos_;
 };
 
 Status Graph::InferAndVerifySubgraphTypes(const Node& node, Graph& subgraph,


### PR DESCRIPTION
## Description

Fixes #26261

This PR resolves a regression introduced in v1.23.0 where models with Constant nodes containing tensors larger than 127 bytes fail to load with a shape inference error.

### Root Cause

Commit 3b97d79b3c (PR #25320) introduced an optimization to convert large Constant node tensors (> 127 bytes) into OrtValues with in-memory external data references for better memory management. However, ONNX shape inference cannot distinguish between in-memory and file-based external data, and rejects any TensorProto with `data_location = EXTERNAL`.

### The Fix

Modified `InferenceContextImpl::getInputData()` to:
1. Detect tensors with in-memory external data using `utils::HasExternalDataInMemory()`
2. Retrieve the corresponding OrtValue
3. Create a temporary TensorProto with embedded data (not external reference)
4. Provide this temporary proto to ONNX shape inference

This allows ONNX shape inference to access the actual tensor data without rejecting it as external.

### Memory Impact

This fix introduces a minor and temporary increase in memory usage during the model loading phase. 

- **When:** The additional memory is allocated only when the shape inference engine needs to access the data of a constant tensor that is larger than 127 bytes. This is a one-time event during the initial analysis of the model.
- **What:** The fix creates a temporary in-memory copy of the tensor data.
- **Duration:** This temporary copy is released as soon as shape inference is complete.

The impact on the overall peak memory usage of the application is expected to be negligible. The memory usage during inference is not affected. While it is theoretically possible for the temporary tensor to be large if a multi-gigabyte constant tensor is used for shape inference, this is a highly unlikely scenario in practice for well-designed models.

### Testing

- Tested with the problematic model from issue #26261
- All optimization levels now work correctly (DISABLE_ALL, BASIC, EXTENDED, ALL)
- Unit tests to be added

### Changes

- **onnxruntime/core/graph/graph.cc**: 
  - Modified `getInputData()` method in `InferenceContextImpl` class
  - Added `temp_tensor_protos_` member to store temporary TensorProtos during shape inference

## TODO

- [ ] Add unit tests
- [ ] Run full test suite