### PR TITLE
[build] fix use dotnet

### DIFF
--- a/.github/workflows/windows_x86.yml
+++ b/.github/workflows/windows_x86.yml
@@ -71,7 +71,11 @@ jobs:
       - name: Install VC++ Redistributable x86 2015-2019
         shell: pwsh
         run: |
-          winget install --id=Microsoft.VCRedist.2015+.x86 -e
+          $vcRedistUrl = "https://aka.ms/vs/17/release/vc_redist.x86.exe"
+          $vcRedistPath = "$env:TEMP\vc_redist.x86.exe"
+          Invoke-WebRequest -Uri $vcRedistUrl -OutFile $vcRedistPath
+          Start-Process -FilePath $vcRedistPath -ArgumentList '/install', '/quiet', '/norestart' -Wait
+          Remove-Item $vcRedistPath
 
       - name: verify dotnet installation
         shell: cmd


### PR DESCRIPTION
### Description

The CI pipeline fails because although the `actions/setup-dotnet@v5` step uses `8.x`, the actual build process may still possibly run a latest version.

according to https://learn.microsoft.com/en-us/dotnet/core/tools/global-json, we need to prepare a `global.json` file in the working directory to ensure the correct version of dotnet is used.