### PR TITLE
[JS] Integrate with native RAII APIs

### DIFF
--- a/js/common/lib/inference-session-impl.ts
+++ b/js/common/lib/inference-session-impl.ts
@@ -126,8 +126,12 @@ export class InferenceSession implements InferenceSessionInterface {
     return returnValue;
   }
 
-  async release(): Promise<void> {
+  release(): Promise<void> {
     return this.handler.dispose();
+  }
+
+  [Symbol.asyncDispose](): Promise<void> {
+    return this.release();
   }
 
   static create(path: string, options?: SessionOptions): Promise<InferenceSessionInterface>;

--- a/js/common/lib/inference-session.ts
+++ b/js/common/lib/inference-session.ts
@@ -520,7 +520,7 @@ export declare namespace InferenceSession {
 /**
  * Represent a runtime instance of an ONNX model.
  */
-export interface InferenceSession {
+export interface InferenceSession extends AsyncDisposable {
   // #region run()
 
   /**

--- a/js/common/lib/tensor-impl.ts
+++ b/js/common/lib/tensor-impl.ts
@@ -542,6 +542,10 @@ export class Tensor implements TensorInterface {
     this.dataLocation = 'none';
   }
 
+  [Symbol.dispose](): void {
+    this.dispose();
+  }
+
   // #endregion
 
   // #region tensor utilities

--- a/js/common/lib/tensor.ts
+++ b/js/common/lib/tensor.ts
@@ -11,7 +11,7 @@ import { TryGetGlobalType } from './type-helper.js';
 /**
  * represent a basic tensor with specified dimensions and data type.
  */
-interface TypedTensorBase<T extends Tensor.Type> {
+interface TypedTensorBase<T extends Tensor.Type> extends Disposable {
   /**
    * Get the dimensions of the tensor.
    */

--- a/js/common/test/type-tests/tensor/create-using.ts
+++ b/js/common/test/type-tests/tensor/create-using.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { InferenceSession, Tensor } from 'onnxruntime-common';
+
+(async () => {
+  // Check that `await using` declarations work with `InferenceSession` (it implements `AsyncDisposable`).
+  // {type-tests}|pass
+  await using session = await InferenceSession.create(new ArrayBuffer(0));
+
+  // Check that `using` declarations work with `Tensor` (it implements `Disposable`).
+  // {type-tests}|pass
+  using tensor = new Tensor('float32', [1, 2, 3], [3]);
+})();

--- a/js/node/lib/binding.ts
+++ b/js/node/lib/binding.ts
@@ -26,7 +26,7 @@ export declare namespace Binding {
     shape: number[];
     type: number;
   }
-  export interface InferenceSession {
+  export interface InferenceSession extends AsyncDisposable {
     loadModel(modelPath: string, options: SessionOptions): void;
     loadModel(buffer: ArrayBuffer, byteOffset: number, byteLength: number, options: SessionOptions): void;
 


### PR DESCRIPTION
### Description

As the test showcases, this allow to use the native `using` operator with sessions and tensors.

### Motivation and Context

It allows to auto-dispose sessions and tensors a bit more easily via the `using` operator, just like you can in e.g. C#.

Fixes #26684.