### PR TITLE
[webgpu] Fix graph capture broken

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/group_query_attention.cc
@@ -287,7 +287,7 @@ Status GroupQueryAttention::ComputeInternal(onnxruntime::webgpu::ComputeContext&
       !use_sliding_window &&
       CanApplyFlashAttention(attention_bias, present_key, present_value, parameters, context)) {
     return ApplyFlashAttention(query, key, value, attention_bias, output, past_key, present_key, past_value,
-                               present_value, parameters, context);
+                               present_value, parameters, context, seqlen_k);
   }
 
   TensorShapeVector q_new_dims({parameters.batch_size_, parameters.num_heads_,


### PR DESCRIPTION
#26297 deleted `seqlen_k` by accident which broke the graph capture in phi4. This PR brings it back. 


