### PR TITLE
Don't pin SelectorActionTransformer replacement nodes to CPU

### DIFF
--- a/onnxruntime/core/optimizer/selectors_actions/actions.cc
+++ b/onnxruntime/core/optimizer/selectors_actions/actions.cc
@@ -88,8 +88,14 @@ static Status CreateReplacementNode(Graph& graph,
                                     &replacement_attributes,
                                     domain);
 
+  // Inherit the target's EP assignment. If the target hasn't been partitioned yet (empty EP),
+  // leave the replacement's EP empty too so a later partitioning pass can place it freely.
+  // Forcing CPU here would silently pin the new node to CPU and prevent any non-CPU EP from
+  // claiming it via GetCapability. This matters for fusions registered before partitioning.
   const auto& target_provider = target.GetExecutionProviderType();
-  replacement.SetExecutionProviderType(target_provider.empty() ? kCpuExecutionProvider : target_provider);
+  if (!target_provider.empty()) {
+    replacement.SetExecutionProviderType(target_provider);
+  }
 
   ORT_RETURN_IF_ERROR(MoveInputOutput(graph, selected_nodes, replacement, value_moves, only_update_dest_definitions));
 

--- a/onnxruntime/core/optimizer/selectors_actions/actions.cc
+++ b/onnxruntime/core/optimizer/selectors_actions/actions.cc
@@ -88,10 +88,8 @@ static Status CreateReplacementNode(Graph& graph,
                                     &replacement_attributes,
                                     domain);
 
-  // Inherit the target's EP assignment. If the target hasn't been partitioned yet (empty EP),
-  // leave the replacement's EP empty too so a later partitioning pass can place it freely.
-  // Forcing CPU here would silently pin the new node to CPU and prevent any non-CPU EP from
-  // claiming it via GetCapability. This matters for fusions registered before partitioning.
+  // If the target hasn't been partitioned yet (empty EP), leave the replacement's EP empty too
+  // so a later partitioning pass can place it freely.
   const auto& target_provider = target.GetExecutionProviderType();
   if (!target_provider.empty()) {
     replacement.SetExecutionProviderType(target_provider);

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -2572,6 +2572,35 @@ TEST_F(GraphTransformationTests, FuseConvClip11Activation) {
   }
 }
 
+// Regression test: when a SelectorActionTransformer fusion runs before partitioning, the
+// target nodes still have empty (unassigned) EP. The replacement node must inherit the empty
+// EP rather than being silently pinned to CPU; otherwise non-CPU EPs cannot claim the new
+// node via GetCapability and the fusion locks them out.
+TEST_F(GraphTransformationTests, FuseConvActivationPreEpAssignmentLeavesEpEmpty) {
+  constexpr const ORTCHAR_T* model_uri = MODEL_FOLDER "fusion/conv_relu.onnx";
+  std::shared_ptr<Model> p_model;
+  ASSERT_STATUS_OK(Model::Load(model_uri, p_model, nullptr, *logger_));
+  Graph& graph = p_model->MainGraph();
+
+  // Sanity: nodes start with empty EP (loaded from disk, not yet partitioned).
+  for (const Node& node : graph.Nodes()) {
+    ASSERT_TRUE(node.GetExecutionProviderType().empty())
+        << "expected empty EP on freshly loaded node " << node.Name();
+  }
+
+  onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<ConvActivationFusion>(),
+                                                     TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
+
+  ASSERT_EQ(graph.NumberOfNodes(), 1);
+  const Node& fused = *graph.Nodes().begin();
+  ASSERT_EQ(fused.OpType(), "FusedConv");
+  EXPECT_TRUE(fused.GetExecutionProviderType().empty())
+      << "FusedConv replacement should inherit the target's empty EP, got '"
+      << fused.GetExecutionProviderType() << "'";
+}
+
 TEST_F(GraphTransformationTests, FuseConvActivationPreservingAttributes) {
   constexpr const ORTCHAR_T* model_uri = MODEL_FOLDER "fusion/conv_with_padding_relu.onnx";
   std::shared_ptr<Model> p_model;

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -2592,6 +2592,10 @@ TEST_F(GraphTransformationTests, FuseConvActivationPreEpAssignmentLeavesEpEmpty)
   // the regression scenario this test guards against. Level2+ runs after
   // GraphPartitioner::Partition in the real session pipeline, so it would not
   // exercise the empty-EP code path.
+  //
+  // Note: ConvActivationFusion is currently registered at Level2 in production;
+  // this test validates the fix for any SelectorActionTransformer-based fusion
+  // that may be registered pre-partitioning in the future (e.g., for CoreML EP).
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
   ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<ConvActivationFusion>(),
                                                      TransformerLevel::Level1));

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -2588,10 +2588,14 @@ TEST_F(GraphTransformationTests, FuseConvActivationPreEpAssignmentLeavesEpEmpty)
         << "expected empty EP on freshly loaded node " << node.Name();
   }
 
