### PR TITLE
Add session config options to disable input/output validation in Run()

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -481,3 +481,26 @@ static const char* const kOrtSessionOptionsRecordEpGraphAssignmentInfo = "sessio
 // - "0": disable. (default)
 // - "1": enable.
 static const char* const kOrtSessionOptionEpEnableWeightlessEpContextNodes = "ep.enable_weightless_ep_context_nodes";
+
+// Set to '1' to disable all input tensor validation during Run().
+// This skips all checks on input names, types, and shapes for every Run() call in this session.
+// This can be useful when using execution providers that supply inputs with types or shapes
+// that differ from the model's declared inputs (e.g., custom EPs that perform dynamic
+// transformations before execution).
+// WARNING: Disabling input validation may lead to undefined behavior or crashes if the
+// inputs are genuinely incompatible with the model.
+// "0": input validation is enabled (default).
+// "1": input validation is disabled.
+static const char* const kOrtSessionOptionsConfigDisableInputValidation =
+    "session.disable_input_validation";
+
+// Set to '1' to disable all output tensor validation during Run().
+// This skips all checks on output names, types, and shapes for every Run() call in this session.
+// This can be useful when using execution providers that produce outputs with types or shapes
+// that differ from the model's declared outputs.
+// WARNING: Disabling output validation may lead to undefined behavior or crashes if the
+// outputs are genuinely incompatible with the model.
+// "0": output validation is enabled (default).
+// "1": output validation is disabled.
+static const char* const kOrtSessionOptionsConfigDisableOutputValidation =
+    "session.disable_output_validation";

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -2662,6 +2662,28 @@ common::Status InferenceSession::Initialize() {
         graph.DomainToVersionMap(), model_file_name, graph.Name(), model_weight_type, model_graph_hash, model_weight_hash,
         model_->MetaData(), telemetry_.event_name_, execution_providers_.GetIds(), model_has_fp16_inputs, false);
 
+    // Set disable flags from session config to use during Run().
+    disable_input_validation_ =
+        session_options_.config_options.GetConfigOrDefault(
+            kOrtSessionOptionsConfigDisableInputValidation, "0") == "1";
+    disable_output_validation_ =
+        session_options_.config_options.GetConfigOrDefault(
+            kOrtSessionOptionsConfigDisableOutputValidation, "0") == "1";
+
+    // Warn if input/output validation has been disabled for this session
+    if (disable_input_validation_) {
+      LOGS(*session_logger_, WARNING)
+          << "Input validation is disabled for this session via session config option '"
+          << kOrtSessionOptionsConfigDisableInputValidation << "'. "
+          << "Ensure all inputs are compatible with the model to avoid undefined behavior.";
+    }
+    if (disable_output_validation_) {
+      LOGS(*session_logger_, WARNING)
+          << "Output validation is disabled for this session via session config option '"
+          << kOrtSessionOptionsConfigDisableOutputValidation << "'. "
+          << "Ensure all outputs are compatible with the model to avoid undefined behavior.";
+    }
+
     LOGS(*session_logger_, INFO) << "Session successfully initialized.";
   }
 
