### PR TITLE
Support ONNX overloaded functions (IR version 10+)

### DIFF
--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -145,6 +145,14 @@ class Node {
    */
   const std::string& Domain() const noexcept { return domain_; }
 
+  /** Gets the overload identifier for model-local function dispatch (IR version 10+).
+   * @remarks Empty string for non-overloaded operators.
+   */
+  const std::string& Overload() const noexcept { return overload_; }
+
+  /** Sets the overload identifier for model-local function dispatch. */
+  void SetOverload(std::string_view overload) { overload_ = overload; }
+
   /** Gets the path of the owning model if any. */
   const std::filesystem::path& ModelPath() const noexcept;
 
@@ -638,6 +646,9 @@ class Node {
 
   // OperatorSet domain of op_type_.
   std::string domain_;
+
+  // Overload identifier for model-local function dispatch (IR version 10+).
+  std::string overload_;
 
 #if !defined(ORT_MINIMAL_BUILD)
   // OperatorSchema that <*this> node refers to.

--- a/onnxruntime/core/framework/graph_partitioner.cc
+++ b/onnxruntime/core/framework/graph_partitioner.cc
@@ -919,7 +919,7 @@ static Status InlineFunctionsAOTImpl(const ExecutionProviders& execution_provide
         ++inlined_count;
       } else {
         // OpType is the same as function name.
-        auto function_id = function_utils::GetFunctionIdentifier(node->Domain(), node->OpType());
+        auto function_id = function_utils::GetFunctionIdentifier(node->Domain(), node->OpType(), node->Overload());
         ORT_IGNORE_RETURN_VALUE(not_inlined.insert(std::move(function_id)));
       }
     }

--- a/onnxruntime/core/graph/function_utils.cc
+++ b/onnxruntime/core/graph/function_utils.cc
@@ -269,15 +269,17 @@ static void IOTypeConstraintHelper(const ONNX_NAMESPACE::FunctionProto& onnx_fun
 
 std::unique_ptr<ONNX_NAMESPACE::OpSchema> CreateSchema(const std::string& function_domain,
                                                        const std::string& function_name,
+                                                       const std::string& function_overload,
                                                        const std::unordered_map<std::string, const ONNX_NAMESPACE::FunctionProto*>& model_local_functions,
                                                        const std::unordered_map<std::string, int>& domain_version_map,
                                                        const SchemaRegistryManager& schema_registry,
                                                        const logging::Logger& logger,
                                                        bool allow_released_opsets_only) {
-  std::string func_identifier = function_utils::GetFunctionIdentifier(function_domain, function_name);
+  std::string func_identifier = function_utils::GetFunctionIdentifier(function_domain, function_name, function_overload);
   auto iter = model_local_functions.find(func_identifier);
   if (iter == model_local_functions.end()) {
-    ORT_THROW("The given function name: ", function_name, ", domain: ", function_domain, " is not found in model local functions");
+    ORT_THROW("The given function name: ", function_name, ", domain: ", function_domain,
+              ", overload: ", function_overload, " is not found in model local functions");
   }
 
   auto* onnx_func_proto = iter->second;

--- a/onnxruntime/core/graph/function_utils.h
+++ b/onnxruntime/core/graph/function_utils.h
@@ -29,6 +29,7 @@ std::unique_ptr<ONNX_NAMESPACE::OpSchema> CreateSchema(const Graph& graph,
 /** Create a OpSchema given from a local function in onnx model.
  * @param function_domain The domain of the function.
  * @param function_name The name of the function.
+ * @param function_overload The overload identifier of the function (IR version 10+). Empty for non-overloaded functions.
  * @param model_local_functions The map of local functions in the same onnx model.
  *                              This will be used as context for the function's type/shape inference.
  *                              This argument is captured by shape inferencing lambda by reference and must
@@ -40,6 +41,7 @@ std::unique_ptr<ONNX_NAMESPACE::OpSchema> CreateSchema(const Graph& graph,
  */
 std::unique_ptr<ONNX_NAMESPACE::OpSchema> CreateSchema(const std::string& function_domain,
                                                        const std::string& function_name,
+                                                       const std::string& function_overload,
                                                        const std::unordered_map<std::string, const ONNX_NAMESPACE::FunctionProto*>& model_local_functions,
                                                        const std::unordered_map<std::string, int>& domain_version_map,
                                                        const SchemaRegistryManager& schema_registry,
@@ -50,9 +52,15 @@ std::unique_ptr<ONNX_NAMESPACE::OpSchema> CreateSchema(const std::string& functi
  * relevant model local function from it's container.
  * @param function_domain Domain for the function.
  * @param function_name Name of the function. Name should match the OpType of the node which references the function.
+ * @param function_overload Overload identifier for the function (IR version 10+). Empty for non-overloaded functions.
  */
-inline std::string GetFunctionIdentifier(std::string_view function_domain, std::string_view function_name) {
-  return function_domain.data() + std::string(":") + function_name.data();
+inline std::string GetFunctionIdentifier(std::string_view function_domain, std::string_view function_name,
+                                         std::string_view function_overload = std::string_view{}) {
+  std::string id = std::string(function_domain) + ":" + std::string(function_name);
+  if (!function_overload.empty()) {
+    id += ":" + std::string(function_overload);
+  }
+  return id;
 }
 
 void Specialize(ONNX_NAMESPACE::FunctionProto& called_function, const ONNX_NAMESPACE::NodeProto& calling_node,

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -659,6 +659,9 @@ void Node::ToProto(NodeProto& proto, bool update_subgraphs) const {
   if (!domain_.empty())
     proto.set_domain(domain_);
 
+  if (!overload_.empty())
+    proto.set_overload(overload_);
+
   if (!description_.empty())
     proto.set_doc_string(description_);
 
@@ -3495,7 +3498,7 @@ Status Graph::VerifyNodeAndOpMatch(const ResolveOptions& options) {
 
       if (!node.op_) {
         // check whether it refer to a function.
-        std::string func_identifier = function_utils::GetFunctionIdentifier(node.Domain(), node.OpType());
+        std::string func_identifier = function_utils::GetFunctionIdentifier(node.Domain(), node.OpType(), node.Overload());
         const auto& model_local_func_templates = owning_model_.GetModelLocalFunctionTemplates();
         auto iter = model_local_func_templates.find(func_identifier);
         if (iter != model_local_func_templates.end()) {
@@ -4386,6 +4389,10 @@ Node& Graph::AddNode(const Node& other) {
                            &other.GetAttributes(),
                            other.Domain());
 
+  if (!other.Overload().empty()) {
+    new_node.SetOverload(other.Overload());
+  }
+
   // Preserve layering annotation from the source node so that graph transformers
   // that reconstruct nodes (or function inlining) retain the EP assignment hint.
   const auto& annotation = other.GetLayeringAnnotation();
@@ -4417,6 +4424,10 @@ Node& Graph::AddNode(const NodeProto& node_proto,
                            output_defs,
                            &attributes,
                            node_proto.domain());
+
+  if (!node_proto.overload().empty()) {
+    new_node.SetOverload(node_proto.overload());
+  }
 
 #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
   auto maybe_annotation = utils::GetNodeProtoLayeringAnnotation(node_proto);

--- a/onnxruntime/core/graph/model.cc
+++ b/onnxruntime/core/graph/model.cc
@@ -61,7 +61,7 @@ void Model::RemoveLocalFunctionsProtos(const InlinedHashSet<std::string>& retain
     }
 
     for (auto it = local_functions->begin(); it != local_functions->end();) {
-      const auto function_id = function_utils::GetFunctionIdentifier(it->domain(), it->name());
+      const auto function_id = function_utils::GetFunctionIdentifier(it->domain(), it->name(), it->overload());
       if (retained.find(function_id) == retained_end) {
         it = local_functions->erase(it);
       } else {
@@ -125,7 +125,7 @@ Model::Model(const std::string& graph_name,
   for (auto& func : model_local_functions) {
     auto func_ptr = model_proto_.add_functions();
     func_ptr->CopyFrom(func);
-    model_local_functions_.insert_or_assign(function_utils::GetFunctionIdentifier(func_ptr->domain(), func_ptr->name()),
+    model_local_functions_.insert_or_assign(function_utils::GetFunctionIdentifier(func_ptr->domain(), func_ptr->name(), func_ptr->overload()),
                                             func_ptr);
   }
 
@@ -133,6 +133,7 @@ Model::Model(const std::string& graph_name,
   for (auto& func : model_proto_.functions()) {
     auto func_schema_ptr = function_utils::CreateSchema(func.domain(),
                                                         func.name(),
+                                                        func.overload(),
                                                         model_local_functions_,
                                                         *p_domain_to_version,
                                                         *schema_registry,
@@ -142,7 +143,8 @@ Model::Model(const std::string& graph_name,
     func_template_ptr->op_schema_ = std::move(func_schema_ptr);
     func_template_ptr->onnx_func_proto_ = &func;
     model_local_function_templates_maps_.insert_or_assign(function_utils::GetFunctionIdentifier(func.domain(),
-                                                                                                func.name()),
+                                                                                                func.name(),
+                                                                                                func.overload()),
                                                           std::move(func_template_ptr));
   }
 
@@ -256,13 +258,14 @@ Model::Model(ModelProto&& model_proto, const PathString& model_path,
 
   model_local_functions_.reserve(model_proto_.functions().size());
   for (auto& func : model_proto_.functions()) {
-    model_local_functions_.insert_or_assign(function_utils::GetFunctionIdentifier(func.domain(), func.name()), &func);
+    model_local_functions_.insert_or_assign(function_utils::GetFunctionIdentifier(func.domain(), func.name(), func.overload()), &func);
   }
 
   model_local_function_templates_maps_.reserve(model_proto_.functions().size());
   for (auto& func : model_proto_.functions()) {
     auto func_schema_ptr = function_utils::CreateSchema(func.domain(),
                                                         func.name(),
+                                                        func.overload(),
                                                         model_local_functions_,
                                                         domain_to_version,
                                                         *schema_registry,
@@ -272,7 +275,8 @@ Model::Model(ModelProto&& model_proto, const PathString& model_path,
     func_template_ptr->op_schema_ = std::move(func_schema_ptr);
     func_template_ptr->onnx_func_proto_ = &func;
     model_local_function_templates_maps_.insert_or_assign(function_utils::GetFunctionIdentifier(func.domain(),
-                                                                                                func.name()),
+                                                                                                func.name(),
+                                                                                                func.overload()),
                                                           std::move(func_template_ptr));
   }
 

--- a/onnxruntime/test/framework/function_test.cc
+++ b/onnxruntime/test/framework/function_test.cc
@@ -818,5 +818,108 @@ TEST(FunctionTest, InlinedNodesInheritDistinctAnnotationsPerCallSite) {
   EXPECT_TRUE(found_b) << "No node found with AnnotationB";
 }
 
+// Test that overloaded functions (IR version 10+) are resolved correctly.
+// Two functions with the same domain and name but different overload identifiers.
+TEST(FunctionTest, OverloadedFunctions) {
+  const char* code = R"(
+        <
+        ir_version: 10,
+        opset_import: [ "" : 17, "local" : 1 ]
+        >
+        agraph (float[N] x) => (float[N] y, float[N] z)
+        {
+            y = local.myfun:double_it (x)
+            z = local.myfun:triple_it (x)
+        }
+
+        <
+        opset_import: [ "" : 17 ],
+        domain: "local",
+        overload: "double_it"
+        >
+        myfun (lx) => (ly) {
+            two = Constant <value = float[1] {2.0}> ()
+            ly = Mul (lx, two)
+        }
+
+        <
+        opset_import: [ "" : 17 ],
+        domain: "local",
+        overload: "triple_it"
+        >
+        myfun (lx) => (ly) {
+            three = Constant <value = float[1] {3.0}> ()
+            ly = Mul (lx, three)
+        }
+        )";
+
+  // Serialize and then load model:
+  std::string serialized_model;
+  ParseOnnxSource(code, serialized_model);
+
+  SessionOptions session_options;
+  InferenceSession session_object{session_options, GetEnvironment()};
+
+  std::stringstream sstr(serialized_model);
+  auto status = session_object.Load(sstr);
+  ASSERT_TRUE(status.IsOK()) << status.ErrorMessage();
+  status = session_object.Initialize();
+  ASSERT_TRUE(status.IsOK()) << status.ErrorMessage();
+
+  RunOptions run_options;
+  run_options.run_tag = session_options.session_logid;
+
+  NameMLValMap feeds;
+  std::unique_ptr<CPUExecutionProvider> provider = std::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo());
+  std::vector<float> input_values = {1.0f, 2.0f, 3.0f};
+  OrtValue ort_value;
+  CreateMLValue<float>(provider->CreatePreferredAllocators()[0], {int64_t(input_values.size())}, input_values, &ort_value);
+  feeds.insert(std::make_pair(std::string("x"), ort_value));
+
+  std::vector<OrtValue> fetches;
+  status = session_object.Run(run_options, feeds, AsSpan({std::string("y"), std::string("z")}), &fetches);
+  ASSERT_TRUE(status.IsOK()) << "Session Run failed: " << status.ErrorMessage() << std::endl;
+
+  // Check "y" output (doubled)
+  auto& tensor_y = fetches[0].Get<Tensor>();
+  auto* data_y = tensor_y.Data<float>();
+  EXPECT_NEAR(data_y[0], 2.0f, 0.001f);
+  EXPECT_NEAR(data_y[1], 4.0f, 0.001f);
+  EXPECT_NEAR(data_y[2], 6.0f, 0.001f);
+
+  // Check "z" output (tripled)
+  auto& tensor_z = fetches[1].Get<Tensor>();
+  auto* data_z = tensor_z.Data<float>();
+  EXPECT_NEAR(data_z[0], 3.0f, 0.001f);
+  EXPECT_NEAR(data_z[1], 6.0f, 0.001f);
+  EXPECT_NEAR(data_z[2], 9.0f, 0.001f);
+}
+
+// Test that non-overloaded functions (empty overload) still work as before.
+TEST(FunctionTest, OverloadedFunctionBackwardCompat) {
+  // Same as basic_code but with ir_version: 10 to verify backward compatibility
+  const char* code = R"(
+        <
+        ir_version: 10,
+        opset_import: [ "" : 17, "local" : 1 ]
+        >
+        agraph (float[N] x) => (float[N] y)
+        {
+            y = local.myfun (x)
+        }
+
+        <
+        opset_import: [ "" : 17 ],
+        domain: "local"
+        >
+        myfun (lx) => (ly) {
+            two = Constant <value = float[1] {2.0}> ()
+            ly = Mul (lx, two)
+        }
+        )";
+
+  Check(code, "x", {1.0, 2.0, 3.0}, "y", {2.0, 4.0, 6.0});
+}
+
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
Add support for the overload field in FunctionProto and NodeProto, as specified in ONNX IR version 10. Functions are now uniquely identified by the triple (domain, name, overload) instead of just (domain, name).

Changes:
- function_utils.h: GetFunctionIdentifier accepts optional overload param
- function_utils.cc: CreateSchema takes overload for correct lookup
- graph.h: Node class gains overload_ member, Overload()/SetOverload()
- graph.cc: Store overload from NodeProto, serialize in ToProto, copy on AddNode, use overload in function resolution
- model.cc: Include overload in all function map keys
- graph_partitioner.cc: Include overload in not-inlined function tracking
- function_test.cc: Add tests for overloaded and backward-compatible cases

### Description
Support overloaded model-local functions as per ONNX spec.

### Motivation and Context
Support ONNX spec.


