### PR TITLE
Bring IR_VERSION and some other changes into provider_api.h

### DIFF
--- a/onnxruntime/core/providers/shared_library/provider_api.h
+++ b/onnxruntime/core/providers/shared_library/provider_api.h
@@ -79,6 +79,7 @@ enum TensorProto_DataType : int {
   TensorProto_DataType_UINT4 = 21,
   TensorProto_DataType_INT4 = 22,
   TensorProto_DataType_FLOAT4E2M1 = 23,
+  TensorProto_DataType_FLOAT8E8M0 = 24,
 };
 
 enum TensorProto_DataLocation : int {
@@ -98,7 +99,8 @@ enum Version : int {
   IR_VERSION_2021_7_31 = 8,
   IR_VERSION_2023_5_5 = 9,
   IR_VERSION_2024_3_25 = 10,
-  IR_VERSION = 11
+  IR_VERSION_2025_05_12 = 11,
+  IR_VERSION = 12
 };
 
 enum OperatorStatus : int {


### PR DESCRIPTION
### Description
Copy the most recent changes and update IR_VERSION in provider_api.h
which was lost during the most recent update.


### Motivation and Context
Some changes from the most recent ONNX update did not make it to provider_api.h.
This causes the max version check with version 11 fail for the newly created models for DLL based EPs
even though compiled from the same tree.
