### PR TITLE
[QDQ] Fix cleanup of Q->DQ/DQ->Q pairs with multiple downstream nodes

### DIFF
--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_final_cleanup.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_final_cleanup.cc
@@ -47,14 +47,9 @@ bool CleanUpNodeSequence(NodeSequence node_sequence_type, Graph& graph, NodeInde
       return graph.GetConstantInitializer(initializer_name, true);
     };
 
-    const bool produces_graph_output = graph.NodeProducesGraphOutput(*second_node_ptr);
-    const auto output_edges_count = second_node_ptr->GetOutputEdgesCount();
-
     if (!match_second(*second_node_ptr) ||
         !QDQ::IsQDQPairSupported(graph, first_node, *second_node_ptr, get_constant_initializer,
-                                 graph.ModelPath(), false) ||
-        (produces_graph_output && output_edges_count != 0) ||
-        (!produces_graph_output && output_edges_count != 1)) {
+                                 graph.ModelPath(), false)) {
       return false;
     }
   }
@@ -77,8 +72,6 @@ bool CleanUpNodeSequence(NodeSequence node_sequence_type, Graph& graph, NodeInde
     // src node or graph input/initializer -> first_node -> second_node -> downstream node or graph output
     NodeIndex src_node_idx = 0;
     int src_arg_idx = -1;
-    NodeIndex downstream_node_idx = 0;
-    int downstream_arg_idx = -1;
 
     // input could be node or initializer/graph input so need to handle both.
     // if it's a node we need to replace the edge, so need info on which output idx it was attached to on the src node.
@@ -97,31 +90,33 @@ bool CleanUpNodeSequence(NodeSequence node_sequence_type, Graph& graph, NodeInde
     // both DQ and Q are single input single output so src idx and dest idx must be 0
     graph.RemoveEdge(first_node.Index(), second_node.Index(), 0, 0);
 
-    if (!produces_graph_output) {
-      // remove edge to downstream node
-      const Node::EdgeEnd& output_edge = *second_node.OutputEdgesBegin();
-      downstream_node_idx = output_edge.GetNode().Index();
-      downstream_arg_idx = output_edge.GetDstArgIndex();
+    // handle downstream edges
+    std::vector<std::tuple<NodeIndex, int>> downstream_edges;
+    downstream_edges.reserve(second_node.GetOutputEdgesCount());
 
-      // source arg idx is 0 as Q/DQ only has one output
+    for (auto it = second_node.OutputEdgesBegin(), end = second_node.OutputEdgesEnd(); it != end; ++it) {
+      const Node::EdgeEnd& output_edge = *it;
+      downstream_edges.emplace_back(output_edge.GetNode().Index(), output_edge.GetDstArgIndex());
+    }
+
+    for (const auto& [downstream_node_idx, downstream_arg_idx] : downstream_edges) {
       graph.RemoveEdge(second_node.Index(), downstream_node_idx, 0, downstream_arg_idx);
 
-      // replace input on downstream node
       Node& downstream_node = *graph.GetNode(downstream_node_idx);
       downstream_node.MutableInputDefs()[downstream_arg_idx] = first_node.MutableInputDefs()[0];
 
-      // create edge between src_node (if available) and downstream node
       if (input_edge) {
         graph.AddEdge(src_node_idx, downstream_node_idx, src_arg_idx, downstream_arg_idx);
       }
-    } else {
+    }
+
+    // handle graph output
+    if (produces_graph_output) {
       NodeArg* graph_output_nodearg = second_node.MutableOutputDefs()[0];
       if (src_arg_idx >= 0 && second_node_ptrs.size() == 1) {
-        // update the src node to produce the graph output that was being provided by second_node
         Node& src_node = *graph.GetNode(src_node_idx);
         src_node.MutableOutputDefs()[src_arg_idx] = graph_output_nodearg;
       } else {
-        // add Identity node to connect the graph input or initializer to the graph output.
         Node& id_node = graph.AddNode(graph.GenerateNodeName("QDQFinalCleanupTransformer"),
                                       "Identity", "", {first_node.MutableInputDefs()[0]}, {graph_output_nodearg});
         id_node.SetExecutionProviderType(second_node.GetExecutionProviderType());

--- a/onnxruntime/test/optimizer/qdq_transformer_test.cc
+++ b/onnxruntime/test/optimizer/qdq_transformer_test.cc
@@ -5283,6 +5283,177 @@ TEST(QDQTransformerTests, QDQFinalCleanupTransformer_BasicDQQsCleanup) {
 #endif
 }
 
+// test removal of Q->DQ or DQ->Q pair where the second node has multiple downstream nodes
+// by QDQFinalCleanupTransformer
+TEST(QDQTransformerTests, QDQFinalCleanupTransformer_QDQMultipleDownstream) {
+  // is_q_dq=true:  float Input -> Q -> DQ -> Transpose1 -> Output1
+  //                                       -> Transpose2 -> Output2
+  // is_q_dq=false: uint8 Input -> DQ -> Q -> Transpose1 -> Output1
+  //                                       -> Transpose2 -> Output2
+  // After cleanup, the Q->DQ or DQ->Q pair should be removed.
+  auto test_case = [&](bool is_q_dq, bool use_contrib_qdq) {
+    auto build_test_case = [&](ModelTestBuilder& builder) {
+      NodeArg* pair_input = nullptr;
+      if (is_q_dq) {
+        pair_input = builder.MakeInput<float>({1, 2, 4}, -1.f, 1.f);
+      } else {
+        pair_input = builder.MakeInput<uint8_t>({1, 2, 4},
+                                                std::numeric_limits<uint8_t>::min(),
+                                                std::numeric_limits<uint8_t>::max());
+      }
+
+      // Build Q->DQ or DQ->Q pair; pair_output is the output of the second node.
+      NodeArg* pair_output = nullptr;
+      if (is_q_dq) {
+        auto* q_output = builder.MakeIntermediate();
+        builder.AddQuantizeLinearNode<uint8_t>(pair_input, 0.05f, 128, q_output, use_contrib_qdq);
+        auto* dq_output = builder.MakeIntermediate();
+        builder.AddDequantizeLinearNode<uint8_t>(q_output, 0.05f, 128, dq_output, use_contrib_qdq);
+        pair_output = dq_output;
+      } else {
+        auto* dq_output = builder.MakeIntermediate();
+        builder.AddDequantizeLinearNode<uint8_t>(pair_input, 0.05f, 128, dq_output, use_contrib_qdq);
+        auto* q_output = builder.MakeIntermediate();
+        builder.AddQuantizeLinearNode<uint8_t>(dq_output, 0.05f, 128, q_output, use_contrib_qdq);
+        pair_output = q_output;
+      }
+
+      auto* output1 = builder.MakeOutput();
+      builder.AddNode("Transpose", {pair_output}, {output1});
+      auto* output2 = builder.MakeOutput();
+      builder.AddNode("Transpose", {pair_output}, {output2});
+    };
+
+    auto check_graph = [use_contrib_qdq](InferenceSessionWrapper& session) {
+      auto op_to_count = CountOpsInGraph(session.GetGraph());
+      const QDQOpKeys qdq_keys = GetQDQOpKeys(use_contrib_qdq);
+      EXPECT_EQ(op_to_count[qdq_keys.quantize_linear], 0);
+      EXPECT_EQ(op_to_count[qdq_keys.dequantize_linear], 0);
+      EXPECT_EQ(op_to_count["Transpose"], 2);
+    };
+
+    auto add_session_options = [is_q_dq](SessionOptions& so) {
+      if (!is_q_dq) {
+        // The function EnsureUniqueDQForEachExplicitOutputEdge does not account for this particular case. Disable it
+        // to prevent test failures.
+        ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsDisableQuantQDQ, "1"));
+      }
+      ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsEnableQuantQDQCleanup, "1"));
+    };
+
+    TransformerTester(build_test_case,
+                      check_graph,
+                      TransformerLevel::Level1,
+                      TransformerLevel::Level2,
+                      12 /*opset_version*/,
+                      0.025f /*per_sample_tolerance*/,
+                      0.01f /*relative_per_sample_tolerance*/,
+                      std::make_unique<QDQFinalCleanupTransformer>(true /*enable_q_dq_cleanup*/),
+                      add_session_options);
+    TransformerTester(build_test_case,
+                      check_graph,
+                      TransformerLevel::Level1,
+                      TransformerLevel::Level2,
+                      18 /*opset_version*/,
+                      0.025f /*per_sample_tolerance*/,
+                      0.01f /*relative_per_sample_tolerance*/,
+                      std::make_unique<QDQFinalCleanupTransformer>(true /*enable_q_dq_cleanup*/),
+                      add_session_options);
+    TransformerTester(build_test_case,
+                      check_graph,
+                      TransformerLevel::Level1,
+                      TransformerLevel::Level2,
+                      19 /*opset_version*/,
+                      0.025f /*per_sample_tolerance*/,
+                      0.01f /*relative_per_sample_tolerance*/,
+                      std::make_unique<QDQFinalCleanupTransformer>(true /*enable_q_dq_cleanup*/),
+                      add_session_options);
+  };
+
+  test_case(true, false);
+  test_case(false, false);
+
+#if !defined(DISABLE_CONTRIB_OPS)
+  test_case(true, true);
+  test_case(false, true);
+#endif
+}
+
+// test removal when second_node produces graph output AND has downstream nodes
+TEST(QDQTransformerTests, QDQFinalCleanupTransformer_QDQMultipleDownstreamWithGraphOutput) {
+  auto test_case = [](bool is_q_dq, bool use_contrib_qdq) {
+    auto build_test_case = [&](ModelTestBuilder& builder) {
+      NodeArg* pair_input = is_q_dq ? builder.MakeInput<float>({1, 2, 4}, -1.f, 1.f)
+                                    : builder.MakeInput<uint8_t>({1, 2, 4}, 0, 255);
+
+      auto* q_or_dq_output = builder.MakeIntermediate();
+      auto* pair_output = builder.MakeOutput();
+
+      if (is_q_dq) {
+        builder.AddQuantizeLinearNode<uint8_t>(pair_input, 0.05f, 128, q_or_dq_output, use_contrib_qdq);
+        builder.AddDequantizeLinearNode<uint8_t>(q_or_dq_output, 0.05f, 128, pair_output, use_contrib_qdq);
+      } else {
+        builder.AddDequantizeLinearNode<uint8_t>(pair_input, 0.05f, 128, q_or_dq_output, use_contrib_qdq);
+        builder.AddQuantizeLinearNode<uint8_t>(q_or_dq_output, 0.05f, 128, pair_output, use_contrib_qdq);
+      }
+
+      auto* downstream_output = builder.MakeOutput();
+      builder.AddNode("Transpose", {pair_output}, {downstream_output});
+    };
+
+    auto check_graph = [use_contrib_qdq](InferenceSessionWrapper& session) {
+      auto op_to_count = CountOpsInGraph(session.GetGraph());
+      const QDQOpKeys qdq_keys = GetQDQOpKeys(use_contrib_qdq);
+      EXPECT_EQ(op_to_count[qdq_keys.quantize_linear], 0);
+      EXPECT_EQ(op_to_count[qdq_keys.dequantize_linear], 0);
+      EXPECT_EQ(op_to_count["Identity"], 1);
+      EXPECT_EQ(op_to_count["Transpose"], 1);
+    };
+
+    auto add_session_options = [is_q_dq](SessionOptions& so) {
+      if (!is_q_dq) {
+        ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsDisableQuantQDQ, "1"));
+      }
+      ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsEnableQuantQDQCleanup, "1"));
+    };
+
+    TransformerTester(build_test_case,
+                      check_graph,
+                      TransformerLevel::Level1,
+                      TransformerLevel::Level2,
+                      12 /*opset_version*/,
+                      0.025f /*per_sample_tolerance*/,
+                      0.01f /*relative_per_sample_tolerance*/,
+                      std::make_unique<QDQFinalCleanupTransformer>(true /*enable_q_dq_cleanup*/),
+                      add_session_options);
+    TransformerTester(build_test_case,
+                      check_graph,
+                      TransformerLevel::Level1,
+                      TransformerLevel::Level2,
+                      18 /*opset_version*/,
+                      0.025f /*per_sample_tolerance*/,
+                      0.01f /*relative_per_sample_tolerance*/,
+                      std::make_unique<QDQFinalCleanupTransformer>(true /*enable_q_dq_cleanup*/),
+                      add_session_options);
+    TransformerTester(build_test_case,
+                      check_graph,
+                      TransformerLevel::Level1,
+                      TransformerLevel::Level2,
+                      19 /*opset_version*/,
+                      0.025f /*per_sample_tolerance*/,
+                      0.01f /*relative_per_sample_tolerance*/,
+                      std::make_unique<QDQFinalCleanupTransformer>(true /*enable_q_dq_cleanup*/),
+                      add_session_options);
+  };
+
+  test_case(true, false);
+  test_case(false, false);
+#if !defined(DISABLE_CONTRIB_OPS)
+  test_case(true, true);
+  test_case(false, true);
+#endif
+}
+
 // test removal when we have graph input -> Q/DQ pair -> graph output
 TEST(QDQTransformerTests, QDQFinalCleanupTransformer_GraphInputToOutput) {
   auto test_case = [](bool is_q_dq, bool use_contrib_qdq) {


### PR DESCRIPTION
### Description
Remove the condition output_edges_count in qdq_final_cleanup.

### Motivation and Context
The QDQFinalCleanupTransformer incorrectly skipped cleanup when the second node in a Q->DQ or DQ->Q pair had more than one output edge. Remove the single-output restriction and extend the downstream edge handling to iterate over all output edges of the second node, so every downstream consumer is correctly rewired to the upstream source.