### PR TITLE
fix: replace ort-nightly with stable onnxruntime package

### DIFF
--- a/onnxruntime/python/tools/transformers/models/longformer/convert_to_onnx.py
+++ b/onnxruntime/python/tools/transformers/models/longformer/convert_to_onnx.py
@@ -19,7 +19,7 @@
 #   conda activate longformer
 #   python3 -m pip install torch==1.9.0+cu111 torchvision==0.10.0+cu111 torchaudio==0.9.0 -f https://download.pytorch.org/whl/torch_stable.html
 #   python3 -m pip install flatbuffers numpy packaging sympy protobuf==3.20.1 onnx==1.12.0 transformers==4.18.0
-#   python3 -m pip install -i https://test.pypi.org/simple/ ort-nightly-gpu
+#   python3 -m pip install onnxruntime-gpu
 #   cd ./torch_extensions
 #   rm -rf build
 #   python setup.py install

--- a/onnxruntime/python/tools/transformers/notebooks/Tensorflow_Tf2onnx_Bert-Squad_OnnxRuntime_CPU.ipynb
+++ b/onnxruntime/python/tools/transformers/notebooks/Tensorflow_Tf2onnx_Bert-Squad_OnnxRuntime_CPU.ipynb
@@ -46,31 +46,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "source": [
-    "import sys\n",
-    " \n",
-    "!{sys.executable} -m pip install --quiet --upgrade tensorflow==2.6.0\n",
-    "!{sys.executable} -m pip install -i https://test.pypi.org/simple/ ort-nightly\n",
-    "!{sys.executable} -m pip install --quiet --upgrade tf2onnx==1.9.2\n",
-    "!{sys.executable} -m pip install --quiet transformers==4.9.2\n",
-    "!{sys.executable} -m pip install --quiet onnxconverter_common\n",
-    "!{sys.executable} -m pip install --quiet psutil wget pandas"
-   ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Looking in indexes: https://test.pypi.org/simple/\n",
-      "Requirement already satisfied: ort-nightly in /bert_ort/wy/anaconda3/envs/cpu_env/lib/python3.8/site-packages (1.8.2.dev20210901001)\n",
-      "Requirement already satisfied: protobuf in /bert_ort/wy/anaconda3/envs/cpu_env/lib/python3.8/site-packages (from ort-nightly) (3.17.3)\n",
-      "Requirement already satisfied: numpy>=1.16.6 in /bert_ort/wy/anaconda3/envs/cpu_env/lib/python3.8/site-packages (from ort-nightly) (1.19.5)\n",
-      "Requirement already satisfied: flatbuffers in /bert_ort/wy/anaconda3/envs/cpu_env/lib/python3.8/site-packages (from ort-nightly) (1.12)\n",
-      "Requirement already satisfied: six>=1.9 in /bert_ort/wy/anaconda3/envs/cpu_env/lib/python3.8/site-packages (from protobuf->ort-nightly) (1.15.0)\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "source": "import sys\n \n!{sys.executable} -m pip install --quiet --upgrade tensorflow==2.6.0\n!{sys.executable} -m pip install --quiet onnxruntime\n!{sys.executable} -m pip install --quiet --upgrade tf2onnx==1.9.2\n!{sys.executable} -m pip install --quiet transformers==4.9.2\n!{sys.executable} -m pip install --quiet onnxconverter_common\n!{sys.executable} -m pip install --quiet psutil wget pandas",
+   "outputs": [],
    "metadata": {
     "scrolled": true
    }


### PR DESCRIPTION
Two files reference `ort-nightly` (ONNX Runtime nightly builds):

- `onnxruntime/python/tools/transformers/models/longformer/convert_to_onnx.py`
- `onnxruntime/python/tools/transformers/notebooks/Tensorflow_Tf2onnx_Bert-Squad_OnnxRuntime_CPU.ipynb`

`ort-nightly` builds are published intermittently and old versions are not maintained. For production usage and example scripts, the stable `onnxruntime` package is more appropriate and avoids any version confusion risks.

This PR replaces `ort-nightly` with `onnxruntime` in both files.
