### PR TITLE
Tweak external resource importer handle structs

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
@@ -43,11 +43,9 @@ ORT_RUNTIME_CLASS(ExternalResourceImporterImpl);
  * \since Version 1.24.
  */
 struct OrtExternalMemoryHandle {
-  uint32_t version;                         ///< Must be ORT_API_VERSION
-  const OrtEpDevice* ep_device;             ///< EP device that created this handle
-  OrtExternalMemoryHandleType handle_type;  ///< Original handle type for tracking
-  size_t size_bytes;                        ///< Size of the imported memory
-  size_t offset_bytes;                      ///< Offset into the imported memory
+  uint32_t version;                        ///< Must be ORT_API_VERSION
+  const OrtEpDevice* ep_device;            ///< EP device that created this handle
+  OrtExternalMemoryDescriptor descriptor;  ///< External memory descriptor
 
   /** \brief Release callback for this handle. EP sets this to its release function.
    *
@@ -72,9 +70,9 @@ struct OrtExternalMemoryHandle {
  * \since Version 1.24.
  */
 struct OrtExternalSemaphoreHandle {
-  uint32_t version;               ///< Must be ORT_API_VERSION
-  const OrtEpDevice* ep_device;   ///< EP device that created this handle
-  OrtExternalSemaphoreType type;  ///< Original semaphore type
+  uint32_t version;                           ///< Must be ORT_API_VERSION
+  const OrtEpDevice* ep_device;               ///< EP device that created this handle
+  OrtExternalSemaphoreDescriptor descriptor;  ///< External semaphore descriptor
 
   /** \brief Release callback for this handle. EP sets this to its release function.
    *

--- a/onnxruntime/test/autoep/library/example_plugin_ep/ep_external_resource_importer.h
+++ b/onnxruntime/test/autoep/library/example_plugin_ep/ep_external_resource_importer.h
@@ -19,14 +19,12 @@
 struct ExampleExternalMemoryHandle : OrtExternalMemoryHandle {
   std::unique_ptr<char[]> simulated_ptr;  ///< Simulated mapped pointer (CPU memory for testing)
 
-  ExampleExternalMemoryHandle()
+  ExampleExternalMemoryHandle(const OrtExternalMemoryDescriptor& descriptor_in)
       : simulated_ptr(nullptr) {
     // Initialize base struct fields
     version = ORT_API_VERSION;
     ep_device = nullptr;
-    handle_type = ORT_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE;
-    size_bytes = 0;
-    offset_bytes = 0;
+    descriptor = descriptor_in;
     Release = ReleaseCallback;
   }
 
@@ -48,12 +46,12 @@ struct ExampleExternalMemoryHandle : OrtExternalMemoryHandle {
 struct ExampleExternalSemaphoreHandle : OrtExternalSemaphoreHandle {
   std::atomic<uint64_t> value;  ///< Simulated fence value for testing
 
-  ExampleExternalSemaphoreHandle()
+  ExampleExternalSemaphoreHandle(const OrtExternalSemaphoreDescriptor& descriptor_in)
       : value(0) {
     // Initialize base struct fields
     version = ORT_API_VERSION;
     ep_device = nullptr;
-    type = ORT_EXTERNAL_SEMAPHORE_D3D12_FENCE;
+    descriptor = descriptor_in;
     Release = ReleaseCallback;
   }
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Use the descriptor struct in the external resource handle. 

We were copying most fields, but the setup is a little more intuitive when the descriptor is used directly.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


