### PR TITLE
[CoreML EP] Add QuickGelu support

### DIFF
--- a/onnxruntime/core/providers/coreml/builders/impl/quick_gelu_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/quick_gelu_op_builder.cc
@@ -35,6 +35,11 @@ class QuickGeluOpBuilder : public BaseOpBuilder {
 Status QuickGeluOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
                                                  const Node& node,
                                                  const logging::Logger& logger) const {
+  // IsOpSupportedImpl gates this, but fail fast rather than silently produce an
+  // invalid model if the path is ever reached without MLProgram.
+  ORT_RETURN_IF_NOT(model_builder.CreateMLProgram(),
+                    "QuickGelu is only supported by the CoreML EP in MLProgram format");
+
   NodeAttrHelper helper(node);
   const float alpha = helper.Get("alpha", 1.702f);
 
@@ -45,7 +50,7 @@ Status QuickGeluOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
   std::vector<int64_t> x_shape;
   ORT_RETURN_IF_NOT(GetShape(*node.InputDefs()[0], x_shape, logger), "Failed to get QuickGelu input shape");
 
-  if (model_builder.CreateMLProgram()) {
+  {
     using namespace CoreML::Specification::MILSpec;
 
     // When alpha ≈ 1.0 (e.g. CLIP's approximate GELU, `x * sigmoid(x)`), skip
@@ -93,11 +98,25 @@ Status QuickGeluOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
   return Status::OK();
 }
 
-bool QuickGeluOpBuilder::IsOpSupportedImpl(const Node& /*node*/, const OpBuilderInputParams& input_params,
-                                           const logging::Logger& /*logger*/) const {
+bool QuickGeluOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputParams& input_params,
+                                           const logging::Logger& logger) const {
   // Only the MLProgram path is implemented. NeuralNetwork format is deprecated
   // on Apple Silicon and not worth carrying a second implementation for.
-  return input_params.create_mlprogram;
+  if (!input_params.create_mlprogram) {
+    LOGS(logger, VERBOSE) << "QuickGelu: only MLProgram format is supported by the CoreML EP";
+    return false;
+  }
+
+  // AddToModelBuilderImpl requires the input shape to size intermediate MIL
+  // outputs, so check here and fall back to CPU if shape inference was
+  // incomplete — don't claim the node and then fail at model-build time.
+  std::vector<int64_t> x_shape;
+  if (!GetShape(*node.InputDefs()[0], x_shape, logger)) {
+    LOGS(logger, VERBOSE) << "QuickGelu: failed to get input shape";
+    return false;
+  }
+
+  return true;
 }
 
 void CreateQuickGeluOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {

--- a/onnxruntime/core/providers/coreml/builders/impl/quick_gelu_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/quick_gelu_op_builder.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <cmath>
+
 #include "core/providers/common.h"
 #include "core/providers/coreml/builders/helper.h"
 #include "core/providers/coreml/builders/impl/base_op_builder.h"
@@ -46,31 +48,44 @@ Status QuickGeluOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
   if (model_builder.CreateMLProgram()) {
     using namespace CoreML::Specification::MILSpec;
 
-    // 1. alpha_x = mul(x, alpha)
-    auto mul_alpha = model_builder.CreateOperation(node, "mul", "alpha");
-    AddOperationInput(*mul_alpha, "x", x_name);
-    if (input_dtype == ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {
-      AddOperationInput(*mul_alpha, "y", model_builder.AddScalarConstant(mul_alpha->type(), "alpha", alpha));
-    } else {
-      AddOperationInput(*mul_alpha, "y",
-                        model_builder.AddScalarConstant(mul_alpha->type(), "alpha", MLFloat16(alpha)));
-    }
-    const std::string& alpha_x_name = model_builder.GetUniqueName(node, "quick_gelu_alpha_x");
-    AddIntermediateOperationOutput(*mul_alpha, alpha_x_name, elem_type, x_shape);
+    // When alpha ≈ 1.0 (e.g. CLIP's approximate GELU, `x * sigmoid(x)`), skip
+    // the leading mul and feed x straight into sigmoid. Saves one op and
+    // avoids the rounding it would introduce. Mirrors QNN's builder at
+    // qnn/builder/opbuilder/quick_gelu_op_builder.cc:42-49.
+    constexpr float kAlphaEpsilon = 1e-6f;
+    const bool skip_alpha_mul = std::abs(alpha - 1.0f) < kAlphaEpsilon;
 
-    // 2. sig = sigmoid(alpha_x)
+    std::string sigmoid_input_name = x_name;
+    std::unique_ptr<Operation> mul_alpha;
+    if (!skip_alpha_mul) {
+      // alpha_x = mul(x, alpha)
+      mul_alpha = model_builder.CreateOperation(node, "mul", "alpha");
+      AddOperationInput(*mul_alpha, "x", x_name);
+      if (input_dtype == ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {
+        AddOperationInput(*mul_alpha, "y", model_builder.AddScalarConstant(mul_alpha->type(), "alpha", alpha));
+      } else {
+        AddOperationInput(*mul_alpha, "y",
+                          model_builder.AddScalarConstant(mul_alpha->type(), "alpha", MLFloat16(alpha)));
+      }
+      sigmoid_input_name = model_builder.GetUniqueName(node, "quick_gelu_alpha_x");
+      AddIntermediateOperationOutput(*mul_alpha, sigmoid_input_name, elem_type, x_shape);
+    }
+
+    // sig = sigmoid(sigmoid_input)
     auto sig = model_builder.CreateOperation(node, "sigmoid");
-    AddOperationInput(*sig, "x", alpha_x_name);
+    AddOperationInput(*sig, "x", sigmoid_input_name);
     const std::string& sig_name = model_builder.GetUniqueName(node, "quick_gelu_sigmoid");
     AddIntermediateOperationOutput(*sig, sig_name, elem_type, x_shape);
 
-    // 3. y = mul(x, sig)
+    // y = mul(x, sig)
     auto mul_final = model_builder.CreateOperation(node, "mul", "final");
     AddOperationInput(*mul_final, "x", x_name);
     AddOperationInput(*mul_final, "y", sig_name);
     AddOperationOutput(*mul_final, *node.OutputDefs()[0]);
 
-    model_builder.AddOperation(std::move(mul_alpha));
+    if (mul_alpha) {
+      model_builder.AddOperation(std::move(mul_alpha));
+    }
     model_builder.AddOperation(std::move(sig));
     model_builder.AddOperation(std::move(mul_final));
   }

--- a/onnxruntime/core/providers/coreml/builders/impl/quick_gelu_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/quick_gelu_op_builder.cc
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/common.h"
+#include "core/providers/coreml/builders/helper.h"
+#include "core/providers/coreml/builders/impl/base_op_builder.h"
+#include "core/providers/coreml/builders/impl/builder_utils.h"
+#include "core/providers/coreml/builders/model_builder.h"
+#include "core/providers/coreml/builders/op_builder_factory.h"
+#include "core/providers/coreml/shape_utils.h"
+#include "core/providers/shared/utils/utils.h"
+
+namespace onnxruntime {
+namespace coreml {
+
+// com.microsoft:QuickGelu is produced by ORT's QuickGeluFusion pass
+// (onnxruntime/core/optimizer/quick_gelu_fusion.cc) at optimization level
+// ORT_ENABLE_EXTENDED and above. The schema in contrib_defs.cc defines it as
+//     Y = X * Sigmoid(alpha * X)    default alpha = 1.702
+// CoreML has no native equivalent, so we decompose to three MIL ops — all
+// primitives are already CoreML-supported. Same approach the QNN EP uses
+// in qnn/builder/opbuilder/quick_gelu_op_builder.cc.
+class QuickGeluOpBuilder : public BaseOpBuilder {
+  Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node,
+                               const logging::Logger& logger) const override;
+
+  bool IsOpSupportedImpl(const Node& node, const OpBuilderInputParams& input_params,
+                         const logging::Logger& logger) const override;
+
+  bool SupportsMLProgram() const override { return true; }
+};
+
+Status QuickGeluOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
+                                                 const Node& node,
+                                                 const logging::Logger& logger) const {
+  NodeAttrHelper helper(node);
+  const float alpha = helper.Get("alpha", 1.702f);
+
+  const auto input_dtype = node.InputDefs()[0]->TypeAsProto()->tensor_type().elem_type();
+  const int32_t elem_type = static_cast<int32_t>(input_dtype);
+  const std::string& x_name = node.InputDefs()[0]->Name();
+
+  std::vector<int64_t> x_shape;
+  ORT_RETURN_IF_NOT(GetShape(*node.InputDefs()[0], x_shape, logger), "Failed to get QuickGelu input shape");
+
+  if (model_builder.CreateMLProgram()) {
+    using namespace CoreML::Specification::MILSpec;
+
+    // 1. alpha_x = mul(x, alpha)
+    auto mul_alpha = model_builder.CreateOperation(node, "mul", "alpha");
+    AddOperationInput(*mul_alpha, "x", x_name);
+    if (input_dtype == ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {
+      AddOperationInput(*mul_alpha, "y", model_builder.AddScalarConstant(mul_alpha->type(), "alpha", alpha));
+    } else {
+      AddOperationInput(*mul_alpha, "y",
+                        model_builder.AddScalarConstant(mul_alpha->type(), "alpha", MLFloat16(alpha)));
+    }
+    const std::string& alpha_x_name = model_builder.GetUniqueName(node, "quick_gelu_alpha_x");
+    AddIntermediateOperationOutput(*mul_alpha, alpha_x_name, elem_type, x_shape);
+
+    // 2. sig = sigmoid(alpha_x)
+    auto sig = model_builder.CreateOperation(node, "sigmoid");
+    AddOperationInput(*sig, "x", alpha_x_name);
+    const std::string& sig_name = model_builder.GetUniqueName(node, "quick_gelu_sigmoid");
+    AddIntermediateOperationOutput(*sig, sig_name, elem_type, x_shape);
+
+    // 3. y = mul(x, sig)
+    auto mul_final = model_builder.CreateOperation(node, "mul", "final");
+    AddOperationInput(*mul_final, "x", x_name);
+    AddOperationInput(*mul_final, "y", sig_name);
+    AddOperationOutput(*mul_final, *node.OutputDefs()[0]);
+
+    model_builder.AddOperation(std::move(mul_alpha));
+    model_builder.AddOperation(std::move(sig));
+    model_builder.AddOperation(std::move(mul_final));
+  }
+
+  return Status::OK();
+}
+
+bool QuickGeluOpBuilder::IsOpSupportedImpl(const Node& /*node*/, const OpBuilderInputParams& input_params,
+                                           const logging::Logger& /*logger*/) const {
+  // Only the MLProgram path is implemented. NeuralNetwork format is deprecated
+  // on Apple Silicon and not worth carrying a second implementation for.
+  return input_params.create_mlprogram;
+}
+
+void CreateQuickGeluOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
+  op_registrations.builders.push_back(std::make_unique<QuickGeluOpBuilder>());
+  op_registrations.op_builder_map.emplace(op_type, op_registrations.builders.back().get());
+}
+
+}  // namespace coreml
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/coreml/builders/op_builder_factory.cc
+++ b/onnxruntime/core/providers/coreml/builders/op_builder_factory.cc
@@ -26,6 +26,9 @@ static OpBuilderRegistrations CreateOpBuilderRegistrations() {
   CreateActivationOpBuilder("Elu", op_registrations);
   CreateActivationOpBuilder("HardSigmoid", op_registrations);
 
+  // Microsoft-domain ops produced by ORT's own optimizer passes
+  CreateQuickGeluOpBuilder("QuickGelu", op_registrations);
+
   // Unary ops
   CreateUnaryOpBuilder("Erf", op_registrations);
   CreateUnaryOpBuilder("Reciprocal", op_registrations);

--- a/onnxruntime/core/providers/coreml/builders/op_builder_factory.h
+++ b/onnxruntime/core/providers/coreml/builders/op_builder_factory.h
@@ -44,6 +44,7 @@ void CreateSplitOpBuilder(const std::string& op_type, OpBuilderRegistrations& op
 void CreateSqueezeOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateTransposeOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateUnaryOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+void CreateQuickGeluOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 
 }  // namespace coreml
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/coreml/coreml_basic_test.cc
+++ b/onnxruntime/test/providers/coreml/coreml_basic_test.cc
@@ -1017,6 +1017,75 @@ TEST(CoreMLExecutionProviderTest, QuickGeluTest) {
 #endif
 }
 
+TEST(CoreMLExecutionProviderTest, QuickGeluTestAlphaOne) {
+  // alpha == 1.0 triggers the "skip leading mul" optimization in the op
+  // builder. Verify correctness on that branch — the emitted MIL graph is
+  // sigmoid(x) -> mul(x, sigmoid(x)) instead of the 3-op decomposition.
+  ONNX_NAMESPACE::ModelProto model_proto;
+  model_proto.set_ir_version(ONNX_NAMESPACE::IR_VERSION);
+  auto* onnx_opset = model_proto.add_opset_import();
+  onnx_opset->set_domain("");
+  onnx_opset->set_version(13);
+  auto* ms_opset = model_proto.add_opset_import();
+  ms_opset->set_domain("com.microsoft");
+  ms_opset->set_version(1);
+
+  auto* graph_proto = model_proto.mutable_graph();
+  graph_proto->set_name("quick_gelu_alpha_one_test");
+
+  auto* input = graph_proto->add_input();
+  input->set_name("X");
+  auto* input_shape = input->mutable_type()->mutable_tensor_type()->mutable_shape();
+  input->mutable_type()->mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  input_shape->add_dim()->set_dim_value(1);
+  input_shape->add_dim()->set_dim_value(3);
+  input_shape->add_dim()->set_dim_value(2);
+  input_shape->add_dim()->set_dim_value(4);
+
+  auto* output = graph_proto->add_output();
+  output->set_name("Y");
+  auto* output_shape = output->mutable_type()->mutable_tensor_type()->mutable_shape();
+  output->mutable_type()->mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  output_shape->add_dim()->set_dim_value(1);
+  output_shape->add_dim()->set_dim_value(3);
+  output_shape->add_dim()->set_dim_value(2);
+  output_shape->add_dim()->set_dim_value(4);
+
+  auto* node = graph_proto->add_node();
+  node->set_op_type("QuickGelu");
+  node->set_domain("com.microsoft");
+  node->add_input("X");
+  node->add_output("Y");
+  auto* alpha_attr = node->add_attribute();
+  alpha_attr->set_name("alpha");
+  alpha_attr->set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_FLOAT);
+  alpha_attr->set_f(1.0f);
+
+  std::string model_data;
+  ASSERT_TRUE(model_proto.SerializeToString(&model_data));
+  gsl::span<const std::byte> model_span{reinterpret_cast<const std::byte*>(model_data.data()), model_data.size()};
+
+#if defined(__APPLE__)
+  std::vector<int64_t> dims = {1, 3, 2, 4};
+  std::vector<float> input_data = {-10.0f, -3.0f, -1.0f, -0.5f, 0.0f, 0.5f, 1.0f, 3.0f,
+                                   10.0f, -5.0f, 5.0f, 2.0f, -2.0f, 4.0f, -4.0f, 0.25f,
+                                   -0.25f, 7.0f, -7.0f, 1.5f, -1.5f, 0.1f, -0.1f, 20.0f};
+  OrtValue ml_value_x;
+  AllocatorPtr allocator = CPUAllocator::DefaultInstance();
+  CreateMLValue<float>(allocator, dims, input_data, &ml_value_x);
+
+  NameMLValMap feeds;
+  feeds.insert(std::make_pair("X", ml_value_x));
+
+  RunAndVerifyOutputsWithEP(model_span, "QuickGeluTestAlphaOne_MLProgram",
+                            MakeCoreMLExecutionProvider("MLProgram"),
+                            feeds,
+                            EPVerificationParams{ExpectedEPNodeAssignment::All});
+#else
+  TestModelLoad(model_span, MakeCoreMLExecutionProvider("MLProgram"), ExpectedEPNodeAssignment::All);
+#endif
+}
+
 TEST(CoreMLExecutionProviderTest, QuickGeluTestFp16) {
   // FLOAT16 variant of QuickGeluTest. Exercises the MLFloat16 branch of the
   // alpha-scalar wiring in QuickGeluOpBuilder::AddToModelBuilderImpl.

--- a/onnxruntime/test/providers/coreml/coreml_basic_test.cc
+++ b/onnxruntime/test/providers/coreml/coreml_basic_test.cc
@@ -1017,6 +1017,84 @@ TEST(CoreMLExecutionProviderTest, QuickGeluTest) {
 #endif
 }
 
+TEST(CoreMLExecutionProviderTest, QuickGeluTestFp16) {
+  // FLOAT16 variant of QuickGeluTest. Exercises the MLFloat16 branch of the
+  // alpha-scalar wiring in QuickGeluOpBuilder::AddToModelBuilderImpl.
+  ONNX_NAMESPACE::ModelProto model_proto;
+  model_proto.set_ir_version(ONNX_NAMESPACE::IR_VERSION);
+  auto* onnx_opset = model_proto.add_opset_import();
+  onnx_opset->set_domain("");
+  onnx_opset->set_version(13);
+  auto* ms_opset = model_proto.add_opset_import();
+  ms_opset->set_domain("com.microsoft");
+  ms_opset->set_version(1);
+
+  auto* graph_proto = model_proto.mutable_graph();
+  graph_proto->set_name("quick_gelu_fp16_test");
+
+  auto* input = graph_proto->add_input();
+  input->set_name("X");
+  auto* input_shape = input->mutable_type()->mutable_tensor_type()->mutable_shape();
+  input->mutable_type()->mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT16);
+  input_shape->add_dim()->set_dim_value(1);
+  input_shape->add_dim()->set_dim_value(3);
+  input_shape->add_dim()->set_dim_value(2);
+  input_shape->add_dim()->set_dim_value(4);
+
+  auto* output = graph_proto->add_output();
+  output->set_name("Y");
+  auto* output_shape = output->mutable_type()->mutable_tensor_type()->mutable_shape();
+  output->mutable_type()->mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT16);
+  output_shape->add_dim()->set_dim_value(1);
+  output_shape->add_dim()->set_dim_value(3);
+  output_shape->add_dim()->set_dim_value(2);
+  output_shape->add_dim()->set_dim_value(4);
+
+  auto* node = graph_proto->add_node();
+  node->set_op_type("QuickGelu");
+  node->set_domain("com.microsoft");
+  node->add_input("X");
+  node->add_output("Y");
+  auto* alpha_attr = node->add_attribute();
+  alpha_attr->set_name("alpha");
+  alpha_attr->set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_FLOAT);
+  alpha_attr->set_f(1.5f);
+
+  std::string model_data;
+  ASSERT_TRUE(model_proto.SerializeToString(&model_data));
+  gsl::span<const std::byte> model_span{reinterpret_cast<const std::byte*>(model_data.data()), model_data.size()};
+
+#if defined(__APPLE__)
+  std::vector<int64_t> dims = {1, 3, 2, 4};
+  const std::vector<float> input_floats = {-10.0f, -3.0f, -1.0f, -0.5f, 0.0f, 0.5f, 1.0f, 3.0f,
+                                           10.0f, -5.0f, 5.0f, 2.0f, -2.0f, 4.0f, -4.0f, 0.25f,
+                                           -0.25f, 7.0f, -7.0f, 1.5f, -1.5f, 0.1f, -0.1f, 20.0f};
+  std::vector<MLFloat16> input_data;
+  input_data.reserve(input_floats.size());
+  for (float f : input_floats) input_data.emplace_back(f);
+
+  OrtValue ml_value_x;
+  AllocatorPtr allocator = CPUAllocator::DefaultInstance();
+  CreateMLValue<MLFloat16>(allocator, dims, input_data, &ml_value_x);
+
+  NameMLValMap feeds;
+  feeds.insert(std::make_pair("X", ml_value_x));
+
+  EPVerificationParams params{};
+  params.ep_node_assignment = ExpectedEPNodeAssignment::All;
+  // fp16 accumulates larger absolute error than fp32 across the three-op
+  // decomposition (mul, sigmoid, mul). Outputs are bounded by |x|, max ~20 in
+  // this test; fp16 ulp at that magnitude is ~0.01, so 2e-2 leaves headroom.
+  params.fp32_abs_err = 2e-2f;
+
+  RunAndVerifyOutputsWithEP(model_span, "QuickGeluTestFp16_MLProgram",
+                            MakeCoreMLExecutionProvider("MLProgram"),
+                            feeds, params);
+#else
+  TestModelLoad(model_span, MakeCoreMLExecutionProvider("MLProgram"), ExpectedEPNodeAssignment::All);
+#endif
+}
+
 #endif  // !(ORT_MINIMAL_BUILD)
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/coreml/coreml_basic_test.cc
+++ b/onnxruntime/test/providers/coreml/coreml_basic_test.cc
@@ -946,6 +946,77 @@ TEST(CoreMLExecutionProviderTest, HardSigmoidTest) {
   TestModelLoad(model_span, MakeCoreMLExecutionProvider("MLProgram"), ExpectedEPNodeAssignment::All);
 #endif
 }
+
+TEST(CoreMLExecutionProviderTest, QuickGeluTest) {
+  // Single com.microsoft:QuickGelu node (produced by ORT's QuickGeluFusion pass
+  // from the pattern x * sigmoid(alpha * x)). Verify the CoreML MLProgram path
+  // claims the whole graph and produces the same output as CPU.
+  ONNX_NAMESPACE::ModelProto model_proto;
+  model_proto.set_ir_version(ONNX_NAMESPACE::IR_VERSION);
+  auto* onnx_opset = model_proto.add_opset_import();
+  onnx_opset->set_domain("");
+  onnx_opset->set_version(13);
+  auto* ms_opset = model_proto.add_opset_import();
+  ms_opset->set_domain("com.microsoft");
+  ms_opset->set_version(1);
+
+  auto* graph_proto = model_proto.mutable_graph();
+  graph_proto->set_name("quick_gelu_test");
+
+  auto* input = graph_proto->add_input();
+  input->set_name("X");
+  auto* input_shape = input->mutable_type()->mutable_tensor_type()->mutable_shape();
+  input->mutable_type()->mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  input_shape->add_dim()->set_dim_value(1);
+  input_shape->add_dim()->set_dim_value(3);
+  input_shape->add_dim()->set_dim_value(2);
+  input_shape->add_dim()->set_dim_value(4);
+
+  auto* output = graph_proto->add_output();
+  output->set_name("Y");
+  auto* output_shape = output->mutable_type()->mutable_tensor_type()->mutable_shape();
+  output->mutable_type()->mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  output_shape->add_dim()->set_dim_value(1);
+  output_shape->add_dim()->set_dim_value(3);
+  output_shape->add_dim()->set_dim_value(2);
+  output_shape->add_dim()->set_dim_value(4);
+
+  auto* node = graph_proto->add_node();
+  node->set_op_type("QuickGelu");
+  node->set_domain("com.microsoft");
+  node->add_input("X");
+  node->add_output("Y");
+  // Use a non-default alpha so the test catches any attribute-wiring bug.
+  auto* alpha_attr = node->add_attribute();
+  alpha_attr->set_name("alpha");
+  alpha_attr->set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_FLOAT);
+  alpha_attr->set_f(1.5f);
+
+  std::string model_data;
+  ASSERT_TRUE(model_proto.SerializeToString(&model_data));
+  gsl::span<const std::byte> model_span{reinterpret_cast<const std::byte*>(model_data.data()), model_data.size()};
+
+#if defined(__APPLE__)
+  std::vector<int64_t> dims = {1, 3, 2, 4};
+  std::vector<float> input_data = {-10.0f, -3.0f, -1.0f, -0.5f, 0.0f, 0.5f, 1.0f, 3.0f,
+                                   10.0f, -5.0f, 5.0f, 2.0f, -2.0f, 4.0f, -4.0f, 0.25f,
+                                   -0.25f, 7.0f, -7.0f, 1.5f, -1.5f, 0.1f, -0.1f, 20.0f};
+  OrtValue ml_value_x;
+  AllocatorPtr allocator = CPUAllocator::DefaultInstance();
+  CreateMLValue<float>(allocator, dims, input_data, &ml_value_x);
+
+  NameMLValMap feeds;
+  feeds.insert(std::make_pair("X", ml_value_x));
+
+  RunAndVerifyOutputsWithEP(model_span, "QuickGeluTest_MLProgram",
+                            MakeCoreMLExecutionProvider("MLProgram"),
+                            feeds,
+                            EPVerificationParams{ExpectedEPNodeAssignment::All});
+#else
+  TestModelLoad(model_span, MakeCoreMLExecutionProvider("MLProgram"), ExpectedEPNodeAssignment::All);
+#endif
+}
+
 #endif  // !(ORT_MINIMAL_BUILD)
 }  // namespace test
 }  // namespace onnxruntime

