### PR TITLE
Raise the timeout for the ios simulator job

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -72,7 +72,7 @@ jobs:
       matrix:
         target_arch: [x86_64, arm64]
 
-    timeout-minutes: 90
+    timeout-minutes: 120
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
### Description
As title - it looks like the duration of the job is very close to the timeout

### Motivation and Context
Reduce retrry attempts for the ios sim job

My own PR - https://github.com/microsoft/onnxruntime/pull/26688 keep timing out this job leg


