### PR TITLE
Merge ConstantOfShape and Cast in clean_graph optimization

### DIFF
--- a/onnxruntime/python/tools/transformers/onnx_model_bert.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_bert.py
@@ -267,7 +267,7 @@ class BertOnnxModel(OnnxModel):
             #          |                                                     |
             #          |                                                     v
             #          +----> Shape --> Gather(indices=1) --> Unsqueeze--->  Concat --> ConstantOfShape -->Cast --> EmbedLayerNormaliation/ReduceSum
-            # After:
+            # After (Concat path simplified, Cast merged into ConstantOfShape):
             #  input_ids --> Shape --> ConstantOfShape --> EmbedLayerNormalization/ReduceSum
             op_input_id = {"EmbedLayerNormalization": 1, "ReduceSum": 0, "Attention": 3}
             if node.op_type in op_input_id:
@@ -300,20 +300,23 @@ class BertOnnxModel(OnnxModel):
                         # Merge ConstantOfShape → Cast: update the value attribute dtype
                         # so ConstantOfShape directly produces the target type.
                         cast_to_type = OnnxModel.get_node_attribute(cast, "to")
-                        if cast_to_type is not None:
-                            cos_value = constant_of_shape.attribute[0].t
-                            fill_val = numpy_helper.to_array(cos_value).flat[0]
+                        cos_tensor = OnnxModel.get_node_attribute(constant_of_shape, "value")
+                        if cast_to_type is not None and cos_tensor is not None:
+                            fill_val = numpy_helper.to_array(cos_tensor).flat[0]
                             np_dtype = helper.tensor_dtype_to_np_dtype(cast_to_type)
                             new_val = numpy_helper.from_array(np.array([fill_val], dtype=np_dtype))
-                            constant_of_shape.attribute[0].t.CopyFrom(new_val)
+                            for i, attr in enumerate(constant_of_shape.attribute):
+                                if attr.name == "value":
+                                    constant_of_shape.attribute[i].CopyFrom(helper.make_attribute("value", new_val))
+                                    break
                             self.replace_input_of_all_nodes(cast.output[0], constant_of_shape.output[0])
                             nodes_to_remove.append(cast)
 
                         output_name_to_node = self.output_name_to_node()
 
             if node.op_type == "Attention":
-                # Before:
-                #   input_ids --> Shape -->ConstantOfShape -->Cast --> ReduceSum --> Attention
+                # Before (Cast present or already merged into ConstantOfShape):
+                #   input_ids --> Shape --> ConstantOfShape [--> Cast] --> ReduceSum --> Attention
                 # After:
                 #   remove this path, and remove the optional mask_index input of Attention node.
                 parent_nodes = self.match_parent_path(
@@ -322,6 +325,14 @@ class BertOnnxModel(OnnxModel):
                     [3, 0, 0, 0],
                     output_name_to_node,
                 )
+                if parent_nodes is None:
+                    # Also try merged pattern (Cast already folded into ConstantOfShape).
+                    parent_nodes = self.match_parent_path(
+                        node,
+                        ["ReduceSum", "ConstantOfShape", "Shape"],
+                        [3, 0, 0],
+                        output_name_to_node,
+                    )
                 if parent_nodes is not None:
                     if parent_nodes[-1].input[0] == self.graph().input[0].name:
                         attention_node = helper.make_node(
@@ -332,7 +343,7 @@ class BertOnnxModel(OnnxModel):
                         )
                         attention_node.domain = "com.microsoft"
                         attention_node.attribute.extend([helper.make_attribute("num_heads", self.num_heads)])
-                        self.add_node(attention_node, self.get_graph_by_node(attention_node).name)
+                        self.add_node(attention_node, self.get_graph_by_node(node).name)
                         nodes_to_remove.append(node)
         self.remove_nodes(nodes_to_remove)
 

--- a/onnxruntime/test/python/transformers/test_clean_graph.py
+++ b/onnxruntime/test/python/transformers/test_clean_graph.py
@@ -43,21 +43,31 @@ def _make_constantofshape_cast_model():
 
     # Gather indices=0 (batch dim)
     gather_0_idx = numpy_helper.from_array(np.array(0, dtype=np.int64), name="gather_0_idx")
-    gather_0 = helper.make_node("Gather", inputs=["shape_out", "gather_0_idx"], outputs=["gather_0_out"], name="gather_0", axis=0)
+    gather_0 = helper.make_node(
+        "Gather", inputs=["shape_out", "gather_0_idx"], outputs=["gather_0_out"], name="gather_0", axis=0
+    )
 
     # Gather indices=1 (seq dim)
     gather_1_idx = numpy_helper.from_array(np.array(1, dtype=np.int64), name="gather_1_idx")
