### PR TITLE
QDQ refactor: rename registration-phase functions to reflect their true meaning

### DIFF
--- a/onnxruntime/python/tools/quantization/operators/activation.py
+++ b/onnxruntime/python/tools/quantization/operators/activation.py
@@ -99,11 +99,11 @@ class QDQRemovableActivation(QDQOperatorBase):
     def __init__(self, onnx_quantizer, onnx_node):
         super().__init__(onnx_quantizer, onnx_node)
 
-    def quantize(self):
+    def reg2quant(self):
         node = self.node
 
         # If input to this node is not quantized then keep this node
-        if not self.quantizer.is_tensor_quantized(node.input[0]):
+        if not self.quantizer.is_tensor_reg2quant(node.input[0]):
             return
 
         if (
@@ -113,7 +113,7 @@ class QDQRemovableActivation(QDQOperatorBase):
         ):
             self.quantizer.remove_node(self.node)
         else:
-            self.quantizer.quantize_activation_tensor(node.input[0])
+            self.quantizer.reg2quant_activation_tensor(node.input[0])
 
         if not self.disable_qdq_for_node_output:
-            self.quantizer.quantize_activation_tensor(node.output[0])
+            self.quantizer.reg2quant_activation_tensor(node.output[0])

--- a/onnxruntime/python/tools/quantization/operators/conv.py
+++ b/onnxruntime/python/tools/quantization/operators/conv.py
@@ -240,21 +240,21 @@ class QDQConv(QDQOperatorBase):
     def __init__(self, onnx_quantizer, onnx_node):
         super().__init__(onnx_quantizer, onnx_node)
 
-    def quantize(self):
+    def reg2quant(self):
         node = self.node
         assert node.op_type == "Conv" or node.op_type == "ConvTranspose"
 
-        self.quantizer.quantize_activation_tensor(node.input[0])
+        self.quantizer.reg2quant_activation_tensor(node.input[0])
         if not self.disable_qdq_for_node_output:
-            self.quantizer.quantize_activation_tensor(node.output[0])
+            self.quantizer.reg2quant_activation_tensor(node.output[0])
 
         is_weight_per_channel, weight_axis = self.quantizer.is_tensor_per_channel(
             node.input[1], default_axis=0 if node.op_type == "Conv" else 1
         )
         if is_weight_per_channel:
-            self.quantizer.quantize_weight_tensor_per_channel(node.input[1], weight_axis)
+            self.quantizer.reg2quant_weight_tensor_per_channel(node.input[1], weight_axis)
         else:
-            self.quantizer.quantize_weight_tensor(node.input[1])
+            self.quantizer.reg2quant_weight_tensor(node.input[1])
 
         if len(node.input) == 3:
-            self.quantizer.quantize_bias_tensor(node.name, node.input[2], node.input[0], node.input[1])
+            self.quantizer.reg2quant_bias_tensor(node.name, node.input[2], node.input[0], node.input[1])

--- a/onnxruntime/python/tools/quantization/operators/direct_q8.py
+++ b/onnxruntime/python/tools/quantization/operators/direct_q8.py
@@ -69,10 +69,10 @@ class QDQDirect8BitOp(QDQOperatorBase):
     def __init__(self, onnx_quantizer, onnx_node):
         super().__init__(onnx_quantizer, onnx_node)
 
-    def quantize(self):
+    def reg2quant(self):
         if self.quantizer.force_quantize_no_input_check:
-            self.quantizer.quantize_activation_tensor(self.node.input[0])
+            self.quantizer.reg2quant_activation_tensor(self.node.input[0])
             if not self.disable_qdq_for_node_output:
-                self.quantizer.quantize_output_same_as_input(self.node.output[0], self.node.input[0], self.node.name)
-        elif self.quantizer.is_tensor_quantized(self.node.input[0]) and not self.disable_qdq_for_node_output:
-            self.quantizer.quantize_output_same_as_input(self.node.output[0], self.node.input[0], self.node.name)
+                self.quantizer.reg2quant_output_same_as_input(self.node.output[0], self.node.input[0], self.node.name)
+        elif self.quantizer.is_tensor_reg2quant(self.node.input[0]) and not self.disable_qdq_for_node_output:
+            self.quantizer.reg2quant_output_same_as_input(self.node.output[0], self.node.input[0], self.node.name)

--- a/onnxruntime/python/tools/quantization/operators/gather.py
+++ b/onnxruntime/python/tools/quantization/operators/gather.py
@@ -53,12 +53,12 @@ class QDQGather(QDQOperatorBase):
     def __init__(self, onnx_quantizer, onnx_node):
         super().__init__(onnx_quantizer, onnx_node)
 
