### PR TITLE
[CUDA Plugin EP] Add NuGet packaging pipeline

### DIFF
--- a/plugin-ep-cuda/csharp/Microsoft.ML.OnnxRuntime.EP.Cuda/CudaEp.cs
+++ b/plugin-ep-cuda/csharp/Microsoft.ML.OnnxRuntime.EP.Cuda/CudaEp.cs
@@ -1,0 +1,109 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.ML.OnnxRuntime.EP.Cuda
+{
+    /// <summary>
+    /// Provides helper methods to locate the CUDA plugin EP native library
+    /// and retrieve the EP name for registration with ONNX Runtime.
+    /// </summary>
+    public static class CudaEp
+    {
+        /// <summary>
+        /// Returns the path to the CUDA plugin EP native library contained by this package.
+        /// Can be passed to <c>OrtEnv.RegisterExecutionProviderLibrary()</c>.
+        /// </summary>
+        /// <returns>Full path to the EP native library.</returns>
+        /// <exception cref="FileNotFoundException">If the native library file does not exist at the expected path.</exception>
+        public static string GetLibraryPath()
+        {
+            string rootDir = GetNativeDirectory();
+            string rid = GetRuntimeIdentifier();
+            string libraryName = GetLibraryName();
+
+            // Probe the standard NuGet runtimes/<rid>/native/ layout first, then fall back
+            // to the base directory for single-file/published layouts where native assets
+            // can land directly next to the managed assembly.
+            string[] candidates =
+            {
+                Path.Combine(rootDir, "runtimes", rid, "native", libraryName),
+                Path.Combine(rootDir, libraryName),
+            };
+
+            foreach (var candidate in candidates)
+            {
+                if (File.Exists(candidate))
+                    return Path.GetFullPath(candidate);
+            }
+
+            throw new FileNotFoundException(
+                $"Did not find CUDA EP library file. Probed: {string.Join(", ", candidates)}");
+        }
+
+        /// <summary>
+        /// Returns the names of the EPs created by the CUDA plugin EP library.
+        /// Can be used to select an <c>OrtEpDevice</c> from those returned by <c>OrtEnv.GetEpDevices()</c>.
+        /// </summary>
+        /// <returns>Array of EP names.</returns>
+        public static string[] GetEpNames()
+        {
+            return new[] { GetEpName() };
+        }
+
+        /// <summary>
+        /// Returns the name of the one EP supported by this plugin EP library.
+        /// Convenience method for plugin EP packages that expose a single EP.
+        /// </summary>
+        /// <returns>The EP name string.</returns>
+        public static string GetEpName()
+        {
+            return "CudaPluginExecutionProvider";
+        }
+
+        private static string GetNativeDirectory()
+        {
+            var assemblyDir = Path.GetDirectoryName(typeof(CudaEp).Assembly.Location);
+
+            if (!string.IsNullOrEmpty(assemblyDir) && Directory.Exists(assemblyDir))
+                return assemblyDir;
+
+            return AppContext.BaseDirectory;
+        }
+
+        private static string GetRuntimeIdentifier()
+        {
+            return GetOSTag() + "-" + GetArchTag();
+        }
+
+        private static string GetLibraryName()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return "onnxruntime_providers_cuda_plugin.dll";
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                return "libonnxruntime_providers_cuda_plugin.so";
+
+            throw new PlatformNotSupportedException(
+                $"CUDA plugin EP does not support OS platform: {RuntimeInformation.OSDescription}");
+        }
+
+        private static string GetOSTag()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return "win";
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return "linux";
+            throw new PlatformNotSupportedException(
+                $"CUDA plugin EP does not support OS platform: {RuntimeInformation.OSDescription}");
+        }
+
+        private static string GetArchTag()
+        {
+            return RuntimeInformation.ProcessArchitecture switch
+            {
+                Architecture.X64 => "x64",
+                Architecture.Arm64 => "arm64",
+                _ => throw new PlatformNotSupportedException(
+                    $"CUDA plugin EP does not support process architecture: {RuntimeInformation.ProcessArchitecture}"),
+            };
+        }
+    }
+}

