### PR TITLE
Disable KleidiAI for older versions of MSVC without Aarch64 SME support.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -565,7 +565,7 @@ if(onnxruntime_USE_KLEIDIAI)
       return()
     endif()
 
-    if(MSVC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.40")
+    if(MSVC AND CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND MSVC_VERSION VERSION_LESS 1940)
       message(WARNING "KleidiAI requires MSVC compiler version 19.40 or newer, KleidiAI will be disabled in this build.")
 
       set(${is_supported_var} FALSE PARENT_SCOPE)


### PR DESCRIPTION
### Description
Support for Aarch64 SME intrinsics was added to version 19.40 of MSVC. The ONNX Runtime stated supported version of Visual Studio 2022 can go back before version 19.40.

This patch modifies cmake/CMakeLists.txt to check the version of MSVC, if it is the target compiler. For versions less than 19.40 KleidiAi will be disabled in the build.

### Motivation and Context
This issue was raised when cross compiling 1.24 for Windows on Arm.
https://github.com/microsoft/onnxruntime/issues/27304

