### PR TITLE
Fix Doxygen documentation build error in onnxruntime_c_api.h

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -1062,8 +1062,8 @@ typedef struct OrtEnvCreationOptions {
    * \note Logging messages which are less severe than the `logging_severity_level` are not emitted.
    *
    * \note Serves as the default logging severity level for session creation and runs.
-   *       Use ::SetSessionLogSeverityLevel() to set a logging severity level for the creation of specific session.
-   *       Use ::RunOptionsSetRunLogSeverityLevel() to set a logging severity level for a specific session run.
+   *       Use OrtApi::SetSessionLogSeverityLevel to set a logging severity level for the creation of specific session.
+   *       Use OrtApi::RunOptionsSetRunLogSeverityLevel to set a logging severity level for a specific session run.
    *
    * \since Version 1.24.
    */
@@ -1116,7 +1116,7 @@ typedef struct OrtEnvCreationOptions {
    * \note Refer to onnxruntime_env_config_keys.h for common config entry keys and their supported values.
    *
    * \note An application provides environment-level configuration options for execution provider libraries by
-   *       using keys with the prefix 'ep_factory.<ep_name>.'. Ex: the key 'ep_factory.my_ep.some_ep_key' represents
+   *       using keys with the prefix 'ep_factory.\\<ep_name\\>.'. Ex: the key 'ep_factory.my_ep.some_ep_key' represents
    *       a key named 'some_ep_key' that is meant to be consumed by an execution provider named 'my_ep'. Refer to
    *       the specific execution provider's documentation for valid keys and values.
    *
@@ -7979,7 +7979,7 @@ struct OrtInteropApi {
 
   /** \brief Release an OrtExternalResourceImporter instance.
    *
-   * \param[in] importer The OrtExternalResourceImporter instance to release. May be nullptr.
+   * \param[in] input The OrtExternalResourceImporter instance to release. May be nullptr.
    *
    * \since Version 1.24.
    */
@@ -8022,7 +8022,7 @@ struct OrtInteropApi {
 
   /** \brief Release an OrtExternalMemoryHandle instance.
    *
-   * \param[in] handle The OrtExternalMemoryHandle instance to release. May be nullptr.
+   * \param[in] input The OrtExternalMemoryHandle instance to release. May be nullptr.
    *
    * \since Version 1.24.
    */
@@ -8088,7 +8088,7 @@ struct OrtInteropApi {
 
   /** \brief Release an OrtExternalSemaphoreHandle instance.
    *
-   * \param[in] handle The OrtExternalSemaphoreHandle instance to release. May be nullptr.
+   * \param[in] input The OrtExternalSemaphoreHandle instance to release. May be nullptr.
    *
    * \since Version 1.24.
    */

--- a/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
@@ -664,7 +664,7 @@ struct OrtLoopKernelHelper;
 typedef struct OrtLoopKernelHelper OrtLoopKernelHelper;
 
 /**
- * \brief Contains helper functions for a Loop OrtKernelImpl created via ::CreateLoopKernel().
+ * \brief Contains helper functions for a Loop OrtKernelImpl created via OrtEpApi::CreateLoopKernel.
  * \since Version 1.24.
  */
 struct OrtLoopKernelHelper {
@@ -707,7 +707,7 @@ struct OrtScanKernelHelper;
 typedef struct OrtScanKernelHelper OrtScanKernelHelper;
 
 /**
- * \brief Contains helper functions for a Scan OrtKernelImpl created via ::CreateScanKernel().
+ * \brief Contains helper functions for a Scan OrtKernelImpl created via OrtEpApi::CreateScanKernel.
  * \since Version 1.24.
  */
 struct OrtScanKernelHelper {
@@ -1431,13 +1431,13 @@ struct OrtEpApi {
   /** \brief Gets a new OrtKeyValuePairs instance containing a copy of all configuration entries set on the environment.
    *
    * \note An application provides environment-level configuration options for execution provider libraries by
-   *       using keys with the prefix 'ep_factory.<ep_name>.'. Ex: the key 'ep_factory.my_ep.some_ep_key' represents
+   *       using keys with the prefix 'ep_factory.\\<ep_name\\>.'. Ex: the key 'ep_factory.my_ep.some_ep_key' represents
    *       a key named 'some_ep_key' that is meant to be consumed by an execution provider named 'my_ep'. Refer to
    *       the specific execution provider's documentation for valid keys and values.
    *
    * \note Refer to onnxruntime_env_config_keys.h for common configuration entry keys and their supported values.
    *
-   * \param[out] out Output parameter set to the OrtKeyValuePairs instance containing all configuration entries.
+   * \param[out] config_entries Output parameter set to the OrtKeyValuePairs instance containing all configuration entries.
    *                 Must be released via OrtApi::ReleaseKeyValuePairs.
    *
    * \snippet{doc} snippets.dox OrtStatus Return Value


### PR DESCRIPTION
# Fix Doxygen documentation build errors from recent PRs

Fixes multiple Doxygen errors introduced by recent API additions that cause the nightly documentation build to fail (`WARN_AS_ERROR=YES`).

## Root Cause Analysis

| Error | File | Line | Introduced By | Commit | Fix |
|-------|------|------|---------------|--------|-----|
| Duplicate `\addtogroup Global` | onnxruntime_c_api.h | 973 | PR #26828 - OrtExternalResourceImporter API | c54be3c7 | Remove redundant group markers |
| Unresolved `::SetSessionLogSeverityLevel()` | onnxruntime_c_api.h | 1065 | PR #26971 - CreateEnvWithOptions API | 3874516d | Use `OrtApi::SetSessionLogSeverityLevel` |
| Unresolved `::RunOptionsSetRunLogSeverityLevel()` | onnxruntime_c_api.h | 1066 | PR #26971 - CreateEnvWithOptions API | 3874516d | Use `OrtApi::RunOptionsSetRunLogSeverityLevel` |
| `<ep_name>` interpreted as HTML | onnxruntime_c_api.h | 1119 | PR #26971 - CreateEnvWithOptions API | 3874516d | Escape as `\<ep_name\>` |
| `\param[in] importer` not found | onnxruntime_c_api.h | 7982 | PR #26828 - OrtExternalResourceImporter API | c54be3c7 | Use `\param[in] input` (macro expands to `input`) |
| `\param[in] handle` not found | onnxruntime_c_api.h | 8025 | PR #26828 - OrtExternalResourceImporter API | c54be3c7 | Use `\param[in] input` |
| `\param[in] handle` not found | onnxruntime_c_api.h | 8091 | PR #26828 - OrtExternalResourceImporter API | c54be3c7 | Use `\param[in] input` |
| Unresolved `::CreateLoopKernel()` | onnxruntime_ep_c_api.h | 667 | PR #26927 - Control flow kernels API | 1ed8fd90 | Use `OrtEpApi::CreateLoopKernel` |
| Unresolved `::CreateScanKernel()` | onnxruntime_ep_c_api.h | 710 | PR #26927 - Control flow kernels API | 1ed8fd90 | Use `OrtEpApi::CreateScanKernel` |
| `<ep_name>` interpreted as HTML | onnxruntime_ep_c_api.h | 1434 | PR #26971 - CreateEnvWithOptions API | 3874516d | Escape as `\<ep_name\>` |
| `\param[out] out` not found | onnxruntime_ep_c_api.h | 1440 | PR #26971 - CreateEnvWithOptions API | 3874516d | Use `\param[out] config_entries` |

## Summary by PR

| PR | Issues |
|----|--------|
| **#26828** (c54be3c7) - OrtExternalResourceImporter API for D3D12 | Duplicate Doxygen group, incorrect `\param` names for `ORT_CLASS_RELEASE` macros |
| **#26927** (1ed8fd90) - Control flow kernels API | `::Method()` syntax unresolvable by Doxygen |
| **#26971** (3874516d) - CreateEnvWithOptions API | `::Method()` syntax, `<ep_name>` HTML interpretation, incorrect param name |

## Technical Details

### `ORT_CLASS_RELEASE` Macro Issue

The `ORT_CLASS_RELEASE(X)` macro at line 164 expands to:
```cpp
void(ORT_API_CALL * Release##X)(_Frees_ptr_opt_ Ort##X * input)
```

The parameter is always named `input`, but the documentation in PR #26828 used semantic names like `importer` and `handle`. Doxygen validates `\param` names against actual parameter names in the expanded code.

### Doxygen Link Resolution

Doxygen 1.9.8 cannot resolve `::MethodName()` as a link to a method. The correct syntax is to qualify with the struct name: `OrtApi::MethodName`.

## Testing

Verified locally with Doxygen 1.9.8 (matches CI configuration).
