### PR TITLE
Build onnxruntime with training, training_apis, tests and gcc-15

### DIFF
--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -610,10 +610,17 @@ endif()
 if(onnxruntime_ENABLE_TRAINING OR (onnxruntime_ENABLE_TRAINING_APIS AND onnxruntime_BUILD_UNIT_TESTS))
   # Once code under orttraining/orttraining/models dir is removed "onnxruntime_ENABLE_TRAINING" should be removed from
   # this conditional
+  if(Patch_FOUND)
+    set(ONNXRUNTIME_CXXOPTS_PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/cxxopts/gcc-15-compat.patch)
+  else()
+    set(ONNXRUNTIME_CXXOPTS_PATCH_COMMAND "")
+  endif()
+
   onnxruntime_fetchcontent_declare(
     cxxopts
     URL ${DEP_URL_cxxopts}
     URL_HASH SHA1=${DEP_SHA1_cxxopts}
+    PATCH_COMMAND ${ONNXRUNTIME_CXXOPTS_PATCH_COMMAND}
     EXCLUDE_FROM_ALL
     FIND_PACKAGE_ARGS NAMES cxxopts
   )

--- a/cmake/patches/cxxopts/gcc-15-compat.patch
+++ b/cmake/patches/cxxopts/gcc-15-compat.patch
@@ -1,0 +1,13 @@
+diff --git a/include/cxxopts.hpp b/include/cxxopts.hpp
+index 991ba3fc..a2e71faf 100644
+--- a/include/cxxopts.hpp
++++ b/include/cxxopts.hpp
+@@ -25,6 +25,7 @@
+ #ifndef CXXOPTS_HPP_INCLUDED
+ #define CXXOPTS_HPP_INCLUDED
+ 
++#include <cstdint>
+ #include <cstring>
+ #include <cctype>
+ #include <exception>
+


### PR DESCRIPTION
### Description
This change is needed to build onnxruntime with gcc-15 when training, training_apis and tests are enabled.


### Motivation and Context
When building onnxruntime on fedora 43, both s390x and x86, with following command line, build fails:
`./build.sh --config Debug --parallel 0 --enable_pybind --build_wheel --enable_training --enable_training_apis --enable_training_ops --allow_running_as_root --compile_no_warning_as_error`.

This change fixes build failure caused by cxxopts missing correct includes.