### PR TITLE
rel-1.25.0 cherry pick 2

### DIFF
--- a/.github/actions/linux-web-init-and-check/action.yml
+++ b/.github/actions/linux-web-init-and-check/action.yml
@@ -50,7 +50,7 @@ runs:
 
     - name: Check unformatted files
       run: |
-        node -e "a=require('child_process').execSync('git diff --name-only').toString();if(a)throw new Error('Following source files are not formatted: (did you run \"npm run format\"?)\n'+a)"
+        node -e "a=require('child_process').execSync('git diff --name-only -- .').toString();if(a)throw new Error('Following source files are not formatted: (did you run \"npm run format\"?)\n'+a)"
       shell: bash
       working-directory: ${{ github.workspace }}/js
 
@@ -66,6 +66,6 @@ runs:
 
     - name: Check out of dated documents
       run: |
-        node -e "a=require('child_process').execSync('git diff --name-only').toString();if(a)throw new Error('Following documents are not up-to-date: (did you run \"npm run build:doc\"?)\n'+a)"
+        node -e "a=require('child_process').execSync('git diff --name-only -- .').toString();if(a)throw new Error('Following documents are not up-to-date: (did you run \"npm run build:doc\"?)\n'+a)"
       shell: bash
       working-directory: ${{ github.workspace }}/js/web

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -34,7 +34,7 @@ microsoft_gsl;https://github.com/microsoft/GSL/archive/refs/tags/v4.0.0.zip;cf36
 microsoft_wil;https://github.com/microsoft/wil/archive/refs/tags/v1.0.250325.1.zip;826c8bd47c2258ec61b8b218e031e5b33d27f761
 mimalloc;https://github.com/microsoft/mimalloc/archive/refs/tags/v2.1.1.zip;d5ee7d34223d0567892db5179849939c8769dc41
 mp11;https://github.com/boostorg/mp11/archive/refs/tags/boost-1.82.0.zip;9bc9e01dffb64d9e0773b2e44d2f22c51aace063
-onnx;https://github.com/onnx/onnx/archive/refs/tags/v1.20.1.zip;30b80c81a1a381188896e86abe460c3c3f3091fd
+onnx;https://github.com/onnx/onnx/archive/refs/tags/v1.21.0.zip;321d4acc807c8e0fb0bbcc0424a143dffde1e846
 # Use the latest commit of 10.9-GA
 onnx_tensorrt;https://github.com/onnx/onnx-tensorrt/archive/d5dce67db7c2e64b07e055571f5ec06f7f254de2.zip;01114d3b67650857281fa50faa2e412130a63b69
 protobuf;https://github.com/protocolbuffers/protobuf/archive/refs/tags/v21.12.zip;7cf2733949036c7d52fda017badcab093fe73bfa

--- a/cmake/onnxruntime_providers_cuda_plugin.cmake
+++ b/cmake/onnxruntime_providers_cuda_plugin.cmake
@@ -111,6 +111,10 @@ onnxruntime_add_shared_library_module(onnxruntime_providers_cuda_plugin
     ${CUDA_PLUGIN_EP_CC_SRCS}
     ${CUDA_PLUGIN_EP_CU_SRCS}
 )
+
+# Mirror directory structure in the Visual Studio solution tree under "onnxruntime".
+source_group(TREE ${ONNXRUNTIME_ROOT} PREFIX "onnxruntime" FILES ${CUDA_EP_CC_SRCS} ${CUDA_EP_CU_SRCS})
+source_group(TREE ${ONNXRUNTIME_ROOT} PREFIX "onnxruntime" FILES ${CUDA_CONTRIB_OPS_CC_SRCS} ${CUDA_CONTRIB_OPS_CU_SRCS})
 # Keep the plugin CUDA target aligned with the repo-wide C++20 baseline.
 # Forcing CUDA C++17 here breaks newer protobuf/absl headers used by the plugin
 # build, as absl::compare expects standard ordering support in this configuration.
@@ -143,8 +147,12 @@ target_compile_options(onnxruntime_providers_cuda_plugin PRIVATE
     "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--std c++20>"
     "$<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr;-Xcudafe;--diag_suppress=550>"
     "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --diag_suppress=2810>"
-    "$<$<COMPILE_LANGUAGE:CXX>:-include;${REPO_ROOT}/include/onnxruntime/ep/adapters.h>"
-    "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-include ${CUDA_PLUGIN_EP_DIR}/cuda_kernel_adapter.h>"
+    # Force-include adapters.h and cuda_kernel_adapter.h for CXX sources.
+    # GCC/Clang use -include, MSVC uses /FI.
+    "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<NOT:$<CXX_COMPILER_ID:MSVC>>>:-include;${REPO_ROOT}/include/onnxruntime/ep/adapters.h>"
+    "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<NOT:$<CXX_COMPILER_ID:MSVC>>>:SHELL:-include ${CUDA_PLUGIN_EP_DIR}/cuda_kernel_adapter.h>"
+    "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>>:/FI${REPO_ROOT}/include/onnxruntime/ep/adapters.h>"
+    "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>>:/FI${CUDA_PLUGIN_EP_DIR}/cuda_kernel_adapter.h>"
 )
 
 if (MSVC)
@@ -158,6 +166,11 @@ if (MSVC)
     )
 
     target_compile_options(onnxruntime_providers_cuda_plugin PRIVATE
+        # /permissive is required for CUTLASS cute headers (cute::stride.hpp, cute::Layout etc.)
+        "$<$<COMPILE_LANGUAGE:CXX>:/permissive>"
+        # /permissive disables C++ alternative tokens (or, and, not, etc.).
+        # Force-include iso646.h to restore them as macros.
+        "$<$<COMPILE_LANGUAGE:CXX>:/FIiso646.h>"
         "$<$<COMPILE_LANGUAGE:CXX>:/wd4127>"
     )
 endif()
@@ -275,9 +288,10 @@ endif()
 
 
 
-# Set output name
+# Set output name and solution folder
 set_target_properties(onnxruntime_providers_cuda_plugin PROPERTIES
     OUTPUT_NAME "onnxruntime_providers_cuda_plugin"
+    FOLDER "ONNXRuntime"
 )
 
 # Install

--- a/cmake/onnxruntime_providers_webgpu.cmake
+++ b/cmake/onnxruntime_providers_webgpu.cmake
@@ -248,7 +248,6 @@
     endif()
   endif()
 
-  target_compile_features(onnxruntime_providers_webgpu PRIVATE cxx_std_20)
   add_dependencies(onnxruntime_providers_webgpu onnx ${onnxruntime_EXTERNAL_DEPENDENCIES})
 
   if (onnxruntime_WGSL_TEMPLATE)

--- a/cmake/onnxruntime_session.cmake
+++ b/cmake/onnxruntime_session.cmake
@@ -7,6 +7,8 @@ file(GLOB onnxruntime_session_srcs CONFIGURE_DEPENDS
     "${ONNXRUNTIME_ROOT}/core/session/*.cc"
     "${ONNXRUNTIME_ROOT}/core/session/plugin_ep/*.h"
     "${ONNXRUNTIME_ROOT}/core/session/plugin_ep/*.cc"
+    "${ONNXRUNTIME_ROOT}/core/session/model_package/*.h"
+    "${ONNXRUNTIME_ROOT}/core/session/model_package/*.cc"
     )
 
 if (onnxruntime_ENABLE_TRAINING_APIS)
@@ -25,6 +27,7 @@ endif()
 if (onnxruntime_MINIMAL_BUILD)
   file(GLOB autoep_srcs
     "${ONNXRUNTIME_ROOT}/core/session/plugin_ep/*.*"
+    "${ONNXRUNTIME_ROOT}/core/session/model_package/*.*"
   )
 
   set(onnxruntime_session_src_exclude
@@ -72,4 +75,3 @@ if (NOT onnxruntime_BUILD_SHARED_LIB)
             RUNTIME   DESTINATION ${CMAKE_INSTALL_BINDIR}
             FRAMEWORK DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
-

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -509,6 +509,13 @@ if (onnxruntime_USE_CUDA AND NOT onnxruntime_MINIMAL_BUILD AND NOT onnxruntime_R
     )
   list(APPEND onnxruntime_test_providers_src ${onnxruntime_test_providers_cuda_src})
 
+  if (onnxruntime_BUILD_CUDA_EP_AS_PLUGIN)
+    file(GLOB onnxruntime_test_providers_cuda_plugin_src CONFIGURE_DEPENDS
+      "${TEST_SRC_DIR}/providers/cuda/plugin/*.cc"
+    )
+    list(APPEND onnxruntime_test_providers_src ${onnxruntime_test_providers_cuda_plugin_src})
+  endif()
+
   if (onnxruntime_USE_CUDA_NHWC_OPS AND CUDNN_MAJOR_VERSION GREATER 8)
     file(GLOB onnxruntime_test_providers_cuda_nhwc_src CONFIGURE_DEPENDS
       "${TEST_SRC_DIR}/providers/cuda/nhwc/*.cc"

--- a/cmake/patches/onnx/onnx.patch
+++ b/cmake/patches/onnx/onnx.patch
@@ -1,16 +1,16 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 584c0419a..5d4ffff99 100644
+index 044996e..ded7e39 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -52,6 +52,7 @@ option(ONNX_USE_LITE_PROTO "Use lite protobuf instead of full." OFF)
+@@ -53,6 +53,7 @@ option(ONNX_USE_LITE_PROTO "Use lite protobuf instead of full." OFF)
  option(ONNX_DISABLE_EXCEPTIONS "Disable exception handling." OFF)
  option(ONNX_DISABLE_STATIC_REGISTRATION "Disable static registration for ONNX operator schemas." OFF)
  option(ONNX_USE_UNITY_BUILD "Enable Unity (Jumbo) build for" OFF)
 +option(ONNX_MINIMAL_BUILD "Build only essential ONNX components" OFF)
+ option(ONNX_INSTALL "Install ONNX targets, headers, and CMake config files" ON)
  if(WIN32)
    option(ONNX_USE_MSVC_STATIC_RUNTIME "Build with MSVC static runtime" OFF)
- endif()
-@@ -397,14 +398,28 @@ relative_protobuf_generate_cpp(ONNX_PROTO_SRCS
+@@ -399,14 +400,28 @@ relative_protobuf_generate_cpp(ONNX_PROTO_SRCS
                                 onnx/onnx-operators.in.proto
                                 onnx/onnx-data.in.proto)
  
@@ -48,10 +48,10 @@ index 584c0419a..5d4ffff99 100644
  set(LINKED_PROTOBUF_TARGET protobuf::libprotobuf)
  if(ONNX_USE_LITE_PROTO)
 diff --git a/cmake/Utils.cmake b/cmake/Utils.cmake
-index 07f2b9071..388d9f7a3 100644
+index 1987edd..04b3088 100644
 --- a/cmake/Utils.cmake
 +++ b/cmake/Utils.cmake
-@@ -31,18 +31,7 @@ endfunction()
+@@ -103,18 +103,7 @@ endfunction()
  
  function(add_onnx_compile_options target)
    if(MSVC)
@@ -71,10 +71,10 @@ index 07f2b9071..388d9f7a3 100644
        target_compile_options(${target} PRIVATE "/WX")
      endif()
 diff --git a/onnx/defs/nn/old.cc b/onnx/defs/nn/old.cc
-index 887151217..ac2e8c463 100644
+index a6a8a83..153da87 100644
 --- a/onnx/defs/nn/old.cc
 +++ b/onnx/defs/nn/old.cc
-@@ -4152,7 +4152,6 @@ ONNX_OPERATOR_SET_SCHEMA(
+@@ -4026,7 +4026,6 @@ ONNX_OPERATOR_SET_SCHEMA(
      GroupNormalization,
      18,
      OpSchema()

--- a/cmake/vcpkg-ports/onnx/binskim.patch
+++ b/cmake/vcpkg-ports/onnx/binskim.patch
@@ -1,16 +1,16 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 584c0419a..5d4ffff99 100644
+index 044996e..ded7e39 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -52,6 +52,7 @@ option(ONNX_USE_LITE_PROTO "Use lite protobuf instead of full." OFF)
+@@ -53,6 +53,7 @@ option(ONNX_USE_LITE_PROTO "Use lite protobuf instead of full." OFF)
  option(ONNX_DISABLE_EXCEPTIONS "Disable exception handling." OFF)
  option(ONNX_DISABLE_STATIC_REGISTRATION "Disable static registration for ONNX operator schemas." OFF)
  option(ONNX_USE_UNITY_BUILD "Enable Unity (Jumbo) build for" OFF)
 +option(ONNX_MINIMAL_BUILD "Build only essential ONNX components" OFF)
+ option(ONNX_INSTALL "Install ONNX targets, headers, and CMake config files" ON)
  if(WIN32)
    option(ONNX_USE_MSVC_STATIC_RUNTIME "Build with MSVC static runtime" OFF)
- endif()
-@@ -397,14 +398,28 @@ relative_protobuf_generate_cpp(ONNX_PROTO_SRCS
+@@ -399,14 +400,28 @@ relative_protobuf_generate_cpp(ONNX_PROTO_SRCS
                                 onnx/onnx-operators.in.proto
                                 onnx/onnx-data.in.proto)
  
@@ -48,10 +48,10 @@ index 584c0419a..5d4ffff99 100644
  set(LINKED_PROTOBUF_TARGET protobuf::libprotobuf)
  if(ONNX_USE_LITE_PROTO)
 diff --git a/cmake/Utils.cmake b/cmake/Utils.cmake
-index 07f2b9071..388d9f7a3 100644
+index 1987edd..04b3088 100644
 --- a/cmake/Utils.cmake
 +++ b/cmake/Utils.cmake
-@@ -31,18 +31,7 @@ endfunction()
+@@ -103,18 +103,7 @@ endfunction()
  
  function(add_onnx_compile_options target)
    if(MSVC)
@@ -71,10 +71,10 @@ index 07f2b9071..388d9f7a3 100644
        target_compile_options(${target} PRIVATE "/WX")
      endif()
 diff --git a/onnx/defs/nn/old.cc b/onnx/defs/nn/old.cc
-index 887151217..ac2e8c463 100644
+index a6a8a83..153da87 100644
 --- a/onnx/defs/nn/old.cc
 +++ b/onnx/defs/nn/old.cc
-@@ -4152,7 +4152,6 @@ ONNX_OPERATOR_SET_SCHEMA(
+@@ -4026,7 +4026,6 @@ ONNX_OPERATOR_SET_SCHEMA(
      GroupNormalization,
      18,
      OpSchema()

--- a/cmake/vcpkg-ports/onnx/portfile.cmake
+++ b/cmake/vcpkg-ports/onnx/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO onnx/onnx
     REF "v${VERSION}"
-    SHA512 4bbc4c09e4bb3eb6049d653ce49200564e8c5dcf1154a30f894f24e15f1986d1f2fe2f4ca32fe383c559e2a0b20681f33d649376bf63e4345df6972a2c78eac8
+    SHA512 3cee4c0fbc9e260e360a62a59e324e0b127a5749f958e0704989b407a4c1179c637ef86e41a406e7868537a62a11a821e3433005eb0725f979145f8d514926bd
     PATCHES
         fix-cmakelists.patch
         fix-dependency-protobuf.patch

--- a/cmake/vcpkg-ports/onnx/vcpkg.json
+++ b/cmake/vcpkg-ports/onnx/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "onnx",
-  "version-semver": "1.20.1",
-  "port-version": 1,
+  "version-semver": "1.21.0",
+  "port-version": 0,
   "description": "Open standard for machine learning interoperability",
   "homepage": "https://onnx.ai",
   "license": "Apache-2.0",

--- a/docs/OperatorKernels.md
+++ b/docs/OperatorKernels.md
@@ -54,6 +54,7 @@ Do not modify directly.*
 |||14|**T** = tensor(double), tensor(float)<br/> **U** = tensor(double), tensor(float)|
 |||[9, 13]|**T** = tensor(double), tensor(float)|
 |||[7, 8]|**T** = tensor(double), tensor(float)|
+|BitCast|*in* input:**T1**<br> *out* output:**T2**|26+|**T1** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)<br/> **T2** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)|
 |BitShift|*in* X:**T**<br> *in* Y:**T**<br> *out* Z:**T**|11+|**T** = tensor(uint32), tensor(uint64), tensor(uint8)|
 |BitwiseAnd|*in* A:**T**<br> *in* B:**T**<br> *out* C:**T**|18+|**T** = tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)|
 |BitwiseNot|*in* X:**T**<br> *out* Y:**T**|18+|**T** = tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)|
@@ -99,6 +100,7 @@ Do not modify directly.*
 |Cosh|*in* input:**T**<br> *out* output:**T**|22+|**T** = tensor(float)|
 |||[9, 21]|**T** = tensor(float)|
 |Crop|*in* input:**T**<br> *out* output:**T**|1+|**T** = tensor(float)|
+|CumProd|*in* x:**T**<br> *in* axis:**T2**<br> *out* y:**T**|26+|**T** = tensor(double), tensor(float), tensor(int32), tensor(int64), tensor(uint32), tensor(uint64)<br/> **T2** = tensor(int32), tensor(int64)|
 |CumSum|*in* x:**T**<br> *in* axis:**T2**<br> *out* y:**T**|14+|**T** = tensor(double), tensor(float), tensor(int32), tensor(int64)<br/> **T2** = tensor(int32), tensor(int64)|
 |||[11, 13]|**T** = tensor(double), tensor(float), tensor(int32), tensor(int64)<br/> **T2** = tensor(int32), tensor(int64)|
 |DFT|*in* input:**T1**<br> *in* dft_length:**T2**<br> *in* axis:**tensor(int64)**<br> *out* output:**T1**<br><br>or<br><br>*in* input:**T1**<br> *in* dft_length:**T2**<br> *out* output:**T1**|20+|**T1** = tensor(double), tensor(float)<br/> **T2** = tensor(int32), tensor(int64)|

--- a/docs/annotated_partitioning/PartitioningWithAnnotationsAndMemoryConstraints.md
+++ b/docs/annotated_partitioning/PartitioningWithAnnotationsAndMemoryConstraints.md
@@ -1,0 +1,308 @@
+# Graph Partitioning with Annotations and Memory Constraints
+
+ONNX Runtime automatically partitions a model graph across the execution providers (EPs) registered with a session. This page describes the advanced partitioning features introduced for controlling how nodes are assigned to devices and how GPU memory consumption is managed during partitioning.
+
+## Overview
+
+Large models may exceed the memory capacity of a single accelerator (e.g., a CUDA GPU). These features allow you to:
+1. Annotate model layers so that specific parts of the model are directed to specific devices (CPU, GPU, NPU).
+2. Collect per-node memory statistics during a profiling run.
+3. Set a memory budget for an EP so that ONNX Runtime only places nodes on the accelerator until the budget is exhausted; remaining nodes are then eligible for assignment by the subsequent EPs in the session's provider list (often CPU, but not necessarily).
+
+Together, these form a two-phase workflow: profile the model once to collect memory data, then partition it in production using that data and a memory limit.
+
+## Layer Assignment Annotations
+
+### Concept
+
+Each node in an ONNX model can carry a metadata property called `layer_ann` (layering annotation). This is a free-form string that identifies which logical layer or group the node belongs to. At session creation time, you provide a configuration that maps annotation patterns to target devices. ONNX Runtime then uses these mappings to pre-assign nodes to the corresponding EPs before the normal capability-based partitioning runs.
+
+### Annotating the Model
+
+Annotations are stored in each ONNX `NodeProto`'s `metadata_props` field with the key `layer_ann`. You can add them manually using the ONNX Python API:
+
+```python
+import onnx
+model = onnx.load("model.onnx")
+for node in model.graph.node:
+    # Assign a layer annotation based on your own logic
+    entry = next((prop for prop in node.metadata_props if prop.key == "layer_ann"), None)
+    if entry is None:
+        entry = node.metadata_props.add()
+        entry.key = "layer_ann"
+    entry.value = "encoder_layer_0"  # your annotation string
+
+onnx.save(model, "model_annotated.onnx")
+```
+
+### Annotating with Olive
+
+Olive provides built-in support for adding layer annotations during ONNX conversion via the `CaptureLayerAnnotations` pass (added in [PR #2361](https://github.com/microsoft/Olive/pull/2361)). You supply a `layer_annotations` dictionary where each **key** is the annotation string to write into `layer_ann`, and each **value** is a list of node-name substrings. During ONNX export, every node whose name contains one of the substrings receives the corresponding `layer_ann` metadata property. If multiple substrings match, the first one in iteration order wins.
+
+Many exported transformer models use consistent node naming patterns. For example, node names often include recurring substrings such as `embed_tokens`, `self_attn`, `mlp`, or `norm`. Because `CaptureLayerAnnotations` matches node-name substrings, these patterns can be used to group related nodes into logical layers and write the corresponding `layer_ann` values during export. Adjust the substrings to match the naming conventions in your own model.
+
+#### Step 1 — Create the workflow config file
+
+Save the following as `annotate_model.json`:
+
+```json
+{
+  "input_model": {
+    "type": "HfModel",
+    "model_path": "microsoft/Phi-3.5-mini-instruct"
+  },
+  "passes": {
+    "capture_annotations": {
+      "type": "CaptureLayerAnnotations",
+      "layer_annotations": {
+        "embedding_layer": ["embed_tokens"],
+        "attention_layer": ["self_attn", "q_proj", "k_proj", "v_proj", "o_proj"],
+        "mlp_layer": ["mlp", "gate_proj", "up_proj", "down_proj"],
+        "norm_layer": ["norm", "layernorm"]
+      }
+    },
+    "conversion": {
+      "type": "OnnxConversion",
+      "target_opset": 16,
+      "save_as_external_data": true,
+      "all_tensors_to_one_file": true
+    }
+  },
+  "log_severity_level": 1,
+  "output_dir": "models/annotated_phi3"
+}
+```
+
+The `layer_annotations` dictionary maps annotation names to node-name substring patterns:
+- Any node whose name contains `"embed_tokens"` → annotated as `"embedding_layer"`
+- Any node whose name contains `"self_attn"`, `"q_proj"`, etc. → annotated as `"attention_layer"`
+- And so on for `"mlp_layer"` and `"norm_layer"`.
+
+You can also use `ModelBuilder` instead of `OnnxConversion` — both paths apply the annotations automatically:
+
+```json
+    "conversion": {
+      "type": "ModelBuilder",
+      "precision": "int4"
+    }
+```
+
+#### Step 2 — Run the workflow
+
+```bash
+pip install 'olive-ai[auto-opt]'
+olive run --config annotate_model.json
+```
+
+This will:
+1. Download the model from Hugging Face.
+2. Store the `layer_annotations` mapping inside `model_attributes` (via `CaptureLayerAnnotations`).
+3. Convert to ONNX and stamp every matching node with `metadata_props["layer_ann"]` set to the corresponding annotation name.
+4. Write the annotated ONNX model to `models/annotated_phi3/`.
+
+#### Verifying the annotations
+
+You can verify that the annotations were applied:
+
+```python
+import onnx
+
+model = onnx.load("models/annotated_phi3/model.onnx", load_external_data=False)
+for node in model.graph.node:
+    for prop in node.metadata_props:
+        if prop.key == "layer_ann":
+            print(f"{node.name}: {prop.value}")
+```
+
+The annotated model is now ready for use with the ORT session options described below.
+
+### Configuring Layer Assignment at Runtime
+
+Use the session option `session.layer_assignment_settings` to tell ONNX Runtime how to map annotations to devices.
+
+```
+device1(annotation1, annotation2, ...); device2(=annotation3, annotation4, ...)
+```
+
+- `device`: a recognized device designator, matched against the execution providers registered in the session. The supported designators are:
+
+| Device Designator | Meaning | Examples of EPs That May Bind |
+|:------------------|:--------|:-----------------------------|
+| `cpu` | Any CPU device | CPUExecutionProvider |
+| `gpu` | Anything discovered and designated as `OrtHardwareDeviceType_GPU` | CUDA EP, ROCm EP, DirectML EP running on discrete or integrated GPUs |
+| `cuda` | NVIDIA CUDA GPU. A device that is `OrtHardwareDeviceType_GPU` and NVIDIA is a vendor. Same as `gpu:nvidia`. | CUDAExecutionProvider |
+| `dml` | DirectX-compatible GPU | DMLExecutionProvider |
+| `npu` | Neural processing unit | Qualcomm QNN EP, Intel NPU EP |
+| `fpga` | FPGA-backed accelerators | Custom plugin EPs |
+| `accelerator` | Catch-all for any non-CPU device | Any vendor EP |
+| `gpu:<vendor>` | Vendor specialization | `gpu:nvidia`, `gpu:amd`, `gpu:intel` |
+| `gpu:<index>` | Specific device index | GPU 0, GPU 1 |
+
+- `annotation`: string to match against the `layer_ann` value on each node.
+- `=` prefix: denotes an exact match. Without `=`, the annotation is treated as a prefix match (any node whose `layer_ann` starts with the string will match).
+- Prefix rules have higher priority than exact-match rules. Within the same match type, priority is left-to-right.
+- Multiple device rules are separated by `;`.
+
+```python
+import onnxruntime as ort
+
+opts = ort.SessionOptions()
+
+# Nodes annotated with layer_ann starting with "encoder" go to GPU,
+# nodes with exact annotation "final_output" go to CPU.
+opts.add_session_config_entry(
+    "session.layer_assignment_settings",
+    "gpu(encoder); cpu(=final_output)"
+)
+
+session = ort.InferenceSession("model_annotated.onnx", opts,
+                               providers=["CUDAExecutionProvider", "CPUExecutionProvider"])
+```
+
+#### Targeting a Specific GPU
+
+On a machine with multiple GPUs, use `gpu:<index>` to direct annotations to a particular device:
+
+```python
+opts.add_session_config_entry(
+    "session.layer_assignment_settings",
+    "gpu:1(encoder, decoder); cpu(=postprocess)"
+)
+```
+
+> **Note:** ONNX Runtime currently allows only one instance of a given EP type per session, so you cannot split annotations across multiple GPUs in a single session. The `gpu:<index>` designator selects *which* GPU the single registered EP targets.
+
+Nodes that do not match any rule fall through to the normal EP capability-based assignment.
+
+> **Unmatched device designators:** If a device designator in the settings does not match any EP registered in the session, ONNX Runtime logs a warning and skips that rule. Nodes covered by the skipped rule are not pre-assigned and fall through to the normal capability-based partitioning.
+
+> **Note — Annotations vs. actual placement:** An annotation expresses a *preference*, not a guarantee. If the target EP does not have a registered kernel for a node (for example, a particular data-type / opset-version combination is not implemented in the CUDA EP), that node will not be placed on the requested device. Instead it falls through to the next EP in the provider list that can handle it.
+
+## Capacity-Aware Partitioning (implemented for CUDA)
+
+When running models on a CUDA GPU with limited memory, you can set a memory budget so ONNX Runtime stops assigning nodes to the CUDA EP once the estimated memory consumption reaches the limit. Nodes are considered in topological order and assignment halts at the first node that would exceed the budget — ONNX Runtime does not search ahead for smaller nodes that might still fit. Remaining nodes are then eligible for assignment by the subsequent EPs in the session's provider list (often CPU, but not necessarily).
+
+### Step 1: Collect Memory Statistics (Profiling Run)
+
+Run the model once with memory statistics collection enabled. This records per-node allocation data to a CSV file.
+
+```python
+import onnxruntime as ort
+import numpy as np
+
+opts = ort.SessionOptions()
+# Disable memory patterns for accurate per-node measurement
+opts.enable_mem_pattern = False
+opts.add_session_config_entry(
+    "session.collect_node_memory_stats_to_file",
+    "node_memory_stats.csv"
+)
+
+session = ort.InferenceSession("model.onnx", opts,
+                               providers=["CUDAExecutionProvider", "CPUExecutionProvider"])
+
+def make_concrete_shape(shape, default_dim=1):
+    """ORT input shapes may contain symbolic dims or None (e.g. batch size).
+    Replace those with a small concrete value for profiling.
+
+    For the most accurate memory statistics, use the largest input shapes
+    your production workload will encounter.  For example, if your service
+    runs with a maximum batch size of 8, pass default_dim=8 so the profiled
+    allocations reflect that peak usage."""
+    return tuple(
+        dim if isinstance(dim, int) and dim > 0 else default_dim
+        for dim in shape
+    )
+
+# Run inference at least once to collect statistics.
+# For models with dynamic inputs, prefer real sample inputs or model-appropriate
+# concrete shapes instead of relying on the declared ORT input shape directly.
+input_data = {
+    inp.name: np.zeros(make_concrete_shape(inp.shape), dtype=np.float32)
+    for inp in session.get_inputs()
+}
+session.run(None, input_data)
+```
+
+This produces a CSV file with columns:
+`#name,input_sizes,initializers_sizes,total_dynamic_sizes,total_temp_allocations`
+
+In this example, `node_memory_stats.csv` is a relative path. Relative paths are resolved against the model's directory when the model was loaded from a filesystem path. If you provide an absolute path, that path is used as-is. If the model was not loaded from a filesystem path (for example, it was loaded from bytes), the output file is written relative to the current working directory.
+
+Multiple `session.run()` calls update the stats with the maximum values observed per node.
+
+> **What if the GPU cannot hold the entire model?**  The profiling run itself requires the model to fit in GPU memory because the CUDA EP must execute each node to record its actual allocations. If the model exceeds GPU capacity during profiling, reduce the input dimensions (e.g., use a smaller batch size) so that the run completes. The resulting per-node statistics will still be representative of relative node costs and can be used to set the memory budget for subsequent production sessions.
+
+### Step 2: Partition with a Memory Budget
+
+In a subsequent session, provide the memory limit and the stats file to enable capacity-aware partitioning.
+
+```python
+import onnxruntime as ort
+
+opts = ort.SessionOptions()
+
+# Format: "memory_limit_in_kb,stats_filename"
+# Set a 4 GB limit and use the stats from the profiling run
+opts.add_session_config_entry(
+    "session.resource_cuda_partitioning_settings",
+    "4194304,node_memory_stats.csv"
+)
+
+session = ort.InferenceSession("model.onnx", opts,
+                               providers=["CUDAExecutionProvider", "CPUExecutionProvider"])
+```
+
+ONNX Runtime processes nodes in topological order, accumulating estimated memory. When the cumulative cost exceeds the budget, assignment to the CUDA EP halts immediately — remaining nodes are not considered even if they would individually fit within the budget. Those nodes are eligible for assignment by the subsequent EPs in the session's provider list.
+
+Because assignment follows topological order, groups of nodes that you would prefer to offload (for example, MoE expert blocks) may appear at arbitrary positions in the graph. If you want specific node groups to have the lowest priority for device placement, combine the memory budget with layer annotations: annotate the nodes you want to offload to CPU explicitly, and let the capacity-aware partitioner handle the rest.
+
+### Ad-Hoc Mode (No Stats File)
+
+If you do not have pre-recorded statistics, you can specify only a memory limit. ONNX Runtime will estimate per-node cost from initializer sizes and static output shapes, applying a 1.5x safety multiplier.
+
+This mode is less accurate than using pre-recorded stats but provides a quick way to constrain GPU memory without a profiling run.
+
+```python
+# Memory limit only, no stats file (note the trailing comma)
+opts.add_session_config_entry(
+    "session.resource_cuda_partitioning_settings",
+    "4194304,"
+)
+```
+
+### Setting Format Summary
+The value of `session.resource_cuda_partitioning_settings` is a comma-separated pair:
+
+| Format | Meaning |
+|:------|:-------|
+| `<limit_kb>,<stats_file>` | Use both memory limit and pre-recorded stats |
+| `<limit_kb>,` | Memory limit only (ad-hoc estimation) |
+| `,<stats_file>` | Stats only (no explicit limit) |
+| `,` | Neither (EP attempts auto-detection) |
+
+The stats file path follows the same resolution rules described above: relative paths are resolved against the model's directory, absolute paths are used as-is.
+
+## Combining Both Features
+Layer annotations and capacity-aware partitioning can be used together. When both are configured:
+- Layer annotations provide the initial node-to-device mapping.
+- The capacity-aware partitioner enforces the memory budget, potentially overriding assignments that would exceed the GPU memory limit.
+
+This combination gives you fine-grained control: use annotations to express logical model structure, and let the memory budget act as a safety net.
+
+```python
+opts = ort.SessionOptions()
+
+opts.add_session_config_entry(
+    "session.layer_assignment_settings",
+    "gpu(encoder, decoder); cpu(=postprocess)"
+)
+
+opts.add_session_config_entry(
+    "session.resource_cuda_partitioning_settings",
+    "4194304,node_memory_stats.csv"
+)
+
+session = ort.InferenceSession("model_annotated.onnx", opts,
+                               providers=["CUDAExecutionProvider", "CPUExecutionProvider"])
+```

--- a/docs/cuda_plugin_ep/arena_allocator_migration_design.md
+++ b/docs/cuda_plugin_ep/arena_allocator_migration_design.md
@@ -1,0 +1,757 @@
+# CUDA Plugin EP — Arena Allocator Integration Design
+
+## 1. Problem Statement
+
+The CUDA plugin EP currently uses raw `cudaMalloc`/`cudaFree` through `CudaDeviceAllocator` (an `OrtAllocator*` wrapper). The in-tree (bridge-based) CUDA EP wraps its allocators in arenas by default:
+
+| Allocator | In-Tree CUDA EP | Plugin CUDA EP (today) |
+|-----------|----------------|----------------------|
+| GPU device | `CUDAAllocator` → arena (stream-aware) | `CudaDeviceAllocator` → raw `cudaMalloc`/`cudaFree` |
+| GPU device (mempool) | `CudaMempoolArena` (native CUDA mempool) | Not available |
+| Pinned (host) | `CUDAPinnedAllocator` → arena (non-stream-aware) | `CudaPinnedAllocator` → raw `cudaHostAlloc`/`cudaFreeHost` |
+
+This gap means the plugin EP has significantly worse allocation performance for typical workloads.
+
+---
+
+## 2. Reference Implementation: Example Plugin EP Arena
+
+The ORT test suite contains a complete reference implementation of a plugin-hosted arena in `onnxruntime/test/autoep/library/example_plugin_ep/`:
+
+| File | Purpose |
+|------|---------|
+| `ep_arena.h` | `ArenaConfig`, `ArenaImpl` (arena allocator — ~632 lines), `ArenaAllocator` (OrtAllocator wrapper) |
+| `ep_arena.cc` | `ArenaImpl` implementation: bins, chunks, region management, stream-aware allocation |
+| `ep_allocator.h` | `BaseAllocator` (virtual dtor for `OrtAllocator`), `CustomAllocator` (raw malloc/free device allocator), `AllocatorStats` |
+| `ep_factory.cc` | `CreateAllocatorImpl` — creates shared `ArenaAllocator` wrapping `CustomAllocator`; ref-counted lifecycle |
+| `ep_stream_support.cc` | `StreamImpl::OnSessionRunEndImpl` — calls `arena->ResetChunksUsingStream()` |
+
+### 2.1 Key Design Patterns
+
+**Arena lives inside the plugin.** The arena implementation is self-contained in the plugin library. ORT core sees only an `OrtAllocator*` with `OrtDeviceAllocator` type — it is unaware that the allocator internally manages an arena. This is the intended plugin EP architecture: the EP library owns its allocation strategy.
+
+**Factory creates a shared arena.** `ExampleEpFactory::CreateAllocatorImpl` creates one `ArenaAllocator` instance on first call and returns the same pointer on subsequent calls, with reference counting:
+
+```cpp
+// ep_factory.cc — CreateAllocatorImpl (simplified)
+if (!factory.arena_allocator_) {
+  AllocatorUniquePtr ep_allocator = std::make_unique<CustomAllocator>(memory_info, factory);
+  factory.arena_allocator_using_default_settings_ = allocator_options == nullptr;
+  ArenaAllocator::CreateOrtArenaAllocator(std::move(ep_allocator), allocator_options,
+                                          factory.ort_api, factory.default_logger_,
+                                          factory.arena_allocator_);
+} else {
+  if (factory.arena_allocator_using_default_settings_ && allocator_options) {
+    // arena settings may have changed — EP decides how to handle
+  }
+}
+++factory.num_arena_users_;
+*allocator = factory.arena_allocator_.get();
+```
+
+**Arena config via `OrtKeyValuePairs`.** `ArenaConfig::FromKeyValuePairs()` parses standard `arena.*` keys:
+
+| Key | Type | Default |
+|-----|------|---------|
+| `arena.extend_strategy` | `"0"` (power of two) or `"1"` (same as requested) | `kNextPowerOfTwo` |
+| `arena.initial_chunk_size_bytes` | int | 1 MB |
+| `arena.max_dead_bytes_per_chunk` | int | 128 MB |
+| `arena.initial_growth_chunk_size_bytes` | int | 2 MB |
+| `arena.max_power_of_two_extend_bytes` | int64 | 1 GB |
+| `arena.max_mem` | size_t | `SIZE_MAX` |
+
+**Stream-aware allocation.** `ArenaImpl::AllocOnStream(size, stream)` tracks which chunks are assigned to which stream. `ResetChunksUsingStream(stream_impl)` is called from `OrtSyncStreamImpl::OnSessionRunEnd` to release chunk-to-stream assignments when a session run completes.
+
+**Read-only allocator bypasses arena.** The factory creates a plain `CustomAllocator` (no arena) for `OrtReadOnlyAllocator` (initializers), since initializer memory doesn't benefit from arena allocation.
+
+### 2.2 How ORT Core Calls the Factory
+
+**Path 1: Shared allocators (environment level)**
+```
+RegisterExecutionProviderLibrary()
+  → CreateSharedAllocatorImpl(ep_device, memory_info, OrtDeviceAllocator, nullptr, ...)
+    → ep_factory->CreateAllocator(factory, &mem_info, /*options=*/ nullptr, &alloc)
+      → [factory creates ArenaAllocator wrapping raw allocator]
+    → if alloc->version >= 25 && alloc->Shrink != nullptr:
+        IArenaImplWrappingOrtAllocator(alloc)   // wraps as IArena (see Section 5.4)
+      else:
+        IAllocatorImplWrappingOrtAllocator(alloc)
+    → shared_allocators_.push_back(wrapped)
+```
+
+**Path 2: Per-session allocators**
+```
+SessionState constructor
+  → ep->CreatePreferredAllocators()
+    → PluginExecutionProvider::CreatePreferredAllocators()
+      → OrtEp::CreateAllocator(ep, &mem_info, &alloc)   [if set]
+        OR ep_factory.CreateAllocator(&factory, &mem_info, /*options=*/ nullptr, &alloc)
+        → [factory returns same shared ArenaAllocator]
+      → if alloc->Shrink != nullptr:
+          IArenaImplWrappingOrtAllocator(alloc)
+        else:
+          IAllocatorImplWrappingOrtAllocator(alloc)
+    → session allocator maps
+```
+
+**Path 3: User-created allocators (public API)**
+```
+OrtApi::CreateSharedAllocator(env, ep_device, mem_type, alloc_type, allocator_options, &alloc)
+  → Environment::CreateSharedAllocator()
+    → CreateSharedAllocatorImpl(ep_device, mem_info, alloc_type, allocator_options, &alloc, replace=true)
+      → ep_factory->CreateAllocator(factory, &mem_info, allocator_options, &alloc)
+        → [factory creates ArenaAllocator with user-provided config]
+```
+
+**Key point:** `CreateSharedAllocatorImpl` explicitly rejects `OrtArenaAllocator` type from plugin factories and verifies the returned allocator doesn't use it either. The arena is opaque — ORT core sees `OrtDeviceAllocator`.
+
+---
+
+## 3. Applying the Pattern to CUDA Plugin EP
+
+The CUDA plugin EP should follow the example plugin's architecture: **the arena lives inside the plugin library**. The previous design explored ORT-core-wrapping approaches (wrapping plugin allocators in ORT's internal arena). The example plugin EP demonstrates the intended approach: the EP library includes its own arena and wraps its raw allocators (both device and pinned) internally.
+
+### 3.1 What Needs to Change in the CUDA Plugin Factory
+
+`CudaEpFactory::CreateAllocatorImpl` currently creates raw `CudaDeviceAllocator` or `CudaPinnedAllocator` and returns them directly. The change:
+
+```cpp
+// Current (cuda_ep_factory.cc — CreateAllocatorImpl):
+if (strcmp(name, "Cuda") == 0) {
+  auto cuda_allocator = std::make_unique<CudaDeviceAllocator>(memory_info, req_device_id);
+  *allocator = cuda_allocator.release();  // raw cudaMalloc/cudaFree
+}
+
+// Target: wrap in CudaArenaAllocator, following the example plugin pattern.
+// NOTE: The factory must maintain a separate arena per device_id, since each GPU
+// has its own memory space. The factory already has a device_cache_ mapping
+// HardwareDeviceKey → DeviceCacheEntry; the arena is stored there. Because
+// CreateAllocatorImpl only knows the CUDA ordinal (from OrtMemoryInfoGetId),
+// the factory must also maintain an efficient ordinal → DeviceCacheEntry mapping
+// (e.g., a std::unordered_map<int, HardwareDeviceKey> built during
+// GetSupportedDevicesImpl when device_cache_ is populated).
+if (strcmp(name, "Cuda") == 0) {
+  auto& entry = factory.GetDeviceCacheEntryForOrdinal(req_device_id);
+  std::lock_guard<std::mutex> lock{entry.arena_mutex};
+
+  if (/* use_cuda_mempool option */) {
+    // CudaMempoolArena path — see Section 4
+  } else if (!entry.device_arena) {
+    // Arena path — first call for this device:
+    AllocatorUniquePtr raw_allocator(
+        new CudaDeviceAllocator(memory_info, req_device_id),
+        [](OrtAllocator* p) { delete static_cast<CudaDeviceAllocator*>(p); });
+    entry.device_arena_using_defaults = (allocator_options == nullptr);
+    CudaArenaAllocator::Create(CudaAllocatorKind::kDevice, memory_info,
+                               std::move(raw_allocator), allocator_options,
+                               factory.ort_api_, factory.default_logger_,
+                               entry.device_arena);
+  }
+  ++entry.num_device_arena_users;
+  *allocator = entry.device_arena.get();
+}
+
+if (strcmp(name, "CudaPinned") == 0) {
+  // Pinned memory is CPU-side and technically shared, but each device's pinned
+  // allocator has a distinct OrtMemoryInfo (device_id). Keep per-device.
+  auto& entry = factory.GetDeviceCacheEntryForOrdinal(req_device_id);
+  std::lock_guard<std::mutex> lock{entry.arena_mutex};
+
+  if (!entry.pinned_arena) {
+    AllocatorUniquePtr raw_allocator(
+        new CudaPinnedAllocator(memory_info),
+        [](OrtAllocator* p) { delete static_cast<CudaPinnedAllocator*>(p); });
+    CudaArenaAllocator::Create(CudaAllocatorKind::kPinned, memory_info,
+                               std::move(raw_allocator), allocator_options,
+                               factory.ort_api_, factory.default_logger_,
+                               entry.pinned_arena);
+  }
+  ++entry.num_pinned_arena_users;
+  *allocator = entry.pinned_arena.get();
+}
+```
+
+### 3.2 Adapting the Arena Code for CUDA
+
+The `ep_arena.h`/`ep_arena.cc` from the example plugin are designed to be copied and adapted. For the CUDA plugin EP, the raw allocator (`CustomAllocator` in the example) is replaced with `CudaDeviceAllocator` (for GPU) or `CudaPinnedAllocator` (for pinned).
+
+#### Arena wrapper: `CudaArenaAllocator : CudaAllocatorBase`
+
+The example plugin defines `ArenaAllocator : BaseAllocator`, where `BaseAllocator` adds a virtual destructor to `OrtAllocator` so that `std::unique_ptr<BaseAllocator>` can delete derived types. We do **not** introduce `BaseAllocator` into the CUDA plugin. Instead, `CudaArenaAllocator` inherits from the existing `CudaAllocatorBase`:
+
+```cpp
+// In cuda_arena.h:
+class CudaArenaAllocator final : public CudaAllocatorBase {
+ public:
+  static OrtStatus* Create(CudaAllocatorKind kind,
+                           const OrtMemoryInfo* memory_info,
+                           AllocatorUniquePtr raw_allocator,
+                           const OrtKeyValuePairs* options,
+                           const OrtApi& api,
+                           const OrtLogger& logger,
+                           std::unique_ptr<CudaArenaAllocator>& out);
+
+  CudaArenaAllocator(CudaAllocatorKind kind, const OrtMemoryInfo* memory_info,
+                     std::unique_ptr<ArenaImpl> impl)
+      : CudaAllocatorBase(kind, memory_info), impl_(std::move(impl)) {
+    version = ORT_API_VERSION;
+    Alloc = AllocImpl;
+    Reserve = ReserveImpl;
+    Free = FreeImpl;
+    Info = InfoImpl;
+    GetStats = GetStatsImpl;
+    // Stream-aware only for device arena, not pinned
+    AllocOnStream = (kind == CudaAllocatorKind::kDevice) ? AllocOnStreamImpl : nullptr;
+  }
+
+  OrtStatus* ResetChunksUsingStream(const OrtSyncStreamImpl* stream_impl) {
+    impl_->ResetChunksUsingStream(stream_impl);
+    return nullptr;
+  }
+
+ private:
+  static void* ORT_API_CALL AllocImpl(OrtAllocator* this_, size_t size);
+  static void* ORT_API_CALL AllocOnStreamImpl(OrtAllocator* this_, size_t size, OrtSyncStream* stream);
+  static void* ORT_API_CALL ReserveImpl(OrtAllocator* this_, size_t size);
+  static void ORT_API_CALL FreeImpl(OrtAllocator* this_, void* p);
+  static const OrtMemoryInfo* ORT_API_CALL InfoImpl(const OrtAllocator* this_);
+  static OrtStatus* ORT_API_CALL GetStatsImpl(const OrtAllocator* this_, OrtKeyValuePairs** out) noexcept;
+
+  std::unique_ptr<ArenaImpl> impl_;
+};
+```
+
+**Why this works.** `CudaAllocatorBase` is intentionally defined as a standard-layout type with the `OrtAllocator` base subobject at offset 0; it only adds plain data members (`kind_`, `memory_info_`) after the `OrtAllocator` C struct layout. Under this constraint, `OrtAllocator*` and `CudaAllocatorBase*` (and further-derived pointers) all share the same address. In production code this should be enforced with `static_assert(std::is_standard_layout_v<CudaAllocatorBase>)`, and pointer comparisons should use `static_cast<OrtAllocator*>(entry.device_arena.get())` rather than relying on implicit same-address assumptions. This means:
+
+- **`ReleaseAllocatorImpl`** can safely `static_cast<CudaAllocatorBase*>(allocator)` on arena pointers — `GetKind()` returns `kDevice` or `kPinned` correctly.
+- **`AllocOnStream`** is set to `nullptr` for pinned arenas at construction time; ORT's `AllocateBufferWithOptions` falls through to plain `Alloc()` when `AllocOnStream` is null.
+- **No ABI impact (by construction)** — given the standard-layout/offset-0 requirement, the object layout is compatible across `CudaAllocatorBase` subclasses (`CudaDeviceAllocator`, `CudaPinnedAllocator`, `CudaArenaAllocator`) for the `OrtAllocator` portion.
+
+#### Raw allocator ownership inside `ArenaImpl`
+
+`ArenaImpl` stores and owns the raw allocator (e.g. `CudaDeviceAllocator`). It interacts with it exclusively through the C-level `OrtAllocator` function pointers (`Alloc`, `Free`, `Info`). Since `CudaAllocatorBase` has no virtual destructor, `ArenaImpl` uses a type-erasing deleter:
+
+```cpp
+// In cuda_arena.h:
+using AllocatorUniquePtr = std::unique_ptr<OrtAllocator, std::function<void(OrtAllocator*)>>;
+```
+
+The factory creates the raw allocator with a deleter that knows the concrete type:
+
+```cpp
+AllocatorUniquePtr raw(
+    new CudaDeviceAllocator(memory_info, device_id),
+    [](OrtAllocator* p) { delete static_cast<CudaDeviceAllocator*>(p); });
+```
+
+This is safe because the arena code (`ArenaImpl`) only calls through the C function pointers and never casts the stored allocator to a C++ type.
+
+#### Class hierarchy
+
+All CUDA plugin allocators inherit from `CudaAllocatorBase`, keeping a uniform object layout and enabling `ReleaseAllocatorImpl` to use `GetKind()` on any plugin-created allocator:
+
+```
+OrtAllocator (C struct)
+  └─ CudaAllocatorBase (adds kind_, memory_info_ — no virtual functions)
+       ├─ CudaDeviceAllocator     (raw cudaMalloc/cudaFree)
+       ├─ CudaPinnedAllocator     (raw cudaHostAlloc/cudaFreeHost)
+       ├─ CudaArenaAllocator      (BFC arena wrapping a raw allocator via ArenaImpl)
+       └─ CudaMempoolOrtAllocator (CUDA native mempool — see Section 4.4)
+```
+
+### 3.3 Shared Arena Lifecycle and Reference Counting
+
+**Multi-GPU consideration.** A system may have multiple CUDA devices. Each GPU has its own device memory, so each needs its own arena. The CUDA plugin factory already maintains a per-device cache (`device_cache_`) mapping `HardwareDeviceKey → DeviceCacheEntry` that stores `OrtMemoryInfo` instances per GPU. The arena pointers and ref counts are added to this existing cache structure.
+
+**Per-device key correctness.** `HardwareDeviceKey` is `{type, vendor_id, device_id, cuda_ordinal}`. The `device_id` field is the PCI Device ID — it identifies the hardware *model* (e.g. 0x2684 for all RTX 4090s), **not** an individual physical device. On a host with two identical GPUs, `{type, vendor_id, device_id}` alone would produce the same key for both, causing them to share a single `DeviceCacheEntry` and a single arena — allocating memory on only one GPU. Including `cuda_ordinal` (assigned sequentially by the factory during `GetSupportedDevicesImpl`) ensures each physical GPU gets its own cache entry, arena, and `OrtMemoryInfo`.
+
+```cpp
+// Existing structure in cuda_ep_factory.h — extended with arena members:
+struct DeviceCacheEntry {
+  int cuda_device_id{-1};
+  Ort::MemoryInfo device_memory_info{nullptr};      // GPU device memory
+  Ort::MemoryInfo pinned_memory_info{nullptr};      // CPU pinned memory for this GPU
+
+  // Arena members (new):
+  std::mutex arena_mutex;
+  std::unique_ptr<CudaArenaAllocator> device_arena;
+  std::unique_ptr<CudaArenaAllocator> pinned_arena;
+  std::unique_ptr<CudaMempoolOrtAllocator> mempool_allocator;  // alternative to device_arena (Section 4)
+  int num_device_arena_users = 0;
+  int num_pinned_arena_users = 0;
+  int num_mempool_users = 0;
+  bool device_arena_using_defaults = true;
+};
+```
+
+The factory's `device_cache_` is populated during `GetSupportedDevicesImpl` (one entry per GPU discovered). `CreateAllocatorImpl` extracts the `device_id` from the incoming `OrtMemoryInfo`, locates the corresponding `DeviceCacheEntry`, and creates/returns the arena for that device. Each GPU gets independent arena instances with independent lifecycle.
+
+`CreateAllocatorImpl` creates the arena on first call for a given device and increments its ref count. `ReleaseAllocatorImpl` decrements; when zero, the arena is destroyed:
+
+```cpp
+// cuda_ep_factory.cc — ReleaseAllocatorImpl:
+/*static*/
+void ORT_API_CALL CudaEpFactory::ReleaseAllocatorImpl(
+    OrtEpFactory* this_ptr, OrtAllocator* allocator) noexcept {
+  if (!allocator) return;
+  auto* factory = static_cast<CudaEpFactory*>(this_ptr);
+
+  // Check if allocator is a shared arena or mempool (pointer identity match).
+  for (auto& [key, entry] : factory->device_cache_) {
+    std::lock_guard<std::mutex> lock{entry.arena_mutex};
+    if (allocator == entry.device_arena.get()) {
+      if (--entry.num_device_arena_users == 0) entry.device_arena.reset();
+      return;
+    }
+    if (allocator == entry.pinned_arena.get()) {
+      if (--entry.num_pinned_arena_users == 0) entry.pinned_arena.reset();
+      return;
+    }
+    if (allocator == entry.mempool_allocator.get()) {
+      if (--entry.num_mempool_users == 0) entry.mempool_allocator.reset();
+      return;
+    }
+  }
+
+  // Fallback: raw allocator not managed by arena/mempool (e.g. read-only allocator).
+  // CudaAllocatorBase cast is safe — all CUDA plugin allocators inherit from it.
+  auto* typed = static_cast<CudaAllocatorBase*>(allocator);
+  switch (typed->GetKind()) {
+    case CudaAllocatorKind::kDevice:
+      delete static_cast<CudaDeviceAllocator*>(allocator);
+      return;
+    case CudaAllocatorKind::kPinned:
+      delete static_cast<CudaPinnedAllocator*>(allocator);
+      return;
+    default:
+      assert(false && "Unknown CudaAllocatorKind");
+      return;
+  }
+}
+```
+
+This handles:
+- **Shared allocators** — `RegisterExecutionProviderLibrary` iterates over each `OrtEpDevice` and calls `CreateAllocator` for each device's memory infos. Each device gets its own shared arena.
+- **Per-session allocators** — each session calls `CreateAllocator` (returning the same shared arena for the device) and `ReleaseAllocator` on session teardown.
+
+The `OrtApi::CreateSharedAllocator` public API also flows through `CreateAllocatorImpl` with `replace_existing=true`. When replacing, `ReleaseAllocator` is called on the old allocator first (dropping that device's arena if ref count hits zero), then `CreateAllocator` is called again with the new options — potentially creating a new arena with different config for that specific device.
+
+**Note:** The example plugin EP uses single `arena_allocator_` / `num_arena_users_` members because it only registers for one device (`device_id=0`). The CUDA plugin must generalize this to per-device storage.
+
+### 3.4 Stream Integration
+
+The CUDA plugin's `CudaSyncStream` (from `OrtSyncStreamImpl`) must call `ResetChunksUsingStream` on the device arena at session run end, following the example. Since there may be multiple GPUs, the stream must know which device's arena to reset. Each stream is created for a specific `OrtMemoryDevice`, which has a device_id — this maps to the corresponding `DeviceCacheEntry`:
+
+```cpp
+// cuda_stream_plugin.cc — OnSessionRunEndImpl:
+OrtStatus* ORT_API_CALL CudaSyncStream::OnSessionRunEndImpl(OrtSyncStreamImpl* this_ptr) noexcept {
+  auto& impl = *static_cast<CudaSyncStream*>(this_ptr);
+  // impl.device_id_ was set at stream creation from the OrtMemoryDevice
+  auto* arena = impl.factory_->GetDeviceArenaAllocator(impl.device_id_);
+  if (arena) {
+    arena->ResetChunksUsingStream(this_ptr);
+  }
+  return nullptr;
+}
+```
+
+`GetDeviceArenaAllocator(device_id)` looks up the `DeviceCacheEntry` for the given device and returns its `device_arena.get()`.
+
+The pinned allocator is also wrapped in `CudaArenaAllocator` but must **not** be stream-aware, matching the in-tree EP where pinned uses plain `BFCArena` (not `StreamAwareBFCArena`). `CudaArenaAllocator`'s constructor handles this: it sets `AllocOnStream = nullptr` when `kind == CudaAllocatorKind::kPinned` (see Section 3.2). ORT's `AllocateBufferWithOptions` checks for a non-null `AllocOnStream` before calling it, so the pinned arena transparently falls through to plain `Alloc()`. Accordingly, `ResetChunksUsingStream` is not called for the pinned arena at session run end.
+
+### 3.5 Arena Config Flow
+
+**Shared allocators (environment level):**
+
+`RegisterExecutionProviderLibrary` calls `CreateSharedAllocatorImpl` with `allocator_options = nullptr`. This means the factory's first arena creation uses default `ArenaConfig` values. This is acceptable:
+- The defaults (1 MB initial chunk, 128 MB max dead, kNextPowerOfTwo growth) are reasonable.
+- If the user configures arena options via `OrtApi::CreateSharedAllocator` later, the old allocator is released and a new one is created with the provided options (because `replace_existing=true`).
+
+**Per-session allocators:**
+
+`PluginExecutionProvider::CreatePreferredAllocators()` calls `ep_factory_.CreateAllocator()` for each memory info registered by the EP's devices. Today this passes `allocator_options = nullptr`, which means the factory always creates arenas with default config.
+
+**Session-level plumbing (new).** To support session-level arena config (e.g. `ep.cudapluginexecutionprovider.arena.max_mem`), `PluginExecutionProvider` needs to:
+
+1. **Extract arena options at construction time (gated).** The constructor already receives `const OrtSessionOptions& session_options`. The extraction is gated on `ep_factory_.CreateAllocator != nullptr` — only factory-based allocator creation accepts `allocator_options`, so the scan is skipped entirely for plugin EPs that don't implement factory-level allocator creation (the `OrtEp::CreateAllocator` path has no options parameter). When gated in, the constructor constructs the EP-specific prefix via `OrtSessionOptions::GetProviderOptionPrefix(ep->GetName(ep.get()))` (which lowercases the EP name), appends `"arena."`, and scans `session_options.value.config_options` for matching keys. Matching keys are stored with the EP prefix stripped (bare `"arena.*"` keys) in a `std::optional<OrtKeyValuePairs>` member (`session_arena_options_`). The EP-name prefix ensures that only keys intended for this specific EP are extracted — e.g. `ep.cudapluginexecutionprovider.arena.*` keys will never match a session for a different plugin EP.
+
+2. **Pass options in `CreatePreferredAllocators`.** If `session_arena_options_` has a value, pass it as `allocator_options` to `ep_factory_.CreateAllocator()`. Otherwise pass `nullptr` (preserving existing behavior for EPs that don't use arena keys).
+
+This means:
+- The factory's first `CreateAllocator` call (from `RegisterExecutionProviderLibrary` → shared allocators) uses env-level arena config (or defaults if none).
+- Subsequent calls from `CreatePreferredAllocators` pass session-level arena config. If the factory already holds a shared arena for that device (from the env-level path) and the incoming session options differ, the factory decides how to handle it — typically logging a warning and keeping the existing arena (since it's shared). If no shared arena exists yet (e.g. `use_env_allocators=0`), the factory creates a new arena with the session-provided config.
+- The `OrtApi::CreateSharedAllocator` public API also flows through `CreateAllocatorImpl` with `replace_existing=true`, allowing users to replace an existing arena with a new config at any time.
+
+```
+Session-level flow:
+SessionOptionsAppendExecutionProvider_V2(session, ep_devices, keys[], values[])
+  → keys stored in session_options.config_options as "ep.cudapluginexecutionprovider.arena.*"
+  → PluginExecutionProvider constructor extracts "arena.*" keys
+  → CreatePreferredAllocators() builds OrtKeyValuePairs and passes to CreateAllocator()
+  → factory creates/reuses arena with provided config
+```
+
+**ORT core change required:** `PluginExecutionProvider` constructor and `CreatePreferredAllocators()` in `ep_plugin_provider_interfaces.cc/.h` (see Section 5.3).
+
+**User-provided config via `CreateEnvWithOptions`:**
+
+Environment-level config can be passed via `OrtEnvCreationOptions::config_entries`:
+
+```cpp
+api->AddKeyValuePair(kvps, "ep_factory.CudaPluginExecutionProvider.arena.extend_strategy", "1");
+api->AddKeyValuePair(kvps, "ep_factory.CudaPluginExecutionProvider.arena.max_mem", "4294967296");
+
+OrtEnvCreationOptions options{};
+options.config_entries = kvps;
+api->CreateEnvWithOptions(&options, &env);
+```
+
+**Current gap:** `RegisterExecutionProviderLibrary` does not extract env config entries and pass them as `allocator_options` to `CreateSharedAllocatorImpl`. To support env-level arena config, this needs to be plumbed:
+
+1. `RegisterExecutionProviderLibrary` constructs a prefix via `"ep_factory." + std::string(factory->GetName ? factory->GetName(factory) : "") + "."` (case-sensitive, using `GetName` as-is — see Section 3.6). Note: `GetName` is a C function pointer on `OrtEpFactory`, invoked as `factory->GetName(factory)`. Implementations must handle `GetName == nullptr` or a `nullptr` return defensively. The prefix is then used to obtain a snapshot of the environment config entries via `Environment::GetConfigEntries()` (which acquires `config_entries_mutex_` under a shared lock)
+2. Scans the snapshot for keys matching the prefix, strips the prefix, and builds `OrtKeyValuePairs` with bare `arena.*` keys
+3. Passes to `CreateSharedAllocatorImpl` as `allocator_options`
+4. `CreateSharedAllocatorImpl` forwards to `ep_factory->CreateAllocator`
+
+**Concurrency note:** `config_entries_` is guarded by `config_entries_mutex_` (a `std::shared_mutex`). `RegisterExecutionProviderLibrary` does not hold any lock itself. Implementations must use `GetConfigEntries()` (which takes a shared lock and returns a copy) rather than iterating `config_entries_` directly.
+
+This is a small ORT core change that enables the existing config mechanism to reach the plugin's arena.
+
+### 3.6 Environment vs. Session Config
+
+ORT has two separate configuration namespaces for EP-specific options.
+
+#### Current state
+
+| | Environment-level | Session-level |
+|---|---|---|
+| **Prefix pattern** | `ep_factory.<ep_name>.` | `ep.<ep_name>.` |
+| **Who constructs the prefix?** | No one — convention from C API doc comments only | ORT core (`GetProviderOptionPrefix`) |
+| **Lowercasing applied?** | **Not defined** — ORT never constructs or parses this prefix today | **Yes** — `GetLowercaseString(GetName())` |
+| **Backing store** | `std::map<string,string>` (case-sensitive) | `std::unordered_map<string,string>` (case-sensitive) |
+| **Set via** | `CreateEnvWithOptions` (`OrtEnvCreationOptions.config_entries`) | `SessionOptionsAppendExecutionProvider_V2` |
+| **CUDA plugin `GetName()`** | `"CudaPluginExecutionProvider"` | `"CudaPluginExecutionProvider"` |
+
+The C API documentation (`onnxruntime_c_api.h`) describes the environment-level prefix as `ep_factory.<ep_name>.` where `<ep_name>` is the factory's own name (from `OrtEpFactory::GetName()`), **not** the user-provided registration name passed to `RegisterExecutionProviderLibrary`. However, ORT core does not currently construct, parse, or normalize this prefix — it is purely a documentation convention. The design (Section 3.5 / 5.3) proposes new code in `RegisterExecutionProviderLibrary` that would extract these keys for the first time, which requires deciding on a casing convention.
+
+The session-level prefix is always lowercased by ORT via `GetLowercaseString`:
+
+```cpp
+// abi_session_options.cc — GetProviderOptionPrefix
+std::string key_prefix = "ep.";
+key_prefix += onnxruntime::utils::GetLowercaseString(provider_name);
+key_prefix += ".";
+```
+
+Both backing stores (`std::map` and `std::unordered_map`) use exact string comparison — key lookup is case-sensitive.
+
+#### Casing convention for `ep_factory.` prefix
+
+Since new code must be written to extract `ep_factory.` keys, we must decide how the `<ep_name>` portion is matched:
+
+| Option | Env-level example key | Pros | Cons |
+|--------|----------------------|------|------|
+| **(A) Use `GetName()` as-is** | `ep_factory.CudaPluginExecutionProvider.arena.*` | Exact match to factory identity; unambiguous | Inconsistent with session-level (lowercase); users must get casing exactly right; error-prone |
+| **(B) Lowercase like session-level** | `ep_factory.cudapluginexecutionprovider.arena.*` | Consistent with `ep.cudapluginexecutionprovider.*`; users see one pattern | Diverges from C API doc comment which doesn't specify lowercasing; slight surprise if user reads `GetName()` |
+| **(C) Case-insensitive matching** | Either casing works | Most forgiving for users | Requires scanning all map entries (can't use `std::map::find`); unusual; extra code |
+
+**Recommendation: Option A** — use `GetName()` as-is, respecting the C API specification which is case-sensitive. The `ep_factory.<ep_name>.` prefix uses the factory's own name verbatim:
+
+```
+Environment: ep_factory.CudaPluginExecutionProvider.arena.extend_strategy
+Session:     ep.cudapluginexecutionprovider.arena.extend_strategy
+```
+
+The new code in `RegisterExecutionProviderLibrary` constructs the prefix as:
+
+```cpp
+// Note: GetName is a function pointer on the C struct OrtEpFactory.
+// Must be called as factory->GetName(factory) and null-checked.
+const char* ep_name = (factory->GetName) ? factory->GetName(factory) : nullptr;
+std::string prefix = "ep_factory." + std::string(ep_name ? ep_name : "") + ".";
+```
+
+The session-level prefix continues to use `GetLowercaseString` independently. While the two prefixes use different casing conventions, the `ep_factory.` prefix is specified by the C API documentation as `<ep_name>` (the factory's identity), and the backing store (`std::map`) is case-sensitive. Introducing lowercasing here would diverge from the documented contract.
+
+#### Conflict between namespaces
+
+The EP factory may receive arena config from two sources: environment-level keys (via `RegisterExecutionProviderLibrary`) and session-level keys (via `PluginExecutionProvider::CreatePreferredAllocators`). The factory is unaware of conflicts between these two namespaces. This is acceptable because:
+- Shared allocators are created first (environment level) — only env config applies at that point.
+- Per-session `CreatePreferredAllocators` calls arrive later with session-level config. Since the factory typically holds a shared arena already, session options are only effective if: (a) no shared arena exists yet, or (b) the user explicitly calls `OrtApi::CreateSharedAllocator` with `replace_existing=true`.
+- When per-session config differs from the shared arena's config, the factory logs a warning but keeps the existing arena (it's shared across sessions and cannot be reconfigured mid-flight).
+- The two config paths serve different lifecycle scopes and are independent.
+
+**Runtime validation (recommended):** When `CreateAllocatorImpl` receives `allocator_options` and the factory already holds a shared arena for that device, log a warning if the incoming keys differ from the keys used at first creation. This makes misconfiguration visible without silently ignoring the second set of options.
+
+---
+
+## 4. Migrating `CudaMempoolArena` to the Plugin
+
+### 4.1 Overview
+
+`CudaMempoolArena` is CUDA's native memory pool (`cudaMallocFromPoolAsync`/`cudaFreeAsync`). It is an alternative to the plugin's arena for GPU device memory — mutually exclusive, selected by config. It is self-contained (CUDA SDK only) and already stream-aware.
+
+### 4.2 Current Dependencies
+
+| Dependency | Plugin-Safe? | Notes |
+|-----------|-------------|-------|
+| `<cuda_runtime_api.h>` | ✅ | CUDA SDK — always available |
+| `core/common/common.h` | ✅ | `ORT_THROW`, `ORT_ENFORCE` — no framework deps |
+| `core/providers/cuda/cuda_stream_handle.h` | ❌ | Pulls in in-tree framework types (`OrtDevice`, `Stream` base class); plugin CMake excludes its `.cc`. Use `OrtApi::SyncStream_GetHandle` on `OrtSyncStream*` to obtain `cudaStream_t` instead |
+| `core/providers/cuda/shared_inc/cuda_call.h` | ✅ | CUDA error-handling macros |
+| `core/providers/shared_library/provider_api.h` | ❌ | Provider-bridge header defining `logging::Logger` forward decl used by `CudaMempoolArena`; must be removed/guarded in plugin build |
+| `logging::Logger*` | ❌ | **Primary blocker** — provider-bridge logger type (from `provider_api.h`), not available in plugin build |
+
+### 4.3 Logger Adaptation
+
+Replace `const logging::Logger* logger_` with a build-conditional type using `#ifdef BUILD_CUDA_EP_AS_PLUGIN`. This follows the established pattern already used across 20+ CUDA provider files (`cuda_common.h`, `cuda_kernel.h`, `cudnn_common.h`, `space_depth_ops.h`, `identity_op.cc`, `pad.cc`, `scatter_nd.cc`, etc.) where shared headers use `#ifdef BUILD_CUDA_EP_AS_PLUGIN` to adapt between in-tree and plugin builds:
+
+```cpp
+#ifdef BUILD_CUDA_EP_AS_PLUGIN
+  const OrtApi& ort_api_;                  // stored reference to OrtApi (set at construction)
+  const OrtLogger* logger_;                // plugin: OrtLogger from EP C API
+  // Logger_LogMessage returns OrtStatus* which must be released if non-null.
+  #define MEMPOOL_LOG(ort_api_ref, logger, level, msg) do {          \
+    OrtStatus* _s = (ort_api_ref).Logger_LogMessage(                 \
+        (logger), ORT_LOGGING_LEVEL_##level,                         \
+        (msg).c_str(), ORT_FILE, __LINE__, __FUNCTION__);            \
+    if (_s) (ort_api_ref).ReleaseStatus(_s);                         \
+  } while (0)
+#else
+  const logging::Logger* logger_;          // in-tree: ORT internal logger
+  #define MEMPOOL_LOG(ort_api_ref, logger, level, msg) LOGS(*logger, level) << msg
+#endif
+```
+
+The plugin build stores a `const OrtApi&` reference (passed at construction from the factory) so the macro can call `Logger_LogMessage`. The returned `OrtStatus*` is released if non-null — logging failures are not propagated.
+
+**Decision:** Use the `#ifdef` macro approach (not a virtual `ICudaMempoolLogger` interface) for consistency with the existing codebase convention.
+
+### 4.4 OrtAllocator Wrapper
+
+The factory returns `CudaMempoolArena` wrapped behind `OrtAllocator*`, inheriting from `CudaAllocatorBase` — consistent with all other CUDA plugin allocators (see Section 3.2 class hierarchy). This keeps `ReleaseAllocatorImpl`'s `GetKind()` dispatch and pointer-identity match working for mempool allocators:
+
+```cpp
+class CudaMempoolOrtAllocator final : public CudaAllocatorBase {
+ public:
+  static OrtStatus* Create(const OrtMemoryInfo* memory_info,
+                           const OrtKeyValuePairs* options,
+                           const OrtApi& api,
+                           const OrtLogger& logger,
+                           std::unique_ptr<CudaMempoolOrtAllocator>& out);
+
+  CudaMempoolOrtAllocator(const OrtMemoryInfo* memory_info, /* ... */)
+      : CudaAllocatorBase(CudaAllocatorKind::kDevice, memory_info) {
+    version = ORT_API_VERSION;
+    Alloc = AllocImpl;
+    AllocOnStream = AllocOnStreamImpl;  // mempool is stream-aware
+    Free = FreeImpl;
+    Reserve = ReserveImpl;
+    Info = InfoImpl;
+    GetStats = GetStatsImpl;
+  }
+
+ private:
+  // OrtAllocator callbacks — delegate to CudaMempoolArena
+  static void* ORT_API_CALL AllocImpl(OrtAllocator* this_, size_t size);
+  static void* ORT_API_CALL AllocOnStreamImpl(OrtAllocator* this_, size_t size, OrtSyncStream* stream);
+  static void ORT_API_CALL FreeImpl(OrtAllocator* this_, void* p);
+  static void* ORT_API_CALL ReserveImpl(OrtAllocator* this_, size_t size);
+  static const OrtMemoryInfo* ORT_API_CALL InfoImpl(const OrtAllocator* this_);
+  static OrtStatus* ORT_API_CALL GetStatsImpl(const OrtAllocator* this_, OrtKeyValuePairs** out) noexcept;
+
+  const OrtApi& ort_api_;                    // needed for SyncStream_GetHandle, KVP creation
+  std::unique_ptr<CudaMempoolArena> arena_;
+};
+```
+
+`AllocOnStreamImpl` resolves `OrtSyncStream*` → `cudaStream_t` via `OrtApi::SyncStream_GetHandle()`. This requires the wrapper to store a reference to `const OrtApi&` (already present via the `Create` factory method's `api` parameter). The stored `OrtApi` reference is also needed for `GetStatsImpl` (to create `OrtKeyValuePairs`) and for `Create` itself (to parse config options). The `OrtApi` pointer is available in all allocator callback contexts because it is captured in the `CudaMempoolOrtAllocator` instance that `this_` points to.
+
+**OrtMemoryInfo type:** Must be `OrtDeviceAllocator` (ORT core rejects `OrtArenaAllocator` from plugins).
+
+### 4.5 Arena Mode Selection in CreateAllocatorImpl
+
+The factory selects between the plugin's arena and CUDA mempool based on allocator options:
+
+```cpp
+OrtStatus* CudaEpFactory::CreateAllocatorImpl(OrtEpFactory* this_ptr,
+                                              const OrtMemoryInfo* memory_info,
+                                              const OrtKeyValuePairs* allocator_options,
+                                              OrtAllocator** allocator) noexcept {
+  auto& factory = *static_cast<CudaEpFactory*>(this_ptr);
+  // ...
+  if (strcmp(name, "Cuda") == 0) {
+    bool use_mempool = false;
+    if (allocator_options) {
+      const char* v = factory.ort_api_.GetKeyValue(allocator_options, "arena.use_cuda_mempool");
+      use_mempool = v && std::string(v) == "1";
+    }
+
+    if (use_mempool) {
+      auto& entry = factory.GetOrCreateDeviceCacheEntry(req_device_id);
+      std::lock_guard<std::mutex> lock{entry.arena_mutex};
+      if (!entry.mempool_allocator) {
+        CudaMempoolOrtAllocator::Create(memory_info, allocator_options,
+                                        factory.ort_api_, factory.default_logger_,
+                                        entry.mempool_allocator);
+      }
+      ++entry.num_mempool_users;
+      *allocator = entry.mempool_allocator.get();
+    } else {
+      // Arena path (Section 3.1)
+    }
+  }
+}
+```
+
+### 4.6 Config Keys for Mempool
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `arena.use_cuda_mempool` | `"0"` or `"1"` | `"0"` | Enable CUDA native mempool instead of the plugin arena |
+| `arena.cuda_mempool_release_threshold` | uint64 bytes | `0` | `cudaMemPoolAttrReleaseThreshold` value |
+| `arena.cuda_mempool_bytes_to_keep_on_shrink` | size_t bytes | `0` | Target for `cudaMemPoolTrimTo()` on `Shrink()` |
+
+---
+
+## 5. Summary of Changes
+
+### 5.1 Files Copied from Example Plugin EP
+
+The arena implementation in `onnxruntime/test/autoep/library/example_plugin_ep/` is the reference. Two files are copied into the CUDA plugin directory and adapted:
+
+| Source | Target | What to copy | Adaptations needed |
+|---|---|---|---|
+| `ep_arena.h` (~632 lines) | `plugin/cuda_arena.h` | `ArenaExtendStrategy` enum, `ArenaConfig` struct (with `FromKeyValuePairs` parser and `ConfigKeyNames`), `ArenaImpl` class (full arena implementation) | **License header:** Preserve the original Apache-2.0 TensorFlow-derived license header and attribution notices. **Namespace:** Wrap in `onnxruntime::cuda_plugin`. **Includes:** Replace `#include "ep_allocator.h"` and `#include "../plugin_ep_utils.h"` with `#include "cuda_allocator_plugin.h"` and `#include "cuda_plugin_utils.h"`. **`ArenaAllocator` → `CudaArenaAllocator`:** The example’s `ArenaAllocator : BaseAllocator` is replaced by `CudaArenaAllocator : CudaAllocatorBase` (see Section 3.2), defined in `cuda_arena.h` alongside the copied `ArenaImpl`. **`AllocatorUniquePtr`:** Redefine as `std::unique_ptr<OrtAllocator, std::function<void(OrtAllocator*)>>` (type-erasing deleter — see Section 3.2). **Macros:** The `EP_ENFORCE`, `LOG`, `RETURN_ERROR` macros come from `plugin_ep_utils.h`; replace with equivalents from `cuda_plugin_utils.h` or define locally (see 5.2). **No CUDA-specific changes** — the arena operates on the `OrtAllocator` C interface and is CUDA-agnostic. |
+| `ep_arena.cc` (~750 lines) | `plugin/cuda_arena.cc` | Full `ArenaImpl` implementation: constructor, destructor, `Alloc`, `AllocOnStream`, `Free`, `Reserve`, `Extend`, `FindChunkPtr`, `SplitChunk`, `Merge`, `FreeAndMaybeCoalesce`, `Coalesce`, `ResetChunksUsingStream`, `DumpMemoryLog`, `GetStats` | **License header:** Preserve the original Apache-2.0 TensorFlow-derived license header and attribution notices. **Namespace:** Wrap in `onnxruntime::cuda_plugin`. **Include:** `#include "cuda_arena.h"`. **Macros:** Same as header. No other changes needed — the implementation is allocator-agnostic (delegates to `device_allocator_->Alloc/Free`). |
+
+**Not copied** — `ep_allocator.h`. The CUDA plugin already has `cuda_allocator_plugin.h` with `CudaAllocatorBase`, `CudaDeviceAllocator`, `CudaPinnedAllocator`. We add `AllocatorStats` to this existing file (see 5.2). `AllocatorUniquePtr` (type-erasing deleter) is defined in `cuda_arena.h` alongside `ArenaImpl` which uses it. `BaseAllocator` is **not** needed — see Section 3.2.
+
+**CMake:** No changes needed. The plugin CMake uses `file(GLOB_RECURSE ... "core/providers/cuda/*.cc")` which automatically picks up new `.cc` files in the `plugin/` directory.
+
+### 5.2 CUDA Plugin Changes
+
+| File | Change |
+|------|--------|
+| `plugin/cuda_arena.h` | **New file.** Copied from `ep_arena.h` with namespace/include adaptations per 5.1. Contains `ArenaExtendStrategy`, `ArenaConfig`, `ArenaImpl`, `AllocatorUniquePtr` typedef, and `CudaArenaAllocator` (replaces example’s `ArenaAllocator`). |
+| `plugin/cuda_arena.cc` | **New file.** Copied from `ep_arena.cc` with namespace/include adaptations per 5.1. |
+| `plugin/cuda_allocator_plugin.h` | **(a)** Add `AllocatorStats` struct (POD with `ToKeyValuePairs` helper, copied from `ep_allocator.h`). **(b)** Add arena-support macros: `EP_ENFORCE` (ostringstream + throw), `LOG` (delegates to `OrtApi::Logger_LogMessage`), `RETURN_ERROR` (creates OrtStatus). These can go in `cuda_plugin_utils.h` instead if preferred. |
+| `plugin/cuda_ep_factory.h` | Extend `DeviceCacheEntry` with per-device arena and mempool members: `std::mutex arena_mutex; std::unique_ptr<CudaArenaAllocator> device_arena; std::unique_ptr<CudaArenaAllocator> pinned_arena; std::unique_ptr<CudaMempoolOrtAllocator> mempool_allocator;` plus ref counts and `device_arena_using_defaults` flag (Section 3.3). Add `#include "cuda_arena.h"`. Add helper `CudaArenaAllocator* GetDeviceArenaForDevice(int device_id)` for stream integration. |
+| `plugin/cuda_ep_factory.cc` | Rewrite `CreateAllocatorImpl`: extract `device_id` from `OrtMemoryInfo`, find `DeviceCacheEntry`, create/return shared `CudaArenaAllocator` wrapping `CudaDeviceAllocator` or `CudaPinnedAllocator` per device (Section 3.1 pseudocode). Rewrite `ReleaseAllocatorImpl`: pointer identity match against `DeviceCacheEntry` arenas and mempool allocator, decrement ref count, destroy if zero; fall back to `CudaAllocatorBase`-based `delete` for raw allocators (Section 3.3 pseudocode). |
+| `plugin/cuda_stream_plugin.cc` | Update `CudaSyncStream::OnSessionRunEndImpl`: after stream synchronization and deferred buffer cleanup, call `factory.GetDeviceArenaForDevice(stream->device_id_)->ResetChunksUsingStream(this_ptr)` to release chunk-to-stream assignments (Section 3.4). |
+
+### 5.3 ORT Core Changes (Minimal)
+
+| File | Change |
+|------|--------|
+| `allocator.h` | Added `virtual IArena* AsArena()` (const and non-const, returning `nullptr`) to `IAllocator`. Overridden in `IArena` to return `this`. This eliminates the RTTI dependency in `SafeArenaCast()`, which now delegates to `allocator->AsArena()`. |
+| `allocator.cc` | Simplified `SafeArenaCast()` to `return allocator ? allocator->AsArena() : nullptr;` — no `dynamic_cast`, no `#ifdef ORT_NO_RTTI`. |
+| `allocator_adapters.h` | Added `IArenaImplWrappingOrtAllocator` — wraps an `OrtAllocator*` that implements `Shrink()` as an `IArena`. See Section 5.4. |
+| `allocator_adapters.cc` | Implemented `IArenaImplWrappingOrtAllocator` methods (Alloc, Free, Reserve, IsStreamAware, AllocOnStream, GetStats, Shrink). Added `GetStatsFromOrtAllocator()` helper using safe `TryParseStringWithClassicLocale` parsing. Added `kOrtAllocatorShrinkMinVersion = 25`. |
+| `environment.cc` | **`CreateSharedAllocator`**: When the plugin allocator's `version >= 25` and `Shrink != nullptr`, wraps it as `IArenaImplWrappingOrtAllocator` (IArena) instead of `IAllocatorImplWrappingOrtAllocator` (IAllocator). This makes plugin arenas discoverable by session-level arena management such as `ShrinkMemoryArenas`. |
+| `inference_session.cc` | **`ValidateAndParseShrinkArenaString`** and **`ShrinkMemoryArenas`**: simplified to use `allocator->AsArena()` directly, which now also discovers plugin arenas wrapped via `IArenaImplWrappingOrtAllocator`. |
+| `device_stream_collection.cc` | `ReleaseSingleStreamBuffers`: simplified to use `allocator->AsArena()` directly (removed `alloc_type == OrtArenaAllocator` check). |
+| Future: `environment.cc` | `RegisterExecutionProviderLibrary`: construct prefix `"ep_factory." + factory->GetName(factory) + "."` (case-sensitive, with null-guard), obtain config snapshot via `GetConfigEntries()`, extract matching `arena.*` keys, strip prefix, build `OrtKeyValuePairs` with bare `arena.*` keys, pass as `allocator_options` to `CreateSharedAllocatorImpl` instead of `nullptr` (see Section 3.6 for casing convention). |
+| Future: `ep_plugin_provider_interfaces.h` | Add `std::optional<OrtKeyValuePairs> session_arena_options_` member to `PluginExecutionProvider` to store session-level arena config extracted at construction time. |
+| Future: `ep_plugin_provider_interfaces.cc` | **(a)** In `PluginExecutionProvider` constructor: gated on `ep_factory_.CreateAllocator != nullptr` — construct EP prefix via `GetProviderOptionPrefix(ep->GetName(ep.get()))`, scan `session_options.value.config_options` for keys matching `<prefix>arena.*`, strip the EP prefix, and store as bare `"arena.*"` keys in `session_arena_options_`. The EP-name prefix naturally scopes extraction to the current EP. **(b)** In `CreatePreferredAllocators()`: if `session_arena_options_` has a value, pass it as `allocator_options` to `ep_factory_.CreateAllocator()` instead of `nullptr`. |
+
+### 5.4 Shrink and ORT Core Arena Integration
+
+The in-tree CUDA EP's `BFCArena` / `StreamAwareBFCArena` directly implements the `IArena` interface inside ORT core. ORT session-level code — `InferenceSession::ShrinkMemoryArenas()`, `DeviceStreamCollection::ReleaseSingleStreamBuffers()`, `ValidateAndParseShrinkArenaString()` — discovers arenas via `IArena::SafeArenaCast()` and calls `Shrink()` or `ReleaseStreamBuffers()` on them. Plugin EP allocators are returned as `OrtAllocator*` (a C struct), which ORT core wraps in a C++ `IAllocator` adapter. Without additional work, plugin arenas are invisible to these session-level arena management paths.
+
+This PR introduces two complementary mechanisms to bridge the gap:
+
+#### 5.4.1 `IArenaImplWrappingOrtAllocator` — Plugin Arena as IArena
+
+`IArenaImplWrappingOrtAllocator` (in `allocator_adapters.h/.cc`) wraps an `OrtAllocator*` whose `Shrink` function pointer is non-null, exposing it through the standard `IArena` C++ interface:
+
+| IArena method | How it maps to OrtAllocator |
+|---|---|
+| `Alloc(size)` | `ort_allocator_->Alloc(ort_allocator_, size)` |
+| `Free(p)` | `ort_allocator_->Free(ort_allocator_, p)` |
+| `Reserve(size)` | `ort_allocator_->Reserve(ort_allocator_, size)` (version ≥ 18) |
+| `IsStreamAware()` | `ort_allocator_->AllocOnStream != nullptr` (version ≥ 23) |
+| `AllocOnStream(size, stream)` | `ort_allocator_->AllocOnStream(ort_allocator_, size, stream->GetRawHandle())` |
+| `GetStats(stats)` | Calls `ort_allocator_->GetStats` (version ≥ 23), parses the returned `OrtKeyValuePairs` into `AllocatorStats` using safe `TryParseStringWithClassicLocale` |
+| **`Shrink()`** | `ort_allocator_->Shrink(ort_allocator_)` → converts returned `OrtStatus*` to `Status` (version ≥ 25) |
+| `ReleaseStreamBuffers(stream)` | **No-op** — plugin EPs handle stream buffer cleanup internally via `OrtSyncStreamImpl::OnSessionRunEnd` → `ResetChunksUsingStream()` |
+
+The version gate `kOrtAllocatorShrinkMinVersion = 25` ensures the `Shrink` field is only accessed on allocators that declare support for it.
+
+#### 5.4.2 `AsArena()` Virtual Method — RTTI-Free Arena Discovery
+
+`IAllocator` now declares `virtual IArena* AsArena()` (both const and non-const), returning `nullptr` by default. `IArena` overrides this to return `this`. `SafeArenaCast()` delegates to `AsArena()`, removing the previous dependency on `dynamic_cast` (or unsafe `static_cast` in `ORT_NO_RTTI` builds).
+
+Because `IArenaImplWrappingOrtAllocator` inherits from `IArena`, its `AsArena()` automatically returns a non-null pointer, making plugin arenas discoverable by all existing arena-aware code paths without any RTTI.
+
+#### 5.4.3 How Plugin Arenas Participate in `ShrinkMemoryArenas`
+
+The end-to-end flow for shrinking plugin arenas:
+
+```
+User calls OrtApi::ShrinkMemoryArenas(session, "arena_name:0")
+  → InferenceSession::ShrinkMemoryArenas()
+    → iterates session allocators
+      → allocator->AsArena()   // non-null for IArenaImplWrappingOrtAllocator
+      → arena->Shrink()
+        → IArenaImplWrappingOrtAllocator::Shrink()
+          → ort_allocator_->Shrink(ort_allocator_)  // crosses into plugin DLL
+            → CudaArenaAllocator::ShrinkImpl()
+              → ArenaImpl::Shrink()  // releases free regions back to CUDA
+```
+
+For `CudaMempoolOrtAllocator`, the same path calls `cudaMemPoolTrimTo()` with the configured `bytes_to_keep_on_shrink`.
+
+#### 5.4.4 Selection Logic in `Environment::CreateSharedAllocator`
+
+`Environment::CreateSharedAllocator` inspects the `OrtAllocator*` returned by the plugin factory:
+
+```cpp
+if (allocator->version >= 25 && allocator->Shrink != nullptr) {
+  shared_allocator = std::make_shared<IArenaImplWrappingOrtAllocator>(std::move(ort_allocator));
+} else {
+  shared_allocator = std::make_shared<IAllocatorImplWrappingOrtAllocator>(std::move(ort_allocator));
+}
+```
+
+Plugin allocators that do not implement `Shrink` (e.g., read-only allocators) continue to be wrapped as plain `IAllocator`. The selection is automatic — no user-facing configuration is needed.
+
+---
+
+## 6. Implementation Plan
+
+### Phase 1: Arena in CUDA Plugin
+
+1. **Add support types to `cuda_allocator_plugin.h`:** Add `AllocatorStats` (POD). No changes to `CudaAllocatorBase` inheritance.
+2. **Add arena macros to `cuda_plugin_utils.h`:** Add `EP_ENFORCE` (ostringstream throw), `LOG` (delegates to `OrtApi::Logger_LogMessage`), `RETURN_ERROR` (creates OrtStatus). These are needed by the arena code copied from the example plugin.
+3. **Copy `ep_arena.h` → `plugin/cuda_arena.h`:** Wrap in `onnxruntime::cuda_plugin` namespace. Replace includes with `cuda_allocator_plugin.h` and `cuda_plugin_utils.h`. Replace `ArenaAllocator : BaseAllocator` with `CudaArenaAllocator : CudaAllocatorBase` (see Section 3.2). Add `AllocatorUniquePtr` typedef (type-erasing deleter). Set `AllocOnStream` conditionally by `CudaAllocatorKind` in the constructor.
+4. **Copy `ep_arena.cc` → `plugin/cuda_arena.cc`:** Wrap in `onnxruntime::cuda_plugin` namespace. Replace includes. No other changes needed.
+5. **Extend `DeviceCacheEntry` in `cuda_ep_factory.h`:** Add per-device arena members (`device_arena`, `pinned_arena`, ref counts, mutex) as described in Section 3.3. Add `#include "cuda_arena.h"`. Add `CudaArenaAllocator* GetDeviceArenaForDevice(int device_id)` accessor.
+6. **Rewrite `CreateAllocatorImpl` in `cuda_ep_factory.cc`:** Look up `DeviceCacheEntry` by `device_id`, create shared `CudaArenaAllocator` wrapping `CudaDeviceAllocator`/`CudaPinnedAllocator` on first call per device, return same pointer on subsequent calls (Section 3.1 pseudocode).
+7. **Rewrite `ReleaseAllocatorImpl` in `cuda_ep_factory.cc`:** Pointer identity match against device cache entries, decrement ref count, destroy if zero. Fall back to `CudaAllocatorBase`-based `delete` for non-arena types (Section 3.3 pseudocode).
+8. **Update `OnSessionRunEndImpl` in `cuda_stream_plugin.cc`:** After existing stream sync and deferred buffer cleanup, call `arena->ResetChunksUsingStream(this_ptr)` for the device's arena (Section 3.4).
+9. **No CMake changes needed:** The glob picks up new `.cc` files in `plugin/` automatically.
+10. **Update `RegisterExecutionProviderLibrary` in `environment.cc`:** Construct prefix via `factory->GetName(factory)` (case-sensitive, with null-guard), obtain config snapshot via `GetConfigEntries()`, extract `ep_factory.<ep_name>.arena.*` keys, pass as `allocator_options` to `CreateSharedAllocatorImpl` (see Section 3.6).
+11. **Plumb session-level arena options in `PluginExecutionProvider`:** In the constructor (`ep_plugin_provider_interfaces.cc`), extract `ep.<ep_name>.arena.*` keys from `session_options.value.config_options`, strip the EP prefix, and store as bare `arena.*` keys. In `CreatePreferredAllocators()`, build `OrtKeyValuePairs` from the stored map and pass to `ep_factory_.CreateAllocator()` (see Section 3.5).
+
+### Phase 2: CudaMempoolArena Migration
+
+1. Add conditional logger abstraction to `cuda_mempool_arena.h/.cc`
+2. Create `CudaMempoolOrtAllocator : CudaAllocatorBase` wrapper (Section 4.4)
+3. Add mempool arena mode selection in `CreateAllocatorImpl` based on `arena.use_cuda_mempool` option
+4. Remove `cuda_mempool_arena.cc` from plugin CMake exclusion list
+
+### Phase 3: Validation
+
+1. Verify default arena gives same allocation behavior as in-tree EP
+2. Test mempool mode with `arena.use_cuda_mempool=1`
+3. Test env-level arena config via `CreateEnvWithOptions`
+4. Test shared allocator replacement via `OrtApi::CreateSharedAllocator`
+5. Benchmark allocation performance vs. in-tree EP
+6. Verify `use_env_allocators=1` works correctly (shared arena replaces per-session)
+
+---
+
+## 7. Open Questions
+
+1. **Arena code sharing vs. copying.** Should the CUDA plugin copy `ep_arena.h/cc` verbatim, or should there be a shared location for the arena code that multiple plugin EPs can use? Copying is simpler and avoids coupling, but risks divergence if bugs are found. A shared `plugin_arena/` directory under `onnxruntime/test/autoep/library/` (or a new location) could be consumed by multiple plugin EPs.

--- a/docs/cuda_plugin_ep/cuda_plugin_ep_design.md
+++ b/docs/cuda_plugin_ep/cuda_plugin_ep_design.md
@@ -263,6 +263,16 @@ Some CPU base classes have heavy dependencies (protobuf, `UnpackTensor`) that ma
 - Registers itself in a global `cudaStream_t -> CudaSyncStream*` map so migrated kernels can recover per-stream handles from a raw CUDA stream
 - Defers host-buffer cleanup until `OnSessionRunEnd()` after the stream is synchronized
 
+#### 5.1.1 Device Synchronization (Sync API)
+
+`CudaEp` implements `OrtEp::Sync` to block until the configured CUDA device has completed all preceding work. ORT uses this path for scenarios such as `IOBinding`, where asynchronous input copies must finish before kernel execution begins.
+
+Implementation details:
+- `CudaEp::SyncImpl` temporarily switches to the EP's configured device via `cudaSetDevice(device_id)` and restores the caller's previous CUDA device before returning
+- It then issues `cudaDeviceSynchronize()` as a conservative device-wide barrier
+
+This is intentionally conservative and correct for the plugin EP's first sync integration. A narrower stream-scoped synchronization strategy can be considered later if profiling shows a need.
+
 ### 5.2 Handle Access Path
 
 ```
@@ -304,7 +314,7 @@ For stream bridging, the preferred helpers are:
 - `GetComputeStream(ctx)` when the kernel API already accepts the adapter's opaque stream pointer
 - `GetOrtStream(ctx)` when framework-style `Stream*` plumbing is still needed by shared helper code
 
-### 5.3.1 NHWC Layout-Transformation Support
+#### 5.3.1 NHWC Layout-Transformation Support
 
 The bundled CUDA EP's NHWC path is not just a kernel-registration feature. It is a coordinated contract between provider configuration, ORT's layout transformer, kernel registration, adapter/provider access, and graph partitioning. On the current branch, the CUDA plugin EP now supports this path when NHWC is compiled in and the session requests `prefer_nhwc`.
 
@@ -557,7 +567,7 @@ Section 7 reflects the current source exclusions in `cmake/onnxruntime_providers
 | `cuda_stream_handle.cc` | Replaced by `cuda_stream_plugin.cc` |
 | `cuda_execution_provider_info.cc` | Config parsed directly in `CudaEp::Config` |
 | `cuda_graph.cc` | CUDA graph support deferred (files removed pending OrtEp API extension) |
-| `cuda_mempool_arena.cc` | Plugin uses `cudaMalloc`/`cudaFree` directly |
+| `cuda_mempool_arena.cc` | Replaced by plugin-native `cuda_mempool_allocator_plugin.h/.cc` (uses CUDA mempool directly behind `OrtAllocator`) |
 | `cuda_common.cc` | Utility functions shimmed in `cuda_kernel_adapter.h` |
 | `cuda_nhwc_kernels.cc` | Replaced by `PluginKernelCollector` auto-registration |
 | `cuda_contrib_kernels.cc` | Replaced by `PluginKernelCollector` auto-registration |
@@ -842,23 +852,54 @@ This is a quality-of-life improvement rather than a required change — the exis
 
 ---
 
-## 12. File Layout
+## 12. Memory Arena Integration
+
+The CUDA plugin EP now includes a full BFC-style arena (`CudaArenaAllocator` / `ArenaImpl`) and a CUDA native mempool allocator (`CudaMempoolOrtAllocator`), both residing inside the plugin library. The detailed design — factory lifecycle, per-device cache, stream integration, arena config flow, and the `CudaMempoolArena` migration — is documented in [arena_allocator_migration_design.md](arena_allocator_migration_design.md).
+
+**ORT core integration:** Plugin arenas implement `OrtAllocator::Shrink` (added in ORT API version 25). When ORT core detects a non-null `Shrink` function pointer on the returned `OrtAllocator*`, it wraps the allocator as `IArenaImplWrappingOrtAllocator` (an `IArena`). This makes the plugin arena visible to session-level arena management — `InferenceSession::ShrinkMemoryArenas()`, `ValidateAndParseShrinkArenaString()`, `DeviceStreamCollection::ReleaseSingleStreamBuffers()` — through the standard `IArena::SafeArenaCast()` / `AsArena()` virtual method, without requiring RTTI.
+
+**Key files introduced:**
+
+| File | Purpose |
+|------|---------|
+| `plugin/cuda_arena.h` | `ArenaConfig`, `ArenaImpl` (BFC arena), `CudaArenaAllocator` (`OrtAllocator` wrapper) |
+| `plugin/cuda_arena.cc` | Arena implementation: bins, chunks, regions, stream-aware alloc, `Shrink()`, `GetStats()` |
+| `plugin/cuda_mempool_allocator_plugin.h` | `CudaMempoolOrtAllocator` — wraps CUDA native mempool behind `OrtAllocator` |
+| `plugin/cuda_mempool_allocator_plugin.cc` | Mempool implementation: `cudaMallocFromPoolAsync`/`cudaFreeAsync`, pool lifecycle, `Shrink()` via `cudaMemPoolTrimTo` |
+| `core/session/allocator_adapters.h` | `IArenaImplWrappingOrtAllocator` — wraps plugin `OrtAllocator*` with `Shrink` as `IArena` |
+| `core/session/allocator_adapters.cc` | Adapter implementation; `GetStatsFromOrtAllocator()` helper; `kOrtAllocatorShrinkMinVersion` |
+
+---
+
+## 13. File Layout
 
 ```
 onnxruntime/core/providers/cuda/plugin/
 ├── cuda_kernel_adapter.h        # CudaKernel base, macros, CPU shims (force-included)
-├── cuda_ep.h / .cc              # CudaEp : OrtEp implementation
-├── cuda_ep_factory.h / .cc      # CudaEpFactory : OrtEpFactory
+├── cuda_ep.h / .cc              # CudaEp : OrtEp implementation (GetCapability, Sync, CreateSyncStreamForDevice)
+├── cuda_ep_factory.h / .cc      # CudaEpFactory : OrtEpFactory (arena lifecycle, per-device cache)
 ├── cuda_plugin_ep.cc            # DLL entry points (CreateEpFactories/ReleaseEpFactory)
 ├── cuda_plugin_ep_symbols.def   # Windows DLL export definitions
 ├── cuda_plugin_kernels.h / .cu  # Kernel registry creation
-├── cuda_stream_plugin.h / .cc   # CudaSyncStream (handles, notifications)
-├── cuda_allocator_plugin.h / .cc    # Device/pinned allocators
+├── cuda_stream_plugin.h / .cc   # CudaSyncStream (handles, notifications, arena chunk reset)
+├── cuda_allocator_plugin.h / .cc    # Device/pinned raw allocators (CudaAllocatorBase hierarchy)
+├── cuda_arena.h / .cc           # BFC arena (ArenaConfig, ArenaImpl, CudaArenaAllocator)
+├── cuda_mempool_allocator_plugin.h / .cc  # CUDA native mempool allocator (CudaMempoolOrtAllocator)
 ├── cuda_data_transfer_plugin.h / .cc # GPU↔CPU data transfer
 ├── cuda_memcpy_plugin.cc        # MemcpyFromHost/MemcpyToHost standalone kernels
 ├── cuda_controlflow_plugin.h / .cc / .cu  # If/Loop/Scan wrappers
 ├── cuda_plugin_utils.h          # Common macros, error handling
 └── provider_api_shims.cc        # Reimplemented utility functions
+
+onnxruntime/core/session/
+├── allocator_adapters.h / .cc   # OrtAllocator↔IAllocator/IArena bidirectional adapters
+│                                # (IAllocatorImplWrappingOrtAllocator, IArenaImplWrappingOrtAllocator,
+│                                #  OrtAllocatorImplWrappingIAllocator)
+└── ...
+
+include/onnxruntime/core/framework/
+├── allocator.h                  # IAllocator (AsArena virtual), IArena (Shrink, SafeArenaCast)
+└── ...
 
 include/onnxruntime/ep/
 ├── README.md                    # EP adapter layer overview
@@ -882,76 +923,27 @@ include/onnxruntime/ep/
 
 ---
 
-## 13. Future Work
+## 14. Future Work
 
-1. **Memory arena / allocator parity** — The plugin currently relies on direct `cudaMalloc`/`cudaFree` in `CudaDeviceAllocator` instead of an arena-backed allocator. Two complementary improvements are planned:
+1. **Profiling and observability** — The in-tree CUDA EP exposes an EP profiler, while the plugin shim currently does not surface equivalent profiling hooks. Future work should wire up `GetProfiler()` for the plugin path, integrate CUDA/NVTX/CUPTI-based tracing where appropriate, and make plugin execution visible in the same profiling flows users already rely on for the bundled CUDA EP.
 
-   **A. `CudaMempoolArena` (commit e6023b0c)**
+2. **Stream/adapter parity for framework-style `Stream*` consumers** — A number of excluded or recently re-included kernels still assume access to a richer framework `Stream*` object rather than only a raw `cudaStream_t` view. Extending the adapter path here would unblock additional LLM, FFT, quantization, diffusion, and other CUDA kernels.
 
-   The in-tree CUDA EP gained a native-CUDA-mempool allocator (`cuda_mempool_arena.h/.cc`) that uses `cudaMallocFromPoolAsync` / `cudaFreeAsync` on stream-ordered allocation paths, with a configurable `cudaMemPoolAttrReleaseThreshold` to return memory to the device as it becomes idle. Enabling this in the plugin requires:
+3. **Contrib LLM migration pass** — The core CUDA LLM attention path is now adapter-safe, but `contrib_ops/cuda/llm/*` remains excluded as a separate follow-up.
 
-   1. **Make `CudaMempoolArena` compilable in the plugin build.** `cuda_mempool_arena.h` currently includes `cuda_stream_handle.h` and `provider_api.h` (both `SHARED_PROVIDER`-only). The only real dependency is resolving the stream framework pointer. When migrating for plugin use, this class can be refactored to accept a raw `cudaStream_t` directly (or an `OrtSyncStream*`), bypassing the internal `stream->GetHandle()` logic.
+4. **Tunable ops** — Implement a plugin-side `ITuningContext` and remove the `ORT_USE_EP_API_ADAPTERS` guards in `matmul.cc`/`gemm.cc` so the plugin can recover runtime kernel selection and profiling-based tuning behavior.
 
-   2. **Implement a thin `OrtAllocator` wrapper around `CudaMempoolArena`.** The plugin factory's `CreateAllocatorImpl` returns an `OrtAllocator*`, while `CudaMempoolArena` is an `IArena` / `IAllocator`. A new class (e.g., `CudaMempoolOrtAllocator`) should own a `CudaMempoolArena` instance and forward the `OrtAllocator` callbacks to it:
+5. **TensorSeq and additional C API coverage** — Add enough sequence/tensor-sequence support to unblock `sequence_op.cc` (the last remaining TensorSeq-dependent file), and extend the ORT C API where needed for remaining framework-style attribute accessors such as string-array attributes used by RNN kernels. Note: `identity_op.cc` is now included in the plugin build — its TensorSeq code path is guarded by `#ifndef BUILD_CUDA_EP_AS_PLUGIN` and opset 14+ registrations use `AllFixedSizeTensorTypes()` (Tensor-only) instead of `AllFixedSizeTensorAndSequenceTensorTypes()`.
 
-      | `OrtAllocator` callback | Implementation |
-      |-------------------------|----------------|
-      | `Alloc(size)` | `arena_->Alloc(size)` (allocates on the legacy default stream) |
-      | `Free(ptr)` | `arena_->Free(ptr)` |
-      | `Reserve(size)` | `arena_->Reserve(size)` |
-      | `AllocOnStream(size, stream)` | `cudaStream_t cu_stream = (cudaStream_t)api->SyncStream_GetHandle(stream);` <br> `arena_->AllocWithCudaStream(size, cu_stream);` |
-      | `GetStats(kvps)` | Populate from `arena_->GetStats()` |
-      | `Info()` | Return the `OrtMemoryInfo*` used at construction |
+6. **Remaining contrib exclusions** — The FFT (`fft_ops.cc`), crop (`crop.cc`), and dynamicslice (`dynamicslice.cc`) exclusions have been removed. These files now compile in the plugin build: FFT ops use `Stream(context)` (which works in both builds) and the `CUFFT_RETURN_IF_ERROR` macro was added to the adapter; crop and dynamicslice had no real framework blockers once tested. The plugin CMake now links `CUDA::cufft` for cuFFT symbol resolution. Remaining contrib exclusions are: `shrunken_gather.cc` (training), `transformers/*` (subgraph), `aten_ops/*` (ATen), `collective/*` (NCCL), and `llm/*` (contrib LLM pass).
 
-      The `OrtAllocator` C API already supports stream-aware allocation via the optional `AllocOnStream` callback (set on `OrtAllocator` when `version >= kOrtAllocatorAllocOnStreamMinVersion`). ORT core wraps every plugin `OrtAllocator` into `IAllocatorImplWrappingOrtAllocator` (`allocator_adapters.cc`), which dispatches to `AllocOnStream` when the wrapper reports `IsStreamAware() == true`. So there is **no additional plumbing needed in the adapter or framework** — the plugin allocator just needs to set `AllocOnStream` to a non-null function pointer to get full stream-ordered semantics.
+7. **CI integration and targeted benchmarking** — Add plugin build + test coverage to CI and include perf-oriented validation so allocator, profiling, and tunable-op regressions are caught early.
 
-      **Important:** The `OrtMemoryInfo::alloc_type` returned by the wrapper must be `OrtDeviceAllocator`, **not** `OrtArenaAllocator`. Both `PluginExecutionProvider::CreatePreferredAllocators()` and `Environment::CreateSharedAllocatorImpl()` explicitly reject `OrtArenaAllocator` from plugin factories — the arena is expected to be opaque to ORT.
+8. **NHWC cleanup and hardening** — Complete the follow-up work described in [Section 5.3.1](#531-nhwc-layout-transformation-support): unify the allowlist, improve internal-domain diagnostics, and add stronger structural NHWC assertions.
 
-   3. **Parse mempool options.** ORT can pass allocator configuration to the plugin factory through the `allocator_options` (`OrtKeyValuePairs*`) argument of `OrtEpFactory::CreateAllocator`. The relevant keys are defined in `OrtArenaCfg::Keys` (in `allocator.h`):
-      - `arena.use_cuda_mempool` — set to `"1"` to enable
-      - `arena.cuda_mempool_release_threshold` — bytes; `0` disables the threshold
-      - `arena.cuda_mempool_bytes_to_keep_on_shrink` — bytes retained after `Shrink()`
+9. **CUDA Graph API for plugin EPs** — Add `IsGraphCaptureEnabled`, `IsGraphCaptured`, and `ReplayGraph` callbacks to the `OrtEp` C API (see [Section 5.4.4](#544-what-needs-to-change-in-ort-core-option-a)). This is required for efficient CUDA graph replay in the plugin EP. The capture/replay infrastructure will be reintroduced once the API is extended.
 
-      **How options reach the plugin factory — two paths:**
-
-      | Path | How it calls `CreateAllocator` | `allocator_options` |
-      |------|-------------------------------|---------------------|
-      | **Shared allocator** (`OrtApi::CreateSharedAllocator`) | `Environment::CreateSharedAllocatorImpl` → `ep_factory->CreateAllocator(factory, &mem_info, allocator_options, &alloc)` | Caller-provided `OrtKeyValuePairs*` — can carry arena keys |
-      | **Per-EP allocator** (`PluginExecutionProvider::CreatePreferredAllocators`) | `ep_factory.CreateAllocator(&ep_factory, memory_info, /*options*/ nullptr, &alloc)` | Always `nullptr` today |
-
-      The per-EP path currently passes `nullptr` for options. To support mempool configuration on this path, either:
-      - **(a)** Parse the arena keys from session options inside `CudaEp` / `CudaEpFactory` (similar to how `CudaEp::Config` already parses other provider options) and store them so `CreateAllocatorImpl` can read them without needing `allocator_options`.
-      - **(b)** Extend the ORT core per-EP allocator path to forward the config entries to `CreateAllocator` (requires an ORT core change).
-
-      Option (a) is self-contained within the plugin and does not require ORT core changes.
-
-   4. **Thread the factory logger.** `CudaMempoolArena` takes a `const logging::Logger*`. The plugin factory already owns a logger (`factory.default_logger_` / the `OrtLogger` passed at EP creation). Convert or wrap it and pass it to the arena constructor.
-
-   5. **Handle `ReleaseAllocatorImpl`.** The factory's `ReleaseAllocatorImpl` switch currently only knows about `CudaDeviceAllocator` and `CudaPinnedAllocator`. Add a third case (`kMempool` or similar) to correctly destroy the new wrapper and its owned `CudaMempoolArena`.
-
-   **B. BFC arena (longer term)**
-
-   If BFC-style arena behavior (`gpu_mem_limit`, `arena_extend_strategy`) is also needed, a similar `OrtAllocator`-wrapping approach would work for `BFCArena`, once its `SHARED_PROVIDER`-only dependencies are removed. The same `AllocOnStream` / `OrtDeviceAllocator` / option-parsing patterns apply.
-
-2. **Profiling and observability** — The in-tree CUDA EP exposes an EP profiler, while the plugin shim currently does not surface equivalent profiling hooks. Future work should wire up `GetProfiler()` for the plugin path, integrate CUDA/NVTX/CUPTI-based tracing where appropriate, and make plugin execution visible in the same profiling flows users already rely on for the bundled CUDA EP.
-
-3. **Stream/adapter parity for framework-style `Stream*` consumers** — A number of excluded or recently re-included kernels still assume access to a richer framework `Stream*` object rather than only a raw `cudaStream_t` view. Extending the adapter path here would unblock additional LLM, FFT, quantization, diffusion, and other CUDA kernels.
-
-4. **Contrib LLM migration pass** — The core CUDA LLM attention path is now adapter-safe, but `contrib_ops/cuda/llm/*` remains excluded as a separate follow-up.
-
-5. **Tunable ops** — Implement a plugin-side `ITuningContext` and remove the `ORT_USE_EP_API_ADAPTERS` guards in `matmul.cc`/`gemm.cc` so the plugin can recover runtime kernel selection and profiling-based tuning behavior.
-
-6. **TensorSeq and additional C API coverage** — Add enough sequence/tensor-sequence support to unblock `sequence_op.cc` (the last remaining TensorSeq-dependent file), and extend the ORT C API where needed for remaining framework-style attribute accessors such as string-array attributes used by RNN kernels. Note: `identity_op.cc` is now included in the plugin build — its TensorSeq code path is guarded by `#ifndef BUILD_CUDA_EP_AS_PLUGIN` and opset 14+ registrations use `AllFixedSizeTensorTypes()` (Tensor-only) instead of `AllFixedSizeTensorAndSequenceTensorTypes()`.
-
-7. **Remaining contrib exclusions** — The FFT (`fft_ops.cc`), crop (`crop.cc`), and dynamicslice (`dynamicslice.cc`) exclusions have been removed. These files now compile in the plugin build: FFT ops use `Stream(context)` (which works in both builds) and the `CUFFT_RETURN_IF_ERROR` macro was added to the adapter; crop and dynamicslice had no real framework blockers once tested. The plugin CMake now links `CUDA::cufft` for cuFFT symbol resolution. Remaining contrib exclusions are: `shrunken_gather.cc` (training), `transformers/*` (subgraph), `aten_ops/*` (ATen), `collective/*` (NCCL), and `llm/*` (contrib LLM pass).
-
-8. **CI integration and targeted benchmarking** — Add plugin build + test coverage to CI and include perf-oriented validation so allocator, profiling, and tunable-op regressions are caught early.
-
-9. **NHWC cleanup and hardening** — Complete the follow-up work described in [Section 5.3.1](#531-nhwc-layout-transformation-support): unify the allowlist, improve internal-domain diagnostics, and add stronger structural NHWC assertions.
-
-10. **CUDA Graph API for plugin EPs** — Add `IsGraphCaptureEnabled`, `IsGraphCaptured`, and `ReplayGraph` callbacks to the `OrtEp` C API (see [Section 5.4.4](#544-what-needs-to-change-in-ort-core-option-a)). This is required for efficient CUDA graph replay in the plugin EP. The capture/replay infrastructure will be reintroduced once the API is extended.
-
-11. **OpSchema-validated kernel registration (PR #27713)** — PR #27713 adds `OrtEpApi` functions that let plugin EPs query ONNX operator schemas from ORT's global registry (see [Section 3.5.1](#351-type-constraint-names-and-opschema-access)). Concrete follow-up work for the CUDA plugin EP:
+10. **OpSchema-validated kernel registration (PR #27713)** — PR #27713 adds `OrtEpApi` functions that let plugin EPs query ONNX operator schemas from ORT's global registry (see [Section 3.5.1](#351-type-constraint-names-and-opschema-access)). Concrete follow-up work for the CUDA plugin EP:
 
     **A. Registration-time validation pass**
 
@@ -979,7 +971,7 @@ include/onnxruntime/ep/
     | `cuda_ep.cc` / `GetCapabilityImpl()` | (Optional) Add schema-based diagnostic when `EpGraphSupportInfo_LookUpKernel` returns nullptr |
     | `test_cuda_plugin_ep.py` | Add a validation stage that exercises schema-validated registration |
 
-12. **Resource accounting and annotation-based partitioning (PR #27595)** — ORT is acquiring two related features that affect how graph nodes are partitioned to EPs:
+11. **Resource accounting and annotation-based partitioning (PR #27595)** — ORT is acquiring two related features that affect how graph nodes are partitioned to EPs:
 
     **A. Resource accounting**
 

--- a/include/onnxruntime/core/framework/allocator.h
+++ b/include/onnxruntime/core/framework/allocator.h
@@ -176,6 +176,11 @@ class IAllocator {
     *stats = {};
   }
 
+  // Returns a pointer to this allocator as an IArena if it is one, nullptr otherwise.
+  // Used by SafeArenaCast to avoid dependency on RTTI.
+  virtual class IArena* AsArena() { return nullptr; }
+  virtual const class IArena* AsArena() const { return nullptr; }
+
   static bool CalcMemSizeForArray(size_t nmemb, size_t size, size_t* out) noexcept {
     return CalcMemSizeForArrayWithAlignment(nmemb, size, 0, out);
   }
@@ -364,6 +369,8 @@ class IArena : public IAllocator {
   virtual Status Shrink() = 0;
   // Only implemented when IsStreamAware() returns true
   virtual void ReleaseStreamBuffers(Stream* /*stream*/) {}
+  IArena* AsArena() override { return this; }
+  const IArena* AsArena() const override { return this; }
   static IArena* SafeArenaCast(IAllocator* allocator);
 };
 

--- a/include/onnxruntime/core/framework/execution_provider.h
+++ b/include/onnxruntime/core/framework/execution_provider.h
@@ -84,10 +84,23 @@ class IExecutionProvider {
       : default_device_(device), type_{type}, logger_{&logger} {
   }
 
+  IExecutionProvider(const std::string& type, OrtDevice device,
+                     std::vector<const OrtEpDevice*> ep_devices, const logging::Logger& logger)
+      : default_device_(device), ep_devices_{ep_devices}, type_{type}, logger_{&logger} {
+  }
+
   /*
      default device for this ExecutionProvider
   */
   const OrtDevice default_device_;
+
+  /*
+     The OrtEpDevice list this execution provider supports.
+
+     It's mainly for plugin EP which implements this interface or provider-bridge EP that
+     implements OrtEpFactory as OrtEpDevice(s) are available for such scenarios.
+  */
+  const std::vector<const OrtEpDevice*> ep_devices_;
 
  public:
   virtual ~IExecutionProvider() = default;
@@ -186,6 +199,11 @@ class IExecutionProvider {
    * Get the OrtDevice the execution provider was registered with.
    */
   const OrtDevice& GetDevice() const { return default_device_; }
+
+  /**
+   * Get the OrtEpDevice list the execution provider was registered with.
+   */
+  const std::vector<const OrtEpDevice*>& GetEpDevices() const { return ep_devices_; }
 
   /**
      Get execution provider's configuration options.

--- a/include/onnxruntime/core/framework/op_kernel.h
+++ b/include/onnxruntime/core/framework/op_kernel.h
@@ -105,9 +105,9 @@ class OpKernel {
     return Status::OK();
   }
 
-  // Note: New implementations should override OpKernel::UseSharedPrePackedBuffers_V2 instead.
   // Override this function to use provided pre-packed weight.
   // Status UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+  //                                 gsl::span<const size_t> prepacked_buffer_sizes,
   //                                 int input_idx,
   //                                 /*out*/ bool& used_shared_buffers) {
   //     used_shared_buffers = true;
@@ -121,35 +121,16 @@ class OpKernel {
   //                            and must use the same order for retrieval in UseSharedPrePackedBuffers(). Though each element
   //                           of this vector is a BufferUniquePtr, the deleter of the BufferUniquePtr is NULL. So actually they
   //                           are raw pointers.
+  // @param prepacked_buffer_sizes: The sizes (in bytes) of each buffer in prepacked_buffers.
   // @param input_idx: The input index of the tensor in this kernel
   // @param used_shared_buffers: Boolean flag set by the kernel implementation indicating
   // that the provided weight has been used by the kernel.
   virtual Status UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& /*prepacked_buffers*/,
+                                           gsl::span<const size_t> /*prepacked_buffer_sizes*/,
                                            int /*input_idx*/,
                                            /*out*/ bool& used_shared_buffers) {
     used_shared_buffers = false;
     return Status::OK();
-  }
-
-  /// <summary>
-  /// Version 2 of OpKernel::UseSharedPrePackedBuffers() that additionally accepts the buffer sizes as a parameter.
-  /// The default implementation of this function just calls directly to OpKernel::UseSharedPrePackedBuffers()
-  /// to avoid the need to update all existing kernel-based provider-bridge EPs.
-  ///
-  /// TODO: Consolidate UseSharedPrePackedBuffers and UseSharedPrePackedBuffers_V2 into a single function,
-  /// which will require updating kernel-based provider-bridge EPs (cpu, cuda, webgpu).
-  ///
-  /// </summary>
-  /// <param name="prepacked_buffers"></param>
-  /// <param name="prepacked_buffer_sizes"></param>
-  /// <param name="input_idx"></param>
-  /// <param name="used_shared_buffers"></param>
-  /// <returns></returns>
-  virtual Status UseSharedPrePackedBuffers_V2(std::vector<BufferUniquePtr>& prepacked_buffers,
-                                              gsl::span<const size_t> /*prepacked_buffer_sizes*/,
-                                              int input_idx,
-                                              /*out*/ bool& used_shared_buffers) {
-    return UseSharedPrePackedBuffers(prepacked_buffers, input_idx, used_shared_buffers);
   }
 
   const OrtDevice GetDevice(OrtMemType mem_type) const;

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -418,6 +418,22 @@ typedef struct OrtAllocator {
    * \since 1.23
    */
   void*(ORT_API_CALL* AllocOnStream)(struct OrtAllocator* this_, size_t size, OrtSyncStream* stream);
+
+  /** \brief Release unused memory held by the allocator back to the system.
+   *
+   * For arena-based allocators, this frees allocation regions that are completely unused.
+   * For mempool-based allocators, this trims the pool to a configured minimum.
+   * For non-arena allocators this is a no-op.
+   *
+   * \param[in] this_ OrtAllocator instance
+   *
+   * \return nullptr on success, or an OrtStatus* on failure.
+   *
+   * \note Implementation of this function is optional and Shrink may be set to a nullptr.
+   *       Callers must check for nullptr before invoking.
+   * \since 1.25
+   */
+  ORT_API2_STATUS(Shrink, _In_ struct OrtAllocator* this_);
 } OrtAllocator;
 
 typedef void(ORT_API_CALL* OrtLoggingFunction)(

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -1048,6 +1048,7 @@ struct AllocatorImpl : Base<T> {
   using B::B;
 
   void* Alloc(size_t size);
+  void* Reserve(size_t size);
   MemoryAllocation GetAllocation(size_t size);
   void Free(void* p);
   ConstMemoryInfo GetInfo() const;
@@ -1057,6 +1058,12 @@ struct AllocatorImpl : Base<T> {
    * \return A pointer to a KeyValuePairs object that will be filled with the allocator statistics.
    */
   KeyValuePairs GetStats() const;
+
+  /** \brief Release unused memory held by the allocator.
+   *
+   * Calls the optional Shrink function pointer if available; does nothing otherwise.
+   */
+  void Shrink();
 };
 }  // namespace detail
 
@@ -3613,12 +3620,6 @@ struct KernelRegistry : detail::Base<OrtKernelRegistry> {
 };
 
 namespace detail {
-/** \brief Non-owning wrapper around a `const OrtOpSchemaTypeConstraint*`.
- *
- * Holds a single type constraint from an operator schema, providing access to
- * the constraint's name, allowed data types, and associated input/output indices.
- * This is a non-owning view — the lifetime is tied to the parent OrtOpSchema.
- */
 template <typename T>
 struct OpSchemaTypeConstraintImpl : Base<T> {
   using B = Base<T>;
@@ -3639,15 +3640,11 @@ struct OpSchemaTypeConstraintImpl : Base<T> {
 }  // namespace detail
 
 /// Non-owning wrapper around a `const OrtOpSchemaTypeConstraint*`.
+/// Holds a single type constraint from an operator schema, providing access to
+/// the constraint's name, allowed data types, and associated input/output indices.
 using ConstOpSchemaTypeConstraint = detail::OpSchemaTypeConstraintImpl<detail::Unowned<const OrtOpSchemaTypeConstraint>>;
 
 namespace detail {
-/** \brief Owning wrapper around an `OrtOpSchema*`.
- *
- * Provides access to operator schema metadata such as version, input/output names,
- * and type constraints. The underlying OrtOpSchema is owned by this wrapper and
- * released automatically on destruction.
- */
 template <typename T>
 struct OpSchemaImpl : Base<T> {
   using B = Base<T>;
@@ -3685,6 +3682,9 @@ struct OpSchemaImpl : Base<T> {
 }  // namespace detail
 
 /// Owning wrapper around an `OrtOpSchema*`.
+/// Provides access to operator schema metadata such as version, input/output names,
+/// and type constraints. The underlying OrtOpSchema is owned by this wrapper and
+/// released automatically on destruction.
 using OpSchema = detail::OpSchemaImpl<OrtOpSchema>;
 
 /// \brief Get an operator schema from the global schema registry.

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -225,6 +225,19 @@ inline void* AllocatorImpl<T>::Alloc(size_t size) {
 }
 
 template <typename T>
+inline void* AllocatorImpl<T>::Reserve(size_t size) {
+  // Reserve was added in version 18. For older allocators the field may be
+  // uninitialized, so we must not dereference it.
+  if (this->p_->version >= 18 && this->p_->Reserve) {
+    return this->p_->Reserve(this->p_, size);
+  }
+  // Fall back to Alloc() for allocators that don't implement Reserve,
+  // matching the ORT-core adapter behavior (IAllocatorImplWrappingOrtAllocator,
+  // IArenaImplWrappingOrtAllocator).
+  return this->p_->Alloc(this->p_, size);
+}
+
+template <typename T>
 inline MemoryAllocation AllocatorImpl<T>::GetAllocation(size_t size) {
   void* out;
   ThrowOnError(GetApi().AllocatorAlloc(this->p_, size, &out));
@@ -249,6 +262,15 @@ inline KeyValuePairs AllocatorImpl<T>::GetStats() const {
   OrtKeyValuePairs* out;
   ThrowOnError(GetApi().AllocatorGetStats(this->p_, &out));
   return KeyValuePairs(out);
+}
+
+template <typename T>
+inline void AllocatorImpl<T>::Shrink() {
+  // Shrink was added in version 25. For older allocators the field may be
+  // uninitialized, so we must not dereference it.
+  if (this->p_->version >= 25 && this->p_->Shrink) {
+    ThrowOnError(this->p_->Shrink(this->p_));
+  }
 }
 }  // namespace detail
 

--- a/js/web/docs/webgl-operators.md
+++ b/js/web/docs/webgl-operators.md
@@ -24,6 +24,7 @@ See [Compatibility](../README.md#Compatibility) for a list of the supported plat
 | [AveragePool](https://github.com/onnx/onnx/blob/main/docs/Operators.md#AveragePool) | [7-9](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#AveragePool-7), [10](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#AveragePool-10), [11-18](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#AveragePool-11), [19-21](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#AveragePool-19), [22+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#AveragePool-22) |
 | [BatchNormalization](https://github.com/onnx/onnx/blob/main/docs/Operators.md#BatchNormalization) | [7-8](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#BatchNormalization-7), [9-13](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#BatchNormalization-9), [14](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#BatchNormalization-14), [15+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#BatchNormalization-15) |
 | [Bernoulli](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Bernoulli) |  |
+| [BitCast](https://github.com/onnx/onnx/blob/main/docs/Operators.md#BitCast) |  |
 | [BitShift](https://github.com/onnx/onnx/blob/main/docs/Operators.md#BitShift) |  |
 | [BitwiseAnd](https://github.com/onnx/onnx/blob/main/docs/Operators.md#BitwiseAnd) |  |
 | [BitwiseNot](https://github.com/onnx/onnx/blob/main/docs/Operators.md#BitwiseNot) |  |
@@ -47,6 +48,7 @@ See [Compatibility](../README.md#Compatibility) for a list of the supported plat
 | [ConvTranspose](https://github.com/onnx/onnx/blob/main/docs/Operators.md#ConvTranspose) | [1-10](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ConvTranspose-1), [11-21](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ConvTranspose-11), [22+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ConvTranspose-22) |
 | [Cos](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Cos) | [7-21](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Cos-7), [22+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Cos-22) |
 | [Cosh](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Cosh) |  |
+| [CumProd](https://github.com/onnx/onnx/blob/main/docs/Operators.md#CumProd) |  |
 | [CumSum](https://github.com/onnx/onnx/blob/main/docs/Operators.md#CumSum) |  |
 | [DFT](https://github.com/onnx/onnx/blob/main/docs/Operators.md#DFT) |  |
 | [DeformConv](https://github.com/onnx/onnx/blob/main/docs/Operators.md#DeformConv) |  |

--- a/onnxruntime/contrib_ops/cpu/bert/attention.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/attention.cc
@@ -34,6 +34,7 @@ class Attention : public OpKernel, public AttentionCPUBase {
                  /*out*/ PrePackedWeights* prepacked_weights) override;
 
   Status UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                   gsl::span<const size_t> /*prepacked_buffer_sizes*/,
                                    int input_idx,
                                    /*out*/ bool& used_shared_buffers) override;
 
@@ -176,6 +177,7 @@ Status Attention<T>::PrePack(const Tensor& weights, int input_idx, AllocatorPtr 
 
 template <typename T>
 Status Attention<T>::UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                               gsl::span<const size_t> /*prepacked_buffer_sizes*/,
                                                int input_idx,
                                                /*out*/ bool& used_shared_buffers) {
   if (1 != input_idx) {

--- a/onnxruntime/contrib_ops/cpu/moe/moe_quantization_cpu.cc
+++ b/onnxruntime/contrib_ops/cpu/moe/moe_quantization_cpu.cc
@@ -578,10 +578,10 @@ Status QMoECPU<T>::PrePack(const Tensor& tensor, int input_idx, AllocatorPtr all
 }
 
 template <typename T>
-Status QMoECPU<T>::UseSharedPrePackedBuffers_V2(std::vector<BufferUniquePtr>& prepacked_buffers,
-                                                gsl::span<const size_t> /*prepacked_buffer_sizes*/,
-                                                int input_idx,
-                                                /*out*/ bool& used_shared_buffers) {
+Status QMoECPU<T>::UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                             gsl::span<const size_t> /*prepacked_buffer_sizes*/,
+                                             int input_idx,
+                                             /*out*/ bool& used_shared_buffers) {
   used_shared_buffers = false;
 
   if (expert_weight_bits_ != 4) {
@@ -1577,11 +1577,11 @@ template QMoECPU<float>::QMoECPU(const OpKernelInfo& op_kernel_info);
 
 template Status QMoECPU<float>::Compute(OpKernelContext* context) const;
 template Status QMoECPU<float>::PrePack(const Tensor& tensor, int input_idx, AllocatorPtr alloc, bool& is_packed, PrePackedWeights* prepacked_weights);
-template Status QMoECPU<float>::UseSharedPrePackedBuffers_V2(std::vector<BufferUniquePtr>& prepacked_buffers, gsl::span<const size_t> prepacked_buffer_sizes, int input_idx, bool& used_shared_buffers);
+template Status QMoECPU<float>::UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers, gsl::span<const size_t> prepacked_buffer_sizes, int input_idx, bool& used_shared_buffers);
 template QMoECPU<MLFloat16>::QMoECPU(const OpKernelInfo& op_kernel_info);
 template Status QMoECPU<MLFloat16>::Compute(OpKernelContext* context) const;
 template Status QMoECPU<MLFloat16>::PrePack(const Tensor& tensor, int input_idx, AllocatorPtr alloc, bool& is_packed, PrePackedWeights* prepacked_weights);
-template Status QMoECPU<MLFloat16>::UseSharedPrePackedBuffers_V2(std::vector<BufferUniquePtr>& prepacked_buffers, gsl::span<const size_t> prepacked_buffer_sizes, int input_idx, bool& used_shared_buffers);
+template Status QMoECPU<MLFloat16>::UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers, gsl::span<const size_t> prepacked_buffer_sizes, int input_idx, bool& used_shared_buffers);
 
 // Kernel Registration
 ONNX_OPERATOR_TYPED_KERNEL_EX(

--- a/onnxruntime/contrib_ops/cpu/moe/moe_quantization_cpu.h
+++ b/onnxruntime/contrib_ops/cpu/moe/moe_quantization_cpu.h
@@ -32,10 +32,10 @@ class QMoECPU final : public OpKernel, public MoEBaseCPU {
                  /*out*/ bool& is_packed,
                  /*out*/ PrePackedWeights* prepacked_weights) override;
 
-  Status UseSharedPrePackedBuffers_V2(std::vector<BufferUniquePtr>& prepacked_buffers,
-                                      gsl::span<const size_t> prepacked_buffer_sizes,
-                                      int input_idx,
-                                      /*out*/ bool& used_shared_buffers) override;
+  Status UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                   gsl::span<const size_t> prepacked_buffer_sizes,
+                                   int input_idx,
+                                   /*out*/ bool& used_shared_buffers) override;
 
   void ApplyActivationVectorized(float* data, int64_t size) const;
 

--- a/onnxruntime/contrib_ops/cpu/quantization/attention_quant.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/attention_quant.cc
@@ -28,6 +28,7 @@ class QAttention : public OpKernel, public AttentionCPUBase {
                  /*out*/ PrePackedWeights* prepacked_weights) override;
 
   Status UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                   gsl::span<const size_t> /*prepacked_buffer_sizes*/,
                                    int input_idx,
                                    /*out*/ bool& used_shared_buffers) override;
 
@@ -117,6 +118,7 @@ Status QAttention<T>::PrePack(const Tensor& weights, int input_idx, AllocatorPtr
 
 template <typename T>
 Status QAttention<T>::UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                                gsl::span<const size_t> /*prepacked_buffer_sizes*/,
                                                 int input_idx,
                                                 /*out*/ bool& used_shared_buffers) {
   if (1 != input_idx) {

--- a/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_lstm.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_lstm.cc
@@ -17,6 +17,7 @@ class DynamicQuantizeLSTM : public OpKernel, public LSTMBase {
                  /*out*/ PrePackedWeights* prepacked_weights) override;
 
   Status UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                   gsl::span<const size_t> /*prepacked_buffer_sizes*/,
                                    int input_idx,
                                    /*out*/ bool& used_shared_buffers) override;
 
@@ -117,6 +118,7 @@ Status DynamicQuantizeLSTM::PrePack(const Tensor& tensor, int input_idx, Allocat
 }
 
 Status DynamicQuantizeLSTM::UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                                      gsl::span<const size_t> /*prepacked_buffer_sizes*/,
                                                       int input_idx,
                                                       /*out*/ bool& used_shared_buffers) {
   used_shared_buffers = false;

--- a/onnxruntime/contrib_ops/cpu/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/matmul_nbits.cc
@@ -135,7 +135,9 @@ class MatMulNBits final : public OpKernel {
                  /*out*/ bool& is_packed,
                  /*out*/ PrePackedWeights* prepacked_weights) override;
 
-  Status UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers, int input_idx,
+  Status UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                   gsl::span<const size_t> /*prepacked_buffer_sizes*/,
+                                   int input_idx,
                                    /*out*/ bool& used_shared_buffers) override;
 
  private:
@@ -557,7 +559,9 @@ Status MatMulNBits<MLFloat16>::PrePack(const Tensor& tensor, int input_idx, /*ou
 #endif  // end !MLAS_F16VEC_INTRINSICS_SUPPORTED || !MLAS_TARGET_ARM64
 
 template <typename T1>
-Status MatMulNBits<T1>::UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers, int input_idx,
+Status MatMulNBits<T1>::UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                                  gsl::span<const size_t> /*prepacked_buffer_sizes*/,
+                                                  int input_idx,
                                                   /*out*/ bool& used_shared_buffers) {
   used_shared_buffers = false;
 

--- a/onnxruntime/contrib_ops/cpu/word_conv_embedding.cc
+++ b/onnxruntime/contrib_ops/cpu/word_conv_embedding.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <cstring>
+
 #include <core/common/safeint.h>
 #include "word_conv_embedding.h"
 
@@ -14,6 +16,7 @@ namespace contrib {
 void WordConvEmbedding::CharEmbeddingLookup(
     const int* seq_ptr,
     const float* char_embedding_weight_p,
+    size_t char_embedding_table_size,
     size_t seq_len,
     size_t word_len,
     size_t char_embedding_size,
@@ -26,7 +29,12 @@ void WordConvEmbedding::CharEmbeddingLookup(
       float* cur_dst_ptr = dst + word_inx * word_len * char_embedding_size;
       size_t char_length_to_lookup = std::max<size_t>(words_len_ptr[word_inx], filter_width);
       for (size_t char_inx = 0; char_inx < char_length_to_lookup; char_inx++) {
-        memcpy(cur_dst_ptr, char_embedding_weight_p + (*cur_seq_ptr) * char_embedding_size, sizeof(float) * char_embedding_size);
+        const int char_index = *cur_seq_ptr;
+        if (char_index >= 0 && static_cast<size_t>(char_index) < char_embedding_table_size) {
+          memcpy(cur_dst_ptr,
+                 char_embedding_weight_p + static_cast<size_t>(char_index) * char_embedding_size,
+                 sizeof(float) * char_embedding_size);
+        }
         cur_dst_ptr += char_embedding_size;
         cur_seq_ptr++;
       }
@@ -131,7 +139,23 @@ void WordConvEmbedding::CalculateLengthOfEachWordInSequence(
   }
 }
 
-Status WordConvEmbedding::ValidateInputShape(const TensorShape& w_conv_shape, const TensorShape& w_char_embedding_shape) const {
+Status WordConvEmbedding::ValidateInputShape(const TensorShape& sequence_shape, const TensorShape& w_conv_shape,
+                                             const TensorShape& w_char_embedding_shape) const {
+  if (sequence_shape.NumDimensions() <= 1) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Sequence input must have rank greater than 1.",
+                           " Sequence rank: ", sequence_shape.NumDimensions());
+  }
+
+  if (w_conv_shape.NumDimensions() <= 3) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Conv weight input must have rank greater than 3.",
+                           " Conv weight rank: ", w_conv_shape.NumDimensions());
+  }
+
+  if (w_char_embedding_shape.NumDimensions() <= 1) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Char embedding input must have rank greater than 1.",
+                           " Char embedding rank: ", w_char_embedding_shape.NumDimensions());
+  }
+
   if (embedding_size_ != -1 && w_conv_shape[0] != embedding_size_) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Conv filter size does not match embedding_size attribute.",
                            " embedding_size attribute: ", embedding_size_,
@@ -156,6 +180,12 @@ Status WordConvEmbedding::ValidateInputShape(const TensorShape& w_conv_shape, co
                            " Conv kernal size 2 : ", w_conv_shape[3]);
   }
 
+  if (w_conv_shape[2] > sequence_shape[1]) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Conv kernel width must not exceed word length.",
+                           " Conv kernel width: ", w_conv_shape[2],
+                           " Word length: ", sequence_shape[1]);
+  }
+
   return Status::OK();
 }
 
@@ -170,7 +200,7 @@ Status WordConvEmbedding::Compute(OpKernelContext* ctx) const {
   const TensorShape& w_conv_shape = w_conv.Shape();
   const TensorShape& w_char_embedding_shape = w_char_embedding.Shape();
 
-  ORT_RETURN_IF_ERROR(ValidateInputShape(w_conv_shape, w_char_embedding_shape));
+  ORT_RETURN_IF_ERROR(ValidateInputShape(sequence_shape, w_conv_shape, w_char_embedding_shape));
 
   int64_t seq_len = sequence_shape[0];
   int64_t word_len = sequence_shape[1];
@@ -198,6 +228,7 @@ Status WordConvEmbedding::Compute(OpKernelContext* ctx) const {
 
   CharEmbeddingLookup(seq_ptr,
                       w_char_embedding.Data<float>(),
+                      onnxruntime::narrow<size_t>(w_char_embedding_shape[0]),
                       onnxruntime::narrow<size_t>(seq_len),
                       onnxruntime::narrow<size_t>(word_len),
                       onnxruntime::narrow<size_t>(char_embedding_size),

--- a/onnxruntime/contrib_ops/cpu/word_conv_embedding.h
+++ b/onnxruntime/contrib_ops/cpu/word_conv_embedding.h
@@ -26,6 +26,7 @@ class WordConvEmbedding final : public OpKernel {
   void CharEmbeddingLookup(
       const int* seq_ptr,
       const float* char_embedding_weight_p,
+      size_t char_embedding_table_size,
       size_t seq_len,
       size_t word_len,
       size_t char_embedding_size,
@@ -51,6 +52,7 @@ class WordConvEmbedding final : public OpKernel {
       size_t word_len) const;
 
   Status ValidateInputShape(
+      const TensorShape& sequence_shape,
       const TensorShape& w_conv_shape,
       const TensorShape& w_char_embedding_shape) const;
 

--- a/onnxruntime/contrib_ops/cuda/tensor/dynamic_time_warping.h
+++ b/onnxruntime/contrib_ops/cuda/tensor/dynamic_time_warping.h
@@ -9,8 +9,10 @@ namespace onnxruntime {
 namespace contrib {
 namespace cuda {
 
+#ifndef BUILD_CUDA_EP_AS_PLUGIN
 using onnxruntime::OpKernelContext;
 using onnxruntime::OpKernelInfo;
+#endif
 using onnxruntime::cuda::CudaKernel;
 class DynamicTimeWarping final : public CudaKernel {
  public:

--- a/onnxruntime/contrib_ops/cuda/tensor/unfold.h
+++ b/onnxruntime/contrib_ops/cuda/tensor/unfold.h
@@ -9,8 +9,10 @@ namespace onnxruntime {
 namespace contrib {
 namespace cuda {
 
+#ifndef BUILD_CUDA_EP_AS_PLUGIN
 using onnxruntime::OpKernelContext;
 using onnxruntime::OpKernelInfo;
+#endif
 using onnxruntime::cuda::CudaKernel;
 class UnfoldTensor final : public CudaKernel {
  public:

--- a/onnxruntime/contrib_ops/webgpu/bert/bias_add.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/bias_add.cc
@@ -30,7 +30,7 @@ Status BiasAddProgram::GenerateShaderCode(ShaderHelper& shader) const {
                             << "  let value = " << input.GetByOffset("global_idx")
                             << "  + " << bias.GetByOffset("global_idx % uniforms.channels")
                             << "  + " << residual.GetByOffset("global_idx") << ";\n"
-                            << "  " + output.SetByOffset("global_idx", "value");
+                            << "  " << output.SetByOffset("global_idx", "value");
 
   return Status::OK();
 }

--- a/onnxruntime/contrib_ops/webgpu/bert/rotary_embedding.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/rotary_embedding.cc
@@ -40,7 +40,7 @@ Status RotaryEmbeddingProgram::GenerateShaderCode(ShaderHelper& shader) const {
                             << "    let j = i + select(half_rotary_emb_dim, 1, " << interleaved_str << ");\n"
                             << "    let re = " << input.GetByOffset("i") << " * " << cos_cache.GetByIndices("vec2<u32>(position_id, bsnh[3])") << " - " << input.GetByOffset("j") << " * " << sin_cache.GetByIndices("vec2<u32>(position_id, bsnh[3])") << ";\n"
                             << "    " << output.SetByOffset("i", "re") << "\n"
-                            << "    let im = " << input.GetByOffset("i") << " * " << sin_cache.GetByIndices("vec2<u32>(position_id, bsnh[3])") << " + " << input.GetByOffset("j") + " * " << cos_cache.GetByIndices("vec2<u32>(position_id, bsnh[3])") << ";\n"
+                            << "    let im = " << input.GetByOffset("i") << " * " << sin_cache.GetByIndices("vec2<u32>(position_id, bsnh[3])") << " + " << input.GetByOffset("j") << " * " << cos_cache.GetByIndices("vec2<u32>(position_id, bsnh[3])") << ";\n"
                             << "    " << output.SetByOffset("j", "im") << "\n"
                             << "  } else { \n"
                                "    let k = dot(bsnh, uniforms.input_output_stride) + half_rotary_emb_dim;\n"

--- a/onnxruntime/core/framework/allocator.cc
+++ b/onnxruntime/core/framework/allocator.cc
@@ -191,12 +191,7 @@ void* AllocateBufferWithOptions(IAllocator& alloc, size_t size, bool use_reserve
 }
 
 IArena* IArena::SafeArenaCast(IAllocator* allocator) {
-#if !defined(ORT_NO_RTTI)
-  auto* result = dynamic_cast<IArena*>(allocator);
-  return result;
-#else
-  return static_cast<IArena*>(allocator);
-#endif
+  return allocator ? allocator->AsArena() : nullptr;
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/framework/device_stream_collection.cc
+++ b/onnxruntime/core/framework/device_stream_collection.cc
@@ -36,15 +36,10 @@ class DeviceStreamCollectionImpl {
   void ReleaseSingleStreamBuffers(Stream* stream) {
     if (!stream) return;
     for (const auto& it : allocators_) {
-      if (it.second->Info().device == stream->GetDevice() &&
-          it.second->Info().alloc_type == OrtArenaAllocator) {
-        if (it.second->IsStreamAware()) {
-          // Previously we only had one StreamAwareBFCArena. We need to guard
-          // against multiple allocators now.
-          auto* arena_alloc = IArena::SafeArenaCast(it.second.get());
-          if (arena_alloc) {
-            arena_alloc->ReleaseStreamBuffers(stream);
-          }
+      if (it.second->Info().device == stream->GetDevice()) {
+        auto* arena = it.second->AsArena();
+        if (arena && arena->IsStreamAware()) {
+          arena->ReleaseStreamBuffers(stream);
         }
       }
     }

--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -436,8 +436,8 @@ static Status KernelUseSharedPrePackedBuffers(OpKernel& kernel, int input_idx,
   }
 
   bool used_shared_buffers = false;
-  ORT_RETURN_IF_ERROR(kernel.UseSharedPrePackedBuffers_V2(shared_prepacked_buffers, shared_prepacked_buffer_sizes,
-                                                          input_idx, used_shared_buffers));
+  ORT_RETURN_IF_ERROR(kernel.UseSharedPrePackedBuffers(shared_prepacked_buffers, shared_prepacked_buffer_sizes,
+                                                       input_idx, used_shared_buffers));
 
   // BUG CHECK: Ensure that the kernel used the provided shared buffers
   // Mostly a debug check to ensure that the kernel has an overridden implementation of the

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.h
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.h
@@ -35,19 +35,17 @@ inline bool HasRawData(const ONNX_NAMESPACE::TensorProto& ten_proto) {
   ONNX_CONTRIB_OPERATOR_SCHEMA_UNIQ_HELPER(__COUNTER__, name)
 #define ONNX_CONTRIB_OPERATOR_SCHEMA_UNIQ_HELPER(Counter, name) \
   ONNX_CONTRIB_OPERATOR_SCHEMA_UNIQ(Counter, name)
-#define ONNX_CONTRIB_OPERATOR_SCHEMA_UNIQ(Counter, name)         \
-  static ONNX_NAMESPACE::OpSchemaRegistry::OpSchemaRegisterOnce( \
-      op_schema_register_once##name##Counter) ONNX_UNUSED =      \
-      ONNX_NAMESPACE::OpSchema(#name, __FILE__, __LINE__)
+#define ONNX_CONTRIB_OPERATOR_SCHEMA_UNIQ(Counter, name)                                               \
+  static ONNX_NAMESPACE::OpSchemaRegistry::OpSchemaRegisterOnce op_schema_register_once##name##Counter \
+      [[maybe_unused]] = ONNX_NAMESPACE::OpSchema(#name, __FILE__, __LINE__)
 
 #define ONNX_CONTRIB_OPERATOR_SCHEMA_ELSEWHERE(name, schema_func) \
   ONNX_CONTRIB_OPERATOR_SCHEMA_UNIQ_HELPER_ELSEWHERE(__COUNTER__, name, schema_func)
 #define ONNX_CONTRIB_OPERATOR_SCHEMA_UNIQ_HELPER_ELSEWHERE(Counter, name, schema_func) \
   ONNX_CONTRIB_OPERATOR_SCHEMA_UNIQ_ELSEWHERE(Counter, name, schema_func)
-#define ONNX_CONTRIB_OPERATOR_SCHEMA_UNIQ_ELSEWHERE(Counter, name, schema_func) \
-  static ONNX_NAMESPACE::OpSchemaRegistry::OpSchemaRegisterOnce(                \
-      op_schema_register_once##name##Counter) ONNX_UNUSED =                     \
-      schema_func(ONNX_NAMESPACE::OpSchema(#name, __FILE__, __LINE__))
+#define ONNX_CONTRIB_OPERATOR_SCHEMA_UNIQ_ELSEWHERE(Counter, name, schema_func)                        \
+  static ONNX_NAMESPACE::OpSchemaRegistry::OpSchemaRegisterOnce op_schema_register_once##name##Counter \
+      [[maybe_unused]] = schema_func(ONNX_NAMESPACE::OpSchema(#name, __FILE__, __LINE__))
 
 void RegisterContribSchemas();
 void RegisterNchwcSchemas();

--- a/onnxruntime/core/graph/dml_ops/dml_defs.h
+++ b/onnxruntime/core/graph/dml_ops/dml_defs.h
@@ -11,19 +11,17 @@ namespace dml {
   MS_DML_OPERATOR_SCHEMA_UNIQ_HELPER(__COUNTER__, name)
 #define MS_DML_OPERATOR_SCHEMA_UNIQ_HELPER(Counter, name) \
   MS_DML_OPERATOR_SCHEMA_UNIQ(Counter, name)
-#define MS_DML_OPERATOR_SCHEMA_UNIQ(Counter, name)               \
-  static ONNX_NAMESPACE::OpSchemaRegistry::OpSchemaRegisterOnce( \
-      op_schema_register_once##name##Counter) ONNX_UNUSED =      \
-      ONNX_NAMESPACE::OpSchema(#name, __FILE__, __LINE__)
+#define MS_DML_OPERATOR_SCHEMA_UNIQ(Counter, name)                                                     \
+  static ONNX_NAMESPACE::OpSchemaRegistry::OpSchemaRegisterOnce op_schema_register_once##name##Counter \
+      [[maybe_unused]] = ONNX_NAMESPACE::OpSchema(#name, __FILE__, __LINE__)
 
 #define MS_DML_OPERATOR_SCHEMA_ELSEWHERE(name, schema_func) \
   MS_DML_OPERATOR_SCHEMA_UNIQ_HELPER_ELSEWHERE(__COUNTER__, name, schema_func)
 #define MS_DML_OPERATOR_SCHEMA_UNIQ_HELPER_ELSEWHERE(Counter, name, schema_func) \
   MS_DML_OPERATOR_SCHEMA_UNIQ_ELSEWHERE(Counter, name, schema_func)
-#define MS_DML_OPERATOR_SCHEMA_UNIQ_ELSEWHERE(Counter, name, schema_func) \
-  static ONNX_NAMESPACE::OpSchemaRegistry::OpSchemaRegisterOnce(          \
-      op_schema_register_once##name##Counter) ONNX_UNUSED =               \
-      schema_func(ONNX_NAMESPACE::OpSchema(#name, __FILE__, __LINE__))
+#define MS_DML_OPERATOR_SCHEMA_UNIQ_ELSEWHERE(Counter, name, schema_func)                              \
+  static ONNX_NAMESPACE::OpSchemaRegistry::OpSchemaRegisterOnce op_schema_register_once##name##Counter \
+      [[maybe_unused]] = schema_func(ONNX_NAMESPACE::OpSchema(#name, __FILE__, __LINE__))
 
 void RegisterDmlSchemas();
 }  // namespace dml

--- a/onnxruntime/core/optimizer/attention_fusion.cc
+++ b/onnxruntime/core/optimizer/attention_fusion.cc
@@ -2,14 +2,672 @@
 // Licensed under the MIT License.
 
 #include "core/graph/graph_utils.h"
+#include "core/common/safeint.h"
+#include "core/framework/tensorprotoutils.h"
 #include "core/optimizer/initializer.h"
 #include "core/optimizer/attention_fusion.h"
 #include "core/optimizer/utils.h"
 #include "core/optimizer/attention_fusion_helper.h"
-#include "core/graph/graph_utils.h"
 #include <cmath>
+#include <optional>
 
 namespace onnxruntime {
+
+static bool ValidateMatMulInitializer(const Graph& graph, const Node& matmul, int64_t hidden_size);
+
+namespace {
+
+static bool ValidateAddBiasInitializerEitherInput(const Graph& graph, const Node& add, int64_t hidden_size) {
+  if (add.InputDefs().size() < 2) {
+    return false;
+  }
+
+  const NodeArg& input_0 = *(add.InputDefs()[0]);
+  const NodeArg& input_1 = *(add.InputDefs()[1]);
+  const bool input_0_is_bias = graph_utils::IsInitializer(graph, input_0.Name(), true) &&
+                               optimizer_utils::ValidateShape(input_0, {hidden_size});
+  const bool input_1_is_bias = graph_utils::IsInitializer(graph, input_1.Name(), true) &&
+                               optimizer_utils::ValidateShape(input_1, {hidden_size});
+  return input_0_is_bias || input_1_is_bias;
+}
+
+static bool ValidateProjectionGemmInitializer(const Graph& graph, const Node& gemm, int64_t hidden_size) {
+  if (gemm.InputDefs().size() < 3) {
+    return false;
+  }
+
+  if (const auto* alpha_attr = graph_utils::GetNodeAttribute(gemm, "alpha");
+      alpha_attr && std::abs(alpha_attr->f() - 1.0f) > 1e-6f) {
+    return false;
+  }
+
+  if (const auto* beta_attr = graph_utils::GetNodeAttribute(gemm, "beta");
+      beta_attr && std::abs(beta_attr->f() - 1.0f) > 1e-6f) {
+    return false;
+  }
+
+  if (const auto* trans_a_attr = graph_utils::GetNodeAttribute(gemm, "transA");
+      trans_a_attr && trans_a_attr->i() != 0) {
+    return false;
+  }
+
+  if (const auto* trans_b_attr = graph_utils::GetNodeAttribute(gemm, "transB");
+      trans_b_attr && trans_b_attr->i() != 0) {
+    return false;
+  }
+
+  const NodeArg& input_b = *(gemm.InputDefs()[1]);
+  const NodeArg& input_c = *(gemm.InputDefs()[2]);
+  if (!graph_utils::IsInitializer(graph, input_b.Name(), true) ||
+      !graph_utils::IsInitializer(graph, input_c.Name(), true)) {
+    return false;
+  }
+
+  return optimizer_utils::ValidateShape(input_b, {hidden_size, hidden_size}) &&
+         optimizer_utils::ValidateShape(input_c, {hidden_size});
+}
+
+// Most attention fusions require all matched nodes to already be assigned to an execution provider
+// that supports the fused op. MobileClipMHA is also matched before partitioning in graph-transform
+// tests, so nodes may still be unassigned here. Accept nodes that are either unassigned or already
+// assigned to a compatible provider, and preserve the original provider string on the fused nodes
+// once the pattern is rewritten.
+static bool IsSupportedOrUnassignedNode(const Node& node,
+                                        const InlinedHashSet<std::string_view>& compatible_execution_providers) {
+  return node.GetExecutionProviderType().empty() ||
+         graph_utils::IsSupportedProvider(node, compatible_execution_providers);
+}
+
+static bool IsSupportedOrUnassignedNode(const Node& node,
+                                        std::string_view required_execution_provider) {
+  const auto& execution_provider = node.GetExecutionProviderType();
+  return execution_provider.empty() ||
+         execution_provider == required_execution_provider;
+}
+
+static bool AreSupportedOrUnassignedNodes(
+    const Node& anchor_node,
+    const std::initializer_list<const Node*>& nodes,
+    const InlinedHashSet<std::string_view>& compatible_execution_providers) {
+  if (!IsSupportedOrUnassignedNode(anchor_node, compatible_execution_providers)) {
+    return false;
+  }
+
+  const auto& required_execution_provider = anchor_node.GetExecutionProviderType();
+  for (const Node* node : nodes) {
+    if (node == nullptr) {
+      continue;
+    }
+
+    if (!IsSupportedOrUnassignedNode(*node, required_execution_provider)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+static bool HasExpectedPerm(const Node& node, const std::initializer_list<int64_t>& expected_perm) {
+  return optimizer_utils::IsAttributeWithExpectedValues(node, "perm", std::vector<int64_t>(expected_perm));
+}
+
+static bool HasExpectedAxesInput(const Graph& graph, const Node& node, const std::initializer_list<int64_t>& expected_axes) {
+  if (node.InputDefs().size() < 2) {
+    return false;
+  }
+
+  InlinedVector<int64_t> axes;
+  if (!optimizer_utils::AppendTensorFromInitializer(graph, *node.InputDefs()[1], axes, true)) {
+    return false;
+  }
+
+  return axes == InlinedVector<int64_t>(expected_axes.begin(), expected_axes.end());
+}
+
+static bool TryGetMobileClipQkvReshapeInfo(const Graph& graph, const Node& qkv_reshape,
+                                           int64_t& num_heads, int64_t& head_size, int64_t& hidden_size) {
+  if (qkv_reshape.InputDefs().size() < 2) {
+    return false;
+  }
+
+  InlinedVector<int64_t> reshape_dims;
+  if (!optimizer_utils::AppendTensorFromInitializer(graph, *qkv_reshape.InputDefs()[1], reshape_dims, true)) {
+    return false;
+  }
+
+  if (reshape_dims.size() != 5 || reshape_dims[2] != 3 || reshape_dims[3] <= 0 || reshape_dims[4] <= 0) {
+    return false;
+  }
+
+  num_heads = reshape_dims[3];
+  head_size = reshape_dims[4];
+
+  try {
+    hidden_size = SafeInt<int64_t>(num_heads) * head_size;
+  } catch (const OnnxRuntimeException&) {
+    return false;
+  }
+
+  return hidden_size > 0;
+}
+
+static std::optional<ONNX_NAMESPACE::TypeProto> TryCreateMobileClipMhaOutputType(const NodeArg& qkv_output,
+                                                                                 int64_t hidden_size) {
+  const auto* qkv_output_type = qkv_output.TypeAsProto();
+  if (qkv_output_type == nullptr || !qkv_output_type->has_tensor_type()) {
+    return std::nullopt;
+  }
+
+  ONNX_NAMESPACE::TypeProto mha_output_type(*qkv_output_type);
+  auto* shape = mha_output_type.mutable_tensor_type()->mutable_shape();
+  if (shape->dim_size() > 0) {
+    auto* last_dim = shape->mutable_dim(shape->dim_size() - 1);
+    last_dim->clear_dim_param();
+    last_dim->set_dim_value(hidden_size);
+  }
+
+  return mha_output_type;
+}
+
+static Node* GetOnlyChildByOutputIndex(Graph& graph, const Node& node, size_t output_index, const char* child_op_type) {
+  const auto output_edges = graph_utils::GraphEdge::GetNodeOutputEdges(node, output_index);
+  if (output_edges.size() != 1) {
+    return nullptr;
+  }
+
+  Node* child = graph.GetNode(output_edges[0].dst_node);
+  if (child == nullptr || child->OpType() != child_op_type) {
+    return nullptr;
+  }
+
+  return child;
+}
+
+static bool TryCreateNormalizedProjectionGemm(Graph& graph,
+                                              NodeArg& projection_input,
+                                              const NodeArg& original_projection_input,
+                                              const NodeArg& proj_weight,
+                                              const NodeArg& proj_bias,
+                                              NodeArg& projection_output,
+                                              const std::string& base_name,
+                                              const std::string& provider_type) {
+  const auto* proj_input_shape = original_projection_input.Shape();
+  const auto* proj_weight_shape = proj_weight.Shape();
+  if (proj_input_shape == nullptr || proj_weight_shape == nullptr || proj_weight_shape->dim_size() != 2) {
+    return false;
+  }
+
+  auto input_shape = utils::GetTensorShapeFromTensorShapeProto(*proj_input_shape);
+  if (input_shape.Size() == -1 || input_shape.NumDimensions() < 2) {
+    return false;
+  }
+
+  const auto& dim_k = proj_weight_shape->dim(0);
+  const auto& dim_n = proj_weight_shape->dim(1);
+  if (!utils::HasDimValue(dim_k) || !utils::HasDimValue(dim_n)) {
+    return false;
+  }
+
+  const int64_t m = input_shape.SizeToDimension(input_shape.NumDimensions() - 1);
+  if (m <= 0) {
+    return false;
+  }
+
+  const int64_t k = dim_k.dim_value();
+  const int64_t n = dim_n.dim_value();
+  if (input_shape[input_shape.NumDimensions() - 1] != k) {
+    return false;
+  }
+
+  const auto* bias_shape = proj_bias.Shape();
+  if (bias_shape == nullptr || bias_shape->dim_size() != 1 || !utils::HasDimValue(bias_shape->dim(0)) ||
+      bias_shape->dim(0).dim_value() != n) {
+    return false;
+  }
+
+  const auto* input_type = original_projection_input.TypeAsProto();
+  if (input_type == nullptr || !input_type->has_tensor_type()) {
+    return false;
+  }
+
+  const auto element_type = static_cast<ONNX_NAMESPACE::TensorProto_DataType>(input_type->tensor_type().elem_type());
+
+  auto add_shape_initializer = [&](const std::string& name, const InlinedVector<int64_t>& shape) -> NodeArg& {
+    ONNX_NAMESPACE::TensorProto shape_initializer_proto;
+    shape_initializer_proto.set_name(graph.GenerateNodeArgName(name));
+    shape_initializer_proto.add_dims(static_cast<int64_t>(shape.size()));
+    shape_initializer_proto.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_INT64);
+    const size_t shape_bytes = SafeInt<size_t>(shape.size()) * sizeof(int64_t);
+    utils::SetRawDataInTensorProto(shape_initializer_proto, shape.data(), shape_bytes);
+    return graph_utils::AddInitializerWithOrtValue(graph, shape_initializer_proto);
+  };
+
+  auto make_tensor_arg = [&](const std::string& name, const InlinedVector<int64_t>& shape) -> NodeArg* {
+    ONNX_NAMESPACE::TypeProto type_proto;
+    type_proto.mutable_tensor_type()->set_elem_type(element_type);
+    for (int64_t dim_value : shape) {
+      type_proto.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(dim_value);
+    }
+
+    return &graph.GetOrCreateNodeArg(graph.GenerateNodeArgName(name), &type_proto);
+  };
+
+  InlinedVector<int64_t> gemm_input_shape{m, k};
+  InlinedVector<int64_t> gemm_output_shape{m, n};
+  InlinedVector<int64_t> output_shape_values = input_shape.AsShapeVector();
+  output_shape_values.back() = n;
+
+  NodeArg* gemm_input_arg = make_tensor_arg("mobileclip_proj_gemm_input", gemm_input_shape);
+  NodeArg* gemm_output_arg = make_tensor_arg("mobileclip_proj_gemm_output", gemm_output_shape);
+  NodeArg& gemm_input_shape_arg = add_shape_initializer("mobileclip_proj_gemm_input_shape", gemm_input_shape);
+  NodeArg& gemm_output_shape_arg = add_shape_initializer("mobileclip_proj_gemm_output_shape", output_shape_values);
+
+  Node& input_reshape = graph.AddNode(
+      graph.GenerateNodeName("MobileClipProjGemmInputReshape"),
+      "Reshape",
+      "Reshape MobileCLIP projection input for Gemm",
+      {&projection_input, &gemm_input_shape_arg},
+      {gemm_input_arg});
+  input_reshape.SetExecutionProviderType(provider_type);
+
+  Node& gemm_node = graph.AddNode(
+      graph.GenerateNodeName(base_name + "/MobileClipProjectionGemm"),
+      "Gemm",
+      "Normalized MobileCLIP projection Gemm",
+      {gemm_input_arg, const_cast<NodeArg*>(&proj_weight), const_cast<NodeArg*>(&proj_bias)},
+      {gemm_output_arg});
+  gemm_node.SetExecutionProviderType(provider_type);
+
+  Node& output_reshape = graph.AddNode(
+      graph.GenerateNodeName("MobileClipProjGemmOutputReshape"),
+      "Reshape",
+      "Restore MobileCLIP projection output shape after Gemm",
+      {gemm_output_arg, &gemm_output_shape_arg},
+      {&projection_output});
+  output_reshape.SetExecutionProviderType(provider_type);
+
+  return true;
+}
+
+static bool TryRewriteProjectionMatMulAddToGemm(Graph& graph,
+                                                NodeArg& projection_input,
+                                                Node& proj_matmul,
+                                                Node& proj_add) {
+  if (proj_matmul.InputDefs().size() < 2 || proj_add.InputDefs().size() < 2) {
+    return false;
+  }
+
+  const int bias_idx = proj_matmul.OutputDefs()[0]->Name() == proj_add.InputDefs()[0]->Name() ? 1 : 0;
+  return TryCreateNormalizedProjectionGemm(graph,
+                                           projection_input,
+                                           *proj_matmul.InputDefs()[0],
+                                           *proj_matmul.InputDefs()[1],
+                                           *proj_add.InputDefs()[bias_idx],
+                                           *proj_add.MutableOutputDefs()[0],
+                                           proj_matmul.Name(),
+                                           proj_matmul.GetExecutionProviderType());
+}
+
+static bool TryRewriteProjectionGemm(Graph& graph,
+                                     NodeArg& projection_input,
+                                     Node& proj_gemm) {
+  if (proj_gemm.InputDefs().size() < 3 || proj_gemm.OutputDefs().empty()) {
+    return false;
+  }
+
+  return TryCreateNormalizedProjectionGemm(graph,
+                                           projection_input,
+                                           *proj_gemm.InputDefs()[0],
+                                           *proj_gemm.InputDefs()[1],
+                                           *proj_gemm.InputDefs()[2],
+                                           *proj_gemm.MutableOutputDefs()[0],
+                                           proj_gemm.Name(),
+                                           proj_gemm.GetExecutionProviderType());
+}
+
+static bool TryFuseMobileClipMHA(Node& qkv_matmul,
+                                 Graph& graph,
+                                 const InlinedHashSet<std::string_view>& compatible_execution_providers,
+                                 const logging::Logger& logger) {
+  const auto fail = [&](const char* message) {
+    LOGS(logger, VERBOSE) << "MobileClipMHA[" << qkv_matmul.Name() << "]: fusion skipped: " << message;
+    return false;
+  };
+
+  if (!graph_utils::IsSupportedOptypeVersionAndDomain(qkv_matmul, "MatMul", {1, 9, 13}, kOnnxDomain)) {
+    return false;
+  }
+
+  if (!IsSupportedOrUnassignedNode(qkv_matmul, compatible_execution_providers)) {
+    return false;
+  }
+
+  if (!optimizer_utils::CheckOutputEdges(graph, qkv_matmul, 1) || qkv_matmul.InputDefs().size() < 2 ||
+      !graph_utils::IsInitializer(graph, qkv_matmul.InputDefs()[1]->Name(), true)) {
+    return fail("qkv MatMul output count or weight initializer check failed");
+  }
+
+  const Node* sequence_transpose = graph_utils::GetInputNode(qkv_matmul, 0);
+  if (sequence_transpose == nullptr ||
+      !graph_utils::IsSupportedOptypeVersionAndDomain(*sequence_transpose, "Transpose", {1, 13}, kOnnxDomain) ||
+      !HasExpectedPerm(*sequence_transpose, {0, 2, 1}) ||
+      !optimizer_utils::CheckOutputEdges(graph, *sequence_transpose, 1)) {
+    return false;
+  }
+
+  const Node* input_reshape = graph_utils::GetInputNode(*sequence_transpose, 0);
+  if (input_reshape == nullptr ||
+      !graph_utils::IsSupportedOptypeVersionAndDomain(*input_reshape, "Reshape", {5, 13, 14}, kOnnxDomain) ||
+      !optimizer_utils::CheckOutputEdges(graph, *input_reshape, 1)) {
+    return fail("missing input Reshape before sequence transpose");
+  }
+
+  Node* qkv_reshape = GetOnlyChildByOutputIndex(graph, qkv_matmul, 0, "Reshape");
+  if (qkv_reshape == nullptr ||
+      !graph_utils::IsSupportedOptypeVersionAndDomain(*qkv_reshape, "Reshape", {5, 13, 14}, kOnnxDomain) ||
+      !optimizer_utils::CheckOutputEdges(graph, *qkv_reshape, 1)) {
+    return fail("qkv Reshape after MatMul not matched");
+  }
+
+  Node* split = GetOnlyChildByOutputIndex(graph, *qkv_reshape, 0, "Split");
+  if (split == nullptr || !graph_utils::IsSupportedOptypeVersionAndDomain(*split, "Split", {13, 18}, kOnnxDomain) ||
+      split->OutputDefs().size() != 3 || !optimizer_utils::IsAttributeWithExpectedValue(*split, "axis", static_cast<int64_t>(2))) {
+    return fail("qkv Split(axis=2, outputs=3) not matched");
+  }
+
+  Node* q_transpose = GetOnlyChildByOutputIndex(graph, *split, 0, "Transpose");
+  Node* k_squeeze = GetOnlyChildByOutputIndex(graph, *split, 1, "Squeeze");
+  Node* v_transpose = GetOnlyChildByOutputIndex(graph, *split, 2, "Transpose");
+  if (q_transpose == nullptr || k_squeeze == nullptr || v_transpose == nullptr ||
+      !graph_utils::IsSupportedOptypeVersionAndDomain(*q_transpose, "Transpose", {1, 13}, kOnnxDomain) ||
+      !graph_utils::IsSupportedOptypeVersionAndDomain(*k_squeeze, "Squeeze", {13}, kOnnxDomain) ||
+      !graph_utils::IsSupportedOptypeVersionAndDomain(*v_transpose, "Transpose", {1, 13}, kOnnxDomain) ||
+      !HasExpectedPerm(*q_transpose, {2, 0, 3, 1, 4}) ||
+      !HasExpectedPerm(*v_transpose, {2, 0, 3, 1, 4}) ||
+      !HasExpectedAxesInput(graph, *k_squeeze, {2})) {
+    return fail("q/k/v branch entry pattern after Split not matched");
+  }
+
+  Node* q_squeeze = GetOnlyChildByOutputIndex(graph, *q_transpose, 0, "Squeeze");
+  Node* v_squeeze = GetOnlyChildByOutputIndex(graph, *v_transpose, 0, "Squeeze");
+  if (q_squeeze == nullptr || v_squeeze == nullptr ||
+      !graph_utils::IsSupportedOptypeVersionAndDomain(*q_squeeze, "Squeeze", {13}, kOnnxDomain) ||
+      !graph_utils::IsSupportedOptypeVersionAndDomain(*v_squeeze, "Squeeze", {13}, kOnnxDomain) ||
+      !HasExpectedAxesInput(graph, *q_squeeze, {0}) ||
+      !HasExpectedAxesInput(graph, *v_squeeze, {0})) {
+    return fail("q/v squeeze pattern not matched");
+  }
+
+  Node* q_scale_mul = GetOnlyChildByOutputIndex(graph, *q_squeeze, 0, "Mul");
+  Node* k_transpose = GetOnlyChildByOutputIndex(graph, *k_squeeze, 0, "Transpose");
+  if (q_scale_mul == nullptr || k_transpose == nullptr ||
+      !graph_utils::IsSupportedOptypeVersionAndDomain(*q_scale_mul, "Mul", {7, 13, 14}, kOnnxDomain) ||
+      !graph_utils::IsSupportedOptypeVersionAndDomain(*k_transpose, "Transpose", {1, 13}, kOnnxDomain) ||
+      !HasExpectedPerm(*k_transpose, {0, 2, 3, 1})) {
+    return fail("q scale Mul or k Transpose(0,2,3,1) not matched");
+  }
+
+  float scale = 0.0f;
+  if (q_scale_mul->InputDefs().size() < 2) {
+    return fail("q scale constant not found");
+  }
+
+  const NodeArg* q_squeeze_output = q_squeeze->OutputDefs()[0];
+  const NodeArg* mul_input_0 = q_scale_mul->InputDefs()[0];
+  const NodeArg* mul_input_1 = q_scale_mul->InputDefs()[1];
+  const bool input_0_is_q_squeeze = mul_input_0 != nullptr && q_squeeze_output != nullptr &&
+                                    mul_input_0->Name() == q_squeeze_output->Name();
+  const bool input_1_is_q_squeeze = mul_input_1 != nullptr && q_squeeze_output != nullptr &&
+                                    mul_input_1->Name() == q_squeeze_output->Name();
+
+  const NodeArg* scale_input = nullptr;
+  if (input_0_is_q_squeeze && !input_1_is_q_squeeze) {
+    scale_input = mul_input_1;
+  } else if (input_1_is_q_squeeze && !input_0_is_q_squeeze) {
+    scale_input = mul_input_0;
+  }
+
+  if (scale_input == nullptr ||
+      !optimizer_utils::GetScalarInitializerValue<float>(graph, *scale_input, scale, true)) {
+    return fail("q scale constant not found");
+  }
+
+  Node* qk_matmul = GetOnlyChildByOutputIndex(graph, *q_scale_mul, 0, "MatMul");
+  if (qk_matmul == nullptr ||
+      !graph_utils::IsSupportedOptypeVersionAndDomain(*qk_matmul, "MatMul", {1, 9, 13}, kOnnxDomain) ||
+      graph_utils::GetInputNode(*qk_matmul, 1) == nullptr ||
+      graph_utils::GetInputNode(*qk_matmul, 1)->Index() != k_transpose->Index() ||
+      !optimizer_utils::CheckOutputEdges(graph, *qk_matmul, 1)) {
+    return fail("qk MatMul not matched");
+  }
+
+  Node* softmax = GetOnlyChildByOutputIndex(graph, *qk_matmul, 0, "Softmax");
+  if (softmax == nullptr ||
+      !graph_utils::IsSupportedOptypeVersionAndDomain(*softmax, "Softmax", {1, 11, 13}, kOnnxDomain) ||
+      !optimizer_utils::IsAttributeWithExpectedValue(*softmax, "axis", static_cast<int64_t>(-1)) ||
+      !optimizer_utils::CheckOutputEdges(graph, *softmax, 1)) {
+    return fail("Softmax(axis=-1) not matched");
+  }
+
+  Node* qkv_matmul_1 = GetOnlyChildByOutputIndex(graph, *softmax, 0, "MatMul");
+  if (qkv_matmul_1 == nullptr ||
+      !graph_utils::IsSupportedOptypeVersionAndDomain(*qkv_matmul_1, "MatMul", {1, 9, 13}, kOnnxDomain) ||
+      graph_utils::GetInputNode(*qkv_matmul_1, 1) == nullptr ||
+      graph_utils::GetInputNode(*qkv_matmul_1, 1)->Index() != v_squeeze->Index() ||
+      !optimizer_utils::CheckOutputEdges(graph, *qkv_matmul_1, 1)) {
+    return fail("attention-value MatMul not matched");
+  }
+
+  Node* transpose_3 = GetOnlyChildByOutputIndex(graph, *qkv_matmul_1, 0, "Transpose");
+  if (transpose_3 == nullptr ||
+      !graph_utils::IsSupportedOptypeVersionAndDomain(*transpose_3, "Transpose", {1, 13}, kOnnxDomain) ||
+      !HasExpectedPerm(*transpose_3, {0, 2, 1, 3}) ||
+      !optimizer_utils::CheckOutputEdges(graph, *transpose_3, 1)) {
+    return fail("output Transpose(0,2,1,3) not matched");
+  }
+
+  Node* reshape_2 = GetOnlyChildByOutputIndex(graph, *transpose_3, 0, "Reshape");
+  if (reshape_2 == nullptr ||
+      !graph_utils::IsSupportedOptypeVersionAndDomain(*reshape_2, "Reshape", {5, 13, 14}, kOnnxDomain) ||
+      !optimizer_utils::CheckOutputEdges(graph, *reshape_2, 1)) {
+    return fail("output Reshape not matched");
+  }
+
+  Node* proj_matmul = GetOnlyChildByOutputIndex(graph, *reshape_2, 0, "MatMul");
+  Node* proj_gemm = proj_matmul == nullptr ? GetOnlyChildByOutputIndex(graph, *reshape_2, 0, "Gemm") : nullptr;
+  Node* proj_gemm_input_reshape = nullptr;
+  Node* proj_gemm_output_reshape = nullptr;
+  Node* proj_add = nullptr;
+
+  if (proj_matmul != nullptr) {
+    if (!graph_utils::IsSupportedOptypeVersionAndDomain(*proj_matmul, "MatMul", {1, 9, 13}, kOnnxDomain) ||
+        proj_matmul->InputDefs().size() < 2 ||
+        !graph_utils::IsInitializer(graph, proj_matmul->InputDefs()[1]->Name(), true) ||
+        !optimizer_utils::CheckOutputEdges(graph, *proj_matmul, 1)) {
+      return fail("projection MatMul not matched");
+    }
+
+    proj_add = GetOnlyChildByOutputIndex(graph, *proj_matmul, 0, "Add");
+    if (proj_add == nullptr ||
+        !graph_utils::IsSupportedOptypeVersionAndDomain(*proj_add, "Add", {7, 13, 14}, kOnnxDomain) ||
+        !optimizer_utils::CheckOutputEdges(graph, *proj_add, 1)) {
+      return fail("projection Add not matched");
+    }
+  } else {
+    if (proj_gemm == nullptr) {
+      proj_gemm_input_reshape = GetOnlyChildByOutputIndex(graph, *reshape_2, 0, "Reshape");
+      if (proj_gemm_input_reshape == nullptr ||
+          !graph_utils::IsSupportedOptypeVersionAndDomain(*proj_gemm_input_reshape, "Reshape", {5, 13, 14}, kOnnxDomain) ||
+          !optimizer_utils::CheckOutputEdges(graph, *proj_gemm_input_reshape, 1)) {
+        return fail("projection MatMul/Gemm not matched");
+      }
+
+      proj_gemm = GetOnlyChildByOutputIndex(graph, *proj_gemm_input_reshape, 0, "Gemm");
+      if (proj_gemm == nullptr ||
+          !graph_utils::IsSupportedOptypeVersionAndDomain(*proj_gemm, "Gemm", {7, 9, 11, 13}, kOnnxDomain) ||
+          !optimizer_utils::CheckOutputEdges(graph, *proj_gemm, 1)) {
+        return fail("projection MatMul/Gemm not matched");
+      }
+
+      proj_gemm_output_reshape = GetOnlyChildByOutputIndex(graph, *proj_gemm, 0, "Reshape");
+      if (proj_gemm_output_reshape == nullptr ||
+          !graph_utils::IsSupportedOptypeVersionAndDomain(*proj_gemm_output_reshape, "Reshape", {5, 13, 14}, kOnnxDomain) ||
+          !optimizer_utils::CheckOutputEdges(graph, *proj_gemm_output_reshape, 1)) {
+        return fail("normalized projection Gemm output Reshape not matched");
+      }
+    } else if (!graph_utils::IsSupportedOptypeVersionAndDomain(*proj_gemm, "Gemm", {7, 9, 11, 13}, kOnnxDomain) ||
+               !optimizer_utils::CheckOutputEdges(graph, *proj_gemm, 1)) {
+      return fail("projection MatMul/Gemm not matched");
+    }
+  }
+
+  int64_t num_heads = 0;
+  int64_t head_size = 0;
+  int64_t hidden_size = 0;
+  if (!TryGetMobileClipQkvReshapeInfo(graph, *qkv_reshape, num_heads, head_size, hidden_size)) {
+    return fail("unable to derive num_heads/head_size from qkv reshape initializer");
+  }
+
+  if (proj_matmul != nullptr) {
+    if (!ValidateMatMulInitializer(graph, *proj_matmul, hidden_size) ||
+        !ValidateAddBiasInitializerEitherInput(graph, *proj_add, hidden_size)) {
+      return fail("projection weight/bias shape validation failed");
+    }
+  } else {
+    if (!ValidateProjectionGemmInitializer(graph, *proj_gemm, hidden_size)) {
+      return fail("projection Gemm weight/bias shape validation failed");
+    }
+  }
+
+  const NodeArg& qkv_weight = *qkv_matmul.InputDefs()[1];
+  if (!optimizer_utils::ValidateShape(qkv_weight, {hidden_size, 3 * hidden_size})) {
+    return fail("qkv weight shape is not [hidden, 3*hidden]");
+  }
+
+  if (!AreSupportedOrUnassignedNodes(
+          qkv_matmul,
+          {sequence_transpose,
+           input_reshape,
+           qkv_reshape,
+           split,
+           q_transpose,
+           k_squeeze,
+           v_transpose,
+           q_squeeze,
+           v_squeeze,
+           q_scale_mul,
+           k_transpose,
+           qk_matmul,
+           softmax,
+           qkv_matmul_1,
+           transpose_3,
+           reshape_2,
+           proj_matmul,
+           proj_add,
+           proj_gemm_input_reshape,
+           proj_gemm,
+           proj_gemm_output_reshape},
+          compatible_execution_providers)) {
+    return fail("matched nodes are assigned to incompatible execution providers");
+  }
+
+  auto mha_output_type = TryCreateMobileClipMhaOutputType(*qkv_matmul.OutputDefs()[0], hidden_size);
+  auto* mha_output = &graph.GetOrCreateNodeArg(
+      graph.GenerateNodeArgName("mobileclip_mha_output"),
+      mha_output_type ? &*mha_output_type : nullptr);
+
+  if (proj_matmul != nullptr) {
+    if (!TryRewriteProjectionMatMulAddToGemm(graph, *mha_output, *proj_matmul, *proj_add)) {
+      return fail("projection MatMul/Add could not be rewritten to Gemm");
+    }
+  } else if (proj_gemm_input_reshape == nullptr) {
+    if (!TryRewriteProjectionGemm(graph, *mha_output, *proj_gemm)) {
+      return fail("projection Gemm could not be normalized");
+    }
+  }
+
+  ONNX_NAMESPACE::TensorProto split_sizes_tensor;
+  split_sizes_tensor.set_name(graph.GenerateNodeArgName("mobileclip_mha_split_sizes"));
+  split_sizes_tensor.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_INT64);
+  split_sizes_tensor.add_dims(3);
+  const std::array<int64_t, 3> split_sizes{hidden_size, hidden_size, hidden_size};
+  utils::SetRawDataInTensorProto(split_sizes_tensor, split_sizes.data(), split_sizes.size() * sizeof(int64_t));
+  NodeArg& split_sizes_arg = graph_utils::AddInitializerWithOrtValue(graph, split_sizes_tensor);
+
+  auto* mha_q = &graph.GetOrCreateNodeArg(graph.GenerateNodeArgName("mobileclip_mha_q"), nullptr);
+  auto* mha_k = &graph.GetOrCreateNodeArg(graph.GenerateNodeArgName("mobileclip_mha_k"), nullptr);
+  auto* mha_v = &graph.GetOrCreateNodeArg(graph.GenerateNodeArgName("mobileclip_mha_v"), nullptr);
+
+  Node& split_for_mha = graph.AddNode(
+      graph.GenerateNodeName("MobileClipSplitForMHA"),
+      "Split",
+      "Split packed MobileCLIP QKV for MultiHeadAttention",
+      {qkv_matmul.MutableOutputDefs()[0], &split_sizes_arg},
+      {mha_q, mha_k, mha_v},
+      nullptr,
+      kOnnxDomain);
+  split_for_mha.AddAttribute("axis", static_cast<int64_t>(2));
+
+  Node& mha_node = graph.AddNode(
+      graph.GenerateNodeName("MobileClipMultiHeadAttention"),
+      "MultiHeadAttention",
+      "Fused MobileCLIP attention subgraph",
+      {mha_q, mha_k, mha_v},
+      {mha_output},
+      nullptr,
+      kMSDomain);
+  mha_node.AddAttribute("num_heads", num_heads);
+  mha_node.AddAttribute("scale", scale);
+
+  const auto& provider = qkv_matmul.GetExecutionProviderType();
+  split_for_mha.SetExecutionProviderType(provider);
+  mha_node.SetExecutionProviderType(provider);
+
+  if (proj_gemm_input_reshape != nullptr) {
+    graph_utils::ReplaceDownstreamNodeInput(graph, *reshape_2, 0, mha_node, 0);
+  }
+
+  std::vector<NodeIndex> nodes_to_remove{
+      qkv_reshape->Index(),
+      split->Index(),
+      q_transpose->Index(),
+      q_squeeze->Index(),
+      q_scale_mul->Index(),
+      k_squeeze->Index(),
+      k_transpose->Index(),
+      qk_matmul->Index(),
+      softmax->Index(),
+      v_transpose->Index(),
+      v_squeeze->Index(),
+      qkv_matmul_1->Index(),
+      transpose_3->Index(),
+      reshape_2->Index(),
+  };
+
+  if (proj_matmul != nullptr) {
+    nodes_to_remove.push_back(proj_matmul->Index());
+    nodes_to_remove.push_back(proj_add->Index());
+  } else if (proj_gemm_input_reshape == nullptr) {
+    nodes_to_remove.push_back(proj_gemm->Index());
+  }
+
+  for (const auto& node_index : nodes_to_remove) {
+    Node* node = graph.GetNode(node_index);
+    if (node == nullptr) {
+      continue;
+    }
+
+    graph_utils::RemoveNodeOutputEdges(graph, *node);
+    graph.RemoveNode(node_index);
+  }
+
+  LOGS(logger, VERBOSE) << "MobileClipMHA[" << qkv_matmul.Name()
+                        << "]: fused MobileCLIP attention subgraph to MultiHeadAttention";
+
+  return true;
+}
+
+}  // namespace
 
 static bool ValidateMatMulInitializer(const Graph& graph, const Node& matmul, int64_t hidden_size) {
   const NodeArg& input_b = *(matmul.InputDefs()[1]);
@@ -178,6 +836,12 @@ Status AttentionFusion::ApplyImpl(Graph& graph, bool& modified, int graph_level,
 
     Node& node = *p_node;
     ORT_RETURN_IF_ERROR(Recurse(node, modified, graph_level, logger));
+
+    if (TryFuseMobileClipMHA(node, graph, GetCompatibleExecutionProviders(), logger)) {
+      fused_count++;
+      modified = true;
+      continue;
+    }
 
     // Add node.GetOutputEdgesCount() == 5/6 for distilbert
     if ((node.GetOutputEdgesCount() >= 2 && node.GetOutputEdgesCount() <= 6) &&

--- a/onnxruntime/core/optimizer/transpose_optimization/optimizer_api.h
+++ b/onnxruntime/core/optimizer/transpose_optimization/optimizer_api.h
@@ -478,7 +478,7 @@ class GraphRef {
 }  // namespace api
 
 constexpr int64_t kMinSupportedOpset = 7;
-constexpr int64_t kMaxSupportedOpset = 25;
+constexpr int64_t kMaxSupportedOpset = 26;
 
 // enum of results that a CostCheckFn can return.
 enum class CostCheckResult {

--- a/onnxruntime/core/platform/windows/dll_load_error.cc
+++ b/onnxruntime/core/platform/windows/dll_load_error.cc
@@ -47,10 +47,24 @@ std::wstring DetermineLoadLibraryError(const wchar_t* filename_in, DWORD flags) 
     flags = 0;  // Dependent libraries are relative, and flags like LOAD_WITH_ALTERED_SEARCH_PATH is undefined for those.
     for (; import_desc->Characteristics; import_desc++) {
       const char* dll_name = reinterpret_cast<const char*>(reinterpret_cast<const BYTE*>(hModule.get()) + import_desc->Name);
+
+      // Convert the narrow (ANSI) DLL name to a wide string for the W API.
+      // PE import table names are ANSI strings, so CP_ACP is the correct code page.
+      int wide_len = MultiByteToWideChar(CP_ACP, 0, dll_name, -1, nullptr, 0);
+      if (wide_len <= 0) {
+        continue;  // Skip this entry if conversion fails.
+      }
+      std::wstring wide_dll_name(wide_len, L'\0');  // wide_len includes the null terminator
+      int converted = MultiByteToWideChar(CP_ACP, 0, dll_name, -1, wide_dll_name.data(), wide_len);
+      if (converted <= 0) {
+        continue;  // Skip this entry if conversion fails.
+      }
+      wide_dll_name.resize(static_cast<size_t>(converted - 1));
+
       // Try to load the dependent DLL, and if it fails, we loop again with this as the DLL and we'll be one step closer to the missing file.
-      ModulePtr hDepModule{LoadLibrary(dll_name)};
+      ModulePtr hDepModule{LoadLibraryW(wide_dll_name.c_str())};
       if (!hDepModule) {
-        filename = std::wstring(dll_name, dll_name + strlen(dll_name));
+        filename = wide_dll_name;
         error += L" which depends on";
         break;
       }

--- a/onnxruntime/core/providers/acl/math/matmul.cc
+++ b/onnxruntime/core/providers/acl/math/matmul.cc
@@ -269,6 +269,7 @@ Status MatMul::PrePack(const Tensor& tensor, int input_idx, AllocatorPtr alloc,
 }
 
 Status MatMul::UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                         gsl::span<const size_t> /*prepacked_buffer_sizes*/,
                                          int input_idx, /*out*/ bool& used_shared_buffers) {
   used_shared_buffers = false;
   if (input_idx != 1) {

--- a/onnxruntime/core/providers/acl/math/matmul.h
+++ b/onnxruntime/core/providers/acl/math/matmul.h
@@ -34,6 +34,7 @@ class MatMul : public OpKernel {
                  bool& is_packed, PrePackedWeights*) override;
 
   Status UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>&,
+                                   gsl::span<const size_t>,
                                    int, bool&) override;
 
   Status Compute(OpKernelContext* context) const override;

--- a/onnxruntime/core/providers/acl/nn/conv.cc
+++ b/onnxruntime/core/providers/acl/nn/conv.cc
@@ -370,6 +370,7 @@ Status Conv::PrePack(const Tensor& tensor, int input_idx, AllocatorPtr alloc,
 }
 
 Status Conv::UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                       gsl::span<const size_t> /*prepacked_buffer_sizes*/,
                                        int input_idx, /*out*/ bool& used_shared_buffers) {
   used_shared_buffers = false;
   if (isQuantized ? (input_idx != 3) : (input_idx != 1)) {

--- a/onnxruntime/core/providers/acl/nn/conv.h
+++ b/onnxruntime/core/providers/acl/nn/conv.h
@@ -36,6 +36,7 @@ class Conv : public onnxruntime::OpKernel {
                  bool& is_packed, PrePackedWeights*) override;
 
   Status UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>&,
+                                   gsl::span<const size_t>,
                                    int, bool&) override;
 
   Status Compute(OpKernelContext* context) const override;

--- a/onnxruntime/core/providers/cpu/cpu_execution_provider.cc
+++ b/onnxruntime/core/providers/cpu/cpu_execution_provider.cc
@@ -1501,6 +1501,15 @@ class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 25, Un
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 25, Scan);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 25, Size);
 
+// Opset 26
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 26, BitCast);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 26, float, CumProd);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 26, double, CumProd);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 26, int32_t, CumProd);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 26, int64_t, CumProd);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 26, uint32_t, CumProd);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 26, uint64_t, CumProd);
+
 // !!PLEASE READ BELOW!! Following that, add new entries above this comment
 
 /*  *** IMPORTANT! ***
@@ -3669,6 +3678,15 @@ Status RegisterOnnxOperatorKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 25, Squeeze)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 25, Transpose)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 25, Unsqueeze)>,
+
+      // opset 26
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 26, BitCast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 26, float, CumProd)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 26, double, CumProd)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 26, int32_t, CumProd)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 26, int64_t, CumProd)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 26, uint32_t, CumProd)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 26, uint64_t, CumProd)>,
   };
   for (auto& function_table_entry : function_table) {
     KernelCreateInfo info = function_table_entry();

--- a/onnxruntime/core/providers/cpu/fp16/fp16_conv.cc
+++ b/onnxruntime/core/providers/cpu/fp16/fp16_conv.cc
@@ -54,6 +54,7 @@ class FusedConvFp16 final : public OpKernel {
                  /*out*/ bool& is_packed, /*out*/ PrePackedWeights* prepacked_weights) override;
 
   Status UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                   gsl::span<const size_t> /*prepacked_buffer_sizes*/,
                                    int input_idx,
                                    /*out*/ bool& used_shared_buffers) override;
 
@@ -211,6 +212,7 @@ Status FusedConvFp16::PrePack(const Tensor& tensor, int input_idx, AllocatorPtr 
 }
 
 Status FusedConvFp16::UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                                gsl::span<const size_t> /*prepacked_buffer_sizes*/,
                                                 int input_idx,
                                                 /*out*/ bool& used_shared_buffers) {
   if (input_idx != 1) {

--- a/onnxruntime/core/providers/cpu/llm/attention.cc
+++ b/onnxruntime/core/providers/cpu/llm/attention.cc
@@ -3,6 +3,7 @@
 
 #include "core/providers/cpu/llm/attention.h"
 #include "core/providers/cpu/llm/attention_helper.h"
+#include "core/providers/cpu/llm/attention_softmax.h"
 
 #include "core/common/common.h"
 #include "core/common/safeint.h"
@@ -75,23 +76,6 @@ void make_copy<MLFloat16, bool>(MLFloat16* mask_data, const bool* mask_index, si
   for (size_t i = 0; i < size; ++i) {
     mask_data[i] = mask_index[i] ? MLFloat16(0.f) : mask_filter_value<MLFloat16>();
   }
-}
-
-template <typename T>
-inline void ComputeAttentionSoftmaxInplace(T* score, int N, int D, ThreadPool* tp, AllocatorPtr) {
-  MlasComputeSoftmax(score, score, N, D, false, false, 0.0f, tp);
-}
-
-template <>
-inline void ComputeAttentionSoftmaxInplace<MLFloat16>(MLFloat16* score, int N, int D, ThreadPool* tp, AllocatorPtr allocator) {
-  ORT_ENFORCE(tp == nullptr, "No parallelized version of softmax for float16.");
-  // Mlas Lacks kernels for fp16 softmax, we convert into float32 and call the float32 version.
-  void* allocated_ptr = allocator->Alloc(static_cast<size_t>(N * D * sizeof(float)));
-  BufferUniquePtr float_buffer(allocated_ptr, BufferDeleter(allocator));
-  float* ptr = reinterpret_cast<float*>(allocated_ptr);
-  MlasConvertHalfToFloatBuffer(score, ptr, N * D);
-  MlasComputeSoftmax(ptr, ptr, N, D, false, false, 0.0f, tp);
-  MlasConvertFloatToHalfBuffer(ptr, score, N * D);
 }
 
 template <typename T>

--- a/onnxruntime/core/providers/cpu/llm/attention_softmax.h
+++ b/onnxruntime/core/providers/cpu/llm/attention_softmax.h
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/common/common.h"
+#include "core/common/float16.h"
+#include "core/common/safeint.h"
+#include "core/framework/allocator.h"
+#include "core/framework/buffer_deleter.h"
+#include "core/mlas/inc/mlas.h"
+#include "core/platform/threadpool.h"
+
+namespace onnxruntime {
+
+template <typename T>
+inline void ComputeAttentionSoftmaxInplace(T* score, size_t N, size_t D,
+                                           concurrency::ThreadPool* tp, AllocatorPtr) {
+  MlasComputeSoftmax(score, score, N, D, false, false, 0.0f, tp);
+}
+
+template <>
+inline void ComputeAttentionSoftmaxInplace<MLFloat16>(MLFloat16* score, size_t N, size_t D,
+                                                      concurrency::ThreadPool* tp, AllocatorPtr allocator) {
+  ORT_ENFORCE(tp == nullptr, "No parallelized version of softmax for float16.");
+  // MLAS lacks kernels for fp16 softmax, so we convert to float32 and use the float32 version.
+  auto num_elements = SafeInt<size_t>(N) * D;
+  void* allocated_ptr = allocator->Alloc(num_elements * sizeof(float));
+  BufferUniquePtr float_buffer(allocated_ptr, BufferDeleter(allocator));
+  float* ptr = reinterpret_cast<float*>(allocated_ptr);
+  MlasConvertHalfToFloatBuffer(score, ptr, num_elements);
+  MlasComputeSoftmax(ptr, ptr, N, D, false, false, 0.0f, tp);
+  MlasConvertFloatToHalfBuffer(ptr, score, num_elements);
+}
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cpu/math/cumprod.cc
+++ b/onnxruntime/core/providers/cpu/math/cumprod.cc
@@ -1,0 +1,246 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <functional>
+#include <numeric>
+
+#include "cumprod.h"
+#include "core/providers/common.h"
+#include "core/providers/cpu/tensor/utils.h"
+#include "core/framework/op_kernel.h"
+#include "core/framework/tensorprotoutils.h"
+#include "core/platform/threadpool.h"
+
+namespace onnxruntime {
+
+namespace cumprod_op {
+Status GetAxis(const Tensor* axis_tensor, int64_t input_rank, int64_t& axis_out) {
+  if (!axis_tensor)
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Axis tensor must be provided to the CumProd op");
+
+  if (axis_tensor->Shape().NumDimensions() > 1 || axis_tensor->Shape().Size() != 1)
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "Axis tensor must be a scalar (0-D) or 1-D tensor with exactly one element");
+
+  if (axis_tensor->IsDataType<int32_t>()) {
+    axis_out = static_cast<int64_t>(axis_tensor->Data<int32_t>()[0]);
+  } else if (axis_tensor->IsDataType<int64_t>()) {
+    axis_out = axis_tensor->Data<int64_t>()[0];
+  } else {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Axis tensor should be of type `int32_t` or `int64_t`");
+  }
+
+  axis_out = HandleNegativeAxis(axis_out, input_rank);
+
+  return Status::OK();
+}
+
+}  // namespace cumprod_op
+
+// Opset 26 kernels
+ONNX_CPU_OPERATOR_TYPED_KERNEL(
+    CumProd,
+    26,
+    float,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>())
+        .TypeConstraint("T2", std::vector<MLDataType>{DataTypeImpl::GetTensorType<int32_t>(),
+                                                      DataTypeImpl::GetTensorType<int64_t>()}),
+    CumProd<float>);
+
+ONNX_CPU_OPERATOR_TYPED_KERNEL(
+    CumProd,
+    26,
+    double,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<double>())
+        .TypeConstraint("T2", std::vector<MLDataType>{DataTypeImpl::GetTensorType<int32_t>(),
+                                                      DataTypeImpl::GetTensorType<int64_t>()}),
+    CumProd<double>);
+
+ONNX_CPU_OPERATOR_TYPED_KERNEL(
+    CumProd,
+    26,
+    int32_t,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<int32_t>())
+        .TypeConstraint("T2", std::vector<MLDataType>{DataTypeImpl::GetTensorType<int32_t>(),
+                                                      DataTypeImpl::GetTensorType<int64_t>()}),
+    CumProd<int32_t>);
+
+ONNX_CPU_OPERATOR_TYPED_KERNEL(
+    CumProd,
+    26,
+    int64_t,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<int64_t>())
+        .TypeConstraint("T2", std::vector<MLDataType>{DataTypeImpl::GetTensorType<int32_t>(),
+                                                      DataTypeImpl::GetTensorType<int64_t>()}),
+    CumProd<int64_t>);
+
+ONNX_CPU_OPERATOR_TYPED_KERNEL(
+    CumProd,
+    26,
+    uint32_t,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<uint32_t>())
+        .TypeConstraint("T2", std::vector<MLDataType>{DataTypeImpl::GetTensorType<int32_t>(),
+                                                      DataTypeImpl::GetTensorType<int64_t>()}),
+    CumProd<uint32_t>);
+
+ONNX_CPU_OPERATOR_TYPED_KERNEL(
+    CumProd,
+    26,
+    uint64_t,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<uint64_t>())
+        .TypeConstraint("T2", std::vector<MLDataType>{DataTypeImpl::GetTensorType<int32_t>(),
+                                                      DataTypeImpl::GetTensorType<int64_t>()}),
+    CumProd<uint64_t>);
+
+template <typename T>
+CumProd<T>::CumProd(const OpKernelInfo& info) : OpKernel(info), exclusive_(), reverse_() {
+  int64_t exclusive = 0;
+  auto status = info.GetAttr("exclusive", &exclusive);
+  if (status.IsOK()) {
+    ORT_ENFORCE(exclusive == 0 || exclusive == 1, "exclusive attribute must be 0 or 1, got: ", exclusive);
+    exclusive_ = exclusive;
+  }
+  int64_t reverse = 0;
+  status = info.GetAttr("reverse", &reverse);
+  if (status.IsOK()) {
+    ORT_ENFORCE(reverse == 0 || reverse == 1, "reverse attribute must be 0 or 1, got: ", reverse);
+    reverse_ = reverse;
+  }
+}
+
+template <typename T>
+Status CumProd<T>::Compute(OpKernelContext* ctx) const {
+  const Tensor* input = ctx->Input<Tensor>(0);
+  int64_t rank = static_cast<int64_t>(input->Shape().NumDimensions());
+  if (rank == 0)
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Cannot apply CumProd operator on a scalar");
+
+  const Tensor* axis_tensor = ctx->Input<Tensor>(1);
+
+  TensorShape output_shape(input->Shape());
+  auto& output_tensor = *ctx->Output(0, output_shape);
+
+  if (output_shape.Size() == 0)
+    return Status::OK();
+
+  int64_t axis_input = 0;
+  ORT_THROW_IF_ERROR(cumprod_op::GetAxis(axis_tensor, rank, axis_input));
+
+  // We solve the problem by using the identity that (in the case of exclusive)
+  // 1) out[upper_dims...][0][lower_dims...] = 1
+  // 2) out[upper_dims...][i][lower_dims...] =
+  //      in[upper_dims...][i-1][lower_dims...] * out[upper_dims...][i-1][lower_dims...]
+  // We loop through the [upper_dims...] and start applying the identity in each slice.
+  // Since the [lower_dims...] are adjacent in memory, we can multiply them like vectors.
+
+  const auto input_shape = input->Shape().GetDims();
+  const size_t axis = onnxruntime::narrow<size_t>(axis_input);
+  const int64_t dim = input->Shape()[axis];  // dimension size for the axis
+  const int64_t upper_dim_count =            // number of slices we can walk through iteratively
+      std::accumulate(input_shape.begin(), input_shape.begin() + axis, static_cast<int64_t>(1), std::multiplies<int64_t>());
+  const int64_t lower_dim_size =  // sizes of the slices we can treat as 1D arrays
+      std::accumulate(input_shape.begin() + axis + 1, input_shape.end(), static_cast<int64_t>(1), std::multiplies<int64_t>());
+
+  const T* input_data = input->Data<T>();
+  T* output_data = output_tensor.MutableData<T>();
+  const int64_t slice_size = dim * lower_dim_size;
+  auto* tp = ctx->GetOperatorThreadPool();
+
+  if (!reverse_) {
+    if (exclusive_) {
+      concurrency::ThreadPool::TryBatchParallelFor(
+          tp, static_cast<int32_t>(upper_dim_count),
+          [&](ptrdiff_t outer) {
+            const int64_t base = outer * slice_size;
+            const T* in = input_data + base;
+            T* out = output_data + base;
+
+            for (int64_t inner = 0; inner < lower_dim_size; inner++) {
+              out[inner] = static_cast<T>(1);
+            }
+            for (int64_t cum_axis = 1; cum_axis < dim; cum_axis++) {
+              const int64_t curr_offset = cum_axis * lower_dim_size;
+              const int64_t prev_offset = (cum_axis - 1) * lower_dim_size;
+              for (int64_t inner = 0; inner < lower_dim_size; inner++) {
+                out[curr_offset + inner] = out[prev_offset + inner] * in[prev_offset + inner];
+              }
+            }
+          },
+          0);
+    } else {
+      concurrency::ThreadPool::TryBatchParallelFor(
+          tp, static_cast<int32_t>(upper_dim_count),
+          [&](ptrdiff_t outer) {
+            const int64_t base = outer * slice_size;
+            const T* in = input_data + base;
+            T* out = output_data + base;
+
+            for (int64_t inner = 0; inner < lower_dim_size; inner++) {
+              out[inner] = in[inner];
+            }
+            for (int64_t cum_axis = 1; cum_axis < dim; cum_axis++) {
+              const int64_t curr_offset = cum_axis * lower_dim_size;
+              const int64_t prev_offset = (cum_axis - 1) * lower_dim_size;
+              for (int64_t inner = 0; inner < lower_dim_size; inner++) {
+                out[curr_offset + inner] = out[prev_offset + inner] * in[curr_offset + inner];
+              }
+            }
+          },
+          0);
+    }
+  } else {
+    if (exclusive_) {
+      concurrency::ThreadPool::TryBatchParallelFor(
+          tp, static_cast<int32_t>(upper_dim_count),
+          [&](ptrdiff_t outer) {
+            const int64_t base = outer * slice_size;
+            const T* in = input_data + base;
+            T* out = output_data + base;
+
+            const int64_t last_offset = (dim - 1) * lower_dim_size;
+            for (int64_t inner = 0; inner < lower_dim_size; inner++) {
+              out[last_offset + inner] = static_cast<T>(1);
+            }
+            for (int64_t cum_axis = dim - 2; cum_axis >= 0; cum_axis--) {
+              const int64_t curr_offset = cum_axis * lower_dim_size;
+              const int64_t next_offset = (cum_axis + 1) * lower_dim_size;
+              for (int64_t inner = 0; inner < lower_dim_size; inner++) {
+                out[curr_offset + inner] = out[next_offset + inner] * in[next_offset + inner];
+              }
+            }
+          },
+          0);
+    } else {
+      concurrency::ThreadPool::TryBatchParallelFor(
+          tp, static_cast<int32_t>(upper_dim_count),
+          [&](ptrdiff_t outer) {
+            const int64_t base = outer * slice_size;
+            const T* in = input_data + base;
+            T* out = output_data + base;
+
+            const int64_t last_offset = (dim - 1) * lower_dim_size;
+            for (int64_t inner = 0; inner < lower_dim_size; inner++) {
+              out[last_offset + inner] = in[last_offset + inner];
+            }
+            for (int64_t cum_axis = dim - 2; cum_axis >= 0; cum_axis--) {
+              const int64_t curr_offset = cum_axis * lower_dim_size;
+              const int64_t next_offset = (cum_axis + 1) * lower_dim_size;
+              for (int64_t inner = 0; inner < lower_dim_size; inner++) {
+                out[curr_offset + inner] = out[next_offset + inner] * in[curr_offset + inner];
+              }
+            }
+          },
+          0);
+    }
+  }
+
+  return Status::OK();
+}
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cpu/math/cumprod.h
+++ b/onnxruntime/core/providers/cpu/math/cumprod.h
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/common/common.h"
+#include "core/framework/op_kernel.h"
+
+namespace onnxruntime {
+
+template <class T>
+class CumProd final : public OpKernel {
+ public:
+  explicit CumProd(const OpKernelInfo& op_kernel_info);
+
+  Status Compute(OpKernelContext* p_op_kernel_context) const override;
+
+ private:
+  int64_t exclusive_;
+  int64_t reverse_;
+};
+
+namespace cumprod_op {
+
+Status GetAxis(const Tensor* axis_tensor, int64_t input_rank, int64_t& axis_out);
+
+}  // namespace cumprod_op
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cpu/math/gemm.cc
+++ b/onnxruntime/core/providers/cpu/math/gemm.cc
@@ -296,6 +296,7 @@ Status Gemm<float>::PrePack(const Tensor& tensor, int input_idx,
 
 template <typename T>
 Status Gemm<T>::UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& /*prepacked_buffers*/,
+                                          gsl::span<const size_t> /*prepacked_buffer_sizes*/,
                                           int /*input_idx*/,
                                           /*out*/ bool& used_shared_buffers) {
   used_shared_buffers = false;
@@ -304,6 +305,7 @@ Status Gemm<T>::UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& /*prepac
 
 template <>
 Status Gemm<float>::UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                              gsl::span<const size_t> /*prepacked_buffer_sizes*/,
                                               int input_idx,
                                               /*out*/ bool& used_shared_buffers) {
   used_shared_buffers = false;

--- a/onnxruntime/core/providers/cpu/math/gemm.h
+++ b/onnxruntime/core/providers/cpu/math/gemm.h
@@ -37,6 +37,7 @@ class Gemm : protected GemmBase, public OpKernel {
                  /*out*/ PrePackedWeights* prepacked_weights) override;
 
   Status UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                   gsl::span<const size_t> /*prepacked_buffer_sizes*/,
                                    int input_idx,
                                    /*out*/ bool& used_shared_buffers) override;
 

--- a/onnxruntime/core/providers/cpu/math/matmul.cc
+++ b/onnxruntime/core/providers/cpu/math/matmul.cc
@@ -220,6 +220,7 @@ Status MatMul<float>::PrePack(const Tensor& tensor, int input_idx, /*out*/ Alloc
 }
 
 Status MatMul<float>::UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                                gsl::span<const size_t> /*prepacked_buffer_sizes*/,
                                                 int input_idx,
                                                 /*out*/ bool& used_shared_buffers) {
   used_shared_buffers = false;

--- a/onnxruntime/core/providers/cpu/math/matmul.h
+++ b/onnxruntime/core/providers/cpu/math/matmul.h
@@ -47,7 +47,9 @@ class MatMul<float> final : public OpKernel {
                  /*out*/ bool& is_packed,
                  /*out*/ PrePackedWeights* prepacked_weights) override;
 
-  Status UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers, int input_idx,
+  Status UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                   gsl::span<const size_t> /*prepacked_buffer_sizes*/,
+                                   int input_idx,
                                    /*out*/ bool& used_shared_buffers) override;
 
   Status Compute(OpKernelContext* context) const override;

--- a/onnxruntime/core/providers/cpu/nn/conv_transpose.cc
+++ b/onnxruntime/core/providers/cpu/nn/conv_transpose.cc
@@ -102,6 +102,7 @@ Status ConvTranspose<float>::PrePack(const Tensor& tensor, int input_idx, Alloca
 
 template <typename T>
 Status ConvTranspose<T>::UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& /*prepacked_buffers*/,
+                                                   gsl::span<const size_t> /*prepacked_buffer_sizes*/,
                                                    int /*input_idx*/,
                                                    /*out*/ bool& used_shared_buffers) {
   used_shared_buffers = false;
@@ -110,6 +111,7 @@ Status ConvTranspose<T>::UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>&
 
 template <>
 Status ConvTranspose<float>::UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                                       gsl::span<const size_t> /*prepacked_buffer_sizes*/,
                                                        int input_idx,
                                                        /*out*/ bool& used_shared_buffers) {
   used_shared_buffers = false;

--- a/onnxruntime/core/providers/cpu/nn/conv_transpose.h
+++ b/onnxruntime/core/providers/cpu/nn/conv_transpose.h
@@ -35,6 +35,7 @@ class ConvTranspose : public OpKernel {
                  /*out*/ PrePackedWeights* prepacked_weights) override;
 
   Status UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                   gsl::span<const size_t> /*prepacked_buffer_sizes*/,
                                    int input_idx,
                                    /*out*/ bool& used_shared_buffers) override;
 

--- a/onnxruntime/core/providers/cpu/nn/lrn.cc
+++ b/onnxruntime/core/providers/cpu/nn/lrn.cc
@@ -18,14 +18,11 @@
 #include "core/providers/cpu/nn/lrn.h"
 #include "core/providers/cpu/element_wise_ranged_transform.h"
 
+#include "core/common/narrow.h"
 #include "core/common/safeint.h"
 #include "core/util/math.h"
 #include "core/util/math_cpuonly.h"
-// TODO: fix the warnings
-#if defined(_MSC_VER) && !defined(__clang__)
-// Chance of arithmetic overflow could be reduced
-#pragma warning(disable : 26451)
-#endif
+
 namespace onnxruntime {
 
 namespace functors {
@@ -49,36 +46,47 @@ struct Powx {
   }
 };
 }  // namespace functors
+
 template <>
 Status LRN<float>::Compute(OpKernelContext* context) const {
-  const auto* X = context->Input<Tensor>(0);
-  if (X == nullptr)
-    return Status(common::ONNXRUNTIME, common::FAIL, "input count mismatch");
+  const auto& X = context->RequiredInput<Tensor>(0);
+  const auto& X_shape = X.Shape();
 
-  Tensor* Y = context->Output(0, X->Shape());
+  Tensor* Y = context->Output(0, X_shape);
 
   // Supports NCHW image format.
-  ORT_ENFORCE(X->Shape().NumDimensions() == 4);
-  const int N = gsl::narrow_cast<int>(X->Shape()[0]);
-  const int C = gsl::narrow_cast<int>(X->Shape()[1]);
-  const int H = gsl::narrow_cast<int>(X->Shape()[2]);
-  const int W = gsl::narrow_cast<int>(X->Shape()[3]);
-  const int image_size = C * H * W;
-  const int pre_pad = (size_ - 1) / 2;
 
-  const auto* Xdata = X->Data<float>();
+  ORT_ENFORCE(X_shape.NumDimensions() == 4);
+  const ptrdiff_t N = narrow<ptrdiff_t>(X_shape[0]);
+  const ptrdiff_t C = narrow<ptrdiff_t>(X_shape[1]);
+  const ptrdiff_t H = narrow<ptrdiff_t>(X_shape[2]);
+  const ptrdiff_t W = narrow<ptrdiff_t>(X_shape[3]);
+
+  const ptrdiff_t X_size = narrow<ptrdiff_t>(X_shape.Size());
+
+  if (X_size == 0) {
+    // Nothing to compute.
+    return Status::OK();
+  }
+
+  // Note: `ptrdiff_t X_size` being set successfully implies that N*C*H*W will not overflow ptrdiff_t.
+
+  const ptrdiff_t image_size = C * H * W;
+  const ptrdiff_t pre_pad = (size_ - 1) / 2;
+  const int H_times_W = SafeInt<int>(H) * W;  // H_times_W is passed to math::Axpy() which takes an int.
+
+  const auto* Xdata = X.Data<float>();
   auto* Ydata = Y->MutableData<float>();
 
   AllocatorPtr alloc;
   ORT_RETURN_IF_ERROR(context->GetTempSpaceAllocator(&alloc));
 
-  const int Xsize = gsl::narrow_cast<int>(X->Shape().Size());
-  auto sdata = alloc->Alloc(SafeInt<size_t>(sizeof(float)) * Xsize);
+  void* sdata = alloc->Alloc(SafeInt<size_t>(sizeof(float)) * X_size);
   BufferUniquePtr scale_buffer(sdata, BufferDeleter(alloc));
   auto* scale_data = static_cast<float*>(scale_buffer.get());
-  math::Set<float, CPUMathUtil>(Xsize, bias_, scale_data, &CPUMathUtil::Instance());
+  math::Set<float, CPUMathUtil>(X_size, bias_, scale_data, &CPUMathUtil::Instance());
 
-  const size_t padded_square_size = (static_cast<size_t>(C) + size_ - 1) * H * W;
+  const ptrdiff_t padded_square_size = (SafeInt<ptrdiff_t>(C) + size_ - 1) * H * W;
   auto psdata = alloc->Alloc(SafeInt<size_t>(sizeof(float)) * padded_square_size);
   BufferUniquePtr padded_square_buffer(psdata, BufferDeleter(std::move(alloc)));
   auto* padded_square_data = static_cast<float*>(padded_square_buffer.get());
@@ -86,28 +94,39 @@ Status LRN<float>::Compute(OpKernelContext* context) const {
 
   const float alpha_over_size = alpha_ / size_;
   // go through the images
-  for (int n = 0; n < N; ++n) {
+  for (ptrdiff_t n = 0; n < N; ++n) {
+    const ptrdiff_t n_times_image_size = n * image_size;
+
     // compute the padded square
-    math::Sqr<float, CPUMathUtil>(image_size, Xdata + image_size * n, padded_square_data + pre_pad * H * W,
-                                  &CPUMathUtil::Instance());
+    {
+      const ptrdiff_t padded_square_data_offset = SafeInt<ptrdiff_t>(pre_pad) * H_times_W;
+      math::Sqr<float, CPUMathUtil>(image_size, Xdata + n_times_image_size, padded_square_data + padded_square_data_offset,
+                                    &CPUMathUtil::Instance());
+    }
     // Create the first channel scale
-    for (int c = 0; c < size_; ++c) {
-      math::Axpy<float, CPUMathUtil>(H * W, alpha_over_size, padded_square_data + c * H * W,
-                                     scale_data + image_size * n, &CPUMathUtil::Instance());
+    for (ptrdiff_t c = 0; c < size_; ++c) {
+      const ptrdiff_t padded_square_data_offset = c * H_times_W;
+      math::Axpy<float, CPUMathUtil>(H_times_W, alpha_over_size, padded_square_data + padded_square_data_offset,
+                                     scale_data + n_times_image_size, &CPUMathUtil::Instance());
     }
 
-    for (int c = 1; c < C; ++c) {
-      float* this_scale_slice = scale_data + n * image_size + c * H * W;
+    for (ptrdiff_t c = 1; c < C; ++c) {
+      const ptrdiff_t this_scale_offset = n * image_size + c * H_times_W;
+
+      float* this_scale_slice = scale_data + this_scale_offset;
       // copy previous scale
-      memcpy(this_scale_slice, this_scale_slice - H * W, H * W * sizeof(float));
+      memcpy(this_scale_slice, this_scale_slice - H_times_W, SafeInt<size_t>(H_times_W) * sizeof(float));
       // add head
-      math::Axpy<float, CPUMathUtil>(H * W, alpha_over_size, padded_square_data + (c + size_ - 1) * H * W,
+      const ptrdiff_t padded_square_data_head_offset = (SafeInt<ptrdiff_t>(c) + size_ - 1) * H_times_W;
+      math::Axpy<float, CPUMathUtil>(H_times_W, alpha_over_size, padded_square_data + padded_square_data_head_offset,
                                      this_scale_slice, &CPUMathUtil::Instance());
       // subtract tail
-      math::Axpy<float, CPUMathUtil>(H * W, -alpha_over_size, padded_square_data + (c - 1) * H * W, this_scale_slice,
-                                     &CPUMathUtil::Instance());
+      const ptrdiff_t padded_square_data_tail_offset = (c - 1) * H_times_W;
+      math::Axpy<float, CPUMathUtil>(H_times_W, -alpha_over_size, padded_square_data + padded_square_data_tail_offset,
+                                     this_scale_slice, &CPUMathUtil::Instance());
     }
   }
+
   concurrency::ThreadPool* tp = context->GetOperatorThreadPool();
   using T = float;
   functors::Powx<T> f;
@@ -115,7 +134,7 @@ Status LRN<float>::Compute(OpKernelContext* context) const {
   f.input2 = Xdata;
   f.b = -beta_;
   f.output = Ydata;
-  concurrency::ThreadPool::TryParallelFor(tp, static_cast<std::ptrdiff_t>(Xsize),
+  concurrency::ThreadPool::TryParallelFor(tp, static_cast<std::ptrdiff_t>(X_size),
                                           {static_cast<float>(sizeof(T)), static_cast<float>(sizeof(T)), f.Cost()}, f);
   return Status::OK();
 }

--- a/onnxruntime/core/providers/cpu/nn/lrn.h
+++ b/onnxruntime/core/providers/cpu/nn/lrn.h
@@ -3,10 +3,11 @@
 
 #pragma once
 
-#include <gsl/gsl>
+#include <cstddef>
+#include <cstdint>
 
 #include "core/common/common.h"
-#include "core/common/exceptions.h"
+#include "core/common/narrow.h"
 #include "core/framework/op_kernel.h"
 
 namespace onnxruntime {
@@ -16,18 +17,15 @@ class LRN : public OpKernel {
  public:
   LRN(const OpKernelInfo& info) : OpKernel(info) {
     int64_t size;
-    ORT_ENFORCE(info.GetAttr<int64_t>("size", &size).IsOK());
-    size_ = gsl::narrow_cast<int>(size);
+    ORT_THROW_IF_ERROR(info.GetAttr<int64_t>("size", &size));
+    size_ = narrow<ptrdiff_t>(size);
     ORT_ENFORCE(size_ > 0);
     ORT_ENFORCE(size_ % 2 == 1);
-    ORT_ENFORCE(info.GetAttr<float>("alpha", &alpha_).IsOK());
+    ORT_THROW_IF_ERROR(info.GetAttr<float>("alpha", &alpha_));
     ORT_ENFORCE(alpha_ > 0.0f);
-    ORT_ENFORCE(info.GetAttr<float>("beta", &beta_).IsOK());
+    ORT_THROW_IF_ERROR(info.GetAttr<float>("beta", &beta_));
     ORT_ENFORCE(beta_ > 0.0f);
-    Status status = info.GetAttr<float>("bias", &bias_);
-    if (!status.IsOK()) {
-      bias_ = 1.0f;
-    }
+    ORT_THROW_IF_ERROR(info.GetAttr<float>("bias", &bias_));
   }
 
   Status Compute(OpKernelContext* p_op_kernel_context) const override;
@@ -36,6 +34,6 @@ class LRN : public OpKernel {
   float alpha_;
   float beta_;
   float bias_;
-  int size_;
+  ptrdiff_t size_;
 };
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cpu/quantization/matmul_integer_base.h
+++ b/onnxruntime/core/providers/cpu/quantization/matmul_integer_base.h
@@ -80,6 +80,7 @@ class MatMulIntegerBase : public OpKernel {
   }
 
   Status UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                   gsl::span<const size_t> /*prepacked_buffer_sizes*/,
                                    int input_idx,
                                    /*out*/ bool& used_shared_buffers) override {
     used_shared_buffers = false;

--- a/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
+++ b/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
@@ -30,6 +30,7 @@ class QLinearConv : public OpKernel {
                  /*out*/ PrePackedWeights* prepacked_weights) override;
 
   Status UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                   gsl::span<const size_t> /*prepacked_buffer_sizes*/,
                                    int input_idx,
                                    /*out*/ bool& used_shared_buffers) override;
 
@@ -495,6 +496,7 @@ Status QLinearConv<ActType>::PrePack(const Tensor& tensor, int input_idx, Alloca
 
 template <typename ActType>
 Status QLinearConv<ActType>::UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                                       gsl::span<const size_t> /*prepacked_buffer_sizes*/,
                                                        int input_idx,
                                                        /*out*/ bool& used_shared_buffers) {
   if (input_idx != 3) {

--- a/onnxruntime/core/providers/cpu/rnn/deep_cpu_gru.cc
+++ b/onnxruntime/core/providers/cpu/rnn/deep_cpu_gru.cc
@@ -322,6 +322,7 @@ Status DeepCpuGruOp::PrePack(const Tensor& tensor, int input_idx, AllocatorPtr a
 }
 
 Status DeepCpuGruOp::UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                               gsl::span<const size_t> /*prepacked_buffer_sizes*/,
                                                int input_idx,
                                                /*out*/ bool& used_shared_buffers) {
   used_shared_buffers = false;

--- a/onnxruntime/core/providers/cpu/rnn/deep_cpu_gru.h
+++ b/onnxruntime/core/providers/cpu/rnn/deep_cpu_gru.h
@@ -69,6 +69,7 @@ class DeepCpuGruOp final : public OpKernel {
                  /*out*/ PrePackedWeights* prepacked_weights) override;
 
   Status UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                   gsl::span<const size_t> /*prepacked_buffer_sizes*/,
                                    int input_idx,
                                    /*out*/ bool& used_shared_buffers) override;
 

--- a/onnxruntime/core/providers/cpu/rnn/deep_cpu_lstm.cc
+++ b/onnxruntime/core/providers/cpu/rnn/deep_cpu_lstm.cc
@@ -260,6 +260,7 @@ Status DeepCpuLstmOp::PrePack(const Tensor& tensor, int input_idx,
 }
 
 Status DeepCpuLstmOp::UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                                gsl::span<const size_t> /*prepacked_buffer_sizes*/,
                                                 int input_idx,
                                                 /*out*/ bool& used_shared_buffers) {
   used_shared_buffers = false;

--- a/onnxruntime/core/providers/cpu/rnn/deep_cpu_lstm.h
+++ b/onnxruntime/core/providers/cpu/rnn/deep_cpu_lstm.h
@@ -24,6 +24,7 @@ class DeepCpuLstmOp final : public OpKernel, public LSTMBase {
                  /*out*/ PrePackedWeights* prepacked_weights) override;
 
   Status UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                   gsl::span<const size_t> /*prepacked_buffer_sizes*/,
                                    int input_idx,
                                    /*out*/ bool& used_shared_buffers) override;
 

--- a/onnxruntime/core/providers/cpu/tensor/bitcast_op.cc
+++ b/onnxruntime/core/providers/cpu/tensor/bitcast_op.cc
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "bitcast_op.h"
+#include "core/framework/op_kernel.h"
+#include "core/framework/tensor.h"
+
+#include <cstring>
+
+namespace onnxruntime {
+
+ONNX_CPU_OPERATOR_KERNEL(
+    BitCast,
+    26,
+    KernelDefBuilder()
+        .TypeConstraint("T1", {DataTypeImpl::GetTensorType<float>(),
+                               DataTypeImpl::GetTensorType<double>(),
+                               DataTypeImpl::GetTensorType<int8_t>(),
+                               DataTypeImpl::GetTensorType<int16_t>(),
+                               DataTypeImpl::GetTensorType<int32_t>(),
+                               DataTypeImpl::GetTensorType<int64_t>(),
+                               DataTypeImpl::GetTensorType<uint8_t>(),
+                               DataTypeImpl::GetTensorType<uint16_t>(),
+                               DataTypeImpl::GetTensorType<uint32_t>(),
+                               DataTypeImpl::GetTensorType<uint64_t>(),
+                               DataTypeImpl::GetTensorType<MLFloat16>(),
+                               DataTypeImpl::GetTensorType<BFloat16>()})
+        .TypeConstraint("T2", {DataTypeImpl::GetTensorType<float>(),
+                               DataTypeImpl::GetTensorType<double>(),
+                               DataTypeImpl::GetTensorType<int8_t>(),
+                               DataTypeImpl::GetTensorType<int16_t>(),
+                               DataTypeImpl::GetTensorType<int32_t>(),
+                               DataTypeImpl::GetTensorType<int64_t>(),
+                               DataTypeImpl::GetTensorType<uint8_t>(),
+                               DataTypeImpl::GetTensorType<uint16_t>(),
+                               DataTypeImpl::GetTensorType<uint32_t>(),
+                               DataTypeImpl::GetTensorType<uint64_t>(),
+                               DataTypeImpl::GetTensorType<MLFloat16>(),
+                               DataTypeImpl::GetTensorType<BFloat16>()})
+        .MayInplace(0, 0),
+    BitCast);
+
+BitCast::BitCast(const OpKernelInfo& info) : OpKernel(info) {
+  int64_t to;
+  Status status = info.GetAttr("to", &to);
+  ORT_ENFORCE(status.IsOK(), "Attribute 'to' is not set.");
+  to_ = gsl::narrow_cast<ONNX_NAMESPACE::TensorProto_DataType>(to);
+}
+
+Status BitCast::Compute(OpKernelContext* context) const {
+  const Tensor* input = context->Input<Tensor>(0);
+  ORT_ENFORCE(input != nullptr, "BitCast: input tensor is null.");
+
+  const size_t input_element_size = input->DataType()->Size();
+
+  const auto* output_type = DataTypeImpl::TensorTypeFromONNXEnum(to_);
+  ORT_RETURN_IF_NOT(output_type != nullptr,
+                    "BitCast: unsupported target type (ONNX enum value: ", to_, ").");
+  const size_t output_element_size = output_type->GetElementType()->Size();
+
+  ORT_RETURN_IF_NOT(input_element_size == output_element_size,
+                    "BitCast requires input and output types to have the same bit-width. ",
+                    "Input element size: ", input_element_size, " bytes, ",
+                    "output element size: ", output_element_size, " bytes.");
+
+  Tensor* output = context->Output(0, input->Shape());
+
+  const size_t num_bytes = input->SizeInBytes();
+  if (num_bytes > 0) {
+    const void* src = input->DataRaw();
+    void* dst = output->MutableDataRaw();
+    if (src != dst) {
+      std::memcpy(dst, src, num_bytes);
+    }
+  }
+
+  return Status::OK();
+}
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cpu/tensor/bitcast_op.h
+++ b/onnxruntime/core/providers/cpu/tensor/bitcast_op.h
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/common/common.h"
+#include "core/framework/op_kernel.h"
+#include "core/graph/onnx_protobuf.h"
+
+namespace onnxruntime {
+
+class BitCast final : public OpKernel {
+ public:
+  explicit BitCast(const OpKernelInfo& info);
+  Status Compute(OpKernelContext* context) const override;
+
+ private:
+  ONNX_NAMESPACE::TensorProto_DataType to_;
+};
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/cuda_call.cc
+++ b/onnxruntime/core/providers/cuda/cuda_call.cc
@@ -3,7 +3,12 @@
 
 #include "core/providers/shared_library/provider_api.h"
 #include "shared_inc/cuda_call.h"
+#ifdef BUILD_CUDA_EP_AS_PLUGIN
+#include "ep/adapters.h"
+#include "plugin/provider_api_shims.h"
+#else
 #include <core/platform/env.h>
+#endif
 
 #ifdef _WIN32
 #else  // POSIX

--- a/onnxruntime/core/providers/cuda/cuda_provider_factory.cc
+++ b/onnxruntime/core/providers/cuda/cuda_provider_factory.cc
@@ -373,6 +373,7 @@ struct CudaOrtAllocator : OrtAllocator {
     Reserve = AllocImpl;      // no special behavior for Reserve so use AllocImpl
     GetStats = nullptr;       // GetStatsImpl. The CUDA allocators don't have stats currently so we can skip.
     AllocOnStream = nullptr;  // TODO. Plugin EP arena to provide this.
+    Shrink = nullptr;
 
     const OrtEpApi& ep_api = *api.GetEpApi();
     const OrtMemoryDevice* mem_device = ep_api.MemoryInfo_GetMemoryDevice(mem_info);

--- a/onnxruntime/core/providers/cuda/cuda_stream_handle.cc
+++ b/onnxruntime/core/providers/cuda/cuda_stream_handle.cc
@@ -24,6 +24,10 @@ DeferredCpuAllocator::DeferredCpuAllocator(CudaStream& cuda_stream) : cuda_strea
         auto self = reinterpret_cast<const DeferredCpuAllocator*>(this_);
         return &self->cuda_stream_.GetCpuAllocator()->Info();
       };
+  OrtAllocator::Reserve = nullptr;
+  OrtAllocator::GetStats = nullptr;
+  OrtAllocator::AllocOnStream = nullptr;
+  OrtAllocator::Shrink = nullptr;
 }
 
 struct CudaNotification : public synchronize::Notification {

--- a/onnxruntime/core/providers/cuda/cudnn_fe_call.cc
+++ b/onnxruntime/core/providers/cuda/cudnn_fe_call.cc
@@ -3,7 +3,12 @@
 
 #include "core/providers/cuda/shared_inc/cudnn_fe_call.h"
 #include "core/providers/shared_library/provider_api.h"
+#ifdef BUILD_CUDA_EP_AS_PLUGIN
+#include "ep/adapters.h"
+#include "plugin/provider_api_shims.h"
+#else
 #include <core/platform/env.h>
+#endif
 #if !defined(__CUDACC__) && !defined(USE_CUDA_MINIMAL)
 #include <cudnn_frontend.h>
 #endif

--- a/onnxruntime/core/providers/cuda/llm/attention.cc
+++ b/onnxruntime/core/providers/cuda/llm/attention.cc
@@ -134,7 +134,7 @@ static Status TransposeBSNHtoBNSH(int batch_size, int sequence_length,
 
 // ============================================================================
 // ConvertAttnMaskToBias: shared helper for mask→additive bias conversion.
-// Used by both Flash (nonpad+mask) and MEA paths to avoid code duplication.
+// Used by the MEA path to convert masks before the CUTLASS kernel call.
 // Converts bool masks to additive bias (true→0, false→mask_filter_value),
 // passes float masks through directly, and sets broadcast flags from mask shape.
 // ============================================================================
@@ -186,15 +186,12 @@ Status Attention<T>::ConvertAttnMaskToBias(
 // Flash Attention dispatch paths:
 //   Path 1: nonpad_kv_seqlen (opset 24 external cache) -> mha_fwd_kvcache
 //   Path 2: past_key + past_value (internal cache decode) -> mha_fwd_kvcache
-//           - Supports: bool mask -> seqlens_k, no mask -> fill past_seq_len
+//           - No mask support (attn_mask rejected at eligibility)
 //           - 4D BNSH: transposes Q/K/V to BSNH before kernel
 //   Path 3: no past, no mask (prompt) -> mha_fwd
-//   Eligibility: fp16/bf16, head_size==v_head_size, no output_qk,
-//                (no mask OR bool mask + past OR nonpad_kv_seqlen without mask)
+//   Eligibility: fp16/bf16, head_size==v_head_size, no output_qk, attn_mask==nullptr
 //   Note: softcap is passed to the Flash kernel natively. softmax_precision is
 //   inherently satisfied (Flash accumulates softmax in FP32).
-//   Note: nonpad_kv_seqlen + attn_mask routes to MEA/unfused, not Flash
-//         (Flash has no bias parameter for this combination).
 //
 // PERFORMANCE NOTE: ONNX Attention's internal-cache decode path (past_key/past_value)
 // is ~15-30% slower than contrib GQA's decode path for grouped-query attention workloads.
@@ -227,7 +224,7 @@ template <typename T>
 Status Attention<T>::RunFlashAttention(
     OpKernelContext* context,
     const Tensor* Q, const Tensor* K, const Tensor* V,
-    const Tensor* attn_mask, const Tensor* past_key, const Tensor* past_value,
+    const Tensor* past_key, const Tensor* past_value,
     const Tensor* nonpad_kv_seqlen,
     Tensor* Y, Tensor* present_key, Tensor* present_value,
     const attention_helper::AttentionParameters& parameters) const {
@@ -294,6 +291,8 @@ Status Attention<T>::RunFlashAttention(
                 "(past_sequence_length must be 0, got ",
                 parameters.past_sequence_length, ").");
 
+    // seqlens_k_buffer lifetime: allocated via BFC arena, remains valid for all kernel
+    // launches on the same CUDA stream until the IAllocatorUniquePtr goes out of scope.
     auto seqlens_k_buffer = GetScratchBuffer<int>(parameters.batch_size, GetComputeStream(context));
     ORT_RETURN_IF_ERROR(LaunchConvertNonpadKvSeqlenToFlashSeqlensK(
         nonpad_kv_seqlen->Data<int64_t>(),
@@ -348,25 +347,11 @@ Status Attention<T>::RunFlashAttention(
 
     // Step 1: Compute per-batch past sequence lengths for the concat kernel.
     // The concat kernel needs past_seq_lens to know where past data ends and new begins.
+    // attn_mask is always nullptr here (Flash rejects attn_mask), so use uniform past_seq.
     auto past_seqlens_buffer = GetScratchBuffer<int>(parameters.batch_size, GetComputeStream(context));
-    if (attn_mask != nullptr && attn_mask->IsDataType<bool>()) {
-      size_t mask_dims = attn_mask->Shape().NumDimensions();
-      auto dims = attn_mask->Shape().GetDims();
-      int64_t mask_dim0 = dims[0];
-      int64_t mask_dim1 = mask_dims >= 3 ? dims[1] : 0;
-      int64_t mask_dim2 = mask_dims >= 4 ? dims[2] : 0;
-      // Offset -kv_seq: mask encodes total valid count; subtract to get past-only count.
-      int seqlen_offset = -parameters.kv_sequence_length;
-      ORT_RETURN_IF_ERROR(LaunchConvertMaskToFlashSeqlensK(
-          attn_mask->Data<bool>(), past_seqlens_buffer.get(),
-          parameters.batch_size, parameters.total_sequence_length,
-          static_cast<int>(mask_dims), mask_dim0, mask_dim1, mask_dim2,
-          cuda_stream, device_prop.maxThreadsPerBlock, seqlen_offset));
-    } else {
-      ORT_RETURN_IF_ERROR(LaunchFillInt32(past_seqlens_buffer.get(), parameters.past_sequence_length,
-                                          parameters.batch_size, cuda_stream,
-                                          device_prop.maxThreadsPerBlock));
-    }
+    ORT_RETURN_IF_ERROR(LaunchFillInt32(past_seqlens_buffer.get(), parameters.past_sequence_length,
+                                        parameters.batch_size, cuda_stream,
+                                        device_prop.maxThreadsPerBlock));
 
     // Step 2: Transpose K/V to BSNH if input is 4D BNSH (concat kernel reads new as BSNH).
     const T* k_new_bsnh = K->Data<T>();
@@ -399,11 +384,7 @@ Status Attention<T>::RunFlashAttention(
     // into present buffer at [past_seq, past_seq + kv_seq), all in BNSH.
     // Note: is_bsnh=false means past/present cache layout is BNSH. New tokens
     // (k_new_bsnh/v_new_bsnh) are always read as BSNH by the kernel (hardcoded strides).
-    // NOTE: When bool masks produce variable per-batch past_seq_lens, positions in the range
-    // [past_seq_lens[b] + kv_sequence_length, total_sequence_length) for each batch b are left
-    // uninitialized by the concat kernel. Flash Attention reads only up to seqlens_k[b] positions
-    // per batch, so these values are never accessed. In the no-mask case (uniform past_seq_lens),
-    // every position in the present buffer is written.
+    // past_seqlens is uniform (no mask) so every position in the present buffer is written.
     ORT_RETURN_IF_ERROR(onnxruntime::contrib::cuda::LaunchConcatNewToPastKV<NativeCudaT>(
         parameters.batch_size,
         parameters.kv_num_heads,
@@ -427,27 +408,13 @@ Status Attention<T>::RunFlashAttention(
     // Step 4: Compute total seqlens for mha_fwd_kvcache.
     // With k_new=nullptr, the kernel treats seqlens_k as the total valid token count
     // (not pre-append count), so we need past + new.
+    // attn_mask is always nullptr here (Flash rejects attn_mask), so use uniform seqlens.
     auto seqlens_k_buffer = GetScratchBuffer<int>(parameters.batch_size, GetComputeStream(context));
-    if (attn_mask != nullptr && attn_mask->IsDataType<bool>()) {
-      size_t mask_dims = attn_mask->Shape().NumDimensions();
-      auto dims = attn_mask->Shape().GetDims();
-      int64_t mask_dim0 = dims[0];
-      int64_t mask_dim1 = mask_dims >= 3 ? dims[1] : 0;
-      int64_t mask_dim2 = mask_dims >= 4 ? dims[2] : 0;
-      // Offset 0: mask encodes total valid count, which is exactly what we need.
-      int seqlen_offset = 0;
-      ORT_RETURN_IF_ERROR(LaunchConvertMaskToFlashSeqlensK(
-          attn_mask->Data<bool>(), seqlens_k_buffer.get(),
-          parameters.batch_size, parameters.total_sequence_length,
-          static_cast<int>(mask_dims), mask_dim0, mask_dim1, mask_dim2,
-          cuda_stream, device_prop.maxThreadsPerBlock, seqlen_offset));
-    } else {
-      ORT_RETURN_IF_ERROR(LaunchFillInt32(
-          seqlens_k_buffer.get(),
-          parameters.past_sequence_length + parameters.kv_sequence_length,
-          parameters.batch_size, cuda_stream,
-          device_prop.maxThreadsPerBlock));
-    }
+    ORT_RETURN_IF_ERROR(LaunchFillInt32(
+        seqlens_k_buffer.get(),
+        parameters.past_sequence_length + parameters.kv_sequence_length,
+        parameters.batch_size, cuda_stream,
+        device_prop.maxThreadsPerBlock));
 
     // Step 5: Flash attention on pre-populated cache.
     // k_new=nullptr tells mha_fwd_kvcache to skip its internal Append_KV — the cache
@@ -542,7 +509,6 @@ Status Attention<T>::RunFlashAttention(
   ORT_UNUSED_PARAMETER(Q);
   ORT_UNUSED_PARAMETER(K);
   ORT_UNUSED_PARAMETER(V);
-  ORT_UNUSED_PARAMETER(attn_mask);
   ORT_UNUSED_PARAMETER(past_key);
   ORT_UNUSED_PARAMETER(past_value);
   ORT_UNUSED_PARAMETER(nonpad_kv_seqlen);
@@ -730,6 +696,22 @@ Status Attention<T>::RunMemoryEfficientAttention(
       p.workspace = nullptr;
     }
     onnxruntime::contrib::cuda::run_memory_efficient_attention(p);
+
+    // On the MEA (CUTLASS) path (used for both MHA and GQA when nonpad_kv_seqlen is provided),
+    // zero out output for fully-masked batches to produce zeros (matching Flash behavior).
+    // CUTLASS epilogue computes 1/s_prime where s_prime=0 for seqlens_k=0, producing NaN.
+    {
+      using CudaT = typename onnxruntime::cuda::OrtToCudaType<T>::type;
+      int64_t elements_per_batch = static_cast<int64_t>(parameters.q_sequence_length) *
+                                   parameters.q_num_heads * parameters.v_head_size;
+      ORT_RETURN_IF_ERROR(LaunchZeroOutputForFullyMaskedBatches<CudaT>(
+          reinterpret_cast<CudaT*>(out_data),
+          seqlens_k_buffer.get(),
+          parameters.batch_size,
+          elements_per_batch,
+          cuda_stream,
+          device_prop.maxThreadsPerBlock));
+    }
   }
   // Standard MEA path: float attention bias, bool mask (converted to bias), or no mask.
   // Bool masks are converted to additive attention bias (true→0, false→mask_filter_value)
@@ -858,6 +840,8 @@ Status Attention<T>::RunUnfusedAttention(
     Tensor* output_qk,
     const attention_helper::AttentionParameters& parameters) const {
   using CudaT = typename ToCudaType<T>::MappedType;
+  // OrtToCudaType maps BFloat16 → __nv_bfloat16 (native HW type), matching kernel instantiations.
+  using NativeCudaT = typename onnxruntime::cuda::OrtToCudaType<T>::type;
   auto& device_prop = GetDeviceProp();
   auto cuda_stream = Stream(context);
   auto ort_stream = GetOrtStream(context);
@@ -938,7 +922,6 @@ Status Attention<T>::RunUnfusedAttention(
   IAllocatorUniquePtr<void> mask_bias_buffer;  // temp buffer for mask→bias when composing
   if (nonpad_kv_seqlen != nullptr) {
     // Convert nonpad_kv_seqlen to additive attention bias: [B, q_seq, total_seq]
-    using NativeCudaT = typename onnxruntime::cuda::OrtToCudaType<T>::type;
     int64_t bias_elements = static_cast<int64_t>(parameters.batch_size) *
                             parameters.q_sequence_length *
                             parameters.total_sequence_length;
@@ -1004,7 +987,6 @@ Status Attention<T>::RunUnfusedAttention(
     contribop_parameters.broadcast_attn_bias_dim_1 = true;
   } else if (attn_mask != nullptr) {
     if (attn_mask->IsDataType<bool>()) {
-      using NativeCudaT = typename onnxruntime::cuda::OrtToCudaType<T>::type;
       int64_t num_elements = attn_mask->Shape().Size();
       converted_mask_buffer = GetScratchBuffer<void>(num_elements * sizeof(NativeCudaT), GetComputeStream(context));
       ORT_RETURN_IF_ERROR(LaunchConvertBoolMaskToAttentionBias<NativeCudaT>(
@@ -1049,6 +1031,9 @@ Status Attention<T>::RunUnfusedAttention(
   cublasHandle_t cublas = GetCublasHandle(context);
   cudnnHandle_t cudnn = GetCudnnHandle(context);
 
+  // Note: unfused attention produces valid finite output (mean-of-V via uniform softmax)
+  // for fully-masked batches, so ZeroOutput is not needed here. Only MEA requires
+  // ZeroOutput to prevent NaN from the CUTLASS epilogue's 1/s_prime division.
   return onnxruntime::contrib::cuda::QkvToContext<CudaT, CudaT>(
       device_prop, cublas, cudnn, ort_stream.get(), contribop_parameters, data);
 }
@@ -1134,20 +1119,17 @@ Status Attention<T>::ComputeInternal(OpKernelContext* context) const {
                                             parameters.q_num_heads, parameters.kv_num_heads) &&
         parameters.head_size == parameters.v_head_size &&
         !has_output_qk &&
-        // Bool masks without past_key (prompt) can't use flash because mha_fwd_kvcache's
-        // causal semantics are decode-oriented (window offset by seqlens_k). For causal
-        // prompt with padding, MEA handles it correctly via attention bias conversion.
-        // Flash handles: no mask, decode with past (±mask), nonpad_kv_seqlen.
-        // Note: contrib MHA similarly excludes flash when attention_bias is present
-        // (no mask support in mha_fwd). Float masks and bool prompt masks route to MEA
-        // which supports additive bias natively.
-        (attn_mask == nullptr || (attn_mask->IsDataType<bool>() && past_key != nullptr)) &&
-        // Flash cannot handle nonpad_kv_seqlen + attn_mask simultaneously (no bias parameter
-        // in mha_fwd/mha_fwd_kvcache when seqlens_k is used). Route to MEA instead.
-        !(nonpad_kv_seqlen != nullptr && attn_mask != nullptr);
+        // Flash does not support attention masks (no bias parameter in mha_fwd/mha_fwd_kvcache).
+        // Bool attn_mask + past_key is rejected because Flash uses paged KV cache semantics
+        // that produce spec-divergent present_kv layout for partial masks (e.g. [T,T,T,F]).
+        // Unfused handles bool+past_key spec-correctly via standard ConcatPastToPresent.
+        // TODO(titaiwang): GQA + bool attn_mask + past_key currently has no runner (Flash
+        // rejected here, unfused doesn't support GQA, MEA blocked by past_key != nullptr).
+        // Once PR #27851 merges (MEA supports past_key), this gap will be covered.
+        attn_mask == nullptr;
 
     if (flash_eligible) {
-      return RunFlashAttention(context, Q, K, V, attn_mask, past_key, past_value,
+      return RunFlashAttention(context, Q, K, V, past_key, past_value,
                                nonpad_kv_seqlen, Y, present_key, present_value, parameters);
     }
   }
@@ -1171,13 +1153,14 @@ Status Attention<T>::ComputeInternal(OpKernelContext* context) const {
     // total_sequence_length. Skip MEA if this stride can't satisfy the kernel's
     // minimum alignment requirement.
     if (mea_eligible && attn_mask != nullptr) {
-      int min_bias_align = 1;
-      if ((std::is_same<T, float>::value && sm >= 80) ||
-          (!std::is_same<T, float>::value && sm >= 75)) {
-        min_bias_align = 4;  // TensorOp on Sm80+ (float) or Sm75+ (fp16/bf16)
-      } else if (!std::is_same<T, float>::value && sm >= 70) {
-        min_bias_align = 2;  // TensorOp on Volta (fp16)
-      }
+      // NOTE: CUTLASS uses kMinimumAlignment = 4 (elements, not bytes) for the bias
+      // pointer in its epilogue. total_sequence_length is the bias row stride in elements,
+      // so we check alignment in element count. The contrib_ops convention (4 * sizeof(T))
+      // conflates bytes with elements; we use the correct value of 4 elements here.
+      // Note: on SM50/53 (Maxwell), CUTLASS kMinimumAlignment=1, so this is stricter than
+      // necessary — cases with odd total_sequence_length that previously used MEA on those
+      // GPUs will now fall to unfused. This is acceptable for these very old architectures.
+      constexpr int min_bias_align = 4;
       if (parameters.total_sequence_length % min_bias_align != 0) {
         mea_eligible = false;
       }
@@ -1215,8 +1198,9 @@ Status Attention<T>::ComputeInternal(OpKernelContext* context) const {
     // to replicate kv_num_heads -> q_num_heads before unfused can process.
     // Requires ~160 lines. See issue #27516.
     return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED,
-                           "GQA (q_num_heads != kv_num_heads) requires flash or memory efficient attention, "
-                           "but neither is eligible. Ensure fp16/bf16 on Ampere+ GPU, or check head_size constraints.");
+                           "ONNX Attention with GQA (q_num_heads != kv_num_heads) is not supported by the "
+                           "unfused runner. Flash requires fp16/bf16, SM>=80, and attn_mask==nullptr; MEA "
+                           "requires past_key==nullptr. See PR #27851 for MEA past_key support.");
   }
 
   return RunUnfusedAttention(context, Q, K, V, attn_mask, past_key, past_value,

--- a/onnxruntime/core/providers/cuda/llm/attention.h
+++ b/onnxruntime/core/providers/cuda/llm/attention.h
@@ -18,7 +18,7 @@ class Attention final : public CudaKernel {
   Status RunFlashAttention(
       OpKernelContext* context,
       const Tensor* Q, const Tensor* K, const Tensor* V,
-      const Tensor* attn_mask, const Tensor* past_key, const Tensor* past_value,
+      const Tensor* past_key, const Tensor* past_value,
       const Tensor* nonpad_kv_seqlen,
       Tensor* Y, Tensor* present_key, Tensor* present_value,
       const attention_helper::AttentionParameters& parameters) const;

--- a/onnxruntime/core/providers/cuda/llm/attention_mask_impl.cu
+++ b/onnxruntime/core/providers/cuda/llm/attention_mask_impl.cu
@@ -7,144 +7,6 @@
 namespace onnxruntime {
 namespace cuda {
 
-// CUDA kernel to convert boolean attention mask to sequence lengths.
-// Also validates that the mask follows right-padding convention.
-//
-// The kernel processes one batch per thread.
-// For each batch, it finds the first False in the mask row, which indicates
-// where padding starts. The sequence length is the index of first False.
-//
-// Validation:
-// - All-false masks are valid (represents fully masked / zero-length sequence)
-// - After the first False, all remaining elements must be False (contiguous padding)
-// - CUDA_KERNEL_ASSERT fires in debug builds if mask is non-contiguous
-// - In release builds, non-contiguous masks produce safe output: seqlens_k is the
-//   count of leading True values (up to first False), ignoring later True values
-//
-// Handle broadcasting:
-// - 2D mask (q_seq_len, total_seq_len): broadcasts over batch; uses first query position (row 0)
-// - 3D mask (num_heads, q_seq_len, total_seq_len): broadcasts to [1, num_heads, q_seq, total_seq]
-//   No per-batch variation; uses first head, first q position for all batches
-// - 4D mask (B, H, q_seq_len, total_seq_len): we look at first head, first q position
-__global__ void ConvertMaskToSeqlensKernel(
-    const bool* __restrict__ attn_mask,
-    int* __restrict__ seqlens_k,
-    const int batch_size,
-    const int total_seq_len,
-    const int mask_dims,
-    const int64_t mask_dim0,
-    const int64_t mask_dim1,
-    const int64_t mask_dim2,
-    const int seqlen_offset) {
-  int batch_idx = threadIdx.x + blockIdx.x * blockDim.x;
-  if (batch_idx >= batch_size) {
-    return;
-  }
-
-  // Calculate the starting offset for this batch's mask row
-  // We need to figure out which row of the mask to use based on broadcasting rules
-  const bool* mask_row = nullptr;
-
-  if (mask_dims == 2) {
-    // Shape: (q_seq_len, total_seq_len) per ONNX spec. Broadcasts over batch.
-    // Use first query position (row 0) for sequence length determination.
-    // For 2D masks [q_seq, total_seq], only used in decode path where q_seq=1,
-    // so row 0 is always correct. Flash excludes 2D bool masks for prompt.
-    mask_row = attn_mask;
-  } else if (mask_dims == 3) {
-    // Shape: (num_heads, q_seq_len, total_seq_len)
-    // This broadcasts to [1, num_heads, q_seq, total_seq] - same mask for all batches
-    // We look at first head (h_idx = 0) and first q position (q_idx = 0)
-    int h_idx = 0;  // First head
-    int q_idx = 0;  // First query position
-    // Stride: q_seq_len * total_seq_len per head
-    int64_t head_stride = mask_dim1 * total_seq_len;  // mask_dim1 = q_seq_len
-    int64_t q_stride = total_seq_len;
-    // Same mask row for all batches since 3D has no batch dimension
-    mask_row = attn_mask + h_idx * head_stride + q_idx * q_stride;
-  } else {
-    // 4D: Shape (B, H, q_seq_len, total_seq_len)
-    // B could be batch_size or 1 (broadcast)
-    // H could be num_heads or 1 (broadcast)
-    // We look at first head (h_idx = 0) and first q position (q_idx = 0)
-    int effective_batch = (mask_dim0 == 1) ? 0 : batch_idx;
-    int h_idx = 0;  // First head
-    int q_idx = 0;  // First query position
-    // Strides
-    int64_t batch_stride = mask_dim1 * mask_dim2 * total_seq_len;
-    int64_t head_stride = mask_dim2 * total_seq_len;
-    int64_t q_stride = total_seq_len;
-    mask_row = attn_mask + effective_batch * batch_stride + h_idx * head_stride + q_idx * q_stride;
-  }
-
-  // Find the first False (where padding starts)
-  // All elements before first False must be True, all after must be False (right-padding convention)
-  int seq_len;
-  if (!mask_row[0]) {
-    // Entire row is padding (all-false mask)
-    seq_len = 0;
-  } else {
-    seq_len = total_seq_len;  // Default: all True (no padding)
-    bool found_first_false = false;
-
-    for (int i = 1; i < total_seq_len; ++i) {
-      bool current = mask_row[i];
-
-      if (!found_first_false && !current) {
-        // Found first False - this is where padding starts
-        seq_len = i;
-        found_first_false = true;
-      } else if (found_first_false && current) {
-        // Found True after False - mask is not contiguous (invalid)
-        CUDA_KERNEL_ASSERT(false);  // mask must be contiguous (no True after False)
-        break;                      // Safe: seq_len already reflects leading-True count
-      }
-    }
-  }
-
-  // seqlens_k output: seq_len + seqlen_offset
-  // Decode with past (seqlen_offset=-kv_seq_len): pre-append cache count
-  // Prompt/MEA (seqlen_offset=0): actual token count
-  // Clamp to 0: all-false mask (seq_len=0) with negative decode offset
-  // would produce negative seqlens_k, which is undefined in Flash kernels.
-  seqlens_k[batch_idx] = max(0, seq_len + seqlen_offset);
-}
-
-// Convert boolean mask to sequence lengths with a configurable offset.
-// seqlens_k[b] = num_true_tokens + seqlen_offset
-Status LaunchConvertMaskToFlashSeqlensK(
-    const bool* attn_mask_bool,
-    int* seqlens_k,
-    int batch_size,
-    int total_seq_len,
-    int mask_dims,
-    int64_t mask_dim0,
-    int64_t mask_dim1,
-    int64_t mask_dim2,
-    cudaStream_t stream,
-    int max_threads_per_block,
-    int seqlen_offset) {
-  if (batch_size == 0 || total_seq_len == 0) {
-    return Status::OK();
-  }
-
-  int threads = std::min(batch_size, max_threads_per_block);
-  int blocks = (batch_size + threads - 1) / threads;
-
-  ConvertMaskToSeqlensKernel<<<blocks, threads, 0, stream>>>(
-      attn_mask_bool,
-      seqlens_k,
-      batch_size,
-      total_seq_len,
-      mask_dims,
-      mask_dim0,
-      mask_dim1,
-      mask_dim2,
-      seqlen_offset);
-
-  return CUDA_CALL(cudaGetLastError());
-}
-
 template <typename T>
 __global__ void ConvertBoolMaskToAttentionBiasKernel(
     const bool* __restrict__ attn_mask,
@@ -327,6 +189,58 @@ Status LaunchAddBiasInPlace(
 template Status LaunchAddBiasInPlace<float>(float*, const float*, int64_t, int64_t, cudaStream_t, int);
 template Status LaunchAddBiasInPlace<__half>(__half*, const __half*, int64_t, int64_t, cudaStream_t, int);
 template Status LaunchAddBiasInPlace<__nv_bfloat16>(__nv_bfloat16*, const __nv_bfloat16*, int64_t, int64_t, cudaStream_t, int);
+
+// Zero output elements for batches where seqlens_k == 0 (fully masked).
+// CUTLASS MEA epilogue computes 1/s_prime where s_prime=0 → NaN for fully-masked
+// batches. The unfused path produces uniform softmax weights (finite mask_filter_value,
+// not -inf) so output is valid but non-zero; we still zero for Flash parity.
+// Flash handles this natively with an early-exit for empty sequences.
+template <typename T>
+__global__ void ZeroOutputForFullyMaskedBatchesKernel(
+    T* __restrict__ output,
+    const int* __restrict__ seqlens_k,
+    const int batch_size,
+    const int64_t elements_per_batch) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  int64_t total = static_cast<int64_t>(batch_size) * elements_per_batch;
+  for (; idx < total; idx += static_cast<int64_t>(gridDim.x) * blockDim.x) {
+    int b = static_cast<int>(idx / elements_per_batch);
+    if (seqlens_k[b] == 0) {
+      output[idx] = T(0.0f);
+    }
+  }
+}
+
+template <typename T>
+Status LaunchZeroOutputForFullyMaskedBatches(
+    T* output,
+    const int* seqlens_k,
+    int batch_size,
+    int64_t elements_per_batch,
+    cudaStream_t stream,
+    int max_threads_per_block) {
+  int64_t total = static_cast<int64_t>(batch_size) * elements_per_batch;
+  if (total == 0) {
+    return Status::OK();
+  }
+
+  int threads = static_cast<int>(std::min(static_cast<int64_t>(max_threads_per_block), total));
+  int64_t blocks = (total + threads - 1) / threads;
+  constexpr int64_t kMaxGridDimX = 65535;
+  unsigned int grid_size = static_cast<unsigned int>(std::min(blocks, kMaxGridDimX));
+
+  ZeroOutputForFullyMaskedBatchesKernel<T><<<grid_size, threads, 0, stream>>>(
+      output, seqlens_k, batch_size, elements_per_batch);
+
+  return CUDA_CALL(cudaGetLastError());
+}
+
+template Status LaunchZeroOutputForFullyMaskedBatches<float>(
+    float*, const int*, int, int64_t, cudaStream_t, int);
+template Status LaunchZeroOutputForFullyMaskedBatches<__half>(
+    __half*, const int*, int, int64_t, cudaStream_t, int);
+template Status LaunchZeroOutputForFullyMaskedBatches<__nv_bfloat16>(
+    __nv_bfloat16*, const int*, int, int64_t, cudaStream_t, int);
 
 // Simple kernel to fill an int32 buffer with a constant value on device.
 // Used for CUDA-graph-capturable seqlens_k initialization (no host memory).

--- a/onnxruntime/core/providers/cuda/llm/attention_mask_impl.h
+++ b/onnxruntime/core/providers/cuda/llm/attention_mask_impl.h
@@ -8,45 +8,6 @@
 namespace onnxruntime {
 namespace cuda {
 
-// Convert a boolean attention mask to sequence lengths with a configurable offset.
-//
-// The mask is expected to have the following properties:
-// 1. It represents right-padding only (valid tokens first, padding at the end)
-// 2. All-false masks (zero-length sequence) are valid; otherwise mask should start with True
-// 3. True values should be contiguous, followed by contiguous False (padding) values
-// 4. The mask must be broadcastable to (batch_size, num_heads, q_seq_len, total_seq_len)
-//
-// For 2D mask (q_seq_len, total_seq_len): broadcasts over batch; uses first query position (row 0)
-// For 3D mask (num_heads, q_seq_len, total_seq_len): broadcasts across batches, uses first head/q
-// For 4D mask (B, H, q_seq_len, total_seq_len): uses first head, first q position
-//
-// seqlen_offset adjusts the raw token count:
-//   seqlens_k[b] = num_true_tokens + seqlen_offset
-//
-// Common offsets:
-//   0: total valid token count (for decode Step 4 where mha_fwd_kvcache reads from
-//      pre-populated cache with k_new=nullptr, and for MEA custom right padding)
-//  -N: subtract N from count (for decode with mha_fwd_kvcache where N=kv_sequence_length,
-//      giving the number of tokens already in cache BEFORE appending new ones)
-//
-// Note: Mask validity (right-padding convention, contiguous True/False)
-//   is checked via CUDA_KERNEL_ASSERT inside the kernel (debug builds only).
-//   In release builds, non-contiguous masks produce memory-safe but semantically incorrect output:
-//   seqlens_k is computed as the count of leading True values (up to the first False),
-//   ignoring any True values that appear after the first False.
-Status LaunchConvertMaskToFlashSeqlensK(
-    const bool* attn_mask_bool,
-    int* seqlens_k,
-    int batch_size,
-    int total_seq_len,
-    int mask_dims,
-    int64_t mask_dim0,
-    int64_t mask_dim1,
-    int64_t mask_dim2,
-    cudaStream_t stream,
-    int max_threads_per_block,
-    int seqlen_offset = 0);
-
 // Convert a boolean attention mask to an additive attention bias for the MHA path.
 // Maps true -> 0.0 (attend) and false -> mask_filter_value (mask out).
 // The output has the same shape as the input mask.
@@ -95,6 +56,20 @@ Status LaunchAddBiasInPlace(
     const T* addend,
     int64_t total_elements,
     int64_t addend_elements,
+    cudaStream_t stream,
+    int max_threads_per_block);
+
+// Zero output elements for batches where seqlens_k == 0 (fully masked).
+// Used in the MEA path only: CUTLASS epilogue computes 1/s_prime where s_prime=0,
+// producing NaN for fully-masked batches. This kernel overwrites those NaN outputs
+// with zeros. The unfused path produces valid finite output (mean-of-V via uniform
+// softmax) and does not need this. Flash handles it natively with an early-exit.
+template <typename T>
+Status LaunchZeroOutputForFullyMaskedBatches(
+    T* output,
+    const int* seqlens_k,
+    int batch_size,
+    int64_t elements_per_batch,
     cudaStream_t stream,
     int max_threads_per_block);
 

--- a/onnxruntime/core/providers/cuda/plugin/cuda_allocator_plugin.h
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_allocator_plugin.h
@@ -10,6 +10,11 @@
 
 #include "cuda_plugin_utils.h"
 
+#include <algorithm>
+#include <sstream>
+#include <string>
+#include <type_traits>
+
 namespace onnxruntime {
 namespace cuda_plugin {
 
@@ -33,6 +38,52 @@ class CudaAllocatorBase : public OrtAllocator {
  private:
   CudaAllocatorKind kind_;
   const OrtMemoryInfo* memory_info_;
+};
+
+// CudaAllocatorBase derives from OrtAllocator via single non-virtual inheritance.
+// This guarantees OrtAllocator sits at offset 0 in the derived layout, so
+// static_cast between OrtAllocator* and CudaAllocatorBase* is safe.
+static_assert(!std::is_polymorphic_v<CudaAllocatorBase>,
+              "CudaAllocatorBase must not be polymorphic (no virtual functions) "
+              "to ensure OrtAllocator is at offset 0.");
+
+/// Allocator statistics tracked by arena allocators.
+struct AllocatorStats {
+  int64_t num_allocs = 0;
+  int64_t num_reserves = 0;
+  int64_t num_arena_extensions = 0;
+  int64_t num_arena_shrinkages = 0;
+  int64_t bytes_in_use = 0;
+  int64_t total_allocated_bytes = 0;
+  int64_t max_bytes_in_use = 0;
+  int64_t max_alloc_size = 0;
+  int64_t bytes_limit = 0;
+
+  void ToKeyValuePairs(const OrtApi& api, OrtKeyValuePairs* kvps) const {
+    api.AddKeyValuePair(kvps, "Limit", std::to_string(bytes_limit).c_str());
+    api.AddKeyValuePair(kvps, "InUse", std::to_string(bytes_in_use).c_str());
+    api.AddKeyValuePair(kvps, "TotalAllocated", std::to_string(total_allocated_bytes).c_str());
+    api.AddKeyValuePair(kvps, "MaxInUse", std::to_string(max_bytes_in_use).c_str());
+    api.AddKeyValuePair(kvps, "NumAllocs", std::to_string(num_allocs).c_str());
+    api.AddKeyValuePair(kvps, "NumReserves", std::to_string(num_reserves).c_str());
+    api.AddKeyValuePair(kvps, "NumArenaExtensions", std::to_string(num_arena_extensions).c_str());
+    api.AddKeyValuePair(kvps, "NumArenaShrinkages", std::to_string(num_arena_shrinkages).c_str());
+    api.AddKeyValuePair(kvps, "MaxAllocSize", std::to_string(max_alloc_size).c_str());
+  }
+
+  std::string DebugString() const {
+    std::ostringstream ss;
+    ss << "Limit:                    " << bytes_limit << "\n"
+       << "InUse:                    " << bytes_in_use << "\n"
+       << "TotalAllocated:           " << total_allocated_bytes << "\n"
+       << "MaxInUse:                 " << max_bytes_in_use << "\n"
+       << "NumAllocs:                " << num_allocs << "\n"
+       << "NumReserves:              " << num_reserves << "\n"
+       << "NumArenaExtensions:       " << num_arena_extensions << "\n"
+       << "NumArenaShrinkages:       " << num_arena_shrinkages << "\n"
+       << "MaxAllocSize:             " << max_alloc_size << "\n";
+    return ss.str();
+  }
 };
 
 /// CUDA device memory allocator using cudaMalloc/cudaFree.

--- a/onnxruntime/core/providers/cuda/plugin/cuda_arena.cc
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_arena.cc
@@ -1,0 +1,831 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+// Portions Copyright (c) Microsoft Corporation
+// Adapted from onnxruntime/test/autoep/library/example_plugin_ep/ep_arena.cc
+// for the CUDA plugin EP arena allocator.
+
+#include "cuda_arena.h"
+
+#include <cassert>
+#include <map>
+
+#include "core/common/inlined_containers_fwd.h"
+#include "core/common/narrow.h"
+
+namespace onnxruntime {
+namespace cuda_plugin {
+
+namespace {
+std::string GetAllocatorName(const OrtApi& api, OrtAllocator& allocator) {
+  const OrtMemoryInfo* mem_info = allocator.Info(&allocator);
+  const char* allocator_name;
+  auto* status = api.MemoryInfoGetName(mem_info, &allocator_name);  // never fails
+  static_cast<void>(status);
+  return allocator_name;
+}
+}  // namespace
+
+ArenaImpl::ArenaImpl(AllocatorUniquePtr allocator, const ArenaConfig& config, const OrtApi& api,
+                     const OrtLogger& logger)
+    : device_allocator_{std::move(allocator)},
+      allocator_name_{GetAllocatorName(api, *device_allocator_)},
+      config_{config},
+      next_allocation_id_(1),
+      free_chunks_list_(kInvalidChunkHandle),
+      api_{api},
+      ep_api_{*api_.GetEpApi()},
+      logger_{logger} {
+  CUDA_ARENA_LOG(INFO, "Creating ArenaImpl for "
+                           << allocator_name_
+                           << " with following configs: initial_chunk_size_bytes: " << config_.initial_chunk_size_bytes
+                           << " max_dead_bytes_per_chunk: " << config_.max_dead_bytes_per_chunk
+                           << " initial_growth_chunk_size_bytes: " << config_.initial_growth_chunk_size_bytes
+                           << " max_power_of_two_extend_bytes: " << config_.max_power_of_two_extend_bytes
+                           << " memory limit: " << config_.max_mem
+                           << " arena_extend_strategy: " << config_.arena_extend_strategy);
+
+  curr_region_allocation_bytes_ = RoundedBytes(
+      std::min(config_.max_mem, static_cast<size_t>(config_.initial_chunk_size_bytes)));
+
+  stats_.bytes_limit = config.max_mem > static_cast<size_t>(std::numeric_limits<int64_t>::max())
+                           ? std::numeric_limits<int64_t>::max()
+                           : static_cast<int64_t>(config.max_mem);
+
+  // Create bins of various sizes.
+  CUDA_ARENA_LOG(VERBOSE, "Creating " << kNumBins << " bins of max chunk size "
+                                      << BinNumToSize(0) << " to " << BinNumToSize(kNumBins - 1));
+
+  for (BinNum b = 0; b < kNumBins; b++) {
+    size_t bin_size = BinNumToSize(b);
+    new (BinFromIndex(b)) Bin(this, bin_size);
+    CUDA_ARENA_ENFORCE((BinForSize(bin_size) == BinFromIndex(b) &&
+                        BinForSize(bin_size + 255) == BinFromIndex(b) &&
+                        BinForSize(bin_size * 2 - 1) == BinFromIndex(b)),
+                       "Invalid bin size for bin " << b);
+
+    if (b + 1 < kNumBins) {
+      CUDA_ARENA_ENFORCE(BinForSize(bin_size * 2) != BinFromIndex(b), "Invalid bin size for " << b);
+    }
+  }
+}
+
+ArenaImpl::~ArenaImpl() {
+  for (const auto& region : region_manager_.regions()) {
+    device_allocator_->Free(device_allocator_.get(), region.ptr());
+  }
+
+  for (const auto& reserve_chunk : reserved_chunks_) {
+    device_allocator_->Free(device_allocator_.get(), reserve_chunk.first);
+  }
+
+  for (BinNum b = 0; b < kNumBins; b++) {
+    BinFromIndex(b)->~Bin();
+  }
+}
+
+ArenaImpl::Chunk* ArenaImpl::ChunkFromHandle(ChunkHandle h) {
+  CUDA_ARENA_ENFORCE(h < chunks_.size(), "ChunkFromHandle");
+  return &(chunks_[h]);
+}
+
+OrtStatus* ArenaImpl::Extend(size_t rounded_bytes) {
+  size_t available_bytes = config_.max_mem - static_cast<size_t>(stats_.total_allocated_bytes);
+  available_bytes = (available_bytes / kMinAllocationSize) * kMinAllocationSize;
+
+  if (rounded_bytes > available_bytes) {
+    CUDA_ARENA_RETURN_ERROR(ORT_EP_FAIL, "Available memory of " << available_bytes
+                                                                << " is smaller than requested bytes of "
+                                                                << rounded_bytes);
+  }
+
+  auto safe_alloc = [this](size_t alloc_bytes) {
+    void* new_mem = nullptr;
+    ORT_TRY {
+      new_mem = device_allocator_->Alloc(device_allocator_.get(), alloc_bytes);
+    }
+    ORT_CATCH(const std::bad_alloc&) {
+    }
+    return new_mem;
+  };
+
+  auto get_extend_bytes = [this, available_bytes](const size_t bytes, size_t& extend_bytes) -> OrtStatus* {
+    extend_bytes = 0;
+    if (config_.arena_extend_strategy == ArenaExtendStrategy::kNextPowerOfTwo) {
+      bool increased_allocation = false;
+      while (bytes > curr_region_allocation_bytes_) {
+        if (curr_region_allocation_bytes_ > std::numeric_limits<size_t>::max() / 2) {
+          // Cannot double without overflow — cap at max.
+          curr_region_allocation_bytes_ = std::numeric_limits<size_t>::max();
+          break;
+        }
+        curr_region_allocation_bytes_ *= 2;
+        increased_allocation = true;
+      }
+
+      extend_bytes = std::min(static_cast<size_t>(curr_region_allocation_bytes_), available_bytes);
+
+      if (!increased_allocation) {
+        // Use overflow-safe comparison: double only when the current value
+        // is less than half the cap, so the result cannot exceed the cap.
+        const size_t max_extend = static_cast<size_t>(config_.max_power_of_two_extend_bytes);
+        if (curr_region_allocation_bytes_ < max_extend / 2) {
+          curr_region_allocation_bytes_ *= 2;
+        } else {
+          curr_region_allocation_bytes_ = max_extend;
+        }
+      }
+    } else if (config_.arena_extend_strategy == ArenaExtendStrategy::kSameAsRequested) {
+      extend_bytes = bytes;
+    } else {
+      CUDA_ARENA_RETURN_ERROR(ORT_INVALID_ARGUMENT,
+                              "Invalid arena extend strategy." << config_.arena_extend_strategy);
+    }
+
+    return nullptr;
+  };
+
+  size_t bytes;
+  {
+    OrtStatus* status = get_extend_bytes(rounded_bytes, bytes);
+    if (status != nullptr) return status;
+  }
+
+  void* mem_addr = safe_alloc(bytes);
+
+  static constexpr float kBackpedalFactor = 0.9f;
+  while (mem_addr == nullptr) {
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(push)
+#pragma warning(disable : 26451)
+#endif
+    bytes = RoundedBytes(static_cast<size_t>(bytes * kBackpedalFactor));
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(pop)
+#endif
+    if (bytes < rounded_bytes || bytes < 8 * 1024)
+      break;
+
+    mem_addr = safe_alloc(bytes);
+  }
+
+  if (mem_addr == nullptr) {
+    CUDA_ARENA_RETURN_ERROR(ORT_EP_FAIL,
+                            "Failed to allocate memory for requested buffer of size " << rounded_bytes);
+  }
+
+  CUDA_ARENA_LOG(INFO, "Extended allocation by " << bytes << " bytes.");
+
+  // Guard against leaking mem_addr if any operation below throws (e.g. vector reallocation
+  // inside AddAllocationRegion). On success we set mem_addr to nullptr to dismiss the guard.
+  struct AllocGuard {
+    OrtAllocator* alloc;
+    void*& addr;
+    ~AllocGuard() {
+      if (addr) alloc->Free(alloc, addr);
+    }
+  } alloc_guard{device_allocator_.get(), mem_addr};
+
+  stats_.total_allocated_bytes += bytes;
+  CUDA_ARENA_LOG(INFO, "Total allocated bytes: " << stats_.total_allocated_bytes);
+  CUDA_ARENA_LOG(INFO, "Allocated memory at " << mem_addr << " to "
+                                              << static_cast<void*>(static_cast<char*>(mem_addr) + bytes));
+
+  region_manager_.AddAllocationRegion(mem_addr, bytes, stats_.num_arena_extensions);
+  stats_.num_arena_extensions += 1;
+
+  ChunkHandle h = AllocateChunk();
+  Chunk* c = ChunkFromHandle(h);
+  c->ptr = mem_addr;
+  c->size = bytes;
+  c->allocation_id = -1;
+  c->prev = kInvalidChunkHandle;
+  c->next = kInvalidChunkHandle;
+  c->stream = nullptr;
+
+  region_manager_.set_handle(c->ptr, h);
+
+  InsertFreeChunkIntoBin(h);
+
+  // All operations completed successfully — dismiss the guard.
+  mem_addr = nullptr;
+
+  return nullptr;
+}
+
+ArenaImpl::ChunkHandle ArenaImpl::AllocateChunk() {
+  if (free_chunks_list_ != kInvalidChunkHandle) {
+    ChunkHandle h = free_chunks_list_;
+    Chunk* c = ChunkFromHandle(h);
+    free_chunks_list_ = c->next;
+    return h;
+  }
+  ChunkHandle h = chunks_.size();
+  chunks_.resize(h + 1);
+  return h;
+}
+
+void ArenaImpl::DeallocateChunk(ChunkHandle h) {
+  Chunk* c = ChunkFromHandle(h);
+
+  if (c->stream) {
+    if (auto it = stream_to_chunks_.find(c->stream); it != stream_to_chunks_.end()) {
+      size_t result = it->second.erase(h);
+      static_cast<void>(result);
+
+      if (it->second.empty()) {
+        stream_to_chunks_.erase(it);
+        impl_to_stream_.erase(ep_api_.SyncStream_GetImpl(c->stream));
+      }
+    }
+
+    c->stream = nullptr;
+    c->stream_sync_id = 0;
+  }
+
+  c->next = free_chunks_list_;
+  free_chunks_list_ = h;
+}
+
+size_t ArenaImpl::RoundedBytes(size_t bytes) {
+  return (kMinAllocationSize * ((bytes + kMinAllocationSize - 1) / kMinAllocationSize));
+}
+
+void* ArenaImpl::Alloc(size_t size) {
+  return AllocateRawInternal(size, nullptr, false);
+}
+
+void* ArenaImpl::AllocOnStream(size_t size, OrtSyncStream* stream) {
+  return AllocateRawInternal(size, stream, false);
+}
+
+void* ArenaImpl::Reserve(size_t size) {
+  if (size == 0)
+    return nullptr;
+
+  std::lock_guard<std::mutex> lock(lock_);
+
+  // Check remaining budget before allocating.
+  // Use narrow<> to catch truncation (int64_t -> size_t), then avoid overflow
+  // by comparing size against the remaining budget rather than summing.
+  size_t allocated = 0;
+  ORT_TRY {
+    allocated = onnxruntime::narrow<size_t>(stats_.total_allocated_bytes);
+  }
+  ORT_CATCH(const std::exception& ex) {
+    ORT_HANDLE_EXCEPTION([&]() {
+      CUDA_ARENA_LOG(ERROR, "Reserve: total_allocated_bytes (" << stats_.total_allocated_bytes
+                                                               << ") cannot be converted to size_t: " << ex.what());
+    });
+    return nullptr;
+  }
+  if (allocated > config_.max_mem || size > config_.max_mem - allocated) {
+    CUDA_ARENA_LOG(WARNING, "Reserve of " << size << " bytes would exceed arena max_mem ("
+                                          << config_.max_mem << "). Returning nullptr.");
+    return nullptr;
+  }
+
+  CUDA_ARENA_LOG(INFO, "Reserving memory in ArenaImpl for " << allocator_name_ << " size: " << size);
+
+  void* ptr = device_allocator_->Alloc(device_allocator_.get(), size);
+  if (ptr == nullptr) {
+    return nullptr;
+  }
+  CUDA_ARENA_ENFORCE(reserved_chunks_.find(ptr) == reserved_chunks_.end(), __FUNCTION__);
+  reserved_chunks_.insert(std::pair<void*, size_t>(ptr, size));
+  stats_.bytes_in_use += size;
+  stats_.num_reserves += 1;
+  stats_.num_allocs += 1;
+  stats_.max_alloc_size = std::max<size_t>(static_cast<size_t>(stats_.max_alloc_size), size);
+  stats_.max_bytes_in_use = std::max<int64_t>(static_cast<int64_t>(stats_.max_bytes_in_use), stats_.bytes_in_use);
+  stats_.total_allocated_bytes += size;
+  return ptr;
+}
+
+size_t ArenaImpl::RequestedSize(const void* ptr) {
+  std::lock_guard<std::mutex> lock(lock_);
+  ChunkHandle h = region_manager_.get_handle(ptr);
+  CUDA_ARENA_ENFORCE(h != kInvalidChunkHandle, __FUNCTION__);
+  Chunk* c = ChunkFromHandle(h);
+  return c->requested_size;
+}
+
+size_t ArenaImpl::AllocatedSize(const void* ptr) {
+  std::lock_guard<std::mutex> lock(lock_);
+  ChunkHandle h = region_manager_.get_handle(ptr);
+  CUDA_ARENA_ENFORCE(h != kInvalidChunkHandle, __FUNCTION__);
+  Chunk* c = ChunkFromHandle(h);
+  return c->size;
+}
+
+void* ArenaImpl::AllocateRawInternal(size_t num_bytes, OrtSyncStream* stream, bool dump_log_on_failure) {
+  if (num_bytes == 0) {
+    return nullptr;
+  }
+
+  size_t rounded_bytes = RoundedBytes(num_bytes);
+  BinNum bin_num = BinNumForSize(rounded_bytes);
+
+  std::lock_guard<std::mutex> lock(lock_);
+
+  if (stream && stream_to_chunks_.find(stream) == stream_to_chunks_.end()) {
+    stream_to_chunks_.insert({stream, std::set<size_t>{}});
+    const OrtSyncStreamImpl* stream_impl = ep_api_.SyncStream_GetImpl(stream);
+    assert(stream_impl);
+    impl_to_stream_.insert({stream_impl, stream});
+  }
+
+  auto* chunk = FindChunkPtr(bin_num, rounded_bytes, num_bytes, stream);
+
+  if (chunk != nullptr) {
+    return chunk->ptr;
+  }
+
+  CUDA_ARENA_LOG(INFO, "Extending arena for " << allocator_name_
+                                              << ". bin_num:" << bin_num
+                                              << " (requested) num_bytes: " << num_bytes
+                                              << " (actual) rounded_bytes:" << rounded_bytes);
+
+  auto status = Extend(rounded_bytes);
+  if (status == nullptr) {
+    chunk = FindChunkPtr(bin_num, rounded_bytes, num_bytes, stream);
+    if (chunk != nullptr) {
+      return chunk->ptr;
+    } else {
+      status = api_.CreateStatus(ORT_EP_FAIL,
+                                 ("Failed to find a free memory block despite calling Extend. rounded_bytes=" +
+                                  std::to_string(rounded_bytes))
+                                     .c_str());
+    }
+  }
+
+  if (dump_log_on_failure) {
+    CUDA_ARENA_LOG(ERROR, "BFC Arena ran out of memory trying to allocate " << num_bytes);
+    DumpMemoryLog(rounded_bytes);
+  }
+
+  // Release the OrtStatus and return nullptr instead of throwing — allocate
+  // calls must not propagate exceptions across the C API boundary.
+  api_.ReleaseStatus(status);
+  return nullptr;
+}
+
+OrtStatus* ArenaImpl::GetStats(OrtKeyValuePairs** stats) {
+  std::lock_guard<std::mutex> lock(lock_);
+
+  api_.CreateKeyValuePairs(stats);
+  stats_.ToKeyValuePairs(api_, *stats);
+
+  return nullptr;
+}
+
+OrtStatus* ArenaImpl::Shrink() {
+  std::lock_guard<std::mutex> lock(lock_);
+
+  // Note: Reserved memory (via Reserve()) is allocated directly through the device
+  // allocator and stored in reserved_chunks_, bypassing the region/chunk system.
+  // Shrink() intentionally does NOT free reserved memory because it is used for
+  // model initializers that must remain valid for the session lifetime.
+
+  // Snapshot region pointers/sizes before mutation — we will modify the
+  // region list while iterating.  Matches in-tree BFCArena::Shrink().
+  const auto num_regions = region_manager_.regions().size();
+  InlinedVector<void*> region_ptrs;
+  InlinedVector<size_t> region_sizes;
+  region_ptrs.reserve(num_regions);
+  region_sizes.reserve(num_regions);
+
+  for (const auto& region : region_manager_.regions()) {
+    region_ptrs.push_back(region.ptr());
+    region_sizes.push_back(region.memory_size());
+  }
+
+  // For each region, check if every chunk is free. If so, deallocate the region.
+  size_t i = 0;
+  for (void* region_ptr : region_ptrs) {
+    bool deallocate_region = true;
+    ChunkHandle region_begin_chunk = region_manager_.get_handle(region_ptr);
+    ChunkHandle h = region_begin_chunk;
+    while (h != kInvalidChunkHandle) {
+      const Chunk* c = ChunkFromHandle(h);
+      if (c->in_use()) {
+        // at-least one used chunk found in the allocation region -
+        // so we cannot deallocate it
+        deallocate_region = false;
+        break;
+      }
+      h = c->next;
+    }
+
+    if (deallocate_region) {
+      auto shrink_size = region_sizes[i];
+      stats_.num_arena_shrinkages += 1;
+      stats_.total_allocated_bytes -= static_cast<int64_t>(shrink_size);
+
+      CUDA_ARENA_LOG(VERBOSE, allocator_name_ << " ArenaImpl shrunk by "
+                                              << shrink_size << " bytes. "
+                                              << "Total allocated is now " << stats_.total_allocated_bytes);
+
+      h = region_begin_chunk;
+      ChunkHandle temp = region_begin_chunk;
+      while (h != kInvalidChunkHandle) {
+        const Chunk* c = ChunkFromHandle(h);
+        temp = c->next;
+        RemoveFreeChunkFromBin(h);
+        DeleteChunk(h);
+        h = temp;
+      }
+
+      device_allocator_->Free(device_allocator_.get(), region_ptr);
+      region_manager_.RemoveAllocationRegion(region_ptr);
+      stats_.num_arena_extensions--;
+    }
+
+    ++i;
+  }
+
+  // Reset growth so the arena can grow fresh if needed later.
+  // Matches BFCArena which resets to initial_growth_chunk_size_bytes_.
+  curr_region_allocation_bytes_ = RoundedBytes(
+      static_cast<size_t>(config_.initial_growth_chunk_size_bytes));
+
+  return nullptr;
+}
+
+ArenaImpl::Chunk* ArenaImpl::SplitFreeChunkFromBin(Bin::FreeChunkSet* free_chunks,
+                                                   const Bin::FreeChunkSet::iterator& citer,
+                                                   size_t rounded_bytes,
+                                                   size_t num_bytes) {
+  const ChunkHandle h = (*citer);
+  RemoveFreeChunkIterFromBin(free_chunks, citer);
+  Chunk* chunk = ChunkFromHandle(h);
+
+  if (chunk->size >= rounded_bytes * 2 ||
+      static_cast<int64_t>(chunk->size - rounded_bytes) >= config_.max_dead_bytes_per_chunk) {
+    SplitChunk(h, rounded_bytes);
+    chunk = ChunkFromHandle(h);
+  }
+
+  chunk->requested_size = num_bytes;
+  chunk->allocation_id = next_allocation_id_++;
+
+  ++stats_.num_allocs;
+  stats_.bytes_in_use += chunk->size;
+  stats_.max_bytes_in_use = std::max(stats_.max_bytes_in_use, stats_.bytes_in_use);
+  stats_.max_alloc_size = std::max<int64_t>(stats_.max_alloc_size, static_cast<int64_t>(chunk->size));
+
+  return chunk;
+}
+
+ArenaImpl::Chunk* ArenaImpl::FindChunkPtr(BinNum bin_num, size_t rounded_bytes, size_t num_bytes,
+                                          OrtSyncStream* stream) {
+  for (; bin_num < kNumBins; bin_num++) {
+    Bin* b = BinFromIndex(bin_num);
+    for (auto citer = b->free_chunks.begin(); citer != b->free_chunks.end(); ++citer) {
+      const ChunkHandle h = (*citer);
+      Chunk* chunk = ChunkFromHandle(h);
+      CUDA_ARENA_ENFORCE(!chunk->in_use(), __FUNCTION__);
+
+      if (chunk->size >= rounded_bytes) {
+        bool safe_to_use = chunk->stream == stream ||
+                           !chunk->stream ||
+                           (stream && chunk->stream &&
+                            chunk->stream_sync_id < ep_api_.GetSyncIdForLastWaitOnSyncStream(chunk->stream, stream));
+
+        if (safe_to_use) {
+          chunk = SplitFreeChunkFromBin(&b->free_chunks, citer, rounded_bytes, num_bytes);
+
+          if (stream) {
+            chunk->stream = stream;
+            chunk->stream_sync_id = ep_api_.SyncStream_GetSyncId(stream);
+            stream_to_chunks_[stream].insert(h);
+          }
+
+          return chunk;
+        }
+      }
+    }
+  }
+
+  return nullptr;
+}
+
+void ArenaImpl::SplitChunk(ChunkHandle h, size_t num_bytes) {
+  ChunkHandle h_new_chunk = AllocateChunk();
+
+  Chunk* c = ChunkFromHandle(h);
+  CUDA_ARENA_ENFORCE(!c->in_use() && (c->bin_num == kInvalidBinNum), __FUNCTION__);
+
+  Chunk* new_chunk = ChunkFromHandle(h_new_chunk);
+  new_chunk->stream = c->stream;
+  new_chunk->stream_sync_id = c->stream_sync_id;
+
+  // Track the remainder chunk's stream assignment so ResetChunksUsingStream
+  // can clear it later. Without this, the free remainder retains a stale
+  // stream pointer after the stream is released — risking use-after-free
+  // in GetSyncIdForLastWaitOnSyncStream.
+  if (new_chunk->stream) {
+    stream_to_chunks_[new_chunk->stream].insert(h_new_chunk);
+  }
+
+  new_chunk->ptr = static_cast<void*>(static_cast<char*>(c->ptr) + num_bytes);
+  region_manager_.set_handle(new_chunk->ptr, h_new_chunk);
+
+  new_chunk->size = c->size - num_bytes;
+  c->size = num_bytes;
+
+  new_chunk->allocation_id = -1;
+
+  ChunkHandle h_neighbor = c->next;
+  new_chunk->prev = h;
+  new_chunk->next = h_neighbor;
+  c->next = h_new_chunk;
+  if (h_neighbor != kInvalidChunkHandle) {
+    Chunk* c_neighbor = ChunkFromHandle(h_neighbor);
+    c_neighbor->prev = h_new_chunk;
+  }
+
+  InsertFreeChunkIntoBin(h_new_chunk);
+}
+
+void ArenaImpl::Free(void* p) {
+  if (p == nullptr) {
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(lock_);
+  auto it = reserved_chunks_.find(p);
+  if (it != reserved_chunks_.end()) {
+    device_allocator_->Free(device_allocator_.get(), it->first);
+    stats_.bytes_in_use -= it->second;
+    stats_.total_allocated_bytes -= it->second;
+    reserved_chunks_.erase(it);
+  } else {
+    DeallocateRawInternal(p);
+  }
+}
+
+void ArenaImpl::DeallocateRawInternal(void* ptr) {
+  ChunkHandle h = region_manager_.get_handle(ptr);
+  CUDA_ARENA_ENFORCE(h != kInvalidChunkHandle, __FUNCTION__);
+  FreeAndMaybeCoalesce(h);
+}
+
+void ArenaImpl::Merge(ChunkHandle h1, ChunkHandle h2) {
+  Chunk* c1 = ChunkFromHandle(h1);
+  Chunk* c2 = ChunkFromHandle(h2);
+  CUDA_ARENA_ENFORCE(!c1->in_use() && !c2->in_use() && c1->stream == c2->stream, __FUNCTION__);
+
+  ChunkHandle h3 = c2->next;
+  c1->next = h3;
+  CUDA_ARENA_ENFORCE(c2->prev == h1, __FUNCTION__);
+  if (h3 != kInvalidChunkHandle) {
+    Chunk* c3 = ChunkFromHandle(h3);
+    c3->prev = h1;
+  }
+
+  c1->size += c2->size;
+
+  assert(c1->stream == c2->stream);
+  c1->stream_sync_id = std::max(c1->stream_sync_id, c2->stream_sync_id);
+
+  DeleteChunk(h2);
+}
+
+void ArenaImpl::DeleteChunk(ChunkHandle h) {
+  Chunk* c = ChunkFromHandle(h);
+  region_manager_.erase(c->ptr);
+  DeallocateChunk(h);
+}
+
+void ArenaImpl::InsertFreeChunkIntoBin(ChunkHandle h) {
+  Chunk* c = ChunkFromHandle(h);
+  CUDA_ARENA_ENFORCE(!c->in_use() && (c->bin_num == kInvalidBinNum), __FUNCTION__);
+  BinNum bin_num = BinNumForSize(c->size);
+  Bin* new_bin = BinFromIndex(bin_num);
+  c->bin_num = bin_num;
+  new_bin->free_chunks.insert(h);
+}
+
+void ArenaImpl::RemoveFreeChunkIterFromBin(Bin::FreeChunkSet* free_chunks,
+                                           const Bin::FreeChunkSet::iterator& citer) {
+  ChunkHandle h = *citer;
+  Chunk* c = ChunkFromHandle(h);
+  CUDA_ARENA_ENFORCE(!c->in_use() && (c->bin_num != kInvalidBinNum), __FUNCTION__);
+  free_chunks->erase(citer);
+  c->bin_num = kInvalidBinNum;
+}
+
+void ArenaImpl::RemoveFreeChunkFromBin(ChunkHandle h) {
+  Chunk* c = ChunkFromHandle(h);
+  CUDA_ARENA_ENFORCE(!c->in_use() && (c->bin_num != kInvalidBinNum), __FUNCTION__);
+  CUDA_ARENA_ENFORCE(BinFromIndex(c->bin_num)->free_chunks.erase(h) > 0, "Could not find chunk in bin");
+  c->bin_num = kInvalidBinNum;
+}
+
+void ArenaImpl::FreeAndMaybeCoalesce(ChunkHandle h) {
+  Chunk* c = ChunkFromHandle(h);
+  CUDA_ARENA_ENFORCE(c->in_use() && (c->bin_num == kInvalidBinNum), __FUNCTION__);
+
+  c->allocation_id = -1;
+  stats_.bytes_in_use -= c->size;
+
+  ChunkHandle chunk_to_reassign = Coalesce(h);
+  InsertFreeChunkIntoBin(chunk_to_reassign);
+}
+
+ArenaImpl::ChunkHandle ArenaImpl::Coalesce(ChunkHandle h) {
+  Chunk* c = ChunkFromHandle(h);
+  CUDA_ARENA_ENFORCE(!c->in_use(), __FUNCTION__);
+
+  ChunkHandle chunk_to_reassign = h;
+
+  if (c->next != kInvalidChunkHandle) {
+    Chunk* cnext = ChunkFromHandle(c->next);
+    if (!cnext->in_use() && cnext->stream == c->stream) {
+      chunk_to_reassign = h;
+      RemoveFreeChunkFromBin(c->next);
+      Merge(h, ChunkFromHandle(h)->next);
+    }
+  }
+
+  c = ChunkFromHandle(h);
+  if (c->prev != kInvalidChunkHandle) {
+    Chunk* cprev = ChunkFromHandle(c->prev);
+    if (!cprev->in_use() && cprev->stream == c->stream) {
+      chunk_to_reassign = c->prev;
+      RemoveFreeChunkFromBin(c->prev);
+      Merge(ChunkFromHandle(h)->prev, h);
+    }
+  }
+
+  return chunk_to_reassign;
+}
+
+std::array<ArenaImpl::BinDebugInfo, ArenaImpl::kNumBins> ArenaImpl::GetBinDebugInfo() {
+  std::array<BinDebugInfo, kNumBins> bin_infos;
+
+  for (const auto& region : region_manager_.regions()) {
+    ChunkHandle h = region_manager_.get_handle(region.ptr());
+    while (h != kInvalidChunkHandle) {
+      const Chunk* c = ChunkFromHandle(h);
+      BinNum bin_num = BinNumForSize(c->size);
+      BinDebugInfo& bin_info = bin_infos[bin_num];
+      bin_info.total_bytes_in_bin += c->size;
+      bin_info.total_chunks_in_bin++;
+
+      if (c->in_use()) {
+        bin_info.total_bytes_in_use += c->size;
+        bin_info.total_requested_bytes_in_use += c->requested_size;
+        bin_info.total_chunks_in_use++;
+      } else {
+        Bin* bin = BinFromIndex(bin_num);
+        CUDA_ARENA_ENFORCE(bin->free_chunks.count(h) == 1 && c->bin_num == bin_num, __FUNCTION__);
+      }
+
+      h = c->next;
+    }
+  }
+  return bin_infos;
+}
+
+void ArenaImpl::DumpMemoryLog(size_t num_bytes) {
+  const std::array<BinDebugInfo, kNumBins> bin_infos = GetBinDebugInfo();
+  CUDA_ARENA_LOG(INFO, "Allocator:" << allocator_name_);
+  CUDA_ARENA_LOG(INFO, "Bin size: Chunks in_use/total (if not zero). Allocated bytes in_use/total. Requested bytes.");
+
+  size_t waste = 0;
+  for (BinNum bin_num = 0; bin_num < kNumBins; bin_num++) {
+    Bin* b = BinFromIndex(bin_num);
+    const BinDebugInfo& bin_info = bin_infos[bin_num];
+    CUDA_ARENA_ENFORCE(b->free_chunks.size() == bin_info.total_chunks_in_bin - bin_info.total_chunks_in_use,
+                       __FUNCTION__);
+
+    if (bin_info.total_chunks_in_bin > 0) {
+      CUDA_ARENA_LOG(INFO, b->bin_size
+                               << ": Chunks " << bin_info.total_chunks_in_use << "/" << bin_info.total_chunks_in_bin
+                               << ". Bytes "
+                               << bin_info.total_bytes_in_use << "/" << bin_info.total_bytes_in_bin << ". "
+                               << "Requested " << bin_info.total_requested_bytes_in_use << ".");
+
+      waste += bin_info.total_bytes_in_use - bin_info.total_requested_bytes_in_use;
+    }
+  }
+
+  if (waste > 0) {
+    CUDA_ARENA_LOG(INFO, "Diff between in-use and requested bytes is " << waste);
+  }
+
+  Bin* b = BinForSize(num_bytes);
+
+  CUDA_ARENA_LOG(INFO, "Bin for " << num_bytes
+                                  << " bytes has max bytes of " << b->bin_size
+                                  << ", Chunk State: ");
+
+  for (ChunkHandle h : b->free_chunks) {
+    Chunk* c = ChunkFromHandle(h);
+    CUDA_ARENA_LOG(INFO, "  " << c->DebugString(this, true));
+  }
+
+  CUDA_ARENA_LOG(INFO, "Overall chunks summary:");
+  std::map<size_t, int> in_use_by_size;
+  for (const auto& region : region_manager_.regions()) {
+    ChunkHandle h = region_manager_.get_handle(region.ptr());
+    while (h != kInvalidChunkHandle) {
+      const Chunk* c = ChunkFromHandle(h);
+      if (c->in_use()) {
+        in_use_by_size[c->size]++;
+      }
+      CUDA_ARENA_LOG(INFO, (c->in_use() ? "  Chunk" : "  Free ")
+                               << " at " << c->ptr << " of size " << c->size);
+      h = c->next;
+    }
+  }
+
+  CUDA_ARENA_LOG(INFO, "Summary of in-use chunks by size: ");
+  size_t total_bytes = 0;
+  for (auto& it : in_use_by_size) {
+    CUDA_ARENA_LOG(INFO, "  " << it.second << " chunks of size " << it.first
+                              << ". Total " << it.first * it.second);
+    total_bytes += (it.first * it.second);
+  }
+
+  CUDA_ARENA_LOG(INFO, "Sum Total of in-use chunks: " << total_bytes);
+  CUDA_ARENA_LOG(INFO, "Stats: \n"
+                           << stats_.DebugString());
+}
+
+OrtStatus* ArenaImpl::ResetChunksUsingStream(const OrtSyncStreamImpl* stream_impl) {
+  std::lock_guard<std::mutex> lock(lock_);
+
+  auto impl_it = impl_to_stream_.find(stream_impl);
+  if (impl_it == impl_to_stream_.end()) {
+    return nullptr;  // stream hasn't been used with this arena
+  }
+
+  const OrtSyncStream* stream = impl_it->second;
+
+  auto it = stream_to_chunks_.find(stream);
+  if (it != stream_to_chunks_.end()) {
+    const auto& chunk_handles = it->second;
+    for (size_t handle : chunk_handles) {
+      Chunk* c = ChunkFromHandle(handle);
+      assert(c->stream == stream);
+      c->stream = nullptr;
+    }
+
+    stream_to_chunks_.erase(it);
+    impl_to_stream_.erase(stream_impl);
+  }
+
+  // Coalesce free chunks after clearing stream assignments.
+  // Coalesce returns the (possibly different) handle of the merged chunk,
+  // so we must use that handle for the remainder of the iteration.
+  for (const auto& region : region_manager_.regions()) {
+    ChunkHandle h = region_manager_.get_handle(region.ptr());
+    while (h != kInvalidChunkHandle) {
+      Chunk* c = ChunkFromHandle(h);
+      if (!c->in_use()) {
+        RemoveFreeChunkFromBin(h);
+        h = Coalesce(h);
+        c = ChunkFromHandle(h);
+        InsertFreeChunkIntoBin(h);
+      }
+      h = c->next;
+    }
+  }
+
+  return nullptr;
+}
+
+// CudaArenaAllocator factory method
+/*static*/
+OrtStatus* CudaArenaAllocator::Create(CudaAllocatorKind kind,
+                                      const OrtMemoryInfo* memory_info,
+                                      AllocatorUniquePtr raw_allocator,
+                                      const OrtKeyValuePairs* options,
+                                      const OrtApi& api,
+                                      const OrtLogger& logger,
+                                      std::unique_ptr<CudaArenaAllocator>& out) {
+  ArenaConfig config = options ? ArenaConfig::FromKeyValuePairs(api, *options) : ArenaConfig{};
+  if (!config.IsValid()) {
+    return api.CreateStatus(ORT_INVALID_ARGUMENT, "Invalid CUDA arena allocator configuration.");
+  }
+  auto impl = std::make_unique<ArenaImpl>(std::move(raw_allocator), config, api, logger);
+  out = std::make_unique<CudaArenaAllocator>(kind, memory_info, std::move(impl));
+  return nullptr;
+}
+
+}  // namespace cuda_plugin
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/plugin/cuda_arena.h
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_arena.h
@@ -1,0 +1,695 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+// Portions Copyright (c) Microsoft Corporation
+// Adapted from onnxruntime/test/autoep/library/example_plugin_ep/ep_arena.h
+// for the CUDA plugin EP arena allocator.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "cuda_allocator_plugin.h"
+
+#include "core/common/common.h"
+
+#if defined(PLATFORM_WINDOWS) || defined(_WIN32)
+#include <intrin.h>
+#endif
+
+namespace onnxruntime {
+namespace cuda_plugin {
+
+// Type-erasing unique_ptr for raw OrtAllocator ownership.
+// The factory creates the raw allocator with a deleter that knows the concrete type.
+using AllocatorUniquePtr = std::unique_ptr<OrtAllocator, std::function<void(OrtAllocator*)>>;
+
+enum ArenaExtendStrategy {
+  kDefault = -1,
+  kNextPowerOfTwo = 0,
+  kSameAsRequested = 1,
+};
+
+// Copied from onnxruntime::OrtArenaCfg so the values and config key names match.
+struct ArenaConfig {
+  static const ArenaExtendStrategy DEFAULT_ARENA_EXTEND_STRATEGY = ArenaExtendStrategy::kNextPowerOfTwo;
+  static const int DEFAULT_INITIAL_CHUNK_SIZE_BYTES = 1 * 1024 * 1024;
+  static const int DEFAULT_MAX_DEAD_BYTES_PER_CHUNK = 128 * 1024 * 1024;
+  static const int DEFAULT_INITIAL_GROWTH_CHUNK_SIZE_BYTES = 2 * 1024 * 1024;
+  static const int64_t DEFAULT_MAX_POWER_OF_TWO_EXTEND_BYTES = 1024 * 1024 * 1024;  // 1GB
+  static const size_t DEFAULT_MAX_MEM = std::numeric_limits<size_t>::max();
+
+  ArenaConfig(size_t max_mem = std::numeric_limits<size_t>::max(),
+              ArenaExtendStrategy arena_extend_strategy = DEFAULT_ARENA_EXTEND_STRATEGY,
+              int initial_chunk_size_bytes = DEFAULT_INITIAL_CHUNK_SIZE_BYTES,
+              int max_dead_bytes_per_chunk = DEFAULT_MAX_DEAD_BYTES_PER_CHUNK,
+              int initial_growth_chunk_size_bytes = DEFAULT_INITIAL_GROWTH_CHUNK_SIZE_BYTES,
+              int64_t max_power_of_two_extend_bytes = DEFAULT_MAX_POWER_OF_TWO_EXTEND_BYTES)
+      : max_mem(max_mem),
+        arena_extend_strategy(arena_extend_strategy),
+        initial_chunk_size_bytes(initial_chunk_size_bytes),
+        max_dead_bytes_per_chunk(max_dead_bytes_per_chunk),
+        initial_growth_chunk_size_bytes(initial_growth_chunk_size_bytes),
+        max_power_of_two_extend_bytes(max_power_of_two_extend_bytes) {
+    if (arena_extend_strategy == ArenaExtendStrategy::kDefault) {
+      arena_extend_strategy = ArenaExtendStrategy::kNextPowerOfTwo;
+    }
+  }
+
+  size_t max_mem;
+  ArenaExtendStrategy arena_extend_strategy;
+  int initial_chunk_size_bytes;
+  int max_dead_bytes_per_chunk;
+  int initial_growth_chunk_size_bytes;
+  int64_t max_power_of_two_extend_bytes;
+
+  bool IsValid() const {
+    return max_mem > 0 &&
+           (arena_extend_strategy == kNextPowerOfTwo || arena_extend_strategy == kSameAsRequested) &&
+           initial_chunk_size_bytes > 0 &&
+           max_dead_bytes_per_chunk > 0 &&
+           initial_growth_chunk_size_bytes > 0 &&
+           max_power_of_two_extend_bytes > 0;
+  }
+
+  struct ConfigKeyNames {
+    static constexpr const char* ArenaExtendStrategy = "arena.extend_strategy";
+    static constexpr const char* InitialChunkSizeBytes = "arena.initial_chunk_size_bytes";
+    static constexpr const char* MaxDeadBytesPerChunk = "arena.max_dead_bytes_per_chunk";
+    static constexpr const char* InitialGrowthChunkSizeBytes = "arena.initial_growth_chunk_size_bytes";
+    static constexpr const char* MaxPowerOfTwoExtendBytes = "arena.max_power_of_two_extend_bytes";
+    static constexpr const char* MaxMem = "arena.max_mem";
+  };
+
+  static ArenaConfig FromKeyValuePairs(const OrtApi& api, const OrtKeyValuePairs& kvps) {
+    ArenaConfig config{};
+    const char* value = nullptr;
+
+    if (value = api.GetKeyValue(&kvps, ConfigKeyNames::ArenaExtendStrategy); value) {
+      const std::string sval(value);
+      if (sval == "0") {
+        config.arena_extend_strategy = kNextPowerOfTwo;
+      } else if (sval == "1") {
+        config.arena_extend_strategy = kSameAsRequested;
+      } else {
+        config.arena_extend_strategy = static_cast<ArenaExtendStrategy>(-2);  // invalid — will fail IsValid()
+      }
+    }
+
+    if (value = api.GetKeyValue(&kvps, ConfigKeyNames::InitialChunkSizeBytes); value) {
+      ORT_TRY {
+        int64_t parsed = std::stoll(std::string(value));
+        if (parsed <= 0 || parsed > std::numeric_limits<int>::max()) {
+          config.initial_chunk_size_bytes = -1;  // will fail IsValid()
+        } else {
+          config.initial_chunk_size_bytes = static_cast<int>(parsed);
+        }
+      }
+      ORT_CATCH(const std::exception&) {
+        ORT_HANDLE_EXCEPTION([&]() {
+          config.initial_chunk_size_bytes = -1;  // will fail IsValid()
+        });
+      }
+    }
+
+    if (value = api.GetKeyValue(&kvps, ConfigKeyNames::MaxDeadBytesPerChunk); value) {
+      ORT_TRY {
+        int64_t parsed = std::stoll(std::string(value));
+        if (parsed <= 0 || parsed > std::numeric_limits<int>::max()) {
+          config.max_dead_bytes_per_chunk = -1;  // will fail IsValid()
+        } else {
+          config.max_dead_bytes_per_chunk = static_cast<int>(parsed);
+        }
+      }
+      ORT_CATCH(const std::exception&) {
+        ORT_HANDLE_EXCEPTION([&]() {
+          config.max_dead_bytes_per_chunk = -1;  // will fail IsValid()
+        });
+      }
+    }
+
+    if (value = api.GetKeyValue(&kvps, ConfigKeyNames::InitialGrowthChunkSizeBytes); value) {
+      ORT_TRY {
+        int64_t parsed = std::stoll(std::string(value));
+        if (parsed <= 0 || parsed > std::numeric_limits<int>::max()) {
+          config.initial_growth_chunk_size_bytes = -1;  // will fail IsValid()
+        } else {
+          config.initial_growth_chunk_size_bytes = static_cast<int>(parsed);
+        }
+      }
+      ORT_CATCH(const std::exception&) {
+        ORT_HANDLE_EXCEPTION([&]() {
+          config.initial_growth_chunk_size_bytes = -1;  // will fail IsValid()
+        });
+      }
+    }
+
+    if (value = api.GetKeyValue(&kvps, ConfigKeyNames::MaxPowerOfTwoExtendBytes); value) {
+      ORT_TRY {
+        config.max_power_of_two_extend_bytes = std::stoll(value);
+      }
+      ORT_CATCH(const std::exception&) {
+        ORT_HANDLE_EXCEPTION([&]() {
+          config.max_power_of_two_extend_bytes = -1;  // will fail IsValid()
+        });
+      }
+    }
+
+    if (value = api.GetKeyValue(&kvps, ConfigKeyNames::MaxMem); value) {
+      const std::string sval(value);
+      ORT_TRY {
+        // std::stoull silently wraps negative values via strtoull.
+        // Reject leading '-' explicitly so that e.g. "-100" doesn't become a huge budget.
+        if (!sval.empty() && sval[0] == '-') {
+          config.max_mem = 0;  // will fail IsValid()
+        } else {
+          size_t parsed = static_cast<size_t>(std::stoull(sval));
+          // Treat 0 as unlimited — avoids arithmetic issues and silent allocation failures.
+          config.max_mem = (parsed == 0) ? std::numeric_limits<size_t>::max() : parsed;
+        }
+      }
+      ORT_CATCH(const std::exception&) {
+        ORT_HANDLE_EXCEPTION([&]() {
+          config.max_mem = 0;  // will fail IsValid()
+        });
+      }
+    }
+
+    return config;
+  }
+};
+
+// Macros used by ArenaImpl (adapted from plugin_ep_utils.h for CUDA plugin namespace).
+
+#define CUDA_ARENA_ENFORCE(condition, ...)               \
+  do {                                                   \
+    if (!(condition)) {                                  \
+      std::ostringstream oss;                            \
+      oss << "CUDA_ARENA_ENFORCE failed: " << #condition \
+          << " " << __VA_ARGS__;                         \
+      ORT_THROW(oss.str());                              \
+    }                                                    \
+  } while (false)
+
+#define CUDA_ARENA_LOG(level, ...)                                                                         \
+  do {                                                                                                     \
+    std::ostringstream ss;                                                                                 \
+    ss << __VA_ARGS__;                                                                                     \
+    OrtStatus* _log_status = api_.Logger_LogMessage(&logger_, ORT_LOGGING_LEVEL_##level, ss.str().c_str(), \
+                                                    ORT_FILE, __LINE__, __FUNCTION__);                     \
+    if (_log_status) api_.ReleaseStatus(_log_status);                                                      \
+  } while (false)
+
+#define CUDA_ARENA_RETURN_ERROR(code, ...)            \
+  do {                                                \
+    std::ostringstream ss;                            \
+    ss << __VA_ARGS__;                                \
+    return api_.CreateStatus(code, ss.str().c_str()); \
+  } while (false)
+
+// A memory allocator that implements a 'best-fit with coalescing' algorithm.
+// This is essentially a very simple version of Doug Lea's malloc (dlmalloc).
+//
+// Adapted from the example plugin EP arena (ep_arena.h/cc).
+class ArenaImpl {
+ public:
+  ArenaImpl(AllocatorUniquePtr allocator, const ArenaConfig& config, const OrtApi& api,
+            const OrtLogger& logger);
+
+  ~ArenaImpl();
+
+  void* Alloc(size_t size);
+  void* AllocOnStream(size_t size, OrtSyncStream* stream);
+  void Free(void* p);
+
+  // Allocate memory directly. Used for initializers so they don't affect arena growth patterns.
+  void* Reserve(size_t size);
+
+  // Release unused memory. Frees all allocation regions where every chunk is free.
+  // Resets growth to initial_growth_chunk_size_bytes_.
+  OrtStatus* Shrink();
+
+  OrtStatus* GetStats(OrtKeyValuePairs** stats);
+
+  size_t RequestedSize(const void* ptr);
+  size_t AllocatedSize(const void* ptr);
+
+  // Un-assign chunks that are currently assigned to the stream.
+  // Called from OrtSyncStreamImpl::OnSessionRunEnd.
+  OrtStatus* ResetChunksUsingStream(const OrtSyncStreamImpl* stream_impl);
+
+ private:
+  void* AllocateRawInternal(size_t num_bytes, OrtSyncStream* stream, bool dump_log_on_failure);
+  void DeallocateRawInternal(void* ptr);
+
+  using ChunkHandle = size_t;
+  static const size_t kInvalidChunkHandle = static_cast<size_t>(-1);
+
+  using BinNum = int;
+  static const int kInvalidBinNum = -1;
+  static const int kNumBins = 21;
+
+  struct Chunk {
+    size_t size = 0;
+    size_t requested_size = 0;
+    int64_t allocation_id = -1;
+    void* ptr = nullptr;
+    ChunkHandle prev = kInvalidChunkHandle;
+    ChunkHandle next = kInvalidChunkHandle;
+    BinNum bin_num = kInvalidBinNum;
+    OrtSyncStream* stream = nullptr;
+    uint64_t stream_sync_id = 0;
+
+    bool in_use() const { return allocation_id != -1; }
+
+    std::string DebugString(ArenaImpl* a, bool recurse) {
+      std::ostringstream ss;
+      ss << "  Size: " << size << " | Requested Size: " << requested_size << " | in_use: " << in_use();
+      if (recurse && prev != ArenaImpl::kInvalidChunkHandle) {
+        Chunk* p = a->ChunkFromHandle(prev);
+        ss << ", prev: " << p->DebugString(a, false);
+      }
+      if (recurse && next != ArenaImpl::kInvalidChunkHandle) {
+        Chunk* n = a->ChunkFromHandle(next);
+        ss << ", next: " << n->DebugString(a, false);
+      }
+      return ss.str();
+    }
+  };
+
+  struct Bin {
+    size_t bin_size = 0;
+
+    struct ChunkComparator {
+      explicit ChunkComparator(ArenaImpl* allocator)
+          : allocator_(allocator) {}
+
+      bool operator()(const ChunkHandle ha, const ChunkHandle hb) const {
+        const Chunk* a = allocator_->ChunkFromHandle(ha);
+        const Chunk* b = allocator_->ChunkFromHandle(hb);
+        if (a->size != b->size) {
+          return a->size < b->size;
+        }
+        return a->ptr < b->ptr;
+      }
+
+     private:
+      ArenaImpl* allocator_;
+    };
+
+    typedef std::set<ChunkHandle, ChunkComparator> FreeChunkSet;
+    FreeChunkSet free_chunks;
+    Bin(ArenaImpl* allocator, size_t bs)
+        : bin_size(bs), free_chunks(ChunkComparator(allocator)) {}
+  };
+
+  static const size_t kMinAllocationBits = 8;
+  static const size_t kMinAllocationSize = 1 << kMinAllocationBits;
+
+  class AllocationRegion {
+   public:
+    AllocationRegion(void* ptr, size_t memory_size, int64_t id)
+        : ptr_(ptr),
+          memory_size_(memory_size),
+          end_ptr_(static_cast<void*>(static_cast<char*>(ptr_) + memory_size_)),
+          id_(id) {
+      CUDA_ARENA_ENFORCE(0 == memory_size % kMinAllocationSize, __FUNCTION__);
+      const size_t n_handles = (memory_size + kMinAllocationSize - 1) / kMinAllocationSize;
+      handles_ = std::make_unique<ChunkHandle[]>(n_handles);
+      for (size_t i = 0; i < n_handles; i++) {
+        handles_[i] = kInvalidChunkHandle;
+      }
+    }
+
+    AllocationRegion(AllocationRegion&& other) noexcept { Swap(other); }
+    AllocationRegion() = default;
+    ~AllocationRegion() = default;
+
+    AllocationRegion& operator=(AllocationRegion&& other) noexcept {
+      Swap(other);
+      return *this;
+    }
+
+    void* ptr() const { return ptr_; }
+    void* end_ptr() const { return end_ptr_; }
+    size_t memory_size() const { return memory_size_; }
+    int64_t id() const { return id_; }
+
+    ChunkHandle get_handle(const void* p) const {
+      return handles_[IndexFor(p)];
+    }
+
+    void set_handle(const void* p, ChunkHandle h) {
+      handles_[IndexFor(p)] = h;
+    }
+
+    void erase(const void* p) {
+      set_handle(p, kInvalidChunkHandle);
+    }
+
+   private:
+    void Swap(AllocationRegion& other) {
+      std::swap(ptr_, other.ptr_);
+      std::swap(memory_size_, other.memory_size_);
+      std::swap(end_ptr_, other.end_ptr_);
+      std::swap(id_, other.id_);
+      std::swap(handles_, other.handles_);
+    }
+
+    size_t IndexFor(const void* p) const {
+      std::uintptr_t p_int = reinterpret_cast<std::uintptr_t>(p);
+      std::uintptr_t base_int = reinterpret_cast<std::uintptr_t>(ptr_);
+      CUDA_ARENA_ENFORCE(p_int >= base_int, "AllocationRegion::IndexFor");
+      CUDA_ARENA_ENFORCE(p_int < base_int + memory_size_, "AllocationRegion::IndexFor");
+      return static_cast<size_t>((p_int - base_int) >> kMinAllocationBits);
+    }
+
+    void* ptr_ = nullptr;
+    size_t memory_size_ = 0;
+    void* end_ptr_ = nullptr;
+    int64_t id_ = -1;
+    std::unique_ptr<ChunkHandle[]> handles_;
+
+    AllocationRegion& operator=(const AllocationRegion&) = delete;
+  };
+
+  class RegionManager {
+   public:
+    RegionManager() = default;
+    ~RegionManager() = default;
+
+    void AddAllocationRegion(void* ptr, size_t memory_size, int64_t id) {
+      auto entry = std::upper_bound(regions_.begin(), regions_.end(), ptr, &Comparator);
+      regions_.insert(entry, AllocationRegion(ptr, memory_size, id));
+    }
+
+    void RemoveAllocationRegion(void* ptr) {
+      auto entry = std::upper_bound(regions_.begin(), regions_.end(), ptr, &Comparator);
+      CUDA_ARENA_ENFORCE(entry != regions_.end(),
+                         "RegionManager::RemoveAllocationRegion Could not find Region for: " << ptr);
+      regions_.erase(entry);
+    }
+
+    ChunkHandle get_handle(const void* p) const {
+      return RegionFor(p)->get_handle(p);
+    }
+
+    void set_handle(const void* p, ChunkHandle h) {
+      return MutableRegionFor(p)->set_handle(p, h);
+    }
+
+    void erase(const void* p) { return MutableRegionFor(p)->erase(p); }
+
+    const std::vector<AllocationRegion>& regions() const { return regions_; }
+
+   private:
+    RegionManager(const RegionManager&) = delete;
+    RegionManager& operator=(const RegionManager&) = delete;
+    RegionManager(RegionManager&&) = delete;
+    RegionManager& operator=(RegionManager&&) = delete;
+
+    static bool Comparator(const void* ptr, const AllocationRegion& other) {
+      return ptr < other.end_ptr();
+    }
+
+    AllocationRegion* MutableRegionFor(const void* p) {
+      return const_cast<AllocationRegion*>(RegionFor(p));
+    }
+
+    const AllocationRegion* RegionFor(const void* p) const {
+      auto entry = std::upper_bound(regions_.begin(), regions_.end(), p, &Comparator);
+
+      CUDA_ARENA_ENFORCE(entry != regions_.end(),
+                         "RegionManager::RegionFor Could not find Region for: " << p);
+      return &(*entry);
+    }
+
+   private:
+    std::vector<AllocationRegion> regions_;
+  };
+
+  size_t RoundedBytes(size_t bytes);
+  OrtStatus* Extend(size_t rounded_bytes);
+  Chunk* FindChunkPtr(BinNum bin_num, size_t rounded_bytes, size_t num_bytes, OrtSyncStream* stream);
+  void SplitChunk(ChunkHandle h, size_t num_bytes);
+  void Merge(ChunkHandle h, ChunkHandle h2);
+  void FreeAndMaybeCoalesce(ChunkHandle h);
+  ChunkHandle Coalesce(ChunkHandle h);
+  void InsertFreeChunkIntoBin(ChunkHandle h);
+  void RemoveFreeChunkIterFromBin(Bin::FreeChunkSet* free_chunks,
+                                  const Bin::FreeChunkSet::iterator& c);
+  void RemoveFreeChunkFromBin(ChunkHandle h);
+  Chunk* SplitFreeChunkFromBin(Bin::FreeChunkSet* free_chunks,
+                               const Bin::FreeChunkSet::iterator& citer,
+                               size_t rounded_bytes,
+                               size_t num_bytes);
+  void DeleteChunk(ChunkHandle h);
+  void DumpMemoryLog(size_t num_bytes);
+  ChunkHandle AllocateChunk();
+  void DeallocateChunk(ChunkHandle h);
+  Chunk* ChunkFromHandle(ChunkHandle h);
+
+  struct BinDebugInfo {
+    size_t total_bytes_in_use = 0;
+    size_t total_bytes_in_bin = 0;
+    size_t total_requested_bytes_in_use = 0;
+    size_t total_chunks_in_use = 0;
+    size_t total_chunks_in_bin = 0;
+  };
+
+  std::array<BinDebugInfo, kNumBins> GetBinDebugInfo();
+
+  int Log2FloorNonZeroSlow(uint64_t n) {
+    int r = 0;
+    while (n > 0) {
+      r++;
+      n >>= 1;
+    }
+    return r - 1;
+  }
+
+  int Log2FloorNonZero(uint64_t n) {
+#if defined(__GNUC__)
+    return 63 ^ __builtin_clzll(n);
+#elif defined(PLATFORM_WINDOWS) || defined(_WIN32)
+    unsigned long index;
+#if defined(_WIN64)
+    _BitScanReverse64(&index, n);
+#else
+    auto high = static_cast<unsigned long>(n >> 32);
+    if (_BitScanReverse(&index, high) > 0) {
+      index += 32;
+    } else {
+      auto low = static_cast<unsigned long>((n << 32) >> 32);
+      _BitScanReverse(&index, low);
+    }
+#endif
+    return index;
+#else
+    return Log2FloorNonZeroSlow(n);
+#endif
+  }
+
+  Bin* BinFromIndex(BinNum index) {
+    return reinterpret_cast<Bin*>(&(bins_space_[index * sizeof(Bin)]));
+  }
+
+  size_t BinNumToSize(BinNum index) {
+    return static_cast<size_t>(256) << index;
+  }
+
+  BinNum BinNumForSize(size_t bytes) {
+    uint64_t v = std::max<size_t>(bytes, 256) >> kMinAllocationBits;
+    int b = std::min(kNumBins - 1, Log2FloorNonZero(v));
+    return b;
+  }
+
+  Bin* BinForSize(size_t bytes) {
+    return BinFromIndex(BinNumForSize(bytes));
+  }
+
+  alignas(Bin) char bins_space_[sizeof(Bin) * kNumBins];
+
+  mutable std::mutex lock_;
+
+  AllocatorUniquePtr device_allocator_;
+  const std::string allocator_name_;
+  const ArenaConfig config_;
+
+  RegionManager region_manager_;
+  size_t curr_region_allocation_bytes_;
+
+  int64_t next_allocation_id_;
+
+  std::vector<Chunk> chunks_;
+  ChunkHandle free_chunks_list_;
+  std::unordered_map<void*, size_t> reserved_chunks_;
+
+  std::unordered_map<const OrtSyncStream*, std::set<ChunkHandle>> stream_to_chunks_;
+  std::unordered_map<const OrtSyncStreamImpl*, const OrtSyncStream*> impl_to_stream_;
+
+  AllocatorStats stats_{};
+
+  const OrtApi& api_;
+  const OrtEpApi& ep_api_;
+  const OrtLogger& logger_;
+
+  ArenaImpl(const ArenaImpl&) = delete;
+  ArenaImpl& operator=(const ArenaImpl&) = delete;
+  ArenaImpl(ArenaImpl&&) = delete;
+  ArenaImpl& operator=(ArenaImpl&&) = delete;
+};
+
+// CudaArenaAllocator wraps ArenaImpl and presents an OrtAllocator interface.
+// Inherits from CudaAllocatorBase for uniform allocator handling.
+class CudaArenaAllocator final : public CudaAllocatorBase {
+ public:
+  static OrtStatus* Create(CudaAllocatorKind kind,
+                           const OrtMemoryInfo* memory_info,
+                           AllocatorUniquePtr raw_allocator,
+                           const OrtKeyValuePairs* options,
+                           const OrtApi& api,
+                           const OrtLogger& logger,
+                           std::unique_ptr<CudaArenaAllocator>& out);
+
+  CudaArenaAllocator(CudaAllocatorKind kind, const OrtMemoryInfo* memory_info,
+                     std::unique_ptr<ArenaImpl> impl)
+      : CudaAllocatorBase(kind, memory_info), impl_(std::move(impl)) {
+    version = ORT_API_VERSION;
+    Alloc = AllocImpl;
+    Reserve = ReserveImpl;
+    Free = FreeImpl;
+    Info = InfoImpl;
+    GetStats = GetStatsImpl;
+    Shrink = ShrinkImpl;
+    // Stream-aware only for device arena, not pinned
+    AllocOnStream = (kind == CudaAllocatorKind::kDevice) ? AllocOnStreamImpl : nullptr;
+  }
+
+  OrtStatus* ResetChunksUsingStream(const OrtSyncStreamImpl* stream_impl) {
+    OrtStatus* err = nullptr;
+    ORT_TRY {
+      err = impl_->ResetChunksUsingStream(stream_impl);
+    }
+    ORT_CATCH(const std::exception& ex) {
+      ORT_HANDLE_EXCEPTION([&]() {
+        err = Ort::GetApi().CreateStatus(ORT_RUNTIME_EXCEPTION, ex.what());
+      });
+    }
+    ORT_CATCH(...) {
+      err = Ort::GetApi().CreateStatus(ORT_RUNTIME_EXCEPTION,
+                                       "CudaArenaAllocator::ResetChunksUsingStream failed with an unknown exception.");
+    }
+    return err;  // required for ORT_NO_EXCEPTIONS
+  }
+
+ private:
+  static void* ORT_API_CALL AllocImpl(OrtAllocator* this_, size_t size) noexcept {
+    ORT_TRY {
+      auto& arena = *static_cast<CudaArenaAllocator*>(this_);
+      return arena.impl_->Alloc(size);
+    }
+    ORT_CATCH(...) {
+    }
+    return nullptr;
+  }
+
+  static void* ORT_API_CALL AllocOnStreamImpl(OrtAllocator* this_, size_t size, OrtSyncStream* stream) noexcept {
+    ORT_TRY {
+      auto& arena = *static_cast<CudaArenaAllocator*>(this_);
+      return arena.impl_->AllocOnStream(size, stream);
+    }
+    ORT_CATCH(...) {
+    }
+    return nullptr;
+  }
+
+  static void* ORT_API_CALL ReserveImpl(OrtAllocator* this_, size_t size) noexcept {
+    ORT_TRY {
+      auto& arena = *static_cast<CudaArenaAllocator*>(this_);
+      return arena.impl_->Reserve(size);
+    }
+    ORT_CATCH(...) {
+    }
+    return nullptr;
+  }
+
+  static void ORT_API_CALL FreeImpl(OrtAllocator* this_, void* p) noexcept {
+    ORT_TRY {
+      auto& arena = *static_cast<CudaArenaAllocator*>(this_);
+      arena.impl_->Free(p);
+    }
+    ORT_CATCH(...) {
+      // Swallow: exceptions must not propagate across C ABI boundary.
+    }
+  }
+
+  static const OrtMemoryInfo* ORT_API_CALL InfoImpl(const OrtAllocator* this_) noexcept {
+    const auto& arena = *static_cast<const CudaArenaAllocator*>(this_);
+    return arena.GetMemoryInfo();
+  }
+
+  static OrtStatus* ORT_API_CALL GetStatsImpl(const OrtAllocator* this_, OrtKeyValuePairs** out) noexcept {
+    OrtStatus* err = nullptr;
+    ORT_TRY {
+      const auto& arena = *static_cast<const CudaArenaAllocator*>(this_);
+      err = arena.impl_->GetStats(out);
+    }
+    ORT_CATCH(const std::exception& ex) {
+      ORT_HANDLE_EXCEPTION([&]() {
+        err = Ort::GetApi().CreateStatus(ORT_RUNTIME_EXCEPTION, ex.what());
+      });
+    }
+    ORT_CATCH(...) {
+      err = Ort::GetApi().CreateStatus(ORT_RUNTIME_EXCEPTION,
+                                       "CudaArenaAllocator::GetStats failed with an unknown exception.");
+    }
+    return err;
+  }
+
+  static OrtStatus* ORT_API_CALL ShrinkImpl(OrtAllocator* this_) noexcept {
+    OrtStatus* err = nullptr;
+    ORT_TRY {
+      auto& arena = *static_cast<CudaArenaAllocator*>(this_);
+      err = arena.impl_->Shrink();
+    }
+    ORT_CATCH(const std::exception& ex) {
+      ORT_HANDLE_EXCEPTION([&]() {
+        err = Ort::GetApi().CreateStatus(ORT_RUNTIME_EXCEPTION, ex.what());
+      });
+    }
+    ORT_CATCH(...) {
+      err = Ort::GetApi().CreateStatus(ORT_RUNTIME_EXCEPTION,
+                                       "CudaArenaAllocator::Shrink failed with an unknown exception.");
+    }
+    return err;
+  }
+
+  std::unique_ptr<ArenaImpl> impl_;
+};
+
+}  // namespace cuda_plugin
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/plugin/cuda_ep_factory.cc
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_ep_factory.cc
@@ -9,6 +9,9 @@
 #include <algorithm>
 #include <cassert>
 #include <cctype>
+#include <climits>
+#include <cstdlib>
+#include <limits>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -103,7 +106,7 @@ std::string GetProviderOptionPrefix(std::string_view provider_name) {
   return "ep." + onnxruntime::utils::GetLowercaseString(std::string{provider_name}) + ".";
 }
 
-void LogWarning(const OrtApi& ort_api, const OrtLogger& logger, const char* file, int line,
+void LogWarning(const OrtApi& ort_api, const OrtLogger& logger, const ORTCHAR_T* file, int line,
                 const char* function, const char* msg) {
   OrtStatus* st = ort_api.Logger_LogMessage(&logger, ORT_LOGGING_LEVEL_WARNING, msg, file, line, function);
   if (st != nullptr) {
@@ -114,11 +117,13 @@ void LogWarning(const OrtApi& ort_api, const OrtLogger& logger, const char* file
 }  // namespace
 
 CudaEpFactory::HardwareDeviceKey CudaEpFactory::MakeDeviceKey(const OrtApi& ort_api,
-                                                              const OrtHardwareDevice& device) {
+                                                              const OrtHardwareDevice& device,
+                                                              int cuda_ordinal) {
   return {
       ort_api.HardwareDevice_Type(&device),
       ort_api.HardwareDevice_VendorId(&device),
       ort_api.HardwareDevice_DeviceId(&device),
+      cuda_ordinal,
   };
 }
 
@@ -133,6 +138,13 @@ OrtStatus* ORT_API_CALL CudaEpFactory::GetSupportedDevicesImpl(
   auto* factory = static_cast<CudaEpFactory*>(this_ptr);
   size_t& num_ep_devices = *p_num_ep_devices;
   num_ep_devices = 0;
+
+  // Clear stale ordinal mappings from any prior enumeration.
+  {
+    std::lock_guard<std::mutex> lock(factory->device_cache_mutex_);
+    factory->ordinal_to_device_key_.clear();
+  }
+
   auto release_ep_devices = [&](OrtStatus* status) -> OrtStatus* {
     for (size_t j = 0; j < num_ep_devices; ++j) {
       factory->ep_api_.ReleaseEpDevice(ep_devices[j]);
@@ -141,6 +153,13 @@ OrtStatus* ORT_API_CALL CudaEpFactory::GetSupportedDevicesImpl(
     num_ep_devices = 0;
     return status;
   };
+
+  // Query CUDA device count once upfront so we can validate assigned ordinals.
+  int cuda_device_count = 0;
+  cudaError_t cuda_err = cudaGetDeviceCount(&cuda_device_count);
+  if (cuda_err != cudaSuccess) {
+    cuda_device_count = 0;  // no CUDA devices available
+  }
 
   int cuda_device_index = 0;
   for (size_t i = 0; i < num_devices && num_ep_devices < max_ep_devices; ++i) {
@@ -160,7 +179,14 @@ OrtStatus* ORT_API_CALL CudaEpFactory::GetSupportedDevicesImpl(
       // mapping from the filtered hardware-device list instead of relying on the
       // ORT hardware device id, which is not guaranteed to be a CUDA ordinal.
       int current_device_id = cuda_device_index++;
-      const auto device_key = CudaEpFactory::MakeDeviceKey(factory->ort_api_, device);
+
+      // Validate the assigned ordinal is within the range of CUDA-visible devices.
+      // If hardware enumeration reports GPUs not visible to CUDA (e.g. due to
+      // CUDA_VISIBLE_DEVICES), skip them to avoid failures in allocator/stream creation.
+      if (current_device_id >= cuda_device_count) {
+        continue;
+      }
+      const auto device_key = CudaEpFactory::MakeDeviceKey(factory->ort_api_, device, current_device_id);
       DeviceCacheEntry* cache_entry = nullptr;
       {
         std::lock_guard<std::mutex> lock(factory->device_cache_mutex_);
@@ -182,6 +208,8 @@ OrtStatus* ORT_API_CALL CudaEpFactory::GetSupportedDevicesImpl(
 
         cache_entry = &it->second;
         current_device_id = cache_entry->cuda_device_id;
+        // Build ordinal → key mapping for CreateAllocatorImpl lookups.
+        factory->ordinal_to_device_key_[current_device_id] = device_key;
       }
 
       OrtKeyValuePairs* ep_metadata = nullptr;
@@ -192,9 +220,7 @@ OrtStatus* ORT_API_CALL CudaEpFactory::GetSupportedDevicesImpl(
       factory->ort_api_.AddKeyValuePair(ep_options, "device_id", std::to_string(current_device_id).c_str());
 
       // Get CUDA device properties for metadata
-      int cuda_device_count = 0;
-      cudaError_t err = cudaGetDeviceCount(&cuda_device_count);
-      if (err == cudaSuccess && cuda_device_count > 0 && current_device_id < cuda_device_count) {
+      {
         cudaDeviceProp prop;
         if (cudaGetDeviceProperties(&prop, current_device_id) == cudaSuccess) {
           factory->ort_api_.AddKeyValuePair(ep_metadata, "cuda_device_name", prop.name);
@@ -245,7 +271,7 @@ OrtStatus* ORT_API_CALL CudaEpFactory::GetSupportedDevicesImpl(
 OrtStatus* ORT_API_CALL CudaEpFactory::CreateEpImpl(
     OrtEpFactory* this_ptr,
     const OrtHardwareDevice* const* devices,
-    const OrtKeyValuePairs* const* /*ep_metadata*/,
+    const OrtKeyValuePairs* const* ep_metadata,
     size_t num_devices,
     const OrtSessionOptions* session_options,
     const OrtLogger* logger,
@@ -273,15 +299,42 @@ OrtStatus* ORT_API_CALL CudaEpFactory::CreateEpImpl(
   CudaEp::Config config{};
 
   {
+    // Resolve the CUDA ordinal from ep_metadata (set during GetSupportedDevicesImpl).
+    int cuda_ordinal = -1;
+    if (!ep_metadata || !ep_metadata[0]) {
+      return factory->ort_api_.CreateStatus(
+          ORT_INVALID_ARGUMENT,
+          "CUDA EP factory requires ep_metadata with a 'cuda_device_id' entry. "
+          "Ensure GetSupportedDevices has been called and its ep_metadata is forwarded.");
+    }
+
+    {
+      const char* ordinal_str = factory->ort_api_.GetKeyValue(ep_metadata[0], "cuda_device_id");
+      if (!ordinal_str) {
+        return factory->ort_api_.CreateStatus(
+            ORT_INVALID_ARGUMENT,
+            "Missing 'cuda_device_id' in ep_metadata. "
+            "Ensure GetSupportedDevices has been called and its ep_metadata is forwarded.");
+      }
+      char* end = nullptr;
+      long parsed = std::strtol(ordinal_str, &end, 10);
+      if (end == ordinal_str || *end != '\0' || parsed < 0 || parsed > std::numeric_limits<int>::max()) {
+        return factory->ort_api_.CreateStatus(
+            ORT_INVALID_ARGUMENT,
+            (std::string("Invalid cuda_device_id in ep_metadata: '") + ordinal_str + "'").c_str());
+      }
+      cuda_ordinal = static_cast<int>(parsed);
+    }
+
     std::lock_guard<std::mutex> lock(factory->device_cache_mutex_);
-    auto it = factory->device_cache_.find(CudaEpFactory::MakeDeviceKey(factory->ort_api_, *devices[0]));
-    if (it == factory->device_cache_.end()) {
+    auto* entry = factory->FindDeviceCacheEntryByOrdinalLocked(cuda_ordinal);
+    if (!entry) {
       return factory->ort_api_.CreateStatus(
           ORT_INVALID_ARGUMENT,
           "CUDA EP factory could not resolve the requested device. "
           "Enumerate EP devices again and retry session creation.");
     }
-    config.device_id = it->second.cuda_device_id;
+    config.device_id = entry->cuda_device_id;
   }
 
   auto try_get_session_config = [&](std::string_view key) -> std::optional<std::string> {
@@ -352,10 +405,11 @@ OrtStatus* ORT_API_CALL CudaEpFactory::CreateEpImpl(
         continue;
       }
 
-      try {
+      ORT_TRY {
         value = std::stoi(*raw_value);
         return;
-      } catch (const std::exception&) {
+      }
+      ORT_CATCH(const std::exception&) {
       }
 
       const auto normalized = ToUpper(*raw_value);
@@ -384,7 +438,7 @@ OrtStatus* ORT_API_CALL CudaEpFactory::CreateEpImpl(
         continue;
       }
 
-      try {
+      ORT_TRY {
         int parsed = std::stoi(*raw_value);
         if (parsed < 0) {
           log_invalid_session_config(key, "a non-negative integer");
@@ -393,7 +447,8 @@ OrtStatus* ORT_API_CALL CudaEpFactory::CreateEpImpl(
 
         value = parsed;
         return;
-      } catch (const std::exception&) {
+      }
+      ORT_CATCH(const std::exception&) {
       }
 
       log_invalid_session_config(key, "a non-negative integer");
@@ -457,8 +512,10 @@ void ORT_API_CALL CudaEpFactory::ReleaseEpImpl(OrtEpFactory* /*this_ptr*/, OrtEp
 OrtStatus* ORT_API_CALL CudaEpFactory::CreateAllocatorImpl(
     OrtEpFactory* this_ptr,
     const OrtMemoryInfo* memory_info,
-    const OrtKeyValuePairs* /*allocator_options*/,
+    const OrtKeyValuePairs* allocator_options,
     OrtAllocator** allocator) noexcept {
+  EXCEPTION_TO_STATUS_BEGIN
+
   auto& factory = *static_cast<CudaEpFactory*>(this_ptr);
   *allocator = nullptr;
 
@@ -474,20 +531,93 @@ OrtStatus* ORT_API_CALL CudaEpFactory::CreateAllocatorImpl(
   }
 
   if (name != nullptr && strcmp(name, "Cuda") == 0) {
-    auto cuda_allocator = std::make_unique<CudaDeviceAllocator>(memory_info, req_device_id);
-    *allocator = cuda_allocator.release();
+    // The returned pointer is safe to use after the cache mutex is released because
+    // device_cache_ is std::unordered_map (node-based) and entries are never erased.
+    DeviceCacheEntry* entry = factory.FindDeviceCacheEntryByOrdinal(req_device_id);
+    if (!entry) {
+      return factory.ort_api_.CreateStatus(
+          ORT_INVALID_ARGUMENT,
+          ("CUDA EP factory has no registered device for ordinal " +
+           std::to_string(req_device_id))
+              .c_str());
+    }
+
+    // Check if the caller requested CUDA native mempool instead of the BFC arena.
+    bool use_mempool = false;
+    if (allocator_options) {
+      const char* v = factory.ort_api_.GetKeyValue(
+          allocator_options, CudaMempoolOrtAllocator::ConfigKeyNames::UseCudaMempool);
+      use_mempool = (v != nullptr && std::string(v) == "1");
+    }
+
+    std::lock_guard<std::mutex> lock{entry->arena_mutex};
+
+    if (use_mempool) {
+      if (!entry->mempool_allocator) {
+        status = CudaMempoolOrtAllocator::Create(memory_info, allocator_options,
+                                                 factory.ort_api_, factory.default_logger_,
+                                                 entry->mempool_allocator);
+        if (status != nullptr) return status;
+      }
+      ++entry->num_mempool_users;
+      *allocator = entry->mempool_allocator.get();
+      return nullptr;
+    }
+
+    if (!entry->device_arena) {
+      AllocatorUniquePtr raw_allocator(
+          new CudaDeviceAllocator(memory_info, req_device_id),
+          [](OrtAllocator* p) { delete static_cast<CudaDeviceAllocator*>(p); });
+      status = CudaArenaAllocator::Create(CudaAllocatorKind::kDevice, memory_info,
+                                          std::move(raw_allocator), allocator_options,
+                                          factory.ort_api_, factory.default_logger_,
+                                          entry->device_arena);
+      if (status != nullptr) return status;
+    } else if (allocator_options) {
+      LogWarning(factory.ort_api_, factory.default_logger_, ORT_FILE, __LINE__, __FUNCTION__,
+                 "CUDA device arena already exists; session arena options are ignored.");
+    }
+    ++entry->num_device_arena_users;
+    *allocator = entry->device_arena.get();
     return nullptr;
   }
 
   if (name != nullptr && strcmp(name, "CudaPinned") == 0) {
-    auto pinned_allocator = std::make_unique<CudaPinnedAllocator>(memory_info);
-    *allocator = pinned_allocator.release();
+    // Pinned memory is CPU-side; find the cache entry for the device it's associated with.
+    // Pointer stability: same guarantee as the Cuda branch above.
+    DeviceCacheEntry* entry = factory.FindDeviceCacheEntryByOrdinal(req_device_id);
+    if (!entry) {
+      // Fallback: if no device cache entry (shouldn't normally happen), create raw allocator.
+      auto pinned_allocator = std::make_unique<CudaPinnedAllocator>(memory_info);
+      *allocator = pinned_allocator.release();
+      return nullptr;
+    }
+
+    std::lock_guard<std::mutex> lock{entry->arena_mutex};
+
+    if (!entry->pinned_arena) {
+      AllocatorUniquePtr raw_allocator(
+          new CudaPinnedAllocator(memory_info),
+          [](OrtAllocator* p) { delete static_cast<CudaPinnedAllocator*>(p); });
+      status = CudaArenaAllocator::Create(CudaAllocatorKind::kPinned, memory_info,
+                                          std::move(raw_allocator), allocator_options,
+                                          factory.ort_api_, factory.default_logger_,
+                                          entry->pinned_arena);
+      if (status != nullptr) return status;
+    } else if (allocator_options) {
+      LogWarning(factory.ort_api_, factory.default_logger_, ORT_FILE, __LINE__, __FUNCTION__,
+                 "CUDA pinned arena already exists; session arena options are ignored.");
+    }
+    ++entry->num_pinned_arena_users;
+    *allocator = entry->pinned_arena.get();
     return nullptr;
   }
 
   return factory.ort_api_.CreateStatus(
       ORT_INVALID_ARGUMENT,
       "Unknown memory info provided to CUDA EP CreateAllocator.");
+
+  EXCEPTION_TO_STATUS_END
 }
 
 /*static*/
@@ -495,6 +625,47 @@ void ORT_API_CALL CudaEpFactory::ReleaseAllocatorImpl(
     OrtEpFactory* this_ptr, OrtAllocator* allocator) noexcept {
   if (!allocator) return;
   auto* factory = static_cast<CudaEpFactory*>(this_ptr);
+
+  // Check if allocator is a shared arena or mempool (pointer identity match).
+  // Lock ordering: device_cache_mutex_ must always be acquired BEFORE any entry.arena_mutex.
+  {
+    std::lock_guard<std::mutex> cache_lock(factory->device_cache_mutex_);
+    for (auto& [key, entry] : factory->device_cache_) {
+      std::lock_guard<std::mutex> lock{entry.arena_mutex};
+      if (allocator == entry.device_arena.get()) {
+        if (entry.num_device_arena_users <= 0) {
+          LogWarning(factory->ort_api_, factory->default_logger_, ORT_FILE, __LINE__,
+                     "CudaEpFactory::ReleaseAllocatorImpl",
+                     "Refcount underflow in ReleaseAllocatorImpl (device_arena). Ignoring release.");
+          return;
+        }
+        if (--entry.num_device_arena_users == 0) entry.device_arena.reset();
+        return;
+      }
+      if (allocator == entry.pinned_arena.get()) {
+        if (entry.num_pinned_arena_users <= 0) {
+          LogWarning(factory->ort_api_, factory->default_logger_, ORT_FILE, __LINE__,
+                     "CudaEpFactory::ReleaseAllocatorImpl",
+                     "Refcount underflow in ReleaseAllocatorImpl (pinned_arena). Ignoring release.");
+          return;
+        }
+        if (--entry.num_pinned_arena_users == 0) entry.pinned_arena.reset();
+        return;
+      }
+      if (allocator == entry.mempool_allocator.get()) {
+        if (entry.num_mempool_users <= 0) {
+          LogWarning(factory->ort_api_, factory->default_logger_, ORT_FILE, __LINE__,
+                     "CudaEpFactory::ReleaseAllocatorImpl",
+                     "Refcount underflow in ReleaseAllocatorImpl (mempool). Ignoring release.");
+          return;
+        }
+        if (--entry.num_mempool_users == 0) entry.mempool_allocator.reset();
+        return;
+      }
+    }
+  }
+
+  // Fallback: raw allocator not managed by arena (e.g. read-only allocator).
   auto* typed_allocator = static_cast<CudaAllocatorBase*>(allocator);
   switch (typed_allocator->GetKind()) {
     case CudaAllocatorKind::kDevice:
@@ -504,7 +675,7 @@ void ORT_API_CALL CudaEpFactory::ReleaseAllocatorImpl(
       delete static_cast<CudaPinnedAllocator*>(allocator);
       return;
     default:
-      LogWarning(factory->ort_api_, factory->default_logger_, __FILE__, __LINE__,
+      LogWarning(factory->ort_api_, factory->default_logger_, ORT_FILE, __LINE__,
                  "CudaEpFactory::ReleaseAllocatorImpl",
                  "ReleaseAllocatorImpl received an unknown CudaAllocatorKind. Leaking the allocator instance.");
       assert(false && "Unknown CudaAllocatorKind");
@@ -546,6 +717,43 @@ OrtStatus* ORT_API_CALL CudaEpFactory::CreateSyncStreamForDeviceImpl(
   return nullptr;
 
   EXCEPTION_TO_STATUS_END
+}
+
+CudaEpFactory::DeviceCacheEntry* CudaEpFactory::FindDeviceCacheEntryByOrdinalLocked(int cuda_ordinal) {
+  auto key_it = ordinal_to_device_key_.find(cuda_ordinal);
+  if (key_it == ordinal_to_device_key_.end()) {
+    return nullptr;
+  }
+  auto cache_it = device_cache_.find(key_it->second);
+  if (cache_it == device_cache_.end()) {
+    return nullptr;
+  }
+  return &cache_it->second;
+}
+
+// IMPORTANT: Entries are never erased from device_cache_ after insertion.
+// This guarantees pointer stability for DeviceCacheEntry* returned by
+// FindDeviceCacheEntryByOrdinal() after the lock is released.
+CudaEpFactory::DeviceCacheEntry* CudaEpFactory::FindDeviceCacheEntryByOrdinal(int cuda_ordinal) {
+  std::lock_guard<std::mutex> lock(device_cache_mutex_);
+  return FindDeviceCacheEntryByOrdinalLocked(cuda_ordinal);
+}
+
+CudaArenaAllocator* CudaEpFactory::GetDeviceArenaForDevice(int device_id) {
+  // Pointer stability: std::unordered_map is node-based; entries are never erased.
+  DeviceCacheEntry* entry = FindDeviceCacheEntryByOrdinal(device_id);
+  if (!entry) return nullptr;
+  std::lock_guard<std::mutex> lock{entry->arena_mutex};
+  return entry->device_arena.get();
+}
+
+OrtStatus* CudaEpFactory::ResetDeviceArenaChunksUsingStream(int device_id,
+                                                            const OrtSyncStreamImpl* stream_impl) {
+  DeviceCacheEntry* entry = FindDeviceCacheEntryByOrdinal(device_id);
+  if (!entry) return nullptr;
+  std::lock_guard<std::mutex> lock{entry->arena_mutex};
+  if (!entry->device_arena) return nullptr;
+  return entry->device_arena->ResetChunksUsingStream(stream_impl);
 }
 
 }  // namespace cuda_plugin

--- a/onnxruntime/core/providers/cuda/plugin/cuda_ep_factory.h
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_ep_factory.h
@@ -5,6 +5,8 @@
 
 #include "cuda_plugin_utils.h"
 #include "cuda_allocator_plugin.h"
+#include "cuda_arena.h"
+#include "cuda_mempool_allocator_plugin.h"
 #include "cuda_data_transfer_plugin.h"
 #include "cuda_stream_plugin.h"
 
@@ -12,6 +14,8 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+
+#include "core/common/inlined_containers.h"
 
 namespace onnxruntime {
 namespace cuda_plugin {
@@ -29,6 +33,14 @@ class CudaEpFactory : public OrtEpFactory {
   const OrtApi& GetOrtApi() const { return ort_api_; }
   const OrtEpApi& GetEpApi() const { return ep_api_; }
   const std::string& GetEpName() const { return ep_name_; }
+
+  /// Get the device arena allocator for the given CUDA ordinal, or nullptr if none.
+  CudaArenaAllocator* GetDeviceArenaForDevice(int device_id);
+
+  /// Reset arena chunk-to-stream assignments for a device while holding the arena lock.
+  /// This avoids the use-after-free risk of calling GetDeviceArenaForDevice() and then
+  /// using the raw pointer after the arena_mutex is released.
+  OrtStatus* ResetDeviceArenaChunksUsingStream(int device_id, const OrtSyncStreamImpl* stream_impl);
 
   /// Get or create the shared kernel registry for this factory.
   /// Lazily created on first call; subsequent calls return the cached instance.
@@ -94,12 +106,22 @@ class CudaEpFactory : public OrtEpFactory {
     int cuda_device_id{-1};
     Ort::MemoryInfo device_memory_info{nullptr};
     Ort::MemoryInfo pinned_memory_info{nullptr};
+
+    // Arena members
+    std::mutex arena_mutex;
+    std::unique_ptr<CudaArenaAllocator> device_arena;
+    std::unique_ptr<CudaArenaAllocator> pinned_arena;
+    std::unique_ptr<CudaMempoolOrtAllocator> mempool_allocator;
+    int num_device_arena_users = 0;
+    int num_pinned_arena_users = 0;
+    int num_mempool_users = 0;
   };
 
   struct HardwareDeviceKey {
     OrtHardwareDeviceType type{OrtHardwareDeviceType::OrtHardwareDeviceType_CPU};
     uint32_t vendor_id{0};
-    uint32_t device_id{0};
+    uint32_t device_id{0};  // PCI device ID — identifies the hardware model, NOT a unique device
+    int cuda_ordinal{-1};   // CUDA ordinal — unique per physical GPU on this host
 
     bool operator==(const HardwareDeviceKey&) const = default;
   };
@@ -109,17 +131,29 @@ class CudaEpFactory : public OrtEpFactory {
       size_t hash = static_cast<size_t>(key.type);
       hash = (hash * 1315423911u) ^ static_cast<size_t>(key.vendor_id);
       hash = (hash * 1315423911u) ^ static_cast<size_t>(key.device_id);
+      hash = (hash * 1315423911u) ^ static_cast<size_t>(key.cuda_ordinal);
       return hash;
     }
   };
 
   static HardwareDeviceKey MakeDeviceKey(const OrtApi& ort_api,
-                                         const OrtHardwareDevice& device);
+                                         const OrtHardwareDevice& device,
+                                         int cuda_ordinal);
 
-  // Stable per-device cache keyed by public hardware-device properties instead
-  // of the transient OrtHardwareDevice* pointer received during enumeration.
+  // Per-physical-device cache. The key includes the CUDA ordinal to distinguish
+  // identical GPUs (same PCI vendor/device ID) on multi-GPU hosts.
   std::mutex device_cache_mutex_;
   std::unordered_map<HardwareDeviceKey, DeviceCacheEntry, HardwareDeviceKeyHasher> device_cache_;
+
+  // Ordinal-to-HardwareDeviceKey mapping built during GetSupportedDevicesImpl.
+  InlinedHashMap<int, HardwareDeviceKey> ordinal_to_device_key_;
+
+  /// Find the DeviceCacheEntry for a given CUDA ordinal.
+  /// Returns nullptr if the ordinal has not been registered.
+  DeviceCacheEntry* FindDeviceCacheEntryByOrdinal(int cuda_ordinal);
+
+  /// Same as FindDeviceCacheEntryByOrdinal but assumes device_cache_mutex_ is already held.
+  DeviceCacheEntry* FindDeviceCacheEntryByOrdinalLocked(int cuda_ordinal);
 
   // Kernel registry (cached, shared across EP instances)
   OrtKernelRegistry* kernel_registry_ = nullptr;

--- a/onnxruntime/core/providers/cuda/plugin/cuda_kernel_adapter.h
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_kernel_adapter.h
@@ -21,6 +21,7 @@
 #include "core/common/float8.h"
 #include "core/framework/float4.h"
 #include "core/framework/allocator.h"
+#include "core/framework/stream_handles.h"
 #include "core/framework/tensor_shape.h"
 #include "core/util/math.h"
 #include <gsl/gsl>

--- a/onnxruntime/core/providers/cuda/plugin/cuda_mempool_allocator_plugin.cc
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_mempool_allocator_plugin.cc
@@ -1,0 +1,438 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "cuda_mempool_allocator_plugin.h"
+
+#include <algorithm>
+#include <sstream>
+#include <string>
+
+#include "core/common/common.h"
+
+namespace onnxruntime {
+namespace cuda_plugin {
+
+namespace {
+
+void LogMessage(const OrtApi& api, const OrtLogger& logger,
+                OrtLoggingLevel level, const char* msg) {
+  OrtStatus* st = api.Logger_LogMessage(&logger, level, msg, ORT_FILE, __LINE__,
+                                        "CudaMempoolOrtAllocator");
+  if (st != nullptr) {
+    api.ReleaseStatus(st);
+  }
+}
+
+}  // namespace
+
+// static
+OrtStatus* CudaMempoolOrtAllocator::Create(const OrtMemoryInfo* memory_info,
+                                           const OrtKeyValuePairs* options,
+                                           const OrtApi& api,
+                                           const OrtLogger& logger,
+                                           std::unique_ptr<CudaMempoolOrtAllocator>& out) {
+  // Parse config from options
+  uint64_t pool_release_threshold = 0;
+  size_t bytes_to_keep_on_shrink = 0;
+
+  if (options) {
+    auto parse_uint64 = [&](const char* key, uint64_t& out_val) -> OrtStatus* {
+      const char* v = api.GetKeyValue(options, key);
+      if (!v) return nullptr;
+      const std::string sval(v);
+      // std::stoull silently wraps negative values via strtoull.
+      // Reject leading '-' so e.g. "-1" doesn't become a huge value.
+      if (!sval.empty() && sval[0] == '-') {
+        return api.CreateStatus(
+            ORT_INVALID_ARGUMENT,
+            (std::string("Negative value for ") + key + ": '" + v + "'").c_str());
+      }
+      OrtStatus* parse_status = nullptr;
+      ORT_TRY {
+        out_val = std::stoull(sval);
+      }
+      ORT_CATCH(const std::exception& ex) {
+        ORT_HANDLE_EXCEPTION([&]() {
+          parse_status = api.CreateStatus(
+              ORT_INVALID_ARGUMENT,
+              (std::string("Invalid value for ") + key + ": '" + v + "' — " + ex.what())
+                  .c_str());
+        });
+      }
+      return parse_status;
+    };
+
+    OrtStatus* st = parse_uint64(ConfigKeyNames::PoolReleaseThreshold, pool_release_threshold);
+    if (st) return st;
+
+    uint64_t keep_val = 0;
+    st = parse_uint64(ConfigKeyNames::BytesToKeepOnShrink, keep_val);
+    if (st) return st;
+    bytes_to_keep_on_shrink = static_cast<size_t>(keep_val);
+  }
+
+  // Get device id from memory_info
+  int device_id = 0;
+  OrtStatus* status = api.MemoryInfoGetId(memory_info, &device_id);
+  if (status != nullptr) {
+    return status;
+  }
+
+  // Check CUDA version supports mempools (requires 11.2+)
+  int cuda_rt_version = 0;
+  cudaError_t cuda_err = cudaRuntimeGetVersion(&cuda_rt_version);
+  if (cuda_err != cudaSuccess || cuda_rt_version < 11020) {
+    return api.CreateStatus(
+        ORT_NOT_IMPLEMENTED,
+        "CUDA mempool requires CUDA runtime 11.2 or later.");
+  }
+
+  int cuda_driver_version = 0;
+  cuda_err = cudaDriverGetVersion(&cuda_driver_version);
+  if (cuda_err != cudaSuccess || cuda_driver_version < 11020) {
+    return api.CreateStatus(
+        ORT_NOT_IMPLEMENTED,
+        "CUDA mempool requires CUDA driver 11.2 or later.");
+  }
+
+  // Create a process-local device memory pool
+  cudaMemPoolProps props{};
+  props.allocType = cudaMemAllocationTypePinned;
+  props.handleTypes = cudaMemHandleTypeNone;
+  props.location.type = cudaMemLocationTypeDevice;
+  props.location.id = device_id;
+
+  cudaMemPool_t pool = nullptr;
+  cuda_err = cudaMemPoolCreate(&pool, &props);
+  if (cuda_err != cudaSuccess) {
+    std::string msg = "cudaMemPoolCreate failed for device " + std::to_string(device_id) +
+                      ": " + cudaGetErrorName(cuda_err) + ": " + cudaGetErrorString(cuda_err);
+    return api.CreateStatus(ORT_EP_FAIL, msg.c_str());
+  }
+
+  if (pool_release_threshold != 0) {
+    cuda_err = cudaMemPoolSetAttribute(pool, cudaMemPoolAttrReleaseThreshold,
+                                       &pool_release_threshold);
+    if (cuda_err != cudaSuccess) {
+      cudaMemPoolDestroy(pool);
+      std::string msg = "cudaMemPoolSetAttribute(ReleaseThreshold) failed: " +
+                        std::string(cudaGetErrorName(cuda_err));
+      return api.CreateStatus(ORT_EP_FAIL, msg.c_str());
+    }
+  }
+
+  out = std::unique_ptr<CudaMempoolOrtAllocator>(
+      new CudaMempoolOrtAllocator(memory_info, api, logger, pool, device_id,
+                                  pool_release_threshold, bytes_to_keep_on_shrink));
+
+  {
+    std::ostringstream oss;
+    oss << "CudaMempoolOrtAllocator created on device " << device_id
+        << " with pool_release_threshold=" << pool_release_threshold
+        << " bytes_to_keep_on_shrink=" << bytes_to_keep_on_shrink << ".";
+    LogMessage(api, logger, ORT_LOGGING_LEVEL_INFO, oss.str().c_str());
+  }
+
+  return nullptr;
+}
+
+CudaMempoolOrtAllocator::CudaMempoolOrtAllocator(const OrtMemoryInfo* memory_info,
+                                                 const OrtApi& api,
+                                                 const OrtLogger& logger,
+                                                 cudaMemPool_t pool,
+                                                 int device_id,
+                                                 uint64_t pool_release_threshold,
+                                                 size_t bytes_to_keep_on_shrink)
+    : CudaAllocatorBase(CudaAllocatorKind::kDevice, memory_info),
+      ort_api_(api),
+      logger_(logger),
+      device_id_(device_id),
+      pool_(pool),
+      pool_release_threshold_(pool_release_threshold),
+      bytes_to_keep_on_shrink_(bytes_to_keep_on_shrink) {
+  version = ORT_API_VERSION;
+  Alloc = AllocImpl;
+  AllocOnStream = AllocOnStreamImpl;
+  Free = FreeImpl;
+  Reserve = ReserveImpl;
+  Info = InfoImpl;
+  GetStats = GetStatsImpl;
+  Shrink = ShrinkImpl;
+}
+
+CudaMempoolOrtAllocator::~CudaMempoolOrtAllocator() {
+  // Ensure we target the correct GPU — cudaDeviceSynchronize() and the default
+  // stream are per-current-device, not per-pool.
+  int prev_device = -1;
+  const bool restore = cudaGetDevice(&prev_device) == cudaSuccess;
+  ORT_IGNORE_RETURN_VALUE(cudaSetDevice(device_id_));
+
+  // Enqueue frees for any remaining allocations on their recorded streams.
+  for (auto& [ptr, rec] : alloc_map_) {
+    ORT_IGNORE_RETURN_VALUE(cudaFreeAsync(ptr, rec.stream));
+  }
+
+  SyncAllKnownStreams();
+  alloc_map_.clear();
+  stream_map_.clear();
+
+  // Safety barrier: SyncAllKnownStreams() only synchronizes streams tracked in
+  // stream_map_. If any allocation was made visible to a stream not tracked here
+  // (e.g., via cudaMemPoolExportPointer or external code passing the pointer to
+  // another stream), those operations would not be captured. cudaDeviceSynchronize()
+  // ensures all such untracked work completes before we trim/destroy the pool.
+  ORT_IGNORE_RETURN_VALUE(cudaDeviceSynchronize());
+
+  if (pool_) {
+    // Destructor always trims to 0 — the pool is about to be destroyed.
+    // bytes_to_keep_on_shrink_ is for the explicit Shrink() path, not teardown.
+    ORT_IGNORE_RETURN_VALUE(cudaMemPoolTrimTo(pool_, 0));
+    ORT_IGNORE_RETURN_VALUE(cudaMemPoolDestroy(pool_));
+    pool_ = nullptr;
+  }
+
+  if (restore) {
+    ORT_IGNORE_RETURN_VALUE(cudaSetDevice(prev_device));
+  }
+}
+
+void* CudaMempoolOrtAllocator::AllocInternal(size_t size, cudaStream_t stream) {
+  void* p = nullptr;
+  cudaError_t err = cudaMallocFromPoolAsync(&p, size, pool_, stream);
+  if (err != cudaSuccess) {
+    // Return nullptr for all CUDA errors — ORT_THROW would abort() under
+    // ORT_NO_EXCEPTIONS, and exceptions must not propagate across the C ABI
+    // boundary from the noexcept Alloc/AllocOnStream callbacks.
+    std::string msg = std::string("CudaMempoolOrtAllocator: cudaMallocFromPoolAsync failed: ") +
+                      cudaGetErrorName(err) + ": " + cudaGetErrorString(err) +
+                      ", size=" + std::to_string(size);
+    LogMessage(ort_api_, logger_, ORT_LOGGING_LEVEL_ERROR, msg.c_str());
+    return nullptr;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    alloc_map_.emplace(p, AllocationRecord{size, stream});
+    stream_map_[stream].insert(p);
+
+    in_use_bytes_ += size;
+    max_bytes_in_use_ = std::max(max_bytes_in_use_, in_use_bytes_);
+    max_alloc_size_ = std::max(max_alloc_size_, size);
+    ++num_allocs_;
+  }
+
+  return p;
+}
+
+cudaStream_t CudaMempoolOrtAllocator::ResolveCudaStream(OrtSyncStream* stream) const {
+  if (!stream) return static_cast<cudaStream_t>(0);
+  return static_cast<cudaStream_t>(ort_api_.SyncStream_GetHandle(stream));
+}
+
+void CudaMempoolOrtAllocator::SyncAllKnownStreams() noexcept {
+  for (const auto& [stream, ptrs] : stream_map_) {
+    ORT_IGNORE_RETURN_VALUE(cudaStreamSynchronize(stream));
+  }
+}
+
+// --- OrtAllocator C callbacks ---
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(push)
+#pragma warning(disable : 4702)  // unreachable code — required for ORT_NO_EXCEPTIONS builds
+#endif
+
+/*static*/
+void* ORT_API_CALL CudaMempoolOrtAllocator::AllocImpl(OrtAllocator* this_, size_t size) noexcept {
+  if (size == 0) return nullptr;
+  ORT_TRY {
+    auto& self = *static_cast<CudaMempoolOrtAllocator*>(this_);
+    constexpr cudaStream_t kDefaultStream = static_cast<cudaStream_t>(0);
+    // The legacy default stream (NULL / 0) is per-current-device. Ensure we
+    // target the correct GPU so the allocation lands on the pool's device.
+    int prev_device = -1;
+    const bool restore = cudaGetDevice(&prev_device) == cudaSuccess;
+    if (cudaSetDevice(self.device_id_) != cudaSuccess) {
+      if (restore) cudaSetDevice(prev_device);
+      return nullptr;
+    }
+    void* p = self.AllocInternal(size, kDefaultStream);
+    if (restore) cudaSetDevice(prev_device);
+    return p;
+  }
+  ORT_CATCH(...) {
+    return nullptr;
+  }
+  return nullptr;
+}
+
+/*static*/
+void* ORT_API_CALL CudaMempoolOrtAllocator::AllocOnStreamImpl(OrtAllocator* this_, size_t size,
+                                                              OrtSyncStream* stream) noexcept {
+  if (size == 0) return nullptr;
+  ORT_TRY {
+    auto& self = *static_cast<CudaMempoolOrtAllocator*>(this_);
+    cudaStream_t s = self.ResolveCudaStream(stream);
+    return self.AllocInternal(size, s);
+  }
+  ORT_CATCH(...) {
+    return nullptr;
+  }
+  return nullptr;
+}
+
+/*static*/
+void ORT_API_CALL CudaMempoolOrtAllocator::FreeImpl(OrtAllocator* this_, void* p) noexcept {
+  if (!p) return;
+  ORT_TRY {
+    auto& self = *static_cast<CudaMempoolOrtAllocator*>(this_);
+
+    cudaStream_t s = static_cast<cudaStream_t>(0);
+    size_t sz = 0;
+
+    {
+      std::lock_guard<std::mutex> lock(self.mutex_);
+      auto it = self.alloc_map_.find(p);
+      if (it == self.alloc_map_.end()) {
+        LogMessage(self.ort_api_, self.logger_, ORT_LOGGING_LEVEL_WARNING,
+                   "CudaMempoolOrtAllocator::Free: pointer not found in allocation map; ignoring.");
+        return;
+      }
+
+      s = it->second.stream;
+      sz = it->second.bytes;
+      self.alloc_map_.erase(it);
+
+      auto sit = self.stream_map_.find(s);
+      if (sit != self.stream_map_.end()) {
+        sit->second.erase(p);
+        if (sit->second.empty()) {
+          self.stream_map_.erase(sit);
+        }
+      }
+
+      self.in_use_bytes_ = (sz <= self.in_use_bytes_) ? (self.in_use_bytes_ - sz) : 0;
+    }
+
+    // Ordered free on the stream that allocated p
+    cudaError_t err = cudaFreeAsync(p, s);
+    if (err != cudaSuccess) {
+      LogMessage(self.ort_api_, self.logger_, ORT_LOGGING_LEVEL_WARNING,
+                 "CudaMempoolOrtAllocator::Free: cudaFreeAsync failed.");
+    }
+  }
+  ORT_CATCH(...) {
+    // Swallow: exceptions must not propagate across C ABI boundary.
+  }
+}
+
+/*static*/
+void* ORT_API_CALL CudaMempoolOrtAllocator::ReserveImpl(OrtAllocator* this_, size_t size) noexcept {
+  // Reserve is implemented as Alloc — all memory is freed when the allocator is destroyed.
+  return AllocImpl(this_, size);
+}
+
+/*static*/
+const OrtMemoryInfo* ORT_API_CALL CudaMempoolOrtAllocator::InfoImpl(
+    const OrtAllocator* this_) noexcept {
+  const auto& self = *static_cast<const CudaMempoolOrtAllocator*>(this_);
+  return self.GetMemoryInfo();
+}
+
+/*static*/
+OrtStatus* ORT_API_CALL CudaMempoolOrtAllocator::GetStatsImpl(
+    const OrtAllocator* this_, OrtKeyValuePairs** out) noexcept {
+  ORT_TRY {
+    const auto& self = *static_cast<const CudaMempoolOrtAllocator*>(this_);
+
+    OrtKeyValuePairs* kvps = nullptr;
+    self.ort_api_.CreateKeyValuePairs(&kvps);
+
+    AllocatorStats stats{};
+    {
+      std::lock_guard<std::mutex> lock(self.mutex_);
+      stats.num_allocs = static_cast<int64_t>(self.num_allocs_);
+      stats.bytes_in_use = static_cast<int64_t>(self.in_use_bytes_);
+      stats.max_bytes_in_use = static_cast<int64_t>(self.max_bytes_in_use_);
+      stats.max_alloc_size = static_cast<int64_t>(self.max_alloc_size_);
+      stats.num_arena_shrinkages = static_cast<int64_t>(self.num_arena_shrinkages_);
+    }
+
+    // TotalAllocated reflects memory currently reserved by the pool (held from the
+    // driver), matching BFC arena semantics where it tracks region memory in use.
+    size_t reserved = 0;
+    if (cudaMemPoolGetAttribute(self.pool_, cudaMemPoolAttrReservedMemCurrent, &reserved) == cudaSuccess) {
+      stats.total_allocated_bytes = static_cast<int64_t>(reserved);
+    }
+
+    stats.ToKeyValuePairs(self.ort_api_, kvps);
+    *out = kvps;
+    return nullptr;
+  }
+  ORT_CATCH(const std::exception& ex) {
+    OrtStatus* err = nullptr;
+    ORT_HANDLE_EXCEPTION([&]() {
+      err = Ort::GetApi().CreateStatus(ORT_RUNTIME_EXCEPTION, ex.what());
+    });
+    return err;
+  }
+  ORT_CATCH(...) {
+    return Ort::GetApi().CreateStatus(ORT_RUNTIME_EXCEPTION,
+                                      "CudaMempoolOrtAllocator::GetStats failed.");
+  }
+  return nullptr;  // required for ORT_NO_EXCEPTIONS
+}
+
+/*static*/
+OrtStatus* ORT_API_CALL CudaMempoolOrtAllocator::ShrinkImpl(OrtAllocator* this_) noexcept {
+  ORT_TRY {
+    auto& self = *static_cast<CudaMempoolOrtAllocator*>(this_);
+
+    cudaError_t err = cudaMemPoolTrimTo(self.pool_, self.bytes_to_keep_on_shrink_);
+    if (err != cudaSuccess) {
+      std::string msg = std::string("cudaMemPoolTrimTo failed: ") +
+                        cudaGetErrorName(err) + ": " + cudaGetErrorString(err);
+      return Ort::GetApi().CreateStatus(ORT_EP_FAIL, msg.c_str());
+    }
+
+    {
+      std::ostringstream oss;
+
+      size_t reserved_size = 0;
+      if (cudaMemPoolGetAttribute(self.pool_, cudaMemPoolAttrReservedMemCurrent,
+                                  &reserved_size) == cudaSuccess) {
+        oss << "CudaMempoolOrtAllocator::Shrink: reserved size after trim: "
+            << reserved_size << " bytes.";
+      } else {
+        oss << "CudaMempoolOrtAllocator::Shrink: pool trimmed; unable to query reserved size.";
+      }
+      LogMessage(self.ort_api_, self.logger_, ORT_LOGGING_LEVEL_INFO, oss.str().c_str());
+    }
+
+    {
+      std::lock_guard<std::mutex> lock(self.mutex_);
+      ++self.num_arena_shrinkages_;
+    }
+
+    return nullptr;
+  }
+  ORT_CATCH(const std::exception& ex) {
+    OrtStatus* err = nullptr;
+    ORT_HANDLE_EXCEPTION([&]() {
+      err = Ort::GetApi().CreateStatus(ORT_RUNTIME_EXCEPTION, ex.what());
+    });
+    return err;
+  }
+  ORT_CATCH(...) {
+    return Ort::GetApi().CreateStatus(ORT_RUNTIME_EXCEPTION,
+                                      "CudaMempoolOrtAllocator::Shrink failed.");
+  }
+  return nullptr;  // required for ORT_NO_EXCEPTIONS
+}
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(pop)
+#endif
+
+}  // namespace cuda_plugin
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/plugin/cuda_mempool_allocator_plugin.h
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_mempool_allocator_plugin.h
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// CudaMempoolOrtAllocator: OrtAllocator wrapper around CUDA native memory pools
+// (cudaMallocFromPoolAsync / cudaFreeAsync) for the plugin EP.
+// Stream-aware, using a process-local cudaMemPool_t per device.
+
+#pragma once
+
+#include <cuda_runtime_api.h>
+
+#include <cstdint>
+#include <mutex>
+
+#include "cuda_allocator_plugin.h"
+#include "cuda_plugin_utils.h"
+
+#include "core/common/inlined_containers.h"
+
+namespace onnxruntime {
+namespace cuda_plugin {
+
+/// OrtAllocator wrapper around a private CUDA mempool for stream-ordered allocation.
+/// Inherits from CudaAllocatorBase so the factory's ReleaseAllocatorImpl can identify
+/// and manage it via GetKind() and pointer-identity matching.
+class CudaMempoolOrtAllocator final : public CudaAllocatorBase {
+ public:
+  /// Config keys recognized in the allocator_options OrtKeyValuePairs.
+  struct ConfigKeyNames {
+    static constexpr const char* UseCudaMempool = "arena.use_cuda_mempool";
+    static constexpr const char* PoolReleaseThreshold = "arena.cuda_mempool_release_threshold";
+    static constexpr const char* BytesToKeepOnShrink = "arena.cuda_mempool_bytes_to_keep_on_shrink";
+  };
+
+  /// Create a CudaMempoolOrtAllocator for the given memory_info device.
+  /// @param memory_info   OrtMemoryInfo identifying the CUDA device.
+  /// @param options        Optional config (release threshold, shrink target).
+  /// @param api            The OrtApi for logging and KVP operations.
+  /// @param logger         The OrtLogger for diagnostic messages.
+  /// @param[out] out       Receives the created allocator on success.
+  /// @return nullptr on success, OrtStatus* on failure.
+  static OrtStatus* Create(const OrtMemoryInfo* memory_info,
+                           const OrtKeyValuePairs* options,
+                           const OrtApi& api,
+                           const OrtLogger& logger,
+                           std::unique_ptr<CudaMempoolOrtAllocator>& out);
+
+  ~CudaMempoolOrtAllocator();
+
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(CudaMempoolOrtAllocator);
+
+ private:
+  CudaMempoolOrtAllocator(const OrtMemoryInfo* memory_info,
+                          const OrtApi& api,
+                          const OrtLogger& logger,
+                          cudaMemPool_t pool,
+                          int device_id,
+                          uint64_t pool_release_threshold,
+                          size_t bytes_to_keep_on_shrink);
+
+  // OrtAllocator callback implementations
+  static void* ORT_API_CALL AllocImpl(OrtAllocator* this_, size_t size) noexcept;
+  static void* ORT_API_CALL AllocOnStreamImpl(OrtAllocator* this_, size_t size,
+                                              OrtSyncStream* stream) noexcept;
+  static void ORT_API_CALL FreeImpl(OrtAllocator* this_, void* p) noexcept;
+  static void* ORT_API_CALL ReserveImpl(OrtAllocator* this_, size_t size) noexcept;
+  static const OrtMemoryInfo* ORT_API_CALL InfoImpl(const OrtAllocator* this_) noexcept;
+  static OrtStatus* ORT_API_CALL GetStatsImpl(const OrtAllocator* this_,
+                                              OrtKeyValuePairs** out) noexcept;
+  static OrtStatus* ORT_API_CALL ShrinkImpl(OrtAllocator* this_) noexcept;
+
+  /// Allocate size bytes on the given CUDA stream.
+  void* AllocInternal(size_t size, cudaStream_t stream);
+
+  /// Resolve OrtSyncStream* to cudaStream_t; null → legacy default stream (0).
+  cudaStream_t ResolveCudaStream(OrtSyncStream* stream) const;
+
+  /// Best-effort synchronization of all streams that have live allocations.
+  void SyncAllKnownStreams() noexcept;
+
+  struct AllocationRecord {
+    size_t bytes;
+    cudaStream_t stream;
+  };
+
+  const OrtApi& ort_api_;
+  const OrtLogger& logger_;
+  int device_id_{0};  // CUDA ordinal for cudaSetDevice guards
+
+  cudaMemPool_t pool_{nullptr};
+  uint64_t pool_release_threshold_;
+  size_t bytes_to_keep_on_shrink_;
+
+  // Bookkeeping (guarded by mutex_)
+  mutable std::mutex mutex_;
+  InlinedHashMap<void*, AllocationRecord> alloc_map_;
+  InlinedHashMap<cudaStream_t, InlinedHashSet<void*>> stream_map_;
+
+  // Stats (guarded by mutex_)
+  size_t in_use_bytes_ = 0;
+  size_t max_bytes_in_use_ = 0;
+  size_t num_allocs_ = 0;
+  size_t max_alloc_size_ = 0;
+  size_t num_arena_shrinkages_ = 0;
+};
+
+}  // namespace cuda_plugin
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/plugin/cuda_plugin_utils.h
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_plugin_utils.h
@@ -9,6 +9,8 @@
 #include "onnxruntime_c_api.h"
 #include "onnxruntime_cxx_api.h"
 
+#include "core/common/common.h"
+
 #include <cuda_runtime_api.h>
 #include <cublas_v2.h>
 #include <cudnn.h>
@@ -33,14 +35,13 @@
 // Throwing variant for use in constructors and non-OrtStatus contexts.
 // Analogous to CUDA_CALL_THROW in the non-plugin build.
 #ifndef PL_CUDA_CALL_THROW
-#define PL_CUDA_CALL_THROW(cuda_call_expr)                                   \
-  do {                                                                       \
-    cudaError_t _cuda_err = (cuda_call_expr);                                \
-    if (_cuda_err != cudaSuccess) {                                          \
-      throw std::runtime_error(                                              \
-          std::string("CUDA error: ") + cudaGetErrorName(_cuda_err) + ": " + \
-          cudaGetErrorString(_cuda_err));                                    \
-    }                                                                        \
+#define PL_CUDA_CALL_THROW(cuda_call_expr)                         \
+  do {                                                             \
+    cudaError_t _cuda_err = (cuda_call_expr);                      \
+    if (_cuda_err != cudaSuccess) {                                \
+      ORT_THROW("CUDA error: ", cudaGetErrorName(_cuda_err), ": ", \
+                cudaGetErrorString(_cuda_err));                    \
+    }                                                              \
   } while (0)
 #endif
 
@@ -72,17 +73,35 @@
   } while (0)
 #endif
 
-#define EXCEPTION_TO_STATUS_BEGIN try {
-#define EXCEPTION_TO_STATUS_END                 \
-  }                                             \
-  catch (const Ort::Exception& ex) {            \
-    Ort::Status status(ex);                     \
-    return status.release();                    \
-  }                                             \
-  catch (const std::exception& ex) {            \
-    Ort::Status status(ex.what(), ORT_EP_FAIL); \
-    return status.release();                    \
-  }
+#if defined(_MSC_VER) && !defined(__clang__)
+// C4702: unreachable code - the trailing return is required for ORT_NO_EXCEPTIONS builds
+#define EXCEPTION_TO_STATUS_UNREACHABLE_GUARD_BEGIN __pragma(warning(push)) __pragma(warning(disable : 4702))
+#define EXCEPTION_TO_STATUS_UNREACHABLE_GUARD_END __pragma(warning(pop))
+#else
+#define EXCEPTION_TO_STATUS_UNREACHABLE_GUARD_BEGIN
+#define EXCEPTION_TO_STATUS_UNREACHABLE_GUARD_END
+#endif
+
+#define EXCEPTION_TO_STATUS_BEGIN EXCEPTION_TO_STATUS_UNREACHABLE_GUARD_BEGIN ORT_TRY {
+#define EXCEPTION_TO_STATUS_END                   \
+  }                                               \
+  ORT_CATCH(const Ort::Exception& ex) {           \
+    OrtStatus* _ort_ex_st = nullptr;              \
+    ORT_HANDLE_EXCEPTION([&]() {                  \
+      Ort::Status status(ex);                     \
+      _ort_ex_st = status.release();              \
+    });                                           \
+    return _ort_ex_st;                            \
+  }                                               \
+  ORT_CATCH(const std::exception& ex) {           \
+    OrtStatus* _std_ex_st = nullptr;              \
+    ORT_HANDLE_EXCEPTION([&]() {                  \
+      Ort::Status status(ex.what(), ORT_EP_FAIL); \
+      _std_ex_st = status.release();              \
+    });                                           \
+    return _std_ex_st;                            \
+  }                                               \
+  EXCEPTION_TO_STATUS_UNREACHABLE_GUARD_END
 
 /// Stored API pointers accessible to all plugin components.
 struct CudaPluginApis {

--- a/onnxruntime/core/providers/cuda/plugin/cuda_stream_plugin.cc
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_stream_plugin.cc
@@ -172,6 +172,20 @@ OrtStatus* CudaSyncStream::CleanupDeferredCPUBuffers() noexcept {
   // Synchronize before releasing deferred CPU buffers to ensure
   // all async copies using those buffers have completed.
   PL_CUDA_RETURN_IF_ERROR(cudaStreamSynchronize(stream->cuda_stream_));
+
+  // Reset arena chunk-to-stream assignments for this device's current arena.
+  // Uses ResetDeviceArenaChunksUsingStream to hold the arena_mutex across the
+  // entire operation, preventing a concurrent ReleaseAllocatorImpl from destroying
+  // the arena while we hold a raw pointer to it.
+  {
+    OrtStatus* arena_status = stream->factory_.ResetDeviceArenaChunksUsingStream(
+        stream->device_id_, this_ptr);
+    if (arena_status != nullptr) {
+      // Ignore the arena reset error and continue session run end — buffer cleanup is more critical.
+      Ort::GetApi().ReleaseStatus(arena_status);
+    }
+  }
+
   return stream->CleanupDeferredCPUBuffers();
 }
 

--- a/onnxruntime/core/providers/cuda/plugin/cuda_stream_plugin.h
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_stream_plugin.h
@@ -11,9 +11,9 @@
 
 #include "cuda_plugin_utils.h"
 
-#include <vector>
-#include <unordered_map>
 #include <mutex>
+#include <unordered_map>
+#include <vector>
 
 namespace onnxruntime {
 namespace cuda_plugin {

--- a/onnxruntime/core/providers/cuda/plugin/provider_api_shims.cc
+++ b/onnxruntime/core/providers/cuda/plugin/provider_api_shims.cc
@@ -7,9 +7,12 @@
 // halfToFloat). Plugin builds skip SHARED_PROVIDER entirely, so these thin
 // wrappers ensure the migrated kernel code compiles and links.
 
+#include "provider_api_shims.h"
+
 #include <string>
 #include <cstdlib>
 #include "core/common/float16.h"
+#include "core/platform/env_var.h"  // detail::GetEnvironmentVar
 
 namespace onnxruntime {
 

--- a/onnxruntime/core/providers/cuda/plugin/provider_api_shims.h
+++ b/onnxruntime/core/providers/cuda/plugin/provider_api_shims.h
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Declarations for provider API shims used by the CUDA plugin EP build.
+// In-tree builds get these via the SHARED_PROVIDER bridge (provider_api.h);
+// the plugin build skips that bridge, so these thin wrappers provide direct
+// implementations (defined in provider_api_shims.cc).
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace onnxruntime {
+
+std::string GetEnvironmentVar(const std::string& var_name);
+
+namespace math {
+uint16_t floatToHalf(float f);
+float halfToFloat(uint16_t h);
+}  // namespace math
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_provider_factory.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_provider_factory.cc
@@ -230,6 +230,7 @@ struct NvTrtRtxOrtAllocator : OrtAllocator {
     Info = InfoImpl;
     Reserve = AllocImpl;  // no special behavior for Reserve so use AllocImpl
     GetStats = nullptr;   // GetStatsImpl. The CUDA allocators don't have stats currently so we can skip.
+    Shrink = nullptr;
 
     const OrtEpApi& ep_api = *api.GetEpApi();
     const OrtMemoryDevice* mem_device = ep_api.MemoryInfo_GetMemoryDevice(mem_info);

--- a/onnxruntime/core/providers/webgpu/math/einsum.cc
+++ b/onnxruntime/core/providers/webgpu/math/einsum.cc
@@ -4,6 +4,7 @@
 #include "core/providers/webgpu/math/einsum.h"
 
 #include <algorithm>
+#include <cctype>
 #include <regex>
 #include <set>
 #include <vector>
@@ -24,7 +25,7 @@ static const std::regex lhs_pattern("(([a-zA-Z]|\\.\\.\\.)*,)*([a-zA-Z]|\\.\\.\\
 // Helper function to remove all whitespaces in a given string.
 std::string RemoveAllWhitespace(const std::string& str) {
   std::string result = str;
-  result.erase(std::remove_if(result.begin(), result.end(), ::isspace), result.end());
+  std::erase_if(result, [](unsigned char c) { return std::isspace(c); });
   return result;
 }
 
@@ -318,7 +319,7 @@ Status EinsumProgram::GenerateShaderCode(ShaderHelper& shader) const {
               symbol));
 
           // Check if we've already processed this symbol to avoid duplicate loop generation
-          if (uniform_symbol_set.find(symbol) == uniform_symbol_set.end()) {
+          if (!uniform_symbol_set.contains(symbol)) {
             // Add symbol to tracked set to prevent duplicate processing
             uniform_symbol_set.insert(symbol);
 

--- a/onnxruntime/core/providers/webgpu/math/unary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/webgpu/math/unary_elementwise_ops.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <utility>
+#include <cstring>
 #include <limits>
 
 #include "core/providers/webgpu/math/unary_elementwise_ops.h"
@@ -194,10 +195,6 @@ class Clip final : public UnaryElementwise {
                          "Clip",
                          std::is_same_v<T, MLFloat16> ? ClipF16Impl : ClipImpl,
                          "", ShaderUsage::UseElementTypeAlias} {}
-#if defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
-#endif
 
   Status ConfigureProgram(const ComputeContext& context, UnaryElementwiseProgram& program) const override {
     const auto* clip_min_tensor = context.Input<Tensor>(1);
@@ -209,7 +206,9 @@ class Clip final : public UnaryElementwise {
                                       : std::numeric_limits<T>::max()};
     if constexpr (std::is_same_v<T, MLFloat16>) {
       // F16: stores span<f16, 2> as a single float
-      float encoded_value = *reinterpret_cast<const float*>(attr);
+      float encoded_value;
+      static_assert(sizeof(encoded_value) == 2 * sizeof(MLFloat16));
+      std::memcpy(&encoded_value, attr, sizeof(encoded_value));
       program.AddUniformVariable({encoded_value});
     } else {
       static_assert(sizeof(T) == sizeof(float), "T must be f32, i32 or u32");
@@ -218,9 +217,6 @@ class Clip final : public UnaryElementwise {
     }
     return Status::OK();
   }
-#if defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
 
   // uniforms.attr is a f32 value. It is encoded as a float for 2 f16 values.
   // bitcast<vec2<f16>>(uniforms.attr)[0] is clip_min, bitcast<vec2<f16>>(uniforms.attr)[1] is clip_max

--- a/onnxruntime/core/providers/webgpu/nn/conv.cc
+++ b/onnxruntime/core/providers/webgpu/nn/conv.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #include "core/providers/webgpu/nn/conv.h"
 #include "core/providers/webgpu/nn/conv2d_mm.h"
+#include "core/providers/webgpu/nn/conv3d_naive.h"
 #include "core/providers/webgpu/nn/im2col_matmul.h"
 #include "core/providers/webgpu/shader_helper.h"
 #include "core/providers/webgpu/webgpu_supported_types.h"
@@ -80,8 +81,42 @@ Status Conv<is_channels_last, is_fused>::ComputeInternal(ComputeContext& context
   std::transform(local_dilations.begin(), local_dilations.end(), std::back_inserter(dilations), transform_dim);
   auto rank = input_shape.NumDimensions();
   const InlinedVector<size_t> perm = {2, 3, 1, 0};
-  if (rank > 4) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Only Conv1d and Conv2d are supported.");
+  if (rank > 5) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Only Conv1d, Conv2d, and Conv3d are supported.");
+  } else if (rank == 5) {
+    // Conv3D - use naive per-element shader (matching JS implementation)
+    if (conv_attrs_.group != 1) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Conv3D does not support grouped convolution (group=", conv_attrs_.group, ").");
+    }
+    const auto output_size = static_cast<uint32_t>(output_shape.Size());
+    const auto kernel_depth = static_cast<uint32_t>(kernel_shape[2]);
+    const auto kernel_height = static_cast<uint32_t>(kernel_shape[3]);
+    const auto kernel_width = static_cast<uint32_t>(kernel_shape[4]);
+    // pads: head padding values for each spatial dim (front, top, left)
+    std::vector<uint32_t> pads_3d{pads[0], pads[1], pads[2]};
+    // Extract spatial dims and channels for explicit uniforms
+    const auto x_depth = static_cast<uint32_t>(input_shape[is_channels_last ? 1 : 2]);
+    const auto x_height = static_cast<uint32_t>(input_shape[is_channels_last ? 2 : 3]);
+    const auto x_width = static_cast<uint32_t>(input_shape[is_channels_last ? 3 : 4]);
+    const auto x_channels = static_cast<uint32_t>(input_shape[is_channels_last ? 4 : 1]);
+    Conv3DNaiveProgram program(activation_, has_bias, is_channels_last);
+    program.CacheHint(activation_.ToString(), std::to_string(is_channels_last))
+        .AddInput({input, ProgramTensorMetadataDependency::TypeAndRank, input_shape, 1})
+        .AddInput({kernel, ProgramTensorMetadataDependency::TypeAndRank, kernel_shape, 1})
+        .AddOutput({output, ProgramTensorMetadataDependency::TypeAndRank, output_shape, 1})
+        .AddUniformVariables({{output_size},
+                              {std::vector<uint32_t>{kernel_depth, kernel_height, kernel_width}},
+                              {pads_3d},
+                              {strides},
+                              {dilations},
+                              {std::vector<uint32_t>{x_depth, x_height, x_width}},
+                              {x_channels}})
+        .SetDispatchGroupSize((output_size + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE);
+    if (has_bias) {
+      program.AddInput({bias, ProgramTensorMetadataDependency::TypeAndRank, bias->Shape(), 1});
+    }
+    return context.RunProgram(program);
   } else if (rank == 4) {
     // Conv2D
   } else if (rank == 3) {

--- a/onnxruntime/core/providers/webgpu/nn/conv3d_naive.cc
+++ b/onnxruntime/core/providers/webgpu/nn/conv3d_naive.cc
@@ -1,0 +1,174 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <string>
+
+#include "core/providers/webgpu/nn/conv3d_naive.h"
+#include "core/providers/webgpu/nn/fuse_utils.h"
+#include "core/providers/webgpu/shader_helper.h"
+#include "core/providers/webgpu/shader_variable.h"
+
+namespace onnxruntime {
+namespace webgpu {
+
+Status Conv3DNaiveProgram::GenerateShaderCode(ShaderHelper& shader) const {
+  const auto& x = shader.AddInput("x", ShaderUsage::UseUniform |
+                                           ShaderUsage::UseIndicesTypeAlias |
+                                           ShaderUsage::UseValueTypeAlias |
+                                           ShaderUsage::UseElementTypeAlias);
+  const auto& w = shader.AddInput("w", ShaderUsage::UseUniform |
+                                           ShaderUsage::UseIndicesTypeAlias |
+                                           ShaderUsage::UseValueTypeAlias);
+  const auto& output = shader.AddOutput("output", ShaderUsage::UseUniform |
+                                                      ShaderUsage::UseIndicesTypeAlias |
+                                                      ShaderUsage::UseValueTypeAlias |
+                                                      ShaderUsage::UseElementTypeAlias);
+
+  std::string apply_activation = GetActivationSnippet(activation_, "x_value_t", "x_element_t");
+
+  // Helper functions to access x and w by 5D indices
+  shader.AdditionalImplementation()
+      << "fn getX(d0 : u32, d1 : u32, d2 : u32, d3 : u32, d4 : u32) -> x_value_t {\n"
+      << "  let aIndices = x_indices_t(d0, d1, d2, d3, d4);\n"
+      << "  return " << x.GetByIndices("aIndices") << ";\n"
+      << "}\n"
+      << "fn getW(d0 : u32, d1 : u32, d2 : u32, d3 : u32, d4 : u32) -> x_value_t {\n"
+      << "  let aIndices = w_indices_t(d0, d1, d2, d3, d4);\n"
+      << "  return " << w.GetByIndices("aIndices") << ";\n"
+      << "}\n";
+
+  // Spatial dimensions and channels are passed as explicit uniforms
+  // to avoid rank-5 shape packing issues (array<vec4<u32>,2> vs vec4<u32>).
+  shader.MainFunctionBody()
+      << shader.GuardAgainstOutOfBoundsWorkgroupSizes("uniforms.output_size")
+      << "let output_indices = " << output.OffsetToIndices("global_idx") << ";\n"
+      << "let batch = output_indices[0];\n"
+      << "let d2 = " << output.IndicesGet("output_indices", is_channels_last_ ? "4" : "1") << ";\n"
+      << "let xFRCCorner = vec3<u32>(" << output.IndicesGet("output_indices", is_channels_last_ ? "1" : "2") << ", "
+      << output.IndicesGet("output_indices", is_channels_last_ ? "2" : "3") << ", "
+      << output.IndicesGet("output_indices", is_channels_last_ ? "3" : "4") << ") * uniforms.strides - uniforms.pads;\n"
+      << "let xFCorner = xFRCCorner.x;\n"
+      << "let xRCorner = xFRCCorner.y;\n"
+      << "let xCCorner = xFRCCorner.z;\n"
+      << "let xDepth = uniforms.x_spatial[0];\n"
+      << "let xHeight = uniforms.x_spatial[1];\n"
+      << "let xWidth = uniforms.x_spatial[2];\n"
+      << "let xChannels = uniforms.x_channels;\n"
+      << "let inputChannelsNearestVec4 = (xChannels / 4u) * 4u;\n"
+      << "let inputChannelsVec4Remainder = xChannels % 4u;\n"
+      << "\n"
+      << "var value = x_value_t(0);\n"
+      << "for (var wF = 0u; wF < uniforms.filter_dims[0]; wF++) {\n"
+      << "  let xF = xFCorner + wF * uniforms.dilations[0];\n"
+      << "  if (xF >= xDepth) {\n"
+      << "    continue;\n"
+      << "  }\n"
+      << "  for (var wR = 0u; wR < uniforms.filter_dims[1]; wR++) {\n"
+      << "    let xR = xRCorner + wR * uniforms.dilations[1];\n"
+      << "    if (xR >= xHeight) {\n"
+      << "      continue;\n"
+      << "    }\n"
+      << "    for (var wC = 0u; wC < uniforms.filter_dims[2]; wC++) {\n"
+      << "      let xC = xCCorner + wC * uniforms.dilations[2];\n"
+      << "      if (xC >= xWidth) {\n"
+      << "        continue;\n"
+      << "      }\n"
+      << "      for (var d1 = 0u; d1 < inputChannelsNearestVec4; d1 += 4u) {\n";
+
+  // vec4 dot product accumulation over input channels
+  if (is_channels_last_) {
+    shader.MainFunctionBody()
+        << "        let xValues = vec4<x_element_t>(\n"
+        << "            getX(batch, xF, xR, xC, d1),\n"
+        << "            getX(batch, xF, xR, xC, d1 + 1u),\n"
+        << "            getX(batch, xF, xR, xC, d1 + 2u),\n"
+        << "            getX(batch, xF, xR, xC, d1 + 3u));\n";
+  } else {
+    shader.MainFunctionBody()
+        << "        let xValues = vec4<x_element_t>(\n"
+        << "            getX(batch, d1, xF, xR, xC),\n"
+        << "            getX(batch, d1 + 1u, xF, xR, xC),\n"
+        << "            getX(batch, d1 + 2u, xF, xR, xC),\n"
+        << "            getX(batch, d1 + 3u, xF, xR, xC));\n";
+  }
+  shader.MainFunctionBody()
+      << "        let wValues = vec4<x_element_t>(\n"
+      << "            getW(d2, d1, wF, wR, wC),\n"
+      << "            getW(d2, d1 + 1u, wF, wR, wC),\n"
+      << "            getW(d2, d1 + 2u, wF, wR, wC),\n"
+      << "            getW(d2, d1 + 3u, wF, wR, wC));\n"
+      << "        value += x_value_t(dot(xValues, wValues));\n"
+      << "      }\n";
+
+  // Handle remainder channels (1, 2, or 3)
+  shader.MainFunctionBody()
+      << "      if (inputChannelsVec4Remainder == 1u) {\n";
+  if (is_channels_last_) {
+    shader.MainFunctionBody()
+        << "        value += getX(batch, xF, xR, xC, inputChannelsNearestVec4)\n"
+        << "            * getW(d2, inputChannelsNearestVec4, wF, wR, wC);\n";
+  } else {
+    shader.MainFunctionBody()
+        << "        value += getX(batch, inputChannelsNearestVec4, xF, xR, xC)\n"
+        << "            * getW(d2, inputChannelsNearestVec4, wF, wR, wC);\n";
+  }
+  shader.MainFunctionBody()
+      << "      } else if (inputChannelsVec4Remainder == 2u) {\n";
+  if (is_channels_last_) {
+    shader.MainFunctionBody()
+        << "        let xValues = vec2<x_element_t>(\n"
+        << "            getX(batch, xF, xR, xC, inputChannelsNearestVec4),\n"
+        << "            getX(batch, xF, xR, xC, inputChannelsNearestVec4 + 1u));\n";
+  } else {
+    shader.MainFunctionBody()
+        << "        let xValues = vec2<x_element_t>(\n"
+        << "            getX(batch, inputChannelsNearestVec4, xF, xR, xC),\n"
+        << "            getX(batch, inputChannelsNearestVec4 + 1u, xF, xR, xC));\n";
+  }
+  shader.MainFunctionBody()
+      << "        let wValues = vec2<x_element_t>(\n"
+      << "            getW(d2, inputChannelsNearestVec4, wF, wR, wC),\n"
+      << "            getW(d2, inputChannelsNearestVec4 + 1u, wF, wR, wC));\n"
+      << "        value += x_value_t(dot(xValues, wValues));\n"
+      << "      } else if (inputChannelsVec4Remainder == 3u) {\n";
+  if (is_channels_last_) {
+    shader.MainFunctionBody()
+        << "        let xValues = vec3<x_element_t>(\n"
+        << "            getX(batch, xF, xR, xC, inputChannelsNearestVec4),\n"
+        << "            getX(batch, xF, xR, xC, inputChannelsNearestVec4 + 1u),\n"
+        << "            getX(batch, xF, xR, xC, inputChannelsNearestVec4 + 2u));\n";
+  } else {
+    shader.MainFunctionBody()
+        << "        let xValues = vec3<x_element_t>(\n"
+        << "            getX(batch, inputChannelsNearestVec4, xF, xR, xC),\n"
+        << "            getX(batch, inputChannelsNearestVec4 + 1u, xF, xR, xC),\n"
+        << "            getX(batch, inputChannelsNearestVec4 + 2u, xF, xR, xC));\n";
+  }
+  shader.MainFunctionBody()
+      << "        let wValues = vec3<x_element_t>(\n"
+      << "            getW(d2, inputChannelsNearestVec4, wF, wR, wC),\n"
+      << "            getW(d2, inputChannelsNearestVec4 + 1u, wF, wR, wC),\n"
+      << "            getW(d2, inputChannelsNearestVec4 + 2u, wF, wR, wC));\n"
+      << "        value += x_value_t(dot(xValues, wValues));\n"
+      << "      }\n"
+      << "    }\n"
+      << "  }\n"
+      << "}\n";
+
+  // Apply bias
+  if (has_bias_) {
+    const auto& b = shader.AddInput("bias", ShaderUsage::UseUniform | ShaderUsage::UseValueTypeAlias);
+    shader.MainFunctionBody() << "value = value + " << b.GetByIndices("d2") << ";\n";
+  }
+
+  // Apply activation
+  shader.MainFunctionBody() << apply_activation << "\n";
+
+  // Write output
+  shader.MainFunctionBody() << output.SetByOffset("global_idx", "value");
+
+  return Status::OK();
+}
+
+}  // namespace webgpu
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/nn/conv3d_naive.h
+++ b/onnxruntime/core/providers/webgpu/nn/conv3d_naive.h
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/webgpu/nn/fuse_utils.h"
+#include "core/providers/webgpu/program.h"
+
+namespace onnxruntime {
+namespace webgpu {
+
+class Conv3DNaiveProgram final : public Program<Conv3DNaiveProgram> {
+ public:
+  Conv3DNaiveProgram(const Activation& activation, bool has_bias, bool is_channels_last)
+      : Program("Conv3DNaive"), activation_(activation), has_bias_(has_bias), is_channels_last_(is_channels_last) {
+  }
+  Status GenerateShaderCode(ShaderHelper& shader) const override;
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
+      {"output_size", ProgramUniformVariableDataType::Uint32},
+      {"filter_dims", ProgramUniformVariableDataType::Uint32},
+      {"pads", ProgramUniformVariableDataType::Uint32},
+      {"strides", ProgramUniformVariableDataType::Uint32},
+      {"dilations", ProgramUniformVariableDataType::Uint32},
+      {"x_spatial", ProgramUniformVariableDataType::Uint32},
+      {"x_channels", ProgramUniformVariableDataType::Uint32});
+
+ private:
+  const Activation& activation_;
+  bool has_bias_;
+  bool is_channels_last_;
+};
+
+}  // namespace webgpu
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/nn/lp_norm.cc
+++ b/onnxruntime/core/providers/webgpu/nn/lp_norm.cc
@@ -1,0 +1,135 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/webgpu/shader_helper.h"
+#include "core/providers/webgpu/webgpu_supported_types.h"
+#include "core/providers/webgpu/nn/lp_norm.h"
+#include "core/providers/common.h"
+
+namespace onnxruntime {
+namespace webgpu {
+
+Status LpNormProgram::GenerateShaderCode(ShaderHelper& shader) const {
+  shader.AddInput("x", ShaderUsage::UseUniform | ShaderUsage::UseValueTypeAlias | ShaderUsage::UseElementTypeAlias);
+  shader.AddOutput("y", ShaderUsage::UseUniform);
+
+  shader.AdditionalImplementation()
+      << "var<workgroup> norm_shared : array<f32, workgroup_size_x>;\n";
+
+  shader.MainFunctionBody()
+      << "let ix = local_idx;\n"
+      << "let norm_group = workgroup_idx;\n"
+      << "if (norm_group >= uniforms.norm_count) { return; }\n"
+
+      // Compute base offset for this norm group.
+      // Elements in the norm group are at: base + j * stride_factor, j = 0..norm_size-1
+      << "let base = (norm_group / uniforms.stride_factor) * uniforms.stride_factor * uniforms.norm_size"
+      << " + (norm_group % uniforms.stride_factor);\n"
+
+      // Distribute elements across threads
+      << "var elements_per_thread = uniforms.norm_size / workgroup_size_x;\n"
+      << "let remainder = uniforms.norm_size % workgroup_size_x;\n"
+      << "var start: u32 = 0u;\n"
+      << "if (ix < remainder) {\n"
+      << "  elements_per_thread = elements_per_thread + 1u;\n"
+      << "  start = ix * elements_per_thread;\n"
+      << "} else {\n"
+      << "  start = ix * elements_per_thread + remainder;\n"
+      << "}\n"
+
+      // Phase 1: Accumulate norm contribution
+      << "var local_sum: f32 = 0.0;\n"
+      << "for (var j: u32 = 0u; j < elements_per_thread; j++) {\n"
+      << "  let val = f32(x[base + (start + j) * uniforms.stride_factor]);\n";
+
+  if (p_ == 1) {
+    shader.MainFunctionBody()
+        << "  local_sum += abs(val);\n";
+  } else {
+    shader.MainFunctionBody()
+        << "  local_sum += val * val;\n";
+  }
+
+  shader.MainFunctionBody()
+      << "}\n"
+      << "norm_shared[ix] = local_sum;\n"
+      << "workgroupBarrier();\n"
+
+      // Phase 2: Parallel reduction
+      << "var reduce_size : u32 = workgroup_size_x;\n"
+      << "for (var curr_size = reduce_size >> 1; curr_size > 0; curr_size = reduce_size >> 1) {\n"
+      << "  reduce_size = curr_size + (reduce_size & 1);\n"
+      << "  if (ix < curr_size) {\n"
+      << "    norm_shared[ix] += norm_shared[ix + reduce_size];\n"
+      << "  }\n"
+      << "  workgroupBarrier();\n"
+      << "}\n";
+
+  // Phase 3: Compute norm value
+  if (p_ == 1) {
+    shader.MainFunctionBody()
+        << "let norm_val = norm_shared[0];\n";
+  } else {
+    shader.MainFunctionBody()
+        << "let norm_val = sqrt(norm_shared[0]);\n";
+  }
+
+  // Phase 4: Normalize
+  shader.MainFunctionBody()
+      << "for (var j: u32 = 0u; j < elements_per_thread; j++) {\n"
+      << "  let offset = base + (start + j) * uniforms.stride_factor;\n"
+      << "  if (norm_val != 0.0) {\n"
+      << "    y[offset] = x_element_t(f32(x[offset]) / norm_val);\n"
+      << "  } else {\n"
+      << "    y[offset] = x_element_t(0.0);\n"
+      << "  }\n"
+      << "}\n";
+
+  return Status::OK();
+}
+
+Status LpNorm::ComputeInternal(ComputeContext& context) const {
+  const auto* x = context.Input(0);
+  const auto x_shape = x->Shape();
+
+  if (x_shape.Size() == 0) {
+    context.Output(0, x_shape);
+    return Status::OK();
+  }
+
+  const auto rank = static_cast<int64_t>(x_shape.NumDimensions());
+  const auto canonical_axis = HandleNegativeAxis(axis_, rank);
+
+  const uint32_t m = onnxruntime::narrow<uint32_t>(x_shape.GetDims()[onnxruntime::narrow<size_t>(canonical_axis)]);
+  const uint32_t n = onnxruntime::narrow<uint32_t>(x_shape.Size() / m);
+  const uint32_t sf = (canonical_axis + 1 < rank)
+                          ? onnxruntime::narrow<uint32_t>(x_shape.SizeFromDimension(onnxruntime::narrow<size_t>(canonical_axis) + 1))
+                          : 1u;
+
+  auto* y = context.Output(0, x_shape);
+
+  TensorShape override_shape{x_shape.Size()};
+
+  LpNormProgram program{p_};
+  program.CacheHint(p_)
+      .AddInputs({{x, ProgramTensorMetadataDependency::Type, override_shape, 1}})
+      .AddOutputs({{y, ProgramTensorMetadataDependency::None, override_shape, 1}})
+      .AddUniformVariables({{n}})
+      .AddUniformVariables({{m}})
+      .AddUniformVariables({{sf}});
+
+  program.SetDispatchGroupSize(n);
+
+  return context.RunProgram(program);
+}
+
+ONNX_OPERATOR_VERSIONED_KERNEL_EX(LpNormalization, kOnnxDomain, 1, 21, kWebGpuExecutionProvider,
+                                  (*KernelDefBuilder::Create()).TypeConstraint("T", WebGpuSupportedFloatTypes()),
+                                  LpNorm);
+
+ONNX_OPERATOR_KERNEL_EX(LpNormalization, kOnnxDomain, 22, kWebGpuExecutionProvider,
+                        (*KernelDefBuilder::Create()).TypeConstraint("T", WebGpuSupportedFloatTypes()),
+                        LpNorm);
+
+}  // namespace webgpu
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/nn/lp_norm.h
+++ b/onnxruntime/core/providers/webgpu/nn/lp_norm.h
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/webgpu/program.h"
+#include "core/providers/webgpu/webgpu_kernel.h"
+
+namespace onnxruntime {
+namespace webgpu {
+
+class LpNormProgram final : public Program<LpNormProgram> {
+ public:
+  LpNormProgram(int64_t p) : Program{"LpNorm"}, p_{p} {}
+
+  Status GenerateShaderCode(ShaderHelper& sh) const override;
+
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
+      {"norm_count", ProgramUniformVariableDataType::Uint32},
+      {"norm_size", ProgramUniformVariableDataType::Uint32},
+      {"stride_factor", ProgramUniformVariableDataType::Uint32});
+
+ private:
+  int64_t p_;
+};
+
+class LpNorm final : public WebGpuKernel {
+ public:
+  LpNorm(const OpKernelInfo& info) : WebGpuKernel(info) {
+    info.GetAttrOrDefault<int64_t>("axis", &axis_, -1);
+    info.GetAttrOrDefault<int64_t>("p", &p_, 2);
+  }
+
+  Status ComputeInternal(ComputeContext& context) const override;
+
+ private:
+  int64_t axis_;
+  int64_t p_;
+};
+
+}  // namespace webgpu
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/nn/pool.cc
+++ b/onnxruntime/core/providers/webgpu/nn/pool.cc
@@ -249,7 +249,7 @@ Status Pool<PoolType, is_nhwc>::ComputeInternal(ComputeContext& context) const {
   Tensor* Y = context.Output(0, output_shape);
 
   std::vector<uint32_t> kernel_strides(kernel_shape.size());
-  ORT_ENFORCE(kernel_shape.size() > 0, "kernel_shape must have at least one element.");
+  ORT_ENFORCE(!kernel_shape.empty(), "kernel_shape must have at least one element.");
   // Calculate the kernel element strides for each dimension in reverse order. For example:
   //   kernel_shape = [3, 2], kernel_strides = [2, 1]
   //   kernel_shape = [2, 3, 2], kernel_strides = [6, 2, 1]

--- a/onnxruntime/core/providers/webgpu/program.h
+++ b/onnxruntime/core/providers/webgpu/program.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <array>
 #include <string>
 #include <vector>
 #include <iosfwd>
@@ -164,27 +165,18 @@ enum class ProgramTensorMetadataDependency : int {
 };
 OStringStream& operator<<(OStringStream& os, ProgramTensorMetadataDependency);
 
-#if defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
-#endif
-
 inline ProgramTensorMetadataDependency operator|(ProgramTensorMetadataDependency a, ProgramTensorMetadataDependency b) {
-  return (ProgramTensorMetadataDependency)((int&)a | (int&)b);
+  return static_cast<ProgramTensorMetadataDependency>(static_cast<int>(a) | static_cast<int>(b));
 }
 inline ProgramTensorMetadataDependency operator&(ProgramTensorMetadataDependency a, ProgramTensorMetadataDependency b) {
-  return (ProgramTensorMetadataDependency)((int&)a & (int&)b);
+  return static_cast<ProgramTensorMetadataDependency>(static_cast<int>(a) & static_cast<int>(b));
 }
 inline ProgramTensorMetadataDependency& operator|=(ProgramTensorMetadataDependency& a, ProgramTensorMetadataDependency b) {
-  return (ProgramTensorMetadataDependency&)((int&)a |= (int&)b);
+  return a = a | b;
 }
 inline ProgramTensorMetadataDependency& operator&=(ProgramTensorMetadataDependency& a, ProgramTensorMetadataDependency b) {
-  return (ProgramTensorMetadataDependency&)((int&)a &= (int&)b);
+  return a = a & b;
 }
-
-#if defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
 
 constexpr SafeInt<uint32_t> WORKGROUP_SIZE = 64;
 
@@ -417,133 +409,55 @@ class ProgramWrapper : public ProgramBase {
   ProgramWrapper(Args&&... args) : ProgramBase{std::forward<Args>(args)...} {}
 };
 
-#if defined(ORT_WEBGPU_REGISTER_DERIVED_PROGRAM_CLASS_TYPE_CHECK)
-#error "macro ORT_WEBGPU_REGISTER_DERIVED_PROGRAM_CLASS_TYPE_CHECK is already defined"
-#endif
-
-#define ORT_WEBGPU_REGISTER_DERIVED_PROGRAM_CLASS_TYPE_CHECK(identifier, element_type)                                                   \
- private:                                                                                                                                \
-  template <typename U>                                                                                                                  \
-  static auto test_has_##identifier(int) -> decltype(U::identifier, std::true_type{}); /* checks if member exists */                     \
-  template <typename...>                                                                                                                 \
-  static auto test_has_##identifier(...) -> std::false_type;                                                                             \
-                                                                                                                                         \
-  template <typename U,                                                                       /* The following type check uses SFINAE */ \
-            typename = std::enable_if_t<                                                      /* to ensure the specific member:       */ \
-                                        is_const_std_array<decltype(U::identifier)>::value && /*  - is a const std::array             */ \
-                                        std::is_const_v<decltype(U::identifier)> &&           /*  - has "const" modifier              */ \
-                                        !std::is_member_pointer_v<decltype(&U::identifier)>>> /*  - is static                         */ \
-  static auto test_has_##identifier##_with_correct_type(int) -> std::true_type;                                                          \
-  template <typename...>                                                                                                                 \
-  static auto test_has_##identifier##_with_correct_type(...) -> std::false_type;                                                         \
-                                                                                                                                         \
- public:                                                                                                                                 \
-  static constexpr bool has_##identifier = decltype(test_has_##identifier<T>(0))::value;                                                 \
-  static constexpr bool has_##identifier##_with_correct_type = decltype(test_has_##identifier##_with_correct_type<T>(0))::value
-
 // the following template class checks whether the type is a const std::array
 template <typename T>
 struct is_const_std_array : std::false_type {};
 template <typename T, size_t N>
 struct is_const_std_array<const std::array<T, N>> : std::true_type {};
 
-// the following template class checks whether certain static members exist in the derived class (SFINAE)
+// The following variable templates check whether certain static members exist in the derived class.
+// Uses std::void_t with decltype(T::member) for SFINAE-based detection of named static data members.
+
+template <typename T, typename = void>
+inline constexpr bool has_member_constants = false;
 template <typename T>
-class DerivedProgramClassTypeCheck {
-  ORT_WEBGPU_REGISTER_DERIVED_PROGRAM_CLASS_TYPE_CHECK(constants, ProgramConstant);
-  ORT_WEBGPU_REGISTER_DERIVED_PROGRAM_CLASS_TYPE_CHECK(overridable_constants, ProgramOverridableConstantDefinition);
-  ORT_WEBGPU_REGISTER_DERIVED_PROGRAM_CLASS_TYPE_CHECK(uniform_variables, ProgramUniformVariableDefinition);
-};
+inline constexpr bool has_member_constants<T, std::void_t<decltype(T::constants)>> = true;
 
-// compile-time tests for the type check
-//
-// TODO: move this to test folder
-namespace test {
+template <typename T, typename = void>
+inline constexpr bool has_member_overridable_constants = false;
+template <typename T>
+inline constexpr bool has_member_overridable_constants<T, std::void_t<decltype(T::overridable_constants)>> = true;
+
+template <typename T, typename = void>
+inline constexpr bool has_member_uniform_variables = false;
+template <typename T>
+inline constexpr bool has_member_uniform_variables<T, std::void_t<decltype(T::uniform_variables)>> = true;
+
+// C++20 concepts for checking whether the member has the correct type (static const std::array).
 
 template <typename T>
-class TestTypeCheck {
-  ORT_WEBGPU_REGISTER_DERIVED_PROGRAM_CLASS_TYPE_CHECK(a, int);
+concept has_constants_correct_type = requires {
+  T::constants;
+  requires is_const_std_array<decltype(T::constants)>::value;
+  requires std::is_const_v<decltype(T::constants)>;
+  requires !std::is_member_pointer_v<decltype(&T::constants)>;
 };
 
-struct TestClass_Empty {};
-static_assert(!TestTypeCheck<TestClass_Empty>::has_a);
-static_assert(!TestTypeCheck<TestClass_Empty>::has_a_with_correct_type);
-
-struct TestClass_NotArray_0 {
-  int b;
+template <typename T>
+concept has_overridable_constants_correct_type = requires {
+  T::overridable_constants;
+  requires is_const_std_array<decltype(T::overridable_constants)>::value;
+  requires std::is_const_v<decltype(T::overridable_constants)>;
+  requires !std::is_member_pointer_v<decltype(&T::overridable_constants)>;
 };
-static_assert(!TestTypeCheck<TestClass_NotArray_0>::has_a);
-static_assert(!TestTypeCheck<TestClass_NotArray_0>::has_a_with_correct_type);
 
-struct TestClass_NotArray_1 {
-  int a;
+template <typename T>
+concept has_uniform_variables_correct_type = requires {
+  T::uniform_variables;
+  requires is_const_std_array<decltype(T::uniform_variables)>::value;
+  requires std::is_const_v<decltype(T::uniform_variables)>;
+  requires !std::is_member_pointer_v<decltype(&T::uniform_variables)>;
 };
-static_assert(TestTypeCheck<TestClass_NotArray_1>::has_a);
-static_assert(!TestTypeCheck<TestClass_NotArray_1>::has_a_with_correct_type);
-
-struct TestClass_NotArray_2 {
-  const int a;
-};
-static_assert(TestTypeCheck<TestClass_NotArray_2>::has_a);
-static_assert(!TestTypeCheck<TestClass_NotArray_2>::has_a_with_correct_type);
-
-struct TestClass_NotStdArray_0 {
-  const int a[2];
-};
-static_assert(TestTypeCheck<TestClass_NotStdArray_0>::has_a);
-static_assert(!TestTypeCheck<TestClass_NotStdArray_0>::has_a_with_correct_type);
-
-struct TestClass_NotStdArray_1 {
-  static constexpr int a[] = {0};
-};
-static_assert(TestTypeCheck<TestClass_NotStdArray_1>::has_a);
-static_assert(!TestTypeCheck<TestClass_NotStdArray_1>::has_a_with_correct_type);
-
-struct TestClass_NotStdArray_2 {
-  static int a[];
-};
-static_assert(TestTypeCheck<TestClass_NotStdArray_2>::has_a);
-static_assert(!TestTypeCheck<TestClass_NotStdArray_2>::has_a_with_correct_type);
-
-struct TestClass_NotStdArray_3 {
-  static const int a[];
-};
-static_assert(TestTypeCheck<TestClass_NotStdArray_3>::has_a);
-static_assert(!TestTypeCheck<TestClass_NotStdArray_3>::has_a_with_correct_type);
-
-struct TestClass_StdArray_0 {
-  std::array<int, 1> a = {1};
-};
-static_assert(TestTypeCheck<TestClass_StdArray_0>::has_a);
-static_assert(!TestTypeCheck<TestClass_StdArray_0>::has_a_with_correct_type);
-
-struct TestClass_StdArray_1 {
-  static constexpr std::array<int, 2> a = {1, 2};
-};
-static_assert(TestTypeCheck<TestClass_StdArray_1>::has_a);
-static_assert(TestTypeCheck<TestClass_StdArray_1>::has_a_with_correct_type);
-
-struct TestClass_StdArray_2 {
-  static const std::array<int, 3> a;
-};
-static_assert(TestTypeCheck<TestClass_StdArray_2>::has_a);
-static_assert(TestTypeCheck<TestClass_StdArray_2>::has_a_with_correct_type);
-
-struct TestClass_StdArray_3 {
-  static constexpr const std::array<int, 4> a = {1, 2, 3, 4};
-};
-static_assert(TestTypeCheck<TestClass_StdArray_3>::has_a);
-static_assert(TestTypeCheck<TestClass_StdArray_3>::has_a_with_correct_type);
-
-struct TestClass_StdArray_4 {
-  static std::array<int, 5> a;
-};
-static_assert(TestTypeCheck<TestClass_StdArray_4>::has_a);
-static_assert(!TestTypeCheck<TestClass_StdArray_4>::has_a_with_correct_type);
-
-}  // namespace test
-
-#undef ORT_WEBGPU_REGISTER_DERIVED_PROGRAM_CLASS_TYPE_CHECK
 
 }  // namespace details
 
@@ -555,39 +469,39 @@ class Program : public details::ProgramWrapper {
 
   static ProgramMetadata GetMetadata() {
     ProgramMetadata metadata;
-    if constexpr (details::DerivedProgramClassTypeCheck<T>::has_constants) {
-      constexpr const ProgramConstant* ptr = T::constants.data();
-      constexpr size_t len = T::constants.size();
-
-      static_assert(details::DerivedProgramClassTypeCheck<T>::has_constants_with_correct_type,
+    if constexpr (details::has_member_constants<T>) {
+      static_assert(details::has_constants_correct_type<T>,
                     "Derived class of \"Program\" has member \"constants\" but its type is incorrect. "
                     "Please use macro WEBGPU_PROGRAM_DEFINE_CONSTANTS() or WEBGPU_PROGRAM_EXTEND_CONSTANTS() to declare constants.");
+
+      constexpr const ProgramConstant* ptr = T::constants.data();
+      constexpr size_t len = T::constants.size();
 
       metadata.constants = {ptr, len};
     } else {
       metadata.constants = {};
     }
 
-    if constexpr (details::DerivedProgramClassTypeCheck<T>::has_overridable_constants) {
-      constexpr const ProgramOverridableConstantDefinition* ptr = T::overridable_constants.data();
-      constexpr size_t len = T::overridable_constants.size();
-
-      static_assert(details::DerivedProgramClassTypeCheck<T>::has_overridable_constants_with_correct_type,
+    if constexpr (details::has_member_overridable_constants<T>) {
+      static_assert(details::has_overridable_constants_correct_type<T>,
                     "Derived class of \"Program\" has member \"overridable_constants\" but its type is incorrect. "
                     "Please use macro WEBGPU_PROGRAM_DEFINE_OVERRIDABLE_CONSTANTS() or WEBGPU_PROGRAM_EXTEND_OVERRIDABLE_CONSTANTS() to declare overridable constants.");
+
+      constexpr const ProgramOverridableConstantDefinition* ptr = T::overridable_constants.data();
+      constexpr size_t len = T::overridable_constants.size();
 
       metadata.overridable_constants = {ptr, len};
     } else {
       metadata.overridable_constants = {};
     }
 
-    if constexpr (details::DerivedProgramClassTypeCheck<T>::has_uniform_variables) {
-      constexpr const ProgramUniformVariableDefinition* ptr = T::uniform_variables.data();
-      constexpr size_t len = T::uniform_variables.size();
-
-      static_assert(details::DerivedProgramClassTypeCheck<T>::has_uniform_variables_with_correct_type,
+    if constexpr (details::has_member_uniform_variables<T>) {
+      static_assert(details::has_uniform_variables_correct_type<T>,
                     "Derived class of \"Program\" has member \"uniform_variables\" but its type is incorrect. "
                     "Please use macro WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES() or WEBGPU_PROGRAM_EXTEND_UNIFORM_VARIABLES() to declare uniform variables.");
+
+      constexpr const ProgramUniformVariableDefinition* ptr = T::uniform_variables.data();
+      constexpr size_t len = T::uniform_variables.size();
 
       metadata.uniform_variables = {ptr, len};
     } else {
@@ -599,20 +513,6 @@ class Program : public details::ProgramWrapper {
 };
 
 namespace details {
-// helper function to convert a C-style array to std::array
-//
-// This is basically the same as std::to_array in C++20.
-//
-template <typename T, size_t N, size_t... Idx>
-constexpr auto _to_std_array_impl(T (&arr)[N], std::index_sequence<Idx...>) -> std::array<std::remove_cv_t<T>, N> {
-  return {{arr[Idx]...}};
-}
-
-template <typename T, size_t N>
-constexpr auto _to_std_array(T (&arr)[N]) -> std::array<std::remove_cv_t<T>, N> {
-  return _to_std_array_impl(arr, std::make_index_sequence<N>{});
-}
-
 // helper function to concatenate a std::array and a C-style array to a std::array
 //
 template <typename T, size_t L, size_t... IdxL, size_t R, size_t... IdxR>
@@ -632,7 +532,7 @@ constexpr std::array<std::remove_cv_t<T>, L + R> _concat2(const std::array<T, L>
 #define WEBGPU_PROGRAM_DEFINE_(identifier, T, ...)             \
   static constexpr const T identifier##_own[] = {__VA_ARGS__}; \
   static constexpr const auto identifier =                     \
-      onnxruntime::webgpu::details::_to_std_array(identifier##_own)
+      std::to_array(identifier##_own)
 
 #define WEBGPU_PROGRAM_EXTEND_(identifier, T, BASE, ...)       \
   static constexpr const T identifier##_own[] = {__VA_ARGS__}; \

--- a/onnxruntime/core/providers/webgpu/program_test.cc
+++ b/onnxruntime/core/providers/webgpu/program_test.cc
@@ -1,0 +1,146 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Compile-time tests for the type detection utilities in program.h.
+// These static_asserts verify that is_const_std_array, the has_member_* variable templates,
+// and has_*_correct_type concepts correctly detect static const std::array members.
+
+#include "core/providers/webgpu/program.h"
+
+namespace onnxruntime {
+namespace webgpu {
+namespace details {
+namespace test {
+
+// ============================================================================
+// Tests for is_const_std_array
+// ============================================================================
+
+static_assert(!is_const_std_array<int>::value);
+static_assert(!is_const_std_array<const int>::value);
+static_assert(!is_const_std_array<std::array<int, 3>>::value);
+static_assert(is_const_std_array<const std::array<int, 3>>::value);
+static_assert(is_const_std_array<const std::array<int, 0>>::value);
+
+// ============================================================================
+// Tests for has_member_constants / has_constants_correct_type
+// ============================================================================
+
+struct NoMembers {};
+static_assert(!has_member_constants<NoMembers>);
+static_assert(!has_constants_correct_type<NoMembers>);
+
+struct Constants_WrongName {
+  static constexpr std::array<int, 1> not_constants = {1};
+};
+static_assert(!has_member_constants<Constants_WrongName>);
+static_assert(!has_constants_correct_type<Constants_WrongName>);
+
+struct Constants_PlainInt {
+  int constants;
+};
+static_assert(has_member_constants<Constants_PlainInt>);
+static_assert(!has_constants_correct_type<Constants_PlainInt>);
+
+struct Constants_ConstInt {
+  const int constants;
+};
+static_assert(has_member_constants<Constants_ConstInt>);
+static_assert(!has_constants_correct_type<Constants_ConstInt>);
+
+struct Constants_CArray {
+  const int constants[2];
+};
+static_assert(has_member_constants<Constants_CArray>);
+static_assert(!has_constants_correct_type<Constants_CArray>);
+
+struct Constants_StaticCArray {
+  static constexpr int constants[] = {0};
+};
+static_assert(has_member_constants<Constants_StaticCArray>);
+static_assert(!has_constants_correct_type<Constants_StaticCArray>);
+
+struct Constants_StaticNonConstCArray {
+  static int constants[];
+};
+static_assert(has_member_constants<Constants_StaticNonConstCArray>);
+static_assert(!has_constants_correct_type<Constants_StaticNonConstCArray>);
+
+struct Constants_StaticConstCArray {
+  static const int constants[];
+};
+static_assert(has_member_constants<Constants_StaticConstCArray>);
+static_assert(!has_constants_correct_type<Constants_StaticConstCArray>);
+
+struct Constants_NonConstStdArray {
+  std::array<int, 1> constants = {1};
+};
+static_assert(has_member_constants<Constants_NonConstStdArray>);
+static_assert(!has_constants_correct_type<Constants_NonConstStdArray>);
+
+struct Constants_NonConstStaticStdArray {
+  static std::array<int, 5> constants;
+};
+static_assert(has_member_constants<Constants_NonConstStaticStdArray>);
+static_assert(!has_constants_correct_type<Constants_NonConstStaticStdArray>);
+
+struct Constants_StaticConstexprStdArray {
+  static constexpr std::array<int, 2> constants = {1, 2};
+};
+static_assert(has_member_constants<Constants_StaticConstexprStdArray>);
+static_assert(has_constants_correct_type<Constants_StaticConstexprStdArray>);
+
+struct Constants_StaticConstStdArray {
+  static const std::array<int, 3> constants;
+};
+static_assert(has_member_constants<Constants_StaticConstStdArray>);
+static_assert(has_constants_correct_type<Constants_StaticConstStdArray>);
+
+struct Constants_StaticConstexprConstStdArray {
+  static constexpr const std::array<int, 4> constants = {1, 2, 3, 4};
+};
+static_assert(has_member_constants<Constants_StaticConstexprConstStdArray>);
+static_assert(has_constants_correct_type<Constants_StaticConstexprConstStdArray>);
+
+// ============================================================================
+// Tests for has_member_overridable_constants / has_overridable_constants_correct_type
+// ============================================================================
+
+static_assert(!has_member_overridable_constants<NoMembers>);
+static_assert(!has_overridable_constants_correct_type<NoMembers>);
+
+struct OverridableConstants_WrongType {
+  int overridable_constants;
+};
+static_assert(has_member_overridable_constants<OverridableConstants_WrongType>);
+static_assert(!has_overridable_constants_correct_type<OverridableConstants_WrongType>);
+
+struct OverridableConstants_Correct {
+  static constexpr std::array<int, 1> overridable_constants = {1};
+};
+static_assert(has_member_overridable_constants<OverridableConstants_Correct>);
+static_assert(has_overridable_constants_correct_type<OverridableConstants_Correct>);
+
+// ============================================================================
+// Tests for has_member_uniform_variables / has_uniform_variables_correct_type
+// ============================================================================
+
+static_assert(!has_member_uniform_variables<NoMembers>);
+static_assert(!has_uniform_variables_correct_type<NoMembers>);
+
+struct UniformVariables_WrongType {
+  int uniform_variables;
+};
+static_assert(has_member_uniform_variables<UniformVariables_WrongType>);
+static_assert(!has_uniform_variables_correct_type<UniformVariables_WrongType>);
+
+struct UniformVariables_Correct {
+  static constexpr std::array<int, 1> uniform_variables = {1};
+};
+static_assert(has_member_uniform_variables<UniformVariables_Correct>);
+static_assert(has_uniform_variables_correct_type<UniformVariables_Correct>);
+
+}  // namespace test
+}  // namespace details
+}  // namespace webgpu
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/reduction/reduction_ops.cc
+++ b/onnxruntime/core/providers/webgpu/reduction/reduction_ops.cc
@@ -187,7 +187,7 @@ std::unordered_map<ReduceOpType, ReduceOpSpecificCode> reduce_op_naive_code_map 
 };
 
 ReduceOpType StringToReduceOp(std::string name) {
-  ORT_ENFORCE(reduce_op_types.find(name) != reduce_op_types.end(), "Unsupported reduction op type: ", name);
+  ORT_ENFORCE(reduce_op_types.contains(name), "Unsupported reduction op type: ", name);
   return reduce_op_types[name];
 }
 

--- a/onnxruntime/core/providers/webgpu/reduction/reduction_ops.h
+++ b/onnxruntime/core/providers/webgpu/reduction/reduction_ops.h
@@ -17,12 +17,12 @@ namespace webgpu {
 // The first element is the loop header, the second element is the loop body, and the third element is the loop footer.
 // The loop header is the code that is executed before the loop starts. The loop body is the code that is executed for each element in the loop.
 // The loop footer is the code that is executed after the loop ends. The loop body should contain the code that accumulates the result of the reduction and
-// the loop footer should contain the code that assigins output_value the result of the reduction.
-typedef struct ReduceOpSpecificCode {
+// the loop footer should contain the code that assigns output_value the result of the reduction.
+struct ReduceOpSpecificCode {
   std::string loop_header_;
   std::string loop_body_;
   std::string loop_footer_;
-} ReduceOpSpecificCode;
+};
 
 enum class ReduceOpType {
   Max,

--- a/onnxruntime/core/providers/webgpu/shader_helper.cc
+++ b/onnxruntime/core/providers/webgpu/shader_helper.cc
@@ -499,7 +499,7 @@ Status ShaderHelper::GenerateSourceCode(std::string& code, std::vector<int>& sha
 
   // store shape uniform ranks in shape_uniform_ranks
   bool use_any_shape_uniform = false;
-  ORT_ENFORCE(shape_uniform_ranks.size() == 0);
+  ORT_ENFORCE(shape_uniform_ranks.empty());
   shape_uniform_ranks.reserve(input_vars_.size() + output_vars_.size() + indices_vars_.size());
 
   for (const auto& input : input_vars_) {

--- a/onnxruntime/core/providers/webgpu/shader_variable.cc
+++ b/onnxruntime/core/providers/webgpu/shader_variable.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <array>
 #include <memory>
 #include <string>
 #include <sstream>
@@ -39,7 +40,7 @@ constexpr static const std::string_view STORAGE_TYPE_ARRAY[] = {
     "u32",        // Uint4x8
     "u32",        // Int4x8
 };
-constexpr static const auto STORAGE_TYPE = details::_to_std_array(STORAGE_TYPE_ARRAY);
+constexpr static const auto STORAGE_TYPE = std::to_array(STORAGE_TYPE_ARRAY);
 
 constexpr static const std::string_view VALUE_TYPE_ARRAY[] = {
     "f32",         // Float32
@@ -66,7 +67,7 @@ constexpr static const std::string_view VALUE_TYPE_ARRAY[] = {
     "u32",         // Uint4x8
     "u32",         // Int4x8
 };
-constexpr static const auto VALUE_TYPE = details::_to_std_array(VALUE_TYPE_ARRAY);
+constexpr static const auto VALUE_TYPE = std::to_array(VALUE_TYPE_ARRAY);
 
 constexpr static const std::string_view ELEMENT_TYPE_ARRAY[] = {
     "f32",   // Float32
@@ -93,7 +94,7 @@ constexpr static const std::string_view ELEMENT_TYPE_ARRAY[] = {
     "u32",   // Uint4x8
     "i32",   // Int4x8
 };
-constexpr static const auto ELEMENT_TYPE = details::_to_std_array(ELEMENT_TYPE_ARRAY);
+constexpr static const auto ELEMENT_TYPE = std::to_array(ELEMENT_TYPE_ARRAY);
 
 constexpr static const uint32_t BYTES_ARRAY[] = {
     4,   // Float32
@@ -120,7 +121,7 @@ constexpr static const uint32_t BYTES_ARRAY[] = {
     4,   // Uint4x8 (packed in u32)
     4,   // Int4x8 (packed in u32)
 };
-constexpr static const auto BYTES = details::_to_std_array(BYTES_ARRAY);
+constexpr static const auto BYTES = std::to_array(BYTES_ARRAY);
 
 inline std::string GetIndicesType(int rank) {
   return rank < 2 ? "u32"

--- a/onnxruntime/core/providers/webgpu/shader_variable.h
+++ b/onnxruntime/core/providers/webgpu/shader_variable.h
@@ -14,8 +14,8 @@ namespace onnxruntime {
 namespace webgpu {
 
 template <typename TIdx,
-          typename TRank,
-          typename = std::enable_if_t<std::is_same_v<TRank, int> || std::is_same_v<TRank, size_t>>>
+          typename TRank>
+  requires(std::is_same_v<TRank, int> || std::is_same_v<TRank, size_t>)
 std::string GetElementAt(std::string_view var, const TIdx& idx, TRank rank, bool is_f16 = false) {
   if (var.starts_with("uniforms.")) {
     if (is_f16) {
@@ -210,32 +210,25 @@ class ShaderVariableHelper : public ShaderIndicesHelper {
 
   friend class ShaderHelper;
 };
-#if defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
-#endif
 
 inline ShaderUsage operator|(ShaderUsage a, ShaderUsage b) {
-  return (uint32_t)a.usage | (uint32_t)b.usage;
+  return static_cast<uint32_t>(a.usage) | static_cast<uint32_t>(b.usage);
 }
 inline ShaderUsage operator&(ShaderUsage a, ShaderUsage b) {
-  return (uint32_t)a.usage & (uint32_t)b.usage;
+  return static_cast<uint32_t>(a.usage) & static_cast<uint32_t>(b.usage);
 }
 inline ShaderUsage& operator|=(ShaderUsage& a, ShaderUsage b) {
-  (uint32_t&)a.usage |= (uint32_t)b.usage;
+  a = a | b;
   return a;
 }
 inline ShaderUsage& operator&=(ShaderUsage& a, ShaderUsage b) {
-  (uint32_t&)a.usage &= (uint32_t)b.usage;
+  a = a & b;
   return a;
 }
 
-#if defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
-
 namespace detail {
-template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+template <typename T>
+  requires std::is_integral_v<T>
 std::string pass_as_string(T&& v) {
   return std::to_string(std::forward<T>(v));
 }

--- a/onnxruntime/core/providers/webgpu/string_utils.h
+++ b/onnxruntime/core/providers/webgpu/string_utils.h
@@ -75,8 +75,8 @@ class FastOStringStream {
 
   // Integer types
   template <typename T>
-  std::enable_if_t<std::is_integral_v<T> && !std::is_same_v<T, char>, FastOStringStream&>
-  operator<<(T value) {
+    requires(std::is_integral_v<T> && !std::is_same_v<T, char>)
+  FastOStringStream& operator<<(T value) {
     std::array<char, 32> buffer;
     auto [ptr, ec] = std::to_chars(buffer.data(), buffer.data() + buffer.size(), value);
     str_.append(buffer.data(), ptr - buffer.data());
@@ -85,8 +85,8 @@ class FastOStringStream {
 
   // Floating point types
   template <typename T>
-  std::enable_if_t<std::is_floating_point_v<T>, FastOStringStream&>
-  operator<<(T value) {
+    requires std::is_floating_point_v<T>
+  FastOStringStream& operator<<(T value) {
     std::array<char, 64> buffer;
     auto [ptr, ec] = std::to_chars(buffer.data(), buffer.data() + buffer.size(), value);
     str_.append(buffer.data(), ptr - buffer.data());

--- a/onnxruntime/core/providers/webgpu/tensor/split.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/split.cc
@@ -82,7 +82,7 @@ Status Split::ComputeInternal(ComputeContext& context) const {
 
   split_sizes.assign(split_sizes_.begin(), split_sizes_.end());
   // Compute split_sizes from the 'split' input tensor.
-  if (split_sizes_.size() == 0 && context.InputCount() > 1) {
+  if (split_sizes_.empty() && context.InputCount() > 1) {
     const Tensor* split_tensor = context.Input<Tensor>(1);
     // Check if split_tensor is valid.
     if (split_tensor != nullptr) {

--- a/onnxruntime/core/providers/webgpu/tensor/upsample.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/upsample.cc
@@ -19,7 +19,7 @@ Status Upsample::BaseCompute(ComputeContext& context,
   auto dims = X->Shape().GetDims();
   ORT_ENFORCE(output_dims.size() == dims.size(), "Rank of input and output tensor should be same.");
 
-  if (dims.size() == 0) {
+  if (dims.empty()) {
     return Status(ONNXRUNTIME, INVALID_ARGUMENT,
                   is_resize_ ? "Resize: input tensor cannot be scalar."
                              : "Upsample: input tensor cannot be scalar.");

--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -86,7 +86,7 @@ void WebGpuContext::Initialize(const WebGpuContextConfig& config) {
 #endif
 
       std::vector<wgpu::FeatureName> required_features = GetAvailableRequiredFeatures(adapter);
-      if (required_features.size() > 0) {
+      if (!required_features.empty()) {
         device_desc.requiredFeatures = required_features.data();
         device_desc.requiredFeatureCount = required_features.size();
       }
@@ -188,7 +188,7 @@ Status WebGpuContext::Run(ComputeContextBase& context, const ProgramBase& progra
   const auto& inputs = program.Inputs();
   const auto& outputs = program.Outputs();
 
-  if (outputs.size() == 0) {
+  if (outputs.empty()) {
     return Status::OK();
   }
 

--- a/onnxruntime/core/providers/webgpu/webgpu_context.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.h
@@ -170,7 +170,7 @@ class WebGpuContext final {
 
   const wgpu::AdapterInfo& AdapterInfo() const { return adapter_info_; }
   const wgpu::Limits& DeviceLimits() const { return device_limits_; }
-  bool DeviceHasFeature(wgpu::FeatureName feature) const { return device_features_.find(feature) != device_features_.end(); }
+  bool DeviceHasFeature(wgpu::FeatureName feature) const { return device_features_.contains(feature); }
 #if !defined(__wasm__)
   const wgpu::AdapterPropertiesSubgroupMatrixConfigs& SubgroupMatrixConfigs() const { return subgroup_matrix_configs_; }
 #endif

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -391,6 +391,8 @@ class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxD
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 13, Tile);
 
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 17, LayerNormalization);
+class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 1, 21, LpNormalization);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 22, LpNormalization);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 1, 5, InstanceNormalization);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSInternalNHWCDomain, 1, 5, InstanceNormalization);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 6, 21, InstanceNormalization);
@@ -742,6 +744,9 @@ std::unique_ptr<KernelRegistry> RegisterKernels(bool enable_graph_capture, bool 
 
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 17, LayerNormalization)>,
 
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 1, 21, LpNormalization)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 22, LpNormalization)>,
+
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 1, 5, InstanceNormalization)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSInternalNHWCDomain, 1, 5, InstanceNormalization)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 6, 21, InstanceNormalization)>,
@@ -1031,7 +1036,7 @@ std::vector<std::unique_ptr<ComputeCapability>> WebGpuExecutionProvider::GetCapa
   auto cpu_nodes = GetCpuPreferredNodes(graph, kernel_lookup, tenative_candidates, *GetLogger());
   std::vector<std::unique_ptr<ComputeCapability>> result;
   for (auto& node_index : candidates) {
-    if (cpu_nodes.count(node_index) > 0) {
+    if (cpu_nodes.contains(node_index)) {
       continue;
     }
 

--- a/onnxruntime/core/session/abi_devices.h
+++ b/onnxruntime/core/session/abi_devices.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <sstream>
 #include <string>
 #include <unordered_map>
 
@@ -32,6 +33,44 @@ struct OrtHardwareDevice {
     }
 
     return h;
+  }
+
+  std::string ToString() const {
+    const char* type_str = "UNKNOWN";
+    switch (type) {
+      case OrtHardwareDeviceType_CPU:
+        type_str = "CPU";
+        break;
+      case OrtHardwareDeviceType_GPU:
+        type_str = "GPU";
+        break;
+      case OrtHardwareDeviceType_NPU:
+        type_str = "NPU";
+        break;
+      default:
+        break;
+    }
+
+    std::ostringstream oss;
+    oss << "OrtHardwareDevice{"
+        << "type=" << type_str
+        << ", vendor_id=" << vendor_id
+        << ", device_id=" << device_id
+        << ", vendor=\"" << vendor << "\"";
+
+    if (!metadata.Entries().empty()) {
+      oss << ", metadata={";
+      bool first = true;
+      for (const auto& [k, v] : metadata.Entries()) {
+        if (!first) oss << ", ";
+        first = false;
+        oss << k << "=" << v;
+      }
+      oss << "}";
+    }
+
+    oss << "}";
+    return oss.str();
   }
 };
 
@@ -74,6 +113,40 @@ struct OrtEpDevice {
   // the user provides const OrtEpDevice instances, but the OrtEpFactory API takes non-const instances for all
   // get/create methods to be as flexible as possible. this helper converts to a non-const factory instance.
   OrtEpFactory* GetMutableFactory() const { return ep_factory; }
+
+  std::string ToString() const {
+    std::ostringstream oss;
+    oss << "OrtEpDevice{"
+        << "ep_name=\"" << ep_name << "\""
+        << ", ep_vendor=\"" << ep_vendor << "\""
+        << ", device=" << (device ? device->ToString() : "null");
+
+    if (!ep_metadata.Entries().empty()) {
+      oss << ", ep_metadata={";
+      bool first = true;
+      for (const auto& [k, v] : ep_metadata.Entries()) {
+        if (!first) oss << ", ";
+        first = false;
+        oss << k << "=" << v;
+      }
+      oss << "}";
+    }
+
+    if (!ep_options.Entries().empty()) {
+      oss << ", ep_options={";
+      bool first = true;
+      for (const auto& [k, v] : ep_options.Entries()) {
+        if (!first) oss << ", ";
+        first = false;
+        oss << k << "=" << v;
+      }
+      oss << "}";
+    }
+
+    oss << "}";
+
+    return oss.str();
+  }
 };
 
 struct OrtDeviceEpIncompatibilityDetails {

--- a/onnxruntime/core/session/allocator_adapters.cc
+++ b/onnxruntime/core/session/allocator_adapters.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "allocator_adapters.h"
+#include "core/common/parse_string.h"
 #include "core/framework/error_code_helper.h"
 #include "core/framework/plugin_ep_stream.h"
 #include "core/session/abi_devices.h"
@@ -23,6 +24,51 @@ namespace {
 constexpr uint32_t kOrtAllocatorReserveMinVersion = 18;
 constexpr uint32_t kOrtAllocatorStatsMinVersion = 23;
 constexpr uint32_t kOrtAllocatorAllocOnStreamMinVersion = 23;
+constexpr uint32_t kOrtAllocatorShrinkMinVersion = 25;
+
+// Shared helper to parse OrtKeyValuePairs stats into AllocatorStats.
+// Used by both IAllocatorImplWrappingOrtAllocator and IArenaImplWrappingOrtAllocator.
+void GetStatsFromOrtAllocator(OrtAllocator* ort_allocator, AllocatorStats* stats) {
+  if (ort_allocator->version >= kOrtAllocatorStatsMinVersion && ort_allocator->GetStats) {
+    OrtKeyValuePairs* kvps = nullptr;
+    Ort::ThrowOnError(ort_allocator->GetStats(ort_allocator, &kvps));
+
+    auto release_fn = [](OrtKeyValuePairs** kvp) {
+      OrtApis::ReleaseKeyValuePairs(*kvp);
+    };
+
+    std::unique_ptr<OrtKeyValuePairs*, decltype(release_fn)> kvp_guard(&kvps, release_fn);
+
+    const auto keys = kvps->Keys(), values = kvps->Values();
+
+    for (size_t i = 0; i < keys.size(); ++i) {
+      int64_t val = 0;
+      if (!TryParseStringWithClassicLocale(std::string_view(values[i]), val)) {
+        continue;  // skip unparseable entries
+      }
+      if (strcmp(keys[i], "Limit") == 0) {
+        stats->bytes_limit = val;
+      } else if (strcmp(keys[i], "InUse") == 0) {
+        stats->bytes_in_use = val;
+      } else if (strcmp(keys[i], "TotalAllocated") == 0) {
+        stats->total_allocated_bytes = val;
+      } else if (strcmp(keys[i], "MaxInUse") == 0) {
+        stats->max_bytes_in_use = val;
+      } else if (strcmp(keys[i], "NumAllocs") == 0) {
+        stats->num_allocs = val;
+      } else if (strcmp(keys[i], "NumReserves") == 0) {
+        stats->num_reserves = val;
+      } else if (strcmp(keys[i], "NumArenaExtensions") == 0) {
+        stats->num_arena_extensions = val;
+      } else if (strcmp(keys[i], "NumArenaShrinkages") == 0) {
+        stats->num_arena_shrinkages = val;
+      } else if (strcmp(keys[i], "MaxAllocSize") == 0) {
+        stats->max_alloc_size = val;
+      }
+    }
+  }
+}
+
 }  // namespace
 
 OrtAllocatorImplWrappingIAllocator::OrtAllocatorImplWrappingIAllocator(onnxruntime::AllocatorPtr&& i_allocator)
@@ -64,6 +110,9 @@ OrtAllocatorImplWrappingIAllocator::OrtAllocatorImplWrappingIAllocator(onnxrunti
       return static_cast<OrtAllocatorImplWrappingIAllocator*>(this_)->AllocOnStream(size, stream);
     };
   }
+
+  // Shrink is not forwarded through the generic adapter — only plugin allocators implement it directly.
+  OrtAllocator::Shrink = nullptr;
 }
 
 void* OrtAllocatorImplWrappingIAllocator::Alloc(size_t size) {
@@ -151,41 +200,55 @@ void IAllocatorImplWrappingOrtAllocator::Free(void* p) {
 
 void IAllocatorImplWrappingOrtAllocator::GetStats(AllocatorStats* stats) {
   *stats = {};
+  GetStatsFromOrtAllocator(ort_allocator_.get(), stats);
+}
 
-  if (ort_allocator_->version >= kOrtAllocatorStatsMinVersion && ort_allocator_->GetStats) {
-    OrtKeyValuePairs* kvps = nullptr;
-    Ort::ThrowOnError(ort_allocator_->GetStats(ort_allocator_.get(), &kvps));
+// ---------------------------------------------------------------------------
+// IArenaImplWrappingOrtAllocator
+// ---------------------------------------------------------------------------
 
-    auto release_fn = [](OrtKeyValuePairs** kvp) {
-      OrtApis::ReleaseKeyValuePairs(*kvp);
-    };
+IArenaImplWrappingOrtAllocator::IArenaImplWrappingOrtAllocator(OrtAllocatorUniquePtr ort_allocator)
+    : IArena(*ort_allocator->Info(ort_allocator.get())), ort_allocator_(std::move(ort_allocator)) {
+}
 
-    std::unique_ptr<OrtKeyValuePairs*, decltype(release_fn)> kvp_guard(&kvps, release_fn);
+void* IArenaImplWrappingOrtAllocator::Alloc(size_t size) {
+  return ort_allocator_->Alloc(ort_allocator_.get(), size);
+}
 
-    const auto keys = kvps->Keys(), values = kvps->Values();
+void IArenaImplWrappingOrtAllocator::Free(void* p) {
+  return ort_allocator_->Free(ort_allocator_.get(), p);
+}
 
-    for (size_t i = 0; i < keys.size(); ++i) {
-      if (strcmp(keys[i], "Limit") == 0) {
-        stats->bytes_limit = std::stoll(values[i]);
-      } else if (strcmp(keys[i], "InUse") == 0) {
-        stats->bytes_in_use = std::stoll(values[i]);
-      } else if (strcmp(keys[i], "TotalAllocated") == 0) {
-        stats->total_allocated_bytes = std::stoll(values[i]);
-      } else if (strcmp(keys[i], "MaxInUse") == 0) {
-        stats->max_bytes_in_use = std::stoll(values[i]);
-      } else if (strcmp(keys[i], "NumAllocs") == 0) {
-        stats->num_allocs = std::stoll(values[i]);
-      } else if (strcmp(keys[i], "NumReserves") == 0) {
-        stats->num_reserves = std::stoll(values[i]);
-      } else if (strcmp(keys[i], "NumArenaExtensions") == 0) {
-        stats->num_arena_extensions = std::stoll(values[i]);
-      } else if (strcmp(keys[i], "NumArenaShrinkages") == 0) {
-        stats->num_arena_shrinkages = std::stoll(values[i]);
-      } else if (strcmp(keys[i], "MaxAllocSize") == 0) {
-        stats->max_alloc_size = std::stoll(values[i]);
-      }
-    }
+void* IArenaImplWrappingOrtAllocator::Reserve(size_t size) {
+  if (ort_allocator_->version >= kOrtAllocatorReserveMinVersion && ort_allocator_->Reserve) {
+    return ort_allocator_->Reserve(ort_allocator_.get(), size);
   }
+
+  return ort_allocator_->Alloc(ort_allocator_.get(), size);
+}
+
+bool IArenaImplWrappingOrtAllocator::IsStreamAware() const {
+  return ort_allocator_->version >= kOrtAllocatorAllocOnStreamMinVersion && ort_allocator_->AllocOnStream != nullptr;
+}
+
+void* IArenaImplWrappingOrtAllocator::AllocOnStream(size_t size, Stream* stream) {
+  if (ort_allocator_->version >= kOrtAllocatorAllocOnStreamMinVersion && ort_allocator_->AllocOnStream) {
+    return ort_allocator_->AllocOnStream(ort_allocator_.get(), size, static_cast<OrtSyncStream*>(stream));
+  }
+
+  return ort_allocator_->Alloc(ort_allocator_.get(), size);
+}
+
+void IArenaImplWrappingOrtAllocator::GetStats(AllocatorStats* stats) {
+  *stats = {};
+  GetStatsFromOrtAllocator(ort_allocator_.get(), stats);
+}
+
+Status IArenaImplWrappingOrtAllocator::Shrink() {
+  if (ort_allocator_->version >= kOrtAllocatorShrinkMinVersion && ort_allocator_->Shrink) {
+    return ToStatusAndRelease(ort_allocator_->Shrink(ort_allocator_.get()));
+  }
+  return Status::OK();
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/session/allocator_adapters.h
+++ b/onnxruntime/core/session/allocator_adapters.h
@@ -72,4 +72,35 @@ class IAllocatorImplWrappingOrtAllocator final : public IAllocator {
   OrtAllocatorUniquePtr ort_allocator_ = nullptr;
 };
 
+/// Wraps an OrtAllocator* that supports Shrink() as an IArena.
+/// This allows session-level code to discover and call Shrink() through the standard IArena interface.
+/// ReleaseStreamBuffers() is intentionally a no-op: plugin EPs handle stream cleanup internally
+/// via OrtSyncStreamImpl::OnSessionRunEnd.
+class IArenaImplWrappingOrtAllocator final : public IArena {
+ public:
+  explicit IArenaImplWrappingOrtAllocator(OrtAllocatorUniquePtr ort_allocator);
+
+  void* Alloc(size_t size) override;
+  void Free(void* p) override;
+  void* Reserve(size_t size) override;
+
+  bool IsStreamAware() const override;
+  void* AllocOnStream(size_t size, Stream* stream) override;
+
+  void GetStats(AllocatorStats* stats) override;
+
+  Status Shrink() override;
+  // ReleaseStreamBuffers is intentionally not overridden — the default IArena no-op is correct.
+  // Plugin EPs handle stream buffer cleanup internally via OnSessionRunEnd.
+
+  const OrtAllocator* GetWrappedOrtAllocator() const {
+    return ort_allocator_.get();
+  }
+
+  ORT_DISALLOW_COPY_AND_ASSIGNMENT(IArenaImplWrappingOrtAllocator);
+
+ private:
+  OrtAllocatorUniquePtr ort_allocator_ = nullptr;
+};
+
 }  // namespace onnxruntime

--- a/onnxruntime/core/session/default_cpu_allocator_c_api.cc
+++ b/onnxruntime/core/session/default_cpu_allocator_c_api.cc
@@ -28,6 +28,8 @@ struct OrtDefaultCpuAllocator : onnxruntime::OrtAllocatorImpl {
       *stats = reinterpret_cast<OrtKeyValuePairs*>(kvp.release());
       return nullptr;
     };
+    OrtAllocator::AllocOnStream = nullptr;
+    OrtAllocator::Shrink = nullptr;
     Ort::ThrowOnError(OrtApis::CreateCpuMemoryInfo(OrtDeviceAllocator, OrtMemTypeDefault, &cpu_memory_info));
   }
 

--- a/onnxruntime/core/session/environment.cc
+++ b/onnxruntime/core/session/environment.cc
@@ -862,7 +862,14 @@ Status Environment::CreateSharedAllocatorImpl(const OrtEpDevice& ep_device,
 
   shared_ort_allocators_.insert(allocator);
 
-  AllocatorPtr shared_allocator = std::make_shared<IAllocatorImplWrappingOrtAllocator>(std::move(ort_allocator));
+  // Wrap as IArena when the plugin allocator implements Shrink(), making it
+  // discoverable by session-level arena management (e.g. ShrinkMemoryArenas).
+  AllocatorPtr shared_allocator;
+  if (allocator->version >= 25 && allocator->Shrink != nullptr) {
+    shared_allocator = std::make_shared<IArenaImplWrappingOrtAllocator>(std::move(ort_allocator));
+  } else {
+    shared_allocator = std::make_shared<IAllocatorImplWrappingOrtAllocator>(std::move(ort_allocator));
+  }
   shared_allocators_.push_back(std::move(shared_allocator));
 
   if (allocator_out != nullptr) {

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -3872,12 +3872,12 @@ common::Status InferenceSession::ValidateAndParseShrinkArenaString(const std::st
       ++iter;
     }
 
-    // Shrink if it is a BFCArena allocator
-    // Iterate through the registered allocators as we could have multiple allocators for the device+type
-    // if they differ by vendor_id.
+    // Shrink if it is an arena allocator.
+    // Both in-tree arenas (BFCArena) and plugin EP arenas (IArenaImplWrappingOrtAllocator)
+    // inherit IArena, so AsArena() returns non-null for both.
     for (const auto& [device, allocator_ptr] : session_state_->GetAllocators()) {
       if (device.Type() == device_type && device.MemType() == memory_type && device.Id() == device_id) {
-        if (allocator_ptr->Info().alloc_type == OrtAllocatorType::OrtArenaAllocator) {
+        if (allocator_ptr->AsArena() != nullptr) {
           arenas_to_shrink.push_back(allocator_ptr);
           break;
         }
@@ -3896,7 +3896,13 @@ common::Status InferenceSession::ValidateAndParseShrinkArenaString(const std::st
 
 void InferenceSession::ShrinkMemoryArenas(gsl::span<const AllocatorPtr> arenas_to_shrink) {
   for (auto& alloc : arenas_to_shrink) {
-    auto status = static_cast<IArena*>(alloc.get())->Shrink();
+    auto* arena = alloc->AsArena();
+    if (!arena) {
+      LOGS(*session_logger_, WARNING) << "Allocator is not an IArena, skipping Shrink: " << alloc->Info().ToString();
+      continue;
+    }
+
+    auto status = arena->Shrink();
 
     if (!status.IsOK()) {
       LOGS(*session_logger_, WARNING) << "Unable to shrink arena: " << alloc->Info().ToString()

--- a/onnxruntime/core/session/model_package/README.md
+++ b/onnxruntime/core/session/model_package/README.md
@@ -1,0 +1,134 @@
+# Model Package Format
+
+This document describes the model package directory layout and the JSON files used by ONNX Runtime to discover and load model packages. All JSON files must be UTF-8 encoded.
+
+## Definitions
+
+- Model Package
+
+  - A model package defines the overall logical ‘model’
+  - A model package contains one or more ‘component models’
+  - The component models are executed when running the model package to provide the overall functionality of the logical model
+  - A model package may contain configuration information to support running multiple component models
+
+- Component Model
+  - A component model comprises one or more ‘model variants’
+  - All variants have the same model inputs and outputs with the same shapes.
+    - The data types may vary.
+
+- Model Variant
+  - A ‘model variant’ is a single ONNX or ORT format model.
+
+## Directory layout
+
+````
+<model>.ortpackage/ 
+├── manifest.json
+├── pipeline.json
+├── configs/ 
+|   ├── genai_config.json 
+|   └── chat_template.jinja
+└── models/ 
+    └── model_name/ 
+        ├── metadata.json
+        |   └── Contains general information on the component model,
+        |       and specific information about each model variant
+        |       such as data types, quantization algo, EP, etc. that
+        |       is updated on add/remove of model variant
+        └── shared_weights/ (shared weights from all variants)
+            └── <checksum of weights file A>/
+                └── model.data
+            └── <checksum of weights file B>/
+                └── model.data
+            └── ...
+        └── base model /   
+            ├── model.onnx  
+        └── variant A / 
+            ├── optimized model.onnx (contains EPContext nodes) 
+            └── [Compilation artifacts] 
+        └── variant B / 
+            ├── optimized model.onnx (contains EPContext nodes) 
+            └── [Compilation artifacts] 
+````
+
+
+## Notes:
+- Shared weights is not yet supported, but the format allows for it in the future.
+
+## `manifest.json` (required)
+
+Location: `<package_root>/manifest.json`
+
+Purpose: Provides the overall package identity and (optionally) lists component models available in the package.
+
+Schema:
+- `model_name` (string, required): Logical package name.
+- `model_version` (string, optional): Version of the model package.
+- `component_models` (array of strings, optional): List of component model names. If this field is omitted, ONNX Runtime will discover component models by enumerating subdirectories under `models/`. If present, the names listed here must match the subdirectory names under `models/`.
+
+### `manifest.json` example
+
+```json
+{
+    "model_name":  <logical_model_name>,
+    "model_version": "1.0",
+    "component_models": [
+        <component_model_name_1>,
+        <component_model_name_2>
+    ]
+}
+```
+
+## `metadata.json` (required per component model)
+
+Location: `<package_root>/models/<component_model>/metadata.json`
+
+Purpose: Describes the variants available for a specific component model.
+
+Schema:
+- `component_model_name` (string, required): Name of the component model.
+- `model_variants` (object, required): Map of variant names to variant descriptors.
+  - `<variant_name>` (object, required):
+    - `model_type` (string, optional): Type of the model (e.g., `"onnx"`, `"ORT"`). If omitted, ORT will treat it as an ONNX model by default.
+    - `model_file` (string, optional): Path relative to the model variant directory. Can point to an ONNX model file or a directory. If it is a directory, or if `model_file` is omitted, ORT will discover the ONNX model file within that directory.
+    - `model_id` (string, optional): Unique identifier for the model variant. It should match a catalog value if the model comes from a catalog. If `model_id` is present, the model will be in the <component_model_name>/`model_id`/ directory.
+    - `constraints` (object, required):
+      - `ep` (string, required (except base model)): Execution provider name (e.g., `"TensorrtExecutionProvider"`, `"QNNExecutionProvider"`, `"OpenVINOExecutionProvider"`).
+      - `device` (string, optional): Target device type (e.g., `"cpu"`, `"gpu"`, `"npu"`). Must match a supported `OrtHardwareDevice`. If the EPContext model can support multiple device types, this field can be omitted and EP should record supported device types in `ep_compatibility_info` instead.
+      - `architecture` (string, optional): Hardware architecture hint; interpreted by the EP if needed.
+      - `ep_compatibility_info` (string, optional): EP-specific compatibility string (as produced by `OrtEp::GetCompiledModelCompatibilityInfo()`); validated by the EP when selecting a variant. **The compatibility value returned by the EP is critical—ORT uses it to rank and choose the model variant.**
+
+### `metadata.json` example
+```json
+{
+    "component_model_name":  <component_model_name>,
+    "model_variants": {
+        <variant_1>: {
+            "model_type": "onnx",
+            "model_file": "model_ctx.onnx",
+            "constraints": {
+                "ep": "TensorrtExecutionProvider",
+                "ep_compatibility_info": "..."
+            }
+        },
+        <variant_2>: {
+            "model_type": "onnx",
+            "model_file": "model_ctx.onnx",
+             "constraints": {
+                 "ep": "OpenVINOExecutionProvider",
+                 "device": "cpu",
+                 "ep_compatibility_info": "..."
+             }
+        }
+    }
+}
+```
+
+
+## Processing rules (runtime expectations)
+
+- ONNX Runtime reads `manifest.json` if the path passed in is the package root directory; if `component_models` is present, it uses that to determine which component models to load. If `component_models` is not present, ONNX Runtime discovers component models by enumerating subdirectories under `models/`. (In this case, ONNX Runtime expects only one component model exist in the model package.)
+- ONNX Runtime reads component model's `metadata.json` and ignores `manifest.json` if the path passed in points directly to a component model directory.
+- For each component model, `metadata.json` supplies the definitive list of variants and constraints.
+- Variant selection is performed by matching constraints (EP, device, `ep_compatibility_info`, and optionally architecture). **The EP’s returned compatibility value (e.g., `EP_SUPPORTED_OPTIMAL`, `EP_SUPPORTED_PREFER_RECOMPILATION`) is used to score and pick the winning model variant.**
+- All file paths must be relative paths; avoid absolute paths to keep packages portable

--- a/onnxruntime/core/session/model_package/model_package_context.cc
+++ b/onnxruntime/core/session/model_package/model_package_context.cc
@@ -1,0 +1,299 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <limits>
+#include <sstream>
+#include <string>
+
+#include "core/common/logging/logging.h"
+#include "core/framework/error_code_helper.h"
+#include "core/session/model_package/model_package_context.h"
+#include "core/session/model_package/model_package_descriptor_parser.h"
+
+namespace onnxruntime {
+namespace {
+std::string ToLower(std::string_view s) {
+  std::string result(s);
+  std::transform(result.begin(), result.end(), result.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  return result;
+}
+
+bool MatchesDevice(const OrtHardwareDevice* hd, std::string_view value) {
+  if (value.empty() || hd == nullptr) {
+    return value.empty();
+  }
+
+  const std::string device_type = ToLower(value);
+  switch (hd->type) {
+    case OrtHardwareDeviceType::OrtHardwareDeviceType_CPU:
+      return device_type == "cpu";
+    case OrtHardwareDeviceType::OrtHardwareDeviceType_GPU:
+      return device_type == "gpu";
+    case OrtHardwareDeviceType::OrtHardwareDeviceType_NPU:
+      return device_type == "npu";
+    default:
+      return false;
+  }
+}
+
+const OrtHardwareDevice* FindMatchingHardwareDevice(std::string_view device_constraint,
+                                                    gsl::span<const OrtHardwareDevice* const> hardware_devices) {
+  if (device_constraint.empty()) {
+    return nullptr;
+  }
+
+  for (const auto* hd : hardware_devices) {
+    if (MatchesDevice(hd, device_constraint)) {
+      return hd;
+    }
+  }
+
+  return nullptr;
+}
+
+Status ValidateCompiledModelCompatibilityInfo(const VariantSelectionEpInfo& ep_info,
+                                              const std::string& compatibility_info,
+                                              std::vector<const OrtHardwareDevice*>& constraint_devices,
+                                              OrtCompiledModelCompatibility* compiled_model_compatibility) {
+  if (compatibility_info.empty()) {
+    LOGS_DEFAULT(INFO) << "No compatibility info constraint for this variant. Skip compatibility validation.";
+    return Status::OK();
+  }
+
+  auto* ep_factory = ep_info.ep_factory;
+
+  if (ep_factory &&
+      ep_factory->ort_version_supported >= 23 &&
+      ep_factory->ValidateCompiledModelCompatibilityInfo != nullptr) {
+    auto status = ep_factory->ValidateCompiledModelCompatibilityInfo(ep_factory,
+                                                                     constraint_devices.data(),
+                                                                     constraint_devices.size(),
+                                                                     compatibility_info.c_str(),
+                                                                     compiled_model_compatibility);
+    ORT_RETURN_IF_ERROR(ToStatusAndRelease(status));
+  }
+
+  return Status::OK();
+}
+
+bool MatchesVariant(ModelVariantInfo& variant, const VariantSelectionEpInfo& ep_info) {
+  LOGS_DEFAULT(INFO) << "Checking model variant with EP constraint '" << variant.ep
+                     << "', device constraint '" << variant.device
+                     << "' and compatibility info constraint '" << variant.compatibility_info
+                     << "' against EP '" << ep_info.ep_name << "' with supported devices: "
+                     << [&ep_info]() {
+                          std::string devices_str;
+                          for (const auto* hd : ep_info.hardware_devices) {
+                            if (!devices_str.empty()) {
+                              devices_str += ", ";
+                            }
+                            devices_str += hd->vendor + " " + std::to_string(hd->device_id);
+                          }
+                          return devices_str.empty() ? "none" : devices_str;
+                        }();
+
+  // 1) Check EP constraint
+  if (!variant.ep.empty() && variant.ep != ep_info.ep_name) {
+    LOGS_DEFAULT(INFO) << "Variant EP constraint '" << variant.ep << "' does not match EP name '"
+                       << ep_info.ep_name << "'. Skip this variant.";
+    return false;
+  }
+
+  // 2) Check device constraint
+  bool device_ok = variant.device.empty();
+
+  // For EPs that don't implement the OrtEpFactory interface, ep_info.hardware_devices will be empty and ORT won't
+  // have the supported device information for those EPs.
+  // In that case, we will skip the device constraint validation for those EPs.
+  if (ep_info.hardware_devices.empty()) {
+    device_ok = true;
+  }
+
+  // The constraint_devices is the target device(s) and will be passed to ValidateCompiledModelCompatibilityInfo
+  // for compatibility validation.
+  std::vector<const OrtHardwareDevice*> constraint_devices = ep_info.hardware_devices;
+
+  if (!device_ok) {
+    if (const auto* matched = FindMatchingHardwareDevice(variant.device, ep_info.hardware_devices)) {
+      device_ok = true;
+      constraint_devices = {matched};
+    }
+  }
+
+  if (!device_ok) {
+    LOGS_DEFAULT(INFO) << "Variant device constraint '" << variant.device
+                       << "' does not match any device supported by EP '"
+                       << ep_info.ep_name << "'. Skip this variant.";
+    return false;
+  }
+
+  // 3) Check ep_compatibility_info constraint
+  //
+  // ORT does not directly evaluate the architecture constraint. Instead, it relies on
+  // the ep_compatibility_info constraint, which may encode architecture information
+  // if needed.
+  //
+  // The ep_compatibility_info value is expected to match the EP compatibility string
+  // stored in the EPContext model metadata.
+  // (See OrtEp::GetCompiledModelCompatibilityInfo() for how this string is generated.)
+  //
+  // The EP implementation of EpFactory::ValidateCompiledModelCompatibilityInfo()
+  // is responsible for validating the compatibility string against the target device
+  // (i.e. OrtHardwareDevice), and returning the compatibility result.
+  auto status = ValidateCompiledModelCompatibilityInfo(ep_info, variant.compatibility_info,
+                                                       constraint_devices, &variant.compiled_model_compatibility);
+  if (!status.IsOK()) {
+    LOGS_DEFAULT(WARNING) << "Failed to validate compatibility info for variant with EP constraint '"
+                          << variant.ep << "': " << status.ToString()
+                          << ". Simply skip this compatibility validation.";
+
+    variant.compiled_model_compatibility = OrtCompiledModelCompatibility_EP_NOT_APPLICABLE;
+  }
+
+  if (variant.compiled_model_compatibility == OrtCompiledModelCompatibility_EP_UNSUPPORTED) {
+    LOGS_DEFAULT(INFO) << "Variant compatibility info indicates unsupported model for EP '" << ep_info.ep_name
+                       << "'. Compatibility info: '" << variant.compatibility_info
+                       << "'. Skip this variant.";
+    return false;
+  }
+
+  LOGS_DEFAULT(INFO) << "This model variant is selected and could be used for EP '" << ep_info.ep_name << "'.";
+
+  return true;
+}
+}  // namespace
+
+// Calculate a score for the model variant based on its constraints and metadata.
+//
+// It's only used to choose the best model variant among multiple candidates that match constraints.
+// Higher score means more preferred.
+//
+// For example:
+// If one model variant/EPContext is compatible with the EP and has compatiliby value indicating optimal compatibility
+// (i.e. compiled_model_compatibility == OrtCompiledModelCompatibility_EP_SUPPORTED_OPTIMAL) while another model variant/EPContext
+// is also compatible with the EP but has compatibility value indicating prefer recompilation
+// (i.e. compiled_model_compatibility == OrtCompiledModelCompatibility_EP_SUPPORTED_PREFER_RECOMPILATION),
+// the former will have a higher score and thus be selected.
+//
+int ModelVariantSelector::CalculateVariantScore(const ModelVariantInfo& variant) const {
+  int score = 0;
+
+  if (variant.compiled_model_compatibility == OrtCompiledModelCompatibility_EP_SUPPORTED_OPTIMAL) {
+    score += 100;
+  } else if (variant.compiled_model_compatibility == OrtCompiledModelCompatibility_EP_SUPPORTED_PREFER_RECOMPILATION) {
+    score += 50;
+  }
+
+  // The base model with no constraints (meaning any EP can run it) gets a base score of 0.
+  // Other model variants with EP constraint get a higher score, so that they will be preferred over the base model.
+  if (!variant.ep.empty()) {
+    score += 10;
+  }
+
+  return score;
+}
+
+Status ModelVariantSelector::SelectVariant(const ModelPackageContext& context,
+                                           gsl::span<VariantSelectionEpInfo> ep_infos,
+                                           std::optional<std::filesystem::path>& selected_variant_path) const {
+  selected_variant_path.reset();
+
+  // explicit local copy as this function will be modifying the variant info
+  // (e.g. setting compatibility validation result) during the selection process.
+  std::vector<ModelVariantInfo> variants = context.GetModelVariantInfos();
+
+  if (variants.empty()) {
+    return Status::OK();
+  }
+
+  // Only one SelectionEpInfo in `ep_infos` is supported for now.
+  if (ep_infos.empty()) {
+    return Status::OK();
+  }
+  if (ep_infos.size() > 1) {
+    LOGS_DEFAULT(WARNING) << "Multiple EP info provided for model variant selection, but only the first one with ep name '"
+                          << ep_infos[0].ep_name << "' will be used.";
+  }
+  const auto& ep_info = ep_infos[0];
+
+  std::unordered_set<size_t> candidate_indices_set;
+
+  // 1) Check unconstrained variants.
+  for (size_t i = 0, end = variants.size(); i < end; ++i) {
+    const auto& c = variants[i];
+    if (c.ep.empty() && c.device.empty() && c.architecture.empty() && c.compatibility_info.empty()) {
+      candidate_indices_set.insert(i);
+    }
+  }
+
+  // 2) Check all variants that match the EP info.
+  for (size_t i = 0, end = variants.size(); i < end; ++i) {
+    if (candidate_indices_set.count(i) > 0) {
+      continue;
+    }
+    auto& c = variants[i];
+    if (MatchesVariant(c, ep_info)) {
+      candidate_indices_set.insert(i);
+    }
+  }
+
+  // Log all matched candidates.
+  {
+    std::ostringstream oss;
+    oss << candidate_indices_set.size() << " Model variant(s) matched constraints: ";
+    size_t i = 0;
+    for (size_t idx : candidate_indices_set) {
+      const auto& path = variants[idx].model_path;
+      oss << path.string();
+      if (i + 1 < candidate_indices_set.size()) {
+        oss << "; ";
+      }
+      ++i;
+    }
+    LOGS_DEFAULT(INFO) << oss.str();
+  }
+
+  if (candidate_indices_set.empty()) {
+    return Status::OK();
+  }
+
+  // 3) If only one candidate, select it.
+  if (candidate_indices_set.size() == 1) {
+    selected_variant_path = variants[*candidate_indices_set.begin()].model_path;
+    return Status::OK();
+  }
+
+  // 4) If there are multiple candidates, choose the highest-score model variant among them.
+  int best_score = std::numeric_limits<int>::min();
+  size_t best_index = *candidate_indices_set.begin();
+
+  for (size_t idx : candidate_indices_set) {
+    const auto& v = variants[idx];
+    int variant_best_score = std::numeric_limits<int>::min();
+    variant_best_score = std::max(variant_best_score, CalculateVariantScore(v));
+
+    if (variant_best_score > best_score) {
+      best_score = variant_best_score;
+      best_index = idx;
+    }
+  }
+
+  selected_variant_path = variants[best_index].model_path;
+
+  return Status::OK();
+}
+
+ModelPackageContext::ModelPackageContext(const std::filesystem::path& package_root) {
+  ModelPackageDescriptorParser parser(logging::LoggingManager::DefaultLogger());
+  ORT_THROW_IF_ERROR(parser.ParseVariantsFromRoot(package_root, model_variant_infos_));
+}
+
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/core/session/model_package/model_package_context.h
+++ b/onnxruntime/core/session/model_package/model_package_context.h
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include "core/session/abi_session_options_impl.h"
+#include "core/session/environment.h"
+#include "core/session/onnxruntime_c_api.h"
+#include "core/common/common.h"
+
+#include "nlohmann/json.hpp"
+using json = nlohmann::json;
+
+namespace onnxruntime {
+
+struct ModelVariantInfo {
+  std::string ep{};
+  std::string device{};
+  std::string architecture{};
+  std::string compatibility_info{};
+  std::unordered_map<std::string, std::string> metadata{};
+  OrtCompiledModelCompatibility compiled_model_compatibility{};
+  std::filesystem::path model_path{};
+};
+
+struct VariantSelectionEpInfo {
+  std::string ep_name{};
+  OrtEpFactory* ep_factory{nullptr};
+  std::vector<const OrtEpDevice*> ep_devices{};
+  std::vector<const OrtHardwareDevice*> hardware_devices{};
+  std::vector<const OrtKeyValuePairs*> ep_metadata{};
+  ProviderOptions ep_options{};
+};
+
+class ModelPackageContext {
+ public:
+  ModelPackageContext(const std::filesystem::path& package_root);
+
+  const std::vector<ModelVariantInfo>& GetModelVariantInfos() const noexcept {
+    return model_variant_infos_;
+  }
+
+ private:
+  std::vector<ModelVariantInfo> model_variant_infos_;
+};
+
+class ModelVariantSelector {
+ public:
+  ModelVariantSelector() = default;
+
+  // Select model variants that match the provided EP/device info. If multiple
+  // variants match, the one with the highest variant score is chosen.
+  Status SelectVariant(const ModelPackageContext& context,
+                       gsl::span<VariantSelectionEpInfo> ep_infos,
+                       std::optional<std::filesystem::path>& selected_variant_path) const;
+
+ private:
+  // Compute a score for a variant
+  int CalculateVariantScore(const ModelVariantInfo& variant) const;
+};
+
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/core/session/model_package/model_package_descriptor_parser.cc
+++ b/onnxruntime/core/session/model_package/model_package_descriptor_parser.cc
@@ -1,0 +1,482 @@
+// # Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <algorithm>
+#include <fstream>
+#include <sstream>
+#include <unordered_set>
+#include <unordered_map>
+#include <vector>
+#include <optional>
+
+#include "core/common/logging/logging.h"
+#include "core/framework/error_code_helper.h"
+#include "core/session/model_package/model_package_descriptor_parser.h"
+
+namespace onnxruntime {
+namespace {
+
+struct VariantConstraintsSchema {
+  std::optional<std::string> ep;
+  std::optional<std::string> device;
+  std::optional<std::string> architecture;
+  std::optional<std::string> ep_compatibility_info;
+};
+
+struct VariantSchema {
+  std::optional<std::string> model_type;
+  std::optional<std::string> model_file;
+  std::optional<std::string> model_id;
+  std::optional<VariantConstraintsSchema> constraints;
+};
+
+struct ManifestSchema {
+  std::string model_name;
+  std::optional<std::string> model_version;
+  std::optional<std::vector<std::string>> component_models;
+};
+
+struct MetadataSchema {
+  std::optional<std::string> component_model_name;
+  std::unordered_map<std::string, VariantSchema> model_variants;
+};
+
+void from_json(const json& j, VariantConstraintsSchema& c) {
+  if (j.contains(kEpKey) && j[kEpKey].is_string()) c.ep = j[kEpKey].get<std::string>();
+  if (j.contains(kDeviceKey) && j[kDeviceKey].is_string()) c.device = j[kDeviceKey].get<std::string>();
+  if (j.contains(kArchitectureKey) && j[kArchitectureKey].is_string()) c.architecture = j[kArchitectureKey].get<std::string>();
+  if (j.contains(kEpCompatibilityInfoKey) && j[kEpCompatibilityInfoKey].is_string()) {
+    c.ep_compatibility_info = j[kEpCompatibilityInfoKey].get<std::string>();
+  }
+}
+
+void from_json(const json& j, VariantSchema& v) {
+  if (j.contains(kModelTypeKey) && j[kModelTypeKey].is_string()) v.model_type = j[kModelTypeKey].get<std::string>();
+  if (j.contains(kModelFileKey) && j[kModelFileKey].is_string()) v.model_file = j[kModelFileKey].get<std::string>();
+  if (j.contains(kModelIdKey) && j[kModelIdKey].is_string()) v.model_id = j[kModelIdKey].get<std::string>();
+  if (j.contains(kConstraintsKey) && j[kConstraintsKey].is_object()) {
+    v.constraints = j[kConstraintsKey].get<VariantConstraintsSchema>();
+  }
+}
+
+void from_json(const json& j, ManifestSchema& m) {
+  m.model_name = j.at(kModelNameKey).get<std::string>();  // required
+
+  if (j.contains(kModelVersionKey) && j[kModelVersionKey].is_string()) {
+    m.model_version = j[kModelVersionKey].get<std::string>();
+  }
+
+  if (j.contains(kComponentModelsKey)) {
+    if (!j[kComponentModelsKey].is_array()) {
+      throw std::invalid_argument("\"component_models\" must be an array of strings");
+    }
+    m.component_models = j[kComponentModelsKey].get<std::vector<std::string>>();
+  }
+}
+
+void from_json(const json& j, MetadataSchema& m) {
+  if (j.contains("component_model_name") && j["component_model_name"].is_string()) {
+    m.component_model_name = j["component_model_name"].get<std::string>();
+  }
+  m.model_variants = j.at(kModelVariantsKey).get<std::unordered_map<std::string, VariantSchema>>();  // required
+}
+
+Status FindSingleOnnxFile(const std::filesystem::path& search_dir,
+                          std::filesystem::path& resolved_path) {
+  std::vector<std::filesystem::path> onnx_files;
+  for (const auto& entry : std::filesystem::directory_iterator(search_dir)) {
+    if (!entry.is_regular_file()) {
+      continue;
+    }
+
+    std::string ext = entry.path().extension().string();
+    std::transform(ext.begin(), ext.end(), ext.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    if (ext == ".onnx") {
+      onnx_files.push_back(entry.path());
+    }
+  }
+
+  if (onnx_files.empty()) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                           "No ONNX model file found under ", search_dir.string());
+  }
+
+  if (onnx_files.size() > 1) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                           "Multiple ONNX model files found under ", search_dir.string(),
+                           ". Multiple ONNX files per variant are not supported yet.");
+  }
+
+  resolved_path = onnx_files.front();
+  return Status::OK();
+};
+
+void ApplyVariantConstraints(const VariantConstraintsSchema& c, ModelVariantInfo& variant) {
+  if (c.ep.has_value()) variant.ep = *c.ep;
+  if (c.device.has_value()) variant.device = *c.device;
+  if (c.architecture.has_value()) variant.architecture = *c.architecture;
+  if (c.ep_compatibility_info.has_value()) variant.compatibility_info = *c.ep_compatibility_info;
+}
+
+std::string SanitizeModelIdForPath(std::string model_id) {
+  for (char& ch : model_id) {
+    switch (ch) {
+      case '<':
+      case '>':
+      case ':':
+      case '"':
+      case '/':
+      case '\\':
+      case '|':
+      case '?':
+      case '*':
+        ch = '_';
+        break;
+      default:
+        break;
+    }
+  }
+  return model_id;
+}
+
+}  // namespace
+
+// The package_root could be either a component model root (contains metadata.json) or a model package root (contains
+// manifest.json). The parsing logic will first check for metadata.json to see if it's a component model root, and if
+// not found, it will look for manifest.json to treat it as a model package root.
+//
+// This function parses information from manifest.json and/or metadata.json for the model variants from the same
+// component model, producing a unified list of ModelVariantInfo.
+//
+// Note: If the package_root is a model package root, currently it only supports one component model.
+// #TODO: In the future we may want ORT to support running multiple component models in a single "virtual" session.
+//
+// A manifest.json may look like this:
+//
+// {
+//     "model_name" : <logical_model_name>,
+//     "model_version": "1.0",
+//     "component_models" : [<component_model_name_1>,
+//                           <component_model_name_2>]
+// }
+//
+// A metadata.json for the component model may look like this:
+//
+// {
+//    "component_model_name" : <component_model_name>,
+//    "model_variants" : {
+//        <variant_name_1> : {
+//            "model_type": "onnx",
+//            "model_file" : <ep_context_model_1 onnx file>,
+//            "constraints" : {
+//                "ep" : <ep_name>,
+//                "device" : <device_type>,
+//                "ep_compatibility_info" : <ep_compatibility_info_1>
+//            }
+//        },
+//        <variant_name_2> : {
+//             "model_type": "onnx",
+//             "model_file" : <ep_context_model_2 onnx file>,
+//             "constraints" : {
+//                 "ep" : <ep_name>,
+//                 "device" : <device_type>,
+//                 "ep_compatibility_info" : <ep_compatibility_info_1>
+//             }
+//         }
+//     }
+// }
+Status ModelPackageDescriptorParser::ParseVariantsFromRoot(const std::filesystem::path& package_root,
+                                                           /*out*/ std::vector<ModelVariantInfo>& variants) const {
+  variants.clear();
+
+  // package_root could be either a component model root (contains metadata.json) or a model package root (contains manifest.json).
+
+  // Mode 1: package_root is a component model root (contains metadata.json).
+  // In this mode metadata.json is the source of truth and manifest.json is ignored.
+  const auto component_metadata_path = package_root / kComponentModelMetadataFileName;
+  if (std::filesystem::exists(component_metadata_path) &&
+      std::filesystem::is_regular_file(component_metadata_path)) {
+    std::ifstream mf(component_metadata_path, std::ios::binary);
+    if (!mf) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                             "Failed to open metadata.json at ", component_metadata_path.string());
+    }
+
+    json metadata_doc;
+    ORT_TRY {
+      metadata_doc = json::parse(mf);
+    }
+    ORT_CATCH(const std::exception& ex) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                             "metadata.json at ", component_metadata_path.string(),
+                             " is not valid JSON: ", ex.what());
+    }
+
+    MetadataSchema metadata_schema;
+    ORT_TRY {
+      metadata_schema = metadata_doc.get<MetadataSchema>();
+    }
+    ORT_CATCH(const std::exception& ex) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                             "metadata.json at ", component_metadata_path.string(),
+                             " has invalid schema: ", ex.what());
+    }
+
+    const std::string component_model_name =
+        metadata_schema.component_model_name.has_value()
+            ? *metadata_schema.component_model_name
+            : package_root.filename().string();
+
+    // component-root mode
+    ORT_RETURN_IF_ERROR(ParseVariantsFromComponent(component_model_name,
+                                                   package_root,
+                                                   &metadata_doc[kModelVariantsKey],
+                                                   variants));
+
+    for (const auto& v : variants) {
+      LOGS(logger_, INFO) << "model variant: file='" << v.model_path.string()
+                          << "' ep='" << v.ep << "' device='" << v.device
+                          << "' arch='" << v.architecture << "'";
+    }
+
+    return Status::OK();
+  }
+
+  // Mode 2: package_root is a model package root, resolve via manifest.json.
+  const auto manifest_path = package_root / kModelPackageManifestFileName;
+  if (!std::filesystem::exists(manifest_path)) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                           "No manifest.json found at ", manifest_path.string());
+  }
+
+  std::ifstream f(manifest_path, std::ios::binary);
+  if (!f) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                           "Failed to open manifest.json at ", manifest_path.string());
+  }
+
+  json doc;
+  ORT_TRY {
+    doc = json::parse(f);
+  }
+  ORT_CATCH(const std::exception& ex) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                           "manifest.json is not valid JSON: ", ex.what());
+  }
+
+  ManifestSchema manifest_schema;
+  ORT_TRY {
+    manifest_schema = doc.get<ManifestSchema>();
+  }
+  ORT_CATCH(const std::exception& ex) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                           "manifest.json has invalid schema: ", ex.what());
+  }
+
+  if (manifest_schema.model_name.empty()) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                           "The \"model_name\" field in the manifest.json is missing or empty");
+  }
+
+  // Locate component models.
+  const bool has_component_models = manifest_schema.component_models.has_value();
+  std::vector<std::string> component_model_names;
+  std::unordered_map<std::string, json> discovered_metadata_docs;
+
+  if (has_component_models) {
+    component_model_names = *manifest_schema.component_models;
+  } else {
+    // Fallback: discover component models under package_root/models where a metadata.json exists.
+    const auto models_dir = package_root / "models";
+    if (!std::filesystem::exists(models_dir) || !std::filesystem::is_directory(models_dir)) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                             "manifest.json missing \"component_models\" and no discoverable models directory at ",
+                             models_dir.string());
+    }
+
+    for (const auto& entry : std::filesystem::directory_iterator(models_dir)) {
+      if (!entry.is_directory()) {
+        continue;
+      }
+
+      const auto component_model_name = entry.path().filename().string();
+      const auto metadata_path = entry.path() / kComponentModelMetadataFileName;
+      if (!std::filesystem::exists(metadata_path)) {
+        continue;  // only folders with metadata.json count as component models
+      }
+
+      std::ifstream mf(metadata_path, std::ios::binary);
+      if (!mf) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                               "Failed to open metadata.json at ", metadata_path.string());
+      }
+
+      json metadata_doc;
+      ORT_TRY {
+        metadata_doc = json::parse(mf);
+      }
+      ORT_CATCH(const std::exception& ex) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                               "metadata.json at ", metadata_path.string(),
+                               " is not valid JSON: ", ex.what());
+      }
+
+      ORT_TRY {
+        (void)metadata_doc.get<MetadataSchema>();
+      }
+      ORT_CATCH(const std::exception& ex) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                               "metadata.json at ", metadata_path.string(),
+                               " has invalid schema: ", ex.what());
+      }
+
+      discovered_metadata_docs.emplace(component_model_name, std::move(metadata_doc));
+      component_model_names.push_back(component_model_name);
+    }
+
+    if (component_model_names.empty()) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                             "manifest.json missing \"component_models\" and no component model folders with metadata.json were found under ",
+                             models_dir.string());
+    }
+  }
+
+  if (component_model_names.size() != 1) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                           "manifest.json should contain exactly one component model name in \"component_models\" array "
+                           "or the models directory should contain exactly one component model.");
+  }
+
+  for (const auto& component_model_name : component_model_names) {
+    const auto component_model_root = package_root / "models" / component_model_name;
+
+    // If component model is listed in manifest.json but corresponding directory is missing, warn and skip.
+    if (has_component_models &&
+        (!std::filesystem::exists(component_model_root) || !std::filesystem::is_directory(component_model_root))) {
+      LOGS(logger_, WARNING) << "Component model '" << component_model_name
+                             << "' is listed in manifest.json but directory does not exist: "
+                             << component_model_root.string()
+                             << ". Skipping this component model.";
+      continue;
+    }
+
+    // Load metadata.json (if present) for this component model.
+    json metadata_doc;
+    const json* metadata_variants_obj = nullptr;
+    const auto metadata_path = component_model_root / kComponentModelMetadataFileName;
+
+    if (!has_component_models) {
+      auto it_meta = discovered_metadata_docs.find(component_model_name);
+      if (it_meta != discovered_metadata_docs.end()) {
+        metadata_doc = it_meta->second;
+        metadata_variants_obj = &metadata_doc[kModelVariantsKey];
+      }
+    } else if (std::filesystem::exists(metadata_path)) {
+      std::ifstream mf(metadata_path, std::ios::binary);
+      if (mf) {
+        ORT_TRY {
+          metadata_doc = json::parse(mf);
+          (void)metadata_doc.get<MetadataSchema>();  // typed schema validation
+          metadata_variants_obj = &metadata_doc[kModelVariantsKey];
+        }
+        ORT_CATCH(const std::exception&) {
+          // Ignore metadata parse/schema errors; fall back to metadata-absent handling below.
+        }
+      }
+    }
+
+    ORT_RETURN_IF_ERROR(ParseVariantsFromComponent(component_model_name,
+                                                   component_model_root,
+                                                   metadata_variants_obj,
+                                                   variants));
+  }
+
+  if (variants.empty()) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                           "No valid component models were found under ", (package_root / "models").string());
+  }
+
+  for (const auto& v : variants) {
+    LOGS(logger_, INFO) << "model variant: file='" << v.model_path.string()
+                        << "' ep='" << v.ep << "' device='" << v.device
+                        << "' arch='" << v.architecture << "'";
+  }
+
+  return Status::OK();
+}
+
+Status ModelPackageDescriptorParser::ParseVariantsFromComponent(
+    const std::string& component_model_name,
+    const std::filesystem::path& component_model_root,
+    const json* metadata_variants_obj,
+    /*in,out*/ std::vector<ModelVariantInfo>& variants) const {
+  if (metadata_variants_obj == nullptr) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                           "Missing metadata model variants for component model: ",
+                           component_model_name);
+  }
+
+  std::unordered_map<std::string, VariantSchema> metadata_variants;
+  ORT_TRY {
+    metadata_variants = metadata_variants_obj->get<std::unordered_map<std::string, VariantSchema>>();
+  }
+  ORT_CATCH(const std::exception& ex) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                           "Invalid metadata variant schema for component model '",
+                           component_model_name, "': ", ex.what());
+  }
+
+  for (const auto& kv : metadata_variants) {
+    const std::string& variant_name = kv.first;
+    const VariantSchema& variant_schema = kv.second;
+
+    ModelVariantInfo variant{};
+    std::filesystem::path model_dir = component_model_root / variant_name;
+
+    if (variant_schema.model_id.has_value() && !variant_schema.model_id->empty()) {
+      model_dir = component_model_root / SanitizeModelIdForPath(*variant_schema.model_id);
+    }
+
+    std::filesystem::path resolved_model_path;
+
+    if (variant_schema.model_file.has_value()) {
+      const std::filesystem::path candidate_path = model_dir / *variant_schema.model_file;
+
+      if (!std::filesystem::exists(candidate_path)) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                               "Variant '", variant_name, "' file path does not exist: ",
+                               candidate_path.string());
+      }
+
+      if (std::filesystem::is_regular_file(candidate_path)) {
+        resolved_model_path = candidate_path;
+      } else if (std::filesystem::is_directory(candidate_path)) {
+        ORT_RETURN_IF_ERROR(FindSingleOnnxFile(candidate_path, resolved_model_path));
+      } else {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                               "Variant '", variant_name,
+                               "' file path is neither a file nor a directory: ",
+                               candidate_path.string());
+      }
+    } else {
+      ORT_RETURN_IF_ERROR(FindSingleOnnxFile(model_dir, resolved_model_path));
+    }
+
+    variant.model_path = std::move(resolved_model_path);
+
+    if (variant_schema.constraints.has_value()) {
+      ApplyVariantConstraints(*variant_schema.constraints, variant);
+    }
+
+    variants.push_back(std::move(variant));
+  }
+
+  return Status::OK();
+}
+
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/core/session/model_package/model_package_descriptor_parser.h
+++ b/onnxruntime/core/session/model_package/model_package_descriptor_parser.h
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include "core/session/model_package/model_package_context.h"
+
+namespace onnxruntime {
+
+//
+// Keys for parsing the model package manifest json and component model metadata json.
+//
+static constexpr const char* kModelPackageManifestFileName = "manifest.json";
+static constexpr const char* kModelNameKey = "model_name";
+static constexpr const char* kModelVersionKey = "model_version";
+static constexpr const char* kComponentModelsKey = "component_models";
+static constexpr const char* kComponentModelMetadataFileName = "metadata.json";
+static constexpr const char* kModelVariantsKey = "model_variants";
+static constexpr const char* kVariantNameKey = "variant_name";
+static constexpr const char* kModelTypeKey = "model_type";
+static constexpr const char* kModelFileKey = "model_file";
+static constexpr const char* kModelIdKey = "model_id";
+static constexpr const char* kConstraintsKey = "constraints";
+static constexpr const char* kEpKey = "ep";
+static constexpr const char* kDeviceKey = "device";
+static constexpr const char* kArchitectureKey = "architecture";
+static constexpr const char* kEpCompatibilityInfoKey = "ep_compatibility_info";
+
+class ModelPackageDescriptorParser {
+ public:
+  explicit ModelPackageDescriptorParser(const logging::Logger& logger) : logger_(logger) {}
+
+  Status ParseVariantsFromRoot(const std::filesystem::path& package_root,
+                               /*out*/ std::vector<ModelVariantInfo>& components) const;
+
+ private:
+  Status ParseVariantsFromComponent(const std::string& component_model_name,
+                                    const std::filesystem::path& component_model_root,
+                                    const json* metadata_variants_obj,
+                                    /*in,out*/ std::vector<ModelVariantInfo>& variants) const;
+
+  const logging::Logger& logger_;
+};
+
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/core/session/plugin_ep/ep_kernel_registration.cc
+++ b/onnxruntime/core/session/plugin_ep/ep_kernel_registration.cc
@@ -126,9 +126,9 @@ class PluginEpOpKernel final : public controlflow::IControlFlowKernel {
     return Status::OK();
   }
 
-  Status UseSharedPrePackedBuffers_V2(std::vector<BufferUniquePtr>& buffer_unique_ptrs,
-                                      gsl::span<const size_t> buffer_sizes,
-                                      int input_idx, /*out*/ bool& used_shared_buffers) override {
+  Status UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& buffer_unique_ptrs,
+                                   gsl::span<const size_t> buffer_sizes,
+                                   int input_idx, /*out*/ bool& used_shared_buffers) override {
     assert(kernel_impl_ != nullptr);  // Should be ensured by PluginEpOpKernel::Create().
 
     if (kernel_impl_->ort_version_supported < 24 || kernel_impl_->SetSharedPrePackedWeight == nullptr) {

--- a/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
+++ b/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
@@ -17,6 +17,7 @@
 #include "core/graph/model_editor_api_types.h"
 #include "core/session/abi_devices.h"
 #include "core/session/abi_ep_types.h"
+#include "core/session/abi_key_value_pairs.h"
 #include "core/session/abi_logger.h"
 #include "core/session/abi_session_options_impl.h"
 #include "core/session/allocator_adapters.h"
@@ -164,12 +165,30 @@ PluginExecutionProvider::PluginExecutionProvider(UniqueOrtEp ep, const OrtSessio
                                                  gsl::span<const OrtEpDevice* const> ep_devices,
                                                  std::shared_ptr<KernelRegistry> kernel_registry,
                                                  const logging::Logger& logger)
-    : IExecutionProvider(ep->GetName(ep.get()), GetOrtDeviceForPluginEp(ep_devices), logger),
+    : IExecutionProvider(ep->GetName(ep.get()), GetOrtDeviceForPluginEp(ep_devices),
+                         std::vector<const OrtEpDevice*>(ep_devices.begin(), ep_devices.end()), logger),
       ort_ep_(std::move(ep)),
       ep_factory_(ep_factory),
       ep_devices_(ep_devices.begin(), ep_devices.end()),
       kernel_registry_(std::move(kernel_registry)) {
   generate_ep_ctx_model_ = session_options.value.GetEpContextGenerationOptions().enable;
+
+  // Extract session-level arena options (ep.<ep_name>.arena.* keys) when the factory
+  // supports allocator creation with options. Only the factory path (not OrtEp::CreateAllocator)
+  // accepts allocator_options, so skip the scan when the factory path won't be used.
+  if (ep_factory_.CreateAllocator && !ort_ep_->CreateAllocator) {
+    const std::string ep_prefix = OrtSessionOptions::GetProviderOptionPrefix(ort_ep_->GetName(ort_ep_.get()));
+    const std::string arena_prefix = ep_prefix + "arena.";
+    for (const auto& [key, value] : session_options.value.config_options.GetConfigOptionsMap()) {
+      if (key.compare(0, arena_prefix.size(), arena_prefix) == 0) {
+        // Build OrtKeyValuePairs on first match; store bare "arena.*" keys.
+        if (!session_arena_options_) {
+          session_arena_options_.emplace();
+        }
+        session_arena_options_->Add(key.substr(ep_prefix.size()).c_str(), value.c_str());
+      }
+    }
+  }
 
   for (const auto* ep_device : ep_devices_) {
     if (ep_device->device_memory_info != nullptr) {
@@ -672,6 +691,8 @@ std::vector<AllocatorPtr> PluginExecutionProvider::CreatePreferredAllocators() {
   std::vector<AllocatorPtr> allocators;
   allocators.reserve(allocator_mem_infos_.size());
 
+  const OrtKeyValuePairs* allocator_options = session_arena_options_ ? &*session_arena_options_ : nullptr;
+
   for (const auto* memory_info : allocator_mem_infos_) {
     OrtAllocator* ort_allocator_ptr = nullptr;
 
@@ -682,7 +703,7 @@ std::vector<AllocatorPtr> PluginExecutionProvider::CreatePreferredAllocators() {
     // prefer OrtEp function if available, otherwise fall back to using the OrtEpFactory implementation.
     OrtStatus* ort_status = ort_ep_->CreateAllocator
                                 ? ort_ep_->CreateAllocator(ort_ep_.get(), memory_info, &ort_allocator_ptr)
-                                : ep_factory_.CreateAllocator(&ep_factory_, memory_info, /*options*/ nullptr,
+                                : ep_factory_.CreateAllocator(&ep_factory_, memory_info, allocator_options,
                                                               &ort_allocator_ptr);
 
     // throw or log? start with throw
@@ -702,7 +723,17 @@ std::vector<AllocatorPtr> PluginExecutionProvider::CreatePreferredAllocators() {
         [this](OrtAllocator* allocator) {
           ep_factory_.ReleaseAllocator(&ep_factory_, allocator);
         });
-    allocators.push_back(std::make_shared<IAllocatorImplWrappingOrtAllocator>(std::move(ort_allocator)));
+
+    // Use the arena wrapper when the allocator supports Shrink(), matching
+    // the logic in Environment::CreateSharedAllocatorImpl. This ensures
+    // per-session plugin arenas are visible to ShrinkMemoryArenas.
+    AllocatorPtr alloc_ptr;
+    if (ort_allocator->version >= 25 && ort_allocator->Shrink != nullptr) {
+      alloc_ptr = std::make_shared<IArenaImplWrappingOrtAllocator>(std::move(ort_allocator));
+    } else {
+      alloc_ptr = std::make_shared<IAllocatorImplWrappingOrtAllocator>(std::move(ort_allocator));
+    }
+    allocators.push_back(std::move(alloc_ptr));
   }
 
   return allocators;

--- a/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.h
+++ b/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.h
@@ -5,6 +5,7 @@
 
 #include <gsl/gsl>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -14,6 +15,7 @@
 #include "core/framework/execution_provider.h"
 #include "core/framework/model_metadef_id_generator.h"
 #include "core/providers/providers.h"
+#include "core/session/abi_key_value_pairs.h"
 #include "core/session/onnxruntime_c_api.h"
 
 namespace onnxruntime {
@@ -158,6 +160,10 @@ class PluginExecutionProvider : public IExecutionProvider {
   std::vector<const OrtEpDevice*> ep_devices_;
   std::vector<const OrtMemoryInfo*> allocator_mem_infos_;
   bool generate_ep_ctx_model_ = false;
+
+  // Arena options extracted from session-level config (ep.<ep_name>.arena.* keys).
+  // Built once at construction; passed directly to ep_factory_.CreateAllocator.
+  std::optional<OrtKeyValuePairs> session_arena_options_;
 
   std::vector<OrtNodeComputeInfo*> api_node_compute_infos_;
 

--- a/onnxruntime/core/session/provider_policy_context.cc
+++ b/onnxruntime/core/session/provider_policy_context.cc
@@ -51,10 +51,35 @@ bool IsDefaultCpuEp(const OrtEpDevice* d) {
          d->ep_vendor == "Microsoft";
 }
 
+OrtKeyValuePairs GetModelMetadata(const InferenceSession& session) {
+  OrtKeyValuePairs metadata;
+  auto status_and_metadata = session.GetModelMetadata();
+
+  if (!status_and_metadata.first.IsOK()) {
+    return metadata;
+  }
+
+  // use field names from onnx.proto
+  const auto& model_metadata = *status_and_metadata.second;
+  metadata.Add("producer_name", model_metadata.producer_name);
+  metadata.Add("producer_version", model_metadata.producer_version);
+  metadata.Add("domain", model_metadata.domain);
+  metadata.Add("model_version", std::to_string(model_metadata.version));
+  metadata.Add("doc_string", model_metadata.description);
+  metadata.Add("graph_name", model_metadata.graph_name);                // name from main GraphProto
+  metadata.Add("graph_description", model_metadata.graph_description);  // descriptions from main GraphProto
+  for (const auto& entry : model_metadata.custom_metadata_map) {
+    metadata.Add(entry.first, entry.second);
+  }
+
+  return metadata;
+}
+}  // namespace
+
 // Sort devices. NPU -> GPU -> CPU
 // Within in type, vendor owned, not.
 // Default CPU EP is last
-std::vector<const OrtEpDevice*> OrderDevices(const std::vector<const OrtEpDevice*>& devices) {
+std::vector<const OrtEpDevice*> ProviderPolicyContext::OrderDevices(const std::vector<const OrtEpDevice*>& devices) {
   std::vector<const OrtEpDevice*> sorted_devices(devices.begin(), devices.end());
   std::sort(sorted_devices.begin(), sorted_devices.end(), [](const OrtEpDevice* a, const OrtEpDevice* b) {
     auto aDeviceType = a->device->type;
@@ -115,45 +140,12 @@ std::vector<const OrtEpDevice*> OrderDevices(const std::vector<const OrtEpDevice
   return sorted_devices;
 }
 
-OrtKeyValuePairs GetModelMetadata(const InferenceSession& session) {
-  OrtKeyValuePairs metadata;
-  auto status_and_metadata = session.GetModelMetadata();
-
-  if (!status_and_metadata.first.IsOK()) {
-    return metadata;
-  }
-
-  // use field names from onnx.proto
-  const auto& model_metadata = *status_and_metadata.second;
-  metadata.Add("producer_name", model_metadata.producer_name);
-  metadata.Add("producer_version", model_metadata.producer_version);
-  metadata.Add("domain", model_metadata.domain);
-  metadata.Add("model_version", std::to_string(model_metadata.version));
-  metadata.Add("doc_string", model_metadata.description);
-  metadata.Add("graph_name", model_metadata.graph_name);                // name from main GraphProto
-  metadata.Add("graph_description", model_metadata.graph_description);  // descriptions from main GraphProto
-  for (const auto& entry : model_metadata.custom_metadata_map) {
-    metadata.Add(entry.first, entry.second);
-  }
-
-  return metadata;
-}
-}  // namespace
-
-// Select execution providers based on the device policy and available devices and add to session
-Status ProviderPolicyContext::SelectEpsForSession(const Environment& env, const OrtSessionOptions& options,
-                                                  InferenceSession& sess) {
-  // Get the list of devices from the environment and order them.
-  // Ordered by preference within each type. NPU -> GPU -> NPU
-  // TODO: Should environment.cc do the ordering?
-  std::vector<const OrtEpDevice*> execution_devices = OrderDevices(env.GetOrtEpDevices());
-
-  // The list of devices selected by policies
-  std::vector<const OrtEpDevice*> devices_selected;
-
+Status ProviderPolicyContext::SelectEpDevices(std::vector<const OrtEpDevice*>& execution_devices,
+                                              const OrtSessionOptions& options,
+                                              OrtKeyValuePairs& model_metadata,
+                                              std::vector<const OrtEpDevice*>& devices_selected) {
   // Run the delegate if it was passed in lieu of any other policy
   if (options.value.ep_selection_policy.delegate) {
-    auto model_metadata = GetModelMetadata(sess);
     OrtKeyValuePairs runtime_metadata;  // TODO: where should this come from?
 
     std::vector<const OrtEpDevice*> delegate_devices(execution_devices.begin(), execution_devices.end());
@@ -222,67 +214,171 @@ Status ProviderPolicyContext::SelectEpsForSession(const Environment& env, const 
                            "No execution providers selected. Please check the device policy and available devices.");
   }
 
-  // Log telemetry for auto EP selection
-  {
-    std::vector<std::string> requested_ep_ids;
-    requested_ep_ids.reserve(devices_selected.size());
+  return Status::OK();
+}
 
-    for (const auto* device : devices_selected) {
-      if (device != nullptr) {
-        requested_ep_ids.push_back(device->ep_name);
-      }
+Status ProviderPolicyContext::LogTelemetry(InferenceSession& sess,
+                                           const OrtSessionOptions& options,
+                                           const std::vector<const OrtEpDevice*>& execution_devices,
+                                           const std::vector<const OrtEpDevice*>& devices_selected) {
+  std::vector<std::string> requested_ep_ids;
+  requested_ep_ids.reserve(devices_selected.size());
+
+  for (const auto* device : devices_selected) {
+    if (device != nullptr) {
+      requested_ep_ids.push_back(device->ep_name);
     }
-
-    // Extract available execution provider IDs
-    std::vector<std::string> available_ep_ids;
-    available_ep_ids.reserve(execution_devices.size());
-    for (const auto* device : execution_devices) {
-      available_ep_ids.push_back(device->ep_name);
-    }
-
-    std::string policy_type;
-    if (options.value.ep_selection_policy.delegate) {
-      policy_type = "custom_delegate";
-    } else {
-      switch (options.value.ep_selection_policy.policy) {
-        case OrtExecutionProviderDevicePolicy_DEFAULT:
-          policy_type = "DEFAULT";
-          break;
-        case OrtExecutionProviderDevicePolicy_PREFER_CPU:
-          policy_type = "PREFER_CPU";
-          break;
-        case OrtExecutionProviderDevicePolicy_PREFER_NPU:
-          policy_type = "PREFER_NPU";
-          break;
-        case OrtExecutionProviderDevicePolicy_PREFER_GPU:
-          policy_type = "PREFER_GPU";
-          break;
-        case OrtExecutionProviderDevicePolicy_MAX_PERFORMANCE:
-          policy_type = "MAX_PERFORMANCE";
-          break;
-        case OrtExecutionProviderDevicePolicy_MAX_EFFICIENCY:
-          policy_type = "MAX_EFFICIENCY";
-          break;
-        case OrtExecutionProviderDevicePolicy_MIN_OVERALL_POWER:
-          policy_type = "MIN_OVERALL_POWER";
-          break;
-        default:
-          policy_type = "UNKNOWN";
-          break;
-      }
-    }
-
-    const Env& os_env = Env::Default();
-    os_env.GetTelemetryProvider().LogAutoEpSelection(
-        sess.GetCurrentSessionId(),
-        policy_type,
-        requested_ep_ids,
-        available_ep_ids);
   }
+
+  // Extract available execution provider IDs
+  std::vector<std::string> available_ep_ids;
+  available_ep_ids.reserve(execution_devices.size());
+  for (const auto* device : execution_devices) {
+    available_ep_ids.push_back(device->ep_name);
+  }
+
+  std::string policy_type;
+  if (options.value.ep_selection_policy.delegate) {
+    policy_type = "custom_delegate";
+  } else {
+    switch (options.value.ep_selection_policy.policy) {
+      case OrtExecutionProviderDevicePolicy_DEFAULT:
+        policy_type = "DEFAULT";
+        break;
+      case OrtExecutionProviderDevicePolicy_PREFER_CPU:
+        policy_type = "PREFER_CPU";
+        break;
+      case OrtExecutionProviderDevicePolicy_PREFER_NPU:
+        policy_type = "PREFER_NPU";
+        break;
+      case OrtExecutionProviderDevicePolicy_PREFER_GPU:
+        policy_type = "PREFER_GPU";
+        break;
+      case OrtExecutionProviderDevicePolicy_MAX_PERFORMANCE:
+        policy_type = "MAX_PERFORMANCE";
+        break;
+      case OrtExecutionProviderDevicePolicy_MAX_EFFICIENCY:
+        policy_type = "MAX_EFFICIENCY";
+        break;
+      case OrtExecutionProviderDevicePolicy_MIN_OVERALL_POWER:
+        policy_type = "MIN_OVERALL_POWER";
+        break;
+      default:
+        policy_type = "UNKNOWN";
+        break;
+    }
+  }
+
+  const Env& os_env = Env::Default();
+  os_env.GetTelemetryProvider().LogAutoEpSelection(
+      sess.GetCurrentSessionId(),
+      policy_type,
+      requested_ep_ids,
+      available_ep_ids);
+
+  return Status::OK();
+}
+
+Status ProviderPolicyContext::CreateExecutionProviders(const Environment& env, InferenceSession& sess,
+                                                       std::vector<const OrtEpDevice*>& devices_selected,
+                                                       std::vector<std::unique_ptr<IExecutionProvider>>& providers) {
+  // Create OrtSessionOptions for the CreateEp call.
+  // Once the InferenceSession is created, its SessionOptions is the source of truth and contains all the values from
+  // the user provided OrtSessionOptions. We do a copy for simplicity. The OrtSessionOptions instance goes away
+  // once we exit this function so an EP implementation should not use OrtSessionOptions after it returns from
+  // CreateEp.
+  auto& session_options = sess.GetMutableSessionOptions();
+  OrtSessionOptions ort_so;
+  ort_so.value = session_options;
+  const auto& session_logger = sess.GetLogger();
+  const OrtLogger& api_session_logger = *session_logger->ToExternal();
+
+  // Remove the ORT CPU EP if configured to do so
+  bool disable_ort_cpu_ep = ort_so.value.config_options.GetConfigEntry(kOrtSessionOptionsDisableCPUEPFallback) == "1";
+  if (disable_ort_cpu_ep) {
+    RemoveOrtCpuDevice(devices_selected);
+  }
+
+  // Fold the EPs into a single structure per factory
+  std::vector<SelectionInfo> eps_selected;
+  FoldSelectedDevices(devices_selected, eps_selected);
+
+  // Iterate through the selected EPs and create them
+  for (size_t idx = 0; idx < eps_selected.size(); ++idx) {
+    std::unique_ptr<IExecutionProvider> ep = nullptr;
+    ORT_RETURN_IF_ERROR(CreateExecutionProvider(env, ort_so, api_session_logger, eps_selected[idx], ep));
+    if (ep != nullptr) {
+      providers.push_back(std::move(ep));
+    }
+  }
+
+  return Status::OK();
+}
+
+Status ProviderPolicyContext::SelectEpsForModelPackage(const Environment& env,
+                                                       OrtSessionOptions& options,
+                                                       OrtKeyValuePairs& model_metadata,
+                                                       std::vector<const OrtEpDevice*>& execution_devices,
+                                                       std::vector<const OrtEpDevice*>& devices_selected,
+                                                       std::vector<std::unique_ptr<IExecutionProvider>>& providers) {
+  // Get the list of devices from the environment and order them.
+  // Ordered by preference within each type. NPU -> GPU -> NPU
+  // TODO: Should environment.cc do the ordering?
+  execution_devices = OrderDevices(env.GetOrtEpDevices());
+
+  ORT_RETURN_IF_ERROR(SelectEpDevices(execution_devices, options, model_metadata, devices_selected));
 
   // Configure the session options for the devices. This updates the SessionOptions in the InferenceSession with any
   // EP options that have not been overridden by the user.
-  ORT_RETURN_IF_ERROR(AddEpDefaultOptionsToSession(sess, devices_selected));
+  ORT_RETURN_IF_ERROR(AddEpDefaultOptionsToSession(options.value, devices_selected));
+
+  // Remove the ORT CPU EP if configured to do so
+  bool disable_ort_cpu_ep = options.value.config_options.GetConfigEntry(kOrtSessionOptionsDisableCPUEPFallback) == "1";
+  if (disable_ort_cpu_ep) {
+    RemoveOrtCpuDevice(devices_selected);
+  }
+
+  // Fold the EPs into a single structure per factory
+  std::vector<SelectionInfo> eps_selected;
+  FoldSelectedDevices(devices_selected, eps_selected);
+
+  OrtSessionOptions ort_so = options;
+
+  // Iterate through the selected EPs and create them
+  for (size_t idx = 0; idx < eps_selected.size(); ++idx) {
+    std::unique_ptr<IExecutionProvider> ep = nullptr;
+    ORT_RETURN_IF_ERROR(CreateExecutionProvider(env,
+                                                ort_so,
+                                                *logging::LoggingManager::DefaultLogger().ToExternal(),
+                                                eps_selected[idx], ep));
+    if (ep != nullptr) {
+      providers.push_back(std::move(ep));
+    }
+  }
+
+  return Status::OK();
+}
+
+// Select execution providers based on the device policy and available devices and add to session
+Status ProviderPolicyContext::SelectEpsForSession(const Environment& env, const OrtSessionOptions& options,
+                                                  InferenceSession& sess) {
+  // Get the list of devices from the environment and order them.
+  // Ordered by preference within each type. NPU -> GPU -> NPU
+  // TODO: Should environment.cc do the ordering?
+  std::vector<const OrtEpDevice*> execution_devices = OrderDevices(env.GetOrtEpDevices());
+
+  // The list of devices selected by policies
+  std::vector<const OrtEpDevice*> devices_selected;
+
+  auto model_metadata = GetModelMetadata(sess);
+  ORT_RETURN_IF_ERROR(SelectEpDevices(execution_devices, options, model_metadata, devices_selected));
+
+  // Log telemetry for auto EP selection
+  ORT_RETURN_IF_ERROR(LogTelemetry(sess, options, execution_devices, devices_selected));
+
+  // Configure the session options for the devices. This updates the SessionOptions in the InferenceSession with any
+  // EP options that have not been overridden by the user.
+  ORT_RETURN_IF_ERROR(AddEpDefaultOptionsToSession(sess.GetMutableSessionOptions(), devices_selected));
 
   // Create OrtSessionOptions for the CreateEp call.
   // Once the InferenceSession is created, its SessionOptions is the source of truth and contains all the values from
@@ -369,9 +465,9 @@ Status ProviderPolicyContext::CreateExecutionProvider(const Environment& env, Or
   return Status::OK();
 }
 
-Status ProviderPolicyContext::AddEpDefaultOptionsToSession(InferenceSession& sess,
+Status ProviderPolicyContext::AddEpDefaultOptionsToSession(SessionOptions& sess_options,
                                                            std::vector<const OrtEpDevice*> devices) {
-  auto& config_options = sess.GetMutableSessionOptions().config_options;
+  auto& config_options = sess_options.config_options;
   for (auto device : devices) {
     const std::string ep_options_prefix = OrtSessionOptions::GetProviderOptionPrefix(device->ep_name.c_str());
     for (const auto& [key, value] : device->ep_options.Entries()) {

--- a/onnxruntime/core/session/provider_policy_context.h
+++ b/onnxruntime/core/session/provider_policy_context.h
@@ -40,13 +40,32 @@ class ProviderPolicyContext {
  public:
   ProviderPolicyContext() = default;
 
+  Status SelectEpDevices(std::vector<const OrtEpDevice*>& execution_devices, const OrtSessionOptions& options,
+                         OrtKeyValuePairs& model_metadata, std::vector<const OrtEpDevice*>& devices_selected);
   Status SelectEpsForSession(const Environment& env, const OrtSessionOptions& options, InferenceSession& sess);
-  Status AddEpDefaultOptionsToSession(InferenceSession& sess, std::vector<const OrtEpDevice*> devices);
+  Status SelectEpsForModelPackage(const Environment& env,
+                                  OrtSessionOptions& options,
+                                  OrtKeyValuePairs& model_metadata,
+                                  std::vector<const OrtEpDevice*>& execution_devices,
+                                  std::vector<const OrtEpDevice*>& devices_selected,
+                                  std::vector<std::unique_ptr<IExecutionProvider>>& providers);
+  Status AddEpDefaultOptionsToSession(SessionOptions& sess_options, std::vector<const OrtEpDevice*> devices);
   void RemoveOrtCpuDevice(std::vector<const OrtEpDevice*>& devices);
   Status CreateExecutionProvider(const Environment& env, OrtSessionOptions& options, const OrtLogger& logger,
                                  SelectionInfo& info, std::unique_ptr<IExecutionProvider>& ep);
   void FoldSelectedDevices(std::vector<const OrtEpDevice*> devices_selected,  // copy
                            std::vector<SelectionInfo>& eps_selected);
+
+  std::vector<const OrtEpDevice*> OrderDevices(const std::vector<const OrtEpDevice*>& devices);
+
+  Status LogTelemetry(InferenceSession& sess,
+                      const OrtSessionOptions& options,
+                      const std::vector<const OrtEpDevice*>& execution_devices,
+                      const std::vector<const OrtEpDevice*>& devices_selected);
+
+  Status CreateExecutionProviders(const Environment& env, InferenceSession& sess,
+                                  std::vector<const OrtEpDevice*>& devices_selected,
+                                  std::vector<std::unique_ptr<IExecutionProvider>>& providers);
 
  private:
 };

--- a/onnxruntime/core/session/utils.cc
+++ b/onnxruntime/core/session/utils.cc
@@ -5,6 +5,10 @@
 
 #include <memory>
 #include <utility>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
 
 #include "core/framework/error_code_helper.h"
 #include "core/framework/execution_provider.h"
@@ -20,6 +24,7 @@
 #include "core/session/ort_apis.h"
 #include "core/session/ort_env.h"
 #include "core/session/onnxruntime_ep_device_ep_metadata_keys.h"
+#include "core/session/model_package/model_package_context.h"
 
 #if !defined(ORT_MINIMAL_BUILD)
 #include "core/graph/model_editor_api_types.h"
@@ -96,6 +101,115 @@ Status TestAutoSelectEPsImpl(const Environment& env, InferenceSession& sess, con
     // once we have the EP and one device that's enough for test purposes.
     break;
   }
+
+  return Status::OK();
+}
+
+Status PrintAvailableAndSelectedEpInfos(const Environment& env, std::vector<VariantSelectionEpInfo>& ep_infos) {
+  const auto& execution_devices = env.GetOrtEpDevices();
+
+  std::string available_eps_info = "Available EPs and devices:\n";
+  if (execution_devices.empty()) {
+    available_eps_info += "  (none)\n";
+  } else {
+    for (const auto* ep_device : execution_devices) {
+      if (ep_device == nullptr) {
+        continue;
+      }
+
+      available_eps_info += "  " + ep_device->ToString() + "\n";
+    }
+  }
+
+  std::string selected_eps_info = "Selected EPs:\n";
+  if (ep_infos.empty()) {
+    selected_eps_info += "  (none)\n";
+  } else {
+    for (const auto& ep_info : ep_infos) {
+      selected_eps_info += "  EP: " + ep_info.ep_name + "\n";
+      const auto& selected_ep_devices = ep_info.ep_devices;
+      for (const auto* selected_ep_device : selected_ep_devices) {
+        if (selected_ep_device == nullptr) {
+          continue;
+        }
+        selected_eps_info += "    " + selected_ep_device->ToString() + "\n";
+      }
+    }
+  }
+
+  LOGS_DEFAULT(INFO) << available_eps_info;
+  LOGS_DEFAULT(INFO) << selected_eps_info;
+  return Status::OK();
+}
+
+// Gets EP info needed for model package workflow to select suitable model.
+//
+// For simplicity, there are some constraints in this initial implementation:
+// - Only one EP is supported, skip ORT CPU EP.
+// - All devices should be supported by the same EP
+//
+Status GetVariantSelectionEpInfo(const OrtSessionOptions* session_options,
+                                 std::vector<std::unique_ptr<IExecutionProvider>>& provider_list,
+                                 std::vector<VariantSelectionEpInfo>& ep_infos) {
+  if (provider_list.empty()) {
+    return Status::OK();
+  }
+
+  // Pick the first non-CPU provider if available; otherwise fall back to the first provider.
+  size_t selected_idx = 0;
+  for (size_t i = 0; i < provider_list.size(); ++i) {
+    const auto& provider = provider_list[i];
+    if (provider && provider->Type() != onnxruntime::kCpuExecutionProvider) {
+      selected_idx = i;
+      break;
+    }
+  }
+
+  auto& provider = provider_list[selected_idx];
+
+  if (provider && provider->Type() == onnxruntime::kCpuExecutionProvider) {
+    return Status::OK();
+  }
+
+  ep_infos.push_back(VariantSelectionEpInfo{});
+  auto& ep_info = ep_infos.back();
+
+  // Add ep name to ep_info
+  ep_info.ep_name = provider->Type();
+  ORT_ENFORCE(!ep_info.ep_name.empty(), "EP name should have been set at this point.");
+
+  // Add ep devices to ep_info
+  auto& ep_devices = provider->GetEpDevices();
+  ep_info.ep_devices = ep_devices;
+
+  // Add ep factory to ep_info
+  ep_info.ep_factory = ep_devices.empty() ? nullptr : ep_devices.front()->ep_factory;
+
+  // Add hardware devices to ep_info
+  ep_info.hardware_devices.reserve(ep_devices.size());
+  for (const auto& ep_device : ep_devices) {
+    if (ep_device->device != nullptr) {
+      ep_info.hardware_devices.push_back(ep_device->device);
+    }
+  }
+
+  // Add ep metadata to ep_info
+  ep_info.ep_metadata.reserve(ep_devices.size());
+  for (const auto& ep_device : ep_devices) {
+    ep_info.ep_metadata.push_back(&ep_device->ep_metadata);
+  }
+
+  // Add ep provider options to ep_info
+  ProviderOptions provider_options;
+  const std::string ep_options_prefix = OrtSessionOptions::GetProviderOptionPrefix(ep_info.ep_name.c_str());
+  const auto& configs = session_options->value.config_options.configurations;
+
+  for (const auto& kv : configs) {
+    if (kv.first.rfind(ep_options_prefix, 0) == 0) {                                   // starts with prefix
+      provider_options.emplace(kv.first.substr(ep_options_prefix.size()), kv.second);  // strip prefix
+    }
+  }
+  ep_info.ep_options = std::move(provider_options);
 
   return Status::OK();
 }
@@ -179,14 +293,55 @@ common::Status CopyStringToOutputArg(std::string_view str, const char* err_msg, 
   return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, err_msg);
 }
 
-// Internal function that creates an InferenceSession and loads the model.
-// Caller should provide either model_path, or modal_data + model_data_length.
-static OrtStatus* CreateSessionAndLoadModelImpl(_In_ const OrtSessionOptions* options,
-                                                const onnxruntime::Environment& env,
-                                                _In_opt_z_ const ORTCHAR_T* model_path,
-                                                _In_opt_ const void* model_data,
-                                                size_t model_data_length,
-                                                std::unique_ptr<onnxruntime::InferenceSession>& sess) {
+static Status CreateAndRegisterExecutionProviders(_In_ const OrtSessionOptions* options,
+                                                  _In_ onnxruntime::InferenceSession& sess) {
+  const logging::Logger* session_logger = sess.GetLogger();
+  ORT_ENFORCE(session_logger != nullptr,
+              "Session logger is invalid, but should have been initialized during session construction.");
+
+  const bool has_provider_factories = options != nullptr && !options->provider_factories.empty();
+
+  if (has_provider_factories) {
+    std::vector<std::unique_ptr<IExecutionProvider>> provider_list;
+    for (auto& factory : options->provider_factories) {
+      auto provider = factory->CreateProvider(*options, *session_logger->ToExternal());
+      provider_list.push_back(std::move(provider));
+    }
+    // register the providers
+    for (auto& provider : provider_list) {
+      if (provider) {
+        ORT_RETURN_IF_ERROR(sess.RegisterExecutionProvider(std::move(provider)));
+      }
+    }
+  }
+#if !defined(ORT_MINIMAL_BUILD)
+  else {
+    // TEMPORARY for testing. Manually specify the EP to select.
+    auto auto_select_ep_name = sess.GetSessionOptions().config_options.GetConfigEntry("test.ep_to_select");
+    if (auto_select_ep_name) {
+      ORT_RETURN_IF_ERROR(TestAutoSelectEPsImpl(sess.GetEnvironment(), sess, *auto_select_ep_name));
+    }
+
+    // if there are no providers registered, and there's an ep selection policy set, do auto ep selection.
+    // note: the model has already been loaded so model metadata should be available to the policy delegate callback.
+    if (options != nullptr && options->value.ep_selection_policy.enable) {
+      ProviderPolicyContext context;
+      ORT_RETURN_IF_ERROR(context.SelectEpsForSession(sess.GetEnvironment(), *options, sess));
+    }
+  }
+#endif  // !defined(ORT_MINIMAL_BUILD)
+
+  return Status::OK();
+}
+
+// Internal function that creates an InferenceSession and loads a single model.
+// Caller should provide either model_path, or model_data + model_data_length.
+static OrtStatus* CreateSessionAndLoadSingleModelImpl(_In_ const OrtSessionOptions* options,
+                                                      const onnxruntime::Environment& env,
+                                                      _In_opt_z_ const ORTCHAR_T* model_path,
+                                                      _In_opt_ const void* model_data,
+                                                      size_t model_data_length,
+                                                      std::unique_ptr<onnxruntime::InferenceSession>& sess) {
   // quick check here to decide load path. InferenceSession will provide error message for invalid values.
   // TODO: Could move to a helper
   const Env& os_env = Env::Default();  // OS environment (!= ORT environment)
@@ -287,6 +442,111 @@ static OrtStatus* CreateSessionAndLoadModelImpl(_In_ const OrtSessionOptions* op
   }
 
   return nullptr;
+}
+
+// Internal function that creates an InferenceSession and loads the model.
+// Caller should provide either a model file path, model_data + model_data_length, or a model package directory.
+static OrtStatus* CreateSessionAndLoadModelImpl(_In_ const OrtSessionOptions* options,
+                                                const onnxruntime::Environment& env,
+                                                _In_opt_z_ const ORTCHAR_T* model_path,
+                                                _In_opt_ const void* model_data,
+                                                size_t model_data_length,
+                                                std::unique_ptr<onnxruntime::InferenceSession>& sess) {
+  // `model_path` could be a single ONNX file path, an ORT format model path, or a model package directory.
+  const ORTCHAR_T* model_path_to_use = model_path;
+
+  // keep storage alive if ORT selects a model variant.
+  std::filesystem::path selected_model_path;
+
+  if (model_path_to_use != nullptr) {
+    std::error_code ec;
+    std::filesystem::path package_root{model_path_to_use};
+
+    if (std::filesystem::is_directory(package_root, ec) &&
+        !ec) {
+#if !defined(ORT_MINIMAL_BUILD)
+      OrtSessionOptions* options_to_use = nullptr;
+      OrtSessionOptions ort_sess_options = options ? *options : OrtSessionOptions();
+      if (options) {
+        options_to_use = &ort_sess_options;
+      }
+
+      std::vector<std::unique_ptr<IExecutionProvider>> provider_list;
+      const bool has_provider_factories = options_to_use != nullptr && !options_to_use->provider_factories.empty();
+      ProviderPolicyContext provider_policy_context;
+      std::vector<const OrtEpDevice*> execution_devices;
+      std::vector<const OrtEpDevice*> devices_selected;
+
+      // Create the IExecutionProvider instances to gather EP name and EP devices.
+      if (has_provider_factories) {
+        for (auto& factory : options_to_use->provider_factories) {
+          auto provider = factory->CreateProvider(*options_to_use, *logging::LoggingManager::DefaultLogger().ToExternal());
+          provider_list.push_back(std::move(provider));
+        }
+      } else if (options_to_use != nullptr && options_to_use->value.ep_selection_policy.enable) {
+        // No model loaded yet, so no model metadata. Pass empty metadata for now.
+        // TODO: Pass metadata from manifest json to delegate policy?
+        OrtKeyValuePairs model_metadata;
+        auto status = provider_policy_context.SelectEpsForModelPackage(env, *options_to_use, model_metadata,
+                                                                       execution_devices, devices_selected,
+                                                                       provider_list);
+        ORT_API_RETURN_IF_STATUS_NOT_OK(status);
+      }
+
+      // Build EP info from finalized providers.
+      std::vector<VariantSelectionEpInfo> ep_infos;
+      ORT_API_RETURN_IF_STATUS_NOT_OK(GetVariantSelectionEpInfo(options_to_use, provider_list, ep_infos));
+
+      ORT_API_RETURN_IF_STATUS_NOT_OK(PrintAvailableAndSelectedEpInfos(env, ep_infos));
+
+      if (ep_infos.empty()) {
+        return OrtApis::CreateStatus(ORT_FAIL,
+                                     "No execution providers were provided or selected. "
+                                     "Check the EP selection policy or explicitly specify EPs.");
+      }
+
+      // Select the most suitable model variant based on EP info and model constraints.
+      ModelPackageContext model_package_context(package_root);
+      ModelVariantSelector model_variant_selector;
+      std::optional<std::filesystem::path> selected_model_variant_path;
+
+      ORT_API_RETURN_IF_STATUS_NOT_OK(model_variant_selector.SelectVariant(model_package_context, ep_infos, selected_model_variant_path));
+
+      if (selected_model_variant_path.has_value()) {
+        selected_model_path = *selected_model_variant_path;
+        model_path_to_use = selected_model_path.c_str();
+      } else {
+        return OrtApis::CreateStatus(ORT_FAIL,
+                                     "No suitable model variant found for the available execution providers."
+                                     "Try specifying the model file path instead of a model package, or check the "
+                                     "model variants' constraints in the manifest json or metadata json.");
+      }
+
+      ORT_API_RETURN_IF_ERROR(CreateSessionAndLoadSingleModelImpl(options_to_use, env, model_path_to_use,
+                                                                  model_data, model_data_length, sess));
+
+      // Register execution providers
+      for (auto& provider : provider_list) {
+        if (provider) {
+          ORT_API_RETURN_IF_STATUS_NOT_OK(sess->RegisterExecutionProvider(std::move(provider)));
+        }
+      }
+
+      // Log telemetry for auto EP selection
+      if (!has_provider_factories &&
+          options_to_use != nullptr &&
+          options_to_use->value.ep_selection_policy.enable) {
+        ORT_API_RETURN_IF_STATUS_NOT_OK(provider_policy_context.LogTelemetry(*sess, *options_to_use,
+                                                                             execution_devices, devices_selected));
+      }
+#else
+      return OrtApis::CreateStatus(ORT_FAIL, "Model package is not supported in this build.");
+#endif
+      return nullptr;
+    }
+  }
+
+  return CreateSessionAndLoadSingleModelImpl(options, env, model_path, model_data, model_data_length, sess);
 }
 
 #if !defined(ORT_MINIMAL_BUILD)
@@ -500,42 +760,9 @@ static Status ValidateCompiledModelCompatibility(InferenceSession& sess) {
 OrtStatus* InitializeSession(_In_ const OrtSessionOptions* options,
                              _In_ onnxruntime::InferenceSession& sess,
                              _Inout_opt_ OrtPrepackedWeightsContainer* prepacked_weights_container) {
-  const logging::Logger* session_logger = sess.GetLogger();
-  ORT_ENFORCE(session_logger != nullptr,
-              "Session logger is invalid, but should have been initialized during session construction.");
-
-  const bool has_provider_factories = options != nullptr && !options->provider_factories.empty();
-
-  if (has_provider_factories) {
-    std::vector<std::unique_ptr<IExecutionProvider>> provider_list;
-    for (auto& factory : options->provider_factories) {
-      auto provider = factory->CreateProvider(*options, *session_logger->ToExternal());
-      provider_list.push_back(std::move(provider));
-    }
-
-    // register the providers
-    for (auto& provider : provider_list) {
-      if (provider) {
-        ORT_API_RETURN_IF_STATUS_NOT_OK(sess.RegisterExecutionProvider(std::move(provider)));
-      }
-    }
+  if (sess.GetRegisteredProviderTypes().empty()) {
+    ORT_API_RETURN_IF_STATUS_NOT_OK(CreateAndRegisterExecutionProviders(options, sess));
   }
-#if !defined(ORT_MINIMAL_BUILD)
-  else {
-    // TEMPORARY for testing. Manually specify the EP to select.
-    auto auto_select_ep_name = sess.GetSessionOptions().config_options.GetConfigEntry("test.ep_to_select");
-    if (auto_select_ep_name) {
-      ORT_API_RETURN_IF_STATUS_NOT_OK(TestAutoSelectEPsImpl(sess.GetEnvironment(), sess, *auto_select_ep_name));
-    }
-
-    // if there are no providers registered, and there's an ep selection policy set, do auto ep selection.
-    // note: the model has already been loaded so model metadata should be available to the policy delegate callback.
-    if (options != nullptr && options->value.ep_selection_policy.enable) {
-      ProviderPolicyContext context;
-      ORT_API_RETURN_IF_STATUS_NOT_OK(context.SelectEpsForSession(sess.GetEnvironment(), *options, sess));
-    }
-  }
-#endif  // !defined(ORT_MINIMAL_BUILD)
 
   if (prepacked_weights_container != nullptr) {
     ORT_API_RETURN_IF_STATUS_NOT_OK(sess.AddPrePackedWeightsContainer(

--- a/onnxruntime/test/autoep/library/example_plugin_ep/ep.cc
+++ b/onnxruntime/test/autoep/library/example_plugin_ep/ep.cc
@@ -701,11 +701,12 @@ const char* ORT_API_CALL ExampleEp::GetCompiledModelCompatibilityInfoImpl(OrtEp*
   // - EP name
   // - EP version (from factory)
   // - ORT API version
+  // - Hardware Architecture (It's used for model package test)
   //
   // In a real EP, this might include driver versions, hardware IDs, etc.
   // The string format is EP-defined and should be parseable by ValidateCompiledModelCompatibilityInfo.
   ep->compatibility_info_ = ep->name_ + ";version=" + ep->factory_.GetEpVersionString() + ";ort_api_version=" +
-                            std::to_string(ORT_API_VERSION);
+                            std::to_string(ORT_API_VERSION) + ";hardware_architecture=arch1";
 
   IGNORE_ORTSTATUS(ep->ort_api.Logger_LogMessage(&ep->logger_,
                                                  OrtLoggingLevel::ORT_LOGGING_LEVEL_INFO,

--- a/onnxruntime/test/autoep/library/example_plugin_ep/ep_allocator.h
+++ b/onnxruntime/test/autoep/library/example_plugin_ep/ep_allocator.h
@@ -71,6 +71,7 @@ struct CustomAllocator : BaseAllocator {
     Reserve = AllocImpl;      // no special reserve logic and most likely unnecessary unless you have your own arena
     GetStats = GetStatsImpl;  // this can be set to nullptr if you don't want to implement it
     AllocOnStream = nullptr;
+    Shrink = nullptr;
   }
 
   static void* ORT_API_CALL AllocImpl(struct OrtAllocator* this_, size_t size) {

--- a/onnxruntime/test/autoep/library/example_plugin_ep/ep_arena.h
+++ b/onnxruntime/test/autoep/library/example_plugin_ep/ep_arena.h
@@ -588,6 +588,7 @@ struct ArenaAllocator : BaseAllocator {
     Info = InfoImpl;
     GetStats = GetStatsImpl;
     AllocOnStream = AllocOnStreamImpl;
+    Shrink = nullptr;
   }
 
   // remove the OrtSyncStream* from any chunks that were using the stream

--- a/onnxruntime/test/autoep/library/example_plugin_ep/ep_factory.cc
+++ b/onnxruntime/test/autoep/library/example_plugin_ep/ep_factory.cc
@@ -484,10 +484,27 @@ OrtStatus* ORT_API_CALL ExampleEpFactory::ValidateCompiledModelCompatibilityInfo
   // Check ORT API version if present
   if (ort_version_pos != std::string::npos) {
     size_t ort_version_start = ort_version_pos + 16;  // length of "ort_api_version="
-    std::string ort_version = info.substr(ort_version_start);
+    size_t ort_version_end = info.find(';', ort_version_start);
+    std::string ort_version = (ort_version_end != std::string::npos)
+                                  ? info.substr(ort_version_start, ort_version_end - ort_version_start)
+                                  : info.substr(ort_version_start);
     std::string current_ort_version = std::to_string(ORT_API_VERSION);
     if (ort_version != current_ort_version) {
       // Different ORT version - might still work but prefer recompilation
+      *model_compatibility = OrtCompiledModelCompatibility_EP_SUPPORTED_PREFER_RECOMPILATION;
+      return nullptr;
+    }
+  }
+
+  // Check hardware architecture compatibility if that information is included in the compatibility_info string.
+  size_t hardware_arch_pos = info.find("hardware_architecture=");
+  if (hardware_arch_pos != std::string::npos) {
+    size_t hardware_arch_start = hardware_arch_pos + 22;  // length of "hardware_architecture="
+    std::string hardware_arch = info.substr(hardware_arch_start);
+    std::string current_hardware_arch = "arch1";  // "arch1" is for test purpose.
+                                                  // Replace with actual hardware architecture detection if needed
+    if (hardware_arch != current_hardware_arch) {
+      // Different hardware architecture - might still work but prefer recompilation
       *model_compatibility = OrtCompiledModelCompatibility_EP_SUPPORTED_PREFER_RECOMPILATION;
       return nullptr;
     }

--- a/onnxruntime/test/autoep/library/example_plugin_ep_kernel_registry/ep_allocator.h
+++ b/onnxruntime/test/autoep/library/example_plugin_ep_kernel_registry/ep_allocator.h
@@ -26,6 +26,7 @@ struct CustomAllocator : BaseAllocator {
     Reserve = AllocImpl;  // no special reserve logic and most likely unnecessary unless you have your own arena
     GetStats = nullptr;
     AllocOnStream = nullptr;
+    Shrink = nullptr;
   }
 
   static void* ORT_API_CALL AllocImpl(struct OrtAllocator* /*this_*/, size_t size) {

--- a/onnxruntime/test/autoep/test_allocators.cc
+++ b/onnxruntime/test/autoep/test_allocators.cc
@@ -30,6 +30,7 @@ struct DummyAllocator : OrtAllocator {
     Reserve = AllocImpl;      // no special reserve logic and most likely unnecessary unless you have your own arena
     GetStats = nullptr;       // this can be set to nullptr if not implemented
     AllocOnStream = nullptr;  // optional
+    Shrink = nullptr;
   }
 
   static void* ORT_API_CALL AllocImpl(struct OrtAllocator* this_, size_t size) {

--- a/onnxruntime/test/autoep/test_execution.cc
+++ b/onnxruntime/test/autoep/test_execution.cc
@@ -605,11 +605,11 @@ TEST(OrtEpLibrary, PluginEp_CompatibilityInfo_WrittenToMetadata) {
     std::string compatibility_value = value.get();
     ASSERT_GT(compatibility_value.length(), 0) << "Compatibility info should not be empty";
 
-    // Validate the exact compatibility string format and values
-    // Format: "example_ep;version=0.1.0;ort_api_version=<ORT_API_VERSION>"
+    // Validate the compatibility string format and values
+    // Format: "example_ep;version=0.1.0;ort_api_version=<ORT_API_VERSION>;..."
     std::string expected_compatibility_info = "example_ep;version=0.1.0;ort_api_version=" +
                                               std::to_string(ORT_API_VERSION);
-    EXPECT_EQ(compatibility_value, expected_compatibility_info);
+    EXPECT_TRUE(compatibility_value.starts_with(expected_compatibility_info));
   }
 
   std::filesystem::remove(output_model_file);

--- a/onnxruntime/test/autoep/test_model_package.cc
+++ b/onnxruntime/test/autoep/test_model_package.cc
@@ -1,0 +1,757 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "core/session/model_package/model_package_context.h"
+#include "core/session/model_package/model_package_descriptor_parser.h"
+#include "core/session/abi_devices.h"
+#include "test/autoep/test_autoep_utils.h"
+#include "test/util/include/asserts.h"
+#include "test/util/include/api_asserts.h"
+
+extern std::unique_ptr<Ort::Env> ort_env;
+
+namespace onnxruntime {
+namespace test {
+namespace {
+// ------------------------------------------------------------------
+// Helpers to build a test model package on disk
+// ------------------------------------------------------------------
+
+std::filesystem::path CreateManifestJson(const std::filesystem::path& package_root,
+                                         std::string_view manifest_json) {
+  std::filesystem::path manifest_path = package_root / "manifest.json";
+  std::filesystem::create_directories(package_root);
+
+  std::ofstream os(manifest_path, std::ios::binary);
+  os << manifest_json;
+  return manifest_path;
+}
+
+std::filesystem::path CreateModelPackage(
+    const std::filesystem::path& package_root,
+    std::string_view manifest_json,
+    std::string_view component_model_name,
+    std::string_view variant_name_1,
+    std::string_view variant_name_2,
+    const std::filesystem::path& source_model_1,
+    const std::filesystem::path& source_model_2) {
+  std::error_code ec;
+  std::filesystem::remove_all(package_root, ec);
+  std::filesystem::create_directories(package_root);
+
+  CreateManifestJson(package_root, manifest_json);
+
+  const auto models_root = package_root / "models" / component_model_name;
+  const auto variant1_dir = models_root / variant_name_1;
+  const auto variant2_dir = models_root / variant_name_2;
+
+  std::filesystem::create_directories(variant1_dir);
+  std::filesystem::create_directories(variant2_dir);
+
+  const auto variant1_model = variant1_dir / source_model_1.filename();
+  const auto variant2_model = variant2_dir / source_model_2.filename();
+
+  std::filesystem::copy_file(source_model_1, variant1_model, std::filesystem::copy_options::overwrite_existing, ec);
+  std::filesystem::copy_file(source_model_2, variant2_model, std::filesystem::copy_options::overwrite_existing, ec);
+  return package_root;
+}
+
+std::filesystem::path CreateComponentModelMetadata(
+    const std::filesystem::path& package_root,
+    std::string_view component_model_name,
+    std::string_view metadata_json) {
+  const auto component_root = package_root / "models" / component_model_name;
+  std::error_code ec;
+
+  // Ensure component root and metadata.json exist
+  std::filesystem::create_directories(component_root);
+
+  const std::filesystem::path metadata_path = component_root / "metadata.json";
+  std::ofstream os(metadata_path, std::ios::binary);
+  os << metadata_json;
+
+  return component_root;
+}
+
+std::string MakeManifestJson(std::string_view model_name,
+                             std::string_view component_model_name) {
+  std::ostringstream oss;
+  oss << R"({
+    "model_name": ")"
+      << model_name << R"(",
+    "model_version": "1.0",
+    "component_models": [")"
+      << component_model_name << R"("]
+  })";
+  return oss.str();
+}
+
+}  // namespace
+
+// ------------------------------------------------------------------
+// Model package end-to-end test
+// ------------------------------------------------------------------
+TEST(ModelPackageTest, LoadModelPackageAndRunInference_PluginEp_AppendV2) {
+  // Test Case 1:
+  // package_root is a model package directory which contains a manifest.json.
+  // This model package only contains one component model and it has a metadata.json.
+  // ORT should parse the manifest and the metadata.json to get model variants' constraints.
+  // ORT selects most suitable model variant based on constraints and then loads it to run inference successfully.
+  {
+    // Build model package on disk
+    const auto package_root = std::filesystem::temp_directory_path() / "ort_model_package_test";
+    CreateModelPackage(package_root, MakeManifestJson("test_model", "model_1"),
+                       "model_1", "variant_1", "variant_2",
+                       std::filesystem::path{"testdata/mul_1.onnx"}, std::filesystem::path{"testdata/mul_16.onnx"});
+
+    constexpr std::string_view metadata_json = R"({
+      "component_model_name": "model_1",
+      "model_variants": {
+        "variant_1": {
+          "model_file": "mul_1.onnx",
+          "constraints": {
+            "ep": "example_ep",
+            "device": "cpu",
+            "architecture": "arch1"
+          }
+        },
+        "variant_2": {
+          "model_file": "mul_16.onnx",
+          "constraints": {
+            "ep": "example_ep",
+            "device": "npu",
+            "architecture": "arch2"
+          }
+        }
+      }
+    })";
+
+    CreateComponentModelMetadata(package_root,
+                                 "model_1",
+                                 metadata_json);
+
+    // Register example EP and get its device
+    RegisteredEpDeviceUniquePtr example_ep;
+    ASSERT_NO_FATAL_FAILURE(Utils::RegisterAndGetExampleEp(*ort_env, Utils::example_ep_info, example_ep));
+    Ort::ConstEpDevice plugin_ep_device(example_ep.get());
+
+    // Prepare session options with ExampleEP appended
+    Ort::SessionOptions session_options;
+    std::unordered_map<std::string, std::string> ep_options;
+    session_options.AppendExecutionProvider_V2(*ort_env, {plugin_ep_device}, ep_options);
+
+    // Create session from package root (directory)
+    // ORT should pick the variant_1 model since the constraints match the example EP device (device "cpu" matches)
+    Ort::Session session(*ort_env, package_root.c_str(), session_options);
+
+    // Prepare input X
+    Ort::MemoryInfo memory_info = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
+    std::vector<int64_t> shape = {3, 2};
+    std::vector<float> input_data = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
+    Ort::Value input = Ort::Value::CreateTensor<float>(memory_info, input_data.data(), input_data.size(),
+                                                       shape.data(), shape.size());
+    const char* input_names[] = {"X"};
+    const char* output_names[] = {"Y"};
+    std::vector<Ort::Value> inputs;
+    inputs.push_back(std::move(input));
+
+    // Run
+    auto outputs = session.Run(Ort::RunOptions{nullptr}, input_names, inputs.data(), inputs.size(),
+                               output_names, 1);
+    ASSERT_EQ(outputs.size(), 1u);
+    const float* out = outputs[0].GetTensorData<float>();
+    gsl::span<const float> out_span(out, input_data.size());
+    EXPECT_THAT(out_span, ::testing::ElementsAre(1.f, 4.f, 9.f, 16.f, 25.f, 36.f));
+
+    // Cleanup
+    std::error_code ec;
+    std::filesystem::remove_all(package_root, ec);
+  }
+
+  // Test Case 2:
+  // package_root is a component model directory which contains a metadata.json.
+  // ORT should parse metadata.json to get model variants' constraints.
+  // ORT selects most suitable model variant based on constraints and then loads it to run inference successfully.
+  {
+    // Build model package on disk
+    const auto package_root = std::filesystem::temp_directory_path() / "ort_model_package_test";
+
+    CreateModelPackage(package_root, MakeManifestJson("test_model", "model_1"),
+                       "model_1", "variant_1", "variant_2",
+                       std::filesystem::path{"testdata/mul_1.onnx"}, std::filesystem::path{"testdata/mul_16.onnx"});
+
+    constexpr std::string_view metadata_json = R"({
+      "component_model_name": "model_1",
+      "model_variants": {
+        "variant_1": {
+          "model_file": "mul_1.onnx",
+          "constraints": {
+            "ep": "example_ep",
+            "device": "cpu",
+            "architecture": "arch1"
+          }
+        },
+        "variant_2": {
+          "model_file": "mul_16.onnx",
+          "constraints": {
+            "ep": "example_ep",
+            "device": "npu",
+            "architecture": "arch2"
+          }
+        }
+      }
+    })";
+
+    const auto component_model_root = CreateComponentModelMetadata(package_root,
+                                                                   "model_1",
+                                                                   metadata_json);
+
+    // Register example EP and get its device
+    RegisteredEpDeviceUniquePtr example_ep;
+    ASSERT_NO_FATAL_FAILURE(Utils::RegisterAndGetExampleEp(*ort_env, Utils::example_ep_info, example_ep));
+    Ort::ConstEpDevice plugin_ep_device(example_ep.get());
+
+    // Prepare session options with ExampleEP appended
+    Ort::SessionOptions session_options;
+    std::unordered_map<std::string, std::string> ep_options;
+    session_options.AppendExecutionProvider_V2(*ort_env, {plugin_ep_device}, ep_options);
+
+    // Create session from component model root (directory)
+    // ORT should pick the variant_1 model since the constraints match the example EP device (device "cpu" matches)
+    Ort::Session session(*ort_env, component_model_root.c_str(), session_options);
+
+    // Prepare input X
+    Ort::MemoryInfo memory_info = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
+    std::vector<int64_t> shape = {3, 2};
+    std::vector<float> input_data = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
+    Ort::Value input = Ort::Value::CreateTensor<float>(memory_info, input_data.data(), input_data.size(),
+                                                       shape.data(), shape.size());
+    const char* input_names[] = {"X"};
+    const char* output_names[] = {"Y"};
+    std::vector<Ort::Value> inputs;
+    inputs.push_back(std::move(input));
+
+    // Run
+    auto outputs = session.Run(Ort::RunOptions{nullptr}, input_names, inputs.data(), inputs.size(),
+                               output_names, 1);
+    ASSERT_EQ(outputs.size(), 1u);
+    const float* out = outputs[0].GetTensorData<float>();
+    gsl::span<const float> out_span(out, input_data.size());
+    EXPECT_THAT(out_span, ::testing::ElementsAre(1.f, 4.f, 9.f, 16.f, 25.f, 36.f));
+
+    // Cleanup
+    std::error_code ec;
+    std::filesystem::remove_all(package_root, ec);
+  }
+}
+
+TEST(ModelPackageTest, LoadModelPackageAndRunInference_PreferCpu) {
+  // Build model package on disk
+  const auto package_root = std::filesystem::temp_directory_path() / "ort_model_package_test";
+
+  CreateModelPackage(package_root, MakeManifestJson("test_model", "model_1"),
+                     "model_1", "variant_1", "variant_2",
+                     std::filesystem::path{"testdata/mul_1.onnx"}, std::filesystem::path{"testdata/mul_16.onnx"});
+
+  constexpr std::string_view metadata_json = R"({
+      "component_model_name": "model_1",
+      "model_variants": {
+        "variant_1": {
+          "model_file": "mul_1.onnx",
+          "constraints": {
+            "ep": "example_ep",
+            "device": "cpu",
+            "architecture": "arch1"
+          }
+        },
+        "variant_2": {
+          "model_file": "mul_16.onnx",
+          "constraints": {
+            "ep": "example_ep",
+            "device": "npu",
+            "architecture": "arch2"
+          }
+        }
+      }
+    })";
+
+  CreateComponentModelMetadata(package_root,
+                               "model_1",
+                               metadata_json);
+
+  // Register example EP and get its device
+  RegisteredEpDeviceUniquePtr example_ep;
+  ASSERT_NO_FATAL_FAILURE(Utils::RegisterAndGetExampleEp(*ort_env, Utils::example_ep_info, example_ep));
+  Ort::ConstEpDevice plugin_ep_device(example_ep.get());
+
+  // Prepare session options with ExampleEP appended
+  Ort::SessionOptions session_options;
+  session_options.SetEpSelectionPolicy(OrtExecutionProviderDevicePolicy_PREFER_CPU);
+
+  // Create session from package root (directory)
+  // ORT should pick the variant_1 model since the constraints match the example EP device (device "cpu" matches)
+  Ort::Session session(*ort_env, package_root.c_str(), session_options);
+
+  // Prepare input X
+  Ort::MemoryInfo memory_info = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
+  std::vector<int64_t> shape = {3, 2};
+  std::vector<float> input_data = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
+  Ort::Value input = Ort::Value::CreateTensor<float>(memory_info, input_data.data(), input_data.size(),
+                                                     shape.data(), shape.size());
+  const char* input_names[] = {"X"};
+  const char* output_names[] = {"Y"};
+  std::vector<Ort::Value> inputs;
+  inputs.push_back(std::move(input));
+
+  // Run
+  auto outputs = session.Run(Ort::RunOptions{nullptr}, input_names, inputs.data(), inputs.size(),
+                             output_names, 1);
+  ASSERT_EQ(outputs.size(), 1u);
+  const float* out = outputs[0].GetTensorData<float>();
+  gsl::span<const float> out_span(out, input_data.size());
+  EXPECT_THAT(out_span, ::testing::ElementsAre(1.f, 4.f, 9.f, 16.f, 25.f, 36.f));
+
+  // Cleanup
+  std::error_code ec;
+  std::filesystem::remove_all(package_root, ec);
+}
+
+TEST(ModelPackageTest, CheckCompiledModelCompatibilityInfo) {
+  RegisteredEpDeviceUniquePtr example_ep;
+  ASSERT_NO_FATAL_FAILURE(Utils::RegisterAndGetExampleEp(*ort_env, Utils::example_ep_info, example_ep));
+  Ort::ConstEpDevice plugin_ep_device(example_ep.get());
+
+  const ORTCHAR_T* input_model_file = ORT_TSTR("testdata/mul_1.onnx");
+  const ORTCHAR_T* output_model_file = ORT_TSTR("plugin_ep_compat_test.onnx");
+  std::filesystem::remove(output_model_file);
+
+  // Compile the model
+  {
+    Ort::SessionOptions session_options;
+    std::unordered_map<std::string, std::string> ep_options;
+    session_options.AppendExecutionProvider_V2(*ort_env, {plugin_ep_device}, ep_options);
+
+    Ort::ModelCompilationOptions compile_options(*ort_env, session_options);
+    compile_options.SetFlags(OrtCompileApiFlags_ERROR_IF_NO_NODES_COMPILED);
+    compile_options.SetInputModelPath(input_model_file);
+    compile_options.SetOutputModelPath(output_model_file);
+
+    ASSERT_CXX_ORTSTATUS_OK(Ort::CompileModel(*ort_env, compile_options));
+    ASSERT_TRUE(std::filesystem::exists(output_model_file));
+  }
+
+  // Build model package on disk
+  const auto package_root = std::filesystem::temp_directory_path() / "ort_model_package_test";
+
+  CreateModelPackage(package_root, MakeManifestJson("test_model", "model_1"),
+                     "model_1", "variant_2", "variant_1",
+                     std::filesystem::path{"testdata/mul_16.onnx"}, std::filesystem::path{"plugin_ep_compat_test.onnx"});
+
+  constexpr std::string_view metadata_json = R"({
+      "component_model_name": "model_1",
+      "model_variants": {
+        "variant_2": {
+          "model_file": "mul_16.onnx",
+          "constraints": {
+            "ep": "example_ep",
+            "device": "cpu",
+            "architecture": "arch2",
+            "ep_compatibility_info": "example_ep;version=0.1.0;ort_api_version=25;hardware_architecture=arch2"
+          }
+        },
+        "variant_1": {
+          "model_file": "plugin_ep_compat_test.onnx",
+          "constraints": {
+            "ep": "example_ep",
+            "device": "cpu",
+            "architecture": "arch1",
+            "ep_compatibility_info": "example_ep;version=0.1.0;ort_api_version=25;hardware_architecture=arch1"
+          }
+        }
+      }
+    })";
+
+  CreateComponentModelMetadata(package_root,
+                               "model_1",
+                               metadata_json);
+
+  // Prepare session options with ExampleEP appended
+  Ort::SessionOptions session_options;
+  std::unordered_map<std::string, std::string> ep_options;
+  session_options.AppendExecutionProvider_V2(*ort_env, {plugin_ep_device}, ep_options);
+
+  // Create session from package root (directory)
+  // ORT should pick the variant_1 model since it has OrtCompiledModelCompatibility_EP_SUPPORTED_OPTIMAL for the example EP,
+  // while variant_2 is only OrtCompiledModelCompatibility_EP_SUPPORTED_PREFER_RECOMPILATION.
+  // If variant_2 was selected and loaded, i.e. mul_16.onnx, session initialization would fail with error "Error No Op registered for Mul16".
+  Ort::Session session(*ort_env, package_root.c_str(), session_options);
+
+  // Cleanup
+  std::error_code ec;
+  std::filesystem::remove_all(package_root, ec);
+}
+
+TEST(ModelPackageTest, LoadModelPackageAndRunInference_DiscoverComponentsFromModelsFolder) {
+  // manifest.json without "component_models"; discovery should scan models/* with metadata.json.
+  const auto package_root = std::filesystem::temp_directory_path() / "ort_model_package_discover_test";
+  constexpr std::string_view manifest_json = R"({
+    "model_name": "test_model"
+  })";
+
+  CreateModelPackage(package_root, manifest_json,
+                     "model_1", "variant_1", "variant_2",
+                     std::filesystem::path{"testdata/mul_1.onnx"}, std::filesystem::path{"testdata/mul_16.onnx"});
+
+  // Prepare component model with metadata and variants
+  const std::string component_model_name = "model_1";
+  constexpr std::string_view metadata_json = R"({
+      "component_model_name": "model_1",
+      "model_variants": {
+        "variant_1": {
+          "model_file": "mul_1.onnx",
+          "constraints": {
+            "ep": "example_ep",
+            "device": "cpu",
+            "architecture": "arch1"
+          }
+        },
+        "variant_2": {
+          "model_file": "mul_16.onnx",
+          "constraints": {
+            "ep": "example_ep",
+            "device": "npu",
+            "architecture": "arch2"
+          }
+        }
+      }
+    })";
+
+  // Create metadata.json under models/model_1
+  const auto component_root = CreateComponentModelMetadata(package_root,
+                                                           component_model_name,
+                                                           metadata_json);
+
+  // Add another component folder without metadata to ensure it's ignored
+  std::filesystem::create_directories(package_root / "models" / "ignored_component");
+
+  // Register example EP and get its device
+  RegisteredEpDeviceUniquePtr example_ep;
+  ASSERT_NO_FATAL_FAILURE(Utils::RegisterAndGetExampleEp(*ort_env, Utils::example_ep_info, example_ep));
+  Ort::ConstEpDevice plugin_ep_device(example_ep.get());
+
+  // Prepare session options with ExampleEP appended
+  Ort::SessionOptions session_options;
+  std::unordered_map<std::string, std::string> ep_options;
+  session_options.AppendExecutionProvider_V2(*ort_env, {plugin_ep_device}, ep_options);
+
+  // Create session from package root (directory). Discovery should find model_1 via metadata.json,
+  // then pick variant_1 (device cpu) matching the example EP device.
+  // If variant_2 was selected and loaded, i.e. mul_16.onnx, session initialization would fail with error "Error No Op registered for Mul16".
+  Ort::Session session(*ort_env, package_root.c_str(), session_options);
+
+  // Prepare input X
+  Ort::MemoryInfo memory_info = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
+  std::vector<int64_t> shape = {3, 2};
+  std::vector<float> input_data = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
+  Ort::Value input = Ort::Value::CreateTensor<float>(memory_info, input_data.data(), input_data.size(),
+                                                     shape.data(), shape.size());
+  const char* input_names[] = {"X"};
+  const char* output_names[] = {"Y"};
+  std::vector<Ort::Value> inputs;
+  inputs.push_back(std::move(input));
+
+  // Run
+  auto outputs = session.Run(Ort::RunOptions{nullptr}, input_names, inputs.data(), inputs.size(),
+                             output_names, 1);
+  ASSERT_EQ(outputs.size(), 1u);
+  const float* out = outputs[0].GetTensorData<float>();
+  gsl::span<const float> out_span(out, input_data.size());
+  EXPECT_THAT(out_span, ::testing::ElementsAre(1.f, 4.f, 9.f, 16.f, 25.f, 36.f));
+
+  // Cleanup
+  std::error_code ec;
+  std::filesystem::remove_all(package_root, ec);
+}
+
+TEST(ModelPackageTest, ParseVariantFileResolution) {
+  const auto package_root = std::filesystem::temp_directory_path() / "ort_model_package_parse_variant";
+  std::error_code ec;
+
+  auto write_manifest = [&]() {
+    CreateManifestJson(package_root, MakeManifestJson("test_model", "model_1"));
+  };
+
+  auto write_metadata = [&](std::string_view metadata_json) {
+    CreateComponentModelMetadata(package_root, "model_1", metadata_json);
+  };
+
+  // Subcase 1: "model_file" points to a directory containing exactly one .onnx file.
+  {
+    std::filesystem::remove_all(package_root, ec);
+    write_manifest();
+
+    constexpr std::string_view metadata_json = R"({
+      "component_model_name": "model_1",
+      "model_variants": {
+        "variant_dir": {
+          "model_file": "subdir",
+          "constraints": {}
+        }
+      }
+    })";
+    write_metadata(metadata_json);
+
+    const auto variant_dir = package_root / "models" / "model_1" / "variant_dir";
+    const auto subdir = variant_dir / "subdir";
+    std::filesystem::create_directories(subdir);
+    std::filesystem::copy_file("testdata/mul_1.onnx", subdir / "only.onnx",
+                               std::filesystem::copy_options::overwrite_existing, ec);
+
+    ModelPackageDescriptorParser parser(logging::LoggingManager::DefaultLogger());
+    std::vector<ModelVariantInfo> variants;
+    auto status = parser.ParseVariantsFromRoot(package_root, variants);
+    ASSERT_TRUE(status.IsOK()) << status.ErrorMessage();
+    ASSERT_EQ(variants.size(), 1u);
+    EXPECT_EQ(variants[0].model_path.filename().string(), "only.onnx");
+  }
+
+  // Subcase 2: No "model_file" field; discover the single .onnx in the variant directory.
+  {
+    std::filesystem::remove_all(package_root, ec);
+    write_manifest();
+
+    constexpr std::string_view metadata_json = R"({
+      "component_model_name": "model_1",
+      "model_variants": {
+        "variant_autodiscover": {
+          "constraints": {}
+        }
+      }
+    })";
+    write_metadata(metadata_json);
+
+    const auto variant_dir = package_root / "models" / "model_1" / "variant_autodiscover";
+    std::filesystem::create_directories(variant_dir);
+    std::filesystem::copy_file("testdata/mul_1.onnx", variant_dir / "auto.onnx",
+                               std::filesystem::copy_options::overwrite_existing, ec);
+
+    ModelPackageDescriptorParser parser(logging::LoggingManager::DefaultLogger());
+    std::vector<ModelVariantInfo> variants;
+    auto status = parser.ParseVariantsFromRoot(package_root, variants);
+    ASSERT_TRUE(status.IsOK()) << status.ErrorMessage();
+    ASSERT_EQ(variants.size(), 1u);
+    EXPECT_EQ(variants[0].model_path.filename().string(), "auto.onnx");
+  }
+
+  // Subcase 3: Multiple .onnx files -> error.
+  {
+    std::filesystem::remove_all(package_root, ec);
+    write_manifest();
+
+    constexpr std::string_view metadata_json = R"({
+      "component_model_name": "model_1",
+      "model_variants": {
+        "variant_multi": {
+          "constraints": {}
+        }
+      }
+    })";
+    write_metadata(metadata_json);
+
+    const auto variant_dir = package_root / "models" / "model_1" / "variant_multi";
+    std::filesystem::create_directories(variant_dir);
+    std::filesystem::copy_file("testdata/mul_1.onnx", variant_dir / "a.onnx",
+                               std::filesystem::copy_options::overwrite_existing, ec);
+    std::filesystem::copy_file("testdata/mul_16.onnx", variant_dir / "b.onnx",
+                               std::filesystem::copy_options::overwrite_existing, ec);
+
+    ModelPackageDescriptorParser parser(logging::LoggingManager::DefaultLogger());
+    std::vector<ModelVariantInfo> variants;
+    auto status = parser.ParseVariantsFromRoot(package_root, variants);
+    ASSERT_FALSE(status.IsOK());
+    EXPECT_THAT(status.ErrorMessage(),
+                ::testing::HasSubstr("Multiple ONNX model files found under"));
+  }
+
+  std::filesystem::remove_all(package_root, ec);
+}
+
+TEST(ModelPackageTest, ParseVariantsFromRoot_PackageRootDirectory) {
+  const auto package_root = std::filesystem::temp_directory_path() / "ort_model_package_parse_from_package_root";
+  std::error_code ec;
+  std::filesystem::remove_all(package_root, ec);
+
+  // package_root is a model package directory (has manifest.json).
+  constexpr std::string_view manifest_json = R"({
+    "model_name": "test_model",
+    "component_models": ["model_1"]
+  })";
+
+  CreateModelPackage(package_root, manifest_json,
+                     "model_1", "variant_1", "variant_2",
+                     std::filesystem::path{"testdata/mul_1.onnx"}, std::filesystem::path{"testdata/mul_16.onnx"});
+
+  constexpr std::string_view metadata_json = R"({
+    "component_model_name": "model_1",
+    "model_variants": {
+      "variant_1": {
+        "model_file": "mul_1.onnx",
+        "constraints": {
+          "ep": "example_ep",
+          "device": "cpu",
+          "architecture": "arch1"
+        }
+      },
+      "variant_2": {
+        "model_file": "mul_16.onnx",
+        "constraints": {
+          "ep": "example_ep",
+          "device": "npu",
+          "architecture": "arch2"
+        }
+      }
+    }
+  })";
+
+  CreateComponentModelMetadata(package_root, "model_1", metadata_json);
+
+  ModelPackageDescriptorParser parser(logging::LoggingManager::DefaultLogger());
+  std::vector<ModelVariantInfo> variants;
+  auto status = parser.ParseVariantsFromRoot(package_root, variants);
+
+  ASSERT_TRUE(status.IsOK()) << status.ErrorMessage();
+  ASSERT_EQ(variants.size(), 2u);
+
+  std::unordered_map<std::string, const ModelVariantInfo*> by_file;
+  for (const auto& v : variants) {
+    by_file.emplace(v.model_path.filename().string(), &v);
+  }
+
+  ASSERT_EQ(by_file.count("mul_1.onnx"), 1u);
+  ASSERT_EQ(by_file.count("mul_16.onnx"), 1u);
+
+  const auto* v1 = by_file.at("mul_1.onnx");
+  EXPECT_EQ(v1->ep, "example_ep");
+  EXPECT_EQ(v1->device, "cpu");
+  EXPECT_EQ(v1->architecture, "arch1");
+
+  const auto* v2 = by_file.at("mul_16.onnx");
+  EXPECT_EQ(v2->ep, "example_ep");
+  EXPECT_EQ(v2->device, "npu");
+  EXPECT_EQ(v2->architecture, "arch2");
+
+  std::filesystem::remove_all(package_root, ec);
+}
+
+TEST(ModelPackageTest, ParseVariantsFromRoot_ComponentModelDirectory) {
+  const auto component_root = std::filesystem::temp_directory_path() / "ort_model_package_parse_from_component_root";
+  std::error_code ec;
+  std::filesystem::remove_all(component_root, ec);
+  std::filesystem::create_directories(component_root);
+
+  // package_root is a component model directory (has metadata.json, no manifest.json).
+  const auto variant_dir = component_root / "variant_1";
+  std::filesystem::create_directories(variant_dir);
+  std::filesystem::copy_file("testdata/mul_1.onnx", variant_dir / "mul_1.onnx",
+                             std::filesystem::copy_options::overwrite_existing, ec);
+
+  constexpr std::string_view metadata_json = R"({
+    "component_model_name": "model_1",
+    "model_variants": {
+      "variant_1": {
+        "model_file": "mul_1.onnx",
+        "constraints": {
+          "ep": "example_ep",
+          "device": "cpu",
+          "architecture": "arch1"
+        }
+      }
+    }
+  })";
+
+  {
+    std::ofstream os(component_root / "metadata.json", std::ios::binary);
+    os << metadata_json;
+  }
+
+  ModelPackageDescriptorParser parser(logging::LoggingManager::DefaultLogger());
+  std::vector<ModelVariantInfo> variants;
+  auto status = parser.ParseVariantsFromRoot(component_root, variants);
+
+  ASSERT_TRUE(status.IsOK()) << status.ErrorMessage();
+  ASSERT_EQ(variants.size(), 1u);
+  EXPECT_EQ(variants[0].model_path.filename().string(), "mul_1.onnx");
+  EXPECT_EQ(variants[0].ep, "example_ep");
+  EXPECT_EQ(variants[0].device, "cpu");
+  EXPECT_EQ(variants[0].architecture, "arch1");
+
+  std::filesystem::remove_all(component_root, ec);
+}
+
+TEST(ModelPackageTest, ParseVariantsFromRoot_UsesModelIdForModelDirectory) {
+  const auto package_root = std::filesystem::temp_directory_path() / "ort_model_package_model_id_dir_test";
+  std::error_code ec;
+  std::filesystem::remove_all(package_root, ec);
+
+  constexpr std::string_view manifest_json = R"({
+    "model_name": "test_model",
+    "model_version": "1.0",
+    "component_models": ["model_1"]
+  })";
+
+  CreateManifestJson(package_root, manifest_json);
+
+  // Variant name intentionally does not match the model_id-derived directory name.
+  // model_id = "phi4-cpu:1" should map to directory "phi4-cpu_1".
+  constexpr std::string_view metadata_json = R"({
+    "component_model_name": "model_1",
+    "model_variants": {
+      "catalog_variant": {
+        "model_id": "phi4-cpu:1",
+        "model_file": "model.onnx",
+        "constraints": {
+          "ep": "example_ep",
+          "device": "cpu",
+          "architecture": "arch1"
+        }
+      }
+    }
+  })";
+
+  CreateComponentModelMetadata(package_root, "model_1", metadata_json);
+
+  // Create the model under model_id-derived directory: models/model_1/phi4-cpu_1/model.onnx
+  const auto model_dir = package_root / "models" / "model_1" / "phi4-cpu_1";
+  std::filesystem::create_directories(model_dir);
+  std::filesystem::copy_file("testdata/mul_1.onnx",
+                             model_dir / "model.onnx",
+                             std::filesystem::copy_options::overwrite_existing,
+                             ec);
+
+  ModelPackageDescriptorParser parser(logging::LoggingManager::DefaultLogger());
+  std::vector<ModelVariantInfo> variants;
+  auto status = parser.ParseVariantsFromRoot(package_root, variants);
+
+  ASSERT_TRUE(status.IsOK()) << status.ErrorMessage();
+  ASSERT_EQ(variants.size(), 1u);
+
+  EXPECT_EQ(variants[0].model_path.filename().string(), "model.onnx");
+  EXPECT_EQ(variants[0].model_path.parent_path().filename().string(), "phi4-cpu_1");
+  EXPECT_EQ(variants[0].ep, "example_ep");
+  EXPECT_EQ(variants[0].device, "cpu");
+  EXPECT_EQ(variants[0].architecture, "arch1");
+
+  std::filesystem::remove_all(package_root, ec);
+}
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/autoep/tools/print_onnx_metadata.py
+++ b/onnxruntime/test/autoep/tools/print_onnx_metadata.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import onnx
+
+
+def model_metadata_to_dict(model: onnx.ModelProto) -> dict[str, Any]:
+    custom_metadata = {entry.key: entry.value for entry in model.metadata_props}
+
+    graph = model.graph
+    info = {
+        "ir_version": model.ir_version,
+        "producer_name": model.producer_name,
+        "producer_version": model.producer_version,
+        "domain": model.domain,
+        "model_version": model.model_version,
+        "doc_string": model.doc_string,
+        "graph_name": graph.name,
+        "opset_imports": [{"domain": o.domain, "version": o.version} for o in model.opset_import],
+        "counts": {
+            "inputs": len(graph.input),
+            "outputs": len(graph.output),
+            "nodes": len(graph.node),
+            "initializers": len(graph.initializer),
+        },
+        "custom_metadata": custom_metadata,
+    }
+
+    return info
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Print metadata from an ONNX model file.")
+    parser.add_argument("model", type=Path, help="Path to .onnx file")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON output")
+    args = parser.parse_args()
+
+    if not args.model.is_file():
+        raise FileNotFoundError(f"Model file not found: {args.model}")
+
+    model = onnx.load(str(args.model))
+    info = model_metadata_to_dict(model)
+
+    if args.pretty:
+        print(json.dumps(info, indent=2, ensure_ascii=False))
+    else:
+        print(json.dumps(info, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/onnxruntime/test/contrib_ops/tensor_op_test.cc
+++ b/onnxruntime/test/contrib_ops/tensor_op_test.cc
@@ -121,7 +121,12 @@ void MeanVarianceNormalizationAcrossChannels(bool across_channels, bool normaliz
   test.AddAttribute("normalize_variance", normalize_variance ? one : zero);
   test.AddInput<float>("input", {N, C, H, W}, X);
   test.AddOutput<float>("output", {N, C, H, W}, result);
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kOpenVINOExecutionProvider, kTensorrtExecutionProvider});  // OpenVINO doesn't support MVN operator below opset 9. TensorRT doesn't support opset 8 of MVN operator.
+  // DML currently has known failures in this 4D MVN coverage.
+  // See https://github.com/microsoft/onnxruntime/issues/27933 and remove this exclusion once
+  // that issue is fixed. OpenVINO does not support MVN below opset 9. TensorRT does not
+  // support MVN opset 8.
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kDmlExecutionProvider, kOpenVINOExecutionProvider, kTensorrtExecutionProvider});
 }
 
 void MeanVarianceNormalizationPerChannel(bool across_channels, bool normalize_variance) {
@@ -188,7 +193,12 @@ void MeanVarianceNormalizationPerChannel(bool across_channels, bool normalize_va
   test.AddAttribute("normalize_variance", normalize_variance ? one : zero);
   test.AddInput<float>("input", {N, C, H, W}, X);
   test.AddOutput<float>("output", {N, C, H, W}, result);
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kOpenVINOExecutionProvider, kTensorrtExecutionProvider});  // OpenVINO doesn't support MVN operator below opset 9. TensorRT doesn't support opset 8 of MVN operator.
+  // OpenVINO does not support MVN below opset 9. TensorRT does not support MVN opset 8.
+  // DML currently has known failures in this 4D MVN coverage.
+  // See https://github.com/microsoft/onnxruntime/issues/27933 and remove this exclusion once
+  // that issue is fixed.
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kDmlExecutionProvider, kOpenVINOExecutionProvider, kTensorrtExecutionProvider});
 }
 
 TEST(MVNContribOpTest, MeanVarianceNormalizationCPUTest_Version1_TO_8) {

--- a/onnxruntime/test/contrib_ops/word_conv_embedding_test.cc
+++ b/onnxruntime/test/contrib_ops/word_conv_embedding_test.cc
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <cmath>
 #include <vector>
 #include "gtest/gtest.h"
 #include "test/providers/provider_test_utils.h"
@@ -124,6 +125,46 @@ TEST(ContribOpTest, WordConvEmbedding_char_embedding_shape_conv_shape_not_match)
   test.AddOutput<float>("Y", output_shape, output);
 
   test.Run(OpTester::ExpectResult::kExpectFailure);
+}
+
+TEST(ContribOpTest, WordConvEmbedding_out_of_range_char_index_treated_as_padding) {
+  OpTester test("WordConvEmbedding", 1, onnxruntime::kMSDomain);
+
+  test.AddAttribute<int64_t>("embedding_size", 1LL);
+  test.AddAttribute<int64_t>("conv_window_size", 2LL);
+  test.AddAttribute<int64_t>("char_embedding_size", 1LL);
+
+  test.AddInput<int>("Sequence", {1, 2}, {1, 99});
+  test.AddInput<float>("W", {1, 1, 2, 1}, {1.0f, 1.0f});
+  test.AddInput<float>("B", {1}, {0.0f});
+  test.AddInput<float>("C", {2, 1}, {123.0f, 2.0f});
+  test.AddOutput<float>("Y", {1, 1}, {std::tanh(2.0f)});
+
+  test.Run();
+}
+
+TEST(ContribOpTest, WordConvEmbedding_rejects_filter_width_larger_than_word_length) {
+  OpTester test("WordConvEmbedding", 1, onnxruntime::kMSDomain);
+
+  test.AddInput<int>("Sequence", {1, 2}, {1, 2});
+  test.AddInput<float>("W", {1, 1, 3, 1}, {1.0f, 1.0f, 1.0f});
+  test.AddInput<float>("B", {1}, {0.0f});
+  test.AddInput<float>("C", {3, 1}, {0.0f, 1.0f, 2.0f});
+  test.AddOutput<float>("Y", {1, 1}, {0.0f});
+
+  test.Run(OpTester::ExpectResult::kExpectFailure, "Conv kernel width must not exceed word length");
+}
+
+TEST(ContribOpTest, WordConvEmbedding_rejects_sequence_rank_one) {
+  OpTester test("WordConvEmbedding", 1, onnxruntime::kMSDomain);
+
+  test.AddInput<int>("Sequence", {2}, {1, 2});
+  test.AddInput<float>("W", {1, 1, 2, 1}, {1.0f, 1.0f});
+  test.AddInput<float>("B", {1}, {0.0f});
+  test.AddInput<float>("C", {3, 1}, {0.0f, 1.0f, 2.0f});
+  test.AddOutput<float>("Y", {1, 1}, {0.0f});
+
+  test.Run(OpTester::ExpectResult::kExpectFailure, "Sequence input must have rank greater than 1");
 }
 
 }  // namespace test

--- a/onnxruntime/test/framework/allocator_test.cc
+++ b/onnxruntime/test/framework/allocator_test.cc
@@ -4,6 +4,9 @@
 
 #include "core/framework/allocator.h"
 #include "core/framework/allocator_utils.h"
+#include "core/session/allocator_adapters.h"
+#include "core/session/abi_key_value_pairs.h"
+#include "core/session/ort_apis.h"
 
 #include "test/unittest_util/framework_test_utils.h"
 #include "gtest/gtest.h"
@@ -109,5 +112,183 @@ TEST(AllocatorTest, TestOverflowChecks) {
   EXPECT_TRUE(IAllocator::CalcMemSizeForArrayWithAlignment<kAllocAlignment>(num_elements, element_size - (kAllocAlignment / num_elements), &size));
   EXPECT_FALSE(IAllocator::CalcMemSizeForArrayWithAlignment<kAllocAlignment>(num_elements, element_size, &size));
 }
+
+// --- AsArena / SafeArenaCast tests ---
+
+TEST(AllocatorTest, AsArena_ReturnsNullForNonArena) {
+  auto cpu_allocator = std::make_shared<CPUAllocator>();
+  EXPECT_EQ(cpu_allocator->AsArena(), nullptr);
+  EXPECT_EQ(static_cast<const IAllocator*>(cpu_allocator.get())->AsArena(), nullptr);
+  EXPECT_EQ(IArena::SafeArenaCast(cpu_allocator.get()), nullptr);
+}
+
+TEST(AllocatorTest, AsArena_ReturnsNonNullForArena) {
+  if (!DoesCpuAllocatorSupportArenaUsage()) {
+    GTEST_SKIP() << "CPU arena not enabled in this build";
+  }
+  auto cpu_arena = TestCPUExecutionProvider()->CreatePreferredAllocators()[0];
+  EXPECT_NE(cpu_arena->AsArena(), nullptr);
+  EXPECT_EQ(cpu_arena->AsArena(), IArena::SafeArenaCast(cpu_arena.get()));
+}
+
+TEST(AllocatorTest, SafeArenaCast_NullInput) {
+  EXPECT_EQ(IArena::SafeArenaCast(nullptr), nullptr);
+}
+
+// --- IArenaImplWrappingOrtAllocator tests ---
+
+namespace {
+// Minimal OrtAllocator with arena-like Shrink support for unit testing.
+struct MockArenaOrtAllocator : OrtAllocator {
+  int alloc_count = 0;
+  int free_count = 0;
+  int reserve_count = 0;
+  int shrink_count = 0;
+  bool shrink_should_fail = false;
+
+  static OrtMemoryInfo mem_info_;
+
+  MockArenaOrtAllocator() {
+    version = ORT_API_VERSION;
+    Alloc = AllocImpl;
+    Free = FreeImpl;
+    Info = InfoImpl;
+    Reserve = ReserveImpl;
+    GetStats = GetStatsImpl;
+    AllocOnStream = nullptr;
+    Shrink = ShrinkImpl;
+  }
+
+  static void* ORT_API_CALL AllocImpl(OrtAllocator* this_, size_t size) {
+    auto& self = *static_cast<MockArenaOrtAllocator*>(this_);
+    self.alloc_count++;
+    if (size == 0) return nullptr;
+    return malloc(size);
+  }
+
+  static void ORT_API_CALL FreeImpl(OrtAllocator* this_, void* p) {
+    auto& self = *static_cast<MockArenaOrtAllocator*>(this_);
+    self.free_count++;
+    free(p);
+  }
+
+  static const OrtMemoryInfo* ORT_API_CALL InfoImpl(const OrtAllocator* /*this_*/) {
+    return &mem_info_;
+  }
+
+  static void* ORT_API_CALL ReserveImpl(OrtAllocator* this_, size_t size) {
+    auto& self = *static_cast<MockArenaOrtAllocator*>(this_);
+    self.reserve_count++;
+    if (size == 0) return nullptr;
+    return malloc(size);
+  }
+
+  static OrtStatusPtr ORT_API_CALL GetStatsImpl(const OrtAllocator* this_, OrtKeyValuePairs** out) noexcept {
+    auto& self = *static_cast<const MockArenaOrtAllocator*>(this_);
+    auto kvp = std::make_unique<OrtKeyValuePairs>();
+    kvp->CopyFromMap(std::map<std::string, std::string>{
+        {"NumAllocs", std::to_string(self.alloc_count)},
+        {"NumArenaShrinkages", std::to_string(self.shrink_count)},
+        {"InUse", "0"},
+        {"TotalAllocated", "0"},
+        {"MaxInUse", "0"},
+        {"Limit", "0"},
+        {"NumReserves", std::to_string(self.reserve_count)},
+        {"NumArenaExtensions", "0"},
+        {"MaxAllocSize", "0"},
+    });
+    *out = kvp.release();
+    return nullptr;
+  }
+
+  static OrtStatusPtr ORT_API_CALL ShrinkImpl(OrtAllocator* this_) noexcept {
+    auto& self = *static_cast<MockArenaOrtAllocator*>(this_);
+    if (self.shrink_should_fail) {
+      return OrtApis::CreateStatus(ORT_EP_FAIL, "Mock shrink failure");
+    }
+    self.shrink_count++;
+    return nullptr;
+  }
+};
+
+OrtMemoryInfo MockArenaOrtAllocator::mem_info_{"MockArena", OrtAllocatorType::OrtDeviceAllocator};
+}  // namespace
+
+TEST(AllocatorTest, IArenaWrapper_AsArenaReturnsThis) {
+  MockArenaOrtAllocator mock;
+  auto wrapper = std::make_shared<IArenaImplWrappingOrtAllocator>(
+      OrtAllocatorUniquePtr(&mock, [](OrtAllocator*) {}));
+
+  EXPECT_NE(wrapper->AsArena(), nullptr);
+  EXPECT_EQ(wrapper->AsArena(), wrapper.get());
+  EXPECT_EQ(IArena::SafeArenaCast(wrapper.get()), wrapper.get());
+}
+
+TEST(AllocatorTest, IArenaWrapper_AllocFreeReserve) {
+  MockArenaOrtAllocator mock;
+  auto wrapper = std::make_shared<IArenaImplWrappingOrtAllocator>(
+      OrtAllocatorUniquePtr(&mock, [](OrtAllocator*) {}));
+
+  void* p = wrapper->Alloc(256);
+  EXPECT_NE(p, nullptr);
+  EXPECT_EQ(mock.alloc_count, 1);
+
+  wrapper->Free(p);
+  EXPECT_EQ(mock.free_count, 1);
+
+  void* r = wrapper->Reserve(512);
+  EXPECT_NE(r, nullptr);
+  EXPECT_EQ(mock.reserve_count, 1);
+  wrapper->Free(r);
+}
+
+TEST(AllocatorTest, IArenaWrapper_ShrinkForwards) {
+  MockArenaOrtAllocator mock;
+  auto wrapper = std::make_shared<IArenaImplWrappingOrtAllocator>(
+      OrtAllocatorUniquePtr(&mock, [](OrtAllocator*) {}));
+
+  auto status = wrapper->Shrink();
+  EXPECT_TRUE(status.IsOK());
+  EXPECT_EQ(mock.shrink_count, 1);
+}
+
+TEST(AllocatorTest, IArenaWrapper_ShrinkPropagatesError) {
+  MockArenaOrtAllocator mock;
+  mock.shrink_should_fail = true;
+  auto wrapper = std::make_shared<IArenaImplWrappingOrtAllocator>(
+      OrtAllocatorUniquePtr(&mock, [](OrtAllocator*) {}));
+
+  auto status = wrapper->Shrink();
+  EXPECT_FALSE(status.IsOK());
+}
+
+TEST(AllocatorTest, IArenaWrapper_GetStatsRoundTrip) {
+  MockArenaOrtAllocator mock;
+  // Do some operations to populate counters
+  void* p = MockArenaOrtAllocator::AllocImpl(&mock, 100);
+  MockArenaOrtAllocator::FreeImpl(&mock, p);
+  void* r = MockArenaOrtAllocator::ReserveImpl(&mock, 200);
+  MockArenaOrtAllocator::FreeImpl(&mock, r);
+  MockArenaOrtAllocator::ShrinkImpl(&mock);
+
+  auto wrapper = std::make_shared<IArenaImplWrappingOrtAllocator>(
+      OrtAllocatorUniquePtr(&mock, [](OrtAllocator*) {}));
+
+  AllocatorStats stats{};
+  wrapper->GetStats(&stats);
+  EXPECT_EQ(stats.num_allocs, 1);
+  EXPECT_EQ(stats.num_reserves, 1);
+  EXPECT_EQ(stats.num_arena_shrinkages, 1);
+}
+
+TEST(AllocatorTest, IArenaWrapper_ReleaseStreamBuffersIsNoop) {
+  MockArenaOrtAllocator mock;
+  auto wrapper = std::make_shared<IArenaImplWrappingOrtAllocator>(
+      OrtAllocatorUniquePtr(&mock, [](OrtAllocator*) {}));
+
+  // Should not crash — ReleaseStreamBuffers is inherited no-op from IArena
+  wrapper->ReleaseStreamBuffers(nullptr);
+}
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/framework/ep_plugin_provider_test.cc
+++ b/onnxruntime/test/framework/ep_plugin_provider_test.cc
@@ -4,6 +4,7 @@
 #include "core/session/plugin_ep/ep_plugin_provider_interfaces.h"
 
 #include <algorithm>
+#include <cstring>
 #include <filesystem>
 #include <limits>
 #include "gsl/gsl"
@@ -876,11 +877,8 @@ TEST(OpSchemaTypeConstraintTest, Add_SingleConstraint) {
   // T should allow tensor(float) and tensor(double) among others
   auto allowed_types = tc.GetAllowedTypes();
   EXPECT_GT(allowed_types.size(), 1u);
-  auto has_type = [&](const char* t) {
-    return std::find(allowed_types.begin(), allowed_types.end(), t) != allowed_types.end();
-  };
-  EXPECT_TRUE(has_type("tensor(float)")) << "Expected T to allow tensor(float)";
-  EXPECT_TRUE(has_type("tensor(double)")) << "Expected T to allow tensor(double)";
+  EXPECT_THAT(allowed_types, ::testing::Contains("tensor(float)")) << "Expected T to allow tensor(float)";
+  EXPECT_THAT(allowed_types, ::testing::Contains("tensor(double)")) << "Expected T to allow tensor(double)";
 
   // Both inputs use T
   auto input_indices = tc.GetInputIndices();
@@ -921,22 +919,18 @@ TEST(OpSchemaTypeConstraintTest, LSTM_MultipleConstraints) {
   ASSERT_NE(t_ptr, nullptr) << "Expected to find type constraint 'T'";
   ASSERT_NE(t1_ptr, nullptr) << "Expected to find type constraint 'T1'";
 
-  auto has_type = [](gsl::span<const std::string> types, const char* t) {
-    return std::find(types.begin(), types.end(), t) != types.end();
-  };
-
   // T should include tensor(float) and tensor(double)
   auto t_types = t_tc.GetAllowedTypes();
   EXPECT_GT(t_types.size(), 0u);
-  EXPECT_TRUE(has_type(t_types, "tensor(float)")) << "Expected T to allow tensor(float)";
-  EXPECT_TRUE(has_type(t_types, "tensor(double)")) << "Expected T to allow tensor(double)";
+  EXPECT_THAT(t_types, ::testing::Contains("tensor(float)")) << "Expected T to allow tensor(float)";
+  EXPECT_THAT(t_types, ::testing::Contains("tensor(double)")) << "Expected T to allow tensor(double)";
 
   // T1 should include tensor(int32) (sequence_lens is int32)
   auto t1_types = t1_tc.GetAllowedTypes();
   EXPECT_GT(t1_types.size(), 0u);
 
   // T1 is for sequence_lens which is int32
-  EXPECT_TRUE(has_type(t1_types, "tensor(int32)")) << "Expected T1 to allow tensor(int32)";
+  EXPECT_THAT(t1_types, ::testing::Contains("tensor(int32)")) << "Expected T1 to allow tensor(int32)";
 
   // T should map to inputs X (0), W (1), R (2), B (3), initial_h (5), initial_c (6), P (7)
   auto t_inputs = t_tc.GetInputIndices();
@@ -1104,5 +1098,122 @@ TEST(PluginExecutionProviderTest, ProfilingEvent_ConstWrapper) {
   EXPECT_EQ(const_event.GetDurationUs(), 111);
 }
 #endif  // !defined(ORT_NO_EXCEPTIONS)
+
+// ---------------------------------------------------------------------------
+// Test that CreatePreferredAllocators wraps a Shrink-capable plugin allocator
+// as IArena (not just IAllocator), so ShrinkMemoryArenas can find it.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Minimal fake OrtAllocator with Shrink support.
+// Tracks Shrink calls via a counter.
+struct FakeArenaOrtAllocator : OrtAllocator {
+  int shrink_call_count = 0;
+  OrtMemoryInfo* mem_info = nullptr;
+};
+
+static void* ORT_API_CALL FakeAlloc(OrtAllocator*, size_t) noexcept { return nullptr; }
+static void ORT_API_CALL FakeFree(OrtAllocator*, void*) noexcept {}
+static const OrtMemoryInfo* ORT_API_CALL FakeInfo(const OrtAllocator* self) noexcept {
+  return static_cast<const FakeArenaOrtAllocator*>(self)->mem_info;
+}
+static OrtStatus* ORT_API_CALL FakeShrink(OrtAllocator* self) noexcept {
+  static_cast<FakeArenaOrtAllocator*>(self)->shrink_call_count++;
+  return nullptr;
+}
+static OrtStatus* ORT_API_CALL FakeGetStats(const OrtAllocator*, OrtKeyValuePairs** out) noexcept {
+  ::OrtGetApiBase()->GetApi(ORT_API_VERSION)->CreateKeyValuePairs(out);
+  return nullptr;
+}
+
+static FakeArenaOrtAllocator MakeFakeArenaAllocator(OrtMemoryInfo* mem_info, bool with_shrink = true) {
+  FakeArenaOrtAllocator fa{};
+  static_assert(std::is_standard_layout_v<OrtAllocator>);
+  std::memset(static_cast<OrtAllocator*>(&fa), 0, sizeof(OrtAllocator));
+  fa.version = ORT_API_VERSION;
+  fa.mem_info = mem_info;
+  fa.Alloc = FakeAlloc;
+  fa.Free = FakeFree;
+  fa.Info = FakeInfo;
+  fa.Shrink = with_shrink ? FakeShrink : nullptr;
+  fa.GetStats = FakeGetStats;
+  return fa;
+}
+
+// Namespace-level storage so C function pointers can access the fake allocator.
+static OrtAllocator* g_fake_allocator_for_test = nullptr;
+
+static OrtStatus* ORT_API_CALL FakeCreateAllocator(OrtEp*, const OrtMemoryInfo*,
+                                                   OrtAllocator** out) noexcept {
+  *out = g_fake_allocator_for_test;
+  return nullptr;
+}
+
+static void ORT_API_CALL FakeReleaseAllocator(OrtEpFactory*, OrtAllocator*) noexcept {
+  // No-op: tests own the fake allocator lifetime.
+}
+
+}  // namespace
+
+TEST(PluginExecutionProviderTest, CreatePreferredAllocators_ShrinkCapableAllocatorExposedAsArena) {
+  // Set up a device with device_memory_info so CreatePreferredAllocators iterates it.
+  auto ort_device = test_plugin_ep::MakeTestOrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT);
+  auto ort_memory_info = std::make_unique<OrtMemoryInfo>("FakeGPU", OrtAllocatorType::OrtDeviceAllocator,
+                                                         ort_device, OrtMemTypeDefault);
+
+  // Create the fake arena allocator with Shrink support.
+  auto fake_allocator = MakeFakeArenaAllocator(ort_memory_info.get(), /*with_shrink=*/true);
+  FakeArenaOrtAllocator* fake_alloc_ptr = &fake_allocator;
+
+  auto ort_hw_device = test_plugin_ep::MakeTestOrtHardwareDevice(OrtHardwareDeviceType_GPU);
+  auto ort_ep_device = test_plugin_ep::MakeTestOrtEpDevice(ort_hw_device.get(), ort_memory_info.get());
+  std::vector<const OrtEpDevice*> ep_devices{ort_ep_device.get()};
+
+  auto [ep, ort_ep] = test_plugin_ep::MakeTestOrtEp(ep_devices);
+
+  g_fake_allocator_for_test = fake_alloc_ptr;
+  ort_ep->CreateAllocator = FakeCreateAllocator;
+  test_plugin_ep::g_test_ort_ep_factory.ReleaseAllocator = FakeReleaseAllocator;
+
+  auto allocators = ep->CreatePreferredAllocators();
+  ASSERT_EQ(allocators.size(), 1u);
+
+  // The allocator supports Shrink, so it should be wrapped as IArena.
+  auto* arena = allocators[0]->AsArena();
+  ASSERT_NE(arena, nullptr) << "Shrink-capable plugin allocator must be exposed as IArena";
+
+  // Shrink should forward to the fake allocator's Shrink callback.
+  ASSERT_EQ(fake_alloc_ptr->shrink_call_count, 0);
+  auto status = arena->Shrink();
+  ASSERT_TRUE(status.IsOK());
+  EXPECT_EQ(fake_alloc_ptr->shrink_call_count, 1);
+}
+
+TEST(PluginExecutionProviderTest, CreatePreferredAllocators_NonShrinkAllocatorNotExposedAsArena) {
+  auto ort_device = test_plugin_ep::MakeTestOrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT);
+  auto ort_memory_info = std::make_unique<OrtMemoryInfo>("FakeGPU", OrtAllocatorType::OrtDeviceAllocator,
+                                                         ort_device, OrtMemTypeDefault);
+
+  auto fake_allocator = MakeFakeArenaAllocator(ort_memory_info.get(), /*with_shrink=*/false);
+  FakeArenaOrtAllocator* fake_alloc_ptr = &fake_allocator;
+
+  auto ort_hw_device = test_plugin_ep::MakeTestOrtHardwareDevice(OrtHardwareDeviceType_GPU);
+  auto ort_ep_device = test_plugin_ep::MakeTestOrtEpDevice(ort_hw_device.get(), ort_memory_info.get());
+  std::vector<const OrtEpDevice*> ep_devices{ort_ep_device.get()};
+
+  auto [ep, ort_ep] = test_plugin_ep::MakeTestOrtEp(ep_devices);
+
+  g_fake_allocator_for_test = fake_alloc_ptr;
+  ort_ep->CreateAllocator = FakeCreateAllocator;
+  test_plugin_ep::g_test_ort_ep_factory.ReleaseAllocator = FakeReleaseAllocator;
+
+  auto allocators = ep->CreatePreferredAllocators();
+  ASSERT_EQ(allocators.size(), 1u);
+
+  // Without Shrink, the allocator should NOT be exposed as IArena.
+  EXPECT_EQ(allocators[0]->AsArena(), nullptr)
+      << "Non-Shrink allocator must not be exposed as IArena";
+}
 
 }  // namespace onnxruntime::test

--- a/onnxruntime/test/framework/session_state_test.cc
+++ b/onnxruntime/test/framework/session_state_test.cc
@@ -662,6 +662,7 @@ class PrePackingTestOpKernel : public OpKernel {
   }
 
   Status UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                   gsl::span<const size_t> /*prepacked_buffer_sizes*/,
                                    int input_idx,
                                    /*out*/ bool& used_shared_buffers) override {
     ORT_UNUSED_PARAMETER(input_idx);

--- a/onnxruntime/test/onnx/TestCase.cc
+++ b/onnxruntime/test/onnx/TestCase.cc
@@ -1462,6 +1462,12 @@ std::unique_ptr<std::set<BrokenTest>> GetBrokenTests(const std::string& provider
     broken_tests->insert({"attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal_expanded", "unknown version"});
     broken_tests->insert({"attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal_expanded", "unknown version"});
     broken_tests->insert({"convinteger_with_padding", "unknown version"});
+    // Fails since ONNX==1.21.0
+    broken_tests->insert({"dft_irfft", "unknown version"});
+    broken_tests->insert({"dft_irfft_opset19", "unknown version"});
+    broken_tests->insert({"dft_rfft", "unknown version"});
+    broken_tests->insert({"dft_rfft_opset19", "unknown version"});
+    broken_tests->insert({"bitcast_bool_to_uint8", "ORT BitCast kernel does not register bool type"});
   }
 
 #ifdef DISABLE_CONTRIB_OPS

--- a/onnxruntime/test/opaque_api/test_opaque_api.cc
+++ b/onnxruntime/test/opaque_api/test_opaque_api.cc
@@ -118,10 +118,9 @@ ONNX_OPERATOR_KERNEL_EX(
   ONNX_TEST_OPERATOR_SCHEMA_UNIQ_HELPER(__COUNTER__, name)
 #define ONNX_TEST_OPERATOR_SCHEMA_UNIQ_HELPER(Counter, name) \
   ONNX_TEST_OPERATOR_SCHEMA_UNIQ(Counter, name)
-#define ONNX_TEST_OPERATOR_SCHEMA_UNIQ(Counter, name)            \
-  static ONNX_NAMESPACE::OpSchemaRegistry::OpSchemaRegisterOnce( \
-      op_schema_register_once##name##Counter) ONNX_UNUSED =      \
-      ONNX_NAMESPACE::OpSchema(#name, __FILE__, __LINE__)
+#define ONNX_TEST_OPERATOR_SCHEMA_UNIQ(Counter, name)                                                  \
+  static ONNX_NAMESPACE::OpSchemaRegistry::OpSchemaRegisterOnce op_schema_register_once##name##Counter \
+      [[maybe_unused]] = ONNX_NAMESPACE::OpSchema(#name, __FILE__, __LINE__)
 
 static void RegisterCustomKernel() {
   // Register our custom type

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -4757,7 +4757,7 @@ TEST_F(GraphTransformationTests, ReshapeFusion_Contiguous_Reshape) {
   auto build_test_case = [&](ModelTestBuilder& builder) {
     auto* input_arg = builder.MakeInput<float>({{8, 16, 32}});
     auto* shape_initializer_1 = builder.MakeInitializer<int64_t>({4}, {2, 4, 16, 32});
-    auto* shape_initializer_2 = builder.MakeInitializer<int64_t>({4}, {2, 64, 32});
+    auto* shape_initializer_2 = builder.MakeInitializer<int64_t>({3}, {2, 64, 32});
     auto* axes_initializer = builder.MakeInitializer<int64_t>({1}, {1});
     auto* reshape_out_1 = builder.MakeIntermediate();
     auto* reshape_out_2 = builder.MakeIntermediate();
@@ -5824,6 +5824,363 @@ TEST_F(GraphTransformationTests, AttentionFusionDistilBertTest) {
   EXPECT_EQ(op_to_count["Transpose"], 0);
   EXPECT_EQ(op_to_count["Softmax"], 0);
   EXPECT_EQ(op_to_count["Shape"], 0);
+}
+
+enum class MobileClipProjectionType {
+  MatMulAdd,
+  GemmWithReshapes,
+};
+
+struct MobileClipAttentionShapeConfig {
+  int64_t input_channels = 512;
+  int64_t hidden_size = 512;
+  int64_t num_heads = 16;
+  int64_t head_size = 32;
+  int64_t qkv_weight_input_dim = 512;
+};
+
+static void BuildMobileClipAttentionTestCase(ModelTestBuilder& builder,
+                                             MobileClipProjectionType projection_type,
+                                             const MobileClipAttentionShapeConfig& shape_config = {},
+                                             bool use_non_default_projection_gemm_attributes = false,
+                                             bool use_runtime_projection_shape_input = false) {
+  const int64_t input_channels = shape_config.input_channels;
+  const int64_t hidden_size = shape_config.hidden_size;
+  const int64_t num_heads = shape_config.num_heads;
+  const int64_t head_size = shape_config.head_size;
+  const int64_t qkv_weight_input_dim = shape_config.qkv_weight_input_dim;
+  const int64_t qkv_hidden_size = num_heads * head_size;
+  const int64_t qkv_output_size = 3 * qkv_hidden_size;
+
+  auto* input_x = builder.MakeInput<float>({1, input_channels, 8, 8}, -1.0f, 1.0f);
+  auto* input_skip = builder.MakeInput<float>({1, hidden_size, 8, 8}, -1.0f, 1.0f);
+
+  auto* reshape0_shape = builder.Make1DInitializer<int64_t>({1, input_channels, 64});
+  auto* qkv_weight = builder.MakeInitializer<float>({qkv_weight_input_dim, qkv_output_size}, -0.05f, 0.05f);
+  auto* qkv_reshape_shape = builder.Make1DInitializer<int64_t>({1, 64, 3, num_heads, head_size});
+  auto* split_sizes = builder.Make1DInitializer<int64_t>({1, 1, 1});
+  auto* squeeze_axis_0 = builder.Make1DInitializer<int64_t>({0});
+  auto* squeeze_axis_2 = builder.Make1DInitializer<int64_t>({2});
+  auto* scale = builder.MakeScalarInitializer<float>(1.0f / std::sqrt(static_cast<float>(head_size)));
+  auto* reshape2_shape = use_runtime_projection_shape_input
+                             ? builder.MakeInput<int64_t>({3}, {1, 64, hidden_size})
+                             : builder.Make1DInitializer<int64_t>({1, 64, hidden_size});
+  auto* proj_gemm_input_shape = builder.Make1DInitializer<int64_t>({64, hidden_size});
+  auto* proj_weight = builder.MakeInitializer<float>({hidden_size, hidden_size}, -0.05f, 0.05f);
+  auto* proj_bias = builder.MakeInitializer<float>({hidden_size}, -0.02f, 0.02f);
+  auto* proj_gemm_output_shape = builder.Make1DInitializer<int64_t>({1, 64, hidden_size});
+  auto* reshape3_shape = builder.Make1DInitializer<int64_t>({1, hidden_size, 8, 8});
+  auto* layer_scale = builder.MakeInitializer<float>({hidden_size, 1, 1}, 0.9f, 1.1f);
+
+  auto* reshape0_out = builder.MakeIntermediate<float>(std::vector<int64_t>{1, input_channels, 64});
+  auto* transpose0_out = builder.MakeIntermediate<float>(std::vector<int64_t>{1, 64, input_channels});
+  auto* qkv_out = builder.MakeIntermediate<float>(std::vector<int64_t>{1, 64, qkv_output_size});
+  auto* qkv_reshape_out = builder.MakeIntermediate<float>(std::vector<int64_t>{1, 64, 3, num_heads, head_size});
+  auto* split_q = builder.MakeIntermediate<float>(std::vector<int64_t>{1, 64, 1, num_heads, head_size});
+  auto* split_k = builder.MakeIntermediate<float>(std::vector<int64_t>{1, 64, 1, num_heads, head_size});
+  auto* split_v = builder.MakeIntermediate<float>(std::vector<int64_t>{1, 64, 1, num_heads, head_size});
+  auto* q_transpose_out = builder.MakeIntermediate<float>(std::vector<int64_t>{1, 1, num_heads, 64, head_size});
+  auto* q_squeeze_out = builder.MakeIntermediate<float>(std::vector<int64_t>{1, num_heads, 64, head_size});
+  auto* k_squeeze_out = builder.MakeIntermediate<float>(std::vector<int64_t>{1, 64, num_heads, head_size});
+  auto* k_transpose_out = builder.MakeIntermediate<float>(std::vector<int64_t>{1, num_heads, head_size, 64});
+  auto* q_scaled_out = builder.MakeIntermediate<float>(std::vector<int64_t>{1, num_heads, 64, head_size});
+  auto* qk_out = builder.MakeIntermediate<float>(std::vector<int64_t>{1, num_heads, 64, 64});
+  auto* softmax_out = builder.MakeIntermediate<float>(std::vector<int64_t>{1, num_heads, 64, 64});
+  auto* v_transpose_out = builder.MakeIntermediate<float>(std::vector<int64_t>{1, 1, num_heads, 64, head_size});
+  auto* v_squeeze_out = builder.MakeIntermediate<float>(std::vector<int64_t>{1, num_heads, 64, head_size});
+  auto* attn_out = builder.MakeIntermediate<float>(std::vector<int64_t>{1, num_heads, 64, head_size});
+  auto* transpose3_out = builder.MakeIntermediate<float>(std::vector<int64_t>{1, 64, num_heads, head_size});
+  auto* reshape2_out = use_runtime_projection_shape_input
+                           ? builder.MakeIntermediate<float>(std::nullopt)
+                           : builder.MakeIntermediate<float>(std::vector<int64_t>{1, 64, hidden_size});
+  auto* proj_gemm_input_out = builder.MakeIntermediate<float>(std::vector<int64_t>{64, hidden_size});
+  auto* proj_gemm_out = builder.MakeIntermediate<float>(std::vector<int64_t>{64, hidden_size});
+  auto* proj_linear_out = builder.MakeIntermediate<float>(std::vector<int64_t>{1, 64, hidden_size});
+  auto* transpose4_out = builder.MakeIntermediate<float>(std::vector<int64_t>{1, hidden_size, 64});
+  auto* reshape3_out = builder.MakeIntermediate<float>(std::vector<int64_t>{1, hidden_size, 8, 8});
+  auto* layer_scale_out = builder.MakeIntermediate<float>(std::vector<int64_t>{1, hidden_size, 8, 8});
+  auto* output = builder.MakeOutput<float>(std::vector<int64_t>{1, hidden_size, 8, 8});
+
+  auto& reshape0 = builder.AddNode("Reshape", std::vector<NodeArg*>{input_x, reshape0_shape}, std::vector<NodeArg*>{reshape0_out});
+  reshape0.AddAttribute("allowzero", static_cast<int64_t>(0));
+
+  auto& transpose0 = builder.AddNode("Transpose", std::vector<NodeArg*>{reshape0_out}, std::vector<NodeArg*>{transpose0_out});
+  transpose0.AddAttribute("perm", std::vector<int64_t>{0, 2, 1});
+
+  builder.AddNode("MatMul", std::vector<NodeArg*>{transpose0_out, qkv_weight}, std::vector<NodeArg*>{qkv_out});
+
+  auto& qkv_reshape = builder.AddNode("Reshape", std::vector<NodeArg*>{qkv_out, qkv_reshape_shape}, std::vector<NodeArg*>{qkv_reshape_out});
+  qkv_reshape.AddAttribute("allowzero", static_cast<int64_t>(0));
+
+  auto& split = builder.AddNode("Split", std::vector<NodeArg*>{qkv_reshape_out, split_sizes}, std::vector<NodeArg*>{split_q, split_k, split_v});
+  split.AddAttribute("axis", static_cast<int64_t>(2));
+
+  auto& q_transpose = builder.AddNode("Transpose", std::vector<NodeArg*>{split_q}, std::vector<NodeArg*>{q_transpose_out});
+  q_transpose.AddAttribute("perm", std::vector<int64_t>{2, 0, 3, 1, 4});
+
+  builder.AddNode("Squeeze", std::vector<NodeArg*>{q_transpose_out, squeeze_axis_0}, std::vector<NodeArg*>{q_squeeze_out});
+  builder.AddNode("Squeeze", std::vector<NodeArg*>{split_k, squeeze_axis_2}, std::vector<NodeArg*>{k_squeeze_out});
+
+  auto& k_transpose = builder.AddNode("Transpose", std::vector<NodeArg*>{k_squeeze_out}, std::vector<NodeArg*>{k_transpose_out});
+  k_transpose.AddAttribute("perm", std::vector<int64_t>{0, 2, 3, 1});
+
+  builder.AddNode("Mul", std::vector<NodeArg*>{q_squeeze_out, scale}, std::vector<NodeArg*>{q_scaled_out});
+  builder.AddNode("MatMul", std::vector<NodeArg*>{q_scaled_out, k_transpose_out}, std::vector<NodeArg*>{qk_out});
+
+  auto& softmax = builder.AddNode("Softmax", std::vector<NodeArg*>{qk_out}, std::vector<NodeArg*>{softmax_out});
+  softmax.AddAttribute("axis", static_cast<int64_t>(-1));
+
+  auto& v_transpose = builder.AddNode("Transpose", std::vector<NodeArg*>{split_v}, std::vector<NodeArg*>{v_transpose_out});
+  v_transpose.AddAttribute("perm", std::vector<int64_t>{2, 0, 3, 1, 4});
+
+  builder.AddNode("Squeeze", std::vector<NodeArg*>{v_transpose_out, squeeze_axis_0}, std::vector<NodeArg*>{v_squeeze_out});
+  builder.AddNode("MatMul", std::vector<NodeArg*>{softmax_out, v_squeeze_out}, std::vector<NodeArg*>{attn_out});
+
+  auto& transpose3 = builder.AddNode("Transpose", std::vector<NodeArg*>{attn_out}, std::vector<NodeArg*>{transpose3_out});
+  transpose3.AddAttribute("perm", std::vector<int64_t>{0, 2, 1, 3});
+
+  auto& reshape2 = builder.AddNode("Reshape", std::vector<NodeArg*>{transpose3_out, reshape2_shape}, std::vector<NodeArg*>{reshape2_out});
+  reshape2.AddAttribute("allowzero", static_cast<int64_t>(0));
+
+  if (projection_type == MobileClipProjectionType::GemmWithReshapes) {
+    auto& proj_gemm_input = builder.AddNode("Reshape", std::vector<NodeArg*>{reshape2_out, proj_gemm_input_shape},
+                                            std::vector<NodeArg*>{proj_gemm_input_out});
+    proj_gemm_input.AddAttribute("allowzero", static_cast<int64_t>(0));
+
+    auto& proj_gemm = builder.AddNode("Gemm", std::vector<NodeArg*>{proj_gemm_input_out, proj_weight, proj_bias},
+                                      std::vector<NodeArg*>{proj_gemm_out});
+    if (use_non_default_projection_gemm_attributes) {
+      proj_gemm.AddAttribute("transB", static_cast<int64_t>(1));
+    }
+
+    auto& proj_gemm_output = builder.AddNode("Reshape", std::vector<NodeArg*>{proj_gemm_out, proj_gemm_output_shape},
+                                             std::vector<NodeArg*>{proj_linear_out});
+    proj_gemm_output.AddAttribute("allowzero", static_cast<int64_t>(0));
+  } else {
+    auto* proj_matmul_out = builder.MakeIntermediate<float>(std::vector<int64_t>{1, 64, hidden_size});
+    builder.AddNode("MatMul", std::vector<NodeArg*>{reshape2_out, proj_weight}, std::vector<NodeArg*>{proj_matmul_out});
+    builder.AddNode("Add", std::vector<NodeArg*>{proj_bias, proj_matmul_out}, std::vector<NodeArg*>{proj_linear_out});
+  }
+
+  auto& transpose4 = builder.AddNode("Transpose", std::vector<NodeArg*>{proj_linear_out}, std::vector<NodeArg*>{transpose4_out});
+  transpose4.AddAttribute("perm", std::vector<int64_t>{0, 2, 1});
+
+  auto& reshape3 = builder.AddNode("Reshape", std::vector<NodeArg*>{transpose4_out, reshape3_shape}, std::vector<NodeArg*>{reshape3_out});
+  reshape3.AddAttribute("allowzero", static_cast<int64_t>(0));
+
+  builder.AddNode("Mul", std::vector<NodeArg*>{layer_scale, reshape3_out}, std::vector<NodeArg*>{layer_scale_out});
+  builder.AddNode("Add", std::vector<NodeArg*>{input_skip, layer_scale_out}, std::vector<NodeArg*>{output});
+}
+
+static Status CheckMobileClipAttentionFusedGraph(Graph& graph) {
+  auto op_to_count = CountOpsInGraph(graph);
+  TEST_RETURN_IF_NOT(op_to_count["com.microsoft.MultiHeadAttention"] == 1);
+  TEST_RETURN_IF_NOT(op_to_count["Gemm"] == 1);
+  TEST_RETURN_IF_NOT(op_to_count["Softmax"] == 0);
+  TEST_RETURN_IF_NOT(op_to_count["Squeeze"] == 0);
+  TEST_RETURN_IF_NOT(op_to_count["Split"] == 1);
+  TEST_RETURN_IF_NOT(op_to_count["MatMul"] == 1);
+  TEST_RETURN_IF_NOT(op_to_count["Transpose"] == 2);
+  TEST_RETURN_IF_NOT(op_to_count["Reshape"] == 4);
+  TEST_RETURN_IF_NOT(op_to_count["Mul"] == 1);
+  TEST_RETURN_IF_NOT(op_to_count["Add"] == 1);
+
+  int mha_nodes = 0;
+  int gemm_nodes = 0;
+  int split_nodes = 0;
+  for (Node& node : graph.Nodes()) {
+    if (node.OpType() == "MultiHeadAttention" && node.Domain() == kMSDomain) {
+      ++mha_nodes;
+      TEST_RETURN_IF_NOT(node.GetAttributes().at("num_heads").i() == 16);
+      TEST_RETURN_IF_NOT(std::abs(node.GetAttributes().at("scale").f() - (1.0f / std::sqrt(32.0f))) < 1e-6f);
+      TEST_RETURN_IF_NOT(node.OutputDefs().size() == 1);
+      TEST_RETURN_IF_NOT(node.OutputDefs()[0]->Shape() != nullptr);
+      TEST_RETURN_IF_NOT(node.OutputDefs()[0]->Shape()->dim_size() == 3);
+    } else if (node.OpType() == "Split") {
+      ++split_nodes;
+    } else if (node.OpType() == "Gemm") {
+      ++gemm_nodes;
+      TEST_RETURN_IF_NOT(node.InputDefs().size() == 3);
+      TEST_RETURN_IF_NOT(node.OutputDefs().size() == 1);
+      TEST_RETURN_IF_NOT(node.InputDefs()[0]->Shape() != nullptr);
+      TEST_RETURN_IF_NOT(node.InputDefs()[0]->Shape()->dim_size() == 2);
+      TEST_RETURN_IF_NOT(node.OutputDefs()[0]->Shape() != nullptr);
+      TEST_RETURN_IF_NOT(node.OutputDefs()[0]->Shape()->dim_size() == 2);
+
+      const Node* gemm_input_node = graph_utils::GetInputNode(node, 0);
+      TEST_RETURN_IF_NOT(gemm_input_node != nullptr);
+      TEST_RETURN_IF_NOT(gemm_input_node->OpType() == "Reshape");
+
+      bool has_output_reshape = false;
+      for (const Node& consumer : graph.Nodes()) {
+        for (const NodeArg* input_def : consumer.InputDefs()) {
+          if (input_def != nullptr && input_def->Name() == node.OutputDefs()[0]->Name()) {
+            has_output_reshape = consumer.OpType() == "Reshape";
+            break;
+          }
+        }
+
+        if (has_output_reshape) {
+          break;
+        }
+      }
+
+      TEST_RETURN_IF_NOT(has_output_reshape);
+    }
+  }
+
+  TEST_RETURN_IF_NOT(mha_nodes == 1);
+  TEST_RETURN_IF_NOT(gemm_nodes == 1);
+  TEST_RETURN_IF_NOT(split_nodes == 1);
+  return Status::OK();
+}
+
+static Status CheckMobileClipAttentionFusedGraphOnProvider(Graph& graph, const char* provider) {
+  ORT_RETURN_IF_ERROR(CheckMobileClipAttentionFusedGraph(graph));
+
+  for (Node& node : graph.Nodes()) {
+    TEST_RETURN_IF_NOT(node.GetExecutionProviderType() == provider);
+  }
+
+  return Status::OK();
+}
+
+static Status CheckMobileClipAttentionUnfusedProjectionGemmGraph(Graph& graph) {
+  auto op_to_count = CountOpsInGraph(graph);
+  TEST_RETURN_IF_NOT(op_to_count["com.microsoft.MultiHeadAttention"] == 0);
+  TEST_RETURN_IF_NOT(op_to_count["Gemm"] == 1);
+  TEST_RETURN_IF_NOT(op_to_count["Softmax"] == 1);
+  TEST_RETURN_IF_NOT(op_to_count["Squeeze"] == 3);
+  TEST_RETURN_IF_NOT(op_to_count["Split"] == 1);
+  TEST_RETURN_IF_NOT(op_to_count["MatMul"] == 3);
+  TEST_RETURN_IF_NOT(op_to_count["Transpose"] == 6);
+  TEST_RETURN_IF_NOT(op_to_count["Reshape"] == 6);
+  TEST_RETURN_IF_NOT(op_to_count["Mul"] == 2);
+  TEST_RETURN_IF_NOT(op_to_count["Add"] == 1);
+
+  int gemm_nodes = 0;
+  for (Node& node : graph.Nodes()) {
+    if (node.OpType() != "Gemm") {
+      continue;
+    }
+
+    ++gemm_nodes;
+    const auto& attrs = node.GetAttributes();
+    auto trans_b_attr = attrs.find("transB");
+    TEST_RETURN_IF_NOT(trans_b_attr != attrs.end());
+    TEST_RETURN_IF_NOT(trans_b_attr->second.i() == 1);
+  }
+
+  TEST_RETURN_IF_NOT(gemm_nodes == 1);
+  return Status::OK();
+}
+
+static Status CheckMobileClipAttentionUnfusedMatMulGraph(Graph& graph) {
+  auto op_to_count = CountOpsInGraph(graph);
+  TEST_RETURN_IF_NOT(op_to_count["com.microsoft.MultiHeadAttention"] == 0);
+  TEST_RETURN_IF_NOT(op_to_count["Gemm"] == 0);
+  TEST_RETURN_IF_NOT(op_to_count["Softmax"] == 1);
+  TEST_RETURN_IF_NOT(op_to_count["Squeeze"] == 3);
+  TEST_RETURN_IF_NOT(op_to_count["Split"] == 1);
+  TEST_RETURN_IF_NOT(op_to_count["MatMul"] == 4);
+  TEST_RETURN_IF_NOT(op_to_count["Transpose"] == 6);
+  TEST_RETURN_IF_NOT(op_to_count["Reshape"] == 4);
+  TEST_RETURN_IF_NOT(op_to_count["Mul"] == 2);
+  TEST_RETURN_IF_NOT(op_to_count["Add"] == 2);
+  return Status::OK();
+}
+
+TEST_F(GraphTransformationTests, AttentionFusionMobileClipMhaTest) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildMobileClipAttentionTestCase(builder, MobileClipProjectionType::MatMulAdd);
+  };
+
+  ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 14, *logger_, std::make_unique<AttentionFusion>(),
+                                        TransformerLevel::Level2, 1, nullptr, CheckMobileClipAttentionFusedGraph));
+}
+
+TEST_F(GraphTransformationTests, AttentionFusionMobileClipMhaProjectionGemmTest) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildMobileClipAttentionTestCase(builder, MobileClipProjectionType::GemmWithReshapes);
+  };
+
+  ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 14, *logger_, std::make_unique<AttentionFusion>(),
+                                        TransformerLevel::Level2, 1, nullptr, CheckMobileClipAttentionFusedGraph));
+}
+
+TEST_F(GraphTransformationTests, AttentionFusionMobileClipMhaCudaEpTest) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildMobileClipAttentionTestCase(builder, MobileClipProjectionType::MatMulAdd);
+  };
+
+  auto pre_graph_checker = [](Graph& graph) {
+    for (Node& node : graph.Nodes()) {
+      node.SetExecutionProviderType(kCudaExecutionProvider);
+    }
+
+    return Status::OK();
+  };
+
+  auto post_graph_checker = [](Graph& graph) {
+    return CheckMobileClipAttentionFusedGraphOnProvider(graph, kCudaExecutionProvider);
+  };
+
+  ASSERT_STATUS_OK(TestGraphTransformer(
+      build_test_case, 14, *logger_, std::make_unique<AttentionFusion>(InlinedHashSet<std::string_view>{kCudaExecutionProvider}),
+      TransformerLevel::Level2, 1, pre_graph_checker, post_graph_checker));
+}
+
+TEST_F(GraphTransformationTests, AttentionFusionMobileClipMhaProjectionGemmCudaEpTest) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildMobileClipAttentionTestCase(builder, MobileClipProjectionType::GemmWithReshapes);
+  };
+
+  auto pre_graph_checker = [](Graph& graph) {
+    for (Node& node : graph.Nodes()) {
+      node.SetExecutionProviderType(kCudaExecutionProvider);
+    }
+
+    return Status::OK();
+  };
+
+  auto post_graph_checker = [](Graph& graph) {
+    return CheckMobileClipAttentionFusedGraphOnProvider(graph, kCudaExecutionProvider);
+  };
+
+  ASSERT_STATUS_OK(TestGraphTransformer(
+      build_test_case, 14, *logger_, std::make_unique<AttentionFusion>(InlinedHashSet<std::string_view>{kCudaExecutionProvider}),
+      TransformerLevel::Level2, 1, pre_graph_checker, post_graph_checker));
+}
+
+TEST_F(GraphTransformationTests, AttentionFusionMobileClipMhaInvalidQkvWeightShapeTest) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildMobileClipAttentionTestCase(builder,
+                                     MobileClipProjectionType::MatMulAdd,
+                                     MobileClipAttentionShapeConfig{512, 510, 15, 34, 512});
+  };
+
+  ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 14, *logger_, std::make_unique<AttentionFusion>(),
+                                        TransformerLevel::Level2, 1, nullptr, CheckMobileClipAttentionUnfusedMatMulGraph));
+}
+
+TEST_F(GraphTransformationTests, AttentionFusionMobileClipMhaProjectionGemmNonDefaultAttributesTest) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildMobileClipAttentionTestCase(builder, MobileClipProjectionType::GemmWithReshapes, {}, true);
+  };
+
+  ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 14, *logger_, std::make_unique<AttentionFusion>(),
+                                        TransformerLevel::Level2, 1, nullptr,
+                                        CheckMobileClipAttentionUnfusedProjectionGemmGraph));
+}
+
+TEST_F(GraphTransformationTests, AttentionFusionMobileClipMhaProjectionRewriteFailureLeavesGraphUnfusedTest) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildMobileClipAttentionTestCase(builder, MobileClipProjectionType::MatMulAdd, {}, false, true);
+  };
+
+  ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 14, *logger_, std::make_unique<AttentionFusion>(),
+                                        TransformerLevel::Level2, 1, nullptr,
+                                        CheckMobileClipAttentionUnfusedMatMulGraph));
 }
 
 TEST_F(GraphTransformationTests, GeluFusionTest) {

--- a/onnxruntime/test/providers/cpu/llm/attention_op_test.cc
+++ b/onnxruntime/test/providers/cpu/llm/attention_op_test.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <cassert>
+#include <limits>
 #include "gtest/gtest.h"
 #include "core/session/onnxruntime_cxx_api.h"
 #include "test/common/tensor_op_test_utils.h"
@@ -513,9 +514,13 @@ TEST(AttentionTest, Attention4DAttnMaskBoolAllFalse) {
   );
 }
 
-// Regression test: all-false bool mask in decode mode (past_sequence_length > 0).
-// Before the fix: seq_len=0 + negative seqlen_offset produced negative seqlens_k → UB/crash.
-// After the fix: clamped to max(0, ...) → uniform softmax → mean of V values.
+// Regression guard: all-false bool mask in decode mode (past_sequence_length > 0).
+// Guards against a bug where fully-masked batches produce NaN or incorrect output.
+// Expected behavior: uniform softmax over past KV values produces Y = mean-of-V.
+// With past_v = [10,20,30,40] and [20,40,60,80] per head, and all positions masked out,
+// softmax(all -inf + constant mask_filter_value) → uniform weights → Y = {25, 50}.
+// This test originally came from upstream/main and validates that both CPU and CUDA
+// (unfused path) handle the all-false mask case identically.
 TEST(AttentionTest, Attention4DAttnMaskBoolAllFalseDecodeWithPast) {
   int batch_size = 1;
   int q_num_heads = 2;
@@ -575,9 +580,11 @@ TEST(AttentionTest, Attention4DAttnMaskBoolAllFalseDecodeWithPast) {
       0.8f, 0.8f, 0.8f, 0.8f, 0.8f, 0.8f, 0.8f, 0.8f};
 
   // With all-false mask, softmax produces uniform weights: 1/4 per position.
-  // Output = mean of V rows (past_value concat new_v):
+  // Standard concat places new token at past_sequence_length, so present_value =
+  // [past_v[0], past_v[1], past_v[2], new_v]. Output = mean of all V rows:
   //   head 0: mean(0.1, 0.2, 0.3, 0.4) = 0.25
   //   head 1: mean(0.5, 0.6, 0.7, 0.8) = 0.65
+  // These values match upstream/main behavior (unfused standard concat path).
   std::vector<float> y = {
       // head 0
       0.25f, 0.25f, 0.25f, 0.25f, 0.25f, 0.25f, 0.25f, 0.25f,
@@ -602,9 +609,9 @@ TEST(AttentionTest, Attention4DAttnMaskBoolAllFalseDecodeWithPast) {
   );
 }
 
-// Flash decode path with fp16 and all-true bool attention mask.
-// Exercises LaunchConcatNewToPastKV + mha_fwd_kvcache(k_new=nullptr) with mask.
-// head_size=64 is Flash-eligible. Uniform keys make output analytically verifiable:
+// Unfused decode path with fp16 and all-true bool attention mask.
+// Flash rejects attn_mask (requires attn_mask==nullptr), so CUDA routes to unfused.
+// head_size=64. Uniform keys make output analytically verifiable:
 // all attention scores are equal, so softmax is uniform over all positions.
 TEST(AttentionTest, Attention4DAttnMaskBoolDecodeWithPastFloat16) {
   int batch_size = 1;
@@ -686,17 +693,13 @@ TEST(AttentionTest, Attention4DAttnMaskBoolDecodeWithPastFloat16) {
   );
 }
 
-// Flash decode path with fp16 and partial bool mask (CUDA-only, direct OpTester).
-// mask [T,T,T,F] → Flash counts 3 leading trues, past_seqlens=2, new token at position 2.
-// Flash attends to [past[0], past[1], new_token] → Y = mean of those 3.
-// Uses direct OpTester for per-output tolerance: present_key/value position 3 may be
-// uninitialized (concat kernel only fills past_seqlens+1 positions).
-// CUDA-only because Flash's seqlens_k mask semantics differ from CPU's element-wise mask.
+// Decode with partial bool mask [T,T,T,F]: the new token is masked out.
+// With mask [T,T,T,F] past_seq=3 total=4: only positions 0,1,2 are attended (past only).
+// Flash is ineligible (bool+past_key rejected), so CUDA uses unfused which handles this
+// spec-correctly via standard ConcatPastToPresent + element-wise mask application.
+// Y = uniform mean over the 3 attended past values (Q=K=constant → uniform softmax).
+// CPU always runs; CUDA runs when SM 5.3+ is available.
 TEST(AttentionTest, Attention4DAttnMaskBoolPartialMaskDecodeFloat16) {
-  if (!HasCudaEnvironment(530)) {
-    return;  // fp16 requires SM 5.3+
-  }
-
   int batch_size = 1;
   int q_num_heads = 2;
   int q_sequence_length = 1;
@@ -727,21 +730,26 @@ TEST(AttentionTest, Attention4DAttnMaskBoolPartialMaskDecodeFloat16) {
                     v_head_size, pv[h][s]);
   }
 
-  // Y: uniform 1/3 over [past_v[0], past_v[1], v_new]
-  //   head 0: (0.1 + 0.2 + 0.4) / 3 = 7/30
-  //   head 1: (0.5 + 0.6 + 0.8) / 3 = 19/30
+  // Y: uniform 1/3 over past values [past_v[0], past_v[1], past_v[2]] (new token masked out).
+  //   head 0: (0.1 + 0.2 + 0.3) / 3 = 0.2
+  //   head 1: (0.5 + 0.6 + 0.7) / 3 = 0.6
   std::vector<float> y(batch_size * q_num_heads * q_sequence_length * v_head_size);
   {
-    float y_per_head[] = {7.0f / 30.0f, 19.0f / 30.0f};
+    float y_per_head[] = {0.2f, 0.6f};
     for (int h = 0; h < q_num_heads; ++h)
       std::fill_n(y.begin() + h * v_head_size, v_head_size, y_per_head[h]);
   }
 
-  // Skip present_key/value validation: trailing positions beyond valid tokens are
-  // intentionally uninitialized for performance (Flash respects seqlens_k bounds).
-  // Other tests (AllTrueMask, UnfusedPrompt) verify present_key/value for fully-valid cases.
-  // We must still declare these outputs (required when past_key is provided), but use
-  // placeholder values — the op validates shapes, not content, for optional outputs.
+  // present_key/value: standard concat — all past rows + new at position past_sequence_length.
+  std::vector<float> present_key(batch_size * kv_num_heads * total_sequence_length * head_size, 0.5f);
+  std::vector<float> present_value(batch_size * kv_num_heads * total_sequence_length * v_head_size);
+  {
+    float pv_expected[2][4] = {{0.1f, 0.2f, 0.3f, 0.4f}, {0.5f, 0.6f, 0.7f, 0.8f}};
+    for (int h = 0; h < kv_num_heads; ++h)
+      for (int s = 0; s < total_sequence_length; ++s)
+        std::fill_n(present_value.begin() + (h * total_sequence_length + s) * v_head_size,
+                    v_head_size, pv_expected[h][s]);
+  }
 
   OpTester test("Attention", 23, onnxruntime::kOnnxDomain);
   test.AddInput<MLFloat16>("Q", {batch_size, q_num_heads, q_sequence_length, head_size}, ToFloat16(q));
@@ -751,92 +759,33 @@ TEST(AttentionTest, Attention4DAttnMaskBoolPartialMaskDecodeFloat16) {
   test.AddInput<MLFloat16>("past_key", {batch_size, kv_num_heads, past_sequence_length, head_size}, ToFloat16(past_key));
   test.AddInput<MLFloat16>("past_value", {batch_size, kv_num_heads, past_sequence_length, v_head_size}, ToFloat16(past_value));
 
-  // Declare all 3 outputs (required for graph construction). present_key/value use
-  // placeholder expected data — actual validation is done by the custom verifier below.
   test.AddOutput<MLFloat16>("Y", {batch_size, q_num_heads, q_sequence_length, v_head_size},
                             ToFloat16(y));
-  std::vector<float> present_key_placeholder(batch_size * kv_num_heads * total_sequence_length * head_size, 0.0f);
-  std::vector<float> present_value_placeholder(batch_size * kv_num_heads * total_sequence_length * v_head_size, 0.0f);
   test.AddOutput<MLFloat16>("present_key", {batch_size, kv_num_heads, total_sequence_length, head_size},
-                            ToFloat16(present_key_placeholder));
+                            ToFloat16(present_key));
   test.AddOutput<MLFloat16>("present_value", {batch_size, kv_num_heads, total_sequence_length, v_head_size},
-                            ToFloat16(present_value_placeholder));
+                            ToFloat16(present_value));
 
-  // Custom verifier: validate Y and present_key/value prefix (NaN-safe for uninitialized tail).
-  // With mask [T,T,T,F] and seqlen_offset=-1: past_seqlens=2, valid positions=[0,3), position 3 uninitialized.
-  auto expected_y_fp16 = ToFloat16(y);
-  const int valid_seq_positions = 3;  // past_seqlens(2) + kv_sequence_length(1)
-  test.SetCustomOutputVerifier(
-      [&](const std::vector<OrtValue>& fetches, const std::string& provider_type) {
-        ASSERT_GE(fetches.size(), 3u) << "Expected 3 outputs, provider: " << provider_type;
+  test.SetOutputAbsErr("Y", 3e-3f);
+  test.SetOutputAbsErr("present_key", 1e-3f);
+  test.SetOutputAbsErr("present_value", 1e-3f);
 
-        // Validate Y (output 0).
-        const auto& y_tensor = fetches[0].Get<Tensor>();
-        auto y_span = y_tensor.DataAsSpan<MLFloat16>();
-        ASSERT_EQ(y_span.size(), expected_y_fp16.size()) << "Y size mismatch, provider: " << provider_type;
-        for (size_t i = 0; i < y_span.size(); ++i) {
-          ASSERT_NEAR(y_span[i].ToFloat(), expected_y_fp16[i].ToFloat(), 3e-3f)
-              << "Y mismatch at " << i << ", provider: " << provider_type;
-        }
-
-        // Validate present_key prefix (output 1): positions [0, valid_seq_positions) in BNSH layout.
-        // past_seqlens=2 rows from past_key, then 1 row from k. Position 3 is uninitialized (skip).
-        const int past_seqlens = valid_seq_positions - kv_sequence_length;  // = 2
-        {
-          auto pk_span = fetches[1].Get<Tensor>().DataAsSpan<MLFloat16>();
-          for (int h = 0; h < kv_num_heads; ++h) {
-            int present_h = h * total_sequence_length * head_size;
-            int past_h = h * past_sequence_length * head_size;
-            // Check past rows [0, past_seqlens)
-            for (int s = 0; s < past_seqlens; ++s)
-              for (int d = 0; d < head_size; ++d)
-                ASSERT_NEAR(pk_span[present_h + s * head_size + d].ToFloat(),
-                            past_key[past_h + s * head_size + d], 1e-3f)
-                    << "present_key past mismatch h=" << h << " s=" << s << " d=" << d;
-            // Check new key row at position past_seqlens
-            int k_h = h * kv_sequence_length * head_size;
-            for (int d = 0; d < head_size; ++d)
-              ASSERT_NEAR(pk_span[present_h + past_seqlens * head_size + d].ToFloat(),
-                          k[k_h + d], 1e-3f)
-                  << "present_key new-key mismatch h=" << h << " d=" << d;
-          }
-        }
-
-        // Validate present_value prefix (output 2): same structure with v_head_size.
-        {
-          auto pv_span = fetches[2].Get<Tensor>().DataAsSpan<MLFloat16>();
-          for (int h = 0; h < kv_num_heads; ++h) {
-            int present_h = h * total_sequence_length * v_head_size;
-            int past_h = h * past_sequence_length * v_head_size;
-            for (int s = 0; s < past_seqlens; ++s)
-              for (int d = 0; d < v_head_size; ++d)
-                ASSERT_NEAR(pv_span[present_h + s * v_head_size + d].ToFloat(),
-                            past_value[past_h + s * v_head_size + d], 1e-3f)
-                    << "present_value past mismatch h=" << h << " s=" << s << " d=" << d;
-            int v_h = h * kv_sequence_length * v_head_size;
-            for (int d = 0; d < v_head_size; ++d)
-              ASSERT_NEAR(pv_span[present_h + past_seqlens * v_head_size + d].ToFloat(),
-                          v[v_h + d], 1e-3f)
-                  << "present_value new-value mismatch h=" << h << " d=" << d;
-          }
-        }
-        // Position 3 (index [h, 3, :]) intentionally not validated — uninitialized for performance.
-      });
-
+  // CPU always runs; CUDA runs when SM 5.3+ is available for fp16.
   std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
-  execution_providers.push_back(DefaultCudaExecutionProvider());
+  if (HasCudaEnvironment(530)) {
+    execution_providers.push_back(DefaultCudaExecutionProvider());
+  }
+  execution_providers.push_back(DefaultCpuExecutionProvider());
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
 }
 
-// Multi-batch Flash decode with per-batch partial bool masks (CUDA-only, direct OpTester).
-// batch_size=2 with different masks: batch 0 has 3 leading trues (past_seqlens=2),
-// batch 1 has 6 leading trues (past_seqlens=5). Tests LaunchConcatNewToPastKV with
-// variable per-batch past_seq_lens and validates present_key/value per-batch.
-TEST(AttentionTest, FlashAttention_Decode_PartialMask_MultiBatch_Float16) {
-  if (!HasCudaEnvironment(530)) {
-    return;  // fp16 requires SM 5.3+
-  }
-
+// Multi-batch decode with per-batch partial bool masks.
+// batch_size=2: batch 0 [T,T,T,F,F,F] (3 leading trues), batch 1 [T,T,T,T,T,T] (all true).
+// Flash is ineligible (bool+past_key rejected), CUDA uses unfused.
+// Unfused applies standard ConcatPastToPresent (new token at position past_sequence_length=5
+// for all batches) and element-wise mask in softmax.
+// Runs on both CPU and CUDA to verify cross-EP consistency.
+TEST(AttentionTest, Attention4DAttnMaskBoolPartialMask_MultiBatch_Float16) {
   int batch_size = 2;
   int q_num_heads = 2;
   int q_sequence_length = 1;
@@ -847,12 +796,10 @@ TEST(AttentionTest, FlashAttention_Decode_PartialMask_MultiBatch_Float16) {
   int past_sequence_length = 5;
   int total_sequence_length = past_sequence_length + kv_sequence_length;  // 6
 
-  // Uniform Q and K → equal attention scores → softmax is uniform.
   std::vector<float> q(batch_size * q_num_heads * q_sequence_length * head_size, 0.5f);
   std::vector<float> k(batch_size * kv_num_heads * kv_sequence_length * head_size, 0.5f);
   std::vector<float> past_key(batch_size * kv_num_heads * past_sequence_length * head_size, 0.5f);
 
-  // V: [2, 2, 1, 64] — new token values per batch per head.
   std::vector<float> v(batch_size * kv_num_heads * kv_sequence_length * v_head_size);
   {
     float v_new[2][2] = {{0.4f, 0.8f}, {0.6f, 1.0f}};
@@ -862,12 +809,12 @@ TEST(AttentionTest, FlashAttention_Decode_PartialMask_MultiBatch_Float16) {
   }
 
   // past_value: [2, 2, 5, 64] — distinct per-row values.
-  // Batch 0: only positions 0,1 are valid past (mask has 3 leading trues, past_seqlens=2).
-  // Batch 1: all 5 positions are valid past (mask has 6 leading trues, past_seqlens=5).
+  // Batch 0 mask [T,T,T,F,F,F] → 3 valid positions (all past).
+  // Batch 1 mask [T,T,T,T,T,T] → 6 valid positions (all past + new).
   std::vector<float> past_value(batch_size * kv_num_heads * past_sequence_length * v_head_size);
   {
     float pv[2][2][5] = {
-        {{0.1f, 0.2f, 0.0f, 0.0f, 0.0f}, {0.5f, 0.6f, 0.0f, 0.0f, 0.0f}},  // batch 0
+        {{0.1f, 0.2f, 0.3f, 0.0f, 0.0f}, {0.5f, 0.6f, 0.7f, 0.0f, 0.0f}},  // batch 0
         {{0.1f, 0.2f, 0.3f, 0.4f, 0.5f}, {0.5f, 0.6f, 0.7f, 0.8f, 0.9f}}   // batch 1
     };
     for (int b = 0; b < batch_size; ++b)
@@ -878,27 +825,41 @@ TEST(AttentionTest, FlashAttention_Decode_PartialMask_MultiBatch_Float16) {
                       v_head_size, pv[b][h][s]);
   }
 
-  // 4D bool mask: [2, 1, 1, 6] — per-batch varying masks.
-  // Batch 0: [T,T,T,F,F,F] → 3 leading trues → past_seqlens=2
-  // Batch 1: [T,T,T,T,T,T] → 6 leading trues → past_seqlens=5
-  // Note: use bool array instead of vector<bool> (which is bit-packed and lacks .data()).
   const bool mask[] = {
       true, true, true, false, false, false,  // batch 0
       true, true, true, true, true, true      // batch 1
   };
 
-  // Y: uniform attention over valid positions.
-  // Batch 0 (3 valid): head 0: mean(0.1, 0.2, 0.4) = 7/30, head 1: mean(0.5, 0.6, 0.8) = 19/30
-  // Batch 1 (6 valid): head 0: mean(0.1..0.5, 0.6) = 0.35, head 1: mean(0.5..0.9, 1.0) = 0.75
+  // Y: uniform attention over valid positions (spec-correct).
+  // Batch 0 (3 valid, all past): head 0: mean(0.1, 0.2, 0.3) = 0.2
+  //                               head 1: mean(0.5, 0.6, 0.7) = 0.6
+  // Batch 1 (6 valid, all past + new): head 0: mean(0.1..0.5, 0.6) = 0.35
+  //                                     head 1: mean(0.5..0.9, 1.0) = 0.75
   std::vector<float> y(batch_size * q_num_heads * q_sequence_length * v_head_size);
   {
     float y_per_bh[2][2] = {
-        {7.0f / 30.0f, 19.0f / 30.0f},  // batch 0
-        {0.35f, 0.75f}                  // batch 1
+        {0.2f, 0.6f},   // batch 0
+        {0.35f, 0.75f}  // batch 1
     };
     for (int b = 0; b < batch_size; ++b)
       for (int h = 0; h < q_num_heads; ++h)
         std::fill_n(y.begin() + (b * q_num_heads + h) * v_head_size, v_head_size, y_per_bh[b][h]);
+  }
+
+  // present_key/value: standard concat — all 5 past rows + new at position 5.
+  std::vector<float> present_key(batch_size * kv_num_heads * total_sequence_length * head_size, 0.5f);
+  std::vector<float> present_value(batch_size * kv_num_heads * total_sequence_length * v_head_size);
+  {
+    float pv_expected[2][2][6] = {
+        {{0.1f, 0.2f, 0.3f, 0.0f, 0.0f, 0.4f}, {0.5f, 0.6f, 0.7f, 0.0f, 0.0f, 0.8f}},  // batch 0
+        {{0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f}, {0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f}}   // batch 1
+    };
+    for (int b = 0; b < batch_size; ++b)
+      for (int h = 0; h < kv_num_heads; ++h)
+        for (int s = 0; s < total_sequence_length; ++s)
+          std::fill_n(present_value.begin() +
+                          ((b * kv_num_heads + h) * total_sequence_length + s) * v_head_size,
+                      v_head_size, pv_expected[b][h][s]);
   }
 
   OpTester test("Attention", 23, onnxruntime::kOnnxDomain);
@@ -914,85 +875,27 @@ TEST(AttentionTest, FlashAttention_Decode_PartialMask_MultiBatch_Float16) {
 
   test.AddOutput<MLFloat16>("Y", {batch_size, q_num_heads, q_sequence_length, v_head_size},
                             ToFloat16(y));
-  std::vector<float> present_key_placeholder(batch_size * kv_num_heads * total_sequence_length * head_size, 0.0f);
-  std::vector<float> present_value_placeholder(batch_size * kv_num_heads * total_sequence_length * v_head_size, 0.0f);
   test.AddOutput<MLFloat16>("present_key", {batch_size, kv_num_heads, total_sequence_length, head_size},
-                            ToFloat16(present_key_placeholder));
+                            ToFloat16(present_key));
   test.AddOutput<MLFloat16>("present_value", {batch_size, kv_num_heads, total_sequence_length, v_head_size},
-                            ToFloat16(present_value_placeholder));
+                            ToFloat16(present_value));
 
-  // Per-batch valid positions: batch 0 = 3 (past_seqlens=2 + kv_seq=1), batch 1 = 6 (all).
-  const int valid_positions[] = {3, 6};
+  test.SetOutputAbsErr("Y", 3e-3f);
+  test.SetOutputAbsErr("present_key", 1e-3f);
+  test.SetOutputAbsErr("present_value", 1e-3f);
 
-  test.SetCustomOutputVerifier(
-      [&](const std::vector<OrtValue>& fetches, const std::string& provider_type) {
-        ASSERT_GE(fetches.size(), 3u) << "Expected 3 outputs, provider: " << provider_type;
-
-        // Validate Y (output 0).
-        auto expected_y_fp16 = ToFloat16(y);
-        auto y_span = fetches[0].Get<Tensor>().DataAsSpan<MLFloat16>();
-        ASSERT_EQ(y_span.size(), expected_y_fp16.size()) << "Y size mismatch, provider: " << provider_type;
-        for (size_t i = 0; i < y_span.size(); ++i) {
-          ASSERT_NEAR(y_span[i].ToFloat(), expected_y_fp16[i].ToFloat(), 3e-3f)
-              << "Y mismatch at " << i << ", provider: " << provider_type;
-        }
-
-        // Validate present_key prefix per batch (output 1).
-        {
-          auto pk_span = fetches[1].Get<Tensor>().DataAsSpan<MLFloat16>();
-          for (int b = 0; b < batch_size; ++b) {
-            int past_seqlens = valid_positions[b] - kv_sequence_length;
-            for (int h = 0; h < kv_num_heads; ++h) {
-              int present_bh = (b * kv_num_heads + h) * total_sequence_length * head_size;
-              int past_bh = (b * kv_num_heads + h) * past_sequence_length * head_size;
-              // Check past rows [0, past_seqlens)
-              for (int s = 0; s < past_seqlens; ++s)
-                for (int d = 0; d < head_size; ++d)
-                  ASSERT_NEAR(pk_span[present_bh + s * head_size + d].ToFloat(),
-                              past_key[past_bh + s * head_size + d], 1e-3f)
-                      << "present_key past mismatch b=" << b << " h=" << h << " s=" << s << " d=" << d;
-              // Check new key at position past_seqlens
-              int k_bh = (b * kv_num_heads + h) * kv_sequence_length * head_size;
-              for (int d = 0; d < head_size; ++d)
-                ASSERT_NEAR(pk_span[present_bh + past_seqlens * head_size + d].ToFloat(),
-                            k[k_bh + d], 1e-3f)
-                    << "present_key new-key mismatch b=" << b << " h=" << h << " d=" << d;
-            }
-          }
-        }
-
-        // Validate present_value prefix per batch (output 2).
-        {
-          auto pv_span = fetches[2].Get<Tensor>().DataAsSpan<MLFloat16>();
-          for (int b = 0; b < batch_size; ++b) {
-            int past_seqlens = valid_positions[b] - kv_sequence_length;
-            for (int h = 0; h < kv_num_heads; ++h) {
-              int present_bh = (b * kv_num_heads + h) * total_sequence_length * v_head_size;
-              int past_bh = (b * kv_num_heads + h) * past_sequence_length * v_head_size;
-              for (int s = 0; s < past_seqlens; ++s)
-                for (int d = 0; d < v_head_size; ++d)
-                  ASSERT_NEAR(pv_span[present_bh + s * v_head_size + d].ToFloat(),
-                              past_value[past_bh + s * v_head_size + d], 1e-3f)
-                      << "present_value past mismatch b=" << b << " h=" << h << " s=" << s << " d=" << d;
-              int v_bh = (b * kv_num_heads + h) * kv_sequence_length * v_head_size;
-              for (int d = 0; d < v_head_size; ++d)
-                ASSERT_NEAR(pv_span[present_bh + past_seqlens * v_head_size + d].ToFloat(),
-                            v[v_bh + d], 1e-3f)
-                    << "present_value new-value mismatch b=" << b << " h=" << h << " d=" << d;
-            }
-          }
-        }
-        // Uninitialized tail positions beyond valid_positions[b] per batch intentionally not validated.
-      });
-
+  // CPU always runs; CUDA runs when SM 5.3+ is available for fp16.
   std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
-  execution_providers.push_back(DefaultCudaExecutionProvider());
+  if (HasCudaEnvironment(530)) {
+    execution_providers.push_back(DefaultCudaExecutionProvider());
+  }
+  execution_providers.push_back(DefaultCpuExecutionProvider());
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
 }
 
 // MEA/unfused prompt path with fp16 and bool mask (single token, no past KV cache).
 // past_key/past_value are absent (None); with bool mask and no past_key, CUDA routes to
-// MEA/unfused (not Flash — flash_eligible requires past_key != nullptr with bool mask).
+// MEA/unfused (not Flash — Flash requires attn_mask == nullptr).
 TEST(AttentionTest, Attention4DAttnMaskBoolUnfusedPromptFloat16) {
   int batch_size = 1;
   int q_num_heads = 2;

--- a/onnxruntime/test/providers/cpu/llm/attention_softmax_test.cc
+++ b/onnxruntime/test/providers/cpu/llm/attention_softmax_test.cc
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if !defined(ORT_NO_EXCEPTIONS)
+
+#include <exception>
+#include <limits>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "core/framework/allocator.h"
+#include "core/providers/cpu/llm/attention_softmax.h"
+
+namespace onnxruntime {
+namespace test {
+
+// Regression test for integer overflow in FP16 softmax allocation.
+// ComputeAttentionSoftmaxInplace<MLFloat16> previously used int for N and D, so N*D could overflow int32.
+// The fix changed parameters to size_t and uses SafeInt for the multiplication.
+//
+// This test calls ComputeAttentionSoftmaxInplace<MLFloat16> directly with overflow-triggering dimensions
+// (N=46341, D=46341, where N*D > INT_MAX).
+// A custom allocator intercepts the Alloc call to verify the requested size is computed correctly with size_t
+// arithmetic, without actually allocating the ~8GB buffer.
+//
+// On 32-bit builds, SafeInt<size_t> will signal an overflow for the requested size.
+TEST(AttentionSoftmaxTest, Fp16OverflowAllocation) {
+  // Custom exception thrown by the allocator to distinguish it from SafeInt overflow.
+  struct AllocationIntercepted : std::exception {
+    const char* what() const noexcept override { return "allocation intercepted"; }
+  };
+
+  // Custom allocator that records the requested allocation size and throws to avoid actually allocating the
+  // (very large) buffer.
+  class OverflowCheckAllocator : public IAllocator {
+   public:
+    OverflowCheckAllocator()
+        : IAllocator(OrtMemoryInfo(CPU, OrtDeviceAllocator)) {}
+    void* Alloc(size_t size) override {
+      last_alloc_size_ = size;
+      throw AllocationIntercepted();
+    }
+    void Free(void*) override {}
+    size_t LastAllocSize() const { return last_alloc_size_; }
+
+   private:
+    size_t last_alloc_size_ = 0;
+  };
+
+  constexpr size_t N = 46341;
+  constexpr size_t D = 46341;
+
+  // Verify at compile time that these dimensions would overflow int32.
+  static_assert(int64_t{N} * int64_t{D} > int64_t{std::numeric_limits<int>::max()},
+                "Test dimensions must cause int32 overflow in N*D");
+
+  auto alloc = std::make_shared<OverflowCheckAllocator>();
+  MLFloat16 dummy_score{0.0f};
+
+  // The allocation size must reflect correct size_t arithmetic: N * D * sizeof(float).
+  // With the old int parameters, N * D would overflow to a small/negative value, producing a wrong allocation size.
+  constexpr uintmax_t expected_allocation_size = uintmax_t{N} * D * sizeof(float);
+
+  if constexpr (expected_allocation_size <= uintmax_t{std::numeric_limits<size_t>::max()}) {
+    // Allocation size fits in size_t. The function reaches Alloc, which records the requested size and throws
+    // AllocationIntercepted.
+    EXPECT_THROW(ComputeAttentionSoftmaxInplace<MLFloat16>(&dummy_score, N, D, nullptr, alloc),
+                 AllocationIntercepted);
+
+    EXPECT_EQ(alloc->LastAllocSize(), static_cast<size_t>(expected_allocation_size));
+  } else {
+    // Allocation size overflows size_t (i.e., in a 32-bit build), so SafeInt<size_t> will throw an exception.
+    try {
+      ComputeAttentionSoftmaxInplace<MLFloat16>(&dummy_score, N, D, nullptr, alloc);
+      FAIL() << "Expected OnnxRuntimeException to be thrown";
+    } catch (const OnnxRuntimeException& e) {
+      EXPECT_THAT(e.what(), testing::HasSubstr("Integer overflow"));
+    }
+  }
+}
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_NO_EXCEPTIONS)

--- a/onnxruntime/test/providers/cpu/math/cumprod_test.cc
+++ b/onnxruntime/test/providers/cpu/math/cumprod_test.cc
@@ -1,0 +1,409 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gtest/gtest.h"
+#include "test/providers/provider_test_utils.h"
+#include "test/util/include/default_providers.h"
+#include "core/util/math.h"
+
+namespace onnxruntime {
+namespace test {
+
+// 1D tests - basic functionality
+TEST(CumProdTest, _1DTest) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddInput<float>("x", {5}, {1.f, 2.f, 3.f, 4.f, 5.f});
+  test.AddInput<int32_t>("axis", {}, {0});
+  test.AddOutput<float>("y", {5}, {1.f, 2.f, 6.f, 24.f, 120.f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(CumProdTest, _1DTestInvalidAxis) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddInput<float>("x", {5}, {1.f, 2.f, 3.f, 4.f, 5.f});
+  test.AddInput<int32_t>("axis", {}, {-3});
+  test.AddOutput<float>("y", {5}, {1.f, 2.f, 6.f, 24.f, 120.f});
+  test.Run(OpTester::ExpectResult::kExpectFailure, "", {kTensorrtExecutionProvider});
+}
+
+TEST(CumProdTest, _1DTestNegAxis) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddInput<float>("x", {5}, {1.f, 2.f, 3.f, 4.f, 5.f});
+  test.AddInput<int32_t>("axis", {}, {-1});
+  test.AddOutput<float>("y", {5}, {1.f, 2.f, 6.f, 24.f, 120.f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+// Exclusive mode: identity element is 1, shift right
+// input:  [1, 2, 3, 4, 5]
+// output: [1, 1, 2, 6, 24]
+TEST(CumProdTest, _1DTestExclusive) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddAttribute<int64_t>("exclusive", 1);
+  test.AddInput<float>("x", {5}, {1.f, 2.f, 3.f, 4.f, 5.f});
+  test.AddInput<int32_t>("axis", {}, {0});
+  test.AddOutput<float>("y", {5}, {1.f, 1.f, 2.f, 6.f, 24.f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+// Exclusive with axis dim=1: all elements should be identity (1)
+TEST(CumProdTest, _1DTestExclusiveAxisHasSingleValue) {
+  {
+    // forward
+    OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+    test.AddAttribute<int64_t>("exclusive", 1);
+    test.AddInput<float>("x", {1, 2}, {3.f, 4.f});
+    test.AddInput<int32_t>("axis", {}, {0});
+    test.AddOutput<float>("y", {1, 2}, {1.f, 1.f});
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+  }
+  {
+    // reverse
+    OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+    test.AddAttribute<int64_t>("exclusive", 1);
+    test.AddAttribute<int64_t>("reverse", 1);
+    test.AddInput<float>("x", {1, 2}, {3.f, 4.f});
+    test.AddInput<int32_t>("axis", {}, {0});
+    test.AddOutput<float>("y", {1, 2}, {1.f, 1.f});
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+  }
+}
+
+// 2D tests
+// input: [[1, 2, 3], [4, 5, 6]], axis=0
+// output: [[1, 2, 3], [4, 10, 18]]
+TEST(CumProdTest, _2DTestAxis0) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddInput<float>("x", {2, 3}, {1.f, 2.f, 3.f, 4.f, 5.f, 6.f});
+  test.AddInput<int32_t>("axis", {}, {0});
+  test.AddOutput<float>("y", {2, 3}, {1.f, 2.f, 3.f, 4.f, 10.f, 18.f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+// input: [[1, 2, 3], [4, 5, 6]], axis=1
+// output: [[1, 2, 6], [4, 20, 120]]
+TEST(CumProdTest, _2DTestAxis1) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddInput<float>("x", {2, 3}, {1.f, 2.f, 3.f, 4.f, 5.f, 6.f});
+  test.AddInput<int32_t>("axis", {}, {1});
+  test.AddOutput<float>("y", {2, 3}, {1.f, 2.f, 6.f, 4.f, 20.f, 120.f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+// Exclusive 2D axis=0: identity row, then element-wise product with input
+// input: [[1, 2, 3], [4, 5, 6]], axis=0, exclusive
+// output: [[1, 1, 1], [1, 2, 3]]
+TEST(CumProdTest, _2DTestExclusiveAxis0) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddAttribute<int64_t>("exclusive", 1);
+  test.AddInput<float>("x", {2, 3}, {1.f, 2.f, 3.f, 4.f, 5.f, 6.f});
+  test.AddInput<int32_t>("axis", {}, {0});
+  test.AddOutput<float>("y", {2, 3}, {1.f, 1.f, 1.f, 1.f, 2.f, 3.f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+// Exclusive 2D axis=1
+// input: [[1, 2, 3], [4, 5, 6]], axis=1, exclusive
+// output: [[1, 1, 2], [1, 4, 20]]
+TEST(CumProdTest, _2DTestExclusiveAxis1) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddAttribute<int64_t>("exclusive", 1);
+  test.AddInput<float>("x", {2, 3}, {1.f, 2.f, 3.f, 4.f, 5.f, 6.f});
+  test.AddInput<int32_t>("axis", {}, {1});
+  test.AddOutput<float>("y", {2, 3}, {1.f, 1.f, 2.f, 1.f, 4.f, 20.f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+// 3D tests with shape {2, 3, 4}
+// Using values 1..24
+TEST(CumProdTest, _3DTestAxis0) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddInput<float>("x", {2, 3, 4},
+                       {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f,
+                        13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f});
+  test.AddInput<int32_t>("axis", {}, {0});
+  // axis=0: product along first dimension
+  // out[0,:,:] = x[0,:,:], out[1,:,:] = x[0,:,:] * x[1,:,:]
+  test.AddOutput<float>("y", {2, 3, 4},
+                        {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f,
+                         13.f, 28.f, 45.f, 64.f, 85.f, 108.f, 133.f, 160.f, 189.f, 220.f, 253.f, 288.f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(CumProdTest, _3DTestAxis1) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddInput<float>("x", {2, 3, 4},
+                       {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f,
+                        13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f});
+  test.AddInput<int32_t>("axis", {}, {1});
+  // axis=1: product along second dimension
+  // out[:,0,:] = x[:,0,:], out[:,1,:] = x[:,0,:]*x[:,1,:], out[:,2,:] = x[:,0,:]*x[:,1,:]*x[:,2,:]
+  test.AddOutput<float>("y", {2, 3, 4},
+                        {1.f, 2.f, 3.f, 4.f, 5.f, 12.f, 21.f, 32.f, 45.f, 120.f, 231.f, 384.f,
+                         13.f, 14.f, 15.f, 16.f, 221.f, 252.f, 285.f, 320.f, 4641.f, 5544.f, 6555.f, 7680.f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(CumProdTest, _3DTestAxis2) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddInput<float>("x", {2, 3, 4},
+                       {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f,
+                        13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f});
+  test.AddInput<int32_t>("axis", {}, {2});
+  // axis=2: product along last dimension
+  // out[:,:,0] = x[:,:,0], out[:,:,1] = x[:,:,0]*x[:,:,1], etc.
+  test.AddOutput<float>("y", {2, 3, 4},
+                        {1.f, 2.f, 6.f, 24.f, 5.f, 30.f, 210.f, 1680.f, 9.f, 90.f, 990.f, 11880.f,
+                         13.f, 182.f, 2730.f, 43680.f, 17.f, 306.f, 5814.f, 116280.f, 21.f, 462.f, 10626.f, 255024.f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+// 3D exclusive tests
+TEST(CumProdTest, _3DTestAxis0Exclusive) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddAttribute<int64_t>("exclusive", 1);
+  test.AddInput<float>("x", {2, 3, 4},
+                       {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f,
+                        13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f});
+  test.AddInput<int32_t>("axis", {}, {0});
+  // exclusive axis=0: first slice is all 1s, second = x[0,:,:]
+  test.AddOutput<float>("y", {2, 3, 4},
+                        {1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
+                         1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(CumProdTest, _3DTestAxis1Exclusive) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddAttribute<int64_t>("exclusive", 1);
+  test.AddInput<float>("x", {2, 3, 4},
+                       {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f,
+                        13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f});
+  test.AddInput<int32_t>("axis", {}, {1});
+  // exclusive axis=1: out[:,0,:] = 1, out[:,1,:] = x[:,0,:], out[:,2,:] = x[:,0,:]*x[:,1,:]
+  test.AddOutput<float>("y", {2, 3, 4},
+                        {1.f, 1.f, 1.f, 1.f, 1.f, 2.f, 3.f, 4.f, 5.f, 12.f, 21.f, 32.f,
+                         1.f, 1.f, 1.f, 1.f, 13.f, 14.f, 15.f, 16.f, 221.f, 252.f, 285.f, 320.f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(CumProdTest, _3DTestAxis2Exclusive) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddAttribute<int64_t>("exclusive", 1);
+  test.AddInput<float>("x", {2, 3, 4},
+                       {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f,
+                        13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f});
+  test.AddInput<int32_t>("axis", {}, {2});
+  // exclusive axis=2: out[:,:,0] = 1, out[:,:,1] = x[:,:,0], out[:,:,2] = x[:,:,0]*x[:,:,1], etc.
+  test.AddOutput<float>("y", {2, 3, 4},
+                        {1.f, 1.f, 2.f, 6.f, 1.f, 5.f, 30.f, 210.f, 1.f, 9.f, 90.f, 990.f,
+                         1.f, 13.f, 182.f, 2730.f, 1.f, 17.f, 306.f, 5814.f, 1.f, 21.f, 462.f, 10626.f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+// Reverse tests
+// input: [1, 2, 3, 4, 5], reverse
+// output: [120, 120, 60, 20, 5]
+TEST(CumProdTest, _1DTestReverse) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddAttribute<int64_t>("reverse", 1);
+  test.AddInput<float>("x", {5}, {1.f, 2.f, 3.f, 4.f, 5.f});
+  test.AddInput<int32_t>("axis", {}, {0});
+  test.AddOutput<float>("y", {5}, {120.f, 120.f, 60.f, 20.f, 5.f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+// Reverse exclusive
+// input: [1, 2, 3, 4, 5], reverse, exclusive
+// output: [120, 60, 20, 5, 1]
+TEST(CumProdTest, _1DTestReverseExclusive) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddAttribute<int64_t>("exclusive", 1);
+  test.AddAttribute<int64_t>("reverse", 1);
+  test.AddInput<float>("x", {5}, {1.f, 2.f, 3.f, 4.f, 5.f});
+  test.AddInput<int32_t>("axis", {}, {0});
+  test.AddOutput<float>("y", {5}, {120.f, 60.f, 20.f, 5.f, 1.f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+// 3D reverse tests
+TEST(CumProdTest, _3DTestAxis0Reverse) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddAttribute<int64_t>("reverse", 1);
+  test.AddInput<float>("x", {2, 3, 4},
+                       {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f,
+                        13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f});
+  test.AddInput<int32_t>("axis", {}, {0});
+  // reverse axis=0: out[1,:,:]=x[1,:,:], out[0,:,:]=x[0,:,:]*x[1,:,:]
+  test.AddOutput<float>("y", {2, 3, 4},
+                        {13.f, 28.f, 45.f, 64.f, 85.f, 108.f, 133.f, 160.f, 189.f, 220.f, 253.f, 288.f,
+                         13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(CumProdTest, _3DTestAxis1Reverse) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddAttribute<int64_t>("reverse", 1);
+  test.AddInput<float>("x", {2, 3, 4},
+                       {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f,
+                        13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f});
+  test.AddInput<int32_t>("axis", {}, {1});
+  // reverse axis=1: out[:,2,:]=x[:,2,:], out[:,1,:]=x[:,1,:]*x[:,2,:], out[:,0,:]=x[:,0,:]*x[:,1,:]*x[:,2,:]
+  test.AddOutput<float>("y", {2, 3, 4},
+                        {45.f, 120.f, 231.f, 384.f, 45.f, 60.f, 77.f, 96.f, 9.f, 10.f, 11.f, 12.f,
+                         4641.f, 5544.f, 6555.f, 7680.f, 357.f, 396.f, 437.f, 480.f, 21.f, 22.f, 23.f, 24.f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(CumProdTest, _3DTestAxis2Reverse) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddAttribute<int64_t>("reverse", 1);
+  test.AddInput<float>("x", {2, 3, 4},
+                       {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f,
+                        13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f});
+  test.AddInput<int32_t>("axis", {}, {2});
+  // reverse axis=2: out[:,:,3]=x[:,:,3], out[:,:,2]=x[:,:,2]*x[:,:,3], etc.
+  test.AddOutput<float>("y", {2, 3, 4},
+                        {24.f, 24.f, 12.f, 4.f, 1680.f, 336.f, 56.f, 8.f, 11880.f, 1320.f, 132.f, 12.f,
+                         43680.f, 3360.f, 240.f, 16.f, 116280.f, 6840.f, 380.f, 20.f, 255024.f, 12144.f, 552.f, 24.f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+// 3D reverse exclusive tests
+TEST(CumProdTest, _3DTestAxis0ReverseExclusive) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddAttribute<int64_t>("reverse", 1);
+  test.AddAttribute<int64_t>("exclusive", 1);
+  test.AddInput<float>("x", {2, 3, 4},
+                       {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f,
+                        13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f});
+  test.AddInput<int32_t>("axis", {}, {0});
+  // reverse exclusive axis=0: out[1,:,:]=1, out[0,:,:]=x[1,:,:]
+  test.AddOutput<float>("y", {2, 3, 4},
+                        {13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f,
+                         1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(CumProdTest, _3DTestAxis1ReverseExclusive) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddAttribute<int64_t>("reverse", 1);
+  test.AddAttribute<int64_t>("exclusive", 1);
+  test.AddInput<float>("x", {2, 3, 4},
+                       {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f,
+                        13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f});
+  test.AddInput<int32_t>("axis", {}, {1});
+  // reverse exclusive axis=1: out[:,2,:]=1, out[:,1,:]=x[:,2,:], out[:,0,:]=x[:,1,:]*x[:,2,:]
+  test.AddOutput<float>("y", {2, 3, 4},
+                        {45.f, 60.f, 77.f, 96.f, 9.f, 10.f, 11.f, 12.f, 1.f, 1.f, 1.f, 1.f,
+                         357.f, 396.f, 437.f, 480.f, 21.f, 22.f, 23.f, 24.f, 1.f, 1.f, 1.f, 1.f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(CumProdTest, _3DTestAxis2ReverseExclusive) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddAttribute<int64_t>("reverse", 1);
+  test.AddAttribute<int64_t>("exclusive", 1);
+  test.AddInput<float>("x", {2, 3, 4},
+                       {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f,
+                        13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f});
+  test.AddInput<int32_t>("axis", {}, {2});
+  // reverse exclusive axis=2: out[:,:,3]=1, out[:,:,2]=x[:,:,3], out[:,:,1]=x[:,:,2]*x[:,:,3], etc.
+  test.AddOutput<float>("y", {2, 3, 4},
+                        {24.f, 12.f, 4.f, 1.f, 336.f, 56.f, 8.f, 1.f, 1320.f, 132.f, 12.f, 1.f,
+                         3360.f, 240.f, 16.f, 1.f, 6840.f, 380.f, 20.f, 1.f, 12144.f, 552.f, 24.f, 1.f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+// Type-specific tests
+TEST(CumProdTest, _1DTestInt32) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddInput<int32_t>("x", {5}, {1, 2, 3, 4, 5});
+  test.AddInput<int32_t>("axis", {}, {0});
+  test.AddOutput<int32_t>("y", {5}, {1, 2, 6, 24, 120});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(CumProdTest, _1DTestInt64) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddInput<int64_t>("x", {5}, {1, 2, 3, 4, 5});
+  test.AddInput<int32_t>("axis", {}, {0});
+  test.AddOutput<int64_t>("y", {5}, {1, 2, 6, 24, 120});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(CumProdTest, _1DTestDouble) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddInput<double>("x", {5}, {1., 2., 3., 4., 5.});
+  test.AddInput<int32_t>("axis", {}, {0});
+  test.AddOutput<double>("y", {5}, {1., 2., 6., 24., 120.});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(CumProdTest, _1DTestDouble_WithInt64Axis) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddInput<double>("x", {5}, {1., 2., 3., 4., 5.});
+  test.AddInput<int64_t>("axis", {}, {0});
+  test.AddOutput<double>("y", {5}, {1., 2., 6., 24., 120.});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(CumProdTest, _1DTestUint32) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddInput<uint32_t>("x", {5}, {1, 2, 3, 4, 5});
+  test.AddInput<int32_t>("axis", {}, {0});
+  test.AddOutput<uint32_t>("y", {5}, {1, 2, 6, 24, 120});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(CumProdTest, _1DTestUint64) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddInput<uint64_t>("x", {5}, {1, 2, 3, 4, 5});
+  test.AddInput<int32_t>("axis", {}, {0});
+  test.AddOutput<uint64_t>("y", {5}, {1, 2, 6, 24, 120});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+// Matches ONNX spec example exactly
+// input: [1, 2, 3], axis=0 -> [1, 2, 6]
+TEST(CumProdTest, _OnnxSpecExample) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddInput<float>("x", {3}, {1.f, 2.f, 3.f});
+  test.AddInput<int32_t>("axis", {}, {0});
+  test.AddOutput<float>("y", {3}, {1.f, 2.f, 6.f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+// ONNX spec example: exclusive=1 -> [1, 1, 2]
+TEST(CumProdTest, _OnnxSpecExampleExclusive) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddAttribute<int64_t>("exclusive", 1);
+  test.AddInput<float>("x", {3}, {1.f, 2.f, 3.f});
+  test.AddInput<int32_t>("axis", {}, {0});
+  test.AddOutput<float>("y", {3}, {1.f, 1.f, 2.f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+// ONNX spec example: reverse=1 -> [6, 6, 3]
+TEST(CumProdTest, _OnnxSpecExampleReverse) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddAttribute<int64_t>("reverse", 1);
+  test.AddInput<float>("x", {3}, {1.f, 2.f, 3.f});
+  test.AddInput<int32_t>("axis", {}, {0});
+  test.AddOutput<float>("y", {3}, {6.f, 6.f, 3.f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+// ONNX spec example: exclusive=1, reverse=1 -> [6, 3, 1]
+TEST(CumProdTest, _OnnxSpecExampleReverseExclusive) {
+  OpTester test("CumProd", 26, onnxruntime::kOnnxDomain);
+  test.AddAttribute<int64_t>("exclusive", 1);
+  test.AddAttribute<int64_t>("reverse", 1);
+  test.AddInput<float>("x", {3}, {1.f, 2.f, 3.f});
+  test.AddInput<int32_t>("axis", {}, {0});
+  test.AddOutput<float>("y", {3}, {6.f, 3.f, 1.f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/nn/conv_fp16_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/conv_fp16_test.cc
@@ -686,6 +686,8 @@ TEST(ConvFp16Test, Conv2D_AutoPad2) {
   TestConvFp16Op(attrs, {X, W}, {X_shape, W_shape}, expected_vals, Y_shape, true);
 }
 
+// TODO: Enable Conv3D fp16 tests for WebGPU when the test infrastructure supports
+// conditionally skipping based on device capabilities (e.g., wgpu::FeatureName::ShaderF16).
 TEST(ConvFp16Test, Conv3D_1) {
   ConvOpAndTestAttributes attrs = {
       "",                                 // auto_pad

--- a/onnxruntime/test/providers/cpu/nn/conv_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/conv_op_test.cc
@@ -812,7 +812,7 @@ TEST(ConvTest, Conv3D_1) {
       vector<int64_t>{1, 1, 1},           // kernel_shape
       vector<int64_t>{0, 0, 0, 0, 0, 0},  // pads
       vector<int64_t>{1, 1, 1},           // strides
-      {kWebGpuExecutionProvider}          // excluded EPs
+      {}                                  // excluded EPs
   };
 
   vector<float> X = {-0.43337246775627136f, -0.48385289311408997f, -0.30954962968826294f,
@@ -849,7 +849,7 @@ TEST(ConvTest, Conv3D_2) {
       vector<int64_t>{1, 1, 1},           // kernel_shape
       vector<int64_t>{2, 2, 2, 2, 2, 2},  // pads
       vector<int64_t>{2, 2, 2},           // strides
-      {kWebGpuExecutionProvider}          // excluded EPs
+      {}                                  // excluded EPs
   };
 
   vector<float> X = {0.010772407054901123f, -0.43806642293930054f, 0.455391526222229f, -0.28657248616218567f,
@@ -892,7 +892,7 @@ TEST(ConvTest, Conv3D_Bias) {
       vector<int64_t>{2, 2, 2},           // kernel_shape
       vector<int64_t>{2, 2, 2, 2, 2, 2},  // pads
       vector<int64_t>{2, 2, 2},           // strides
-      {kWebGpuExecutionProvider}          // excluded EPs
+      {}                                  // excluded EPs
   };
 
   vector<float> X = {0.46796226501464844f, -0.4613912105560303f, 0.33512794971466064f, -0.4010460674762726f,

--- a/onnxruntime/test/providers/cpu/nn/lrn_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/lrn_op_test.cc
@@ -1,13 +1,46 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <cmath>
+#include <algorithm>
+
 #include "gtest/gtest.h"
 #include "default_providers.h"
 #include "test/common/dnnl_op_test_utils.h"
 #include "test/providers/provider_test_utils.h"
+
 using namespace std;
 namespace onnxruntime {
 namespace test {
+
+// Compute reference LRN output using the ONNX formula:
+//   Y[n,c,h,w] = X[n,c,h,w] * (bias + alpha/size * sum(X[n,j,h,w]^2))^(-beta)
+// where j ranges over [max(0, c - floor(size/2)), min(C-1, c + floor(size/2))].
+// Input shape must be NCHW.
+static vector<float> ComputeLRNReference(const vector<float>& X,
+                                         int64_t N, int64_t C, int64_t H, int64_t W,
+                                         float alpha, float beta, float bias, int64_t size) {
+  const int64_t total = N * C * H * W;
+  const int64_t pre_pad = (size - 1) / 2;
+  vector<float> expected(static_cast<size_t>(total));
+  for (int64_t n = 0; n < N; ++n) {
+    for (int64_t c = 0; c < C; ++c) {
+      for (int64_t h = 0; h < H; ++h) {
+        for (int64_t w = 0; w < W; ++w) {
+          float sum_sq = 0.0f;
+          for (int64_t j = std::max(int64_t{0}, c - pre_pad); j <= std::min(C - 1, c + pre_pad); ++j) {
+            float val = X[n * C * H * W + j * H * W + h * W + w];
+            sum_sq += val * val;
+          }
+          float scale = bias + (alpha / size) * sum_sq;
+          int64_t idx = n * C * H * W + c * H * W + h * W + w;
+          expected[idx] = X[idx] * std::pow(scale, -beta);
+        }
+      }
+    }
+  }
+  return expected;
+}
 
 TEST(LRNTest, LRN_1) {
   OpTester test("LRN");
@@ -101,6 +134,168 @@ TEST(LRNTest, LRN_2) {
 
   test.AddInput<float>("X", shape, X);
   test.AddOutput<float>("Y", shape, expected_output);
+  test.Run();
+}
+
+// Test that size > C is handled correctly (window is clamped to valid channel range).
+TEST(LRNTest, SizeGreaterThanChannels) {
+  constexpr float alpha = 0.001f;
+  constexpr float beta = 0.75f;
+  constexpr float bias = 1.0f;
+  constexpr int64_t size = 5;
+
+  OpTester test("LRN");
+  test.AddAttribute("alpha", alpha);
+  test.AddAttribute("beta", beta);
+  test.AddAttribute("bias", bias);
+  test.AddAttribute("size", size);
+
+  // N=1, C=3, H=2, W=2 with size=5 > C=3
+  vector<float> X = {1.0f, 2.0f, 3.0f, 4.0f,
+                     5.0f, 6.0f, 7.0f, 8.0f,
+                     9.0f, 10.0f, 11.0f, 12.0f};
+  vector<int64_t> shape = {1, 3, 2, 2};
+
+  vector<float> expected = ComputeLRNReference(X, 1, 3, 2, 2, alpha, beta, bias, size);
+
+  test.AddInput<float>("X", shape, X);
+  test.AddOutput<float>("Y", shape, expected);
+  test.Run();
+}
+
+// Test with minimum valid size (size=3) where size == C for a 3-channel input.
+TEST(LRNTest, SizeEqualsChannels) {
+  constexpr float alpha = 0.0001f;
+  constexpr float beta = 0.75f;
+  constexpr float bias = 1.0f;
+  constexpr int64_t size = 3;
+
+  OpTester test("LRN");
+  test.AddAttribute("alpha", alpha);
+  test.AddAttribute("beta", beta);
+  test.AddAttribute("bias", bias);
+  test.AddAttribute("size", size);
+
+  // N=1, C=3, H=1, W=1
+  vector<float> X = {1.0f, 2.0f, 3.0f};
+  vector<int64_t> shape = {1, 3, 1, 1};
+
+  vector<float> expected = ComputeLRNReference(X, 1, 3, 1, 1, alpha, beta, bias, size);
+
+  test.AddInput<float>("X", shape, X);
+  test.AddOutput<float>("Y", shape, expected);
+  test.Run();
+}
+
+// Test with larger spatial dimensions to verify correctness with non-trivial H and W.
+TEST(LRNTest, LargerSpatialDims) {
+  constexpr float alpha = 0.001f;
+  constexpr float beta = 0.75f;
+  constexpr float bias = 1.0f;
+  constexpr int64_t size = 3;
+
+  OpTester test("LRN");
+  test.AddAttribute("alpha", alpha);
+  test.AddAttribute("beta", beta);
+  test.AddAttribute("bias", bias);
+  test.AddAttribute("size", size);
+
+  constexpr int64_t N = 1, C = 3, H = 128, W = 128;
+  constexpr int64_t total = N * C * H * W;
+  vector<float> X(total);
+  // Fill with a simple pattern
+  for (int64_t i = 0; i < total; ++i) {
+    X[i] = static_cast<float>(i % 7) * 0.1f + 0.1f;
+  }
+  vector<int64_t> shape = {N, C, H, W};
+
+  vector<float> expected = ComputeLRNReference(X, N, C, H, W, alpha, beta, bias, size);
+
+  test.AddInput<float>("X", shape, X);
+  test.AddOutput<float>("Y", shape, expected);
+  test.Run();
+}
+
+// Test with multiple batch items (N > 1) to cover the outer loop with n * image_size arithmetic.
+TEST(LRNTest, MultipleBatches) {
+  constexpr float alpha = 0.01f;
+  constexpr float beta = 0.5f;
+  constexpr float bias = 1.0f;
+  constexpr int64_t size = 3;
+
+  OpTester test("LRN");
+  test.AddAttribute("alpha", alpha);
+  test.AddAttribute("beta", beta);
+  test.AddAttribute("bias", bias);
+  test.AddAttribute("size", size);
+
+  constexpr int64_t N = 2, C = 3, H = 2, W = 2;
+  constexpr int64_t total = N * C * H * W;
+  vector<float> X(total);
+  for (int64_t i = 0; i < total; ++i) {
+    X[i] = static_cast<float>(i + 1) * 0.05f;
+  }
+  vector<int64_t> shape = {N, C, H, W};
+
+  vector<float> expected = ComputeLRNReference(X, N, C, H, W, alpha, beta, bias, size);
+
+  test.AddInput<float>("X", shape, X);
+  test.AddOutput<float>("Y", shape, expected);
+  test.Run();
+}
+
+// Test with more channels than size to exercise the sliding window (add head / subtract tail) path.
+TEST(LRNTest, ManyChannels) {
+  constexpr float alpha = 0.0001f;
+  constexpr float beta = 0.75f;
+  constexpr float bias = 1.0f;
+  constexpr int64_t size = 3;
+
+  OpTester test("LRN");
+  test.AddAttribute("alpha", alpha);
+  test.AddAttribute("beta", beta);
+  test.AddAttribute("bias", bias);
+  test.AddAttribute("size", size);
+
+  // C > size to exercise the c=1..C-1 loop with head/tail updates
+  constexpr int64_t N = 1, C = 8, H = 2, W = 2;
+  constexpr int64_t total = N * C * H * W;
+  vector<float> X(total);
+  for (int64_t i = 0; i < total; ++i) {
+    X[i] = static_cast<float>((i % 5) + 1) * 0.2f;
+  }
+  vector<int64_t> shape = {N, C, H, W};
+
+  vector<float> expected = ComputeLRNReference(X, N, C, H, W, alpha, beta, bias, size);
+
+  test.AddInput<float>("X", shape, X);
+  test.AddOutput<float>("Y", shape, expected);
+  test.Run();
+}
+
+// Test with all-zero input -- edge case where squared values are all zero.
+TEST(LRNTest, ZeroInput) {
+  constexpr float alpha = 0.001f;
+  constexpr float beta = 0.75f;
+  constexpr float bias = 1.0f;
+  constexpr int64_t size = 3;
+
+  OpTester test("LRN");
+  test.AddAttribute("alpha", alpha);
+  test.AddAttribute("beta", beta);
+  test.AddAttribute("bias", bias);
+  test.AddAttribute("size", size);
+
+  constexpr int64_t N = 1, C = 3, H = 2, W = 2;
+  constexpr int64_t total = N * C * H * W;
+  vector<float> X(total, 0.0f);
+  vector<int64_t> shape = {N, C, H, W};
+
+  // With all zeros: scale = bias = 1.0, Y = 0 * pow(1.0, -beta) = 0
+  vector<float> expected(total, 0.0f);
+
+  test.AddInput<float>("X", shape, X);
+  test.AddOutput<float>("Y", shape, expected);
   test.Run();
 }
 

--- a/onnxruntime/test/providers/cpu/tensor/bitcast_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/bitcast_op_test.cc
@@ -1,0 +1,183 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gtest/gtest.h"
+#include "test/providers/provider_test_utils.h"
+#include "core/framework/to_tensor_proto_element_type.h"
+
+#include <cstring>
+#include <vector>
+
+namespace onnxruntime {
+namespace test {
+
+template <typename SrcType, typename DstType>
+void TestBitCastOp(const std::vector<int64_t>& shape,
+                   const std::vector<SrcType>& input,
+                   const std::vector<DstType>& expected_output) {
+  OpTester test("BitCast", 26, onnxruntime::kOnnxDomain);
+  test.AddAttribute<int64_t>("to", utils::ToTensorProtoElementType<DstType>());
+  test.AddInput<SrcType>("input", shape, input);
+  test.AddOutput<DstType>("output", shape, expected_output);
+  // BitCast is CPU-only for now; exclude providers that don't support it.
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+}
+
+// float32 and int32 are both 4 bytes.
+// IEEE 754: 1.0f = 0x3F800000 = 1065353216 as int32
+TEST(BitCastTest, Float32ToInt32) {
+  std::vector<float> input = {0.0f, 1.0f, -1.0f, 0.5f};
+  std::vector<int32_t> expected(input.size());
+  std::memcpy(expected.data(), input.data(), input.size() * sizeof(float));
+
+  TestBitCastOp<float, int32_t>({4}, input, expected);
+}
+
+TEST(BitCastTest, Int32ToFloat32) {
+  // 0x3F800000 = 1065353216 -> 1.0f
+  // 0x40000000 = 1073741824 -> 2.0f
+  std::vector<int32_t> input = {0, 1065353216, 1073741824};
+  std::vector<float> expected(input.size());
+  std::memcpy(expected.data(), input.data(), input.size() * sizeof(int32_t));
+
+  TestBitCastOp<int32_t, float>({3}, input, expected);
+}
+
+// double and int64 are both 8 bytes.
+TEST(BitCastTest, DoubleToInt64) {
+  std::vector<double> input = {0.0, 1.0, -1.0};
+  std::vector<int64_t> expected(input.size());
+  std::memcpy(expected.data(), input.data(), input.size() * sizeof(double));
+
+  TestBitCastOp<double, int64_t>({3}, input, expected);
+}
+
+TEST(BitCastTest, Int64ToDouble) {
+  std::vector<int64_t> input = {0, 4607182418800017408};  // 0 and 1.0 as int64
+  std::vector<double> expected(input.size());
+  std::memcpy(expected.data(), input.data(), input.size() * sizeof(int64_t));
+
+  TestBitCastOp<int64_t, double>({2}, input, expected);
+}
+
+// float16 and uint16 are both 2 bytes.
+TEST(BitCastTest, Float16ToUInt16) {
+  std::vector<MLFloat16> input = {MLFloat16(0.0f), MLFloat16(1.0f), MLFloat16(0.5f)};
+  std::vector<uint16_t> expected(input.size());
+  std::memcpy(expected.data(), input.data(), input.size() * sizeof(MLFloat16));
+
+  TestBitCastOp<MLFloat16, uint16_t>({3}, input, expected);
+}
+
+TEST(BitCastTest, UInt16ToFloat16) {
+  std::vector<uint16_t> input = {0x0000, 0x3C00, 0x3800};  // 0.0, 1.0, 0.5 in float16
+  std::vector<MLFloat16> expected;
+  expected.reserve(input.size());
+  for (auto v : input) {
+    expected.push_back(MLFloat16::FromBits(v));
+  }
+
+  TestBitCastOp<uint16_t, MLFloat16>({3}, input, expected);
+}
+
+// BFloat16 and int16 are both 2 bytes.
+TEST(BitCastTest, BFloat16ToInt16) {
+  std::vector<BFloat16> input = {BFloat16(0.0f), BFloat16(1.0f)};
+  std::vector<int16_t> expected(input.size());
+  std::memcpy(expected.data(), input.data(), input.size() * sizeof(BFloat16));
+
+  TestBitCastOp<BFloat16, int16_t>({2}, input, expected);
+}
+
+// int8 and uint8 are both 1 byte.
+TEST(BitCastTest, Int8ToUInt8) {
+  std::vector<int8_t> input = {0, 1, -1, 127, -128};
+  std::vector<uint8_t> expected(input.size());
+  std::memcpy(expected.data(), input.data(), input.size() * sizeof(int8_t));
+
+  TestBitCastOp<int8_t, uint8_t>({5}, input, expected);
+}
+
+TEST(BitCastTest, UInt8ToInt8) {
+  std::vector<uint8_t> input = {0, 1, 127, 128, 255};
+  std::vector<int8_t> expected(input.size());
+  std::memcpy(expected.data(), input.data(), input.size() * sizeof(uint8_t));
+
+  TestBitCastOp<uint8_t, int8_t>({5}, input, expected);
+}
+
+// Same type (identity-like).
+TEST(BitCastTest, Float32ToFloat32) {
+  std::vector<float> input = {1.0f, 2.0f, 3.0f};
+  TestBitCastOp<float, float>({3}, input, input);
+}
+
+// Multi-dimensional input.
+TEST(BitCastTest, Float32ToInt32_2D) {
+  std::vector<float> input = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+  std::vector<int32_t> expected(input.size());
+  std::memcpy(expected.data(), input.data(), input.size() * sizeof(float));
+
+  TestBitCastOp<float, int32_t>({2, 3}, input, expected);
+}
+
+TEST(BitCastTest, Float32ToInt32_3D) {
+  std::vector<float> input = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f,
+                              7.0f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f};
+  std::vector<int32_t> expected(input.size());
+  std::memcpy(expected.data(), input.data(), input.size() * sizeof(float));
+
+  TestBitCastOp<float, int32_t>({2, 2, 3}, input, expected);
+}
+
+// Empty tensor.
+TEST(BitCastTest, EmptyTensor) {
+  std::vector<float> input = {};
+  std::vector<int32_t> expected = {};
+  TestBitCastOp<float, int32_t>({0}, input, expected);
+}
+
+// Scalar (0-dim) tensor.
+TEST(BitCastTest, ScalarTensor) {
+  std::vector<float> input = {42.0f};
+  std::vector<int32_t> expected(1);
+  std::memcpy(expected.data(), input.data(), sizeof(float));
+
+  OpTester test("BitCast", 26, onnxruntime::kOnnxDomain);
+  test.AddAttribute<int64_t>("to", utils::ToTensorProtoElementType<int32_t>());
+  test.AddInput<float>("input", {}, input);
+  test.AddOutput<int32_t>("output", {}, expected);
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+}
+
+// uint32 and float32 (same size, 4 bytes).
+TEST(BitCastTest, UInt32ToFloat32) {
+  std::vector<uint32_t> input = {0, 0x3F800000, 0x40000000};  // 0.0f, 1.0f, 2.0f
+  std::vector<float> expected(input.size());
+  std::memcpy(expected.data(), input.data(), input.size() * sizeof(uint32_t));
+
+  TestBitCastOp<uint32_t, float>({3}, input, expected);
+}
+
+// uint64 and double (same size, 8 bytes).
+TEST(BitCastTest, UInt64ToDouble) {
+  std::vector<uint64_t> input = {0, 0x3FF0000000000000ULL};  // 0.0 and 1.0 as uint64
+  std::vector<double> expected(input.size());
+  std::memcpy(expected.data(), input.data(), input.size() * sizeof(uint64_t));
+
+  TestBitCastOp<uint64_t, double>({2}, input, expected);
+}
+
+// int16 and uint16 (same size, 2 bytes).
+TEST(BitCastTest, Int16ToUInt16) {
+  std::vector<int16_t> input = {0, 1, -1, 32767, -32768};
+  std::vector<uint16_t> expected(input.size());
+  std::memcpy(expected.data(), input.data(), input.size() * sizeof(int16_t));
+
+  TestBitCastOp<int16_t, uint16_t>({5}, input, expected);
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/tensor/mean_variance_normalization_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/mean_variance_normalization_test.cc
@@ -69,7 +69,10 @@ TEST(MeanVarianceNormalizationTest, DefaultAxes) {
   OpTester test("MeanVarianceNormalization", 9);
   test.AddInput<float>("input", {N, C, H, W}, X);
   test.AddOutput<float>("output", {N, C, H, W}, result);
-  test.Run();
+  // DML currently has known failures in this 4D default-axes MVN coverage.
+  // See https://github.com/microsoft/onnxruntime/issues/27933 and remove this exclusion once
+  // that issue is fixed.
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kDmlExecutionProvider});
 }
 
 static void TestMeanVarianceNormalizationOverAllAxes(const std::vector<int64_t>& shape) {
@@ -90,7 +93,14 @@ static void TestMeanVarianceNormalizationOverAllAxes(const std::vector<int64_t>&
   test.AddInput<float>("input", shape, X);
   test.AddOutput<float>("output", shape, Y);
 
-  test.Run();
+  if (shape.size() == 4) {
+    // Restrict the DML exclusion to the known failing 4D all-axes coverage.
+    // See https://github.com/microsoft/onnxruntime/issues/27933 and remove this exclusion once
+    // that issue is fixed.
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kDmlExecutionProvider});
+  } else {
+    test.Run();
+  }
 }
 
 TEST(MeanVarianceNormalizationTest, AllAxes) {
@@ -157,6 +167,7 @@ TEST(MeanVarianceNormalizationTest, AxesSubsets5D) {
     test.AddOutput<float>("output", shape, Y.data(), Y.size());
 
     if (DefaultDmlExecutionProvider().get() != nullptr) {
+      // 5D subset-axis coverage stays enabled for DML.
       test.SetOutputTolerance(0.001f);
     }
 

--- a/onnxruntime/test/providers/cuda/plugin/cuda_plugin_arena_test.cc
+++ b/onnxruntime/test/providers/cuda/plugin/cuda_plugin_arena_test.cc
@@ -1,0 +1,1273 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Tests for the CUDA plugin EP arena allocator integration.
+// Validates that CreateAllocatorImpl wraps raw allocators in CudaArenaAllocator,
+// arena stats are reported, and CUDA device/pinned memory is properly managed.
+
+#if defined(ORT_UNIT_TEST_HAS_CUDA_PLUGIN_EP)
+
+#include <algorithm>
+#include <cstring>
+#include <filesystem>
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <cuda_runtime_api.h>
+#include <gtest/gtest.h>
+
+#include "core/session/onnxruntime_cxx_api.h"
+#include "test/util/include/file_util.h"
+
+extern std::unique_ptr<Ort::Env> ort_env;
+
+namespace onnxruntime {
+namespace test {
+namespace {
+
+constexpr const char* kCudaPluginEpRegistrationName = "CudaPluginArenaTest";
+
+// Helper: get a stat value as string from allocator stats, or empty if not found.
+std::string GetStatValue(const Ort::KeyValuePairs& stats, const char* key) {
+  const char* v = stats.GetValue(key);
+  return v ? std::string(v) : std::string{};
+}
+
+// Helper: get a stat value as int64, returning 0 if not found.
+int64_t GetStatInt(const Ort::KeyValuePairs& stats, const char* key) {
+  const char* v = stats.GetValue(key);
+  return v ? std::stoll(v) : 0;
+}
+
+// Resolve the CUDA plugin EP shared library path.
+std::filesystem::path GetCudaPluginLibraryPath() {
+  return GetSharedLibraryFileName(ORT_TSTR("onnxruntime_providers_cuda_plugin"));
+}
+
+// RAII handle that registers/unregisters the CUDA plugin EP library.
+class ScopedCudaPluginRegistration {
+ public:
+  ScopedCudaPluginRegistration(Ort::Env& env, const char* registration_name)
+      : env_(env), name_(registration_name) {
+    auto lib_path = GetCudaPluginLibraryPath();
+    if (!std::filesystem::exists(lib_path)) {
+      available_ = false;
+      return;
+    }
+    env_.RegisterExecutionProviderLibrary(name_.c_str(), lib_path.c_str());
+    available_ = true;
+  }
+
+  ~ScopedCudaPluginRegistration() {
+    if (available_) {
+      try {
+        env_.UnregisterExecutionProviderLibrary(name_.c_str());
+      } catch (...) {
+      }
+    }
+  }
+
+  bool IsAvailable() const { return available_; }
+
+  ScopedCudaPluginRegistration(const ScopedCudaPluginRegistration&) = delete;
+  ScopedCudaPluginRegistration& operator=(const ScopedCudaPluginRegistration&) = delete;
+
+ private:
+  Ort::Env& env_;
+  std::string name_;
+  bool available_ = false;
+};
+
+// Find the CUDA plugin EP device after registration.
+Ort::ConstEpDevice FindCudaPluginDevice(Ort::Env& env) {
+  auto ep_devices = env.GetEpDevices();
+  for (const auto& device : ep_devices) {
+    if (strcmp(device.EpName(), "CudaPluginExecutionProvider") == 0) {
+      return device;
+    }
+  }
+  return Ort::ConstEpDevice{nullptr};
+}
+
+}  // namespace
+
+class CudaPluginArenaTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    int device_count = 0;
+    cudaError_t err = cudaGetDeviceCount(&device_count);
+    if (err != cudaSuccess || device_count == 0) {
+      GTEST_SKIP() << "No CUDA device available.";
+    }
+
+    registration_ = std::make_unique<ScopedCudaPluginRegistration>(
+        *ort_env, kCudaPluginEpRegistrationName);
+    if (!registration_->IsAvailable()) {
+      GTEST_SKIP() << "CUDA plugin EP library not found.";
+    }
+
+    cuda_device_ = FindCudaPluginDevice(*ort_env);
+    if (!cuda_device_) {
+      GTEST_SKIP() << "No CUDA plugin EP device found after registration.";
+    }
+  }
+
+  void TearDown() override {
+    registration_.reset();
+    cudaDeviceSynchronize();
+  }
+
+  std::unique_ptr<ScopedCudaPluginRegistration> registration_;
+  Ort::ConstEpDevice cuda_device_{nullptr};
+};
+
+// Verify that the shared device allocator is backed by an arena.
+TEST_F(CudaPluginArenaTest, DeviceAllocator_IsArena) {
+  auto device_memory_info = cuda_device_.GetMemoryInfo(OrtDeviceMemoryType_DEFAULT);
+  auto allocator = ort_env->GetSharedAllocator(device_memory_info);
+  ASSERT_NE(allocator, nullptr);
+
+  void* p = allocator.Alloc(1024);
+  ASSERT_NE(p, nullptr);
+  allocator.Free(p);
+
+  auto stats = allocator.GetStats();
+  EXPECT_FALSE(GetStatValue(stats, "NumAllocs").empty());
+  EXPECT_FALSE(GetStatValue(stats, "NumArenaExtensions").empty());
+  EXPECT_GE(GetStatInt(stats, "NumArenaExtensions"), 1);
+}
+
+// Verify that CUDA device memory allocated through the arena is usable.
+TEST_F(CudaPluginArenaTest, DeviceAllocator_CudaMemoryIsValid) {
+  auto device_memory_info = cuda_device_.GetMemoryInfo(OrtDeviceMemoryType_DEFAULT);
+  auto allocator = ort_env->GetSharedAllocator(device_memory_info);
+  ASSERT_NE(allocator, nullptr);
+
+  constexpr size_t kBytes = 4096;
+  void* gpu_ptr = allocator.Alloc(kBytes);
+  ASSERT_NE(gpu_ptr, nullptr);
+  auto gpu_ptr_guard = std::unique_ptr<void, std::function<void(void*)>>(
+      gpu_ptr, [&allocator](void* p) { allocator.Free(p); });
+
+  ASSERT_EQ(cudaSuccess, cudaMemset(gpu_ptr, 0xAB, kBytes));
+  ASSERT_EQ(cudaSuccess, cudaDeviceSynchronize());
+
+  std::vector<unsigned char> host_buf(kBytes);
+  ASSERT_EQ(cudaSuccess, cudaMemcpy(host_buf.data(), gpu_ptr, kBytes, cudaMemcpyDeviceToHost));
+  for (size_t i = 0; i < kBytes; ++i) {
+    ASSERT_EQ(host_buf[i], 0xAB) << "Mismatch at byte " << i;
+  }
+}
+
+// Verify that multiple alloc/free cycles reuse arena memory (no new extensions).
+TEST_F(CudaPluginArenaTest, DeviceAllocator_ArenaReusesMemory) {
+  auto device_memory_info = cuda_device_.GetMemoryInfo(OrtDeviceMemoryType_DEFAULT);
+  auto allocator = ort_env->GetSharedAllocator(device_memory_info);
+  ASSERT_NE(allocator, nullptr);
+
+  constexpr size_t kBytes = 512;
+
+  void* p1 = allocator.Alloc(kBytes);
+  ASSERT_NE(p1, nullptr);
+  allocator.Free(p1);
+
+  auto stats1 = allocator.GetStats();
+  int64_t extensions_after_first = GetStatInt(stats1, "NumArenaExtensions");
+
+  void* p2 = allocator.Alloc(kBytes);
+  ASSERT_NE(p2, nullptr);
+  allocator.Free(p2);
+
+  auto stats2 = allocator.GetStats();
+  int64_t extensions_after_second = GetStatInt(stats2, "NumArenaExtensions");
+
+  EXPECT_EQ(extensions_after_first, extensions_after_second)
+      << "Arena should reuse previously freed chunk without extending.";
+}
+
+// Verify multiple concurrent allocations from the arena.
+TEST_F(CudaPluginArenaTest, DeviceAllocator_MultipleAllocations) {
+  auto device_memory_info = cuda_device_.GetMemoryInfo(OrtDeviceMemoryType_DEFAULT);
+  auto allocator = ort_env->GetSharedAllocator(device_memory_info);
+  ASSERT_NE(allocator, nullptr);
+
+  constexpr int kNumAllocs = 10;
+  constexpr size_t kBytes = 2048;
+  std::vector<void*> ptrs;
+  ptrs.reserve(kNumAllocs);
+
+  // RAII cleanup: free all pointers on early exit.
+  auto cleanup = [&]() {
+    for (void* ptr : ptrs) allocator.Free(ptr);
+  };
+  auto guard = std::unique_ptr<void, std::function<void(void*)>>(
+      reinterpret_cast<void*>(1), [&](void*) { cleanup(); });
+
+  for (int i = 0; i < kNumAllocs; ++i) {
+    void* p = allocator.Alloc(kBytes);
+    ASSERT_NE(p, nullptr) << "Allocation " << i << " failed.";
+    ASSERT_EQ(cudaSuccess, cudaMemset(p, static_cast<int>(i & 0xFF), kBytes));
+    ptrs.push_back(p);
+  }
+
+  ASSERT_EQ(cudaSuccess, cudaDeviceSynchronize());
+
+  std::vector<unsigned char> host_buf(kBytes);
+  for (int i = 0; i < kNumAllocs; ++i) {
+    ASSERT_EQ(cudaSuccess, cudaMemcpy(host_buf.data(), ptrs[i], kBytes, cudaMemcpyDeviceToHost));
+    unsigned char expected = static_cast<unsigned char>(i & 0xFF);
+    for (size_t j = 0; j < kBytes; ++j) {
+      ASSERT_EQ(host_buf[j], expected) << "Mismatch at alloc " << i << " byte " << j;
+    }
+  }
+
+  // Guard will free remaining pointers; clear to avoid double-free.
+  cleanup();
+  ptrs.clear();
+
+  auto stats = allocator.GetStats();
+  EXPECT_GE(GetStatInt(stats, "NumAllocs"), kNumAllocs);
+}
+
+// Verify that the pinned allocator is also backed by an arena.
+TEST_F(CudaPluginArenaTest, PinnedAllocator_IsArena) {
+  auto pinned_memory_info = cuda_device_.GetMemoryInfo(OrtDeviceMemoryType_HOST_ACCESSIBLE);
+  if (!pinned_memory_info) {
+    GTEST_SKIP() << "No pinned memory info available for this device.";
+  }
+
+  auto allocator = ort_env->GetSharedAllocator(pinned_memory_info);
+  if (!allocator) {
+    GTEST_SKIP() << "No shared pinned allocator available.";
+  }
+
+  void* p = allocator.Alloc(1024);
+  ASSERT_NE(p, nullptr);
+
+  std::memset(p, 0xCD, 1024);
+  auto* bytes = static_cast<unsigned char*>(p);
+  EXPECT_EQ(bytes[0], 0xCD);
+  EXPECT_EQ(bytes[1023], 0xCD);
+
+  allocator.Free(p);
+
+  auto stats = allocator.GetStats();
+  EXPECT_GE(GetStatInt(stats, "NumArenaExtensions"), 1);
+}
+
+// Verify arena can handle zero-size allocation.
+TEST_F(CudaPluginArenaTest, DeviceAllocator_ZeroSizeAlloc) {
+  auto device_memory_info = cuda_device_.GetMemoryInfo(OrtDeviceMemoryType_DEFAULT);
+  auto allocator = ort_env->GetSharedAllocator(device_memory_info);
+  ASSERT_NE(allocator, nullptr);
+
+  void* p = allocator.Alloc(0);
+  EXPECT_EQ(p, nullptr);
+
+  allocator.Free(nullptr);
+}
+
+// Verify arena handles a large allocation.
+TEST_F(CudaPluginArenaTest, DeviceAllocator_LargeAllocation) {
+  auto device_memory_info = cuda_device_.GetMemoryInfo(OrtDeviceMemoryType_DEFAULT);
+  auto allocator = ort_env->GetSharedAllocator(device_memory_info);
+  ASSERT_NE(allocator, nullptr);
+
+  constexpr size_t kLargeSize = 32 * 1024 * 1024;
+  void* p = allocator.Alloc(kLargeSize);
+  ASSERT_NE(p, nullptr);
+  auto p_guard = std::unique_ptr<void, std::function<void(void*)>>(
+      p, [&allocator](void* ptr) { allocator.Free(ptr); });
+
+  ASSERT_EQ(cudaSuccess, cudaMemset(p, 0xFF, kLargeSize));
+  ASSERT_EQ(cudaSuccess, cudaDeviceSynchronize());
+}
+
+// Verify GetStats reports InUse correctly during allocation lifecycle.
+TEST_F(CudaPluginArenaTest, DeviceAllocator_StatsTrackBytesInUse) {
+  auto device_memory_info = cuda_device_.GetMemoryInfo(OrtDeviceMemoryType_DEFAULT);
+  auto allocator = ort_env->GetSharedAllocator(device_memory_info);
+  ASSERT_NE(allocator, nullptr);
+
+  auto stats_before = allocator.GetStats();
+  int64_t inuse_before = GetStatInt(stats_before, "InUse");
+
+  constexpr size_t kBytes = 4096;
+  void* p = allocator.Alloc(kBytes);
+  ASSERT_NE(p, nullptr);
+
+  auto stats_during = allocator.GetStats();
+  int64_t inuse_during = GetStatInt(stats_during, "InUse");
+  EXPECT_GT(inuse_during, inuse_before);
+
+  allocator.Free(p);
+
+  auto stats_after = allocator.GetStats();
+  int64_t inuse_after = GetStatInt(stats_after, "InUse");
+  EXPECT_LE(inuse_after, inuse_before);
+}
+
+// Verify arena can be replaced via CreateSharedAllocator with custom config.
+// Restores the default allocator at the end to avoid affecting shuffled test ordering.
+TEST_F(CudaPluginArenaTest, DeviceAllocator_ReplaceWithCustomConfig) {
+  auto device_memory_info = cuda_device_.GetMemoryInfo(OrtDeviceMemoryType_DEFAULT);
+  auto allocator = ort_env->GetSharedAllocator(device_memory_info);
+  ASSERT_NE(allocator, nullptr);
+
+  Ort::KeyValuePairs allocator_options;
+  allocator_options.Add("arena.initial_chunk_size_bytes", "25600");
+
+  auto new_allocator = ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator,
+      allocator_options);
+  ASSERT_NE(new_allocator, nullptr);
+
+  void* p = new_allocator.Alloc(256);
+  ASSERT_NE(p, nullptr);
+  new_allocator.Free(p);
+
+  auto stats = new_allocator.GetStats();
+  int64_t total_allocated = GetStatInt(stats, "TotalAllocated");
+  EXPECT_EQ(total_allocated, 25600);
+
+  // Restore the default shared allocator so subsequent tests (under --gtest_shuffle)
+  // can call GetSharedAllocator without hitting an empty slot.
+  ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator, {});
+}
+
+// --- Negative / defensive tests ---
+
+TEST_F(CudaPluginArenaTest, DeviceAllocator_FreeNullptrIsSafe) {
+  auto device_memory_info = cuda_device_.GetMemoryInfo(OrtDeviceMemoryType_DEFAULT);
+  auto allocator = ort_env->GetSharedAllocator(device_memory_info);
+  ASSERT_NE(allocator, nullptr);
+
+  // Free(nullptr) should be a no-op; must not crash.
+  allocator.Free(nullptr);
+}
+
+TEST_F(CudaPluginArenaTest, DeviceAllocator_InvalidConfigIsRejected) {
+  // Providing a non-numeric value for a numeric arena config key should
+  // result in an invalid ArenaConfig (IsValid() == false) which causes
+  // CreateSharedAllocator to return an error.
+  Ort::KeyValuePairs bad_options;
+  bad_options.Add("arena.initial_chunk_size_bytes", "not_a_number");
+
+  try {
+    ORT_IGNORE_RETURN_VALUE(ort_env->CreateSharedAllocator(
+        cuda_device_, OrtDeviceMemoryType_DEFAULT,
+        OrtDeviceAllocator,
+        bad_options));
+    // If we get here, the allocator was created — that's wrong.
+    // Clean up and fail.
+    ort_env->CreateSharedAllocator(
+        cuda_device_, OrtDeviceMemoryType_DEFAULT,
+        OrtDeviceAllocator, {});
+    FAIL() << "Expected CreateSharedAllocator to reject invalid config.";
+  } catch (const Ort::Exception&) {
+    // Expected: invalid config should produce an error.
+  }
+
+  // Restore the default shared allocator.
+  ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator, {});
+}
+
+TEST_F(CudaPluginArenaTest, DeviceAllocator_NegativeConfigIsRejected) {
+  // Negative values for arena config should fail validation.
+  Ort::KeyValuePairs bad_options;
+  bad_options.Add("arena.initial_chunk_size_bytes", "-100");
+
+  try {
+    ORT_IGNORE_RETURN_VALUE(ort_env->CreateSharedAllocator(
+        cuda_device_, OrtDeviceMemoryType_DEFAULT,
+        OrtDeviceAllocator,
+        bad_options));
+    ort_env->CreateSharedAllocator(
+        cuda_device_, OrtDeviceMemoryType_DEFAULT,
+        OrtDeviceAllocator, {});
+    FAIL() << "Expected CreateSharedAllocator to reject negative config value.";
+  } catch (const Ort::Exception&) {
+    // Expected
+  }
+
+  ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator, {});
+}
+
+TEST_F(CudaPluginArenaTest, DeviceAllocator_MaxMemZeroTreatedAsUnlimited) {
+  // arena.max_mem=0 should be treated as unlimited (SIZE_MAX).
+  // The arena should create successfully and allow allocations.
+  Ort::KeyValuePairs options;
+  options.Add("arena.max_mem", "0");
+
+  auto allocator = ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator,
+      options);
+  ASSERT_NE(allocator, nullptr);
+
+  void* p = allocator.Alloc(1024);
+  ASSERT_NE(p, nullptr);
+  allocator.Free(p);
+
+  // Restore default.
+  ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator, {});
+}
+
+TEST_F(CudaPluginArenaTest, DeviceAllocator_ReserveRespectsBudget) {
+  // Set a small max_mem budget and verify Reserve returns nullptr
+  // when allocation would exceed it.
+  Ort::KeyValuePairs options;
+  options.Add("arena.max_mem", "65536");
+  options.Add("arena.initial_chunk_size_bytes", "4096");
+
+  auto allocator = ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator,
+      options);
+  ASSERT_NE(allocator, nullptr);
+
+  // Reserve more than the budget should return nullptr.
+  void* p = allocator.Reserve(128 * 1024);
+  EXPECT_EQ(p, nullptr);
+
+  // Restore default.
+  ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator, {});
+}
+
+// ---------------------------------------------------------------------------
+// CudaMempoolOrtAllocator tests
+// ---------------------------------------------------------------------------
+
+TEST_F(CudaPluginArenaTest, Mempool_BasicAllocFree) {
+  // Enable mempool and verify basic alloc/free roundtrip on device memory.
+  Ort::KeyValuePairs options;
+  options.Add("arena.use_cuda_mempool", "1");
+
+  auto allocator = ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator,
+      options);
+  ASSERT_NE(allocator, nullptr);
+
+  // RAII: restore default allocator on any exit path.
+  auto restore_default = std::unique_ptr<void, std::function<void(void*)>>(
+      reinterpret_cast<void*>(1), [&](void*) {
+        ort_env->CreateSharedAllocator(
+            cuda_device_, OrtDeviceMemoryType_DEFAULT,
+            OrtDeviceAllocator, {});
+      });
+
+  constexpr size_t kBytes = 4096;
+  void* p = allocator.Alloc(kBytes);
+  ASSERT_NE(p, nullptr);
+  auto p_guard = std::unique_ptr<void, std::function<void(void*)>>(
+      p, [&allocator](void* ptr) { allocator.Free(ptr); });
+
+  // Verify the memory is usable on the GPU.
+  ASSERT_EQ(cudaSuccess, cudaMemset(p, 0xAB, kBytes));
+  ASSERT_EQ(cudaSuccess, cudaDeviceSynchronize());
+
+  std::vector<unsigned char> host_buf(kBytes);
+  ASSERT_EQ(cudaSuccess, cudaMemcpy(host_buf.data(), p, kBytes, cudaMemcpyDeviceToHost));
+  for (size_t i = 0; i < kBytes; ++i) {
+    ASSERT_EQ(host_buf[i], 0xAB) << "Mismatch at byte " << i;
+  }
+}
+
+TEST_F(CudaPluginArenaTest, Mempool_MultipleAllocations) {
+  Ort::KeyValuePairs options;
+  options.Add("arena.use_cuda_mempool", "1");
+
+  auto allocator = ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator,
+      options);
+  ASSERT_NE(allocator, nullptr);
+
+  // RAII: restore default allocator on any exit path.
+  auto restore_default = std::unique_ptr<void, std::function<void(void*)>>(
+      reinterpret_cast<void*>(1), [&](void*) {
+        ort_env->CreateSharedAllocator(
+            cuda_device_, OrtDeviceMemoryType_DEFAULT,
+            OrtDeviceAllocator, {});
+      });
+
+  constexpr int kNumAllocs = 8;
+  constexpr size_t kBytes = 2048;
+  std::vector<void*> ptrs;
+  ptrs.reserve(kNumAllocs);
+
+  auto cleanup_ptrs = [&]() {
+    for (void* ptr : ptrs) allocator.Free(ptr);
+  };
+  auto ptrs_guard = std::unique_ptr<void, std::function<void(void*)>>(
+      reinterpret_cast<void*>(1), [&](void*) { cleanup_ptrs(); });
+
+  for (int i = 0; i < kNumAllocs; ++i) {
+    void* p = allocator.Alloc(kBytes);
+    ASSERT_NE(p, nullptr) << "Allocation " << i << " failed.";
+    ASSERT_EQ(cudaSuccess, cudaMemset(p, static_cast<int>(i & 0xFF), kBytes));
+    ptrs.push_back(p);
+  }
+
+  ASSERT_EQ(cudaSuccess, cudaDeviceSynchronize());
+
+  std::vector<unsigned char> host_buf(kBytes);
+  for (int i = 0; i < kNumAllocs; ++i) {
+    ASSERT_EQ(cudaSuccess, cudaMemcpy(host_buf.data(), ptrs[i], kBytes, cudaMemcpyDeviceToHost));
+    unsigned char expected = static_cast<unsigned char>(i & 0xFF);
+    for (size_t j = 0; j < kBytes; ++j) {
+      ASSERT_EQ(host_buf[j], expected) << "Mismatch at alloc " << i << " byte " << j;
+    }
+  }
+
+  // Explicit cleanup; clear to prevent guard double-free.
+  cleanup_ptrs();
+  ptrs.clear();
+}
+
+TEST_F(CudaPluginArenaTest, Mempool_StatsAreReported) {
+  Ort::KeyValuePairs options;
+  options.Add("arena.use_cuda_mempool", "1");
+
+  auto allocator = ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator,
+      options);
+  ASSERT_NE(allocator, nullptr);
+
+  auto restore_default = std::unique_ptr<void, std::function<void(void*)>>(
+      reinterpret_cast<void*>(1), [&](void*) {
+        ort_env->CreateSharedAllocator(
+            cuda_device_, OrtDeviceMemoryType_DEFAULT,
+            OrtDeviceAllocator, {});
+      });
+
+  constexpr size_t kBytes = 1024;
+  void* p = allocator.Alloc(kBytes);
+  ASSERT_NE(p, nullptr);
+  auto p_guard = std::unique_ptr<void, std::function<void(void*)>>(
+      p, [&allocator](void* ptr) { allocator.Free(ptr); });
+
+  auto stats = allocator.GetStats();
+  EXPECT_GE(GetStatInt(stats, "NumAllocs"), 1);
+  EXPECT_GT(GetStatInt(stats, "InUse"), 0);
+
+  p_guard.reset();  // Free p
+
+  auto stats_after = allocator.GetStats();
+  EXPECT_EQ(GetStatInt(stats_after, "InUse"), 0);
+}
+
+TEST_F(CudaPluginArenaTest, Mempool_ZeroSizeAllocReturnsNull) {
+  Ort::KeyValuePairs options;
+  options.Add("arena.use_cuda_mempool", "1");
+
+  auto allocator = ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator,
+      options);
+  ASSERT_NE(allocator, nullptr);
+
+  auto restore_default = std::unique_ptr<void, std::function<void(void*)>>(
+      reinterpret_cast<void*>(1), [&](void*) {
+        ort_env->CreateSharedAllocator(
+            cuda_device_, OrtDeviceMemoryType_DEFAULT,
+            OrtDeviceAllocator, {});
+      });
+
+  void* p = allocator.Alloc(0);
+  EXPECT_EQ(p, nullptr);
+
+  // Free(nullptr) should be safe.
+  allocator.Free(nullptr);
+}
+
+TEST_F(CudaPluginArenaTest, Mempool_LargeAllocation) {
+  Ort::KeyValuePairs options;
+  options.Add("arena.use_cuda_mempool", "1");
+
+  auto allocator = ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator,
+      options);
+  ASSERT_NE(allocator, nullptr);
+
+  // RAII: restore default allocator on any exit path.
+  auto restore_default = std::unique_ptr<void, std::function<void(void*)>>(
+      reinterpret_cast<void*>(1), [&](void*) {
+        ort_env->CreateSharedAllocator(
+            cuda_device_, OrtDeviceMemoryType_DEFAULT,
+            OrtDeviceAllocator, {});
+      });
+
+  constexpr size_t kLargeSize = 32 * 1024 * 1024;  // 32 MB
+  void* p = allocator.Alloc(kLargeSize);
+  ASSERT_NE(p, nullptr);
+  auto p_guard = std::unique_ptr<void, std::function<void(void*)>>(
+      p, [&allocator](void* ptr) { allocator.Free(ptr); });
+
+  ASSERT_EQ(cudaSuccess, cudaMemset(p, 0xFF, kLargeSize));
+  ASSERT_EQ(cudaSuccess, cudaDeviceSynchronize());
+}
+
+TEST_F(CudaPluginArenaTest, Mempool_CustomReleaseThreshold) {
+  // Verify mempool can be created with a custom release threshold.
+  Ort::KeyValuePairs options;
+  options.Add("arena.use_cuda_mempool", "1");
+  options.Add("arena.cuda_mempool_release_threshold", "1048576");  // 1 MB
+
+  auto allocator = ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator,
+      options);
+  ASSERT_NE(allocator, nullptr);
+
+  auto restore_default = std::unique_ptr<void, std::function<void(void*)>>(
+      reinterpret_cast<void*>(1), [&](void*) {
+        ort_env->CreateSharedAllocator(
+            cuda_device_, OrtDeviceMemoryType_DEFAULT,
+            OrtDeviceAllocator, {});
+      });
+
+  void* p = allocator.Alloc(4096);
+  ASSERT_NE(p, nullptr);
+  allocator.Free(p);
+}
+
+TEST_F(CudaPluginArenaTest, Mempool_FreeNullptrIsSafe) {
+  Ort::KeyValuePairs options;
+  options.Add("arena.use_cuda_mempool", "1");
+
+  auto allocator = ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator,
+      options);
+  ASSERT_NE(allocator, nullptr);
+
+  auto restore_default = std::unique_ptr<void, std::function<void(void*)>>(
+      reinterpret_cast<void*>(1), [&](void*) {
+        ort_env->CreateSharedAllocator(
+            cuda_device_, OrtDeviceMemoryType_DEFAULT,
+            OrtDeviceAllocator, {});
+      });
+
+  // Must not crash.
+  allocator.Free(nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// Arena config coverage tests
+// ---------------------------------------------------------------------------
+
+// Verify kSameAsRequested extend strategy allocates exactly the requested amount.
+TEST_F(CudaPluginArenaTest, DeviceAllocator_SameAsRequestedStrategy) {
+  Ort::KeyValuePairs options;
+  options.Add("arena.extend_strategy", "1");  // kSameAsRequested
+  options.Add("arena.initial_chunk_size_bytes", "4096");
+
+  auto allocator = ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator,
+      options);
+  ASSERT_NE(allocator, nullptr);
+
+  auto restore_default = std::unique_ptr<void, std::function<void(void*)>>(
+      reinterpret_cast<void*>(1), [&](void*) {
+        ort_env->CreateSharedAllocator(
+            cuda_device_, OrtDeviceMemoryType_DEFAULT,
+            OrtDeviceAllocator, {});
+      });
+
+  void* p = allocator.Alloc(2048);
+  ASSERT_NE(p, nullptr);
+  allocator.Free(p);
+
+  auto stats = allocator.GetStats();
+  // kSameAsRequested: each extension allocates exactly what's needed (rounded to kMinAllocationSize).
+  EXPECT_GE(GetStatInt(stats, "NumArenaExtensions"), 1);
+}
+
+// Verify max_dead_bytes_per_chunk config is accepted and arena works.
+TEST_F(CudaPluginArenaTest, DeviceAllocator_MaxDeadBytesConfig) {
+  Ort::KeyValuePairs options;
+  options.Add("arena.max_dead_bytes_per_chunk", "1024");
+
+  auto allocator = ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator,
+      options);
+  ASSERT_NE(allocator, nullptr);
+
+  auto restore_default = std::unique_ptr<void, std::function<void(void*)>>(
+      reinterpret_cast<void*>(1), [&](void*) {
+        ort_env->CreateSharedAllocator(
+            cuda_device_, OrtDeviceMemoryType_DEFAULT,
+            OrtDeviceAllocator, {});
+      });
+
+  // A small max_dead_bytes forces more aggressive splitting.
+  void* p1 = allocator.Alloc(512);
+  ASSERT_NE(p1, nullptr);
+  void* p2 = allocator.Alloc(256);
+  ASSERT_NE(p2, nullptr);
+  allocator.Free(p1);
+  allocator.Free(p2);
+}
+
+// Verify initial_growth_chunk_size_bytes config is accepted.
+TEST_F(CudaPluginArenaTest, DeviceAllocator_InitialGrowthChunkSizeConfig) {
+  Ort::KeyValuePairs options;
+  options.Add("arena.initial_growth_chunk_size_bytes", "8192");
+
+  auto allocator = ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator,
+      options);
+  ASSERT_NE(allocator, nullptr);
+
+  auto restore_default = std::unique_ptr<void, std::function<void(void*)>>(
+      reinterpret_cast<void*>(1), [&](void*) {
+        ort_env->CreateSharedAllocator(
+            cuda_device_, OrtDeviceMemoryType_DEFAULT,
+            OrtDeviceAllocator, {});
+      });
+
+  void* p = allocator.Alloc(1024);
+  ASSERT_NE(p, nullptr);
+  allocator.Free(p);
+}
+
+// Verify max_power_of_two_extend_bytes config is accepted.
+TEST_F(CudaPluginArenaTest, DeviceAllocator_MaxPowerOfTwoExtendConfig) {
+  Ort::KeyValuePairs options;
+  options.Add("arena.max_power_of_two_extend_bytes", "1048576");  // 1 MB cap
+
+  auto allocator = ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator,
+      options);
+  ASSERT_NE(allocator, nullptr);
+
+  auto restore_default = std::unique_ptr<void, std::function<void(void*)>>(
+      reinterpret_cast<void*>(1), [&](void*) {
+        ort_env->CreateSharedAllocator(
+            cuda_device_, OrtDeviceMemoryType_DEFAULT,
+            OrtDeviceAllocator, {});
+      });
+
+  void* p = allocator.Alloc(2048);
+  ASSERT_NE(p, nullptr);
+  allocator.Free(p);
+}
+
+// Verify multiple config keys combined.
+TEST_F(CudaPluginArenaTest, DeviceAllocator_CombinedConfig) {
+  Ort::KeyValuePairs options;
+  options.Add("arena.extend_strategy", "1");  // kSameAsRequested
+  options.Add("arena.initial_chunk_size_bytes", "8192");
+  options.Add("arena.max_dead_bytes_per_chunk", "512");
+  options.Add("arena.max_mem", "2097152");  // 2 MB
+
+  auto allocator = ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator,
+      options);
+  ASSERT_NE(allocator, nullptr);
+
+  auto restore_default = std::unique_ptr<void, std::function<void(void*)>>(
+      reinterpret_cast<void*>(1), [&](void*) {
+        ort_env->CreateSharedAllocator(
+            cuda_device_, OrtDeviceMemoryType_DEFAULT,
+            OrtDeviceAllocator, {});
+      });
+
+  void* p = allocator.Alloc(4096);
+  ASSERT_NE(p, nullptr);
+  allocator.Free(p);
+
+  auto stats = allocator.GetStats();
+  EXPECT_GE(GetStatInt(stats, "NumAllocs"), 1);
+}
+
+// Verify arena chunk splitting: allocate a large chunk then a small one.
+// The second allocation should reuse a split portion of the first free chunk.
+TEST_F(CudaPluginArenaTest, DeviceAllocator_ChunkSplitting) {
+  Ort::KeyValuePairs options;
+  options.Add("arena.initial_chunk_size_bytes", "65536");
+  options.Add("arena.max_dead_bytes_per_chunk", "256");  // force aggressive splitting
+
+  auto allocator = ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator,
+      options);
+  ASSERT_NE(allocator, nullptr);
+
+  auto restore_default = std::unique_ptr<void, std::function<void(void*)>>(
+      reinterpret_cast<void*>(1), [&](void*) {
+        ort_env->CreateSharedAllocator(
+            cuda_device_, OrtDeviceMemoryType_DEFAULT,
+            OrtDeviceAllocator, {});
+      });
+
+  // First alloc triggers arena extension.
+  void* p1 = allocator.Alloc(256);
+  ASSERT_NE(p1, nullptr);
+
+  auto stats1 = allocator.GetStats();
+  int64_t ext1 = GetStatInt(stats1, "NumArenaExtensions");
+
+  // Second alloc should reuse the remainder of the first chunk (no new extension).
+  void* p2 = allocator.Alloc(256);
+  ASSERT_NE(p2, nullptr);
+
+  auto stats2 = allocator.GetStats();
+  int64_t ext2 = GetStatInt(stats2, "NumArenaExtensions");
+  EXPECT_EQ(ext1, ext2) << "Second alloc should split from existing chunk, not extend.";
+
+  allocator.Free(p1);
+  allocator.Free(p2);
+}
+
+// Verify chunk coalescing: alloc two adjacent chunks, free both, then alloc a large one
+// that only fits if the two free chunks are merged.
+TEST_F(CudaPluginArenaTest, DeviceAllocator_ChunkCoalescing) {
+  Ort::KeyValuePairs options;
+  // Use kNextPowerOfTwo (default) so that both small allocations come from
+  // a single extension region and their freed chunks are contiguous.
+  options.Add("arena.initial_chunk_size_bytes", "16384");
+
+  auto allocator = ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator,
+      options);
+  ASSERT_NE(allocator, nullptr);
+
+  auto restore_default = std::unique_ptr<void, std::function<void(void*)>>(
+      reinterpret_cast<void*>(1), [&](void*) {
+        ort_env->CreateSharedAllocator(
+            cuda_device_, OrtDeviceMemoryType_DEFAULT,
+            OrtDeviceAllocator, {});
+      });
+
+  constexpr size_t kSize = 4096;
+  void* p1 = allocator.Alloc(kSize);
+  void* p2 = allocator.Alloc(kSize);
+  ASSERT_NE(p1, nullptr);
+  ASSERT_NE(p2, nullptr);
+
+  auto stats_before = allocator.GetStats();
+  int64_t ext_before = GetStatInt(stats_before, "NumArenaExtensions");
+
+  // Free both — the arena should coalesce them into a single free chunk.
+  allocator.Free(p1);
+  allocator.Free(p2);
+
+  // Allocate a size that fits into the coalesced free chunk.
+  void* p3 = allocator.Alloc(kSize * 2);
+  ASSERT_NE(p3, nullptr);
+
+  auto stats_after = allocator.GetStats();
+  int64_t ext_after = GetStatInt(stats_after, "NumArenaExtensions");
+  // Coalescing: the large alloc should reuse the merged free chunk without extending.
+  EXPECT_EQ(ext_before, ext_after) << "Coalesced free chunk should serve the large alloc.";
+
+  allocator.Free(p3);
+}
+
+// Verify Reserve within budget succeeds and the reserved memory is freed correctly.
+TEST_F(CudaPluginArenaTest, DeviceAllocator_ReserveWithinBudget) {
+  Ort::KeyValuePairs options;
+  options.Add("arena.max_mem", "2097152");  // 2 MB
+  options.Add("arena.initial_chunk_size_bytes", "4096");
+
+  auto allocator = ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator,
+      options);
+  ASSERT_NE(allocator, nullptr);
+
+  auto restore_default = std::unique_ptr<void, std::function<void(void*)>>(
+      reinterpret_cast<void*>(1), [&](void*) {
+        ort_env->CreateSharedAllocator(
+            cuda_device_, OrtDeviceMemoryType_DEFAULT,
+            OrtDeviceAllocator, {});
+      });
+
+  void* p = allocator.Reserve(4096);
+  ASSERT_NE(p, nullptr);
+
+  // Reserved memory contributes to InUse.
+  auto stats = allocator.GetStats();
+  EXPECT_GT(GetStatInt(stats, "InUse"), 0);
+  EXPECT_GE(GetStatInt(stats, "NumReserves"), 1);
+
+  // Free the reserved chunk.
+  allocator.Free(p);
+
+  auto stats_after = allocator.GetStats();
+  EXPECT_EQ(GetStatInt(stats_after, "InUse"), 0);
+}
+
+// Verify max_mem exactly exhausted: alloc up to the limit, then one more should fail.
+TEST_F(CudaPluginArenaTest, DeviceAllocator_MaxMemExhaustion) {
+  constexpr size_t kMaxMem = 65536;
+  Ort::KeyValuePairs options;
+  options.Add("arena.max_mem", std::to_string(kMaxMem).c_str());
+  options.Add("arena.initial_chunk_size_bytes", std::to_string(kMaxMem).c_str());
+
+  auto allocator = ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator,
+      options);
+  ASSERT_NE(allocator, nullptr);
+
+  auto restore_default = std::unique_ptr<void, std::function<void(void*)>>(
+      reinterpret_cast<void*>(1), [&](void*) {
+        ort_env->CreateSharedAllocator(
+            cuda_device_, OrtDeviceMemoryType_DEFAULT,
+            OrtDeviceAllocator, {});
+      });
+
+  // Exhaust the arena.
+  void* p1 = allocator.Alloc(kMaxMem);
+  ASSERT_NE(p1, nullptr);
+
+  // Arena is full — next alloc should return nullptr (not crash).
+  void* p2 = allocator.Alloc(256);
+  EXPECT_EQ(p2, nullptr);
+
+  allocator.Free(p1);
+}
+
+// Verify non-numeric max_mem is rejected.
+TEST_F(CudaPluginArenaTest, DeviceAllocator_InvalidMaxMemIsRejected) {
+  Ort::KeyValuePairs bad_options;
+  bad_options.Add("arena.max_mem", "abc");
+
+  try {
+    ORT_IGNORE_RETURN_VALUE(ort_env->CreateSharedAllocator(
+        cuda_device_, OrtDeviceMemoryType_DEFAULT,
+        OrtDeviceAllocator,
+        bad_options));
+    ort_env->CreateSharedAllocator(
+        cuda_device_, OrtDeviceMemoryType_DEFAULT,
+        OrtDeviceAllocator, {});
+    FAIL() << "Expected CreateSharedAllocator to reject invalid max_mem.";
+  } catch (const Ort::Exception&) {
+    // Expected
+  }
+
+  ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator, {});
+}
+
+// Verify pinned allocator with custom config.
+TEST_F(CudaPluginArenaTest, PinnedAllocator_CustomConfig) {
+  auto pinned_memory_info = cuda_device_.GetMemoryInfo(OrtDeviceMemoryType_HOST_ACCESSIBLE);
+  if (!pinned_memory_info) {
+    GTEST_SKIP() << "No pinned memory info available for this device.";
+  }
+
+  Ort::KeyValuePairs options;
+  options.Add("arena.initial_chunk_size_bytes", "16384");
+
+  auto allocator = ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_HOST_ACCESSIBLE,
+      OrtDeviceAllocator,
+      options);
+  if (!allocator) {
+    GTEST_SKIP() << "No shared pinned allocator from CreateSharedAllocator.";
+  }
+
+  auto restore_default = std::unique_ptr<void, std::function<void(void*)>>(
+      reinterpret_cast<void*>(1), [&](void*) {
+        ort_env->CreateSharedAllocator(
+            cuda_device_, OrtDeviceMemoryType_HOST_ACCESSIBLE,
+            OrtDeviceAllocator, {});
+      });
+
+  void* p = allocator.Alloc(1024);
+  ASSERT_NE(p, nullptr);
+
+  // Pinned memory should be directly usable from host.
+  std::memset(p, 0xAA, 1024);
+  auto* bytes = static_cast<unsigned char*>(p);
+  EXPECT_EQ(bytes[0], 0xAA);
+  EXPECT_EQ(bytes[1023], 0xAA);
+
+  allocator.Free(p);
+
+  auto stats = allocator.GetStats();
+  EXPECT_EQ(GetStatInt(stats, "TotalAllocated"), 16384);
+}
+
+// Verify pinned: alloc, free, realloc reuses memory.
+TEST_F(CudaPluginArenaTest, PinnedAllocator_Reuse) {
+  auto pinned_memory_info = cuda_device_.GetMemoryInfo(OrtDeviceMemoryType_HOST_ACCESSIBLE);
+  if (!pinned_memory_info) {
+    GTEST_SKIP() << "No pinned memory info available for this device.";
+  }
+
+  auto allocator = ort_env->GetSharedAllocator(pinned_memory_info);
+  if (!allocator) {
+    GTEST_SKIP() << "No shared pinned allocator available.";
+  }
+
+  void* p1 = allocator.Alloc(512);
+  ASSERT_NE(p1, nullptr);
+  allocator.Free(p1);
+
+  auto stats1 = allocator.GetStats();
+  int64_t ext1 = GetStatInt(stats1, "NumArenaExtensions");
+
+  void* p2 = allocator.Alloc(512);
+  ASSERT_NE(p2, nullptr);
+  allocator.Free(p2);
+
+  auto stats2 = allocator.GetStats();
+  int64_t ext2 = GetStatInt(stats2, "NumArenaExtensions");
+  EXPECT_EQ(ext1, ext2) << "Pinned arena should reuse freed chunk.";
+}
+
+// Verify all stat keys are reported for the device arena.
+TEST_F(CudaPluginArenaTest, DeviceAllocator_AllStatsKeysPresent) {
+  auto device_memory_info = cuda_device_.GetMemoryInfo(OrtDeviceMemoryType_DEFAULT);
+  auto allocator = ort_env->GetSharedAllocator(device_memory_info);
+  ASSERT_NE(allocator, nullptr);
+
+  void* p = allocator.Alloc(1024);
+  ASSERT_NE(p, nullptr);
+  allocator.Free(p);
+
+  auto stats = allocator.GetStats();
+  // All known stat keys should be present.
+  EXPECT_FALSE(GetStatValue(stats, "Limit").empty());
+  EXPECT_FALSE(GetStatValue(stats, "InUse").empty());
+  EXPECT_FALSE(GetStatValue(stats, "TotalAllocated").empty());
+  EXPECT_FALSE(GetStatValue(stats, "MaxInUse").empty());
+  EXPECT_FALSE(GetStatValue(stats, "NumAllocs").empty());
+  EXPECT_FALSE(GetStatValue(stats, "NumReserves").empty());
+  EXPECT_FALSE(GetStatValue(stats, "NumArenaExtensions").empty());
+  EXPECT_FALSE(GetStatValue(stats, "NumArenaShrinkages").empty());
+  EXPECT_FALSE(GetStatValue(stats, "MaxAllocSize").empty());
+}
+
+// Verify mempool bytes_to_keep_on_shrink config is accepted.
+TEST_F(CudaPluginArenaTest, Mempool_BytesToKeepOnShrinkConfig) {
+  Ort::KeyValuePairs options;
+  options.Add("arena.use_cuda_mempool", "1");
+  options.Add("arena.cuda_mempool_bytes_to_keep_on_shrink", "65536");
+
+  auto allocator = ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator,
+      options);
+  ASSERT_NE(allocator, nullptr);
+
+  auto restore_default = std::unique_ptr<void, std::function<void(void*)>>(
+      reinterpret_cast<void*>(1), [&](void*) {
+        ort_env->CreateSharedAllocator(
+            cuda_device_, OrtDeviceMemoryType_DEFAULT,
+            OrtDeviceAllocator, {});
+      });
+
+  void* p = allocator.Alloc(4096);
+  ASSERT_NE(p, nullptr);
+  allocator.Free(p);
+}
+
+// Verify mempool all stat keys present.
+TEST_F(CudaPluginArenaTest, Mempool_AllStatsKeysPresent) {
+  Ort::KeyValuePairs options;
+  options.Add("arena.use_cuda_mempool", "1");
+
+  auto allocator = ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator,
+      options);
+  ASSERT_NE(allocator, nullptr);
+
+  auto restore_default = std::unique_ptr<void, std::function<void(void*)>>(
+      reinterpret_cast<void*>(1), [&](void*) {
+        ort_env->CreateSharedAllocator(
+            cuda_device_, OrtDeviceMemoryType_DEFAULT,
+            OrtDeviceAllocator, {});
+      });
+
+  void* p = allocator.Alloc(256);
+  ASSERT_NE(p, nullptr);
+  allocator.Free(p);
+
+  auto stats = allocator.GetStats();
+  EXPECT_FALSE(GetStatValue(stats, "NumAllocs").empty());
+  EXPECT_FALSE(GetStatValue(stats, "TotalAllocated").empty());
+  EXPECT_FALSE(GetStatValue(stats, "InUse").empty());
+  EXPECT_FALSE(GetStatValue(stats, "MaxInUse").empty());
+  EXPECT_FALSE(GetStatValue(stats, "MaxAllocSize").empty());
+}
+
+// Verify that Shrink on the device arena frees unused regions and updates stats.
+TEST_F(CudaPluginArenaTest, DeviceAllocator_ShrinkFreesUnusedRegions) {
+  auto device_memory_info = cuda_device_.GetMemoryInfo(OrtDeviceMemoryType_DEFAULT);
+
+  // Create a fresh allocator so stats are clean regardless of test order.
+  ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator, {});
+  auto restore = std::unique_ptr<void, std::function<void(void*)>>(
+      reinterpret_cast<void*>(1), [&](void*) {
+        ort_env->CreateSharedAllocator(
+            cuda_device_, OrtDeviceMemoryType_DEFAULT,
+            OrtDeviceAllocator, {});
+      });
+
+  auto allocator = ort_env->GetSharedAllocator(device_memory_info);
+  ASSERT_NE(allocator, nullptr);
+
+  // Allocate and free to create a region.
+  constexpr size_t kBytes = 4096;
+  void* p = allocator.Alloc(kBytes);
+  ASSERT_NE(p, nullptr);
+  allocator.Free(p);
+
+  auto stats_before = allocator.GetStats();
+  int64_t total_before = GetStatInt(stats_before, "TotalAllocated");
+  ASSERT_GT(total_before, 0);
+
+  // Shrink should free the (now entirely free) region.
+  allocator.Shrink();
+
+  auto stats_after = allocator.GetStats();
+  int64_t total_after = GetStatInt(stats_after, "TotalAllocated");
+  EXPECT_LT(total_after, total_before);
+  EXPECT_GE(GetStatInt(stats_after, "NumArenaShrinkages"), 1);
+}
+
+// Verify that Shrink does not free regions that have live allocations.
+TEST_F(CudaPluginArenaTest, DeviceAllocator_ShrinkKeepsLiveRegions) {
+  auto device_memory_info = cuda_device_.GetMemoryInfo(OrtDeviceMemoryType_DEFAULT);
+
+  // Fresh allocator for isolation.
+  ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator, {});
+  auto restore = std::unique_ptr<void, std::function<void(void*)>>(
+      reinterpret_cast<void*>(1), [&](void*) {
+        ort_env->CreateSharedAllocator(
+            cuda_device_, OrtDeviceMemoryType_DEFAULT,
+            OrtDeviceAllocator, {});
+      });
+
+  auto allocator = ort_env->GetSharedAllocator(device_memory_info);
+  ASSERT_NE(allocator, nullptr);
+
+  constexpr size_t kBytes = 4096;
+  void* p = allocator.Alloc(kBytes);
+  ASSERT_NE(p, nullptr);
+  auto p_guard = std::unique_ptr<void, std::function<void(void*)>>(
+      p, [&allocator](void* ptr) { allocator.Free(ptr); });
+
+  auto stats_before = allocator.GetStats();
+  int64_t total_before = GetStatInt(stats_before, "TotalAllocated");
+
+  // Shrink while allocation is live — nothing should change.
+  allocator.Shrink();
+
+  auto stats_after = allocator.GetStats();
+  EXPECT_EQ(GetStatInt(stats_after, "TotalAllocated"), total_before);
+}
+
+// Verify that Shrink on the pinned arena works.
+TEST_F(CudaPluginArenaTest, PinnedAllocator_ShrinkFreesUnusedRegions) {
+  auto pinned_memory_info = cuda_device_.GetMemoryInfo(OrtDeviceMemoryType_HOST_ACCESSIBLE);
+  if (!pinned_memory_info) {
+    GTEST_SKIP() << "No pinned memory info available for this device.";
+  }
+
+  // Fresh allocator for isolation.
+  ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_HOST_ACCESSIBLE,
+      OrtDeviceAllocator, {});
+  auto restore = std::unique_ptr<void, std::function<void(void*)>>(
+      reinterpret_cast<void*>(1), [&](void*) {
+        ort_env->CreateSharedAllocator(
+            cuda_device_, OrtDeviceMemoryType_HOST_ACCESSIBLE,
+            OrtDeviceAllocator, {});
+      });
+
+  auto allocator = ort_env->GetSharedAllocator(pinned_memory_info);
+  if (!allocator) {
+    GTEST_SKIP() << "No shared pinned allocator available.";
+  }
+
+  void* p = allocator.Alloc(1024);
+  ASSERT_NE(p, nullptr);
+  allocator.Free(p);
+
+  auto stats_before = allocator.GetStats();
+  int64_t total_before = GetStatInt(stats_before, "TotalAllocated");
+  ASSERT_GT(total_before, 0);
+
+  allocator.Shrink();
+
+  auto stats_after = allocator.GetStats();
+  EXPECT_LT(GetStatInt(stats_after, "TotalAllocated"), total_before);
+  EXPECT_GE(GetStatInt(stats_after, "NumArenaShrinkages"), 1);
+}
+
+// Verify that Shrink on the mempool allocator increments shrinkage counter.
+TEST_F(CudaPluginArenaTest, MempoolAllocator_ShrinkTrimsPool) {
+  // Create a mempool-based allocator via session config.
+  Ort::KeyValuePairs options;
+  options.Add("arena.use_cuda_mempool", "1");
+
+  ort_env->CreateSharedAllocator(
+      cuda_device_, OrtDeviceMemoryType_DEFAULT,
+      OrtDeviceAllocator,
+      options);
+
+  auto device_memory_info = cuda_device_.GetMemoryInfo(OrtDeviceMemoryType_DEFAULT);
+  auto allocator = ort_env->GetSharedAllocator(device_memory_info);
+  ASSERT_NE(allocator, nullptr);
+
+  auto restore_default = std::unique_ptr<void, std::function<void(void*)>>(
+      reinterpret_cast<void*>(1), [&](void*) {
+        ort_env->CreateSharedAllocator(
+            cuda_device_, OrtDeviceMemoryType_DEFAULT,
+            OrtDeviceAllocator, {});
+      });
+
+  // Allocate and free to make the pool non-empty.
+  void* p = allocator.Alloc(1024);
+  ASSERT_NE(p, nullptr);
+  allocator.Free(p);
+  cudaDeviceSynchronize();
+
+  auto stats_before = allocator.GetStats();
+  int64_t shrinkages_before = GetStatInt(stats_before, "NumArenaShrinkages");
+
+  allocator.Shrink();
+
+  auto stats_after = allocator.GetStats();
+  EXPECT_EQ(GetStatInt(stats_after, "NumArenaShrinkages"), shrinkages_before + 1);
+}
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // defined(ORT_UNIT_TEST_HAS_CUDA_PLUGIN_EP)

--- a/onnxruntime/test/python/requirements.txt
+++ b/onnxruntime/test/python/requirements.txt
@@ -1,3 +1,3 @@
-onnx==1.20.1
+onnx==1.21.0
 pytest
 onnx-ir

--- a/onnxruntime/test/python/transformers/test_onnx_attention/test_gqa.py
+++ b/onnxruntime/test/python/transformers/test_onnx_attention/test_gqa.py
@@ -863,22 +863,26 @@ class TestONNXAttentionMemoryEfficientGQA(unittest.TestCase):
     # flash attention.
 
 
+# TODO(titaiwang): Re-enable once PR #27851 merges (MEA supports past_key for GQA).
+# Flash now rejects attn_mask (requires attn_mask==nullptr). GQA + bool mask + past_key
+# has no runner until MEA supports past_key. See issue #27885.
+@unittest.skip(
+    "Flash now rejects attn_mask. GQA + bool mask + past_key has no runner "
+    "until PR #27851 (MEA with past_key). See issue #27885."
+)
 @unittest.skipIf(not has_flash_attention(), "Flash Attention is not available, skipping tests.")
 @patch.dict(os.environ, {"ORT_DISABLE_FLASH_ATTENTION": "0"})
 class TestONNXAttentionPaddingMaskGQA(unittest.TestCase):
     """
     Test ONNX Attention op (opset 23) GQA path with boolean padding masks.
 
-    Requires SM80+: decode+padding tests explicitly force Flash via
-    ORT_DISABLE_FLASH_ATTENTION=0.  Prompt+padding uses MEA fallback and is
-    tested separately in TestONNXAttentionPaddingMaskMemoryEfficientGQA.
+    SKIPPED: Flash now requires attn_mask == nullptr. GQA + bool attn_mask +
+    past_key currently has no runner (Flash rejected, unfused doesn't support GQA,
+    MEA blocked by past_key != nullptr). Will be re-enabled when PR #27851 lands.
 
     These tests verify that the boolean attn_mask is correctly converted to
     sequence lengths on GPU and that the attention computation respects the
     padding. Tests cover 2D, 3D, and 4D mask shapes.
-
-    Note: prompt+bool_mask is ineligible for flash (routed to MEA), so prompt
-    padding tests live in TestONNXAttentionPaddingMaskMemoryEfficientGQA only.
     """
 
     @parameterized.expand(gqa_past_padding_test_cases())

--- a/onnxruntime/test/python/transformers/test_onnx_attention/test_mha.py
+++ b/onnxruntime/test/python/transformers/test_onnx_attention/test_mha.py
@@ -1460,10 +1460,8 @@ class TestONNXAttentionMHA2DMaskBroadcast(unittest.TestCase):
         attn_mask[0, 4:] = False
         attn_mask[1, 6:] = False
 
-        # Zero out K/V at padded positions (use row 0's pattern since 2D mask broadcasts)
-        # For bool mask, the effective seqlen for all batches comes from row 0 (most restrictive)
-        # Actually for cross-attention with different masking per query, just zero out nothing
-        # The reference uses key_padding_mask for padding, or we can use attn_bias directly
+        # Build additive bias from the bool mask for the PyTorch reference.
+        # 2D mask broadcasts identically across batches and heads.
         mask_filter_value = torch.finfo(torch_type).min
         attn_bias_ref = torch.where(
             attn_mask.unsqueeze(0).unsqueeze(0).expand(config.batch_size, config.q_num_heads, -1, -1),
@@ -1490,6 +1488,13 @@ class TestONNXAttentionMHA2DMaskBroadcast(unittest.TestCase):
         out_np = out_ort.float().detach().cpu().numpy()
         out_ref_np = out_ref.float().detach().cpu().numpy()
         numpy.testing.assert_allclose(out_np, out_ref_np, rtol=rtol["fp16"], atol=atol["fp16"])
+
+
+# NOTE: GQA fully-masked batch fix (ZeroOutputForFullyMaskedBatches) is validated by
+# C++ test Attention_NonPadKVSeqLen_AllMasked_FP16_GQA. Python graph-level test omitted
+# because the fix is a CUDA kernel in the MEA path — a CPU-only test cannot validate it,
+# and CUDA debug builds trigger kernel assertions for zero seqlens (pre-existing issue
+# with 4D mask alignment in attention_transpose.cu).
 
 
 if __name__ == "__main__":

--- a/onnxruntime/test/shared_lib/test_model_builder_api.cc
+++ b/onnxruntime/test/shared_lib/test_model_builder_api.cc
@@ -125,6 +125,7 @@ struct TestAllocator : public OrtAllocator {
 
     GetStats = nullptr;
     AllocOnStream = nullptr;
+    Shrink = nullptr;
   }
 
   // initializers that are used directly by the model. as there's no copy they must remain valid.

--- a/onnxruntime/test/shared_lib/test_version.cc
+++ b/onnxruntime/test/shared_lib/test_version.cc
@@ -27,5 +27,5 @@ TEST(CApiTest, VersionConsistencyWithApiVersion) {
 
   ASSERT_NE(to_uint32_t(version_string_components[0]), std::nullopt);
   ASSERT_EQ(to_uint32_t(version_string_components[1]), uint32_t{ORT_API_VERSION});
-  ASSERT_NE(to_uint32_t(version_string_components[0]), std::nullopt);
+  ASSERT_NE(to_uint32_t(version_string_components[2]), std::nullopt);
 }

--- a/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
+++ b/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
@@ -377,7 +377,16 @@
         "^test_quantizelinear_int4",
         "^test_quantizelinear_uint4",
         // topk uint64 is not implemented in ORT yet.
-        "^test_top_k_uint64"
+        "^test_top_k_uint64",
+        // ORT DFT kernel does not implement IRFFT (inverse real FFT) — it always outputs
+        // complex (last dim=2) which is wrong for IRFFT. These ONNX backend tests were
+        // added in onnx commit ee910d0e4 for DFT-20 spec clarification.
+        "^test_dft_rfft",
+        "^test_dft_irfft",
+        "^test_dft_rfft_opset19",
+        "^test_dft_irfft_opset19",
+        // ORT BitCast kernel does not support bool type.
+        "^test_bitcast_bool_to_uint8"
     ],
     "current_failing_tests_x86": [
         "^test_vgg19",

--- a/onnxruntime/test/unittest_main/test_main.cc
+++ b/onnxruntime/test/unittest_main/test_main.cc
@@ -3,12 +3,14 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <iterator>
 #include <memory>
 #include <optional>
 #include <string>
 #include <vector>
 #ifdef _WIN32
-#include <iostream>
 #include <locale>
 #endif
 
@@ -51,6 +53,9 @@ constexpr const char* kLogLevel = "ORT_UNIT_TEST_MAIN_LOG_LEVEL";
 // Specify dynamic plugin EP configuration JSON.
 // Refer to `onnxruntime::test::dynamic_plugin_ep_infra::ParseInitializationConfig()` for more information.
 constexpr const char* kDynamicPluginEpConfigJson = "ORT_UNIT_TEST_MAIN_DYNAMIC_PLUGIN_EP_CONFIG_JSON";
+// Specify a file path from which to read dynamic plugin EP configuration JSON.
+// Mutually exclusive with kDynamicPluginEpConfigJson.
+constexpr const char* kDynamicPluginEpConfigJsonFile = "ORT_UNIT_TEST_MAIN_DYNAMIC_PLUGIN_EP_CONFIG_JSON_FILE";
 #endif  // defined(TEST_MAIN_ENABLE_DYNAMIC_PLUGIN_EP_USAGE)
 }  // namespace env_var_names
 
@@ -79,9 +84,27 @@ extern "C" void ortenv_setup() {
 #if defined(TEST_MAIN_ENABLE_DYNAMIC_PLUGIN_EP_USAGE)
     {
       namespace dynamic_plugin_ep_infra = onnxruntime::test::dynamic_plugin_ep_infra;
-      if (auto dynamic_plugin_ep_config_json = onnxruntime::ParseEnvironmentVariable<std::string>(
-              env_var_names::kDynamicPluginEpConfigJson);
-          dynamic_plugin_ep_config_json.has_value()) {
+
+      auto dynamic_plugin_ep_config_json = onnxruntime::ParseEnvironmentVariable<std::string>(
+          env_var_names::kDynamicPluginEpConfigJson);
+      auto dynamic_plugin_ep_config_json_file = onnxruntime::ParseEnvironmentVariable<std::string>(
+          env_var_names::kDynamicPluginEpConfigJsonFile);
+
+      ORT_ENFORCE(!dynamic_plugin_ep_config_json.has_value() || !dynamic_plugin_ep_config_json_file.has_value(),
+                  "Only one of ", env_var_names::kDynamicPluginEpConfigJson,
+                  " and ", env_var_names::kDynamicPluginEpConfigJsonFile,
+                  " should be set, not both.");
+
+      if (dynamic_plugin_ep_config_json_file.has_value()) {
+        const auto& config_file_path = *dynamic_plugin_ep_config_json_file;
+        std::cout << "Reading dynamic plugin EP configuration from file: " << config_file_path << "\n";
+        std::ifstream config_file{config_file_path};
+        ORT_ENFORCE(config_file, "Failed to open dynamic plugin EP configuration file: ", config_file_path);
+        dynamic_plugin_ep_config_json.emplace(
+            std::istreambuf_iterator<char>{config_file}, std::istreambuf_iterator<char>{});
+      }
+
+      if (dynamic_plugin_ep_config_json.has_value()) {
         std::cout << "Initializing dynamic plugin EP infrastructure with configuration:\n"
                   << *dynamic_plugin_ep_config_json << "\n";
         dynamic_plugin_ep_infra::InitializationConfig config{};

--- a/onnxruntime/test/util/test_allocator.cc
+++ b/onnxruntime/test/util/test_allocator.cc
@@ -14,6 +14,8 @@ MockedOrtAllocator::MockedOrtAllocator() {
     *stats = static_cast<const MockedOrtAllocator*>(this_)->Stats();
     return nullptr;
   };
+  OrtAllocator::AllocOnStream = nullptr;
+  OrtAllocator::Shrink = nullptr;
   Ort::ThrowOnError(Ort::GetApi().CreateCpuMemoryInfo(OrtDeviceAllocator, OrtMemTypeDefault, &cpu_memory_info));
 }
 

--- a/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-cuda-minimal-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-cuda-minimal-ci-pipeline.yml
@@ -93,6 +93,10 @@ jobs:
               --volume $(Build.BinariesDirectory):/build \
               --volume /data/models:/build/models:ro \
               --volume $HOME/.onnx:/home/onnxruntimedev/.onnx \
+              -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc \
+              --volume "${NPM_CONFIG_USERCONFIG}:/tmp/.npmrc:ro" \
+              --volume $HOME/.m2:/home/onnxruntimedev/.m2:ro \
+              --volume $HOME/.gradle:/home/onnxruntimedev/.gradle \
               -e ALLOW_RELEASED_ONNX_OPSET_ONLY=0 \
               -e NIGHTLY_BUILD \
               -e BUILD_BUILDNUMBER \

--- a/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-cuda-minimal-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-cuda-minimal-ci-pipeline.yml
@@ -67,10 +67,9 @@ jobs:
     clean: true
     submodules: none
 
-  - task: UsePythonVersion@0
-    inputs:
+  - template: templates/setup-feeds-and-python-steps.yml
+    parameters:
       versionSpec: '3.12'
-      addToPath: true
       architecture: 'x64'
 
   - template: templates/get-docker-image-steps.yml

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
@@ -37,15 +37,9 @@ stages:
       value: '-Dorg.gradle.daemon=false'
 
     steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.12'
-        addToPath: true
-        architecture: x64
-    - task: PipAuthenticate@1
-      displayName: 'Pip Authenticate'
-      inputs:
-        artifactFeeds: 'Lotus'
+    - template: ../../templates/setup-feeds-and-python-steps.yml
+      parameters:
+        architecture: 'x64'
 
     - task: NuGetToolInstaller@0
       displayName: Use Nuget 6.10.x
@@ -69,7 +63,7 @@ stages:
     - download: build
       displayName: 'Download Nuget'
       artifact: 'drop-signed-nuget-${{ parameters.ArtifactSuffix }}'
-   
+
 
     - template: get-nuget-package-version-as-variable.yml
       parameters:

--- a/tools/ci_build/github/azure-pipelines/post-merge-jobs.yml
+++ b/tools/ci_build/github/azure-pipelines/post-merge-jobs.yml
@@ -398,11 +398,9 @@ stages:
     - checkout: self
       submodules: false
 
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.12'
-        addToPath: true
-        architecture: x64
+    - template: templates/setup-feeds-and-python-steps.yml
+      parameters:
+        architecture: 'x64'
 
     - task: CmdLine@2
       displayName: 'Run build_custom_android_package.py'
@@ -432,11 +430,10 @@ stages:
       vmImage: "macOS-14"
 
     steps:
-    - task: UsePythonVersion@0
-      inputs:
+    - template: templates/setup-feeds-and-python-steps.yml
+      parameters:
         versionSpec: "3.12"
-        addToPath: true
-        architecture: "x64"
+        architecture: 'x64'
 
     - template: templates/use-xcode-version.yml
 

--- a/tools/ci_build/github/azure-pipelines/py-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/py-packaging-pipeline.yml
@@ -19,26 +19,6 @@ parameters:
   type: boolean
   default: true
 
-- name: enable_windows_arm64_qnn
-  displayName: 'Whether Windows ARM64 package with QNN EP is built.'
-  type: boolean
-  default: true
-
-- name: enable_windows_arm64ec_qnn
-  displayName: 'Whether Windows ARM64EC package with QNN EP is built.'
-  type: boolean
-  default: true
-
-- name: enable_windows_x64_qnn
-  displayName: 'Whether Windows x86_64 package with QNN EP is built.'
-  type: boolean
-  default: true
-
-- name: enable_linux_x64_qnn
-  displayName: 'Whether Linux x86_64 package with QNN EP is built.'
-  type: boolean
-  default: true
-
 - name: build_py_parameters
   displayName: 'Specify extra build parameters'
   type: string
@@ -55,11 +35,6 @@ parameters:
   - RelWithDebInfo
   - MinSizeRel
 
-# Only applies to QNN packages.
-- name: qnn_sdk_version
-  type: string
-  displayName: 'QNN SDK version. Only for QNN packages.'
-  default: 2.42.0.251225
 
 trigger: none
 
@@ -103,10 +78,5 @@ extends:
         enable_windows_cpu: ${{ parameters.enable_windows_cpu }}
         enable_mac_cpu: ${{ parameters.enable_mac_cpu }}
         enable_linux_arm: ${{ parameters.enable_linux_arm }}
-        enable_windows_arm64_qnn: ${{ parameters.enable_windows_arm64_qnn }}
-        enable_windows_arm64ec_qnn: ${{ parameters.enable_windows_arm64ec_qnn }}
-        enable_windows_x64_qnn: ${{ parameters.enable_windows_x64_qnn }}
-        enable_linux_x64_qnn: ${{ parameters.enable_linux_x64_qnn }}
         build_py_parameters: ${{ parameters.build_py_parameters }}
         cmake_build_type: ${{ parameters.cmake_build_type }}
-        qnn_sdk_version: ${{ parameters.qnn_sdk_version }}

--- a/tools/ci_build/github/azure-pipelines/stages/jobs/react-natvie-andriod-e2e-test-job.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/jobs/react-natvie-andriod-e2e-test-job.yml
@@ -23,12 +23,9 @@ jobs:
     ANDROID_AVD_HOME: $(Agent.TempDirectory)
   timeoutInMinutes: 90
   steps:
-  - task: UsePythonVersion@0
-    displayName: Use python 3.12
-    inputs:
-      versionSpec: "3.12"
-      addToPath: true
-      architecture: "x64"
+  - template: ../../templates/setup-feeds-and-python-steps.yml
+    parameters:
+      architecture: 'x64'
 
   - task: JavaToolInstaller@0
     displayName: Use jdk 17

--- a/tools/ci_build/github/azure-pipelines/stages/nodejs-linux-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nodejs-linux-packaging-stage.yml
@@ -33,6 +33,9 @@ stages:
     - checkout: self
       clean: true
       submodules: recursive
+
+    - template: ../templates/setup-feeds-and-python-steps.yml
+
     - template: ../templates/get-docker-image-steps.yml
       parameters:
         Dockerfile: tools/ci_build/github/linux/docker/inference/x86_64/default/cuda${{ variables.CUDA_VERSION_MAJOR }}/Dockerfile

--- a/tools/ci_build/github/azure-pipelines/stages/nuget-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nuget-cuda-packaging-stage.yml
@@ -40,6 +40,9 @@ stages:
     steps:
     - checkout: self
       submodules: true
+
+    - template: ../templates/setup-feeds-and-python-steps.yml
+
     - template: ../templates/flex-downloadPipelineArtifact.yml
       parameters:
         StepName: 'Download Pipeline Artifact - NuGet'
@@ -71,16 +74,6 @@ stages:
         TargetPath: '$(Build.BinariesDirectory)/nuget-artifact'
         SpecificArtifact: ${{ parameters.SpecificArtifact }}
         BuildId: ${{ parameters.BuildId }}
-
-    - task: UsePythonVersion@0
-      displayName: 'Use Python'
-      inputs:
-        versionSpec: 3.12
-
-    - task: PipAuthenticate@1
-      displayName: 'Pip Authenticate'
-      inputs:
-        artifactFeeds: 'Lotus'
 
     - template: ../templates/set-version-number-variables-step.yml
 

--- a/tools/ci_build/github/azure-pipelines/stages/nuget-linux-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nuget-linux-cuda-packaging-stage.yml
@@ -30,11 +30,8 @@ stages:
     - name: CUDA_VERSION
       value: ${{ parameters.CudaVersion }}
     steps:
+    - template: ../templates/setup-feeds-and-python-steps.yml
     - template: ../templates/set-version-number-variables-step.yml
-    - task: UsePythonVersion@0
-      displayName: Use Python 3.12
-      inputs:
-        versionSpec: 3.12
     - template: ../templates/get-docker-image-steps.yml
       parameters:
         Dockerfile: tools/ci_build/github/linux/docker/inference/x86_64/default/cuda${{ variables.CUDA_VERSION_MAJOR }}/Dockerfile
@@ -90,10 +87,7 @@ stages:
     - checkout: self
       clean: true
       submodules: recursive
-    - task: UsePythonVersion@0
-      displayName: Use Python 3.12
-      inputs:
-        versionSpec: 3.12
+    - template: ../templates/setup-feeds-and-python-steps.yml
     - template: ../templates/get-docker-image-steps.yml
       parameters:
         Dockerfile: tools/ci_build/github/linux/docker/inference/x86_64/default/cuda${{ variables.CUDA_VERSION_MAJOR }}/Dockerfile

--- a/tools/ci_build/github/azure-pipelines/stages/nuget-win-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nuget-win-cuda-packaging-stage.yml
@@ -127,6 +127,8 @@ stages:
     - checkout: onnxruntime-inference-examples # due to checkout multiple repos, the root directory is $(Build.SourcesDirectory)/onnxruntime-inference-examples
       submodules: false
 
+    - template: ../templates/setup-feeds-and-python-steps.yml
+
     - script: dir $(Build.SourcesDirectory)
     - template: ../templates/jobs/download_win_gpu_library.yml
       parameters:

--- a/tools/ci_build/github/azure-pipelines/stages/py-cpu-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/py-cpu-packaging-stage.yml
@@ -25,26 +25,6 @@ parameters:
   type: boolean
   default: true
 
-- name: enable_windows_arm64_qnn
-  displayName: 'Whether Windows ARM64 package with QNN EP is built.'
-  type: boolean
-  default: true
-
-- name: enable_windows_arm64ec_qnn
-  displayName: 'Whether Windows ARM64EC package with QNN EP is built.'
-  type: boolean
-  default: true
-
-- name: enable_windows_x64_qnn
-  displayName: 'Whether Windows x86_64 package with QNN EP is built.'
-  type: boolean
-  default: true
-
-- name: enable_linux_x64_qnn
-  displayName: 'Whether Linux x86_64 package with QNN EP is built.'
-  type: boolean
-  default: true
-
 - name: cmake_build_type
   type: string
   displayName: 'Linux packages cmake build type. Linux Only.'
@@ -54,12 +34,6 @@ parameters:
    - Release
    - RelWithDebInfo
    - MinSizeRel
-
-# Only applies to QNN packages.
-- name: qnn_sdk_version
-  type: string
-  displayName: 'QNN SDK version. Only for QNN packages.'
-  default: 2.42.0.251225
 
 stages:
 - ${{ if eq(parameters.enable_windows_cpu, true) }}:
@@ -130,71 +104,6 @@ stages:
       parameters:
         arch: 'x86_64'
         machine_pool: 'onnxruntime-Ubuntu2404-AMD-CPU'
-        extra_build_arg: ${{ parameters.build_py_parameters }}
-        cmake_build_type: ${{ parameters.cmake_build_type }}
-        is1ES: true
-
-- ${{ if eq(parameters.enable_windows_arm64_qnn, true) }}:
-  - stage: Python_Packaging_Windows_ARM64_QNN
-    dependsOn: []
-    jobs:
-    - template: ../templates/py-win-arm64-qnn.yml
-      parameters:
-        MACHINE_POOL: 'onnxruntime-qnn-windows-vs-2022-arm64'
-        QNN_SDK: ${{ parameters.qnn_sdk_version }}
-        BUILD_PY_PARAMETERS: ${{ parameters.build_py_parameters }}
-        PYTHON_VERSION: '3.11'
-
-    - template: ../templates/py-win-arm64-qnn.yml
-      parameters:
-        MACHINE_POOL: 'onnxruntime-qnn-windows-vs-2022-arm64'
-        QNN_SDK: ${{ parameters.qnn_sdk_version }}
-        BUILD_PY_PARAMETERS: ${{ parameters.build_py_parameters }}
-        PYTHON_VERSION: '3.12'
-
-    - template: ../templates/py-win-arm64-qnn.yml
-      parameters:
-        MACHINE_POOL: 'onnxruntime-qnn-windows-vs-2022-arm64'
-        QNN_SDK: ${{ parameters.qnn_sdk_version }}
-        BUILD_PY_PARAMETERS: ${{ parameters.build_py_parameters }}
-        PYTHON_VERSION: '3.13'
-
-    - template: ../templates/py-win-arm64-qnn.yml
-      parameters:
-        MACHINE_POOL: 'onnxruntime-qnn-windows-vs-2022-arm64'
-        QNN_SDK: ${{ parameters.qnn_sdk_version }}
-        BUILD_PY_PARAMETERS: ${{ parameters.build_py_parameters }}
-        PYTHON_VERSION: '3.14'
-
-- ${{ if eq(parameters.enable_windows_arm64ec_qnn, true) }}:
-  - stage: Python_Packaging_Windows_arm64ec_QNN
-    dependsOn: []
-    jobs:
-      - template: ../templates/py-win-arm64ec-qnn.yml
-        parameters:
-          MACHINE_POOL: 'Onnxruntime-QNNEP-Windows-2022-CPU'
-          QNN_SDK: ${{ parameters.qnn_sdk_version }}
-          BUILD_PY_PARAMETERS: ${{ parameters.build_py_parameters }}
-
-- ${{ if eq(parameters.enable_windows_x64_qnn, true) }}:
-  - stage: Python_Packaging_Windows_x64_QNN
-    dependsOn: []
-    jobs:
-      - template: ../templates/py-win-x64-qnn.yml
-        parameters:
-          MACHINE_POOL: 'Onnxruntime-QNNEP-Windows-2022-CPU'
-          QNN_SDK: ${{ parameters.qnn_sdk_version }}
-          BUILD_PY_PARAMETERS: ${{ parameters.build_py_parameters }}
-          is1ES: true
-
-- ${{ if eq(parameters.enable_linux_x64_qnn, true) }}:
-  - stage: Python_Packaging_Linux_x64_QNN
-    dependsOn: []
-    jobs:
-    - template: ../templates/py-linux-qnn.yml
-      parameters:
-        machine_pool: 'onnxruntime-Ubuntu2404-AMD-CPU'
-        QnnSdk: ${{ parameters.qnn_sdk_version }}
         extra_build_arg: ${{ parameters.build_py_parameters }}
         cmake_build_type: ${{ parameters.cmake_build_type }}
         is1ES: true

--- a/tools/ci_build/github/azure-pipelines/stages/py-win-gpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/py-win-gpu-stage.yml
@@ -201,16 +201,10 @@ stages:
           clean: true
           submodules: none
 
-        - task: UsePythonVersion@0
-          inputs:
+        - template: ../templates/setup-feeds-and-python-steps.yml
+          parameters:
             versionSpec: ${{ parameters.PYTHON_VERSION }}
-            addToPath: true
             architecture: 'x64'
-
-        - task: PipAuthenticate@1
-          displayName: 'Pip Authenticate'
-          inputs:
-            artifactFeeds: 'Lotus'
 
         - template: ../templates/jobs/download_win_gpu_library.yml
           parameters:

--- a/tools/ci_build/github/azure-pipelines/stages/py-win-webgpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/py-win-webgpu-stage.yml
@@ -155,16 +155,10 @@ stages:
           clean: true
           submodules: none
 
-        - task: UsePythonVersion@0
-          inputs:
+        - template: ../templates/setup-feeds-and-python-steps.yml
+          parameters:
             versionSpec: ${{ parameters.PYTHON_VERSION }}
-            addToPath: true
             architecture: 'x64'
-
-        - task: PipAuthenticate@1
-          displayName: 'Pip Authenticate'
-          inputs:
-            artifactFeeds: 'Lotus'
 
         - script: python -m pip install -r $(Build.SourcesDirectory)\tools\ci_build\github\windows\python\requirements.txt
           env:

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -348,16 +348,7 @@ stages:
         DisplayName: 'ESRP - Sign C# dlls'
         DoEsrp: true
 
-    - task: UsePythonVersion@0
-      displayName: 'Use Python'
-      inputs:
-        versionSpec: 3.12
-
-    - task: PipAuthenticate@1
-      displayName: 'Pip Authenticate'
-      inputs:
-        artifactFeeds: 'Lotus'
-
+    - template: setup-feeds-and-python-steps.yml
 
     - task: MSBuild@1
       displayName: 'Build Nuget Packages'

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -74,6 +74,10 @@ jobs:
         set -e -x
         mkdir -p $HOME/.onnx
         docker run -e SYSTEM_COLLECTIONURI --rm --volume /data/onnx:/data/onnx:ro --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build \
+        -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc \
+        --volume "${NPM_CONFIG_USERCONFIG}:/tmp/.npmrc:ro" \
+        --volume $HOME/.m2:/home/onnxruntimedev/.m2:ro \
+        --volume $HOME/.gradle:/home/onnxruntimedev/.gradle \
         --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimecpubuildcentos8${{parameters.OnnxruntimeArch}}_packaging /bin/bash -c "python3 \
         /onnxruntime_src/tools/ci_build/build.py --enable_lto --build_java --build_nodejs --build_dir /build --config Release \
         --skip_submodule_sync --parallel --use_vcpkg --use_vcpkg_ms_internal_asset_cache --use_binskim_compliant_compile_flags --use_vcpkg --use_vcpkg_ms_internal_asset_cache --build_shared_lib ${{ parameters.AdditionalBuildFlags }} && cd /build/Release && make install DESTDIR=/build/installed"

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -46,12 +46,10 @@ jobs:
     clean: true
     submodules: none
 
-  - ${{ if eq(parameters.OnnxruntimeArch, 'x64') }}:
-    # Only need to install Python on x64 agents as Python is pre-installed on arm64 agents
-    - task: UsePythonVersion@0
-      displayName: Use Python 3.12
-      inputs:
-        versionSpec: 3.12
+  # Authenticate to Lotus to pull pip in UsePythonVersion task
+  - template: ../templates/setup-feeds-and-python-steps.yml
+    parameters:
+      architecture: ${{ parameters.OnnxruntimeArch }}
 
   - template: set-version-number-variables-step.yml
   - ${{ if eq(parameters.OnnxruntimeArch, 'x64') }}:

--- a/tools/ci_build/github/azure-pipelines/templates/check_test_result.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/check_test_result.yml
@@ -3,17 +3,11 @@ parameters:
   type: string
 
 steps:
-  - task: UsePythonVersion@0
-    inputs:
+
+  - template: setup-feeds-and-python-steps.yml
+    parameters:
       versionSpec: '3.x'
-      addToPath: true
       architecture: 'x64'
-
-  - task: PipAuthenticate@1
-    displayName: 'Pip Authenticate'
-    inputs:
-      artifactFeeds: 'Lotus'
-
 
   - task: PythonScript@0
     displayName: 'Check test result yml'

--- a/tools/ci_build/github/azure-pipelines/templates/foundry-local-nuget-packaging.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/foundry-local-nuget-packaging.yml
@@ -58,15 +58,7 @@ stages:
         artifactName: 'onnxruntime-osx'
         targetPath: '$(Build.BinariesDirectory)/osx'
 
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.12'
-        addToPath: true
-
-    - task: PipAuthenticate@1
-      displayName: 'Pip Authenticate'
-      inputs:
-        artifactFeeds: 'Lotus'
+    - template: setup-feeds-and-python-steps.yml
 
     - task: PowerShell@2
       displayName: 'Create osx directories'

--- a/tools/ci_build/github/azure-pipelines/templates/jar-maven-signing-linux.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jar-maven-signing-linux.yml
@@ -12,10 +12,7 @@ steps:
       SecretsFilter: "java-pgp-pwd,java-pgp-key"
       RunAsPreJob: false
 
-  - task: UsePythonVersion@0
-    displayName: "Use Python 3.12"
-    inputs:
-      versionSpec: "3.12"
+  - template: setup-feeds-and-python-steps.yml
 
   - task: PythonScript@0
     displayName: "Sign files: GnuPG, sha1, and md5"

--- a/tools/ci_build/github/azure-pipelines/templates/jar-packaging.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jar-packaging.yml
@@ -15,15 +15,9 @@ steps:
 - checkout: self
   submodules: false
 
-- task: UsePythonVersion@0
-  inputs:
+- template: setup-feeds-and-python-steps.yml
+  parameters:
     versionSpec: '3.13'
-    addToPath: true
-
-- task: PipAuthenticate@1
-  displayName: 'Pip Authenticate'
-  inputs:
-    artifactFeeds: 'Lotus'
 
 - template: set-version-number-variables-step.yml
 

--- a/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
@@ -84,10 +84,9 @@ jobs:
       git submodule update --init --recursive
     workingDirectory: '$(Build.SourcesDirectory)'
     displayName: 'Checkout submodules'
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '3.12'
-      addToPath: true
+  - template: templates/setup-feeds-and-python-steps.yml
+    parameters:
+      versionSpec: "3.12"
       architecture: $(buildArch)
   - task: NodeTool@0
     inputs:

--- a/tools/ci_build/github/azure-pipelines/templates/linux-web-init-and-check.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-web-init-and-check.yml
@@ -34,9 +34,10 @@ steps:
 - script: |
     npm run format
   workingDirectory: '$(Build.SourcesDirectory)/js'
-  displayName: 'Clang-format'
+  displayName: 'npm run format'
+# stash any changes to `NuGet.config` (expected from setup-feed auth) to prevent false positives. restore after diff check.
 - script: |
-    node -e "a=require('child_process').execSync('git diff --name-only').toString();if(a)throw new Error('Following source files are not formatted: (did you run \"npm run format\"?)\n'+a)"
+    node -e "a=require('child_process').execSync('git diff --name-only -- .').toString();if(a)throw new Error('Following source files are not formatted: (did you run \"npm run format\"?)\n'+a)"
   workingDirectory: '$(Build.SourcesDirectory)/js'
   displayName: 'Check unformatted files'
 - script: |
@@ -48,6 +49,6 @@ steps:
   workingDirectory: '$(Build.SourcesDirectory)/js/web'
   displayName: 'Generating documents'
 - script: |
-    node -e "a=require('child_process').execSync('git diff --name-only').toString();if(a)throw new Error('Following documents are not up-to-date: (did you run \"npm run build:doc\"?)\n'+a)"
+    node -e "a=require('child_process').execSync('git diff --name-only -- .').toString();if(a)throw new Error('Following documents are not up-to-date: (did you run \"npm run build:doc\"?)\n'+a)"
   workingDirectory: '$(Build.SourcesDirectory)/js/web'
   displayName: 'Check out of dated documents'

--- a/tools/ci_build/github/azure-pipelines/templates/make_java_win_binaries.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/make_java_win_binaries.yml
@@ -22,28 +22,34 @@ parameters:
 steps:
 - task: PowerShell@2
   displayName: 'Build and Package Java Artifacts'
+  env:
+    msbuild_platform: ${{ parameters.msbuildPlatform }}
+    java_artifact_id: ${{ parameters.java_artifact_id }}
+    pre_release_version_suffix_string: ${{ parameters.PreReleaseVersionSuffixString }}
+    pre_release_version_suffix_number: ${{ parameters.PreReleaseVersionSuffixNumber }}
+    build_only: ${{ parameters.buildOnly }}
   inputs:
     targetType: 'inline'
     script: |
       # Define arguments for the Python script
       $scriptArgs = @(
-        "--sources-dir", "$(Build.SourcesDirectory)",
-        "--binaries-dir", "$(Build.BinariesDirectory)",
-        "--platform", "${{ parameters.msbuildPlatform }}",
-        "--build-config", "RelWithDebInfo",
-        "--java-artifact-id", "${{ parameters.java_artifact_id }}",
-        "--pre-release-version-suffix-string", "${{ parameters.PreReleaseVersionSuffixString }}",
-        "--pre-release-version-suffix-number", "${{ parameters.PreReleaseVersionSuffixNumber }}",
-        "--commit-hash", "$(OnnxRuntimeGitCommitHash)"
+        "--sources-dir",                        "${env:BUILD_SOURCESDIRECTORY}",
+        "--binaries-dir",                       "${env:BUILD_BINARIESDIRECTORY}",
+        "--platform",                           "${env:msbuild_platform}",
+        "--build-config",                       "RelWithDebInfo",
+        "--java-artifact-id",                   "${env:java_artifact_id}",
+        "--pre-release-version-suffix-string",  "${env:pre_release_version_suffix_string}",
+        "--pre-release-version-suffix-number",  "${env:pre_release_version_suffix_number}",
+        "--commit-hash",                        "${env:ONNXRUNTIMEGITCOMMITHASH}"
       )
 
       # Conditionally add the --build-only flag if the parameter is true
-      if ('${{ parameters.buildOnly }}' -eq 'True') {
+      if (${env:build_only} -eq 'True') {
         $scriptArgs += "--build-only"
       }
 
       # Define the path to the python script within your repository
-      $scriptPath = "$(Build.SourcesDirectory)/tools/ci_build/manage_java_artifacts.py"
+      $scriptPath = "${env:BUILD_SOURCESDIRECTORY}/tools/ci_build/manage_java_artifacts.py"
 
       # Execute the Python script, passing all arguments
       Write-Host "Executing Python script: $scriptPath with arguments: $($scriptArgs -join ' ')"

--- a/tools/ci_build/github/azure-pipelines/templates/managed-nuget-for-foundry-local.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/managed-nuget-for-foundry-local.yml
@@ -37,10 +37,7 @@ stages:
     steps:
     - template: set-version-number-variables-step.yml
 
-    - task: UsePythonVersion@0
-      displayName: 'Use Python'
-      inputs:
-        versionSpec: 3.12
+    - template: setup-feeds-and-python-steps.yml
 
     - task: DownloadPipelineArtifact@0
       displayName: 'Download Pipeline Artifact - win-x64'

--- a/tools/ci_build/github/azure-pipelines/templates/publish-nuget-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/publish-nuget-steps.yml
@@ -30,10 +30,7 @@ stages:
     - checkout: self
       submodules: false
 
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.12'
-        addToPath: true
+    - template: setup-feeds-and-python-steps.yml
 
     - template: set-version-number-variables-step.yml
 
@@ -130,5 +127,3 @@ stages:
         packageParentPath: '$(Build.BinariesDirectory)'
         publishVstsFeed: '2692857e-05ef-43b4-ba9c-ccf1c22c437c/7982ae20-ed19-4a35-a362-a96ac99897b7'
         allowPackageConflicts: true
-
-

--- a/tools/ci_build/github/azure-pipelines/templates/py-package-smoking-test.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-package-smoking-test.yml
@@ -37,9 +37,8 @@ jobs:
   steps:
   - checkout: none
 
-  - task: UsePythonVersion@0
-    displayName: 'Use Python'
-    inputs:
+  - template: setup-feeds-and-python-steps.yml
+    parameters:
       versionSpec: $(PythonVersion)
 
   - download: build   # pipeline resource identifier.

--- a/tools/ci_build/github/azure-pipelines/templates/setup-build-tools.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/setup-build-tools.yml
@@ -16,16 +16,10 @@ parameters:
 steps:
 - template: telemetry-steps.yml
 
-- task: UsePythonVersion@0
-  displayName: 'Use Python ${{ parameters.python_version }} ${{ parameters.host_cpu_arch }}'
-  inputs:
+- template: setup-feeds-and-python-steps.yml
+  parameters:
     versionSpec: ${{ parameters.python_version }}
     architecture: ${{ parameters.host_cpu_arch }}
-
-- task: PipAuthenticate@1
-  displayName: 'Pip Authenticate'
-  inputs:
-    artifactFeeds: 'Lotus'
 
 # The following task does not support different arches.
 - task: UseNode@1

--- a/tools/ci_build/github/azure-pipelines/templates/setup-feeds-and-python-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/setup-feeds-and-python-steps.yml
@@ -23,8 +23,14 @@ steps:
 # HACK: Ensure there are no leftover m2 settings from previous runs. Agent pools are currently stateful.
 #       Ideally we'd just push/pop/layer specific splices to the settings (auth & mirror stuff), but there's no easy
 #       mechanism for that AFAIK.
-- pwsh: if (Test-Path ~/.m2/settings.xml) { Remove-Item ~/.m2/settings.xml }
+- task: PowerShell@2
   displayName: Maven - remove existing ~/.m2/settings.xml
+  inputs:
+    targetType: 'inline'
+    script: |
+      if (Test-Path ~/.m2/settings.xml) {
+        Remove-Item ~/.m2/settings.xml
+      }
 
 - task: NuGetAuthenticate@1 # just auth w/ internal feeds
 
@@ -48,24 +54,27 @@ steps:
     ${{ if ne(parameters.architecture, '') }}:
       architecture: ${{ parameters.architecture }}
 
-- pwsh: |
-    # Check if python is available in PATH
-    $pythonCmd = Get-Command "python${env:python_version_spec}" -ErrorAction SilentlyContinue
-    if ($pythonCmd) {
-      Write-Host "Found `python${env:python_version_spec}` at $($pythonCmd.Source)"
-      exit 0
-    }
-
-    $pythonCmd = Get-Command "python" -ErrorAction SilentlyContinue
-    if ($pythonCmd) {
-      Write-Host "Found `python` at $($pythonCmd.Source)."
-      # FUTURE WORK: validate it matches the requested version spec
-      exit 0
-    }
-
-    Write-Host "##vso[task.logissue type=error]Neither `python` nor `python${env:python_version_spec}` are on PATH."
-    exit 1
+- task: PowerShell@2
   displayName: 'Verify Python ${{ parameters.versionSpec }} is on path'
+  inputs:
+    targetType: 'inline'
+    script: |
+      # Check if python is available in PATH
+      $pythonCmd = Get-Command "python${env:python_version_spec}" -ErrorAction SilentlyContinue
+      if ($pythonCmd) {
+        Write-Host "Found `python${env:python_version_spec}` at $($pythonCmd.Source)"
+        exit 0
+      }
+
+      $pythonCmd = Get-Command "python" -ErrorAction SilentlyContinue
+      if ($pythonCmd) {
+        Write-Host "Found `python` at $($pythonCmd.Source)."
+        # FUTURE WORK: validate it matches the requested version spec
+        exit 0
+      }
+
+      Write-Host "##vso[task.logissue type=error]Neither `python` nor `python${env:python_version_spec}` are on PATH."
+      exit 1
   env:
     python_version_spec: ${{ parameters.versionSpec }}
 
@@ -73,47 +82,65 @@ steps:
 #       across all runs.
 #       Proper fix would be to have a post-job task to clean up our junk, but we can't do that without a full task def.
 #       (Or intrusively set GRADLE_USER_HOME env var to an agent temp dir. Maven doesn't have equiv facilities.)
-- pwsh: |
-    # Force everything in Maven to go through & authenticate using the main feed.
-    # HACK: Does not escape `parameters.artifactFeeds`. Assumes pattern is [A-Za-z0-9]+.
-    # HACK: Assumes feed is a org-scoped feed in `aiinfra`.
-    $m2SettingsXmlPath = "~/.m2/settings.xml"
-    $m2SettingsContent = Get-Content $m2SettingsXmlPath -Raw
+- task: PowerShell@2
+  displayName: 'Maven/Gradle - mirror / feed via `${{ parameters.artifactFeeds }}`'
+  env:
+    central_maven_feed_name: ${{ parameters.artifactFeeds }}
+  inputs:
+    targetType: 'inline'
+    script: |
+      # Force everything in Maven to go through & authenticate using the main feed.
+      # HACK: Does not escape `parameters.artifactFeeds`. Assumes pattern is [A-Za-z0-9]+.
+      # HACK: Assumes feed is a org-scoped feed in `aiinfra`.
+      $m2SettingsXmlPath = "~/.m2/settings.xml"
+        $m2SettingsContent = Get-Content $m2SettingsXmlPath -Raw
 
-    if ($m2SettingsContent -match '<mirrors>') {
-      echo "##vso[task.logissue type=error]Configuration already contains `<mirrors>`, cannot inject feed mirror w/o corrupting existing config."
-      exit 1
-    }
+      if ($m2SettingsContent -match '<mirrors>') {
+        echo "##vso[task.logissue type=error]Configuration already contains `<mirrors>`, cannot inject feed mirror w/o corrupting existing config."
+        exit 1
+      }
 
-    echo "Injecting Maven mirrors section for 1ES feed"
-    $( $m2SettingsContent -replace '</settings>', "<mirrors><mirror><id>${env:central_maven_feed_name}</id><name>1ES Feed Override</name><url>https://aiinfra.pkgs.visualstudio.com/_packaging/${env:central_maven_feed_name}/maven/v1</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>" ) | `
-      Set-Content $m2SettingsXmlPath
+      echo "Injecting Maven mirrors section for 1ES feed"
+      $( $m2SettingsContent -replace '</settings>', "<mirrors><mirror><id>${env:central_maven_feed_name}</id><name>1ES Feed Override</name><url>https://aiinfra.pkgs.visualstudio.com/_packaging/${env:central_maven_feed_name}/maven/v1</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>" ) | `
+        Set-Content $m2SettingsXmlPath
 
 
-    # gradle - inject 1ES feed repo into all projects/buildscripts. Auth using creds from maven settings.xml.
-    # nb: see HACK note above.
-    $gradleInitDir = if ($env:GRADLE_HOME_DIR) { $env:GRADLE_HOME_DIR } else { "~/.gradle" }
-    if (!(Test-Path -Path "${gradleInitDir}/init.d")) {
-      New-Item -ItemType Directory -Path "${gradleInitDir}/init.d"
-    }
-    Set-Content -Path "${gradleInitDir}/init.d/1es-feed-inject.init.gradle" -Value @"
-    // Use official 1ES feed. Network isolation prevents us from reaching out directly to other feeds.
+      # gradle - inject 1ES feed repo into all projects/buildscripts. Auth using creds from maven settings.xml.
+      # nb: see HACK note above.
+      $gradleInitDir = if ($env:GRADLE_HOME_DIR) { $env:GRADLE_HOME_DIR } else { "~/.gradle" }
+      if (!(Test-Path -Path "${gradleInitDir}/init.d")) {
+        New-Item -ItemType Directory -Path "${gradleInitDir}/init.d"
+      }
+      Set-Content -Path "${gradleInitDir}/init.d/1es-feed-inject.init.gradle" -Value @"
+      // Use official 1ES feed. Network isolation prevents us from reaching out directly to other feeds.
 
-    def mavenSettingsServers = {
-      File mavenSettings = new File(System.getProperty("user.home"), ".m2/settings.xml")
-      return new XmlSlurper().parse(mavenSettings)."servers"."server"
-    }
+      def mavenSettingsServers = {
+        File mavenSettings = new File(System.getProperty("user.home"), ".m2/settings.xml")
+        return new XmlSlurper().parse(mavenSettings)."servers"."server"
+      }
 
-    def oneEsFeedCredentials = {
-      for (x in mavenSettingsServers()) {
-        if (x."id".text() == "${env:central_maven_feed_name}") {
-          return [username: x.username.text(), password: x.password.text()]
+      def oneEsFeedCredentials = {
+        for (x in mavenSettingsServers()) {
+          if (x."id".text() == "${env:central_maven_feed_name}") {
+            return [username: x.username.text(), password: x.password.text()]
+          }
         }
       }
-    }
 
-    allprojects {
-      buildscript {
+      allprojects {
+        buildscript {
+          repositories {
+            maven {
+              name "1ES Feed"
+              url uri("https://aiinfra.pkgs.visualstudio.com/_packaging/${env:central_maven_feed_name}/maven/v1")
+              credentials(PasswordCredentials) {
+                username oneEsFeedCredentials().username
+                password oneEsFeedCredentials().password
+              }
+            }
+          }
+        }
+
         repositories {
           maven {
             name "1ES Feed"
@@ -125,42 +152,30 @@ steps:
           }
         }
       }
+      "@
 
-      repositories {
-        maven {
-          name "1ES Feed"
-          url uri("https://aiinfra.pkgs.visualstudio.com/_packaging/${env:central_maven_feed_name}/maven/v1")
-          credentials(PasswordCredentials) {
-            username oneEsFeedCredentials().username
-            password oneEsFeedCredentials().password
-          }
-        }
-      }
-    }
-    "@
-  displayName: 'Maven/Gradle - mirror / feed via `${{ parameters.artifactFeeds }}`'
-  env:
-    central_maven_feed_name: ${{ parameters.artifactFeeds }}
-
-- pwsh: |
-    # NuGet appears to fail if any of the pkg sources are unreachable.
-    # Replace the NuGet.config w/ one that only has the internal feed.
-    # HACK: We'd rather splice the structure, not override the file.
-    Set-Content -Path "NuGet.config" -Value @"
-    <?xml version="1.0" encoding="utf-8"?>
-    <configuration>
-      <solution>
-        <add key="disableSourceControlIntegration" value="true" />
-      </solution>
-      <packageSources>
-        <clear />
-        <add key="1ES Feed" value="https://pkgs.dev.azure.com/aiinfra/_packaging/${env:central_maven_feed_name}/nuget/v3/index.json" />
-      </packageSources>
-      <disabledPackageSources>
-        <clear />
-      </disabledPackageSources>
-    </configuration>
-    "@
+- task: PowerShell@2
   displayName: NuGet - override `NuGet.config` to lock feed to `${{ parameters.artifactFeeds }}`
   env:
     central_maven_feed_name: ${{ parameters.artifactFeeds }}
+  inputs:
+    targetType: 'inline'
+    script: |
+      # NuGet appears to fail if any of the pkg sources are unreachable.
+      # Replace the NuGet.config w/ one that only has the internal feed.
+      # HACK: We'd rather splice the structure, not override the file.
+      Set-Content -Path "NuGet.config" -Value @"
+      <?xml version="1.0" encoding="utf-8"?>
+      <configuration>
+        <solution>
+          <add key="disableSourceControlIntegration" value="true" />
+        </solution>
+        <packageSources>
+          <clear />
+          <add key="1ES Feed" value="https://pkgs.dev.azure.com/aiinfra/_packaging/${env:central_maven_feed_name}/nuget/v3/index.json" />
+        </packageSources>
+        <disabledPackageSources>
+          <clear />
+        </disabledPackageSources>
+      </configuration>
+      "@

--- a/tools/ci_build/github/azure-pipelines/templates/setup-feeds-and-python-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/setup-feeds-and-python-steps.yml
@@ -4,7 +4,7 @@
 #   - maven & gradle
 #   - nuget
 #
-# FIXME: Not idempotent.
+# n.b. This template writes to user profile files.
 
 parameters:
 - name: artifactFeeds
@@ -20,8 +20,15 @@ parameters:
   default: ''
 
 steps:
+# HACK: Ensure there are no leftover m2 settings from previous runs. Agent pools are currently stateful.
+#       Ideally we'd just push/pop/layer specific splices to the settings (auth & mirror stuff), but there's no easy
+#       mechanism for that AFAIK.
+- pwsh: if (Test-Path ~/.m2/settings.xml) { Remove-Item ~/.m2/settings.xml }
+  displayName: Maven - remove existing ~/.m2/settings.xml
+
 - task: NuGetAuthenticate@1 # just auth w/ internal feeds
 
+# Creates/touches ~/.m2/settings.xml
 - task: MavenAuthenticate@0
   inputs:
     artifactsFeeds: ${{ parameters.artifactFeeds }}
@@ -62,16 +69,29 @@ steps:
   env:
     python_version_spec: ${{ parameters.versionSpec }}
 
+# HACK: If agent pools are stateful then we have to ensure that `1es-feed-inject.init.gradle` file path is constant
+#       across all runs.
+#       Proper fix would be to have a post-job task to clean up our junk, but we can't do that without a full task def.
+#       (Or intrusively set GRADLE_USER_HOME env var to an agent temp dir. Maven doesn't have equiv facilities.)
 - pwsh: |
-    # Force everything to go through & authenticate using the main feed.
-    # ASSUME: there is no `mirrors` section already present in the settings.xml.
+    # Force everything in Maven to go through & authenticate using the main feed.
     # HACK: Does not escape `parameters.artifactFeeds`. Assumes pattern is [A-Za-z0-9]+.
     # HACK: Assumes feed is a org-scoped feed in `aiinfra`.
-    (Get-Content ~/.m2/settings.xml) | `
-      %{ $_ -replace '</settings>', "<mirrors><mirror><id>${env:central_maven_feed_name}</id><name>1ES Feed Override</name><url>https://aiinfra.pkgs.visualstudio.com/_packaging/${env:central_maven_feed_name}/maven/v1</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>" } | `
-      Set-Content ~/.m2/settings.xml
+    $m2SettingsXmlPath = "~/.m2/settings.xml"
+    $m2SettingsContent = Get-Content $m2SettingsXmlPath -Raw
+
+    if ($m2SettingsContent -match '<mirrors>') {
+      echo "##vso[task.logissue type=error]Configuration already contains `<mirrors>`, cannot inject feed mirror w/o corrupting existing config."
+      exit 1
+    }
+
+    echo "Injecting Maven mirrors section for 1ES feed"
+    $( $m2SettingsContent -replace '</settings>', "<mirrors><mirror><id>${env:central_maven_feed_name}</id><name>1ES Feed Override</name><url>https://aiinfra.pkgs.visualstudio.com/_packaging/${env:central_maven_feed_name}/maven/v1</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>" ) | `
+      Set-Content $m2SettingsXmlPath
+
 
     # gradle - inject 1ES feed repo into all projects/buildscripts. Auth using creds from maven settings.xml.
+    # nb: see HACK note above.
     $gradleInitDir = if ($env:GRADLE_HOME_DIR) { $env:GRADLE_HOME_DIR } else { "~/.gradle" }
     if (!(Test-Path -Path "${gradleInitDir}/init.d")) {
       New-Item -ItemType Directory -Path "${gradleInitDir}/init.d"

--- a/tools/ci_build/github/azure-pipelines/templates/setup-feeds-and-python-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/setup-feeds-and-python-steps.yml
@@ -1,0 +1,146 @@
+# Template for setting up the package feeds and installing python.
+# Feeds configured:
+#   - pip
+#   - maven & gradle
+#   - nuget
+#
+# FIXME: Not idempotent.
+
+parameters:
+- name: artifactFeeds
+  type: string
+  default: 'Lotus'
+
+- name: versionSpec
+  type: string
+  default: '3.12'
+
+- name: architecture
+  type: string
+  default: ''
+
+steps:
+- task: NuGetAuthenticate@1 # just auth w/ internal feeds
+
+- task: MavenAuthenticate@0
+  inputs:
+    artifactsFeeds: ${{ parameters.artifactFeeds }}
+
+- task: PipAuthenticate@1
+  displayName: 'Pip Authenticate'
+  inputs:
+    artifactFeeds: ${{ parameters.artifactFeeds }}
+
+- task: UsePythonVersion@0
+  displayName: 'Use Python ${{ parameters.versionSpec }}'
+  # aarch64 (aka arm64) is not currently available (2026-04-09). Skip installation.
+  # We'll be verifying the requested version of python is already installed below.
+  condition: ne('${{ parameters.architecture }}', 'aarch64')
+  inputs:
+    versionSpec: ${{ parameters.versionSpec }}
+    ${{ if ne(parameters.architecture, '') }}:
+      architecture: ${{ parameters.architecture }}
+
+- pwsh: |
+    # Check if python is available in PATH
+    $pythonCmd = Get-Command "python${env:python_version_spec}" -ErrorAction SilentlyContinue
+    if ($pythonCmd) {
+      Write-Host "Found `python${env:python_version_spec}` at $($pythonCmd.Source)"
+      exit 0
+    }
+
+    $pythonCmd = Get-Command "python" -ErrorAction SilentlyContinue
+    if ($pythonCmd) {
+      Write-Host "Found `python` at $($pythonCmd.Source)."
+      # FUTURE WORK: validate it matches the requested version spec
+      exit 0
+    }
+
+    Write-Host "##vso[task.logissue type=error]Neither `python` nor `python${env:python_version_spec}` are on PATH."
+    exit 1
+  displayName: 'Verify Python ${{ parameters.versionSpec }} is on path'
+  env:
+    python_version_spec: ${{ parameters.versionSpec }}
+
+- pwsh: |
+    # Force everything to go through & authenticate using the main feed.
+    # ASSUME: there is no `mirrors` section already present in the settings.xml.
+    # HACK: Does not escape `parameters.artifactFeeds`. Assumes pattern is [A-Za-z0-9]+.
+    # HACK: Assumes feed is a org-scoped feed in `aiinfra`.
+    (Get-Content ~/.m2/settings.xml) | `
+      %{ $_ -replace '</settings>', "<mirrors><mirror><id>${env:central_maven_feed_name}</id><name>1ES Feed Override</name><url>https://aiinfra.pkgs.visualstudio.com/_packaging/${env:central_maven_feed_name}/maven/v1</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>" } | `
+      Set-Content ~/.m2/settings.xml
+
+    # gradle - inject 1ES feed repo into all projects/buildscripts. Auth using creds from maven settings.xml.
+    $gradleInitDir = if ($env:GRADLE_HOME_DIR) { $env:GRADLE_HOME_DIR } else { "~/.gradle" }
+    if (!(Test-Path -Path "${gradleInitDir}/init.d")) {
+      New-Item -ItemType Directory -Path "${gradleInitDir}/init.d"
+    }
+    Set-Content -Path "${gradleInitDir}/init.d/1es-feed-inject.init.gradle" -Value @"
+    // Use official 1ES feed. Network isolation prevents us from reaching out directly to other feeds.
+
+    def mavenSettingsServers = {
+      File mavenSettings = new File(System.getProperty("user.home"), ".m2/settings.xml")
+      return new XmlSlurper().parse(mavenSettings)."servers"."server"
+    }
+
+    def oneEsFeedCredentials = {
+      for (x in mavenSettingsServers()) {
+        if (x."id".text() == "${env:central_maven_feed_name}") {
+          return [username: x.username.text(), password: x.password.text()]
+        }
+      }
+    }
+
+    allprojects {
+      buildscript {
+        repositories {
+          maven {
+            name "1ES Feed"
+            url uri("https://aiinfra.pkgs.visualstudio.com/_packaging/${env:central_maven_feed_name}/maven/v1")
+            credentials(PasswordCredentials) {
+              username oneEsFeedCredentials().username
+              password oneEsFeedCredentials().password
+            }
+          }
+        }
+      }
+
+      repositories {
+        maven {
+          name "1ES Feed"
+          url uri("https://aiinfra.pkgs.visualstudio.com/_packaging/${env:central_maven_feed_name}/maven/v1")
+          credentials(PasswordCredentials) {
+            username oneEsFeedCredentials().username
+            password oneEsFeedCredentials().password
+          }
+        }
+      }
+    }
+    "@
+  displayName: 'Maven/Gradle - mirror / feed via `${{ parameters.artifactFeeds }}`'
+  env:
+    central_maven_feed_name: ${{ parameters.artifactFeeds }}
+
+- pwsh: |
+    # NuGet appears to fail if any of the pkg sources are unreachable.
+    # Replace the NuGet.config w/ one that only has the internal feed.
+    # HACK: We'd rather splice the structure, not override the file.
+    Set-Content -Path "NuGet.config" -Value @"
+    <?xml version="1.0" encoding="utf-8"?>
+    <configuration>
+      <solution>
+        <add key="disableSourceControlIntegration" value="true" />
+      </solution>
+      <packageSources>
+        <clear />
+        <add key="1ES Feed" value="https://pkgs.dev.azure.com/aiinfra/_packaging/${env:central_maven_feed_name}/nuget/v3/index.json" />
+      </packageSources>
+      <disabledPackageSources>
+        <clear />
+      </disabledPackageSources>
+    </configuration>
+    "@
+  displayName: NuGet - override `NuGet.config` to lock feed to `${{ parameters.artifactFeeds }}`
+  env:
+    central_maven_feed_name: ${{ parameters.artifactFeeds }}

--- a/tools/ci_build/github/azure-pipelines/templates/setup-feeds-and-python-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/setup-feeds-and-python-steps.yml
@@ -1,8 +1,9 @@
 # Template for setting up the package feeds and installing python.
 # Feeds configured:
-#   - pip
 #   - maven & gradle
+#   - npm
 #   - nuget
+#   - pip
 #
 # n.b. This template writes to user profile files.
 
@@ -31,6 +32,32 @@ steps:
       if (Test-Path ~/.m2/settings.xml) {
         Remove-Item ~/.m2/settings.xml
       }
+
+# use `PowerShell@2` instead of `pwsh` as it is available on arm64 agents, whereas `pwsh` is not. (2026-04-15)
+- task: PowerShell@2
+  displayName: 'NPM - set NPM_CONFIG_USERCONFIG to agent temp config'
+  env:
+    artifact_feed: ${{ parameters.artifactFeeds }}
+  inputs:
+    targetType: 'inline'
+    script: |
+      # ensure we have a clean/empty npm config. config file must exist prior to `npmAuthenticate`.
+      $npmrcPath = "${env:AGENT_TEMPDIRECTORY}/.npmrc"
+
+      Set-Content -Force -Path $npmrcPath -Value @"
+      registry=https://aiinfra.pkgs.visualstudio.com/_packaging/${env:artifact_feed}/npm/registry/
+      always-auth=true
+      "@
+
+      Write-Host "Generated npmrc contents:"
+      Get-Content $npmrcPath | Write-Host
+
+      echo "##vso[task.setvariable variable=NPM_CONFIG_USERCONFIG]${npmrcPath}"
+
+# FUTURE WORK: use `Npm@1` task in pipelines and specify the feed there?
+- task: npmAuthenticate@0
+  inputs:
+    workingFile: $(NPM_CONFIG_USERCONFIG)
 
 - task: NuGetAuthenticate@1 # just auth w/ internal feeds
 

--- a/tools/ci_build/github/azure-pipelines/templates/validate-package.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/validate-package.yml
@@ -9,11 +9,6 @@ parameters:
   workingDirectory: "$(Build.BinariesDirectory)"
 
 steps:
-    - task: UsePythonVersion@0
-      displayName: 'Use Python'
-      inputs:
-        versionSpec: 3.12
-
     - task: PythonScript@0
       displayName: 'Validate Package'
       inputs:

--- a/tools/ci_build/github/azure-pipelines/templates/win-wasm-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-wasm-ci.yml
@@ -71,10 +71,8 @@ jobs:
      git submodule update --init --recursive
     workingDirectory: '$(Build.SourcesDirectory)'
     displayName: 'Checkout submodules'
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '3.12'
-      addToPath: true
+  - template: setup-feeds-and-python-steps.yml
+    parameters:
       architecture: $(buildArch)
   - task: NodeTool@0
     inputs:

--- a/tools/ci_build/github/azure-pipelines/templates/win-web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-web-ci.yml
@@ -76,7 +76,7 @@ jobs:
       git checkout -- .gitattributes
     workingDirectory: '$(Build.SourcesDirectory)'
     displayName: 'Testing: force EOL to lf on windows for /js/**'
-  
+
   - template: setup-build-tools.yml
     parameters:
       host_cpu_arch: 'x64'
@@ -129,9 +129,10 @@ jobs:
   - script: |
       npm run format
     workingDirectory: '$(Build.SourcesDirectory)\js'
-    displayName: 'Clang-format'
+    displayName: 'npm run format'
+  # stash any changes to `NuGet.config` (expected from setup-feed auth) to prevent false positives. restore after diff check.
   - script: |
-      node -e "a=require('child_process').execSync('git diff --name-only').toString();if(a)throw new Error('Following source files are not formatted: (did you run \"npm run format\"?)\n'+a)"
+      node -e "a=require('child_process').execSync('git diff --name-only -- .').toString();if(a)throw new Error('Following source files are not formatted: (did you run \"npm run format\"?)\n'+a)"
     workingDirectory: '$(Build.SourcesDirectory)\js'
     displayName: 'Check unformatted files'
   - script: |
@@ -139,7 +140,7 @@ jobs:
     workingDirectory: '$(Build.SourcesDirectory)\js\web'
     displayName: 'Generating documents'
   - script: |
-      node -e "a=require('child_process').execSync('git diff --name-only').toString();if(a)throw new Error('Following documents are not up-to-date: (did you run \"npm run build:doc\"?)\n'+a)"
+      node -e "a=require('child_process').execSync('git diff --name-only -- .').toString();if(a)throw new Error('Following documents are not up-to-date: (did you run \"npm run build:doc\"?)\n'+a)"
     workingDirectory: '$(Build.SourcesDirectory)\js\web'
     displayName: 'Check out of dated documents'
   - task: Cache@2

--- a/tools/ci_build/github/linux/build_cuda_c_api_package.sh
+++ b/tools/ci_build/github/linux/build_cuda_c_api_package.sh
@@ -12,6 +12,10 @@ fi
 
 docker run -e SYSTEM_COLLECTIONURI --rm --volume \
 $BUILD_SOURCESDIRECTORY:/onnxruntime_src --volume $BUILD_BINARIESDIRECTORY:/build \
+-e NPM_CONFIG_USERCONFIG=/tmp/.npmrc \
+--volume "${NPM_CONFIG_USERCONFIG}:/tmp/.npmrc:ro" \
+--volume $HOME/.m2:/home/onnxruntimedev/.m2:ro \
+--volume $HOME/.gradle:/home/onnxruntimedev/.gradle \
 -e NIGHTLY_BUILD onnxruntimecuda${CUDA_VERSION_MAJOR}build \
 /bin/bash -c "/usr/bin/python3 /onnxruntime_src/tools/ci_build/build.py --enable_lto --build_java --build_nodejs \
 --build_dir /build --config Release --skip_submodule_sync  --parallel --use_binskim_compliant_compile_flags --build_shared_lib \

--- a/tools/ci_build/github/linux/build_nodejs_package.sh
+++ b/tools/ci_build/github/linux/build_nodejs_package.sh
@@ -13,6 +13,10 @@ fi
 mkdir -p $HOME/.onnx
 docker run -e SYSTEM_COLLECTIONURI --rm --volume /data/onnx:/data/onnx:ro --volume $BUILD_SOURCESDIRECTORY:/onnxruntime_src \
 --volume $BUILD_BINARIESDIRECTORY:/build --volume /data/models:/build/models:ro \
+-e NPM_CONFIG_USERCONFIG=/tmp/.npmrc \
+--volume "${NPM_CONFIG_USERCONFIG}:/tmp/.npmrc:ro" \
+--volume $HOME/.m2:/home/onnxruntimedev/.m2:ro \
+--volume $HOME/.gradle:/home/onnxruntimedev/.gradle \
 --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimecuda${CUDA_VERSION_MAJOR}xtrt86build \
 /bin/bash -c "/usr/bin/python3 /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config Release \
 --skip_tests --skip_submodule_sync --parallel --use_binskim_compliant_compile_flags --build_shared_lib --build_nodejs \

--- a/tools/ci_build/github/linux/build_tensorrt_c_api_package.sh
+++ b/tools/ci_build/github/linux/build_tensorrt_c_api_package.sh
@@ -13,6 +13,10 @@ fi
 mkdir -p $HOME/.onnx
 docker run -e SYSTEM_COLLECTIONURI --rm --volume /data/onnx:/data/onnx:ro --volume $BUILD_SOURCESDIRECTORY:/onnxruntime_src \
   --volume $BUILD_BINARIESDIRECTORY:/build --volume /data/models:/build/models:ro \
+  -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc \
+  --volume "${NPM_CONFIG_USERCONFIG}:/tmp/.npmrc:ro" \
+  --volume $HOME/.m2:/home/onnxruntimedev/.m2:ro \
+  --volume $HOME/.gradle:/home/onnxruntimedev/.gradle \
   --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimecuda${CUDA_VERSION_MAJOR}xtrt86build \
   /bin/bash -c "/usr/bin/python3 /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config Release --skip_tests \
   --skip_submodule_sync --parallel --use_binskim_compliant_compile_flags --build_shared_lib --build_java --build_nodejs \

--- a/tools/ci_build/github/linux/docker/inference/aarch64/python/cpu/scripts/requirements.txt
+++ b/tools/ci_build/github/linux/docker/inference/aarch64/python/cpu/scripts/requirements.txt
@@ -7,4 +7,4 @@ wheel
 protobuf==4.25.8
 sympy==1.14
 flatbuffers
-onnx==1.20.1
+onnx==1.21.0

--- a/tools/ci_build/github/linux/docker/scripts/lort/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/lort/requirements.txt
@@ -3,7 +3,7 @@ beartype==0.15.0
 flatbuffers
 cerberus
 h5py
-onnx==1.20.1
+onnx==1.21.0
 # Python dependencies required for pytorch development
 astunparse
 expecttest!=0.2.0

--- a/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
@@ -9,4 +9,4 @@ sympy==1.14
 flatbuffers
 neural-compressor>=2.2.1
 triton==3.5.0
-onnx==1.20.1
+onnx==1.21.0

--- a/tools/ci_build/github/linux/docker/scripts/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/requirements.txt
@@ -12,4 +12,4 @@ protobuf==6.33.0
 packaging
 onnxscript==0.6.2
 onnx-ir==0.1.16
-onnx==1.20.1
+onnx==1.21.0

--- a/tools/ci_build/github/linux/python/requirements.txt
+++ b/tools/ci_build/github/linux/python/requirements.txt
@@ -12,4 +12,4 @@ onnxscript==0.6.2
 onnx-ir==0.1.16
 jinja2
 markupsafe
-onnx==1.20.1
+onnx==1.21.0

--- a/tools/ci_build/github/linux/run_python_dockerbuild.sh
+++ b/tools/ci_build/github/linux/run_python_dockerbuild.sh
@@ -27,12 +27,17 @@ if [ "${BUILD_EXTR_PAR}" != "" ] ; then
     DOCKER_SCRIPT_OPTIONS+=("-x" "${BUILD_EXTR_PAR}")
 fi
 
+# HACK: `ADDITIONAL_DOCKER_PARAMETER` is passed in via env in some pipelines
 docker run -e SYSTEM_COLLECTIONURI --rm \
     --volume /data/onnx:/data/onnx:ro \
     --volume "${BUILD_SOURCESDIRECTORY}:/onnxruntime_src" \
     --volume "${BUILD_BINARIESDIRECTORY}:/build" \
     --volume /data/models:/build/models:ro \
     --volume "${HOME}/.onnx:/home/onnxruntimedev/.onnx" \
+    -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc \
+    --volume "${NPM_CONFIG_USERCONFIG}:/tmp/.npmrc:ro" \
+    --volume "$HOME/.m2:/home/onnxruntimedev/.m2:ro" \
+    --volume "$HOME/.gradle:/home/onnxruntimedev/.gradle" \
     -w /onnxruntime_src \
     -e NIGHTLY_BUILD \
     -e BUILD_BUILDNUMBER \

--- a/tools/ci_build/github/linux/run_python_dockertest.sh
+++ b/tools/ci_build/github/linux/run_python_dockertest.sh
@@ -1,29 +1,37 @@
 #!/bin/bash
-set -e -x
+set -xeuo pipefail
 BUILD_CONFIG="Release"
 
-while getopts "i:d:x:c:" parameter_Option
-do case "${parameter_Option}"
-in
-i) DOCKER_IMAGE=${OPTARG};;
-d) DEVICE=${OPTARG};;
-c) BUILD_CONFIG=${OPTARG};;
-esac
+while getopts "i:d:c:" parameter_Option; do
+  case "${parameter_Option}" in
+  i) DOCKER_IMAGE=${OPTARG} ;;
+  d) DEVICE=${OPTARG} ;;
+  c) BUILD_CONFIG=${OPTARG} ;;
+  *)
+    echo "Usage: $0 -i <docker_image> -d <GPU|CPU> [-c <build_config>]"
+    exit 1
+    ;;
+  esac
 done
 
-if [ $DEVICE = "GPU" ]; then
-  ADDITIONAL_DOCKER_PARAMETER="--gpus all"
+ADDITIONAL_DOCKER_PARAMETERS=()
+if [ "$DEVICE" = "GPU" ]; then
+  ADDITIONAL_DOCKER_PARAMETERS+=("--gpus" "all")
 fi
 
-mkdir -p $HOME/.onnx
+mkdir -p "$HOME/.onnx"
 docker run -e SYSTEM_COLLECTIONURI --rm \
-    --volume /data/onnx:/data/onnx:ro \
-    --volume $BUILD_SOURCESDIRECTORY:/onnxruntime_src \
-    --volume $BUILD_BINARIESDIRECTORY:/build \
-    --volume /data/models:/build/models:ro \
-    --volume $HOME/.onnx:/home/onnxruntimedev/.onnx \
-    -w /onnxruntime_src \
-    -e NIGHTLY_BUILD \
-    -e BUILD_BUILDNUMBER \
-    $ADDITIONAL_DOCKER_PARAMETER \
-    $DOCKER_IMAGE tools/ci_build/github/linux/run_python_tests.sh -d $DEVICE -c $BUILD_CONFIG
+  --volume /data/onnx:/data/onnx:ro \
+  --volume "$BUILD_SOURCESDIRECTORY:/onnxruntime_src" \
+  --volume "$BUILD_BINARIESDIRECTORY:/build" \
+  --volume /data/models:/build/models:ro \
+  --volume "$HOME/.onnx:/home/onnxruntimedev/.onnx" \
+  -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc \
+  --volume "${NPM_CONFIG_USERCONFIG}:/tmp/.npmrc:ro" \
+  --volume "$HOME/.m2:/home/onnxruntimedev/.m2:ro" \
+  --volume "$HOME/.gradle:/home/onnxruntimedev/.gradle" \
+  -w /onnxruntime_src \
+  -e NIGHTLY_BUILD \
+  -e BUILD_BUILDNUMBER \
+  "${ADDITIONAL_DOCKER_PARAMETERS[@]}" \
+  "$DOCKER_IMAGE" tools/ci_build/github/linux/run_python_tests.sh -d "$DEVICE" -c "$BUILD_CONFIG"

--- a/tools/ci_build/github/windows/python/requirements.txt
+++ b/tools/ci_build/github/windows/python/requirements.txt
@@ -14,4 +14,4 @@ jinja2
 markupsafe
 semver
 packaging
-onnx==1.20.1
+onnx==1.21.0

--- a/winml/adapter/winml_adapter_execution_provider.cpp
+++ b/winml/adapter/winml_adapter_execution_provider.cpp
@@ -20,6 +20,10 @@ struct OrtAllocatorWrapper : public OrtAllocator {
     Alloc = AllocImpl;
     Free = FreeImpl;
     Info = InfoImpl;
+    Reserve = nullptr;
+    GetStats = nullptr;
+    AllocOnStream = nullptr;
+    Shrink = nullptr;
   }
 
   static void* ORT_API_CALL AllocImpl(struct OrtAllocator* this_, size_t size) {


### PR DESCRIPTION
This cherry-picks the following commits for the release:

| Commit ID | PR Number | Commit Title |
|-----------|-----------|-------------|
| 445dcff7ba | #27945 | Add ORT_UNIT_TEST_MAIN_DYNAMIC_PLUGIN_EP_CONFIG_JSON_FILE env var |
| 63dfc33012 | #28034 | fix: idempotent feed setup |
| 58f99ead81 | #28064 | [C] fix: ADO CI spuriously failing format check due to picking up NuGet.config |
| f9c83ae09b | #28084 | Fix the python pipeline |
| cafbd7c497 | #28079 | [CI] fix: use internal feed for NPM on ADO |
| 94f32ec532 | #27289 | [CORE]: Improve filesystem error messages during Linux device discovery |
