### PR TITLE
Apply model size limit before converting size_t input to int32_t

### DIFF
--- a/js/node/test/unittests/lib/inference-session.ts
+++ b/js/node/test/unittests/lib/inference-session.ts
@@ -95,7 +95,7 @@ describe('UnitTests - InferenceSession.create()', () => {
       async () => {
         await InferenceSession.create(new Uint8Array(0));
       },
-      { name: 'Error', message: /No graph was found in the protobuf/ },
+      { name: 'Error', message: /Model data pointer is null./ },
     );
   });
   // #endregion

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -3958,7 +3958,7 @@ ORT_API_STATUS_IMPL(OrtApis::GetCompatibilityInfoFromModelBytes,
   }
 
   ONNX_NAMESPACE::ModelProto model_proto;
-  auto status = Model::LoadFromBytes(static_cast<int>(model_data_length), model_data, model_proto);
+  auto status = Model::LoadFromBytes(narrow<int32_t>(model_data_length), model_data, model_proto);
   if (!status.IsOK()) {
     return OrtApis::CreateStatus(ORT_INVALID_GRAPH, status.ErrorMessage().c_str());
   }

--- a/onnxruntime/core/session/utils.cc
+++ b/onnxruntime/core/session/utils.cc
@@ -3,16 +3,18 @@
 
 #include "core/session/utils.h"
 
-#include <memory>
-#include <utility>
 #include <filesystem>
+#include <limits>
+#include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "core/framework/error_code_helper.h"
 #include "core/framework/execution_provider.h"
 #include "core/framework/provider_options.h"
+#include "core/common/narrow.h"
 #include "core/platform/env.h"
 #include "core/platform/telemetry.h"
 #include "core/session/abi_session_options_impl.h"
@@ -374,6 +376,14 @@ static OrtStatus* CreateSessionAndLoadSingleModelImpl(_In_ const OrtSessionOptio
     }
   }
 
