### PR TITLE
Backport Tianleis Fix for symbol publishing

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/publish-symbolrequestprod-api.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/publish-symbolrequestprod-api.yml
@@ -68,7 +68,7 @@ steps:
 
         # Convert the SecureString token to a plain text string for the HTTP header
         # This is done just-in-time before its use.
-        $plainTextToken = $secureTokenObject | ConvertFrom-SecureString -AsPlainText
+        $plainTextToken = [System.Net.NetworkCredential]::new("", $secureTokenObject).Password
         Write-Host "Token converted to plain text for API call (will not be logged)."
 
         # Part 2: Publish Symbols using internal REST API


### PR DESCRIPTION
### Description
Update publishing powershell to support powershell or pwsh. Backported from rel-1.24.2

### Motivation and Context


