### PR TITLE
[CXX API] Fix memory leak for KernelContext_GetAllocator

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -4593,7 +4593,7 @@ struct OrtApi {
    *
    * \param[in] context OrtKernelContext instance
    * \param[in] mem_info OrtMemoryInfo instance
-   * \param[out] out A pointer to OrtAllocator.
+   * \param[out] out A pointer to OrtAllocator. Must be released with OrtApi::ReleaseAllocator.
    *
    * \snippet{doc} snippets.dox OrtStatus Return Value
    *

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -1059,6 +1059,9 @@ struct AllocatorWithDefaultOptions : detail::AllocatorImpl<detail::Unowned<OrtAl
 struct Allocator : detail::AllocatorImpl<OrtAllocator> {
   explicit Allocator(std::nullptr_t) {}  ///< Convenience to create a class member and then replace with an instance
   Allocator(const Session& session, const OrtMemoryInfo*);
+
+  ///< Take ownership of a pointer created by C API
+  explicit Allocator(OrtAllocator* p) : AllocatorImpl<OrtAllocator>{p} {}
 };
 
 using UnownedAllocator = detail::AllocatorImpl<detail::Unowned<OrtAllocator>>;
@@ -2722,7 +2725,7 @@ struct KernelContext {
   UnownedValue GetOutput(size_t index, const std::vector<int64_t>& dims) const;
   void* GetGPUComputeStream() const;
   Logger GetLogger() const;
-  OrtAllocator* GetAllocator(const OrtMemoryInfo& memory_info) const;
+  Ort::Allocator GetAllocator(const OrtMemoryInfo& memory_info) const;
   OrtKernelContext* GetOrtKernelContext() const { return ctx_; }
   void ParallelFor(void (*fn)(void*, size_t), size_t total, size_t num_batch, void* usr_data) const;
 

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -2547,10 +2547,10 @@ inline void* KernelContext::GetGPUComputeStream() const {
   return out;
 }
 
-inline OrtAllocator* KernelContext::GetAllocator(const OrtMemoryInfo& memory_info) const {
+inline Ort::Allocator KernelContext::GetAllocator(const OrtMemoryInfo& memory_info) const {
   OrtAllocator* out = nullptr;
   Ort::ThrowOnError(GetApi().KernelContext_GetAllocator(ctx_, &memory_info, &out));
-  return out;
+  return Ort::Allocator{out};
 }
 
 inline Logger KernelContext::GetLogger() const {

--- a/onnxruntime/test/shared_lib/custom_op_utils.cc
+++ b/onnxruntime/test/shared_lib/custom_op_utils.cc
@@ -41,11 +41,10 @@ void MyCustomKernel::Compute(OrtKernelContext* context) {
   OrtMemoryInfo mem_info("", OrtAllocatorType::OrtArenaAllocator,
                          OrtDevice(OrtDevice::CPU, OrtDevice::MemType::DEFAULT, OrtDevice::VendorIds::NONE, 0));
 #endif
-  OrtAllocator* allocator;
-  Ort::ThrowOnError(ort_.KernelContext_GetAllocator(context, &mem_info, &allocator));
-  void* allocated = allocator->Alloc(allocator, 2);
+  Ort::Allocator allocator = ctx.GetAllocator(mem_info);
+  void* allocated = allocator.Alloc(2);
   EXPECT_NE(allocated, nullptr) << "KernelContext_GetAllocator() can successfully allocate some memory";
-  allocator->Free(allocator, allocated);
+  allocator.Free(allocated);
 
   // Do computation
 #ifdef USE_CUDA


### PR DESCRIPTION
### Description
- Updates the C++ API function `Ort::KernelContext::GetAllocator` to return a `Ort::Allocator`, which releases the allocator instance on destruction.
- Fixes a memory leak in a unit test by using the fixed `Ort::KernelContext::GetAllocator` API.



### Motivation and Context
Users of the C++ API should not have to manually call `ReleaseAllocator` on the result of `Ort::KernelContext::GetAllocator`. This expectation will make leaking memory common.

Refer to original PR that added the API: https://github.com/microsoft/onnxruntime/pull/15591


