### PR TITLE
Fix doxygen issues

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -7344,7 +7344,7 @@ struct OrtApi {
 
   /** \brief Get the element data type and shape for an OrtValue that represents a Tensor (scalar, dense, or sparse).
    *
-   * \note This function is an alternative to ::GetTensorTypeAndShape() that does not allocate a new array for
+   * \note This function is an alternative to OrtApi::GetTensorTypeAndShape that does not allocate a new array for
    *       the shape data. The OrtValue instance's internal shape data is returned directly.
    *
    * \note Returns an error if the underlying OrtValue is not a Tensor.
@@ -7411,7 +7411,6 @@ struct OrtApi {
   ORT_API2_STATUS(KernelInfoGetAttributeArray_string, _In_ const OrtKernelInfo* info, _In_ const char* name,
                   _Inout_ OrtAllocator* allocator, _Outptr_result_buffer_maybenull_(*size) char*** out, _Out_ size_t* size);
 
-  /// @}
   /// \name OrtEnv
   /// @{
 

--- a/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
@@ -14,6 +14,9 @@
 extern "C" {
 #endif
 
+/** \addtogroup Global
+ * @{
+ */
 ORT_RUNTIME_CLASS(Ep);
 ORT_RUNTIME_CLASS(EpFactory);
 ORT_RUNTIME_CLASS(EpGraphSupportInfo);
@@ -30,6 +33,7 @@ ORT_RUNTIME_CLASS(OpSchema);
 ORT_RUNTIME_CLASS(OpSchemaTypeConstraint);
 ORT_RUNTIME_CLASS(ProfilingEventsContainer);
 ORT_RUNTIME_CLASS(ProfilingEvent);  // Based on the Trace Event Format's "complete event"
+/// @}
 
 /** \brief Base struct for imported external memory handles.
  *
@@ -1552,8 +1556,8 @@ struct OrtEpApi {
    * \param[in] kernel_info The ::OrtKernelInfo instance for an If node. This function returns error ORT_FAIL
    *                        if the opset version specified by `kernel_info` is unsupported.
    * \param[out] kernel_out Output parameter set to the OrtKernelImpl instance for the If node.
-   *                        Must be released via ::ReleaseKernelImpl, unless ownership is transferred
-   *                        to ORT (see OrtKernelCreateFunc and ::KernelRegistry_AddKernel()).
+   *                        Must be released via OrtEpApi::ReleaseKernelImpl, unless ownership is transferred
+   *                        to ORT (see OrtKernelCreateFunc and OrtEpApi::KernelRegistry_AddKernel).
    *
    * \snippet{doc} snippets.dox OrtStatus Return Value
    * \since Version 1.24
@@ -1588,8 +1592,8 @@ struct OrtEpApi {
    *                   execution to operate on tensors allocated with the EP's device memory.
    *                   ORT will call OrtLoopKernelHelper::Release() to release the helper and its resources.
    * \param[out] kernel_out Output parameter set to the OrtKernelImpl instance for the Loop node.
-   *                        Must be released via ::ReleaseKernelImpl, unless ownership is transferred
-   *                        to ORT (see OrtKernelCreateFunc and ::KernelRegistry_AddKernel()).
+   *                        Must be released via OrtEpApi::ReleaseKernelImpl, unless ownership is transferred
+   *                        to ORT (see OrtKernelCreateFunc and OrtEpApi::KernelRegistry_AddKernel).
    *
    * \snippet{doc} snippets.dox OrtStatus Return Value
    * \since Version 1.24
@@ -1620,8 +1624,8 @@ struct OrtEpApi {
    *                   execution to operate on tensors allocated with the EP's device memory.
    *                   ORT will call OrtScanKernelHelper::Release() to release the helper and its resources.
    * \param[out] kernel_out Output parameter set to the OrtKernelImpl instance for the Scan node.
-   *                        Must be released via ::ReleaseKernelImpl, unless ownership is transferred
-   *                        to ORT (see OrtKernelCreateFunc and ::KernelRegistry_AddKernel()).
+   *                        Must be released via OrtEpApi::ReleaseKernelImpl, unless ownership is transferred
+   *                        to ORT (see OrtKernelCreateFunc and OrtEpApi::KernelRegistry_AddKernel).
    *
    * \snippet{doc} snippets.dox OrtStatus Return Value
    * \since Version 1.24


### PR DESCRIPTION
This pull request makes several documentation improvements and clarifications to the ONNX Runtime C API header files. The changes focus on improving the accuracy and consistency of API references, especially for function and ownership documentation, and on enhancing Doxygen group annotations.

**Documentation and API Reference Improvements:**

* Updated references to function names in documentation comments to use the correct qualified names (e.g., `OrtApi::GetTensorTypeAndShape` instead of `::GetTensorTypeAndShape`) for clarity and consistency.
* Improved documentation for kernel ownership and release by referencing methods via `OrtEpApi` (e.g., `OrtEpApi::ReleaseKernelImpl` and `OrtEpApi::KernelRegistry_AddKernel`) instead of global functions, ensuring the documentation matches the API design. [[1]](diffhunk://#diff-2d8e6d37bb0ef428daa560918f0fc5e9de31ff9eb5b66f857fed0769bebccb80L1555-R1560) [[2]](diffhunk://#diff-2d8e6d37bb0ef428daa560918f0fc5e9de31ff9eb5b66f857fed0769bebccb80L1591-R1596) [[3]](diffhunk://#diff-2d8e6d37bb0ef428daa560918f0fc5e9de31ff9eb5b66f857fed0769bebccb80L1623-R1628)

**Doxygen Group Annotation Enhancements:**

* Added and corrected Doxygen group annotations (`\addtogroup Global` and `@}`) in `onnxruntime_ep_c_api.h` to properly group related API declarations, improving generated documentation structure. [[1]](diffhunk://#diff-2d8e6d37bb0ef428daa560918f0fc5e9de31ff9eb5b66f857fed0769bebccb80R17-R19) [[2]](diffhunk://#diff-2d8e6d37bb0ef428daa560918f0fc5e9de31ff9eb5b66f857fed0769bebccb80R36)

**Minor Cleanup:**

* Removed an extraneous documentation group annotation to maintain proper Doxygen formatting.