### PR TITLE
[Build] Fix Nuget Test Pipeline AAR Testing with ReleaseVersionSuffix

### DIFF
--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-test-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-test-pipelines.yml
@@ -69,6 +69,8 @@ stages:
 
 - stage: Android_Java_API_AAR_Testing_Full
   dependsOn: Setup
+  variables:
+    ReleaseVersionSuffix: $[ stageDependencies.Setup.Restore_And_Use_Variables.outputs['Set_Release_Version_Suffix.ReleaseVersionSuffix'] ]
   jobs:
   - template: templates/android-java-api-aar-test.yml
     parameters:
@@ -77,11 +79,14 @@ stages:
 
 - stage: Final_AAR_Testing_Android_QNN
   dependsOn: Setup
+  variables:
+    ReleaseVersionSuffix: $[ stageDependencies.Setup.Restore_And_Use_Variables.outputs['Set_Release_Version_Suffix.ReleaseVersionSuffix'] ]
   jobs:
   - template: templates/android-java-api-aar-test.yml
     parameters:
       artifactName: 'onnxruntime-android-qnn-aar'
       packageName: 'onnxruntime-android-qnn'
+      ReleaseVersionSuffix: $(ReleaseVersionSuffix)
       #TODO: get this information from the setup stage
       QnnSDKVersion: '2.42.0.251225'
 

--- a/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar-test.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar-test.yml
@@ -58,7 +58,14 @@ jobs:
         mkdir -p android_test/android/app/libs
         cd android_test/android
         cp -av $(Build.SourcesDirectory)/java/src/test/android/* ./
-        cp $(Pipeline.Workspace)/build/${{parameters.artifactName}}/${{parameters.packageName}}-$(OnnxRuntimeVersion)${{parameters.ReleaseVersionSuffix}}.aar app/libs/${{parameters.packageName}}.aar
+        # Use a more robust way to copy the AAR, picking the first one found if multiple exist
+        # Check if the file exists to provide a better error message
+        AAR_SOURCE=$(ls $(Pipeline.Workspace)/build/${{parameters.artifactName}}/*.aar 2>/dev/null | head -n 1)
+        if [ -z "$AAR_SOURCE" ]; then
+            echo "Error: No .aar file found in $(Pipeline.Workspace)/build/${{parameters.artifactName}}"
+            exit 1
+        fi
+        cp "$AAR_SOURCE" app/libs/${{parameters.packageName}}.aar
     displayName: Copy Android test files and AAR to android_test directory
     workingDirectory: $(Build.BinariesDirectory)
 


### PR DESCRIPTION
# Description
This PR fixes failures in the Android Java API AAR testing stages of the NuGet packaging pipeline for release candidate.

# Background
The Android test stages in `c-api-noopenmp-test-pipelines.yml` were failing for two reasons:
1. **Variable Resolution**: The `ReleaseVersionSuffix` (e.g., `-rc.1`) was not being correctly passed between stages, causing bash script errors.
2. **Version Mismatch**: The test script attempted to construct the AAR filename using the local `VERSION_NUMBER` file, which often mismatched the version used to build the packaged artifact, causing `cp` failures.

# Changes
- **Fixed Variable Mapping**: Explicitly mapped the `ReleaseVersionSuffix` output variable from the `Setup` stage to the `Android_Java_API_AAR_Testing_Full` and `Final_AAR_Testing_Android_QNN` stages.
- **Robust AAR Selection**: Updated the AAR copy logic in `templates/android-java-api-aar-test.yml` to use wildcard matching (`*.aar`) and select the first available file.
- **Added Error Handling**: Added a check to verify that an `.aar` file exists in the artifact directory, providing a clear error message and failing early if it's missing.

# Files Modified
- `tools/ci_build/github/azure-pipelines/c-api-noopenmp-test-pipelines.yml`: Added stage variables for `ReleaseVersionSuffix`.
- `tools/ci_build/github/azure-pipelines/templates/android-java-api-aar-test.yml`: Updated AAR copy command with check/wildcard.

# Testing
- Verified that `$(ReleaseVersionSuffix)` resolves correctly in the bash environment.
- Verified that the `cp` command correctly finds and rename-copies the AAR even when local version files differ from artifact versions.