### PR TITLE
Fix DRM loop error propagation bypassing PCI fallback on vGPU instances

### DIFF
--- a/onnxruntime/core/platform/linux/device_discovery.cc
+++ b/onnxruntime/core/platform/linux/device_discovery.cc
@@ -278,7 +278,11 @@ Status GetGpuDevices(std::vector<OrtHardwareDevice>& gpu_devices_out) {
 
   for (const auto& gpu_sysfs_path_info : gpu_sysfs_path_infos) {
     OrtHardwareDevice gpu_device{};
-    ORT_RETURN_IF_ERROR(GetGpuDeviceFromSysfs(gpu_sysfs_path_info, gpu_device));
+    auto drm_status = GetGpuDeviceFromSysfs(gpu_sysfs_path_info, gpu_device);
+    if (!drm_status.IsOK()) {
+      LOGS_DEFAULT(WARNING) << "Skipping DRM device at " << gpu_sysfs_path_info.path << ": " << drm_status.ErrorMessage();
+      continue;
+    }
     gpu_devices.emplace_back(std::move(gpu_device));
   }
 


### PR DESCRIPTION
## Description

Fixes #27806.

On AWS EC2 vGPU instances (e.g. g5.xlarge with A10G), `/sys/class/drm/card0` exists as a simple-framebuffer for console VGA but lacks `device/vendor`. `GetGpuDeviceFromSysfs` fails, and `ORT_RETURN_IF_ERROR` propagates the error immediately, preventing the PCI fallback (added in #27591) from ever running.

The PCI path has the correct data:
```
/sys/bus/pci/devices/0000:00:1e.0/vendor = 0x10de  (NVIDIA)
/sys/bus/pci/devices/0000:00:1e.0/class  = 0x030200 (3D controller)
```

## Change

Change the DRM loop in `GetGpuDevices()` to log a warning and `continue` instead of `ORT_RETURN_IF_ERROR`, as suggested by @tianleiwu during the [#27591 review](https://github.com/microsoft/onnxruntime/pull/27591). This allows the loop to skip non-GPU DRM entries (like simple-framebuffer) and fall through to the PCI fallback when no valid GPU is found via DRM.

**Before:**
```cpp
ORT_RETURN_IF_ERROR(GetGpuDeviceFromSysfs(gpu_sysfs_path_info, gpu_device));
```

**After:**
```cpp
auto drm_status = GetGpuDeviceFromSysfs(gpu_sysfs_path_info, gpu_device);
if (!drm_status.IsOK()) {
  LOGS_DEFAULT(WARNING) << "Skipping DRM device at " << gpu_sysfs_path_info.path << ": " << drm_status.ErrorMessage();
  continue;
}
```

## Testing

Verified on AWS EC2 g5.xlarge (NVIDIA A10G, Ubuntu 24.04):
- **Before**: `GetEpDevices()` returns only `CPUExecutionProvider`; warning: `GPU device discovery failed: Failed to open file: "/sys/class/drm/card0/device/vendor"`
- **After**: `GetEpDevices()` returns both `CPUExecutionProvider` and `CUDAExecutionProvider`; warning: `Skipping DRM device at "/sys/class/drm/card0": Failed to open file: "/sys/class/drm/card0/device/vendor"` (PCI fallback finds GPU correctly)

## Motivation and Context

This blocks the plugin EP architecture (`RegisterExecutionProviderLibrary`, `CopyTensors`, shared allocators) on all AWS EC2 GPU instances where the vGPU driver does not expose nvidia-drm vendor metadata via sysfs.
