### PR TITLE
[webgpu] Support any batch size for dp4a matmul path

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/quantization/dp4a_matmul.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/quantization/dp4a_matmul.wgsl.template
@@ -54,18 +54,18 @@ var<workgroup> scale_B : array<output_element_t, tile_size>;                    
     var<workgroup> zeroes : array<i32, tile_size>;
 #endif
 
-fn loadSHMA(a_global_base:u32, kidx_v:u32, row: u32, col: u32)
+fn loadSHMA(batch:u32, a_global_base:u32, kidx_v:u32, row: u32, col: u32)
 {
     let a_global = a_global_base + row;
     if (a_global >= uniforms.M)
     {
         return;
     }
-    tile_A[col][row] = a.getByOffset(a_global*uniforms.K16+kidx_v+col);
+    tile_A[col][row] = a.getByOffset(batch*uniforms.M*uniforms.K16+a_global*uniforms.K16+kidx_v+col);
     if (col == 0)
     {
         // kidx_v - covers 16 values of k
-        scale_A[row] = scales_a.getByOffset(a_global*(uniforms.K/128) + kidx_v/8);
+        scale_A[row] = scales_a.getByOffset(batch*uniforms.M*(uniforms.K/128) + a_global*(uniforms.K/128) + kidx_v/8);
     }
 }
 
