### PR TITLE
[VitisAI] pass base timestamp for vitisai profiling

### DIFF
--- a/onnxruntime/core/providers/vitisai/imp/global_api.cc
+++ b/onnxruntime/core/providers/vitisai/imp/global_api.cc
@@ -91,6 +91,8 @@ struct OrtVitisAIEpAPI {
       const std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>& eps,
       const char* const* keys,
       const char* const* values, size_t kv_len) = nullptr;
+  void (*profiler_start)(uint64_t profiling_start_time_ns);
+  void (*profiler_stop)();
   void (*profiler_collect)(
       std::vector<EventInfo>& api_events,
       std::vector<EventInfo>& kernel_events);
@@ -132,6 +134,8 @@ struct OrtVitisAIEpAPI {
     }
     std::ignore = env.GetSymbolFromLibrary(handle_, "vaip_get_version",
                                            (void**)&vaip_get_version);
+    std::ignore = env.GetSymbolFromLibrary(handle_, "profiler_start", (void**)&profiler_start);
+    std::ignore = env.GetSymbolFromLibrary(handle_, "profiler_stop", (void**)&profiler_stop);
     std::ignore = env.GetSymbolFromLibrary(handle_, "profiler_collect", (void**)&profiler_collect);
     ORT_THROW_IF_ERROR(env.GetSymbolFromLibrary(handle_, "create_ep_context_nodes", (void**)&create_ep_context_nodes));
     ORT_THROW_IF_ERROR(env.GetSymbolFromLibrary(handle_, "vitisai_ep_on_run_start", (void**)&vitisai_ep_on_run_start));
@@ -157,6 +161,18 @@ static std::vector<OrtCustomOpDomain*> s_domains_vitisaiep;
 static vaip_core::OrtApiForVaip the_global_api;
 std::shared_ptr<KernelRegistry> get_kernel_registry_vitisaiep() { return s_kernel_registry_vitisaiep; }
 const std::vector<OrtCustomOpDomain*>& get_domains_vitisaiep() { return s_domains_vitisaiep; }
+
+void profiler_start(uint64_t profiling_start_time_ns) {
+  if (s_library_vitisaiep.profiler_start) {
+    s_library_vitisaiep.profiler_start(profiling_start_time_ns);
+  }
+}
+
+void profiler_stop() {
+  if (s_library_vitisaiep.profiler_stop) {
+    s_library_vitisaiep.profiler_stop();
+  }
+}
 
 void profiler_collect(
     std::vector<EventInfo>& api_events,

--- a/onnxruntime/core/providers/vitisai/include/vaip/global_api.h
+++ b/onnxruntime/core/providers/vitisai/include/vaip/global_api.h
@@ -37,6 +37,16 @@ using EventInfo = std::tuple<
     long long,    // timestamp
     long long     // duration
     >;
+
+// Notify EP that profiling has started with the base timestamp (in nanoseconds since epoch)
+// The EP can use this to:
+// 1. Calculate relative timestamps (event_ts - base_ts) for the profiling timeline
+// 2. Store the absolute base timestamp if needed for other purposes
+void profiler_start(uint64_t profiling_start_time_ns);
+
+// Notify EP that profiling has stopped
+void profiler_stop();
+
 void profiler_collect(
     std::vector<EventInfo>& api_events,
     std::vector<EventInfo>& kernel_events);

--- a/onnxruntime/core/providers/vitisai/vitisai_profiler.cc
+++ b/onnxruntime/core/providers/vitisai/vitisai_profiler.cc
@@ -9,10 +9,17 @@ namespace profiling {
 #if defined(USE_VITISAI)
 
 bool VitisaiProfiler::StartProfiling(TimePoint tp) {
+  // Notify VAIP EP that profiling has started with base timestamp
+  profiler_start(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                     tp.time_since_epoch())
+                     .count());
   return true;
 }
 
 void VitisaiProfiler::EndProfiling(TimePoint tp, Events& events) {
+  // Notify VAIP EP that profiling has stopped
+  profiler_stop();
+
   auto time_point =
       std::chrono::duration_cast<std::chrono::microseconds>(tp.time_since_epoch()).count();
 


### PR DESCRIPTION
### Description
Pass base timestamp for vitisai profiling

Notify EP that profiling has started with the base timestamp (in nanoseconds since epoch)
The VitisAI EP can use this to:
1. Calculate relative timestamps (event_ts - base_ts) for the profiling timeline
2. Store the absolute base timestamp if needed for other purposes



### Motivation and Context
Due to onnxruntime default profiling json file just have the offset timestamp, it doesn't provider the base timestamp for VitisAI EP, To combine the VaitisAI timeline profiling info and  the onnxruntime default profiling json file info, We need pass the timestamp for VitisAI EP.


