### PR TITLE
DQ→MatMulNBits fusion transformer for NvTensorRtRtx ep 

### DIFF
--- a/include/onnxruntime/core/optimizer/graph_transformer_utils.h
+++ b/include/onnxruntime/core/optimizer/graph_transformer_utils.h
@@ -57,8 +57,7 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
     const IExecutionProvider& execution_provider /*required by constant folding*/,
     const logging::Logger& logger,
     const InlinedHashSet<std::string>& rules_and_transformers_to_disable = {},
-    concurrency::ThreadPool* intra_op_thread_pool = nullptr,
-    bool enable_dq_matmulnbits_fusion = false);
+    concurrency::ThreadPool* intra_op_thread_pool = nullptr);
 
 #endif  // !defined(ORT_MINIMAL_BUILD)
 

--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -385,6 +385,11 @@ static const char* const kOrtSessionOptionsMlasLutGemm = "mlas.use_lut_gemm";
 // If not provided, default is 4.
 static const char* const kOrtSessionOptionsQDQMatMulNBitsAccuracyLevel = "session.qdq_matmulnbits_accuracy_level";
 
+// Enable the DQ->MatMulNBits fusion graph transformer.
+// "0": disabled (default). "1": enabled.
+// This is typically set automatically by InferenceSession when the NvTensorRTRTX EP is registered.
+static const char* const kOrtSessionOptionsEnableDQMatMulNBitsFusion = "session.enable_dq_matmulnbits_fusion";
+
 // THIS OPTION IS NOT A REGULAR SESSION OPTION SINCE IT CAN BE MODIFIED AT ANY TIME
 // Meant to be used with SetEpDynamicOptions
 // Specify the type of workload for this session.

--- a/onnxruntime/core/optimizer/dq_matmulnbits_fusion.cc
+++ b/onnxruntime/core/optimizer/dq_matmulnbits_fusion.cc
@@ -3,7 +3,10 @@
 
 #include "core/optimizer/dq_matmulnbits_fusion.h"
 
+#if !defined(ORT_MINIMAL_BUILD)
+
 #include "core/common/common.h"
+#include "core/common/safeint.h"
 #include "core/framework/tensorprotoutils.h"
 #include "core/graph/constants.h"
 #include "core/graph/graph_utils.h"
@@ -51,7 +54,9 @@ bool HasRank2Shape(const ONNX_NAMESPACE::TensorProto& tp, int64_t dim0, int64_t 
   return tp.dims_size() == 2 && tp.dims(0) == dim0 && tp.dims(1) == dim1;
 }
 
