### PR TITLE
Fix WebGPU ConvTranspose shader bugs for non-vectorizable input channels

### DIFF
--- a/onnxruntime/core/providers/webgpu/nn/conv_backprop.cc
+++ b/onnxruntime/core/providers/webgpu/nn/conv_backprop.cc
@@ -36,7 +36,7 @@ Status ConvTranspose2DProgram::GenerateShaderCode(ShaderHelper& shader) const {
            << "w_offset += 2;\n";
       } else if (a_components_ == 1) {
         ss << "let xValue = vec4<dy_element_t>(" << dy.GetByOffset("x_offset") << ", " << dy.GetByOffset("x_offset + 1u") << ", " << dy.GetByOffset("x_offset + 2u") << ", " << dy.GetByOffset("x_offset + 3u") << ");\n"
-           << "let wValue = vec4<dy_element_t>(" << w.GetByOffset("x_offset") << ", " << w.GetByOffset("x_offset + 1u") << ", " << w.GetByOffset("x_offset + 2u") << ", " << w.GetByOffset("x_offset + 3u") << ");\n"
+           << "let wValue = vec4<dy_element_t>(" << w.GetByOffset("w_offset") << ", " << w.GetByOffset("w_offset + 1u") << ", " << w.GetByOffset("w_offset + 2u") << ", " << w.GetByOffset("w_offset + 3u") << ");\n"
            << "dotProd = dotProd + dot(xValue, wValue);\n"
            << "x_offset += 4;\n"
            << "w_offset += 4;\n";
@@ -69,7 +69,7 @@ Status ConvTranspose2DProgram::GenerateShaderCode(ShaderHelper& shader) const {
       ORT_ENFORCE(pack_input_as4_, "Invalid input_channels_remainder: ", input_channels_remainder_);
       if (a_components_ == 1) {
         for (uint32_t i = 0; i < input_channels_remainder_; ++i) {
-          ss << "dotProd = dotProd + " << dy.GetByOffset("x_offset + " + std::to_string(i)) << ";\n";
+          ss << "dotProd = dotProd + " << dy.GetByOffset("x_offset + " + std::to_string(i)) << " * " << w.GetByOffset("w_offset + " + std::to_string(i)) << ";\n";
         }
       } else if (a_components_ == 2) {
         if (input_channels_remainder_ != 2) {


### PR DESCRIPTION
## Description

Fix two bugs in the WebGPU ConvTranspose shader code generation (conv_backprop.cc) in the `pack_input_as4_` code path when `a_components_ == 1` (triggered when input channels per group is not divisible by 2 or 4, e.g., 5 or 7).

### Bug 1: Wrong offset for weight reads
Weight values were read using `x_offset` (the input/dy tensor offset) instead of `w_offset` (the weight tensor offset), producing incorrect convolution results.

### Bug 2: Missing weight multiplication in remainder loop
The remainder loop (handling leftover channels when `inputChannelsPerGroup` is not a multiple of 4) was adding raw input values to `dotProd` without multiplying by the corresponding weight values.

## Motivation and Context

The `inChannels = 5` and `inChannels = 7` test cases in `conv-transpose.jsonc` were failing because these channel counts aren't divisible by 2 or 4, triggering the buggy `a_components_ == 1` branch. Cases like `inChannels = 6` (`a_components_ = 2`) and `inChannels = 8` (`a_components_ = 4`) were unaffected.

## Testing

All 22 conv-transpose WebGPU tests now pass:
```
npm test -- op conv-transpose.jsonc -b=webgpu -e=node
22 passing (23s)
```
