### PR TITLE
Use weights_only for torch.load checkpoints

### DIFF
--- a/onnxruntime/python/tools/transformers/models/t5/t5_helper.py
+++ b/onnxruntime/python/tools/transformers/models/t5/t5_helper.py
@@ -19,6 +19,19 @@ from onnxruntime import InferenceSession
 
 logger = logging.getLogger(__name__)
 
+
+def _torch_load_weights_only(path: str, **kwargs):
+    try:
+        return torch.load(path, weights_only=True, **kwargs)
+    except TypeError:
+        logger.warning(
+            "Current PyTorch version does not support torch.load(..., weights_only=True); "
+            "falling back to default torch.load behavior for %s.",
+            path,
+        )
+        return torch.load(path, **kwargs)
+
+
 PRETRAINED_T5_MODELS = ["t5-small", "t5-base", "t5-large", "t5-3b", "t5-11b"]
 PRETRAINED_MT5_MODELS = [
     "google/mt5-small",
@@ -88,7 +101,7 @@ class T5Helper:
             raise ValueError("only support mode_type=t5 or mt5")
 
         if state_dict_path:
-            model.load_state_dict(torch.load(state_dict_path))
+            model.load_state_dict(_torch_load_weights_only(state_dict_path))
 
         decoder = T5Decoder(model.decoder, model.lm_head, model.config)
         decoder.eval().to(device)

--- a/orttraining/tools/scripts/nv_run_pretraining.py
+++ b/orttraining/tools/scripts/nv_run_pretraining.py
@@ -48,6 +48,18 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+def _torch_load_weights_only(path, **kwargs):
+    try:
+        return torch.load(path, weights_only=True, **kwargs)
+    except TypeError:
+        logger.warning(
+            "Current PyTorch version does not support torch.load(..., weights_only=True); "
+            "falling back to default torch.load behavior for %s.",
+            path,
+        )
+        return torch.load(path, **kwargs)
+
+
 def create_pretraining_dataset(input_file, max_pred_length, shared_list, args):
     train_data = pretraining_dataset(input_file=input_file, max_pred_length=max_pred_length)
     train_sampler = RandomSampler(train_data)
@@ -271,7 +283,9 @@ def prepare_model_and_optimizer(args, device):
             args.resume_step = max([int(x.split(".pt")[0].split("_")[1].strip()) for x in model_names])
         global_step = args.resume_step
 
-        checkpoint = torch.load(os.path.join(args.output_dir, f"ckpt_{global_step}.pt"), map_location="cpu")
+        checkpoint = _torch_load_weights_only(
+            os.path.join(args.output_dir, f"ckpt_{global_step}.pt"), map_location="cpu"
+        )
         model.load_state_dict(checkpoint["model"], strict=False)
         if args.phase2:
             global_step -= args.phase1_end_step


### PR DESCRIPTION
### Description

This PR updates PyTorch checkpoint loading in the T5 helper and NVIDIA pretraining resume script to prefer `torch.load(..., weights_only=True)`. Newer PyTorch versions recommend this safer load mode for checkpoints because default pickle-based loading can execute arbitrary code when a `.pt` file is malicious.

Behavior changes across PyTorch versions:
* PyTorch 1.10 ~ 2.5: weights_only exists, but default = False
* PyTorch 2.6+: Default changed to True (security-driven change)

### Summary of Changes

| File | Change |
|------|--------|
| `onnxruntime/python/tools/transformers/models/t5/t5_helper.py` | Adds a local helper that loads state dict checkpoints with `weights_only=True` when available and uses it for `state_dict_path`. |
| `orttraining/tools/scripts/nv_run_pretraining.py` | Adds the same compatibility helper and uses it when resuming from `ckpt_*.pt` training checkpoints. |

### Motivation and Context

`torch.load` can deserialize Python pickle payloads. Using `weights_only=True` narrows loading to tensor/checkpoint data on supported PyTorch versions and is the safer default for model weights. This reduces risk if an attacker can place or substitute a local `.pt` file, or persuades an operator to download and resume from a malicious checkpoint.

### Testing

- `python -m py_compile onnxruntime/python/tools/transformers/models/t5/t5_helper.py orttraining/tools/scripts/nv_run_pretraining.py`