### PR TITLE
Implement GetAvaiableResource() callback 

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
@@ -982,6 +982,9 @@ typedef struct OrtResourceCount {
   } value;
 
 #ifdef __cplusplus
+  /** Default-construct a None (unset) resource count. */
+  OrtResourceCount() noexcept : kind{OrtResourceCountKind_None}, reserved{0}, value{} {}
+
   /** Construct a zero/unset resource count. */
   static OrtResourceCount None() noexcept {
     return OrtResourceCount{};

--- a/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
@@ -956,15 +956,16 @@ struct OrtScanKernelHelper {
  */
 typedef enum OrtResourceCountKind {
   OrtResourceCountKind_None = 0,        ///< Unset / zero-cost sentinel.
-  OrtResourceCountKind_TotalBytes = 1,  ///< Single uint64_t: total estimated bytes.
+  OrtResourceCountKind_TotalBytes = 1,  ///< Single uint64_t: byte count (cost or budget).
 } OrtResourceCountKind;
 
 /**
  * \brief ABI-stable tagged union representing a resource cost or budget.
  *
  * This struct is a C-safe variant that can be passed by value across the plugin DLL boundary.
- * The `kind` field selects which union member is active. The `_storage` member reserves space
- * for future resource types without changing the struct layout.
+ * The `kind` field selects which member of the `value` union is active. The
+ * `value.reserved_words` storage reserves space for future resource types without changing
+ * the struct layout.
  *
  * Adding new resource types requires only: (a) a new OrtResourceCountKind enum value,
  * (b) a new union member. No new C API functions are needed.
@@ -1003,7 +1004,6 @@ typedef struct OrtResourceCount {
 
 #ifdef __cplusplus
 static_assert(sizeof(OrtResourceCount) == 56, "OrtResourceCount size must not change to maintain ABI stability");
-static_assert(alignof(OrtResourceCount) == 8, "OrtResourceCount alignment must not change to maintain ABI stability");
 #endif
 
 /**

--- a/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
@@ -947,6 +947,66 @@ struct OrtScanKernelHelper {
 };
 
 /**
+ * \brief Discriminator for the resource count type stored in an OrtResourceCount.
+ *
+ * New resource accounting types can be added by appending new enum values.
+ * The OrtResourceCount union storage is large enough to hold all current and future types.
+ *
+ * \since Version 1.26.
+ */
+typedef enum OrtResourceCountKind {
+  OrtResourceCountKind_None = 0,        ///< Unset / zero-cost sentinel.
+  OrtResourceCountKind_TotalBytes = 1,  ///< Single uint64_t: total estimated bytes.
+} OrtResourceCountKind;
+
+/**
+ * \brief ABI-stable tagged union representing a resource cost or budget.
+ *
+ * This struct is a C-safe variant that can be passed by value across the plugin DLL boundary.
+ * The `kind` field selects which union member is active. The `_storage` member reserves space
+ * for future resource types without changing the struct layout.
+ *
+ * Adding new resource types requires only: (a) a new OrtResourceCountKind enum value,
+ * (b) a new union member. No new C API functions are needed.
+ *
+ * \since Version 1.26.
+ */
+typedef struct OrtResourceCount {
+  uint32_t kind;     /**< OrtResourceCountKind discriminator. */
+  uint32_t reserved; /**< Must be zero. Ensures natural alignment for the value union. */
+
+  union {
+    uint64_t total_bytes;       /**< Active when kind == OrtResourceCountKind_TotalBytes. */
+    uint64_t reserved_words[6]; /**< 48 bytes fixed storage for future resource types. */
+  } value;
+
+#ifdef __cplusplus
+  /** Construct a zero/unset resource count. */
+  static OrtResourceCount None() noexcept {
+    return OrtResourceCount{};
+  }
+
+  /** Construct a resource count representing total bytes. */
+  static OrtResourceCount FromTotalBytes(uint64_t bytes) noexcept {
+    OrtResourceCount rc{};
+    rc.kind = OrtResourceCountKind_TotalBytes;
+    rc.value.total_bytes = bytes;
+    return rc;
+  }
+
+  /** Read the total_bytes value (caller must check kind first). */
+  uint64_t AsTotalBytes() const noexcept {
+    return value.total_bytes;
+  }
+#endif
+} OrtResourceCount;
+
+#ifdef __cplusplus
+static_assert(sizeof(OrtResourceCount) == 56, "OrtResourceCount size must not change to maintain ABI stability");
+static_assert(alignof(OrtResourceCount) == 8, "OrtResourceCount alignment must not change to maintain ABI stability");
+#endif
+
+/**
  * \brief The OrtEpApi struct provides functions that are relevant to the implementation of an execution provider.
  *
  * \since Version 1.22.
@@ -2462,6 +2522,28 @@ struct OrtEp {
    */
   ORT_API_T(OrtGraphCaptureNodeAssignmentPolicy, GetGraphCaptureNodeAssignmentPolicy,
             _In_ const OrtEp* this_ptr);
+
+  /** \brief Query the available device resource for partitioning budget.
+   *
+   * Called by ORT during graph partitioning when no explicit resource budget threshold
+   * has been configured via session options. The EP should query its device for the
+   * currently available resource (e.g., free GPU memory) and return it as an OrtResourceCount.
+   *
+   * If the EP does not support resource querying, set this function pointer to NULL.
+   * ORT will skip threshold-based budget enforcement in that case.
+   *
+   * \param[in] this_ptr The OrtEp instance.
+   * \param[out] available The available device resource.
+   *
+   * \snippet{doc} snippets.dox OrtStatus Return Value
+   *
+   * \note Implementation of this function is optional. If set to NULL, no automatic
+   *       resource threshold is established and budget enforcement requires an explicit
+   *       threshold from session options.
+   *
+   * \since Version 1.26.
+   */
+  ORT_API2_STATUS(GetAvailableResource, _In_ const OrtEp* this_ptr, _Out_ OrtResourceCount* available);
 };
 
 /** \brief The function signature that ORT will call to create OrtEpFactory instances.

--- a/onnxruntime/core/providers/cuda/plugin/cuda_ep.cc
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_ep.cc
@@ -607,6 +607,10 @@ OrtStatus* ORT_API_CALL CudaEp::GetAvailableResourceImpl(
     const OrtEp* this_ptr, OrtResourceCount* available) noexcept {
   EXCEPTION_TO_STATUS_BEGIN
 
+  if (available == nullptr) {
+    return Ort::GetApi().CreateStatus(ORT_INVALID_ARGUMENT, "`available` must not be null");
+  }
+
   auto* ep = static_cast<const CudaEp*>(this_ptr);
   int current_device = 0;
   auto cuda_err = cudaGetDevice(&current_device);

--- a/onnxruntime/core/providers/cuda/plugin/cuda_ep.cc
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_ep.cc
@@ -131,6 +131,9 @@ CudaEp::CudaEp(CudaEpFactory& factory, const Config& config, const OrtLogger& lo
   ReplayGraph = ReplayGraphImpl;
   GetGraphCaptureNodeAssignmentPolicy = GetGraphCaptureNodeAssignmentPolicyImpl;
 
+  // Resource accounting — allows ORT to query available device memory for budget enforcement
+  GetAvailableResource = GetAvailableResourceImpl;
+
   const OrtApi& ort_api = factory_.GetOrtApi();
   Ort::Status log_status(ort_api.Logger_LogMessage(&logger_, ORT_LOGGING_LEVEL_INFO,
                                                    "CUDA Plugin EP created",
@@ -597,6 +600,51 @@ OrtStatus* ORT_API_CALL CudaEp::ReplayGraphImpl(OrtEp* this_ptr, int graph_annot
 OrtGraphCaptureNodeAssignmentPolicy ORT_API_CALL CudaEp::GetGraphCaptureNodeAssignmentPolicyImpl(
     const OrtEp* /*this_ptr*/) noexcept {
   return OrtGraphCaptureNodeAssignmentPolicy_ALLOW_CPU_FOR_SHAPES;
+}
+
+/*static*/
+OrtStatus* ORT_API_CALL CudaEp::GetAvailableResourceImpl(
+    const OrtEp* this_ptr, OrtResourceCount* available) noexcept {
+  EXCEPTION_TO_STATUS_BEGIN
+
+  auto* ep = static_cast<const CudaEp*>(this_ptr);
+  int current_device = 0;
+  auto cuda_err = cudaGetDevice(&current_device);
+  if (cuda_err != cudaSuccess) {
+    return Ort::GetApi().CreateStatus(
+        ORT_RUNTIME_EXCEPTION,
+        (std::string("cudaGetDevice failed: ") + cudaGetErrorString(cuda_err)).c_str());
+  }
+
+  // Switch to the EP's configured device if needed
+  if (current_device != ep->config_.device_id) {
+    cuda_err = cudaSetDevice(ep->config_.device_id);
+    if (cuda_err != cudaSuccess) {
+      return Ort::GetApi().CreateStatus(
+          ORT_RUNTIME_EXCEPTION,
+          (std::string("cudaSetDevice failed: ") + cudaGetErrorString(cuda_err)).c_str());
+    }
+  }
+
+  size_t free_memory = 0;
+  size_t total_memory = 0;
+  cuda_err = cudaMemGetInfo(&free_memory, &total_memory);
+
+  // Restore the original device
+  if (current_device != ep->config_.device_id) {
+    cudaSetDevice(current_device);  // best-effort restore
+  }
+
+  if (cuda_err != cudaSuccess) {
+    return Ort::GetApi().CreateStatus(
+        ORT_RUNTIME_EXCEPTION,
+        (std::string("cudaMemGetInfo failed: ") + cudaGetErrorString(cuda_err)).c_str());
+  }
+
+  *available = OrtResourceCount::FromTotalBytes(static_cast<uint64_t>(free_memory));
+  return nullptr;
+
+  EXCEPTION_TO_STATUS_END
 }
 
 }  // namespace cuda_plugin

