### PR TITLE
Bound total output allocation size in Tile kernel

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/tile.cc
+++ b/onnxruntime/core/providers/cpu/tensor/tile.cc
@@ -169,6 +169,50 @@ Status Tile::Compute(OpKernelContext* ctx) const {
     output_dims[axis] = SafeInt<int64_t>(output_dims[axis]) * repeats[axis];
   }
 
+  // Per-axis SafeInt multiplication above detects integer overflow when computing
+  // any single output dimension. In addition, bound the total tiled byte count so
+  // that a combination of large (but individually in-range) dimensions cannot
+  // request an allocation that exceeds a reasonable upper limit. This also applies
+  // to std::string tensors, whose backing storage is sizeof(std::string) per element.
+  //
+  // Use a division-based bound check rather than SafeInt multiplication so that
+  // over-limit inputs always produce the INVALID_ARGUMENT status below instead of
+  // a SafeInt overflow exception.
+  {
+    constexpr int64_t kMaxTileOutputBytes = int64_t{4} * 1024 * 1024 * 1024;  // 4 GiB
+    const int64_t element_size = static_cast<int64_t>(input_tensor.DataType()->Size());
+    if (element_size <= 0) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                             "Invalid element size for Tile input tensor type.");
+    }
+    const int64_t max_elements = kMaxTileOutputBytes / element_size;
+
+    int64_t total_elements = 1;
+    for (size_t axis = 0; axis < input_rank; ++axis) {
+      const int64_t dim = output_dims[axis];
+      if (dim == 0) {
+        total_elements = 0;
+        break;
+      }
+      if (total_elements > max_elements / dim) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                               "Tile output tensor would require more than ",
+                               kMaxTileOutputBytes,
+                               " bytes, which exceeds the supported maximum of ",
+                               kMaxTileOutputBytes, " bytes.");
+      }
+      total_elements *= dim;
+    }
+
+    const int64_t total_bytes = total_elements * element_size;
+    if (total_bytes > kMaxTileOutputBytes) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Tile output tensor would require ", total_bytes,
+                             " bytes, which exceeds the supported maximum of ",
+                             kMaxTileOutputBytes, " bytes.");
+    }
+  }
+
   TensorShape output_shape(output_dims);
   auto& output_tensor = *ctx->Output(0, output_shape);
 

--- a/onnxruntime/core/providers/cpu/tensor/tile.cc
+++ b/onnxruntime/core/providers/cpu/tensor/tile.cc
@@ -12,6 +12,8 @@
 #include "core/providers/cpu/tensor/tile.h"
 #include "core/providers/cpu/tensor/utils.h"
 
+#include <limits>
+
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
@@ -161,12 +163,53 @@ Status Tile::Compute(OpKernelContext* ctx) const {
   // Calculate the shape of the output tensor
   const auto* repeats = repeats_tensor.Data<int64_t>();
   auto output_dims = input_shape.AsShapeVector();
+
+  // Bound the total tiled byte count so that a combination of large (but
+  // individually in-range) per-axis repeats cannot request an allocation that
+  // exceeds a reasonable upper limit. Track the running product using
+  // division-based checks so we can return INVALID_ARGUMENT instead of throwing
+  // an integer overflow exception from SafeInt.
+  constexpr int64_t kMaxTileOutputBytes = int64_t{4} * 1024 * 1024 * 1024;  // 4 GiB
+  constexpr int64_t kMaxSupportedTileOutputBytes =
+      std::numeric_limits<size_t>::max() < static_cast<uint64_t>(kMaxTileOutputBytes)
+          ? static_cast<int64_t>(std::numeric_limits<size_t>::max())
+          : kMaxTileOutputBytes;
+  const int64_t element_size = narrow<int64_t>(input_tensor.DataType()->Size());
+  const int64_t max_elements = kMaxSupportedTileOutputBytes / element_size;
+  int64_t total_elements = 1;
+
   for (size_t axis = 0; axis < input_rank; axis++) {
     if (repeats[axis] < 0) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                              "Tile repeat value must be non-negative, got: ", repeats[axis]);
     }
