### PR TITLE
fix(quantization): emit axis on DequantizeLinear for per-channel dynamic quantization

### DIFF
--- a/onnxruntime/python/tools/quantization/onnx_quantizer.py
+++ b/onnxruntime/python/tools/quantization/onnx_quantizer.py
@@ -1072,7 +1072,7 @@ class ONNXQuantizer(BaseQuantizer):
             scale_name,
             zp_name,
             QuantizedValueType.Initializer,
-            None,
+            channel_axis,
         )
         self.quantized_value_map[weight_name] = quantized_value
 
@@ -1097,8 +1097,9 @@ class ONNXQuantizer(BaseQuantizer):
             if self.model.model.producer_name != "onnx-quantizer" or (
                 self.model.model.producer_name == "onnx-quantizer" and scale_init is not None
             ):
-                # axis is not specified so scale_init must be a scalar.
-                assert scale_init is None or onnx.numpy_helper.to_array(scale_init).size == 1
+                # Per-tensor (axis=None) requires a scalar scale.
+                if quantized_value.axis is None:
+                    assert scale_init is None or onnx.numpy_helper.to_array(scale_init).size == 1
 
             dqlinear_name = value_name + "_DequantizeLinear"
             dqlinear_node = self.model.find_node_by_name(dqlinear_name, self.new_nodes, self.model.graph())
@@ -1109,7 +1110,11 @@ class ONNXQuantizer(BaseQuantizer):
                     quantized_value.zp_name,
                 ]
                 dequantize_node = onnx.helper.make_node(
-                    "DequantizeLinear", dqlinear_inputs, [value_name], dqlinear_name
+                    "DequantizeLinear",
+                    dqlinear_inputs,
+                    [value_name],
+                    dqlinear_name,
+                    axis=quantized_value.axis,
                 )
                 return dequantize_node
             else:

--- a/onnxruntime/test/python/quantization/test_quant_issues.py
+++ b/onnxruntime/test/python/quantization/test_quant_issues.py
@@ -126,10 +126,11 @@ class TestQuantIssues(unittest.TestCase):
         `quantize_dynamic(per_channel=True)` previously constructed QuantizedValue
         with axis=None and built DequantizeLinear without an axis attribute, producing
         an invalid per-tensor dequantization for per-channel quantized weights.
