### PR TITLE
[webgpu] Fix div precision

### DIFF
--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
@@ -307,12 +307,12 @@ WEBGPU_BINARY_KERNEL(Add, 14, Add, WebGpuSupportedNumberTypes())
 std::string GetDivImpl(int lhs_element_type, int /* rhs_element_type */) {
   if (lhs_element_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT || lhs_element_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16) {
     return "fn precise_div(a: output_value_t, b: output_value_t) -> output_value_t {\n"
-        "  return select(a / b, round(a / b), (a % b) == output_value_t(0.0));\n"
-        "}\n";
+           "  return select(a / b, round(a / b), (a % b) == output_value_t(0.0));\n"
+           "}\n";
   }
   return "fn precise_div(a: output_value_t, b: output_value_t) -> output_value_t {\n"
-      "  return a / b;\n"
-      "}\n";
+         "  return a / b;\n"
+         "}\n";
 }
 
 WEBGPU_BINARY_IMPL(Div, "precise_div(a, b)", GetDivImpl)


### PR DESCRIPTION
### Description
For float types, GPU f32 division can introduce small ULP errors that cause exact integer quotients to be slightly off (e.g., 165.0/15.0 = 11.000001). When followed by Ceil (like it is for granite speech), this produces wrong results. We fix this by rounding the result when the operands are exactly divisible.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->



Closes #27661

