### PR TITLE
Fix build error on vsinpu provider

### DIFF
--- a/cmake/onnxruntime_providers_vsinpu.cmake
+++ b/cmake/onnxruntime_providers_vsinpu.cmake
@@ -35,3 +35,8 @@
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter")
     target_link_libraries(onnxruntime_providers_vsinpu PRIVATE ${TIMVX_LIBRARY})
   endif()
+  install(TARGETS onnxruntime_providers_vsinpu EXPORT ${PROJECT_NAME}Targets
+          ARCHIVE   DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          LIBRARY   DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          RUNTIME   DESTINATION ${CMAKE_INSTALL_BINDIR}
+          FRAMEWORK DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
There are two places to need fix.
1.  `onnxruntime_config.h`, but it exists at ${CMAKE_CURRENT_BINARY_DIR} directory, other providers, like openvino, qnn have been include ${CMAKE_CURRENT_BINARY_DIR} 
2. onnxruntime_providers_vsinpu need to export to install set.

