### PR TITLE
[VitisAI] Remove unused function body handling in graph fusion

### DIFF
--- a/onnxruntime/core/providers/vitisai/imp/graph.cc
+++ b/onnxruntime/core/providers/vitisai/imp/graph.cc
@@ -248,12 +248,6 @@ Node& graph_fuse(Graph& graph, const std::string& name,
   indexed_subgraph->SetMetaDef(std::move(meta_def));
 
   auto& fused_node = graph.FuseSubGraph(*indexed_subgraph, name);
-  auto function_body = fused_node.GetFunctionBody();
-  if (function_body) {
-    auto proto = function_body->Body().ToGraphProto();
-    *proto->mutable_name() = name;
-    fused_node.AddAttribute("body", *proto);
-  }
   for (auto&& o : fused_node.OutputDefs()) {
     graph.UpdateProducerNode(o->Name(), fused_node.Index());
   }


### PR DESCRIPTION
### Description
Vitis AI EP graph_fuse memory optimize.
This PR removes unused function body handling code in the VitisAI graph fusion implementation.

### Changes
- Removed unused function body handling in graph fusion (`onnxruntime/core/providers/vitisai/imp/graph.cc`)

### Context
The function body handling code in the graph fusion logic was not being used and can be safely removed to simplify the implementation.



