### PR TITLE
[CoreML EP] Add Expand and Where op builders for BERT model support

### DIFF
--- a/onnxruntime/core/providers/coreml/builders/impl/cast_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/cast_op_builder.cc
@@ -150,8 +150,8 @@ bool CastOpBuilder::HasSupportedInputsImpl(const Node& node, [[maybe_unused]] co
     } else {
       LOGS(logger, VERBOSE) << "[" << node.OpType()
                             << "] Input type: [" << input_type
-                            << "] or output type: [" << output_type
-                            << "] is not supported.";
+                            << "] and/or output type: [" << output_type
+                            << "] is not supported for ML Program Cast.";
       return false;
     }
   }

--- a/onnxruntime/core/providers/coreml/builders/impl/cast_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/cast_op_builder.cc
@@ -77,13 +77,16 @@ Status CastOpBuilder::AddToModelBuilderImpl([[maybe_unused]] ModelBuilder& model
 
 bool CastOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputParams& input_params,
                                       const logging::Logger& logger) const {
+  // ML Program supports Cast on all inputs including graph inputs with no preceding nodes.
+  // This is important for models like BERT where Cast is applied directly to graph inputs
+  // (e.g., casting attention_mask from INT64 to FLOAT).
+  if (input_params.create_mlprogram) {
+    return true;
+  }
+
   if (node.GetInputEdgesCount() == 0) {
     LOGS(logger, VERBOSE) << "Cast has no preceding nodes.";
     return false;
-  }
-
-  if (input_params.create_mlprogram) {
-    return true;
   }
 
   const auto& prec_node = node.InputEdgesBegin()->GetNode();
@@ -132,18 +135,22 @@ bool CastOpBuilder::HasSupportedInputsImpl(const Node& node, [[maybe_unused]] co
   }
 
   if (input_params.create_mlprogram) {
-    if ((input_type == ONNX_NAMESPACE::TensorProto_DataType_INT32 ||
-         input_type == ONNX_NAMESPACE::TensorProto_DataType_INT64 ||
-         input_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT ||
-         input_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT16) &&
-        (output_type == ONNX_NAMESPACE::TensorProto_DataType_INT32 ||
-         output_type == ONNX_NAMESPACE::TensorProto_DataType_INT64 ||
-         output_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT ||
-         output_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT16)) {
+    // ML Program Cast supports INT32, INT64, FLOAT, FLOAT16, and BOOL types.
+    // BOOL support is important for models like BERT that cast boolean attention masks.
+    const auto is_supported_type = [](int32_t type) {
+      return type == ONNX_NAMESPACE::TensorProto_DataType_INT32 ||
+             type == ONNX_NAMESPACE::TensorProto_DataType_INT64 ||
+             type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT ||
+             type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT16 ||
+             type == ONNX_NAMESPACE::TensorProto_DataType_BOOL;
+    };
+
+    if (is_supported_type(input_type) && is_supported_type(output_type)) {
       return true;
     } else {
       LOGS(logger, VERBOSE) << "[" << node.OpType()
                             << "] Input type: [" << input_type
+                            << "] or output type: [" << output_type
                             << "] is not supported.";
       return false;
     }

--- a/onnxruntime/core/providers/coreml/builders/impl/expand_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/expand_op_builder.cc
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/optimizer/initializer.h"
+#include "core/providers/coreml/builders/helper.h"
+#include "core/providers/coreml/builders/impl/base_op_builder.h"
+#include "core/providers/coreml/builders/impl/builder_utils.h"
+#include "core/providers/coreml/builders/model_builder.h"
+#include "core/providers/coreml/builders/op_builder_factory.h"
+#include "core/providers/coreml/shape_utils.h"
+#include "core/providers/shared/utils/utils.h"
+
+namespace onnxruntime {
+namespace coreml {
+
+class ExpandOpBuilder : public BaseOpBuilder {
+  void AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) const override;
+
+  Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node,
+                               const logging::Logger& logger) const override;
+
+  bool IsOpSupportedImpl(const Node& node, const OpBuilderInputParams& input_params,
+                         const logging::Logger& logger) const override;
+
+  // Expand opset 8 is the first version with the shape input
+  int GetMinSupportedOpSet(const Node& /* node */) const override { return 8; }
+
+  bool SupportsMLProgram() const override { return true; }
+};
+
+void ExpandOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) const {
+  const auto& input_defs = node.InputDefs();
+  // Skip the shape input if it is a constant initializer, as we will consume it directly
+  if (input_defs.size() > 1) {
+    const auto* shape_initializer = model_builder.GetConstantInitializer(input_defs[1]->Name());
+    if (shape_initializer) {
+      model_builder.AddInitializerToSkip(input_defs[1]->Name());
+    }
+  }
+}
+
+Status ExpandOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node,
+                                              const logging::Logger& logger) const {
+  const auto& input_defs = node.InputDefs();
+
+  if (model_builder.CreateMLProgram()) {
+    using namespace CoreML::Specification::MILSpec;
+
+    // https://apple.github.io/coremltools/source/coremltools.converters.mil.mil.ops.defs.html#coremltools.converters.mil.mil.ops.defs.iOS15.tensor_transformation.broadcast_to
+    //
+    // CoreML broadcast_to: broadcasts the input tensor to the given shape.
+    // Inputs: x (tensor), shape (1D int32 tensor of target shape)
+    std::unique_ptr<Operation> op = model_builder.CreateOperation(node, "broadcast_to");
+    AddOperationInput(*op, "x", input_defs[0]->Name());
+
+    const auto* shape_initializer = model_builder.GetConstantInitializer(input_defs[1]->Name());
+    if (shape_initializer) {
+      // Shape is a constant initializer — read it and add as a const operation
+      Initializer unpacked_tensor(model_builder.GetGraphViewer().GetGraph(), *shape_initializer);
+      auto shape_data = unpacked_tensor.DataAsSpan<int64_t>();
+      AddOperationInput(*op, "shape",
+                        model_builder.AddConstant(op->type(), "shape", shape_data));
+    } else {
+      // Shape is a dynamic runtime value — pass it through directly.
+      // CoreML will handle the int64->int32 conversion at the framework level.
+      AddOperationInput(*op, "shape", input_defs[1]->Name());
+    }
+
+    AddOperationOutput(*op, *node.OutputDefs()[0]);
+    model_builder.AddOperation(std::move(op));
+  } else {
+    // NeuralNetwork path is not supported for Expand
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "ExpandOpBuilder: Expand is only supported in ML Program mode");
+  }
+
+  ORT_UNUSED_PARAMETER(logger);
+  return Status::OK();
+}
+
+bool ExpandOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputParams& input_params,
+                                        const logging::Logger& logger) const {
+  if (!input_params.create_mlprogram) {
+    LOGS(logger, VERBOSE) << "Expand is only supported in ML Program mode";
+    return false;
+  }
+
+  const auto& input_defs = node.InputDefs();
+  if (input_defs.size() < 2) {
+    LOGS(logger, VERBOSE) << "Expand requires 2 inputs (data and shape)";
+    return false;
+  }
+
+  // Validate output rank does not exceed 5 (CoreML limitation)
+  const auto* output_shape = node.OutputDefs()[0]->Shape();
+  if (output_shape && output_shape->dim_size() > 5) {
+    LOGS(logger, VERBOSE) << "Expand output rank " << output_shape->dim_size()
+                          << " exceeds CoreML limit of 5";
+    return false;
+  }
+
+  return true;
+}
+
+void CreateExpandOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
+  op_registrations.builders.push_back(std::make_unique<ExpandOpBuilder>());
+  op_registrations.op_builder_map.emplace(op_type, op_registrations.builders.back().get());
+}
+
+}  // namespace coreml
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/coreml/builders/impl/expand_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/expand_op_builder.cc
@@ -61,9 +61,18 @@ Status ExpandOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const
       AddOperationInput(*op, "shape",
                         model_builder.AddConstant(op->type(), "shape", shape_data));
     } else {
-      // Shape is a dynamic runtime value — pass it through directly.
-      // CoreML will handle the int64->int32 conversion at the framework level.
-      AddOperationInput(*op, "shape", input_defs[1]->Name());
+      // Shape is a dynamic runtime value. CoreML broadcast_to requires shape as int32,
+      // but ONNX Expand provides shape as int64. Insert a cast op to convert.
+      std::unique_ptr<Operation> cast_op = model_builder.CreateOperation(node, "cast", "shape_cast");
+      AddOperationInput(*cast_op, "x", input_defs[1]->Name());
+      AddOperationInput(*cast_op, "dtype",
+                        model_builder.AddScalarConstant(cast_op->type(), "dtype", std::string("int32")));
+      const auto& cast_output = model_builder.GetUniqueName(node, "shape_int32");
+      AddIntermediateOperationOutput(*cast_op, cast_output,
+                                     ONNX_NAMESPACE::TensorProto_DataType_INT32, std::nullopt);
+      model_builder.AddOperation(std::move(cast_op));
+
+      AddOperationInput(*op, "shape", cast_output);
     }
 
     AddOperationOutput(*op, *node.OutputDefs()[0]);

