### PR TITLE
Add M-tile loop with dispatch capping for Intel Xe2/3-LPG

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/quantization/subgroup_matrix_matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/webgpu/quantization/subgroup_matrix_matmul_nbits.cc
@@ -293,13 +293,31 @@ Status ApplySubgroupMatrixMatMulNBits(const Tensor* a, const Tensor* b, const Te
   const bool has_weight_idx = weight_index > 0 || has_weight_idx_indirect;
   SubgroupMatrixMatMulNBitsProgram mul_program{nbits, config_index, has_zero_points, has_bias, has_weight_idx, has_weight_idx_indirect};
   mul_program.SetWorkgroupSize(work_group_size);
-  mul_program.SetDispatchGroupSize(
-      (N + tile_size_b - 1) / tile_size_b,
-      (M + tile_size_a - 1) / tile_size_a, 1);
+  uint32_t dispatch_x = (N + tile_size_b - 1) / tile_size_b;
+  uint32_t num_m_tiles = (M + tile_size_a - 1) / tile_size_a;
+  uint32_t dispatch_y = num_m_tiles;
+  // For large M on Intel Xe, cap dispatch_y so each workgroup processes multiple
+  // M-tiles sequentially, reducing scheduling overhead.
+  if (M > 2048 && context.AdapterInfo().vendor == std::string_view{"intel"}) {
+    // Each XeCore has 4 XVE x 8 SIMD-32 hardware threads = 32 subgroups.
+    uint32_t hw_subgroups = 0;
+    if (context.AdapterInfo().architecture == std::string_view{"xe-3lpg"}) {
+      hw_subgroups = 384;  // 12 XeCore x 32
+    } else if (context.AdapterInfo().architecture == std::string_view{"xe-2lpg"}) {
+      hw_subgroups = 256;  // 8 XeCore x 32
+    }
+    if (hw_subgroups > 0) {
+      constexpr uint32_t kOccupancyFactor = 16;  // empirically tuned on Xe2/Xe3 devices
+      uint32_t target_wgs = hw_subgroups * kOccupancyFactor / (work_group_size / 32);
+      dispatch_y = std::min(dispatch_y, (target_wgs + dispatch_x - 1) / dispatch_x);
+    }
+  }
+  uint32_t m_tiles_per_wg = (num_m_tiles + dispatch_y - 1) / dispatch_y;
+  mul_program.SetDispatchGroupSize(dispatch_x, dispatch_y, 1);
   mul_program.AddInputs({{a, ProgramTensorMetadataDependency::TypeAndRank, 1},
                          {b, ProgramTensorMetadataDependency::TypeAndRank, static_cast<int>(nbits == 4 ? kU32Components : 2 * kU32Components)},
                          {scales, ProgramTensorMetadataDependency::TypeAndRank, 1}})
-      .AddUniformVariables({{M}, {N}, {K}, {zero_blocks_per_col}, {weight_index}})
+      .AddUniformVariables({{M}, {N}, {K}, {zero_blocks_per_col}, {weight_index}, {m_tiles_per_wg}})
       .AddOutput({y, ProgramTensorMetadataDependency::TypeAndRank, y_shape, 1})
       .CacheHint(nbits, has_zero_points, has_bias, has_weight_idx, has_weight_idx_indirect);
   if (has_zero_points) {

--- a/onnxruntime/contrib_ops/webgpu/quantization/subgroup_matrix_matmul_nbits.h
+++ b/onnxruntime/contrib_ops/webgpu/quantization/subgroup_matrix_matmul_nbits.h
@@ -32,7 +32,8 @@ class SubgroupMatrixMatMulNBitsProgram final : public Program<SubgroupMatrixMatM
       {"N", ProgramUniformVariableDataType::Uint32},
       {"K", ProgramUniformVariableDataType::Uint32},
       {"zero_blocks_per_col", ProgramUniformVariableDataType::Uint32},
-      {"weight_idx", ProgramUniformVariableDataType::Uint32});
+      {"weight_idx", ProgramUniformVariableDataType::Uint32},
+      {"m_tiles_per_wg", ProgramUniformVariableDataType::Uint32});
 
  private:
   uint32_t nbits_;

