### PR TITLE
[webgpu] Fix the check of `ValidateVariableDataType()` with Split-K

### DIFF
--- a/onnxruntime/core/providers/webgpu/shader_helper.cc
+++ b/onnxruntime/core/providers/webgpu/shader_helper.cc
@@ -140,8 +140,12 @@ namespace {
 // Validate if the tensor element type matches the program variable data type
 Status ValidateVariableDataType(int32_t element_type, ProgramVariableDataType var_type, bool is_atomic = false) {
   if (is_atomic) {
-    // float32 is not a valid data type for atomic. However the data may be bitcast-ed to i32 and used to simulate atomic operation using  atomicCompareExchangeWeak.
-    ORT_RETURN_IF_NOT(var_type == ProgramVariableDataType::Int32 || var_type == ProgramVariableDataType::Uint32 || var_type == ProgramVariableDataType::Float32,
+    // float32, float32x4 and float16x4 are not valid data types for atomic. However the data may be bitcast-ed to i32 and used to simulate atomic operation using  atomicCompareExchangeWeak.
+    ORT_RETURN_IF_NOT(var_type == ProgramVariableDataType::Int32 ||
+                          var_type == ProgramVariableDataType::Uint32 ||
+                          var_type == ProgramVariableDataType::Float32 ||
+                          var_type == ProgramVariableDataType::Float16x4 ||
+                          var_type == ProgramVariableDataType::Float32x4,
                       "Unexpected program variable type ", int(var_type), " for atomic variable");
   }
 


### PR DESCRIPTION
### Description
This patch adds the support of `float16x4` and `float32x4` in `ValidateVariableDataType()` as we may declare them as atomic variables when Split-K is used.



### Motivation and Context
Previously we failed to discover this issue because `ValidateVariableDataType()` is only used in the Debug build.


