### PR TITLE
Log Framework name to more Windows ML relevant events

### DIFF
--- a/onnxruntime/core/platform/windows/telemetry.cc
+++ b/onnxruntime/core/platform/windows/telemetry.cc
@@ -415,7 +415,8 @@ void WindowsTelemetry::LogSessionCreation(uint32_t session_id, int64_t ir_versio
                       TraceLoggingString(model_metadata_string.c_str(), "modelMetaData"),
                       TraceLoggingString(loaded_from.c_str(), "loadedFrom"),
                       TraceLoggingString(execution_provider_string.c_str(), "executionProviderIds"),
-                      TraceLoggingString(service_names.c_str(), "serviceNames"));
+                      TraceLoggingString(service_names.c_str(), "serviceNames"),
+                      TraceLoggingString(ORT_CALLER_FRAMEWORK, "frameworkName"));
   }
 }
 
@@ -662,7 +663,8 @@ void WindowsTelemetry::LogProviderOptions(const std::string& provider_id, const 
                       // Telemetry info
                       TraceLoggingUInt8(0, "schemaVersion"),
                       TraceLoggingString(provider_id.c_str(), "providerId"),
-                      TraceLoggingString(provider_options_string.c_str(), "providerOptions"));
+                      TraceLoggingString(provider_options_string.c_str(), "providerOptions"),
+                      TraceLoggingString(ORT_CALLER_FRAMEWORK, "frameworkName"));
   }
 }
 


### PR DESCRIPTION
This PR adds the frameworkName field to critical Windows ML telemetry events to ensure proper event attribution and prevent data loss.

## Reason
The frameworkName field is added to ensure that Windows ML events are not lost and do not require joins with events that might have been emitted outside the scope of the time span the processing scripts check for long-running apps/processes. This allows each event to be self-contained with framework identification.

## Events Modified
The following telemetry events now include the frameworkName field:

1. **SessionCreationStart** - Logs when session creation begins
2. **SessionCreation** - Logs session creation details including model metadata
3. **RuntimeError** - Logs runtime errors (both DEBUG and release builds)
4. **RuntimePerf** - Logs runtime performance metrics including total runs and duration
5. **AutoEpSelection** - Logs automatic execution provider selection policy and results
6. **ProviderOptions** - Logs execution provider configuration options

All events now include TraceLoggingString(ORT_CALLER_FRAMEWORK, "frameworkName") to maintain consistent framework identification across the telemetry pipeline.