### PR TITLE
Use SafeInt for size arithmetic in CPU tensor operators to prevent overflow

### DIFF
--- a/onnxruntime/core/providers/cpu/nn/tfidfvectorizer.cc
+++ b/onnxruntime/core/providers/cpu/nn/tfidfvectorizer.cc
@@ -382,7 +382,7 @@ Status TfIdfVectorizer::Compute(OpKernelContext* ctx) const {
     // TfidfVectorizer returns a zero tensor of shape
     // {b_dim, output_size} when b_dim is the number of received observations
     // and output_size the is the maximum value in ngram_indexes attribute plus 1.
-    memset(output_data, 0, SafeInt<size_t>(output_shape.Size()) * sizeof(float));
+    memset(output_data, 0, static_cast<size_t>(SafeInt<size_t>(output_shape.Size()) * sizeof(float)));
     return Status::OK();
   }
 

--- a/onnxruntime/core/providers/cpu/nn/tfidfvectorizer.cc
+++ b/onnxruntime/core/providers/cpu/nn/tfidfvectorizer.cc
@@ -382,7 +382,7 @@ Status TfIdfVectorizer::Compute(OpKernelContext* ctx) const {
     // TfidfVectorizer returns a zero tensor of shape
     // {b_dim, output_size} when b_dim is the number of received observations
     // and output_size the is the maximum value in ngram_indexes attribute plus 1.
-    memset(output_data, 0, static_cast<size_t>(output_shape.Size() * sizeof(float)));
+    memset(output_data, 0, SafeInt<size_t>(output_shape.Size()) * sizeof(float));
     return Status::OK();
   }
 

--- a/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
+++ b/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
@@ -251,7 +251,7 @@ class QLinearConv : public OpKernel {
         //
         // Note: The size of this buffer is less than or equal to the size of the original
         // weight tensor, so the allocation size is guaranteed to fit inside size_t.
-        auto* group_reordered_W = static_cast<int8_t*>(alloc->Alloc(group_output_channels * group_input_channels * kernel_size));
+        auto* group_reordered_W = static_cast<int8_t*>(alloc->Alloc(SafeInt<size_t>(group_output_channels) * group_input_channels * kernel_size));
         BufferUniquePtr group_reordered_W_buffer(group_reordered_W, BufferDeleter(alloc));
 
         const size_t W_offset = group_output_channels * kernel_dim;
@@ -439,7 +439,7 @@ Status QLinearConv<ActType>::PrePack(const Tensor& tensor, int input_idx, Alloca
       //
       // Note: The size of this buffer is less than or equal to the size of the original
       // weight tensor, so the allocation size is guaranteed to fit inside size_t.
-      auto group_reordered_W_buffer = IAllocator::MakeUniquePtr<void>(alloc, group_output_channels * group_input_channels * kernel_size, true);
+      auto group_reordered_W_buffer = IAllocator::MakeUniquePtr<void>(alloc, SafeInt<size_t>(group_output_channels) * group_input_channels * kernel_size, true);
       auto* group_reordered_W = static_cast<uint8_t*>(group_reordered_W_buffer.get());
 
       const size_t W_offset = group_output_channels * kernel_dim;

--- a/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
+++ b/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
@@ -251,7 +251,8 @@ class QLinearConv : public OpKernel {
         //
         // Note: The size of this buffer is less than or equal to the size of the original
         // weight tensor, so the allocation size is guaranteed to fit inside size_t.
-        auto* group_reordered_W = static_cast<int8_t*>(alloc->Alloc(SafeInt<size_t>(group_output_channels) * group_input_channels * kernel_size));
+        auto* group_reordered_W = static_cast<int8_t*>(alloc->Alloc(
+            static_cast<size_t>(SafeInt<size_t>(group_output_channels) * group_input_channels * kernel_size)));
         BufferUniquePtr group_reordered_W_buffer(group_reordered_W, BufferDeleter(alloc));
 
         const size_t W_offset = group_output_channels * kernel_dim;
@@ -439,7 +440,9 @@ Status QLinearConv<ActType>::PrePack(const Tensor& tensor, int input_idx, Alloca
       //
       // Note: The size of this buffer is less than or equal to the size of the original
       // weight tensor, so the allocation size is guaranteed to fit inside size_t.
-      auto group_reordered_W_buffer = IAllocator::MakeUniquePtr<void>(alloc, SafeInt<size_t>(group_output_channels) * group_input_channels * kernel_size, true);
+      auto group_reordered_W_buffer = IAllocator::MakeUniquePtr<void>(
+          alloc, static_cast<size_t>(SafeInt<size_t>(group_output_channels) * group_input_channels * kernel_size),
+          true);
       auto* group_reordered_W = static_cast<uint8_t*>(group_reordered_W_buffer.get());
 
       const size_t W_offset = group_output_channels * kernel_dim;

--- a/onnxruntime/core/providers/cpu/quantization/quantize_linear.cc
+++ b/onnxruntime/core/providers/cpu/quantization/quantize_linear.cc
@@ -872,7 +872,7 @@ void ComputeLoop(OpKernelContext* ctx, const InT* input, const InT* scale, const
         output_index += static_cast<size_t>(N);                                                                   \
       }                                                                                                           \
     }                                                                                                             \
-    assert(output_index == SafeInt<size_t>(M) * K * N);                                                       \
+    assert(output_index == SafeInt<size_t>(M) * K * N);                                                           \
   }
 
 DEFINE_COMPUTE_LOOP_FP32_TO_SUB_BYTE(Int4x2, ParQuantizeLinearStdS4, 2)
@@ -890,7 +890,7 @@ DEFINE_COMPUTE_LOOP_FP32_TO_SUB_BYTE(UInt2x4, ParQuantizeLinearStdU2, 4)
                                              int64_t K, int64_t N, bool saturate) {                                    \
     ORT_UNUSED_PARAMETER(saturate);                                                                                    \
                                                                                                                        \
-    size_t total_size = SafeInt<size_t>(M) * K * N;                                                                \
+    size_t total_size = SafeInt<size_t>(M) * K * N;                                                                    \
     auto tmp_buf = std::make_unique<SUB_BYTE_TYPE::UnpackedType[]>(total_size);                                        \
     size_t tmp_buf_index = 0;                                                                                          \
     constexpr size_t shift_bits = (ELEMENTS_PER_BYTE == 2) ? 1 : 2; /* log2(ELEMENTS_PER_BYTE) */                      \

--- a/onnxruntime/core/providers/cpu/quantization/quantize_linear.cc
+++ b/onnxruntime/core/providers/cpu/quantization/quantize_linear.cc
@@ -872,7 +872,7 @@ void ComputeLoop(OpKernelContext* ctx, const InT* input, const InT* scale, const
         output_index += static_cast<size_t>(N);                                                                   \
       }                                                                                                           \
     }                                                                                                             \
-    assert(output_index == static_cast<size_t>(M * K * N));                                                       \
+    assert(output_index == SafeInt<size_t>(M) * K * N);                                                       \
   }
 
 DEFINE_COMPUTE_LOOP_FP32_TO_SUB_BYTE(Int4x2, ParQuantizeLinearStdS4, 2)
@@ -890,7 +890,7 @@ DEFINE_COMPUTE_LOOP_FP32_TO_SUB_BYTE(UInt2x4, ParQuantizeLinearStdU2, 4)
                                              int64_t K, int64_t N, bool saturate) {                                    \
     ORT_UNUSED_PARAMETER(saturate);                                                                                    \
                                                                                                                        \
-    size_t total_size = static_cast<size_t>(M * K * N);                                                                \
+    size_t total_size = SafeInt<size_t>(M) * K * N;                                                                \
     auto tmp_buf = std::make_unique<SUB_BYTE_TYPE::UnpackedType[]>(total_size);                                        \
     size_t tmp_buf_index = 0;                                                                                          \
     constexpr size_t shift_bits = (ELEMENTS_PER_BYTE == 2) ? 1 : 2; /* log2(ELEMENTS_PER_BYTE) */                      \

--- a/onnxruntime/core/providers/cpu/quantization/quantize_linear.cc
+++ b/onnxruntime/core/providers/cpu/quantization/quantize_linear.cc
@@ -872,7 +872,7 @@ void ComputeLoop(OpKernelContext* ctx, const InT* input, const InT* scale, const
         output_index += static_cast<size_t>(N);                                                                   \
       }                                                                                                           \
     }                                                                                                             \
-    assert(output_index == SafeInt<size_t>(M) * K * N);                                                           \
+    assert(output_index == static_cast<size_t>(SafeInt<size_t>(M) * K * N));                                      \
   }
 
 DEFINE_COMPUTE_LOOP_FP32_TO_SUB_BYTE(Int4x2, ParQuantizeLinearStdS4, 2)
