### PR TITLE
[CI] fix: use internal feed for NPM on ADO

### DIFF
--- a/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-cuda-minimal-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-cuda-minimal-ci-pipeline.yml
@@ -93,6 +93,9 @@ jobs:
               --volume $(Build.BinariesDirectory):/build \
               --volume /data/models:/build/models:ro \
               --volume $HOME/.onnx:/home/onnxruntimedev/.onnx \
+              -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc --volume $(Agent.TempDirectory)/.npmrc:/tmp/.npmrc:ro \
+              --volume $HOME/.m2:/home/onnxruntimedev/.m2:ro \
+              --volume $HOME/.gradle:/home/onnxruntimedev/.gradle \
               -e ALLOW_RELEASED_ONNX_OPSET_ONLY=0 \
               -e NIGHTLY_BUILD \
               -e BUILD_BUILDNUMBER \

--- a/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-cuda-minimal-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-cuda-minimal-ci-pipeline.yml
@@ -93,7 +93,8 @@ jobs:
               --volume $(Build.BinariesDirectory):/build \
               --volume /data/models:/build/models:ro \
               --volume $HOME/.onnx:/home/onnxruntimedev/.onnx \
-              -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc --volume $(Agent.TempDirectory)/.npmrc:/tmp/.npmrc:ro \
+              -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc \
+              --volume "${NPM_CONFIG_USERCONFIG}:/tmp/.npmrc:ro" \
               --volume $HOME/.m2:/home/onnxruntimedev/.m2:ro \
               --volume $HOME/.gradle:/home/onnxruntimedev/.gradle \
               -e ALLOW_RELEASED_ONNX_OPSET_ONLY=0 \

--- a/tools/ci_build/github/azure-pipelines/stages/nodejs-linux-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nodejs-linux-packaging-stage.yml
@@ -33,6 +33,9 @@ stages:
     - checkout: self
       clean: true
       submodules: recursive
+
+    - template: ../templates/setup-feeds-and-python-steps.yml
+
     - template: ../templates/get-docker-image-steps.yml
       parameters:
         Dockerfile: tools/ci_build/github/linux/docker/inference/x86_64/default/cuda${{ variables.CUDA_VERSION_MAJOR }}/Dockerfile

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -76,6 +76,7 @@ jobs:
         docker run -e SYSTEM_COLLECTIONURI --rm --volume /data/onnx:/data/onnx:ro --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build \
         -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc --volume $(Agent.TempDirectory)/.npmrc:/tmp/.npmrc:ro \
         --volume $HOME/.m2:/home/onnxruntimedev/.m2:ro \
+        --volume $HOME/.gradle:/home/onnxruntimedev/.gradle:ro \
         --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimecpubuildcentos8${{parameters.OnnxruntimeArch}}_packaging /bin/bash -c "python3 \
         /onnxruntime_src/tools/ci_build/build.py --enable_lto --build_java --build_nodejs --build_dir /build --config Release \
         --skip_submodule_sync --parallel --use_vcpkg --use_vcpkg_ms_internal_asset_cache --use_binskim_compliant_compile_flags --use_vcpkg --use_vcpkg_ms_internal_asset_cache --build_shared_lib ${{ parameters.AdditionalBuildFlags }} && cd /build/Release && make install DESTDIR=/build/installed"

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -74,6 +74,7 @@ jobs:
         set -e -x
         mkdir -p $HOME/.onnx
         docker run -e SYSTEM_COLLECTIONURI --rm --volume /data/onnx:/data/onnx:ro --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build \
