### PR TITLE
[Plugin WebGPU EP] Fix API initialization error handling

### DIFF
--- a/onnxruntime/core/providers/webgpu/ep/api.cc
+++ b/onnxruntime/core/providers/webgpu/ep/api.cc
@@ -5,6 +5,7 @@
 #include "onnxruntime_cxx_api.h"
 #undef ORT_API_MANUAL_INIT
 
+#include <iostream>
 #include <memory>
 
 #include "core/providers/webgpu/ep/factory.h"
@@ -36,10 +37,33 @@ extern "C" {
 EXPORT_SYMBOL OrtStatus* CreateEpFactories(const char* /*registration_name*/, const OrtApiBase* ort_api_base,
                                            const OrtLogger* default_logger,
                                            OrtEpFactory** factories, size_t max_factories, size_t* num_factories) noexcept {
-  EXCEPTION_TO_RETURNED_STATUS_BEGIN
+  {
+    // Note: We can't use the EXCEPTION_TO_RETURNED_STATUS_BEGIN/EXCEPTION_TO_RETURNED_STATUS_END macros before the
+    // call to `onnxruntime::ep::ApiInit()`. We need to create an OrtStatus more conservatively.
 
-  // Manual init for the C++ API
-  onnxruntime::ep::ApiInit(ort_api_base);
+    // Creates an OrtStatus* for the error or falls back to printing an error message.
+    auto report_error = [](const OrtApiBase* ort_api_base, const char* message) -> OrtStatus* {
+      if (ort_api_base != nullptr) {
+        // Note: CreateStatus has been around since the v1 API, so we'll try to obtain it with the v1 API.
+        if (const OrtApi* ort_api_v1 = ort_api_base->GetApi(1); ort_api_v1 != nullptr) {
+          return ort_api_v1->CreateStatus(OrtErrorCode::ORT_FAIL, message);
+        }
+      }
+      std::cerr << "Error: " << message << "\n";
+      return nullptr;
+    };
+
+    try {
+      // Manual init for the C++ API
+      onnxruntime::ep::ApiInit(ort_api_base);
+    } catch (std::exception& e) {
+      return report_error(ort_api_base, e.what());
+    } catch (...) {
+      return report_error(ort_api_base, "Unknown exception");
+    }
+  }
+
+  EXCEPTION_TO_RETURNED_STATUS_BEGIN
 
   if (max_factories < 1) {
     return onnxruntime::ep::Api().ort.CreateStatus(ORT_INVALID_ARGUMENT,

--- a/onnxruntime/core/providers/webgpu/ep/api.cc
+++ b/onnxruntime/core/providers/webgpu/ep/api.cc
@@ -39,7 +39,7 @@ EXPORT_SYMBOL OrtStatus* CreateEpFactories(const char* /*registration_name*/, co
                                            const OrtLogger* default_logger,
                                            OrtEpFactory** factories, size_t max_factories, size_t* num_factories) noexcept {
   {
-    // Note: We can't use the EXCEPTION_TO_RETURNED_STATUS_BEGIN/EXCEPTION_TO_RETURNED_STATUS_END macros before the
+    // Note: We can't use the EXCEPTION_TO_RETURNED_STATUS_BEGIN/EXCEPTION_TO_RETURNED_STATUS_END macros around the
     // call to `onnxruntime::ep::ApiInit()` because they depend on the API to create `OrtStatus`. We need to create an
     // `OrtStatus` more conservatively.
 
@@ -55,7 +55,7 @@ EXPORT_SYMBOL OrtStatus* CreateEpFactories(const char* /*registration_name*/, co
         }
       }
 
-      fprintf(stderr, "Error: %s\nUnable to create an OrtStatus. Aborting.\n", message);
+      fprintf(stderr, "Error: %s\nUnable to use OrtApi::CreateStatus() to create an OrtStatus. Aborting.\n", message);
       std::abort();
     };
 

--- a/onnxruntime/core/providers/webgpu/ep/api.cc
+++ b/onnxruntime/core/providers/webgpu/ep/api.cc
@@ -5,7 +5,8 @@
 #include "onnxruntime_cxx_api.h"
 #undef ORT_API_MANUAL_INIT
 
-#include <iostream>
+#include <cstdio>
+#include <cstdlib>
 #include <memory>
 
 #include "core/providers/webgpu/ep/factory.h"
@@ -39,24 +40,29 @@ EXPORT_SYMBOL OrtStatus* CreateEpFactories(const char* /*registration_name*/, co
                                            OrtEpFactory** factories, size_t max_factories, size_t* num_factories) noexcept {
   {
     // Note: We can't use the EXCEPTION_TO_RETURNED_STATUS_BEGIN/EXCEPTION_TO_RETURNED_STATUS_END macros before the
-    // call to `onnxruntime::ep::ApiInit()`. We need to create an OrtStatus more conservatively.
+    // call to `onnxruntime::ep::ApiInit()` because they depend on the API to create `OrtStatus`. We need to create an
+    // `OrtStatus` more conservatively.
 
-    // Creates an OrtStatus* for the error or falls back to printing an error message.
+    // Creates an `OrtStatus` for the error or falls back to printing the error message and aborting.
     auto report_error = [](const OrtApiBase* ort_api_base, const char* message) -> OrtStatus* {
       if (ort_api_base != nullptr) {
-        // Note: CreateStatus has been around since the v1 API, so we'll try to obtain it with the v1 API.
+        // Note: `OrtApi::CreateStatus` has been around since the v1 API, so we'll try to obtain it with the v1 API.
+        // We assume that `CreateStatus` has the same offset in the `OrtApi` struct in v1 and the current version.
+        // `OrtApiBase::GetApi()` could theoretically return `OrtApi` structs with different layouts for different
+        // versions, but `CreateStatus` has maintained the same offset across all versions so far.
         if (const OrtApi* ort_api_v1 = ort_api_base->GetApi(1); ort_api_v1 != nullptr) {
           return ort_api_v1->CreateStatus(OrtErrorCode::ORT_FAIL, message);
         }
       }
-      std::cerr << "Error: " << message << "\n";
-      return nullptr;
+
+      fprintf(stderr, "Error: %s\nUnable to create an OrtStatus. Aborting.\n", message);
+      std::abort();
     };
 
     try {
       // Manual init for the C++ API
       onnxruntime::ep::ApiInit(ort_api_base);
-    } catch (std::exception& e) {
+    } catch (const std::exception& e) {
       return report_error(ort_api_base, e.what());
     } catch (...) {
       return report_error(ort_api_base, "Unknown exception");

--- a/onnxruntime/core/providers/webgpu/ep/api.cc
+++ b/onnxruntime/core/providers/webgpu/ep/api.cc
@@ -47,9 +47,12 @@ EXPORT_SYMBOL OrtStatus* CreateEpFactories(const char* /*registration_name*/, co
     auto report_error = [](const OrtApiBase* ort_api_base, const char* message) -> OrtStatus* {
       if (ort_api_base != nullptr) {
         // Note: `OrtApi::CreateStatus` has been around since the v1 API, so we'll try to obtain it with the v1 API.
-        // We assume that `CreateStatus` has the same offset in the `OrtApi` struct in v1 and the current version.
-        // `OrtApiBase::GetApi()` could theoretically return `OrtApi` structs with different layouts for different
-        // versions, but `CreateStatus` has maintained the same offset across all versions so far.
+        // The `static_assert` ensures that `CreateStatus` has the same offset in the `OrtApi` struct in v1 and the
+        // current version. `OrtApiBase::GetApi()` could theoretically return `OrtApi` structs with different layouts
+        // for different versions, but `CreateStatus` has maintained the same offset across all versions so far.
+        constexpr size_t kCreateStatusOffsetInV1Api = 0;
+        static_assert(offsetof(OrtApi, CreateStatus) / sizeof(void*) == kCreateStatusOffsetInV1Api,
+                      "OrtApi::CreateStatus is not at the same offset as it was in the v1 OrtApi.");
         if (const OrtApi* ort_api_v1 = ort_api_base->GetApi(1); ort_api_v1 != nullptr) {
           return ort_api_v1->CreateStatus(OrtErrorCode::ORT_FAIL, message);
         }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

This pull request improves error handling in the `CreateEpFactories` function in `onnxruntime/core/providers/webgpu/ep/api.cc`.

The main enhancement is the addition of a more conservative mechanism for creating `OrtStatus` objects when exceptions occur during API initialization.

The existing code was attempting to create a C++ API `Ort::Status` instance even if the API was not initialized successfully.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix crash that was hiding underlying error message.