### PR TITLE
Add workflow to replace Windows GPU Doc Gen CI Pipeline

### DIFF
--- a/.github/workflows/windows_gpu_doc_gen.yml
+++ b/.github/workflows/windows_gpu_doc_gen.yml
@@ -37,7 +37,6 @@ jobs:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
       setVcvars: true
       ALLOW_RELEASED_ONNX_OPSET_ONLY: '0'
-      DocUpdateNeeded: false
       AZCOPY_AUTO_LOGIN_TYPE: MSI
       AZCOPY_MSI_CLIENT_ID: 63b63039-6328-442f-954b-5a64d124e5b4
     runs-on: [
@@ -152,16 +151,11 @@ jobs:
           }
         shell: pwsh
 
-      - name: Upload OperatorKernels.md
-        if: failure() && env.DocUpdateNeeded == 'true'
+      - name: Upload updated documentation
+        if: failure()
         uses: actions/upload-artifact@v6
         with:
-          name: OperatorKernels.md
-          path: ${{ github.workspace }}/docs/OperatorKernels.md
-
-      - name: Upload ContribOperators.md
-        if: failure() && env.DocUpdateNeeded == 'true'
-        uses: actions/upload-artifact@v6
-        with:
-          name: ContribOperators.md
-          path: ${{ github.workspace }}/docs/ContribOperators.md
+          name: updated-docs
+          path: |
+            ${{ github.workspace }}/docs/OperatorKernels.md
+            ${{ github.workspace }}/docs/ContribOperators.md

--- a/.github/workflows/windows_gpu_doc_gen.yml
+++ b/.github/workflows/windows_gpu_doc_gen.yml
@@ -1,0 +1,167 @@
+name: ONNX Runtime Windows GPU Doc Gen CI
+
+on:
+  push:
+    branches:
+      - main
+      - rel-*
+    paths-ignore:
+      - 'docs/**'
+      - README.md
+      - CONTRIBUTING.md
+      - BUILD.md
+      - 'js/web/**'
+      - 'onnxruntime/core/providers/js/**'
+  pull_request:
+    branches:
+      - main
+      - rel-*
+    paths-ignore:
+      - 'docs/**'
+      - README.md
+      - CONTRIBUTING.md
+      - BUILD.md
+      - 'js/web/**'
+      - 'onnxruntime/core/providers/js/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  kernel_documentation:
+    name: Windows GPU Kernel Documentation Validation
+    env:
+      OrtPackageId: Microsoft.ML.OnnxRuntime
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+      setVcvars: true
+      ALLOW_RELEASED_ONNX_OPSET_ONLY: '0'
+      DocUpdateNeeded: false
+      AZCOPY_AUTO_LOGIN_TYPE: MSI
+      AZCOPY_MSI_CLIENT_ID: 63b63039-6328-442f-954b-5a64d124e5b4
+    runs-on: [
+        "self-hosted",
+        "1ES.Pool=onnxruntime-github-Win2022-GPU-A10",
+        "JobId=windows-gpu-doc-gen-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"
+        ]
+    timeout-minutes: 300
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: 'none'
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          architecture: x64
+
+      - name: Locate vcvarsall and Setup Env
+        uses: ./.github/actions/locate-vcvarsall-and-setup-env
+        with:
+          architecture: x64
+
+      - name: Install python modules
+        run: python -m pip install -r .\tools\ci_build\github\windows\python\requirements.txt
+        working-directory: ${{ github.workspace }}
+        shell: cmd
+
+      - name: Download CUDA SDK v12.8
+        working-directory: ${{ runner.temp }}
+        run: |
+          azcopy.exe cp --recursive "https://lotusscus.blob.core.windows.net/models/cuda_sdk/v12.8" .
+          dir
+        shell: pwsh
+
+      - name: Add CUDA to PATH
+        shell: powershell
+        run: |
+          Write-Host "Adding CUDA to PATH"
+          Write-Host "CUDA Path: $env:RUNNER_TEMP\v12.8\bin"
+          Add-Content -Path $env:GITHUB_PATH -Value "$env:RUNNER_TEMP\v12.8\bin"
+          Add-Content -Path $env:GITHUB_PATH -Value "$env:RUNNER_TEMP\v12.8\extras\CUPTI\lib64"
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20.x'
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          architecture: x64
+
+      - name: API Documentation Check and generate
+        run: |
+          set ORT_DOXY_SRC=${{ github.workspace }}
+          set ORT_DOXY_OUT=${{ runner.temp }}\build\RelWithDebInfo\RelWithDebInfo
+          mkdir %ORT_DOXY_SRC%
+          mkdir %ORT_DOXY_OUT%
+          "C:\Program Files\doxygen\bin\doxygen.exe" ${{ github.workspace }}\tools\ci_build\github\Doxyfile_csharp.cfg
+        working-directory: ${{ github.workspace }}
+        shell: cmd
+
+      - uses: actions/setup-dotnet@v5
+        env:
+          PROCESSOR_ARCHITECTURE: x64
+        with:
+          dotnet-version: '8.x'
+
+      - name: Use Nuget 6.x
+        uses: nuget/setup-nuget@v2
+        with:
+          nuget-version: '6.x'
+
+      - name: NuGet restore
+        run: nuget restore ${{ github.workspace }}\packages.config -ConfigFile ${{ github.workspace }}\NuGet.config -PackagesDirectory ${{ runner.temp }}\build\RelWithDebInfo
+        shell: cmd
+
+      - name: Set OnnxRuntimeBuildDirectory
+        shell: pwsh
+        run: |
+          $buildDir = Join-Path ${{ runner.temp }} "build"
+          echo "OnnxRuntimeBuildDirectory=$buildDir" >> $env:GITHUB_ENV
+
+      - name: Build
+        working-directory: ${{ runner.temp }}
+        run: |
+          python.exe ${{ github.workspace }}\tools\ci_build\build.py --config RelWithDebInfo --build_dir build --skip_submodule_sync --build_csharp --parallel --use_binskim_compliant_compile_flags --cmake_generator "Visual Studio 17 2022" --build_shared_lib --update --build --gen_doc validate --skip_tests --build_wheel --use_dml --use_cuda --cuda_home="$env:RUNNER_TEMP\v12.8" --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=86 --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF
+          if ($lastExitCode -ne 0) {
+            exit $lastExitCode
+          }
+          Remove-Item "${{ runner.temp }}\build\RelWithDebInfo" -Include "*.obj" -Recurse
+        shell: pwsh
+
+      - name: Validate C# native delegates
+        run: python tools\ValidateNativeDelegateAttributes.py
+        working-directory: ${{ github.workspace }}\csharp
+        shell: cmd
+
+      - name: Install ONNX Runtime Wheel
+        uses: ./.github/actions/install-onnxruntime-wheel
+        with:
+          whl-directory: ${{ runner.temp }}\build\RelWithDebInfo\RelWithDebInfo\dist
+
+      - name: Generate and validate documentation
+        working-directory: ${{ runner.temp }}\build
+        run: |
+          python.exe ${{ github.workspace }}\tools\ci_build\build.py --config RelWithDebInfo --build_dir ${{ runner.temp }}\build --gen_doc validate
+          if ($lastExitCode -ne 0) {
+            exit $lastExitCode
+          }
+        shell: pwsh
+
+      - name: Upload OperatorKernels.md
+        if: failure() && env.DocUpdateNeeded == 'true'
+        uses: actions/upload-artifact@v6
+        with:
+          name: OperatorKernels.md
+          path: ${{ github.workspace }}/docs/OperatorKernels.md
+
+      - name: Upload ContribOperators.md
+        if: failure() && env.DocUpdateNeeded == 'true'
+        uses: actions/upload-artifact@v6
+        with:
+          name: ContribOperators.md
+          path: ${{ github.workspace }}/docs/ContribOperators.md

