### PR TITLE
[webgpu] Fix BatchNormalization ShapeInferenceError for 2D inputs

### DIFF
--- a/onnxruntime/core/graph/contrib_ops/nhwc_inference_context.h
+++ b/onnxruntime/core/graph/contrib_ops/nhwc_inference_context.h
@@ -83,7 +83,8 @@ class NhwcInferenceContext : public ONNX_NAMESPACE::InferenceContext {
       const int rank = nchw_shape.dim_size();
       // N and C dims are required. Some operators like AveragePool allow 1D input
       if (rank < 3) {
-        fail_shape_inference("Output tensor must have at least 3 dimensions");
+        *nhwc_tp.mutable_tensor_type()->mutable_shape() = nchw_shape;
+        return;
       }
 
       // Convert output shape from N, C, H {, W, ...} to N, H {, W, ...}, C.
@@ -105,8 +106,8 @@ class NhwcInferenceContext : public ONNX_NAMESPACE::InferenceContext {
       const int rank = nhwc_shape.dim_size();
       // N and C dims are required. Some operators like AveragePool allow 1D input.
       if (rank < 3) {
-        fail_shape_inference(
-            "Tensor must have at least 3 dimensions to convert between channels first and channels last.");
+        *nchw_tp.mutable_tensor_type()->mutable_shape() = nhwc_shape;
+        return;
       }
 
       // Convert input shape from {N, H, W, ..., C} to {N, C, H, W, ...}.


### PR DESCRIPTION
### Description

Test model (happens with any 2D inputs): [2191__visual_projection_visual_projection.1_BatchNormalization.onnx.zip](https://github.com/user-attachments/files/23758390/2191__visual_projection_visual_projection.1_BatchNormalization.onnx.zip)


Command:
```
python -c "import onnxruntime as ort; ort.InferenceSession('2191__visual_projection_visual_projection.1_BatchNormalization.onnx', providers=['WebGpuExecutionProvider'])"
```

Before (failure):
```
Op (BatchNormalization) [ShapeInferenceError] Tensor must have at least 3 dimensions to convert between channels first and channels last.
```

After (success):
```
(nothing, meaning success)
```

### Motivation and Context

This fixes BatchNormalization on WebGPU, matching CPU version.

cc @guschmue
