### PR TITLE
[Mobile] Fix OrtCallbackDelegate MarshalAs

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.shared.cs
@@ -1137,7 +1137,7 @@ namespace Microsoft.ML.OnnxRuntime
         }
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private delegate void OrtCallbackDelegate(IntPtr userData, IntPtr[] outputs, uint numOutputs, IntPtr status);
+        private delegate void OrtCallbackDelegate(IntPtr userData, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] IntPtr[] outputs, uint numOutputs, IntPtr status);
 
         private static OrtCallbackDelegate ortCallback = new OrtCallbackDelegate(OrtCallback);
 


### PR DESCRIPTION
### Description
`OrtCallbackDelegate`'s `outputs` needs a `MarshalAs` attribute. Without it, immediate crash with no thrown Exception or printed stacktrace. Tested on Android and Win11 x64.

### Motivation and Context
Fixes #26587 