+  // Register at Level1 so the transformer runs before EP assignment, mirroring
+  // the regression scenario this test guards against. Level2+ runs after
+  // GraphPartitioner::Partition in the real session pipeline, so it would not
+  // exercise the empty-EP code path.
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
   ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<ConvActivationFusion>(),
-                                                     TransformerLevel::Level2));
-  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
+                                                     TransformerLevel::Level1));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   ASSERT_EQ(graph.NumberOfNodes(), 1);
   const Node& fused = *graph.Nodes().begin();


### PR DESCRIPTION
### Description

\`ReplaceWithNew::CreateReplacementNode\` in \`onnxruntime/core/optimizer/selectors_actions/actions.cc\` defaults the replacement node's execution provider type to \`kCpuExecutionProvider\` when the target's EP is empty:

\`\`\`cpp
const auto& target_provider = target.GetExecutionProviderType();
replacement.SetExecutionProviderType(
    target_provider.empty() ? kCpuExecutionProvider : target_provider);
\`\`\`

Fine for fusions that run post-partitioning (Level 2+) — the target already has its EP set, so the replacement inherits it. But for any fusion registered **before** partitioning (Level 1), the target's EP is genuinely empty, and defaulting the replacement to CPU silently pins the new node to the CPU EP. The partitioner's per-EP supported-node check (\`graph_utils::IsSupportedProvider\` / \`CreateSupportedPartitionNodeGroups\`) then refuses to claim that node for any non-CPU EP via \`GetCapability\`. The fused node ends up on CPU regardless of which EP could have run it.

### Repro / observable symptom

Register \`ConvActivationFusion\` at Level 1 so it runs pre-partitioning, with an EP that supports \`com.microsoft:FusedConv\` (e.g. an extended CoreML conv builder). Without this fix, the partitioner reports \`FusedConv\` as unsupported by the EP even though the EP's \`GetCapability\` would otherwise claim it — partition counts grow and the fused nodes silently fall back to CPU. With this fix, partition counts and node assignment match the unfused baseline.

### Fix

When the target's EP is empty, leave the replacement's EP empty too. A later partitioning pass then assigns it like any other unassigned node. When the target already has an EP, the replacement still inherits it as before — preserving Level-2+ behaviour.

### Tests

Adds \`GraphTransformationTests.FuseConvActivationPreEpAssignmentLeavesEpEmpty\`:

- Loads \`fusion/conv_relu.onnx\` (no explicit EP assignment, so all nodes have empty EP — simulating pre-partition state).
- Runs \`ConvActivationFusion\`.
- Asserts the resulting \`FusedConv\` has empty EP, not \`CPUExecutionProvider\`.

I verified the test fails on \`origin/main\` (replacement gets EP \"CPUExecutionProvider\") and passes with this change. Pre-existing \`GraphTransformationTests.FuseConvActivation\` and \`GraphTransformationTests.FuseConvActivationPreservingAttributes\` continue to pass.

### Notes

- The motivating use case is wiring \`ConvActivationFusion\` so it runs pre-partitioning for EPs (e.g. CoreML) that natively claim \`com.microsoft:FusedConv\`. The Level-2 timing is too late for those EPs because their multi-node fused-subgraph metanodes have already been formed by the partitioner.
- This is a minimal, targeted fix scoped to the empty-EP case. Behaviour for non-empty target EPs is unchanged.