### PR TITLE
Fix OrtApi static_assert violation, add instructions for updating additional API structs.

### DIFF
--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -4839,7 +4839,7 @@ static_assert(offsetof(OrtApi, SetEpDynamicOptions) / sizeof(void*) == 284, "Siz
 
 static_assert(offsetof(OrtApi, GetEpApi) / sizeof(void*) == 317, "Size of version 22 API cannot change");
 static_assert(offsetof(OrtApi, CreateExternalInitializerInfo) / sizeof(void*) == 389, "Size of version 23 API cannot change");
-static_assert(offsetof(OrtApi, RunOptionsSetSyncStream) / sizeof(void*) == 411, "Size of version 24 API cannot change");
+static_assert(offsetof(OrtApi, RunOptionsSetSyncStream) / sizeof(void*) == 413, "Size of version 24 API cannot change");
 
 // So that nobody forgets to finish an API version, this check will serve as a reminder:
 static_assert(std::string_view(ORT_VERSION) == "1.25.0",
@@ -4851,9 +4851,10 @@ static_assert(std::string_view(ORT_VERSION) == "1.25.0",
 //    b. Add a static_assert in the directly above list of version sizes to ensure nobody adds any more functions to the just shipped API version
 //
 // 3. There are additional API structs that may have been updated. Repeat step 2 for these instances:
-//    - ort_model_editor_api in onnxruntime/onnxruntime/core/session/model_editor_c_api.cc
 //    - ort_compile_api in onnxruntime/onnxruntime/core/session/compile_api.cc
 //    - ort_ep_api in onnxruntime/onnxruntime/core/session/plugin_ep/ep_api.cc
+//    - ort_interop_api in onnxruntime/core/session/interop_api.cc
+//    - ort_model_editor_api in onnxruntime/onnxruntime/core/session/model_editor_c_api.cc
 
 ORT_API(const OrtApi*, OrtApis::GetApi, uint32_t version) {
   if (version >= 1 && version <= ORT_API_VERSION)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Fix OrtApi 1.24 API size static_assert violation triggered by addition of new APIs in https://github.com/microsoft/onnxruntime/commit/f481b17a5b95d6197229cb6167d92ae9f9067170.

Add version update instructions for updating additional API structs.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix build on main.

Add info about other API structs to version update instructions.