### PR TITLE
[OVEP] ORT 1.24 Release Patch

### DIFF
--- a/onnxruntime/core/providers/openvino/ov_shared_context.cc
+++ b/onnxruntime/core/providers/openvino/ov_shared_context.cc
@@ -10,9 +10,10 @@
 namespace onnxruntime {
 namespace openvino_ep {
 
-SharedContext::SharedContext(std::filesystem::path bin_path)
-    : bin_path_(std::move(bin_path)),
-      bin_manager_(bin_path_) {
+SharedContext::SharedContext(const std::filesystem::path& bin_path)
+    : bin_path_(bin_path),
+      bin_manager_(bin_path_),
+      weight_file_manager_(WeightFileManager::Get()) {
 }
 
 static bool InRange(size_t offset, size_t size, size_t total_size) {
@@ -74,7 +75,7 @@ void SharedContext::LoadTensorFromFile(
   const auto weights_location = model_dir / value.serialized.location;
   auto& weights_file = weight_files_[weights_location];
   if (!weights_file) {
-    weights_file = std::make_unique<WeightsFile>(weights_location);
+    weights_file = weight_file_manager_->GetOrCreateWeightsFile(weights_location);
   }
 
   ov::Tensor tensor;


### PR DESCRIPTION
### Description
Re-use weight files and their underlying memory maps across shared contexts.

### Motivation and Context
This reduces resident memory when different ep shared context sets reference the same weight file.
