### PR TITLE
POWER : Fix build failure due to unsupported cpuinfo on ppc64le

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -1520,8 +1520,13 @@ endif()
                               onnxruntime_common ${CMAKE_DL_LIBS})
         set_target_properties(onnxruntime_runtime_path_test_shared_library PROPERTIES AIX_SHARED_LIBRARY_ARCHIVE OFF)
       else()
-        target_link_libraries(onnxruntime_runtime_path_test_shared_library PRIVATE
-                              onnxruntime_common cpuinfo ${CMAKE_DL_LIBS})
+        if (CPUINFO_SUPPORTED)
+          target_link_libraries(onnxruntime_runtime_path_test_shared_library PRIVATE
+                                onnxruntime_common cpuinfo ${CMAKE_DL_LIBS})
+        else()
+          target_link_libraries(onnxruntime_runtime_path_test_shared_library PRIVATE
+                                onnxruntime_common ${CMAKE_DL_LIBS})
+        endif()
       endif()
       target_include_directories(onnxruntime_runtime_path_test_shared_library PRIVATE ${ONNXRUNTIME_ROOT})
 


### PR DESCRIPTION
Description
Conditionally disable linking of cpuinfo for
onnxruntime_runtime_path_test_shared_library on targets, where cpuinfo is not supported.

Motivation and Context
Recent changes enabling onnxruntime_autoep_test and related shared library tests on non-Windows platforms exposed a transitive dependency issue. cpuinfo was being linked unconditionally on Linux, leading to linker failures on ppc64le (cannot find -lcpuinfo).

Solution
Add CPUINFO_SUPPORTED guards to exclude cpuinfo from the link list while preserving existing behavior.


