### PR TITLE
Fix MatMulInteger heap-buffer-overflow with mismatched 1D inputs

### DIFF
--- a/onnxruntime/core/providers/cpu/math/matmul_helper.h
+++ b/onnxruntime/core/providers/cpu/math/matmul_helper.h
@@ -170,7 +170,7 @@ class MatMulComputeHelper {
         ORT_RETURN_IF_NOT(M_ == 1 && N_ == 1, "M_ == 1 && N_ == 1 was false");
         // Both inputs are 1D vectors: left(K) dot right(K) => scalar.
         // Validate K dimensions match to prevent out-of-bounds reads.
-        ORT_RETURN_IF_NOT(K_ == static_cast<ptrdiff_t>(right_shape[0]),
+        ORT_RETURN_IF_NOT(K_ == right_shape[0],
                           "MatMul dimension mismatch");
       } else {
         if (left_num_dims == 1) {

--- a/onnxruntime/test/providers/cpu/math/matmul_integer_test.cc
+++ b/onnxruntime/test/providers/cpu/math/matmul_integer_test.cc
@@ -504,29 +504,42 @@ TEST(MatmulIntegerOpTest, SharedPrepackedWeights) {
 }
 #endif
 
-// Regression test: 1D inputs with mismatched K dimensions must fail
+// Regression test: 1D×1D inputs with mismatched K dimensions must fail
 // instead of causing an out-of-bounds read in the MLAS backend.
 TEST(MatmulIntegerOpTest, MatMulInteger_1D_DimensionMismatch) {
   OpTester test("MatMulInteger", 10);
-  // A is 1D with K=5, B is 1D with K=1 — dimensions don't match.
+  // Omit shape info so ONNX shape inference won't reject 1D inputs at graph build time.
+  test.AddShapeToTensorData(false);
+  // A is [5] (K=5), B is [1] (K=1) — vector×vector K dimensions don't match.
   test.AddInput<uint8_t>("T1", {5}, {11, 7, 3, 10, 6});
   test.AddInput<uint8_t>("T2", {1}, {1});
   test.AddInput<uint8_t>("a_zero_point", {}, {0});
   test.AddInput<uint8_t>("b_zero_point", {}, {0});
   test.AddOutput<int32_t>("T3", {}, {0});
-  test.Run(OpTester::ExpectResult::kExpectFailure, "MatMul dimension mismatch");
+
+  // Restrict to CPU — other EPs may not support 1D quantized inputs.
+  std::vector<std::unique_ptr<IExecutionProvider>> cpu_only;
+  cpu_only.push_back(DefaultCpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectFailure, "MatMul dimension mismatch",
+           {}, nullptr, &cpu_only);
 }
 
-// Valid 1D × 1D dot product: both vectors have the same K.
+// Valid 1D×1D dot product: both vectors have the same K, producing scalar output.
 TEST(MatmulIntegerOpTest, MatMulInteger_1D_Valid) {
   OpTester test("MatMulInteger", 10);
-  // A=[2,3], B=[4,5] => dot = 2*4 + 3*5 = 23
+  // Omit shape info so ONNX shape inference won't reject 1D inputs at graph build time.
+  test.AddShapeToTensorData(false);
+  // A=[2,3], B=[4,5] => scalar dot = 2*4 + 3*5 = 23
   test.AddInput<uint8_t>("T1", {2}, {2, 3});
   test.AddInput<uint8_t>("T2", {2}, {4, 5});
   test.AddInput<uint8_t>("a_zero_point", {}, {0});
   test.AddInput<uint8_t>("b_zero_point", {}, {0});
   test.AddOutput<int32_t>("T3", {}, {23});
-  test.Run();
+
+  // Restrict to CPU — other EPs may not support 1D quantized inputs.
+  std::vector<std::unique_ptr<IExecutionProvider>> cpu_only;
+  cpu_only.push_back(DefaultCpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &cpu_only);
 }
 
 }  // namespace test


### PR DESCRIPTION
### Description

Fix a heap-buffer-overflow (out-of-bounds read) in `MatMulInteger` triggered when both inputs are 1D vectors with mismatched K dimensions (e.g., `A=[5]`, `B=[1]`).

### Root Cause

`MatMulComputeHelper::Compute` in `matmul_helper.h` validated K-dimension mismatches for all input rank combinations **except** the vector×vector case (both 1D, `num_output_dims == 0`). This allowed mismatched shapes to pass through to the MLAS GEMM backend, which assumed B had K elements and read past its allocation in `MlasGemmQuantCopyPackB`.

### Fix

Added the missing `ORT_RETURN_IF_NOT(K_ == right_shape[0], "MatMul dimension mismatch")` check in the vector×vector branch of `MatMulComputeHelper::Compute` — matching the pattern already used in the other branches.

### Testing

- `MatMulInteger_1D_DimensionMismatch`: verifies mismatched 1D shapes are rejected
- `MatMulInteger_1D_Valid`: verifies correct 1D dot products still work
- Both tests restricted to CPU EP only

### Motivation and Context

Security fix — prevents out-of-bounds heap reads when processing untrusted ONNX models with malformed `MatMulInteger` inputs on the CPUExecutionProvider.