--- a/tools/ci_build/github/apple/coreml_supported_mlprogram_ops.md
+++ b/tools/ci_build/github/apple/coreml_supported_mlprogram_ops.md
@@ -52,3 +52,4 @@ Keep in sync with doco generated from /docs/execution-providers/CoreML-Execution
 |ai.onnx:Tanh||
 |ai.onnx:Transpose||
 |ai.onnx:Unsqueeze||
+|com.microsoft:QuickGelu|Produced by ORT's `QuickGeluFusion` optimizer pass. Decomposed into `mul` / `sigmoid` / `mul`.|


### PR DESCRIPTION
### Description

Adds support for `com.microsoft:QuickGelu` (`x * Sigmoid(alpha * x)`) to the CoreML Execution Provider's MLProgram path. The builder decomposes QuickGelu into three MIL ops (`mul` / `sigmoid` / `mul`), matching the op's own schema function-body in `contrib_defs.cc:605-631` and the approach the QNN EP already uses in `qnn/builder/opbuilder/quick_gelu_op_builder.cc`. Only the MLProgram path is implemented; NeuralNetwork is deprecated on Apple Silicon.

Adds `CoreMLExecutionProviderTest.QuickGeluTest` which builds a single `com.microsoft:QuickGelu` node with non-default `alpha=1.5` and verifies the entire graph is claimed by the CoreML EP via `ExpectedEPNodeAssignment::All`. Verified with a negative test: temporarily removing the `CreateQuickGeluOpBuilder` registration causes the new test to fail with a `VerifyEPNodeAssignment` fatal failure, proving it genuinely exercises the CoreML path.

