### PR TITLE
Fix DoubleQDQPairsRemover adding spurious dimension to scalar scale/zero-point

### DIFF
--- a/onnxruntime/core/optimizer/double_qdq_pairs_remover.cc
+++ b/onnxruntime/core/optimizer/double_qdq_pairs_remover.cc
@@ -52,7 +52,6 @@ static void ApplyNewInputValue(Graph& graph, Node& node, QDQ::InputIndex index, 
   input_init.ToProto(new_input_tensor);
   auto new_name = graph.GenerateNodeArgName("DoubleQDQRemoved_" + node.InputDefs()[index]->Name());
   new_input_tensor.set_name(new_name);
-  new_input_tensor.add_dims(1);
   NodeArg& new_input = graph_utils::AddInitializerWithOrtValue(graph, new_input_tensor);
   graph_utils::ReplaceNodeInput(node, index, new_input);
 }


### PR DESCRIPTION
When the scale or zero-point values need to be recomputed during double QDQ pair removal, the `add_dims(1)` call in `ApplyNewInputValue` was promoting scalar initializers to rank-1 tensors of shape `[1]`, which breaks type inference in ops like `QLinearAveragePool` that require scalar scale/zero-point. Removing that line is sufficient since `Initializer::ToProto` already serializes the correct shape from the underlying tensor. Fixes #28030.