### PR TITLE
bug fix for qnn nuget windows pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/stages/set_packaging_variables_stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/set_packaging_variables_stage.yml
@@ -35,7 +35,6 @@ stages:
         targetPath: $(Build.ArtifactStagingDirectory)
         artifactName: 'parameters_artifact'
     steps:
-    - checkout: none
     - bash: |
         # Do not output ##vso[] commands with `set -x` or they may be parsed again and include a trailing quote.
         set +x


### PR DESCRIPTION
pipeline is complaining that is cannot find `tsaconfig.json` file because it is not checking out the code

test: https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=991866&view=results