### PR TITLE
[QNN-EP] Fix use-after-free of logger object

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -468,9 +468,7 @@ void QnnLogging(const char* format,
   }
 }
 
-Status QnnBackendManager::InitializeQnnLog(const logging::Logger& logger) {
-  logger_ = &logger;
-
+Status QnnBackendManager::InitializeQnnLog() {
   // Set Qnn log level align with Ort log level
   auto ort_log_level = logger_->GetSeverity();
   QnnLog_Level_t qnn_log_level = MapOrtSeverityToQNNLogLevel(ort_log_level);
@@ -1564,6 +1562,8 @@ Status QnnBackendManager::SetupBackend(const logging::Logger& logger,
                                        std::unordered_map<std::string, std::unique_ptr<std::vector<std::string>>>& context_bin_map,
                                        bool enable_htp_extended_udma_mode) {
   std::lock_guard<std::recursive_mutex> lock(logger_recursive_mutex_);
+  if (logger_ != &logger)
+    logger_ = &logger;
   if (backend_setup_completed_) {
     LOGS(logger, VERBOSE) << "Backend setup already!";
 
@@ -1630,7 +1630,7 @@ Status QnnBackendManager::SetupBackend(const logging::Logger& logger,
   }
 
   if (status.IsOK()) {
-    status = InitializeQnnLog(logger);
+    status = InitializeQnnLog();
   }
   if (status.IsOK()) {
     LOGS(logger, VERBOSE) << "SetLogger succeed.";

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -321,7 +321,7 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
 
   // Sets the ORT logger and creates a corresponding QNN logger with the same log level.
   // NOTE: caller must lock the `logger_recursive_mutex_` before calling this function.
-  Status InitializeQnnLog(const logging::Logger& logger);
+  Status InitializeQnnLog();
 
   // Terminate logging in the backend
   // NOTE: This function locks the internal `logger_recursive_mutex_`.


### PR DESCRIPTION
### Description
Update logger object in QnnBackendManager::SetupBackend.



### Motivation and Context
While generating weight sharing context binary, Inference Session is created once for each graph. Inference session creates logger object and passes it to QnnBackendManager. QnnBackendManager stores this pointer in logger_ pointer and holds it long after Inference Session destroys Logger. On next Inference Session, another Logger object is created but QnnBackendManager do not use this as backend_setup_completed_ is already set, using this causes UAF.


