### PR TITLE
Update shape operator inference for opset 15 with start and end attributes

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -1837,7 +1837,25 @@ class SymbolicShapeInference:
         self._fuse_tensor_type(node, 0, vi_out_seq.type, vi_tensor.type)
 
     def _infer_Shape(self, node):  # noqa: N802
-        self.sympy_data_[node.output[0]] = self._get_sympy_shape(node, 0)
+        sympy_shape = self._get_sympy_shape(node, 0)
+
+        # Shape op started supporting start/end attributes in opset 15.
+        if get_opset(self.out_mp_) >= 15:
+            rank = len(sympy_shape)
+            start = get_attribute(node, "start", 0)
+            end = get_attribute(node, "end", rank)
+
+            # Normalize negative indices, then clamp into [0, rank].
+            if start < 0:
+                start += rank
+            if end < 0:
+                end += rank
+            start = max(0, min(start, rank))
+            end = max(0, min(end, rank))
+
+            sympy_shape = sympy_shape[start:end]
+
+        self.sympy_data_[node.output[0]] = sympy_shape
 
     def _infer_Size(self, node):  # noqa: N802
         sympy_shape = self._get_sympy_shape(node, 0)

--- a/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
@@ -205,6 +205,32 @@ class TestSymbolicShapeInferenceForOperators(unittest.TestCase):
         ]
         self._check_shapes(graph, inferred.graph, expected_shapes)
 
+    def test_shape_with_start_end_opset_15(self):
+        graph = helper.make_graph(
+            [
+                helper.make_node("Shape", ["input"], ["partial_shape"], start=1, end=3),
+                helper.make_node("ConstantOfShape", ["partial_shape"], ["output"]),
+            ],
+            "Shape_Start_End_Test",
+            [
+                helper.make_tensor_value_info(
+                    "input", TensorProto.FLOAT, ["b", "s", "h"]
+                ),
+            ],
+            [
+                helper.make_tensor_value_info("output", TensorProto.FLOAT, None),
+            ],
+        )
+        model = helper.make_model(graph, producer_name="Shape_Start_End_Test_Model")
+        model.opset_import[0].version = 15
+
+        inferred = SymbolicShapeInference.infer_shapes(model, auto_merge=True)
+        expected_shapes = [
+            helper.make_tensor_value_info("partial_shape", TensorProto.INT64, [2]),
+            helper.make_tensor_value_info("output", TensorProto.FLOAT, ["s", "h"]),
+        ]
+        self._check_shapes(graph, inferred.graph, expected_shapes)
+
     def test_embed_layer_norm(self):
         hidden_size = 32
         initializers = [


### PR DESCRIPTION
### Description
Fixes a bug in symbolic shape inference class where shape operator inference was done without using start and end attributes for opset 15 or greater.

### Motivation and Context
- Symbolic shape inference using dynamic axes and torch export with dynamo fails as shape operator infer function.
- The shape operator in its actual implementation returns the full shape tensor (ignoring the start and end attributes) leading to failed auto merging of dimensions emerging from the _merge_symbols function.
- This modification/bugfix makes the infer shape function compatible with pytorch dynamo export graph and the resulting model can be quantized successfully.


