### PR TITLE
Refine specification of CMake C/C++ standard version requirement

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1236,9 +1236,10 @@ function(onnxruntime_configure_target target_name)
   endif()
 
   # Add compile features for minimum required language standard versions.
+  # Wrap in $<BUILD_INTERFACE:...> so the requirement is not exported to consumers of installed ORT targets.
   target_compile_features(${target_name} PUBLIC
-                          ${onnxruntime_c_std_compile_feature}
-                          ${onnxruntime_cxx_std_compile_feature})
+                          $<BUILD_INTERFACE:${onnxruntime_c_std_compile_feature}>
+                          $<BUILD_INTERFACE:${onnxruntime_cxx_std_compile_feature}>)
 endfunction()
 
 function(onnxruntime_add_shared_library target_name)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1235,10 +1235,10 @@ function(onnxruntime_configure_target target_name)
     target_link_options(${target_name} PRIVATE "$<$<LINK_LANGUAGE:CXX,C>:/CETCOMPAT>")
   endif()
 
-  # Link to minimum language standard version targets.
-  target_link_libraries(${target_name} PUBLIC
-                        $<BUILD_INTERFACE:onnxruntime_c_standard>
-                        $<BUILD_INTERFACE:onnxruntime_cxx_standard>)
+  # Add compile features for minimum required language standard versions.
+  target_compile_features(${target_name} PUBLIC
+                          ${onnxruntime_c_std_compile_feature}
+                          ${onnxruntime_cxx_std_compile_feature})
 endfunction()
 
 function(onnxruntime_add_shared_library target_name)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -10,15 +10,7 @@ cmake_policy(SET CMP0104 OLD)
 # Project
 project(onnxruntime C CXX ASM)
 
-# Set C/C++ standard versions
-if (NOT CMAKE_C_STANDARD)
-  # Needed for Java
-  set(CMAKE_C_STANDARD 99)
-endif()
-
-if (NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 20)
-endif()
+include(onnxruntime_language_standard_versions.cmake)
 
 # We don't use C++20 modules yet.
 # There are some known issues to address first:
@@ -1243,6 +1235,10 @@ function(onnxruntime_configure_target target_name)
     target_link_options(${target_name} PRIVATE "$<$<LINK_LANGUAGE:CXX,C>:/CETCOMPAT>")
   endif()
 
+  # Link to minimum language standard version targets.
+  target_link_libraries(${target_name} PUBLIC
+                        $<BUILD_INTERFACE:onnxruntime_c_standard>
+                        $<BUILD_INTERFACE:onnxruntime_cxx_standard>)
 endfunction()
 
 function(onnxruntime_add_shared_library target_name)

--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -275,7 +275,7 @@ onnxruntime_fetchcontent_declare(
   URL_HASH SHA1=${DEP_SHA1_date}
   EXCLUDE_FROM_ALL
   PATCH_COMMAND
-    ${Patch_EXECUTABLE} -p1 < ${PROJECT_SOURCE_DIR}/patches/date/date.patch
+    ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/date/date.patch
   FIND_PACKAGE_ARGS 3...<4 NAMES date
 )
 onnxruntime_fetchcontent_makeavailable(date)

--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -274,6 +274,8 @@ onnxruntime_fetchcontent_declare(
   URL ${DEP_URL_date}
   URL_HASH SHA1=${DEP_SHA1_date}
   EXCLUDE_FROM_ALL
+  PATCH_COMMAND
+    ${Patch_EXECUTABLE} -p1 < ${PROJECT_SOURCE_DIR}/patches/date/date.patch
   FIND_PACKAGE_ARGS 3...<4 NAMES date
 )
 onnxruntime_fetchcontent_makeavailable(date)

--- a/cmake/onnxruntime_language_standard_versions.cmake
+++ b/cmake/onnxruntime_language_standard_versions.cmake
@@ -5,7 +5,7 @@
 # Minimum required language standard versions.
 #
 
-set(onnxruntime_MINIMUM_C_STANDARD_VERSION 99)
+set(onnxruntime_MINIMUM_C_STANDARD_VERSION   99)
 set(onnxruntime_MINIMUM_CXX_STANDARD_VERSION 20)
 
 #
