### PR TITLE
Expose Python `OrtDeviceVendorId` enum and use it for vendor-aware `OrtDevice` aliases

### DIFF
--- a/onnxruntime/__init__.py
+++ b/onnxruntime/__init__.py
@@ -83,6 +83,7 @@ from onnxruntime.capi.onnxruntime_inference_collection import (
     IOBinding,  # noqa: F401
     ModelCompiler,  # noqa: F401
     OrtDevice,  # noqa: F401
+    OrtDeviceVendorId,  # noqa: F401
     OrtValue,  # noqa: F401
     SparseTensor,  # noqa: F401
     copy_tensors,  # noqa: F401

--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -10,6 +10,7 @@ import os
 import typing
 import warnings
 from collections.abc import Callable, Sequence
+from enum import IntEnum
 from typing import Any
 
 from onnxruntime.capi import _pybind_state as C
@@ -38,6 +39,30 @@ def get_ort_device_type(device_type: str) -> int:
         return C.OrtDevice.npu()
     else:
         raise Exception("Unsupported device type: " + device_type)
+
+
+class OrtDeviceVendorId(IntEnum):
+    """Vendor IDs aligned with OrtDevice::VendorIds in ortdevice.h."""
+
+    NONE = 0x0000
+    AMD = 0x1002
+    NVIDIA = 0x10DE
+    ARM = 0x13B5
+    MICROSOFT = 0x1414
+    HUAWEI = 0x19E5
+    QUALCOMM = 0x5143
+    INTEL = 0x8086
+
+
+def get_vendor_id_for_device_type(device_type: str) -> OrtDeviceVendorId | None:
+    if device_type == "cuda":
+        return OrtDeviceVendorId.NVIDIA
+    elif device_type == "dml":
+        return OrtDeviceVendorId.MICROSOFT
+    elif device_type == "cann":
+        return OrtDeviceVendorId.HUAWEI
+    else:
+        return None
 
 
 class AdapterFormat:
@@ -1012,7 +1037,9 @@ class OrtValue:
         return self._ortvalue
 
     @classmethod
-    def ortvalue_from_numpy(cls, numpy_obj: np.ndarray, /, device_type="cpu", device_id=0, vendor_id=-1) -> OrtValue:
+    def ortvalue_from_numpy(
+        cls, numpy_obj: np.ndarray, /, device_type="cpu", device_id=0, vendor_id: int | OrtDeviceVendorId = -1
+    ) -> OrtValue:
         """
         Factory method to construct an OrtValue (which holds a Tensor) from a given Numpy object
         A copy of the data in the Numpy object is held by the OrtValue only if the device is NOT cpu
@@ -1020,7 +1047,7 @@ class OrtValue:
         :param numpy_obj: The Numpy object to construct the OrtValue from
         :param device_type: e.g. cpu, cuda, cann, cpu by default
         :param device_id: device id, e.g. 0
-        :param vendor_id: The device's PCI vendor id. If provided, the device_type should be "gpu" or "npu".
+        :param vendor_id: The device's PCI vendor id as an int or OrtDeviceVendorId. If provided, the device_type should be "gpu" or "npu".
         """
         # Hold a reference to the numpy object (if device_type is 'cpu') as the OrtValue
         # is backed directly by the data buffer of the numpy object and so the numpy object
@@ -1049,7 +1076,12 @@ class OrtValue:
 
     @classmethod
     def ortvalue_from_shape_and_type(
-        cls, shape: Sequence[int], element_type, device_type: str = "cpu", device_id: int = 0, vendor_id: int = -1
+        cls,
+        shape: Sequence[int],
+        element_type,
+        device_type: str = "cpu",
+        device_id: int = 0,
+        vendor_id: int | OrtDeviceVendorId = -1,
     ) -> OrtValue:
         """
         Factory method to construct an OrtValue (which holds a Tensor) from given shape and element_type
@@ -1058,7 +1090,7 @@ class OrtValue:
         :param element_type: The data type of the elements. It can be either numpy type (like numpy.float32) or an integer for onnx type (like onnx.TensorProto.BFLOAT16).
         :param device_type: e.g. cpu, cuda, cann, cpu by default
         :param device_id: device id, e.g. 0
-        :param vendor_id: If provided the device type should be "gpu" or "npu".
+        :param vendor_id: The device's PCI vendor id as an int or OrtDeviceVendorId. If provided, the device type should be "gpu" or "npu".
         """
 
         device = OrtDevice.make(device_type, device_id, vendor_id)._get_c_device()
@@ -1211,9 +1243,24 @@ class OrtDevice:
         return self._ort_device
 
     @staticmethod
-    def make(ort_device_name, device_id, vendor_id=-1):
+    def make(ort_device_name, device_id, vendor_id: int | OrtDeviceVendorId = -1):
         if vendor_id < 0:
-            # backwards compatibility with predefined OrtDevice names
+            # Preserve the historical convenience aliases ("cuda", "dml", "cann")
+            # while making them work with plugin EP shared allocators. Those
+            # allocators are keyed by vendor-specific OrtDevice values even when the
+            # Python package itself was built without the corresponding built-in EP.
+            alias_vendor_id = get_vendor_id_for_device_type(ort_device_name)
+            if alias_vendor_id is not None:
+                return OrtDevice(
+                    C.OrtDevice(
+                        get_ort_device_type(ort_device_name),
+                        C.OrtDevice.default_memory(),
+                        int(alias_vendor_id),
+                        device_id,
+                    )
+                )
+
+            # backwards compatibility with generic predefined OrtDevice names
             return OrtDevice(
                 C.OrtDevice(
                     get_ort_device_type(ort_device_name),
@@ -1228,7 +1275,7 @@ class OrtDevice:
                 C.OrtDevice(
                     get_ort_device_type(ort_device_name),
                     C.OrtDevice.default_memory(),
-                    vendor_id,
+                    int(vendor_id),
                     device_id,
                 )
             )

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -1601,8 +1601,12 @@ class TestInferenceSession(unittest.TestCase):
         cpu_device = onnxrt.OrtDevice.make("cpu", 0)
         self.assertEqual(cpu_device.device_id(), 0)
         self.assertEqual(cpu_device.device_type(), 0)
-        self.assertEqual(cpu_device.device_vendor_id(), 0)
+        self.assertEqual(cpu_device.device_vendor_id(), onnxrt.OrtDeviceVendorId.NONE)
         self.assertEqual(cpu_device.device_mem_type(), 0)
+
+        cuda_device = onnxrt.OrtDevice.make("cuda", 0)
+        self.assertEqual(cuda_device.device_vendor_id(), onnxrt.OrtDeviceVendorId.NVIDIA)
+        self.assertEqual(onnxrt.OrtDeviceVendorId.NVIDIA, 0x10DE)
 
     def test_ort_memory_info(self):
         cpu_memory_info = onnxrt.OrtMemoryInfo(


### PR DESCRIPTION
# Summary

This change replaces the Python-side PCI vendor ID constants in `onnxruntime_inference_collection.py` with a
public `OrtDeviceVendorId` enum, exports that enum from `onnxruntime.__init__`, and continues using vendor-aware
`OrtDevice` construction for well-known aliases like `"cuda"`, `"dml"`, and `"cann"`.

The goal is to make vendor IDs reusable across Python APIs without duplicating raw integer constants while still
fixing the plugin EP allocator lookup issue for `OrtValue.ortvalue_from_numpy(..., "cuda", ...)`.

# Problem

The Python wrapper now needs vendor IDs in more than one place.

Keeping them as standalone integer constants is workable for a narrow fix, but it does not give Python callers a
clear public API for vendor identity. As more APIs accept or return vendor IDs, users would have to either:

- remember the raw PCI ID values
- depend on private implementation details
- repeat ad hoc constants in their own code

That is not a good public surface for something that is now part of regular Python device construction flows.

# Why We Need This Change

Dynamic EP registration is intended to let a Python package gain hardware capability without requiring that hardware
support to be built into the package itself.

That only works if the Python-side device description matches the device identity used by dynamically registered EP
allocators and data transfers.

Without the underlying vendor-aware alias behavior:

- registering the CUDA plugin library succeeds
- sessions can use `CudaPluginExecutionProvider`
- but Python cannot create CUDA `OrtValue`s with `OrtValue.ortvalue_from_numpy(..., "cuda", 0)`

At the same time, without a public enum:

- vendor IDs remain scattered as raw integers
- Python callers do not have a clean symbolic way to specify vendor-specific `"gpu"` / `"npu"` devices
- future vendor-aware APIs would keep expanding the same constant-style pattern

# Example Use Case

Our immediate use case is the CUDA plugin EP flow from Python.

We register `libonnxruntime_providers_cuda_plugin.so` from Python and create sessions with
`CudaPluginExecutionProvider`. That part works.

Stage 4 of the plugin flow needs to create GPU-resident `OrtValue`s:

```python
onnxruntime.OrtValue.ortvalue_from_numpy(array, "cuda", 0)
```

Before the vendor-aware alias fix, that failed in a CPU-only Python package even after the CUDA plugin was
registered, because the Python wrapper constructed a generic GPU `OrtDevice` without the NVIDIA vendor ID.

With this change, Python also has a public enum for vendor IDs, so callers can write explicit vendor-aware code
when using generic device names:

```python
onnxruntime.OrtValue.ortvalue_from_numpy(
    array,
    "gpu",
    0,
    onnxruntime.OrtDeviceVendorId.NVIDIA,
)
```

# Fix

The change does three things:

1. Replace the Python-side PCI vendor ID constants with an `IntEnum` named `OrtDeviceVendorId`.
2. Export `OrtDeviceVendorId` from `onnxruntime.__init__` so it is part of the public Python API.
3. Keep the vendor-aware alias behavior in `OrtDevice.make(...)` so that the historical shorthand aliases:
   - `"cuda"` -> `OrtDeviceVendorId.NVIDIA`
   - `"dml"` -> `OrtDeviceVendorId.MICROSOFT`
   - `"cann"` -> `OrtDeviceVendorId.HUAWEI`

   use the 4-argument `C.OrtDevice(...)` constructor with an explicit vendor ID.

Generic device names like `"gpu"` and `"npu"` continue to behave as before unless the caller explicitly provides a
vendor ID, and callers can now use either an integer or `OrtDeviceVendorId`.

# Why This Approach

An enum is the better public API here because it:

- keeps Python aligned with the core runtime vendor ID definitions in `ortdevice.h`
- preserves integer compatibility because `IntEnum` still works naturally with the pybind layer
- gives users readable, discoverable names instead of undocumented raw PCI IDs
- scales better as vendor-aware device APIs become more common

This keeps the original plugin fix intact while improving the Python API shape instead of just adding more module
constants.

# Validation

Validated in the Python layer by:

- confirming the new enum-based implementation preserves vendor-aware alias handling for `"cuda"`, `"dml"`, and `"cann"`
- exporting `OrtDeviceVendorId` from the top-level `onnxruntime` package
- adding Python test coverage that checks `OrtDevice.make("cuda", 0)` resolves to the NVIDIA vendor ID via the enum
- running `python -m compileall` on the updated Python files

Targeted pytest execution could not be completed in this workspace because the local source tree does not provide an
importable `onnxruntime.capi` module without a built package.

# Notes

This PR keeps backward compatibility for existing Python call sites:

- shorthand aliases like `"cuda"` continue to work
- explicit `vendor_id` arguments can still be passed as integers
- callers now also have the option to use `onnxruntime.OrtDeviceVendorId`