### PR TITLE
Add EP-specific weight layout transformation framework

### DIFF
--- a/include/onnxruntime/core/framework/execution_provider.h
+++ b/include/onnxruntime/core/framework/execution_provider.h
@@ -378,6 +378,39 @@ class IExecutionProvider {
     return std::nullopt;
   }
 
+  /**
+    Query the preferred format descriptor for an initializer without performing the transformation.
+    This is a lightweight query called during session initialization to determine what format
+    transformations are needed.
+
+    @param node The node that consumes the initializer
+    @param input_index The input index of the initializer in the node
+    @param[out] format_descriptor A string that uniquely identifies the preferred format.
+                                  Empty string means no transformation is needed.
+                                  Examples: "ABcd16a4b", "hwio".
+    @return Status::OK() if query succeeded (format_descriptor will be set).
+            Failed status indicates no transformation is needed.
+  */
+  virtual Status GetPreferredInitializerFormat(const Node& /*node*/, int /*input_index*/,
+                                               std::string& /*format_descriptor*/) const {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "No format transformation needed");
+  }
+
+  /**
+    Transform an initializer to the specified format.
+    This performs the actual data transformation. It is only called once per unique format
+    even if multiple nodes need the same format.
+
+    @param original_tensor The original initializer tensor
+    @param format_descriptor The target format (from GetPreferredInitializerFormat)
+    @param[out] transformed_tensor The EP should allocate and fill this with the transformed data.
+    @return Status::OK() if transformation succeeded.
+  */
+  virtual Status TransformInitializerFormat(const Tensor& /*original_tensor*/, const std::string& /*format_descriptor*/,
+                                            std::unique_ptr<Tensor>& /*transformed_tensor*/) const {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Format transformation not supported");
+  }
+
   virtual void RegisterStreamHandlers(IStreamCommandHandleRegistry& /*stream_handle_registry*/, AllocatorMap&) const {}
 
   /** Does the EP support concurrent calls to InferenceSession::Run to execute the model.

--- a/include/onnxruntime/core/framework/tensor.h
+++ b/include/onnxruntime/core/framework/tensor.h
@@ -282,6 +282,19 @@ class Tensor final {
     byte_offset_ = byte_offset;
   }
 
+  /**
+   * Get the memory format descriptor for this tensor.
+   * Returns empty string if the tensor is in standard format.
+   */
+  inline const std::string& GetFormatDescriptor() const { return format_descriptor_; }
+
+  /**
+   * Set the memory format descriptor for this tensor.
+   * Used for EP-specific memory layouts (e.g., "ABcd16a4b" for blocked format).
+   * The format string encodes all necessary information including block sizes.
+   */
+  inline void SetFormatDescriptor(const std::string& format) { format_descriptor_ = format; }
+
   /// <summary>
   /// The number of Tensor "storage" elements. A single storage element may contain multiple sub-elements for
   /// sub-byte data types (e.g., int4/float4).
@@ -349,6 +362,9 @@ class Tensor final {
   const PrimitiveDataTypeBase* dtype_;
   OrtMemoryInfo alloc_info_;
   ptrdiff_t byte_offset_;
+
+  // Memory format descriptor for EP-specific layouts (e.g., "ABcd16a4b")
+  std::string format_descriptor_;
 };
 #ifdef __GNUC__
 #pragma GCC diagnostic pop

--- a/onnxruntime/core/framework/session_state.h
+++ b/onnxruntime/core/framework/session_state.h
@@ -431,6 +431,12 @@ class SessionState {
                                   const InlinedHashMap<OrtValueName, OrtDevice>& outer_scope_node_arg_to_location_map = {},
                                   bool graph_info_already_created = false);
 
+  /**
+   * Transform initializer tensors to EP-preferred memory formats.
+   * This is called during session initialization before kernel creation.
+   */
+  Status TransformInitializersToPreferredFormat();
+
 #ifdef ENABLE_TRAINING
   Status GeneratePatternGroupCache(
       gsl::span<const OrtValue> inputs,

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -227,6 +227,11 @@ common::Status CopyTensorFromCPUToDevice(
     }
     return copy_status;
   } else {
+    // Preserve format descriptor when copying from CPU to device
+    const std::string& format = deserialized_tensor.GetFormatDescriptor();
+    if (!format.empty()) {
+      tensor.SetFormatDescriptor(format);
+    }
     Tensor::InitOrtValue(std::move(tensor), ort_value);
     return common::Status::OK();
   }

