### PR TITLE
Do not run auditwheel on QNN whls

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -299,7 +299,7 @@ try:
 
             # qnn links libc++ rather than libstdc++ for its x86_64 dependencies which we currently do not
             # support for many_linux. This is not the case for other platforms.
-            qnn_run_audit = os.environ.get("AUDITWHEEL_ARCH", "x86_64") != "x86_64"
+            qnn_run_audit = environ.get("AUDITWHEEL_ARCH", "x86_64") != "x86_64"
 
             _bdist_wheel.run(self)
             if is_manylinux and not disable_auditwheel_repair and not is_openvino and (not is_qnn or qnn_run_audit):


### PR DESCRIPTION
### Description
[Change 26634](https://github.com/microsoft/onnxruntime/pull/26634) added the qnn variant to the audit wheel process, but the qnn libraries do not pass audit repair due to a dependency on libc++. Continue to not audit qnn and rely on the correct dependencies being available for the user.


### Motivation and Context
Fixes build packaging pipeline