--- a/plugin-ep-cuda/csharp/Microsoft.ML.OnnxRuntime.EP.Cuda/Microsoft.ML.OnnxRuntime.EP.Cuda.csproj
+++ b/plugin-ep-cuda/csharp/Microsoft.ML.OnnxRuntime.EP.Cuda/Microsoft.ML.OnnxRuntime.EP.Cuda.csproj
@@ -1,0 +1,83 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+
+    <!-- Package info -->
+    <PackageId>Microsoft.ML.OnnxRuntime.EP.Cuda</PackageId>
+    <!-- Sentinel default; overridden via -p:Version=<x.y.z> when packing (see pack_nuget.py). -->
+    <Version>0.0.0-dev</Version>
+    <Authors>Microsoft</Authors>
+    <Company>Microsoft</Company>
+    <Description>ONNX Runtime CUDA Plugin Execution Provider.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageTags>ONNX;ONNX Runtime;Machine Learning;AI;Deep Learning;CUDA;GPU</PackageTags>
+
+    <!-- License/Repository -->
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/microsoft/onnxruntime</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+
+    <!-- Include symbols/source for better debugging experience -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <!--
+    Minimum required Microsoft.ML.OnnxRuntime version is read from a file (single source
+    of truth, shared with the other plugin EP packages). The path is overridable via
+    -p:OnnxRuntimeMinVersionFile=<absolute path> so callers (e.g. pack_nuget.py, which
+    builds out of a staged copy) can point at the original file in the source tree.
+  -->
+  <PropertyGroup>
+    <OnnxRuntimeMinVersionFile Condition="'$(OnnxRuntimeMinVersionFile)' == ''">$(MSBuildThisFileDirectory)..\..\MIN_ONNXRUNTIME_VERSION</OnnxRuntimeMinVersionFile>
+    <OnnxRuntimeMinVersion Condition="Exists('$(OnnxRuntimeMinVersionFile)')">$([System.IO.File]::ReadAllText('$(OnnxRuntimeMinVersionFile)').Trim())</OnnxRuntimeMinVersion>
+  </PropertyGroup>
+
+  <Target Name="_ValidateOnnxRuntimeMinVersion" BeforeTargets="CollectPackageReferences">
+    <Error Condition="!Exists('$(OnnxRuntimeMinVersionFile)')"
+           Text="OnnxRuntimeMinVersionFile not found: '$(OnnxRuntimeMinVersionFile)'. Set -p:OnnxRuntimeMinVersionFile=&lt;absolute path&gt; or restore the file at the default location." />
+    <Error Condition="'$(OnnxRuntimeMinVersion)' == ''"
+           Text="OnnxRuntimeMinVersion resolved to an empty value from '$(OnnxRuntimeMinVersionFile)'." />
+  </Target>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(OnnxRuntimeMinVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Ensure README is included in the package -->
+    <None Include="README.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <!-- Native binaries per platform. Each ItemGroup is conditioned on the runtimes/ directory
+       existing so the project can build cleanly from the source tree. At pack time, pack_nuget.py
+       populates the staging directory with whichever platforms are available. -->
+  <ItemGroup>
+    <None Include="runtimes\win-x64\native\**"
+          Pack="true"
+          PackagePath="runtimes/win-x64/native/"
+          CopyToOutputDirectory="PreserveNewest"
+          Condition="Exists('runtimes\win-x64\native')" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="runtimes\linux-x64\native\**"
+          Pack="true"
+          PackagePath="runtimes/linux-x64/native/"
+          CopyToOutputDirectory="PreserveNewest"
+          Condition="Exists('runtimes\linux-x64\native')" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="runtimes\linux-arm64\native\**"
+          Pack="true"
+          PackagePath="runtimes/linux-arm64/native/"
+          CopyToOutputDirectory="PreserveNewest"
+          Condition="Exists('runtimes\linux-arm64\native')" />
+  </ItemGroup>
+
+</Project>

--- a/plugin-ep-cuda/csharp/Microsoft.ML.OnnxRuntime.EP.Cuda/README.md
+++ b/plugin-ep-cuda/csharp/Microsoft.ML.OnnxRuntime.EP.Cuda/README.md
@@ -1,0 +1,51 @@
+## Microsoft.ML.OnnxRuntime.EP.Cuda
+
+CUDA plugin Execution Provider for [ONNX Runtime](https://github.com/microsoft/onnxruntime).
+
+### Usage
+
+```csharp
+// Note: Error handling is omitted for brevity.
+
+using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.OnnxRuntime.EP.Cuda;
+
+// Register the CUDA EP plugin library
+var env = OrtEnv.Instance();
+env.RegisterExecutionProviderLibrary("cuda_ep", CudaEp.GetLibraryPath());
+
+// Find the CUDA EP device
+OrtEpDevice? cudaDevice = null;
+foreach (var d in env.GetEpDevices())
+{
+    if (d.EpName == CudaEp.GetEpName())
+    {
+        cudaDevice = d;
+        break;
+    }
+}
+
+// Create a session with the CUDA EP
+using var sessionOptions = new SessionOptions();
+sessionOptions.AppendExecutionProvider(env, new[] { cudaDevice }, new Dictionary<string, string>());
+
+using var session = new InferenceSession("model.onnx", sessionOptions);
+// ... run inference ...
+
+// Unregister when done
+env.UnregisterExecutionProviderLibrary("cuda_ep");
+```
+
+### Supported Platforms
+
+| Platform | Runtime Identifier |
+|---|---|
+| Windows x64 | `win-x64` |
+| Linux x64 | `linux-x64` |
+| Linux ARM64 | `linux-arm64` |
+
+### Requirements
+
+- NVIDIA GPU with CUDA support
+- CUDA toolkit and cuDNN installed on the system
+- ONNX Runtime 1.26.0 or later

--- a/plugin-ep-cuda/csharp/README.md
+++ b/plugin-ep-cuda/csharp/README.md
@@ -1,0 +1,133 @@
+# CUDA Plugin EP — NuGet Packaging
+
+This directory contains the C# NuGet package project and test app for the CUDA plugin Execution Provider.
+
+## Directory Structure
+
+```
+csharp/
+├── pack_nuget.py                                   # Helper script to build the NuGet package
+├── Microsoft.ML.OnnxRuntime.EP.Cuda/
+│   ├── Microsoft.ML.OnnxRuntime.EP.Cuda.csproj     # NuGet package project (netstandard2.0)
+│   ├── CudaEp.cs                                   # Helper class for native library resolution
+│   └── README.md                                   # Package readme (shipped inside .nupkg)
+└── test/
+    └── CudaEpNuGetTest/
+        ├── CudaEpNuGetTest.csproj                  # Test console app (net8.0)
+        ├── Program.cs                              # Registers EP, runs inference, validates output
+        ├── mul.onnx                                # Test model (element-wise multiply)
+        └── generate_mul_model.py                   # Script to regenerate mul.onnx
+```
+
+## Prerequisites
+
+- .NET SDK 8.0 or later
+- A built CUDA plugin EP shared library
+- NVIDIA GPU with CUDA support
+- CUDA toolkit and cuDNN installed on the system
+
+## Building the NuGet Package
+
+Use `pack_nuget.py` to stage native binaries and run `dotnet pack`. The script copies everything into a staging
+directory before building — the source tree is never modified. By default, an auto-cleaned temporary directory is used;
+pass `--staging-dir` to use an explicit one (required when running with `--build-only` or `--pack-only`).
+
+At least one binary directory (or `--artifacts-dir` with matching subdirectories) must be provided. Platforms without
+a binary directory are skipped. Run `python pack_nuget.py --help` for the full list of options and their defaults.
+
+### Pack with a local build (single platform)
+
+```powershell
+cd plugin-ep-cuda/csharp
+
+python pack_nuget.py --version 0.1.0-dev `
+  --binary-dir-win-x64 <path-to-win-x64-binaries>
+```
+
+### Pack multiple platforms
+
+Each `--binary-dir-*` points at the directory containing that platform's already-built native binaries. In practice
+the binaries are produced on different machines and combined in CI; locally you'd typically only set the one(s)
+you have available.
+
+```powershell
+python pack_nuget.py --version 0.1.0-dev `
+  --binary-dir-win-x64 <path-to-win-x64-binaries> `
+  --binary-dir-linux-x64 <path-to-linux-x64-binaries> `
+  --binary-dir-linux-aarch64 <path-to-linux-aarch64-binaries>
+```
+
+## Versioning
+
+The package version is supplied to `pack_nuget.py` via `--version`. In the packaging pipeline, the release or
+pre-release version is derived from [`VERSION_NUMBER`](../../VERSION_NUMBER).
+
+## Inspecting the Package
+
+The `.nupkg` is a ZIP file. To verify its contents:
+
+```powershell
+Expand-Archive nuget_output/Microsoft.ML.OnnxRuntime.EP.Cuda.0.1.0-dev.nupkg `
+  -DestinationPath nuget_output/inspect -Force
+
+Get-ChildItem nuget_output/inspect -Recurse | Select-Object FullName
+```
+
+Expected layout inside the package:
+
+```
+lib/netstandard2.0/Microsoft.ML.OnnxRuntime.EP.Cuda.dll
+runtimes/win-x64/native/onnxruntime_providers_cuda_plugin.dll
+runtimes/linux-x64/native/libonnxruntime_providers_cuda_plugin.so
+runtimes/linux-arm64/native/libonnxruntime_providers_cuda_plugin.so
+```
+
+## Testing the Package
+
+The test app registers the CUDA EP, creates a session, runs a simple Mul model, and validates the output.
+
+```powershell
+# Point the test project's nuget.config at the pack output
+$localFeed = (Resolve-Path nuget_output).Path
+@"
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="local" value="$localFeed" />
+  </packageSources>
+</configuration>
+"@ | Set-Content test/CudaEpNuGetTest/nuget.config
+
+# Build and run
+dotnet run --project test/CudaEpNuGetTest/CudaEpNuGetTest.csproj --configuration Release
+```
+
+A successful run prints `PASSED: All outputs match expected values.` and exits with code 0.
+
+## Regenerating the Test Model
+
+```bash
+python test/CudaEpNuGetTest/generate_mul_model.py
+```
+
+Requires the `onnx` Python package.
+
+## CI Pipeline
+
+The NuGet packaging is integrated into the CUDA plugin pipeline:
+
+- **Pipeline:** `tools/ci_build/github/azure-pipelines/plugin-cuda-pipeline.yml`
+- **Packaging stage:** `tools/ci_build/github/azure-pipelines/stages/plugin-cuda-nuget-packaging-stage.yml`
+
+The CI stage downloads build artifacts from all enabled platform stages, invokes `pack_nuget.py`, ESRP-signs the
+package, and runs the test app on a GPU agent.
+
+## Native Binaries Per Platform
+
+| RID | Required Files |
+|---|---|
+| `win-x64` | `onnxruntime_providers_cuda_plugin.dll` |
+| `linux-x64` | `libonnxruntime_providers_cuda_plugin.so` |
+| `linux-arm64` | `libonnxruntime_providers_cuda_plugin.so` |

--- a/plugin-ep-cuda/csharp/pack_nuget.py
+++ b/plugin-ep-cuda/csharp/pack_nuget.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+"""Build the Microsoft.ML.OnnxRuntime.EP.Cuda NuGet package.
+
+Stages native binaries from build artifacts into the runtimes/ layout expected
+by the .csproj and runs `dotnet pack` to produce the .nupkg / .snupkg files.
+
+Can be invoked locally or from CI. In CI, pass --artifacts-dir to point at the
+downloaded pipeline artifacts. Locally, pass individual --binary-dir-* options.
+
+Examples
+--------
+Local: pack win-x64 only from a local build:
+
+    python pack_nuget.py --version 0.1.0-dev \\
+        --binary-dir-win-x64 ../../build/cuda.plugin/Release/Release
+
+CI: pack all platforms from downloaded artifacts:
+
+    python pack_nuget.py --version $(PluginPackageVersion) \\
+        --artifacts-dir $(Build.BinariesDirectory)/artifacts \\
+        --output-dir $(Build.ArtifactStagingDirectory)/nuget
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Platform name -> (RID, list of native binary filenames expected in the source dir).
+PLATFORMS: dict[str, tuple[str, tuple[str, ...]]] = {
+    "win_x64": ("win-x64", ("onnxruntime_providers_cuda_plugin.dll",)),
+    "linux_x64": ("linux-x64", ("libonnxruntime_providers_cuda_plugin.so",)),
+    "linux_aarch64": ("linux-arm64", ("libonnxruntime_providers_cuda_plugin.so",)),
+}
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+PROJECT_DIR = SCRIPT_DIR / "Microsoft.ML.OnnxRuntime.EP.Cuda"
+CSPROJ = PROJECT_DIR / "Microsoft.ML.OnnxRuntime.EP.Cuda.csproj"
+MIN_ORT_VERSION_FILE = SCRIPT_DIR.parent / "MIN_ONNXRUNTIME_VERSION"
+
+
+class PackError(RuntimeError):
+    """Raised for any user-actionable failure during packaging."""
+
+
+def parse_args() -> argparse.Namespace:
+    def _absolute_path(value: str) -> Path:
+        """argparse `type` converter: parse a string as an absolute Path."""
+        return Path(value).resolve()
+
+    p = argparse.ArgumentParser(
+        description="Build the Microsoft.ML.OnnxRuntime.EP.Cuda NuGet package.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--version", required=True, help="Package version (e.g. 0.1.0-dev).")
+    p.add_argument(
+        "--output-dir",
+        type=_absolute_path,
+        default=(SCRIPT_DIR / "nuget_output").resolve(),
+        help="Directory for the .nupkg / .snupkg output (default: ./nuget_output).",
+    )
+    p.add_argument("--configuration", default="Release", help="Build configuration (default: Release).")
+
+    # CI mode: a single root containing per-platform subdirectories.
+    p.add_argument(
+        "--artifacts-dir",
+        type=_absolute_path,
+        help="CI mode: root containing <platform>/bin/ subdirectories for each platform.",
+    )
+
+    # Local mode: explicit per-platform binary directories. Each takes precedence over
+    # --artifacts-dir for that platform.
+    for name in PLATFORMS:
+        flag = f"--binary-dir-{name.replace('_', '-')}"
+        p.add_argument(flag, type=_absolute_path, dest=f"binary_dir_{name}", help=f"Path to {name} native binaries.")
+
+    p.add_argument(
+        "--nuget-config", type=_absolute_path, help="Optional NuGet.config passed to dotnet via --configfile."
+    )
+    p.add_argument(
+        "--staging-dir",
+        type=_absolute_path,
+        help=(
+            "Explicit staging directory. Required with --build-only / --pack-only "
+            "(caller owns its lifecycle). When omitted, an auto-cleaned temporary "
+            "directory is used for the full build+pack flow."
+        ),
+    )
+
+    phase = p.add_mutually_exclusive_group()
+    phase.add_argument(
+        "--build-only",
+        action="store_true",
+        help="Stage and build the managed DLL only; skip dotnet pack. Preserves the staging dir.",
+    )
+    phase.add_argument(
+        "--pack-only",
+        action="store_true",
+        help="Skip staging/build and run dotnet pack against an existing staging directory.",
+    )
+
+    p.add_argument(
+        "--required-platforms",
+        default="",
+        help=(
+            "Comma-separated list of platforms that MUST be staged successfully. "
+            "When omitted, the script just requires at least one platform to be staged."
+        ),
+    )
+
+    return p.parse_args()
+
+
+def parse_required_platforms(value: str) -> list[str]:
+    names = [tok.strip() for tok in value.split(",") if tok.strip()]
+    invalid = [n for n in names if n not in PLATFORMS]
+    if invalid:
+        raise PackError(
+            f"unknown platform(s) in --required-platforms: {', '.join(invalid)}. valid: {', '.join(PLATFORMS)}."
+        )
+    return names
+
+
+def stage_sources(staging_dir: Path) -> None:
+    """Copy project sources into staging, excluding bin/obj."""
+    print(f"Staging project files to {staging_dir}")
+    if staging_dir.exists():
+        shutil.rmtree(staging_dir)
+    shutil.copytree(
+        PROJECT_DIR,
+        staging_dir,
+        ignore=shutil.ignore_patterns("bin", "obj"),
+    )
+
+
+def resolve_platform_source(
+    name: str,
+    binary_dir_override: Path | None,
+    artifacts_dir: Path | None,
+    is_required: bool,
+) -> Path | None:
+    """Return the source dir for a platform, or None to skip."""
+    if binary_dir_override is not None:
+        return binary_dir_override
+    if artifacts_dir is not None:
+        candidate = artifacts_dir / name / "bin"
+        if candidate.is_dir():
+            return candidate
+        if is_required:
+            raise PackError(f"required platform '{name}' artifact directory not found: {candidate}")
+    if is_required:
+        raise PackError(
+            f"required platform '{name}' has no binary directory "
+            f"(pass --binary-dir-{name.replace('_', '-')} or --artifacts-dir)."
+        )
+    return None
+
+
+def stage_binaries(
+    staging_dir: Path,
+    args: argparse.Namespace,
+    required_platforms: list[str],
+) -> None:
+    staged: set[str] = set()
+
+    for name, (rid, files) in PLATFORMS.items():
+        binary_dir_override: Path | None = getattr(args, f"binary_dir_{name}")
+        is_required = name in required_platforms
+        source_dir = resolve_platform_source(name, binary_dir_override, args.artifacts_dir, is_required)
+        if source_dir is None:
+            print(f"Skipping {name} (no binary directory provided)")
+            continue
+        if not source_dir.is_dir():
+            raise PackError(f"binary directory does not exist: {source_dir}")
+
+        target_dir = staging_dir / "runtimes" / rid / "native"
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        print(f"Staging {name} -> runtimes/{rid}/native/")
+        for filename in files:
+            src = source_dir / filename
+            if not src.is_file():
+                raise PackError(f"expected binary not found: {src}")
+            shutil.copy2(src, target_dir / filename)
+            print(f"  {filename}")
+        staged.add(name)
+
+    if required_platforms:
+        missing = [n for n in required_platforms if n not in staged]
+        if missing:
+            raise PackError(f"required platforms not staged: {', '.join(missing)}")
+    elif not staged:
+        raise PackError("no platform binaries were staged. Provide at least one --binary-dir-* or --artifacts-dir.")
+
+    print()
+    print("Runtimes layout:")
+    for path in sorted((staging_dir / "runtimes").rglob("*")):
+        print(f"  {path}")
+
+
+def dotnet_common_args(
+    staged_csproj: Path,
+    args: argparse.Namespace,
+    min_ort_version_file: Path,
+) -> list[str]:
+    common = [
+        str(staged_csproj),
+        "--configuration",
+        args.configuration,
+        f"-p:Version={args.version}",
+        f"-p:OnnxRuntimeMinVersionFile={min_ort_version_file}",
+    ]
+    if args.nuget_config:
+        common.extend(["--configfile", str(args.nuget_config)])
+        print(f"Using NuGet.config: {args.nuget_config}")
+    return common
+
+
+def do_build(staged_csproj: Path, staging_dir: Path, args: argparse.Namespace, min_ort_version_file: Path) -> None:
+    print()
+    print(f"Running dotnet build (Version={args.version}, Configuration={args.configuration})...")
+    cmd = ["dotnet", "build", *dotnet_common_args(staged_csproj, args, min_ort_version_file)]
+    print("+ " + " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+    # Note: "netstandard2.0" must match <TargetFramework> in Microsoft.ML.OnnxRuntime.EP.Cuda.csproj.
+    managed_dll = staging_dir / "bin" / args.configuration / "netstandard2.0" / "Microsoft.ML.OnnxRuntime.EP.Cuda.dll"
+    if not managed_dll.is_file():
+        raise PackError(f"managed DLL not found after build: {managed_dll}")
+    print()
+    print(f"Built managed DLL: {managed_dll}")
+    print("Staging directory preserved for subsequent --pack-only invocation.")
+
+
+def do_pack(
+    staged_csproj: Path,
+    output_dir: Path,
+    args: argparse.Namespace,
+    min_ort_version_file: Path,
+) -> None:
+    print()
+    print(f"Running dotnet pack (Version={args.version}, Configuration={args.configuration})...")
+    pack_args = [
+        "dotnet",
+        "pack",
+        *dotnet_common_args(staged_csproj, args, min_ort_version_file),
+        "--output",
+        str(output_dir),
+    ]
+    if args.pack_only:
+        pack_args.append("--no-build")
+    print("+ " + " ".join(pack_args))
+    subprocess.run(pack_args, check=True)
+
+    print()
+    nupkgs = sorted(output_dir.glob("*.nupkg"))
+    if not nupkgs:
+        raise PackError(f"no .nupkg files found in {output_dir}")
+    for pkg in nupkgs:
+        print(f"Produced: {pkg.name} ({pkg.stat().st_size / (1024 * 1024):.2f} MB)")
+    for pkg in sorted(output_dir.glob("*.snupkg")):
+        print(f"Produced: {pkg.name} ({pkg.stat().st_size / (1024 * 1024):.2f} MB)")
+
+
+def run_in_staging(args: argparse.Namespace, staging_dir: Path, min_ort_version_file: Path) -> None:
+    staged_csproj = staging_dir / "Microsoft.ML.OnnxRuntime.EP.Cuda.csproj"
+    output_dir: Path = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+    required_platforms = parse_required_platforms(args.required_platforms)
+
+    if args.pack_only:
+        if not staged_csproj.is_file():
+            raise PackError(f"staged project not found at {staged_csproj}. Run with --build-only first.")
+        print(f"Reusing existing staging directory: {staging_dir}")
+    else:
+        stage_sources(staging_dir)
+        stage_binaries(staging_dir, args, required_platforms)
+
+    if args.build_only:
+        do_build(staged_csproj, staging_dir, args, min_ort_version_file)
+        return
+
+    do_pack(staged_csproj, output_dir, args, min_ort_version_file)
+
+    print()
+    print(f"Done. Output: {output_dir}")
+
+
+def run(args: argparse.Namespace) -> None:
+    if not CSPROJ.is_file():
+        raise PackError(f"project file not found: {CSPROJ}")
+    if not MIN_ORT_VERSION_FILE.is_file():
+        raise PackError(f"MIN_ONNXRUNTIME_VERSION file not found: {MIN_ORT_VERSION_FILE}")
+    if args.nuget_config and not args.nuget_config.is_file():
+        raise PackError(f"NuGet.config not found: {args.nuget_config}")
+
+    if (args.build_only or args.pack_only) and not args.staging_dir:
+        raise PackError("--staging-dir is required when using --build-only or --pack-only.")
+
+    min_ort_version_file = MIN_ORT_VERSION_FILE.resolve()
+
+    if args.staging_dir:
+        staging_dir: Path = args.staging_dir
+        staging_dir.mkdir(parents=True, exist_ok=True)
+        run_in_staging(args, staging_dir, min_ort_version_file)
+        return
+
+    # Full build+pack flow with no caller-managed staging dir: use a temp dir that
+    # is cleaned up automatically (including on exception).
+    with tempfile.TemporaryDirectory(prefix="cuda_pack_") as tmp:
+        run_in_staging(args, Path(tmp), min_ort_version_file)
+
+
+if __name__ == "__main__":
+    try:
+        run(parse_args())
+    except PackError as e:
+        print(f"\nERROR: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/plugin-ep-cuda/csharp/test/CudaEpNuGetTest/CudaEpNuGetTest.csproj
+++ b/plugin-ep-cuda/csharp/test/CudaEpNuGetTest/CudaEpNuGetTest.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!--
+      Version of the EP package to test. CI overrides this with the exact version produced by
+      pack_nuget.py via -p:OrtCudaPackageVersion=<version> so the test consumes the freshly
+      built package deterministically. The floating fallback is for local development against
+      a single-package local feed.
+    -->
+    <OrtCudaPackageVersion Condition="'$(OrtCudaPackageVersion)' == ''">*-*</OrtCudaPackageVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Microsoft.ML.OnnxRuntime is pulled in transitively via the EP package. -->
+    <PackageReference Include="Microsoft.ML.OnnxRuntime.EP.Cuda" Version="$(OrtCudaPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="mul.onnx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+</Project>

--- a/plugin-ep-cuda/csharp/test/CudaEpNuGetTest/Program.cs
+++ b/plugin-ep-cuda/csharp/test/CudaEpNuGetTest/Program.cs
@@ -1,0 +1,82 @@
+using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.OnnxRuntime.EP.Cuda;
+
+class Program
+{
+    static int Main()
+    {
+        string epLibPath = CudaEp.GetLibraryPath();
+        string epRegistrationName = "cuda_ep_registration";
+        string epName = CudaEp.GetEpName();
+
+        Console.WriteLine($"CUDA EP library path: {epLibPath}");
+
+        var env = OrtEnv.Instance();
+        env.RegisterExecutionProviderLibrary(epRegistrationName, epLibPath);
+        Console.WriteLine($"Registered EP library: {epLibPath}");
+
+        try
+        {
+            // Find the OrtEpDevice for the CUDA EP
+            OrtEpDevice? epDevice = null;
+            foreach (var d in env.GetEpDevices())
+            {
+                if (string.Equals(epName, d.EpName, StringComparison.Ordinal))
+                {
+                    epDevice = d;
+                    break;
+                }
+            }
+
+            if (epDevice == null)
+            {
+                Console.Error.WriteLine($"ERROR: Unable to find OrtEpDevice with name '{epName}'");
+                return 1;
+            }
+            Console.WriteLine($"Found OrtEpDevice for EP: {epName}");
+
+            // Create session with CUDA EP
+            using var sessionOptions = new SessionOptions();
+            sessionOptions.AppendExecutionProvider(env, new[] { epDevice }, new Dictionary<string, string>());
+            sessionOptions.AddSessionConfigEntry("session.disable_cpu_ep_fallback", "1");
+
+            string inputModelPath = Path.Combine(AppContext.BaseDirectory, "mul.onnx");
+            Console.WriteLine($"Loading model: {inputModelPath}");
+
+            using var session = new InferenceSession(inputModelPath, sessionOptions);
+
+            // Run model: mul(x, y) = x * y
+            float[] inputData = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f };
+            using var inputOrtValue = OrtValue.CreateTensorValueFromMemory<float>(inputData, new long[] { 2, 3 });
+            var inputValues = new List<OrtValue> { inputOrtValue, inputOrtValue }.AsReadOnly();
+            var inputNames = new List<string> { "x", "y" }.AsReadOnly();
+            using var runOptions = new RunOptions();
+
+            using var outputs = session.Run(runOptions, inputNames, inputValues, session.OutputNames);
+
+            float[] expected = { 1.0f, 4.0f, 9.0f, 16.0f, 25.0f, 36.0f };
+            var actual = outputs[0].GetTensorDataAsSpan<float>().ToArray();
+
+            Console.WriteLine($"Input:    {string.Join(", ", inputData)}");
+            Console.WriteLine($"Output:   {string.Join(", ", actual)}");
+            Console.WriteLine($"Expected: {string.Join(", ", expected)}");
+
+            // Validate output
+            for (int i = 0; i < expected.Length; i++)
+            {
+                if (Math.Abs(actual[i] - expected[i]) > 1e-5f)
+                {
+                    Console.Error.WriteLine($"ERROR: Output mismatch at index {i}: expected {expected[i]}, got {actual[i]}");
+                    return 1;
+                }
+            }
+
+            Console.WriteLine("PASSED: All outputs match expected values.");
+            return 0;
+        }
+        finally
+        {
+            env.UnregisterExecutionProviderLibrary(epRegistrationName);
+        }
+    }
+}

--- a/plugin-ep-cuda/csharp/test/CudaEpNuGetTest/generate_mul_model.py
+++ b/plugin-ep-cuda/csharp/test/CudaEpNuGetTest/generate_mul_model.py
@@ -1,0 +1,25 @@
+"""Generate a simple Mul ONNX model for testing.
+
+Produces mul.onnx in the same directory as this script.
+The model computes z = x * y (element-wise) for float32 tensors of shape [2, 3].
+"""
+
+import os
+
+from onnx import TensorProto, checker, helper, save
+
+X = helper.make_tensor_value_info("x", TensorProto.FLOAT, [2, 3])
+Y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [2, 3])
+Z = helper.make_tensor_value_info("z", TensorProto.FLOAT, [2, 3])
+
+mul_node = helper.make_node("Mul", inputs=["x", "y"], outputs=["z"])
+
+graph = helper.make_graph([mul_node], "mul_graph", [X, Y], [Z])
+model = helper.make_model(graph, producer_name="onnxruntime-cuda-ep-test")
+model.opset_import[0].version = 13
+
+checker.check_model(model)
+
+output_path = os.path.join(os.path.dirname(__file__), "mul.onnx")
+save(model, output_path)
+print(f"Saved {output_path}")

--- a/plugin-ep-cuda/csharp/test/CudaEpNuGetTest/mul.onnx
+++ b/plugin-ep-cuda/csharp/test/CudaEpNuGetTest/mul.onnx
@@ -1,0 +1,16 @@
+onnxruntime-cuda-ep-test:Z
+
+x
+yz"Mul	mul_graphZ
+x
+
+
+Z
+y
+
+
+b
+z
+
+
+B

--- a/plugin-ep-webgpu/README.md
+++ b/plugin-ep-webgpu/README.md
@@ -9,7 +9,7 @@ For more information about plugin EPs, see the documentation [here](https://onnx
 
 - [`VERSION_NUMBER`](VERSION_NUMBER) — Base plugin EP version consumed by the CI pipeline. The pipeline derives the
   final package version (release, dev) from this via
-  [`tools/ci_build/github/azure-pipelines/templates/set-plugin-build-variables-step.yml`](../tools/ci_build/github/azure-pipelines/templates/set-plugin-build-variables-step.yml).
+  [`tools/ci_build/github/azure-pipelines/templates/set-plugin-ep-build-variables-step.yml`](../tools/ci_build/github/azure-pipelines/templates/set-plugin-ep-build-variables-step.yml).
 - [`MIN_ONNXRUNTIME_VERSION`](MIN_ONNXRUNTIME_VERSION) — Minimum compatible core `onnxruntime` version. Single source
   of truth shared by all packages built from this directory.
 - [`python/`](python/) — Sources and build script for the `onnxruntime-ep-webgpu` Python wheel. See

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-cuda-nuget-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-cuda-nuget-packaging-stage.yml
@@ -1,0 +1,175 @@
+# NuGet packaging stage for CUDA plugin EP.
+# Downloads platform-specific build artifacts, packs them into a single multi-platform NuGet package,
+# signs it, and publishes the artifact.
+
+parameters:
+- name: package_version
+  type: string
+
+- name: version_file
+  type: string
+
+- name: DoEsrp
+  type: boolean
+  default: true
+
+- name: platforms
+  type: object
+  default:
+    win_x64: false
+    linux_x64: false
+    linux_aarch64: false
+
+stages:
+- stage: NuGet_Packaging
+  displayName: 'NuGet Packaging'
+  dependsOn:
+  - ${{ if eq(parameters.platforms.win_x64, true) }}:
+    - Win_plugin_cuda_x64_Build
+  - ${{ if eq(parameters.platforms.linux_x64, true) }}:
+    - Linux_plugin_cuda_x64
+  - ${{ if eq(parameters.platforms.linux_aarch64, true) }}:
+    - Linux_plugin_cuda_aarch64
+  jobs:
+  # ---------- Pack job ----------
+  - job: NuGet_Pack
+    displayName: 'Pack NuGet'
+    timeoutInMinutes: 30
+    workspace:
+      clean: all
+    pool:
+      name: onnxruntime-Win-CPU-VS2022-Latest
+      os: windows
+    templateContext:
+      outputs:
+      - output: pipelineArtifact
+        targetPath: '$(Build.ArtifactStagingDirectory)\nuget'
+        artifactName: cuda_plugin_nuget
+    variables:
+    - template: ../templates/common-variables.yml
+    - name: CudaPackStagingDir
+      value: '$(Build.BinariesDirectory)\cuda_pack_staging'
+    # Common arguments shared by the Build and Pack invocations of pack_nuget.py.
+    - name: CudaPackNuGetCommonArgs
+      value: >-
+        --version "$(PluginPackageVersion)"
+        --output-dir "$(Build.ArtifactStagingDirectory)\nuget"
+        --staging-dir "$(CudaPackStagingDir)"
+        --configuration Release
+        --nuget-config "$(Build.SourcesDirectory)\NuGet.config"
+    steps:
+    - checkout: self
+      clean: true
+      submodules: none
+
+    - template: ../templates/setup-build-tools.yml
+      parameters:
+        host_cpu_arch: 'x64'
+
+    - template: ../templates/set-nightly-build-option-variable-step.yml
+
+    - template: ../templates/set-plugin-ep-build-variables-step.yml
+      parameters:
+        package_version: ${{ parameters.package_version }}
+        version_file: ${{ parameters.version_file }}
+
+    # Download platform artifacts
+    - ${{ if eq(parameters.platforms.win_x64, true) }}:
+      - task: DownloadPipelineArtifact@2
+        displayName: 'Download win-x64 artifacts'
+        inputs:
+          artifactName: cuda_plugin_win_x64
+          targetPath: '$(Build.BinariesDirectory)\artifacts\win_x64'
+
+    - ${{ if eq(parameters.platforms.linux_x64, true) }}:
+      - task: DownloadPipelineArtifact@2
+        displayName: 'Download linux-x64 artifacts'
+        inputs:
+          artifactName: cuda_plugin_linux_x64
+          targetPath: '$(Build.BinariesDirectory)\artifacts\linux_x64'
+
+    - ${{ if eq(parameters.platforms.linux_aarch64, true) }}:
+      - task: DownloadPipelineArtifact@2
+        displayName: 'Download linux-aarch64 artifacts'
+        inputs:
+          artifactName: cuda_plugin_linux_aarch64
+          targetPath: '$(Build.BinariesDirectory)\artifacts\linux_aarch64'
+
+    # Compute the set of required platforms from the pipeline parameters and verify the
+    # corresponding artifact directories actually downloaded. This catches renamed/moved
+    # upstream artifacts loudly before any pack work, and feeds pack_nuget.py the same
+    # list so it fails fast if any required platform's binaries are missing.
+    - task: PythonScript@0
+      displayName: 'Compute required platforms'
+      inputs:
+        scriptSource: inline
+        script: |
+          import os
+          import sys
+
+          # The string literals below are filled in by ADO template expansion at queue
+          # time and resolve to a boolean value 'True' or 'False'. Compare case-insensitively.
+          platforms_enabled = {
+              "win_x64":        "${{ parameters.platforms.win_x64 }}".lower() == "true",
+              "linux_x64":      "${{ parameters.platforms.linux_x64 }}".lower() == "true",
+              "linux_aarch64":  "${{ parameters.platforms.linux_aarch64 }}".lower() == "true",
+          }
+          expected = [name for name, enabled in platforms_enabled.items() if enabled]
+
+          if not expected:
+              print("##vso[task.logissue type=error]No platforms enabled in 'platforms' parameter — nothing to pack.")
+              sys.exit(1)
+
+          artifacts_dir = r"$(Build.BinariesDirectory)\artifacts"
+          missing = [
+              f"{p} ({d})"
+              for p in expected
+              for d in [os.path.join(artifacts_dir, p, "bin")]
+              if not os.path.isdir(d)
+          ]
+          if missing:
+              print("##vso[task.logissue type=error]Expected artifact directories not found:")
+              for m in missing:
+                  print(f"##vso[task.logissue type=error]  {m}")
+              sys.exit(1)
+
+          required = ",".join(expected)
+          print(f"Required platforms: {required}")
+          print(f"##vso[task.setvariable variable=CudaRequiredPlatforms]{required}")
+
+    # Stage binaries and build the managed assembly (so it can be ESRP-signed before packing).
+    - task: PythonScript@0
+      displayName: 'Build managed DLL'
+      inputs:
+        scriptSource: filePath
+        scriptPath: '$(Build.SourcesDirectory)\plugin-ep-cuda\csharp\pack_nuget.py'
+        arguments: >-
+          $(CudaPackNuGetCommonArgs)
+          --artifacts-dir "$(Build.BinariesDirectory)\artifacts"
+          --required-platforms $(CudaRequiredPlatforms)
+          --build-only
+
+    # ESRP-sign the managed DLL before it gets embedded in the .nupkg.
+    - template: ../templates/win-esrp-dll.yml
+      parameters:
+        FolderPath: '$(CudaPackStagingDir)'
+        Pattern: 'Microsoft.ML.OnnxRuntime.EP.Cuda.dll'
+        DisplayName: 'ESRP - Sign managed DLL'
+        DoEsrp: ${{ parameters.DoEsrp }}
+
+    # Pack the (now-signed) managed DLL plus native binaries into the .nupkg.
+    - task: PythonScript@0
+      displayName: 'Pack NuGet package'
+      inputs:
+        scriptSource: filePath
+        scriptPath: '$(Build.SourcesDirectory)\plugin-ep-cuda\csharp\pack_nuget.py'
+        arguments: >-
+          $(CudaPackNuGetCommonArgs)
+          --pack-only
+
+    # ESRP sign
+    - template: ../templates/esrp_nuget.yml
+      parameters:
+        FolderPath: '$(Build.ArtifactStagingDirectory)\nuget'
+        DisplayName: 'ESRP - Sign NuGet package'
+        DoEsrp: ${{ parameters.DoEsrp }}

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-cuda-packaging-stage.yml
@@ -155,3 +155,14 @@ stages:
               inputs:
                 artifact: cuda_plugin_linux_aarch64
                 targetPath: $(Build.ArtifactStagingDirectory)/cuda_plugin/aarch64
+
+    # NuGet packaging (runs after all platform builds)
+    - template: plugin-cuda-nuget-packaging-stage.yml
+      parameters:
+        package_version: ${{ parameters.package_type }}
+        version_file: ${{ parameters.version_file }}
+        DoEsrp: true
+        platforms:
+          win_x64: ${{ parameters.build_windows_x64 }}
+          linux_x64: ${{ parameters.build_linux_x64 }}
+          linux_aarch64: ${{ parameters.build_linux_aarch64 }}

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-linux-cuda-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-linux-cuda-stage.yml
@@ -88,7 +88,7 @@ stages:
         parameters:
           architecture: ${{ parameters.arch }}
 
-      - template: ../templates/set-plugin-build-variables-step.yml
+      - template: ../templates/set-plugin-ep-build-variables-step.yml
         parameters:
           package_version: ${{ parameters.package_version }}
           version_file: ${{ parameters.version_file }}
@@ -186,7 +186,7 @@ stages:
         parameters:
           architecture: ${{ parameters.arch }}
 
-      - template: ../templates/set-plugin-build-variables-step.yml
+      - template: ../templates/set-plugin-ep-build-variables-step.yml
         parameters:
           package_version: ${{ parameters.package_version }}
           version_file: ${{ parameters.version_file }}

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-linux-cuda-test-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-linux-cuda-test-stage.yml
@@ -1,7 +1,7 @@
 parameters:
 - name: machine_pool
   type: string
-  default: 'onnxruntime-Ubuntu2404-AMD-GPU-A10'
+  default: 'Onnxruntime-Linux-GPU-A10'
 
 - name: cuda_version
   type: string
@@ -53,7 +53,7 @@ stages:
         docker run --rm --gpus all \
           --volume "$(Build.SourcesDirectory):/onnxruntime_src" \
           --volume "$(Build.BinariesDirectory):/build" \
-          --env "PIP_INDEX_URL=${PIP_INDEX_URL}" \
+          --env PIP_INDEX_URL \
           --env "NVIDIA_VISIBLE_DEVICES=all" \
           --env "ORT_TEST_VERBOSE=$(System.Debug)" \
           onnxruntimecuda${{ replace(parameters.cuda_version, '.', '') }}plugintestx64 \

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-linux-webgpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-linux-webgpu-stage.yml
@@ -48,7 +48,7 @@ stages:
 
       - template: ../templates/set-nightly-build-option-variable-step.yml
 
-      - template: ../templates/set-plugin-build-variables-step.yml
+      - template: ../templates/set-plugin-ep-build-variables-step.yml
         parameters:
           package_version: ${{ parameters.package_version }}
           version_file: ${{ parameters.version_file }}
@@ -124,7 +124,7 @@ stages:
 
     - template: ../templates/set-nightly-build-option-variable-step.yml
 
-    - template: ../templates/set-plugin-build-variables-step.yml
+    - template: ../templates/set-plugin-ep-build-variables-step.yml
       parameters:
         package_version: ${{ parameters.package_version }}
         version_file: ${{ parameters.version_file }}

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-mac-webgpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-mac-webgpu-stage.yml
@@ -52,7 +52,7 @@ stages:
 
     - template: ../templates/set-nightly-build-option-variable-step.yml
 
-    - template: ../templates/set-plugin-build-variables-step.yml
+    - template: ../templates/set-plugin-ep-build-variables-step.yml
       parameters:
         package_version: ${{ parameters.package_version }}
         version_file: ${{ parameters.version_file }}
@@ -162,7 +162,7 @@ stages:
 
     - template: ../templates/set-nightly-build-option-variable-step.yml
 
-    - template: ../templates/set-plugin-build-variables-step.yml
+    - template: ../templates/set-plugin-ep-build-variables-step.yml
       parameters:
         package_version: ${{ parameters.package_version }}
         version_file: ${{ parameters.version_file }}

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-webgpu-nuget-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-webgpu-nuget-packaging-stage.yml
@@ -71,7 +71,7 @@ stages:
 
     - template: ../templates/set-nightly-build-option-variable-step.yml
 
-    - template: ../templates/set-plugin-build-variables-step.yml
+    - template: ../templates/set-plugin-ep-build-variables-step.yml
       parameters:
         package_version: ${{ parameters.package_version }}
         version_file: ${{ parameters.version_file }}

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-stage.yml
@@ -73,7 +73,7 @@ stages:
 
       - template: ../templates/set-nightly-build-option-variable-step.yml
 
-      - template: ../templates/set-plugin-build-variables-step.yml
+      - template: ../templates/set-plugin-ep-build-variables-step.yml
         parameters:
           package_version: ${{ parameters.package_version }}
           version_file: ${{ parameters.version_file }}
@@ -98,9 +98,9 @@ stages:
       # Since CUDA 13.0, CUDA DLLs are in bin\x64 folder instead of bin folder for Windows.
       - powershell: |
           Write-Host "Adding CUDA to PATH"
-          Write-Host "##vso[task.prependpath]$(Agent.TempDirectory)\v${{ parameters.cuda_version }}\bin"
-          Write-Host "##vso[task.prependpath]$(Agent.TempDirectory)\v${{ parameters.cuda_version }}\bin\x64"
-          Write-Host "##vso[task.prependpath]$(Agent.TempDirectory)\v${{ parameters.cuda_version }}\extras\CUPTI\lib64"
+          Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v${{ parameters.cuda_version }}\bin"
+          Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v${{ parameters.cuda_version }}\bin\x64"
+          Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v${{ parameters.cuda_version }}\extras\CUPTI\lib64"
         displayName: 'Add CUDA to PATH'
 
       # Download cuDNN separately for CUDA 13.0
@@ -245,7 +245,7 @@ stages:
 
       - template: ../templates/set-nightly-build-option-variable-step.yml
 
-      - template: ../templates/set-plugin-build-variables-step.yml
+      - template: ../templates/set-plugin-ep-build-variables-step.yml
         parameters:
           package_version: ${{ parameters.package_version }}
           version_file: ${{ parameters.version_file }}

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-test-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-test-stage.yml
@@ -82,3 +82,108 @@ stages:
 
           echo "running test_cuda_plugin_ep.py"
           python -u "$env:BUILD_SOURCESDIRECTORY\plugin-ep-cuda\python\test\test_cuda_plugin_ep.py"
+
+  # NuGet package test
+  - job: Win_plugin_cuda_nuget_Test
+    timeoutInMinutes: 30
+    workspace:
+      clean: all
+    pool:
+      name: onnxruntime-Win2022-GPU-A10
+      os: windows
+    variables:
+      CudaTestProject: '$(Build.SourcesDirectory)\plugin-ep-cuda\csharp\test\CudaEpNuGetTest\CudaEpNuGetTest.csproj'
+    steps:
+    - checkout: self
+      submodules: none
+
+    - template: ../templates/setup-feeds-and-python-steps.yml
+
+    - task: AzureCLI@2
+      displayName: 'Download CUDA SDK v${{ parameters.cuda_version }}'
+      inputs:
+        azureSubscription: AIInfraBuildOnnxRuntimeOSS
+        scriptType: 'batch'
+        scriptLocation: 'inlineScript'
+        inlineScript: |
+          set AZCOPY_AUTO_LOGIN_TYPE=AZCLI
+          azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cuda_sdk/v${{ parameters.cuda_version }} "%AGENT_TEMPDIRECTORY%"
+
+    # Download cuDNN separately for CUDA 13.0
+    - ${{ if eq(parameters.cuda_version, '13.0') }}:
+      - task: AzureCLI@2
+        displayName: 'Download cuDNN for CUDA 13.0'
+        inputs:
+          azureSubscription: AIInfraBuildOnnxRuntimeOSS
+          scriptType: 'batch'
+          scriptLocation: 'inlineScript'
+          inlineScript: |
+            set AZCOPY_AUTO_LOGIN_TYPE=AZCLI
+            azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cudnn_sdk/9.14.0.64_cuda13 "%AGENT_TEMPDIRECTORY%"
+
+    - powershell: |
+        Write-Host "Adding CUDA to PATH"
+        Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v${{ parameters.cuda_version }}\bin"
+        Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v${{ parameters.cuda_version }}\bin\x64"
+        Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v${{ parameters.cuda_version }}\extras\CUPTI\lib64"
+      displayName: 'Add CUDA to PATH'
+
+    # Download the NuGet package produced by the packaging pipeline run that
+    # triggered this pipeline (or that was selected at queue time).
+    - download: build
+      artifact: cuda_plugin_nuget
+      displayName: 'Download NuGet package'
+
+    # Set up local NuGet feed and extract the package version from the .nupkg filename
+    # so the test project can pin to it (instead of resolving via a floating version).
+    - pwsh: |
+        $ErrorActionPreference = 'Stop'
+        $localFeedDir = "$(Build.BinariesDirectory)\local_feed"
+        New-Item -ItemType Directory -Path $localFeedDir -Force | Out-Null
+
+        # Locate the .nupkg.
+        $nupkg = Get-ChildItem "$(Pipeline.Workspace)\build\cuda_plugin_nuget\Microsoft.ML.OnnxRuntime.EP.Cuda.*.nupkg" |
+                 Select-Object -First 1
+        if (-not $nupkg) {
+            throw "No matching .nupkg found under $(Pipeline.Workspace)\build\cuda_plugin_nuget"
+        }
+        Copy-Item $nupkg.FullName $localFeedDir -Force
+
+        # Extract version from filename: Microsoft.ML.OnnxRuntime.EP.Cuda.<version>.nupkg
+        # The version starts with a digit, which disambiguates from any future filename suffixes.
+        if ($nupkg.BaseName -notmatch '^Microsoft\.ML\.OnnxRuntime\.EP\.Cuda\.(\d.*)$') {
+            throw "Could not extract version from .nupkg filename: $($nupkg.Name)"
+        }
+        $packageVersion = $Matches[1]
+        Write-Host "Detected package version: $packageVersion"
+        Write-Host "##vso[task.setvariable variable=OrtCudaPackageVersion]$packageVersion"
+
+        # Write a project-level nuget.config that adds ONLY the local feed.
+        # NuGet merges this with the repo-root NuGet.config.
+        $nugetConfig = "$(Build.SourcesDirectory)\plugin-ep-cuda\csharp\test\CudaEpNuGetTest\nuget.config"
+        Set-Content -Path $nugetConfig -Encoding UTF8 -Value @"
+        <?xml version="1.0" encoding="utf-8"?>
+        <configuration>
+          <packageSources>
+            <add key="local" value="$localFeedDir" />
+          </packageSources>
+        </configuration>
+        "@
+        Write-Host "Wrote project-level nuget.config with local feed: $localFeedDir"
+        Write-Host "Local feed contents:"
+        Get-ChildItem $localFeedDir | ForEach-Object { Write-Host "  $($_.Name)" }
+      displayName: 'Set up local NuGet feed'
+
+    - pwsh: |
+        dotnet build `
+          "$(CudaTestProject)" `
+          --configuration Release `
+          -p:OrtCudaPackageVersion=$(OrtCudaPackageVersion)
+      displayName: 'Build test project'
+
+    - pwsh: |
+        dotnet run `
+          --project "$(CudaTestProject)" `
+          --configuration Release `
+          --no-build
+      displayName: 'Run NuGet package test'

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-test-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-test-stage.yml
@@ -35,13 +35,25 @@ stages:
         scriptLocation: 'inlineScript'
         inlineScript: |
           set AZCOPY_AUTO_LOGIN_TYPE=AZCLI
-          azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cuda_sdk/v${{ parameters.cuda_version }} "$(Agent.TempDirectory)"
+          azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cuda_sdk/v${{ parameters.cuda_version }} "%AGENT_TEMPDIRECTORY%"
+
+    # Download cuDNN separately for CUDA 13.0
+    - ${{ if eq(parameters.cuda_version, '13.0') }}:
+      - task: AzureCLI@2
+        displayName: 'Download cuDNN for CUDA 13.0'
+        inputs:
+          azureSubscription: AIInfraBuildOnnxRuntimeOSS
+          scriptType: 'batch'
+          scriptLocation: 'inlineScript'
+          inlineScript: |
+            set AZCOPY_AUTO_LOGIN_TYPE=AZCLI
+            azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cudnn_sdk/9.14.0.64_cuda13 "%AGENT_TEMPDIRECTORY%"
 
     - powershell: |
         Write-Host "Adding CUDA to PATH"
-        Write-Host "##vso[task.prependpath]$(Agent.TempDirectory)\v${{ parameters.cuda_version }}\bin"
-        Write-Host "##vso[task.prependpath]$(Agent.TempDirectory)\v${{ parameters.cuda_version }}\bin\x64"
-        Write-Host "##vso[task.prependpath]$(Agent.TempDirectory)\v${{ parameters.cuda_version }}\extras\CUPTI\lib64"
+        Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v${{ parameters.cuda_version }}\bin"
+        Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v${{ parameters.cuda_version }}\bin\x64"
+        Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v${{ parameters.cuda_version }}\extras\CUPTI\lib64"
       displayName: 'Add CUDA to PATH'
 
     - task: PowerShell@2
@@ -55,18 +67,18 @@ stages:
           $ErrorActionPreference = 'Stop'
 
           echo "creating test_venv"
-          python -m venv "$(Build.BinariesDirectory)\test_venv"
+          python -m venv "$env:BUILD_BINARIESDIRECTORY\test_venv"
 
           echo "activating test_venv"
-          & "$(Build.BinariesDirectory)\test_venv\Scripts\Activate.ps1"
+          & "$env:BUILD_BINARIESDIRECTORY\test_venv\Scripts\Activate.ps1"
 
           echo "installing onnxruntime onnx numpy"
           python -m pip install onnxruntime onnx numpy
 
-          $wheelDir = "$(Pipeline.Workspace)\build\cuda_plugin_python_win_x64_cuda${{ replace(parameters.cuda_version, '.', '') }}"
+          $wheelDir = "$env:PIPELINE_WORKSPACE\build\cuda_plugin_python_win_x64_cuda${{ replace(parameters.cuda_version, '.', '') }}"
           $wheel = (Get-ChildItem "$wheelDir\onnxruntime*ep*cuda*.whl")[0]
-          echo "installing ${wheel}"
+          echo "installing $($wheel.Name)"
           python -m pip install $wheel.FullName
 
           echo "running test_cuda_plugin_ep.py"
-          python -u "$(Build.SourcesDirectory)\plugin-ep-cuda\python\test\test_cuda_plugin_ep.py"
+          python -u "$env:BUILD_SOURCESDIRECTORY\plugin-ep-cuda\python\test\test_cuda_plugin_ep.py"

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-stage.yml
@@ -83,7 +83,7 @@ stages:
 
       - template: ../templates/set-nightly-build-option-variable-step.yml
 
-      - template: ../templates/set-plugin-build-variables-step.yml
+      - template: ../templates/set-plugin-ep-build-variables-step.yml
         parameters:
           package_version: ${{ parameters.package_version }}
           version_file: ${{ parameters.version_file }}
@@ -265,7 +265,7 @@ stages:
 
         - template: ../templates/set-nightly-build-option-variable-step.yml
 
-        - template: ../templates/set-plugin-build-variables-step.yml
+        - template: ../templates/set-plugin-ep-build-variables-step.yml
           parameters:
             package_version: ${{ parameters.package_version }}
             version_file: ${{ parameters.version_file }}

--- a/tools/ci_build/github/azure-pipelines/templates/set-plugin-ep-build-variables-step.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/set-plugin-ep-build-variables-step.yml
@@ -1,14 +1,14 @@
 # This file is used to set variables for plugin build stages. It sets the package version
-# variable based on the package_version parameter ('release', 'RC', or 'dev').
+# variable based on the package_version parameter ('release', 'rc', or 'dev').
 
 parameters:
-# The package version type: 'release', 'RC', or 'dev'. Controls how the final version
+# The package version type: 'release', 'rc', or 'dev'. Controls how the final version
 # string is derived from the contents of the version_file.
 - name: package_version
   type: string
   values:
   - release
-  - RC
+  - rc
   - dev
 
 # Path, relative to the repository root, of the file containing the base version number
@@ -28,5 +28,5 @@ steps:
 # Use 'script' (not 'bash') so this works on both Linux and Windows agents.
 # On Linux aarch64 agents UsePythonVersion@0 is unavailable, so we call the configured
 # Python executable directly instead of using PythonScript@0.
-- script: ${{ parameters.python_command }} "$(Build.SourcesDirectory)/tools/ci_build/set_plugin_build_variables.py" "${{ parameters.package_version }}" "${{ parameters.version_file }}"
-  displayName: 'Set plugin package version string'
+- script: ${{ parameters.python_command }} "$(Build.SourcesDirectory)/tools/ci_build/set_plugin_ep_build_variables.py" "${{ parameters.package_version }}" "${{ parameters.version_file }}"
+  displayName: 'Set plugin EP package version string'

--- a/tools/ci_build/github/linux/docker/scripts/manylinux/install_centos.sh
+++ b/tools/ci_build/github/linux/docker/scripts/manylinux/install_centos.sh
@@ -7,14 +7,14 @@ echo "installing for os major version : $os_major_version"
 if [ "$os_major_version" -gt 7 ]; then
     PACKAGE_MANAGER="dnf"
     if [ "$os_major_version" -ge 9 ]; then
-        $PACKAGE_MANAGER install -y which expat-devel tar unzip zlib-devel make bzip2 bzip2-devel perl-IPC-Cmd openssl-devel wget
+        "${PACKAGE_MANAGER}" install -y which expat-devel tar unzip zlib-devel make bzip2 bzip2-devel perl-IPC-Cmd openssl-devel wget
     else
-        $PACKAGE_MANAGER install -y which redhat-lsb-core expat-devel tar unzip zlib-devel make bzip2 bzip2-devel perl-IPC-Cmd openssl-devel wget
+        "${PACKAGE_MANAGER}" install -y which redhat-lsb-core expat-devel tar unzip zlib-devel make bzip2 bzip2-devel perl-IPC-Cmd openssl-devel wget
     fi
 fi
 
 # Install automatic documentation generation dependencies
-$PACKAGE_MANAGER install -y graphviz
+"${PACKAGE_MANAGER}" install -y graphviz
 
 if ! command -v ccache &>/dev/null; then
     "$PACKAGE_MANAGER" install -y ccache # FIXME: base image should already have ccache installed

--- a/tools/ci_build/set_plugin_ep_build_variables.py
+++ b/tools/ci_build/set_plugin_ep_build_variables.py
@@ -2,13 +2,13 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-"""Set plugin package version variables for Azure Pipelines.
+"""Set plugin EP package version variables for Azure Pipelines.
 
 Usage:
-    python set_plugin_build_variables.py <package_version> <version_file_rel>
+    python set_plugin_ep_build_variables.py <package_version> <version_file_rel>
 
 Where:
-    package_version: 'release', 'RC', or 'dev'
+    package_version: 'release', 'rc', or 'dev'
     version_file_rel: path relative to BUILD_SOURCESDIRECTORY of the VERSION_NUMBER file
 """
 
@@ -51,7 +51,7 @@ def main():
         universal_version = original_ver
         python_version = original_ver
 
-    elif package_version == "RC":
+    elif package_version == "rc":
         # RC versioning is not yet implemented. Fail the build to prevent publishing
         # an ambiguous version without an RC number.
         print("##vso[task.logissue type=error]RC versioning is not yet implemented. Use 'dev' or 'release' instead.")
@@ -87,7 +87,7 @@ def main():
 
     else:
         print(
-            f"##vso[task.logissue type=error]Unknown package_version '{package_version}'. Must be 'release', 'RC', or 'dev'."
+            f"##vso[task.logissue type=error]Unknown package_version '{package_version}'. Must be 'release', 'rc', or 'dev'."
         )
         sys.exit(1)
 


### PR DESCRIPTION
### Description

This PR adds C#/.NET (NuGet) packaging support for the CUDA plugin Execution Provider, following the pattern established by the WebGPU plugin EP NuGet packaging (PR #28313). It introduces a new NuGet package (`Microsoft.ML.OnnxRuntime.EP.Cuda`), the packaging pipeline stage, and a CI test that validates the produced package on a GPU agent.

### Motivation and Context

Create CUDA plugin EP NuGet package to enable C#/.NET consumers to use the CUDA plugin EP via NuGet, complementing the existing Python wheel distribution.

### Key Changes

**C#/.NET Package Infrastructure (`plugin-ep-cuda/csharp/`):**
- `Microsoft.ML.OnnxRuntime.EP.Cuda/` — NuGet package project (netstandard2.0) with `CudaEp.cs` helper class for native library path resolution and EP name retrieval
- `pack_nuget.py` — Staging and packing script supporting `--build-only`/`--pack-only` phases for the CI ESRP signing workflow
- `test/CudaEpNuGetTest/` — Test console app that registers the EP, runs inference on a Mul model, and validates output

**Pipeline Changes:**
- `plugin-cuda-nuget-packaging-stage.yml` — New NuGet packaging stage that downloads platform artifacts, builds managed DLL, ESRP-signs it, packs the NuGet, and signs the .nupkg
- `plugin-cuda-packaging-stage.yml` — Updated to include the NuGet packaging stage after platform builds
- `plugin-win-cuda-test-stage.yml` — Added `Win_plugin_cuda_nuget_Test` job that downloads the NuGet package, sets up a local feed, builds and runs the test project on a GPU agent

**Supported Platforms:**
| RID | Native Binary |
|---|---|
| `win-x64` | `onnxruntime_providers_cuda_plugin.dll` |
| `linux-x64` | `libonnxruntime_providers_cuda_plugin.so` |
| `linux-arm64` | `libonnxruntime_providers_cuda_plugin.so` |

### Related PRs
- #28313 — WebGPU plugin EP NuGet packaging (pattern reference)
- #28375 — C# tests for CUDA Plugin EP (EP name reference: `CudaPluginExecutionProvider`)
