### PR TITLE
Move WASM builds to large VMs

### DIFF
--- a/.github/workflows/linux-wasm-ci-build-and-test-workflow.yml
+++ b/.github/workflows/linux-wasm-ci-build-and-test-workflow.yml
@@ -39,8 +39,8 @@ jobs:
   build-wasm:
     runs-on: [
         "self-hosted",
-        "1ES.Pool=onnxruntime-github-Ubuntu2204-AMD-CPU",
-        "JobId=build-wasm-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"
+        "1ES.Pool=onnxruntime-github-linux-large",
+        "JobId=build-wasm-${{inputs.job_name}}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"
         ]
     env:
       buildArch: x64


### PR DESCRIPTION
### Description
Move WASM builds to 128gb RAM VMs. Fix VM leak with non unique run name.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


