### PR TITLE
Fix build.sh --parallel 1 incorrectly triggering parallel build

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1330,7 +1330,7 @@ def build_targets(args, cmake_path, build_dir, configs, num_parallel_jobs, targe
             cmd_args.extend(["--target", *targets])
 
         build_tool_args = []
-        if num_parallel_jobs != 1:
+        if num_parallel_jobs != 0:
             if is_windows() and args.cmake_generator != "Ninja" and not args.build_wasm:
                 # https://github.com/Microsoft/checkedc-clang/wiki/Parallel-builds-of-clang-on-Windows suggests
                 # not maxing out CL_MPCount


### PR DESCRIPTION
### Description
This PR fixes an issue where running

```bash
bash build.sh ...... --parallel 1 ......
```

still triggers a parallel build.

The previous logic only added -j when num_parallel_jobs != 1, which caused Ninja/Make/Xcode to use all CPU cores by default.

### Motivation and Context
When building ONNX Runtime, using parallel 4 caused an out-of-memory (OOM) error in my computer. However, changing it to parallel 1 still triggered parallel compilation and caused OOM again.


