### PR TITLE
Fix QNN SDK version propagation in Linux ort-qnn wheel build

### DIFF
--- a/tools/ci_build/github/azure-pipelines/stages/py-cpu-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/py-cpu-packaging-stage.yml
@@ -194,6 +194,7 @@ stages:
     - template: ../templates/py-linux-qnn.yml
       parameters:
         machine_pool: 'onnxruntime-Ubuntu2404-AMD-CPU'
+        QnnSdk: ${{ parameters.qnn_sdk_version }}
         extra_build_arg: ${{ parameters.build_py_parameters }}
         cmake_build_type: ${{ parameters.cmake_build_type }}
         is1ES: true


### PR DESCRIPTION
### Description

QNN python wheel pipeline for Linux didn't take into account the QNN version that the user can override when running the pipeline and always used whatever was the default in the pipeline yamls. Allow for overriding QNN version in onnxruntime-qnn Linux python wheel pipelines.


