### PR TITLE
[QNN EP] Skip inputs/outputs shape validation for QNN Batch Multiple

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -415,3 +415,10 @@ static const char* const kOrtSessionOptionsFailOnSuboptimalCompiledModel =
 // "high_power_saver", "low_balanced", "extreme_power_saver", "low_power_saver", "power_saver",
 // "sustained_high_performance". Default to "default".
 static const char* const kOrtEpDynamicOptionsQnnHtpPerformanceMode = "ep.dynamic.qnn_htp_performance_mode";
+
+// Enable QNN HTP batch multiplier
+//
+// Option values:
+// - "0": QNN htp batch multiplier is disabled. [DEFAULT]
+// - "1": QNN htp batch multiplier is enabaled.
+static const char* const kOrtSessionOptionsQnnHtpBatchMultiplier = "ep.qnn.enable_htp_batch_multiplier";


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

* QNN EP supports batch multiplier during inference, which allows the compile batch size is different to running batch size. 
* However, InferenceSession::ValidateInputs & InferenceSession::ValidateOutputs validates the input_output_shape against the expected_shape.
* We avoid these validations if qnn batch multiplier options is used.
* p.s. QNN EP does not support dynamic shapes. We cannot convert ONNX graphs with dynamic shapes into static shapes inside QNN EP. There is no internal mechanism to infer or materialize static shapes from dynamic ones.
* A separate PR will be submitted for the implementation of batch multiplier support in QNN EP.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

* This change supports batch multiplier in QNN API to ORT as described in this page: https://docs.qualcomm.com/bundle/publicresource/topics/80-63442-10/function_QnnGraph_8h_1a3ea05f42a9295f9a74a2e3a0cdd64228.html

@microsoft-github-policy-service agree company="Qualcomm"

