### PR TITLE
Pre-downloads and caches the Gradle distribution

### DIFF
--- a/.github/workflows/windows_cuda.yml
+++ b/.github/workflows/windows_cuda.yml
@@ -70,10 +70,12 @@ jobs:
           java-version: '17'
           architecture: x64
 
-      - name: Setup Gradle
+      - name: Pre-download and cache Gradle (version from java/gradle/wrapper)
         uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: '8.7'
+          # 'wrapper' tells the action to read the Gradle version from
+          # java/gradle/wrapper/gradle-wrapper.properties (currently 8.7).
+          gradle-version: 'wrapper'
 
       - uses: actions/cache@v5
         id: onnx-node-tests-cache
@@ -191,10 +193,12 @@ jobs:
           java-version: '17'
           architecture: x64
 
-      - name: Setup Gradle
+      - name: Pre-download and cache Gradle (version from java/gradle/wrapper)
         uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: '8.7'
+          # 'wrapper' tells the action to read the Gradle version from
+          # java/gradle/wrapper/gradle-wrapper.properties (currently 8.7).
+          gradle-version: 'wrapper'
 
       - name: Locate vcvarsall and Setup Env
         uses: ./.github/actions/locate-vcvarsall-and-setup-env

--- a/.github/workflows/windows_cuda.yml
+++ b/.github/workflows/windows_cuda.yml
@@ -15,6 +15,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: true
 
+# Must match the version in java/gradle/wrapper/gradle-wrapper.properties.
+env:
+  GRADLE_VERSION: '8.7'
+
 #TODO: enable  --build_nodejs
 jobs:
   build:
@@ -70,12 +74,10 @@ jobs:
           java-version: '17'
           architecture: x64
 
-      - name: Pre-download and cache Gradle (version from java/gradle/wrapper)
+      - name: Pre-download and cache Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          # 'wrapper' tells the action to read the Gradle version from
-          # java/gradle/wrapper/gradle-wrapper.properties (currently 8.7).
-          gradle-version: 'wrapper'
+          gradle-version: ${{ env.GRADLE_VERSION }}
 
       - uses: actions/cache@v5
         id: onnx-node-tests-cache
@@ -193,12 +195,10 @@ jobs:
           java-version: '17'
           architecture: x64
 
-      - name: Pre-download and cache Gradle (version from java/gradle/wrapper)
+      - name: Pre-download and cache Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          # 'wrapper' tells the action to read the Gradle version from
-          # java/gradle/wrapper/gradle-wrapper.properties (currently 8.7).
-          gradle-version: 'wrapper'
+          gradle-version: ${{ env.GRADLE_VERSION }}
 
       - name: Locate vcvarsall and Setup Env
         uses: ./.github/actions/locate-vcvarsall-and-setup-env

--- a/.github/workflows/windows_cuda.yml
+++ b/.github/workflows/windows_cuda.yml
@@ -70,6 +70,11 @@ jobs:
           java-version: '17'
           architecture: x64
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '8.7'
+
       - uses: actions/cache@v5
         id: onnx-node-tests-cache
         with:
@@ -185,6 +190,11 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
           architecture: x64
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '8.7'
 
       - name: Locate vcvarsall and Setup Env
         uses: ./.github/actions/locate-vcvarsall-and-setup-env


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for Windows CUDA builds by adding a dedicated step to set up Gradle using the official Gradle action. This ensures that Gradle version 8.7 is reliably installed and configured in the workflow before subsequent steps execute.

Workflow improvements:

* Added a `Setup Gradle` step using `gradle/actions/setup-gradle@v4` with `gradle-version: '8.7'` to the Windows CUDA workflow, ensuring consistent Gradle setup for build and test jobs. [[1]](diffhunk://#diff-45a637051c3fc0845e491240089180391b9b3ee24be4c85dd5a2c298725e1626R73-R77) [[2]](diffhunk://#diff-45a637051c3fc0845e491240089180391b9b3ee24be4c85dd5a2c298725e1626R194-R198)