### PR TITLE
Fixes for unicode path handling

### DIFF
--- a/onnxruntime/core/framework/ep_context_options.cc
+++ b/onnxruntime/core/framework/ep_context_options.cc
@@ -6,6 +6,7 @@
 #include <string>
 #include <utility>
 #include "core/common/common.h"
+#include "core/common/path_string.h"
 #include "core/framework/ep_context_options.h"
 #include "core/session/onnxruntime_session_options_config_keys.h"
 
@@ -22,8 +23,11 @@ ModelGenOptions::ModelGenOptions(const ConfigOptions& config_options) {
   enable = config_options.GetConfigOrDefault(kOrtSessionOptionEpContextEnable, "0") == "1";
 
   // Note: the older compilation approach only supports compiling to an output file.
+  // Use ToPathString() so that the UTF-8 session config value is decoded correctly
+  // on Windows (via MultiByteToWideChar(CP_UTF8)) rather than the ANSI code page,
+  // which would garble non-ASCII Unicode characters.
   output_model_location = std::filesystem::path(
-      config_options.GetConfigOrDefault(kOrtSessionOptionEpContextFilePath, ""));
+      ToPathString(config_options.GetConfigOrDefault(kOrtSessionOptionEpContextFilePath, "")));
 
   std::string external_initializers_file_path = config_options.GetConfigOrDefault(
       kOrtSessionOptionsEpContextModelExternalInitializersFileName, "");

