### PR TITLE
Fix WebGPU MoE swiglu_limit (default to infinity)

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/moe/moe.h
+++ b/onnxruntime/contrib_ops/webgpu/moe/moe.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <limits>
+
 #include "core/providers/webgpu/program.h"
 #include "core/providers/webgpu/webgpu_kernel.h"
 
@@ -31,7 +33,7 @@ class MoE : public WebGpuKernel {
     activation_alpha_ = static_cast<float>(info.GetAttrOrDefault<float>("activation_alpha", 1.0));
     activation_beta_ = static_cast<float>(info.GetAttrOrDefault<float>("activation_beta", 1.0));
     swiglu_fusion_ = static_cast<int>(info.GetAttrOrDefault<int64_t>("swiglu_fusion", 0));
-    swiglu_limit_ = info.GetAttrOrDefault<float>("swiglu_limit", 0);
+    swiglu_limit_ = info.GetAttrOrDefault<float>("swiglu_limit", std::numeric_limits<float>::infinity());
     k_ = static_cast<int>(info.GetAttrOrDefault<int64_t>("k", 4));
     normalize_routing_weights_ = info.GetAttrOrDefault<int64_t>("normalize_routing_weights", 0) == 1;
     use_sparse_mixer_ = info.GetAttrOrDefault<int64_t>("use_sparse_mixer", 0) == 1;


### PR DESCRIPTION

### Description

According to https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#commicrosoftmoe, 

> swiglu_limit : float
The limit used to clamp in SwiGLU. No clamp when limit is not provided.

However, currently, the default is set to 0, meaning we clamp to 0 if no limit is provided.


### Motivation and Context

Fixes #27220. See there for bug description and reproduction.

Hoping to get this in before 1.24.0 releases. cc @guschmue
