### PR TITLE
Fix QuickGelu fusion failure caused by duplicated dequant

### DIFF
--- a/onnxruntime/core/optimizer/quick_gelu_fusion.cc
+++ b/onnxruntime/core/optimizer/quick_gelu_fusion.cc
@@ -12,6 +12,22 @@ using namespace onnxruntime::common;
 
 namespace onnxruntime {
 
+std::string removeDuplicatedSuffix(const std::string& s) {
+    const std::string suffix = "/duplicated";
+    if (s.length() >= suffix.length() &&
+        s.substr(s.length() - suffix.length()) == suffix) {
+        return s.substr(0, s.length() - suffix.length());
+    }
+    return s;
+}
+
+bool endsWith(const std::string& str, const std::string& suffix) {
+    if (str.size() < suffix.size()) {
+        return false;
+    }
+    return str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
 /**
 Rewrite x*sigmoid(alpha*x) or x*sigmoid(x) to QuickGelu.
 */
@@ -81,9 +97,19 @@ Status QuickGeluFusion::ApplyImpl(Graph& graph, bool& modified, int graph_level,
     int sigmoid_output_index = optimizer_utils::IndexOfNodeInput(mul_node, *sigmoid_node.MutableOutputDefs()[0]);
     if (!graph_utils::IsSupportedOptypeVersionAndDomain(mul_node, "Mul", {7, 13, 14}) ||
         !graph_utils::IsSupportedProvider(mul_node, GetCompatibleExecutionProviders()) ||
-        mul_node.MutableInputDefs()[(sigmoid_output_index + 1) % 2]->Name() != quick_gelu_input_arg->Name()) {
+        removeDuplicatedSuffix(mul_node.MutableInputDefs()[(sigmoid_output_index + 1) % 2]->Name())
+        != removeDuplicatedSuffix(quick_gelu_input_arg->Name())) {
       continue;
     }
+
+    int other_input_index = (sigmoid_output_index + 1) % 2;
+    NodeArg* other_input_arg = mul_node.MutableInputDefs()[other_input_index];
+    const Node* producer_nod = graph.GetProducerNode(other_input_arg->Name());
+    if(producer_nod && producer_nod->OutputDefs().size() == 1 &&
+       endsWith(producer_nod->Name(), "DequantizeLinear/duplicated")){
+      nodes_to_fuse.emplace_back(*graph.GetNode(producer_nod->Index()));
+    }
+
     nodes_to_fuse.emplace_back(mul_node);
 
     NodeArg* quick_gelu_output_arg = mul_node.MutableOutputDefs()[0];


### PR DESCRIPTION
Handle "/duplicated" suffix added by EnsureUniqueDQForNodeUnit optimization to enable QuickGelu fusion when Conv is quantized.

### Description
Recently, I only quantized the Conv layers in the YOLOv5 model. During inference, I noticed that the QuickGelu optimization wasn't taking effect. Analysis revealed that `EnsureUniqueDQForNodeUnit` was creating some `DequantizeLinear`/`duplicated` nodes. This caused the QuickGelu requirement for two inputs to have identical names to fail. However, QuickGelu fusion is still possible in such cases. Therefore, I modified the validation criteria.

`我最近在yolov5模型中只对Conv进行了量化，执行推理时发现QuickGelu优化并没有生效，分析发现EnsureUniqueDQForNodeUnit 会创建一些DequantizeLinear/duplicated 节点，导致QuickGelu中要求两个输入名称相同的判定失败，但这种情况下是可以进行QuickGelu融合的，因此我修改了下判定条件。`  


<img width="571" height="474" alt="image-20260304095359499" src="https://github.com/user-attachments/assets/ff8e5531-a253-475c-821a-8d5b1ddb4c78" />  

In the diagram, Mul's B input has changed from 122 to 122/duplicated.  
`图中Mul的B输入由122变为了122/duplicated`

This is a test model I prepared.   
[yolov5s-export.zip](https://github.com/user-attachments/files/25783121/yolov5s-export.zip)

