### PR TITLE
Fix return type of CalibrationDataReader.get_next

### DIFF
--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -12,6 +12,7 @@ import uuid
 from collections.abc import Sequence
 from enum import Enum
 from pathlib import Path
+from typing import Optional
 
 import numpy as np
 import onnx
@@ -164,7 +165,7 @@ class CalibrationDataReader(metaclass=abc.ABCMeta):
         return (hasattr(subclass, "get_next") and callable(subclass.get_next)) or NotImplemented
 
     @abc.abstractmethod
-    def get_next(self) -> dict:
+    def get_next(self) -> Optional[dict]:
         """generate the input data dict for ONNXinferenceSession run"""
         raise NotImplementedError
 


### PR DESCRIPTION
## Describe your changes

`CalibrationDataReader.get_next` was annotated with `-> dict`, but the method contract allows returning `None` to signal end-of-data — as evidenced by `__next__` checking `if result is None: raise StopIteration`.

This PR fixes the return type annotation to `Optional[dict]` and adds the necessary `from typing import Optional` import.

### Change summary
- `onnxruntime/python/tools/quantization/calibrate.py`: Change `get_next(self) -> dict` to `get_next(self) -> Optional[dict]`

## Motivation and Context

The incorrect type annotation causes type-checking tools (e.g. mypy, pyright) to flag any code that checks `if result is None` as unreachable, and misleads users implementing the abstract method into thinking `None` is not a valid return value.

## Test Plan

This is a type annotation fix only — no behavioral changes. Existing tests cover the runtime behavior.

## Related Issues

N/A