### PR TITLE
Fix DLA core selection for cached TensorRT engines

### DIFF
--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -1800,6 +1800,12 @@ TensorrtExecutionProvider::TensorrtExecutionProvider(const TensorrtExecutionProv
     runtime_ = std::unique_ptr<nvinfer1::IRuntime>(nvinfer1::createInferRuntime(GetTensorrtLogger(detailed_build_log_)));
   }
 
+  // Set DLA core on the runtime before any deserializeCudaEngine() calls.
+  // Without this, deserialized engines always dispatch to DLA core 0
+  // regardless of the trt_dla_core provider option.
+  if (dla_enable_ && dla_core_ >= 0) {
+    runtime_->setDLACore(dla_core_);
+  }
   trt_version_ = getInferLibVersion();
   CUDA_CALL_THROW(cudaRuntimeGetVersion(&cuda_version_));
 


### PR DESCRIPTION
### Description
Call `runtime_->setDLACore(dla_core_)` immediately after runtime creation, mirroring the existing pattern used for the builder config. This ensures both fresh engine builds and cache loads respect the configured DLA core index.

When a cached TensorRT engine is deserialized via the runtime object, the DLA core assignment is lost because `runtime_->setDLACore()` is never called. This causes all deserialized engines to dispatch to **DLA core 0** regardless of the `trt_dla_core` provider option.

The DLA core is correctly set on the builder config (`setDLACore`) when building a new engine, but the runtime object used for deserialization is created without any DLA core configuration. Since `deserializeCudaEngine()` uses the runtime's DLA core setting to determine dispatch, cached engines always land on core 0.

I've verified that after this change `jtop` shows activity on the correct core.  


### Motivation and Context
Affects users with multi-DLA hardware (e.g., NVIDIA Orin) who set `trt_dla_core=1` and use engine caching (`trt_engine_cache_enable=1`). Without this fix, the second DLA core is unreachable for cached engines.

This problem has been mentioned before in https://github.com/microsoft/onnxruntime/issues/26680 but the issue was closed due to inactivity. I think I've been experiencing the same issue and this change should fix it. 