--- a/onnxruntime/contrib_ops/webgpu/quantization/subgroup_matrix_matmul_nbits_8x16x16.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/quantization/subgroup_matrix_matmul_nbits_8x16x16.wgsl.template
@@ -132,98 +132,107 @@ fn dequant_b_to_tile(n_base: u32, k_idx: u32, n_idx: u32, k_chunk_idx: u32) {
 #endif
 
 $MAIN {
-    let global_base_a = workgroup_id.y * kTileM;
     let global_base_b = workgroup_id.x * kTileN;
-
     let sg_idx = u32(local_idx / sg_size);
     let sg_mat_count_k = uniforms.K / kSgMatK;
-    let sg_mat_idx = (workgroup_id.y * kSgMatCountM + sg_idx) * sg_mat_count_k;
+    let num_tiles_m = (uniforms.M + kTileM - 1) / kTileM;
 
-    var sg_mat_offset_a = sg_mat_idx * kSgMatSizeLeft;
+    // Zero-initialized accumulator template (used to reset per M-tile iteration).
+    var sg_mat_zero: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
 
-    var sg_mat_c0: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
-    var sg_mat_c1: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
-    var sg_mat_c2: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
-    var sg_mat_c3: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
-    for (var k_idx: u32 = 0; k_idx < uniforms.K; k_idx += kTileK) {
-        // Load Phase
-        dequant_b_to_tile(global_base_b, k_idx, local_idx / 4, local_idx % 4);
-        workgroupBarrier();
+    // Sequential M-loop: each workgroup processes a contiguous block of M-tiles.
+    let m_start = workgroup_id.y * uniforms.m_tiles_per_wg;
+    let m_end = min(m_start + uniforms.m_tiles_per_wg, num_tiles_m);
+    for (var m_tile: u32 = m_start; m_tile < m_end; m_tile++) {
+        let global_base_a = m_tile * kTileM;
+        let sg_mat_idx = (m_tile * kSgMatCountM + sg_idx) * sg_mat_count_k;
 
-        for (var sg_mat_k_idx: u32 = 0; sg_mat_k_idx < kTileK; sg_mat_k_idx += kSgMatK)
-        {
-            // Load A from global memory (prepacked layout).
-            // Syntax: subgroupMatrixLoad src_ptr, src_offset, is_col_major, src_stride
-            var sg_mat_a0: subgroup_matrix_left<f16, sg_mat_k, sg_mat_m> =
-                subgroupMatrixLoad<subgroup_matrix_left<f16, sg_mat_k, sg_mat_m>>(
-                    &input_a, sg_mat_offset_a, false, kSgMatK);
-            sg_mat_offset_a += kSgMatSizeLeft;
+        var sg_mat_offset_a = sg_mat_idx * kSgMatSizeLeft;
 
-            // Load B from shared local memory.
-            // tile_b [kTileN, kTileK] is stored as column major.
-            var sg_mat_b0: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
-                subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>>(
-                    &tile_b, sg_mat_k_idx, true, kTileK);
-            var sg_mat_b1: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
-                subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>>(
-                    &tile_b, sg_mat_k_idx + kSgMatStrideN, true, kTileK);
-            var sg_mat_b2: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
-                subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>>(
-                    &tile_b, sg_mat_k_idx + 2 * kSgMatStrideN, true, kTileK);
-            var sg_mat_b3: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
-                subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>>(
-                    &tile_b, sg_mat_k_idx + 3 * kSgMatStrideN, true, kTileK);
+        var sg_mat_c0 = sg_mat_zero;
+        var sg_mat_c1 = sg_mat_zero;
+        var sg_mat_c2 = sg_mat_zero;
+        var sg_mat_c3 = sg_mat_zero;
+        for (var k_idx: u32 = 0; k_idx < uniforms.K; k_idx += kTileK) {
+            // Load Phase
+            dequant_b_to_tile(global_base_b, k_idx, local_idx / 4, local_idx % 4);
+            workgroupBarrier();
 
-            // Compute Phase
-            // Syntax: subgroupMatrixMultiplyAccumulate left, right, accumulate -> accumulate
-            sg_mat_c0 = subgroupMatrixMultiplyAccumulate(sg_mat_a0, sg_mat_b0, sg_mat_c0);
-            sg_mat_c1 = subgroupMatrixMultiplyAccumulate(sg_mat_a0, sg_mat_b1, sg_mat_c1);
-            sg_mat_c2 = subgroupMatrixMultiplyAccumulate(sg_mat_a0, sg_mat_b2, sg_mat_c2);
-            sg_mat_c3 = subgroupMatrixMultiplyAccumulate(sg_mat_a0, sg_mat_b3, sg_mat_c3);
+            for (var sg_mat_k_idx: u32 = 0; sg_mat_k_idx < kTileK; sg_mat_k_idx += kSgMatK)
+            {
+                // Load A from global memory (prepacked layout).
+                // Syntax: subgroupMatrixLoad src_ptr, src_offset, is_col_major, src_stride
+                var sg_mat_a0: subgroup_matrix_left<f16, sg_mat_k, sg_mat_m> =
+                    subgroupMatrixLoad<subgroup_matrix_left<f16, sg_mat_k, sg_mat_m>>(
+                        &input_a, sg_mat_offset_a, false, kSgMatK);
+                sg_mat_offset_a += kSgMatSizeLeft;
+
+                // Load B from shared local memory.
+                // tile_b [kTileN, kTileK] is stored as column major.
+                var sg_mat_b0: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
+                    subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>>(
+                        &tile_b, sg_mat_k_idx, true, kTileK);
+                var sg_mat_b1: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
+                    subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>>(
+                        &tile_b, sg_mat_k_idx + kSgMatStrideN, true, kTileK);
+                var sg_mat_b2: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
+                    subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>>(
+                        &tile_b, sg_mat_k_idx + 2 * kSgMatStrideN, true, kTileK);
+                var sg_mat_b3: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
+                    subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>>(
+                        &tile_b, sg_mat_k_idx + 3 * kSgMatStrideN, true, kTileK);
+
+                // Compute Phase
+                // Syntax: subgroupMatrixMultiplyAccumulate left, right, accumulate -> accumulate
+                sg_mat_c0 = subgroupMatrixMultiplyAccumulate(sg_mat_a0, sg_mat_b0, sg_mat_c0);
+                sg_mat_c1 = subgroupMatrixMultiplyAccumulate(sg_mat_a0, sg_mat_b1, sg_mat_c1);
+                sg_mat_c2 = subgroupMatrixMultiplyAccumulate(sg_mat_a0, sg_mat_b2, sg_mat_c2);
+                sg_mat_c3 = subgroupMatrixMultiplyAccumulate(sg_mat_a0, sg_mat_b3, sg_mat_c3);
+            }
+            workgroupBarrier();
         }
-        workgroupBarrier();
-    }
 
-    // Write out
+        // Write out
 #if has_bias
-    // Store results to scratch workgroup memory, then add bias and write to output.
-    // scratch layout: [kTileM, kTileN] row-major
-    let scratch_m_base = sg_idx * kSgMatM;
-    subgroupMatrixStore(&scratch, scratch_m_base * kTileN, sg_mat_c0, false, kTileN);
-    subgroupMatrixStore(&scratch, scratch_m_base * kTileN + kSgMatN, sg_mat_c1, false, kTileN);
-    subgroupMatrixStore(&scratch, scratch_m_base * kTileN + 2 * kSgMatN, sg_mat_c2, false, kTileN);
-    subgroupMatrixStore(&scratch, scratch_m_base * kTileN + 3 * kSgMatN, sg_mat_c3, false, kTileN);
-    workgroupBarrier();
+        // Store results to scratch workgroup memory, then add bias and write to output.
+        // scratch layout: [kTileM, kTileN] row-major
+        let scratch_m_base = sg_idx * kSgMatM;
+        subgroupMatrixStore(&scratch, scratch_m_base * kTileN, sg_mat_c0, false, kTileN);
+        subgroupMatrixStore(&scratch, scratch_m_base * kTileN + kSgMatN, sg_mat_c1, false, kTileN);
+        subgroupMatrixStore(&scratch, scratch_m_base * kTileN + 2 * kSgMatN, sg_mat_c2, false, kTileN);
+        subgroupMatrixStore(&scratch, scratch_m_base * kTileN + 3 * kSgMatN, sg_mat_c3, false, kTileN);
+        workgroupBarrier();
 
-    // 256 threads write 64x64 = 4096 elements. Each thread handles 16 elements.
-    // Thread mapping: m = local_idx / 4, n_base = (local_idx % 4) * 16
-    let out_m = local_idx / 4;
-    let out_n_base = (local_idx % 4) * 16;
-    let global_m = global_base_a + out_m;
-    if (global_m < uniforms.M) {
-        let global_n_base = global_base_b + out_n_base;
-        let scratch_base = out_m * kTileN + out_n_base;
-        let out_base = global_m * uniforms.N + global_n_base;
+        // 256 threads write 64x64 = 4096 elements. Each thread handles 16 elements.
+        // Thread mapping: m = local_idx / 4, n_base = (local_idx % 4) * 16
+        let out_m = local_idx / 4;
+        let out_n_base = (local_idx % 4) * 16;
+        let global_m = global_base_a + out_m;
+        if (global_m < uniforms.M) {
+            let global_n_base = global_base_b + out_n_base;
+            let scratch_base = out_m * kTileN + out_n_base;
+            let out_base = global_m * uniforms.N + global_n_base;
 #if has_weight_idx_indirect
-        let bias_offset = weight_index_indirect[uniforms.weight_idx] * uniforms.N;
+            let bias_offset = weight_index_indirect[uniforms.weight_idx] * uniforms.N;
 #elif has_weight_idx
-        let bias_offset = uniforms.weight_idx * uniforms.N;
+            let bias_offset = uniforms.weight_idx * uniforms.N;
 #else
-        const bias_offset: u32 = 0;
+            const bias_offset: u32 = 0;
 #endif
-        for (var i: u32 = 0; i < 16; i++) {
-            if (global_n_base + i < uniforms.N) {
-                let val = output_element_t(scratch[scratch_base + i])
-                    + bias[bias_offset + global_n_base + i];
-                output.setByOffset(out_base + i, val);
+            for (var i: u32 = 0; i < 16; i++) {
+                if (global_n_base + i < uniforms.N) {
+                    let val = output_element_t(scratch[scratch_base + i])
+                        + bias[bias_offset + global_n_base + i];
+                    output.setByOffset(out_base + i, val);
+                }
             }
         }
-    }
 #else
-    let sg_mat_offset_c = global_base_a * uniforms.N + global_base_b + sg_idx * kSgMatM * uniforms.N;
-    subgroupMatrixStore(&output, sg_mat_offset_c, sg_mat_c0, false, uniforms.N);
-    subgroupMatrixStore(&output, sg_mat_offset_c + kSgMatN, sg_mat_c1, false, uniforms.N);
-    subgroupMatrixStore(&output, sg_mat_offset_c + 2 * kSgMatN, sg_mat_c2, false, uniforms.N);
-    subgroupMatrixStore(&output, sg_mat_offset_c + 3 * kSgMatN, sg_mat_c3, false, uniforms.N);
+        let sg_mat_offset_c = global_base_a * uniforms.N + global_base_b + sg_idx * kSgMatM * uniforms.N;
+        subgroupMatrixStore(&output, sg_mat_offset_c, sg_mat_c0, false, uniforms.N);
+        subgroupMatrixStore(&output, sg_mat_offset_c + kSgMatN, sg_mat_c1, false, uniforms.N);
+        subgroupMatrixStore(&output, sg_mat_offset_c + 2 * kSgMatN, sg_mat_c2, false, uniforms.N);
+        subgroupMatrixStore(&output, sg_mat_offset_c + 3 * kSgMatN, sg_mat_c3, false, uniforms.N);
 #endif
+    } // end M-tile loop
 }  // MAIN


### PR DESCRIPTION
- Wrap 8x16x16 MatMulNBits(SubgroupMatrix) kernel body in M-tile loop using uniforms.m_tiles_per_wg for tile assignment per workgroup
- Cap dispatch_y on Xe2/3-LPG when M > 2k, with occupancy factor 16x
- Non-Intel or small-M paths pass m_tiles_per_wg=1 (no behavior change)