### PR TITLE
[QNN-EP] SSR Handling Enablement

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -767,6 +767,12 @@ if(onnxruntime_USE_QNN AND NOT onnxruntime_MINIMAL_BUILD AND NOT onnxruntime_RED
   list(APPEND onnxruntime_test_framework_src_patterns ${TEST_SRC_DIR}/providers/qnn/qnn_node_group/*)
   list(APPEND onnxruntime_test_framework_src_patterns ${TEST_SRC_DIR}/providers/qnn/optimizer/*)
   list(APPEND onnxruntime_test_providers_dependencies onnxruntime_providers_qnn)
+  onnxruntime_add_shared_library_module(QnnMockSSR
+    ${TEST_SRC_DIR}/providers/qnn/ssr/qnn_mock_ssr.cc
+    ${TEST_SRC_DIR}/providers/qnn/ssr/qnn_mock_ssr.def
+  )
+  target_link_libraries(QnnMockSSR PRIVATE onnxruntime_common)
+  target_include_directories(QnnMockSSR PRIVATE ${onnxruntime_QNN_HOME}/include/QNN)
   if(NOT onnxruntime_BUILD_QNN_EP_STATIC_LIB)
     list(APPEND onnxruntime_test_providers_dependencies onnxruntime_providers_shared)
   endif()

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -999,6 +999,18 @@ std::unique_ptr<unsigned char[]> QnnBackendManager::GetContextBinaryBuffer(uint6
   return context_buffer;
 }
 
+Status QnnBackendManager::SaveContextToBinary(const logging::Logger& logger) {
+  LOGS(logger, VERBOSE) << "[SSR Handle] SaveContextToBinary for recover";
+  uint64_t writtenBufferSize{0};
+  qnn_save_buffer_ = GetContextBinaryBuffer(writtenBufferSize);
+  qnn_save_buffer_size_ = writtenBufferSize;
+
+  ORT_RETURN_IF(qnn_save_buffer_ == nullptr || writtenBufferSize == 0,
+                "Failed to get valid context binary buffer.");
+
+  return Status::OK();
+}
+
 Status QnnBackendManager::GetMaxSpillFillBufferSize(unsigned char* buffer,
                                                     uint64_t buffer_length,
                                                     uint64_t& max_spill_fill_buffer_size) {
@@ -1219,6 +1231,7 @@ Status QnnBackendManager::SetupBackend(const logging::Logger& logger,
                                        bool need_load_system_lib,
                                        bool share_ep_contexts,
                                        bool enable_vtcm_backup_buffer_sharing,
+                                       bool enable_ssr_handling,
                                        std::unordered_map<std::string, std::unique_ptr<std::vector<std::string>>>& context_bin_map) {
   std::lock_guard<std::recursive_mutex> lock(logger_recursive_mutex_);
   if (backend_setup_completed_) {
@@ -1251,6 +1264,7 @@ Status QnnBackendManager::SetupBackend(const logging::Logger& logger,
   }
 
   vtcm_backup_buffer_sharing_enabled_ = enable_vtcm_backup_buffer_sharing;
+  enable_ssr_handling_ = enable_ssr_handling;
 
   Status status = Status::OK();
   if (!qnn_serializer_config_) {
@@ -2091,6 +2105,73 @@ Status QnnBackendManager::GetOrRegisterContextMemHandle(Qnn_ContextHandle_t cont
                                                                        std::move(unregister_mem_handle)));
   }
 
+  return Status::OK();
+}
+
+Status QnnBackendManager::InvokeWithSSRHandle(
+    const std::function<Status()>& operation,
+    const std::function<Status()>& ssr_recover,
+    const std::string& operation_name,
+    const logging::Logger& logger) const {
+  Status result;
+
+  // State machine to track SSR handling progress:
+  // - Init: First attempt at operation
+  // - Retry: Attempting operation after SSR recovery
+  // - End: Processing complete (success or unrecoverable failure)
+  enum class SSRHandleState { Init = 0,
+                              Retry = 1,
+                              End = 2 };
+  SSRHandleState retry_state = SSRHandleState::Init;
+
+  // Validate input functions
+  ORT_RETURN_IF_NOT(operation, "Operation function cannot be null");
+  ORT_RETURN_IF_NOT(ssr_recover, "SSR recover function cannot be null");
+
+  do {
+    // Execute the operation (first attempt or retry)
+    result = operation();
+
+    if (retry_state == SSRHandleState::Init) {
+      // Determine next state: retry if SSR occurred, otherwise we're done
+      if (enable_ssr_handling_ && qnn::utils::IsSSRCapture(result)) {
+        ORT_RETURN_IF_ERROR(ssr_recover());
+        retry_state = SSRHandleState::Retry;
+      } else {
+        retry_state = SSRHandleState::End;
+      }
+    } else if (retry_state == SSRHandleState::Retry) {
+      // Log the result of the retry attempt
+      LOGS(logger, VERBOSE) << "[SSR Handle during " << operation_name << "] " << result;
+      retry_state = SSRHandleState::End;  // Always exit after one retry
+    }
+  } while (retry_state != SSRHandleState::End);  // Continue until we reach End state
+
+  return result;  // Return final status (success or error)
+}
+
+Status QnnBackendManager::SSRCleanUp(const logging::Logger& logger) {
+  LOGS(logger, VERBOSE) << "[SSR Handle] SSRCleanUp";
+  // Customer Recover Routines
+  // ReleaseContext helps contextFree with custom deleter
+  ORT_RETURN_IF_ERROR(ReleaseContext());
+  if (qnn_save_buffer_size_ == 0) {
+    ORT_RETURN_IF_ERROR(CreateContext(false));
+  } else {
+    uint64_t max_spill_fill_buffer_size = 0;
+    ORT_RETURN_IF_ERROR(GetMaxSpillFillBufferSize(
+        qnn_save_buffer_.get(),
+        qnn_save_buffer_size_,
+        max_spill_fill_buffer_size));
+    // If there are multiple graphs in the buffer, LoadCachedQnnContextFromBuffer will fetch
+    // graph names from QnnSystemContext_GraphInfo_t
+    ORT_RETURN_IF_ERROR(LoadCachedQnnContextFromBuffer(
+        reinterpret_cast<char*>(qnn_save_buffer_.get()),
+        qnn_save_buffer_size_,
+        qnn_models_.begin()->first,
+        qnn_models_,
+        max_spill_fill_buffer_size));
+  }
   return Status::OK();
 }
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_def.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_def.h
@@ -574,7 +574,9 @@ class GraphInfo {
   const std::vector<QnnTensorWrapper>& InputTensors() const { return input_tensors_; }
   const std::vector<QnnTensorWrapper>& OutputTensors() const { return output_tensors_; }
   Qnn_GraphHandle_t Graph() const { return graph_; }
+  void SetGraph(Qnn_GraphHandle_t graph) { graph_ = graph; }
   Qnn_ContextHandle_t GraphContext() const { return graph_context_; }
+  void SetGraphContext(Qnn_ContextHandle_t graph_context) { graph_context_ = graph_context; }
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(GraphInfo);
 
  private:

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.h
@@ -105,6 +105,8 @@ class QnnModel {
     return outputs_info_;
   }
 
+  const std::unique_ptr<GraphInfo>& GetGraphInfo() const { return graph_info_; }
+
   const std::string& Name() const { return graph_info_->Name(); }
 
  private:

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
@@ -59,9 +59,9 @@ class QnnModelWrapper {
 
   const ModelSettings& GetModelSettings() const { return model_settings_; }
 
-  bool CreateQnnGraph(const Qnn_ContextHandle_t& context,
-                      const std::string& graph_name,
-                      const QnnGraph_Config_t** graph_configs = nullptr);
+  Status CreateQnnGraph(const Qnn_ContextHandle_t& context,
+                        const std::string& graph_name,
+                        const QnnGraph_Config_t** graph_configs = nullptr);
 
   // Make a QnnTensorWrapper from an onnx input or output.
   Status MakeTensorWrapper(const NodeUnitIODef& tensor, QnnTensorWrapper& tensor_wrapper) const;
@@ -93,7 +93,7 @@ class QnnModelWrapper {
                      std::vector<std::string>&& param_tensor_names,
                      bool do_op_validation = false);
 
-  bool ComposeQnnGraph(bool build_json_qnn_graph = false);
+  Status ComposeQnnGraph(bool build_json_qnn_graph = false);
 
   Qnn_GraphHandle_t GetQnnGraph() const { return graph_; }
 
@@ -293,17 +293,17 @@ class QnnModelWrapper {
                                /*out*/ int64_t& axis) const;
 
  private:
-  bool CreateQnnInputOutputTensors(const std::string& qnn_node_name,
-                                   const std::vector<std::string>& names,
-                                   std::vector<Qnn_Tensor_t>& tensor_wrappers,
-                                   bool do_op_validation = false);
+  Status CreateQnnInputOutputTensors(const std::string& qnn_node_name,
+                                     const std::vector<std::string>& names,
+                                     std::vector<Qnn_Tensor_t>& tensor_wrappers,
+                                     bool do_op_validation = false);
 
   bool QnnParamExists(const std::string& param_tensor_name) const;
 
-  bool CreateQnnParamTensors(const std::string& qnn_node_name,
-                             const std::vector<std::string>& param_tensor_names,
-                             std::vector<Qnn_Param_t>& qnn_params,
-                             bool do_op_validation = false);
+  Status CreateQnnParamTensors(const std::string& qnn_node_name,
+                               const std::vector<std::string>& param_tensor_names,
+                               std::vector<Qnn_Param_t>& qnn_params,
+                               bool do_op_validation = false);
 
   bool IsQDQNode(const Node& node) const {
     if (node.OpType() == "QuantizeLinear" || node.OpType() == "DequantizeLinear") {

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -1170,6 +1170,10 @@ std::string GetVerboseQnnErrorMessage(const QNN_INTERFACE_VER_TYPE& qnn_interfac
   return MakeString("Unknown error. QNN error handle: ", qnn_error_handle);
 }
 
+bool IsSSRCapture(Status status) {
+  return status.ErrorMessage().find(std::to_string(QNN_COMMON_ERROR_SYSTEM_COMMUNICATION)) != std::string::npos;
+}
+
 TensorShape GetTensorProtoShape(const ONNX_NAMESPACE::TensorShapeProto& tensor_shape_proto) {
   const auto& onnx_dims = tensor_shape_proto.dim();
   const size_t num_dims = static_cast<size_t>(onnx_dims.size());

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.h
@@ -354,6 +354,9 @@ std::string GetQnnErrorMessage(const QNN_INTERFACE_VER_TYPE& qnn_interface,
 std::string GetVerboseQnnErrorMessage(const QNN_INTERFACE_VER_TYPE& qnn_interface,
                                       Qnn_ErrorHandle_t qnn_error_handle);
 
+// Check if the status returned representing SSR detected
+bool IsSSRCapture(Status status);
+
 // NCHW shape to channel last
 template <typename T>
 Status NchwShapeToNhwc(gsl::span<const T> nchw_shape, gsl::span<T> nhwc_shape) {

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -532,6 +532,9 @@ QNNExecutionProvider::QNNExecutionProvider(const ProviderOptions& provider_optio
   // Add this option because this feature requires QnnSystem lib and it's no supported for Windows x86_64 platform
   enable_spill_fill_buffer_ = ParseBoolOption("enable_htp_spill_fill_buffer", false, provider_options_map);
 
+  // Handling SSR requires QnnSystem lib and it's no supported for Windows x86_64 platform
+  enable_ssr_handling_ = ParseBoolOption("enable_ssr_handling", false, provider_options_map);
+
   model_settings_.offload_graph_io_quantization = ParseBoolOption("offload_graph_io_quantization", true,
                                                                   provider_options_map);
 
@@ -939,11 +942,20 @@ QNNExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_viewer
   // It will load the QnnSystem lib if is_qnn_ctx_model=true, and
   // delay the Qnn context creation to Compile() using the cached context binary
   // or generate context cache enable, need to use use QnnSystem lib to parse the binary to get the max spill fill buffer size
-  auto rt = qnn_backend_manager_->SetupBackend(logger, is_qnn_ctx_model,
-                                               context_cache_enabled_ && enable_spill_fill_buffer_,
-                                               share_ep_contexts_,
-                                               enable_vtcm_backup_buffer_sharing_,
-                                               context_bin_map);
+  Status rt = qnn_backend_manager_->InvokeWithSSRHandle(
+      [&]() {
+        return qnn_backend_manager_->SetupBackend(logger, is_qnn_ctx_model,
+                                                  enable_ssr_handling_ || (context_cache_enabled_ && enable_spill_fill_buffer_),
+                                                  share_ep_contexts_,
+                                                  enable_vtcm_backup_buffer_sharing_,
+                                                  enable_ssr_handling_,
+                                                  context_bin_map);
+      },
+      [&]() {
+        return Status::OK();  // No SSR recover needed since SetupBackend help clean up on failure"
+      },
+      "SetupBackend",
+      logger);
 
   context_bin_map.clear();
 
@@ -1089,7 +1101,7 @@ Status QNNExecutionProvider::CreateComputeFunc(std::vector<NodeComputeInfo>& nod
   NodeComputeInfo compute_info;
   compute_info.create_state_func = [&](ComputeContext* context, FunctionState* state) {
     LOGS(logger, VERBOSE) << "compute_info.create_state_func context->node_name: " << context->node_name;
-    *state = qnn_models_[context->node_name].get();
+    *state = qnn_backend_manager_->GetQnnModels()[context->node_name].get();
     return 0;
   };
 
@@ -1202,7 +1214,7 @@ Status QNNExecutionProvider::CompileFromOrtGraph(const std::vector<FusedNodeAndG
     ORT_RETURN_IF_ERROR(qnn_model->SetupQnnInputOutput(logger));
 
     LOGS(logger, VERBOSE) << "fused node name: " << fused_node.Name();
-    qnn_models_.emplace(fused_node.Name(), std::move(qnn_model));
+    qnn_backend_manager_->GetQnnModels().emplace(fused_node.Name(), std::move(qnn_model));
 
     ORT_RETURN_IF_ERROR(CreateComputeFunc(node_compute_funcs, logger));
   }
@@ -1238,7 +1250,7 @@ Status QNNExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& fused
           ORT_RETURN_IF(nullptr == qnn_model_shared, "Graph: " + key + " not found from shared EP contexts.");
           ORT_RETURN_IF_ERROR(qnn_model_shared->SetGraphInputOutputInfo(graph_viewer, fused_node, logger));
           ORT_RETURN_IF_ERROR(qnn_model_shared->SetupQnnInputOutput(logger));
-          qnn_models_.emplace(graph_meta_id, std::move(qnn_model_shared));
+          qnn_backend_manager_->GetQnnModels().emplace(graph_meta_id, std::move(qnn_model_shared));
           ORT_RETURN_IF_ERROR(CreateComputeFunc(node_compute_funcs, logger));
         }
         return Status::OK();
@@ -1286,7 +1298,7 @@ Status QNNExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& fused
 
       // fused node name is QNNExecutionProvider_QNN_[hash_id]_[id]
       // the name here must be same with context->node_name in compute_info
-      qnn_models_.emplace(graph_meta_id, std::move(qnn_model));
+      qnn_backend_manager_->GetQnnModels().emplace(graph_meta_id, std::move(qnn_model));
       qnn_models.erase(key);
 
       ORT_RETURN_IF_ERROR(CreateComputeFunc(node_compute_funcs, logger));
@@ -1306,7 +1318,22 @@ Status QNNExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& fused
     return Status::OK();
   }
 
-  ORT_RETURN_IF_ERROR(CompileFromOrtGraph(fused_nodes_and_graphs, node_compute_funcs, logger));
+  Status compile_res = qnn_backend_manager_->InvokeWithSSRHandle(
+      [&]() {
+        return CompileFromOrtGraph(fused_nodes_and_graphs, node_compute_funcs, logger);
+      },
+      [&]() {
+        // Cleanup after SSR capture
+        ORT_RETURN_IF_ERROR(qnn_backend_manager_->SSRCleanUp(logger));
+        return Status::OK();
+      },
+      "Compile",
+      logger);
+  ORT_RETURN_IF_ERROR(compile_res);
+
+  if (enable_ssr_handling_) {
+    ORT_RETURN_IF_ERROR(qnn_backend_manager_->SaveContextToBinary(logger));
+  }
   // Generate QNN context model if it's QDQ model + context_cache_enabled=true + not exist already
   if (!is_qnn_ctx_model && context_cache_enabled_ && !is_ctx_file_exist) {
     // All partitioned graph share single QNN context, included in the same context binary
@@ -1325,7 +1352,7 @@ Status QNNExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& fused
                                                   buffer_size,
                                                   qnn_backend_manager_->GetSdkVersion(),
                                                   fused_nodes_and_graphs,
-                                                  qnn_models_,
+                                                  qnn_backend_manager_->GetQnnModels(),
                                                   context_model_path,
                                                   qnn_context_embed_mode_,
 

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -86,7 +86,6 @@ class QNNExecutionProvider : public IExecutionProvider {
   // Note: Using shared_ptr<QnnBackendManager> so that we can refer to it with a weak_ptr from a
   // HtpSharedMemoryAllocator allocation cleanup callback.
   std::shared_ptr<qnn::QnnBackendManager> qnn_backend_manager_;
-  std::unordered_map<std::string, std::unique_ptr<qnn::QnnModel>> qnn_models_;
   bool context_cache_enabled_ = false;
   std::string context_cache_path_cfg_ = "";
   std::string context_node_name_prefix_ = "";
@@ -104,6 +103,7 @@ class QNNExecutionProvider : public IExecutionProvider {
   bool share_ep_contexts_ = false;
   bool stop_share_ep_contexts_ = false;
   bool enable_spill_fill_buffer_ = false;
+  bool enable_ssr_handling_ = false;
 #if defined(_WIN32)
   onnxruntime::logging::EtwRegistrationManager::EtwInternalCallback callback_ETWSink_provider_ = nullptr;
 #endif

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -86,6 +86,8 @@ void usage() {
       "\t    [QNN only] [htp_arch]: The minimum HTP architecture. The driver will use ops compatible with this architecture. \n"
       "\t    Options are '0', '68', '69', '73', '75'. Defaults to '0' (none). \n"
       "\t    [QNN only] [device_id]: The ID of the device to use when setting 'htp_arch'. Defaults to '0' (for single device). \n"
+      "\t    [QNN only] [enable_ssr_handling]: Enable Subsystem Restart (SSR) handling so that ORT executes recovery routines during an SSR event. \n"
+      "\t    Default to '0'. (Error out on SSR events) \n"
       "\t    [QNN only] [enable_htp_fp16_precision]: Enable the HTP_FP16 precision so that the float32 model will be inferenced with fp16 precision. \n"
       "\t    Otherwise, it will be fp32 precision. Works for float32 model for HTP backend. Defaults to '1' (with FP16 precision.). \n"
       "\t    [QNN only] [offload_graph_io_quantization]: Offload graph input quantization and graph output dequantization to another EP (typically CPU EP). \n"
@@ -615,7 +617,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
             std::string str = str_stream.str();
             ORT_THROW("Wrong value for htp_arch. select from: " + str);
           }
-        } else if (key == "enable_htp_fp16_precision" || key == "offload_graph_io_quantization") {
+        } else if (key == "enable_htp_fp16_precision" || key == "offload_graph_io_quantization" || key == "enable_ssr_handling") {
           std::unordered_set<std::string> supported_options = {"0", "1"};
           if (supported_options.find(value) == supported_options.end()) {
             std::ostringstream str_stream;
@@ -629,7 +631,8 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
               "Wrong key type entered. Choose from options: ['backend_type', 'backend_path', "
               "'profiling_level', 'profiling_file_path', 'rpc_control_latency', 'vtcm_mb', 'htp_performance_mode', "
               "'qnn_saver_path', 'htp_graph_finalization_optimization_mode', 'op_packages', 'qnn_context_priority', "
-              "'soc_model', 'htp_arch', 'device_id', 'enable_htp_fp16_precision', 'offload_graph_io_quantization']");
+              "'soc_model', 'htp_arch', 'device_id', 'enable_ssr_handling', 'enable_htp_fp16_precision', "
+              "'offload_graph_io_quantization']");
         }
 
         qnn_options[key] = value;

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -324,7 +324,7 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
                          "rpc_control_latency", "vtcm_mb", "soc_model", "device_id", "htp_performance_mode", "op_packages",
                          "qnn_saver_path", "htp_graph_finalization_optimization_mode", "qnn_context_priority",
                          "htp_arch", "enable_htp_fp16_precision", "offload_graph_io_quantization",
-                         "enable_htp_spill_fill_buffer", "enable_htp_shared_memory_allocator", "dump_json_qnn_graph",
+                         "enable_htp_spill_fill_buffer", "enable_ssr_handling", "enable_htp_shared_memory_allocator", "dump_json_qnn_graph",
                          "json_qnn_graph_dir"});
     for (const auto& provider_option : provider_options) {
       const std::string& key = provider_option.first;
@@ -388,6 +388,7 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
       } else if (key == "enable_htp_fp16_precision" ||
                  key == "offload_graph_io_quantization" ||
                  key == "enable_htp_spill_fill_buffer" ||
+                 key == "enable_ssr_handling" ||
                  key == "enable_htp_shared_memory_allocator" ||
                  key == "dump_json_qnn_graph") {
         std::set<std::string> supported_options = {"0", "1"};

--- a/onnxruntime/test/providers/qnn/ssr/qnn_mock_ssr.cc
+++ b/onnxruntime/test/providers/qnn/ssr/qnn_mock_ssr.cc
@@ -1,0 +1,265 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <cassert>
+#include <vector>
+#include <thread>
+#include "QnnCommon.h"
+#include "QnnInterface.h"
+#include "qnn_mock_ssr_controller.h"
+#include "rpcmem_utils.h"
+
+extern "C" QnnMockSSRController* GetQnnMockSSRController() { return &QnnMockSSRController::Instance(); }
+
+const QnnInterface_t** real_providerList{nullptr};
+uint32_t real_numProviders{0};
+
+namespace {
+#if defined(_WIN32)
+// Register a free_qnn_htp_fn to ensure we release QnnHtp.dll before
+// destructing QnnMockSSR.dll
+auto free_qnn_htp_fn = [](HMODULE m) {
+  if (m) FreeLibrary(m);
+};
+
+std::unique_ptr<std::remove_pointer_t<HMODULE>, decltype(free_qnn_htp_fn)> qnn_htp(
+    LoadLibraryW(L"QnnHtp.dll"), free_qnn_htp_fn);
+
+FARPROC addr = GetProcAddress(qnn_htp.get(), "QnnInterface_getProviders");
+typedef Qnn_ErrorHandle_t (*QnnApiFnType_t)(const QnnInterface_t***, uint32_t*);
+QnnApiFnType_t real_QnnInterface_getProviders = reinterpret_cast<QnnApiFnType_t>(addr);
+auto res = real_QnnInterface_getProviders((const QnnInterface_t***)&real_providerList, &real_numProviders);
+#endif  // defined(_WIN32)
+}  // namespace
+
+#if defined(_WIN32)
+
+QNN_API
+Qnn_ErrorHandle_t QnnGraph_create(Qnn_ContextHandle_t contextHandle,
+                                  const char* graphName,
+                                  const QnnGraph_Config_t** config,
+                                  Qnn_GraphHandle_t* graphHandle) {
+  static int call_cnt = 0;
+  if (call_cnt == 0) {
+    call_cnt += 1;
+    onnxruntime::test::TriggerPDReset();
+    std::this_thread::sleep_for(std::chrono::milliseconds(3000));
+  }
+  return real_providerList[0]->QNN_INTERFACE_VER_NAME.graphCreate(contextHandle, graphName, config, graphHandle);
+}
+
+QNN_API
+Qnn_ErrorHandle_t QnnBackend_getBuildId(const char** id) {
+  static int call_cnt = 0;
+  if (call_cnt == 0) {
+    call_cnt += 1;
+    onnxruntime::test::TriggerPDReset();
+    std::this_thread::sleep_for(std::chrono::milliseconds(3000));
+  }
+  return real_providerList[0]->QNN_INTERFACE_VER_NAME.backendGetBuildId(id);
+}
+
+QNN_API
+Qnn_ErrorHandle_t QnnLog_create(QnnLog_Callback_t callback,
+                                QnnLog_Level_t maxLogLevel,
+                                Qnn_LogHandle_t* logger) {
+  static int call_cnt = 0;
+  if (call_cnt == 0) {
+    call_cnt += 1;
+    onnxruntime::test::TriggerPDReset();
+    std::this_thread::sleep_for(std::chrono::milliseconds(3000));
+  }
+  return real_providerList[0]->QNN_INTERFACE_VER_NAME.logCreate(callback, maxLogLevel, logger);
+}
+
+QNN_API
+Qnn_ErrorHandle_t QnnBackend_create(Qnn_LogHandle_t logHandle,
+                                    const QnnBackend_Config_t** config,
+                                    Qnn_BackendHandle_t* backend) {
+  static int call_cnt = 0;
+  if (call_cnt == 0) {
+    call_cnt += 1;
+    onnxruntime::test::TriggerPDReset();
+    std::this_thread::sleep_for(std::chrono::milliseconds(3000));
+  }
+  return real_providerList[0]->QNN_INTERFACE_VER_NAME.backendCreate(logHandle, config, backend);
+}
+
+QNN_API
+Qnn_ErrorHandle_t QnnContext_create(Qnn_BackendHandle_t backend,
+                                    Qnn_DeviceHandle_t device,
+                                    const QnnContext_Config_t** config,
+                                    Qnn_ContextHandle_t* context) {
+  static int call_cnt = 0;
+  if (call_cnt == 0) {
+    call_cnt += 1;
+    onnxruntime::test::TriggerPDReset();
+    std::this_thread::sleep_for(std::chrono::milliseconds(3000));
+  }
+  return real_providerList[0]->QNN_INTERFACE_VER_NAME.contextCreate(backend, device, config, context);
+}
+
+QNN_API
+Qnn_ErrorHandle_t QnnBackend_validateOpConfig(Qnn_BackendHandle_t backend,
+                                              Qnn_OpConfig_t opConfig) {
+  static int call_cnt = 0;
+  if (call_cnt == 0) {
+    call_cnt += 1;
+    onnxruntime::test::TriggerPDReset();
+    std::this_thread::sleep_for(std::chrono::milliseconds(3000));
+  }
+  return real_providerList[0]->QNN_INTERFACE_VER_NAME.backendValidateOpConfig(backend, opConfig);
+}
+
+QNN_API
+Qnn_ErrorHandle_t QnnGraph_addNode(Qnn_GraphHandle_t graph, Qnn_OpConfig_t opConfig) {
+  static int call_cnt = 0;
+  if (call_cnt == 0) {
+    call_cnt += 1;
+    onnxruntime::test::TriggerPDReset();
+    std::this_thread::sleep_for(std::chrono::milliseconds(3000));
+  }
+  return real_providerList[0]->QNN_INTERFACE_VER_NAME.graphAddNode(
+      graph, opConfig);
+}
+
+QNN_API
+Qnn_ErrorHandle_t QnnTensor_createGraphTensor(Qnn_GraphHandle_t graph, Qnn_Tensor_t* tensor) {
+  static int call_cnt = 0;
+  if (call_cnt == 0) {
+    call_cnt += 1;
+    onnxruntime::test::TriggerPDReset();
+    std::this_thread::sleep_for(std::chrono::milliseconds(3000));
+  }
+  return real_providerList[0]->QNN_INTERFACE_VER_NAME.tensorCreateGraphTensor(graph, tensor);
+}
+
+QNN_API
+Qnn_ErrorHandle_t QnnGraph_retrieve(Qnn_ContextHandle_t contextHandle,
+                                    const char* graphName,
+                                    Qnn_GraphHandle_t* graphHandle) {
+  static int call_cnt = 0;
+  if (call_cnt == 0) {
+    call_cnt += 1;
+    onnxruntime::test::TriggerPDReset();
+    std::this_thread::sleep_for(std::chrono::milliseconds(3000));
+  }
+  return real_providerList[0]->QNN_INTERFACE_VER_NAME.graphRetrieve(contextHandle, graphName, graphHandle);
+}
+
+QNN_API
+Qnn_ErrorHandle_t QnnGraph_finalize(Qnn_GraphHandle_t graph,
+                                    Qnn_ProfileHandle_t profileHandle,
+                                    Qnn_SignalHandle_t signalHandle) {
+  static int call_cnt = 0;
+  if (call_cnt == 0) {
+    call_cnt += 1;
+    onnxruntime::test::TriggerPDReset();
+    std::this_thread::sleep_for(std::chrono::milliseconds(3000));
+  }
+  return real_providerList[0]->QNN_INTERFACE_VER_NAME.graphFinalize(graph, profileHandle, signalHandle);
+}
+
+QNN_API
+Qnn_ErrorHandle_t QnnContext_getBinarySize(Qnn_ContextHandle_t context,
+                                           Qnn_ContextBinarySize_t* binaryBufferSize) {
+  static int call_cnt = 0;
+  if (call_cnt == 0) {
+    call_cnt += 1;
+    onnxruntime::test::TriggerPDReset();
+    std::this_thread::sleep_for(std::chrono::milliseconds(3000));
+  }
+  return real_providerList[0]->QNN_INTERFACE_VER_NAME.contextGetBinarySize(context, binaryBufferSize);
+}
+
+QNN_API
+Qnn_ErrorHandle_t QnnContext_getBinary(Qnn_ContextHandle_t context,
+                                       void* binaryBuffer,
+                                       Qnn_ContextBinarySize_t binaryBufferSize,
+                                       Qnn_ContextBinarySize_t* writtenBufferSize) {
+  static int call_cnt = 0;
+  if (call_cnt == 0) {
+    call_cnt += 1;
+    onnxruntime::test::TriggerPDReset();
+    std::this_thread::sleep_for(std::chrono::milliseconds(3000));
+  }
+  return real_providerList[0]->QNN_INTERFACE_VER_NAME.contextGetBinary(
+      context, binaryBuffer, binaryBufferSize, writtenBufferSize);
+}
+
+QNN_API
+Qnn_ErrorHandle_t QnnGraph_execute(Qnn_GraphHandle_t graphHandle,
+                                   const Qnn_Tensor_t* inputs,
+                                   uint32_t numInputs,
+                                   Qnn_Tensor_t* outputs,
+                                   uint32_t numOutputs,
+                                   Qnn_ProfileHandle_t profileHandle,
+                                   Qnn_SignalHandle_t signalHandle) {
+  static int call_cnt = 0;
+  if (call_cnt == 0) {
+    call_cnt += 1;
+    onnxruntime::test::TriggerPDReset();
+    std::this_thread::sleep_for(std::chrono::milliseconds(3000));
+  }
+  return real_providerList[0]->QNN_INTERFACE_VER_NAME.graphExecute(graphHandle,
+                                                                   inputs, numInputs, outputs, numOutputs, profileHandle, signalHandle);
+}
+#endif  // defined(_WIN32)
+
+extern "C" Qnn_ErrorHandle_t QnnInterface_getProviders(const QnnInterface_t*** providerList,
+                                                       uint32_t* numProviders) {
+  static QnnInterface_t interface;
+  interface.backendId = 0;
+  interface.providerName = "MockSSR";
+#if defined(_WIN32)
+  interface.apiVersion = real_providerList[0]->apiVersion;
+  interface.QNN_INTERFACE_VER_NAME = real_providerList[0]->QNN_INTERFACE_VER_NAME;
+  switch (QnnMockSSRController::Instance().GetTiming()) {
+    case QnnMockSSRController::Timing::BackendGetBuildId:
+      interface.QNN_INTERFACE_VER_NAME.backendGetBuildId = QnnBackend_getBuildId;
+      break;
+    case QnnMockSSRController::Timing::BackendCreate:
+      interface.QNN_INTERFACE_VER_NAME.backendCreate = QnnBackend_create;
+      break;
+    case QnnMockSSRController::Timing::ContextCreate:
+      interface.QNN_INTERFACE_VER_NAME.contextCreate = QnnContext_create;
+      break;
+    case QnnMockSSRController::Timing::BackendValidateOpConfig:
+      interface.QNN_INTERFACE_VER_NAME.backendValidateOpConfig = QnnBackend_validateOpConfig;
+      break;
+    case QnnMockSSRController::Timing::LogCreate:
+      interface.QNN_INTERFACE_VER_NAME.logCreate = QnnLog_create;
+      break;
+    case QnnMockSSRController::Timing::ContextGetBinarySize:
+      interface.QNN_INTERFACE_VER_NAME.contextGetBinarySize = QnnContext_getBinarySize;
+      break;
+    case QnnMockSSRController::Timing::ContextGetBinary:
+      interface.QNN_INTERFACE_VER_NAME.contextGetBinary = QnnContext_getBinary;
+      break;
+    case QnnMockSSRController::Timing::TensorCreateGraphTensor:
+      interface.QNN_INTERFACE_VER_NAME.tensorCreateGraphTensor = QnnTensor_createGraphTensor;
+      break;
+    case QnnMockSSRController::Timing::GraphCreate:
+      interface.QNN_INTERFACE_VER_NAME.graphCreate = QnnGraph_create;
+      break;
+    case QnnMockSSRController::Timing::GraphRetrieve:
+      interface.QNN_INTERFACE_VER_NAME.graphRetrieve = QnnGraph_retrieve;
+      break;
+    case QnnMockSSRController::Timing::GraphAddNode:
+      interface.QNN_INTERFACE_VER_NAME.graphAddNode = QnnGraph_addNode;
+      break;
+    case QnnMockSSRController::Timing::GraphFinalize:
+      interface.QNN_INTERFACE_VER_NAME.graphFinalize = QnnGraph_finalize;
+      break;
+    case QnnMockSSRController::Timing::GraphExecute:
+      interface.QNN_INTERFACE_VER_NAME.graphExecute = QnnGraph_execute;
+      break;
+    default:
+      break;
+  }
+#endif  // defined(_WIN32)
+  static std::vector<const QnnInterface_t*> m_providerPtrs = {&interface};
+  *providerList = m_providerPtrs.data(),
+  *numProviders = 1;
+  return QNN_SUCCESS;
+}

--- a/onnxruntime/test/providers/qnn/ssr/qnn_mock_ssr.def
+++ b/onnxruntime/test/providers/qnn/ssr/qnn_mock_ssr.def
@@ -1,0 +1,4 @@
+LIBRARY QnnMockSSR
+EXPORTS
+    QnnInterface_getProviders
+    GetQnnMockSSRController

--- a/onnxruntime/test/providers/qnn/ssr/qnn_mock_ssr_controller.h
+++ b/onnxruntime/test/providers/qnn/ssr/qnn_mock_ssr_controller.h
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+class QnnMockSSRController {
+ public:
+  enum class Timing {
+    BackendGetBuildId,
+    LogCreate,
+    BackendCreate,
+    ContextCreate,
+    BackendValidateOpConfig,
+    GraphCreate,
+    GraphRetrieve,
+    TensorCreateGraphTensor,
+    GraphAddNode,
+    GraphFinalize,
+    ContextGetBinarySize,
+    ContextGetBinary,
+    GraphExecute
+  };
+
+  static QnnMockSSRController& Instance() {
+    static QnnMockSSRController instance;
+    return instance;
+  }
+
+  void SetTiming(Timing timing) {
+    timing_ = timing;
+  }
+
+  Timing GetTiming() const {
+    return timing_;
+  }
+
+ private:
+  QnnMockSSRController() : timing_(Timing::GraphExecute) {};
+  QnnMockSSRController(const QnnMockSSRController&) = delete;
+  QnnMockSSRController& operator=(const QnnMockSSRController&) = delete;
+
+  // The timing to trigger SSR. Default to triggering SSR at graphExecute
+  Timing timing_ = Timing::GraphExecute;
+};

--- a/onnxruntime/test/providers/qnn/ssr/rpcmem_utils.h
+++ b/onnxruntime/test/providers/qnn/ssr/rpcmem_utils.h
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License
+
+#include <filesystem>
+#include "core/common/common.h"
+#include "core/common/path_string.h"
+#include "core/common/status.h"
+#include "test/util/include/test/test_environment.h"
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+namespace onnxruntime {
+namespace test {
+#if defined(_WIN32)
+
+Status ReadEnvironmentVariable(const wchar_t* name, std::wstring& value_out) {
+  const DWORD value_size = ::GetEnvironmentVariableW(name, nullptr, 0);
+  ORT_RETURN_IF(value_size == 0,
+                "Failed to get environment variable length. GetEnvironmentVariableW error: ", ::GetLastError());
+
+  std::vector<wchar_t> value(value_size);
+
+  ORT_RETURN_IF(::GetEnvironmentVariableW(name, value.data(), value_size) == 0,
+                "Failed to get environment variable value. GetEnvironmentVariableW error: ", ::GetLastError());
+
+  value_out = std::wstring{value.data()};
+  return Status::OK();
+}
+
+Status GetServiceBinaryDirectoryPath(const wchar_t* service_name,
+                                     std::filesystem::path& service_binary_directory_path_out) {
+  struct ServiceHandleDeleter {
+    void operator()(SC_HANDLE handle) { ::CloseServiceHandle(handle); }
+  };
+
+  using UniqueServiceHandle = std::unique_ptr<std::remove_pointer_t<SC_HANDLE>, ServiceHandleDeleter>;
+
+  SC_HANDLE scm_handle_raw = ::OpenSCManagerW(nullptr,  // local computer
+                                              nullptr,  // SERVICES_ACTIVE_DATABASE
+                                              STANDARD_RIGHTS_READ);
+  ORT_RETURN_IF(scm_handle_raw == nullptr,
+                "Failed to open handle to service control manager. OpenSCManagerW error: ", ::GetLastError());
+
+  auto scm_handle = UniqueServiceHandle{scm_handle_raw};
+
+  SC_HANDLE service_handle_raw = ::OpenServiceW(scm_handle.get(),
+                                                service_name,
+                                                SERVICE_QUERY_CONFIG);
+  ORT_RETURN_IF(service_handle_raw == nullptr,
+                "Failed to open service handle. OpenServiceW error: ", ::GetLastError());
+
+  auto service_handle = UniqueServiceHandle{service_handle_raw};
+
+  // get service config required buffer size
+  DWORD service_config_buffer_size{};
+  ORT_RETURN_IF(!::QueryServiceConfigW(service_handle.get(), nullptr, 0, &service_config_buffer_size) &&
+                    ::GetLastError() != ERROR_INSUFFICIENT_BUFFER,
+                "Failed to query service configuration buffer size. QueryServiceConfigW error: ", ::GetLastError());
+
+  // get the service config
+  std::vector<std::byte> service_config_buffer(service_config_buffer_size);
+  QUERY_SERVICE_CONFIGW* service_config = reinterpret_cast<QUERY_SERVICE_CONFIGW*>(service_config_buffer.data());
+  ORT_RETURN_IF(!::QueryServiceConfigW(service_handle.get(), service_config, service_config_buffer_size,
+                                       &service_config_buffer_size),
+                "Failed to query service configuration. QueryServiceConfigW error: ", ::GetLastError());
+
+  std::wstring service_binary_path_name = service_config->lpBinaryPathName;
+
+  // replace system root placeholder with the value of the SYSTEMROOT environment variable
+  const std::wstring system_root_placeholder = L"\\SystemRoot";
+
+  ORT_RETURN_IF(service_binary_path_name.find(system_root_placeholder, 0) != 0,
+                "Service binary path '", ToUTF8String(service_binary_path_name),
+                "' does not start with expected system root placeholder value '",
+                ToUTF8String(system_root_placeholder), "'.");
+
+  std::wstring system_root{};
+  ORT_RETURN_IF_ERROR(ReadEnvironmentVariable(L"SYSTEMROOT", system_root));
+  service_binary_path_name.replace(0, system_root_placeholder.size(), system_root);
+
+  const auto service_binary_path = std::filesystem::path{service_binary_path_name};
+  auto service_binary_directory_path = service_binary_path.parent_path();
+
+  ORT_RETURN_IF(!std::filesystem::exists(service_binary_directory_path),
+                "Service binary directory path does not exist: ", service_binary_directory_path.string());
+
+  service_binary_directory_path_out = std::move(service_binary_directory_path);
+  return Status::OK();
+}
+
+#endif  // defined(_WIN32)
+
+Status GetRpcMemDynamicLibraryPath(PathString& path_out) {
+#if defined(_WIN32)
+
+  std::filesystem::path qcnspmcdm_dir_path{};
+  ORT_RETURN_IF_ERROR(GetServiceBinaryDirectoryPath(L"qcnspmcdm", qcnspmcdm_dir_path));
+  const auto libcdsprpc_path = qcnspmcdm_dir_path / L"libcdsprpc.dll";
+  path_out = libcdsprpc_path.wstring();
+  return Status::OK();
+
+#else  // ^^^ defined(_WIN32) / vvv !defined(_WIN32)
+
+  path_out = ORT_TSTR("libcdsprpc.so");
+  return Status::OK();
+
+#endif  // !defined(_WIN32)
+}
+
+void TriggerPDReset() {
+#if defined(_WIN32)
+  onnxruntime::PathString rpcmem_library_path{};
+  Status res = GetRpcMemDynamicLibraryPath(rpcmem_library_path);
+  HMODULE lib_handle = LoadLibraryW(rpcmem_library_path.c_str());
+  if (!lib_handle) {
+    return;  // Failed to load library
+  }
+  typedef int (*RscFnHandleType_t)(uint32_t, void*, uint32_t);
+  FARPROC addr = GetProcAddress(lib_handle, "remote_session_control");
+  if (!addr) {
+    FreeLibrary(lib_handle);
+    return;  // Failed to get procedure address
+  }
+  RscFnHandleType_t rsc_call = reinterpret_cast<RscFnHandleType_t>(addr);
+  typedef struct {
+    int domain;
+  } remote_rpc_process_clean_params;
+  remote_rpc_process_clean_params scdata;
+  scdata.domain = 3; /*CDSP_DOMAIN_ID*/
+  rsc_call(/*FASTRPC_REMOTE_PROCESS_KILL*/ 6, &scdata, sizeof(remote_rpc_process_clean_params));
+  if (lib_handle) {
+    FreeLibrary(lib_handle);
+  }
+  lib_handle = nullptr;
+#endif  // !defined(_WIN32)
+}
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/providers/qnn/ssr_test.cc
+++ b/onnxruntime/test/providers/qnn/ssr_test.cc
@@ -1,0 +1,205 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <string>
+#include "core/graph/graph.h"
+#include "core/graph/node_attr_utils.h"
+#include "core/session/inference_session.h"
+#include "core/framework/session_options.h"
+
+#include "test/providers/qnn/qnn_test_utils.h"
+
+#include "gtest/gtest.h"
+
+#include "ssr/qnn_mock_ssr_controller.h"
+
+namespace onnxruntime {
+namespace test {
+
+#if defined(_WIN32) && (defined(_M_ARM64) || defined(_M_ARM64EC))
+
+class QnnMockSSRBackendTests : public QnnHTPBackendTests {
+ protected:
+  void SetUp() override;
+  void TearDown() override;
+#if defined(_WIN32)
+  HMODULE lib_handle;
+  FARPROC addr;
+#endif  // defined(_WIN32)
+  QnnMockSSRController* controller = nullptr;
+  TestInputDef<float> input_def;
+  TestInputDef<float> scale_def;
+  TestInputDef<float> bias_def;
+  ProviderOptions provider_options;
+};
+
+void QnnMockSSRBackendTests::SetUp() {
+#if defined(_WIN32) && (defined(_M_ARM64) || defined(_M_ARM64EC))
+#include <windows.h>
+  QnnHTPBackendTests::SetUp();
+  lib_handle = LoadLibraryW(L"QnnMockSSR.dll");
+  ASSERT_NE(lib_handle, nullptr) << "Failed to load QnnMockSSR.dll";
+
+  typedef QnnMockSSRController* (*GetQnnMockSSRControllerFn_t)();
+  GetQnnMockSSRControllerFn_t GetQnnMockSSRController = reinterpret_cast<GetQnnMockSSRControllerFn_t>(
+      GetProcAddress(lib_handle, "GetQnnMockSSRController"));
+  ASSERT_NE(GetQnnMockSSRController, nullptr) << "Failed to get GetQnnMockSSRController function";
+
+  controller = GetQnnMockSSRController();
+  ASSERT_NE(controller, nullptr) << "GetQnnMockSSRController returned null";
+
+#endif  // defined(_WIN32) && (defined(_M_ARM64) || defined(_M_ARM64EC))
+  input_def = TestInputDef<float>({1, 2, 3, 3}, false, {-10.0f, 10.0f});
+  scale_def = TestInputDef<float>({2}, true, {1.0f, 2.0f});
+  bias_def = TestInputDef<float>({2}, true, {1.0f, 3.0f});
+  provider_options = {
+      {"backend_path", "QnnMockSSR.dll"},
+      {"offload_graph_io_quantization", "0"},
+      {"enable_ssr_handling", "1"},
+  };
+}
+
+void QnnMockSSRBackendTests::TearDown() {
+#if defined(_WIN32) && (defined(_M_ARM64) || defined(_M_ARM64EC))
+  if (lib_handle) {
+    FreeLibrary(lib_handle);
+  }
+#endif  // defined(_WIN32) && (defined(_M_ARM64) || defined(_M_ARM64EC))
+}
+
+TEST_F(QnnMockSSRBackendTests, SSRBackendGetBuildId) {
+  controller->SetTiming(QnnMockSSRController::Timing::BackendGetBuildId);
+  RunQnnModelTest(BuildOpTestCase<float>("InstanceNormalization",
+                                         {input_def, scale_def, bias_def}, {}, {}),
+                  provider_options,
+                  18,
+                  ExpectedEPNodeAssignment::All,
+                  5e-3f);
+}
+
+TEST_F(QnnMockSSRBackendTests, SSRBackendCreate) {
+  controller->SetTiming(QnnMockSSRController::Timing::BackendCreate);
+  RunQnnModelTest(BuildOpTestCase<float>("InstanceNormalization",
+                                         {input_def, scale_def, bias_def}, {}, {}),
+                  provider_options,
+                  18,
+                  ExpectedEPNodeAssignment::All,
+                  5e-3f);
+}
+
+TEST_F(QnnMockSSRBackendTests, SSRContextCreate) {
+  controller->SetTiming(QnnMockSSRController::Timing::ContextCreate);
+  RunQnnModelTest(BuildOpTestCase<float>("InstanceNormalization",
+                                         {input_def, scale_def, bias_def}, {}, {}),
+                  provider_options,
+                  18,
+                  ExpectedEPNodeAssignment::All,
+                  5e-3f);
+}
+
+TEST_F(QnnMockSSRBackendTests, DISABLED_SSRBackendValidateOpConfig) {
+  controller->SetTiming(QnnMockSSRController::Timing::BackendValidateOpConfig);
+  RunQnnModelTest(BuildOpTestCase<float>("InstanceNormalization",
+                                         {input_def, scale_def, bias_def}, {}, {}),
+                  provider_options,
+                  18,
+                  ExpectedEPNodeAssignment::All,
+                  5e-3f);
+}
+
+TEST_F(QnnMockSSRBackendTests, SSRLogCreate) {
+  controller->SetTiming(QnnMockSSRController::Timing::LogCreate);
+  RunQnnModelTest(BuildOpTestCase<float>("InstanceNormalization",
+                                         {input_def, scale_def, bias_def}, {}, {}),
+                  provider_options,
+                  18,
+                  ExpectedEPNodeAssignment::All,
+                  5e-3f);
+}
+
+TEST_F(QnnMockSSRBackendTests, SSRGraphCreate) {
+  controller->SetTiming(QnnMockSSRController::Timing::GraphCreate);
+  RunQnnModelTest(BuildOpTestCase<float>("InstanceNormalization",
+                                         {input_def, scale_def, bias_def}, {}, {}),
+                  provider_options,
+                  18,
+                  ExpectedEPNodeAssignment::All,
+                  5e-3f);
+}
+
+TEST_F(QnnMockSSRBackendTests, SSRGraphRetrieve) {
+  controller->SetTiming(QnnMockSSRController::Timing::GraphRetrieve);
+  RunQnnModelTest(BuildOpTestCase<float>("InstanceNormalization",
+                                         {input_def, scale_def, bias_def}, {}, {}),
+                  provider_options,
+                  18,
+                  ExpectedEPNodeAssignment::All,
+                  5e-3f);
+}
+
+TEST_F(QnnMockSSRBackendTests, SSRContextGetBinarySize) {
+  controller->SetTiming(QnnMockSSRController::Timing::ContextGetBinarySize);
+  RunQnnModelTest(BuildOpTestCase<float>("InstanceNormalization",
+                                         {input_def, scale_def, bias_def}, {}, {}),
+                  provider_options,
+                  18,
+                  ExpectedEPNodeAssignment::All,
+                  5e-3f);
+}
+
+TEST_F(QnnMockSSRBackendTests, SSRContextGetBinary) {
+  controller->SetTiming(QnnMockSSRController::Timing::ContextGetBinary);
+  RunQnnModelTest(BuildOpTestCase<float>("InstanceNormalization",
+                                         {input_def, scale_def, bias_def}, {}, {}),
+                  provider_options,
+                  18,
+                  ExpectedEPNodeAssignment::All,
+                  5e-3f);
+}
+
+TEST_F(QnnMockSSRBackendTests, SSRTensorCreateGraphTensor) {
+  controller->SetTiming(QnnMockSSRController::Timing::TensorCreateGraphTensor);
+  RunQnnModelTest(BuildOpTestCase<float>("InstanceNormalization",
+                                         {input_def, scale_def, bias_def}, {}, {}),
+                  provider_options,
+                  18,
+                  ExpectedEPNodeAssignment::All,
+                  5e-3f);
+}
+
+TEST_F(QnnMockSSRBackendTests, SSRGraphAddNode) {
+  controller->SetTiming(QnnMockSSRController::Timing::GraphAddNode);
+  RunQnnModelTest(BuildOpTestCase<float>("InstanceNormalization",
+                                         {input_def, scale_def, bias_def}, {}, {}),
+                  provider_options,
+                  18,
+                  ExpectedEPNodeAssignment::All,
+                  5e-3f);
+}
+
+TEST_F(QnnMockSSRBackendTests, SSRGraphFinalize) {
+  controller->SetTiming(QnnMockSSRController::Timing::GraphFinalize);
+  RunQnnModelTest(BuildOpTestCase<float>("InstanceNormalization",
+                                         {input_def, scale_def, bias_def}, {}, {}),
+                  provider_options,
+                  18,
+                  ExpectedEPNodeAssignment::All,
+                  5e-3f);
+}
+
+TEST_F(QnnMockSSRBackendTests, SSRGraphExecute) {
+  controller->SetTiming(QnnMockSSRController::Timing::GraphExecute);
+  RunQnnModelTest(BuildOpTestCase<float>("InstanceNormalization",
+                                         {input_def, scale_def, bias_def}, {}, {}),
+                  provider_options,
+                  18,
+                  ExpectedEPNodeAssignment::All,
+                  5e-3f);
+}
+#endif  // defined(__aarch64__) || defined(_M_ARM64)
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Introduced a new provider option: `enable_ssr_handling`
- Handle SSR before graphFinalize
    - `SetupBackend`: Re-run SetupBackend to re-create context as
    - `CompileFromOrtGraph`: Release invalid Context API objects and re-create Graph and Context
- Handle SSR after graphFinalize
    - `ExecuteGraph`: Release invalid Context, load the Context from the pre-saved binary and re-execute the graph
- Minor fix to function return values to propagate SSR-specific error codes
- Add test framework of QNNEP SSR Handling
    - Introduce `QnnMockSSR.dll`, which mimics the functionality of `QnnHtp.dll` but consistently triggers SSR to validate QNNEP behavior

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- QNN APIs support SSR by allowing users to release and recreate specific handles when a subsystem restart occurs.
- This PR enhances ORT's robustness by enabling it to handle SSR scenarios gracefully.
- It also introduces a mock implementation to facilitate testing and validation of SSR handling across different stages of the QNN workflow.