--- a/onnxruntime/core/framework/tensor.cc
+++ b/onnxruntime/core/framework/tensor.cc
@@ -195,7 +195,8 @@ Tensor::Tensor(Tensor&& other) noexcept
 #endif
       dtype_(other.dtype_),
       alloc_info_(other.alloc_info_),
-      byte_offset_(other.byte_offset_) {
+      byte_offset_(other.byte_offset_),
+      format_descriptor_(std::move(other.format_descriptor_)) {
   other.p_data_ = nullptr;
   other.buffer_deleter_ = nullptr;
   other.dtype_ = DataTypeImpl::GetType<float>()->AsPrimitiveDataType();
@@ -221,6 +222,7 @@ Tensor& Tensor::operator=(Tensor&& other) noexcept {
     dtype_ = other.dtype_;
     alloc_info_ = other.alloc_info_;
     byte_offset_ = other.byte_offset_;
+    format_descriptor_ = std::move(other.format_descriptor_);
 
     other.p_data_ = nullptr;
     other.buffer_deleter_ = nullptr;

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -1424,6 +1424,15 @@ Status TensorProtoToTensor(const Env& env, const std::filesystem::path& model_pa
     }
   }
 
+  // Read format metadata from TensorProto string_data
+  for (const auto& attr_str : tensor_proto.string_data()) {
+    if (attr_str.find("onnxruntime_format:") == 0) {
+      std::string format = attr_str.substr(19);  // Skip "onnxruntime_format:"
+      tensor.SetFormatDescriptor(format);
+      break;  // Only one format descriptor expected
+    }
+  }
+
   return Status::OK();
 }
 

--- a/onnxruntime/core/providers/webgpu/nn/conv.h
+++ b/onnxruntime/core/providers/webgpu/nn/conv.h
@@ -28,6 +28,10 @@ class Conv : public WebGpuKernel {
   Activation activation_;
 };
 
+// Get the preferred kernel format for Conv operator
+// Returns format descriptor string (e.g., "hwio", "ABcd16a4b"), or empty string if no transformation needed
+Status ConvGetPreferredKernelFormat(const Node& node, int input_index, std::string& format_descriptor);
+
 Status TransposeKernel(ComputeContext& context, const Tensor* kernel, const TensorShape& kernel_shape, Tensor* transposed_kernel, const InlinedVector<size_t>& perm);
 
 }  // namespace webgpu

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.h
@@ -64,6 +64,12 @@ class WebGpuExecutionProvider : public IExecutionProvider {
                                                    std::string_view node_op_type,
                                                    DataLayout target_data_layout) const override;
 
+  Status GetPreferredInitializerFormat(const Node& node, int input_index,
+                                       std::string& format_descriptor) const override;
+
+  Status TransformInitializerFormat(const Tensor& original_tensor, const std::string& format_descriptor,
+                                    std::unique_ptr<Tensor>& transformed_tensor) const override;
+
   FusionStyle GetFusionStyle() const override { return FusionStyle::FilteredGraphViewer; }
 
   // WebGPU EP disallow concurrent run because actual implementation (eg. WebGPU backend) relies on global states to

