### PR TITLE
fix: packaging onnxruntime for macOS x86-64

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -38,7 +38,7 @@ jobs:
       use_coreml: true
       matrix_include: >-
         [
-          {"machine": "arm64", "target": "x86_64", "build_config": "Release"},
+          {"machine": "x86_64", "target": "x86_64", "build_config": "Release"},
           {"machine": "arm64", "target": "arm64", "build_config": "Debug"},
           {"machine": "arm64", "target": "arm64", "build_config": "Release"}
         ]
@@ -61,7 +61,7 @@ jobs:
       use_webgpu: true
       matrix_include: >-
         [
-          {"machine": "arm64", "target": "x86_64", "build_config": "Release"},
+          {"machine": "x86_64", "target": "x86_64", "build_config": "Release"},
           {"machine": "arm64", "target": "arm64", "build_config": "Debug"},
           {"machine": "arm64", "target": "arm64", "build_config": "Release"}
         ]

--- a/.github/workflows/macos-ci-build-and-test-workflow.yml
+++ b/.github/workflows/macos-ci-build-and-test-workflow.yml
@@ -48,7 +48,7 @@ jobs:
         #
         include: ${{ fromJSON(inputs.matrix_include) }}
 
-    # "macos-15" is an arm64 image.
+    # "macos-15-intel" is a x86_64 image, and "macos-15" is an arm64 image.
     # see also: https://github.com/actions/runner-images/blob/main/README.md
     runs-on: ${{ matrix.machine == 'x86_64' && 'macos-15-intel' || 'macos-15' }}
     env:

--- a/tools/ci_build/github/azure-pipelines/stages/nodejs-npm-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nodejs-npm-packaging-stage.yml
@@ -73,6 +73,7 @@ stages:
     #  - Windows arm64 (CPU, DML, WebGPU)
     #  - Linux x64 (CPU, CUDA, TensorRT, WebGPU)
     #  - Linux arm64 (CPU only)
+    #  - macOS x64 (CPU, CoreML, WebGPU)
     #  - macOS arm64 (CPU, CoreML, WebGPU)
     #
     # File manifest:
@@ -109,6 +110,12 @@ stages:
     #      - onnxruntime_binding.node
     #      - libonnxruntime.so.1
     #
+    #  - macOS x64 (CPU, CoreML, WebGPU):
+    #    dependency: MacOS_C_API_Packaging_CPU_x86_64 (drop-onnxruntime-nodejs-osx-x86_64)
+    #    files:
+    #      - onnxruntime_binding.node
+    #      - libonnxruntime.{version}.dylib
+    #
     #  - macOS arm64 (CPU, CoreML, WebGPU):
     #    stage: MacOS_C_API_Packaging_CPU, job: MacOS_C_API_Packaging_CPU_arm64 (drop-onnxruntime-nodejs-osx-arm64)
     #    files:
@@ -135,6 +142,12 @@ stages:
       inputs:
         artifactName: 'drop-onnxruntime-nodejs-win-arm64'
         targetPath: '$(Build.BinariesDirectory)/nodejs-artifacts/win32/arm64/'
+
+    - task: DownloadPipelineArtifact@0
+      displayName: 'Download Pipeline Artifact - Nodejs (macOS x86_64)'
+      inputs:
+        artifactName: 'drop-onnxruntime-nodejs-osx-x86_64'
+        targetPath: '$(Build.BinariesDirectory)/nodejs-artifacts/darwin/x64/'
 
     - task: DownloadPipelineArtifact@0
       displayName: 'Download Pipeline Artifact - Nodejs (macOS arm64)'
@@ -211,6 +224,16 @@ stages:
           libonnxruntime.so.1
           *.node
         TargetFolder: '$(Build.SourcesDirectory)\js\node\bin\napi-v6\linux\arm64'
