### PR TITLE
Lift minimum numpy to 1.24.4 for Python 3.11 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 flatbuffers
-numpy >= 1.21.6
+numpy >= 1.24.4
 packaging
 protobuf


### PR DESCRIPTION
### Description

<!-- Describe your changes. -->
1.24.4 has support support of Python 3.11.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
The old minimum numpy does not support Python 3.11.

