### PR TITLE
Remove CMake HAS_ARRAY_BOUNDS variable.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -610,7 +610,6 @@ else()
   check_cxx_compiler_flag(-Wambiguous-reversed-operator HAS_AMBIGUOUS_REVERSED_OPERATOR)
   # -Winterference-size was added in GCC 13
   check_cxx_compiler_flag(-Winterference-size HAS_INTERFERENCE_SIZE)
-  check_cxx_compiler_flag(-Warray-bounds HAS_ARRAY_BOUNDS)
   check_cxx_compiler_flag(-Wbitwise-instead-of-logical HAS_BITWISE_INSTEAD_OF_LOGICAL)
   check_cxx_compiler_flag(-Wcast-function-type HAS_CAST_FUNCTION_TYPE)
   check_cxx_compiler_flag(-Wcatch-value HAS_CATCH_VALUE)

--- a/cmake/onnxruntime_config.h.in
+++ b/cmake/onnxruntime_config.h.in
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#cmakedefine HAS_ARRAY_BOUNDS
 #cmakedefine HAS_BITWISE_INSTEAD_OF_LOGICAL
 #cmakedefine HAS_CAST_FUNCTION_TYPE
 #cmakedefine HAS_CATCH_VALUE

--- a/include/onnxruntime/core/framework/int2.h
+++ b/include/onnxruntime/core/framework/int2.h
@@ -7,7 +7,6 @@
 #include <type_traits>
 #include "core/common/common.h"
 #include <gsl/gsl>
-#include "onnxruntime_config.h"
 
 namespace onnxruntime {
 
@@ -140,12 +139,12 @@ struct Int2x4Base {
     // Process complete groups of 4 elements
 
     for (; dst_i < full_quads; dst_i++) {
-#if defined(__GNUC__) && defined(HAS_ARRAY_BOUNDS)
+#if defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
 #endif
       dst[dst_i] = Int2x4Base<Signed>(src[src_i], src[src_i + 1], src[src_i + 2], src[src_i + 3]);
-#if defined(__GNUC__) && defined(HAS_ARRAY_BOUNDS)
+#if defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
       src_i += 4;


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Remove CMake `HAS_ARRAY_BOUNDS` variable. Just assume that `-Warray-bounds` is available for Clang and GCC.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

The assumption is that `-Warray-bounds` is supported by GCC and Clang versions that we care about.

We specify a minimum version of GCC 11.1, which supports it. We don't specify a minimum version of Clang, but it has been supported since at least Clang 3.0.0.

https://godbolt.org/z/vTaejqsGv

Follow up to #27449 and #27454