@@ -154,7 +154,11 @@ $MAIN {
 #endif
     // During the load phase we use all 256 threads to load 64 rows of A/B.
     // For each row we load tile_size_k_vec (2) vectorized elements, which are 32 elements of K.
-    let a_global_base = u32(workgroup_idx / uniforms.num_N_tile) * tile_size;
+    let batch = workgroup_idx / (uniforms.num_M_tile * uniforms.num_N_tile);
+    if (batch >= uniforms.batch_count) {
+        return;
+    }
+    let a_global_base = u32((workgroup_idx / uniforms.num_N_tile) % uniforms.num_M_tile) * tile_size;
     let b_global_base = (workgroup_idx % uniforms.num_N_tile) * tile_size;
     let load_AorB = u32(local_idx/128);
     let load_row = u32((local_idx%128)/2);
@@ -199,7 +203,7 @@ $MAIN {
         // Load Phase: Populate shared memory for the workgroup.
         if (load_AorB == 0)
         {
-            loadSHMA(a_global_base, kidx_v, load_row, load_col);
+            loadSHMA(batch, a_global_base, kidx_v, load_row, load_col);
         }
         else
         {
@@ -380,7 +384,7 @@ $MAIN {
 
     let a_global = a_global_base + base_A + a_idx;
     let b_global = b_global_base + base_B;
-    let output_idx = ((a_global) * uniforms.N + b_global)/4;
+    let output_idx = (batch * uniforms.M * uniforms.N + a_global * uniforms.N + b_global)/4;
 #if has_bias
 #if has_weight_idx
     let b_bias_offset = uniforms.weight_idx * uniforms.N;

--- a/onnxruntime/contrib_ops/webgpu/quantization/dp4a_matmul_nbits.h
+++ b/onnxruntime/contrib_ops/webgpu/quantization/dp4a_matmul_nbits.h
@@ -32,11 +32,13 @@ class DP4AMatMulNBitsProgram final : public Program<DP4AMatMulNBitsProgram> {
                                                                   is_qualcomm_(is_qualcomm) {}
   Status GenerateShaderCode(ShaderHelper& sh) const override;
   WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
+      {"batch_count", ProgramUniformVariableDataType::Uint32},
       {"M", ProgramUniformVariableDataType::Uint32},
       {"N", ProgramUniformVariableDataType::Uint32},
       {"K", ProgramUniformVariableDataType::Uint32},
       {"K8", ProgramUniformVariableDataType::Uint32},
       {"K16", ProgramUniformVariableDataType::Uint32},
+      {"num_M_tile", ProgramUniformVariableDataType::Uint32},
       {"num_N_tile", ProgramUniformVariableDataType::Uint32},
       {"zero_blocks_per_col", ProgramUniformVariableDataType::Uint32},
       {"weight_idx", ProgramUniformVariableDataType::Uint32});
@@ -64,6 +66,7 @@ class DP4AMatMulNBitsSmallMProgram final : public Program<DP4AMatMulNBitsSmallMP
                                                                                  single_scale_weights_(single_scale_weights) {}
   Status GenerateShaderCode(ShaderHelper& sh) const override;
   WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
+      {"batch_count", ProgramUniformVariableDataType::Uint32},
       {"M", ProgramUniformVariableDataType::Uint32},
       {"N", ProgramUniformVariableDataType::Uint32},
       {"K", ProgramUniformVariableDataType::Uint32},
@@ -86,6 +89,7 @@ class DP4AMatMulNBitsSmallMProgram final : public Program<DP4AMatMulNBitsSmallMP
 
 Status ApplyDP4AMatrixMatMulNBits(const Tensor* a, const Tensor* b, const Tensor* scales,
                                   const Tensor* zero_points, const Tensor* bias,
+                                  uint32_t batch_count,
                                   uint32_t M,
                                   uint32_t N,
                                   uint32_t K,
@@ -100,7 +104,6 @@ Status ApplyDP4AMatrixMatMulNBits(const Tensor* a, const Tensor* b, const Tensor
 bool CanApplyDP4AMatrixMatMulNBits(onnxruntime::webgpu::ComputeContext& context,
                                    uint64_t accuracy_level,
                                    uint32_t block_size,
-                                   uint32_t batch_count,
                                    uint32_t N,
                                    uint32_t K,
                                    uint32_t components_k);

--- a/onnxruntime/contrib_ops/webgpu/quantization/dp4a_matmul_small_m.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/quantization/dp4a_matmul_small_m.wgsl.template
@@ -45,23 +45,27 @@ var<workgroup> tile_A : array<vec4<u32>, double_tile_size_k_vec>;
 const scale_a_size_in_tile_a = double_tile_size_k_vec / 8;
 var<workgroup> scale_A : array<output_element_t, scale_a_size_in_tile_a>;
 
-fn loadSHMA(a_global: u32, kidx_v: u32, col: u32)
+fn loadSHMA(batch: u32, a_global: u32, kidx_v: u32, col: u32)
 {
     let k_offset = kidx_v + col;
     if (k_offset >= uniforms.K16) {
     return;
     }
 
-    tile_A[col] = a.getByOffset(a_global*uniforms.K16+k_offset);
+    tile_A[col] = a.getByOffset(batch*uniforms.M*uniforms.K16+a_global*uniforms.K16+k_offset);
     if (col < scale_a_size_in_tile_a)
     {
     // kidx_v - covers 16 values of k in input_a
-    scale_A[col] = scales_a.getByOffset(a_global*(uniforms.K/128) + kidx_v/8 + col);
+    scale_A[col] = scales_a.getByOffset(batch*uniforms.M*(uniforms.K/128) + a_global*(uniforms.K/128) + kidx_v/8 + col);
     }
 }
 
 $MAIN {
-    let a_global = u32(workgroup_idx / uniforms.num_N_tile);
+    let batch = workgroup_idx / (uniforms.M * uniforms.num_N_tile);
+    if (batch >= uniforms.batch_count) {
+        return;
+    }
+    let a_global = u32((workgroup_idx / uniforms.num_N_tile) % uniforms.M);
     let b_global_base = (workgroup_idx % uniforms.num_N_tile) * tile_size;
     // Handle each workgroup threads as a block of [sub_tile_count][tile_size_k_vec]
     let local_col = local_idx % tile_size_k_vec;
@@ -95,7 +99,7 @@ $MAIN {
         // Load Phase: Populate shared memory for the workgroup.
         if (local_idx < double_tile_size_k_vec)
         {
-        loadSHMA(a_global, kidx_v * 2, local_idx);
+        loadSHMA(batch, a_global, kidx_v * 2, local_idx);
         }
         workgroupBarrier();
         var own_a: vec4<u32> = tile_A[local_col * 2];
@@ -153,7 +157,7 @@ $MAIN {
         output_value += inter_results[local_idx][b];
       }
       let b_global =  b_global_base + local_idx;
-      let output_idx = a_global * uniforms.N + b_global;
+      let output_idx = batch * uniforms.M * uniforms.N + a_global * uniforms.N + b_global;
       if (b_global < uniforms.N) {
 #if has_bias
         let bias_value = bias[b_global + b_bias_offset];

--- a/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.cc
@@ -220,8 +220,8 @@ Status ApplyMatMulNBits(const Tensor* a, const Tensor* b, const Tensor* scales, 
 
   // On FP32 only GPUs, integer math is faster than FP32 therefore always use DP4A independent of length of M.
   if ((M >= kMinMForTileOptimization || y->DataType() == DataTypeImpl::GetType<float>() || context.AdapterInfo().vendor == std::string_view{"qualcomm"}) &&
-      CanApplyDP4AMatrixMatMulNBits(context, accuracy_level, block_size, batch_count, N, K, components_a)) {
-    return ApplyDP4AMatrixMatMulNBits(a, b, scales, zero_points, bias, M, N, K, block_size, zero_blocks_per_col, kMinMForTileOptimization, static_cast<uint32_t>(nbits), context, y, weight_index);
+      CanApplyDP4AMatrixMatMulNBits(context, accuracy_level, block_size, N, K, components_a)) {
+    return ApplyDP4AMatrixMatMulNBits(a, b, scales, zero_points, bias, batch_count, M, N, K, block_size, zero_blocks_per_col, kMinMForTileOptimization, static_cast<uint32_t>(nbits), context, y, weight_index);
   }
 
   // WideTileProgram

--- a/onnxruntime/test/contrib_ops/matmul_4bits_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_4bits_test.cc
@@ -73,6 +73,7 @@ void QuantizeDequantize(std::vector<float>& raw_vals,
 }
 
 struct TestOptions {
+  int64_t batch_count{1};
   int64_t M{1};
   int64_t N{1};
   int64_t K{1};
@@ -91,7 +92,8 @@ struct TestOptions {
 };
 
 [[maybe_unused]] std::ostream& operator<<(std::ostream& os, const TestOptions& opts) {
-  return os << "M:" << opts.M << ", N:" << opts.N << ", K:" << opts.K
+  return os << "batch_count:" << opts.batch_count
+            << ", M:" << opts.M << ", N:" << opts.N << ", K:" << opts.K
             << ", block_size:" << opts.block_size
             << ", accuracy_level:" << opts.accuracy_level
             << ", has_zero_point:" << opts.has_zero_point
@@ -116,12 +118,13 @@ void RunTest(const TestOptions& opts,
 
   const bool zp_is_4bit = opts.zp_is_4bit || opts.has_g_idx;
 
+  const int64_t batch_count = opts.batch_count;
   const int64_t M = opts.M;
   const int64_t K = opts.K;
   const int64_t N = opts.N;
 
   RandomValueGenerator random{1234};
-  std::vector<float> input0_vals(random.Gaussian<float>(AsSpan({M, K}), 0.0f, 0.25f));
+  std::vector<float> input0_vals(random.Gaussian<float>(AsSpan({batch_count, M, K}), 0.0f, 0.25f));
   std::vector<float> input1_f_vals(random.Gaussian<float>(AsSpan({K, N}), 0.0f, 0.25f));
 
   int64_t k_blocks = (K + opts.block_size - 1) / opts.block_size;
@@ -151,14 +154,16 @@ void RunTest(const TestOptions& opts,
     return std::nullopt;
   }();
 
-  std::vector<float> expected_vals(M * N);
-  for (int64_t m = 0; m < M; m++) {
-    for (int64_t n = 0; n < N; n++) {
-      float sum = 0.0f;
-      for (int64_t k = 0; k < K; k++) {
-        sum += input0_vals[m * K + k] * input1_f_vals[n * K + k];
+  std::vector<float> expected_vals(batch_count * M * N);
+  for (int64_t b = 0; b < batch_count; b++) {
+    for (int64_t m = 0; m < M; m++) {
+      for (int64_t n = 0; n < N; n++) {
+        float sum = 0.0f;
+        for (int64_t k = 0; k < K; k++) {
+          sum += input0_vals[b * M * K + m * K + k] * input1_f_vals[n * K + k];
+        }
+        expected_vals[b * M * N + m * N + n] = sum + (bias.has_value() ? (*bias)[n] : 0.0f);
       }
-      expected_vals[m * N + n] = sum + (bias.has_value() ? (*bias)[n] : 0.0f);
     }
   }
 
@@ -170,11 +175,11 @@ void RunTest(const TestOptions& opts,
   test.AddAttribute<int64_t>("accuracy_level", opts.accuracy_level);
 
   if constexpr (std::is_same_v<T1, float>) {
-    test.AddInput<T1>("A", {M, K}, input0_vals, false);
+    test.AddInput<T1>("A", {batch_count, M, K}, input0_vals, false);
   } else if constexpr (std::is_same<T1, MLFloat16>::value) {
-    test.AddInput<T1>("A", {M, K}, FloatsToMLFloat16s(input0_vals), false);
+    test.AddInput<T1>("A", {batch_count, M, K}, FloatsToMLFloat16s(input0_vals), false);
   } else if constexpr (std::is_same<T1, BFloat16>::value) {
-    test.AddInput<T1>("A", {M, K}, FloatsToBFloat16s(input0_vals), false);
+    test.AddInput<T1>("A", {batch_count, M, K}, FloatsToBFloat16s(input0_vals), false);
   }
 
   test.AddInput<uint8_t>("B", {N, k_blocks, blob_size}, input1_vals, true);
@@ -249,11 +254,11 @@ void RunTest(const TestOptions& opts,
   }
 
   if constexpr (std::is_same<T1, float>::value) {
-    test.AddOutput<T1>("Y", {M, N}, expected_vals);
+    test.AddOutput<T1>("Y", {batch_count, M, N}, expected_vals);
   } else if constexpr (std::is_same<T1, MLFloat16>::value) {
-    test.AddOutput<T1>("Y", {M, N}, FloatsToMLFloat16s(expected_vals));
+    test.AddOutput<T1>("Y", {batch_count, M, N}, FloatsToMLFloat16s(expected_vals));
   } else if constexpr (std::is_same<T1, BFloat16>::value) {
-    test.AddOutput<T1>("Y", {M, N}, FloatsToBFloat16s(expected_vals));
+    test.AddOutput<T1>("Y", {batch_count, M, N}, FloatsToBFloat16s(expected_vals));
   }
 
   if (opts.output_abs_error.has_value()) {
@@ -496,6 +501,84 @@ TEST(MatMulNBits, LegacyShape_4b) {
   constexpr bool legacy_shape = true;
   TestMatMulNBitsTyped<float, 4, 2, 16, 16, 4, legacy_shape>();
   TestMatMulNBitsTyped<MLFloat16, 1, 2, 16, 16, 4, legacy_shape>();
+}
+
+// Batch tests for DP4A path (accuracy_level 4)
+TEST(MatMulNBits, Float32_4b_Accuracy4_Batch) {
+  // Test batch support with DP4A requirements:
+  // - accuracy_level == 4
+  // - block_size % 32 == 0
+  // - K % 128 == 0
+  // - N % 16 == 0
+
+  // Small batch tests
+  TestOptions opts{};
+  opts.accuracy_level = 4;
+  opts.output_abs_error = 0.1f;
+  opts.output_rel_error = 0.02f;
+
+  // Batch=2 tests
+  opts.batch_count = 2;
+  opts.M = 1;
+  opts.N = 16;
+  opts.K = 128;
+  opts.block_size = 32;
+  RunTest<float>(opts);
+
+  opts.M = 2;
+  opts.N = 32;
+  opts.K = 128;
+  opts.block_size = 32;
+  RunTest<float>(opts);
+
+  opts.M = 32;
+  opts.N = 64;
+  opts.K = 256;
+  opts.block_size = 64;
+  RunTest<float>(opts);
+
+  opts.M = 100;
+  opts.N = 288;
+  opts.K = 1024;
+  opts.block_size = 128;
+  RunTest<float>(opts);
+
+  // Batch=4 tests
+  opts.batch_count = 4;
+  opts.M = 1;
+  opts.N = 16;
+  opts.K = 128;
+  opts.block_size = 32;
+  RunTest<float>(opts);
+
+  opts.M = 32;
+  opts.N = 64;
+  opts.K = 256;
+  opts.block_size = 64;
+  RunTest<float>(opts);
+
+  opts.M = 100;
+  opts.N = 288;
+  opts.K = 1024;
+  opts.block_size = 128;
+  RunTest<float>(opts);
+
+  // Batch=8 test
+  opts.batch_count = 8;
+  opts.M = 32;
+  opts.N = 128;
+  opts.K = 256;
+  opts.block_size = 64;
+  RunTest<float>(opts);
+
+  // Test with bias
+  opts.batch_count = 2;
+  opts.M = 32;
+  opts.N = 64;
+  opts.K = 256;
+  opts.block_size = 64;
+  opts.has_bias = true;
+  RunTest<float>(opts);
 }
 
 #endif


### PR DESCRIPTION
This pull request adds support for batched matrix multiplication in the DP4A quantized matmul WebGPU kernels and their associated C++ code and tests. The changes update the kernel code, tensor shapes, dispatch logic, and test infrastructure to properly handle a `batch_count` greater than 1, enabling efficient batched execution.

