### PR TITLE
Validate conv bias shape in WordConvEmbedding to prevent OOB read

### DIFF
--- a/onnxruntime/contrib_ops/cpu/word_conv_embedding.cc
+++ b/onnxruntime/contrib_ops/cpu/word_conv_embedding.cc
@@ -202,6 +202,11 @@ Status WordConvEmbedding::Compute(OpKernelContext* ctx) const {
 
   ORT_RETURN_IF_ERROR(ValidateInputShape(sequence_shape, w_conv_shape, w_char_embedding_shape));
 
+  const TensorShape& b_conv_shape = b_conv.Shape();
+  ORT_RETURN_IF_NOT(b_conv_shape.NumDimensions() == 1 && b_conv_shape[0] == w_conv_shape[0],
+                    "WordConvEmbedding: conv bias B must be a 1-D tensor of length ",
+                    w_conv_shape[0], ", but got shape ", b_conv_shape);
+
   int64_t seq_len = sequence_shape[0];
   int64_t word_len = sequence_shape[1];
   int64_t char_embedding_size = w_char_embedding_shape[1];

--- a/onnxruntime/test/contrib_ops/word_conv_embedding_test.cc
+++ b/onnxruntime/test/contrib_ops/word_conv_embedding_test.cc
@@ -167,5 +167,31 @@ TEST(ContribOpTest, WordConvEmbedding_rejects_sequence_rank_one) {
   test.Run(OpTester::ExpectResult::kExpectFailure, "Sequence input must have rank greater than 1");
 }
 
+TEST(ContribOpTest, WordConvEmbedding_rejects_undersized_bias) {
+  OpTester test("WordConvEmbedding", 1, onnxruntime::kMSDomain);
+
+  // W has 2 filters but B has only 1 element
+  test.AddInput<int>("Sequence", {1, 2}, {1, 2});
+  test.AddInput<float>("W", {2, 1, 2, 1}, {1.0f, 1.0f, 1.0f, 1.0f});
+  test.AddInput<float>("B", {1}, {0.0f});
+  test.AddInput<float>("C", {3, 1}, {0.0f, 1.0f, 2.0f});
+  test.AddOutput<float>("Y", {1, 2}, {0.0f, 0.0f});
+
+  test.Run(OpTester::ExpectResult::kExpectFailure, "conv bias B must be a 1-D tensor of length 2");
+}
+
+TEST(ContribOpTest, WordConvEmbedding_rejects_2d_bias) {
+  OpTester test("WordConvEmbedding", 1, onnxruntime::kMSDomain);
+
+  // B has correct element count but wrong rank
+  test.AddInput<int>("Sequence", {1, 2}, {1, 2});
+  test.AddInput<float>("W", {2, 1, 2, 1}, {1.0f, 1.0f, 1.0f, 1.0f});
+  test.AddInput<float>("B", {1, 2}, {0.0f, 0.0f});
+  test.AddInput<float>("C", {3, 1}, {0.0f, 1.0f, 2.0f});
+  test.AddOutput<float>("Y", {1, 2}, {0.0f, 0.0f});
+
+  test.Run(OpTester::ExpectResult::kExpectFailure, "conv bias B must be a 1-D tensor of length 2");
+}
+
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
### Description

Add shape validation for the conv bias input (`B`) in `WordConvEmbedding::Compute()` to prevent out-of-bounds heap reads when a crafted model provides a bias tensor shorter than `num_filters`.

### Root Cause

`WordConvEmbedding::Compute` passes `b_conv.Data<float>()` directly to `ComputeConvMaxPoolWithActivation`, which iterates over `num_filters` (= `w_conv.shape[0]`) elements of the bias buffer. `ValidateInputShape` only checks the sequence, conv weight, and char embedding shapes — the bias shape is never validated. A model with `b_conv.shape[0] < w_conv.shape[0]` causes the inner loop to read past the bias buffer, and the leaked heap bytes propagate through tanh activation and max-pooling into the output tensor.

### Fix

Add an inline check after `ValidateInputShape` that rejects bias tensors whose shape is not `[num_filters]`:

```cpp
ORT_RETURN_IF_NOT(b_conv_shape.NumDimensions() == 1 && b_conv_shape[0] == w_conv_shape[0],
                  "WordConvEmbedding: conv bias B must be a 1-D tensor of length ",
                  w_conv_shape[0], ", but got shape ", b_conv_shape);