### PR TITLE
Add bounds validation for character indices in WordConvEmbedding

### DIFF
--- a/onnxruntime/contrib_ops/cpu/word_conv_embedding.cc
+++ b/onnxruntime/contrib_ops/cpu/word_conv_embedding.cc
@@ -11,7 +11,7 @@
 namespace onnxruntime {
 namespace contrib {
 
-void WordConvEmbedding::CharEmbeddingLookup(
+Status WordConvEmbedding::CharEmbeddingLookup(
     const int* seq_ptr,
     const float* char_embedding_weight_p,
     size_t num_chars,
@@ -27,15 +27,16 @@ void WordConvEmbedding::CharEmbeddingLookup(
       float* cur_dst_ptr = dst + word_inx * word_len * char_embedding_size;
       size_t char_length_to_lookup = std::min(std::max<size_t>(words_len_ptr[word_inx], filter_width), word_len);
       for (size_t char_inx = 0; char_inx < char_length_to_lookup; char_inx++) {
-        ORT_ENFORCE(*cur_seq_ptr >= 0 && static_cast<size_t>(*cur_seq_ptr) < num_chars,
-                    "CharEmbeddingLookup: character index ", *cur_seq_ptr,
-                    " is out of range [0, ", num_chars, ").");
+        ORT_RETURN_IF_NOT(*cur_seq_ptr >= 0 && static_cast<size_t>(*cur_seq_ptr) < num_chars,
+                          "CharEmbeddingLookup: character index ", *cur_seq_ptr,
+                          " is out of range [0, ", num_chars, ").");
         memcpy(cur_dst_ptr, char_embedding_weight_p + (*cur_seq_ptr) * char_embedding_size, sizeof(float) * char_embedding_size);
         cur_dst_ptr += char_embedding_size;
         cur_seq_ptr++;
       }
     }
   }
+  return Status::OK();
 }
 
 // input : [sequence_length, word_length, char_embedding_size]
@@ -200,15 +201,18 @@ Status WordConvEmbedding::Compute(OpKernelContext* ctx) const {
 
   CalculateLengthOfEachWordInSequence(seq_ptr, words_length_ptr.get(), onnxruntime::narrow<size_t>(seq_len), onnxruntime::narrow<size_t>(word_len));
 
-  CharEmbeddingLookup(seq_ptr,
-                      w_char_embedding.Data<float>(),
-                      onnxruntime::narrow<size_t>(w_char_embedding_shape[0]),
-                      onnxruntime::narrow<size_t>(seq_len),
-                      onnxruntime::narrow<size_t>(word_len),
-                      onnxruntime::narrow<size_t>(char_embedding_size),
-                      onnxruntime::narrow<size_t>(filter_width),
-                      words_length_ptr.get(),
-                      chars_embeddings_ptr.get());
+  ORT_RETURN_IF_ERROR(CharEmbeddingLookup(seq_ptr,
+                                         w_char_embedding.Data<float>(),
+                                         onnxruntime::narrow<size_t>(w_char_embedding_shape[0]),
+                                         onnxruntime::narrow<size_t>(seq_len),
+                                         onnxruntime::narrow<size_t>(word_len),
+                                         onnxruntime::narrow<size_t>(char_embedding_size),
+                                         onnxruntime::narrow<size_t>(filter_width),
+                                         words_length_ptr.get(),
+                                         chars_embeddings_ptr.get()));
+
+  ORT_RETURN_IF_NOT(filter_width <= word_len,
+                    "filter_width (", filter_width, ") must be <= word_len (", word_len, ").");
 
   ComputeConvMaxPoolWithActivation(
       alloc,

--- a/onnxruntime/contrib_ops/cpu/word_conv_embedding.h
+++ b/onnxruntime/contrib_ops/cpu/word_conv_embedding.h
@@ -23,7 +23,7 @@ class WordConvEmbedding final : public OpKernel {
   Status Compute(OpKernelContext* context) const override;
 
  private:
-  void CharEmbeddingLookup(
+  Status CharEmbeddingLookup(
       const int* seq_ptr,
       const float* char_embedding_weight_p,
       size_t num_chars,

--- a/onnxruntime/test/contrib_ops/word_conv_embedding_test.cc
+++ b/onnxruntime/test/contrib_ops/word_conv_embedding_test.cc
@@ -198,5 +198,44 @@ TEST(ContribOpTest, WordConvEmbedding_oob_char_index) {
   test.Run(OpTester::ExpectResult::kExpectFailure, "CharEmbeddingLookup: character index");
 }
 
+TEST(ContribOpTest, WordConvEmbedding_filter_width_exceeds_word_len) {
+  OpTester test("WordConvEmbedding", 1, onnxruntime::kMSDomain);
+
+  // word_len=2 but filter_width=3 (from W_conv_shape[2]) → should fail
+  std::vector<int64_t> seq_words_shape = {2, 2};
+  std::vector<int> seq_words{1, 2,
+                             3, 4};
+
+  std::vector<int64_t> W_char_embedding_shape = {5, 3};
+  std::vector<float> W_char_embedding{0.1f, 0.2f, 0.3f,
+                                      0.2f, 0.3f, 0.1f,
+                                      0.3f, 0.1f, 0.2f,
+                                      0.4f, 0.5f, 0.6f,
+                                      0.7f, 0.8f, 0.9f};
+
+  // filter_width = W_conv_shape[2] = 3, which exceeds word_len = 2
+  std::vector<int64_t> W_conv_shape = {2, 1, 3, 3};
+  std::vector<float> W_conv{0.1f, 0.2f, 0.3f,
+                            0.2f, 0.3f, 0.1f,
+                            0.3f, 0.1f, 0.2f,
+                            1.0f, 1.1f, 1.2f,
+                            1.3f, 1.4f, 1.5f,
+                            1.6f, 1.7f, 1.8f};
+
+  std::vector<int64_t> B_conv_shape = {2};
+  std::vector<float> B_conv{0.1f, 0.2f};
+
+  std::vector<int64_t> output_shape = {2, 2};
+  std::vector<float> output{0.0f, 0.0f, 0.0f, 0.0f};
+
+  test.AddInput<int>("Sequence", seq_words_shape, seq_words);
+  test.AddInput<float>("W", W_conv_shape, W_conv);
+  test.AddInput<float>("B", B_conv_shape, B_conv);
+  test.AddInput<float>("C", W_char_embedding_shape, W_char_embedding);
+  test.AddOutput<float>("Y", output_shape, output);
+
+  test.Run(OpTester::ExpectResult::kExpectFailure, "filter_width");
+}
+
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION

The `CharEmbeddingLookup` function in `WordConvEmbedding` uses character indices from the model's \Sequence\ input as direct offsets into the char embedding table without any bounds validation. A crafted ONNX model can supply negative or out-of-range indices in the \Sequence\ tensor, causing a heap out-of-bounds read via the `memcpy` at the embedding lookup.

### Fix
- Added `um_chars` parameter to `CharEmbeddingLookup` (private helper) representing the row count of the char embedding table.
- Added `ORT_ENFORCE` to validate each character index is in `[0, num_chars)` before the `memcpy`.
- Capped `char_length_to_lookup` at `word_len` to prevent reading past the sequence buffer when `ilter_width > word_len`.
