### PR TITLE
Add DiT attention fusion for F5-TTS and diffusion transformer models

### DIFF
--- a/onnxruntime/python/tools/transformers/fusion_mha_dit.py
+++ b/onnxruntime/python/tools/transformers/fusion_mha_dit.py
@@ -405,10 +405,27 @@ class FusionMultiHeadAttentionDiT(Fusion):
             # K is natively in BNHS format, add a Transpose to convert to BNSH
             k_bnsh = self.transpose_bnhs_to_bnsh(k_transposed_input)
 
+        # Trace K back through any Cast to find the source tensor's element type.
+        # When K reaches matmul_qk through a casted BNHS tensor (e.g., a Cast FP32→FP16
+        # inserted before the pre-transpose), get_dtype(k_bnsh) returns the Cast output
+        # type rather than the source type. Tracing through the Cast lets us compare the
+        # true source dtype against Q, matching the same pattern used for V above.
+        # Note: we do NOT walk through synthesised Transpose nodes (added by
+        # transpose_bnhs_to_bnsh) for guard purposes — those have no type annotation and
+        # walking through them would make the dtype unresolvable, incorrectly triggering
+        # a bail-out on the normal FP16 test path.
+        k_traced_through_cast = False
+        k_bnsh_for_dtype = k_bnsh
+        if k_bnsh_for_dtype in output_name_to_node:
+            k_producer = output_name_to_node[k_bnsh_for_dtype]
+            if k_producer.op_type == "Cast":
+                k_bnsh_for_dtype = k_producer.input[0]
+                k_traced_through_cast = True
+
         # Verify Q, K, V element types are consistent. MHA's type parameter T binds
         # all three inputs to the same type — mismatches produce invalid graphs.
         q_dtype = self.model.get_dtype(q_bnsh)
-        k_dtype = self.model.get_dtype(k_bnsh)
+        k_dtype = self.model.get_dtype(k_bnsh_for_dtype)
         v_dtype = self.model.get_dtype(v_bnsh)
         if q_dtype is not None and v_dtype is not None and q_dtype != v_dtype:
             logger.debug("fuse_dit_attention: Q/V element type mismatch (%s vs %s), skipping", q_dtype, v_dtype)
@@ -430,6 +447,18 @@ class FusionMultiHeadAttentionDiT(Fusion):
                     v_dtype,
                 )
                 return
+        # Bail out only when K was traced through a Cast (positive evidence of a type
+        # conversion on the K path) AND the source dtype is known AND it differs from Q.
+        # When K's dtype is simply unresolvable (None) with no Cast on its path, we
+        # preserve prior behaviour and do not bail — the dtype-mismatch check above
+        # already handles the case where both sides are known and differ.
+        if k_traced_through_cast and q_dtype is not None and k_dtype is not None and q_dtype != k_dtype:
+            logger.debug(
+                "fuse_dit_attention: K Cast source dtype mismatch with Q (%s vs %s), skipping",
+                k_dtype,
+                q_dtype,
+            )
+            return
 
         # ========================================================================
         # Detect num_heads
@@ -488,6 +517,16 @@ class FusionMultiHeadAttentionDiT(Fusion):
         nodes_to_remove = [matmul_sv, transpose_out, reshape_out]
         if cast_after_softmax is not None:
             nodes_to_remove.append(cast_after_softmax)
+
+        # Guard: bail out if any downstream intermediate has consumers outside the
+        # nodes we are about to remove. The MHA output (reshape_out.output[0]) is the
+        # value that will be produced by the fused node, so it must be kept.
+        if not self.model.is_safe_to_fuse_nodes(
+            nodes_to_remove, [reshape_out.output[0]], input_name_to_nodes, output_name_to_node
+        ):
+            logger.debug("fuse_dit_attention: downstream nodes have external consumers, skipping")
+            return
+
         self.nodes_to_remove.extend(nodes_to_remove)
 
         # Use prune graph to remove remaining unreferenced nodes

--- a/onnxruntime/python/tools/transformers/fusion_mha_dit.py
+++ b/onnxruntime/python/tools/transformers/fusion_mha_dit.py
@@ -61,10 +61,19 @@ class FusionMultiHeadAttentionDiT(Fusion):
         Returns:
             int: the input index (0 or 1) of the data input, or None if ambiguous.
         """
+        is_scalar_constant = [False, False]
         for i in range(2):
             value = self.model.get_constant_value(mul_node.input[i])
-            if value is not None and isinstance(value, np.ndarray) and value.size == 1:
-                return 1 - i  # The other input is data
+            if value is not None:
+                if isinstance(value, np.ndarray):
+                    is_scalar_constant[i] = value.size == 1
+                elif isinstance(value, (int, float)):
+                    is_scalar_constant[i] = True
+
+        if is_scalar_constant[0] and not is_scalar_constant[1]:
+            return 1
+        if is_scalar_constant[1] and not is_scalar_constant[0]:
+            return 0
         return None
 
     def detect_num_heads(self, tensor_name: str, output_name_to_node: dict) -> int:
@@ -134,24 +143,36 @@ class FusionMultiHeadAttentionDiT(Fusion):
 
         return 0
 
-    def detect_num_heads_from_output(self, reshape_out: NodeProto, transpose_out: NodeProto) -> int:
-        """Try to detect num_heads from the output Reshape or Transpose shape info.
+    def detect_num_heads_from_input_shape(self, tensor_name: str) -> int:
+        """Try to detect num_heads from a BNSH tensor's shape in graph inputs or value_info.
 
-        The Transpose converts BNSH → BSNH. If we can find the shape of Q/K,
-        the N dimension gives us num_heads.
-
-        Falls back to trying value_info shape data.
+        For BNSH tensors, the N dimension (index 1) is num_heads.
         """
-        # Try to find shape info from the graph's value_info
-        transpose_input = transpose_out.input[0]
+        # Check graph inputs (e.g., when Q/K/V are direct graph inputs)
+        for inp in self.model.model.graph.input:
+            if inp.name == tensor_name:
+                shape = inp.type.tensor_type.shape
+                if shape and len(shape.dim) == 4:
+                    dim_n = shape.dim[1]
+                    if dim_n.dim_value > 0:
+                        return dim_n.dim_value
+
+        # Check value_info
         for vi in self.model.model.graph.value_info:
-            if vi.name == transpose_input:
+            if vi.name == tensor_name:
                 shape = vi.type.tensor_type.shape
                 if shape and len(shape.dim) == 4:
                     dim_n = shape.dim[1]
                     if dim_n.dim_value > 0:
                         return dim_n.dim_value
         return 0
