### PR TITLE
Revert "[QNN EP] Upgrade QNN to 2.42.0 (#26958)"

### DIFF
--- a/.github/workflows/windows_qnn_x64.yml
+++ b/.github/workflows/windows_qnn_x64.yml
@@ -51,14 +51,14 @@ jobs:
       - name: Download QNN SDK
         working-directory: ${{ runner.temp }}
         run: |
-          azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/qnnsdk/qnn-v2.42.0.251225 .
+          azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/qnnsdk/qnn-v2.41.0.251128 .
           dir
         shell: pwsh
 
       - name: Set QNN_SDK_ROOT environment variable
         shell: pwsh
         run: |
-          $qnn_sdk_path = Join-Path $env:RUNNER_TEMP "qnn-v2.42.0.251225"
+          $qnn_sdk_path = Join-Path $env:RUNNER_TEMP "qnn-v2.41.0.251128"
           echo "QNN_SDK_ROOT=$qnn_sdk_path" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "QNN SDK Root: $qnn_sdk_path"
           dir $qnn_sdk_path

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/layer_norm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/layer_norm_op_builder.cc
@@ -35,15 +35,6 @@ class LayerNormOpBuilder : public BaseOpBuilder {
 Status LayerNormOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
                                          const NodeUnit& node_unit,
                                          const logging::Logger& logger) const {
-  bool is_cpu_backend = IsCpuBackend(qnn_model_wrapper.GetQnnBackendType());
-
-  // Disable LayerNorm for CPU backend when API version > 2.31
-  // This catches SDK version 2.42 which has API version 2.32
-  if (is_cpu_backend && (QNN_API_VERSION_MAJOR == 2 && QNN_API_VERSION_MINOR > 31)) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED,
-                           "LayerNorm is not supported on QNN CPU backend with QNN SDK version > 2.41 due to accuracy issues");
-  }
-
   // Also check output type is float for CPU.
   const auto& outputs = node_unit.Outputs();
   ORT_RETURN_IF(outputs.size() > 1, "QNN LayerNorm only support 1 output.");

--- a/onnxruntime/test/providers/qnn/layer_norm_test.cc
+++ b/onnxruntime/test/providers/qnn/layer_norm_test.cc
@@ -32,37 +32,35 @@ static void RunLayerNormCpuTest(const TestInputDef<float>& input_def,
                   expected_ep_assignment);
 }
 
