### PR TITLE
Prevent double-free in OrtModelEditorApi ownership transfer

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -7729,8 +7729,7 @@ struct OrtModelEditorApi {
   /** \brief Add an initializer to the OrtGraph
    *
    * ORT will copy the OrtValue internally. The caller retains ownership of the OrtValue and should
-   * release it with ReleaseValue when done. The underlying tensor data is shared via reference counting,
-   * so the copy is cheap and the data remains valid as long as either the caller or the graph holds a reference.
+   * release it with ReleaseValue when done.
    *
    * Two options:
    *

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -7728,7 +7728,9 @@ struct OrtModelEditorApi {
 
   /** \brief Add an initializer to the OrtGraph
    *
-   * ORT will take ownership of the OrtValue and you should NOT call ReleaseOrtValue.
+   * ORT will copy the OrtValue internally. The caller retains ownership of the OrtValue and should
+   * release it with ReleaseValue when done. The underlying tensor data is shared via reference counting,
+   * so the copy is cheap and the data remains valid as long as either the caller or the graph holds a reference.
    *
    * Two options:
    *

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -7697,7 +7697,7 @@ struct OrtModelEditorApi {
   /** \brief Set the inputs for the OrtGraph.
    *
    * Set the graph inputs. This will replace any existing inputs with the new values.
-   * The OrtGraph takes ownership of the OrtValueInfo instances and you should NOT call ReleaseOrtValueInfo.
+   * The OrtGraph takes ownership of the OrtValueInfo instances and you should NOT call OrtApi::ReleaseValueInfo.
    *
    * \param[in] graph The OrtGraph instance to update.
    * \param[in] inputs The input OrtValueInfo instances.
@@ -7713,7 +7713,7 @@ struct OrtModelEditorApi {
   /** \brief Set the outputs for the OrtGraph.
    *
    * Set the graph outputs. This will replace any existing outputs with the new values.
-   * The OrtGraph takes ownership of the OrtValueInfo instances provided and you should NOT call ReleaseOrtValueInfo.
+   * The OrtGraph takes ownership of the OrtValueInfo instances provided and you should NOT call OrtApi::ReleaseValueInfo.
    *
    * \param[in] graph The OrtGraph instance to update.
    * \param[in] outputs The output OrtValueInfo instances.
@@ -7729,29 +7729,29 @@ struct OrtModelEditorApi {
   /** \brief Add an initializer to the OrtGraph
    *
    * ORT will copy the OrtValue wrapper internally. The caller retains ownership of the OrtValue and should
-   * release it with ReleaseValue when done. Note that the underlying data buffer is not copied.
-   * If the OrtValue was created with a user-provided buffer (e.g., CreateTensorWithDataAsOrtValue),
+   * release it with OrtApi::ReleaseValue when done. Note that the underlying data buffer is not copied.
+   * If the OrtValue was created with a user-provided buffer (e.g., OrtApi::CreateTensorWithDataAsOrtValue),
    * that buffer must remain valid for the duration of the inference session.
    *
    * Two options:
    *
    * Allocated memory:
-   *    Use CreateTensorAsOrtValue (allocates memory) and populate the tensor with the data.
+   *    Use OrtApi::CreateTensorAsOrtValue (allocates memory) and populate the tensor with the data.
    *    Set `data_is_external` to false.
    *
    * Pre-existing memory:
-   *    Use CreateTensorWithDataAsOrtValue or CreateTensorWithDataAndDeleterAsOrtValue to create an OrtValue
+   *    Use OrtApi::CreateTensorWithDataAsOrtValue or OrtApi::CreateTensorWithDataAndDeleterAsOrtValue to create an OrtValue
    *    with a tensor that contains a pointer to the existing data.
    *    Set `data_is_external` to true.
    *
    *    The pointer must remain valid for the duration of the inference session.
-   *    If using CreateTensorWithDataAsOrtValue you are responsible for freeing the memory after the inference session
+   *    If using OrtApi::CreateTensorWithDataAsOrtValue you are responsible for freeing the memory after the inference session
    *    is released.
-   *    If using CreateTensorWithDataAndDeleterAsOrtValue, ORT will free the memory using the provided deleter as
+   *    If using OrtApi::CreateTensorWithDataAndDeleterAsOrtValue, ORT will free the memory using the provided deleter as
    *    soon as the OrtValue is no longer in use.
    *
    *    NOTE: A tensor containing pre-existing memory MUST have 128 bytes of data or more.
-   *          For smaller tensors use CreateTensorAsOrtValue.
+   *          For smaller tensors use OrtApi::CreateTensorAsOrtValue.
    *
    *          ONNX shape inferencing does not support external data. An initializer involved in shape inferencing is
    *          typically small (a single value or limited by the rank of a tensor) and uses less than 128 bytes of
@@ -7772,7 +7772,7 @@ struct OrtModelEditorApi {
 
   /** \brief Add an OrtNode to an OrtGraph
    *
-   * Add the node to the graph. The OrtGraph will take ownership of OrtNode and you should NOT call ReleaseOrtNode.
+   * Add the node to the graph. The OrtGraph will take ownership of OrtNode and you should NOT call OrtApi::ReleaseNode.
    *
    * \param[in] graph The OrtGraph instance to update.
    * \param[in] node The OrtNode instance to add to the graph.
@@ -7811,7 +7811,7 @@ struct OrtModelEditorApi {
    *
    * Add the graph to a model. This should be called once when creating a new model.
    *
-   * The OrtModel takes ownership of the OrtGraph and you should NOT call ReleaseOrtGraph.
+   * The OrtModel takes ownership of the OrtGraph and you should NOT call OrtApi::ReleaseGraph.
    *
    * \param[in] model The OrtModel instance to update.
    * \param[in] graph The OrtGraph instance to add to the model.
@@ -7829,7 +7829,7 @@ struct OrtModelEditorApi {
    * and SetGraphOutputs must have been called.
    * This will validate the model, run optimizers, and prepare the session for inferencing.
    *
-   * ReleaseOrtModel must be called to free the OrtModel after session creation.
+   * OrtApi::ReleaseModel must be called to free the OrtModel after session creation.
    *
    * \param[in] env The OrtEnv instance.
    * \param[in] model The OrtModel instance.
@@ -7849,13 +7849,13 @@ struct OrtModelEditorApi {
    * Nodes can be added before or after the existing nodes in the model. ONNX Runtime will connect the nodes when the
    * model is finalized.
    *
-   * To add nodes and initializers to the existing model, first create an OrtModel using CreateModel.
-   * Add nodes and initializers to the OrtModel using AddNodeToGraph and AddInitializerToGraph.
-   * Graph inputs/outputs should be updated with SetGraphInputs and SetGraphOutputs as needed to reflect changes made
+   * To add nodes and initializers to the existing model, first create an OrtModel using CreateModel().
+   * Add nodes and initializers to the OrtModel using AddNodeToGraph() and AddInitializerToGraph().
+   * Graph inputs/outputs should be updated with SetGraphInputs() and SetGraphOutputs() as needed to reflect changes made
    * by the new nodes. The list of graph inputs/outputs should be for the overall model and not just the new nodes.
    *
-   * Add the new information from the OrtModel to the original model using ApplyModelToSession, and prepare the
-   * session for inferencing by calling FinalizeModelEditorSession.
+   * Add the new information from the OrtModel to the original model using ApplyModelToSession(), and prepare the
+   * session for inferencing by calling FinalizeModelEditorSession().
    *
    * \param{in} env The OrtEnv instance.
    * \param{in} model_path The path to the existing ONNX model to augment.
@@ -7875,13 +7875,13 @@ struct OrtModelEditorApi {
    * Nodes can be added before or after the existing nodes in the model. ONNX Runtime will connect the nodes when the
    * model is finalized.
    *
-   * To add nodes and initializers to the existing model, first create an OrtModel using CreateModel.
-   * Add nodes and initializers to the OrtModel using AddNodeToGraph and AddInitializerToGraph.
-   * Graph inputs/outputs should be updated with SetGraphInputs and SetGraphOutputs as needed to reflect changes made
+   * To add nodes and initializers to the existing model, first create an OrtModel using CreateModel().
+   * Add nodes and initializers to the OrtModel using AddNodeToGraph() and AddInitializerToGraph().
+   * Graph inputs/outputs should be updated with SetGraphInputs() and SetGraphOutputs() as needed to reflect changes made
    * by the new nodes. The list of graph inputs/outputs should be for the overall model and not just the new nodes.
    *
-   * Add the new information from the OrtModel to the original model using ApplyModelToSession, and prepare the
-   * session for inferencing by calling FinalizeModelEditorSession.
+   * Add the new information from the OrtModel to the original model using ApplyModelToSession(), and prepare the
+   * session for inferencing by calling FinalizeModelEditorSession().
    *
    * \param{in} env The OrtEnv instance.
    * \param{in} model_data The model data for the existing model to augment.

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -7728,8 +7728,10 @@ struct OrtModelEditorApi {
 
   /** \brief Add an initializer to the OrtGraph
    *
-   * ORT will copy the OrtValue internally. The caller retains ownership of the OrtValue and should
-   * release it with ReleaseValue when done.
+   * ORT will copy the OrtValue wrapper internally. The caller retains ownership of the OrtValue and should
+   * release it with ReleaseValue when done. Note that the underlying data buffer is not copied.
+   * If the OrtValue was created with a user-provided buffer (e.g., CreateTensorWithDataAsOrtValue),
+   * that buffer must remain valid for the duration of the inference session.
    *
    * Two options:
    *
@@ -7758,15 +7760,15 @@ struct OrtModelEditorApi {
    *
    * \param[in] graph The OrtGraph instance to update.
    * \param[in] name The value name for the initializer.
-   * \param[in] tensor The OrtValue instance containing the tensor data.
-   * \param[in] data_is_external Set to true if the data is external and should not be copied.
+   * \param[in] ort_value The OrtValue instance containing the tensor data.
+   * \param[in] data_is_external Set to true if the data is external and should not be serialized into the model.
    *
    * \snippet{doc} snippets.dox OrtStatus Return Value
    *
    * \since Version 1.22.
    */
-  ORT_API2_STATUS(AddInitializerToGraph, _Inout_ OrtGraph* graph, _In_ const char* name, _In_ OrtValue* tensor,
-                  bool data_is_external);
+  ORT_API2_STATUS(AddInitializerToGraph, _Inout_ OrtGraph* graph, _In_ const char* name,
+                  _In_ const OrtValue* ort_value, bool data_is_external);
 
   /** \brief Add an OrtNode to an OrtGraph
    *

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -3480,7 +3480,7 @@ struct GraphImpl : ConstGraphImpl<T> {
   // <Wraps GetModelEditorApi().SetGraphOutputs()
   void SetOutputs(std::vector<ValueInfo>& outputs);
   // <Wraps GetModelEditorApi().AddInitializerToGraph()
-  void AddInitializer(const std::string& name, Value& initializer, bool data_is_external);  // Graph takes ownership of Value
+  void AddInitializer(const std::string& name, const Value& initializer, bool data_is_external);  // Graph copies the OrtValue internally
   // <Wraps GetModelEditorApi().AddNodeToGraph()
   void AddNode(Node& node);  // Graph takes ownership of Node
 #endif                       // !defined(ORT_MINIMAL_BUILD)

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -3868,10 +3868,9 @@ inline void GraphImpl<T>::SetOutputs(std::vector<ValueInfo>& outputs) {
 
 template <typename T>
 inline void GraphImpl<T>::AddInitializer(const std::string& name, Value& initializer, bool data_is_external) {
-  // Graph takes ownership of `initializer`
-  // On error the ownership is not transferred.
+  // Graph copies the OrtValue internally (shared_ptr refcount increment).
+  // Caller retains ownership of initializer and should let it destruct normally.
   ThrowOnError(GetModelEditorApi().AddInitializerToGraph(this->p_, name.c_str(), initializer, data_is_external));
-  initializer.release();
 }
 
 template <typename T>

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -3868,8 +3868,7 @@ inline void GraphImpl<T>::SetOutputs(std::vector<ValueInfo>& outputs) {
 
 template <typename T>
 inline void GraphImpl<T>::AddInitializer(const std::string& name, Value& initializer, bool data_is_external) {
-  // Graph copies the OrtValue internally (shared_ptr refcount increment).
-  // Caller retains ownership of initializer and should let it destruct normally.
+  // Graph copies the OrtValue internally. Caller retains ownership of initializer.
   ThrowOnError(GetModelEditorApi().AddInitializerToGraph(this->p_, name.c_str(), initializer, data_is_external));
 }
 

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -3867,7 +3867,7 @@ inline void GraphImpl<T>::SetOutputs(std::vector<ValueInfo>& outputs) {
 }
 
 template <typename T>
-inline void GraphImpl<T>::AddInitializer(const std::string& name, Value& initializer, bool data_is_external) {
+inline void GraphImpl<T>::AddInitializer(const std::string& name, const Value& initializer, bool data_is_external) {
   // Graph copies the OrtValue internally. Caller retains ownership of initializer.
   ThrowOnError(GetModelEditorApi().AddInitializerToGraph(this->p_, name.c_str(), initializer, data_is_external));
 }

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -6716,12 +6716,12 @@ Status Graph::LoadFromModelEditorApiModel(const OrtGraph& api_graph, bool updati
     }
   };
 
-  auto add_initializers = [this](const std::unordered_map<std::string, std::unique_ptr<OrtValue>>& initializers,
+  auto add_initializers = [this](const std::unordered_map<std::string, OrtValue>& initializers,
                                  bool is_external) {
     for (auto& name_and_ortvalue : initializers) {
       // convert from OrtValue to TensorProto
       const std::string& name = name_and_ortvalue.first;
-      OrtValue& v = *name_and_ortvalue.second;
+      const OrtValue& v = name_and_ortvalue.second;
 
       ORT_ENFORCE(v.IsTensor(), "Initializers must be Tensors");
       const Tensor& t = v.Get<Tensor>();
@@ -6742,7 +6742,7 @@ Status Graph::LoadFromModelEditorApiModel(const OrtGraph& api_graph, bool updati
                                                      offset, t.SizeInBytes(), tensor_proto);
 
         // add OrtValue to ortvalue_initializers_ to keep it alive and to store the deleter if provided.
-        ortvalue_initializers_.emplace(name, std::move(v));
+        ortvalue_initializers_.emplace(name, v);
       } else {
         onnxruntime::utils::SetRawDataInTensorProto(tensor_proto, t.DataRaw(), t.SizeInBytes());
       }

--- a/onnxruntime/core/graph/model_editor_api_types.h
+++ b/onnxruntime/core/graph/model_editor_api_types.h
@@ -239,6 +239,7 @@ struct ModelEditorGraph : public OrtGraph {
   std::unordered_map<std::string, std::unique_ptr<OrtValue>> initializers;
   std::unordered_map<std::string, std::unique_ptr<OrtValue>> external_initializers;
   onnxruntime::InlinedHashSet<const OrtValue*> owned_initializer_ptrs_;  // tracks owned OrtValue pointers to prevent double-free
+  bool owned_ = false;                                                   // true after ownership transferred to a model
   std::vector<std::unique_ptr<onnxruntime::ModelEditorNode>> nodes;
   std::string name = "ModelEditorGraph";
   std::filesystem::path model_path;

--- a/onnxruntime/core/graph/model_editor_api_types.h
+++ b/onnxruntime/core/graph/model_editor_api_types.h
@@ -81,6 +81,7 @@ struct ModelEditorValueInfo : public OrtValueInfo {
                            "OrtModelEditorApi does not support querying if a OrtValueInfo is defined in an outer scope.");
   }
 
+  bool owned_ = false;  // true after ownership transferred to a graph
   std::string name;
   std::unique_ptr<OrtTypeInfo> type_info;
 };

--- a/onnxruntime/core/graph/model_editor_api_types.h
+++ b/onnxruntime/core/graph/model_editor_api_types.h
@@ -239,8 +239,7 @@ struct ModelEditorGraph : public OrtGraph {
   onnxruntime::InlinedVector<std::unique_ptr<onnxruntime::ModelEditorValueInfo>> outputs;
   std::unordered_map<std::string, std::unique_ptr<OrtValue>> initializers;
   std::unordered_map<std::string, std::unique_ptr<OrtValue>> external_initializers;
-  onnxruntime::InlinedHashSet<const OrtValue*> owned_initializer_ptrs_;  // tracks owned OrtValue pointers to prevent double-free
-  bool owned_ = false;                                                   // true after ownership transferred to a model
+  bool owned_ = false;  // true after ownership transferred to a model
   std::vector<std::unique_ptr<onnxruntime::ModelEditorNode>> nodes;
   std::string name = "ModelEditorGraph";
   std::filesystem::path model_path;

--- a/onnxruntime/core/graph/model_editor_api_types.h
+++ b/onnxruntime/core/graph/model_editor_api_types.h
@@ -9,7 +9,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include "core/common/inlined_containers_fwd.h"
+#include "core/common/inlined_containers.h"
 #include "core/framework/ort_value.h"
 #include "core/graph/abi_graph_types.h"
 #include "core/graph/onnx_protobuf.h"
@@ -154,6 +154,7 @@ struct ModelEditorNode : public OrtNode {
                            "OrtModelEditorApi does not support getting the parent graph for OrtNode");
   }
 
+  bool owned_ = false;  // true after ownership transferred to a graph
   size_t id = 0;
   std::string operator_name;
   std::string domain_name;
@@ -237,6 +238,7 @@ struct ModelEditorGraph : public OrtGraph {
   onnxruntime::InlinedVector<std::unique_ptr<onnxruntime::ModelEditorValueInfo>> outputs;
   std::unordered_map<std::string, std::unique_ptr<OrtValue>> initializers;
   std::unordered_map<std::string, std::unique_ptr<OrtValue>> external_initializers;
+  onnxruntime::InlinedHashSet<const OrtValue*> owned_initializer_ptrs_;  // tracks owned OrtValue pointers to prevent double-free
   std::vector<std::unique_ptr<onnxruntime::ModelEditorNode>> nodes;
   std::string name = "ModelEditorGraph";
   std::filesystem::path model_path;

--- a/onnxruntime/core/graph/model_editor_api_types.h
+++ b/onnxruntime/core/graph/model_editor_api_types.h
@@ -9,7 +9,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include "core/common/inlined_containers.h"
+#include "core/common/inlined_containers_fwd.h"
 #include "core/framework/ort_value.h"
 #include "core/graph/abi_graph_types.h"
 #include "core/graph/onnx_protobuf.h"
@@ -237,8 +237,8 @@ struct ModelEditorGraph : public OrtGraph {
 
   onnxruntime::InlinedVector<std::unique_ptr<onnxruntime::ModelEditorValueInfo>> inputs;
   onnxruntime::InlinedVector<std::unique_ptr<onnxruntime::ModelEditorValueInfo>> outputs;
-  std::unordered_map<std::string, std::unique_ptr<OrtValue>> initializers;
-  std::unordered_map<std::string, std::unique_ptr<OrtValue>> external_initializers;
+  std::unordered_map<std::string, OrtValue> initializers;
+  std::unordered_map<std::string, OrtValue> external_initializers;
   bool owned_ = false;  // true after ownership transferred to a model
   std::vector<std::unique_ptr<onnxruntime::ModelEditorNode>> nodes;
   std::string name = "ModelEditorGraph";

--- a/onnxruntime/core/session/model_editor_api.h
+++ b/onnxruntime/core/session/model_editor_api.h
@@ -33,7 +33,7 @@ ORT_API_STATUS_IMPL(SetGraphInputs, _In_ OrtGraph* graph,
                     _In_reads_(inputs_len) _In_ OrtValueInfo** inputs, _In_ size_t inputs_len);
 ORT_API_STATUS_IMPL(SetGraphOutputs, _In_ OrtGraph* graph,
                     _In_reads_(outputs_len) _In_ OrtValueInfo** outputs, _In_ size_t outputs_len);
-ORT_API_STATUS_IMPL(AddInitializerToGraph, _In_ OrtGraph* graph, _In_ const char* name, _Inout_ OrtValue* tensor,
+ORT_API_STATUS_IMPL(AddInitializerToGraph, _In_ OrtGraph* graph, _In_ const char* name, _In_ OrtValue* tensor,
                     bool data_is_external);
 ORT_API_STATUS_IMPL(AddNodeToGraph, _In_ OrtGraph* graph, _Inout_ OrtNode* node);
 

--- a/onnxruntime/core/session/model_editor_api.h
+++ b/onnxruntime/core/session/model_editor_api.h
@@ -33,7 +33,8 @@ ORT_API_STATUS_IMPL(SetGraphInputs, _In_ OrtGraph* graph,
                     _In_reads_(inputs_len) _In_ OrtValueInfo** inputs, _In_ size_t inputs_len);
 ORT_API_STATUS_IMPL(SetGraphOutputs, _In_ OrtGraph* graph,
                     _In_reads_(outputs_len) _In_ OrtValueInfo** outputs, _In_ size_t outputs_len);
-ORT_API_STATUS_IMPL(AddInitializerToGraph, _In_ OrtGraph* graph, _In_ const char* name, _In_ OrtValue* tensor,
+ORT_API_STATUS_IMPL(AddInitializerToGraph, _In_ OrtGraph* graph, _In_ const char* name,
+                    _In_ const OrtValue* ort_value,
                     bool data_is_external);
 ORT_API_STATUS_IMPL(AddNodeToGraph, _In_ OrtGraph* graph, _Inout_ OrtNode* node);
 

--- a/onnxruntime/core/session/model_editor_c_api.cc
+++ b/onnxruntime/core/session/model_editor_c_api.cc
@@ -3,6 +3,7 @@
 
 #if !defined(ORT_MINIMAL_BUILD)
 
+#include <algorithm>
 #include <variant>
 
 #include "core/common/inlined_containers.h"
@@ -225,7 +226,7 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::SetGraphOutputs, _In_ OrtGraph* ort_graph
 }
 
 ORT_API_STATUS_IMPL(OrtModelEditorAPI::AddInitializerToGraph, _In_ OrtGraph* ort_graph, _In_ const char* name,
-                    _Inout_ OrtValue* tensor, bool data_is_external) {
+                    _In_ OrtValue* tensor, bool data_is_external) {
   API_IMPL_BEGIN
   if (name == nullptr || *name == '\0') {
     return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "name cannot be null or empty string");
@@ -321,10 +322,12 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::AddNodeToGraph, _In_ OrtGraph* ort_graph,
   }
 
   // All validation done. Take ownership.
-  // Reserve first so push_back won't reallocate — if reserve() throws, node is not yet
-  // owned by a unique_ptr and the caller still safely owns it.
+  // Reserve with geometric growth so emplace_back won't reallocate.
+  // If reserve() throws, node is not yet owned by a unique_ptr and the caller still safely owns it.
   node->id = graph->nodes.size();
-  graph->nodes.reserve(graph->nodes.size() + 1);
+  if (graph->nodes.size() == graph->nodes.capacity()) {
+    graph->nodes.reserve(std::max(graph->nodes.capacity() * 2, size_t{1}));
+  }
   graph->nodes.emplace_back(node);  // constructs unique_ptr in-place; won't reallocate
   node->owned_ = true;
   return nullptr;

--- a/onnxruntime/core/session/model_editor_c_api.cc
+++ b/onnxruntime/core/session/model_editor_c_api.cc
@@ -125,10 +125,20 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::SetGraphInputs, _In_ OrtGraph* ort_graph,
   // Check for duplicate pointers in the input array to prevent double-free
   onnxruntime::InlinedHashSet<const OrtValueInfo*> seen;
   for (size_t i = 0; i < inputs_len; ++i) {
-    if (inputs[i] != nullptr && !seen.insert(inputs[i]).second) {
+    if (inputs[i] == nullptr) {
+      continue;  // null entries are validated in the transfer loop below
+    }
+    if (!seen.insert(inputs[i]).second) {
       return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
                                    "Duplicate OrtValueInfo pointer found in inputs array. "
                                    "Each OrtValueInfo can only appear once.");
+    }
+    // Reject already-owned ValueInfos (prevents double-free if reused across calls)
+    onnxruntime::ModelEditorValueInfo* vi = onnxruntime::ModelEditorValueInfo::ToInternal(inputs[i]);
+    if (vi != nullptr && vi->owned_) {
+      return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
+                                   "This OrtValueInfo has already been added to a graph. "
+                                   "Each OrtValueInfo can only be added once.");
     }
   }
 
@@ -145,6 +155,7 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::SetGraphInputs, _In_ OrtGraph* ort_graph,
     }
 
     graph->inputs.push_back(std::unique_ptr<onnxruntime::ModelEditorValueInfo>(input));  // take ownership
+    input->owned_ = true;
     inputs[i] = nullptr;
   }
 
@@ -173,10 +184,20 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::SetGraphOutputs, _In_ OrtGraph* ort_graph
   // Check for duplicate pointers in the output array to prevent double-free
   onnxruntime::InlinedHashSet<const OrtValueInfo*> seen;
   for (size_t i = 0; i < outputs_len; ++i) {
-    if (outputs[i] != nullptr && !seen.insert(outputs[i]).second) {
+    if (outputs[i] == nullptr) {
+      continue;  // null entries are validated in the transfer loop below
+    }
+    if (!seen.insert(outputs[i]).second) {
       return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
                                    "Duplicate OrtValueInfo pointer found in outputs array. "
                                    "Each OrtValueInfo can only appear once.");
+    }
+    // Reject already-owned ValueInfos (prevents double-free if reused across calls)
+    onnxruntime::ModelEditorValueInfo* vi = onnxruntime::ModelEditorValueInfo::ToInternal(outputs[i]);
+    if (vi != nullptr && vi->owned_) {
+      return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
+                                   "This OrtValueInfo has already been added to a graph. "
+                                   "Each OrtValueInfo can only be added once.");
     }
   }
 
@@ -193,6 +214,7 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::SetGraphOutputs, _In_ OrtGraph* ort_graph
     }
 
     graph->outputs.push_back(std::unique_ptr<onnxruntime::ModelEditorValueInfo>(output));  // take ownership
+    output->owned_ = true;
     outputs[i] = nullptr;
   }
 

--- a/onnxruntime/core/session/model_editor_c_api.cc
+++ b/onnxruntime/core/session/model_editor_c_api.cc
@@ -228,12 +228,18 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::AddInitializerToGraph, _In_ OrtGraph* ort
                                  "Each OrtValue can only be added once.");
   }
 
+  // Track the pointer before transferring ownership to the map.
+  // This ensures exception safety: if the map insertion throws, the tracking set
+  // is already updated but no ownership was transferred, so the caller still owns the pointer.
+  graph->owned_initializer_ptrs_.insert(tensor);
+
   if (data_is_external) {
     // enforce that an external initializer is not used if the data size is < 128 bytes.
     // the reason for this is to avoid potential shape inferencing errors if this initializer is providing an
     // input involved in that. the ONNX shape inferencing does not support external data for those values.
     // e.g. Reshape's `shape` input, Reduce's `axes', Slice's `starts`, `ends`, `steps`, Clip's `min`, `max`, etc.
     if (t.SizeInBytes() < 128) {
+      graph->owned_initializer_ptrs_.erase(tensor);
       return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
                                    "External initializer should only be used for data >= 128 bytes. "
                                    "Please use CreateTensorAsOrtValue instead.");
@@ -243,8 +249,6 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::AddInitializerToGraph, _In_ OrtGraph* ort
   } else {
     graph->initializers[name] = std::unique_ptr<OrtValue>(tensor);  // take ownership
   }
-
-  graph->owned_initializer_ptrs_.insert(tensor);
 
   return nullptr;
   API_IMPL_END

--- a/onnxruntime/core/session/model_editor_c_api.cc
+++ b/onnxruntime/core/session/model_editor_c_api.cc
@@ -107,6 +107,14 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::CreateGraph, _Outptr_ OrtGraph** graph) {
 ORT_API_STATUS_IMPL(OrtModelEditorAPI::SetGraphInputs, _In_ OrtGraph* ort_graph,
                     _In_reads_(inputs_len) _In_ OrtValueInfo** inputs, _In_ size_t inputs_len) {
   API_IMPL_BEGIN
+  if (ort_graph == nullptr) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "graph cannot be null");
+  }
+
+  if (inputs == nullptr && inputs_len != 0) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "inputs cannot be null when inputs_len is non-zero");
+  }
+
   onnxruntime::ModelEditorGraph* graph = onnxruntime::ModelEditorGraph::ToInternal(ort_graph);
 
   if (graph == nullptr) {
@@ -147,6 +155,14 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::SetGraphInputs, _In_ OrtGraph* ort_graph,
 ORT_API_STATUS_IMPL(OrtModelEditorAPI::SetGraphOutputs, _In_ OrtGraph* ort_graph,
                     _In_reads_(outputs_len) _In_ OrtValueInfo** outputs, _In_ size_t outputs_len) {
   API_IMPL_BEGIN
+  if (ort_graph == nullptr) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "graph cannot be null");
+  }
+
+  if (outputs == nullptr && outputs_len != 0) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "outputs cannot be null when outputs_len is non-zero");
+  }
+
   onnxruntime::ModelEditorGraph* graph = onnxruntime::ModelEditorGraph::ToInternal(ort_graph);
 
   if (graph == nullptr) {
@@ -193,6 +209,10 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::AddInitializerToGraph, _In_ OrtGraph* ort
 
   if (tensor == nullptr) {
     return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "tensor cannot be null");
+  }
+
+  if (ort_graph == nullptr) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "graph cannot be null");
   }
 
   onnxruntime::ModelEditorGraph* graph = onnxruntime::ModelEditorGraph::ToInternal(ort_graph);
@@ -265,6 +285,10 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::AddNodeToGraph, _In_ OrtGraph* ort_graph,
     return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "node cannot be null");
   }
 
+  if (ort_graph == nullptr) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "graph cannot be null");
+  }
+
   onnxruntime::ModelEditorGraph* graph = onnxruntime::ModelEditorGraph::ToInternal(ort_graph);
 
   if (graph == nullptr) {
@@ -330,7 +354,22 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::AddGraphToModel, _In_ OrtModel* model, _I
                                  "Model already has a graph. Each OrtModel can only have one graph.");
   }
 
+  // Reject if this graph has already been added to a model (prevents double-free across models)
+  onnxruntime::ModelEditorGraph* me_graph = onnxruntime::ModelEditorGraph::ToInternal(graph);
+  if (me_graph == nullptr) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
+                                 "Invalid OrtGraph variant for use in the OrtModelEditorApi");
+  }
+
+  if (me_graph->owned_) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
+                                 "This graph has already been added to a model. "
+                                 "Each OrtGraph can only be added once.");
+  }
+
   model->graph = std::unique_ptr<OrtGraph>(graph);  // take ownership
+  me_graph->owned_ = true;
+
   return nullptr;
   API_IMPL_END
 }

--- a/onnxruntime/core/session/model_editor_c_api.cc
+++ b/onnxruntime/core/session/model_editor_c_api.cc
@@ -142,6 +142,7 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::SetGraphInputs, _In_ OrtGraph* ort_graph,
     }
   }
 
+  graph->inputs.reserve(inputs_len);  // pre-allocate so push_back won't reallocate during ownership transfer
   graph->inputs.clear();
   for (size_t i = 0; i < inputs_len; ++i) {
     if (inputs[i] == nullptr) {
@@ -201,6 +202,7 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::SetGraphOutputs, _In_ OrtGraph* ort_graph
     }
   }
 
+  graph->outputs.reserve(outputs_len);  // pre-allocate so push_back won't reallocate during ownership transfer
   graph->outputs.clear();
   for (size_t i = 0; i < outputs_len; ++i) {
     if (outputs[i] == nullptr) {

--- a/onnxruntime/core/session/model_editor_c_api.cc
+++ b/onnxruntime/core/session/model_editor_c_api.cc
@@ -263,13 +263,6 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::AddInitializerToGraph, _In_ OrtGraph* ort
                                  "An initializer with this name has already been added to the graph.");
   }
 
-  // Reject if this OrtValue pointer was already added (prevents double-free via same pointer, different name)
-  if (graph->owned_initializer_ptrs_.count(tensor) != 0) {
-    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
-                                 "This tensor has already been added as an initializer. "
-                                 "Each OrtValue can only be added once.");
-  }
-
   if (data_is_external) {
     // enforce that an external initializer is not used if the data size is < 128 bytes.
     // the reason for this is to avoid potential shape inferencing errors if this initializer is providing an
@@ -282,20 +275,13 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::AddInitializerToGraph, _In_ OrtGraph* ort
     }
   }
 
-  // All validation done. Take ownership with exception-safe rollback.
-  // Insert into tracking set first, then try to insert into the map.
-  // If the map insertion throws, roll back the tracking set so the caller can retry.
-  // The actual ownership transfer (reset) is noexcept.
-  graph->owned_initializer_ptrs_.insert(tensor);
-  try {
-    auto& m = data_is_external ? graph->external_initializers : graph->initializers;
-    auto [it, inserted] = m.try_emplace(name, nullptr);
-    ORT_ENFORCE(inserted, "Unexpected duplicate name after validation. This is a bug.");
-    it->second.reset(tensor);  // noexcept ownership transfer
-  } catch (...) {
-    graph->owned_initializer_ptrs_.erase(tensor);
-    throw;  // API_IMPL_END converts to OrtStatus
-  }
+  // All validation done. Copy the OrtValue into the graph.
+  // OrtValue uses shared_ptr internally, so copying is cheap (refcount increment, no data copy).
+  // The caller retains their original OrtValue and is responsible for releasing it.
+  auto& m = data_is_external ? graph->external_initializers : graph->initializers;
+  auto copy = std::make_unique<OrtValue>(*tensor);  // may throw; caller's tensor is untouched
+  auto [it, inserted] = m.emplace(name, std::move(copy));
+  ORT_ENFORCE(inserted, "Unexpected duplicate name after validation. This is a bug.");
 
   return nullptr;
   API_IMPL_END

--- a/onnxruntime/core/session/model_editor_c_api.cc
+++ b/onnxruntime/core/session/model_editor_c_api.cc
@@ -228,26 +228,31 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::AddInitializerToGraph, _In_ OrtGraph* ort
                                  "Each OrtValue can only be added once.");
   }
 
-  // Track the pointer before transferring ownership to the map.
-  // This ensures exception safety: if the map insertion throws, the tracking set
-  // is already updated but no ownership was transferred, so the caller still owns the pointer.
-  graph->owned_initializer_ptrs_.insert(tensor);
-
   if (data_is_external) {
     // enforce that an external initializer is not used if the data size is < 128 bytes.
     // the reason for this is to avoid potential shape inferencing errors if this initializer is providing an
     // input involved in that. the ONNX shape inferencing does not support external data for those values.
     // e.g. Reshape's `shape` input, Reduce's `axes', Slice's `starts`, `ends`, `steps`, Clip's `min`, `max`, etc.
     if (t.SizeInBytes() < 128) {
-      graph->owned_initializer_ptrs_.erase(tensor);
       return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
                                    "External initializer should only be used for data >= 128 bytes. "
                                    "Please use CreateTensorAsOrtValue instead.");
     }
+  }
 
-    graph->external_initializers[name] = std::unique_ptr<OrtValue>(tensor);  // take ownership
-  } else {
-    graph->initializers[name] = std::unique_ptr<OrtValue>(tensor);  // take ownership
+  // All validation done. Take ownership with exception-safe rollback.
+  // Insert into tracking set first, then try to insert into the map.
+  // If the map insertion throws, roll back the tracking set so the caller can retry.
+  // The actual ownership transfer (reset) is noexcept.
+  graph->owned_initializer_ptrs_.insert(tensor);
+  try {
+    auto& m = data_is_external ? graph->external_initializers : graph->initializers;
+    auto [it, inserted] = m.try_emplace(name, nullptr);
+    ORT_ENFORCE(inserted, "Unexpected duplicate name after validation. This is a bug.");
+    it->second.reset(tensor);  // noexcept ownership transfer
+  } catch (...) {
+    graph->owned_initializer_ptrs_.erase(tensor);
+    throw;  // API_IMPL_END converts to OrtStatus
   }
 
   return nullptr;
@@ -281,8 +286,12 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::AddNodeToGraph, _In_ OrtGraph* ort_graph,
                                  "Each OrtNode can only be added once.");
   }
 
+  // All validation done. Take ownership.
+  // Reserve first so push_back won't reallocate — if reserve() throws, node is not yet
+  // owned by a unique_ptr and the caller still safely owns it.
   node->id = graph->nodes.size();
-  graph->nodes.push_back(std::unique_ptr<onnxruntime::ModelEditorNode>(node));  // take ownership
+  graph->nodes.reserve(graph->nodes.size() + 1);
+  graph->nodes.emplace_back(node);  // constructs unique_ptr in-place; won't reallocate
   node->owned_ = true;
   return nullptr;
   API_IMPL_END

--- a/onnxruntime/core/session/model_editor_c_api.cc
+++ b/onnxruntime/core/session/model_editor_c_api.cc
@@ -5,6 +5,8 @@
 
 #include <variant>
 
+#include "core/common/inlined_containers.h"
+
 #include "core/framework/error_code_helper.h"
 #include "core/framework/ort_value.h"
 #include "core/framework/onnxruntime_typeinfo.h"
@@ -112,6 +114,16 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::SetGraphInputs, _In_ OrtGraph* ort_graph,
                                  "Invalid OrtGraph variant for use in the OrtModelEditorApi");
   }
 
+  // Check for duplicate pointers in the input array to prevent double-free
+  onnxruntime::InlinedHashSet<const OrtValueInfo*> seen;
+  for (size_t i = 0; i < inputs_len; ++i) {
+    if (inputs[i] != nullptr && !seen.insert(inputs[i]).second) {
+      return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
+                                   "Duplicate OrtValueInfo pointer found in inputs array. "
+                                   "Each OrtValueInfo can only appear once.");
+    }
+  }
+
   graph->inputs.clear();
   for (size_t i = 0; i < inputs_len; ++i) {
     if (inputs[i] == nullptr) {
@@ -142,6 +154,16 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::SetGraphOutputs, _In_ OrtGraph* ort_graph
                                  "Invalid OrtGraph variant for use in the OrtModelEditorApi");
   }
 
+  // Check for duplicate pointers in the output array to prevent double-free
+  onnxruntime::InlinedHashSet<const OrtValueInfo*> seen;
+  for (size_t i = 0; i < outputs_len; ++i) {
+    if (outputs[i] != nullptr && !seen.insert(outputs[i]).second) {
+      return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
+                                   "Duplicate OrtValueInfo pointer found in outputs array. "
+                                   "Each OrtValueInfo can only appear once.");
+    }
+  }
+
   graph->outputs.clear();
   for (size_t i = 0; i < outputs_len; ++i) {
     if (outputs[i] == nullptr) {
@@ -165,6 +187,14 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::SetGraphOutputs, _In_ OrtGraph* ort_graph
 ORT_API_STATUS_IMPL(OrtModelEditorAPI::AddInitializerToGraph, _In_ OrtGraph* ort_graph, _In_ const char* name,
                     _Inout_ OrtValue* tensor, bool data_is_external) {
   API_IMPL_BEGIN
+  if (name == nullptr || *name == '\0') {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "name cannot be null or empty string");
+  }
+
+  if (tensor == nullptr) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "tensor cannot be null");
+  }
+
   onnxruntime::ModelEditorGraph* graph = onnxruntime::ModelEditorGraph::ToInternal(ort_graph);
 
   if (graph == nullptr) {
@@ -185,6 +215,19 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::AddInitializerToGraph, _In_ OrtGraph* ort
     return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "Only CPU based tensors are currently supported.");
   }
 
+  // Reject duplicate name in either map
+  if (graph->initializers.count(name) != 0 || graph->external_initializers.count(name) != 0) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
+                                 "An initializer with this name has already been added to the graph.");
+  }
+
+  // Reject if this OrtValue pointer was already added (prevents double-free via same pointer, different name)
+  if (graph->owned_initializer_ptrs_.count(tensor) != 0) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
+                                 "This tensor has already been added as an initializer. "
+                                 "Each OrtValue can only be added once.");
+  }
+
   if (data_is_external) {
     // enforce that an external initializer is not used if the data size is < 128 bytes.
     // the reason for this is to avoid potential shape inferencing errors if this initializer is providing an
@@ -201,12 +244,18 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::AddInitializerToGraph, _In_ OrtGraph* ort
     graph->initializers[name] = std::unique_ptr<OrtValue>(tensor);  // take ownership
   }
 
+  graph->owned_initializer_ptrs_.insert(tensor);
+
   return nullptr;
   API_IMPL_END
 }
 
 ORT_API_STATUS_IMPL(OrtModelEditorAPI::AddNodeToGraph, _In_ OrtGraph* ort_graph, _Inout_ OrtNode* ort_node) {
   API_IMPL_BEGIN
+  if (ort_node == nullptr) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "node cannot be null");
+  }
+
   onnxruntime::ModelEditorGraph* graph = onnxruntime::ModelEditorGraph::ToInternal(ort_graph);
 
   if (graph == nullptr) {
@@ -221,8 +270,16 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::AddNodeToGraph, _In_ OrtGraph* ort_graph,
                                  "Invalid OrtNode variant for use in the OrtModelEditorApi");
   }
 
+  // Reject if this node has already been added to a graph (prevents double-free)
+  if (node->owned_) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
+                                 "This node has already been added to a graph. "
+                                 "Each OrtNode can only be added once.");
+  }
+
   node->id = graph->nodes.size();
   graph->nodes.push_back(std::unique_ptr<onnxruntime::ModelEditorNode>(node));  // take ownership
+  node->owned_ = true;
   return nullptr;
   API_IMPL_END
 }
@@ -246,8 +303,18 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::CreateModel,
 ORT_API_STATUS_IMPL(OrtModelEditorAPI::AddGraphToModel, _In_ OrtModel* model, _Inout_ OrtGraph* graph) {
   API_IMPL_BEGIN
 
+  if (model == nullptr) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "model cannot be null");
+  }
+
   if (graph == nullptr) {
     return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "graph cannot be null");
+  }
+
+  // Reject if model already has a graph (prevents double-free/UAF)
+  if (model->graph != nullptr) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
+                                 "Model already has a graph. Each OrtModel can only have one graph.");
   }
 
   model->graph = std::unique_ptr<OrtGraph>(graph);  // take ownership

--- a/onnxruntime/core/session/model_editor_c_api.cc
+++ b/onnxruntime/core/session/model_editor_c_api.cc
@@ -127,14 +127,13 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::SetGraphInputs, _In_ OrtGraph* ort_graph,
   onnxruntime::InlinedHashSet<const OrtValueInfo*> seen;
   for (size_t i = 0; i < inputs_len; ++i) {
     if (inputs[i] == nullptr) {
-      continue;  // null entries are validated in the transfer loop below
+      continue;
     }
     if (!seen.insert(inputs[i]).second) {
       return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
                                    "Duplicate OrtValueInfo pointer found in inputs array. "
                                    "Each OrtValueInfo can only appear once.");
     }
-    // Reject already-owned ValueInfos (prevents double-free if reused across calls)
     onnxruntime::ModelEditorValueInfo* vi = onnxruntime::ModelEditorValueInfo::ToInternal(inputs[i]);
     if (vi != nullptr && vi->owned_) {
       return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
@@ -143,7 +142,7 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::SetGraphInputs, _In_ OrtGraph* ort_graph,
     }
   }
 
-  graph->inputs.reserve(inputs_len);  // pre-allocate so push_back won't reallocate during ownership transfer
+  graph->inputs.reserve(inputs_len);
   graph->inputs.clear();
   for (size_t i = 0; i < inputs_len; ++i) {
     if (inputs[i] == nullptr) {
@@ -187,14 +186,13 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::SetGraphOutputs, _In_ OrtGraph* ort_graph
   onnxruntime::InlinedHashSet<const OrtValueInfo*> seen;
   for (size_t i = 0; i < outputs_len; ++i) {
     if (outputs[i] == nullptr) {
-      continue;  // null entries are validated in the transfer loop below
+      continue;
     }
     if (!seen.insert(outputs[i]).second) {
       return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
                                    "Duplicate OrtValueInfo pointer found in outputs array. "
                                    "Each OrtValueInfo can only appear once.");
     }
-    // Reject already-owned ValueInfos (prevents double-free if reused across calls)
     onnxruntime::ModelEditorValueInfo* vi = onnxruntime::ModelEditorValueInfo::ToInternal(outputs[i]);
     if (vi != nullptr && vi->owned_) {
       return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
@@ -203,7 +201,7 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::SetGraphOutputs, _In_ OrtGraph* ort_graph
     }
   }
 
-  graph->outputs.reserve(outputs_len);  // pre-allocate so push_back won't reallocate during ownership transfer
+  graph->outputs.reserve(outputs_len);
   graph->outputs.clear();
   for (size_t i = 0; i < outputs_len; ++i) {
     if (outputs[i] == nullptr) {
@@ -278,9 +276,6 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::AddInitializerToGraph, _In_ OrtGraph* ort
     }
   }
 
-  // All validation done. Copy the OrtValue into the graph.
-  // OrtValue uses shared_ptr internally, so copying is cheap (refcount increment, no data copy).
-  // The caller retains their original OrtValue and is responsible for releasing it.
   auto& m = data_is_external ? graph->external_initializers : graph->initializers;
   auto [it, inserted] = m.emplace(name, *ort_value);
   ORT_ENFORCE(inserted, "Unexpected duplicate name after validation. This is a bug.");
@@ -320,14 +315,11 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::AddNodeToGraph, _In_ OrtGraph* ort_graph,
                                  "Each OrtNode can only be added once.");
   }
 
-  // All validation done. Take ownership.
-  // Reserve with geometric growth so emplace_back won't reallocate.
-  // If reserve() throws, node is not yet owned by a unique_ptr and the caller still safely owns it.
   node->id = graph->nodes.size();
   if (graph->nodes.size() == graph->nodes.capacity()) {
     graph->nodes.reserve(std::max(graph->nodes.capacity() * 2, size_t{1}));
   }
-  graph->nodes.emplace_back(node);  // constructs unique_ptr in-place; won't reallocate
+  graph->nodes.emplace_back(node);
   node->owned_ = true;
   return nullptr;
   API_IMPL_END

--- a/onnxruntime/core/session/model_editor_c_api.cc
+++ b/onnxruntime/core/session/model_editor_c_api.cc
@@ -226,14 +226,14 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::SetGraphOutputs, _In_ OrtGraph* ort_graph
 }
 
 ORT_API_STATUS_IMPL(OrtModelEditorAPI::AddInitializerToGraph, _In_ OrtGraph* ort_graph, _In_ const char* name,
-                    _In_ OrtValue* tensor, bool data_is_external) {
+                    _In_ const OrtValue* ort_value, bool data_is_external) {
   API_IMPL_BEGIN
   if (name == nullptr || *name == '\0') {
     return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "name cannot be null or empty string");
   }
 
-  if (tensor == nullptr) {
-    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "tensor cannot be null");
+  if (ort_value == nullptr) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "ort_value cannot be null");
   }
 
   if (ort_graph == nullptr) {
@@ -247,15 +247,15 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::AddInitializerToGraph, _In_ OrtGraph* ort
                                  "Invalid OrtGraph variant for use in the OrtModelEditorApi");
   }
 
-  if (!tensor->IsTensor()) {
+  if (!ort_value->IsTensor()) {
     return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "Only Tensor is currently supported.");
   }
 
-  if (!tensor->IsAllocated()) {
+  if (!ort_value->IsAllocated()) {
     return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "Tensor must be allocated.");
   }
 
-  const auto& t = tensor->Get<onnxruntime::Tensor>();
+  const auto& t = ort_value->Get<onnxruntime::Tensor>();
   if (t.Location().device.Type() != OrtDevice::CPU) {
     return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "Only CPU based tensors are currently supported.");
   }
@@ -282,8 +282,7 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::AddInitializerToGraph, _In_ OrtGraph* ort
   // OrtValue uses shared_ptr internally, so copying is cheap (refcount increment, no data copy).
   // The caller retains their original OrtValue and is responsible for releasing it.
   auto& m = data_is_external ? graph->external_initializers : graph->initializers;
-  auto copy = std::make_unique<OrtValue>(*tensor);  // may throw; caller's tensor is untouched
-  auto [it, inserted] = m.emplace(name, std::move(copy));
+  auto [it, inserted] = m.emplace(name, *ort_value);
   ORT_ENFORCE(inserted, "Unexpected duplicate name after validation. This is a bug.");
 
   return nullptr;

--- a/onnxruntime/core/session/model_editor_c_api.cc
+++ b/onnxruntime/core/session/model_editor_c_api.cc
@@ -142,8 +142,8 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::SetGraphInputs, _In_ OrtGraph* ort_graph,
     }
   }
 
-  graph->inputs.reserve(inputs_len);
   graph->inputs.clear();
+  graph->inputs.reserve(inputs_len);
   for (size_t i = 0; i < inputs_len; ++i) {
     if (inputs[i] == nullptr) {
       return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "inputs cannot contain null entries");
@@ -201,8 +201,8 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::SetGraphOutputs, _In_ OrtGraph* ort_graph
     }
   }
 
-  graph->outputs.reserve(outputs_len);
   graph->outputs.clear();
+  graph->outputs.reserve(outputs_len);
   for (size_t i = 0; i < outputs_len; ++i) {
     if (outputs[i] == nullptr) {
       return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "outputs cannot contain null entries");

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2622,14 +2622,32 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsSetCustomJoinThreadFn, _Inout_ OrtSes
 }
 
 ORT_API(void, OrtApis::ReleaseValueInfo, _Frees_ptr_opt_ OrtValueInfo* value_info) {
+  if (value_info != nullptr) {
+    if (auto* me = onnxruntime::ModelEditorValueInfo::ToInternal(value_info);
+        me != nullptr && me->owned_) {
+      return;  // owned by a graph — caller should not release
+    }
+  }
   delete value_info;
 }
 
 ORT_API(void, OrtApis::ReleaseNode, _Frees_ptr_opt_ OrtNode* node) {
+  if (node != nullptr) {
+    if (auto* me = onnxruntime::ModelEditorNode::ToInternal(node);
+        me != nullptr && me->owned_) {
+      return;  // owned by a graph — caller should not release
+    }
+  }
   delete node;
 }
 
 ORT_API(void, OrtApis::ReleaseGraph, _Frees_ptr_opt_ OrtGraph* graph) {
+  if (graph != nullptr) {
+    if (auto* me = onnxruntime::ModelEditorGraph::ToInternal(graph);
+        me != nullptr && me->owned_) {
+      return;  // owned by a model — caller should not release
+    }
+  }
   delete graph;
 }
 

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2625,7 +2625,8 @@ ORT_API(void, OrtApis::ReleaseValueInfo, _Frees_ptr_opt_ OrtValueInfo* value_inf
   if (value_info != nullptr) {
     if (auto* me = onnxruntime::ModelEditorValueInfo::ToInternal(value_info);
         me != nullptr && me->owned_) {
-      return;  // owned by a graph — caller should not release
+      assert(false && "Releasing an OrtValueInfo that is owned by a graph");
+      return;
     }
   }
   delete value_info;
@@ -2635,7 +2636,8 @@ ORT_API(void, OrtApis::ReleaseNode, _Frees_ptr_opt_ OrtNode* node) {
   if (node != nullptr) {
     if (auto* me = onnxruntime::ModelEditorNode::ToInternal(node);
         me != nullptr && me->owned_) {
-      return;  // owned by a graph — caller should not release
+      assert(false && "Releasing an OrtNode that is owned by a graph");
+      return;
     }
   }
   delete node;
@@ -2645,7 +2647,8 @@ ORT_API(void, OrtApis::ReleaseGraph, _Frees_ptr_opt_ OrtGraph* graph) {
   if (graph != nullptr) {
     if (auto* me = onnxruntime::ModelEditorGraph::ToInternal(graph);
         me != nullptr && me->owned_) {
-      return;  // owned by a model — caller should not release
+      assert(false && "Releasing an OrtGraph that is owned by a model");
+      return;
     }
   }
   delete graph;

--- a/onnxruntime/test/shared_lib/test_model_builder_api.cc
+++ b/onnxruntime/test/shared_lib/test_model_builder_api.cc
@@ -235,7 +235,7 @@ TEST(ModelEditorAPITest, Basic_CApi) {
                                                      &y_tensor));
 
     Ort::ThrowOnError(model_editor_api.AddInitializerToGraph(graph, "Y", y_tensor, /*data is external*/ true));
