### PR TITLE
Refactor and modernize StringNormalizer.

### DIFF
--- a/onnxruntime/core/common/utf8_util.h
+++ b/onnxruntime/core/common/utf8_util.h
@@ -5,6 +5,8 @@
 
 #include "core/common/common.h"
 
+#include <string>
+
 namespace onnxruntime {
 namespace utf8_util {
 
@@ -24,12 +26,11 @@ inline bool utf8_bytes(unsigned char ch, size_t& len) {
     len = 2;
     return true;
   }
-  unsigned int result = (ch & 0xF0);
-  if (result == 0xE0) {
+  if ((ch & 0xF0) == 0xE0) {
     len = 3;
     return true;
   }
-  if (result == 0xF0) {
+  if ((ch & 0xF8) == 0xF0) {
     len = 4;
     return true;
   }
@@ -148,4 +149,167 @@ inline bool utf8_validate(const unsigned char* s, size_t len, size_t& utf8_chars
 }
 
 }  // namespace utf8_util
+
+// UTF-8 <-> wchar_t (UTF-32 on non-Windows) conversion utilities.
+// These assume wchar_t is at least 32 bits (Linux, macOS, wasm).
+// On Windows, use the Win32 MultiByteToWideChar/WideCharToMultiByte APIs instead.
+#ifndef _WIN32
+
+/// Compute the number of UTF-8 bytes required to encode a wide string.
+inline size_t WideToUtf8RequiredSize(const std::wstring& wstr) {
+  size_t result = 0;
+  for (wchar_t wc : wstr) {
+    char32_t cp = static_cast<char32_t>(wc);
+    if (cp <= 0x7F) {
+      result += 1;
+    } else if (cp <= 0x7FF) {
+      result += 2;
+    } else if (cp <= 0xFFFF) {
+      result += 3;
+    } else if (cp <= 0x10FFFF) {
+      result += 4;
+    } else {
+      ORT_THROW("Invalid Unicode codepoint U+", std::hex, static_cast<uint32_t>(cp));
+    }
+  }
+  return result;
+}
+
+/// Convert a wide string to UTF-8, writing into a pre-allocated std::string.
+/// The string is resized to the actual number of bytes written.
+inline Status WideToUtf8(const std::wstring& wstr, std::string& str) {
+  if (wstr.empty()) {
+    str.clear();
+    return Status::OK();
+  }
+
+  char* dest = str.data();
+  char* dest_end = dest + str.size();
+
+  for (wchar_t wc : wstr) {
+    char32_t cp = static_cast<char32_t>(wc);
+    if (cp <= 0x7F) {
+      if (dest >= dest_end) break;
+      *dest++ = static_cast<char>(cp);
+    } else if (cp <= 0x7FF) {
+      if (dest + 1 >= dest_end) break;
+      *dest++ = static_cast<char>(0xC0 | (cp >> 6));
+      *dest++ = static_cast<char>(0x80 | (cp & 0x3F));
+    } else if (cp <= 0xFFFF) {
+      if (dest + 2 >= dest_end) break;
+      *dest++ = static_cast<char>(0xE0 | (cp >> 12));
+      *dest++ = static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+      *dest++ = static_cast<char>(0x80 | (cp & 0x3F));
+    } else if (cp <= 0x10FFFF) {
+      if (dest + 3 >= dest_end) break;
+      *dest++ = static_cast<char>(0xF0 | (cp >> 18));
+      *dest++ = static_cast<char>(0x80 | ((cp >> 12) & 0x3F));
+      *dest++ = static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+      *dest++ = static_cast<char>(0x80 | (cp & 0x3F));
+    } else {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                             "Invalid Unicode codepoint during UTF-8 conversion");
+    }
+  }
+
+  str.resize(static_cast<size_t>(dest - str.data()));
+  return Status::OK();
+}
+
+/// Convert a UTF-8 string to a wide string, writing into a pre-allocated std::wstring.
+/// The wstring is resized to the actual number of characters written.
+/// Validates continuation bytes and rejects overlong encodings and surrogates.
+inline Status Utf8ToWide(const std::string& str, std::wstring& wstr) {
+  if (str.empty()) {
+    wstr.clear();
+    return Status::OK();
+  }
+
+  const auto* src = reinterpret_cast<const unsigned char*>(str.data());
+  const auto* src_end = src + str.size();
+  wchar_t* dest = wstr.data();
+
+  while (src < src_end) {
+    char32_t cp = 0;
+    size_t byte_len = 0;
+
+    if ((*src & 0x80) == 0) {
+      cp = *src;
+      byte_len = 1;
+    } else if ((*src & 0xE0) == 0xC0) {
+      byte_len = 2;
+      if (static_cast<size_t>(src_end - src) < 2) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Truncated UTF-8 sequence");
+      }
+      if ((src[1] & 0xC0) != 0x80) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Invalid UTF-8 continuation byte");
+      }
+      cp = (static_cast<char32_t>(src[0] & 0x1F) << 6) |
+           static_cast<char32_t>(src[1] & 0x3F);
+      // Reject overlong encoding (must be >= 0x80 for 2-byte)
+      if (cp < 0x80) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Overlong UTF-8 encoding");
+      }
+    } else if ((*src & 0xF0) == 0xE0) {
+      byte_len = 3;
+      if (static_cast<size_t>(src_end - src) < 3) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Truncated UTF-8 sequence");
+      }
+      if ((src[1] & 0xC0) != 0x80 || (src[2] & 0xC0) != 0x80) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Invalid UTF-8 continuation byte");
+      }
+      cp = (static_cast<char32_t>(src[0] & 0x0F) << 12) |
+           (static_cast<char32_t>(src[1] & 0x3F) << 6) |
+           static_cast<char32_t>(src[2] & 0x3F);
+      // Reject overlong encoding (must be >= 0x800 for 3-byte)
+      if (cp < 0x800) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Overlong UTF-8 encoding");
+      }
+      // Reject UTF-16 surrogates (U+D800..U+DFFF)
+      if (cp >= 0xD800 && cp <= 0xDFFF) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Invalid UTF-8: surrogate codepoint");
+      }
+    } else if ((*src & 0xF8) == 0xF0) {
+      byte_len = 4;
+      if (static_cast<size_t>(src_end - src) < 4) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Truncated UTF-8 sequence");
+      }
+      if ((src[1] & 0xC0) != 0x80 || (src[2] & 0xC0) != 0x80 || (src[3] & 0xC0) != 0x80) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Invalid UTF-8 continuation byte");
+      }
+      cp = (static_cast<char32_t>(src[0] & 0x07) << 18) |
+           (static_cast<char32_t>(src[1] & 0x3F) << 12) |
+           (static_cast<char32_t>(src[2] & 0x3F) << 6) |
+           static_cast<char32_t>(src[3] & 0x3F);
+      // Reject overlong encoding (must be >= 0x10000 for 4-byte)
+      if (cp < 0x10000) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Overlong UTF-8 encoding");
+      }
+      // Reject codepoints beyond Unicode range
+      if (cp > 0x10FFFF) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Invalid UTF-8: codepoint beyond U+10FFFF");
+      }
+    } else {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Invalid UTF-8 lead byte");
+    }
+
+    *dest++ = static_cast<wchar_t>(cp);
+    src += byte_len;
+  }
+
+  wstr.resize(static_cast<size_t>(dest - wstr.data()));
+  return Status::OK();
+}
+
+/// Convenience: convert UTF-8 string to wstring (throws on error).
+inline std::wstring Utf8ToWideString(const std::string& s) {
+  // UTF-8 byte count is an upper bound on wchar_t count
+  std::wstring result;
+  result.resize(s.size());
+  ORT_THROW_IF_ERROR(Utf8ToWide(s, result));
+  return result;
+}
+
+#endif  // !_WIN32
+
 }  // namespace onnxruntime

