### PR TITLE
[MIGraphX EP] Bugfix for toVector Function causing rollover with int64 inputs

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -364,11 +364,11 @@ static bool getMIGraphXType(ONNXTensorElementDataType type,
   return true;
 }
 
-std::vector<int> toVector(const ONNX_NAMESPACE::int64s& nums) {
-  std::vector<int> result;
-  int num = nums.size();
-  for (int i = 0; i < num; ++i) {
-    result.push_back(static_cast<int>(nums[i]));
+std::vector<int64_t> toVector(const ONNX_NAMESPACE::int64s& nums) {
+  std::vector<int64_t> result;
+  size_t num = nums.size();
+  for (size_t i = 0; i < num; ++i) {
+    result.push_back(nums[i]);
   }
 
   return result;
@@ -541,6 +541,7 @@ static bool IsUnsupportedOpMode(const onnxruntime::GraphViewer& graph_viewer, co
     if (attributes.count("starts") > 0 && attributes.count("ends") > 0) {
       auto starts = toVector((*attributes.find("starts")).second.ints());
       auto ends = toVector((*attributes.find("ends")).second.ints());
+
       for (std::size_t i = 0; i < starts.size(); ++i) {
         if (starts.at(i) > ends.at(i)) {
           return true;


### PR DESCRIPTION
Refactors the toVector function which causes narrowing of the datatype for vector inputs such as in the slice operator

### Description
<!-- Describe your changes. -->
Removes the casting done for toVector as that causes rollovers due to some Onnx Operators using int64_t inputs rather than int32_t. This case causes us to actually incorrectly represent axis, start and end values in the slice operator


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fixes a bug since this causes some of our Onnx operators to not operate in the full correct data range for input vectors 
