### PR TITLE
Update python_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -874,7 +874,7 @@ setup(
     data_files=data_files,
     install_requires=install_requires,
     extras_require=extras_require,
-    python_requires=">=3.10",
+    python_requires=">=3.11",
     keywords="onnx machine learning",
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
### Description
The requires-python field in the [metadata](https://pypi.org/pypi/onnxruntime/json) is currently set to `python >= 3.10`. However, since ONNX Runtime has dropped support for `Python 3.10`, this constraint is now inaccurate and may lead to dependency resolution issues in `uv lock`.

Related Commits: #26397



