### PR TITLE
Use `_tpause` instead of `__builtin_ia32_tpause`

### DIFF
--- a/onnxruntime/core/common/spin_pause.cc
+++ b/onnxruntime/core/common/spin_pause.cc
@@ -13,9 +13,8 @@
 
 #if defined(_M_AMD64) || defined(__x86_64__)
 #include "core/common/cpuid_info.h"
-#if defined(__linux__)
+#if defined(__WAITPKG__)
 #include <x86intrin.h>
-#include <immintrin.h>
 #endif
 #endif
 
@@ -32,10 +31,8 @@ void SpinPause() {
   static const bool has_tpause = CPUIDInfo::GetCPUIDInfo().HasTPAUSE();
   static constexpr uint64_t tpause_spin_delay_cycles = 1000;
   if (has_tpause) {
-#if defined(_WIN32)
+#if defined(_WIN32) || defined(__WAITPKG__)
     _tpause(0x0, __rdtsc() + tpause_spin_delay_cycles);
-#elif defined(__linux__)
-    __builtin_ia32_tpause(0x0, __rdtsc() + tpause_spin_delay_cycles);
 #else
     _mm_pause();
 #endif


### PR DESCRIPTION
### Description

Use `_tpause` function defined in `waitpkgintrin.h` instead of calling the compiler built-in function (`__builtin_ia32_tpause`) directly.

### Motivation and Context

The [`_tpause`][intel-intrinsics-guide] is independent of the compiler, whereas its implementation via the built-in function `__builtin_ia32_tpause` varies by compiler. Therefore, it is advisable not to use it directly. For example, [GCC][waitpkgintrin-gcc] and [LLVM][waitpkgintrin-llvm] have different arguments, leading to portability issues.

[intel-intrinsics-guide]: https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=tpause&techs=Other&ig_expand=6888
[waitpkgintrin-gcc]: https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/config/i386/waitpkgintrin.h;h=42c6b0cd02866eccdfe3308f4792f17fe8c6ae38;hb=HEAD#l51
[waitpkgintrin-llvm]: https://github.com/llvm/llvm-project/blob/a682073ae7a49de4b95498ba01b9ea32e6b5f607/clang/lib/Headers/waitpkgintrin.h#L33-L38