-        When the per-channel quantized weight also appears as a graph output,
-        _dequantize_outputs calls _dequantize_value, which triggered an assertion
-        error (scale not scalar) and would have emitted a DequantizeLinear lacking
-        the required axis attribute.
+        The quantizer encounters the unsupported `Identity` op consuming `weight`
+        and dequantizes the (now-quantized) per-channel weight initializer back to
+        float for it. That `_dequantize_value` call previously triggered an
+        assertion error (scale not scalar) and would have emitted a
+        DequantizeLinear lacking the required axis attribute.
         """
         try:
             import numpy as np  # noqa: PLC0415
@@ -141,9 +142,11 @@ class TestQuantIssues(unittest.TestCase):
             raise unittest.SkipTest(f"Required import missing: {exc}") from exc
 
         # Build a model: input (5, 4) @ weight (4, 8) -> output (5, 8).
-        # The weight is also passed through Identity and exposed as a second graph
-        # output so that _dequantize_outputs calls _dequantize_value on the
-        # per-channel-quantized weight initializer.
+        # The weight is also fed through Identity (an op the quantizer does not
+        # support); when the quantizer processes that Identity it dequantizes
+        # the per-channel-quantized weight initializer via _dequantize_value
+        # so the Identity input remains float. Exposing the Identity output as
+        # a graph output keeps the Identity reachable from the optimized graph.
         # Weight axis=1 is the output-feature axis (per-channel quantization target).
         np.random.seed(42)
         weight_data = np.random.normal(0, 0.1, (4, 8)).astype(np.float32)

--- a/onnxruntime/test/python/quantization/test_quant_issues.py
+++ b/onnxruntime/test/python/quantization/test_quant_issues.py
@@ -119,6 +119,95 @@ class TestQuantIssues(unittest.TestCase):
                 f"Expected quantized model at {output_path!r}",
             )
 
+    def test_dynamic_quantize_per_channel_emits_axis_attribute(self):
+        """Per-channel dynamic quantization must emit axis on DequantizeLinear nodes.
+
+        Regression test for https://github.com/microsoft/onnxruntime/issues/19997.
+        `quantize_dynamic(per_channel=True)` previously constructed QuantizedValue
+        with axis=None and built DequantizeLinear without an axis attribute, producing
+        an invalid per-tensor dequantization for per-channel quantized weights.
+        When the per-channel quantized weight also appears as a graph output,
+        _dequantize_outputs calls _dequantize_value, which triggered an assertion
+        error (scale not scalar) and would have emitted a DequantizeLinear lacking
+        the required axis attribute.
+        """
+        try:
+            import numpy as np  # noqa: PLC0415
+            import onnx  # noqa: PLC0415
+            from onnx import TensorProto, helper, numpy_helper  # noqa: PLC0415
+
+            from onnxruntime.quantization import QuantType, quantize_dynamic  # noqa: PLC0415
+        except ImportError as exc:
+            raise unittest.SkipTest(f"Required import missing: {exc}") from exc
+
+        # Build a model: input (5, 4) @ weight (4, 8) -> output (5, 8).
+        # The weight is also passed through Identity and exposed as a second graph
+        # output so that _dequantize_outputs calls _dequantize_value on the
+        # per-channel-quantized weight initializer.
+        # Weight axis=1 is the output-feature axis (per-channel quantization target).
+        np.random.seed(42)
+        weight_data = np.random.normal(0, 0.1, (4, 8)).astype(np.float32)
+        weight_init = numpy_helper.from_array(weight_data, name="weight")
+
+        input_vi = helper.make_tensor_value_info("input", TensorProto.FLOAT, [5, 4])
+        output_vi = helper.make_tensor_value_info("output", TensorProto.FLOAT, [5, 8])
+        weight_out_vi = helper.make_tensor_value_info("weight_out", TensorProto.FLOAT, [4, 8])
+
+        matmul_node = helper.make_node("MatMul", ["input", "weight"], ["output"])
+        identity_node = helper.make_node("Identity", ["weight"], ["weight_out"])
+
+        graph = helper.make_graph(
+            [matmul_node, identity_node],
+            "test_graph",
+            [input_vi],
+            [output_vi, weight_out_vi],
+            [weight_init],
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+        model.ir_version = 8
+
+        with tempfile.TemporaryDirectory() as tmp:
+            model_fp_path = os.path.join(tmp, "model_fp.onnx")
+            model_q_path = os.path.join(tmp, "model_q.onnx")
+            onnx.save(model, model_fp_path)
+
+            # This must not raise AssertionError due to per-channel scale not being scalar.
+            quantize_dynamic(
+                model_fp_path,
+                model_q_path,
+                per_channel=True,
+                weight_type=QuantType.QInt8,
+            )
+
+            q_model = onnx.load(model_q_path)
+
+        # Find the DequantizeLinear node that dequantizes the weight initializer.
+        init_names = {init.name for init in q_model.graph.initializer}
+        dq_nodes = [n for n in q_model.graph.node if n.op_type == "DequantizeLinear"]
+        self.assertGreater(len(dq_nodes), 0, "Expected at least one DequantizeLinear node")
+
+        weight_dq = None
+        for node in dq_nodes:
+            if node.input[0] in init_names:
+                weight_dq = node
+                break
+        self.assertIsNotNone(weight_dq, "No DequantizeLinear node found with a weight initializer as input")
+
+        # The axis attribute must be present.
+        # MatMulInteger passes axis=-1 (last dimension) to quantize_weight_per_channel.
+        axis_attrs = [attr for attr in weight_dq.attribute if attr.name == "axis"]
+        self.assertEqual(len(axis_attrs), 1, "DequantizeLinear node is missing the 'axis' attribute")
+        # MatMulInteger quantizes weight with axis=-1 (default in __quantize_inputs).
+        self.assertEqual(axis_attrs[0].i, -1, f"Expected axis=-1, got axis={axis_attrs[0].i}")
+
+        # The scale initializer must be 1-D with size > 1 (truly per-channel, not collapsed).
+        scale_name = weight_dq.input[1]
+        scale_init = next((i for i in q_model.graph.initializer if i.name == scale_name), None)
+        self.assertIsNotNone(scale_init, f"Scale initializer '{scale_name}' not found")
+        scale_array = numpy_helper.to_array(scale_init)
+        self.assertEqual(scale_array.ndim, 1, f"Expected 1-D scale, got shape {scale_array.shape}")
+        self.assertGreater(scale_array.size, 1, "Scale has only one element; expected per-channel scale")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- Fix `quantize_dynamic(per_channel=True)` so weights quantized per-channel produce a `DequantizeLinear` node with the correct `axis` attribute.
- Stop dropping the channel axis when `quantize_weight_per_channel` populates `QuantizedValue` (was hardcoded to `None`).
- Gate the scalar-scale assertion in `_dequantize_value` on `axis is None` so per-channel scales (1-D tensors) are accepted.

## Motivation
Fixes #19997.

When a model is quantized with `quantize_dynamic(..., per_channel=True)` and a per-channel weight reaches `_dequantize_value` (e.g. via `_dequantize_outputs` when the weight is in the graph outputs), two bugs surface:

1. `quantize_weight_per_channel` stores `QuantizedValue.axis = None` even though it received a real `channel_axis`, so the per-channel information is lost.
2. `_dequantize_value` (a) asserts `scale_init.size == 1`, which fails for a 1-D per-channel scale, and (b) builds the `DequantizeLinear` node without an `axis` attribute, producing an invalid ONNX node when the model is consumed.

PR #22283 (Nov 2024) softened the assertion against `None`-typed scales but left the underlying axis-propagation bug in place.

## Changes
- `onnxruntime/python/tools/quantization/onnx_quantizer.py`
  - `quantize_weight_per_channel`: pass `channel_axis` (was `None`) into `QuantizedValue`.
  - `_dequantize_value`: only require a scalar scale on the per-tensor path (`axis is None`); forward `axis=quantized_value.axis` to `onnx.helper.make_node("DequantizeLinear", ...)`. `make_node` silently omits the attribute when `axis` is `None`, so the per-tensor path is unchanged.
- `onnxruntime/test/python/quantization/test_quant_issues.py`
  - New regression test `test_dynamic_quantize_per_channel_emits_axis_attribute` that builds a minimal MatMul model with the weight routed to a graph output (to force the `_dequantize_outputs` -> `_dequantize_value` path), runs `quantize_dynamic(per_channel=True)`, and asserts the emitted `DequantizeLinear` has the `axis` attribute and a 1-D multi-element scale initializer.

## Test Plan
- `python -m pytest onnxruntime/test/python/quantization/test_quant_issues.py -xvs` — new test passes; existing test skipped as before.
- `python -m pytest onnxruntime/test/python/quantization/test_op_matmul.py` — 7 passed, 8 skipped (no regression).
- `python -m pytest onnxruntime/test/python/quantization/test_qdq.py -k per_channel` — 1 passed.
- `lintrunner -a` on changed files: clean.