### PR TITLE
[QNN-EP] Re-enable Where op unit tests

### DIFF
--- a/onnxruntime/test/providers/qnn/where_htp_test.cc
+++ b/onnxruntime/test/providers/qnn/where_htp_test.cc
@@ -86,8 +86,7 @@ static void RunWhereQDQTest(const TestInputDef<bool>& condition_def,
 }
 
 // Check that QNN compiles DQ -> Where -> Q as a single unit.
-// Fails since QNN 2.37.1: Failed to finalize QNN graph. Error code: 1002
-TEST_F(QnnHTPBackendTests, DISABLED_WhereQDQU8) {
+TEST_F(QnnHTPBackendTests, WhereQDQU8) {
   RunWhereQDQTest(TestInputDef<bool>({4, 3, 2}, false,
                                      {true, false, true, false, true, false,
                                       true, false, true, false, true, false,
@@ -100,8 +99,7 @@ TEST_F(QnnHTPBackendTests, DISABLED_WhereQDQU8) {
 
 // Check that QNN compiles DQ -> Where -> Q as a single unit.
 // Check QNN Where works with broadcast
-// Fails since QNN 2.37.1: Failed to finalize QNN graph. Error code: 1002
-TEST_F(QnnHTPBackendTests, DISABLED_WhereBroadcastU8) {
+TEST_F(QnnHTPBackendTests, WhereBroadcastU8) {
   RunWhereQDQTest(TestInputDef<bool>({2}, false, {true, false}),
                   TestInputDef<float>({4, 3, 2}, true, -2.0f, 2.0f),
                   TestInputDef<float>({1}, true, {3.0f}),


### PR DESCRIPTION
### Description
This change re-enables previously disabled Where operator unit tests to restore test coverage.

### Motivation and Context
Starting with QNN 2.37, two Where op unit tests failed during QNN graph finalization, so they were disabled. From QNN 2.41 onward, these tests now pass successfully. Re-enabling them ensures coverage and validates correctness under the updated QNN version.


