### PR TITLE
[WebGPU plugin EP packaging] Remove explicit ORT package dependency

### DIFF
--- a/plugin-ep-webgpu/README.md
+++ b/plugin-ep-webgpu/README.md
@@ -11,7 +11,9 @@ For more information about plugin EPs, see the documentation [here](https://onnx
   final package version (release, dev) from this via
   [`tools/ci_build/github/azure-pipelines/templates/set-plugin-build-variables-step.yml`](../tools/ci_build/github/azure-pipelines/templates/set-plugin-build-variables-step.yml).
 - [`MIN_ONNXRUNTIME_VERSION`](MIN_ONNXRUNTIME_VERSION) — Minimum compatible core `onnxruntime` version. Single source
-  of truth shared by all packages built from this directory.
+  of truth shared by all packages built from this directory. The packages do not declare a hard dependency on a
+  specific ONNX Runtime package; instead, this version string is injected into each package's README at build/pack
+  time, and the native plugin EP code validates compatibility at registration time.
 - [`python/`](python/) — Sources and build script for the `onnxruntime-ep-webgpu` Python wheel. See
   [`python/README.md`](python/README.md) for build and test instructions.
 - [`csharp/`](csharp/) — Sources and packaging script for the `Microsoft.ML.OnnxRuntime.EP.WebGpu` NuGet package. See

--- a/plugin-ep-webgpu/_packaging_utils.py
+++ b/plugin-ep-webgpu/_packaging_utils.py
@@ -1,0 +1,44 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+"""Shared utilities for the WebGPU plugin EP packaging scripts. Not a public API."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# Matches "@var@" template variables.
+_TEMPLATE_VARIABLE_PATTERN = re.compile(r"@(\w+)@")
+
+
+def gen_file_from_template(
+    template_file: Path, output_file: Path, variable_substitutions: dict[str, str], strict: bool = True
+) -> None:
+    """Generate a file from a template by substituting "@var@" markers with provided values.
+
+    If `strict` is True, raises ValueError when the set of "@var@" names found in the template
+    does not match the keys of `variable_substitutions`.
+
+    Note: substituted values are inserted verbatim with no awareness of the target file's syntax.
+    The caller is responsible for any quoting/escaping required by the target format.
+    """
+    content = template_file.read_text(encoding="utf-8")
+
+    variables_in_file: set[str] = set()
+
+    def replace(match: re.Match[str]) -> str:
+        name = match.group(1)
+        variables_in_file.add(name)
+        return variable_substitutions.get(name, match.group(0))
+
+    content = _TEMPLATE_VARIABLE_PATTERN.sub(replace, content)
+
+    if strict and variables_in_file != variable_substitutions.keys():
+        provided = set(variable_substitutions.keys())
+        raise ValueError(
+            f"Template variables and substitution keys do not match for {template_file}. "
+            f"Only in template: {sorted(variables_in_file - provided)}. "
+            f"Only in substitutions: {sorted(provided - variables_in_file)}."
+        )
+
+    output_file.write_text(content, encoding="utf-8")

--- a/plugin-ep-webgpu/csharp/Microsoft.ML.OnnxRuntime.EP.WebGpu/Microsoft.ML.OnnxRuntime.EP.WebGpu.csproj
+++ b/plugin-ep-webgpu/csharp/Microsoft.ML.OnnxRuntime.EP.WebGpu/Microsoft.ML.OnnxRuntime.EP.WebGpu.csproj
@@ -26,28 +26,6 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
-  <!--
-    Minimum required Microsoft.ML.OnnxRuntime version is read from a file (single source
-    of truth, shared with the other plugin EP packages). The path is overridable via
-    -p:OnnxRuntimeMinVersionFile=<absolute path> so callers (e.g. pack_nuget.py, which
-    builds out of a staged copy) can point at the original file in the source tree.
-  -->
-  <PropertyGroup>
-    <OnnxRuntimeMinVersionFile Condition="'$(OnnxRuntimeMinVersionFile)' == ''">$(MSBuildThisFileDirectory)..\..\MIN_ONNXRUNTIME_VERSION</OnnxRuntimeMinVersionFile>
-    <OnnxRuntimeMinVersion Condition="Exists('$(OnnxRuntimeMinVersionFile)')">$([System.IO.File]::ReadAllText('$(OnnxRuntimeMinVersionFile)').Trim())</OnnxRuntimeMinVersion>
-  </PropertyGroup>
-
-  <Target Name="_ValidateOnnxRuntimeMinVersion" BeforeTargets="CollectPackageReferences">
-    <Error Condition="!Exists('$(OnnxRuntimeMinVersionFile)')"
-           Text="OnnxRuntimeMinVersionFile not found: '$(OnnxRuntimeMinVersionFile)'. Set -p:OnnxRuntimeMinVersionFile=&lt;absolute path&gt; or restore the file at the default location." />
-    <Error Condition="'$(OnnxRuntimeMinVersion)' == ''"
-           Text="OnnxRuntimeMinVersion resolved to an empty value from '$(OnnxRuntimeMinVersionFile)'." />
-  </Target>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(OnnxRuntimeMinVersion)" />
-  </ItemGroup>
-
   <ItemGroup>
     <!-- Ensure README is included in the package -->
     <None Include="README.md" Pack="true" PackagePath="" />

--- a/plugin-ep-webgpu/csharp/Microsoft.ML.OnnxRuntime.EP.WebGpu/README.md
+++ b/plugin-ep-webgpu/csharp/Microsoft.ML.OnnxRuntime.EP.WebGpu/README.md
@@ -2,6 +2,14 @@
 
 WebGPU plugin Execution Provider for [ONNX Runtime](https://github.com/microsoft/onnxruntime).
 
+### Prerequisites
+
+This package provides the WebGPU plugin EP only. Your project must separately reference an ONNX Runtime
+core package (e.g. `Microsoft.ML.OnnxRuntime`) of version `@min_onnxruntime_version@` or later.
+
+If the referenced ONNX Runtime is incompatible, the plugin EP will report an error when its library is
+registered.
+
 ### Usage
 
 ```csharp

--- a/plugin-ep-webgpu/csharp/pack_nuget.py
+++ b/plugin-ep-webgpu/csharp/pack_nuget.py
@@ -45,6 +45,10 @@ PROJECT_DIR = SCRIPT_DIR / "Microsoft.ML.OnnxRuntime.EP.WebGpu"
 CSPROJ = PROJECT_DIR / "Microsoft.ML.OnnxRuntime.EP.WebGpu.csproj"
 MIN_ORT_VERSION_FILE = SCRIPT_DIR.parent / "MIN_ONNXRUNTIME_VERSION"
 
+# Import the shared template helper from _packaging_utils.py in the parent directory.
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+from _packaging_utils import gen_file_from_template  # noqa: E402  (path setup must precede import)
+
 
 class PackError(RuntimeError):
     """Raised for any user-actionable failure during packaging."""
@@ -208,14 +212,12 @@ def stage_binaries(
 def dotnet_common_args(
     staged_csproj: Path,
     args: argparse.Namespace,
-    min_ort_version_file: Path,
 ) -> list[str]:
     common = [
         str(staged_csproj),
         "--configuration",
         args.configuration,
         f"-p:Version={args.version}",
-        f"-p:OnnxRuntimeMinVersionFile={min_ort_version_file}",
     ]
     if args.nuget_config:
         common.extend(["--configfile", str(args.nuget_config)])
@@ -223,10 +225,10 @@ def dotnet_common_args(
     return common
 
 
-def do_build(staged_csproj: Path, staging_dir: Path, args: argparse.Namespace, min_ort_version_file: Path) -> None:
+def do_build(staged_csproj: Path, staging_dir: Path, args: argparse.Namespace) -> None:
     print()
     print(f"Running dotnet build (Version={args.version}, Configuration={args.configuration})...")
-    cmd = ["dotnet", "build", *dotnet_common_args(staged_csproj, args, min_ort_version_file)]
+    cmd = ["dotnet", "build", *dotnet_common_args(staged_csproj, args)]
     print("+ " + " ".join(cmd))
     subprocess.run(cmd, check=True)
 
@@ -243,14 +245,13 @@ def do_pack(
     staged_csproj: Path,
     output_dir: Path,
     args: argparse.Namespace,
-    min_ort_version_file: Path,
 ) -> None:
     print()
     print(f"Running dotnet pack (Version={args.version}, Configuration={args.configuration})...")
     pack_args = [
         "dotnet",
         "pack",
-        *dotnet_common_args(staged_csproj, args, min_ort_version_file),
+        *dotnet_common_args(staged_csproj, args),
         "--output",
         str(output_dir),
     ]
@@ -269,6 +270,21 @@ def do_pack(
         print(f"Produced: {pkg.name} ({pkg.stat().st_size / (1024 * 1024):.2f} MB)")
 
 
+def render_readme(staging_dir: Path, min_ort_version: str) -> None:
+    """Substitute the minimum ORT version into the staged README in place."""
+    readme = staging_dir / "README.md"
+    if not readme.is_file():
+        raise PackError(f"staged README not found: {readme}")
+    try:
+        gen_file_from_template(
+            readme,
+            readme,
+            {"min_onnxruntime_version": min_ort_version},
+        )
+    except ValueError as e:
+        raise PackError(str(e)) from e
+
+
 def run_in_staging(args: argparse.Namespace, staging_dir: Path, min_ort_version_file: Path) -> None:
     staged_csproj = staging_dir / "Microsoft.ML.OnnxRuntime.EP.WebGpu.csproj"
     output_dir: Path = args.output_dir
@@ -282,12 +298,16 @@ def run_in_staging(args: argparse.Namespace, staging_dir: Path, min_ort_version_
     else:
         stage_sources(staging_dir)
         stage_binaries(staging_dir, args, required_platforms)
+        min_ort_version = min_ort_version_file.read_text(encoding="utf-8").strip()
+        if not min_ort_version:
+            raise PackError(f"{min_ort_version_file} is empty")
+        render_readme(staging_dir, min_ort_version)
 
     if args.build_only:
-        do_build(staged_csproj, staging_dir, args, min_ort_version_file)
+        do_build(staged_csproj, staging_dir, args)
         return
 
-    do_pack(staged_csproj, output_dir, args, min_ort_version_file)
+    do_pack(staged_csproj, output_dir, args)
 
     print()
     print(f"Done. Output: {output_dir}")

--- a/plugin-ep-webgpu/csharp/test/WebGpuEpNuGetTest/WebGpuEpNuGetTest.csproj
+++ b/plugin-ep-webgpu/csharp/test/WebGpuEpNuGetTest/WebGpuEpNuGetTest.csproj
@@ -13,10 +13,18 @@
       a single-package local feed.
     -->
     <OrtWebGpuPackageVersion Condition="'$(OrtWebGpuPackageVersion)' == ''">*-*</OrtWebGpuPackageVersion>
+    <!--
+      Version of the ONNX Runtime core package to test against. CI overrides this with
+      -p:OrtCoreTestVersion=<exact version> to pin the test to a specific version; the floating
+      fallback is for local development.
+    -->
+    <OrtCoreTestVersion Condition="'$(OrtCoreTestVersion)' == ''">*-*</OrtCoreTestVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Microsoft.ML.OnnxRuntime is pulled in transitively via the EP package. -->
+    <!-- The plugin EP package does not declare a hard dependency on a core ORT package, so reference
+         one explicitly here. -->
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(OrtCoreTestVersion)" />
     <PackageReference Include="Microsoft.ML.OnnxRuntime.EP.WebGpu" Version="$(OrtWebGpuPackageVersion)" />
   </ItemGroup>
 

--- a/plugin-ep-webgpu/python/build_wheel.py
+++ b/plugin-ep-webgpu/python/build_wheel.py
@@ -10,7 +10,6 @@ Usage:
 
 import argparse
 import platform
-import re
 import shutil
 import subprocess
 import sys
@@ -20,41 +19,9 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).parent
 MIN_ONNXRUNTIME_VERSION_FILE = SCRIPT_DIR.parent / "MIN_ONNXRUNTIME_VERSION"
 
-# Matches "@var@" template variables.
-_TEMPLATE_VARIABLE_PATTERN = re.compile(r"@(\w+)@")
-
-
-def gen_file_from_template(
-    template_file: Path, output_file: Path, variable_substitutions: dict[str, str], strict: bool = True
-) -> None:
-    """Generate a file from a template by substituting "@var@" markers with provided values.
-
-    If `strict` is True, raises ValueError when the set of "@var@" names found in the template
-    does not match the keys of `variable_substitutions`.
-
-    Note: substituted values are inserted verbatim with no awareness of the target file's syntax.
-    The caller is responsible for any quoting/escaping required by the target format.
-    """
-    content = template_file.read_text(encoding="utf-8")
-
-    variables_in_file: set[str] = set()
-
-    def replace(match: re.Match[str]) -> str:
-        name = match.group(1)
-        variables_in_file.add(name)
-        return variable_substitutions.get(name, match.group(0))
-
-    content = _TEMPLATE_VARIABLE_PATTERN.sub(replace, content)
-
-    if strict and variables_in_file != variable_substitutions.keys():
-        provided = set(variable_substitutions.keys())
-        raise ValueError(
-            f"Template variables and substitution keys do not match for {template_file}. "
-            f"Only in template: {sorted(variables_in_file - provided)}. "
-            f"Only in substitutions: {sorted(provided - variables_in_file)}."
-        )
-
-    output_file.write_text(content, encoding="utf-8")
+# Import the shared template helper from _packaging_utils.py in the parent directory.
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+from _packaging_utils import gen_file_from_template  # noqa: E402, I001  (path setup must precede import)
 
 
 # Patterns for binaries to include in the package
@@ -98,15 +65,23 @@ def prepare_staging_dir(staging_dir: Path, binary_dir: Path, version: str):
     if not copied:
         raise FileNotFoundError(f"No plugin binaries found in {binary_dir}. Looked for: {BINARY_PATTERNS}")
 
-    # Render pyproject.toml from its template
+    # Substitute the minimum ORT version into the staged README in place.
     min_ort_version = MIN_ONNXRUNTIME_VERSION_FILE.read_text(encoding="utf-8").strip()
     if not min_ort_version:
         raise ValueError(f"{MIN_ONNXRUNTIME_VERSION_FILE} is empty")
 
+    staged_readme = package_dir / "README.md"
+    gen_file_from_template(
+        staged_readme,
+        staged_readme,
+        {"min_onnxruntime_version": min_ort_version},
+    )
+
+    # Render pyproject.toml from its template
     gen_file_from_template(
         SCRIPT_DIR / "pyproject.toml.in",
         staging_dir / "pyproject.toml",
-        {"version": version, "min_onnxruntime_version": min_ort_version},
+        {"version": version},
     )
 
 

--- a/plugin-ep-webgpu/python/onnxruntime_ep_webgpu/README.md
+++ b/plugin-ep-webgpu/python/onnxruntime_ep_webgpu/README.md
@@ -1,10 +1,20 @@
 # ONNX Runtime WebGPU Plugin Execution Provider
 
-WebGPU Execution Provider plugin for ONNX Runtime. Install alongside `onnxruntime` to enable WebGPU acceleration.
+WebGPU Execution Provider plugin for ONNX Runtime. Install alongside `onnxruntime` to enable WebGPU
+acceleration.
+
+## Prerequisites
+
+This package provides the WebGPU plugin EP only. You must separately install an ONNX Runtime package
+(e.g. `onnxruntime`) of version `@min_onnxruntime_version@` or later.
+
+If the installed ONNX Runtime is incompatible, the plugin EP will report an error when its library is
+registered.
 
 ## Installation
 
 ```bash
+pip install "onnxruntime>=@min_onnxruntime_version@"
 pip install onnxruntime-ep-webgpu
 ```
 

--- a/plugin-ep-webgpu/python/pyproject.toml.in
+++ b/plugin-ep-webgpu/python/pyproject.toml.in
@@ -9,9 +9,6 @@ description = "ONNX Runtime WebGPU Plugin Execution Provider"
 readme = "onnxruntime_ep_webgpu/README.md"
 license = {text = "MIT"}
 requires-python = ">=3.11"
-dependencies = [
-  "onnxruntime>=@min_onnxruntime_version@",
-]
 
 [tool.setuptools.packages.find]
 include = ["onnxruntime_ep_webgpu*"]

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-linux-webgpu-test-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-linux-webgpu-test-stage.yml
@@ -71,7 +71,7 @@ stages:
             set -e -x
             python3 -m venv /build/test_venv
             source /build/test_venv/bin/activate
-            python3 -m pip install onnx numpy
+            python3 -m pip install onnx onnxruntime numpy
             wheel=\$(find /build/python_wheel -name 'onnxruntime_ep_webgpu-*.whl' | head -1)
             python3 -m pip install \"\$wheel\"
             python3 -u /onnxruntime_src/plugin-ep-webgpu/python/test/test_webgpu_plugin_ep.py

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-linux-webgpu-test-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-linux-webgpu-test-stage.yml
@@ -62,7 +62,7 @@ stages:
         swiftshader_icd=/opt/swiftshader/vk_swiftshader_icd.json
 
         min_ort_version_file="$(Build.SourcesDirectory)/plugin-ep-webgpu/MIN_ONNXRUNTIME_VERSION"
-        min_ort_version=$(tr -d '[:space:]' < "$min_ort_version_file")
+        min_ort_version=$(tr -d '\r\n' < "$min_ort_version_file")
         echo "using minimum onnxruntime version ${min_ort_version} from ${min_ort_version_file}"
 
         docker run --rm \

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-linux-webgpu-test-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-linux-webgpu-test-stage.yml
@@ -53,12 +53,18 @@ stages:
 
     - script: |
         set -e -x
+
         # Pin Vulkan to SwiftShader (software Vulkan, built from source in
         # the Docker image) so the test does not require a GPU agent.
         # Keeping these env vars at `docker run` time (rather than baking
         # them into the image) leaves the image reusable for a potential
         # future real-GPU test job.
         swiftshader_icd=/opt/swiftshader/vk_swiftshader_icd.json
+
+        min_ort_version_file="$(Build.SourcesDirectory)/plugin-ep-webgpu/MIN_ONNXRUNTIME_VERSION"
+        min_ort_version=$(tr -d '[:space:]' < "$min_ort_version_file")
+        echo "using minimum onnxruntime version ${min_ort_version} from ${min_ort_version_file}"
+
         docker run --rm \
           --volume "$(Build.SourcesDirectory):/onnxruntime_src" \
           --volume "$(Build.BinariesDirectory):/build" \
@@ -66,14 +72,15 @@ stages:
           --env "VK_ICD_FILENAMES=${swiftshader_icd}" \
           --env "VK_DRIVER_FILES=${swiftshader_icd}" \
           --env "ORT_TEST_VERBOSE=$(System.Debug)" \
+          --env "MIN_ORT_VERSION=${min_ort_version}" \
           onnxruntimewebgpuplugin \
-          /bin/bash -c "
+          /bin/bash -c '
             set -e -x
             python3 -m venv /build/test_venv
             source /build/test_venv/bin/activate
-            python3 -m pip install onnx onnxruntime numpy
-            wheel=\$(find /build/python_wheel -name 'onnxruntime_ep_webgpu-*.whl' | head -1)
-            python3 -m pip install \"\$wheel\"
+            python3 -m pip install onnx "onnxruntime==${MIN_ORT_VERSION}" numpy
+            wheel=$(find /build/python_wheel -name "onnxruntime_ep_webgpu-*.whl" | head -1)
+            python3 -m pip install "$wheel"
             python3 -u /onnxruntime_src/plugin-ep-webgpu/python/test/test_webgpu_plugin_ep.py
-          "
+          '
       displayName: 'Install and test Python package'

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-mac-webgpu-test-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-mac-webgpu-test-stage.yml
@@ -30,7 +30,7 @@ stages:
         set -e -x
         python3 -m venv "$(Build.BinariesDirectory)/test_venv"
         source "$(Build.BinariesDirectory)/test_venv/bin/activate"
-        python3 -m pip install onnx numpy
+        python3 -m pip install onnx onnxruntime numpy
         wheel=$(find "$(Pipeline.Workspace)/build/webgpu_plugin_python_macos_arm64" -name "onnxruntime_ep_webgpu-*.whl" | head -1)
         python3 -m pip install "$wheel"
         python3 -u "$(Build.SourcesDirectory)/plugin-ep-webgpu/python/test/test_webgpu_plugin_ep.py"

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-mac-webgpu-test-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-mac-webgpu-test-stage.yml
@@ -33,7 +33,7 @@ stages:
         source "$(Build.BinariesDirectory)/test_venv/bin/activate"
 
         min_ort_version_file="$(Build.SourcesDirectory)/plugin-ep-webgpu/MIN_ONNXRUNTIME_VERSION"
-        min_ort_version=$(tr -d '[:space:]' < "$min_ort_version_file")
+        min_ort_version=$(tr -d '\r\n' < "$min_ort_version_file")
         echo "using minimum onnxruntime version ${min_ort_version} from ${min_ort_version_file}"
 
         python3 -m pip install onnx "onnxruntime==${min_ort_version}" numpy

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-mac-webgpu-test-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-mac-webgpu-test-stage.yml
@@ -28,11 +28,19 @@ stages:
 
     - script: |
         set -e -x
+
         python3 -m venv "$(Build.BinariesDirectory)/test_venv"
         source "$(Build.BinariesDirectory)/test_venv/bin/activate"
-        python3 -m pip install onnx onnxruntime numpy
+
+        min_ort_version_file="$(Build.SourcesDirectory)/plugin-ep-webgpu/MIN_ONNXRUNTIME_VERSION"
+        min_ort_version=$(tr -d '[:space:]' < "$min_ort_version_file")
+        echo "using minimum onnxruntime version ${min_ort_version} from ${min_ort_version_file}"
+
+        python3 -m pip install onnx "onnxruntime==${min_ort_version}" numpy
+
         wheel=$(find "$(Pipeline.Workspace)/build/webgpu_plugin_python_macos_arm64" -name "onnxruntime_ep_webgpu-*.whl" | head -1)
         python3 -m pip install "$wheel"
+
         python3 -u "$(Build.SourcesDirectory)/plugin-ep-webgpu/python/test/test_webgpu_plugin_ep.py"
       displayName: 'Install and test Python package'
       env:

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-test-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-test-stage.yml
@@ -41,7 +41,7 @@ stages:
         & "$(Build.BinariesDirectory)\test_venv\Scripts\Activate.ps1"
 
         echo "installing test dependencies"
-        python -m pip install onnx numpy
+        python -m pip install onnx onnxruntime numpy
 
         $wheelDir = "$(Pipeline.Workspace)\build\webgpu_plugin_python_win_${{ parameters.arch }}"
         $wheel = (Get-ChildItem "$wheelDir\onnxruntime_ep_webgpu-*.whl")[0]

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-test-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-test-stage.yml
@@ -40,8 +40,12 @@ stages:
         echo "activating test_venv"
         & "$(Build.BinariesDirectory)\test_venv\Scripts\Activate.ps1"
 
+        $minOrtVersionFile = "$(Build.SourcesDirectory)\plugin-ep-webgpu\MIN_ONNXRUNTIME_VERSION"
+        $minOrtVersion = (Get-Content $minOrtVersionFile -Raw).Trim()
+        echo "using minimum onnxruntime version $minOrtVersion from $minOrtVersionFile"
+
         echo "installing test dependencies"
-        python -m pip install onnx onnxruntime numpy
+        python -m pip install onnx "onnxruntime==$minOrtVersion" numpy
 
         $wheelDir = "$(Pipeline.Workspace)\build\webgpu_plugin_python_win_${{ parameters.arch }}"
         $wheel = (Get-ChildItem "$wheelDir\onnxruntime_ep_webgpu-*.whl")[0]
@@ -102,6 +106,11 @@ stages:
           Write-Host "Detected package version: $packageVersion"
           Write-Host "##vso[task.setvariable variable=OrtWebGpuPackageVersion]$packageVersion"
 
+          $minOrtVersionFile = "$(Build.SourcesDirectory)\plugin-ep-webgpu\MIN_ONNXRUNTIME_VERSION"
+          $minOrtVersion = (Get-Content $minOrtVersionFile -Raw).Trim()
+          Write-Host "Using minimum core ORT version: $minOrtVersion from $minOrtVersionFile"
+          Write-Host "##vso[task.setvariable variable=OrtCoreTestVersion]$minOrtVersion"
+
           # Write a project-level nuget.config that adds ONLY the local feed.
           # NuGet merges this with the repo-root NuGet.config.
           $nugetConfig = "$(Build.SourcesDirectory)\plugin-ep-webgpu\csharp\test\WebGpuEpNuGetTest\nuget.config"
@@ -122,7 +131,8 @@ stages:
           dotnet build `
             "$(WebGpuTestProject)" `
             --configuration Release `
-            -p:OrtWebGpuPackageVersion=$(OrtWebGpuPackageVersion)
+            -p:OrtWebGpuPackageVersion=$(OrtWebGpuPackageVersion) `
+            -p:OrtCoreTestVersion=$(OrtCoreTestVersion)
         displayName: 'Build test project'
 
       - pwsh: |


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

This pull request refactors how the minimum required ONNX Runtime (ORT) version is handled and communicated for the WebGPU plugin EP packages (both Python and C#). Instead of declaring a hard dependency on a specific ORT version in package manifests, the minimum compatible version is now injected into package READMEs at build time, and ORT version compatibility will be checked at runtime. The packaging scripts are updated to use a shared template utility, and the CI/test setup is adjusted accordingly.

The most important changes are:

**Minimum ORT Version Handling and Documentation:**
* The Python and C# plugin EP packages no longer declare a hard dependency on a specific ONNX Runtime package version in their manifests (`pyproject.toml`, `.csproj`). Instead, the minimum required ORT version is injected into the package `README.md` during packaging, and users are instructed to install or reference the correct ORT version themselves.

**Packaging and Build Script Refactoring:**
* A new shared utility, `_packaging_utils.py`, is added for template-based file generation, and both Python (`build_wheel.py`) and C# (`pack_nuget.py`) packaging scripts are updated to use this helper for injecting the minimum ORT version into `README.md`. Duplicate template code is removed.
* The C# packaging script and project file are refactored to remove the mechanism for passing the minimum ORT version via MSBuild properties, since the dependency is now documented rather than enforced at build/package time.

**Test and CI Adjustments:**
* The Python test pipelines for Linux, macOS, and Windows are updated to explicitly install `onnxruntime` before testing the plugin EP, since it is no longer a transitive dependency.

These changes improve clarity for users about required dependencies, centralize version management, and simplify the packaging scripts.

NOTE: The WebGPU EP ORT version compatibility check does not actually use the value in `./plugin-ep-webgpu/MIN_ONNXRUNTIME_VERSION` yet. That can be done in another PR.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

There are multiple packages that can provide an ORT library. Even though the basic, CPU EP-only ORT package would typically be sufficient, we don't want to mandate usage of a specific package flavor.