### PR TITLE
Fix CoreML-enabled static build on macOS

### DIFF
--- a/cmake/onnxruntime_providers_coreml.cmake
+++ b/cmake/onnxruntime_providers_coreml.cmake
@@ -26,7 +26,7 @@ file(GLOB coreml_proto_srcs "${COREML_PROTO_ROOT}/*.proto")
 onnxruntime_add_static_library(coreml_proto ${coreml_proto_srcs})
 target_include_directories(coreml_proto
                            PUBLIC $<TARGET_PROPERTY:${PROTOBUF_LIB},INTERFACE_INCLUDE_DIRECTORIES>
-                           "${CMAKE_CURRENT_BINARY_DIR}")
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 target_compile_definitions(coreml_proto
                            PUBLIC $<TARGET_PROPERTY:${PROTOBUF_LIB},INTERFACE_COMPILE_DEFINITIONS>)
 set_target_properties(coreml_proto PROPERTIES COMPILE_FLAGS "-fvisibility=hidden")
@@ -42,6 +42,7 @@ onnxruntime_protobuf_generate(
 
 if (NOT onnxruntime_BUILD_SHARED_LIB)
   install(TARGETS coreml_proto
+          EXPORT ${PROJECT_NAME}Targets
           ARCHIVE   DESTINATION ${CMAKE_INSTALL_LIBDIR}
           LIBRARY   DESTINATION ${CMAKE_INSTALL_LIBDIR}
           RUNTIME   DESTINATION ${CMAKE_INSTALL_BINDIR}


### PR DESCRIPTION
### Description

The `coreml_proto` target must be properly exported to `onnxruntimeTargets`. Its include directories must not contain any paths from the build tree during the install phase.

### Motivation and Context

This change fixes a build failure on macOS when attempting to create a static library of ONNX Runtime with the CoreML Execution Provider (EP) using the following command:

```sh
./build.sh --use_coreml --cmake_extra_defines CMAKE_POLICY_VERSION_MINIMUM=3.5
```

**Note**: `CMAKE_POLICY_VERSION_MINIMUM=3.5` is required for modern macOS environment. The current version of CMake available on Homebrew is `4.3.1`, and it won't allow `cmake_minimum_required(3.5)`. It seems that ignoring `cmake_minimum_required(3.5)` in the ONNX Runtime tree is not harmful.

The build fails because `coreml_proto` has no export sets specified and it violates CMake's requirement that exported targets must not reference paths from the build tree when installed. Currently, `coreml_proto` depends on `${CMAKE_CURRENT_BINARY_DIR}` to locate generated Protobuf definitions. I suppose these definitions are required only during the build phase and not needed for the installation.

This change set resolves it by:

- Exporting `coreml_proto` to `${PROJECT_NAME}Targets`.
- Replacing `${CMAKE_CURRENT_BINARY_DIR}` with `$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>`.