### PR TITLE
Add notes for bumping version as part of a release

### DIFF
--- a/docs/Versioning.md
+++ b/docs/Versioning.md
@@ -65,7 +65,7 @@ npm --version    # Should be v8.0 or newer
 
 5. **Commit and create PR**
 
-   Commit all changes and create a PR targeting the release branch.
+   Commit all changes and create a PR targeting `main` or a release branch as appropriate.
 
 ### Notes
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
When creating a release branch for a new ORT release, there are some steps required to comprehensively update the version number across the codebase. This change adds the steps for that for anyone driving a release.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
This will help with the release process and ensure that any bits produced from release branches carry the right version information. 

