### PR TITLE
[CI] Fix Linux CUDA and TensorRT CI GPU visibility and shared memory failures

### DIFF
--- a/.github/workflows/linux_cuda_ci.yml
+++ b/.github/workflows/linux_cuda_ci.yml
@@ -98,6 +98,15 @@ jobs:
       - name: Enable GPU persistence mode
         run: sudo nvidia-smi -pm 1
 
+      # Verify the GPU is accessible inside Docker before running the full test suite.
+      # If the NVIDIA Container Toolkit fails to expose /dev/nvidia* devices,
+      # tests will fail with "CUDA failure 100" and waste 10+ minutes.
+      - name: Verify GPU access in Docker
+        run: |
+          docker run --rm --gpus all \
+            "${{ steps.build_docker_image_step.outputs.full-image-name }}" \
+            nvidia-smi
+
       # Run docker directly (instead of run-build-script-in-docker action) so we can pass
       # --ipc=host. cuDNN 9.x requires adequate shared memory for handle creation; Docker's
       # default 64 MB /dev/shm causes CUDNN_STATUS_INTERNAL_ERROR when multiple test

--- a/.github/workflows/linux_cuda_ci.yml
+++ b/.github/workflows/linux_cuda_ci.yml
@@ -91,6 +91,13 @@ jobs:
           fi
 
       # --- Run Tests using the downloaded build ---
+      # Enable NVIDIA GPU persistence mode so the driver stays loaded between test
+      # processes. Without this, the GPU can become invisible after the C++ test
+      # binary exits, causing "CUDA failure 100: no CUDA-capable device" in
+      # subsequent Python tests.
+      - name: Enable GPU persistence mode
+        run: sudo nvidia-smi -pm 1
+
       # Run docker directly (instead of run-build-script-in-docker action) so we can pass
       # --ipc=host. cuDNN 9.x requires adequate shared memory for handle creation; Docker's
       # default 64 MB /dev/shm causes CUDNN_STATUS_INTERNAL_ERROR when multiple test

--- a/.github/workflows/linux_cuda_ci.yml
+++ b/.github/workflows/linux_cuda_ci.yml
@@ -91,15 +91,44 @@ jobs:
           fi
 
       # --- Run Tests using the downloaded build ---
-      # The run-build-script-in-docker action mounts ${{ runner.temp }} to /onnxruntime_src/build
-      # So build.py --build_dir build/Release inside the container correctly finds the artifacts.
+      # Run docker directly (instead of run-build-script-in-docker action) so we can pass
+      # --ipc=host. cuDNN 9.x requires adequate shared memory for handle creation; Docker's
+      # default 64 MB /dev/shm causes CUDNN_STATUS_INTERNAL_ERROR when multiple test
+      # processes create cuDNN handles in parallel.
       - name: Test ONNX Runtime
         id: test_step
-        uses: microsoft/onnxruntime-github-actions/run-build-script-in-docker@8bad63a3c05d448311dfa8e5f531171c97471aa1 # v0.0.12
-        with:
-          docker_image: ${{ steps.build_docker_image_step.outputs.full-image-name }}
-          build_config: Release
-          mode: 'test' # Set mode to test
-          execution_providers: 'cuda'
-          extra_build_flags: '--use_binskim_compliant_compile_flags --cuda_version=12.8 --cuda_home=/usr/local/cuda-12.8 --cudnn_home=/usr/local/cuda-12.8 --enable_cuda_profiling --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=86 onnxruntime_BUILD_UNIT_TESTS=ON onnxruntime_ENABLE_CUDA_EP_INTERNAL_TESTS=ON'
-          python_path_prefix: 'PATH=/opt/python/cp310-cp310/bin:$PATH'
+        run: |
+          set -e
+          # Ensure host directories exist for mounts
+          mkdir -p "$HOME/.cache" "$HOME/.onnx"
+          docker run --rm \
+            --gpus all \
+            --ipc=host \
+            --volume "${{ github.workspace }}:/onnxruntime_src" \
+            --volume "${{ runner.temp }}:/onnxruntime_src/build" \
+            --volume "$HOME/.cache:/home/onnxruntimedev/.cache" \
+            --volume "/data/onnx:/data/onnx:ro" \
+            --volume "/data/models:/data/models:ro" \
+            --volume "$HOME/.onnx:/home/onnxruntimedev/.onnx" \
+            -w /onnxruntime_src \
+            -e ALLOW_RELEASED_ONNX_OPSET_ONLY=0 \
+            -e NIGHTLY_BUILD=1 \
+            -e RUNNER_TEMP=/onnxruntime_src/build \
+            -e CCACHE_DIR=/home/onnxruntimedev/.cache/ccache \
+            "${{ steps.build_docker_image_step.outputs.full-image-name }}" \
+            /bin/bash -c "set -ex; PATH=/opt/python/cp310-cp310/bin:\$PATH && \
+              ccache --version && ccache --max-size=20GiB && ccache --zero-stats && \
+              python3 tools/ci_build/build.py \
+                --build_dir build/Release --config Release \
+                --cmake_generator Ninja \
+                --skip_submodule_sync \
+                --build_shared_lib --parallel \
+                --use_vcpkg --use_vcpkg_ms_internal_asset_cache \
+                --enable_onnx_tests \
+                --use_cuda \
+                --use_binskim_compliant_compile_flags \
+                --cuda_version=12.8 --cuda_home=/usr/local/cuda-12.8 --cudnn_home=/usr/local/cuda-12.8 \
+                --enable_cuda_profiling \
+                --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=86 onnxruntime_BUILD_UNIT_TESTS=ON onnxruntime_ENABLE_CUDA_EP_INTERNAL_TESTS=ON \
+                --test && \
+              ccache --show-stats"

