### PR TITLE
Add continue when one or more checks fail

### DIFF
--- a/onnxruntime/core/platform/linux/device_discovery.cc
+++ b/onnxruntime/core/platform/linux/device_discovery.cc
@@ -155,8 +155,15 @@ Status GetGpuDevices(std::vector<OrtHardwareDevice>& gpu_devices_out) {
 
   for (const auto& gpu_sysfs_path_info : gpu_sysfs_path_infos) {
     OrtHardwareDevice gpu_device{};
-    ORT_RETURN_IF_ERROR(GetGpuDeviceFromSysfs(gpu_sysfs_path_info, gpu_device));
-    gpu_devices.emplace_back(std::move(gpu_device));
+    // Changed from ORT_RETURN_IF_ERROR to just check status and continue on error
+    Status status = GetGpuDeviceFromSysfs(gpu_sysfs_path_info, gpu_device);
+    if (status.IsOK()) {
+      gpu_devices.emplace_back(std::move(gpu_device));
+    } else {
+      LOGS_DEFAULT(WARNING) << "Failed to get GPU device from sysfs path: " << status.ErrorMessage();
+      // Continue to next GPU instead of returning error
+      continue;
+    }
   }
 
   gpu_devices_out = std::move(gpu_devices);

--- a/onnxruntime/core/platform/linux/device_discovery.cc
+++ b/onnxruntime/core/platform/linux/device_discovery.cc
@@ -155,13 +155,11 @@ Status GetGpuDevices(std::vector<OrtHardwareDevice>& gpu_devices_out) {
 
   for (const auto& gpu_sysfs_path_info : gpu_sysfs_path_infos) {
     OrtHardwareDevice gpu_device{};
-    // Changed from ORT_RETURN_IF_ERROR to just check status and continue on error
     Status status = GetGpuDeviceFromSysfs(gpu_sysfs_path_info, gpu_device);
     if (status.IsOK()) {
       gpu_devices.emplace_back(std::move(gpu_device));
     } else {
       LOGS_DEFAULT(WARNING) << "Failed to get GPU device from sysfs path: " << status.ErrorMessage();
-      // Continue to next GPU instead of returning error
       continue;
     }
   }


### PR DESCRIPTION
### Description
When running the discover the function is apt to fail quickly instead of testing additional folders

### Motivation and Context
When attempting to use this library on a system with different kinds of GPUs, it will fail if any of the cardN options do not have the vendor directory populated.


