### PR TITLE
Fix memleak due to improper deletion of onnx::TypeProto wrapper in provider-bridge API

### DIFF
--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -381,6 +381,7 @@ struct ProviderHost {
 
   // TypeProto
   virtual std::unique_ptr<ONNX_NAMESPACE::TypeProto> TypeProto__construct() = 0;
+  virtual void TypeProto__operator_delete(ONNX_NAMESPACE::TypeProto* p) = 0;
   virtual void TypeProto__CopyFrom(ONNX_NAMESPACE::TypeProto* p, const ONNX_NAMESPACE::TypeProto* other) = 0;
   virtual bool TypeProto__has_tensor_type(const ONNX_NAMESPACE::TypeProto* p) = 0;
   virtual const ONNX_NAMESPACE::TypeProto_Tensor& TypeProto__tensor_type(const ONNX_NAMESPACE::TypeProto* p) = 0;

--- a/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
+++ b/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
@@ -366,6 +366,7 @@ struct TypeProto_Sequence final {
 
 struct TypeProto final {
   static std::unique_ptr<TypeProto> Create() { return g_host->TypeProto__construct(); }
+  static void operator delete(void* p) { g_host->TypeProto__operator_delete(reinterpret_cast<TypeProto*>(p)); }
 
   bool has_tensor_type() const { return g_host->TypeProto__has_tensor_type(this); }
   const TypeProto_Tensor& tensor_type() const { return g_host->TypeProto__tensor_type(this); }

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -516,6 +516,7 @@ struct ProviderHostImpl : ProviderHost {
 
   // TypeProto (wrapped)
   std::unique_ptr<ONNX_NAMESPACE::TypeProto> TypeProto__construct() override { return std::make_unique<ONNX_NAMESPACE::TypeProto>(); }
+  void TypeProto__operator_delete(ONNX_NAMESPACE::TypeProto* p) override { delete p; }
   void TypeProto__CopyFrom(ONNX_NAMESPACE::TypeProto* p, const ONNX_NAMESPACE::TypeProto* other) override { p->CopyFrom(*other); }
   bool TypeProto__has_tensor_type(const ONNX_NAMESPACE::TypeProto* p) override { return p->has_tensor_type(); }
   const ONNX_NAMESPACE::TypeProto_Tensor& TypeProto__tensor_type(const ONNX_NAMESPACE::TypeProto* p) override { return p->tensor_type(); }


### PR DESCRIPTION
### Description
There is a memory leak whenever an EP uses the provider-bridge API to create a `std::unique_ptr<onnx::TypeProto>`. The `onnx::TypeProto` is not properly deleted due to a missing `operator delete()` override for the `TypeProto` wrapper class. This delete operator override is necessary because the onnx library may use custom allocators.

Affected EPs:
Run `git grep -rn "TypeProto::Create()" onnxruntime/core/providers/`

- QNN EP: Happens when QNN EP creates an EPContext model. To reproduce, run the `onnxruntime_provider_tests` with `--gtest_filter=*ContextBinary*`.
  - https://github.com/microsoft/onnxruntime/blob/860d0853a6eefdf19e21b0e9982bde2ffbc8a65d/onnxruntime/core/providers/qnn/builder/onnx_ctx_model_helper.cc#L73. 
- OpenVINO EP: Happens during QDQ stripping. However, I believe OpenVINO EP's dll statically links with onnx, which provides a valid destructor for `onnx::TypeProto`. So, this may not be an issue for this EP.
  - https://github.com/microsoft/onnxruntime/blob/860d0853a6eefdf19e21b0e9982bde2ffbc8a65d/onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc#L76
  - https://github.com/microsoft/onnxruntime/blob/860d0853a6eefdf19e21b0e9982bde2ffbc8a65d/onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc#L473
  - https://github.com/microsoft/onnxruntime/blob/860d0853a6eefdf19e21b0e9982bde2ffbc8a65d/onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc#L654
- NV EP: I believe NV EP's dll statically links with onnx, which provides a valid destructor for onnx::TypeProto. So, this may not be an issue for this EP.
  - https://github.com/microsoft/onnxruntime/blob/860d0853a6eefdf19e21b0e9982bde2ffbc8a65d/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_helper.cc#L213
- VitisAI EP: I believe VitisAI EP's dll statically links with onnx, which provides a valid destructor for onnx::TypeProto. So, this may not be an issue for this EP.
  - https://github.com/microsoft/onnxruntime/blob/860d0853a6eefdf19e21b0e9982bde2ffbc8a65d/onnxruntime/core/providers/vitisai/imp/node_arg.cc#L94


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


