### PR TITLE
fix: CoreML EP crash when loading model with external data file

### DIFF
--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -357,9 +357,12 @@ Status TensorProtoWithExternalDataToTensorProto(
       ++data;
     }
   } else {
-    // Load the external data into memory
+    // Load the external data into memory.
+    // model_path is the full model file path (e.g., "/path/to/model.onnx").
+    // ReadExternalDataForTensor expects the parent directory, matching the
+    // pattern used by UnpackInitializerData() at line ~2572.
     std::vector<uint8_t> unpacked_data;
-    ORT_RETURN_IF_ERROR(ReadExternalDataForTensor(ten_proto, model_path, unpacked_data));
+    ORT_RETURN_IF_ERROR(ReadExternalDataForTensor(ten_proto, model_path.parent_path(), unpacked_data));
 
     // Set the raw data in the new tensor
     onnxruntime::utils::SetRawDataInTensorProto(result, unpacked_data.data(), unpacked_data.size());


### PR DESCRIPTION
Fixes #28005

CoreML EP crashes with SIGBUS when loading models that use external data files (.onnx_data). CPU EP works fine which is what tipped me off that it was provider-specific.

The bug is in TensorProtoWithExternalDataToTensorProto() -- it passes model_path straight to ReadExternalDataForTensor() but model_path is the full file path like /path/to/model.onnx not the directory. So GetExternalDataInfo() builds a garbage path like /path/to/model.onnx/model.onnx_data.

Fix is model_path.parent_path() instead. Same thing UnpackInitializerData() already does at line ~2572. Only affects CoreML EP since thats the only caller passing a non-empty path here.

```diff
- ORT_RETURN_IF_ERROR(ReadExternalDataForTensor(ten_proto, model_path, unpacked_data));
+ ORT_RETURN_IF_ERROR(ReadExternalDataForTensor(ten_proto, model_path.parent_path(), unpacked_data));
```