### PR TITLE
Enhance stale issue management with new label checks

### DIFF
--- a/.github/policies/updateStaleIssues.yml
+++ b/.github/policies/updateStaleIssues.yml
@@ -56,13 +56,3 @@ configuration:
         then:
           - removeLabel:
               label: stale
-      - description: Re-open stale issue if closed stale issue is commented on
-        if:
-          - payloadType: Issue_Comment
-          - and:
-              - not:
-                  isOpen
-              - hasLabel:
-                  label: stale
-        then:
-          - reopenIssue


### PR DESCRIPTION
- Updated stale issue policy to include 'no stale' label checks and modified reply message.
- Do not reopen closed stale issues automatically, as it is just noisy. Instead, we could encourage issue owners to reopen manually or create new issues.

