### PR TITLE
Fix EpGraphAssignmentInfo missing issue on nodes assigned to CPU-EP by InsertCastTransformer

### DIFF
--- a/onnxruntime/core/optimizer/insert_cast_transformer.cc
+++ b/onnxruntime/core/optimizer/insert_cast_transformer.cc
@@ -4,6 +4,8 @@
 #include "core/optimizer/insert_cast_transformer.h"
 #include "core/framework/data_types.h"
 #include "core/graph/graph_utils.h"
+#include "core/framework/compute_capability.h"
+#include "core/graph/indexed_sub_graph.h"
 
 using namespace ONNX_NAMESPACE;
 using namespace ::onnxruntime::common;
@@ -548,6 +550,14 @@ Status InsertCastTransformer::ApplyImpl(onnxruntime::Graph& graph, bool& modifie
       // Set current node to run on the CPU execution provider
       // Keep in mind that the EP will be empty because NeedInsertCast() already insures that
       node->SetExecutionProviderType(kCpuExecutionProvider);
+
+      // Record the CPU reassignment via the partition assignment callback if provided.
+      if (on_partition_assignment_fn_) {
+        auto sub_graph = std::make_unique<IndexedSubGraph>();
+        sub_graph->nodes = {node->Index()};
+        ComputeCapability capability(std::move(sub_graph));
+        on_partition_assignment_fn_(graph, capability, kCpuExecutionProvider);
+      }
 
       // Some ONNX operators have an attribute `dtype` which define the output type for these operators
       // (mostly Generator ops like RandomNormal, RandomNormalLike, EyeLike, etc.).

--- a/onnxruntime/core/optimizer/insert_cast_transformer.cc
+++ b/onnxruntime/core/optimizer/insert_cast_transformer.cc
@@ -232,11 +232,11 @@ static bool IsIsolatedFp16NodeOnCpu(const onnxruntime::Node& node, onnxruntime::
 // not for nodes whose partitioner assignment is already on record.
 static Status ForceSingleNodeCPUFloat16ToFloat32(onnxruntime::Graph& graph, const KernelRegistry& cpu_kernel_registry,
                                                  const logging::Logger& logger,
-                                                 InlinedHashSet<NodeIndex>& already_assigned_nodes) {
+                                                 InlinedHashSet<NodeIndex>& nodes_with_recorded_cpu_assignment) {
   for (auto& node : graph.Nodes()) {
     if (IsIsolatedFp16NodeOnCpu(node, graph, cpu_kernel_registry, logger)) {
       // unassign the node so that NeedInsertCast will return true for it, forcing it to fp32
-      already_assigned_nodes.insert(node.Index());
+      nodes_with_recorded_cpu_assignment.insert(node.Index());
       node.SetExecutionProviderType("");
     }
   }
@@ -522,10 +522,10 @@ Status InsertCastTransformer::ApplyImpl(onnxruntime::Graph& graph, bool& modifie
   // assigned to CPU EP by the partitioner (they have an fp16 CPU kernel and got cast-wrapped to
   // avoid isolated fp16 islands).  Those nodes are tracked here so we can skip the callback —
   // their assignment was already recorded by the partitioner.
-  InlinedHashSet<NodeIndex> already_assigned_nodes;
+  InlinedHashSet<NodeIndex> nodes_with_recorded_cpu_assignment;
   if (force_cpu_fp32_)
     ORT_RETURN_IF_ERROR(ForceSingleNodeCPUFloat16ToFloat32(graph, *cpu_kernel_registries_, logger,
-                                                           already_assigned_nodes));
+                                                           nodes_with_recorded_cpu_assignment));
 
   GraphViewer graph_viewer(graph);
   auto& order = graph_viewer.GetNodesInTopologicalOrder();
@@ -570,9 +570,9 @@ Status InsertCastTransformer::ApplyImpl(onnxruntime::Graph& graph, bool& modifie
       node->SetExecutionProviderType(kCpuExecutionProvider);
 
       // Record the new CPU EP assignment via the partition assignment callback if provided.
-      // Skip nodes in already_assigned_nodes: their CPU EP assignment was made by the partitioner
+      // Skip nodes in nodes_with_recorded_cpu_assignment: their CPU EP assignment was made by the partitioner
       // and is already on record; the callback must not fire again for them.
-      if (on_partition_assignment_fn_ && already_assigned_nodes.find(node->Index()) == already_assigned_nodes.end()) {
+      if (on_partition_assignment_fn_ && nodes_with_recorded_cpu_assignment.find(node->Index()) == nodes_with_recorded_cpu_assignment.end()) {
         auto sub_graph = std::make_unique<IndexedSubGraph>();
         sub_graph->nodes = {node->Index()};
         ComputeCapability capability(std::move(sub_graph));

--- a/onnxruntime/core/optimizer/insert_cast_transformer.cc
+++ b/onnxruntime/core/optimizer/insert_cast_transformer.cc
@@ -224,11 +224,19 @@ static bool IsIsolatedFp16NodeOnCpu(const onnxruntime::Node& node, onnxruntime::
   return false;
 }
 
+// These nodes have an fp16 CPU kernel and were therefore assigned to CPU EP by the partitioner;
+// that assignment has already been recorded.  Clearing the EP is the mechanism that makes
+// NeedInsertCast return true so they get wrapped with fp32 casts like any other unassigned node.
+// Collect their indices so ApplyImpl can skip the on_partition_assignment_fn_ callback for them:
+// the callback is only for nodes that are newly receiving a CPU EP fallback from this transformer,
+// not for nodes whose partitioner assignment is already on record.
 static Status ForceSingleNodeCPUFloat16ToFloat32(onnxruntime::Graph& graph, const KernelRegistry& cpu_kernel_registry,
-                                                 const logging::Logger& logger) {
+                                                 const logging::Logger& logger,
+                                                 InlinedHashSet<NodeIndex>& already_assigned_nodes) {
   for (auto& node : graph.Nodes()) {
     if (IsIsolatedFp16NodeOnCpu(node, graph, cpu_kernel_registry, logger)) {
       // unassign the node so that NeedInsertCast will return true for it, forcing it to fp32
+      already_assigned_nodes.insert(node.Index());
       node.SetExecutionProviderType("");
     }
   }
@@ -506,8 +514,18 @@ class RemoveDuplicateCastTransformer : public GraphTransformer {
 
 Status InsertCastTransformer::ApplyImpl(onnxruntime::Graph& graph, bool& modified, int graph_level,
                                         const logging::Logger& logger) const {
+  // This transformer implements a targeted fallback policy: any unassigned node with an fp16 input
+  // is rewritten to consume fp32 (via inserted casts) and given a CPU EP assignment.
+  // on_partition_assignment_fn_ is fired to record each such new CPU EP assignment.
+  //
+  // Exception: ForceSingleNodeCPUFloat16ToFloat32 may clear the EP of nodes that were already
+  // assigned to CPU EP by the partitioner (they have an fp16 CPU kernel and got cast-wrapped to
+  // avoid isolated fp16 islands).  Those nodes are tracked here so we can skip the callback —
+  // their assignment was already recorded by the partitioner.
+  InlinedHashSet<NodeIndex> already_assigned_nodes;
   if (force_cpu_fp32_)
-    ORT_RETURN_IF_ERROR(ForceSingleNodeCPUFloat16ToFloat32(graph, *cpu_kernel_registries_, logger));
+    ORT_RETURN_IF_ERROR(ForceSingleNodeCPUFloat16ToFloat32(graph, *cpu_kernel_registries_, logger,
+                                                           already_assigned_nodes));
 
   GraphViewer graph_viewer(graph);
   auto& order = graph_viewer.GetNodesInTopologicalOrder();
@@ -551,8 +569,10 @@ Status InsertCastTransformer::ApplyImpl(onnxruntime::Graph& graph, bool& modifie
       // Keep in mind that the EP will be empty because NeedInsertCast() already insures that
       node->SetExecutionProviderType(kCpuExecutionProvider);
 
-      // Record the CPU reassignment via the partition assignment callback if provided.
-      if (on_partition_assignment_fn_) {
+      // Record the new CPU EP assignment via the partition assignment callback if provided.
+      // Skip nodes in already_assigned_nodes: their CPU EP assignment was made by the partitioner
+      // and is already on record; the callback must not fire again for them.
+      if (on_partition_assignment_fn_ && already_assigned_nodes.find(node->Index()) == already_assigned_nodes.end()) {
         auto sub_graph = std::make_unique<IndexedSubGraph>();
         sub_graph->nodes = {node->Index()};
         ComputeCapability capability(std::move(sub_graph));

--- a/onnxruntime/core/optimizer/insert_cast_transformer.h
+++ b/onnxruntime/core/optimizer/insert_cast_transformer.h
@@ -8,6 +8,7 @@
 #include "core/optimizer/graph_transformer.h"
 #include "core/framework/kernel_registry_manager.h"
 #include "core/framework/kernel_registry.h"
+#include "core/framework/graph_partitioner.h"
 
 namespace onnxruntime {
 
@@ -23,10 +24,12 @@ class InsertCastTransformer : public onnxruntime::GraphTransformer {
    * @param name                    for logging purpose
    * @param cpu_kernel_registry     used to query whether an op node can be safely created
    */
-  InsertCastTransformer(const std::string& name, const KernelRegistry* cpu_kernel_registry)
+  InsertCastTransformer(const std::string& name, const KernelRegistry* cpu_kernel_registry,
+                        OnPartitionAssignmentFunction on_partition_assignment_fn = {})
       : onnxruntime::GraphTransformer(name),
         cpu_kernel_registries_(cpu_kernel_registry),
-        force_cpu_fp32_(cpu_kernel_registry != nullptr) {}
+        force_cpu_fp32_(cpu_kernel_registry != nullptr),
+        on_partition_assignment_fn_(std::move(on_partition_assignment_fn)) {}
 
  private:
   Status ApplyImpl(onnxruntime::Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const override;
@@ -39,5 +42,9 @@ class InsertCastTransformer : public onnxruntime::GraphTransformer {
   // A better solution is to have a cost model to evaluate does it works to place the node on float16.
   // Here for simplify, we only force the single-node-float16 sub-graph to float32
   const bool force_cpu_fp32_;
+
+  // Optional callback to record when nodes are reassigned to CPU EP by this transformer.
+  // Reuses the same callback type as GraphPartitioner to maintain consistent EP assignment tracking.
+  OnPartitionAssignmentFunction on_partition_assignment_fn_;
 };
 }  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/insert_cast_transformer.h
+++ b/onnxruntime/core/optimizer/insert_cast_transformer.h
@@ -43,7 +43,7 @@ class InsertCastTransformer : public onnxruntime::GraphTransformer {
   // Here for simplify, we only force the single-node-float16 sub-graph to float32
   const bool force_cpu_fp32_;
 
-  // Optional callback to record when nodes are reassigned to CPU EP by this transformer.
+  // Optional callback to record when nodes are assigned to CPU EP by this transformer.
   // Reuses the same callback type as GraphPartitioner to maintain consistent EP assignment tracking.
   OnPartitionAssignmentFunction on_partition_assignment_fn_;
 };

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1678,7 +1678,7 @@ common::Status InferenceSession::TransformGraph(onnxruntime::Graph& graph, bool 
         cpu_regs = kernel_regs[kernel_regs.size() - 1];
       }
 
-      InsertCastTransformer insert_cast_transformer{"CastFloat16Transformer", cpu_regs};
+      InsertCastTransformer insert_cast_transformer{"CastFloat16Transformer", cpu_regs, on_partition_assignment_fn};
       ORT_RETURN_IF_ERROR_SESSIONID_(
           apply_transformer_once(insert_cast_transformer, *session_logger_, graph,
                                  ((graph_optimizations_loop_level > 1) ? &is_graph_modified : nullptr)));

--- a/onnxruntime/test/autoep/test_execution.cc
+++ b/onnxruntime/test/autoep/test_execution.cc
@@ -327,9 +327,12 @@ void RunMulModelWithPluginEpUsingIOBinding(const Ort::SessionOptions& session_op
   EXPECT_THAT(output_span, ::testing::ElementsAre(2, 4, 6, 8, 10, 12));
 }
 
-// Builds a minimal ONNX model bytes with a single FP16 Relu node.
-// Graph: X[1,4 float16] -> Relu -> Y[1,4 float16]
-std::string BuildFp16ReluModelBytes() {
+// Builds a minimal ONNX model bytes with a single FP16 HardSigmoid node.
+// Graph: X[1,4 float16] -> HardSigmoid -> Y[1,4 float16]
+// HardSigmoid is used because it has NO MLFloat16 CPU kernel on any build config,
+// ensuring the node remains unassigned during partitioning and exercises the
+// InsertCastTransformer callback path.
+std::string BuildFp16HardSigmoidModelBytes() {
   ONNX_NAMESPACE::ModelProto model;
   model.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
   auto* opset = model.add_opset_import();
@@ -337,7 +340,7 @@ std::string BuildFp16ReluModelBytes() {
   opset->set_version(14);
 
   ONNX_NAMESPACE::GraphProto* graph = model.mutable_graph();
-  graph->set_name("fp16_relu");
+  graph->set_name("fp16_hardsigmoid");
 
   auto add_fp16_value_info = [](ONNX_NAMESPACE::GraphProto* g, bool is_input,
                                 const std::string& name) {
@@ -353,14 +356,14 @@ std::string BuildFp16ReluModelBytes() {
   add_fp16_value_info(graph, /*is_input=*/false, "Y");
 
   auto* node = graph->add_node();
-  node->set_name("relu_0");
-  node->set_op_type("Relu");
+  node->set_name("hardsigmoid_0");
+  node->set_op_type("HardSigmoid");
   node->set_domain("");
   node->add_input("X");
   node->add_output("Y");
 
   std::string bytes;
-  EXPECT_TRUE(model.SerializeToString(&bytes)) << "Failed to serialize FP16 Relu ONNX model";
+  EXPECT_TRUE(model.SerializeToString(&bytes)) << "Failed to serialize FP16 HardSigmoid ONNX model";
   return bytes;
 }
 
@@ -445,18 +448,18 @@ TEST(OrtEpLibrary, PluginEp_AppendV2_PartiallySupportedModelInference) {
   RunAddMulAddModel(session_options, check_ep_node_assignment);
 }
 
-// Verifies that GetEpGraphAssignmentInfo() correctly captures the FP16 Relu node being assigned
-// to the CPU EP by InsertCastTransformer.
+// Verifies that GetEpGraphAssignmentInfo() correctly captures the FP16 HardSigmoid node being
+// assigned to the CPU EP by InsertCastTransformer.
 //
-// During graph partitioning (step 4 in TransformGraph), the FP16 Relu node is not claimed by any
-// EP (the example EP only supports FP32 Mul; the CPU EP has no FP16 Relu kernel), so
+// During graph partitioning (step 4 in TransformGraph), the FP16 assigned node is not claimed by
+// any EP (the example EP only supports FP32 Mul; the CPU EP has no FP16 HardSigmoid kernel), so
 // on_partition_assignment_fn is never called at that stage.
 //
-// InsertCastTransformer (step 6) then converts the FP16 Relu: it inserts Cast(FP16->FP32) before
-// the node, assigns the Relu to the CPU EP, and inserts Cast(FP32->FP16) after.
-// InsertCastTransformer now invokes on_partition_assignment_fn when it assigns the Relu to CPU,
-// so the node must appear in GetEpGraphAssignmentInfo().
-TEST(OrtEpLibrary, PluginEp_AppendV2_Fp16Relu_EpGraphAssignmentInfo) {
+// InsertCastTransformer (step 6) then converts the FP16 HardSigmoid: it inserts Cast(FP16->FP32)
+// before the node, assigns the HardSigmoid to the CPU EP, and inserts Cast(FP32->FP16) after.
+// InsertCastTransformer now invokes on_partition_assignment_fn when it assigns the HardSigmoid to
+// CPU, so the node must appear in GetEpGraphAssignmentInfo().
+TEST(OrtEpLibrary, PluginEp_AppendV2_Fp16HardSigmoid_EpGraphAssignmentInfo) {
   RegisteredEpDeviceUniquePtr example_ep;
   ASSERT_NO_FATAL_FAILURE(Utils::RegisterAndGetExampleEp(*ort_env, Utils::example_ep_info, example_ep));
   Ort::ConstEpDevice plugin_ep_device(example_ep.get());
@@ -468,23 +471,23 @@ TEST(OrtEpLibrary, PluginEp_AppendV2_Fp16Relu_EpGraphAssignmentInfo) {
   session_options.AddConfigEntry(kOrtSessionOptionsRecordEpGraphAssignmentInfo, "1");
   session_options.AppendExecutionProvider_V2(*ort_env, {plugin_ep_device}, ep_options);
 
-  const std::string model_bytes = BuildFp16ReluModelBytes();
+  const std::string model_bytes = BuildFp16HardSigmoidModelBytes();
   Ort::Session session(*ort_env, model_bytes.data(), model_bytes.size(), session_options);
 
-  // InsertCastTransformer assigns the Relu to CPU EP and fires the callback, so there must be
-  // exactly one subgraph entry: the Relu node on the CPU EP.
+  // InsertCastTransformer assigns the HardSigmoid to CPU EP and fires the callback, so there must
+  // be exactly one subgraph entry: the HardSigmoid node on the CPU EP.
   std::vector<Ort::ConstEpAssignedSubgraph> ep_subgraphs = session.GetEpGraphAssignmentInfo();
   ASSERT_EQ(ep_subgraphs.size(), 1u)
-      << "Expected exactly one EP subgraph (Relu on CPU EP), got " << ep_subgraphs.size();
+      << "Expected exactly one EP subgraph (HardSigmoid on CPU EP), got " << ep_subgraphs.size();
 
   std::string ep_name = ep_subgraphs[0].GetEpName();
   ASSERT_EQ(ep_name, kCpuExecutionProvider)
-      << "Expected Relu to be assigned to CPU EP, got: " << ep_name;
+      << "Expected HardSigmoid to be assigned to CPU EP, got: " << ep_name;
 
   const std::vector<Ort::ConstEpAssignedNode> ep_nodes = ep_subgraphs[0].GetNodes();
   ASSERT_EQ(ep_nodes.size(), 1u) << "Expected exactly one node in the CPU EP subgraph";
-  ASSERT_EQ(ep_nodes[0].GetOperatorType(), std::string("Relu"));
-  ASSERT_EQ(ep_nodes[0].GetName(), std::string("relu_0"));
+  ASSERT_EQ(ep_nodes[0].GetOperatorType(), std::string("HardSigmoid"));
+  ASSERT_EQ(ep_nodes[0].GetName(), std::string("hardsigmoid_0"));
 }
 
 // Generate an EPContext model with a plugin EP.

--- a/onnxruntime/test/autoep/test_execution.cc
+++ b/onnxruntime/test/autoep/test_execution.cc
@@ -331,7 +331,7 @@ void RunMulModelWithPluginEpUsingIOBinding(const Ort::SessionOptions& session_op
 // Graph: X[1,4 float16] -> Relu -> Y[1,4 float16]
 std::string BuildFp16ReluModelBytes() {
   ONNX_NAMESPACE::ModelProto model;
-  model.set_ir_version(7);
+  model.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
   auto* opset = model.add_opset_import();
   opset->set_domain("");
   opset->set_version(14);
@@ -360,7 +360,7 @@ std::string BuildFp16ReluModelBytes() {
   node->add_output("Y");
 
   std::string bytes;
-  model.SerializeToString(&bytes);
+  EXPECT_TRUE(model.SerializeToString(&bytes)) << "Failed to serialize FP16 Relu ONNX model";
   return bytes;
 }
 

--- a/onnxruntime/test/autoep/test_execution.cc
+++ b/onnxruntime/test/autoep/test_execution.cc
@@ -10,6 +10,7 @@
 #include <gtest/gtest.h>
 
 #include "core/graph/constants.h"
+#include "core/graph/onnx_protobuf.h"
 #include "core/session/onnxruntime_cxx_api.h"
 #include "core/session/onnxruntime_session_options_config_keys.h"
 #include "core/session/onnxruntime_ep_device_ep_metadata_keys.h"
@@ -326,6 +327,43 @@ void RunMulModelWithPluginEpUsingIOBinding(const Ort::SessionOptions& session_op
   EXPECT_THAT(output_span, ::testing::ElementsAre(2, 4, 6, 8, 10, 12));
 }
 
+// Builds a minimal ONNX model bytes with a single FP16 Relu node.
+// Graph: X[1,4 float16] -> Relu -> Y[1,4 float16]
+std::string BuildFp16ReluModelBytes() {
+  ONNX_NAMESPACE::ModelProto model;
+  model.set_ir_version(7);
+  auto* opset = model.add_opset_import();
+  opset->set_domain("");
+  opset->set_version(14);
+
+  ONNX_NAMESPACE::GraphProto* graph = model.mutable_graph();
+  graph->set_name("fp16_relu");
+
+  auto add_fp16_value_info = [](ONNX_NAMESPACE::GraphProto* g, bool is_input,
+                                const std::string& name) {
+    auto* v = is_input ? g->add_input() : g->add_output();
+    v->set_name(name);
+    auto* t = v->mutable_type()->mutable_tensor_type();
+    t->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT16);
+    t->mutable_shape()->add_dim()->set_dim_value(1);
+    t->mutable_shape()->add_dim()->set_dim_value(4);
+  };
+
+  add_fp16_value_info(graph, /*is_input=*/true, "X");
+  add_fp16_value_info(graph, /*is_input=*/false, "Y");
+
+  auto* node = graph->add_node();
+  node->set_name("relu_0");
+  node->set_op_type("Relu");
+  node->set_domain("");
+  node->add_input("X");
+  node->add_output("Y");
+
+  std::string bytes;
+  model.SerializeToString(&bytes);
+  return bytes;
+}
+
 }  // namespace
 
 // Creates a session with the example plugin EP and runs a model with a single Mul node.
@@ -405,6 +443,48 @@ TEST(OrtEpLibrary, PluginEp_AppendV2_PartiallySupportedModelInference) {
   };
 
   RunAddMulAddModel(session_options, check_ep_node_assignment);
+}
+
+// Verifies that GetEpGraphAssignmentInfo() correctly captures the FP16 Relu node being assigned
+// to the CPU EP by InsertCastTransformer.
+//
+// During graph partitioning (step 4 in TransformGraph), the FP16 Relu node is not claimed by any
+// EP (the example EP only supports FP32 Mul; the CPU EP has no FP16 Relu kernel), so
+// on_partition_assignment_fn is never called at that stage.
+//
+// InsertCastTransformer (step 6) then converts the FP16 Relu: it inserts Cast(FP16->FP32) before
+// the node, reassigns the Relu to the CPU EP, and inserts Cast(FP32->FP16) after.
+// InsertCastTransformer now invokes on_partition_assignment_fn when it reassigns the Relu to CPU,
+// so the node must appear in GetEpGraphAssignmentInfo().
+TEST(OrtEpLibrary, PluginEp_AppendV2_Fp16Relu_EpGraphAssignmentInfo) {
+  RegisteredEpDeviceUniquePtr example_ep;
+  ASSERT_NO_FATAL_FAILURE(Utils::RegisterAndGetExampleEp(*ort_env, Utils::example_ep_info, example_ep));
+  Ort::ConstEpDevice plugin_ep_device(example_ep.get());
+
+  Ort::SessionOptions session_options;
+  std::unordered_map<std::string, std::string> ep_options;
+
+  // Enable recording of EP-graph assignment info.
+  session_options.AddConfigEntry(kOrtSessionOptionsRecordEpGraphAssignmentInfo, "1");
+  session_options.AppendExecutionProvider_V2(*ort_env, {plugin_ep_device}, ep_options);
+
+  const std::string model_bytes = BuildFp16ReluModelBytes();
+  Ort::Session session(*ort_env, model_bytes.data(), model_bytes.size(), session_options);
+
+  // InsertCastTransformer reassigns the Relu to CPU EP and fires the callback, so there must be
+  // exactly one subgraph entry: the Relu node on the CPU EP.
+  std::vector<Ort::ConstEpAssignedSubgraph> ep_subgraphs = session.GetEpGraphAssignmentInfo();
+  ASSERT_EQ(ep_subgraphs.size(), 1u)
+      << "Expected exactly one EP subgraph (Relu on CPU EP), got " << ep_subgraphs.size();
+
+  std::string ep_name = ep_subgraphs[0].GetEpName();
+  ASSERT_EQ(ep_name, kCpuExecutionProvider)
+      << "Expected Relu to be assigned to CPU EP, got: " << ep_name;
+
+  const std::vector<Ort::ConstEpAssignedNode> ep_nodes = ep_subgraphs[0].GetNodes();
+  ASSERT_EQ(ep_nodes.size(), 1u) << "Expected exactly one node in the CPU EP subgraph";
+  ASSERT_EQ(ep_nodes[0].GetOperatorType(), std::string("Relu"));
+  ASSERT_EQ(ep_nodes[0].GetName(), std::string("relu_0"));
 }
 
 // Generate an EPContext model with a plugin EP.

--- a/onnxruntime/test/autoep/test_execution.cc
+++ b/onnxruntime/test/autoep/test_execution.cc
@@ -453,8 +453,8 @@ TEST(OrtEpLibrary, PluginEp_AppendV2_PartiallySupportedModelInference) {
 // on_partition_assignment_fn is never called at that stage.
 //
 // InsertCastTransformer (step 6) then converts the FP16 Relu: it inserts Cast(FP16->FP32) before
-// the node, reassigns the Relu to the CPU EP, and inserts Cast(FP32->FP16) after.
-// InsertCastTransformer now invokes on_partition_assignment_fn when it reassigns the Relu to CPU,
+// the node, assigns the Relu to the CPU EP, and inserts Cast(FP32->FP16) after.
+// InsertCastTransformer now invokes on_partition_assignment_fn when it assigns the Relu to CPU,
 // so the node must appear in GetEpGraphAssignmentInfo().
 TEST(OrtEpLibrary, PluginEp_AppendV2_Fp16Relu_EpGraphAssignmentInfo) {
   RegisteredEpDeviceUniquePtr example_ep;
@@ -471,7 +471,7 @@ TEST(OrtEpLibrary, PluginEp_AppendV2_Fp16Relu_EpGraphAssignmentInfo) {
   const std::string model_bytes = BuildFp16ReluModelBytes();
   Ort::Session session(*ort_env, model_bytes.data(), model_bytes.size(), session_options);
 
-  // InsertCastTransformer reassigns the Relu to CPU EP and fires the callback, so there must be
+  // InsertCastTransformer assigns the Relu to CPU EP and fires the callback, so there must be
   // exactly one subgraph entry: the Relu node on the CPU EP.
   std::vector<Ort::ConstEpAssignedSubgraph> ep_subgraphs = session.GetEpGraphAssignmentInfo();
   ASSERT_EQ(ep_subgraphs.size(), 1u)

--- a/onnxruntime/test/framework/insert_cast_transformer_test.cc
+++ b/onnxruntime/test/framework/insert_cast_transformer_test.cc
@@ -568,5 +568,78 @@ TEST(TransformerTest, CrossEpCastNodesNotFused) {
       << "Cast_2 input should remain float32, not be changed to int64";
 }
 
+// Verify that on_partition_assignment_fn_ is NOT called for a node whose CPU EP assignment was
+// already recorded by the partitioner, even when ForceSingleNodeCPUFloat16ToFloat32 later clears
+// that assignment to force the node through the fp32 cast-wrapping path.
+//
+// Graph: I1(fp16) -> Relu(no fp16 kernel, EP empty) -> O1(fp16)
+//                 -> Concat(fp16 kernel, EP=CPU)     -> O2(fp16)
+//                 -> Relu(no fp16 kernel, EP empty)  -> O3(fp16)
+//
+// The two Relu nodes are unassigned.  InsertCastTransformer's fallback policy wraps them with
+// fp32 casts and assigns them to CPU EP; the callback should fire once for each.
+//
+// Concat was already assigned to CPU EP by the partitioner (it has an fp16 CPU kernel).
+// ForceSingleNodeCPUFloat16ToFloat32 clears its EP so it also gets cast-wrapped (avoiding an
+// isolated fp16 island).  When the transformer then assigns Concat to CPU EP as a fallback, it
+// must NOT fire the callback — that would duplicate the partitioner's already-recorded assignment.
+TEST(TransformerTest, IsolatedFp16NodeDoesNotDuplicatePartitionCallback) {
+  auto model = std::make_shared<onnxruntime::Model>("test", false, DefaultLoggingManager().DefaultLogger());
+  onnxruntime::Graph& graph = model->MainGraph();
+
+  TypeProto tensor_float_16;
+  tensor_float_16.mutable_tensor_type()->set_elem_type(TensorProto_DataType_FLOAT16);
+
+  onnxruntime::NodeArg i1_def("I1", &tensor_float_16),
+      o1_def("O1", &tensor_float_16),
+      o2_def("O2", &tensor_float_16),
+      o3_def("O3", &tensor_float_16);
+
+  // Relu nodes have no fp16 CPU kernel — leave EP unset so InsertCastTransformer will wrap them.
+  auto& relu1 = graph.AddNode("relu1", "Relu", "no fp16", {&i1_def}, {&o1_def});
+  // Concat has an fp16 CPU kernel — simulate partitioner assignment.
+  NodeAttributes concat_attrs = {{"axis", utils::MakeAttribute("axis", static_cast<int64_t>(0))}};
+  auto& concat = graph.AddNode("concat", "Concat", "fp16 capable", {&o1_def}, {&o2_def}, &concat_attrs);
+  concat.SetExecutionProviderType(onnxruntime::kCpuExecutionProvider);
+  auto& relu2 = graph.AddNode("relu2", "Relu", "no fp16", {&o2_def}, {&o3_def});
+
+  auto status = graph.Resolve();
+  ASSERT_TRUE(status.IsOK()) << status.ErrorMessage();
+
+  // Collect the node indices reported to the partition callback.
+  std::vector<NodeIndex> callback_indices;
+  auto on_assignment = [&callback_indices](const Graph&, const ComputeCapability& capability,
+                                           const std::string&) {
+    if (capability.sub_graph) {
+      for (NodeIndex idx : capability.sub_graph->nodes) {
+        callback_indices.push_back(idx);
+      }
+    }
+  };
+
+  InsertCastTransformer transformer("Test", DefaultCpuExecutionProvider()->GetKernelRegistry().get(),
+                                    on_assignment);
+
+  bool modified = false;
+  status = transformer.Apply(graph, modified, DefaultLoggingManager().DefaultLogger());
+  EXPECT_TRUE(status.IsOK()) << status.ErrorMessage();
+  EXPECT_TRUE(modified);
+
+  // Only the two Relu nodes (new CPU assignments) should have fired the callback.
+  // Concat was already assigned by the partitioner — re-assigning it must not produce a duplicate.
+  ASSERT_EQ(callback_indices.size(), 2u)
+      << "on_partition_assignment_fn_ must fire exactly once per newly-assigned node; "
+         "Concat was already assigned and must not produce a duplicate record";
+
+  const NodeIndex relu1_idx = relu1.Index();
+  const NodeIndex relu2_idx = relu2.Index();
+  EXPECT_NE(std::find(callback_indices.begin(), callback_indices.end(), relu1_idx), callback_indices.end())
+      << "Relu1 should have been reported as a new CPU assignment";
+  EXPECT_NE(std::find(callback_indices.begin(), callback_indices.end(), relu2_idx), callback_indices.end())
+      << "Relu2 should have been reported as a new CPU assignment";
+  EXPECT_EQ(std::find(callback_indices.begin(), callback_indices.end(), concat.Index()), callback_indices.end())
+      << "Concat was already assigned to CPU EP — its re-assignment must not fire the callback again";
+}
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/framework/insert_cast_transformer_test.cc
+++ b/onnxruntime/test/framework/insert_cast_transformer_test.cc
@@ -595,13 +595,13 @@ TEST(TransformerTest, IsolatedFp16NodeDoesNotDuplicatePartitionCallback) {
       o2_def("O2", &tensor_float_16),
       o3_def("O3", &tensor_float_16);
 
-  // Relu nodes have no fp16 CPU kernel — leave EP unset so InsertCastTransformer will wrap them.
-  auto& relu1 = graph.AddNode("relu1", "Relu", "no fp16", {&i1_def}, {&o1_def});
-  // Concat has an fp16 CPU kernel — simulate partitioner assignment.
+  // Leave the Relu nodes' EP unset so InsertCastTransformer treats them as newly assigned and wraps them.
+  auto& relu1 = graph.AddNode("relu1", "Relu", "EP unset", {&i1_def}, {&o1_def});
+  // Simulate a node that was already assigned by the partitioner.
   NodeAttributes concat_attrs = {{"axis", utils::MakeAttribute("axis", static_cast<int64_t>(0))}};
-  auto& concat = graph.AddNode("concat", "Concat", "fp16 capable", {&o1_def}, {&o2_def}, &concat_attrs);
+  auto& concat = graph.AddNode("concat", "Concat", "pre-assigned", {&o1_def}, {&o2_def}, &concat_attrs);
   concat.SetExecutionProviderType(onnxruntime::kCpuExecutionProvider);
-  auto& relu2 = graph.AddNode("relu2", "Relu", "no fp16", {&o2_def}, {&o3_def});
+  auto& relu2 = graph.AddNode("relu2", "Relu", "EP unset", {&o2_def}, {&o3_def});
 
   auto status = graph.Resolve();
   ASSERT_TRUE(status.IsOK()) << status.ErrorMessage();


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Pass `on_partition_assignment_fn` into `InsertCastTransformer` so that CPU assignments made during cast insertion are recorded with the same callback used by `GraphPartitioner`.
- Avoid duplicated records in `ForceSingleNodeCPUFloat16ToFloat32`

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

- `InferenceSession::TransformGraph()` records EP-to-node assignments via `on_partition_assignment_fn`,      which is invoked by `GraphPartitioner` during **step 4** (graph partitioning). However, **step 6** (`InsertCastTransformer`) can silently assign nodes to the CPU EP after this recording window has closed.                                                                                                                                                                                                      
- Specifically, `InsertCastTransformer::ApplyImpl()` assigns them to CPU EP via `node->SetExecutionProviderType(kCpuExecutionProvider)`. Because this happens after `GraphPartitioner` has already run, `on_partition_assignment_fn` is never invoked for these nodes, resulting in an empty or incomplete `GetEpGraphAssignmentInfo()` for models that contain FP16 ops not supported by any registered EP (e.g. a FP16 Relu model with no FP16-capable EP).

