### PR TITLE
[React Native] Add react-native.config.js and Expo plugin MainApplication patch to fix autolinking

### DIFF
--- a/js/react_native/README.md
+++ b/js/react_native/README.md
@@ -16,6 +16,18 @@ With ONNX Runtime React Native, React Native developers can score pre-trained ON
 npm install onnxruntime-react-native
 ```
 
+React Native's autolinking registers the native Android and iOS modules automatically. No manual changes to `settings.gradle`, `build.gradle`, or `MainApplication` are required for bare React Native projects.
+
+For Expo managed/prebuild workflows, add the config plugin to your `app.json`/`app.config.js`:
+
+```json
+{
+  "plugins": ["onnxruntime-react-native"]
+}
+```
+
+Then run `npx expo prebuild` to apply the native changes.
+
 ### Usage
 
 ```js

--- a/js/react_native/app.plugin.js
+++ b/js/react_native/app.plugin.js
@@ -52,14 +52,23 @@ const withOrt = (config) => {
         offset: 0,
         comment: '//',
       }).contents;
-      config.modResults.contents = generateCode.mergeContents({
-        src: config.modResults.contents,
-        newSrc: '      packages.add(new OnnxruntimePackage());',
-        tag: 'onnxruntime-react-native-package',
-        anchor: /getPackages\(\)/,
-        offset: 2,
-        comment: '//',
-      }).contents;
+      if (!config.modResults.contents.includes('packages.add(new OnnxruntimePackage())')) {
+        if (/return\s+new PackageList\(this\)\.getPackages\(\);/.test(config.modResults.contents)) {
+          config.modResults.contents = config.modResults.contents.replace(
+            /(\s*)return\s+new PackageList\(this\)\.getPackages\(\);/,
+            '$1List<ReactPackage> packages = new PackageList(this).getPackages();\n$1packages.add(new OnnxruntimePackage());\n$1return packages;',
+          );
+        } else {
+          config.modResults.contents = generateCode.mergeContents({
+            src: config.modResults.contents,
+            newSrc: '      packages.add(new OnnxruntimePackage());',
+            tag: 'onnxruntime-react-native-package',
+            anchor: /^\s*List<ReactPackage>\s+packages\s*=\s*new PackageList\(this\)\.getPackages\(\);\s*$/m,
+            offset: 1,
+            comment: '//',
+          }).contents;
+        }
+      }
     }
     return config;
   });

--- a/js/react_native/app.plugin.js
+++ b/js/react_native/app.plugin.js
@@ -23,6 +23,47 @@ const withOrt = (config) => {
     return config;
   });
 
+  // Register OnnxruntimePackage in MainApplication for New Architecture / Expo prebuild
+  config = configPlugin.withMainApplication(config, (config) => {
+    const lang = config.modResults.language;
+    if (lang === 'kt') {
+      config.modResults.contents = generateCode.mergeContents({
+        src: config.modResults.contents,
+        newSrc: 'import ai.onnxruntime.reactnative.OnnxruntimePackage',
+        tag: 'onnxruntime-react-native-import',
+        anchor: /^import /m,
+        offset: 0,
+        comment: '//',
+      }).contents;
+      config.modResults.contents = generateCode.mergeContents({
+        src: config.modResults.contents,
+        newSrc: '      add(OnnxruntimePackage())',
+        tag: 'onnxruntime-react-native-package',
+        anchor: /override fun getPackages\(\)/,
+        offset: 2,
+        comment: '//',
+      }).contents;
+    } else if (lang === 'java') {
+      config.modResults.contents = generateCode.mergeContents({
+        src: config.modResults.contents,
+        newSrc: 'import ai.onnxruntime.reactnative.OnnxruntimePackage;',
+        tag: 'onnxruntime-react-native-import',
+        anchor: /^import /m,
+        offset: 0,
+        comment: '//',
+      }).contents;
+      config.modResults.contents = generateCode.mergeContents({
+        src: config.modResults.contents,
+        newSrc: '      packages.add(new OnnxruntimePackage());',
+        tag: 'onnxruntime-react-native-package',
+        anchor: /getPackages\(\)/,
+        offset: 2,
+        comment: '//',
+      }).contents;
+    }
+    return config;
+  });
+
   // Add build dependency to pod file
   config = configPlugin.withDangerousMod(config, [
     'ios',

--- a/js/react_native/package.json
+++ b/js/react_native/package.json
@@ -49,6 +49,7 @@
     "ios/*.mm",
     "onnxruntime-react-native.podspec",
     "app.plugin.js",
+    "react-native.config.js",
     "unimodule.json",
     "!dist/commonjs/*.js.map",
     "!dist/module/*.js.map",

--- a/js/react_native/react-native.config.js
+++ b/js/react_native/react-native.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  dependency: {
+    platforms: {
+      android: {
+        packageImportPath: 'import ai.onnxruntime.reactnative.OnnxruntimePackage;',
+        packageInstance: 'new OnnxruntimePackage()',
+      },
+      ios: {},
+    },
+  },
+};


### PR DESCRIPTION
## Summary

This PR fixes the long-standing issue where `onnxruntime-react-native` requires
manual native setup after installation, causing the `TypeError: Cannot read property
'install' of null` runtime crash.

**Root cause:** The package shipped without a `react-native.config.js`, so the RN
community CLI autolinking did not register `OnnxruntimePackage` on Android. For Expo
users on the New Architecture, the existing `app.plugin.js` patched Gradle and the
Podfile but never registered the package class in `MainApplication`.

**Changes:**

- **`react-native.config.js`** (new) — enables RN community autolinking for Android.
  With RN 0.74+ this covers both old and new architecture via the generated
  `PackageList.java`. No manual `settings.gradle` or `MainApplication` edits needed
  for bare RN.

- **`app.plugin.js`** — adds a `withMainApplication` mod that idempotently inserts
  the `OnnxruntimePackage` import and registration into `MainApplication.kt`/`.java`
  during `expo prebuild`. Uses the same `mergeContents` tag pattern as the existing
  Gradle/Podfile mods, so it is safe to run multiple times.

- **`package.json`** — includes `react-native.config.js` in the npm `files` array so
  it ships in the tarball.

- **`README.md`** — documents that autolinking handles registration automatically and
  adds the Expo plugin usage snippet.

## Testing

- Bare RN: `npx react-native config | jq '.dependencies["onnxruntime-react-native"]'`
  should show `packageImportPath` populated; `PackageList.java` should include
  `OnnxruntimePackage` after a Gradle sync.
- Expo: `npx expo prebuild --clean` should produce a `MainApplication.kt` containing
  `import ai.onnxruntime.reactnative.OnnxruntimePackage` and `add(OnnxruntimePackage())`.

Fixes #19510
See also #17773
