### PR TITLE
Address DML crashes in WebNN QDQ subgraph tests 

### DIFF
--- a/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selector_action_transformer.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selector_action_transformer.cc
@@ -163,8 +163,8 @@ void UnaryOpQDQRules(SelectorActionRegistry& qdq_selector_action_registry) {
   // Operators without DML QLinear kernel support (CPU only).
   // DML EP does not have QLinearLeakyRelu or QLinearSoftmax kernels.
   // See https://github.com/microsoft/onnxruntime/issues/26531
-  std::vector<const char*> cpu_only_providers = {kCpuExecutionProvider};
-  std::unique_ptr<NodeSelector> cpu_selector = std::make_unique<QDQ::UnarySelector>(cpu_only_providers);
+  std::vector<const char*> cpu_only_provider = {kCpuExecutionProvider};
+  std::unique_ptr<NodeSelector> cpu_selector = std::make_unique<QDQ::UnarySelector>(cpu_only_provider);
   qdq_selector_action_registry.RegisterSelectorAndAction(cpu_action_name,
                                                          {{"LeakyRelu", {}},
                                                           {"Softmax", {}}},


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
This change proposes a fix to some DML crashes observed in WebNN QDQ subgraph tests. The root cause of the problem as analyzed in the issue linked below is that the DML EP does not have kernels implemented for the QLinear versions of LeakyRelu and Softmax. The QDQ transformer has logic to fuse a 3-node sequence in the graph to the associated QLinear custom op. There is an operator registry which contains the mapping between EPs and the ops that the transformer consults for computing the quantized variants. 

The registry currently has the CPU and DML EPs supporting the same sets of operators (thereby assuming that the fused node would also be supported by the EP), so what I did was split out a separate registration for the LeakyRelu and Softmax ops and associate them with the CPU EP, while removing those ops from the prior list. 

I was trying to also explore other options like seeing if I could somehow check to see if the EP has a supported kernel for the op before proceeding with the assignment- I could not figure out a way to do this, though. 

I validated this change by building a private version of ORT and running the affected tests in Edge Canary. The crash did not occur for those tests with the fix in place. 

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
This bug causes crashes in the web browser's GPU sandbox process, which is a blocker for WebNN origin trials. The crashes need to be resolved. 

Fixes #26531. 