### PR TITLE
[DML EP] Disable 4-D MVN tests for DirectML

### DIFF
--- a/onnxruntime/test/contrib_ops/tensor_op_test.cc
+++ b/onnxruntime/test/contrib_ops/tensor_op_test.cc
@@ -122,7 +122,9 @@ void MeanVarianceNormalizationAcrossChannels(bool across_channels, bool normaliz
   test.AddInput<float>("input", {N, C, H, W}, X);
   test.AddOutput<float>("output", {N, C, H, W}, result);
   // DML currently has known failures in this 4D MVN coverage.
-  // OpenVINO does not support MVN below opset 9. TensorRT does not support MVN opset 8.
+  // See https://github.com/microsoft/onnxruntime/issues/27933 and remove this exclusion once
+  // that issue is fixed. OpenVINO does not support MVN below opset 9. TensorRT does not
+  // support MVN opset 8.
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
            {kDmlExecutionProvider, kOpenVINOExecutionProvider, kTensorrtExecutionProvider});
 }
@@ -191,8 +193,10 @@ void MeanVarianceNormalizationPerChannel(bool across_channels, bool normalize_va
   test.AddAttribute("normalize_variance", normalize_variance ? one : zero);
   test.AddInput<float>("input", {N, C, H, W}, X);
   test.AddOutput<float>("output", {N, C, H, W}, result);
-  // DML currently has known failures in this 4D MVN coverage.
   // OpenVINO does not support MVN below opset 9. TensorRT does not support MVN opset 8.
+  // DML currently has known failures in this 4D MVN coverage.
+  // See https://github.com/microsoft/onnxruntime/issues/27933 and remove this exclusion once
+  // that issue is fixed.
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
            {kDmlExecutionProvider, kOpenVINOExecutionProvider, kTensorrtExecutionProvider});
 }

--- a/onnxruntime/test/providers/cpu/tensor/mean_variance_normalization_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/mean_variance_normalization_test.cc
@@ -69,8 +69,9 @@ TEST(MeanVarianceNormalizationTest, DefaultAxes) {
   OpTester test("MeanVarianceNormalization", 9);
   test.AddInput<float>("input", {N, C, H, W}, X);
   test.AddOutput<float>("output", {N, C, H, W}, result);
-  // DML currently has known failures in this 4D default-axes MVN coverage. Keep coverage on
-  // CPU/other EPs while the DML-specific issue is investigated.
+  // DML currently has known failures in this 4D default-axes MVN coverage.
+  // See https://github.com/microsoft/onnxruntime/issues/27933 and remove this exclusion once
+  // that issue is fixed.
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kDmlExecutionProvider});
 }
 
@@ -94,6 +95,8 @@ static void TestMeanVarianceNormalizationOverAllAxes(const std::vector<int64_t>&
 
   if (shape.size() == 4) {
     // Restrict the DML exclusion to the known failing 4D all-axes coverage.
+    // See https://github.com/microsoft/onnxruntime/issues/27933 and remove this exclusion once
+    // that issue is fixed.
     test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kDmlExecutionProvider});
   } else {
     test.Run();
@@ -164,8 +167,7 @@ TEST(MeanVarianceNormalizationTest, AxesSubsets5D) {
     test.AddOutput<float>("output", shape, Y.data(), Y.size());
 
     if (DefaultDmlExecutionProvider().get() != nullptr) {
-      // 5D subset-axis coverage stays enabled for DML. Use a small tolerance to account for
-      // expected numeric drift without masking the separate 4D DML-specific failures.
+      // 5D subset-axis coverage stays enabled for DML.
       test.SetOutputTolerance(0.001f);
     }
 


### PR DESCRIPTION
### Description
Disable 4-D MVN tests as there seems to be some issue within DirectML such that the tests pass sometimes on the same machine SKU but fail some other times. The 5-D tests always seem to pass (based on limited eyeballing of several runs). If that changes in future, we can disable the 5-D tests too. The bug might be narrrower than just 4-D cases. I think it is for 4-D inputs that ALSO includes 0 in the `axes` parameter but it needs more evidence to support that claim and it needs investigating from someone familiar with the core DML stack. Pending that, I am disabling the 4-D input tests for the MVN op from running using the DML EP.

Without this fix
Sample "passing" run: https://github.com/microsoft/onnxruntime/actions/runs/23826498144/job/69450582096#step:13:21501

Sample "failing" run: https://github.com/microsoft/onnxruntime/actions/runs/23831205376/job/69484574894#step:13:22000 

### Motivation and Context
Mitigate DML EP MVN failires on CI

Temporarily mitigates issue described in https://github.com/microsoft/onnxruntime/issues/27933


