### PR TITLE
fix(ci): feed auth for android react native

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar.yml
@@ -74,7 +74,7 @@ jobs:
     ${{ if contains(parameters.pool_name, 'mac')}}:
       os: macOS
 
-  templateContext:        
+  templateContext:
     outputs:
     - output: pipelineArtifact
       targetPath: $(Build.BinariesDirectory)/.artifacts
@@ -83,6 +83,8 @@ jobs:
   - checkout: self
     clean: true
     submodules: none
+
+  - template: setup-feeds-and-python-steps.yml
 
   - task: CmdLine@2
     displayName: Create artifacts directory
@@ -132,6 +134,10 @@ jobs:
           --volume $(Build.BinariesDirectory):/build \
           --volume $ANDROID_HOME:/android_home \
           --volume $NDK_HOME:/ndk_home \
+          -e NPM_CONFIG_USERCONFIG=/tmp/.npmrc \
+          --volume "${NPM_CONFIG_USERCONFIG}:/tmp/.npmrc:ro" \
+          --volume "$HOME/.m2:/home/onnxruntimedev/.m2:ro" \
+          --volume "$HOME/.gradle:/home/onnxruntimedev/.gradle" \
           --volume $(Build.BinariesDirectory)/.artifacts:/home/onnxruntimedev/.artifacts \
           --volume $(Build.BinariesDirectory)/.build_settings:/home/onnxruntimedev/.build_settings \
           $QNN_VOLUME \


### PR DESCRIPTION
### Description

Missing feed override/auth fwding for docker container instance.


### Motivation and Context

Android React Native subproject cannot build w/o this change. This subproject is currently expected for NPM publishing.