### PR TITLE
Add weight layout transformation cache for Conv operator

### DIFF
--- a/onnxruntime/core/providers/webgpu/compute_context.h
+++ b/onnxruntime/core/providers/webgpu/compute_context.h
@@ -139,6 +139,13 @@ class ComputeContext final {
     return webgpu_context_.Run(*this, program);
   }
 
+  //
+  // Get the execution provider.
+  //
+  inline const WebGpuExecutionProvider& GetExecutionProvider() const {
+    return ep_;
+  }
+
  private:
   WebGpuContext& webgpu_context_;
   OpKernelContext& kernel_context_;

--- a/onnxruntime/core/providers/webgpu/nn/conv.h
+++ b/onnxruntime/core/providers/webgpu/nn/conv.h
@@ -20,12 +20,26 @@ class Conv : public WebGpuKernel {
     if (is_fused) {
       ORT_ENFORCE(GetFusedActivationAttr(info, activation_).IsOK());
     }
+    // Extract weight input name (input index 1) for caching
+    const auto& input_defs = info.node().InputDefs();
+    if (input_defs.size() > 1 && input_defs[1]->Exists()) {
+      weight_name_ = input_defs[1]->Name();
+    }
   }
   Status ComputeInternal(ComputeContext& context) const override;
 
  protected:
   ConvAttributes conv_attrs_;
   Activation activation_;
+  std::string weight_name_;  // Name of weight input for cache key
+
+  // Cached transformed weight pointer (set on first inference)
+  mutable const Tensor* transformed_weight_ = nullptr;
+  mutable bool weight_transform_attempted_ = false;
+
+  // Get or create transformed weight (lazy transformation on first inference)
+  Status GetTransformedWeight(ComputeContext& context, const Tensor* original_weight,
+                              const Tensor*& transformed_weight) const;
 };
 
 Status TransposeKernel(ComputeContext& context, const Tensor* kernel, const TensorShape& kernel_shape, Tensor* transposed_kernel, const InlinedVector<size_t>& perm);

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.h
@@ -9,6 +9,7 @@
 #include "core/graph/constants.h"
 #include "core/providers/providers.h"
 #include "core/providers/webgpu/buffer_manager.h"
