### PR TITLE
Fix out of bounds read issue in cross.entropy.cc

### DIFF
--- a/orttraining/orttraining/test/training_ops/cuda/cross_entropy_test.cc
+++ b/orttraining/orttraining/test/training_ops/cuda/cross_entropy_test.cc
@@ -151,6 +151,53 @@ TEST(CrossEntropyTest, SparseSoftmaxCrossEntropy_Basic) {
   test.Run();
 }
 
+TEST(CrossEntropyTest, SparseSoftmaxCrossEntropy_LabelTooLarge) {
+  OpTester test("SparseSoftmaxCrossEntropy", 9);
+  test.AddAttribute("reduction", "mean");
+
+  std::vector<float> X_data(3 * 5, 1.0f);
+  std::vector<int64_t> index_data = {0, 5, 2};  // 5 is out of range [0, 5)
+
+  test.AddInput<float>("X", {3, 5}, X_data);
+  test.AddInput<int64_t>("index", {3}, index_data);
+  test.AddOutput<float>("output", {}, {0.0f});
+  test.AddOutput<float>("log_prob", {3, 5}, std::vector<float>(15, 0.0f));
+
+  test.Run(OpTester::ExpectResult::kExpectFailure, "out of range");
+}
+
+TEST(CrossEntropyTest, SparseSoftmaxCrossEntropy_NegativeLabel) {
+  OpTester test("SparseSoftmaxCrossEntropy", 9);
+  test.AddAttribute("reduction", "mean");
+
+  std::vector<float> X_data(3 * 5, 1.0f);
+  std::vector<int64_t> index_data = {0, -1, 2};  // -1 is out of range
+
+  test.AddInput<float>("X", {3, 5}, X_data);
+  test.AddInput<int64_t>("index", {3}, index_data);
+  test.AddOutput<float>("output", {}, {0.0f});
+  test.AddOutput<float>("log_prob", {3, 5}, std::vector<float>(15, 0.0f));
+
+  test.Run(OpTester::ExpectResult::kExpectFailure, "out of range");
+}
+
+TEST(CrossEntropyTest, SparseSoftmaxCrossEntropy_LabelTooLargeWithWeights) {
+  OpTester test("SparseSoftmaxCrossEntropy", 9);
+  test.AddAttribute("reduction", "mean");
+
+  std::vector<float> X_data(3 * 5, 1.0f);
+  std::vector<int64_t> index_data = {0, 100, 2};  // 100 is out of range
+  std::vector<float> weight_data = {1.0f, 1.0f, 1.0f};
+
+  test.AddInput<float>("X", {3, 5}, X_data);
+  test.AddInput<int64_t>("index", {3}, index_data);
+  test.AddInput<float>("weight", {3}, weight_data);
+  test.AddOutput<float>("output", {}, {0.0f});
+  test.AddOutput<float>("log_prob", {3, 5}, std::vector<float>(15, 0.0f));
+
+  test.Run(OpTester::ExpectResult::kExpectFailure, "out of range");
+}
+
 static void TestSparseSoftmaxCrossEntropy(const std::vector<int64_t>* X_dims,
                                           const std::vector<int64_t>* index_dims,
                                           const std::vector<int64_t>* weight_dims,

--- a/orttraining/orttraining/training_ops/cpu/loss/cross_entropy.cc
+++ b/orttraining/orttraining/training_ops/cpu/loss/cross_entropy.cc
@@ -191,19 +191,19 @@ Status SparseSoftmaxCrossEntropy<T>::Compute(OpKernelContext* context) const {
   float* loss_data = loss->template MutableData<float>();
   float* log_prob_data = log_prob->template MutableData<float>();
 
-  // computation begins here
-  std::vector<float> shifted_logit(nd);
-
-  ComputeShareSoftmaxCrossEntropyCPU(n, d, nd, logit_data,
-                                     shifted_logit.data(),
-                                     log_prob_data);
-
   // Validate label values are within [0, d) to prevent out-of-bounds reads.
   for (ptrdiff_t i = 0; i < n; i++) {
     ORT_RETURN_IF(label_data[i] < 0 || label_data[i] >= d,
                   "SparseSoftmaxCrossEntropy: label value ", label_data[i],
                   " at index ", i, " is out of range [0, ", d, ")");
   }
+
+  // computation begins here
+  std::vector<float> shifted_logit(nd);
+
+  ComputeShareSoftmaxCrossEntropyCPU(n, d, nd, logit_data,
+                                     shifted_logit.data(),
+                                     log_prob_data);
 
   std::vector<float> loss_sample(n);
 


### PR DESCRIPTION
### Description
Add bounds checking for label tensor values in `SparseSoftmaxCrossEntropy::Compute` to prevent out-of-bounds memory reads.


The `SparseSoftmaxCrossEntropy` operator uses `label_data[i]` (int64_t) directly as an array index into the log-probability buffer without validating that the value falls within `[0, D)` where `D` is the number of classes. A malicious ONNX model can embed arbitrary label values in a model initializer, causing the operator to read heap memory beyond the log-probability buffer.

Affected expressions in `cross_entropy.cc`:
```cpp
loss_sample[i] = -log_prob_data[i * d + label_data[i]] * weight_data[i];  // weighted path
loss_sample[i] = -log_prob_data[i * d + label_data[i]];                   // unweighted path
```

Existing shape validation confirms label and logit dimensions are compatible, but never validates label **values** against the class dimension.

## Fix

Added a validation loop before the loss computation that returns an error status if any label value is outside `[0, D)`:

```cpp
for (ptrdiff_t i = 0; i < n; i++) {
  ORT_RETURN_IF(label_data[i] < 0 || label_data[i] >= d,
                "SparseSoftmaxCrossEntropy: label value ", label_data[i],
                " at index ", i, " is out of range [0, ", d, ")");
}
```


