### PR TITLE
fixes to pass webnn DequantizeLinear compliance tests over webgpu ep

### DIFF
--- a/onnxruntime/core/providers/webgpu/quantization/quantize_linear.cc
+++ b/onnxruntime/core/providers/webgpu/quantization/quantize_linear.cc
@@ -65,13 +65,11 @@ Status DequantizeLinearProgram::GenerateShaderCode(ShaderHelper& shader) const {
         << "let scale_value = " << scale.GetByOffset("scale_index") << ";\n";
   } else {
     // Block quantization. Scale input rank is same as input/output rank.
-    // Divide each dimension by its block size (output_shape[i] / scale_shape[i]).
+    // On the block axis, divide by block_size; on other axes, use output index directly.
     shader.MainFunctionBody() << "var scale_indices: scale_indices_t;\n";
     for (int i = 0; i < rank_; i++) {
-      std::string output_dim = GetElementAt("uniforms.output_shape", i, rank_);
-      std::string scale_dim = GetElementAt("uniforms.scale_shape", i, rank_);
-      std::string block_expr = "(" + output_dim + " / " + scale_dim + ")";
-      std::string value_expr = output.IndicesGet("output_indices", i) + " / " + block_expr;
+      std::string idx = output.IndicesGet("output_indices", i);
+      std::string value_expr = "select(" + idx + ", " + idx + " / uniforms.block_size, " + std::to_string(i) + "u == uniforms.axis)";
       shader.MainFunctionBody() << scale.IndicesSet("scale_indices", i, value_expr) << "\n";
     }
     shader.MainFunctionBody()
@@ -208,6 +206,28 @@ Status DequantizeLinear::ComputeInternal(ComputeContext& context) const {
     }
     if (block_size == 0) {
       block_size = 1;  // all dims match, default to block_size=1
+    }
+  }
+
+  // Validate shapes for blocked quantization.
+  if (!per_layer && !per_axis && block_size > 0) {
+    const auto& scale_shape = x_scale->Shape();
+    ORT_RETURN_IF(scale_shape.NumDimensions() != x_shape.NumDimensions(),
+                  "x_scale and x must have the same rank for blocked quantization");
+    for (size_t i = 0; i < x_shape.NumDimensions(); i++) {
+      if (static_cast<int64_t>(i) == axis) {
+        ORT_RETURN_IF(scale_shape[i] != (x_shape[i] + block_size - 1) / block_size,
+                      "x_scale must be ceil(Di/block_size) on the quantize axis i for blocked quantization");
+      } else {
+        ORT_RETURN_IF(scale_shape[i] != x_shape[i],
+                      "x_scale and x must have the same shape on non-quantize axes for blocked quantization");
+      }
+    }
+    if (x_zeropoint != nullptr) {
+      for (size_t i = 0; i < x_shape.NumDimensions(); i++) {
+        ORT_RETURN_IF(x_zeropoint->Shape()[i] != scale_shape[i],
+                      "x_zero_point and x_scale must have the same shape for blocked quantization");
+      }
     }
   }
 

--- a/onnxruntime/core/providers/webgpu/quantization/quantize_linear.h
+++ b/onnxruntime/core/providers/webgpu/quantization/quantize_linear.h
@@ -48,6 +48,7 @@ class DequantizeLinear final : public WebGpuKernel {
     axis_ = info.GetAttrOrDefault<int64_t>("axis", 1);
     block_size_ = info.GetAttrOrDefault<int64_t>("block_size", 0);
     output_dtype_ = info.GetAttrOrDefault<int64_t>("output_dtype", 0);
+    ORT_ENFORCE(block_size_ >= 0, "'block_size' must be non-negative.");
   }
 
   Status ComputeInternal(ComputeContext& context) const override;

