### PR TITLE
Plugin EP API - Add OrtEp::IsConcurrentRunSupported

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
@@ -1129,6 +1129,20 @@ struct OrtEp {
    */
   ORT_API2_STATUS(GetKernelRegistry, _In_ OrtEp* this_ptr,
                   _Outptr_result_maybenull_ const OrtKernelRegistry** kernel_registry);
+
+  /** \brief Gets whether the execution provider supports concurrent run calls made on the session.
+   *
+   * \param[in] this_ptr The OrtEp instance.
+   * \param[out] is_supported Whether concurrent runs are supported.
+   *
+   * \snippet{doc} snippets.dox OrtStatus Return Value
+   *
+   * \note Implementation of this function is optional and it may be set to NULL.
+   *       If not implemented, ORT assumes that concurrent runs are supported.
+   *
+   * \since Version 1.24.
+   */
+  ORT_API2_STATUS(IsConcurrentRunSupported, _In_ OrtEp* this_ptr, _Outptr_ bool* is_supported);
 };
 
 /** \brief The function signature that ORT will call to create OrtEpFactory instances.

--- a/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
+++ b/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
@@ -603,6 +603,17 @@ std::optional<bool> PluginExecutionProvider::ShouldConvertDataLayoutForOp(std::s
   }
 }
 
+bool PluginExecutionProvider::ConcurrentRunSupported() const {
+  if (ort_ep_->ort_version_supported < 24 || ort_ep_->IsConcurrentRunSupported == nullptr) {
+    return true;
+  }
+
+  bool is_supported = false;
+  ORT_THROW_IF_ERROR(ToStatusAndRelease(ort_ep_->IsConcurrentRunSupported(ort_ep_.get(), &is_supported)));
+
+  return is_supported;
+}
+
 Status PluginExecutionProvider::OnRunStart(const RunOptions& run_options) {
   if (ort_ep_->OnRunStart == nullptr) {
     return Base::OnRunStart(run_options);

--- a/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.h
+++ b/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.h
@@ -108,6 +108,8 @@ class PluginExecutionProvider : public IExecutionProvider {
                                                    std::string_view node_op_type,
                                                    DataLayout target_data_layout) const override;
 
+  bool ConcurrentRunSupported() const override;
+
   Status OnRunStart(const RunOptions& run_options) override;
 
   Status OnRunEnd(bool sync_stream, const RunOptions& run_options) override;


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Add Plugin EP API `OrtEp::IsConcurrentRunSupported()` and connect it to the internal `PluginExecutionProvider::ConcurrentRunSupported()` member function.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Additional plugin EP support.