+        -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc --volume $(AGENT_TEMPDIRECTORY)/.npmrc:/tmp/.npmrc:ro \
         --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimecpubuildcentos8${{parameters.OnnxruntimeArch}}_packaging /bin/bash -c "python3 \
         /onnxruntime_src/tools/ci_build/build.py --enable_lto --build_java --build_nodejs --build_dir /build --config Release \
         --skip_submodule_sync --parallel --use_vcpkg --use_vcpkg_ms_internal_asset_cache --use_binskim_compliant_compile_flags --use_vcpkg --use_vcpkg_ms_internal_asset_cache --build_shared_lib ${{ parameters.AdditionalBuildFlags }} && cd /build/Release && make install DESTDIR=/build/installed"

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -74,7 +74,8 @@ jobs:
         set -e -x
         mkdir -p $HOME/.onnx
         docker run -e SYSTEM_COLLECTIONURI --rm --volume /data/onnx:/data/onnx:ro --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build \
-        -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc --volume $(Agent.TempDirectory)/.npmrc:/tmp/.npmrc:ro \
+        -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc \
+        --volume "${NPM_CONFIG_USERCONFIG}:/tmp/.npmrc:ro" \
         --volume $HOME/.m2:/home/onnxruntimedev/.m2:ro \
         --volume $HOME/.gradle:/home/onnxruntimedev/.gradle \
         --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimecpubuildcentos8${{parameters.OnnxruntimeArch}}_packaging /bin/bash -c "python3 \

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -74,7 +74,7 @@ jobs:
         set -e -x
         mkdir -p $HOME/.onnx
         docker run -e SYSTEM_COLLECTIONURI --rm --volume /data/onnx:/data/onnx:ro --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build \
-        -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc --volume $(AGENT_TEMPDIRECTORY)/.npmrc:/tmp/.npmrc:ro \
+        -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc --volume $(Agent.TempDirectory)/.npmrc:/tmp/.npmrc:ro \
         --volume $HOME/.m2:/home/onnxruntimedev/.m2:ro \
         --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimecpubuildcentos8${{parameters.OnnxruntimeArch}}_packaging /bin/bash -c "python3 \
         /onnxruntime_src/tools/ci_build/build.py --enable_lto --build_java --build_nodejs --build_dir /build --config Release \

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -76,7 +76,7 @@ jobs:
         docker run -e SYSTEM_COLLECTIONURI --rm --volume /data/onnx:/data/onnx:ro --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build \
         -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc --volume $(Agent.TempDirectory)/.npmrc:/tmp/.npmrc:ro \
         --volume $HOME/.m2:/home/onnxruntimedev/.m2:ro \
-        --volume $HOME/.gradle:/home/onnxruntimedev/.gradle:ro \
+        --volume $HOME/.gradle:/home/onnxruntimedev/.gradle \
         --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimecpubuildcentos8${{parameters.OnnxruntimeArch}}_packaging /bin/bash -c "python3 \
         /onnxruntime_src/tools/ci_build/build.py --enable_lto --build_java --build_nodejs --build_dir /build --config Release \
         --skip_submodule_sync --parallel --use_vcpkg --use_vcpkg_ms_internal_asset_cache --use_binskim_compliant_compile_flags --use_vcpkg --use_vcpkg_ms_internal_asset_cache --build_shared_lib ${{ parameters.AdditionalBuildFlags }} && cd /build/Release && make install DESTDIR=/build/installed"

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -75,6 +75,7 @@ jobs:
         mkdir -p $HOME/.onnx
         docker run -e SYSTEM_COLLECTIONURI --rm --volume /data/onnx:/data/onnx:ro --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build \
         -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc --volume $(AGENT_TEMPDIRECTORY)/.npmrc:/tmp/.npmrc:ro \
+        --volume $HOME/.m2:/home/onnxruntimedev/.m2:ro \
         --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimecpubuildcentos8${{parameters.OnnxruntimeArch}}_packaging /bin/bash -c "python3 \
         /onnxruntime_src/tools/ci_build/build.py --enable_lto --build_java --build_nodejs --build_dir /build --config Release \
         --skip_submodule_sync --parallel --use_vcpkg --use_vcpkg_ms_internal_asset_cache --use_binskim_compliant_compile_flags --use_vcpkg --use_vcpkg_ms_internal_asset_cache --build_shared_lib ${{ parameters.AdditionalBuildFlags }} && cd /build/Release && make install DESTDIR=/build/installed"

