### PR TITLE
Optimize for VSCode C++ extension file scan

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,23 @@
         "-build/include_subdir",
         "-runtime/references"
     ],
-    "C_Cpp.autoAddFileAssociations": false
+    "C_Cpp.autoAddFileAssociations": false,
+
+    // Exclude build directories and non-essential folders from C++ parsing
+    "C_Cpp.files.exclude": {
+        "**/build/**": true,
+        "**/build_*/**": true,
+        "**/cmake/external/**": true,
+        "**/node_modules/**": true,
+        "**/.git/**": true
+    },
+
+    // Exclude from search but keep in explorer
+    "search.exclude": {
+        "**/build/**": true,
+        "**/build_*/**": true,
+        "**/cmake/external/**": true,
+        "**/node_modules/**": true,
+        "**/.git/**": true
+    }
 }


### PR DESCRIPTION
### Description

Update the settings for VSCode C++ extension to reduce the file scanning. (potentially extend the life of the SSD on the devbox)

Added a few common folders into the exclusion list to help reduce the time of file scanning.


### Motivation and Context

By default the VSCode C++ extension will scan all folders in the workspace unless it's excluded. This will cause the default build folder being scanned, which contains 100k+ files and 20k+ C++ source files for a WebGPU build.


A simple analyze of my local workspace:
```
Folder                              Exists   Total Files  C++ Files    Top Extensions
----------------------------------------------------------------------------------------------------
build_webgpu                        Yes      255.4K       36.1K        .cpp:14084, .h:12229, .cc:6548, .c:2569, .hpp:257
build                               Yes      167.2K       26.3K        .h:11012, .cpp:8448, .cc:3899, .c:1689, .hpp:611
build_wasm_inferencing_webgpu       Yes      130.0K       17.8K        .cpp:6994, .h:6040, .cc:3183, .c:1285, .hpp:124
cmake                               Yes      27.9K        7.0K         .h:3561, .c:2601, .cpp:587, .cc:119, .inc:43
cmake/external                      Yes      27.8K        6.9K         .h:3557, .c:2600, .cpp:587, .cc:119, .inc:43
build_jsep                          Yes      17.8K        4.4K         .h:1618, .cpp:1515, .cc:1006, .c:127, .hpp:88
onnxruntime                         Yes      6.5K         4.1K         .cc:2002, .h:1840, .cpp:273, .inc:21, .hpp:3
orttraining                         Yes      812          563          .cc:289, .h:268, .hpp:4, .cpp:2
winml                               Yes      341          224          .h:149, .cpp:75
include                             Yes      123          121          .h:121
js                                  Yes      52.4K        43           .h:26, .cc:8, .cpp:7, .c:2
objectivec                          Yes      51           22           .h:22
java                                Yes      128          21           .c:20, .h:1
csharp                              Yes      385          1            .cpp:1
.git                                Yes      3.3K         1            .cc:1
rust                                Yes      39           0            -
dockerfiles                         Yes      13           0            -
docs                                Yes      76           0            -
tools/ci_build                      Yes      307          0            -
samples                             Yes      15           0            -
----------------------------------------------------------------------------------------------------
```