### PR TITLE
Compute cpabality as kCURRENT by default

### DIFF
--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
@@ -2634,7 +2634,12 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
     trt_config->setMemoryPoolLimit(nvinfer1::MemoryPoolType::kTACTIC_SHARED_MEMORY, max_shared_mem_size_);
   }
 
-  // Only set compute capability for Turing
+  // Set compute capability to kCURRENT by default
+  // Must set the number of compute capabilities before setting the capability itself
+  constexpr int kDefaultNumComputeCapabilities = 1;
+  if (trt_config->getNbComputeCapabilities() == 0) {
+    trt_config->setNbComputeCapabilities(kDefaultNumComputeCapabilities);
+  }
   trt_config->setComputeCapability(nvinfer1::ComputeCapability::kCURRENT, 0);
 
   int num_inputs = trt_network->getNbInputs();


### PR DESCRIPTION
Made compute capability as kCURRENT by default

For better performance, benchmarking and based on current state most use cases today to be build and run on same device or same SM.