### PR TITLE
[CPU] Use MayInPlace kernel def hint for FusedConv kernel

### DIFF
--- a/onnxruntime/contrib_ops/cpu/fused_conv.cc
+++ b/onnxruntime/contrib_ops/cpu/fused_conv.cc
@@ -19,6 +19,10 @@ ONNX_CPU_OPERATOR_TYPED_MS_KERNEL(
     1,
     float,
     KernelDefBuilder()
+        // If the fused "sum" input is available to the FusedConv node,
+        // provide a hint to the allocation planner that it can re-use the
+        // "sum"'s input as the output buffer of the FusedConv node.
+        .MayInplace(3, 0)
         .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
     FusedConvFloat);
 


### PR DESCRIPTION
### Description
Use MayInPlace hint for the FusedConv NCHW CPU kernel that allows for the allocation planner to re-use the optional "sum" input buffer as the kernel's output buffer. It will potentially save [this copy](https://github.com/microsoft/onnxruntime/blob/06004826cc99dd8b8b92dbf000db3d3525716f22/onnxruntime/core/providers/cpu/nn/conv.cc#L209) if the buffers can be shared (in most cases the buffers can be shared)



### Motivation and Context
The kernel already had logic to save the copy but the kernel def was missing the hint to the allocation planner.

Found while investigating improvements to a Conv model's performance on ARM64


