### PR TITLE
Enable API doc generation builds in PR checks

### DIFF
--- a/.github/workflows/publish-c-apidocs.yml
+++ b/.github/workflows/publish-c-apidocs.yml
@@ -1,6 +1,8 @@
 name: Update C/C++ API Docs
 
-# Run when the C API changes or every month so that the artifact does not expire
+# Run when the C API changes or every week so that the artifact does not expire.
+# Also runs on pull requests that touch relevant files so doc generation errors
+# are caught early. The artifact is only published on the main branch.
 on:
   push:
     branches:
@@ -8,13 +10,19 @@ on:
     paths:
       - include/onnxruntime/core/session/**
       - orttraining/orttraining/training_api/include/**
+      - docs/c_cxx/**
+  pull_request:
+    paths:
+      - include/onnxruntime/core/session/**
+      - orttraining/orttraining/training_api/include/**
+      - docs/c_cxx/**
   schedule:
     - cron: '0 0 * * 0'
   workflow_dispatch:
 
 concurrency:
-  group: "apidocs-c"
-  cancel-in-progress: false
+  group: "apidocs-c-${{ github.ref }}"
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: write
@@ -49,6 +57,7 @@ jobs:
           rm -rf site/docs/api/c
           mv build/doxygen/html _site/docs/api/c
       - name: Upload new site
+        if: github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v6
         with:
           name: onnxruntime-c-apidocs

--- a/.github/workflows/publish-c-apidocs.yml
+++ b/.github/workflows/publish-c-apidocs.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Move C/C++ docs into site
         run: |
           mkdir -p _site/docs/api
-          rm -rf site/docs/api/c
+          rm -rf _site/docs/api/c
           mv build/doxygen/html _site/docs/api/c
       - name: Upload new site
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/publish-csharp-apidocs.yml
+++ b/.github/workflows/publish-csharp-apidocs.yml
@@ -1,10 +1,15 @@
 name: Update C# API Docs
 
-# Run when the C# API changes or every month so that the artifact does not expire
+# Run when the C# API changes or every week so that the artifact does not expire.
+# Also runs on pull requests that touch relevant files so doc generation errors
+# are caught early. The artifact is only published on the main branch.
 on:
   push:
     branches:
       - main
+    paths:
+      - csharp/**
+  pull_request:
     paths:
       - csharp/**
   schedule:
@@ -12,8 +17,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: "apidocs-csharp"
-  cancel-in-progress: false
+  group: "apidocs-csharp-${{ github.ref }}"
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: write
@@ -60,6 +65,7 @@ jobs:
         if (Test-Path $OutputDirectory) { Remove-Item -Recurse -Force $OutputDirectory }
         Move-Item -Path csharp\ApiDocs\csharp -Destination $OutputDirectory
     - name: Upload docs artifact
+      if: github.ref == 'refs/heads/main'
       uses: actions/upload-artifact@v6
       with:
         name: onnxruntime-csharp-apidocs

--- a/.github/workflows/publish-java-apidocs.yml
+++ b/.github/workflows/publish-java-apidocs.yml
@@ -1,10 +1,15 @@
 name: Update Java API Docs
 
-# Run when the Java API changes or every month so that the artifact does not expire
+# Run when the Java API changes or every week so that the artifact does not expire.
+# Also runs on pull requests that touch relevant files so doc generation errors
+# are caught early. The artifact is only published on the main branch.
 on:
   push:
     branches:
       - main
+    paths:
+      - java/**
+  pull_request:
     paths:
       - java/**
   schedule:
@@ -12,8 +17,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: "apidocs-java"
-  cancel-in-progress: false
+  group: "apidocs-java-${{ github.ref }}"
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: write
@@ -47,6 +52,7 @@ jobs:
           mkdir -p _site/docs/api
           mv java/build/docs/javadoc _site/docs/api/java
       - name: Upload new site
+        if: github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v6
         with:
           name: onnxruntime-java-apidocs

--- a/.github/workflows/publish-js-apidocs.yml
+++ b/.github/workflows/publish-js-apidocs.yml
@@ -1,10 +1,15 @@
 name: Update JS API Docs
 
-# Run when the JS API changes or every month so that the artifact does not expire
+# Run when the JS API changes or every week so that the artifact does not expire.
+# Also runs on pull requests that touch relevant files so doc generation errors
+# are caught early. The artifact is only published on the main branch.
 on:
   push:
     branches:
       - main
+    paths:
+      - js/common/**
+  pull_request:
     paths:
       - js/common/**
   schedule:
@@ -12,8 +17,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: "apidocs-js"
-  cancel-in-progress: false
+  group: "apidocs-js-${{ github.ref }}"
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: write
@@ -47,6 +52,7 @@ jobs:
           mkdir -p _site/docs/api
           mv js/common/docs _site/docs/api/js
       - name: Upload docs artifact
+        if: github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v6
         with:
           name: onnxruntime-node-apidocs

--- a/.github/workflows/publish-objectivec-apidocs.yml
+++ b/.github/workflows/publish-objectivec-apidocs.yml
@@ -1,10 +1,15 @@
 name: Update Objective-C API Docs
 
-# Run when the Objective-C API changes or every month so that the artifact does not expire
+# Run when the Objective-C API changes or every week so that the artifact does not expire.
+# Also runs on pull requests that touch relevant files so doc generation errors
+# are caught early. The artifact is only published on the main branch.
 on:
   push:
     branches:
     - main
+    paths:
+    - objectivec/**
+  pull_request:
     paths:
     - objectivec/**
   schedule:
@@ -12,8 +17,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: "apidocs-objectivec"
-  cancel-in-progress: false
+  group: "apidocs-objectivec-${{ github.ref }}"
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: write
@@ -52,6 +57,7 @@ jobs:
       shell: bash
 
     - name: Upload new site
+      if: github.ref == 'refs/heads/main'
       uses: actions/upload-artifact@v6
       with:
         name: onnxruntime-objectivec-apidocs

--- a/.github/workflows/publish-python-apidocs.yml
+++ b/.github/workflows/publish-python-apidocs.yml
@@ -1,10 +1,16 @@
 name: Update Python API Docs
 
-# Run when the Python API changes or every month so that the artifact does not expire
+# Run when the Python API changes or every week so that the artifact does not expire.
+# Also runs on pull requests that touch relevant files so doc generation errors
+# are caught early. The artifact is only published on the main branch.
 on:
   push:
     branches:
       - main
+    paths:
+      - onnxruntime/python/**
+      - docs/python/**
+  pull_request:
     paths:
       - onnxruntime/python/**
       - docs/python/**
@@ -13,8 +19,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: "apidocs-python"
-  cancel-in-progress: true
+  group: "apidocs-python-${{ github.ref }}"
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: write
@@ -54,6 +60,7 @@ jobs:
           mkdir -p _site/docs/api/
           mv build/docs/html _site/docs/api/python
       - name: Upload docs artifact
+        if: github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v6
         with:
           name: onnxruntime-python-apidocs


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

This pull request updates the API documentation publishing workflows for all major language bindings (C/C++, C#, Java, JS, Objective-C, Python). The main goals are to ensure that documentation is regenerated and errors are caught earlier by running the workflows on relevant pull requests, and to only publish artifacts from the main branch. Additionally, concurrency controls are improved to prevent overlapping workflow runs.

The most important changes are:

* Each language's API docs workflow now runs not only on pushes to `main` and on a weekly schedule, but also on pull requests that modify relevant source or docs files, ensuring doc generation errors are caught before merging.

* Artifacts are now only uploaded when the workflow runs on the `main` branch, preventing unnecessary uploads from pull requests or other branches.

* Concurrency group names now include the branch reference, and in-progress runs are only cancelled for non-`main` branches. This avoids cancelling main branch doc builds while preventing redundant runs on other branches.

* Workflow comments were updated to clarify that docs are rebuilt weekly instead of monthly, and to explain the new triggers and artifact publishing behavior.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Catch doc generation errors earlier.