### PR TITLE
[QNN] Support QNN HTA backend through better Op validation (#26739)

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
@@ -23,6 +23,11 @@ std::string BaseOpBuilder::GetOpBuilderType() const {
 Status BaseOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
                                     const NodeUnit& node_unit,
                                     const logging::Logger& logger) const {
+  const std::string qnn_op_name = GetQnnOpType(node_unit.OpType());
+  const bool isOpSupported = qnn_model_wrapper.IsOpSupported(qnn_op_name);
+
+  ORT_RETURN_IF_NOT(isOpSupported, "Operation " + qnn_op_name + " is unsupported for the current backend");
+
   // General Datatype checks on various QNN backend (HTP, CPU, GPU)
   ORT_RETURN_IF_ERROR(ProcessDataTypes(qnn_model_wrapper, node_unit));
   return AddToModelBuilder(qnn_model_wrapper, node_unit, logger, true);

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -11,6 +11,7 @@
 #include "CPU/QnnCpuCommon.h"
 #include "GPU/QnnGpuCommon.h"
 #include "DSP/QnnDspCommon.h"
+#include "HTA/QnnHtaCommon.h"
 #include "HTP/QnnHtpCommon.h"
 #include "HTP/QnnHtpContext.h"
 #include "HTP/QnnHtpPerfInfrastructure.h"
@@ -278,6 +279,9 @@ void QnnBackendManager::SetQnnBackendType(uint32_t backend_id) {
       break;
     case QNN_BACKEND_ID_DSP:
       qnn_backend_type_ = QnnBackendType::DSP;
+      break;
+    case QNN_BACKEND_ID_HTA:
+      qnn_backend_type_ = QnnBackendType::HTA;
       break;
     case QNN_BACKEND_ID_HTP:
       qnn_backend_type_ = QnnBackendType::HTP;
@@ -925,6 +929,7 @@ Status QnnBackendManager::CreateContext(bool enable_htp_weight_sharing) {
   switch (GetQnnBackendType()) {
     case QnnBackendType::HTP:
     case QnnBackendType::DSP:
+    case QnnBackendType::HTA:
       configs = npu_context_configs;
       break;
     case QnnBackendType::GPU:

--- a/onnxruntime/core/providers/qnn/builder/qnn_def.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_def.cc
@@ -579,7 +579,7 @@ bool IsIrBackend(QnnBackendType backend_type) {
 }
 
 bool IsNpuBackend(QnnBackendType backend_type) {
-  return backend_type == QnnBackendType::HTP || backend_type == QnnBackendType::DSP;
+  return backend_type == QnnBackendType::HTP || backend_type == QnnBackendType::DSP || backend_type == QnnBackendType::HTA;
 }
 
 bool IsGpuBackend(QnnBackendType backend_type) {

--- a/onnxruntime/core/providers/qnn/builder/qnn_def.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_def.h
@@ -91,6 +91,7 @@ enum class QnnBackendType : uint8_t {
   CPU = 0,
   GPU,
   DSP,
+  HTA,
   HTP,
   HTP_FP16,
   SERIALIZER,


### PR DESCRIPTION
### Description
Provide better operation validation for the different QNN backends through qnn_interface backendGetSupportedOperations.

This resolves an issue with the QNN HTA backend not working for most convolutional models, as the automatically inserted transpose nodes are incorrectly marked as supported

Public APIs (C/C++ APIs and corresponding C# native methods) are not touched.

### Motivation and Context
Fixes an open issue with [QNN HTA support due to bad operation validation](https://github.com/microsoft/onnxruntime/issues/26739)

