### PR TITLE
fix(ci): 'rc' qualifier ignored when packaging `onnxruntime-node`

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -421,10 +421,14 @@ stages:
         targetPath: $(Build.ArtifactStagingDirectory)
         artifactName: 'NPM_packages'
     variables:
-      ${{ if eq(parameters.IsReleaseBuild, true) }}:
+      ${{ if and(parameters.IsReleaseBuild, eq(parameters.PreReleaseVersionSuffixString, 'none')) }}:
         NpmPackagingMode: 'release'
-      ${{ if not(eq(parameters.IsReleaseBuild, true)) }}:
+      ${{ elseif and(parameters.IsReleaseBuild, eq(parameters.PreReleaseVersionSuffixString, 'rc')) }}:
+        NpmPackagingMode: 'rc'
+      ${{ elseif not(parameters.IsReleaseBuild) }}:
         NpmPackagingMode: 'dev'
+      ${{ else }}: # IsReleaseBuild + beta, alpha, etc. We don't support those and those suffixes are deprecated.
+        NpmPackagingMode: '<INVALID/UNSUPPORTED COMBINATION>'
 
     steps:
     - checkout: self


### PR DESCRIPTION
### Description

Fix `onnxruntime-node` and `onnxruntime-common` NPM packages lacking an RC suffix when built in Release + RC mode.
This isn't great, the suffix looks like `-QUAL.DATE-COMMIT`. This'll break the publishing pipeline if the packaging pipelines (zip-nuget and NPM) span more than a single day due to same-version checks/enforcement.

### Motivation and Context

Missing the RC qualifier/suffix fails the NPM publish pipeline. It correctly assets that the (onnxruntime-node, onnxruntime-common, and onnxruntime-web) do not share a common version specifier.