### PR TITLE
Add windows server to supported OS

### DIFF
--- a/onnxruntime/python/onnxruntime_validation.py
+++ b/onnxruntime/python/onnxruntime_validation.py
@@ -23,9 +23,9 @@ def check_distro_info():
         __my_distro__ = __my_system__
         __my_distro_ver__ = platform.release().lower()
 
-        if __my_distro_ver__ not in ["10", "11"]:
+        if __my_distro_ver__ not in ["10", "11", "2016server", "2019server", "2022server", "2025server"]:
             warnings.warn(
-                f"Unsupported Windows version ({__my_distro_ver__}). ONNX Runtime supports Windows 10 and above, only."
+                f"Unsupported Windows version ({__my_distro_ver__}). ONNX Runtime supports Windows 10 and above, or Windows Server 2016 and above."
             )
     elif __my_system__ == "linux":
         """Although the 'platform' python module for getting Distro information works well on standard OS images


### PR DESCRIPTION
Add windows server to supported list to avoid confusing users:

Marketing Name | Internal Version | platform.release().lower() | Release Year | Based on
-- | -- | -- | -- | --
Windows Server 2025 | 10.0.26100+ | "2025server" | 2024–2025 | Windows 11 (24H2)
Windows Server 2022 | 10.0.20348 | "2022server" | 2021 | Windows 10 (21H2)
Windows Server 2019 | 10.0.17763 | "2019server" | 2018 | Windows 10 (1809)
Windows Server 2016 | 10.0.14393 | "2016server" | 2016 | Windows 10 (1607)