### PR TITLE
Add Qwen3 model type support to Python transformer optimizer

### DIFF
--- a/onnxruntime/python/tools/transformers/fusion_options.py
+++ b/onnxruntime/python/tools/transformers/fusion_options.py
@@ -64,7 +64,7 @@ class FusionOptions:
         self.enable_gemm_fast_gelu = False
         self.group_norm_channels_last = True
 
-        if model_type == "clip":
+        if model_type in ["clip", "qwen3"]:
             self.enable_embed_layer_norm = False
 
         # Set default to sequence length for BERT model to use fused attention to speed up.
@@ -72,7 +72,7 @@ class FusionOptions:
         self.attention_mask_format = AttentionMaskFormat.AttentionMask
         if model_type == "bert":
             self.attention_mask_format = AttentionMaskFormat.MaskIndexEnd
-        elif model_type == "vit":
+        elif model_type in ["vit", "qwen3"]:
             self.attention_mask_format = AttentionMaskFormat.NoMask
 
         self.attention_op_type = None

--- a/onnxruntime/python/tools/transformers/fusion_skiplayernorm.py
+++ b/onnxruntime/python/tools/transformers/fusion_skiplayernorm.py
@@ -110,8 +110,9 @@ class FusionSkipLayerNormalization(Fusion):
                     )
                     return
             else:
-                logger.debug("skip SkipLayerNormalization fusion since symbolic shape inference failed")
-                return
+                # Shape inference failed. Use default skip_index=1 (no broadcasting) since both
+                # Add inputs have already been verified as non-initializer dynamic tensors above.
+                logger.debug("symbolic shape inference failed, using default skip_index for SkipLayerNormalization")
 
         gather_path = self.model.match_parent_path(add, ["Gather"], [None])
         if gather_path is not None and self.model.find_graph_input(gather_path[0].input[1]) is None:

