### PR TITLE
Fix heap OOB write in MaxPoolGrad via indices bounds validation

### DIFF
--- a/orttraining/orttraining/test/training_ops/cpu/nn/pool_gradient_op_test.cc
+++ b/orttraining/orttraining/test/training_ops/cpu/nn/pool_gradient_op_test.cc
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "gtest/gtest.h"
 
 #include "test/providers/provider_test_utils.h"

--- a/orttraining/orttraining/training_ops/cpu/nn/pool_gradient_op.cc
+++ b/orttraining/orttraining/training_ops/cpu/nn/pool_gradient_op.cc
@@ -55,7 +55,8 @@ Status MaxPoolGrad<T>::Compute(OpKernelContext* context) const {
   const int64_t dX_size = dX_shape.Size();
   EigenVectorMap<T>(dX_data, narrow<Eigen::Index>(dX_size)).setZero();
 
-  for (int64_t i = 0; i < dY->Shape().Size(); ++i) {
+  const int64_t dY_size = dY->Shape().Size();
+  for (int64_t i = 0; i < dY_size; ++i) {
     if (indices_data[i] < 0 || indices_data[i] >= dX_size) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                              "MaxPoolGrad: index value ", indices_data[i],


### PR DESCRIPTION
### Description

`MaxPoolGrad` uses `Indices` tensor values as raw pointer offsets into the output buffer without bounds checking. A malicious model can supply arbitrary index values to write to arbitrary heap locations.

**Fix:** Validate each index is in `[0, dX_size)` before use via `ORT_RETURN_IF`, returning an error for out-of-range values.

