### PR TITLE
Add 28 + 35 to CMake download_retry_codes

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -225,6 +225,13 @@ option(onnxruntime_ENABLE_EXTERNAL_CUSTOM_OP_SCHEMAS "Enable registering user de
 
 set(ONNX_CUSTOM_PROTOC_EXECUTABLE "" CACHE STRING "Specify custom protoc executable to build ONNX")
 
+# Enable retries on connection time out and TLS handshake failures for older CMake versions
+# This is implemented in latter versions of CMake, but is a nice-to-have when building
+# with older versions, since onnxruntime pulls in lots of dependencies!
+# 35 is in the default download_retry_codes from v3.28.5 onwards.
+# 28 is in the default download_retry_codes from v3.26.1 onwards
+set(download_retry_codes 7 6 8 15 28 35)
+
 # pre-build python path
 option(onnxruntime_PREBUILT_PYTORCH_PATH "Path to pytorch installation dir")
 


### PR DESCRIPTION
These are the default in later versions of CMake, but for people in positions like me, building on older HW, depending on older dependencies, and on somewhat poor network connections, having retries as default is helpful in the build process.

This was implemented by request as per [1].

I am also building onnxruntime from source on a Jetson Orin, so I'm confined to specific CUDA/TensorRT versions as per [2], and I imagine there are others in my situation whom this would benefit!

[1] https://discourse.cmake.org/t/feature-request-more-robust-retry-policy-for-fetchcontent-externalproject-add-in-download-cmake/7560/3
[2] https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#requirements

### Description

Manually set `cmake_download_retries` as per latter versions of `cmake` for those compiling `onnxruntime` forced to use earlier versions of cmake.

### Motivation and Context

I'm on a less-than-ideal internet connection, trying to build `onnxruntime` from source on a Jetson Orin. I'm locked into older versions of CMake (understandably), and `onnxruntime` pulls in a bunch of dependencies. I don't want to walk away from my desk and see my build stopped 30 mins ago because downloading a zip file timed out!


