### PR TITLE
[QNN-EP] Enable skip_qnn_version_check in qnn unit test

### DIFF
--- a/onnxruntime/test/providers/qnn/README.md
+++ b/onnxruntime/test/providers/qnn/README.md
@@ -43,13 +43,22 @@ The tests are built as part of the regular ONNX Runtime build. After a successfu
 3. Verbose
     - `QNN_VERBOSE`: Sets the ONNX Runtime log level to `ORT_LOGGING_LEVEL_VERBOSE`
 
-4. You can enable any combination of these environment variables, for example:
+4. Version Check Control
+    - `QNN_SKIP_VERSION_CHECK`: Skips the QNN SDK version compatibility check during test execution
+        - This is useful for:
+            - Testing with custom or experimental QNN SDK builds
+            - Running tests across multiple QNN SDK versions during development
+            - Debugging scenarios where version validation is not the focus
+        - **Note**: Skipping version checks may lead to unexpected behavior if there are actual incompatibilities between the ONNX Runtime QNN EP and the QNN SDK version being used. Use this option with caution and only when you understand the compatibility implications.
+
+5. You can enable any combination of these environment variables, for example:
     - On Linux/macOS
         ```bash
         export QNN_DUMP_ONNX=1
         export QNN_DUMP_JSON=1
         export QNN_DUMP_DLC=1
         export QNN_VERBOSE=1
+        export QNN_SKIP_VERSION_CHECK=1
         ```
     - On Windows
         ```cmd
@@ -57,12 +66,14 @@ The tests are built as part of the regular ONNX Runtime build. After a successfu
         set QNN_DUMP_JSON=1
         set QNN_DUMP_DLC=1
         set QNN_VERBOSE=1
+        set QNN_SKIP_VERSION_CHECK=1
         ```
         ```ps1
         $Env:QNN_DUMP_ONNX = "1"
         $Env:QNN_DUMP_JSON = "1"
         $Env:QNN_DUMP_DLC = "1"
         $Env:QNN_VERBOSE = "1"
+        $Env:QNN_SKIP_VERSION_CHECK = "1"
         ```
 
 # Note

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.cc
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.cc
@@ -154,6 +154,9 @@ void RunQnnModelTest(const GetTestModelFn& build_test_case, ProviderOptions prov
     provider_options["dump_json_qnn_graph"] = "1";
     provider_options["json_qnn_graph_dir"] = output_dir.string();
   }
+  if (QNNTestEnvironment::GetInstance().skip_qnn_version_check()) {
+    provider_options["skip_qnn_version_check"] = "1";
+  }
   RunAndVerifyOutputsWithEP(AsByteSpan(model_data.data(), model_data.size()), "QNN_EP_TestLogID",
                             QnnExecutionProviderWithOptions(provider_options),
                             helper.feeds_, verification_params,
@@ -212,6 +215,9 @@ void RunQnnModelTestHTPNoVerify(const GetTestModelFn& build_test_case, ProviderO
   if (QNNTestEnvironment::GetInstance().dump_json()) {
     provider_options["dump_json_qnn_graph"] = "1";
     provider_options["json_qnn_graph_dir"] = output_dir.string();
+  }
+  if (QNNTestEnvironment::GetInstance().skip_qnn_version_check()) {
+    provider_options["skip_qnn_version_check"] = "1";
   }
 
   SessionOptions so;
@@ -408,7 +414,7 @@ static BackendSupport GetHTPSupport(const onnxruntime::logging::Logger& logger) 
   MockKernelLookup kernel_lookup;
   onnxruntime::GraphViewer graph_viewer(graph);
   std::unique_ptr<onnxruntime::IExecutionProvider> qnn_ep = QnnExecutionProviderWithOptions(
-      {{"backend_type", "htp"}, {"offload_graph_io_quantization", "0"}});
+      {{"backend_type", "htp"}, {"offload_graph_io_quantization", "0"}, {"skip_qnn_version_check", "1"}});
   GraphOptimizerRegistry graph_optimizer_registry(nullptr, nullptr, nullptr);  // as a placeholder to feed into GetCapability
 
   qnn_ep->SetLogger(&logger);
@@ -466,7 +472,7 @@ static BackendSupport GetGPUSupport(const onnxruntime::logging::Logger& logger) 
   MockKernelLookup kernel_lookup;
   onnxruntime::GraphViewer graph_viewer(graph);
   std::unique_ptr<onnxruntime::IExecutionProvider> qnn_ep = QnnExecutionProviderWithOptions(
-      {{"backend_type", "gpu"}, {"offload_graph_io_quantization", "0"}});
+      {{"backend_type", "gpu"}, {"offload_graph_io_quantization", "0"}, {"skip_qnn_version_check", "1"}});
   GraphOptimizerRegistry graph_optimizer_registry(nullptr, nullptr, nullptr);  // as a placeholder to feed into GetCapability
 
   qnn_ep->SetLogger(&logger);
