### PR TITLE
webgpu: add FormatTransform kernel and tests

### DIFF
--- a/onnxruntime/core/providers/webgpu/vendor/intel/contrib/format_transform.cc
+++ b/onnxruntime/core/providers/webgpu/vendor/intel/contrib/format_transform.cc
@@ -1,0 +1,147 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/webgpu/vendor/intel/contrib/format_transform.h"
+#include "core/providers/webgpu/shader_helper.h"
+#include "core/providers/webgpu/webgpu_supported_types.h"
+#include "core/providers/webgpu/string_macros.h"
+#include "core/common/narrow.h"
+
+namespace onnxruntime {
+namespace webgpu {
+namespace intel {
+
+namespace {
+BlockedFormat ParseFormat(const std::string& format_str) {
+  if (format_str == "Plain" || format_str == "NCHW") {
+    return BlockedFormat::Plain;
+  } else if (format_str == "nChw4c") {
+    return BlockedFormat::nChw4c;
+  } else if (format_str == "ABcd16a4b") {
+    return BlockedFormat::ABcd16a4b;
+  } else {
+    ORT_THROW("Unsupported format: ", format_str);
+  }
+}
+
+Status GetOutputShapeForFormat(const TensorShape& input_shape,
+                               BlockedFormat dst_format,
+                               TensorShape& output_shape) {
+  ORT_RETURN_IF_NOT(input_shape.NumDimensions() == 4, "FormatTransform only supports 4D tensors");
+
+  const auto& dims = input_shape.GetDims();
+  const int64_t N = dims[0];
+  const int64_t C = dims[1];
+  const int64_t H = dims[2];
+  const int64_t W = dims[3];
+
+  switch (dst_format) {
+    case BlockedFormat::Plain:
+      output_shape = input_shape;
+      break;
+    case BlockedFormat::nChw4c: {
+      const int64_t padded_C = ((C + 3) / 4) * 4;
+      output_shape = TensorShape({N, padded_C, H, W});
+      break;
+    }
+    case BlockedFormat::ABcd16a4b: {
+      const int64_t padded_N = ((N + 15) / 16) * 16;
+      const int64_t padded_C = ((C + 3) / 4) * 4;
+      output_shape = TensorShape({padded_N, padded_C, H, W});
+      break;
+    }
+    default:
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Unsupported destination format: ", static_cast<int>(dst_format));
+  }
+
+  return Status::OK();
+}
+
+}  // namespace
+
+FormatTransformProgram::FormatTransformProgram(BlockedFormat src_format, BlockedFormat dst_format,
+                                               const TensorShape& input_shape)
+    : Program{"FormatTransform"},
+      src_format_(src_format),
+      dst_format_(dst_format),
+      input_shape_(input_shape) {
+}
+
+Status FormatTransformProgram::GenerateShaderCode(ShaderHelper& sh) const {
+  const auto& input = sh.AddInput("input", ShaderUsage::UseUniform | ShaderUsage::UseShapeAndStride);
+  const auto& output = sh.AddOutput("output", ShaderUsage::UseUniform | ShaderUsage::UseShapeAndStride | ShaderUsage::UseValueTypeAlias);
+
+  auto rank = input_shape_.NumDimensions();
+  ORT_RETURN_IF_NOT(rank == 4, "FormatTransform currently only supports 4D tensors (NCHW)");
+
+  const int src_format_val = static_cast<int>(src_format_);
+  const int dst_format_val = static_cast<int>(dst_format_);
+
+  return WGSL_TEMPLATE_APPLY(sh, "vendor/intel/contrib/format_transform.wgsl.template",
+                             WGSL_TEMPLATE_PARAMETER(dst_format, dst_format_val),
+                             WGSL_TEMPLATE_PARAMETER(src_format, src_format_val),
+                             WGSL_TEMPLATE_VARIABLE(input, input),
+                             WGSL_TEMPLATE_VARIABLE(output, output));
+}
+
+FormatTransform::FormatTransform(const OpKernelInfo& info)
+    : WebGpuKernel(info) {
+  std::string src_format_str = info.GetAttrOrDefault<std::string>("src_format", "Plain");
+  std::string dst_format_str = info.GetAttrOrDefault<std::string>("dst_format", "Plain");
+
+  src_format_ = ParseFormat(src_format_str);
+  dst_format_ = ParseFormat(dst_format_str);
+}
+
+Status FormatTransform::ComputeInternal(ComputeContext& context) const {
+  const auto* input = context.Input<Tensor>(0);
+  const auto& input_shape = input->Shape();
+
+  TensorShape output_shape;
+  ORT_RETURN_IF_ERROR(GetOutputShapeForFormat(input_shape, dst_format_, output_shape));
+
+  auto* output = context.Output(0, output_shape);
+
+  FormatTransformProgram program{src_format_, dst_format_, input_shape};
+  program
+      .AddInput({input, ProgramTensorMetadataDependency::TypeAndRank})
+      .AddOutput({output, ProgramTensorMetadataDependency::None})
+      .SetDispatchGroupSize((static_cast<uint32_t>(output_shape.Size()) + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE)
+      .CacheHint(static_cast<int>(src_format_), static_cast<int>(dst_format_))
+      .AddUniformVariables({{static_cast<uint32_t>(output_shape.Size())}});
+
+  return context.RunProgram(program);
+}
+
+/*static*/ Status FormatTransform::TransformPlainToBlocked(ComputeContextBase& context,
+                                                           const Tensor& input,
+                                                           BlockedFormat dst_format,
+                                                           AllocatorPtr alloc,
+                                                           std::unique_ptr<Tensor>& output) {
+  ORT_RETURN_IF(dst_format == BlockedFormat::Plain,
+                "TransformPlainToBlocked should only be used for blocked destinations.");
+  ORT_RETURN_IF(alloc == nullptr, "Allocator must not be null.");
+
+  TensorShape output_shape;
+  ORT_RETURN_IF_ERROR(GetOutputShapeForFormat(input.Shape(), dst_format, output_shape));
+
+  auto transformed = std::make_unique<Tensor>(input.DataType(), output_shape, alloc);
+
+  FormatTransformProgram program{BlockedFormat::Plain, dst_format, input.Shape()};
+  program
+      .AddInput({&input, ProgramTensorMetadataDependency::TypeAndRank})
+      .AddOutput({transformed.get(), ProgramTensorMetadataDependency::None})
+      .SetDispatchGroupSize((static_cast<uint32_t>(output_shape.Size()) + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE)
+      .CacheHint(static_cast<int>(BlockedFormat::Plain), static_cast<int>(dst_format))
+      .AddUniformVariables({{static_cast<uint32_t>(output_shape.Size())}});
+
+  ORT_RETURN_IF_ERROR(context.RunProgram(program));
+
+  output = std::move(transformed);
+  return Status::OK();
+}
+
+}  // namespace intel
+}  // namespace webgpu
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/vendor/intel/contrib/format_transform.h
+++ b/onnxruntime/core/providers/webgpu/vendor/intel/contrib/format_transform.h
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <memory>
+
+#include "core/providers/webgpu/webgpu_kernel.h"
+#include "core/providers/webgpu/program.h"
+
+namespace onnxruntime {
+namespace webgpu {
+namespace intel {
+
+// OneDNN blocked format types
+// IMPORTANT: keep enum order/numeric values in sync with format_transform.wgsl.template format macro values.
+enum class BlockedFormat {
+  Plain,      // Standard NCHW layout
+  nChw4c,     // Blocked with 4-channel blocks
+  ABcd16a4b,  // 2D blocked format: blocks A dimension with 16, B dimension with 4
+};
+
+class FormatTransformProgram final : public Program<FormatTransformProgram> {
+ public:
+  FormatTransformProgram(BlockedFormat src_format, BlockedFormat dst_format,
+                         const TensorShape& input_shape);
+
+  Status GenerateShaderCode(ShaderHelper& sh) const override;
+
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES({"output_size", ProgramUniformVariableDataType::Uint32});
+
+ private:
+  BlockedFormat src_format_;
+  BlockedFormat dst_format_;
+  TensorShape input_shape_;
+};
+
+// Internal operator for format transformation between plain and blocked formats
+class FormatTransform final : public WebGpuKernel {
+ public:
+  // Helper that converts a plain-format tensor into the requested blocked layout on the GPU.
+  // The returned tensor uses the provided allocator, and the shader dispatch is issued via context.
+  static Status TransformPlainToBlocked(ComputeContextBase& context,
+                                        const Tensor& input,
+                                        BlockedFormat dst_format,
+                                        AllocatorPtr alloc,
+                                        std::unique_ptr<Tensor>& output);
+
+  FormatTransform(const OpKernelInfo& info);
+  Status ComputeInternal(ComputeContext& context) const override;
+
+ private:
+  BlockedFormat src_format_;
+  BlockedFormat dst_format_;
+};
+
+}  // namespace intel
+}  // namespace webgpu
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/vendor/intel/contrib/format_transform.wgsl.template
+++ b/onnxruntime/core/providers/webgpu/vendor/intel/contrib/format_transform.wgsl.template
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Format transformation shader for OneDNN blocked layouts
+// Supports Plain (NCHW), nChw4c, and ABcd16a4b formats
+
+#define FORMAT_PLAIN 0
+#define FORMAT_NCHW4C 1
+#define FORMAT_ABCD16A4B 2
+
+#use getElementAt
+#use .getByOffset .setByOffset
+#use guardAgainstOutOfBoundsWorkgroupSizes
+
+#param src_format
+#param dst_format
+
+$MAIN {
+    guardAgainstOutOfBoundsWorkgroupSizes(uniforms.output_size);
+
+  // Get shapes from uniforms
+  let N = uniforms.input_shape[0];
+  let C = uniforms.input_shape[1];
+  let H = uniforms.input_shape[2];
+  let W = uniforms.input_shape[3];
+
+  let out_N = uniforms.output_shape[0];
+  let out_C = uniforms.output_shape[1];
+  let out_H = uniforms.output_shape[2];
+  let out_W = uniforms.output_shape[3];
+
+  // Calculate NCHW indices from output global index
+  let n = global_idx / (out_C * out_H * out_W);
+  let chw_idx = global_idx % (out_C * out_H * out_W);
+  let c = chw_idx / (out_H * out_W);
+  let hw_idx = chw_idx % (out_H * out_W);
+  let h = hw_idx / out_W;
+  let w = hw_idx % out_W;
+
+  var output_idx: u32 = 0u;
+#if dst_format == FORMAT_PLAIN
+  // Plain format: NCHW
+  output_idx = n * C * H * W + c * H * W + h * W + w;
+#elif dst_format == FORMAT_NCHW4C
+  // nChw4c format: [N, C/4, H, W, 4]
+  let block_size = 4u;
+  let num_blocks = (out_C + block_size - 1u) / block_size;
+  let block_idx = c / block_size;
+  let c_in_block = c % block_size;
+  output_idx = n * num_blocks * out_H * out_W * block_size +
+               block_idx * out_H * out_W * block_size +
+               h * out_W * block_size +
+               w * block_size +
+               c_in_block;
+#elif dst_format == FORMAT_ABCD16A4B
+  // ABcd16a4b format: [N/16, C/4, H, W, 16, 4]
+  let a_block = 16u;
+  let b_block = 4u;
+  let num_a_blocks = (out_N + a_block - 1u) / a_block;
+  let num_b_blocks = (out_C + b_block - 1u) / b_block;
+  let a_block_idx = n / a_block;
+  let n_in_block = n % a_block;
+  let b_block_idx = c / b_block;
+  let c_in_block = c % b_block;
+  output_idx = a_block_idx * num_b_blocks * out_H * out_W * a_block * b_block +
+               b_block_idx * out_H * out_W * a_block * b_block +
+               h * out_W * a_block * b_block +
+               w * a_block * b_block +
+               n_in_block * b_block +
+               c_in_block;
+#endif
+
+  // Check if this output position is within input bounds
+  if (n >= N || c >= C || h >= H || w >= W) {
+    // Padding area - fill with zero
+    output.setByOffset(output_idx, output_value_t(0));
+  } else {
+    // Within input bounds - transform data
+    // Calculate input index
+#if src_format == FORMAT_PLAIN
+    // Plain format: NCHW
+    let input_idx = n * C * H * W + c * H * W + h * W + w;
+#elif src_format == FORMAT_NCHW4C
+    // nChw4c format: [N, C/4, H, W, 4]
+    let block_size = 4u;
+    let num_blocks = (C + block_size - 1u) / block_size;
+    let block_idx = c / block_size;
+    let c_in_block = c % block_size;
+    let input_idx = n * num_blocks * H * W * block_size +
+                    block_idx * H * W * block_size +
+                    h * W * block_size +
+                    w * block_size +
+                    c_in_block;
+#elif src_format == FORMAT_ABCD16A4B
+    // ABcd16a4b format: [N/16, C/4, H, W, 16, 4]
+    let a_block = 16u;
+    let b_block = 4u;
+    let num_a_blocks = (N + a_block - 1u) / a_block;
+    let num_b_blocks = (C + b_block - 1u) / b_block;
+    let a_block_idx = n / a_block;
+    let n_in_block = n % a_block;
+    let b_block_idx = c / b_block;
+    let c_in_block = c % b_block;
+    let input_idx = a_block_idx * num_b_blocks * H * W * a_block * b_block +
+                    b_block_idx * H * W * a_block * b_block +
+                    h * W * a_block * b_block +
+                    w * a_block * b_block +
+                    n_in_block * b_block +
+                    c_in_block;
+#endif
+
+    output.setByOffset(output_idx, input.getByOffset(input_idx));
+  }
+} // MAIN

--- a/onnxruntime/test/providers/format_transform_test.cc
+++ b/onnxruntime/test/providers/format_transform_test.cc
@@ -1,0 +1,354 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <cassert>
+
+#include "gtest/gtest.h"
+#include "test/providers/provider_test_utils.h"
+#include "test/common/tensor_op_test_utils.h"
+#include "test/util/include/default_providers.h"
+
+#ifdef USE_WEBGPU
+
+namespace onnxruntime {
+namespace test {
+
+namespace {
+
+void RunOnWebGpu(OpTester& test) {
+  auto webgpu_ep = DefaultWebGpuExecutionProvider();
+  if (!webgpu_ep) {
+    GTEST_SKIP() << "WebGPU execution provider is not available.";
+  }
+  test.ConfigEp(std::move(webgpu_ep));
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+constexpr int kNChw4cBlock = 4;
+constexpr int kABcd16aBlock = 16;
+constexpr int kABcd4bBlock = 4;
+
+int ComputePaddedSize(int value, int block) {
+  return ((value + block - 1) / block) * block;
+}
+
+// Helper to reshape plain NCHW data into nChw4c layout for expectations.
+std::vector<float> PlainToBlockedNChw4c(const std::vector<float>& plain,
+                                        int N,
+                                        int C,
+                                        int H,
+                                        int W,
+                                        int padded_C_override = -1) {
+  const int padded_C = padded_C_override > 0 ? padded_C_override : ComputePaddedSize(C, kNChw4cBlock);
+  const int channel_blocks = padded_C / kNChw4cBlock;
+  std::vector<float> blocked(static_cast<size_t>(N) * padded_C * H * W, 0.0f);
+
+  for (int n = 0; n < N; ++n) {
+    for (int c = 0; c < C; ++c) {
+      for (int h = 0; h < H; ++h) {
+        for (int w = 0; w < W; ++w) {
+          const int plain_idx = ((n * C + c) * H + h) * W + w;
+          const int block_idx = c / kNChw4cBlock;
+          const int c_in_block = c % kNChw4cBlock;
+          const int blocked_idx = ((((n * channel_blocks) + block_idx) * H + h) * W + w) * kNChw4cBlock + c_in_block;
+          blocked[blocked_idx] = plain[plain_idx];
+        }
+      }
+    }
+  }
+
+  return blocked;
+}
+
+std::vector<float> PlainToBlockedABcd16a4b(const std::vector<float>& plain,
+                                           int N,
+                                           int C,
+                                           int H,
+                                           int W,
+                                           int padded_N_override = -1,
+                                           int padded_C_override = -1) {
+  assert(static_cast<int>(plain.size()) == N * C * H * W);
+  const int padded_N = padded_N_override > 0 ? padded_N_override : ComputePaddedSize(N, kABcd16aBlock);
+  const int padded_C = padded_C_override > 0 ? padded_C_override : ComputePaddedSize(C, kABcd4bBlock);
+  const int c_blocks = padded_C / kABcd4bBlock;
+  std::vector<float> blocked(static_cast<size_t>(padded_N) * padded_C * H * W, 0.0f);
+
+  for (int n = 0; n < N; ++n) {
+    for (int c = 0; c < C; ++c) {
+      for (int h = 0; h < H; ++h) {
+        for (int w = 0; w < W; ++w) {
+          const int plain_idx = ((n * C + c) * H + h) * W + w;
+          const int a_block_idx = n / kABcd16aBlock;
+          const int n_in_block = n % kABcd16aBlock;
+          const int b_block_idx = c / kABcd4bBlock;
+          const int c_in_block = c % kABcd4bBlock;
+          const int blocked_idx = (((((a_block_idx * c_blocks) + b_block_idx) * H + h) * W + w) * kABcd16aBlock + n_in_block) * kABcd4bBlock + c_in_block;
+          blocked[blocked_idx] = plain[plain_idx];
+        }
+      }
+    }
+  }
+
+  return blocked;
+}
+
+}  // namespace
+
+// Test Plain (NCHW) to Blocked (nChw4c) format transformation
+TEST(FormatTransformTest, PlainToBlocked_nChw4c) {
+  OpTester test("FormatTransform", 1, kMSInternalNHWCDomain);
+
+  // Attributes
+  test.AddAttribute<std::string>("src_format", "Plain");
+  test.AddAttribute<std::string>("dst_format", "nChw4c");
+
+  // Input: [1, 16, 4, 4] in NCHW format
+  std::vector<float> input_data(1 * 16 * 4 * 4);
+  for (size_t i = 0; i < input_data.size(); ++i) {
+    input_data[i] = static_cast<float>(i);
+  }
+  test.AddInput<float>("X", {1, 16, 4, 4}, input_data);
+
+  // Output: Still [1, 16, 4, 4] shape but with blocked layout
+  const auto output_data = PlainToBlockedNChw4c(input_data, 1, 16, 4, 4);
+  test.AddOutput<float>("Y", {1, 16, 4, 4}, output_data);
+
+  RunOnWebGpu(test);
+}
+
+// Test Blocked (nChw4c) to Plain (NCHW) format transformation
+TEST(FormatTransformTest, BlockedToPlain_nChw4c) {
+  OpTester test("FormatTransform", 1, kMSInternalNHWCDomain);
+
+  // Attributes
+  test.AddAttribute<std::string>("src_format", "nChw4c");
+  test.AddAttribute<std::string>("dst_format", "Plain");
+
+  // Input: [1, 16, 4, 4] in blocked nChw4c format
+  std::vector<float> plain_reference(1 * 16 * 4 * 4);
+  for (size_t i = 0; i < plain_reference.size(); ++i) {
+    plain_reference[i] = static_cast<float>(100 + i);
+  }
+  const auto input_data = PlainToBlockedNChw4c(plain_reference, 1, 16, 4, 4);
+
+  test.AddInput<float>("X", {1, 16, 4, 4}, input_data);
+
+  // Output: [1, 16, 4, 4] in NCHW format
+  test.AddOutput<float>("Y", {1, 16, 4, 4}, plain_reference);
+
+  RunOnWebGpu(test);
+}
+
+// Test Plain to Blocked with padding (non-divisible channels)
+TEST(FormatTransformTest, PlainToBlocked_WithPadding) {
+  OpTester test("FormatTransform", 1, kMSInternalNHWCDomain);
+
+  // Attributes
+  test.AddAttribute<std::string>("src_format", "Plain");
+  test.AddAttribute<std::string>("dst_format", "nChw4c");
+
+  // Input: [1, 10, 2, 2] - 10 channels, not divisible by 4
+  std::vector<float> input_data(1 * 10 * 2 * 2);
+  for (size_t i = 0; i < input_data.size(); ++i) {
+    input_data[i] = static_cast<float>(i % 100);
+  }
+  test.AddInput<float>("X", {1, 10, 2, 2}, input_data);
+
+  // Output: [1, 12, 2, 2] - padded to 12 channels (3 blocks of 4)
+  // The last 2 channels (10-11) will be filled with zeros (padding)
+  const int output_C = 12;  // Padded from 10 to 12
+  const auto output_data = PlainToBlockedNChw4c(input_data, 1, 10, 2, 2, output_C);
+  test.AddOutput<float>("Y", {1, 12, 2, 2}, output_data);
+
+  RunOnWebGpu(test);
+}
+
+// Test round-trip transformation: Plain -> Blocked -> Plain
+TEST(FormatTransformTest, RoundTrip) {
+  // Original data in plain format
+  std::vector<float> original_data(1 * 16 * 4 * 4);
+  for (size_t i = 0; i < original_data.size(); ++i) {
+    original_data[i] = static_cast<float>(i);
+  }
+
+  // First transformation: Plain to nChw4c
+  OpTester test1("FormatTransform", 1, kMSInternalNHWCDomain);
+  test1.AddAttribute<std::string>("src_format", "Plain");
+  test1.AddAttribute<std::string>("dst_format", "nChw4c");
+
+  test1.AddInput<float>("X", {1, 16, 4, 4}, original_data);
+
+  // Calculate blocked output
+  const auto blocked_data = PlainToBlockedNChw4c(original_data, 1, 16, 4, 4);
+  test1.AddOutput<float>("Y", {1, 16, 4, 4}, blocked_data);
+  RunOnWebGpu(test1);
+
+  // Second transformation: nChw4c back to Plain
+  OpTester test2("FormatTransform", 1, kMSInternalNHWCDomain);
+  test2.AddAttribute<std::string>("src_format", "nChw4c");
+  test2.AddAttribute<std::string>("dst_format", "Plain");
+
+  test2.AddInput<float>("X", {1, 16, 4, 4}, blocked_data);
+  test2.AddOutput<float>("Y", {1, 16, 4, 4}, original_data);
+
+  RunOnWebGpu(test2);
+}
+
+TEST(FormatTransformTest, PlainToBlocked_ABcd16a4b) {
+  OpTester test("FormatTransform", 1, kMSInternalNHWCDomain);
+
+  test.AddAttribute<std::string>("src_format", "Plain");
+  test.AddAttribute<std::string>("dst_format", "ABcd16a4b");
+
+  // Input: [32, 8, 4, 4] in plain NCHW format
+  // This will be transformed to ABcd16a4b format: [32/16, 8/4, 4, 4, 16, 4]
+  // N=32 (2 blocks of 16), C=8 (2 blocks of 4)
+  std::vector<float> input_data;
+  for (int n = 0; n < 32; n++) {
+    for (int c = 0; c < 8; c++) {
+      for (int h = 0; h < 4; h++) {
+        for (int w = 0; w < 4; w++) {
+          input_data.push_back(static_cast<float>(n * 1000 + c * 100 + h * 10 + w));
+        }
+      }
+    }
+  }
+
+  // Expected output in ABcd16a4b format
+  const auto expected_data = PlainToBlockedABcd16a4b(input_data, 32, 8, 4, 4);
+
+  test.AddInput<float>("X", {32, 8, 4, 4}, input_data);
+  test.AddOutput<float>("Y", {32, 8, 4, 4}, expected_data);
+
+  RunOnWebGpu(test);
+}
+
+TEST(FormatTransformTest, PlainToBlocked_ABcd16a4b_WithPadding) {
+  OpTester test("FormatTransform", 1, kMSInternalNHWCDomain);
+
+  test.AddAttribute<std::string>("src_format", "Plain");
+  test.AddAttribute<std::string>("dst_format", "ABcd16a4b");
+
+  const int N = 18;
+  const int C = 6;
+  const int H = 2;
+  const int W = 2;
+  std::vector<float> input_data(N * C * H * W);
+  for (size_t i = 0; i < input_data.size(); ++i) {
+    input_data[i] = static_cast<float>(i);
+  }
+
+  test.AddInput<float>("X", {N, C, H, W}, input_data);
+
+  const int padded_N = ComputePaddedSize(N, kABcd16aBlock);
+  const int padded_C = ComputePaddedSize(C, kABcd4bBlock);
+  const auto expected_data = PlainToBlockedABcd16a4b(input_data, N, C, H, W, padded_N, padded_C);
+
+  test.AddOutput<float>("Y", {padded_N, padded_C, H, W}, expected_data);
+
+  RunOnWebGpu(test);
+}
+
+TEST(FormatTransformTest, BlockedToPlain_ABcd16a4b) {
+  OpTester test("FormatTransform", 1, kMSInternalNHWCDomain);
+
+  test.AddAttribute<std::string>("src_format", "ABcd16a4b");
+  test.AddAttribute<std::string>("dst_format", "Plain");
+
+  // Input and expected tensors in plain format
+  std::vector<float> plain_data;
+  for (int n = 0; n < 32; n++) {
+    for (int c = 0; c < 8; c++) {
+      for (int h = 0; h < 4; h++) {
+        for (int w = 0; w < 4; w++) {
+          plain_data.push_back(static_cast<float>(n * 1000 + c * 100 + h * 10 + w));
+        }
+      }
+    }
+  }
+  const auto input_data = PlainToBlockedABcd16a4b(plain_data, 32, 8, 4, 4);
+
+  test.AddInput<float>("X", {32, 8, 4, 4}, input_data);
+  test.AddOutput<float>("Y", {32, 8, 4, 4}, plain_data);
+
+  RunOnWebGpu(test);
+}
+
+TEST(FormatTransformTest, BlockedToPlain_ABcd16a4b_WithPadding) {
+  OpTester test("FormatTransform", 1, kMSInternalNHWCDomain);
+
+  test.AddAttribute<std::string>("src_format", "ABcd16a4b");
+  test.AddAttribute<std::string>("dst_format", "Plain");
+
+  const int N = 18;
+  const int C = 6;
+  const int H = 2;
+  const int W = 2;
+  const int padded_N = ComputePaddedSize(N, kABcd16aBlock);
+  const int padded_C = ComputePaddedSize(C, kABcd4bBlock);
+
+  std::vector<float> plain_data(N * C * H * W);
+  for (size_t i = 0; i < plain_data.size(); ++i) {
+    plain_data[i] = static_cast<float>(1000 + i);
+  }
+
+  const auto input_data = PlainToBlockedABcd16a4b(plain_data, N, C, H, W, padded_N, padded_C);
+
+  std::vector<float> expected_data(static_cast<size_t>(padded_N) * padded_C * H * W, 0.0f);
+  for (int n = 0; n < N; ++n) {
+    for (int c = 0; c < C; ++c) {
+      for (int h = 0; h < H; ++h) {
+        for (int w = 0; w < W; ++w) {
+          const int padded_idx = ((n * padded_C + c) * H + h) * W + w;
+          const int compact_idx = ((n * C + c) * H + h) * W + w;
+          expected_data[padded_idx] = plain_data[compact_idx];
+        }
+      }
+    }
+  }
+
+  test.AddInput<float>("X", {padded_N, padded_C, H, W}, input_data);
+  test.AddOutput<float>("Y", {padded_N, padded_C, H, W}, expected_data);
+
+  RunOnWebGpu(test);
+}
+
+TEST(FormatTransformTest, RoundTrip_ABcd16a4b) {
+  OpTester test1("FormatTransform", 1, kMSInternalNHWCDomain);
+  test1.AddAttribute<std::string>("src_format", "Plain");
+  test1.AddAttribute<std::string>("dst_format", "ABcd16a4b");
+
+  std::vector<float> input_data;
+  for (int n = 0; n < 32; n++) {
+    for (int c = 0; c < 8; c++) {
+      for (int h = 0; h < 2; h++) {
+        for (int w = 0; w < 2; w++) {
+          input_data.push_back(static_cast<float>(n * 100 + c * 10 + h * 2 + w));
+        }
+      }
+    }
+  }
+
+  // First transform to ABcd16a4b
+  const auto intermediate_data = PlainToBlockedABcd16a4b(input_data, 32, 8, 2, 2);
+
+  test1.AddInput<float>("X", {32, 8, 2, 2}, input_data);
+  test1.AddOutput<float>("Y", {32, 8, 2, 2}, intermediate_data);
+
+  RunOnWebGpu(test1);
+
+  // Then transform back to Plain
+  OpTester test2("FormatTransform", 1, kMSInternalNHWCDomain);
+  test2.AddAttribute<std::string>("src_format", "ABcd16a4b");
+  test2.AddAttribute<std::string>("dst_format", "Plain");
+
+  test2.AddInput<float>("X", {32, 8, 2, 2}, intermediate_data);
+  test2.AddOutput<float>("Y", {32, 8, 2, 2}, input_data);
+
+  RunOnWebGpu(test2);
+}
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // USE_WEBGPU


### PR DESCRIPTION
- add the WebGPU FormatTransform kernel, headers, and WGSL template, supporting Plain <-> nChw4c/ABcd16a4b conversions
- register the FormatTransform schema in the internal NHWC domain with padding-aware shape inference
- hook the kernel into the WebGPU execution provider and add WebGPU tests covering both blocked formats, padding cases, and round trips