-    gather_1 = helper.make_node("Gather", inputs=["shape_out", "gather_1_idx"], outputs=["gather_1_out"], name="gather_1", axis=0)
+    gather_1 = helper.make_node(
+        "Gather", inputs=["shape_out", "gather_1_idx"], outputs=["gather_1_out"], name="gather_1", axis=0
+    )
 
     # Unsqueeze both
     unsqueeze_0_axes = numpy_helper.from_array(np.array([0], dtype=np.int64), name="unsqueeze_0_axes")
-    unsqueeze_0 = helper.make_node("Unsqueeze", inputs=["gather_0_out", "unsqueeze_0_axes"], outputs=["unsqueeze_0_out"], name="unsqueeze_0")
+    unsqueeze_0 = helper.make_node(
+        "Unsqueeze", inputs=["gather_0_out", "unsqueeze_0_axes"], outputs=["unsqueeze_0_out"], name="unsqueeze_0"
+    )
 
     unsqueeze_1_axes = numpy_helper.from_array(np.array([0], dtype=np.int64), name="unsqueeze_1_axes")
-    unsqueeze_1 = helper.make_node("Unsqueeze", inputs=["gather_1_out", "unsqueeze_1_axes"], outputs=["unsqueeze_1_out"], name="unsqueeze_1")
+    unsqueeze_1 = helper.make_node(
+        "Unsqueeze", inputs=["gather_1_out", "unsqueeze_1_axes"], outputs=["unsqueeze_1_out"], name="unsqueeze_1"
+    )
 
     # Concat
-    concat = helper.make_node("Concat", inputs=["unsqueeze_0_out", "unsqueeze_1_out"], outputs=["concat_out"], name="concat_0", axis=0)
+    concat = helper.make_node(
+        "Concat", inputs=["unsqueeze_0_out", "unsqueeze_1_out"], outputs=["concat_out"], name="concat_0", axis=0
+    )
 
     # ConstantOfShape with float value
     cos_value = numpy_helper.from_array(np.array([1.0], dtype=np.float32))
@@ -164,6 +174,119 @@ class TestCleanGraph(unittest.TestCase):
 
         cos_nodes = self._get_node_by_op(cleaned, "ConstantOfShape")
         self.assertEqual(len(cos_nodes), 1, "ConstantOfShape should remain")
