### PR TITLE
Do not create numpy on top of Tensor non-owning buffer

### DIFF
--- a/onnxruntime/python/onnxruntime_pybind_mlvalue.h
+++ b/onnxruntime/python/onnxruntime_pybind_mlvalue.h
@@ -129,7 +129,8 @@ void CreateGenericMLValue(const onnxruntime::InputDefList* input_def_list, const
 
 pybind11::object GetPyObjFromTensor(const OrtValue& rtensor,
                                     const DataTransferManager* data_transfer_manager = nullptr,
-                                    const std::unordered_map<OrtDevice, MemCpyFunc>* mem_cpy_to_host_functions = nullptr);
+                                    const std::unordered_map<OrtDevice, MemCpyFunc>* mem_cpy_to_host_functions = nullptr,
+                                    bool zero_copy_non_owning = false);
 
 // The below two functions are used to convert OrtValue to numpy arrays
 

--- a/onnxruntime/python/onnxruntime_pybind_mlvalue.h
+++ b/onnxruntime/python/onnxruntime_pybind_mlvalue.h
@@ -127,6 +127,12 @@ void CreateGenericMLValue(const onnxruntime::InputDefList* input_def_list, const
                           bool accept_only_numpy_array = false, bool use_numpy_data_memory = true,
                           const MemCpyFunc& mem_cpy_to_device = CpuToCpuMemCpy);
 
+/// @param zero_copy_non_owning  When false (default), CPU tensors that do not own
+///   their buffer are copied to a new numpy array to prevent dangling pointers
+///   (e.g. when a model output aliases a numpy input array).  Set to true ONLY
+///   when the caller explicitly manages the backing memory lifetime — currently
+///   this is limited to OrtValue.numpy(), where the user holds the OrtValue
+///   Python object and is responsible for keeping it alive.
 pybind11::object GetPyObjFromTensor(const OrtValue& rtensor,
                                     const DataTransferManager* data_transfer_manager = nullptr,
                                     const std::unordered_map<OrtDevice, MemCpyFunc>* mem_cpy_to_host_functions = nullptr,

--- a/onnxruntime/python/onnxruntime_pybind_ortvalue.cc
+++ b/onnxruntime/python/onnxruntime_pybind_ortvalue.cc
@@ -419,6 +419,10 @@ void addOrtValueMethods(pybind11::module& m) {
                                       /*zero_copy_non_owning=*/true);
 #endif
           default:
+            // OrtValue.numpy() is called by the user who explicitly holds the OrtValue
+            // Python object, so the backing memory lifetime is managed externally.
+            // zero_copy_non_owning=true is safe here (and required to preserve the
+            // zero-copy semantics that OrtValue.numpy() / __array__ rely on).
             return GetPyObjFromTensor(*ml_value, nullptr, nullptr,
                                       /*zero_copy_non_owning=*/true);
         }

