### PR TITLE
Fix the bug in setting `_fallback_providers`

### DIFF
--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -513,23 +513,6 @@ class InferenceSession(Session):
         available_providers = C.get_available_providers()
 
         # Tensorrt can fall back to CUDA if it's explicitly assigned. All others fall back to CPU.
-        if "TensorrtExecutionProvider" in available_providers:
-            if (
-                providers
-                and any(
-                    provider == "CUDAExecutionProvider"
-                    or (isinstance(provider, tuple) and provider[0] == "CUDAExecutionProvider")
-                    for provider in providers
-                )
-                and any(
-                    provider == "TensorrtExecutionProvider"
-                    or (isinstance(provider, tuple) and provider[0] == "TensorrtExecutionProvider")
-                    for provider in providers
-                )
-            ):
-                self._fallback_providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
-            else:
-                self._fallback_providers = ["CPUExecutionProvider"]
         if "NvTensorRTRTXExecutionProvider" in available_providers:
             if (
                 providers
@@ -541,6 +524,23 @@ class InferenceSession(Session):
                 and any(
                     provider == "NvTensorRTRTXExecutionProvider"
                     or (isinstance(provider, tuple) and provider[0] == "NvExecutionProvider")
+                    for provider in providers
+                )
+            ):
+                self._fallback_providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+            else:
+                self._fallback_providers = ["CPUExecutionProvider"]
+        elif "TensorrtExecutionProvider" in available_providers:
+            if (
+                providers
+                and any(
+                    provider == "CUDAExecutionProvider"
+                    or (isinstance(provider, tuple) and provider[0] == "CUDAExecutionProvider")
+                    for provider in providers
+                )
+                and any(
+                    provider == "TensorrtExecutionProvider"
+                    or (isinstance(provider, tuple) and provider[0] == "TensorrtExecutionProvider")
                     for provider in providers
                 )
             ):


### PR DESCRIPTION
### Description
This PR fixes a bug regarding how `_fallback_providers` is set. With this change, when setting providers to `["TensorrtExecutionProvider", "CUDAExecutionProvider"]`, _fallback_providers will correctly resolve to `["CUDAExecutionProvider", "CPUExecutionProvider"]`.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Fixes #27006

When setting providers to `["TensorrtExecutionProvider", "CUDAExecutionProvider"]`, _fallback_providers is expected to be `["CUDAExecutionProvider", "CPUExecutionProvider"]`. However, currently it results in `["CPUExecutionProvider"]`.

This issue originates from the else statement logic within `NvTensorRTRTXExecutionProvider`. It appears the original intention was to prioritize `NvTensorRTRTXExecutionProvider`, but it inadvertently caused this bug.

This PR fixes the issue while preserving the original design intention.

