### PR TITLE
Remove dependency on execinfo in release build

### DIFF
--- a/onnxruntime/core/platform/posix/stacktrace.cc
+++ b/onnxruntime/core/platform/posix/stacktrace.cc
@@ -3,7 +3,7 @@
 
 #include "core/common/common.h"
 
-#if !defined(__ANDROID__) && !defined(__wasm__) && !defined(_OPSCHEMA_LIB_) && !defined(_AIX)
+#if !defined(NDEBUG) && !defined(__ANDROID__) && !defined(__wasm__) && !defined(_OPSCHEMA_LIB_) && !defined(_AIX)
 #include <execinfo.h>
 #endif
 #include <vector>


### PR DESCRIPTION
### Description
The release version doesn't build on Alpine Linux. I fixed it and checked on Alpine Linux 3.23.2.

### Motivation and Context
- [execinfo can't be installed](https://gitlab.alpinelinux.org/alpine/aports/-/issues/10896) on Alpine Linux since 3.17 without workaround
- `execinfo` is not required in release build (NDEBUG)
https://github.com/microsoft/onnxruntime/blob/6e7c5f80ee0352ac71dd72edb28cb7e6a3064a86/onnxruntime/core/platform/posix/stacktrace.cc#L16

<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


