### PR TITLE
Revert "Consistent with the configuration in the packaged cmake"

### DIFF
--- a/tools/ci_build/github/linux/copy_strip_binary.sh
+++ b/tools/ci_build/github/linux/copy_strip_binary.sh
@@ -18,6 +18,8 @@ EXIT_CODE=1
 uname -a
 cd "$BINARY_DIR"
 mv installed/usr/local $ARTIFACT_NAME
+mv $ARTIFACT_NAME/include/onnxruntime/* $ARTIFACT_NAME/include
+rmdir $ARTIFACT_NAME/include/onnxruntime
 # Do not ship onnx_test_runner
 rm -rf $ARTIFACT_NAME/bin
 echo "Copy debug symbols in a separate file and strip the original binary."
@@ -27,6 +29,9 @@ then
     strip -S $BINARY_DIR/$ARTIFACT_NAME/lib/$LIB_NAME
     # copy the CoreML EP header for macOS build (libs with .dylib ext)
     cp $SOURCE_DIR/include/onnxruntime/core/providers/coreml/coreml_provider_factory.h  $BINARY_DIR/$ARTIFACT_NAME/include
+else
+   # Linux
+   mv $ARTIFACT_NAME/lib64 $ARTIFACT_NAME/lib
 fi
 
 # copy the README, licence and TPN


### PR DESCRIPTION
Reverts microsoft/onnxruntime#26104

It seems like this fix although is correct and necessary, it needs some patches in some other places (like release pipelines and onnxruntime inference examples). We will try and address the actual issue the PR was addressing in a subsequent release. I will re-open all the GH issues that the fix PR closed out so that the actual issue is still tracked.

Will reopen:

https://github.com/microsoft/onnxruntime/issues/24003
https://github.com/microsoft/onnxruntime/issues/26186
https://github.com/microsoft/onnxruntime/issues/23642
https://github.com/microsoft/onnxruntime/issues/25279
https://github.com/microsoft/onnxruntime/issues/25242