### PR TITLE
fix: linearAttension's shape inference

### DIFF
--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -2427,7 +2427,7 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
             // H_q * d_v: d_v = value.dim(2) / kv_num_heads, then H_q * d_v
             if (value_shape.dim(2).has_dim_value()) {
               int64_t d_v = value_shape.dim(2).dim_value() / kv_num_heads;
-              output_shape.add_dim()->set_dim_value(kv_num_heads * d_v);
+              output_shape.add_dim()->set_dim_value(q_num_heads * d_v);
             } else {
               output_shape.add_dim();  // unknown
             }


### PR DESCRIPTION
### Description
The output shape defined in [ContribOperators](https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#com.microsoft.LinearAttention) is inconsistent with the result inferred by shape inference, which causes the shape to become unknown.



### Motivation and Context
Try to correct this shape inference


