### PR TITLE
Add options to onnxruntime_perf_runner to externalize weights

### DIFF
--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -750,6 +750,17 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
   }
   if (!performance_test_config.run_config.optimized_model_path.empty()) {
     session_options.SetOptimizedModelFilePath(performance_test_config.run_config.optimized_model_path.c_str());
+    if (!performance_test_config.run_config.optimized_model_data_path.empty()) {
+      session_options.AddConfigEntry(kOrtSessionOptionsOptimizedModelExternalInitializersFileName,
+                                     performance_test_config.run_config.optimized_model_data_path.c_str());
+      if (!performance_test_config.run_config.optimized_model_weight_min_size.empty()) {
+        session_options.AddConfigEntry(kOrtSessionOptionsOptimizedModelExternalInitializersMinSizeInBytes,
+                                       performance_test_config.run_config.optimized_model_weight_min_size.c_str());
+      }
+      if (performance_test_config.run_config.optimized_save_optimized_prepacks) {
+        session_options.AddConfigEntry(kOrtSessionOptionsSavePrePackedConstantInitializers, "1");
+      }
+    }
   }
   if (performance_test_config.run_config.set_denormal_as_zero) {
     warn_dup_config_entry(kOrtSessionOptionsConfigSetDenormalAsZero);

--- a/onnxruntime/test/perftest/test_configuration.h
+++ b/onnxruntime/test/perftest/test_configuration.h
@@ -54,7 +54,10 @@ struct RunConfig {
   int intra_op_num_threads{0};
   int inter_op_num_threads{0};
   GraphOptimizationLevel optimization_level{ORT_ENABLE_ALL};
-  std::basic_string<ORTCHAR_T> optimized_model_path;
+  PathString optimized_model_path;
+  std::string optimized_model_data_path;  // Always UTF-8
+  std::string optimized_model_weight_min_size;
+  bool optimized_save_optimized_prepacks{false};
   int cudnn_conv_algo{0};
   bool do_cuda_copy_in_separate_stream{false};
   bool set_denormal_as_zero{false};


### PR DESCRIPTION
### Description
Allow the user to externalize weights, set the minimum weight threshold, and save pre-packs when saving an optimized model.

### Motivation and Context
Add several options that make the tool more useful.
Some models fail to optimize because they are too large. Externalizing initializers makes this possible.

