### PR TITLE
Add Microsoft.ML.OnnxRuntime nuget props for Linux and MacOS

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
@@ -889,8 +889,8 @@ namespace Microsoft.ML.OnnxRuntime
 #if !NETSTANDARD2_0 && !__ANDROID__ && !__IOS__
         /// <summary>
         /// Custom DllImportResolver to handle platform-specific library loading.
-        /// On Windows, it explicitly loads the library with a lowercase .dll extension to handle
-        /// case-sensitive filesystems.
+        /// It handles the addition of "lib" prefix and file extensions (.so/.dylib) for Linux/macOS,
+        /// and .dll extension for Windows (handling case-sensitivity).
         /// </summary>
         private static IntPtr DllImportResolver(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
         {
@@ -915,74 +915,10 @@ namespace Microsoft.ML.OnnxRuntime
 
                 if (mappedName != null)
                 {
-                    // 1. Try default loading (name only)
                     if (NativeLibrary.TryLoad(mappedName, assembly, searchPath, out IntPtr handle))
                     {
                         return handle;
                     }
-
-                    // 2. Try relative to assembly location (look into runtimes subfolders)
-                    string assemblyLocation = null;
-                    try { assemblyLocation = assembly.Location; } catch { }
-                    if (!string.IsNullOrEmpty(assemblyLocation))
-                    {
-                        string assemblyDir = System.IO.Path.GetDirectoryName(assemblyLocation);
-                        string rid = RuntimeInformation.RuntimeIdentifier;
-
-                        // Probe the specific RID first, then common fallbacks for the current OS
-                        string[] ridsToTry;
-                        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                        {
-                            ridsToTry = new[] { rid, "win-x64", "win-arm64" };
-                        }
-                        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                        {
-                            ridsToTry = new[] { rid, "linux-x64", "linux-arm64" };
-                        }
-                        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                        {
-                            // We no longer provide osx-x64 in official package since 1.24.
-                            // However, we keep it in the list for build-from-source users.
-                            ridsToTry = new[] { rid, "osx-arm64", "osx-x64" };
-                        }
-                        else
-                        {
-                            ridsToTry = new[] { rid };
-                        }
-
-                        foreach (var tryRid in ridsToTry)
-                        {
-                            string probePath = System.IO.Path.Combine(assemblyDir, "runtimes", tryRid, "native", mappedName);
-                            if (System.IO.File.Exists(probePath) && NativeLibrary.TryLoad(probePath, assembly, searchPath, out handle))
-                            {
-                                LogLibLoad($"[DllImportResolver] Loaded {mappedName} from: {probePath}");
-                                return handle;
-                            }
-                        }
-                    }
-
-                    // 3. Try AppContext.BaseDirectory as a fallback
-                    string baseDir = AppContext.BaseDirectory;
-                    if (!string.IsNullOrEmpty(baseDir))
-                    {
-                        string probePath = System.IO.Path.Combine(baseDir, mappedName);
-                        if (NativeLibrary.TryLoad(probePath, assembly, searchPath, out handle))
-                        {
-                            LogLibLoad($"[DllImportResolver] Loaded {mappedName} from: {probePath}");
-                            return handle;
-                        }
-
-                        string rid = RuntimeInformation.RuntimeIdentifier;
-                        probePath = System.IO.Path.Combine(baseDir, "runtimes", rid, "native", mappedName);
-                        if (NativeLibrary.TryLoad(probePath, assembly, searchPath, out handle))
-                        {
-                            LogLibLoad($"[DllImportResolver] Loaded {mappedName} from: {probePath}");
-                            return handle;
-                        }
-                    }
-
-                    LogLibLoad($"[DllImportResolver] Failed loading {mappedName} (RID: {RuntimeInformation.RuntimeIdentifier}, Assembly: {assemblyLocation})");
-
                 }
             }
 
@@ -990,14 +926,7 @@ namespace Microsoft.ML.OnnxRuntime
             return IntPtr.Zero;
         }
 
-        private static void LogLibLoad(string message)
-        {
-            System.Diagnostics.Trace.WriteLine(message);
-            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("ORT_LOADER_VERBOSITY")))
-            {
-                Console.WriteLine(message);
-            }
-        }
+
 #endif
 
         [DllImport(NativeLib.DllName, CharSet = CharSet.Ansi)]

