### PR TITLE
[wasm] adding back uin4/int4 types in webgpu build

### DIFF
--- a/onnxruntime/wasm/reduced_types.config
+++ b/onnxruntime/wasm/reduced_types.config
@@ -11,4 +11,4 @@
 !no_ops_specified_means_all_ops_are_required
 
 # Globally allowed types for all operators
-!globally_allowed_types;bool,int8_t,uint8_t,int32_t,uint32_t,int64_t,uint64_t,float,MLFloat16
+!globally_allowed_types;bool,int8_t,uint8_t,int32_t,uint32_t,int64_t,uint64_t,float,MLFloat16,UInt4x2,Int4x2


### PR DESCRIPTION
### Description

Adding uint4/int4 back to WebAssembly WebGPU build.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