+
+    # Node.js binding darwin/x64
+    - task: CopyFiles@2
+      displayName: 'Copy nodejs binaries to: $(Build.SourcesDirectory)\js\node\bin\napi-v6\darwin\x64\'
+      inputs:
+        SourceFolder: '$(Build.BinariesDirectory)\nodejs-artifacts\darwin\x64'
+        Contents: |
+          libonnxruntime.*.dylib
+          *.node
+        TargetFolder: '$(Build.SourcesDirectory)\js\node\bin\napi-v6\darwin\x64'
 
     # Node.js binding darwin/arm64
     - task: CopyFiles@2

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -279,6 +279,10 @@ stages:
         targetPath: '$(Build.BinariesDirectory)\java-artifact\onnxruntime-java-linux-aarch64'
 
       - input: pipelineArtifact
+        artifactName: drop-onnxruntime-java-osx-x86_64
+        targetPath: '$(Build.BinariesDirectory)\java-artifact\onnxruntime-java-osx-x86_64'
+
+      - input: pipelineArtifact
         artifactName: drop-onnxruntime-java-osx-arm64
         targetPath: '$(Build.BinariesDirectory)\java-artifact\onnxruntime-java-osx-arm64'
       outputs:

--- a/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packaging-pipeline.yml
@@ -26,6 +26,13 @@ stages:
   jobs:
   - template: mac-cpu-packing-jobs.yml
     parameters:
+      MacosArch: 'x86_64'
+      AllowReleasedOpsetOnly: ${{ parameters.AllowReleasedOpsetOnly }}
+      AdditionalBuildFlags: ${{ parameters.AdditionalBuildFlags }}
+
+  - template: mac-cpu-packing-jobs.yml
+    parameters:
+      MacosArch: 'arm64'
       AllowReleasedOpsetOnly: ${{ parameters.AllowReleasedOpsetOnly }}
       AdditionalBuildFlags: ${{ parameters.AdditionalBuildFlags }}
 
@@ -40,6 +47,9 @@ stages:
       - ImageOverride -equals ACES_VM_SharedPool_Sequoia
     templateContext:
       inputs:
+      - input: pipelineArtifact
+        artifactName: onnxruntime-osx-x86_64
+        targetPath: $(Build.ArtifactStagingDirectory)
       - input: pipelineArtifact
         artifactName: onnxruntime-osx-arm64 # The files in this artifact are not signed
         targetPath: $(Build.ArtifactStagingDirectory)
@@ -56,16 +66,12 @@ stages:
         architecture: arm64
         addToPath: true
 
-    - script: |
-        set -ex
-        cd $(Build.ArtifactStagingDirectory)
-        # Find and extract the arm64 tarball
-        find . -name 'onnxruntime-osx-arm64*.tgz' -exec tar -xzf {} \;
-        # Remove _manifest directories if they exist
-        find . -type d -name '_manifest' -exec rm -rf {} + || true
-        # Find the extracted directory and zip it
-        find . -maxdepth 1 -type d -name 'onnxruntime-osx-arm64*' -exec zip -FSr --symlinks {}.zip {} \;
-      displayName: 'Prepare ARM64 Package for Signing'
+    - task: PythonScript@0
+      displayName: 'Prepare, Create Universal Binary, and Zip with Python'
+      inputs:
+        scriptSource: 'filePath'
+        scriptPath: 'tools/ci_build/prepare_macos_package.py'
+        arguments: '--staging_dir $(Build.ArtifactStagingDirectory)'
 
     - template: mac-esrp-dylib.yml
       parameters:

--- a/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packaging-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packaging-steps.yml
@@ -1,7 +1,9 @@
 parameters:
 - name: MacosArch
   type: string
-  default: 'arm64'
+  values:
+  - 'x86_64'
+  - 'arm64'
 
 - name: AdditionalBuildFlags
   displayName: Additional build flags for build.py
@@ -59,6 +61,9 @@ steps:
 
 - template: nodejs-artifacts-package-and-publish-steps-posix.yml
   parameters:
-      arch: arm64
+      ${{ if eq(parameters.MacosArch, 'x86_64') }}:
+          arch: x64
+      ${{ if eq(parameters.MacosArch, 'arm64') }}:
+          arch: arm64
       os: 'darwin'
       artifactName: 'drop-onnxruntime-nodejs-osx-${{ parameters.MacosArch }}'

