### PR TITLE
[Cherry-Pick] Add OrtModel input support for Compile API (#27332)

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeCompileApiMethods.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeCompileApiMethods.shared.cs
@@ -25,6 +25,7 @@ namespace Microsoft.ML.OnnxRuntime.CompileApi
         public IntPtr ModelCompilationOptions_SetGraphOptimizationLevel;
         public IntPtr ModelCompilationOptions_SetOutputModelWriteFunc;
         public IntPtr ModelCompilationOptions_SetOutputModelGetInitializerLocationFunc;
+        public IntPtr ModelCompilationOptions_SetInputModel;
     }
 
     internal class NativeMethods
@@ -136,6 +137,12 @@ namespace Microsoft.ML.OnnxRuntime.CompileApi
         public DOrtModelCompilationOptions_SetOutputModelGetInitializerLocationFunc
                         OrtModelCompilationOptions_SetOutputModelGetInitializerLocationFunc;
 
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate IntPtr /* OrtStatus* */ DOrtModelCompilationOptions_SetInputModel(
+            IntPtr /* OrtModelCompilationOptions* */ options,
+            IntPtr /* const OrtModel* */ inputModel);
+        public DOrtModelCompilationOptions_SetInputModel OrtModelCompilationOptions_SetInputModel;
+
         internal NativeMethods(OnnxRuntime.NativeMethods.DOrtGetCompileApi getCompileApi)
         {
 
@@ -216,6 +223,11 @@ namespace Microsoft.ML.OnnxRuntime.CompileApi
                 GetDelegateForFunctionPointer(
                     _compileApi.ModelCompilationOptions_SetOutputModelGetInitializerLocationFunc,
                     typeof(DOrtModelCompilationOptions_SetOutputModelGetInitializerLocationFunc));
+
+            OrtModelCompilationOptions_SetInputModel =
+                (DOrtModelCompilationOptions_SetInputModel)Marshal.GetDelegateForFunctionPointer(
+                    _compileApi.ModelCompilationOptions_SetInputModel,
+                    typeof(DOrtModelCompilationOptions_SetInputModel));
 
         }
     }

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -8015,6 +8015,29 @@ struct OrtCompileApi {
   ORT_API2_STATUS(ModelCompilationOptions_SetOutputModelGetInitializerLocationFunc,
                   _In_ OrtModelCompilationOptions* model_compile_options,
                   _In_ OrtGetInitializerLocationFunc get_initializer_location_func, _In_ void* state);
+
+  /** \brief Sets the OrtModel to compile.
+   *
+   * Sets an OrtModel created via the Model Editor API as the input for compilation.
+   *
+   * The input model's source (file path, memory buffer, or OrtModel) must be set with
+   * one of: ModelCompilationOptions_SetInputModelPath, ModelCompilationOptions_SetInputModelFromBuffer,
+   * or ModelCompilationOptions_SetInputModel.
+   *
+   * The OrtModel must have a complete graph with inputs, outputs, and nodes defined.
+   * The caller retains ownership of the OrtModel and must not release it until after
+   * CompileModel returns.
+   *
+   * \param[in] model_compile_options The OrtModelCompilationOptions instance.
+   * \param[in] model The OrtModel to compile. The model is borrowed (not copied or owned).
+   *
+   * \snippet{doc} snippets.dox OrtStatus Return Value
+   *
+   * \since Version 1.24.
+   */
+  ORT_API2_STATUS(ModelCompilationOptions_SetInputModel,
+                  _In_ OrtModelCompilationOptions* model_compile_options,
+                  _In_ const OrtModel* model);
 };
 
 /**

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -1599,6 +1599,8 @@ struct ModelCompilationOptions : detail::Base<OrtModelCompilationOptions> {
   ModelCompilationOptions& SetFlags(uint32_t flags);                                    ///< Wraps OrtApi::ModelCompilationOptions_SetFlags
 
   ModelCompilationOptions& SetGraphOptimizationLevel(GraphOptimizationLevel graph_optimization_level);  ///< Wraps OrtApi::ModelCompilationOptions_SetGraphOptimizationLevel
+
+  ModelCompilationOptions& SetInputModel(const OrtModel* model);  ///< Wraps OrtCompileApi::ModelCompilationOptions_SetInputModel
 };
 
 /** \brief Compiles an input model to generate a model with EPContext nodes that execute EP-specific kernels. Wraps OrtApi::CompileModels.

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -1170,6 +1170,11 @@ inline ModelCompilationOptions& ModelCompilationOptions::SetGraphOptimizationLev
   return *this;
 }
 
+inline ModelCompilationOptions& ModelCompilationOptions::SetInputModel(const OrtModel* model) {
+  Ort::ThrowOnError(GetCompileApi().ModelCompilationOptions_SetInputModel(this->p_, model));
+  return *this;
+}
+
 namespace detail {
 
 template <typename T>

--- a/onnxruntime/core/session/compile_api.cc
+++ b/onnxruntime/core/session/compile_api.cc
@@ -306,6 +306,27 @@ ORT_API_STATUS_IMPL(OrtCompileAPI::ModelCompilationOptions_SetGraphOptimizationL
   API_IMPL_END
 }
 
+ORT_API_STATUS_IMPL(OrtCompileAPI::ModelCompilationOptions_SetInputModel,
+                    _In_ OrtModelCompilationOptions* ort_model_compile_options,
+                    _In_ const OrtModel* model) {
+  API_IMPL_BEGIN
+#if !defined(ORT_MINIMAL_BUILD)
+  auto model_compile_options = reinterpret_cast<onnxruntime::ModelCompilationOptions*>(ort_model_compile_options);
+
+  if (model == nullptr) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "Invalid input model: OrtModel pointer is null");
+  }
+
+  model_compile_options->SetInputModel(model);
+  return nullptr;
+#else
+  ORT_UNUSED_PARAMETER(ort_model_compile_options);
+  ORT_UNUSED_PARAMETER(model);
+  return OrtApis::CreateStatus(ORT_NOT_IMPLEMENTED, "Compile API is not supported in this build");
+#endif  // !defined(ORT_MINIMAL_BUILD)
+  API_IMPL_END
+}
+
 ORT_API_STATUS_IMPL(OrtCompileAPI::CompileModel, _In_ const OrtEnv* env,
                     _In_ const OrtModelCompilationOptions* ort_model_compile_options) {
   API_IMPL_BEGIN
@@ -343,6 +364,9 @@ static constexpr OrtCompileApi ort_compile_api = {
     &OrtCompileAPI::ModelCompilationOptions_SetOutputModelWriteFunc,
     &OrtCompileAPI::ModelCompilationOptions_SetOutputModelGetInitializerLocationFunc,
     // End of Version 23 - DO NOT MODIFY ABOVE
+
+    &OrtCompileAPI::ModelCompilationOptions_SetInputModel,
+    // End of Version 24 - DO NOT MODIFY ABOVE
 };
 
 // checks that we don't violate the rule that the functions must remain in the slots they were originally assigned
@@ -350,6 +374,8 @@ static_assert(offsetof(OrtCompileApi, CompileModel) / sizeof(void*) == 8,
               "Size of version 22 Api cannot change");  // initial version in ORT 1.22
 static_assert(offsetof(OrtCompileApi, ModelCompilationOptions_SetOutputModelGetInitializerLocationFunc) / sizeof(void*) == 13,
               "Size of version 23 of Api cannot change");
+static_assert(offsetof(OrtCompileApi, ModelCompilationOptions_SetInputModel) / sizeof(void*) == 14,
+              "Size of version 24 of Api cannot change");
 
 ORT_API(const OrtCompileApi*, OrtCompileAPI::GetCompileApi) {
   return &ort_compile_api;

--- a/onnxruntime/core/session/compile_api.h
+++ b/onnxruntime/core/session/compile_api.h
@@ -41,5 +41,8 @@ ORT_API_STATUS_IMPL(ModelCompilationOptions_SetOutputModelWriteFunc,
 ORT_API_STATUS_IMPL(ModelCompilationOptions_SetOutputModelGetInitializerLocationFunc,
                     _In_ OrtModelCompilationOptions* model_compile_options,
                     _In_ OrtGetInitializerLocationFunc get_initializer_location_func, _In_ void* state);
+ORT_API_STATUS_IMPL(ModelCompilationOptions_SetInputModel,
+                    _In_ OrtModelCompilationOptions* model_compile_options,
+                    _In_ const OrtModel* model);
 
 }  // namespace OrtCompileAPI

--- a/onnxruntime/core/session/model_compilation_options.h
+++ b/onnxruntime/core/session/model_compilation_options.h
@@ -10,6 +10,7 @@
 #include "core/common/status.h"
 #include "core/common/path_string.h"
 #include "core/framework/allocator.h"
+#include "core/graph/model_editor_api_types.h"
 #include "core/session/abi_session_options_impl.h"
 #include "core/session/onnxruntime_c_api.h"
 #include "core/session/onnxruntime_session_options_config_keys.h"
@@ -44,6 +45,14 @@ class ModelCompilationOptions {
   /// <param name="input_model_data">Buffer containing the input ONNX model</param>
   /// <param name="input_model_data_size">The size in bytes of the input model's buffer</param>
   void SetInputModelFromBuffer(const void* input_model_data, size_t input_model_data_size);
+
+  /// <summary>
+  /// Sets the OrtModel to compile.
+  /// The OrtModel is borrowed (not copied) - caller must keep it alive until CompileModel returns.
+  /// Overrides any previous call to SetInputModelPath(), SetInputModelFromBuffer(), or SetInputModel().
+  /// </summary>
+  /// <param name="model">The OrtModel to compile</param>
+  void SetInputModel(const OrtModel* model);
 
   /// <summary>
   /// Sets the file path to store the output/compiled ONNX model.
@@ -133,6 +142,18 @@ class ModelCompilationOptions {
   bool InputModelComesFromFile() const;
 
   /// <summary>
+  /// Returns true if the input model comes from an OrtModel pointer.
+  /// </summary>
+  /// <returns>true if input model comes from an OrtModel</returns>
+  bool InputModelComesFromOrtModel() const;
+
+  /// <summary>
+  /// Returns the OrtModel to compile, or nullptr if not set.
+  /// </summary>
+  /// <returns>pointer to the OrtModel or nullptr</returns>
+  const OrtModel* GetInputModel() const;
+
+  /// <summary>
   /// Returns the buffer that contains the bytes for the input ONNX model.
   /// Returns nullptr if the input model is not stored in a buffer.
   /// </summary>
@@ -162,9 +183,9 @@ class ModelCompilationOptions {
   // Telemetry helper methods
 
   /// <summary>
-  /// Returns a string describing the input source type: "file" or "buffer".
+  /// Returns a string describing the input source type: "file", "buffer", or "ort_model".
   /// </summary>
-  /// <returns>"file" or "buffer"</returns>
+  /// <returns>"file", "buffer", or "ort_model"</returns>
   std::string GetInputSourceForTelemetry() const;
 
   /// <summary>
@@ -205,6 +226,7 @@ class ModelCompilationOptions {
   std::filesystem::path input_model_path_;
   const void* input_model_data_ = nullptr;
   size_t input_model_data_size_ = 0;
+  const OrtModel* input_model_ = nullptr;  // Borrowed pointer
 };
 }  // namespace onnxruntime
 #endif  // !defined(ORT_MINIMAL_BUILD)


### PR DESCRIPTION
### Description
This change adds a feature to the Compile API, allowing an in-memory OrtModel created via the Model Editor API to be compiled directly without first serializing to a file or buffer.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. --> The Model Editor API and Compile API are both public C APIs in the ONNX Runtime, but until now there was no way to pass a programmatically constructed model directly to compilation. This change attempts to closes that gap (see #26750) and ensures the new code path behaves identically to the established file and buffer paths.

---------

### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Cherry-pick is needed to unblock WebNN Origin Trial work. 