### PR TITLE
Fix default graph optimization loop to avoid rerunning L2/L3

### DIFF
--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1453,14 +1453,17 @@ common::Status InferenceSession::TransformGraph(onnxruntime::Graph& graph, bool 
     // after the fusion, the nodes are can be in a format which might be supported by other graph transforms which
     // were skipped before. Hence, some of the transforms not applied before is now valid and can be applied to
     // create a more optimal graph for execution.
-    ORT_RETURN_IF_ERROR_SESSIONID_(
-        apply_transformer_at_level(graph_transformer_mgr_, TransformerLevel::Level2,
-                                   *session_logger_, graph,
-                                   ((graph_optimizations_loop_level > 1) ? &is_graph_modified : nullptr)));
-    ORT_RETURN_IF_ERROR_SESSIONID_(
-        apply_transformer_at_level(graph_transformer_mgr_, TransformerLevel::Level3,
-                                   *session_logger_, graph,
-                                   ((graph_optimizations_loop_level > 1) ? &is_graph_modified : nullptr)));
+    const bool rerun_level2_and_3 = graph_optimizations_loop_level > 1 || steps == 0;
+    if (rerun_level2_and_3) {
+      ORT_RETURN_IF_ERROR_SESSIONID_(
+          apply_transformer_at_level(graph_transformer_mgr_, TransformerLevel::Level2,
+                                     *session_logger_, graph,
+                                     ((graph_optimizations_loop_level > 1) ? &is_graph_modified : nullptr)));
+      ORT_RETURN_IF_ERROR_SESSIONID_(
+          apply_transformer_at_level(graph_transformer_mgr_, TransformerLevel::Level3,
+                                     *session_logger_, graph,
+                                     ((graph_optimizations_loop_level > 1) ? &is_graph_modified : nullptr)));
+    }
 
     // Insert cast node/s.
     {


### PR DESCRIPTION
### Description
- Fix the optimization loop: with the default `graph_optimizations_loop_level` (1), Level2/Level3 run only in the first pass;
subsequent iterations only repeat InsertCast + Level4. Level2/Level3 still re-run when loop_level > 1.
- Add regression test `TransformerTest.SimplifiedLayerNormWithFp16ConstantDoesNotRevisitLevel3AtDefaultLoopLevel`, a simplified LayerNorm pattern with an FP16 Constant exponent to guard the prior crash.

### Motivation and Context
- The latest ONNX Runtime failed to run this model: https://huggingface.co/Xenova/clip-vit-base-patch32/blob/main/onnx/model_fp16.onnx with an error of `[E:onnxruntime:, inference_session.cc:2287 operator()] Exception during initialization: /home/zt/rk3588-nn/expr/onnxruntime/onnxruntime/core/graph/graph_utils.cc:27 int onnxruntime::graph_utils::GetIndexFromName(const onnxruntime::Node&, const std::string&, bool) itr != node_args.end() was false. Attempting to get index by a name which does not exist:InsertedPrecisionFreeCast_/text_model/encoder/layers.10/layer_norm2/Constant_output_0for node: /text_model/encoder/layers.0/layer_norm1/Mul/SimplifiedLayerNormFusion/`
- After some bisecting work, we found this bug was introduced with https://github.com/microsoft/onnxruntime/commit/340b188c9cb76a4292898a04f80fda046376879e ( https://github.com/microsoft/onnxruntime/pull/24726 ). 
- Root cause: The new loop re-ran Level3 after InsertCast, exposing `InsertedPrecisionFreeCast_*` nodes to SimplifiedLayerNorm
fusion. `FinalizeNodeFusion` then looked up an input name that doesn’t exist on the replacement node, triggering
`graph_utils::GetIndexFromName` and crashing on models like `text_model.onnx`.
- Fix: Restore intended default behavior—only loop based on Level4 (and InsertCast) at loop_level=1—so Level3 doesn’t see the
post-InsertCast Casts. Users can still opt into re-running L2/L3 by setting loop_level > 1 explicitly.
- Result: Crash reproduced and eliminated; targeted test now covers the FP16-constant LayerNorm case.

### Testing
- `./build.sh --config Debug --build_shared_lib --parallel --compile_no_warning_as_error --skip_submodule_sync`
- `build/Linux/Debug/onnxruntime_test_all
--gtest_filter=TransformerTest.SimplifiedLayerNormWithFp16ConstantDoesNotRevisitLevel3AtDefaultLoopLevel`

### Follow-ups / Future work
- If we need safe L2/L3 re-runs at higher loop levels: either fuse/strip InsertCast-produced Constant+Cast in Level4, or harden
LayerNorm fusion/FinalizeNodeFusion to ignore `InsertedPrecisionFreeCast_*` inputs when matching replacements.

### Note
- The bug analysis and subsequent coding/documenting work is done by GPT-5.1-Codex-Max medium, inside OpenAI Codex CLI.