-    def quantize(self):
+    def reg2quant(self):
         node = self.node
         assert node.op_type == "Gather" or node.op_type == "GatherElements"
 
         if self.quantizer.is_valid_quantize_weight(node.input[0]) or self.quantizer.force_quantize_no_input_check:
-            self.quantizer.quantize_activation_tensor(node.input[0])
-            self.quantizer.quantize_output_same_as_input(node.output[0], node.input[0], node.name)
-        elif self.quantizer.is_tensor_quantized(node.input[0]):
-            self.quantizer.quantize_output_same_as_input(node.output[0], node.input[0], node.name)
+            self.quantizer.reg2quant_activation_tensor(node.input[0])
+            self.quantizer.reg2quant_output_same_as_input(node.output[0], node.input[0], node.name)
+        elif self.quantizer.is_tensor_reg2quant(node.input[0]):
+            self.quantizer.reg2quant_output_same_as_input(node.output[0], node.input[0], node.name)

--- a/onnxruntime/python/tools/quantization/operators/gemm.py
+++ b/onnxruntime/python/tools/quantization/operators/gemm.py
@@ -144,25 +144,25 @@ class QDQGemm(QDQOperatorBase):
     def __init__(self, onnx_quantizer, onnx_node):
         super().__init__(onnx_quantizer, onnx_node)
 
-    def quantize(self):
+    def reg2quant(self):
         node = self.node
         assert node.op_type == "Gemm"
 
-        self.quantizer.quantize_activation_tensor(node.input[0])
+        self.quantizer.reg2quant_activation_tensor(node.input[0])
         if not self.disable_qdq_for_node_output:
-            self.quantizer.quantize_activation_tensor(node.output[0])
+            self.quantizer.reg2quant_activation_tensor(node.output[0])
 
         is_weight_per_channel, weight_axis = self.quantizer.is_tensor_per_channel(
             node.input[1], default_axis=0 if is_B_transposed(node) else 1
         )
         if is_weight_per_channel:
-            self.quantizer.quantize_weight_tensor_per_channel(node.input[1], weight_axis)
+            self.quantizer.reg2quant_weight_tensor_per_channel(node.input[1], weight_axis)
         else:
-            self.quantizer.quantize_weight_tensor(node.input[1])
+            self.quantizer.reg2quant_weight_tensor(node.input[1])
 
         if len(node.input) == 3:
             if self.quantizer.is_input_a_initializer(node.input[2]):
-                self.quantizer.quantize_bias_tensor(
+                self.quantizer.reg2quant_bias_tensor(
                     node.name, node.input[2], node.input[0], node.input[1], get_beta(self.node)
                 )
                 set_default_beta(self.node)

--- a/onnxruntime/python/tools/quantization/operators/matmul.py
+++ b/onnxruntime/python/tools/quantization/operators/matmul.py
@@ -209,7 +209,7 @@ class QDQMatMul(QDQOperatorBase):
     def __init__(self, onnx_quantizer, onnx_node):
         super().__init__(onnx_quantizer, onnx_node)
 
-    def quantize(self):
+    def reg2quant(self):
         node = self.node
         assert node.op_type == "MatMul"
 
@@ -224,8 +224,8 @@ class QDQMatMul(QDQOperatorBase):
                     tensor_name, default_axis=1, op_type=node.op_type
                 )
                 if is_per_channel:
-                    self.quantizer.quantize_weight_tensor_per_channel(tensor_name, channel_axis)
+                    self.quantizer.reg2quant_weight_tensor_per_channel(tensor_name, channel_axis)
                 else:
-                    self.quantizer.quantize_weight_tensor(tensor_name)
+                    self.quantizer.reg2quant_weight_tensor(tensor_name)
             else:
-                self.quantizer.quantize_activation_tensor(tensor_name)
+                self.quantizer.reg2quant_activation_tensor(tensor_name)

--- a/onnxruntime/python/tools/quantization/operators/maxpool.py
+++ b/onnxruntime/python/tools/quantization/operators/maxpool.py
@@ -22,7 +22,7 @@ class QDQMaxPool(QDQDirect8BitOp):
     def __init__(self, onnx_quantizer, onnx_node):
         super().__init__(onnx_quantizer, onnx_node)
 
-    def quantize(self):
+    def reg2quant(self):
         node = self.node
         assert node.op_type == "MaxPool"
 
@@ -31,4 +31,4 @@ class QDQMaxPool(QDQDirect8BitOp):
             return
 
         # Direct 8bits op
-        return super().quantize()
+        return super().reg2quant()