+
+    def detect_num_heads_from_output(self, reshape_out: NodeProto, transpose_out: NodeProto) -> int:
+        """Try to detect num_heads from the output Transpose's input shape.
+
+        The Transpose converts BNSH -> BSNH. The N dimension gives us num_heads.
+        """
+        return self.detect_num_heads_from_input_shape(transpose_out.input[0])
 
     def reshape_to_3d(self, input_name: str, output_name: str) -> str:
         """Add a Reshape node to convert 4D BxSxNxH to 3D BxSxD.
@@ -254,6 +275,12 @@ class FusionMultiHeadAttentionDiT(Fusion):
 
         # Softmax output shall not be graph output.
         if self.model.find_graph_output(softmax.output[0]):
+            return
+
+        # MultiHeadAttention normalizes along the last axis. Only fuse when Softmax
+        # uses the last axis (default for opset 13+), otherwise semantics would change.
+        axis = OnnxModel.get_node_attribute(softmax, "axis")
+        if axis is not None and axis not in (-1, 3):
             return
 
         # ========================================================================
@@ -370,6 +397,11 @@ class FusionMultiHeadAttentionDiT(Fusion):
         if num_heads <= 0:
             # Try detecting from V path
             num_heads = self.detect_num_heads(v_bnsh, output_name_to_node)
+        if num_heads <= 0:
+            # Try detecting from graph input/value_info shapes (e.g., when Q/V are graph inputs)
+            num_heads = self.detect_num_heads_from_input_shape(q_bnsh)
+        if num_heads <= 0:
+            num_heads = self.detect_num_heads_from_input_shape(v_bnsh)
         if num_heads <= 0:
             # Try detecting from output shape info
             num_heads = self.detect_num_heads_from_output(reshape_out, transpose_out)

--- a/onnxruntime/python/tools/transformers/fusion_mha_dit.py
+++ b/onnxruntime/python/tools/transformers/fusion_mha_dit.py
@@ -279,8 +279,12 @@ class FusionMultiHeadAttentionDiT(Fusion):
 
         # MultiHeadAttention normalizes along the last axis. Only fuse when Softmax
         # uses the last axis (default for opset 13+), otherwise semantics would change.
+        # For opset < 13, ONNX Softmax defaults axis to 1 when omitted, so an absent
+        # axis attribute is NOT safe to fuse — it would silently change semantics.
         axis = OnnxModel.get_node_attribute(softmax, "axis")
         if axis is not None and axis not in (-1, 3):
+            return
+        if axis is None and self.model.get_opset_version() < 13:
             return
 
         # ========================================================================
@@ -380,6 +384,17 @@ class FusionMultiHeadAttentionDiT(Fusion):
         k_transposed_input = matmul_qk.input[1]
         v_bnsh = matmul_sv.input[1]
 
+        # In the cast-wrapped path, V may have been cast to match the post-Softmax
+        # attention weights' type (e.g., V cast from FP32 to FP16). The fused MHA op
+        # requires Q, K, V to share the same element type (type parameter T), so we
+        # trace V back through any Cast that was inserted for type consistency.
+        v_traced_through_cast = False
+        if cast_after_softmax is not None and v_bnsh in output_name_to_node:
+            v_producer = output_name_to_node[v_bnsh]
+            if v_producer.op_type == "Cast":
+                v_bnsh = v_producer.input[0]
+                v_traced_through_cast = True
+
         # Check if K^T comes from Transpose(perm=0,1,3,2) — if so, use K_BNSH directly
         k_transpose_node = self.model.match_parent(
             matmul_qk, "Transpose", input_index=1, output_name_to_node=output_name_to_node
@@ -389,6 +404,32 @@ class FusionMultiHeadAttentionDiT(Fusion):
         else:
             # K is natively in BNHS format, add a Transpose to convert to BNSH
             k_bnsh = self.transpose_bnhs_to_bnsh(k_transposed_input)
+
+        # Verify Q, K, V element types are consistent. MHA's type parameter T binds
+        # all three inputs to the same type — mismatches produce invalid graphs.
+        q_dtype = self.model.get_dtype(q_bnsh)
+        k_dtype = self.model.get_dtype(k_bnsh)
+        v_dtype = self.model.get_dtype(v_bnsh)
+        if q_dtype is not None and v_dtype is not None and q_dtype != v_dtype:
+            logger.debug("fuse_dit_attention: Q/V element type mismatch (%s vs %s), skipping", q_dtype, v_dtype)
+            return
+        if q_dtype is not None and k_dtype is not None and q_dtype != k_dtype:
+            logger.debug("fuse_dit_attention: Q/K element type mismatch (%s vs %s), skipping", q_dtype, k_dtype)
+            return
+        # When casts are present and V was NOT traced back through one, we can't be
+        # sure V matches Q/K's type. Bail out if types are unverifiable — proceeding
+        # could create a type-invalid MHA (e.g., Q=float32 but V=float16).
+        # When V WAS traced back, the trace-back already recovered the pre-cast tensor,
+        # so type consistency is structurally guaranteed.
+        if (cast_before_softmax is not None or cast_after_softmax is not None) and not v_traced_through_cast:
+            if q_dtype is None or v_dtype is None:
+                logger.debug(
+                    "fuse_dit_attention: cast nodes present, V not traced through Cast, "
+                    "types unverifiable (q=%s, v=%s), skipping",
+                    q_dtype,
+                    v_dtype,
+                )
+                return
 
         # ========================================================================
         # Detect num_heads
@@ -414,6 +455,20 @@ class FusionMultiHeadAttentionDiT(Fusion):
         # ========================================================================
         q_bsnh = self.transpose_bnsh_to_bsnh(q_bnsh)
         q_bsd = self.reshape_to_3d(q_bsnh, q_bsnh + "_BSD")
+
+        # ========================================================================
+        # Single-consumer guard: bail out if any matched intermediate tensor feeds
+        # another node. Removing multi-consumer intermediates would break the graph.
+        # ========================================================================
+        intermediate_outputs = [matmul_qk.output[0], mul_scale.output[0], softmax.output[0]]
+        if cast_before_softmax is not None:
+            intermediate_outputs.append(cast_before_softmax.output[0])
+        if cast_after_softmax is not None:
+            intermediate_outputs.append(cast_after_softmax.output[0])
+        for tensor_name in intermediate_outputs:
+            if tensor_name in input_name_to_nodes and len(input_name_to_nodes[tensor_name]) > 1:
+                logger.debug("fuse_dit_attention: intermediate %s has multiple consumers, skipping", tensor_name)
+                return
 
         # ========================================================================
         # Create MultiHeadAttention node

--- a/onnxruntime/python/tools/transformers/fusion_mha_dit.py
+++ b/onnxruntime/python/tools/transformers/fusion_mha_dit.py
@@ -1,0 +1,407 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+from logging import getLogger
+
+import numpy as np
+from fusion_base import Fusion
+from fusion_utils import FusionUtils
+from onnx import NodeProto, helper, numpy_helper
+from onnx_model import OnnxModel
+
+logger = getLogger(__name__)
+
+
+class FusionMultiHeadAttentionDiT(Fusion):
+    """
+    Fuse MultiHeadAttention for Diffusion Transformer (DiT) models like F5-TTS.
+
+    Recognizes attention patterns where Q, K, V are pre-computed (e.g., after RoPE)
+    and K is pre-transposed, with optional Cast nodes for mixed-precision (FP16) inference
+    and a custom scalar scale factor before Softmax.
+
+    Supported patterns (anchored at Softmax):
+
+        MatMul(Q, K^T) → [Cast(FP16→FP32)] → Mul(scale) → Softmax → [Cast(FP32→FP16)] → MatMul(attn, V)
+            → Transpose(perm=0,2,1,3) → Reshape → output
+
+    Where:
+        - Q is in BNSH format (post-RoPE or post-projection)
+        - K is pre-transposed to BNHS format (via Transpose(perm=0,1,3,2) or natively)
+        - V is in BNSH format
+        - Scale is an arbitrary scalar constant (e.g., 100.0 for DiT, or 1/sqrt(d_k))
+        - Cast nodes are optional (present in FP16 models for FP32 Softmax stability)
+    """
+
+    def __init__(self, model: OnnxModel):
+        super().__init__(model, fused_op_type="MultiHeadAttention", search_op_types=["Softmax"])
+
+    def get_scale_from_mul(self, mul_node: NodeProto) -> float | None:
+        """Extract the scalar scale constant from a Mul node.
+
+        The scale can be in either input[0] or input[1].
+
+        Returns:
+            float: the scale value, or None if not found.
+        """
+        for i in range(2):
+            value = self.model.get_constant_value(mul_node.input[i])
+            if value is not None:
+                if isinstance(value, np.ndarray):
+                    if value.size == 1:
+                        return float(value.item())
+                elif isinstance(value, (int, float)):
+                    return float(value)
+        return None
+
+    def get_data_input_of_mul(self, mul_node: NodeProto) -> int | None:
+        """Determine which input of Mul is the data (non-constant) input.
+
+        Returns:
+            int: the input index (0 or 1) of the data input, or None if ambiguous.
+        """
+        for i in range(2):
+            value = self.model.get_constant_value(mul_node.input[i])
+            if value is not None and isinstance(value, np.ndarray) and value.size == 1:
+                return 1 - i  # The other input is data
+        return None
+
+    def detect_num_heads(self, tensor_name: str, output_name_to_node: dict) -> int:
+        """Detect num_heads by walking upstream from a BNSH tensor looking for a Reshape node.
+
+        Typical upstream patterns:
+            Reshape(shape=[B, S, N, H]) → Transpose(perm=0,2,1,3) → ... → tensor_BNSH
+            Reshape(shape=Concat(..., N, H)) → Transpose(perm=0,2,1,3) → ... → tensor_BNSH
+
+        Returns:
+            int: number of heads, or 0 if not detected.
+        """
+        if tensor_name not in output_name_to_node:
+            return 0
+
+        # Walk upstream looking for Transpose → Reshape pattern (possibly with other ops between)
+        current = output_name_to_node[tensor_name]
+        depth = 0
+        max_depth = 10  # Don't walk too far
+
+        while current is not None and depth < max_depth:
+            if current.op_type == "Transpose":
+                perm = OnnxModel.get_node_attribute(current, "perm")
+                if perm == [0, 2, 1, 3]:
+                    # Found the BSNH → BNSH transpose, look for Reshape before it
+                    if current.input[0] in output_name_to_node:
+                        parent = output_name_to_node[current.input[0]]
+                        num_heads = self._get_num_heads_from_reshape(parent)
+                        if num_heads > 0:
+                            return num_heads
+                    # Also try looking one step further (e.g., through Add/Norm)
+                    break
+
+            # Move to the first input
+            if current.input[0] in output_name_to_node:
+                current = output_name_to_node[current.input[0]]
+            else:
+                break
+            depth += 1
+
+        return 0
+
+    def _get_num_heads_from_reshape(self, node: NodeProto) -> int:
+        """Extract num_heads from a Reshape node's shape parameter.
+
+        Handles:
+            - Static shape constant: [B, S, num_heads, head_dim]
+            - Concat-based shape: Concat([B_dim], [S_dim], [num_heads], [head_dim])
+        """
+        if node.op_type != "Reshape":
+            return 0
+
+        # Try static shape constant
+        if len(node.input) >= 2:
+            shape_value = self.model.get_constant_value(node.input[1])
+            if shape_value is not None and isinstance(shape_value, np.ndarray) and shape_value.size == 4:
+                return int(shape_value[2])
+
+        # Try Concat-based shape
+        if len(node.input) >= 2 and node.input[1] in {n.output[0] for n in self.model.get_nodes_by_op_type("Concat")}:
+            concat_nodes = [n for n in self.model.get_nodes_by_op_type("Concat") if n.output[0] == node.input[1]]
+            if concat_nodes and len(concat_nodes[0].input) == 4:
+                value = self.model.get_constant_value(concat_nodes[0].input[2])
+                if value is not None:
+                    if isinstance(value, np.ndarray) and value.size == 1:
+                        return int(value.item())
+
+        return 0
+
+    def detect_num_heads_from_output(self, reshape_out: NodeProto, transpose_out: NodeProto) -> int:
+        """Try to detect num_heads from the output Reshape or Transpose shape info.
+
+        The Transpose converts BNSH → BSNH. If we can find the shape of Q/K,
+        the N dimension gives us num_heads.
+
+        Falls back to trying value_info shape data.
+        """
+        # Try to find shape info from the graph's value_info
+        transpose_input = transpose_out.input[0]
+        for vi in self.model.model.graph.value_info:
+            if vi.name == transpose_input:
+                shape = vi.type.tensor_type.shape
+                if shape and len(shape.dim) == 4:
+                    dim_n = shape.dim[1]
+                    if dim_n.dim_value > 0:
+                        return dim_n.dim_value
+        return 0
+
+    def reshape_to_3d(self, input_name: str, output_name: str) -> str:
+        """Add a Reshape node to convert 4D BxSxNxH to 3D BxSxD.
+
+        Args:
+            input_name: input name for the 4D tensor of shape BxSxNxH.
+            output_name: output name for the 3D tensor of shape BxSxD.
+
+        Returns:
+            str: the output name.
+        """
+        new_dims_name = "bsnh_to_bsd_reshape_dims"
+        new_dims = self.model.get_initializer(new_dims_name)
+        if new_dims is None:
+            new_dims = numpy_helper.from_array(np.array([0, 0, -1], dtype="int64"), name=new_dims_name)
+            self.model.add_initializer(new_dims, self.this_graph_name)
+        reshape_node = helper.make_node(
+            "Reshape",
+            inputs=[input_name, new_dims_name],
+            outputs=[output_name],
+            name=self.model.create_node_name("Reshape"),
+        )
+        self.nodes_to_add.append(reshape_node)
+        self.node_name_to_graph_name[reshape_node.name] = self.this_graph_name
+        return output_name
+
+    def transpose_bnsh_to_bsnh(self, input_name: str) -> str:
+        """Add a Transpose node to convert BNSH to BSNH format."""
+        output_name = input_name + "_BSNH"
+        transpose_node = helper.make_node(
+            "Transpose",
+            [input_name],
+            [output_name],
+            name=self.model.create_node_name("Transpose", name_prefix="Transpose_BNSH_to_BSNH"),
+            perm=[0, 2, 1, 3],
+        )
+        self.nodes_to_add.append(transpose_node)
+        self.node_name_to_graph_name[transpose_node.name] = self.this_graph_name
+        return output_name
+
+    def transpose_bnhs_to_bnsh(self, input_name: str) -> str:
+        """Add a Transpose node to convert BNHS to BNSH format."""
+        output_name = input_name + "_BNSH"
+        transpose_node = helper.make_node(
+            "Transpose",
+            [input_name],
+            [output_name],
+            name=self.model.create_node_name("Transpose", name_prefix="Transpose_BNHS_to_BNSH"),
+            perm=[0, 1, 3, 2],
+        )
+        self.nodes_to_add.append(transpose_node)
+        self.node_name_to_graph_name[transpose_node.name] = self.this_graph_name
+        return output_name
+
+    def create_multihead_attention_node(
+        self,
+        q: str,
+        k: str,
+        v: str,
+        output: str,
+        num_heads: int,
+        scale: float | None = None,
+    ) -> NodeProto:
+        """Create a MultiHeadAttention node.
+
+        Args:
+            q: name of query input (BSD format, 3D).
+            k: name of key input (BNSH format, 4D).
+            v: name of value input (BNSH format, 4D).
+            output: output name of MHA.
+            num_heads: number of attention heads.
+            scale: optional custom scale factor for attention logits.
+
+        Returns:
+            NodeProto: the node created.
+        """
+        assert num_heads > 0
+
+        mha_inputs = [q, k, v]
+        mha_outputs = [output]
+
+        mha_node = helper.make_node(
+            "MultiHeadAttention",
+            inputs=mha_inputs,
+            outputs=mha_outputs,
+            name=self.model.create_node_name("MultiHeadAttention"),
+        )
+
+        mha_node.domain = "com.microsoft"
+        mha_node.attribute.extend([helper.make_attribute("num_heads", num_heads)])
+
+        if scale is not None:
+            mha_node.attribute.extend([helper.make_attribute("scale", scale)])
+
+        return mha_node
+
+    def fuse(self, node, input_name_to_nodes, output_name_to_node):
+        assert node.op_type == "Softmax"
+        softmax = node
+
+        # Softmax output shall not be graph output.
+        if self.model.find_graph_output(softmax.output[0]):
+            return
+
+        # ========================================================================
+        # Match output path: Softmax → [Cast] → MatMul → Transpose → Reshape
+        # ========================================================================
+        cast_after_softmax = None
+
+        # Try with Cast first (FP16 models: Softmax → Cast(FP32→FP16) → MatMul → ...)
+        child_nodes = self.model.match_child_path(
+            softmax,
+            ["Cast", "MatMul", "Transpose", "Reshape"],
+            [(0, 0), (0, 0), (0, 0), (0, 0)],
+            input_name_to_nodes,
+        )
+        if child_nodes is not None:
+            cast_after_softmax, matmul_sv, transpose_out, reshape_out = child_nodes
+        else:
+            # Try without Cast (FP32 models: Softmax → MatMul → Transpose → Reshape)
+            child_nodes = self.model.match_child_path(
+                softmax,
+                ["MatMul", "Transpose", "Reshape"],
+                [(0, 0), (0, 0), (0, 0)],
+                input_name_to_nodes,
+            )
+            if child_nodes is None:
+                return
+            matmul_sv, transpose_out, reshape_out = child_nodes
+
+        # Verify the output Transpose is BNSH → BSNH
+        if not FusionUtils.check_node_attribute(transpose_out, "perm", [0, 2, 1, 3]):
+            return
+
+        # ========================================================================
+        # Match input path: MatMul → [Cast] → Mul → Softmax
+        # ========================================================================
+        cast_before_softmax = None
+
+        # Try: Softmax ← Mul ← Cast ← MatMul (FP16 model)
+        parent_nodes = self.model.match_parent_path(
+            softmax,
+            ["Mul", "Cast", "MatMul"],
+            [0, None, 0],
+        )
+        if parent_nodes is not None:
+            mul_scale, cast_before_softmax, matmul_qk = parent_nodes
+        else:
+            # Try: Softmax ← Mul ← MatMul (FP32 model)
+            parent_nodes = self.model.match_parent_path(
+                softmax,
+                ["Mul", "MatMul"],
+                [0, None],
+            )
+            if parent_nodes is None:
+                return
+            mul_scale, matmul_qk = parent_nodes
+
+        # ========================================================================
+        # Extract scale from Mul
+        # ========================================================================
+        scale = self.get_scale_from_mul(mul_scale)
+        if scale is None:
+            logger.debug("fuse_dit_attention: failed to extract scale from Mul node")
+            return
+
+        # Determine which Mul input is data vs scale constant
+        data_input_idx = self.get_data_input_of_mul(mul_scale)
+        if data_input_idx is None:
+            return
+
+        # Verify the data input connects to the Cast/MatMul
+        expected_data_source = cast_before_softmax.output[0] if cast_before_softmax else matmul_qk.output[0]
+        if mul_scale.input[data_input_idx] != expected_data_source:
+            # Try matching with the other parent path index for Mul
+            if cast_before_softmax:
+                parent_nodes_alt = self.model.match_parent_path(
+                    softmax,
+                    ["Mul", "Cast", "MatMul"],
+                    [0, 1 - data_input_idx, 0],
+                )
+                if parent_nodes_alt is None:
+                    return
+                mul_scale, cast_before_softmax, matmul_qk = parent_nodes_alt
+            else:
+                parent_nodes_alt = self.model.match_parent_path(
+                    softmax,
+                    ["Mul", "MatMul"],
+                    [0, 1 - data_input_idx],
+                )
+                if parent_nodes_alt is None:
+                    return
+                mul_scale, matmul_qk = parent_nodes_alt
+
+        # ========================================================================
+        # Get Q, K^T, V
+        # ========================================================================
+        q_bnsh = matmul_qk.input[0]
+        k_transposed_input = matmul_qk.input[1]
+        v_bnsh = matmul_sv.input[1]
+
+        # Check if K^T comes from Transpose(perm=0,1,3,2) — if so, use K_BNSH directly
+        k_transpose_node = self.model.match_parent(
+            matmul_qk, "Transpose", input_index=1, output_name_to_node=output_name_to_node
+        )
+        if k_transpose_node is not None and FusionUtils.check_node_attribute(k_transpose_node, "perm", [0, 1, 3, 2]):
+            k_bnsh = k_transpose_node.input[0]
+        else:
+            # K is natively in BNHS format, add a Transpose to convert to BNSH
+            k_bnsh = self.transpose_bnhs_to_bnsh(k_transposed_input)
+
+        # ========================================================================
+        # Detect num_heads
+        # ========================================================================
+        num_heads = self.detect_num_heads(q_bnsh, output_name_to_node)
+        if num_heads <= 0:
+            # Try detecting from V path
+            num_heads = self.detect_num_heads(v_bnsh, output_name_to_node)
+        if num_heads <= 0:
+            # Try detecting from output shape info
+            num_heads = self.detect_num_heads_from_output(reshape_out, transpose_out)
+        if num_heads <= 0:
+            logger.debug("fuse_dit_attention: failed to detect num_heads")
+            return
+
+        # ========================================================================
+        # Convert Q from BNSH to BSD (required by MHA op)
+        # ========================================================================
+        q_bsnh = self.transpose_bnsh_to_bsnh(q_bnsh)
+        q_bsd = self.reshape_to_3d(q_bsnh, q_bsnh + "_BSD")
+
+        # ========================================================================
+        # Create MultiHeadAttention node
+        # ========================================================================
+        mha_node = self.create_multihead_attention_node(
+            q=q_bsd,
+            k=k_bnsh,
+            v=v_bnsh,
+            output=reshape_out.output[0],
+            num_heads=num_heads,
+            scale=scale,
+        )
+        self.nodes_to_add.append(mha_node)
+        self.node_name_to_graph_name[mha_node.name] = self.this_graph_name
+
+        # Remove fused nodes
+        nodes_to_remove = [matmul_sv, transpose_out, reshape_out]
+        if cast_after_softmax is not None:
+            nodes_to_remove.append(cast_after_softmax)
+        self.nodes_to_remove.extend(nodes_to_remove)
+
+        # Use prune graph to remove remaining unreferenced nodes
+        self.prune_graph = True

--- a/onnxruntime/python/tools/transformers/onnx_model_mmdit.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_mmdit.py
@@ -6,6 +6,7 @@
 import logging
 
 from fusion_layernorm import FusionLayerNormalization
+from fusion_mha_dit import FusionMultiHeadAttentionDiT
 from fusion_mha_mmdit import FusionMultiHeadAttentionMMDit
 from fusion_options import FusionOptions
 from import_utils import is_installed
@@ -43,8 +44,14 @@ class MmditOnnxModel(BertOnnxModel):
         fusion.apply()
 
     def fuse_multi_head_attention(self):
+        # MMDit fusion for Stable Diffusion 3.x / Flux patterns
         fusion = FusionMultiHeadAttentionMMDit(self)
         fusion.apply()
+
+        # DiT fusion for F5-TTS and other diffusion transformer patterns
+        # with pre-computed Q/K/V (post-RoPE), custom scaling, and optional FP16 Casts
+        dit_fusion = FusionMultiHeadAttentionDiT(self)
+        dit_fusion.apply()
 
     def optimize(self, options: FusionOptions | None = None, add_dynamic_axes: bool = False):
         assert not add_dynamic_axes

--- a/onnxruntime/test/python/transformers/dit_model_generator.py
+++ b/onnxruntime/test/python/transformers/dit_model_generator.py
@@ -116,11 +116,15 @@ def create_dit_attention(
         # Cast attention weights FP32 → FP16
         nodes.append(helper.make_node("Cast", ["attn_weights"], ["attn_weights_fp16"], "cast_to_fp16", to=10))
         attn_matmul_input = "attn_weights_fp16"
+        # Cast V to FP16 so MatMul inputs are type-consistent (both FP16)
+        nodes.append(helper.make_node("Cast", ["v_bnsh"], ["v_bnsh_fp16"], "cast_v_to_fp16", to=10))
+        v_matmul_input = "v_bnsh_fp16"
     else:
         attn_matmul_input = "attn_weights"
+        v_matmul_input = "v_bnsh"
 
     # Attention @ V: [B, N, S, S] @ [B, N, S, H] → [B, N, S, H]
-    nodes.append(helper.make_node("MatMul", [attn_matmul_input, "v_bnsh"], ["attn_out"], "attn_v_matmul"))
+    nodes.append(helper.make_node("MatMul", [attn_matmul_input, v_matmul_input], ["attn_out"], "attn_v_matmul"))
 
     # --- Output: Transpose(BNSH → BSNH) → Reshape(BSD) → output projection ---
     nodes.append(helper.make_node("Transpose", ["attn_out"], ["attn_transposed"], "attn_transpose", perm=[0, 2, 1, 3]))

--- a/onnxruntime/test/python/transformers/dit_model_generator.py
+++ b/onnxruntime/test/python/transformers/dit_model_generator.py
@@ -1,0 +1,212 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+# Licensed under the MIT License.  See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+"""Synthetic ONNX graph generators for Diffusion Transformer (DiT) attention fusion tests.
+
+DiT models (F5-TTS, etc.) use an attention pattern where:
+  - Q, K, V are pre-computed (e.g., after RoPE) in BNSH format
+  - K is pre-transposed to BNHS for the attention MatMul
+  - A custom scalar scale (e.g., 100.0) is applied before Softmax
+  - Optional Cast nodes (FP16↔FP32) wrap Softmax for mixed-precision
+"""
+
+import numpy as np
+from onnx import TensorProto, helper
+
+
+def _float_tensor(name, shape, random=False):
+    total = 1
+    for d in shape:
+        total *= d
+    vals = [np.random.uniform(0, 1) for _ in range(total)] if random else [1.0] * total
+    return helper.make_tensor(name, TensorProto.FLOAT, shape, vals)
+
+
+def create_dit_attention(
+    batch_size=2,
+    seq_len=16,
+    num_heads=16,
+    head_dim=64,
+    scale=100.0,
+    use_fp16_casts=False,
+):
+    """Create a DiT attention subgraph that exercises FusionMultiHeadAttentionDiT.
+
+    The generated graph models the F5-TTS DiT attention pattern:
+
+        hidden_states → Q/K/V projections → Reshape → Transpose → (K pre-transpose)
+        → MatMul(Q, K^T) → [Cast FP16→FP32] → Mul(scale) → Softmax
+        → [Cast FP32→FP16] → MatMul(attn, V) → Transpose → Reshape → output_projection
+
+    Args:
+        batch_size: batch size (e.g., 2 for classifier-free guidance).
+        seq_len: sequence length.
+        num_heads: number of attention heads.
+        head_dim: dimension per head.
+        scale: attention logit scale factor (e.g., 100.0).
+        use_fp16_casts: if True, add Cast nodes around Softmax (simulates FP16 model).
+
+    Returns:
+        onnx.ModelProto: the generated model.
+    """
+    hidden_size = num_heads * head_dim
+
+    nodes = []
+    initializers = []
+
+    inputs = [
+        helper.make_tensor_value_info("input_0", TensorProto.FLOAT, [batch_size, seq_len, hidden_size]),
+    ]
+
+    # --- Q projection: MatMul → Reshape(BSNH) → Transpose(BNSH) ---
+    nodes.append(helper.make_node("MatMul", ["input_0", "q_weight"], ["q_proj"], "q_matmul"))
+    initializers.append(_float_tensor("q_weight", [hidden_size, hidden_size], random=True))
+
+    q_shape = [batch_size, seq_len, num_heads, head_dim]
+    nodes.append(helper.make_node("Reshape", ["q_proj", "q_shape"], ["q_reshaped"], "q_reshape"))
+    initializers.append(helper.make_tensor("q_shape", TensorProto.INT64, [4], q_shape))
+
+    nodes.append(helper.make_node("Transpose", ["q_reshaped"], ["q_bnsh"], "q_transpose", perm=[0, 2, 1, 3]))
+
+    # --- K projection: MatMul → Reshape(BSNH) → Transpose(BNSH) → Transpose(BNHS, pre-transpose) ---
+    nodes.append(helper.make_node("MatMul", ["input_0", "k_weight"], ["k_proj"], "k_matmul"))
+    initializers.append(_float_tensor("k_weight", [hidden_size, hidden_size], random=True))
+
+    k_shape = [batch_size, seq_len, num_heads, head_dim]
+    nodes.append(helper.make_node("Reshape", ["k_proj", "k_shape"], ["k_reshaped"], "k_reshape"))
+    initializers.append(helper.make_tensor("k_shape", TensorProto.INT64, [4], k_shape))
+
+    nodes.append(helper.make_node("Transpose", ["k_reshaped"], ["k_bnsh"], "k_transpose", perm=[0, 2, 1, 3]))
+
+    # Pre-transpose K: BNSH → BNHS (this is the optimization done in DiT models)
+    nodes.append(helper.make_node("Transpose", ["k_bnsh"], ["k_bnhs"], "k_pre_transpose", perm=[0, 1, 3, 2]))
+
+    # --- V projection: MatMul → Reshape(BSNH) → Transpose(BNSH) ---
+    nodes.append(helper.make_node("MatMul", ["input_0", "v_weight"], ["v_proj"], "v_matmul"))
+    initializers.append(_float_tensor("v_weight", [hidden_size, hidden_size], random=True))
+
+    v_shape = [batch_size, seq_len, num_heads, head_dim]
+    nodes.append(helper.make_node("Reshape", ["v_proj", "v_shape"], ["v_reshaped"], "v_reshape"))
+    initializers.append(helper.make_tensor("v_shape", TensorProto.INT64, [4], v_shape))
+
+    nodes.append(helper.make_node("Transpose", ["v_reshaped"], ["v_bnsh"], "v_transpose", perm=[0, 2, 1, 3]))
+
+    # --- Attention: MatMul(Q, K^T) → [Cast] → Mul(scale) → Softmax → [Cast] → MatMul(attn, V) ---
+    # QK^T: [B, N, S, H] @ [B, N, H, S] → [B, N, S, S]
+    nodes.append(helper.make_node("MatMul", ["q_bnsh", "k_bnhs"], ["qk_scores"], "qk_matmul"))
+
+    if use_fp16_casts:
+        # Cast QK scores FP16 → FP32 (simulating FP16 model needing FP32 Softmax)
+        nodes.append(helper.make_node("Cast", ["qk_scores"], ["qk_scores_fp32"], "cast_to_fp32", to=1))
+        mul_input = "qk_scores_fp32"
+    else:
+        mul_input = "qk_scores"
+
+    # Mul by custom scale
+    initializers.append(helper.make_tensor("attn_scale", TensorProto.FLOAT, [], [scale]))
+    nodes.append(helper.make_node("Mul", [mul_input, "attn_scale"], ["qk_scaled"], "qk_scale"))
+
+    # Softmax
+    nodes.append(helper.make_node("Softmax", ["qk_scaled"], ["attn_weights"], "softmax", axis=-1))
+
+    if use_fp16_casts:
+        # Cast attention weights FP32 → FP16
+        nodes.append(helper.make_node("Cast", ["attn_weights"], ["attn_weights_fp16"], "cast_to_fp16", to=10))
+        attn_matmul_input = "attn_weights_fp16"
+    else:
+        attn_matmul_input = "attn_weights"
+
+    # Attention @ V: [B, N, S, S] @ [B, N, S, H] → [B, N, S, H]
+    nodes.append(helper.make_node("MatMul", [attn_matmul_input, "v_bnsh"], ["attn_out"], "attn_v_matmul"))
+
+    # --- Output: Transpose(BNSH → BSNH) → Reshape(BSD) → output projection ---
+    nodes.append(helper.make_node("Transpose", ["attn_out"], ["attn_transposed"], "attn_transpose", perm=[0, 2, 1, 3]))
+
+    out_shape = [batch_size, seq_len, hidden_size]
+    nodes.append(helper.make_node("Reshape", ["attn_transposed", "out_shape"], ["attn_flat"], "attn_reshape"))
+    initializers.append(helper.make_tensor("out_shape", TensorProto.INT64, [3], out_shape))
+
+    # Output projection
+    nodes.append(helper.make_node("MatMul", ["attn_flat", "o_weight"], ["output_0"], "o_matmul"))
+    initializers.append(_float_tensor("o_weight", [hidden_size, hidden_size], random=True))
+
+    # --- Graph definition ---
+    graph = helper.make_graph(
+        nodes,
+        "dit_attention",
+        inputs,
+        [
+            helper.make_tensor_value_info("output_0", TensorProto.FLOAT, [batch_size, seq_len, hidden_size]),
+        ],
+        initializers,
+    )
+
+    model = helper.make_model(graph)
+    model.ir_version = 7
+    model.opset_import[0].version = 17
+    return model
+
+
+def create_dit_attention_no_k_transpose(
+    batch_size=2,
+    seq_len=16,
+    num_heads=16,
+    head_dim=64,
+    scale=100.0,
+):
+    """Create a DiT attention graph where K is directly in BNHS format (no explicit Transpose).
+
+    This tests the path where the fusion needs to add its own Transpose for K.
+    Uses graph inputs for Q/K/V in the expected 4D formats.
+
+    Returns:
+        onnx.ModelProto: the generated model.
+    """
+    hidden_size = num_heads * head_dim
+
+    nodes = []
+    initializers = []
+
+    # Use 4D inputs directly (as if Q/K/V come from RoPE or other external computation)
+    inputs = [
+        helper.make_tensor_value_info("q_bnsh", TensorProto.FLOAT, [batch_size, num_heads, seq_len, head_dim]),
+        helper.make_tensor_value_info("k_bnhs", TensorProto.FLOAT, [batch_size, num_heads, head_dim, seq_len]),
+        helper.make_tensor_value_info("v_bnsh", TensorProto.FLOAT, [batch_size, num_heads, seq_len, head_dim]),
+    ]
+
+    # QK^T: [B, N, S, H] @ [B, N, H, S] → [B, N, S, S]
+    nodes.append(helper.make_node("MatMul", ["q_bnsh", "k_bnhs"], ["qk_scores"], "qk_matmul"))
+
+    # Mul by scale
+    initializers.append(helper.make_tensor("attn_scale", TensorProto.FLOAT, [], [scale]))
+    nodes.append(helper.make_node("Mul", ["qk_scores", "attn_scale"], ["qk_scaled"], "qk_scale"))
+
+    # Softmax
+    nodes.append(helper.make_node("Softmax", ["qk_scaled"], ["attn_weights"], "softmax", axis=-1))
+
+    # Attention @ V
+    nodes.append(helper.make_node("MatMul", ["attn_weights", "v_bnsh"], ["attn_out"], "attn_v_matmul"))
+
+    # Transpose + Reshape
+    nodes.append(helper.make_node("Transpose", ["attn_out"], ["attn_transposed"], "attn_transpose", perm=[0, 2, 1, 3]))
+    out_shape = [batch_size, seq_len, hidden_size]
+    nodes.append(helper.make_node("Reshape", ["attn_transposed", "out_shape"], ["output_0"], "attn_reshape"))
+    initializers.append(helper.make_tensor("out_shape", TensorProto.INT64, [3], out_shape))
+
+    graph = helper.make_graph(
+        nodes,
+        "dit_attention_no_k_transpose",
+        inputs,
+        [
+            helper.make_tensor_value_info("output_0", TensorProto.FLOAT, [batch_size, seq_len, hidden_size]),
+        ],
+        initializers,
+    )
+
+    model = helper.make_model(graph)
+    model.ir_version = 7
+    model.opset_import[0].version = 17
+    return model

--- a/onnxruntime/test/python/transformers/dit_model_generator.py
+++ b/onnxruntime/test/python/transformers/dit_model_generator.py
@@ -14,22 +14,19 @@ DiT models (F5-TTS, etc.) use an attention pattern where:
 """
 
 import numpy as np
