### PR TITLE
OpenVINO: replace std::format with string concatenation for C++20 com…

### DIFF
--- a/onnxruntime/core/providers/openvino/backend_manager.cc
+++ b/onnxruntime/core/providers/openvino/backend_manager.cc
@@ -4,6 +4,7 @@
 #include <array>
 #include <algorithm>
 #include <cassert>
+#include <cstdlib>
 #include <fstream>
 #include <regex>
 #include <sstream>
@@ -434,8 +435,9 @@ static void ReadExternalDataFields(const ONNX_NAMESPACE::TensorProto* src_init, 
     if (pb_key == "location") {
       location = pb_value;
     } else if (pb_key == "offset") {
-      const auto res = std::from_chars(pb_value.data(), pb_value.data() + pb_value.size(), offset);
-      if (res.ec != std::errc()) {
+      char* end_ptr = nullptr;
+      offset = std::strtoull(pb_value.c_str(), &end_ptr, 10);
+      if (end_ptr == pb_value.c_str() || (end_ptr != nullptr && *end_ptr != '\0')) {
         std::ostringstream err_msg;
         err_msg << "External data in memory has invalid offset field: "
                 << src_init->name() << "], location: " << location
@@ -443,8 +445,9 @@ static void ReadExternalDataFields(const ONNX_NAMESPACE::TensorProto* src_init, 
         ORT_THROW(err_msg.str());
       }
     } else if (pb_key == "length") {
-      const auto res = std::from_chars(pb_value.data(), pb_value.data() + pb_value.size(), length);
-      if (res.ec != std::errc()) {
+      char* end_ptr = nullptr;
+      length = std::strtoull(pb_value.c_str(), &end_ptr, 10);
+      if (end_ptr == pb_value.c_str() || (end_ptr != nullptr && *end_ptr != '\0')) {
         std::ostringstream err_msg;
         err_msg << "External data in memory has invalid length field: "
                 << src_init->name() << "], location: " << location

--- a/onnxruntime/core/providers/openvino/exceptions.h
+++ b/onnxruntime/core/providers/openvino/exceptions.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstdlib>
 #include <exception>
 #include <regex>
 #include <string>
@@ -69,7 +70,8 @@ struct ovep_exception : public std::exception {
     std::regex error_code_pattern("code 0x([0-9a-fA-F]+)");
     std::smatch matches;
     if (std::regex_search(ov_exception_string, matches, error_code_pattern)) {
-      std::from_chars(&(*matches[1].first), &(*matches[1].second), error_code, 16);
+      std::string hex_str(matches[1].first, matches[1].second);
+      error_code = static_cast<uint32_t>(std::strtoul(hex_str.c_str(), nullptr, 16));
     }
     return error_code;
   }

--- a/onnxruntime/core/providers/openvino/ov_factory.cc
+++ b/onnxruntime/core/providers/openvino/ov_factory.cc
@@ -7,7 +7,7 @@
 #include <algorithm>
 #include <vector>
 #include <ranges>
-#include <format>
+#include <ranges>
 
 #define ORT_API_MANUAL_INIT
 #include "onnxruntime_cxx_api.h"
@@ -170,7 +170,8 @@ OrtStatus* CreateEpFactories(const char* /*registration_name*/, const OrtApiBase
 
   const size_t required_factories = supported_factories.size();
   if (max_factories < required_factories) {
-    return Ort::Status(std::format("Not enough space to return EP factories. Need at least {} factories.", required_factories).c_str(), ORT_INVALID_ARGUMENT);
+    std::string msg = "Not enough space to return EP factories. Need at least " + std::to_string(required_factories) + " factories.";
+    return Ort::Status(msg.c_str(), ORT_INVALID_ARGUMENT);
   }
 
   size_t factory_index = 0;


### PR DESCRIPTION
…patibility (#26936)

### Description
Fixes GCC build failure on Linux distributions where GCC < 13 is used (e.g., Ubuntu 22.04, Debian 12, CentOS Stream 9) by removing the usage of C++20 `std::format`.


### Motivation and Context
Resolves #26936.
The OpenVINO provider recently introduced a dependency on `<format>` which makes the build fail on systems with older GCC versions (missing `std::format` support).

