### PR TITLE
[VitisAI EP] Fix error in graph resolving

### DIFF
--- a/onnxruntime/core/providers/vitisai/imp/graph.cc
+++ b/onnxruntime/core/providers/vitisai/imp/graph.cc
@@ -285,7 +285,7 @@ Model* model_clone(const Model& original_model, int64_t external_data_threshold)
   }
   for (auto& node : original_graph.Nodes()) {
     auto* node_proto = graph_proto->add_node();
-    node->ToProto(*node_proto, false);
+    node->ToProto(*node_proto, true);
     for (auto output : node->OutputDefs()) {
       if (output->Exists()) {
         auto* value_info = graph_proto->mutable_value_info()->Add();


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Use the updated subgraph when cloning the model.

### Motivation and Context

When a node in model contains a subgraph attribute, onnxruntime will optimize the subgraph. If the updated subgraph is not used in the cloned model, it may cause errors during graph resolving.