--- a/onnxruntime/python/tools/quantization/operators/norm.py
+++ b/onnxruntime/python/tools/quantization/operators/norm.py
@@ -10,12 +10,12 @@ class QDQNormalization(QDQOperatorBase):
     def __init__(self, onnx_quantizer, onnx_node):
         super().__init__(onnx_quantizer, onnx_node)
 
-    def quantize(self):
+    def reg2quant(self):
         node = self.node
         assert node.op_type in {"InstanceNormalization", "LayerNormalization", "BatchNormalization"}
 
         # Input
-        self.quantizer.quantize_activation_tensor(node.input[0])
+        self.quantizer.reg2quant_activation_tensor(node.input[0])
 
         # Scale
         scale_is_initializer = self.quantizer.is_input_a_initializer(node.input[1])
@@ -24,17 +24,17 @@ class QDQNormalization(QDQOperatorBase):
         )
 
         if scale_is_per_channel:
-            self.quantizer.quantize_weight_tensor_per_channel(node.input[1], axis=scale_channel_axis)
+            self.quantizer.reg2quant_weight_tensor_per_channel(node.input[1], axis=scale_channel_axis)
         elif scale_is_initializer:
-            self.quantizer.quantize_weight_tensor(node.input[1])
+            self.quantizer.reg2quant_weight_tensor(node.input[1])
         else:
-            self.quantizer.quantize_activation_tensor(node.input[1])
+            self.quantizer.reg2quant_activation_tensor(node.input[1])
 
         # Bias
         if len(node.input) > 2 and node.input[2]:
-            self.quantizer.quantize_bias_tensor(node.name, node.input[2], node.input[0], node.input[1])
+            self.quantizer.reg2quant_bias_tensor(node.name, node.input[2], node.input[0], node.input[1])
 
         # Output
         if not self.disable_qdq_for_node_output:
             for output_name in node.output:
-                self.quantizer.quantize_activation_tensor(output_name)
+                self.quantizer.reg2quant_activation_tensor(output_name)

--- a/onnxruntime/python/tools/quantization/operators/pad.py
+++ b/onnxruntime/python/tools/quantization/operators/pad.py
@@ -158,15 +158,15 @@ class QDQPad(QDQOperatorBase):
 
         return False
 
-    def quantize(self):
+    def reg2quant(self):
         assert self.node.op_type == "Pad"
 
         for input_name in self.node.input:
             if input_name:
-                self.quantizer.quantize_activation_tensor(input_name)
+                self.quantizer.reg2quant_activation_tensor(input_name)
 
         if not self.disable_qdq_for_node_output:
             if self._should_quantize_output_same_as_input():
-                self.quantizer.quantize_output_same_as_input(self.node.output[0], self.node.input[0], self.node.name)
+                self.quantizer.reg2quant_output_same_as_input(self.node.output[0], self.node.input[0], self.node.name)
             else:
-                self.quantizer.quantize_activation_tensor(self.node.output[0])
+                self.quantizer.reg2quant_activation_tensor(self.node.output[0])

--- a/onnxruntime/python/tools/quantization/operators/qdq_base_operator.py
+++ b/onnxruntime/python/tools/quantization/operators/qdq_base_operator.py
@@ -10,7 +10,7 @@ class QDQOperatorBase:
         self.node = onnx_node
         self.disable_qdq_for_node_output = onnx_node.op_type in onnx_quantizer.op_types_to_exclude_output_quantization
 
-    def quantize(self):
+    def reg2quant(self):
         node = self.node
 
         if self.disable_qdq_for_node_output:
@@ -19,4 +19,4 @@ class QDQOperatorBase:
             tensors_to_quantize = itertools.chain(node.input, node.output)
 
         for tensor_name in tensors_to_quantize:
-            self.quantizer.quantize_activation_tensor(tensor_name)
+            self.quantizer.reg2quant_activation_tensor(tensor_name)

--- a/onnxruntime/python/tools/quantization/operators/resize.py
+++ b/onnxruntime/python/tools/quantization/operators/resize.py
@@ -22,7 +22,7 @@ class QDQResize(QDQDirect8BitOp):
     def __init__(self, onnx_quantizer, onnx_node):
         super().__init__(onnx_quantizer, onnx_node)
 
-    def quantize(self):
+    def reg2quant(self):
         node = self.node
         assert node.op_type == "Resize"
 
@@ -31,4 +31,4 @@ class QDQResize(QDQDirect8BitOp):
             return
 
         # Direct 8bits op
-        return super().quantize()
+        return super().reg2quant()

--- a/onnxruntime/python/tools/quantization/operators/split.py
+++ b/onnxruntime/python/tools/quantization/operators/split.py
@@ -52,12 +52,12 @@ class QSplit(QuantOperatorBase):
 
 
 class QDQSplit(QDQOperatorBase):
