### PR TITLE
Remove data hash from hashing code, to prevent unbounded growth issue

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -9,6 +9,9 @@ set(MLAS_INC_DIR ${MLAS_ROOT}/inc)
 # mlas_private_compile_definitions contains compile definitions that are private to onnxruntime_mlas and targets which
 # use internal MLAS headers like mlasi.h.
 set(mlas_private_compile_definitions)
+if(onnxruntime_BUILD_UNIT_TESTS)
+  list(APPEND mlas_private_compile_definitions MLAS_ENABLE_TEST_HOOKS)
+endif()
 #
 # All hardware agnostic source files here
 # hardware specific files would cause trouble in

--- a/onnxruntime/core/mlas/lib/kleidiai/convolve_kleidiai.cpp
+++ b/onnxruntime/core/mlas/lib/kleidiai/convolve_kleidiai.cpp
@@ -44,14 +44,12 @@ struct LhsCacheKey {
     size_t padding, sh, sw;
     size_t kh, kw;
     size_t dilationh, dilationw;
-    size_t data_hash;
 
     bool operator==(const LhsCacheKey& other) const {
         return ci == other.ci && ih == other.ih && iw == other.iw &&
                padding == other.padding && sh == other.sh && sw == other.sw &&
                kh == other.kh && kw == other.kw &&
-               dilationh == other.dilationh && dilationw == other.dilationw &&
-               data_hash == other.data_hash;
+               dilationh == other.dilationh && dilationw == other.dilationw;
     }
 };
 
