### PR TITLE
ORT 1.25.2 Cherry Picks, Round 1

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/identity_op.h
+++ b/onnxruntime/core/providers/cpu/tensor/identity_op.h
@@ -49,21 +49,8 @@ class IdentityOp final : public OpKernel {
       const auto* X = &input_ort_value->Get<Tensor>();
       const TensorShape& shape = X->Shape();
       Tensor* Y = context->Output(0, shape);
-      auto X_type = X->DataType();
 
-      const void* source = X->DataRaw(X_type);
-      void* target = Y->MutableDataRaw(X_type);
-      // If source and target pointers are not equal, we need to copy the data.
-      if (target != source) {
-        if (!X->IsDataTypeString()) {
-          memcpy(target, source, SafeInt<size_t>(shape.Size()) * X_type->Size());
-        } else {
-          // handle std::string
-          const auto* src = X->Data<std::string>();
-          auto* dst = Y->MutableData<std::string>();
-          std::copy(src, src + shape.Size(), dst);
-        }
-      }
+      CopyCpuTensor(X, Y);
 
       if (is_dropout) {
         Tensor* mask = context->Output(1, shape);

--- a/onnxruntime/core/providers/cpu/tensor/utils.h
+++ b/onnxruntime/core/providers/cpu/tensor/utils.h
@@ -452,9 +452,7 @@ inline void CopyCpuTensor(const Tensor* src, Tensor* tgt) {
       auto* dst_string = tgt->MutableData<std::string>();
       std::copy(src_span.begin(), src_span.end(), dst_string);
     } else {
-      const auto element_size = src->DataType()->Size();
-      const auto elements = src->Shape().Size();
-      memcpy(target, source, SafeInt<size_t>(elements) * element_size);
+      memcpy(target, source, src->SizeInBytes());
     }
   }
 }

--- a/onnxruntime/core/providers/vitisai/imp/global_api.cc
+++ b/onnxruntime/core/providers/vitisai/imp/global_api.cc
@@ -93,9 +93,16 @@ struct OrtVitisAIEpAPI {
       const std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>& eps,
       const char* const* keys,
       const char* const* values, size_t kv_len) = nullptr;
+  void (*profiler_start)(uint64_t profiling_start_time_us) = nullptr;
+  void (*profiler_stop)() = nullptr;
+  // v1: Original 5-element EventInfo
   void (*profiler_collect)(
       std::vector<EventInfo>& api_events,
-      std::vector<EventInfo>& kernel_events);
+      std::vector<EventInfo>& kernel_events) = nullptr;
+  // v2: Extended 6-element EventInfoV2 with args
+  void (*profiler_collect_v2)(
+      std::vector<EventInfoV2>& api_events,
+      std::vector<EventInfoV2>& kernel_events) = nullptr;
   const char* (*get_compiled_model_compatibility_info)(
       const std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>* eps,
       const void* graph_viewer) = nullptr;
@@ -144,7 +151,10 @@ struct OrtVitisAIEpAPI {
     }
     std::ignore = env.GetSymbolFromLibrary(handle_, "vaip_get_version",
                                            (void**)&vaip_get_version);
+    std::ignore = env.GetSymbolFromLibrary(handle_, "profiler_start", (void**)&profiler_start);
+    std::ignore = env.GetSymbolFromLibrary(handle_, "profiler_stop", (void**)&profiler_stop);
     std::ignore = env.GetSymbolFromLibrary(handle_, "profiler_collect", (void**)&profiler_collect);
+    std::ignore = env.GetSymbolFromLibrary(handle_, "profiler_collect_v2", (void**)&profiler_collect_v2);
     std::ignore = env.GetSymbolFromLibrary(handle_, "get_compiled_model_compatibility_info", (void**)&get_compiled_model_compatibility_info);
     std::ignore = env.GetSymbolFromLibrary(handle_, "validate_compiled_model_compatibility_info", (void**)&validate_compiled_model_compatibility_info);
     ORT_THROW_IF_ERROR(env.GetSymbolFromLibrary(handle_, "create_ep_context_nodes", (void**)&create_ep_context_nodes));