@@ -542,7 +548,7 @@ static BackendSupport GetCPUSupport(const onnxruntime::logging::Logger& logger, 
   MockKernelLookup kernel_lookup;
   onnxruntime::GraphViewer graph_viewer(graph);
   std::unique_ptr<onnxruntime::IExecutionProvider> qnn_ep = QnnExecutionProviderWithOptions(
-      {{"backend_type", backend_type}, {"offload_graph_io_quantization", "0"}});
+      {{"backend_type", backend_type}, {"offload_graph_io_quantization", "0"}, {"skip_qnn_version_check", "1"}});
   GraphOptimizerRegistry graph_optimizer_registry(nullptr, nullptr, nullptr);  // as a placeholder to feed into GetCapability
 
   qnn_ep->SetLogger(&logger);

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.h
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.h
@@ -515,6 +515,7 @@ class QNNTestEnvironment {
   bool dump_json() const { return dump_json_; }
   bool dump_dlc() const { return dump_dlc_; }
   bool verbose() const { return verbose_; }
+  bool skip_qnn_version_check() const { return skip_qnn_version_check_; }
 
   std::filesystem::path CreateTestcaseDirs() {
     std::string test_suite_name = ::testing::UnitTest::GetInstance()->current_test_info()->test_suite_name();
@@ -562,12 +563,18 @@ class QNNTestEnvironment {
       std::cout << "Verbose enabled via environment variable." << std::endl;
       verbose_ = true;
     }
+
+    if (IsEnvVarSet("QNN_SKIP_VERSION_CHECK")) {
+      std::cout << "[QNN only] Skip QNN version check via environment variable." << std::endl;
+      skip_qnn_version_check_ = true;
+    }
   }
 
   bool dump_onnx_ = false;
   bool dump_json_ = false;
   bool dump_dlc_ = false;
   bool verbose_ = false;
+  bool skip_qnn_version_check_ = false;
 };
 
 /**
@@ -694,6 +701,9 @@ inline void TestQDQModelAccuracy(const GetTestModelFn& f32_model_fn, const GetTe
   if (QNNTestEnvironment::GetInstance().dump_json()) {
     qnn_options["dump_json_qnn_graph"] = "1";
     qnn_options["json_qnn_graph_dir"] = output_dir.string();
+  }
+  if (QNNTestEnvironment::GetInstance().skip_qnn_version_check()) {
+    qnn_options["skip_qnn_version_check"] = "1";
   }
   std::vector<OrtValue> qnn_qdq_outputs;
   if (!qnn_ctx_model_path.empty()) {
@@ -928,6 +938,9 @@ inline void TestFp16ModelAccuracy(const GetTestModelFn& f32_model_fn,
   if (QNNTestEnvironment::GetInstance().dump_json()) {
     qnn_options["dump_json_qnn_graph"] = "1";
     qnn_options["json_qnn_graph_dir"] = output_dir.string();
+  }
+  if (QNNTestEnvironment::GetInstance().skip_qnn_version_check()) {
+    qnn_options["skip_qnn_version_check"] = "1";
   }
   std::vector<OrtValue> qnn_f16_outputs;
   if (!qnn_ctx_model_path.empty()) {


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- This PR allow users to specify the environment variable `QNN_SKIP_VERSION_CHECK` to enable the `skip_qnn_version_check` flag in QNN unit tests.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- Developers can run unit tests with different QNN SDK versions during development and debugging **without rebuild**
- Developers can test new features that are compatible across multiple QNN versions **without rebuild**