### PR TITLE
Fix O(n²) model load time for TreeEnsemble with categorical feature chains

### DIFF
--- a/onnxruntime/core/providers/cpu/ml/tree_ensemble_common.h
+++ b/onnxruntime/core/providers/cpu/ml/tree_ensemble_common.h
@@ -384,6 +384,9 @@ bool TreeEnsembleCommon<InputType, ThresholdType, OutputType>::CheckIfSubtreesAr
     gsl::span<const ThresholdType> nodes_values_as_tensor, gsl::span<const float> node_values,
     gsl::span<const float> target_class_weights, gsl::span<const ThresholdType> target_class_weights_as_tensor,
     const InlinedVector<TreeNodeElementId>& node_tree_ids, InlinedVector<std::pair<TreeNodeElementId, uint32_t>> indices) {
+  if (left_id == right_id) {
+    return true;
+  }
   // Leaves have values set at 0
   if (cmodes[left_id] != cmodes[right_id] || nodes_featureids[left_id] != nodes_featureids[right_id] ||
       (!nodes_values_as_tensor.empty() && nodes_values_as_tensor[left_id] != nodes_values_as_tensor[right_id]) ||


### PR DESCRIPTION
### Description
Profiling shows that CheckIfSubtreesAreEqual is invoked recursively for many node pairs for LightGBM models with categorical features. A significant portion of this work consists of self-comparisons (left_id == right_id), leading to effectively O(n²) comparing trees to themselves during model loading.

This change adds a fast-path for trivial equality, avoiding unnecessary recursive comparisons.

Example results:
 - model with 7K BRANCH_EQ nodes: 527 ms → 47 ms (~11× faster)
 - model with 106K BRANCH_EQ nodes: 141 s → 80 ms (~1760× faster)

### Motivation and Context
We have some LightGBM exported models that make heavy use of categorical features and exhibit extremely slow load times (minutes for a single 2.5mb model).

Heres a diagram to illustrate the issue:
<img width="1008" height="1229" alt="image" src="https://github.com/user-attachments/assets/348e16cb-9eec-448f-ac5c-e1edb60e2a3d" />

the 106K model has much longer "member of" chains, with chains that lead into more chains:

<details>
  <summary>"trees"</summary>
  
<img width="1405" height="593" alt="image" src="https://github.com/user-attachments/assets/12f0c43f-5987-4b33-9001-2a2b526e537f" />

  
</details>

Interestingly we did also try using the new onnx.ml opset 5 node that has MEMBER, but it seems even slower as it recreates these branch EQ chains. 

