### PR TITLE
Validate seqlens_k against cos_cache bounds in GroupQueryAttention to…

### DIFF
--- a/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
@@ -144,16 +144,18 @@ Status GroupQueryAttention<T>::Compute(OpKernelContext* context) const {
   T* k_rotary = packed_qkv ? nullptr : K.GetMutable<Tensor>()->MutableData<T>();
   if (do_rotary_) {
     ORT_ENFORCE(cos_cache != nullptr && sin_cache != nullptr, "cos_cache and sin_cache must be provided when do_rotary is true");
-    // Validate seqlens_k values against cos_cache size to prevent OOB in rotary embedding lookup.
+    // Validate seqlens_k values against cos/sin cache size to prevent OOB in rotary embedding lookup.
+    // Use the minimum of cos_cache and sin_cache dim-0 since CheckRotaryCaches does not enforce equality.
     {
-      const int cos_cache_max_seq = static_cast<int>(cos_cache->Shape().GetDims()[0]);
+      const int rotary_cache_max_seq = static_cast<int>(std::min(cos_cache->Shape().GetDims()[0],
+                                                                  sin_cache->Shape().GetDims()[0]));
       const int32_t* seqlens_k_data = seqlens_k->Data<int32_t>();
       for (int b = 0; b < batch_size; b++) {
-        // position_id = seqlens_k[b] (in token generation), must be < cos_cache rows
-        if (seqlens_k_data[b] >= cos_cache_max_seq) {
+        // position_id = seqlens_k[b] (in token generation), must be < cache rows
+        if (seqlens_k_data[b] >= rotary_cache_max_seq) {
           return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                                  "seqlens_k[", b, "] = ", seqlens_k_data[b],
-                                 " exceeds cos_cache dimension 0 (", cos_cache_max_seq, ")");
+                                 " exceeds rotary cache dimension 0 (", rotary_cache_max_seq, ")");
         }
       }
     }

--- a/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
@@ -152,10 +152,10 @@ Status GroupQueryAttention<T>::Compute(OpKernelContext* context) const {
       const int32_t* seqlens_k_data = seqlens_k->Data<int32_t>();
       for (int b = 0; b < batch_size; b++) {
         // position_id = seqlens_k[b] (in token generation), must be < cache rows
-        if (seqlens_k_data[b] >= rotary_cache_max_seq) {
+        if (seqlens_k_data[b] < 0 || seqlens_k_data[b] >= rotary_cache_max_seq) {
           return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                                  "seqlens_k[", b, "] = ", seqlens_k_data[b],
-                                 " exceeds rotary cache dimension 0 (", rotary_cache_max_seq, ")");
+                                 " is out of range for rotary cache dimension 0 (", rotary_cache_max_seq, ")");
         }
       }
     }