--- a/tools/ci_build/github/azure-pipelines/templates/setup-feeds-and-python-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/setup-feeds-and-python-steps.yml
@@ -35,11 +35,18 @@ steps:
       # ensure we have a clean/empty npm config. config file must exist prior to `npmAuthenticate`.
       $npmrcPath = "${env:AGENT_TEMPDIRECTORY}/.npmrc"
 
-      if (Test-Path $npmrcPath) { Remove-Item $npmrcPath }
+      if (Test-Path $npmrcPath)
+      {
+        Remove-Item $npmrcPath
+      }
+
       Set-Content -Path $npmrcPath -Value @"
-      registry=https://aiinfra.pkgs.visualstudio.com/Lotus/_packaging/${{parameters.artifactFeeds}}/npm/registry/
+      registry=https://aiinfra.pkgs.visualstudio.com/_packaging/${{parameters.artifactFeeds}}/npm/registry/
       always-auth=true
       "@
+
+      Write-Host "Generated npmrc contents:"
+      Get-Content $npmrcPath | Write-Host
 
       echo "##vso[task.setvariable variable=NPM_CONFIG_USERCONFIG]${npmrcPath}"
 

--- a/tools/ci_build/github/azure-pipelines/templates/setup-feeds-and-python-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/setup-feeds-and-python-steps.yml
@@ -36,7 +36,10 @@ steps:
       $npmrcPath = "${env:AGENT_TEMPDIRECTORY}/.npmrc"
 
       if (Test-Path $npmrcPath) { Remove-Item $npmrcPath }
-      New-Item $npmrcPath -ItemType File -Force
+      Set-Content -Path $npmrcPath -Value @"
+      registry=https://aiinfra.pkgs.visualstudio.com/Lotus/_packaging/${{parameters.artifactFeeds}}/npm/registry/
+      always-auth=true
+      "@
 
       echo "##vso[task.setvariable variable=NPM_CONFIG_USERCONFIG]${npmrcPath}"
 

--- a/tools/ci_build/github/azure-pipelines/templates/setup-feeds-and-python-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/setup-feeds-and-python-steps.yml
@@ -29,19 +29,16 @@ steps:
 # use `PowerShell@2` instead of `pwsh` as it is available on arm64 agents, whereas `pwsh` is not. (2026-04-15)
 - task: PowerShell@2
   displayName: 'NPM - set NPM_CONFIG_USERCONFIG to agent temp config'
+  env:
+    artifact_feed: ${{ parameters.artifactFeeds }}
   inputs:
     targetType: 'inline'
     script: |
       # ensure we have a clean/empty npm config. config file must exist prior to `npmAuthenticate`.
       $npmrcPath = "${env:AGENT_TEMPDIRECTORY}/.npmrc"
 
-      if (Test-Path $npmrcPath)
-      {
-        Remove-Item $npmrcPath
-      }
-
-      Set-Content -Path $npmrcPath -Value @"
-      registry=https://aiinfra.pkgs.visualstudio.com/_packaging/${{parameters.artifactFeeds}}/npm/registry/
+      Set-Content -Force -Path $npmrcPath -Value @"
+      registry=https://aiinfra.pkgs.visualstudio.com/_packaging/${env:artifact_feed}/npm/registry/
       always-auth=true
       "@
 

--- a/tools/ci_build/github/azure-pipelines/templates/setup-feeds-and-python-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/setup-feeds-and-python-steps.yml
@@ -1,8 +1,9 @@
 # Template for setting up the package feeds and installing python.
 # Feeds configured:
-#   - pip
 #   - maven & gradle
+#   - npm
 #   - nuget
+#   - pip
 #
 # n.b. This template writes to user profile files.
 

--- a/tools/ci_build/github/azure-pipelines/templates/setup-feeds-and-python-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/setup-feeds-and-python-steps.yml
@@ -26,6 +26,25 @@ steps:
 - pwsh: if (Test-Path ~/.m2/settings.xml) { Remove-Item ~/.m2/settings.xml }
   displayName: Maven - remove existing ~/.m2/settings.xml
 
