### PR TITLE
fix: invalid ccache args when running with old ccache version

### DIFF
--- a/tools/ci_build/github/linux/build_cuda_ci.sh
+++ b/tools/ci_build/github/linux/build_cuda_ci.sh
@@ -36,16 +36,18 @@ else
     BUILD_ARGS+=('--build_dir' 'build')
 fi
 
-if [ -x "$(command -v ccache)" ]; then
-    ccache -s;
-    #BUILD_ARGS+=("--use_cache")
+if command -v ccache &> /dev/null; then
+    ccache --zero-stats
+    BUILD_ARGS+=("--use_cache")
 fi
+
 if [ -f /opt/python/cp312-cp312/bin/python3 ]; then
     PATH=/opt/python/cp312-cp312/bin:$PATH python tools/ci_build/build.py "${BUILD_ARGS[@]}"
 else
     python3 tools/ci_build/build.py "${BUILD_ARGS[@]}"
 fi
-if [ -x "$(command -v ccache)" ]; then
-    ccache -sv
-    ccache -z
+
+if command -v ccache &> /dev/null; then
+    # FIXME: can't use `-vv` for extra details b/c we're shipping with a decrepit version of ccache (3.something) that doesn't support it.
+    ccache --show-stats # -vv
 fi

--- a/tools/ci_build/github/linux/build_linux_python_package.sh
+++ b/tools/ci_build/github/linux/build_linux_python_package.sh
@@ -18,7 +18,7 @@ PYTHON_EXES=(
   "/opt/python/cp312-cp312/bin/python3.12"
   )
 
-while getopts "d:p:x:c:e" parameter_Option
+while getopts "d:p:x:c:" parameter_Option
 do case "${parameter_Option}"
 in
 #GPU|WEBGPU|CPU|NPU.
@@ -34,7 +34,6 @@ p)
   ;;
 x) EXTRA_ARG=${OPTARG};;
 c) BUILD_CONFIG=${OPTARG};;
-e) ENABLE_CACHE=true;;
 *) echo "Usage: $0 -d <GPU|WEBGPU|CPU|NPU> [-p <python_exe_path>] [-x <extra_build_arg>] [-c <build_config>]"
    exit 1;;
 esac
@@ -45,9 +44,10 @@ BUILD_ARGS=("--build_dir" "/build" "--config" "$BUILD_CONFIG" "--update" "--buil
 if [ "$BUILD_CONFIG" != "Debug" ]; then
     BUILD_ARGS+=("--enable_lto")
 fi
-if [ "$ENABLE_CACHE" = true ] ; then
+
+if command -v ccache &> /dev/null; then
+    ccache --zero-stats
     BUILD_ARGS+=("--use_cache")
-    ccache -s;
 fi
 
 ARCH=$(uname -m)
@@ -116,6 +116,7 @@ do
   cp /build/"$BUILD_CONFIG"/dist/*.whl /build/dist
 done
 
-if [ "$ENABLE_CACHE" = true ] ; then
-  which ccache && ccache -sv && ccache -z
+if command -v ccache &> /dev/null; then
+  # FIXME: can't use `-vv` for extra details b/c we're shipping with a decrepit version of ccache (3.something) that doesn't support it.
+  ccache --show-stats # -vv
 fi

--- a/tools/ci_build/github/linux/build_tensorrt_ci.sh
+++ b/tools/ci_build/github/linux/build_tensorrt_ci.sh
@@ -45,16 +45,18 @@ else
     BUILD_ARGS+=('--build_dir' 'build')
 fi
 
-if [ -x "$(command -v ccache)" ]; then
-    ccache -s;
+if command -v ccache &> /dev/null; then
+    ccache --zero-stats
     BUILD_ARGS+=("--use_cache")
 fi
+
 if [ -f /opt/python/cp312-cp312/bin/python3 ]; then
     PATH=/opt/python/cp312-cp312/bin:$PATH /opt/python/cp312-cp312/bin/python3 tools/ci_build/build.py "${BUILD_ARGS[@]}"
 else
     python3 tools/ci_build/build.py "${BUILD_ARGS[@]}"
 fi
-if [ -x "$(command -v ccache)" ]; then
-    ccache -sv
-    ccache -z
+
+if command -v ccache &> /dev/null; then
+    # FIXME: can't use `-vv` for extra details b/c we're shipping with a decrepit version of ccache (3.something) that doesn't support it.
+    ccache --show-stats # -vv
 fi


### PR DESCRIPTION
### Description
Don't try to show extended ccache stats.

### Motivation and Context
Current docker images are on a package set that contains a decrepit version of ccache that doesn't understand `--verbose` (`-v`).
If `ccache` is added via the pkg manager -> build scripts fail.
This matters b/c we will be soon enabling ccache throughout various pipelines/workflows.