### PR TITLE
Fix regression in agents for Windows ARM64

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/py-win-arm64-qnn.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-win-arm64-qnn.yml
@@ -33,7 +33,8 @@ jobs:
     os: windows
     hostArchitecture: Arm64
     demands:
-      - Agent.Version -equals 4.264.2  templateContext:
+      - Agent.Version -equals 4.264.2
+  templateContext:
     sdl:
       codeSignValidation:
         enabled: true

--- a/tools/ci_build/github/azure-pipelines/win-qnn-arm64-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-qnn-arm64-ci-pipeline.yml
@@ -37,7 +37,10 @@ parameters:
 
 jobs:
 - job: 'BUILD_QNN_EP'
-  pool: 'onnxruntime-qnn-windows-vs-2022-arm64'
+  pool:
+    name: 'onnxruntime-qnn-windows-vs-2022-arm64'
+    demands:
+      - Agent.Version -equals 4.264.2
   variables:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     buildArch: arm64
@@ -83,7 +86,7 @@ jobs:
         --config $(BuildConfig)
         --build_dir $(Build.BinariesDirectory)
         --cmake_generator "Visual Studio 17 2022"
-        --build_shared_lib --use_vcpkg --use_vcpkg_ms_internal_asset_cache 
+        --build_shared_lib --use_vcpkg --use_vcpkg_ms_internal_asset_cache
         --use_qnn $(QnnLibKind)
         --qnn_home $(QnnSDKRootDir)
         --update --build --parallel $(ExtraQnnBuildArgs)


### PR DESCRIPTION
### Description
A recent push to the agent infrastructure broke python on Windows ARM64. This patch will unblock CICD until an infrastructure patch can get rolled out.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


