### PR TITLE
[Build] Add validate package to DML nuget pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/dml-nuget-packaging.yml
+++ b/tools/ci_build/github/azure-pipelines/dml-nuget-packaging.yml
@@ -111,3 +111,4 @@ extends:
     - template: stages/nuget_dml_packaging_stage.yml
       parameters:
         DoEsrp: ${{ parameters.DoEsrp }}
+        IsReleaseBuild: ${{ parameters.IsReleaseBuild }}

--- a/tools/ci_build/github/azure-pipelines/stages/nuget_dml_packaging_stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nuget_dml_packaging_stage.yml
@@ -56,3 +56,12 @@ stages:
         DisplayName: 'ESRP - sign NuGet package'
         FolderPath: '$(Build.ArtifactStagingDirectory)'
         DoEsrp: ${{ parameters.DoEsrp }}
+
+    - template: ../templates/validate-package.yml
+      parameters:
+        PackageType: 'nuget'
+        PackagePath: '$(Build.ArtifactStagingDirectory)'
+        PackageName: 'Microsoft.ML.OnnxRuntime.DirectML.*nupkg'
+        PlatformsSupported: 'win-x64,win-arm64'
+        VerifyNugetSigning: false
+        IsReleaseBuild: ${{ parameters.IsReleaseBuild }}


### PR DESCRIPTION
This adds a missing validation step to the DirectML NuGet packaging pipeline to ensure the bundled x64/arm64 package is verified after creation. This makes the DML nuget pipeline to be consistent with other pipelines on package validation.  

