### PR TITLE
[QNN EP] Add Static bias encoding support for Conv op

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -1057,6 +1057,80 @@ Status QuantizeData(gsl::span<const float> data, gsl::span<const uint32_t> shape
   return Status::OK();
 }
 
+Status DequantizePerChannel(gsl::span<const uint8_t> quant_bytes, gsl::span<const uint32_t> shape,
+                            gsl::span<const float> scales, gsl::span<const int32_t> offsets,
+                            /*out*/ gsl::span<float> data, Qnn_DataType_t data_type,
+                            std::optional<int64_t> axis) {
+  const size_t num_dims = shape.size();
+  const size_t num_elems = ShapeSizeCalc(shape, 0, num_dims);
+  ORT_RETURN_IF_NOT(num_elems == data.size(), "Shape mismatch with data to dequantize");
+  size_t expected_num_quant_bytes = GetElementSizeByType(data_type) * data.size();
+  ORT_RETURN_IF_NOT(quant_bytes.size() == expected_num_quant_bytes,
+                    "Cannot dequantize data because input buffer is not the correct size");
+
+  size_t block_count = 1;
+  size_t broadcast_dim = 1;
+  size_t block_size = num_elems;
+
+  if (axis.has_value()) {
+    size_t axis_no_neg = *axis < 0 ? static_cast<size_t>(*axis) + num_dims : static_cast<size_t>(*axis);
+    block_count = ShapeSizeCalc(shape, 0, axis_no_neg);
+    broadcast_dim = shape[axis_no_neg];
+    block_size = ShapeSizeCalc(shape, axis_no_neg + 1, num_dims);
+  }
+
+  ORT_RETURN_IF_NOT(scales.size() == broadcast_dim, "Unexpected size of scales input buffer");
+  ORT_RETURN_IF_NOT(offsets.size() == broadcast_dim, "Unexpected size of offsets input buffer");
+
+  size_t i = 0;
+  for (size_t n = 0; n < block_count; n++) {
+    for (size_t bd = 0; bd < broadcast_dim; bd++) {
+      switch (data_type) {
+        case QNN_DATATYPE_SFIXED_POINT_8: {
+          const int8_t* input = reinterpret_cast<const int8_t*>(&quant_bytes[i * sizeof(int8_t)]);
+          for (size_t j = 0; j < block_size; j++) {
+            data[i + j] = static_cast<float>(Dequantize(offsets[bd], scales[bd], static_cast<double>(input[j])));
+          }
+          break;
+        }
+        case QNN_DATATYPE_UFIXED_POINT_8: {
+          const uint8_t* input = reinterpret_cast<const uint8_t*>(&quant_bytes[i * sizeof(uint8_t)]);
+          for (size_t j = 0; j < block_size; j++) {
+            data[i + j] = static_cast<float>(Dequantize(offsets[bd], scales[bd], static_cast<double>(input[j])));
+          }
+          break;
+        }
+        case QNN_DATATYPE_SFIXED_POINT_16: {
+          const int16_t* input = reinterpret_cast<const int16_t*>(&quant_bytes[i * sizeof(int16_t)]);
+          for (size_t j = 0; j < block_size; j++) {
+            data[i + j] = static_cast<float>(Dequantize(offsets[bd], scales[bd], static_cast<double>(input[j])));
+          }
+          break;
+        }
+        case QNN_DATATYPE_UFIXED_POINT_16: {
+          const uint16_t* input = reinterpret_cast<const uint16_t*>(&quant_bytes[i * sizeof(uint16_t)]);
+          for (size_t j = 0; j < block_size; j++) {
+            data[i + j] = static_cast<float>(Dequantize(offsets[bd], scales[bd], static_cast<double>(input[j])));
+          }
+          break;
+        }
+        case QNN_DATATYPE_SFIXED_POINT_32: {
+          const int32_t* input = reinterpret_cast<const int32_t*>(&quant_bytes[i * sizeof(int32_t)]);
+          for (size_t j = 0; j < block_size; j++) {
+            data[i + j] = static_cast<float>(Dequantize(offsets[bd], scales[bd], static_cast<double>(input[j])));
+          }
+          break;
+        }
+        default:
+          return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Unsupported quantization data type for DequantizeData");
+      }
+      i += block_size;
+    }
+  }
+
+  return Status::OK();
+}
+
 /**
  * @brief QuantizeData with LPBQ encodings (per_channel_float_scales, per_block_int_scales)
  * @pre-condition data should have axis at 0
@@ -1429,6 +1503,59 @@ Status GetPermToLastAxis(uint32_t axis, uint32_t rank, std::vector<uint32_t>& pe
 uint64_t GetTimeStampInUs() {
   auto timestamp = std::chrono::steady_clock::now().time_since_epoch();
   return std::chrono::duration_cast<std::chrono::microseconds>(timestamp).count();
+}
+
+bool CheckBiasScaleMatch(float bias_scale, float weights_scale, float activation_scale, float tolerance) {
+  float expected_scale = weights_scale * activation_scale;
+  return std::abs(bias_scale - expected_scale) <= tolerance;
+}
+
+Status RequantizeBiasTensor(const std::vector<uint8_t>& original_bias_data,
+                            const std::vector<uint32_t>& bias_shape,
+                            gsl::span<const float> current_scales,
+                            gsl::span<const int32_t> current_offsets,
+                            gsl::span<const float> weights_scales,
+                            float activation_scale,
+                            Qnn_DataType_t data_type,
+                            /*out*/ std::vector<uint8_t>& requantized_bias_data,
+                            /*out*/ std::vector<float>& new_scales,
+                            /*out*/ std::vector<int32_t>& new_offsets,
+                            std::optional<int64_t> axis) {
+  const size_t num_dims = bias_shape.size();
+  const size_t num_elems = ShapeSizeCalc(bias_shape, 0, num_dims);
+
+  // Step 1: Dequantize the bias tensor to float
+  std::vector<float> float_bias_data(num_elems);
+  ORT_RETURN_IF_ERROR(DequantizePerChannel(original_bias_data, bias_shape, current_scales, current_offsets,
+                                           float_bias_data, data_type, axis));
+
+  // Step 2: Calculate new quantization parameters
+  size_t broadcast_dim = 1;
+  if (axis.has_value()) {
+    size_t axis_no_neg = *axis < 0 ? static_cast<size_t>(*axis) + num_dims : static_cast<size_t>(*axis);
+    broadcast_dim = bias_shape[axis_no_neg];
+  }
+
+  // Resize output vectors
+  new_scales.resize(broadcast_dim);
+  new_offsets.resize(broadcast_dim);
+
+  // Calculate per-channel bias scales: bias_scale[i] = weights_scale[i] * activation_scale
+  for (size_t i = 0; i < broadcast_dim; ++i) {
+    // Use the corresponding weight scale if available, otherwise use the first one
+    float weight_scale = (i < weights_scales.size()) ? weights_scales[i] : weights_scales[0];
+    new_scales[i] = weight_scale * activation_scale;
+    new_offsets[i] = 0;
+  }
+
+  // Step 3: Quantize back with new parameters
+  size_t expected_output_bytes = GetElementSizeByType(data_type) * num_elems;
+  requantized_bias_data.resize(expected_output_bytes);
+
+  ORT_RETURN_IF_ERROR(QuantizeData(float_bias_data, bias_shape, new_scales, new_offsets,
+                                   requantized_bias_data, data_type, axis));
+
+  return Status::OK();
 }
 
 }  // namespace utils

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.h
@@ -185,6 +185,15 @@ Status GetQuantParams(float rmin,
 
 double Dequantize(int32_t offset, float scale, const double quant_value);
 
+// Dequantizes the given quantized data using the provided quantization parameters (scales and offsets).
+// Supports both per-tensor and per-channel quantization. Must provide an axis argument
+// for per-channel quantization.
+// The provided offsets must use the QNN convention where offset = -zero_point.
+Status DequantizePerChannel(gsl::span<const uint8_t> quant_bytes, gsl::span<const uint32_t> shape,
+                            gsl::span<const float> scales, gsl::span<const int32_t> offsets,
+                            /*out*/ gsl::span<float> data, Qnn_DataType_t data_type,
+                            std::optional<int64_t> axis = std::nullopt);
+
 Status Quantize(const double double_value,
                 const float scale,
                 const int32_t zero_point,
@@ -459,6 +468,28 @@ Status GetPermToLastAxis(uint32_t axis, uint32_t rank, std::vector<uint32_t>& pe
  * @return the current timestamp in microseconds
  */
 uint64_t GetTimeStampInUs();
+
+// Checks if bias scale matches the expected scale (weights_scale * activation_scale)
+// Returns true if they match within a tolerance, false otherwise
+bool CheckBiasScaleMatch(float bias_scale, float weights_scale, float activation_scale,
+                         float tolerance = 1e-5f);
+
+// Requantizes a static bias tensor with new quantization parameters
+// This function:
+// 1. Dequantizes the bias tensor to float using current parameters
+// 2. Calculates new bias_scale[i] = weights_scale[i] * activation_scale for each channel
+// 3. Quantizes back to the target data type with new parameters
+Status RequantizeBiasTensor(const std::vector<uint8_t>& original_bias_data,
+                            const std::vector<uint32_t>& bias_shape,
+                            gsl::span<const float> current_scales,
+                            gsl::span<const int32_t> current_offsets,
+                            gsl::span<const float> weights_scales,
+                            float activation_scale,
+                            Qnn_DataType_t data_type,
+                            /*out*/ std::vector<uint8_t>& requantized_bias_data,
+                            /*out*/ std::vector<float>& new_scales,
+                            /*out*/ std::vector<int32_t>& new_offsets,
+                            std::optional<int64_t> axis = std::nullopt);
 
 }  // namespace utils
 }  // namespace qnn

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -73,6 +73,181 @@ static GetTestModelFn BuildF32ConvTestCase(const std::string& conv_op_type, cons
   };
 }
 