--- a/onnxruntime/core/providers/cuda/plugin/cuda_ep.h
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_ep.h
@@ -88,6 +88,9 @@ class CudaEp : public onnxruntime::ep::adapter::Ep {
   static OrtGraphCaptureNodeAssignmentPolicy ORT_API_CALL GetGraphCaptureNodeAssignmentPolicyImpl(
       const OrtEp* this_ptr) noexcept;
 
+  static OrtStatus* ORT_API_CALL GetAvailableResourceImpl(
+      const OrtEp* this_ptr, OrtResourceCount* available) noexcept;
+
   /// Helper to parse the graph annotation ID from run options.
   CudaGraphAnnotation_t GetGraphAnnotationId(const OrtRunOptions* run_options) const;
 

--- a/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
+++ b/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
@@ -15,7 +15,8 @@
 #include "core/framework/plugin_ep_stream.h"
 #include "core/framework/resource_accountant.h"
 #include "core/common/inlined_containers.h"
-#include "core/common/narrow.h"
+#include <limits>
+
 #include "core/graph/ep_api_types.h"
 #include "core/graph/model_editor_api_types.h"
 #include "core/session/abi_devices.h"
@@ -283,7 +284,12 @@ PluginExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_vie
     OrtResourceCount available{};
     if (auto* ort_status = ort_ep_->GetAvailableResource(ort_ep_.get(), &available); ort_status == nullptr) {
       if (available.kind == OrtResourceCountKind_TotalBytes) {
-        resource_accountant->SetThreshold(ResourceCount{narrow<size_t>(available.value.total_bytes)});
+        auto bytes = available.value.total_bytes;
+        // Clamp to size_t max on 32-bit builds instead of throwing via narrow<>.
+        size_t clamped = (bytes > std::numeric_limits<size_t>::max())
+                             ? std::numeric_limits<size_t>::max()
+                             : static_cast<size_t>(bytes);
+        resource_accountant->SetThreshold(ResourceCount{clamped});
         LOGS(logger, VERBOSE) << Type() << " set resource threshold from device: "
                               << available.value.total_bytes << " bytes";
       }

--- a/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
+++ b/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
@@ -15,6 +15,7 @@
 #include "core/framework/plugin_ep_stream.h"
 #include "core/framework/resource_accountant.h"
 #include "core/common/inlined_containers.h"
+#include "core/common/narrow.h"
 #include "core/graph/ep_api_types.h"
 #include "core/graph/model_editor_api_types.h"
 #include "core/session/abi_devices.h"
@@ -273,6 +274,26 @@ PluginExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_vie
   // Host-side resource budget enforcement.
   // The host computes costs and enforces the budget uniformly for all node grouping kinds.
   // Plugin EPs only propose supported nodes; the host decides which to accept.
+
+  // If an accountant exists but has no explicit threshold (i.e., the session option didn't specify a memory limit),
+  // ask the EP for the available device resource (e.g., free GPU memory) and use that as the threshold.
+  // This mirrors the in-tree CUDA EP behavior that calls cudaMemGetInfo as a fallback.
+  if (resource_accountant != nullptr && !resource_accountant->GetThreshold().has_value() &&
+      ort_ep_->ort_version_supported >= 26 && ort_ep_->GetAvailableResource != nullptr) {
+    OrtResourceCount available{};
+    if (auto* ort_status = ort_ep_->GetAvailableResource(ort_ep_.get(), &available); ort_status == nullptr) {
+      if (available.kind == OrtResourceCountKind_TotalBytes) {
+        resource_accountant->SetThreshold(ResourceCount{narrow<size_t>(available.value.total_bytes)});
+        LOGS(logger, VERBOSE) << Type() << " set resource threshold from device: "
+                              << available.value.total_bytes << " bytes";
+      }
+    } else {
+      // Log warning and continue without a device-derived threshold
+      auto status_releaser = Status(ToStatusAndRelease(ort_status));
+      LOGS(logger, WARNING) << Type() << " GetAvailableResource failed: " << status_releaser.ToString();
+    }
+  }
+
   const bool has_budget = resource_accountant != nullptr && resource_accountant->GetThreshold().has_value();
   ResourceCount consumed = resource_accountant != nullptr
                                ? resource_accountant->GetConsumedAmount()

--- a/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
+++ b/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
@@ -284,14 +284,18 @@ PluginExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_vie
     OrtResourceCount available{};
     if (auto* ort_status = ort_ep_->GetAvailableResource(ort_ep_.get(), &available); ort_status == nullptr) {
       if (available.kind == OrtResourceCountKind_TotalBytes) {
-        auto bytes = available.value.total_bytes;
+        const auto bytes = available.value.total_bytes;
         // Clamp to size_t max on 32-bit builds instead of throwing via narrow<>.
-        size_t clamped = (bytes > std::numeric_limits<size_t>::max())
-                             ? std::numeric_limits<size_t>::max()
-                             : static_cast<size_t>(bytes);
+        const size_t clamped = (bytes > std::numeric_limits<size_t>::max())
+                                   ? std::numeric_limits<size_t>::max()
+                                   : static_cast<size_t>(bytes);
         resource_accountant->SetThreshold(ResourceCount{clamped});
         LOGS(logger, VERBOSE) << Type() << " set resource threshold from device: "
-                              << available.value.total_bytes << " bytes";
+                              << clamped << " bytes"
+                              << (clamped != bytes ? " (clamped from " + std::to_string(bytes) + " bytes)" : "");
+      } else if (available.kind != OrtResourceCountKind_None) {
+        LOGS(logger, WARNING) << Type() << " GetAvailableResource returned unsupported kind: "
+                              << static_cast<int>(available.kind);
       }
     } else {
       // Log warning and continue without a device-derived threshold

--- a/onnxruntime/test/framework/ep_plugin_provider_test.cc
+++ b/onnxruntime/test/framework/ep_plugin_provider_test.cc
@@ -1448,7 +1448,7 @@ static IResourceAccountant* CallGetCapabilityWithAccountant(
   ep.SetLogger(&logger);
   ep.GetCapability(graph_viewer,
                    test_plugin_ep::MockKernelLookup(),
-                   GraphOptimizerRegistry(nullptr, nullptr, logger),
+                   GraphOptimizerRegistry(nullptr, nullptr, &logger),
                    accountant);
   return accountant;
 }

--- a/onnxruntime/test/framework/ep_plugin_provider_test.cc
+++ b/onnxruntime/test/framework/ep_plugin_provider_test.cc
@@ -11,13 +11,17 @@
 #include "gtest/gtest.h"
 
 #include "core/common/logging/sinks/file_sink.h"
+#include "core/framework/config_options.h"
 #include "core/framework/kernel_def_builder.h"
 #include "core/framework/op_kernel.h"
+#include "core/framework/resource_accountant.h"
+#include "core/graph/constants.h"
 #include "core/graph/graph_viewer.h"
 #include "core/graph/model.h"
 #include "core/optimizer/graph_optimizer_registry.h"
 #include "core/session/abi_devices.h"
 #include "core/session/onnxruntime_cxx_api.h"
+#include "core/session/onnxruntime_session_options_config_keys.h"
 #include "test/util/include/api_asserts.h"
 #include "test/util/include/asserts.h"
 #include "test/util/include/test_environment.h"
@@ -1413,6 +1417,100 @@ TEST(PluginExecutionProviderTest, GetGraphCaptureNodeAssignmentPolicy) {
     ASSERT_EQ(ep->GetGraphCaptureNodeAssignmentPolicy(), OrtGraphCaptureNodeAssignmentPolicy_ALL_NODES_ON_EP);
     ort_ep->ort_version_supported = ORT_API_VERSION;  // Restore.
   }
+}
+
+// Helper: create a no-threshold resource accountant via the real factory (config ",").
+static IResourceAccountant* CreateNoThresholdAccountant(std::optional<ResourceAccountantMap>& acc_map) {
+  ConfigOptions config;
+  EXPECT_STATUS_OK(config.AddConfigEntry(kOrtSessionOptionsResourceCudaPartitioningSettings, ","));
+  EXPECT_STATUS_OK(CreateAccountants(config, /*model_path=*/{}, acc_map));
+  auto it = acc_map->find(kCudaExecutionProvider);
+  return it != acc_map->end() ? it->second.get() : nullptr;
+}
+
+// Helper: call GetCapability on a mock EP with a no-threshold accountant, returning the accountant for inspection.
+static IResourceAccountant* CallGetCapabilityWithAccountant(
+    IExecutionProvider& ep,
+    test_plugin_ep::TestOrtEp* ort_ep,
+    std::optional<ResourceAccountantMap>& acc_map) {
+  ort_ep->GetCapability = GetCapabilityTakeAllNodesOneGroup;
+
+  std::shared_ptr<Model> model;
+  EXPECT_STATUS_OK(Model::Load(ORT_TSTR("testdata/add_mul_add.onnx"), model, nullptr,
+                               DefaultLoggingManager().DefaultLogger()));
+
+  auto* accountant = CreateNoThresholdAccountant(acc_map);
+  EXPECT_NE(accountant, nullptr);
+  EXPECT_FALSE(accountant->GetThreshold().has_value());
+
+  GraphViewer graph_viewer(model->MainGraph());
+  auto& logger = DefaultLoggingManager().DefaultLogger();
+  ep.SetLogger(&logger);
+  ep.GetCapability(graph_viewer,
+                   test_plugin_ep::MockKernelLookup(),
+                   GraphOptimizerRegistry(nullptr, nullptr, logger),
+                   accountant);
+  return accountant;
+}
+
+// GetAvailableResource returns TotalBytes → threshold should be set to that value.
+TEST(PluginExecutionProviderTest, GetAvailableResource_SetsThresholdFromTotalBytes) {
+  auto [ep, ort_ep] = test_plugin_ep::MakeTestOrtEp();
+
+  constexpr uint64_t kBudget = 42000;
+
+  ort_ep->GetAvailableResource = [](const OrtEp* /*this_ptr*/, OrtResourceCount* available) noexcept -> OrtStatus* {
+    *available = OrtResourceCount::FromTotalBytes(42000);
+    return nullptr;
+  };
+
+  std::optional<ResourceAccountantMap> acc_map;
+  auto* accountant = CallGetCapabilityWithAccountant(*ep, ort_ep, acc_map);
+
+  ASSERT_TRUE(accountant->GetThreshold().has_value());
+  EXPECT_EQ(std::get<size_t>(*accountant->GetThreshold()), static_cast<size_t>(kBudget));
+}
+
+// GetAvailableResource returns None → threshold should remain unset (EP has no info).
+TEST(PluginExecutionProviderTest, GetAvailableResource_NoneKindLeavesThresholdUnset) {
+  auto [ep, ort_ep] = test_plugin_ep::MakeTestOrtEp();
+
+  ort_ep->GetAvailableResource = [](const OrtEp* /*this_ptr*/, OrtResourceCount* available) noexcept -> OrtStatus* {
+    *available = OrtResourceCount::None();
+    return nullptr;
+  };
+
+  std::optional<ResourceAccountantMap> acc_map;
+  auto* accountant = CallGetCapabilityWithAccountant(*ep, ort_ep, acc_map);
+
+  EXPECT_FALSE(accountant->GetThreshold().has_value());
+}
+
+// GetAvailableResource returns an error status → threshold should remain unset.
+TEST(PluginExecutionProviderTest, GetAvailableResource_ErrorLeavesThresholdUnset) {
+  auto [ep, ort_ep] = test_plugin_ep::MakeTestOrtEp();
+
+  ort_ep->GetAvailableResource = [](const OrtEp* this_ptr, OrtResourceCount* /*available*/) noexcept -> OrtStatus* {
+    auto* test_ep = static_cast<const test_plugin_ep::TestOrtEp*>(this_ptr);
+    return test_ep->ort_api->CreateStatus(ORT_RUNTIME_EXCEPTION, "device unavailable");
+  };
+
+  std::optional<ResourceAccountantMap> acc_map;
+  auto* accountant = CallGetCapabilityWithAccountant(*ep, ort_ep, acc_map);
+
+  EXPECT_FALSE(accountant->GetThreshold().has_value());
+}
+
+// GetAvailableResource is nullptr (old EP) → threshold should remain unset, no crash.
+TEST(PluginExecutionProviderTest, GetAvailableResource_NullCallbackLeavesThresholdUnset) {
+  auto [ep, ort_ep] = test_plugin_ep::MakeTestOrtEp();
+
+  ort_ep->GetAvailableResource = nullptr;
+
+  std::optional<ResourceAccountantMap> acc_map;
+  auto* accountant = CallGetCapabilityWithAccountant(*ep, ort_ep, acc_map);
+
+  EXPECT_FALSE(accountant->GetThreshold().has_value());
 }
 
 }  // namespace onnxruntime::test

--- a/onnxruntime/test/providers/cuda/plugin/cuda_resource_partitioning_test.cc
+++ b/onnxruntime/test/providers/cuda/plugin/cuda_resource_partitioning_test.cc
@@ -275,6 +275,38 @@ class CudaPluginPartitioningTest : public ::testing::Test {
 
   std::unique_ptr<ScopedCudaPluginRegistration> registration_;
   Ort::ConstEpDevice cuda_device_{nullptr};
+
+  // Overload that accepts a raw config string for kOrtSessionOptionsResourceCudaPartitioningSettings.
+  // This allows tests to set the config without a budget (e.g., ",") to trigger
+  // accountant creation without an explicit threshold.
+  void LoadAndVerifyPartitioningWithConfig(
+      const std::string& model_bytes,
+      const std::string& partitioning_config,
+      const std::function<void(const Graph&)>& verifier) {
+    OrtSessionOptions ort_options;
+
+    const OrtEpDevice* device_ptr = static_cast<const OrtEpDevice*>(cuda_device_);
+    auto ep_devices_span = gsl::make_span(&device_ptr, 1);
+
+    std::unique_ptr<IExecutionProviderFactory> factory;
+    ASSERT_STATUS_OK(CreateIExecutionProviderFactoryForEpDevices(
+        GetOrtEnv().GetEnvironment(), ep_devices_span, factory));
+
+    ort_options.provider_factories.push_back(std::move(factory));
+
+    if (!partitioning_config.empty()) {
+      ASSERT_STATUS_OK(ort_options.value.config_options.AddConfigEntry(
+          kOrtSessionOptionsResourceCudaPartitioningSettings, partitioning_config.c_str()));
+    }
+
+    InferenceSessionWrapper session(ort_options.value, GetOrtEnv().GetEnvironment());
+    ASSERT_STATUS_OK(session.Load(model_bytes.data(), static_cast<int>(model_bytes.size())));
+
+    OrtStatus* status = InitializeSession(&ort_options, session);
+    ASSERT_STATUS_OK(ToStatusAndRelease(status));
+
+    verifier(session.GetGraph());
+  }
 };
 
 // With no resource budget, all CUDA-supported nodes should be assigned to the plugin EP.
@@ -343,6 +375,70 @@ TEST_F(CudaPluginPartitioningTest, TinyBudget_NodesOffloadedToCpu) {
   EXPECT_LT(constrained_plugin_count, baseline_plugin_count)
       << "A 10 KB budget should reduce plugin EP node count from the no-budget baseline ("
       << baseline_plugin_count << " nodes)";
+}
+
+// When the partitioning config specifies no explicit memory limit but does trigger
+// accountant creation (e.g., ","), the plugin EP's GetAvailableResource callback
+// should be invoked to derive the threshold from the device's free memory.
+// This verifies the fix for the missing cudaMemGetInfo fallback in plugin EPs.
+TEST_F(CudaPluginPartitioningTest, NoExplicitLimit_DeviceMemoryUsedAsThreshold) {
+  // Build a model large enough to exercise the budget path meaningfully.
+  // 6 Add nodes, each with a 256-element (1 KB) initializer.
+  const std::string model = BuildAddChainModel(/*num_nodes=*/6, /*weight_elements=*/256);
+
+  // Config ",": empty memory limit (triggers GetAvailableResource), no stats file.
+  // This creates an accountant with no threshold — the host wrapper should
+  // call GetAvailableResource on the plugin EP to get the GPU's free memory.
+  size_t device_threshold_plugin_count = 0;
+  LoadAndVerifyPartitioningWithConfig(model, ",", [&](const Graph& graph) {
+    for (const auto& node : graph.Nodes()) {
+      if (node.GetExecutionProviderType() == kCudaPluginExecutionProvider) {
+        ++device_threshold_plugin_count;
+      }
+    }
+  });
+
+  // With the device's free memory as the threshold (typically many GB),
+  // a 6-node chain with tiny initializers should all fit.
+  // The key verification is that the session initializes successfully —
+  // i.e., the accountant path doesn't crash or skip all nodes.
+  EXPECT_GT(device_threshold_plugin_count, size_t{0})
+      << "With device-derived threshold, at least some nodes should be assigned to the plugin EP";
+}
+
+// When the config triggers accountant creation with no explicit limit, the outcome
+// should match the no-budget baseline for small models (device memory >> model size).
+TEST_F(CudaPluginPartitioningTest, NoExplicitLimit_MatchesNoBudgetBaseline) {
+  const std::string model = BuildAddChainModel(/*num_nodes=*/6, /*weight_elements=*/256);
+
+  // Baseline: no partitioning config at all (no accountant created).
+  size_t no_budget_count = 0;
+  LoadAndVerifyPartitioning(model, /*budget_kb=*/0, [&](const Graph& graph) {
+    for (const auto& node : graph.Nodes()) {
+      if (node.GetExecutionProviderType() == kCudaPluginExecutionProvider) {
+        ++no_budget_count;
+      }
+    }
+  });
+  ASSERT_GT(no_budget_count, size_t{0});
+
+  // Device-derived threshold: config "," creates an accountant, GetAvailableResource
+  // returns the device's free memory which should be far larger than the model.
+  size_t device_threshold_count = 0;
+  LoadAndVerifyPartitioningWithConfig(model, ",", [&](const Graph& graph) {
+    for (const auto& node : graph.Nodes()) {
+      if (node.GetExecutionProviderType() == kCudaPluginExecutionProvider) {
+        ++device_threshold_count;
+      }
+    }
+  });
+
+  // For a tiny model on a GPU with gigabytes of free memory, the device-derived
+  // threshold should accept the same nodes as the no-budget path.
+  EXPECT_EQ(device_threshold_count, no_budget_count)
+      << "Device-derived threshold should accept all nodes for a small model "
+      << "(device_threshold=" << device_threshold_count
+      << ", no_budget=" << no_budget_count << ")";
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
This pull request introduces a new resource accounting mechanism to the ONNX Runtime Execution Provider (EP) plugin API, enabling execution providers to report available device resources (such as free GPU memory) for use in budget enforcement during graph partitioning. The main changes include the definition of an ABI-stable `OrtResourceCount` struct and enum, a new optional API for querying available resources, and a CUDA EP implementation that reports free device memory. Host-side logic is updated to use this information when explicit session memory limits are not set.

**API and Struct Additions:**

* Introduced the `OrtResourceCountKind` enum and ABI-stable `OrtResourceCount` struct to represent device resource counts in a forward-compatible way, including C++ helpers and ABI stability checks. (`include/onnxruntime/core/session/onnxruntime_ep_c_api.h`)
* Added the optional `GetAvailableResource` function pointer to the `OrtEp` struct, allowing EPs to report available device resources for partitioning budget. (`include/onnxruntime/core/session/onnxruntime_ep_c_api.h`)

**CUDA EP Implementation:**

* Implemented `GetAvailableResourceImpl` in `CudaEp`, which queries the current device for free memory using `cudaMemGetInfo` and returns it as an `OrtResourceCount`. (`onnxruntime/core/providers/cuda/plugin/cuda_ep.cc`, `onnxruntime/core/providers/cuda/plugin/cuda_ep.h`) [[1]](diffhunk://#diff-0890d267a71ca02f4173c2ab226e6c5707fcbbf6bbb5f602fa5d92aa82f42a80R605-R649) [[2]](diffhunk://#diff-82888350617a2e54bb30b1a11cd2563ecaf2b45ed0baba736674d9156c912b20R91-R93)
* Registered the new API in the CUDA EP constructor. (`onnxruntime/core/providers/cuda/plugin/cuda_ep.cc`)

**Host-Side Integration:**

* Updated the host-side plugin EP logic to call `GetAvailableResource` if no explicit threshold is set, using the returned value as the resource budget for partitioning (mirroring in-tree CUDA EP behavior). (`onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc`)
* Added necessary includes for type narrowing. (`onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc`)