### PR TITLE
fix: support Float16/BFloat16/Float8 in TensorArray custom op

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_lite_custom_op.h
+++ b/include/onnxruntime/core/session/onnxruntime_lite_custom_op.h
@@ -330,6 +330,12 @@ struct TensorArray : public ArgBase {
           case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:
             tensor = std::make_unique<Custom::Tensor<float>>(ctx, ith_input, true);
             break;
+          case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
+            tensor = std::make_unique<Custom::Tensor<Ort::Float16_t>>(ctx, ith_input, true);
+            break;
+          case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:
+            tensor = std::make_unique<Custom::Tensor<Ort::BFloat16_t>>(ctx, ith_input, true);
+            break;
           case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:
             tensor = std::make_unique<Custom::Tensor<double>>(ctx, ith_input, true);
             break;
@@ -359,6 +365,18 @@ struct TensorArray : public ArgBase {
             break;
           case ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING:
             tensor = std::make_unique<Custom::Tensor<std::string>>(ctx, ith_input, true);
+            break;
+          case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FN:
+            tensor = std::make_unique<Custom::Tensor<Ort::Float8E4M3FN_t>>(ctx, ith_input, true);
+            break;
+          case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FNUZ:
+            tensor = std::make_unique<Custom::Tensor<Ort::Float8E4M3FNUZ_t>>(ctx, ith_input, true);
+            break;
+          case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2:
+            tensor = std::make_unique<Custom::Tensor<Ort::Float8E5M2_t>>(ctx, ith_input, true);
+            break;
+          case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2FNUZ:
+            tensor = std::make_unique<Custom::Tensor<Ort::Float8E5M2FNUZ_t>>(ctx, ith_input, true);
             break;
           default:
             ORT_CXX_API_THROW("unknown input type", ORT_RUNTIME_EXCEPTION);


### PR DESCRIPTION
### Description
The `Ort::Custom::TensorArray` (alias `Variadic`) constructor in `include/onnxruntime/core/session/onnxruntime_lite_custom_op.h` was missing `case` arms for `Float16`, `BFloat16`, and the four `Float8*` variants. Any custom op accepting `const Ort::Custom::TensorArray&` with one of those input types fell through to the `default:` arm and threw `"unknown input type"` at construction.

This PR adds the six missing `case` arms so the constructor handles every floating-point variant the rest of the file already supports. The new arms mirror the type-name parity already established in `CREATE_TUPLE` (around lines 619-637) and `PARSE_ARGS` (around lines 744-762) within the same header — same `Ort::Float16_t` / `Ort::BFloat16_t` / `Ort::Float8E4M3FN_t` / `Ort::Float8E4M3FNUZ_t` / `Ort::Float8E5M2_t` / `Ort::Float8E5M2FNUZ_t` template arguments.

The change is purely additive: 18 lines, header-only, no API/ABI impact, no behavior change for any previously-supported type.

### Motivation and Context
Fixes #23373.

Custom ops authored against the Lite Custom Op API and declared with a `const Ort::Custom::TensorArray&` parameter currently cannot accept fp16, bf16, or fp8 inputs even though `Custom::Tensor<Ort::Float16_t>` etc. are first-class everywhere else in the API. This blocks half-precision and 8-bit-float variadic custom op authors on CPU EP and any EP that dispatches via the lite API.