--- a/.github/workflows/linux_tensorrt_ci.yml
+++ b/.github/workflows/linux_tensorrt_ci.yml
@@ -93,6 +93,13 @@ jobs:
           fi
 
       # --- Run Tests using the downloaded build ---
+      # Enable NVIDIA GPU persistence mode so the driver stays loaded between test
+      # processes. Without this, the GPU can become invisible after the C++ test
+      # binary exits, causing "CUDA failure 100: no CUDA-capable device" in
+      # subsequent Python tests.
+      - name: Enable GPU persistence mode
+        run: sudo nvidia-smi -pm 1
+
       # Run docker directly (instead of run-build-script-in-docker action) so we can pass
       # --ipc=host. cuDNN 9.x requires adequate shared memory for handle creation; Docker's
       # default 64 MB /dev/shm causes CUDNN_STATUS_INTERNAL_ERROR when multiple test

--- a/.github/workflows/linux_tensorrt_ci.yml
+++ b/.github/workflows/linux_tensorrt_ci.yml
@@ -93,15 +93,47 @@ jobs:
           fi
 
       # --- Run Tests using the downloaded build ---
-      # The run-build-script-in-docker action mounts ${{ runner.temp }} to /onnxruntime_src/build
-      # So build.py --build_dir build/Release inside the container correctly finds the artifacts.
+      # Run docker directly (instead of run-build-script-in-docker action) so we can pass
+      # --ipc=host. cuDNN 9.x requires adequate shared memory for handle creation; Docker's
+      # default 64 MB /dev/shm causes CUDNN_STATUS_INTERNAL_ERROR when multiple test
+      # processes create cuDNN handles in parallel.
       - name: Test ONNX Runtime
         id: test_step
-        uses: microsoft/onnxruntime-github-actions/run-build-script-in-docker@8bad63a3c05d448311dfa8e5f531171c97471aa1 # v0.0.12
-        with:
-          docker_image: ${{ steps.build_docker_image_step.outputs.full-image-name }}
-          build_config: Release
-          mode: 'test' # Set mode to test
-          execution_providers: 'cuda tensorrt'
-          extra_build_flags: '--use_binskim_compliant_compile_flags --build_wheel --cuda_version=12.8 --cuda_home=/usr/local/cuda-12.8 --cudnn_home=/usr/local/cuda-12.8 --use_tensorrt --tensorrt_home /usr  --build_java --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=86 onnxruntime_BUILD_UNIT_TESTS=ON onnxruntime_ENABLE_CUDA_EP_INTERNAL_TESTS=ON'
-          python_path_prefix: 'PATH=/opt/python/cp310-cp310/bin:$PATH'
+        run: |
+          set -e
+          # Ensure host directories exist for mounts
+          mkdir -p "$HOME/.cache" "$HOME/.onnx"
+          docker run --rm \
+            --gpus all \
+            --ipc=host \
+            --volume "${{ github.workspace }}:/onnxruntime_src" \
+            --volume "${{ runner.temp }}:/onnxruntime_src/build" \
+            --volume "$HOME/.cache:/home/onnxruntimedev/.cache" \
+            --volume "/data/onnx:/data/onnx:ro" \
+            --volume "/data/models:/data/models:ro" \
+            --volume "$HOME/.onnx:/home/onnxruntimedev/.onnx" \
+            -w /onnxruntime_src \
+            -e ALLOW_RELEASED_ONNX_OPSET_ONLY=0 \
+            -e NIGHTLY_BUILD=1 \
+            -e RUNNER_TEMP=/onnxruntime_src/build \
+            -e CCACHE_DIR=/home/onnxruntimedev/.cache/ccache \
+            "${{ steps.build_docker_image_step.outputs.full-image-name }}" \
+            /bin/bash -c "set -ex; PATH=/opt/python/cp310-cp310/bin:\$PATH && \
+              ccache --version && ccache --max-size=20GiB && ccache --zero-stats && \
+              python3 -m pip install --user -r tools/ci_build/github/linux/python/requirements.txt && \
+              python3 tools/ci_build/build.py \
+                --build_dir build/Release --config Release \
+                --cmake_generator Ninja \
+                --skip_submodule_sync \
+                --build_shared_lib --parallel \
+                --use_vcpkg --use_vcpkg_ms_internal_asset_cache \
+                --enable_onnx_tests \
+                --use_cuda --use_tensorrt \
+                --use_binskim_compliant_compile_flags \
+                --build_wheel \
+                --cuda_version=12.8 --cuda_home=/usr/local/cuda-12.8 --cudnn_home=/usr/local/cuda-12.8 \
+                --use_tensorrt --tensorrt_home /usr \
+                --build_java \
+                --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=86 onnxruntime_BUILD_UNIT_TESTS=ON onnxruntime_ENABLE_CUDA_EP_INTERNAL_TESTS=ON \
+                --test && \
+              ccache --show-stats"

