### PR TITLE
docs: add missing `import os` in FAQ.md Python code snippet

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -41,6 +41,7 @@ This is supported in ONNX Runtime v1.3.0+
 **Python example:**
 ```
 #!/usr/bin/python3
+import os
 os.environ["OMP_NUM_THREADS"] = "1"
 import onnxruntime
 


### PR DESCRIPTION
## Summary

Fixes a broken Python code example in `docs/FAQ.md`.

## Problem

The FAQ section **"How do I force single threaded execution mode in ORT?"** contains a Python snippet that calls `os.environ["OMP_NUM_THREADS"] = "1"` **before** importing `os`. Running this snippet as-is raises:

```
NameError: name 'os' is not defined
```

## Fix

Added `import os` on the line immediately before the `os.environ` call.

## Changes

- `docs/FAQ.md`: Insert `import os` before `os.environ["OMP_NUM_THREADS"] = "1"`

Closes #28219

---
Signed-off-by: Cocoon-Break <86288566+lingxiu58@users.noreply.github.com>