### PR TITLE
add cuda 13 support to onnxruntime-node

### DIFF
--- a/js/node/script/install-utils.js
+++ b/js/node/script/install-utils.js
@@ -207,7 +207,7 @@ async function resolvePackage(type, index, packageName, version) {
 }
 
 function tryGetCudaVersion() {
-  // Should only return 11 or 12.
+  // Should only return 12 or 13.
 
   // try to get the CUDA version from the system ( `nvcc --version` )
   let ver = 12;
@@ -216,7 +216,7 @@ function tryGetCudaVersion() {
     const match = nvccVersion.match(/release (\d+)/);
     if (match) {
       ver = parseInt(match[1]);
-      if (ver !== 11 && ver !== 12) {
+      if (ver !== 11 && ver !== 12 && ver !== 13) {
         throw new Error(`Unsupported CUDA version: ${ver}`);
       }
     }
@@ -262,6 +262,10 @@ function parseInstallFlag() {
       if (flag === 12) {
         return 'cuda12';
       }
+      if (flag === 13) {
+        console.warn('Pre-built binaries for CUDA 13 are not yet available. Skipping CUDA EP installation.');
+        return undefined;
+      }
       return undefined;
     }
     default:
@@ -292,6 +296,8 @@ function parseInstallCudaFlag() {
       return 11;
     case 'v12':
       return 12;
+    case 'v13':
+      return 13;
     case 'skip':
     case undefined:
       return flag;


### PR DESCRIPTION
stop npm install from crashing on systems with cuda 13

cuda 13 nuget binaries aren't published yet (1.26.0 is still linked against `libcudart.so.12`), so this just stops the hard throw and warns instead. metadata can follow once the cuda 13 package is out