### PR TITLE
Fix Python lint issues in onnxruntime_test_python.py

### DIFF
--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -9,6 +9,7 @@ import os
 import pathlib
 import platform
 import queue
+import subprocess
 import sys
 import threading
 import unittest
@@ -103,6 +104,30 @@ class TestInferenceSession(unittest.TestCase):
     def test_get_build_info(self):
         self.assertIsNot(onnxrt.get_build_info(), None)
         self.assertIn("Build Info", onnxrt.get_build_info())
+
+    def test_get_default_logger_severity(self):
+        # Default severity should be WARNING (2) when ORT_LOGGING_LEVEL is not set.
+        severity = onnxrt.get_default_logger_severity()
+        self.assertIsInstance(severity, int)
+        self.assertGreaterEqual(severity, 0)
+        self.assertLessEqual(severity, 4)
+
+    def test_ort_logging_level_env_var(self):
+        # Verify that ORT_LOGGING_LEVEL is honored on import by running a subprocess.
+        for level in [0, 1, 2, 3, 4]:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    "import onnxruntime as ort; print(ort.get_default_logger_severity())",
+                ],
+                capture_output=True,
+                check=False,
+                text=True,
+                env={**os.environ, "ORT_LOGGING_LEVEL": str(level)},
+            )
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            self.assertEqual(result.stdout.strip(), str(level), msg=f"Expected severity {level}, got {result.stdout.strip()}")
 
     def test_model_serialization(self):
         try:


### PR DESCRIPTION
## What

Fix two ruff lint errors in `onnxruntime/test/python/onnxruntime_test_python.py` introduced alongside new tests for the `ORT_LOGGING_LEVEL` environment variable (see #27645):

- Move `import subprocess` from inside a test method body to the module-level stdlib import block
- Add explicit `check=False` to `subprocess.run()`

Also includes the two new tests themselves:

- `test_get_default_logger_severity` – verifies the new `get_default_logger_severity()` API (added in #27645) returns a value in `[0, 4]`
- `test_ort_logging_level_env_var` – spawns a subprocess for each valid level (0–4) with `ORT_LOGGING_LEVEL` set and confirms the reported severity matches

## Why

`PLC0415` (`import` inside function body) and `PLW1510` (`subprocess.run` without explicit `check` argument) are enforced by the project's ruff configuration and would fail CI lint checks.

## How

- `import subprocess` relocated to the module-level stdlib imports section (alphabetically correct position)
- `check=False` added to `subprocess.run()` call to satisfy `PLW1510`; the return code is already checked manually via `self.assertEqual(result.returncode, 0, ...)`

## Files Modified

- `onnxruntime/test/python/onnxruntime_test_python.py`

## Lint Status

| Check | Before | After |
|-------|--------|-------|
| ruff (this file) | 2 errors | 2 errors (pre-existing, unrelated to this PR) |
| `PLC0415` | present | fixed |
| `PLW1510` | present | fixed |

The 2 remaining errors (`I001` import ordering, `FURB171` single-item membership test) exist in `main` and are out of scope.

## Note

The new tests depend on `ort.get_default_logger_severity()` introduced in #27645. They are included here as the tests are the reason this file was touched at all, and keeping the lint fixes alongside the tests avoids a dangling import on `main`.