### PR TITLE
Disable matmul 1d tests on DML

### DIFF
--- a/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
+++ b/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
@@ -805,7 +805,10 @@
         "^test_reduce_max_empty_set_cpu",   // DNNL result in "(shapes (2, 1, 4), (1, 0, 1) mismatch)". this is the same for test_reduce_min_empty_set which is already in the list
         "^test_reduce_min_empty_set_cpu",
         "^test_resize_upsample_sizes_nearest_not_smaller_cpu",
-        "^test_clip_min_greater_than_max_cpu"
+        "^test_clip_min_greater_than_max_cpu",
+        // Fail since v1.20.1 (new matmul 1D tests)
+        "^test_matmul_1d_1d_cpu",
+        "^test_matmul_4d_1d_cpu"
     ],
     // ORT first supported opset 7, so models with nodes that require versions prior to opset 7 are not supported
     "tests_with_pre_opset7_dependencies": [


### PR DESCRIPTION
The new matmul 1d tests are introduced in ONNX v1.20.1 (https://github.com/microsoft/onnxruntime/pull/26579). They are not currently supported by DML.

Original PR on ONNX: https://github.com/onnx/onnx/pull/7407

