### PR TITLE
Fix allocator lifetime in EP library plugin

### DIFF
--- a/include/onnxruntime/core/session/environment.h
+++ b/include/onnxruntime/core/session/environment.h
@@ -197,10 +197,6 @@ class Environment {
 
   Status RegisterAllocatorImpl(AllocatorPtr allocator);
   Status UnregisterAllocatorImpl(const OrtMemoryInfo& mem_info, bool error_if_not_found = true);
-  Status CreateSharedAllocatorImpl(const OrtEpDevice& ep_device,
-                                   const OrtMemoryInfo& memory_info, OrtAllocatorType allocator_type,
-                                   const OrtKeyValuePairs* allocator_options, OrtAllocator** allocator,
-                                   bool replace_existing);
 
   // Inserts (or assigns) a config entry into `config_entries_`. Locks `config_entries_mutex_`.
   void InsertOrAssignConfigEntry(std::string key, std::string value);
@@ -246,7 +242,7 @@ class Environment {
     // calls EpLibrary::Load
     // for each factory gets the OrtEpDevice instances and adds to execution_devices
     // internal_factory is set if this is an internal EP
-    static Status Create(std::unique_ptr<EpLibrary> library_in, std::unique_ptr<EpInfo>& out,
+    static Status Create(std::unique_ptr<EpLibrary> library_in, std::shared_ptr<EpInfo>& out,
                          const std::vector<EpFactoryInternal*>& internal_factories = {});
 
     // removes entries for this library from execution_devices
@@ -263,8 +259,18 @@ class Environment {
     EpInfo() = default;
   };
 
-  // registration name to EpInfo for library
-  std::unordered_map<std::string, std::unique_ptr<EpInfo>> ep_libraries_;
+  // Captures shared_ptr<EpInfo> in the allocator's deleter lambda to prevent the
+  // EP library from being unloaded while allocator wrappers still exist.
+  Status CreateSharedAllocatorImpl(const OrtEpDevice& ep_device,
+                                   const OrtMemoryInfo& memory_info, OrtAllocatorType allocator_type,
+                                   const OrtKeyValuePairs* allocator_options, OrtAllocator** allocator,
+                                   bool replace_existing,
+                                   std::shared_ptr<EpInfo> ep_info);
+
+  // Registration name to EpInfo for library.
+  // shared_ptr so that allocator deleters can prevent EpInfo (and its factory/library) from being
+  // destroyed while allocator wrappers still exist.
+  std::unordered_map<std::string, std::shared_ptr<EpInfo>> ep_libraries_;
 
   // combined set of OrtEpDevices for all registered OrtEpFactory instances
   // std::vector so we can use directly in GetEpDevices.

--- a/onnxruntime/core/session/environment.cc
+++ b/onnxruntime/core/session/environment.cc
@@ -547,7 +547,7 @@ Status Environment::RegisterExecutionProviderLibrary(const std::string& registra
 
   ORT_TRY {
     // create the EpInfo which loads the library if required
-    std::unique_ptr<EpInfo> ep_info = nullptr;
+    std::shared_ptr<EpInfo> ep_info = nullptr;
     ORT_RETURN_IF_ERROR(EpInfo::Create(std::move(ep_library), ep_info));
 
     // add the pointers to the OrtEpDevice instances to our global list
@@ -560,12 +560,12 @@ Status Environment::RegisterExecutionProviderLibrary(const std::string& registra
       // to blow away any custom allocators previously added by the user.
       if (ed->device_memory_info != nullptr) {
         ORT_RETURN_IF_ERROR(CreateSharedAllocatorImpl(*ed, *ed->device_memory_info, OrtDeviceAllocator, nullptr,
-                                                      nullptr, /*replace_existing*/ false));
+                                                      nullptr, /*replace_existing*/ false, ep_info));
       }
 
       if (ed->host_accessible_memory_info != nullptr) {
         ORT_RETURN_IF_ERROR(CreateSharedAllocatorImpl(*ed, *ed->host_accessible_memory_info, OrtDeviceAllocator,
-                                                      nullptr, nullptr, /*replace_existing*/ false));
+                                                      nullptr, nullptr, /*replace_existing*/ false, ep_info));
       }
     }
 
@@ -787,8 +787,22 @@ Status Environment::CreateSharedAllocator(const OrtEpDevice& ep_device,
   }
 
   std::lock_guard<std::mutex> lock{mutex_};
+
+  // Find the EpInfo that owns this factory so the allocator's deleter can prevent
+  // the EP library from being unloaded while allocator wrappers still exist.
+  std::shared_ptr<EpInfo> ep_info;
+  for (const auto& [name, info] : ep_libraries_) {
+    for (auto* f : info->factories) {
+      if (f == ep_device.ep_factory) {
+        ep_info = info;
+        break;
+      }
+    }
+    if (ep_info) break;
+  }
+
   return CreateSharedAllocatorImpl(ep_device, *memory_info, allocator_type, allocator_options, allocator_out,
-                                   /*replace_existing*/ true);
+                                   /*replace_existing*/ true, ep_info);
 }
 
 Status Environment::CreateSharedAllocatorImpl(const OrtEpDevice& ep_device,
@@ -796,7 +810,8 @@ Status Environment::CreateSharedAllocatorImpl(const OrtEpDevice& ep_device,
                                               OrtAllocatorType allocator_type,
                                               const OrtKeyValuePairs* allocator_options,
                                               OrtAllocator** allocator_out,
-                                              bool replace_existing) {
+                                              bool replace_existing,
+                                              std::shared_ptr<EpInfo> ep_info) {
   // NOTE: memory_info is guaranteed to come from the OrtEpDevice when this is called
 
   if (allocator_type == OrtAllocatorType::OrtArenaAllocator) {
@@ -838,9 +853,18 @@ Status Environment::CreateSharedAllocatorImpl(const OrtEpDevice& ep_device,
                            "EP library should be opaque to ORT");
   }
 
+  // Capture ep_info (shared_ptr) to prevent the EP library from being unloaded
+  // while this allocator wrapper exists. The OrtAllocatorUniquePtr may outlive the
+  // Environment if a session or tensor holds a shared_ptr<IAllocator>. Without this,
+  // ~EpInfo() would call EpLibrary::Unload() (destroying factories and dlclose-ing
+  // the .so) while the allocator deleter still needs to call ReleaseAllocator.
+  //
+  // If ep_info is null (e.g., allocator not from a registered EP library), fall back
+  // to capturing the factory pointer by value.
+  auto* ep_factory = ep_device.ep_factory;
   auto ort_allocator = OrtAllocatorUniquePtr(allocator,
-                                             [&ep_device](OrtAllocator* allocator) {
-                                               ep_device.ep_factory->ReleaseAllocator(ep_device.ep_factory, allocator);
+                                             [ep_factory, ep_info](OrtAllocator* allocator) {
+                                               ep_factory->ReleaseAllocator(ep_factory, allocator);
                                              });
 
   shared_ort_allocators_.insert(allocator);
@@ -867,13 +891,13 @@ Status Environment::ReleaseSharedAllocator(const OrtEpDevice& ep_device, OrtDevi
   return status;
 }
 
-Status Environment::EpInfo::Create(std::unique_ptr<EpLibrary> library_in, std::unique_ptr<EpInfo>& out,
+Status Environment::EpInfo::Create(std::unique_ptr<EpLibrary> library_in, std::shared_ptr<EpInfo>& out,
                                    const std::vector<EpFactoryInternal*>& internal_factories) {
   if (!library_in) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "EpLibrary was null");
   }
 
-  out.reset(new EpInfo());  // can't use make_unique with private ctor
+  out.reset(new EpInfo());  // can't use make_shared with private ctor
   EpInfo& instance = *out;
   instance.library = std::move(library_in);
   instance.internal_factories = internal_factories;


### PR DESCRIPTION
### Description

This PR changes `ep_info` from `unique_ptr<EpInfo>` to `shared_ptr<EpInfo>` and captures `ep_info` by value in the `OrtAllocatorUniquePtr` deleter lambda inside `CreateSharedAllocatorImpl` to fix a lifetime issue that can cause a non-deterministic segfault: https://github.com/microsoft/onnxruntime/blob/46126133442d08cfcf98267702e602434b4f3578/onnxruntime/core/session/environment.cc#L841

### Motivation and Context

When a session or tensor holds a `shared_ptr<IAllocator>` past `Environment` destruction, the allocator's deleter may fire after `~EpInfo()` has called `EpLibrary::Unload()`, releasing the ep factory and dlclosing the plugin `.so`. At that point `ep_factory` captured in the `OrtAllocatorUniquePtr` lambda points into freed memory, making the `ReleaseAllocator` call in the deleter a use-after-free.

As `Tensor` stores the allocator as `buffer_deleter_` (a `shared_ptr<IAllocator>`) to free its buffer on destruction, this could happen: e.g. in Python, `OrtValue` could outlive the `Environment` and the GC could trigger this behaviour.


