### PR TITLE
Add DML EP timing instrumentation and disable graph fusion for profiling

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionHelper.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionHelper.cpp
@@ -3,6 +3,9 @@
 #include "DmlGraphFusionHelper.h"
 #include "DmlRuntimeFusedGraphKernel.h"
 
+#include <chrono>
+#include <cstdio>
+
 using namespace Windows::AI::MachineLearning::Adapter;
 
 namespace Dml
@@ -582,10 +585,19 @@ namespace DmlGraphFusionHelper
         ORT_THROW_IF_FAILED(device.As(&device1));
 
         ComPtr<IDMLCompiledOperator> compiledExecutionPlanOperator;
+        auto compileGraphStart = std::chrono::steady_clock::now();
         ORT_THROW_IF_FAILED(device1->CompileGraph(
             &dmlGraphDesc,
             executionFlags,
             IID_PPV_ARGS(&compiledExecutionPlanOperator)));
+        auto compileGraphEnd = std::chrono::steady_clock::now();
+        double compileGraphMs = std::chrono::duration<double, std::milli>(compileGraphEnd - compileGraphStart).count();
+        fprintf(stderr, "[DML_TIMING]   CompileGraph internal: %.1fms (nodes=%u, edges: in=%zu, out=%zu, intermediate=%zu)\n",
+            compileGraphMs,
+            dmlGraphDesc.NodeCount,
+            dmlInputEdges.size(),
+            dmlOutputEdges.size(),
+            dmlIntermediateEdges.size());
 
         // UINT32_MAX is currently the maximum number of bytes allowed by D3D12 for the offset of a view over a resource
         if (compiledExecutionPlanOperator->GetBindingProperties().PersistentResourceSize > UINT32_MAX)

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionTransformer.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionTransformer.cpp
@@ -12,6 +12,9 @@
 #include "MLOperatorAuthorImpl.h"
 #include "DmlGraphFusionHelper.h"
 
+#include <chrono>
+#include <cstdio>
+
 
 namespace Dml
 {
@@ -92,8 +95,15 @@ namespace Dml
             }
         }
 
+        auto applyImplStart = std::chrono::steady_clock::now();
+        uint32_t splitRetryCount = 0;
+        uint32_t totalDmlPartitionsCompiled = 0;
+        double totalBuildGraphDescMs = 0.0;
+        double totalCompileOperatorMs = 0.0;
+
         do
         {
+            splitRetryCount++;
             // Initializers needed by any graph partition
             std::unordered_set<std::string> requiredInitializerMap;
             std::unordered_set<std::string> dynamicCpuInputMap;
@@ -245,6 +255,8 @@ namespace Dml
                     std::unordered_map<uint32_t, uint32_t> serializedGraphInputIndexToSubgraphInputIndex;
                     std::unordered_map<std::string_view, uint32_t> serializedGraphLargeConstantNameToSubgraphInputIndex;
                     std::vector<std::unique_ptr<std::byte[]>> smallConstantData;
+
+                    auto buildDescStart = std::chrono::steady_clock::now();
                     GraphDescBuilder::GraphDesc graphDesc = GraphDescBuilder::BuildGraphDesc(
                         isInputsUploadedByDmlEP.data(),
                         isInputsUploadedByDmlEP.size(),
@@ -258,14 +270,27 @@ namespace Dml
                         serializedGraphInputIndexToSubgraphInputIndex,
                         serializedGraphLargeConstantNameToSubgraphInputIndex,
                         smallConstantData);
+                    auto buildDescEnd = std::chrono::steady_clock::now();
+                    double buildDescMs = std::chrono::duration<double, std::milli>(buildDescEnd - buildDescStart).count();
+                    totalBuildGraphDescMs += buildDescMs;
 
-                    // Compile the operator
+                    auto compileStart = std::chrono::steady_clock::now();
                     auto compiledPartition = DmlGraphFusionHelper::TryCreateCompiledOperator(
                         graphDesc,
                         indexedSubGraph,
                         m_providerImpl,
                         &serializedGraphInputIndexToSubgraphInputIndex,
                         &serializedGraphLargeConstantNameToSubgraphInputIndex);
+                    auto compileEnd = std::chrono::steady_clock::now();
+                    double compileMs = std::chrono::duration<double, std::milli>(compileEnd - compileStart).count();
+                    totalCompileOperatorMs += compileMs;
+                    totalDmlPartitionsCompiled++;
+
+                    fprintf(stderr, "[DML_TIMING] Partition %u: nodes=%zu, BuildGraphDesc=%.1fms, CompileOperator=%.1fms\n",
+                        partitionIndex,
+                        indexedSubGraph.nodes.size(),
+                        buildDescMs,
+                        compileMs);
 
                     if (!compiledPartition)
                     {
@@ -295,6 +320,16 @@ namespace Dml
             }
         }
         while (!additionalSplittingNodes.empty());
+
+        auto applyImplEnd = std::chrono::steady_clock::now();
+        double applyImplMs = std::chrono::duration<double, std::milli>(applyImplEnd - applyImplStart).count();
+        fprintf(stderr, "[DML_TIMING] === ApplyImplHelper Summary ===\n");
+        fprintf(stderr, "[DML_TIMING]   Total time: %.1fms (%.1fs)\n", applyImplMs, applyImplMs / 1000.0);
+        fprintf(stderr, "[DML_TIMING]   DML partitions compiled: %u\n", totalDmlPartitionsCompiled);
+        fprintf(stderr, "[DML_TIMING]   Split/retry iterations: %u\n", splitRetryCount);
+        fprintf(stderr, "[DML_TIMING]   Total BuildGraphDesc: %.1fms\n", totalBuildGraphDescMs);
+        fprintf(stderr, "[DML_TIMING]   Total CompileOperator: %.1fms\n", totalCompileOperatorMs);
+        fprintf(stderr, "[DML_TIMING] ============================\n");
 
         uint32_t partitionIndex = 0;
         for (auto&& compiledPartitionInfo : compiledPartitionInfos)

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -534,6 +534,8 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
       provider_options["enable_graph_capture"] = "false";
     }
     session_options.AppendExecutionProvider("DML", provider_options);
+    session_options.AddConfigEntry(kOrtSessionOptionsConfigDisableDmlGraphFusion, "1");
+    fprintf(stderr, "[DML_CONFIG] Graph fusion disabled (ep.dml.disable_graph_fusion=1)\n");
 #else
     ORT_THROW("DML is not supported in this build\n");
 #endif


### PR DESCRIPTION


### Description

Add timing instrumentation to the DML EP graph fusion pipeline to diagnose
the very long compilation bottleneck, and disable graph fusion
in the perf test tool as a workaround for internal experimentation.

**Changes:**
- `DmlGraphFusionTransformer.cpp`: Add per-partition timing for `BuildGraphDesc` and `TryCreateCompiledOperator`, plus a summary of total time, partition count, and split/retry iterations
- `DmlGraphFusionHelper.cpp`: Add timing around `IDMLDevice1::CompileGraph()`
- `ort_test_session.cc`: Set `ep.dml.disable_graph_fusion=1` for DML EP sessions

### Motivation and Context

Investigating the root cause of excessive DML EP session initialization time
on large models. Instrumentation confirmed the bottleneck is split/retry
churn in `DmlGraphFusionTransformer::ApplyImplHelper()` — see GitHub issue #21255.i