### PR TITLE
fix(ci): incorrect relative template includes for setup-feeds

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -47,7 +47,7 @@ jobs:
     submodules: none
 
   # Authenticate to Lotus to pull pip in UsePythonVersion task
-  - template: ../templates/setup-feeds-and-python-steps.yml
+  - template: setup-feeds-and-python-steps.yml
     parameters:
       architecture: ${{ parameters.OnnxruntimeArch }}
 

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-linux-test-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-linux-test-cpu.yml
@@ -50,7 +50,7 @@ jobs:
   - download: build   # pipeline resource identifier.
     artifact: 'onnxruntime-${{ parameters.arch }}-${{ parameters.ep }}'
 
-  - template: templates/setup-feeds-and-python-steps.yml
+  - template: setup-feeds-and-python-steps.yml
     parameters:
       architecture: ${{ parameters.arch }}
 

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-linux-test-cuda.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-linux-test-cuda.yml
@@ -64,7 +64,7 @@ jobs:
     clean: true
     submodules: none
 
-  - template: templates/setup-feeds-and-python-steps.yml
+  - template: setup-feeds-and-python-steps.yml
     parameters:
       architecture: ${{ parameters.arch }}
 


### PR DESCRIPTION
### Description

Fix more bad relative includes for `setup-feeds-and-python-steps.yml`.

### Motivation and Context

Fixes CI test pipelines, which are currently broken.


