### PR TITLE
[GH Pages] Remove invalid Ignite 2024 session link

### DIFF
--- a/src/routes/events/+page.svelte
+++ b/src/routes/events/+page.svelte
@@ -14,11 +14,7 @@
 			blurb:
 				'ONNX Runtime will be used in the Boost Edge AI session at Microsoft Ignite 2024, as well as behind the scenes as an inference runtime in many other sessions. ONNX Runtime, equipped with NPU acceleration, enables developers to efficiently deploy state-of-the-art models on edge devices including mobile phones.',
 			linkarr: [
-				{ name: 'Microsoft Ignite Page', link: 'https://ignite.microsoft.com/en-US/home' },
-				{
-					name: 'Boost Edge AI (IRL Session)',
-					link: 'https://ignite.microsoft.com/en-US/sessions/THR602?source=sessions'
-				}
+				{ name: 'Microsoft Ignite Page', link: 'https://ignite.microsoft.com/en-US/home' }
 			],
 			image: ignite2024,
 			imagealt:


### PR DESCRIPTION
### Description
Removes an invalid link for an Ignite 2024 session. We should probably replace Ignite 2024 links, but I'll let someone who knows what they're doing handle it.

For now, this fixes the CI that checks for invalid links.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


