### PR TITLE
Honor ORT_LOGGING_LEVEL environment variable on Python import

### DIFF
--- a/onnxruntime/__init__.py
+++ b/onnxruntime/__init__.py
@@ -56,6 +56,7 @@ try:
         get_all_providers,  # noqa: F401
         get_available_providers,  # noqa: F401
         get_build_info,  # noqa: F401
+        get_default_logger_severity,  # noqa: F401
         get_device,  # noqa: F401
         get_ep_devices,  # noqa: F401
         get_version_string,  # noqa: F401

--- a/onnxruntime/python/onnxruntime_pybind_module.cc
+++ b/onnxruntime/python/onnxruntime_pybind_module.cc
@@ -3,6 +3,7 @@
 
 #include "onnxruntime_pybind_exceptions.h"
 #include "onnxruntime_pybind_module_functions.h"
+#include <cstdlib>
 #include <pybind11/stl.h>
 #include "core/providers/get_execution_providers.h"
 #include "onnxruntime_config.h"
@@ -33,7 +34,21 @@ OrtEnv* GetOrtEnv() {
 }
 static Status CreateOrtEnv() {
   Env::Default().GetTelemetryProvider().SetLanguageProjection(OrtLanguageProjection::ORT_PROJECTION_PYTHON);
-  OrtEnv::LoggingManagerConstructionInfo lm_info{nullptr, nullptr, ORT_LOGGING_LEVEL_WARNING, "Default"};
+
+  // Allow the default logging severity to be configured via ORT_LOGGING_LEVEL before the first import.
+  // Valid integer values: 0 (Verbose), 1 (Info), 2 (Warning), 3 (Error), 4 (Fatal).
+  OrtLoggingLevel logging_level = ORT_LOGGING_LEVEL_WARNING;
+  const std::string logging_env = Env::Default().GetEnvironmentVar("ORT_LOGGING_LEVEL");
+  if (!logging_env.empty()) {
+    char* end = nullptr;
+    long level = std::strtol(logging_env.c_str(), &end, 10);
+    if (end != logging_env.c_str() && *end == '\0' &&
+        level >= ORT_LOGGING_LEVEL_VERBOSE && level <= ORT_LOGGING_LEVEL_FATAL) {
+      logging_level = static_cast<OrtLoggingLevel>(level);
+    }
+  }
+
+  OrtEnv::LoggingManagerConstructionInfo lm_info{nullptr, nullptr, logging_level, "Default"};
   Status status;
   ort_env = OrtEnv::GetOrCreateInstance(lm_info, status, use_global_tp ? &global_tp_options : nullptr).release();
   if (!status.IsOK()) return status;

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -1468,6 +1468,11 @@ void addGlobalMethods(py::module& m) {
       },
       "Sets the default logging severity. 0:Verbose, 1:Info, 2:Warning, 3:Error, 4:Fatal");
   m.def(
+      "get_default_logger_severity", []() -> int {
+        return static_cast<int>(logging::LoggingManager::DefaultLogger().GetSeverity());
+      },
+      "Gets the default logging severity. 0:Verbose, 1:Info, 2:Warning, 3:Error, 4:Fatal");
+  m.def(
       "set_default_logger_verbosity", [](int vlog_level) {
         logging::LoggingManager* default_logging_manager = GetEnv().GetLoggingManager();
         default_logging_manager->SetDefaultLoggerVerbosity(vlog_level);

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -9,6 +9,7 @@ import os
 import pathlib
 import platform
 import queue
+import subprocess
 import sys
 import threading
 import unittest
@@ -103,6 +104,30 @@ class TestInferenceSession(unittest.TestCase):
     def test_get_build_info(self):
         self.assertIsNot(onnxrt.get_build_info(), None)
         self.assertIn("Build Info", onnxrt.get_build_info())
+
+    def test_get_default_logger_severity(self):
+        # Default severity should be WARNING (2) when ORT_LOGGING_LEVEL is not set.
+        severity = onnxrt.get_default_logger_severity()
+        self.assertIsInstance(severity, int)
+        self.assertGreaterEqual(severity, 0)
+        self.assertLessEqual(severity, 4)
+
+    def test_ort_logging_level_env_var(self):
+        # Verify that ORT_LOGGING_LEVEL is honored on import by running a subprocess.
+        for level in [0, 1, 2, 3, 4]:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    "import onnxruntime as ort; print(ort.get_default_logger_severity())",
+                ],
+                capture_output=True,
+                check=False,
+                text=True,
+                env={**os.environ, "ORT_LOGGING_LEVEL": str(level)},
+            )
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            self.assertEqual(result.stdout.strip(), str(level), msg=f"Expected severity {level}, got {result.stdout.strip()}")
 
     def test_model_serialization(self):
         try:

