### PR TITLE
Fix API doc comment for OrtApi::RunOptionsEnableProfiling

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -7200,7 +7200,7 @@ struct OrtApi {
    *
    * \param[in] options
    * \param[in] profile_file_prefix The prefix for the profile file. The actual filename will be:
-   *                                <profile_file_prefix>_<timestamp>.json
+   *                                [profile_file_prefix]_[timestamp].json
    *
    * \snippet{doc} snippets.dox OrtStatus Return Value
    *


### PR DESCRIPTION
### Description
Fixes C++ documentation generation by replacing `<` and `>` with `[` and `]`. Angle brackets are mistaken as html tags.

Successful run: https://github.com/microsoft/onnxruntime/actions/runs/21456738258

### Motivation and Context
Allow C++ document generation to succeed.


