### PR TITLE
[MLAS/RISC-V] Add RVV INT8 GEMM/GEMV, M=1 routing, and activation kernels (follow-up #28261)

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -963,6 +963,8 @@ endif()
               ${MLAS_SRC_DIR}/riscv64/sconv_nchwc_kernel_rvv.cpp
               ${MLAS_SRC_DIR}/riscv64/rotary_embedding_kernel_rvv.cpp
               ${MLAS_SRC_DIR}/riscv64/layernorm_kernel_rvv.cpp
+              ${MLAS_SRC_DIR}/riscv64/qgemm_kernel_rvv.cpp
+              ${MLAS_SRC_DIR}/riscv64/activation_kernel_rvv.cpp
             )
             list(REMOVE_ITEM mlas_platform_srcs
               "${MLAS_SRC_DIR}/sconv_nchw_depthwise_multiplier_1.cpp")
@@ -974,6 +976,8 @@ endif()
               ${MLAS_SRC_DIR}/riscv64/sconv_nchwc_kernel_rvv.cpp
               ${MLAS_SRC_DIR}/riscv64/rotary_embedding_kernel_rvv.cpp
               ${MLAS_SRC_DIR}/riscv64/layernorm_kernel_rvv.cpp
+              ${MLAS_SRC_DIR}/riscv64/qgemm_kernel_rvv.cpp
+              ${MLAS_SRC_DIR}/riscv64/activation_kernel_rvv.cpp
               PROPERTIES COMPILE_FLAGS "-march=rv64gcv -mabi=lp64d")
             list(APPEND mlas_private_compile_definitions MLAS_USE_RVV=1)
 

