### PR TITLE
[CI] fix: bad relative ref to setup-feeds template

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
@@ -84,10 +84,12 @@ jobs:
       git submodule update --init --recursive
     workingDirectory: '$(Build.SourcesDirectory)'
     displayName: 'Checkout submodules'
-  - template: templates/setup-feeds-and-python-steps.yml
+
+  - template: setup-feeds-and-python-steps.yml
     parameters:
       versionSpec: "3.12"
       architecture: $(buildArch)
+
   - task: NodeTool@0
     inputs:
       versionSpec: '22.x'


### PR DESCRIPTION
### Description

Fix `linux-wasm-ci.yml` setup-feed having a spurious `templates/` path prefix.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


