### PR TITLE
fix: rewrite cmake and pkg-config paths after Linux tarball reshape

### DIFF
--- a/tools/ci_build/github/linux/copy_strip_binary.sh
+++ b/tools/ci_build/github/linux/copy_strip_binary.sh
@@ -43,6 +43,19 @@ then
 else
    # Linux
    mv $ARTIFACT_NAME/lib64 $ARTIFACT_NAME/lib
+   # Fix stale paths baked into cmake config files by `install(EXPORT ...)`
+   # - lib64/ was renamed to lib/ above
+   # - include/onnxruntime/ was flattened into include/ above
+   if [ -d "$ARTIFACT_NAME/lib/cmake" ]; then
+       find "$ARTIFACT_NAME/lib/cmake" -type f -name "*.cmake" -exec \
+           sed -i -e 's|/lib64/|/lib/|g' -e 's|/include/onnxruntime"|/include"|g' {} +
+   fi
+   # Fix pkg-config file similarly
+   if [ -f "$ARTIFACT_NAME/lib/pkgconfig/libonnxruntime.pc" ]; then
+       sed -i -e 's|/lib64$|/lib|' -e 's|/lib64/|/lib/|g' \
+              -e 's|/include/onnxruntime$|/include|' -e 's|/include/onnxruntime/|/include/|g' \
+           "$ARTIFACT_NAME/lib/pkgconfig/libonnxruntime.pc"
+   fi
 fi
 
 # copy the README, licence and TPN

--- a/tools/ci_build/github/linux/copy_strip_binary.sh
+++ b/tools/ci_build/github/linux/copy_strip_binary.sh
@@ -43,19 +43,26 @@ then
 else
    # Linux
    mv $ARTIFACT_NAME/lib64 $ARTIFACT_NAME/lib
-   # Fix stale paths baked into cmake config files by `install(EXPORT ...)`
+   # Fix stale lib64 paths baked into cmake config files by `install(EXPORT ...)`
    # - lib64/ was renamed to lib/ above
-   # - include/onnxruntime/ was flattened into include/ above
    if [ -d "$ARTIFACT_NAME/lib/cmake" ]; then
-       find "$ARTIFACT_NAME/lib/cmake" -type f -name "*.cmake" -exec \
-           sed -i -e 's|/lib64/|/lib/|g' -e 's|/include/onnxruntime"|/include"|g' {} +
+       find "$ARTIFACT_NAME/lib/cmake" -type f -name "*.cmake" -exec sh -c \
+           'sed -i.bak -e '"'"'s|/lib64/|/lib/|g'"'"' "$1" && rm "$1.bak"' _ {} \;
    fi
    # Fix pkg-config file similarly
    if [ -f "$ARTIFACT_NAME/lib/pkgconfig/libonnxruntime.pc" ]; then
-       sed -i -e 's|/lib64$|/lib|' -e 's|/lib64/|/lib/|g' \
+       sed -i.bak -e 's|/lib64$|/lib|' -e 's|/lib64/|/lib/|g' \
               -e 's|/include/onnxruntime$|/include|' -e 's|/include/onnxruntime/|/include/|g' \
-           "$ARTIFACT_NAME/lib/pkgconfig/libonnxruntime.pc"
+           "$ARTIFACT_NAME/lib/pkgconfig/libonnxruntime.pc" && \
+       rm "$ARTIFACT_NAME/lib/pkgconfig/libonnxruntime.pc.bak"
    fi
+fi
+
+# Fix cmake include paths on both Linux and macOS: include/onnxruntime/ was
+# flattened into include/ above (line 21), so update any baked-in cmake paths.
+if [ -d "$ARTIFACT_NAME/lib/cmake" ]; then
+    find "$ARTIFACT_NAME/lib/cmake" -type f -name "*.cmake" -exec sh -c \
+        'sed -i.bak -e '"'"'s|/include/onnxruntime"|/include"|g'"'"' "$1" && rm "$1.bak"' _ {} \;
 fi
 
 # copy the README, licence and TPN


### PR DESCRIPTION
## Summary
- Patch stale `lib64/` and `include/onnxruntime/` paths in the generated cmake export and pkg-config files after the Linux tarball packaging script reshapes the directory layout.
- Makes `find_package(onnxruntime CONFIG)` and `pkg-config --libs onnxruntime` work against the released Linux tarball.

## Motivation
Fixes #23642.

On x86-64 Linux, `GNUInstallDirs` sets `CMAKE_INSTALL_LIBDIR=lib64` and the build installs headers under `include/onnxruntime/`. The packaging script `tools/ci_build/github/linux/copy_strip_binary.sh` then reshapes the tarball:

- `mv $ARTIFACT_NAME/lib64 $ARTIFACT_NAME/lib`
- `mv $ARTIFACT_NAME/include/onnxruntime/* $ARTIFACT_NAME/include && rmdir $ARTIFACT_NAME/include/onnxruntime`

The files produced by `install(EXPORT onnxruntimeTargets ...)` (`onnxruntimeTargets-release.cmake`, etc.) and `configure_file(libonnxruntime.pc.cmake.in ...)` still reference the pre-reshape locations, so downstream consumers see:

- `IMPORTED_LOCATION_RELEASE "${_IMPORT_PREFIX}/lib64/libonnxruntime.so.X"` — file does not exist
- `INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include/onnxruntime"` — directory does not exist
- `libdir=${prefix}/lib64` / `includedir=${prefix}/include/onnxruntime` in `libonnxruntime.pc`

An earlier attempt (#26104) tried to eliminate the reshape itself and was reverted (#26767) because downstream release pipelines and example repos depended on the `lib/` + flat `include/` layout. This change takes the opposite approach: keep the existing tarball layout and fix the metadata to match it — fully self-contained in the packaging step.

## Changes
`tools/ci_build/github/linux/copy_strip_binary.sh` — after the existing `mv lib64 lib` step, add two guarded `sed` blocks:

- Rewrite `/lib64/` → `/lib/` and `/include/onnxruntime"` → `/include"` in every `*.cmake` under `$ARTIFACT_NAME/lib/cmake` (covers `onnxruntimeConfig.cmake`, `onnxruntimeTargets.cmake`, and per-config `onnxruntimeTargets-*.cmake`).
- Rewrite `libdir` and `includedir` entries in `$ARTIFACT_NAME/lib/pkgconfig/libonnxruntime.pc`.

Patterns are anchored (trailing `/`, trailing `"`, or end-of-line) to avoid over-matching. Guarded with `[ -d ]` / `[ -f ]` so builds that don't install cmake exports or pkg-config files are unaffected. No cmake build-system changes; no effect on the macOS branch.

## Test Plan
- `bash -n tools/ci_build/github/linux/copy_strip_binary.sh` — syntax clean.
- Mock tarball exercised locally: populated `lib/cmake/onnxruntime/onnxruntimeTargets-release.cmake` with `${_IMPORT_PREFIX}/lib64/libonnxruntime.so.X` and `${_IMPORT_PREFIX}/include/onnxruntime`, and `lib/pkgconfig/libonnxruntime.pc` with `libdir=${prefix}/lib64` / `includedir=${prefix}/include/onnxruntime`. After running the new block, `grep -r 'lib64\|include/onnxruntime' lib/` returns no matches; the rewritten `IMPORTED_LOCATION_RELEASE` and `libdir` point at the real, reshaped locations.
- CI Linux packaging pipelines will exercise the end-to-end tarball consumption.