--- a/onnxruntime/core/common/utf8_util.h
+++ b/onnxruntime/core/common/utf8_util.h
@@ -65,6 +65,11 @@ inline bool utf8_validate(const unsigned char* s, size_t len, size_t& utf8_chars
         case 1:
           break;
         case 2: {
+          // Reject overlong 2-byte sequences. Valid Unicode 2-byte encodings
+          // start at U+0080, so lead bytes 0xC0 and 0xC1 are invalid.
+          if (ch < 0xC2u) {
+            return false;
+          }
           if (++idx >= len || s[idx] < 0x80u || s[idx] > 0xBFu) {
             return false;
           }
@@ -150,10 +155,19 @@ inline bool utf8_validate(const unsigned char* s, size_t len, size_t& utf8_chars
 
 }  // namespace utf8_util
 
-// UTF-8 <-> wchar_t (UTF-32 on non-Windows) conversion utilities.
-// These assume wchar_t is at least 32 bits (Linux, macOS, wasm).
+// UTF-8 <-> wchar_t conversion utilities for non-Windows builds.
+// These helpers operate on one wchar_t code unit per Unicode scalar value.
+// They are fully Unicode-correct on platforms where wchar_t stores scalar values
+// directly, which is commonly the case for 32-bit wchar_t builds such as Linux,
+// macOS, and wasm.
+// They do not implement UTF-16 surrogate-pair handling, so non-Windows builds
+// with 16-bit wchar_t cannot represent supplementary-plane characters correctly
+// via these helpers.
 // On Windows, use the Win32 MultiByteToWideChar/WideCharToMultiByte APIs instead.
 #ifndef _WIN32
+
+static_assert(sizeof(wchar_t) >= 4,
+              "Non-Windows UTF-8/wchar_t conversion helpers require wchar_t to be at least 32 bits.");
 
 /// Compute the number of UTF-8 bytes required to encode a wide string.
 inline size_t WideToUtf8RequiredSize(const std::wstring& wstr) {

--- a/onnxruntime/core/common/utf8_util.h
+++ b/onnxruntime/core/common/utf8_util.h
@@ -174,6 +174,9 @@ inline size_t WideToUtf8RequiredSize(const std::wstring& wstr) {
   size_t result = 0;
   for (wchar_t wc : wstr) {
     char32_t cp = static_cast<char32_t>(wc);
+    if (cp >= 0xD800 && cp <= 0xDFFF) {
+      ORT_THROW("Invalid Unicode surrogate codepoint U+", std::hex, static_cast<uint32_t>(cp));
+    }
     if (cp <= 0x7F) {
       result += 1;
     } else if (cp <= 0x7FF) {
@@ -202,20 +205,32 @@ inline Status WideToUtf8(const std::wstring& wstr, std::string& str) {
 
   for (wchar_t wc : wstr) {
     char32_t cp = static_cast<char32_t>(wc);
+    if (cp >= 0xD800 && cp <= 0xDFFF) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                             "Invalid Unicode surrogate codepoint during UTF-8 conversion");
+    }
     if (cp <= 0x7F) {
-      if (dest >= dest_end) break;
+      if (dest >= dest_end) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Destination buffer too small for UTF-8 conversion");
+      }
       *dest++ = static_cast<char>(cp);
     } else if (cp <= 0x7FF) {
-      if (dest + 1 >= dest_end) break;
+      if (dest + 1 >= dest_end) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Destination buffer too small for UTF-8 conversion");
+      }
       *dest++ = static_cast<char>(0xC0 | (cp >> 6));
       *dest++ = static_cast<char>(0x80 | (cp & 0x3F));
     } else if (cp <= 0xFFFF) {
-      if (dest + 2 >= dest_end) break;
+      if (dest + 2 >= dest_end) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Destination buffer too small for UTF-8 conversion");
+      }
       *dest++ = static_cast<char>(0xE0 | (cp >> 12));
       *dest++ = static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
       *dest++ = static_cast<char>(0x80 | (cp & 0x3F));
     } else if (cp <= 0x10FFFF) {
-      if (dest + 3 >= dest_end) break;
+      if (dest + 3 >= dest_end) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Destination buffer too small for UTF-8 conversion");
+      }
       *dest++ = static_cast<char>(0xF0 | (cp >> 18));
       *dest++ = static_cast<char>(0x80 | ((cp >> 12) & 0x3F));
       *dest++ = static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
@@ -237,6 +252,10 @@ inline Status Utf8ToWide(const std::string& str, std::wstring& wstr) {
   if (str.empty()) {
     wstr.clear();
     return Status::OK();
+  }
+
+  if (wstr.size() < str.size()) {
+    wstr.resize(str.size());
   }
 
   const auto* src = reinterpret_cast<const unsigned char*>(str.data());

--- a/onnxruntime/core/common/utf8_util.h
+++ b/onnxruntime/core/common/utf8_util.h
@@ -11,12 +11,13 @@ namespace onnxruntime {
 namespace utf8_util {
 
 /// <summary>
-/// Checks the extension bytes and returns a number of
-/// bytes in the UTF-8 character
+/// Classifies a UTF-8 lead byte by encoded length.
+/// This is a structural prefix check only; full well-formedness validation
+/// is handled by utf8_validate.
 /// </summary>
-/// <param name="ch"></param>
-/// <param name="len">result</param>
-/// <returns>false if the char len is greater than 4 otherwise true</returns>
+/// <param name="ch">lead byte candidate</param>
+/// <param name="len">decoded byte length</param>
+/// <returns>false if the byte does not match any 1-4 byte UTF-8 lead-byte prefix</returns>
 inline bool utf8_bytes(unsigned char ch, size_t& len) {
   if ((ch & 0x80) == 0) {
     len = 1;
@@ -152,8 +153,6 @@ inline bool utf8_validate(const unsigned char* s, size_t len, size_t& utf8_chars
   utf8_chars = utf8_len;
   return true;
 }
-
-}  // namespace utf8_util
 
 // UTF-8 <-> wchar_t conversion utilities for non-Windows builds.
 // These helpers operate on one wchar_t code unit per Unicode scalar value.
@@ -345,4 +344,5 @@ inline std::wstring Utf8ToWideString(const std::string& s) {
 
 #endif  // !_WIN32
 
+}  // namespace utf8_util
 }  // namespace onnxruntime

--- a/onnxruntime/core/common/utf8_util.h
+++ b/onnxruntime/core/common/utf8_util.h
@@ -209,25 +209,29 @@ inline Status WideToUtf8(const std::wstring& wstr, std::string& str) {
                              "Invalid Unicode surrogate codepoint during UTF-8 conversion");
     }
     if (cp <= 0x7F) {
-      if (dest >= dest_end) {
+      const size_t remaining = static_cast<size_t>(dest_end - dest);
+      if (remaining < 1) {
         return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Destination buffer too small for UTF-8 conversion");
       }
       *dest++ = static_cast<char>(cp);
     } else if (cp <= 0x7FF) {
-      if (dest + 1 >= dest_end) {
+      const size_t remaining = static_cast<size_t>(dest_end - dest);
+      if (remaining < 2) {
         return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Destination buffer too small for UTF-8 conversion");
       }
       *dest++ = static_cast<char>(0xC0 | (cp >> 6));
       *dest++ = static_cast<char>(0x80 | (cp & 0x3F));
     } else if (cp <= 0xFFFF) {
-      if (dest + 2 >= dest_end) {
+      const size_t remaining = static_cast<size_t>(dest_end - dest);
+      if (remaining < 3) {
         return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Destination buffer too small for UTF-8 conversion");
       }
       *dest++ = static_cast<char>(0xE0 | (cp >> 12));
       *dest++ = static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
       *dest++ = static_cast<char>(0x80 | (cp & 0x3F));
     } else if (cp <= 0x10FFFF) {
-      if (dest + 3 >= dest_end) {
+      const size_t remaining = static_cast<size_t>(dest_end - dest);
+      if (remaining < 4) {
         return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Destination buffer too small for UTF-8 conversion");
       }
       *dest++ = static_cast<char>(0xF0 | (cp >> 18));

--- a/onnxruntime/core/providers/cpu/text/string_normalizer.cc
+++ b/onnxruntime/core/providers/cpu/text/string_normalizer.cc
@@ -330,6 +330,13 @@ Status StringNormalizer::Compute(OpKernelContext* ctx) const {
                   "Input dimensions are either[C > 0] or [1][C > 0] allowed");
   }
 
+  auto validate_utf8 = [](const std::string& value) {
+    size_t utf8_chars = 0;
+    ORT_RETURN_IF_NOT(utf8_util::utf8_validate(reinterpret_cast<const unsigned char*>(value.data()), value.size(), utf8_chars),
+                      "Input strings must be valid UTF-8");
+    return Status::OK();
+  };
+
   // Special case, no filtering and no case change
   if (case_change_action_ == NONE &&
       ((is_case_sensitive_ && stopwords_.empty()) ||
@@ -337,7 +344,10 @@ Status StringNormalizer::Compute(OpKernelContext* ctx) const {
     output_shape.push_back(C);
     auto output_tensor = ctx->Output(0, output_shape);
     auto const output_data = output_tensor->MutableData<std::string>();
-    std::copy(input_span.begin(), input_span.end(), output_data);
+    for (size_t i = 0, lim = input_span.size(); i < lim; ++i) {
+      ORT_RETURN_IF_ERROR(validate_utf8(input_span[i]));
+      output_data[i] = input_span[i];
+    }
     return Status::OK();
   }
 
@@ -423,6 +433,7 @@ Status StringNormalizer::Compute(OpKernelContext* ctx) const {
 
       for (size_t i = 0, lim = input_span.size(); i < lim; ++i) {
         const std::string& s = input_span[i];
+        ORT_RETURN_IF_ERROR(validate_utf8(s));
         if (stopwords_.count(s) == 0) {
           filtered_strings_indices.push_back(i);
         }

--- a/onnxruntime/core/providers/cpu/text/string_normalizer.cc
+++ b/onnxruntime/core/providers/cpu/text/string_normalizer.cc
@@ -5,6 +5,7 @@
 
 #include "string_normalizer.h"
 #include "core/common/common.h"
+#include "core/common/utf8_util.h"
 #include "core/framework/tensor.h"
 
 #ifdef _MSC_VER
@@ -26,176 +27,34 @@ ONNX_CPU_OPERATOR_KERNEL(
 
 namespace string_normalizer {
 
-// Manual UTF-8 <-> wchar_t (UTF-32 on non-Windows) converter.
-// Replaces the deprecated std::codecvt_utf8<wchar_t>.
+#ifndef _MSC_VER
+// Thin wrapper around the common utf8_util functions, providing the same interface
+// as Utf8ConverterWindows so the code below can use either via the Utf8Converter alias.
 class Utf8ConverterGeneric {
  public:
   size_t ComputeRequiredSizeToUtf8(const std::wstring& wstr) const {
-    if (wstr.empty()) {
-      return 0;
-    }
-
-    size_t result = 0;
-    for (wchar_t wc : wstr) {
-      char32_t cp = static_cast<char32_t>(wc);
-      if (cp <= 0x7F) {
-        result += 1;
-      } else if (cp <= 0x7FF) {
-        result += 2;
-      } else if (cp <= 0xFFFF) {
-        result += 3;
-      } else if (cp <= 0x10FFFF) {
-        result += 4;
-      } else {
-        ORT_THROW("Invalid Unicode codepoint U+", std::hex, static_cast<uint32_t>(cp));
-      }
-    }
-    return result;
+    return WideToUtf8RequiredSize(wstr);
   }
 
   Status ConvertToUtf8(const std::wstring& wstr, std::string& str) const {
-    if (wstr.empty()) {
-      str.clear();
-      return Status::OK();
-    }
-
-    char* dest = str.data();
-    char* dest_end = dest + str.size();
-
-    for (wchar_t wc : wstr) {
-      char32_t cp = static_cast<char32_t>(wc);
-      if (cp <= 0x7F) {
-        if (dest >= dest_end) break;
-        *dest++ = static_cast<char>(cp);
-      } else if (cp <= 0x7FF) {
-        if (dest + 1 >= dest_end) break;
-        *dest++ = static_cast<char>(0xC0 | (cp >> 6));
-        *dest++ = static_cast<char>(0x80 | (cp & 0x3F));
-      } else if (cp <= 0xFFFF) {
-        if (dest + 2 >= dest_end) break;
-        *dest++ = static_cast<char>(0xE0 | (cp >> 12));
-        *dest++ = static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
-        *dest++ = static_cast<char>(0x80 | (cp & 0x3F));
-      } else if (cp <= 0x10FFFF) {
-        if (dest + 3 >= dest_end) break;
-        *dest++ = static_cast<char>(0xF0 | (cp >> 18));
-        *dest++ = static_cast<char>(0x80 | ((cp >> 12) & 0x3F));
-        *dest++ = static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
-        *dest++ = static_cast<char>(0x80 | (cp & 0x3F));
-      } else {
-        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
-                               "Invalid Unicode codepoint during UTF-8 conversion");
-      }
-    }
-
-    str.resize(static_cast<size_t>(dest - str.data()));
-    return Status::OK();
+    return WideToUtf8(wstr, str);
   }
 
   Status ComputeRequiredSizeToWideChar(const std::string& str, size_t& wchars) {
-    if (str.empty()) {
-      wchars = 0;
-      return Status::OK();
-    }
-
-    size_t result = 0;
-    const auto* src = reinterpret_cast<const unsigned char*>(str.data());
-    const auto* src_end = src + str.size();
-
-    while (src < src_end) {
-      size_t byte_len = 0;
-      if ((*src & 0x80) == 0) {
-        byte_len = 1;
-      } else if ((*src & 0xE0) == 0xC0) {
-        byte_len = 2;
-      } else if ((*src & 0xF0) == 0xE0) {
-        byte_len = 3;
-      } else if ((*src & 0xF8) == 0xF0) {
-        byte_len = 4;
-      } else {
-        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
-                               "Invalid UTF-8 lead byte at offset ",
-                               static_cast<size_t>(src - reinterpret_cast<const unsigned char*>(str.data())));
-      }
-
-      if (static_cast<size_t>(src_end - src) < byte_len) {
-        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
-                               "Truncated UTF-8 sequence at offset ",
-                               static_cast<size_t>(src - reinterpret_cast<const unsigned char*>(str.data())));
-      }
-
-      src += byte_len;
-      ++result;
-    }
-
-    wchars = result;
+    // UTF-8 byte count is an upper bound on wchar_t count; use it directly.
+    wchars = str.size();
     return Status::OK();
   }
 
   Status ConvertToWideChar(const std::string& str, std::wstring& wstr) {
-    if (str.empty()) {
-      wstr.clear();
-      return Status::OK();
-    }
-
-    const auto* src = reinterpret_cast<const unsigned char*>(str.data());
-    const auto* src_end = src + str.size();
-    wchar_t* dest = wstr.data();
-
-    while (src < src_end) {
-      char32_t cp = 0;
-      size_t byte_len = 0;
-
-      if ((*src & 0x80) == 0) {
-        cp = *src;
-        byte_len = 1;
-      } else if ((*src & 0xE0) == 0xC0) {
-        byte_len = 2;
-        if (static_cast<size_t>(src_end - src) < 2) {
-          return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Truncated UTF-8 sequence");
-        }
-        cp = (static_cast<char32_t>(src[0] & 0x1F) << 6) |
-             static_cast<char32_t>(src[1] & 0x3F);
-      } else if ((*src & 0xF0) == 0xE0) {
-        byte_len = 3;
-        if (static_cast<size_t>(src_end - src) < 3) {
-          return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Truncated UTF-8 sequence");
-        }
-        cp = (static_cast<char32_t>(src[0] & 0x0F) << 12) |
-             (static_cast<char32_t>(src[1] & 0x3F) << 6) |
-             static_cast<char32_t>(src[2] & 0x3F);
-      } else if ((*src & 0xF8) == 0xF0) {
-        byte_len = 4;
-        if (static_cast<size_t>(src_end - src) < 4) {
-          return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Truncated UTF-8 sequence");
-        }
-        cp = (static_cast<char32_t>(src[0] & 0x07) << 18) |
-             (static_cast<char32_t>(src[1] & 0x3F) << 12) |
-             (static_cast<char32_t>(src[2] & 0x3F) << 6) |
-             static_cast<char32_t>(src[3] & 0x3F);
-      } else {
-        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Invalid UTF-8 lead byte");
-      }
-
-      *dest++ = static_cast<wchar_t>(cp);
-      src += byte_len;
-    }
-
-    wstr.resize(static_cast<size_t>(dest - wstr.data()));
-    return Status::OK();
+    return Utf8ToWide(str, wstr);
   }
 
   std::wstring from_bytes(const std::string& s) {
-    std::wstring result;
-
-    size_t wchars = 0;
-    ORT_THROW_IF_ERROR(ComputeRequiredSizeToWideChar(s, wchars));
-
-    result.resize(wchars);
-    ORT_THROW_IF_ERROR(ConvertToWideChar(s, result));
-    return result;
+    return Utf8ToWideString(s);
   }
 };
+#endif  // !_MSC_VER
 
 // We need to specialize for MS as there is
 // a std::locale creation bug that affects different
@@ -550,31 +409,6 @@ Status StringNormalizer::Compute(OpKernelContext* ctx) const {
     return Status::OK();
   };
 
-  // Output filtered strings with pre-computed wide forms (avoids double conversion).
-  auto output_filtered_with_wide = [&](const TensorShape& output_shape,
-                                       gsl::span<const size_t> filtered_indices,
-                                       InlinedVector<std::wstring>& wide_forms) {
-    auto output_tensor = ctx->Output(0, output_shape);
-    auto output_data = output_tensor->MutableData<std::string>();
-    for (size_t idx = 0; idx < filtered_indices.size(); ++idx) {
-      if (case_change_action_ != NONE) {
-        // wide_forms were lowercased for comparison; re-convert from original and apply target case
-        const std::string& s = input_span[filtered_indices[idx]];
-        wchar_buffer.resize(max_wide_buffer_len);
-        ORT_RETURN_IF_ERROR(converter.ConvertToWideChar(s, wchar_buffer));
-        locale.ChangeCase(case_change_action_, wchar_buffer);
-
-        auto& dest = *output_data++;
-        size_t utf8_buffer_len = converter.ComputeRequiredSizeToUtf8(wchar_buffer);
-        dest.resize(utf8_buffer_len);
-        ORT_RETURN_IF_ERROR(converter.ConvertToUtf8(wchar_buffer, dest));
-      } else {
-        *output_data++ = input_span[filtered_indices[idx]];
-      }
-    }
-    return Status::OK();
-  };
-
   Status status;
 
   if (is_case_sensitive_) {
@@ -605,16 +439,10 @@ Status StringNormalizer::Compute(OpKernelContext* ctx) const {
       status = output_no_filtering(output_shape);
     } else {
       // Case insensitive filtering: convert to wchar_t and case-fold for comparison.
-      // If case_change_action_ matches compare_caseaction_, we can reuse the wide form
-      // directly for output, avoiding a second conversion.
-      const bool can_reuse_wide = (case_change_action_ == compare_caseaction_);
-
+      // Re-conversion during output is cheaper than caching N wide strings (each requiring
+      // a heap allocation), especially under multi-threaded contention for the allocator lock.
       InlinedVector<size_t> filtered_strings_indices;
-      InlinedVector<std::wstring> filtered_wide_forms;
       filtered_strings_indices.reserve(input_span.size());
-      if (can_reuse_wide) {
-        filtered_wide_forms.reserve(input_span.size());
-      }
 
       for (size_t i = 0, lim = input_span.size(); i < lim; ++i) {
         const std::string& s = input_span[i];
@@ -623,30 +451,12 @@ Status StringNormalizer::Compute(OpKernelContext* ctx) const {
         locale.ChangeCase(compare_caseaction_, wchar_buffer);
         if (wstopwords_.count(wchar_buffer) == 0) {
           filtered_strings_indices.push_back(i);
-          if (can_reuse_wide) {
-            filtered_wide_forms.push_back(wchar_buffer);
-          }
         }
       }
 
       const int64_t filtered_count = std::max<int64_t>(1, narrow<int64_t>(filtered_strings_indices.size()));
       output_shape.push_back(filtered_count);
-
-      if (can_reuse_wide && case_change_action_ != NONE) {
-        // Reuse the already case-converted wide forms directly for output
-        auto output_tensor = ctx->Output(0, output_shape);
-        auto output_data = output_tensor->MutableData<std::string>();
-        for (size_t idx = 0; idx < filtered_strings_indices.size(); ++idx) {
-          const std::wstring& wide = filtered_wide_forms[idx];
-          auto& dest = *output_data++;
-          size_t utf8_buffer_len = converter.ComputeRequiredSizeToUtf8(wide);
-          dest.resize(utf8_buffer_len);
-          ORT_RETURN_IF_ERROR(converter.ConvertToUtf8(wide, dest));
-        }
-        status = Status::OK();
-      } else {
-        status = output_filtered_with_wide(output_shape, filtered_strings_indices, filtered_wide_forms);
-      }
+      status = output_filtered(output_shape, filtered_strings_indices);
     }
   }
 

--- a/onnxruntime/core/providers/cpu/text/string_normalizer.cc
+++ b/onnxruntime/core/providers/cpu/text/string_normalizer.cc
@@ -6,24 +6,14 @@
 #include "string_normalizer.h"
 #include "core/common/common.h"
 #include "core/framework/tensor.h"
-// Used below HAS_DEPRECATED_DECLARATIONS
-#include "onnxruntime_config.h"
 
 #ifdef _MSC_VER
 #include <Windows.h>
 #include <locale.h>
 #endif  // _MSC_VER
 
-#include <codecvt>
 #include <locale>
 #include <functional>
-
-#if defined(__GNUC__)
-// Allow deprecated-declarations warning - std::codecvt_utf8 is deprecatedd
-#if defined(HAS_DEPRECATED_DECLARATIONS)
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-#endif  // defined(HAS_DEPRECATED_DECLARATIONS)
-#endif  // defined(__GNUC__)
 
 namespace onnxruntime {
 
@@ -36,7 +26,8 @@ ONNX_CPU_OPERATOR_KERNEL(
 
 namespace string_normalizer {
 
-// codecvt_utf8 is deprecated, we will want to replace it with our class
+// Manual UTF-8 <-> wchar_t (UTF-32 on non-Windows) converter.
+// Replaces the deprecated std::codecvt_utf8<wchar_t>.
 class Utf8ConverterGeneric {
  public:
   size_t ComputeRequiredSizeToUtf8(const std::wstring& wstr) const {
@@ -45,82 +36,59 @@ class Utf8ConverterGeneric {
     }
 
     size_t result = 0;
-    std::mbstate_t state = std::mbstate_t();
-
-    const wchar_t* src = wstr.data();
-    const wchar_t* src_end = src + wstr.length();
-
-    char dummy_dest[128] = {0};
-
-    char* char_next = dummy_dest;
-    const wchar_t* wchar_next = src;
-
-    size_t converted = 0;
-
-    std::codecvt_base::result ret_code = std::codecvt_base::ok;
-
-    // Continue while we exhaust the sequence
-    while (converted < wstr.length()) {
-      ret_code = converter_.out(state,
-                                wchar_next,
-                                src_end,
-                                wchar_next,
-                                std::begin(dummy_dest),
-                                std::end(dummy_dest),
-                                char_next);
-      result += (char_next - dummy_dest);
-      converted = (wchar_next - src);
-
-      if (ret_code != std::codecvt_base::partial &&
-          ret_code != std::codecvt_base::ok) {
-        break;
+    for (wchar_t wc : wstr) {
+      char32_t cp = static_cast<char32_t>(wc);
+      if (cp <= 0x7F) {
+        result += 1;
+      } else if (cp <= 0x7FF) {
+        result += 2;
+      } else if (cp <= 0xFFFF) {
+        result += 3;
+      } else if (cp <= 0x10FFFF) {
+        result += 4;
+      } else {
+        ORT_THROW("Invalid Unicode codepoint U+", std::hex, static_cast<uint32_t>(cp));
       }
     }
-
-    ORT_ENFORCE(ret_code != std::codecvt_base::noconv, "Conversion is expected");
-
-    if (ret_code != std::codecvt_base::ok) {
-      ORT_THROW("Failed to compute size for UTF-8. Converted only first: ",
-                converted, " codepoints out of: ", wstr.length());
-    }
-
     return result;
   }
 
-  // We assume the caller pre-allocated the correct length
   Status ConvertToUtf8(const std::wstring& wstr, std::string& str) const {
     if (wstr.empty()) {
       str.clear();
       return Status::OK();
     }
 
-    std::mbstate_t state = std::mbstate_t();
-
-    const wchar_t* src = wstr.data();
-    const wchar_t* src_end = src + wstr.length();
-
     char* dest = str.data();
-    char* dest_end = dest + str.length();
+    char* dest_end = dest + str.size();
 
-    char* char_next = dest;
-    const wchar_t* wchar_next = src;
-
-    std::codecvt_base::result ret_code = converter_.out(state,
-                                                        src,
-                                                        src_end,
-                                                        wchar_next,
-                                                        dest,
-                                                        dest_end,
-                                                        char_next);
-
-    if (ret_code != std::codecvt_base::ok) {
-      size_t converted = narrow<size_t>(wchar_next - wstr.data());
-      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to convert to UTF-8. Converted only first: ",
-                             converted, " codepoints out of: ", wstr.length());
+    for (wchar_t wc : wstr) {
+      char32_t cp = static_cast<char32_t>(wc);
+      if (cp <= 0x7F) {
+        if (dest >= dest_end) break;
+        *dest++ = static_cast<char>(cp);
+      } else if (cp <= 0x7FF) {
+        if (dest + 1 >= dest_end) break;
+        *dest++ = static_cast<char>(0xC0 | (cp >> 6));
+        *dest++ = static_cast<char>(0x80 | (cp & 0x3F));
+      } else if (cp <= 0xFFFF) {
+        if (dest + 2 >= dest_end) break;
+        *dest++ = static_cast<char>(0xE0 | (cp >> 12));
+        *dest++ = static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+        *dest++ = static_cast<char>(0x80 | (cp & 0x3F));
+      } else if (cp <= 0x10FFFF) {
+        if (dest + 3 >= dest_end) break;
+        *dest++ = static_cast<char>(0xF0 | (cp >> 18));
+        *dest++ = static_cast<char>(0x80 | ((cp >> 12) & 0x3F));
+        *dest++ = static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+        *dest++ = static_cast<char>(0x80 | (cp & 0x3F));
+      } else {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                               "Invalid Unicode codepoint during UTF-8 conversion");
+      }
     }
 
-    str.resize(char_next - dest);
-
+    str.resize(static_cast<size_t>(dest - str.data()));
     return Status::OK();
   }
 
@@ -131,83 +99,89 @@ class Utf8ConverterGeneric {
     }
 
     size_t result = 0;
-    std::mbstate_t state = std::mbstate_t();
+    const auto* src = reinterpret_cast<const unsigned char*>(str.data());
+    const auto* src_end = src + str.size();
 
-    const char* src = str.data();
-    const char* src_end = src + str.length();
-
-    wchar_t dummy_dest[128] = {0};
-    const char* char_next = src;
-    wchar_t* wchar_next = dummy_dest;
-
-    size_t converted = 0;
-
-    std::codecvt_base::result ret_code = std::codecvt_base::ok;
-    while (converted < str.length()) {
-      ret_code = converter_.in(state,
-                               char_next,
-                               src_end,
-                               char_next,
-                               std::begin(dummy_dest),
-                               std::end(dummy_dest),
-                               wchar_next);
-      result += (wchar_next - dummy_dest);
-      converted = (char_next - src);
-
-      if (ret_code != std::codecvt_base::partial &&
-          ret_code != std::codecvt_base::ok) {
-        break;
+    while (src < src_end) {
+      size_t byte_len = 0;
+      if ((*src & 0x80) == 0) {
+        byte_len = 1;
+      } else if ((*src & 0xE0) == 0xC0) {
+        byte_len = 2;
+      } else if ((*src & 0xF0) == 0xE0) {
+        byte_len = 3;
+      } else if ((*src & 0xF8) == 0xF0) {
+        byte_len = 4;
+      } else {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                               "Invalid UTF-8 lead byte at offset ",
+                               static_cast<size_t>(src - reinterpret_cast<const unsigned char*>(str.data())));
       }
-    }
 
-    ORT_ENFORCE(ret_code != std::codecvt_base::noconv, "Conversion is expected");
+      if (static_cast<size_t>(src_end - src) < byte_len) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                               "Truncated UTF-8 sequence at offset ",
+                               static_cast<size_t>(src - reinterpret_cast<const unsigned char*>(str.data())));
+      }
 
-    if (ret_code != std::codecvt_base::ok) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
-                             "Failed to compute buffer size for wchar_t. Converted only first: ",
-                             converted, " bytes out of: ", str.length(),
-                             " Source: ", src);
+      src += byte_len;
+      ++result;
     }
 
     wchars = result;
     return Status::OK();
   }
 
-  // We assume the destination buffer is preallocated correctly
   Status ConvertToWideChar(const std::string& str, std::wstring& wstr) {
     if (str.empty()) {
-      // Preserve the buffer for re-use, just set size to 0
       wstr.clear();
       return Status::OK();
     }
 
-    std::mbstate_t state = std::mbstate_t();
-    const char* src = str.data();
-    const char* src_end = src + str.length();
-
+    const auto* src = reinterpret_cast<const unsigned char*>(str.data());
+    const auto* src_end = src + str.size();
     wchar_t* dest = wstr.data();
-    wchar_t* dest_end = dest + wstr.length();
 
-    const char* char_next = src;
-    wchar_t* wchar_next = dest;
+    while (src < src_end) {
+      char32_t cp = 0;
+      size_t byte_len = 0;
 
-    std::codecvt_base::result ret_code = converter_.in(state,
-                                                       src,
-                                                       src_end,
-                                                       char_next,
-                                                       dest,
-                                                       dest_end,
-                                                       wchar_next);
+      if ((*src & 0x80) == 0) {
+        cp = *src;
+        byte_len = 1;
+      } else if ((*src & 0xE0) == 0xC0) {
+        byte_len = 2;
+        if (static_cast<size_t>(src_end - src) < 2) {
+          return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Truncated UTF-8 sequence");
+        }
+        cp = (static_cast<char32_t>(src[0] & 0x1F) << 6) |
+             static_cast<char32_t>(src[1] & 0x3F);
+      } else if ((*src & 0xF0) == 0xE0) {
+        byte_len = 3;
+        if (static_cast<size_t>(src_end - src) < 3) {
+          return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Truncated UTF-8 sequence");
+        }
+        cp = (static_cast<char32_t>(src[0] & 0x0F) << 12) |
+             (static_cast<char32_t>(src[1] & 0x3F) << 6) |
+             static_cast<char32_t>(src[2] & 0x3F);
+      } else if ((*src & 0xF8) == 0xF0) {
+        byte_len = 4;
+        if (static_cast<size_t>(src_end - src) < 4) {
+          return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Truncated UTF-8 sequence");
+        }
+        cp = (static_cast<char32_t>(src[0] & 0x07) << 18) |
+             (static_cast<char32_t>(src[1] & 0x3F) << 12) |
+             (static_cast<char32_t>(src[2] & 0x3F) << 6) |
+             static_cast<char32_t>(src[3] & 0x3F);
+      } else {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Invalid UTF-8 lead byte");
+      }
 
-    if (ret_code != std::codecvt_base::ok) {
-      size_t converted = narrow<size_t>(char_next - str.data());
-      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to convert to wchar_t. Converted only first: ",
-                             converted, " bytes out of: ", str.length(),
-                             " Source: ", src);
+      *dest++ = static_cast<wchar_t>(cp);
+      src += byte_len;
     }
 
-    wstr.resize(wchar_next - dest);
-
+    wstr.resize(static_cast<size_t>(dest - wstr.data()));
     return Status::OK();
   }
 
@@ -221,9 +195,6 @@ class Utf8ConverterGeneric {
     ORT_THROW_IF_ERROR(ConvertToWideChar(s, result));
     return result;
   }
-
- private:
-  std::codecvt_utf8<wchar_t> converter_;
 };
 
 // We need to specialize for MS as there is
@@ -416,15 +387,7 @@ class Locale {
   std::locale loc_;
 };
 
-#if defined(__APPLE__) || defined(__ANDROID__)
-
 using Utf8Converter = Utf8ConverterGeneric;
-
-#else
-
-using Utf8Converter = Utf8ConverterGeneric;
-
-#endif
 
 #if defined(__APPLE__)
 #include <TargetConditionals.h>
@@ -528,18 +491,25 @@ Status StringNormalizer::Compute(OpKernelContext* ctx) const {
   Locale locale(locale_name_);
   Utf8Converter converter;
 
-  // Compute the largest widestring buffer needed.
+  // Determine whether we need wchar conversion at all.
+  // We need it if: (a) case change is requested, or (b) case-insensitive filtering.
+  const bool needs_wchar = (case_change_action_ != NONE) || !is_case_sensitive_;
+
   size_t max_wide_buffer_len = 0;
-  for (const auto& s : input_span) {
-    size_t wchars = 0;
-    // Checks for invalid UTF-8 characters on Windows
-    ORT_RETURN_IF_ERROR(converter.ComputeRequiredSizeToWideChar(s, wchars));
-    max_wide_buffer_len = std::max(max_wide_buffer_len, wchars);
+  if (needs_wchar) {
+    // UTF-8 byte count is an upper bound on wchar_t count: each codepoint requires
+    // at least 1 byte but produces exactly 1 wchar_t (UTF-32) or at most 2 (UTF-16).
+    // This avoids a full UTF-8 decode pass just to compute buffer sizes.
+    for (const auto& s : input_span) {
+      max_wide_buffer_len = std::max(max_wide_buffer_len, s.size());
+    }
   }
 
   // Reuse reserved space
   std::wstring wchar_buffer;
-  wchar_buffer.reserve(max_wide_buffer_len);
+  if (needs_wchar) {
+    wchar_buffer.reserve(max_wide_buffer_len);
+  }
 
   // Output everything and change case as required
   auto output_no_filtering = [&](const TensorShape& output_shape) {
@@ -580,6 +550,31 @@ Status StringNormalizer::Compute(OpKernelContext* ctx) const {
     return Status::OK();
   };
 
+  // Output filtered strings with pre-computed wide forms (avoids double conversion).
+  auto output_filtered_with_wide = [&](const TensorShape& output_shape,
+                                       gsl::span<const size_t> filtered_indices,
+                                       InlinedVector<std::wstring>& wide_forms) {
+    auto output_tensor = ctx->Output(0, output_shape);
+    auto output_data = output_tensor->MutableData<std::string>();
+    for (size_t idx = 0; idx < filtered_indices.size(); ++idx) {
+      if (case_change_action_ != NONE) {
+        // wide_forms were lowercased for comparison; re-convert from original and apply target case
+        const std::string& s = input_span[filtered_indices[idx]];
+        wchar_buffer.resize(max_wide_buffer_len);
+        ORT_RETURN_IF_ERROR(converter.ConvertToWideChar(s, wchar_buffer));
+        locale.ChangeCase(case_change_action_, wchar_buffer);
+
+        auto& dest = *output_data++;
+        size_t utf8_buffer_len = converter.ComputeRequiredSizeToUtf8(wchar_buffer);
+        dest.resize(utf8_buffer_len);
+        ORT_RETURN_IF_ERROR(converter.ConvertToUtf8(wchar_buffer, dest));
+      } else {
+        *output_data++ = input_span[filtered_indices[idx]];
+      }
+    }
+    return Status::OK();
+  };
+
   Status status;
 
   if (is_case_sensitive_) {
@@ -588,7 +583,7 @@ Status StringNormalizer::Compute(OpKernelContext* ctx) const {
       output_shape.push_back(C);
       status = output_no_filtering(output_shape);
     } else {
-      // we need to filter
+      // Case-sensitive filtering: direct string compare, no wchar needed for comparison.
       InlinedVector<size_t> filtered_strings_indices;
       filtered_strings_indices.reserve(input_span.size());
 
@@ -599,8 +594,6 @@ Status StringNormalizer::Compute(OpKernelContext* ctx) const {
         }
       }
 
-      // According to the spec, if all strings are filtered out
-      // the output must have a shape of {1} with a single empty string.
       const int64_t filtered_count = std::max<int64_t>(1, narrow<int64_t>(filtered_strings_indices.size()));
       output_shape.push_back(filtered_count);
       status = output_filtered(output_shape, filtered_strings_indices);
@@ -611,11 +604,18 @@ Status StringNormalizer::Compute(OpKernelContext* ctx) const {
       output_shape.push_back(C);
       status = output_no_filtering(output_shape);
     } else {
-      // Case insensitive filtering is performed by converting the input strings
-      // to compare_caseaction_. For that we convert to wchar_t UNICODE.
-      // Otherwise, we need to pull ICU library on all platforms.
+      // Case insensitive filtering: convert to wchar_t and case-fold for comparison.
+      // If case_change_action_ matches compare_caseaction_, we can reuse the wide form
+      // directly for output, avoiding a second conversion.
+      const bool can_reuse_wide = (case_change_action_ == compare_caseaction_);
+
       InlinedVector<size_t> filtered_strings_indices;
+      InlinedVector<std::wstring> filtered_wide_forms;
       filtered_strings_indices.reserve(input_span.size());
+      if (can_reuse_wide) {
+        filtered_wide_forms.reserve(input_span.size());
+      }
+
       for (size_t i = 0, lim = input_span.size(); i < lim; ++i) {
         const std::string& s = input_span[i];
         wchar_buffer.resize(max_wide_buffer_len);
@@ -623,14 +623,30 @@ Status StringNormalizer::Compute(OpKernelContext* ctx) const {
         locale.ChangeCase(compare_caseaction_, wchar_buffer);
         if (wstopwords_.count(wchar_buffer) == 0) {
           filtered_strings_indices.push_back(i);
+          if (can_reuse_wide) {
+            filtered_wide_forms.push_back(wchar_buffer);
+          }
         }
       }
 
-      // According to the spec, if all strings are filtered out
-      // the output must have a shape of {1} with a single empty string.
       const int64_t filtered_count = std::max<int64_t>(1, narrow<int64_t>(filtered_strings_indices.size()));
       output_shape.push_back(filtered_count);
-      status = output_filtered(output_shape, filtered_strings_indices);
+
+      if (can_reuse_wide && case_change_action_ != NONE) {
+        // Reuse the already case-converted wide forms directly for output
+        auto output_tensor = ctx->Output(0, output_shape);
+        auto output_data = output_tensor->MutableData<std::string>();
+        for (size_t idx = 0; idx < filtered_strings_indices.size(); ++idx) {
+          const std::wstring& wide = filtered_wide_forms[idx];
+          auto& dest = *output_data++;
+          size_t utf8_buffer_len = converter.ComputeRequiredSizeToUtf8(wide);
+          dest.resize(utf8_buffer_len);
+          ORT_RETURN_IF_ERROR(converter.ConvertToUtf8(wide, dest));
+        }
+        status = Status::OK();
+      } else {
+        status = output_filtered_with_wide(output_shape, filtered_strings_indices, filtered_wide_forms);
+      }
     }
   }
 

--- a/onnxruntime/core/providers/cpu/text/string_normalizer.cc
+++ b/onnxruntime/core/providers/cpu/text/string_normalizer.cc
@@ -33,11 +33,11 @@ namespace string_normalizer {
 class Utf8ConverterGeneric {
  public:
   size_t ComputeRequiredSizeToUtf8(const std::wstring& wstr) const {
-    return WideToUtf8RequiredSize(wstr);
+    return utf8_util::WideToUtf8RequiredSize(wstr);
   }
 
   Status ConvertToUtf8(const std::wstring& wstr, std::string& str) const {
-    return WideToUtf8(wstr, str);
+    return utf8_util::WideToUtf8(wstr, str);
   }
 
   Status ComputeRequiredSizeToWideChar(const std::string& str, size_t& wchars) {
@@ -47,11 +47,11 @@ class Utf8ConverterGeneric {
   }
 
   Status ConvertToWideChar(const std::string& str, std::wstring& wstr) {
-    return Utf8ToWide(str, wstr);
+    return utf8_util::Utf8ToWide(str, wstr);
   }
 
   std::wstring from_bytes(const std::string& s) {
-    return Utf8ToWideString(s);
+    return utf8_util::Utf8ToWideString(s);
   }
 };
 #endif  // !_WIN32
@@ -445,7 +445,7 @@ Status StringNormalizer::Compute(OpKernelContext* ctx) const {
       output_shape.push_back(C);
       status = output_no_filtering(output_shape);
     } else {
-      // Case insensitive filtering: convert to wchar_t and case-fold for comparison.
+      // Case insensitive filtering: convert to wchar_t and lowercase for comparison.
       // Re-conversion during output is cheaper than caching N wide strings (each requiring
       // a heap allocation), especially under multi-threaded contention for the allocator lock.
       InlinedVector<size_t> filtered_strings_indices;

--- a/onnxruntime/core/providers/cpu/text/string_normalizer.cc
+++ b/onnxruntime/core/providers/cpu/text/string_normalizer.cc
@@ -8,10 +8,10 @@
 #include "core/common/utf8_util.h"
 #include "core/framework/tensor.h"
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #include <Windows.h>
 #include <locale.h>
-#endif  // _MSC_VER
+#endif  // _WIN32
 
 #include <locale>
 #include <functional>
@@ -27,7 +27,7 @@ ONNX_CPU_OPERATOR_KERNEL(
 
 namespace string_normalizer {
 
-#ifndef _MSC_VER
+#ifndef _WIN32
 // Thin wrapper around the common utf8_util functions, providing the same interface
 // as Utf8ConverterWindows so the code below can use either via the Utf8Converter alias.
 class Utf8ConverterGeneric {
@@ -54,47 +54,12 @@ class Utf8ConverterGeneric {
     return Utf8ToWideString(s);
   }
 };
-#endif  // !_MSC_VER
+#endif  // !_WIN32
 
 // We need to specialize for MS as there is
 // a std::locale creation bug that affects different
 // environments in a different way
-#ifdef _MSC_VER
-
-class Locale {
- public:
-  explicit Locale(const std::string& name)
-      : loc_(nullptr) {
-    loc_ = _create_locale(LC_CTYPE, name.c_str());
-    if (loc_ == nullptr) {
-      ORT_THROW("Failed to construct locale with name:",
-                name, ":", ":Please, install necessary language-pack-XX and configure locales");
-    }
-  }
-
-  ~Locale() {
-    if (loc_ != nullptr) {
-      _free_locale(loc_);
-    }
-  }
-
-  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(Locale);
-
-  void ChangeCase(StringNormalizer::CaseAction caseaction,
-                  std::wstring& wstr) const {
-    assert(caseaction != StringNormalizer::NONE);
-    if (caseaction == StringNormalizer::LOWER) {
-      std::transform(wstr.begin(), wstr.end(), wstr.begin(),
-                     [this](wchar_t ch) { return ::_towlower_l(ch, loc_); });
-    } else {
-      std::transform(wstr.begin(), wstr.end(), wstr.begin(),
-                     [this](wchar_t ch) { return ::_towupper_l(ch, loc_); });
-    }
-  }
-
- private:
-  _locale_t loc_;
-};
+#ifdef _WIN32
 
 class Utf8ConverterWindows {
  public:
@@ -212,39 +177,7 @@ const std::string default_locale("en-US");
 
 using Utf8Converter = Utf8ConverterWindows;
 
-#else  // _MSC_VER
-
-class Locale {
- public:
-  explicit Locale(const std::string& name) {
-    ORT_TRY {
-      loc_ = std::locale(name.c_str());
-    }
-    ORT_CATCH(const std::runtime_error& e) {
-      ORT_HANDLE_EXCEPTION([&]() {
-        ORT_THROW("Failed to construct locale with name:",
-                  name, ":", e.what(), ":Please, install necessary language-pack-XX and configure locales");
-      });
-    }
-  }
-
-  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(Locale);
-
-  void ChangeCase(StringNormalizer::CaseAction caseaction,
-                  std::wstring& wstr) const {
-    assert(caseaction != StringNormalizer::NONE);
-    if (caseaction == StringNormalizer::LOWER) {
-      std::transform(wstr.begin(), wstr.end(), wstr.begin(),
-                     [this](wchar_t ch) { return std::tolower(ch, loc_); });
-    } else {
-      std::transform(wstr.begin(), wstr.end(), wstr.begin(),
-                     [this](wchar_t ch) { return std::toupper(ch, loc_); });
-    }
-  }
-
- private:
-  std::locale loc_;
-};
+#else  // _WIN32
 
 using Utf8Converter = Utf8ConverterGeneric;
 
@@ -259,10 +192,66 @@ const std::string default_locale("en_US.UTF-8");  // Other kinds of Apple Platfo
 const std::string default_locale("en_US.UTF-8");  // All non-MS and not Apple
 #endif
 
-#endif  // _MSC_VER
+#endif  // _WIN32
 }  // namespace string_normalizer
 
 using namespace string_normalizer;
+
+#ifdef _WIN32
+
+StringNormalizer::Locale::Locale(const std::string& name) {
+  loc_ = _create_locale(LC_CTYPE, name.c_str());
+  if (loc_ == nullptr) {
+    ORT_THROW("Failed to construct locale with name:",
+              name, ":", ":Please, install necessary language-pack-XX and configure locales");
+  }
+}
+
+StringNormalizer::Locale::~Locale() {
+  if (loc_ != nullptr) {
+    _free_locale(loc_);
+  }
+}
+
+void StringNormalizer::Locale::ChangeCase(CaseAction caseaction, std::wstring& wstr) const {
+  assert(caseaction != NONE);
+  if (caseaction == LOWER) {
+    std::transform(wstr.begin(), wstr.end(), wstr.begin(),
+                   [this](wchar_t ch) { return ::_towlower_l(ch, loc_); });
+  } else {
+    std::transform(wstr.begin(), wstr.end(), wstr.begin(),
+                   [this](wchar_t ch) { return ::_towupper_l(ch, loc_); });
+  }
+}
+
+#else
+
+StringNormalizer::Locale::Locale(const std::string& name) {
+  ORT_TRY {
+    loc_ = std::locale(name.c_str());
+  }
+  ORT_CATCH(const std::runtime_error& e) {
+    ORT_HANDLE_EXCEPTION([&]() {
+      ORT_THROW("Failed to construct locale with name:",
+                name, ":", e.what(), ":Please, install necessary language-pack-XX and configure locales");
+    });
+  }
+}
+
+StringNormalizer::Locale::~Locale() = default;
+
+void StringNormalizer::Locale::ChangeCase(CaseAction caseaction, std::wstring& wstr) const {
+  assert(caseaction != NONE);
+  if (caseaction == LOWER) {
+    std::transform(wstr.begin(), wstr.end(), wstr.begin(),
+                   [this](wchar_t ch) { return std::tolower(ch, loc_); });
+  } else {
+    std::transform(wstr.begin(), wstr.end(), wstr.begin(),
+                   [this](wchar_t ch) { return std::toupper(ch, loc_); });
+  }
+}
+
+#endif
 
 StringNormalizer::StringNormalizer(const OpKernelInfo& info) : OpKernel(info) {
   int64_t iscasesensitive = 0;
@@ -283,21 +272,26 @@ StringNormalizer::StringNormalizer(const OpKernelInfo& info) : OpKernel(info) {
     ORT_ENFORCE(false, "attribute case_change_action has invalid value");
   }
 
-  locale_name_ = info.GetAttrOrDefault("locale", default_locale);
+  const std::string locale_name = info.GetAttrOrDefault("locale", default_locale);
 
   std::vector<std::string> stop_words = info.GetAttrsOrDefault<std::string>("stopwords");
+  const bool needs_runtime_locale = case_change_action_ != NONE || (!is_case_sensitive_ && !stop_words.empty());
+  if (needs_runtime_locale) {
+    locale_.emplace(locale_name);
+  }
+
   if (is_case_sensitive_) {
     stopwords_.reserve(stop_words.size());
     for (std::string& s : stop_words) {
       stopwords_.insert(std::move(s));
     }
-  } else {
-    Locale locale(locale_name_);
+  } else if (!stop_words.empty()) {
+    assert(locale_.has_value());
     Utf8Converter converter;
     wstopwords_.reserve(stop_words.size());
     for (std::string& s : stop_words) {
       std::wstring wstr = converter.from_bytes(s);
-      locale.ChangeCase(compare_caseaction_, wstr);
+      locale_->ChangeCase(compare_caseaction_, wstr);
       wstopwords_.insert(std::move(wstr));
     }
   }
@@ -357,8 +351,8 @@ Status StringNormalizer::Compute(OpKernelContext* ctx) const {
   // to widechar, lowercase it and then compare. Case-insensitive comparison is complicated
   // for UTF-8 and requires additional dependency.
 
-  Locale locale(locale_name_);
   Utf8Converter converter;
+  const Locale* locale = locale_ ? &*locale_ : nullptr;
 
   // Determine whether we need wchar conversion at all.
   // We need it if: (a) case change is requested, or (b) case-insensitive filtering.
@@ -388,7 +382,8 @@ Status StringNormalizer::Compute(OpKernelContext* ctx) const {
       const std::string& s = input_span[i];
       wchar_buffer.resize(max_wide_buffer_len);
       ORT_RETURN_IF_ERROR(converter.ConvertToWideChar(s, wchar_buffer));
-      locale.ChangeCase(case_change_action_, wchar_buffer);
+      assert(locale != nullptr);
+      locale->ChangeCase(case_change_action_, wchar_buffer);
 
       auto& dest = output_data[i];
       size_t utf8_buffer_len = converter.ComputeRequiredSizeToUtf8(wchar_buffer);
@@ -406,7 +401,8 @@ Status StringNormalizer::Compute(OpKernelContext* ctx) const {
       if (case_change_action_ != NONE) {
         wchar_buffer.resize(max_wide_buffer_len);
         ORT_RETURN_IF_ERROR(converter.ConvertToWideChar(s, wchar_buffer));
-        locale.ChangeCase(case_change_action_, wchar_buffer);
+        assert(locale != nullptr);
+        locale->ChangeCase(case_change_action_, wchar_buffer);
 
         auto& dest = *output_data++;
         size_t utf8_buffer_len = converter.ComputeRequiredSizeToUtf8(wchar_buffer);
@@ -459,7 +455,8 @@ Status StringNormalizer::Compute(OpKernelContext* ctx) const {
         const std::string& s = input_span[i];
         wchar_buffer.resize(max_wide_buffer_len);
         ORT_RETURN_IF_ERROR(converter.ConvertToWideChar(s, wchar_buffer));
-        locale.ChangeCase(compare_caseaction_, wchar_buffer);
+        assert(locale != nullptr);
+        locale->ChangeCase(compare_caseaction_, wchar_buffer);
         if (wstopwords_.count(wchar_buffer) == 0) {
           filtered_strings_indices.push_back(i);
         }

--- a/onnxruntime/core/providers/cpu/text/string_normalizer.cc
+++ b/onnxruntime/core/providers/cpu/text/string_normalizer.cc
@@ -376,8 +376,8 @@ Status StringNormalizer::Compute(OpKernelContext* ctx) const {
 
   // Output everything and change case as required
   auto output_no_filtering = [&](const TensorShape& output_shape) {
-    auto output_tensor = ctx->Output(0, output_shape);
-    auto const output_data = output_tensor->MutableData<std::string>();
+    auto* output_tensor = ctx->Output(0, output_shape);
+    auto* output_data = output_tensor->MutableData<std::string>();
     for (size_t i = 0, lim = input_span.size(); i < lim; ++i) {
       const std::string& s = input_span[i];
       wchar_buffer.resize(max_wide_buffer_len);
@@ -394,8 +394,8 @@ Status StringNormalizer::Compute(OpKernelContext* ctx) const {
   };
 
   auto output_filtered = [&](const TensorShape& output_shape, gsl::span<const size_t> filtered_indices) {
-    auto output_tensor = ctx->Output(0, output_shape);
-    auto output_data = output_tensor->MutableData<std::string>();
+    auto* output_tensor = ctx->Output(0, output_shape);
+    auto* output_data = output_tensor->MutableData<std::string>();
     for (size_t i : filtered_indices) {
       const std::string& s = input_span[i];
       if (case_change_action_ != NONE) {

--- a/onnxruntime/core/providers/cpu/text/string_normalizer.h
+++ b/onnxruntime/core/providers/cpu/text/string_normalizer.h
@@ -29,8 +29,14 @@ class StringNormalizer : public OpKernel {
  private:
   bool is_case_sensitive_{true};
   CaseAction case_change_action_{NONE};
-  // Set this to lower because some characters do not have upper case.
-  // used for case-insensitive compare
+  // Hardcoded to LOWER for case-insensitive stopword comparison.
+  // Lowercase is used because:
+  // - Some characters have no uppercase form or uppercase to multiple characters
+  //   (e.g., ß → SS), which std::transform cannot handle (it's 1:1 per character).
+  // - Lowercasing is almost always a 1:1 mapping in Unicode, making it safe
+  //   for per-character transforms.
+  // The ideal approach would be Unicode case folding (ICU), but that's not
+  // warranted for this operator.
   CaseAction compare_caseaction_{LOWER};
   std::string locale_name_;
   // Either if these are populated but not both

--- a/onnxruntime/core/providers/cpu/text/string_normalizer.h
+++ b/onnxruntime/core/providers/cpu/text/string_normalizer.h
@@ -30,11 +30,13 @@ class StringNormalizer : public OpKernel {
   bool is_case_sensitive_{true};
   CaseAction case_change_action_{NONE};
   // Hardcoded to LOWER for case-insensitive stopword comparison.
-  // Lowercase is used because:
+  // Lowercase is used here as a practical fit for the current per-character
+  // std::transform-based implementation:
   // - Some characters have no uppercase form or uppercase to multiple characters
-  //   (e.g., ß → SS), which std::transform cannot handle (it's 1:1 per character).
-  // - Lowercasing is almost always a 1:1 mapping in Unicode, making it safe
-  //   for per-character transforms.
+  //   (e.g., ß -> SS), which this implementation cannot handle because it
+  //   transforms one wchar_t at a time.
+  // - Unicode casing can be locale-, context-, and length-dependent, so this
+  //   should not be interpreted as full Unicode case folding.
   // The ideal approach would be Unicode case folding (ICU), but that's not
   // warranted for this operator.
   CaseAction compare_caseaction_{LOWER};

--- a/onnxruntime/core/providers/cpu/text/string_normalizer.h
+++ b/onnxruntime/core/providers/cpu/text/string_normalizer.h
@@ -9,7 +9,12 @@
 #include "core/framework/op_kernel.h"
 
 #include <locale>
+#include <optional>
 #include <string>
+
+#ifdef _WIN32
+#include <locale.h>
+#endif
 
 namespace onnxruntime {
 
@@ -27,6 +32,23 @@ class StringNormalizer : public OpKernel {
   Status Compute(OpKernelContext* ctx) const override;
 
  private:
+  class Locale {
+   public:
+    explicit Locale(const std::string& name);
+    ~Locale();
+
+    ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(Locale);
+
+    void ChangeCase(CaseAction caseaction, std::wstring& wstr) const;
+
+   private:
+#ifdef _WIN32
+    _locale_t loc_{nullptr};
+#else
+    std::locale loc_;
+#endif
+  };
+
   bool is_case_sensitive_{true};
   CaseAction case_change_action_{NONE};
   // Hardcoded to LOWER for case-insensitive stopword comparison.
@@ -40,7 +62,7 @@ class StringNormalizer : public OpKernel {
   // The ideal approach would be Unicode case folding (ICU), but that's not
   // warranted for this operator.
   CaseAction compare_caseaction_{LOWER};
-  std::string locale_name_;
+  std::optional<Locale> locale_;
   // Either if these are populated but not both
   InlinedHashSet<std::string> stopwords_;
   InlinedHashSet<std::wstring> wstopwords_;

--- a/onnxruntime/test/common/utf8_util_test.cc
+++ b/onnxruntime/test/common/utf8_util_test.cc
@@ -41,5 +41,328 @@ TEST(Utf8UtilTest, Validate) {
   }
 }
 
+// --- utf8_bytes tests ---
+
+TEST(Utf8UtilTest, Utf8Bytes_Ascii) {
+  using namespace utf8_util;
+  size_t len = 0;
+  // All ASCII bytes (0x00-0x7F) should be 1-byte
+  EXPECT_TRUE(utf8_bytes(0x00, len));
+  EXPECT_EQ(1U, len);
+  EXPECT_TRUE(utf8_bytes('A', len));
+  EXPECT_EQ(1U, len);
+  EXPECT_TRUE(utf8_bytes(0x7F, len));
+  EXPECT_EQ(1U, len);
+}
+
+TEST(Utf8UtilTest, Utf8Bytes_TwoByte) {
+  using namespace utf8_util;
+  size_t len = 0;
+  // 0xC0-0xDF are 2-byte lead bytes
+  EXPECT_TRUE(utf8_bytes(0xC0, len));
+  EXPECT_EQ(2U, len);
+  EXPECT_TRUE(utf8_bytes(0xC2, len));
+  EXPECT_EQ(2U, len);
+  EXPECT_TRUE(utf8_bytes(0xDF, len));
+  EXPECT_EQ(2U, len);
+}
+
+TEST(Utf8UtilTest, Utf8Bytes_ThreeByte) {
+  using namespace utf8_util;
+  size_t len = 0;
+  // 0xE0-0xEF are 3-byte lead bytes
+  EXPECT_TRUE(utf8_bytes(0xE0, len));
+  EXPECT_EQ(3U, len);
+  EXPECT_TRUE(utf8_bytes(0xED, len));
+  EXPECT_EQ(3U, len);
+  EXPECT_TRUE(utf8_bytes(0xEF, len));
+  EXPECT_EQ(3U, len);
+}
+
+TEST(Utf8UtilTest, Utf8Bytes_FourByte) {
+  using namespace utf8_util;
+  size_t len = 0;
+  // 0xF0-0xF7 are 4-byte lead bytes
+  EXPECT_TRUE(utf8_bytes(0xF0, len));
+  EXPECT_EQ(4U, len);
+  EXPECT_TRUE(utf8_bytes(0xF4, len));
+  EXPECT_EQ(4U, len);
+  EXPECT_TRUE(utf8_bytes(0xF7, len));
+  EXPECT_EQ(4U, len);
+}
+
+TEST(Utf8UtilTest, Utf8Bytes_Invalid) {
+  using namespace utf8_util;
+  size_t len = 99;
+  // Continuation bytes (0x80-0xBF) are not valid lead bytes
+  EXPECT_FALSE(utf8_bytes(0x80, len));
+  EXPECT_FALSE(utf8_bytes(0xBF, len));
+  // 0xF8-0xFF are invalid (would be 5+ byte sequences)
+  EXPECT_FALSE(utf8_bytes(0xF8, len));
+  EXPECT_FALSE(utf8_bytes(0xF9, len));
+  EXPECT_FALSE(utf8_bytes(0xFC, len));
+  EXPECT_FALSE(utf8_bytes(0xFE, len));
+  EXPECT_FALSE(utf8_bytes(0xFF, len));
+}
+
+// --- utf8_len tests ---
+
+TEST(Utf8UtilTest, Utf8Len_Empty) {
+  using namespace utf8_util;
+  size_t len = 99;
+  EXPECT_TRUE(utf8_len(reinterpret_cast<const unsigned char*>(""), 0, len));
+  EXPECT_EQ(0U, len);
+}
+
+TEST(Utf8UtilTest, Utf8Len_Ascii) {
+  using namespace utf8_util;
+  size_t len = 0;
+  const char* s = "Hello";
+  EXPECT_TRUE(utf8_len(reinterpret_cast<const unsigned char*>(s), 5, len));
+  EXPECT_EQ(5U, len);
+}
+
+TEST(Utf8UtilTest, Utf8Len_Multibyte) {
+  using namespace utf8_util;
+  size_t len = 0;
+  // "café" = 'c' 'a' 'f' U+00E9(2 bytes) = 5 bytes, 4 chars
+  const char* s = "caf\xc3\xa9";
+  EXPECT_TRUE(utf8_len(reinterpret_cast<const unsigned char*>(s), 5, len));
+  EXPECT_EQ(4U, len);
+}
+
+TEST(Utf8UtilTest, Utf8Len_ThreeByteChars) {
+  using namespace utf8_util;
+  size_t len = 0;
+  // U+4E16 (世) = 0xE4 0xB8 0x96, U+754C (界) = 0xE7 0x95 0x8C
+  const char* s = "\xe4\xb8\x96\xe7\x95\x8c";  // "世界"
+  EXPECT_TRUE(utf8_len(reinterpret_cast<const unsigned char*>(s), 6, len));
+  EXPECT_EQ(2U, len);
+}
+
+TEST(Utf8UtilTest, Utf8Len_FourByteChars) {
+  using namespace utf8_util;
+  size_t len = 0;
+  // U+1F600 (😀) = 0xF0 0x9F 0x98 0x80
+  const char* s = "\xf0\x9f\x98\x80";
+  EXPECT_TRUE(utf8_len(reinterpret_cast<const unsigned char*>(s), 4, len));
+  EXPECT_EQ(1U, len);
+}
+
+TEST(Utf8UtilTest, Utf8Len_Mixed) {
+  using namespace utf8_util;
+  size_t len = 0;
+  // "A" (1) + U+00F1 (2) + U+4E16 (3) + U+1F600 (4) = 10 bytes, 4 chars
+  const char* s = "A\xc3\xb1\xe4\xb8\x96\xf0\x9f\x98\x80";
+  EXPECT_TRUE(utf8_len(reinterpret_cast<const unsigned char*>(s), 10, len));
+  EXPECT_EQ(4U, len);
+}
+
+TEST(Utf8UtilTest, Utf8Len_InvalidLeadByte) {
+  using namespace utf8_util;
+  size_t len = 0;
+  // 0xF8 is invalid lead byte
+  const char* s = "\xf8\x80\x80\x80";
+  EXPECT_FALSE(utf8_len(reinterpret_cast<const unsigned char*>(s), 4, len));
+}
+
+TEST(Utf8UtilTest, Utf8Len_Truncated) {
+  using namespace utf8_util;
+  size_t len = 0;
+  // 2-byte sequence but only 1 byte available
+  const char* s = "\xc3";
+  EXPECT_FALSE(utf8_len(reinterpret_cast<const unsigned char*>(s), 1, len));
+}
+
+// --- utf8_validate additional tests ---
+
+TEST(Utf8UtilTest, Validate_EmptyString) {
+  using namespace utf8_util;
+  size_t chars = 99;
+  EXPECT_TRUE(utf8_validate(reinterpret_cast<const unsigned char*>(""), 0, chars));
+  EXPECT_EQ(0U, chars);
+}
+
+TEST(Utf8UtilTest, Validate_MultiCharString) {
+  using namespace utf8_util;
+  size_t chars = 0;
+  // "Héllo" = 'H' U+00E9(2b) 'l' 'l' 'o' = 6 bytes, 5 chars
+  const char* s = "H\xc3\xa9llo";
+  EXPECT_TRUE(utf8_validate(reinterpret_cast<const unsigned char*>(s), 6, chars));
+  EXPECT_EQ(5U, chars);
+}
+
+TEST(Utf8UtilTest, Validate_OverlongTwoByte) {
+  using namespace utf8_util;
+  size_t chars = 0;
+  // Overlong encoding of U+0000: 0xC0 0x80 (should be rejected)
+  const char* s = "\xc0\x80";
+  EXPECT_FALSE(utf8_validate(reinterpret_cast<const unsigned char*>(s), 2, chars));
+}
+
+TEST(Utf8UtilTest, Validate_SurrogatePair) {
+  using namespace utf8_util;
+  size_t chars = 0;
+  // U+D800 encoded as 3-byte: 0xED 0xA0 0x80 (invalid surrogate)
+  const char* s = "\xed\xa0\x80";
+  EXPECT_FALSE(utf8_validate(reinterpret_cast<const unsigned char*>(s), 3, chars));
+}
+
+TEST(Utf8UtilTest, Validate_MaxCodepoint) {
+  using namespace utf8_util;
+  size_t chars = 0;
+  // U+10FFFF = 0xF4 0x8F 0xBF 0xBF (valid, max Unicode codepoint)
+  const char* s = "\xf4\x8f\xbf\xbf";
+  EXPECT_TRUE(utf8_validate(reinterpret_cast<const unsigned char*>(s), 4, chars));
+  EXPECT_EQ(1U, chars);
+}
+
+TEST(Utf8UtilTest, Validate_BeyondMaxCodepoint) {
+  using namespace utf8_util;
+  size_t chars = 0;
+  // U+110000 = 0xF4 0x90 0x80 0x80 (invalid, beyond U+10FFFF)
+  const char* s = "\xf4\x90\x80\x80";
+  EXPECT_FALSE(utf8_validate(reinterpret_cast<const unsigned char*>(s), 4, chars));
+}
+
+TEST(Utf8UtilTest, Validate_ContinuationByteAlone) {
+  using namespace utf8_util;
+  size_t chars = 0;
+  // A lone continuation byte
+  const char* s = "\x80";
+  EXPECT_FALSE(utf8_validate(reinterpret_cast<const unsigned char*>(s), 1, chars));
+}
+
+// --- Non-Windows conversion tests ---
+#ifndef _WIN32
+
+TEST(Utf8UtilTest, WideToUtf8RequiredSize_Ascii) {
+  std::wstring ws = L"Hello";
+  EXPECT_EQ(5U, WideToUtf8RequiredSize(ws));
+}
+
+TEST(Utf8UtilTest, WideToUtf8RequiredSize_Multibyte) {
+  // U+00E9 -> 2 bytes, U+4E16 -> 3 bytes, U+1F600 -> 4 bytes
+  std::wstring ws;
+  ws += static_cast<wchar_t>(0x00E9);   // 2 bytes
+  ws += static_cast<wchar_t>(0x4E16);   // 3 bytes
+  ws += static_cast<wchar_t>(0x1F600);  // 4 bytes
+  EXPECT_EQ(9U, WideToUtf8RequiredSize(ws));
+}
+
+TEST(Utf8UtilTest, WideToUtf8_RoundTrip_Ascii) {
+  std::wstring ws = L"Hello World";
+  std::string result;
+  result.resize(WideToUtf8RequiredSize(ws));
+  ASSERT_TRUE(WideToUtf8(ws, result).IsOK());
+  EXPECT_EQ("Hello World", result);
+}
+
+TEST(Utf8UtilTest, WideToUtf8_RoundTrip_Multibyte) {
+  // Build wide string with various codepoints
+  std::wstring ws;
+  ws += static_cast<wchar_t>(0x00E9);   // é
+  ws += static_cast<wchar_t>(0x4E16);   // 世
+  ws += static_cast<wchar_t>(0x1F600);  // 😀
+
+  std::string utf8;
+  utf8.resize(WideToUtf8RequiredSize(ws));
+  ASSERT_TRUE(WideToUtf8(ws, utf8).IsOK());
+
+  // Verify via round-trip
+  std::wstring back;
+  back.resize(utf8.size());
+  ASSERT_TRUE(Utf8ToWide(utf8, back).IsOK());
+  EXPECT_EQ(ws, back);
+}
+
+TEST(Utf8UtilTest, WideToUtf8_Empty) {
+  std::wstring ws;
+  std::string result = "notempty";
+  ASSERT_TRUE(WideToUtf8(ws, result).IsOK());
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(Utf8UtilTest, Utf8ToWide_Empty) {
+  std::string s;
+  std::wstring result = L"notempty";
+  ASSERT_TRUE(Utf8ToWide(s, result).IsOK());
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(Utf8UtilTest, Utf8ToWide_Ascii) {
+  std::string s = "ABC";
+  std::wstring result;
+  result.resize(s.size());
+  ASSERT_TRUE(Utf8ToWide(s, result).IsOK());
+  EXPECT_EQ(L"ABC", result);
+}
+
+TEST(Utf8UtilTest, Utf8ToWide_TruncatedSequence) {
+  // 3-byte sequence missing last byte
+  std::string s = "\xe4\xb8";
+  std::wstring result;
+  result.resize(s.size());
+  EXPECT_FALSE(Utf8ToWide(s, result).IsOK());
+}
+
+TEST(Utf8UtilTest, Utf8ToWide_InvalidContinuationByte) {
+  // 2-byte lead 0xC3 followed by non-continuation 0x28
+  std::string s = "\xc3\x28";
+  std::wstring result;
+  result.resize(s.size());
+  EXPECT_FALSE(Utf8ToWide(s, result).IsOK());
+}
+
+TEST(Utf8UtilTest, Utf8ToWide_OverlongEncoding) {
+  // Overlong 2-byte for U+002F ('/') = 0xC0 0xAF
+  std::string s = "\xc0\xaf";
+  std::wstring result;
+  result.resize(s.size());
+  EXPECT_FALSE(Utf8ToWide(s, result).IsOK());
+}
+
+TEST(Utf8UtilTest, Utf8ToWide_SurrogateCodepoint) {
+  // U+D800 as 3-byte UTF-8: 0xED 0xA0 0x80
+  std::string s = "\xed\xa0\x80";
+  std::wstring result;
+  result.resize(s.size());
+  EXPECT_FALSE(Utf8ToWide(s, result).IsOK());
+}
+
+TEST(Utf8UtilTest, Utf8ToWide_BeyondUnicode) {
+  // U+110000: 0xF4 0x90 0x80 0x80
+  std::string s = "\xf4\x90\x80\x80";
+  std::wstring result;
+  result.resize(s.size());
+  EXPECT_FALSE(Utf8ToWide(s, result).IsOK());
+}
+
+TEST(Utf8UtilTest, Utf8ToWide_InvalidLeadByte) {
+  // 0xF8 is not a valid UTF-8 lead byte
+  std::string s = "\xf8\x80\x80\x80\x80";
+  std::wstring result;
+  result.resize(s.size());
+  EXPECT_FALSE(Utf8ToWide(s, result).IsOK());
+}
+
+TEST(Utf8UtilTest, Utf8ToWideString_ValidInput) {
+  std::string s = "caf\xc3\xa9";  // "café"
+  std::wstring result = Utf8ToWideString(s);
+  EXPECT_EQ(4U, result.size());
+  EXPECT_EQ(static_cast<wchar_t>('c'), result[0]);
+  EXPECT_EQ(static_cast<wchar_t>('a'), result[1]);
+  EXPECT_EQ(static_cast<wchar_t>('f'), result[2]);
+  EXPECT_EQ(static_cast<wchar_t>(0x00E9), result[3]);
+}
+
+TEST(Utf8UtilTest, Utf8ToWideString_InvalidInput) {
+  // Should throw on invalid UTF-8
+  std::string s = "\xc0\xaf";
+  EXPECT_THROW(Utf8ToWideString(s), OnnxRuntimeException);
+}
+
+#endif  // !_WIN32
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/common/utf8_util_test.cc
+++ b/onnxruntime/test/common/utf8_util_test.cc
@@ -284,6 +284,28 @@ TEST(Utf8UtilTest, WideToUtf8_BufferTooSmall) {
   EXPECT_FALSE(WideToUtf8(ws, result).IsOK());
 }
 
+TEST(Utf8UtilTest, WideToUtf8_EmptyDestinationBuffer) {
+  std::wstring ws = L"A";
+  std::string result;
+  EXPECT_FALSE(WideToUtf8(ws, result).IsOK());
+}
+
+TEST(Utf8UtilTest, WideToUtf8_ThreeByteBufferTooSmall) {
+  std::wstring ws;
+  ws += static_cast<wchar_t>(0x4E16);  // 3 bytes in UTF-8
+  std::string result;
+  result.resize(2);
+  EXPECT_FALSE(WideToUtf8(ws, result).IsOK());
+}
+
+TEST(Utf8UtilTest, WideToUtf8_FourByteBufferTooSmall) {
+  std::wstring ws;
+  ws += static_cast<wchar_t>(0x1F600);  // 4 bytes in UTF-8
+  std::string result;
+  result.resize(3);
+  EXPECT_FALSE(WideToUtf8(ws, result).IsOK());
+}
+
 TEST(Utf8UtilTest, WideToUtf8_RoundTrip_Multibyte) {
   // Build wide string with various codepoints
   std::wstring ws;

--- a/onnxruntime/test/common/utf8_util_test.cc
+++ b/onnxruntime/test/common/utf8_util_test.cc
@@ -258,6 +258,14 @@ TEST(Utf8UtilTest, WideToUtf8_RoundTrip_Ascii) {
   EXPECT_EQ("Hello World", result);
 }
 
+TEST(Utf8UtilTest, WideToUtf8_BufferTooSmall) {
+  std::wstring ws;
+  ws += static_cast<wchar_t>(0x00E9);  // 2 bytes in UTF-8
+  std::string result;
+  result.resize(1);
+  EXPECT_FALSE(WideToUtf8(ws, result).IsOK());
+}
+
 TEST(Utf8UtilTest, WideToUtf8_RoundTrip_Multibyte) {
   // Build wide string with various codepoints
   std::wstring ws;
@@ -294,6 +302,13 @@ TEST(Utf8UtilTest, Utf8ToWide_Ascii) {
   std::string s = "ABC";
   std::wstring result;
   result.resize(s.size());
+  ASSERT_TRUE(Utf8ToWide(s, result).IsOK());
+  EXPECT_EQ(L"ABC", result);
+}
+
+TEST(Utf8UtilTest, Utf8ToWide_AutoResizeDestination) {
+  std::string s = "ABC";
+  std::wstring result;
   ASSERT_TRUE(Utf8ToWide(s, result).IsOK());
   EXPECT_EQ(L"ABC", result);
 }
@@ -356,10 +371,26 @@ TEST(Utf8UtilTest, Utf8ToWideString_ValidInput) {
   EXPECT_EQ(static_cast<wchar_t>(0x00E9), result[3]);
 }
 
+#if !defined(ORT_NO_EXCEPTIONS)
 TEST(Utf8UtilTest, Utf8ToWideString_InvalidInput) {
   // Should throw on invalid UTF-8
   std::string s = "\xc0\xaf";
   EXPECT_THROW(Utf8ToWideString(s), OnnxRuntimeException);
+}
+
+TEST(Utf8UtilTest, WideToUtf8RequiredSize_SurrogateCodepoint) {
+  std::wstring ws;
+  ws += static_cast<wchar_t>(0xD800);
+  EXPECT_THROW(WideToUtf8RequiredSize(ws), OnnxRuntimeException);
+}
+#endif  // !defined(ORT_NO_EXCEPTIONS)
+
+TEST(Utf8UtilTest, WideToUtf8_SurrogateCodepoint) {
+  std::wstring ws;
+  ws += static_cast<wchar_t>(0xD800);
+  std::string result;
+  result.resize(4);
+  EXPECT_FALSE(WideToUtf8(ws, result).IsOK());
 }
 
 #endif  // !_WIN32

--- a/onnxruntime/test/common/utf8_util_test.cc
+++ b/onnxruntime/test/common/utf8_util_test.cc
@@ -58,7 +58,8 @@ TEST(Utf8UtilTest, Utf8Bytes_Ascii) {
 TEST(Utf8UtilTest, Utf8Bytes_TwoByte) {
   using namespace utf8_util;
   size_t len = 0;
-  // 0xC0-0xDF are 2-byte lead bytes
+  // 0xC0-0xDF share the 2-byte lead-byte prefix.
+  // Full well-formedness checks happen in utf8_validate.
   EXPECT_TRUE(utf8_bytes(0xC0, len));
   EXPECT_EQ(2U, len);
   EXPECT_TRUE(utf8_bytes(0xC2, len));
@@ -82,7 +83,8 @@ TEST(Utf8UtilTest, Utf8Bytes_ThreeByte) {
 TEST(Utf8UtilTest, Utf8Bytes_FourByte) {
   using namespace utf8_util;
   size_t len = 0;
-  // 0xF0-0xF7 are 4-byte lead bytes
+  // 0xF0-0xF7 share the 4-byte lead-byte prefix.
+  // Full well-formedness checks happen in utf8_validate.
   EXPECT_TRUE(utf8_bytes(0xF0, len));
   EXPECT_EQ(4U, len);
   EXPECT_TRUE(utf8_bytes(0xF4, len));
@@ -200,6 +202,13 @@ TEST(Utf8UtilTest, Validate_OverlongTwoByte) {
   EXPECT_FALSE(utf8_validate(reinterpret_cast<const unsigned char*>(s), 2, chars));
 }
 
+TEST(Utf8UtilTest, Validate_OverlongTwoByteLeadByteC1) {
+  using namespace utf8_util;
+  size_t chars = 0;
+  const char* s = "\xc1\xbf";
+  EXPECT_FALSE(utf8_validate(reinterpret_cast<const unsigned char*>(s), 2, chars));
+}
+
 TEST(Utf8UtilTest, Validate_SurrogatePair) {
   using namespace utf8_util;
   size_t chars = 0;
@@ -225,6 +234,13 @@ TEST(Utf8UtilTest, Validate_BeyondMaxCodepoint) {
   EXPECT_FALSE(utf8_validate(reinterpret_cast<const unsigned char*>(s), 4, chars));
 }
 
+TEST(Utf8UtilTest, Validate_FourByteLeadByteAboveUnicodeRange) {
+  using namespace utf8_util;
+  size_t chars = 0;
+  const char* s = "\xf7\xbf\xbf\xbf";
+  EXPECT_FALSE(utf8_validate(reinterpret_cast<const unsigned char*>(s), 4, chars));
+}
+
 TEST(Utf8UtilTest, Validate_ContinuationByteAlone) {
   using namespace utf8_util;
   size_t chars = 0;
@@ -235,6 +251,8 @@ TEST(Utf8UtilTest, Validate_ContinuationByteAlone) {
 
 // --- Non-Windows conversion tests ---
 #ifndef _WIN32
+
+using namespace utf8_util;
 
 TEST(Utf8UtilTest, WideToUtf8RequiredSize_Ascii) {
   std::wstring ws = L"Hello";

--- a/onnxruntime/test/providers/cpu/text/string_normalizer_test.cc
+++ b/onnxruntime/test/providers/cpu/text/string_normalizer_test.cc
@@ -494,6 +494,30 @@ TEST(ContribOpTest, StringNormalizerInvalidLocale) {
            "Failed to construct locale with name:");
 }
 
+TEST(ContribOpTest, StringNormalizerPassthroughRejectsInvalidUtf8) {
+  // Byte-only passthrough path should still validate UTF-8 input.
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "NONE", true, {}, test_locale);
+  std::vector<int64_t> dims{1};
+  std::vector<std::string> input{std::string("\xF0\x28\x8C\x28", 4)};
+  test.AddInput<std::string>("T", dims, input);
+  test.AddOutput<std::string>("Y", dims, input);
+  test.Run(OpTester::ExpectResult::kExpectFailure,
+           "Input strings must be valid UTF-8");
+}
+
+TEST(ContribOpTest, StringNormalizerSensitiveFilteringRejectsInvalidUtf8) {
+  // Case-sensitive filtering path should validate UTF-8 even when no wchar conversion is needed.
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "NONE", true, {"keep"}, test_locale);
+  std::vector<int64_t> dims{2};
+  std::vector<std::string> input{"keep", std::string("\xF0\x28\x8C\x28", 4)};
+  test.AddInput<std::string>("T", dims, input);
+  test.AddOutput<std::string>("Y", {1}, std::vector<std::string>{std::string("\xF0\x28\x8C\x28", 4)});
+  test.Run(OpTester::ExpectResult::kExpectFailure,
+           "Input strings must be valid UTF-8");
+}
+
 TEST(ContribOpTest, StringNormalizerGermanEszettLower) {
   // German Eszett (ß) lowercasing: ß should remain ß.
   // This tests the converter and case logic with the problematic German character.

--- a/onnxruntime/test/providers/cpu/text/string_normalizer_test.cc
+++ b/onnxruntime/test/providers/cpu/text/string_normalizer_test.cc
@@ -232,5 +232,281 @@ TEST(ContribOpTest, StringNormalizerSensitiveFilterOutUpperSameOutput) {
 }
 #endif
 
+// ============================================================
+// Additional tests for coverage gaps
+// ============================================================
+
+TEST(ContribOpTest, StringNormalizerInsensitiveFilterOutLower) {
+  // Case-insensitive filtering + LOWER case change.
+  // This exercises the can_reuse_wide fast path (compare_caseaction_ == LOWER == case_change_action_).
+  // Tests French (accented), German (umlaut/eszett), Russian, Chinese.
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "LOWER", false, {"Понедельник", "Besançon"}, test_locale);
+  std::vector<int64_t> dims{6};
+  std::vector<std::string> input = {"ПОНЕДЕЛЬНИК",  // matches "Понедельник" case-insensitively
+                                    "BESANÇON",     // matches "Besançon" case-insensitively
+                                    "École élémentaire",
+                                    "mit freundlichen grüßen",
+                                    "中文",
+                                    "Tuesday"};
+  test.AddInput<std::string>("T", dims, input);
+
+  std::vector<std::string> output = {"école élémentaire",
+                                     "mit freundlichen grüßen",  // ß stays ß when lowercased
+                                     "中文",                     // Chinese has no case
+                                     "tuesday"};
+  test.AddOutput<std::string>("Y", {4}, output);
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, StringNormalizerInsensitiveFilterOutNone) {
+  // Case-insensitive filtering + NO case change.
+  // Strings matching stopwords are removed; survivors keep original case.
+  // Tests that Cyrillic and accented Latin stopwords match case-insensitively.
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "NONE", false, {"понедельник", "école élémentaire"}, test_locale);
+  std::vector<int64_t> dims{5};
+  std::vector<std::string> input = {"Понедельник",        // matches "понедельник"
+                                    "École Élémentaire",  // matches "école élémentaire"
+                                    "Besançon",
+                                    "中文",
+                                    "Thursday"};
+  test.AddInput<std::string>("T", dims, input);
+
+  // Filtered strings are removed; survivors keep original case
+  std::vector<std::string> output = {"Besançon", "中文", "Thursday"};
+  test.AddOutput<std::string>("Y", {3}, output);
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, StringNormalizerInsensitiveNoStopwordsLower) {
+  // Case-insensitive, no stopwords, LOWER case change.
+  // Exercises output_no_filtering path with multilingual input.
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "LOWER", false, {}, test_locale);
+  std::vector<int64_t> dims{5};
+  std::vector<std::string> input = {"BESANÇON",
+                                    "ÉCOLE ÉLÉMENTAIRE",
+                                    "ПОНЕДЕЛЬНИК",
+                                    "MIT FREUNDLICHEN GRÜßEN",
+                                    "中文"};
+  test.AddInput<std::string>("T", dims, input);
+
+  std::vector<std::string> output = {"besançon",
+                                     "école élémentaire",
+                                     "понедельник",
+                                     "mit freundlichen grüßen",
+                                     "中文"};
+  test.AddOutput<std::string>("Y", {5}, output);
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, StringNormalizerInsensitiveFilterUpperMultilingual) {
+  // Case-insensitive filtering + UPPER case change (case_change != compare_caseaction_).
+  // Exercises the output_filtered_with_wide fallback (cannot reuse cached lowercase wide forms).
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "UPPER", false, {"besançon", "中文"}, test_locale);
+  std::vector<int64_t> dims{5};
+  std::vector<std::string> input = {"Besançon",  // matches "besançon"
+                                    "École élémentaire",
+                                    "Понедельник",
+                                    "mit freundlichen grüßen",
+                                    "中文"};  // matches "中文" (no case, exact match)
+  test.AddInput<std::string>("T", dims, input);
+
+  std::vector<std::string> output = {"ÉCOLE ÉLÉMENTAIRE",
+                                     "ПОНЕДЕЛЬНИК",
+  // Eszett behavior differs by platform
+#ifdef __wasm__
+                                     "MIT FREUNDLICHEN GRÜẞEN"
+#else
+                                     "MIT FREUNDLICHEN GRÜßEN"
+#endif
+  };
+  test.AddOutput<std::string>("Y", {3}, output);
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, StringNormalizerEmptyStringInInput) {
+  // Input contains empty strings — should not crash or produce invalid output.
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "UPPER", true, {}, test_locale);
+  std::vector<int64_t> dims{3};
+  std::vector<std::string> input = {"hello", "", "world"};
+  test.AddInput<std::string>("T", dims, input);
+
+  std::vector<std::string> output = {"HELLO", "", "WORLD"};
+  test.AddOutput<std::string>("Y", {3}, output);
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, StringNormalizerSingleElement) {
+  // Single-element input tensor with multi-byte UTF-8.
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "LOWER", true, {}, test_locale);
+  std::vector<int64_t> dims{1};
+  std::vector<std::string> input = {"ÉCOLE"};
+  test.AddInput<std::string>("T", dims, input);
+
+  std::vector<std::string> output = {"école"};
+  test.AddOutput<std::string>("Y", {1}, output);
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, StringNormalizerInsensitiveAllFilteredOutMultilingual) {
+  // Case-insensitive: all strings match stopwords → output is [1] with empty string.
+  // Uses Cyrillic and Chinese stopwords.
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "UPPER", false, {"понедельник", "中文", "grüßen"}, test_locale);
+  std::vector<int64_t> dims{3};
+  std::vector<std::string> input = {"ПОНЕДЕЛЬНИК", "中文", "Grüßen"};
+  test.AddInput<std::string>("T", dims, input);
+
+  std::vector<std::string> output{""};
+  test.AddOutput<std::string>("Y", {1}, output);
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, StringNormalizerInsensitiveMixedCaseStopwords) {
+  // Stopwords given in mixed case with accented characters should still match.
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "NONE", false, {"ПОНЕДЕЛЬНИК", "École Élémentaire"}, test_locale);
+  std::vector<int64_t> dims{4};
+  std::vector<std::string> input = {"понедельник",        // matches "ПОНЕДЕЛЬНИК"
+                                    "école élémentaire",  // matches "École Élémentaire"
+                                    "Besançon",
+                                    "中文"};
+  test.AddInput<std::string>("T", dims, input);
+
+  std::vector<std::string> output = {"Besançon", "中文"};
+  test.AddOutput<std::string>("Y", {2}, output);
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, StringNormalizer2DInputWithFilteringMultilingual) {
+  // 2D shape [1, C] with filtering using multilingual input.
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "LOWER", true, {"Понедельник"}, test_locale);
+  std::vector<int64_t> dims{1, 4};
+  std::vector<std::string> input = {"Понедельник", "BESANÇON", "中文", "ÉCOLE"};
+  test.AddInput<std::string>("T", dims, input);
+
+  std::vector<std::string> output = {"besançon", "中文", "école"};
+  test.AddOutput<std::string>("Y", {1, 3}, output);
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, StringNormalizer2DInputAllFilteredOut) {
+  // 2D shape [1, C] with all filtered → output shape [1, 1] with empty string.
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "NONE", true, {"中文", "Понедельник"}, test_locale);
+  std::vector<int64_t> dims{1, 2};
+  std::vector<std::string> input = {"中文", "Понедельник"};
+  test.AddInput<std::string>("T", dims, input);
+
+  std::vector<std::string> output{""};
+  test.AddOutput<std::string>("Y", {1, 1}, output);
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, StringNormalizerInvalidDimensions3D) {
+  // Input with 3 dimensions → should fail.
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "NONE", true, {}, test_locale);
+  std::vector<int64_t> dims{1, 1, 2};
+  std::vector<std::string> input = {"hello", "world"};
+  test.AddInput<std::string>("T", dims, input);
+  test.AddOutput<std::string>("Y", {1, 1, 2}, input);
+  test.Run(OpTester::ExpectResult::kExpectFailure,
+           "Input dimensions are either[C > 0] or [1][C > 0] allowed");
+}
+
+TEST(ContribOpTest, StringNormalizerInvalidDimensions2DFirstNotOne) {
+  // 2D input with first dim != 1 → should fail.
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "NONE", true, {}, test_locale);
+  std::vector<int64_t> dims{2, 2};
+  std::vector<std::string> input = {"a", "b", "c", "d"};
+  test.AddInput<std::string>("T", dims, input);
+  test.AddOutput<std::string>("Y", {2, 2}, input);
+  test.Run(OpTester::ExpectResult::kExpectFailure,
+           "Input dimensions are either[C > 0] or [1][C > 0] allowed");
+}
+
+TEST(ContribOpTest, StringNormalizerGermanEszettLower) {
+  // German Eszett (ß) lowercasing: ß should remain ß.
+  // This tests the converter and case logic with the problematic German character.
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "LOWER", true, {}, test_locale);
+  std::vector<int64_t> dims{2};
+  std::vector<std::string> input = {"GRÜßEN", "STRAßE"};
+  test.AddInput<std::string>("T", dims, input);
+
+  std::vector<std::string> output = {"grüßen", "straße"};
+  test.AddOutput<std::string>("Y", {2}, output);
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, StringNormalizerGermanEszettUpper) {
+  // German Eszett (ß) uppercasing: platform-dependent behavior.
+  // On wasm, ß uppercases to ẞ (capital eszett U+1E9E).
+  // On other platforms, ß remains ß (no single-char uppercase form recognized).
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "UPPER", true, {}, test_locale);
+  std::vector<int64_t> dims{2};
+  std::vector<std::string> input = {"grüßen", "straße"};
+  test.AddInput<std::string>("T", dims, input);
+
+#ifdef __wasm__
+  std::vector<std::string> output = {"GRÜẞEN", "STRAẞE"};
+#else
+  std::vector<std::string> output = {"GRÜßEN", "STRAßE"};
+#endif
+  test.AddOutput<std::string>("Y", {2}, output);
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, StringNormalizerInsensitiveGermanEszettFilter) {
+  // Case-insensitive filtering with German Eszett in stopwords.
+  // "grüßen" lowercased stays "grüßen", should match stopword "grüßen".
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "NONE", false, {"grüßen"}, test_locale);
+  std::vector<int64_t> dims{3};
+  std::vector<std::string> input = {"Grüßen", "Straße", "中文"};
+  test.AddInput<std::string>("T", dims, input);
+
+  // "Grüßen" lowercased → "grüßen" → matches stopword
+  std::vector<std::string> output = {"Straße", "中文"};
+  test.AddOutput<std::string>("Y", {2}, output);
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, StringNormalizerCyrillicCaseChange) {
+  // Full Cyrillic case conversion test.
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "UPPER", true, {}, test_locale);
+  std::vector<int64_t> dims{3};
+  std::vector<std::string> input = {"понедельник", "Вторник", "среда"};
+  test.AddInput<std::string>("T", dims, input);
+
+  std::vector<std::string> output = {"ПОНЕДЕЛЬНИК", "ВТОРНИК", "СРЕДА"};
+  test.AddOutput<std::string>("Y", {3}, output);
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, StringNormalizerNoStopwordsNoCaseChange) {
+  // No stopwords, NONE case change → pure passthrough (fast path).
+  // Tests with multilingual content to ensure passthrough preserves bytes exactly.
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "NONE", true, {}, test_locale);
+  std::vector<int64_t> dims{4};
+  std::vector<std::string> input = {"Besançon", "Понедельник", "中文", "grüßen"};
+  test.AddInput<std::string>("T", dims, input);
+
+  std::vector<std::string> output = {"Besançon", "Понедельник", "中文", "grüßen"};
+  test.AddOutput<std::string>("Y", {4}, output);
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/text/string_normalizer_test.cc
+++ b/onnxruntime/test/providers/cpu/text/string_normalizer_test.cc
@@ -236,6 +236,19 @@ TEST(ContribOpTest, StringNormalizerSensitiveFilterOutUpperSameOutput) {
 // Additional tests for coverage gaps
 // ============================================================
 
+TEST(ContribOpTest, StringNormalizerDefaultIsCaseSensitiveIsFalse) {
+  // Omit is_case_sensitive and rely on the schema default of false.
+  OpTester test("StringNormalizer", opset_ver, domain);
+  test.AddAttribute("stopwords", std::vector<std::string>{"monday"});
+  std::vector<int64_t> dims{3};
+  std::vector<std::string> input = {"Monday", "Tuesday", "Wednesday"};
+  test.AddInput<std::string>("T", dims, input);
+
+  std::vector<std::string> output = {"Tuesday", "Wednesday"};
+  test.AddOutput<std::string>("Y", {2}, output);
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
 TEST(ContribOpTest, StringNormalizerInsensitiveFilterOutLower) {
   // Case-insensitive filtering + LOWER case change.
   // This exercises the can_reuse_wide fast path (compare_caseaction_ == LOWER == case_change_action_).
@@ -418,7 +431,7 @@ TEST(ContribOpTest, StringNormalizerInvalidDimensions3D) {
   test.AddInput<std::string>("T", dims, input);
   test.AddOutput<std::string>("Y", {1, 1, 2}, input);
   test.Run(OpTester::ExpectResult::kExpectFailure,
-           "Input dimensions are either[C > 0] or [1][C > 0] allowed");
+           "Input shape must have either [C] or [1,C] dimensions where C > 0");
 }
 
 TEST(ContribOpTest, StringNormalizerInvalidDimensions2DFirstNotOne) {
@@ -430,7 +443,55 @@ TEST(ContribOpTest, StringNormalizerInvalidDimensions2DFirstNotOne) {
   test.AddInput<std::string>("T", dims, input);
   test.AddOutput<std::string>("Y", {2, 2}, input);
   test.Run(OpTester::ExpectResult::kExpectFailure,
+           "Input shape must have either [C] or [1,C] dimensions where C > 0");
+}
+
+TEST(ContribOpTest, StringNormalizerEmpty1DInputRejectedForCompatibility) {
+  // Preserve current ORT behavior for empty 1D input.
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "NONE", true, {}, test_locale);
+  std::vector<int64_t> dims{0};
+  std::vector<std::string> input{};
+  test.AddInput<std::string>("T", dims, input);
+  test.AddOutput<std::string>("Y", {0}, input);
+  test.Run(OpTester::ExpectResult::kExpectFailure,
+           "Single dimension value must be greater than 0");
+}
+
+TEST(ContribOpTest, StringNormalizerEmpty2DInputRejectedForCompatibility) {
+  // Preserve current ORT behavior for empty [1, 0] input.
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "NONE", true, {}, test_locale);
+  std::vector<int64_t> dims{1, 0};
+  std::vector<std::string> input{};
+  test.AddInput<std::string>("T", dims, input);
+  test.AddOutput<std::string>("Y", {1, 0}, input);
+  test.Run(OpTester::ExpectResult::kExpectFailure,
            "Input dimensions are either[C > 0] or [1][C > 0] allowed");
+}
+
+TEST(ContribOpTest, StringNormalizerInvalidCaseChangeAction) {
+  // Invalid case_change_action should be rejected during kernel construction.
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "TITLE", true, {}, test_locale);
+  std::vector<int64_t> dims{1};
+  std::vector<std::string> input{"hello"};
+  test.AddInput<std::string>("T", dims, input);
+  test.AddOutput<std::string>("Y", dims, input);
+  test.Run(OpTester::ExpectResult::kExpectFailure,
+           "attribute case_change_action has invalid value");
+}
+
+TEST(ContribOpTest, StringNormalizerInvalidLocale) {
+  // Invalid locale should be rejected when locale-sensitive processing is required.
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "NONE", false, {}, "ort_invalid_locale_for_test");
+  std::vector<int64_t> dims{1};
+  std::vector<std::string> input{"hello"};
+  test.AddInput<std::string>("T", dims, input);
+  test.AddOutput<std::string>("Y", dims, input);
+  test.Run(OpTester::ExpectResult::kExpectFailure,
+           "Failed to construct locale with name:");
 }
 
 TEST(ContribOpTest, StringNormalizerGermanEszettLower) {

--- a/onnxruntime/test/providers/cpu/text/string_normalizer_test.cc
+++ b/onnxruntime/test/providers/cpu/text/string_normalizer_test.cc
@@ -423,27 +423,29 @@ TEST(ContribOpTest, StringNormalizer2DInputAllFilteredOut) {
 }
 
 TEST(ContribOpTest, StringNormalizerInvalidDimensions3D) {
-  // Input with 3 dimensions → should fail.
+  // Input with 3 dimensions -> bypass shape metadata so the kernel validation path runs.
   OpTester test("StringNormalizer", opset_ver, domain);
+  test.AddShapeToTensorData(false);
   InitTestAttr(test, "NONE", true, {}, test_locale);
   std::vector<int64_t> dims{1, 1, 2};
   std::vector<std::string> input = {"hello", "world"};
   test.AddInput<std::string>("T", dims, input);
   test.AddOutput<std::string>("Y", {1, 1, 2}, input);
   test.Run(OpTester::ExpectResult::kExpectFailure,
-           "Input shape must have either [C] or [1,C] dimensions where C > 0");
+           "Input dimensions are either[C > 0] or [1][C > 0] allowed");
 }
 
 TEST(ContribOpTest, StringNormalizerInvalidDimensions2DFirstNotOne) {
-  // 2D input with first dim != 1 → should fail.
+  // 2D input with first dim != 1 -> bypass shape metadata so the kernel validation path runs.
   OpTester test("StringNormalizer", opset_ver, domain);
+  test.AddShapeToTensorData(false);
   InitTestAttr(test, "NONE", true, {}, test_locale);
   std::vector<int64_t> dims{2, 2};
   std::vector<std::string> input = {"a", "b", "c", "d"};
   test.AddInput<std::string>("T", dims, input);
   test.AddOutput<std::string>("Y", {2, 2}, input);
   test.Run(OpTester::ExpectResult::kExpectFailure,
-           "Input shape must have either [C] or [1,C] dimensions where C > 0");
+           "Input dimensions are either[C > 0] or [1][C > 0] allowed");
 }
 
 TEST(ContribOpTest, StringNormalizerEmpty1DInputRejectedForCompatibility) {

--- a/onnxruntime/test/providers/cpu/text/string_normalizer_test.cc
+++ b/onnxruntime/test/providers/cpu/text/string_normalizer_test.cc
@@ -483,15 +483,32 @@ TEST(ContribOpTest, StringNormalizerInvalidCaseChangeAction) {
 }
 
 TEST(ContribOpTest, StringNormalizerInvalidLocale) {
-  // Invalid locale should be rejected when locale-sensitive processing is required.
+  // Invalid locale should be rejected when locale-sensitive processing is required
+  // on platforms that validate locale names. On wasm, locale construction accepts
+  // arbitrary names, so this path succeeds.
+  OpTester test("StringNormalizer", opset_ver, domain);
+  InitTestAttr(test, "UPPER", true, {}, "ort_invalid_locale_for_test");
+  std::vector<int64_t> dims{1};
+  std::vector<std::string> input{"hello"};
+  test.AddInput<std::string>("T", dims, input);
+  test.AddOutput<std::string>("Y", dims, input);
+#ifdef __wasm__
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+#else
+  test.Run(OpTester::ExpectResult::kExpectFailure,
+           "Failed to construct locale with name:");
+#endif
+}
+
+TEST(ContribOpTest, StringNormalizerInvalidLocaleIgnoredWhenUnused) {
+  // Invalid locale should not matter when the runtime stays on the UTF-8 passthrough fast path.
   OpTester test("StringNormalizer", opset_ver, domain);
   InitTestAttr(test, "NONE", false, {}, "ort_invalid_locale_for_test");
   std::vector<int64_t> dims{1};
   std::vector<std::string> input{"hello"};
   test.AddInput<std::string>("T", dims, input);
   test.AddOutput<std::string>("Y", dims, input);
-  test.Run(OpTester::ExpectResult::kExpectFailure,
-           "Failed to construct locale with name:");
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
 TEST(ContribOpTest, StringNormalizerPassthroughRejectsInvalidUtf8) {

--- a/onnxruntime/test/providers/cpu/text/string_normalizer_test.cc
+++ b/onnxruntime/test/providers/cpu/text/string_normalizer_test.cc
@@ -76,6 +76,7 @@ TEST(ContribOpTest, StringNormalizerSensitiveFilterOutNoCase) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
+#ifndef ORT_IOS
 TEST(ContribOpTest, StringNormalizerSensitiveFilterOutLower) {
   // - casesensitive approach
   // - filter out monday
@@ -211,9 +212,6 @@ TEST(ContribOpTest, StringNormalizerSensitiveFilterOutUpperEmptyCase) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-// Fails on iOS because necessary locales are not installed
-// MacOS runs fine.
-#ifndef ORT_IOS
 TEST(ContribOpTest, StringNormalizerSensitiveFilterOutUpperSameOutput) {
   // Empty output case
   // - casesensitive approach
@@ -236,6 +234,7 @@ TEST(ContribOpTest, StringNormalizerSensitiveFilterOutUpperSameOutput) {
 // Additional tests for coverage gaps
 // ============================================================
 
+#ifndef ORT_IOS
 TEST(ContribOpTest, StringNormalizerDefaultIsCaseSensitiveIsFalse) {
   // Omit is_case_sensitive and rely on the schema default of false.
   OpTester test("StringNormalizer", opset_ver, domain);
@@ -408,6 +407,7 @@ TEST(ContribOpTest, StringNormalizer2DInputWithFilteringMultilingual) {
   test.AddOutput<std::string>("Y", {1, 3}, output);
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
+#endif
 
 TEST(ContribOpTest, StringNormalizer2DInputAllFilteredOut) {
   // 2D shape [1, C] with all filtered → output shape [1, 1] with empty string.
@@ -485,16 +485,17 @@ TEST(ContribOpTest, StringNormalizerInvalidCaseChangeAction) {
 TEST(ContribOpTest, StringNormalizerInvalidLocale) {
   // Invalid locale should be rejected when locale-sensitive processing is required
   // on platforms that validate locale names. On wasm, locale construction accepts
-  // arbitrary names, so this path succeeds.
+  // arbitrary names, so this path succeeds and UPPER still applies.
   OpTester test("StringNormalizer", opset_ver, domain);
   InitTestAttr(test, "UPPER", true, {}, "ort_invalid_locale_for_test");
   std::vector<int64_t> dims{1};
   std::vector<std::string> input{"hello"};
   test.AddInput<std::string>("T", dims, input);
-  test.AddOutput<std::string>("Y", dims, input);
 #ifdef __wasm__
+  test.AddOutput<std::string>("Y", dims, std::vector<std::string>{"HELLO"});
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 #else
+  test.AddOutput<std::string>("Y", dims, input);
   test.Run(OpTester::ExpectResult::kExpectFailure,
            "Failed to construct locale with name:");
 #endif
@@ -535,6 +536,7 @@ TEST(ContribOpTest, StringNormalizerSensitiveFilteringRejectsInvalidUtf8) {
            "Input strings must be valid UTF-8");
 }
 
+#ifndef ORT_IOS
 TEST(ContribOpTest, StringNormalizerGermanEszettLower) {
   // German Eszett (ß) lowercasing: ß should remain ß.
   // This tests the converter and case logic with the problematic German character.
@@ -545,25 +547,6 @@ TEST(ContribOpTest, StringNormalizerGermanEszettLower) {
   test.AddInput<std::string>("T", dims, input);
 
   std::vector<std::string> output = {"grüßen", "straße"};
-  test.AddOutput<std::string>("Y", {2}, output);
-  test.Run(OpTester::ExpectResult::kExpectSuccess);
-}
-
-TEST(ContribOpTest, StringNormalizerGermanEszettUpper) {
-  // German Eszett (ß) uppercasing: platform-dependent behavior.
-  // On wasm, ß uppercases to ẞ (capital eszett U+1E9E).
-  // On other platforms, ß remains ß (no single-char uppercase form recognized).
-  OpTester test("StringNormalizer", opset_ver, domain);
-  InitTestAttr(test, "UPPER", true, {}, test_locale);
-  std::vector<int64_t> dims{2};
-  std::vector<std::string> input = {"grüßen", "straße"};
-  test.AddInput<std::string>("T", dims, input);
-
-#ifdef __wasm__
-  std::vector<std::string> output = {"GRÜẞEN", "STRAẞE"};
-#else
-  std::vector<std::string> output = {"GRÜßEN", "STRAßE"};
-#endif
   test.AddOutput<std::string>("Y", {2}, output);
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
@@ -595,6 +578,7 @@ TEST(ContribOpTest, StringNormalizerCyrillicCaseChange) {
   test.AddOutput<std::string>("Y", {3}, output);
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
+#endif
 
 TEST(ContribOpTest, StringNormalizerNoStopwordsNoCaseChange) {
   // No stopwords, NONE case change → pure passthrough (fast path).


### PR DESCRIPTION
This pull request refactors and modernizes the UTF-8 and wide character (wchar_t) string conversion logic in the string normalizer CPU kernel, replacing deprecated and complex code with new, platform-appropriate utilities. The changes improve code maintainability, portability, and performance, especially on non-Windows platforms, by introducing custom UTF-8 conversion routines and simplifying buffer management.

The most important changes are:

**UTF-8 and Wide Character Conversion Utilities:**
* Added new UTF-8 <-> wchar_t conversion functions (`WideToUtf8RequiredSize`, `WideToUtf8`, `Utf8ToWide`, and `Utf8ToWideString`) for non-Windows platforms in `utf8_util.h`, avoiding deprecated `std::codecvt` and providing robust Unicode handling.
* Updated `Utf8ConverterGeneric` in `string_normalizer.cc` to use these new utilities, greatly simplifying the code and removing legacy/deprecated conversion logic.

**Code Simplification and Performance:**
* Simplified buffer size estimation for conversions: now directly uses the UTF-8 string size as an upper bound for the wide buffer, removing the need for a full decode pass just to compute buffer sizes.
* Improved comments and logic for case-insensitive filtering, clarifying why lowercasing is used and how conversions are managed for efficiency. [[1]](diffhunk://#diff-20cdc2200d64f7c8dba541825ed6de8e69c5aaf0c0ece6967d3613482d0aaf16L32-R39) [[2]](diffhunk://#diff-26d2562f008c04f6d64a9c805054957c6a888040bd0912d5c16a53ed05512ca8L614-R446)

**Cleanup and Modernization:**
* Removed all usage of deprecated `std::codecvt` and related workaround code, as well as unnecessary includes and platform-specific handling, resulting in cleaner and more maintainable code. [[1]](diffhunk://#diff-26d2562f008c04f6d64a9c805054957c6a888040bd0912d5c16a53ed05512ca8R8-L27) [[2]](diffhunk://#diff-26d2562f008c04f6d64a9c805054957c6a888040bd0912d5c16a53ed05512ca8L39-R57) [[3]](diffhunk://#diff-26d2562f008c04f6d64a9c805054957c6a888040bd0912d5c16a53ed05512ca8L419-L428)

These changes collectively modernize the string normalization kernel, improve portability, and make the codebase easier to maintain.