### PR TITLE
Validate CSR and COO indices in SparseToDenseMatMul

### DIFF
--- a/onnxruntime/contrib_ops/cpu/math/sparse_dense_matmul.cc
+++ b/onnxruntime/contrib_ops/cpu/math/sparse_dense_matmul.cc
@@ -79,11 +79,43 @@ inline void SparseDenseMatMulImpl<float>(const ComputeCtx& ctx, const ConstSpars
 // Handle CSR sparse format using Eigen
 template <class T>
 struct SparseToDenseCsr {
-  void operator()(const ComputeCtx& ctx, const SparseTensor& A, const Tensor& B, Tensor& output) const {
+  Status operator()(const ComputeCtx& ctx, const SparseTensor& A, const Tensor& B, Tensor& output) const {
     const auto& a_dims = A.DenseShape().GetDims();
     const auto& b_dims = B.Shape().GetDims();
     const auto& out_dims = output.Shape().GetDims();
+    const auto cols = a_dims[1];
+    const auto nnz = static_cast<int64_t>(A.NumValues());
+
     auto csr_view = A.AsCsr();
+
+    // Validate CSR index values before passing to Eigen
+    gsl::span<const int64_t> inner_raw = csr_view.Inner().DataAsSpan<int64_t>();
+    gsl::span<const int64_t> outer_raw = csr_view.Outer().DataAsSpan<int64_t>();
+
+    for (size_t i = 0; i < inner_raw.size(); ++i) {
+      ORT_RETURN_IF_NOT(inner_raw[i] >= 0 && inner_raw[i] < cols,
+                        "CSR inner index ", inner_raw[i], " at position ", i,
+                        " is out of bounds [0, ", cols, ")");
+    }
+
+    if (!outer_raw.empty()) {
+      ORT_RETURN_IF_NOT(outer_raw[0] == 0,
+                        "CSR outer index must start at 0, got ", outer_raw[0]);
+      ORT_RETURN_IF_NOT(outer_raw[outer_raw.size() - 1] == nnz,
+                        "CSR outer index must end at nnz (", nnz, "), got ",
+                        outer_raw[outer_raw.size() - 1]);
+    }
+
+    for (size_t i = 0; i < outer_raw.size(); ++i) {
+      ORT_RETURN_IF_NOT(outer_raw[i] >= 0 && outer_raw[i] <= nnz,
+                        "CSR outer index ", outer_raw[i], " at position ", i,
+                        " is out of bounds [0, ", nnz, "]");
+      if (i > 0) {
+        ORT_RETURN_IF_NOT(outer_raw[i] >= outer_raw[i - 1],
+                          "CSR outer indices must be non-decreasing at position ", i);
+      }
+    }
+
     const Eigen::Index* inner_index_pointer = nullptr;
     const Eigen::Index* outer_index_pointer = nullptr;
     // For auto-release the above two pointers when they are not NULL.
@@ -122,6 +154,7 @@ struct SparseToDenseCsr {
     // XXX: Consider re-writing it as a parallel loop as Eigen requires it to use OpenMP
     // XXX: Consider vectorization
     SparseDenseMatMulImpl(ctx, map_A, map_B, output_map);
+    return Status::OK();
   }
 };
 
@@ -164,8 +197,8 @@ struct SparseToDenseCoo {
     for (size_t i = 0; i < nnz; ++i) {
       const auto m = a_indicies_map(i, lhs_index_a);
       const auto k = a_indicies_map(i, rhs_index_a);
-      ORT_RETURN_IF_NOT(k < lhs_right, "COO k index: ", k, " is out of bounds of lhs_right: ", lhs_right);
-      ORT_RETURN_IF_NOT(m < out_left, "COO m index: ", m, " is out of bounds of out_left: ", out_left);
+      ORT_RETURN_IF_NOT(k >= 0 && k < lhs_right, "COO k index: ", k, " is out of bounds [0, ", lhs_right, ")");
+      ORT_RETURN_IF_NOT(m >= 0 && m < out_left, "COO m index: ", m, " is out of bounds [0, ", out_left, ")");
       const T a_value = a_values[i];
       for (int64_t n = 0; n < rhs_right; ++n) {
         const T b_value =
@@ -223,7 +256,8 @@ Status SparseToDenseMatMul::Compute(OpKernelContext* ctx) const {
     ORT_RETURN_IF_NOT(A->Values().Shape().Size() == csr_view.Inner().Shape().Size(),
                       "Expecting the same number NNZ == size of Inner indices");
     ORT_RETURN_IF_NOT((A_shape.GetDims()[0] + 1) == csr_view.Outer().Shape().Size(), "Outer size must be M + 1");
-    t_disp.Invoke<SparseToDenseCsr>(compute_ctx, *A, *B, *output);
+    auto status = t_disp.InvokeRet<Status, SparseToDenseCsr>(compute_ctx, *A, *B, *output);
+    ORT_RETURN_IF_ERROR(status);
   } else {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Currently support only COO and CSR(x64) formats");
   }

--- a/onnxruntime/test/contrib_ops/math/matmul_sparse_test.cc
+++ b/onnxruntime/test/contrib_ops/math/matmul_sparse_test.cc
@@ -380,11 +380,12 @@ TEST(SparseToDenseMatMul, TestCoo) {
 }
 
 // Regression tests for CSR/COO index bounds validation
-TEST(SparseToDenseMatMul, CsrInnerIndexOutOfBounds) {
-  // Inner index (column index) >= cols should fail
+
+// CSR tests
+TEST(SparseToDenseMatMul, Csr_NegativeInnerIndex) {
   const std::vector<int64_t> A_shape = {3, 3};
   const std::vector<float> A_values = {1.0f, 2.0f, 3.0f};
-  std::vector<int64_t> A_inner = {0, 99, 2};  // 99 is out of bounds for 3 cols
+  std::vector<int64_t> A_inner = {0, -1, 2};
   const std::vector<int64_t> A_outer = {0, 1, 2, 3};
 
   const std::vector<int64_t> B_shape = {3, 3};
@@ -397,27 +398,27 @@ TEST(SparseToDenseMatMul, CsrInnerIndexOutOfBounds) {
   tester.Run(OpTester::ExpectResult::kExpectFailure, "CSR inner index");
 }
 
-TEST(SparseToDenseMatMul, CsrNegativeInnerIndex) {
-  const std::vector<int64_t> A_shape = {3, 3};
+TEST(SparseToDenseMatMul, Csr_InnerIndexExceedsColumns_NonSquare) {
+  const std::vector<int64_t> A_shape = {3, 2};
   const std::vector<float> A_values = {1.0f, 2.0f, 3.0f};
-  std::vector<int64_t> A_inner = {0, -1, 2};  // negative index
+  std::vector<int64_t> A_inner = {0, 2, 1};  // 2 == cols, out of bounds [0, 2)
   const std::vector<int64_t> A_outer = {0, 1, 2, 3};
 
-  const std::vector<int64_t> B_shape = {3, 3};
-  const std::vector<float> B_data = {1, 0, 0, 0, 1, 0, 0, 0, 1};
+  const std::vector<int64_t> B_shape = {2, 2};
+  const std::vector<float> B_data = {1, 0, 0, 1};
 
   OpTester tester("SparseToDenseMatMul", 1, onnxruntime::kMSDomain);
   tester.AddSparseCsrInput("A", A_shape, A_values, A_inner, A_outer);
   tester.AddInput("B", B_shape, B_data);
-  tester.AddOutput("X", {3, 3}, std::vector<float>(9, 0.0f));
+  tester.AddOutput("X", {3, 2}, std::vector<float>(6, 0.0f));
   tester.Run(OpTester::ExpectResult::kExpectFailure, "CSR inner index");
 }
 
-TEST(SparseToDenseMatMul, CsrOuterIndexOutOfBounds) {
+TEST(SparseToDenseMatMul, Csr_NegativeOuterIndex) {
   const std::vector<int64_t> A_shape = {3, 3};
   const std::vector<float> A_values = {1.0f, 2.0f, 3.0f};
   const std::vector<int64_t> A_inner = {0, 1, 2};
-  std::vector<int64_t> A_outer = {0, 1, 2, 100};  // 100 > nnz (3)
+  std::vector<int64_t> A_outer = {0, -1, 2, 3};
 
   const std::vector<int64_t> B_shape = {3, 3};
   const std::vector<float> B_data = {1, 0, 0, 0, 1, 0, 0, 0, 1};
@@ -429,11 +430,27 @@ TEST(SparseToDenseMatMul, CsrOuterIndexOutOfBounds) {
   tester.Run(OpTester::ExpectResult::kExpectFailure, "CSR outer index");
 }
 
-TEST(SparseToDenseMatMul, CsrOuterIndexNonDecreasing) {
+TEST(SparseToDenseMatMul, Csr_OuterIndexExceedsNnz) {
   const std::vector<int64_t> A_shape = {3, 3};
   const std::vector<float> A_values = {1.0f, 2.0f, 3.0f};
   const std::vector<int64_t> A_inner = {0, 1, 2};
-  std::vector<int64_t> A_outer = {0, 2, 1, 3};  // non-monotonic: 2 > 1
+  std::vector<int64_t> A_outer = {0, 1, 4, 3};  // mid-array value 4 > nnz (3)
+
+  const std::vector<int64_t> B_shape = {3, 3};
+  const std::vector<float> B_data = {1, 0, 0, 0, 1, 0, 0, 0, 1};
+
+  OpTester tester("SparseToDenseMatMul", 1, onnxruntime::kMSDomain);
+  tester.AddSparseCsrInput("A", A_shape, A_values, A_inner, A_outer);
+  tester.AddInput("B", B_shape, B_data);
+  tester.AddOutput("X", {3, 3}, std::vector<float>(9, 0.0f));
+  tester.Run(OpTester::ExpectResult::kExpectFailure, "CSR outer index");
+}
+
+TEST(SparseToDenseMatMul, Csr_OuterIndexNotMonotonic) {
+  const std::vector<int64_t> A_shape = {3, 3};
+  const std::vector<float> A_values = {1.0f, 2.0f, 3.0f};
+  const std::vector<int64_t> A_inner = {0, 1, 2};
+  std::vector<int64_t> A_outer = {0, 2, 1, 3};  // 2 > 1
 
   const std::vector<int64_t> B_shape = {3, 3};
   const std::vector<float> B_data = {1, 0, 0, 0, 1, 0, 0, 0, 1};
@@ -445,11 +462,11 @@ TEST(SparseToDenseMatMul, CsrOuterIndexNonDecreasing) {
   tester.Run(OpTester::ExpectResult::kExpectFailure, "CSR outer indices must be non-decreasing");
 }
 
-TEST(SparseToDenseMatMul, CsrOuterFirstEntryNonZero) {
+TEST(SparseToDenseMatMul, Csr_OuterStartNotZero) {
   const std::vector<int64_t> A_shape = {3, 3};
   const std::vector<float> A_values = {1.0f, 2.0f, 3.0f};
   const std::vector<int64_t> A_inner = {0, 1, 2};
-  std::vector<int64_t> A_outer = {1, 1, 2, 3};  // first entry != 0
+  std::vector<int64_t> A_outer = {1, 1, 2, 3};
 
   const std::vector<int64_t> B_shape = {3, 3};
   const std::vector<float> B_data = {1, 0, 0, 0, 1, 0, 0, 0, 1};
@@ -461,7 +478,7 @@ TEST(SparseToDenseMatMul, CsrOuterFirstEntryNonZero) {
   tester.Run(OpTester::ExpectResult::kExpectFailure, "CSR outer index must start at 0");
 }
 
-TEST(SparseToDenseMatMul, CsrOuterLastEntryNotNnz) {
+TEST(SparseToDenseMatMul, Csr_OuterEndNotNnz) {
   const std::vector<int64_t> A_shape = {3, 3};
   const std::vector<float> A_values = {1.0f, 2.0f, 3.0f};
   const std::vector<int64_t> A_inner = {0, 1, 2};
@@ -477,10 +494,10 @@ TEST(SparseToDenseMatMul, CsrOuterLastEntryNotNnz) {
   tester.Run(OpTester::ExpectResult::kExpectFailure, "CSR outer index must end at nnz");
 }
 
-TEST(SparseToDenseMatMul, CooNegativeIndices) {
+// COO tests
+TEST(SparseToDenseMatMul, Coo_NegativeRowIndex) {
   const std::vector<int64_t> A_shape = {3, 3};
   const std::vector<float> A_values = {1.0f, 2.0f};
-  // Row -1 is invalid
   const std::vector<int64_t> A_indices = {-1, 0, 1, 1};
 
   const std::vector<int64_t> B_shape = {3, 3};
@@ -490,14 +507,13 @@ TEST(SparseToDenseMatMul, CooNegativeIndices) {
   tester.AddSparseCooInput("A", A_shape, A_values, A_indices);
   tester.AddInput("B", B_shape, B_data);
   tester.AddOutput("X", {3, 3}, std::vector<float>(9, 0.0f));
-  tester.Run(OpTester::ExpectResult::kExpectFailure, "COO");
+  tester.Run(OpTester::ExpectResult::kExpectFailure, "COO m index");
 }
 
-TEST(SparseToDenseMatMul, CooOutOfBoundsIndices) {
+TEST(SparseToDenseMatMul, Coo_NegativeColumnIndex) {
   const std::vector<int64_t> A_shape = {3, 3};
   const std::vector<float> A_values = {1.0f, 2.0f};
-  // Column index 50 is out of bounds for 3 cols
-  const std::vector<int64_t> A_indices = {0, 50, 1, 1};
+  const std::vector<int64_t> A_indices = {0, -1, 1, 1};
 
   const std::vector<int64_t> B_shape = {3, 3};
   const std::vector<float> B_data = {1, 0, 0, 0, 1, 0, 0, 0, 1};
@@ -506,7 +522,37 @@ TEST(SparseToDenseMatMul, CooOutOfBoundsIndices) {
   tester.AddSparseCooInput("A", A_shape, A_values, A_indices);
   tester.AddInput("B", B_shape, B_data);
   tester.AddOutput("X", {3, 3}, std::vector<float>(9, 0.0f));
-  tester.Run(OpTester::ExpectResult::kExpectFailure, "COO");
+  tester.Run(OpTester::ExpectResult::kExpectFailure, "COO k index");
+}
+
+TEST(SparseToDenseMatMul, Coo_RowIndexExceedsDimension) {
+  const std::vector<int64_t> A_shape = {3, 3};
+  const std::vector<float> A_values = {1.0f};
+  const std::vector<int64_t> A_indices = {3, 0};  // row 3 == rows
+
+  const std::vector<int64_t> B_shape = {3, 3};
+  const std::vector<float> B_data = {1, 0, 0, 0, 1, 0, 0, 0, 1};
+
+  OpTester tester("SparseToDenseMatMul", 1, onnxruntime::kMSDomain);
+  tester.AddSparseCooInput("A", A_shape, A_values, A_indices);
+  tester.AddInput("B", B_shape, B_data);
+  tester.AddOutput("X", {3, 3}, std::vector<float>(9, 0.0f));
+  tester.Run(OpTester::ExpectResult::kExpectFailure, "COO m index");
+}
+
+TEST(SparseToDenseMatMul, Coo_ColumnIndexExceedsDimension_NonSquare) {
+  const std::vector<int64_t> A_shape = {3, 2};
+  const std::vector<float> A_values = {1.0f};
+  const std::vector<int64_t> A_indices = {0, 2};  // col 2 == cols
+
+  const std::vector<int64_t> B_shape = {2, 4};
+  const std::vector<float> B_data = {1, 0, 0, 0, 0, 1, 0, 0};
+
+  OpTester tester("SparseToDenseMatMul", 1, onnxruntime::kMSDomain);
+  tester.AddSparseCooInput("A", A_shape, A_values, A_indices);
+  tester.AddInput("B", B_shape, B_data);
+  tester.AddOutput("X", {3, 4}, std::vector<float>(12, 0.0f));
+  tester.Run(OpTester::ExpectResult::kExpectFailure, "COO k index");
 }
 #endif  // !defined(DISABLE_SPARSE_TENSORS)
 

--- a/onnxruntime/test/contrib_ops/math/matmul_sparse_test.cc
+++ b/onnxruntime/test/contrib_ops/math/matmul_sparse_test.cc
@@ -378,6 +378,138 @@ TEST(SparseToDenseMatMul, TestCoo) {
     tester.Run(OpTester::ExpectResult::kExpectSuccess);
   }
 }
+
+// Regression tests for CSR/COO index bounds validation
+TEST(SparseToDenseMatMul, CsrInnerIndexOutOfBounds) {
+  // Inner index (column index) >= cols should fail
+  const std::vector<int64_t> A_shape = {3, 3};
+  const std::vector<float> A_values = {1.0f, 2.0f, 3.0f};
+  std::vector<int64_t> A_inner = {0, 99, 2};  // 99 is out of bounds for 3 cols
+  const std::vector<int64_t> A_outer = {0, 1, 2, 3};
+
+  const std::vector<int64_t> B_shape = {3, 3};
+  const std::vector<float> B_data = {1, 0, 0, 0, 1, 0, 0, 0, 1};
+
+  OpTester tester("SparseToDenseMatMul", 1, onnxruntime::kMSDomain);
+  tester.AddSparseCsrInput("A", A_shape, A_values, A_inner, A_outer);
+  tester.AddInput("B", B_shape, B_data);
+  tester.AddOutput("X", {3, 3}, std::vector<float>(9, 0.0f));
+  tester.Run(OpTester::ExpectResult::kExpectFailure, "CSR inner index");
+}
+
+TEST(SparseToDenseMatMul, CsrNegativeInnerIndex) {
+  const std::vector<int64_t> A_shape = {3, 3};
+  const std::vector<float> A_values = {1.0f, 2.0f, 3.0f};
+  std::vector<int64_t> A_inner = {0, -1, 2};  // negative index
+  const std::vector<int64_t> A_outer = {0, 1, 2, 3};
+
+  const std::vector<int64_t> B_shape = {3, 3};
+  const std::vector<float> B_data = {1, 0, 0, 0, 1, 0, 0, 0, 1};
+
+  OpTester tester("SparseToDenseMatMul", 1, onnxruntime::kMSDomain);
+  tester.AddSparseCsrInput("A", A_shape, A_values, A_inner, A_outer);
+  tester.AddInput("B", B_shape, B_data);
+  tester.AddOutput("X", {3, 3}, std::vector<float>(9, 0.0f));
+  tester.Run(OpTester::ExpectResult::kExpectFailure, "CSR inner index");
+}
+
+TEST(SparseToDenseMatMul, CsrOuterIndexOutOfBounds) {
+  const std::vector<int64_t> A_shape = {3, 3};
+  const std::vector<float> A_values = {1.0f, 2.0f, 3.0f};
+  const std::vector<int64_t> A_inner = {0, 1, 2};
+  std::vector<int64_t> A_outer = {0, 1, 2, 100};  // 100 > nnz (3)
+
+  const std::vector<int64_t> B_shape = {3, 3};
+  const std::vector<float> B_data = {1, 0, 0, 0, 1, 0, 0, 0, 1};
+
+  OpTester tester("SparseToDenseMatMul", 1, onnxruntime::kMSDomain);
+  tester.AddSparseCsrInput("A", A_shape, A_values, A_inner, A_outer);
+  tester.AddInput("B", B_shape, B_data);
+  tester.AddOutput("X", {3, 3}, std::vector<float>(9, 0.0f));
+  tester.Run(OpTester::ExpectResult::kExpectFailure, "CSR outer index");
+}
+
+TEST(SparseToDenseMatMul, CsrOuterIndexNonDecreasing) {
+  const std::vector<int64_t> A_shape = {3, 3};
+  const std::vector<float> A_values = {1.0f, 2.0f, 3.0f};
+  const std::vector<int64_t> A_inner = {0, 1, 2};
+  std::vector<int64_t> A_outer = {0, 2, 1, 3};  // non-monotonic: 2 > 1
+
+  const std::vector<int64_t> B_shape = {3, 3};
+  const std::vector<float> B_data = {1, 0, 0, 0, 1, 0, 0, 0, 1};
+
+  OpTester tester("SparseToDenseMatMul", 1, onnxruntime::kMSDomain);
+  tester.AddSparseCsrInput("A", A_shape, A_values, A_inner, A_outer);
+  tester.AddInput("B", B_shape, B_data);
+  tester.AddOutput("X", {3, 3}, std::vector<float>(9, 0.0f));
+  tester.Run(OpTester::ExpectResult::kExpectFailure, "CSR outer indices must be non-decreasing");
+}
+
+TEST(SparseToDenseMatMul, CsrOuterFirstEntryNonZero) {
+  const std::vector<int64_t> A_shape = {3, 3};
+  const std::vector<float> A_values = {1.0f, 2.0f, 3.0f};
+  const std::vector<int64_t> A_inner = {0, 1, 2};
+  std::vector<int64_t> A_outer = {1, 1, 2, 3};  // first entry != 0
+
+  const std::vector<int64_t> B_shape = {3, 3};
+  const std::vector<float> B_data = {1, 0, 0, 0, 1, 0, 0, 0, 1};
+
+  OpTester tester("SparseToDenseMatMul", 1, onnxruntime::kMSDomain);
+  tester.AddSparseCsrInput("A", A_shape, A_values, A_inner, A_outer);
+  tester.AddInput("B", B_shape, B_data);
+  tester.AddOutput("X", {3, 3}, std::vector<float>(9, 0.0f));
+  tester.Run(OpTester::ExpectResult::kExpectFailure, "CSR outer index must start at 0");
+}
+
+TEST(SparseToDenseMatMul, CsrOuterLastEntryNotNnz) {
+  const std::vector<int64_t> A_shape = {3, 3};
+  const std::vector<float> A_values = {1.0f, 2.0f, 3.0f};
+  const std::vector<int64_t> A_inner = {0, 1, 2};
+  std::vector<int64_t> A_outer = {0, 1, 2, 2};  // last entry (2) != nnz (3)
+
+  const std::vector<int64_t> B_shape = {3, 3};
+  const std::vector<float> B_data = {1, 0, 0, 0, 1, 0, 0, 0, 1};
+
+  OpTester tester("SparseToDenseMatMul", 1, onnxruntime::kMSDomain);
+  tester.AddSparseCsrInput("A", A_shape, A_values, A_inner, A_outer);
+  tester.AddInput("B", B_shape, B_data);
+  tester.AddOutput("X", {3, 3}, std::vector<float>(9, 0.0f));
+  tester.Run(OpTester::ExpectResult::kExpectFailure, "CSR outer index must end at nnz");
+}
+
+TEST(SparseToDenseMatMul, CooNegativeIndices) {
+  const std::vector<int64_t> A_shape = {3, 3};
+  const std::vector<float> A_values = {1.0f, 2.0f};
+  // Row -1 is invalid
+  const std::vector<int64_t> A_indices = {-1, 0, 1, 1};
+  const std::vector<int64_t> A_indices_shape = {2, 2};
+
+  const std::vector<int64_t> B_shape = {3, 3};
+  const std::vector<float> B_data = {1, 0, 0, 0, 1, 0, 0, 0, 1};
+
+  OpTester tester("SparseToDenseMatMul", 1, onnxruntime::kMSDomain);
+  tester.AddSparseCooInput("A", A_shape, A_values, A_indices);
+  tester.AddInput("B", B_shape, B_data);
+  tester.AddOutput("X", {3, 3}, std::vector<float>(9, 0.0f));
+  tester.Run(OpTester::ExpectResult::kExpectFailure, "COO");
+}
+
+TEST(SparseToDenseMatMul, CooOutOfBoundsIndices) {
+  const std::vector<int64_t> A_shape = {3, 3};
+  const std::vector<float> A_values = {1.0f, 2.0f};
+  // Column index 50 is out of bounds for 3 cols
+  const std::vector<int64_t> A_indices = {0, 50, 1, 1};
+  const std::vector<int64_t> A_indices_shape = {2, 2};
+
+  const std::vector<int64_t> B_shape = {3, 3};
+  const std::vector<float> B_data = {1, 0, 0, 0, 1, 0, 0, 0, 1};
+
+  OpTester tester("SparseToDenseMatMul", 1, onnxruntime::kMSDomain);
+  tester.AddSparseCooInput("A", A_shape, A_values, A_indices);
+  tester.AddInput("B", B_shape, B_data);
+  tester.AddOutput("X", {3, 3}, std::vector<float>(9, 0.0f));
+  tester.Run(OpTester::ExpectResult::kExpectFailure, "COO");
+}
 #endif  // !defined(DISABLE_SPARSE_TENSORS)
 
 }  // namespace test

--- a/onnxruntime/test/contrib_ops/math/matmul_sparse_test.cc
+++ b/onnxruntime/test/contrib_ops/math/matmul_sparse_test.cc
@@ -482,7 +482,6 @@ TEST(SparseToDenseMatMul, CooNegativeIndices) {
   const std::vector<float> A_values = {1.0f, 2.0f};
   // Row -1 is invalid
   const std::vector<int64_t> A_indices = {-1, 0, 1, 1};
-  const std::vector<int64_t> A_indices_shape = {2, 2};
 
   const std::vector<int64_t> B_shape = {3, 3};
   const std::vector<float> B_data = {1, 0, 0, 0, 1, 0, 0, 0, 1};
@@ -499,7 +498,6 @@ TEST(SparseToDenseMatMul, CooOutOfBoundsIndices) {
   const std::vector<float> A_values = {1.0f, 2.0f};
   // Column index 50 is out of bounds for 3 cols
   const std::vector<int64_t> A_indices = {0, 50, 1, 1};
-  const std::vector<int64_t> A_indices_shape = {2, 2};
 
   const std::vector<int64_t> B_shape = {3, 3};
   const std::vector<float> B_data = {1, 0, 0, 0, 1, 0, 0, 0, 1};


### PR DESCRIPTION
### Description
Fix out-of-bounds heap reads in the `SparseToDenseMatMul` contrib op by validating CSR and COO sparse tensor indices before use.

### Motivation and Context
The CSR path passed user-provided index arrays directly to Eigen's sparse matrix map without bounds checking, allowing crafted sparse tensors to read beyond allocated memory. The COO path had upper-bound checks but was missing non-negative index validation.

### Changes
- **CSR path**: Validate inner indices are in `[0, cols)`, outer indices are in `[0, nnz]`, non-decreasing, start at 0, and end at nnz. Changed return type to `Status` to propagate errors.
- **COO path**: Added `>= 0` checks alongside existing upper-bound checks.
- **Tests**: 11 regression tests covering all validation predicates, including non-square matrix cases to catch dimension mixups.