### PR TITLE
perftest: support plugin eps for compile_ep_context

### DIFF
--- a/onnxruntime/test/perftest/command_args_parser.cc
+++ b/onnxruntime/test/perftest/command_args_parser.cc
@@ -203,6 +203,7 @@ ABSL_FLAG(std::string, filter_ep_devices, "",
 ABSL_FLAG(bool, compile_ep_context, DefaultPerformanceTestConfig().run_config.compile_ep_context, "Generate an EP context model");
 ABSL_FLAG(std::string, compile_model_path, "model_ctx.onnx", "The compiled model path for saving EP context model. Overwrites if already exists");
 ABSL_FLAG(bool, compile_binary_embed, DefaultPerformanceTestConfig().run_config.compile_binary_embed, "Embed binary blob within EP context node");
+ABSL_FLAG(bool, compile_only, DefaultPerformanceTestConfig().run_config.compile_only, "Only compile EP context model without running it");
 ABSL_FLAG(bool, h, false, "Print program usage.");
 
 namespace onnxruntime {
@@ -582,6 +583,9 @@ bool CommandLineParser::ParseArguments(PerformanceTestConfig& test_config, int a
 
   // --compile_binary_embed
   test_config.run_config.compile_binary_embed = absl::GetFlag(FLAGS_compile_binary_embed);
+
+  // --compile_only
+  test_config.run_config.compile_only = absl::GetFlag(FLAGS_compile_only);
 
   if (positional.size() == 2) {
     test_config.model_info.model_file_path = ToPathString(positional[1]);

--- a/onnxruntime/test/perftest/common_utils.cc
+++ b/onnxruntime/test/perftest/common_utils.cc
@@ -90,6 +90,116 @@ std::vector<char*> CStringsFromStrings(std::vector<std::string>& utf8_args) {
   return utf8_argv;
 }
 
+void AppendPluginExecutionProviders(Ort::Env& env,
+                                    Ort::SessionOptions& session_options,
+                                    const PerformanceTestConfig& test_config) {
+  if (test_config.registered_plugin_eps.empty()) {
+    return;
+  }
+
+  std::vector<Ort::ConstEpDevice> ep_devices = env.GetEpDevices();
+  // EP -> associated EP devices (All OrtEpDevice instances must be from the same execution provider)
+  std::unordered_map<std::string, std::vector<Ort::ConstEpDevice>> added_ep_devices;
+  std::unordered_set<int> added_ep_device_index_set;
+
+  auto& ep_list = test_config.machine_config.plugin_provider_type_list;
+  std::unordered_set<std::string> ep_set(ep_list.begin(), ep_list.end());
+
+  // Select EP devices by provided device index
+  if (!test_config.selected_ep_device_indices.empty()) {
+    std::vector<int> device_list;
+    device_list.reserve(test_config.selected_ep_device_indices.size());
+    ParseEpDeviceIndexList(test_config.selected_ep_device_indices, device_list);
+    for (auto index : device_list) {
+      if (static_cast<size_t>(index) > (ep_devices.size() - 1)) {
+        fprintf(stderr, "%s", "The device index provided is not correct. Will skip this device id.");
+        continue;
+      }
+
+      Ort::ConstEpDevice& device = ep_devices[index];
+      if (ep_set.find(std::string(device.EpName())) != ep_set.end()) {
+        if (added_ep_device_index_set.find(index) == added_ep_device_index_set.end()) {
+          added_ep_devices[device.EpName()].push_back(device);
+          added_ep_device_index_set.insert(index);
+          fprintf(stdout, "[Plugin EP] EP Device [Index: %d, Name: %s, Type: %d] has been added to session.\n", static_cast<int>(index), device.EpName(), device.Device().Type());
+        }
+      } else {
+        std::string err_msg = "[Plugin EP] [WARNING] : The EP device index and its corresponding OrtEpDevice is not created from " +
+                              test_config.machine_config.provider_type_name + ". Will skip adding this device.\n";
+        fprintf(stderr, "%s", err_msg.c_str());
+      }
+    }
+  } else if (!test_config.filter_ep_device_kv_pairs.empty()) {
+    // Find and select the OrtEpDevice associated with the EP in "--filter_ep_devices".
+    for (const auto& kv : test_config.filter_ep_device_kv_pairs) {
+      for (size_t index = 0; index < ep_devices.size(); ++index) {
+        auto device = ep_devices[index];
+        if (ep_set.find(std::string(device.EpName())) == ep_set.end())
+          continue;
+
+        // Skip if deviceid was already added
+        if (added_ep_devices.find(device.EpName()) != added_ep_devices.end() &&
+            std::find(added_ep_devices[device.EpName()].begin(), added_ep_devices[device.EpName()].end(), device) != added_ep_devices[device.EpName()].end())
+          continue;
+
+        // Check both EP metadata and device metadata for a match
+        auto ep_metadata_kv_pairs = device.EpMetadata().GetKeyValuePairs();
+        auto device_metadata_kv_pairs = device.Device().Metadata().GetKeyValuePairs();
+        auto ep_metadata_itr = ep_metadata_kv_pairs.find(kv.first);
+        auto device_metadata_itr = device_metadata_kv_pairs.find(kv.first);
+
+        if ((ep_metadata_itr != ep_metadata_kv_pairs.end() && kv.second == ep_metadata_itr->second) ||
+            (device_metadata_itr != device_metadata_kv_pairs.end() && kv.second == device_metadata_itr->second)) {
+          added_ep_devices[device.EpName()].push_back(device);
+          fprintf(stdout, "[Plugin EP] EP Device [Index: %d, Name: %s, Type: %d] has been added to session.\n", static_cast<int>(index), device.EpName(), device.Device().Type());
+          break;
+        }
+      }
+    }
+  } else {
+    // Find and select the OrtEpDevice associated with the EP in "--plugin_eps".
+    for (size_t index = 0; index < ep_devices.size(); ++index) {
+      Ort::ConstEpDevice& device = ep_devices[index];
+      if (ep_set.find(std::string(device.EpName())) != ep_set.end()) {
+        added_ep_devices[device.EpName()].push_back(device);
+        fprintf(stdout, "[Plugin EP] EP Device [Index: %d, Name: %s] has been added to session.\n", static_cast<int>(index), device.EpName());
+      }
+    }
+  }
+
+  if (added_ep_devices.empty()) {
+    ORT_THROW("[ERROR] [Plugin EP]: No matching EP devices found.");
+  }
+
+  std::string ep_option_string = ToUTF8String(test_config.run_config.ep_runtime_config_string);
+
+  // EP's associated provider option lists
+  std::vector<std::unordered_map<std::string, std::string>> ep_options_list;
+  ParseEpOptions(ep_option_string, ep_options_list);
+
+  // If user only provide the EPs' provider option lists for the first several EPs,
+  // add empty provider option lists for the rest EPs.
+  if (ep_options_list.size() < ep_list.size()) {
+    for (size_t i = ep_options_list.size(); i < ep_list.size(); ++i) {
+      ep_options_list.emplace_back();  // Adds a new empty map
+    }
+  } else if (ep_options_list.size() > ep_list.size()) {
+    ORT_THROW("[ERROR] [Plugin EP]: Too many EP provider option lists provided.");
+  }
+
+  // EP -> associated provider options
+  std::unordered_map<std::string, std::unordered_map<std::string, std::string>> ep_options_map;
+  for (size_t i = 0; i < ep_list.size(); ++i) {
+    ep_options_map.emplace(ep_list[i], ep_options_list[i]);
+  }
+
+  for (auto& ep_and_devices : added_ep_devices) {
+    auto& ep = ep_and_devices.first;
+    auto& devices = ep_and_devices.second;
+    session_options.AppendExecutionProvider_V2(env, devices, ep_options_map[ep]);
+  }
+}
+
 }  // namespace utils
 }  // namespace perftest
 }  // namespace onnxruntime

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -21,6 +21,7 @@
 #include "providers.h"
 #include "TestCase.h"
 #include "strings_helper.h"
+#include "utils.h"
 
 #ifdef USE_OPENVINO
 #include "nlohmann/json.hpp"
@@ -90,107 +91,7 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
 
   // Add EP devices if any (created by plugin EP)
   if (!performance_test_config.registered_plugin_eps.empty()) {
-    std::vector<Ort::ConstEpDevice> ep_devices = env.GetEpDevices();
-    // EP -> associated EP devices (All OrtEpDevice instances must be from the same execution provider)
-    std::unordered_map<std::string, std::vector<Ort::ConstEpDevice>> added_ep_devices;
-    std::unordered_set<int> added_ep_device_index_set;
-
-    auto& ep_list = performance_test_config.machine_config.plugin_provider_type_list;
-    std::unordered_set<std::string> ep_set(ep_list.begin(), ep_list.end());
-
-    // Select EP devices by provided device index
-    if (!performance_test_config.selected_ep_device_indices.empty()) {
-      std::vector<int> device_list;
-      device_list.reserve(performance_test_config.selected_ep_device_indices.size());
-      ParseEpDeviceIndexList(performance_test_config.selected_ep_device_indices, device_list);
-      for (auto index : device_list) {
-        if (static_cast<size_t>(index) > (ep_devices.size() - 1)) {
-          fprintf(stderr, "%s", "The device index provided is not correct. Will skip this device id.");
-          continue;
-        }
-
-        Ort::ConstEpDevice& device = ep_devices[index];
-        if (ep_set.find(std::string(device.EpName())) != ep_set.end()) {
-          if (added_ep_device_index_set.find(index) == added_ep_device_index_set.end()) {
-            added_ep_devices[device.EpName()].push_back(device);
-            added_ep_device_index_set.insert(index);
-            fprintf(stdout, "[Plugin EP] EP Device [Index: %d, Name: %s, Type: %d] has been added to session.\n", static_cast<int>(index), device.EpName(), device.Device().Type());
-          }
-        } else {
-          std::string err_msg = "[Plugin EP] [WARNING] : The EP device index and its corresponding OrtEpDevice is not created from " +
-                                performance_test_config.machine_config.provider_type_name + ". Will skip adding this device.\n";
-          fprintf(stderr, "%s", err_msg.c_str());
-        }
-      }
-    } else if (!performance_test_config.filter_ep_device_kv_pairs.empty()) {
-      // Find and select the OrtEpDevice associated with the EP in "--filter_ep_devices".
-      for (const auto& kv : performance_test_config.filter_ep_device_kv_pairs) {
-        for (size_t index = 0; index < ep_devices.size(); ++index) {
-          auto device = ep_devices[index];
-          if (ep_set.find(std::string(device.EpName())) == ep_set.end())
-            continue;
-
-          // Skip if deviced was already added
-          if (added_ep_devices.find(device.EpName()) != added_ep_devices.end() &&
-              std::find(added_ep_devices[device.EpName()].begin(), added_ep_devices[device.EpName()].end(), device) != added_ep_devices[device.EpName()].end())
-            continue;
-
-          // Check both EP metadata and device metadata for a match
-          auto ep_metadata_kv_pairs = device.EpMetadata().GetKeyValuePairs();
-          auto device_metadata_kv_pairs = device.Device().Metadata().GetKeyValuePairs();
-          auto ep_metadata_itr = ep_metadata_kv_pairs.find(kv.first);
-          auto device_metadata_itr = device_metadata_kv_pairs.find(kv.first);
-
-          if ((ep_metadata_itr != ep_metadata_kv_pairs.end() && kv.second == ep_metadata_itr->second) ||
-              (device_metadata_itr != device_metadata_kv_pairs.end() && kv.second == device_metadata_itr->second)) {
-            added_ep_devices[device.EpName()].push_back(device);
-            fprintf(stdout, "[Plugin EP] EP Device [Index: %d, Name: %s, Type: %d] has been added to session.\n", static_cast<int>(index), device.EpName(), device.Device().Type());
-            break;
-          }
-        }
-      }
-    } else {
-      // Find and select the OrtEpDevice associated with the EP in "--plugin_eps".
-      for (size_t index = 0; index < ep_devices.size(); ++index) {
-        Ort::ConstEpDevice& device = ep_devices[index];
-        if (ep_set.find(std::string(device.EpName())) != ep_set.end()) {
-          added_ep_devices[device.EpName()].push_back(device);
-          fprintf(stdout, "EP Device [Index: %d, Name: %s] has been added to session.\n", static_cast<int>(index), device.EpName());
-        }
-      }
-    }
-
-    if (added_ep_devices.empty()) {
-      ORT_THROW("[ERROR] [Plugin EP]: No matching EP devices found.");
-    }
-
-    std::string ep_option_string = ToUTF8String(performance_test_config.run_config.ep_runtime_config_string);
-
-    // EP's associated provider option lists
-    std::vector<std::unordered_map<std::string, std::string>> ep_options_list;
-    ParseEpOptions(ep_option_string, ep_options_list);
-
-    // If user only provide the EPs' provider option lists for the first several EPs,
-    // add empty provider option lists for the rest EPs.
-    if (ep_options_list.size() < ep_list.size()) {
-      for (size_t i = ep_options_list.size(); i < ep_list.size(); ++i) {
-        ep_options_list.emplace_back();  // Adds a new empty map
-      }
-    } else if (ep_options_list.size() > ep_list.size()) {
-      ORT_THROW("[ERROR] [Plugin EP]: Too many EP provider option lists provided.");
-    }
-
-    // EP -> associated provider options
-    std::unordered_map<std::string, std::unordered_map<std::string, std::string>> ep_options_map;
-    for (size_t i = 0; i < ep_list.size(); ++i) {
-      ep_options_map.emplace(ep_list[i], ep_options_list[i]);
-    }
-
-    for (auto& ep_and_devices : added_ep_devices) {
-      auto& ep = ep_and_devices.first;
-      auto& devices = ep_and_devices.second;
-      session_options.AppendExecutionProvider_V2(env, devices, ep_options_map[ep]);
-    }
+    perftest::utils::AppendPluginExecutionProviders(env, session_options, performance_test_config);
   }
 
   provider_name_ = performance_test_config.machine_config.provider_type_name;

--- a/onnxruntime/test/perftest/test_configuration.h
+++ b/onnxruntime/test/perftest/test_configuration.h
@@ -77,6 +77,7 @@ struct RunConfig {
   bool compile_ep_context{false};
   std::basic_string<ORTCHAR_T> compile_model_path;
   bool compile_binary_embed{false};
+  bool compile_only{false};
   struct CudaMempoolArenaConfig {
     std::string release_threshold;
     std::string bytes_to_keep;

--- a/onnxruntime/test/perftest/utils.h
+++ b/onnxruntime/test/perftest/utils.h
@@ -33,6 +33,10 @@ void UnregisterExecutionProviderLibrary(Ort::Env& env, PerformanceTestConfig& te
 
 void ListEpDevices(const Ort::Env& env);
 
+void AppendPluginExecutionProviders(Ort::Env& env,
+                                    Ort::SessionOptions& session_options,
+                                    const PerformanceTestConfig& test_config);
+
 }  // namespace utils
 }  // namespace perftest
 }  // namespace onnxruntime


### PR DESCRIPTION
* Extend compile_ep_context to also support plugin eps
* Adds compile_only option to skip execution, can be used when compiling for virtual devices

compile_ep_context (physical device)
<img width="1259" height="510" alt="image" src="https://github.com/user-attachments/assets/14650c17-0c8a-4002-a7ce-e8e4c815a516" />

compile_ep_context + compile_only (virtual device)
<img width="1262" height="173" alt="image" src="https://github.com/user-attachments/assets/2f0844cc-5e83-4b2d-bf0a-0d815d9bad29" />