+# use `PowerShell@2` instead of `pwsh` as it is available on arm64 agents, whereas `pwsh` is not. (2026-04-15)
+- task: PowerShell@2
+  displayName: 'NPM - set NPM_CONFIG_USERCONFIG to agent temp config'
+  inputs:
+    targetType: 'inline'
+    script: |
+      # ensure we have a clean/empty npm config. config file must exist prior to `npmAuthenticate`.
+      $npmrcPath = "${env:AGENT_TEMPDIRECTORY}/.npmrc"
+
+      if (Test-Path $npmrcPath) { Remove-Item $npmrcPath }
+      New-Item $npmrcPath -ItemType File -Force
+
+      echo "##vso[task.setvariable variable=NPM_CONFIG_USERCONFIG]${npmrcPath}"
+
+# FUTURE WORK: use `Npm@1` task in pipelines and specify the feed there?
+- task: npmAuthenticate@0
+  inputs:
+    workingFile: $(NPM_CONFIG_USERCONFIG)
+
 - task: NuGetAuthenticate@1 # just auth w/ internal feeds
 
 # Creates/touches ~/.m2/settings.xml

--- a/tools/ci_build/github/linux/build_cuda_c_api_package.sh
+++ b/tools/ci_build/github/linux/build_cuda_c_api_package.sh
@@ -12,6 +12,9 @@ fi
 
 docker run -e SYSTEM_COLLECTIONURI --rm --volume \
 $BUILD_SOURCESDIRECTORY:/onnxruntime_src --volume $BUILD_BINARIESDIRECTORY:/build \
+-e NPM_CONFIG_USERCONFIG=/tmp/.npmrc --volume $AGENT_TEMPDIRECTORY/.npmrc:/tmp/.npmrc:ro \
+--volume $HOME/.m2:/home/onnxruntimedev/.m2:ro \
+--volume $HOME/.gradle:/home/onnxruntimedev/.gradle \
 -e NIGHTLY_BUILD onnxruntimecuda${CUDA_VERSION_MAJOR}build \
 /bin/bash -c "/usr/bin/python3 /onnxruntime_src/tools/ci_build/build.py --enable_lto --build_java --build_nodejs \
 --build_dir /build --config Release --skip_submodule_sync  --parallel --use_binskim_compliant_compile_flags --build_shared_lib \

--- a/tools/ci_build/github/linux/build_cuda_c_api_package.sh
+++ b/tools/ci_build/github/linux/build_cuda_c_api_package.sh
@@ -12,7 +12,8 @@ fi
 
 docker run -e SYSTEM_COLLECTIONURI --rm --volume \
 $BUILD_SOURCESDIRECTORY:/onnxruntime_src --volume $BUILD_BINARIESDIRECTORY:/build \
--e NPM_CONFIG_USERCONFIG=/tmp/.npmrc --volume $AGENT_TEMPDIRECTORY/.npmrc:/tmp/.npmrc:ro \
+-e NPM_CONFIG_USERCONFIG=/tmp/.npmrc \
+--volume "${NPM_CONFIG_USERCONFIG}:/tmp/.npmrc:ro" \
 --volume $HOME/.m2:/home/onnxruntimedev/.m2:ro \
 --volume $HOME/.gradle:/home/onnxruntimedev/.gradle \
 -e NIGHTLY_BUILD onnxruntimecuda${CUDA_VERSION_MAJOR}build \

--- a/tools/ci_build/github/linux/build_nodejs_package.sh
+++ b/tools/ci_build/github/linux/build_nodejs_package.sh
@@ -14,6 +14,9 @@ mkdir -p $HOME/.onnx
 docker run -e SYSTEM_COLLECTIONURI --rm --volume /data/onnx:/data/onnx:ro --volume $BUILD_SOURCESDIRECTORY:/onnxruntime_src \
 --volume $BUILD_BINARIESDIRECTORY:/build --volume /data/models:/build/models:ro \
 --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimecuda${CUDA_VERSION_MAJOR}xtrt86build \
