### PR TITLE
Test model package

### DIFF
--- a/onnxruntime/core/session/model_package/README.md
+++ b/onnxruntime/core/session/model_package/README.md
@@ -18,6 +18,8 @@ This document describes the model package directory layout and the JSON files us
 
 - Model Variant
   - A ‘model variant’ is a single ONNX or ORT format model.
+  - When multiple component models use the same variant name (for example, `qnn_mixed`),
+    those per-component variant entries form a single logical package-level variant.
 
 ## Directory layout
 
@@ -92,6 +94,10 @@ Schema:
     - `model_type` (string, optional): Type of the model (e.g., `"onnx"`, `"ORT"`). If omitted, ORT will treat it as an ONNX model by default.
     - `model_file` (string, optional): Path relative to the model variant directory. Can point to an ONNX model file or a directory. If it is a directory, or if `model_file` is omitted, ORT will discover the ONNX model file within that directory.
     - `model_id` (string, optional): Unique identifier for the model variant. It should match a catalog value if the model comes from a catalog. If `model_id` is present, the model will be in the <component_model_name>/`model_id`/ directory.
+    - `package_variant_id` (string, optional): Logical package-level variant id. If omitted, ONNX Runtime uses the local `<variant_name>`.
+    - `execution` (object, optional): Per-component execution hints.
+      - `provider_options` (object, optional): Provider options to apply when creating the component session. Caller-specified values override these values.
+      - `session_config_entries` (object, optional): Session config entries to apply when creating the component session. Caller-specified values override these values.
     - `constraints` (object, required):
       - `ep` (string, required (except base model)): Execution provider name (e.g., `"TensorrtExecutionProvider"`, `"QNNExecutionProvider"`, `"OpenVINOExecutionProvider"`).
       - `device` (string, optional): Target device type (e.g., `"cpu"`, `"gpu"`, `"npu"`). Must match a supported `OrtHardwareDevice`. If the EPContext model can support multiple device types, this field can be omitted and EP should record supported device types in `ep_compatibility_info` instead.
