### PR TITLE
Use `_tpause` also for clang

### DIFF
--- a/onnxruntime/core/common/spin_pause.cc
+++ b/onnxruntime/core/common/spin_pause.cc
@@ -32,7 +32,7 @@ void SpinPause() {
   static const bool has_tpause = CPUIDInfo::GetCPUIDInfo().HasTPAUSE();
   static constexpr uint64_t tpause_spin_delay_cycles = 1000;
   if (has_tpause) {
-#if defined(_WIN32)
+#if defined(_WIN32) || defined(__clang__)
     _tpause(0x0, __rdtsc() + tpause_spin_delay_cycles);
 #elif defined(__linux__)
     __builtin_ia32_tpause(0x0, __rdtsc() + tpause_spin_delay_cycles);


### PR DESCRIPTION
### Description
[`_tpause` is also supported](https://clang.llvm.org/doxygen/waitpkgintrin_8h.html#a371e36b9996fa91a80c52c182ae6f0d4) when using the clang compiler so that it can be used in this location in the code. The alternative code path which uses `__builtin_ia32_tpause` lets it fail when using the clang compiler.

### Motivation and Context
I read somewhere that you are only supporting gcc but besides that change I was able to compile with clang so maybe you are interested in this simple fix for widening compiler support :-)