### PR TITLE
[CXX Lora] Prevent heap OOB from maliciously crafted Lora Adapters.

### DIFF
--- a/onnxruntime/lora/adapter_format_utils.cc
+++ b/onnxruntime/lora/adapter_format_utils.cc
@@ -150,18 +150,32 @@ struct ReadDataForBigEndian {
 std::pair<std::string, OrtValue> CreateOrtValueOverLoraParameter(const Parameter& param) {
   OrtValue result;
 
+  const auto* param_name = param.name();
+  ORT_ENFORCE(param_name != nullptr, "Lora Parameter: name is missing");
+
   std::string name;
-  LoadStringFromLoraFormat(name, param.name());
+  LoadStringFromLoraFormat(name, param_name);
 
   const auto data_type = param.data_type();
+  ORT_ENFORCE(data_type != TensorDataType::UNDEFINED,
+              "Lora Param '", name, "': data_type is UNDEFINED");
+
+  const auto* dims = param.dims();
+  ORT_ENFORCE(dims != nullptr && dims->size() > 0,
+              "Lora Param '", name, "': dims is missing or empty");
+
+  const auto* raw_data = param.raw_data();
+  ORT_ENFORCE(raw_data != nullptr,
+              "Lora Param '", name, "': raw_data is missing");
+
   // Copying shape takes care of endianess using flatbuffers accessors
-  TensorShapeVector shape(param.dims()->begin(), param.dims()->end());
+  TensorShapeVector shape(dims->begin(), dims->end());
   TensorShape tensor_shape(shape);
   const auto elem_type = DataTypeImpl::TensorTypeFromONNXEnum(static_cast<int32_t>(data_type))->GetElementType();
   const size_t expected_raw_data_size = SafeInt<size_t>(tensor_shape.Size()) * elem_type->Size();
-  if (param.raw_data()->size() != expected_raw_data_size) {
+  if (raw_data->size() != expected_raw_data_size) {
     ORT_THROW("Lora Param '", name,
-              "': raw_data size (", param.raw_data()->size(),
+              "': raw_data size (", raw_data->size(),
               ") does not match expected size (", expected_raw_data_size,
               ") calculated from tensor shape and element type");
   }
@@ -177,7 +191,7 @@ std::pair<std::string, OrtValue> CreateOrtValueOverLoraParameter(const Parameter
       // const_cast is necessary due to Tensor class API
       Tensor::InitOrtValue(elem_type,
                            tensor_shape,
-                           const_cast<uint8_t*>(param.raw_data()->data()),
+                           const_cast<uint8_t*>(raw_data->data()),
                            cpu_meminfo,
                            result);
     }
@@ -185,7 +199,7 @@ std::pair<std::string, OrtValue> CreateOrtValueOverLoraParameter(const Parameter
     // const_cast is necessary due to Tensor class API
     Tensor::InitOrtValue(elem_type,
                          tensor_shape,
-                         const_cast<uint8_t*>(param.raw_data()->data()),
+                         const_cast<uint8_t*>(raw_data->data()),
                          cpu_meminfo,
                          result);
   }

--- a/onnxruntime/test/lora/lora_test.cc
+++ b/onnxruntime/test/lora/lora_test.cc
@@ -174,6 +174,20 @@ struct TestDataType {
   }
 };
 
+// Helper that wraps a single Parameter offset into a finished Adapter flatbuffer
+// and returns a pointer to the deserialized Parameter.
+// The FlatBufferBuilder must outlive the returned pointer.
+const adapters::Parameter* BuildAdapterAndGetParam(flatbuffers::FlatBufferBuilder& fbb,
+                                                   flatbuffers::Offset<adapters::Parameter> param_offset) {
+  auto params_offset = fbb.CreateVector(&param_offset, 1);
+  auto adapter_offset = adapters::CreateAdapter(
+      fbb, adapters::kAdapterFormatVersion, kAdapterVersion, kModelVersion, params_offset);
+  adapters::FinishAdapterBuffer(fbb, adapter_offset);
+
+  const auto* adapter = adapters::GetAdapter(fbb.GetBufferPointer());
+  return adapter->parameters()->Get(0);
+}
+
 }  // namespace
 
 TEST(LoraAdapterTest, Load) {
@@ -339,6 +353,93 @@ TEST(LoraAdapterTest, Load_RawDataSizeMismatch) {
 
   lora::LoraAdapter adapter;
   ASSERT_THROW(adapter.Load(std::move(buffer)), OnnxRuntimeException);
+}
+
+TEST(LoraAdapterTest, CreateOrtValueOverLoraParameter_MissingName) {
+  // Parameter with null name should throw gracefully.
+  flatbuffers::FlatBufferBuilder fbb;
+
+  std::vector<int64_t> dims = {2, 2};
+  std::vector<uint8_t> raw_data(16, 0);  // 2*2 floats = 16 bytes
+
+  // name is nullptr, all other fields are valid
+  auto param_offset = adapters::CreateParameterDirect(
+      fbb, /*name=*/nullptr, &dims, adapters::TensorDataType::FLOAT, &raw_data);
+
+  const auto* param = BuildAdapterAndGetParam(fbb, param_offset);
+  ASSERT_NE(param, nullptr);
+  ASSERT_EQ(param->name(), nullptr);
+
+  ASSERT_THROW(adapters::utils::CreateOrtValueOverLoraParameter(*param), OnnxRuntimeException);
+}
+
+TEST(LoraAdapterTest, CreateOrtValueOverLoraParameter_MissingDims) {
+  // Parameter with null dims should throw gracefully.
+  flatbuffers::FlatBufferBuilder fbb;
+
+  std::vector<uint8_t> raw_data(16, 0);
+
+  // dims is nullptr
+  auto param_offset = adapters::CreateParameterDirect(
+      fbb, "no_dims_param", /*dims=*/nullptr, adapters::TensorDataType::FLOAT, &raw_data);
+
+  const auto* param = BuildAdapterAndGetParam(fbb, param_offset);
+  ASSERT_NE(param, nullptr);
+  ASSERT_EQ(param->dims(), nullptr);
+
+  ASSERT_THROW(adapters::utils::CreateOrtValueOverLoraParameter(*param), OnnxRuntimeException);
+}
+
+TEST(LoraAdapterTest, CreateOrtValueOverLoraParameter_EmptyDims) {
+  // Parameter with an empty dims vector should throw gracefully.
+  flatbuffers::FlatBufferBuilder fbb;
+
+  std::vector<int64_t> empty_dims;
+  std::vector<uint8_t> raw_data(16, 0);
+
+  auto param_offset = adapters::CreateParameterDirect(
+      fbb, "empty_dims_param", &empty_dims, adapters::TensorDataType::FLOAT, &raw_data);
+
+  const auto* param = BuildAdapterAndGetParam(fbb, param_offset);
+  ASSERT_NE(param, nullptr);
+  ASSERT_EQ(param->dims()->size(), 0u);
+
+  ASSERT_THROW(adapters::utils::CreateOrtValueOverLoraParameter(*param), OnnxRuntimeException);
+}
+
+TEST(LoraAdapterTest, CreateOrtValueOverLoraParameter_MissingRawData) {
+  // Parameter with null raw_data should throw gracefully.
+  flatbuffers::FlatBufferBuilder fbb;
+
+  std::vector<int64_t> dims = {2, 2};
+
+  // raw_data is nullptr
+  auto param_offset = adapters::CreateParameterDirect(
+      fbb, "no_data_param", &dims, adapters::TensorDataType::FLOAT, /*raw_data=*/nullptr);
+
+  const auto* param = BuildAdapterAndGetParam(fbb, param_offset);
+  ASSERT_NE(param, nullptr);
+  ASSERT_EQ(param->raw_data(), nullptr);
+
+  ASSERT_THROW(adapters::utils::CreateOrtValueOverLoraParameter(*param), OnnxRuntimeException);
+}
+
+TEST(LoraAdapterTest, CreateOrtValueOverLoraParameter_UndefinedDataType) {
+  // Parameter with UNDEFINED data_type should throw gracefully.
+  flatbuffers::FlatBufferBuilder fbb;
+
+  std::vector<int64_t> dims = {2, 2};
+  std::vector<uint8_t> raw_data(16, 0);
+
+  // data_type defaults to UNDEFINED when not set
+  auto param_offset = adapters::CreateParameterDirect(
+      fbb, "undef_type_param", &dims, adapters::TensorDataType::UNDEFINED, &raw_data);
+
+  const auto* param = BuildAdapterAndGetParam(fbb, param_offset);
+  ASSERT_NE(param, nullptr);
+  ASSERT_EQ(param->data_type(), adapters::TensorDataType::UNDEFINED);
+
+  ASSERT_THROW(adapters::utils::CreateOrtValueOverLoraParameter(*param), OnnxRuntimeException);
 }
 
 #ifdef USE_CUDA


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Detect and test mismatch between raw data size and declared data type and shape of the lora adapter parameter.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Disallow maliciously crafted lora adapters leading to heap OOB.

