### PR TITLE
[QNN-EP] Fix ScatterElements UT failures by aligning input encodings

### DIFF
--- a/onnxruntime/test/providers/qnn/qnn_test_utils.h
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.h
@@ -315,6 +315,22 @@ inline QuantParams<QType> GetTestInputQuantParams(const TestInputDef<float>& inp
 }
 
 template <typename QType>
+inline QuantParams<QType> GetTestInputsQuantParams(const std::vector<TestInputDef<float>>& input_defs,
+                                                   bool symmetric = false) {
+  std::pair<float, float> frange = {std::numeric_limits<float>::max(), std::numeric_limits<float>::lowest()};
+
+  // Compute range across all input_defs
+  for (const auto& input_def : input_defs) {
+    const auto input_range = input_def.GetRange();
+    frange.first = std::min(frange.first, input_range.first);
+    frange.second = std::max(frange.second, input_range.second);
+  }
+
+  // Compute QuantParams using combined range
+  return QuantParams<QType>::Compute(frange.first, frange.second, symmetric);
+}
+
+template <typename QType>
 static void GetTestInputQuantParamsPerChannel(const TestInputDef<float>& input_def, std::vector<float>& scales,
                                               std::vector<QType>& zero_points, size_t axis, bool symmetric = false) {
   const auto f32_ranges = input_def.GetRangePerChannel(axis);
@@ -1242,17 +1258,24 @@ inline GetTestQDQModelFn<QuantType> BuildQDQOpTestCase(
     const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
     const std::string& op_domain = kOnnxDomain,
     bool use_contrib_qdq = false,
-    AllocatorPtr input_allocator = nullptr) {
+    AllocatorPtr input_allocator = nullptr,
+    bool combine_quant_inputs_qparams = false) {
   return [op_type, quant_input_defs, non_quant_input_defs, quant_input_defs_2, attrs, op_domain,
-          use_contrib_qdq, input_allocator](
+          use_contrib_qdq, input_allocator, combine_quant_inputs_qparams](
              ModelTestBuilder& builder, std::vector<QuantParams<QuantType>>& output_qparams) {
     std::vector<NodeArg*> op_inputs;
     op_inputs.reserve(quant_input_defs.size() + non_quant_input_defs.size() + quant_input_defs_2.size());
 
+    std::vector<TestInputDef<float>> combined_input_defs;
+    combined_input_defs.reserve(quant_input_defs.size() + quant_input_defs_2.size());
+    combined_input_defs.insert(combined_input_defs.end(), quant_input_defs.begin(), quant_input_defs.end());
+    combined_input_defs.insert(combined_input_defs.end(), quant_input_defs_2.begin(), quant_input_defs_2.end());
+    QuantParams<QuantType> combined_input_qparams = GetTestInputsQuantParams<QuantType>(combined_input_defs);
+
     // Create QDQ inputs
     for (const auto& input_def : quant_input_defs) {
       NodeArg* input = MakeTestInput<float>(builder, input_def, input_allocator);
-      QuantParams<QuantType> input_qparams = GetTestInputQuantParams<QuantType>(input_def);
+      QuantParams<QuantType> input_qparams = combine_quant_inputs_qparams ? combined_input_qparams : GetTestInputQuantParams<QuantType>(input_def);
       NodeArg* input_after_qdq = AddQDQNodePair<QuantType>(builder, input, input_qparams.scale,
                                                            input_qparams.zero_point, use_contrib_qdq);
       op_inputs.push_back(input_after_qdq);
@@ -1267,7 +1290,7 @@ inline GetTestQDQModelFn<QuantType> BuildQDQOpTestCase(
     // Create QDQ inputs
     for (const auto& input_def : quant_input_defs_2) {
       NodeArg* input = MakeTestInput<float>(builder, input_def, input_allocator);
-      QuantParams<QuantType> input_qparams = GetTestInputQuantParams<QuantType>(input_def);
+      QuantParams<QuantType> input_qparams = combine_quant_inputs_qparams ? combined_input_qparams : GetTestInputQuantParams<QuantType>(input_def);
       NodeArg* input_after_qdq = AddQDQNodePair<QuantType>(builder, input, input_qparams.scale,
                                                            input_qparams.zero_point, use_contrib_qdq);
       op_inputs.push_back(input_after_qdq);

--- a/onnxruntime/test/providers/qnn/simple_op_htp_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_htp_test.cc
@@ -173,14 +173,15 @@ static void RunQDQOpTest(const std::string& op_type,
                          ExpectedEPNodeAssignment expected_ep_assignment,
                          const std::string& op_domain = kOnnxDomain,
                          bool use_contrib_qdq = false,
-                         QDQTolerance tolerance = QDQTolerance()) {
+                         QDQTolerance tolerance = QDQTolerance(),
+                         bool combine_quant_inputs_qparams = false) {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
 
   TestQDQModelAccuracy(BuildOpTestCase<float, InputType2>(op_type, input_defs_1, input_defs_2, input_defs_3, attrs, op_domain),
                        BuildQDQOpTestCase<InputQType, InputType2>(op_type, input_defs_1, input_defs_2, input_defs_3, attrs,
-                                                                  op_domain, use_contrib_qdq),
+                                                                  op_domain, use_contrib_qdq, nullptr, combine_quant_inputs_qparams),
                        provider_options,
                        opset_version,
                        expected_ep_assignment,
@@ -1314,8 +1315,9 @@ TEST_F(QnnHTPBackendTests, ScatterElements_Float_Reduction_None) {
 }
 
 // Test ScatterElements with default attributes on HTP
-// Disable this due to an accuracy issue with selected data range
-TEST_F(QnnHTPBackendTests, DISABLED_ScatterElements_Int8_Reduction_None) {
+// HTP implicitly expects that data and updates tensors share the same encoding,
+// Therefore, we need to combine their quantization parameters.
+TEST_F(QnnHTPBackendTests, ScatterElements_Int8_Reduction_None) {
   std::vector<float> data = {0.0f, 1.0f, 2.0f, 3.0f};
   std::vector<int64_t> indices = {1};
   std::vector<float> updates = {10.0f};
@@ -1331,12 +1333,17 @@ TEST_F(QnnHTPBackendTests, DISABLED_ScatterElements_Int8_Reduction_None) {
                                  },
                                  {},
                                  17,
-                                 ExpectedEPNodeAssignment::All);
+                                 ExpectedEPNodeAssignment::All,
+                                 kOnnxDomain,
+                                 false,
+                                 QDQTolerance(),
+                                 true);
 }
 
 // Test ScatterElements with reduction ADD on HTP
-// Disable this due to an accuracy issue with selected data range
-TEST_F(QnnHTPBackendTests, DISABLED_ScatterElements_Int8_Reduction_Add) {
+// HTP implicitly expects that data and updates tensors share the same encoding,
+// Therefore, we need to combine their quantization parameters.
+TEST_F(QnnHTPBackendTests, ScatterElements_Int8_Reduction_Add) {
   std::vector<float> data = {0.0f, 1.0f, 2.0f, 3.0f};
   std::vector<int64_t> indices = {1};
   std::vector<float> updates = {10.0f};
@@ -1354,10 +1361,16 @@ TEST_F(QnnHTPBackendTests, DISABLED_ScatterElements_Int8_Reduction_Add) {
                                      utils::MakeAttribute("reduction", "add"),
                                  },
                                  17,
-                                 ExpectedEPNodeAssignment::All);
+                                 ExpectedEPNodeAssignment::All,
+                                 kOnnxDomain,
+                                 false,
+                                 QDQTolerance(),
+                                 true);
 }
 
 // Test ScatterElements with reduction Max on HTP
+// HTP implicitly expects that data and updates tensors share the same encoding,
+// Therefore, we need to combine their quantization parameters.
 TEST_F(QnnHTPBackendTests, ScatterElements_Int8_Reduction_Max) {
   std::vector<float> data = {0.0f, 1.0f, 2.0f, 3.0f};
   std::vector<int64_t> indices = {1};
@@ -1376,10 +1389,16 @@ TEST_F(QnnHTPBackendTests, ScatterElements_Int8_Reduction_Max) {
                                      utils::MakeAttribute("reduction", "max"),
                                  },
                                  17,
-                                 ExpectedEPNodeAssignment::All);
+                                 ExpectedEPNodeAssignment::All,
+                                 kOnnxDomain,
+                                 false,
+                                 QDQTolerance(),
+                                 true);
 }
 
 // Test ScatterElements with reduction Mul on HTP
+// HTP implicitly expects that data and updates tensors share the same encoding,
+// Therefore, we need to combine their quantization parameters.
 TEST_F(QnnHTPBackendTests, ScatterElements_int8_reduction_mul) {
   std::vector<float> data = {0.0f, 1.0f, 2.0f, 3.0f};
   std::vector<int64_t> indices = {1};
@@ -1398,7 +1417,11 @@ TEST_F(QnnHTPBackendTests, ScatterElements_int8_reduction_mul) {
                                      utils::MakeAttribute("reduction", "mul"),
                                  },
                                  17,
-                                 ExpectedEPNodeAssignment::All);
+                                 ExpectedEPNodeAssignment::All,
+                                 kOnnxDomain,
+                                 false,
+                                 QDQTolerance(),
+                                 true);
 }
 
 // Test 8-bit QDQ GridSample with bilinear


### PR DESCRIPTION
### Description
Fix ScatterElements unit test failures by aligning input encodings. Aggregated min/max values of both inputs (data and updates) when calculating encodings and re-enabled the previously disabled unit test.



### Motivation and Context
QNN HTP assumes that ScatterElements inputs share the same encoding. The previous UT implementation did not consider this implicit assumption, leading to failures. Combining min/max values ensures consistent encoding and resolves the issue.


