### PR TITLE
Fix TreeEnsemble LOGISTIC post_transform for single target regression

### DIFF
--- a/onnxruntime/core/providers/cpu/ml/tree_ensemble_aggregator.h
+++ b/onnxruntime/core/providers/cpu/ml/tree_ensemble_aggregator.h
@@ -223,9 +223,18 @@ class TreeAggregator {
 
   void FinalizeScores1(OutputType* Z, ScoreValue<ThresholdType>& prediction, int64_t* /*Y*/) const {
     prediction.score = prediction.has_score ? (prediction.score + origin_) : origin_;
-    *Z = this->post_transform_ == POST_EVAL_TRANSFORM::PROBIT
-             ? static_cast<OutputType>(ComputeProbit(static_cast<float>(prediction.score)))
-             : static_cast<OutputType>(prediction.score);
+    switch (this->post_transform_) {
+      case POST_EVAL_TRANSFORM::PROBIT:
+        *Z = static_cast<OutputType>(ComputeProbit(static_cast<float>(prediction.score)));
+        break;
+      case POST_EVAL_TRANSFORM::LOGISTIC:
+        *Z = static_cast<OutputType>(ComputeLogistic(static_cast<float>(prediction.score)));
+        break;
+      case POST_EVAL_TRANSFORM::NONE:
+      default:
+        *Z = static_cast<OutputType>(prediction.score);
+        break;
+    }
   }
 
   // N outputs
@@ -278,9 +287,18 @@ class TreeAggregatorSum : public TreeAggregator<InputType, ThresholdType, Output
 
   void FinalizeScores1(OutputType* Z, ScoreValue<ThresholdType>& prediction, int64_t* /*Y*/) const {
     prediction.score += this->origin_;
-    *Z = this->post_transform_ == POST_EVAL_TRANSFORM::PROBIT
-             ? static_cast<OutputType>(ComputeProbit(static_cast<float>(prediction.score)))
-             : static_cast<OutputType>(prediction.score);
+    switch (this->post_transform_) {
+      case POST_EVAL_TRANSFORM::PROBIT:
+        *Z = static_cast<OutputType>(ComputeProbit(static_cast<float>(prediction.score)));
+        break;
+      case POST_EVAL_TRANSFORM::LOGISTIC:
+        *Z = static_cast<OutputType>(ComputeLogistic(static_cast<float>(prediction.score)));
+        break;
+      case POST_EVAL_TRANSFORM::NONE:
+      default:
+        *Z = static_cast<OutputType>(prediction.score);
+        break;
+    }
   }
 
   // N outputs
@@ -333,9 +351,18 @@ class TreeAggregatorAverage : public TreeAggregatorSum<InputType, ThresholdType,
   void FinalizeScores1(OutputType* Z, ScoreValue<ThresholdType>& prediction, int64_t* /*Y*/) const {
     prediction.score /= this->n_trees_;
     prediction.score += this->origin_;
-    *Z = this->post_transform_ == POST_EVAL_TRANSFORM::PROBIT
-             ? static_cast<OutputType>(ComputeProbit(static_cast<float>(prediction.score)))
-             : static_cast<OutputType>(prediction.score);
+    switch (this->post_transform_) {
+      case POST_EVAL_TRANSFORM::PROBIT:
+        *Z = static_cast<OutputType>(ComputeProbit(static_cast<float>(prediction.score)));
+        break;
+      case POST_EVAL_TRANSFORM::LOGISTIC:
+        *Z = static_cast<OutputType>(ComputeLogistic(static_cast<float>(prediction.score)));
+        break;
+      case POST_EVAL_TRANSFORM::NONE:
+      default:
+        *Z = static_cast<OutputType>(prediction.score);
+        break;
+    }
   }
 
   void FinalizeScores(InlinedVector<ScoreValue<ThresholdType>>& predictions,

--- a/onnxruntime/test/providers/cpu/ml/tree_ensembler_test.cc
+++ b/onnxruntime/test/providers/cpu/ml/tree_ensembler_test.cc
@@ -452,5 +452,34 @@ TEST(MLOpTest, TreeEnsembleIssue25400) {
   test.Run();
 }
 
+TEST(MLOpTest, TreeEnsembleSingleTargetLogistic) {
+  OpTester test("TreeEnsembleRegressor", 3, onnxruntime::kMLDomain);
+
+  test.AddAttribute("post_transform", std::string("LOGISTIC"));
+  test.AddAttribute("n_targets", int64_t(1));
+
+  // Single tree with single leaf node
+  test.AddAttribute("nodes_treeids", std::vector<int64_t>{0});
+  test.AddAttribute("nodes_nodeids", std::vector<int64_t>{0});
+  test.AddAttribute("nodes_featureids", std::vector<int64_t>{0});
+  test.AddAttribute("nodes_modes", std::vector<std::string>{"LEAF"});
+  test.AddAttribute("nodes_values", std::vector<float>{0.0f});
+  test.AddAttribute("nodes_truenodeids", std::vector<int64_t>{0});
+  test.AddAttribute("nodes_falsenodeids", std::vector<int64_t>{0});
+
+  // Target/weight for the leaf
+  test.AddAttribute("target_treeids", std::vector<int64_t>{0});
+  test.AddAttribute("target_nodeids", std::vector<int64_t>{0});
+  test.AddAttribute("target_ids", std::vector<int64_t>{0});
+  test.AddAttribute("target_weights", std::vector<float>{10.0f});
+
+  test.AddInput<float>("X", {1, 1}, {1.0f});
+
+  // 1 / (1 + exp(-10.0)) = 0.9999546021312976
+  test.AddOutput<float>("Y", {1, 1}, {0.9999546f}, 1e-4f);
+
+  test.Run();
+}
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/ml/tree_ensembler_test.cc
+++ b/onnxruntime/test/providers/cpu/ml/tree_ensembler_test.cc
@@ -476,7 +476,7 @@ TEST(MLOpTest, TreeEnsembleSingleTargetLogistic) {
   test.AddInput<float>("X", {1, 1}, {1.0f});
 
   // 1 / (1 + exp(-10.0)) = 0.9999546021312976
-  test.AddOutput<float>("Y", {1, 1}, {0.9999546f}, 1e-4f);
+  test.AddOutput<float>("Y", {1, 1}, {0.9999546f}, 1e-4);
 
   test.Run();
 }


### PR DESCRIPTION
Fixes #26596

- Updated FinalizeScores1 methods in TreeAggregator, TreeAggregatorSum, and TreeAggregatorAverage to handle LOGISTIC transform
- Added test case TreeEnsembleSingleTargetLogistic to verify correct behavior

### Description
- The LOGISTIC post-transform was not being applied to single-target TreeEnsemble regression models. The `FinalizeScores1` methods only checked for PROBIT transform and ignored LOGISTIC, causing models to output raw scores instead of applying the logistic function.


### Motivation and Context
- According to the ONNX ML spec, TreeEnsemble operators should support LOGISTIC post-transform. However, for single-target regression models, only PROBIT was being applied. This caused models with `post_transform=LOGISTIC` to return raw prediction scores (10.0) instead of transformed values (0.9999546).