+  int32_t model_data_length_int = 0;
+  if (model_path == nullptr) {
+    ORT_RETURN_IF(model_data == nullptr, "Model data pointer is null.");
+    ORT_RETURN_IF(model_data_length > static_cast<size_t>(std::numeric_limits<int32_t>::max()),
+                  "Model data size exceeds maximum supported size (2GB).");
+    model_data_length_int = narrow<int32_t>(model_data_length);
+  }
+
   if (load_config_from_model) {
 #if !defined(ORT_MINIMAL_BUILD)
     if (model_path != nullptr) {
@@ -385,7 +395,7 @@ static OrtStatus* CreateSessionAndLoadSingleModelImpl(_In_ const OrtSessionOptio
       sess = std::make_unique<onnxruntime::InferenceSession>(
           options == nullptr ? onnxruntime::SessionOptions() : options->value,
           env,
-          model_data, static_cast<int>(model_data_length));
+          model_data, model_data_length_int);
     }
 #else
     return OrtApis::CreateStatus(ORT_FAIL, "Loading config from ONNX models is not supported in this build.");
@@ -437,7 +447,7 @@ static OrtStatus* CreateSessionAndLoadSingleModelImpl(_In_ const OrtSessionOptio
     if (model_path != nullptr) {
       ORT_API_RETURN_IF_STATUS_NOT_OK(sess->Load(model_path));
     } else {
-      ORT_API_RETURN_IF_STATUS_NOT_OK(sess->Load(model_data, static_cast<int>(model_data_length)));
+      ORT_API_RETURN_IF_STATUS_NOT_OK(sess->Load(model_data, model_data_length_int));
     }
   }
 

--- a/onnxruntime/core/session/utils.cc
+++ b/onnxruntime/core/session/utils.cc
@@ -378,9 +378,9 @@ static OrtStatus* CreateSessionAndLoadSingleModelImpl(_In_ const OrtSessionOptio
 
   int32_t model_data_length_int = 0;
   if (model_path == nullptr) {
-    ORT_RETURN_IF(model_data == nullptr, "Model data pointer is null.");
-    ORT_RETURN_IF(model_data_length > static_cast<size_t>(std::numeric_limits<int32_t>::max()),
-                  "Model data size exceeds maximum supported size (2GB).");
+    ORT_API_RETURN_IF(model_data == nullptr, ORT_INVALID_ARGUMENT, "Model data pointer is null.");
+    ORT_API_RETURN_IF(model_data_length > static_cast<size_t>(std::numeric_limits<int32_t>::max()),
+                      ORT_INVALID_ARGUMENT, "Model data size exceeds maximum supported size (2GB).");
     model_data_length_int = narrow<int32_t>(model_data_length);
   }
 

--- a/onnxruntime/test/shared_lib/test_model_loading.cc
+++ b/onnxruntime/test/shared_lib/test_model_loading.cc
@@ -6,6 +6,7 @@
 #include "core/common/narrow.h"
 #include "test/util/include/asserts.h"
 #include <fstream>
+#include <limits>
 #include "test_fixture.h"
 #include "file_util.h"
 
@@ -64,6 +65,20 @@ TEST(CApiTest, model_from_array) {
   so.AppendExecutionProvider_CUDA_V2(*options);
   create_session(so);
 #endif
+}
+
+TEST(CApiTest, model_from_array_rejects_oversized_input) {
+  const char dummy_model_data[] = "invalid";
+  const size_t oversized_length = static_cast<size_t>(std::numeric_limits<int32_t>::max()) + 1ULL;
+  Ort::SessionOptions so;
+
+  try {
+    Ort::Session session(*ort_env.get(), dummy_model_data, oversized_length, so);
+    FAIL() << "Creation of session should have thrown exception";
+  } catch (const Ort::Exception& ex) {
+    EXPECT_EQ(ex.GetOrtErrorCode(), ORT_INVALID_ARGUMENT);
+    ASSERT_THAT(ex.what(), testing::HasSubstr("maximum supported size"));
+  }
 }
 
 #if !defined(ORT_MINIMAL_BUILD) && !defined(ORT_EXTENDED_MINIMAL_BUILD)

--- a/winml/adapter/winml_adapter_model.cpp
+++ b/winml/adapter/winml_adapter_model.cpp
@@ -179,9 +179,10 @@ OrtStatus* OrtModelImpl::CreateOrtModelFromPath(const char* path, size_t len, Or
 }
 
 OrtStatus* OrtModelImpl::CreateOrtModelFromData(void* data, size_t len, ::OrtModel** model) {
-  if (len > static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
+  constexpr int32_t kMaxModelDataLength = std::numeric_limits<int32_t>::max();
+  if (len > static_cast<size_t>(kMaxModelDataLength)) {
     return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
-                                 "Model data size exceeds maximum supported size (2147483647 bytes, approximately 2GB).");
+                                 "Model data size exceeds maximum supported size (INT32_MAX bytes, approximately 2GB).");
   }
 
   auto model_proto = std::unique_ptr<ONNX_NAMESPACE::ModelProto>(new ONNX_NAMESPACE::ModelProto());

--- a/winml/adapter/winml_adapter_model.cpp
+++ b/winml/adapter/winml_adapter_model.cpp
@@ -179,10 +179,11 @@ OrtStatus* OrtModelImpl::CreateOrtModelFromPath(const char* path, size_t len, Or
 }
 
 OrtStatus* OrtModelImpl::CreateOrtModelFromData(void* data, size_t len, ::OrtModel** model) {
-  constexpr int32_t kMaxModelDataLength = std::numeric_limits<int32_t>::max();
-  if (len > static_cast<size_t>(kMaxModelDataLength)) {
-    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
-                                 "Model data size exceeds maximum supported size (INT32_MAX bytes, approximately 2GB).");
+  constexpr int32_t kProtobufMaxArraySize = std::numeric_limits<int32_t>::max();
+  if (len > static_cast<size_t>(kProtobufMaxArraySize)) {
+    const auto error_message = onnxruntime::MakeString(
+      "Model data size (", len, " bytes) exceeds maximum supported size (INT32_MAX bytes, approximately 2GB).");
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, error_message.c_str());
   }
 
   auto model_proto = std::unique_ptr<ONNX_NAMESPACE::ModelProto>(new ONNX_NAMESPACE::ModelProto());

--- a/winml/adapter/winml_adapter_model.cpp
+++ b/winml/adapter/winml_adapter_model.cpp
@@ -180,7 +180,8 @@ OrtStatus* OrtModelImpl::CreateOrtModelFromPath(const char* path, size_t len, Or
 
 OrtStatus* OrtModelImpl::CreateOrtModelFromData(void* data, size_t len, ::OrtModel** model) {
   if (len > static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
-    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "Model data size exceeds maximum supported size (2GB).");
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
+                                 "Model data size exceeds maximum supported size (2147483647 bytes, approximately 2GB).");
   }
 
   auto model_proto = std::unique_ptr<ONNX_NAMESPACE::ModelProto>(new ONNX_NAMESPACE::ModelProto());

--- a/winml/adapter/winml_adapter_model.cpp
+++ b/winml/adapter/winml_adapter_model.cpp
@@ -16,6 +16,7 @@
 
 #include <io.h>
 #include <fcntl.h>
+#include <limits>
 #include "google/protobuf/io/zero_copy_stream_impl.h"
 #include "core/framework/onnxruntime_typeinfo.h"
 
@@ -178,6 +179,10 @@ OrtStatus* OrtModelImpl::CreateOrtModelFromPath(const char* path, size_t len, Or
 }
 
 OrtStatus* OrtModelImpl::CreateOrtModelFromData(void* data, size_t len, ::OrtModel** model) {
+  if (len > static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "Model data size exceeds maximum supported size (2GB).");
+  }
+
   auto model_proto = std::unique_ptr<ONNX_NAMESPACE::ModelProto>(new ONNX_NAMESPACE::ModelProto());
 
   auto parse_succeeded = model_proto->ParseFromArray(data, onnxruntime::narrow<int32_t>(len));

--- a/winml/adapter/winml_adapter_model.cpp
+++ b/winml/adapter/winml_adapter_model.cpp
@@ -12,6 +12,7 @@
 #include "winml_adapter_apis.h"
 #include "core/framework/error_code_helper.h"
 #include "core/common/common.h"
+#include "core/common/narrow.h"
 
 #include <io.h>
 #include <fcntl.h>
@@ -179,7 +180,7 @@ OrtStatus* OrtModelImpl::CreateOrtModelFromPath(const char* path, size_t len, Or
 OrtStatus* OrtModelImpl::CreateOrtModelFromData(void* data, size_t len, ::OrtModel** model) {
   auto model_proto = std::unique_ptr<ONNX_NAMESPACE::ModelProto>(new ONNX_NAMESPACE::ModelProto());
 
-  auto parse_succeeded = model_proto->ParseFromArray(data, static_cast<int>(len));
+  auto parse_succeeded = model_proto->ParseFromArray(data, onnxruntime::narrow<int32_t>(len));
   if (!parse_succeeded) {
     return OrtApis::CreateStatus(ORT_INVALID_PROTOBUF, "Failed to parse model stream!");
   }

--- a/winml/adapter/winml_adapter_model.cpp
+++ b/winml/adapter/winml_adapter_model.cpp
@@ -182,7 +182,8 @@ OrtStatus* OrtModelImpl::CreateOrtModelFromData(void* data, size_t len, ::OrtMod
   constexpr int32_t kProtobufMaxArraySize = std::numeric_limits<int32_t>::max();
   if (len > static_cast<size_t>(kProtobufMaxArraySize)) {
     const auto error_message = onnxruntime::MakeString(
-      "Model data size (", len, " bytes) exceeds maximum supported size (INT32_MAX bytes, approximately 2GB).");
+      "Model data size (", len, " bytes) exceeds maximum supported size (INT32_MAX bytes, approximately 2GB)."
+    );
     return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, error_message.c_str());
   }
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Apply check before converting size_t num bytes input value to int32_t.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Fix unchecked cast.