@@ -167,6 +177,12 @@ struct OrtVitisAIEpAPI {
       auto status = env.UnloadDynamicLibrary(handle_);
       vai_assert(status.IsOK(), status.ErrorMessage());
       handle_ = nullptr;
+      // reset profiler function pointers introduced by #27808
+      // this is to avoid calling the function pointers after the library is unloaded
+      profiler_start = nullptr;
+      profiler_stop = nullptr;
+      profiler_collect = nullptr;
+      profiler_collect_v2 = nullptr;
     }
   }
 
@@ -181,12 +197,34 @@ static vaip_core::OrtApiForVaip the_global_api;
 std::shared_ptr<KernelRegistry> get_kernel_registry_vitisaiep() { return s_kernel_registry_vitisaiep; }
 const std::vector<OrtCustomOpDomain*>& get_domains_vitisaiep() { return s_domains_vitisaiep; }
 
+void profiler_start(uint64_t profiling_start_time_us) {
+  if (s_library_vitisaiep.profiler_start) {
+    s_library_vitisaiep.profiler_start(profiling_start_time_us);
+  }
+}
+
+void profiler_stop() {
+  if (s_library_vitisaiep.profiler_stop) {
+    s_library_vitisaiep.profiler_stop();
+  }
+}
+
 void profiler_collect(
     std::vector<EventInfo>& api_events,
     std::vector<EventInfo>& kernel_events) {
   if (s_library_vitisaiep.profiler_collect) {
     s_library_vitisaiep.profiler_collect(api_events, kernel_events);
   }
+}
+
+bool profiler_collect_v2(
+    std::vector<EventInfoV2>& api_events,
+    std::vector<EventInfoV2>& kernel_events) {
+  if (s_library_vitisaiep.profiler_collect_v2) {
+    s_library_vitisaiep.profiler_collect_v2(api_events, kernel_events);
+    return true;
+  }
+  return false;
 }
 
 std::string get_compiled_model_compatibility_info(

--- a/onnxruntime/core/providers/vitisai/include/vaip/global_api.h
+++ b/onnxruntime/core/providers/vitisai/include/vaip/global_api.h
@@ -27,10 +27,19 @@ int vitisai_ep_set_ep_dynamic_options(
     const std::vector<std::unique_ptr<vaip_core::ExecutionProvider>>& eps,
     const char* const* keys,
     const char* const* values, size_t kv_len);
+
+// Notify EP that profiling has started with the base timestamp (in microseconds since epoch)
+// The EP can use this to:
+// 1. Calculate relative timestamps (event_ts - base_ts) for the profiling timeline
+// 2. Store the absolute base timestamp if needed for other purposes
+void profiler_start(uint64_t profiling_start_time_us);
+
+// Notify EP that profiling has stopped
+void profiler_stop();
+
 /**
- * Replace EventRecord with std::tuple<std::string, int ,int, long long, long long>,
- * because EventRecord is defined in profiler_common.h which is used inside onnxruntime.
- * However, profiler_collect function will call vitis ep which can't include profiler_common.h.
+ * EventInfo: Original 5-element tuple (v1 API)
+ * Kept for backward compatibility with older vaip versions.
  */
 using EventInfo = std::tuple<
     std::string,  // name
@@ -42,6 +51,28 @@ using EventInfo = std::tuple<
 void profiler_collect(
     std::vector<EventInfo>& api_events,
     std::vector<EventInfo>& kernel_events);
+
+/**
+ * EventInfoV2: Extended 6-element tuple with args map (v2 API)
+ * 6th element: args map for extended metadata (subgraph_name, flow_type, kernel_idx)
+ */
+using EventInfoV2 = std::tuple<
+    std::string,                                  // name
+    int,                                          // pid
+    int,                                          // tid
+    long long,                                    // timestamp
+    long long,                                    // duration
+    std::unordered_map<std::string, std::string>  // args
+    >;
+
+// v2 API
+// Returns true if the v2 collector symbol was present in the loaded VAIP
+// library (i.e. the EP is v2-capable). Returns false if the symbol is not
+// available, in which case callers should fall back to profiler_collect (v1).
+bool profiler_collect_v2(
+    std::vector<EventInfoV2>& api_events,
+    std::vector<EventInfoV2>& kernel_events);
+
 std::unique_ptr<onnxruntime::IExecutionProvider>
 CreateExecutionProviderFromAnotherEp(const std::string& lib, const OrtSessionOptions& session_options,
                                      std::unordered_map<std::string, std::string>& provider_options);

--- a/onnxruntime/core/providers/vitisai/vitisai_profiler.cc
+++ b/onnxruntime/core/providers/vitisai/vitisai_profiler.cc
@@ -11,37 +11,82 @@ namespace profiling {
 #if defined(USE_VITISAI)
 
 bool VitisaiProfiler::StartProfiling(TimePoint tp) {
+  // Notify VAIP EP that profiling has started with base timestamp
+  profiler_start(std::chrono::duration_cast<std::chrono::microseconds>(
+                     tp.time_since_epoch())
+                     .count());
   return true;
 }
 
 void VitisaiProfiler::EndProfiling(TimePoint tp, Events& events) {
+  // Notify VAIP EP that profiling has stopped
+  // Contract: the VAIP EP must preserve any pending/buffered event data after
+  // profiler_stop() returns, so that the subsequent profiler_collect[_v2]()
+  // call below can still retrieve the full set of recorded events. The EP is
+  // expected to release that buffered data only after collection completes
+  // (or on the next profiler_start()).
+  profiler_stop();
+
   auto time_point =
       std::chrono::duration_cast<std::chrono::microseconds>(tp.time_since_epoch()).count();
 
-  std::vector<EventInfo> api_events;
-  std::vector<EventInfo> kernel_events;
-  profiler_collect(api_events, kernel_events);
+  // Try v2 first
+  // Use the free function wrappers which internally null-check the pointers.
+  std::vector<EventInfoV2> api_events_v2;
+  std::vector<EventInfoV2> kernel_events_v2;
+  const bool v2_available = profiler_collect_v2(api_events_v2, kernel_events_v2);
 
-  InlinedHashMap<std::string, std::string> event_args;
+  if (v2_available) {
+    for (auto& a : api_events_v2) {
+      auto& src_args = std::get<5>(a);
+      decltype(EventRecord::args) args(src_args.begin(), src_args.end());
+      events.emplace_back(EventCategory::API_EVENT,
+                          std::get<1>(a),
+                          std::get<2>(a),
+                          std::get<0>(a),
+                          std::get<3>(a) - time_point,
+                          std::get<4>(a),
+                          std::move(args));
+    }
 
-  for (auto& a : api_events) {
-    events.emplace_back(EventCategory::API_EVENT,
-                        std::get<1>(a),               // pid
-                        std::get<2>(a),               // tid
-                        std::get<0>(a),               // name
-                        std::get<3>(a) - time_point,  // timestamp
-                        std::get<4>(a),               // duration
-                        event_args);
-  }
+    for (auto& k : kernel_events_v2) {
+      auto& src_args = std::get<5>(k);
+      decltype(EventRecord::args) args(src_args.begin(), src_args.end());
+      events.emplace_back(EventCategory::KERNEL_EVENT,
+                          std::get<1>(k),
+                          std::get<2>(k),
+                          std::get<0>(k),
+                          std::get<3>(k) - time_point,
+                          std::get<4>(k),
+                          std::move(args));
+    }
+  } else {
+    // Fall back to v1 API
+    std::vector<EventInfo> api_events;
+    std::vector<EventInfo> kernel_events;
+    profiler_collect(api_events, kernel_events);
 
-  for (auto& k : kernel_events) {
-    events.emplace_back(EventCategory::KERNEL_EVENT,
-                        std::get<1>(k),
-                        std::get<2>(k),
-                        std::get<0>(k),
-                        std::get<3>(k) - time_point,
-                        std::get<4>(k),
-                        event_args);
+    decltype(EventRecord::args) event_args;
+
+    for (auto& a : api_events) {
+      events.emplace_back(EventCategory::API_EVENT,
+                          std::get<1>(a),
+                          std::get<2>(a),
+                          std::get<0>(a),
+                          std::get<3>(a) - time_point,
+                          std::get<4>(a),
+                          event_args);
+    }
+
+    for (auto& k : kernel_events) {
+      events.emplace_back(EventCategory::KERNEL_EVENT,
+                          std::get<1>(k),
+                          std::get<2>(k),
+                          std::get<0>(k),
+                          std::get<3>(k) - time_point,
+                          std::get<4>(k),
+                          event_args);
+    }
   }
 }
 

--- a/onnxruntime/test/providers/cpu/tensor/cast_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/cast_op_test.cc
@@ -10,6 +10,9 @@
 #include "gtest/gtest.h"
 
 #include "core/framework/data_types_internal.h"
+#include "core/framework/int2.h"
+#include "core/framework/tensor.h"
+#include "core/providers/cpu/tensor/utils.h"
 
 #include "test/common/cuda_op_test_utils.h"
 #include "test/providers/provider_test_utils.h"
@@ -2730,6 +2733,220 @@ TEST(CastOpTest, Float4E2M1x2ToFloat) {
 }
 
 #endif
+
+// Regression tests for sub-byte same-type cast (CopyCpuTensor heap overflow fix).
+// When src and dst types are the same, Cast::Compute calls CopyCpuTensor which must
+// use SizeInBytes() (not shape.Size() * DataType()->Size()) for the memcpy byte count.
+
+TEST(CastOpTest, Int4x2ToInt4x2_SameType) {
+  const std::vector<int64_t> shape{3, 3};  // 9 elements (odd, tests ceil-division)
+  const std::vector<Int4x2> input = {
+      Int4x2(-8, 7),
+      Int4x2(0, -1),
+      Int4x2(3, -5),
+      Int4x2(6, 2),
+      Int4x2(1, 0)  // 9th element in low nibble of 5th byte (padding in high nibble)
+  };
+
+  TestCastOp(gsl::make_span(input), gsl::make_span(input), shape);
+}
+
+TEST(CastOpTest, UInt4x2ToUInt4x2_SameType) {
+  const std::vector<int64_t> shape{2, 5};  // 10 elements (even)
+  const std::vector<UInt4x2> input = {
+      UInt4x2(0, 15),
+      UInt4x2(1, 14),
+      UInt4x2(7, 8),
+      UInt4x2(3, 6),
+      UInt4x2(9, 11)};
+
+  TestCastOp(gsl::make_span(input), gsl::make_span(input), shape);
+}
+
+TEST(CastOpTest, Int4x2ToInt4x2_LargeShape) {
+  // Large shape (16464 elements)
+  const std::vector<int64_t> shape{28, 6, 14, 7};
+  const int64_t num_elements = 28 * 6 * 14 * 7;  // 16464
+  const size_t num_storage = static_cast<size_t>((num_elements + 1) / 2);
+
+  std::vector<Int4x2> input_vec(num_storage);
+  for (size_t i = 0; i < num_storage; ++i) {
+    input_vec[i] = Int4x2(static_cast<int8_t>(i % 8), static_cast<int8_t>(-(static_cast<int8_t>(i % 7))));
+  }
+  const auto& input = input_vec;
+
+  TestCastOp(gsl::make_span(input), gsl::make_span(input), shape);
+}
+
+TEST(CastOpTest, Int2x4ToInt2x4_SameType) {
+  const std::vector<int64_t> shape{5};  // 5 elements (not multiple of 4, tests ceil-division)
+  const std::vector<Int2x4> input = {
+      Int2x4(-2, 1, 0, -1),
+      Int2x4(1, 0, 0, 0)  // 5th element in first position (padding in positions 2-4)
+  };
+
+  TestCastOpInt2(gsl::make_span(input), gsl::make_span(input), shape);
+}
+
+TEST(CastOpTest, UInt4x2ToUInt4x2_LargeShape) {
+  const std::vector<int64_t> shape{28, 6, 14, 7};
+  const int64_t num_elements = 28 * 6 * 14 * 7;  // 16464
+  const size_t num_storage = static_cast<size_t>((num_elements + 1) / 2);
+
+  std::vector<UInt4x2> input_vec(num_storage);
+  for (size_t i = 0; i < num_storage; ++i) {
+    input_vec[i] = UInt4x2(static_cast<uint8_t>(i % 16), static_cast<uint8_t>((i + 3) % 16));
+  }
+  const auto& input = input_vec;
+
+  TestCastOp(gsl::make_span(input), gsl::make_span(input), shape);
+}
+
+TEST(CastOpTest, Int2x4ToInt2x4_LargeShape) {
+  const std::vector<int64_t> shape{100, 100};  // 10000 elements (not multiple of 4)
+  const int64_t num_elements = 100 * 100;
+  const size_t num_storage = static_cast<size_t>((num_elements + 3) / 4);
+
+  std::vector<Int2x4> input_vec(num_storage);
+  for (size_t i = 0; i < num_storage; ++i) {
+    input_vec[i] = Int2x4(static_cast<int8_t>(i % 2), static_cast<int8_t>(-(static_cast<int8_t>(i % 2))),
+                          static_cast<int8_t>((i + 1) % 2), static_cast<int8_t>(0));
+  }
+  const auto& input = input_vec;
+
+  TestCastOpInt2(gsl::make_span(input), gsl::make_span(input), shape);
+}
+
+TEST(CastOpTest, UInt2x4ToUInt2x4_LargeShape) {
+  const std::vector<int64_t> shape{100, 101};  // 10100 elements (not multiple of 4)
+  const int64_t num_elements = 100 * 101;
+  const size_t num_storage = static_cast<size_t>((num_elements + 3) / 4);
+
+  std::vector<UInt2x4> input_vec(num_storage);
+  for (size_t i = 0; i < num_storage; ++i) {
+    input_vec[i] = UInt2x4(static_cast<uint8_t>(i % 4), static_cast<uint8_t>((i + 1) % 4),
+                           static_cast<uint8_t>((i + 2) % 4), static_cast<uint8_t>((i + 3) % 4));
+  }
+  const auto& input = input_vec;
+
+  TestCastOpInt2(gsl::make_span(input), gsl::make_span(input), shape);
+}
+
+// Direct CopyCpuTensor test with guaranteed distinct buffers to exercise the memcpy path.
+// This bypasses the MayInplace optimization that can alias input/output in OpTester.
+// Uses guard bytes after the valid buffer region to detect overflow deterministically
+// without relying on ASan — the pre-fix code would overwrite these sentinel bytes.
+TEST(CastOpTest, CopyCpuTensor_SubByteTypes_DistinctBuffers) {
+  constexpr uint8_t kGuardByte = 0xCD;
+  constexpr size_t kGuardSize = 64;
+
+  // Helper: allocate a buffer of `valid_bytes` + guard region, fill guard with sentinel,
+  // then construct a non-owning Tensor over the valid portion.
+  auto make_guarded_tensor = [&](MLDataType dtype, const TensorShape& shape,
+                                 size_t valid_bytes, std::vector<uint8_t>& backing) {
+    backing.resize(valid_bytes + kGuardSize);
+    std::memset(backing.data() + valid_bytes, kGuardByte, kGuardSize);
+    return Tensor(dtype, shape, backing.data(), OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator));
+  };
+
+  auto check_guard = [&](const std::vector<uint8_t>& backing, size_t valid_bytes,
+                         const char* label) {
+    for (size_t i = 0; i < kGuardSize; ++i) {
+      EXPECT_EQ(backing[valid_bytes + i], kGuardByte)
+          << label << ": guard byte at offset " << i << " was overwritten (heap overflow detected)";
+    }
+  };
+
+  // Test Int4x2 with odd element count (ceil-division edge case)
+  {
+    const int64_t num_logical_elements = 17;  // odd: requires ceil(17/2) = 9 storage bytes
+    TensorShape shape({num_logical_elements});
+    auto int4_type = DataTypeImpl::GetType<Int4x2>();
+    constexpr size_t expected_bytes = 9;
+
+    std::vector<uint8_t> src_backing, dst_backing;
+    Tensor src = make_guarded_tensor(int4_type, shape, expected_bytes, src_backing);
+    Tensor dst = make_guarded_tensor(int4_type, shape, expected_bytes, dst_backing);
+
+    ASSERT_EQ(src.SizeInBytes(), expected_bytes);
+
+    // Fill source with known pattern
+    for (size_t i = 0; i < expected_bytes; ++i) {
+      src_backing[i] = static_cast<uint8_t>(0xA0 + i);
+    }
+    // Fill destination valid region with different pattern
+    std::memset(dst_backing.data(), 0xFF, expected_bytes);
+
+    ASSERT_NE(src.DataRaw(), dst.MutableDataRaw());
+
+    CopyCpuTensor(&src, &dst);
+
+    // Verify copy correctness
+    for (size_t i = 0; i < expected_bytes; ++i) {
+      EXPECT_EQ(dst_backing[i], src_backing[i]) << "Int4x2: mismatch at byte " << i;
+    }
+    // Verify no overflow past the valid region
+    check_guard(src_backing, expected_bytes, "Int4x2 src");
+    check_guard(dst_backing, expected_bytes, "Int4x2 dst");
+  }
+
+  // Test UInt4x2 with large even element count (matches PoC shape)
+  {
+    const int64_t num_logical_elements = 16464;  // from PoC: ceil(16464/2) = 8232 bytes
+    TensorShape shape({num_logical_elements});
+    auto uint4_type = DataTypeImpl::GetType<UInt4x2>();
+    constexpr size_t expected_bytes = 8232;
+
+    std::vector<uint8_t> src_backing, dst_backing;
+    Tensor src = make_guarded_tensor(uint4_type, shape, expected_bytes, src_backing);
+    Tensor dst = make_guarded_tensor(uint4_type, shape, expected_bytes, dst_backing);
+
+    ASSERT_EQ(src.SizeInBytes(), expected_bytes);
+
+    for (size_t i = 0; i < expected_bytes; ++i) {
+      src_backing[i] = static_cast<uint8_t>(i & 0xFF);
+    }
+    std::memset(dst_backing.data(), 0xFF, expected_bytes);
+
+    ASSERT_NE(src.DataRaw(), dst.MutableDataRaw());
+
+    CopyCpuTensor(&src, &dst);
+
+    for (size_t i = 0; i < expected_bytes; ++i) {
+      EXPECT_EQ(dst_backing[i], src_backing[i]) << "UInt4x2: mismatch at byte " << i;
+    }
+    check_guard(src_backing, expected_bytes, "UInt4x2 src");
+    check_guard(dst_backing, expected_bytes, "UInt4x2 dst");
+  }
+
+  // Test Int2x4 (4 elements per byte — would be 4x overflow with old code)
+  {
+    const int64_t num_logical_elements = 7;  // ceil(7/4) = 2 storage bytes
+    TensorShape shape({num_logical_elements});
+    auto int2_type = DataTypeImpl::GetType<Int2x4>();
+    constexpr size_t expected_bytes = 2;
+
+    std::vector<uint8_t> src_backing, dst_backing;
+    Tensor src = make_guarded_tensor(int2_type, shape, expected_bytes, src_backing);
+    Tensor dst = make_guarded_tensor(int2_type, shape, expected_bytes, dst_backing);
+
+    ASSERT_EQ(src.SizeInBytes(), expected_bytes);
+
+    src_backing[0] = 0xAB;
+    src_backing[1] = 0xCD;
+    std::memset(dst_backing.data(), 0xFF, expected_bytes);
+
+    ASSERT_NE(src.DataRaw(), dst.MutableDataRaw());
+
+    CopyCpuTensor(&src, &dst);
+
+    for (size_t i = 0; i < expected_bytes; ++i) {
+      EXPECT_EQ(dst_backing[i], src_backing[i]) << "Int2x4: mismatch at byte " << i;
+    }
+    check_guard(src_backing, expected_bytes, "Int2x4 src");
+    check_guard(dst_backing, expected_bytes, "Int2x4 dst");
+  }
+}
 
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
This cherry-picks the following commits for the release:

#28171 Fix overflow in CopyCpuTensor for sub-byte types
#27808 [VitisAI] pass base timestamp for vitisai profiling

