### PR TITLE
Fix runtime-unresolvable type annotations in Session and InferenceSession

### DIFF
--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -19,8 +19,6 @@ if typing.TYPE_CHECKING:
     import numpy as np
     import numpy.typing as npt
 
-    import onnxruntime
-
 
 def get_ort_device_type(device_type: str) -> int:
     if device_type == "cuda":
@@ -204,35 +202,35 @@ class Session:
         self._sess = None
         self._enable_fallback = enable_fallback
 
-    def get_session_options(self) -> onnxruntime.SessionOptions:
+    def get_session_options(self) -> C.SessionOptions:
         "Return the session options. See :class:`onnxruntime.SessionOptions`."
         return self._sess_options
 
-    def get_inputs(self) -> Sequence[onnxruntime.NodeArg]:
+    def get_inputs(self) -> Sequence[C.NodeArg]:
         "Return the inputs metadata as a list of :class:`onnxruntime.NodeArg`."
         return self._inputs_meta
 
-    def get_outputs(self) -> Sequence[onnxruntime.NodeArg]:
+    def get_outputs(self) -> Sequence[C.NodeArg]:
         "Return the outputs metadata as a list of :class:`onnxruntime.NodeArg`."
         return self._outputs_meta
 
-    def get_overridable_initializers(self) -> Sequence[onnxruntime.NodeArg]:
+    def get_overridable_initializers(self) -> Sequence[C.NodeArg]:
         "Return the inputs (including initializers) metadata as a list of :class:`onnxruntime.NodeArg`."
         return self._overridable_initializers
 
-    def get_modelmeta(self) -> onnxruntime.ModelMetadata:
+    def get_modelmeta(self) -> C.ModelMetadata:
         "Return the metadata. See :class:`onnxruntime.ModelMetadata`."
         return self._model_meta
 
-    def get_input_memory_infos(self) -> Sequence[onnxruntime.MemoryInfo]:
+    def get_input_memory_infos(self) -> Sequence[C.OrtMemoryInfo]:
         "Return the memory info for the inputs."
         return self._input_meminfos
 
-    def get_output_memory_infos(self) -> Sequence[onnxruntime.MemoryInfo]:
+    def get_output_memory_infos(self) -> Sequence[C.OrtMemoryInfo]:
         "Return the memory info for the outputs."
         return self._output_meminfos
 
-    def get_input_epdevices(self) -> Sequence[onnxruntime.OrtEpDevice]:
+    def get_input_epdevices(self) -> Sequence[C.OrtEpDevice]:
         "Return the execution providers for the inputs."
         return self._input_epdevices
 
@@ -244,7 +242,7 @@ class Session:
         "Return registered execution providers' configurations."
         return self._provider_options
 
-    def get_provider_graph_assignment_info(self) -> Sequence[onnxruntime.OrtEpAssignedSubgraph]:
+    def get_provider_graph_assignment_info(self) -> Sequence[C.OrtEpAssignedSubgraph]:
         """
         Get information about the subgraphs assigned to each execution provider and the nodes within.
 
@@ -469,7 +467,7 @@ class InferenceSession(Session):
     def __init__(
         self,
         path_or_bytes: str | bytes | os.PathLike,
-        sess_options: onnxruntime.SessionOptions | None = None,
+        sess_options: C.SessionOptions | None = None,
         providers: Sequence[str | tuple[str, dict[Any, Any]]] | None = None,
         provider_options: Sequence[dict[Any, Any]] | None = None,
         **kwargs,
@@ -740,7 +738,7 @@ class ModelCompiler:
 
     def __init__(
         self,
-        sess_options: onnxruntime.SessionOptions,
+        sess_options: C.SessionOptions,
         input_model_path_or_bytes: str | os.PathLike | bytes,
         embed_compiled_data_into_model: bool = False,
         external_initializers_file_path: str | os.PathLike | None = None,


### PR DESCRIPTION
## Summary
- Replace `onnxruntime.X` type annotations with `C.X` (`_pybind_state`) in `onnxruntime_inference_collection.py` so they resolve at runtime via `typing.get_type_hints()`
- Fix incorrect `onnxruntime.MemoryInfo` annotation → `C.OrtMemoryInfo` (the actual exported class name)
- Remove unused `import onnxruntime` from `TYPE_CHECKING` block

## Motivation
Fixes #17676

The `Session` and `InferenceSession` classes use `onnxruntime.SessionOptions`, `onnxruntime.NodeArg`, etc. in type annotations. However, `import onnxruntime` is guarded under `typing.TYPE_CHECKING`, which means it is only available to static type checkers — not at runtime. Combined with `from __future__ import annotations` (PEP 563), calling `typing.get_type_hints()` on any of these methods raises `NameError: name 'onnxruntime' is not defined`.

This breaks any tool that relies on runtime type introspection (e.g., `help()`, Sphinx autodoc, pydantic, FastAPI).

The `_pybind_state` module is already imported unconditionally as `C` on line 16 and used extensively throughout the file for runtime references (e.g., `C.GraphOptimizationLevel` on line 749). Switching annotations to use `C.X` is consistent with the existing file style and makes them resolvable both statically and at runtime.

Additionally, `onnxruntime.MemoryInfo` was used in annotations for `get_input_memory_infos()` and `get_output_memory_infos()`, but `MemoryInfo` does not exist in the Python API — the pybind11-exported class is `OrtMemoryInfo`. This was a latent bug masked by the fact that annotations were never evaluated at runtime.

## Changes
- `onnxruntime/python/onnxruntime_inference_collection.py`:
  - `onnxruntime.SessionOptions` → `C.SessionOptions` (3 locations: `Session.get_session_options`, `InferenceSession.__init__`, `ModelCompiler.__init__`)
  - `onnxruntime.NodeArg` → `C.NodeArg` (3 locations: `get_inputs`, `get_outputs`, `get_overridable_initializers`)
  - `onnxruntime.ModelMetadata` → `C.ModelMetadata` (`get_modelmeta`)
  - `onnxruntime.MemoryInfo` → `C.OrtMemoryInfo` (`get_input_memory_infos`, `get_output_memory_infos`)
  - `onnxruntime.OrtEpDevice` → `C.OrtEpDevice` (`get_input_epdevices`)
  - `onnxruntime.OrtEpAssignedSubgraph` → `C.OrtEpAssignedSubgraph` (`get_provider_graph_assignment_info`)
  - Removed unused `import onnxruntime` from `TYPE_CHECKING` block

## Test Plan
- Verified all six `C.X` type names exist in the pybind11 bindings (`onnxruntime_pybind_state.cc`)
- `ruff check` — all checks passed
- `ruff format --check` — already formatted
- `lintrunner` — no lint issues
- No functional behavior changes; only type annotation metadata is affected