### PR TITLE
Unified Native Library Staging for Java API

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -183,7 +183,7 @@ test {
 	if (cmakeBuildDir != null) {
 		workingDir cmakeBuildDir
 	}
-	systemProperties System.getProperties().subMap([
+	def allowlist = [
 		'ENABLE_TRAINING_APIS',
 		'JAVA_FULL_TEST',
 		'USE_ACL',
@@ -206,7 +206,10 @@ test {
 		'USE_WEBGPU',
 		'USE_WEBNN',
 		'USE_XNNPACK',
-		])
+		]
+	def dynamicProps = System.getProperties().findAll { it.key.toString().startsWith('onnxruntime.native.') }
+	def explicitProps = System.getProperties().findAll { allowlist.contains(it.key.toString()) }
+	systemProperties(explicitProps + dynamicProps)
 	testLogging {
 		events "passed", "skipped", "failed"
 		showStandardStreams = true

--- a/java/src/main/java/ai/onnxruntime/OnnxRuntime.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxRuntime.java
@@ -5,6 +5,7 @@
 package ai.onnxruntime;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
@@ -123,12 +124,10 @@ final class OnnxRuntime {
       stager = new OnnxStager();
       stager.stage(ONNXRUNTIME_NATIVE_PREFIX, ONNXRUNTIME_LIBRARY_NAME, CLASSPATH_BASE);
       stager.stage(ONNXRUNTIME_NATIVE_PREFIX, ONNXRUNTIME_LIBRARY_SHARED_NAME, CLASSPATH_BASE);
-      String jniLibraryPath =
-          stager
-              .stage(ONNXRUNTIME_NATIVE_PREFIX, ONNXRUNTIME_JNI_LIBRARY_NAME, CLASSPATH_BASE)
-              .toString();
+      Path jniLibraryPath =
+          stager.stage(ONNXRUNTIME_NATIVE_PREFIX, ONNXRUNTIME_JNI_LIBRARY_NAME, CLASSPATH_BASE);
       if (jniLibraryPath != null) {
-        System.load(jniLibraryPath);
+        System.load(jniLibraryPath.toString());
       }
     }
     ortApiHandle = initialiseAPIBase(ORT_API_VERSION_23);

--- a/java/src/main/java/ai/onnxruntime/OnnxRuntime.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxRuntime.java
@@ -4,19 +4,10 @@
  */
 package ai.onnxruntime;
 
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.EnumSet;
 import java.util.HashSet;
-import java.util.Locale;
-import java.util.Optional;
 import java.util.Set;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -48,62 +39,53 @@ final class OnnxRuntime {
   // The initial release of the ORT training API.
   private static final int ORT_TRAINING_API_VERSION_1 = 1;
 
-  /**
-   * The name of the system property which when set gives the path on disk where the ONNX Runtime
-   * native libraries are stored.
-   */
-  static final String ONNXRUNTIME_NATIVE_PATH = "onnxruntime.native.path";
+  private static final String ONNXRUNTIME_NATIVE_PREFIX = "onnxruntime.native";
+
+  private static final String CLASSPATH_BASE = "/ai/onnxruntime/native";
 
   /** The short name of the ONNX runtime shared library */
-  static final String ONNXRUNTIME_LIBRARY_NAME = "onnxruntime";
+  private static final String ONNXRUNTIME_LIBRARY_NAME = "onnxruntime";
 
   /** The short name of the ONNX runtime JNI shared library */
-  static final String ONNXRUNTIME_JNI_LIBRARY_NAME = "onnxruntime4j_jni";
+  private static final String ONNXRUNTIME_JNI_LIBRARY_NAME = "onnxruntime4j_jni";
 
   /** The short name of the ONNX runtime shared provider library */
-  static final String ONNXRUNTIME_LIBRARY_SHARED_NAME = "onnxruntime_providers_shared";
+  private static final String ONNXRUNTIME_LIBRARY_SHARED_NAME = "onnxruntime_providers_shared";
 
   /** The short name of the ONNX runtime CUDA provider library */
-  static final String ONNXRUNTIME_LIBRARY_CUDA_NAME = "onnxruntime_providers_cuda";
+  private static final String ONNXRUNTIME_LIBRARY_CUDA_NAME = "onnxruntime_providers_cuda";
 
   /** The short name of the ONNX runtime ROCM provider library */
-  static final String ONNXRUNTIME_LIBRARY_ROCM_NAME = "onnxruntime_providers_rocm";
+  private static final String ONNXRUNTIME_LIBRARY_ROCM_NAME = "onnxruntime_providers_rocm";
 
   /** The short name of the ONNX runtime DNNL provider library */
-  static final String ONNXRUNTIME_LIBRARY_DNNL_NAME = "onnxruntime_providers_dnnl";
+  private static final String ONNXRUNTIME_LIBRARY_DNNL_NAME = "onnxruntime_providers_dnnl";
 
   /** The short name of the ONNX runtime OpenVINO provider library */
-  static final String ONNXRUNTIME_LIBRARY_OPENVINO_NAME = "onnxruntime_providers_openvino";
+  private static final String ONNXRUNTIME_LIBRARY_OPENVINO_NAME = "onnxruntime_providers_openvino";
 
   /** The short name of the ONNX runtime TensorRT provider library */
-  static final String ONNXRUNTIME_LIBRARY_TENSORRT_NAME = "onnxruntime_providers_tensorrt";
+  private static final String ONNXRUNTIME_LIBRARY_TENSORRT_NAME = "onnxruntime_providers_tensorrt";
 
   /** The short name of the ONNX runtime QNN provider library */
-  static final String ONNXRUNTIME_LIBRARY_QNN_NAME = "onnxruntime_providers_qnn";
+  private static final String ONNXRUNTIME_LIBRARY_QNN_NAME = "onnxruntime_providers_qnn";
 
   /** The short name of the WebGPU DAWN library */
-  static final String ONNXRUNTIME_LIBRARY_WEBGPU_DAWN_NAME = "webgpu_dawn";
+  private static final String ONNXRUNTIME_LIBRARY_WEBGPU_DAWN_NAME = "webgpu_dawn";
 
   /** The short name of the WebGPU DXC library "dxil.dll" */
-  static final String ONNXRUNTIME_LIBRARY_WEBGPU_DXC_DXIL_NAME = "dxil";
+  private static final String ONNXRUNTIME_LIBRARY_WEBGPU_DXC_DXIL_NAME = "dxil";
 
   /** The short name of the WebGPU DXC library "dxcompiler.dll" */
-  static final String ONNXRUNTIME_LIBRARY_WEBGPU_DXC_DXCOMPILER_NAME = "dxcompiler";
-
-  /** The OS & CPU architecture string */
-  private static final String OS_ARCH_STR = initOsArch();
+  private static final String ONNXRUNTIME_LIBRARY_WEBGPU_DXC_DXCOMPILER_NAME = "dxcompiler";
 
   /** Have the core ONNX Runtime native libraries been loaded */
   private static boolean loaded = false;
 
-  /** The temp directory where native libraries are extracted */
-  private static Path tempDirectory;
-
-  /** The value of the {@link #ONNXRUNTIME_NATIVE_PATH} system property */
-  private static String libraryDirPathProperty;
-
   /** Tracks if the shared providers have been extracted */
   private static final Set<String> extractedSharedProviders = new HashSet<>();
+
+  private static OnnxStager stager;
 
   /** The API handle. */
   static long ortApiHandle;
@@ -125,42 +107,6 @@ final class OnnxRuntime {
 
   private OnnxRuntime() {}
 
-  /* Computes and initializes OS_ARCH_STR (such as linux-x64) */
-  private static String initOsArch() {
-    String detectedOS = null;
-    String os = System.getProperty("os.name", "generic").toLowerCase(Locale.ENGLISH);
-    if (os.contains("mac") || os.contains("darwin")) {
-      detectedOS = "osx";
-    } else if (os.contains("win")) {
-      detectedOS = "win";
-    } else if (os.contains("nux")) {
-      detectedOS = "linux";
-    } else if (isAndroid()) {
-      detectedOS = "android";
-    } else {
-      throw new IllegalStateException("Unsupported os:" + os);
-    }
-    String detectedArch = null;
-    String arch = System.getProperty("os.arch", "generic").toLowerCase(Locale.ENGLISH);
-    if (arch.startsWith("amd64") || arch.startsWith("x86_64")) {
-      detectedArch = "x64";
-    } else if (arch.startsWith("x86")) {
-      // 32-bit x86 is not supported by the Java API
-      detectedArch = "x86";
-    } else if (arch.startsWith("aarch64")) {
-      detectedArch = "aarch64";
-    } else if (arch.startsWith("ppc64")) {
-      detectedArch = "ppc64";
-    } else if (arch.startsWith("loongarch64")) {
-      detectedArch = "loongarch64";
-    } else if (isAndroid()) {
-      detectedArch = arch;
-    } else {
-      throw new IllegalStateException("Unsupported arch:" + arch);
-    }
-    return detectedOS + '-' + detectedArch;
-  }
-
   /**
    * Loads the native C library.
    *
@@ -171,53 +117,31 @@ final class OnnxRuntime {
     if (loaded) {
       return;
     }
-    tempDirectory = isAndroid() ? null : Files.createTempDirectory("onnxruntime-java");
-    try {
-      libraryDirPathProperty = System.getProperty(ONNXRUNTIME_NATIVE_PATH);
-      // Extract and prepare the shared provider library but don't try to load it,
-      // the ONNX Runtime native library will load it
-      extractProviderLibrary(ONNXRUNTIME_LIBRARY_SHARED_NAME);
-
-      // Extract and prepare the Dawn shared libraries (if present) but don't try to load them,
-      // the ONNX Runtime native library will load them
-      extractProviderLibrary(ONNXRUNTIME_LIBRARY_WEBGPU_DAWN_NAME);
-      extractProviderLibrary(ONNXRUNTIME_LIBRARY_WEBGPU_DXC_DXIL_NAME);
-      extractProviderLibrary(ONNXRUNTIME_LIBRARY_WEBGPU_DXC_DXCOMPILER_NAME);
-
-      if (!isAndroid()) {
-        load(ONNXRUNTIME_LIBRARY_NAME);
-      }
-      load(ONNXRUNTIME_JNI_LIBRARY_NAME);
-
-      ortApiHandle = initialiseAPIBase(ORT_API_VERSION_23);
-      if (ortApiHandle == 0L) {
-        throw new IllegalStateException(
-            "There is a mismatch between the ORT class files and the ORT native library, and the native library could not be loaded");
-      }
-      ortTrainingApiHandle = initialiseTrainingAPIBase(ortApiHandle, ORT_API_VERSION_23);
-      ortCompileApiHandle = initialiseCompileAPIBase(ortApiHandle);
-      trainingEnabled = ortTrainingApiHandle != 0L;
-      providers = initialiseProviders(ortApiHandle);
-      version = initialiseVersion();
-      loaded = true;
-    } finally {
-      if (tempDirectory != null) {
-        cleanUp(tempDirectory.toFile());
+    if (isAndroid()) {
+      System.loadLibrary(ONNXRUNTIME_JNI_LIBRARY_NAME);
+    } else {
+      stager = new OnnxStager();
+      stager.stage(ONNXRUNTIME_NATIVE_PREFIX, ONNXRUNTIME_LIBRARY_NAME, CLASSPATH_BASE);
+      stager.stage(ONNXRUNTIME_NATIVE_PREFIX, ONNXRUNTIME_LIBRARY_SHARED_NAME, CLASSPATH_BASE);
+      String jniLibraryPath =
+          stager
+              .stage(ONNXRUNTIME_NATIVE_PREFIX, ONNXRUNTIME_JNI_LIBRARY_NAME, CLASSPATH_BASE)
+              .toString();
+      if (jniLibraryPath != null) {
+        System.load(jniLibraryPath);
       }
     }
-  }
-
-  /**
-   * Marks the file for delete on exit.
-   *
-   * @param file The file to remove.
-   */
-  private static void cleanUp(File file) {
-    if (!file.exists()) {
-      return;
+    ortApiHandle = initialiseAPIBase(ORT_API_VERSION_23);
+    if (ortApiHandle == 0L) {
+      throw new IllegalStateException(
+          "There is a mismatch between the ORT class files and the ORT native library, and the native library could not be loaded");
     }
-    logger.log(Level.FINE, "Deleting " + file + " on exit");
-    file.deleteOnExit();
+    ortTrainingApiHandle = initialiseTrainingAPIBase(ortApiHandle, ORT_API_VERSION_23);
+    ortCompileApiHandle = initialiseCompileAPIBase(ortApiHandle);
+    trainingEnabled = ortTrainingApiHandle != 0L;
+    providers = initialiseProviders(ortApiHandle);
+    version = initialiseVersion();
+    loaded = true;
   }
 
   /**
@@ -230,98 +154,100 @@ final class OnnxRuntime {
   }
 
   /**
-   * Extracts the CUDA provider library from the classpath resources if present, or checks to see if
-   * the CUDA provider library is in the directory specified by {@link #ONNXRUNTIME_NATIVE_PATH}.
+   * Stages the WebGPU provider libraries according to the default staging procedure specified by
+   * {@link ai.onnxruntime}.
    *
-   * @return True if the CUDA provider library is ready for loading, false otherwise.
+   * @return True if the WebGPU provider libraries is ready for loading by the native runtime, false
+   *     otherwise.
    */
-  static boolean extractCUDA() {
-    return extractProviderLibrary(ONNXRUNTIME_LIBRARY_CUDA_NAME);
+  static boolean stageWebGPU() {
+    return stageProviderLibrary(ONNXRUNTIME_LIBRARY_WEBGPU_DAWN_NAME)
+        && stageProviderLibrary(ONNXRUNTIME_LIBRARY_WEBGPU_DXC_DXIL_NAME)
+        && stageProviderLibrary(ONNXRUNTIME_LIBRARY_WEBGPU_DXC_DXCOMPILER_NAME);
   }
 
   /**
-   * Extracts the ROCM provider library from the classpath resources if present, or checks to see if
-   * the ROCM provider library is in the directory specified by {@link #ONNXRUNTIME_NATIVE_PATH}.
+   * Stages the CUDA provider library according to the default staging procedure specified by {@link
+   * ai.onnxruntime}.
    *
-   * @return True if the ROCM provider library is ready for loading, false otherwise.
+   * @return True if the CUDA library libraries is ready for loading by the native runtime, false
+   *     otherwise.
    */
-  static boolean extractROCM() {
-    return extractProviderLibrary(ONNXRUNTIME_LIBRARY_ROCM_NAME);
+  static boolean stageCUDA() {
+    return stageProviderLibrary(ONNXRUNTIME_LIBRARY_CUDA_NAME);
   }
 
   /**
-   * Extracts the DNNL provider library from the classpath resources if present, or checks to see if
-   * the DNNL provider library is in the directory specified by {@link #ONNXRUNTIME_NATIVE_PATH}.
+   * Stages the ROCM provider library according to the default staging procedure specified by {@link
+   * ai.onnxruntime}.
    *
-   * @return True if the DNNL provider library is ready for loading, false otherwise.
+   * @return True if the ROCM library libraries is ready for loading by the native runtime, false
+   *     otherwise.
    */
-  static boolean extractDNNL() {
-    return extractProviderLibrary(ONNXRUNTIME_LIBRARY_DNNL_NAME);
+  static boolean stageROCM() {
+    return stageProviderLibrary(ONNXRUNTIME_LIBRARY_ROCM_NAME);
   }
 
   /**
-   * Extracts the OpenVINO provider library from the classpath resources if present, or checks to
-   * see if the OpenVINO provider library is in the directory specified by {@link
-   * #ONNXRUNTIME_NATIVE_PATH}.
+   * Stages the DNNL provider library according to the default staging procedure specified by {@link
+   * ai.onnxruntime}.
    *
-   * @return True if the OpenVINO provider library is ready for loading, false otherwise.
+   * @return True if the DNNL library libraries is ready for loading by the native runtime, false
+   *     otherwise.
    */
-  static boolean extractOpenVINO() {
-    return extractProviderLibrary(ONNXRUNTIME_LIBRARY_OPENVINO_NAME);
+  static boolean stageDNNL() {
+    return stageProviderLibrary(ONNXRUNTIME_LIBRARY_DNNL_NAME);
   }
 
   /**
-   * Extracts the TensorRT provider library from the classpath resources if present, or checks to
-   * see if the TensorRT provider library is in the directory specified by {@link
-   * #ONNXRUNTIME_NATIVE_PATH}.
+   * Stages the OpenVINO provider library according to the default staging procedure specified by
+   * {@link ai.onnxruntime}.
    *
-   * @return True if the TensorRT provider library is ready for loading, false otherwise.
+   * @return True if the OpenVINO library libraries is ready for loading by the native runtime,
+   *     false otherwise.
    */
-  static boolean extractTensorRT() {
-    return extractProviderLibrary(ONNXRUNTIME_LIBRARY_TENSORRT_NAME);
+  static boolean stageOpenVINO() {
+    return stageProviderLibrary(ONNXRUNTIME_LIBRARY_OPENVINO_NAME);
   }
 
   /**
-   * Extracts the QNN provider library from the classpath resources if present, or checks to see if
-   * the QNN provider library is in the directory specified by {@link #ONNXRUNTIME_NATIVE_PATH}.
+   * Stages the TensorRT provider library according to the default staging procedure specified by
+   * {@link ai.onnxruntime}.
    *
-   * @return True if the QNN provider library is ready for loading, false otherwise.
+   * @return True if the TensorRT library libraries is ready for loading by the native runtime,
+   *     false otherwise.
    */
-  static boolean extractQNN() {
-    return extractProviderLibrary(ONNXRUNTIME_LIBRARY_QNN_NAME);
+  static boolean stageTensorRT() {
+    return stageProviderLibrary(ONNXRUNTIME_LIBRARY_TENSORRT_NAME);
   }
 
   /**
-   * Extracts a shared provider library from the classpath resources if present, or checks to see if
-   * that library is in the directory specified by {@link #ONNXRUNTIME_NATIVE_PATH}.
+   * Stages the QNN provider library according to the default staging procedure specified by {@link
+   * ai.onnxruntime}.
    *
-   * @param libraryName The shared provider library to load.
+   * @return True if the QNN library libraries is ready for loading by the native runtime, false
+   *     otherwise.
+   */
+  static boolean stageQNN() {
+    return stageProviderLibrary(ONNXRUNTIME_LIBRARY_QNN_NAME);
+  }
+
+  /**
+   * Stages the ROCM provider library according to the default staging procedure specified by {@link
+   * ai.onnxruntime}.
+   *
+   * @param libraryName The shared provider library to stage.
    * @return True if the library is ready for loading by ORT's native code, false otherwise.
    */
-  static synchronized boolean extractProviderLibrary(String libraryName) {
+  private static synchronized boolean stageProviderLibrary(String libraryName) {
     // Android does not need to extract provider libraries.
     if (isAndroid()) {
       return false;
     }
-    // Check if we've already extracted or check this provider, and it's ready
-    if (extractedSharedProviders.contains(libraryName)) {
+    try {
+      stager.stage(ONNXRUNTIME_NATIVE_PREFIX, libraryName, CLASSPATH_BASE);
       return true;
-    }
-    // If a native library directory is configured, prefer it and skip extraction when present.
-    if (libraryDirPathProperty != null) {
-      String libraryFileName = mapLibraryName(libraryName);
-      File libraryFile = Paths.get(libraryDirPathProperty, libraryFileName).toFile();
-      if (libraryFile.exists()) {
-        extractedSharedProviders.add(libraryName);
-        return true;
-      }
-    }
-    // Otherwise extract the file from the classpath resources.
-    Optional<File> file = extractFromResources(libraryName);
-    if (file.isPresent()) {
-      extractedSharedProviders.add(libraryName);
-      return true;
-    } else {
+    } catch (IOException e) {
       return false;
     }
   }
@@ -333,141 +259,6 @@ final class OnnxRuntime {
    */
   static boolean isAndroid() {
     return System.getProperty("java.vendor", "generic").equals("The Android Project");
-  }
-
-  /**
-   * Load a shared library by name.
-   *
-   * <p>If the library path is not specified via a system property then it attempts to extract the
-   * library from the classpath before loading it.
-   *
-   * @param library The bare name of the library.
-   * @throws IOException If the file failed to read or write.
-   */
-  private static void load(String library) throws IOException {
-    // On Android, we simply use System.loadLibrary
-    if (isAndroid()) {
-      System.loadLibrary(library);
-      return;
-    }
-
-    // 1) The user may skip loading of this library:
-    String skip = System.getProperty("onnxruntime.native." + library + ".skip");
-    if (Boolean.TRUE.toString().equalsIgnoreCase(skip)) {
-      logger.log(Level.FINE, "Skipping load of native library '" + library + "'");
-      return;
-    }
-
-    // Resolve the platform dependent library name.
-    String libraryFileName = mapLibraryName(library);
-
-    // 2) The user may explicitly specify the path to a directory containing all shared libraries:
-    if (libraryDirPathProperty != null) {
-      logger.log(
-          Level.FINE,
-          "Attempting to load native library '"
-              + library
-              + "' from specified path: "
-              + libraryDirPathProperty);
-      // TODO: Switch this to Path.of when the minimum Java version is 11.
-      File libraryFile = Paths.get(libraryDirPathProperty, libraryFileName).toFile();
-      String libraryFilePath = libraryFile.getAbsolutePath();
-      if (!libraryFile.exists()) {
-        throw new IOException("Native library '" + library + "' not found at " + libraryFilePath);
-      }
-      System.load(libraryFilePath);
-      logger.log(Level.FINE, "Loaded native library '" + library + "' from specified path");
-      return;
-    }
-
-    // 3) The user may explicitly specify the path to their shared library:
-    String libraryPathProperty = System.getProperty("onnxruntime.native." + library + ".path");
-    if (libraryPathProperty != null) {
-      logger.log(
-          Level.FINE,
-          "Attempting to load native library '"
-              + library
-              + "' from specified path: "
-              + libraryPathProperty);
-      File libraryFile = new File(libraryPathProperty);
-      String libraryFilePath = libraryFile.getAbsolutePath();
-      if (!libraryFile.exists()) {
-        throw new IOException("Native library '" + library + "' not found at " + libraryFilePath);
-      }
-      System.load(libraryFilePath);
-      logger.log(Level.FINE, "Loaded native library '" + library + "' from specified path");
-      return;
-    }
-
-    // 4) try loading from resources or library path:
-    Optional<File> extractedPath = extractFromResources(library);
-    if (extractedPath.isPresent()) {
-      // extracted library from resources
-      System.load(extractedPath.get().getAbsolutePath());
-      logger.log(Level.FINE, "Loaded native library '" + library + "' from resource path");
-    } else {
-      // failed to load library from resources, try to load it from the library path
-      logger.log(
-          Level.FINE, "Attempting to load native library '" + library + "' from library path");
-      System.loadLibrary(library);
-      logger.log(Level.FINE, "Loaded native library '" + library + "' from library path");
-    }
-  }
-
-  /**
-   * Extracts the library from the classpath resources. returns optional.empty if it failed to
-   * extract or couldn't be found.
-   *
-   * @param library The library name
-   * @return An optional containing the file if it is successfully extracted, or an empty optional
-   *     if it failed to extract or couldn't be found.
-   */
-  private static Optional<File> extractFromResources(String library) {
-    String libraryFileName = mapLibraryName(library);
-    String resourcePath = "/ai/onnxruntime/native/" + OS_ARCH_STR + '/' + libraryFileName;
-    File tempFile = tempDirectory.resolve(libraryFileName).toFile();
-    try (InputStream is = OnnxRuntime.class.getResourceAsStream(resourcePath)) {
-      if (is == null) {
-        // Not found in classpath resources
-        return Optional.empty();
-      } else {
-        // Found in classpath resources, load via temporary file
-        logger.log(
-            Level.FINE,
-            "Attempting to load native library '"
-                + library
-                + "' from resource path "
-                + resourcePath
-                + " copying to "
-                + tempFile);
-        byte[] buffer = new byte[4096];
-        int readBytes;
-        try (FileOutputStream os = new FileOutputStream(tempFile)) {
-          while ((readBytes = is.read(buffer)) != -1) {
-            os.write(buffer, 0, readBytes);
-          }
-        }
-        logger.log(Level.FINE, "Extracted native library '" + library + "' from resource path");
-        return Optional.of(tempFile);
-      }
-    } catch (IOException e) {
-      logger.log(
-          Level.WARNING, "Failed to extract library '" + library + "' from the resources", e);
-      return Optional.empty();
-    } finally {
-      cleanUp(tempFile);
-    }
-  }
-
-  /**
-   * Maps the library name into a platform dependent library filename. Converts macOS's "jnilib" to
-   * "dylib" but otherwise is the same as {@link System#mapLibraryName(String)}.
-   *
-   * @param library The library name
-   * @return The library filename.
-   */
-  private static String mapLibraryName(String library) {
-    return System.mapLibraryName(library).replace("jnilib", "dylib");
   }
 
   /**

--- a/java/src/main/java/ai/onnxruntime/OnnxStager.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxStager.java
@@ -102,12 +102,19 @@ final class OnnxStager {
    */
   public synchronized Path stage(String prefix, String library, String classpathDirectory)
       throws IOException {
+    // 1) The user may skip staging of all libraries with this prefix:
+    String skipAll = System.getProperty(prefix + ".skip");
+    if (Boolean.TRUE.toString().equalsIgnoreCase(skipAll)) {
+      logger.log(Level.FINE, "Skipping staging of native library '" + library + "'");
+      return null;
+    }
+
     String prefixedName = prefix + "." + library;
     if (staged.containsKey(prefixedName)) {
       return staged.get(prefixedName);
     }
 
-    // 1) The user may skip staging of this library:
+    // 2) The user may skip staging of this library:
     String skip = System.getProperty(prefixedName + ".skip");
     if (Boolean.TRUE.toString().equalsIgnoreCase(skip)) {
       logger.log(Level.FINE, "Skipping staging of native library '" + library + "'");
@@ -117,7 +124,7 @@ final class OnnxStager {
     // Resolve the platform dependent library name.
     String libraryFileName = mapLibraryName(library);
 
-    // 2) The user may explicitly specify the path to their shared library:
+    // 3) The user may explicitly specify the path to their shared library:
     String libraryPathProperty = System.getProperty(prefixedName + ".path");
     if (libraryPathProperty != null) {
       logger.log(
@@ -141,7 +148,7 @@ final class OnnxStager {
 
     Path target = stagingDirectory.resolve(libraryFileName);
 
-    // 3) The user may explicitly specify the path to a directory containing all
+    // 4) The user may explicitly specify the path to a directory containing all
     // shared libraries:
     String libraryDirPathProperty = System.getProperty(prefix + ".path");
     if (libraryDirPathProperty != null) {
@@ -164,7 +171,7 @@ final class OnnxStager {
       }
     }
 
-    // 4) try loading from resources or library path:
+    // 5) try loading from resources or library path:
     extractFromResources(classpathDirectory, target);
     logger.log(Level.FINE, "Using native library '" + library + "' from resource path");
     staged.put(prefixedName, target);

--- a/java/src/main/java/ai/onnxruntime/OnnxStager.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxStager.java
@@ -1,0 +1,258 @@
+package ai.onnxruntime;
+
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Stages native libraries required by the OnnxRuntime Java API into a temporary directory. Supports
+ * several resolution strategies, see {@link ai.onnxruntime}.
+ *
+ * <p>Staged libraries are cached so that each logical library is only resolved once per {@code
+ * OnnxStager} instance.
+ */
+final class OnnxStager {
+  private static final Logger logger = Logger.getLogger(OnnxStager.class.getName());
+
+  /**
+   * Detects the current operating system and CPU architecture and returns a canonical {@code
+   * "<os>-<arch>"} string (e.g. {@code "linux-x64"}, {@code "win-x64"}).
+   *
+   * @return the OS/architecture identifier string
+   * @throws IllegalStateException if the OS or CPU architecture is not supported
+   */
+  private static String initOsArch() {
+    String detectedOS = null;
+    String os = System.getProperty("os.name", "generic").toLowerCase(Locale.ENGLISH);
+    if (os.contains("mac") || os.contains("darwin")) {
+      detectedOS = "osx";
+    } else if (os.contains("win")) {
+      detectedOS = "win";
+    } else if (os.contains("nux")) {
+      detectedOS = "linux";
+    } else {
+      throw new IllegalStateException("Unsupported os:" + os);
+    }
+    String detectedArch = null;
+    String arch = System.getProperty("os.arch", "generic").toLowerCase(Locale.ENGLISH);
+    if (arch.startsWith("amd64") || arch.startsWith("x86_64")) {
+      detectedArch = "x64";
+    } else if (arch.startsWith("x86")) {
+      // 32-bit x86 is not supported by the Java API
+      detectedArch = "x86";
+    } else if (arch.startsWith("aarch64")) {
+      detectedArch = "aarch64";
+    } else if (arch.startsWith("ppc64")) {
+      detectedArch = "ppc64";
+    } else if (arch.startsWith("loongarch64")) {
+      detectedArch = "loongarch64";
+    } else {
+      throw new IllegalStateException("Unsupported arch:" + arch);
+    }
+    return detectedOS + '-' + detectedArch;
+  }
+
+  /** The OS & CPU architecture string */
+  private final String osArchStr;
+
+  /**
+   * Map from prefixed library name (e.g. {@code "onnxruntime.native.onnxruntime4j_jni"}) to its
+   * staged path.
+   */
+  private final Map<String, Path> staged;
+
+  /** Temporary directory into which native libraries are staged before loading. */
+  private final Path stagingDirectory;
+
+  /**
+   * Creates a new {@code OnnxStager} and allocates a temporary staging directory. The directory is
+   * registered for deletion on JVM exit.
+   *
+   * @throws IOException if the temporary directory cannot be created
+   */
+  OnnxStager() throws IOException {
+    osArchStr = initOsArch();
+    staged = new HashMap<>();
+    stagingDirectory = Files.createTempDirectory("onnxruntime-java");
+    stagingDirectory.toFile().deleteOnExit();
+  }
+
+  /**
+   * Resolves and stages a single native library, returning its path in the staging directory. For
+   * resolution order see {@link ai.onnxruntime}.
+   *
+   * <p>Once a library is staged its path is cached; subsequent calls with the same {@code prefix}
+   * and {@code library} return the cached path immediately.
+   *
+   * @param prefix the property-key prefix (e.g. {@code "onnxruntime.native"})
+   * @param library the platform-independent library name (e.g. {@code "onnxruntime4j_jni"})
+   * @param classpathDirectory the classpath resource directory containing the bundled native
+   *     libraries
+   * @return the {@link Path} to the staged library file, or {@code null} if staging was skipped
+   * @throws IOException if the library cannot be found or copied to the staging directory
+   */
+  public synchronized Path stage(String prefix, String library, String classpathDirectory)
+      throws IOException {
+    String prefixedName = prefix + "." + library;
+    if (staged.containsKey(prefixedName)) {
+      return staged.get(prefixedName);
+    }
+
+    // 1) The user may skip staging of this library:
+    String skip = System.getProperty(prefixedName + ".skip");
+    if (Boolean.TRUE.toString().equalsIgnoreCase(skip)) {
+      logger.log(Level.FINE, "Skipping staging of native library '" + library + "'");
+      return null;
+    }
+
+    // Resolve the platform dependent library name.
+    String libraryFileName = mapLibraryName(library);
+
+    // 2) The user may explicitly specify the path to their shared library:
+    String libraryPathProperty = System.getProperty(prefixedName + ".path");
+    if (libraryPathProperty != null) {
+      logger.log(
+          Level.FINE,
+          "Attempting to use native library '"
+              + library
+              + "' from specified path: "
+              + libraryPathProperty);
+      // TODO: Switch this to Path.of when the minimum Java version is 11.
+      Path libraryFilePath = Paths.get(libraryPathProperty).toAbsolutePath();
+      if (!libraryFilePath.toFile().exists()) {
+        throw new IOException("Native library '" + library + "' not found at " + libraryFilePath);
+      } else {
+        // Keep the name the user provided
+        Path target = stagingDirectory.resolve(libraryFilePath.getFileName());
+        pull(libraryFilePath, target);
+        staged.put(prefixedName, target);
+        return target;
+      }
+    }
+
+    Path target = stagingDirectory.resolve(libraryFileName);
+
+    // 3) The user may explicitly specify the path to a directory containing all
+    // shared libraries:
+    String libraryDirPathProperty = System.getProperty(prefix + ".path");
+    if (libraryDirPathProperty != null) {
+      logger.log(
+          Level.FINE,
+          "Attempting to use native library '"
+              + library
+              + "' from specified path: "
+              + libraryDirPathProperty);
+      // TODO: Switch this to Path.of when the minimum Java version is 11.
+      Path libraryFilePath = Paths.get(libraryDirPathProperty, libraryFileName).toAbsolutePath();
+      if (libraryFilePath.toFile().exists()) {
+        pull(libraryFilePath, target);
+        staged.put(prefixedName, target);
+        return target;
+      } else {
+        logger.log(
+            Level.WARNING,
+            "Library '" + libraryFilePath + "'' not found, falling back to bundeled instance.");
+      }
+    }
+
+    // 4) try loading from resources or library path:
+    extractFromResources(classpathDirectory, target);
+    logger.log(Level.FINE, "Using native library '" + library + "' from resource path");
+    staged.put(prefixedName, target);
+    return target;
+  }
+
+  /**
+   * Extracts a bundled native library from classpath resources to the given target path.
+   *
+   * <p>The resource is located at {@code <resourceDir>/<osArchStr>/<filename>} and written to
+   * {@code target} using a 4 KiB copy buffer.
+   *
+   * @param resourceDir the classpath resource directory containing the platform-specific
+   *     subdirectories
+   * @param target the destination path to write the extracted library to
+   * @throws FileNotFoundException if the resource cannot be found on the classpath
+   * @throws IOException if reading the resource or writing the target file fails
+   */
+  private void extractFromResources(String resourceDir, Path target) throws IOException {
+    String name = target.getFileName().toString();
+    String resourcePath = resourceDir + "/" + osArchStr + "/" + name;
+    try (InputStream is = OnnxRuntime.class.getResourceAsStream(resourcePath)) {
+      if (is == null) {
+        throw new FileNotFoundException("Library " + resourcePath + " not found on classpath!");
+      } else {
+        // Found in classpath resources, load via temporary file
+        logger.log(
+            Level.FINE,
+            "Attempting to extracting native library '"
+                + name
+                + "' from resource path "
+                + resourcePath);
+        byte[] buffer = new byte[4096];
+        int readBytes;
+        try (FileOutputStream os = new FileOutputStream(target.toFile())) {
+          while ((readBytes = is.read(buffer)) != -1) {
+            os.write(buffer, 0, readBytes);
+          }
+        }
+        logger.log(Level.FINE, "Extracted native library '" + name + "' from resource path");
+      }
+    }
+  }
+
+  /**
+   * Makes the file at {@code from} accessible at {@code to} by creating a hard link (Windows) or a
+   * symbolic link (other platforms). Falls back to a full file copy if link creation fails.
+   *
+   * @param from the source file path
+   * @param to the destination path in the staging directory
+   * @throws IOException if both link creation and the copy fallback fail
+   */
+  private void pull(Path from, Path to) throws IOException {
+    try {
+      if (isWindows()) {
+        Files.createLink(to, from);
+      } else {
+        Files.createSymbolicLink(from, to);
+      }
+    } catch (Exception e) {
+      logger.log(
+          Level.FINE,
+          "Could not create "
+              + (isWindows() ? "hard link" : "soft link")
+              + "due to "
+              + e.getMessage()
+              + ", falling back to copying...");
+      Files.copy(from, to);
+    }
+  }
+
+  /**
+   * Maps the library name into a platform dependent library filename. Converts macOS's "jnilib" to
+   * "dylib" but otherwise is the same as {@link System#mapLibraryName(String)}.
+   *
+   * @param library The library name
+   * @return The library filename.
+   */
+  private String mapLibraryName(String library) {
+    return System.mapLibraryName(library).replace("jnilib", "dylib");
+  }
+
+  /**
+   * Returns {@code true} if the current platform is Windows.
+   *
+   * @return {@code true} on Windows, {@code false} otherwise
+   */
+  private boolean isWindows() {
+    return osArchStr.startsWith("win");
+  }
+}

--- a/java/src/main/java/ai/onnxruntime/OrtProviderOptions.java
+++ b/java/src/main/java/ai/onnxruntime/OrtProviderOptions.java
@@ -107,31 +107,31 @@ public abstract class OrtProviderOptions implements AutoCloseable {
     // Shared providers need their libraries loaded before options can be defined.
     switch (provider) {
       case CUDA:
-        if (!OnnxRuntime.extractCUDA()) {
+        if (!OnnxRuntime.stageCUDA()) {
           throw new OrtException(
               OrtException.OrtErrorCode.ORT_EP_FAIL, "Failed to find CUDA shared provider");
         }
         break;
       case DNNL:
-        if (!OnnxRuntime.extractDNNL()) {
+        if (!OnnxRuntime.stageDNNL()) {
           throw new OrtException(
               OrtException.OrtErrorCode.ORT_EP_FAIL, "Failed to find DNNL shared provider");
         }
         break;
       case OPEN_VINO:
-        if (!OnnxRuntime.extractOpenVINO()) {
+        if (!OnnxRuntime.stageOpenVINO()) {
           throw new OrtException(
               OrtException.OrtErrorCode.ORT_EP_FAIL, "Failed to find OpenVINO shared provider");
         }
         break;
       case ROCM:
-        if (!OnnxRuntime.extractROCM()) {
+        if (!OnnxRuntime.stageROCM()) {
           throw new OrtException(
               OrtException.OrtErrorCode.ORT_EP_FAIL, "Failed to find ROCm shared provider");
         }
         break;
       case TENSOR_RT:
-        if (!OnnxRuntime.extractTensorRT()) {
+        if (!OnnxRuntime.stageTensorRT()) {
           throw new OrtException(
               OrtException.OrtErrorCode.ORT_EP_FAIL, "Failed to find TensorRT shared provider");
         }

--- a/java/src/main/java/ai/onnxruntime/OrtSession.java
+++ b/java/src/main/java/ai/onnxruntime/OrtSession.java
@@ -1061,7 +1061,7 @@ public class OrtSession implements AutoCloseable {
      */
     public void addCUDA(int deviceNum) throws OrtException {
       checkClosed();
-      if (OnnxRuntime.extractCUDA()) {
+      if (OnnxRuntime.stageCUDA()) {
         addCUDA(OnnxRuntime.ortApiHandle, nativeHandle, deviceNum);
       } else {
         throw new OrtException(
@@ -1077,7 +1077,7 @@ public class OrtSession implements AutoCloseable {
      */
     public void addCUDA(OrtCUDAProviderOptions cudaOpts) throws OrtException {
       checkClosed();
-      if (OnnxRuntime.extractCUDA()) {
+      if (OnnxRuntime.stageCUDA()) {
         // Cast is to make the compiler pick the right overload.
         ((OrtProviderOptions) cudaOpts).applyToNative();
         addCUDAV2(OnnxRuntime.ortApiHandle, nativeHandle, cudaOpts.nativeHandle);
@@ -1104,7 +1104,7 @@ public class OrtSession implements AutoCloseable {
      */
     public void addROCM(int deviceNum) throws OrtException {
       checkClosed();
-      if (OnnxRuntime.extractROCM()) {
+      if (OnnxRuntime.stageROCM()) {
         addROCM(OnnxRuntime.ortApiHandle, nativeHandle, deviceNum);
       } else {
         throw new OrtException(
@@ -1134,7 +1134,7 @@ public class OrtSession implements AutoCloseable {
      */
     public void addDnnl(boolean useArena) throws OrtException {
       checkClosed();
-      if (OnnxRuntime.extractDNNL()) {
+      if (OnnxRuntime.stageDNNL()) {
         addDnnl(OnnxRuntime.ortApiHandle, nativeHandle, useArena ? 1 : 0);
       } else {
         throw new OrtException(
@@ -1150,7 +1150,7 @@ public class OrtSession implements AutoCloseable {
      */
     public void addOpenVINO(String deviceId) throws OrtException {
       checkClosed();
-      if (OnnxRuntime.extractOpenVINO()) {
+      if (OnnxRuntime.stageOpenVINO()) {
         addOpenVINO(OnnxRuntime.ortApiHandle, nativeHandle, deviceId);
       } else {
         throw new OrtException(
@@ -1166,7 +1166,7 @@ public class OrtSession implements AutoCloseable {
      */
     public void addTensorrt(int deviceNum) throws OrtException {
       checkClosed();
-      if (OnnxRuntime.extractTensorRT()) {
+      if (OnnxRuntime.stageTensorRT()) {
         addTensorrt(OnnxRuntime.ortApiHandle, nativeHandle, deviceNum);
       } else {
         throw new OrtException(
@@ -1182,7 +1182,7 @@ public class OrtSession implements AutoCloseable {
      */
     public void addTensorrt(OrtTensorRTProviderOptions tensorRTOpts) throws OrtException {
       checkClosed();
-      if (OnnxRuntime.extractTensorRT()) {
+      if (OnnxRuntime.stageTensorRT()) {
         // Cast is to make the compiler pick the right overload.
         ((OrtProviderOptions) tensorRTOpts).applyToNative();
         addTensorrtV2(OnnxRuntime.ortApiHandle, nativeHandle, tensorRTOpts.nativeHandle);
@@ -1343,7 +1343,7 @@ public class OrtSession implements AutoCloseable {
 
       // QNN can either be built as a shared or static library. extractQNN() will extract the
       // (lib)onnxruntime_providers_qnn(.so/.dll) from classpath resources if present.
-      OnnxRuntime.extractQNN();
+      OnnxRuntime.stageQNN();
       addExecutionProvider(qnnProviderName, providerOptions);
     }
 

--- a/java/src/main/java/ai/onnxruntime/package-info.java
+++ b/java/src/main/java/ai/onnxruntime/package-info.java
@@ -10,38 +10,29 @@
  * Java (such as fp16) are converted into the nearest Java primitive type when accessed through this
  * API.
  *
- * <p>There are two shared libraries required: <code>onnxruntime</code> and <code>onnxruntime4j_jni
- * </code>. The loader is in {@link ai.onnxruntime.OnnxRuntime} and the logic is in this order:
+ * <p>There are three shared libraries required: <code>onnxruntime</code>, <code>onnxruntime4j_jni
+ * </code> and <code>onnxruntime_providers_shared</code>. Additional execution providers such as
+ * CUDA, ROCM, DNNL, OpenVINO and TensorRT need additional libraries, e.g. <code>
+ * onnxruntime_providers_cuda</code>. On non-Android systems all libraries are linked (or copied if
+ * linking fails) into a temporary staging directory. From there {@link java.lang.System#load} is
+ * called on <code>onnxruntime4j_jni</code> (except if staging of it was exempted by one of the
+ * following rules).
+ *
+ * <p>This behavior can be influneced; the loader is in {@link ai.onnxruntime.OnnxRuntime} and
+ * chooses the libraries to add to the staging direcgory in this order:
  *
  * <ol>
- *   <li>The user may signal to skip loading of a shared library using a property in the form <code>
+ *   <li>The user may signal to skip staging of a shared library using a property in the form <code>
  *       onnxruntime.native.LIB_NAME.skip</code> with a value of <code>true</code>. This means the
  *       user has decided to load the library by some other means.
  *   <li>The user may specify an explicit location of all native library files using a property in
- *       the form <code>onnxruntime.native.path</code>. This uses {@link java.lang.System#load}.
+ *       the form <code>onnxruntime.native.path</code>.
  *   <li>The user may specify an explicit location of the shared library file using a property in
- *       the form <code>onnxruntime.native.LIB_NAME.path</code>. This uses {@link
- *       java.lang.System#load}.
- *   <li>The shared library is autodiscovered:
- *       <ol>
- *         <li>If the shared library is present in the classpath resources, load using {@link
- *             java.lang.System#load} via a temporary file. Ideally, this should be the default use
- *             case when adding JAR's/dependencies containing the shared libraries to your
- *             classpath.
- *         <li>If the shared library is not present in the classpath resources, then load using
- *             {@link java.lang.System#loadLibrary}, which usually looks elsewhere on the filesystem
- *             for the library. The semantics and behavior of that method are system/JVM dependent.
- *             Typically, the <code>java.library.path</code> property is used to specify the
- *             location of native libraries.
- *       </ol>
+ *       the form <code>onnxruntime.native.LIB_NAME.path</code>.
+ *   <li>Lastly, if no matching property is set, the library is copied from the JARs classpath.
  * </ol>
  *
- * For troubleshooting, all shared library loading events are reported to Java logging at the level
- * FINE.
- *
- * <p>Note that CUDA, ROCM, DNNL, OpenVINO and TensorRT are all "shared library execution providers"
- * and must be stored either in the directory containing the ONNX Runtime core native library, or as
- * a classpath resource. This is because these providers are loaded by the ONNX Runtime native
- * library itself and the Java API cannot control the loading location.
+ * <p>For troubleshooting, all shared library loading events are reported to Java logging at the
+ * level FINE.
  */
 package ai.onnxruntime;

--- a/java/src/main/java/ai/onnxruntime/package-info.java
+++ b/java/src/main/java/ai/onnxruntime/package-info.java
@@ -22,6 +22,10 @@
  * chooses the libraries to add to the staging direcgory in this order:
  *
  * <ol>
+ *   <li>The user may signal to skip staging of all libraries with the name-prefix <code>
+ *       onnxruntime.native</code> using the property <code>onnxruntime.native.skip</code> with a
+ *       value of <code>true</code>. This means the user has decided to load the library by some
+ *       other means.
  *   <li>The user may signal to skip staging of a shared library using a property in the form <code>
  *       onnxruntime.native.LIB_NAME.skip</code> with a value of <code>true</code>. This means the
  *       user has decided to load the library by some other means.

--- a/java/src/test/java/ai/onnxruntime/InferenceTest.java
+++ b/java/src/test/java/ai/onnxruntime/InferenceTest.java
@@ -1482,7 +1482,7 @@ public class InferenceTest {
 
       try (SessionOptions options = new SessionOptions()) {
         options.registerCustomOpLibrary(customLibraryName);
-        if (OnnxRuntime.extractCUDA()) {
+        if (OnnxRuntime.stageCUDA()) {
           options.addCUDA();
         }
         try (OrtSession session = env.createSession(customOpLibraryTestModel, options)) {
@@ -1551,7 +1551,7 @@ public class InferenceTest {
           options.registerCustomOpsUsingFunction("RegisterCustomOps");
 
           if (isWindows || isMac) {
-            if (OnnxRuntime.extractCUDA()) {
+            if (OnnxRuntime.stageCUDA()) {
               options.addCUDA();
             }
             try (OrtSession session = env.createSession(customOpLibraryTestModel, options)) {


### PR DESCRIPTION
This PR follows a long discussion in #27656 and refactors the native library loading and extraction logic in `OnnxRuntime.java` to ensure consistency and fix a fundamental issue with shared Execution Provider (EP) loading when custom paths are used.

### The Problem
Currently, the Java API's loading logic is split between `load()` (for core libs) and `extractProviderLibrary()` (for EPs). This leads to several issues:
* **Broken Co-location:** `dlopen` inside `libonnxruntime.so` relies on `$ORIGIN` RPATH to find EPs. If a user specifies a custom path for the core library via `-Donnxruntime.native.path`, but the EPs are extracted to a generated temp directory, `dlopen` fails because the libraries are no longer co-located.
* **Inconsistent Semantics:** Core libraries throw hard errors if paths are missing, while providers silently fall back to classpath extraction, often leading to version mismatches or loading failures.
* For a more detailed write-up of the current state see https://github.com/microsoft/onnxruntime/issues/27656#issuecomment-4126387941

### The Solution: Staging Directory
This PR introduces a **Staging Directory** strategy to unify the lifecycle of all native components:

1.  **Unified Staging:** All required libraries (JNI, Core, and EPs) are now "staged" into a single directory. This guarantees co-location and ensures `$ORIGIN` RPATH resolution works regardless of the source of the libraries. Only the JNI library is loaded expliticly which will be able to discover other needed libraries on its own.
2.  **Smart "Pull" Logic:** Instead of strictly extracting from the JAR, the logic now supports "pulling" libraries. If a library exists on the filesystem (via `onnxruntime.native.path`), the system attempts to create a symbolic or hard link to the staging area to avoid unnecessary I/O, falling back to a copy if linking is unavailable.
3.  **Consistent Property Handling:** Standardizes the behavior of `onnxruntime.native.path` and library-specific overrides across both core and provider libraries.
4.  **Lazy Loading:** Moves towards a more consistent lazy-loading pattern for providers to simplify the initial `init()` phase.

### Key Changes
* Refactored `OnnxRuntime.java` to use a central `stage()` method for all native assets.
* Implemented symlink/hardlink support for co-locating system-provided libraries with extracted ones.
* Standardized error messages and fallback warnings when path properties are set but invalid.
* Documentation updated accordingly

---
The `test` section in `build.gradle` was also updated to passthrough `onnxruntime.native.` prefixed system properties to the tests.

My local containered build passed most tests using
```sh
./gradlew test --info -Donnxruntime.native.path=/onnxruntime/build/Linux/Release/java/native-lib/ai/onnxruntime/native/linux-x64 -Donnxruntime.native.onnxruntime4j_jni.path=/onnxruntime/build/Linux/Release/java/native-jni/ai/onnxruntime/native/linux-x64/libonnxruntime4j_jni.so
```

I primarily opend this PR to discuss and test the staging directory idea and hope someone could run the tests pipelines...