+
+    def test_attention_mask_cleanup_after_cast_merge(self):
+        """Attention mask_index path should be removed even after Cast is merged.
+
+        When an Attention node consumes ReduceSum → Cast → ConstantOfShape → Shape
+        on input[3], the Cast merge fires first (folding Cast into ConstantOfShape).
+        The Attention cleanup must still match the post-merge pattern
+        (ReduceSum → ConstantOfShape → Shape) and remove the mask_index input.
+        """
+        batch_size = 2
+        seq_len = 8
+        hidden_size = 16
+
+        input_ids = helper.make_tensor_value_info("input_ids", TensorProto.INT64, [batch_size, seq_len])
+        attn_output = helper.make_tensor_value_info("attn_output", TensorProto.FLOAT, None)
+
+        # Shape → Gather → Unsqueeze → Concat → ConstantOfShape → Cast → ReduceSum
+        # (same mask path as _make_constantofshape_cast_model)
+        shape_node = helper.make_node("Shape", inputs=["input_ids"], outputs=["shape_out"], name="shape_0")
+
+        gather_0_idx = numpy_helper.from_array(np.array(0, dtype=np.int64), name="gather_0_idx")
+        gather_0 = helper.make_node(
+            "Gather", inputs=["shape_out", "gather_0_idx"], outputs=["gather_0_out"], name="gather_0", axis=0
+        )
+        gather_1_idx = numpy_helper.from_array(np.array(1, dtype=np.int64), name="gather_1_idx")
+        gather_1 = helper.make_node(
+            "Gather", inputs=["shape_out", "gather_1_idx"], outputs=["gather_1_out"], name="gather_1", axis=0
+        )
+
+        unsqueeze_0_axes = numpy_helper.from_array(np.array([0], dtype=np.int64), name="unsqueeze_0_axes")
+        unsqueeze_0 = helper.make_node(
+            "Unsqueeze", inputs=["gather_0_out", "unsqueeze_0_axes"], outputs=["unsqueeze_0_out"], name="unsqueeze_0"
+        )
+        unsqueeze_1_axes = numpy_helper.from_array(np.array([0], dtype=np.int64), name="unsqueeze_1_axes")
+        unsqueeze_1 = helper.make_node(
+            "Unsqueeze", inputs=["gather_1_out", "unsqueeze_1_axes"], outputs=["unsqueeze_1_out"], name="unsqueeze_1"
+        )
+
+        concat = helper.make_node(
+            "Concat", inputs=["unsqueeze_0_out", "unsqueeze_1_out"], outputs=["concat_out"], name="concat_0", axis=0
+        )
+
+        cos_value = numpy_helper.from_array(np.array([1.0], dtype=np.float32))
+        constant_of_shape = helper.make_node(
+            "ConstantOfShape", inputs=["concat_out"], outputs=["cos_out"], name="cos_0", value=cos_value
+        )
+        cast = helper.make_node("Cast", inputs=["cos_out"], outputs=["cast_out"], name="cast_0", to=TensorProto.INT64)
+        reduce_sum = helper.make_node(
+            "ReduceSum", inputs=["cast_out"], outputs=["reduce_sum_out"], name="reduce_sum_0", keepdims=0
+        )
+
+        # Dummy QKV initializers for Attention inputs[0:3]
+        qkv_data = numpy_helper.from_array(
+            np.zeros([batch_size, seq_len, hidden_size], dtype=np.float32), name="qkv_input"
+        )
+        weight_data = numpy_helper.from_array(np.zeros([hidden_size, hidden_size], dtype=np.float32), name="weight")
+        bias_data = numpy_helper.from_array(np.zeros([hidden_size], dtype=np.float32), name="bias")
+
+        # Attention node with mask_index at input[3]
+        attention = helper.make_node(
+            "Attention",
+            inputs=["qkv_input", "weight", "bias", "reduce_sum_out"],
+            outputs=["attn_output"],
+            name="attention_0",
+            num_heads=2,
+        )
+        attention.domain = "com.microsoft"
+
+        nodes = [
+            shape_node,
+            gather_0,
+            gather_1,
+            unsqueeze_0,
+            unsqueeze_1,
+            concat,
+            constant_of_shape,
+            cast,
+            reduce_sum,
+            attention,
+        ]
+        initializers = [
+            gather_0_idx,
+            gather_1_idx,
+            unsqueeze_0_axes,
+            unsqueeze_1_axes,
+            qkv_data,
+            weight_data,
+            bias_data,
+        ]
+
+        graph = helper.make_graph(nodes, "attention_mask_test", [input_ids], [attn_output], initializer=initializers)
+        model = helper.make_model(
+            graph,
+            opset_imports=[helper.make_opsetid("", 16), helper.make_opsetid("com.microsoft", 1)],
+        )
+
+        bert_model = BertOnnxModel(model, num_heads=2, hidden_size=hidden_size)
+        bert_model.clean_graph()
+        bert_model.prune_graph()
+        cleaned = bert_model.model
+
+        # Cast should be merged
+        cast_nodes = self._get_node_by_op(cleaned, "Cast")
+        self.assertEqual(len(cast_nodes), 0, "Cast node should be removed after merge")
+
+        # Attention node should have mask_index removed (3 inputs instead of 4)
+        attn_nodes = self._get_node_by_op(cleaned, "Attention")
+        self.assertEqual(len(attn_nodes), 1, "Should have exactly 1 Attention node")
+        self.assertEqual(
+            len(attn_nodes[0].input),
+            3,
+            f"Attention should have 3 inputs (mask removed), got {len(attn_nodes[0].input)}",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Resolve the TODO in `BertOnnxModel.clean_graph()` by folding the `Cast` node into `ConstantOfShape`
- Update the `value` attribute dtype so `ConstantOfShape` directly produces the target type
- Add first dedicated test suite for `clean_graph` with 3 tests

## Motivation
Fixes #27481

In the attention mask shape optimization path, `clean_graph()` simplifies a `Concat → Unsqueeze → Gather` chain to a direct `Shape → ConstantOfShape` connection, but leaves a redundant `ConstantOfShape(float) → Cast(to=int64)` sequence. The existing TODO (line 271) noted this should be merged.

## Changes
- **onnx_model_bert.py**: After the Concat path simplification, update `ConstantOfShape`'s `value` attribute to the Cast target dtype using `helper.tensor_dtype_to_np_dtype`, then redirect consumers from the Cast output to the ConstantOfShape output. The Cast node is collected for removal. (+2 imports: `numpy`, `numpy_helper`)
- **test_clean_graph.py** (new): 3 tests covering the merge (Cast removed, ConstantOfShape produces int64), fill value preservation (0 → int64(0)), and Concat path simplification (Concat/Gather pruned).

## Test Plan
- [x] 3 new tests pass: `python -m unittest test_clean_graph.TestCleanGraph -v`
- [x] Existing `test_attention_fusion` tests pass
- [x] `ruff check` clean on both files