### PR TITLE
[node] remove incorrect error check

### DIFF
--- a/js/node/src/inference_session_wrap.cc
+++ b/js/node/src/inference_session_wrap.cc
@@ -15,10 +15,6 @@
 Napi::Object InferenceSessionWrap::Init(Napi::Env env, Napi::Object exports) {
   // create ONNX runtime env
   Ort::InitApi();
-  ORT_NAPI_THROW_ERROR_IF(
-      &Ort::GetApi() == nullptr, env,
-      "Failed to initialize ONNX Runtime API. It could happen when this nodejs binding was built with a higher version "
-      "ONNX Runtime but now runs with a lower version ONNX Runtime DLL(or shared library).");
 
   // initialize binding
   Napi::HandleScope scope(env);


### PR DESCRIPTION
### Description

remove the code that generates warning.

```
[6/8] Building CXX object CMakeFiles/o...ing.dir/src/inference_session_wrap.cc.
/s/js/node/src/inference_session_wrap.cc:19:8: warning: reference cannot be bound to dereferenced null pointer in well-defined C++ code; comparison may be assumed to always evaluate to false [-Wtautological-undefined-compare]
   19 |       &Ort::GetApi() == nullptr, env,
      |        ^~~~~~~~~~~~~    ~~~~~~~
/s/js/node/src/common.h:41:67: note: expanded from macro 'ORT_NAPI_THROW_ERROR_IF'
   41 | #define ORT_NAPI_THROW_ERROR_IF(COND, ENV, ...) ORT_NAPI_THROW_IF(COND, Error, ENV, __VA_ARGS__)
      |                                                                   ^~~~
/s/js/node/src/common.h:38:7: note: expanded from macro 'ORT_NAPI_THROW_IF'
   38 |   if (COND) {                                    \
      |       ^~~~
/s/js/node/../../include/onnxruntime/core/session/onnxruntime_cxx_api.h:189:22: note: 'GetApi' returns a reference
  189 | inline const OrtApi& GetApi() noexcept { return *detail::Global::Api(); }
      |                      ^
1 warning generated.
```

