### PR TITLE
Suppress spurious Array Out of Bounds warnings produced by GCC 14.2 compiler on Linux builds

### DIFF
--- a/include/onnxruntime/core/framework/int2.h
+++ b/include/onnxruntime/core/framework/int2.h
@@ -140,14 +140,14 @@ struct Int2x4Base {
     // Process complete groups of 4 elements
 
     for (; dst_i < full_quads; dst_i++) {
-      #if defined (__GNUC__) && defined(HAS_ARRAY_BOUNDS)
-      #pragma GCC diagnostic push
-      #pragma GCC diagnostic ignored "-Warray-bounds"
-      #endif
+#if defined(__GNUC__) && defined(HAS_ARRAY_BOUNDS)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
       dst[dst_i] = Int2x4Base<Signed>(src[src_i], src[src_i + 1], src[src_i + 2], src[src_i + 3]);
-      #if defined (__GNUC__) && defined(HAS_ARRAY_BOUNDS)
-      #pragma GCC diagnostic pop
-      #endif
+#if defined(__GNUC__) && defined(HAS_ARRAY_BOUNDS)
+#pragma GCC diagnostic pop
+#endif
       src_i += 4;
     }
 


### PR DESCRIPTION
### Description
Suppress spurious Array Out of Bounds warnings produced by GCC 14.2 compiler on Linux builds



### Motivation and Context
Linux build fails when compiled with GCC 14.2 due to spurious Array Out of Bounds warnings (Warnings Treated as Errors)


