### PR TITLE
docs: update EP support table

### DIFF
--- a/docs/get-started/with-javascript/node.md
+++ b/docs/get-started/with-javascript/node.md
@@ -36,6 +36,8 @@ const ort = require('onnxruntime-node');
 
 - Follow the [Quick Start](https://github.com/microsoft/onnxruntime-inference-examples/tree/main/js/quick-start_onnxruntime-node) instructions for ONNX Runtime Node.js binding.
 
+## Supported Versions
+
 The following table lists the supported versions of ONNX Runtime Node.js binding provided with pre-built binaries.
 
 | EPs/Platforms | Windows x64        | Windows arm64      | Linux x64          | Linux arm64        | MacOS x64          | MacOS arm64        |


### PR DESCRIPTION
### Description

Aligns https://github.com/microsoft/onnxruntime/blob/main/js/node/README.md

### Motivation and Context

Currently, https://github.com/microsoft/onnxruntime/blob/gh-pages/docs/get-started/with-javascript/node.md is not sync & updated with https://github.com/microsoft/onnxruntime/blob/main/js/node/README.md is , this Pull Request updated the supporting matrix & table for getting started page.