### PR TITLE
Adds automatic loading of the external `tensorrt_plugins` library in the TensorRT-RTX Execution Provider to support custom transformer plugins

### DIFF
--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_custom_ops.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_custom_ops.cc
@@ -67,6 +67,23 @@ common::Status CreateTensorRTCustomOpDomainList(std::vector<OrtCustomOpDomain*>&
     is_loaded = true;
   }
 
+  // Load external tensorrt_plugins library from EP directory (same location as nvinfer_plugin)
+  // This library contains GroupQueryAttention and RotaryEmbedding plugins for transformer models
+  try {
+    const auto& env = onnxruntime::GetDefaultEnv();
+    auto external_plugin_path = env.GetRuntimePath() +
+                                PathString(LIBRARY_PREFIX ORT_TSTR("tensorrt_plugins") LIBRARY_EXTENSION);
+    void* external_plugin_handle = nullptr;
+    auto status = env.LoadDynamicLibrary(external_plugin_path, false, &external_plugin_handle);
+    if (status.IsOK()) {
+      LOGS_DEFAULT(INFO) << "[NvTensorRTRTX EP] External plugins loaded: tensorrt_plugins (GQA + RotaryEmbedding)";
+    } else {
+      LOGS_DEFAULT(VERBOSE) << "[NvTensorRTRTX EP] tensorrt_plugins library not found in runtime path (optional)";
+    }
+  } catch (const std::exception& e) {
+    LOGS_DEFAULT(VERBOSE) << "[NvTensorRTRTX EP] tensorrt_plugins library not available: " << e.what();
+  }
+
   try {
     // Get all registered TRT plugins from registry
     LOGS_DEFAULT(VERBOSE) << "[NvTensorRTRTX EP] Getting all registered TRT plugins from TRT plugin registry ...";


### PR DESCRIPTION
External TensorRT plugins for transformer models were previously only available as internal TensorRT components. To enable flexible deployment these plugins have been externalized into a separate library.