### PR TITLE
Quant tool: Use 2D scales and zp in default MatMulNBitsQuantizer

### DIFF
--- a/onnxruntime/python/tools/quantization/matmul_nbits_quantizer.py
+++ b/onnxruntime/python/tools/quantization/matmul_nbits_quantizer.py
@@ -823,8 +823,8 @@ class DefaultWeightOnlyQuantizer:
 
             # block wise quantization, each block comes from a single column
             packed = np.zeros((cols, k_blocks, blob_size), dtype="uint8")
-            zero_point = np.zeros(cols * ((k_blocks + kpack - 1) // kpack), dtype="uint8")
-            scales = np.zeros((cols * k_blocks), dtype=fp32weight.dtype)
+            zero_point = np.zeros((cols, ((k_blocks + kpack - 1) // kpack)), dtype="uint8")
+            scales = np.zeros((cols, k_blocks), dtype=fp32weight.dtype)
             if qbits == 2:
                 quantize_matmul_2bits(
                     packed, fp32weight, scales, zero_point, block_size, cols, rows, self.config.is_symmetric


### PR DESCRIPTION
### Description
#24828 updated the specs for the operator to use 2D scales and zero points but the default quantizer still produces 1D values.

### Motivation and Context
Produce models that are consistent with the specs