@@ -88,8 +86,7 @@ namespace std {
     template<>
     struct hash<LhsCacheKey> {
         size_t operator()(const LhsCacheKey& k) const {
-            return k.data_hash ^
-                (std::hash<size_t>()(k.ci) << 1) ^
+            return (std::hash<size_t>()(k.ci) << 1) ^
                 (std::hash<size_t>()(k.ih) << 2) ^
                 (std::hash<size_t>()(k.iw) << 3) ^
                 (std::hash<size_t>()(k.padding) << 4) ^
@@ -103,6 +100,42 @@ namespace std {
     };
 
 }
+
+namespace {
+
+using LhsPtrsCache = std::unordered_map<LhsCacheKey, std::shared_ptr<const void*[]>>;
+
+thread_local std::unordered_map<const float*, LhsPtrsCache> lhs_ptrs_cache_by_pad;
+thread_local const float* last_pad_ptr = nullptr;
+
+size_t LhsPtrsCacheEntryCount() {
+    size_t count = 0;
+    for (const auto& cache_group : lhs_ptrs_cache_by_pad) {
+        count += cache_group.second.size();
+    }
+    return count;
+}
+
+void ClearLhsPtrsCache() {
+    lhs_ptrs_cache_by_pad.clear();
+    last_pad_ptr = nullptr;
+}
+
+}  // namespace
+
+#if defined(MLAS_ENABLE_TEST_HOOKS)
+size_t
+MLASCALL
+ArmKleidiAI::MlasConvLhsCacheEntryCountForTest() {
+    return LhsPtrsCacheEntryCount();
+}
+
+void
+MLASCALL
+ArmKleidiAI::MlasConvClearLhsCacheForTest() {
+    ClearLhsPtrsCache();
+}
+#endif
 
 
 static constexpr size_t ComputeKernelSize(const size_t D, const size_t K) {
@@ -491,23 +524,19 @@ static std::unique_ptr<std::byte[]> LhsPackImageDataSme(const size_t ci, const s
     // Entries include pointers to the pad buffer for out-of-bounds pixels, so we must not reuse entries after the
     // pad buffer is reallocated. To avoid clearing the entire cache, we group caches by pad buffer identity and
     // invalidate only the old group when the pad buffer moves.
-    using LhsPtrsCache = std::unordered_map<LhsCacheKey, std::shared_ptr<const void*[]>>;
-    thread_local std::unordered_map<const float*, LhsPtrsCache> lhs_ptrs_cache_by_pad;
-
     // If pad_ptr moved (vector reallocation), drop only the old group to avoid accumulating unreachable entries.
-    thread_local const float* last_pad_ptr = nullptr;
     const float* cur_pad_ptr = pad_ptr.data();
     if (last_pad_ptr != nullptr && last_pad_ptr != cur_pad_ptr) {
         lhs_ptrs_cache_by_pad.erase(last_pad_ptr);
     }
     last_pad_ptr = cur_pad_ptr;
 
+    // LhsPtrFill stores geometry offsets only; the current input base is supplied when packing.
     LhsCacheKey key = {
         ci, ih, iw,
         padding, sh, sw,
         kh, kw,
-        1, 1,
-        HashWeights(in)
+        1, 1
     };
 
     auto& lhs_ptrs_cache = lhs_ptrs_cache_by_pad[cur_pad_ptr];

--- a/onnxruntime/core/mlas/lib/kleidiai/mlasi_kleidiai.h
+++ b/onnxruntime/core/mlas/lib/kleidiai/mlasi_kleidiai.h
@@ -199,6 +199,16 @@ MlasConv(
     float* Output,
     MLAS_THREADPOOL* ThreadPool
     );
+
+#if defined(MLAS_ENABLE_TEST_HOOKS)
+size_t
+MLASCALL
+MlasConvLhsCacheEntryCountForTest();
+
+void
+MLASCALL
+MlasConvClearLhsCacheForTest();
+#endif
 }
 
 /*++

--- a/onnxruntime/test/mlas/unittest/test_conv2d.h
+++ b/onnxruntime/test/mlas/unittest/test_conv2d.h
@@ -4,11 +4,16 @@
 #pragma once
 
 #include <cstring>
+#include <vector>
 
 #include "test_util.h"
 
 #if defined(MLAS_TARGET_AMD64)
 #include "core/mlas/lib/mlasi.h"
+#endif
+
+#if defined(USE_KLEIDIAI) && defined(MLAS_ENABLE_TEST_HOOKS)
+#include "core/mlas/lib/kleidiai/mlasi_kleidiai.h"
 #endif
 
 template <bool Threaded>
@@ -302,6 +307,168 @@ class MlasConv2DTest : public MlasTestBase {
   }
 
   MlasConv2DTest() : threadpool_(Threaded ? GetMlasThreadPool() : nullptr) {}
+
+#if defined(USE_KLEIDIAI) && defined(MLAS_ENABLE_TEST_HOOKS)
+  void TestKleidiAILhsCacheIgnoresInputContent() {
+    if (!ArmKleidiAI::UseSME) {
+      return;
+    }
+
+    struct ConvGeometry {
+      const char* name;
+      size_t input_channels;
+      size_t input_height;
+      size_t input_width;
+      size_t filter_count;
+      size_t kernel_height;
+      size_t kernel_width;
+      size_t padding;
+      size_t dilation_height;
+      size_t dilation_width;
+      size_t stride_height;
+      size_t stride_width;
+    };
+
+    constexpr size_t BatchCount = 1;
+    constexpr size_t GroupCount = 1;
+    constexpr ConvGeometry geometries[] = {
+        {"padded_3x3", 16, 11, 11, 32, 3, 3, 1, 1, 1, 1, 1},
+        {"strided_3x3", 24, 13, 9, 16, 3, 3, 1, 1, 1, 2, 2},
+        {"dilated_3x3", 8, 15, 13, 20, 3, 3, 2, 2, 2, 1, 1},
+        {"wide_kernel", 12, 10, 12, 24, 3, 5, 2, 1, 1, 1, 2},
+    };
+
+    const auto fill_input = [](std::vector<float>& input, size_t seed) {
+      for (size_t i = 0; i < input.size(); ++i) {
+        input[i] = static_cast<float>((static_cast<int>((i * (seed + 3)) % 31) - 15) * 0.075f +
+                                      static_cast<float>(seed) * 0.125f);
+      }
+    };
+
+    for (const auto& geometry : geometries) {
+      SCOPED_TRACE(geometry.name);
+
+      const int64_t output_height64 =
+          ((int64_t(geometry.input_height) + 2 * int64_t(geometry.padding)) -
+           (int64_t(geometry.dilation_height) * (int64_t(geometry.kernel_height) - 1) + 1)) /
+              int64_t(geometry.stride_height) +
+          1;
+      const int64_t output_width64 =
+          ((int64_t(geometry.input_width) + 2 * int64_t(geometry.padding)) -
+           (int64_t(geometry.dilation_width) * (int64_t(geometry.kernel_width) - 1) + 1)) /
+              int64_t(geometry.stride_width) +
+          1;
+
+      ASSERT_GT(output_height64, 0);
+      ASSERT_GT(output_width64, 0);
+
+      const size_t output_height = static_cast<size_t>(output_height64);
+      const size_t output_width = static_cast<size_t>(output_width64);
+      const size_t input_elements =
+          BatchCount * GroupCount * geometry.input_channels * geometry.input_height * geometry.input_width;
+      const size_t filter_elements = GroupCount * geometry.filter_count * geometry.input_channels *
+                                     geometry.kernel_height * geometry.kernel_width;
+      const size_t bias_elements = GroupCount * geometry.filter_count;
+      const size_t output_elements = BatchCount * GroupCount * geometry.filter_count * output_height * output_width;
+
+      std::vector<float> input_a(input_elements);
+      std::vector<float> input_a_copy(input_elements);
+      std::vector<float> input_b(input_elements);
+      std::vector<float> filter(filter_elements);
+      std::vector<float> bias(bias_elements);
+      std::vector<float> output(output_elements);
+      std::vector<float> output_reference(output_elements);
+
+      fill_input(input_a, 1);
+      input_a_copy = input_a;
+      fill_input(input_b, 2);
+
+      for (size_t i = 0; i < filter_elements; ++i) {
+        filter[i] = static_cast<float>((static_cast<int>((i * 5) % 23) - 11) * 0.05f);
+      }
+
+      for (size_t i = 0; i < bias_elements; ++i) {
+        bias[i] = static_cast<float>((static_cast<int>(i % 7) - 3) * 0.02f);
+      }
+
+      const auto verify_conv = [&](const std::vector<float>& input, const char* label) {
+        SCOPED_TRACE(label);
+
+        MlasConv2D(BatchCount,
+                   GroupCount,
+                   geometry.input_channels,
+                   geometry.input_height,
+                   geometry.input_width,
+                   geometry.filter_count,
+                   geometry.kernel_height,
+                   geometry.kernel_width,
+                   geometry.padding,
+                   geometry.padding,
+                   geometry.padding,
+                   geometry.padding,
+                   geometry.dilation_height,
+                   geometry.dilation_width,
+                   geometry.stride_height,
+                   geometry.stride_width,
+                   output_height,
+                   output_width,
+                   input.data(),
+                   filter.data(),
+                   bias.data(),
+                   output.data());
+
+        ReferenceConv2D(BatchCount,
+                        GroupCount,
+                        geometry.input_channels,
+                        geometry.input_height,
+                        geometry.input_width,
+                        geometry.filter_count,
+                        geometry.kernel_height,
+                        geometry.kernel_width,
+                        geometry.padding,
+                        geometry.padding,
+                        geometry.dilation_height,
+                        geometry.dilation_width,
+                        geometry.stride_height,
+                        geometry.stride_width,
+                        output_height,
+                        output_width,
+                        input.data(),
+                        filter.data(),
+                        bias.data(),
+                        output_reference.data());
+
+        for (size_t i = 0; i < output_elements; ++i) {
+          ASSERT_TRUE(CloseEnough(output[i], output_reference[i]))
+              << "Mismatch at output index " << i
+              << ": actual=" << output[i]
+              << ", expected=" << output_reference[i];
+        }
+      };
+
+      ArmKleidiAI::MlasConvClearLhsCacheForTest();
+      EXPECT_EQ(ArmKleidiAI::MlasConvLhsCacheEntryCountForTest(), size_t{0});
+
+      verify_conv(input_a, "initial_input");
+      EXPECT_EQ(ArmKleidiAI::MlasConvLhsCacheEntryCountForTest(), size_t{1});
+
+      verify_conv(input_a_copy, "same_content_different_buffer");
+      EXPECT_EQ(ArmKleidiAI::MlasConvLhsCacheEntryCountForTest(), size_t{1})
+          << "same geometry with a different input buffer should reuse the LHS indirection cache";
+
+      verify_conv(input_b, "different_content_different_buffer");
+      EXPECT_EQ(ArmKleidiAI::MlasConvLhsCacheEntryCountForTest(), size_t{1})
+          << "same geometry with different input content should reuse the LHS indirection cache";
+
+      fill_input(input_a, 3);
+      verify_conv(input_a, "different_content_same_buffer");
+      EXPECT_EQ(ArmKleidiAI::MlasConvLhsCacheEntryCountForTest(), size_t{1})
+          << "same geometry with mutated input content should not add cache entries";
+    }
+
+    ArmKleidiAI::MlasConvClearLhsCacheForTest();
+  }
+#endif
 
 #if defined(MLAS_TARGET_AMD64)
   void TestMobileClipAvx512DispatchSelection(size_t GroupCount,
@@ -678,6 +845,9 @@ class MlasConv2DTest : public MlasTestBase {
   }
 
   void ExecuteShort(void) override {
+#if defined(USE_KLEIDIAI) && defined(MLAS_ENABLE_TEST_HOOKS)
+    TestKleidiAILhsCacheIgnoresInputContent();
+#endif
 #if defined(MLAS_TARGET_AMD64)
     TestMobileClipAvx512DispatchSelection(64, 64, 64);
     TestMobileClipAvx512DispatchSelection(128, 32, 32);


### PR DESCRIPTION
### Description
The fix removes input-content hashing from the LHS indirection cache key, because with repeated convolutions of the same shape over different input tensors, a data hash makes each input miss the cache and creates unbounded per-input cache growth

Additionally this add's a test and some scaffolding for verifying that the caching is behaving as expected. Verified using before/after of the change Example failures below (which no longer occur)

Using the original description and model from https://github.com/microsoft/onnxruntime/issues/28231 no longer observed ever increasing memory usage.

```
[ RUN      ] Conv2d_SingleThread.ShortExecute
/Users/jonclo01/kfi-devenv/repos/onnxruntime/onnxruntime/test/mlas/unittest/test_conv2d.h:460: Failure
Expected equality of these values:
  ArmKleidiAI::MlasConvLhsCacheEntryCountForTest()
    Which is: 2
  size_t{1}
    Which is: 1
same geometry with different input content should reuse the LHS indirection cache
Google Test trace:
/Users/jonclo01/kfi-devenv/repos/onnxruntime/onnxruntime/test/mlas/unittest/test_conv2d.h:349: padded_3x3
Stack trace:
  0x100d74970: MlasConv2DTest<>::ExecuteShort()
  0x100fbecec: testing::internal::HandleExceptionsInMethodIfSupported<>()
  0x100fbeb60: testing::Test::Run()
  0x100fbffec: testing::TestInfo::Run()
  0x100fc11ec: testing::TestSuite::Run()
... Google Test internal frames ...

/Users/jonclo01/kfi-devenv/repos/onnxruntime/onnxruntime/test/mlas/unittest/test_conv2d.h:465: Failure
Expected equality of these values:
  ArmKleidiAI::MlasConvLhsCacheEntryCountForTest()
    Which is: 3
  size_t{1}
    Which is: 1
same geometry with mutated input content should not add cache entries
Google Test trace:
/Users/jonclo01/kfi-devenv/repos/onnxruntime/onnxruntime/test/mlas/unittest/test_conv2d.h:349: padded_3x3
Stack trace:
  0x100d74970: MlasConv2DTest<>::ExecuteShort()
  0x100fbecec: testing::internal::HandleExceptionsInMethodIfSupported<>()
  0x100fbeb60: testing::Test::Run()
  0x100fbffec: testing::TestInfo::Run()
  0x100fc11ec: testing::TestSuite::Run()
... Google Test internal frames ...

/Users/jonclo01/kfi-devenv/repos/onnxruntime/onnxruntime/test/mlas/unittest/test_conv2d.h:460: Failure
Expected equality of these values:
  ArmKleidiAI::MlasConvLhsCacheEntryCountForTest()
    Which is: 2
  size_t{1}
    Which is: 1
same geometry with different input content should reuse the LHS indirection cache
Google Test trace:
/Users/jonclo01/kfi-devenv/repos/onnxruntime/onnxruntime/test/mlas/unittest/test_conv2d.h:349: strided_3x3
Stack trace:
  0x100d74970: MlasConv2DTest<>::ExecuteShort()
  0x100fbecec: testing::internal::HandleExceptionsInMethodIfSupported<>()
  0x100fbeb60: testing::Test::Run()
  0x100fbffec: testing::TestInfo::Run()
  0x100fc11ec: testing::TestSuite::Run()
... Google Test internal frames ...

/Users/jonclo01/kfi-devenv/repos/onnxruntime/onnxruntime/test/mlas/unittest/test_conv2d.h:465: Failure
Expected equality of these values:
  ArmKleidiAI::MlasConvLhsCacheEntryCountForTest()
    Which is: 3
  size_t{1}
    Which is: 1
same geometry with mutated input content should not add cache entries
Google Test trace:
/Users/jonclo01/kfi-devenv/repos/onnxruntime/onnxruntime/test/mlas/unittest/test_conv2d.h:349: strided_3x3
Stack trace:
  0x100d74970: MlasConv2DTest<>::ExecuteShort()
  0x100fbecec: testing::internal::HandleExceptionsInMethodIfSupported<>()
  0x100fbeb60: testing::Test::Run()
  0x100fbffec: testing::TestInfo::Run()
  0x100fc11ec: testing::TestSuite::Run()
... Google Test internal frames ...

/Users/jonclo01/kfi-devenv/repos/onnxruntime/onnxruntime/test/mlas/unittest/test_conv2d.h:460: Failure
Expected equality of these values:
  ArmKleidiAI::MlasConvLhsCacheEntryCountForTest()
    Which is: 2
  size_t{1}
    Which is: 1
same geometry with different input content should reuse the LHS indirection cache
Google Test trace:
/Users/jonclo01/kfi-devenv/repos/onnxruntime/onnxruntime/test/mlas/unittest/test_conv2d.h:349: dilated_3x3
Stack trace:
  0x100d74970: MlasConv2DTest<>::ExecuteShort()
  0x100fbecec: testing::internal::HandleExceptionsInMethodIfSupported<>()
  0x100fbeb60: testing::Test::Run()
  0x100fbffec: testing::TestInfo::Run()
  0x100fc11ec: testing::TestSuite::Run()
... Google Test internal frames ...

/Users/jonclo01/kfi-devenv/repos/onnxruntime/onnxruntime/test/mlas/unittest/test_conv2d.h:465: Failure
Expected equality of these values:
  ArmKleidiAI::MlasConvLhsCacheEntryCountForTest()
    Which is: 3
  size_t{1}
    Which is: 1
same geometry with mutated input content should not add cache entries
Google Test trace:
/Users/jonclo01/kfi-devenv/repos/onnxruntime/onnxruntime/test/mlas/unittest/test_conv2d.h:349: dilated_3x3
Stack trace:
  0x100d74970: MlasConv2DTest<>::ExecuteShort()
  0x100fbecec: testing::internal::HandleExceptionsInMethodIfSupported<>()
  0x100fbeb60: testing::Test::Run()
  0x100fbffec: testing::TestInfo::Run()
  0x100fc11ec: testing::TestSuite::Run()
... Google Test internal frames ...

/Users/jonclo01/kfi-devenv/repos/onnxruntime/onnxruntime/test/mlas/unittest/test_conv2d.h:460: Failure
Expected equality of these values:
  ArmKleidiAI::MlasConvLhsCacheEntryCountForTest()
    Which is: 2
  size_t{1}
    Which is: 1
same geometry with different input content should reuse the LHS indirection cache
Google Test trace:
/Users/jonclo01/kfi-devenv/repos/onnxruntime/onnxruntime/test/mlas/unittest/test_conv2d.h:349: wide_kernel
Stack trace:
  0x100d74970: MlasConv2DTest<>::ExecuteShort()
  0x100fbecec: testing::internal::HandleExceptionsInMethodIfSupported<>()
  0x100fbeb60: testing::Test::Run()
  0x100fbffec: testing::TestInfo::Run()
  0x100fc11ec: testing::TestSuite::Run()
... Google Test internal frames ...

/Users/jonclo01/kfi-devenv/repos/onnxruntime/onnxruntime/test/mlas/unittest/test_conv2d.h:465: Failure
Expected equality of these values:
  ArmKleidiAI::MlasConvLhsCacheEntryCountForTest()
    Which is: 3
  size_t{1}
    Which is: 1
same geometry with mutated input content should not add cache entries
Google Test trace:
/Users/jonclo01/kfi-devenv/repos/onnxruntime/onnxruntime/test/mlas/unittest/test_conv2d.h:349: wide_kernel
Stack trace:
  0x100d74970: MlasConv2DTest<>::ExecuteShort()
  0x100fbecec: testing::internal::HandleExceptionsInMethodIfSupported<>()
  0x100fbeb60: testing::Test::Run()
  0x100fbffec: testing::TestInfo::Run()
  0x100fc11ec: testing::TestSuite::Run()
... Google Test internal frames ...

[  FAILED  ] Conv2d_SingleThread.ShortExecute (25 ms)

```