### PR TITLE
Fix for Cuda Graph in pre-compiled path

### DIFF
--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
@@ -3328,6 +3328,14 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromPrecompiledEngine(const Gra
   auto trt_runtime_config = std::unique_ptr<nvinfer1::IRuntimeConfig>(trt_engine->createRuntimeConfig());
   if (trt_runtime_config && cuda_graph_enable_) {
     trt_runtime_config->setDynamicShapesKernelSpecializationStrategy(nvinfer1::DynamicShapesKernelSpecializationStrategy::kEAGER);
+#if TRT_MAJOR_RTX > 1 || (TRT_MAJOR_RTX == 1 && TRT_MINOR_RTX >= 3)
+    auto cuda_strategy_flag = trt_runtime_config->setCudaGraphStrategy(nvinfer1::CudaGraphStrategy::kWHOLE_GRAPH_CAPTURE);
+    LOGS_DEFAULT(INFO) << "[NvTensorRTRTX EP] CUDA graph strategy with RTX Graph capture enabled : " << cuda_strategy_flag;
+#else
+    LOGS_DEFAULT(WARNING) << "[NvTensorRTRTX EP] CUDA graph is enabled but RTX Graph capture is not available. "
+                          << "The current TRT RTX version does not support RTX Graph. "
+                          << "Please upgrade to TRT RTX >= 1.3 to use RTX Graph capture feature for optimal CUDA graph performance.";
+#endif
   }
   trt_runtime_config->setExecutionContextAllocationStrategy(nvinfer1::ExecutionContextAllocationStrategy::kUSER_MANAGED);
   std::string runtime_cache_file = "";


### PR DESCRIPTION
### Description
setCudaGraphStrategy(kWHOLE_GRAPH_CAPTURE) was present in the dynamic engine build path (CreateNodeComputeInfoFromGraph) but missing from the precompiled/AOT engine path (CreateNodeComputeInfoFromEPContext). Since TRT RTX defaults the CUDA Graph strategy to kDISABLED, CUDA Graph capture never occurred when loading precompiled engines. Applied the same setCudaGraphStrategy call (guarded by the existing TRT_MAJOR_RTX >= 1.3 version check) to the precompiled path to match the dynamic path behavior



### Motivation and Context
Fixes [#27329](https://github.com/microsoft/onnxruntime/issues/27329) — users reported that cudaGraphLaunch was not occurring when using precompiled (AOT-built) TensorRT-RTX engines, causing individual kernel launches and unnecessary CPU overhead instead of batched graph execution.


