### PR TITLE
[Node.js] Fix float16 tensor input support

### DIFF
--- a/js/node/src/tensor_helper.cc
+++ b/js/node/src/tensor_helper.cc
@@ -214,7 +214,8 @@ Ort::Value NapiValueToOrtValue(Napi::Env env, Napi::Value value, OrtMemoryInfo* 
 
       ORT_NAPI_THROW_TYPEERROR_IF(!isValidTypedArray, env,
                                   "Tensor.data must be a typed array (", DATA_TYPE_TYPEDARRAY_MAP[elemType],
-                                  " or Float16Array) for ", tensorTypeString, " tensors, but got typed array (", typedArrayType, ").");
+                                  elemType == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16 ? " or Float16Array" : "",
+                                  ") for ", tensorTypeString, " tensors, but got typed array (", typedArrayType, ").");
 
       char* buffer = reinterpret_cast<char*>(tensorDataTypedArray.ArrayBuffer().Data());
       size_t bufferByteOffset = tensorDataTypedArray.ByteOffset();


### PR DESCRIPTION
Accept both Uint16Array and Float16Array for float16 tensors in the Node.js binding. Float16Array is a newer JavaScript type (ES2024) that N-API supports as napi_float16_array (type 11) in Node.js 23+.

For older Node.js versions, define napi_float16_array to ensure compatibility when users pass Float16Array data.
  ## Summary                                                                                   
  Fixes #26791 - Users cannot pass float16 input tensors from JavaScript.                      
                                                                                               
  **Changes:**                                                                                 
  - Define `napi_float16_array` for older Node.js versions (added in Node.js 23/N-API v10)     
  - Accept both `Uint16Array` and `Float16Array` for float16 tensors in validation             
                                                                                               
  **Root cause:** The validation in `tensor_helper.cc` only accepted `Uint16Array` for float16 
  tensors, rejecting the newer `Float16Array` type.                                            
                                                                                               
  ## Test Plan                                                                                 
  - [ ] Test with `Uint16Array` for float16 tensors (all Node.js versions)                     
  - [ ] Test with `Float16Array` for float16 tensors (Node.js 22+) 



