### PR TITLE
 Add missing attribute array validation for TreeEnsembleClassifier

### DIFF
--- a/onnxruntime/core/providers/cpu/ml/tree_ensemble_attribute.h
+++ b/onnxruntime/core/providers/cpu/ml/tree_ensemble_attribute.h
@@ -89,7 +89,7 @@ struct TreeEnsembleAttributesV3 {
                 "nodes_falsenodeids and nodes_truenodeids must have the same size, got ",
                 nodes_falsenodeids.size(), " and ", nodes_truenodeids.size());
     ORT_ENFORCE(nodes_falsenodeids.size() == nodes_values.size() ||
-                nodes_falsenodeids.size() == nodes_values_as_tensor.size(),
+                    nodes_falsenodeids.size() == nodes_values_as_tensor.size(),
                 "nodes_falsenodeids size (", nodes_falsenodeids.size(),
                 ") must match nodes_values (", nodes_values.size(),
                 ") or nodes_values_as_tensor (", nodes_values_as_tensor.size(), ")");

--- a/onnxruntime/test/providers/cpu/ml/tree_ensembler_classifier_test.cc
+++ b/onnxruntime/test/providers/cpu/ml/tree_ensembler_classifier_test.cc
@@ -408,7 +408,6 @@ TEST(MLOpTest, TreeEnsembleClassifierMismatchedClassArrays) {
            "target_class_ids and target_class_nodeids must have the same size");
 }
 
-
 TEST(MLOpTest, TreeEnsembleClassifierMismatchedNodeArrays) {
   OpTester test("TreeEnsembleClassifier", 1, onnxruntime::kMLDomain);
 


### PR DESCRIPTION

### Description
The `TreeEnsembleAttributesV3` constructor in `tree_ensemble_attribute.h` had 15 `ORT_ENFORCE` size-validation checks in the regressor path but none in the classifier path.  A malformed ONNX model with mismatched `TreeEnsembleClassifier` attribute arrays (e.g., `class_ids` vs `class_nodeids`) could cause out-of-bounds access.

To fix this, moved all `ORT_ENFORCE` validation checks out of the `else` (regressor) branch so they apply to **both** classifier and regressor paths.