-    output_dims[axis] = SafeInt<int64_t>(output_dims[axis]) * repeats[axis];
+    const int64_t input_dim = output_dims[axis];
+    const int64_t r = repeats[axis];
+    // Compute output_dims[axis] = input_dim * r while detecting both int64
+    // overflow and exceeding the supported byte budget. If the result would
+    // exceed max_elements it cannot fit anyway, so we reject in either case
+    // with the same controlled error message.
+    int64_t dim;
+    if (input_dim == 0 || r == 0) {
+      dim = 0;
+    } else if (input_dim > max_elements / r) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Tile output tensor would require more than ",
+                             kMaxSupportedTileOutputBytes,
+                             " bytes, which exceeds the supported maximum of ",
+                             kMaxSupportedTileOutputBytes, " bytes.");
+    } else {
+      dim = input_dim * r;
+    }
+    output_dims[axis] = dim;
+    if (dim > 0 && total_elements > max_elements / dim) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Tile output tensor would require more than ",
+                             kMaxSupportedTileOutputBytes,
+                             " bytes, which exceeds the supported maximum of ",
+                             kMaxSupportedTileOutputBytes, " bytes.");
+    }
+    total_elements *= dim;
   }
 
   TensorShape output_shape(output_dims);

--- a/onnxruntime/core/providers/cuda/tensor/tile.cc
+++ b/onnxruntime/core/providers/cuda/tensor/tile.cc
@@ -125,6 +125,49 @@ Status Tile::ComputeInternal(OpKernelContext* ctx) const {
     output_dims[axis] = SafeInt<int64_t>(output_dims[axis]) * repeats[axis];
   }
 
+  // Per-axis SafeInt multiplication above detects integer overflow when computing
+  // any single output dimension. In addition, bound the total tiled byte count so
+  // that a combination of large (but individually in-range) dimensions cannot
+  // request an allocation that exceeds a reasonable upper limit.
+  //
+  // Use a division-based bound check rather than SafeInt multiplication so that
+  // over-limit inputs always produce the INVALID_ARGUMENT status below instead of
+  // a SafeInt overflow exception.
+  {
+    constexpr int64_t kMaxTileOutputBytes = int64_t{4} * 1024 * 1024 * 1024;  // 4 GiB
+    const int64_t element_size = static_cast<int64_t>(input_tensor.DataType()->Size());
+    if (element_size <= 0) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                             "Invalid element size for Tile input tensor type.");
+    }
+    const int64_t max_elements = kMaxTileOutputBytes / element_size;
+
+    int64_t total_elements = 1;
+    for (int32_t axis = 0; axis < input_rank; ++axis) {
+      const int64_t dim = output_dims[axis];
+      if (dim == 0) {
+        total_elements = 0;
+        break;
+      }
+      if (total_elements > max_elements / dim) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                               "Tile output tensor would require more than ",
+                               kMaxTileOutputBytes,
+                               " bytes, which exceeds the supported maximum of ",
+                               kMaxTileOutputBytes, " bytes.");
+      }
+      total_elements *= dim;
+    }
+
+    const int64_t total_bytes = total_elements * element_size;
+    if (total_bytes > kMaxTileOutputBytes) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Tile output tensor would require ", total_bytes,
+                             " bytes, which exceeds the supported maximum of ",
+                             kMaxTileOutputBytes, " bytes.");
+    }
+  }
+
   TensorShape output_shape(output_dims);
   auto& output_tensor = *ctx->Output(0, output_shape);
 

--- a/onnxruntime/core/providers/cuda/tensor/tile.cc
+++ b/onnxruntime/core/providers/cuda/tensor/tile.cc
@@ -5,6 +5,8 @@
 #include "core/providers/cpu/tensor/utils.h"
 #include "tile_impl.h"
 
