### PR TITLE
Quant tool: Don't store original outputs in MinMax Calibrator

### DIFF
--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -420,7 +420,9 @@ class MinMaxCalibrater(CalibraterBase):
             self.intermediate_outputs.append(
                 [
                     value if sess_o.name not in self.model_original_outputs else None
-                    for sess_o, value in zip(self.infer_session.get_outputs(), self.infer_session.run(None, inputs))
+                    for sess_o, value in zip(
+                        self.infer_session.get_outputs(), self.infer_session.run(None, inputs), strict=False
+                    )
                 ]
             )
             if (


### PR DESCRIPTION
### Description
The MixMax calibrator stores all the outputs of each session run as intermediate outputs. However, it only needs the augmented min and max values. This causes the memory usage to unnecessarily grow with each iteration of the calibration data, especially for llms which have large outputs (logits and kv cache). 

This PR fixes this by not storing the values from the model's original outputs that are not needed for calibration.

### Motivation and Context
Improve memory usage.