--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -58,6 +58,7 @@ MODEL_TYPES = {
     "gpt2_tf": (Gpt2OnnxModel, "tf2onnx", 0),  # might add a class for GPT2OnnxModel for TF later.
     "gpt_neox": (BertOnnxModel, "pytorch", 0),  # GPT-NeoX
     "phi": (PhiOnnxModel, "pytorch", 0),
+    "qwen3": (Gpt2OnnxModel, "pytorch", 0),  # Qwen3 (decoder-only with RoPE, GQA, RMSNorm)
     "sam2": (Sam2OnnxModel, "pytorch", 1),
     "swin": (BertOnnxModel, "pytorch", 1),
     "tnlr": (TnlrOnnxModel, "pytorch", 1),

--- a/onnxruntime/test/python/transformers/qwen3_model_generator.py
+++ b/onnxruntime/test/python/transformers/qwen3_model_generator.py
@@ -1,0 +1,178 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+# Licensed under the MIT License.  See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+"""Synthetic ONNX graph generators for Qwen3 transformer optimization tests.
+
+Qwen3 is a decoder-only architecture with:
+  - RMSNorm (SimplifiedLayerNormalization) instead of LayerNorm
+  - Grouped Query Attention (GQA): fewer KV heads than Q heads
+  - QK-Norm: RMSNorm applied to Q and K after projection
+  - RoPE: rotary positional embeddings
+  - SwiGLU activation in FFN
+"""
+
+import numpy as np
+from onnx import TensorProto, helper
+
+
+def _float_tensor(name, shape, random=False):
+    total = 1
+    for d in shape:
+        total *= d
+    vals = [np.random.uniform(0, 1) for _ in range(total)] if random else [1.0] * total
+    return helper.make_tensor(name, TensorProto.FLOAT, shape, vals)
+
+
+def _rmsnorm_nodes(prefix, input_name, weight_name, output_name, eps=1e-6):
+    """Build the raw-op RMSNorm pattern: Pow -> ReduceMean -> Add(eps) -> Sqrt -> Reciprocal -> Mul -> Mul(weight).
+
+    This is the pattern that FusionSimplifiedLayerNormalization fuses into SimplifiedLayerNormalization.
+    """
+    return [
+        helper.make_node("Pow", [input_name, f"{prefix}_pow_exp"], [f"{prefix}_pow_out"], f"{prefix}_pow"),
+        helper.make_node(
+            "ReduceMean",
+            [f"{prefix}_pow_out"],
+            [f"{prefix}_mean_out"],
+            f"{prefix}_mean",
+            axes=[-1],
+            keepdims=1,
+        ),
+        helper.make_node(
+            "Add", [f"{prefix}_mean_out", f"{prefix}_eps"], [f"{prefix}_add_eps_out"], f"{prefix}_add_eps"
+        ),
+        helper.make_node("Sqrt", [f"{prefix}_add_eps_out"], [f"{prefix}_sqrt_out"], f"{prefix}_sqrt"),
+        helper.make_node("Reciprocal", [f"{prefix}_sqrt_out"], [f"{prefix}_rsqrt_out"], f"{prefix}_rsqrt"),
+        helper.make_node("Mul", [input_name, f"{prefix}_rsqrt_out"], [f"{prefix}_normed"], f"{prefix}_mul_rsqrt"),
+        helper.make_node("Mul", [weight_name, f"{prefix}_normed"], [output_name], f"{prefix}_mul_weight"),
+    ]
+
+
+def _rmsnorm_initializers(prefix, hidden_size, eps=1e-6):
+    """Initializers for a single RMSNorm block."""
+    return [
+        helper.make_tensor(f"{prefix}_pow_exp", TensorProto.FLOAT, [1], [2.0]),
+        helper.make_tensor(f"{prefix}_eps", TensorProto.FLOAT, [], [eps]),
+    ]
+
+
+def create_qwen3_decoder_layer(
+    hidden_size=64,
+    num_heads=8,
+    num_kv_heads=2,
+    batch_size=1,
+    seq_len=4,
+):
+    """Create a single Qwen3 decoder layer with RMSNorm, Q/K/V projections, QK-Norm, and residual Add.
+
+    The generated graph exercises:
+      - SimplifiedLayerNormalization fusion (pre-attn RMSNorm, Q-norm, K-norm)
+      - SkipSimplifiedLayerNormalization fusion (residual Add + post-attn RMSNorm)
+
+    Returns an onnx.ModelProto.
+    """
+    head_dim = hidden_size // num_heads
+    kv_dim = num_kv_heads * head_dim
+
+    nodes = []
+    initializers = []
+
+    # --- Pre-attention RMSNorm ---
+    nodes.extend(_rmsnorm_nodes("pre_ln", "input_0", "pre_ln_weight", "pre_ln_out"))
+    initializers.extend(_rmsnorm_initializers("pre_ln", hidden_size))
+    initializers.append(_float_tensor("pre_ln_weight", [hidden_size]))
+
+    # --- Q projection: MatMul ---
+    nodes.append(helper.make_node("MatMul", ["pre_ln_out", "q_weight"], ["q_proj"], "q_matmul"))
+    initializers.append(_float_tensor("q_weight", [hidden_size, hidden_size], random=True))
+
+    # --- K projection: MatMul ---
+    nodes.append(helper.make_node("MatMul", ["pre_ln_out", "k_weight"], ["k_proj"], "k_matmul"))
+    initializers.append(_float_tensor("k_weight", [hidden_size, kv_dim], random=True))
+
+    # --- V projection: MatMul ---
+    nodes.append(helper.make_node("MatMul", ["pre_ln_out", "v_weight"], ["v_proj"], "v_matmul"))
+    initializers.append(_float_tensor("v_weight", [hidden_size, kv_dim], random=True))
+
+    # --- Q reshape to (batch, seq, num_heads, head_dim) ---
+    q_shape = [batch_size, seq_len, num_heads, head_dim]
+    nodes.append(helper.make_node("Reshape", ["q_proj", "q_shape"], ["q_reshaped"], "q_reshape"))
+    initializers.append(helper.make_tensor("q_shape", TensorProto.INT64, [4], q_shape))
+
+    # --- K reshape to (batch, seq, num_kv_heads, head_dim) ---
+    k_shape = [batch_size, seq_len, num_kv_heads, head_dim]
+    nodes.append(helper.make_node("Reshape", ["k_proj", "k_shape"], ["k_reshaped"], "k_reshape"))
+    initializers.append(helper.make_tensor("k_shape", TensorProto.INT64, [4], k_shape))
+
+    # --- QK-Norm: RMSNorm on Q ---
+    nodes.extend(_rmsnorm_nodes("q_norm", "q_reshaped", "q_norm_weight", "q_normed"))
+    initializers.extend(_rmsnorm_initializers("q_norm", head_dim))
+    initializers.append(_float_tensor("q_norm_weight", [head_dim]))
+
+    # --- QK-Norm: RMSNorm on K ---
+    nodes.extend(_rmsnorm_nodes("k_norm", "k_reshaped", "k_norm_weight", "k_normed"))
+    initializers.extend(_rmsnorm_initializers("k_norm", head_dim))
+    initializers.append(_float_tensor("k_norm_weight", [head_dim]))
+
+    # --- Transposes for multi-head layout ---
+    nodes.append(helper.make_node("Transpose", ["q_normed"], ["q_transposed"], "q_transpose", perm=[0, 2, 1, 3]))
+    nodes.append(helper.make_node("Transpose", ["k_normed"], ["k_transposed"], "k_transpose", perm=[0, 2, 1, 3]))
+
+    # --- V reshape + transpose ---
+    nodes.append(helper.make_node("Reshape", ["v_proj", "k_shape"], ["v_reshaped"], "v_reshape"))
+    nodes.append(helper.make_node("Transpose", ["v_reshaped"], ["v_transposed"], "v_transpose", perm=[0, 2, 1, 3]))
+
+    # --- Simplified attention: QK^T -> Softmax -> *V ---
+    nodes.append(helper.make_node("Transpose", ["k_transposed"], ["k_T"], "k_transpose_for_matmul", perm=[0, 1, 3, 2]))
+    nodes.append(helper.make_node("MatMul", ["q_transposed", "k_T"], ["qk_scores"], "qk_matmul"))
+    nodes.append(helper.make_node("Mul", ["qk_scores", "scale_factor"], ["qk_scaled"], "qk_scale"))
+    initializers.append(helper.make_tensor("scale_factor", TensorProto.FLOAT, [1], [1.0 / (head_dim**0.5)]))
+    nodes.append(helper.make_node("Softmax", ["qk_scaled"], ["attn_weights"], "softmax", axis=-1))
+    nodes.append(helper.make_node("MatMul", ["attn_weights", "v_transposed"], ["attn_out"], "attn_v_matmul"))
+
+    # --- Transpose attention output back ---
+    nodes.append(helper.make_node("Transpose", ["attn_out"], ["attn_transposed"], "attn_transpose", perm=[0, 2, 1, 3]))
+
+    # --- Reshape to (batch, seq, hidden) ---
+    out_shape = [batch_size, seq_len, hidden_size]
+    nodes.append(helper.make_node("Reshape", ["attn_transposed", "out_shape"], ["attn_flat"], "attn_reshape"))
+    initializers.append(helper.make_tensor("out_shape", TensorProto.INT64, [3], out_shape))
+
+    # --- Output projection ---
+    nodes.append(helper.make_node("MatMul", ["attn_flat", "o_weight"], ["o_proj"], "o_matmul"))
+    initializers.append(_float_tensor("o_weight", [hidden_size, hidden_size], random=True))
+
+    # --- Residual Add -> SkipSimplifiedLayerNormalization pattern ---
+    nodes.append(helper.make_node("Add", ["input_0", "o_proj"], ["residual_add"], "residual_add"))
+
+    # --- Post-attention RMSNorm (anchored on residual_add -> will fuse to SkipSimplifiedLN) ---
+    nodes.extend(_rmsnorm_nodes("post_ln", "residual_add", "post_ln_weight", "post_ln_out"))
+    initializers.extend(_rmsnorm_initializers("post_ln", hidden_size))
+    initializers.append(_float_tensor("post_ln_weight", [hidden_size]))
+
+    # --- Simplified FFN: just a MatMul + residual for testing ---
+    nodes.append(helper.make_node("MatMul", ["post_ln_out", "ffn_weight"], ["ffn_out"], "ffn_matmul"))
+    initializers.append(_float_tensor("ffn_weight", [hidden_size, hidden_size], random=True))
+
+    nodes.append(helper.make_node("Add", ["residual_add", "ffn_out"], ["output_0"], "ffn_residual_add"))
+
+    # --- Graph definition ---
+    graph = helper.make_graph(
+        nodes,
+        "qwen3_decoder_layer",
+        [
+            helper.make_tensor_value_info("input_0", TensorProto.FLOAT, [batch_size, seq_len, hidden_size]),
+        ],
+        [
+            helper.make_tensor_value_info("output_0", TensorProto.FLOAT, [batch_size, seq_len, hidden_size]),
+        ],
+        initializers,
+    )
+
+    model = helper.make_model(graph)
+    model.ir_version = 7
+    model.opset_import[0].version = 17
+    return model

--- a/onnxruntime/test/python/transformers/test_attention_fusion.py
+++ b/onnxruntime/test/python/transformers/test_attention_fusion.py
@@ -14,6 +14,7 @@ from bert_model_generator import create_bert_attention, create_bert_attention_pr
 from gpt2_model_generator import create_gpt2_attention
 from model_loader import get_test_data_path
 from parity_utilities import find_transformers_source
+from qwen3_model_generator import create_qwen3_decoder_layer
 
 if find_transformers_source():
     from fusion_options import FusionOptions
@@ -325,6 +326,56 @@ class TestFusion(unittest.TestCase):
 
             model_name = f"gpt2_megatron_{model_suffix}.onnx"
             self.verify_fusion(optimized_model, model_name)
+
+    def test_qwen3_normalization_fusion(self):
+        """Test Qwen3 decoder layer optimization.
+
+        Verifies that the optimizer fuses:
+          - RMSNorm patterns into SimplifiedLayerNormalization (pre-attn, Q-norm, K-norm)
+          - Add + RMSNorm into SkipSimplifiedLayerNormalization (residual connection)
+        """
+        hidden_size = 64
+        num_heads = 8
+        num_kv_heads = 2
+
+        model = create_qwen3_decoder_layer(
+            hidden_size=hidden_size,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+        )
+
+        dir = tempfile.mkdtemp()
+        model_path = os.path.join(dir, "qwen3_decoder.onnx")
+        onnx.save(model, model_path)
+
+        options = FusionOptions("qwen3")
+        optimized_model = optimize_model(
+            model_path,
+            model_type="qwen3",
+            num_heads=num_heads,
+            hidden_size=hidden_size,
+            optimization_options=options,
+        )
+
+        os.remove(model_path)
+
+        nodes = optimized_model.model.graph.node
+        sln_count = sum(1 for n in nodes if n.op_type == "SimplifiedLayerNormalization")
+        ssln_count = sum(1 for n in nodes if n.op_type == "SkipSimplifiedLayerNormalization")
+
+        # 4 RMSNorm patterns: pre-attn, Q-norm, K-norm, post-attn.
+        # Post-attn RMSNorm has an Add parent (residual) → fused as SkipSimplifiedLayerNormalization.
+        # Remaining 3 stay as SimplifiedLayerNormalization.
+        self.assertEqual(
+            sln_count,
+            3,
+            f"Expected 3 SimplifiedLayerNormalization (pre-attn + Q-norm + K-norm), got {sln_count}",
+        )
+        self.assertEqual(
+            ssln_count,
+            1,
+            f"Expected 1 SkipSimplifiedLayerNormalization (residual + post-attn RMSNorm), got {ssln_count}",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description

Add `qwen3` to the Python transformer optimizer's model type registry, enabling graph optimization for Qwen3 models (e.g., Qwen3-Embedding-0.6B, ranked 4th on MTEB).

### Motivation

Fixes https://github.com/microsoft/onnxruntime/issues/25083

Running `optimum-cli export onnx --optimize O3` on Qwen3 models fails with:
```
ValueError: Unsupported model type: qwen3
```
This PR resolves that by registering the model type and fixing a fusion gap that blocked normalization fusions.

### Changes

**Model type registration** (`optimizer.py`):
- Add `"qwen3": (Gpt2OnnxModel, "pytorch", 0)` to `MODEL_TYPES`
- Uses `Gpt2OnnxModel` (not `BertOnnxModel`) because its `fuse_attention()` calls `FusionRotaryAttention`, which searches on `SkipSimplifiedLayerNormalization` anchors — needed for RMSNorm-based models

**Fusion option defaults** (`fusion_options.py`):
- Disable `EmbedLayerNormalization` (decoder-only, no BERT-style embedding)
- Set `AttentionMaskFormat.NoMask` (causal masking is implicit)

**SkipLayerNormalization fusion fallback** (`fusion_skiplayernorm.py`):
- When symbolic shape inference fails (common with dynamo-exported models), the fusion previously returned early, skipping all `SkipLayerNormalization` / `SkipSimplifiedLayerNormalization` fusions
- Now it falls through with the safe default `skip_index=1` (second Add input is skip), since both inputs are already verified as non-initializer dynamic tensors (lines 88-90)
- This enables `SkipSimplifiedLayerNormalization` fusion on Qwen3 models where shape inference fails

**Test** (`test_attention_fusion.py`, `qwen3_model_generator.py`):
- Synthetic Qwen3 decoder layer graph with pre-attention RMSNorm, Q/K/V projections, QK-Norm, simplified attention, output projection, residual connection, and post-attention RMSNorm
- Verifies 3× `SimplifiedLayerNormalization` (pre-attn, Q-norm, K-norm) + 1× `SkipSimplifiedLayerNormalization` (residual + post-attn RMSNorm)

**Verified on real model**: Running the optimizer on an exported Qwen3-Embedding-0.6B (2-layer) reduces nodes from 208 → 150 (28% reduction). All 9 RMSNorm patterns fuse correctly: 5× `SimplifiedLayerNormalization` + 4× `SkipSimplifiedLayerNormalization`.

**Scope note**: Full RotaryEmbedding + MultiHeadAttention fusion for Qwen3's dynamo-exported graphs requires additional pattern matching work (static Slice indices, on-the-fly sin/cos computation, QK-Norm in Q/K paths, GQA expansion). That will be addressed in a follow-up PR.

### Test Plan

- [x] `test_attention_fusion.py::TestFusion::test_qwen3_normalization_fusion` passes
- [x] All 14 existing tests in `test_attention_fusion.py` pass (no regressions)
- [x] All 4 tests in `test_optimizer_huggingface_bert.py` pass (bert, distillbert, roberta, xlm_roberta — no regressions from the SkipLayerNorm fallback change)
- [x] `lintrunner -a` clean