### PR TITLE
Remove s_kernel_registry_vitisaiep.reset() in deinitialize_vitisai_ep()

### DIFF
--- a/onnxruntime/core/providers/vitisai/imp/global_api.cc
+++ b/onnxruntime/core/providers/vitisai/imp/global_api.cc
@@ -386,7 +386,6 @@ void deinitialize_vitisai_ep() {
   s_domains_vitisaiep.clear();
 
   s_library_vitisaiep.Clear();
-  s_kernel_registry_vitisaiep.reset();
 }
 
 static void set_version_info(vaip_core::OrtApiForVaip& api) {


### PR DESCRIPTION
Remove unnecessary s_kernel_registry_vitisaiep.reset() call in deinitialize_vitisai_ep() function. The kernel registry will be repopulated on next initialization, making this reset redundant.