### PR TITLE
webgpu: extend gemm-subgroup to Conv operator

### DIFF
--- a/onnxruntime/core/providers/webgpu/math/matmul.cc
+++ b/onnxruntime/core/providers/webgpu/math/matmul.cc
@@ -167,7 +167,7 @@ Status MatMul::ComputeInternal(ComputeContext& context) const {
     inputs[2] = bias;
   }
 
-  if (intel::CanApplyMatMulIntel(context, helper.M(), helper.N(), helper.K())) {
+  if (intel::CanApplyMatMulIntel(context, helper.OutputOffsets().size(), helper.M(), helper.N(), helper.K())) {
     return intel::ApplyMatMulIntel(context, Activation(), inputs, output_tensor);
   }
 

--- a/onnxruntime/core/providers/webgpu/nn/conv.cc
+++ b/onnxruntime/core/providers/webgpu/nn/conv.cc
@@ -10,6 +10,7 @@
 #include "core/providers/webgpu/nn/grouped_conv.h"
 #include "core/providers/webgpu/webgpu_utils.h"
 #include "core/providers/webgpu/math/matmul.h"
+#include "core/providers/webgpu/vendor/intel/math/matmul.h"
 
 namespace onnxruntime {
 namespace webgpu {
@@ -270,6 +271,12 @@ Status Conv<is_channels_last, is_fused>::ComputeInternal(ComputeContext& context
           .AddUniformVariables({{output_size}, {static_cast<uint32_t>(matmul_output_shape[1])}, {static_cast<uint32_t>(matmul_output_shape[2])}, {static_cast<uint32_t>(K)}});
       return context.RunProgram(program);
     } else {
+      if (is_channels_last) {
+        auto M = matmul_output_shape.SizeToDimension(matmul_output_shape.NumDimensions() - 1);
+        if (intel::CanApplyMatMulIntel(context, M, N, K)) {
+          return intel::ApplyMatMulIntel(context, activation_, inputs, output, matmul_input_reshapes[0], matmul_input_reshapes[1]);
+        }
+      }
       return ComputeMatMul(&context, activation_, matmul_inputs, output, is_channels_last, matmul_input_reshapes[0], matmul_input_reshapes[1]);
     }
   }

--- a/onnxruntime/core/providers/webgpu/nn/conv.cc
+++ b/onnxruntime/core/providers/webgpu/nn/conv.cc
@@ -272,8 +272,8 @@ Status Conv<is_channels_last, is_fused>::ComputeInternal(ComputeContext& context
       return context.RunProgram(program);
     } else {
       if (is_channels_last) {
-        auto M = matmul_output_shape.SizeToDimension(matmul_output_shape.NumDimensions() - 1);
-        if (intel::CanApplyMatMulIntel(context, M, N, K)) {
+        auto M = matmul_output_shape[1];
+        if (intel::CanApplyMatMulIntel(context, batch, M, N, K)) {
           return intel::ApplyMatMulIntel(context, activation_, inputs, output, matmul_input_reshapes[0], matmul_input_reshapes[1]);
         }
       }

--- a/onnxruntime/core/providers/webgpu/vendor/intel/math/gemm.cc
+++ b/onnxruntime/core/providers/webgpu/vendor/intel/math/gemm.cc
@@ -35,7 +35,7 @@ Status GemmSubgroupProgram::GenerateShaderCode(ShaderHelper& shader) const {
 }
 
 bool CanApplyGemmIntel(const ComputeContext& context, int64_t M, int64_t N, int64_t K, bool transA, bool transB) {
-  return CanApplySubgroup(context, M, N, K, transA, transB);
+  return CanApplySubgroup(context, 1, M, N, K, transA, transB);
 }
 
 Status ApplyGemmIntel(const Tensor* a,

--- a/onnxruntime/core/providers/webgpu/vendor/intel/math/gemm_subgroup.cc
+++ b/onnxruntime/core/providers/webgpu/vendor/intel/math/gemm_subgroup.cc
@@ -85,10 +85,11 @@ std::string CalculateAccStr(const ShaderIndicesHelper* batch_dims, int64_t eleme
 }  // namespace
 
 bool CanApplySubgroup(const ComputeContext& context, int64_t M, int64_t N, int64_t K, bool transA, bool transB) {
-  if (context.AdapterInfo().vendor == std::string_view{"intel"}) {
-    bool use_subgroup = context.HasFeature(wgpu::FeatureName::Subgroups) &&
-                        M >= 64 && N >= 512 && K >= 32 && !transA && !transB;
-    return use_subgroup;
+  if (!transA && !transB && context.AdapterInfo().vendor == std::string_view{"intel"} &&
+      context.HasFeature(wgpu::FeatureName::Subgroups)) {
+    // Ensure enough parallelism for good performance. The thresholds (24) are based on testing and may need to
+    // be adjusted in the future when more performance data is collected.
+    return M >= 64 && N > 64 && K >= 32 && (((M + 63) / 64) * ((N + 127) / 128)) >= 24;
   }
 
   return false;

--- a/onnxruntime/core/providers/webgpu/vendor/intel/math/gemm_subgroup.cc
+++ b/onnxruntime/core/providers/webgpu/vendor/intel/math/gemm_subgroup.cc
@@ -84,12 +84,12 @@ std::string CalculateAccStr(const ShaderIndicesHelper* batch_dims, int64_t eleme
 
 }  // namespace
 
-bool CanApplySubgroup(const ComputeContext& context, int64_t M, int64_t N, int64_t K, bool transA, bool transB) {
+bool CanApplySubgroup(const ComputeContext& context, int64_t batch, int64_t M, int64_t N, int64_t K, bool transA, bool transB) {
   if (!transA && !transB && context.AdapterInfo().vendor == std::string_view{"intel"} &&
       context.HasFeature(wgpu::FeatureName::Subgroups)) {
     // Ensure enough parallelism for good performance. The thresholds (24) are based on testing and may need to
     // be adjusted in the future when more performance data is collected.
-    return M >= 64 && N > 64 && K >= 32 && (((M + 63) / 64) * ((N + 127) / 128)) >= 24;
+    return M > 32 && N > 64 && K >= 32 && (batch * ((M + 63) / 64) * ((N + 127) / 128)) >= 24;
   }
 
   return false;

--- a/onnxruntime/core/providers/webgpu/vendor/intel/math/gemm_subgroup.h
+++ b/onnxruntime/core/providers/webgpu/vendor/intel/math/gemm_subgroup.h
@@ -13,7 +13,7 @@ const uint32_t kSubgroupLogicalWorkGroupSizeX = 32;
 const uint32_t kSubgroupLogicalWorkGroupSizeY = 8;
 const uint32_t kSubgroupLogicalWorkGroupSizeZ = 1;
 
-bool CanApplySubgroup(const ComputeContext& context, int64_t M, int64_t N, int64_t K, bool transA = false, bool transB = false);
+bool CanApplySubgroup(const ComputeContext& context, int64_t batch, int64_t M, int64_t N, int64_t K, bool transA = false, bool transB = false);
 
 int64_t ElementsPerThreadY(bool is_vec4, uint32_t M);
 

--- a/onnxruntime/core/providers/webgpu/vendor/intel/math/matmul.cc
+++ b/onnxruntime/core/providers/webgpu/vendor/intel/math/matmul.cc
@@ -28,7 +28,7 @@ Status MatMulSubgroupProgram::GenerateShaderCode(ShaderHelper& shader) const {
   std::string apply_activation = GetActivationSnippet(activation_, "output_value_t", "output_element_t");
   // declare the read and write functions
   MatMulReadFnSource(shader, a, b, &batch_dims, /*transA = */ false, /*transB = */ false);
-  MatMulWriteFnSourceForMatMul(shader, output, bias, apply_activation, /*is_channels_last = */ false);
+  MatMulWriteFnSourceForMatMul(shader, output, bias, apply_activation, /*is_channels_last = */ true);
   // generate the main function
   ORT_RETURN_IF_ERROR(MakeMatMulSubgroupSource(shader, elements_per_thread_, &batch_dims, is_vec4_));
   return Status::OK();
@@ -41,12 +41,14 @@ bool CanApplyMatMulIntel(const ComputeContext& context, int64_t M, int64_t N, in
 Status ApplyMatMulIntel(ComputeContext& context,
                         const Activation& activation,
                         std::vector<const Tensor*>& inputs,
-                        Tensor* output) {
+                        Tensor* output,
+                        const TensorShape& input_a_reshape,
+                        const TensorShape& input_b_reshape) {
   const auto* a = inputs[0];
   const auto* b = inputs[1];
   bool has_bias = inputs.size() > 2;
-  TensorShape a_shape = a->Shape();
-  TensorShape b_shape = b->Shape();
+  TensorShape a_shape = input_a_reshape.NumDimensions() > 0 ? input_a_reshape : a->Shape();
+  TensorShape b_shape = input_b_reshape.NumDimensions() > 0 ? input_b_reshape : b->Shape();
 
   MatMulComputeHelper helper;
   ORT_THROW_IF_ERROR(helper.Compute(a_shape, b_shape));
@@ -120,7 +122,7 @@ Status ApplyMatMulIntel(ComputeContext& context,
       .SetWorkgroupSize(kSubgroupLogicalWorkGroupSizeX * kSubgroupLogicalWorkGroupSizeY, 1, 1);
 
   if (has_bias) {
-    auto bias_components = 1;
+    auto bias_components = components;
     const auto* bias = inputs[2];
     TensorShape reduced_bias_shape = ReduceShapeByComponents(bias->Shape(), bias_components);
     program.AddInput({bias, ProgramTensorMetadataDependency::Rank, reduced_bias_shape, bias_components});

--- a/onnxruntime/core/providers/webgpu/vendor/intel/math/matmul.cc
+++ b/onnxruntime/core/providers/webgpu/vendor/intel/math/matmul.cc
@@ -34,8 +34,8 @@ Status MatMulSubgroupProgram::GenerateShaderCode(ShaderHelper& shader) const {
   return Status::OK();
 }
 
-bool CanApplyMatMulIntel(const ComputeContext& context, int64_t M, int64_t N, int64_t K) {
-  return CanApplySubgroup(context, M, N, K);
+bool CanApplyMatMulIntel(const ComputeContext& context, int64_t batch, int64_t M, int64_t N, int64_t K) {
+  return CanApplySubgroup(context, batch, M, N, K);
 }
 
 Status ApplyMatMulIntel(ComputeContext& context,

--- a/onnxruntime/core/providers/webgpu/vendor/intel/math/matmul.h
+++ b/onnxruntime/core/providers/webgpu/vendor/intel/math/matmul.h
@@ -41,7 +41,9 @@ bool CanApplyMatMulIntel(const ComputeContext& context, int64_t M, int64_t N, in
 Status ApplyMatMulIntel(ComputeContext& context,
                         const Activation& activation,
                         std::vector<const Tensor*>& inputs,
-                        Tensor* output);
+                        Tensor* output,
+                        const TensorShape& input_a_reshape = TensorShape(),
+                        const TensorShape& input_b_reshape = TensorShape());
 
 }  // namespace intel
 }  // namespace webgpu

--- a/onnxruntime/core/providers/webgpu/vendor/intel/math/matmul.h
+++ b/onnxruntime/core/providers/webgpu/vendor/intel/math/matmul.h
@@ -36,7 +36,7 @@ class MatMulSubgroupProgram final : public Program<MatMulSubgroupProgram> {
   const InlinedVector<int64_t> elements_per_thread_;
 };
 
-bool CanApplyMatMulIntel(const ComputeContext& context, int64_t M, int64_t N, int64_t K);
+bool CanApplyMatMulIntel(const ComputeContext& context, int64_t batch, int64_t M, int64_t N, int64_t K);
 
 Status ApplyMatMulIntel(ComputeContext& context,
                         const Activation& activation,

--- a/onnxruntime/test/providers/webgpu/conv_large_test.cc
+++ b/onnxruntime/test/providers/webgpu/conv_large_test.cc
@@ -1,0 +1,143 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gtest/gtest.h"
+
+#include "test/providers/provider_test_utils.h"
+#include "test/common/tensor_op_test_utils.h"
+#include "default_providers.h"
+
+namespace onnxruntime {
+namespace test {
+
+// Compute Conv2D output height/width given input, kernel, pad, stride, dilation.
+static int64_t ConvOutputSize(int64_t input_size, int64_t kernel_size, int64_t pad_begin, int64_t pad_end,
+                              int64_t stride, int64_t dilation) {
+  int64_t effective_kernel = (kernel_size - 1) * dilation + 1;
+  return (input_size + pad_begin + pad_end - effective_kernel) / stride + 1;
+}
+
+// Reference implementation for Conv2D (NCHW layout) with group, stride, pad, dilation, and optional bias.
+static void ComputeExpectedConv2D(const std::vector<float>& x_vals, const std::vector<float>& w_vals,
+                                  const std::vector<float>& b_vals, std::vector<float>& out_vals,
+                                  int64_t N, int64_t C, int64_t H, int64_t W,
+                                  int64_t M, int64_t kH, int64_t kW,
+                                  int64_t oH, int64_t oW,
+                                  int64_t pad_h_begin, int64_t pad_w_begin,
+                                  int64_t stride_h, int64_t stride_w,
+                                  int64_t dilation_h, int64_t dilation_w,
+                                  int64_t group) {
+  const int64_t C_per_group = C / group;
+  const int64_t M_per_group = M / group;
+
+  for (int64_t n = 0; n < N; ++n) {
+    for (int64_t m = 0; m < M; ++m) {
+      const int64_t g = m / M_per_group;
+      const int64_t m_in_group = m % M_per_group;
+      for (int64_t oh = 0; oh < oH; ++oh) {
+        for (int64_t ow = 0; ow < oW; ++ow) {
+          float sum = b_vals.empty() ? 0.0f : b_vals[m];
+          for (int64_t c = 0; c < C_per_group; ++c) {
+            for (int64_t kh = 0; kh < kH; ++kh) {
+              const int64_t ih = oh * stride_h + kh * dilation_h - pad_h_begin;
+              if (ih < 0 || ih >= H) continue;
+              for (int64_t kw = 0; kw < kW; ++kw) {
+                const int64_t iw = ow * stride_w + kw * dilation_w - pad_w_begin;
+                if (iw < 0 || iw >= W) continue;
+                const size_t x_idx = static_cast<size_t>(((n * C + g * C_per_group + c) * H + ih) * W + iw);
+                const size_t w_idx = static_cast<size_t>(((m_in_group + g * M_per_group) * C_per_group + c) * kH * kW +
+                                                         kh * kW + kw);
+                sum += x_vals[x_idx] * w_vals[w_idx];
+              }
+            }
+          }
+          const size_t o_idx = static_cast<size_t>(((n * M + m) * oH + oh) * oW + ow);
+          out_vals[o_idx] = sum;
+        }
+      }
+    }
+  }
+}
+
+struct ConvTestParams {
+  // Input: [N, C, H, W]
+  int64_t N, C, H, W;
+  // Weight: [M, C/group, kH, kW]
+  int64_t M, kH, kW;
+  // Conv attributes
+  int64_t pad_h, pad_w;
+  int64_t stride_h, stride_w;
+  int64_t dilation_h, dilation_w;
+  int64_t group;
+  bool has_bias;
+};
+
+template <typename T, int version = 11>
+void RunConvTest(const ConvTestParams& p) {
+  static_assert(std::is_same_v<T, float> || std::is_same_v<T, MLFloat16>, "unexpected type for T");
+
+  const int64_t C_per_group = p.C / p.group;
+  const int64_t oH = ConvOutputSize(p.H, p.kH, p.pad_h, p.pad_h, p.stride_h, p.dilation_h);
+  const int64_t oW = ConvOutputSize(p.W, p.kW, p.pad_w, p.pad_w, p.stride_w, p.dilation_w);
+
+  std::vector<int64_t> x_dims = {p.N, p.C, p.H, p.W};
+  std::vector<int64_t> w_dims = {p.M, C_per_group, p.kH, p.kW};
+  std::vector<int64_t> b_dims = p.has_bias ? std::vector<int64_t>{p.M} : std::vector<int64_t>{};
+  std::vector<int64_t> y_dims = {p.N, p.M, oH, oW};
+
+  RandomValueGenerator random{1234};
+  std::vector<float> x_vals(random.Gaussian<float>(x_dims, 0.0f, 0.25f));
+  std::vector<float> w_vals(random.Gaussian<float>(w_dims, 0.0f, 0.25f));
+  std::vector<float> b_vals;
+  if (p.has_bias) {
+    b_vals = random.Gaussian<float>(b_dims, 0.0f, 0.1f);
+  }
+
+  std::vector<float> expected_vals(static_cast<size_t>(p.N * p.M * oH * oW), 0.0f);
+  ComputeExpectedConv2D(x_vals, w_vals, b_vals, expected_vals,
+                        p.N, p.C, p.H, p.W, p.M, p.kH, p.kW, oH, oW,
+                        p.pad_h, p.pad_w, p.stride_h, p.stride_w,
+                        p.dilation_h, p.dilation_w, p.group);
+
+  OpTester test("Conv", version);
+  test.AddAttribute("group", p.group);
+  test.AddAttribute("kernel_shape", std::vector<int64_t>{p.kH, p.kW});
+  test.AddAttribute("pads", std::vector<int64_t>{p.pad_h, p.pad_w, p.pad_h, p.pad_w});
+  test.AddAttribute("strides", std::vector<int64_t>{p.stride_h, p.stride_w});
+  test.AddAttribute("dilations", std::vector<int64_t>{p.dilation_h, p.dilation_w});
+
+  if constexpr (std::is_same_v<T, float>) {
+    test.AddInput<T>("X", x_dims, x_vals);
+    test.AddInput<T>("W", w_dims, w_vals, true /*is_initializer*/);
+    if (p.has_bias)
+      test.AddInput<T>("B", b_dims, b_vals);
+    test.AddOutput<T>("Y", y_dims, expected_vals);
+  } else {
+    test.AddInput<T>("X", x_dims, FloatsToMLFloat16s(x_vals));
+    test.AddInput<T>("W", w_dims, FloatsToMLFloat16s(w_vals), true /*is_initializer*/);
+    if (p.has_bias)
+      test.AddInput<T>("B", b_dims, FloatsToMLFloat16s(b_vals));
+    test.AddOutput<T>("Y", y_dims, FloatsToMLFloat16s(expected_vals));
+    test.SetOutputAbsErr("Y", 0.06f);
+    test.SetOutputRelErr("Y", 0.02f);
+  }
+
+  // Disable TensorRT because weight as input is not supported.
+  // QNN SDK 2.10.0 has a bug that breaks support for dynamic bias inputs.
+  std::unordered_set<std::string> excluded_providers = {kTensorrtExecutionProvider, kQnnExecutionProvider};
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", excluded_providers);
+}
+
+template <int version = 11>
+void RunConvBothTypes(const ConvTestParams& p) {
+  RunConvTest<float, version>(p);
+  RunConvTest<MLFloat16, version>(p);
+}
+
+TEST(Conv_Large, DISABLED_Conv1x1) {
+  RunConvBothTypes({1, 256, 56, 56, 512, 1, 1, 0, 0, 1, 1, 1, 1, 1, true});
+  RunConvBothTypes({1, 256, 56, 56, 511, 1, 1, 0, 0, 1, 1, 1, 1, 1, true});
+}
+
+}  // namespace test
+}  // namespace onnxruntime


### PR DESCRIPTION
The patch extends gemm-subgroup to Conv operator, and determines whether to enable gemm-subgroup according to the number of workgroups.

### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


