### PR TITLE
[DOCS ]Add annotated partitioning documentation

### DIFF
--- a/docs/annotated_partitioning/PartitioningWithAnnotationsAndMemoryConstraints.md
+++ b/docs/annotated_partitioning/PartitioningWithAnnotationsAndMemoryConstraints.md
@@ -159,18 +159,22 @@ session = ort.InferenceSession("model_annotated.onnx", opts,
                                providers=["CUDAExecutionProvider", "CPUExecutionProvider"])
 ```
 
-#### Multi-GPU Example
+#### Targeting a Specific GPU
 
-On a machine with multiple GPUs, use `gpu:<index>` to target specific devices:
+On a machine with multiple GPUs, use `gpu:<index>` to direct annotations to a particular device:
 
 ```python
 opts.add_session_config_entry(
     "session.layer_assignment_settings",
-    "gpu:0(encoder); gpu:1(decoder); cpu(=postprocess)"
+    "gpu:1(encoder, decoder); cpu(=postprocess)"
 )
 ```
 
+> **Note:** ONNX Runtime currently allows only one instance of a given EP type per session, so you cannot split annotations across multiple GPUs in a single session. The `gpu:<index>` designator selects *which* GPU the single registered EP targets.
+
 Nodes that do not match any rule fall through to the normal EP capability-based assignment.
+
+> **Unmatched device designators:** If a device designator in the settings does not match any EP registered in the session, ONNX Runtime logs a warning and skips that rule. Nodes covered by the skipped rule are not pre-assigned and fall through to the normal capability-based partitioning.
 
 > **Note — Annotations vs. actual placement:** An annotation expresses a *preference*, not a guarantee. If the target EP does not have a registered kernel for a node (for example, a particular data-type / opset-version combination is not implemented in the CUDA EP), that node will not be placed on the requested device. Instead it falls through to the next EP in the provider list that can handle it.
 


### PR DESCRIPTION
This pull request introduces a new documentation page, `PartitioningWithAnnotationsAndMemoryConstraints.md`, which explains advanced ONNX Runtime features for partitioning model graphs across devices with explicit control. The doc covers how to annotate model layers for device assignment, collect per-node memory statistics, and enforce GPU memory budgets during partitioning. These features enable precise control over device placement and memory usage for large models.

The most important changes are:

**New Documentation: Advanced Partitioning Features**
* Adds a comprehensive guide (`PartitioningWithAnnotationsAndMemoryConstraints.md`) describing how to use ONNX Runtime’s layer annotation and memory constraint features for graph partitioning.

**Layer Assignment via Annotations**
* Explains how to annotate ONNX model nodes with `layer_ann` metadata, including manual annotation and automated annotation using Olive’s `CaptureLayerAnnotations` pass.
* Provides configuration examples for mapping annotation patterns to devices at runtime using the `session.layer_assignment_settings` session option.

**Capacity-Aware Partitioning**
* Details a two-phase workflow for profiling per-node memory usage and then enforcing a memory budget with the `session.resource_cuda_partitioning_settings` session option.
* Covers both profiling-based and ad-hoc (estimation-only) approaches for memory-constrained partitioning. ([docs/annotated_partitioning/PartitioningWithAnnotationsAndMemoryConstraints.mdR1-R267](diffhunk://#diff-10b3051b9e36eccfc7ca0f2d44ce78a9980ca573cde0f931ffd1456da2c681daR1-R267)

This is a follow up for https://github.com/microsoft/onnxruntime/pull/27595