-from onnx import TensorProto, helper
+from onnx import TensorProto, helper, numpy_helper
 
 
 def _float_tensor(name, shape, random=False):
-    total = 1
-    for d in shape:
-        total *= d
-    vals = [np.random.uniform(0, 1) for _ in range(total)] if random else [1.0] * total
-    return helper.make_tensor(name, TensorProto.FLOAT, shape, vals)
+    vals = np.random.uniform(0, 1, size=shape).astype(np.float32) if random else np.ones(shape, dtype=np.float32)
+    return numpy_helper.from_array(vals, name)
 
 
 def create_dit_attention(
     batch_size=2,
-    seq_len=16,
-    num_heads=16,
-    head_dim=64,
+    seq_len=4,
+    num_heads=4,
+    head_dim=8,
     scale=100.0,
     use_fp16_casts=False,
 ):
@@ -37,9 +34,9 @@ def create_dit_attention(
 
     The generated graph models the F5-TTS DiT attention pattern:
 
-        hidden_states → Q/K/V projections → Reshape → Transpose → (K pre-transpose)
-        → MatMul(Q, K^T) → [Cast FP16→FP32] → Mul(scale) → Softmax
-        → [Cast FP32→FP16] → MatMul(attn, V) → Transpose → Reshape → output_projection
+        hidden_states -> Q/K/V projections -> Reshape -> Transpose -> (K pre-transpose)
+        -> MatMul(Q, K^T) -> [Cast FP16->FP32] -> Mul(scale) -> Softmax
+        -> [Cast FP32->FP16] -> MatMul(attn, V) -> Transpose -> Reshape -> output_projection
 
     Args:
         batch_size: batch size (e.g., 2 for classifier-free guidance).
@@ -61,7 +58,7 @@ def create_dit_attention(
         helper.make_tensor_value_info("input_0", TensorProto.FLOAT, [batch_size, seq_len, hidden_size]),
     ]
 
-    # --- Q projection: MatMul → Reshape(BSNH) → Transpose(BNSH) ---
+    # --- Q projection: MatMul -> Reshape(BSNH) -> Transpose(BNSH) ---
     nodes.append(helper.make_node("MatMul", ["input_0", "q_weight"], ["q_proj"], "q_matmul"))
     initializers.append(_float_tensor("q_weight", [hidden_size, hidden_size], random=True))
 
@@ -71,7 +68,7 @@ def create_dit_attention(
 
     nodes.append(helper.make_node("Transpose", ["q_reshaped"], ["q_bnsh"], "q_transpose", perm=[0, 2, 1, 3]))
 
-    # --- K projection: MatMul → Reshape(BSNH) → Transpose(BNSH) → Transpose(BNHS, pre-transpose) ---
+    # --- K projection: MatMul -> Reshape(BSNH) -> Transpose(BNSH) -> Transpose(BNHS, pre-transpose) ---
     nodes.append(helper.make_node("MatMul", ["input_0", "k_weight"], ["k_proj"], "k_matmul"))
     initializers.append(_float_tensor("k_weight", [hidden_size, hidden_size], random=True))
 
@@ -81,10 +78,10 @@ def create_dit_attention(
 
     nodes.append(helper.make_node("Transpose", ["k_reshaped"], ["k_bnsh"], "k_transpose", perm=[0, 2, 1, 3]))
 
-    # Pre-transpose K: BNSH → BNHS (this is the optimization done in DiT models)
+    # Pre-transpose K: BNSH -> BNHS (this is the optimization done in DiT models)
     nodes.append(helper.make_node("Transpose", ["k_bnsh"], ["k_bnhs"], "k_pre_transpose", perm=[0, 1, 3, 2]))
 
-    # --- V projection: MatMul → Reshape(BSNH) → Transpose(BNSH) ---
+    # --- V projection: MatMul -> Reshape(BSNH) -> Transpose(BNSH) ---
     nodes.append(helper.make_node("MatMul", ["input_0", "v_weight"], ["v_proj"], "v_matmul"))
     initializers.append(_float_tensor("v_weight", [hidden_size, hidden_size], random=True))
 
@@ -94,12 +91,12 @@ def create_dit_attention(
 
     nodes.append(helper.make_node("Transpose", ["v_reshaped"], ["v_bnsh"], "v_transpose", perm=[0, 2, 1, 3]))
 
-    # --- Attention: MatMul(Q, K^T) → [Cast] → Mul(scale) → Softmax → [Cast] → MatMul(attn, V) ---
-    # QK^T: [B, N, S, H] @ [B, N, H, S] → [B, N, S, S]
+    # --- Attention: MatMul(Q, K^T) -> [Cast] -> Mul(scale) -> Softmax -> [Cast] -> MatMul(attn, V) ---
+    # QK^T: [B, N, S, H] @ [B, N, H, S] -> [B, N, S, S]
     nodes.append(helper.make_node("MatMul", ["q_bnsh", "k_bnhs"], ["qk_scores"], "qk_matmul"))
 
     if use_fp16_casts:
-        # Cast QK scores FP16 → FP32 (simulating FP16 model needing FP32 Softmax)
+        # Cast QK scores FP16 -> FP32 (simulating FP16 model needing FP32 Softmax)
         nodes.append(helper.make_node("Cast", ["qk_scores"], ["qk_scores_fp32"], "cast_to_fp32", to=1))
         mul_input = "qk_scores_fp32"
     else:
@@ -113,7 +110,7 @@ def create_dit_attention(
     nodes.append(helper.make_node("Softmax", ["qk_scaled"], ["attn_weights"], "softmax", axis=-1))
 
     if use_fp16_casts:
-        # Cast attention weights FP32 → FP16
+        # Cast attention weights FP32 -> FP16
         nodes.append(helper.make_node("Cast", ["attn_weights"], ["attn_weights_fp16"], "cast_to_fp16", to=10))
         attn_matmul_input = "attn_weights_fp16"
         # Cast V to FP16 so MatMul inputs are type-consistent (both FP16)
@@ -123,18 +120,26 @@ def create_dit_attention(
         attn_matmul_input = "attn_weights"
         v_matmul_input = "v_bnsh"
 
-    # Attention @ V: [B, N, S, S] @ [B, N, S, H] → [B, N, S, H]
+    # Attention @ V: [B, N, S, S] @ [B, N, S, H] -> [B, N, S, H]
     nodes.append(helper.make_node("MatMul", [attn_matmul_input, v_matmul_input], ["attn_out"], "attn_v_matmul"))
 
-    # --- Output: Transpose(BNSH → BSNH) → Reshape(BSD) → output projection ---
+    # --- Output: Transpose(BNSH -> BSNH) -> Reshape(BSD) -> output projection ---
     nodes.append(helper.make_node("Transpose", ["attn_out"], ["attn_transposed"], "attn_transpose", perm=[0, 2, 1, 3]))
 
     out_shape = [batch_size, seq_len, hidden_size]
     nodes.append(helper.make_node("Reshape", ["attn_transposed", "out_shape"], ["attn_flat"], "attn_reshape"))
     initializers.append(helper.make_tensor("out_shape", TensorProto.INT64, [3], out_shape))
 
+    if use_fp16_casts:
+        # Cast attention output back to FP32 so the output projection MatMul
+        # has type-consistent inputs with FP32 o_weight.
+        nodes.append(helper.make_node("Cast", ["attn_flat"], ["attn_flat_fp32"], "cast_attn_flat_to_fp32", to=1))
+        o_matmul_input = "attn_flat_fp32"
+    else:
+        o_matmul_input = "attn_flat"
+
     # Output projection
-    nodes.append(helper.make_node("MatMul", ["attn_flat", "o_weight"], ["output_0"], "o_matmul"))
+    nodes.append(helper.make_node("MatMul", [o_matmul_input, "o_weight"], ["output_0"], "o_matmul"))
     initializers.append(_float_tensor("o_weight", [hidden_size, hidden_size], random=True))
 
     # --- Graph definition ---
@@ -156,9 +161,9 @@ def create_dit_attention(
 
 def create_dit_attention_no_k_transpose(
     batch_size=2,
-    seq_len=16,
-    num_heads=16,
-    head_dim=64,
+    seq_len=4,
+    num_heads=4,
+    head_dim=8,
     scale=100.0,
 ):
     """Create a DiT attention graph where K is directly in BNHS format (no explicit Transpose).
@@ -181,7 +186,7 @@ def create_dit_attention_no_k_transpose(
         helper.make_tensor_value_info("v_bnsh", TensorProto.FLOAT, [batch_size, num_heads, seq_len, head_dim]),
     ]
 
-    # QK^T: [B, N, S, H] @ [B, N, H, S] → [B, N, S, S]
+    # QK^T: [B, N, S, H] @ [B, N, H, S] -> [B, N, S, S]
     nodes.append(helper.make_node("MatMul", ["q_bnsh", "k_bnhs"], ["qk_scores"], "qk_matmul"))
 
     # Mul by scale

--- a/onnxruntime/test/python/transformers/test_attention_fusion.py
+++ b/onnxruntime/test/python/transformers/test_attention_fusion.py
@@ -12,6 +12,7 @@ import numpy as np
 import onnx
 from bart_model_generator import create_bart_attention_sdpa
 from bert_model_generator import create_bert_attention, create_bert_attention_pre_ln, create_tf2onnx_attention_3d
+from dit_model_generator import create_dit_attention
 from gpt2_model_generator import create_gpt2_attention, create_gpt2_attention_no_past
 from model_loader import get_test_data_path
 from onnx import numpy_helper
@@ -601,6 +602,95 @@ class TestFusion(unittest.TestCase):
                 rtol=1e-6,
                 err_msg=f"sin_cache mismatch at position {pos}",
             )
+
+    def test_dit_attention_fusion(self):
+        """Test DiT attention fusion for F5-TTS-style pattern (FP32, with K pre-transpose)."""
+        model = create_dit_attention(
+            batch_size=2,
+            seq_len=16,
+            num_heads=16,
+            head_dim=64,
+            scale=100.0,
+            use_fp16_casts=False,
+        )
+        dir = tempfile.mkdtemp()
+        model_path = os.path.join(dir, "dit_attention.onnx")
+        onnx.save(model, model_path)
+
+        optimized_model = optimize_model(model_path, model_type="mmdit", opt_level=0)
+        os.remove(model_path)
+
+        mha_nodes = [n for n in optimized_model.model.graph.node if n.op_type == "MultiHeadAttention"]
+        self.assertEqual(len(mha_nodes), 1, "Expected exactly 1 fused MultiHeadAttention node")
+
+        # Verify num_heads attribute
+        num_heads_attr = next((a for a in mha_nodes[0].attribute if a.name == "num_heads"), None)
+        self.assertIsNotNone(num_heads_attr)
+        self.assertEqual(num_heads_attr.i, 16)
+
+        # Verify scale attribute
+        scale_attr = next((a for a in mha_nodes[0].attribute if a.name == "scale"), None)
+        self.assertIsNotNone(scale_attr)
+        self.assertAlmostEqual(scale_attr.f, 100.0, places=5)
+
+        # Verify no Softmax remains (it should be absorbed into MHA)
+        softmax_count = sum(1 for n in optimized_model.model.graph.node if n.op_type == "Softmax")
+        self.assertEqual(softmax_count, 0, "Softmax should be fused into MultiHeadAttention")
+
+    def test_dit_attention_fusion_with_fp16_casts(self):
+        """Test DiT attention fusion with FP16 Cast nodes around Softmax."""
+        model = create_dit_attention(
+            batch_size=2,
+            seq_len=16,
+            num_heads=16,
+            head_dim=64,
+            scale=100.0,
+            use_fp16_casts=True,
+        )
+        dir = tempfile.mkdtemp()
+        model_path = os.path.join(dir, "dit_attention_fp16.onnx")
+        onnx.save(model, model_path)
+
+        optimized_model = optimize_model(model_path, model_type="mmdit", opt_level=0)
+        os.remove(model_path)
+
+        mha_nodes = [n for n in optimized_model.model.graph.node if n.op_type == "MultiHeadAttention"]
+        self.assertEqual(len(mha_nodes), 1, "Expected exactly 1 fused MultiHeadAttention node")
+
+        # Verify num_heads and scale
+        num_heads_attr = next((a for a in mha_nodes[0].attribute if a.name == "num_heads"), None)
+        self.assertIsNotNone(num_heads_attr)
+        self.assertEqual(num_heads_attr.i, 16)
+
+        scale_attr = next((a for a in mha_nodes[0].attribute if a.name == "scale"), None)
+        self.assertIsNotNone(scale_attr)
+        self.assertAlmostEqual(scale_attr.f, 100.0, places=5)
+
+    def test_dit_attention_fusion_custom_scale(self):
+        """Test DiT attention fusion with standard 1/sqrt(d_k) scale."""
+        head_dim = 64
+        standard_scale = 1.0 / (head_dim**0.5)
+        model = create_dit_attention(
+            batch_size=1,
+            seq_len=8,
+            num_heads=8,
+            head_dim=head_dim,
+            scale=standard_scale,
+            use_fp16_casts=False,
+        )
+        dir = tempfile.mkdtemp()
+        model_path = os.path.join(dir, "dit_attention_standard_scale.onnx")
+        onnx.save(model, model_path)
+
+        optimized_model = optimize_model(model_path, model_type="mmdit", opt_level=0)
+        os.remove(model_path)
+
+        mha_nodes = [n for n in optimized_model.model.graph.node if n.op_type == "MultiHeadAttention"]
+        self.assertEqual(len(mha_nodes), 1, "Expected exactly 1 fused MultiHeadAttention node")
+
+        scale_attr = next((a for a in mha_nodes[0].attribute if a.name == "scale"), None)
+        self.assertIsNotNone(scale_attr)
+        self.assertAlmostEqual(scale_attr.f, standard_scale, places=5)
 
 
 if __name__ == "__main__":

--- a/onnxruntime/test/python/transformers/test_attention_fusion.py
+++ b/onnxruntime/test/python/transformers/test_attention_fusion.py
@@ -12,7 +12,7 @@ import numpy as np
 import onnx
 from bart_model_generator import create_bart_attention_sdpa
 from bert_model_generator import create_bert_attention, create_bert_attention_pre_ln, create_tf2onnx_attention_3d
-from dit_model_generator import create_dit_attention
+from dit_model_generator import create_dit_attention, create_dit_attention_no_k_transpose
 from gpt2_model_generator import create_gpt2_attention, create_gpt2_attention_no_past
 from model_loader import get_test_data_path
 from onnx import numpy_helper
@@ -607,9 +607,9 @@ class TestFusion(unittest.TestCase):
         """Test DiT attention fusion for F5-TTS-style pattern (FP32, with K pre-transpose)."""
         model = create_dit_attention(
             batch_size=2,
-            seq_len=16,
-            num_heads=16,
-            head_dim=64,
+            seq_len=4,
+            num_heads=4,
+            head_dim=8,
             scale=100.0,
             use_fp16_casts=False,
         )
@@ -626,7 +626,7 @@ class TestFusion(unittest.TestCase):
         # Verify num_heads attribute
         num_heads_attr = next((a for a in mha_nodes[0].attribute if a.name == "num_heads"), None)
         self.assertIsNotNone(num_heads_attr)
-        self.assertEqual(num_heads_attr.i, 16)
+        self.assertEqual(num_heads_attr.i, 4)
 
         # Verify scale attribute
         scale_attr = next((a for a in mha_nodes[0].attribute if a.name == "scale"), None)
@@ -641,9 +641,9 @@ class TestFusion(unittest.TestCase):
         """Test DiT attention fusion with FP16 Cast nodes around Softmax."""
         model = create_dit_attention(
             batch_size=2,
-            seq_len=16,
-            num_heads=16,
-            head_dim=64,
+            seq_len=4,
+            num_heads=4,
+            head_dim=8,
             scale=100.0,
             use_fp16_casts=True,
         )
@@ -660,7 +660,7 @@ class TestFusion(unittest.TestCase):
         # Verify num_heads and scale
         num_heads_attr = next((a for a in mha_nodes[0].attribute if a.name == "num_heads"), None)
         self.assertIsNotNone(num_heads_attr)
-        self.assertEqual(num_heads_attr.i, 16)
+        self.assertEqual(num_heads_attr.i, 4)
 
         scale_attr = next((a for a in mha_nodes[0].attribute if a.name == "scale"), None)
         self.assertIsNotNone(scale_attr)
@@ -672,12 +672,12 @@ class TestFusion(unittest.TestCase):
 
     def test_dit_attention_fusion_custom_scale(self):
         """Test DiT attention fusion with standard 1/sqrt(d_k) scale."""
-        head_dim = 64
+        head_dim = 8
         standard_scale = 1.0 / (head_dim**0.5)
         model = create_dit_attention(
             batch_size=1,
-            seq_len=8,
-            num_heads=8,
+            seq_len=4,
+            num_heads=4,
             head_dim=head_dim,
             scale=standard_scale,
             use_fp16_casts=False,
@@ -699,6 +699,39 @@ class TestFusion(unittest.TestCase):
         # Verify no Softmax remains (it should be absorbed into MHA)
         softmax_count = sum(1 for n in optimized_model.model.graph.node if n.op_type == "Softmax")
         self.assertEqual(softmax_count, 0, "Softmax should be fused into MultiHeadAttention")
+
+    def test_dit_attention_fusion_no_k_transpose(self):
+        """Test DiT attention fusion when K is natively BNHS (no explicit Transpose node)."""
+        model = create_dit_attention_no_k_transpose(
+            batch_size=2,
+            seq_len=4,
+            num_heads=4,
+            head_dim=8,
+            scale=100.0,
+        )
+        dir = tempfile.mkdtemp()
+        model_path = os.path.join(dir, "dit_attention_no_k_transpose.onnx")
+        onnx.save(model, model_path)
+
+        optimized_model = optimize_model(model_path, model_type="mmdit", opt_level=0)
+        os.remove(model_path)
+
+        mha_nodes = [n for n in optimized_model.model.graph.node if n.op_type == "MultiHeadAttention"]
+        self.assertEqual(len(mha_nodes), 1, "Expected exactly 1 fused MultiHeadAttention node")
+
+        # Verify scale attribute
+        scale_attr = next((a for a in mha_nodes[0].attribute if a.name == "scale"), None)
+        self.assertIsNotNone(scale_attr)
+        self.assertAlmostEqual(scale_attr.f, 100.0, places=5)
+
+        # Verify no Softmax remains
+        softmax_count = sum(1 for n in optimized_model.model.graph.node if n.op_type == "Softmax")
+        self.assertEqual(softmax_count, 0, "Softmax should be fused into MultiHeadAttention")
+
+        # Verify the fusion added a Transpose for K (BNHS -> BNSH)
+        transpose_nodes = [n for n in optimized_model.model.graph.node if n.op_type == "Transpose"]
+        has_bnhs_to_bnsh = any(OnnxModel.get_node_attribute(t, "perm") == [0, 1, 3, 2] for t in transpose_nodes)
+        self.assertTrue(has_bnhs_to_bnsh, "Fusion should add Transpose(BNHS->BNSH) for K")
 
 
 if __name__ == "__main__":

--- a/onnxruntime/test/python/transformers/test_attention_fusion.py
+++ b/onnxruntime/test/python/transformers/test_attention_fusion.py
@@ -666,6 +666,10 @@ class TestFusion(unittest.TestCase):
         self.assertIsNotNone(scale_attr)
         self.assertAlmostEqual(scale_attr.f, 100.0, places=5)
 
+        # Verify no Softmax remains (it should be absorbed into MHA)
+        softmax_count = sum(1 for n in optimized_model.model.graph.node if n.op_type == "Softmax")
+        self.assertEqual(softmax_count, 0, "Softmax should be fused into MultiHeadAttention")
+
     def test_dit_attention_fusion_custom_scale(self):
         """Test DiT attention fusion with standard 1/sqrt(d_k) scale."""
         head_dim = 64
@@ -691,6 +695,10 @@ class TestFusion(unittest.TestCase):
         scale_attr = next((a for a in mha_nodes[0].attribute if a.name == "scale"), None)
         self.assertIsNotNone(scale_attr)
         self.assertAlmostEqual(scale_attr.f, standard_scale, places=5)
+
+        # Verify no Softmax remains (it should be absorbed into MHA)
+        softmax_count = sum(1 for n in optimized_model.model.graph.node if n.op_type == "Softmax")
+        self.assertEqual(softmax_count, 0, "Softmax should be fused into MultiHeadAttention")
 
 
 if __name__ == "__main__":

--- a/onnxruntime/test/python/transformers/test_attention_fusion.py
+++ b/onnxruntime/test/python/transformers/test_attention_fusion.py
@@ -30,6 +30,45 @@ else:
 
 
 class TestFusion(unittest.TestCase):
+    def _validate_mha_input_types(self, optimized_model):
+        """Verify all MultiHeadAttention inputs share the same element type.
+
+        MHA's type parameter T binds Q, K, V to a single type. A mismatch
+        (e.g., Q=float32, V=float16) produces a graph that ORT rejects at load time.
+
+        Runs ONNX shape inference first to populate type info for intermediate
+        tensors — without this, get_dtype returns None for outputs of internal
+        nodes and the check would pass vacuously even if types are mismatched.
+        """
+        # Run shape inference to propagate types through standard ONNX ops
+        # so that MHA inputs (from Reshape, Transpose, etc.) have type info.
+        try:
+            inferred = onnx.shape_inference.infer_shapes(optimized_model.model, check_type=True, strict_mode=False)
+            optimized_model.model.CopyFrom(inferred)
+            # Reset cached dtype dict so get_dtype picks up inferred types
+            optimized_model._dtype_dict = None
+        except Exception:
+            pass  # Custom ops (com.microsoft) may cause warnings; proceed with available info
+
+        for node in optimized_model.model.graph.node:
+            if node.op_type == "MultiHeadAttention":
+                input_types = []
+                for inp_name in node.input[:3]:  # Q, K, V
+                    if not inp_name:
+                        continue
+                    dtype = optimized_model.get_dtype(inp_name)
+                    if dtype is not None:
+                        input_types.append((inp_name, dtype))
+                if len(input_types) >= 2:
+                    first_name, first_dtype = input_types[0]
+                    for inp_name, dtype in input_types[1:]:
+                        self.assertEqual(
+                            dtype,
+                            first_dtype,
+                            f"MHA input type mismatch: {first_name} has type {first_dtype} "
+                            f"but {inp_name} has type {dtype}",
+                        )
+
     def verify_fusion(self, optimized_model, expected_model_filename):
         optimized_model.topological_sort(is_deterministic=True)
 
@@ -620,6 +659,9 @@ class TestFusion(unittest.TestCase):
         optimized_model = optimize_model(model_path, model_type="mmdit", opt_level=0)
         os.remove(model_path)
 
+        # Validate the optimized model produces a type-consistent fused graph.
+        self._validate_mha_input_types(optimized_model)
+
         mha_nodes = [n for n in optimized_model.model.graph.node if n.op_type == "MultiHeadAttention"]
         self.assertEqual(len(mha_nodes), 1, "Expected exactly 1 fused MultiHeadAttention node")
 
@@ -653,6 +695,10 @@ class TestFusion(unittest.TestCase):
 
         optimized_model = optimize_model(model_path, model_type="mmdit", opt_level=0)
         os.remove(model_path)
+
+        # Validate MHA input types — catches mixed-dtype fused graphs (e.g.,
+        # Q=float32 but V=float16) that pass structural assertions but fail at ORT load.
+        self._validate_mha_input_types(optimized_model)
 
         mha_nodes = [n for n in optimized_model.model.graph.node if n.op_type == "MultiHeadAttention"]
         self.assertEqual(len(mha_nodes), 1, "Expected exactly 1 fused MultiHeadAttention node")
@@ -689,6 +735,8 @@ class TestFusion(unittest.TestCase):
         optimized_model = optimize_model(model_path, model_type="mmdit", opt_level=0)
         os.remove(model_path)
 
+        self._validate_mha_input_types(optimized_model)
+
         mha_nodes = [n for n in optimized_model.model.graph.node if n.op_type == "MultiHeadAttention"]
         self.assertEqual(len(mha_nodes), 1, "Expected exactly 1 fused MultiHeadAttention node")
 
@@ -715,6 +763,8 @@ class TestFusion(unittest.TestCase):
 
         optimized_model = optimize_model(model_path, model_type="mmdit", opt_level=0)
         os.remove(model_path)
+
+        self._validate_mha_input_types(optimized_model)
 
         mha_nodes = [n for n in optimized_model.model.graph.node if n.op_type == "MultiHeadAttention"]
         self.assertEqual(len(mha_nodes), 1, "Expected exactly 1 fused MultiHeadAttention node")


### PR DESCRIPTION
## Summary
- Add `FusionMultiHeadAttentionDiT` to recognize DiT-style attention patterns (F5-TTS, etc.) and fuse them into `MultiHeadAttention`, enabling Flash Attention dispatch.
- Register the new fusion as a second pass in `MmditOnnxModel.fuse_multi_head_attention()`, alongside the existing MMDit fusion for SD3/Flux.
- Add test model generator and three test cases covering FP32, FP16 cast, and custom-scale variants.

## Motivation
Fixes #27983

DiT models like F5-TTS use an attention pattern where Q, K, V are pre-computed (e.g., after RoPE) in BNSH format, K is pre-transposed to BNHS, and a custom scalar scale (e.g., 100.0) is applied via `Mul` before `Softmax`. Optional `Cast` nodes (FP16↔FP32) may wrap `Softmax` for mixed-precision inference.

The existing MMDit fusion (for SD3/Flux) expects a specific `Mul→Sqrt→Div→Sqrt→Cast→Slice→Shape` scaling path and does not match the simpler `Mul(scalar_constant)` pattern, so the attention is never fused and Flash Attention is never dispatched. This causes ~44 extra Cast ops per inference and ~200ms overhead per forward pass.

## Changes

**New files:**
- `onnxruntime/python/tools/transformers/fusion_mha_dit.py` — Core fusion class that matches the pattern:
  ```
  MatMul(Q, K^T) → [Cast FP16→FP32] → Mul(scale) → Softmax → [Cast FP32→FP16] → MatMul(attn, V)
      → Transpose(0,2,1,3) → Reshape → output
  ```
  and replaces it with a single `MultiHeadAttention` op (with `scale` attribute).
  
- `onnxruntime/test/python/transformers/dit_model_generator.py` — Synthetic ONNX graph generators for testing.

**Modified files:**
- `onnxruntime/python/tools/transformers/onnx_model_mmdit.py` — Register `FusionMultiHeadAttentionDiT` as a second fusion pass after the existing MMDit fusion.
- `onnxruntime/test/python/transformers/test_attention_fusion.py` — Three new test cases:
  - `test_dit_attention_fusion` — FP32 with K pre-transpose, scale=100.0
  - `test_dit_attention_fusion_with_fp16_casts` — FP16 Cast nodes around Softmax
  - `test_dit_attention_fusion_custom_scale` — Standard 1/√d_k scale

## Test Plan
- All three new DiT fusion tests pass, verifying:
  - Exactly 1 `MultiHeadAttention` node is produced
  - `num_heads` attribute is correctly detected from upstream Reshape shapes
  - `scale` attribute matches the original scalar constant
  - No `Softmax` nodes remain after fusion
- Existing attention fusion tests remain unaffected
- `ruff check`, `ruff format`, and `lintrunner -a` pass clean