--- a/csharp/src/Microsoft.ML.OnnxRuntime/targets/netstandard/props.xml
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/targets/netstandard/props.xml
@@ -142,5 +142,125 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
     </None>
+
+    <!-- linux-x64 -->
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-x64\native\libonnxruntime.so"
+          Condition="('$(PlatformTarget)' == 'x64' OR ('$(PlatformTarget)' == 'AnyCPU' AND '$(Prefer32Bit)' != 'true')) AND
+                     Exists('$(MSBuildThisFileDirectory)..\..\runtimes\linux-x64\native\libonnxruntime.so')">
+      <Link>libonnxruntime.so</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-x64\native\libonnxruntime_providers_shared.so"
+          Condition="('$(PlatformTarget)' == 'x64' OR ('$(PlatformTarget)' == 'AnyCPU' AND '$(Prefer32Bit)' != 'true')) AND
+                     Exists('$(MSBuildThisFileDirectory)..\..\runtimes\linux-x64\native\libonnxruntime_providers_shared.so')">
+      <Link>libonnxruntime_providers_shared.so</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-x64\native\libonnxruntime_providers_cuda.so"
+          Condition="('$(PlatformTarget)' == 'x64' OR ('$(PlatformTarget)' == 'AnyCPU' AND '$(Prefer32Bit)' != 'true')) AND
+                     Exists('$(MSBuildThisFileDirectory)..\..\runtimes\linux-x64\native\libonnxruntime_providers_cuda.so')">
+      <Link>libonnxruntime_providers_cuda.so</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-x64\native\libonnxruntime_providers_dnnl.so"
+          Condition="('$(PlatformTarget)' == 'x64' OR ('$(PlatformTarget)' == 'AnyCPU' AND '$(Prefer32Bit)' != 'true')) AND
+                     Exists('$(MSBuildThisFileDirectory)..\..\runtimes\linux-x64\native\libonnxruntime_providers_dnnl.so')">
+      <Link>libonnxruntime_providers_dnnl.so</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-x64\native\libonnxruntime_providers_tensorrt.so"
+          Condition="('$(PlatformTarget)' == 'x64' OR ('$(PlatformTarget)' == 'AnyCPU' AND '$(Prefer32Bit)' != 'true')) AND
+                     Exists('$(MSBuildThisFileDirectory)..\..\runtimes\linux-x64\native\libonnxruntime_providers_tensorrt.so')">
+      <Link>libonnxruntime_providers_tensorrt.so</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-x64\native\libonnxruntime_providers_openvino.so"
+          Condition="('$(PlatformTarget)' == 'x64' OR ('$(PlatformTarget)' == 'AnyCPU' AND '$(Prefer32Bit)' != 'true')) AND
+                     Exists('$(MSBuildThisFileDirectory)..\..\runtimes\linux-x64\native\libonnxruntime_providers_openvino.so')">
+      <Link>libonnxruntime_providers_openvino.so</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+
+    <!-- linux-arm64 -->
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-arm64\native\libonnxruntime.so"
+          Condition="'$(PlatformTarget)' == 'ARM64' AND
+                     Exists('$(MSBuildThisFileDirectory)..\..\runtimes\linux-arm64\native\libonnxruntime.so')">
+      <Link>libonnxruntime.so</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-arm64\native\libonnxruntime_providers_shared.so"
+          Condition="'$(PlatformTarget)' == 'ARM64' AND
+                     Exists('$(MSBuildThisFileDirectory)..\..\runtimes\linux-arm64\native\libonnxruntime_providers_shared.so')">
+      <Link>libonnxruntime_providers_shared.so</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-arm64\native\libonnxruntime_providers_cuda.so"
+          Condition="'$(PlatformTarget)' == 'ARM64' AND
+                     Exists('$(MSBuildThisFileDirectory)..\..\runtimes\linux-arm64\native\libonnxruntime_providers_cuda.so')">
+      <Link>libonnxruntime_providers_cuda.so</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-arm64\native\libonnxruntime_providers_dnnl.so"
+          Condition="'$(PlatformTarget)' == 'ARM64' AND
+                     Exists('$(MSBuildThisFileDirectory)..\..\runtimes\linux-arm64\native\libonnxruntime_providers_dnnl.so')">
+      <Link>libonnxruntime_providers_dnnl.so</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-arm64\native\libonnxruntime_providers_tensorrt.so"
+          Condition="'$(PlatformTarget)' == 'ARM64' AND
+                     Exists('$(MSBuildThisFileDirectory)..\..\runtimes\linux-arm64\native\libonnxruntime_providers_tensorrt.so')">
+      <Link>libonnxruntime_providers_tensorrt.so</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-arm64\native\libonnxruntime_providers_openvino.so"
+          Condition="'$(PlatformTarget)' == 'ARM64' AND
+                     Exists('$(MSBuildThisFileDirectory)..\..\runtimes\linux-arm64\native\libonnxruntime_providers_openvino.so')">
+      <Link>libonnxruntime_providers_openvino.so</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+
+    <!-- osx-x64 -->
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx-x64\native\libonnxruntime.dylib"
+          Condition="('$(PlatformTarget)' == 'x64' OR ('$(PlatformTarget)' == 'AnyCPU' AND '$(Prefer32Bit)' != 'true')) AND
+                     Exists('$(MSBuildThisFileDirectory)..\..\runtimes\osx-x64\native\libonnxruntime.dylib')">
+      <Link>libonnxruntime.dylib</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx-x64\native\libonnxruntime_providers_shared.dylib"
+          Condition="('$(PlatformTarget)' == 'x64' OR ('$(PlatformTarget)' == 'AnyCPU' AND '$(Prefer32Bit)' != 'true')) AND
+                     Exists('$(MSBuildThisFileDirectory)..\..\runtimes\osx-x64\native\libonnxruntime_providers_shared.dylib')">
+      <Link>libonnxruntime_providers_shared.dylib</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+
+    <!-- osx-arm64 -->
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx-arm64\native\libonnxruntime.dylib"
+          Condition="'$(PlatformTarget)' == 'ARM64' AND
+                     Exists('$(MSBuildThisFileDirectory)..\..\runtimes\osx-arm64\native\libonnxruntime.dylib')">
+      <Link>libonnxruntime.dylib</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx-arm64\native\libonnxruntime_providers_shared.dylib"
+          Condition="'$(PlatformTarget)' == 'ARM64' AND
+                     Exists('$(MSBuildThisFileDirectory)..\..\runtimes\osx-arm64\native\libonnxruntime_providers_shared.dylib')">
+      <Link>libonnxruntime_providers_shared.dylib</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

