### PR TITLE
Add blackwell check in TRTRTX EP unit tests for FP4/FP8 Custom ops

### DIFF
--- a/onnxruntime/test/common/cuda_op_test_utils.cc
+++ b/onnxruntime/test/common/cuda_op_test_utils.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <iostream>
+
 #if defined(USE_CUDA) || defined(USE_NV)
 #include "cuda_runtime_api.h"
 #endif
@@ -25,6 +27,15 @@ int GetCudaArchitecture() {
     // If cuda device has issue, test will fail anyway so no need to raise error here.
     if (cudaSuccess == cudaGetDeviceProperties(&prop, current_device_id)) {
       cuda_arch = prop.major * 100 + prop.minor * 10;
+    }
+
+    // Log GPU compute capability
+    if (cuda_arch == -1) {
+      std::cout << "WARNING: CUDA is not available or failed to initialize" << std::endl;
+    } else {
+      std::cout << "GPU Compute Capability: SM "
+                << cuda_arch / 100 << "." << (cuda_arch % 100) / 10
+                << " (value: " << cuda_arch << ")" << std::endl;
     }
   }
 #endif

--- a/onnxruntime/test/providers/nv_tensorrt_rtx/nv_basic_test.cc
+++ b/onnxruntime/test/providers/nv_tensorrt_rtx/nv_basic_test.cc
@@ -24,7 +24,7 @@ namespace onnxruntime {
 namespace test {
 
 // Helper function to check if GPU is Blackwell (SM 12.0+) or above
-// Logs GPU compute capability and returns true if requirement is met
+// Returns true if requirement is met
 // Returns false if CUDA is unavailable or GPU is below SM 12.0
 static bool IsBlackwellOrAbove() {
   constexpr int kBlackwellMinCapability = 1200;  // SM 12.0 = 12 * 100 + 0 * 10
@@ -32,14 +32,8 @@ static bool IsBlackwellOrAbove() {
 
   // Check if CUDA is available
   if (cuda_arch == -1) {
-    std::cout << "WARNING: CUDA is not available or failed to initialize" << std::endl;
     return false;
   }
-
-  // Log GPU compute capability
-  std::cout << "GPU Compute Capability: SM "
-            << cuda_arch / 100 << "." << (cuda_arch % 100) / 10
-            << " (value: " << cuda_arch << ")" << std::endl;
 
   return cuda_arch >= kBlackwellMinCapability;
 }


### PR DESCRIPTION
### Description

- Follow-up to [PR-26555](https://github.com/microsoft/onnxruntime/pull/26555) -  add Blackwell check in TRTRTX EP unit tests for FP4/FP8 Custom ops since Blackwell

### Motivation and Context
- NVFP4 recipe (combination of FP4 and FP8) is primarily intended for Blackwell+ GPUs as they have Tensor Cores for FP4 data type.


