### PR TITLE
Shell injection constant strings

### DIFF
--- a/tools/nuget/validate_package.py
+++ b/tools/nuget/validate_package.py
@@ -5,6 +5,8 @@ import argparse
 import glob
 import os
 import re
+import shutil
+import subprocess
 import sys
 import zipfile  # Available Python 3.2 or higher
 
@@ -238,7 +240,7 @@ def validate_tarball(args):
     package_folder = re.search("(.*)[.].*", package_name).group(1)
 
     print("tar zxvf " + package_name)
-    os.system("tar zxvf " + package_name)
+    subprocess.run(["tar", "zxvf", package_name], check=True)
 
     is_windows_ai_package = False
     zip_file = None
@@ -336,7 +338,7 @@ def validate_nuget(args):
 
         # Make a copy of the Nuget package
         print("Copying [" + full_nuget_path + "] -> [" + nupkg_copy_name + "], and extracting its contents")
-        os.system("copy " + full_nuget_path + " " + nupkg_copy_name)
+        shutil.copy2(full_nuget_path, nupkg_copy_name)
 
         # Convert nupkg to zip
         os.rename(nupkg_copy_name, zip_copy_name)


### PR DESCRIPTION
### Description
See below



### Motivation and Context
Summary:The vulnerability lies in the ONNX Runtime's validate_package.py script, which uses unsanitized string concatenation with os.system() to construct shell commands. This allows attackers to inject arbitrary shell commands via the --package_name argument, leading to potential remote code execution. The issue affects the release validation pipeline, which operates with elevated privileges, exposing sensitive credentials and secrets. The root cause is the lack of input sanitization and the use of os.system() for command execution.

Affected code locations:

tools/nuget/validate_package.py line 241: os.system("tar zxvf " + package_name)
tools/nuget/validate_package.py line 339: os.system("copy " + full_nuget_path + " " + nupkg_copy_name)
Suggested fix: Replace os.system() with subprocess.run() using argument lists (no shell interpolation):

```
# Instead of: os.system("tar zxvf " + package_name)
subprocess.run(["tar", "zxvf", package_name], check=True)

# Instead of: os.system("copy " + full_nuget_path + " " + nupkg_copy_name)
shutil.copy2(full_nuget_path, nupkg_copy_name)
```

