### PR TITLE
fix: guard ORT_USE_CPUINFO on __linux__ to fix FreeBSD build

### DIFF
--- a/onnxruntime/core/platform/posix/env.cc
+++ b/onnxruntime/core/platform/posix/env.cc
@@ -38,11 +38,12 @@ limitations under the License.
 #include <utility>  // for std::forward
 #include <vector>
 
-// We can not use CPUINFO if it is not supported and we do not want to use
+// We can not use CPUINFO if it is not supported and we do not want to used
 // it on certain platforms because of the binary size increase.
 // We could use it to find out the number of physical cores for certain supported platforms
-#if defined(CPUINFO_SUPPORTED) && defined(__linux__)
+#if defined(CPUINFO_SUPPORTED) && !defined(__APPLE__) && !defined(__ANDROID__) && !defined(__wasm__) && !defined(_AIX) && defined(__linux__)
 #include <cpuinfo.h>
+#define ORT_USE_CPUINFO
 #endif
 
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__)
@@ -266,17 +267,17 @@ class PosixEnv : public Env {
 
   // Return the number of physical cores
   int GetNumPhysicalCpuCores() const override {
-#if defined(CPUINFO_SUPPORTED) && defined(__linux__)
+#ifdef ORT_USE_CPUINFO
     if (cpuinfo_available_) {
       return narrow<int>(cpuinfo_get_cores_count());
     }
-#endif  // defined(CPUINFO_SUPPORTED) && defined(__linux__)
+#endif  // ORT_USE_CPUINFO
     return DefaultNumCores();
   }
 
   std::vector<LogicalProcessors> GetDefaultThreadAffinities() const override {
     std::vector<LogicalProcessors> ret;
-#if defined(CPUINFO_SUPPORTED) && defined(__linux__)
+#ifdef ORT_USE_CPUINFO
     if (cpuinfo_available_) {
       auto num_phys_cores = cpuinfo_get_cores_count();
       ret.reserve(num_phys_cores);
@@ -292,7 +293,7 @@ class PosixEnv : public Env {
         ret.push_back(std::move(th_aff));
       }
     }
-#endif  // defined(CPUINFO_SUPPORTED) && defined(__linux__)
+#endif
     // Just the size of the thread-pool
     if (ret.empty()) {
       ret.resize(GetNumPhysicalCpuCores());
@@ -626,7 +627,7 @@ class PosixEnv : public Env {
 
  private:
   Telemetry telemetry_provider_;
-#if defined(CPUINFO_SUPPORTED) && defined(__linux__)
+#ifdef ORT_USE_CPUINFO
   PosixEnv() {
     cpuinfo_available_ = cpuinfo_initialize();
     if (!cpuinfo_available_) {
@@ -644,7 +645,7 @@ class PosixEnv : public Env {
     }
   }
   bool cpuinfo_available_{false};
-#endif  // defined(CPUINFO_SUPPORTED) && defined(__linux__)
+#endif  // ORT_USE_CPUINFO
 };
 
 }  // namespace

--- a/onnxruntime/core/platform/posix/env.cc
+++ b/onnxruntime/core/platform/posix/env.cc
@@ -41,7 +41,7 @@ limitations under the License.
 // We can not use CPUINFO if it is not supported and we do not want to used
 // it on certain platforms because of the binary size increase.
 // We could use it to find out the number of physical cores for certain supported platforms
-#if defined(CPUINFO_SUPPORTED) && !defined(__APPLE__) && !defined(__ANDROID__) && !defined(__wasm__) && !defined(_AIX) && defined(__linux__)
+#if defined(CPUINFO_SUPPORTED) && !defined(__APPLE__) && !defined(__ANDROID__) && !defined(__wasm__) && !defined(_AIX)
 #include <cpuinfo.h>
 #define ORT_USE_CPUINFO
 #endif
@@ -277,7 +277,7 @@ class PosixEnv : public Env {
 
   std::vector<LogicalProcessors> GetDefaultThreadAffinities() const override {
     std::vector<LogicalProcessors> ret;
-#ifdef ORT_USE_CPUINFO
+#if defined(ORT_USE_CPUINFO) && defined(__linux__)
     if (cpuinfo_available_) {
       auto num_phys_cores = cpuinfo_get_cores_count();
       ret.reserve(num_phys_cores);
@@ -293,7 +293,7 @@ class PosixEnv : public Env {
         ret.push_back(std::move(th_aff));
       }
     }
-#endif
+#endif  // defined(ORT_USE_CPUINFO) && defined(__linux__)
     // Just the size of the thread-pool
     if (ret.empty()) {
       ret.resize(GetNumPhysicalCpuCores());

--- a/onnxruntime/core/platform/posix/env.cc
+++ b/onnxruntime/core/platform/posix/env.cc
@@ -38,12 +38,11 @@ limitations under the License.
 #include <utility>  // for std::forward
 #include <vector>
 
-// We can not use CPUINFO if it is not supported and we do not want to used
+// We can not use CPUINFO if it is not supported and we do not want to use
 // it on certain platforms because of the binary size increase.
 // We could use it to find out the number of physical cores for certain supported platforms
-#if defined(CPUINFO_SUPPORTED) && !defined(__APPLE__) && !defined(__ANDROID__) && !defined(__wasm__) && !defined(_AIX) && defined(__linux__)
+#if defined(CPUINFO_SUPPORTED) && defined(__linux__)
 #include <cpuinfo.h>
-#define ORT_USE_CPUINFO
 #endif
 
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__)
@@ -267,17 +266,17 @@ class PosixEnv : public Env {
 
   // Return the number of physical cores
   int GetNumPhysicalCpuCores() const override {
-#ifdef ORT_USE_CPUINFO
+#if defined(CPUINFO_SUPPORTED) && defined(__linux__)
     if (cpuinfo_available_) {
       return narrow<int>(cpuinfo_get_cores_count());
     }
-#endif  // ORT_USE_CPUINFO
+#endif  // defined(CPUINFO_SUPPORTED) && defined(__linux__)
     return DefaultNumCores();
   }
 
   std::vector<LogicalProcessors> GetDefaultThreadAffinities() const override {
     std::vector<LogicalProcessors> ret;
-#ifdef ORT_USE_CPUINFO
+#if defined(CPUINFO_SUPPORTED) && defined(__linux__)
     if (cpuinfo_available_) {
       auto num_phys_cores = cpuinfo_get_cores_count();
       ret.reserve(num_phys_cores);
@@ -293,7 +292,7 @@ class PosixEnv : public Env {
         ret.push_back(std::move(th_aff));
       }
     }
-#endif
+#endif  // defined(CPUINFO_SUPPORTED) && defined(__linux__)
     // Just the size of the thread-pool
     if (ret.empty()) {
       ret.resize(GetNumPhysicalCpuCores());
@@ -627,7 +626,7 @@ class PosixEnv : public Env {
 
  private:
   Telemetry telemetry_provider_;
-#ifdef ORT_USE_CPUINFO
+#if defined(CPUINFO_SUPPORTED) && defined(__linux__)
   PosixEnv() {
     cpuinfo_available_ = cpuinfo_initialize();
     if (!cpuinfo_available_) {
@@ -645,7 +644,7 @@ class PosixEnv : public Env {
     }
   }
   bool cpuinfo_available_{false};
-#endif  // ORT_USE_CPUINFO
+#endif  // defined(CPUINFO_SUPPORTED) && defined(__linux__)
 };
 
 }  // namespace

--- a/onnxruntime/core/platform/posix/env.cc
+++ b/onnxruntime/core/platform/posix/env.cc
@@ -41,7 +41,7 @@ limitations under the License.
 // We can not use CPUINFO if it is not supported and we do not want to used
 // it on certain platforms because of the binary size increase.
 // We could use it to find out the number of physical cores for certain supported platforms
-#if defined(CPUINFO_SUPPORTED) && !defined(__APPLE__) && !defined(__ANDROID__) && !defined(__wasm__) && !defined(_AIX)
+#if defined(CPUINFO_SUPPORTED) && !defined(__APPLE__) && !defined(__ANDROID__) && !defined(__wasm__) && !defined(_AIX) && defined(__linux__)
 #include <cpuinfo.h>
 #define ORT_USE_CPUINFO
 #endif


### PR DESCRIPTION
### Description

Building OnnxRuntime on FreeBSD currently fails with:

```
error: no member named 'linux_id' in 'cpuinfo_processor'
```

`cpuinfo`'s `cpuinfo_processor::linux_id` field is only defined when `__linux__` is set (it represents the Linux sysfs / `cpu_set_t` processor index). The existing guard in `onnxruntime/core/platform/posix/env.cc` excluded Apple, Android, wasm and AIX, but left FreeBSD (and other non-Linux POSIX targets such as NetBSD/OpenBSD) inside `ORT_USE_CPUINFO`, so `GetDefaultThreadAffinities` accessed a non-existent field on those platforms.

### Fix

Add `&& defined(__linux__)` to the `ORT_USE_CPUINFO` guard. This:

- Mirrors the field's own visibility in upstream `pytorch/cpuinfo`.
- Matches the pattern already used in `onnxruntime/core/common/cpuid_info.cc`, which wraps all `CPUINFO_SUPPORTED` usage in `#if defined(__linux__)`.
- Is a no-op on Linux (where `__linux__` is always defined) and on the platforms that were already excluded.
- Restores the FreeBSD / non-Linux POSIX build, which falls back to the existing `DefaultNumCores()` / empty-affinity path that those targets had before cpuinfo was introduced.

### Behavior

- Linux: unchanged (cpuinfo still drives `GetNumPhysicalCpuCores` and `GetDefaultThreadAffinities`).
- Apple / Android / wasm / AIX: unchanged (already excluded).
- FreeBSD / NetBSD / OpenBSD / other non-Linux POSIX: builds successfully, uses the pre-existing fallback paths.

### Verification

- `lintrunner -a` clean.
- Diff is a single token added to one preprocessor line; no test or runtime-behavior changes on Linux.
- Build verification on non-Linux POSIX targets is left to the FreeBSD ports / downstream CI as no FreeBSD CI lane exists in this repo.

Fixes #23181