### PR TITLE
Remove AzurePowerShell pwsh parameter in tools/ci_build/github/azure-pipelines/templates/publish-symbolrequestprod-api.yml

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/py-win-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-win-cpu.yml
@@ -85,22 +85,6 @@ jobs:
 
   - template: set-nightly-build-option-variable-step.yml
 
-  # TODO for testing!!!
-  - powershell: |-
-      Get-PackageProvider -Name NuGet -ForceBootstrap
-      Install-Module -Verbose -AllowClobber -Force Az.Accounts, Az.Storage, Az.Network, Az.Resources, Az.Compute
-    displayName: Install Azure Module Dependencies
-
-  - task: AzurePowerShell@5
-    displayName: Test AzurePowerShell
-    inputs:
-      azureSubscription: OnnxrunTimeCodeSign_20240611
-      azurePowerShellVersion: LatestVersion
-      ScriptType: InlineScript
-      Inline: |
-        Write-Host "Hello from AzurePowerShell"
-  # end of testing changes
-
   - script: python -m pip install -r $(Build.SourcesDirectory)\tools\ci_build\github\windows\python\requirements.txt
     env:
       TMPDIR: "$(Agent.TempDirectory)"


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Remove AzurePowerShell pwsh parameter in tools/ci_build/github/azure-pipelines/templates/publish-symbolrequestprod-api.yml so it will default to powershell.exe instead of pwsh.exe.

Some Windows build agents don't have pwsh.exe.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix Win ARM64 Python packaging pipeline issue.