### PR TITLE
[Test Only] End profiling after 10 runs

### DIFF
--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -2572,6 +2572,10 @@ int InferenceSession::GetCurrentNumRuns() const {
   return current_num_runs_.load();
 }
 
+int InferenceSession::GetTotalRunCount() const {
+  return total_run_count_.load();
+}
+
 const std::vector<std::string>& InferenceSession::GetRegisteredProviderTypes() const {
   return execution_providers_.GetIds();
 }
@@ -2941,6 +2945,9 @@ Status InferenceSession::Run(const RunOptions& run_options,
   Status retval = Status::OK();
   const Env& env = Env::Default();
 
+  // Increment total run count for this session
+  total_run_count_.fetch_add(1, std::memory_order_relaxed);
+
   int graph_annotation_id = 0;
   const std::string& graph_annotation_str =
       run_options.config_options.GetConfigOrDefault(kOrtRunOptionsConfigCudaGraphAnnotation, "");
@@ -3138,6 +3145,11 @@ Status InferenceSession::Run(const RunOptions& run_options,
   // send out profiling events (optional)
   if (session_profiler_.IsEnabled()) {
     session_profiler_.EndTimeAndRecordEvent(profiling::SESSION_EVENT, "model_run", tp);
+  }
+  // Check if we've reached 10 runs and need to stop profiling
+  if (total_run_count_.load() == 10 && session_options_.enable_profiling) {
+    session_options_.enable_profiling = false;
+    EndProfiling();
   }
 #ifdef ONNXRUNTIME_ENABLE_INSTRUMENT
   TraceLoggingWriteStop(ortrun_activity, "OrtRun");

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -490,6 +490,11 @@ class InferenceSession {
   int GetCurrentNumRuns() const;
 
   /**
+   * Get the total number of Run calls made for this session.
+   */
+  int GetTotalRunCount() const;
+
+  /**
    * Get the names of registered Execution Providers. The returned vector is ordered by Execution Provider
    * priority. The first provider in the vector has the highest priority.
    */
@@ -926,6 +931,9 @@ class InferenceSession {
 
   // Number of concurrently running executors
   std::atomic<int> current_num_runs_ = 0;
+
+  // Total number of Run calls for this session
+  std::atomic<int> total_run_count_ = 0;
 
   mutable std::mutex session_mutex_;         // to ensure only one thread can invoke Load/Initialize
   bool is_model_loaded_ = false;             // GUARDED_BY(session_mutex_)


### PR DESCRIPTION
This pull request adds a mechanism to track the total number of inference runs in an `InferenceSession` and uses this count to automatically stop profiling after 10 runs if profiling is enabled. The main changes include introducing a new counter, exposing it via a getter, incrementing it on each run, and updating profiling logic accordingly.


