### PR TITLE
Prevent concurrent OM read/write race by introducing file-based locking during dump and load (#26778)

### DIFF
--- a/onnxruntime/core/providers/cann/cann_execution_provider.cc
+++ b/onnxruntime/core/providers/cann/cann_execution_provider.cc
@@ -1403,9 +1403,9 @@ Status CANNExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& fuse
         std::lock_guard<std::mutex> lock(g_mutex);
         auto filename_with_suffix = cann::MatchFile(filename);
         if (!filename_with_suffix.empty()) {
-          std::string om_flie = filename + ".om";
+          std::string om_file = filename + ".om";
 
-          int fd = open(om_file.c_str(), O_RDWR | O_CREATE, 0666);
+          int fd = open(om_file.c_str(), O_RDWR | O_CREAT, 0666);
 
           if (fd >= 0){
             flock(fd, LOCK_SH);

--- a/onnxruntime/core/providers/cann/cann_graph.cc
+++ b/onnxruntime/core/providers/cann/cann_graph.cc
@@ -122,7 +122,7 @@ Status BuildONNXModel(ge::Graph& graph, std::string input_shape, const char* soc
   if (info.dump_om_model) {
     std::string final_file = file_name + ".om";
 
-    int lock_fd = open(final_flie.c_str(), O_CREATE | O_RDWR, 0666);
+    int lock_fd = open(final_file.c_str(), O_CREAT | O_RDWR, 0666);
 
     if (flock(lock_fd, LOCK_EX) == 0){
       CANN_GRAPH_RETURN_IF_ERROR(ge::aclgrphSaveModel(file_name.c_str(), model));


### PR DESCRIPTION
### Description
This PR introduces a file-based locking mechanism using `flock` to serialize OM file access:
**1.  Exclusive lock during OM dump**
When dumping the OM model:
- Open the target `.om` file
- Acquire an exlusive lock (`LOCK_EX`)
- Perform `Save`
- Release the lock after the dump completes

**2.  Shared lock during OM load**
When loading an existing OM model from disk:
- Open the same `.om` file
- Acquire an exlusive lock (`LOCK_SH`)
- Perform `Load`
- Release the lock after the load completes



### Motivation and Context
Fixed #26778 

