### PR TITLE
[WebGPU] Fix the typo `splitted` with `split`

### DIFF
--- a/onnxruntime/core/providers/webgpu/math/gemm_utils.cc
+++ b/onnxruntime/core/providers/webgpu/math/gemm_utils.cc
@@ -158,9 +158,9 @@ Status MakeMatMulPackedVec4Source(ShaderHelper& shader,
                                   int output_components,
                                   uint32_t tile_inner,
                                   bool split_k,
-                                  uint32_t splitted_dim_inner) {
+                                  uint32_t split_dim_inner) {
   ORT_UNUSED_PARAMETER(split_k);
-  ORT_UNUSED_PARAMETER(splitted_dim_inner);
+  ORT_UNUSED_PARAMETER(split_dim_inner);
 
   const std::string type_string = MakeScalarOrVectorType(4 /*components */, data_type);
 
@@ -356,9 +356,9 @@ Status MakeMatMulPackedSource(ShaderHelper& shader,
                               bool need_handle_matmul,
                               uint32_t tile_inner,
                               bool split_k,
-                              uint32_t splitted_dim_inner) {
+                              uint32_t split_dim_inner) {
   ORT_UNUSED_PARAMETER(split_k);
-  ORT_UNUSED_PARAMETER(splitted_dim_inner);
+  ORT_UNUSED_PARAMETER(split_dim_inner);
 
   const auto elements_per_thread_x = elements_per_thread[0];
   const auto elements_per_thread_y = elements_per_thread[1];

--- a/onnxruntime/core/providers/webgpu/math/gemm_utils.h
+++ b/onnxruntime/core/providers/webgpu/math/gemm_utils.h
@@ -43,7 +43,7 @@ Status MakeMatMulPackedVec4Source(ShaderHelper& shader,
                                   int output_components = 4,
                                   uint32_t tile_inner = 32,
                                   bool split_k = false,
-                                  uint32_t splitted_dim_inner = 32);
+                                  uint32_t split_dim_inner = 32);
 
 Status MakeMatMulPackedSource(ShaderHelper& shader,
                               const InlinedVector<int64_t>& elements_per_thread,
@@ -57,7 +57,7 @@ Status MakeMatMulPackedSource(ShaderHelper& shader,
                               bool need_handle_matmul = true,
                               uint32_t tile_inner = 32,
                               bool split_k = false,
-                              uint32_t splitted_dim_inner = 32);
+                              uint32_t split_dim_inner = 32);
 
 }  // namespace webgpu
 }  // namespace onnxruntime


### PR DESCRIPTION
### Description
This patch fixes all `splitted` with `split` as `splitted` is not a correct word.