+-e NPM_CONFIG_USERCONFIG=/tmp/.npmrc --volume $AGENT_TEMPDIRECTORY/.npmrc:/tmp/.npmrc:ro \
+--volume $HOME/.m2:/home/onnxruntimedev/.m2:ro \
+--volume $HOME/.gradle:/home/onnxruntimedev/.gradle \
 /bin/bash -c "/usr/bin/python3 /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config Release \
 --skip_tests --skip_submodule_sync --parallel --use_binskim_compliant_compile_flags --build_shared_lib --build_nodejs \
 --use_webgpu --use_tensorrt --cuda_version=$CUDA_VERSION --cuda_home=/usr/local/cuda-$CUDA_VERSION \

--- a/tools/ci_build/github/linux/build_nodejs_package.sh
+++ b/tools/ci_build/github/linux/build_nodejs_package.sh
@@ -13,7 +13,8 @@ fi
 mkdir -p $HOME/.onnx
 docker run -e SYSTEM_COLLECTIONURI --rm --volume /data/onnx:/data/onnx:ro --volume $BUILD_SOURCESDIRECTORY:/onnxruntime_src \
 --volume $BUILD_BINARIESDIRECTORY:/build --volume /data/models:/build/models:ro \
--e NPM_CONFIG_USERCONFIG=/tmp/.npmrc --volume $AGENT_TEMPDIRECTORY/.npmrc:/tmp/.npmrc:ro \
+-e NPM_CONFIG_USERCONFIG=/tmp/.npmrc \
+--volume "${NPM_CONFIG_USERCONFIG}:/tmp/.npmrc:ro" \
 --volume $HOME/.m2:/home/onnxruntimedev/.m2:ro \
 --volume $HOME/.gradle:/home/onnxruntimedev/.gradle \
 --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimecuda${CUDA_VERSION_MAJOR}xtrt86build \

--- a/tools/ci_build/github/linux/build_nodejs_package.sh
+++ b/tools/ci_build/github/linux/build_nodejs_package.sh
@@ -13,10 +13,10 @@ fi
 mkdir -p $HOME/.onnx
 docker run -e SYSTEM_COLLECTIONURI --rm --volume /data/onnx:/data/onnx:ro --volume $BUILD_SOURCESDIRECTORY:/onnxruntime_src \
 --volume $BUILD_BINARIESDIRECTORY:/build --volume /data/models:/build/models:ro \
---volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimecuda${CUDA_VERSION_MAJOR}xtrt86build \
 -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc --volume $AGENT_TEMPDIRECTORY/.npmrc:/tmp/.npmrc:ro \
 --volume $HOME/.m2:/home/onnxruntimedev/.m2:ro \
 --volume $HOME/.gradle:/home/onnxruntimedev/.gradle \
+--volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimecuda${CUDA_VERSION_MAJOR}xtrt86build \
 /bin/bash -c "/usr/bin/python3 /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config Release \
 --skip_tests --skip_submodule_sync --parallel --use_binskim_compliant_compile_flags --build_shared_lib --build_nodejs \
 --use_webgpu --use_tensorrt --cuda_version=$CUDA_VERSION --cuda_home=/usr/local/cuda-$CUDA_VERSION \

--- a/tools/ci_build/github/linux/build_tensorrt_c_api_package.sh
+++ b/tools/ci_build/github/linux/build_tensorrt_c_api_package.sh
@@ -13,10 +13,10 @@ fi
 mkdir -p $HOME/.onnx
 docker run -e SYSTEM_COLLECTIONURI --rm --volume /data/onnx:/data/onnx:ro --volume $BUILD_SOURCESDIRECTORY:/onnxruntime_src \
   --volume $BUILD_BINARIESDIRECTORY:/build --volume /data/models:/build/models:ro \
