### PR TITLE
webgpu: split transpose perm{2310} in two steps

### DIFF
--- a/onnxruntime/core/providers/webgpu/tensor/transpose.h
+++ b/onnxruntime/core/providers/webgpu/tensor/transpose.h
@@ -23,8 +23,8 @@ class Transpose final : public WebGpuKernel, public TransposeBase {
 
 class TransposeProgram final : public Program<TransposeProgram> {
  public:
-  TransposeProgram(const gsl::span<const size_t>& permutations, bool use_shared)
-      : Program{"Transpose"}, perm_(permutations.begin(), permutations.end()), use_shared_(use_shared) {
+  TransposeProgram(const gsl::span<const size_t>& permutations, bool use_shared, bool map_first_channels_first = false)
+      : Program{"Transpose"}, perm_(permutations.begin(), permutations.end()), use_shared_(use_shared), map_first_channels_first_(map_first_channels_first) {
   }
 
   Status GenerateShaderCode(ShaderHelper& sh) const override;
@@ -35,6 +35,7 @@ class TransposeProgram final : public Program<TransposeProgram> {
  private:
   InlinedVector<int64_t> perm_;
   const bool use_shared_;
+  const bool map_first_channels_first_;
 };
 
 }  // namespace webgpu

--- a/onnxruntime/test/providers/cpu/tensor/transpose_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/transpose_test.cc
@@ -689,6 +689,28 @@ TEST(TransposeOpTest, NDim) {
   TransposeTest(input_shape, input_vals, &perm, input_shape, expected_vals2);
 }
 
+TEST(TransposeOpTest, 4Dim_perm2310) {
+  std::vector<int64_t> input_shape({2, 2, 2, 2});
+  std::vector<float> input_vals = {1.0f, 2.0f, 3.0f, 4.0f,
+                                   5.0f, 6.0f, 7.0f, 8.0f,
+                                   9.0f, 10.0f, 11.0f, 12.0f,
+                                   13.0f, 14.0f, 15.0f, 16.0f};
+
+  std::vector<int64_t> perm = {0, 2, 3, 1};
+  std::vector<float> expected_vals = {1.0f, 5.0f, 2.0f, 6.0f,
+                                      3.0f, 7.0f, 4.0f, 8.0f,
+                                      9.0f, 13.0f, 10.0f, 14.0f,
+                                      11.0f, 15.0f, 12.0f, 16.0f};
+  TransposeTest(input_shape, input_vals, &perm, input_shape, expected_vals);
+
+  perm = {1, 2, 3, 0};
+  std::vector<float> expected_vals2 = {1.0f, 9.0f, 5.0f, 13.0f,
+                                       2.0f, 10.0f, 6.0f, 14.0f,
+                                       3.0f, 11.0f, 7.0f, 15.0f,
+                                       4.0f, 12.0f, 8.0f, 16.0f};
+  TransposeTest(input_shape, expected_vals, &perm, input_shape, expected_vals2);
+}
+
 TEST(TransposeOpTest, DoTransposeImpl) {
   std::vector<int64_t> input_shape({5, 2, 1, 3});
   std::vector<float> input_vals(30);


### PR DESCRIPTION
In order to use transpose-shared instead transpose-naive, we could split transpose perm{2310} in two steps, which benifits Conv operator.

### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


