### PR TITLE
[C] fix: ADO CI spuriously failing format check due to picking up NuGet.config

### DIFF
--- a/.github/actions/linux-web-init-and-check/action.yml
+++ b/.github/actions/linux-web-init-and-check/action.yml
@@ -50,7 +50,7 @@ runs:
 
     - name: Check unformatted files
       run: |
-        node -e "a=require('child_process').execSync('git diff --name-only').toString();if(a)throw new Error('Following source files are not formatted: (did you run \"npm run format\"?)\n'+a)"
+        node -e "a=require('child_process').execSync('git diff --name-only -- .').toString();if(a)throw new Error('Following source files are not formatted: (did you run \"npm run format\"?)\n'+a)"
       shell: bash
       working-directory: ${{ github.workspace }}/js
 
@@ -66,6 +66,6 @@ runs:
 
     - name: Check out of dated documents
       run: |
-        node -e "a=require('child_process').execSync('git diff --name-only').toString();if(a)throw new Error('Following documents are not up-to-date: (did you run \"npm run build:doc\"?)\n'+a)"
+        node -e "a=require('child_process').execSync('git diff --name-only -- .').toString();if(a)throw new Error('Following documents are not up-to-date: (did you run \"npm run build:doc\"?)\n'+a)"
       shell: bash
       working-directory: ${{ github.workspace }}/js/web

--- a/tools/ci_build/github/azure-pipelines/templates/linux-web-init-and-check.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-web-init-and-check.yml
@@ -34,9 +34,10 @@ steps:
 - script: |
     npm run format
   workingDirectory: '$(Build.SourcesDirectory)/js'
-  displayName: 'Clang-format'
+  displayName: 'npm run format'
+# stash any changes to `NuGet.config` (expected from setup-feed auth) to prevent false positives. restore after diff check.
 - script: |
-    node -e "a=require('child_process').execSync('git diff --name-only').toString();if(a)throw new Error('Following source files are not formatted: (did you run \"npm run format\"?)\n'+a)"
+    node -e "a=require('child_process').execSync('git diff --name-only -- .').toString();if(a)throw new Error('Following source files are not formatted: (did you run \"npm run format\"?)\n'+a)"
   workingDirectory: '$(Build.SourcesDirectory)/js'
   displayName: 'Check unformatted files'
 - script: |
@@ -48,6 +49,6 @@ steps:
   workingDirectory: '$(Build.SourcesDirectory)/js/web'
   displayName: 'Generating documents'
 - script: |
-    node -e "a=require('child_process').execSync('git diff --name-only').toString();if(a)throw new Error('Following documents are not up-to-date: (did you run \"npm run build:doc\"?)\n'+a)"
+    node -e "a=require('child_process').execSync('git diff --name-only -- .').toString();if(a)throw new Error('Following documents are not up-to-date: (did you run \"npm run build:doc\"?)\n'+a)"
   workingDirectory: '$(Build.SourcesDirectory)/js/web'
   displayName: 'Check out of dated documents'

--- a/tools/ci_build/github/azure-pipelines/templates/win-web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-web-ci.yml
@@ -76,7 +76,7 @@ jobs:
       git checkout -- .gitattributes
     workingDirectory: '$(Build.SourcesDirectory)'
     displayName: 'Testing: force EOL to lf on windows for /js/**'
-  
+
   - template: setup-build-tools.yml
     parameters:
       host_cpu_arch: 'x64'
@@ -129,9 +129,10 @@ jobs:
   - script: |
       npm run format
     workingDirectory: '$(Build.SourcesDirectory)\js'
-    displayName: 'Clang-format'
+    displayName: 'npm run format'
+  # stash any changes to `NuGet.config` (expected from setup-feed auth) to prevent false positives. restore after diff check.
   - script: |
-      node -e "a=require('child_process').execSync('git diff --name-only').toString();if(a)throw new Error('Following source files are not formatted: (did you run \"npm run format\"?)\n'+a)"
+      node -e "a=require('child_process').execSync('git diff --name-only -- .').toString();if(a)throw new Error('Following source files are not formatted: (did you run \"npm run format\"?)\n'+a)"
     workingDirectory: '$(Build.SourcesDirectory)\js'
     displayName: 'Check unformatted files'
   - script: |
@@ -139,7 +140,7 @@ jobs:
     workingDirectory: '$(Build.SourcesDirectory)\js\web'
     displayName: 'Generating documents'
   - script: |
-      node -e "a=require('child_process').execSync('git diff --name-only').toString();if(a)throw new Error('Following documents are not up-to-date: (did you run \"npm run build:doc\"?)\n'+a)"
+      node -e "a=require('child_process').execSync('git diff --name-only -- .').toString();if(a)throw new Error('Following documents are not up-to-date: (did you run \"npm run build:doc\"?)\n'+a)"
     workingDirectory: '$(Build.SourcesDirectory)\js\web'
     displayName: 'Check out of dated documents'
   - task: Cache@2


### PR DESCRIPTION
### Description &  Motivation

On ADO CI we modify `/NuGet.config` to add an authenticated feed.
This trips up some format checks, which mistakenly considers unformatted b/c git reports it as dirty.
Scope to just the CWD and below to avoid picking up `/NuGet.config`.
