### PR TITLE
Add documentation for compile API

### DIFF
--- a/docs/execution-providers/plugin-ep-packaging.md
+++ b/docs/execution-providers/plugin-ep-packaging.md
@@ -1,4 +1,19 @@
+---
+title: Plugin Execution Provider Packaging Guidance
+description: Packaging guidance for plugin EP packages
+parent: Execution Providers
+nav_order: 18
+redirect_from: /docs/reference/execution-providers/Plugin-EP-Packaging
+---
+
 # ONNX Runtime Plugin Execution Provider Packaging Guidance
+{: .no_toc }
+
+## Contents
+{: .no_toc }
+
+* TOC placeholder
+{:toc}
 
 ## Overview
 


### PR DESCRIPTION
### Description
Preview: https://adrianlizarraga.github.io/onnxruntime/docs/execution-providers/EP-Context-Design.html#compile-api

Adds documentation for the ORT compile API.  Includes the following examples:
- Compiling to an output stream with custom function that allows an application to specify where each initializer is stored.
- Cross-compiling with plugin EPs
- EPContext weight sharing with plugin EPs



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


