### PR TITLE
[QNN-EP] Remove outdated comment for per-channel quantization

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -110,7 +110,7 @@ Status ConvOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
     }
   }
 
-  // Validate that weight is signed type for per-channel quantization (required by QNN docs).
+  // Validate quantization axis for per-channel quantized weights.
   bool is_npu_backend = IsNpuBackend(qnn_model_wrapper.GetQnnBackendType());
   if (is_npu_backend) {
     const auto& input_1 = inputs[1];  // weight


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Conv2D supports per-channel uint8 quantized weights since QNN SDK 2.36.
This PR updates outdated comments related to signed quantization checks for Conv.
The check itself was removed in #25986 , which has been merged.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
#25986 


