### PR TITLE
QNN Preprocess bug fix for updated onnx metadata_props

### DIFF
--- a/onnxruntime/python/tools/quantization/execution_providers/qnn/preprocess.py
+++ b/onnxruntime/python/tools/quantization/execution_providers/qnn/preprocess.py
@@ -191,7 +191,8 @@ def save_and_reload_optimize_model(model: onnx.ModelProto, shape_infer: bool) ->
         ret_model = onnx.load_model(model_out_path)
         ret_metaprops = {"onnx.infer": "onnxruntime.tools.qnn.preprocess"}
         if ret_model.metadata_props:
-            ret_metaprops.update(ret_model.metadata_props)
+            for prop in ret_model.metadata_props:
+                ret_metaprops.update({prop.key: prop.value})
         onnx.helper.set_model_props(ret_model, ret_metaprops)
         return ret_model
 


### PR DESCRIPTION
### Description
Update in _save_and_reload_optimize_model_ function for QNN Preprocess



### Motivation and Context
Error while using qnn_preprocess_model due to change in data type of onnx metadata_props
