### PR TITLE
Fix DoS vulnerability in FuseReluClip: handle empty tensor

### DIFF
--- a/onnxruntime/core/optimizer/relu_clip_fusion.cc
+++ b/onnxruntime/core/optimizer/relu_clip_fusion.cc
@@ -57,6 +57,12 @@ Status FuseReluClip::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_eff
       data_type = initializer->data_type();
       // construct an initializer to gracefully handle typed or raw data in the TensorProto
       Initializer i(graph, *initializer, graph.ModelPath());
+
+      // Empty tensor is invalid for 'min' input - skip optimization to avoid null pointer dereference
+      if (i.size() == 0) {
+        return Status::OK();
+      }
+
       switch (data_type) {
         case ONNX_NAMESPACE::TensorProto_DataType_FLOAT:
           if (*i.data<float>() < 0.f) {


### PR DESCRIPTION
### Description

This PR fixes a null pointer dereference crash in the FuseReluClip::Apply() optimizer rule when the Clip node's min input is an empty tensor (e.g., shape [0, 0, 0, 0]).

#### Root Cause

When the clip_min initializer has zero elements, the Initializer class constructs an empty tensor with a null or invalid 
data_pointer. The code then attempts to dereference this pointer without checking if the tensor has any elements:
```
cpp
Initializer i(graph, *initializer, graph.ModelPath());
switch (data_type) {
  case ONNX_NAMESPACE::TensorProto_DataType_FLOAT:
    if (*i.data<float>() < 0.f) {  // ← Crash: null pointer dereference
```

#### Fix
Added a size check before accessing the initializer's data. If the tensor is empty (which is invalid per ONNX spec for the min input), the optimization is gracefully skipped:
```
cpp
Initializer i(graph, *initializer, graph.ModelPath());
// Empty tensor is invalid for 'min' input - skip optimization to avoid null pointer dereference
if (i.size() == 0) {
  return Status::OK();
}
switch (data_type) {
```

#### Motivation and Context

Security: A malformed ONNX model with an empty clip_min tensor could crash the ONNX Runtime session, causing a local Denial of Service.
Robustness: While the specific trigger condition (empty tensor for min) is invalid per the ONNX spec, the optimizer should handle this gracefully without crashing.

The fix ensures malformed models won't crash during graph optimization. The Relu→Clip fusion will simply be skipped for invalid models, allowing subsequent validation to handle the error appropriately.


