### PR TITLE
Add DLPack and numpy array protocols to OrtValue Python wrapper

### DIFF
--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -1209,6 +1209,77 @@ class OrtValue:
         """
         self._ortvalue.update_inplace(np_arr)
 
+    def __dlpack__(self, *, stream: Any = None) -> Any:
+        """Return a DLPack capsule representing the tensor (DLPack protocol).
+
+        This enables zero-copy interop with frameworks that support DLPack, e.g.::
+
+            torch.from_dlpack(ort_value)
+            np.from_dlpack(ort_value)
+
+        :param stream: An optional stream/queue for synchronization. Currently unused.
+        :return: A PyCapsule with a ``DLManagedTensor``.
+        :raises AttributeError: If DLPack is not enabled in this build.
+        """
+        return self._ortvalue.__dlpack__(stream=stream)
+
+    def __dlpack_device__(self) -> tuple[int, int]:
+        """Return the device type and device id (DLPack protocol).
+
+        :return: A tuple ``(device_type, device_id)`` following DLPack conventions.
+        :raises AttributeError: If DLPack is not enabled in this build.
+        """
+        return self._ortvalue.__dlpack_device__()
+
+    @classmethod
+    def from_dlpack(cls, data: Any) -> OrtValue:
+        """Create an OrtValue from a DLPack-compatible object.
+
+        Accepts either a raw DLPack capsule or any object implementing
+        the ``__dlpack__`` protocol (e.g. PyTorch tensors, NumPy arrays,
+        JAX arrays, or other OrtValues).
+
+        Example::
+
+            ort_val = OrtValue.from_dlpack(torch_tensor)
+            ort_val = OrtValue.from_dlpack(numpy_array)
+            ort_val = OrtValue.from_dlpack(other_ort_value)
+
+        :param data: A DLPack capsule or any object with a ``__dlpack__`` method.
+        :return: A new :class:`OrtValue` wrapping the tensor data (zero-copy when possible).
+        :raises TypeError: If *data* does not support the DLPack protocol.
+        :raises AttributeError: If DLPack is not enabled in this build.
+        """
+        if hasattr(data, "__dlpack__"):
+            capsule = data.__dlpack__()
+        else:
+            capsule = data
+        is_bool = C.is_dlpack_uint8_tensor(capsule)
+        return cls(C.OrtValue.from_dlpack(capsule, is_bool))
+
+    def __array__(self, dtype: Any = None, copy: bool | None = None) -> np.ndarray:
+        """Support ``numpy.array(ort_value)`` and ``numpy.asarray(ort_value)``.
+
+        Implements the ``__array__`` protocol so that OrtValue integrates
+        seamlessly with NumPy operations::
+
+            arr = numpy.array(ort_value)
+            arr = numpy.asarray(ort_value)
+
+        :param dtype: Optional NumPy dtype to cast to.
+        :param copy: Optional flag. If ``False``, a copy is never forced when
+            the data already resides on CPU. ``True`` always copies. ``None``
+            (default) copies only when necessary.
+        :return: A NumPy ndarray with the tensor data.
+        """
+        result = self._ortvalue.numpy()
+
+        if dtype is not None:
+            result = result.astype(dtype, copy=copy if copy is not None else True)
+        elif copy:
+            result = result.copy()
+        return result
+
 
 def copy_tensors(src: Sequence[OrtValue], dst: Sequence[OrtValue], stream=None) -> None:
     """

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -1475,6 +1475,116 @@ class TestInferenceSession(unittest.TestCase):
                 ortvalue2 = C.OrtValue.from_dlpack(dlp2, False)
                 self.assertEqual(list(shape), list(ortvalue2.shape()))
 
