### PR TITLE
[MLAS] Fix building on FreeBSD / powerpc64le

### DIFF
--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -34,6 +34,9 @@ Abstract:
 #define POWER_10_ANDUP (POWER_10)
 #include <sys/systemcfg.h>
 #define __power_10_andup() (_system_configuration.implementation & POWER_10_ANDUP)
+#elif defined(__FreeBSD__)
+#include <machine/cpu.h>
+#include <sys/auxv.h>
 #endif
 #endif
 

--- a/onnxruntime/core/mlas/lib/power/qgemm_kernel_power10.cpp
+++ b/onnxruntime/core/mlas/lib/power/qgemm_kernel_power10.cpp
@@ -880,14 +880,14 @@ MlasQgemmStoreVectorMMA
 {
     size_t RowCount;
     __vector signed int vsum0, vsum1, vsum2, vsum3;
-#if defined(_AIX) && defined(__clang__)
+#if (defined(_AIX) || defined(__FreeBSD__)) && defined(__clang__)
     __vector signed int columnsum = *reinterpret_cast<const __vector int *>(&ColumnSumBuffer[pos]);
 #else
     __vector signed int columnsum = *reinterpret_cast<const __vector int32_t *>(&ColumnSumBuffer[pos]);
 #endif
     C += VectorCount;
     if (ZeroPointB != nullptr) {
-#if defined(_AIX) && defined(__clang__)
+#if (defined(_AIX) || defined(__FreeBSD__)) && defined(__clang__)
         __vector signed int zeropoint = *reinterpret_cast<const __vector int *>(&ZeroPointB[pos]);
 #else
         __vector signed int zeropoint = *reinterpret_cast<const __vector int32_t *>(&ZeroPointB[pos]);

--- a/onnxruntime/core/mlas/lib/qlmul.cpp
+++ b/onnxruntime/core/mlas/lib/qlmul.cpp
@@ -325,7 +325,7 @@ MlasQLinearMulKernel(
     }
 
     while (N >= 4) {
-#if defined(_AIX) && defined(__clang__)
+#if (defined(_AIX) || defined(__FreeBSD__)) && defined(__clang__)
         __vector int IntegerAVector {InputA[0], InputA[1], InputA[2], InputA[3]};
 #else
         __vector int32_t  IntegerAVector {InputA[0], InputA[1], InputA[2], InputA[3]};
@@ -334,7 +334,7 @@ MlasQLinearMulKernel(
         auto ValueAVector = vec_mul(ScaleAVector, vec_ctf(IntegerVector, 0));
 
         if (!IsScalarB) {
-#if defined(_AIX) && defined(__clang__)
+#if (defined(_AIX) || defined(__FreeBSD__)) && defined(__clang__)
             __vector int  IntegerBVector {InputB[0], InputB[1], InputB[2], InputB[3]};
 #else
             __vector int32_t  IntegerBVector {InputB[0], InputB[1], InputB[2], InputB[3]};


### PR DESCRIPTION

### Description
<!-- Describe your changes. -->
1. platform.cpp missed inclusion of sys/auxv.h (for elf_aux_info)
and machine/cpu.h (for PPC_FEATURE2_ARCH_3_00). I missed that in my
previous commit.
2. Same as on AIX, __vector int32_t is not defined and __vector int
needs to be used.



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Fixes build on FreeBSD / powerpc64le platform.
