### PR TITLE
Optimize KLEIDIAI LHS packing in convolution

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -91,6 +91,7 @@ option(onnxruntime_USE_SVE "Build with SVE support in MLAS" OFF)
 option(onnxruntime_USE_ARM_NEON_NCHWC "Build with ARM Neon NCHWc kernels in MLAS" OFF)
 
 option(onnxruntime_USE_KLEIDIAI "Build with KleidiAI integration in MLAS" OFF)
+set(onnxruntime_KLEIDIAI_MAX_LHS_PACK_BYTES 2097152 CACHE STRING "Maximum temporary buffer size (in bytes) for KLEIDIAI LHS packing")
 option(onnxruntime_USE_QMX_KLEIDIAI_COEXIST "Build with QMX and Arm KLEIDIAI libraries" OFF)
 option(onnxruntime_BUILD_UNIT_TESTS "Build ONNXRuntime unit tests" ON)
 option(onnxruntime_BUILD_CSHARP "Build C# library" OFF)

--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -305,6 +305,9 @@ function(setup_kleidiai)
     target_compile_definitions(onnxruntime_mlas PRIVATE KLEIDIAI_KERNEL=1)
   endif()
 
+  target_compile_definitions(onnxruntime_mlas PRIVATE KLEIDIAI_MAX_LHS_PACK_BYTES=${onnxruntime_KLEIDIAI_MAX_LHS_PACK_BYTES})
+
+
   if (NOT onnxruntime_BUILD_SHARED_LIB)
     install(TARGETS kleidiai EXPORT ${PROJECT_NAME}Targets
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}


### PR DESCRIPTION
In previously, the convolution kernel for KLEIDIAI would allocate a large contiguous buffer for the LHS (left-hand-side) matrix packing, which could consume excessive memory and reduce cache efficiency.

This patch modifies the packing strategy to use a chunked approach:
- Introduce a compile-time upper bound for temporary LHS packing buffers
- Allocate a moderate-sized temporary buffer once.
- Pack LHS rows in chunks, perform computation, then reuse the buffer for the next chunk.

Benefits:
- Significantly reduces peak memory usage.
- Improves cache utilization and overall computation efficiency.
- Avoids potential memory allocation failures for large convolutions.

Performance improvement:
- Test with model https://huggingface.co/garavv/arcface-onnx on MTK D9500

    Before this patch
    ```
    ./build/RelWithDebInfo/onnxruntime_perf_test -x 1  -r 1000 arc.onnx

    Number of inferences per second: 4.25327
    ```

    After this patch
    ```
    ./build/RelWithDebInfo/onnxruntime_perf_test -x 1  -r 1000 arc.onnx

    Number of inferences per second: 5.03257
    ```

---------------------------------------------------------------------------------------------------------------- sme_with_patch | sme_without_patch  | Diff (μs) | Change % | Node Name ----------------------------------------------------------------------------------------------------------------
  11975.10 |    31235.30 |     19260.20 |    160.84% | StatefulPartitionedCall/ResNet34/conv2_block1_1_conv/Conv2D
   4514.80 |     7691.70 |      3176.90 |     70.37% | StatefulPartitionedCall/ResNet34/conv2_block2_1_conv/Conv2D
   4220.20 |     7120.70 |      2900.50 |     68.73% | StatefulPartitionedCall/ResNet34/conv2_block3_1_conv/Conv2D
   5429.20 |     8279.60 |      2850.40 |     52.50% | StatefulPartitionedCall/ResNet34/conv3_block1_1_conv/Conv2D
   4497.80 |     5478.40 |       980.60 |     21.80% | StatefulPartitionedCall/ResNet34/conv4_block1_1_conv/Conv2D
   3474.30 |     4351.80 |       877.50 |     25.26% | StatefulPartitionedCall/ResNet34/conv3_block3_1_conv/Conv2D
   3627.30 |     4504.00 |       876.70 |     24.17% | StatefulPartitionedCall/ResNet34/conv3_block4_1_conv/Conv2D
   5244.20 |     5961.10 |       716.90 |     13.67% | StatefulPartitionedCall/ResNet34/conv1_conv/Conv2D
   3439.80 |     4050.90 |       611.10 |     17.77% | StatefulPartitionedCall/ResNet34/conv3_block2_1_conv/Conv2D
   9749.80 |    10195.50 |       445.70 |      4.57% | StatefulPartitionedCall/ResNet34/conv2_block2_2_conv/Conv2D
   3814.00 |     4209.80 |       395.80 |     10.38% | StatefulPartitionedCall/ResNet34/conv5_block2_2_conv/Conv2D
   2715.90 |     3034.70 |       318.80 |     11.74% | StatefulPartitionedCall/ResNet34/conv4_block6_1_conv/Conv2D
   4089.10 |     4367.80 |       278.70 |      6.82% | StatefulPartitionedCall/ResNet34/conv5_block1_1_conv/Conv2D
   2698.00 |     2959.50 |       261.50 |      9.69% | StatefulPartitionedCall/ResNet34/conv4_block5_1_conv/Conv2D
   3869.20 |     4102.80 |       233.60 |      6.04% | StatefulPartitionedCall/ResNet34/conv5_block3_2_conv/Conv2D
   2767.90 |     2966.80 |       198.90 |      7.19% | StatefulPartitionedCall/ResNet34/conv4_block4_1_conv/Conv2D
   9652.10 |     9816.60 |       164.50 |      1.70% | StatefulPartitionedCall/ResNet34/conv2_block3_2_conv/Conv2D
   2897.50 |     3054.60 |       157.10 |      5.42% | StatefulPartitionedCall/ResNet34/conv4_block3_1_conv/Conv2D
   4601.20 |     4748.60 |       147.40 |      3.20% | StatefulPartitionedCall/ResNet34/conv5_block1_2_conv/Conv2D
   3134.00 |     3246.10 |       112.10 |      3.58% | StatefulPartitionedCall/ResNet34/conv4_block2_1_conv/Conv2D



