### PR TITLE
Internal dupe of https://github.com/microsoft/onnxruntime/pull/26104

### DIFF
--- a/tools/ci_build/github/linux/copy_strip_binary.sh
+++ b/tools/ci_build/github/linux/copy_strip_binary.sh
@@ -17,27 +17,27 @@ EXIT_CODE=1
 
 uname -a
 cd "$BINARY_DIR"
-mv installed/usr/local $ARTIFACT_NAME
+mv installed/usr/local "$ARTIFACT_NAME"
 # Do not ship onnx_test_runner
-rm -rf $ARTIFACT_NAME/bin
+rm -rf "$ARTIFACT_NAME"/bin
 echo "Copy debug symbols in a separate file and strip the original binary."
-if [[ $LIB_NAME == *.dylib ]]
+if [[ "$LIB_NAME" == *.dylib ]]
 then
-    dsymutil $BINARY_DIR/$ARTIFACT_NAME/lib/$LIB_NAME -o $BINARY_DIR/$ARTIFACT_NAME/lib/$LIB_NAME.dSYM
-    strip -S $BINARY_DIR/$ARTIFACT_NAME/lib/$LIB_NAME
+    dsymutil "$BINARY_DIR"/"$ARTIFACT_NAME"/lib/"$LIB_NAME" -o "$BINARY_DIR"/"$ARTIFACT_NAME"/lib/"$LIB_NAME".dSYM
+    strip -S "$BINARY_DIR"/"$ARTIFACT_NAME"/lib/"$LIB_NAME"
     # copy the CoreML EP header for macOS build (libs with .dylib ext)
-    cp $SOURCE_DIR/include/onnxruntime/core/providers/coreml/coreml_provider_factory.h  $BINARY_DIR/$ARTIFACT_NAME/include
+    cp "$SOURCE_DIR"/include/onnxruntime/core/providers/coreml/coreml_provider_factory.h  "$BINARY_DIR"/"$ARTIFACT_NAME"/include
 fi
 
-# copy the README, licence and TPN
-cp $SOURCE_DIR/README.md $BINARY_DIR/$ARTIFACT_NAME/README.md
-cp $SOURCE_DIR/docs/Privacy.md $BINARY_DIR/$ARTIFACT_NAME/Privacy.md
-cp $SOURCE_DIR/LICENSE $BINARY_DIR/$ARTIFACT_NAME/LICENSE
-cp $SOURCE_DIR/ThirdPartyNotices.txt $BINARY_DIR/$ARTIFACT_NAME/ThirdPartyNotices.txt
-cp $SOURCE_DIR/VERSION_NUMBER $BINARY_DIR/$ARTIFACT_NAME/VERSION_NUMBER
+# copy the README, license and TPN
+cp "$SOURCE_DIR"/README.md "$BINARY_DIR"/"$ARTIFACT_NAME"/README.md
+cp "$SOURCE_DIR"/docs/Privacy.md "$BINARY_DIR"/"$ARTIFACT_NAME"/Privacy.md
+cp "$SOURCE_DIR"/LICENSE "$BINARY_DIR"/"$ARTIFACT_NAME"/LICENSE
+cp "$SOURCE_DIR"/ThirdPartyNotices.txt "$BINARY_DIR"/"$ARTIFACT_NAME"/ThirdPartyNotices.txt
+cp "$SOURCE_DIR"/VERSION_NUMBER "$BINARY_DIR"/"$ARTIFACT_NAME"/VERSION_NUMBER
 
 
-echo $COMMIT_ID > $BINARY_DIR/$ARTIFACT_NAME/GIT_COMMIT_ID
+echo "$COMMIT_ID" > "$BINARY_DIR"/"$ARTIFACT_NAME"/GIT_COMMIT_ID
 
 EXIT_CODE=$?
 


### PR DESCRIPTION
### Description
Dupe of https://github.com/microsoft/onnxruntime/pull/26104. For some reason, I am not able to restart the failing pipeline in that PR.

Credit to @WangFengtu1996 for the contribution.

### Motivation and Context
Should keep the binary paths and the header locations consistent with the packaged cmake on Linux and Mac platforms.

Should fix:
https://github.com/microsoft/onnxruntime/issues/23642
https://github.com/microsoft/onnxruntime/issues/26186
https://github.com/microsoft/onnxruntime/issues/24003
https://github.com/microsoft/onnxruntime/issues/25279
https://github.com/microsoft/onnxruntime/issues/25242

