### PR TITLE
[docs] Plugin EP usage - Add references to Python and C# usage examples

### DIFF
--- a/docs/execution-providers/plugin-ep-libraries/usage.md
+++ b/docs/execution-providers/plugin-ep-libraries/usage.md
@@ -11,6 +11,12 @@ nav_order: 1
 
 This page provides a reference on how to use a plugin EP library with the ONNX Runtime API.
 
+The code on this page is C++ and uses the ONNX Runtime C++ API.
+
+There are also some usage examples in other languages:
+- [Python example](https://github.com/microsoft/onnxruntime-inference-examples/blob/main/plugin_execution_providers/basic/python/example_usage/example_usage.py)
+- [C# example](https://github.com/microsoft/onnxruntime-inference-examples/blob/main/plugin_execution_providers/basic/csharp/SampleApp/Program.cs)
+
 ## Contents
 {: .no_toc }
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Add references to Python and C# usage examples in the plugin EP usage documentation.

Preview: https://edgchen1.github.io/onnxruntime/docs/execution-providers/plugin-ep-libraries/usage.html

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Make examples more accessible.