### PR TITLE
[Build] Fix DML Nuget ESRP CodeSign

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/esrp_nuget.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/esrp_nuget.yml
@@ -1,10 +1,10 @@
 parameters:
   FolderPath: ''
   DisplayName: ''
-  DoEsrp: 'false'
+  DoEsrp: false
 
 steps:
-- ${{ if eq(parameters['DoEsrp'], 'true') }}:
+- ${{ if eq(parameters.DoEsrp, true) }}:
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
     displayName: 'ESRP CodeSigning'
     inputs:


### PR DESCRIPTION
# Description
Fixes the issue where DirectML NuGet packages are unsigned in the final pipeline artifacts.

### Problem
In the updated NuGet pipeline, DirectML packages were found to be unsigned. Investigation revealed that the [bundle_dml_package.ps1](https://github.com/microsoft/onnxruntime/blob/ed0478ad64d96da419dba46f18a1fa8a9fea8644/tools/ci_build/github/windows/bundle_dml_package.ps1) script (introduced in #27349) extracts the original package, merges ARM64 binaries, and re-compresses it using 7-Zip. This process inherently destroys any existing digital signatures on the `.nupkg`.

### Root Cause
While the pipeline includes a re-signing step using the [esrp_nuget.yml](https://github.com/microsoft/onnxruntime/blob/ed0478ad64d96da419dba46f18a1fa8a9fea8644/tools/ci_build/github/azure-pipelines/templates/esrp_nuget.yml) template, this task was being silently skipped due to a type mismatch in its compile-time condition:
- The template expected `DoEsrp` to be a string `'true'`: `${{ if eq(parameters['DoEsrp'], 'true') }}`.
- The DML pipeline (and its intermediate stages) explicitly defines `DoEsrp` as a `boolean` and passes a literal `true`.
- In Azure DevOps, the primitive boolean `true` is not equal to the string `'true'` in these expressions, leading to the signing task being excluded.

Other pipelines (like CUDA) often work by "luck" because they pass `DoEsrp` through untyped intermediate parameters, which Azure DevOps coerces into strings. DML's strict typing made this bug apparent and fatal.

### Changes
- **Modified**: [tools/ci_build/github/azure-pipelines/templates/esrp_nuget.yml](https://github.com/microsoft/onnxruntime/blob/ed0478ad64d96da419dba46f18a1fa8a9fea8644/tools/ci_build/github/azure-pipelines/templates/esrp_nuget.yml)
    - Changed `DoEsrp` parameter type to `boolean`.
    - Updated the conditional logic to use a robust boolean comparison: `${{ if eq(parameters.DoEsrp, true) }}`.

### Verification
- Traced the parameter path in [dml-nuget-packaging.yml](https://github.com/microsoft/onnxruntime/blob/ed0478ad64d96da419dba46f18a1fa8a9fea8644/tools/ci_build/github/azure-pipelines/dml-nuget-packaging.yml) and [stages/nuget_dml_packaging_stage.yml](https://github.com/microsoft/onnxruntime/blob/ed0478ad64d96da419dba46f18a1fa8a9fea8644/tools/ci_build/github/azure-pipelines/stages/nuget_dml_packaging_stage.yml) to confirm boolean type consistency.
- Verified that the updated logic correctly evaluates to `true` when a boolean is provided, ensuring the `EsrpCodeSigning@5` task is included in the generated pipeline.

### Motivation and Context
This fix is critical for ensuring that bundled multi-architecture NuGet packages (like DirectML) are correctly signed before they are published to NuGet.org or internal feeds.

