### PR TITLE
Apply absl cuda warning patch to othe OS

### DIFF
--- a/cmake/external/abseil-cpp.cmake
+++ b/cmake/external/abseil-cpp.cmake
@@ -27,6 +27,8 @@ if(Patch_FOUND)
   else()
     set(ABSL_PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/abseil/absl_cuda_warnings.patch)
   endif()
+else()
+  set(ABSL_PATCH_COMMAND "")
 endif()
 
 # NB! Advancing Abseil version changes its internal namespace,


### PR DESCRIPTION
Fix #27125 

It does fix the build issue on Linux, but I am not entirely sure whether this is the optimal fix.