@@ -890,7 +890,7 @@ DEFINE_COMPUTE_LOOP_FP32_TO_SUB_BYTE(UInt2x4, ParQuantizeLinearStdU2, 4)
                                              int64_t K, int64_t N, bool saturate) {                                    \
     ORT_UNUSED_PARAMETER(saturate);                                                                                    \
                                                                                                                        \
-    size_t total_size = SafeInt<size_t>(M) * K * N;                                                                    \
+    size_t total_size = static_cast<size_t>(SafeInt<size_t>(M) * K * N);                                               \
     auto tmp_buf = std::make_unique<SUB_BYTE_TYPE::UnpackedType[]>(total_size);                                        \
     size_t tmp_buf_index = 0;                                                                                          \
     constexpr size_t shift_bits = (ELEMENTS_PER_BYTE == 2) ? 1 : 2; /* log2(ELEMENTS_PER_BYTE) */                      \

--- a/onnxruntime/core/providers/cpu/sequence/sequence_ops.cc
+++ b/onnxruntime/core/providers/cpu/sequence/sequence_ops.cc
@@ -518,7 +518,8 @@ Status SplitToSequence::ComputeImpl(OpKernelContext& context, const Tensor& inpu
     void* output_data = output_tensor.MutableDataRaw();
 
     const auto M = before_dims;
-    const auto* A = static_cast<const char*>(input_data) + static_cast<size_t>(SafeInt<size_t>(input_offset) * element_size);
+    const auto* A =
+        static_cast<const char*>(input_data) + static_cast<size_t>(SafeInt<size_t>(input_offset) * element_size);
     const auto lda = after_dims_including_split_axis;
     auto* B = output_data;
 
@@ -529,7 +530,7 @@ Status SplitToSequence::ComputeImpl(OpKernelContext& context, const Tensor& inpu
       const auto* src = reinterpret_cast<const std::string*>(A);
       auto* dst = reinterpret_cast<std::string*>(B);
       if (lda == N) {
-        copy_data<std::string>(src, dst, SafeInt<size_t>(M) * N);
+        copy_data<std::string>(src, dst, static_cast<size_t>(SafeInt<size_t>(M) * N));
       } else {
         size_t lda_offset = 0;
         size_t ldb_offset = 0;
@@ -541,13 +542,13 @@ Status SplitToSequence::ComputeImpl(OpKernelContext& context, const Tensor& inpu
     } else {
       if (lda == N) {
         // if the data is contiguous, we can just copy the data
-        const size_t bytes_to_copy = static_cast<size_t>(N) * static_cast<size_t>(M) * element_size;
+        const size_t bytes_to_copy = static_cast<size_t>(SafeInt<size_t>(N) * M * element_size);
         memcpy(B, A, bytes_to_copy);
       } else {
         // otherwise we need to copy each row
-        const size_t row_bytes = SafeInt<size_t>(N) * element_size;
-        const auto lda_bytes_inc = SafeInt<size_t>(lda) * element_size;
-        const auto ldb_bytes_inc = SafeInt<size_t>(ldb) * element_size;
+        const size_t row_bytes = static_cast<size_t>(SafeInt<size_t>(N) * element_size);
+        const auto lda_bytes_inc = static_cast<size_t>(SafeInt<size_t>(lda) * element_size);
+        const auto ldb_bytes_inc = static_cast<size_t>(SafeInt<size_t>(ldb) * element_size);
         SafeInt<size_t> lda_bytes_offset = 0;
         SafeInt<size_t> ldb_bytes_offset = 0;
         for (size_t idx = 0; idx < static_cast<size_t>(M); ++idx,

--- a/onnxruntime/core/providers/cpu/sequence/sequence_ops.cc
+++ b/onnxruntime/core/providers/cpu/sequence/sequence_ops.cc
@@ -518,7 +518,7 @@ Status SplitToSequence::ComputeImpl(OpKernelContext& context, const Tensor& inpu
     void* output_data = output_tensor.MutableDataRaw();
 
     const auto M = before_dims;
-    const auto* A = static_cast<const char*>(input_data) + SafeInt<size_t>(input_offset) * element_size;
+    const auto* A = static_cast<const char*>(input_data) + static_cast<size_t>(SafeInt<size_t>(input_offset) * element_size);
     const auto lda = after_dims_including_split_axis;
     auto* B = output_data;
 

--- a/onnxruntime/core/providers/cpu/sequence/sequence_ops.cc
+++ b/onnxruntime/core/providers/cpu/sequence/sequence_ops.cc
@@ -4,6 +4,7 @@
 #include "core/providers/cpu/sequence/sequence_ops.h"
 
 #include "core/common/narrow.h"
+#include "core/common/safeint.h"
 #include "core/framework/tensorprotoutils.h"
 #include "core/framework/TensorSeq.h"
 #include "core/framework/op_kernel_type_control_utils.h"
@@ -517,7 +518,7 @@ Status SplitToSequence::ComputeImpl(OpKernelContext& context, const Tensor& inpu
     void* output_data = output_tensor.MutableDataRaw();
 
     const auto M = before_dims;
-    const auto* A = static_cast<const char*>(input_data) + static_cast<size_t>(input_offset * element_size);
+    const auto* A = static_cast<const char*>(input_data) + SafeInt<size_t>(input_offset) * element_size;
     const auto lda = after_dims_including_split_axis;
     auto* B = output_data;
 
@@ -528,7 +529,7 @@ Status SplitToSequence::ComputeImpl(OpKernelContext& context, const Tensor& inpu
       const auto* src = reinterpret_cast<const std::string*>(A);
       auto* dst = reinterpret_cast<std::string*>(B);
       if (lda == N) {
-        copy_data<std::string>(src, dst, static_cast<size_t>(M * N));
+        copy_data<std::string>(src, dst, SafeInt<size_t>(M) * N);
       } else {
         size_t lda_offset = 0;
         size_t ldb_offset = 0;

--- a/onnxruntime/core/providers/cpu/tensor/affine_grid.cc
+++ b/onnxruntime/core/providers/cpu/tensor/affine_grid.cc
@@ -4,6 +4,7 @@
 #include "core/providers/cpu/tensor/affine_grid.h"
 
 #include "core/common/common.h"
+#include "core/common/safeint.h"
 #include "core/providers/op_kernel_type_control.h"
 #include "core/util/math_cpuonly.h"
 #include <Eigen/Dense>
@@ -78,9 +79,9 @@ void affine_grid_generator_2d(const Tensor* theta, const Eigen::Matrix<T, 2, Eig
   const Eigen::Matrix<T, 2, 2, option> theta_R{{theta_data[0], theta_data[1]}, {theta_data[3], theta_data[4]}};  // 2x2
   const Eigen::Array<T, 2, 1> theta_T(theta_data[2], theta_data[5]);                                             // 2x1
 
-  auto grid_batch_offset = batch_num * H * W * 2;
+  auto grid_batch_offset = SafeInt<size_t>(batch_num) * H * W * 2;
   T* grid_data = grid->MutableData<T>() + grid_batch_offset;
-  Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, 2, option>> grid_matrix(grid_data, narrow<size_t>(H * W), 2);
+  Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, 2, option>> grid_matrix(grid_data, SafeInt<size_t>(H) * W, 2);
   grid_matrix = ((theta_R * base_grid_transposed).array().colwise() + theta_T).matrix().transpose();  // ((2x2 * 2xN).array().colwise() + 2x1).matrix().transpose() => Nx2
 }
 
@@ -97,9 +98,9 @@ void affine_grid_generator_3d(const Tensor* theta, const Eigen::Matrix<T, 3, Eig
 
   const Eigen::Array<T, 3, 1> theta_T(theta_data[3], theta_data[7], theta_data[11]);  // 3x1
 
-  auto grid_batch_offset = batch_num * D * H * W * 3;
+  auto grid_batch_offset = SafeInt<size_t>(batch_num) * D * H * W * 3;
   T* grid_data = grid->MutableData<T>() + grid_batch_offset;
-  Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, 3, option>> grid_matrix(grid_data, narrow<size_t>(D * H * W), 3);
+  Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, 3, option>> grid_matrix(grid_data, SafeInt<size_t>(D) * H * W, 3);
   grid_matrix = ((theta_R * base_grid_transposed).array().colwise() + theta_T).matrix().transpose();
 }
 

--- a/onnxruntime/core/providers/cpu/tensor/affine_grid.cc
+++ b/onnxruntime/core/providers/cpu/tensor/affine_grid.cc
@@ -79,9 +79,10 @@ void affine_grid_generator_2d(const Tensor* theta, const Eigen::Matrix<T, 2, Eig
   const Eigen::Matrix<T, 2, 2, option> theta_R{{theta_data[0], theta_data[1]}, {theta_data[3], theta_data[4]}};  // 2x2
   const Eigen::Array<T, 2, 1> theta_T(theta_data[2], theta_data[5]);                                             // 2x1
 
-  size_t grid_batch_offset = SafeInt<size_t>(batch_num) * H * W * 2;
+  const auto grid_batch_offset = static_cast<size_t>(SafeInt<size_t>(batch_num) * H * W * 2);
   T* grid_data = grid->MutableData<T>() + grid_batch_offset;
-  Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, 2, option>> grid_matrix(grid_data, static_cast<size_t>(SafeInt<size_t>(H) * W), 2);
+  Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, 2, option>> grid_matrix(
+      grid_data, static_cast<size_t>(SafeInt<size_t>(H) * W), 2);
   grid_matrix = ((theta_R * base_grid_transposed).array().colwise() + theta_T).matrix().transpose();  // ((2x2 * 2xN).array().colwise() + 2x1).matrix().transpose() => Nx2
 }
 
@@ -98,9 +99,10 @@ void affine_grid_generator_3d(const Tensor* theta, const Eigen::Matrix<T, 3, Eig
 
   const Eigen::Array<T, 3, 1> theta_T(theta_data[3], theta_data[7], theta_data[11]);  // 3x1
 
-  size_t grid_batch_offset = SafeInt<size_t>(batch_num) * D * H * W * 3;
+  const auto grid_batch_offset = static_cast<size_t>(SafeInt<size_t>(batch_num) * D * H * W * 3);
   T* grid_data = grid->MutableData<T>() + grid_batch_offset;
-  Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, 3, option>> grid_matrix(grid_data, static_cast<size_t>(SafeInt<size_t>(D) * H * W), 3);
+  Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, 3, option>> grid_matrix(
+      grid_data, static_cast<size_t>(SafeInt<size_t>(D) * H * W), 3);
   grid_matrix = ((theta_R * base_grid_transposed).array().colwise() + theta_T).matrix().transpose();
 }
 

--- a/onnxruntime/core/providers/cpu/tensor/affine_grid.cc
+++ b/onnxruntime/core/providers/cpu/tensor/affine_grid.cc
@@ -79,9 +79,9 @@ void affine_grid_generator_2d(const Tensor* theta, const Eigen::Matrix<T, 2, Eig
   const Eigen::Matrix<T, 2, 2, option> theta_R{{theta_data[0], theta_data[1]}, {theta_data[3], theta_data[4]}};  // 2x2
   const Eigen::Array<T, 2, 1> theta_T(theta_data[2], theta_data[5]);                                             // 2x1
 
-  auto grid_batch_offset = SafeInt<size_t>(batch_num) * H * W * 2;
+  size_t grid_batch_offset = SafeInt<size_t>(batch_num) * H * W * 2;
   T* grid_data = grid->MutableData<T>() + grid_batch_offset;
-  Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, 2, option>> grid_matrix(grid_data, SafeInt<size_t>(H) * W, 2);
+  Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, 2, option>> grid_matrix(grid_data, static_cast<size_t>(SafeInt<size_t>(H) * W), 2);
   grid_matrix = ((theta_R * base_grid_transposed).array().colwise() + theta_T).matrix().transpose();  // ((2x2 * 2xN).array().colwise() + 2x1).matrix().transpose() => Nx2
 }
 
@@ -98,9 +98,9 @@ void affine_grid_generator_3d(const Tensor* theta, const Eigen::Matrix<T, 3, Eig
 
   const Eigen::Array<T, 3, 1> theta_T(theta_data[3], theta_data[7], theta_data[11]);  // 3x1
 
-  auto grid_batch_offset = SafeInt<size_t>(batch_num) * D * H * W * 3;
+  size_t grid_batch_offset = SafeInt<size_t>(batch_num) * D * H * W * 3;
   T* grid_data = grid->MutableData<T>() + grid_batch_offset;
-  Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, 3, option>> grid_matrix(grid_data, SafeInt<size_t>(D) * H * W, 3);
+  Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, 3, option>> grid_matrix(grid_data, static_cast<size_t>(SafeInt<size_t>(D) * H * W), 3);
   grid_matrix = ((theta_R * base_grid_transposed).array().colwise() + theta_T).matrix().transpose();
 }
 

--- a/onnxruntime/core/providers/cpu/tensor/grid_sample.cc
+++ b/onnxruntime/core/providers/cpu/tensor/grid_sample.cc
@@ -384,9 +384,10 @@ Status GridSample<T>::Compute(OpKernelContext* context) const {
         concurrency::ThreadPool::TrySimpleParallelFor(
             tp, onnxruntime::narrow<std::ptrdiff_t>(C),
             [&](std::ptrdiff_t c) {
+              const SafeInt<size_t> nc = SafeInt<size_t>(n) * SafeInt<size_t>(C) + SafeInt<size_t>(c);
               const T* X_data =
-                  input->Data<T>() + static_cast<size_t>(SafeInt<size_t>(n * C + c) * H_in * W_in);
-              T* Y_data = Y.MutableData<T>() + static_cast<size_t>(SafeInt<size_t>(n * C + c) * H_out * W_out);
+                  input->Data<T>() + static_cast<size_t>(nc * H_in * W_in);
+              T* Y_data = Y.MutableData<T>() + static_cast<size_t>(nc * H_out * W_out);
 
               for (int64_t oy = 0; oy < H_out; oy++) {
                 for (int64_t ox = 0; ox < W_out; ox++) {
@@ -475,10 +476,11 @@ Status GridSample<T>::Compute(OpKernelContext* context) const {
       concurrency::ThreadPool::TrySimpleParallelFor(
           tp, onnxruntime::narrow<std::ptrdiff_t>(C),
           [&](std::ptrdiff_t c) {
+            const SafeInt<size_t> plane_index = SafeInt<size_t>(n) * SafeInt<size_t>(C) + SafeInt<size_t>(c);
             const T* X_data =
-                input->Data<T>() + static_cast<size_t>(SafeInt<size_t>(n * C + c) * D_in * H_in * W_in);
+                input->Data<T>() + static_cast<size_t>(plane_index * SafeInt<size_t>(D_in) * SafeInt<size_t>(H_in) * SafeInt<size_t>(W_in));
             T* Y_data =
-                Y.MutableData<T>() + static_cast<size_t>(SafeInt<size_t>(n * C + c) * D_out * H_out * W_out);
+                Y.MutableData<T>() + static_cast<size_t>(plane_index * SafeInt<size_t>(D_out) * SafeInt<size_t>(H_out) * SafeInt<size_t>(W_out));
 
             for (int64_t oz = 0; oz < D_out; oz++) {
               for (int64_t oy = 0; oy < H_out; oy++) {

--- a/onnxruntime/core/providers/cpu/tensor/grid_sample.cc
+++ b/onnxruntime/core/providers/cpu/tensor/grid_sample.cc
@@ -384,7 +384,8 @@ Status GridSample<T>::Compute(OpKernelContext* context) const {
         concurrency::ThreadPool::TrySimpleParallelFor(
             tp, onnxruntime::narrow<std::ptrdiff_t>(C),
             [&](std::ptrdiff_t c) {
-              const T* X_data = input->Data<T>() + static_cast<size_t>(SafeInt<size_t>(n * C + c) * H_in * W_in);
+              const T* X_data =
+                  input->Data<T>() + static_cast<size_t>(SafeInt<size_t>(n * C + c) * H_in * W_in);
               T* Y_data = Y.MutableData<T>() + static_cast<size_t>(SafeInt<size_t>(n * C + c) * H_out * W_out);
 
               for (int64_t oy = 0; oy < H_out; oy++) {
@@ -474,8 +475,10 @@ Status GridSample<T>::Compute(OpKernelContext* context) const {
       concurrency::ThreadPool::TrySimpleParallelFor(
           tp, onnxruntime::narrow<std::ptrdiff_t>(C),
           [&](std::ptrdiff_t c) {
-            const T* X_data = input->Data<T>() + static_cast<size_t>(SafeInt<size_t>(n * C + c) * D_in * H_in * W_in);
-            T* Y_data = Y.MutableData<T>() + static_cast<size_t>(SafeInt<size_t>(n * C + c) * D_out * H_out * W_out);
+            const T* X_data =
+                input->Data<T>() + static_cast<size_t>(SafeInt<size_t>(n * C + c) * D_in * H_in * W_in);
+            T* Y_data =
+                Y.MutableData<T>() + static_cast<size_t>(SafeInt<size_t>(n * C + c) * D_out * H_out * W_out);
 
             for (int64_t oz = 0; oz < D_out; oz++) {
               for (int64_t oy = 0; oy < H_out; oy++) {

--- a/onnxruntime/core/providers/cpu/tensor/grid_sample.cc
+++ b/onnxruntime/core/providers/cpu/tensor/grid_sample.cc
@@ -3,6 +3,7 @@
 
 #include <vector>
 
+#include "core/common/safeint.h"
 #include "core/providers/cpu/tensor/grid_sample.h"
 #include "core/framework/element_type_lists.h"
 #include "core/framework/TensorSeq.h"
@@ -379,12 +380,12 @@ Status GridSample<T>::Compute(OpKernelContext* context) const {
       }
     } else {
       for (int64_t n = 0; n < N; n++) {
-        const T* grid_data = grid->Data<T>() + n * (H_out * W_out) * 2;
+        const T* grid_data = grid->Data<T>() + SafeInt<size_t>(n) * H_out * W_out * 2;
         concurrency::ThreadPool::TrySimpleParallelFor(
             tp, onnxruntime::narrow<std::ptrdiff_t>(C),
             [&](std::ptrdiff_t c) {
-              const T* X_data = input->Data<T>() + (n * C + c) * (H_in * W_in);
-              T* Y_data = Y.MutableData<T>() + (n * C + c) * (H_out * W_out);
+              const T* X_data = input->Data<T>() + SafeInt<size_t>(n * C + c) * H_in * W_in;
+              T* Y_data = Y.MutableData<T>() + SafeInt<size_t>(n * C + c) * H_out * W_out;
 
               for (int64_t oy = 0; oy < H_out; oy++) {
                 for (int64_t ox = 0; ox < W_out; ox++) {
@@ -469,12 +470,12 @@ Status GridSample<T>::Compute(OpKernelContext* context) const {
 
     concurrency::ThreadPool* tp = D_out * H_out * W_out > 64 ? context->GetOperatorThreadPool() : nullptr;
     for (int64_t n = 0; n < N; n++) {
-      const T* grid_data = grid->Data<T>() + n * (D_out * H_out * W_out) * 3;
+      const T* grid_data = grid->Data<T>() + SafeInt<size_t>(n) * D_out * H_out * W_out * 3;
       concurrency::ThreadPool::TrySimpleParallelFor(
           tp, onnxruntime::narrow<std::ptrdiff_t>(C),
           [&](std::ptrdiff_t c) {
-            const T* X_data = input->Data<T>() + (n * C + c) * (D_in * H_in * W_in);
-            T* Y_data = Y.MutableData<T>() + (n * C + c) * (D_out * H_out * W_out);
+            const T* X_data = input->Data<T>() + SafeInt<size_t>(n * C + c) * D_in * H_in * W_in;
+            T* Y_data = Y.MutableData<T>() + SafeInt<size_t>(n * C + c) * D_out * H_out * W_out;
 
             for (int64_t oz = 0; oz < D_out; oz++) {
               for (int64_t oy = 0; oy < H_out; oy++) {

--- a/onnxruntime/core/providers/cpu/tensor/grid_sample.cc
+++ b/onnxruntime/core/providers/cpu/tensor/grid_sample.cc
@@ -476,11 +476,13 @@ Status GridSample<T>::Compute(OpKernelContext* context) const {
       concurrency::ThreadPool::TrySimpleParallelFor(
           tp, onnxruntime::narrow<std::ptrdiff_t>(C),
           [&](std::ptrdiff_t c) {
-            const SafeInt<size_t> plane_index = SafeInt<size_t>(n) * SafeInt<size_t>(C) + SafeInt<size_t>(c);
+            const SafeInt<size_t> nc = SafeInt<size_t>(n) * SafeInt<size_t>(C) + SafeInt<size_t>(c);
+            const SafeInt<size_t> input_plane_offset = nc * SafeInt<size_t>(D_in) * SafeInt<size_t>(H_in) * SafeInt<size_t>(W_in);
+            const SafeInt<size_t> output_plane_offset = nc * SafeInt<size_t>(D_out) * SafeInt<size_t>(H_out) * SafeInt<size_t>(W_out);
             const T* X_data =
-                input->Data<T>() + static_cast<size_t>(plane_index * SafeInt<size_t>(D_in) * SafeInt<size_t>(H_in) * SafeInt<size_t>(W_in));
+                input->Data<T>() + static_cast<size_t>(input_plane_offset);
             T* Y_data =
-                Y.MutableData<T>() + static_cast<size_t>(plane_index * SafeInt<size_t>(D_out) * SafeInt<size_t>(H_out) * SafeInt<size_t>(W_out));
+                Y.MutableData<T>() + static_cast<size_t>(output_plane_offset);
 
             for (int64_t oz = 0; oz < D_out; oz++) {
               for (int64_t oy = 0; oy < H_out; oy++) {

--- a/onnxruntime/core/providers/cpu/tensor/grid_sample.cc
+++ b/onnxruntime/core/providers/cpu/tensor/grid_sample.cc
@@ -380,12 +380,12 @@ Status GridSample<T>::Compute(OpKernelContext* context) const {
       }
     } else {
       for (int64_t n = 0; n < N; n++) {
-        const T* grid_data = grid->Data<T>() + SafeInt<size_t>(n) * H_out * W_out * 2;
+        const T* grid_data = grid->Data<T>() + static_cast<size_t>(SafeInt<size_t>(n) * H_out * W_out * 2);
         concurrency::ThreadPool::TrySimpleParallelFor(
             tp, onnxruntime::narrow<std::ptrdiff_t>(C),
             [&](std::ptrdiff_t c) {
-              const T* X_data = input->Data<T>() + SafeInt<size_t>(n * C + c) * H_in * W_in;
-              T* Y_data = Y.MutableData<T>() + SafeInt<size_t>(n * C + c) * H_out * W_out;
+              const T* X_data = input->Data<T>() + static_cast<size_t>(SafeInt<size_t>(n * C + c) * H_in * W_in);
+              T* Y_data = Y.MutableData<T>() + static_cast<size_t>(SafeInt<size_t>(n * C + c) * H_out * W_out);
 
               for (int64_t oy = 0; oy < H_out; oy++) {
                 for (int64_t ox = 0; ox < W_out; ox++) {
@@ -470,12 +470,12 @@ Status GridSample<T>::Compute(OpKernelContext* context) const {
 
     concurrency::ThreadPool* tp = D_out * H_out * W_out > 64 ? context->GetOperatorThreadPool() : nullptr;
     for (int64_t n = 0; n < N; n++) {
-      const T* grid_data = grid->Data<T>() + SafeInt<size_t>(n) * D_out * H_out * W_out * 3;
+      const T* grid_data = grid->Data<T>() + static_cast<size_t>(SafeInt<size_t>(n) * D_out * H_out * W_out * 3);
       concurrency::ThreadPool::TrySimpleParallelFor(
           tp, onnxruntime::narrow<std::ptrdiff_t>(C),
           [&](std::ptrdiff_t c) {
-            const T* X_data = input->Data<T>() + SafeInt<size_t>(n * C + c) * D_in * H_in * W_in;
-            T* Y_data = Y.MutableData<T>() + SafeInt<size_t>(n * C + c) * D_out * H_out * W_out;
+            const T* X_data = input->Data<T>() + static_cast<size_t>(SafeInt<size_t>(n * C + c) * D_in * H_in * W_in);
+            T* Y_data = Y.MutableData<T>() + static_cast<size_t>(SafeInt<size_t>(n * C + c) * D_out * H_out * W_out);
 
             for (int64_t oz = 0; oz < D_out; oz++) {
               for (int64_t oy = 0; oy < H_out; oy++) {

--- a/onnxruntime/core/providers/cpu/tensor/upsample_antialias.h
+++ b/onnxruntime/core/providers/cpu/tensor/upsample_antialias.h
@@ -254,16 +254,16 @@ void ComputeInterpolationAtLevel1(int64_t num_channels, int64_t input_height, in
   concurrency::ThreadPool::TrySimpleParallelFor(
       tp, narrow<std::ptrdiff_t>(num_channels),
       [&](std::ptrdiff_t c) {
-        auto x_start = c * (input_height * input_width);
-        auto y_start = c * (output_height * output_width);
+        const auto x_start = static_cast<size_t>(SafeInt<size_t>(c) * input_height * input_width);
+        const auto y_start = static_cast<size_t>(SafeInt<size_t>(c) * output_height * output_width);
 
         const InputType* Xdata = Xdata_span.data() + x_start;
         InputType* Ydata = Ydata_span.data() + y_start;
         // no need to do scale
         if (output_width == input_width) {
-          std::copy_n(Xdata_span.begin() + narrow<size_t>(x_start),
+          std::copy_n(Xdata_span.begin() + x_start,
                       static_cast<size_t>(SafeInt<size_t>(output_height) * output_width),
-                      Ydata_span.begin() + narrow<size_t>(y_start));
+                      Ydata_span.begin() + y_start);
           return;
         }
 
@@ -325,16 +325,16 @@ void ComputeInterpolationAtLevel2(int64_t num_channels, int64_t input_height, in
     concurrency::ThreadPool::TrySimpleParallelFor(
         tp, narrow<std::ptrdiff_t>(num_channels),
         [&](std::ptrdiff_t c) {
-          auto x_start = c * (input_height * input_width);
-          auto y_start = c * (output_height * output_width);
+          const auto x_start = static_cast<size_t>(SafeInt<size_t>(c) * input_height * input_width);
+          const auto y_start = static_cast<size_t>(SafeInt<size_t>(c) * output_height * output_width);
 
           const InputType* Xdata = Xdata_span.data() + x_start;
           InputType* Ydata = Ydata_span.data() + y_start;
 
           if (output_height == input_height) {
-            std::copy_n(Xdata_span.begin() + narrow<size_t>(x_start),
+            std::copy_n(Xdata_span.begin() + x_start,
                         static_cast<size_t>(SafeInt<size_t>(output_height) * output_width),
-                        Ydata_span.begin() + narrow<size_t>(y_start));
+                        Ydata_span.begin() + y_start);
             return;
           }
 
@@ -382,8 +382,8 @@ void ComputeInterpolationAtLevel2(int64_t num_channels, int64_t input_height, in
             auto c = start / output_height;
             auto y = start % output_height;
 
-            auto x_start = c * (input_height * input_width);
-            auto y_start = c * (output_height * output_width);
+            const auto x_start = static_cast<size_t>(SafeInt<size_t>(c) * input_height * input_width);
+            const auto y_start = static_cast<size_t>(SafeInt<size_t>(c) * output_height * output_width);
 
             const InputType* Xdata = Xdata_span.data() + x_start;
             InputType* Ydata = Ydata_span.data() + y_start;
@@ -425,11 +425,13 @@ void HandleExtrapolation(int64_t num_channels,
   concurrency::ThreadPool::TrySimpleParallelFor(
       tp, static_cast<std::ptrdiff_t>(num_channels),
       [&](std::ptrdiff_t nc) {
-        InputType* Ydata_base_nc = Ydata_span.data() + (nc) * (output_depth * output_height * output_width);
+        InputType* Ydata_base_nc =
+            Ydata_span.data() + static_cast<size_t>(SafeInt<size_t>(nc) * output_depth * output_height * output_width);
 
         for (int64_t z = 0; z < output_depth && p.dim_x.out_of_bound_idx.size() > 0; ++z) {
           for (int64_t y = 0; y < output_height; ++y) {
-            InputType* Ydata_offset = Ydata_base_nc + (z * output_height + y) * output_width;
+            const auto offset = static_cast<size_t>((SafeInt<size_t>(z) * output_height + y) * output_width);
+            InputType* Ydata_offset = Ydata_base_nc + offset;
             for (int64_t idx_x : p.dim_x.out_of_bound_idx) {
               Ydata_offset[narrow<size_t>(idx_x)] = static_cast<InputType>(extrapolation_value);
             }
@@ -438,13 +440,15 @@ void HandleExtrapolation(int64_t num_channels,
 
         for (int64_t z = 0; z < output_depth && p.dim_y.out_of_bound_idx.size() > 0; ++z) {
           for (int64_t y : p.dim_y.out_of_bound_idx) {
-            InputType* Ydata_offset = Ydata_base_nc + (z * output_height + y) * output_width;
+            const auto offset = static_cast<size_t>((SafeInt<size_t>(z) * output_height + y) * output_width);
+            InputType* Ydata_offset = Ydata_base_nc + offset;
             std::fill_n(Ydata_offset, narrow<size_t>(output_width), static_cast<InputType>(extrapolation_value));
           }
         }
 
         for (int64_t z : p.dim_z.out_of_bound_idx) {
-          InputType* Ydata_offset = Ydata_base_nc + z * output_height * output_width;
+          InputType* Ydata_offset =
+              Ydata_base_nc + static_cast<size_t>(SafeInt<size_t>(z) * output_height * output_width);
           std::fill_n(Ydata_offset, static_cast<size_t>(SafeInt<size_t>(output_height) * output_width),
                       static_cast<InputType>(extrapolation_value));
         }

--- a/onnxruntime/core/providers/cpu/tensor/upsample_antialias.h
+++ b/onnxruntime/core/providers/cpu/tensor/upsample_antialias.h
@@ -17,6 +17,7 @@
 #ifndef SHARED_PROVIDER
 #include "core/framework/op_kernel.h"
 #endif
+#include "core/common/safeint.h"
 #include "core/providers/cpu/tensor/upsamplebase.h"
 
 namespace onnxruntime {
@@ -130,7 +131,7 @@ void SetupUpsampleFilterAntiAlias(FilterParamsAntiAlias<T>& p,
     float support = (scale >= 1.0f) ? (p.support_size * 0.5f) * scale : p.support_size * 0.5f;
 
     int32_t window_size = narrow<int32_t>(ceilf(support)) * 2 + 1;
-    const size_t scale_buffer_size = narrow<size_t>(window_size * output_size);
+    const size_t scale_buffer_size = SafeInt<size_t>(window_size) * output_size;
 
     param_base.weight_coefficients = IAllocator::MakeUniquePtr<T>(alloc, scale_buffer_size);
     // Get pointers to appropriate memory locations in the scratch buffer
@@ -260,7 +261,7 @@ void ComputeInterpolationAtLevel1(int64_t num_channels, int64_t input_height, in
         InputType* Ydata = Ydata_span.data() + y_start;
         // no need to do scale
         if (output_width == input_width) {
-          std::copy_n(Xdata_span.begin() + narrow<size_t>(x_start), narrow<size_t>(output_height * output_width),
+          std::copy_n(Xdata_span.begin() + narrow<size_t>(x_start), SafeInt<size_t>(output_height) * output_width,
                       Ydata_span.begin() + narrow<size_t>(y_start));
           return;
         }
@@ -330,7 +331,7 @@ void ComputeInterpolationAtLevel2(int64_t num_channels, int64_t input_height, in
           InputType* Ydata = Ydata_span.data() + y_start;
 
           if (output_height == input_height) {
-            std::copy_n(Xdata_span.begin() + narrow<size_t>(x_start), narrow<size_t>(output_height * output_width),
+            std::copy_n(Xdata_span.begin() + narrow<size_t>(x_start), SafeInt<size_t>(output_height) * output_width,
                         Ydata_span.begin() + narrow<size_t>(y_start));
             return;
           }
@@ -368,8 +369,8 @@ void ComputeInterpolationAtLevel2(int64_t num_channels, int64_t input_height, in
         [&](std::ptrdiff_t first, std::ptrdiff_t last) {
           if (output_height == input_height) {
             auto workload_in_thread = narrow<size_t>(last) - narrow<size_t>(first);
-            std::copy_n(Xdata_span.begin() + narrow<size_t>(first * input_width), narrow<size_t>(workload_in_thread * output_width),
-                        Ydata_span.begin() + narrow<size_t>(first * output_width));
+            std::copy_n(Xdata_span.begin() + SafeInt<size_t>(first) * input_width, SafeInt<size_t>(workload_in_thread) * output_width,
+                        Ydata_span.begin() + SafeInt<size_t>(first) * output_width);
             return;
           }
 
@@ -440,7 +441,7 @@ void HandleExtrapolation(int64_t num_channels,
 
         for (int64_t z : p.dim_z.out_of_bound_idx) {
           InputType* Ydata_offset = Ydata_base_nc + z * output_height * output_width;
-          std::fill_n(Ydata_offset, narrow<size_t>(output_height * output_width), static_cast<InputType>(extrapolation_value));
+          std::fill_n(Ydata_offset, SafeInt<size_t>(output_height) * output_width, static_cast<InputType>(extrapolation_value));
         }
       });
 }
@@ -460,14 +461,14 @@ void UpsampleBaseAntiAlias(FilterParamsAntiAlias<T1>& p,
                            AllocatorPtr& alloc,
                            concurrency::ThreadPool* tp) {
   IAllocatorUniquePtr<T> image_temp_buffer = IAllocator::MakeUniquePtr<T>(
-      alloc, static_cast<size_t>(input_height * output_width * num_channels));
+      alloc, SafeInt<size_t>(input_height) * output_width * num_channels);
 
   for (int64_t n = 0; n < batch_size; ++n) {
     {
       // horizon interpolate
       auto xdata_span = gsl::make_span(Xdata_base + n * (input_height * num_channels * input_width),
-                                       narrow<size_t>(input_height * num_channels * input_width));
-      auto ydata_span = gsl::make_span(image_temp_buffer.get(), narrow<size_t>(input_height * num_channels * output_width));
+                                       SafeInt<size_t>(input_height) * num_channels * input_width);
+      auto ydata_span = gsl::make_span(image_temp_buffer.get(), SafeInt<size_t>(input_height) * num_channels * output_width);
 
       // This computes only the width direction.Thus height keeps unchanged.
       ComputeInterpolationAtLevel1(num_channels, input_height, input_width, input_height, output_width,
@@ -476,9 +477,9 @@ void UpsampleBaseAntiAlias(FilterParamsAntiAlias<T1>& p,
     {
       // vertical interpolate
       auto xdata_span = gsl::make_span<const T>(image_temp_buffer.get(),
-                                                narrow<size_t>(input_height * num_channels * output_width));
+                                                SafeInt<size_t>(input_height) * num_channels * output_width);
       auto ydata_span = gsl::make_span<T>(Ydata_base + n * (output_height * num_channels * output_width),
-                                          narrow<size_t>(output_height * num_channels * output_width));
+                                          SafeInt<size_t>(output_height) * num_channels * output_width);
 
       ComputeInterpolationAtLevel2(num_channels, input_height, output_width, output_height, output_width,
                                    xdata_span, ydata_span, p, p.dim_y, tp);
@@ -486,7 +487,7 @@ void UpsampleBaseAntiAlias(FilterParamsAntiAlias<T1>& p,
   }
   if (use_extrapolation) {
     auto ydata_span = gsl::make_span<T>(Ydata_base,
-                                        narrow<size_t>(batch_size * output_height * num_channels * output_width));
+                                        SafeInt<size_t>(batch_size) * output_height * num_channels * output_width);
     HandleExtrapolation(batch_size * num_channels, output_height, output_width, 1,
                         extrapolation_value, ydata_span, p, tp);
   }
@@ -596,14 +597,14 @@ void NhwcUpsampleBasicAntiAlias(FilterParamsAntiAlias<T1>& p,
                                 AllocatorPtr& alloc,
                                 concurrency::ThreadPool* tp) {
   IAllocatorUniquePtr<T> image_temp_buffer = IAllocator::MakeUniquePtr<T>(
-      alloc, static_cast<size_t>(input_height * output_width * num_channels));
+      alloc, SafeInt<size_t>(input_height) * output_width * num_channels);
 
   for (int64_t n = 0; n < batch_size; ++n) {
     // horizon interpolate
     {
       auto xdata_span = gsl::make_span(Xdata_base + n * (input_height * num_channels * input_width),
-                                       narrow<size_t>(input_height * num_channels * input_width));
-      auto ydata_span = gsl::make_span(image_temp_buffer.get(), narrow<size_t>(input_height * num_channels * output_width));
+                                       SafeInt<size_t>(input_height) * num_channels * input_width);
+      auto ydata_span = gsl::make_span(image_temp_buffer.get(), SafeInt<size_t>(input_height) * num_channels * output_width);
 
       ComputeInterpolationAtLevel2(input_height, input_width, num_channels, output_width, num_channels,
                                    xdata_span, ydata_span, p, p.dim_x, tp);
@@ -613,9 +614,9 @@ void NhwcUpsampleBasicAntiAlias(FilterParamsAntiAlias<T1>& p,
     {
       // vertical interpolate
       auto xdata_span = gsl::make_span<const T>(image_temp_buffer.get(),
-                                                narrow<size_t>(input_height * num_channels * output_width));
+                                                SafeInt<size_t>(input_height) * num_channels * output_width);
       auto ydata_span = gsl::make_span<T>(Ydata_base + n * (output_height * num_channels * output_width),
-                                          narrow<size_t>(output_height * num_channels * output_width));
+                                          SafeInt<size_t>(output_height) * num_channels * output_width);
 
       ComputeInterpolationAtLevel2(1, input_height, output_width * num_channels, output_height, output_width * num_channels,
                                    xdata_span, ydata_span, p, p.dim_y, tp);
@@ -624,7 +625,7 @@ void NhwcUpsampleBasicAntiAlias(FilterParamsAntiAlias<T1>& p,
 
   if (use_extrapolation) {
     auto ydata_span = gsl::make_span<T>(Ydata_base,
-                                        narrow<size_t>(batch_size * output_height * num_channels * output_width));
+                                        SafeInt<size_t>(batch_size) * output_height * num_channels * output_width);
     HandleExtrapolation(batch_size * num_channels, output_height, output_width, 1,
                         extrapolation_value, ydata_span, p, tp);
   }
@@ -692,8 +693,8 @@ void UpsampleTrilinearAntiAlias(int64_t batch_size,
                                alloc, get_original_coordinate, exclude_outside, true);
 
   IAllocatorUniquePtr<T> image_temp_buffer = IAllocator::MakeUniquePtr<T>(
-      alloc, static_cast<size_t>(batch_size * output_height * output_width *
-                                 input_depth * num_channels));
+      alloc, SafeInt<size_t>(batch_size) * output_height * output_width *
+                 input_depth * num_channels);
 
   UpsampleBaseAntiAlias<T>(p, batch_size, num_channels * input_depth, input_height, input_width, output_height, output_width,
                            false, extrapolation_value,
@@ -706,9 +707,9 @@ void UpsampleTrilinearAntiAlias(int64_t batch_size,
     {
       // depth interpolate
       auto xdata_span = gsl::make_span<const T>(image_temp_buffer.get() + n * (output_height * num_channels * output_width * input_depth),
-                                                narrow<size_t>(output_height * num_channels * output_width * input_depth));
+                                                SafeInt<size_t>(output_height) * num_channels * output_width * input_depth);
       auto ydata_span = gsl::make_span<T>(Ydata_base + n * (output_height * num_channels * output_width * output_depth),
-                                          narrow<size_t>(output_height * num_channels * output_width * output_depth));
+                                          SafeInt<size_t>(output_height) * num_channels * output_width * output_depth);
 
       ComputeInterpolationAtLevel2(m_channel_size, input_depth, output_height * output_width, output_depth, output_height * output_width,
                                    xdata_span, ydata_span, p, p.dim_z, tp);
@@ -717,7 +718,7 @@ void UpsampleTrilinearAntiAlias(int64_t batch_size,
 
   if (use_extrapolation) {
     auto ydata_span = gsl::make_span<T>(Ydata_base,
-                                        narrow<size_t>(batch_size * output_height * num_channels * output_width * output_depth));
+                                        SafeInt<size_t>(batch_size) * output_height * num_channels * output_width * output_depth);
     HandleExtrapolation(batch_size * num_channels, output_height, output_width, output_depth,
                         extrapolation_value, ydata_span, p, tp);
   }

--- a/onnxruntime/core/providers/cpu/tensor/upsample_antialias.h
+++ b/onnxruntime/core/providers/cpu/tensor/upsample_antialias.h
@@ -254,8 +254,8 @@ void ComputeInterpolationAtLevel1(int64_t num_channels, int64_t input_height, in
   concurrency::ThreadPool::TrySimpleParallelFor(
       tp, narrow<std::ptrdiff_t>(num_channels),
       [&](std::ptrdiff_t c) {
-        const auto x_start = static_cast<size_t>(SafeInt<size_t>(c) * input_height * input_width);
-        const auto y_start = static_cast<size_t>(SafeInt<size_t>(c) * output_height * output_width);
+        const size_t x_start = SafeInt<size_t>(c) * input_height * input_width;
+        const size_t y_start = SafeInt<size_t>(c) * output_height * output_width;
 
         const InputType* Xdata = Xdata_span.data() + x_start;
         InputType* Ydata = Ydata_span.data() + y_start;
@@ -325,8 +325,8 @@ void ComputeInterpolationAtLevel2(int64_t num_channels, int64_t input_height, in
     concurrency::ThreadPool::TrySimpleParallelFor(
         tp, narrow<std::ptrdiff_t>(num_channels),
         [&](std::ptrdiff_t c) {
-          const auto x_start = static_cast<size_t>(SafeInt<size_t>(c) * input_height * input_width);
-          const auto y_start = static_cast<size_t>(SafeInt<size_t>(c) * output_height * output_width);
+          const size_t x_start = SafeInt<size_t>(c) * input_height * input_width;
+          const size_t y_start = SafeInt<size_t>(c) * output_height * output_width;
 
           const InputType* Xdata = Xdata_span.data() + x_start;
           InputType* Ydata = Ydata_span.data() + y_start;
@@ -382,8 +382,8 @@ void ComputeInterpolationAtLevel2(int64_t num_channels, int64_t input_height, in
             auto c = start / output_height;
             auto y = start % output_height;
 
-            const auto x_start = static_cast<size_t>(SafeInt<size_t>(c) * input_height * input_width);
-            const auto y_start = static_cast<size_t>(SafeInt<size_t>(c) * output_height * output_width);
+            const size_t x_start = SafeInt<size_t>(c) * input_height * input_width;
+            const size_t y_start = SafeInt<size_t>(c) * output_height * output_width;
 
             const InputType* Xdata = Xdata_span.data() + x_start;
             InputType* Ydata = Ydata_span.data() + y_start;
@@ -430,8 +430,8 @@ void HandleExtrapolation(int64_t num_channels,
 
         for (int64_t z = 0; z < output_depth && p.dim_x.out_of_bound_idx.size() > 0; ++z) {
           for (int64_t y = 0; y < output_height; ++y) {
-            const auto offset = static_cast<size_t>((SafeInt<size_t>(z) * output_height + y) * output_width);
-            InputType* Ydata_offset = Ydata_base_nc + offset;
+            const SafeInt<size_t> offset = (SafeInt<size_t>(z) * output_height + y) * output_width;
+            InputType* Ydata_offset = Ydata_base_nc + static_cast<size_t>(offset);
             for (int64_t idx_x : p.dim_x.out_of_bound_idx) {
               Ydata_offset[narrow<size_t>(idx_x)] = static_cast<InputType>(extrapolation_value);
             }
@@ -440,8 +440,8 @@ void HandleExtrapolation(int64_t num_channels,
 
         for (int64_t z = 0; z < output_depth && p.dim_y.out_of_bound_idx.size() > 0; ++z) {
           for (int64_t y : p.dim_y.out_of_bound_idx) {
-            const auto offset = static_cast<size_t>((SafeInt<size_t>(z) * output_height + y) * output_width);
-            InputType* Ydata_offset = Ydata_base_nc + offset;
+            const SafeInt<size_t> offset = (SafeInt<size_t>(z) * output_height + y) * output_width;
+            InputType* Ydata_offset = Ydata_base_nc + static_cast<size_t>(offset);
             std::fill_n(Ydata_offset, narrow<size_t>(output_width), static_cast<InputType>(extrapolation_value));
           }
         }

--- a/onnxruntime/core/providers/cpu/tensor/upsample_antialias.h
+++ b/onnxruntime/core/providers/cpu/tensor/upsample_antialias.h
@@ -131,7 +131,7 @@ void SetupUpsampleFilterAntiAlias(FilterParamsAntiAlias<T>& p,
     float support = (scale >= 1.0f) ? (p.support_size * 0.5f) * scale : p.support_size * 0.5f;
 
     int32_t window_size = narrow<int32_t>(ceilf(support)) * 2 + 1;
-    const size_t scale_buffer_size = SafeInt<size_t>(window_size) * output_size;
+    const size_t scale_buffer_size = static_cast<size_t>(SafeInt<size_t>(window_size) * output_size);
 
     param_base.weight_coefficients = IAllocator::MakeUniquePtr<T>(alloc, scale_buffer_size);
     // Get pointers to appropriate memory locations in the scratch buffer
@@ -261,7 +261,8 @@ void ComputeInterpolationAtLevel1(int64_t num_channels, int64_t input_height, in
         InputType* Ydata = Ydata_span.data() + y_start;
         // no need to do scale
         if (output_width == input_width) {
-          std::copy_n(Xdata_span.begin() + narrow<size_t>(x_start), SafeInt<size_t>(output_height) * output_width,
+          std::copy_n(Xdata_span.begin() + narrow<size_t>(x_start),
+                      static_cast<size_t>(SafeInt<size_t>(output_height) * output_width),
                       Ydata_span.begin() + narrow<size_t>(y_start));
           return;
         }
@@ -331,7 +332,8 @@ void ComputeInterpolationAtLevel2(int64_t num_channels, int64_t input_height, in
           InputType* Ydata = Ydata_span.data() + y_start;
 
           if (output_height == input_height) {
-            std::copy_n(Xdata_span.begin() + narrow<size_t>(x_start), SafeInt<size_t>(output_height) * output_width,
+            std::copy_n(Xdata_span.begin() + narrow<size_t>(x_start),
+                        static_cast<size_t>(SafeInt<size_t>(output_height) * output_width),
                         Ydata_span.begin() + narrow<size_t>(y_start));
             return;
           }
@@ -369,8 +371,10 @@ void ComputeInterpolationAtLevel2(int64_t num_channels, int64_t input_height, in
         [&](std::ptrdiff_t first, std::ptrdiff_t last) {
           if (output_height == input_height) {
             auto workload_in_thread = narrow<size_t>(last) - narrow<size_t>(first);
-            std::copy_n(Xdata_span.begin() + SafeInt<size_t>(first) * input_width, SafeInt<size_t>(workload_in_thread) * output_width,
-                        Ydata_span.begin() + SafeInt<size_t>(first) * output_width);
+            const auto input_offset = static_cast<size_t>(SafeInt<size_t>(first) * input_width);
+            const auto output_offset = static_cast<size_t>(SafeInt<size_t>(first) * output_width);
+            const auto copy_count = static_cast<size_t>(SafeInt<size_t>(workload_in_thread) * output_width);
+            std::copy_n(Xdata_span.begin() + input_offset, copy_count, Ydata_span.begin() + output_offset);
             return;
           }
 
@@ -441,7 +445,8 @@ void HandleExtrapolation(int64_t num_channels,
 
         for (int64_t z : p.dim_z.out_of_bound_idx) {
           InputType* Ydata_offset = Ydata_base_nc + z * output_height * output_width;
-          std::fill_n(Ydata_offset, SafeInt<size_t>(output_height) * output_width, static_cast<InputType>(extrapolation_value));
+          std::fill_n(Ydata_offset, static_cast<size_t>(SafeInt<size_t>(output_height) * output_width),
+                      static_cast<InputType>(extrapolation_value));
         }
       });
 }
@@ -460,15 +465,19 @@ void UpsampleBaseAntiAlias(FilterParamsAntiAlias<T1>& p,
                            T* Ydata_base,
                            AllocatorPtr& alloc,
                            concurrency::ThreadPool* tp) {
+  const auto input_span_size = static_cast<size_t>(SafeInt<size_t>(input_height) * num_channels * input_width);
+  const auto temp_span_size = static_cast<size_t>(SafeInt<size_t>(input_height) * num_channels * output_width);
+  const auto output_span_size = static_cast<size_t>(SafeInt<size_t>(output_height) * num_channels * output_width);
+
   IAllocatorUniquePtr<T> image_temp_buffer = IAllocator::MakeUniquePtr<T>(
-      alloc, SafeInt<size_t>(input_height) * output_width * num_channels);
+      alloc, temp_span_size);
 
   for (int64_t n = 0; n < batch_size; ++n) {
     {
       // horizon interpolate
-      auto xdata_span = gsl::make_span(Xdata_base + n * (input_height * num_channels * input_width),
-                                       SafeInt<size_t>(input_height) * num_channels * input_width);
-      auto ydata_span = gsl::make_span(image_temp_buffer.get(), SafeInt<size_t>(input_height) * num_channels * output_width);
+      auto xdata_span = gsl::make_span(Xdata_base + static_cast<size_t>(SafeInt<size_t>(n) * input_span_size),
+                                       input_span_size);
+      auto ydata_span = gsl::make_span(image_temp_buffer.get(), temp_span_size);
 
       // This computes only the width direction.Thus height keeps unchanged.
       ComputeInterpolationAtLevel1(num_channels, input_height, input_width, input_height, output_width,
@@ -476,10 +485,9 @@ void UpsampleBaseAntiAlias(FilterParamsAntiAlias<T1>& p,
     }
     {
       // vertical interpolate
-      auto xdata_span = gsl::make_span<const T>(image_temp_buffer.get(),
-                                                SafeInt<size_t>(input_height) * num_channels * output_width);
-      auto ydata_span = gsl::make_span<T>(Ydata_base + n * (output_height * num_channels * output_width),
-                                          SafeInt<size_t>(output_height) * num_channels * output_width);
+      auto xdata_span = gsl::make_span<const T>(image_temp_buffer.get(), temp_span_size);
+      auto ydata_span = gsl::make_span<T>(Ydata_base + static_cast<size_t>(SafeInt<size_t>(n) * output_span_size),
+                                          output_span_size);
 
       ComputeInterpolationAtLevel2(num_channels, input_height, output_width, output_height, output_width,
                                    xdata_span, ydata_span, p, p.dim_y, tp);
@@ -487,7 +495,7 @@ void UpsampleBaseAntiAlias(FilterParamsAntiAlias<T1>& p,
   }
   if (use_extrapolation) {
     auto ydata_span = gsl::make_span<T>(Ydata_base,
-                                        SafeInt<size_t>(batch_size) * output_height * num_channels * output_width);
+                                        static_cast<size_t>(SafeInt<size_t>(batch_size) * output_span_size));
     HandleExtrapolation(batch_size * num_channels, output_height, output_width, 1,
                         extrapolation_value, ydata_span, p, tp);
   }
@@ -596,15 +604,19 @@ void NhwcUpsampleBasicAntiAlias(FilterParamsAntiAlias<T1>& p,
                                 T* Ydata_base,
                                 AllocatorPtr& alloc,
                                 concurrency::ThreadPool* tp) {
+  const auto input_span_size = static_cast<size_t>(SafeInt<size_t>(input_height) * num_channels * input_width);
+  const auto temp_span_size = static_cast<size_t>(SafeInt<size_t>(input_height) * num_channels * output_width);
+  const auto output_span_size = static_cast<size_t>(SafeInt<size_t>(output_height) * num_channels * output_width);
+
   IAllocatorUniquePtr<T> image_temp_buffer = IAllocator::MakeUniquePtr<T>(
-      alloc, SafeInt<size_t>(input_height) * output_width * num_channels);
+      alloc, temp_span_size);
 
   for (int64_t n = 0; n < batch_size; ++n) {
     // horizon interpolate
     {
-      auto xdata_span = gsl::make_span(Xdata_base + n * (input_height * num_channels * input_width),
-                                       SafeInt<size_t>(input_height) * num_channels * input_width);
-      auto ydata_span = gsl::make_span(image_temp_buffer.get(), SafeInt<size_t>(input_height) * num_channels * output_width);
+      auto xdata_span = gsl::make_span(Xdata_base + static_cast<size_t>(SafeInt<size_t>(n) * input_span_size),
+                                       input_span_size);
+      auto ydata_span = gsl::make_span(image_temp_buffer.get(), temp_span_size);
 
       ComputeInterpolationAtLevel2(input_height, input_width, num_channels, output_width, num_channels,
                                    xdata_span, ydata_span, p, p.dim_x, tp);
@@ -613,10 +625,9 @@ void NhwcUpsampleBasicAntiAlias(FilterParamsAntiAlias<T1>& p,
     // vertical interpolate
     {
       // vertical interpolate
-      auto xdata_span = gsl::make_span<const T>(image_temp_buffer.get(),
-                                                SafeInt<size_t>(input_height) * num_channels * output_width);
-      auto ydata_span = gsl::make_span<T>(Ydata_base + n * (output_height * num_channels * output_width),
-                                          SafeInt<size_t>(output_height) * num_channels * output_width);
+      auto xdata_span = gsl::make_span<const T>(image_temp_buffer.get(), temp_span_size);
+      auto ydata_span = gsl::make_span<T>(Ydata_base + static_cast<size_t>(SafeInt<size_t>(n) * output_span_size),
+                                          output_span_size);
 
       ComputeInterpolationAtLevel2(1, input_height, output_width * num_channels, output_height, output_width * num_channels,
                                    xdata_span, ydata_span, p, p.dim_y, tp);
@@ -625,7 +636,7 @@ void NhwcUpsampleBasicAntiAlias(FilterParamsAntiAlias<T1>& p,
 
   if (use_extrapolation) {
     auto ydata_span = gsl::make_span<T>(Ydata_base,
-                                        SafeInt<size_t>(batch_size) * output_height * num_channels * output_width);
+                                        static_cast<size_t>(SafeInt<size_t>(batch_size) * output_span_size));
     HandleExtrapolation(batch_size * num_channels, output_height, output_width, 1,
                         extrapolation_value, ydata_span, p, tp);
   }
@@ -693,8 +704,8 @@ void UpsampleTrilinearAntiAlias(int64_t batch_size,
                                alloc, get_original_coordinate, exclude_outside, true);
 
   IAllocatorUniquePtr<T> image_temp_buffer = IAllocator::MakeUniquePtr<T>(
-      alloc, SafeInt<size_t>(batch_size) * output_height * output_width *
-                 input_depth * num_channels);
+      alloc, static_cast<size_t>(SafeInt<size_t>(batch_size) * output_height * output_width *
+                                 input_depth * num_channels));
 
   UpsampleBaseAntiAlias<T>(p, batch_size, num_channels * input_depth, input_height, input_width, output_height, output_width,
                            false, extrapolation_value,
@@ -702,14 +713,20 @@ void UpsampleTrilinearAntiAlias(int64_t batch_size,
 
   auto m_batch_size = batch_size * num_channels < tp->DegreeOfParallelism(tp) ? 1 : batch_size;
   auto m_channel_size = batch_size * num_channels < tp->DegreeOfParallelism(tp) ? num_channels * batch_size : num_channels;
+  const auto depth_input_span_size =
+      static_cast<size_t>(SafeInt<size_t>(output_height) * num_channels * output_width * input_depth);
+  const auto depth_output_span_size =
+      static_cast<size_t>(SafeInt<size_t>(output_height) * num_channels * output_width * output_depth);
   for (int64_t n = 0; n < m_batch_size; ++n) {
     // depth interpolate
     {
       // depth interpolate
-      auto xdata_span = gsl::make_span<const T>(image_temp_buffer.get() + n * (output_height * num_channels * output_width * input_depth),
-                                                SafeInt<size_t>(output_height) * num_channels * output_width * input_depth);
-      auto ydata_span = gsl::make_span<T>(Ydata_base + n * (output_height * num_channels * output_width * output_depth),
-                                          SafeInt<size_t>(output_height) * num_channels * output_width * output_depth);
+      auto xdata_span = gsl::make_span<const T>(
+          image_temp_buffer.get() + static_cast<size_t>(SafeInt<size_t>(n) * depth_input_span_size),
+          depth_input_span_size);
+      auto ydata_span = gsl::make_span<T>(
+          Ydata_base + static_cast<size_t>(SafeInt<size_t>(n) * depth_output_span_size),
+          depth_output_span_size);
 
       ComputeInterpolationAtLevel2(m_channel_size, input_depth, output_height * output_width, output_depth, output_height * output_width,
                                    xdata_span, ydata_span, p, p.dim_z, tp);
@@ -718,7 +735,7 @@ void UpsampleTrilinearAntiAlias(int64_t batch_size,
 
   if (use_extrapolation) {
     auto ydata_span = gsl::make_span<T>(Ydata_base,
-                                        SafeInt<size_t>(batch_size) * output_height * num_channels * output_width * output_depth);
+                                        static_cast<size_t>(SafeInt<size_t>(batch_size) * depth_output_span_size));
     HandleExtrapolation(batch_size * num_channels, output_height, output_width, output_depth,
                         extrapolation_value, ydata_span, p, tp);
   }


### PR DESCRIPTION
### Description

Replace unchecked `int64_t` size/offset arithmetic with `SafeInt<size_t>` across several CPU operator implementations to prevent silent integer overflow when computing buffer offsets and allocation sizes.

All changed expressions compute non-negative element counts or byte offsets used in pointer arithmetic, `memset`, `std::copy_n`, `std::fill_n`, or allocator calls. On models with large tensor dimensions the intermediate products (e.g., `N * C * H * W`) can overflow `int64_t` before the result is used. Wrapping the leading factor in `SafeInt<size_t>()` ensures every intermediate multiplication is overflow-checked and produces a `size_t` result.

### Motivation and Context

Integer overflow in size calculations can lead to undersized allocations, out-of-bounds memory access, or incorrect pointer offsets — all of which are security-sensitive. This change hardens the affected code paths against such overflow.

### Key Changes

| File | Change |
|---|---|
| `core/providers/cpu/tensor/grid_sample.cc` | Wrap grid/input/output offset computations with `SafeInt<size_t>`, chain all factors through SafeInt instead of parenthesized sub-expressions |
| `core/providers/cpu/tensor/affine_grid.cc` | Wrap batch offset and Eigen map size computations with `SafeInt<size_t>` |
| `core/providers/cpu/tensor/upsample_antialias.h` | Replace `narrow<size_t>(a * b)` and `static_cast<size_t>(a * b)` with `SafeInt<size_t>(a) * b` for temp buffer sizes, span extents, and copy counts |
| `core/providers/cpu/nn/tfidfvectorizer.cc` | Wrap `memset` byte-count computation with `SafeInt` |
| `core/providers/cpu/quantization/qlinearconv.cc` | Wrap `Alloc()` / `MakeUniquePtr` size computation with `SafeInt` |
| `core/providers/cpu/quantization/quantize_linear.cc` | Wrap sub-byte quantization total-size computation with `SafeInt` |
| `core/providers/cpu/sequence/sequence_ops.cc` | Wrap `SplitToSequence` offset and copy-count computations with `SafeInt` |

### Testing

Existing unit tests cover the functional behavior of all affected operators. The change is purely defensive — it makes previously unchecked arithmetic throw on overflow instead of silently wrapping, with no change to behavior for in-range inputs.