--- a/onnxruntime/python/onnxruntime_pybind_ortvalue.cc
+++ b/onnxruntime/python/onnxruntime_pybind_ortvalue.cc
@@ -399,23 +399,28 @@ void addOrtValueMethods(pybind11::module& m) {
         switch (device.Vendor()) {
 #ifdef USE_CUDA
           case OrtDevice::VendorIds::NVIDIA:
-            return GetPyObjFromTensor(*ml_value, nullptr, GetCudaToHostMemCpyFunction(device));
+            return GetPyObjFromTensor(*ml_value, nullptr, GetCudaToHostMemCpyFunction(device),
+                                      /*zero_copy_non_owning=*/true);
 #endif
 #ifdef USE_CANN
           case OrtDevice::VendorIds::HUAWEI:
-            return GetPyObjFromTensor(*ml_value, nullptr, GetCannToHostMemCpyFunction());
+            return GetPyObjFromTensor(*ml_value, nullptr, GetCannToHostMemCpyFunction(),
+                                      /*zero_copy_non_owning=*/true);
 #endif
 
 #ifdef USE_DML
           case OrtDevice::VendorIds::MICROSOFT:
-            return GetPyObjFromTensor(*ml_value, nullptr, GetDmlToHostMemCpyFunction(device));
+            return GetPyObjFromTensor(*ml_value, nullptr, GetDmlToHostMemCpyFunction(device),
+                                      /*zero_copy_non_owning=*/true);
 #endif
 #ifdef USE_MIGRAPHX
           case OrtDevice::VendorIds::AMD:
-            return GetPyObjFromTensor(*ml_value, nullptr, GetMIGraphXToHostMemCpyFunction(device));
+            return GetPyObjFromTensor(*ml_value, nullptr, GetMIGraphXToHostMemCpyFunction(device),
+                                      /*zero_copy_non_owning=*/true);
 #endif
           default:
-            return GetPyObjFromTensor(*ml_value, nullptr, nullptr);
+            return GetPyObjFromTensor(*ml_value, nullptr, nullptr,
+                                      /*zero_copy_non_owning=*/true);
         }
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -264,7 +264,8 @@ pybind11::array PrimitiveTensorToNumpyFromDevice(const OrtValue& ort_value, cons
 // pretty much does what a DataTransferManager does - copy data from device(s) to the host
 py::object GetPyObjFromTensor(const OrtValue& ort_value,
                               const DataTransferManager* data_transfer_manager,
-                              const std::unordered_map<OrtDevice, MemCpyFunc>* mem_cpy_to_host_functions) {
+                              const std::unordered_map<OrtDevice, MemCpyFunc>* mem_cpy_to_host_functions,
+                              bool zero_copy_non_owning) {
   ORT_ENFORCE(ort_value.IsTensor(), "This function only supports tensors");
 
   const auto& tensor = ort_value.Get<Tensor>();
@@ -278,9 +279,21 @@ py::object GetPyObjFromTensor(const OrtValue& ort_value,
   }
 
   const auto device_type = device.Type();
-  // Create an numpy array on top of the OrtValue memory, no copy
+  // Create a numpy array on top of the OrtValue memory, no copy,
+  // but only when the tensor owns the buffer. When the tensor wraps external
+  // memory (e.g. a numpy input array passed through as output), the buffer
+  // lifetime is not tied to the OrtValue and zero-copy would create a
+  // dangling pointer. See https://github.com/microsoft/onnxruntime/issues/21922
   if (device_type == OrtDevice::CPU) {
-    py::array result = PrimitiveTensorToNumpyOverOrtValue(ort_value);
+    if (tensor.OwnsBuffer() || zero_copy_non_owning) {
+      py::array result = PrimitiveTensorToNumpyOverOrtValue(ort_value);
+      return py::cast<py::object>(result);
+    }
+    // Tensor does not own the buffer — must copy to avoid dangling pointers
+    // when the underlying memory (e.g. a numpy input array) is freed.
+    // See https://github.com/microsoft/onnxruntime/issues/21922
+    MemCpyFunc cpu_copy = CpuToCpuMemCpy;
+    py::array result = PrimitiveTensorToNumpyFromDevice(ort_value, cpu_copy);
     return py::cast<py::object>(result);
   }
 

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -1514,6 +1514,87 @@ class TestInferenceSession(unittest.TestCase):
         np.testing.assert_equal(bool_arr, result_bool)
         self.assertEqual(result_bool.dtype, np.bool_)
 
+    def test_run_output_does_not_alias_input_passthrough(self):
+        """Test that session.run() returns independent numpy arrays when a model
+        input passes through as a model output. Reproduces the dangling-pointer
+        corruption described in https://github.com/microsoft/onnxruntime/issues/21922
+        """
+        import onnx  # noqa: PLC0415
+        from onnx import TensorProto, helper  # noqa: PLC0415
+
+        # Build a model where 'input_0' is both a graph input and a graph output,
+        # plus a computed output (input_0 + 10).
+        inp_shape = [1, 2, 2, 2]
+        input_0 = helper.make_tensor_value_info("input_0", TensorProto.FLOAT, inp_shape)
+        output_plus10 = helper.make_tensor_value_info("plus_10", TensorProto.FLOAT, inp_shape)
+        ten_const = onnx.numpy_helper.from_array(np.array(10, dtype=np.float32), "ten_const")
+        add_node = helper.make_node("Add", ["input_0", "ten_const"], ["plus_10"], name="Add0")
+        graph = helper.make_graph(
+            [add_node],
+            "PassthroughTest",
+            [input_0],
+            [output_plus10, input_0],
+            initializer=[ten_const],
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
+        model = onnx.shape_inference.infer_shapes(model)
+
+        sess_options = onnxrt.SessionOptions()
+        sess_options.graph_optimization_level = onnxrt.GraphOptimizationLevel.ORT_DISABLE_ALL
+        session = onnxrt.InferenceSession(
+            model.SerializeToString(),
+            sess_options=sess_options,
+            providers=["CPUExecutionProvider"],
+        )
+
+        num_runs = 7
+        all_run_outputs = []
+        for run_index in range(num_runs):
+            input_data = np.full(inp_shape, float(run_index), dtype=np.float32)
+            outputs = session.run(None, {"input_0": input_data})
+
+            # Immediately after run, outputs must be correct
+            np.testing.assert_array_equal(
+                outputs[0],
+                np.full(inp_shape, run_index + 10.0, dtype=np.float32),
+                err_msg=f"Run {run_index}: 'plus_10' wrong immediately after run",
+            )
+            np.testing.assert_array_equal(
+                outputs[1],
+                np.full(inp_shape, float(run_index), dtype=np.float32),
+                err_msg=f"Run {run_index}: 'input_0' wrong immediately after run",
+            )
+
+            # The pass-through output must NOT alias the input buffer —
+            # it must be an independent copy so it survives across runs.
+            all_run_outputs.append(outputs)
+
+        # After all runs, every saved output must still hold its original value.
+        for run_index, outputs in enumerate(all_run_outputs):
+            np.testing.assert_array_equal(
+                outputs[0],
+                np.full(inp_shape, run_index + 10.0, dtype=np.float32),
+                err_msg=f"Run {run_index}: 'plus_10' corrupted after loop",
+            )
+            np.testing.assert_array_equal(
+                outputs[1],
+                np.full(inp_shape, float(run_index), dtype=np.float32),
+                err_msg=f"Run {run_index}: 'input_0' corrupted after loop (issue #21922)",
+            )
+
+    def test_run_session_owned_output_is_zero_copy(self):
+        """Verify that session-allocated CPU outputs (the common case) still use
+        zero-copy numpy arrays backed by the OrtValue buffer."""
+        sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=["CPUExecutionProvider"])
+        input_name = sess.get_inputs()[0].name
+        x = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
+        result = sess.run(None, {input_name: x})
+        # The output should be a numpy array; for a session-owned buffer
+        # it should not be a separately-allocated copy.  We can verify that
+        # the output base object is a PyCapsule (the zero-copy indicator).
+        output = result[0]
+        self.assertIsNotNone(output.base, "Session-owned output should be zero-copy (has a base)")
+
     @unittest.skipIf(not hasattr(C.OrtValue, "from_dlpack"), "dlpack not enabled in this build")
     def test_ort_value_dlpack_protocol(self):
         """Test that OrtValue exposes __dlpack__ and __dlpack_device__ protocols."""

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -1591,17 +1591,17 @@ class TestInferenceSession(unittest.TestCase):
             )
 
     def test_run_session_owned_output_is_zero_copy(self):
-        """Verify that session-allocated CPU outputs (the common case) still use
-        zero-copy numpy arrays backed by the OrtValue buffer."""
+        """Verify that session-allocated CPU outputs (the common case) expose
+        a backing base object instead of owning a separate numpy buffer."""
         sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=["CPUExecutionProvider"])
         input_name = sess.get_inputs()[0].name
         x = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
         result = sess.run(None, {input_name: x})
         # The output should be a numpy array; for a session-owned buffer
-        # it should not be a separately-allocated copy.  We can verify that
-        # the output base object is a PyCapsule (the zero-copy indicator).
+        # it should not be a separately-allocated copy.  We verify that by
+        # checking the array is backed by another object via ``output.base``.
         output = result[0]
-        self.assertIsNotNone(output.base, "Session-owned output should be zero-copy (has a base)")
+        self.assertIsNotNone(output.base, "Session-owned output should have a backing base object")
 
     @unittest.skipIf(not hasattr(C.OrtValue, "from_dlpack"), "dlpack not enabled in this build")
     def test_ort_value_dlpack_protocol(self):

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import ctypes
 import gc
+import importlib.util
 import os
 import pathlib
 import platform
@@ -1514,29 +1515,32 @@ class TestInferenceSession(unittest.TestCase):
         np.testing.assert_equal(bool_arr, result_bool)
         self.assertEqual(result_bool.dtype, np.bool_)
 
+    @unittest.skipUnless(
+        importlib.util.find_spec("onnx") is not None,
+        "onnx package is required to build the test model",
+    )
     def test_run_output_does_not_alias_input_passthrough(self):
         """Test that session.run() returns independent numpy arrays when a model
         input passes through as a model output. Reproduces the dangling-pointer
         corruption described in https://github.com/microsoft/onnxruntime/issues/21922
         """
         import onnx  # noqa: PLC0415
-        from onnx import TensorProto, helper  # noqa: PLC0415
 
         # Build a model where 'input_0' is both a graph input and a graph output,
         # plus a computed output (input_0 + 10).
         inp_shape = [1, 2, 2, 2]
-        input_0 = helper.make_tensor_value_info("input_0", TensorProto.FLOAT, inp_shape)
-        output_plus10 = helper.make_tensor_value_info("plus_10", TensorProto.FLOAT, inp_shape)
+        input_0 = onnx.helper.make_tensor_value_info("input_0", onnx.TensorProto.FLOAT, inp_shape)
+        output_plus10 = onnx.helper.make_tensor_value_info("plus_10", onnx.TensorProto.FLOAT, inp_shape)
         ten_const = onnx.numpy_helper.from_array(np.array(10, dtype=np.float32), "ten_const")
-        add_node = helper.make_node("Add", ["input_0", "ten_const"], ["plus_10"], name="Add0")
-        graph = helper.make_graph(
+        add_node = onnx.helper.make_node("Add", ["input_0", "ten_const"], ["plus_10"], name="Add0")
+        graph = onnx.helper.make_graph(
             [add_node],
             "PassthroughTest",
             [input_0],
             [output_plus10, input_0],
             initializer=[ten_const],
         )
-        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
+        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 21)])
         model = onnx.shape_inference.infer_shapes(model)
 
         sess_options = onnxrt.SessionOptions()