--- a/onnxruntime/core/framework/ep_context_options.cc
+++ b/onnxruntime/core/framework/ep_context_options.cc
@@ -23,9 +23,8 @@ ModelGenOptions::ModelGenOptions(const ConfigOptions& config_options) {
   enable = config_options.GetConfigOrDefault(kOrtSessionOptionEpContextEnable, "0") == "1";
 
   // Note: the older compilation approach only supports compiling to an output file.
-  // Use ToPathString() so that the UTF-8 session config value is decoded correctly
-  // on Windows (via MultiByteToWideChar(CP_UTF8)) rather than the ANSI code page,
-  // which would garble non-ASCII Unicode characters.
+  // Use ToPathString() so that the UTF-8 session config value is converted to the
+  // platform-native path string on Windows, preserving non-ASCII Unicode characters.
   output_model_location = std::filesystem::path(
       ToPathString(config_options.GetConfigOrDefault(kOrtSessionOptionEpContextFilePath, "")));
 

--- a/onnxruntime/core/framework/model_metadef_id_generator.cc
+++ b/onnxruntime/core/framework/model_metadef_id_generator.cc
@@ -5,6 +5,7 @@
 #include <mutex>
 #include "core/graph/graph_viewer.h"
 #include "core/framework/murmurhash3.h"
+#include "core/common/path_string.h"
 
 namespace onnxruntime {
 int ModelMetadefIdGenerator::GenerateId(const onnxruntime::GraphViewer& graph_viewer,
@@ -40,7 +41,7 @@ int ModelMetadefIdGenerator::GenerateId(const onnxruntime::GraphViewer& graph_vi
 
     // prefer path the model was loaded from
     // this may not be available if the model was loaded from a stream or in-memory bytes
-    const auto model_path_str = main_graph.ModelPath().string();
+    const auto model_path_str = PathToUTF8String(main_graph.ModelPath().native());
     if (!model_path_str.empty()) {
       MurmurHash3::x86_128(model_path_str.data(), model_path_str.size(), hash[0], &hash);
     } else {

--- a/onnxruntime/test/autoep/test_execution.cc
+++ b/onnxruntime/test/autoep/test_execution.cc
@@ -841,6 +841,10 @@ TEST(OrtEpLibrary, PluginEp_GenEpContextModel_UnicodePath) {
   const fs::path unicode_dir{fs::path(u8"\u4e2d\u6587")};
   fs::remove_all(unicode_dir);
   fs::create_directories(unicode_dir);
+  auto cleanup = gsl::finally([&unicode_dir] {
+    std::error_code ec;
+    fs::remove_all(unicode_dir, ec);
+  });
 
   const fs::path input_model = unicode_dir / fs::path(u8"\u4e2d\u6587.onnx");
   const fs::path output_model = unicode_dir / fs::path(u8"\u4e2d\u6587_ctx.onnx");
@@ -868,8 +872,6 @@ TEST(OrtEpLibrary, PluginEp_GenEpContextModel_UnicodePath) {
     Ort::Session session(*ort_env, input_model.c_str(), session_options);
     ASSERT_TRUE(fs::exists(output_model)) << "EPContext not created at: " << utf8_output_path;
   }
-
-  fs::remove_all(unicode_dir);
 }
 
 // Test that inference works correctly when non-ASCII Unicode characters appear in the model file path.
@@ -879,6 +881,10 @@ TEST(OrtEpLibrary, PluginEp_Inference_UnicodePath) {
   const fs::path unicode_dir{fs::path(u8"\u4e2d\u6587")};
   fs::remove_all(unicode_dir);
   fs::create_directories(unicode_dir);
+  auto cleanup = gsl::finally([&unicode_dir] {
+    std::error_code ec;
+    fs::remove_all(unicode_dir, ec);
+  });
 
   const fs::path input_model = unicode_dir / fs::path(u8"\u4e2d\u6587.onnx");
   fs::copy_file(ORT_TSTR("testdata/mul_1.onnx"), input_model, fs::copy_options::overwrite_existing);
@@ -891,8 +897,6 @@ TEST(OrtEpLibrary, PluginEp_Inference_UnicodePath) {
   Ort::SessionOptions session_options;
   session_options.AppendExecutionProvider_V2(*ort_env, {plugin_ep_device}, ep_options);
   RunMulModelWithPluginEp(input_model.c_str(), session_options);
-
-  fs::remove_all(unicode_dir);
 }
 
 TEST(OrtEpLibrary, KernelPluginEp_Inference) {

--- a/onnxruntime/test/autoep/test_execution.cc
+++ b/onnxruntime/test/autoep/test_execution.cc
@@ -28,8 +28,8 @@ namespace test {
 
 namespace {
 
-void RunMulModelWithPluginEp(const Ort::SessionOptions& session_options) {
-  Ort::Session session(*ort_env, ORT_TSTR("testdata/mul_1.onnx"), session_options);
+void RunMulModelWithPluginEp(const ORTCHAR_T* model_path, const Ort::SessionOptions& session_options) {
+  Ort::Session session(*ort_env, model_path, session_options);
 
   // Create input
   Ort::MemoryInfo memory_info = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
@@ -52,6 +52,10 @@ void RunMulModelWithPluginEp(const Ort::SessionOptions& session_options) {
   const float* output_data = ort_output.GetTensorData<float>();
   gsl::span<const float> output_span(output_data, 6);
   EXPECT_THAT(output_span, ::testing::ElementsAre(2, 4, 6, 8, 10, 12));
+}
+
+void RunMulModelWithPluginEp(const Ort::SessionOptions& session_options) {
+  RunMulModelWithPluginEp(ORT_TSTR("testdata/mul_1.onnx"), session_options);
 }
 
 void RunCustomMulModelWithPluginEp(const Ort::SessionOptions& session_options) {
@@ -826,6 +830,69 @@ TEST(OrtEpLibrary, PluginEp_GenEpContextModel_ErrorOutputModelExists_AutoGenOutp
   }
 
   std::filesystem::remove(expected_output_model_file);
+}
+
+// Test that EPContext generation and inference work correctly when non-ASCII Unicode characters
+// appear in both the model file path and the EPContext output path.
+TEST(OrtEpLibrary, PluginEp_GenEpContextModel_UnicodePath) {
+  namespace fs = std::filesystem;
+
+  // Set up a Unicode working directory and model path (U+4E2D U+6587, "中文").
+  const fs::path unicode_dir{fs::path(u8"\u4e2d\u6587")};
+  fs::remove_all(unicode_dir);
+  fs::create_directories(unicode_dir);
+
+  const fs::path input_model = unicode_dir / fs::path(u8"\u4e2d\u6587.onnx");
+  const fs::path output_model = unicode_dir / fs::path(u8"\u4e2d\u6587_ctx.onnx");
+
+  fs::copy_file(ORT_TSTR("testdata/mul_1.onnx"), input_model, fs::copy_options::overwrite_existing);
+  fs::remove(output_model);
+
+  RegisteredEpDeviceUniquePtr example_ep;
+  ASSERT_NO_FATAL_FAILURE(Utils::RegisterAndGetExampleEp(*ort_env, Utils::example_ep_info, example_ep));
+  Ort::ConstEpDevice plugin_ep_device(example_ep.get());
+  std::unordered_map<std::string, std::string> ep_options;
+
+  // Convert the Unicode output path to a UTF-8 string for the session config entry.
+  // ep_context_options.cc must correctly convert this back to a wide path on Windows.
+  const auto u8str = output_model.u8string();
+  const std::string utf8_output_path(u8str.begin(), u8str.end());
+
+  // Generate EPContext model.
+  {
+    Ort::SessionOptions session_options;
+    session_options.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
+    session_options.AddConfigEntry(kOrtSessionOptionEpContextFilePath, utf8_output_path.c_str());
+    session_options.AppendExecutionProvider_V2(*ort_env, {plugin_ep_device}, ep_options);
+
+    Ort::Session session(*ort_env, input_model.c_str(), session_options);
+    ASSERT_TRUE(fs::exists(output_model)) << "EPContext not created at: " << utf8_output_path;
+  }
+
+  fs::remove_all(unicode_dir);
+}
+
+// Test that inference works correctly when non-ASCII Unicode characters appear in the model file path.
+TEST(OrtEpLibrary, PluginEp_Inference_UnicodePath) {
+  namespace fs = std::filesystem;
+
+  const fs::path unicode_dir{fs::path(u8"\u4e2d\u6587")};
+  fs::remove_all(unicode_dir);
+  fs::create_directories(unicode_dir);
+
+  const fs::path input_model = unicode_dir / fs::path(u8"\u4e2d\u6587.onnx");
+  fs::copy_file(ORT_TSTR("testdata/mul_1.onnx"), input_model, fs::copy_options::overwrite_existing);
+
+  RegisteredEpDeviceUniquePtr example_ep;
+  ASSERT_NO_FATAL_FAILURE(Utils::RegisterAndGetExampleEp(*ort_env, Utils::example_ep_info, example_ep));
+  Ort::ConstEpDevice plugin_ep_device(example_ep.get());
+  std::unordered_map<std::string, std::string> ep_options;
+
+  Ort::SessionOptions session_options;
+  session_options.AppendExecutionProvider_V2(*ort_env, {plugin_ep_device}, ep_options);
+  RunMulModelWithPluginEp(input_model.c_str(), session_options);
+
+  fs::remove_all(unicode_dir);
 }
 
 TEST(OrtEpLibrary, KernelPluginEp_Inference) {


### PR DESCRIPTION
### Description
Replace `path::string()` / bare `std::filesystem::path(string)` with
`PathToUTF8String` / `ToPathString` in two places that handle user-supplied
paths.

### Motivation and Context
On Windows, `path::string()` and `std::filesystem::path(std::string)` use the
system ANSI code page (CP_ACP). When a model or EPContext output file sits in a
directory with non-ASCII Unicode characters, this corrupts the path and causes:

- `ModelMetadefIdGenerator::GenerateId` — throws during session initialization
  ("No mapping for the Unicode character exists in the target multi-byte code page")
- `ModelGenOptions` (EPContext options) — constructs a garbled path, failing
  EPContext file creation with `ENOENT`