### PR TITLE
[MLAS] Rework the mechanism for checking SME capabilities

### DIFF
--- a/onnxruntime/core/mlas/lib/convolve.cpp
+++ b/onnxruntime/core/mlas/lib/convolve.cpp
@@ -938,8 +938,9 @@ Return Value:
 --*/
 {
     // Override
-    if(GetMlasPlatform().MlasConvOverride != nullptr &&
-        GetMlasPlatform().MlasConvOverride(Parameters,Input,Filter,Bias,WorkingBuffer,Output,ThreadPool)){
+    if(SMEInfo::IsSMEAvailable &&
+       GetMlasPlatform().MlasConvOverride != nullptr &&
+       GetMlasPlatform().MlasConvOverride(Parameters,Input,Filter,Bias,WorkingBuffer,Output,ThreadPool)) {
     return;
     }
 
@@ -1201,7 +1202,8 @@ Return Value:
 --*/
 {
     // Override
-    if (GetMlasPlatform().MlasConvPrepareOverride != nullptr &&
+    if (SMEInfo::IsSMEAvailable &&
+        GetMlasPlatform().MlasConvPrepareOverride != nullptr &&
         GetMlasPlatform().MlasConvPrepareOverride(Parameters, Dimensions, BatchCount, GroupCount, InputChannels,
         InputShape,KernelShape,DilationShape, Padding, StrideShape, OutputShape, FilterCount,
         Activation, WorkingBufferSize, Beta, ThreadPool)){

--- a/onnxruntime/core/mlas/lib/kleidiai/mlasi_kleidiai.h
+++ b/onnxruntime/core/mlas/lib/kleidiai/mlasi_kleidiai.h
@@ -51,9 +51,6 @@
 
 namespace ArmKleidiAI {
 
-// By default we should try for SME2 first before falling back to SME.
-inline const bool UseSME2 = MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME2();
-
 // Buffer packing routines.
 //
 size_t

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -317,13 +317,21 @@ operator!=(const MLFloat16& left, const MLFloat16& right)
 
 #endif  // BUILD_MLAS_NO_ONNXRUNTIME
 
-#if defined(MLAS_TARGET_ARM64)
-
 struct SMEInfo {
     static const bool CanUseSME2;
     static const bool CanUseSME;
     static const bool IsSMEAvailable;
 };
+
+#if !defined(MLAS_TARGET_ARM64)
+// SME is only available on arm64 systems but the structure is available in places which can be accessed by all system types
+inline const bool SMEInfo::CanUseSME2 = false;
+inline const bool SMEInfo::CanUseSME  = false;
+inline const bool SMEInfo::IsSMEAvailable = false;
+
+#endif  // !MLAS_TARGET_ARM64
+
+#if defined(MLAS_TARGET_ARM64)
 
 // Boolean condition to determine if we can use SME2
 // By default we should try for SME2 first before falling back to SME.

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -201,6 +201,10 @@ class MLASCPUIDInfo
 
     bool HasArmNeon_BF16() const { return has_arm_neon_bf16_; }
 
+    bool HasArm_SME() const { return has_arm_sme_; }
+
+    bool HasArm_SME2() const { return has_arm_sme2_; }
+
    private:
     MLASCPUIDInfo();
 
@@ -210,6 +214,8 @@ class MLASCPUIDInfo
     bool has_arm_sve_{false};
     bool has_arm_sve_i8mm_{false};
     bool has_arm_neon_bf16_{false};
+    bool has_arm_sme_{false};
+    bool has_arm_sme2_{false};
 };
 using MLAS_CPUIDINFO = MLASCPUIDInfo;
 
@@ -310,6 +316,24 @@ operator!=(const MLFloat16& left, const MLFloat16& right)
 }
 
 #endif  // BUILD_MLAS_NO_ONNXRUNTIME
+
+#if defined(MLAS_TARGET_ARM64)
+
+struct SMEInfo {
+    static const bool CanUseSME2;
+    static const bool CanUseSME;
+    static const bool IsSMEAvailable;
+};
+
+// Boolean condition to determine if we can use SME2
+// By default we should try for SME2 first before falling back to SME.
+inline const bool SMEInfo::CanUseSME2 = MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME2();
+// Boolean condition to determine if we can use SME
+inline const bool SMEInfo::CanUseSME  = MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME();
+// Boolean condition to tell us if SME is enabled on this system
+inline const bool SMEInfo::IsSMEAvailable = SMEInfo::CanUseSME2 || SMEInfo::CanUseSME;
+
+#endif // MLAS_TARGET_ARM64
 
 static_assert(sizeof(MLAS_FP16) == FP16_SIZE);
 

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -601,7 +601,7 @@ Return Value:
     }
 
 #if defined(USE_KLEIDIAI) && !defined(_MSC_VER)
-    if(MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME()){
+    if (SMEInfo::IsSMEAvailable) {
         this->MlasGemmBatchOverride = ArmKleidiAI::MlasGemmBatch;
         this->MlasGemmPackBSizeOverride = ArmKleidiAI::MlasGemmPackBSize;
         this->MlasGemmPackBOverride = ArmKleidiAI::MlasGemmPackB;

--- a/onnxruntime/core/mlas/lib/qgemm.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm.cpp
@@ -206,7 +206,7 @@ MLASCALL
 MlasIsDynamicQGemmAvailable()
 {
 #if defined(USE_KLEIDIAI) && !defined(_MSC_VER)
-  return ArmKleidiAI::UseSME2;
+  return SMEInfo::CanUseSME2;
 #else
   return false;
 #endif
@@ -223,8 +223,10 @@ MlasDynamicQGemmBatch (
     assert(MlasIsDynamicQGemmAvailable());
 
 #if defined(USE_KLEIDIAI) && !defined(_MSC_VER)
-    //No fallback
-    ArmKleidiAI::MlasDynamicQGemmBatch(Shape, DataParams, BatchN, ThreadPool);
+    //No fallback and putting in guards. This implementation is SME2 specific.
+    if(SMEInfo::CanUseSME2){
+        ArmKleidiAI::MlasDynamicQGemmBatch(Shape, DataParams, BatchN, ThreadPool);
+    }
 #endif
 
     MLAS_UNREFERENCED_PARAMETER(Shape);
@@ -349,7 +351,9 @@ MlasDynamicQgemmPackBSize(
 #if defined(USE_KLEIDIAI) && !defined(_MSC_VER)
     //No fallback available
     //TODO: Insert Override
-    bytes = ArmKleidiAI::MlasDynamicQgemmPackBSize(N, K);
+    if(MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME2()){//Still require this since no override
+        bytes = ArmKleidiAI::MlasDynamicQgemmPackBSize(N, K);
+    }
 #endif
 
     MLAS_UNREFERENCED_PARAMETER(N);
@@ -442,7 +446,9 @@ MlasDynamicQgemmPackB(
 
 #if defined(USE_KLEIDIAI) && !defined(_MSC_VER)
     //No fallback
-    ArmKleidiAI::MlasDynamicQgemmPackB(N, K, B, Scales, Bias, PackedB);
+    if(MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME2()){//Still require this since no override
+        ArmKleidiAI::MlasDynamicQgemmPackB(N, K, B, Scales, Bias, PackedB);
+    }
 #endif
 
     MLAS_UNREFERENCED_PARAMETER(N);


### PR DESCRIPTION
### Description
In Various parts of Onnxruntime and in particular MLAS with kleidiai enabled. We rely on cpu info checks for SME and/or SME2 this patch aims to simplify that process by adding a struct which gives easy to understand information and adding it to the relevant places in the code.

Additionally it gates qgemm_kleidiai.cpp properly against non sme2 hardware gaining access. This will address https://github.com/microsoft/onnxruntime/issues/26377 which raises one such instance of this occurring on a device with has SME1 support but not SME2


