### PR TITLE
Address CI build failure

### DIFF
--- a/onnxruntime/core/providers/cuda/ml/label_encoder.cc
+++ b/onnxruntime/core/providers/cuda/ml/label_encoder.cc
@@ -45,6 +45,7 @@ static bool TryGetScalarTensorAttribute(const OpKernelInfo& info, const std::str
                                         const std::string& attr_name, T& value) {
 #ifdef BUILD_CUDA_EP_AS_PLUGIN
   // Plugin EP: use Ort C++ API to read tensor attributes.
+  ORT_UNUSED_PARAMETER(attr_name);
   try {
     Ort::AllocatorWithDefaultOptions allocator;
     auto tensor_value = info.GetKernelInfo().GetTensorAttribute(tensor_name.c_str(), allocator);


### PR DESCRIPTION
This pull request makes a small change to the CUDA label encoder kernel to address unused parameter warnings. The change marks the `attr_name` parameter as unused in the `TryGetScalarTensorAttribute` function when building with the plugin execution provider.

* Code quality improvement:
  * Marked the `attr_name` parameter as unused with `ORT_UNUSED_PARAMETER(attr_name);` to suppress compiler warnings when building with `BUILD_CUDA_EP_AS_PLUGIN`.