### PR TITLE
Add optional dependency for quantization utilities (ml_dtypes)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -842,8 +842,10 @@ def save_build_and_package_info(package_name, version_number, cuda_version, qnn_
 save_build_and_package_info(package_name, version_number, cuda_version, qnn_version)
 
 # sympy is optional - only needed for symbolic shape inference
+# ml_dtypes is optional - needed for quantization utilities
 extras_require = {
     "symbolic": ["sympy"],
+    "quantization": ["ml_dtypes"],
 }
 if package_name == "onnxruntime-gpu" and cuda_major_version:
     # Determine cufft version: CUDA 13 uses cufft 12, CUDA 12 uses cufft 11


### PR DESCRIPTION
Summary
This PR adds a quantization optional dependency in extras_require and maps it to ml_dtypes in setup.py.

Motivation
onnxruntime.quantization can fail in a clean environment with:
ModuleNotFoundError: No module named 'ml_dtypes'

This is reproducible with:
- onnx==1.18.0
- onnxruntime==1.24.2

Related issue: #27257 
Change
- Updated setup.py to include:
  - extras_require["quantization"] = ["ml_dtypes"]

Validation
- Reproduced the issue in a clean venv.
- Verified that installing ml_dtypes resolves the import error.
- Ran local build and tests successfully:
  - ./build.sh --config RelWithDebInfo --build --parallel
  - ./build.sh --config RelWithDebInfo --test --parallel
  - Result: 100% tests passed, 0 failed.

Notes
This is a minimal packaging change and does not modify runtime/operator behavior.