--- a/onnxruntime/test/providers/cpu/tensor/quantize_linear_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/quantize_linear_test.cc
@@ -1280,6 +1280,11 @@ void DequantizeLinearOp21BlockedTest_InvalidBlockSize_Int(int64_t block_size,
   SessionOptions so;
   std::vector<std::string> log_msgs;  // redirect error messages
   std::vector<std::unique_ptr<IExecutionProvider>> eps;
+  auto webgpu_ep = DefaultWebGpuExecutionProvider();
+  if (webgpu_ep) {
+    eps.push_back(std::move(webgpu_ep));
+  }
+
   eps.push_back(DefaultCpuExecutionProvider());
   so.user_logging_function = [](void* param, OrtLoggingLevel severity, const char* category,
                                 const char* logid, const char* code_location, const char* message) {
@@ -1325,6 +1330,12 @@ void DequantizeLinearOp21BlockedTest_InvalidBlockSize_Int4(int64_t block_size,
   SessionOptions so;
   std::vector<std::string> log_msgs;  // redirect error messages
   std::vector<std::unique_ptr<IExecutionProvider>> eps;
+  if (!ep) {
+    auto webgpu_ep = DefaultWebGpuExecutionProvider();
+    if (webgpu_ep) {
+      eps.push_back(std::move(webgpu_ep));
+    }
+  }
   eps.push_back(ep ? std::move(ep) : DefaultCpuExecutionProvider());
   so.user_logging_function = [](void* param, OrtLoggingLevel severity, const char* category,
                                 const char* logid, const char* code_location, const char* message) {
@@ -1370,6 +1381,10 @@ void DequantizeLinearOp21BlockedTest_InvalidBlockSize_Float8(int64_t block_size,
   SessionOptions so;
   std::vector<std::string> log_msgs;  // redirect error messages
   std::vector<std::unique_ptr<IExecutionProvider>> eps;
+  auto webgpu_ep = DefaultWebGpuExecutionProvider();
+  if (webgpu_ep) {
+    eps.push_back(std::move(webgpu_ep));
+  }
   eps.push_back(DefaultCpuExecutionProvider());
   so.user_logging_function = [](void* param, OrtLoggingLevel severity, const char* category,
                                 const char* logid, const char* code_location, const char* message) {
@@ -1558,7 +1573,14 @@ void DequantizeLinearOp21BlockedTest_Int4_Succeed(std::vector<int64_t>&& dims,
   std::vector<Tout> x_scale, y;
   std::vector<Tin> x, x_zero_point;
   std::vector<std::unique_ptr<IExecutionProvider>> eps;
+  if (!ep) {
+    auto webgpu_ep = DefaultWebGpuExecutionProvider();
+    if (webgpu_ep) {
+      eps.push_back(std::move(webgpu_ep));
+    }
+  }
   eps.push_back(ep ? std::move(ep) : DefaultCpuExecutionProvider());
+
   int64_t non_neg_axis = axis < 0 ? axis + dims.size() : axis;
   bool use_zero_point = !x_zero_point_.empty();
 
@@ -1602,6 +1624,10 @@ void DequantizeLinearOp21BlockedTest_Int_Succeed(std::vector<int64_t>&& dims,
   std::vector<Tout> x_scale, y;
   std::vector<Tin> x, x_zero_point;
   std::vector<std::unique_ptr<IExecutionProvider>> eps;
+  auto webgpu_ep = DefaultWebGpuExecutionProvider();
+  if (webgpu_ep) {
+    eps.push_back(std::move(webgpu_ep));
+  }
   eps.push_back(DefaultCpuExecutionProvider());
 
   int64_t non_neg_axis = axis < 0 ? axis + dims.size() : axis;
@@ -1638,6 +1664,10 @@ void DequantizeLinearOp21BlockedTest_Float8_Succeed(std::vector<int64_t>&& dims,
   std::vector<Tout> x_scale, y;
   std::vector<Tin> x, x_zero_point;
   std::vector<std::unique_ptr<IExecutionProvider>> eps;
+  auto webgpu_ep = DefaultWebGpuExecutionProvider();
+  if (webgpu_ep) {
+    eps.push_back(std::move(webgpu_ep));
+  }
   eps.push_back(DefaultCpuExecutionProvider());
 
   int64_t non_neg_axis = axis < 0 ? axis + dims.size() : axis;


### PR DESCRIPTION
This PR is on top of a previous PR and fixes the remaining issues.
https://github.com/microsoft/onnxruntime/pull/27706

All tests here should be passing now over webgpu:
https://wpt.live/webnn/conformance_tests/dequantizeLinear.https.any.html?gpu
