### PR TITLE
[QNN EP] ETW log level rule change

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -682,8 +682,9 @@ Status QnnBackendManager::ReleaseDevice() {
 
 Status QnnBackendManager::InitializeProfiling() {
   profiling_level_merge_ = profiling_level_;
-  // use profiling level from ETW if ETW is enabled
-  if (profiling_level_etw_ != ProfilingLevel::INVALID) {
+  // Only use ETW level if it provides higher fidelity
+  if (profiling_level_etw_ != ProfilingLevel::INVALID &&
+      profiling_level_etw_ > profiling_level_) {
     profiling_level_merge_ = profiling_level_etw_;
   }
 


### PR DESCRIPTION


### Description
- ETW log level takes precedence over the QNN log level
- This is now changed to only using ETW log level when it provides higher fidelity



### Motivation and Context
- ETW log level takes precedence over the QNN log level
- If ETW log level = Baisc ; Qnn log level = detailed, QNN EP still picks basic logging over detailed.


