### PR TITLE
chore(ci): `NIGHTLY_BUILD` env-var is now set via pipeline parameter

### DIFF
--- a/tools/ci_build/github/azure-pipelines/py-cuda-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/py-cuda-packaging-pipeline.yml
@@ -6,7 +6,13 @@ resources:
     type: git
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
+
 parameters:
+  - name: is_nightly_build
+    displayName: 'Nightly or Release Candidate build. Set to false if Release build.'
+    type: boolean
+    default: true
+
   - name: cmake_build_type
     type: string
     default: 'Release'
@@ -15,6 +21,13 @@ parameters:
       - Release
       - RelWithDebInfo
       - MinSizeRel
+
+variables:
+  # Magic env-var used by CI build scripts & piped around several docker containers.
+  # This should also be set to `1` for release candidates, despite the name. RCs do not yet have proper handling, so
+  # wheels can only be nightly or full release.
+  # FUTURE WORK: Add proper RC handling/suffix for wheels. Replace this w/ nightly/RC/release options.
+  NIGHTLY_BUILD: ${{ iif(parameters.is_nightly_build, '1', '0') }}
 
 extends:
   # The pipeline extends the 1ES PT which will inject different SDL and compliance tasks.

--- a/tools/ci_build/github/azure-pipelines/py-cuda13-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/py-cuda13-packaging-pipeline.yml
@@ -6,7 +6,13 @@ resources:
     type: git
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
+
 parameters:
+  - name: is_nightly_build
+    displayName: 'Nightly or Release Candidate build. Set to false if Release build.'
+    type: boolean
+    default: true
+
   - name: cmake_build_type
     type: string
     default: 'Release'
@@ -15,6 +21,13 @@ parameters:
       - Release
       - RelWithDebInfo
       - MinSizeRel
+
+variables:
+  # Magic env-var used by CI build scripts & piped around several docker containers.
+  # This should also be set to `1` for release candidates, despite the name. RCs do not yet have proper handling, so
+  # wheels can only be nightly or full release.
+  # FUTURE WORK: Add proper RC handling/suffix for wheels. Replace this w/ nightly/RC/release options.
+  NIGHTLY_BUILD: ${{ iif(parameters.is_nightly_build, '1', '0') }}
 
 extends:
   # The pipeline extends the 1ES PT which will inject different SDL and compliance tasks.

--- a/tools/ci_build/github/azure-pipelines/py-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/py-packaging-pipeline.yml
@@ -1,4 +1,10 @@
 parameters:
+
+- name: is_nightly_build
+  displayName: 'Nightly or Release Candidate build. Set to false if Release build.'
+  type: boolean
+  default: true
+
 - name: enable_linux_cpu
   displayName: 'Whether Linux CPU package is built.'
   type: boolean
@@ -35,6 +41,12 @@ parameters:
   - RelWithDebInfo
   - MinSizeRel
 
+variables:
+  # Magic env-var used by CI build scripts & piped around several docker containers.
+  # This should also be set to `1` for release candidates, despite the name. RCs do not yet have proper handling, so
+  # wheels can only be nightly or full release.
+  # FUTURE WORK: Add proper RC handling/suffix for wheels. Replace this w/ nightly/RC/release options.
+  NIGHTLY_BUILD: ${{ iif(parameters.is_nightly_build, '1', '0') }}
 
 trigger: none
 

--- a/tools/ci_build/github/azure-pipelines/py-webgpu-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/py-webgpu-packaging-pipeline.yml
@@ -6,7 +6,13 @@ resources:
     type: git
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
+
 parameters:
+  - name: is_nightly_build
+    displayName: 'Nightly or Release Candidate build. Set to false if Release build.'
+    type: boolean
+    default: true
+
   - name: cmake_build_type
     type: string
     default: 'Release'
@@ -15,6 +21,13 @@ parameters:
       - Release
       - RelWithDebInfo
       - MinSizeRel
+
+variables:
+  # Magic env-var used by CI build scripts & piped around several docker containers.
+  # This should also be set to `1` for release candidates, despite the name. RCs do not yet have proper handling, so
+  # wheels can only be nightly or full release.
+  # FUTURE WORK: Add proper RC handling/suffix for wheels. Replace this w/ nightly/RC/release options.
+  NIGHTLY_BUILD: ${{ iif(parameters.is_nightly_build, '1', '0') }}
 
 extends:
   # The pipeline extends the 1ES PT which will inject different SDL and compliance tasks.


### PR DESCRIPTION
### Description

CI Python packaging pipelines now specify their packaging type (nightly vs. release) via an explicit pipeline parameter rather than the implicitly defined pipeline var `NIGHTLY_BUILD`.

### Motivation and Context

Much less error prone than an implicitly defined pipeline variable.