-    y_tensor = nullptr;  // graph now owns
+    api.ReleaseValue(y_tensor);  // caller releases; graph holds its own copy
 
     if (use_constant_node) {
       // Test that a Constant node is converted to an initializer
@@ -1116,12 +1116,13 @@ TEST(ModelEditorAPITest, AddInitializerToGraph_DuplicateName_Fails) {
   EXPECT_FALSE(status.IsOK());
   EXPECT_THAT(status.GetErrorMessage(), ::testing::HasSubstr("already been added"));
 
-  // Clean up tensor2 since ownership was NOT transferred
+  // Clean up — caller retains ownership under copy semantics
+  api.ReleaseValue(tensor1);
   api.ReleaseValue(tensor2);
   api.ReleaseGraph(graph);
 }
 
-TEST(ModelEditorAPITest, AddInitializerToGraph_DuplicatePointer_Fails) {
+TEST(ModelEditorAPITest, AddInitializerToGraph_SamePointerDifferentName_Succeeds) {
   const auto& api = Ort::GetApi();
   const auto& model_editor_api = Ort::GetModelEditorApi();
 
@@ -1136,14 +1137,12 @@ TEST(ModelEditorAPITest, AddInitializerToGraph_DuplicatePointer_Fails) {
   Ort::ThrowOnError(api.CreateTensorAsOrtValue(allocator, dims.data(), dims.size(),
                                                ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &tensor));
 
-  // First add should succeed
+  // Both adds succeed — each creates an independent copy sharing the same underlying data
   ASSERT_ORTSTATUS_OK(model_editor_api.AddInitializerToGraph(graph, "W1", tensor, false));
+  ASSERT_ORTSTATUS_OK(model_editor_api.AddInitializerToGraph(graph, "W2", tensor, false));
 
-  // Second add with same pointer but different name should fail (prevents double-free)
-  Ort::Status status{model_editor_api.AddInitializerToGraph(graph, "W2", tensor, false)};
-  EXPECT_FALSE(status.IsOK());
-  EXPECT_THAT(status.GetErrorMessage(), ::testing::HasSubstr("already been added"));
-
+  // Caller retains ownership and releases
+  api.ReleaseValue(tensor);
   api.ReleaseGraph(graph);
 }
 

--- a/onnxruntime/test/shared_lib/test_model_builder_api.cc
+++ b/onnxruntime/test/shared_lib/test_model_builder_api.cc
@@ -1083,3 +1083,180 @@ TEST(ModelEditorCompileAPITest, EmbedModeWithBufferOutputSatisfiesValidation) {
     allocator->Free(output_buffer);
   }
 }
+
+//
+// Regression tests for double-free / ownership-transfer bugs in OrtModelEditorApi.
+// These test that the API rejects attempts to transfer ownership of the same object twice.
+//
+
+TEST(ModelEditorAPITest, AddInitializerToGraph_DuplicateName_Fails) {
+  const auto& api = Ort::GetApi();
+  const auto& model_editor_api = Ort::GetModelEditorApi();
+
+  OrtGraph* graph = nullptr;
+  Ort::ThrowOnError(model_editor_api.CreateGraph(&graph));
+
+  // Create two small ORT-allocated tensors (< 128 bytes, so data_is_external = false)
+  std::vector<int64_t> dims = {2, 2};
+  OrtAllocator* allocator = nullptr;
+  Ort::ThrowOnError(api.GetAllocatorWithDefaultOptions(&allocator));
+
+  OrtValue* tensor1 = nullptr;
+  OrtValue* tensor2 = nullptr;
+  Ort::ThrowOnError(api.CreateTensorAsOrtValue(allocator, dims.data(), dims.size(),
+                                               ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &tensor1));
+  Ort::ThrowOnError(api.CreateTensorAsOrtValue(allocator, dims.data(), dims.size(),
+                                               ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &tensor2));
+
+  // First add should succeed
+  ASSERT_ORTSTATUS_OK(model_editor_api.AddInitializerToGraph(graph, "W", tensor1, false));
+
+  // Second add with same name should fail
+  Ort::Status status{model_editor_api.AddInitializerToGraph(graph, "W", tensor2, false)};
+  EXPECT_FALSE(status.IsOK());
+  EXPECT_THAT(status.GetErrorMessage(), ::testing::HasSubstr("already been added"));
+
+  // Clean up tensor2 since ownership was NOT transferred
+  api.ReleaseValue(tensor2);
+  api.ReleaseGraph(graph);
+}
+
+TEST(ModelEditorAPITest, AddInitializerToGraph_DuplicatePointer_Fails) {
+  const auto& api = Ort::GetApi();
+  const auto& model_editor_api = Ort::GetModelEditorApi();
+
+  OrtGraph* graph = nullptr;
+  Ort::ThrowOnError(model_editor_api.CreateGraph(&graph));
+
+  std::vector<int64_t> dims = {2, 2};
+  OrtAllocator* allocator = nullptr;
+  Ort::ThrowOnError(api.GetAllocatorWithDefaultOptions(&allocator));
+
+  OrtValue* tensor = nullptr;
+  Ort::ThrowOnError(api.CreateTensorAsOrtValue(allocator, dims.data(), dims.size(),
+                                               ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &tensor));
+
+  // First add should succeed
+  ASSERT_ORTSTATUS_OK(model_editor_api.AddInitializerToGraph(graph, "W1", tensor, false));
+
+  // Second add with same pointer but different name should fail (prevents double-free)
+  Ort::Status status{model_editor_api.AddInitializerToGraph(graph, "W2", tensor, false)};
+  EXPECT_FALSE(status.IsOK());
+  EXPECT_THAT(status.GetErrorMessage(), ::testing::HasSubstr("already been added"));
+
+  api.ReleaseGraph(graph);
+}
+
+TEST(ModelEditorAPITest, AddNodeToGraph_DuplicateNode_Fails) {
+  const auto& api = Ort::GetApi();
+  const auto& model_editor_api = Ort::GetModelEditorApi();
+
+  OrtGraph* graph = nullptr;
+  Ort::ThrowOnError(model_editor_api.CreateGraph(&graph));
+
+  OrtNode* node = CreateNode(model_editor_api, "Relu", "relu1", {"X"}, {"Y"});
+
+  // First add should succeed
+  ASSERT_ORTSTATUS_OK(model_editor_api.AddNodeToGraph(graph, node));
+
+  // Second add of same node should fail (prevents double-free)
+  Ort::Status status{model_editor_api.AddNodeToGraph(graph, node)};
+  EXPECT_FALSE(status.IsOK());
+  EXPECT_THAT(status.GetErrorMessage(), ::testing::HasSubstr("already been added"));
+
+  api.ReleaseGraph(graph);
+}
+
+TEST(ModelEditorAPITest, AddGraphToModel_DuplicateGraph_Fails) {
+  const auto& api = Ort::GetApi();
+  const auto& model_editor_api = Ort::GetModelEditorApi();
+
+  OrtGraph* graph1 = nullptr;
+  OrtGraph* graph2 = nullptr;
+  Ort::ThrowOnError(model_editor_api.CreateGraph(&graph1));
+  Ort::ThrowOnError(model_editor_api.CreateGraph(&graph2));
+
+  std::vector<const char*> domain_names = {onnxruntime::kOnnxDomain};
+  std::vector<int> opset_versions = {18};
+  OrtModel* model = nullptr;
+  Ort::ThrowOnError(model_editor_api.CreateModel(domain_names.data(), opset_versions.data(),
+                                                 domain_names.size(), &model));
+
+  // First add should succeed
+  ASSERT_ORTSTATUS_OK(model_editor_api.AddGraphToModel(model, graph1));
+
+  // Second add should fail (model already has a graph)
+  Ort::Status status{model_editor_api.AddGraphToModel(model, graph2)};
+  EXPECT_FALSE(status.IsOK());
+  EXPECT_THAT(status.GetErrorMessage(), ::testing::HasSubstr("already has a graph"));
+
+  // Clean up graph2 since ownership was NOT transferred
+  api.ReleaseGraph(graph2);
+  api.ReleaseModel(model);
+}
+
+TEST(ModelEditorAPITest, SetGraphInputs_DuplicatePointer_Fails) {
+  const auto& api = Ort::GetApi();
+  const auto& model_editor_api = Ort::GetModelEditorApi();
+
+  OrtGraph* graph = nullptr;
+  Ort::ThrowOnError(model_editor_api.CreateGraph(&graph));
+
+  // Create a single OrtValueInfo
+  OrtTensorTypeAndShapeInfo* tensor_type_info = nullptr;
+  std::vector<int64_t> dims = {3, 4};
+  Ort::ThrowOnError(api.CreateTensorTypeAndShapeInfo(&tensor_type_info));
+  Ort::ThrowOnError(api.SetTensorElementType(tensor_type_info, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT));
+  Ort::ThrowOnError(api.SetDimensions(tensor_type_info, dims.data(), dims.size()));
+
+  OrtTypeInfo* type_info = nullptr;
+  Ort::ThrowOnError(model_editor_api.CreateTensorTypeInfo(tensor_type_info, &type_info));
+  api.ReleaseTensorTypeAndShapeInfo(tensor_type_info);
+
+  OrtValueInfo* value_info = nullptr;
+  Ort::ThrowOnError(model_editor_api.CreateValueInfo("X", type_info, &value_info));
+  api.ReleaseTypeInfo(type_info);
+
+  // Pass the same pointer twice in the inputs array — should fail
+  std::vector<OrtValueInfo*> inputs = {value_info, value_info};
+  Ort::Status status{model_editor_api.SetGraphInputs(graph, inputs.data(), inputs.size())};
+  EXPECT_FALSE(status.IsOK());
+  EXPECT_THAT(status.GetErrorMessage(), ::testing::HasSubstr("Duplicate"));
+
+  // Clean up — ownership was NOT transferred
+  api.ReleaseValueInfo(value_info);
+  api.ReleaseGraph(graph);
+}
+
+TEST(ModelEditorAPITest, SetGraphOutputs_DuplicatePointer_Fails) {
+  const auto& api = Ort::GetApi();
+  const auto& model_editor_api = Ort::GetModelEditorApi();
+
+  OrtGraph* graph = nullptr;
+  Ort::ThrowOnError(model_editor_api.CreateGraph(&graph));
+
+  // Create a single OrtValueInfo
+  OrtTensorTypeAndShapeInfo* tensor_type_info = nullptr;
+  std::vector<int64_t> dims = {3, 4};
+  Ort::ThrowOnError(api.CreateTensorTypeAndShapeInfo(&tensor_type_info));
+  Ort::ThrowOnError(api.SetTensorElementType(tensor_type_info, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT));
+  Ort::ThrowOnError(api.SetDimensions(tensor_type_info, dims.data(), dims.size()));
+
+  OrtTypeInfo* type_info = nullptr;
+  Ort::ThrowOnError(model_editor_api.CreateTensorTypeInfo(tensor_type_info, &type_info));
+  api.ReleaseTensorTypeAndShapeInfo(tensor_type_info);
+
+  OrtValueInfo* value_info = nullptr;
+  Ort::ThrowOnError(model_editor_api.CreateValueInfo("Y", type_info, &value_info));
+  api.ReleaseTypeInfo(type_info);
+
+  // Pass the same pointer twice in the outputs array — should fail
+  std::vector<OrtValueInfo*> outputs = {value_info, value_info};
+  Ort::Status status{model_editor_api.SetGraphOutputs(graph, outputs.data(), outputs.size())};
+  EXPECT_FALSE(status.IsOK());
+  EXPECT_THAT(status.GetErrorMessage(), ::testing::HasSubstr("Duplicate"));
+
+  // Clean up — ownership was NOT transferred
+  api.ReleaseValueInfo(value_info);
+  api.ReleaseGraph(graph);
+}

--- a/onnxruntime/test/shared_lib/test_model_builder_api.cc
+++ b/onnxruntime/test/shared_lib/test_model_builder_api.cc
@@ -1303,3 +1303,123 @@ TEST(ModelEditorAPITest, AddGraphToModel_SameGraphTwoModels_Fails) {
   api.ReleaseModel(model2);
   api.ReleaseModel(model1);
 }
+
+// Regression tests for Release-after-ownership-transfer (yuslepukhin review comments).
+// These verify that calling Release on an object after ownership has been transferred
+// to a graph/model is safely ignored (no double-free).
+
+TEST(ModelEditorAPITest, ReleaseNode_AfterAddToGraph_IsNoOp) {
+  const auto& api = Ort::GetApi();
+  const auto& model_editor_api = Ort::GetModelEditorApi();
+
+  OrtGraph* graph = nullptr;
+  Ort::ThrowOnError(model_editor_api.CreateGraph(&graph));
+
+  OrtNode* node = CreateNode(model_editor_api, "Relu", "relu1", {"X"}, {"Y"});
+
+  // Transfer ownership to graph
+  ASSERT_ORTSTATUS_OK(model_editor_api.AddNodeToGraph(graph, node));
+
+  // Caller still holds raw pointer — Release should be a safe no-op
+  api.ReleaseNode(node);
+
+  // Graph destructor should safely clean up the node (no double-free)
+  api.ReleaseGraph(graph);
+}
+
+TEST(ModelEditorAPITest, ReleaseGraph_AfterAddToModel_IsNoOp) {
+  const auto& api = Ort::GetApi();
+  const auto& model_editor_api = Ort::GetModelEditorApi();
+
+  OrtGraph* graph = nullptr;
+  Ort::ThrowOnError(model_editor_api.CreateGraph(&graph));
+
+  std::vector<const char*> domain_names = {onnxruntime::kOnnxDomain};
+  std::vector<int> opset_versions = {18};
+  OrtModel* model = nullptr;
+  Ort::ThrowOnError(model_editor_api.CreateModel(domain_names.data(), opset_versions.data(),
+                                                 domain_names.size(), &model));
+
+  // Transfer ownership to model
+  ASSERT_ORTSTATUS_OK(model_editor_api.AddGraphToModel(model, graph));
+
+  // Caller still holds raw pointer — Release should be a safe no-op
+  api.ReleaseGraph(graph);
+
+  // Model destructor should safely clean up the graph (no double-free)
+  api.ReleaseModel(model);
+}
+
+TEST(ModelEditorAPITest, ReleaseValueInfo_AfterSetGraphInputs_IsNoOp) {
+  const auto& api = Ort::GetApi();
+  const auto& model_editor_api = Ort::GetModelEditorApi();
+
+  OrtGraph* graph = nullptr;
+  Ort::ThrowOnError(model_editor_api.CreateGraph(&graph));
+
+  // Create OrtValueInfo
+  OrtTensorTypeAndShapeInfo* tensor_type_info = nullptr;
+  std::vector<int64_t> dims = {3, 4};
+  Ort::ThrowOnError(api.CreateTensorTypeAndShapeInfo(&tensor_type_info));
+  Ort::ThrowOnError(api.SetTensorElementType(tensor_type_info, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT));
+  Ort::ThrowOnError(api.SetDimensions(tensor_type_info, dims.data(), dims.size()));
+
+  OrtTypeInfo* type_info = nullptr;
+  Ort::ThrowOnError(model_editor_api.CreateTensorTypeInfo(tensor_type_info, &type_info));
+  api.ReleaseTensorTypeAndShapeInfo(tensor_type_info);
+
+  OrtValueInfo* x_info = nullptr;
+  Ort::ThrowOnError(model_editor_api.CreateValueInfo("X", type_info, &x_info));
+  api.ReleaseTypeInfo(type_info);
+
+  // Save the raw pointer before SetGraphInputs nulls out the array entry
+  OrtValueInfo* saved_ptr = x_info;
+  std::vector<OrtValueInfo*> inputs = {x_info};
+  ASSERT_ORTSTATUS_OK(model_editor_api.SetGraphInputs(graph, inputs.data(), inputs.size()));
+
+  // Caller still holds saved_ptr — Release should be a safe no-op
+  api.ReleaseValueInfo(saved_ptr);
+
+  // Graph destructor should safely clean up the ValueInfo (no double-free)
+  api.ReleaseGraph(graph);
+}
+
+TEST(ModelEditorAPITest, SetGraphInputs_AlreadyOwnedValueInfo_Fails) {
+  const auto& api = Ort::GetApi();
+  const auto& model_editor_api = Ort::GetModelEditorApi();
+
+  OrtGraph* graph1 = nullptr;
+  OrtGraph* graph2 = nullptr;
+  Ort::ThrowOnError(model_editor_api.CreateGraph(&graph1));
+  Ort::ThrowOnError(model_editor_api.CreateGraph(&graph2));
+
+  // Create OrtValueInfo
+  OrtTensorTypeAndShapeInfo* tensor_type_info = nullptr;
+  std::vector<int64_t> dims = {3, 4};
+  Ort::ThrowOnError(api.CreateTensorTypeAndShapeInfo(&tensor_type_info));
+  Ort::ThrowOnError(api.SetTensorElementType(tensor_type_info, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT));
+  Ort::ThrowOnError(api.SetDimensions(tensor_type_info, dims.data(), dims.size()));
+
+  OrtTypeInfo* type_info = nullptr;
+  Ort::ThrowOnError(model_editor_api.CreateTensorTypeInfo(tensor_type_info, &type_info));
+  api.ReleaseTensorTypeAndShapeInfo(tensor_type_info);
+
+  OrtValueInfo* x_info = nullptr;
+  Ort::ThrowOnError(model_editor_api.CreateValueInfo("X", type_info, &x_info));
+  api.ReleaseTypeInfo(type_info);
+
+  // Save the raw pointer before SetGraphInputs nulls out the array entry
+  OrtValueInfo* saved_ptr = x_info;
+  std::vector<OrtValueInfo*> inputs = {x_info};
+  ASSERT_ORTSTATUS_OK(model_editor_api.SetGraphInputs(graph1, inputs.data(), inputs.size()));
+
+  // Try to add the already-owned ValueInfo to a second graph — should fail
+  std::vector<OrtValueInfo*> inputs2 = {saved_ptr};
+  Ort::Status status{model_editor_api.SetGraphInputs(graph2, inputs2.data(), inputs2.size())};
+  EXPECT_FALSE(status.IsOK());
+  EXPECT_THAT(status.GetErrorMessage(), ::testing::HasSubstr("already been added"));
+
+  // graph1 owns x_info, graph2 is empty
+  api.ReleaseGraph(graph2);
+  api.ReleaseGraph(graph1);
+}

--- a/onnxruntime/test/shared_lib/test_model_builder_api.cc
+++ b/onnxruntime/test/shared_lib/test_model_builder_api.cc
@@ -1260,3 +1260,46 @@ TEST(ModelEditorAPITest, SetGraphOutputs_DuplicatePointer_Fails) {
   api.ReleaseValueInfo(value_info);
   api.ReleaseGraph(graph);
 }
+
+TEST(ModelEditorAPITest, AddNodeToGraph_NullGraph_Fails) {
+  const auto& api = Ort::GetApi();
+  const auto& model_editor_api = Ort::GetModelEditorApi();
+
+  OrtNode* node = CreateNode(model_editor_api, "Relu", "relu1", {"X"}, {"Y"});
+
+  // Null graph should fail without crashing
+  Ort::Status status{model_editor_api.AddNodeToGraph(nullptr, node)};
+  EXPECT_FALSE(status.IsOK());
+  EXPECT_THAT(status.GetErrorMessage(), ::testing::HasSubstr("null"));
+
+  api.ReleaseNode(node);
+}
+
+TEST(ModelEditorAPITest, AddGraphToModel_SameGraphTwoModels_Fails) {
+  const auto& api = Ort::GetApi();
+  const auto& model_editor_api = Ort::GetModelEditorApi();
+
+  OrtGraph* graph = nullptr;
+  Ort::ThrowOnError(model_editor_api.CreateGraph(&graph));
+
+  std::vector<const char*> domain_names = {onnxruntime::kOnnxDomain};
+  std::vector<int> opset_versions = {18};
+  OrtModel* model1 = nullptr;
+  OrtModel* model2 = nullptr;
+  Ort::ThrowOnError(model_editor_api.CreateModel(domain_names.data(), opset_versions.data(),
+                                                 domain_names.size(), &model1));
+  Ort::ThrowOnError(model_editor_api.CreateModel(domain_names.data(), opset_versions.data(),
+                                                 domain_names.size(), &model2));
+
+  // First add should succeed
+  ASSERT_ORTSTATUS_OK(model_editor_api.AddGraphToModel(model1, graph));
+
+  // Second add to different model should fail (graph already owned)
+  Ort::Status status{model_editor_api.AddGraphToModel(model2, graph)};
+  EXPECT_FALSE(status.IsOK());
+  EXPECT_THAT(status.GetErrorMessage(), ::testing::HasSubstr("already been added"));
+
+  // model2 doesn't own anything, model1 owns graph
+  api.ReleaseModel(model2);
+  api.ReleaseModel(model1);
+}

--- a/onnxruntime/test/shared_lib/test_model_builder_api.cc
+++ b/onnxruntime/test/shared_lib/test_model_builder_api.cc
@@ -1304,10 +1304,14 @@ TEST(ModelEditorAPITest, AddGraphToModel_SameGraphTwoModels_Fails) {
 }
 
 // Regression tests for Release-after-ownership-transfer (yuslepukhin review comments).
-// These verify that calling Release on an object after ownership has been transferred
-// to a graph/model is safely ignored (no double-free).
+// In debug builds, releasing an owned object triggers an assert to flag the programming error.
+// In release builds, the release is a safe no-op (prevents double-free).
 
-TEST(ModelEditorAPITest, ReleaseNode_AfterAddToGraph_IsNoOp) {
+#ifdef NDEBUG
+TEST(ModelEditorAPITest, ReleaseNode_AfterAddToGraph_NoOpInRelease) {
+#else
+TEST(ModelEditorAPIDeathTest, ReleaseNode_AfterAddToGraph_AssertsInDebug) {
+#endif
   const auto& api = Ort::GetApi();
   const auto& model_editor_api = Ort::GetModelEditorApi();
 
@@ -1319,14 +1323,23 @@ TEST(ModelEditorAPITest, ReleaseNode_AfterAddToGraph_IsNoOp) {
   // Transfer ownership to graph
   ASSERT_ORTSTATUS_OK(model_editor_api.AddNodeToGraph(graph, node));
 
-  // Caller still holds raw pointer — Release should be a safe no-op
+#ifdef NDEBUG
+  // Release build: safe no-op
   api.ReleaseNode(node);
+#else
+  // Debug build: assert fires
+  ASSERT_DEATH(api.ReleaseNode(node), ".*");
+#endif
 
   // Graph destructor should safely clean up the node (no double-free)
   api.ReleaseGraph(graph);
 }
 
-TEST(ModelEditorAPITest, ReleaseGraph_AfterAddToModel_IsNoOp) {
+#ifdef NDEBUG
+TEST(ModelEditorAPITest, ReleaseGraph_AfterAddToModel_NoOpInRelease) {
+#else
+TEST(ModelEditorAPIDeathTest, ReleaseGraph_AfterAddToModel_AssertsInDebug) {
+#endif
   const auto& api = Ort::GetApi();
   const auto& model_editor_api = Ort::GetModelEditorApi();
 
@@ -1342,14 +1355,23 @@ TEST(ModelEditorAPITest, ReleaseGraph_AfterAddToModel_IsNoOp) {
   // Transfer ownership to model
   ASSERT_ORTSTATUS_OK(model_editor_api.AddGraphToModel(model, graph));
 
-  // Caller still holds raw pointer — Release should be a safe no-op
+#ifdef NDEBUG
+  // Release build: safe no-op
   api.ReleaseGraph(graph);
+#else
+  // Debug build: assert fires
+  ASSERT_DEATH(api.ReleaseGraph(graph), ".*");
+#endif
 
   // Model destructor should safely clean up the graph (no double-free)
   api.ReleaseModel(model);
 }
 
-TEST(ModelEditorAPITest, ReleaseValueInfo_AfterSetGraphInputs_IsNoOp) {
+#ifdef NDEBUG
+TEST(ModelEditorAPITest, ReleaseValueInfo_AfterSetGraphInputs_NoOpInRelease) {
+#else
+TEST(ModelEditorAPIDeathTest, ReleaseValueInfo_AfterSetGraphInputs_AssertsInDebug) {
+#endif
   const auto& api = Ort::GetApi();
   const auto& model_editor_api = Ort::GetModelEditorApi();
 
@@ -1376,8 +1398,13 @@ TEST(ModelEditorAPITest, ReleaseValueInfo_AfterSetGraphInputs_IsNoOp) {
   std::vector<OrtValueInfo*> inputs = {x_info};
   ASSERT_ORTSTATUS_OK(model_editor_api.SetGraphInputs(graph, inputs.data(), inputs.size()));
 
-  // Caller still holds saved_ptr — Release should be a safe no-op
+#ifdef NDEBUG
+  // Release build: safe no-op
   api.ReleaseValueInfo(saved_ptr);
+#else
+  // Debug build: assert fires
+  ASSERT_DEATH(api.ReleaseValueInfo(saved_ptr), ".*");
+#endif
 
   // Graph destructor should safely clean up the ValueInfo (no double-free)
   api.ReleaseGraph(graph);

--- a/onnxruntime/test/shared_lib/test_model_builder_api.cc
+++ b/onnxruntime/test/shared_lib/test_model_builder_api.cc
@@ -235,7 +235,7 @@ TEST(ModelEditorAPITest, Basic_CApi) {
                                                      &y_tensor));
 
     Ort::ThrowOnError(model_editor_api.AddInitializerToGraph(graph, "Y", y_tensor, /*data is external*/ true));
-    api.ReleaseValue(y_tensor);  // caller releases; graph holds its own copy
+    api.ReleaseValue(y_tensor);
 
     if (use_constant_node) {
       // Test that a Constant node is converted to an initializer
@@ -1303,15 +1303,9 @@ TEST(ModelEditorAPITest, AddGraphToModel_SameGraphTwoModels_Fails) {
   api.ReleaseModel(model1);
 }
 
-// Regression tests for Release-after-ownership-transfer (yuslepukhin review comments).
-// In debug builds, releasing an owned object triggers an assert to flag the programming error.
-// In release builds, the release is a safe no-op (prevents double-free).
-
+// Skipped in debug builds where the assert in Release functions would fire.
 #ifdef NDEBUG
-TEST(ModelEditorAPITest, ReleaseNode_AfterAddToGraph_NoOpInRelease) {
-#else
-TEST(ModelEditorAPIDeathTest, ReleaseNode_AfterAddToGraph_AssertsInDebug) {
-#endif
+TEST(ModelEditorAPITest, ReleaseNode_AfterAddToGraph_IsNoOp) {
   const auto& api = Ort::GetApi();
   const auto& model_editor_api = Ort::GetModelEditorApi();
 
@@ -1320,26 +1314,12 @@ TEST(ModelEditorAPIDeathTest, ReleaseNode_AfterAddToGraph_AssertsInDebug) {
 
   OrtNode* node = CreateNode(model_editor_api, "Relu", "relu1", {"X"}, {"Y"});
 
-  // Transfer ownership to graph
   ASSERT_ORTSTATUS_OK(model_editor_api.AddNodeToGraph(graph, node));
-
-#ifdef NDEBUG
-  // Release build: safe no-op
   api.ReleaseNode(node);
-#else
-  // Debug build: assert fires
-  ASSERT_DEATH(api.ReleaseNode(node), ".*");
-#endif
-
-  // Graph destructor should safely clean up the node (no double-free)
   api.ReleaseGraph(graph);
 }
 
-#ifdef NDEBUG
-TEST(ModelEditorAPITest, ReleaseGraph_AfterAddToModel_NoOpInRelease) {
-#else
-TEST(ModelEditorAPIDeathTest, ReleaseGraph_AfterAddToModel_AssertsInDebug) {
-#endif
+TEST(ModelEditorAPITest, ReleaseGraph_AfterAddToModel_IsNoOp) {
   const auto& api = Ort::GetApi();
   const auto& model_editor_api = Ort::GetModelEditorApi();
 
@@ -1352,33 +1332,18 @@ TEST(ModelEditorAPIDeathTest, ReleaseGraph_AfterAddToModel_AssertsInDebug) {
   Ort::ThrowOnError(model_editor_api.CreateModel(domain_names.data(), opset_versions.data(),
                                                  domain_names.size(), &model));
 
-  // Transfer ownership to model
   ASSERT_ORTSTATUS_OK(model_editor_api.AddGraphToModel(model, graph));
-
-#ifdef NDEBUG
-  // Release build: safe no-op
   api.ReleaseGraph(graph);
-#else
-  // Debug build: assert fires
-  ASSERT_DEATH(api.ReleaseGraph(graph), ".*");
-#endif
-
-  // Model destructor should safely clean up the graph (no double-free)
   api.ReleaseModel(model);
 }
 
-#ifdef NDEBUG
-TEST(ModelEditorAPITest, ReleaseValueInfo_AfterSetGraphInputs_NoOpInRelease) {
-#else
-TEST(ModelEditorAPIDeathTest, ReleaseValueInfo_AfterSetGraphInputs_AssertsInDebug) {
-#endif
+TEST(ModelEditorAPITest, ReleaseValueInfo_AfterSetGraphInputs_IsNoOp) {
   const auto& api = Ort::GetApi();
   const auto& model_editor_api = Ort::GetModelEditorApi();
 
   OrtGraph* graph = nullptr;
   Ort::ThrowOnError(model_editor_api.CreateGraph(&graph));
 
-  // Create OrtValueInfo
   OrtTensorTypeAndShapeInfo* tensor_type_info = nullptr;
   std::vector<int64_t> dims = {3, 4};
   Ort::ThrowOnError(api.CreateTensorTypeAndShapeInfo(&tensor_type_info));
@@ -1393,22 +1358,14 @@ TEST(ModelEditorAPIDeathTest, ReleaseValueInfo_AfterSetGraphInputs_AssertsInDebu
   Ort::ThrowOnError(model_editor_api.CreateValueInfo("X", type_info, &x_info));
   api.ReleaseTypeInfo(type_info);
 
-  // Save the raw pointer before SetGraphInputs nulls out the array entry
   OrtValueInfo* saved_ptr = x_info;
   std::vector<OrtValueInfo*> inputs = {x_info};
   ASSERT_ORTSTATUS_OK(model_editor_api.SetGraphInputs(graph, inputs.data(), inputs.size()));
 
-#ifdef NDEBUG
-  // Release build: safe no-op
   api.ReleaseValueInfo(saved_ptr);
-#else
-  // Debug build: assert fires
-  ASSERT_DEATH(api.ReleaseValueInfo(saved_ptr), ".*");
-#endif
-
-  // Graph destructor should safely clean up the ValueInfo (no double-free)
   api.ReleaseGraph(graph);
 }
+#endif  // NDEBUG
 
 TEST(ModelEditorAPITest, SetGraphInputs_AlreadyOwnedValueInfo_Fails) {
   const auto& api = Ort::GetApi();


### PR DESCRIPTION
### Description

The OrtModelEditorApi C API functions (AddNodeToGraph, AddGraphToModel, SetGraphInputs/SetGraphOutputs) take raw pointers and wrap them in unique_ptr to transfer ownership. Without guards, callers can pass the same pointer twice or call Release after ownership transfer, causing double-free on destruction.

### Changes
- **AddInitializerToGraph**: Copy OrtValue internally instead of taking raw pointer ownership. OrtValue uses shared_ptr for its data, so copying is cheap (refcount increment). The caller retains ownership and is responsible for releasing. This eliminates the double-free class entirely for initializers.
- **AddNodeToGraph**: Add \owned_\ flag to ModelEditorNode to reject double-add, add null check
- **AddGraphToModel**: Reject if model already has a graph, add null check for model. Add \owned_\ flag to ModelEditorGraph to reject same graph added to two models.
- **SetGraphInputs/SetGraphOutputs**: Add \owned_\ flag to ModelEditorValueInfo to reject already-owned ValueInfos. Detect duplicate pointers in input arrays. Pre-allocate vector capacity before ownership-transfer loop for exception safety.
- **ReleaseNode/ReleaseGraph/ReleaseValueInfo**: Check \owned_\ flag before deleting. If already owned by a graph/model, the release is a safe no-op.
- **C++ wrapper**: Remove initializer.release() in AddInitializer to match copy semantics.
- **Regression tests**: Tests covering ownership-transfer guard paths, release-after-ownership, and duplicate detection.