### PR TITLE
[WebGPU] Fix Conv prepacking mismatch with Im2ColMatMul path detection

### DIFF
--- a/onnxruntime/core/providers/webgpu/nn/conv.cc
+++ b/onnxruntime/core/providers/webgpu/nn/conv.cc
@@ -298,7 +298,9 @@ Status Conv<is_channels_last, is_fused>::PrePackInternal(ComputeContextBase& con
   // Im2ColMatMul path uses a different transpose (OIHW -> OHWI) and reads
   // kernel directly from context.Input(1), ignoring prepacked weights.
   // Skip prepacking when this path will be used at runtime.
-  if (CanApplyIm2ColMatMulProgram(context, is_channels_last, is_fused, kernel_shape, conv_attrs_.auto_pad, onnxruntime::narrow<uint32_t>(conv_attrs_.group))) {
+  if (CanApplyIm2ColMatMulProgram(context, is_channels_last, activation_.activation_kind_ != ActivationKind::None,
+                                  kernel_shape, conv_attrs_.auto_pad,
+                                  onnxruntime::narrow<uint32_t>(conv_attrs_.group))) {
     return Status::OK();
   }
 


### PR DESCRIPTION
Fix a bug where Conv kernel prepacking could incorrectly happen when the Im2ColMatMul execution path would be taken at runtime. This caused a "Missing Input" error because:

1. In PrePackInternal, the is_fused template parameter was passed to CanApplyIm2ColMatMulProgram
2. In ComputeInternal, activation_.activation_kind_ != ActivationKind::None was passed instead

For fused Conv kernels (is_fused=true) without an actual activation set, this mismatch caused CanApplyIm2ColMatMulProgram to return false during prepacking (allowing prepacking to occur) but true at runtime (selecting the Im2ColMatMul path which needs context.Input(1)).

The fix uses the same activation check in both places to ensure consistent path detection between prepack time and compute time.
