### PR TITLE
[CI] fix: release NPM requires reactive-native by default

### DIFF
--- a/tools/python/trigger_and_wait_pipelines.py
+++ b/tools/python/trigger_and_wait_pipelines.py
@@ -144,6 +144,7 @@ PIPELINE_REGISTRY: list[PipelineConfig] = [
         key="npm_packaging",
         template_parameters={
             "NpmPublish": "production (@latest)",
+            "EnableReactNative": True,
         },
     ),
     PipelineConfig(


### PR DESCRIPTION
### Description

Meta-release pipeline now triggers NPM packaging w/ react-native enabled.

### Motivation and Context

React native is currently required for releases.


