### PR TITLE
[Build] Fix nuget pipelines to pass IsReleaseBuild to validate-package

### DIFF
--- a/tools/ci_build/github/azure-pipelines/stages/nuget-combine-cuda-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nuget-combine-cuda-stage.yml
@@ -57,6 +57,7 @@ stages:
     CudaVersion: ${{ parameters.CudaVersion }}
     buildJava: ${{ parameters.buildJava }}
     buildNodejs: ${{ parameters.buildNodejs }}
+    IsReleaseBuild: ${{ parameters.IsReleaseBuild }}
 
 - ${{ if eq(parameters.buildNodejs, 'true') }}:
   - template: nodejs-linux-packaging-stage.yml
@@ -71,6 +72,7 @@ stages:
     win_trt_home: ${{ parameters.win_trt_home }}
     win_cuda_home: ${{ parameters.win_cuda_home }}
     buildJava: ${{ parameters.buildJava }}
+    IsReleaseBuild: ${{ parameters.IsReleaseBuild }}
     PreReleaseVersionSuffixString: ${{ parameters.PreReleaseVersionSuffixString }}
     PreReleaseVersionSuffixNumber: ${{ parameters.PreReleaseVersionSuffixNumber }}
     CudaArchs: ${{ parameters.CudaArchs }}

--- a/tools/ci_build/github/azure-pipelines/stages/nuget-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nuget-cuda-packaging-stage.yml
@@ -186,6 +186,7 @@ stages:
         # 1* stands for version number. we use it to filter Gpu.Windows and Gpu.Linux packages
         PackageName: 'Microsoft.ML.OnnxRuntime.Gpu.1*nupkg'
         VerifyNugetSigning: false
+        IsReleaseBuild: ${{ parameters.IsReleaseBuild }}
 
     - template: ../templates/validate-package.yml
       parameters:
@@ -194,6 +195,7 @@ stages:
         PackageName: 'Microsoft.ML.OnnxRuntime.Gpu.Windows.*nupkg'
         PlatformsSupported: 'win-x64'
         VerifyNugetSigning: false
+        IsReleaseBuild: ${{ parameters.IsReleaseBuild }}
 
     - template: ../templates/validate-package.yml
       parameters:
@@ -202,6 +204,7 @@ stages:
         PackageName: 'Microsoft.ML.OnnxRuntime.Gpu.Linux.*nupkg'
         PlatformsSupported: 'linux-x64'
         VerifyNugetSigning: false
+        IsReleaseBuild: ${{ parameters.IsReleaseBuild }}
 
     - task: MSBuild@1
       displayName: 'Clean C#'

--- a/tools/ci_build/github/azure-pipelines/stages/nuget-linux-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nuget-linux-cuda-packaging-stage.yml
@@ -6,6 +6,9 @@ parameters:
   type: boolean
 - name: buildNodejs
   type: boolean
+- name: IsReleaseBuild
+  type: boolean
+  default: false
 
 stages:
 - stage: Linux_C_API_Packaging_GPU
@@ -202,6 +205,7 @@ stages:
         ScriptPath: '$(Build.SourcesDirectory)/onnxruntime/tools/nuget/validate_package.py'
         PlatformsSupported: 'linux-x64'
         VerifyNugetSigning: false
+        IsReleaseBuild: ${{ parameters.IsReleaseBuild }}
         workingDirectory: '$(Build.ArtifactStagingDirectory)'
 
 

--- a/tools/ci_build/github/azure-pipelines/stages/nuget-win-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nuget-win-cuda-packaging-stage.yml
@@ -55,6 +55,9 @@ parameters:
 - name: win_cudnn_home
   type: string
   default: ''
+- name: IsReleaseBuild
+  type: boolean
+  default: false
 
 stages:
 # Windows CUDA without TensorRT Packaging
@@ -179,6 +182,7 @@ stages:
         ScriptPath: '$(Build.SourcesDirectory)\onnxruntime\tools\nuget\validate_package.py'
         PlatformsSupported: 'win-x64'
         VerifyNugetSigning: false
+        IsReleaseBuild: ${{ parameters.IsReleaseBuild }}
         workingDirectory: '$(Build.ArtifactStagingDirectory)'
 
     - task: BatchScript@1


### PR DESCRIPTION
## Summary
This PR fixes an issue where the is_release_build parameter was not being correctly passed to the validate_package.py script across various Azure Pipelines.

## Changes
- Updated the combined CUDA packaging stage and its sub-stages to pass the IsReleaseBuild parameter through the template chain.
- Added missing IsReleaseBuild parameter definitions to following templates:
  tools/ci_build/github/azure-pipelines/stages/nuget-linux-cuda-packaging-stage.yml
  tools/ci_build/github/azure-pipelines/stages/nuget-win-cuda-packaging-stage.yml
- Ensured all calls to validate-package.yml (including the main CUDA NuGet stage) now explicitly pass the IsReleaseBuild flag.

## Context
It is based on https://github.com/microsoft/onnxruntime/pull/27382.