-// Disabled all QNN CPU LayerNorm tests due to bug in 2.42 SDK
-
-TEST_F(QnnCPUBackendTests, DISABLED_LayerNorm) {
+TEST_F(QnnCPUBackendTests, LayerNorm) {
   RunLayerNormCpuTest(TestInputDef<float>({2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
                       TestInputDef<float>({2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
                       {utils::MakeAttribute("axis", static_cast<int64_t>(0))},
                       ExpectedEPNodeAssignment::All);
 }
 
-TEST_F(QnnCPUBackendTests, DISABLED_LayerNorm1D_Axis0) {
+TEST_F(QnnCPUBackendTests, LayerNorm1D_Axis0) {
   RunLayerNormCpuTest(TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
                       TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
                       {utils::MakeAttribute("axis", static_cast<int64_t>(0))},
                       ExpectedEPNodeAssignment::All);
 }
 
-TEST_F(QnnCPUBackendTests, DISABLED_LayerNorm1D_AxisLast) {
+TEST_F(QnnCPUBackendTests, LayerNorm1D_AxisLast) {
   RunLayerNormCpuTest(TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
                       TestInputDef<float>({3}, false, GetFloatDataInRange(0.0f, 10.0f, 3)),
                       {utils::MakeAttribute("axis", static_cast<int64_t>(-1))},
                       ExpectedEPNodeAssignment::All);
 }
 
-TEST_F(QnnCPUBackendTests, DISABLED_LayerNorm2D) {
+TEST_F(QnnCPUBackendTests, LayerNorm2D) {
   RunLayerNormCpuTest(TestInputDef<float>({1, 2, 3, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 18)),
                       TestInputDef<float>({1, 2, 3, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 18)),
                       {utils::MakeAttribute("axis", static_cast<int64_t>(0))},
                       ExpectedEPNodeAssignment::All);
 }
 
-TEST_F(QnnCPUBackendTests, DISABLED_LayerNorm3D) {
+TEST_F(QnnCPUBackendTests, LayerNorm3D) {
   RunLayerNormCpuTest(TestInputDef<float>({1, 2, 3, 3, 4}, false, GetFloatDataInRange(0.0f, 10.0f, 72)),
                       TestInputDef<float>({1, 2, 3, 3, 4}, false, GetFloatDataInRange(0.0f, 10.0f, 72)),
                       {utils::MakeAttribute("axis", static_cast<int64_t>(0))},

--- a/tools/ci_build/github/azure-pipelines/android-arm64-v8a-QNN-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-arm64-v8a-QNN-crosscompile-ci-pipeline.yml
@@ -32,7 +32,7 @@ parameters:
 - name: QnnSdk
   displayName: QNN SDK version
   type: string
-  default: 2.42.0.251225
+  default: 2.41.0.251128
 
 jobs:
 - job: Build_QNN_EP

--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -55,7 +55,7 @@ parameters:
 - name: QnnSdk
   displayName: QNN SDK Version
   type: string
-  default: 2.42.0.251225
+  default: 2.41.0.251128
 
 - name: CudaVersion
   displayName: CUDA version

--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-test-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-test-pipelines.yml
@@ -83,7 +83,7 @@ stages:
       artifactName: 'onnxruntime-android-qnn-aar'
       packageName: 'onnxruntime-android-qnn'
       #TODO: get this information from the setup stage
-      QnnSDKVersion: '2.42.0.251225'
+      QnnSDKVersion: '2.41.0.251128'
 
 - template: nuget/templates/test_win.yml
   parameters:

--- a/tools/ci_build/github/azure-pipelines/linux-qnn-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-qnn-ci-pipeline.yml
@@ -33,7 +33,7 @@ parameters:
 - name: QnnSdk
   displayName: QNN SDK version
   type: string
-  default: 2.42.0.251225
+  default: 2.41.0.251128
 
 jobs:
   - job: Build_QNN_EP

--- a/tools/ci_build/github/azure-pipelines/py-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/py-packaging-pipeline.yml
@@ -59,7 +59,7 @@ parameters:
 - name: qnn_sdk_version
   type: string
   displayName: 'QNN SDK version. Only for QNN packages.'
-  default: 2.42.0.251225
+  default: 2.41.0.251128
 
 trigger: none
 

--- a/tools/ci_build/github/azure-pipelines/qnn-ep-nuget-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/qnn-ep-nuget-packaging-pipeline.yml
@@ -2,7 +2,7 @@ parameters:
 - name: QnnSdk
   displayName: QNN SDK Version
   type: string
-  default: 2.42.0.251225
+  default: 2.41.0.251128
 
 - name: build_config
   displayName: Build Configuration

--- a/tools/ci_build/github/azure-pipelines/stages/py-cpu-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/py-cpu-packaging-stage.yml
@@ -59,7 +59,7 @@ parameters:
 - name: qnn_sdk_version
   type: string
   displayName: 'QNN SDK version. Only for QNN packages.'
-  default: 2.42.0.251225
+  default: 2.41.0.251128
 
 stages:
 - ${{ if eq(parameters.enable_windows_cpu, true) }}:

--- a/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar-test.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar-test.yml
@@ -19,7 +19,7 @@ parameters:
 - name: QnnSDKVersion
   displayName: QNN SDK Version
   type: string
-  default: '2.42.0.251225'
+  default: '2.41.0.251128'
 
 - name: enableWebGpu
   displayName: Enable WebGPU test

--- a/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar.yml
@@ -53,7 +53,7 @@ parameters:
 - name: QnnSDKVersion
   displayName: QNN SDK Version
   type: string
-  default: '2.42.0.251225'
+  default: '2.41.0.251128'
 
 - name: is1ES
   displayName: Is 1ES pipeline

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -46,7 +46,7 @@ parameters:
 - name: QnnSDKVersion
   displayName: QNN SDK Version
   type: string
-  default: 2.42.0.251225
+  default: 2.41.0.251128
 
 - name: is1ES
   displayName: Is 1ES pipeline

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/download_linux_qnn_sdk.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/download_linux_qnn_sdk.yml
@@ -1,7 +1,7 @@
 parameters:
   - name: QnnSDKVersion
     type: string
-    default: '2.42.0.251225'
+    default: '2.41.0.251128'
 
 steps:
   - script: |

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/download_win_qnn_sdk.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/download_win_qnn_sdk.yml
@@ -1,7 +1,7 @@
 parameters:
   - name: QnnSDKVersion
     type: string
-    default: '2.42.0.251225'
+    default: '2.41.0.251128'
 
 steps:
   - powershell: |

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/init_linux_qnn_sdk_x64.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/init_linux_qnn_sdk_x64.yml
@@ -1,7 +1,7 @@
 parameters:
   - name: QnnSDKVersion
     type: string
-    default: '2.42.0.251225'
+    default: '2.41.0.251128'
 
 steps:
   - bash: |

--- a/tools/ci_build/github/azure-pipelines/templates/py-linux-qnn.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-linux-qnn.yml
@@ -26,7 +26,7 @@ parameters:
 - name: QnnSdk
   displayName: QNN SDK version
   type: string
-  default: 2.42.0.251225
+  default: 2.41.0.251128
 
 - name: is1ES
   displayName: 'Whether the pipeline is running in 1ES'

--- a/tools/ci_build/github/azure-pipelines/templates/py-win-arm64-qnn.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-win-arm64-qnn.yml
@@ -11,7 +11,7 @@ parameters:
 - name: QNN_SDK
   displayName: QNN SDK Version
   type: string
-  default: 2.42.0.251225
+  default: 2.41.0.251128
 
 - name: ENV_SETUP_SCRIPT
   type: string

--- a/tools/ci_build/github/azure-pipelines/templates/py-win-arm64ec-qnn.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-win-arm64ec-qnn.yml
@@ -7,7 +7,7 @@ parameters:
 - name: QNN_SDK
   displayName: QNN SDK Version
   type: string
-  default: 2.42.0.251225
+  default: 2.41.0.251128
 
 - name: ENV_SETUP_SCRIPT
   type: string

--- a/tools/ci_build/github/azure-pipelines/templates/py-win-x64-qnn.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-win-x64-qnn.yml
@@ -7,7 +7,7 @@ parameters:
 - name: QNN_SDK
   displayName: QNN SDK Version
   type: string
-  default: 2.42.0.251225
+  default: 2.41.0.251128
 
 - name: ENV_SETUP_SCRIPT
   type: string

--- a/tools/ci_build/github/azure-pipelines/templates/qnn-ep-win.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/qnn-ep-win.yml
@@ -1,5 +1,5 @@
 parameters:
-  QnnSdk: '2.42.0.251225'
+  QnnSdk: '2.41.0.251128'
   build_config: 'RelWithDebInfo'
   IsReleaseBuild: false
   DoEsrp: false

--- a/tools/ci_build/github/azure-pipelines/win-qnn-arm64-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-qnn-arm64-ci-pipeline.yml
@@ -33,7 +33,7 @@ parameters:
 - name: QnnSdk
   displayName: QNN SDK version
   type: string
-  default: 2.42.0.251225
+  default: 2.41.0.251128
 
 jobs:
 - job: 'BUILD_QNN_EP'


### PR DESCRIPTION
This reverts commit 669128acd5eb804daa5d756e1dcf349abbdfcdac to unblock CI pipeline.
as a backup plan for disabling failed onnx tests.