### PR TITLE
use std::move(model_proto) to avoid extra copy

### DIFF
--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -1239,7 +1239,7 @@ struct ProviderHostImpl : ProviderHost {
   std::unique_ptr<Model> Model__construct(ONNX_NAMESPACE::ModelProto&& model_proto, const PathString& model_path,
                                           const IOnnxRuntimeOpSchemaRegistryList* local_registries,
                                           const logging::Logger& logger) override {
-    return std::make_unique<Model>(model_proto, model_path, local_registries, logger);
+    return std::make_unique<Model>(std::move(model_proto), model_path, local_registries, logger);
   }
   std::unique_ptr<Model> Model__construct(const std::string& graph_name,
                                           bool is_onnx_domain_only,


### PR DESCRIPTION
Previously, model_proto was passed by name, which triggered a copy constructor call instead of move construction. Using std::move(model_proto) ensures that the object is constructed via move semantics, reducing unnecessary memory allocation and copy overhead.