### PR TITLE
Fix Use-After-Free in InferenceSession by adding shutdown barrier and run drain

### DIFF
--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -783,8 +783,11 @@ InferenceSession::InferenceSession(const SessionOptions& session_options, const 
 InferenceSession::~InferenceSession() {
   // Signal that no new Run() calls should be accepted and wait for active ones to finish.
   is_shutting_down_.store(true, std::memory_order_release);
-  while (current_num_runs_.load(std::memory_order_acquire) > 0) {
-    std::this_thread::yield();
+  {
+    std::unique_lock<std::mutex> lock(runs_drain_mutex_);
+    runs_drain_cv_.wait(lock, [this] {
+      return current_num_runs_.load(std::memory_order_acquire) == 0;
+    });
   }
 
   // Flush any remaining RuntimePerf counters
@@ -3030,11 +3033,13 @@ struct ThreadPoolSpinningSwitch {
   concurrency::ThreadPool* intra_tp_{nullptr};
   concurrency::ThreadPool* inter_tp_{nullptr};
   std::atomic<int>& concurrent_num_runs_;
+  std::condition_variable* drain_cv_{nullptr};
   // __Ctor Refcounting and spinning control
   ThreadPoolSpinningSwitch(concurrency::ThreadPool* intra_tp,
                            concurrency::ThreadPool* inter_tp,
-                           std::atomic<int>& ref) noexcept
-      : intra_tp_(intra_tp), inter_tp_(inter_tp), concurrent_num_runs_(ref) {
+                           std::atomic<int>& ref,
+                           std::condition_variable* drain_cv = nullptr) noexcept
+      : intra_tp_(intra_tp), inter_tp_(inter_tp), concurrent_num_runs_(ref), drain_cv_(drain_cv) {
     if (concurrent_num_runs_.fetch_add(1, std::memory_order_relaxed) == 0) {
       if (intra_tp_) intra_tp_->EnableSpinning();
       if (inter_tp_) inter_tp_->EnableSpinning();
@@ -3044,6 +3049,7 @@ struct ThreadPoolSpinningSwitch {
     if (1 == concurrent_num_runs_.fetch_sub(1, std::memory_order_acq_rel)) {
       if (intra_tp_) intra_tp_->DisableSpinning();
       if (inter_tp_) inter_tp_->DisableSpinning();
+      if (drain_cv_) drain_cv_->notify_one();
     }
   }
 };
@@ -3121,11 +3127,6 @@ Status InferenceSession::RunImpl(const RunOptions& run_options,
     }
   }
 
-  // Reject new runs if the session is being destroyed.
-  if (is_shutting_down_.load(std::memory_order_acquire)) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Session is being destroyed. New Run() calls are rejected.");
-  }
-
   // Increment/decrement concurrent_num_runs_ and control
   // session threads spinning as configured. Do nothing for graph replay except the counter.
   const bool control_spinning = use_per_session_threads_ &&
@@ -3133,7 +3134,15 @@ Status InferenceSession::RunImpl(const RunOptions& run_options,
                                 !cached_execution_provider_for_graph_replay_.IsGraphCaptured(graph_annotation_id);
   auto* intra_tp = (control_spinning) ? thread_pool_.get() : nullptr;
   auto* inter_tp = (control_spinning) ? inter_op_thread_pool_.get() : nullptr;
-  ThreadPoolSpinningSwitch runs_refcounter_and_tp_spin_control(intra_tp, inter_tp, current_num_runs_);
+  ThreadPoolSpinningSwitch runs_refcounter_and_tp_spin_control(intra_tp, inter_tp, current_num_runs_, &runs_drain_cv_);
+
+  // Reject new runs if the session is being destroyed.
+  // Checked AFTER incrementing current_num_runs_ to close the race window where a thread
+  // could pass this check, get preempted, and the destructor proceeds seeing zero active runs.
+  // The RAII guard above will decrement and notify the destructor on early return.
+  if (is_shutting_down_.load(std::memory_order_acquire)) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Session is being destroyed. New Run() calls are rejected.");
+  }
 
   // Check if this Run() can skip normal execution and replay a previously captured graph.
   if (cached_execution_provider_for_graph_replay_.IsGraphCaptured(graph_annotation_id)) {

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -3438,6 +3438,14 @@ Status InferenceSession::Run(const RunOptions& run_options,
     return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, kSessionShuttingDownError);
   }
 
+  return RunWithCApiArgs(run_options, feed_names, feeds, fetch_names, fetches);
+}
+
+Status InferenceSession::RunWithCApiArgs(const RunOptions& run_options,
+                                         gsl::span<const char* const> feed_names,
+                                         gsl::span<const OrtValue* const> feeds,
+                                         gsl::span<const char* const> fetch_names,
+                                         gsl::span<OrtValue*> fetches) {
   size_t num_feeds = feed_names.size();
   size_t num_fetches = fetch_names.size();
   InlinedVector<std::string> feed_name_vec;
@@ -3527,11 +3535,13 @@ common::Status InferenceSession::RunAsync(const RunOptions* run_options,
                                   callback, user_data, this, session_access_guard]() mutable {
     Status status = Status::OK();
     ORT_TRY {
+      // Call RunWithCApiArgs directly instead of Run() to avoid creating a second
+      // SessionAccessGuard (admission was already granted by the outer guard).
       if (run_options) {
-        status = Run(*run_options, feed_names, feeds, fetch_names, fetches);
+        status = RunWithCApiArgs(*run_options, feed_names, feeds, fetch_names, fetches);
       } else {
         RunOptions default_run_options;
-        status = Run(default_run_options, feed_names, feeds, fetch_names, fetches);
+        status = RunWithCApiArgs(default_run_options, feed_names, feeds, fetch_names, fetches);
       }
     }
     ORT_CATCH(const std::exception& ex) {

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -786,7 +786,7 @@ InferenceSession::~InferenceSession() {
   {
     std::unique_lock<std::mutex> lock(runs_drain_mutex_);
     runs_drain_cv_.wait(lock, [this] {
-      return current_num_runs_.load(std::memory_order_acquire) == 0;
+      return active_session_runs_.load(std::memory_order_acquire) == 0;
     });
   }
 
@@ -3028,18 +3028,61 @@ Status InferenceSession::PartialRun(onnxruntime::RunOptions& run_options,
 #endif
 
 namespace {
+constexpr const char* kSessionShuttingDownError =
+    "Session is being destroyed. New Run() calls are rejected.";
+
+// Tracks session usage that must finish before teardown can destroy session-owned state.
+class SessionAccessGuard {
+ public:
+  SessionAccessGuard(std::atomic<int>& active_session_runs,
+                     std::atomic<bool>& is_shutting_down,
+                     std::condition_variable* drain_cv) noexcept
+      : active_session_runs_(active_session_runs), drain_cv_(drain_cv) {
+    active_session_runs_.fetch_add(1, std::memory_order_acq_rel);
+    holds_ref_ = true;
+    if (is_shutting_down.load(std::memory_order_acquire)) {
+      Release();
+    }
+  }
+
+  SessionAccessGuard(const SessionAccessGuard&) = delete;
+  SessionAccessGuard& operator=(const SessionAccessGuard&) = delete;
+
+  ~SessionAccessGuard() {
+    Release();
+  }
+
+  bool HoldsRef() const noexcept {
+    return holds_ref_;
+  }
+
+  void Release() noexcept {
+    if (!holds_ref_) {
+      return;
+    }
+
+    holds_ref_ = false;
+    if (1 == active_session_runs_.fetch_sub(1, std::memory_order_acq_rel) && drain_cv_) {
+      drain_cv_->notify_one();
+    }
+  }
+
+ private:
+  std::atomic<int>& active_session_runs_;
+  std::condition_variable* drain_cv_{nullptr};
+  bool holds_ref_{false};
+};
+
 // Concurrent runs counting and thread-pool spin control
 struct ThreadPoolSpinningSwitch {
   concurrency::ThreadPool* intra_tp_{nullptr};
   concurrency::ThreadPool* inter_tp_{nullptr};
   std::atomic<int>& concurrent_num_runs_;
-  std::condition_variable* drain_cv_{nullptr};
   // __Ctor Refcounting and spinning control
   ThreadPoolSpinningSwitch(concurrency::ThreadPool* intra_tp,
                            concurrency::ThreadPool* inter_tp,
-                           std::atomic<int>& ref,
-                           std::condition_variable* drain_cv = nullptr) noexcept
-      : intra_tp_(intra_tp), inter_tp_(inter_tp), concurrent_num_runs_(ref), drain_cv_(drain_cv) {
+                           std::atomic<int>& ref) noexcept
+      : intra_tp_(intra_tp), inter_tp_(inter_tp), concurrent_num_runs_(ref) {
     if (concurrent_num_runs_.fetch_add(1, std::memory_order_relaxed) == 0) {
       if (intra_tp_) intra_tp_->EnableSpinning();
       if (inter_tp_) inter_tp_->EnableSpinning();
@@ -3049,7 +3092,6 @@ struct ThreadPoolSpinningSwitch {
     if (1 == concurrent_num_runs_.fetch_sub(1, std::memory_order_acq_rel)) {
       if (intra_tp_) intra_tp_->DisableSpinning();
       if (inter_tp_) inter_tp_->DisableSpinning();
-      if (drain_cv_) drain_cv_->notify_one();
     }
   }
 };
@@ -3077,6 +3119,11 @@ Status InferenceSession::Run(const RunOptions& run_options,
                              gsl::span<const std::string> feed_names, gsl::span<const OrtValue> feeds,
                              gsl::span<const std::string> output_names, std::vector<OrtValue>* p_fetches,
                              const std::vector<OrtDevice>* p_fetches_device_info) {
+  SessionAccessGuard session_access_guard(active_session_runs_, is_shutting_down_, &runs_drain_cv_);
+  if (!session_access_guard.HoldsRef()) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, kSessionShuttingDownError);
+  }
+
   return RunImpl(run_options, feed_names, feeds, output_names, p_fetches, p_fetches_device_info,
                  /*graph_capture_depth=*/0);
 }
@@ -3134,15 +3181,7 @@ Status InferenceSession::RunImpl(const RunOptions& run_options,
                                 !cached_execution_provider_for_graph_replay_.IsGraphCaptured(graph_annotation_id);
   auto* intra_tp = (control_spinning) ? thread_pool_.get() : nullptr;
   auto* inter_tp = (control_spinning) ? inter_op_thread_pool_.get() : nullptr;
-  ThreadPoolSpinningSwitch runs_refcounter_and_tp_spin_control(intra_tp, inter_tp, current_num_runs_, &runs_drain_cv_);
-
-  // Reject new runs if the session is being destroyed.
-  // Checked AFTER incrementing current_num_runs_ to close the race window where a thread
-  // could pass this check, get preempted, and the destructor proceeds seeing zero active runs.
-  // The RAII guard above will decrement and notify the destructor on early return.
-  if (is_shutting_down_.load(std::memory_order_acquire)) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Session is being destroyed. New Run() calls are rejected.");
-  }
+  ThreadPoolSpinningSwitch runs_refcounter_and_tp_spin_control(intra_tp, inter_tp, current_num_runs_);
 
   // Check if this Run() can skip normal execution and replay a previously captured graph.
   if (cached_execution_provider_for_graph_replay_.IsGraphCaptured(graph_annotation_id)) {
@@ -3394,6 +3433,11 @@ Status InferenceSession::Run(const RunOptions& run_options,
                              gsl::span<const OrtValue* const> feeds,
                              gsl::span<const char* const> fetch_names,
                              gsl::span<OrtValue*> fetches) {
+  SessionAccessGuard session_access_guard(active_session_runs_, is_shutting_down_, &runs_drain_cv_);
+  if (!session_access_guard.HoldsRef()) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, kSessionShuttingDownError);
+  }
+
   size_t num_feeds = feed_names.size();
   size_t num_fetches = fetch_names.size();
   InlinedVector<std::string> feed_name_vec;
@@ -3435,7 +3479,8 @@ Status InferenceSession::Run(const RunOptions& run_options,
   }
 
   Status status;
-  status = Run(run_options, feed_name_vec, feed_vec, fetch_name_vec, &fetch_vec, nullptr);
+  status = RunImpl(run_options, feed_name_vec, feed_vec, fetch_name_vec, &fetch_vec, nullptr,
+                   /*graph_capture_depth=*/0);
 
   if (!status.IsOK())
     return status;
@@ -3467,13 +3512,19 @@ common::Status InferenceSession::RunAsync(const RunOptions* run_options,
                                           gsl::span<OrtValue*> fetches,
                                           RunAsyncCallbackFn callback,
                                           void* user_data) {
+  auto session_access_guard =
+      std::make_shared<SessionAccessGuard>(active_session_runs_, is_shutting_down_, &runs_drain_cv_);
+  if (!session_access_guard->HoldsRef()) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, kSessionShuttingDownError);
+  }
+
   size_t num_fetches = fetch_names.size();
   auto* tp = GetIntraOpThreadPoolToUse();
   if (!tp || concurrency::ThreadPool::DegreeOfParallelism(tp) < 2) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "intra op thread pool must have at least one thread for RunAsync");
   }
   std::function<void()> run_fn = [run_options, feed_names, feeds, fetch_names, fetches, num_fetches,
-                                  callback, user_data, this]() {
+                                  callback, user_data, this, session_access_guard]() mutable {
     Status status = Status::OK();
     ORT_TRY {
       if (run_options) {
@@ -3491,6 +3542,8 @@ common::Status InferenceSession::RunAsync(const RunOptions* run_options,
     ORT_CATCH(...) {
       status = ORT_MAKE_STATUS(ONNXRUNTIME, RUNTIME_EXCEPTION, "unknown exception");
     }
+
+    session_access_guard.reset();
     callback(user_data, fetches.data(), status.IsOK() ? num_fetches : 0, ToOrtStatus(status));
   };  // run_fn
   concurrency::ThreadPool::Schedule(tp, run_fn);
@@ -3504,6 +3557,11 @@ common::Status InferenceSession::Run(const NameMLValMap& feeds, gsl::span<const 
 
 common::Status InferenceSession::Run(const RunOptions& run_options, const NameMLValMap& feeds_map,
                                      gsl::span<const std::string> output_names, std::vector<OrtValue>* p_fetches) {
+  SessionAccessGuard session_access_guard(active_session_runs_, is_shutting_down_, &runs_drain_cv_);
+  if (!session_access_guard.HoldsRef()) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, kSessionShuttingDownError);
+  }
+
   InlinedVector<std::string> feed_names;
   InlinedVector<OrtValue> feeds;
 
@@ -3516,7 +3574,8 @@ common::Status InferenceSession::Run(const RunOptions& run_options, const NameML
     feeds.push_back(pair.second);
   }
 
-  return Run(run_options, feed_names, feeds, output_names, p_fetches, nullptr);
+  return RunImpl(run_options, feed_names, feeds, output_names, p_fetches, nullptr,
+                 /*graph_capture_depth=*/0);
 }
 
 std::pair<common::Status, const ModelMetadata*> InferenceSession::GetModelMetadata() const {
@@ -3756,10 +3815,15 @@ common::Status InferenceSession::NewIOBinding(std::unique_ptr<IOBinding>* io_bin
 }
 
 common::Status InferenceSession::Run(const RunOptions& run_options, IOBinding& io_binding) {
+  SessionAccessGuard session_access_guard(active_session_runs_, is_shutting_down_, &runs_drain_cv_);
+  if (!session_access_guard.HoldsRef()) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, kSessionShuttingDownError);
+  }
+
   // TODO should Run() call io_binding.SynchronizeInputs() or should it let the callers do it?
   // io_binding.SynchronizeInputs();
-  return Run(run_options, io_binding.GetInputNames(), io_binding.GetInputs(), io_binding.GetOutputNames(),
-             &io_binding.GetOutputs(), &io_binding.GetOutputsDeviceInfo());
+  return RunImpl(run_options, io_binding.GetInputNames(), io_binding.GetInputs(), io_binding.GetOutputNames(),
+                 &io_binding.GetOutputs(), &io_binding.GetOutputsDeviceInfo(), /*graph_capture_depth=*/0);
 }
 
 common::Status InferenceSession::Run(IOBinding& io_binding) {

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -781,6 +781,12 @@ InferenceSession::InferenceSession(const SessionOptions& session_options, const 
 #endif  // !defined(ORT_MINIMAL_BUILD)
 
 InferenceSession::~InferenceSession() {
+  // Signal that no new Run() calls should be accepted and wait for active ones to finish.
+  is_shutting_down_.store(true, std::memory_order_release);
+  while (current_num_runs_.load(std::memory_order_acquire) > 0) {
+    std::this_thread::yield();
+  }
+
   // Flush any remaining RuntimePerf counters
   ORT_TRY {
     std::lock_guard<std::mutex> telemetry_lock(telemetry_mutex_);
@@ -3113,6 +3119,11 @@ Status InferenceSession::RunImpl(const RunOptions& run_options,
       return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Failed to parse the cuda graph annotation id: ",
                              graph_annotation_str);
     }
+  }
+
+  // Reject new runs if the session is being destroyed.
+  if (is_shutting_down_.load(std::memory_order_acquire)) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Session is being destroyed. New Run() calls are rejected.");
   }
 
   // Increment/decrement concurrent_num_runs_ and control

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -31,6 +31,7 @@
 #include "core/optimizer/graph_transformer_mgr.h"
 #include "core/optimizer/insert_cast_transformer.h"
 #include "core/session/ep_graph_assignment_info.h"
+#include <condition_variable>
 #include <mutex>
 #ifdef ENABLE_LANGUAGE_INTEROP_OPS
 #include "core/language_interop_ops/language_interop_ops.h"
@@ -972,6 +973,10 @@ class InferenceSession {
 
   // Set to true in destructor to reject new Run() calls and drain active ones.
   std::atomic<bool> is_shutting_down_{false};
+
+  // Signaled when current_num_runs_ drops to zero so the destructor can stop waiting.
+  std::mutex runs_drain_mutex_;
+  std::condition_variable runs_drain_cv_;
 
   mutable std::mutex session_mutex_;         // to ensure only one thread can invoke Load/Initialize
   bool is_model_loaded_ = false;             // GUARDED_BY(session_mutex_)

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -970,6 +970,9 @@ class InferenceSession {
   // Number of concurrently running executors
   std::atomic<int> current_num_runs_ = 0;
 
+  // Set to true in destructor to reject new Run() calls and drain active ones.
+  std::atomic<bool> is_shutting_down_{false};
+
   mutable std::mutex session_mutex_;         // to ensure only one thread can invoke Load/Initialize
   bool is_model_loaded_ = false;             // GUARDED_BY(session_mutex_)
   bool is_inited_ = false;                   // GUARDED_BY(session_mutex_)

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -968,13 +968,16 @@ class InferenceSession {
   // External data loader manager.
   ExternalDataLoaderManager external_data_loader_mgr_;
 
-  // Number of concurrently running executors
+  // Number of runs or queued async callbacks that still hold session state during teardown.
+  std::atomic<int> active_session_runs_ = 0;
+
+  // Number of concurrently running executors. Used for thread-pool spinning control.
   std::atomic<int> current_num_runs_ = 0;
 
   // Set to true in destructor to reject new Run() calls and drain active ones.
   std::atomic<bool> is_shutting_down_{false};
 
-  // Signaled when current_num_runs_ drops to zero so the destructor can stop waiting.
+  // Signaled when active_session_runs_ drops to zero so the destructor can stop waiting.
   std::mutex runs_drain_mutex_;
   std::condition_variable runs_drain_cv_;
 

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -782,6 +782,14 @@ class InferenceSession {
                                        const std::vector<OrtDevice>* p_fetches_device_info,
                                        int graph_capture_depth);
 
+  // Run() body for C API argument types (char* names, OrtValue* pointers).
+  // Separated so RunAsync can call it without creating a second SessionAccessGuard.
+  [[nodiscard]] common::Status RunWithCApiArgs(const RunOptions& run_options,
+                                               gsl::span<const char* const> feed_names,
+                                               gsl::span<const OrtValue* const> feeds,
+                                               gsl::span<const char* const> fetch_names,
+                                               gsl::span<OrtValue*> fetches);
+
   void SetLoggingManager(const SessionOptions& session_options,
                          const Environment& session_env);
   void ConstructorCommon(const SessionOptions& session_options,

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <condition_variable>
 #include <filesystem>
 #include <fstream>
 #include <future>
@@ -4536,6 +4537,53 @@ void CallbackFail(void*, OrtValue**, size_t, OrtStatusPtr) {
   EXPECT_TRUE(false);  // the callback is not supposed to be invoked
 }
 
+struct RunAsyncReleaseState {
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool first_callback_started = false;
+  bool allow_first_callback_finish = false;
+  bool second_callback_invoked = false;
+  bool destroy_completed = false;
+  std::string second_callback_error;
+};
+
+void BlockingCallbackSucceed(void* user_data, OrtValue** outputs, size_t num_outputs, OrtStatusPtr status_ptr) {
+  auto* state = reinterpret_cast<RunAsyncReleaseState*>(user_data);
+  {
+    std::lock_guard<std::mutex> lock(state->mutex);
+    state->first_callback_started = true;
+  }
+  state->cv.notify_all();
+
+  {
+    std::unique_lock<std::mutex> lock(state->mutex);
+    state->cv.wait(lock, [state] { return state->allow_first_callback_finish; });
+  }
+
+  Ort::Status status(status_ptr);
+  EXPECT_TRUE(status.IsOK());
+  EXPECT_EQ(num_outputs, 1UL);
+  Ort::Value output_value(outputs[0]);
+  EXPECT_EQ(output_value.At<float>({1, 0}), 9.f);
+  output_value.release();
+}
+
+void RecordShutdownCallback(void* user_data, OrtValue**, size_t num_outputs, OrtStatusPtr status_ptr) {
+  auto* state = reinterpret_cast<RunAsyncReleaseState*>(user_data);
+  Ort::Status status(status_ptr);
+
+  EXPECT_FALSE(status.IsOK());
+  EXPECT_EQ(num_outputs, 0UL);
+  EXPECT_THAT(status.GetErrorMessage(), testing::HasSubstr("Session is being destroyed"));
+
+  {
+    std::lock_guard<std::mutex> lock(state->mutex);
+    state->second_callback_invoked = true;
+    state->second_callback_error = status.GetErrorMessage();
+  }
+  state->cv.notify_all();
+}
+
 TEST(CApiTest, RunAsyncFail) {
   Ort::SessionOptions session_options;
   session_options.SetIntraOpNumThreads(1);  // This will cause RunAsync fail
@@ -4555,6 +4603,79 @@ TEST(CApiTest, RunAsyncFail) {
 
   Ort::RunOptions run_options;
   EXPECT_THROW(session.RunAsync(run_options, input_names, input_tensors, 1, output_names, output_values, 1, CallbackFail, nullptr), std::exception);
+}
+
+TEST(CApiTest, RunAsyncQueuedCallBlocksSessionDestruction) {
+  RunAsyncReleaseState state;
+
+  Ort::SessionOptions session_options;
+  session_options.SetIntraOpNumThreads(2);
+  auto session = std::make_unique<Ort::Session>(*ort_env, MODEL_URI, session_options);
+
+  const char* input_names[] = {"X"};
+  float x_value[] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+  int64_t x_dim[] = {3, 2};
+  auto memory_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+
+  Ort::Value input_tensors[1] = {
+      Ort::Value::CreateTensor<float>(memory_info, x_value, 6, x_dim, 2),
+  };
+
+  const char* output_names[] = {"Y"};
+  Ort::RunOptions run_options;
+  Ort::Value first_output_values[1] = {Ort::Value{nullptr}};
+  Ort::Value second_output_values[1] = {Ort::Value{nullptr}};
+
+  ASSERT_NO_THROW(session->RunAsync(run_options,
+                                    input_names,
+                                    input_tensors,
+                                    1,
+                                    output_names,
+                                    first_output_values,
+                                    1,
+                                    BlockingCallbackSucceed,
+                                    &state));
+
+  {
+    std::unique_lock<std::mutex> lock(state.mutex);
+    ASSERT_TRUE(state.cv.wait_for(lock, std::chrono::seconds(10), [&state] { return state.first_callback_started; }));
+  }
+
+  ASSERT_NO_THROW(session->RunAsync(run_options,
+                                    input_names,
+                                    input_tensors,
+                                    1,
+                                    output_names,
+                                    second_output_values,
+                                    1,
+                                    RecordShutdownCallback,
+                                    &state));
+
+  std::thread destroy_thread([&session, &state]() {
+    session.reset();
+    {
+      std::lock_guard<std::mutex> lock(state.mutex);
+      state.destroy_completed = true;
+    }
+    state.cv.notify_all();
+  });
+
+  {
+    std::unique_lock<std::mutex> lock(state.mutex);
+    EXPECT_FALSE(state.cv.wait_for(lock, std::chrono::milliseconds(100), [&state] { return state.destroy_completed; }));
+    state.allow_first_callback_finish = true;
+  }
+  state.cv.notify_all();
+
+  {
+    std::unique_lock<std::mutex> lock(state.mutex);
+    ASSERT_TRUE(state.cv.wait_for(lock, std::chrono::seconds(10), [&state] {
+      return state.second_callback_invoked && state.destroy_completed;
+    }));
+    EXPECT_THAT(state.second_callback_error, testing::HasSubstr("Session is being destroyed"));
+  }
+
+  destroy_thread.join();
 }
 
 static void TestRunWithLoraAdapter(const Ort::LoraAdapter& adapter) {


### PR DESCRIPTION
### Description

Fixes a potential Use-After-Free (UAF) when `OrtReleaseSession()` is called on one thread while `OrtRun()` is still executing on another. The existing `current_num_runs_` counter was only used for thread pool spinning control and did not prevent the destructor from proceeding while runs were in-flight.

### Changes

- **Shutdown barrier**: Added `std::atomic<bool> is_shutting_down_` to `InferenceSession`. The destructor sets this flag before tearing down any state.
- **Run rejection**: `RunImpl()` checks `is_shutting_down_` before incrementing the run counter. New `Run()` calls during shutdown return an error status instead of accessing freed memory.
- **Active run drain**: The destructor spin-waits (with `yield`) for `current_num_runs_` to reach zero before proceeding with teardown, ensuring all in-flight runs complete safely.

### Motivation

While the C API contract places object lifetime responsibility on the caller, a defensive check prevents silent memory corruption if the contract is violated. The fix is minimal and zero-cost on the happy path (single atomic load in `RunImpl`).

### Files Changed

- `onnxruntime/core/session/inference_session.h` — Added `is_shutting_down_` member
- `onnxruntime/core/session/inference_session.cc` — Drain loop in destructor, rejection check in `RunImpl()`
