### PR TITLE
[WebGPU EP] Reduce duplicated code in `MatMulReadFnSource()`

### DIFF
--- a/onnxruntime/core/providers/webgpu/math/gemm_utils.cc
+++ b/onnxruntime/core/providers/webgpu/math/gemm_utils.cc
@@ -129,8 +129,8 @@ void MatMulReadFnSource(ShaderHelper& shader,
                         const ShaderIndicesHelper* batch_dims,
                         std::string_view rows,
                         std::string_view components_per_row,
-                        bool transpose,
-                        int components) {
+                        bool transpose) {
+  const int components = input.NumComponents();
   const std::string data_type = "output_element_t";
   const std::string type_string = MakeScalarOrVectorType(components, data_type);
 
@@ -168,11 +168,9 @@ void MatMulReadFnSource(ShaderHelper& shader,
                         const ShaderVariableHelper& b,
                         const ShaderIndicesHelper* batch_dims,
                         bool transA,
-                        bool transB,
-                        bool is_vec4) {
-  const int components = is_vec4 ? 4 : 1;
-  MatMulReadFnSource(shader, "mm_readA", a, "a", batch_dims, "uniforms.dim_a_outer", "uniforms.dim_inner", transA, components);
-  MatMulReadFnSource(shader, "mm_readB", b, "b", batch_dims, "uniforms.dim_inner", "uniforms.dim_b_outer", transB, components);
+                        bool transB) {
+  MatMulReadFnSource(shader, "mm_readA", a, "a", batch_dims, "uniforms.dim_a_outer", "uniforms.dim_inner", transA);
+  MatMulReadFnSource(shader, "mm_readB", b, "b", batch_dims, "uniforms.dim_inner", "uniforms.dim_b_outer", transB);
 }
 
 void MatMulWriteFnSource(ShaderHelper& shader,


### PR DESCRIPTION
### Description
Previously in `MatMulReadFnSource()` we use duplicated code to read data from two inputs `a` and `b`. This patch implements another overload of `MatMulReadFnSource()` to only read data from one input to reduce duplicated code and get ready for further use.


