### PR TITLE
Fix python packaging pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/publish-symbolrequestprod-api.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/publish-symbolrequestprod-api.yml
@@ -68,7 +68,7 @@ steps:
 
         # Convert the SecureString token to a plain text string for the HTTP header
         # This is done just-in-time before its use.
-        $plainTextToken = $secureTokenObject | ConvertFrom-SecureString -AsPlainText
+        $plainTextToken = [System.Net.NetworkCredential]::new("", $secureTokenObject).Password
         Write-Host "Token converted to plain text for API call (will not be logged)."
 
         # Part 2: Publish Symbols using internal REST API


### PR DESCRIPTION
Fix python packaging pipeline for 1.24.2 release.

Previous attempt (https://github.com/microsoft/onnxruntime/pull/27339) to fix python packaging pipeline failed since powershell 5.1 does not support `-AsPlainText`.

It has been verified that python packaging pipeline is good after this fix.