### PR TITLE
blog: Add community blog for ONNX usage in Ionic

### DIFF
--- a/src/routes/blogs/+page.svelte
+++ b/src/routes/blogs/+page.svelte
@@ -448,6 +448,13 @@
 	];
 	let blogsCommunity = [
 		{
+			title: 'Use AI models on-device with Ionic, React, and ONNX Runtime',
+			date: 'December 1, 2025',
+			link: 'https://vault.top/blog/use-ai-models-on-device-with-ionic-react-and-onnx-runtime',
+			blurb:
+				'A practical walkthrough of running AI models locally (on-device) in an Ionic React app across iOS, Android, and the web. Includes pseudocode examples using ONNX Runtime for model setup, inference, and use cases.'
+		},
+		{
 			title: 'Sentence Transformers 3.2.0: 2x-3x Faster Inference with ONNX Runtime',
 			date: 'October 10, 2024',
 			link: 'https://github.com/UKPLab/sentence-transformers/releases/tag/v3.2.0',


### PR DESCRIPTION
### Description
This PR adds a community blog post to show how ONNX Runtime can be added to an Ionic single-page-app and deployed to iOS/Android/or as a normal browser app using WASM. 


### Motivation and Context
I am unsure if the community posts blog section is still active, but I figured this might help others wanting to deploy using the WASM approach in a single-page-app. The use of Ionic as a development framework might not apply universally, but it should be straightforward to bridge to other frameworks. The bundling aspects of the post took the most time to get correct, so I believe that's where there is the most value for others.

No worries at all if this is walkthrough does not match the current goals for the community posts page.


