### PR TITLE
fix: propagate output_dtype attribute when inserting Q after DQ

### DIFF
--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_propagation.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_propagation.cc
@@ -9,6 +9,7 @@
 #include <sstream>
 #include <utility>
 
+#include <onnx/defs/attr_proto_util.h>
 #include "core/common/inlined_containers_fwd.h"
 #include "core/graph/extended_graph_edge.h"
 #include "core/graph/graph_utils.h"
@@ -31,10 +32,25 @@ bool CanNodePropagate(const Node& node) {
 
 // Makes matching attributes for new QuantizeLinear nodes from an existing DequantizeLinear node.
 NodeAttributes MakeQAttrsFromDQ(const Node& dq_node) {
-  assert(dq_node.SinceVersion() <= 21);  // Checked by previous call to QDQ::MatchDQNode().
-  // In opset <= 21, all DQ attributes (i.e., axis and block_size) are also Q attributes.
-  // So, set a copy of the DQ attributes.
-  return dq_node.GetAttributes();
+  // DQ's axis and block_size attributes are also valid Q attributes for all supported opsets.
+  // So, start with a copy of the DQ attributes.
+  NodeAttributes q_attrs = dq_node.GetAttributes();
+
+  // From opset 21 onward, Q supports an "output_dtype" attribute that controls the quantized
+  // element type when no zero-point input is provided. Without it, qdq_util.cc silently falls
+  // back to UINT8, which corrupts negative values for INT8 (or other signed) inputs.
+  if (dq_node.SinceVersion() >= 21) {
+    const auto* input_type_proto = dq_node.InputDefs()[0]->TypeAsProto();
+    if (input_type_proto != nullptr) {
+      const int32_t elem_type = input_type_proto->tensor_type().elem_type();
+      if (elem_type != ONNX_NAMESPACE::TensorProto::UNDEFINED) {
+        q_attrs["output_dtype"] = ONNX_NAMESPACE::MakeAttribute("output_dtype",
+                                                                static_cast<int64_t>(elem_type));
+      }
+    }
+  }
+
+  return q_attrs;
 }
 
 // Makes matching attributes for new DequantizeLinear nodes from an existing QuantizeLinear node.

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_propagation.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_propagation.cc
@@ -55,13 +55,14 @@ NodeAttributes MakeQAttrsFromDQ(const Node& dq_node) {
 
 // Makes matching attributes for new DequantizeLinear nodes from an existing QuantizeLinear node.
 NodeAttributes MakeDQAttrsFromQ(const Node& q_node) {
-  assert(q_node.SinceVersion() <= 21);  // Checked by previous call to QDQ::MatchQNode().
+  // QDQ::MatchQNode() accepts opsets 10–25; the assert below would abort debug builds for
+  // opset 23/24/25 models, so it is intentionally omitted.
   const NodeAttributes& q_attrs = q_node.GetAttributes();
   if (q_attrs.empty()) {
     return {};
   }
 
-  // In opset <= 21, only the "axis" and "block_size" attributes for Q are also DQ attributes.
+  // Only the "axis" and "block_size" attributes for Q are also valid DQ attributes.
   NodeAttributes dq_attrs;
 
   auto axis_attr_it = q_attrs.find("axis");

--- a/onnxruntime/test/optimizer/qdq_transformer_test.cc
+++ b/onnxruntime/test/optimizer/qdq_transformer_test.cc
@@ -3837,6 +3837,80 @@ TEST(QDQTransformerTests, QDQPropagation_QBackward_NoZP_OutputDtypeAttribute) {
   test_case(ONNX_NAMESPACE::TensorProto_DataType_INT16);
 }
 
+// Test forward propagation of a DequantizeLinear node that has no zero-point input, to verify
+// that the inserted QuantizeLinear node receives the correct "output_dtype" attribute matching
+// the DQ's input element type (preventing silent INT8->UINT8 corruption).
+TEST(QDQTransformerTests, QDQPropagation_DQForward_NoZP_OutputDtypeAttribute) {
+  auto test_case = [&](ONNX_NAMESPACE::TensorProto_DataType dq_input_type) {
+    auto build_test_case = [&](ModelTestBuilder& builder) {
+      // Input quantized tensor fed directly into a DQ without a zero-point.
+      // Dispatch on dq_input_type so each iteration exercises a different C++ element type.
+      NodeArg* input_arg = nullptr;
+      constexpr float qdq_scale = 1.0f;
+      switch (dq_input_type) {
+        case ONNX_NAMESPACE::TensorProto_DataType_UINT8:
+          input_arg = builder.MakeInput<uint8_t>({1, 2, 2}, {0, 128, 1, 2});
+          break;
+        case ONNX_NAMESPACE::TensorProto_DataType_INT16:
+          input_arg = builder.MakeInput<int16_t>({1, 2, 2}, {-2, 0, 1, 2});
+          break;
+        case ONNX_NAMESPACE::TensorProto_DataType_UINT16:
+          input_arg = builder.MakeInput<uint16_t>({1, 2, 2}, {0, 128, 1, 2});
+          break;
+        default:  // INT8
+          input_arg = builder.MakeInput<int8_t>({1, 2, 2}, {-2, 0, 1, 2});
+          break;
+      }
+
+      // add DQ with no zero-point (relies on output_dtype attribute to signal the quant type)
+      auto* dq_output = builder.MakeIntermediate();
+      builder.AddDequantizeLinearNode(input_arg, qdq_scale, dq_output);
+
+      // add Reshape — QDQ propagation can insert Q/DQ pairs around Reshape
+      auto* reshape_shape = builder.Make1DInitializer<int64_t>({-1});
+      auto* output_arg = builder.MakeOutput();
+      builder.AddNode("Reshape", {dq_output, reshape_shape}, {output_arg});
+    };
+
+    auto check_graph = [&](InferenceSessionWrapper& session) {
+      const QDQOpKeys qdq_keys = GetQDQOpKeys(false);
+      std::vector<std::string> expected_op_types_in_order = {
+          qdq_keys.dequantize_linear,
+          "Reshape",
+          qdq_keys.quantize_linear,
+          qdq_keys.dequantize_linear,
+      };
+
+      const auto op_types_in_order = GetNodeOpTypesInTopologicalOrder(session.GetGraph(), true);
+      EXPECT_EQ(op_types_in_order, expected_op_types_in_order);
+
+      // Verify the inserted Q node carries the correct output_dtype attribute.
+      GraphViewer graph_viewer{session.GetGraph()};
+      const auto& ordered_nodes = graph_viewer.GetNodesInTopologicalOrder();
+      for (const auto node_idx : ordered_nodes) {
+        const Node* n = graph_viewer.GetNode(node_idx);
+        if (n && n->OpType() == qdq_keys.quantize_linear) {
+          const auto* attr = graph_utils::GetNodeAttribute(*n, "output_dtype");
+          ASSERT_NE(attr, nullptr) << "Inserted Q node is missing the output_dtype attribute";
+          EXPECT_EQ(attr->i(), static_cast<int64_t>(dq_input_type));
+          break;
+        }
+      }
+    };
+
+    TransformerTester(build_test_case,
+                      check_graph,
+                      TransformerLevel::Default,
+                      TransformerLevel::Level1,
+                      21);  // output_dtype attribute requires opset >= 21
+  };
+
+  test_case(ONNX_NAMESPACE::TensorProto_DataType_INT8);
+  test_case(ONNX_NAMESPACE::TensorProto_DataType_UINT8);
+  test_case(ONNX_NAMESPACE::TensorProto_DataType_INT16);
+  test_case(ONNX_NAMESPACE::TensorProto_DataType_UINT16);
+}
+
 TEST(QDQTransformerTests, QDQPropagation_DQForward) {
   auto test_case = [&](const std::vector<int64_t>& input_shape,
                        size_t maxpool_dim,

--- a/onnxruntime/test/optimizer/qdq_transformer_test.cc
+++ b/onnxruntime/test/optimizer/qdq_transformer_test.cc
@@ -3837,6 +3837,56 @@ TEST(QDQTransformerTests, QDQPropagation_QBackward_NoZP_OutputDtypeAttribute) {
   test_case(ONNX_NAMESPACE::TensorProto_DataType_INT16);
 }
 
+// Same as QDQPropagation_QBackward_NoZP_OutputDtypeAttribute but using opset 23, which
+// QDQ::MatchQNode() accepts. MakeDQAttrsFromQ() must not assert on this opset.
+TEST(QDQTransformerTests, QDQPropagation_QBackward_NoZP_OutputDtypeAttribute_Opset23) {
+  auto test_case = [&](ONNX_NAMESPACE::TensorProto_DataType q_output_type) {
+    auto build_test_case = [&](ModelTestBuilder& builder) {
+      auto* input_arg = builder.MakeInput<float>({1, 2, 2}, {-2.0f, 0.0f, 1.0f, 2.0f});
+      auto* output_arg = builder.MakeOutput();
+
+      // add Add
+      auto* const_1_input = builder.MakeScalarInitializer<float>(1.0f);
+      auto* add_output = builder.MakeIntermediate();
+      builder.AddNode("Add", {input_arg, const_1_input}, {add_output});
+
+      // add Transpose
+      auto* transpose_output = builder.MakeIntermediate();
+      builder.AddNode("Transpose", {add_output}, {transpose_output});
+
+      // add Q with a "output_dtype" attribute. Omit the zero-point input (defaults to 0).
+      constexpr float qdq_scale = 1.0f;
+      Node& q_node = builder.AddQuantizeLinearNode(transpose_output, qdq_scale, output_arg);
+      q_node.AddAttribute("output_dtype", static_cast<int64_t>(q_output_type));
+    };
+
+    auto check_graph = [&](InferenceSessionWrapper& session) {
+      const QDQOpKeys qdq_keys = GetQDQOpKeys(false);
+      std::vector<std::string> expected_op_types_in_order = {
+          "Add",
+          qdq_keys.quantize_linear,
+          qdq_keys.dequantize_linear,
+          "Transpose",
+          qdq_keys.quantize_linear,
+      };
+
+      const auto op_types_in_order = GetNodeOpTypesInTopologicalOrder(session.GetGraph(), true);
+      EXPECT_EQ(op_types_in_order, expected_op_types_in_order);
+    };
+
+    TransformerTester(build_test_case,
+                      check_graph,
+                      TransformerLevel::Default,
+                      TransformerLevel::Level1,
+                      23);  // Exercise the opset-23 path that previously triggered the assert
+  };
+
+  test_case(ONNX_NAMESPACE::TensorProto_DataType_UINT8);
+  test_case(ONNX_NAMESPACE::TensorProto_DataType_INT8);
+  test_case(ONNX_NAMESPACE::TensorProto_DataType_UINT16);
+  test_case(ONNX_NAMESPACE::TensorProto_DataType_INT16);
+}
+
 // Test forward propagation of a DequantizeLinear node that has no zero-point input, to verify
 // that the inserted QuantizeLinear node receives the correct "output_dtype" attribute matching
 // the DQ's input element type (preventing silent INT8->UINT8 corruption).


### PR DESCRIPTION
## Summary
- `MakeQAttrsFromDQ()` in `qdq_propagation.cc` only copied the DQ's existing attributes (`axis`, `block_size`) when constructing the inserted `QuantizeLinear` node, omitting `output_dtype`.
- For opset-21+ graphs whose DQ has no `zero_point` input, `qdq_util.cc` falls back to `UINT8` when `output_dtype` is missing, silently saturating negative `INT8` values to 0.
- Inject `output_dtype` derived from the DQ's input element type for opset >= 21, leaving older opsets unchanged.

## Motivation
Fixes #27845. Without this fix, enabling QDQ propagation (`ORT_ENABLE_ALL`) produces different — and silently incorrect — outputs versus `ORT_DISABLE_ALL` for any `DequantizeLinear(int8) -> Reshape/Transpose/...` pattern lacking a zero-point input.

## Changes
- `onnxruntime/core/optimizer/qdq_transformer/qdq_propagation.cc`: when `dq_node.SinceVersion() >= 21`, read the DQ input's element type from `InputDefs()[0]->TypeAsProto()` and inject it as `output_dtype` on the propagated Q node. Removed the stale `assert(SinceVersion() <= 21)` (`MatchDQNode()` accepts opsets up to 25).
- `onnxruntime/test/optimizer/qdq_transformer_test.cc`: new test `QDQPropagation_DQForward_NoZP_OutputDtypeAttribute` parametrized across `INT8`, `UINT8`, `INT16`, `UINT16`, asserting the inserted Q carries `output_dtype` matching the DQ input type.

## Test Plan
- `./onnxruntime_test_all --gtest_filter="QDQTransformerTests.QDQPropagation*"` (covers both the new test and the sibling `QDQPropagation_QBackward_NoZP_OutputDtypeAttribute`).
- Existing CPU EP CI suites.

Fixes #27845