### PR TITLE
fix: make sympy an optional runtime dependency

### DIFF
--- a/onnxruntime/python/tools/quantization/shape_inference.py
+++ b/onnxruntime/python/tools/quantization/shape_inference.py
@@ -13,7 +13,6 @@ from pathlib import Path
 import onnx
 
 import onnxruntime
-from onnxruntime.tools.symbolic_shape_infer import SymbolicShapeInference
 from onnxruntime.transformers.onnx_utils import extract_raw_data_from_model, has_external_data
 
 from .fusions import ReplaceUpsampleWithResize
@@ -88,6 +87,13 @@ def quant_pre_process(
                 model = save_and_reload_model_with_shape_infer(model)
 
         if not skip_symbolic_shape:
+            try:
+                from onnxruntime.tools.symbolic_shape_infer import SymbolicShapeInference
+            except ImportError as e:
+                raise ImportError(
+                    "sympy is required for symbolic shape inference in quantization preprocessing. "
+                    "Install with: 'pip install sympy' or pass skip_symbolic_shape=True to quant_pre_process()."
+                ) from e
             logger.info("Performing symbolic shape inference...")
             model = SymbolicShapeInference.infer_shapes(
                 model,

--- a/onnxruntime/python/tools/quantization/shape_inference.py
+++ b/onnxruntime/python/tools/quantization/shape_inference.py
@@ -88,7 +88,7 @@ def quant_pre_process(
 
         if not skip_symbolic_shape:
             try:
-                from onnxruntime.tools.symbolic_shape_infer import SymbolicShapeInference
+                from onnxruntime.tools.symbolic_shape_infer import SymbolicShapeInference  # noqa: PLC0415
             except ImportError as e:
                 raise ImportError(
                     "sympy is required for symbolic shape inference in quantization preprocessing. "

--- a/onnxruntime/python/tools/transformers/onnx_model.py
+++ b/onnxruntime/python/tools/transformers/onnx_model.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation.  All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+from __future__ import annotations
 
 import itertools
 import logging
@@ -23,7 +24,6 @@ from onnx import (
     save_model,
 )
 from onnx.external_data_helper import load_external_data_for_tensor, uses_external_data
-from shape_infer_helper import SymbolicShapeInferenceHelper
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +51,8 @@ class OnnxModel:
     def infer_runtime_shape(self, dynamic_axis_mapping={}, update=False):  # noqa: B006
         if self.enable_shape_infer:
             if self.shape_infer_helper is None or update:
+                from shape_infer_helper import SymbolicShapeInferenceHelper  # noqa: PLC0415
+
                 self.shape_infer_helper = SymbolicShapeInferenceHelper(self.model)
 
             try:
@@ -764,6 +766,8 @@ class OnnxModel:
         if use_symbolic_shape_infer:
             # Use symbolic shape inference since custom operators (like Gelu, SkipLayerNormalization etc)
             # are not recognized by onnx shape inference.
+            from shape_infer_helper import SymbolicShapeInferenceHelper  # noqa: PLC0415
+
             shape_infer_helper = SymbolicShapeInferenceHelper(model)
             try:
                 model_with_shape = shape_infer_helper.infer_shapes(model, auto_merge=True, guess_output_rank=False)

--- a/onnxruntime/python/tools/transformers/onnx_model.py
+++ b/onnxruntime/python/tools/transformers/onnx_model.py
@@ -10,6 +10,10 @@ import os
 import sys
 from collections import deque
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from shape_infer_helper import SymbolicShapeInferenceHelper
 
 from float16 import convert_float_to_float16
 from onnx import (

--- a/onnxruntime/python/tools/transformers/shape_infer_helper.py
+++ b/onnxruntime/python/tools/transformers/shape_infer_helper.py
@@ -14,13 +14,23 @@ if os.path.exists(os.path.join(file_path, "../tools/symbolic_shape_infer.py")):
 else:
     sys.path.append(os.path.join(file_path, ".."))
 
-from symbolic_shape_infer import SymbolicShapeInference, get_shape_from_type_proto, sympy  # noqa: E402
+try:
+    from symbolic_shape_infer import SymbolicShapeInference, get_shape_from_type_proto, sympy  # noqa: E402
+
+    _symbolic_shape_infer_available = True
+except ImportError:
+    SymbolicShapeInference = object  # type: ignore[assignment,misc]
+    get_shape_from_type_proto = None  # type: ignore[assignment]
+    sympy = None  # type: ignore[assignment]
+    _symbolic_shape_infer_available = False
 
 logger = logging.getLogger(__name__)
 
 
 class SymbolicShapeInferenceHelper(SymbolicShapeInference):
     def __init__(self, model, verbose=0, int_max=2**31 - 1, auto_merge=True, guess_output_rank=False):
+        if not _symbolic_shape_infer_available:
+            raise ImportError("sympy is required for SymbolicShapeInferenceHelper. Install it with: pip install sympy")
         super().__init__(int_max, auto_merge, guess_output_rank, verbose)
         self.model_ = model
         self.all_shapes_inferred_: bool = False

--- a/onnxruntime/python/tools/transformers/shape_infer_helper.py
+++ b/onnxruntime/python/tools/transformers/shape_infer_helper.py
@@ -15,7 +15,7 @@ else:
     sys.path.append(os.path.join(file_path, ".."))
 
 try:
-    from symbolic_shape_infer import SymbolicShapeInference, get_shape_from_type_proto, sympy  # noqa: E402
+    from symbolic_shape_infer import SymbolicShapeInference, get_shape_from_type_proto, sympy
 
     _symbolic_shape_infer_available = True
 except ImportError:

--- a/onnxruntime/python/tools/transformers/shape_infer_helper.py
+++ b/onnxruntime/python/tools/transformers/shape_infer_helper.py
@@ -18,11 +18,13 @@ try:
     from symbolic_shape_infer import SymbolicShapeInference, get_shape_from_type_proto, sympy
 
     _symbolic_shape_infer_available = True
-except ImportError:
+    _symbolic_shape_infer_import_error: ImportError | None = None
+except ImportError as exc:
     SymbolicShapeInference = object  # type: ignore[assignment,misc]
     get_shape_from_type_proto = None  # type: ignore[assignment]
     sympy = None  # type: ignore[assignment]
     _symbolic_shape_infer_available = False
+    _symbolic_shape_infer_import_error = exc
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +32,13 @@ logger = logging.getLogger(__name__)
 class SymbolicShapeInferenceHelper(SymbolicShapeInference):
     def __init__(self, model, verbose=0, int_max=2**31 - 1, auto_merge=True, guess_output_rank=False):
         if not _symbolic_shape_infer_available:
-            raise ImportError("sympy is required for SymbolicShapeInferenceHelper. Install it with: pip install sympy")
+            err = _symbolic_shape_infer_import_error
+            cause = (
+                "missing 'sympy' (install with: pip install sympy)"
+                if err is not None and err.name == "sympy"
+                else f"failed to import symbolic_shape_infer: {err!r}"
+            )
+            raise ImportError(f"SymbolicShapeInferenceHelper is unavailable — {cause}") from err
         super().__init__(int_max, auto_merge, guess_output_rank, verbose)
         self.model_ = model
         self.all_shapes_inferred_: bool = False

--- a/onnxruntime/python/tools/transformers/shape_infer_helper.py
+++ b/onnxruntime/python/tools/transformers/shape_infer_helper.py
@@ -35,7 +35,7 @@ class SymbolicShapeInferenceHelper(SymbolicShapeInference):
             err = _symbolic_shape_infer_import_error
             cause = (
                 "missing 'sympy' (install with: pip install sympy)"
-                if err is not None and err.name == "sympy"
+                if err is not None and "sympy" in str(err)
                 else f"failed to import symbolic_shape_infer: {err!r}"
             )
             raise ImportError(f"SymbolicShapeInferenceHelper is unavailable — {cause}") from err

--- a/onnxruntime/test/python/quantization/test_quant_preprocess.py
+++ b/onnxruntime/test/python/quantization/test_quant_preprocess.py
@@ -158,5 +158,58 @@ class TestClip(unittest.TestCase):
         assert preprocessed_model.opset_import[0].version >= 11
 
 
+class TestSkipSymbolicShape(unittest.TestCase):
+    """Verify that skip_symbolic_shape=True avoids importing sympy."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory(prefix="ort.quant_preprocess_skip_sympy_")
+        self.temp_path = Path(self.temp_dir.name)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def build_simple_model(self):
+        """Build a minimal identity model for testing."""
+        input_tensor = onnx.helper.make_tensor_value_info("input", onnx.TensorProto.FLOAT, [1, 4])
+        output_tensor = onnx.helper.make_tensor_value_info("output", onnx.TensorProto.FLOAT, [1, 4])
+        identity_node = onnx.helper.make_node("Identity", ["input"], ["output"])
+        graph = onnx.helper.make_graph([identity_node], "simple_graph", [input_tensor], [output_tensor])
+        opset_imports = [onnx.helper.make_opsetid("", 13)]
+        return onnx.helper.make_model(graph, opset_imports=opset_imports)
+
+    def test_skip_symbolic_shape_does_not_require_sympy(self):
+        """
+        When skip_symbolic_shape=True, quant_pre_process must not attempt to
+        import onnxruntime.tools.symbolic_shape_infer (which requires sympy).
+        We verify this by temporarily hiding the module from sys.modules and
+        confirming the call succeeds without it.
+        """
+        import sys
+
+        model = self.build_simple_model()
+        input_path = self.temp_path / "simple_model.onnx"
+        output_path = self.temp_path / "out_model.onnx"
+        onnx.save_model(model, str(input_path))
+
+        # Remove sympy and symbolic_shape_infer from sys.modules to simulate absence
+        saved = {}
+        for key in list(sys.modules.keys()):
+            if key == "sympy" or key.startswith("sympy.") or "symbolic_shape_infer" in key:
+                saved[key] = sys.modules.pop(key)
+
+        try:
+            quant_pre_process(
+                input_model=str(input_path),
+                output_model_path=str(output_path),
+                skip_optimization=True,
+                skip_onnx_shape=True,
+                skip_symbolic_shape=True,
+            )
+        finally:
+            sys.modules.update(saved)
+
+        self.assertTrue(output_path.exists(), "Output model should be created even without sympy")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/onnxruntime/test/python/quantization/test_quant_preprocess.py
+++ b/onnxruntime/test/python/quantization/test_quant_preprocess.py
@@ -5,6 +5,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -184,8 +185,6 @@ class TestSkipSymbolicShape(unittest.TestCase):
         We verify this by temporarily hiding the module from sys.modules and
         confirming the call succeeds without it.
         """
-        import sys
-
         model = self.build_simple_model()
         input_path = self.temp_path / "simple_model.onnx"
         output_path = self.temp_path / "out_model.onnx"

--- a/onnxruntime/test/python/quantization/test_quant_preprocess.py
+++ b/onnxruntime/test/python/quantization/test_quant_preprocess.py
@@ -182,20 +182,35 @@ class TestSkipSymbolicShape(unittest.TestCase):
         """
         When skip_symbolic_shape=True, quant_pre_process must not attempt to
         import onnxruntime.tools.symbolic_shape_infer (which requires sympy).
-        We verify this by temporarily hiding the module from sys.modules and
-        confirming the call succeeds without it.
+        We verify this by installing a meta_path finder that raises
+        ModuleNotFoundError for those modules — guaranteeing any fresh import
+        attempt fails — and asserting the call succeeds without ever loading
+        them.
         """
+
+        class _BlockSympyAndSymbolicFinder:
+            blocked_prefixes = ("sympy",)
+            blocked_substrings = ("symbolic_shape_infer",)
+
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == "sympy" or fullname.startswith("sympy."):
+                    raise ModuleNotFoundError(f"blocked by test: {fullname}")
+                if "symbolic_shape_infer" in fullname:
+                    raise ModuleNotFoundError(f"blocked by test: {fullname}")
+                return None
+
         model = self.build_simple_model()
         input_path = self.temp_path / "simple_model.onnx"
         output_path = self.temp_path / "out_model.onnx"
         onnx.save_model(model, str(input_path))
 
-        # Remove sympy and symbolic_shape_infer from sys.modules to simulate absence
         saved = {}
         for key in list(sys.modules.keys()):
             if key == "sympy" or key.startswith("sympy.") or "symbolic_shape_infer" in key:
                 saved[key] = sys.modules.pop(key)
 
+        blocker = _BlockSympyAndSymbolicFinder()
+        sys.meta_path.insert(0, blocker)
         try:
             quant_pre_process(
                 input_model=str(input_path),
@@ -204,7 +219,19 @@ class TestSkipSymbolicShape(unittest.TestCase):
                 skip_onnx_shape=True,
                 skip_symbolic_shape=True,
             )
+
+            for mod_name in list(sys.modules):
+                self.assertFalse(
+                    mod_name == "sympy" or mod_name.startswith("sympy."),
+                    f"sympy was imported despite skip_symbolic_shape=True: {mod_name}",
+                )
+                self.assertNotIn(
+                    "symbolic_shape_infer",
+                    mod_name,
+                    f"symbolic_shape_infer was imported despite skip_symbolic_shape=True: {mod_name}",
+                )
         finally:
+            sys.meta_path.remove(blocker)
             sys.modules.update(saved)
 
         self.assertTrue(output_path.exists(), "Output model should be created even without sympy")


### PR DESCRIPTION
## Summary
- Defer `sympy` import so `import onnxruntime.quantization` succeeds without sympy installed
- Move `SymbolicShapeInference` import in `quant_pre_process` behind `skip_symbolic_shape` gate
- Defer sympy-dependent imports in `transformers.onnx_model` and `transformers.shape_infer_helper`
- Raise a clear, actionable `ImportError` instructing users to install sympy when needed

## Motivation
Fixes #24872. `sympy` (~29 MB plus `mpmath` ~2 MB) was a hard runtime dependency even though it is only needed for symbolic shape inference. Pure-inference users — the common case — pay the install/import cost for functionality they do not use. `setup.py` already declares sympy as an optional extra (`"symbolic": ["sympy"]`), but top-level imports forced it to load unconditionally.

## Changes
- `onnxruntime/python/tools/quantization/shape_inference.py`: move `from onnxruntime.tools.symbolic_shape_infer import SymbolicShapeInference` from module top-level into `quant_pre_process`, guarded by `if not skip_symbolic_shape`. Wrap in `try/except ImportError` that re-raises with install instructions.
- `onnxruntime/python/tools/transformers/onnx_model.py`: move the `from shape_infer_helper import SymbolicShapeInferenceHelper` from module top-level into the two methods that instantiate it. Add `TYPE_CHECKING`-guarded import for type annotations.
- `onnxruntime/python/tools/transformers/shape_infer_helper.py`: wrap the import of `symbolic_shape_infer` in `try/except ImportError`. The `SymbolicShapeInferenceHelper.__init__` now raises a clear `ImportError` when sympy is unavailable, instead of failing at module load time.
- `onnxruntime/test/python/quantization/test_quant_preprocess.py`: add `test_skip_symbolic_shape_does_not_require_sympy` which removes sympy from `sys.modules` and verifies `quant_pre_process(..., skip_symbolic_shape=True)` completes successfully.

No public API signatures change. Users who want symbolic shape inference install sympy as before (`pip install sympy` or `pip install onnxruntime[symbolic]`).

## Test Plan
- `python -m pytest onnxruntime/test/python/quantization/test_quant_preprocess.py -v` — all tests pass including the new coverage.
- Smoke-tested locally: `import onnxruntime.quantization` no longer pulls `sympy` into `sys.modules`.
- `lintrunner -a` clean on all changed files.

Fixes #24872