### PR TITLE
chore: tooling shouldn't ignore forge hidden folders

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,4 @@
+!/.config
+!/.devcontainer
+!/.github
+!/.pipelines


### PR DESCRIPTION
### Description

Forge/config folders (e.g. `.github`) should not be ignored by tooling such as `rg`, `fd`, etc.
Mark these as not-ignored via `.ignore`.


### Motivation and Context

Having to put `-uu` on every `rg` search for references in pipelines/workflows defeats the purpose of ignoring hidden paths.