### PR TITLE
[QNN EP] Handle 0-dim tensor for Concat.

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
@@ -13,6 +13,34 @@ bool IsOptionalNodeUnitIODef(const NodeUnitIODef& node_io_def) {
   const NodeArg& arg = node_io_def.node_arg;
   return !arg.Exists() || arg.Name().empty();
 }
+
+// Function to check whether we should skip processing null input which has 0 dim in shape.
+// Such null inputs often exist in models saved from PyTorch, especially for Concat.
+bool DoesConcatInputShapeContainZero(QnnModelWrapper& qnn_model_wrapper,
+                                     const NodeUnit& node_unit,
+                                     const NodeUnitIODef& node_io_def,
+                                     const logging::Logger& logger) {
+  // Although the 0 dim issue should be handled for all op types, restricting in Concat for now since current cases
+  // only happen on one of Concat inputs. One may rename the function and relax the checking here to extend for other
+  // ops.
+  if (node_unit.OpType() != "Concat") {
+    return false;
+  }
+
+  std::vector<uint32_t> input_shape;
+  if (!qnn_model_wrapper.GetOnnxShape(node_io_def.node_arg, input_shape)) {
+    return false;
+  }
+
+  for (const uint32_t& dim : input_shape) {
+    if (dim == 0) {
+      LOGS(logger, WARNING) << "Tensor has 0 dim, ignore this input: " << node_io_def.node_arg.Name();
+      return true;
+    }
+  }
+
+  return false;
+}
 }  // namespace
 
 std::string BaseOpBuilder::GetOpBuilderType() const {
@@ -126,7 +154,9 @@ Status BaseOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
   const auto& inputs = node_unit.Inputs();
   const auto input_count = GetInputCountQnnRequired(node_unit);
   for (size_t input_i = 0; input_i < input_count; ++input_i) {
-    ORT_RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[input_i], logger, input_names));
+    if (!DoesConcatInputShapeContainZero(qnn_model_wrapper, node_unit, inputs[input_i], logger)) {
+      ORT_RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[input_i], logger, input_names));
+    }
   }
 
   return Status::OK();

--- a/onnxruntime/test/providers/qnn/simple_op_htp_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_htp_test.cc
@@ -128,6 +128,15 @@ TEST_F(QnnCPUBackendTests, DISABLED_UnaryOp_Relu) {
                  ExpectedEPNodeAssignment::All);
 }
 
+TEST_F(QnnCPUBackendTests, Concat_EmptyInput) {
+  RunOpTestOnCPU("Concat",
+                 {TestInputDef<float>({1, 3, 4, 4}, false, -10.0f, 10.0f),
+                  TestInputDef<float>({1, 0, 4, 4}, false, {})},
+                 {utils::MakeAttribute("axis", static_cast<int64_t>(1))},
+                 13,
+                 ExpectedEPNodeAssignment::All);
+}
+
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 // Tests the accuracy of a QDQ model on QNN EP by comparing to CPU EP, which runs both the fp32 model


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Define a util function `IsNullNodeUnitIODef` to check whether given tensor has 0-dim in shape. To restrict the impact, current implementation only skip constructing such tensor for Concat.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
There may exsit tensor with 0-dim in shape, especially for Concat's inputs. Such null inputs often exist in models saved from PyTorch. Since QNN could not execute empty tensors, they must be explicitly handled.

