### PR TITLE
Add regression test for quantize_static with in-memory ModelProto (#23268)

### DIFF
--- a/onnxruntime/test/python/quantization/test_quant_issues.py
+++ b/onnxruntime/test/python/quantization/test_quant_issues.py
@@ -67,6 +67,58 @@ class TestQuantIssues(unittest.TestCase):
             assert os.path.exists(preprocessed_path), f"missing output {preprocessed_path!r}"
             assert os.path.exists(quantized_path), f"missing output {quantized_path!r}"
 
+    def test_issue_23268_quantize_static_modelproto_no_validation_error(self):
+        # Regression test for https://github.com/microsoft/onnxruntime/issues/23268.
+        # Before PR #23322, save_and_reload_model_with_shape_infer() saved the caller's
+        # ModelProto with save_as_external_data=True (mutating it to point at a temp
+        # path), then deleted that temp dir.  Any subsequent onnx.checker.check_model()
+        # call on the original proto therefore raised:
+        #   onnx.onnx_cpp2py_export.checker.ValidationError
+        # because the referenced external-data file no longer existed.
+        # PR #23322 fixed this by deep-copying the proto before saving.
+        import numpy as np  # noqa: PLC0415
+        import onnx.helper as oh  # noqa: PLC0415
+        import onnx.numpy_helper as onp  # noqa: PLC0415
+        from onnx import TensorProto  # noqa: PLC0415
+
+        import onnxruntime.quantization as oq  # noqa: PLC0415
+
+        # Build a minimal Add model: output = input + weight.
+        # Weight shape [32, 32] float32 => 4096 bytes, which is above the
+        # 1024-byte threshold that triggers ONNX external-data serialization
+        # inside save_and_reload_model_with_shape_infer.
+        weight_data = np.ones((32, 32), dtype=np.float32)
+        weight_initializer = onp.from_array(weight_data, name="weight")
+
+        input_vi = oh.make_tensor_value_info("input", TensorProto.FLOAT, [32, 32])
+        output_vi = oh.make_tensor_value_info("output", TensorProto.FLOAT, [32, 32])
+        add_node = oh.make_node("Add", inputs=["input", "weight"], outputs=["output"])
+
+        graph = oh.make_graph([add_node], "test_graph", [input_vi], [output_vi], [weight_initializer])
+        model_proto = oh.make_model(graph, opset_imports=[oh.make_opsetid("", 13)])
+        model_proto.ir_version = 7
+
+        class MockReader:
+            def __init__(self):
+                self.i = 0
+
+            def get_next(self):
+                if self.i > 0:
+                    return None
+                self.i += 1
+                return {"input": np.ones((32, 32), dtype=np.float32)}
+
+        with tempfile.TemporaryDirectory() as temp:
+            output_path = os.path.join(temp, "quantized.onnx")
+            # Before the fix this raised ValidationError because the temp dir
+            # created inside save_and_reload_model_with_shape_infer was deleted
+            # while the mutated proto still referenced it.
+            oq.quantize_static(model_proto, output_path, MockReader())
+            self.assertTrue(
+                os.path.exists(output_path),
+                f"Expected quantized model at {output_path!r}",
+            )
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
### Description

Adds a regression test covering the bug reported in #23268 and fixed in #23322.

Before #23322, calling `quantize_static()` with an in-memory `ModelProto` whose weights were large enough (>= 1024 bytes) to trigger ONNX's external-data serialization would mutate the caller's `ModelProto` inside `save_and_reload_model_with_shape_infer` (via `onnx.save_model(..., save_as_external_data=True)`), clearing `raw_data` and pointing the tensor at a temp-directory path that was then deleted. Subsequent calibration would load the now-invalid proto and raise `onnx.onnx_cpp2py_export.checker.ValidationError`.

PR #23322 addressed the issue by wrapping the input proto in `copy.deepcopy` inside `save_and_reload_model_with_shape_infer`, but no regression test was added. This PR adds that test.

### Motivation and Context

Fixes #23268 (adds the missing regression test for the original bug).

### Changes

- `onnxruntime/test/python/quantization/test_quant_issues.py` — adds `test_issue_23268_quantize_static_modelproto_no_validation_error` to `TestQuantIssues`. The test builds an in-memory Add model with a 32x32 float32 initializer (4096 bytes, above the 1024-byte external-data threshold), runs `quantize_static` against it with an inline minimal calibration reader, and asserts the call completes without raising and produces a quantized output file.

No production code changes.

### Test Plan

```
python -m pytest onnxruntime/test/python/quantization/test_quant_issues.py -v
```

Both tests pass locally (`test_minimal_model` and the new `test_issue_23268_quantize_static_modelproto_no_validation_error`) in ~0.6s. `lintrunner -a` is clean.