### PR TITLE
Fix CrossEntropyLoss block to support multi-output models

### DIFF
--- a/orttraining/orttraining/python/training/onnxblock/_graph_utils.py
+++ b/orttraining/orttraining/python/training/onnxblock/_graph_utils.py
@@ -25,6 +25,39 @@ def get_input_from_input_name(onnx_model: onnx.ModelProto, input_name: str) -> o
     raise LookupError(f"The provided output name {input_name} is not a graph input.")
 
 
+def get_value_info_for_name(onnx_model: onnx.ModelProto, name: str) -> onnx.ValueInfoProto:
+    """Returns the ValueInfoProto for the given name by searching graph outputs, inputs, and value_info.
+
+    Searches in order: graph.output -> graph.input -> graph.value_info. This allows callers to
+    resolve type information for any tensor in the graph, including intermediate tensors that are
+    not yet promoted to graph outputs.
+
+    Args:
+        onnx_model: the ONNX model whose graph is searched.
+        name: the tensor name to look up.
+
+    Returns:
+        The matching ValueInfoProto.
+
+    Raises:
+        LookupError: if no match is found in any of the three collections.
+    """
+
+    for vi in onnx_model.graph.output:
+        if vi.name == name:
+            return vi
+
+    for vi in onnx_model.graph.input:
+        if vi.name == name:
+            return vi
+
+    for vi in onnx_model.graph.value_info:
+        if vi.name == name:
+            return vi
+
+    raise LookupError(f"The provided name '{name}' was not found in graph outputs, inputs, or value_info.")
+
+
 _GRAPH_TOKEN = 0
 
 

--- a/orttraining/orttraining/python/training/onnxblock/_graph_utils.py
+++ b/orttraining/orttraining/python/training/onnxblock/_graph_utils.py
@@ -26,22 +26,7 @@ def get_input_from_input_name(onnx_model: onnx.ModelProto, input_name: str) -> o
 
 
 def get_value_info_for_name(onnx_model: onnx.ModelProto, name: str) -> onnx.ValueInfoProto:
-    """Returns the ValueInfoProto for the given name by searching graph outputs, inputs, and value_info.
-
-    Searches in order: graph.output -> graph.input -> graph.value_info. This allows callers to
-    resolve type information for any tensor in the graph, including intermediate tensors that are
-    not yet promoted to graph outputs.
-
-    Args:
-        onnx_model: the ONNX model whose graph is searched.
-        name: the tensor name to look up.
-
-    Returns:
-        The matching ValueInfoProto.
-
-    Raises:
-        LookupError: if no match is found in any of the three collections.
-    """
+    """Returns the value info for `name`, searching graph outputs, inputs, then value_info."""
 
     for vi in onnx_model.graph.output:
         if vi.name == name:
@@ -55,7 +40,7 @@ def get_value_info_for_name(onnx_model: onnx.ModelProto, name: str) -> onnx.Valu
         if vi.name == name:
             return vi
 
-    raise LookupError(f"The provided name '{name}' was not found in graph outputs, inputs, or value_info.")
+    raise LookupError(f"The provided name {name} was not found in graph outputs, inputs, or value_info.")
 
 
 _GRAPH_TOKEN = 0

--- a/orttraining/orttraining/python/training/onnxblock/loss/loss.py
+++ b/orttraining/orttraining/python/training/onnxblock/loss/loss.py
@@ -116,6 +116,16 @@ class CrossEntropyLoss(blocks.Block):
         )
         self.base.graph.node.append(loss_node)
 
+        # Register log_prob in value_info so the gradient builder can resolve
+        # O(1) (the second output of SoftmaxCrossEntropyLoss).  Without this,
+        # graph optimizers may drop the output def and cause a C++ assertion.
+        scores_info = _graph_utils.get_output_from_output_name(self.base, scores_input_name)
+        scores_elem_type = scores_info.type.tensor_type.elem_type
+        if not any(vi.name == log_prob_output_name for vi in self.base.graph.value_info):
+            self.base.graph.value_info.append(
+                onnx.helper.make_tensor_value_info(log_prob_output_name, scores_elem_type, None)
+            )
+
         return loss_node_output_name
 
 

--- a/orttraining/orttraining/python/training/onnxblock/loss/loss.py
+++ b/orttraining/orttraining/python/training/onnxblock/loss/loss.py
@@ -119,7 +119,7 @@ class CrossEntropyLoss(blocks.Block):
         # Register log_prob in value_info so the gradient builder can resolve
         # O(1) (the second output of SoftmaxCrossEntropyLoss).  Without this,
         # graph optimizers may drop the output def and cause a C++ assertion.
