### PR TITLE
[QNN EP] Update tensor naming logic in DebugNodeInputsOutputs

### DIFF
--- a/onnxruntime/core/framework/debug_node_inputs_outputs_utils.h
+++ b/onnxruntime/core/framework/debug_node_inputs_outputs_utils.h
@@ -54,6 +54,8 @@ constexpr const char* kOpTypeFilter = "ORT_DEBUG_NODE_IO_OP_TYPE_FILTER";
 constexpr const char* kDumpDataDestination = "ORT_DEBUG_NODE_IO_DUMP_DATA_DESTINATION";
 // set to non-zero to append OpenMPI world rank to filename
 constexpr const char* kAppendRankToFileName = "ORT_DEBUG_NODE_IO_APPEND_RANK_TO_FILE_NAME";
+// set to non-zero to prepend ep type to filename
+constexpr const char* kPrependEpToFileName = "ORT_DEBUG_NODE_IO_PREPEND_EP_TO_FILE_NAME";
 // specify the output directory for any data files produced
 constexpr const char* kOutputDir = "ORT_DEBUG_NODE_IO_OUTPUT_DIR";
 // specify the file prefix for sqlite3 db (process id will be appended)
@@ -116,6 +118,9 @@ struct NodeDumpOptions {
     // write to one row per tensor input/output in Sqlite table
     SqliteDb
   } data_destination{DataDestination::StdOut};
+
+  // Whether to prepend ep type to output file name.
+  bool prepend_ep_to_file_name{false};
 
   std::string file_suffix;
   // the output directory for dumped data files


### PR DESCRIPTION
### Description
Introduced a new environment variable ORT_DEBUG_NODE_IO_PREPEND_EP_TO_FILE_NAME to control whether the Execution Provider (EP) type is prepended to tensor file names.
Updated MakeTensorFileName() and related logic to include the EP type in the format: `<EPType>_<TensorName>` when the variable is set to a non-zero value. This change helps avoid file name conflicts and improves clarity when analyzing outputs from multi-EP runs.

### Motivation and Context
Accuracy unit tests may run the same model multiple times using different EPs, such as ORT CPU and QNN HTP. Previously, dumped tensor files used identical names when tensor names matched across sessions, causing file overwrites.

### Example
When ORT_DEBUG_NODE_IO_PREPEND_EP_TO_FILE_NAME=1, dumped tensors include EP-specific prefixes:
```
CPU_input.tensorproto
CPU_input_token_0.tensorproto
CPU_output.tensorproto
QNN_constant.tensorproto
QNN_input.tensorproto
QNN_input_token_0.tensorproto
QNN_output.tensorproto
```
