### PR TITLE
[Quantization] Fix static quantize runner usage.

### DIFF
--- a/onnxruntime/python/tools/quantization/README.md
+++ b/onnxruntime/python/tools/quantization/README.md
@@ -18,16 +18,38 @@ The static quantization tool expects the directory structure of model and data.
 work_dir\resnet18-v1-7
 ├───model.onnx
 ├───test_data_set_0
+│   ├───input_0.pb
+│   └───input_1.pb
 ├───test_data_set_1
+│   ├───input_0.pb
+│   └───input_1.pb
 ├───test_data_set_2
+│   ├───input_0.pb
+│   └───input_1.pb
 ├───test_data_set_3
+│   ├───input_0.pb
+│   └───input_1.pb
 ├───test_data_set_4
+│   ├───input_0.pb
+│   └───input_1.pb
 ├───test_data_set_5
+│   ├───input_0.pb
+│   └───input_1.pb
 ├───test_data_set_6
+│   ├───input_0.pb
+│   └───input_1.pb
 ├───test_data_set_7
+│   ├───input_0.pb
+│   └───input_1.pb
 ├───test_data_set_8
+│   ├───input_0.pb
+│   └───input_1.pb
 └───test_data_set_9
+    ├───input_0.pb
+    └───input_1.pb
 ```
+
+Note that the indexing must fully align the order of model inputs (i.e., `input_0.pb` is expected to be the data for the 1st model input, `input_1.pb` for the 2nd, and so on).
 
 ### Usage
 Install the python tools built in onnxruntime

--- a/onnxruntime/python/tools/quantization/registry.py
+++ b/onnxruntime/python/tools/quantization/registry.py
@@ -87,6 +87,7 @@ QDQRegistry = {
     "LayerNormalization": QDQNormalization,
     "BatchNormalization": QDQNormalization,
     "TopK": QDQDirect8BitOp,
+    "CumSum": QDQOperatorBase,
 }
 
 

--- a/onnxruntime/python/tools/quantization/static_quantize_runner.py
+++ b/onnxruntime/python/tools/quantization/static_quantize_runner.py
@@ -20,7 +20,7 @@ class OnnxModelCalibrationDataReader(CalibrationDataReader):
         name2tensors = []
         for data_dir in data_dirs:
             name2tensor = {}
-            data_paths = [os.path.join(data_dir, a) for a in sorted(os.listdir(data_dir))]
+            data_paths = [os.path.join(data_dir, f"input_{input_idx}.pb") for input_idx in range(len(model_inputs))]
             data_ndarrays = [self.read_onnx_pb_data(data_path) for data_path in data_paths]
             for model_input, data_ndarray in zip(model_inputs, data_ndarrays, strict=False):
                 name2tensor[model_input.name] = data_ndarray


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Input pb files were read in incorrect order.
  - Cause: Python `sorted` was used to acquire sorted input files in order. However, the input files would be in incorrect order since "10" is lexicographically smaller than "2".
  - Fix: Revise to enumerating indices to read input files.
- CumSum's output wasn't quantized.
  - Cause: CumSum wasn't registered into QDQ registry.
  - Fix: Register CumSum with QDQDirect8bitOp.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Fix two issues in `static_quantize_runner` usage.

