### PR TITLE
Fix onnxruntime-qnn python wheel build on WSL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -399,9 +399,7 @@ if platform.system() == "Linux" or platform.system() == "AIX":
         "libHtpPrepare.so",
     ]
     dl_libs.extend(qnn_deps)
-    is_wsl = "microsoft-standard" in platform.uname().release.lower()
-    if is_wsl:
-        libs.extend(qnn_deps)
+    libs.extend(qnn_deps)
     # NV TensorRT RTX
     nv_tensorrt_rtx_deps = ["libtensorrt_rtx.so", "libtensorrt_onnxparser_rtx.so"]
     dl_libs.extend(nv_tensorrt_rtx_deps)


### PR DESCRIPTION
### Description

Building Linux onnxruntime-qnn python wheel didn't work through WSL because QNN lib dependencies were not copied over to the wheel, so this PR resolved the issue.


