### PR TITLE
Skip MEA in GQA for head_dim > 256 (CUTLASS shared memory limit)

### DIFF
--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention.cc
@@ -472,7 +472,12 @@ Status GroupQueryAttention<T, U>::ComputeInternal(OpKernelContext* context) cons
     int sm = (device_prop.major * 10) + device_prop.minor;
     bool use_memory_efficient_attention =
         !disable_memory_efficient_attention_ &&
-        has_memory_efficient_attention(sm, std::is_same<T, MLFloat16>::value, std::is_same<T, BFloat16>::value, parameters.head_size, parameters.head_size);
+        has_memory_efficient_attention(sm, std::is_same<T, MLFloat16>::value, std::is_same<T, BFloat16>::value, parameters.head_size, parameters.head_size) &&
+        // CUTLASS FMHA shared memory scales with queries_per_block × head_dim.
+        // For head_dim > 256 the kernel can exceed the SM's shared memory limit,
+        // causing cudaErrorInvalidValue on launch. Fall through to unfused
+        // attention which handles any head_dim via cuBLAS GEMM.
+        parameters.head_size <= 256;
     data.use_memory_efficient_attention = use_memory_efficient_attention;
 
     // KV buffer for head expansion (when num_heads != kv_num_heads)


### PR DESCRIPTION
CUTLASS FMHA shared memory scales with queries_per_block × head_dim. For head_dim > 256, the kernel exceeds SM shared memory → `cudaErrorInvalidValue`. Add `head_size <= 256` to MEA eligibility in GQA, letting unfused fallback handle large head_dim. Tested: Gemma4 GQA head_dim=512 at 150 tok/s on H200.