--- a/.github/workflows/windows_gpu_doc_gen.yml
+++ b/.github/workflows/windows_gpu_doc_gen.yml
@@ -5,24 +5,30 @@ on:
     branches:
       - main
       - rel-*
-    paths-ignore:
-      - 'docs/**'
-      - README.md
-      - CONTRIBUTING.md
-      - BUILD.md
-      - 'js/web/**'
-      - 'onnxruntime/core/providers/js/**'
+    paths:
+      - '**'
+      - '!docs/**'
+      - 'docs/OperatorKernels.md'
+      - 'docs/ContribOperators.md'
+      - '!README.md'
+      - '!CONTRIBUTING.md'
+      - '!BUILD.md'
+      - '!js/web/**'
+      - '!onnxruntime/core/providers/js/**'
   pull_request:
     branches:
       - main
       - rel-*
-    paths-ignore:
-      - 'docs/**'
-      - README.md
-      - CONTRIBUTING.md
-      - BUILD.md
-      - 'js/web/**'
-      - 'onnxruntime/core/providers/js/**'
+    paths:
+      - '**'
+      - '!docs/**'
+      - 'docs/OperatorKernels.md'
+      - 'docs/ContribOperators.md'
+      - '!README.md'
+      - '!CONTRIBUTING.md'
+      - '!BUILD.md'
+      - '!js/web/**'
+      - '!onnxruntime/core/providers/js/**'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
To avoid "azp run Windows GPU Doc Gen CI Pipeline" for PR from external contributors.

The "Windows GPU Doc Gen CI Pipeline" can be removed after this PR is merged.

Example run that caught doc mismatch, and correct docs are uploaded in "Upload updated documentation": https://github.com/microsoft/onnxruntime/actions/runs/24813688480/job/72623549343?pr=28185
Artifact download URL: https://github.com/microsoft/onnxruntime/actions/runs/24813688480/artifacts/6593754537

