### PR TITLE
Fix error where bytes is not assigned for dynamic qgemm pack b size

### DIFF
--- a/onnxruntime/core/mlas/lib/qgemm.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm.cpp
@@ -351,7 +351,7 @@ MlasDynamicQgemmPackBSize(
 #if defined(USE_KLEIDIAI)
     //No fallback available
     if (GetMlasPlatform().MlasDynamicQGemmPackBSizeOverride != nullptr) {
-        GetMlasPlatform().MlasDynamicQGemmPackBSizeOverride(N, K);
+       bytes = GetMlasPlatform().MlasDynamicQGemmPackBSizeOverride(N, K);
     }
 #endif
 


### PR DESCRIPTION
### Description
Fix for dynamic qgemm pack B size. Byte assignment accidentally removed in previous commit. Which causes test failures with the following error message

C++ exception with description "Dynamic QGEMM requires non-null PackedB pointer." thrown in the test body.