Also updates `coreml_supported_mlprogram_ops.md`.

### Motivation and Context

Fixes #28183.

QuickGelu is produced by ORT's own `QuickGeluFusion` optimizer pass (`onnxruntime/core/optimizer/quick_gelu_fusion.cc`), which runs at `ORT_ENABLE_EXTENDED` — and therefore also at `ORT_ENABLE_ALL`, the default session optimization level. So any model that contains the `x * sigmoid(alpha * x)` pattern (CLIP, several mobile transformers, the DWPose pose estimator) gets silently mutated by ORT into a graph with `QuickGelu` nodes that the CoreML EP then rejects — turning 3 supported primitives into 1 unsupported op, making the fusion strictly harmful for CoreML.

On the DWPose `dw-ll_ucoco_384.onnx` model with batch=1 and `ORT_ENABLE_EXTENDED`, 76 `QuickGelu` nodes get produced. Running the result on the CoreML EP:

| ORT build | CoreML subgraphs | Inference (ms) |
| --- | --- | --- |
| main (QuickGelu rejected) | ~80 (each QuickGelu is a graph break) | 54.77 |
| this PR (QuickGelu supported) | 10 | 13.91 |

The remaining breaks are other ops — see "Related gaps" below. A ~4× speedup at EXTENDED level from this patch alone.

