### PR TITLE
Include license file in built distributions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42.0.0", "wheel"]
+requires = ["setuptools>=61.0.0", "wheel", "packaging"]
 build-backend = "setuptools.build_meta"
 
 [tool.pydocstyle]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=42.0.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [tool.pydocstyle]
 convention = "google"
 

--- a/setup.py
+++ b/setup.py
@@ -872,6 +872,7 @@ setup(
     author_email="onnxruntime@microsoft.com",
     cmdclass=cmd_classes,
     license="MIT License",
+    license_files=["LICENSE", "ThirdPartyNotices.txt"],
     packages=packages,
     ext_modules=ext_modules,
     package_data=package_data,

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,9 @@ from os import environ, getcwd, path, popen, remove
 from pathlib import Path
 from shutil import copyfile
 
+import setuptools
 from packaging.tags import sys_tags
+from packaging.version import Version
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext as _build_ext
 from setuptools.command.install import install as InstallCommandBase
@@ -863,30 +865,34 @@ if package_name == "onnxruntime-gpu" and cuda_major_version:
         }
     )
 
-setup(
-    name=package_name,
-    version=version_number,
-    description="ONNX Runtime is a runtime accelerator for Machine Learning models",
-    long_description=long_description,
-    author="Microsoft Corporation",
-    author_email="onnxruntime@microsoft.com",
-    cmdclass=cmd_classes,
-    license="MIT License",
-    license_files=["LICENSE", "ThirdPartyNotices.txt"],
-    packages=packages,
-    ext_modules=ext_modules,
-    package_data=package_data,
-    url="https://onnxruntime.ai",
-    download_url="https://github.com/microsoft/onnxruntime/tags",
-    data_files=data_files,
-    install_requires=install_requires,
-    extras_require=extras_require,
-    python_requires=">=3.11",
-    keywords="onnx machine learning",
-    entry_points={
+setup_kwargs = {
+    "name": package_name,
+    "version": version_number,
+    "description": "ONNX Runtime is a runtime accelerator for Machine Learning models",
+    "long_description": long_description,
+    "author": "Microsoft Corporation",
+    "author_email": "onnxruntime@microsoft.com",
+    "cmdclass": cmd_classes,
+    "license": "MIT License",
+    "packages": packages,
+    "ext_modules": ext_modules,
+    "package_data": package_data,
+    "url": "https://onnxruntime.ai",
+    "download_url": "https://github.com/microsoft/onnxruntime/tags",
+    "data_files": data_files,
+    "install_requires": install_requires,
+    "extras_require": extras_require,
+    "python_requires": ">=3.11",
+    "keywords": "onnx machine learning",
+    "entry_points": {
         "console_scripts": [
             "onnxruntime_test = onnxruntime.tools.onnxruntime_test:main",
         ]
     },
-    classifiers=classifiers,
-)
+    "classifiers": classifiers,
+}
+
+if Version(setuptools.__version__) >= Version("42"):
+    setup_kwargs["license_files"] = ["LICENSE", "ThirdPartyNotices.txt"]
+
+setup(**setup_kwargs)

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,7 @@ from os import environ, getcwd, path, popen, remove
 from pathlib import Path
 from shutil import copyfile
 
-import setuptools
 from packaging.tags import sys_tags
-from packaging.version import Version
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext as _build_ext
 from setuptools.command.install import install as InstallCommandBase
@@ -865,34 +863,30 @@ if package_name == "onnxruntime-gpu" and cuda_major_version:
         }
     )
 
-setup_kwargs = {
-    "name": package_name,
-    "version": version_number,
-    "description": "ONNX Runtime is a runtime accelerator for Machine Learning models",
-    "long_description": long_description,
-    "author": "Microsoft Corporation",
-    "author_email": "onnxruntime@microsoft.com",
-    "cmdclass": cmd_classes,
-    "license": "MIT License",
-    "packages": packages,
-    "ext_modules": ext_modules,
-    "package_data": package_data,
-    "url": "https://onnxruntime.ai",
-    "download_url": "https://github.com/microsoft/onnxruntime/tags",
-    "data_files": data_files,
-    "install_requires": install_requires,
-    "extras_require": extras_require,
-    "python_requires": ">=3.11",
-    "keywords": "onnx machine learning",
-    "entry_points": {
+setup(
+    name=package_name,
+    version=version_number,
+    description="ONNX Runtime is a runtime accelerator for Machine Learning models",
+    long_description=long_description,
+    author="Microsoft Corporation",
+    author_email="onnxruntime@microsoft.com",
+    cmdclass=cmd_classes,
+    license="MIT License",
+    license_files=["LICENSE", "ThirdPartyNotices.txt"],
+    packages=packages,
+    ext_modules=ext_modules,
+    package_data=package_data,
+    url="https://onnxruntime.ai",
+    download_url="https://github.com/microsoft/onnxruntime/tags",
+    data_files=data_files,
+    install_requires=install_requires,
+    extras_require=extras_require,
+    python_requires=">=3.11",
+    keywords="onnx machine learning",
+    entry_points={
         "console_scripts": [
             "onnxruntime_test = onnxruntime.tools.onnxruntime_test:main",
         ]
     },
-    "classifiers": classifiers,
-}
-
-if Version(setuptools.__version__) >= Version("42"):
-    setup_kwargs["license_files"] = ["LICENSE", "ThirdPartyNotices.txt"]
-
-setup(**setup_kwargs)
+    classifiers=classifiers,
+)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Add explicit license_files to Python package build metadata so wheels/sdists expose standard License-File entries.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Downstream compliance tooling may fail to discover license text when only SPDX/classifier metadata is present and License-File fields are missing, even if license files are included in the wheel.
