### PR TITLE
[onnxruntime_perf_test] Fix Mac peak working set size value

### DIFF
--- a/onnxruntime/test/perftest/posix/utils.cc
+++ b/onnxruntime/test/perftest/posix/utils.cc
@@ -24,7 +24,7 @@ std::size_t GetPeakWorkingSetSize() {
   constexpr size_t kBytesPerMaxRssUnit = 1024;
 #endif
 
-  return static_cast<size_t>(rusage.ru_maxrss * kBytesPerMaxRssUnit);
+  return static_cast<size_t>(rusage.ru_maxrss) * kBytesPerMaxRssUnit;
 }
 
 class CPUUsage : public ICPUUsage {


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

On Mac, `ru_maxrss` is in bytes and on other platforms, it is in kilobytes. This change sets a different multiplier value when `defined(__APPLE__)`.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix peak working set size reporting on Mac.