--- a/onnxruntime/core/mlas/lib/compute.cpp
+++ b/onnxruntime/core/mlas/lib/compute.cpp
@@ -277,7 +277,7 @@ Return Value:
 
 --*/
 {
-#if defined(MLAS_TARGET_AMD64)
+#if defined(MLAS_TARGET_AMD64) || defined(MLAS_TARGET_RISCV64)
     GetMlasPlatform().ComputeExpF32Kernel(Input, Output, N);
 #else
     MlasComputeExpF32Kernel(Input, Output, N);

--- a/onnxruntime/core/mlas/lib/erf.cpp
+++ b/onnxruntime/core/mlas/lib/erf.cpp
@@ -260,7 +260,7 @@ Return Value:
 
 --*/
 {
-#if defined(MLAS_TARGET_AMD64) || defined(MLAS_USE_SVE)
+#if defined(MLAS_TARGET_AMD64) || defined(MLAS_USE_SVE) || defined(MLAS_TARGET_RISCV64)
     GetMlasPlatform().ErfKernelRoutine(Input, Output, N);
 #else
     MlasErfKernel(Input, Output, N);

--- a/onnxruntime/core/mlas/lib/gelu.cpp
+++ b/onnxruntime/core/mlas/lib/gelu.cpp
@@ -53,7 +53,7 @@ MlasComputeGeluErf(
     size_t N
     )
 {
-#if defined(MLAS_TARGET_AMD64)
+#if defined(MLAS_TARGET_AMD64) || defined(MLAS_TARGET_RISCV64)
     // TODO: Add an intermediate fused AVX2/FMA3 GELU(erf) path on AMD64.
     // Today the dispatch jumps from the generic multi-pass implementation to
     // AVX512F, so non-AVX512 x64 machines fall back to the generic kernel.

--- a/onnxruntime/core/mlas/lib/logistic.cpp
+++ b/onnxruntime/core/mlas/lib/logistic.cpp
@@ -181,7 +181,7 @@ Return Value:
 
 --*/
 {
-#if defined(MLAS_TARGET_AMD64) || defined(MLAS_USE_SVE)
+#if defined(MLAS_TARGET_AMD64) || defined(MLAS_USE_SVE) || defined(MLAS_TARGET_RISCV64)
     GetMlasPlatform().LogisticKernelRoutine(Input, Output, N);
 #else
     MlasLogisticKernel(Input, Output, N);

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -1111,7 +1111,7 @@ extern "C" {
 #if defined(MLAS_TARGET_AMD64)
     MLAS_SGEMM_KERNEL_M1_ROUTINE MlasSgemmKernelM1Avx;
     MLAS_SGEMM_KERNEL_M1_ROUTINE MlasSgemmKernelM1TransposeBAvx;
-#elif defined(MLAS_TARGET_ARM64) || defined(MLAS_TARGET_WASM)
+#elif defined(MLAS_TARGET_ARM64) || defined(MLAS_TARGET_WASM) || defined(MLAS_TARGET_RISCV64)
     MLAS_GEMV_FLOAT_KERNEL MlasGemvFloatKernel;
 #endif
 
@@ -1224,6 +1224,12 @@ extern "C" {
     MLAS_POOL_FLOAT_KERNEL MlasPoolMaximumFloatKernelRvv;
     MLAS_POOL_FLOAT_KERNEL MlasPoolAverageExcludePadFloatKernelRvv;
     MLAS_POOL_FLOAT_KERNEL MlasPoolAverageIncludePadFloatKernelRvv;
+    MLAS_COMPUTE_UNARY_FLOAT_KERNEL MlasErfKernelRvv;
+    MLAS_COMPUTE_UNARY_FLOAT_KERNEL MlasLogisticKernelRvv;
+    MLAS_COMPUTE_UNARY_FLOAT_KERNEL MlasGeluErfKernelRvv;
+    MLAS_COMPUTE_UNARY_FLOAT_KERNEL MlasSiluKernelRvv;
+    MLAS_COMPUTE_UNARY_FLOAT_KERNEL MlasTanhKernelRvv;
+    MLAS_COMPUTE_UNARY_FLOAT_KERNEL MlasComputeExpF32KernelRvv;
 #endif
 #if defined(MLAS_TARGET_AMD64)
     MLAS_REDUCE_MAXIMUM_FLOAT_KERNEL MlasReduceMaximumF32KernelAvx;
@@ -1330,6 +1336,7 @@ extern const MLAS_GEMM_QUANT_DISPATCH MlasGemmU8X8DispatchUmmla;
 extern const MLAS_GEMM_QUANT_DISPATCH MlasGemmS8S8DispatchSmmla;
 extern const MLAS_GEMM_QUANT_DISPATCH MlasGemmU8X8DispatchWasmSimd;
 extern const MLAS_GEMM_QUANT_DISPATCH MlasGemmU8X8DispatchWasmRelaxedSimd;
+extern const MLAS_GEMM_QUANT_DISPATCH MlasGemmQuantDispatchRvv;
 extern const MLAS_GEMM_QUANT_DISPATCH MlasGemmQuantDispatchDefault;
 extern const MLAS_GEMM_QUANT_DISPATCH MlasGemm8X8DispatchPOWER10;
 extern const MLAS_GEMM_QUANT_DISPATCH MlasGemm8X8DispatchZVECTOR;
@@ -1542,7 +1549,7 @@ struct MLAS_PLATFORM {
     MLAS_COMPUTE_LOGSOFTMAX_OUTPUT_FLOAT_KERNEL* ComputeLogSoftmaxOutputF32Kernel;
     uint32_t NchwcBlockSize;
 #endif
-#if defined(MLAS_TARGET_AMD64_IX86)
+#if defined(MLAS_TARGET_AMD64_IX86) || defined(MLAS_TARGET_RISCV64)
     const MLAS_GEMM_QUANT_DISPATCH* GemmU8S8Dispatch;
     const MLAS_GEMM_QUANT_DISPATCH* GemmU8U8Dispatch;
     const MLAS_GEMM_QUANT_DISPATCH* GemmS8S8Dispatch{&MlasGemmQuantDispatchDefault};
@@ -1594,6 +1601,15 @@ struct MLAS_PLATFORM {
     MLAS_COMPUTE_LOGSOFTMAX_OUTPUT_FLOAT_KERNEL* ComputeLogSoftmaxOutputF32Kernel;
     MLAS_COMPUTE_SOFTMAX_OUTPUT_FLOAT_KERNEL* ComputeSoftmaxOutputF32Kernel;
 #endif
+#if defined(MLAS_TARGET_AMD64) || defined(MLAS_TARGET_RISCV64)
+    // Hoisted under combined guard so future "shared between AMD64 and RISCV64"
+    // changes won't produce duplicate-member errors. Each platform's init code
+    // assigns these fields independently in platform.cpp.
+    MLAS_COMPUTE_UNARY_FLOAT_KERNEL* GeluErfKernelRoutine;
+    MLAS_COMPUTE_UNARY_FLOAT_KERNEL* SiluKernelRoutine;
+    MLAS_COMPUTE_UNARY_FLOAT_KERNEL* TanhKernelRoutine;
+    MLAS_COMPUTE_UNARY_FLOAT_KERNEL* ComputeExpF32Kernel;
+#endif
 
 #if defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV)
     MLAS_CONV_FLOAT_KERNEL* ConvNchwFloatKernel;
@@ -1609,8 +1625,8 @@ MLAS_COMPUTE_GELU_FP16_KERNEL* GeluFP16KernelRoutine = nullptr;
 MLAS_COMPUTE_TANH_FP16_KERNEL* TanhFP16KernelRoutine = nullptr;
 
 #if defined(MLAS_TARGET_AMD64)
-    MLAS_COMPUTE_UNARY_FLOAT_KERNEL* GeluErfKernelRoutine;
-    MLAS_COMPUTE_UNARY_FLOAT_KERNEL* SiluKernelRoutine;
+    // GeluErfKernelRoutine / SiluKernelRoutine / TanhKernelRoutine /
+    // ComputeExpF32Kernel are declared in the shared AMD64+RISCV64 block above.
     MLAS_SGEMM_KERNEL_M1_ROUTINE* KernelM1Routine;
     MLAS_SGEMM_KERNEL_M1_ROUTINE* KernelM1TransposeBRoutine;
     MLAS_SGEMM_TRANSPOSE_PACKB_BLOCK_ROUTINE* TransposePackB16x4Routine;
@@ -1627,8 +1643,6 @@ MLAS_COMPUTE_TANH_FP16_KERNEL* TanhFP16KernelRoutine = nullptr;
     MLAS_POOL_FLOAT_KERNEL* PoolFloatKernel[MlasPoolingKindCount];
     MLAS_QLINEAR_BINARY_OP_S8_KERNEL* QLinearAddS8Kernel;
     MLAS_QLINEAR_BINARY_OP_U8_KERNEL* QLinearAddU8Kernel;
-    MLAS_COMPUTE_UNARY_FLOAT_KERNEL* ComputeExpF32Kernel;
-    MLAS_COMPUTE_UNARY_FLOAT_KERNEL* TanhKernelRoutine;
     MLAS_REDUCE_MINIMUM_MAXIMUM_FLOAT_KERNEL* ReduceMinimumMaximumF32Kernel;
     MLAS_QUANTIZE_LINEAR_S8_KERNEL* QuantizeLinearS8Kernel;
     MLAS_QUANTIZE_LINEAR_U8_KERNEL* QuantizeLinearU8Kernel;

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -279,8 +279,16 @@ Return Value:
 
 #if defined(MLAS_TARGET_RISCV64)
     this->GemmFloatKernel = nullptr;
+    this->GemmU8S8Dispatch = &MlasGemmQuantDispatchDefault;
+    this->GemmU8U8Dispatch = &MlasGemmQuantDispatchDefault;
+    this->GemmS8S8Dispatch = &MlasGemmQuantDispatchDefault;
+    this->GemmS8U8Dispatch = &MlasGemmQuantDispatchDefault;
     this->ErfKernelRoutine = MlasErfKernel;
     this->LogisticKernelRoutine = MlasLogisticKernel;
+    this->GeluErfKernelRoutine = MlasGeluErfKernel;
+    this->SiluKernelRoutine = MlasSiluKernel;
+    this->TanhKernelRoutine = MlasTanhKernel;
+    this->ComputeExpF32Kernel = MlasComputeExpF32Kernel;
     this->ReduceMaximumF32Kernel = MlasReduceMaximumF32Kernel;
     this->ComputeSumExpF32Kernel = MlasComputeSumExpF32Kernel;
     this->ComputeSoftmaxOutputF32Kernel = MlasComputeSoftmaxOutputF32Kernel;
@@ -288,6 +296,16 @@ Return Value:
 
 #if defined(MLAS_USE_RVV)
     this->GemmFloatKernel = MlasGemmFloatKernelRvv;
+    this->GemmU8S8Dispatch = &MlasGemmQuantDispatchRvv;
+    this->GemmU8U8Dispatch = &MlasGemmQuantDispatchRvv;
+    this->GemmS8S8Dispatch = &MlasGemmQuantDispatchRvv;
+    this->GemmS8U8Dispatch = &MlasGemmQuantDispatchRvv;
+    this->ErfKernelRoutine = MlasErfKernelRvv;
+    this->LogisticKernelRoutine = MlasLogisticKernelRvv;
+    this->GeluErfKernelRoutine = MlasGeluErfKernelRvv;
+    this->SiluKernelRoutine = MlasSiluKernelRvv;
+    this->TanhKernelRoutine = MlasTanhKernelRvv;
+    this->ComputeExpF32Kernel = MlasComputeExpF32KernelRvv;
     this->ReduceMaximumF32Kernel = MlasReduceMaximumF32KernelRvv;
     this->ComputeSumExpF32Kernel = MlasComputeSumExpF32KernelRvv;
     this->ComputeSoftmaxOutputF32Kernel = MlasComputeSoftmaxOutputF32KernelRvv;

--- a/onnxruntime/core/mlas/lib/qgemm.h
+++ b/onnxruntime/core/mlas/lib/qgemm.h
@@ -912,6 +912,14 @@ MlasGemmQuantGetDispatch(
         GemmQuantDispatch =
             BIsSigned ? GetMlasPlatform().GemmU8S8Dispatch : GetMlasPlatform().GemmU8U8Dispatch;
     }
+#elif defined(MLAS_TARGET_RISCV64)
+    if (AIsSigned) {
+        GemmQuantDispatch =
+            BIsSigned ? GetMlasPlatform().GemmS8S8Dispatch : GetMlasPlatform().GemmS8U8Dispatch;
+    } else { // !AIsSigned
+        GemmQuantDispatch =
+            BIsSigned ? GetMlasPlatform().GemmU8S8Dispatch : GetMlasPlatform().GemmU8U8Dispatch;
+    }
 #elif defined(MLAS_TARGET_S390X)
     if (GetMlasPlatform().GemmU8X8Dispatch == &MlasGemm8X8DispatchZVECTOR) {
         GemmQuantDispatch = GetMlasPlatform().GemmU8X8Dispatch;

--- a/onnxruntime/core/mlas/lib/riscv64/activation_kernel_rvv.cpp
+++ b/onnxruntime/core/mlas/lib/riscv64/activation_kernel_rvv.cpp
@@ -1,0 +1,310 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    activation_kernel_rvv.cpp
+
+Abstract:
+
+    RVV unary activation kernels for riscv64: erf, tanh, logistic (sigmoid),
+    exp, silu, gelu(erf). Wired through MLAS_PLATFORM kernel routine fields
+    on builds with RVV support (MLAS_USE_RVV).
+
+    LMUL=m4 throughout (32 floats per vector at VLEN=256), scaling with VLEN
+    via dynamic vsetvli.
+
+--*/
+
+#include <riscv_vector.h>
+#include <stddef.h>
+#include "mlasi.h"
+
+#if defined(MLAS_USE_RVV)
+
+// vfmin/vfmax follow IEEE-754 minNum/maxNum, so a NaN input would be clamped to
+// a finite limit. To let NaN round-trip, each kernel captures an is-NaN mask of
+// the raw input and merges those lanes back into the result before the store.
+
+namespace {
+
+// Cody-Waite constants for exp(x).
+constexpr float LOG2E         = 1.4426950408889634f;
+constexpr float LN2_HI        = 0.6931381225585938f;
+constexpr float LN2_LO        = 9.05800061733627e-6f;
+// Lower bound applied by the activation kernels before their internal exp().
+constexpr float EXP_CLAMP_MIN = -87.0f;
+// Input guard for exp_f32m4's two-step 2^n reconstruction. +/-128 sits past
+// float32 exp()'s saturation points (+inf above ln(FLT_MAX) ~= 88.7, 0 below
+// -150*ln2 ~= -104) so clamping never alters a representable result, yet stays
+// inside |x| ~< 174 where the split halves of n keep the exponent-bit trick in
+// its valid [-126,127] range.
+constexpr float EXP_RECON_MIN = -128.0f;
+constexpr float EXP_RECON_MAX = 128.0f;
+// SiLU clamps its sigmoid argument to this range -- mirrors the generic
+// MlasLogisticConstants [-18, 18] so the sigmoid stays strictly inside (0, 1).
+constexpr float LOGISTIC_CLAMP = 18.0f;
+// Smallest positive normal float; used to floor 1+erf in GELU so the final
+// multiply by x cannot evaluate to the NaN-producing (+/-inf) * 0.
+constexpr float SMALLEST_NORMAL_F32 = 1.17549435e-38f;
+
+// 6th-order minimax polynomial for exp(r), |r| <= ln2/2.
+constexpr float C1 = 1.0f;
+constexpr float C2 = 0.5f;
+constexpr float C3 = 0.16666667f;
+constexpr float C4 = 0.04166667f;
+constexpr float C5 = 0.00833333f;
+constexpr float C6 = 0.00138889f;
+
+MLAS_FORCEINLINE
+vfloat32m4_t exp_f32m4(vfloat32m4_t x, size_t vl)
+{
+    x = __riscv_vfmin_vf_f32m4(x, EXP_RECON_MAX, vl);
+    x = __riscv_vfmax_vf_f32m4(x, EXP_RECON_MIN, vl);
+
+    // n = round(x / ln2)
+    const vfloat32m4_t xlog2e = __riscv_vfmul_vf_f32m4(x, LOG2E, vl);
+    const vint32m4_t   n      = __riscv_vfcvt_x_f_v_i32m4(xlog2e, vl);
+    const vfloat32m4_t nf     = __riscv_vfcvt_f_x_v_f32m4(n, vl);
+
+    // r = x - n*ln2 (Cody-Waite two-step)
+    vfloat32m4_t r = __riscv_vfnmsac_vf_f32m4(x, LN2_HI, nf, vl);
+    r              = __riscv_vfnmsac_vf_f32m4(r, LN2_LO, nf, vl);
+
+    // Horner polynomial for exp(r) = 1 + r*(1 + r*(C2 + r*(C3 + r*(C4 + r*(C5 + r*C6)))))
+    vfloat32m4_t p = __riscv_vfmv_v_f_f32m4(C6, vl);
+    p = __riscv_vfmacc_vv_f32m4(__riscv_vfmv_v_f_f32m4(C5, vl), r, p, vl);
+    p = __riscv_vfmacc_vv_f32m4(__riscv_vfmv_v_f_f32m4(C4, vl), r, p, vl);
+    p = __riscv_vfmacc_vv_f32m4(__riscv_vfmv_v_f_f32m4(C3, vl), r, p, vl);
+    p = __riscv_vfmacc_vv_f32m4(__riscv_vfmv_v_f_f32m4(C2, vl), r, p, vl);
+    p = __riscv_vfmacc_vv_f32m4(__riscv_vfmv_v_f_f32m4(C1, vl), r, p, vl);
+    p = __riscv_vfmacc_vv_f32m4(__riscv_vfmv_v_f_f32m4(1.0f, vl), r, p, vl);
+
+    // 2^n via a two-step IEEE-754 exponent-bit construction: split n = n1 + n2
+    // so each 2^ni stays a representable normal float. The single-step trick is
+    // valid only for n in [-126, 127]; splitting spans exp's full range, so it
+    // yields denormals near the underflow edge and +inf on overflow rather than
+    // saturating valid finite results.
+    const vint32m4_t   n1 = __riscv_vsra_vx_i32m4(n, 1, vl);
+    const vint32m4_t   n2 = __riscv_vsub_vv_i32m4(n, n1, vl);
+    const vfloat32m4_t s1 = __riscv_vreinterpret_v_i32m4_f32m4(
+        __riscv_vsll_vx_i32m4(__riscv_vadd_vx_i32m4(n1, 127, vl), 23, vl));
+    const vfloat32m4_t s2 = __riscv_vreinterpret_v_i32m4_f32m4(
+        __riscv_vsll_vx_i32m4(__riscv_vadd_vx_i32m4(n2, 127, vl), 23, vl));
+    return __riscv_vfmul_vv_f32m4(__riscv_vfmul_vv_f32m4(p, s1, vl), s2, vl);
+}
+
+// Abramowitz & Stegun erf approximation (max error ~2.5e-5, sufficient for GELU)
+constexpr float ERF_P  =  0.3275911f;
+constexpr float ERF_A1 =  0.254829592f;
+constexpr float ERF_A2 = -0.284496736f;
+constexpr float ERF_A3 =  1.421413741f;
+constexpr float ERF_A4 = -1.453152027f;
+constexpr float ERF_A5 =  1.061405429f;
+
+}  // namespace
+
+extern "C"
+void
+MLASCALL
+MlasErfKernelRvv(const float* Input, float* Output, size_t N)
+{
+    while (N > 0) {
+        const size_t vl = __riscv_vsetvl_e32m4(N);
+        const vfloat32m4_t x     = __riscv_vle32_v_f32m4(Input, vl);
+        const vbool8_t nan_mask  = __riscv_vmfne_vv_f32m4_b8(x, x, vl);
+        const vfloat32m4_t abs_x = __riscv_vfabs_v_f32m4(x, vl);
+
+        // t = 1 / (1 + p*|x|)
+        const vfloat32m4_t t_den = __riscv_vfmacc_vf_f32m4(
+            __riscv_vfmv_v_f_f32m4(1.0f, vl), ERF_P, abs_x, vl);
+        const vfloat32m4_t t = __riscv_vfrdiv_vf_f32m4(t_den, 1.0f, vl);
+
+        // poly = ((((a5*t + a4)*t + a3)*t + a2)*t + a1)*t
+        vfloat32m4_t p = __riscv_vfmv_v_f_f32m4(ERF_A5, vl);
+        p = __riscv_vfmacc_vv_f32m4(__riscv_vfmv_v_f_f32m4(ERF_A4, vl), t, p, vl);
+        p = __riscv_vfmacc_vv_f32m4(__riscv_vfmv_v_f_f32m4(ERF_A3, vl), t, p, vl);
+        p = __riscv_vfmacc_vv_f32m4(__riscv_vfmv_v_f_f32m4(ERF_A2, vl), t, p, vl);
+        p = __riscv_vfmacc_vv_f32m4(__riscv_vfmv_v_f_f32m4(ERF_A1, vl), t, p, vl);
+        p = __riscv_vfmul_vv_f32m4(p, t, vl);
+
+        // exp(-x^2)
+        vfloat32m4_t neg_x2 = __riscv_vfneg_v_f32m4(
+            __riscv_vfmul_vv_f32m4(abs_x, abs_x, vl), vl);
+        neg_x2 = __riscv_vfmax_vf_f32m4(neg_x2, EXP_CLAMP_MIN, vl);
+        const vfloat32m4_t exp_neg_x2 = exp_f32m4(neg_x2, vl);
+
+        // erf = (1 - poly * exp(-x^2)) * sign(x)
+        vfloat32m4_t result = __riscv_vfnmsac_vv_f32m4(
+            __riscv_vfmv_v_f_f32m4(1.0f, vl), p, exp_neg_x2, vl);
+        result = __riscv_vfsgnj_vv_f32m4(result, x, vl);
+        result = __riscv_vmerge_vvm_f32m4(result, x, nan_mask, vl);
+
+        __riscv_vse32_v_f32m4(Output, result, vl);
+        Input  += vl;
+        Output += vl;
+        N      -= vl;
+    }
+}
+
+extern "C"
+void
+MLASCALL
+MlasTanhKernelRvv(const float* Input, float* Output, size_t N)
+{
+    while (N > 0) {
+        const size_t vl = __riscv_vsetvl_e32m4(N);
+        const vfloat32m4_t x_in = __riscv_vle32_v_f32m4(Input, vl);
+        const vbool8_t nan_mask = __riscv_vmfne_vv_f32m4_b8(x_in, x_in, vl);
+
+        // tanh saturates for |x| >= 9
+        vfloat32m4_t x = __riscv_vfmin_vf_f32m4(x_in, 9.0f, vl);
+        x = __riscv_vfmax_vf_f32m4(x, -9.0f, vl);
+
+        vfloat32m4_t two_x = __riscv_vfmul_vf_f32m4(x, 2.0f, vl);
+        two_x              = __riscv_vfmax_vf_f32m4(two_x, EXP_CLAMP_MIN, vl);
+        const vfloat32m4_t e2x = exp_f32m4(two_x, vl);
+
+        const vfloat32m4_t num = __riscv_vfsub_vf_f32m4(e2x, 1.0f, vl);
+        const vfloat32m4_t den = __riscv_vfadd_vf_f32m4(e2x, 1.0f, vl);
+        vfloat32m4_t v   = __riscv_vfdiv_vv_f32m4(num, den, vl);
+        v = __riscv_vmerge_vvm_f32m4(v, x_in, nan_mask, vl);
+
+        __riscv_vse32_v_f32m4(Output, v, vl);
+        Input  += vl;
+        Output += vl;
+        N      -= vl;
+    }
+}
+
+extern "C"
+void
+MLASCALL
+MlasLogisticKernelRvv(const float* Input, float* Output, size_t N)
+{
+    while (N > 0) {
+        const size_t vl = __riscv_vsetvl_e32m4(N);
+        const vfloat32m4_t x = __riscv_vle32_v_f32m4(Input, vl);
+        const vbool8_t nan_mask = __riscv_vmfne_vv_f32m4_b8(x, x, vl);
+        vfloat32m4_t neg_x   = __riscv_vfneg_v_f32m4(x, vl);
+        neg_x                = __riscv_vfmax_vf_f32m4(neg_x, EXP_CLAMP_MIN, vl);
+        const vfloat32m4_t exp_neg = exp_f32m4(neg_x, vl);
+        const vfloat32m4_t den     = __riscv_vfadd_vf_f32m4(exp_neg, 1.0f, vl);
+        vfloat32m4_t result        = __riscv_vfrdiv_vf_f32m4(den, 1.0f, vl);
+        result = __riscv_vmerge_vvm_f32m4(result, x, nan_mask, vl);
+        __riscv_vse32_v_f32m4(Output, result, vl);
+        Input  += vl;
+        Output += vl;
+        N      -= vl;
+    }
+}
+
+extern "C"
+void
+MLASCALL
+MlasComputeExpF32KernelRvv(const float* Input, float* Output, size_t N)
+{
+    while (N > 0) {
+        const size_t vl = __riscv_vsetvl_e32m4(N);
+        const vfloat32m4_t v_in = __riscv_vle32_v_f32m4(Input, vl);
+        const vbool8_t nan_mask = __riscv_vmfne_vv_f32m4_b8(v_in, v_in, vl);
+        vfloat32m4_t v = exp_f32m4(v_in, vl);
+        v = __riscv_vmerge_vvm_f32m4(v, v_in, nan_mask, vl);
+        __riscv_vse32_v_f32m4(Output, v, vl);
+        Input  += vl;
+        Output += vl;
+        N      -= vl;
+    }
+}
+
+// silu(x) = x * sigmoid(x) = x / (1 + exp(-x))
+// Fused in a single pass to halve load/store traffic vs a two-kernel
+// composition of logistic + multiply.
+extern "C"
+void
+MLASCALL
+MlasSiluKernelRvv(const float* Input, float* Output, size_t N)
+{
+    while (N > 0) {
+        const size_t vl        = __riscv_vsetvl_e32m4(N);
+        const vfloat32m4_t x   = __riscv_vle32_v_f32m4(Input, vl);
+        const vbool8_t nan_mask = __riscv_vmfne_vv_f32m4_b8(x, x, vl);
+        vfloat32m4_t neg_x     = __riscv_vfneg_v_f32m4(x, vl);
+        // Clamp the sigmoid argument to the generic logistic range [-18, 18];
+        // otherwise exp(-x) overflows to +inf, sigmoid becomes exactly 0, and
+        // x*sigmoid produces NaN for x = -inf and -0 for large negative x.
+        neg_x                  = __riscv_vfmin_vf_f32m4(
+            __riscv_vfmax_vf_f32m4(neg_x, -LOGISTIC_CLAMP, vl), LOGISTIC_CLAMP, vl);
+        const vfloat32m4_t en  = exp_f32m4(neg_x, vl);
+        const vfloat32m4_t den = __riscv_vfadd_vf_f32m4(en, 1.0f, vl);
+        const vfloat32m4_t sig = __riscv_vfrdiv_vf_f32m4(den, 1.0f, vl);
+        vfloat32m4_t out       = __riscv_vfmul_vv_f32m4(x, sig, vl);
+        out = __riscv_vmerge_vvm_f32m4(out, x, nan_mask, vl);
+        __riscv_vse32_v_f32m4(Output, out, vl);
+        Input  += vl;
+        Output += vl;
+        N      -= vl;
+    }
+}
+
+// GELU (erf variant): 0.5 * x * (1 + erf(x / sqrt(2)))
+// Reuses the Abramowitz & Stegun erf approximation inlined for fusion,
+// sharing the ERF_A1..A5 / ERF_P constants with MlasErfKernelRvv.
+extern "C"
+void
+MLASCALL
+MlasGeluErfKernelRvv(const float* Input, float* Output, size_t N)
+{
+    constexpr float INV_SQRT_2 = 0.70710678118654752f;
+
+    while (N > 0) {
+        const size_t vl           = __riscv_vsetvl_e32m4(N);
+        const vfloat32m4_t x      = __riscv_vle32_v_f32m4(Input, vl);
+        const vbool8_t nan_mask   = __riscv_vmfne_vv_f32m4_b8(x, x, vl);
+        const vfloat32m4_t sx     = __riscv_vfmul_vf_f32m4(x, INV_SQRT_2, vl);
+        const vfloat32m4_t abs_sx = __riscv_vfabs_v_f32m4(sx, vl);
+
+        // t = 1 / (1 + p * |sx|)
+        const vfloat32m4_t t_den = __riscv_vfmacc_vf_f32m4(
+            __riscv_vfmv_v_f_f32m4(1.0f, vl), ERF_P, abs_sx, vl);
+        const vfloat32m4_t t = __riscv_vfrdiv_vf_f32m4(t_den, 1.0f, vl);
+
+        // poly = ((((a5*t + a4)*t + a3)*t + a2)*t + a1)*t
+        vfloat32m4_t p = __riscv_vfmv_v_f_f32m4(ERF_A5, vl);
+        p = __riscv_vfmacc_vv_f32m4(__riscv_vfmv_v_f_f32m4(ERF_A4, vl), t, p, vl);
+        p = __riscv_vfmacc_vv_f32m4(__riscv_vfmv_v_f_f32m4(ERF_A3, vl), t, p, vl);
+        p = __riscv_vfmacc_vv_f32m4(__riscv_vfmv_v_f_f32m4(ERF_A2, vl), t, p, vl);
+        p = __riscv_vfmacc_vv_f32m4(__riscv_vfmv_v_f_f32m4(ERF_A1, vl), t, p, vl);
+        p = __riscv_vfmul_vv_f32m4(p, t, vl);
+
+        // exp(-sx^2)
+        vfloat32m4_t neg_x2 = __riscv_vfneg_v_f32m4(
+            __riscv_vfmul_vv_f32m4(abs_sx, abs_sx, vl), vl);
+        neg_x2 = __riscv_vfmax_vf_f32m4(neg_x2, EXP_CLAMP_MIN, vl);
+        const vfloat32m4_t exp_neg_x2 = exp_f32m4(neg_x2, vl);
+
+        // erf(sx) = (1 - poly * exp(-sx^2)) * sign(sx)
+        vfloat32m4_t erf_val = __riscv_vfnmsac_vv_f32m4(
+            __riscv_vfmv_v_f_f32m4(1.0f, vl), p, exp_neg_x2, vl);
+        erf_val = __riscv_vfsgnj_vv_f32m4(erf_val, sx, vl);
+
+        // 0.5 * x * (1 + erf(sx)). erf saturates to -1 for large negative x, so
+        // 1+erf can be exactly 0; floor it to the smallest normal float so the
+        // multiply by x cannot become the NaN-producing (+/-inf) * 0.
+        vfloat32m4_t one_plus_erf = __riscv_vfadd_vf_f32m4(erf_val, 1.0f, vl);
+        one_plus_erf = __riscv_vfmax_vf_f32m4(one_plus_erf, SMALLEST_NORMAL_F32, vl);
+        vfloat32m4_t out = __riscv_vfmul_vv_f32m4(x, one_plus_erf, vl);
+        out = __riscv_vfmul_vf_f32m4(out, 0.5f, vl);
+        out = __riscv_vmerge_vvm_f32m4(out, x, nan_mask, vl);
+
+        __riscv_vse32_v_f32m4(Output, out, vl);
+        Input  += vl;
+        Output += vl;
+        N      -= vl;
+    }
+}
+
+#endif  // MLAS_USE_RVV

--- a/onnxruntime/core/mlas/lib/riscv64/qgemm_kernel_rvv.cpp
+++ b/onnxruntime/core/mlas/lib/riscv64/qgemm_kernel_rvv.cpp
@@ -1,0 +1,499 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    qgemm_kernel_rvv.cpp
+
+Abstract:
+
+    This module implements an RVV INT8 quantized GEMM kernel for riscv64
+    using widening multiply-accumulate (vwmacc.vv). Works for any
+    VLEN >= 128 via dynamic vsetvli.
+
+--*/
+
+#include "mlasi.h"
+#include "qgemm.h"
+
+#include <riscv_vector.h>
+
+struct MLAS_GEMM_QUANT_KERNEL_RVV
+{
+    typedef uint8_t PackedAType;
+    typedef uint8_t PackedBType;
+    typedef uint8_t OffsetAType;
+    typedef uint8_t OffsetBType;
+
+    /* PackedK = number of INT8 elements processed per inner iteration.
+     * VLEN=256 → 32 INT8 per vector register, but PackedK must divide K evenly.
+     * Use 4 to match default kernel's alignment and packing. */
+    static constexpr size_t PackedK = 4;
+
+    /* StrideM/N/K: tile sizes for the outer loops */
+    static constexpr MLAS_GEMM_QUANT_STRIDES Strides{ 4, 128, 256 };
+    static constexpr MLAS_GEMM_QUANT_STRIDES PackedStrides{ 4, 128, 256 };
+};
+
+constexpr size_t MLAS_GEMM_QUANT_KERNEL_RVV::PackedK;
+constexpr MLAS_GEMM_QUANT_STRIDES MLAS_GEMM_QUANT_KERNEL_RVV::Strides;
+constexpr MLAS_GEMM_QUANT_STRIDES MLAS_GEMM_QUANT_KERNEL_RVV::PackedStrides;
+
+/* ── Zero-point fixup (same as default) ── */
+
+template<>
+MLAS_FORCEINLINE constexpr
+int32_t
+MlasGemmQuantFixupZeroPointA<MLAS_GEMM_QUANT_KERNEL_RVV>(
+    int32_t ZeroPointA,
+    bool AIsSigned
+    )
+{
+    if (AIsSigned) {
+        ZeroPointA = (uint8_t)(ZeroPointA ^ 0x80);
+    }
+    return ZeroPointA;
+}
+
+template<>
+MLAS_FORCEINLINE constexpr
+int32_t
+MlasGemmQuantFixupZeroPointB<MLAS_GEMM_QUANT_KERNEL_RVV>(
+    int32_t ZeroPointB,
+    bool BIsSigned
+    )
+{
+    if (BIsSigned) {
+        ZeroPointB = MLAS_GEMM_QUANT_KERNEL_RVV::OffsetBType(ZeroPointB ^ 0x80);
+    }
+    return ZeroPointB;
+}
+
+/* ── M=1 GEMV fast path (U8 × S8 → S32) ──
+ *
+ * Invoked from MlasGemmQuantOperation when RangeCountM == 1 and all
+ * zero-point conditions hold (see qgemm.h). Skips the full PackA/PackB
+ * pipeline since A is a single row and B does not need to be reused.
+ *
+ * Output contract: C[n] = sum_k(A[k] * B[k*ldb + n]) only — plain dot
+ * product, no zero-point or row/column-sum bias folding. This matches
+ * the AVX2 specialization (MlasGemvU8S8KernelAvx2). The caller in
+ * qgemm.h gates entry on ZeroPointA == 0 && ZeroPointB == 0 (and no
+ * per-column ZpB and no OutputProcessor), so the bias terms
+ * (RowSum*ZpB + ColSum*ZpA + K*ZpA*ZpB) all vanish and the bare dot
+ * product equals the final result.
+ *
+ * Strategy: K-outer, N-tiled with LMUL=m4 e32 i32 accumulator. For each
+ * K iteration broadcast A[k] as i16, sign-extend B[k*ldb + n..n+vl) from
+ * i8 to i16, widen-mul-accumulate into the i32 acc. Casting u8(A[k]) to
+ * i16 zero-extends, which keeps the signed-mul correct since u8 is
+ * always representable as a non-negative i16.
+ */
+static void
+MlasGemvU8S8KernelRvv(
+    const uint8_t* A,
+    const int8_t* B,
+    int32_t* C,
+    size_t CountK,
+    size_t CountN,
+    size_t ldb)
+{
+    size_t n = 0;
+    while (n < CountN) {
+        const size_t vl = __riscv_vsetvl_e32m4(CountN - n);
+        vint32m4_t vacc = __riscv_vmv_v_x_i32m4(0, vl);
+        const int8_t* bcol = B + n;
+        for (size_t k = 0; k < CountK; ++k) {
+            vint8m1_t  vb   = __riscv_vle8_v_i8m1(bcol, vl);
+            vint16m2_t vb16 = __riscv_vsext_vf2_i16m2(vb, vl);
+            const int16_t a = static_cast<int16_t>(A[k]);
+            vacc = __riscv_vwmacc_vx_i32m4(vacc, a, vb16, vl);
+            bcol += ldb;
+        }
+        __riscv_vse32_v_i32m4(C + n, vacc, vl);
+        n += vl;
+    }
+}
+
+template<>
+MLAS_FORCEINLINE
+bool
+MlasGemmQuantTryGemvKernel<MLAS_GEMM_QUANT_KERNEL_RVV>(
+    const uint8_t* A,
+    const uint8_t* B,
+    size_t ldb,
+    int32_t* C,
+    size_t CountK,
+    size_t CountN,
+    bool AIsSigned,
+    bool BIsSigned)
+{
+    /* Match the AVX2 contract: only the U8 × S8 combination is wired up.
+     * For other signedness combinations fall back to the packed kernel. */
+    if (AIsSigned || !BIsSigned) {
+        return false;
+    }
+
+    /* TODO(perf): K3 X100 microbench shows the unpacked GEMV path regresses
+     * to ~0.82× at K=N=4096 (16 MB B working set) because the in-order
+     * pipeline cannot hide DRAM bandwidth pressure once B no longer fits in
+     * the cache hierarchy. AVX2 hides this on AMD64 via richer caches.
+     * Cap the fast path at an 8 MB B byte budget; larger GEMV shapes fall
+     * back to MlasGemmQuantOperation's packed kernel, which prefetches +
+     * tiles. Re-tune once K3 sweep data lands in
+     * rv-achievements/reports/runs/. */
+    constexpr size_t kRvvGemvMaxBBytes = 8u * 1024u * 1024u;
+    if (CountK > 0 && CountN > kRvvGemvMaxBBytes / CountK) {
+        return false;
+    }
+
+    MlasGemvU8S8KernelRvv(A, reinterpret_cast<const int8_t*>(B), C,
+                          CountK, CountN, ldb);
+    return true;
+}
+
+/* ── Pack A: row-major copy with row sum computation ── */
+
+template<>
+void
+MlasGemmQuantCopyPackA<MLAS_GEMM_QUANT_KERNEL_RVV>(
+    MLAS_GEMM_QUANT_KERNEL_RVV::PackedAType* D,
+    const uint8_t* A,
+    size_t lda,
+    size_t CountM,
+    size_t CountK,
+    int32_t* RowSumBuffer,
+    bool AIsSigned
+    )
+{
+    const size_t AlignedCountK = (CountK + MLAS_GEMM_QUANT_KERNEL_RVV::PackedK - 1) &
+                                 ~(MLAS_GEMM_QUANT_KERNEL_RVV::PackedK - 1);
+    const uint8_t BitFlipValue = (AIsSigned ? 0x80 : 0);
+
+    while (CountM-- > 0) {
+        int32_t RowSum = 0;
+
+        /* Use RVV to accelerate row sum computation */
+        size_t k = 0;
+        size_t vl;
+
+        /* Vectorized sum + copy. Initialize the full m4 accumulator with
+         * vsetvlmax so the unused tail lanes are well-defined zeros before
+         * the (smaller) per-iteration vl is used to add into them. Without
+         * this, vredsum below would fold uninitialized lanes into the
+         * row sum.
+         */
+        vint32m4_t vacc = __riscv_vmv_v_x_i32m4(0, __riscv_vsetvlmax_e32m4());
+        for (k = 0; k < CountK; ) {
+            vl = __riscv_vsetvl_e8m1(CountK - k);
+            vuint8m1_t va = __riscv_vle8_v_u8m1(A + k, vl);
+            if (BitFlipValue) {
+                va = __riscv_vxor_vx_u8m1(va, BitFlipValue, vl);
+            }
+            __riscv_vse8_v_u8m1(D + k, va, vl);
+
+            /* Widen to u16, then to u32, accumulate sum */
+            vuint16m2_t va16 = __riscv_vzext_vf2_u16m2(va, vl);
+            vuint32m4_t va32 = __riscv_vzext_vf2_u32m4(va16, vl);
+            vacc = __riscv_vadd_vv_i32m4(vacc, __riscv_vreinterpret_v_u32m4_i32m4(va32), vl);
+            k += vl;
+        }
+
+        /* Horizontal sum reduction */
+        vint32m1_t vsum = __riscv_vmv_v_x_i32m1(0, 1);
+        vsum = __riscv_vredsum_vs_i32m4_i32m1(vacc, vsum, __riscv_vsetvl_e32m4(CountK));
+        RowSum = __riscv_vmv_x_s_i32m1_i32(vsum);
+
+        /* Zero-pad remaining */
+        for (size_t p = CountK; p < AlignedCountK; p++) {
+            D[p] = 0;
+        }
+
+        *RowSumBuffer++ = RowSum;
+        A += lda;
+        D += AlignedCountK;
+    }
+}
+
+/* ── Pack B: column-major copy with column sum computation ──
+ *
+ * RVV optimized: use vlse8 (strided load) to gather column data from
+ * row-major B matrix. Replaces scalar per-byte copy with vectorized
+ * strided load + vectorized column sum.
+ *
+ * B layout: row-major [K × ldb], column n starts at B[n], stride=ldb
+ * D layout: column-packed [N × AlignedK], column n at D[n*AlignedK]
+ */
+
+template<>
+void
+MlasGemmQuantCopyPackB<MLAS_GEMM_QUANT_KERNEL_RVV>(
+    MLAS_GEMM_QUANT_KERNEL_RVV::PackedBType* D,
+    const uint8_t* B,
+    size_t ldb,
+    size_t CountN,
+    size_t CountK,
+    int32_t* ColumnSumBuffer,
+    bool BIsSigned
+    )
+{
+    const size_t AlignedCountK = (CountK + MLAS_GEMM_QUANT_KERNEL_RVV::PackedK - 1) &
+                                 ~(MLAS_GEMM_QUANT_KERNEL_RVV::PackedK - 1);
+    const uint8_t BitFlipValue = (BIsSigned ? 0x80 : 0);
+
+    for (size_t n = 0; n < CountN; n++) {
+        const uint8_t* b = B + n;
+        int32_t ColSum = 0;
+
+        /* RVV strided load: gather column from row-major matrix.
+         * Initialize the m4 column-sum accumulator across the full vlmax
+         * so vredsum below sees zero in tail lanes (see RowSum comment).
+         */
+        size_t k = 0;
+        vint32m4_t vsum = __riscv_vmv_v_x_i32m4(0, __riscv_vsetvlmax_e32m4());
+
+        while (k < CountK) {
+            size_t vl = __riscv_vsetvl_e8m1(CountK - k);
+            /* Strided load: load B[k*ldb+n], B[(k+1)*ldb+n], ... */
+            vuint8m1_t vb = __riscv_vlse8_v_u8m1(b + k * ldb, (ptrdiff_t)ldb, vl);
+            if (BitFlipValue) {
+                vb = __riscv_vxor_vx_u8m1(vb, BitFlipValue, vl);
+            }
+            /* Contiguous store to packed output */
+            __riscv_vse8_v_u8m1(D + k, vb, vl);
+            /* Accumulate column sum: widen u8→u16→u32 and add */
+            vuint16m2_t vb16 = __riscv_vzext_vf2_u16m2(vb, vl);
+            vuint32m4_t vb32 = __riscv_vzext_vf2_u32m4(vb16, vl);
+            vsum = __riscv_vadd_vv_i32m4(vsum, __riscv_vreinterpret_v_u32m4_i32m4(vb32), vl);
+            k += vl;
+        }
+
+        /* Horizontal sum */
+        vint32m1_t vzero = __riscv_vmv_v_x_i32m1(0, 1);
+        ColSum = __riscv_vmv_x_s_i32m1_i32(
+            __riscv_vredsum_vs_i32m4_i32m1(vsum, vzero, __riscv_vsetvl_e32m4(CountK)));
+
+        /* Zero-pad remaining */
+        for (size_t p = CountK; p < AlignedCountK; p++) {
+            D[p] = 0;
+        }
+
+        ColumnSumBuffer[n] = ColSum;
+        D += AlignedCountK;
+    }
+}
+
+/* ── INT8 GEMM microkernel using vwmacc.vv ──
+ *
+ * Computes: C[m][n] += sum_k(A[m][k] * B[k][n]) for INT8 inputs → INT32 output
+ * Uses vwmacc.vv: widening multiply-accumulate (INT8 × INT8 → INT32)
+ *
+ * A is packed row-major: [M, AlignedK] as uint8_t
+ * B is packed column-major: [N, AlignedK] as uint8_t (transposed)
+ * C is row-major: [M, N] as int32_t
+ */
+
+template<>
+size_t
+MlasGemmQuantKernel<MLAS_GEMM_QUANT_KERNEL_RVV>(
+    const MLAS_GEMM_QUANT_KERNEL_RVV::PackedAType* A,
+    const MLAS_GEMM_QUANT_KERNEL_RVV::PackedBType* B,
+    int32_t* C,
+    size_t PackedCountK,
+    size_t CountM,
+    size_t CountN,
+    size_t ldc,
+    const int32_t* RowSumBuffer,
+    const int32_t* ColumnSumBuffer,
+    const int32_t* ZeroPointB,
+    bool ZeroMode
+    )
+{
+    /*
+     * RVV INT8 GEMM kernel v4 — 4-row × N-col
+     * Processes 4 rows at a time (return 4), sharing B loads across rows.
+     * For each B column, compute 4 dot products: A[0..3] · B
+     *
+     * vs FP32 4x16 kernel: FP32 does 4 rows × 16 cols per K step.
+     * INT8 does 4 rows × 1 col per K step but with 32 elements/vector (vs 8).
+     * Net: INT8 processes 4×32=128 multiply-adds per vector op set,
+     *       FP32 processes 4×8=32 per vfmacc → INT8 4x more products/step.
+     */
+
+    if (CountM == 0 || CountN == 0) {
+        return 0;
+    }
+
+    const size_t AlignedK = PackedCountK * MLAS_GEMM_QUANT_KERNEL_RVV::PackedK;
+    // 4-row tile is the only optimized path. CountM<4 falls through to the
+    // 1-row loop, whose RowsHandled is also 1, so MlasGemmQuantOperation
+    // re-enters for the remaining rows. TODO: add a real 2-row tile if a
+    // profile shows CountM∈{2,3} is a hot path.
+    size_t RowsHandled = (CountM >= 4) ? 4 : 1;
+
+    /*
+     * Optimized: process 4 B columns at a time, sharing A loads across columns.
+     * Each K step: load 4 A rows (shared) + 4 B columns → 16 dot products.
+     * Reduces A memory reads by 4x compared to per-column processing.
+     *
+     * LMUL: e8m1 (32 elements/vector) for loads,
+     *        u16m2 for widening multiply, u32m4 for accumulation.
+     * 4 rows × 4 cols = 16 accumulators, but we use scalar accumulators
+     * with vector reduction (each dot product reduces to 1 scalar).
+     *
+     * Register budget per 4-col group:
+     *   4 A loads (m1) + 4 B loads (m1) = 8 v-regs
+     *   4 vwmulu results (m2) = 8 v-regs (reused across rows)
+     *   4 vzext results (m4) = 16 v-regs (reused)
+     *   Total peak: ~16 v-regs < 32, fits.
+     */
+    const uint8_t* b_base = B;
+    size_t n = 0;
+
+    /* ═══ 4-row × 1-col path ═══
+     *
+     * v3: Fix register pressure. Use 4 accumulators (not 8/16).
+     *
+     * Register budget (VLEN=256, 32 v-regs):
+     *   4 acc × e32m4 = 16 regs
+     *   4 A loads × e8m1 = 4 regs
+     *   1 B load × e8m1 = 1 reg
+     *   4 vwmulu temps × e16m2 = reused in pipeline
+     *   Total: 21 regs ← fits, no spill!
+     *
+     * Each K step: 32 elements × 4 rows = 128 MACs
+     * Instructions: 5 loads + 4 vwmulu + 4 vwaddu_wv + 1 addi + 1 branch = 15
+     * = 0.117 inst/MAC (vs old 0.516 inst/MAC = 4.4x better)
+     */
+    for (; n < CountN && RowsHandled == 4; n += 1) {
+        // ZeroPointB == nullptr means per-matrix quant: qgemm.h pre-scales
+        // RowSumBuffer by -ZeroPointB, so add it directly (per-column scales it).
+        int32_t Acc0 = RowSumBuffer[0];
+        int32_t Acc1 = RowSumBuffer[1];
+        int32_t Acc2 = RowSumBuffer[2];
+        int32_t Acc3 = RowSumBuffer[3];
+        if (ZeroPointB != nullptr) {
+            Acc0 *= ZeroPointB[n];
+            Acc1 *= ZeroPointB[n];
+            Acc2 *= ZeroPointB[n];
+            Acc3 *= ZeroPointB[n];
+        }
+        Acc0 += ColumnSumBuffer[n];
+        Acc1 += ColumnSumBuffer[n];
+        Acc2 += ColumnSumBuffer[n];
+        Acc3 += ColumnSumBuffer[n];
+
+        const uint8_t* a0 = A;
+        const uint8_t* a1 = A + AlignedK;
+        const uint8_t* a2 = A + 2 * AlignedK;
+        const uint8_t* a3 = A + 3 * AlignedK;
+        const uint8_t* b = b_base + n * AlignedK;
+
+        /* 4 accumulators × e32m4 = 16 regs */
+        size_t vl32 = __riscv_vsetvl_e32m4(AlignedK);
+        vuint32m4_t vacc0 = __riscv_vmv_v_x_u32m4(0, vl32);
+        vuint32m4_t vacc1 = __riscv_vmv_v_x_u32m4(0, vl32);
+        vuint32m4_t vacc2 = __riscv_vmv_v_x_u32m4(0, vl32);
+        vuint32m4_t vacc3 = __riscv_vmv_v_x_u32m4(0, vl32);
+
+        size_t remaining = AlignedK;
+        while (remaining > 0) {
+            size_t vl = __riscv_vsetvl_e8m1(remaining);
+
+            /* Load 1 B column (shared across 4 A rows) */
+            vuint8m1_t vbv = __riscv_vle8_v_u8m1(b, vl);
+            /* Load 4 A rows */
+            vuint8m1_t va0v = __riscv_vle8_v_u8m1(a0, vl);
+            vuint8m1_t va1v = __riscv_vle8_v_u8m1(a1, vl);
+            vuint8m1_t va2v = __riscv_vle8_v_u8m1(a2, vl);
+            vuint8m1_t va3v = __riscv_vle8_v_u8m1(a3, vl);
+
+            /* 4 dot products: vwmulu(e8m1→e16m2) + vwaddu_wv(e32m4 += e16m2) */
+            vuint16m2_t vp0 = __riscv_vwmulu_vv_u16m2(va0v, vbv, vl);
+            vuint16m2_t vp1 = __riscv_vwmulu_vv_u16m2(va1v, vbv, vl);
+            vuint16m2_t vp2 = __riscv_vwmulu_vv_u16m2(va2v, vbv, vl);
+            vuint16m2_t vp3 = __riscv_vwmulu_vv_u16m2(va3v, vbv, vl);
+
+            vacc0 = __riscv_vwaddu_wv_u32m4(vacc0, vp0, vl);
+            vacc1 = __riscv_vwaddu_wv_u32m4(vacc1, vp1, vl);
+            vacc2 = __riscv_vwaddu_wv_u32m4(vacc2, vp2, vl);
+            vacc3 = __riscv_vwaddu_wv_u32m4(vacc3, vp3, vl);
+
+            a0 += vl; a1 += vl; a2 += vl; a3 += vl; b += vl;
+            remaining -= vl;
+        }
+
+        /* Reduce 4 accumulators: u32m4 → scalar */
+        vuint32m1_t vzero = __riscv_vmv_v_x_u32m1(0, 1);
+        Acc0 += (int32_t)__riscv_vmv_x_s_u32m1_u32(__riscv_vredsum_vs_u32m4_u32m1(vacc0, vzero, vl32));
+        Acc1 += (int32_t)__riscv_vmv_x_s_u32m1_u32(__riscv_vredsum_vs_u32m4_u32m1(vacc1, vzero, vl32));
+        Acc2 += (int32_t)__riscv_vmv_x_s_u32m1_u32(__riscv_vredsum_vs_u32m4_u32m1(vacc2, vzero, vl32));
+        Acc3 += (int32_t)__riscv_vmv_x_s_u32m1_u32(__riscv_vredsum_vs_u32m4_u32m1(vacc3, vzero, vl32));
+
+        /* Write back */
+        if (!ZeroMode) {
+            Acc0 += C[0]; Acc1 += C[ldc]; Acc2 += C[2*ldc]; Acc3 += C[3*ldc];
+        }
+        C[0] = Acc0; C[ldc] = Acc1; C[2*ldc] = Acc2; C[3*ldc] = Acc3;
+        C += 1;
+    }
+
+    /* Skip the 1-row fallback below for RowsHandled==4 (already handled) */
+    if (RowsHandled == 4) {
+        return RowsHandled;
+    }
+
+    /* ═══ 1-row fallback (CountM < 4) — RowsHandled already == 1 ═══ */
+    for (; n < CountN; n++) {
+        int32_t colsum = ColumnSumBuffer[n];
+
+        /* Single-row dot product — vwmulu (e8m1×e8m1 → e16m2) + vwaddu.wv (e32m4 += e16m2) */
+        int32_t Acc = RowSumBuffer[0];
+        if (ZeroPointB != nullptr) {
+            Acc *= ZeroPointB[n];
+        }
+        Acc += colsum;
+        const uint8_t* a = A;
+        const uint8_t* b = b_base + n * AlignedK;
+        size_t remaining = AlignedK;
+
+        size_t vl32 = __riscv_vsetvl_e32m4(remaining > 0 ? remaining : 1);
+        vuint32m4_t vacc = __riscv_vmv_v_x_u32m4(0, vl32);
+        while (remaining > 0) {
+            size_t vl = __riscv_vsetvl_e8m1(remaining);
+            vuint8m1_t vav = __riscv_vle8_v_u8m1(a, vl);
+            vuint8m1_t vbv = __riscv_vle8_v_u8m1(b, vl);
+            vuint16m2_t vp = __riscv_vwmulu_vv_u16m2(vav, vbv, vl);
+            vacc = __riscv_vwaddu_wv_u32m4(vacc, vp, vl);
+            a += vl; b += vl; remaining -= vl;
+        }
+        vuint32m1_t vzero = __riscv_vmv_v_x_u32m1(0, 1);
+        vuint32m1_t vs = __riscv_vredsum_vs_u32m4_u32m1(vacc, vzero, vl32);
+        Acc += (int32_t)__riscv_vmv_x_s_u32m1_u32(vs);
+        if (!ZeroMode) Acc += C[0];
+        C[0] = Acc;
+
+        C += 1;
+    }
+
+    /* Reset C pointer for next kernel call (MLAS advances by RowsHandled) */
+    return RowsHandled;
+}
+
+/* ── Dispatch table instantiation ── */
+
+// Single dispatch symbol for all four (A, B) signedness combinations: the
+// kernel handles signedness via MlasGemmQuantFixupZeroPointA/B (XOR 0x80)
+// internally, matching the WASM/LARCH64 pattern. The four MLAS_PLATFORM
+// fields in platform.cpp all alias this same struct.
+const MLAS_GEMM_QUANT_DISPATCH MlasGemmQuantDispatchRvv = {
+    MlasGemmQuantOperation<MLAS_GEMM_QUANT_KERNEL_RVV>,
+    nullptr,
+    nullptr,
+    MLAS_GEMM_QUANT_KERNEL_RVV::PackedK,
+    0,
+    MLAS_GEMM_QUANT_KERNEL_RVV::Strides.M,
+};

--- a/onnxruntime/core/mlas/lib/sgemm.cpp
+++ b/onnxruntime/core/mlas/lib/sgemm.cpp
@@ -1130,7 +1130,7 @@ Return Value:
             return;
         }
 
-#elif defined(MLAS_TARGET_ARM64) || defined(MLAS_TARGET_WASM)
+#elif defined(MLAS_TARGET_ARM64) || defined(MLAS_TARGET_WASM) || defined(MLAS_TARGET_RISCV64)
 
         if (TransB == CblasNoTrans) {
             MlasGemvFloatKernel(A, B, C, K, N, ldb, (beta == 0.0f));

--- a/onnxruntime/core/mlas/lib/silu.cpp
+++ b/onnxruntime/core/mlas/lib/silu.cpp
@@ -40,7 +40,7 @@ MlasComputeSilu(
     size_t N
     )
 {
-#if defined(MLAS_TARGET_AMD64)
+#if defined(MLAS_TARGET_AMD64) || defined(MLAS_TARGET_RISCV64)
     // TODO: Add an intermediate fused AVX2/FMA3 SiLU path on AMD64. Today the
     // dispatch jumps from the generic two-pass implementation to AVX512F, so
     // non-AVX512 x64 machines fall back to the generic kernel.

--- a/onnxruntime/core/mlas/lib/tanh.cpp
+++ b/onnxruntime/core/mlas/lib/tanh.cpp
@@ -178,7 +178,7 @@ Return Value:
 
 --*/
 {
-#if defined(MLAS_TARGET_AMD64)
+#if defined(MLAS_TARGET_AMD64) || defined(MLAS_TARGET_RISCV64)
     GetMlasPlatform().TanhKernelRoutine(Input, Output, N);
 #else
     MlasTanhKernel(Input, Output, N);

--- a/onnxruntime/test/mlas/unittest/test_activation_rvv.cpp
+++ b/onnxruntime/test/mlas/unittest/test_activation_rvv.cpp
@@ -57,7 +57,7 @@ class MlasActivationRvvBoundaryTest : public MlasTestBase {
     const float pinf = std::numeric_limits<float>::infinity();
     struct Expect {
       const char* name;
-      void (*fn)(const float*, float*, size_t);
+      void(MLASCALL* fn)(const float*, float*, size_t);
       float expected;
       bool allow_nan;
     } cases[] = {
@@ -99,7 +99,7 @@ class MlasActivationRvvBoundaryTest : public MlasTestBase {
     const float ninf = -std::numeric_limits<float>::infinity();
     struct Expect {
       const char* name;
-      void (*fn)(const float*, float*, size_t);
+      void(MLASCALL* fn)(const float*, float*, size_t);
       float expected;
     } cases[] = {
         {"Erf-Inf", MlasComputeErf, -1.0f},
@@ -205,17 +205,17 @@ class MlasActivationRvvBoundaryTest : public MlasTestBase {
 
     // Erf
     MlasComputeErf(in.data(), out.data(), N);
-    for (size_t i = 0; i < N; ++i) ref[i] = std::erff(in[i]);
+    for (size_t i = 0; i < N; ++i) ref[i] = std::erf(in[i]);
     CheckRel("Erf", out, ref, 5e-5f, 1e-5f);
 
     // Tanh
     MlasComputeTanh(in.data(), out.data(), N);
-    for (size_t i = 0; i < N; ++i) ref[i] = std::tanhf(in[i]);
+    for (size_t i = 0; i < N; ++i) ref[i] = std::tanh(in[i]);
     CheckRel("Tanh", out, ref, 5e-5f, 1e-5f);
 
     // Logistic (sigmoid)
     MlasComputeLogistic(in.data(), out.data(), N);
-    for (size_t i = 0; i < N; ++i) ref[i] = 1.0f / (1.0f + std::expf(-in[i]));
+    for (size_t i = 0; i < N; ++i) ref[i] = 1.0f / (1.0f + std::exp(-in[i]));
     CheckRel("Logistic", out, ref, 5e-5f, 1e-5f);
 
     // Exp — confine to non-overflowing range
@@ -224,7 +224,7 @@ class MlasActivationRvvBoundaryTest : public MlasTestBase {
       std::vector<float> exp_in(N), exp_out(N), exp_ref(N);
       for (size_t i = 0; i < N; ++i) exp_in[i] = exp_dist(gen);
       MlasComputeExp(exp_in.data(), exp_out.data(), N);
-      for (size_t i = 0; i < N; ++i) exp_ref[i] = std::expf(exp_in[i]);
+      for (size_t i = 0; i < N; ++i) exp_ref[i] = std::exp(exp_in[i]);
       // Exp grows fast: use a relative-only tolerance
       for (size_t i = 0; i < N; ++i) {
         if (!std::isfinite(exp_ref[i])) continue;
@@ -239,21 +239,21 @@ class MlasActivationRvvBoundaryTest : public MlasTestBase {
     // SiLU(x) = x * sigmoid(x)
     MlasComputeSilu(in.data(), out.data(), N);
     for (size_t i = 0; i < N; ++i) {
-      ref[i] = in[i] / (1.0f + std::expf(-in[i]));
+      ref[i] = in[i] / (1.0f + std::exp(-in[i]));
     }
     CheckRel("Silu", out, ref, 1e-4f, 1e-5f);
 
     // GeluErf(x) = 0.5 * x * (1 + erf(x / sqrt(2)))
     MlasComputeGeluErf(in.data(), out.data(), N);
     for (size_t i = 0; i < N; ++i) {
-      ref[i] = 0.5f * in[i] * (1.0f + std::erff(in[i] * 0.7071067811865476f));
+      ref[i] = 0.5f * in[i] * (1.0f + std::erf(in[i] * 0.7071067811865476f));
     }
     CheckRel("GeluErf", out, ref, 1e-4f, 1e-5f);
   }
 
   struct KernelEntry {
     const char* name;
-    void (*fn)(const float*, float*, size_t);
+    void(MLASCALL* fn)(const float*, float*, size_t);
   };
 
   static constexpr KernelEntry kAllKernels[] = {

--- a/onnxruntime/test/mlas/unittest/test_activation_rvv.cpp
+++ b/onnxruntime/test/mlas/unittest/test_activation_rvv.cpp
@@ -1,0 +1,277 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Boundary + random-fuzz tests for the RISC-V RVV activation kernels
+// (Erf / Tanh / Logistic / Exp / SiLU / GELU). These kernels diverge from
+// the scalar reference path by (a) replacing libm-style exp with a packed
+// 2^n + minimax polynomial approximation, (b) clamping inputs before the
+// exponent-bit reconstruction, and (c) inserting explicit `(±inf) * 0`
+// guards on SiLU/GELU. The existing test_activation.cpp exercises the
+// MLAS_ACTIVATION_KIND surface (Identity/Relu/LeakyRelu/Tanh/Logistic/
+// Clip/HardSigmoid) but not the MlasComputeUnary* entry points — these
+// tests fill that gap and pin the kernels' contract under NaN, ±Inf,
+// large negatives, and EXP_RECON_MIN/MAX boundary inputs.
+
+#include "test_util.h"
+
+#include <cmath>
+#include <cstring>
+#include <random>
+
+class MlasActivationRvvBoundaryTest : public MlasTestBase {
+ public:
+  static const char* GetTestSuiteName() {
+    static const std::string suite_name("ActivationRvvBoundary");
+    return suite_name.c_str();
+  }
+
+  void ExecuteShort(void) override {
+    TestBoundaryNaN();
+    TestBoundaryPositiveInf();
+    TestBoundaryNegativeInf();
+    TestBoundarySiluGeluLargeNegative();
+    TestBoundaryExpReconLimits();
+    TestRandomVsScalar();
+  }
+
+ private:
+  // ─── Boundary cases ─────────────────────────────────────────────────────
+
+  void TestBoundaryNaN() {
+    constexpr size_t N = 8;
+    const float qnan = std::nanf("");
+    for (auto& kernel : kAllKernels) {
+      float in[N], out[N];
+      for (size_t i = 0; i < N; ++i) in[i] = qnan;
+      std::memcpy(out, in, sizeof(out));
+      kernel.fn(out, out, N);
+      for (size_t i = 0; i < N; ++i) {
+        EXPECT_TRUE(std::isnan(out[i]))
+            << kernel.name << " did not propagate NaN at i=" << i;
+      }
+    }
+  }
+
+  void TestBoundaryPositiveInf() {
+    constexpr size_t N = 4;
+    const float pinf = std::numeric_limits<float>::infinity();
+    struct Expect {
+      const char* name;
+      void (*fn)(const float*, float*, size_t);
+      float expected;
+      bool allow_nan;
+    } cases[] = {
+        {"Erf+Inf", MlasComputeErf, 1.0f, false},
+        {"Tanh+Inf", MlasComputeTanh, 1.0f, false},
+        {"Logistic+Inf", MlasComputeLogistic, 1.0f, false},
+        // exp(+inf) = +inf; some impls saturate to FLT_MAX, accept either.
+        {"Exp+Inf", MlasComputeExp, pinf, true},
+        // SiLU(+inf) = +inf * sigmoid(+inf) = +inf * 1 = +inf
+        {"Silu+Inf", MlasComputeSilu, pinf, true},
+    };
+    for (auto& c : cases) {
+      float in[N], out[N];
+      for (size_t i = 0; i < N; ++i) in[i] = pinf;
+      c.fn(in, out, N);
+      for (size_t i = 0; i < N; ++i) {
+        const bool ok = out[i] == c.expected ||
+                        (c.allow_nan && std::isnan(out[i])) ||
+                        (c.allow_nan && out[i] >= std::numeric_limits<float>::max() * 0.5f);
+        EXPECT_TRUE(ok)
+            << c.name << " at i=" << i
+            << " got " << out[i] << " expected " << c.expected;
+      }
+    }
+    // GeluErf(+inf) → +inf (or saturated to FLT_MAX)
+    {
+      float in[N], out[N];
+      for (size_t i = 0; i < N; ++i) in[i] = pinf;
+      MlasComputeGeluErf(in, out, N);
+      for (size_t i = 0; i < N; ++i) {
+        EXPECT_TRUE(out[i] == pinf || out[i] >= std::numeric_limits<float>::max() * 0.5f)
+            << "GeluErf+Inf at i=" << i << " got " << out[i];
+      }
+    }
+  }
+
+  void TestBoundaryNegativeInf() {
+    constexpr size_t N = 4;
+    const float ninf = -std::numeric_limits<float>::infinity();
+    struct Expect {
+      const char* name;
+      void (*fn)(const float*, float*, size_t);
+      float expected;
+    } cases[] = {
+        {"Erf-Inf", MlasComputeErf, -1.0f},
+        {"Tanh-Inf", MlasComputeTanh, -1.0f},
+        {"Logistic-Inf", MlasComputeLogistic, 0.0f},
+        // exp(-inf) = 0 (after clamp inside exp_f32m4)
+        {"Exp-Inf", MlasComputeExp, 0.0f},
+    };
+    for (auto& c : cases) {
+      float in[N], out[N];
+      for (size_t i = 0; i < N; ++i) in[i] = ninf;
+      c.fn(in, out, N);
+      for (size_t i = 0; i < N; ++i) {
+        EXPECT_EQ(out[i], c.expected)
+            << c.name << " at i=" << i << " got " << out[i];
+      }
+    }
+  }
+
+  void TestBoundarySiluGeluLargeNegative() {
+    // SiLU(x) = x * sigmoid(x). For very negative x, sigmoid(x) → 0,
+    // so SiLU(x) → 0 (well-defined). The RVV kernel adds a LOGISTIC_CLAMP
+    // and an `(±inf) * 0 → NaN` guard so naive (-inf) * 0 does not leak.
+    // Same idea for GELU(x) ≈ 0 for very negative x via the SMALLEST_NORMAL_F32
+    // floor.
+    constexpr size_t N = 8;
+    const float large_neg[N] = {-1000.0f, -500.0f, -200.0f, -100.0f,
+                                -88.5f, -90.0f, -120.0f, -50.0f};
+    float out_silu[N], out_gelu[N];
+    MlasComputeSilu(large_neg, out_silu, N);
+    MlasComputeGeluErf(large_neg, out_gelu, N);
+    for (size_t i = 0; i < N; ++i) {
+      EXPECT_FALSE(std::isnan(out_silu[i]))
+          << "SiLU(" << large_neg[i] << ") produced NaN — inf*0 guard failed";
+      EXPECT_LE(std::fabs(out_silu[i]), 1e-3f)
+          << "SiLU(" << large_neg[i] << ") should be ~0, got " << out_silu[i];
+      EXPECT_FALSE(std::isnan(out_gelu[i]))
+          << "GeluErf(" << large_neg[i] << ") produced NaN";
+      EXPECT_LE(std::fabs(out_gelu[i]), 1e-3f)
+          << "GeluErf(" << large_neg[i] << ") should be ~0, got " << out_gelu[i];
+    }
+  }
+
+  void TestBoundaryExpReconLimits() {
+    // exp_f32m4 uses 2^n exponent-bit reconstruction with an internal clamp.
+    // Inputs at the edges of the recon range must produce finite, monotone
+    // results — not Inf, NaN, or sign flips.
+    constexpr size_t N = 8;
+    const float boundary[N] = {-88.5f, -88.0f, -87.5f, -1.0f,
+                               1.0f, 87.0f, 87.5f, 88.0f};
+    float out[N];
+    MlasComputeExp(boundary, out, N);
+    float prev = -1.0f;
+    for (size_t i = 0; i < N; ++i) {
+      EXPECT_TRUE(std::isfinite(out[i]))
+          << "Exp boundary[" << i << "]=" << boundary[i]
+          << " produced non-finite " << out[i];
+      EXPECT_GE(out[i], 0.0f)
+          << "Exp should be non-negative at boundary[" << i << "]";
+      EXPECT_GE(out[i], prev)
+          << "Exp monotonicity broken between boundary[" << (i - 1)
+          << "]=" << (i > 0 ? boundary[i - 1] : 0.0f)
+          << " and boundary[" << i << "]=" << boundary[i];
+      prev = out[i];
+    }
+  }
+
+  // ─── Random fuzz against scalar reference ───────────────────────────────
+
+  void TestRandomVsScalar() {
+    // 1000 random inputs in [-50, 50] — a realistic production range for
+    // activation inputs (Transformer/CNN intermediate features) — each
+    // compared against the scalar libm reference. RVV kernels approximate
+    // with a 6th-order minimax polynomial + range reduction, so we accept
+    // up to ~32 ULP for transcendentals, matching what AVX2 specializations
+    // tolerate in the existing test infrastructure.
+    constexpr size_t N = 1000;
+    std::mt19937 gen(0xC0FFEE);
+    std::uniform_real_distribution<float> dist(-50.0f, 50.0f);
+
+    std::vector<float> in(N);
+    for (size_t i = 0; i < N; ++i) in[i] = dist(gen);
+
+    auto CheckRel = [&in](const char* name,
+                          const std::vector<float>& fast,
+                          const std::vector<float>& ref,
+                          float abs_tol,
+                          float rel_tol) {
+      ASSERT_EQ(fast.size(), ref.size()) << name;
+      for (size_t i = 0; i < fast.size(); ++i) {
+        const float a = fast[i];
+        const float b = ref[i];
+        if (!std::isfinite(b)) continue;  // skip overflow points
+        const float diff = std::fabs(a - b);
+        const float scale = std::max(std::fabs(b), 1.0f);
+        EXPECT_LE(diff, abs_tol + rel_tol * scale)
+            << name << " at i=" << i << " in=" << in[i]
+            << " fast=" << a << " ref=" << b << " diff=" << diff;
+      }
+    };
+
+    std::vector<float> out(N), ref(N);
+
+    // Erf
+    MlasComputeErf(in.data(), out.data(), N);
+    for (size_t i = 0; i < N; ++i) ref[i] = std::erff(in[i]);
+    CheckRel("Erf", out, ref, 5e-5f, 1e-5f);
+
+    // Tanh
+    MlasComputeTanh(in.data(), out.data(), N);
+    for (size_t i = 0; i < N; ++i) ref[i] = std::tanhf(in[i]);
+    CheckRel("Tanh", out, ref, 5e-5f, 1e-5f);
+
+    // Logistic (sigmoid)
+    MlasComputeLogistic(in.data(), out.data(), N);
+    for (size_t i = 0; i < N; ++i) ref[i] = 1.0f / (1.0f + std::expf(-in[i]));
+    CheckRel("Logistic", out, ref, 5e-5f, 1e-5f);
+
+    // Exp — confine to non-overflowing range
+    {
+      std::uniform_real_distribution<float> exp_dist(-30.0f, 30.0f);
+      std::vector<float> exp_in(N), exp_out(N), exp_ref(N);
+      for (size_t i = 0; i < N; ++i) exp_in[i] = exp_dist(gen);
+      MlasComputeExp(exp_in.data(), exp_out.data(), N);
+      for (size_t i = 0; i < N; ++i) exp_ref[i] = std::expf(exp_in[i]);
+      // Exp grows fast: use a relative-only tolerance
+      for (size_t i = 0; i < N; ++i) {
+        if (!std::isfinite(exp_ref[i])) continue;
+        const float rel = std::fabs(exp_out[i] - exp_ref[i]) /
+                          std::max(std::fabs(exp_ref[i]), 1e-12f);
+        EXPECT_LE(rel, 5e-5f)
+            << "Exp rel err at i=" << i << " in=" << exp_in[i]
+            << " fast=" << exp_out[i] << " ref=" << exp_ref[i];
+      }
+    }
+
+    // SiLU(x) = x * sigmoid(x)
+    MlasComputeSilu(in.data(), out.data(), N);
+    for (size_t i = 0; i < N; ++i) {
+      ref[i] = in[i] / (1.0f + std::expf(-in[i]));
+    }
+    CheckRel("Silu", out, ref, 1e-4f, 1e-5f);
+
+    // GeluErf(x) = 0.5 * x * (1 + erf(x / sqrt(2)))
+    MlasComputeGeluErf(in.data(), out.data(), N);
+    for (size_t i = 0; i < N; ++i) {
+      ref[i] = 0.5f * in[i] * (1.0f + std::erff(in[i] * 0.7071067811865476f));
+    }
+    CheckRel("GeluErf", out, ref, 1e-4f, 1e-5f);
+  }
+
+  struct KernelEntry {
+    const char* name;
+    void (*fn)(const float*, float*, size_t);
+  };
+
+  static constexpr KernelEntry kAllKernels[] = {
+      {"Erf", MlasComputeErf},
+      {"Tanh", MlasComputeTanh},
+      {"Logistic", MlasComputeLogistic},
+      {"Exp", MlasComputeExp},
+      {"Silu", MlasComputeSilu},
+      {"GeluErf", MlasComputeGeluErf},
+  };
+};
+
+constexpr MlasActivationRvvBoundaryTest::KernelEntry
+    MlasActivationRvvBoundaryTest::kAllKernels[];
+
+static UNUSED_VARIABLE bool added_rvv_boundary_to_main = AddTestRegister(
+    [](bool is_short_execute) {
+      return is_short_execute
+                 ? MlasDirectShortExecuteTests<MlasActivationRvvBoundaryTest>::RegisterShortExecute()
+                 : 0;
+    });


### PR DESCRIPTION
## Description

Follow-up to #28261 (RVV CPU EP). This PR adds four RVV MLAS kernels on
top of the existing `if(HAS_RISCV64_RVV)` block in
`cmake/onnxruntime_mlas.cmake`:

1. **INT8 GEMM** (`riscv64/qgemm_kernel_rvv.cpp`) — `vwmulu.vv` /
   `vwaddu.wv` widening; wired through `MLAS_PLATFORM` 4-signedness
   dispatch (LARCH64 idiom).
2. **M=1 SGEMM routing** — extends the ARM64/WASM `MlasGemvFloatKernel`
   `#elif` to RISCV64; kernel comes from existing `SgemvKernelScalar.cpp`
   (rv-gcc autovec).
3. **Activation kernels** (`riscv64/activation_kernel_rvv.cpp`) — RVV
   `Erf`, `Tanh`, `Logistic`, `ComputeExpF32`, `Silu`, `GeluErf`.
4. **INT8 GEMV M=1 fast path** — `MlasGemmQuantTryGemvKernel<...RVV>`
   specialization (mirrors AVX2 `qgemm_kernel_avx2.cpp:131`); U8×S8 only.

Rebased onto current `main`. Later commits fold in review feedback:
per-signedness dispatch structs, the per-matrix `ZeroPointB` accumulator,
NaN round-trip in the activation kernels, a full-range two-step `exp`,
and infinity handling in SiLU/GELU. The correctness fixes are verified on
SpacemiT K3 (riscv64, RVV) with `onnxruntime_mlas_test`.
## Performance

K3 (SpacemiT X100, VLEN=256, 4 threads, p50 ms over 30 reps, real
BAAI/bge-* ONNX inputs). Baseline = `microsoft/onnxruntime` post-#28261
(`62f742f1aa`).  
Cross-built with `riscv64-linux-gnu-g++` 15.2 + `-march=rv64gcv -mabi=lp64d`.

### FP32 transformer encoders

| Model                          | Upstream  | This PR   | Speedup |
| ------------------------------ | --------: | --------: | :-----: |
| BAAI/bge-small-zh-v1.5         |   66.3 ms |   63.8 ms |  1.04×  |
| BAAI/bge-base-zh-v1.5          |  404.4 ms |  393.5 ms |  1.03×  |
| BAAI/bge-reranker-base         |  403.7 ms |  391.7 ms |  1.03×  |

### INT8 quantized

| Model                          | Upstream  | This PR   | Speedup |
| ------------------------------ | --------: | --------: | :-----: |
| BAAI/bge-small-zh-v1.5 INT8    |  301.3 ms |  131.3 ms |  2.29×  |
| BAAI/bge-base-zh-v1.5 INT8     | 1958.8 ms |  669.2 ms |  **2.93×** |
| BAAI/bge-reranker-base INT8    | 1956.8 ms |  668.6 ms |  **2.93×** |

### INT8 GEMV M=1 (kernel-level micro-bench, 1 thread)

| Shape       |  scalar  | autovec  | this PR  | vs autovec |
| ----------- | -------: | -------: | -------: | :--------: |
| K=N=384     | 1.45 GOPS | 2.34 GOPS | 16.68 GOPS | **7.13×** |
| K=N=768     | 1.46 GOPS | 2.34 GOPS |  6.17 GOPS |  2.64×  |
| K=N=4096    | 1.46 GOPS | 2.33 GOPS |  1.92 GOPS |  0.82× (memory-bound) |

The GEMV path triggers only when `RangeCountM == 1` and zero-points are
zero (`qgemm.h:331` gate); BERT seq=128 encoders do not exercise it, so
its contribution is not visible in the e2e tables above.

