### PR TITLE
Normalize protobuf integration from 4.52 to 6.33

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
@@ -4,8 +4,7 @@ mypy
 pytest
 setuptools>=68.2.2
 wheel
-protobuf==4.25.1; python_version < "3.14"
-protobuf==6.33.0; python_version >= "3.14"
+protobuf==6.33.0
 sympy==1.14
 flatbuffers
 neural-compressor>=2.2.1

--- a/tools/ci_build/github/linux/docker/scripts/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/requirements.txt
@@ -8,8 +8,7 @@ wheel==0.45.1
 argparse
 sympy==1.14
 flatbuffers
-protobuf==4.25.1; python_version < "3.14"
-protobuf==6.33.0; python_version >= "3.14"
+protobuf==6.33.0
 packaging
 onnxscript==0.5.3; python_version < "3.14"
 onnx-ir==0.1.10; python_version < "3.14"

--- a/tools/ci_build/github/linux/python/requirements.txt
+++ b/tools/ci_build/github/linux/python/requirements.txt
@@ -4,8 +4,7 @@ mypy
 pytest
 setuptools>=68.2.2
 wheel
-protobuf==4.25.1; python_version < "3.14"
-protobuf==6.33.0; python_version >= "3.14"
+protobuf==6.33.0
 sympy==1.14
 flatbuffers
 psutil

--- a/tools/ci_build/github/windows/python/requirements.txt
+++ b/tools/ci_build/github/windows/python/requirements.txt
@@ -4,8 +4,7 @@ mypy
 pytest
 setuptools>=68.2.2
 wheel
-protobuf==4.25.1; python_version < "3.14"
-protobuf==6.33.0; python_version >= "3.14"
+protobuf==6.33.0
 sympy==1.14
 flatbuffers
 psutil

--- a/tools/ci_build/requirements/transformers-test/requirements.txt
+++ b/tools/ci_build/requirements/transformers-test/requirements.txt
@@ -1,8 +1,7 @@
 # packages used by transformers python unittest
 packaging
 # protobuf and numpy is same as tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
-protobuf==4.25.1; python_version < "3.14"
-protobuf==6.33.0; python_version >= "3.14"
+protobuf==6.33.0
 numpy==2.2.6; python_version < "3.14"
 numpy==2.3.2; python_version >= "3.14"
 torch==2.8.0


### PR DESCRIPTION
Description

Update protobuf from version 4.25.1 to 6.33.0

Motivation and Context

There is an underlying security vulnerability with 4.25.1. Updating to 6.33.0 will improve our security posture.


