### PR TITLE
Early exit if external initializer files are missing when compiling

### DIFF
--- a/onnxruntime/core/framework/ep_context_utils.cc
+++ b/onnxruntime/core/framework/ep_context_utils.cc
@@ -3,9 +3,11 @@
 
 #if !defined(ORT_MINIMAL_BUILD)
 #include <limits>
+#include <filesystem>
 #include <utility>
 #include "core/framework/ep_context_utils.h"
 #include "core/framework/error_code_helper.h"
+#include "core/framework/tensorprotoutils.h"
 #include "core/graph/model_saving_options.h"
 
 namespace onnxruntime {
@@ -52,6 +54,49 @@ Status EpContextModelToProto(const onnxruntime::Model& ep_context_model,
 
   return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Unexpected location for initializers while generating ",
                          validated_model_path);
+}
+
+static Status GetMissingExternalInitializerFilesImpl(const onnxruntime::Graph& graph,
+                                                     const std::filesystem::path& model_dir,
+                                                     std::unordered_set<std::filesystem::path>& checked_files,
+                                                     std::unordered_set<std::filesystem::path>& invalid_files) {
+  for (const auto& node : graph.Nodes()) {
+    if (node.ContainsSubgraph()) {
+      for (const auto& subgraph : node.GetSubgraphs()) {
+        ORT_RETURN_IF_ERROR(GetMissingExternalInitializerFilesImpl(*subgraph, model_dir,
+                                                                   checked_files, invalid_files));
+      }
+    }
+  }
+
+  for (const auto& [initializer_name, initializer_proto] : graph.GetAllInitializedTensors()) {
+    if (utils::HasExternalDataInFile(*initializer_proto)) {
+      std::unique_ptr<ExternalDataInfo> external_data_info;
+      ORT_RETURN_IF_ERROR(ExternalDataInfo::Create(initializer_proto->external_data(), external_data_info));
+
+      std::filesystem::path initializer_file_path = model_dir / external_data_info->GetRelPath();
+
+      if (checked_files.find(initializer_file_path) != checked_files.end()) {
+        continue;  // Already checked this file
+      }
+
+      if (!std::filesystem::exists(initializer_file_path)) {
+        invalid_files.insert(initializer_file_path);
+      }
+
+      checked_files.insert(std::move(initializer_file_path));
+    }
+  }
+
+  return Status::OK();
+}
+
+Status GetMissingExternalInitializerFiles(const onnxruntime::Graph& graph,
+                                          std::unordered_set<std::filesystem::path>& invalid_files) {
+  std::unordered_set<std::filesystem::path> checked_files;
+  const std::filesystem::path model_dir = graph.GetModel().ModelPath().parent_path();
+
+  return GetMissingExternalInitializerFilesImpl(graph, model_dir, checked_files, invalid_files);
 }
 
 //

--- a/onnxruntime/core/framework/ep_context_utils.h
+++ b/onnxruntime/core/framework/ep_context_utils.h
@@ -7,6 +7,7 @@
 
 #include <filesystem>
 #include <streambuf>
+#include <unordered_set>
 #include <vector>
 
 #include "core/common/status.h"
@@ -29,6 +30,15 @@ Status EpContextModelToProto(const onnxruntime::Model& ep_context_model,
                              const std::filesystem::path& validated_model_path,
                              const epctx::ModelGenOptions& ep_context_gen_options,
                              /*out*/ ONNX_NAMESPACE::ModelProto& model_proto);
+
+/// <summary>
+/// Gets paths for external initializer files that do not exist.
+/// </summary>
+/// <param name="graph">The top-level graph</param>
+/// <param name="invalid_files">Resulting set of paths to missing initializer files, if any</param>
+/// <returns>A status indicating success or an error.</returns>
+Status GetMissingExternalInitializerFiles(const onnxruntime::Graph& graph,
+                                          std::unordered_set<std::filesystem::path>& invalid_files);
 
 // Class that wraps the user's OrtBufferWriteFunc function to enable use with
 // C++'s std::ostream.

--- a/onnxruntime/core/framework/graph_partitioner.cc
+++ b/onnxruntime/core/framework/graph_partitioner.cc
@@ -1310,13 +1310,28 @@ Status GraphPartitioner::Partition(Graph& graph, FuncManager& func_mgr,
   if (mode == Mode::kNormal || mode == Mode::kAssignOnly) {
 #if !defined(ORT_MINIMAL_BUILD)
     if (ep_context_gen_options.enable) {
+      // Checks before EP tries to compile graphs.
       if (const std::filesystem::path* output_model_path_ptr = ep_context_gen_options.TryGetOutputModelPath();
           output_model_path_ptr != nullptr) {
-        // Check before EP compile graphs
+        // Check output path is valid.
         std::filesystem::path context_cache_path;
         ORT_RETURN_IF_ERROR(GetValidatedEpContextPath(*output_model_path_ptr, graph.ModelPath(),
                                                       context_cache_path,
                                                       ep_context_gen_options.error_if_output_file_exists));
+      }
+
+      // Check that external initializer files exist.
+      // Note: Could be expensive for models that use many external initializer files.
+      // TODO: Should this be done in onnxruntime::Graph??
+      std::unordered_set<std::filesystem::path> invalid_ext_initializer_files;
+      ORT_RETURN_IF_ERROR(epctx::GetMissingExternalInitializerFiles(graph, invalid_ext_initializer_files));
+
+      if (!invalid_ext_initializer_files.empty()) {
+        std::ostringstream oss;
+        oss << "Invalid external initializer file path(s). First one is '"
+            << invalid_ext_initializer_files.begin()->string();
+
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, oss.str());
       }
     }
 


### PR DESCRIPTION
### Description
NOT READY.



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