+#include <limits>
+
 using namespace onnxruntime::common;
 namespace onnxruntime {
 namespace cuda {
@@ -117,12 +119,47 @@ Status Tile::ComputeInternal(OpKernelContext* ctx) const {
   const auto& input_shape = input_tensor.Shape();
   const auto input_dims = input_shape.GetDims();
   auto output_dims(input_shape.AsShapeVector());
+
+  // Bound the total tiled byte count and detect overflow with division-based
+  // checks so we return INVALID_ARGUMENT instead of throwing a SafeInt
+  // overflow exception. Mirrors the CPU Tile implementation.
+  constexpr int64_t kMaxTileOutputBytes = int64_t{4} * 1024 * 1024 * 1024;  // 4 GiB
+  constexpr int64_t kMaxSupportedTileOutputBytes =
+      std::numeric_limits<size_t>::max() < static_cast<uint64_t>(kMaxTileOutputBytes)
+          ? static_cast<int64_t>(std::numeric_limits<size_t>::max())
+          : kMaxTileOutputBytes;
+  const int64_t element_size_bytes = narrow<int64_t>(input_tensor.DataType()->Size());
+  const int64_t max_elements = kMaxSupportedTileOutputBytes / element_size_bytes;
+  int64_t total_elements = 1;
+
   for (int32_t axis = 0; axis < input_rank; axis++) {
     if (repeats[axis] < 0) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                              "Tile repeat value must be non-negative, got: ", repeats[axis]);
     }
-    output_dims[axis] = SafeInt<int64_t>(output_dims[axis]) * repeats[axis];
+    const int64_t input_dim = output_dims[axis];
+    const int64_t r = repeats[axis];
+    int64_t dim;
+    if (input_dim == 0 || r == 0) {
+      dim = 0;
+    } else if (input_dim > max_elements / r) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Tile output tensor would require more than ",
+                             kMaxSupportedTileOutputBytes,
+                             " bytes, which exceeds the supported maximum of ",
+                             kMaxSupportedTileOutputBytes, " bytes.");
+    } else {
+      dim = input_dim * r;
+    }
+    output_dims[axis] = dim;
+    if (dim > 0 && total_elements > max_elements / dim) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Tile output tensor would require more than ",
+                             kMaxSupportedTileOutputBytes,
+                             " bytes, which exceeds the supported maximum of ",
+                             kMaxSupportedTileOutputBytes, " bytes.");
+    }
+    total_elements *= dim;
   }
 
   TensorShape output_shape(output_dims);

--- a/onnxruntime/core/providers/webgpu/tensor/tile.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/tile.cc
@@ -7,6 +7,8 @@
 #include "core/providers/webgpu/shader_helper.h"
 #include "core/providers/webgpu/webgpu_supported_types.h"
 
+#include <limits>
+
 namespace onnxruntime {
 namespace webgpu {
 
@@ -52,19 +54,61 @@ Status Tile::ComputeInternal(ComputeContext& context) const {
   size_t input_rank = input_shape.NumDimensions();
 
   const auto* repeats_tensor = context.Input(1);
+  if (repeats_tensor->Shape().NumDimensions() != 1) {
+    return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,
+                  "'repeat' input tensor must be 1 dimensional");
+  }
+  if (size_t(repeats_tensor->Shape().Size()) != input_rank) {
+    return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,
+                  "'repeat' input tensor must have the same length as the 'input' tensor");
+  }
   const auto* repeats_data = repeats_tensor->Data<int64_t>();
-  std::vector<uint32_t> repeats;
+  InlinedVector<uint32_t> repeats;
+  repeats.reserve(input_rank);
 
   auto output_dims = input_shape.AsShapeVector();
+  // Bound the total tiled byte count and detect overflow with division-based
+  // checks so we return INVALID_ARGUMENT instead of throwing a SafeInt
+  // overflow exception. Mirrors the CPU Tile implementation.
+  constexpr int64_t kMaxTileOutputBytes = int64_t{4} * 1024 * 1024 * 1024;  // 4 GiB
+  constexpr int64_t kMaxSupportedTileOutputBytes =
+      std::numeric_limits<size_t>::max() < static_cast<uint64_t>(kMaxTileOutputBytes)
+          ? static_cast<int64_t>(std::numeric_limits<size_t>::max())
+          : kMaxTileOutputBytes;
+  const int64_t element_size = narrow<int64_t>(input_tensor->DataType()->Size());
+  const int64_t max_elements = kMaxSupportedTileOutputBytes / element_size;
+  int64_t total_elements = 1;
   for (size_t axis = 0; axis < input_rank; axis++) {
     if (repeats_data[axis] < 0) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                              "Tile repeat value must be non-negative, got: ", repeats_data[axis]);
     }