@@ -64,18 +64,13 @@ function(onnxruntime_ensure_minimum_language_standard_version
   endif()
 endfunction()
 
-onnxruntime_ensure_minimum_language_standard_version(CMAKE_C_STANDARD ${onnxruntime_MINIMUM_C_STANDARD_VERSION})
+onnxruntime_ensure_minimum_language_standard_version(CMAKE_C_STANDARD   ${onnxruntime_MINIMUM_C_STANDARD_VERSION})
 onnxruntime_ensure_minimum_language_standard_version(CMAKE_CXX_STANDARD ${onnxruntime_MINIMUM_CXX_STANDARD_VERSION})
 
 #
-# Define onnxruntime_<lang>_standard interface targets requiring the minimum standard version.
-# These should be used by all onnxruntime targets.
+# Define onnxruntime_<lang>_std_compile_feature variables specifying the <lang> standard version compile feature name.
+# These should be used by all onnxruntime targets via target_compile_features().
 #
 
-add_library(onnxruntime_c_standard INTERFACE)
-target_compile_features(onnxruntime_c_standard INTERFACE
-                        c_std_${onnxruntime_MINIMUM_C_STANDARD_VERSION})
-
-add_library(onnxruntime_cxx_standard INTERFACE)
-target_compile_features(onnxruntime_cxx_standard INTERFACE
-                        cxx_std_${onnxruntime_MINIMUM_CXX_STANDARD_VERSION})
+set(onnxruntime_c_std_compile_feature   c_std_${onnxruntime_MINIMUM_C_STANDARD_VERSION})
+set(onnxruntime_cxx_std_compile_feature cxx_std_${onnxruntime_MINIMUM_CXX_STANDARD_VERSION})

--- a/cmake/onnxruntime_language_standard_versions.cmake
+++ b/cmake/onnxruntime_language_standard_versions.cmake
@@ -18,11 +18,43 @@ set(onnxruntime_MINIMUM_CXX_STANDARD_VERSION 20)
 # E.g., this is important for Abseil.
 #
 
+# "Normalize" means make suitable for comparison.
+function(onnxruntime_normalize_language_standard_version
+         language_standard_version_var_name
+         version
+         normalized_version_var_name)
+  set(normalized_version ${version})
+
+  # Note: For CMAKE_C_STANDARD and CMAKE_CXX_STANDARD, we assume two-digit versions based on years.
+  if("${language_standard_version_var_name}" STREQUAL "CMAKE_C_STANDARD")
+    if("${version}" EQUAL "90" OR "${version}" EQUAL "99")
+      set(base_year 1900)
+    else()
+      set(base_year 2000)
+    endif()
+    math(EXPR normalized_version "${base_year} + ${version}")
+  elseif("${language_standard_version_var_name}" STREQUAL "CMAKE_CXX_STANDARD")
+    if("${version}" EQUAL "98")
+      set(base_year 1900)
+    else()
+      set(base_year 2000)
+    endif()
+    math(EXPR normalized_version "${base_year} + ${version}")
+  endif()
+
+  set(${normalized_version_var_name} ${normalized_version} PARENT_SCOPE)
+endfunction()
+
 function(onnxruntime_ensure_minimum_language_standard_version
          language_standard_version_var_name
          minimum_version)
   if(DEFINED ${language_standard_version_var_name})
-    if(${language_standard_version_var_name} VERSION_LESS "${minimum_version}")
+    onnxruntime_normalize_language_standard_version(
+        ${language_standard_version_var_name} "${minimum_version}" required_minimum_version)
+    onnxruntime_normalize_language_standard_version(
+        ${language_standard_version_var_name} "${${language_standard_version_var_name}}" actual_minimum_version)
+
+    if(actual_minimum_version VERSION_LESS required_minimum_version)
       message(FATAL_ERROR "${language_standard_version_var_name} must be at least ${minimum_version}. "
                           "It is ${${language_standard_version_var_name}}.")
     endif()
@@ -32,11 +64,8 @@ function(onnxruntime_ensure_minimum_language_standard_version
   endif()
 endfunction()
 
-onnxruntime_ensure_minimum_language_standard_version(
-    CMAKE_C_STANDARD ${onnxruntime_MINIMUM_C_STANDARD_VERSION})
-
-onnxruntime_ensure_minimum_language_standard_version(
-    CMAKE_CXX_STANDARD ${onnxruntime_MINIMUM_CXX_STANDARD_VERSION})
+onnxruntime_ensure_minimum_language_standard_version(CMAKE_C_STANDARD ${onnxruntime_MINIMUM_C_STANDARD_VERSION})
+onnxruntime_ensure_minimum_language_standard_version(CMAKE_CXX_STANDARD ${onnxruntime_MINIMUM_CXX_STANDARD_VERSION})
 
 #
 # Define onnxruntime_<lang>_standard interface targets requiring the minimum standard version.

--- a/cmake/onnxruntime_language_standard_versions.cmake
+++ b/cmake/onnxruntime_language_standard_versions.cmake
@@ -50,11 +50,11 @@ function(onnxruntime_ensure_minimum_language_standard_version
          minimum_version)
   if(DEFINED ${language_standard_version_var_name})
     onnxruntime_normalize_language_standard_version(
-        ${language_standard_version_var_name} "${minimum_version}" required_minimum_version)
+        ${language_standard_version_var_name} "${minimum_version}" normalized_minimum_version)
     onnxruntime_normalize_language_standard_version(
-        ${language_standard_version_var_name} "${${language_standard_version_var_name}}" actual_minimum_version)
+        ${language_standard_version_var_name} "${${language_standard_version_var_name}}" normalized_version)
 
