### PR TITLE
Skip setup-python for arm64 Linux builds

### DIFF
--- a/.github/workflows/reusable_linux_build.yml
+++ b/.github/workflows/reusable_linux_build.yml
@@ -78,6 +78,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Python ${{ inputs.python_version }}
+        if: inputs.architecture != 'arm64'
         uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python_version }}


### PR DESCRIPTION
## Problem
The setup-python action does not support AzureLinux 3.0.20251030 for arm64 architecture, causing workflow failures.

## Solution
Skip the setup-python step for arm64 builds since Python is already available in the Docker containers used for those builds.

## Error Details
```
Version 3.x was not found in the local cache
(node:4478) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
Error: The version '3.x' with architecture 'arm64' was not found for azurelinux 3.0.20251030 undefined.
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

## Changes
- Added conditional `if: inputs.architecture != 'arm64'` to the setup-python step in `.github/workflows/reusable_linux_build.yml`
- This affects `build-linux-arm64-debug` and `build-linux-arm64-release` jobs which recently migrated from Ubuntu to AzureLinux3