+#include "core/providers/webgpu/weight_layout_transform_cache.h"
 
 struct pthreadpool;
 namespace onnxruntime {
@@ -85,6 +86,11 @@ class WebGpuExecutionProvider : public IExecutionProvider {
   Status ReplayGraph(int graph_annotation_id) override;
   webgpu::BufferManager& BufferManager() const;
 
+  // Get weight layout transform cache
+  webgpu::WeightLayoutTransformCache& GetWeightLayoutTransformCache() const {
+    return *weight_layout_transform_cache_;
+  }
+
  private:
   bool IsGraphCaptureAllowed() const;
   void IncrementRegularRunCountBeforeGraphCapture();
@@ -105,6 +111,9 @@ class WebGpuExecutionProvider : public IExecutionProvider {
 
   // Store captured commands directly in the EP instead of in WebGpuContext
   std::vector<webgpu::CapturedCommandInfo> captured_commands_;
+
+  // Cache for transformed weights (e.g., OIHW -> HWIO)
+  std::unique_ptr<webgpu::WeightLayoutTransformCache> weight_layout_transform_cache_;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/weight_layout_transform.cc
+++ b/onnxruntime/core/providers/webgpu/weight_layout_transform.cc
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/webgpu/weight_layout_transform.h"
+#include "core/providers/webgpu/compute_context.h"
+#include "core/providers/webgpu/weight_layout_transform_cache.h"
+#include "core/providers/webgpu/nn/conv.h"  // For TransposeKernel
+
+namespace onnxruntime {
+namespace webgpu {
+
+Status TransformWeightLayout(
+    ComputeContext& context,
+    const Tensor* weight,
+    const std::string& weight_name,
+    const std::string& format_descriptor,
+    WeightLayoutTransformCache& cache,
+    /*out*/ const Tensor*& transformed_weight) {
+  // Check cache first
+  const auto* cached = cache.GetTransformedWeight(weight_name, format_descriptor);
+  if (cached != nullptr) {
+    transformed_weight = cached;
+    return Status::OK();
+  }
+
+  // Not in cache, need to transform
+
+  const auto& original_shape = weight->Shape();
+  auto num_dims = original_shape.NumDimensions();
+
+  // Dispatch transformation based on format
+  Tensor output_tensor;
+  if (format_descriptor == "hwio") {
+    // For 3D tensors, extend to 4D before transposing
+    TensorShape input_shape_for_transpose = original_shape;
+    if (num_dims == 3) {
+      // Extend OIW [O, I, W] to OIHW [O, I, 1, W]
+      TensorShapeVector extended_shape = original_shape.AsShapeVector();
+      extended_shape.insert(extended_shape.begin() + 2, 1);  // Insert H=1 at position 2
+      input_shape_for_transpose = TensorShape(extended_shape);
+    }
+
+    // Use existing TransposeKernel: OIHW [O,I,H,W] -> HWIO [H,W,I,O]
+    // Permutation: [2, 3, 1, 0] means output[i] = input[perm[i]]
+    // TransposeKernel creates the output tensor internally
+    const InlinedVector<size_t> perm = {2, 3, 1, 0};
+    ORT_RETURN_IF_ERROR(TransposeKernel(context, weight, input_shape_for_transpose,
+                                        &output_tensor, perm));
+  } else {
+    // Add more format implementations here
+    return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED,
+                           "Format not yet implemented: ", format_descriptor);
+  }
+
+  // Add to cache
+  cache.AddTransformedWeight(weight_name, format_descriptor, std::move(output_tensor));
+
+  // Return cached tensor
+  const auto* cached_result = cache.GetTransformedWeight(weight_name, format_descriptor);
+  ORT_ENFORCE(cached_result != nullptr, "Failed to cache transformed weight");
+  transformed_weight = cached_result;
+
+  return Status::OK();
+}
+
+}  // namespace webgpu
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/weight_layout_transform.h
+++ b/onnxruntime/core/providers/webgpu/weight_layout_transform.h
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/common/common.h"
+#include "core/framework/tensor.h"
+#include <string>
+
+namespace onnxruntime {
+namespace webgpu {
+
+class ComputeContext;
+class WeightLayoutTransformCache;
+
+// Transform weight tensor to specified format
+// Returns the transformed tensor (either from cache or newly created)
+Status TransformWeightLayout(
+    ComputeContext& context,
+    const Tensor* weight,
+    const std::string& weight_name,
+    const std::string& format_descriptor,
+    WeightLayoutTransformCache& cache,
+    /*out*/ const Tensor*& transformed_weight);
+
+}  // namespace webgpu
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/weight_layout_transform_cache.cc
+++ b/onnxruntime/core/providers/webgpu/weight_layout_transform_cache.cc
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/webgpu/weight_layout_transform_cache.h"
+
+namespace onnxruntime {
+namespace webgpu {
+
+const Tensor* WeightLayoutTransformCache::GetTransformedWeight(
+    const std::string& weight_name,
+    const std::string& format_descriptor) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  std::string cache_key = MakeCacheKey(weight_name, format_descriptor);
+  auto it = cache_.find(cache_key);
+  if (it != cache_.end()) {
+    return &it->second;
+  }
+  return nullptr;
+}
+
+void WeightLayoutTransformCache::AddTransformedWeight(
+    const std::string& weight_name,
+    const std::string& format_descriptor,
+    Tensor&& tensor) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  std::string cache_key = MakeCacheKey(weight_name, format_descriptor);
+  cache_[cache_key] = std::move(tensor);
+}
+
+void WeightLayoutTransformCache::Clear() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  cache_.clear();
+}
+
+}  // namespace webgpu
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/weight_layout_transform_cache.h
+++ b/onnxruntime/core/providers/webgpu/weight_layout_transform_cache.h
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <unordered_map>
+#include <mutex>
+#include <string>
+#include "core/framework/tensor.h"
+#include "core/common/common.h"
+
+namespace onnxruntime {
+namespace webgpu {
+
+// Cache manager for transformed weights
+// Owned by WebGpuExecutionProvider
+class WeightLayoutTransformCache {
+ public:
+  WeightLayoutTransformCache() = default;
+  ~WeightLayoutTransformCache() = default;
+
+  // Get transformed weight from cache (nullptr if not found)
+  const Tensor* GetTransformedWeight(const std::string& weight_name,
+                                     const std::string& format_descriptor) const;
+
+  // Add transformed weight to cache
+  void AddTransformedWeight(const std::string& weight_name,
+                            const std::string& format_descriptor,
+                            Tensor&& tensor);
+
+  // Clear cache (must be called before BufferManager is destroyed)
+  void Clear();
+
+ private:
+  std::string MakeCacheKey(const std::string& weight_name,
+                           const std::string& format) const {
+    return weight_name + ":" + format;
+  }
+
+  mutable std::mutex mutex_;
+  std::unordered_map<std::string, Tensor> cache_;
+};
+
+}  // namespace webgpu
+}  // namespace onnxruntime


### PR DESCRIPTION
Implement lazy weight layout transformation for WebGPU Conv kernel to avoid redundant GPU transposes on every inference.

Key changes:
- Add WeightLayoutTransformCache to cache transformed weights by name and format
- Implement TransformWeightLayout() helper using existing TransposeKernel for OIHW->HWIO transformation
- Cache stored in WebGpuExecutionProvider, shared across all kernels
