### PR TITLE
[MLAS] Fix Flaky LuT GEMM Tests by Replacing Gather with Shuffle

### DIFF
--- a/onnxruntime/core/mlas/lib/sqnbitgemm_lut_kernel_avx2.cpp
+++ b/onnxruntime/core/mlas/lib/sqnbitgemm_lut_kernel_avx2.cpp
@@ -188,7 +188,7 @@ get_bias_scale()
 }
 
 static inline void
-_mm256_loadu_deinterleave_32ps(const float* src, __m256& v0, __m256& v1, __m256& v2, __m256& v3)
+MlasAvx2LoaduDeinterleave32Ps(const float* src, __m256& v0, __m256& v1, __m256& v2, __m256& v3)
 {
     // Process 32 activations contiguously using loadu + shuffle.
     // This allows us to mix neighbors (src[4i], src[4i+1], src[4i+2], src[4i+3]) across lanes,
@@ -210,7 +210,7 @@ _mm256_loadu_deinterleave_32ps(const float* src, __m256& v0, __m256& v1, __m256&
     __m256 u2 = _mm256_castpd_ps(_mm256_unpacklo_pd(_mm256_castps_pd(t1), _mm256_castps_pd(t3)));
     __m256 u3 = _mm256_castpd_ps(_mm256_unpackhi_pd(_mm256_castps_pd(t1), _mm256_castps_pd(t3)));
 
-    static const __m256i perm_idx = _mm256_setr_epi32(0, 4, 1, 5, 2, 6, 3, 7);
+    const __m256i perm_idx = _mm256_setr_epi32(0, 4, 1, 5, 2, 6, 3, 7);
     v0 = _mm256_permutevar8x32_ps(u0, perm_idx);
     v1 = _mm256_permutevar8x32_ps(u1, perm_idx);
     v2 = _mm256_permutevar8x32_ps(u2, perm_idx);
@@ -221,7 +221,7 @@ void
 partial_max_g4_int8_k8(float* lut_scales, const float* b)
 {
     __m256 vec_b0, vec_b1, vec_b2, vec_b3;
-    _mm256_loadu_deinterleave_32ps(b, vec_b0, vec_b1, vec_b2, vec_b3);
+    MlasAvx2LoaduDeinterleave32Ps(b, vec_b0, vec_b1, vec_b2, vec_b3);
 
     const __m256 vec_sign = _mm256_set1_ps(-0.0f);
     __m256 vec_babs0 = _mm256_andnot_ps(vec_sign, vec_b0);
@@ -261,7 +261,7 @@ lut_ctor_g4_int8_impl(
     for (int k = 0; k < act_k / 32; ++k) {
         const float* b_chunk = b + k * 32;
         __m256 vec_b0, vec_b1, vec_b2, vec_b3;
-        _mm256_loadu_deinterleave_32ps(b_chunk, vec_b0, vec_b1, vec_b2, vec_b3);
+        MlasAvx2LoaduDeinterleave32Ps(b_chunk, vec_b0, vec_b1, vec_b2, vec_b3);
 
         PRAGMA_UNROLL
         for (int g = 1; g < 16; g += 2) {

--- a/onnxruntime/test/contrib_ops/matmul_2bits_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_2bits_test.cc
@@ -371,9 +371,9 @@ TEST(MatMulNBitsLutGemm, Float32_2Bits_Symmetric_256x256) {
   TestMatMul2BitsLutGemm<float>(1, 256, 256, 32, false);
 }
 
-// This test was previously disabled due to accuracy issues. It is now re-enabled
-// because the replacement of non-deterministic gather with deterministic load+shuffle
-// operations has resolved the stability and accuracy problems.
+// This test was previously disabled due to accuracy issues related to non-deterministic
+// gather operations. It is now re-enabled after replacing gather with deterministic
+// load+shuffle operations to improve determinism and stability.
 TEST(MatMulNBitsLutGemm, Float32_2Bits_Asymmetric_256x256) {
   TestMatMul2BitsLutGemm<float>(1, 256, 256, 32, true);
 }


### PR DESCRIPTION
## Problem Description
The `MatMulNBitsLutGemm` test suite, specifically `Float32_2Bits_Symmetric_256x256_BlkLen64`, was observing intermittent failures (flakiness).
The failure manifested as numerical mismatches exceeding the tolerance, suggesting non-deterministic behavior in the kernel execution.

## Root Cause Analysis
The issue was traced to the usage of `_mm256_i32gather_ps` in sqnbitgemm_lut_kernel_avx2.cpp
While the gather indices were technically calculating addresses within the bounds of the allocated buffer, gather instructions on certain AVX2 hardware implementations can exhibit non-deterministic behavior or subtle performance/prefetching artifacts when operating on specific stride patterns (in this case, gathering with a stride of 4 floats).

## Solution
This PR replaces the `_mm256_i32gather_ps` instruction with a sequence of **contiguous loads (`_mm256_loadu_ps`) followed by deterministic shuffles**.

### How it works:
1.  **Contiguous Load**: We load 4 contiguous vectors of 8 floats elements using `_mm256_loadu_ps`. This is always memory-safe and deterministic.
2.  **Deterministic Shuffle**: We apply a verified sequence of `unpack` and `permutevar8x32` instructions to rearrange these 32 linearly loaded elements into the exact same stride-4 layout that the gather instruction produced.

### Benefits:
*   **Stability**: Eliminates the hardware-dependent non-determinism of gather.
*   **Safety**: Usage of `loadu` guarantees we only touch memory within the explicit range of the 32 elements we intend to load.
*   **Correctness**: The shuffle logic was verified against the reference gather behavior using a C++ reproduction script to ensure bit-exact layout equivalence.

### Performance

Micro-benchmark on MatMulNBitsLutGemm (256x256, BlkLen=64).
Original (Gather): ~55.55 us
Fixed (Load+Shuffle): ~57.79 us
Delta: +2.24 us (~4% slower)

The slight performance regression is expected because replacing a single hardware gather instruction with a sequence of loadu, unpack, and permute instructions adds instruction count overhead. However, this is a necessary tradeoff to ensure deterministic behavior and memory safety across all AVX2 implementations.

## Verification
*   **Tests**: All 10 tests in `MatMulNBitsLutGemm` passed successfully (including the previously flaky `BlkLen64` case).

