### PR TITLE
WebGPU plugin EP pipeline updates

### DIFF
--- a/tools/ci_build/github/azure-pipelines/plugin-webgpu-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/plugin-webgpu-pipeline.yml
@@ -1,5 +1,13 @@
 trigger: none
 
+schedules:
+- cron: '0 17 * * *'  # Daily at 17:00 UTC
+  displayName: Nightly build
+  branches:
+    include:
+    - main
+  always: false  # Only run if source changed since last successful scheduled run
+
 resources:
   repositories:
   - repository: 1esPipelines
@@ -16,17 +24,17 @@ parameters:
 - name: build_windows_arm64
   displayName: 'Build Windows ARM64'
   type: boolean
-  default: false
+  default: true
 
 - name: build_linux_x64
   displayName: 'Build Linux x64'
   type: boolean
-  default: false
+  default: true
 
 - name: build_macos_arm64
   displayName: 'Build macOS ARM64'
   type: boolean
-  default: false
+  default: true
 
 - name: package_version
   displayName: 'Package Version'

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-linux-webgpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-linux-webgpu-stage.yml
@@ -49,6 +49,8 @@ stages:
         parameters:
           package_version: ${{ parameters.package_version }}
 
+      - template: ../templates/setup-feeds-and-python-steps.yml
+
       - template: ../templates/get-docker-image-steps.yml
         parameters:
           Dockerfile: tools/ci_build/github/linux/docker/inference/x86_64/python/cuda/Dockerfile

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-stage.yml
@@ -89,33 +89,6 @@ stages:
         env:
           TMPDIR: "$(Agent.TempDirectory)"
 
-      - task: PowerShell@2
-        displayName: '[WebGPU] Create .npmrc for WebGPU build'
-        inputs:
-          targetType: 'inline'
-          pwsh: true
-          script: |
-            $npmrcPath = Join-Path "$(Build.SourcesDirectory)" "onnxruntime/core/providers/webgpu/wgsl_templates/.npmrc"
-            $npmrcDir = Split-Path -Parent $npmrcPath
-            $packageJsonPath = Join-Path $npmrcDir "package.json"
-
-            # Check if package.json exists
-            if (-not (Test-Path $packageJsonPath)) {
-              Write-Error "package.json not found at: $packageJsonPath"
-              throw "package.json does not exist in $npmrcDir"
-            }
-
-            # Create .npmrc file with required content
-            $npmrcContent = "registry=${{ parameters.npm_registry_url }}`n`nalways-auth=true"
-
-            Set-Content -Path $npmrcPath -Value $npmrcContent -Encoding UTF8
-            Write-Host "Created .npmrc at: $npmrcPath"
-
-      - task: npmAuthenticate@0
-        displayName: '[WebGPU] Authenticate npm for WebGPU build'
-        inputs:
-          workingFile: '$(Build.SourcesDirectory)/onnxruntime/core/providers/webgpu/wgsl_templates/.npmrc'
-
       - ${{ if eq(parameters.arch, 'arm64') }}:
         - task: DownloadPipelineArtifact@2
           displayName: 'Download WebGPU build tools from x64 build'


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

- Fix issue with custom .npmrc file not being found by tools/ci_build/github/linux/build_webgpu_plugin_package.sh (follow up to #28079)
- Set build-enabled parameters to true by default
- Configure nightly build in yaml
- Remove unnecessary NPM configuration in Windows build - now, it is handled by templates/setup-build-tools.yml

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix pipeline issue. Build all supported platforms nightly.