--- a/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packing-jobs.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packing-jobs.yml
@@ -3,6 +3,11 @@ parameters:
   displayName: Additional build flags for build.py
   type: string
   default: ''
+- name: MacosArch
+  type: string
+  values:
+    - 'x86_64'
+    - 'arm64'
 
 # Must be 1 or 0
 - name: AllowReleasedOpsetOnly
@@ -14,7 +19,7 @@ parameters:
   - 0
 
 jobs:
-- job: MacOS_C_API_Packaging_CPU_arm64
+- job: MacOS_C_API_Packaging_CPU_${{ parameters.MacosArch }}
   workspace:
     clean: all
   variables:
@@ -56,7 +61,14 @@ jobs:
       echo "##vso[task.prependpath]$JAVA_HOME/bin"
     displayName: 'Install JDK 17'
 
-  - template: mac-cpu-packaging-steps.yml
-    parameters:
-      MacosArch: arm64
-      AdditionalBuildFlags: ${{ parameters.AdditionalBuildFlags }} --build_java --build_nodejs --use_coreml --use_webgpu --cmake_extra_defines CMAKE_OSX_ARCHITECTURES=arm64
+  - ${{ if eq(parameters.MacosArch, 'arm64') }}:
+    - template: mac-cpu-packaging-steps.yml
+      parameters:
+        MacosArch: ${{ parameters.MacosArch }}
+        AdditionalBuildFlags: ${{ parameters.AdditionalBuildFlags }} --build_java --build_nodejs --use_coreml --use_webgpu --cmake_extra_defines CMAKE_OSX_ARCHITECTURES=arm64
+
+  - ${{ if eq(parameters.MacosArch, 'x86_64') }}:
+    - template: mac-cpu-packaging-steps.yml
+      parameters:
+        MacosArch: ${{ parameters.MacosArch }}
+        AdditionalBuildFlags: ${{ parameters.AdditionalBuildFlags }} --build_java --build_nodejs --use_coreml --use_webgpu --cmake_extra_defines CMAKE_OSX_ARCHITECTURES=x86_64

--- a/tools/ci_build/github/windows/jar_packaging.py
+++ b/tools/ci_build/github/windows/jar_packaging.py
@@ -232,6 +232,7 @@ def run_packaging(package_type: str, build_dir: str):
             "platforms": [
                 {"path": "onnxruntime-java-linux-x64", "lib": "libcustom_op_library.so", "archive_lib": True},
                 {"path": "onnxruntime-java-linux-aarch64", "lib": "libcustom_op_library.so", "archive_lib": False},
+                {"path": "onnxruntime-java-osx-x86_64", "lib": "libcustom_op_library.dylib", "archive_lib": True},
                 {"path": "onnxruntime-java-osx-arm64", "lib": "libcustom_op_library.dylib", "archive_lib": True},
             ]
         },

--- a/tools/ci_build/github/windows/jar_packaging.py
+++ b/tools/ci_build/github/windows/jar_packaging.py
@@ -232,7 +232,7 @@ def run_packaging(package_type: str, build_dir: str):
             "platforms": [
                 {"path": "onnxruntime-java-linux-x64", "lib": "libcustom_op_library.so", "archive_lib": True},
                 {"path": "onnxruntime-java-linux-aarch64", "lib": "libcustom_op_library.so", "archive_lib": False},
-                {"path": "onnxruntime-java-osx-x86_64", "lib": "libcustom_op_library.dylib", "archive_lib": True},
+                {"path": "onnxruntime-java-osx-x86_64", "lib": "libcustom_op_library.dylib", "archive_lib": False},
                 {"path": "onnxruntime-java-osx-arm64", "lib": "libcustom_op_library.dylib", "archive_lib": True},
             ]
         },


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

- packaging onnxruntime for macOS x86_64
- `macos-13` is now deprecated.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


- Ref https://github.com/actions/runner-images/issues/13046
- Ref #26072
- Close #27961 

- Caused by #26252