### PR TITLE
Add validation of position_ids in RotaryEmbedding operators

### DIFF
--- a/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
@@ -126,6 +126,7 @@ Status GroupQueryAttention<T>::Compute(OpKernelContext* context) const {
   T* q_rotary = Q.GetMutable<Tensor>()->MutableData<T>();
   T* k_rotary = packed_qkv ? nullptr : K.GetMutable<Tensor>()->MutableData<T>();
   if (do_rotary_) {
+    ORT_ENFORCE(cos_cache != nullptr && sin_cache != nullptr, "cos_cache and sin_cache must be provided when do_rotary is true");
     // Initialize rotary parameters
     rotary_embedding_helper::RotaryParameters rotary_params = {};
     rotary_params.batch_size = batch_size;
@@ -134,7 +135,7 @@ Status GroupQueryAttention<T>::Compute(OpKernelContext* context) const {
     rotary_params.head_size = head_size;
     rotary_params.rotary_embedding_dim = parameters.rotary_dim;
     rotary_params.num_heads = num_heads_;
-    rotary_params.max_sequence_length = sequence_length;  // unused
+    rotary_params.max_sequence_length = static_cast<int>(cos_cache->Shape().GetDims()[0]);
     rotary_params.seq_stride = head_size;
     rotary_params.head_stride = sequence_length * rotary_params.seq_stride;
     rotary_params.batch_stride = (packed_qkv ? (num_heads_ + 2 * kv_num_heads_) : num_heads_) * rotary_params.head_stride;

--- a/onnxruntime/contrib_ops/cpu/bert/rotary_embedding.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/rotary_embedding.cc
@@ -61,9 +61,11 @@ Status RunRotaryEmbedding(concurrency::ThreadPool* tp, RotaryParameters paramete
 
   // Validate position_ids values are within cos/sin cache bounds
   if (position_ids_format == 0) {
-    // Format 0: single offset, effective positions are [position_ids[0], position_ids[0] + sequence_length - 1]
+    // Format 0: single offset, effective positions are [base_pos, base_pos + sequence_length - 1].
+    // Check without overflow: base_pos must be in [0, max_sequence_length - sequence_length].
     int64_t base_pos = position_ids[0];
-    if (base_pos < 0 || base_pos + sequence_length - 1 >= static_cast<int64_t>(max_sequence_length)) {
+    int64_t max_valid_base = static_cast<int64_t>(max_sequence_length) - static_cast<int64_t>(sequence_length);
+    if (base_pos < 0 || base_pos > max_valid_base) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                              "position_ids base value ", base_pos,
                              " with sequence_length ", sequence_length,

--- a/onnxruntime/contrib_ops/cpu/bert/rotary_embedding.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/rotary_embedding.cc
@@ -55,8 +55,32 @@ Status RunRotaryEmbedding(concurrency::ThreadPool* tp, RotaryParameters paramete
   const int seq_stride = parameters.seq_stride;
   const int batch_stride = parameters.batch_stride;
   const int position_ids_format = parameters.position_ids_format;
+  const int max_sequence_length = parameters.max_sequence_length;
   const int rotary_emb_dim = parameters.rotary_embedding_dim;
   const int half_rotary_emb_dim = rotary_emb_dim / 2;
+
+  // Validate position_ids values are within cos/sin cache bounds
+  if (position_ids_format == 0) {
+    // Format 0: single offset, effective positions are [position_ids[0], position_ids[0] + sequence_length - 1]
+    int64_t base_pos = position_ids[0];
+    if (base_pos < 0 || base_pos + sequence_length - 1 >= static_cast<int64_t>(max_sequence_length)) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "position_ids base value ", base_pos,
+                             " with sequence_length ", sequence_length,
+                             " exceeds cos/sin cache range [0, ", max_sequence_length, ")");
+    }
+  } else if (position_ids_format == 1) {
+    // Format 1: 2D array (batch_size, sequence_length)
+    for (int i = 0; i < batch_size * sequence_length; ++i) {
+      int64_t pos = position_ids[i];
+      if (pos < 0 || pos >= static_cast<int64_t>(max_sequence_length)) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                               "position_ids value ", pos, " at index ", i,
+                               " is out of range [0, ", max_sequence_length, ")");
+      }
+    }
+  }
+
   // Parallel to calculate based on head_size
   const int loop_len = batch_size * sequence_length * n_heads;
   // The cost is calculated as:

--- a/onnxruntime/contrib_ops/cpu/sparse/sparse_attention.cc
+++ b/onnxruntime/contrib_ops/cpu/sparse/sparse_attention.cc
@@ -136,6 +136,7 @@ Status SparseAttention<T>::Compute(OpKernelContext* context) const {
   T* q_rotary = Q.GetMutable<Tensor>()->MutableData<T>();
   T* k_rotary = packed_qkv ? nullptr : K.GetMutable<Tensor>()->MutableData<T>();
   if (do_rotary_) {
+    ORT_ENFORCE(cos_cache != nullptr && sin_cache != nullptr, "cos_cache and sin_cache must be provided when do_rotary is true");
     rotary_embedding_helper::RotaryParameters rotary_params = {};
     rotary_params.batch_size = batch_size;
     rotary_params.sequence_length = sequence_length;
@@ -143,7 +144,7 @@ Status SparseAttention<T>::Compute(OpKernelContext* context) const {
     rotary_params.head_size = head_size;
     rotary_params.rotary_embedding_dim = parameters.rotary_dim;
     rotary_params.num_heads = num_heads_;
-    rotary_params.max_sequence_length = sequence_length;  // unused
+    rotary_params.max_sequence_length = parameters.max_rotary_sequence_length;
     rotary_params.seq_stride = head_size;
     rotary_params.head_stride = sequence_length * rotary_params.seq_stride;
     rotary_params.batch_stride = (packed_qkv ? (num_heads_ + 2 * kv_num_heads_) : num_heads_) *

--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention_qkv.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention_qkv.cuh
@@ -151,16 +151,24 @@ __global__ void UnpackRoPEAppend(
     const int past_seq_len = past_seq_lens[b];
     const int64_t pos_base = static_cast<int64_t>(b) * sequence_length;
     // Calculate global position for RoPE: use position_ids if provided, else rely on past_seq_len.
-    int pos_id = (position_ids != nullptr) ? static_cast<int>(position_ids[pos_base + s]) : (past_seq_len + s);
-    const int h_idx = h / elements_per_thread;
+    int64_t pos_val = (position_ids != nullptr) ? position_ids[pos_base + s] : static_cast<int64_t>(past_seq_len + s);
+#if !defined(NDEBUG)
+    if (tid == 0) {
+      CUDA_KERNEL_ASSERT(pos_val >= 0 && pos_val < static_cast<int64_t>(max_seqlen));
+    }
+#endif
+    if (pos_val >= 0 && pos_val < static_cast<int64_t>(max_seqlen)) {
+      int pos_id = static_cast<int>(pos_val);
+      const int h_idx = h / elements_per_thread;
 
-    onnxruntime::contrib::cuda::RotaryDispatcher<LoadT, T>::apply(
-        *reinterpret_cast<LoadT*>(vals),
-        reinterpret_cast<const LoadT*>(cos_cache),
-        reinterpret_cast<const LoadT*>(sin_cache),
-        rotary_dim, h_idx, pos_id, interleaved,
-        reinterpret_cast<const LoadT*>(shared_head),
-        0);
+      onnxruntime::contrib::cuda::RotaryDispatcher<LoadT, T>::apply(
+          *reinterpret_cast<LoadT*>(vals),
+          reinterpret_cast<const LoadT*>(cos_cache),
+          reinterpret_cast<const LoadT*>(sin_cache),
+          rotary_dim, h_idx, pos_id, interleaved,
+          reinterpret_cast<const LoadT*>(shared_head),
+          0);
+    }
   }
 
   // 3. Store results back to Global Memory (Unpacked Q and Quantized KV Cache)

--- a/onnxruntime/contrib_ops/cuda/bert/rotary_embedding_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/rotary_embedding_impl.cu
@@ -73,6 +73,11 @@ __global__ void RotaryEmbeddingBSNH(T* output,                         // BxSxNx
     // Validate base without overflow: base must be in [0, max_sequence_length - sequence_length].
     int64_t base_pos = position_ids[0];
     int64_t max_valid_base = static_cast<int64_t>(max_sequence_length) - static_cast<int64_t>(sequence_length);
+#if !defined(NDEBUG)
+    if (i == 0) {
+      CUDA_KERNEL_ASSERT(base_pos >= 0 && base_pos <= max_valid_base);
+    }
+#endif
     if (base_pos < 0 || base_pos > max_valid_base) {
       output_data[i] = use_smem ? smem[i] : input_data[i];
       return;
@@ -80,6 +85,11 @@ __global__ void RotaryEmbeddingBSNH(T* output,                         // BxSxNx
     position_id = static_cast<int>(base_pos) + s;
   } else if (position_ids_format == 1) {
     int64_t pos = position_ids[b * sequence_length + s];
+#if !defined(NDEBUG)
+    if (i == 0) {
+      CUDA_KERNEL_ASSERT(pos >= 0 && pos < static_cast<int64_t>(max_sequence_length));
+    }
+#endif
     if (pos < 0 || pos >= static_cast<int64_t>(max_sequence_length)) {
       output_data[i] = use_smem ? smem[i] : input_data[i];
       return;

--- a/onnxruntime/contrib_ops/cuda/bert/rotary_embedding_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/rotary_embedding_impl.cu
@@ -25,7 +25,8 @@ __global__ void RotaryEmbeddingBSNH(T* output,                         // BxSxNx
                                     const int64_t* position_ids,       // (1) or BxS
                                     const int* past_sequence_lengths,  // (B) for format 2
                                     const int sequence_length, const int num_heads, const int head_size,
-                                    const int rotary_embedding_dim, const int position_ids_format,
+                                    const int rotary_embedding_dim, const int max_sequence_length,
+                                    const int position_ids_format,
                                     const bool interleaved,
                                     int4 in_strides, int4 out_strides  // strides in bnsh coord, h is always contiguous
 ) {
@@ -69,9 +70,19 @@ __global__ void RotaryEmbeddingBSNH(T* output,                         // BxSxNx
   const int half_rotary_embedding_dim = rotary_embedding_dim / 2;
   int position_id = 0;
   if (position_ids_format == 0) {
-    position_id = static_cast<int>(position_ids[0]) + s;
+    int64_t pos = position_ids[0] + static_cast<int64_t>(s);
+    if (pos < 0 || pos >= static_cast<int64_t>(max_sequence_length)) {
+      output_data[i] = use_smem ? smem[i] : input_data[i];
+      return;
+    }
+    position_id = static_cast<int>(pos);
   } else if (position_ids_format == 1) {
-    position_id = static_cast<int>(position_ids[b * sequence_length + s]);
+    int64_t pos = position_ids[b * sequence_length + s];
+    if (pos < 0 || pos >= static_cast<int64_t>(max_sequence_length)) {
+      output_data[i] = use_smem ? smem[i] : input_data[i];
+      return;
+    }
+    position_id = static_cast<int>(pos);
   } else if (position_ids_format == 2) {
     // format 2: past_sequence_length + s
     // used for Decoding (past_sequence_length = seqlens_k[b]) or First Prompt (past=0 if nullptr)
@@ -139,7 +150,7 @@ Status LaunchRotaryEmbeddingKernel(cudaStream_t stream, T* output, const T* inpu
                                    const int* past_sequence_lengths,
                                    const T* cos_cache, const T* sin_cache, const int batch_size,
                                    const int sequence_length, const int num_heads, const int head_size,
-                                   const int rotary_embedding_dim, const int /*max_sequence_length*/,
+                                   const int rotary_embedding_dim, const int max_sequence_length,
                                    const int position_ids_format, const bool interleaved,
                                    const int max_threads_per_block,
                                    int4 in_strides, int4 out_strides  // strides in bnsh coord
@@ -164,13 +175,13 @@ Status LaunchRotaryEmbeddingKernel(cudaStream_t stream, T* output, const T* inpu
     size_t smem_size = head_size * sizeof(T);
     RotaryEmbeddingBSNH<T, true><<<grid, block, smem_size, stream>>>(
         output, input, cos_cache, sin_cache, position_ids, past_sequence_lengths, sequence_length,
-        num_heads, head_size, rotary_embedding_dim, position_ids_format,
+        num_heads, head_size, rotary_embedding_dim, max_sequence_length, position_ids_format,
         interleaved, in_strides, out_strides);
   } else {
     // Separate buffers: no shared memory needed
     RotaryEmbeddingBSNH<T, false><<<grid, block, 0, stream>>>(
         output, input, cos_cache, sin_cache, position_ids, past_sequence_lengths, sequence_length,
-        num_heads, head_size, rotary_embedding_dim, position_ids_format,
+        num_heads, head_size, rotary_embedding_dim, max_sequence_length, position_ids_format,
         interleaved, in_strides, out_strides);
   }
 

--- a/onnxruntime/contrib_ops/cuda/bert/rotary_embedding_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/rotary_embedding_impl.cu
@@ -70,12 +70,14 @@ __global__ void RotaryEmbeddingBSNH(T* output,                         // BxSxNx
   const int half_rotary_embedding_dim = rotary_embedding_dim / 2;
   int position_id = 0;
   if (position_ids_format == 0) {
-    int64_t pos = position_ids[0] + static_cast<int64_t>(s);
-    if (pos < 0 || pos >= static_cast<int64_t>(max_sequence_length)) {
+    // Validate base without overflow: base must be in [0, max_sequence_length - sequence_length].
+    int64_t base_pos = position_ids[0];
+    int64_t max_valid_base = static_cast<int64_t>(max_sequence_length) - static_cast<int64_t>(sequence_length);
+    if (base_pos < 0 || base_pos > max_valid_base) {
       output_data[i] = use_smem ? smem[i] : input_data[i];
       return;
     }
-    position_id = static_cast<int>(pos);
+    position_id = static_cast<int>(base_pos) + s;
   } else if (position_ids_format == 1) {
     int64_t pos = position_ids[b * sequence_length + s];
     if (pos < 0 || pos >= static_cast<int64_t>(max_sequence_length)) {

--- a/onnxruntime/core/providers/cpu/llm/rotary_embedding.cc
+++ b/onnxruntime/core/providers/cpu/llm/rotary_embedding.cc
@@ -52,8 +52,8 @@ Status RunRotaryEmbedding(concurrency::ThreadPool* tp, RotaryParameters paramete
   // Validate position_ids values are within cos/sin cache bounds
   if (position_ids_format != 0) {
     for (int i = 0; i < batch_size * sequence_length; ++i) {
-      int pos = static_cast<int>(position_ids[i]);
-      if (pos < 0 || pos >= max_sequence_length) {
+      int64_t pos = position_ids[i];
+      if (pos < 0 || pos >= static_cast<int64_t>(max_sequence_length)) {
         return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                                "position_ids value ", pos, " at index ", i,
                                " is out of range [0, ", max_sequence_length, ")");

--- a/onnxruntime/core/providers/cpu/llm/rotary_embedding.cc
+++ b/onnxruntime/core/providers/cpu/llm/rotary_embedding.cc
@@ -45,8 +45,22 @@ Status RunRotaryEmbedding(concurrency::ThreadPool* tp, RotaryParameters paramete
   const int seq_stride = parameters.seq_stride;
   const int batch_stride = parameters.batch_stride;
   const int position_ids_format = parameters.position_ids_format;
+  const int max_sequence_length = parameters.max_sequence_length;
   const int rotary_emb_dim = parameters.rotary_embedding_dim;
   const int half_rotary_emb_dim = rotary_emb_dim / 2;
+
+  // Validate position_ids values are within cos/sin cache bounds
+  if (position_ids_format != 0) {
+    for (int i = 0; i < batch_size * sequence_length; ++i) {
+      int pos = static_cast<int>(position_ids[i]);
+      if (pos < 0 || pos >= max_sequence_length) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                               "position_ids value ", pos, " at index ", i,
+                               " is out of range [0, ", max_sequence_length, ")");
+      }
+    }
+  }
+
   // Parallel to calculate based on head_size
   const int loop_len = batch_size * sequence_length * n_heads;
   // The cost is calculated as:

--- a/onnxruntime/core/providers/cuda/llm/rotary_embedding_impl.cu
+++ b/onnxruntime/core/providers/cuda/llm/rotary_embedding_impl.cu
@@ -57,12 +57,13 @@ __global__ void RotaryEmbeddingBSNH(T* output,                    // BxSxNxH
   // position_ids_format == 1 means position_ids is a 2D array of size (batch_size, sequence_length)
   int b_s_index = b * sequence_length + s;
   if (position_ids_format != 0) {
-    b_s_index = static_cast<int>(position_ids[b_s_index]);
-    if (b_s_index < 0 || b_s_index >= max_sequence_length) {
+    int64_t pos = position_ids[b_s_index];
+    if (pos < 0 || pos >= static_cast<int64_t>(max_sequence_length)) {
       // OOB position id — can't propagate error from GPU, so pass through input unchanged.
       output_data[i] = input_data[i];
       return;
     }
+    b_s_index = static_cast<int>(pos);
   }
   cache_offset = b_s_index * half_rotary_embedding_dim;
   const T* cos_data = cos_cache + cache_offset;

--- a/onnxruntime/core/providers/cuda/llm/rotary_embedding_impl.cu
+++ b/onnxruntime/core/providers/cuda/llm/rotary_embedding_impl.cu
@@ -58,6 +58,11 @@ __global__ void RotaryEmbeddingBSNH(T* output,                    // BxSxNxH
   int b_s_index = b * sequence_length + s;
   if (position_ids_format != 0) {
     int64_t pos = position_ids[b_s_index];
+#if !defined(NDEBUG)
+    if (i == 0) {
+      CUDA_KERNEL_ASSERT(pos >= 0 && pos < static_cast<int64_t>(max_sequence_length));
+    }
+#endif
     if (pos < 0 || pos >= static_cast<int64_t>(max_sequence_length)) {
       // OOB position id — can't propagate error from GPU, so pass through input unchanged.
       output_data[i] = input_data[i];

--- a/onnxruntime/core/providers/cuda/llm/rotary_embedding_impl.cu
+++ b/onnxruntime/core/providers/cuda/llm/rotary_embedding_impl.cu
@@ -23,7 +23,8 @@ __global__ void RotaryEmbeddingBSNH(T* output,                    // BxSxNxH
                                     const T* sin_cache,           // BxSx(H/2) or Mx(H/2)
                                     const int64_t* position_ids,  // (0) or BxS
                                     const int sequence_length, const int num_heads, const int head_size,
-                                    const int rotary_embedding_dim, const int position_ids_format,
+                                    const int rotary_embedding_dim, const int max_sequence_length,
+                                    const int position_ids_format,
                                     const bool interleaved,
                                     int4 in_strides, int4 out_strides  // strides in bnsh coord, h is always contiguous
 ) {
@@ -52,11 +53,16 @@ __global__ void RotaryEmbeddingBSNH(T* output,                    // BxSxNxH
   const int half_rotary_embedding_dim = rotary_embedding_dim / 2;
   int cache_offset;
 
-  // position_ids_format == 0 means position_ids is nullptr
+  // position_ids_format == 0 means position_ids is nullptr; cache is (B*S, H/2) and index is always valid.
   // position_ids_format == 1 means position_ids is a 2D array of size (batch_size, sequence_length)
   int b_s_index = b * sequence_length + s;
   if (position_ids_format != 0) {
     b_s_index = static_cast<int>(position_ids[b_s_index]);
+    if (b_s_index < 0 || b_s_index >= max_sequence_length) {
+      // OOB position id — can't propagate error from GPU, so pass through input unchanged.
+      output_data[i] = input_data[i];
+      return;
+    }
   }
   cache_offset = b_s_index * half_rotary_embedding_dim;
   const T* cos_data = cos_cache + cache_offset;
@@ -117,7 +123,7 @@ template <typename T>
 Status LaunchRotaryEmbeddingKernel(cudaStream_t stream, T* output, const T* input, const int64_t* position_ids,
                                    const T* cos_cache, const T* sin_cache, const int batch_size,
                                    const int sequence_length, const int num_heads, const int head_size,
-                                   const int rotary_embedding_dim, const int /*max_sequence_length*/,
+                                   const int rotary_embedding_dim, const int max_sequence_length,
                                    const int position_ids_format, const bool interleaved,
                                    const int max_threads_per_block,
                                    int4 in_strides, int4 out_strides  // strides in bnsh coord
@@ -137,8 +143,8 @@ Status LaunchRotaryEmbeddingKernel(cudaStream_t stream, T* output, const T* inpu
 
   assert(head_size <= max_threads_per_block);
   RotaryEmbeddingBSNH<<<grid, block, 0, stream>>>(output, input, cos_cache, sin_cache, position_ids, sequence_length,
-                                                  num_heads, head_size, rotary_embedding_dim, position_ids_format,
-                                                  interleaved, in_strides, out_strides);
+                                                  num_heads, head_size, rotary_embedding_dim, max_sequence_length,
+                                                  position_ids_format, interleaved, in_strides, out_strides);
   return CUDA_CALL(cudaGetLastError());
 }
 

--- a/onnxruntime/test/contrib_ops/rotary_embedding_op_test.cc
+++ b/onnxruntime/test/contrib_ops/rotary_embedding_op_test.cc
@@ -759,5 +759,192 @@ TEST(ContribOpRotaryEmbeddingTest, RotaryEmbedding_CustomRotaryDim_SmallData_Phi
            true /*use_fp16*/);
 }
 
+// Test that position_ids (format 1) exceeding max_sequence_length is rejected (CPU).
+TEST(RotaryEmbeddingTest, ContribRotaryEmbedding_PositionIds_ExceedsMaxSeqLen) {
+  int batch_size = 1;
+  int sequence_length = 1;
+  int num_heads = 2;
+  int head_size = 4;
+  int max_sequence_length = 8;
+  int hidden_size = num_heads * head_size;
+
+  OpTester test("RotaryEmbedding", 1, onnxruntime::kMSDomain);
+  test.AddAttribute<int64_t>("interleaved", static_cast<int64_t>(0));
+
+  test.AddInput<float>("input", {batch_size, sequence_length, hidden_size},
+                       std::vector<float>(hidden_size, 1.0f));
+  // Format 1: position_ids shape is {B, S}
+  test.AddInput<int64_t>("position_ids", {batch_size, sequence_length}, {2048});
+  test.AddInput<float>("cos_cache", {max_sequence_length, head_size / 2},
+                       std::vector<float>(max_sequence_length * head_size / 2, 1.0f));
+  test.AddInput<float>("sin_cache", {max_sequence_length, head_size / 2},
+                       std::vector<float>(max_sequence_length * head_size / 2, 0.0f));
+
+  test.AddOutput<float>("output", {batch_size, sequence_length, hidden_size},
+                        std::vector<float>(hidden_size, 0.0f));
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectFailure, "position_ids value 2048 at index 0 is out of range",
+           {}, nullptr, &execution_providers);
+}
+
+// Test that negative position_ids (format 1) are rejected (CPU).
+TEST(RotaryEmbeddingTest, ContribRotaryEmbedding_PositionIds_Negative) {
+  int batch_size = 1;
+  int sequence_length = 1;
+  int num_heads = 2;
+  int head_size = 4;
+  int max_sequence_length = 8;
+  int hidden_size = num_heads * head_size;
+
+  OpTester test("RotaryEmbedding", 1, onnxruntime::kMSDomain);
+  test.AddAttribute<int64_t>("interleaved", static_cast<int64_t>(0));
+
+  test.AddInput<float>("input", {batch_size, sequence_length, hidden_size},
+                       std::vector<float>(hidden_size, 1.0f));
+  test.AddInput<int64_t>("position_ids", {batch_size, sequence_length}, {-1});
+  test.AddInput<float>("cos_cache", {max_sequence_length, head_size / 2},
+                       std::vector<float>(max_sequence_length * head_size / 2, 1.0f));
+  test.AddInput<float>("sin_cache", {max_sequence_length, head_size / 2},
+                       std::vector<float>(max_sequence_length * head_size / 2, 0.0f));
+
+  test.AddOutput<float>("output", {batch_size, sequence_length, hidden_size},
+                        std::vector<float>(hidden_size, 0.0f));
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectFailure, "position_ids value -1 at index 0 is out of range",
+           {}, nullptr, &execution_providers);
+}
+
+// Test that out-of-bounds position_ids in a batch (format 1) are rejected (CPU).
+TEST(RotaryEmbeddingTest, ContribRotaryEmbedding_PositionIds_OOB_InBatch) {
+  int batch_size = 2;
+  int sequence_length = 2;
+  int num_heads = 2;
+  int head_size = 4;
+  int max_sequence_length = 8;
+  int hidden_size = num_heads * head_size;
+
+  OpTester test("RotaryEmbedding", 1, onnxruntime::kMSDomain);
+  test.AddAttribute<int64_t>("interleaved", static_cast<int64_t>(0));
+
+  test.AddInput<float>("input", {batch_size, sequence_length, hidden_size},
+                       std::vector<float>(batch_size * sequence_length * hidden_size, 1.0f));
+  // Second batch has position_id = 100 which exceeds max_sequence_length = 8
+  test.AddInput<int64_t>("position_ids", {batch_size, sequence_length}, {0, 1, 2, 100});
+  test.AddInput<float>("cos_cache", {max_sequence_length, head_size / 2},
+                       std::vector<float>(max_sequence_length * head_size / 2, 1.0f));
+  test.AddInput<float>("sin_cache", {max_sequence_length, head_size / 2},
+                       std::vector<float>(max_sequence_length * head_size / 2, 0.0f));
+
+  test.AddOutput<float>("output", {batch_size, sequence_length, hidden_size},
+                        std::vector<float>(batch_size * sequence_length * hidden_size, 0.0f));
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectFailure, "position_ids value 100 at index 3 is out of range",
+           {}, nullptr, &execution_providers);
+}
+
+// Test that format-0 position_ids base offset exceeding cache is rejected (CPU).
+TEST(RotaryEmbeddingTest, ContribRotaryEmbedding_PositionIds_Format0_OOB) {
+  int batch_size = 1;
+  int sequence_length = 2;
+  int num_heads = 2;
+  int head_size = 4;
+  int max_sequence_length = 8;
+  int hidden_size = num_heads * head_size;
+
+  OpTester test("RotaryEmbedding", 1, onnxruntime::kMSDomain);
+  test.AddAttribute<int64_t>("interleaved", static_cast<int64_t>(0));
+
+  test.AddInput<float>("input", {batch_size, sequence_length, hidden_size},
+                       std::vector<float>(batch_size * sequence_length * hidden_size, 1.0f));
+  // Format 0: single value. Effective positions = [7, 8] — position 8 is out of range [0, 8).
+  test.AddInput<int64_t>("position_ids", {1}, {7});
+  test.AddInput<float>("cos_cache", {max_sequence_length, head_size / 2},
+                       std::vector<float>(max_sequence_length * head_size / 2, 1.0f));
+  test.AddInput<float>("sin_cache", {max_sequence_length, head_size / 2},
+                       std::vector<float>(max_sequence_length * head_size / 2, 0.0f));
+
+  test.AddOutput<float>("output", {batch_size, sequence_length, hidden_size},
+                        std::vector<float>(batch_size * sequence_length * hidden_size, 0.0f));
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectFailure, "position_ids base value 7 with sequence_length 2 exceeds cos/sin cache range",
+           {}, nullptr, &execution_providers);
+}
+
+// Test that format-0 negative position_ids base offset is rejected (CPU).
+TEST(RotaryEmbeddingTest, ContribRotaryEmbedding_PositionIds_Format0_Negative) {
+  int batch_size = 1;
+  int sequence_length = 1;
+  int num_heads = 2;
+  int head_size = 4;
+  int max_sequence_length = 8;
+  int hidden_size = num_heads * head_size;
+
+  OpTester test("RotaryEmbedding", 1, onnxruntime::kMSDomain);
+  test.AddAttribute<int64_t>("interleaved", static_cast<int64_t>(0));
+
+  test.AddInput<float>("input", {batch_size, sequence_length, hidden_size},
+                       std::vector<float>(hidden_size, 1.0f));
+  // Format 0: negative base offset
+  test.AddInput<int64_t>("position_ids", {1}, {-5});
+  test.AddInput<float>("cos_cache", {max_sequence_length, head_size / 2},
+                       std::vector<float>(max_sequence_length * head_size / 2, 1.0f));
+  test.AddInput<float>("sin_cache", {max_sequence_length, head_size / 2},
+                       std::vector<float>(max_sequence_length * head_size / 2, 0.0f));
+
+  test.AddOutput<float>("output", {batch_size, sequence_length, hidden_size},
+                        std::vector<float>(hidden_size, 0.0f));
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectFailure, "position_ids base value -5 with sequence_length 1 exceeds cos/sin cache range",
+           {}, nullptr, &execution_providers);
+}
+
+// Test that OOB position_ids on CUDA (format 1) pass through input unchanged.
+TEST(RotaryEmbeddingTest, ContribRotaryEmbedding_PositionIds_OOB_CUDA_Passthrough) {
+  int batch_size = 1;
+  int sequence_length = 1;
+  int num_heads = 2;
+  int head_size = 4;
+  int max_sequence_length = 8;
+  int hidden_size = num_heads * head_size;
+
+  if (!HasCudaEnvironment(0)) {
+    return;  // Skip when CUDA is not available.
+  }
+
+  OpTester test("RotaryEmbedding", 1, onnxruntime::kMSDomain);
+  test.AddAttribute<int64_t>("interleaved", static_cast<int64_t>(0));
+
+  std::vector<float> input_data(hidden_size);
+  for (int i = 0; i < hidden_size; ++i) {
+    input_data[i] = static_cast<float>(i + 1);
+  }
+
+  test.AddInput<float>("input", {batch_size, sequence_length, hidden_size}, input_data);
+  // position_id = 2048 exceeds max_sequence_length = 8 — CUDA should pass through input unchanged.
+  test.AddInput<int64_t>("position_ids", {batch_size, sequence_length}, {2048});
+  test.AddInput<float>("cos_cache", {max_sequence_length, head_size / 2},
+                       std::vector<float>(max_sequence_length * head_size / 2, 1.0f));
+  test.AddInput<float>("sin_cache", {max_sequence_length, head_size / 2},
+                       std::vector<float>(max_sequence_length * head_size / 2, 0.0f));
+
+  // Output should equal input when position_id is OOB (pass-through).
+  test.AddOutput<float>("output", {batch_size, sequence_length, hidden_size}, input_data);
+  test.SetOutputAbsErr("output", 0.0f);
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCudaExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/llm/rotary_embedding_op_test.cc
+++ b/onnxruntime/test/providers/cpu/llm/rotary_embedding_op_test.cc
@@ -1087,5 +1087,98 @@ TEST(RotaryEmbeddingTest, RotaryEmbedding_Interleaved_NoPosIds_SmallData_LlamaMS
            interleaved);
 }
 
+// Test that position_ids exceeding max_sequence_length is rejected (CPU).
+TEST(RotaryEmbeddingTest, RotaryEmbedding_PositionIds_ExceedsMaxSeqLen) {
+  int batch_size = 1;
+  int sequence_length = 1;
+  int num_heads = 2;
+  int head_size = 4;
+  int max_sequence_length = 8;
+  int hidden_size = num_heads * head_size;
+
+  OpTester test("RotaryEmbedding", 23, onnxruntime::kOnnxDomain);
+  test.AddAttribute<int64_t>("interleaved", static_cast<int64_t>(0));
+  test.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(num_heads));
+
+  test.AddInput<float>("input", {batch_size, sequence_length, hidden_size},
+                       std::vector<float>(hidden_size, 1.0f));
+  test.AddInput<float>("cos_cache", {max_sequence_length, head_size / 2},
+                       std::vector<float>(max_sequence_length * head_size / 2, 1.0f));
+  test.AddInput<float>("sin_cache", {max_sequence_length, head_size / 2},
+                       std::vector<float>(max_sequence_length * head_size / 2, 0.0f));
+  // position_id = 2048 exceeds max_sequence_length = 8
+  test.AddInput<int64_t>("position_ids", {batch_size, sequence_length}, {2048});
+
+  test.AddOutput<float>("output", {batch_size, sequence_length, hidden_size},
+                        std::vector<float>(hidden_size, 0.0f));
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectFailure, "position_ids value 2048 at index 0 is out of range",
+           {}, nullptr, &execution_providers);
+}
+
+// Test that negative position_ids values are rejected (CPU).
+TEST(RotaryEmbeddingTest, RotaryEmbedding_PositionIds_Negative) {
+  int batch_size = 1;
+  int sequence_length = 1;
+  int num_heads = 2;
+  int head_size = 4;
+  int max_sequence_length = 8;
+  int hidden_size = num_heads * head_size;
+
+  OpTester test("RotaryEmbedding", 23, onnxruntime::kOnnxDomain);
+  test.AddAttribute<int64_t>("interleaved", static_cast<int64_t>(0));
+  test.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(num_heads));
+
+  test.AddInput<float>("input", {batch_size, sequence_length, hidden_size},
+                       std::vector<float>(hidden_size, 1.0f));
+  test.AddInput<float>("cos_cache", {max_sequence_length, head_size / 2},
+                       std::vector<float>(max_sequence_length * head_size / 2, 1.0f));
+  test.AddInput<float>("sin_cache", {max_sequence_length, head_size / 2},
+                       std::vector<float>(max_sequence_length * head_size / 2, 0.0f));
+  // position_id = -1 is negative
+  test.AddInput<int64_t>("position_ids", {batch_size, sequence_length}, {-1});
+
+  test.AddOutput<float>("output", {batch_size, sequence_length, hidden_size},
+                        std::vector<float>(hidden_size, 0.0f));
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectFailure, "position_ids value -1 at index 0 is out of range",
+           {}, nullptr, &execution_providers);
+}
+
+// Test that out-of-bounds position_ids in a batch are rejected (CPU).
+TEST(RotaryEmbeddingTest, RotaryEmbedding_PositionIds_OOB_InBatch) {
+  int batch_size = 2;
+  int sequence_length = 2;
+  int num_heads = 2;
+  int head_size = 4;
+  int max_sequence_length = 8;
+  int hidden_size = num_heads * head_size;
+
+  OpTester test("RotaryEmbedding", 23, onnxruntime::kOnnxDomain);
+  test.AddAttribute<int64_t>("interleaved", static_cast<int64_t>(0));
+  test.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(num_heads));
+
+  test.AddInput<float>("input", {batch_size, sequence_length, hidden_size},
+                       std::vector<float>(batch_size * sequence_length * hidden_size, 1.0f));
+  test.AddInput<float>("cos_cache", {max_sequence_length, head_size / 2},
+                       std::vector<float>(max_sequence_length * head_size / 2, 1.0f));
+  test.AddInput<float>("sin_cache", {max_sequence_length, head_size / 2},
+                       std::vector<float>(max_sequence_length * head_size / 2, 0.0f));
+  // Second batch has position_id = 100 which exceeds max_sequence_length = 8
+  test.AddInput<int64_t>("position_ids", {batch_size, sequence_length}, {0, 1, 2, 100});
+
+  test.AddOutput<float>("output", {batch_size, sequence_length, hidden_size},
+                        std::vector<float>(batch_size * sequence_length * hidden_size, 0.0f));
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectFailure, "position_ids value 100 at index 3 is out of range",
+           {}, nullptr, &execution_providers);
+}
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/llm/rotary_embedding_op_test.cc
+++ b/onnxruntime/test/providers/cpu/llm/rotary_embedding_op_test.cc
@@ -1180,5 +1180,44 @@ TEST(RotaryEmbeddingTest, RotaryEmbedding_PositionIds_OOB_InBatch) {
            {}, nullptr, &execution_providers);
 }
 
+// Test that out-of-bounds position_ids on CUDA pass through input unchanged.
+TEST(RotaryEmbeddingTest, RotaryEmbedding_PositionIds_OOB_CUDA_Passthrough) {
+  int batch_size = 1;
+  int sequence_length = 1;
+  int num_heads = 2;
+  int head_size = 4;
+  int max_sequence_length = 8;
+  int hidden_size = num_heads * head_size;
+
+  if (!HasCudaEnvironment(0)) {
+    return;  // Skip when CUDA is not available.
+  }
+
+  OpTester test("RotaryEmbedding", 23, onnxruntime::kOnnxDomain);
+  test.AddAttribute<int64_t>("interleaved", static_cast<int64_t>(0));
+  test.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(num_heads));
+
+  std::vector<float> input_data(hidden_size);
+  for (int i = 0; i < hidden_size; ++i) {
+    input_data[i] = static_cast<float>(i + 1);
+  }
+
+  test.AddInput<float>("input", {batch_size, sequence_length, hidden_size}, input_data);
+  test.AddInput<float>("cos_cache", {max_sequence_length, head_size / 2},
+                       std::vector<float>(max_sequence_length * head_size / 2, 1.0f));
+  test.AddInput<float>("sin_cache", {max_sequence_length, head_size / 2},
+                       std::vector<float>(max_sequence_length * head_size / 2, 0.0f));
+  // position_id = 2048 exceeds max_sequence_length = 8 — CUDA should pass through input unchanged.
+  test.AddInput<int64_t>("position_ids", {batch_size, sequence_length}, {2048});
+
+  // Output should equal input when position_id is OOB (pass-through).
+  test.AddOutput<float>("output", {batch_size, sequence_length, hidden_size}, input_data);
+  test.SetOutputAbsErr("output", 0.0f);
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCudaExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
+
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
## Description

Fix out-of-bounds read in the RotaryEmbedding operator when user-provided `position_ids` values exceed the cos/sin cache bounds (`max_sequence_length`).

### Problem

When `position_ids` contains values that are negative or >= `max_sequence_length`, the kernel computes `cache_offset = position_id * half_rotary_embedding_dim` and reads out-of-bounds from `cos_cache` / `sin_cache`. This can cause undefined behavior (incorrect results, crashes, or memory corruption).

### Fix

**CPU (`rotary_embedding.cc`):**
- Added upfront validation of all `position_ids` values before the parallel computation loop. Returns an `INVALID_ARGUMENT` error if any value is out of range `[0, max_sequence_length)`.
- Validation is only applied when `position_ids_format != 0` (i.e., when position_ids are explicitly provided). When `position_ids` is not provided (format 0), the cache is shaped `(B, S, H/2)` and the index `b * S + s` is always in-bounds by construction.

**CUDA (`rotary_embedding_impl.cu`):**
- Plumbed the previously-unused `max_sequence_length` parameter through to the kernel.
- Added a bounds check inside the `position_ids_format != 0` branch. Out-of-bounds position IDs cause the kernel to pass through the input unchanged (errors cannot be propagated from GPU kernels).
- The bounds check is scoped to the `position_ids_format != 0` branch only. When format is 0 (no position_ids), the cache is `(B*S, H/2)` and `b_s_index = b * S + s` is deterministically valid — applying the check unconditionally would incorrectly reject all batches beyond the first since `max_sequence_length == sequence_length` in that case.

### Tests

Added three CPU test cases for the ONNX domain `RotaryEmbedding` op:
- `RotaryEmbedding_PositionIds_ExceedsMaxSeqLen` — position_id far exceeding cache size
- `RotaryEmbedding_PositionIds_Negative` — negative position_id
- `RotaryEmbedding_PositionIds_OOB_InBatch` — OOB position_id in a multi-batch, multi-sequence scenario

### Motivation and Context

Security hardening — prevent out-of-bounds memory access from untrusted model inputs.
