### PR TITLE
Clear cuda error on unsupported CudaMemPool test

### DIFF
--- a/onnxruntime/test/providers/cuda/cuda_mempool_arena_test.cc
+++ b/onnxruntime/test/providers/cuda/cuda_mempool_arena_test.cc
@@ -89,7 +89,9 @@ static ::cudaStream_t NewCudaStream() {
 }
 
 static void DestroyCudaStream(::cudaStream_t s) {
-  if (s) EXPECT_EQ(cudaSuccess, ::cudaStreamDestroy(s));
+  if (s) {
+    EXPECT_EQ(cudaSuccess, ::cudaStreamDestroy(s));
+  }
 }
 
 static void TouchDevice(void* p, size_t bytes, ::cudaStream_t s, unsigned char value = 0xAB) {


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
CudaMemPool test checks if it is supported in a given environment.
We need to clear the error not to affect subsequent tests.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Potential test failure.

