### PR TITLE
[MLAS] Fix rotary avx2 kernel invalid access

### DIFF
--- a/onnxruntime/core/mlas/lib/rotary_embedding_kernel_avx2.cpp
+++ b/onnxruntime/core/mlas/lib/rotary_embedding_kernel_avx2.cpp
@@ -122,20 +122,15 @@ RopeKernel_Avx2_fp16_Impl<true>(
         convert_to_fp16_and_store(output + i + 8, y1);
     }
 
-    for (; i < dim; i++) {
+    // Scalar remainder loop to safely handle trailing elements in pairs.
+    for (; i + 1 < dim; i += 2) {
         size_t cache_idx = i / 2;
-        bool sign = i & 1;
-        size_t j = sign ? i - 1 : i + 1;
-
-        float output_data_i = input[i].ToFloat() * cos_data[cache_idx].ToFloat();
-        float input_data_j = input[j].ToFloat();
-        float sin_data_cache_idx = sin_data[cache_idx].ToFloat();
-        if (sign) {
-            output_data_i += input_data_j * sin_data_cache_idx;
-        } else {
-            output_data_i -= input_data_j * sin_data_cache_idx;
-        }
-        output[i] = MLAS_FP16(output_data_i);
+        float input0 = input[i].ToFloat();
+        float input1 = input[i + 1].ToFloat();
+        float sin_val = sin_data[cache_idx].ToFloat();
+        float cos_val = cos_data[cache_idx].ToFloat();
+        output[i] = MLAS_FP16(input0 * cos_val - input1 * sin_val);
+        output[i + 1] = MLAS_FP16(input0 * sin_val + input1 * cos_val);
     }
 }
 


### PR DESCRIPTION
This fixes an issue that _mm256_maskload_ps intrinsic used in remainder-handling logic introduced in https://github.com/microsoft/onnxruntime/pull/23694.

The core of the problem is that _mm256_maskload_ps (and its store equivalent) can read beyond the masked elements.
Even if mask correctly specifies that you only want to load, for example, 3 floats, the intrinsic may still read the full 32 bytes (8 floats) from the provided memory address.

The invalid access occurs when one of buffers (input, sin_data, or cos_data) ends near the boundary of a memory page, and the part of the 32-byte read that you don't care about (i.e., the masked-off part) falls onto an unmapped page. This will cause a segmentation fault (invalid access).

The Solution: Use a Scalar Remainder Loop

The simplest, safest, and most robust solution is to replace the masked AVX remainder logic with a simple scalar loop. This is the exact strategy already used by your RopeKernel_Avx2_fp16_Impl functions, which are safe from this bug.

The performance impact of this change will be negligible, as this loop only processes the final 1-15 elements.