### PR TITLE
remove lint for /js/ folder

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -115,23 +115,3 @@ jobs:
           level: info
           flags: --linelength=120 --exclude=java/src/main/native/*.c --exclude=onnxruntime/core/mlas/inc/* --exclude=onnxruntime/core/mlas/lib/* --exclude=onnxruntime/contrib_ops/cuda/bert/flash_attention/* --exclude=build/Debug/* --exclude=cmake/* --exclude=csharp/test/* --exclude=onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/GeneratedShaders/* --exclude=orttraining/orttraining/test/* --exclude=onnxruntime/test/* --exclude=winml/*
           filter: "-runtime/references"
-
-  lint-js:
-    name: Lint JavaScript
-    runs-on: [
-        "self-hosted",
-        "1ES.Pool=onnxruntime-github-Ubuntu2204-AMD-CPU",
-        "JobId=lint-js-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"
-        ]
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 20
-      - uses: reviewdog/action-eslint@v1
-        with:
-          reporter: github-pr-check
-          level: error
-          filter_mode: file
-          eslint_flags: "--ext .ts --ext .tsx"
-          workdir: "js/"


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

`js/` linting is already done in the Web CI pipeline so removing redundant check as its signaling false-positives


