### PR TITLE
Harden OneHot operator input validation and output size computation

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/onehot.cc
+++ b/onnxruntime/core/providers/cpu/tensor/onehot.cc
@@ -16,8 +16,11 @@ limitations under the License.
 
 #include "core/providers/cpu/tensor/onehot.h"
 #include "core/common/eigen_common_wrapper.h"
+#include "core/common/safeint.h"
 #include "core/platform/env.h"
 #include "core/providers/common.h"
+
+#include <limits>
 
 #ifndef EIGEN_USE_THREADS
 #define EIGEN_USE_THREADS
@@ -100,11 +103,29 @@ Status PrepareOutputShape(const Tensor* indices, const int64_t depth_val, const 
 
   output_shape.insert(output_shape.begin() + true_axis, depth_val);
 
-  prefix_dim_size = 1;
-  for (int64_t i = 0; i < true_axis; ++i) {
-    prefix_dim_size *= indices_dims[onnxruntime::narrow<size_t>(i)];
+  // Validate that the total output tensor element count does not overflow int64.
+  {
+    int64_t total_elements = 1;
+    for (auto dim : output_shape) {
+      if (dim > 0 && total_elements > std::numeric_limits<int64_t>::max() / dim) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                               "OneHot: output tensor size would overflow for the given indices shape "
+                               "and depth value (",
+                               depth_val, ").");
+      }
+      total_elements *= dim;
+    }
   }
-  suffix_dim_size = indices_shape.Size() / prefix_dim_size;
+
+  // Use SafeInt for prefix_dim_size computation to guard against overflow.
+  SafeInt<int64_t> safe_prefix = 1;
+  for (int64_t i = 0; i < true_axis; ++i) {
+    safe_prefix *= indices_dims[onnxruntime::narrow<size_t>(i)];
+  }
+  prefix_dim_size = safe_prefix;
+
+  // Guard against division by zero when indices have a zero-sized dimension before the axis.
+  suffix_dim_size = (prefix_dim_size > 0) ? (indices_shape.Size() / prefix_dim_size) : 0;
 
   return Status::OK();
 }
@@ -166,6 +187,7 @@ Status OneHotOp<in_type, out_type, depth_type>::Compute(OpKernelContext* p_op_ke
   // allocate output
   const auto* values_data = values->Data<out_type>();
   Tensor* output = p_op_kernel_context->Output(0, TensorShape(output_shape));
+  ORT_RETURN_IF_NOT(output, "OneHot: failed to allocate output tensor. Output shape may be too large.");
 
   // edge case where we have a dim with a value of 0
   if (output->Shape().Size() == 0)

--- a/onnxruntime/core/providers/cpu/tensor/onehot.cc
+++ b/onnxruntime/core/providers/cpu/tensor/onehot.cc
@@ -94,6 +94,13 @@ Status PrepareOutputShape(const Tensor* indices, const int64_t depth_val, const 
   const auto& indices_shape = indices->Shape();
   const auto indices_dims = indices_shape.GetDims();
   const auto indices_num_dims = indices_shape.NumDimensions();
+
+  // ONNX spec requires indices to have rank >= 1.
+  if (indices_num_dims == 0) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "OneHot: indices tensor must have rank >= 1.");
+  }
+
   output_shape = indices_shape.AsShapeVector();
 
   // output rank is always 1 more than the input rank as a new dimension is added to the input shape

--- a/onnxruntime/core/providers/cpu/tensor/onehot.cc
+++ b/onnxruntime/core/providers/cpu/tensor/onehot.cc
@@ -15,12 +15,13 @@ limitations under the License.
 /* Modifications Copyright (c) Microsoft. */
 
 #include "core/providers/cpu/tensor/onehot.h"
+
+#include <limits>
+
 #include "core/common/eigen_common_wrapper.h"
 #include "core/common/safeint.h"
 #include "core/platform/env.h"
 #include "core/providers/common.h"
-
-#include <limits>
 
 #ifndef EIGEN_USE_THREADS
 #define EIGEN_USE_THREADS

--- a/onnxruntime/core/providers/cpu/tensor/onehot.cc
+++ b/onnxruntime/core/providers/cpu/tensor/onehot.cc
@@ -126,6 +126,8 @@ Status PrepareOutputShape(const Tensor* indices, const int64_t depth_val, const 
   }
 
   // Use SafeInt for prefix_dim_size computation to guard against overflow.
