### PR TITLE
Adding candidate metadata key for tracking EP's OS driver version

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_ep_device_ep_metadata_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_ep_device_ep_metadata_keys.h
@@ -9,7 +9,7 @@
 // Key for the execution provider version string. This should be available for all plugin EPs.
 static const char* const kOrtEpDevice_EpMetadataKey_Version = "version";
 
-// Key for the execution provider OS driver version. This should be available for all plugin EPs.
+// Key for the execution provider OS driver version.
 static const char* const kOrtEpDevice_EpMetadataKey_OSDriverVersion = "os_driver_version";
 
 // Prefix for execution provider compatibility information stored in model metadata.


### PR DESCRIPTION
### Description
This change adds a well-known key name (`os_driver_version`) corresponding to the OS driver version associated with an EP. We will eventually flesh this out to enable retrieving it from the `OrtEpDevice` if it's been populated, but for starters we reserve the name. 

### Motivation and Context
We have a scenario in WebNN where the browser would like to get the driver version associated with a given EP (this is to enable policy against the driver, e.g. for maintaining a blocklist if a particular driver version has a scenario-blocking bug in it). Having a mechanism to retrieve the driver version via ORT would help with implementing this feature. 


