### PR TITLE
Add example and documentation for kOrtEpDevice_EpMetadataKey_OSDriverVersion

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_ep_device_ep_metadata_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_ep_device_ep_metadata_keys.h
@@ -10,6 +10,10 @@
 static const char* const kOrtEpDevice_EpMetadataKey_Version = "version";
 
 // Key for the execution provider OS driver version.
+// Value should be a 4-part dot-separated version string in the format "a.b.c.d" (e.g., "31.0.101.4502").
+// This maps to the Windows DXCore DriverVersion adapter property
+// (https://learn.microsoft.com/en-us/windows/win32/api/dxcore_interface/ne-dxcore_interface-dxcoreadapterproperty).
+// On non-Windows platforms, the EP should provide an equivalent OS-level driver version if available.
 static const char* const kOrtEpDevice_EpMetadataKey_OSDriverVersion = "os_driver_version";
 
 // Prefix for execution provider compatibility information stored in model metadata.

--- a/include/onnxruntime/core/session/onnxruntime_ep_device_ep_metadata_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_ep_device_ep_metadata_keys.h
@@ -11,7 +11,7 @@ static const char* const kOrtEpDevice_EpMetadataKey_Version = "version";
 
 // Key for the execution provider OS driver version.
 // Value should be a 4-part dot-separated version string in the format "a.b.c.d" (e.g., "31.0.101.4502").
-// This maps to the Windows DXCore DriverVersion adapter property
+// This maps to the Windows DXCore adapter property DXCoreAdapterProperty::DriverVersion
 // (https://learn.microsoft.com/en-us/windows/win32/api/dxcore_interface/ne-dxcore_interface-dxcoreadapterproperty).
 // On non-Windows platforms, the EP should provide an equivalent OS-level driver version if available.
 static const char* const kOrtEpDevice_EpMetadataKey_OSDriverVersion = "os_driver_version";

--- a/onnxruntime/test/autoep/library/example_plugin_ep/ep_factory.cc
+++ b/onnxruntime/test/autoep/library/example_plugin_ep/ep_factory.cc
@@ -11,6 +11,7 @@
 #include "ep_data_transfer.h"
 #include "ep_stream_support.h"
 
+#include "core/session/onnxruntime_ep_device_ep_metadata_keys.h"
 #include "core/session/onnxruntime_session_options_config_keys.h"
 
 ExampleEpFactory::ExampleEpFactory(const char* ep_name, ApiPtrs apis, const OrtLogger& default_logger)
@@ -141,6 +142,9 @@ OrtStatus* ORT_API_CALL ExampleEpFactory::GetSupportedDevicesImpl(OrtEpFactory* 
 
       // random example using made up values
       factory->ort_api.AddKeyValuePair(ep_metadata, "supported_devices", "CrackGriffin 7+");
+      // Example os_driver_version. A real EP would read the OS driver version from the device.
+      // The format is a 4-part dot-separated version matching the DXCore DriverVersion property.
+      factory->ort_api.AddKeyValuePair(ep_metadata, kOrtEpDevice_EpMetadataKey_OSDriverVersion, "31.0.101.1000");
       factory->ort_api.AddKeyValuePair(ep_options, "run_really_fast", "true");
 
       // OrtEpDevice copies ep_metadata and ep_options.
@@ -171,6 +175,7 @@ OrtStatus* ORT_API_CALL ExampleEpFactory::GetSupportedDevicesImpl(OrtEpFactory* 
     //    Ort::KeyValuePairs ep_metadata;
     //    Ort::KeyValuePairs ep_options;
     //    ep_metadata.Add("supported_devices", "CrackGriffin 7+");
+    //    ep_metadata.Add(kOrtEpDevice_EpMetadataKey_OSDriverVersion, "31.0.101.1000");
     //    ep_options.Add("run_really_fast", "true");
     //    Ort::EpDevice ep_device{*this_ptr, device, ep_metadata.GetConst(), ep_options.GetConst()};
     //    ep_devices[num_ep_devices++] = ep_device.release();

--- a/onnxruntime/test/autoep/test_registration.cc
+++ b/onnxruntime/test/autoep/test_registration.cc
@@ -70,6 +70,8 @@ TEST(OrtEpLibrary, LoadUnloadPluginLibraryCxxApi) {
   auto metadata = test_ep_device->EpMetadata();
   ASSERT_STREQ(metadata.GetValue(kOrtEpDevice_EpMetadataKey_Version), "0.1.0");
   ASSERT_STREQ(metadata.GetValue("supported_devices"), "CrackGriffin 7+");
+  // Verify the os_driver_version is a 4-part dot-separated version string
+  ASSERT_STREQ(metadata.GetValue(kOrtEpDevice_EpMetadataKey_OSDriverVersion), "31.0.101.1000");
 
   auto options = test_ep_device->EpOptions();
   ASSERT_STREQ(options.GetValue("run_really_fast"), "true");

--- a/onnxruntime/test/autoep/test_registration.cc
+++ b/onnxruntime/test/autoep/test_registration.cc
@@ -70,7 +70,7 @@ TEST(OrtEpLibrary, LoadUnloadPluginLibraryCxxApi) {
   auto metadata = test_ep_device->EpMetadata();
   ASSERT_STREQ(metadata.GetValue(kOrtEpDevice_EpMetadataKey_Version), "0.1.0");
   ASSERT_STREQ(metadata.GetValue("supported_devices"), "CrackGriffin 7+");
-  // Verify the os_driver_version is a 4-part dot-separated version string
+  // Verify the example plugin's expected os_driver_version value.
   ASSERT_STREQ(metadata.GetValue(kOrtEpDevice_EpMetadataKey_OSDriverVersion), "31.0.101.1000");
 
   auto options = test_ep_device->EpOptions();


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
This change provides details on the expected value for `kOrtEpDevice_EpMetadataKey_OSDriverVersion` and provides an example in the plugin EP tests. 

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
We introduced a new EP metadata key called `kOrtEpDevice_EpMetadataKey_OSDriverVersion` in #26616 but neglected to provide sufficient detail to guide EP authors in how to fill in the value for this key. This PR is an attempt to address that gap.