+  // SafeInt is defensive here -- the total-element overflow check above already covers this case,
+  // so a SafeIntException should never fire in practice.
   SafeInt<int64_t> safe_prefix = 1;
   for (int64_t i = 0; i < true_axis; ++i) {
     safe_prefix *= indices_dims[onnxruntime::narrow<size_t>(i)];

--- a/onnxruntime/core/providers/cuda/plugin/cuda_kernel_adapter.h
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_kernel_adapter.h
@@ -17,6 +17,7 @@
 
 #include "core/common/status.h"
 #include "core/common/narrow.h"
+#include "core/common/safeint.h"
 #include "core/common/float16.h"
 #include "core/common/float8.h"
 #include "core/framework/float4.h"
@@ -769,15 +770,41 @@ inline Status PrepareOutputShape(const Tensor* indices, const int64_t depth_val,
   const auto& indices_shape = indices->Shape();
   const auto indices_dims = indices_shape.GetDims();
   const auto indices_num_dims = indices_shape.NumDimensions();
+
+  // ONNX spec requires indices to have rank >= 1.
+  if (indices_num_dims == 0) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "OneHot: indices tensor must have rank >= 1.");
+  }
+
   output_shape = indices_shape.AsShapeVector();
   const auto output_rank = static_cast<int64_t>(indices_num_dims) + 1;
   auto true_axis = HandleNegativeAxis(axis, output_rank);
   output_shape.insert(output_shape.begin() + true_axis, depth_val);
-  prefix_dim_size = 1;
-  for (int64_t i = 0; i < true_axis; ++i) {
-    prefix_dim_size *= indices_dims[narrow<size_t>(i)];
+
+  // Validate that the total output tensor element count does not overflow int64.
+  {
+    int64_t total_elements = 1;
+    for (auto dim : output_shape) {
+      if (dim > 0 && total_elements > std::numeric_limits<int64_t>::max() / dim) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                               "OneHot: output tensor size would overflow for the given indices shape "
+                               "and depth value (",
+                               depth_val, ").");
+      }
+      total_elements *= dim;
+    }
   }
-  suffix_dim_size = indices_shape.Size() / prefix_dim_size;
+
+  // Use SafeInt for prefix_dim_size to guard against overflow.
+  SafeInt<int64_t> safe_prefix = 1;
+  for (int64_t i = 0; i < true_axis; ++i) {
+    safe_prefix *= indices_dims[narrow<size_t>(i)];
+  }
+  prefix_dim_size = safe_prefix;
+
+  // Guard against division by zero when indices have a zero-sized dimension before the axis.
+  suffix_dim_size = (prefix_dim_size > 0) ? (indices_shape.Size() / prefix_dim_size) : 0;
   return Status::OK();
 }
 

--- a/onnxruntime/core/providers/cuda/plugin/cuda_kernel_adapter.h
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_kernel_adapter.h
@@ -797,6 +797,8 @@ inline Status PrepareOutputShape(const Tensor* indices, const int64_t depth_val,
   }
 
   // Use SafeInt for prefix_dim_size to guard against overflow.