--- a/.github/workflows/linux_tensorrt_ci.yml
+++ b/.github/workflows/linux_tensorrt_ci.yml
@@ -100,6 +100,15 @@ jobs:
       - name: Enable GPU persistence mode
         run: sudo nvidia-smi -pm 1
 
+      # Verify the GPU is accessible inside Docker before running the full test suite.
+      # If the NVIDIA Container Toolkit fails to expose /dev/nvidia* devices,
+      # tests will fail with "CUDA failure 100" and waste 10+ minutes.
+      - name: Verify GPU access in Docker
+        run: |
+          docker run --rm --gpus all \
+            "${{ steps.build_docker_image_step.outputs.full-image-name }}" \
+            nvidia-smi
+
       # Run docker directly (instead of run-build-script-in-docker action) so we can pass
       # --ipc=host. cuDNN 9.x requires adequate shared memory for handle creation; Docker's
       # default 64 MB /dev/shm causes CUDNN_STATUS_INTERNAL_ERROR when multiple test


### PR DESCRIPTION
# PR: [CI] Fix Linux CUDA and TensorRT CI GPU visibility and shared memory failures

## Description

Fix two root causes of persistent test failures in the Linux CUDA CI and Linux TensorRT CI pipelines on A10 GPU runners:

1. **GPU disappears between test processes** — Without NVIDIA persistence mode, the GPU driver unloads when the C++ test binary (`onnxruntime_provider_test`) exits, making the GPU invisible to the subsequent Python test process (`onnxruntime_test_python.py`). This causes `CUDA failure 100: no CUDA-capable device is detected` across all Python tests.
2. **cuDNN shared memory exhaustion** — cuDNN 9.x requires more shared memory than Docker's default 64 MB `/dev/shm` for `cudnnCreate()`. When `ctest` runs multiple test binaries in parallel, concurrent handle creation exhausts shared memory, causing `CUDNN_STATUS_INTERNAL_ERROR`.

## Summary of Changes

### CI Workflow Changes

| File | Change |
|------|--------|
| `.github/workflows/linux_tensorrt_ci.yml` | Add `nvidia-smi -pm 1` step to enable GPU persistence mode before tests |
| `.github/workflows/linux_tensorrt_ci.yml` | Replace `run-build-script-in-docker` action with direct `docker run --ipc=host` |
| `.github/workflows/linux_cuda_ci.yml` | Add `nvidia-smi -pm 1` step to enable GPU persistence mode before tests |
| `.github/workflows/linux_cuda_ci.yml` | Replace `run-build-script-in-docker` action with direct `docker run --ipc=host` |

The direct `docker run` commands are functionally identical to what the action generated (same mounts, env vars, build.py flags), with the addition of `--gpus all`, `--ipc=host`, and the persistence mode step.

## Root Cause Analysis

### GPU Visibility (primary failure)

From the CI log:
- **C++ tests** (`ctest`): Device discovery finds `Discovered OrtHardwareDevice {vendor_id:0x10de, device_id:0x2236}` (NVIDIA A10). All 11 C++ test binaries pass (5203 tests, 0 failures).
- **Python tests** (0.4s later): Device discovery finds NO NVIDIA GPU. `cudaSetDevice(0)` returns error 100. All 34 CUDA/TRT Python tests fail.

The A10 runner pool (`onnxruntime-github-linux-a10`) does not have GPU persistence mode enabled. When the last CUDA process exits, the driver fully unloads and the GPU drops off the PCI bus / DRM sysfs. `nvidia-smi -pm 1` keeps the driver loaded between processes.

### cuDNN Shared Memory (secondary failure)

cuDNN 9.x (v9.8.0) uses shared memory for inter-process coordination during handle creation. Docker's default 64 MB `/dev/shm` is insufficient when multiple test binaries create cuDNN handles in parallel. `--ipc=host` gives the container access to the host's shared memory namespace.

## Testing

- The fix is CI-only; no runtime code changes.
- Verify by running the TensorRT CI and CUDA CI pipelines on a PR targeting `main`.
- Expected result: All C++ and Python tests pass without `CUDA failure 100` or `CUDNN_STATUS_INTERNAL_ERROR`.

## Motivation and Context

Both pipelines moved from H100 runners to A10 runners (commit `6379acbc6b`). H100 data center GPUs typically have persistence mode enabled by default; the A10 pool does not. The `run-build-script-in-docker` action does not expose `extra_docker_args`, so `--ipc=host` could not be passed through it.