-  --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimecuda${CUDA_VERSION_MAJOR}xtrt86build \
   -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc --volume $AGENT_TEMPDIRECTORY/.npmrc:/tmp/.npmrc:ro \
   --volume $HOME/.m2:/home/onnxruntimedev/.m2:ro \
   --volume $HOME/.gradle:/home/onnxruntimedev/.gradle \
+  --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimecuda${CUDA_VERSION_MAJOR}xtrt86build \
   /bin/bash -c "/usr/bin/python3 /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config Release --skip_tests \
   --skip_submodule_sync --parallel --use_binskim_compliant_compile_flags --build_shared_lib --build_java --build_nodejs \
   --use_tensorrt --cuda_version=$CUDA_VERSION --cuda_home=/usr/local/cuda-$CUDA_VERSION --cudnn_home=/usr --tensorrt_home=/usr \

--- a/tools/ci_build/github/linux/build_tensorrt_c_api_package.sh
+++ b/tools/ci_build/github/linux/build_tensorrt_c_api_package.sh
@@ -13,7 +13,8 @@ fi
 mkdir -p $HOME/.onnx
 docker run -e SYSTEM_COLLECTIONURI --rm --volume /data/onnx:/data/onnx:ro --volume $BUILD_SOURCESDIRECTORY:/onnxruntime_src \
   --volume $BUILD_BINARIESDIRECTORY:/build --volume /data/models:/build/models:ro \
-  -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc --volume $AGENT_TEMPDIRECTORY/.npmrc:/tmp/.npmrc:ro \
+  -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc \
+  --volume "${NPM_CONFIG_USERCONFIG}:/tmp/.npmrc:ro" \
   --volume $HOME/.m2:/home/onnxruntimedev/.m2:ro \
   --volume $HOME/.gradle:/home/onnxruntimedev/.gradle \
   --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimecuda${CUDA_VERSION_MAJOR}xtrt86build \

--- a/tools/ci_build/github/linux/build_tensorrt_c_api_package.sh
+++ b/tools/ci_build/github/linux/build_tensorrt_c_api_package.sh
@@ -14,6 +14,9 @@ mkdir -p $HOME/.onnx
 docker run -e SYSTEM_COLLECTIONURI --rm --volume /data/onnx:/data/onnx:ro --volume $BUILD_SOURCESDIRECTORY:/onnxruntime_src \
   --volume $BUILD_BINARIESDIRECTORY:/build --volume /data/models:/build/models:ro \
   --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimecuda${CUDA_VERSION_MAJOR}xtrt86build \
+  -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc --volume $AGENT_TEMPDIRECTORY/.npmrc:/tmp/.npmrc:ro \
+  --volume $HOME/.m2:/home/onnxruntimedev/.m2:ro \
+  --volume $HOME/.gradle:/home/onnxruntimedev/.gradle \
   /bin/bash -c "/usr/bin/python3 /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config Release --skip_tests \
   --skip_submodule_sync --parallel --use_binskim_compliant_compile_flags --build_shared_lib --build_java --build_nodejs \
   --use_tensorrt --cuda_version=$CUDA_VERSION --cuda_home=/usr/local/cuda-$CUDA_VERSION --cudnn_home=/usr --tensorrt_home=/usr \

--- a/tools/ci_build/github/linux/build_webgpu_plugin_package.sh
+++ b/tools/ci_build/github/linux/build_webgpu_plugin_package.sh
@@ -25,7 +25,8 @@ docker run --rm \
     --volume "${BUILD_BINARIESDIRECTORY}:/build" \
     --volume /data/models:/build/models:ro \
     --volume "${HOME}/.onnx:/home/onnxruntimedev/.onnx" \
-    -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc --volume $AGENT_TEMPDIRECTORY/.npmrc:/tmp/.npmrc:ro \
+    -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc \
+    --volume "${NPM_CONFIG_USERCONFIG}:/tmp/.npmrc:ro" \
     --volume $HOME/.m2:/home/onnxruntimedev/.m2:ro \
     --volume $HOME/.gradle:/home/onnxruntimedev/.gradle \
     -e NIGHTLY_BUILD \

