### PR TITLE
Revert "[QNN EP] Add support for building aarch64 wheels"

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -891,13 +891,12 @@ if (onnxruntime_USE_QNN OR onnxruntime_USE_QNN_INTERFACE)
                                              "${onnxruntime_QNN_HOME}/lib/${QNN_ARCH_ABI}/libHtpPrepare.so"
                                              "${onnxruntime_QNN_HOME}/lib/${QNN_ARCH_ABI}/HtpPrepare.dll")
       if (${QNN_ARCH_ABI} STREQUAL "aarch64-windows-msvc" OR ${QNN_ARCH_ABI} STREQUAL "arm64x-windows-msvc")
-        list(APPEND QNN_LIB_FILES "${onnxruntime_QNN_HOME}/lib/hexagon-v68/unsigned/libQnnHtpV68Skel.so"
-                                  "${onnxruntime_QNN_HOME}/lib/hexagon-v73/unsigned/libQnnHtpV73Skel.so"
-                                  "${onnxruntime_QNN_HOME}/lib/hexagon-v73/unsigned/libqnnhtpv73.cat"
-                                  "${onnxruntime_QNN_HOME}/lib/hexagon-v81/unsigned/libQnnHtpV81Skel.so"
-                                  "${onnxruntime_QNN_HOME}/lib/hexagon-v81/unsigned/libqnnhtpv81.cat")
-      elseif(${QNN_ARCH_ABI} STREQUAL "aarch64-ubuntu-gcc9.4")
-        list(APPEND QNN_LIB_FILES "${onnxruntime_QNN_HOME}/lib/hexagon-v68/unsigned/libQnnHtpV68Skel.so")
+        file(GLOB EXTRA_HTP_LIB LIST_DIRECTORIES false "${onnxruntime_QNN_HOME}/lib/hexagon-v68/unsigned/libQnnHtpV68Skel.so"
+                                               "${onnxruntime_QNN_HOME}/lib/hexagon-v73/unsigned/libQnnHtpV73Skel.so"
+                                               "${onnxruntime_QNN_HOME}/lib/hexagon-v73/unsigned/libqnnhtpv73.cat"
+                                               "${onnxruntime_QNN_HOME}/lib/hexagon-v81/unsigned/libQnnHtpV81Skel.so"
+                                               "${onnxruntime_QNN_HOME}/lib/hexagon-v81/unsigned/libqnnhtpv81.cat")
+        list(APPEND QNN_LIB_FILES ${EXTRA_HTP_LIB})
       endif()
       message(STATUS "QNN lib files: " ${QNN_LIB_FILES})
     endif()

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -293,25 +293,6 @@ void QnnBackendManager::SetQnnBackendType(uint32_t backend_id) {
 }
 
 Status QnnBackendManager::LoadBackend() {
-#if defined(__aarch64__) && defined(__linux__)
-  // QNN requires ADSP_LIBRARY_PATH to be set in order to find skel libs on Linux
-  static std::once_flag set_adsp_path_once;
-
-  std::call_once(set_adsp_path_once, []() {
-    constexpr std::string_view kAdspLibraryPathEnvVar{"ADSP_LIBRARY_PATH"};
-    const char* existing_path = getenv(kAdspLibraryPathEnvVar.data());
-    if (existing_path != nullptr) {
-      LOGS_DEFAULT(WARNING) << "Using existing ADSP_LIBRARY_PATH setting of " << existing_path
-                            << ", which may cause the HTP backend to fail.";
-      return;
-    }
-
-    std::filesystem::path qnn_lib_path(GetDefaultEnv().GetRuntimePath());
-    LOGS_DEFAULT(INFO) << "Setting " << kAdspLibraryPathEnvVar << " = " << qnn_lib_path;
-    setenv(kAdspLibraryPathEnvVar.data(), qnn_lib_path.c_str(), 1);
-  });
-#endif
-
   QnnInterface_t* backend_interface_provider{nullptr};
   auto rt = GetQnnInterfaceProvider<QnnInterfaceGetProvidersFn_t,
                                     QnnInterface_t>(backend_path_.c_str(),

--- a/setup.py
+++ b/setup.py
@@ -117,8 +117,6 @@ manylinux_tags = [
     "manylinux2014_s390x",
     "manylinux_2_28_x86_64",
     "manylinux_2_28_aarch64",
-    "manylinux_2_34_x86_64",
-    "manylinux_2_34_aarch64",
 ]
 is_manylinux = environ.get("AUDITWHEEL_PLAT", None) in manylinux_tags
 
@@ -278,8 +276,6 @@ try:
 
                 cann_dependencies = ["libascendcl.so", "libacl_op_compiler.so", "libfmk_onnx_parser.so"]
 
-                qnn_dependencies = ["libcdsprpc.so"]
-
                 dest = "onnxruntime/capi/libonnxruntime_providers_openvino.so"
                 if path.isfile(dest):
                     subprocess.run(
@@ -298,18 +294,12 @@ try:
                 pass
 
             _bdist_wheel.run(self)
-            if is_manylinux and not disable_auditwheel_repair and not is_openvino:
+            if is_manylinux and not disable_auditwheel_repair and not is_openvino and not is_qnn:
                 assert self.dist_dir is not None
                 file = glob(path.join(self.dist_dir, "*linux*.whl"))[0]
                 logger.info("repairing %s for manylinux1", file)
                 auditwheel_cmd = ["auditwheel", "-v", "repair", "-w", self.dist_dir, file]
-                for i in (
-                    cuda_dependencies
-                    + migraphx_dependencies
-                    + tensorrt_dependencies
-                    + cann_dependencies
-                    + qnn_dependencies
-                ):
+                for i in cuda_dependencies + migraphx_dependencies + tensorrt_dependencies + cann_dependencies:
                     auditwheel_cmd += ["--exclude", i]
                 logger.info("Running %s", " ".join([shlex.quote(arg) for arg in auditwheel_cmd]))
                 try:
@@ -386,12 +376,7 @@ if platform.system() == "Linux" or platform.system() == "AIX":
     # QNN
     qnn_deps = [
         "libQnnCpu.so",
-        "libQnnGpu.so",
         "libQnnHtp.so",
-        "libQnnHtpPrepare.so",
-        "libQnnHtpV68Skel.so",
-        "libQnnHtpV68Stub.so",
-        "libQnnIr.so",
         "libQnnSaver.so",
         "libQnnSystem.so",
         "libHtpPrepare.so",
@@ -449,7 +434,6 @@ else:
         "QnnCpu.dll",
         "QnnGpu.dll",
         "QnnHtp.dll",
-        "QnnIr.dll",
         "QnnSaver.dll",
         "QnnSystem.dll",
         "QnnHtpPrepare.dll",


### PR DESCRIPTION
Reverts microsoft/onnxruntime#26634 due to a packaging pipeline failure.