### PR TITLE
docs: update Python style docs to Ruff, remove TVM EP artifacts

### DIFF
--- a/docs/Coding_Conventions_and_Standards.md
+++ b/docs/Coding_Conventions_and_Standards.md
@@ -188,13 +188,13 @@ new adapter following examples in https://github.com/justinchuby/lintrunner-adap
 
 ## Python Code Style
 
-Follow the [Black formatter](https://black.readthedocs.io)'s coding style when possible. A maximum line length of 120 characters is allowed for consistency with the C++ code.
+Follow the [Ruff formatter](https://docs.astral.sh/ruff/formatter/)'s coding style when possible. A maximum line length of 120 characters is allowed for consistency with the C++ code.
 
 Please adhere to the [PEP8 Style Guide](https://www.python.org/dev/peps/pep-0008/). We use [Google's python style guide](https://google.github.io/styleguide/pyguide.html) as the style guide which is an extension to PEP8.
 
 Use `pyright`, which is provided as a component of the `pylance` extension in VS Code for static type checking.
 
-Auto-formatting is done with `black` and `isort`. The tools are configured in `pyproject.toml`. From the root of the repository, you can run
+Auto-formatting and linting are done with [Ruff](https://docs.astral.sh/ruff/), which handles both code formatting and import sorting. The tools are configured in `pyproject.toml` and `.lintrunner.toml`. From the root of the repository, you can run
 
 ```sh
 lintrunner f --all-files
@@ -202,21 +202,19 @@ lintrunner f --all-files
 
 to format Python files.
 
-Use `pydocstyle` to lint documentation styles. `pydocstyle` is enabled in VS Code.
-
 ## IDEs
 
 ### VS Code
 
 VS Code is automatically configured with workspace configurations.
 
-For Python development is VS Code, read
+For Python development in VS Code, read
 [this tutorial](https://code.visualstudio.com/docs/python/python-tutorial) for
 more information.
 
 ### PyCharm
 
-Follow [black's documentation](https://black.readthedocs.io/en/stable/integrations/editors.html#pycharm-intellij-idea) to set up the black formatter for PyCharm.
+Follow [Ruff's documentation](https://docs.astral.sh/ruff/editors/setup/#pycharm) to set up the Ruff formatter for PyCharm.
 
 ## Testing
 

--- a/include/onnxruntime/core/graph/constants.h
+++ b/include/onnxruntime/core/graph/constants.h
@@ -46,7 +46,6 @@ constexpr const char* kAclExecutionProvider = "ACLExecutionProvider";
 constexpr const char* kCoreMLExecutionProvider = "CoreMLExecutionProvider";
 constexpr const char* kJsExecutionProvider = "JsExecutionProvider";
 constexpr const char* kSnpeExecutionProvider = "SNPEExecutionProvider";
-constexpr const char* kTvmExecutionProvider = "TvmExecutionProvider";
 constexpr const char* kXnnpackExecutionProvider = "XnnpackExecutionProvider";
 constexpr const char* kWebNNExecutionProvider = "WebNNExecutionProvider";
 constexpr const char* kWebGpuExecutionProvider = "WebGpuExecutionProvider";

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -98,13 +98,6 @@ class TestInferenceSession(unittest.TestCase):
             return -1
         return num_device.value
 
-    def test_tvm_imported(self):
-        if "TvmExecutionProvider" not in onnxrt.get_available_providers():
-            return
-        import tvm  # noqa: PLC0415
-
-        self.assertTrue(tvm is not None)
-
     def test_get_version_string(self):
         self.assertIsNot(onnxrt.get_version_string(), None)
 

--- a/onnxruntime/test/util/include/default_providers.h
+++ b/onnxruntime/test/util/include/default_providers.h
@@ -41,7 +41,6 @@ std::unique_ptr<IExecutionProvider> DefaultCudaNHWCExecutionProvider();
 std::unique_ptr<IExecutionProvider> CudaExecutionProviderWithOptions(const OrtCUDAProviderOptionsV2* provider_options);
 std::unique_ptr<IExecutionProvider> DefaultDnnlExecutionProvider();
 std::unique_ptr<IExecutionProvider> DnnlExecutionProviderWithOptions(const OrtDnnlProviderOptions* provider_options);
-// std::unique_ptr<IExecutionProvider> DefaultTvmExecutionProvider();
 std::unique_ptr<IExecutionProvider> DefaultTensorrtExecutionProvider();
 std::unique_ptr<IExecutionProvider> DefaultNvTensorRTRTXExecutionProvider();
 std::unique_ptr<IExecutionProvider> TensorrtExecutionProviderWithOptions(const OrtTensorRTProviderOptions* params);


### PR DESCRIPTION
### Description

Fixes documentation discrepancies found by comparing in-repo docs against actual codebase configuration.

#### Python Code Style docs (`docs/Coding_Conventions_and_Standards.md`)
- **Black → Ruff**: The docs recommended Black and isort, but the actual formatter/linter configured in `.lintrunner.toml` and `requirements-lintrunner.txt` is **Ruff**
- Removed stale `pydocstyle` recommendation (not configured in lintrunner or installed)
- Updated PyCharm section to link to Ruff docs instead of Black docs
- Fixed typo: "development is VS Code" → "development in VS Code"

#### TVM EP cleanup
The TVM Execution Provider was removed in Nov 2024 (commit `13346fdf18`), but a few artifacts remained:
- Removed `kTvmExecutionProvider` constant from `include/onnxruntime/core/graph/constants.h` (no code references it)
- Removed commented-out `DefaultTvmExecutionProvider()` declaration from `default_providers.h`
- Removed dead `test_tvm_imported` test method from `onnxruntime_test_python.py`

> **Note**: The `available_providers_without_tvm` variable in `onnxruntime_test_python.py` is used in ~15 places. Since TVM EP is removed, the filter is a harmless no-op. Cleaning that up is a larger refactor best done separately.

### Motivation and Context

Audited all major in-repo documentation against the actual codebase. The C API Guidelines, OperatorKernels.md, ContribOperators.md, Versioning.md, and PR Guidelines were all verified as accurate. Only the Python style section and TVM EP remnants were out of date.