+    @unittest.skipIf(not hasattr(C.OrtValue, "from_dlpack"), "dlpack not enabled in this build")
+    def test_ortvalue_dlpack_protocol(self):
+        """Test that the Python OrtValue wrapper exposes __dlpack__ and __dlpack_device__."""
+        numpy_arr = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+        ortvalue = onnxrt.OrtValue.ortvalue_from_numpy(numpy_arr)
+
+        # __dlpack_device__ returns (device_type, device_id) tuple
+        device = ortvalue.__dlpack_device__()
+        self.assertIsInstance(device, tuple)
+        self.assertEqual(len(device), 2)
+        # kDLCPU == 1
+        self.assertEqual(device[0], 1)
+        self.assertEqual(device[1], 0)
+
+        # __dlpack__ returns a PyCapsule
+        capsule = ortvalue.__dlpack__()
+        self.assertIsNotNone(capsule)
+
+        # The capsule can be consumed to create a new OrtValue (zero-copy)
+        ortvalue2 = C.OrtValue.from_dlpack(capsule, False)
+        np.testing.assert_equal(numpy_arr, ortvalue2.numpy())
+
+    @unittest.skipIf(not hasattr(C.OrtValue, "from_dlpack"), "dlpack not enabled in this build")
+    def test_ortvalue_from_dlpack_protocol(self):
+        """Test OrtValue.from_dlpack() accepting objects with __dlpack__ method."""
+        numpy_arr = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+        ortvalue_src = onnxrt.OrtValue.ortvalue_from_numpy(numpy_arr)
+
+        # from_dlpack with another OrtValue (has __dlpack__)
+        ortvalue_dst = onnxrt.OrtValue.from_dlpack(ortvalue_src)
+        self.assertIsInstance(ortvalue_dst, onnxrt.OrtValue)
+        np.testing.assert_equal(numpy_arr, ortvalue_dst.numpy())
+        # Zero-copy: same data pointer
+        self.assertEqual(ortvalue_src.data_ptr(), ortvalue_dst.data_ptr())
+
+    @unittest.skipIf(not hasattr(C.OrtValue, "from_dlpack"), "dlpack not enabled in this build")
+    def test_ortvalue_from_dlpack_numpy(self):
+        """Test OrtValue.from_dlpack() with a numpy array (numpy >= 1.22 supports __dlpack__)."""
+        numpy_arr = np.array([[10, 20], [30, 40]], dtype=np.int32)
+        if not hasattr(numpy_arr, "__dlpack__"):
+            self.skipTest("numpy version does not support __dlpack__")
+
+        ortvalue = onnxrt.OrtValue.from_dlpack(numpy_arr)
+        self.assertIsInstance(ortvalue, onnxrt.OrtValue)
+        np.testing.assert_equal(numpy_arr, ortvalue.numpy())
+
+    @unittest.skipIf(not hasattr(C.OrtValue, "from_dlpack"), "dlpack not enabled in this build")
+    def test_ortvalue_from_dlpack_raw_capsule(self):
+        """Test OrtValue.from_dlpack() with a raw DLPack capsule (no __dlpack__)."""
+        numpy_arr = np.array([5.0, 6.0], dtype=np.float32)
+        ortvalue_src = onnxrt.OrtValue.ortvalue_from_numpy(numpy_arr)
+        # Get a raw capsule via the C binding
+        raw_capsule = ortvalue_src._ortvalue.to_dlpack()
+
+        ortvalue_dst = onnxrt.OrtValue.from_dlpack(raw_capsule)
+        self.assertIsInstance(ortvalue_dst, onnxrt.OrtValue)
+        np.testing.assert_equal(numpy_arr, ortvalue_dst.numpy())
+
+    @unittest.skipIf(not hasattr(C.OrtValue, "from_dlpack"), "dlpack not enabled in this build")
+    def test_ortvalue_numpy_from_dlpack(self):
+        """Test that np.from_dlpack(ort_value) works via the __dlpack__ protocol."""
+        numpy_arr = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+        ortvalue = onnxrt.OrtValue.ortvalue_from_numpy(numpy_arr)
+
+        if not hasattr(np, "from_dlpack"):
+            self.skipTest("numpy version does not support np.from_dlpack")
+
+        result = np.from_dlpack(ortvalue)
+        np.testing.assert_equal(numpy_arr, result)
+
+    def test_ortvalue_array_protocol(self):
+        """Test that numpy.array(ort_value) works via __array__."""
+        numpy_arr = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+        ortvalue = onnxrt.OrtValue.ortvalue_from_numpy(numpy_arr)
+
+        result = np.array(ortvalue)
+        np.testing.assert_equal(numpy_arr, result)
+        self.assertEqual(result.dtype, np.float32)
+
+    def test_ortvalue_array_protocol_dtype(self):
+        """Test __array__ with dtype conversion."""
+        numpy_arr = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        ortvalue = onnxrt.OrtValue.ortvalue_from_numpy(numpy_arr)
+
+        result = np.array(ortvalue, dtype=np.float64)
+        np.testing.assert_allclose(numpy_arr.astype(np.float64), result)
+        self.assertEqual(result.dtype, np.float64)
+
+    def test_ortvalue_asarray_protocol(self):
+        """Test that numpy.asarray(ort_value) works via __array__."""
+        numpy_arr = np.array([10, 20, 30], dtype=np.int64)
+        ortvalue = onnxrt.OrtValue.ortvalue_from_numpy(numpy_arr)
+
+        result = np.asarray(ortvalue)
+        np.testing.assert_equal(numpy_arr, result)
+        self.assertEqual(result.dtype, np.int64)
+
+    def test_ortvalue_dlpack_roundtrip(self):
+        """Test full round-trip: numpy -> OrtValue -> dlpack -> OrtValue -> numpy."""
+        if not hasattr(C.OrtValue, "from_dlpack"):
+            self.skipTest("dlpack not enabled in this build")
+
+        for dtype in [np.float32, np.float64, np.int32, np.int64]:
+            with self.subTest(dtype=dtype):
+                original = np.array([1, 2, 3, 4], dtype=dtype)
+                ov1 = onnxrt.OrtValue.ortvalue_from_numpy(original)
+                ov2 = onnxrt.OrtValue.from_dlpack(ov1)
+                result = np.array(ov2)
+                np.testing.assert_equal(original, result)
+
     def test_sparse_tensor_coo_format(self):
         cpu_device = onnxrt.OrtDevice.make("cpu", 0)
         shape = [9, 9]