--- a/tools/ci_build/github/linux/build_webgpu_plugin_package.sh
+++ b/tools/ci_build/github/linux/build_webgpu_plugin_package.sh
@@ -25,6 +25,9 @@ docker run --rm \
     --volume "${BUILD_BINARIESDIRECTORY}:/build" \
     --volume /data/models:/build/models:ro \
     --volume "${HOME}/.onnx:/home/onnxruntimedev/.onnx" \
+    -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc --volume $AGENT_TEMPDIRECTORY/.npmrc:/tmp/.npmrc:ro \
+    --volume $HOME/.m2:/home/onnxruntimedev/.m2:ro \
+    --volume $HOME/.gradle:/home/onnxruntimedev/.gradle \
     -e NIGHTLY_BUILD \
     -e BUILD_BUILDNUMBER \
     -e SYSTEM_COLLECTIONURI \

--- a/tools/ci_build/github/linux/run_python_dockerbuild.sh
+++ b/tools/ci_build/github/linux/run_python_dockerbuild.sh
@@ -33,6 +33,9 @@ docker run -e SYSTEM_COLLECTIONURI --rm \
     --volume "${BUILD_BINARIESDIRECTORY}:/build" \
     --volume /data/models:/build/models:ro \
     --volume "${HOME}/.onnx:/home/onnxruntimedev/.onnx" \
+    -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc --volume $AGENT_TEMPDIRECTORY/.npmrc:/tmp/.npmrc:ro \
+    --volume $HOME/.m2:/home/onnxruntimedev/.m2:ro \
+    --volume $HOME/.gradle:/home/onnxruntimedev/.gradle \
     -w /onnxruntime_src \
     -e NIGHTLY_BUILD \
     -e BUILD_BUILDNUMBER \

--- a/tools/ci_build/github/linux/run_python_dockerbuild.sh
+++ b/tools/ci_build/github/linux/run_python_dockerbuild.sh
@@ -27,15 +27,17 @@ if [ "${BUILD_EXTR_PAR}" != "" ] ; then
     DOCKER_SCRIPT_OPTIONS+=("-x" "${BUILD_EXTR_PAR}")
 fi
 
+# HACK: `ADDITIONAL_DOCKER_PARAMETER` is passed in via env in some pipelines
 docker run -e SYSTEM_COLLECTIONURI --rm \
     --volume /data/onnx:/data/onnx:ro \
     --volume "${BUILD_SOURCESDIRECTORY}:/onnxruntime_src" \
     --volume "${BUILD_BINARIESDIRECTORY}:/build" \
     --volume /data/models:/build/models:ro \
     --volume "${HOME}/.onnx:/home/onnxruntimedev/.onnx" \
-    -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc --volume $AGENT_TEMPDIRECTORY/.npmrc:/tmp/.npmrc:ro \
-    --volume $HOME/.m2:/home/onnxruntimedev/.m2:ro \
-    --volume $HOME/.gradle:/home/onnxruntimedev/.gradle \
+    -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc \
+    --volume "${NPM_CONFIG_USERCONFIG}:/tmp/.npmrc:ro" \
+    --volume "$HOME/.m2:/home/onnxruntimedev/.m2:ro" \
+    --volume "$HOME/.gradle:/home/onnxruntimedev/.gradle" \
     -w /onnxruntime_src \
     -e NIGHTLY_BUILD \
     -e BUILD_BUILDNUMBER \

--- a/tools/ci_build/github/linux/run_python_dockertest.sh
+++ b/tools/ci_build/github/linux/run_python_dockertest.sh
@@ -1,32 +1,37 @@
 #!/bin/bash
-set -e -x
+set -xeuo pipefail
 BUILD_CONFIG="Release"
 
