### PR TITLE
Fix typo in CApiTest.VersionConsistencyWithApiVersion.

### DIFF
--- a/onnxruntime/test/shared_lib/test_version.cc
+++ b/onnxruntime/test/shared_lib/test_version.cc
@@ -27,5 +27,5 @@ TEST(CApiTest, VersionConsistencyWithApiVersion) {
 
   ASSERT_NE(to_uint32_t(version_string_components[0]), std::nullopt);
   ASSERT_EQ(to_uint32_t(version_string_components[1]), uint32_t{ORT_API_VERSION});
-  ASSERT_NE(to_uint32_t(version_string_components[0]), std::nullopt);
+  ASSERT_NE(to_uint32_t(version_string_components[2]), std::nullopt);
 }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Fix typo in CApiTest.VersionConsistencyWithApiVersion. It wasn't checking the third version string component.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix test.