### PR DESCRIPTION
## Summary
- Add `__dlpack__()`, `__dlpack_device__()`, and `from_dlpack()` to the Python `OrtValue` class, enabling zero-copy tensor sharing with PyTorch, JAX, NumPy, and other DLPack-compatible frameworks.
- Add `__array__()` protocol so `np.array(ort_value)` and `np.asarray(ort_value)` work directly.
- The C binding (`C.OrtValue`) already supported these methods — this PR exposes them through the public Python wrapper class.

## Motivation
Fixes https://github.com/microsoft/onnxruntime/issues/24071

The Python `OrtValue` wrapper class did not expose the DLPack or numpy array protocols, even though the underlying C binding had full support (added in #23110). Users had to access the internal `_ortvalue` attribute to use `__dlpack__` or `from_dlpack`, which is fragile and undocumented.

With this change, standard Python interop patterns work out of the box:
```python
# DLPack protocol — zero-copy to/from PyTorch, JAX, etc.
torch_tensor = torch.from_dlpack(ort_value)
np_array = np.from_dlpack(ort_value)
ort_value = OrtValue.from_dlpack(torch_tensor)

# Numpy array protocol
np_array = np.array(ort_value)
np_array = np.asarray(ort_value)
```

## Changes
- **`onnxruntime/python/onnxruntime_inference_collection.py`**: Added 4 methods to `OrtValue`:
  - `__dlpack__(*, stream=None)` — returns a DLPack capsule (delegates to `C.OrtValue.__dlpack__`)
  - `__dlpack_device__()` — returns `(device_type, device_id)` tuple
  - `from_dlpack(data)` — classmethod accepting any `__dlpack__`-compatible object or raw capsule, with automatic bool tensor detection via `is_dlpack_uint8_tensor`
  - `__array__(dtype=None, copy=None)` — numpy array protocol, compatible with NumPy 1.x and 2.x
- **`onnxruntime/test/python/onnxruntime_test_python.py`**: Added 9 test cases covering:
  - `__dlpack__` and `__dlpack_device__` on the Python wrapper
  - `from_dlpack` with OrtValue→OrtValue, numpy→OrtValue, and raw capsule→OrtValue
  - `np.from_dlpack(ort_value)` interop
  - `np.array()`, `np.asarray()`, and dtype conversion via `__array__`
  - Full round-trip across multiple dtypes (float32, float64, int32, int64)

## Test Plan
- [x] All 9 new tests pass locally against pip-installed onnxruntime with DLPack enabled
- [x] Existing `test_ort_value_dlpack` and `test_ort_value_dlpack_zero_size` tests unaffected
- [x] `ruff check` and `ruff format --check` pass on both modified files
- [ ] CI validation