-        scores_info = _graph_utils.get_output_from_output_name(self.base, scores_input_name)
+        scores_info = _graph_utils.get_value_info_for_name(self.base, scores_input_name)
         scores_elem_type = scores_info.type.tensor_type.elem_type
         if not any(vi.name == log_prob_output_name for vi in self.base.graph.value_info):
             self.base.graph.value_info.append(

--- a/orttraining/orttraining/python/training/onnxblock/loss/loss.py
+++ b/orttraining/orttraining/python/training/onnxblock/loss/loss.py
@@ -89,7 +89,7 @@ class CrossEntropyLoss(blocks.Block):
         if not _graph_utils.node_arg_exists(self.base, labels_name):
             # Create a new graph input. This is the labels input needed to compare
             # the graph output against to calculate loss.
-            labels_input = copy.deepcopy(_graph_utils.get_output_from_output_name(self.base, scores_input_name))
+            labels_input = copy.deepcopy(_graph_utils.get_value_info_for_name(self.base, scores_input_name))
             labels_input.name = labels_name
             labels_input.type.tensor_type.elem_type = onnx.TensorProto.INT64
             # Assumes classes is the last dimension

--- a/orttraining/orttraining/test/python/orttraining_test_ort_apis_onnxblock.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ort_apis_onnxblock.py
@@ -1187,3 +1187,60 @@ def test_generate_artifacts_external_data_separate_files(loss):
         assert os.path.exists(os.path.join(temp_dir, "eval_model.onnx"))
         assert os.path.exists(os.path.join(temp_dir, "optimizer_model.onnx"))
         assert os.path.exists(os.path.join(temp_dir, "checkpoint"))
+
+
+def test_crossentropy_loss_multi_output_model():
+    """Regression test for https://github.com/microsoft/onnxruntime/issues/22465.
+
+    generate_artifacts with CrossEntropyLoss must not raise a C++ assertion
+    (i < node_->OutputDefs().size()) when the base model has a multi-dimensional
+    output (e.g. shape [batch, seq_len, vocab_size]).  The root cause was that
+    CrossEntropyLoss.build() constructed a SoftmaxCrossEntropyLoss node with two
+    outputs (loss, log_prob) but never registered log_prob in value_info, causing
+    the gradient builder to dereference a missing output def.
+    """
+
+    class MultiOutputNet(torch.nn.Module):
+        """Simple seq2seq-style model whose output is 3-D (batch, seq, vocab)."""
+
+        def __init__(self, vocab_size: int = 16, hidden_size: int = 8):
+            super().__init__()
+            self.embed = torch.nn.Embedding(vocab_size, hidden_size)
+            self.linear = torch.nn.Linear(hidden_size, vocab_size)
+
+        def forward(self, x):
+            # x: (batch, seq_len)  -> output: (batch, seq_len, vocab_size)
+            return self.linear(self.embed(x))
+
+    vocab_size = 16
+    batch_size = 2
+    seq_len = 4
+    model = MultiOutputNet(vocab_size=vocab_size)
+    model.eval()
+
+    x = torch.randint(0, vocab_size, (batch_size, seq_len))
+    onnx_model = _get_onnx_model(model, (x,))
+
+    requires_grad_params = ["embed.weight", "linear.weight", "linear.bias"]
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # This must not raise "i < node_->OutputDefs().size()" or any other error.
+        artifacts.generate_artifacts(
+            onnx_model,
+            requires_grad=requires_grad_params,
+            loss=artifacts.LossType.CrossEntropyLoss,
+            artifact_directory=temp_dir,
+        )
+
+        # Verify the training model was created.
+        training_model_path = os.path.join(temp_dir, "training_model.onnx")
+        assert os.path.exists(training_model_path)
+
+        # Verify the SoftmaxCrossEntropyLoss node retains both output defs
+        # (loss and log_prob) in the saved training model.
+        training_model = onnx.load(training_model_path)
+        sce_nodes = [n for n in training_model.graph.node if n.op_type == "SoftmaxCrossEntropyLoss"]
+        assert len(sce_nodes) == 1, "Expected exactly one SoftmaxCrossEntropyLoss node"
+        assert len(sce_nodes[0].output) == 2, (
+            f"SoftmaxCrossEntropyLoss node must have 2 outputs (loss, log_prob), got {list(sce_nodes[0].output)}"
+        )


### PR DESCRIPTION
## Summary
- `artifacts.generate_artifacts(..., loss=LossType.CrossEntropyLoss)` no longer aborts with `i < node_->OutputDefs().size()` when the base model has multi-dimensional outputs.
- The `SoftmaxCrossEntropyLoss` op produces two outputs (`loss`, `log_prob`); the second was being dropped by graph optimizers because it had no `value_info` entry, leaving the gradient builder to dereference a missing output def via `O(1)`.

## Motivation
Fixes #22465. Users hit a hard C++ assertion when training models like DistilBERT whose forward graph emits a multi-dimensional last-hidden-state tensor. The same pattern appears for any seq2seq / LM training setup that pipes a 3-D output into `CrossEntropyLoss`.

This is a Python-only change scoped to the `onnxblock` training-artifacts API; the core inference engine is unaffected.

## Changes
- `orttraining/orttraining/python/training/onnxblock/loss/loss.py` — after appending the `SoftmaxCrossEntropyLoss` node, register a `value_info` entry for `log_prob_output_name` so its output def survives shape inference and graph cleanup. Idempotent — guarded against duplicate entries.
- `orttraining/orttraining/test/python/orttraining_test_ort_apis_onnxblock.py` — new `test_crossentropy_loss_multi_output_model` builds a 3-D output toy model, calls `generate_artifacts` with `LossType.CrossEntropyLoss`, and asserts the saved `training_model.onnx` retains both outputs on the SCE node.

## Test Plan
- New test exercises the previously-failing path:
  `python -m pytest orttraining/orttraining/test/python/orttraining_test_ort_apis_onnxblock.py::test_crossentropy_loss_multi_output_model -v`
- Existing CE coverage:
  `python -m pytest orttraining/orttraining/test/python/orttraining_test_ort_apis_onnxblock.py -k crossentropy -v`
- `lintrunner` clean on the diff.

Fixes #22465