### PR TITLE
Removes duplicate macos dylib and fixes packaging for the Microsoft.ML.OnnxRuntime.Foundry package

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/managed-nuget-for-foundry-local.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/managed-nuget-for-foundry-local.yml
@@ -60,7 +60,7 @@ stages:
       displayName: 'Restore NuGet Packages and create project.assets.json'
       inputs:
         solution: '$(Build.SourcesDirectory)\csharp\src\Microsoft.ML.OnnxRuntime\Microsoft.ML.OnnxRuntime.csproj'
-        platform: 'Any CPU'
+        platform: 'AnyCPU'
         configuration: RelWithDebInfo
         msbuildArguments: '-t:restore -p:OrtPackageId=Microsoft.ML.OnnxRuntime -p:IncludeMobileTargets=false'
         workingDirectory: '$(Build.SourcesDirectory)\csharp'
@@ -69,7 +69,7 @@ stages:
       displayName: 'Build C# bindings'
       inputs:
         solution: '$(Build.SourcesDirectory)\csharp\src\Microsoft.ML.OnnxRuntime\Microsoft.ML.OnnxRuntime.csproj'
-        platform: 'Any CPU'
+        platform: 'AnyCPU'
         configuration: RelWithDebInfo
         msbuildArguments: '-p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=Microsoft.ML.OnnxRuntime -p:IsReleaseBuild=${{ parameters.IsReleaseBuild }} -p:ReleaseVersionSuffix=$(ReleaseVersionSuffix) -p:PackageVersion=$(OnnxRuntimeVersion) -p:IncludeMobileTargets=false'
         workingDirectory: '$(Build.SourcesDirectory)\csharp'
@@ -84,7 +84,7 @@ stages:
       displayName: 'Build Nuget Packages'
       inputs:
         solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.proj'
-        platform: 'Any CPU'
+        platform: 'AnyCPU'
         configuration: RelWithDebInfo
         msbuildArguments: '-t:CreatePackage -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=Microsoft.ML.OnnxRuntime -p:IsReleaseBuild=${{ parameters.IsReleaseBuild }} -p:ReleaseVersionSuffix=$(ReleaseVersionSuffix) -p:CurrentTime=$(BuildTime) -p:CurrentDate=$(BuildDate)'
         workingDirectory: '$(Build.SourcesDirectory)\csharp'

--- a/tools/ci_build/github/azure-pipelines/templates/managed-nuget-for-foundry-local.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/managed-nuget-for-foundry-local.yml
@@ -86,7 +86,7 @@ stages:
         solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.proj'
         platform: 'AnyCPU'
         configuration: RelWithDebInfo
-        msbuildArguments: '-t:CreatePackage -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=Microsoft.ML.OnnxRuntime -p:IsReleaseBuild=${{ parameters.IsReleaseBuild }} -p:ReleaseVersionSuffix=$(ReleaseVersionSuffix) -p:CurrentTime=$(BuildTime) -p:CurrentDate=$(BuildDate)'
+        msbuildArguments: '-t:CreatePackage -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=Microsoft.ML.OnnxRuntime -p:IsReleaseBuild=${{ parameters.IsReleaseBuild }} -p:ReleaseVersionSuffix=$(ReleaseVersionSuffix) -p:CurrentTime=$(BuildTime) -p:CurrentDate=$(BuildDate) -p:IncludeMobileTargets=false'
         workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
     - task: CopyFiles@2

--- a/tools/ci_build/github/azure-pipelines/templates/managed-nuget-for-foundry-local.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/managed-nuget-for-foundry-local.yml
@@ -52,22 +52,26 @@ stages:
         targetType: filePath
         filePath: $(Build.SourcesDirectory)\tools\ci_build\github\windows\extract_nuget_files.ps1
 
+    # Build only the managed Microsoft.ML.OnnxRuntime project (not the full solution) so
+    # test projects such as Microsoft.ML.OnnxRuntime.Tests.MAUI are not built. The subsequent
+    # CreatePackage target in OnnxRuntime.CSharp.proj consumes this project's build output
+    # with NoBuild=true. IncludeMobileTargets=false excludes the MAUI/mobile TargetFrameworks.
     - task: MSBuild@1
       displayName: 'Restore NuGet Packages and create project.assets.json'
       inputs:
-        solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln'
+        solution: '$(Build.SourcesDirectory)\csharp\src\Microsoft.ML.OnnxRuntime\Microsoft.ML.OnnxRuntime.csproj'
         platform: 'Any CPU'
         configuration: RelWithDebInfo
-        msbuildArguments: '-t:restore -p:OrtPackageId=Microsoft.ML.OnnxRuntime'
+        msbuildArguments: '-t:restore -p:OrtPackageId=Microsoft.ML.OnnxRuntime -p:IncludeMobileTargets=false'
         workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
     - task: MSBuild@1
       displayName: 'Build C# bindings'
       inputs:
-        solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln'
+        solution: '$(Build.SourcesDirectory)\csharp\src\Microsoft.ML.OnnxRuntime\Microsoft.ML.OnnxRuntime.csproj'
         platform: 'Any CPU'
         configuration: RelWithDebInfo
-        msbuildArguments: '-p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=Microsoft.ML.OnnxRuntime -p:IsReleaseBuild=${{ parameters.IsReleaseBuild }} -p:ReleaseVersionSuffix=$(ReleaseVersionSuffix) -p:PackageVersion=$(OnnxRuntimeVersion)'
+        msbuildArguments: '-p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=Microsoft.ML.OnnxRuntime -p:IsReleaseBuild=${{ parameters.IsReleaseBuild }} -p:ReleaseVersionSuffix=$(ReleaseVersionSuffix) -p:PackageVersion=$(OnnxRuntimeVersion) -p:IncludeMobileTargets=false'
         workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
     - template: win-esrp-dll.yml

--- a/tools/nuget/generate_nuspec_for_custom_nuget.py
+++ b/tools/nuget/generate_nuspec_for_custom_nuget.py
@@ -4,6 +4,7 @@
 import argparse
 import glob
 import os
+import re
 import shutil
 
 from generate_nuspec_for_native_nuget import generate_metadata
@@ -18,6 +19,10 @@ def generate_files(lines, args):
     }
 
     avoid_keywords = {"pdb", "onnxruntime_providers_cuda"}
+    # On macOS the build output contains both libonnxruntime.dylib and a versioned
+    # duplicate like libonnxruntime.1.version_minor.version_patch.dylib (identical contents).
+    # Skip the versioned dylib to avoid bloating the NuGet package with duplicate binaries.
+    versioned_dylib_re = re.compile(r"^lib.+\.\d+(\.\d+)*\.dylib$")
     processed_includes = set()
     for platform, platform_dir in platform_map.items():
         for file in glob.glob(os.path.join(platform_dir, "lib", "*")):
@@ -26,6 +31,9 @@ def generate_files(lines, args):
 
             file_name = os.path.basename(file)
             if any(keyword in file_name for keyword in avoid_keywords):
+                continue
+
+            if platform.startswith("osx-") and versioned_dylib_re.match(file_name):
                 continue
 
             files_list.append(f'<file src="{file}" target="runtimes/{platform}/native/{file_name}" />')


### PR DESCRIPTION
- macOS packaging pipeline generates libonnxruntime.dylib and libonnxruntime.1.26.0.dylib which are identical. This then gets packaged into the nuget package and causes unnecessary bloat. This PR removes the duplicate binary.
- Fixes the foundry nuget packaging pipeline by skipping building the mobile targets.