-    def quantize(self):
+    def reg2quant(self):
         node = self.node
         assert node.op_type == "Split"
 
-        if not self.quantizer.is_tensor_quantized(node.input[0]):
-            self.quantizer.quantize_activation_tensor(node.input[0])
+        if not self.quantizer.is_tensor_reg2quant(node.input[0]):
+            self.quantizer.reg2quant_activation_tensor(node.input[0])
         if not self.disable_qdq_for_node_output:
             for output in node.output:
-                self.quantizer.quantize_output_same_as_input(output, node.input[0], node.name)
+                self.quantizer.reg2quant_output_same_as_input(output, node.input[0], node.name)

--- a/onnxruntime/python/tools/quantization/operators/where.py
+++ b/onnxruntime/python/tools/quantization/operators/where.py
@@ -67,21 +67,21 @@ class QLinearWhere(QuantOperatorBase):
 
 
 class QDQWhere(QDQOperatorBase):
-    def quantize(self):
+    def reg2quant(self):
         node = self.node
         assert node.op_type == "Where"
         if self.quantizer.force_quantize_no_input_check:
-            if not self.quantizer.is_tensor_quantized(node.input[1]):
-                self.quantizer.quantize_activation_tensor(node.input[1])
-            if not self.quantizer.is_tensor_quantized(node.input[2]):
-                self.quantizer.quantize_activation_tensor(node.input[2])
+            if not self.quantizer.is_tensor_reg2quant(node.input[1]):
+                self.quantizer.reg2quant_activation_tensor(node.input[1])
+            if not self.quantizer.is_tensor_reg2quant(node.input[2]):
+                self.quantizer.reg2quant_activation_tensor(node.input[2])
             if not self.disable_qdq_for_node_output:
                 for output in node.output:
-                    self.quantizer.quantize_activation_tensor(output)
+                    self.quantizer.reg2quant_activation_tensor(output)
         elif (
-            self.quantizer.is_tensor_quantized(node.input[1])
-            and self.quantizer.is_tensor_quantized(node.input[2])
+            self.quantizer.is_tensor_reg2quant(node.input[1])
+            and self.quantizer.is_tensor_reg2quant(node.input[2])
             and not self.disable_qdq_for_node_output
         ):
             for output in node.output:
-                self.quantizer.quantize_activation_tensor(output)
+                self.quantizer.reg2quant_activation_tensor(output)

--- a/onnxruntime/python/tools/quantization/registry.py
+++ b/onnxruntime/python/tools/quantization/registry.py
@@ -103,7 +103,7 @@ def CreateOpQuantizer(onnx_quantizer, node):  # noqa: N802
     return QuantOperatorBase(onnx_quantizer, node)
 
 
-def CreateQDQQuantizer(onnx_quantizer, node):  # noqa: N802
+def create_node_tensor_reg2quant(onnx_quantizer, node):
     if node.op_type in QDQRegistry:
         return QDQRegistry[node.op_type](onnx_quantizer, node)
     return QDQOperatorBase(onnx_quantizer, node)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
This PR refactors the QDQ quantization pipeline to use registration-oriented names for the early pass that only marks tensors, without changing runtime behavior. It clarifies the flow (registration → materialization of quantization) and aligns the factory utility with PEP8.
Additionally, a concise term reg2quant_* (“register to quantize”) is introduced to label registration-only identifiers.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/microsoft/onnxruntime/issues/26502

The early pass was using quantize* names while only registering/marking tensors for later quantization. This caused confusion in code reviews, and led to incorrect assumptions that quantization was already applied at that point.

#### Problem

Methods and variables named quantize* in the early pass imply immediate graph mutations (adding Q/DQ), but they only record intent.
for example,
The factory name CreateQDQQuantizer uses CamelCase and implies it creates a “quantizer” rather than a registrar for node tensors.
is_tensor_quantized actually checks if a tensor is marked (registered), not whether it has been quantized.

#### Solution
a concise reg2quant (“register to quantize”)
Rename registration-phase symbols, No functional changes.

#### Scope of Changes (renames):

functions:

quantize_activation_tensor → reg2quant _activation_tensor

quantize_weight_tensor → reg2quant _weight_tensor

quantize_weight_tensor_per_channel → reg2quant _weight_tensor_per_channel

quantize_output_same_as_input → reg2quant _output_same_as_input

__quantize_tensor → __reg2quant _tensor

is_tensor_quantized → is_tensor_reg2quant

CreateQDQQuantizer → create_node_tensor_reg2quant

Per-operator method quantize()  →reg2quant()

variable:
op_quantizer  →op_reg2quanter

Additionally, change the calls to the functions.

No behavioral changes. Graph outputs remain identical.

