### PR TITLE
Revert to use setup-dotnet@v3 for x86 release pipeline

### DIFF
--- a/.github/workflows/windows_x86.yml
+++ b/.github/workflows/windows_x86.yml
@@ -61,9 +61,9 @@ jobs:
         working-directory: ${{ github.workspace }}
 
       - name: Use .NET 8.x
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '8.0.416'
+          dotnet-version: '8.x'
         env:
           PROCESSOR_ARCHITECTURE: x86 # x86 .NET
 


### PR DESCRIPTION
### Description
Revert to use setup-dotnet@v3.
Using actions/setup-dotnet@v5 is having issue as it keeps using latest dotnet 10.0.0 that makes pipeline failed.



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


