### PR TITLE
Fix onnxruntime build on s390x with more recent GCC versions

### DIFF
--- a/cmake/external/eigen.cmake
+++ b/cmake/external/eigen.cmake
@@ -5,12 +5,14 @@ set(EIGEN_BUILD_PKGCONFIG OFF CACHE BOOL "" FORCE)
 set(EIGEN_BUILD_CMAKE_PACKAGE ON CACHE BOOL "" FORCE)
 
 set(PATCH_EIGEN_S390X ${PROJECT_SOURCE_DIR}/patches/eigen/s390x-build.patch)
+set(PATCH_EIGEN_S390X_WERROR ${PROJECT_SOURCE_DIR}/patches/eigen/s390x-build-werror.patch)
 
 onnxruntime_fetchcontent_declare(
     Eigen3
     URL ${DEP_URL_eigen}
     URL_HASH SHA1=${DEP_SHA1_eigen}
-    PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PATCH_EIGEN_S390X}
+    PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PATCH_EIGEN_S390X} &&
+                  ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PATCH_EIGEN_S390X_WERROR}
     EXCLUDE_FROM_ALL
 )
 onnxruntime_fetchcontent_makeavailable(Eigen3)

--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -186,7 +186,8 @@ endif()
 #2. if ONNX_CUSTOM_PROTOC_EXECUTABLE is not set, Compile everything(including protoc) from source code.
 if(Patch_FOUND)
   set(ONNXRUNTIME_PROTOBUF_PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/protobuf/protobuf_cmake.patch &&
-                                         ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/protobuf/protobuf_android_log.patch)
+                                         ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/protobuf/protobuf_android_log.patch &&
+                                         ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/protobuf/protobuf_s390x.patch)
 else()
  set(ONNXRUNTIME_PROTOBUF_PATCH_COMMAND "")
 endif()

--- a/cmake/patches/eigen/s390x-build-werror.patch
+++ b/cmake/patches/eigen/s390x-build-werror.patch
@@ -1,0 +1,13 @@
+Comment out variable unused in onnxruntime
+
+--- a/Eigen/src/Core/arch/ZVector/PacketMath.h.orig	2025-10-21 10:24:49.410176124 +0000
++++ b/Eigen/src/Core/arch/ZVector/PacketMath.h	2025-10-21 10:25:06.010176124 +0000
+@@ -101,7 +101,7 @@
+ 
+ static EIGEN_DECLARE_CONST_FAST_Packet4f(ZERO, 0);     //{ 0.0, 0.0, 0.0, 0.0}
+ static EIGEN_DECLARE_CONST_FAST_Packet4i(MINUS1, -1);  //{ -1, -1, -1, -1}
+-static Packet4f p4f_MZERO = {0x80000000, 0x80000000, 0x80000000, 0x80000000};
++//static Packet4f p4f_MZERO = {0x80000000, 0x80000000, 0x80000000, 0x80000000};
+ #endif
+ 
+ static Packet4i p4i_COUNTDOWN = {0, 1, 2, 3};

--- a/cmake/patches/protobuf/protobuf_s390x.patch
+++ b/cmake/patches/protobuf/protobuf_s390x.patch
@@ -1,0 +1,16 @@
+s390x compatibility changes based on
+
+https://github.com/protocolbuffers/protobuf/commit/a2859cc2ce25711613002104022186c0c37d9f1f
+
+diff --git a/src/google/protobuf/port_def.inc b/src/google/protobuf/port_def.inc
+index edd6d5122598e..a0a296a85da3d 100644
+--- a/src/google/protobuf/port_def.inc
++++ b/src/google/protobuf/port_def.inc
+@@ -255,6 +255,7 @@
+ #error PROTOBUF_TAILCALL was previously defined
+ #endif
+ #if __has_cpp_attribute(clang::musttail) && !defined(__arm__) && \
++    !defined(__s390x__) &&                                       \
+     !defined(_ARCH_PPC) && !defined(__wasm__) &&                 \
+     !(defined(_MSC_VER) && defined(_M_IX86)) &&                  \
+     !(defined(__NDK_MAJOR__) && __NDK_MAJOR <= 24)

--- a/onnxruntime/core/mlas/lib/s390x/Quantize.cpp
+++ b/onnxruntime/core/mlas/lib/s390x/Quantize.cpp
@@ -198,6 +198,9 @@ Return Value:
         auto CharVector = vec_pack(ShortVector0, ShortVector1);
         vec_xst(CharVector, 0, (int8_t *)(&TmpOutput[0]));
 
+        // Workaround for bad GCC warning that variable is set but not used.
+        MLAS_UNREFERENCED_PARAMETER(CharVector);
+
         MlasPackInt4Elements(Output++, TmpOutput[0], TmpOutput[1]);
         MlasPackInt4Elements(Output++, TmpOutput[2], TmpOutput[3]);
         MlasPackInt4Elements(Output++, TmpOutput[4], TmpOutput[5]);


### PR DESCRIPTION
### Description
Port upstream fix for protobuf for s390x.
Fix unused variable warnings.

### Motivation and Context
These changes fix unnoticed issues which might appear when onnxruntime is compiled on s390x with newer gcc versions.