### PR TITLE
Skip building custom_op_library if CUDA_MINIMAL is enabled 

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -1786,7 +1786,7 @@ endif()
   endif()
 endif()
 
-if (NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+if (NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten" AND NOT onnxruntime_CUDA_MINIMAL)
 
   set(custom_op_src_patterns
     "${TEST_SRC_DIR}/testdata/custom_op_library/*.h"


### PR DESCRIPTION
### Description
Skip building `custom_op_library` library if CUDA_MINIMAL is enabled 



### Motivation and Context
https://github.com/microsoft/onnxruntime/pull/27308 removes cudnn include for `custom_op_library` target in cmake if CUDA_MINIMAL is enabled. 

In fact, the `custom_op_library` target does not define the `USE_CUDA_MINIMAL ` macro (no
`target_compile_definitions(custom_op_library PRIVATE -DUSE_CUDA_MINIMAL)` in onnxruntime_unittests.cmake), so one of the files, i.e. cuda_context.h included in cuda_ops.cc still includes cudnn.h and the CI just got lucky to pass becasue cudnn.h is in --cuda_home. If building locally, it might fail to find cudnn.h.