+// Creates a graph with a single Q/DQ Conv operator with mismatched bias scales to test bias requantization.
+template <typename ActivationQType, typename WeightQType>
+static GetTestQDQModelFn<ActivationQType> BuildQDQConvBiasRequantTestCase(
+    const std::string& conv_op_type,
+    const TestInputDef<float>& input_def,
+    const TestInputDef<float>& weights_def,
+    const TestInputDef<float>& bias_def,
+    const std::vector<int64_t>& strides,
+    const std::vector<int64_t>& pads,
+    const std::vector<int64_t>& dilations,
+    std::optional<int64_t> group,
+    const std::string& auto_pad = "NOTSET",
+    bool use_contrib_qdq = false) {
+  return [conv_op_type, input_def, weights_def, bias_def, strides, pads,
+          dilations, group, auto_pad, use_contrib_qdq](ModelTestBuilder& builder,
+                                                       std::vector<QuantParams<ActivationQType>>& output_qparams) {
+    std::vector<NodeArg*> conv_inputs;
+
+    // input -> Q/DQ ->
+    auto* input = MakeTestInput(builder, input_def);
+    QuantParams<ActivationQType> input_qparams = GetTestInputQuantParams<ActivationQType>(input_def);
+    auto* input_qdq = AddQDQNodePair<ActivationQType>(builder, input, input_qparams.scale, input_qparams.zero_point,
+                                                      use_contrib_qdq);
+    conv_inputs.push_back(input_qdq);
+
+    // weights -> Q/DQ ->
+    auto* weights = MakeTestInput(builder, weights_def);
+    QuantParams<WeightQType> weights_qparams = GetTestInputQuantParams<WeightQType>(weights_def);
+    auto* weights_qdq = AddQDQNodePair<WeightQType>(builder, weights, weights_qparams.scale,
+                                                    weights_qparams.zero_point, use_contrib_qdq);
+    conv_inputs.push_back(weights_qdq);
+
+    // bias -> Create bias with MISMATCHED scale to trigger requantization
+    if (!bias_def.GetShape().empty()) {
+      // Intentionally use a WRONG bias scale that doesn't match (input_scale * weight_scale)
+      // This should trigger the bias requantization logic in QNN EP
+      const float correct_bias_scale = input_qparams.scale * weights_qparams.scale;
+      const float wrong_bias_scale = correct_bias_scale * 2.5f;  // Intentionally wrong scale
+
+      conv_inputs.push_back(MakeTestQDQBiasInput(builder, bias_def, wrong_bias_scale, use_contrib_qdq));
+    }
+
+    auto* conv_output = builder.MakeIntermediate();
+    Node& conv_node = builder.AddNode(conv_op_type, conv_inputs, {conv_output});
+
+    conv_node.AddAttribute("auto_pad", auto_pad);
+
+    if (group.has_value()) {
+      conv_node.AddAttribute("group", group.value());
+    }
+
+    if (!pads.empty() && auto_pad == "NOTSET") {
+      conv_node.AddAttribute("pads", pads);
+    }
+    if (!strides.empty()) {
+      conv_node.AddAttribute("strides", strides);
+    }
+    if (!dilations.empty()) {
+      conv_node.AddAttribute("dilations", dilations);
+    }
+
+    AddQDQNodePairWithOutputAsGraphOutput<ActivationQType>(builder, conv_output, output_qparams[0].scale,
+                                                           output_qparams[0].zero_point, use_contrib_qdq);
+  };
+}
+
+// Creates a graph with a single Q/DQ Conv operator with per-channel weights and mismatched bias scales to test bias requantization.
+template <typename ActivationQType, typename WeightQType>
+static GetTestQDQModelFn<ActivationQType> BuildQDQConvPerChannelBiasRequantTestCase(
+    const std::string& conv_op_type,
+    const TestInputDef<float>& input_def,
+    const TestInputDef<float>& weights_def,
+    const TestInputDef<float>& bias_def,
+    int64_t weight_quant_axis,
+    const std::vector<int64_t>& strides,
+    const std::vector<int64_t>& pads,
+    const std::vector<int64_t>& dilations,
+    std::optional<int64_t> group,
+    const std::string& auto_pad = "NOTSET",
+    bool use_contrib_qdq = false) {
+  return [conv_op_type, input_def, weights_def, bias_def, strides, pads,
+          dilations, group, auto_pad, use_contrib_qdq,
+          weight_quant_axis](ModelTestBuilder& builder,
+                             std::vector<QuantParams<ActivationQType>>& output_qparams) {
+    std::vector<NodeArg*> conv_inputs;
+
+    // input -> Q/DQ ->
+    auto* input = MakeTestInput(builder, input_def);
+    QuantParams<ActivationQType> input_qparams = GetTestInputQuantParams<ActivationQType>(input_def);
+    auto* input_qdq = AddQDQNodePair<ActivationQType>(builder, input, input_qparams.scale, input_qparams.zero_point,
+                                                      use_contrib_qdq);
+    conv_inputs.push_back(input_qdq);
+
+    // Quantized(weights) -> DQ -> (per-channel quantization)
+    ORT_ENFORCE(weights_def.IsInitializer() && weights_def.IsRawData());
+    std::vector<float> weight_scales;
+    std::vector<WeightQType> weight_zero_points;
+    TensorShape weights_shape = weights_def.GetTensorShape();
+    int64_t pos_weight_quant_axis = weight_quant_axis;
+    if (pos_weight_quant_axis < 0) {
+      pos_weight_quant_axis += static_cast<int64_t>(weights_shape.NumDimensions());
+    }
+    GetTestInputQuantParamsPerChannel<WeightQType>(weights_def, weight_scales, weight_zero_points,
+                                                   static_cast<size_t>(pos_weight_quant_axis), true);
+
+    std::vector<WeightQType> quantized_weights;
+    size_t num_weight_storage_elems = weights_shape.Size();
+    if constexpr (std::is_same_v<WeightQType, Int4x2> || std::is_same_v<WeightQType, UInt4x2>) {
+      num_weight_storage_elems = Int4x2::CalcNumInt4Pairs(weights_shape.Size());
+    }
+    quantized_weights.resize(num_weight_storage_elems);
+    QuantizeValues<float, WeightQType>(weights_def.GetRawData(), quantized_weights, weights_shape,
+                                       weight_scales, weight_zero_points, pos_weight_quant_axis);
+
+    NodeArg* weights_initializer = builder.MakeInitializer<WeightQType>(weights_def.GetShape(), quantized_weights);
+    NodeArg* weights_dq = builder.MakeIntermediate();
+    Node& weights_dq_node = builder.AddDequantizeLinearNode<WeightQType>(weights_initializer, weight_scales,
+                                                                         weight_zero_points, weights_dq,
+                                                                         nullptr, use_contrib_qdq);
+    weights_dq_node.AddAttribute("axis", weight_quant_axis);
+    conv_inputs.push_back(weights_dq);
+
+    // Quantized(bias) -> DQ -> (per-channel quantization with WRONG scales)
+    if (!bias_def.GetShape().empty()) {
+      // Create INTENTIONALLY WRONG bias scales that don't match input_scale * weight_scale[i]
+      // This should cause QDQ to fail against CPU, but our requantization should fix it
+      ORT_ENFORCE(bias_def.IsInitializer() && bias_def.IsRawData());
+      std::vector<float> wrong_bias_scales = weight_scales;
+      std::vector<int32_t> bias_zero_points(weight_scales.size(), 0);
+
+      // Apply wrong scaling factors to each channel - this will make QDQ fail without requantization
+      for (size_t i = 0; i < wrong_bias_scales.size(); i++) {
+        // Use different wrong multipliers for each channel to make it really wrong
+        float wrong_multiplier = 1.5f + (i * 0.3f);  // 1.5, 1.8, 2.1, etc.
+        wrong_bias_scales[i] = (input_qparams.scale * weight_scales[i]) * wrong_multiplier;
+      }
+
+      TensorShape bias_shape = bias_def.GetTensorShape();
+      std::vector<int32_t> quantized_biases(bias_shape.Size());
+      QuantizeValues<float, int32_t>(bias_def.GetRawData(), quantized_biases, bias_shape, wrong_bias_scales,
+                                     bias_zero_points, 0);
+
+      NodeArg* bias_initializer = builder.MakeInitializer<int32_t>(bias_def.GetShape(), quantized_biases);
+      NodeArg* bias_dq = builder.MakeIntermediate();
+      Node& bias_dq_node = builder.AddDequantizeLinearNode<int32_t>(bias_initializer, wrong_bias_scales, bias_zero_points,
+                                                                    bias_dq, nullptr, use_contrib_qdq);
+
+      bias_dq_node.AddAttribute("axis", static_cast<int64_t>(0));
+      conv_inputs.push_back(bias_dq);
+    }
+
+    auto* conv_output = builder.MakeIntermediate();
+    Node& conv_node = builder.AddNode(conv_op_type, conv_inputs, {conv_output});
+
+    conv_node.AddAttribute("auto_pad", auto_pad);
+
+    if (group.has_value()) {
+      conv_node.AddAttribute("group", group.value());
+    }
+
+    if (!pads.empty() && auto_pad == "NOTSET") {
+      conv_node.AddAttribute("pads", pads);
+    }
+    if (!strides.empty()) {
+      conv_node.AddAttribute("strides", strides);
+    }
+    if (!dilations.empty()) {
+      conv_node.AddAttribute("dilations", dilations);
+    }
+
+    AddQDQNodePairWithOutputAsGraphOutput<ActivationQType>(builder, conv_output, output_qparams[0].scale,
+                                                           output_qparams[0].zero_point, use_contrib_qdq);
+  };
+}
+
 // Runs a Conv model on the QNN CPU backend. Checks the graph node assignment, and that inference
 // outputs for QNN EP and CPU EP match.
 static void RunConvOpTest(const std::string& conv_op_type, const TestInputDef<float>& input_def,
@@ -800,6 +975,79 @@ TEST_F(QnnHTPBackendTests, ConvU16S4S32_PerChannel) {
                                                ExpectedEPNodeAssignment::All,
                                                false,  // use_qdq_contrib_ops
                                                21);    // opset
+}
+
+// Test bias requantization when bias scale doesn't match (weight_scale * activation_scale)
+// This test uses a bias with intentionally wrong scale to trigger the requantization logic in QNN EP
+TEST_F(QnnHTPBackendTests, ConvU8U8S32_BiasRequantization) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  TestQDQModelAccuracy(BuildF32ConvTestCase("Conv",
+                                            TestInputDef<float>({1, 2, 4, 4}, false, -10.0f, 10.0f),  // Input
+                                            TestInputDef<float>({3, 2, 2, 2}, true, -1.0f, 5.0f),     // Weights
+                                            TestInputDef<float>({3}, true, -1.0f, 1.0f),              // Bias
+                                            {1, 1},                                                   // Strides
+                                            {0, 0, 0, 0},                                             // Pads
+                                            {1, 1},                                                   // Dilations
+                                            1,                                                        // Group
+                                            "NOTSET"),                                                // Auto pad
+                       BuildQDQConvBiasRequantTestCase<uint8_t, uint8_t>("Conv",
+                                                                         TestInputDef<float>({1, 2, 4, 4}, false, -10.0f, 10.0f),  // Input
+                                                                         TestInputDef<float>({3, 2, 2, 2}, true, -1.0f, 5.0f),     // Weights
+                                                                         TestInputDef<float>({3}, true, -1.0f, 1.0f),              // Bias (will get wrong scale)
+                                                                         {1, 1},                                                   // Strides
+                                                                         {0, 0, 0, 0},                                             // Pads
+                                                                         {1, 1},                                                   // Dilations
+                                                                         1,                                                        // Group
+                                                                         "NOTSET"),                                                // Auto pad
+                       provider_options,
+                       13,  // opset
+                       ExpectedEPNodeAssignment::All,
+                       QDQTolerance(0.015f));
+}
+
+// Test per-channel bias requantization when bias scales don't match (weight_scale[i] * activation_scale)
+// This test uses a bias with intentionally wrong scales that would cause QDQ to fail against CPU,
+// but the requantization logic should correct it, allowing the test to pass.
+TEST_F(QnnHTPBackendTests, ConvU8S8S32_PerChannel_BiasRequantization) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  TestInputDef<float> input_def({1, 2, 4, 4}, false, -10.0f, 10.0f);
+  std::vector<int64_t> weight_shape = {3, 2, 2, 2};
+  TestInputDef<float> weight_def(weight_shape, true,
+                                 GetFloatDataInRange(-1.0f, 5.0f, TensorShape(weight_shape).Size()));
+  std::vector<int64_t> bias_shape = {3};
+  TestInputDef<float> bias_def(bias_shape, true,
+                               GetFloatDataInRange(-1.0f, 1.0f, TensorShape(bias_shape).Size()));
+
+  TestQDQModelAccuracy(BuildF32ConvTestCase("Conv",
+                                            input_def,
+                                            weight_def,
+                                            bias_def,
+                                            {1, 1},        // Strides
+                                            {0, 0, 0, 0},  // Pads
+                                            {1, 1},        // Dilations
+                                            1,             // Group
+                                            "NOTSET"),     // Auto pad
+                       BuildQDQConvPerChannelBiasRequantTestCase<uint8_t, int8_t>("Conv",
+                                                                                  input_def,
+                                                                                  weight_def,
+                                                                                  bias_def,
+                                                                                  0,             // weight quant axis
+                                                                                  {1, 1},        // Strides
+                                                                                  {0, 0, 0, 0},  // Pads
+                                                                                  {1, 1},        // Dilations
+                                                                                  1,             // Group
+                                                                                  "NOTSET",      // Auto pad
+                                                                                  false),        // use_contrib_qdq
+                       provider_options,
+                       13,  // opset
+                       ExpectedEPNodeAssignment::All,
+                       QDQTolerance(0.015));
 }
 
 // Test per-channel QDQ Conv with INT4 weights and no bias.


### PR DESCRIPTION
- Fix QNN-EP to support static bias tensors with mismatched quantization encodings
- Add requantization logic to ensure bias_scale = weights_scale x activation_scale

### Description
The QNN-EP currently lacks support for static bias tensors with quantization encodings that don't match the expected mathematical relationship bias_scale = weights_scale × activation_scale.



### Motivation and Context
This leads to HTP backend disregard the encodings of the bias tensor and recompute its own causing accuracy drops


