### PR TITLE
[QNN EP] Add more detailed operation validation for QNN EP (#26739)

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
@@ -23,6 +23,12 @@ std::string BaseOpBuilder::GetOpBuilderType() const {
 Status BaseOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
                                     const NodeUnit& node_unit,
                                     const logging::Logger& logger) const {
+  const auto qnn_op_name = GetOptionalQnnOpType(node_unit.OpType());
+  ORT_RETURN_IF_NOT(qnn_op_name.has_value(), "Failed to find equivalent QNN operation for ", node_unit.OpType());
+
+  const bool isOpSupported = qnn_model_wrapper.IsOpSupported(qnn_op_name);
+  ORT_RETURN_IF_NOT(isOpSupported, "Operation ", qnn_op_name, " is unsupported for the current backend");
+
   // General Datatype checks on various QNN backend (HTP, CPU, GPU)
   ORT_RETURN_IF_ERROR(ProcessDataTypes(qnn_model_wrapper, node_unit));
   return AddToModelBuilder(qnn_model_wrapper, node_unit, logger, true);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
@@ -128,7 +128,7 @@ class BaseOpBuilder : public IOpBuilder {
                                                   Qnn_DataType_t qnn_data_type,
                                                   QnnQuantParamsWrapper& quant_param) const ORT_MUST_USE_RESULT;
 
-  static const std::string& GetQnnOpType(const std::string& onnx_op_type) {
+  static const std::optional<std::reference_wrapper<std::string>> GetOptionalQnnOpType(const std::string& onnx_op_type) {
     static const std::unordered_map<std::string, std::string> onnx_op_type_to_qnn_op_type = {
         {"Add", QNN_OP_ELEMENT_WISE_ADD},
         {"Mul", QNN_OP_ELEMENT_WISE_MULTIPLY},
@@ -233,8 +233,16 @@ class BaseOpBuilder : public IOpBuilder {
 
         {"Expand", QNN_OP_ELEMENT_WISE_MULTIPLY}};
     auto it = onnx_op_type_to_qnn_op_type.find(onnx_op_type);
-    ORT_ENFORCE(it != onnx_op_type_to_qnn_op_type.end());
+    if(it == onnx_op_type_to_qnn_op_type.end()){
+      return std::nullopt;
+    }
     return it->second;
+  }
+
+  static const std::string& GetQnnOpType(const std::string& onnx_op_type) {
+    const auto qnn_op_type = GetOptionalQnnOpType(onnx_op_type);
+    ORT_ENFORCE(qnn_op_type.has_value());
+    return qnn_op_type.value();
   }
 
   // Onnx Pads is [x1_begin, x2_begin, x1_end, x2_end], QNN requires [x1_begin, x1_end, x2_begin, x2_end]

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -11,6 +11,7 @@
 #include "CPU/QnnCpuCommon.h"
 #include "GPU/QnnGpuCommon.h"
 #include "DSP/QnnDspCommon.h"
+#include "HTA/QnnHtaCommon.h"
 #include "HTP/QnnHtpCommon.h"
 #include "HTP/QnnHtpContext.h"
 #include "HTP/QnnHtpPerfInfrastructure.h"
@@ -278,6 +279,9 @@ void QnnBackendManager::SetQnnBackendType(uint32_t backend_id) {
       break;
     case QNN_BACKEND_ID_DSP:
       qnn_backend_type_ = QnnBackendType::DSP;
+      break;
+    case QNN_BACKEND_ID_HTA:
+      qnn_backend_type_ = QnnBackendType::HTA;
       break;
     case QNN_BACKEND_ID_HTP:
       qnn_backend_type_ = QnnBackendType::HTP;
@@ -925,6 +929,7 @@ Status QnnBackendManager::CreateContext(bool enable_htp_weight_sharing) {
   switch (GetQnnBackendType()) {
     case QnnBackendType::HTP:
     case QnnBackendType::DSP:
+    case QnnBackendType::HTA:
       configs = npu_context_configs;
       break;
     case QnnBackendType::GPU:

--- a/onnxruntime/core/providers/qnn/builder/qnn_def.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_def.cc
@@ -579,7 +579,7 @@ bool IsIrBackend(QnnBackendType backend_type) {
 }
 
 bool IsNpuBackend(QnnBackendType backend_type) {
-  return backend_type == QnnBackendType::HTP || backend_type == QnnBackendType::DSP;
+  return backend_type == QnnBackendType::HTP || backend_type == QnnBackendType::DSP || backend_type == QnnBackendType::HTA;
 }
 
 bool IsGpuBackend(QnnBackendType backend_type) {

--- a/onnxruntime/core/providers/qnn/builder/qnn_def.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_def.h
@@ -91,6 +91,7 @@ enum class QnnBackendType : uint8_t {
   CPU = 0,
   GPU,
   DSP,
+  HTA,
   HTP,
   HTP_FP16,
   SERIALIZER,


### PR DESCRIPTION
### Description

Provide better operation validation for the different QNN backends through `backendGetSupportedOperations`.

This resolves multiple issues with QNN EP, including:
- Session creation failing if an operation is unsupported on the QNN EP, even if the CPU EP fallback is enabled
- Operation validation not taking into account the specific backend used
- QNN Hta backend failing by default. This is equivalent to the first issue, only that the default inserted transpose operations to handle the different expected input shapes (Nchw vs Nhwc) are unsupported for the Hta backend

Public APIs (C/C++ APIs and corresponding C# native methods) are not touched.

Refer to the issue ticket https://github.com/microsoft/onnxruntime/issues/26739