This PR updates props.xml of ONNX Runtime NuGet package, specifically on macOS and Linux. It aligns the behavior of non-Windows platforms with the existing Windows logic by ensuring native libraries are copied to the build output directory. This change allows for a significant simplification of the `DllImportResolver` in `NativeMethods.shared.cs`.

## Technical Details

### 1. props.xml Update
- **File**: csharp/src/Microsoft.ML.OnnxRuntime/targets/netstandard/props.xml
- **Change**: Added `ItemGroup` entries for `linux-x64`, `linux-arm64`, `osx-x64`, and `osx-arm64`.
- **Logic**: These entries conditionally copy the native libraries (e.g., `libonnxruntime.so`, `libonnxruntime.dylib`) and shared provider libraries (CUDA, DNNL, TensorRT, OpenVINO) from the package's `runtimes` directory to the build output directory. This ensures they are present where the .NET runtime (and DllImport in NativeMethods.shared.cs) expects them.

### 2. DllImportResolver Simplification
- **File**: csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
- **Change**: Removed the manual "Step 2" probing logic that searched `.../runtimes/{rid}/native`.
- **Reasoning**: Since the libraries are now copied to the output directory (AppDomain base), the explicit directory probing is redundant.
- **Details**: 
    - Retained the platform-specific name mapping logic (e.g., mapping `onnxruntime` to `libonnxruntime.so` or `libonnxruntime.dylib`).
    - Removed unused helper methods (`LogLibLoad`).
    - Updated comments to reflect cross-platform support.

## Motivation

This is a follow up of https://github.com/microsoft/onnxruntime/pull/27266#issuecomment-3889015502.

Previously, the DllImportResolver had to manually traverse directory structures to find native assets on non-Windows platforms because they weren't being copied to the bin folder. This was fragile and inconsistent with the Windows behavior. By copying the assets, we leverage standard .NET loading mechanisms and simplify the custom resolver code.



