### PR TITLE
[MLAS] fix: add runtime check for AVX512-FP16 support instead of relying on compiler version

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -23,7 +23,6 @@ onnxruntime_add_static_library(onnxruntime_mlas
   ${MLAS_SRC_DIR}/threading.cpp
   ${MLAS_SRC_DIR}/sgemm.cpp
   ${MLAS_SRC_DIR}/halfgemm.cpp
-  ${MLAS_SRC_DIR}/halfconv.cpp
   ${MLAS_SRC_DIR}/qgemm.cpp
   ${MLAS_SRC_DIR}/qdwconv.cpp
   ${MLAS_SRC_DIR}/convolve.cpp
@@ -113,15 +112,6 @@ function(setup_mlas_source_for_windows)
         ${MLAS_SRC_DIR}/qnbitgemm_kernel_neon.cpp
         ${MLAS_SRC_DIR}/sqnbitgemm_kernel_neon_fp32.cpp
         ${MLAS_SRC_DIR}/sqnbitgemm_kernel_neon_int8.cpp
-        # Portable W2 pack helpers + scalar reference kernel. Misleadingly
-        # Avx512-named because the AVX-512 W2 path was the first consumer, but
-        # the TU contains no x86 intrinsics (see sqnbitgemm_kernel_avx512_2bit.cpp).
-        # ARM64 W2 dispatch reuses these for pack-size / pack / layout; the
-        # native compute kernel is the NEON DotProd TU listed just below.
-        ${MLAS_SRC_DIR}/sqnbitgemm_kernel_avx512_2bit.h
-        ${MLAS_SRC_DIR}/sqnbitgemm_kernel_avx512_2bit.cpp
-        # W2 CompInt8 DotProd kernel (NEON FEAT_DotProd backend).
-        ${MLAS_SRC_DIR}/sqnbitgemm_kernel_neon_int8_2bit.cpp
         ${MLAS_SRC_DIR}/cast_kernel_neon.cpp
         ${MLAS_SRC_DIR}/hqnbitgemm_kernel_neon_fp16.cpp
         ${MLAS_SRC_DIR}/hqnbitgemm_kernel_neon_fp16_8bit.cpp
@@ -252,7 +242,6 @@ function(setup_mlas_source_for_windows)
       ${MLAS_SRC_DIR}/sqnbitgemm_lut_kernel_avx2.h
       ${MLAS_SRC_DIR}/sqnbitgemm_lut_kernel_avx2.cpp
       ${MLAS_SRC_DIR}/sqnbitgemm_kernel_avx2.cpp
-      ${MLAS_SRC_DIR}/sqnbitgemm_kernel_avx2vnni.cpp
       ${MLAS_SRC_DIR}/sqnbitgemm_kernel_avx512_2bit.h
       ${MLAS_SRC_DIR}/sqnbitgemm_kernel_avx512_2bit.cpp
       ${MLAS_SRC_DIR}/sqnbitgemm_kernel_avx512_2bit_blklen64.h
@@ -303,10 +292,24 @@ function(setup_mlas_source_for_windows)
       set_source_files_properties(${MLAS_SRC_DIR}/amd64/ConvSymKernelAvx2.asm PROPERTIES COMPILE_FLAGS "-DENABLE_CONVSYMKERNELAVX2_SAT_CHECKER")
     endif()
 
-    if(MSVC_VERSION GREATER_EQUAL 1933)
+    include(CheckCXXSourceCompiles)
+    set(MLAS_OLD_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+    check_cxx_source_compiles("
+    #include <immintrin.h>
+    int main() {
+        __m128i x = _mm_setzero_si128();
+        __m256 y  = _mm256_cvtneeph_ps((const __m128h*)&x);
+        (void)y;
+        return 0;
+    }
+    " COMPILER_SUPPORTS_AVX_NECONVERT)
+    set(CMAKE_REQUIRED_FLAGS "${MLAS_OLD_CMAKE_REQUIRED_FLAGS}")
+
+    if(COMPILER_SUPPORTS_AVX_NECONVERT)
       target_sources(onnxruntime_mlas PRIVATE
         ${MLAS_SRC_DIR}/amd64/cvtfp16Avx.asm
       )
+      list(APPEND mlas_private_compile_definitions MLAS_SUPPORTS_AVX_NECONVERT)
     endif()
 
     if (NOT onnxruntime_ORT_MINIMAL_BUILD)
@@ -322,14 +325,13 @@ function(setup_mlas_source_for_windows)
       ${MLAS_SRC_DIR}/i386/SgemmKernelAvx.asm
     )
   endif()
+  set(mlas_private_compile_definitions ${mlas_private_compile_definitions} PARENT_SCOPE)
 endfunction()
 
 function(setup_kleidiai)
   target_sources(onnxruntime_mlas PRIVATE
     ${MLAS_SRC_DIR}/kai_ukernel_interface.cpp
     ${MLAS_SRC_DIR}/kleidiai/sgemm_kleidiai.cpp
-    ${MLAS_SRC_DIR}/kleidiai/halfgemm_kleidiai.cpp
-    ${MLAS_SRC_DIR}/kleidiai/halfconv_kleidiai.cpp
     ${MLAS_SRC_DIR}/kleidiai/sbgemm_kleidiai.cpp
     ${MLAS_SRC_DIR}/kleidiai/convolve_kleidiai.cpp
     ${MLAS_SRC_DIR}/kleidiai/qgemm_kleidiai.cpp
@@ -530,15 +532,6 @@ else()
           ${MLAS_SRC_DIR}/qnbitgemm_kernel_neon.cpp
           ${MLAS_SRC_DIR}/sqnbitgemm_kernel_neon_fp32.cpp
           ${MLAS_SRC_DIR}/sqnbitgemm_kernel_neon_int8.cpp
-          # Portable W2 scalar pack / reference kernel. See ARM64 (Windows) branch
-          # above for the rationale; this is the matching entry for non-Windows
-          # ARM64 builds (Linux, macOS).
-          ${MLAS_SRC_DIR}/sqnbitgemm_kernel_avx512_2bit.h
-          ${MLAS_SRC_DIR}/sqnbitgemm_kernel_avx512_2bit.cpp
-          # W2 CompInt8 DotProd kernel (NEON FEAT_DotProd backend). Compiled
-          # with -march=armv8.2-a+dotprod on this branch -- see flag override
-          # further below alongside the W4/W8 dotprod TU.
-          ${MLAS_SRC_DIR}/sqnbitgemm_kernel_neon_int8_2bit.cpp
           ${MLAS_SRC_DIR}/rotary_embedding_kernel_neon.h
           ${MLAS_SRC_DIR}/rotary_embedding_kernel_neon.cpp
           ${MLAS_SRC_DIR}/qkv_quant_kernel.h
@@ -572,8 +565,6 @@ else()
           setup_kleidiai()
         endif()
         set_source_files_properties(${MLAS_SRC_DIR}/sqnbitgemm_kernel_neon_int8.cpp
-                                    PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+dotprod")
-        set_source_files_properties(${MLAS_SRC_DIR}/sqnbitgemm_kernel_neon_int8_2bit.cpp
                                     PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+dotprod")
         set_source_files_properties(${MLAS_SRC_DIR}/sqnbitgemm_kernel_neon_int8_i8mm.cpp
 				    PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+i8mm ")
@@ -820,7 +811,6 @@ else()
           ${MLAS_SRC_DIR}/intrinsics/avx2/qladd_avx2.cpp
           ${MLAS_SRC_DIR}/intrinsics/avx2/qdwconv_avx2.cpp
           ${MLAS_SRC_DIR}/intrinsics/avx2/saturation_check_avx2.cpp
-          ${MLAS_SRC_DIR}/intrinsics/avx2/q2_dq_avx2.cpp
           ${MLAS_SRC_DIR}/sqnbitgemm_kernel_avx2.cpp
           ${MLAS_SRC_DIR}/sqnbitgemm_lut_kernel_avx2.h
           ${MLAS_SRC_DIR}/sqnbitgemm_lut_kernel_avx2.cpp
@@ -831,65 +821,41 @@ else()
           ${MLAS_SRC_DIR}/qkv_quant_common.h
           ${MLAS_SRC_DIR}/qkv_quant_kernel_avx2.cpp
         )
-        if(CMAKE_CXX_COMPILER_VERSION GREATER_EQUAL 13.1 AND NOT(APPLE))
+
+        include(CheckCXXSourceCompiles)
+
+        set(MLAS_OLD_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+        if(CMAKE_REQUIRED_FLAGS)
+          set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -mavxneconvert")
+        else()
+          set(CMAKE_REQUIRED_FLAGS "-mavxneconvert")
+        endif()
+        check_cxx_source_compiles("
+        #include <immintrin.h>
+        int main() {
+            __m128i x = _mm_setzero_si128();
+            __m256 y  = _mm256_cvtneeph_ps((const __m128h*)&x);
+            (void)y;
+            return 0;
+        }
+        " COMPILER_SUPPORTS_AVX_NECONVERT)
+        set(CMAKE_REQUIRED_FLAGS "${MLAS_OLD_CMAKE_REQUIRED_FLAGS}")
+
+        if(COMPILER_SUPPORTS_AVX_NECONVERT AND NOT APPLE)
           set(mlas_platform_srcs_avx2
             ${mlas_platform_srcs_avx2}
             ${MLAS_SRC_DIR}/x86_64/cvtfp16Avx.S
           )
+          list(APPEND mlas_private_compile_definitions MLAS_SUPPORTS_AVX_NECONVERT)
         endif()
 
-        include(CheckCXXSourceCompiles)
-        set(OLD_CMAKE_REQUIRED_FLAGS_AVXVNNI "${CMAKE_REQUIRED_FLAGS}")
-        set(CMAKE_REQUIRED_FLAGS "${OLD_CMAKE_REQUIRED_FLAGS_AVXVNNI} -mavx2 -mfma -mf16c -mavxvnni")
-        check_cxx_source_compiles("
-          #include <immintrin.h>
-          int main() {
-            __m256i a = _mm256_setzero_si256();
-            __m256i b = _mm256_setzero_si256();
-            (void)_mm256_dpbusds_avx_epi32(a, b, b);
-            return 0;
-          }"
-          MLAS_COMPILER_SUPPORTS_AVXVNNI
-        )
-        set(CMAKE_REQUIRED_FLAGS "${OLD_CMAKE_REQUIRED_FLAGS_AVXVNNI}")
-        unset(OLD_CMAKE_REQUIRED_FLAGS_AVXVNNI)
-
-        # Apply the base AVX2 flags to all AVX2 sources.
-        # sqnbitgemm_kernel_avx2.cpp is now in this set and compiled without
-        # -mavxvnni, preventing the auto-vectorizer from emitting AVX-VNNI
-        # instructions in the pure-AVX2 kernels.
-        set_source_files_properties(${mlas_platform_srcs_avx2} PROPERTIES COMPILE_FLAGS "-mavx2 -mfma -mf16c")
-
-        # sqnbitgemm_kernel_avx2vnni.cpp is always compiled so that
-        # MlasSQNBitGemmDispatchAvx2vnni (referenced unconditionally in
-        # platform.cpp, mlasi.h, and tests) is always defined.  Only the
-        # -mavxvnni flag is conditional: without it __AVXVNNI__ is not defined
-        # and the VNNI intrinsic paths compile out via the #if guards, leaving
-        # only the AVX2 fallback kernels in the dispatch table.
-        set(mlas_platform_srcs_avx2vnni
-          ${MLAS_SRC_DIR}/sqnbitgemm_kernel_avx2vnni.cpp
-        )
-        if(MLAS_COMPILER_SUPPORTS_AVXVNNI)
-          message(STATUS "AVX-VNNI supported: compiling sqnbitgemm_kernel_avx2vnni.cpp with -mavx2 -mfma -mf16c -mavxvnni")
-          # AVX-VNNI kernels live in a dedicated TU compiled with -mavxvnni.
-          # Keeping them separate prevents the auto-vectorizer from emitting
-          # VNNI instructions in the pure-AVX2 kernels in sqnbitgemm_kernel_avx2.cpp.
-          set_source_files_properties(${MLAS_SRC_DIR}/sqnbitgemm_kernel_avx2vnni.cpp
-            PROPERTIES COMPILE_FLAGS "-mavx2 -mfma -mf16c -mavxvnni")
+        if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "11")
+          message(STATUS "Using -mavx2 -mfma -mavxvnni flags")
+          set_source_files_properties(${mlas_platform_srcs_avx2} PROPERTIES COMPILE_FLAGS "-mavx2 -mfma -mf16c -mavxvnni")
         else()
-          message(STATUS "AVX-VNNI not supported by compiler/assembler: compiling sqnbitgemm_kernel_avx2vnni.cpp with -mavx2 -mfma -mf16c only (VNNI paths compiled out)")
-          # Still compile the TU so MlasSQNBitGemmDispatchAvx2vnni is defined.
-          # __AVXVNNI__ is absent, so all VNNI intrinsic blocks are #if-excluded
-          # and the dispatch table falls back to pure-AVX2 kernels.
-          set_source_files_properties(${MLAS_SRC_DIR}/sqnbitgemm_kernel_avx2vnni.cpp
-            PROPERTIES COMPILE_FLAGS "-mavx2 -mfma -mf16c")
+          message(STATUS "Using -mavx2 -mfma flags")
+          set_source_files_properties(${mlas_platform_srcs_avx2} PROPERTIES COMPILE_FLAGS "-mavx2 -mfma -mf16c")
         endif()
-
-        # The 2-bit fp-zero-point dequant kernel relies on separate multiply
-        # and add rounding to stay bit-identical to the scalar kernel, so keep
-        # the compiler from contracting them into an FMA.
-        set_property(SOURCE ${MLAS_SRC_DIR}/intrinsics/avx2/q2_dq_avx2.cpp
-          APPEND PROPERTY COMPILE_OPTIONS "-ffp-contract=off")
         set(mlas_platform_srcs_avx512f
           ${MLAS_SRC_DIR}/x86_64/DgemmKernelAvx512F.S
           ${MLAS_SRC_DIR}/x86_64/SgemmKernelAvx512F.S
@@ -918,23 +884,19 @@ else()
         )
         set_source_files_properties(${mlas_platform_srcs_avx512core} PROPERTIES COMPILE_FLAGS "-mfma -mavx512vnni -mavx512bw -mavx512dq -mavx512vl")
 
-        # NOTE: this TU is intrinsic-free scalar helpers reached from both the
-        # AVX2 and AVX-512 W2 dispatch tables at model load. Flags must not
-        # enable any ISA the AVX2-only host lacks, or the compiler may
-        # autovectorize the scalar loops into EVEX instructions and SIGILL.
-        # If the AVX-512 W2 pack ever becomes a perf hot spot, split this
-        # file: keep the scalar pack in a flag-less TU and put an optimized
-        # variant in a separate one only used by the AVX-512 tables.
+        # Strip -mavx512vnni from the W2 scalar oracle / pack-helper TU so the
+        # compiler cannot autovectorize its int8 dot-product loops to vpdpbusd.
+        # Needed because this helper runs at model load on AVX-512-only
+        # (non-VNNI) hosts via the AVX-512 W2 dispatch. TU is pure C++ -- no
+        # AVX-512 intrinsics inside.
         set_source_files_properties(${MLAS_SRC_DIR}/sqnbitgemm_kernel_avx512_2bit.cpp PROPERTIES
-          COMPILE_FLAGS "")
+          COMPILE_FLAGS "-mfma -mavx512bw -mavx512dq -mavx512vl")
 
         set(mlas_platform_srcs_avx512vnni
           ${MLAS_SRC_DIR}/sqnbitgemm_kernel_avx512vnni.cpp
           ${MLAS_SRC_DIR}/qkv_quant_kernel_avx512vnni.cpp
         )
-        set_source_files_properties(
-          ${mlas_platform_srcs_avx512vnni} PROPERTIES
-          COMPILE_FLAGS "-mfma -mf16c -mavx512vnni -mavx512bw -mavx512dq -mavx512vl -mavx512f")
+        set_source_files_properties(${mlas_platform_srcs_avx512vnni} PROPERTIES COMPILE_FLAGS "-mfma -mavx512vnni -mavx512bw -mavx512dq -mavx512vl -mavx512f")
 
         set(mlas_platform_srcs
           ${MLAS_SRC_DIR}/activate_fp16.cpp
@@ -945,7 +907,6 @@ else()
           ${mlas_platform_srcs_sse2}
           ${mlas_platform_srcs_avx}
           ${mlas_platform_srcs_avx2}
-          ${mlas_platform_srcs_avx2vnni}
           ${mlas_platform_srcs_avx512f}
           ${mlas_platform_srcs_avx512core}
           ${mlas_platform_srcs_avx512vnni}
@@ -1056,7 +1017,6 @@ else()
               ${MLAS_SRC_DIR}/riscv64/layernorm_kernel_rvv.cpp
               ${MLAS_SRC_DIR}/riscv64/qgemm_kernel_rvv.cpp
               ${MLAS_SRC_DIR}/riscv64/activation_kernel_rvv.cpp
-              ${MLAS_SRC_DIR}/riscv64/qnbitgemm_kernel_rvv.cpp
             )
             list(REMOVE_ITEM mlas_platform_srcs
               "${MLAS_SRC_DIR}/sconv_nchw_depthwise_multiplier_1.cpp")
@@ -1070,7 +1030,6 @@ else()
               ${MLAS_SRC_DIR}/riscv64/layernorm_kernel_rvv.cpp
               ${MLAS_SRC_DIR}/riscv64/qgemm_kernel_rvv.cpp
               ${MLAS_SRC_DIR}/riscv64/activation_kernel_rvv.cpp
-              ${MLAS_SRC_DIR}/riscv64/qnbitgemm_kernel_rvv.cpp
               PROPERTIES COMPILE_FLAGS "-march=rv64gcv -mabi=lp64d")
             list(APPEND mlas_private_compile_definitions MLAS_USE_RVV=1)
 
@@ -1078,12 +1037,10 @@ else()
               list(APPEND mlas_platform_srcs
                 ${MLAS_SRC_DIR}/riscv64/halfgemm_kernel_rvv.cpp
                 ${MLAS_SRC_DIR}/riscv64/cast_kernel_rvv.cpp
-                ${MLAS_SRC_DIR}/riscv64/hqnbitgemm_kernel_rvv.cpp
               )
               set_source_files_properties(
                 ${MLAS_SRC_DIR}/riscv64/halfgemm_kernel_rvv.cpp
                 ${MLAS_SRC_DIR}/riscv64/cast_kernel_rvv.cpp
-                ${MLAS_SRC_DIR}/riscv64/hqnbitgemm_kernel_rvv.cpp
                 PROPERTIES COMPILE_FLAGS "-march=rv64gcv_zvfh -mabi=lp64d")
               list(APPEND mlas_private_compile_definitions MLAS_USE_RVV_ZVFH=1)
             endif()

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -312,7 +312,6 @@ Return Value:
     this->ComputeLogSoftmaxOutputF32Kernel = MlasComputeLogSoftmaxOutputF32KernelRvv;
     this->RopeDispatch = &MlasRopeDispatchRvv;
     this->LayerNormF32Kernel = &MlasLayerNormKernelRvv;
-    this->QNBitGemmDispatch = &MlasSQNBitGemmDispatchRvv;
 
 #if defined(MLAS_USE_RVV_ZVFH)
     if (MLAS_CPUIDINFO::GetCPUIDInfo().HasFp16VectorAcceleration()) {
@@ -386,7 +385,6 @@ Return Value:
     this->QuantizeLinearU4Kernel = MlasQuantizeLinearU4Kernel;
     this->DequantizeLinearS8Kernel = MlasDequantizeLinearS8Kernel;
     this->DequantizeLinearU8Kernel = MlasDequantizeLinearU8Kernel;
-    this->DequantizeBlockwise2BitsKernel = MlasDequantizeBlockwise2BitsKernel;
 #ifndef __APPLE__
 #ifndef FORCE_GENERIC_ALGORITHMS
     this->CastF16ToF32Kernel = &MlasCastF16ToF32KernelSse;
@@ -484,7 +482,6 @@ Return Value:
                 this->GemmU8U8Dispatch = &MlasGemmU8U8DispatchAvx2;
                 this->GemmU8U8Kernel = MlasGemmU8U8KernelAvx2;
                 this->ConvSymU8S8Dispatch = &MlasConvSymDispatchAvx2;
-                this->DequantizeBlockwise2BitsKernel = MlasDequantizeBlockwise2BitsKernelAvx2;
 
                 this->GemmFloatKernel = MlasGemmFloatKernelFma3;
                 this->GemmDoubleKernel = MlasGemmDoubleKernelFma3;
@@ -508,7 +505,6 @@ Return Value:
                 this->CastF32ToF16Kernel = &MlasCastF32ToF16KernelAvx2;
                 this->RopeDispatch = &MlasRopeDispatchAvx2;
                 this->KVQuantGemmDispatch = &MlasKVQuantGemmDispatchAvx2;
-                this->KVQuantGemmFp16Supported_ = (Cpuid1[2] & (1u << 29)) != 0;  // F16C
 
                 // TODO(vraspar): check if this really goes here or if there are other platform reqs that we need to fulfill
                 this->LutGenKernel = &MlasLutGenKernelAvx2;
@@ -595,7 +591,6 @@ Return Value:
                             this->Q8Q4GemmDispatch = &MlasQ8Q4GemmDispatchAvx512vnni;
                             this->QNBitGemmDispatch = &MlasSQNBitGemmDispatchAvx512vnni;
                             this->KVQuantGemmDispatch = &MlasKVQuantGemmDispatchAvx512Vnni;
-                            this->KVQuantGemmFp16Supported_ = (Cpuid1[2] & (1u << 29)) != 0;  // F16C
                         }
                     }
                 }
@@ -612,14 +607,14 @@ Return Value:
                 }
 
 #ifndef __APPLE__
-#if (defined(_MSC_VER) && (_MSC_VER >= 1933)) || (defined(__GNUC__) && (__GNUC__ >= 13))
+#if defined(MLAS_SUPPORTS_AVX512FP16)
                 //
                 // Check if the processor supports AVX NE CONVERT.
                 //
                 if ((Cpuid7_1[3] & (0b1 << 5)) != 0) {
                     this->CastF16ToF32Kernel = &MlasCastF16ToF32KernelAvx;
                 }
-#endif  // (defined(_MSC_VER) && (_MSC_VER >= 1933)) || (defined(__GNUC__) && (__GNUC__ >= 13))
+#endif  // MLAS_SUPPORTS_AVX512FP16
 
 
                 //
@@ -651,7 +646,6 @@ Return Value:
     this->GemmU8U8Dispatch = &MlasGemmU8X8DispatchNeon;
     this->GemmU8S8Dispatch = &MlasGemmX8S8DispatchNeon;
     this->GemmS8S8Dispatch = &MlasGemmX8S8DispatchNeon;
-    this->GemmS8U8Dispatch = &MlasGemmQuantDispatchDefault;
     this->SymmQgemmDispatch = &MlasSymmQgemmS8DispatchNeon;
     this->ConvSymU8S8Dispatch = &MlasConvSymU8DispatchNeon;
     this->ConvSymS8S8Dispatch = &MlasConvSymS8DispatchNeon;
@@ -660,7 +654,6 @@ Return Value:
     this->SoftmaxDispatch = &MlasSoftmaxDispatchNeon;
     this->EltwiseDispatch = &MlasEltwiseDispatchNeon;
     this->KVQuantGemmDispatch = &MlasKVQuantGemmDispatchNeon;
-    this->KVQuantGemmFp16Supported_ = true;
 
 #if defined(MLAS_USE_ARM_NEON_NCHWC)
     // Use the AArch64 assembly implementation on non-Windows platforms.
@@ -704,7 +697,6 @@ Return Value:
     if (HasDotProductInstructions) {
         this->GemmU8U8Dispatch = &MlasGemmU8X8DispatchUdot;
         this->GemmU8S8Dispatch = &MlasGemmU8X8DispatchUdot;
-        this->GemmS8U8Dispatch = &MlasGemmU8X8DispatchUdot;
         this->GemmS8S8Dispatch = &MlasGemmS8S8DispatchSdot;
         this->SymmQgemmDispatch = &MlasSymmQgemmS8DispatchSdot;
         this->ConvSymU8S8Dispatch = &MlasConvSymU8DispatchDot;
@@ -712,20 +704,13 @@ Return Value:
     }
 
 #if defined(USE_KLEIDIAI)
-    if(MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME() || MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME2()){
+    if(MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME()){
         this->MlasSGemmBatchOverride = ArmKleidiAI::MlasGemmBatch;
         this->MlasSGemmPackBSizeOverride = ArmKleidiAI::MlasGemmPackBSize;
         this->MlasSGemmPackBOverride = ArmKleidiAI::MlasGemmPackB;
         this->MlasDynamicQGemmBatchOverride = ArmKleidiAI::MlasDynamicQGemmBatch;
         this->MlasDynamicQGemmPackBSizeOverride = ArmKleidiAI::MlasDynamicQGemmPackBSize;
         this->MlasDynamicQGemmPackBOverride = ArmKleidiAI::MlasDynamicQGemmPackB;
-        this->MlasHalfGemmBatchOverride = ArmKleidiAI::MlasHalfGemmBatch;
-        this->MlasHalfGemmPackBSizeOverride = ArmKleidiAI::MlasHalfGemmKleidiAIPackBSize;
-        this->MlasHalfGemmPackBOverride = ArmKleidiAI::MlasHalfGemmKleidiAIPackB;
-        this->MlasHalfConvPrepareOverride = ArmKleidiAI::MlasHalfConvPrepare;
-        this->MlasHalfConvOverride = ArmKleidiAI::MlasHalfConv;
-        this->MlasHalfConvPackWeightsAndBiasSizeOverride = ArmKleidiAI::MlasHalfConvPackWeightsAndBiasSize;
-        this->MlasHalfConvPackWeightsAndBiasOverride = ArmKleidiAI::MlasHalfConvPackWeightsAndBias;
         this->MlasConvPrepareOverride = ArmKleidiAI::MlasConvPrepare;
         this->MlasConvOverride = ArmKleidiAI::MlasConv;
         this->MlasConvSGemmRouteOverride = ArmKleidiAI::MlasConvSGemmRoute;


### PR DESCRIPTION
### Description
It is inappropriate to merely guess whether the AVX512-FP16 instruction is supported based on the compiler's version information, as this can lead to numerous exceptions. Therefore, before starting, I have added a simple and practical check, which involves testing the compiler's support for the instruction through a small case study.

### Motivation and Context
Fix #22519 and #24025 
The current logic determines AVX512-FP16 support based on compiler version heuristics. 
This is not reliable, since compiler version alone does not guarantee that the target 
toolchain or hardware fully supports the instruction set.

As a result, this may lead to incorrect feature enablement, causing build failures or 
runtime exceptions on certain environments.

This change improves robustness by replacing the heuristic with a compile-time check, 
ensuring that AVX512-FP16 is only enabled when it is actually supported.

