### PR TITLE
Fix missing include for SetRawDataInTensorProto in NV TensorRT RTX tests

### DIFF
--- a/onnxruntime/test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.cc
+++ b/onnxruntime/test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.cc
@@ -14,6 +14,7 @@
 #include "test/util/include/api_asserts.h"
 #include "core/graph/basic_types.h"
 #include "core/graph/model.h"
+#include "core/framework/tensorprotoutils.h"
 #include "core/graph/onnx_protobuf.h"
 #include "core/graph/model_saving_options.h"
 #include "core/graph/schema_registry.h"


### PR DESCRIPTION
Add #include core/framework/tensorprotoutils.h to test_nv_trt_rtx_ep_util.cc to resolve build error where onnxruntime::utils::SetRawDataInTensorProto was not found.



### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


