### PR TITLE
Fix flaky ResourceAwarePartitioning tests by generating node stats dynamically

### DIFF
--- a/onnxruntime/test/framework/session_state_test.cc
+++ b/onnxruntime/test/framework/session_state_test.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <fstream>
 #include <iostream>
 #include <absl/base/config.h>
 
@@ -12,6 +13,7 @@
 #include "core/framework/op_kernel.h"
 #include "core/framework/bfc_arena.h"
 #include "core/framework/ep_context_options.h"
+#include "core/framework/resource_accountant.h"
 #include "core/framework/session_state.h"
 #include "core/graph/graph_utils.h"
 #include "core/graph/graph_viewer.h"
@@ -414,6 +416,45 @@ namespace {
 
 using ParitionVerifierFn = std::function<void(const Graph&)>;
 
+// Collect unique node names from a graph and all its subgraphs
+// using the same naming scheme as the resource accountant.
+static void CollectNodeNames(const Graph& graph, std::vector<std::string>& names) {
+  for (const auto& node : graph.Nodes()) {
+    names.push_back(IResourceAccountant::MakeUniqueNodeName(node));
+    for (const auto& [_, subgraph] : node.GetAttributeNameToSubgraphMap()) {
+      CollectNodeNames(*subgraph, names);
+    }
+  }
+}
+
+// Generates a node stats file dynamically from the current graph,
+// assigning each node a fixed cost. Returns the total cost across
+// all nodes so callers can choose a threshold relative to the actual total.
+// This avoids relying on a pre-baked stats file whose node name hashes
+// become stale when graph optimizers change node input/output names.
+static size_t GenerateDynamicNodeStatsFile(const ORTCHAR_T* model_path,
+                                           const std::filesystem::path& output_path,
+                                           size_t cost_per_node = 1024) {
+  const auto& default_logger = DefaultLoggingManager().DefaultLogger();
+  std::shared_ptr<onnxruntime::Model> model;
+  EXPECT_STATUS_OK(Model::Load(model_path, model, nullptr, default_logger));
+  Graph& graph = model->MainGraph();
+  EXPECT_STATUS_OK(graph.Resolve());
+
+  std::vector<std::string> node_names;
+  CollectNodeNames(graph, node_names);
+
+  std::ofstream ofs(output_path);
+  EXPECT_TRUE(ofs.is_open());
+  ofs << "#name,input_sizes,initializers_sizes,total_dynamic_sizes,total_temp_allocations\n";
+  for (const auto& name : node_names) {
+    ofs << name << "," << cost_per_node << ",0,0,0\n";
+  }
+  ofs.close();
+
+  return node_names.size() * cost_per_node;
+}
+
 void LoadWithResourceAwarePartitioning(const ORTCHAR_T* model_path,
                                        const SessionOptions& sess_options,
                                        const ParitionVerifierFn& verifier_fn) {
@@ -484,16 +525,27 @@ TEST(SessionStateTest, TestResourceAwarePartitioning_NoLimit) {
 
 TEST(SessionStateTest, TestResourceAwarePartitioning_LargeLimit) {
   constexpr const ORTCHAR_T* model_path = ORT_TSTR("testdata/transformers/tiny_gpt2_beamsearch.onnx");
-  constexpr const char* limit_setting = "10000,tiny_gpt2_beamsearch_node_stats.txt";
+  const std::filesystem::path stats_path =
+      std::filesystem::temp_directory_path() / "tiny_gpt2_beamsearch_dynamic_stats_large.txt";
 
-  // Large limit, all nodes are still assigned
+  // Generate node stats dynamically so names always match the current graph
+  constexpr size_t cost_per_node = 1024;
+  size_t total_cost = GenerateDynamicNodeStatsFile(model_path, stats_path, cost_per_node);
+  ASSERT_GT(total_cost, 0U);
+
+  // Use a limit much larger than total cost so all nodes are assigned CUDA.
+  // Pass the absolute path as the stats filename — LoadNodeAllocationStats resolves
+  // it relative to the model directory, but an absolute path replaces the prefix.
+  size_t large_limit_kb = (total_cost * 2) / 1024 + 1;
+  std::string limit_setting = std::to_string(large_limit_kb) + "," + stats_path.string();
+
   SessionOptions sess_options;
   sess_options.enable_mem_pattern = false;
   sess_options.execution_mode = ExecutionMode::ORT_SEQUENTIAL;
   sess_options.use_deterministic_compute = false;
   sess_options.enable_mem_reuse = false;
   ASSERT_STATUS_OK(sess_options.config_options.AddConfigEntry(
-      kOrtSessionOptionsResourceCudaPartitioningSettings, limit_setting));
+      kOrtSessionOptionsResourceCudaPartitioningSettings, limit_setting.c_str()));
 
   LoadWithResourceAwarePartitioning(model_path, sess_options, [](const Graph& graph) {
     const auto& graph_nodes = graph.Nodes();
@@ -501,20 +553,34 @@ TEST(SessionStateTest, TestResourceAwarePartitioning_LargeLimit) {
       EXPECT_EQ(node.GetExecutionProviderType(), kCudaExecutionProvider);
     }
   });
+
+  std::filesystem::remove(stats_path);
 }
 
 TEST(SessionStateTest, TestResourceAwarePartitioning_CPUOffloaded) {
   constexpr const ORTCHAR_T* model_path = ORT_TSTR("testdata/transformers/tiny_gpt2_beamsearch.onnx");
-  constexpr const char* limit_setting = "5000,tiny_gpt2_beamsearch_node_stats.txt";
+  const std::filesystem::path stats_path =
+      std::filesystem::temp_directory_path() / "tiny_gpt2_beamsearch_dynamic_stats_offload.txt";
 
-  // Large limit, all nodes are still assigned
+  // Generate node stats dynamically so names always match the current graph.
+  // Use a non-trivial cost per node so the threshold math works cleanly.
+  constexpr size_t cost_per_node = 1024;
+  size_t total_cost = GenerateDynamicNodeStatsFile(model_path, stats_path, cost_per_node);
+  ASSERT_GT(total_cost, 0U);
+
+  // Set threshold to half the total cost so some nodes must be offloaded to CPU.
+  // Pass the absolute path as the stats filename.
+  size_t half_limit_kb = (total_cost / 2) / 1024;
+  ASSERT_GT(half_limit_kb, 0U);
+  std::string limit_setting = std::to_string(half_limit_kb) + "," + stats_path.string();
+
   SessionOptions sess_options;
   sess_options.enable_mem_pattern = false;
   sess_options.execution_mode = ExecutionMode::ORT_SEQUENTIAL;
   sess_options.use_deterministic_compute = false;
   sess_options.enable_mem_reuse = false;
   ASSERT_STATUS_OK(sess_options.config_options.AddConfigEntry(
-      kOrtSessionOptionsResourceCudaPartitioningSettings, limit_setting));
+      kOrtSessionOptionsResourceCudaPartitioningSettings, limit_setting.c_str()));
 
   LoadWithResourceAwarePartitioning(model_path, sess_options, [](const Graph& graph) {
     const auto& graph_nodes = graph.Nodes();
@@ -527,6 +593,8 @@ TEST(SessionStateTest, TestResourceAwarePartitioning_CPUOffloaded) {
     }
     EXPECT_TRUE(cpu_node_found);
   });
