### PR TITLE
Add cstdint include to tensor_shape.h

### DIFF
--- a/include/onnxruntime/core/framework/tensor_shape.h
+++ b/include/onnxruntime/core/framework/tensor_shape.h
@@ -8,6 +8,7 @@
 #include <iosfwd>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 #include <gsl/gsl>
 #include "core/common/inlined_containers_fwd.h"


### PR DESCRIPTION


### Description
Depending on the platform, this include is implied in the previous include, but on Linux-musl it is not, resulting in int64_t being undefined later on.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


