### PR TITLE
[WebGPU] Fix MHA to ignore past key/value when no present outputs requested

### DIFF
--- a/js/web/lib/wasm/jsep/webgpu/ops/attention.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/attention.ts
@@ -809,14 +809,17 @@ export const applyAttention = (
 ) => {
   // Assumption is that presentKey/presentValue exists only if pastKey/pastValue exists.
   const outputCount = Math.min(context.outputCount, 1 + (pastKey ? 1 : 0) + (pastValue ? 1 : 0));
+  // When there are no present key/value outputs (outputCount <= 1), ignore past to match CPU EP semantics.
+  const effectivePastKey = outputCount > 1 ? pastKey : undefined;
+  const effectivePastValue = outputCount > 1 ? pastValue : undefined;
   const pastSequenceLength = outputCount > 1 ? parameters.pastSequenceLength : 0;
   const totalSequenceLength = pastSequenceLength + parameters.kvSequenceLength;
   const attentionBias =
     attentionBiasInput && ShapeUtil.size(attentionBiasInput.dims) > 0 ? attentionBiasInput : undefined;
 
   const inputsK = [q, k];
-  if (outputCount > 1 && pastKey && ShapeUtil.size(pastKey.dims) > 0) {
-    inputsK.push(pastKey);
+  if (effectivePastKey && ShapeUtil.size(effectivePastKey.dims) > 0) {
+    inputsK.push(effectivePastKey);
   }
   if (attentionBias) {
     inputsK.push(attentionBias);
@@ -833,7 +836,7 @@ export const applyAttention = (
       outputCount,
       q,
       k,
-      pastKey,
+      effectivePastKey,
       attentionBias,
       parameters,
       pastSequenceLength,
@@ -860,8 +863,8 @@ export const applyAttention = (
 
   // Run AttentionScore
   const inputsV = [probs, v];
-  if (outputCount > 1 && pastValue && ShapeUtil.size(pastValue.dims) > 0) {
-    inputsV.push(pastValue);
+  if (effectivePastValue && ShapeUtil.size(effectivePastValue.dims) > 0) {
+    inputsV.push(effectivePastValue);
   }
   if (seqLens) {
     inputsV.push(seqLens);
@@ -874,7 +877,7 @@ export const applyAttention = (
       outputCount,
       probs,
       v,
-      pastValue,
+      effectivePastValue,
       parameters,
       pastSequenceLength,
       seqLens,


### PR DESCRIPTION
### Description
When MultiHeadAttention has only 1 output (no present_key/present_value outputs), past key/value inputs should be completely ignored, matching CPU EP semantics. The WebGPU EP was passing pastKey/pastValue TensorViews to shader creation functions even when outputCount <= 1, which affected shader cache keys and allowed past data to leak into the attention computation.

This caused the test "MultiHeadAttention Basic, one head and head-size=4 with pastKey and pastValue" to fail with output [17,18,19,20] (pastValue data) instead of expected [9,10,11,12] (V data). The failing output matches exactly what happens when past IS used: Q·pastKey=75 dominates Q·K=35, so softmax gives ~100% weight to pastValue.

### Fix
In `applyAttention()`, introduce `effectivePastKey`/`effectivePastValue` that are set to `undefined` when `outputCount <= 1`. All downstream usage (shader creation, input arrays) uses these effective values instead of the raw parameters. This ensures:
- Shader cache keys correctly reflect the "no past" configuration
- Past tensors are never passed to any shader creation function
- Behavior matches CPU EP (which ignores past when present outputs are null)
- GQA is unaffected (always has outputCount >= 3)
- Vanilla Attention is unaffected (always passes undefined for past)