-while getopts "i:d:x:c:" parameter_Option
-do case "${parameter_Option}"
-in
-i) DOCKER_IMAGE=${OPTARG};;
-d) DEVICE=${OPTARG};;
-c) BUILD_CONFIG=${OPTARG};;
-esac
+while getopts "i:d:c:" parameter_Option; do
+  case "${parameter_Option}" in
+  i) DOCKER_IMAGE=${OPTARG} ;;
+  d) DEVICE=${OPTARG} ;;
+  c) BUILD_CONFIG=${OPTARG} ;;
+  *)
+    echo "Usage: $0 -i <docker_image> -d <GPU|CPU> [-c <build_config>]"
+    exit 1
+    ;;
+  esac
 done
 
-if [ $DEVICE = "GPU" ]; then
-  ADDITIONAL_DOCKER_PARAMETER="--gpus all"
+ADDITIONAL_DOCKER_PARAMETERS=()
+if [ "$DEVICE" = "GPU" ]; then
+  ADDITIONAL_DOCKER_PARAMETERS+=("--gpus" "all")
 fi
 
-mkdir -p $HOME/.onnx
+mkdir -p "$HOME/.onnx"
 docker run -e SYSTEM_COLLECTIONURI --rm \
-    --volume /data/onnx:/data/onnx:ro \
-    --volume $BUILD_SOURCESDIRECTORY:/onnxruntime_src \
-    --volume $BUILD_BINARIESDIRECTORY:/build \
-    --volume /data/models:/build/models:ro \
-    --volume $HOME/.onnx:/home/onnxruntimedev/.onnx \
-    -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc --volume $AGENT_TEMPDIRECTORY/.npmrc:/tmp/.npmrc:ro \
-    --volume $HOME/.m2:/home/onnxruntimedev/.m2:ro \
-    --volume $HOME/.gradle:/home/onnxruntimedev/.gradle \
-    -w /onnxruntime_src \
-    -e NIGHTLY_BUILD \
-    -e BUILD_BUILDNUMBER \
-    $ADDITIONAL_DOCKER_PARAMETER \
-    $DOCKER_IMAGE tools/ci_build/github/linux/run_python_tests.sh -d $DEVICE -c $BUILD_CONFIG
+  --volume /data/onnx:/data/onnx:ro \
+  --volume "$BUILD_SOURCESDIRECTORY:/onnxruntime_src" \
+  --volume "$BUILD_BINARIESDIRECTORY:/build" \
+  --volume /data/models:/build/models:ro \
+  --volume "$HOME/.onnx:/home/onnxruntimedev/.onnx" \
+  -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc \
+  --volume "${NPM_CONFIG_USERCONFIG}:/tmp/.npmrc:ro" \
+  --volume "$HOME/.m2:/home/onnxruntimedev/.m2:ro" \
+  --volume "$HOME/.gradle:/home/onnxruntimedev/.gradle" \
+  -w /onnxruntime_src \
+  -e NIGHTLY_BUILD \
+  -e BUILD_BUILDNUMBER \
+  "${ADDITIONAL_DOCKER_PARAMETERS[@]}" \
+  "$DOCKER_IMAGE" tools/ci_build/github/linux/run_python_tests.sh -d "$DEVICE" -c "$BUILD_CONFIG"

--- a/tools/ci_build/github/linux/run_python_dockertest.sh
+++ b/tools/ci_build/github/linux/run_python_dockertest.sh
@@ -22,6 +22,9 @@ docker run -e SYSTEM_COLLECTIONURI --rm \
     --volume $BUILD_BINARIESDIRECTORY:/build \
     --volume /data/models:/build/models:ro \
     --volume $HOME/.onnx:/home/onnxruntimedev/.onnx \
+    -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc --volume $AGENT_TEMPDIRECTORY/.npmrc:/tmp/.npmrc:ro \
+    --volume $HOME/.m2:/home/onnxruntimedev/.m2:ro \
+    --volume $HOME/.gradle:/home/onnxruntimedev/.gradle \
     -w /onnxruntime_src \
     -e NIGHTLY_BUILD \
     -e BUILD_BUILDNUMBER \


### PR DESCRIPTION
### Description

Use internal NPM feed.

### Motivation and Context

SDL requirements state that we consume everything in 1ES builds from one internal feed.