-    output_dims[axis] = SafeInt<int64_t>(output_dims[axis]) * repeats_data[axis];
+    const int64_t input_dim = output_dims[axis];
+    const int64_t r = repeats_data[axis];
+    int64_t dim;
+    if (input_dim == 0 || r == 0) {
+      dim = 0;
+    } else if (input_dim > max_elements / r) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Tile output tensor would require more than ",
+                             kMaxSupportedTileOutputBytes,
+                             " bytes, which exceeds the supported maximum of ",
+                             kMaxSupportedTileOutputBytes, " bytes.");
+    } else {
+      dim = input_dim * r;
+    }
+    output_dims[axis] = dim;
+    if (dim > 0 && total_elements > max_elements / dim) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Tile output tensor would require more than ",
+                             kMaxSupportedTileOutputBytes,
+                             " bytes, which exceeds the supported maximum of ",
+                             kMaxSupportedTileOutputBytes, " bytes.");
+    }
+    total_elements *= dim;
   }
-  for (size_t i = 0; i < static_cast<size_t>(repeats_tensor->Shape().Size()); i++) {
-    repeats.push_back(static_cast<uint32_t>(repeats_data[i]));
+  for (size_t axis = 0; axis < input_rank; axis++) {
+    repeats.push_back(static_cast<uint32_t>(repeats_data[axis]));
   }
 
   TensorShape output_shape(output_dims);

--- a/onnxruntime/core/providers/webgpu/tensor/tile.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/tile.cc
@@ -108,6 +108,11 @@ Status Tile::ComputeInternal(ComputeContext& context) const {
     total_elements *= dim;
   }
   for (size_t axis = 0; axis < input_rank; axis++) {
+    if (repeats_data[axis] > std::numeric_limits<uint32_t>::max()) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Tile repeat value exceeds the WebGPU supported maximum of ",
+                             std::numeric_limits<uint32_t>::max(), ": ", repeats_data[axis]);
+    }
     repeats.push_back(static_cast<uint32_t>(repeats_data[axis]));
   }
 

--- a/onnxruntime/core/providers/webgpu/tensor/tile.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/tile.cc
@@ -8,6 +8,7 @@
 #include "core/providers/webgpu/webgpu_supported_types.h"
 
 #include <limits>