--- a/onnxruntime/core/providers/coreml/builders/impl/where_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/where_op_builder.cc
@@ -106,6 +106,19 @@ bool WhereOpBuilder::HasSupportedInputsImpl(const Node& node,
     return false;
   }
 
+  // CoreML select requires a and b to have matching element types.
+  // Validate that X and Y have the same dtype.
+  int32_t x_type = ONNX_NAMESPACE::TensorProto_DataType_UNDEFINED;
+  int32_t y_type = ONNX_NAMESPACE::TensorProto_DataType_UNDEFINED;
+  if (!GetType(*input_defs[1], x_type, logger) || !GetType(*input_defs[2], y_type, logger)) {
+    return false;
+  }
+  if (x_type != y_type) {
+    LOGS(logger, VERBOSE) << "[Where] X and Y inputs must have the same type, got X: "
+                          << x_type << " and Y: " << y_type;
+    return false;
+  }
+
   return true;
 }
 

--- a/onnxruntime/core/providers/coreml/builders/impl/where_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/where_op_builder.cc
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/coreml/builders/helper.h"
+#include "core/providers/coreml/builders/impl/base_op_builder.h"
+#include "core/providers/coreml/builders/impl/builder_utils.h"
+#include "core/providers/coreml/builders/model_builder.h"
+#include "core/providers/coreml/builders/op_builder_factory.h"
+#include "core/providers/coreml/shape_utils.h"
+#include "core/providers/shared/utils/utils.h"
+
+namespace onnxruntime {
+namespace coreml {
+
+class WhereOpBuilder : public BaseOpBuilder {
+  Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node,
+                               const logging::Logger& logger) const override;
+
+  bool IsOpSupportedImpl(const Node& node, const OpBuilderInputParams& input_params,
+                         const logging::Logger& logger) const override;
+
+  bool HasSupportedInputsImpl(const Node& node, const OpBuilderInputParams& input_params,
+                              const logging::Logger& logger) const override;
+
+  // Where opset 9 is the first version with broadcasting support
+  int GetMinSupportedOpSet(const Node& /* node */) const override { return 9; }
+
+  bool SupportsMLProgram() const override { return true; }
+};
+
+Status WhereOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node,
+                                             const logging::Logger& logger) const {
+  const auto& input_defs = node.InputDefs();
+
+  if (model_builder.CreateMLProgram()) {
+    using namespace CoreML::Specification::MILSpec;
+
+    // https://apple.github.io/coremltools/source/coremltools.converters.mil.mil.ops.defs.html#coremltools.converters.mil.mil.ops.defs.iOS15.elementwise_binary.select
+    //
+    // CoreML select: return cond ? a : b (element-wise with broadcasting)
+    // Inputs: cond (bool tensor), a (true branch), b (false branch)
+    std::unique_ptr<Operation> op = model_builder.CreateOperation(node, "select");
+    AddOperationInput(*op, "cond", input_defs[0]->Name());
+    AddOperationInput(*op, "a", input_defs[1]->Name());
+    AddOperationInput(*op, "b", input_defs[2]->Name());
+
+    AddOperationOutput(*op, *node.OutputDefs()[0]);
+    model_builder.AddOperation(std::move(op));
+  } else {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "WhereOpBuilder: Where is only supported in ML Program mode");
+  }
+
+  ORT_UNUSED_PARAMETER(logger);
+  return Status::OK();
+}
+
+bool WhereOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputParams& input_params,
+                                       const logging::Logger& logger) const {
+  if (!input_params.create_mlprogram) {
+    LOGS(logger, VERBOSE) << "Where is only supported in ML Program mode";
+    return false;
+  }
+
+  const auto& input_defs = node.InputDefs();
+  if (input_defs.size() < 3) {
+    LOGS(logger, VERBOSE) << "Where requires 3 inputs (condition, X, Y)";
+    return false;
+  }
+
+  // Validate output rank does not exceed 5 (CoreML limitation)
+  const auto* output_shape = node.OutputDefs()[0]->Shape();
+  if (output_shape && output_shape->dim_size() > 5) {
+    LOGS(logger, VERBOSE) << "Where output rank " << output_shape->dim_size()
+                          << " exceeds CoreML limit of 5";
+    return false;
+  }
+
+  return true;
+}
+
+bool WhereOpBuilder::HasSupportedInputsImpl(const Node& node,
+                                            [[maybe_unused]] const OpBuilderInputParams& input_params,
+                                            const logging::Logger& logger) const {
+  // Where has 3 inputs:
+  //   input 0 (condition): must be BOOL
+  //   input 1 (X / true branch): FLOAT, FLOAT16, or INT64 (in ML Program mode)
+  //   input 2 (Y / false branch): same type as X
+  const auto& input_defs = node.InputDefs();
+
+  // Validate condition input is BOOL
+  int32_t cond_type = ONNX_NAMESPACE::TensorProto_DataType_UNDEFINED;
+  if (!GetType(*input_defs[0], cond_type, logger)) {
+    return false;
+  }
+  if (cond_type != ONNX_NAMESPACE::TensorProto_DataType_BOOL) {
+    LOGS(logger, VERBOSE) << "[Where] condition input must be BOOL, got type: " << cond_type;
+    return false;
+  }
+
+  // Validate X and Y inputs have supported types
+  if (!IsInputDtypeSupport(node, 1, input_params, logger)) {
+    return false;
+  }
+  if (!IsInputDtypeSupport(node, 2, input_params, logger)) {
+    return false;
+  }
+
+  return true;
+}
+
+void CreateWhereOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
+  op_registrations.builders.push_back(std::make_unique<WhereOpBuilder>());
+  op_registrations.op_builder_map.emplace(op_type, op_registrations.builders.back().get());
+}
+
+}  // namespace coreml
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/coreml/builders/op_builder_factory.cc
+++ b/onnxruntime/core/providers/coreml/builders/op_builder_factory.cc
@@ -66,6 +66,7 @@ static OpBuilderRegistrations CreateOpBuilderRegistrations() {
   CreateConvOpBuilder("Conv", op_registrations);
   CreateConvTransposeOpBuilder("ConvTranspose", op_registrations);
   CreateDepthToSpaceOpBuilder("DepthToSpace", op_registrations);
+  CreateExpandOpBuilder("Expand", op_registrations);
   CreateFlattenOpBuilder("Flatten", op_registrations);
   CreateGatherOpBuilder("Gather", op_registrations);
   CreateGemmOpBuilder("Gemm", op_registrations);
@@ -82,6 +83,7 @@ static OpBuilderRegistrations CreateOpBuilderRegistrations() {
   CreateSqueezeOpBuilder("Squeeze", op_registrations);
   CreateTransposeOpBuilder("Transpose", op_registrations);
   CreateSqueezeOpBuilder("Unsqueeze", op_registrations);
+  CreateWhereOpBuilder("Where", op_registrations);
 
   return op_registrations;
 }

--- a/onnxruntime/core/providers/coreml/builders/op_builder_factory.h
+++ b/onnxruntime/core/providers/coreml/builders/op_builder_factory.h
@@ -27,6 +27,7 @@ void CreateConcatOpBuilder(const std::string& op_type, OpBuilderRegistrations& o
 void CreateConvOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateConvTransposeOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateDepthToSpaceOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+void CreateExpandOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateFlattenOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateGatherOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateGemmOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
@@ -44,6 +45,7 @@ void CreateSplitOpBuilder(const std::string& op_type, OpBuilderRegistrations& op
 void CreateSqueezeOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateTransposeOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateUnaryOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+void CreateWhereOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 
 }  // namespace coreml
 }  // namespace onnxruntime


### PR DESCRIPTION
## Summary

- Add `Expand` op builder mapping ONNX Expand to CoreML ML Program `broadcast_to`
- Add `Where` op builder mapping ONNX Where to CoreML ML Program `select`
- Fix `Cast` op builder to support graph inputs in ML Program mode (no preceding nodes required)
- Add BOOL type support to Cast's input/output type validation for ML Program

## Motivation

Fixes #25421

BERT-family models running on the CoreML execution provider currently fall back to CPU for several critical operations: Expand, Where, Cast (on graph inputs), Unsqueeze, and attention-layer MatMul. This causes significant performance degradation compared to running the model natively through CoreML.

This PR addresses the most impactful gaps — the two completely missing op builders (Expand and Where) and the Cast limitation that blocked type casting on graph inputs like `attention_mask`.

With these changes, the BERT attention masking pipeline (Unsqueeze → Expand → Cast → Where) can execute entirely on CoreML's ML Program path, enabling ANE/GPU acceleration.

## Changes

**New files:**
- `expand_op_builder.cc` — Maps ONNX `Expand` to CoreML `broadcast_to`. Handles both constant initializer shapes (consumed directly as const ops) and dynamic runtime shapes. ML Program only, opset 8+.
- `where_op_builder.cc` — Maps ONNX `Where` to CoreML `select`. Validates BOOL condition input and FLOAT/FLOAT16/INT64 value inputs. ML Program only, opset 9+.

**Modified files:**
- `cast_op_builder.cc` — Moved the ML Program early return before the `GetInputEdgesCount() == 0` check, so Cast on graph inputs (e.g., casting `attention_mask` from INT64 to FLOAT) is supported in ML Program mode. Also added BOOL to the supported input/output type list for ML Program Cast.
- `op_builder_factory.h` / `op_builder_factory.cc` — Registered the new Expand and Where op builders.

## Test Plan

- [ ] Verify with a BERT token classification model (e.g., `bert-base-uncased` exported to ONNX) that Expand, Where, and Cast nodes are now assigned to CoreMLExecutionProvider instead of CPUExecutionProvider
- [ ] Run existing CoreML EP tests to confirm no regressions
- [ ] Validate on macOS with ML Program mode enabled