### PR TITLE
Add fmt to build OpenVINO on GCC 11.x (#26936)

### DIFF
--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -6119,3 +6119,30 @@ Redistribution and use in source and binary forms, with or without modification,
 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+_____
+
+fmt
+
+https://github.com/fmtlib/fmt
+
+Copyright (c) 2012 - present, Victor Zverovich and {fmt} contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -58,3 +58,4 @@ cudnn_frontend;https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.12.
 dawn;https://github.com/google/dawn/archive/13c1635a14574ebb7116b56a69f5519301417fda.zip;0aadd28fc385cf7d657d5fc70a352372d2d3c76a
 kleidiai;https://github.com/ARM-software/kleidiai/archive/refs/tags/v1.15.0.tar.gz;62ccd24ab60bcef68766440fb42d79071ac2a5d2
 duktape;https://github.com/svaarala/duktape/releases/download/v2.7.0/duktape-2.7.0.tar.xz;8200c8e417dbab7adcc12c4dbdef7651cfc55794
+fmt;https://github.com/fmtlib/fmt/releases/download/12.1.0/fmt-12.1.0.zip;b7ac21c8a893c29a963634e289632c4a202c7b4e

--- a/cmake/onnxruntime_providers_openvino.cmake
+++ b/cmake/onnxruntime_providers_openvino.cmake
@@ -21,6 +21,13 @@
     add_definitions(-DUSE_OVEP_NPU_MEMORY=1)
   endif()
 
+  onnxruntime_fetchcontent_declare(
+    fmt
+    URL ${DEP_URL_fmt}
+    URL_HASH SHA1=${DEP_SHA1_fmt}
+  )
+  onnxruntime_fetchcontent_makeavailable(fmt)
+
   # If building RelWithDebInfo and OV package does not have that configuration map to Release
   get_target_property(ov_rt_implib_rwdi openvino::runtime IMPORTED_IMPLIB_RELWITHDEBINFO)
   if ((CMAKE_BUILD_TYPE STREQUAL RelWithDebInfo) AND NOT ov_rt_implib_rwdi)

--- a/onnxruntime/core/providers/openvino/ov_factory.cc
+++ b/onnxruntime/core/providers/openvino/ov_factory.cc
@@ -7,7 +7,7 @@
 #include <algorithm>
 #include <vector>
 #include <ranges>
-#include <format>
+#include <fmt/std.h>
 
 #define ORT_API_MANUAL_INIT
 #include "onnxruntime_cxx_api.h"
@@ -170,7 +170,7 @@ OrtStatus* CreateEpFactories(const char* /*registration_name*/, const OrtApiBase
 
   const size_t required_factories = supported_factories.size();
   if (max_factories < required_factories) {
-    return Ort::Status(std::format("Not enough space to return EP factories. Need at least {} factories.", required_factories).c_str(), ORT_INVALID_ARGUMENT);
+    return Ort::Status(fmt::format("Not enough space to return EP factories. Need at least {} factories.", required_factories).c_str(), ORT_INVALID_ARGUMENT);
   }
 
   size_t factory_index = 0;

--- a/onnxruntime/core/providers/openvino/ov_interface.cc
+++ b/onnxruntime/core/providers/openvino/ov_interface.cc
@@ -3,7 +3,7 @@
 
 #include "core/providers/openvino/ov_interface.h"
 
-#include <format>
+#include <fmt/std.h>
 
 #define ORT_API_MANUAL_INIT
 #include "core/session/onnxruntime_cxx_api.h"
@@ -18,17 +18,17 @@ namespace onnxruntime {
 namespace openvino_ep {
 
 template <bool typed, typename Func, typename... Args>
-inline auto OvExceptionBoundary(Func&& func, std::format_string<Args...>&& fmt, Args&&... args) {
+inline auto OvExceptionBoundary(Func&& func, fmt::format_string<Args...>&& fmt, Args&&... args) {
   try {
     return func();
   } catch (const ov::Exception& e) {
     if constexpr (typed) {
       throw ovep_exception(e, ovep_exception::type::import_model);
     } else {
-      ORT_THROW(log_tag + std::vformat(fmt.get(), std::make_format_args(args...)) + ": " + std::string(e.what()));
+      ORT_THROW(log_tag + fmt::vformat(fmt.get(), fmt::make_format_args(args...)) + ": " + std::string(e.what()));
     }
   } catch (...) {
-    ORT_THROW(log_tag + std::vformat(fmt.get(), std::make_format_args(args...)));
+    ORT_THROW(log_tag + fmt::vformat(fmt.get(), fmt::make_format_args(args...)));
   }
 }
 
@@ -557,7 +557,7 @@ OVTensorPtr StatefulOVInferRequest::GetTensor(const std::string& input_name) {
   if (_npu_logits_slice_required) {
     if (input_name == "logits") {
       if (tobj->get_shape().size() != 3) {
-        ORT_THROW(log_tag + std::format("Expected logits to have shape of rank 3, but it has shape of rank {}",
+        ORT_THROW(log_tag + fmt::format("Expected logits to have shape of rank 3, but it has shape of rank {}",
                                         tobj->get_shape().size()));
       }
 

--- a/onnxruntime/core/providers/openvino/qdq_transformations/qdq_scales_fix.cc
+++ b/onnxruntime/core/providers/openvino/qdq_transformations/qdq_scales_fix.cc
@@ -268,7 +268,7 @@ struct GraphNode {
       return (val.has_value()) ? print_bool(val.value()) : "None";
     };
 
-    auto string = std::format("node_name={} op_type={} scale_factor={:.2f} visited={} queued={} down_to_output={} processed={} from_node={} to_node={} node_input_name={} node_output_name={}",
+    auto string = fmt::format("node_name={} op_type={} scale_factor={:.2f} visited={} queued={} down_to_output={} processed={} from_node={} to_node={} node_input_name={} node_output_name={}",
                               node_name,
                               op_type,
                               scale_factor,


### PR DESCRIPTION
Added dependences to fmt library to build openvino provider with GCC version 11.