### PR TITLE
[DNNL] Fix DNNL build

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -1220,6 +1220,13 @@ block()
     ${TEST_SRC_DIR}/common/tensor_op_test_utils.h
   )
 
+  if (onnxruntime_USE_DNNL)
+    list(APPEND supporting_test_srcs
+      ${TEST_SRC_DIR}/common/dnnl_op_test_utils.cc
+      ${TEST_SRC_DIR}/common/dnnl_op_test_utils.h
+    )
+  endif()
+
   list(APPEND onnxruntime_provider_test_srcs
     ${supporting_test_srcs}
     ${onnxruntime_unittest_main_src}


### PR DESCRIPTION
### Description
As title. Without including these DNNL files, it results in a link error because it is unable to locate the definition for `DnnlHasBF16Support()` defined in the file



### Motivation and Context
Fix build error


