### PR TITLE
[MIGraphX EP][Documentation] ROCm 7.2 Release updates to MIGraphX EP

### DIFF
--- a/docs/execution-providers/MIGraphX-ExecutionProvider.md
+++ b/docs/execution-providers/MIGraphX-ExecutionProvider.md
@@ -39,6 +39,7 @@ All links can be found on AMD's [repo.radeon manylinux page](https://repo.radeon
 
 |ONNX Runtime Version|MIGraphX ROCm Release| Python 3.8 | Python 3.9 | Python 3.10 | Python 3.12 |
 |---|---|---|---|---|---|
+|1.23.2|7.2||| [3.10](https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/onnxruntime_migraphx-1.23.2-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl) | [3.12](https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/onnxruntime_migraphx-1.23.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl) |
 |1.23.1|7.1.1||| [3.10](https://repo.radeon.com/rocm/manylinux/rocm-rel-7.1.1/onnxruntime_migraphx-1.23.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl) | [3.12](https://repo.radeon.com/rocm/manylinux/rocm-rel-7.1.1/onnxruntime_migraphx-1.23.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl) |
 |1.23.1|7.1||| [3.10](https://repo.radeon.com/rocm/manylinux/rocm-rel-7.1/onnxruntime_migraphx-1.23.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl) | [3.12](https://repo.radeon.com/rocm/manylinux/rocm-rel-7.1/onnxruntime_migraphx-1.23.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl) |
 |1.22.1|7.0||| [3.10](https://repo.radeon.com/rocm/manylinux/rocm-rel-7.0/onnxruntime_rocm-1.22.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl) | [3.12](https://repo.radeon.com/rocm/manylinux/rocm-rel-7.0/onnxruntime_rocm-1.22.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl) |
@@ -110,7 +111,9 @@ Items are added as a python dictionary when invoking the MIGraphX execution prov
 |---|---|---|
 | device_id | INT | Select the device ID specified for the session run (default will be device 0) | 
 | migraphx_fp16_enable | 1 or 0 | Enable FP16 quantization mode via the MIGraphX API of the input model. |
+| migraphx_bf16_enable | 1 or 0 | Enable bf16 quantization mode via the MIGraphX API of the input model. |
 | migraphx_int8_enable | 1 or 0 | Enable int8 static quantization mode of the input model via the MIGraphX API. Requires calibration table path vars to be set (migraphx_int8_calibration_table_name=valid path).|
+| migraphx_fp8_enable  | 1 or 0 | Enable fp8 static quantization mode of the input model via the MIGraphX API. Requires calibration table path vars to be set (migraphx_int8_calibration_table_name=valid path).|
 | migraphx_int8_calibration_table_name | <absolute path to calibration table> | Path to a set of input calibration data for int8 static model quantization. |
 | migraphx_int8_use_native_calibration_table | 1 or 0 | Use a calibration table from Nvidia native int8 format or json dumped format. |
 | migraphx_exhaustive_tune | 1 or 0 (default 0) | Enable exhaustive tuning of parameters as part of compilation via the MIGraphX API. Adds additional compile time for a potential perf boost.|
@@ -118,6 +121,7 @@ Items are added as a python dictionary when invoking the MIGraphX execution prov
 | migraphx_external_alloc | Address | Address of external memory allocator function used for this EP. Useful for reading in larger models weights. |
 | migraphx_external_free | Address  | Address of external memory deallocator function used for this EP. Useful for unloadng what was allocated with the migraphx_external_alloc input. |
 | migraphx_external_empty_cache | Address  | Address of external memory cache used for this model. Useful for caching results of externally allocated models. |
+
 |             |                 |             |
 | Depricated  | Release Removed | Description |
 | migraphx_save_compiled_model | ROCm 6.4 | Enable saving a model as an MIGraphX (.mxr) format after compile when set to 1 |
@@ -149,12 +153,14 @@ Users can invoke Environment and Session variables in the same run but Environme
 |---|---|---|
 | ORT_MIGRAPHX_DUMP_MODEL_OPS | 1 or 0 | Enable dumping of model operators during parsing. | 
 | ORT_MIGRAPHX_FP16_ENABLE | 1 or 0 | Enable FP16 quantization mode via the MIGraphX API of the input model. |
+| ORT_MIGRAPHX_BF16_ENABLE | 1 or 0 | Enable BF16 quantization mode via the MIGraphX API of the input model. |
 | ORT_MIGRAPHX_INT8_ENABLE | 1 or 0 | Enable int8 static quantization mode of the input model via the MIGraphX API.\n Requires calibration table path vars to be set (migraphx_int8_calibration_table_name=<valid path>).|
+| ORT_MIGRAPHX_FP8_ENABLE  | 1 or 0 | Enable fp8 static quantization mode of the input model via the MIGraphX API.\n Requires calibration table path vars to be set (reuses migraphx_int8_calibration_table_name=<valid path>).|
 | ORT_MIGRAPHX_INT8_CALIBRATION_TABLE_NAME | <absolute path to calibration table> | Path to a set of input calibration data for int8 static model quantization. |
 | ORT_MIGRAPHX_INT8_USE_NATIVE_CALIBRATION_TABLE | 1 or 0 | Use a calibration table from Nvidia native int8 format or json dumped format. |
 | ORT_MIGRAPHX_EXHAUSTIVE_TUNE | 1 or 0 (default 0) | Enable exhaustive tuning of parameters as part of compilation via the MIGraphX API. Adds additional compile time for a potential perf boost. |
-| ORT_MIGRAPHX_MODEL_CACHE_PATH | <string> | Path to read and write model specific data such as weights or other model specific data |
-| ORT_MIGRAPHX_MODEL_PATH | <string> | Path to read and write .mxr path occurs after MIGraphX model compile complete |
+| ORT_MIGRAPHX_CACHE_PATH | <string> | Path to read and write model specific data such as weights or other model specific data |
+| ORT_MIGRAPHX_MODEL_CACHE_PATH | <string> | Path to read and write .mxr path occurs after MIGraphX model compile complete |
 |             |                      |             |
 | Depricated  | ROCm Version removed | Description |
 | ORT_MIGRAPHX_SAVE_COMPILED_MODEL | ROCm 6.4 | Enable saving a model as an MIGraphX (.mxr) format after compile. ( 0 or 1) |


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Update documentation to include changes for ROCm 7.2 release for MIGraphX Execution Provider

- Added bf16 env and session option flags
- Added fp8 env and session option flags 
- Add /correct flipped ENV flags for ORT_MIGRPAHX_MODEL_CACHE_PATH and ORT_MIGRAPHX_CACHE_PATH vars


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