-    if(actual_minimum_version VERSION_LESS required_minimum_version)
+    if(normalized_version VERSION_LESS normalized_minimum_version)
       message(FATAL_ERROR "${language_standard_version_var_name} must be at least ${minimum_version}. "
                           "It is ${${language_standard_version_var_name}}.")
     endif()

--- a/cmake/onnxruntime_language_standard_versions.cmake
+++ b/cmake/onnxruntime_language_standard_versions.cmake
@@ -1,0 +1,53 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+#
+# Minimum required language standard versions.
+#
+
+set(onnxruntime_MINIMUM_C_STANDARD_VERSION 99)
+set(onnxruntime_MINIMUM_CXX_STANDARD_VERSION 20)
+
+#
+# Handle CMAKE_<LANG>_STANDARD variables.
+#
+# We only set them if unset. Otherwise, enforce a minimum value.
+#
+# We care about the CMAKE_<LANG>_STANDARD variables because we typically want our dependencies to be built with the
+# same language standard versions as the rest of our code.
+# E.g., this is important for Abseil.
+#
+
+function(onnxruntime_ensure_minimum_language_standard_version
+         language_standard_version_var_name
+         minimum_version)
+  if(DEFINED ${language_standard_version_var_name})
+    if(${language_standard_version_var_name} VERSION_LESS "${minimum_version}")
+      message(FATAL_ERROR "${language_standard_version_var_name} must be at least ${minimum_version}. "
+                          "It is ${${language_standard_version_var_name}}.")
+    endif()
+  else()
+    message(STATUS "Setting ${language_standard_version_var_name} to ${minimum_version}")
+    set(${language_standard_version_var_name} ${minimum_version} PARENT_SCOPE)
+  endif()
+endfunction()
+
+onnxruntime_ensure_minimum_language_standard_version(
+    CMAKE_C_STANDARD ${onnxruntime_MINIMUM_C_STANDARD_VERSION})
+
+onnxruntime_ensure_minimum_language_standard_version(
+    CMAKE_CXX_STANDARD ${onnxruntime_MINIMUM_CXX_STANDARD_VERSION})
+
+
+#
+# Define onnxruntime_<lang>_standard interface targets requiring the minimum standard version.
+# These should be used by all onnxruntime targets.
+#
+
+add_library(onnxruntime_c_standard INTERFACE)
+target_compile_features(onnxruntime_c_standard INTERFACE
+                        c_std_${onnxruntime_MINIMUM_C_STANDARD_VERSION})
+
+add_library(onnxruntime_cxx_standard INTERFACE)
+target_compile_features(onnxruntime_cxx_standard INTERFACE
+                        cxx_std_${onnxruntime_MINIMUM_CXX_STANDARD_VERSION})

--- a/cmake/onnxruntime_language_standard_versions.cmake
+++ b/cmake/onnxruntime_language_standard_versions.cmake
@@ -38,7 +38,6 @@ onnxruntime_ensure_minimum_language_standard_version(
 onnxruntime_ensure_minimum_language_standard_version(
     CMAKE_CXX_STANDARD ${onnxruntime_MINIMUM_CXX_STANDARD_VERSION})
 
-
 #
 # Define onnxruntime_<lang>_standard interface targets requiring the minimum standard version.
 # These should be used by all onnxruntime targets.

--- a/cmake/patches/date/date.patch
+++ b/cmake/patches/date/date.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 012512a..548ee4c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -24,8 +24,8 @@ include( GNUInstallDirs )
+
+ get_directory_property( has_parent PARENT_DIRECTORY )
+
+-# Override by setting on CMake command line.
+-set( CMAKE_CXX_STANDARD 17 CACHE STRING "The C++ standard whose features are requested." )
++# Don't explicitly set CMAKE_CXX_STANDARD as a cache variable.
++# Cache variables are sticky and global. They may override values from other projects.
+
+ option( USE_SYSTEM_TZ_DB "Use the operating system's timezone database" OFF )
+ option( MANUAL_TZ_DB "User will set TZ DB manually by invoking set_install in their code" OFF )


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

- Use `c_std_99` and `cxx_std_20` target compile features to specify minimum C/C++ standard versions for onnxruntime targets.
- Update existing handling of `CMAKE_CXX_STANDARD/CMAKE_C_STANDARD` to error out if existing values don't meet the minimum version requirements. Ideally, we would only use the target compile feature mechanism, but these variables affect dependencies too and we should try to build everything with the same version (e.g., we need to do this for Abseil).
- Patch the external `date` dependency to avoid overriding the project-wide setting of `CMAKE_CXX_STANDARD` to `17`. This causes an issue with non-vcpkg builds and is the motivation for this change.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix C++20 build issue in non-vcpkg builds. Improve minimum language standard version handling.