### PR TITLE
[QNN-EP] Update gather op input tensor cast logic.

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gather_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gather_op_builder.cc
@@ -160,7 +160,7 @@ static Status ProcessIndicesInput(QnnModelWrapper& qnn_model_wrapper,
   }
 
   // Insert QNN Cast op to convert dynamic indices from int64 to int32.
-  auto& input_tensorwrapper = qnn_model_wrapper.GetQnnTensorWrapper(indices_tensor_name);
+  const auto& input_tensorwrapper = qnn_model_wrapper.GetQnnTensorWrapper(indices_tensor_name);
 
   std::string indices_casted_name{indices_tensor_name};
   // Check QNN Tensor data type.


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Gather op was referring to onnx graph when deciding whether to insert `Cast->int32` on indices. But input tensor is created by QNN and it could already casted into int32. Which cause mismatch and resulting adding redundant Cast. This PR changes Gather Op builder to refer to QNN tenser before adding int64->int32 cast.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
It solve QNN-Gather op not to insert redundant Cast->int32.

