### PR TITLE
fix crash in webgpu init when OrtEnv is re-created

### DIFF
--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -945,7 +945,6 @@ WebGpuContext& WebGpuContextFactory::CreateContext(const WebGpuContextConfig& co
     dawnProcSetProcs(dawn_procs);
 #endif
 #endif
-
   });
 
   std::lock_guard<std::mutex> lock(mutex_);


### PR DESCRIPTION
fixes a crash seen with chrome -> webnn -> webgpu-ep when OrtEnv recreated.
The issue is that on OrtEnv destruction we null the default_instance but at init the creation of the default_instance is under std::call_once.

