### PR TITLE
Propagate EP session option modifications during provider creation

### DIFF
--- a/onnxruntime/core/session/utils.cc
+++ b/onnxruntime/core/session/utils.cc
@@ -303,10 +303,24 @@ static Status CreateAndRegisterExecutionProviders(_In_ const OrtSessionOptions* 
 
   if (has_provider_factories) {
     std::vector<std::unique_ptr<IExecutionProvider>> provider_list;
+
+    // Create OrtSessionOptions wrapper for the CreateProvider call.
+    // Once the InferenceSession is created, its SessionOptions is the source of truth
+    // and contains all the values from the user provided OrtSessionOptions.
+    // We wrap the session's copy so any modifications made by the EP (e.g., DisableMemPattern)
+    // will affect the actual session options that will be used.
+    auto& session_options = sess.GetMutableSessionOptions();
+    OrtSessionOptions ort_so;
+    ort_so.value = session_options;
+
     for (auto& factory : options->provider_factories) {
-      auto provider = factory->CreateProvider(*options, *session_logger->ToExternal());
+      auto provider = factory->CreateProvider(ort_so, *session_logger->ToExternal());
       provider_list.push_back(std::move(provider));
     }
+
+    // Copy any modifications made by the EP back to the session's options
+    session_options = ort_so.value;
+
     // register the providers
     for (auto& provider : provider_list) {
       if (provider) {


### PR DESCRIPTION
### Description
Wrap the session's mutable SessionOptions in an OrtSessionOptions before passing it to IExecutionProviderFactory::CreateProvider. This ensures that any modifications made by an EP during creation (e.g., disabling memory pattern optimization) are reflected in the actual session options used during initialization. Previously, EP-side modifications to session options could be lost.



### Motivation and Context
It would be nice to have control over which session options to enable/disable during plugin ep creation. For example, calls like ort_api.DisableMemPattern(const_cast<OrtSessionOptions*>(session_options)); during plugin ep creation were not being reflected in actual session options used during initialization. 


