### PR TITLE
Minimize binary footprint of the FL nuget

### DIFF
--- a/tools/ci_build/github/azure-pipelines/custom-nuget-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/custom-nuget-packaging-pipeline.yml
@@ -3,11 +3,6 @@ parameters:
   type: string
   default: '12.8'
 
-- name: QnnSdk
-  displayName: QNN SDK Version
-  type: string
-  default: 2.41.0.251128
-
 - name: IsReleaseBuild
   displayName: Is a release build? Set it to true if you are doing an Onnx Runtime release.
   type: boolean
@@ -115,19 +110,26 @@ extends:
           SpecificArtifact: false
           BuildId: '0'
 
-      - template: templates/qnn-ep-win.yml
+      - template: templates/win-ci.yml
         parameters:
-          qnn_ep_build_pool_name: 'Onnxruntime-QNNEP-Windows-2022-CPU'
-          QnnSdk: ${{ parameters.QnnSdk }}
+          PreReleaseVersionSuffixString: ${{ parameters.PreReleaseVersionSuffixString }}
+          PreReleaseVersionSuffixNumber: ${{ parameters.PreReleaseVersionSuffixNumber }}
+          ort_build_pool_name: 'Onnxruntime-QNNEP-Windows-2022-CPU'
+          DoCompliance: false
+          DoEsrp: true
+          stage_name_suffix: CPU_arm64
+          buildArch: x64
+          msbuildPlatform: arm64
+          packageName: arm64
+          buildparameter: --arm64ec --buildasx --caller_framework WinAI
+          runTests: false
+          buildJava: false
+          buildNodejs: false
+
+      - template: templates/managed-nuget-for-foundry-local.yml
+        parameters:
           IsReleaseBuild: ${{ parameters.IsReleaseBuild }}
           DoEsrp: true
-          ArtifactName: 'drop-nuget-qnn-arm64'
-          # Add --use_webgpu to enable WebGPU
-          StageName: 'OnnxRuntime_QNN_Nuget_Win_Arm64'
-          build_config: 'RelWithDebInfo'
-          PublishArchive: true
-          PublishNugetToFeed: false
-          AdditionalBuildArgs: '--caller_framework WinAI'
 
       - template: templates/mac-cpu-packaging-pipeline.yml
         parameters:
@@ -136,7 +138,7 @@ extends:
           DoEsrp: true
 
       - stage: NugetPackaging
-        dependsOn: [Windows_Packaging_CUDA, OnnxRuntime_QNN_Nuget_Win_Arm64, MacOS_C_API_Package_Publish]
+        dependsOn: [Windows_Packaging_CUDA, Windows_Packaging_CPU_arm64, ManagedNugetPackaging, MacOS_C_API_Package_Publish]
         jobs:
         - job: CreateNugetPackage
           pool: 'Onnxruntime-Win2022-GPU-A10'
@@ -158,7 +160,7 @@ extends:
           - task: DownloadPipelineArtifact@0
             displayName: 'Download Pipeline Artifact - managed nuget'
             inputs:
-              artifactName: 'drop-signed-nuget-qnn'
+              artifactName: 'onnxruntime-managed-nuget'
               targetPath: '$(Build.BinariesDirectory)/managed-nuget'
 
           - task: DownloadPipelineArtifact@0
@@ -170,7 +172,7 @@ extends:
           - task: DownloadPipelineArtifact@0
             displayName: 'Download Pipeline Artifact - win-arm64'
             inputs:
-              artifactName: 'onnxruntime-win-arm64x-qnn'
+              artifactName: 'onnxruntime-win-arm64'
               targetPath: '$(Build.BinariesDirectory)/win-arm64'
 
           - task: DownloadPipelineArtifact@0
@@ -229,11 +231,11 @@ extends:
               targetType: 'inline'
               script: |
                 Expand-Archive -Path $(Build.BinariesDirectory)/win-x64/onnxruntime-win-x64-cuda*.zip -DestinationPath $(Build.BinariesDirectory)/win-x64
