### PR TITLE
[webgpu] polyfill `device.AdapterInfo` for Safari v26.0

### DIFF
--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -751,9 +751,18 @@ if (onnxruntime_USE_WEBGPU)
           #   Some build warnings are not allowed to be disabled in project level.
           ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/dawn/dawn_binskim.patch &&
 
-          # Android devices doesn't seem to allow fp16 in uniforms so the WebGPU EP has to manually handle passing an fp32
-          # in the uniform and converting to fp16 before using.
-          ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/dawn/uniform_and_storage_buffer_16_bit_access.patch)
+          # The uniform_and_storage_buffer_16_bit_access.patch contains the following changes:
+          #
+          # - (private) Android devices don't seem to allow fp16 in uniforms so the WebGPU EP has to manually handle passing an fp32
+          #   in the uniform and converting to fp16 before using.
+          ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/dawn/uniform_and_storage_buffer_16_bit_access.patch &&
+
+          # The safari_polyfill.patch contains the following changes:
+          #
+          # - (private) Fix compatibility issues with Safari. Contains the following changes:
+          #   - Polyfill for `device.AdapterInfo` (returns `undefined` in Safari v26.0)
+          #
+          ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/dawn/safari_polyfill.patch)
 
       onnxruntime_fetchcontent_declare(
         dawn

--- a/cmake/patches/dawn/safari_polyfill.patch
+++ b/cmake/patches/dawn/safari_polyfill.patch
@@ -1,0 +1,17 @@
+diff --git a/third_party/emdawnwebgpu/pkg/webgpu/src/library_webgpu.js b/third_party/emdawnwebgpu/pkg/webgpu/src/library_webgpu.js
+index a3ce6dc732..7119eae424 100644
+--- a/third_party/emdawnwebgpu/pkg/webgpu/src/library_webgpu.js
++++ b/third_party/emdawnwebgpu/pkg/webgpu/src/library_webgpu.js
+@@ -903,6 +903,12 @@ var LibraryWebGPU = {
+           stackRestore(sp);
+       };
+ 
++      // Polyfill `device.AdapterInfo` if not present (Safari v26.0).
++      // See https://bugs.webkit.org/show_bug.cgi?id=301878
++      if (!('adapterInfo' in device)) {
++        device.adapterInfo = adapter.info;
++      }
++
+       _emwgpuOnRequestDeviceCompleted(futureId, {{{ gpu.RequestDeviceStatus.Success }}},
+         {{{ gpu.passAsPointer('devicePtr') }}}, {{{ gpu.NULLPTR }}});
+     }, (ex) => {


### PR DESCRIPTION
### Description

polyfill `device.AdapterInfo` for Safari v26.0


### Motivation and Context

Fixes #26480