--- a/onnxruntime/core/providers/webgpu/weight_layout_transformer.cc
+++ b/onnxruntime/core/providers/webgpu/weight_layout_transformer.cc
@@ -1,0 +1,181 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/webgpu/weight_layout_transformer.h"
+#include "core/framework/allocator.h"
+#include "core/framework/data_types.h"
+#include "core/framework/tensorprotoutils.h"
+#include <cstring>
+
+namespace onnxruntime {
+namespace webgpu {
+
+// Template helper function to transpose weights from oihw to hwio layout
+template <typename T>
+void WeightLayoutTransformer::TransposeOIHWToHWIO(const T* src, T* dst,
+                                                  int64_t O, int64_t I, int64_t H, int64_t W) {
+  // Transpose from oihw to hwio
+  // Source layout: [O][I][H][W]
+  // Destination layout: [H][W][I][O]
+  // Permutation: {2, 3, 1, 0}
+
+  for (int64_t o = 0; o < O; ++o) {
+    for (int64_t i = 0; i < I; ++i) {
+      for (int64_t h = 0; h < H; ++h) {
+        for (int64_t w = 0; w < W; ++w) {
+          // Source index: oihw
+          const size_t src_idx = ((o * I + i) * H + h) * W + w;
+
+          // Destination index: hwio
+          const size_t dst_idx = ((h * W + w) * I + i) * O + o;
+
+          dst[dst_idx] = src[src_idx];
+        }
+      }
+    }
+  }
+}
+
+// Template helper function to reorder weights from oihw to ABcd16a4b blocked format
+template <typename T>
+void WeightLayoutTransformer::ReorderToBlockedFormat(const T* src, T* dst,
+                                                     int64_t O, int64_t I, int64_t H, int64_t W,
+                                                     int64_t O_blocks, int64_t I_blocks,
+                                                     int64_t block_o, int64_t block_i) {
+  // Reorder from oihw to ABcd16a4b
+  // Source layout: [O][I][H][W]
+  // Destination layout: [O_blocks][I_blocks][H][W][block_o][block_i]
+  //
+  // Destination strides:
+  // - O_blocks: I_blocks * H * W * block_o * block_i
+  // - I_blocks: H * W * block_o * block_i
+  // - H: W * block_o * block_i
+  // - W: block_o * block_i
+  // - block_o: block_i
+  // - block_i: 1
+
+  for (int64_t ob = 0; ob < O_blocks; ++ob) {
+    for (int64_t ib = 0; ib < I_blocks; ++ib) {
+      for (int64_t h = 0; h < H; ++h) {
+        for (int64_t w = 0; w < W; ++w) {
+          for (int64_t o_in_block = 0; o_in_block < block_o; ++o_in_block) {
+            for (int64_t i_in_block = 0; i_in_block < block_i; ++i_in_block) {
+              const int64_t o = ob * block_o + o_in_block;
+              const int64_t i = ib * block_i + i_in_block;
+
+              // Calculate destination index for ABcd16a4b layout
+              const size_t dst_idx =
+                  ob * (I_blocks * H * W * block_o * block_i) +
+                  ib * (H * W * block_o * block_i) +
+                  h * (W * block_o * block_i) +
+                  w * (block_o * block_i) +
+                  o_in_block * block_i +
+                  i_in_block;
+
+              // Only copy if within original dimensions (handle padding)
+              if (o < O && i < I) {
+                // Source index: oihw format
+                const size_t src_idx = ((o * I + i) * H + h) * W + w;
+                dst[dst_idx] = src[src_idx];
+              }
+              // For padding (o >= O or i >= I), dst is already zero-initialized
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+Status WeightLayoutTransformer::TransformLayout(const Tensor& original_tensor,
+                                                const std::string& format_descriptor,
+                                                std::unique_ptr<Tensor>& transformed_tensor) {
+  const auto& orig_shape = original_tensor.Shape();
+  const auto* elem_type = original_tensor.DataType();
+
+  // Only support 4D tensors
+  if (orig_shape.NumDimensions() != 4) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Unsupported format transformation: ", format_descriptor);
+  }
+
+  // Validate tensor location (common for all formats)
+  if (original_tensor.Location().device.Type() != OrtDevice::CPU) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                           "Tensor is not on CPU, device type: ", original_tensor.Location().device.Type());
+  }
+
+  const int64_t O = orig_shape[0];
+  const int64_t I = orig_shape[1];
+  const int64_t H = orig_shape[2];
+  const int64_t W = orig_shape[3];
+
+  // Helper lambda to execute transformation for a specific data type
+  auto execute_transform = [&]<typename T>(auto&& transform_func, const TensorShape& new_shape,
+                                           size_t buffer_size = 0) -> Status {
+    const T* src = original_tensor.Data<T>();
+    if (!src) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Source tensor data pointer is null");
+    }
+
+    auto cpu_allocator = std::make_shared<CPUAllocator>();
+    transformed_tensor = std::make_unique<Tensor>(elem_type, new_shape, cpu_allocator);
+    T* dst = transformed_tensor->MutableData<T>();
+
+    // Zero-initialize if buffer size is specified (for blocked formats with padding)
+    if (buffer_size > 0) {
+      std::memset(dst, 0, buffer_size * sizeof(T));
+    }
+
+    transform_func(src, dst);
+    return Status::OK();
+  };
+
+  // Helper lambda to dispatch based on data type
+  auto dispatch_by_type = [&](auto&& transform_func, const TensorShape& new_shape,
+                              size_t buffer_size = 0, const char* error_msg = "Unsupported data type") -> Status {
+    if (elem_type == DataTypeImpl::GetType<float>()) {
+      return execute_transform.template operator()<float>(transform_func, new_shape, buffer_size);
+    } else if (elem_type == DataTypeImpl::GetType<MLFloat16>()) {
+      return execute_transform.template operator()<MLFloat16>(transform_func, new_shape, buffer_size);
+    } else {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, error_msg);
+    }
+  };
+
+  if (format_descriptor == "hwio") {
+    // Transpose from oihw to hwio
+    // Transposed shape: [H, W, I, O]
+    TensorShape new_shape({H, W, I, O});
+
+    auto transform_func = [&](auto* src, auto* dst) {
+      TransposeOIHWToHWIO(src, dst, O, I, H, W);
+    };
+
+    return dispatch_by_type(transform_func, new_shape, 0, "Unsupported data type for hwio transpose");
+  } else if (format_descriptor == "ABcd16a4b") {
+    // Reorder from oihw to blocked format
+    constexpr int64_t block_o = 16;
+    constexpr int64_t block_i = 4;
+
+    const int64_t O_padded = ((O + block_o - 1) / block_o) * block_o;
+    const int64_t I_padded = ((I + block_i - 1) / block_i) * block_i;
+    const int64_t O_blocks = O_padded / block_o;
+    const int64_t I_blocks = I_padded / block_i;
+
+    // Keep 4D shape for kernel compatibility, but data is in blocked format
+    // Shape: [O_padded, I_padded, H, W] with data internally blocked as ABcd16a4b
+    TensorShape new_shape({O_padded, I_padded, H, W});
+    const size_t buffer_size = O_blocks * I_blocks * H * W * block_o * block_i;
+
+    auto transform_func = [&](auto* src, auto* dst) {
+      ReorderToBlockedFormat(src, dst, O, I, H, W, O_blocks, I_blocks, block_o, block_i);
+    };
+
+    return dispatch_by_type(transform_func, new_shape, buffer_size, "Unsupported data type for blocked format");
+  }
+
+  return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Unsupported format transformation: ", format_descriptor);
+}
+
+}  // namespace webgpu
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/weight_layout_transformer.h
+++ b/onnxruntime/core/providers/webgpu/weight_layout_transformer.h
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/common/status.h"
+#include "core/framework/tensor.h"
+#include <memory>
+#include <string>
+
+namespace onnxruntime {
+namespace webgpu {
+
+// Weight layout transformer for optimized weight formats
+// Handles transformations like oihw->hwio transpose and blocked formats
+class WeightLayoutTransformer {
+ public:
+  // Transform a tensor to a different layout format
+  // format_descriptor: Format string (e.g., "hwio", "ABcd16a4b")
+  // Returns Status::OK() on success, error status otherwise
+  static Status TransformLayout(const Tensor& original_tensor,
+                                const std::string& format_descriptor,
+                                std::unique_ptr<Tensor>& transformed_tensor);
+
+ private:
+  // Transpose weights from oihw to hwio layout
+  template <typename T>
+  static void TransposeOIHWToHWIO(const T* src, T* dst,
+                                  int64_t O, int64_t I, int64_t H, int64_t W);
+
+  // Reorder weights from oihw to ABcd16a4b blocked format
+  template <typename T>
+  static void ReorderToBlockedFormat(const T* src, T* dst,
+                                     int64_t O, int64_t I, int64_t H, int64_t W,
+                                     int64_t O_blocks, int64_t I_blocks,
+                                     int64_t block_o, int64_t block_i);
+};
+
+}  // namespace webgpu
+}  // namespace onnxruntime


### PR DESCRIPTION
This infrastructure enables execution providers to optimize operator weights with custom memory layouts (such as blocked formats) during session initialization, dramatically improving inference performance through better cache utilization and memory access patterns.

Current Implementation:
- HWIO Transpose (WebGPU EP): Transposes Conv weights from OIHW to HWIO layout as the first application of the framework
- ABcd16a4b Blocking (Proof-of-Concept): OneDNN-style blocked format with 16×4 tiles demonstrates the framework's primary purpose

The framework is generic and extensible, allowing any EP to implement custom weight transformations optimized for their target hardware.