-                Expand-Archive -Path $(Build.BinariesDirectory)/win-arm64/onnxruntime-win-arm64x-qnn*.zip -DestinationPath $(Build.BinariesDirectory)/win-arm64
+                Expand-Archive -Path $(Build.BinariesDirectory)/win-arm64/onnxruntime-win-arm64*.zip -DestinationPath $(Build.BinariesDirectory)/win-arm64
                 $osx_arm64_archive = (Get-ChildItem -Path $(Build.BinariesDirectory)/osx-arm64 -Filter onnxruntime-osx-arm64*)[0].FullName
                 tar -xzf $osx_arm64_archive -C $(Build.BinariesDirectory)/osx-arm64 2>$null
                 $win_x64 = (Get-ChildItem -Path $(Build.BinariesDirectory)/win-x64 -Filter onnxruntime-win-x64-cuda*)[0].FullName
-                $win_arm64 = (Get-ChildItem -Path $(Build.BinariesDirectory)/win-arm64 -Filter onnxruntime-win-arm64x-qnn*)[0].FullName
+                $win_arm64 = (Get-ChildItem -Path $(Build.BinariesDirectory)/win-arm64 -Filter onnxruntime-win-arm64*)[0].FullName
                 $osx_arm64 = (Get-ChildItem -Path $(Build.BinariesDirectory)/osx-arm64 -Filter onnxruntime-osx-arm64*)[0].FullName
                 Write-Host "##vso[task.setvariable variable=win_x64;]$win_x64"
                 Write-Host "##vso[task.setvariable variable=win_arm64;]$win_arm64"

--- a/tools/ci_build/github/azure-pipelines/templates/managed-nuget-for-foundry-local.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/managed-nuget-for-foundry-local.yml
@@ -1,0 +1,102 @@
+parameters:
+  build_config: 'RelWithDebInfo'
+  IsReleaseBuild: false
+  DoEsrp: false
+  OrtNugetPackageId: 'Microsoft.ML.OnnxRuntime'
+  StageName: 'ManagedNugetPackaging'
+
+stages:
+- stage: ${{ parameters.StageName }}
+  dependsOn: [Setup, Windows_Packaging_CUDA]
+  jobs:
+  - job: ${{ parameters.StageName }}
+    timeoutInMinutes: 300
+    pool:
+      name: 'onnxruntime-Win2022-GPU-A10'
+      os: windows
+    templateContext:
+      sdl:
+        codeSignValidation:
+          enabled: true
+          break: true
+        psscriptanalyzer:
+          enabled: true
+        binskim:
+          enabled: true
+          scanOutputDirectoryOnly: true
+      outputs:
+      - output: pipelineArtifact
+        targetPath: $(Build.ArtifactStagingDirectory)
+        artifactName: "onnxruntime-managed-nuget"
+    variables:
+      OrtPackageId: ${{ parameters.OrtNugetPackageId }}
+      ReleaseVersionSuffix: $[stageDependencies.Setup.Set_Variables.outputs['Set_Release_Version_Suffix.ReleaseVersionSuffix']]
+      BuildDate: $[stageDependencies.Setup.Set_Variables.outputs['Set_Build_Date.BuildDate']]
+      BuildTime: $[stageDependencies.Setup.Set_Variables.outputs['Set_Build_Time.BuildTime']]
+
+    steps:
+    - template: set-version-number-variables-step.yml
+
+    - task: UsePythonVersion@0
+      displayName: 'Use Python'
+      inputs:
+        versionSpec: 3.12
+
+    - task: DownloadPipelineArtifact@0
+      displayName: 'Download Pipeline Artifact - win-x64'
+      inputs:
+        artifactName: 'onnxruntime-win-x64-cuda'
+        targetPath: '$(Build.BinariesDirectory)/nuget-artifact'
+
+    # Reconstruct the build dir
+    - task: PowerShell@2
+      displayName: 'Extract native libraries for addition to nuget native package'
+      inputs:
+        targetType: filePath
+        filePath: $(Build.SourcesDirectory)\tools\ci_build\github\windows\extract_nuget_files.ps1
+
+    - task: MSBuild@1
+      displayName: 'Restore NuGet Packages and create project.assets.json'
+      inputs:
+        solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln'
+        platform: 'Any CPU'
+        configuration: RelWithDebInfo
+        msbuildArguments: '-t:restore -p:OrtPackageId=Microsoft.ML.OnnxRuntime'
+        workingDirectory: '$(Build.SourcesDirectory)\csharp'
+
+    - task: MSBuild@1
+      displayName: 'Build C# bindings'
+      inputs:
+        solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln'
+        platform: 'Any CPU'
+        configuration: RelWithDebInfo
+        msbuildArguments: '-p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=Microsoft.ML.OnnxRuntime -p:IsReleaseBuild=${{ parameters.IsReleaseBuild }} -p:ReleaseVersionSuffix=$(ReleaseVersionSuffix) -p:PackageVersion=$(OnnxRuntimeVersion)'
+        workingDirectory: '$(Build.SourcesDirectory)\csharp'
+
+    - template: win-esrp-dll.yml
+      parameters:
+        FolderPath: '$(Build.SourcesDirectory)\csharp\src\Microsoft.ML.OnnxRuntime\bin\RelWithDebInfo'
+        DisplayName: 'ESRP - Sign C# dlls'
+        DoEsrp: true
+
+    - task: MSBuild@1
+      displayName: 'Build Nuget Packages'
+      inputs:
+        solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.proj'
+        platform: 'Any CPU'
+        configuration: RelWithDebInfo
+        msbuildArguments: '-t:CreatePackage -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=Microsoft.ML.OnnxRuntime -p:IsReleaseBuild=${{ parameters.IsReleaseBuild }} -p:ReleaseVersionSuffix=$(ReleaseVersionSuffix) -p:CurrentTime=$(BuildTime) -p:CurrentDate=$(BuildDate)'
+        workingDirectory: '$(Build.SourcesDirectory)\csharp'
+
+    - task: CopyFiles@2
+      displayName: 'Copy managed nuget package to: $(Build.ArtifactStagingDirectory)'
+      inputs:
+        SourceFolder: '$(Build.SourcesDirectory)\csharp\src\Microsoft.ML.OnnxRuntime\bin\RelWithDebInfo'
+        Contents: '*.nupkg'
+        TargetFolder: '$(Build.ArtifactStagingDirectory)'
+
+    - template: esrp_nuget.yml
+      parameters:
+        DisplayName: 'ESRP - sign NuGet package'
+        FolderPath: '$(Build.ArtifactStagingDirectory)'
+        DoEsrp: true