+#include <algorithm>
 
 namespace onnxruntime {
 namespace webgpu {
@@ -76,7 +77,14 @@ Status Tile::ComputeInternal(ComputeContext& context) const {
           ? static_cast<int64_t>(std::numeric_limits<size_t>::max())
           : kMaxTileOutputBytes;
   const int64_t element_size = narrow<int64_t>(input_tensor->DataType()->Size());
-  const int64_t max_elements = kMaxSupportedTileOutputBytes / element_size;
+  // The WebGPU shader uses a uint32_t uniform for the total output element
+  // count and dispatches based on it. Clamp the per-element budget to
+  // uint32_t::max() so that any combination of repeats producing more than
+  // 2^32 - 1 elements is rejected by the byte-cap check below instead of
+  // silently truncating to a smaller dispatch / OOB-guard value.
+  const int64_t max_elements =
+      std::min<int64_t>(kMaxSupportedTileOutputBytes / element_size,
+                        static_cast<int64_t>(std::numeric_limits<uint32_t>::max()));
   int64_t total_elements = 1;
   for (size_t axis = 0; axis < input_rank; axis++) {
     if (repeats_data[axis] < 0) {

--- a/onnxruntime/test/providers/cpu/tensor/tile_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/tile_op_test.cc
@@ -357,5 +357,62 @@ TEST(TensorOpTest, TileOverflowMultipleAxes) {
   test.Run(OpTester::ExpectResult::kExpectFailure, "", {kTensorrtExecutionProvider});
 }
 
+// Large per-axis repeat values whose product does not overflow int64 but would
+// still request an allocation above the supported upper bound must be rejected.
+// input [1] float32 with repeat [2^32] => 2^32 elements * 4 bytes = 16 GiB.
+TEST(TensorOpTest, TileOutputSizeExceedsLimit1D) {
+  OpTester test("Tile", 13);
+  test.AddInput<float>("input", {1}, {1.0f});
+  test.AddInput<int64_t>("repeats", {1}, {int64_t{4294967296}});  // 2^32
+  test.AddOutput<float>("output", {0}, {});
+  // DirectML Tile has its own implementation that does not enforce this byte cap.
+  test.Run(OpTester::ExpectResult::kExpectFailure, "exceeds the supported maximum",
+           {kTensorrtExecutionProvider, kDmlExecutionProvider});
+}
+
+// A moderately large but supported repeat value is accepted.
+// input [1] float32 with repeat [1000000] => 1M elements * 4 bytes = 4 MB.
+TEST(TensorOpTest, TileOutputSizeWithinLimit) {
+  RunTest<float>({1}, {1000000});
+}
+
+// Combined per-axis repeats can produce a total that is in range for int64 but
+// still above the supported allocation limit.
+// input [2,2] float32 with repeats [32768, 32768] => ~4 billion elements * 4 bytes = ~16 GiB.
+TEST(TensorOpTest, TileOutputSizeExceedsLimitMultiAxis) {
+  OpTester test("Tile", 13);
+  test.AddInput<float>("input", {2, 2}, {1.0f, 2.0f, 3.0f, 4.0f});
+  test.AddInput<int64_t>("repeats", {2}, {32768, 32768});
+  test.AddOutput<float>("output", {0, 0}, {});
+  // DirectML Tile has its own implementation that does not enforce this byte cap.
+  test.Run(OpTester::ExpectResult::kExpectFailure, "exceeds the supported maximum",
+           {kTensorrtExecutionProvider, kDmlExecutionProvider});
+}
+
+// With 8-byte elements a smaller repeat value crosses the supported limit.
+// input [1] double with repeat [536870913] => ~4 GiB + 8 bytes, just above limit.
+TEST(TensorOpTest, TileOutputSizeExceedsLimitDouble) {
+  OpTester test("Tile", 13);
+  test.AddInput<double>("input", {1}, {1.0});
+  test.AddInput<int64_t>("repeats", {1}, {int64_t{536870913}});
+  test.AddOutput<double>("output", {0}, {});
+  // DirectML Tile has its own implementation that does not enforce this byte cap.
+  test.Run(OpTester::ExpectResult::kExpectFailure, "exceeds the supported maximum",
+           {kTensorrtExecutionProvider, kDmlExecutionProvider});
+}
+
+// The output-size bound applies to std::string tensors as well: the output tensor
+// holds sizeof(std::string) bytes per element for the container backing store.
+// input [1] string with repeat [2^32] easily exceeds the supported maximum.
+TEST(TensorOpTest, TileOutputSizeExceedsLimitString) {
+  OpTester test("Tile", 13);
+  test.AddInput<std::string>("input", {1}, {"x"});
+  test.AddInput<int64_t>("repeats", {1}, {int64_t{4294967296}});  // 2^32
+  test.AddOutput<std::string>("output", {0}, {});
+  // DirectML Tile has its own implementation that does not enforce this byte cap.
+  test.Run(OpTester::ExpectResult::kExpectFailure, "exceeds the supported maximum",
+           {kTensorrtExecutionProvider, kDmlExecutionProvider});
+}
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/tensor/tile_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/tile_op_test.cc
@@ -438,5 +438,60 @@ TEST(TensorOpTest, TileOutputSizeExceedsLimitString) {
            {kTensorrtExecutionProvider, kDmlExecutionProvider});
 }
 
+#if defined(USE_WEBGPU)
+// The WebGPU Tile kernel stores per-axis repeat values in a uint32_t shader
+// uniform. Repeat values that would truncate when cast to uint32_t must be
+// rejected before reaching the shader. A zero-element input is used so that
+// the earlier output-byte-size check (which requires dim > 0) does not fire
+// first, exercising the explicit uint32_t-range guard.
+TEST(TensorOpTest, TileRepeatExceedsUint32MaxWebGpu) {
+  if (DefaultWebGpuExecutionProvider().get() == nullptr) {
+    GTEST_SKIP() << "WebGPU EP not available";
+  }
+  OpTester test("Tile", 13);
+  test.AddInput<float>("input", {0}, {});
+  test.AddInput<int64_t>("repeats", {1}, {int64_t{4294967296}});  // 2^32
+  test.AddOutput<float>("output", {0}, {});
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultWebGpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectFailure,
+           "exceeds the WebGPU supported maximum",
+           {}, nullptr, &execution_providers);
+}
+
+// The WebGPU Tile kernel validates that the 'repeats' input is 1-D, mirroring
+// the CPU kernel's pre-existing check.
+TEST(TensorOpTest, TileRepeatsMustBe1DWebGpu) {
+  if (DefaultWebGpuExecutionProvider().get() == nullptr) {
+    GTEST_SKIP() << "WebGPU EP not available";
+  }
+  OpTester test("Tile", 13);
+  test.AddInput<float>("input", {2, 3}, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
+  test.AddInput<int64_t>("repeats", {1, 2}, {1, 1});
+  test.AddOutput<float>("output", {2, 3}, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultWebGpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectFailure, "must be 1 dimensional",
+           {}, nullptr, &execution_providers);
+}
+
+// The WebGPU Tile kernel validates that the 'repeats' length matches the
+// input rank, mirroring the CPU kernel's pre-existing check.
+TEST(TensorOpTest, TileRepeatsMustMatchInputRankWebGpu) {
+  if (DefaultWebGpuExecutionProvider().get() == nullptr) {
+    GTEST_SKIP() << "WebGPU EP not available";
+  }
+  OpTester test("Tile", 13);
+  test.AddInput<float>("input", {2, 3}, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
+  test.AddInput<int64_t>("repeats", {1}, {1});
+  test.AddOutput<float>("output", {2, 3}, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultWebGpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectFailure,
+           "same length as the 'input' tensor",
+           {}, nullptr, &execution_providers);
+}
+#endif  // defined(USE_WEBGPU)
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/tensor/tile_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/tile_op_test.cc
@@ -3,6 +3,7 @@
 
 #include "gtest/gtest.h"
 #include "test/providers/provider_test_utils.h"
+#include "test/util/include/default_providers.h"
 
 namespace onnxruntime {
 namespace test {
@@ -272,8 +273,10 @@ TEST(TensorOpTest, TileRepeatsMustBe1D) {
   test.AddInput<float>("input", {2, 3}, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
   test.AddInput<int64_t>("repeats", {1, 2}, {1, 1});
   test.AddOutput<float>("output", {2, 3}, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
   test.Run(OpTester::ExpectResult::kExpectFailure, "must be 1 dimensional",
-           {kDmlExecutionProvider});
+           {}, nullptr, &execution_providers);
 }
 
 TEST(TensorOpTest, TileRepeatsMustMatchInputRank) {
@@ -281,9 +284,11 @@ TEST(TensorOpTest, TileRepeatsMustMatchInputRank) {
   test.AddInput<float>("input", {2, 3}, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
   test.AddInput<int64_t>("repeats", {1}, {1});
   test.AddOutput<float>("output", {2, 3}, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
   test.Run(OpTester::ExpectResult::kExpectFailure,
            "same length as the 'input' tensor",
-           {kOpenVINOExecutionProvider, kDmlExecutionProvider});
+           {}, nullptr, &execution_providers);
 }
 
 // Test that negative repeat values are rejected with an error

--- a/onnxruntime/test/providers/cpu/tensor/tile_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/tile_op_test.cc
@@ -267,6 +267,25 @@ TEST(TensorOpTest, TileBoolType) { RunTestWrapperForBool(); }
 TEST(TensorOpTest, TileMLFloat16Type) { RunTestWrapper<MLFloat16>(); }
 #endif
 
+TEST(TensorOpTest, TileRepeatsMustBe1D) {
+  OpTester test("Tile", 13);
+  test.AddInput<float>("input", {2, 3}, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
+  test.AddInput<int64_t>("repeats", {1, 2}, {1, 1});
+  test.AddOutput<float>("output", {2, 3}, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
+  test.Run(OpTester::ExpectResult::kExpectFailure, "must be 1 dimensional",
+           {kDmlExecutionProvider});
+}
+
+TEST(TensorOpTest, TileRepeatsMustMatchInputRank) {
+  OpTester test("Tile", 13);
+  test.AddInput<float>("input", {2, 3}, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
+  test.AddInput<int64_t>("repeats", {1}, {1});
+  test.AddOutput<float>("output", {2, 3}, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
+  test.Run(OpTester::ExpectResult::kExpectFailure,
+           "same length as the 'input' tensor",
+           {kOpenVINOExecutionProvider, kDmlExecutionProvider});
+}
+
 // Test that negative repeat values are rejected with an error
 TEST(TensorOpTest, TileNegativeRepeats) {
   OpTester test("Tile", 13);
@@ -355,6 +374,63 @@ TEST(TensorOpTest, TileOverflowMultipleAxes) {
   test.AddInput<int64_t>("repeats", {3}, {large_repeat, 1, 1});
   test.AddOutput<float>("output", {0, 0, 0}, {});
   test.Run(OpTester::ExpectResult::kExpectFailure, "", {kTensorrtExecutionProvider});
+}
+
+// Large per-axis repeat values whose product does not overflow int64 but would
+// still request an allocation above the supported upper bound must be rejected.
+// input [1] float32 with repeat [2^32] => 2^32 elements * 4 bytes = 16 GiB.
+TEST(TensorOpTest, TileOutputSizeExceedsLimit1D) {
+  OpTester test("Tile", 13);
+  test.AddInput<float>("input", {1}, {1.0f});
+  test.AddInput<int64_t>("repeats", {1}, {int64_t{4294967296}});  // 2^32
+  test.AddOutput<float>("output", {0}, {});
+  // DirectML Tile has its own implementation that does not enforce this byte cap.
+  test.Run(OpTester::ExpectResult::kExpectFailure, "exceeds the supported maximum",
+           {kTensorrtExecutionProvider, kDmlExecutionProvider});
+}
+
+// A moderately large but supported repeat value is accepted.
+// input [1] float32 with repeat [1000000] => 1M elements * 4 bytes = 4 MB.
+TEST(TensorOpTest, TileOutputSizeWithinLimit) {
+  RunTest<float>({1}, {1000000});
+}
+
+// Combined per-axis repeats can produce a total that is in range for int64 but
+// still above the supported allocation limit.
+// input [2,2] float32 with repeats [32768, 32768] => ~4 billion elements * 4 bytes = ~16 GiB.
+TEST(TensorOpTest, TileOutputSizeExceedsLimitMultiAxis) {
+  OpTester test("Tile", 13);
+  test.AddInput<float>("input", {2, 2}, {1.0f, 2.0f, 3.0f, 4.0f});
+  test.AddInput<int64_t>("repeats", {2}, {32768, 32768});
+  test.AddOutput<float>("output", {0, 0}, {});
+  // DirectML Tile has its own implementation that does not enforce this byte cap.
+  test.Run(OpTester::ExpectResult::kExpectFailure, "exceeds the supported maximum",
+           {kTensorrtExecutionProvider, kDmlExecutionProvider});
+}
+
+// With 8-byte elements a smaller repeat value crosses the supported limit.
+// input [1] double with repeat [536870913] => ~4 GiB + 8 bytes, just above limit.
+TEST(TensorOpTest, TileOutputSizeExceedsLimitDouble) {
+  OpTester test("Tile", 13);
+  test.AddInput<double>("input", {1}, {1.0});
+  test.AddInput<int64_t>("repeats", {1}, {int64_t{536870913}});
+  test.AddOutput<double>("output", {0}, {});
+  // DirectML Tile has its own implementation that does not enforce this byte cap.
+  test.Run(OpTester::ExpectResult::kExpectFailure, "exceeds the supported maximum",
+           {kTensorrtExecutionProvider, kDmlExecutionProvider});
+}
+
+// The output-size bound applies to std::string tensors as well: the output tensor
+// holds sizeof(std::string) bytes per element for the container backing store.
+// input [1] string with repeat [2^32] easily exceeds the supported maximum.
+TEST(TensorOpTest, TileOutputSizeExceedsLimitString) {
+  OpTester test("Tile", 13);
+  test.AddInput<std::string>("input", {1}, {"x"});
+  test.AddInput<int64_t>("repeats", {1}, {int64_t{4294967296}});  // 2^32
+  test.AddOutput<std::string>("output", {0}, {});
+  // DirectML Tile has its own implementation that does not enforce this byte cap.
+  test.Run(OpTester::ExpectResult::kExpectFailure, "exceeds the supported maximum",
+           {kTensorrtExecutionProvider, kDmlExecutionProvider});
 }
 
 }  // namespace test


### PR DESCRIPTION
### Description
The per-axis SafeInt multiplication added in #27566 detects overflow when computing an individual output dimension, but combinations of per-axis repeats can still request an int64-representable total that is unreasonably large. This PR adds a 4 GiB upper bound on the total tiled byte count in the CPU, CUDA, and WebGPU Tile kernels and extends validation/tests for the new behavior.

### Changes
- `onnxruntime/core/providers/cpu/tensor/tile.cc`: compute the output shape with division-based checks that reject negative repeats, int64 overflow, and total tiled byte counts above the supported maximum before allocation. The maximum is clamped to `size_t::max()` for 32-bit builds, and the bound applies to `std::string` tensors as well because their output buffers still allocate per-element backing storage.
- `onnxruntime/core/providers/cuda/tensor/tile.cc`: same output-size bound applied to keep CPU and CUDA behavior consistent.
- `onnxruntime/core/providers/webgpu/tensor/tile.cc`: same output-size bound applied to keep WebGPU behavior consistent, plus repeats rank/length validation matching CPU/CUDA.
- `onnxruntime/test/providers/cpu/tensor/tile_op_test.cc`: tests cover malformed repeats rank/length, 1-D, multi-axis, double (8-byte element), and string cases that exceed the bound, plus a positive test confirming a moderate (4 MB) output is still accepted.

### Motivation and Context
Follow-up to #27566, which fixed per-axis overflow but did not bound total allocation size.