@@ -1567,6 +1571,10 @@ class TestInferenceSession(unittest.TestCase):
 
             # The pass-through output must NOT alias the input buffer —
             # it must be an independent copy so it survives across runs.
+            self.assertFalse(
+                np.shares_memory(outputs[1], input_data),
+                f"Run {run_index}: 'input_0' unexpectedly aliases the input buffer",
+            )
             all_run_outputs.append(outputs)
 
         # After all runs, every saved output must still hold its original value.


### PR DESCRIPTION
This pull request improves the safety and correctness of tensor-to-numpy conversions in the ONNX Runtime Python bindings, specifically addressing the issue of dangling pointers when model outputs alias input buffers. It introduces logic to ensure that numpy arrays returned from session outputs do not share memory with input arrays unless it is safe to do so, and adds targeted tests to prevent regressions.

**Tensor-to-Numpy Conversion Safety Improvements:**

* Updated the `GetPyObjFromTensor` function signature in both the header (`onnxruntime_pybind_mlvalue.h`) and implementation (`onnxruntime_pybind_state.cc`) to accept a new `zero_copy_non_owning` boolean parameter, allowing explicit control over zero-copy behavior. [[1]](diffhunk://#diff-e3d44c037b76a79f69ad1c173fe36ef9a84e17962aec9ec0068a16066703f533L132-R133) [[2]](diffhunk://#diff-c46fc0e05521f706449c04aed599ac0229012c007a78b584519e71a57601d63eL267-R268)
* Enhanced the logic in `GetPyObjFromTensor` so that zero-copy numpy arrays are only created if the tensor owns its buffer or if `zero_copy_non_owning` is explicitly set. Otherwise, the data is copied to prevent use-after-free errors when the original input memory might be released.

**Device Handling Updates:**

* Modified device-specific code paths in `onnxruntime_pybind_ortvalue.cc` to always request zero-copy for outputs from non-CPU devices, ensuring consistent and safe behavior across all supported hardware backends.

**Testing and Regression Coverage:**

* Added comprehensive tests in `onnxruntime_test_python.py` to verify that outputs which alias inputs are returned as independent numpy arrays, preventing data corruption from dangling pointers. Also added a test to confirm that session-allocated outputs still use efficient zero-copy numpy arrays.

Addresses issue: https://github.com/microsoft/onnxruntime/issues/21922