--- a/tools/nuget/generate_nuspec_for_custom_nuget.py
+++ b/tools/nuget/generate_nuspec_for_custom_nuget.py
@@ -18,15 +18,16 @@ def generate_files(lines, args):
         "osx-arm64": args.osx_arm64,
     }
 
-    avoid_keywords = {"pdb"}
+    avoid_keywords = {"pdb", "onnxruntime_providers_cuda"}
     processed_includes = set()
     for platform, platform_dir in platform_map.items():
         for file in glob.glob(os.path.join(platform_dir, "lib", "*")):
             if not os.path.isfile(file):
                 continue
-            if any(keyword in file for keyword in avoid_keywords):
-                continue
+
             file_name = os.path.basename(file)
+            if any(keyword in file_name for keyword in avoid_keywords):
+                continue
 
             files_list.append(f'<file src="{file}" target="runtimes/{platform}/native/{file_name}" />')
 
@@ -50,9 +51,6 @@ def generate_files(lines, args):
     files_list.append(f'<file src="{os.path.join(args.root_dir, "docs", "Privacy.md")}" target="Privacy.md" />')
     files_list.append(
         f'<file src="{os.path.join(args.root_dir, "ORT_icon_for_light_bg.png")}" target="ORT_icon_for_light_bg.png" />'
-    )
-    files_list.append(
-        f'<file src="{os.path.join(args.win_arm64, "Qualcomm_LICENSE.pdf")}" target="Qualcomm_LICENSE.pdf" />'
     )
 
     source_props = os.path.join(


### PR DESCRIPTION
This pull-request removes the:

- onnxruntime_providers_cuda.dll
- onnxruntime_providers_qnn.dll
- All the QNN binaries

from the FL nuget package.