### PR TITLE
[EP API] Check for out-of-range node in EpGraph::IndexToEpNodeMap::GetEpNode

### DIFF
--- a/onnxruntime/core/graph/ep_api_types.cc
+++ b/onnxruntime/core/graph/ep_api_types.cc
@@ -543,6 +543,10 @@ void EpGraph::IndexToEpNodeMap::Resize(NodeIndex min_node_index, NodeIndex max_n
 }
 
 EpNode* EpGraph::IndexToEpNodeMap::GetEpNode(NodeIndex node_index) const {
+  if (node_index < min_node_index_ || node_index >= min_node_index_ + nodes_.size()) {
+    return nullptr;
+  }
+
   size_t i = node_index - min_node_index_;
   assert(i < nodes_.size());
   return nodes_[i];


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Check whether given `node_index` is within the target range of nodes during `EpGraph::IndexToEpNodeMap::GetEpNode`. Since EpGraph may be created from a subset of nodes, it should be checked that queried node is inside current EpGraph.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
While operating on partitioned graphs, SegFault occurrs if tries to acquire a node that is partitioned to another EpGraph (i.e., different EP).