--- a/orttraining/orttraining/python/orttraining_python_module.cc
+++ b/orttraining/orttraining/python/orttraining_python_module.cc
@@ -4,6 +4,7 @@
 #include "orttraining/python/orttraining_pybind_common.h"
 #include "python/onnxruntime_pybind_mlvalue.h"
 
+#include <cstdlib>
 #include "core/common/logging/logging.h"
 #include "core/common/logging/severity.h"
 #include "core/common/path_string.h"
@@ -171,7 +172,21 @@ onnxruntime::Environment& GetEnv() {
 
 static Status CreateOrtEnv() {
   Env::Default().GetTelemetryProvider().SetLanguageProjection(OrtLanguageProjection::ORT_PROJECTION_PYTHON);
-  OrtEnv::LoggingManagerConstructionInfo lm_info{nullptr, nullptr, ORT_LOGGING_LEVEL_WARNING, "Default"};
+
+  // Allow the default logging severity to be configured via ORT_LOGGING_LEVEL before the first import.
+  // Valid integer values: 0 (Verbose), 1 (Info), 2 (Warning), 3 (Error), 4 (Fatal).
+  OrtLoggingLevel logging_level = ORT_LOGGING_LEVEL_WARNING;
+  const std::string logging_env = Env::Default().GetEnvironmentVar("ORT_LOGGING_LEVEL");
+  if (!logging_env.empty()) {
+    char* end = nullptr;
+    long level = std::strtol(logging_env.c_str(), &end, 10);
+    if (end != logging_env.c_str() && *end == '\0' &&
+        level >= ORT_LOGGING_LEVEL_VERBOSE && level <= ORT_LOGGING_LEVEL_FATAL) {
+      logging_level = static_cast<OrtLoggingLevel>(level);
+    }
+  }
+
+  OrtEnv::LoggingManagerConstructionInfo lm_info{nullptr, nullptr, logging_level, "Default"};
   Status status;
   OrtEnvPtr ort_env = OrtEnv::GetOrCreateInstance(lm_info, status, use_global_tp ? &global_tp_options : nullptr);
   if (!status.IsOK()) return status;


### PR DESCRIPTION
## What

- `CreateOrtEnv()` in `onnxruntime/python/onnxruntime_pybind_module.cc` now reads the `ORT_LOGGING_LEVEL` environment variable before constructing `OrtEnv`, so the configured severity is active from the very first log message emitted during `import onnxruntime`.
- The identical fix is applied to `orttraining/orttraining/python/orttraining_python_module.cc`.
- A new `get_default_logger_severity()` Python API is added (companion to the existing `set_default_logger_severity()`) and exported from `onnxruntime/__init__.py`.
- Two new tests in `onnxruntime_test_python.py` cover the new API and the env-var behaviour.

## Why

`ORT_LOGGING_LEVEL` is documented as a way to suppress noisy log output (e.g. GPU-discovery warnings in environments without a GPU), but it had no effect because `CreateOrtEnv()` hardcoded `ORT_LOGGING_LEVEL_WARNING`. Users were forced to redirect stderr or call `set_default_logger_severity()` after import, by which point the spurious warnings had already been emitted.

Fixes #27092

## How

`Env::Default().GetEnvironmentVar("ORT_LOGGING_LEVEL")` is read at the start of `CreateOrtEnv()`. If the value is a valid integer in `[0, 4]` it replaces the default `ORT_LOGGING_LEVEL_WARNING`; any invalid or absent value leaves the existing default unchanged.

## Test plan

- `test_get_default_logger_severity` – verifies the new getter returns a value in the valid range.
- `test_ort_logging_level_env_var` – spawns a subprocess for each valid severity level (0–4) with `ORT_LOGGING_LEVEL` set, then checks that `get_default_logger_severity()` returns the expected value immediately after import.