-uint8_t GetPackedUint4Element(const uint8_t* packed, size_t index) {
+uint8_t GetPackedUint4Element(const uint8_t* packed, size_t index, size_t num_elements) {
+  ORT_ENFORCE(index < num_elements, "GetPackedUint4Element: index ", index,
+              " out of bounds (num_elements=", num_elements, ")");
   const uint8_t packed_byte = packed[index / 2];
   return (index % 2 == 0) ? static_cast<uint8_t>(packed_byte & 0x0F)
                           : static_cast<uint8_t>((packed_byte >> 4) & 0x0F);
@@ -59,15 +64,17 @@ uint8_t GetPackedUint4Element(const uint8_t* packed, size_t index) {
 
 void PackUint4Rows(const Initializer& src, int64_t rows, int64_t cols, uint8_t* dst) {
   const int64_t row_bytes = (cols + 1) / 2;
-  memset(dst, 0, static_cast<size_t>(rows * row_bytes));
+  const size_t dst_bytes = SafeInt<size_t>(rows) * row_bytes;
+  const size_t total_elements = SafeInt<size_t>(rows) * cols;
+  memset(dst, 0, dst_bytes);
 
   const auto src_packed = src.DataAsByteSpan();
   for (int64_t r = 0; r < rows; ++r) {
     for (int64_t c = 0; c < cols; ++c) {
-      const size_t src_index = static_cast<size_t>(r * cols + c);
-      const uint8_t value = GetPackedUint4Element(src_packed.data(), src_index);
+      const size_t src_index = SafeInt<size_t>(r) * cols + c;
+      const uint8_t value = GetPackedUint4Element(src_packed.data(), src_index, total_elements);
 
-      const size_t dst_index = static_cast<size_t>(r * row_bytes + c / 2);
+      const size_t dst_index = SafeInt<size_t>(r) * row_bytes + c / 2;
       if ((c & 1) == 0) {
         dst[dst_index] = value;
       } else {
@@ -79,21 +86,26 @@ void PackUint4Rows(const Initializer& src, int64_t rows, int64_t cols, uint8_t* 
 
 // Transpose and pack UINT4 weights from DQ axis=0 layout [K, N] to MatMulNBits layout [N, k_blocks, blob_size].
 // Source: row-major UINT4 with quantization along K (axis=0), shape [K, N].
+// The nibble ordering follows ONNX UINT4 convention: even indices in the low nibble,
+// odd indices in the high nibble of each byte.
 // Dest: UINT8 [N, k_blocks, block_size/2] where each byte packs two 4-bit weights.
 void TransposePackWeightsAxis0(
     const uint8_t* src_packed, int64_t K, int64_t N, int64_t block_size,
     uint8_t* dst) {
   const int64_t k_blocks = (K + block_size - 1) / block_size;
   const int64_t blob_size = block_size / 2;
-  memset(dst, 0, static_cast<size_t>(N * k_blocks * blob_size));
+  const size_t dst_bytes = SafeInt<size_t>(N) * k_blocks * blob_size;
+  const size_t total_elements = SafeInt<size_t>(K) * N;
+  memset(dst, 0, dst_bytes);
 
   for (int64_t n = 0; n < N; ++n) {
     for (int64_t k = 0; k < K; ++k) {
-      const uint8_t val = GetPackedUint4Element(src_packed, static_cast<size_t>(k * N + n));
+      const size_t src_index = SafeInt<size_t>(k) * N + n;
+      const uint8_t val = GetPackedUint4Element(src_packed, src_index, total_elements);
 
       const int64_t kb = k / block_size;
       const int64_t off = k % block_size;
-      const size_t dst_byte = static_cast<size_t>(n * k_blocks * blob_size + kb * blob_size + off / 2);
+      const size_t dst_byte = SafeInt<size_t>(n) * k_blocks * blob_size + kb * blob_size + off / 2;
       if (off % 2 == 0) {
         dst[dst_byte] = static_cast<uint8_t>((dst[dst_byte] & 0xF0) | val);
       } else {
@@ -109,13 +121,16 @@ void TransposePackZPAxis0(
     const uint8_t* src_packed, int64_t k_blocks, int64_t N,
     uint8_t* dst) {
   const int64_t zp_bytes_per_n = (k_blocks + 1) / 2;
-  memset(dst, 0, static_cast<size_t>(N * zp_bytes_per_n));
+  const size_t dst_bytes = SafeInt<size_t>(N) * zp_bytes_per_n;
+  const size_t total_elements = SafeInt<size_t>(k_blocks) * N;
+  memset(dst, 0, dst_bytes);
 
   for (int64_t n = 0; n < N; ++n) {
     for (int64_t kb = 0; kb < k_blocks; ++kb) {
-      const uint8_t val = GetPackedUint4Element(src_packed, static_cast<size_t>(kb * N + n));
+      const size_t src_index = SafeInt<size_t>(kb) * N + n;
+      const uint8_t val = GetPackedUint4Element(src_packed, src_index, total_elements);
 
-      const size_t dst_byte = static_cast<size_t>(n * zp_bytes_per_n + kb / 2);
+      const size_t dst_byte = SafeInt<size_t>(n) * zp_bytes_per_n + kb / 2;
       if (kb % 2 == 0) {
         dst[dst_byte] = static_cast<uint8_t>((dst[dst_byte] & 0xF0) | val);
       } else {
@@ -239,7 +254,7 @@ std::vector<FusionMatch> CollectReshapeTransposeMatches(
     const int64_t bs_dim = weight_const_tp->dims(2);
     if (N <= 0 || blocks <= 0 || bs_dim <= 0) continue;
     if (bs_dim != block_size) continue;
-    const int64_t K = blocks * bs_dim;
+    const int64_t K = SafeInt<int64_t>(blocks) * bs_dim;
 
     const auto* scale_arg = dq_node->InputDefs()[1];
     if (!scale_arg || !scale_arg->Exists()) continue;
@@ -297,8 +312,8 @@ std::vector<FusionMatch> CollectReshapeTransposeMatches(
     }
 
     if (const auto* b_shape = mm_inputs[1]->Shape(); b_shape && b_shape->dim_size() == 2 &&
-        utils::HasDimValue(b_shape->dim(0)) && utils::HasDimValue(b_shape->dim(1)) &&
-        (b_shape->dim(0).dim_value() != K || b_shape->dim(1).dim_value() != N)) {
+                                                     utils::HasDimValue(b_shape->dim(0)) && utils::HasDimValue(b_shape->dim(1)) &&
+                                                     (b_shape->dim(0).dim_value() != K || b_shape->dim(1).dim_value() != N)) {
       continue;
     }
 
@@ -479,7 +494,7 @@ void ApplyReshapeTransposeFusions(
     const int64_t quant_num = weight_tp->dims(1);
     const int64_t bs_dim = weight_tp->dims(2);
     if (N <= 0 || quant_num <= 0 || bs_dim <= 0 || bs_dim != block_size) continue;
-    const int64_t K = quant_num * bs_dim;
+    const int64_t K = SafeInt<int64_t>(quant_num) * bs_dim;
     const int64_t blob_bytes = (block_size + 1) / 2;
 
     Initializer weight_src(graph, *weight_tp, graph.ModelPath());
@@ -490,9 +505,11 @@ void ApplyReshapeTransposeFusions(
     }
 
     auto uint8_type = DataTypeImpl::TensorTypeFromONNXEnum(
-                          ONNX_NAMESPACE::TensorProto_DataType_UINT8)->GetElementType();
+                          ONNX_NAMESPACE::TensorProto_DataType_UINT8)
+                          ->GetElementType();
     auto scale_type = DataTypeImpl::TensorTypeFromONNXEnum(
-                          scale_src.data_type())->GetElementType();
+                          scale_src.data_type())
+                          ->GetElementType();
 
     auto cpu_allocator = CPUAllocator::DefaultInstance();
 
@@ -540,7 +557,7 @@ void ApplyReshapeTransposeFusions(
     } else {
       // DequantizeLinear default zero-point for uint4 is 0, while MatMulNBits
       // default is 8. Emit explicit zeros to preserve semantics.
-      zp_dst_name = graph.GenerateNodeArgName("webnn_fused_DQ_zp_mnb");
+      zp_dst_name = graph.GenerateNodeArgName("fused_DQ_zp_mnb");
       zp_dst = Tensor(uint8_type, TensorShape{zp_size}, cpu_allocator);
       memset(zp_dst->MutableDataRaw(), 0, zp_dst->SizeInBytes());
     }
@@ -585,9 +602,9 @@ void ApplyReshapeTransposeFusions(
     mnb_outputs.push_back(const_cast<NodeArg*>(mm_node->OutputDefs()[0]));
 
     auto& mnb_node = graph.AddNode(
-        graph.GenerateNodeName("WebNNFusedMatMulNBits"),
+        graph.GenerateNodeName("DQFusedMatMulNBits"),
         "MatMulNBits",
-        "Fused from WebNN DQ+Reshape+Transpose+MatMul",
+        "Fused from DQ+Reshape+Transpose+MatMul",
         mnb_inputs, mnb_outputs, &mnb_attrs, kMSDomain);
     mnb_node.SetExecutionProviderType(mm_node->GetExecutionProviderType());
 
@@ -661,16 +678,18 @@ void ApplyDirectDQFusions(
     if (zp_tp && !HasRank2Shape(*zp_tp, k_blocks, N)) continue;
 
     Initializer weight_src(graph, *weight_tp, graph.ModelPath());
-    const size_t required_weight_bytes = static_cast<size_t>(N * k_blocks * blob_bytes);
+    const size_t required_weight_bytes = SafeInt<size_t>(N) * k_blocks * blob_bytes;
     if (weight_src.DataAsByteSpan().size() < required_weight_bytes) continue;
     Initializer scale_src(graph, *scale_tp, graph.ModelPath());
     if (scale_src.data_type() != ONNX_NAMESPACE::TensorProto_DataType_FLOAT &&
         scale_src.data_type() != ONNX_NAMESPACE::TensorProto_DataType_FLOAT16) continue;
 
     auto uint8_type = DataTypeImpl::TensorTypeFromONNXEnum(
-                          ONNX_NAMESPACE::TensorProto_DataType_UINT8)->GetElementType();
+                          ONNX_NAMESPACE::TensorProto_DataType_UINT8)
+                          ->GetElementType();
     auto scale_type = DataTypeImpl::TensorTypeFromONNXEnum(
-                          scale_src.data_type())->GetElementType();
+                          scale_src.data_type())
+                          ->GetElementType();
     auto cpu_allocator = CPUAllocator::DefaultInstance();
 
     auto weight_dst_name = graph.GenerateNodeArgName(weight_arg->Name() + "_mnb");
@@ -679,7 +698,7 @@ void ApplyDirectDQFusions(
                               weight_dst.MutableData<uint8_t>());
 
     auto scale_dst_name = graph.GenerateNodeArgName(scale_arg->Name() + "_mnb");
-    const int64_t scale_count = N * k_blocks;
+    const int64_t scale_count = SafeInt<int64_t>(N) * k_blocks;
     if (scale_src.size() != static_cast<size_t>(scale_count)) continue;
     auto scale_dst = Tensor(scale_type, TensorShape{scale_count}, cpu_allocator);
 
@@ -699,7 +718,7 @@ void ApplyDirectDQFusions(
 
     std::string zp_dst_name;
     std::optional<Tensor> zp_dst;
-    const int64_t zp_bytes_total = N * ((k_blocks + 1) / 2);
+    const int64_t zp_bytes_total = SafeInt<int64_t>(N) * ((k_blocks + 1) / 2);
 
     bool elide_zp = false;
 
@@ -790,11 +809,9 @@ void ApplyDirectDQFusions(
 
 DQMatMulNBitsFusion::DQMatMulNBitsFusion(
     int64_t accuracy_level,
-    concurrency::ThreadPool* intra_op_thread_pool,
     const InlinedHashSet<std::string_view>& compatible_eps)
     : GraphTransformer("DQMatMulNBitsFusion", compatible_eps),
-      accuracy_level_(accuracy_level),
-      intra_op_thread_pool_(intra_op_thread_pool) {
+      accuracy_level_(accuracy_level) {
   ORT_ENFORCE(accuracy_level_ >= 0 && accuracy_level_ <= 4,
               "MatMulNBits accuracy level must be between 0 and 4");
 }
@@ -827,3 +844,5 @@ Status DQMatMulNBitsFusion::ApplyImpl(Graph& graph, bool& modified, int graph_le
 }
 
 }  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/core/optimizer/dq_matmulnbits_fusion.h
+++ b/onnxruntime/core/optimizer/dq_matmulnbits_fusion.h
@@ -3,29 +3,28 @@
 
 #pragma once
 
+#if !defined(ORT_MINIMAL_BUILD)
+
 #include <cstdint>
 
 #include "core/optimizer/graph_transformer.h"
 
 namespace onnxruntime {
-namespace concurrency {
-class ThreadPool;
-}
 
-// Fuses the WebNN-specific pattern:
-//   DequantizeLinear(3D, UINT4, axis=2) -> Reshape(2D) -> Transpose([1,0])
-//   -> [optional Cast] -> MatMul/Gemm
-// into a single MatMulNBits node.
+// Fuses DequantizeLinear chains back into a single MatMulNBits contrib op.
 //
-// This pattern is produced when a quantized model goes through:
-//   1) ORT-Web WebNN EP (lowers MatMulNBits to DQ+Reshape+Transpose+MatMul primitives)
-//   2) Chromium WebNN backend (converts WebNN ops back to ONNX)
-//   3) ORT native graph optimizations (may produce Gemm from MatMul+Add)
+// Supported patterns:
+//   Pattern 1: DQ(3D, UINT4, axis=2) -> Reshape(2D) -> Transpose([1,0])
+//              -> [optional Cast] -> MatMul/Gemm => MatMulNBits
+//   Pattern 2: DQ(2D, UINT4, axis=0) -> MatMul/Gemm => MatMulNBits
+//
+// These patterns are produced when a quantized model goes through external
+// toolchains that lower MatMulNBits to DQ + reshape/transpose + MatMul
+// primitives, and then re-import the graph into ORT.
 class DQMatMulNBitsFusion : public GraphTransformer {
  public:
   explicit DQMatMulNBitsFusion(
       int64_t accuracy_level = 4,
-      concurrency::ThreadPool* intra_op_thread_pool = nullptr,
       const InlinedHashSet<std::string_view>& compatible_eps = {});
 
  private:
@@ -33,7 +32,8 @@ class DQMatMulNBitsFusion : public GraphTransformer {
                    const logging::Logger& logger) const override;
 
   int64_t accuracy_level_;
-  concurrency::ThreadPool* intra_op_thread_pool_;
 };
 
 }  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -13,11 +13,12 @@
 #include "core/optimizer/qdq_transformer/qdq_final_cleanup.h"
 #include "core/optimizer/qdq_transformer/selectors_actions/qdq_selector_action_transformer.h"
 #include "core/optimizer/selectors_actions/selector_action_transformer_apply_contexts.h"
-#include "core/optimizer/dq_matmulnbits_fusion.h"
 #include "core/session/onnxruntime_session_options_config_keys.h"
 #include "core/platform/threadpool.h"
 
 #if !defined(ORT_MINIMAL_BUILD)
+
+#include "core/optimizer/dq_matmulnbits_fusion.h"
 
 #include "core/mlas/inc/mlas.h"
 #include "core/optimizer/attention_fusion.h"
@@ -205,8 +206,7 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
     const IExecutionProvider& cpu_execution_provider, /*required by constant folding*/
     const logging::Logger& logger,
     const InlinedHashSet<std::string>& rules_and_transformers_to_disable,
-    [[maybe_unused]] concurrency::ThreadPool* intra_op_thread_pool,
-    bool enable_dq_matmulnbits_fusion) {
+    [[maybe_unused]] concurrency::ThreadPool* intra_op_thread_pool) {
   InlinedVector<std::unique_ptr<GraphTransformer>> transformers;
   const bool disable_quant_qdq =
       session_options.config_options.GetConfigOrDefault(kOrtSessionOptionsDisableQuantQDQ, "0") == "1";
@@ -277,16 +277,22 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
       }
 
 #if !defined(DISABLE_CONTRIB_OPS)
-      if (enable_dq_matmulnbits_fusion && !disable_quant_qdq) {
-        const int64_t qdq_matmulnbits_accuracy_level =
-            ParseStringWithClassicLocale<int64_t>(
-                session_options.config_options.GetConfigOrDefault(kOrtSessionOptionsQDQMatMulNBitsAccuracyLevel,
-                                                                  "4"));
-        transformers.emplace_back(std::make_unique<DQMatMulNBitsFusion>(
-            qdq_matmulnbits_accuracy_level, intra_op_thread_pool));
+      {
+        const bool enable_dq_matmulnbits_fusion =
+            session_options.config_options.GetConfigOrDefault(
+                kOrtSessionOptionsEnableDQMatMulNBitsFusion, "0") == "1";
+        if (enable_dq_matmulnbits_fusion && !disable_quant_qdq) {
+          const int64_t qdq_matmulnbits_accuracy_level =
+              ParseStringWithClassicLocale<int64_t>(
+                  session_options.config_options.GetConfigOrDefault(kOrtSessionOptionsQDQMatMulNBitsAccuracyLevel,
+                                                                    "4"));
+          transformers.emplace_back(std::make_unique<DQMatMulNBitsFusion>(
+              qdq_matmulnbits_accuracy_level));
+        }
       }
 #else
-      ORT_ENFORCE(!enable_dq_matmulnbits_fusion,
+      ORT_ENFORCE(session_options.config_options.GetConfigOrDefault(
+                      kOrtSessionOptionsEnableDQMatMulNBitsFusion, "0") != "1",
                   "DQ->MatMulNBits fusion requires contrib ops but DISABLE_CONTRIB_OPS is defined");
 #endif
 

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -2279,6 +2279,16 @@ common::Status InferenceSession::Initialize() {
         return Status::OK();
       };
 
+      // Enable DQ->MatMulNBits fusion if NvTensorRTRTX EP is registered.
+      if (execution_providers_.Get(onnxruntime::kNvTensorRTRTXExecutionProvider) != nullptr) {
+        if (session_options_.config_options.GetConfigOrDefault(
+                kOrtSessionOptionsEnableDQMatMulNBitsFusion, "") == "") {
+          ORT_RETURN_IF_ERROR_SESSIONID_(
+              session_options_.config_options.AddConfigEntry(
+                  kOrtSessionOptionsEnableDQMatMulNBitsFusion, "1"));
+        }
+      }
+
       // add predefined transformers
       ORT_RETURN_IF_ERROR_SESSIONID_(AddPredefinedTransformers(graph_transformer_mgr_,
                                                                session_options_.graph_optimization_level,
@@ -3938,8 +3948,6 @@ common::Status InferenceSession::AddPredefinedTransformers(
     RecordRuntimeOptimizationProducedNodeOpSchemaFn record_runtime_optimization_produced_op_schema_fn,
     const logging::Logger& logger) const {
   const auto& cpu_ep = *execution_providers_.Get(onnxruntime::kCpuExecutionProvider);
-  const bool enable_dq_matmulnbits_fusion =
-      execution_providers_.Get(onnxruntime::kNvTensorRTRTXExecutionProvider) != nullptr;
   for (int i = static_cast<int>(TransformerLevel::Default); i <= static_cast<int>(TransformerLevel::MaxLevel); i++) {
     TransformerLevel level = static_cast<TransformerLevel>(i);
     std::function<onnxruntime::InlinedVector<std::unique_ptr<GraphTransformer>>()> transformers_to_register;
@@ -3951,8 +3959,7 @@ common::Status InferenceSession::AddPredefinedTransformers(
         transformers_to_register = [&]() {
           return optimizer_utils::GenerateTransformers(level, session_options_, cpu_ep, logger,
                                                        optimizers_to_disable_,
-                                                       GetIntraOpThreadPoolToUse(),
-                                                       enable_dq_matmulnbits_fusion);
+                                                       GetIntraOpThreadPoolToUse());
         };
       }
     } else {
@@ -3966,8 +3973,7 @@ common::Status InferenceSession::AddPredefinedTransformers(
           if (use_full_build_optimizations) {
             return optimizer_utils::GenerateTransformers(level, session_options_, cpu_ep, logger,
                                                          optimizers_to_disable_,
-                                                         GetIntraOpThreadPoolToUse(),
-                                                         enable_dq_matmulnbits_fusion);
+                                                         GetIntraOpThreadPoolToUse());
           } else {
             const auto sat_context =
                 minimal_build_optimization_handling ==

--- a/onnxruntime/test/optimizer/dq_matmulnbits_fusion_test.cc
+++ b/onnxruntime/test/optimizer/dq_matmulnbits_fusion_test.cc
@@ -1,0 +1,595 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Unit tests for the DQMatMulNBitsFusion graph transformer.
+// Tests Pattern 1: DQ(3D,axis=2)->Reshape->Transpose([1,0])->[Cast]->MatMul/Gemm -> MatMulNBits
+// Tests Pattern 2: DQ(2D,axis=0)->MatMul/Gemm -> MatMulNBits
+
+#include "core/common/span_utils.h"
+#include "core/framework/int4.h"
+#include "core/graph/node_attr_utils.h"
+#include "core/optimizer/dq_matmulnbits_fusion.h"
+
+#include "test/test_environment.h"
+#include "test/unittest_util/framework_test_utils.h"
+#include "test/unittest_util/graph_transform_test_builder.h"
+#include "test/optimizer/graph_transform_test_fixture.h"
+#include "test/util/include/asserts.h"
+
+#include "gtest/gtest.h"
+
+#if !defined(DISABLE_CONTRIB_OPS)
+
+namespace onnxruntime {
+namespace test {
+
+static std::vector<UInt4x2> MakePackedUint4(const std::vector<uint8_t>& values) {
+  const size_t num_pairs = UInt4x2::CalcNumInt4Pairs(values.size());
+  std::vector<UInt4x2> packed(num_pairs);
+  for (size_t i = 0; i < values.size(); i += 2) {
+    uint8_t lo = values[i] & 0x0F;
+    uint8_t hi = (i + 1 < values.size()) ? (values[i + 1] & 0x0F) : 0;
+    packed[i / 2] = UInt4x2(lo, hi);
+  }
+  return packed;
+}
+
+static void BuildPattern1Graph(ModelTestBuilder& builder,
+                               int64_t M, int64_t N, int64_t K,
+                               int64_t block_size,
+                               bool with_zp,
+                               bool with_cast,
+                               bool use_gemm,
+                               const std::vector<uint8_t>* weight_values = nullptr,
+                               const std::vector<float>* scale_values = nullptr,
+                               const std::vector<uint8_t>* zp_values = nullptr) {
+  const int64_t num_blocks = K / block_size;
+
+  auto* input_a = builder.MakeInput<float>({M, K}, -1.0f, 1.0f);
+  auto* output = builder.MakeOutput();
+
+  const int64_t weight_elems = N * num_blocks * block_size;
+  std::vector<uint8_t> w_vals;
+  if (weight_values) {
+    w_vals = *weight_values;
+  } else {
+    w_vals.resize(static_cast<size_t>(weight_elems));
+    for (size_t i = 0; i < w_vals.size(); ++i) {
+      w_vals[i] = static_cast<uint8_t>(i % 16);
+    }
+  }
+  auto w_packed = MakePackedUint4(w_vals);
+  auto* weight_arg = builder.MakeInitializer<UInt4x2>(
+      {N, num_blocks, block_size}, w_packed);
+
+  std::vector<float> s_vals;
+  if (scale_values) {
+    s_vals = *scale_values;
+  } else {
+    s_vals.resize(static_cast<size_t>(N * num_blocks));
+    for (size_t i = 0; i < s_vals.size(); ++i) {
+      s_vals[i] = 0.1f + 0.01f * static_cast<float>(i % 10);
+    }
+  }
+  auto* scale_arg = builder.MakeInitializer<float>({N, num_blocks, 1}, s_vals);
+
+  NodeAttributes dq_attrs;
+  utils::SetNodeAttribute(utils::MakeAttribute("axis", static_cast<int64_t>(2)), dq_attrs);
+  utils::SetNodeAttribute(utils::MakeAttribute("block_size", block_size), dq_attrs);
+
+  auto* dq_output = builder.MakeIntermediate();
+  if (with_zp) {
+    std::vector<uint8_t> z_vals;
+    if (zp_values) {
+      z_vals = *zp_values;
+    } else {
+      z_vals.resize(static_cast<size_t>(N * num_blocks));
+      for (size_t i = 0; i < z_vals.size(); ++i) {
+        z_vals[i] = 8;
+      }
+    }
+    auto zp_packed = MakePackedUint4(z_vals);
+    auto* zp_arg = builder.MakeInitializer<UInt4x2>({N, num_blocks, 1}, zp_packed);
+    builder.AddNode("DequantizeLinear", {weight_arg, scale_arg, zp_arg}, {dq_output}, "", &dq_attrs);
+  } else {
+    builder.AddNode("DequantizeLinear", {weight_arg, scale_arg}, {dq_output}, "", &dq_attrs);
+  }
+
+  auto* reshape_shape = builder.MakeInitializer<int64_t>({2}, {N, K});
+  auto* reshape_output = builder.MakeIntermediate();
+  builder.AddNode("Reshape", {dq_output, reshape_shape}, {reshape_output});
+
+  NodeAttributes tp_attrs;
+  utils::SetNodeAttribute(utils::MakeAttribute("perm", std::vector<int64_t>{1, 0}), tp_attrs);
+  auto* transpose_output = builder.MakeIntermediate();
+  builder.AddNode("Transpose", {reshape_output}, {transpose_output}, "", &tp_attrs);
+
+  NodeArg* matmul_b = transpose_output;
+
+  if (with_cast) {
+    auto* cast_output = builder.MakeIntermediate();
+    NodeAttributes cast_attrs;
+    utils::SetNodeAttribute(utils::MakeAttribute("to", static_cast<int64_t>(1)), cast_attrs);
+    builder.AddNode("Cast", {transpose_output}, {cast_output}, "", &cast_attrs);
+    matmul_b = cast_output;
+  }
+
+  if (use_gemm) {
+    builder.AddNode("Gemm", {input_a, matmul_b}, {output});
+  } else {
+    builder.AddNode("MatMul", {input_a, matmul_b}, {output});
+  }
+}
+
+static void BuildPattern1GemmBiasGraph(ModelTestBuilder& builder,
+                                       int64_t M, int64_t N, int64_t K,
+                                       int64_t block_size,
+                                       bool with_zp) {
+  const int64_t num_blocks = K / block_size;
+
+  auto* input_a = builder.MakeInput<float>({M, K}, -1.0f, 1.0f);
+  auto* output = builder.MakeOutput();
+
+  const int64_t weight_elems = N * num_blocks * block_size;
+  std::vector<uint8_t> w_vals(static_cast<size_t>(weight_elems));
+  for (size_t i = 0; i < w_vals.size(); ++i) w_vals[i] = static_cast<uint8_t>(i % 16);
+  auto w_packed = MakePackedUint4(w_vals);
+  auto* weight_arg = builder.MakeInitializer<UInt4x2>({N, num_blocks, block_size}, w_packed);
+
+  std::vector<float> s_vals(static_cast<size_t>(N * num_blocks));
+  for (size_t i = 0; i < s_vals.size(); ++i) s_vals[i] = 0.1f;
+  auto* scale_arg = builder.MakeInitializer<float>({N, num_blocks, 1}, s_vals);
+
+  NodeAttributes dq_attrs;
+  utils::SetNodeAttribute(utils::MakeAttribute("axis", static_cast<int64_t>(2)), dq_attrs);
+  utils::SetNodeAttribute(utils::MakeAttribute("block_size", block_size), dq_attrs);
+  auto* dq_output = builder.MakeIntermediate();
+
+  if (with_zp) {
+    std::vector<uint8_t> z_vals(static_cast<size_t>(N * num_blocks), 8);
+    auto zp_packed = MakePackedUint4(z_vals);
+    auto* zp_arg = builder.MakeInitializer<UInt4x2>({N, num_blocks, 1}, zp_packed);
+    builder.AddNode("DequantizeLinear", {weight_arg, scale_arg, zp_arg}, {dq_output}, "", &dq_attrs);
+  } else {
+    builder.AddNode("DequantizeLinear", {weight_arg, scale_arg}, {dq_output}, "", &dq_attrs);
+  }
+
+  auto* reshape_shape = builder.MakeInitializer<int64_t>({2}, {N, K});
+  auto* reshape_output = builder.MakeIntermediate();
+  builder.AddNode("Reshape", {dq_output, reshape_shape}, {reshape_output});
+
+  NodeAttributes tp_attrs;
+  utils::SetNodeAttribute(utils::MakeAttribute("perm", std::vector<int64_t>{1, 0}), tp_attrs);
+  auto* transpose_output = builder.MakeIntermediate();
+  builder.AddNode("Transpose", {reshape_output}, {transpose_output}, "", &tp_attrs);
+
+  auto* bias_arg = builder.MakeInitializer<float>({N}, std::vector<float>(static_cast<size_t>(N), 0.5f));
+  builder.AddNode("Gemm", {input_a, transpose_output, bias_arg}, {output});
+}
+
+static void BuildPattern2Graph(ModelTestBuilder& builder,
+                               int64_t M, int64_t N, int64_t K,
+                               int64_t block_size,
+                               bool with_zp,
+                               bool use_gemm) {
+  const int64_t k_blocks = K / block_size;
+
+  auto* input_a = builder.MakeInput<float>({M, K}, -1.0f, 1.0f);
+  auto* output = builder.MakeOutput();
+
+  std::vector<uint8_t> w_vals(static_cast<size_t>(K * N));
+  for (size_t i = 0; i < w_vals.size(); ++i) w_vals[i] = static_cast<uint8_t>(i % 16);
+  auto w_packed = MakePackedUint4(w_vals);
+  auto* weight_arg = builder.MakeInitializer<UInt4x2>({K, N}, w_packed);
+
+  std::vector<float> s_vals(static_cast<size_t>(k_blocks * N));
+  for (size_t i = 0; i < s_vals.size(); ++i) s_vals[i] = 0.1f + 0.01f * static_cast<float>(i % 10);
+  auto* scale_arg = builder.MakeInitializer<float>({k_blocks, N}, s_vals);
+
+  NodeAttributes dq_attrs;
+  utils::SetNodeAttribute(utils::MakeAttribute("axis", static_cast<int64_t>(0)), dq_attrs);
+  utils::SetNodeAttribute(utils::MakeAttribute("block_size", block_size), dq_attrs);
+  auto* dq_output = builder.MakeIntermediate();
+
+  if (with_zp) {
+    std::vector<uint8_t> z_vals(static_cast<size_t>(k_blocks * N), 8);
+    auto zp_packed = MakePackedUint4(z_vals);
+    auto* zp_arg = builder.MakeInitializer<UInt4x2>({k_blocks, N}, zp_packed);
+    builder.AddNode("DequantizeLinear", {weight_arg, scale_arg, zp_arg}, {dq_output}, "", &dq_attrs);
+  } else {
+    builder.AddNode("DequantizeLinear", {weight_arg, scale_arg}, {dq_output}, "", &dq_attrs);
+  }
+
+  if (use_gemm) {
+    builder.AddNode("Gemm", {input_a, dq_output}, {output});
+  } else {
+    builder.AddNode("MatMul", {input_a, dq_output}, {output});
+  }
+}
+
+static void BuildPattern2GemmBiasGraph(ModelTestBuilder& builder,
+                                       int64_t M, int64_t N, int64_t K,
+                                       int64_t block_size,
+                                       bool with_zp) {
+  const int64_t k_blocks = K / block_size;
+
+  auto* input_a = builder.MakeInput<float>({M, K}, -1.0f, 1.0f);
+  auto* output = builder.MakeOutput();
+
+  std::vector<uint8_t> w_vals(static_cast<size_t>(K * N));
+  for (size_t i = 0; i < w_vals.size(); ++i) w_vals[i] = static_cast<uint8_t>(i % 16);
+  auto w_packed = MakePackedUint4(w_vals);
+  auto* weight_arg = builder.MakeInitializer<UInt4x2>({K, N}, w_packed);
+
+  std::vector<float> s_vals(static_cast<size_t>(k_blocks * N));
+  for (size_t i = 0; i < s_vals.size(); ++i) s_vals[i] = 0.1f;
+  auto* scale_arg = builder.MakeInitializer<float>({k_blocks, N}, s_vals);
+
+  NodeAttributes dq_attrs;
+  utils::SetNodeAttribute(utils::MakeAttribute("axis", static_cast<int64_t>(0)), dq_attrs);
+  utils::SetNodeAttribute(utils::MakeAttribute("block_size", block_size), dq_attrs);
+  auto* dq_output = builder.MakeIntermediate();
+
+  if (with_zp) {
+    std::vector<uint8_t> z_vals(static_cast<size_t>(k_blocks * N), 8);
+    auto zp_packed = MakePackedUint4(z_vals);
+    auto* zp_arg = builder.MakeInitializer<UInt4x2>({k_blocks, N}, zp_packed);
+    builder.AddNode("DequantizeLinear", {weight_arg, scale_arg, zp_arg}, {dq_output}, "", &dq_attrs);
+  } else {
+    builder.AddNode("DequantizeLinear", {weight_arg, scale_arg}, {dq_output}, "", &dq_attrs);
+  }
+
+  auto* bias_arg = builder.MakeInitializer<float>({N}, std::vector<float>(static_cast<size_t>(N), 0.5f));
+  builder.AddNode("Gemm", {input_a, dq_output, bias_arg}, {output});
+}
+
+static void BuildPattern1WrongAxis(ModelTestBuilder& builder,
+                                   int64_t M, int64_t N, int64_t K,
+                                   int64_t block_size) {
+  const int64_t num_blocks = K / block_size;
+  auto* input_a = builder.MakeInput<float>({M, K}, -1.0f, 1.0f);
+  auto* output = builder.MakeOutput();
+
+  std::vector<uint8_t> w_vals(static_cast<size_t>(N * num_blocks * block_size));
+  for (size_t i = 0; i < w_vals.size(); ++i) w_vals[i] = static_cast<uint8_t>(i % 16);
+  auto w_packed = MakePackedUint4(w_vals);
+  auto* weight_arg = builder.MakeInitializer<UInt4x2>({N, num_blocks, block_size}, w_packed);
+
+  std::vector<float> s_vals(static_cast<size_t>(N * num_blocks), 0.1f);
+  auto* scale_arg = builder.MakeInitializer<float>({N, num_blocks, 1}, s_vals);
+
+  NodeAttributes dq_attrs;
+  utils::SetNodeAttribute(utils::MakeAttribute("axis", static_cast<int64_t>(0)), dq_attrs);
+  utils::SetNodeAttribute(utils::MakeAttribute("block_size", block_size), dq_attrs);
+  auto* dq_output = builder.MakeIntermediate();
+  builder.AddNode("DequantizeLinear", {weight_arg, scale_arg}, {dq_output}, "", &dq_attrs);
+
+  auto* reshape_shape = builder.MakeInitializer<int64_t>({2}, {N, K});
+  auto* reshape_output = builder.MakeIntermediate();
+  builder.AddNode("Reshape", {dq_output, reshape_shape}, {reshape_output});
+
+  NodeAttributes tp_attrs;
+  utils::SetNodeAttribute(utils::MakeAttribute("perm", std::vector<int64_t>{1, 0}), tp_attrs);
+  auto* transpose_output = builder.MakeIntermediate();
+  builder.AddNode("Transpose", {reshape_output}, {transpose_output}, "", &tp_attrs);
+
+  builder.AddNode("MatMul", {input_a, transpose_output}, {output});
+}
+
+static void BuildPattern2NonConstWeight(ModelTestBuilder& builder,
+                                        int64_t M, int64_t N, int64_t K,
+                                        int64_t block_size) {
+  const int64_t k_blocks = K / block_size;
+  auto* input_a = builder.MakeInput<float>({M, K}, -1.0f, 1.0f);
+  auto* output = builder.MakeOutput();
+
+  auto* weight_arg = builder.MakeInput<UInt4x2>({K, N},
+                                                UInt4x2(UInt4x2::min_val, 0),
+                                                UInt4x2(UInt4x2::max_val, 0));
+
+  std::vector<float> s_vals(static_cast<size_t>(k_blocks * N), 0.1f);
+  auto* scale_arg = builder.MakeInitializer<float>({k_blocks, N}, s_vals);
+
+  NodeAttributes dq_attrs;
+  utils::SetNodeAttribute(utils::MakeAttribute("axis", static_cast<int64_t>(0)), dq_attrs);
+  utils::SetNodeAttribute(utils::MakeAttribute("block_size", block_size), dq_attrs);
+  auto* dq_output = builder.MakeIntermediate();
+  builder.AddNode("DequantizeLinear", {weight_arg, scale_arg}, {dq_output}, "", &dq_attrs);
+
+  builder.AddNode("MatMul", {input_a, dq_output}, {output});
+}
+
+static std::map<std::string, int> CountOpsInGraphByDomain(const Graph& graph) {
+  std::map<std::string, int> op_counts;
+  for (const auto& node : graph.Nodes()) {
+    std::string key = node.OpType();
+    if (!node.Domain().empty() && node.Domain() != kOnnxDomain) {
+      key = node.Domain() + "." + key;
+    }
+    op_counts[key]++;
+  }
+  return op_counts;
+}
+
+class DQMatMulNBitsFusionTest : public GraphTransformationTests {};
+
+TEST_F(DQMatMulNBitsFusionTest, Pattern1_MatMul_NoZP) {
+  constexpr int64_t M = 4, N = 8, K = 32, block_size = 16;
+  auto build = [&](ModelTestBuilder& builder) {
+    BuildPattern1Graph(builder, M, N, K, block_size, false, false, false);
+  };
+
+  auto pre_check = [&](Graph& graph) -> Status {
+    auto ops = CountOpsInGraphByDomain(graph);
+    EXPECT_EQ(ops["DequantizeLinear"], 1);
+    EXPECT_EQ(ops["Reshape"], 1);
+    EXPECT_EQ(ops["Transpose"], 1);
+    EXPECT_EQ(ops["MatMul"], 1);
+    return Status::OK();
+  };
+
+  auto post_check = [&](Graph& graph) -> Status {
+    auto ops = CountOpsInGraphByDomain(graph);
+    EXPECT_EQ(ops.count("DequantizeLinear"), 0);
+    EXPECT_EQ(ops.count("Reshape"), 0);
+    EXPECT_EQ(ops.count("Transpose"), 0);
+    EXPECT_EQ(ops.count("MatMul"), 0);
+    EXPECT_EQ(ops["com.microsoft.MatMulNBits"], 1);
+
+    for (const auto& node : graph.Nodes()) {
+      if (node.OpType() == "MatMulNBits") {
+        const auto& attrs = node.GetAttributes();
+        EXPECT_EQ(attrs.at("K").i(), K);
+        EXPECT_EQ(attrs.at("N").i(), N);
+        EXPECT_EQ(attrs.at("bits").i(), 4);
+        EXPECT_EQ(attrs.at("block_size").i(), block_size);
+        EXPECT_EQ(node.InputDefs().size(), static_cast<size_t>(4));
+      }
+    }
+    return Status::OK();
+  };
+
+  auto transformer = std::make_unique<DQMatMulNBitsFusion>(4);
+  ASSERT_STATUS_OK(TestGraphTransformer(build, 21, *logger_, std::move(transformer),
+                                        TransformerLevel::Level1, 1, pre_check, post_check));
+}
+
+TEST_F(DQMatMulNBitsFusionTest, Pattern1_MatMul_WithDefaultZP8) {
+  constexpr int64_t M = 4, N = 8, K = 32, block_size = 16;
+
+  auto build = [&](ModelTestBuilder& builder) {
+    BuildPattern1Graph(builder, M, N, K, block_size, true, false, false);
+  };
+
+  auto post_check = [&](Graph& graph) -> Status {
+    auto ops = CountOpsInGraphByDomain(graph);
+    EXPECT_EQ(ops["com.microsoft.MatMulNBits"], 1);
+    EXPECT_EQ(ops.count("DequantizeLinear"), 0);
+
+    for (const auto& node : graph.Nodes()) {
+      if (node.OpType() == "MatMulNBits") {
+        EXPECT_EQ(node.InputDefs().size(), static_cast<size_t>(3));
+      }
+    }
+    return Status::OK();
+  };
+
+  auto transformer = std::make_unique<DQMatMulNBitsFusion>(4);
+  ASSERT_STATUS_OK(TestGraphTransformer(build, 21, *logger_, std::move(transformer),
+                                        TransformerLevel::Level1, 1, nullptr, post_check));
+}
+
+TEST_F(DQMatMulNBitsFusionTest, Pattern1_MatMul_WithNonDefaultZP) {
+  constexpr int64_t M = 4, N = 8, K = 32, block_size = 16;
+  const int64_t num_blocks = K / block_size;
+
+  std::vector<uint8_t> zp_vals(static_cast<size_t>(N * num_blocks), 3);
+
+  auto build = [&](ModelTestBuilder& builder) {
+    BuildPattern1Graph(builder, M, N, K, block_size, true, false, false,
+                       nullptr, nullptr, &zp_vals);
+  };
+
+  auto post_check = [&](Graph& graph) -> Status {
+    auto ops = CountOpsInGraphByDomain(graph);
+    EXPECT_EQ(ops["com.microsoft.MatMulNBits"], 1);
+
+    for (const auto& node : graph.Nodes()) {
+      if (node.OpType() == "MatMulNBits") {
+        EXPECT_EQ(node.InputDefs().size(), static_cast<size_t>(4));
+      }
+    }
+    return Status::OK();
+  };
+
+  auto transformer = std::make_unique<DQMatMulNBitsFusion>(4);
+  ASSERT_STATUS_OK(TestGraphTransformer(build, 21, *logger_, std::move(transformer),
+                                        TransformerLevel::Level1, 1, nullptr, post_check));
+}
+
+TEST_F(DQMatMulNBitsFusionTest, Pattern1_MatMul_WithCast) {
+  constexpr int64_t M = 4, N = 8, K = 32, block_size = 16;
+
+  auto build = [&](ModelTestBuilder& builder) {
+    BuildPattern1Graph(builder, M, N, K, block_size, false, true, false);
+  };
+
+  auto post_check = [&](Graph& graph) -> Status {
+    auto ops = CountOpsInGraphByDomain(graph);
+    EXPECT_EQ(ops["com.microsoft.MatMulNBits"], 1);
+    EXPECT_EQ(ops.count("Cast"), 0);
+    EXPECT_EQ(ops.count("MatMul"), 0);
+    return Status::OK();
+  };
+
+  auto transformer = std::make_unique<DQMatMulNBitsFusion>(4);
+  ASSERT_STATUS_OK(TestGraphTransformer(build, 21, *logger_, std::move(transformer),
+                                        TransformerLevel::Level1, 1, nullptr, post_check));
+}
+
+TEST_F(DQMatMulNBitsFusionTest, Pattern1_Gemm_WithBias) {
+  constexpr int64_t M = 4, N = 8, K = 32, block_size = 16;
+
+  auto build = [&](ModelTestBuilder& builder) {
+    BuildPattern1GemmBiasGraph(builder, M, N, K, block_size, true);
+  };
+
+  auto post_check = [&](Graph& graph) -> Status {
+    auto ops = CountOpsInGraphByDomain(graph);
+    EXPECT_EQ(ops["com.microsoft.MatMulNBits"], 1);
+    EXPECT_EQ(ops.count("Gemm"), 0);
+
+    for (const auto& node : graph.Nodes()) {
+      if (node.OpType() == "MatMulNBits") {
+        EXPECT_GE(node.InputDefs().size(), static_cast<size_t>(6));
+        EXPECT_TRUE(node.InputDefs()[5] != nullptr);
+        EXPECT_TRUE(node.InputDefs()[5]->Exists());
+      }
+    }
+    return Status::OK();
+  };
+
+  auto transformer = std::make_unique<DQMatMulNBitsFusion>(4);
+  ASSERT_STATUS_OK(TestGraphTransformer(build, 21, *logger_, std::move(transformer),
+                                        TransformerLevel::Level1, 1, nullptr, post_check));
+}
+
+TEST_F(DQMatMulNBitsFusionTest, Pattern1_Gemm_NoZP) {
+  constexpr int64_t M = 4, N = 8, K = 32, block_size = 16;
+
+  auto build = [&](ModelTestBuilder& builder) {
+    BuildPattern1Graph(builder, M, N, K, block_size, false, false, true);
+  };
+
+  auto post_check = [&](Graph& graph) -> Status {
+    auto ops = CountOpsInGraphByDomain(graph);
+    EXPECT_EQ(ops["com.microsoft.MatMulNBits"], 1);
+    EXPECT_EQ(ops.count("Gemm"), 0);
+    return Status::OK();
+  };
+
+  auto transformer = std::make_unique<DQMatMulNBitsFusion>(4);
+  ASSERT_STATUS_OK(TestGraphTransformer(build, 21, *logger_, std::move(transformer),
+                                        TransformerLevel::Level1, 1, nullptr, post_check));
+}
+
+TEST_F(DQMatMulNBitsFusionTest, Pattern2_MatMul_NoZP) {
+  constexpr int64_t M = 4, N = 8, K = 32, block_size = 16;
+
+  auto build = [&](ModelTestBuilder& builder) {
+    BuildPattern2Graph(builder, M, N, K, block_size, false, false);
+  };
+
+  auto post_check = [&](Graph& graph) -> Status {
+    auto ops = CountOpsInGraphByDomain(graph);
+    EXPECT_EQ(ops.count("DequantizeLinear"), 0);
+    EXPECT_EQ(ops.count("MatMul"), 0);
+    EXPECT_EQ(ops["com.microsoft.MatMulNBits"], 1);
+
+    for (const auto& node : graph.Nodes()) {
+      if (node.OpType() == "MatMulNBits") {
+        EXPECT_EQ(node.GetAttributes().at("K").i(), K);
+        EXPECT_EQ(node.GetAttributes().at("N").i(), N);
+        EXPECT_EQ(node.InputDefs().size(), static_cast<size_t>(4));
+      }
+    }
+    return Status::OK();
+  };
+
+  auto transformer = std::make_unique<DQMatMulNBitsFusion>(4);
+  ASSERT_STATUS_OK(TestGraphTransformer(build, 21, *logger_, std::move(transformer),
+                                        TransformerLevel::Level1, 1, nullptr, post_check));
+}
+
+TEST_F(DQMatMulNBitsFusionTest, Pattern2_MatMul_WithDefaultZP8) {
+  constexpr int64_t M = 4, N = 8, K = 32, block_size = 16;
+
+  auto build = [&](ModelTestBuilder& builder) {
+    BuildPattern2Graph(builder, M, N, K, block_size, true, false);
+  };
+
+  auto post_check = [&](Graph& graph) -> Status {
+    auto ops = CountOpsInGraphByDomain(graph);
+    EXPECT_EQ(ops["com.microsoft.MatMulNBits"], 1);
+
+    for (const auto& node : graph.Nodes()) {
+      if (node.OpType() == "MatMulNBits") {
+        EXPECT_EQ(node.InputDefs().size(), static_cast<size_t>(3));
+      }
+    }
+    return Status::OK();
+  };
+
+  auto transformer = std::make_unique<DQMatMulNBitsFusion>(4);
+  ASSERT_STATUS_OK(TestGraphTransformer(build, 21, *logger_, std::move(transformer),
+                                        TransformerLevel::Level1, 1, nullptr, post_check));
+}
+
+TEST_F(DQMatMulNBitsFusionTest, Pattern2_Gemm_WithBias) {
+  constexpr int64_t M = 4, N = 8, K = 32, block_size = 16;
+
+  auto build = [&](ModelTestBuilder& builder) {
+    BuildPattern2GemmBiasGraph(builder, M, N, K, block_size, false);
+  };
+
+  auto post_check = [&](Graph& graph) -> Status {
+    auto ops = CountOpsInGraphByDomain(graph);
+    EXPECT_EQ(ops["com.microsoft.MatMulNBits"], 1);
+    EXPECT_EQ(ops.count("Gemm"), 0);
+
+    for (const auto& node : graph.Nodes()) {
+      if (node.OpType() == "MatMulNBits") {
+        EXPECT_GE(node.InputDefs().size(), static_cast<size_t>(6));
+      }
+    }
+    return Status::OK();
+  };
+
+  auto transformer = std::make_unique<DQMatMulNBitsFusion>(4);
+  ASSERT_STATUS_OK(TestGraphTransformer(build, 21, *logger_, std::move(transformer),
+                                        TransformerLevel::Level1, 1, nullptr, post_check));
+}
+
+TEST_F(DQMatMulNBitsFusionTest, Negative_Pattern1_WrongAxis) {
+  constexpr int64_t M = 4, N = 8, K = 32, block_size = 16;
+
+  auto build = [&](ModelTestBuilder& builder) {
+    BuildPattern1WrongAxis(builder, M, N, K, block_size);
+  };
+
+  auto post_check = [&](Graph& graph) -> Status {
+    auto ops = CountOpsInGraphByDomain(graph);
+    EXPECT_EQ(ops.count("com.microsoft.MatMulNBits"), 0);
+    EXPECT_EQ(ops["MatMul"], 1);
+    return Status::OK();
+  };
+
+  auto transformer = std::make_unique<DQMatMulNBitsFusion>(4);
+  ASSERT_STATUS_OK(TestGraphTransformer(build, 21, *logger_, std::move(transformer),
+                                        TransformerLevel::Level1, 1, nullptr, post_check));
+}
+
+TEST_F(DQMatMulNBitsFusionTest, Negative_Pattern2_NonConstWeight) {
+  constexpr int64_t M = 4, N = 8, K = 32, block_size = 16;
+
+  auto build = [&](ModelTestBuilder& builder) {
+    BuildPattern2NonConstWeight(builder, M, N, K, block_size);
+  };
+
+  auto post_check = [&](Graph& graph) -> Status {
+    auto ops = CountOpsInGraphByDomain(graph);
+    EXPECT_EQ(ops.count("com.microsoft.MatMulNBits"), 0);
+    EXPECT_EQ(ops["DequantizeLinear"], 1);
+    EXPECT_EQ(ops["MatMul"], 1);
+    return Status::OK();
+  };
+
+  auto transformer = std::make_unique<DQMatMulNBitsFusion>(4);
+  ASSERT_STATUS_OK(TestGraphTransformer(build, 21, *logger_, std::move(transformer),
+                                        TransformerLevel::Level1, 1, nullptr, post_check));
+}
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(DISABLE_CONTRIB_OPS)

--- a/onnxruntime/test/optimizer/graph_transform_utils_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_utils_test.cc
@@ -9,6 +9,7 @@
 #include "gtest/gtest.h"
 #include "core/optimizer/graph_transformer_utils.h"
 #include "core/session/inference_session.h"
+#include "core/session/onnxruntime_session_options_config_keys.h"
 
 using namespace ONNX_NAMESPACE;
 
@@ -67,6 +68,32 @@ TEST(GraphTransformerUtilsTests, TestGenerateGraphTransformers) {
   filtered_transformers = optimizer_utils::GenerateTransformers(TransformerLevel::Level2, {}, cpu_ep, logger,
                                                                 disabled);
   ASSERT_TRUE(filtered_transformers.size() == all_transformers.size() - 1);
+#endif
+}
+TEST(GraphTransformerUtilsTests, TestDQMatMulNBitsFusionConfigWithContribGating) {
+  SessionOptions session_options;
+  const auto status = session_options.config_options.AddConfigEntry(
+      kOrtSessionOptionsEnableDQMatMulNBitsFusion, "1");
+  ASSERT_TRUE(status.IsOK()) << status.ErrorMessage();
+
+  CPUExecutionProvider cpu_ep(CPUExecutionProviderInfo{});
+  const auto& logger = DefaultLoggingManager().DefaultLogger();
+
+#if defined(DISABLE_CONTRIB_OPS)
+  EXPECT_ANY_THROW({
+    std::ignore = optimizer_utils::GenerateTransformers(
+        TransformerLevel::Level1, session_options, cpu_ep, logger);
+  });
+#else
+  auto transformers = optimizer_utils::GenerateTransformers(
+      TransformerLevel::Level1, session_options, cpu_ep, logger);
+
+  const bool has_dq_matmulnbits_fusion =
+      std::any_of(transformers.begin(), transformers.end(), [](const auto& transformer) {
+        return transformer && transformer->Name() == "DQMatMulNBitsFusion";
+      });
+
+  EXPECT_TRUE(has_dq_matmulnbits_fusion);
 #endif
 }
 }  // namespace test


### PR DESCRIPTION
## Summary

Generalize the WebNN-specific DequantizeLinear → MatMulNBits graph fusion transformer so it can be
reused by other execution providers (e.g. NvTensorRTRTX), and add defensive shape/size validation
to prevent crashes on malformed tensors.

### Fusion patterns

**Pattern 1:** `DequantizeLinear → Reshape → Transpose → [Cast] → MatMul/Gemm`  →  **MatMulNBits**

**Pattern 2:** `DequantizeLinear (axis=0) → MatMul/Gemm`  →  **MatMulNBits**