### PR TITLE
Address build failure on ARM

### DIFF
--- a/onnxruntime/core/common/spin_pause.cc
+++ b/onnxruntime/core/common/spin_pause.cc
@@ -8,7 +8,7 @@
 #include <chrono>
 #include <cstdint>
 
-#if defined(_M_AMD64)
+#if defined(_M_AMD64) || defined(_M_ARM64) || defined(_M_ARM64EC)
 #include <intrin.h>
 #endif
 
@@ -44,10 +44,13 @@ void SpinPause() {
   } else {
     _mm_pause();
   }
-#elif defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+#elif defined(_M_ARM64) || defined(_M_ARM64EC)
   // ARM64 hint that yields the pipeline without descheduling the thread.
-  // Emitted as a non-inline asm statement so the optimizer cannot elide it
-  // from the calibration loop in CalibrateSpinPauseNs().
+  // MSVC intrinsic — GCC-style inline asm is not supported by MSVC.
+  __yield();
+#elif defined(__aarch64__)
+  // ARM64 hint (GCC/Clang). Emitted as a non-inline asm statement so the
+  // optimizer cannot elide it from the calibration loop.
   __asm__ __volatile__("yield" ::: "memory");
 #elif defined(__arm__)
   __asm__ __volatile__("yield" ::: "memory");


### PR DESCRIPTION
This pull request updates the platform-specific handling of spin-wait pauses in the `SpinPause` function to improve support for ARM64 architectures, especially on Windows. The changes ensure that the correct intrinsic or assembly instruction is used depending on the compiler and target platform.

Platform-specific spin-wait improvements:

* Added support for `_M_ARM64` and `_M_ARM64EC` (Windows ARM64 and ARM64EC) in the header inclusion logic, ensuring the correct intrinsics are available when compiling for these platforms.
* Updated the `SpinPause` implementation to use the MSVC-specific `__yield()` intrinsic for `_M_ARM64` and `_M_ARM64EC` targets, and reserved the GCC/Clang inline assembly version for `__aarch64__` (Linux/Unix ARM64). This ensures compatibility and optimal behavior across compilers and platforms.