### PR TITLE
[js/rn] Add 16KB page size alignment for Android

### DIFF
--- a/js/react_native/android/CMakeLists.txt
+++ b/js/react_native/android/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(OnnxruntimeJSI)
 cmake_minimum_required(VERSION 3.13)
+project(OnnxruntimeJSI)
 
 set(PACKAGE_NAME "onnxruntime-react-native")
 set(BUILD_DIR ${CMAKE_SOURCE_DIR}/build)


### PR DESCRIPTION
### Description

Added the `-Wl,-z,max-page-size=16384` linker flag to the `onnxruntimejsi` target in `js/react_native/android/CMakeLists.txt` to support **16KB memory page sizes**.

### **Motivation and Context**

Starting with **Android 15**, Google Play requires apps to be compatible with 16KB page size devices.

By default, the Android NDK builds shared libraries with 4KB ELF segment alignment. Without this explicit flag, `libonnxruntimejsi.so` fails the Play Store's 16KB alignment check, leading to potential crashes or installation failures on supported hardware.

### **Changes**

- Updated `js/react_native/android/CMakeLists.txt`.
- Applied `target_link_options` to `onnxruntimejsi` to enforce `max-page-size=16384` (16KB).

### **References**

- [[Android Developer Guide: Support 16 KB page sizes](https://developer.android.com/guide/practices/page-sizes#fix-cmake)](https://developer.android.com/guide/practices/page-sizes#fix-cmake)

@fs-eire 