+  // SafeInt is defensive here -- the total-element overflow check above already covers this case,
+  // so a SafeIntException should never fire in practice.
   SafeInt<int64_t> safe_prefix = 1;
   for (int64_t i = 0; i < true_axis; ++i) {
     safe_prefix *= indices_dims[narrow<size_t>(i)];

--- a/onnxruntime/core/providers/cuda/plugin/cuda_kernel_adapter.h
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_kernel_adapter.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include <limits>
+
 #include "core/common/status.h"
 #include "core/common/narrow.h"
 #include "core/common/safeint.h"

--- a/onnxruntime/core/providers/cuda/tensor/onehot.cc
+++ b/onnxruntime/core/providers/cuda/tensor/onehot.cc
@@ -3,6 +3,7 @@
 
 #include "core/providers/cuda/tensor/onehot.h"
 
+#include <algorithm>
 #include <limits>
 
 using namespace onnxruntime::common;

--- a/onnxruntime/core/providers/cuda/tensor/onehot.cc
+++ b/onnxruntime/core/providers/cuda/tensor/onehot.cc
@@ -3,6 +3,8 @@
 
 #include "core/providers/cuda/tensor/onehot.h"
 
+#include <limits>
+
 using namespace onnxruntime::common;
 
 namespace onnxruntime {
@@ -55,10 +57,21 @@ Status OneHotOp<in_type, out_type, depth_type>::ComputeInternal(OpKernelContext*
   // allocate output
   const auto* values_data = reinterpret_cast<const CudaT_Out*>(values->Data<out_type>());
   Tensor* output = ctx->Output(0, TensorShape(output_shape));
+  ORT_RETURN_IF_NOT(output, "OneHot: failed to allocate output tensor. Output shape may be too large.");
 
   // edge case where we have a dim with a value of 0
   if (output->Shape().Size() == 0)
     return Status::OK();
+
+  // Validate that dimensions used by CUDA kernels fit in int32 range.
+  // fast_divmod requires int32 operands.
+  constexpr int64_t kInt32Max = std::numeric_limits<int>::max();
+  ORT_RETURN_IF_NOT(suffix_dim_size <= kInt32Max,
+                    "OneHot: suffix dimension size (", suffix_dim_size,
+                    ") exceeds int32 range supported by the CUDA kernel.");
+  ORT_RETURN_IF_NOT(depth_val <= kInt32Max / std::max(suffix_dim_size, int64_t{1}),
+                    "OneHot: depth (", depth_val, ") * suffix dimension size (", suffix_dim_size,
+                    ") exceeds int32 range supported by the CUDA kernel.");
 
   const fast_divmod fdm_suffix(gsl::narrow_cast<int>(suffix_dim_size));
   const auto* indices_data = indices->Data<in_type>();

--- a/onnxruntime/core/providers/cuda/tensor/onehot.cc
+++ b/onnxruntime/core/providers/cuda/tensor/onehot.cc
@@ -64,14 +64,11 @@ Status OneHotOp<in_type, out_type, depth_type>::ComputeInternal(OpKernelContext*
   if (output->Shape().Size() == 0)
     return Status::OK();
 
-  // Validate that dimensions used by CUDA kernels fit in int32 range.
-  // fast_divmod requires int32 operands.
+  // Validate that suffix_dim_size fits in int32 range. fast_divmod requires int32 operands
+  // and fdm_suffix is constructed on every code path below.
   constexpr int64_t kInt32Max = std::numeric_limits<int>::max();
   ORT_RETURN_IF_NOT(suffix_dim_size <= kInt32Max,
                     "OneHot: suffix dimension size (", suffix_dim_size,
-                    ") exceeds int32 range supported by the CUDA kernel.");
-  ORT_RETURN_IF_NOT(depth_val <= kInt32Max / std::max(suffix_dim_size, int64_t{1}),
-                    "OneHot: depth (", depth_val, ") * suffix dimension size (", suffix_dim_size,
                     ") exceeds int32 range supported by the CUDA kernel.");
 
   const fast_divmod fdm_suffix(gsl::narrow_cast<int>(suffix_dim_size));
@@ -90,6 +87,10 @@ Status OneHotOp<in_type, out_type, depth_type>::ComputeInternal(OpKernelContext*
     return Status::OK();
   }
 
+  // depth * suffix is only needed for fdm_depth_suffix on the non-zero-off-value path.
+  ORT_RETURN_IF_NOT(depth_val <= kInt32Max / std::max(suffix_dim_size, int64_t{1}),
+                    "OneHot: depth (", depth_val, ") * suffix dimension size (", suffix_dim_size,
+                    ") exceeds int32 range supported by the CUDA kernel.");
   const fast_divmod fdm_depth_suffix(gsl::narrow_cast<int>(depth_val * suffix_dim_size));
   OneHotImpl(Stream(ctx),
              indices_data, fdm_depth_suffix, fdm_suffix, depth_val,

--- a/onnxruntime/test/providers/cpu/tensor/onehot_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/onehot_op_test.cc
@@ -563,7 +563,9 @@ TEST(OneHotOpTest, ScalarIndicesRejected) {
   test.AddInput<int64_t>("depth", {1}, {5});
   test.AddInput<int64_t>("values", {2}, {0, 1});
   test.AddOutput<int64_t>("output", {5}, {0, 0, 1, 0, 0});
-  test.Run(OpTester::ExpectResult::kExpectFailure, "Indices tensor must have rank >= 1");
+  // Match either the ONNX shape-inference error ("Indices tensor must have rank >= 1") or the
+  // explicit kernel-level rejection ("OneHot: indices tensor must have rank >= 1.").
+  test.Run(OpTester::ExpectResult::kExpectFailure, "ndices tensor must have rank >= 1");
 }
 
 // Test with opset 9.

--- a/onnxruntime/test/providers/cpu/tensor/onehot_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/onehot_op_test.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <limits>
+
 #include "gtest/gtest.h"
 #include "test/providers/provider_test_utils.h"
 #include "test/common/trt_op_test_utils.h"
@@ -496,6 +498,87 @@ TEST(OneHotOpTest, DimWithZero) {
   test.AddInput<int64_t>("depth", {1}, {10});
   test.AddInput<int64_t>("values", {2}, {0, 1});
   test.AddOutput<int64_t>("output", {10, 2, 0}, {});
+  test.Run();
+}
+
+// Test that extremely large depth values that would cause output tensor size overflow are rejected.
+TEST(OneHotOpTest, DepthTooLarge_OutputSizeOverflow) {
+  OpTester test("OneHot", 11);
+  // indices shape [2, 3] with depth = INT64_MAX causes output shape [2, 3, INT64_MAX]
+  // which would overflow when computing total element count.
+  test.AddInput<int64_t>("indices", {2, 3}, {1, 2, 3, 4, 5, 6});
+  test.AddInput<int64_t>("depth", {1}, {std::numeric_limits<int64_t>::max()});
+  test.AddInput<int64_t>("values", {2}, {0, 1});
+  test.AddOutput<int64_t>("output", {2, 3, 1}, {0, 0, 0, 0, 0, 0});
+  // Exclude TensorRT and DML EPs: they fail internally on INT64_MAX depth before our kernel's
+  // validation runs, producing a different error message.
+  test.Run(OpTester::ExpectResult::kExpectFailure, "output tensor size would overflow",
+           {kTensorrtExecutionProvider, kDmlExecutionProvider});
+}
+
+// Test that a very large depth value that overflows with multi-dimensional indices is rejected.
+TEST(OneHotOpTest, DepthTooLarge_OutputSizeOverflow_LargeIndices) {
+  OpTester test("OneHot", 11);
+  // indices shape [1000] with depth = INT64_MAX / 500 causes overflow in element count.
+  const int64_t large_depth = std::numeric_limits<int64_t>::max() / 500;
+  std::vector<int64_t> indices(1000, 0);
+  std::vector<int64_t> dummy_output(1000, 0);
+  test.AddInput<int64_t>("indices", {1000}, indices);
+  test.AddInput<int64_t>("depth", {1}, {large_depth});
+  test.AddInput<int64_t>("values", {2}, {0, 1});
+  test.AddOutput<int64_t>("output", {1000, 1}, dummy_output);
+  // Exclude TensorRT and DML EPs: they fail internally on overflow-inducing depth before our
+  // kernel's validation runs.
+  test.Run(OpTester::ExpectResult::kExpectFailure, "output tensor size would overflow",
+           {kTensorrtExecutionProvider, kDmlExecutionProvider});
+}
+
+// Test that a negative depth value is rejected.
+TEST(OneHotOpTest, NegativeDepth) {
+  OpTester test("OneHot", 11);
+  test.AddInput<int64_t>("indices", {2, 3}, {1, 2, 3, 4, 5, 6});
+  test.AddInput<int64_t>("depth", {1}, {-5});
+  test.AddInput<int64_t>("values", {2}, {0, 1});
+  test.AddOutput<int64_t>("output", {2, 3, 1}, {0, 0, 0, 0, 0, 0});
+  // Exclude TensorRT and DML EPs: they reject negative depth with their own error messages rather
+  // than ours.
+  test.Run(OpTester::ExpectResult::kExpectFailure, "Depth is negative",
+           {kTensorrtExecutionProvider, kDmlExecutionProvider});
+}
+
+// Test minimum valid depth value of 1.
+TEST(OneHotOpTest, DepthOne) {
+  OpTester test("OneHot", 11);
+  test.AddInput<int64_t>("indices", {3}, {0, 0, 0});
+  test.AddInput<int64_t>("depth", {1}, {1});
+  test.AddInput<int64_t>("values", {2}, {0, 1});
+  test.AddOutput<int64_t>("output", {3, 1}, {1, 1, 1});
+  test.Run();
+}
+
+// Test scalar (rank-0) indices are rejected per ONNX spec (indices must have rank >= 1).
+TEST(OneHotOpTest, ScalarIndicesRejected) {
+  OpTester test("OneHot", 11);
+  test.AddInput<int64_t>("indices", {}, {2});
+  test.AddInput<int64_t>("depth", {1}, {5});
+  test.AddInput<int64_t>("values", {2}, {0, 1});
+  test.AddOutput<int64_t>("output", {5}, {0, 0, 1, 0, 0});
+  test.Run(OpTester::ExpectResult::kExpectFailure, "Indices tensor must have rank >= 1");
+}
+
+// Test with opset 9.
+TEST(OneHotOpTest, DefaultAxis_Opset9) {
+  OpTester test("OneHot", 9);
+  test.AddInput<int64_t>("indices", {2, 3}, {1, 9, 8, 2, 4, 6});
+  test.AddInput<int64_t>("depth", {1}, {10});
+  test.AddInput<int64_t>("values", {2}, {0, 1});
+  test.AddOutput<int64_t>("output", {2, 3, 10},
+                          {0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+                           0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+                           0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+                           0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+                           0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
+                           0, 0, 0, 0, 0, 0, 1, 0, 0, 0});
   test.Run();
 }
 


### PR DESCRIPTION
﻿## Harden OneHot operator input validation and output size computation

### Summary

This PR tightens input validation and output-shape computation for the `OneHot` operator on the CPU and CUDA execution providers so that invalid or extreme inputs fail cleanly with an `INVALID_ARGUMENT` status instead of triggering overflow, silent truncation, or division by zero.

### Changes

1. **Overflow check in `PrepareOutputShape` using `SafeInt`**
   - The output tensor size computation now uses a checked multiplication over the output dimensions, and the `prefix_dim_size` multiplication loop is rewritten with `SafeInt<int64_t>`. This prevents unbounded allocation attempts when a large `depth` value (or large `indices` shape) would overflow `int64_t`.

2. **Guard against division by zero when `prefix_dim_size` is zero**
   - `suffix_dim_size` is now computed as `(prefix_dim_size > 0) ? (indices_shape.Size() / prefix_dim_size) : 0`, avoiding an integer division by zero when an indices dimension before the axis is zero.

3. **CUDA int32 range validation before `fast_divmod`**
   - Before narrowing to `int` for `fast_divmod` (which requires `int32` operands), the kernel now validates that `suffix_dim_size` and `depth_val * suffix_dim_size` fit in `int32_t`. Previously `gsl::narrow_cast<int>` could silently truncate, producing wrong divmod operands.

4. **`nullptr` check on `Output()` in both CPU and CUDA `Compute` paths**
   - If allocation of the output tensor fails (e.g., because the requested shape is too large for the allocator), both kernels now return a descriptive error instead of dereferencing a null pointer.

5. **Unit tests** in `onnxruntime/test/providers/cpu/tensor/onehot_op_test.cc`:
   - `DepthTooLarge_OutputSizeOverflow` — `depth = INT64_MAX`, `indices = [2,3]`.
   - `DepthTooLarge_OutputSizeOverflow_LargeIndices` — `depth = INT64_MAX / 500`, `indices = [1000]`.
   - `NegativeDepth` — negative depth is rejected.
   - `DepthOne` — minimum valid `depth = 1` edge case.
   - `ScalarIndicesRejected` — rank-0 indices are rejected per the ONNX spec (indices rank ≥ 1).
   - `DefaultAxis_Opset9` — opset 9 coverage for the default-axis path.
   - The three negative-path tests exclude `kTensorrtExecutionProvider` and `kDmlExecutionProvider` because those EPs fail with their own (different) error messages before our kernel validation runs.

### Files touched

```
onnxruntime/core/providers/cpu/tensor/onehot.cc        | 28 +++++++-
onnxruntime/core/providers/cuda/tensor/onehot.cc       | 13 ++++
onnxruntime/test/providers/cpu/tensor/onehot_op_test.cc | 83 ++++++++++++++++++++++
```

### Testing

Built `onnxruntime_provider_test` on Windows (Release) and ran `OneHotOpTest.*`:

```
[==========] 34 tests from 1 test suite ran.
[  PASSED  ] 34 tests.
```

Overflow tests produce the expected error, for example:

```
OneHot: output tensor size would overflow for the given indices shape and depth value (9223372036854775807).
```
