### PR TITLE
Accept legacy WebGPU/WebNN memory info names for backward compatibility

### DIFF
--- a/onnxruntime/core/framework/allocator.cc
+++ b/onnxruntime/core/framework/allocator.cc
@@ -237,9 +237,22 @@ ORT_API_STATUS_IMPL(OrtApis::CreateMemoryInfo, _In_ const char* name1, enum OrtA
         OrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT, OrtDevice::VendorIds::AMD, device_id),
         mem_type1);
   } else if (strcmp(name1, onnxruntime::WEBGPU_BUFFER) == 0 ||
-             strcmp(name1, onnxruntime::WEBNN_TENSOR) == 0) {
+             strcmp(name1, onnxruntime::WEBNN_TENSOR) == 0 ||
+             // Accept pre-1.25 names "WebGPU_Buffer"/"WebNN_Tensor" for backward compatibility
+             // with released onnxruntime-genai that still uses the old names.
+             // Normalize to the current (short) constant so downstream name comparisons work.
+             // See: https://github.com/microsoft/onnxruntime/pull/27207
+             strcmp(name1, "WebGPU_Buffer") == 0 ||
+             strcmp(name1, "WebNN_Tensor") == 0) {
+    // Map old long names to current short constants to keep downstream name comparisons consistent.
+    const char* normalized_name = name1;
+    if (strcmp(name1, "WebGPU_Buffer") == 0) {
+      normalized_name = onnxruntime::WEBGPU_BUFFER;
+    } else if (strcmp(name1, "WebNN_Tensor") == 0) {
+      normalized_name = onnxruntime::WEBNN_TENSOR;
+    }
     *out = new OrtMemoryInfo(
-        name1, type,
+        normalized_name, type,
         OrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT, OrtDevice::VendorIds::NONE, device_id),
         mem_type1);
 

--- a/onnxruntime/test/shared_lib/test_allocator.cc
+++ b/onnxruntime/test/shared_lib/test_allocator.cc
@@ -22,6 +22,27 @@ TEST(CApiTest, allocation_info) {
   ASSERT_EQ(OrtMemTypeDefault, cpu_mem_info_1.GetMemoryType());
 }
 
+// Verify that legacy (pre-1.25) memory info names "WebGPU_Buffer" and "WebNN_Tensor" are accepted
+// and normalized to the current short names "WebGPU_Buf" and "WebNN_Ten".
+// This ensures backward compatibility with released onnxruntime-genai that uses the old names.
+TEST(CApiTest, LegacyWebGpuWebNNMemoryInfoNames) {
+  // Old (pre-1.25) names must be accepted
+  Ort::MemoryInfo legacy_webgpu("WebGPU_Buffer", OrtDeviceAllocator, 0, OrtMemTypeDefault);
+  Ort::MemoryInfo legacy_webnn("WebNN_Tensor", OrtDeviceAllocator, 0, OrtMemTypeDefault);
+
+  // Current (short) names
+  Ort::MemoryInfo current_webgpu("WebGPU_Buf", OrtDeviceAllocator, 0, OrtMemTypeDefault);
+  Ort::MemoryInfo current_webnn("WebNN_Ten", OrtDeviceAllocator, 0, OrtMemTypeDefault);
+
+  // Legacy names should be normalized to the current names
+  ASSERT_EQ(std::string("WebGPU_Buf"), legacy_webgpu.GetAllocatorName());
+  ASSERT_EQ(std::string("WebNN_Ten"), legacy_webnn.GetAllocatorName());
+
+  // Memory infos created with legacy and current names should be equal
+  ASSERT_EQ(legacy_webgpu, current_webgpu);
+  ASSERT_EQ(legacy_webnn, current_webnn);
+}
+
 TEST(CApiTest, DefaultAllocator) {
   Ort::AllocatorWithDefaultOptions default_allocator;
   auto cpu_info = default_allocator.GetInfo();


### PR DESCRIPTION
### Description

Accept pre-1.25 names `"WebGPU_Buffer"`/`"WebNN_Tensor"` as aliases in `CreateMemoryInfo` and normalize them to the current short names `"WebGPU_Buf"`/`"WebNN_Ten"`.

This is the **reverse** of https://github.com/microsoft/onnxruntime/pull/27475 (which added forward compatibility in the 1.24.x patch branch).

### Motivation and Context

Released onnxruntime-genai still uses the old (pre-1.25) long names when calling `CreateMemoryInfo`. Without this change, those calls fail with `ORT_INVALID_ARGUMENT` on main branch.

### Key Design Decision

When an old name is detected, it is **normalized** to the current short constant (e.g., `"WebGPU_Buffer"` -> `"WebGPU_Buf"`). This is critical because downstream code (e.g., `external_data_loader.cc`, `webgpu_context.cc`) compares `OrtMemoryInfo.name` against the current constants. Simply passing through the old name would cause those comparisons to fail.

### Changes
- `onnxruntime/core/framework/allocator.cc`: Accept and normalize legacy names in `CreateMemoryInfo`
- `onnxruntime/test/shared_lib/test_allocator.cc`: Add test verifying legacy names are accepted and normalized

### See Also
- https://github.com/microsoft/onnxruntime/pull/27207 (original rename)
- https://github.com/microsoft/onnxruntime/pull/27475 (forward compat in 1.24.x)
