### PR TITLE
Improve SparseTensors public API input validation as well as sparse utilities

### DIFF
--- a/onnxruntime/core/framework/sparse_utils.cc
+++ b/onnxruntime/core/framework/sparse_utils.cc
@@ -7,6 +7,7 @@
 
 #include "core/common/span_utils.h"
 #include "core/common/status.h"
+#include "core/common/safeint.h"
 #include "core/framework/tensor.h"
 #include "core/framework/data_types_internal.h"
 #include "core/framework/data_transfer_manager.h"
@@ -264,7 +265,9 @@ Status SparseCsrToDenseTensor(const DataTransferManager& data_manager, const Spa
       for (int64_t cnt = 0; cnt < row_size; ++cnt, ++inner_idx) {
         assert(inner_idx < inner_span.size());
         auto col = inner_span[inner_idx];
-        auto dst_idx = (out_i - 1) * cols + col;
+        // The indices bounds are already validated at the C API boundary.
+        // Use SafeInt to prevent overflow during index calculation.
+        int64_t dst_idx = SafeInt<int64_t>(out_i - 1) * cols + col;
         copy_func(output, values, dst_idx, src_idx);
       }
     }
@@ -355,16 +358,17 @@ Status SparseCooToDenseTensor(const DataTransferManager& data_manager, const Spa
     // Linear index
     if (num_indices == num_values) {
       for (int64_t src_idx = 0; src_idx < num_values; ++src_idx) {
+        // The indices bounds are already validated at the C API boundary.
         auto dst_idx = indices[src_idx];
-        ORT_RETURN_IF_NOT(dst_idx < dense_size, "Invalid index: ", dst_idx, " > dense_size: ", dense_size);
         copy_func(output, values, dst_idx, src_idx);
       }
     } else {
       const auto cols = src_dims[1];
       for (int64_t src_idx = 0; src_idx < num_values; ++src_idx) {
         auto tuple_idx = src_idx * 2;
-        auto dst_idx = indices[tuple_idx] * cols + indices[tuple_idx + 1];
-        ORT_RETURN_IF_NOT(dst_idx < dense_size, "Invalid index: ", dst_idx, " > dense_size: ", dense_size);
+        // The indices bounds are already validated at the C API boundary.
+        // Use SafeInt to prevent overflow during index calculation.
+        int64_t dst_idx = SafeInt<int64_t>(indices[tuple_idx]) * cols + indices[tuple_idx + 1];
         copy_func(output, values, dst_idx, src_idx);
       }
     }

--- a/onnxruntime/core/framework/sparse_utils.cc
+++ b/onnxruntime/core/framework/sparse_utils.cc
@@ -257,6 +257,7 @@ Status SparseCsrToDenseTensor(const DataTransferManager& data_manager, const Spa
     }
 
     void* output = cpu_result.MutableDataRaw();
+    const auto dense_size = cpu_result.Shape().Size();
 
     size_t src_idx = 0;
     size_t inner_idx = 0;
@@ -265,9 +266,11 @@ Status SparseCsrToDenseTensor(const DataTransferManager& data_manager, const Spa
       for (int64_t cnt = 0; cnt < row_size; ++cnt, ++inner_idx) {
         assert(inner_idx < inner_span.size());
         auto col = inner_span[inner_idx];
-        // The indices bounds are already validated at the C API boundary.
+        ORT_RETURN_IF_NOT(col >= 0 && col < cols, "Invalid CSR column index: ", col);
         // Use SafeInt to prevent overflow during index calculation.
         int64_t dst_idx = SafeInt<int64_t>(out_i - 1) * cols + col;
+        ORT_RETURN_IF_NOT(dst_idx >= 0 && dst_idx < dense_size,
+                          "Invalid CSR computed index: ", dst_idx);
         copy_func(output, values, dst_idx, src_idx);
       }
     }
@@ -358,17 +361,19 @@ Status SparseCooToDenseTensor(const DataTransferManager& data_manager, const Spa
     // Linear index
     if (num_indices == num_values) {
       for (int64_t src_idx = 0; src_idx < num_values; ++src_idx) {
-        // The indices bounds are already validated at the C API boundary.
         auto dst_idx = indices[src_idx];
+        ORT_RETURN_IF_NOT(dst_idx >= 0 && dst_idx < dense_size,
+                          "Invalid COO index: ", dst_idx);
         copy_func(output, values, dst_idx, src_idx);
       }
     } else {
       const auto cols = src_dims[1];
       for (int64_t src_idx = 0; src_idx < num_values; ++src_idx) {
         auto tuple_idx = src_idx * 2;
-        // The indices bounds are already validated at the C API boundary.
         // Use SafeInt to prevent overflow during index calculation.
         int64_t dst_idx = SafeInt<int64_t>(indices[tuple_idx]) * cols + indices[tuple_idx + 1];
+        ORT_RETURN_IF_NOT(dst_idx >= 0 && dst_idx < dense_size,
+                          "Invalid COO 2D index: (", indices[tuple_idx], ", ", indices[tuple_idx + 1], ")");
         copy_func(output, values, dst_idx, src_idx);
       }
     }

--- a/onnxruntime/core/framework/sparse_utils.cc
+++ b/onnxruntime/core/framework/sparse_utils.cc
@@ -259,19 +259,20 @@ Status SparseCsrToDenseTensor(const DataTransferManager& data_manager, const Spa
     void* output = cpu_result.MutableDataRaw();
     const auto dense_size = cpu_result.Shape().Size();
 
-    size_t src_idx = 0;
     size_t inner_idx = 0;
     for (size_t out_i = 1; out_i < outer_span.size(); ++out_i) {
       auto row_size = outer_span[out_i] - outer_span[out_i - 1];
       for (int64_t cnt = 0; cnt < row_size; ++cnt, ++inner_idx) {
-        assert(inner_idx < inner_span.size());
+        ORT_RETURN_IF_NOT(inner_idx < inner_span.size(),
+                          "CSR inner index out of range: inner_idx=", inner_idx,
+                          " >= inner_span.size()=", inner_span.size());
         auto col = inner_span[inner_idx];
         ORT_RETURN_IF_NOT(col >= 0 && col < cols, "Invalid CSR column index: ", col);
         // Use SafeInt to prevent overflow during index calculation.
         int64_t dst_idx = SafeInt<int64_t>(out_i - 1) * cols + col;
         ORT_RETURN_IF_NOT(dst_idx >= 0 && dst_idx < dense_size,
                           "Invalid CSR computed index: ", dst_idx);
-        copy_func(output, values, dst_idx, src_idx);
+        copy_func(output, values, dst_idx, inner_idx);
       }
     }
   }
@@ -367,13 +368,17 @@ Status SparseCooToDenseTensor(const DataTransferManager& data_manager, const Spa
         copy_func(output, values, dst_idx, src_idx);
       }
     } else {
+      const auto rows = src_dims[0];
       const auto cols = src_dims[1];
       for (int64_t src_idx = 0; src_idx < num_values; ++src_idx) {
         auto tuple_idx = src_idx * 2;
+        auto r = indices[tuple_idx];
+        auto c = indices[tuple_idx + 1];
+        ORT_RETURN_IF_NOT(r >= 0 && r < rows && c >= 0 && c < cols,
+                          "Invalid COO 2D index: (", r, ", ", c,
+                          ") must be in [0, ", rows, ") x [0, ", cols, ")");
         // Use SafeInt to prevent overflow during index calculation.
-        int64_t dst_idx = SafeInt<int64_t>(indices[tuple_idx]) * cols + indices[tuple_idx + 1];
-        ORT_RETURN_IF_NOT(dst_idx >= 0 && dst_idx < dense_size,
-                          "Invalid COO 2D index: (", indices[tuple_idx], ", ", indices[tuple_idx + 1], ")");
+        int64_t dst_idx = SafeInt<int64_t>(r) * cols + c;
         copy_func(output, values, dst_idx, src_idx);
       }
     }

--- a/onnxruntime/core/framework/sparse_utils.cc
+++ b/onnxruntime/core/framework/sparse_utils.cc
@@ -258,9 +258,23 @@ Status SparseCsrToDenseTensor(const DataTransferManager& data_manager, const Spa
 
     void* output = cpu_result.MutableDataRaw();
     const auto dense_size = cpu_result.Shape().Size();
+    const auto outer_size = outer_span.size();
+    const auto inner_size = static_cast<int64_t>(inner_span.size());
+
+    // Validate CSR structural invariants (O(1) checks).
+    if (outer_size > 0) {
+      ORT_RETURN_IF_NOT(outer_span[0] == 0,
+                        "CSR outer index must start at 0, got: ", outer_span[0]);
+      ORT_RETURN_IF_NOT(outer_span[outer_size - 1] == inner_size,
+                        "CSR outer index last element must equal inner index count (",
+                        inner_size, "), got: ", outer_span[outer_size - 1]);
+    }
 
     size_t inner_idx = 0;
-    for (size_t out_i = 1; out_i < outer_span.size(); ++out_i) {
+    for (size_t out_i = 1; out_i < outer_size; ++out_i) {
+      ORT_RETURN_IF_NOT(outer_span[out_i] >= outer_span[out_i - 1],
+                        "CSR outer index not non-decreasing at position ", out_i,
+                        ": ", outer_span[out_i]);
       auto row_size = outer_span[out_i] - outer_span[out_i - 1];
       for (int64_t cnt = 0; cnt < row_size; ++cnt, ++inner_idx) {
         ORT_RETURN_IF_NOT(inner_idx < inner_span.size(),

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -2074,7 +2074,7 @@ static Status CopySparseData(const std::string& name,
   switch (indices.data_type()) {
     case ONNX_NAMESPACE::TensorProto_DataType_INT64:
       if (needs_unpack) {
-        ORT_RETURN_IF_NOT(indices.raw_data().size() == (narrow<size_t>(indices_elements) * sizeof(int64_t)),
+        ORT_RETURN_IF_NOT(indices.raw_data().size() == SafeInt<size_t>(indices_elements) * sizeof(int64_t),
                           "Sparse tensor: ", name, " indices raw data size does not match expected: ",
                           indices_elements * sizeof(int64_t));
         ORT_RETURN_IF_ERROR(UnpackInitializerData(indices, model_path, unpack_buffer));
@@ -2088,7 +2088,7 @@ static Status CopySparseData(const std::string& name,
       break;
     case ONNX_NAMESPACE::TensorProto_DataType_INT32: {
       if (needs_unpack) {
-        ORT_RETURN_IF_NOT(indices.raw_data().size() == (narrow<size_t>(indices_elements) * sizeof(int32_t)),
+        ORT_RETURN_IF_NOT(indices.raw_data().size() == SafeInt<size_t>(indices_elements) * sizeof(int32_t),
                           "Sparse tensor: ", name, " indices raw data size does not match expected: ",
                           indices_elements * sizeof(int32_t));
         ORT_RETURN_IF_ERROR(UnpackInitializerData(indices, model_path, unpack_buffer));
@@ -2107,7 +2107,7 @@ static Status CopySparseData(const std::string& name,
     }
     case ONNX_NAMESPACE::TensorProto_DataType_INT16: {
       if (needs_unpack) {
-        ORT_RETURN_IF_NOT(indices.raw_data().size() == (narrow<size_t>(indices_elements) * sizeof(int16_t)),
+        ORT_RETURN_IF_NOT(indices.raw_data().size() == SafeInt<size_t>(indices_elements) * sizeof(int16_t),
                           "Sparse tensor: ", name, " indices raw data size does not match expected: ",
                           indices_elements * sizeof(int16_t));
         ORT_RETURN_IF_ERROR(UnpackInitializerData(indices, model_path, unpack_buffer));
@@ -2288,12 +2288,12 @@ common::Status SparseTensorProtoToDenseTensorProto(const ONNX_NAMESPACE::SparseT
 
     // by putting the data into a std::string we can avoid a copy as set_raw_data can do a std::move
     // into the TensorProto.
-    std::string dense_data_storage(narrow<size_t>(dense_elements) * element_size, 0);
+    std::string dense_data_storage(SafeInt<size_t>(dense_elements) * element_size, 0);
     if (nnz_elements > 0) {
       // need to read in sparse data first as it could be in a type specific field, in raw data, or in external data
       std::vector<uint8_t> values_data;
       ORT_RETURN_IF_ERROR(UnpackInitializerData(sparse_values, model_path, values_data));
-      ORT_RETURN_IF_NOT(values_data.size() == static_cast<size_t>(nnz_elements) * element_size,
+      ORT_RETURN_IF_NOT(values_data.size() == SafeInt<size_t>(nnz_elements) * element_size,
                         "Sparse tensor: ", name, " values data size does not match expected: ",
                         static_cast<size_t>(nnz_elements) * element_size);
       void* sparse_data = values_data.data();

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -2295,7 +2295,7 @@ common::Status SparseTensorProtoToDenseTensorProto(const ONNX_NAMESPACE::SparseT
       ORT_RETURN_IF_ERROR(UnpackInitializerData(sparse_values, model_path, values_data));
       ORT_RETURN_IF_NOT(values_data.size() == SafeInt<size_t>(nnz_elements) * element_size,
                         "Sparse tensor: ", name, " values data size does not match expected: ",
-                        static_cast<size_t>(nnz_elements) * element_size);
+                        static_cast<size_t>(SafeInt<size_t>(nnz_elements) * element_size));
       void* sparse_data = values_data.data();
       void* dense_data = dense_data_storage.data();
 

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -432,21 +432,21 @@ union PtrConvert {
   const char** strings;
 };
 
-#endif  // !defined(DISABLE_SPARSE_TENSORS)
-}  // namespace
-
-ORT_API_STATUS_IMPL(OrtApis::FillSparseTensorCoo, _Inout_ OrtValue* ort_value, _In_ const OrtMemoryInfo* data_mem_info,
-                    _In_ const int64_t* values_shape, size_t values_shape_len, _In_ const void* values,
-                    _In_ const int64_t* indices_data, size_t indices_num) {
-  API_IMPL_BEGIN
-#if !defined(DISABLE_SPARSE_TENSORS)
-  TensorShape values_t_shape(values_shape, values_shape_len);
-  auto& sparse_tensor = ValidateFillInputArgs(ort_value, values_t_shape, data_mem_info);
-
-  auto values_size = narrow<size_t>(values_t_shape.Size());
-  auto indices_span = gsl::make_span(indices_data, indices_num);
-
-  const auto& dense_shape = sparse_tensor.DenseShape();
+// Shared validation for COO indices used by both FillSparseTensorCoo and UseCooIndices.
+// Returns nullptr on success, OrtStatus* on validation failure.
+OrtStatus* ValidateCooIndices(const int64_t* indices_data, size_t indices_num,
+                              size_t values_size, const TensorShape& dense_shape) {
+  if (indices_num > 0 && indices_data == nullptr) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
+                                 "indices_data must not be null when indices_num > 0.");
+  }
+  if ((values_size == 0) != (indices_num == 0)) {
+    return OrtApis::CreateStatus(
+        ORT_INVALID_ARGUMENT,
+        values_size == 0
+            ? "COO indices must be empty when the sparse tensor has no values."
+            : "COO indices must be provided when the sparse tensor has values.");
+  }
   if (values_size > 0 && indices_num > 0) {
     if (indices_num == values_size) {
       const auto dense_size = dense_shape.Size();
@@ -479,8 +479,82 @@ ORT_API_STATUS_IMPL(OrtApis::FillSparseTensorCoo, _Inout_ OrtValue* ort_value, _
         }
       }
     } else {
-      return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "COO indices count must be equal to or twice the values count.");
+      return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
+                                   "COO indices count must be equal to or twice the values count.");
     }
+  }
+  return nullptr;
+}
+
+// Shared validation for CSR indices used by both FillSparseTensorCsr and UseCsrIndices.
+// Returns nullptr on success, OrtStatus* on validation failure.
+OrtStatus* ValidateCsrIndices(const int64_t* inner_data, size_t inner_num,
+                              const int64_t* outer_data, size_t outer_num,
+                              const TensorShape& dense_shape) {
+  if (inner_num > 0 && inner_data == nullptr) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
+                                 "inner index data must not be null when inner index count > 0.");
+  }
+  if (outer_num > 0 && outer_data == nullptr) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
+                                 "outer index data must not be null when outer index count > 0.");
+  }
+  if (dense_shape.NumDimensions() == 2 && inner_num > 0) {
+    const auto cols = dense_shape.GetDims()[1];
+    for (size_t i = 0; i < inner_num; ++i) {
+      if (inner_data[i] < 0 || inner_data[i] >= cols) {
+        return OrtApis::CreateStatus(
+            ORT_INVALID_ARGUMENT,
+            MakeString("CSR inner index out of bounds: ", inner_data[i],
+                       " must be in [0, ", cols, ")")
+                .c_str());
+      }
+    }
+  }
+  if (outer_num > 0) {
+    if (outer_data[0] != 0) {
+      return OrtApis::CreateStatus(
+          ORT_INVALID_ARGUMENT,
+          MakeString("CSR outer index must start at 0, got: ", outer_data[0]).c_str());
+    }
+    if (outer_data[outer_num - 1] != static_cast<int64_t>(inner_num)) {
+      return OrtApis::CreateStatus(
+          ORT_INVALID_ARGUMENT,
+          MakeString("CSR outer index last element must equal inner index count (",
+                     inner_num, "), got: ", outer_data[outer_num - 1])
+              .c_str());
+    }
+    int64_t prev = 0;
+    for (size_t i = 0; i < outer_num; ++i) {
+      auto val = outer_data[i];
+      if (val < prev || val > static_cast<int64_t>(inner_num)) {
+        return OrtApis::CreateStatus(
+            ORT_INVALID_ARGUMENT,
+            MakeString("CSR outer index out of bounds or not monotonically non-decreasing: ", val).c_str());
+      }
+      prev = val;
+    }
+  }
+  return nullptr;
+}
+
+#endif  // !defined(DISABLE_SPARSE_TENSORS)
+}  // namespace
+
+ORT_API_STATUS_IMPL(OrtApis::FillSparseTensorCoo, _Inout_ OrtValue* ort_value, _In_ const OrtMemoryInfo* data_mem_info,
+                    _In_ const int64_t* values_shape, size_t values_shape_len, _In_ const void* values,
+                    _In_ const int64_t* indices_data, size_t indices_num) {
+  API_IMPL_BEGIN
+#if !defined(DISABLE_SPARSE_TENSORS)
+  TensorShape values_t_shape(values_shape, values_shape_len);
+  auto& sparse_tensor = ValidateFillInputArgs(ort_value, values_t_shape, data_mem_info);
+
+  auto values_size = narrow<size_t>(values_t_shape.Size());
+  auto indices_span = gsl::make_span(indices_data, indices_num);
+
+  if (auto* status = ValidateCooIndices(indices_data, indices_num, values_size,
+                                        sparse_tensor.DenseShape())) {
+    return status;
   }
 
   if (sparse_tensor.IsDataTypeString()) {
@@ -519,42 +593,10 @@ ORT_API_STATUS_IMPL(OrtApis::FillSparseTensorCsr, _Inout_ OrtValue* ort_value, _
   auto inner_indices_span = gsl::make_span(inner_indices_data, inner_indices_num);
   auto outer_indices_span = gsl::make_span(outer_indices_data, outer_indices_num);
 
-  const auto& dense_shape = sparse_tensor.DenseShape();
-  if (dense_shape.NumDimensions() == 2 && inner_indices_num > 0) {
-    const auto cols = dense_shape.GetDims()[1];
-    for (size_t i = 0; i < inner_indices_num; ++i) {
-      if (inner_indices_data[i] < 0 || inner_indices_data[i] >= cols) {
-        return OrtApis::CreateStatus(
-            ORT_INVALID_ARGUMENT,
-            MakeString("CSR inner index out of bounds: ", inner_indices_data[i],
-                       " must be in [0, ", cols, ")")
-                .c_str());
-      }
-    }
-  }
-  if (outer_indices_num > 0) {
-    if (outer_indices_data[0] != 0) {
-      return OrtApis::CreateStatus(
-          ORT_INVALID_ARGUMENT,
-          MakeString("CSR outer index must start at 0, got: ", outer_indices_data[0]).c_str());
-    }
-    if (outer_indices_data[outer_indices_num - 1] != static_cast<int64_t>(inner_indices_num)) {
-      return OrtApis::CreateStatus(
-          ORT_INVALID_ARGUMENT,
-          MakeString("CSR outer index last element must equal inner_indices_num (",
-                     inner_indices_num, "), got: ", outer_indices_data[outer_indices_num - 1])
-              .c_str());
-    }
-    int64_t prev = 0;
-    for (size_t i = 0; i < outer_indices_num; ++i) {
-      auto val = outer_indices_data[i];
-      if (val < prev || val > static_cast<int64_t>(inner_indices_num)) {
-        return OrtApis::CreateStatus(
-            ORT_INVALID_ARGUMENT,
-            MakeString("CSR outer index out of bounds or not monotonically non-decreasing: ", val).c_str());
-      }
-      prev = val;
-    }
+  if (auto* status = ValidateCsrIndices(inner_indices_data, inner_indices_num,
+                                        outer_indices_data, outer_indices_num,
+                                        sparse_tensor.DenseShape())) {
+    return status;
   }
 
   if (sparse_tensor.IsDataTypeString()) {
@@ -664,57 +706,14 @@ ORT_API_STATUS_IMPL(OrtApis::UseCooIndices, _Inout_ OrtValue* ort_value, _Inout_
 #if !defined(DISABLE_SPARSE_TENSORS)
   auto v = reinterpret_cast<::OrtValue*>(ort_value);
   auto& sparse_tensor = SparseTensor::GetSparseTensorFromOrtValue(*v);
-  if (indices_num > 0 && indices_data == nullptr) {
-    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
-                                 "indices_data must not be null when indices_num > 0.");
-  }
   auto indices_span = (indices_num == 0 || indices_data == nullptr)
                           ? gsl::span<int64_t>()
                           : gsl::make_span(indices_data, indices_num);
 
-  const auto values_size = sparse_tensor.NumValues();
-  const auto& dense_shape = sparse_tensor.DenseShape();
-  if ((values_size == 0) != (indices_num == 0)) {
-    return OrtApis::CreateStatus(
-        ORT_INVALID_ARGUMENT,
-        values_size == 0
-            ? "COO indices must be empty when the sparse tensor has no values."
-            : "COO indices must be provided when the sparse tensor has values.");
-  }
-  if (values_size > 0 && indices_num > 0) {
-    if (indices_num == values_size) {
-      const auto dense_size = dense_shape.Size();
-      for (size_t i = 0; i < indices_num; ++i) {
-        if (indices_data[i] < 0 || indices_data[i] >= dense_size) {
-          return OrtApis::CreateStatus(
-              ORT_INVALID_ARGUMENT,
-              MakeString("COO linear index out of bounds: ", indices_data[i],
-                         " must be in [0, ", dense_size, ")")
-                  .c_str());
-        }
-      }
-    } else if (indices_num / 2 == values_size && indices_num % 2 == 0) {
-      if (dense_shape.NumDimensions() != 2) {
-        return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
-                                     "COO 2D indices require dense shape of 2 dimensions");
-      }
-      const auto rows = dense_shape.GetDims()[0];
-      const auto cols = dense_shape.GetDims()[1];
-      size_t tuple_idx = 0;
-      for (size_t i = 0; i < values_size; ++i, tuple_idx += 2) {
-        auto r = indices_data[tuple_idx];
-        auto c = indices_data[tuple_idx + 1];
-        if (r < 0 || r >= rows || c < 0 || c >= cols) {
-          return OrtApis::CreateStatus(
-              ORT_INVALID_ARGUMENT,
-              MakeString("COO 2D index out of bounds: (", r, ", ", c,
-                         ") must be in [0, ", rows, ") x [0, ", cols, ")")
-                  .c_str());
-        }
-      }
-    } else {
-      return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "COO indices count must be equal to or twice the values count.");
-    }
+  if (auto* status = ValidateCooIndices(indices_data, indices_num,
+                                        sparse_tensor.NumValues(),
+                                        sparse_tensor.DenseShape())) {
+    return status;
   }
 
   ORT_THROW_IF_ERROR(sparse_tensor.UseCooIndices(indices_span));
@@ -735,14 +734,6 @@ ORT_API_STATUS_IMPL(OrtApis::UseCsrIndices, _Inout_ OrtValue* ort_value,
   API_IMPL_BEGIN
 #if !defined(DISABLE_SPARSE_TENSORS)
   auto& sparse_tensor = SparseTensor::GetSparseTensorFromOrtValue(*ort_value);
-  if (inner_num > 0 && inner_data == nullptr) {
-    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
-                                 "inner_data must not be null when inner_num > 0.");
-  }
-  if (outer_num > 0 && outer_data == nullptr) {
-    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
-                                 "outer_data must not be null when outer_num > 0.");
-  }
   auto inner_span = (inner_num == 0 || inner_data == nullptr)
                         ? gsl::span<int64_t>()
                         : gsl::make_span(inner_data, inner_num);
@@ -750,42 +741,9 @@ ORT_API_STATUS_IMPL(OrtApis::UseCsrIndices, _Inout_ OrtValue* ort_value,
                         ? gsl::span<int64_t>()
                         : gsl::make_span(outer_data, outer_num);
 
-  const auto& dense_shape = sparse_tensor.DenseShape();
-  if (dense_shape.NumDimensions() == 2 && inner_num > 0) {
-    const auto cols = dense_shape.GetDims()[1];
-    for (size_t i = 0; i < inner_num; ++i) {
-      if (inner_data[i] < 0 || inner_data[i] >= cols) {
-        return OrtApis::CreateStatus(
-            ORT_INVALID_ARGUMENT,
-            MakeString("CSR inner index out of bounds: ", inner_data[i],
-                       " must be in [0, ", cols, ")")
-                .c_str());
-      }
-    }
-  }
-  if (outer_num > 0) {
-    if (outer_data[0] != 0) {
-      return OrtApis::CreateStatus(
-          ORT_INVALID_ARGUMENT,
-          MakeString("CSR outer index must start at 0, got: ", outer_data[0]).c_str());
-    }
-    if (outer_data[outer_num - 1] != static_cast<int64_t>(inner_num)) {
-      return OrtApis::CreateStatus(
-          ORT_INVALID_ARGUMENT,
-          MakeString("CSR outer index last element must equal inner_num (",
-                     inner_num, "), got: ", outer_data[outer_num - 1])
-              .c_str());
-    }
-    int64_t prev = 0;
-    for (size_t i = 0; i < outer_num; ++i) {
-      auto val = outer_data[i];
-      if (val < prev || val > static_cast<int64_t>(inner_num)) {
-        return OrtApis::CreateStatus(
-            ORT_INVALID_ARGUMENT,
-            MakeString("CSR outer index out of bounds or not monotonically non-decreasing: ", val).c_str());
-      }
-      prev = val;
-    }
+  if (auto* status = ValidateCsrIndices(inner_data, inner_num, outer_data, outer_num,
+                                        sparse_tensor.DenseShape())) {
+    return status;
   }
 
   ORT_THROW_IF_ERROR(sparse_tensor.UseCsrIndices(inner_span, outer_span));

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -446,6 +446,33 @@ ORT_API_STATUS_IMPL(OrtApis::FillSparseTensorCoo, _Inout_ OrtValue* ort_value, _
   auto values_size = narrow<size_t>(values_t_shape.Size());
   auto indices_span = gsl::make_span(indices_data, indices_num);
 
+  const auto& dense_shape = sparse_tensor.DenseShape();
+  if (values_size > 0 && indices_num > 0) {
+    if (indices_num == values_size) {
+      const auto dense_size = dense_shape.Size();
+      for (size_t i = 0; i < indices_num; ++i) {
+        ORT_RETURN_IF_NOT(indices_data[i] >= 0 && indices_data[i] < dense_size,
+                          "COO linear index out of bounds: ", indices_data[i],
+                          " must be in [0, ", dense_size, ")");
+      }
+    } else if (indices_num / 2 == values_size && indices_num % 2 == 0) {
+      ORT_RETURN_IF_NOT(dense_shape.NumDimensions() == 2,
+                        "COO 2D indices require dense shape of 2 dimensions");
+      const auto rows = dense_shape.GetDims()[0];
+      const auto cols = dense_shape.GetDims()[1];
+      size_t tuple_idx = 0;
+      for (size_t i = 0; i < values_size; ++i, tuple_idx += 2) {
+        auto r = indices_data[tuple_idx];
+        auto c = indices_data[tuple_idx + 1];
+        ORT_RETURN_IF_NOT(r >= 0 && r < rows && c >= 0 && c < cols,
+                          "COO 2D index out of bounds: (", r, ", ", c,
+                          ") must be in [0, ", rows, ") x [0, ", cols, ")");
+      }
+    } else {
+      return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "COO indices count must be equal to or twice the values count.");
+    }
+  }
+
   if (sparse_tensor.IsDataTypeString()) {
     PtrConvert conv(values);
     ORT_THROW_IF_ERROR(sparse_tensor.MakeCooStrings(values_size, conv.strings, indices_span));
@@ -481,6 +508,26 @@ ORT_API_STATUS_IMPL(OrtApis::FillSparseTensorCsr, _Inout_ OrtValue* ort_value, _
 
   auto inner_indices_span = gsl::make_span(inner_indices_data, inner_indices_num);
   auto outer_indices_span = gsl::make_span(outer_indices_data, outer_indices_num);
+
+  const auto& dense_shape = sparse_tensor.DenseShape();
+  if (dense_shape.NumDimensions() == 2 && inner_indices_num > 0) {
+    const auto cols = dense_shape.GetDims()[1];
+    for (size_t i = 0; i < inner_indices_num; ++i) {
+      ORT_RETURN_IF_NOT(inner_indices_data[i] >= 0 && inner_indices_data[i] < cols,
+                        "CSR inner index out of bounds: ", inner_indices_data[i],
+                        " must be in [0, ", cols, ")");
+    }
+  }
+  if (outer_indices_num > 0) {
+    int64_t prev = 0;
+    for (size_t i = 0; i < outer_indices_num; ++i) {
+      auto val = outer_indices_data[i];
+      ORT_RETURN_IF_NOT(val >= prev && val <= static_cast<int64_t>(inner_indices_num),
+                        "CSR outer index out of bounds or not monotonically non-decreasing: ", val);
+      prev = val;
+    }
+  }
+
   if (sparse_tensor.IsDataTypeString()) {
     PtrConvert conv(values);
     ORT_THROW_IF_ERROR(sparse_tensor.MakeCsrStrings(values_size, conv.strings, inner_indices_span, outer_indices_span));
@@ -592,6 +639,34 @@ ORT_API_STATUS_IMPL(OrtApis::UseCooIndices, _Inout_ OrtValue* ort_value, _Inout_
                           ? gsl::span<int64_t>()
                           : gsl::make_span(indices_data, indices_num);
 
+  const auto values_size = sparse_tensor.NumValues();
+  const auto& dense_shape = sparse_tensor.DenseShape();
+  if (values_size > 0 && indices_num > 0) {
+    if (indices_num == values_size) {
+      const auto dense_size = dense_shape.Size();
+      for (size_t i = 0; i < indices_num; ++i) {
+        ORT_RETURN_IF_NOT(indices_data[i] >= 0 && indices_data[i] < dense_size,
+                          "COO linear index out of bounds: ", indices_data[i],
+                          " must be in [0, ", dense_size, ")");
+      }
+    } else if (indices_num / 2 == values_size && indices_num % 2 == 0) {
+      ORT_RETURN_IF_NOT(dense_shape.NumDimensions() == 2,
+                        "COO 2D indices require dense shape of 2 dimensions");
+      const auto rows = dense_shape.GetDims()[0];
+      const auto cols = dense_shape.GetDims()[1];
+      size_t tuple_idx = 0;
+      for (size_t i = 0; i < values_size; ++i, tuple_idx += 2) {
+        auto r = indices_data[tuple_idx];
+        auto c = indices_data[tuple_idx + 1];
+        ORT_RETURN_IF_NOT(r >= 0 && r < rows && c >= 0 && c < cols,
+                          "COO 2D index out of bounds: (", r, ", ", c,
+                          ") must be in [0, ", rows, ") x [0, ", cols, ")");
+      }
+    } else {
+      return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "COO indices count must be equal to or twice the values count.");
+    }
+  }
+
   ORT_THROW_IF_ERROR(sparse_tensor.UseCooIndices(indices_span));
   return nullptr;
 #else
@@ -616,6 +691,26 @@ ORT_API_STATUS_IMPL(OrtApis::UseCsrIndices, _Inout_ OrtValue* ort_value,
   auto outer_span = (outer_num == 0 || outer_data == nullptr)
                         ? gsl::span<int64_t>()
                         : gsl::make_span(outer_data, outer_num);
+
+  const auto& dense_shape = sparse_tensor.DenseShape();
+  if (dense_shape.NumDimensions() == 2 && inner_num > 0) {
+    const auto cols = dense_shape.GetDims()[1];
+    for (size_t i = 0; i < inner_num; ++i) {
+      ORT_RETURN_IF_NOT(inner_data[i] >= 0 && inner_data[i] < cols,
+                        "CSR inner index out of bounds: ", inner_data[i],
+                        " must be in [0, ", cols, ")");
+    }
+  }
+  if (outer_num > 0) {
+    int64_t prev = 0;
+    for (size_t i = 0; i < outer_num; ++i) {
+      auto val = outer_data[i];
+      ORT_RETURN_IF_NOT(val >= prev && val <= static_cast<int64_t>(inner_num),
+                        "CSR outer index out of bounds or not monotonically non-decreasing: ", val);
+      prev = val;
+    }
+  }
+
   ORT_THROW_IF_ERROR(sparse_tensor.UseCsrIndices(inner_span, outer_span));
   return nullptr;
 #else

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -533,6 +533,18 @@ ORT_API_STATUS_IMPL(OrtApis::FillSparseTensorCsr, _Inout_ OrtValue* ort_value, _
     }
   }
   if (outer_indices_num > 0) {
+    if (outer_indices_data[0] != 0) {
+      return OrtApis::CreateStatus(
+          ORT_INVALID_ARGUMENT,
+          MakeString("CSR outer index must start at 0, got: ", outer_indices_data[0]).c_str());
+    }
+    if (outer_indices_data[outer_indices_num - 1] != static_cast<int64_t>(inner_indices_num)) {
+      return OrtApis::CreateStatus(
+          ORT_INVALID_ARGUMENT,
+          MakeString("CSR outer index last element must equal inner_indices_num (",
+                     inner_indices_num, "), got: ", outer_indices_data[outer_indices_num - 1])
+              .c_str());
+    }
     int64_t prev = 0;
     for (size_t i = 0; i < outer_indices_num; ++i) {
       auto val = outer_indices_data[i];
@@ -658,6 +670,13 @@ ORT_API_STATUS_IMPL(OrtApis::UseCooIndices, _Inout_ OrtValue* ort_value, _Inout_
 
   const auto values_size = sparse_tensor.NumValues();
   const auto& dense_shape = sparse_tensor.DenseShape();
+  if ((values_size == 0) != (indices_num == 0)) {
+    return OrtApis::CreateStatus(
+        ORT_INVALID_ARGUMENT,
+        values_size == 0
+            ? "COO indices must be empty when the sparse tensor has no values."
+            : "COO indices must be provided when the sparse tensor has values.");
+  }
   if (values_size > 0 && indices_num > 0) {
     if (indices_num == values_size) {
       const auto dense_size = dense_shape.Size();
@@ -733,6 +752,18 @@ ORT_API_STATUS_IMPL(OrtApis::UseCsrIndices, _Inout_ OrtValue* ort_value,
     }
   }
   if (outer_num > 0) {
+    if (outer_data[0] != 0) {
+      return OrtApis::CreateStatus(
+          ORT_INVALID_ARGUMENT,
+          MakeString("CSR outer index must start at 0, got: ", outer_data[0]).c_str());
+    }
+    if (outer_data[outer_num - 1] != static_cast<int64_t>(inner_num)) {
+      return OrtApis::CreateStatus(
+          ORT_INVALID_ARGUMENT,
+          MakeString("CSR outer index last element must equal inner_num (",
+                     inner_num, "), got: ", outer_data[outer_num - 1])
+              .c_str());
+    }
     int64_t prev = 0;
     for (size_t i = 0; i < outer_num; ++i) {
       auto val = outer_data[i];

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -664,6 +664,10 @@ ORT_API_STATUS_IMPL(OrtApis::UseCooIndices, _Inout_ OrtValue* ort_value, _Inout_
 #if !defined(DISABLE_SPARSE_TENSORS)
   auto v = reinterpret_cast<::OrtValue*>(ort_value);
   auto& sparse_tensor = SparseTensor::GetSparseTensorFromOrtValue(*v);
+  if (indices_num > 0 && indices_data == nullptr) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
+                                 "indices_data must not be null when indices_num > 0.");
+  }
   auto indices_span = (indices_num == 0 || indices_data == nullptr)
                           ? gsl::span<int64_t>()
                           : gsl::make_span(indices_data, indices_num);
@@ -731,6 +735,14 @@ ORT_API_STATUS_IMPL(OrtApis::UseCsrIndices, _Inout_ OrtValue* ort_value,
   API_IMPL_BEGIN
 #if !defined(DISABLE_SPARSE_TENSORS)
   auto& sparse_tensor = SparseTensor::GetSparseTensorFromOrtValue(*ort_value);
+  if (inner_num > 0 && inner_data == nullptr) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
+                                 "inner_data must not be null when inner_num > 0.");
+  }
+  if (outer_num > 0 && outer_data == nullptr) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
+                                 "outer_data must not be null when outer_num > 0.");
+  }
   auto inner_span = (inner_num == 0 || inner_data == nullptr)
                         ? gsl::span<int64_t>()
                         : gsl::make_span(inner_data, inner_num);

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -451,22 +451,32 @@ ORT_API_STATUS_IMPL(OrtApis::FillSparseTensorCoo, _Inout_ OrtValue* ort_value, _
     if (indices_num == values_size) {
       const auto dense_size = dense_shape.Size();
       for (size_t i = 0; i < indices_num; ++i) {
-        ORT_RETURN_IF_NOT(indices_data[i] >= 0 && indices_data[i] < dense_size,
-                          "COO linear index out of bounds: ", indices_data[i],
-                          " must be in [0, ", dense_size, ")");
+        if (indices_data[i] < 0 || indices_data[i] >= dense_size) {
+          return OrtApis::CreateStatus(
+              ORT_INVALID_ARGUMENT,
+              MakeString("COO linear index out of bounds: ", indices_data[i],
+                         " must be in [0, ", dense_size, ")")
+                  .c_str());
+        }
       }
     } else if (indices_num / 2 == values_size && indices_num % 2 == 0) {
-      ORT_RETURN_IF_NOT(dense_shape.NumDimensions() == 2,
-                        "COO 2D indices require dense shape of 2 dimensions");
+      if (dense_shape.NumDimensions() != 2) {
+        return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
+                                     "COO 2D indices require dense shape of 2 dimensions");
+      }
       const auto rows = dense_shape.GetDims()[0];
       const auto cols = dense_shape.GetDims()[1];
       size_t tuple_idx = 0;
       for (size_t i = 0; i < values_size; ++i, tuple_idx += 2) {
         auto r = indices_data[tuple_idx];
         auto c = indices_data[tuple_idx + 1];
-        ORT_RETURN_IF_NOT(r >= 0 && r < rows && c >= 0 && c < cols,
-                          "COO 2D index out of bounds: (", r, ", ", c,
-                          ") must be in [0, ", rows, ") x [0, ", cols, ")");
+        if (r < 0 || r >= rows || c < 0 || c >= cols) {
+          return OrtApis::CreateStatus(
+              ORT_INVALID_ARGUMENT,
+              MakeString("COO 2D index out of bounds: (", r, ", ", c,
+                         ") must be in [0, ", rows, ") x [0, ", cols, ")")
+                  .c_str());
+        }
       }
     } else {
       return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "COO indices count must be equal to or twice the values count.");
@@ -513,17 +523,24 @@ ORT_API_STATUS_IMPL(OrtApis::FillSparseTensorCsr, _Inout_ OrtValue* ort_value, _
   if (dense_shape.NumDimensions() == 2 && inner_indices_num > 0) {
     const auto cols = dense_shape.GetDims()[1];
     for (size_t i = 0; i < inner_indices_num; ++i) {
-      ORT_RETURN_IF_NOT(inner_indices_data[i] >= 0 && inner_indices_data[i] < cols,
-                        "CSR inner index out of bounds: ", inner_indices_data[i],
-                        " must be in [0, ", cols, ")");
+      if (inner_indices_data[i] < 0 || inner_indices_data[i] >= cols) {
+        return OrtApis::CreateStatus(
+            ORT_INVALID_ARGUMENT,
+            MakeString("CSR inner index out of bounds: ", inner_indices_data[i],
+                       " must be in [0, ", cols, ")")
+                .c_str());
+      }
     }
   }
   if (outer_indices_num > 0) {
     int64_t prev = 0;
     for (size_t i = 0; i < outer_indices_num; ++i) {
       auto val = outer_indices_data[i];
-      ORT_RETURN_IF_NOT(val >= prev && val <= static_cast<int64_t>(inner_indices_num),
-                        "CSR outer index out of bounds or not monotonically non-decreasing: ", val);
+      if (val < prev || val > static_cast<int64_t>(inner_indices_num)) {
+        return OrtApis::CreateStatus(
+            ORT_INVALID_ARGUMENT,
+            MakeString("CSR outer index out of bounds or not monotonically non-decreasing: ", val).c_str());
+      }
       prev = val;
     }
   }
@@ -645,22 +662,32 @@ ORT_API_STATUS_IMPL(OrtApis::UseCooIndices, _Inout_ OrtValue* ort_value, _Inout_
     if (indices_num == values_size) {
       const auto dense_size = dense_shape.Size();
       for (size_t i = 0; i < indices_num; ++i) {
-        ORT_RETURN_IF_NOT(indices_data[i] >= 0 && indices_data[i] < dense_size,
-                          "COO linear index out of bounds: ", indices_data[i],
-                          " must be in [0, ", dense_size, ")");
+        if (indices_data[i] < 0 || indices_data[i] >= dense_size) {
+          return OrtApis::CreateStatus(
+              ORT_INVALID_ARGUMENT,
+              MakeString("COO linear index out of bounds: ", indices_data[i],
+                         " must be in [0, ", dense_size, ")")
+                  .c_str());
+        }
       }
     } else if (indices_num / 2 == values_size && indices_num % 2 == 0) {
-      ORT_RETURN_IF_NOT(dense_shape.NumDimensions() == 2,
-                        "COO 2D indices require dense shape of 2 dimensions");
+      if (dense_shape.NumDimensions() != 2) {
+        return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
+                                     "COO 2D indices require dense shape of 2 dimensions");
+      }
       const auto rows = dense_shape.GetDims()[0];
       const auto cols = dense_shape.GetDims()[1];
       size_t tuple_idx = 0;
       for (size_t i = 0; i < values_size; ++i, tuple_idx += 2) {
         auto r = indices_data[tuple_idx];
         auto c = indices_data[tuple_idx + 1];
-        ORT_RETURN_IF_NOT(r >= 0 && r < rows && c >= 0 && c < cols,
-                          "COO 2D index out of bounds: (", r, ", ", c,
-                          ") must be in [0, ", rows, ") x [0, ", cols, ")");
+        if (r < 0 || r >= rows || c < 0 || c >= cols) {
+          return OrtApis::CreateStatus(
+              ORT_INVALID_ARGUMENT,
+              MakeString("COO 2D index out of bounds: (", r, ", ", c,
+                         ") must be in [0, ", rows, ") x [0, ", cols, ")")
+                  .c_str());
+        }
       }
     } else {
       return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "COO indices count must be equal to or twice the values count.");
@@ -696,17 +723,24 @@ ORT_API_STATUS_IMPL(OrtApis::UseCsrIndices, _Inout_ OrtValue* ort_value,
   if (dense_shape.NumDimensions() == 2 && inner_num > 0) {
     const auto cols = dense_shape.GetDims()[1];
     for (size_t i = 0; i < inner_num; ++i) {
-      ORT_RETURN_IF_NOT(inner_data[i] >= 0 && inner_data[i] < cols,
-                        "CSR inner index out of bounds: ", inner_data[i],
-                        " must be in [0, ", cols, ")");
+      if (inner_data[i] < 0 || inner_data[i] >= cols) {
+        return OrtApis::CreateStatus(
+            ORT_INVALID_ARGUMENT,
+            MakeString("CSR inner index out of bounds: ", inner_data[i],
+                       " must be in [0, ", cols, ")")
+                .c_str());
+      }
     }
   }
   if (outer_num > 0) {
     int64_t prev = 0;
     for (size_t i = 0; i < outer_num; ++i) {
       auto val = outer_data[i];
-      ORT_RETURN_IF_NOT(val >= prev && val <= static_cast<int64_t>(inner_num),
-                        "CSR outer index out of bounds or not monotonically non-decreasing: ", val);
+      if (val < prev || val > static_cast<int64_t>(inner_num)) {
+        return OrtApis::CreateStatus(
+            ORT_INVALID_ARGUMENT,
+            MakeString("CSR outer index out of bounds or not monotonically non-decreasing: ", val).c_str());
+      }
       prev = val;
     }
   }

--- a/onnxruntime/python/onnxruntime_pybind_sparse_tensor.cc
+++ b/onnxruntime/python/onnxruntime_pybind_sparse_tensor.cc
@@ -95,25 +95,29 @@ void addSparseTensorMethods(pybind11::module& m) {
   py::class_<PySparseCooView>(m, "SparseCooView")
       // Returns a numpy array of COO indices backed by Sparse Tensor memory
       // be aware that indices may reside on GPU if Sparse Tensor is on GPU
-      .def("indices", [](const PySparseCooView* view) -> py::array {
+      .def("indices", [](py::object self) -> py::array {
+        auto* view = self.cast<const PySparseCooView*>();
         const auto& indices = view->Indices();
-        return MakeNumpyArrayFromIndices(indices, py::cast(*view));
+        return MakeNumpyArrayFromIndices(indices, self);
       });
 
   py::class_<PySparseCsrView>(m, "SparseCsrView")
-      .def("inner", [](const PySparseCsrView* view) -> py::array {
+      .def("inner", [](py::object self) -> py::array {
+        auto* view = self.cast<const PySparseCsrView*>();
         const auto& indices = view->Inner();
-        return MakeNumpyArrayFromIndices(indices, py::cast(*view));
+        return MakeNumpyArrayFromIndices(indices, self);
       })
-      .def("outer", [](const PySparseCsrView* view) -> py::array {
+      .def("outer", [](py::object self) -> py::array {
+        auto* view = self.cast<const PySparseCsrView*>();
         const auto& indices = view->Outer();
-        return MakeNumpyArrayFromIndices(indices, py::cast(*view));
+        return MakeNumpyArrayFromIndices(indices, self);
       });
 
   py::class_<PySparseBlockSparseView>(m, "SparseBlockSparseView")
-      .def("indices", [](const PySparseBlockSparseView* view) -> py::array {
+      .def("indices", [](py::object self) -> py::array {
+        auto* view = self.cast<const PySparseBlockSparseView*>();
         const auto& indices = view->Indices();
-        return MakeNumpyArrayFromIndices(indices, py::cast(*view));
+        return MakeNumpyArrayFromIndices(indices, self);
       });
 
   py::class_<PySparseTensor> sparse_bind(m, "SparseTensor");
@@ -296,7 +300,8 @@ void addSparseTensorMethods(pybind11::module& m) {
           })
       // Returns a numpy array that is backed by SparseTensor values memory
       // be aware that it may be on GPU
-      .def("values", [](const PySparseTensor* py_tensor) -> py::array {
+      .def("values", [](py::object self) -> py::array {
+        auto* py_tensor = self.cast<const PySparseTensor*>();
         const SparseTensor& sparse_tensor = py_tensor->Instance();
         if (sparse_tensor.Format() == SparseFormat::kUndefined) {
           ORT_THROW("This sparse tensor instance does not contain data");
@@ -311,7 +316,7 @@ void addSparseTensorMethods(pybind11::module& m) {
           auto dtype = t_disp.InvokeRet<py::dtype, MakeDType>();
           const auto& values = sparse_tensor.Values();
           // See https://github.com/pybind/pybind11/issues/2271
-          py::array result(dtype, values.Shape().GetDims(), values.DataRaw(), py::cast(*py_tensor));
+          py::array result(dtype, values.Shape().GetDims(), values.DataRaw(), self);
           assert(!result.owndata());
           // Set a read-only flag
           PyArray_CLEARFLAGS(reinterpret_cast<PyArrayObject*>(result.ptr()), NPY_ARRAY_WRITEABLE);

--- a/onnxruntime/test/framework/sparse_kernels_test.cc
+++ b/onnxruntime/test/framework/sparse_kernels_test.cc
@@ -2294,6 +2294,166 @@ TEST(SparseTensorConversionTests, SparseTensorProtoToDense_ValuesSizeMismatch_Ra
   EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("values data size does not match expected"));
 }
 
+// Tests for SparseTensorProtoToDenseTensorProto with negative indices (model-loading path)
+TEST(SparseTensorConversionTests, SparseTensorProtoToDense_NegativeIndex_Rank1) {
+  // Dense size 4
+  // Index -1 -> negative, out of bounds
+  ONNX_NAMESPACE::SparseTensorProto sparse;
+  sparse.mutable_values()->set_name("test_neg_idx");
+  sparse.add_dims(4);
+
+  auto* val = sparse.mutable_values();
+  val->add_dims(1);
+  val->set_data_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  val->add_float_data(1.0f);
+
+  auto* ind = sparse.mutable_indices();
+  ind->add_dims(1);
+  ind->set_data_type(ONNX_NAMESPACE::TensorProto_DataType_INT64);
+  ind->add_int64_data(-1);
+
+  ONNX_NAMESPACE::TensorProto dense;
+  auto status = utils::SparseTensorProtoToDenseTensorProto(sparse, {}, dense);
+  EXPECT_FALSE(status.IsOK());
+  EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("index is out of bounds"));
+}
+
+TEST(SparseTensorConversionTests, SparseTensorProtoToDense_NegativeIndex_Rank2) {
+  // Dense Shape [3, 3]
+  // Index [-1, 0] -> negative row, out of bounds
+  ONNX_NAMESPACE::SparseTensorProto sparse;
+  sparse.mutable_values()->set_name("test_neg_idx_2d");
+  sparse.add_dims(3);
+  sparse.add_dims(3);
+
+  auto* val = sparse.mutable_values();
+  val->add_dims(1);
+  val->set_data_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  val->add_float_data(1.0f);
+
+  auto* ind = sparse.mutable_indices();
+  ind->add_dims(1);
+  ind->add_dims(2);
+  ind->set_data_type(ONNX_NAMESPACE::TensorProto_DataType_INT64);
+  ind->add_int64_data(-1);
+  ind->add_int64_data(0);
+
+  ONNX_NAMESPACE::TensorProto dense;
+  auto status = utils::SparseTensorProtoToDenseTensorProto(sparse, {}, dense);
+  EXPECT_FALSE(status.IsOK());
+  EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("index is out of bounds"));
+}
+
+// Tests for SparseCooToDenseTensor and SparseCsrToDenseTensor (sparse_utils.cc paths)
+TEST(SparseTensorConversionTests, SparseCooToDense_NegativeLinearIndex) {
+  auto* cpu_provider = TestCPUExecutionProvider();
+  auto cpu_allocator = cpu_provider->CreatePreferredAllocators()[0];
+
+  DataTransferManager dtm;
+  ASSERT_STATUS_OK(dtm.RegisterDataTransfer(cpu_provider->GetDataTransfer()));
+
+  // Create a SparseTensor with COO format and a negative linear index
+  SparseTensor src(DataTypeImpl::GetType<int32_t>(), TensorShape{3, 3}, cpu_allocator);
+  std::vector<int32_t> values = {1, 2, 3};
+  std::vector<int64_t> bad_indices = {-1, 3, 5};  // -1 is invalid
+
+  ASSERT_STATUS_OK(src.MakeCooData(*cpu_provider->GetDataTransfer(), cpu_allocator->Info(),
+                                   values.size(), values.data(), gsl::make_span(bad_indices)));
+
+  Tensor dense_dst;
+  auto status = sparse_utils::SparseCooToDenseTensor(dtm, src, cpu_allocator, cpu_allocator, dense_dst);
+  EXPECT_FALSE(status.IsOK());
+  EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("Invalid COO index"));
+}
+
+TEST(SparseTensorConversionTests, SparseCooToDense_UpperBoundLinearIndex) {
+  auto* cpu_provider = TestCPUExecutionProvider();
+  auto cpu_allocator = cpu_provider->CreatePreferredAllocators()[0];
+
+  DataTransferManager dtm;
+  ASSERT_STATUS_OK(dtm.RegisterDataTransfer(cpu_provider->GetDataTransfer()));
+
+  // Dense 3x3 = 9 elements. Index 9 is out of bounds (valid: 0-8)
+  SparseTensor src(DataTypeImpl::GetType<int32_t>(), TensorShape{3, 3}, cpu_allocator);
+  std::vector<int32_t> values = {1, 2, 3};
+  std::vector<int64_t> bad_indices = {0, 3, 9};
+
+  ASSERT_STATUS_OK(src.MakeCooData(*cpu_provider->GetDataTransfer(), cpu_allocator->Info(),
+                                   values.size(), values.data(), gsl::make_span(bad_indices)));
+
+  Tensor dense_dst;
+  auto status = sparse_utils::SparseCooToDenseTensor(dtm, src, cpu_allocator, cpu_allocator, dense_dst);
+  EXPECT_FALSE(status.IsOK());
+  EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("Invalid COO index"));
+}
+
+TEST(SparseTensorConversionTests, SparseCooToDense_Negative2DIndex) {
+  auto* cpu_provider = TestCPUExecutionProvider();
+  auto cpu_allocator = cpu_provider->CreatePreferredAllocators()[0];
+
+  DataTransferManager dtm;
+  ASSERT_STATUS_OK(dtm.RegisterDataTransfer(cpu_provider->GetDataTransfer()));
+
+  // 2D indices: (-1, 0) is invalid
+  SparseTensor src(DataTypeImpl::GetType<int32_t>(), TensorShape{3, 3}, cpu_allocator);
+  std::vector<int32_t> values = {1, 2};
+  std::vector<int64_t> bad_indices = {-1, 0, 1, 1};  // 2D, first entry has negative row
+
+  ASSERT_STATUS_OK(src.MakeCooData(*cpu_provider->GetDataTransfer(), cpu_allocator->Info(),
+                                   values.size(), values.data(), gsl::make_span(bad_indices)));
+
+  Tensor dense_dst;
+  auto status = sparse_utils::SparseCooToDenseTensor(dtm, src, cpu_allocator, cpu_allocator, dense_dst);
+  EXPECT_FALSE(status.IsOK());
+  EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("Invalid COO 2D index"));
+}
+
+TEST(SparseTensorConversionTests, SparseCsrToDense_NegativeColumnIndex) {
+  auto* cpu_provider = TestCPUExecutionProvider();
+  auto cpu_allocator = cpu_provider->CreatePreferredAllocators()[0];
+
+  DataTransferManager dtm;
+  ASSERT_STATUS_OK(dtm.RegisterDataTransfer(cpu_provider->GetDataTransfer()));
+
+  // 3x3 dense, CSR with a negative column index
+  SparseTensor src(DataTypeImpl::GetType<int32_t>(), TensorShape{3, 3}, cpu_allocator);
+  std::vector<int32_t> values = {1, 2, 3};
+  std::vector<int64_t> inner = {-1, 0, 2};  // -1 is invalid column
+  std::vector<int64_t> outer = {0, 1, 2, 3};
+
+  ASSERT_STATUS_OK(src.MakeCsrData(*cpu_provider->GetDataTransfer(), cpu_allocator->Info(),
+                                   values.size(), values.data(),
+                                   gsl::make_span(inner), gsl::make_span(outer)));
+
+  Tensor dense_dst;
+  auto status = sparse_utils::SparseCsrToDenseTensor(dtm, src, cpu_allocator, cpu_allocator, dense_dst);
+  EXPECT_FALSE(status.IsOK());
+  EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("Invalid CSR column index"));
+}
+
+TEST(SparseTensorConversionTests, SparseCsrToDense_ColumnIndexOutOfBounds) {
+  auto* cpu_provider = TestCPUExecutionProvider();
+  auto cpu_allocator = cpu_provider->CreatePreferredAllocators()[0];
+
+  DataTransferManager dtm;
+  ASSERT_STATUS_OK(dtm.RegisterDataTransfer(cpu_provider->GetDataTransfer()));
+
+  // 3x3 dense, CSR with column index 3 (valid: 0-2)
+  SparseTensor src(DataTypeImpl::GetType<int32_t>(), TensorShape{3, 3}, cpu_allocator);
+  std::vector<int32_t> values = {1, 2, 3};
+  std::vector<int64_t> inner = {1, 3, 1};  // 3 is out of bounds for 3 columns
+  std::vector<int64_t> outer = {0, 1, 2, 3};
+
+  ASSERT_STATUS_OK(src.MakeCsrData(*cpu_provider->GetDataTransfer(), cpu_allocator->Info(),
+                                   values.size(), values.data(),
+                                   gsl::make_span(inner), gsl::make_span(outer)));
+
+  Tensor dense_dst;
+  auto status = sparse_utils::SparseCsrToDenseTensor(dtm, src, cpu_allocator, cpu_allocator, dense_dst);
+  EXPECT_FALSE(status.IsOK());
+  EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("Invalid CSR column index"));
+}
+
 #endif  // !defined(DISABLE_SPARSE_TENSORS)
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/framework/sparse_kernels_test.cc
+++ b/onnxruntime/test/framework/sparse_kernels_test.cc
@@ -2454,6 +2454,91 @@ TEST(SparseTensorConversionTests, SparseCsrToDense_ColumnIndexOutOfBounds) {
   EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("Invalid CSR column index"));
 }
 
+// Regression test: SparseCsrToDenseTensor must use correct source index for each
+// non-zero value. Previously src_idx was never incremented, so all entries got values[0].
+// Using distinct values exposes this bug.
+TEST(SparseTensorConversionTests, SparseCsrToDense_DistinctValuesRoundtrip) {
+  auto* cpu_provider = TestCPUExecutionProvider();
+  auto cpu_allocator = cpu_provider->CreatePreferredAllocators()[0];
+
+  DataTransferManager dtm;
+  ASSERT_STATUS_OK(dtm.RegisterDataTransfer(cpu_provider->GetDataTransfer()));
+
+  // 3x3 dense matrix:
+  //   0  0  10
+  //  20  0  30
+  //   0  0   0
+  // CSR: values={10, 20, 30}, inner(col)={2, 0, 2}, outer={0, 1, 3, 3}
+  SparseTensor src(DataTypeImpl::GetType<int32_t>(), TensorShape{3, 3}, cpu_allocator);
+  std::vector<int32_t> values = {10, 20, 30};
+  std::vector<int64_t> inner = {2, 0, 2};
+  std::vector<int64_t> outer = {0, 1, 3, 3};
+
+  ASSERT_STATUS_OK(src.MakeCsrData(*cpu_provider->GetDataTransfer(), cpu_allocator->Info(),
+                                   values.size(), values.data(),
+                                   gsl::make_span(inner), gsl::make_span(outer)));
+
+  Tensor dense_dst;
+  ASSERT_STATUS_OK(sparse_utils::SparseCsrToDenseTensor(dtm, src, cpu_allocator, cpu_allocator, dense_dst));
+
+  std::vector<int32_t> expected_dense = {
+      0, 0, 10,
+      20, 0, 30,
+      0, 0, 0};
+
+  auto dense_span = dense_dst.DataAsSpan<int32_t>();
+  ASSERT_EQ(dense_span.size(), expected_dense.size());
+  for (size_t i = 0; i < expected_dense.size(); ++i) {
+    EXPECT_EQ(dense_span[i], expected_dense[i]) << "Mismatch at index " << i;
+  }
+}
+
+// Test that COO 2D validation catches out-of-range column even when
+// the linearized index would be in bounds. E.g., for a 3x3 matrix,
+// (row=0, col=4) gives linear index 4 which is in [0,9), but col=4 >= cols=3.
+TEST(SparseTensorConversionTests, SparseCooToDense_2DColumnOutOfRange) {
+  auto* cpu_provider = TestCPUExecutionProvider();
+  auto cpu_allocator = cpu_provider->CreatePreferredAllocators()[0];
+
+  DataTransferManager dtm;
+  ASSERT_STATUS_OK(dtm.RegisterDataTransfer(cpu_provider->GetDataTransfer()));
+
+  SparseTensor src(DataTypeImpl::GetType<int32_t>(), TensorShape{3, 3}, cpu_allocator);
+  std::vector<int32_t> values = {1};
+  // (row=0, col=4): linear index = 0*3+4 = 4, valid linear but col >= cols
+  std::vector<int64_t> bad_indices = {0, 4};
+
+  ASSERT_STATUS_OK(src.MakeCooData(*cpu_provider->GetDataTransfer(), cpu_allocator->Info(),
+                                   values.size(), values.data(), gsl::make_span(bad_indices)));
+
+  Tensor dense_dst;
+  auto status = sparse_utils::SparseCooToDenseTensor(dtm, src, cpu_allocator, cpu_allocator, dense_dst);
+  EXPECT_FALSE(status.IsOK());
+  EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("Invalid COO 2D index"));
+}
+
+// Test that COO 2D validation catches out-of-range row.
+TEST(SparseTensorConversionTests, SparseCooToDense_2DRowOutOfRange) {
+  auto* cpu_provider = TestCPUExecutionProvider();
+  auto cpu_allocator = cpu_provider->CreatePreferredAllocators()[0];
+
+  DataTransferManager dtm;
+  ASSERT_STATUS_OK(dtm.RegisterDataTransfer(cpu_provider->GetDataTransfer()));
+
+  SparseTensor src(DataTypeImpl::GetType<int32_t>(), TensorShape{3, 3}, cpu_allocator);
+  std::vector<int32_t> values = {1};
+  // (row=3, col=0): row >= rows
+  std::vector<int64_t> bad_indices = {3, 0};
+
+  ASSERT_STATUS_OK(src.MakeCooData(*cpu_provider->GetDataTransfer(), cpu_allocator->Info(),
+                                   values.size(), values.data(), gsl::make_span(bad_indices)));
+
+  Tensor dense_dst;
+  auto status = sparse_utils::SparseCooToDenseTensor(dtm, src, cpu_allocator, cpu_allocator, dense_dst);
+  EXPECT_FALSE(status.IsOK());
+  EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("Invalid COO 2D index"));
+}
+
 #endif  // !defined(DISABLE_SPARSE_TENSORS)
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/shared_lib/test_nontensor_types.cc
+++ b/onnxruntime/test/shared_lib/test_nontensor_types.cc
@@ -1256,4 +1256,100 @@ TEST(CApiTest, SparseTensorFillSparseFormatStringsAPI) {
     }
   }
 }
+
+#if !defined(ORT_NO_EXCEPTIONS)
+TEST(CApiTest, SparseTensorInvalidIndicesValidation) {
+  auto allocator = Ort::AllocatorWithDefaultOptions();
+  Ort::MemoryInfo info("Cpu", OrtDeviceAllocator, 0, OrtMemTypeDefault);
+
+  // Common dense shape and values
+  const std::vector<int64_t> dense_shape{3, 3};
+  Ort::Value::Shape ort_dense_shape{dense_shape.data(), dense_shape.size()};
+  std::vector<int32_t> values = {1, 1, 1};
+  constexpr int64_t values_len = 3;
+
+  //
+  // COO Negative linear index
+  //
+  {
+    auto coo_st = Ort::Value::CreateSparseTensor<int32_t>(allocator, ort_dense_shape);
+    std::vector<int64_t> linear_indices = {-1, 3, 5};
+    ASSERT_THROW(
+        coo_st.FillSparseTensorCoo(info, {&values_len, 1U, {values.data()}},
+                                   linear_indices.data(), linear_indices.size()),
+        Ort::Exception);
+  }
+
+  //
+  // COO Linear index out of upper bounds
+  //
+  {
+    auto coo_st = Ort::Value::CreateSparseTensor<int32_t>(allocator, ort_dense_shape);
+    std::vector<int64_t> linear_indices = {0, 3, 9};  // 9 is out of bounds for 3x3=9 (0-8)
+    ASSERT_THROW(
+        coo_st.FillSparseTensorCoo(info, {&values_len, 1U, {values.data()}},
+                                   linear_indices.data(), linear_indices.size()),
+        Ort::Exception);
+  }
+
+  //
+  // COO 2D indices out of row bounds
+  //
+  {
+    auto coo_st = Ort::Value::CreateSparseTensor<int32_t>(allocator, ort_dense_shape);
+    std::vector<int64_t> dim_indices = {
+        0, 1,  // Valid
+        3, 0,  // Invalid row 3
+        2, 2   // Valid
+    };
+    ASSERT_THROW(
+        coo_st.FillSparseTensorCoo(info, {&values_len, 1U, {values.data()}},
+                                   dim_indices.data(), dim_indices.size()),
+        Ort::Exception);
+  }
+
+  //
+  // CSR inner index out of column bounds
+  //
+  {
+    auto csr_st = Ort::Value::CreateSparseTensor<int32_t>(allocator, ort_dense_shape);
+    std::vector<int64_t> inner_indices = {1, 3, 1};  // 3 is out of bounds for 3 cols (0-2)
+    std::vector<int64_t> outer_indices = {0, 1, 2, 3};
+    ASSERT_THROW(
+        csr_st.FillSparseTensorCsr(info, {&values_len, 1U, {values.data()}},
+                                   inner_indices.data(), inner_indices.size(),
+                                   outer_indices.data(), outer_indices.size()),
+        Ort::Exception);
+  }
+
+  //
+  // CSR outer index not monotonically non-decreasing
+  //
+  {
+    auto csr_st = Ort::Value::CreateSparseTensor<int32_t>(allocator, ort_dense_shape);
+    std::vector<int64_t> inner_indices = {0, 1, 2};
+    std::vector<int64_t> outer_indices = {0, 2, 1, 3};  // Drops from 2 to 1
+    ASSERT_THROW(
+        csr_st.FillSparseTensorCsr(info, {&values_len, 1U, {values.data()}},
+                                   inner_indices.data(), inner_indices.size(),
+                                   outer_indices.data(), outer_indices.size()),
+        Ort::Exception);
+  }
+
+  //
+  // CSR outer index out of upper bounds (greater than inner_indices.size())
+  //
+  {
+    auto csr_st = Ort::Value::CreateSparseTensor<int32_t>(allocator, ort_dense_shape);
+    std::vector<int64_t> inner_indices = {0, 1, 2};
+    std::vector<int64_t> outer_indices = {0, 1, 2, 4};  // 4 is > inner_indices.size() (3)
+    ASSERT_THROW(
+        csr_st.FillSparseTensorCsr(info, {&values_len, 1U, {values.data()}},
+                                   inner_indices.data(), inner_indices.size(),
+                                   outer_indices.data(), outer_indices.size()),
+        Ort::Exception);
+  }
+}
+#endif  // !defined(ORT_NO_EXCEPTIONS)
+
 #endif  // !defined(DISABLE_SPARSE_TENSORS)


### PR DESCRIPTION
This pull request significantly improves the safety and robustness of sparse tensor handling in ONNX Runtime. The main focus is on adding thorough bounds checking and using safe integer arithmetic to prevent overflows and invalid memory accesses when working with sparse tensor indices. Additionally, the Python bindings for sparse tensors are refactored to ensure correct object lifetimes and memory management when exposing data to NumPy.

**Sparse Tensor Index Validation and Safety**

* Added comprehensive bounds checks for COO and CSR sparse tensor indices in both the C API (`onnxruntime_c_api.cc`) and core conversion utilities, ensuring indices are within valid ranges and, for CSR, that outer indices are non-decreasing and within bounds. [[1]](diffhunk://#diff-cff364b6b1ab4ef507d87a661a97b873405f569797fcaf91af29491f223555a8R449-R485) [[2]](diffhunk://#diff-cff364b6b1ab4ef507d87a661a97b873405f569797fcaf91af29491f223555a8R521-R547) [[3]](diffhunk://#diff-cff364b6b1ab4ef507d87a661a97b873405f569797fcaf91af29491f223555a8R659-R696) [[4]](diffhunk://#diff-cff364b6b1ab4ef507d87a661a97b873405f569797fcaf91af29491f223555a8R721-R747) [[5]](diffhunk://#diff-620fd022510c5134fc9bd3c8d01bc5772cc78a82043b0da5e44cf2482038dc37L267-R273) [[6]](diffhunk://#diff-620fd022510c5134fc9bd3c8d01bc5772cc78a82043b0da5e44cf2482038dc37L359-R376)
* Replaced direct arithmetic with `SafeInt` for all index and size calculations to prevent integer overflows, especially when converting between types or computing dense tensor offsets. [[1]](diffhunk://#diff-620fd022510c5134fc9bd3c8d01bc5772cc78a82043b0da5e44cf2482038dc37L267-R273) [[2]](diffhunk://#diff-d31e9fbe0f5334fcd949833e035f2b25d5ae810dcd505c545f6b372b546b1406L2077-R2077) [[3]](diffhunk://#diff-d31e9fbe0f5334fcd949833e035f2b25d5ae810dcd505c545f6b372b546b1406L2091-R2091) [[4]](diffhunk://#diff-d31e9fbe0f5334fcd949833e035f2b25d5ae810dcd505c545f6b372b546b1406L2110-R2110) [[5]](diffhunk://#diff-d31e9fbe0f5334fcd949833e035f2b25d5ae810dcd505c545f6b372b546b1406L2291-R2298)
* Improved error messages for invalid indices, making debugging easier by providing more context about the specific error. [[1]](diffhunk://#diff-cff364b6b1ab4ef507d87a661a97b873405f569797fcaf91af29491f223555a8R449-R485) [[2]](diffhunk://#diff-cff364b6b1ab4ef507d87a661a97b873405f569797fcaf91af29491f223555a8R521-R547) [[3]](diffhunk://#diff-cff364b6b1ab4ef507d87a661a97b873405f569797fcaf91af29491f223555a8R659-R696) [[4]](diffhunk://#diff-cff364b6b1ab4ef507d87a661a97b873405f569797fcaf91af29491f223555a8R721-R747) [[5]](diffhunk://#diff-620fd022510c5134fc9bd3c8d01bc5772cc78a82043b0da5e44cf2482038dc37L267-R273) [[6]](diffhunk://#diff-620fd022510c5134fc9bd3c8d01bc5772cc78a82043b0da5e44cf2482038dc37L359-R376)

**Python Bindings Improvements**

* Refactored the pybind11 bindings for sparse tensor views so that NumPy arrays referencing sparse tensor memory correctly keep the parent Python object alive, preventing potential memory issues when the sparse tensor is on the GPU or managed by Python. [[1]](diffhunk://#diff-3c1b21fe3d5903c277b4d3888f5a4c57ff8f8f6f593183a3f4865825c5ab8e0cL98-R120) [[2]](diffhunk://#diff-3c1b21fe3d5903c277b4d3888f5a4c57ff8f8f6f593183a3f4865825c5ab8e0cL299-R304) [[3]](diffhunk://#diff-3c1b21fe3d5903c277b4d3888f5a4c57ff8f8f6f593183a3f4865825c5ab8e0cL314-R319)

**General Code Quality**

* Added missing header include for `safeint.h` to ensure `SafeInt` is available where needed.
* Minor cleanups and improved assertions to clarify intent and ensure correctness.

These changes collectively make sparse tensor support in ONNX Runtime safer, more reliable, and easier to use from both C++ and Python.