### PR TITLE
feat: infer layout rank for layout transformation based on node attri…

### DIFF
--- a/onnxruntime/core/optimizer/layout_transformation/layout_transformation.cc
+++ b/onnxruntime/core/optimizer/layout_transformation/layout_transformation.cc
@@ -31,7 +31,7 @@ std::optional<size_t> TryInferLayoutRank(const api::GraphRef& graph, const api::
 
   const auto input_value_info = graph.GetValueInfo(inputs[0]);
   if (auto rank = input_value_info->ShapeRank(); rank.has_value()) {
-    return rank;
+    return *rank >= 2 ? rank : std::nullopt;
   }
 
   const auto try_infer_from_attrs = [&](std::initializer_list<std::pair<std::string_view, size_t>> attrs)

--- a/onnxruntime/test/optimizer/transpose_optimizer_test.cc
+++ b/onnxruntime/test/optimizer/transpose_optimizer_test.cc
@@ -11,7 +11,9 @@
 
 #include "core/framework/op_node_proto_helper.h"
 #include "core/graph/graph.h"
+#include "core/graph/model.h"
 #include "core/graph/node_attr_utils.h"
+#include "core/optimizer/layout_transformation/layout_transformation.h"
 #include "core/optimizer/transpose_optimization/onnx_transpose_optimization.h"
 #include "core/optimizer/transpose_optimization/optimizer_api.h"
 #include "core/optimizer/transpose_optimization/ort_optimizer_utils.h"
@@ -4681,6 +4683,105 @@ TEST(TransposeOptimizerTests, QnnResizeOpset11) {
   // And the post-Resize Transpose should have been pushed all the way to the end
   GraphViewer viewer(graph);
   EXPECT_EQ(graph.GetNode(viewer.GetNodesInTopologicalOrder().back())->OpType(), "Transpose");
+}
+
+TEST(TransposeOptimizerTests, TransformLayoutForEPInfersConvRankFromAttributesWhenInputRankMissing) {
+  using InternalTestingEP = internal_testing_ep::InternalTestingExecutionProvider;
+
+  std::unordered_map<std::string, int> domain_to_version;
+  domain_to_version[kOnnxDomain] = 11;
+  domain_to_version[kMSDomain] = 1;
+  domain_to_version[kMSInternalNHWCDomain] = 11;
+
+  Model model("TransposeOptimizerTests.TransformLayoutForEPInfersConvRankFromAttributesWhenInputRankMissing",
+              false, ModelMetaData(), PathString(), IOnnxRuntimeOpSchemaRegistryList(), domain_to_version, {},
+              DefaultLoggingManager().DefaultLogger());
+  Graph& graph = model.MainGraph();
+  ModelTestBuilder builder(graph);
+
+  auto* input_arg = builder.MakeInput<float>(std::optional<std::vector<int64_t>>{});
+  auto* weight_arg = builder.MakeInitializer<float>({4, 3, 3, 3}, std::vector<float>(4 * 3 * 3 * 3, 0.5f));
+  auto* output_arg = builder.MakeOutput();
+
+  Node& conv_node = builder.AddNode("Conv", {input_arg, weight_arg}, {output_arg});
+  conv_node.AddAttribute("kernel_shape", std::vector<int64_t>{3, 3});
+  conv_node.AddAttribute("pads", std::vector<int64_t>{1, 1, 1, 1});
+  conv_node.SetExecutionProviderType(internal_testing_ep::kInternalTestingExecutionProvider);
+
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  const std::unordered_set<std::string> supported_ops{"Conv"};
+  InternalTestingEP ep(supported_ops, std::unordered_set<std::string>{}, DataLayout::NHWC);
+
+  bool modified = false;
+  ASSERT_STATUS_OK(layout_transformation::TransformLayoutForEP(
+      graph, modified, ep, TestCPUExecutionProvider()->CreatePreferredAllocators()[0], {}));
+  ASSERT_TRUE(modified);
+  ASSERT_TRUE(graph.GraphResolveNeeded());
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
+  EXPECT_EQ(op_to_count["Transpose"], 2) << "Conv with inferred rank should be wrapped by 2 Transpose nodes.";
+
+  int nhwc_conv_count = 0;
+  for (const auto& node : graph.Nodes()) {
+    if (node.OpType() == "Conv") {
+      ++nhwc_conv_count;
+      EXPECT_EQ(node.Domain(), kMSInternalNHWCDomain)
+          << "Conv should be converted to the internal NHWC domain when rank is inferred from attributes.";
+    }
+  }
+
+  EXPECT_EQ(nhwc_conv_count, 1);
+}
+
+TEST(TransposeOptimizerTests, TransformLayoutForEPSkipsResizeWhenInputRankIsOne) {
+  using InternalTestingEP = internal_testing_ep::InternalTestingExecutionProvider;
+
+  std::unordered_map<std::string, int> domain_to_version;
+  domain_to_version[kOnnxDomain] = 11;
+  domain_to_version[kMSDomain] = 1;
+  domain_to_version[kMSInternalNHWCDomain] = 11;
+
+  Model model("TransposeOptimizerTests.TransformLayoutForEPSkipsResizeWhenInputRankIsOne",
+              false, ModelMetaData(), PathString(), IOnnxRuntimeOpSchemaRegistryList(), domain_to_version, {},
+              DefaultLoggingManager().DefaultLogger());
+  Graph& graph = model.MainGraph();
+  ModelTestBuilder builder(graph);
+
+  auto* input_arg = builder.MakeInput<float>(std::optional<std::vector<int64_t>>{{5}});
+  auto* roi_arg = builder.MakeInitializer<float>({0}, {});
+  auto* scales_arg = builder.MakeInitializer<float>({1}, {2.0f});
+  auto* output_arg = builder.MakeOutput();
+
+  Node& resize_node = builder.AddNode("Resize", {input_arg, roi_arg, scales_arg}, {output_arg});
+  resize_node.SetExecutionProviderType(internal_testing_ep::kInternalTestingExecutionProvider);
+
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  const std::unordered_set<std::string> empty_set;
+  InternalTestingEP ep(empty_set, empty_set, DataLayout::NHWC);
+
+  bool modified = false;
+  ASSERT_STATUS_OK(layout_transformation::TransformLayoutForEP(
+      graph, modified, ep, TestCPUExecutionProvider()->CreatePreferredAllocators()[0], {}));
+  EXPECT_FALSE(modified);
+  EXPECT_FALSE(graph.GraphResolveNeeded());
+
+  std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
+  EXPECT_EQ(op_to_count["Transpose"], 0) << "Rank-1 Resize should not be wrapped with Transpose nodes.";
+
+  int resize_count = 0;
+  for (const auto& node : graph.Nodes()) {
+    if (node.OpType() == "Resize") {
+      ++resize_count;
+      EXPECT_TRUE(node.Domain().empty()) << "Rank-1 Resize should remain in the ONNX domain.";
+    }
+  }
+
+  EXPECT_EQ(resize_count, 1);
 }
 
 // model where layout transform results in transposing a non-const input that is broadcast.


### PR DESCRIPTION
## Description
Enhance layout transformation rank inference in [layout_transformation.cc](vscode-file://vscode-app/c:/Users/huangjinghui/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

This change updates TransformLayoutForEP to avoid relying exclusively on the input tensor shape when determining rank for layout-sensitive operators. When the input rank is unavailable from ValueInfo, the transformer now falls back to inferring rank from operator attributes for convolution and pooling related ops.

The fallback currently covers operators such as Conv, ConvTranspose, ConvInteger, QLinearConv, FusedConv, AveragePool, LpPool, MaxPool, MaxUnpool, and QLinearAveragePool. For these operators, rank can now be derived from attributes like kernel_shape, strides, dilations, pads, output_padding, or output_shape when available.

## Motivation and Context
Some models assigned to layout transformation contain layout-sensitive nodes whose input shape information is incomplete or missing during optimization. In the previous behavior, TransformLayoutForEP would skip layout conversion for those nodes because rank could only be obtained from the input shape.

For operators such as convolution and pooling, the spatial rank is often already encoded in operator attributes, so requiring input shape rank is unnecessarily restrictive. This change allows layout transformation to proceed in more cases by using those attributes as a fallback, reducing missed NHWC conversions while keeping the behavior conservative for operators that do not provide enough information to infer rank safely.