@@ -3147,8 +3169,13 @@ Status InferenceSession::Run(const RunOptions& run_options,
       // log evaluation start to trace logging provider
       env.GetTelemetryProvider().LogEvaluationStart(session_id_);
 
-      ORT_RETURN_IF_ERROR_SESSIONID_(ValidateInputs(feed_names, feeds));
-      ORT_RETURN_IF_ERROR_SESSIONID_(ValidateOutputs(output_names, p_fetches));
+      if (!disable_input_validation_) {
+        ORT_RETURN_IF_ERROR_SESSIONID_(ValidateInputs(feed_names, feeds));
+      }
+
+      if (!disable_output_validation_) {
+        ORT_RETURN_IF_ERROR_SESSIONID_(ValidateOutputs(output_names, p_fetches));
+      }
 
       // shrink certain default memory arenas if the user has requested for it
       const std::string& shrink_memory_arenas =

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -961,6 +961,11 @@ class InferenceSession {
   bool is_inited_ = false;                   // GUARDED_BY(session_mutex_)
   bool is_concurrent_run_supported_ = true;  // Graph execution in Run is GUARDED_BY(session_mutex_) if false
 
+  // Cached flags from session config options to avoid repeated string lookups during Run().
+  // Set once during Initialize().
+  bool disable_input_validation_ = false;   // kOrtSessionOptionsConfigDisableInputValidation
+  bool disable_output_validation_ = false;  // kOrtSessionOptionsConfigDisableOutputValidation
+
 #ifdef ENABLE_LANGUAGE_INTEROP_OPS
   InterOpDomains interop_domains_;
 #endif

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -1096,6 +1096,144 @@ TEST(InferenceSessionTests, InvalidInputTypeOfTensorElement) {
   ASSERT_TRUE(!st.IsOK());
 }
 
+// Test that setting kOrtSessionOptionsConfigDisableInputValidation bypasses input type/shape checks.
+// MODEL_URI (mul_1.onnx) expects a float input "X" of shape [3,2].
+// We feed an int64 tensor (wrong type) and verify:
+//   - Without the flag: Run() fails with a type mismatch error from ValidateInputs.
+//   - With the flag:    Run() does NOT fail due to input validation (it may fail at execution,
+//                       but the error will not be the "Unexpected input data type" validation error).
+TEST(InferenceSessionTests, DisableInputValidation) {
+  const std::vector<int64_t> dims_mul_x = {3, 2};
+  const std::vector<int64_t> values_mul_x = {1, 2, 3, 4, 5, 6};
+
+  auto make_int64_feed = [&]() {
+    OrtValue ml_value;
+    CreateMLValue<int64_t>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0],
+                           dims_mul_x, values_mul_x, &ml_value);
+    NameMLValMap feeds;
+    feeds.insert(std::make_pair("X", ml_value));
+    return feeds;
+  };
+
+  const std::vector<std::string> output_names = {"Y"};
+
+  // Part 1: Without the flag, wrong type should fail validation.
+  {
+    SessionOptions so;
+    so.session_logid = "InferenceSessionTests.DisableInputValidation.WithValidation";
+    InferenceSession session_object{so, GetEnvironment()};
+    ASSERT_STATUS_OK(session_object.Load(MODEL_URI));
+    ASSERT_STATUS_OK(session_object.Initialize());
+
+    RunOptions run_options;
+    std::vector<OrtValue> fetches;
+    auto feeds = make_int64_feed();
+    common::Status st = session_object.Run(run_options, feeds, output_names, &fetches);
+    ASSERT_FALSE(st.IsOK()) << "Expected Run() to fail with type mismatch when validation is enabled";
+    ASSERT_TRUE(st.ErrorMessage().find("Unexpected input data type") != std::string::npos ||
+                st.ErrorMessage().find("tensor") != std::string::npos)
+        << "Unexpected error message: " << st.ErrorMessage();
+  }
+
+  // Part 2: With the flag set, input validation is skipped entirely.
+  {
+    SessionOptions so;
+    so.session_logid = "InferenceSessionTests.DisableInputValidation.WithoutValidation";
+    ASSERT_STATUS_OK(so.config_options.AddConfigEntry(
+        kOrtSessionOptionsConfigDisableInputValidation, "1"));
+    InferenceSession session_object{so, GetEnvironment()};
+    ASSERT_STATUS_OK(session_object.Load(MODEL_URI));
+    ASSERT_STATUS_OK(session_object.Initialize());
+
+    RunOptions run_options;
+    std::vector<OrtValue> fetches;
+    auto feeds = make_int64_feed();
+    common::Status st = session_object.Run(run_options, feeds, output_names, &fetches);
+    // The run may succeed or fail at execution, but must NOT fail with the
+    // "Unexpected input data type" validation error from ValidateInputs.
+    if (!st.IsOK()) {
+      ASSERT_TRUE(st.ErrorMessage().find("Unexpected input data type") == std::string::npos)
+          << "Run() should not fail with input type validation error when "
+          << kOrtSessionOptionsConfigDisableInputValidation << " is set to '1'. "
+          << "Actual error: " << st.ErrorMessage();
+    }
+  }
+}
+
+// Test that setting kOrtSessionOptionsConfigDisableOutputValidation bypasses output shape checks.
+// MODEL_URI (mul_1.onnx) produces a float output "Y" of shape [3,2].
+// We pre-allocate an output tensor of wrong shape [2,3] and verify:
+//   - Without the flag: Run() fails with a shape mismatch error from ValidateOutputs.
+//   - With the flag:    Run() does NOT fail due to output validation.
+TEST(InferenceSessionTests, DisableOutputValidation) {
+  // Prepare a valid float input "X" of shape [3,2].
+  const std::vector<int64_t> input_dims = {3, 2};
+  const std::vector<float> input_values = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+
+  auto make_valid_feed = [&]() {
+    OrtValue ml_value;
+    CreateMLValue<float>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0],
+                         input_dims, input_values, &ml_value);
+    NameMLValMap feeds;
+    feeds.insert(std::make_pair("X", ml_value));
+    return feeds;
+  };
+
+  // Pre-allocate an output tensor with wrong shape [2,3] (model expects [3,2]).
+  const std::vector<int64_t> wrong_output_dims = {2, 3};
+  const std::vector<std::string> output_names = {"Y"};
+
+  auto make_wrong_shape_fetch = [&]() {
+    std::vector<OrtValue> fetches(1);
+    AllocateMLValue<float>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0],
+                           wrong_output_dims, &fetches[0]);
+    return fetches;
+  };
+
+  // Part 1: Without the flag, wrong output shape should fail validation.
+  {
+    SessionOptions so;
+    so.session_logid = "InferenceSessionTests.DisableOutputValidation.WithValidation";
+    InferenceSession session_object{so, GetEnvironment()};
+    ASSERT_STATUS_OK(session_object.Load(MODEL_URI));
+    ASSERT_STATUS_OK(session_object.Initialize());
+
+    RunOptions run_options;
+    auto feeds = make_valid_feed();
+    auto fetches = make_wrong_shape_fetch();
+    common::Status st = session_object.Run(run_options, feeds, output_names, &fetches);
+    ASSERT_FALSE(st.IsOK()) << "Expected Run() to fail with shape mismatch when validation is enabled";
+    ASSERT_TRUE(st.ErrorMessage().find("invalid dimensions") != std::string::npos ||
+                st.ErrorMessage().find("shape") != std::string::npos ||
+                st.ErrorMessage().find("Got invalid") != std::string::npos)
+        << "Unexpected error message: " << st.ErrorMessage();
+  }
+
+  // Part 2: With the flag set, output validation is skipped entirely.
+  {
+    SessionOptions so;
+    so.session_logid = "InferenceSessionTests.DisableOutputValidation.WithoutValidation";
+    ASSERT_STATUS_OK(so.config_options.AddConfigEntry(
+        kOrtSessionOptionsConfigDisableOutputValidation, "1"));
+    InferenceSession session_object{so, GetEnvironment()};
+    ASSERT_STATUS_OK(session_object.Load(MODEL_URI));
+    ASSERT_STATUS_OK(session_object.Initialize());
+
+    RunOptions run_options;
+    auto feeds = make_valid_feed();
+    auto fetches = make_wrong_shape_fetch();
+    common::Status st = session_object.Run(run_options, feeds, output_names, &fetches);
+    // The run may succeed or fail at execution, but must NOT fail with the
+    // shape mismatch validation error from ValidateOutputs.
+    if (!st.IsOK()) {
+      ASSERT_TRUE(st.ErrorMessage().find("Got invalid dimensions") == std::string::npos)
+          << "Run() should not fail with output shape validation error when "
+          << kOrtSessionOptionsConfigDisableOutputValidation << " is set to '1'. "
+          << "Actual error: " << st.ErrorMessage();
+    }
+  }
+}
+
 TEST(InferenceSessionTests, ModelWithoutOpset) {
   SessionOptions so;
 


### PR DESCRIPTION
### Description
Add two SessionOptions config keys:
  session.disable_input_validation  (kOrtSessionOptionsConfigDisableInputValidation)
  session.disable_output_validation (kOrtSessionOptionsConfigDisableOutputValidation)

When set to '1', the corresponding validation call is skipped for every Run() in that session. The flags are cached as bool members during Initialize() to avoid repeated string-map lookups on the hot path. A one-time WARNING log is emitted at Initialize() time when either flag is set.


### Motivation and Context
Custom execution providers sometimes supply tensors whose types or shapes differ from the model's declared signature (e.g. EPs might perform dynamic shape transformations or expect different io buffer sizes). The existing ValidateInputs/ValidateOutputs calls in Run() reject these tensors.

Fixes: https://github.com/microsoft/onnxruntime/issues/27986