--- a/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
@@ -148,7 +148,7 @@ Status GroupQueryAttention<T>::Compute(OpKernelContext* context) const {
     // Use the minimum of cos_cache and sin_cache dim-0 since CheckRotaryCaches does not enforce equality.
     {
       const int rotary_cache_max_seq = static_cast<int>(std::min(cos_cache->Shape().GetDims()[0],
-                                                                  sin_cache->Shape().GetDims()[0]));
+                                                                 sin_cache->Shape().GetDims()[0]));
       const int32_t* seqlens_k_data = seqlens_k->Data<int32_t>();
       for (int b = 0; b < batch_size; b++) {
         // position_id = seqlens_k[b] (in token generation), must be < cache rows

--- a/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
@@ -144,6 +144,19 @@ Status GroupQueryAttention<T>::Compute(OpKernelContext* context) const {
   T* k_rotary = packed_qkv ? nullptr : K.GetMutable<Tensor>()->MutableData<T>();
   if (do_rotary_) {
     ORT_ENFORCE(cos_cache != nullptr && sin_cache != nullptr, "cos_cache and sin_cache must be provided when do_rotary is true");
+    // Validate seqlens_k values against cos_cache size to prevent OOB in rotary embedding lookup.
+    {
+      const int cos_cache_max_seq = static_cast<int>(cos_cache->Shape().GetDims()[0]);
+      const int32_t* seqlens_k_data = seqlens_k->Data<int32_t>();
+      for (int b = 0; b < batch_size; b++) {
+        // position_id = seqlens_k[b] (in token generation), must be < cos_cache rows
+        if (seqlens_k_data[b] >= cos_cache_max_seq) {
+          return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                                 "seqlens_k[", b, "] = ", seqlens_k_data[b],
+                                 " exceeds cos_cache dimension 0 (", cos_cache_max_seq, ")");
+        }
+      }
+    }
     // Initialize rotary parameters
     rotary_embedding_helper::RotaryParameters rotary_params = {};
     rotary_params.batch_size = batch_size;

--- a/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
@@ -144,21 +144,9 @@ Status GroupQueryAttention<T>::Compute(OpKernelContext* context) const {
   T* k_rotary = packed_qkv ? nullptr : K.GetMutable<Tensor>()->MutableData<T>();
   if (do_rotary_) {
     ORT_ENFORCE(cos_cache != nullptr && sin_cache != nullptr, "cos_cache and sin_cache must be provided when do_rotary is true");
-    // Validate seqlens_k values against cos/sin cache size to prevent OOB in rotary embedding lookup.
-    // Use the minimum of cos_cache and sin_cache dim-0 since CheckRotaryCaches does not enforce equality.
-    {
-      const int rotary_cache_max_seq = static_cast<int>(std::min(cos_cache->Shape().GetDims()[0],
-                                                                 sin_cache->Shape().GetDims()[0]));
-      const int32_t* seqlens_k_data = seqlens_k->Data<int32_t>();
-      for (int b = 0; b < batch_size; b++) {
-        // position_id = seqlens_k[b] (in token generation), must be < cache rows
-        if (seqlens_k_data[b] < 0 || seqlens_k_data[b] >= rotary_cache_max_seq) {
-          return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                                 "seqlens_k[", b, "] = ", seqlens_k_data[b],
-                                 " is out of range for rotary cache dimension 0 (", rotary_cache_max_seq, ")");
-        }
-      }
-    }
+    // Validation of seqlens_k against rotary cache size is now performed in CheckInputs()
+    // to ensure all execution providers (CPU, CUDA, etc.) get the protection in one place.
+
     // Initialize rotary parameters
     rotary_embedding_helper::RotaryParameters rotary_params = {};
     rotary_params.batch_size = batch_size;

--- a/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
@@ -144,8 +144,9 @@ Status GroupQueryAttention<T>::Compute(OpKernelContext* context) const {
   T* k_rotary = packed_qkv ? nullptr : K.GetMutable<Tensor>()->MutableData<T>();
   if (do_rotary_) {
     ORT_ENFORCE(cos_cache != nullptr && sin_cache != nullptr, "cos_cache and sin_cache must be provided when do_rotary is true");
-    // Validation of seqlens_k against rotary cache size is now performed in CheckInputs()
-    // to ensure all execution providers (CPU, CUDA, etc.) get the protection in one place.
+    // Validation of seqlens_k against rotary cache size is performed in CheckInputs()
+    // when seqlens_k is on CPU. GPU EPs where seqlens_k resides on device rely on
+    // RunRotaryEmbedding's position_ids validation for OOB protection.
 
     // Initialize rotary parameters
     rotary_embedding_helper::RotaryParameters rotary_params = {};

--- a/onnxruntime/contrib_ops/cpu/bert/group_query_attention_helper.h
+++ b/onnxruntime/contrib_ops/cpu/bert/group_query_attention_helper.h
@@ -289,11 +289,11 @@ Status CheckInputs(const T* query,
     // This prevents OOB access when deriving position IDs from seqlens_k during rotary embedding.
     const bool is_seqlens_k_on_cpu = (seqlens_k->Location().device.Type() == OrtDevice::CPU);
     if (is_seqlens_k_on_cpu) {
-      const int rotary_cache_max_seq = static_cast<int>(std::min(cos_cache->Shape().GetDims()[0],
-                                                                 sin_cache->Shape().GetDims()[0]));
+      const int64_t rotary_cache_max_seq = std::min(cos_cache->Shape().GetDims()[0],
+                                                    sin_cache->Shape().GetDims()[0]);
       const int32_t* seqlens_k_data = seqlens_k->template Data<int32_t>();
       for (int b = 0; b < batch_size; b++) {
-        if (seqlens_k_data[b] < 0 || seqlens_k_data[b] >= rotary_cache_max_seq) {
+        if (seqlens_k_data[b] < 0 || static_cast<int64_t>(seqlens_k_data[b]) >= rotary_cache_max_seq) {
           return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                                  "seqlens_k[", b, "] = ", seqlens_k_data[b],
                                  " is out of range for rotary cache dimension 0 (", rotary_cache_max_seq, ")");

--- a/onnxruntime/contrib_ops/cpu/bert/group_query_attention_helper.h
+++ b/onnxruntime/contrib_ops/cpu/bert/group_query_attention_helper.h
@@ -284,6 +284,22 @@ Status CheckInputs(const T* query,
   int rotary_dim = 0;
   if (cos_cache != nullptr && sin_cache != nullptr) {
     ORT_RETURN_IF_ERROR(CheckRotaryCaches(cos_cache, sin_cache, head_size, total_sequence_length, rotary_dim));
+
+    // Validate seqlens_k against rotary cache size when rotary embeddings are enabled.
+    // This prevents OOB access when deriving position IDs from seqlens_k during rotary embedding.
+    const bool is_seqlens_k_on_cpu = (seqlens_k->Location().device.Type() == OrtDevice::CPU);
+    if (is_seqlens_k_on_cpu) {
+      const int rotary_cache_max_seq = static_cast<int>(std::min(cos_cache->Shape().GetDims()[0],
+                                                                 sin_cache->Shape().GetDims()[0]));
+      const int32_t* seqlens_k_data = seqlens_k->template Data<int32_t>();
+      for (int b = 0; b < batch_size; b++) {
+        if (seqlens_k_data[b] < 0 || seqlens_k_data[b] >= rotary_cache_max_seq) {
+          return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                                 "seqlens_k[", b, "] = ", seqlens_k_data[b],
+                                 " is out of range for rotary cache dimension 0 (", rotary_cache_max_seq, ")");
+        }
+      }
+    }
   } else if (cos_cache != nullptr || sin_cache != nullptr) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                            "Input 'cos_cache' and 'sin_cache' shall be both present or both absent.");

--- a/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
@@ -321,7 +321,7 @@ TEST(GroupQueryAttentionTest, SeqlensKExceedsCosCache_OOB) {
   constexpr int cos_cache_max_seq = 4;  // small rotary cache
   constexpr int past_seq_len = 16;      // large KV cache
   constexpr int seqlens_k_val = 10;     // valid for KV (10 < 16) but OOB for cos (10 >= 4)
-  constexpr int total_seq_len = 11;     // seqlens_k + 1
+  constexpr int total_seq_len = 4;      // passes CheckRotaryCaches (4 <= cos_cache_max_seq)
 
   OpTester tester("GroupQueryAttention", 1, onnxruntime::kMSDomain);
   tester.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(num_heads));
@@ -360,6 +360,60 @@ TEST(GroupQueryAttentionTest, SeqlensKExceedsCosCache_OOB) {
   std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
   execution_providers.push_back(DefaultCpuExecutionProvider());
   tester.Run(OpTester::ExpectResult::kExpectFailure, "exceeds rotary cache dimension 0",
+             {}, nullptr, &execution_providers);
+}
+
+// Positive test: seqlens_k within cos/sin cache bounds with do_rotary enabled should succeed.
+TEST(GroupQueryAttentionTest, SeqlensKWithinCosCache_Rotary) {
+  constexpr int num_heads = 1;
+  constexpr int kv_num_heads = 1;
+  constexpr int head_size = 16;  // must be multiple of 16 for rotary
+  constexpr int hidden_size = num_heads * head_size;
+  constexpr int kv_hidden_size = kv_num_heads * head_size;
+  constexpr int rotary_half_dim = head_size / 2;
+
+  constexpr int cos_cache_max_seq = 16;  // rotary cache large enough
+  constexpr int past_seq_len = 16;
+  constexpr int seqlens_k_val = 3;       // valid: 3 < 16 (cos cache) and 3 < 16 (KV cache)
+  constexpr int total_seq_len = 4;       // seqlens_k + 1
+
+  OpTester tester("GroupQueryAttention", 1, onnxruntime::kMSDomain);
+  tester.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(num_heads));
+  tester.AddAttribute<int64_t>("kv_num_heads", static_cast<int64_t>(kv_num_heads));
+  tester.AddAttribute<int64_t>("do_rotary", static_cast<int64_t>(1));
+
+  tester.AddInput<float>("query", {1, 1, hidden_size}, std::vector<float>(hidden_size, 1.0f));
+  tester.AddInput<float>("key", {1, 1, kv_hidden_size}, std::vector<float>(kv_hidden_size, 1.0f));
+  tester.AddInput<float>("value", {1, 1, kv_hidden_size}, std::vector<float>(kv_hidden_size, 1.0f));
+
+  tester.AddInput<float>("past_key", {1, kv_num_heads, past_seq_len, head_size},
+                         std::vector<float>(kv_num_heads * past_seq_len * head_size, 0.5f));
+  tester.AddInput<float>("past_value", {1, kv_num_heads, past_seq_len, head_size},
+                         std::vector<float>(kv_num_heads * past_seq_len * head_size, 0.5f));
+
+  tester.AddInput<int32_t>("seqlens_k", {1}, {seqlens_k_val});
+  tester.AddInput<int32_t>("total_sequence_length", {1}, {total_seq_len});
+
+  tester.AddInput<float>("cos_cache", {cos_cache_max_seq, rotary_half_dim},
+                         std::vector<float>(cos_cache_max_seq * rotary_half_dim, 1.0f));
+  tester.AddInput<float>("sin_cache", {cos_cache_max_seq, rotary_half_dim},
+                         std::vector<float>(cos_cache_max_seq * rotary_half_dim, 0.0f));
+
+  tester.AddOptionalInputEdge<int64_t>();  // position_ids
+  tester.AddOptionalInputEdge<float>();    // attention_bias
+  tester.AddOptionalInputEdge<float>();    // head_sink
+
+  tester.AddOutput<float>("output", {1, 1, hidden_size}, std::vector<float>(hidden_size, 0.0f));
+  tester.AddOutput<float>("present_key", {1, kv_num_heads, past_seq_len, head_size},
+                          std::vector<float>(kv_num_heads * past_seq_len * head_size, 0.0f));
+  tester.AddOutput<float>("present_value", {1, kv_num_heads, past_seq_len, head_size},
+                          std::vector<float>(kv_num_heads * past_seq_len * head_size, 0.0f));
+
+  tester.SetOutputTolerance(1e6f);  // shape acceptance test, not numerical correctness
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
+  tester.Run(OpTester::ExpectResult::kExpectSuccess, "",
              {}, nullptr, &execution_providers);
 }
 

--- a/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
@@ -359,7 +359,7 @@ TEST(GroupQueryAttentionTest, SeqlensKExceedsCosCache_OOB) {
 
   std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
   execution_providers.push_back(DefaultCpuExecutionProvider());
-  tester.Run(OpTester::ExpectResult::kExpectFailure, "exceeds rotary cache dimension 0",
+  tester.Run(OpTester::ExpectResult::kExpectFailure, "is out of range for rotary cache dimension 0",
              {}, nullptr, &execution_providers);
 }
 
@@ -414,6 +414,65 @@ TEST(GroupQueryAttentionTest, SeqlensKWithinCosCache_Rotary) {
   std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
   execution_providers.push_back(DefaultCpuExecutionProvider());
   tester.Run(OpTester::ExpectResult::kExpectSuccess, "",
+             {}, nullptr, &execution_providers);
+}
+
+// Multi-batch test: one valid and one OOB seqlens_k value.
+// Verifies the validation loop correctly identifies the offending batch index.
+TEST(GroupQueryAttentionTest, SeqlensKExceedsCosCache_MultiBatch) {
+  constexpr int num_heads = 1;
+  constexpr int kv_num_heads = 1;
+  constexpr int head_size = 16;
+  constexpr int hidden_size = num_heads * head_size;
+  constexpr int kv_hidden_size = kv_num_heads * head_size;
+  constexpr int rotary_half_dim = head_size / 2;
+
+  constexpr int cos_cache_max_seq = 4;
+  constexpr int past_seq_len = 16;
+  constexpr int total_seq_len = 4;
+  constexpr int batch_size = 2;
+
+  OpTester tester("GroupQueryAttention", 1, onnxruntime::kMSDomain);
+  tester.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(num_heads));
+  tester.AddAttribute<int64_t>("kv_num_heads", static_cast<int64_t>(kv_num_heads));
+  tester.AddAttribute<int64_t>("do_rotary", static_cast<int64_t>(1));
+
+  tester.AddInput<float>("query", {batch_size, 1, hidden_size},
+                         std::vector<float>(batch_size * hidden_size, 1.0f));
+  tester.AddInput<float>("key", {batch_size, 1, kv_hidden_size},
+                         std::vector<float>(batch_size * kv_hidden_size, 1.0f));
+  tester.AddInput<float>("value", {batch_size, 1, kv_hidden_size},
+                         std::vector<float>(batch_size * kv_hidden_size, 1.0f));
+
+  tester.AddInput<float>("past_key", {batch_size, kv_num_heads, past_seq_len, head_size},
+                         std::vector<float>(batch_size * kv_num_heads * past_seq_len * head_size, 0.5f));
+  tester.AddInput<float>("past_value", {batch_size, kv_num_heads, past_seq_len, head_size},
+                         std::vector<float>(batch_size * kv_num_heads * past_seq_len * head_size, 0.5f));
+
+  // seqlens_k: batch 0 is valid (3 < 4), batch 1 is OOB (10 >= 4)
+  tester.AddInput<int32_t>("seqlens_k", {batch_size}, {3, 10});
+  tester.AddInput<int32_t>("total_sequence_length", {1}, {total_seq_len});
+
+  tester.AddInput<float>("cos_cache", {cos_cache_max_seq, rotary_half_dim},
+                         std::vector<float>(cos_cache_max_seq * rotary_half_dim, 1.0f));
+  tester.AddInput<float>("sin_cache", {cos_cache_max_seq, rotary_half_dim},
+                         std::vector<float>(cos_cache_max_seq * rotary_half_dim, 0.0f));
+
+  tester.AddOptionalInputEdge<int64_t>();  // position_ids
+  tester.AddOptionalInputEdge<float>();    // attention_bias
+  tester.AddOptionalInputEdge<float>();    // head_sink
+
+  tester.AddOutput<float>("output", {batch_size, 1, hidden_size},
+                          std::vector<float>(batch_size * hidden_size, 0.0f));
+  tester.AddOutput<float>("present_key", {batch_size, kv_num_heads, past_seq_len, head_size},
+                          std::vector<float>(batch_size * kv_num_heads * past_seq_len * head_size, 0.0f));
+  tester.AddOutput<float>("present_value", {batch_size, kv_num_heads, past_seq_len, head_size},
+                          std::vector<float>(batch_size * kv_num_heads * past_seq_len * head_size, 0.0f));
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
+  // Error should reference batch index 1: seqlens_k[1] = 10
+  tester.Run(OpTester::ExpectResult::kExpectFailure, "seqlens_k[1] = 10",
              {}, nullptr, &execution_providers);
 }
 

--- a/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
@@ -313,10 +313,10 @@ TEST(GroupQueryAttentionTest, SeqlensKWrongLength) {
 TEST(GroupQueryAttentionTest, SeqlensKExceedsCosCache_OOB) {
   constexpr int num_heads = 1;
   constexpr int kv_num_heads = 1;
-  constexpr int head_size = 8;
+  constexpr int head_size = 16;  // must be multiple of 16 for rotary
   constexpr int hidden_size = num_heads * head_size;
   constexpr int kv_hidden_size = kv_num_heads * head_size;
-  constexpr int rotary_half_dim = head_size / 2;  // cos/sin cache dim-1
+  constexpr int rotary_half_dim = head_size / 2;  // cos/sin cache dim-1 = 8
 
   constexpr int cos_cache_max_seq = 4;   // small rotary cache
   constexpr int past_seq_len = 16;       // large KV cache

--- a/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
@@ -318,10 +318,10 @@ TEST(GroupQueryAttentionTest, SeqlensKExceedsCosCache_OOB) {
   constexpr int kv_hidden_size = kv_num_heads * head_size;
   constexpr int rotary_half_dim = head_size / 2;  // cos/sin cache dim-1 = 8
 
-  constexpr int cos_cache_max_seq = 4;   // small rotary cache
-  constexpr int past_seq_len = 16;       // large KV cache
-  constexpr int seqlens_k_val = 10;      // valid for KV (10 < 16) but OOB for cos (10 >= 4)
-  constexpr int total_seq_len = 11;      // seqlens_k + 1
+  constexpr int cos_cache_max_seq = 4;  // small rotary cache
+  constexpr int past_seq_len = 16;      // large KV cache
+  constexpr int seqlens_k_val = 10;     // valid for KV (10 < 16) but OOB for cos (10 >= 4)
+  constexpr int total_seq_len = 11;     // seqlens_k + 1
 
   OpTester tester("GroupQueryAttention", 1, onnxruntime::kMSDomain);
   tester.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(num_heads));

--- a/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
@@ -307,5 +307,61 @@ TEST(GroupQueryAttentionTest, SeqlensKWrongLength) {
              {}, nullptr, &execution_providers);
 }
 
+// Regression: seqlens_k valid for KV cache but exceeding cos_cache.shape[0] must be rejected
+// when do_rotary is enabled. Without this check, the position ID derived from seqlens_k
+// would index out of bounds in the cos/sin cache, leaking heap memory into output.
+TEST(GroupQueryAttentionTest, SeqlensKExceedsCosCache_OOB) {
+  constexpr int num_heads = 1;
+  constexpr int kv_num_heads = 1;
+  constexpr int head_size = 8;
+  constexpr int hidden_size = num_heads * head_size;
+  constexpr int kv_hidden_size = kv_num_heads * head_size;
+  constexpr int rotary_half_dim = head_size / 2;  // cos/sin cache dim-1
+
+  constexpr int cos_cache_max_seq = 4;   // small rotary cache
+  constexpr int past_seq_len = 16;       // large KV cache
+  constexpr int seqlens_k_val = 10;      // valid for KV (10 < 16) but OOB for cos (10 >= 4)
+  constexpr int total_seq_len = 11;      // seqlens_k + 1
+
+  OpTester tester("GroupQueryAttention", 1, onnxruntime::kMSDomain);
+  tester.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(num_heads));
+  tester.AddAttribute<int64_t>("kv_num_heads", static_cast<int64_t>(kv_num_heads));
+  tester.AddAttribute<int64_t>("do_rotary", static_cast<int64_t>(1));
+
+  tester.AddInput<float>("query", {1, 1, hidden_size}, std::vector<float>(hidden_size, 1.0f));
+  tester.AddInput<float>("key", {1, 1, kv_hidden_size}, std::vector<float>(kv_hidden_size, 1.0f));
+  tester.AddInput<float>("value", {1, 1, kv_hidden_size}, std::vector<float>(kv_hidden_size, 1.0f));
+
+  // Past KV cache is large enough for seqlens_k=10
+  tester.AddInput<float>("past_key", {1, kv_num_heads, past_seq_len, head_size},
+                         std::vector<float>(kv_num_heads * past_seq_len * head_size, 0.5f));
+  tester.AddInput<float>("past_value", {1, kv_num_heads, past_seq_len, head_size},
+                         std::vector<float>(kv_num_heads * past_seq_len * head_size, 0.5f));
+
+  tester.AddInput<int32_t>("seqlens_k", {1}, {seqlens_k_val});
+  tester.AddInput<int32_t>("total_sequence_length", {1}, {total_seq_len});
+
+  // cos/sin cache with only 4 rows — seqlens_k=10 exceeds this
+  tester.AddInput<float>("cos_cache", {cos_cache_max_seq, rotary_half_dim},
+                         std::vector<float>(cos_cache_max_seq * rotary_half_dim, 1.0f));
+  tester.AddInput<float>("sin_cache", {cos_cache_max_seq, rotary_half_dim},
+                         std::vector<float>(cos_cache_max_seq * rotary_half_dim, 0.0f));
+
+  tester.AddOptionalInputEdge<int64_t>();  // position_ids
+  tester.AddOptionalInputEdge<float>();    // attention_bias
+  tester.AddOptionalInputEdge<float>();    // head_sink
+
+  tester.AddOutput<float>("output", {1, 1, hidden_size}, std::vector<float>(hidden_size, 0.0f));
+  tester.AddOutput<float>("present_key", {1, kv_num_heads, past_seq_len, head_size},
+                          std::vector<float>(kv_num_heads * past_seq_len * head_size, 0.0f));
+  tester.AddOutput<float>("present_value", {1, kv_num_heads, past_seq_len, head_size},
+                          std::vector<float>(kv_num_heads * past_seq_len * head_size, 0.0f));
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
+  tester.Run(OpTester::ExpectResult::kExpectFailure, "exceeds rotary cache dimension 0",
+             {}, nullptr, &execution_providers);
+}
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
@@ -374,8 +374,8 @@ TEST(GroupQueryAttentionTest, SeqlensKWithinCosCache_Rotary) {
 
   constexpr int cos_cache_max_seq = 16;  // rotary cache large enough
   constexpr int past_seq_len = 16;
-  constexpr int seqlens_k_val = 3;       // valid: 3 < 16 (cos cache) and 3 < 16 (KV cache)
-  constexpr int total_seq_len = 4;       // seqlens_k + 1
+  constexpr int seqlens_k_val = 3;  // valid: 3 < 16 (cos cache) and 3 < 16 (KV cache)
+  constexpr int total_seq_len = 4;  // seqlens_k + 1
 
   OpTester tester("GroupQueryAttention", 1, onnxruntime::kMSDomain);
   tester.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(num_heads));


### PR DESCRIPTION
### Description

Validate `seqlens_k` values against `cos_cache.shape[0]` in `GroupQueryAttention::Compute()` when `do_rotary` is enabled, to prevent out-of-bounds reads in the rotary embedding lookup.

### Root Cause

`CheckRotaryCaches()` validates `cos_cache.shape[0] >= total_sequence_length`, but runtime position IDs are derived from `seqlens_k` (a separate, per-batch input). An attacker can set `total_sequence_length` small enough to pass the guard while setting `seqlens_k[b]` far beyond `cos_cache.shape[0]`, causing `position_id = seqlens_k[b]` to index out of bounds into the cos/sin cache. The resulting heap bytes are used as rotation values and propagate into the inference output.

### Fix

Add an explicit bounds check in `Compute()` that rejects any `seqlens_k[b] >= cos_cache.shape[0]` before position IDs are computed. This is defense-in-depth alongside the existing `RunRotaryEmbedding` position_ids validation added in #27597.

### Security

- **Impact:** Heap OOB read (CWE-125) — adjacent heap memory leaks into inference output via cos/sin rotation values.
- **Attack vector:** Any GQA-based LLM serving endpoint (Llama, Phi, Mistral) that accepts `seqlens_k` as an inference input. No model modification required.

### Testing

Verified that crafted inputs with `seqlens_k` exceeding `cos_cache` dimensions now return `INVALID_ARGUMENT` instead of silently producing results containing leaked heap data.