### PR TITLE
[CI] fix: missing `branch` specifier in `schedule` directive

### DIFF
--- a/tools/ci_build/github/azure-pipelines/main-release-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/main-release-pipeline.yml
@@ -1,6 +1,9 @@
 schedules:
 - cron: '0 12 * * *'
   displayName: "Nightly RC Build"
+  branches:
+    include:
+    - main
 
 trigger: none
 


### PR DESCRIPTION
### Description

Specify `main` as the target branch for the release candidate cron job.

### Motivation and Context

Pipeline won't work without a branch specifier.