@@ -106,6 +112,7 @@ Schema:
         <variant_1>: {
             "model_type": "onnx",
             "model_file": "model_ctx.onnx",
+            "package_variant_id": "qnn_mixed",
             "constraints": {
                 "ep": "TensorrtExecutionProvider",
                 "ep_compatibility_info": "..."
@@ -114,9 +121,14 @@ Schema:
         <variant_2>: {
             "model_type": "onnx",
             "model_file": "model_ctx.onnx",
+            "execution": {
+                "provider_options": {
+                    "device_type": "CPU"
+                }
+            },
              "constraints": {
-                 "ep": "OpenVINOExecutionProvider",
-                 "device": "cpu",
+                  "ep": "OpenVINOExecutionProvider",
+                  "device": "cpu",
                  "ep_compatibility_info": "..."
              }
         }
@@ -127,8 +139,10 @@ Schema:
 
 ## Processing rules (runtime expectations)
 
-- ONNX Runtime reads `manifest.json` if the path passed in is the package root directory; if `component_models` is present, it uses that to determine which component models to load. If `component_models` is not present, ONNX Runtime discovers component models by enumerating subdirectories under `models/`. (In this case, ONNX Runtime expects only one component model exist in the model package.)
+- ONNX Runtime reads `manifest.json` if the path passed in is the package root directory; if `component_models` is present, it uses that to determine which component models to load. If `component_models` is not present, ONNX Runtime discovers component models by enumerating subdirectories under `models/`.
 - ONNX Runtime reads component model's `metadata.json` and ignores `manifest.json` if the path passed in points directly to a component model directory.
 - For each component model, `metadata.json` supplies the definitive list of variants and constraints.
-- Variant selection is performed by matching constraints (EP, device, `ep_compatibility_info`, and optionally architecture). **The EP’s returned compatibility value (e.g., `EP_SUPPORTED_OPTIMAL`, `EP_SUPPORTED_PREFER_RECOMPILATION`) is used to score and pick the winning model variant.**
+- Component entries that share the same `package_variant_id` (or the same variant name when `package_variant_id` is omitted) form a logical package-level variant. Each component entry may target a different EP/device pair.
+- Package-level selection is performed by matching constraints (EP, device, `ep_compatibility_info`, and optionally architecture) for every required component. **The EP’s returned compatibility value (e.g., `EP_SUPPORTED_OPTIMAL`, `EP_SUPPORTED_PREFER_RECOMPILATION`) is used to score and pick the winning package variant.**
+- Direct `CreateSession(package_root, ...)` remains a convenience path that only works when the resolved package variant contains exactly one component model. Multi-component packages must be resolved first and then loaded as one session per component model.
 - All file paths must be relative paths; avoid absolute paths to keep packages portable

--- a/onnxruntime/core/session/model_package/model_package_context.cc
+++ b/onnxruntime/core/session/model_package/model_package_context.cc
@@ -5,18 +5,22 @@
 
 #include <algorithm>
 #include <cctype>
-#include <fstream>
 #include <limits>
+#include <map>
+#include <optional>
 #include <sstream>
 #include <string>
+#include <unordered_map>
+#include <vector>
 
+#include "core/session/model_package/model_package_context.h"
 #include "core/common/logging/logging.h"
 #include "core/framework/error_code_helper.h"
-#include "core/session/model_package/model_package_context.h"
 #include "core/session/model_package/model_package_descriptor_parser.h"
 
 namespace onnxruntime {
 namespace {
+
 std::string ToLower(std::string_view s) {
   std::string result(s);
   std::transform(result.begin(), result.end(), result.begin(),
@@ -24,22 +28,29 @@ std::string ToLower(std::string_view s) {
   return result;
 }
 
+std::string DeviceTypeToString(const OrtHardwareDevice* hd) {
+  if (hd == nullptr) {
+    return {};
+  }
+
+  switch (hd->type) {
+    case OrtHardwareDeviceType::OrtHardwareDeviceType_CPU:
+      return "cpu";
+    case OrtHardwareDeviceType::OrtHardwareDeviceType_GPU:
+      return "gpu";
+    case OrtHardwareDeviceType::OrtHardwareDeviceType_NPU:
+      return "npu";
+    default:
+      return {};
+  }
+}
+
 bool MatchesDevice(const OrtHardwareDevice* hd, std::string_view value) {
   if (value.empty() || hd == nullptr) {
     return value.empty();
   }
 
-  const std::string device_type = ToLower(value);
-  switch (hd->type) {
-    case OrtHardwareDeviceType::OrtHardwareDeviceType_CPU:
-      return device_type == "cpu";
-    case OrtHardwareDeviceType::OrtHardwareDeviceType_GPU:
-      return device_type == "gpu";
-    case OrtHardwareDeviceType::OrtHardwareDeviceType_NPU:
-      return device_type == "npu";
-    default:
-      return false;
-  }
+  return DeviceTypeToString(hd) == ToLower(value);
 }
 
 const OrtHardwareDevice* FindMatchingHardwareDevice(std::string_view device_constraint,
@@ -55,6 +66,21 @@ const OrtHardwareDevice* FindMatchingHardwareDevice(std::string_view device_cons
   }
 
   return nullptr;
+}
+
+const OrtEpDevice* FindEpDeviceForHardwareDevice(const VariantSelectionEpInfo& ep_info,
+                                                 const OrtHardwareDevice* hardware_device) {
+  if (hardware_device == nullptr) {
+    return ep_info.ep_devices.size() == 1 ? ep_info.ep_devices.front() : nullptr;
+  }
+
+  for (const auto* ep_device : ep_info.ep_devices) {
+    if (ep_device != nullptr && ep_device->device == hardware_device) {
+      return ep_device;
+    }
+  }
+
+  return ep_info.ep_devices.size() == 1 ? ep_info.ep_devices.front() : nullptr;
 }
 
 Status ValidateCompiledModelCompatibilityInfo(const VariantSelectionEpInfo& ep_info,
@@ -82,8 +108,20 @@ Status ValidateCompiledModelCompatibilityInfo(const VariantSelectionEpInfo& ep_i
   return Status::OK();
 }
 
-bool MatchesVariant(ModelVariantInfo& variant, const VariantSelectionEpInfo& ep_info) {
-  LOGS_DEFAULT(INFO) << "Checking model variant with EP constraint '" << variant.ep
+bool MatchesVariant(ModelVariantInfo& variant,
+                    const VariantSelectionEpInfo& ep_info,
+                    const OrtHardwareDevice** matched_hardware_device,
+                    const OrtEpDevice** matched_ep_device) {
+  if (matched_hardware_device != nullptr) {
+    *matched_hardware_device = nullptr;
+  }
+  if (matched_ep_device != nullptr) {
+    *matched_ep_device = nullptr;
+  }
+
+  LOGS_DEFAULT(INFO) << "Checking component '" << variant.component_model_name
+                     << "' package variant '" << variant.package_variant_id
+                     << "' with EP constraint '" << variant.ep
                      << "', device constraint '" << variant.device
                      << "' and compatibility info constraint '" << variant.compatibility_info
                      << "' against EP '" << ep_info.ep_name << "' with supported devices: "
@@ -93,36 +131,44 @@ bool MatchesVariant(ModelVariantInfo& variant, const VariantSelectionEpInfo& ep_
                             if (!devices_str.empty()) {
                               devices_str += ", ";
                             }
+
                             devices_str += hd->vendor + " " + std::to_string(hd->device_id);
                           }
+
                           return devices_str.empty() ? "none" : devices_str;
                         }();
 
-  // 1) Check EP constraint
   if (!variant.ep.empty() && variant.ep != ep_info.ep_name) {
     LOGS_DEFAULT(INFO) << "Variant EP constraint '" << variant.ep << "' does not match EP name '"
                        << ep_info.ep_name << "'. Skip this variant.";
     return false;
   }
 
-  // 2) Check device constraint
   bool device_ok = variant.device.empty();
+  std::vector<const OrtHardwareDevice*> constraint_devices = ep_info.hardware_devices;
 
-  // For EPs that don't implement the OrtEpFactory interface, ep_info.hardware_devices will be empty and ORT won't
-  // have the supported device information for those EPs.
-  // In that case, we will skip the device constraint validation for those EPs.
   if (ep_info.hardware_devices.empty()) {
     device_ok = true;
   }
-
-  // The constraint_devices is the target device(s) and will be passed to ValidateCompiledModelCompatibilityInfo
-  // for compatibility validation.
-  std::vector<const OrtHardwareDevice*> constraint_devices = ep_info.hardware_devices;
 
   if (!device_ok) {
     if (const auto* matched = FindMatchingHardwareDevice(variant.device, ep_info.hardware_devices)) {
       device_ok = true;
       constraint_devices = {matched};
+
+      if (matched_hardware_device != nullptr) {
+        *matched_hardware_device = matched;
+      }
+      if (matched_ep_device != nullptr) {
+        *matched_ep_device = FindEpDeviceForHardwareDevice(ep_info, matched);
+      }
+    }
+  } else {
+    if (!ep_info.hardware_devices.empty() && matched_hardware_device != nullptr) {
+      *matched_hardware_device = ep_info.hardware_devices.front();
+    }
+    if (matched_ep_device != nullptr) {
+      *matched_ep_device = FindEpDeviceForHardwareDevice(ep_info, matched_hardware_device != nullptr ? *matched_hardware_device : nullptr);
     }
   }
 
@@ -133,19 +179,6 @@ bool MatchesVariant(ModelVariantInfo& variant, const VariantSelectionEpInfo& ep_
     return false;
   }
 
-  // 3) Check ep_compatibility_info constraint
-  //
-  // ORT does not directly evaluate the architecture constraint. Instead, it relies on
-  // the ep_compatibility_info constraint, which may encode architecture information
-  // if needed.
-  //
-  // The ep_compatibility_info value is expected to match the EP compatibility string
-  // stored in the EPContext model metadata.
-  // (See OrtEp::GetCompiledModelCompatibilityInfo() for how this string is generated.)
-  //
-  // The EP implementation of EpFactory::ValidateCompiledModelCompatibilityInfo()
-  // is responsible for validating the compatibility string against the target device
-  // (i.e. OrtHardwareDevice), and returning the compatibility result.
   auto status = ValidateCompiledModelCompatibilityInfo(ep_info, variant.compatibility_info,
                                                        constraint_devices, &variant.compiled_model_compatibility);
   if (!status.IsOK()) {
@@ -164,24 +197,21 @@ bool MatchesVariant(ModelVariantInfo& variant, const VariantSelectionEpInfo& ep_
   }
 
   LOGS_DEFAULT(INFO) << "This model variant is selected and could be used for EP '" << ep_info.ep_name << "'.";
-
   return true;
 }
+
+ProviderOptions MergeProviderOptions(const ModelVariantInfo& variant, const VariantSelectionEpInfo& ep_info) {
+  ProviderOptions merged = variant.provider_options;
+  for (const auto& [key, value] : ep_info.ep_options) {
+    merged[key] = value;
+  }
+
+  return merged;
+}
+
 }  // namespace
 
-// Calculate a score for the model variant based on its constraints and metadata.
-//
-// It's only used to choose the best model variant among multiple candidates that match constraints.
-// Higher score means more preferred.
-//
-// For example:
-// If one model variant/EPContext is compatible with the EP and has compatiliby value indicating optimal compatibility
-// (i.e. compiled_model_compatibility == OrtCompiledModelCompatibility_EP_SUPPORTED_OPTIMAL) while another model variant/EPContext
-// is also compatible with the EP but has compatibility value indicating prefer recompilation
-// (i.e. compiled_model_compatibility == OrtCompiledModelCompatibility_EP_SUPPORTED_PREFER_RECOMPILATION),
-// the former will have a higher score and thus be selected.
-//
-int ModelVariantSelector::CalculateVariantScore(const ModelVariantInfo& variant) const {
+int ModelPackageResolver::CalculateVariantScore(const ModelVariantInfo& variant) const {
   int score = 0;
 
   if (variant.compiled_model_compatibility == OrtCompiledModelCompatibility_EP_SUPPORTED_OPTIMAL) {
@@ -190,13 +220,108 @@ int ModelVariantSelector::CalculateVariantScore(const ModelVariantInfo& variant)
     score += 50;
   }
 
-  // The base model with no constraints (meaning any EP can run it) gets a base score of 0.
-  // Other model variants with EP constraint get a higher score, so that they will be preferred over the base model.
   if (!variant.ep.empty()) {
     score += 10;
   }
 
+  if (!variant.device.empty()) {
+    score += 5;
+  }
+
   return score;
+}
+
+Status ModelPackageResolver::Resolve(const ModelPackageContext& context,
+                                     gsl::span<VariantSelectionEpInfo> ep_infos,
+                                     std::optional<ResolvedModelPackageInfo>& resolved_package) const {
+  resolved_package.reset();
+
+  const auto& variants = context.GetModelVariantInfos();
+  if (variants.empty() || ep_infos.empty()) {
+    return Status::OK();
+  }
+
+  std::map<std::string, std::vector<const ModelVariantInfo*>> variants_by_package_id;
+  for (const auto& variant : variants) {
+    const std::string package_variant_id = variant.package_variant_id.empty() ? variant.variant_name : variant.package_variant_id;
+    variants_by_package_id[package_variant_id].push_back(&variant);
+  }
+
+  ResolvedModelPackageInfo best_package{};
+  bool best_package_found = false;
+
+  for (const auto& [package_variant_id, grouped_variants] : variants_by_package_id) {
+    ResolvedModelPackageInfo current_package{};
+    current_package.package_variant_id = package_variant_id;
+    current_package.score = 0;
+
+    bool package_variant_valid = true;
+
+    for (const auto& component_model_name : context.GetComponentModelNames()) {
+      bool component_found = false;
+      int best_component_score = std::numeric_limits<int>::min();
+      ResolvedModelComponentInfo best_component{};
+
+      for (const auto* grouped_variant : grouped_variants) {
+        if (grouped_variant == nullptr || grouped_variant->component_model_name != component_model_name) {
+          continue;
+        }
+
+        for (const auto& ep_info : ep_infos) {
+          ModelVariantInfo candidate = *grouped_variant;
+          const OrtHardwareDevice* matched_hardware_device = nullptr;
+          const OrtEpDevice* matched_ep_device = nullptr;
+
+          if (!MatchesVariant(candidate, ep_info, &matched_hardware_device, &matched_ep_device)) {
+            continue;
+          }
+
+          const int candidate_score = CalculateVariantScore(candidate);
+          if (!component_found || candidate_score > best_component_score) {
+            component_found = true;
+            best_component_score = candidate_score;
+
+            best_component.component_model_name = candidate.component_model_name;
+            best_component.variant_name = candidate.variant_name;
+            best_component.package_variant_id = candidate.package_variant_id;
+            best_component.ep_name = candidate.ep.empty() ? ep_info.ep_name : candidate.ep;
+            best_component.device = candidate.device.empty() ? DeviceTypeToString(matched_hardware_device) : candidate.device;
+            best_component.architecture = candidate.architecture;
+            best_component.compatibility_info = candidate.compatibility_info;
+            best_component.provider_options = MergeProviderOptions(candidate, ep_info);
+            best_component.session_config_entries = candidate.session_config_entries;
+            best_component.compiled_model_compatibility = candidate.compiled_model_compatibility;
+            best_component.model_path = candidate.model_path;
+            best_component.hardware_device = matched_hardware_device;
+            best_component.ep_device = matched_ep_device;
+          }
+        }
+      }
+
+      if (!component_found) {
+        package_variant_valid = false;
+        break;
+      }
+
+      current_package.score += best_component_score;
+      current_package.resolved_components.push_back(std::move(best_component));
+    }
+
+    if (!package_variant_valid) {
+      continue;
+    }
+
+    if (!best_package_found || current_package.score > best_package.score) {
+      best_package = std::move(current_package);
+      best_package_found = true;
+    }
+  }
+
+  if (best_package_found) {
+    resolved_package = std::move(best_package);
+  }
+
+  return Status::OK();
 }
 
 Status ModelVariantSelector::SelectVariant(const ModelPackageContext& context,
@@ -204,94 +329,25 @@ Status ModelVariantSelector::SelectVariant(const ModelPackageContext& context,
                                            std::optional<std::filesystem::path>& selected_variant_path) const {
   selected_variant_path.reset();
 
-  // explicit local copy as this function will be modifying the variant info
-  // (e.g. setting compatibility validation result) during the selection process.
-  std::vector<ModelVariantInfo> variants = context.GetModelVariantInfos();
+  std::optional<ResolvedModelPackageInfo> resolved_package;
+  ModelPackageResolver resolver;
+  ORT_RETURN_IF_ERROR(resolver.Resolve(context, ep_infos, resolved_package));
 
-  if (variants.empty()) {
+  if (!resolved_package.has_value() || resolved_package->resolved_components.empty()) {
     return Status::OK();
   }
 
-  // Only one SelectionEpInfo in `ep_infos` is supported for now.
-  if (ep_infos.empty()) {
-    return Status::OK();
-  }
-  if (ep_infos.size() > 1) {
-    LOGS_DEFAULT(WARNING) << "Multiple EP info provided for model variant selection, but only the first one with ep name '"
-                          << ep_infos[0].ep_name << "' will be used.";
-  }
-  const auto& ep_info = ep_infos[0];
+  ORT_RETURN_IF_NOT(resolved_package->resolved_components.size() == 1,
+                    "Model package resolved to ", resolved_package->resolved_components.size(),
+                    " component models. Direct session creation only supports model packages that resolve to a single component model.");
 
-  std::unordered_set<size_t> candidate_indices_set;
-
-  // 1) Check unconstrained variants.
-  for (size_t i = 0, end = variants.size(); i < end; ++i) {
-    const auto& c = variants[i];
-    if (c.ep.empty() && c.device.empty() && c.architecture.empty() && c.compatibility_info.empty()) {
-      candidate_indices_set.insert(i);
-    }
-  }
-
-  // 2) Check all variants that match the EP info.
-  for (size_t i = 0, end = variants.size(); i < end; ++i) {
-    if (candidate_indices_set.count(i) > 0) {
-      continue;
-    }
-    auto& c = variants[i];
-    if (MatchesVariant(c, ep_info)) {
-      candidate_indices_set.insert(i);
-    }
-  }
-
-  // Log all matched candidates.
-  {
-    std::ostringstream oss;
-    oss << candidate_indices_set.size() << " Model variant(s) matched constraints: ";
-    size_t i = 0;
-    for (size_t idx : candidate_indices_set) {
-      const auto& path = variants[idx].model_path;
-      oss << path.string();
-      if (i + 1 < candidate_indices_set.size()) {
-        oss << "; ";
-      }
-      ++i;
-    }
-    LOGS_DEFAULT(INFO) << oss.str();
-  }
-
-  if (candidate_indices_set.empty()) {
-    return Status::OK();
-  }
-
-  // 3) If only one candidate, select it.
-  if (candidate_indices_set.size() == 1) {
-    selected_variant_path = variants[*candidate_indices_set.begin()].model_path;
-    return Status::OK();
-  }
-
-  // 4) If there are multiple candidates, choose the highest-score model variant among them.
-  int best_score = std::numeric_limits<int>::min();
-  size_t best_index = *candidate_indices_set.begin();
-
-  for (size_t idx : candidate_indices_set) {
-    const auto& v = variants[idx];
-    int variant_best_score = std::numeric_limits<int>::min();
-    variant_best_score = std::max(variant_best_score, CalculateVariantScore(v));
-
-    if (variant_best_score > best_score) {
-      best_score = variant_best_score;
-      best_index = idx;
-    }
-  }
-
-  selected_variant_path = variants[best_index].model_path;
-
+  selected_variant_path = resolved_package->resolved_components.front().model_path;
   return Status::OK();
 }
 
 ModelPackageContext::ModelPackageContext(const std::filesystem::path& package_root) {
   ModelPackageDescriptorParser parser(logging::LoggingManager::DefaultLogger());
-  ORT_THROW_IF_ERROR(parser.ParseVariantsFromRoot(package_root, model_variant_infos_));
+  ORT_THROW_IF_ERROR(parser.ParseVariantsFromRoot(package_root, model_variant_infos_, &component_model_names_));
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/session/model_package/model_package_context.h
+++ b/onnxruntime/core/session/model_package/model_package_context.h
@@ -5,6 +5,12 @@
 
 #if !defined(ORT_MINIMAL_BUILD)
 
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include "core/session/abi_session_options_impl.h"
 #include "core/session/environment.h"
 #include "core/session/onnxruntime_c_api.h"
@@ -16,11 +22,16 @@ using json = nlohmann::json;
 namespace onnxruntime {
 
 struct ModelVariantInfo {
+  std::string component_model_name{};
+  std::string variant_name{};
+  std::string package_variant_id{};
   std::string ep{};
   std::string device{};
   std::string architecture{};
   std::string compatibility_info{};
   std::unordered_map<std::string, std::string> metadata{};
+  ProviderOptions provider_options{};
+  std::unordered_map<std::string, std::string> session_config_entries{};
   OrtCompiledModelCompatibility compiled_model_compatibility{};
   std::filesystem::path model_path{};
 };
@@ -34,6 +45,28 @@ struct VariantSelectionEpInfo {
   ProviderOptions ep_options{};
 };
 
+struct ResolvedModelComponentInfo {
+  std::string component_model_name{};
+  std::string variant_name{};
+  std::string package_variant_id{};
+  std::string ep_name{};
+  std::string device{};
+  std::string architecture{};
+  std::string compatibility_info{};
+  ProviderOptions provider_options{};
+  std::unordered_map<std::string, std::string> session_config_entries{};
+  OrtCompiledModelCompatibility compiled_model_compatibility{};
+  std::filesystem::path model_path{};
+  const OrtHardwareDevice* hardware_device{nullptr};
+  const OrtEpDevice* ep_device{nullptr};
+};
+
+struct ResolvedModelPackageInfo {
+  std::string package_variant_id{};
+  int score{};
+  std::vector<ResolvedModelComponentInfo> resolved_components{};
+};
+
 class ModelPackageContext {
  public:
   ModelPackageContext(const std::filesystem::path& package_root);
@@ -42,23 +75,39 @@ class ModelPackageContext {
     return model_variant_infos_;
   }
 
+  const std::vector<std::string>& GetComponentModelNames() const noexcept {
+    return component_model_names_;
+  }
+
  private:
   std::vector<ModelVariantInfo> model_variant_infos_;
+  std::vector<std::string> component_model_names_;
+};
+
+class ModelPackageResolver {
+ public:
+  ModelPackageResolver() = default;
+
+  // Resolve the best package variant and per-component execution plan for the
+  // provided EP/device info. If no package variant matches, the output is reset.
+  Status Resolve(const ModelPackageContext& context,
+                 gsl::span<VariantSelectionEpInfo> ep_infos,
+                 std::optional<ResolvedModelPackageInfo>& resolved_package) const;
+
+ private:
+  int CalculateVariantScore(const ModelVariantInfo& variant) const;
 };
 
 class ModelVariantSelector {
  public:
   ModelVariantSelector() = default;
 
-  // Select model variants that match the provided EP/device info. If multiple
-  // variants match, the one with the highest variant score is chosen.
+  // Convenience wrapper for the legacy direct-session path. This only succeeds
+  // if the resolved package contains exactly one component model.
   Status SelectVariant(const ModelPackageContext& context,
                        gsl::span<VariantSelectionEpInfo> ep_infos,
                        std::optional<std::filesystem::path>& selected_variant_path) const;
 
- private:
-  // Compute a score for a variant
-  int CalculateVariantScore(const ModelVariantInfo& variant) const;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/session/model_package/model_package_descriptor_parser.cc
+++ b/onnxruntime/core/session/model_package/model_package_descriptor_parser.cc
@@ -25,11 +25,18 @@ struct VariantConstraintsSchema {
   std::optional<std::string> ep_compatibility_info;
 };
 
+struct ExecutionSchema {
+  std::optional<ProviderOptions> provider_options;
+  std::optional<std::unordered_map<std::string, std::string>> session_config_entries;
+};
+
 struct VariantSchema {
   std::optional<std::string> model_type;
   std::optional<std::string> model_file;
   std::optional<std::string> model_id;
+  std::optional<std::string> package_variant_id;
   std::optional<VariantConstraintsSchema> constraints;
+  std::optional<ExecutionSchema> execution;
 };
 
 struct ManifestSchema {
@@ -52,12 +59,28 @@ void from_json(const json& j, VariantConstraintsSchema& c) {
   }
 }
 
+void from_json(const json& j, ExecutionSchema& e) {
+  if (j.contains(kProviderOptionsKey) && j[kProviderOptionsKey].is_object()) {
+    e.provider_options = j[kProviderOptionsKey].get<ProviderOptions>();
+  }
+
+  if (j.contains(kSessionConfigEntriesKey) && j[kSessionConfigEntriesKey].is_object()) {
+    e.session_config_entries = j[kSessionConfigEntriesKey].get<std::unordered_map<std::string, std::string>>();
+  }
+}
+
 void from_json(const json& j, VariantSchema& v) {
   if (j.contains(kModelTypeKey) && j[kModelTypeKey].is_string()) v.model_type = j[kModelTypeKey].get<std::string>();
   if (j.contains(kModelFileKey) && j[kModelFileKey].is_string()) v.model_file = j[kModelFileKey].get<std::string>();
   if (j.contains(kModelIdKey) && j[kModelIdKey].is_string()) v.model_id = j[kModelIdKey].get<std::string>();
+  if (j.contains(kPackageVariantIdKey) && j[kPackageVariantIdKey].is_string()) {
+    v.package_variant_id = j[kPackageVariantIdKey].get<std::string>();
+  }
   if (j.contains(kConstraintsKey) && j[kConstraintsKey].is_object()) {
     v.constraints = j[kConstraintsKey].get<VariantConstraintsSchema>();
+  }
+  if (j.contains(kExecutionKey) && j[kExecutionKey].is_object()) {
+    v.execution = j[kExecutionKey].get<ExecutionSchema>();
   }
 }
 
@@ -121,6 +144,16 @@ void ApplyVariantConstraints(const VariantConstraintsSchema& c, ModelVariantInfo
   if (c.ep_compatibility_info.has_value()) variant.compatibility_info = *c.ep_compatibility_info;
 }
 
+void ApplyVariantExecution(const ExecutionSchema& execution, ModelVariantInfo& variant) {
+  if (execution.provider_options.has_value()) {
+    variant.provider_options = *execution.provider_options;
+  }
+
+  if (execution.session_config_entries.has_value()) {
+    variant.session_config_entries = *execution.session_config_entries;
+  }
+}
+
 std::string SanitizeModelIdForPath(std::string model_id) {
   for (char& ch : model_id) {
     switch (ch) {
@@ -148,11 +181,11 @@ std::string SanitizeModelIdForPath(std::string model_id) {
 // manifest.json). The parsing logic will first check for metadata.json to see if it's a component model root, and if
 // not found, it will look for manifest.json to treat it as a model package root.
 //
-// This function parses information from manifest.json and/or metadata.json for the model variants from the same
-// component model, producing a unified list of ModelVariantInfo.
+// This function parses information from manifest.json and/or metadata.json, producing a unified list of component
+// model entries. Component entries that share the same package_variant_id form a logical package-level variant.
 //
-// Note: If the package_root is a model package root, currently it only supports one component model.
-// #TODO: In the future we may want ORT to support running multiple component models in a single "virtual" session.
+// If package_root refers to a package root, multiple component models are allowed. Direct session creation remains a
+// single-component convenience path that resolves exactly one component model from the package.
 //
 // A manifest.json may look like this:
 //
@@ -189,8 +222,12 @@ std::string SanitizeModelIdForPath(std::string model_id) {
 //     }
 // }
 Status ModelPackageDescriptorParser::ParseVariantsFromRoot(const std::filesystem::path& package_root,
-                                                           /*out*/ std::vector<ModelVariantInfo>& variants) const {
+                                                           /*out*/ std::vector<ModelVariantInfo>& variants,
+                                                           /*out*/ std::vector<std::string>* component_model_names_out) const {
   variants.clear();
+  if (component_model_names_out != nullptr) {
+    component_model_names_out->clear();
+  }
 
   // package_root could be either a component model root (contains metadata.json) or a model package root (contains manifest.json).
 
@@ -229,6 +266,10 @@ Status ModelPackageDescriptorParser::ParseVariantsFromRoot(const std::filesystem
         metadata_schema.component_model_name.has_value()
             ? *metadata_schema.component_model_name
             : package_root.filename().string();
+
+    if (component_model_names_out != nullptr) {
+      component_model_names_out->push_back(component_model_name);
+    }
 
     // component-root mode
     ORT_RETURN_IF_ERROR(ParseVariantsFromComponent(component_model_name,
@@ -344,10 +385,8 @@ Status ModelPackageDescriptorParser::ParseVariantsFromRoot(const std::filesystem
     }
   }
 
-  if (component_model_names.size() != 1) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
-                           "manifest.json should contain exactly one component model name in \"component_models\" array "
-                           "or the models directory should contain exactly one component model.");
+  if (component_model_names_out != nullptr) {
+    *component_model_names_out = component_model_names;
   }
 
   for (const auto& component_model_name : component_model_names) {
@@ -434,6 +473,9 @@ Status ModelPackageDescriptorParser::ParseVariantsFromComponent(
     const VariantSchema& variant_schema = kv.second;
 
     ModelVariantInfo variant{};
+    variant.component_model_name = component_model_name;
+    variant.variant_name = variant_name;
+    variant.package_variant_id = variant_schema.package_variant_id.value_or(variant_name);
     std::filesystem::path model_dir = component_model_root / variant_name;
 
     if (variant_schema.model_id.has_value() && !variant_schema.model_id->empty()) {
@@ -469,6 +511,10 @@ Status ModelPackageDescriptorParser::ParseVariantsFromComponent(
 
     if (variant_schema.constraints.has_value()) {
       ApplyVariantConstraints(*variant_schema.constraints, variant);
+    }
+
+    if (variant_schema.execution.has_value()) {
+      ApplyVariantExecution(*variant_schema.execution, variant);
     }
 
     variants.push_back(std::move(variant));

--- a/onnxruntime/core/session/model_package/model_package_descriptor_parser.h
+++ b/onnxruntime/core/session/model_package/model_package_descriptor_parser.h
@@ -22,7 +22,11 @@ static constexpr const char* kVariantNameKey = "variant_name";
 static constexpr const char* kModelTypeKey = "model_type";
 static constexpr const char* kModelFileKey = "model_file";
 static constexpr const char* kModelIdKey = "model_id";
+static constexpr const char* kPackageVariantIdKey = "package_variant_id";
 static constexpr const char* kConstraintsKey = "constraints";
+static constexpr const char* kExecutionKey = "execution";
+static constexpr const char* kProviderOptionsKey = "provider_options";
+static constexpr const char* kSessionConfigEntriesKey = "session_config_entries";
 static constexpr const char* kEpKey = "ep";
 static constexpr const char* kDeviceKey = "device";
 static constexpr const char* kArchitectureKey = "architecture";
@@ -33,7 +37,8 @@ class ModelPackageDescriptorParser {
   explicit ModelPackageDescriptorParser(const logging::Logger& logger) : logger_(logger) {}
 
   Status ParseVariantsFromRoot(const std::filesystem::path& package_root,
-                               /*out*/ std::vector<ModelVariantInfo>& components) const;
+                               /*out*/ std::vector<ModelVariantInfo>& components,
+                               /*out*/ std::vector<std::string>* component_model_names = nullptr) const;
 
  private:
   Status ParseVariantsFromComponent(const std::string& component_model_name,

--- a/onnxruntime/core/session/utils.cc
+++ b/onnxruntime/core/session/utils.cc
@@ -3,11 +3,13 @@
 
 #include "core/session/utils.h"
 
+#include <algorithm>
 #include <memory>
 #include <utility>
 #include <filesystem>
 #include <optional>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "core/framework/error_code_helper.h"
@@ -142,74 +144,73 @@ Status PrintAvailableAndSelectedEpInfos(const Environment& env, std::vector<Vari
   return Status::OK();
 }
 
-// Gets EP info needed for model package workflow to select suitable model.
-//
-// For simplicity, there are some constraints in this initial implementation:
-// - Only one EP is supported, skip ORT CPU EP.
-// - All devices should be supported by the same EP
-//
+// Gets EP info needed for model package workflow to select suitable model package components.
+// One VariantSelectionEpInfo is produced per available EP. If CPU fallback is allowed, a CPU entry is synthesized so
+// that component models can explicitly target CPUExecutionProvider without requiring an explicit provider factory.
 Status GetVariantSelectionEpInfo(const OrtSessionOptions* session_options,
                                  std::vector<std::unique_ptr<IExecutionProvider>>& provider_list,
                                  std::vector<VariantSelectionEpInfo>& ep_infos) {
-  if (provider_list.empty()) {
-    return Status::OK();
-  }
+  ep_infos.clear();
 
-  // Pick the first non-CPU provider if available; otherwise fall back to the first provider.
-  size_t selected_idx = 0;
-  for (size_t i = 0; i < provider_list.size(); ++i) {
-    const auto& provider = provider_list[i];
-    if (provider && provider->Type() != onnxruntime::kCpuExecutionProvider) {
-      selected_idx = i;
-      break;
+  auto get_provider_options_from_session = [&](const std::string& ep_name) {
+    ProviderOptions provider_options;
+    if (session_options == nullptr) {
+      return provider_options;
     }
-  }
 
-  auto& provider = provider_list[selected_idx];
+    const std::string ep_options_prefix = OrtSessionOptions::GetProviderOptionPrefix(ep_name.c_str());
+    const auto& configs = session_options->value.config_options.configurations;
 
-  if (provider && provider->Type() == onnxruntime::kCpuExecutionProvider) {
-    return Status::OK();
-  }
-
-  ep_infos.push_back(VariantSelectionEpInfo{});
-  auto& ep_info = ep_infos.back();
-
-  // Add ep name to ep_info
-  ep_info.ep_name = provider->Type();
-  ORT_ENFORCE(!ep_info.ep_name.empty(), "EP name should have been set at this point.");
-
-  // Add ep devices to ep_info
-  auto& ep_devices = provider->GetEpDevices();
-  ep_info.ep_devices = ep_devices;
-
-  // Add ep factory to ep_info
-  ep_info.ep_factory = ep_devices.empty() ? nullptr : ep_devices.front()->ep_factory;
-
-  // Add hardware devices to ep_info
-  ep_info.hardware_devices.reserve(ep_devices.size());
-  for (const auto& ep_device : ep_devices) {
-    if (ep_device->device != nullptr) {
-      ep_info.hardware_devices.push_back(ep_device->device);
+    for (const auto& kv : configs) {
+      if (kv.first.rfind(ep_options_prefix, 0) == 0) {
+        provider_options.emplace(kv.first.substr(ep_options_prefix.size()), kv.second);
+      }
     }
-  }
 
-  // Add ep metadata to ep_info
-  ep_info.ep_metadata.reserve(ep_devices.size());
-  for (const auto& ep_device : ep_devices) {
-    ep_info.ep_metadata.push_back(&ep_device->ep_metadata);
-  }
+    return provider_options;
+  };
 
-  // Add ep provider options to ep_info
-  ProviderOptions provider_options;
-  const std::string ep_options_prefix = OrtSessionOptions::GetProviderOptionPrefix(ep_info.ep_name.c_str());
-  const auto& configs = session_options->value.config_options.configurations;
+  std::unordered_set<std::string> ep_names_seen;
 
-  for (const auto& kv : configs) {
-    if (kv.first.rfind(ep_options_prefix, 0) == 0) {                                   // starts with prefix
-      provider_options.emplace(kv.first.substr(ep_options_prefix.size()), kv.second);  // strip prefix
+  for (const auto& provider : provider_list) {
+    if (!provider) {
+      continue;
     }
+
+    ep_infos.push_back(VariantSelectionEpInfo{});
+    auto& ep_info = ep_infos.back();
+
+    ep_info.ep_name = provider->Type();
+    ORT_ENFORCE(!ep_info.ep_name.empty(), "EP name should have been set at this point.");
+    ep_names_seen.insert(ep_info.ep_name);
+
+    auto& ep_devices = provider->GetEpDevices();
+    ep_info.ep_devices = ep_devices;
+    ep_info.ep_factory = ep_devices.empty() ? nullptr : ep_devices.front()->ep_factory;
+
+    ep_info.hardware_devices.reserve(ep_devices.size());
+    ep_info.ep_metadata.reserve(ep_devices.size());
+    for (const auto& ep_device : ep_devices) {
+      if (ep_device != nullptr && ep_device->device != nullptr) {
+        ep_info.hardware_devices.push_back(ep_device->device);
+      }
+
+      if (ep_device != nullptr) {
+        ep_info.ep_metadata.push_back(&ep_device->ep_metadata);
+      }
+    }
+
+    ep_info.ep_options = get_provider_options_from_session(ep_info.ep_name);
   }
-  ep_info.ep_options = std::move(provider_options);
+
+  const bool disable_ort_cpu_ep = session_options != nullptr &&
+                                  session_options->value.config_options.GetConfigEntry(kOrtSessionOptionsDisableCPUEPFallback) == "1";
+  if (!disable_ort_cpu_ep && ep_names_seen.count(onnxruntime::kCpuExecutionProvider) == 0) {
+    ep_infos.push_back(VariantSelectionEpInfo{});
+    auto& cpu_ep_info = ep_infos.back();
+    cpu_ep_info.ep_name = onnxruntime::kCpuExecutionProvider;
+    cpu_ep_info.ep_options = get_provider_options_from_session(cpu_ep_info.ep_name);
+  }
 
   return Status::OK();
 }
@@ -465,14 +466,11 @@ static OrtStatus* CreateSessionAndLoadModelImpl(_In_ const OrtSessionOptions* op
     if (std::filesystem::is_directory(package_root, ec) &&
         !ec) {
 #if !defined(ORT_MINIMAL_BUILD)
-      OrtSessionOptions* options_to_use = nullptr;
       OrtSessionOptions ort_sess_options = options ? *options : OrtSessionOptions();
-      if (options) {
-        options_to_use = &ort_sess_options;
-      }
+      OrtSessionOptions* options_to_use = &ort_sess_options;
 
       std::vector<std::unique_ptr<IExecutionProvider>> provider_list;
-      const bool has_provider_factories = options_to_use != nullptr && !options_to_use->provider_factories.empty();
+      const bool has_provider_factories = !options_to_use->provider_factories.empty();
       ProviderPolicyContext provider_policy_context;
       std::vector<const OrtEpDevice*> execution_devices;
       std::vector<const OrtEpDevice*> devices_selected;
@@ -483,7 +481,7 @@ static OrtStatus* CreateSessionAndLoadModelImpl(_In_ const OrtSessionOptions* op
           auto provider = factory->CreateProvider(*options_to_use, *logging::LoggingManager::DefaultLogger().ToExternal());
           provider_list.push_back(std::move(provider));
         }
-      } else if (options_to_use != nullptr && options_to_use->value.ep_selection_policy.enable) {
+      } else if (options_to_use->value.ep_selection_policy.enable) {
         // No model loaded yet, so no model metadata. Pass empty metadata for now.
         // TODO: Pass metadata from manifest json to delegate policy?
         OrtKeyValuePairs model_metadata;
@@ -505,21 +503,58 @@ static OrtStatus* CreateSessionAndLoadModelImpl(_In_ const OrtSessionOptions* op
                                      "Check the EP selection policy or explicitly specify EPs.");
       }
 
-      // Select the most suitable model variant based on EP info and model constraints.
+      // Resolve the package variant and per-component execution plan based on EP info and model constraints.
       ModelPackageContext model_package_context(package_root);
-      ModelVariantSelector model_variant_selector;
-      std::optional<std::filesystem::path> selected_model_variant_path;
+      ModelPackageResolver model_package_resolver;
+      std::optional<ResolvedModelPackageInfo> resolved_model_package;
 
-      ORT_API_RETURN_IF_STATUS_NOT_OK(model_variant_selector.SelectVariant(model_package_context, ep_infos, selected_model_variant_path));
+      ORT_API_RETURN_IF_STATUS_NOT_OK(model_package_resolver.Resolve(model_package_context, ep_infos, resolved_model_package));
 
-      if (selected_model_variant_path.has_value()) {
-        selected_model_path = *selected_model_variant_path;
-        model_path_to_use = selected_model_path.c_str();
-      } else {
+      if (!resolved_model_package.has_value() || resolved_model_package->resolved_components.empty()) {
         return OrtApis::CreateStatus(ORT_FAIL,
-                                     "No suitable model variant found for the available execution providers."
+                                     "No suitable model variant found for the available execution providers. "
                                      "Try specifying the model file path instead of a model package, or check the "
                                      "model variants' constraints in the manifest json or metadata json.");
+      }
+
+      if (resolved_model_package->resolved_components.size() != 1) {
+        return OrtApis::CreateStatus(ORT_FAIL,
+                                     "Direct session creation only supports model packages that resolve to a single component model. "
+                                     "Resolve the package first and create one session per component model.");
+      }
+
+      const auto& resolved_component = resolved_model_package->resolved_components.front();
+      selected_model_path = resolved_component.model_path;
+      model_path_to_use = selected_model_path.c_str();
+
+      auto& configs = options_to_use->value.config_options.configurations;
+      for (const auto& [key, value] : resolved_component.session_config_entries) {
+        if (configs.count(key) == 0) {
+          ORT_API_RETURN_IF_STATUS_NOT_OK(
+              options_to_use->value.config_options.AddConfigEntry(key.c_str(), value.c_str()));
+        }
+      }
+
+      if (!resolved_component.ep_name.empty()) {
+        const std::string ep_options_prefix = OrtSessionOptions::GetProviderOptionPrefix(resolved_component.ep_name.c_str());
+        for (const auto& [key, value] : resolved_component.provider_options) {
+          const std::string prefixed_key = ep_options_prefix + key;
+          if (configs.count(prefixed_key) == 0) {
+            ORT_API_RETURN_IF_STATUS_NOT_OK(
+                options_to_use->value.config_options.AddConfigEntry(prefixed_key.c_str(), value.c_str()));
+          }
+        }
+      }
+
+      if (resolved_component.ep_name == onnxruntime::kCpuExecutionProvider) {
+        provider_list.clear();
+      } else {
+        provider_list.erase(
+            std::remove_if(provider_list.begin(), provider_list.end(),
+                           [&resolved_component](const std::unique_ptr<IExecutionProvider>& provider) {
+                             return !provider || provider->Type() != resolved_component.ep_name;
+                           }),
+            provider_list.end());
       }
 
       ORT_API_RETURN_IF_ERROR(CreateSessionAndLoadSingleModelImpl(options_to_use, env, model_path_to_use,
@@ -534,7 +569,6 @@ static OrtStatus* CreateSessionAndLoadModelImpl(_In_ const OrtSessionOptions* op
 
       // Log telemetry for auto EP selection
       if (!has_provider_factories &&
-          options_to_use != nullptr &&
           options_to_use->value.ep_selection_policy.enable) {
         ORT_API_RETURN_IF_STATUS_NOT_OK(provider_policy_context.LogTelemetry(*sess, *options_to_use,
                                                                              execution_devices, devices_selected));

--- a/onnxruntime/test/autoep/test_model_package.cc
+++ b/onnxruntime/test/autoep/test_model_package.cc
@@ -11,6 +11,8 @@
 
 #include "gtest/gtest.h"
 
+#include "core/framework/execution_provider.h"
+#include "core/session/onnxruntime_session_options_config_keys.h"
 #include "core/session/model_package/model_package_context.h"
 #include "core/session/model_package/model_package_descriptor_parser.h"
 #include "core/session/abi_devices.h"
@@ -94,6 +96,60 @@ std::string MakeManifestJson(std::string_view model_name,
       << component_model_name << R"("]
   })";
   return oss.str();
+}
+
+std::string MakeManifestJson(std::string_view model_name,
+                             std::initializer_list<std::string_view> component_model_names) {
+  std::ostringstream oss;
+  oss << R"({
+    "model_name": ")"
+      << model_name << R"(",
+    "model_version": "1.0",
+    "component_models": [)";
+
+  size_t index = 0;
+  for (std::string_view component_model_name : component_model_names) {
+    if (index++ > 0) {
+      oss << ", ";
+    }
+    oss << "\"" << component_model_name << "\"";
+  }
+
+  oss << R"(]
+  })";
+  return oss.str();
+}
+
+std::filesystem::path CreateComponentVariantModel(const std::filesystem::path& package_root,
+                                                  std::string_view component_model_name,
+                                                  std::string_view variant_name,
+                                                  const std::filesystem::path& source_model) {
+  const auto variant_dir = package_root / "models" / component_model_name / variant_name;
+  std::filesystem::create_directories(variant_dir);
+
+  std::error_code ec;
+  const auto variant_model_path = variant_dir / source_model.filename();
+  std::filesystem::copy_file(source_model, variant_model_path,
+                             std::filesystem::copy_options::overwrite_existing, ec);
+  return variant_model_path;
+}
+
+VariantSelectionEpInfo MakeEpInfoFromEpDevice(const OrtEpDevice* ep_device) {
+  VariantSelectionEpInfo ep_info{};
+  ep_info.ep_name = ep_device->ep_name;
+  ep_info.ep_factory = ep_device->ep_factory;
+  ep_info.ep_devices = {ep_device};
+  if (ep_device->device != nullptr) {
+    ep_info.hardware_devices = {ep_device->device};
+  }
+  ep_info.ep_metadata = {&ep_device->ep_metadata};
+  return ep_info;
+}
+
+VariantSelectionEpInfo MakeCpuEpInfo() {
+  VariantSelectionEpInfo ep_info{};
+  ep_info.ep_name = onnxruntime::kCpuExecutionProvider;
+  return ep_info;
 }
 
 }  // namespace
@@ -480,6 +536,171 @@ TEST(ModelPackageTest, LoadModelPackageAndRunInference_DiscoverComponentsFromMod
 
   // Cleanup
   std::error_code ec;
+  std::filesystem::remove_all(package_root, ec);
+}
+
+TEST(ModelPackageTest, ResolveModelPackage_MultiComponentSharedVariant) {
+  const auto package_root = std::filesystem::temp_directory_path() / "ort_model_package_multi_component_resolve";
+  std::error_code ec;
+  std::filesystem::remove_all(package_root, ec);
+
+  CreateManifestJson(package_root, MakeManifestJson("decoder", {"embedding", "iterator", "context", "lm_head"}));
+  CreateComponentVariantModel(package_root, "embedding", "qnn_mixed", std::filesystem::path{"testdata/mul_1.onnx"});
+  CreateComponentVariantModel(package_root, "iterator", "qnn_mixed", std::filesystem::path{"testdata/mul_1.onnx"});
+  CreateComponentVariantModel(package_root, "context", "qnn_mixed", std::filesystem::path{"testdata/mul_1.onnx"});
+  CreateComponentVariantModel(package_root, "lm_head", "qnn_mixed", std::filesystem::path{"testdata/mul_1.onnx"});
+
+  CreateComponentModelMetadata(package_root, "embedding", R"({
+    "component_model_name": "embedding",
+    "model_variants": {
+      "qnn_mixed": {
+        "model_file": "mul_1.onnx",
+        "constraints": {
+          "ep": "CPUExecutionProvider",
+          "device": "cpu"
+        }
+      }
+    }
+  })");
+
+  CreateComponentModelMetadata(package_root, "iterator", R"({
+    "component_model_name": "iterator",
+    "model_variants": {
+      "qnn_mixed": {
+        "model_file": "mul_1.onnx",
+        "constraints": {
+          "ep": "example_ep",
+          "device": "cpu"
+        },
+        "execution": {
+          "provider_options": {
+            "run_really_fast": "false"
+          },
+          "session_config_entries": {
+            "session.disable_cpu_ep_fallback": "1"
+          }
+        }
+      }
+    }
+  })");
+
+  CreateComponentModelMetadata(package_root, "context", R"({
+    "component_model_name": "context",
+    "model_variants": {
+      "qnn_mixed": {
+        "model_file": "mul_1.onnx",
+        "constraints": {
+          "ep": "example_ep",
+          "device": "cpu"
+        }
+      }
+    }
+  })");
+
+  CreateComponentModelMetadata(package_root, "lm_head", R"({
+    "component_model_name": "lm_head",
+    "model_variants": {
+      "qnn_mixed": {
+        "model_file": "mul_1.onnx",
+        "constraints": {
+          "ep": "CPUExecutionProvider",
+          "device": "cpu"
+        }
+      }
+    }
+  })");
+
+  RegisteredEpDeviceUniquePtr example_ep;
+  ASSERT_NO_FATAL_FAILURE(Utils::RegisterAndGetExampleEp(*ort_env, Utils::example_ep_info, example_ep));
+
+  ModelPackageContext context(package_root);
+  ASSERT_EQ(context.GetComponentModelNames().size(), 4u);
+
+  std::vector<VariantSelectionEpInfo> ep_infos;
+  ep_infos.push_back(MakeCpuEpInfo());
+  ep_infos.push_back(MakeEpInfoFromEpDevice(example_ep.get()));
+
+  ModelPackageResolver resolver;
+  std::optional<ResolvedModelPackageInfo> resolved_package;
+  auto status = resolver.Resolve(context, ep_infos, resolved_package);
+
+  ASSERT_TRUE(status.IsOK()) << status.ErrorMessage();
+  ASSERT_TRUE(resolved_package.has_value());
+  EXPECT_EQ(resolved_package->package_variant_id, "qnn_mixed");
+  ASSERT_EQ(resolved_package->resolved_components.size(), 4u);
+
+  std::unordered_map<std::string, const ResolvedModelComponentInfo*> components_by_name;
+  for (const auto& component : resolved_package->resolved_components) {
+    components_by_name.emplace(component.component_model_name, &component);
+    EXPECT_EQ(component.package_variant_id, "qnn_mixed");
+  }
+
+  ASSERT_EQ(components_by_name.count("embedding"), 1u);
+  ASSERT_EQ(components_by_name.count("iterator"), 1u);
+  ASSERT_EQ(components_by_name.count("context"), 1u);
+  ASSERT_EQ(components_by_name.count("lm_head"), 1u);
+
+  EXPECT_EQ(components_by_name.at("embedding")->ep_name, onnxruntime::kCpuExecutionProvider);
+  EXPECT_EQ(components_by_name.at("iterator")->ep_name, "example_ep");
+  EXPECT_EQ(components_by_name.at("context")->ep_name, "example_ep");
+  EXPECT_EQ(components_by_name.at("lm_head")->ep_name, onnxruntime::kCpuExecutionProvider);
+  EXPECT_EQ(components_by_name.at("iterator")->provider_options.at("run_really_fast"), "false");
+  EXPECT_EQ(components_by_name.at("iterator")->session_config_entries.at("session.disable_cpu_ep_fallback"), "1");
+
+  std::filesystem::remove_all(package_root, ec);
+}
+
+TEST(ModelPackageTest, LoadMultiComponentModelPackageRequiresExplicitResolve) {
+  const auto package_root = std::filesystem::temp_directory_path() / "ort_model_package_multi_component_session";
+  std::error_code ec;
+  std::filesystem::remove_all(package_root, ec);
+
+  CreateManifestJson(package_root, MakeManifestJson("decoder", {"embedding", "iterator"}));
+  CreateComponentVariantModel(package_root, "embedding", "qnn_mixed", std::filesystem::path{"testdata/mul_1.onnx"});
+  CreateComponentVariantModel(package_root, "iterator", "qnn_mixed", std::filesystem::path{"testdata/mul_1.onnx"});
+
+  CreateComponentModelMetadata(package_root, "embedding", R"({
+    "component_model_name": "embedding",
+    "model_variants": {
+      "qnn_mixed": {
+        "model_file": "mul_1.onnx",
+        "constraints": {
+          "ep": "CPUExecutionProvider",
+          "device": "cpu"
+        }
+      }
+    }
+  })");
+
+  CreateComponentModelMetadata(package_root, "iterator", R"({
+    "component_model_name": "iterator",
+    "model_variants": {
+      "qnn_mixed": {
+        "model_file": "mul_1.onnx",
+        "constraints": {
+          "ep": "example_ep",
+          "device": "cpu"
+        }
+      }
+    }
+  })");
+
+  RegisteredEpDeviceUniquePtr example_ep;
+  ASSERT_NO_FATAL_FAILURE(Utils::RegisterAndGetExampleEp(*ort_env, Utils::example_ep_info, example_ep));
+  Ort::ConstEpDevice plugin_ep_device(example_ep.get());
+
+  Ort::SessionOptions session_options;
+  std::unordered_map<std::string, std::string> ep_options;
+  session_options.AppendExecutionProvider_V2(*ort_env, {plugin_ep_device}, ep_options);
+
+  try {
+    Ort::Session session(*ort_env, package_root.c_str(), session_options);
+    FAIL() << "Expected multi-component model package load to fail";
+  } catch (const Ort::Exception& ex) {
+    EXPECT_THAT(ex.what(),
+                ::testing::HasSubstr("Direct session creation only supports model packages that resolve to a single component model"));
+  }
+
   std::filesystem::remove_all(package_root, ec);
 }
 


### PR DESCRIPTION
This pull request refines the ONNX Runtime model package selection logic and enhances the documentation to clarify multi-component package handling and variant selection. The main changes include improved documentation for package-level variants, an expanded schema supporting per-component execution hints, and a refactored implementation for selecting the best model package variant when multiple components are involved.

**Documentation improvements:**

* Clarified that a "model variant" can be a logical package-level variant formed by multiple component models sharing the same variant name, and explained how package-level selection works. [[1]](diffhunk://#diff-5818bb1df63208258edcb153dc5354ff33db8d8f7f3c3cf9206e85560d754960R21-R22) [[2]](diffhunk://#diff-5818bb1df63208258edcb153dc5354ff33db8d8f7f3c3cf9206e85560d754960L130-R147)
* Updated the schema to add `package_variant_id` for logical grouping and an `execution` object for per-component execution hints, including `provider_options` and `session_config_entries`. [[1]](diffhunk://#diff-5818bb1df63208258edcb153dc5354ff33db8d8f7f3c3cf9206e85560d754960R97-R100) [[2]](diffhunk://#diff-5818bb1df63208258edcb153dc5354ff33db8d8f7f3c3cf9206e85560d754960R115) [[3]](diffhunk://#diff-5818bb1df63208258edcb153dc5354ff33db8d8f7f3c3cf9206e85560d754960R124-R128)

**Model package selection refactor:**

* Refactored the variant selection logic in `model_package_context.cc` to support resolving multi-component package variants, grouping by `package_variant_id`, and scoring the best package variant based on compatibility and constraints.
* Introduced helper functions such as `FindEpDeviceForHardwareDevice` and `MergeProviderOptions` to streamline device/EP matching and provider options merging during variant resolution. [[1]](diffhunk://#diff-6a79338f7a8572899c7eededd031dee511908b441d67e6b1b9936a21382df2ccR71-R85) [[2]](diffhunk://#diff-6a79338f7a8572899c7eededd031dee511908b441d67e6b1b9936a21382df2ccL167-R214)
* Updated the direct session creation path to only allow single-component resolved packages, enforcing correct usage for multi-component packages.

These changes improve the flexibility and correctness of model package handling, especially for complex packages targeting multiple execution providers and devices.### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


