### PR TITLE
Change codeQL server in CI

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ["self-hosted", "1ES.Pool=onnxruntime-github-Ubuntu2204-AMD-CPU"]
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
### Description
Change the server used for CodeQL



### Motivation and Context
The self hosted runner is no longer available 