Even at the default `ORT_ENABLE_ALL` with a symbolic batch dim (where partial shape inference inhibits most fusions), 3 `QuickGelu` nodes still get produced — so this patch helps any CoreML user who hasn't explicitly downgraded to `ORT_ENABLE_BASIC`.

### Related CoreML EP gaps observed (out of scope for this PR)

With QuickGelu fixed, the remaining 9 CPU-fallback nodes on the EXTENDED-optimized DWPose pose model are:

- **`com.microsoft:FusedConv`** (×4) — produced by `ConvActivationFusion`. Fuses `Conv + activation` into one node. Same failure mode as QuickGelu: `Conv` and the activations (`Relu`, `Sigmoid`, `HardSigmoid`, etc.) are individually CoreML-supported, but the fused form isn't. Decomposition is straightforward — emit the underlying `conv` MIL op, then the corresponding activation.
- **`com.microsoft:FusedMatMul`** (×2, from `MatMulScaleFusion`) — `MatMul * alpha` with an optional transpose. Decomposition: `matmul` + scalar `mul`.
- **`ai.onnx:Split`** (×2) — pre-existing CoreML EP gap unrelated to fusion. CoreML MIL has a native `split` op; this one is a straight op-builder omission.

Happy to send follow-up PRs for any of these after this one lands, following the same pattern. Flagging here so they're on the EP coverage roadmap.