### PR TITLE
[EP API] support OpKernelInfo::GetConfigOptions for adapter

### DIFF
--- a/include/onnxruntime/ep/adapter/op_kernel_info.h
+++ b/include/onnxruntime/ep/adapter/op_kernel_info.h
@@ -10,6 +10,7 @@
 #include <memory>
 
 #include "core/common/status.h"
+#include "core/framework/config_options.h"
 #include "core/framework/tensor_shape.h"
 #include "core/framework/tensor.h"
 
@@ -75,6 +76,12 @@ struct OpKernelInfo {
 
   const Ort::ConstKernelInfo GetKernelInfo() const noexcept {
     return info_;
+  }
+
+  ConfigOptions GetConfigOptions() const noexcept {
+    ConfigOptions config_options;
+    config_options.configurations = info_.GetConfigEntries().GetKeyValuePairs();
+    return config_options;
   }
 
   int GetInputCount() const noexcept {


### PR DESCRIPTION
### Description

Returns ConfigOptions object instead of a const reference.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


