### PR TITLE
[webgpu] Simplify the signature of CanApplyFlashAttention

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/bert/attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/attention.cc
@@ -726,16 +726,9 @@ Status Attention::ComputeInternal(onnxruntime::webgpu::ComputeContext& context) 
   parameters.qkv_format_ = Q_K_V_BSNH;
 
   // Check if we can use flash attention
-  // For Attention operator, we need to create present_key and present_value tensors for flash attention
-  // even though they are not exposed as outputs
-  TensorShapeVector present_kv_shape({parameters.batch_size_, parameters.num_heads_,
-                                      parameters.total_sequence_length_, parameters.head_size_});
-  Tensor present_key = context.CreateGPUTensor(input->DataType(), present_kv_shape);
-  Tensor present_value = context.CreateGPUTensor(input->DataType(), present_kv_shape);
-
-  if (CanApplyFlashAttention(nullptr, &present_key, &present_value, parameters, context)) {
+  if (CanApplyFlashAttention(nullptr, parameters, context)) {
     // FlashAttention supports Q_K_V_BSNH format directly
-    return ApplyFlashAttention(&Q_bsd, &K_bsd, &V_bsd, attention_bias, output, nullptr, &present_key, nullptr, &present_value,
+    return ApplyFlashAttention(&Q_bsd, &K_bsd, &V_bsd, attention_bias, output, nullptr, nullptr, nullptr, nullptr,
                                parameters, context, nullptr);
   }
 

--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.h
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.h
@@ -184,7 +184,7 @@ Status ApplyFlashAttention(const Tensor* Q, const Tensor* K, const Tensor* V, co
                            const WebgpuAttentionParameters& parameters, onnxruntime::webgpu::ComputeContext& context, const Tensor* seqlen_k = nullptr,
                            const Tensor* cos_cache = nullptr, const Tensor* sin_cache = nullptr);
 
-bool CanApplyFlashAttention(const Tensor* bias, const Tensor* present_key, const Tensor* present_value,
+bool CanApplyFlashAttention(const Tensor* bias,
                             const WebgpuAttentionParameters& parameters, onnxruntime::webgpu::ComputeContext& context);
 
 // Split packed QKV with Q/K rotary embedding and copy KV cache fusion

--- a/onnxruntime/contrib_ops/webgpu/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/group_query_attention.cc
@@ -252,7 +252,7 @@ Status GroupQueryAttention::ComputeInternal(onnxruntime::webgpu::ComputeContext&
     // Create a temporary parameters copy with is_packed_qkv_ set to false to check if flash attention can be applied after unpacking
     WebgpuAttentionParameters temp_params = parameters;
     temp_params.is_packed_qkv_ = false;
-    will_use_flash_attention = CanApplyFlashAttention(nullptr, present_key, present_value, temp_params, context);
+    will_use_flash_attention = CanApplyFlashAttention(nullptr, temp_params, context);
   }
 
   if (parameters.is_packed_qkv_ && do_rotary_) {

--- a/onnxruntime/contrib_ops/webgpu/bert/multihead_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/multihead_attention.cc
@@ -104,7 +104,7 @@ Status MultiHeadAttention::ComputeInternal(onnxruntime::webgpu::ComputeContext& 
   Tensor* output_qk = context.Output(3, output_qk_shape);
 
   if (output_qk == nullptr &&  // Flash attention does not output QK scores
-      CanApplyFlashAttention(bias, present_key, present_value, parameters, context)) {
+      CanApplyFlashAttention(bias, parameters, context)) {
     return ApplyFlashAttention(query, key, value, attention_bias, output, past_key, present_key, past_value,
                                present_value, parameters, context);
   }


### PR DESCRIPTION
This pull request simplifies the logic for handling present key/value tensors in the WebGPU Flash Attention implementation. The main change is that the responsibility for creating internal present key/value tensors is moved from the caller to the `ApplyFlashAttention` function itself. This reduces code duplication and makes the API easier to use. Additionally, the `CanApplyFlashAttention` function is simplified to remove unnecessary checks for present key/value tensors.