+
+  std::filesystem::remove(stats_path);
 }
 
 #endif  // USE_CUDA


### PR DESCRIPTION
## Problem

The `SessionStateTest.TestResourceAwarePartitioning_CPUOffloaded` (and potentially `_LargeLimit`) tests are flaky on the Linux CUDA CI pipeline. The root cause is a **stale static stats file** (`tiny_gpt2_beamsearch_node_stats.txt`) that contains pre-baked node name hashes.

### How the stats file works

The resource-aware partitioning feature uses `IResourceAccountant::MakeUniqueNodeName(node)` to generate node identifiers of the form `{node_name}_{MurmurHash3(input_defs + output_defs)}`. At runtime, `SizeTAccountant::ComputeResourceCount()` looks up each node's name in a hash map loaded from the stats file to determine memory cost.

### Why it breaks

When graph optimizers on `main` change node input/output def names (e.g., through fusion or layout transformation), the MurmurHash3 hashes change. This causes a mismatch between the names in the static stats file and the names generated at runtime. Unmatched nodes return 0 cost, which lowers the total below the hard-coded threshold, causing the `_CPUOffloaded` test to fail because no nodes get offloaded to CPU.

For example, 6 out of 60 nodes were failing to match, dropping the runtime total from 5,550,436 bytes (in the stats file) to 4,470,500 bytes — below the 5,120,000-byte threshold used by the test.

This is a pre-existing issue on `main`, not caused by any specific PR.

## Solution

Instead of relying on a pre-baked static stats file, **generate the node stats dynamically at test time**:

1. **`CollectNodeNames()`** — Recursively walks the graph and all subgraphs, calling `IResourceAccountant::MakeUniqueNodeName()` for each node. This guarantees the names always match what the runtime will produce.

2. **`GenerateDynamicNodeStatsFile()`** — Loads the model, resolves the graph, collects node names, and writes a temporary CSV stats file with a uniform cost per node. Returns the total cost so tests can set thresholds relative to the actual total.

3. **Tests compute thresholds dynamically**:
   - `_LargeLimit`: threshold = 2× total cost → all nodes stay on CUDA
   - `_CPUOffloaded`: threshold = 0.5× total cost → some nodes must be offloaded to CPU

4. **Stats files are written to the system temp directory** (`std::filesystem::temp_directory_path()`) instead of `testdata/transformers/`, avoiding assumptions about the working directory being writable. This works because `LoadNodeAllocationStats` uses `std::filesystem::path::operator/=`, which replaces the path when the filename is absolute.

5. **Temp files are cleaned up** via `std::filesystem::remove()` after each test.

## Changes

- **`onnxruntime/test/framework/session_state_test.cc`**:
  - Added `#include <fstream>` and `#include "core/framework/resource_accountant.h"`
  - Added helper `CollectNodeNames()` (recursive graph walker)
  - Added helper `GenerateDynamicNodeStatsFile()` (generates temp stats file)
  - Rewrote `TestResourceAwarePartitioning_LargeLimit` to use dynamic stats
  - Rewrote `TestResourceAwarePartitioning_CPUOffloaded` to use dynamic stats
  - `TestResourceAwarePartitioning_NoLimit` left unchanged (does not use a stats file)

## Testing

These tests require a Linux CUDA build to run:
```bash
./onnxruntime_test_all --gtest_filter="SessionStateTest.TestResourceAwarePartitioning*"
```

