### PR TITLE
Address Resize kernel shortcomings

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cpu/tensor/upsample.cc
@@ -1103,18 +1103,6 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
   }
   AllocatorPtr alloc;
   ORT_RETURN_IF_ERROR(context->GetTempSpaceAllocator(&alloc));
-  auto checked_mul_int64 = [](int64_t a, int64_t b, int64_t& out) {
-    if (a < 0 || b < 0) {
-      return false;
-    }
-
-    if (a != 0 && b > std::numeric_limits<int64_t>::max() / a) {
-      return false;
-    }
-
-    out = a * b;
-    return true;
-  };
 
   switch (mode_) {
     case UpsampleMode::NN:
@@ -1197,19 +1185,19 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
                               is_valid_non_negative_int32(output_width_i64),
                           "Resize: dimensions exceed supported int32 range for CPU linear mode.");
 
-        batch_size = narrow<int32_t>(batch_size_i64);
-        num_channels = narrow<int32_t>(num_channels_i64);
-        input_height = narrow<int32_t>(input_height_i64);
-        input_width = narrow<int32_t>(input_width_i64);
-        output_height = narrow<int32_t>(output_height_i64);
-        output_width = narrow<int32_t>(output_width_i64);
+        batch_size = static_cast<int32_t>(batch_size_i64);
+        num_channels = static_cast<int32_t>(num_channels_i64);
+        input_height = static_cast<int32_t>(input_height_i64);
+        input_width = static_cast<int32_t>(input_width_i64);
+        output_height = static_cast<int32_t>(output_height_i64);
+        output_width = static_cast<int32_t>(output_width_i64);
 
         int64_t output_hw = 0;
-        ORT_RETURN_IF_NOT(checked_mul_int64(output_height_i64, output_width_i64, output_hw),
+        ORT_RETURN_IF_NOT(SafeMultiply(output_height_i64, output_width_i64, output_hw),
                           "Resize: output height*width overflows int64.");
 
         int64_t output_hwc = 0;
-        ORT_RETURN_IF_NOT(checked_mul_int64(output_hw, num_channels_i64, output_hwc),
+        ORT_RETURN_IF_NOT(SafeMultiply(output_hw, num_channels_i64, output_hwc),
                           "Resize: output height*width*channels overflows int64.");
 
         if (is_nchw) {
@@ -1290,7 +1278,7 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
         const int64_t output_width = is_3D ? output_dims[2] : output_dims[4];
 
         int64_t output_hw = 0;
-        ORT_RETURN_IF_NOT(checked_mul_int64(output_height, output_width, output_hw),
+        ORT_RETURN_IF_NOT(SafeMultiply(output_height, output_width, output_hw),
                           "Resize: output height*width overflows int64.");
 
         if (antialias_) {

--- a/onnxruntime/core/providers/cpu/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cpu/tensor/upsample.cc
@@ -3,6 +3,7 @@
 
 #include "core/providers/cpu/tensor/upsample.h"
 #include "core/common/safeint.h"
+#include <limits>
 #include "core/platform/threadpool.h"
 #include "core/providers/cpu/tensor/upsample_antialias.h"
 
@@ -1102,6 +1103,19 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
   }
   AllocatorPtr alloc;
   ORT_RETURN_IF_ERROR(context->GetTempSpaceAllocator(&alloc));
+  auto checked_mul_int64 = [](int64_t a, int64_t b, int64_t& out) {
+    if (a < 0 || b < 0) {
+      return false;
+    }
+
+    if (a != 0 && b > std::numeric_limits<int64_t>::max() / a) {
+      return false;
+    }
+
+    out = a * b;
+    return true;
+  };
+
   switch (mode_) {
     case UpsampleMode::NN:
       return UpsampleNearest<T>(X->Data<T>(), Y->MutableData<T>(), X->Shape(), Y->Shape(),
@@ -1116,6 +1130,17 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
         bool is_2D = dims.size() == 2;
         bool is_nchw = true;
 
+        auto is_valid_non_negative_int32 = [](int64_t v) {
+          return v >= 0 && v <= std::numeric_limits<int32_t>::max();
+        };
+
+        int64_t batch_size_i64 = 1;
+        int64_t num_channels_i64 = 1;
+        int64_t input_height_i64 = 0;
+        int64_t input_width_i64 = 0;
+        int64_t output_height_i64 = 0;
+        int64_t output_width_i64 = 0;
+
         int32_t batch_size;
         int32_t num_channels;
         int32_t input_height;
@@ -1128,25 +1153,22 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
         float width_scale;
 
         if (is_2D) {
-          batch_size = 1;
-          num_channels = 1;
-          input_height = static_cast<int32_t>(dims[0]);
-          input_width = static_cast<int32_t>(dims[1]);
-
-          output_height = static_cast<int32_t>(output_dims[0]);
-          output_width = static_cast<int32_t>(output_dims[1]);
+          input_height_i64 = dims[0];
+          input_width_i64 = dims[1];
+          output_height_i64 = output_dims[0];
+          output_width_i64 = output_dims[1];
 
           height_scale = scales[0];
           width_scale = scales[1];
         } else {
           if (scales[1] == 1.0f) {
-            batch_size = static_cast<int32_t>(dims[0]);
-            num_channels = static_cast<int32_t>(dims[1]);
-            input_height = static_cast<int32_t>(dims[2]);
-            input_width = static_cast<int32_t>(dims[3]);
+            batch_size_i64 = dims[0];
+            num_channels_i64 = dims[1];
+            input_height_i64 = dims[2];
+            input_width_i64 = dims[3];
 
-            output_height = static_cast<int32_t>(output_dims[2]);
-            output_width = static_cast<int32_t>(output_dims[3]);
+            output_height_i64 = output_dims[2];
+            output_width_i64 = output_dims[3];
 
             height_scale = scales[2];
             width_scale = scales[3];
@@ -1154,31 +1176,54 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
             ORT_RETURN_IF_NOT(scales[3] == 1.0f, "4-D input with innermost scale (usually channel of NHWC) as 1.");
             is_nchw = false;
 
-            batch_size = static_cast<int32_t>(dims[0]);
-            num_channels = static_cast<int32_t>(dims[3]);
-            input_height = static_cast<int32_t>(dims[1]);
-            input_width = static_cast<int32_t>(dims[2]);
+            batch_size_i64 = dims[0];
+            num_channels_i64 = dims[3];
+            input_height_i64 = dims[1];
+            input_width_i64 = dims[2];
 
-            output_height = static_cast<int32_t>(output_dims[1]);
-            output_width = static_cast<int32_t>(output_dims[2]);
+            output_height_i64 = output_dims[1];
+            output_width_i64 = output_dims[2];
 
             height_scale = scales[1];
             width_scale = scales[2];
           }
         }
 
+        ORT_RETURN_IF_NOT(is_valid_non_negative_int32(batch_size_i64) &&
+                              is_valid_non_negative_int32(num_channels_i64) &&
+                              is_valid_non_negative_int32(input_height_i64) &&
+                              is_valid_non_negative_int32(input_width_i64) &&
+                              is_valid_non_negative_int32(output_height_i64) &&
+                              is_valid_non_negative_int32(output_width_i64),
+                          "Resize: dimensions exceed supported int32 range for CPU linear mode.");
+
+        batch_size = narrow<int32_t>(batch_size_i64);
+        num_channels = narrow<int32_t>(num_channels_i64);
+        input_height = narrow<int32_t>(input_height_i64);
+        input_width = narrow<int32_t>(input_width_i64);
+        output_height = narrow<int32_t>(output_height_i64);
+        output_width = narrow<int32_t>(output_width_i64);
+
+        int64_t output_hw = 0;
+        ORT_RETURN_IF_NOT(checked_mul_int64(output_height_i64, output_width_i64, output_hw),
+                          "Resize: output height*width overflows int64.");
+
+        int64_t output_hwc = 0;
+        ORT_RETURN_IF_NOT(checked_mul_int64(output_hw, num_channels_i64, output_hwc),
+                          "Resize: output height*width*channels overflows int64.");
+
         if (is_nchw) {
           if (antialias_) {
             UpsampleBilinearAntiAlias(batch_size, num_channels, input_height, input_width, output_height, output_width,
                                       height_scale, width_scale, roi, use_extrapolation_, extrapolation_value_, exclude_outside_,
                                       X, Y->MutableData<T>(), alloc, get_original_coordinate_,
-                                      output_height * output_width > 64 ? context->GetOperatorThreadPool() : nullptr);
+                                      output_hw > 64 ? context->GetOperatorThreadPool() : nullptr);
           } else {
             UpsampleBilinear(batch_size, num_channels, input_height, input_width, output_height, output_width,
                              height_scale, width_scale, roi,
                              use_extrapolation_, extrapolation_value_, X->Data<T>(),
                              Y->MutableData<T>(), alloc, get_original_coordinate_,
-                             output_height * output_width > 64 ? context->GetOperatorThreadPool() : nullptr);
+                             output_hw > 64 ? context->GetOperatorThreadPool() : nullptr);
           }
         } else {
           if (use_extrapolation_) {
@@ -1186,7 +1231,7 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
               NhwcUpsampleBilinearAntiAlias(batch_size, num_channels, input_height, input_width, output_height, output_width,
                                             height_scale, width_scale, roi, use_extrapolation_, extrapolation_value_, exclude_outside_,
                                             X, Y->MutableData<T>(), alloc, get_original_coordinate_,
-                                            output_height * output_width > 64 ? context->GetOperatorThreadPool() : nullptr);
+                                            output_hw > 64 ? context->GetOperatorThreadPool() : nullptr);
             } else {
               if (!is_2D &&
                   (Y->GetElementType() == ONNX_NAMESPACE::TensorProto_DataType_UINT8 ||
@@ -1195,13 +1240,13 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
                     batch_size, num_channels, input_height, input_width, output_height, output_width,
                     height_scale, width_scale, roi, extrapolation_value_, X->Data<T>(), Y->MutableData<T>(),
                     alloc, get_original_coordinate_,
-                    output_height * output_width * num_channels > 64 ? context->GetOperatorThreadPool() : nullptr);
+                    output_hwc > 64 ? context->GetOperatorThreadPool() : nullptr);
               } else {
                 NhwcUpsampleBilinear<T, true>(
                     batch_size, num_channels, input_height, input_width, output_height, output_width,
                     height_scale, width_scale, roi, extrapolation_value_, X->Data<T>(), Y->MutableData<T>(),
                     alloc, get_original_coordinate_,
-                    output_height * output_width * num_channels > 64 ? context->GetOperatorThreadPool() : nullptr);
+                    output_hwc > 64 ? context->GetOperatorThreadPool() : nullptr);
               }
             }
           } else {
@@ -1209,7 +1254,7 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
               NhwcUpsampleBilinearAntiAlias(batch_size, num_channels, input_height, input_width, output_height, output_width,
                                             height_scale, width_scale, roi, use_extrapolation_, extrapolation_value_, exclude_outside_,
                                             X, Y->MutableData<T>(), alloc, get_original_coordinate_,
-                                            output_height * output_width > 64 ? context->GetOperatorThreadPool() : nullptr);
+                                            output_hw > 64 ? context->GetOperatorThreadPool() : nullptr);
             } else {
               if (!is_2D &&
                   (Y->GetElementType() == ONNX_NAMESPACE::TensorProto_DataType_UINT8 ||
@@ -1218,13 +1263,13 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
                     batch_size, num_channels, input_height, input_width, output_height, output_width,
                     height_scale, width_scale, roi, extrapolation_value_, X->Data<T>(), Y->MutableData<T>(),
                     alloc, get_original_coordinate_,
-                    output_height * output_width * num_channels > 64 ? context->GetOperatorThreadPool() : nullptr);
+                    output_hwc > 64 ? context->GetOperatorThreadPool() : nullptr);
               } else {
                 NhwcUpsampleBilinear<T, false>(
                     batch_size, num_channels, input_height, input_width, output_height, output_width,
                     height_scale, width_scale, roi, extrapolation_value_, X->Data<T>(), Y->MutableData<T>(),
                     alloc, get_original_coordinate_,
-                    output_height * output_width * num_channels > 64 ? context->GetOperatorThreadPool() : nullptr);
+                    output_hwc > 64 ? context->GetOperatorThreadPool() : nullptr);
               }
             }
           }
@@ -1244,20 +1289,24 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
         const int64_t output_height = is_3D ? output_dims[1] : output_dims[3];
         const int64_t output_width = is_3D ? output_dims[2] : output_dims[4];
 
+        int64_t output_hw = 0;
+        ORT_RETURN_IF_NOT(checked_mul_int64(output_height, output_width, output_hw),
+                          "Resize: output height*width overflows int64.");
+
         if (antialias_) {
           UpsampleTrilinearAntiAlias(batch_size, num_channels, input_depth, input_height, input_width,
                                      output_depth, output_height, output_width,
                                      is_3D ? scales[0] : scales[2], is_3D ? scales[1] : scales[3],
                                      is_3D ? scales[2] : scales[4], roi, use_extrapolation_, extrapolation_value_,
                                      exclude_outside_, X, Y->MutableData<T>(), alloc, get_original_coordinate_,
-                                     output_height * output_width > 64 ? context->GetOperatorThreadPool() : nullptr);
+                                     output_hw > 64 ? context->GetOperatorThreadPool() : nullptr);
         } else {
           UpsampleTrilinear(batch_size, num_channels, input_depth, input_height, input_width,
                             output_depth, output_height, output_width,
                             is_3D ? scales[0] : scales[2], is_3D ? scales[1] : scales[3],
                             is_3D ? scales[2] : scales[4], roi, use_extrapolation_, extrapolation_value_,
                             X->Data<T>(), Y->MutableData<T>(), alloc, get_original_coordinate_,
-                            output_height * output_width > 64 ? context->GetOperatorThreadPool() : nullptr);
+                            output_hw > 64 ? context->GetOperatorThreadPool() : nullptr);
         }
         return Status::OK();
       } else {

--- a/onnxruntime/core/providers/cpu/tensor/upsample_antialias.h
+++ b/onnxruntime/core/providers/cpu/tensor/upsample_antialias.h
@@ -140,13 +140,20 @@ void SetupUpsampleFilterAntiAlias(FilterParamsAntiAlias<T>& p,
     const size_t scale_buffer_size = static_cast<size_t>(SafeInt<size_t>(window_size) * output_size);
 
     param_base.weight_coefficients = IAllocator::MakeUniquePtr<T>(alloc, scale_buffer_size);
-    // Get pointers to appropriate memory locations in the scratch buffer
-    auto* scale_data = reinterpret_cast<float*>(param_base.weight_coefficients.get());
+    auto* output_weights = param_base.weight_coefficients.get();
     int64_t xmin = 0, xmax = 0;
     float inv_scale = (scale >= 1.0f) ? 1.0f / scale : 1.0f;
 
     const auto roi_start = roi.size() / 2 - (rindex + 1);
     const auto roi_end = roi.size() - (rindex + 1);
+
+    // Per-pixel scratch buffer for float weight computation, reused across all output pixels.
+    // window_size = ceil(support) * 2 + 1, where support = support_size * 0.5 * max(scale, 1).
+    //   Downsampling (scale < 1): bilinear=3, bicubic=5 (always).
+    //   Upsampling:  2x bilinear=5, 4x bilinear=9, 8x bilinear=17,
+    //                2x bicubic=9,  4x bicubic=17, 8x bicubic=33.
+    // Inline capacity of 33 covers up to 8x bicubic upsample without heap allocation.
+    InlinedVector<float, 33> scale_buffer(window_size);
 
     for (int32_t i = 0; i < output_size; i++) {
       float center = 0.5f + (scale == 1.0f ? static_cast<float>(i)
@@ -170,41 +177,44 @@ void SetupUpsampleFilterAntiAlias(FilterParamsAntiAlias<T>& p,
       xmax = exclude_outside ? xmax_cut : xmax_real;
       param_base.bounds.push_back({xmin_cut, xmax_cut});
 
-      auto* scale_buffer = &scale_data[i * window_size];
+      std::fill(scale_buffer.begin(), scale_buffer.end(), 0.0f);
       int64_t x = 0;
       xmax -= xmin;
       for (; x < xmax; x++) {
         float w = p.Filter((x + xmin - center + 0.5f) * inv_scale);
-        scale_buffer[x] = w;
+        scale_buffer[narrow<size_t>(x)] = w;
         total_weight += w;
       }
 
       if (!exclude_outside) {
         int64_t neg_xsize = xmin < 0 ? -xmin : 0;
         for (x = 0; x < neg_xsize; x++) {
-          scale_buffer[neg_xsize] += scale_buffer[x];
+          scale_buffer[narrow<size_t>(neg_xsize)] += scale_buffer[narrow<size_t>(x)];
         }
 
         int64_t bound_xsize =
             xmax + xmin > input_size ? xmax + xmin - input_size : 0;
         for (x = xmax - bound_xsize; x < xmax; x++) {
-          scale_buffer[xmax - bound_xsize - 1] +=
-              scale_buffer[x];
+          scale_buffer[narrow<size_t>(xmax - bound_xsize - 1)] +=
+              scale_buffer[narrow<size_t>(x)];
         }
 
         for (x = 0; (neg_xsize | bound_xsize) > 0 && x < xmax_cut - xmin_cut; x++) {
-          scale_buffer[x] = scale_buffer[x + neg_xsize];
+          scale_buffer[narrow<size_t>(x)] = scale_buffer[narrow<size_t>(x + neg_xsize)];
         }
       }
 
-      float total_weight_inv = total_weight == 0.0f ? 1.f : 1.0f / total_weight;
-      auto* scale_buffer_int = reinterpret_cast<int32_t*>(scale_buffer);
-      for (x = 0; x < xmax_cut - xmin_cut; x++) {
-        scale_buffer[x] *= total_weight_inv;
-
-        // normalize the scale to 1 << 22 for int8/uint8
-        if constexpr (std::is_same<T, int32_t>::value) {
-          scale_buffer_int[x] = static_cast<int32_t>(std::round(scale_buffer[x] * ConstValue::mag_factor_x_2));
+      // Normalize weights and write to the output buffer as T.
+      float total_weight_inv = total_weight == 0.0f ? 1.0f : 1.0f / total_weight;
+      auto* dest = &output_weights[i * window_size];
+      const int64_t num_weights = xmax_cut - xmin_cut;
+      for (x = 0; x < num_weights; x++) {
+        float normalized = scale_buffer[narrow<size_t>(x)] * total_weight_inv;
+        if constexpr (std::is_same_v<T, int32_t>) {
+          // Quantized path: normalize the scale to 1 << 22 for int8/uint8
+          dest[x] = static_cast<int32_t>(std::round(normalized * ConstValue::mag_factor_x_2));
+        } else {
+          dest[x] = normalized;
         }
       }
     }

--- a/onnxruntime/core/providers/cpu/tensor/upsample_antialias.h
+++ b/onnxruntime/core/providers/cpu/tensor/upsample_antialias.h
@@ -149,7 +149,6 @@ void SetupUpsampleFilterAntiAlias(FilterParamsAntiAlias<T>& p,
     const auto roi_end = roi.size() - (rindex + 1);
 
     for (int32_t i = 0; i < output_size; i++) {
-      // double center = (i + 0.5) * scale;
       float center = 0.5f + (scale == 1.0f ? static_cast<float>(i)
                                            : get_original_coordinate(static_cast<float>(i), rscale,
                                                                      static_cast<float>(output_size),
@@ -158,13 +157,13 @@ void SetupUpsampleFilterAntiAlias(FilterParamsAntiAlias<T>& p,
       if (center - 0.5f < 0 || center - 0.5f > narrow<float>(input_size - 1)) {
         param_base.out_of_bound_idx.emplace_back(i);
       }
-      float total_weight = 0.0;
+      float total_weight = 0.0f;
 
       auto fmin = std::floor(center - support + 0.5f);
       auto fmax = std::floor(center + support + 0.5f);
       int64_t xmin_real = static_cast<int64_t>(fmin);
       int64_t xmax_real = static_cast<int64_t>(fmax);
-      int64_t xmin_cut = std::max<int64_t>(xmin_real, (0));
+      int64_t xmin_cut = std::max<int64_t>(xmin_real, 0);
       int64_t xmax_cut = std::min<int64_t>(xmax_real, input_size);
 
       xmin = exclude_outside ? xmin_cut : xmin_real;
@@ -208,9 +207,6 @@ void SetupUpsampleFilterAntiAlias(FilterParamsAntiAlias<T>& p,
           scale_buffer_int[x] = static_cast<int32_t>(std::round(scale_buffer[x] * ConstValue::mag_factor_x_2));
         }
       }
-      /*for (; x < window_size; x++) {
-        scale_buffer[x] = 0;
-      }*/
     }
 
     return window_size;
@@ -427,21 +423,25 @@ void HandleExtrapolation(int64_t num_channels,
         InputType* Ydata_base_nc =
             Ydata_span.data() + static_cast<size_t>(SafeInt<size_t>(nc) * output_depth * output_height * output_width);
 
-        for (int64_t z = 0; z < output_depth && p.dim_x.out_of_bound_idx.size() > 0; ++z) {
-          for (int64_t y = 0; y < output_height; ++y) {
-            const SafeInt<size_t> offset = (SafeInt<size_t>(z) * output_height + y) * output_width;
-            InputType* Ydata_offset = Ydata_base_nc + static_cast<size_t>(offset);
-            for (int64_t idx_x : p.dim_x.out_of_bound_idx) {
-              Ydata_offset[narrow<size_t>(idx_x)] = static_cast<InputType>(extrapolation_value);
+        if (!p.dim_x.out_of_bound_idx.empty()) {
+          for (int64_t z = 0; z < output_depth; ++z) {
+            for (int64_t y = 0; y < output_height; ++y) {
+              const SafeInt<size_t> offset = (SafeInt<size_t>(z) * output_height + y) * output_width;
+              InputType* Ydata_offset = Ydata_base_nc + static_cast<size_t>(offset);
+              for (int64_t idx_x : p.dim_x.out_of_bound_idx) {
+                Ydata_offset[narrow<size_t>(idx_x)] = static_cast<InputType>(extrapolation_value);
+              }
             }
           }
         }
 
-        for (int64_t z = 0; z < output_depth && p.dim_y.out_of_bound_idx.size() > 0; ++z) {
-          for (int64_t y : p.dim_y.out_of_bound_idx) {
-            const SafeInt<size_t> offset = (SafeInt<size_t>(z) * output_height + y) * output_width;
-            InputType* Ydata_offset = Ydata_base_nc + static_cast<size_t>(offset);
-            std::fill_n(Ydata_offset, narrow<size_t>(output_width), static_cast<InputType>(extrapolation_value));
+        if (!p.dim_y.out_of_bound_idx.empty()) {
+          for (int64_t z = 0; z < output_depth; ++z) {
+            for (int64_t y : p.dim_y.out_of_bound_idx) {
+              const SafeInt<size_t> offset = (SafeInt<size_t>(z) * output_height + y) * output_width;
+              InputType* Ydata_offset = Ydata_base_nc + static_cast<size_t>(offset);
+              std::fill_n(Ydata_offset, narrow<size_t>(output_width), static_cast<InputType>(extrapolation_value));
+            }
           }
         }
 
@@ -627,7 +627,6 @@ void NhwcUpsampleBasicAntiAlias(FilterParamsAntiAlias<T1>& p,
 
     // vertical interpolate
     {
-      // vertical interpolate
       auto xdata_span = gsl::make_span<const T>(image_temp_buffer.get(), temp_span_size);
       auto ydata_span = gsl::make_span<T>(Ydata_base + static_cast<size_t>(SafeInt<size_t>(n) * output_span_size),
                                           output_span_size);
@@ -638,6 +637,9 @@ void NhwcUpsampleBasicAntiAlias(FilterParamsAntiAlias<T1>& p,
   }
 
   if (use_extrapolation) {
+    // NOTE: HandleExtrapolation assumes NCHW layout (it fills per-channel slices).
+    // For NHWC, we pass batch_size * num_channels as the channel count since the
+    // vertical interpolation output is laid out as [batch * channels, output_height, output_width].
     auto ydata_span = gsl::make_span<T>(Ydata_base,
                                         static_cast<size_t>(SafeInt<size_t>(batch_size) * output_span_size));
     HandleExtrapolation(batch_size * num_channels, output_height, output_width, 1,

--- a/onnxruntime/core/providers/cpu/tensor/upsample_antialias.h
+++ b/onnxruntime/core/providers/cpu/tensor/upsample_antialias.h
@@ -136,7 +136,7 @@ void SetupUpsampleFilterAntiAlias(FilterParamsAntiAlias<T>& p,
     float scale = 1.0f / rscale;
     float support = (scale >= 1.0f) ? (p.support_size * 0.5f) * scale : p.support_size * 0.5f;
 
-    const size_t window_size = SafeInt<size_t>(narrow<size_t>(ceilf(support))) * 2 + 1;
+    const size_t window_size = SafeInt<size_t>(ceilf(support)) * 2 + 1;
     const size_t output_count = narrow<size_t>(output_size);
     const size_t scale_buffer_size = SafeInt<size_t>(window_size) * output_count;
 

--- a/onnxruntime/core/providers/cpu/tensor/upsample_antialias.h
+++ b/onnxruntime/core/providers/cpu/tensor/upsample_antialias.h
@@ -32,7 +32,7 @@ template <typename T>
 struct FilterParamsBaseAntiAlias {
   std::vector<InterpolationBound> bounds;
   std::vector<int64_t> out_of_bound_idx;
-  int64_t window_size = 2;
+  size_t window_size = 2;
   IAllocatorUniquePtr<T> weight_coefficients;
 };
 
@@ -129,15 +129,16 @@ void SetupUpsampleFilterAntiAlias(FilterParamsAntiAlias<T>& p,
                                          const int64_t output_size,
                                          size_t rindex,
                                          FilterParamsBaseAntiAlias<T>& param_base,
-                                         const float rscale) -> int64_t {
+                                         const float rscale) -> size_t {
     param_base.bounds.reserve(static_cast<size_t>(output_size));
     param_base.out_of_bound_idx.reserve(static_cast<size_t>(output_size));
 
     float scale = 1.0f / rscale;
     float support = (scale >= 1.0f) ? (p.support_size * 0.5f) * scale : p.support_size * 0.5f;
 
-    int32_t window_size = narrow<int32_t>(ceilf(support)) * 2 + 1;
-    const size_t scale_buffer_size = static_cast<size_t>(SafeInt<size_t>(window_size) * output_size);
+    const size_t window_size = SafeInt<size_t>(narrow<size_t>(ceilf(support))) * 2 + 1;
+    const size_t output_count = narrow<size_t>(output_size);
+    const size_t scale_buffer_size = SafeInt<size_t>(window_size) * output_count;
 
     param_base.weight_coefficients = IAllocator::MakeUniquePtr<T>(alloc, scale_buffer_size);
     auto* output_weights = param_base.weight_coefficients.get();
@@ -155,7 +156,7 @@ void SetupUpsampleFilterAntiAlias(FilterParamsAntiAlias<T>& p,
     // Inline capacity of 33 covers up to 8x bicubic upsample without heap allocation.
     InlinedVector<float, 33> scale_buffer(window_size);
 
-    for (int32_t i = 0; i < output_size; i++) {
+    for (size_t i = 0; i < output_count; i++) {
       float center = 0.5f + (scale == 1.0f ? static_cast<float>(i)
                                            : get_original_coordinate(static_cast<float>(i), rscale,
                                                                      static_cast<float>(output_size),

--- a/onnxruntime/core/providers/cpu/tensor/upsample_antialias.h
+++ b/onnxruntime/core/providers/cpu/tensor/upsample_antialias.h
@@ -22,9 +22,15 @@
 
 namespace onnxruntime {
 
+// Clamped input coordinate range [min, max) for a single output pixel.
+struct InterpolationBound {
+  int64_t min;
+  int64_t max;
+};
+
 template <typename T>
 struct FilterParamsBaseAntiAlias {
-  std::vector<int64_t> bound;
+  std::vector<InterpolationBound> bounds;
   std::vector<int64_t> out_of_bound_idx;
   int64_t window_size = 2;
   IAllocatorUniquePtr<T> weight_coefficients;
@@ -124,7 +130,7 @@ void SetupUpsampleFilterAntiAlias(FilterParamsAntiAlias<T>& p,
                                          size_t rindex,
                                          FilterParamsBaseAntiAlias<T>& param_base,
                                          const float rscale) -> int64_t {
-    param_base.bound.reserve(static_cast<size_t>(output_size) * 2);
+    param_base.bounds.reserve(static_cast<size_t>(output_size));
     param_base.out_of_bound_idx.reserve(static_cast<size_t>(output_size));
 
     float scale = 1.0f / rscale;
@@ -163,8 +169,7 @@ void SetupUpsampleFilterAntiAlias(FilterParamsAntiAlias<T>& p,
 
       xmin = exclude_outside ? xmin_cut : xmin_real;
       xmax = exclude_outside ? xmax_cut : xmax_real;
-      param_base.bound.push_back(xmin_cut);
-      param_base.bound.push_back(xmax_cut);
+      param_base.bounds.push_back({xmin_cut, xmax_cut});
 
       auto* scale_buffer = &scale_data[i * window_size];
       int64_t x = 0;
@@ -269,15 +274,13 @@ void ComputeInterpolationAtLevel1(int64_t num_channels, int64_t input_height, in
 
         for (size_t y = 0; y < narrow<size_t>(output_height); ++y) {
           auto* Ydata_offset = Ydata + output_width * y;
-          auto* bound = p_dim.bound.data();
           for (size_t x = 0; x < narrow<size_t>(output_width); ++x) {
             AccumulateType output = is_8bit_v<InputType> ? ConstValue::mag_factor : 0;
 
             const auto* weight_coeff = p_dim.weight_coefficients.get() + p_dim.window_size * x;
-            int64_t xmin = *bound++;
-            int64_t xmax = *bound++;
+            const auto& [xmin, xmax] = p_dim.bounds[x];
             const auto* Xdata_offset = Xdata + y * input_width + xmin;
-            for (; xmin < xmax; ++xmin) {
+            for (auto xi = xmin; xi < xmax; ++xi) {
               output += (*Xdata_offset++) * (*weight_coeff++);
             }
 
@@ -338,11 +341,9 @@ void ComputeInterpolationAtLevel2(int64_t num_channels, int64_t input_height, in
             return;
           }
 
-          const auto* y_bound = p_dim.bound.data();
           for (size_t y = 0; y < narrow<size_t>(output_height); ++y) {
             const auto* weight_coeff = p_dim.weight_coefficients.get() + p_dim.window_size * y;
-            int64_t ymin = *y_bound++;
-            int64_t ymax = *y_bound++;
+            const auto& [ymin, ymax] = p_dim.bounds[y];
             auto* Ydata_offset = Ydata + output_width * y;
             for (size_t x = 0; x < narrow<size_t>(output_width); ++x) {
               AccumulateType output = is_8bit_v<InputType> ? ConstValue::mag_factor : 0;
@@ -388,10 +389,8 @@ void ComputeInterpolationAtLevel2(int64_t num_channels, int64_t input_height, in
             const InputType* Xdata = Xdata_span.data() + x_start;
             InputType* Ydata = Ydata_span.data() + y_start;
 
-            const auto* y_bound = p_dim.bound.data();
             const auto* weight_coeff = p_dim.weight_coefficients.get() + p_dim.window_size * y;
-            int64_t ymin = y_bound[2 * narrow<size_t>(y)];
-            int64_t ymax = y_bound[2 * narrow<size_t>(y) + 1];
+            const auto& [ymin, ymax] = p_dim.bounds[narrow<size_t>(y)];
             auto* Ydata_offset = Ydata + output_width * y;
             for (size_t x = 0; x < narrow<size_t>(output_width); ++x) {
               AccumulateType output = is_8bit_v<InputType> ? ConstValue::mag_factor : 0;

--- a/onnxruntime/core/providers/cpu/tensor/upsamplebase.h
+++ b/onnxruntime/core/providers/cpu/tensor/upsamplebase.h
@@ -16,6 +16,7 @@
 #include "core/common/status.h"
 #include <core/common/safeint.h>
 #include <core/common/narrow.h>
+#include "core/providers/common.h"
 #include <type_traits>
 #ifndef SHARED_PROVIDER
 #include "core/framework/op_kernel.h"
@@ -555,14 +556,22 @@ class UpsampleBase {
     // in which case the other axes is ignored and use default scale of 1
     // scales_size == axes_.size() should be guaranteed if axes is not empty
     if (rank > 0 && (scales_size != rank || axes_.size())) {
-      InlinedVector<float> new_scales(size_t(rank), 1.0f);
-      ORT_RETURN_IF_NOT(*std::max_element(axes_.begin(), axes_.end()) < rank && (int64_t(axes_.size()) == scales_size),
-                        "all values in axes should be less than rank of the data");
+      if (axes_.empty()) {
+        ORT_RETURN_IF_NOT(scales_size == rank,
+                          "Number of elements in scales should be equal to rank of the data when axes is not provided.");
+      } else {
+        ORT_RETURN_IF_NOT(int64_t(axes_.size()) == scales_size,
+                          "Number of elements in scales should be equal to number of axes.");
 
-      for (size_t i = 0; i < axes_.size(); i++) {
-        new_scales[static_cast<size_t>(axes_[i])] = scales[i];
+        InlinedVector<float> new_scales(size_t(rank), 1.0f);
+        for (size_t i = 0; i < axes_.size(); i++) {
+          ORT_RETURN_IF_NOT(IsAxisInRange(axes_[i], rank),
+                            "all values in axes should be in the range [-rank, rank - 1]");
+          const int64_t axis = HandleNegativeAxis(axes_[i], rank);
+          new_scales[static_cast<size_t>(axis)] = scales[i];
+        }
+        scales.swap(new_scales);
       }
-      scales.swap(new_scales);
     }
     return ScalesValidation(scales, mode_);
   }
@@ -585,11 +594,12 @@ class UpsampleBase {
 
     if (axes_.size()) {
       output_dims.assign(input_dims.begin(), input_dims.end());
-      ORT_RETURN_IF_NOT(*std::max_element(axes_.begin(), axes_.end()) < int64_t(output_dims.size()),
-                        "axes should be less than output_dims.size()");
-
+      const int64_t rank = static_cast<int64_t>(output_dims.size());
       for (size_t i = 0; i < axes_.size(); i++) {
-        output_dims[static_cast<size_t>(axes_[i])] = size_span[i];
+        ORT_RETURN_IF_NOT(IsAxisInRange(axes_[i], rank),
+                          "all values in axes should be in the range [-rank, rank - 1]");
+        const int64_t axis = HandleNegativeAxis(axes_[i], rank);
+        output_dims[static_cast<size_t>(axis)] = size_span[i];
       }
     } else {
       std::copy(size_span.begin(), size_span.end(), output_dims.begin());
@@ -640,8 +650,11 @@ class UpsampleBase {
       for (size_t i = rank; i < rank * 2; ++i) {
         roi_tmp[i] = 1;
       }
+      const int64_t rank_i64 = static_cast<int64_t>(rank);
       for (size_t i = 0; i < axes_.size(); i++) {
-        auto v_in_axes = static_cast<size_t>(axes_[i]);
+        ORT_ENFORCE(IsAxisInRange(axes_[i], rank_i64), "all values in axes should be in the range [-rank, rank - 1]");
+        const int64_t axis = HandleNegativeAxis(axes_[i], rank_i64);
+        auto v_in_axes = static_cast<size_t>(axis);
         roi_tmp[v_in_axes] = (roi_array[i]);
         roi_tmp[rank + v_in_axes] = (roi_array[axes_.size() + i]);
       }

--- a/onnxruntime/core/providers/cpu/tensor/upsamplebase.h
+++ b/onnxruntime/core/providers/cpu/tensor/upsamplebase.h
@@ -567,13 +567,11 @@ class UpsampleBase {
         ORT_RETURN_IF_NOT(scales_size == rank,
                           "Number of elements in scales should be equal to rank of the data when axes is not provided.");
       } else {
-        ORT_RETURN_IF_NOT(int64_t(axes_.size()) == scales_size,
+        ORT_RETURN_IF_NOT(static_cast<int64_t>(axes_.size()) == scales_size,
                           "Number of elements in scales should be equal to number of axes.");
 
         InlinedVector<float> new_scales(size_t(rank), 1.0f);
         for (size_t i = 0; i < axes_.size(); i++) {
-          ORT_RETURN_IF_NOT(IsAxisInRange(axes_[i], rank),
-                            "all values in axes should be in the range [-rank, rank - 1]");
           const int64_t axis = HandleNegativeAxis(axes_[i], rank);
           new_scales[static_cast<size_t>(axis)] = scales[i];
         }
@@ -603,8 +601,6 @@ class UpsampleBase {
       output_dims.assign(input_dims.begin(), input_dims.end());
       const int64_t rank = static_cast<int64_t>(output_dims.size());
       for (size_t i = 0; i < axes_.size(); i++) {
-        ORT_RETURN_IF_NOT(IsAxisInRange(axes_[i], rank),
-                          "all values in axes should be in the range [-rank, rank - 1]");
         const int64_t axis = HandleNegativeAxis(axes_[i], rank);
         output_dims[static_cast<size_t>(axis)] = size_span[i];
       }
@@ -643,8 +639,8 @@ class UpsampleBase {
 
   // Compute output dimensions from scales and input dimensions.
   // Per the ONNX spec: output_dimension = floor(input_dimension * scale).
-  // We use std::floor (not truncation via static_cast) to correctly handle the case
-  // where the float product is slightly below an integer boundary.
+  // Use std::floor explicitly so the implementation matches the spec-defined
+  // flooring behavior instead of relying on conversion-time truncation semantics.
   void ComputeOutputShape(gsl::span<const float> scales,
                           gsl::span<const int64_t> input_dims,
                           TensorShapeVector& output_dims) const {
@@ -663,7 +659,6 @@ class UpsampleBase {
       }
       const int64_t rank_i64 = static_cast<int64_t>(rank);
       for (size_t i = 0; i < axes_.size(); i++) {
-        ORT_ENFORCE(IsAxisInRange(axes_[i], rank_i64), "all values in axes should be in the range [-rank, rank - 1]");
         const int64_t axis = HandleNegativeAxis(axes_[i], rank_i64);
         auto v_in_axes = static_cast<size_t>(axis);
         roi_tmp[v_in_axes] = (roi_array[i]);

--- a/onnxruntime/core/providers/cpu/tensor/upsamplebase.h
+++ b/onnxruntime/core/providers/cpu/tensor/upsamplebase.h
@@ -59,6 +59,12 @@ enum ResizeNearestMode {
   CEIL = 4,
 };
 
+// Tolerance for detecting .5 ties in nearest-mode rounding (ROUND_PREFER_CEIL / ROUND_PREFER_FLOOR).
+// Coordinate transforms such as half_pixel use float division which introduces rounding error,
+// e.g. (4.5f / 0.3f - 0.5f) yields ~14.4999 instead of the exact 14.5.
+// This epsilon is used in both CPU (upsamplebase.h) and CUDA (resize_impl.cu) nearest-pixel functions.
+constexpr float kNearestModeEps = 1e-6f;
+
 enum class AspectRatioPolicy {
   STRETCH,
   NOT_LARGER,
@@ -463,10 +469,8 @@ class UpsampleBase {
         };
       case ROUND_PREFER_CEIL:
         return [](float x_original, bool) {
-          // for half way cases prefer ceil
-          // std::round rounds away from zero which is correct for positive .5 values
-          // but for negative .5 values (e.g., -0.5) it rounds to -1 instead of 0 (ceil)
-          if (x_original == static_cast<int64_t>(x_original) - 0.5f) {
+          float fraction = x_original - std::floor(x_original);
+          if (std::abs(fraction - 0.5f) <= kNearestModeEps) {
             return static_cast<int64_t>(std::ceil(x_original));
           }
           return static_cast<int64_t>(std::round(x_original));
@@ -481,8 +485,8 @@ class UpsampleBase {
         };
       default:  // default is round_prefer_floor
         return [](float x_original, bool) {
-          // for half way cases prefer floor
-          if (x_original == static_cast<int64_t>(x_original) + 0.5f) {
+          float fraction = x_original - std::floor(x_original);
+          if (std::abs(fraction - 0.5f) <= kNearestModeEps) {
             return static_cast<int64_t>(std::floor(x_original));
           }
           return static_cast<int64_t>(std::round(x_original));

--- a/onnxruntime/core/providers/cpu/tensor/upsamplebase.h
+++ b/onnxruntime/core/providers/cpu/tensor/upsamplebase.h
@@ -152,7 +152,7 @@ inline void AdjustOutputSizeAsPolicy(TensorShapeVector& output_dims, gsl::span<c
       }
     }
   } else if (keep_aspect_ratio_policy == AspectRatioPolicy::NOT_SMALLER) {
-    scale_in_policy = std::numeric_limits<float>::min();
+    scale_in_policy = std::numeric_limits<float>::lowest();
 
     for (size_t i = 0; i < scales.size(); ++i) {
       if (axes_set.empty() || axes_set.count(static_cast<int64_t>(i)) > 0) {
@@ -264,9 +264,12 @@ class UpsampleBase {
     exclude_outside_ = info.template GetAttrOrDefault<int64_t>("exclude_outside", 0) == 0 ? false : true;
 
     if ((exclude_outside_ == 1 && mode_ != CUBIC) && (antialias_ == false || mode_ != LINEAR)) {
+      // ONNX spec allows exclude_outside for CUBIC mode.
+      // Opset 18 extended the antialias filter behavior which requires renormalization
+      // of weights for LINEAR mode as well when antialias is enabled.
       ORT_THROW(
-          "exclude_outside can be set to 1 when (1 mode is CUBIC. "
-          "\n(2 mode is CUBIC or LINEAR when anti-aliasing is on"
+          "exclude_outside can be set to 1 when (1) mode is CUBIC, or "
+          "(2) mode is LINEAR when anti-aliasing is enabled"
           ". Current mode is set to " +
           mode + " and anti-aliasing is set to " + std::to_string(antialias_));
     }
@@ -638,11 +641,15 @@ class UpsampleBase {
     return ScalesValidation(scales, mode_);
   }
 
+  // Compute output dimensions from scales and input dimensions.
+  // Per the ONNX spec: output_dimension = floor(input_dimension * scale).
+  // We use std::floor (not truncation via static_cast) to correctly handle the case
+  // where the float product is slightly below an integer boundary.
   void ComputeOutputShape(gsl::span<const float> scales,
                           gsl::span<const int64_t> input_dims,
                           TensorShapeVector& output_dims) const {
     for (std::size_t i = 0; i < input_dims.size(); i++) {
-      output_dims[i] = static_cast<int64_t>(scales[i] * input_dims[i]);
+      output_dims[i] = static_cast<int64_t>(std::floor(scales[i] * input_dims[i]));
     }
   }
 

--- a/onnxruntime/core/providers/cuda/tensor/resize_antialias_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/resize_antialias_impl.cu
@@ -256,6 +256,89 @@ __global__ void _ComputeInterpolationAtLevel2(
   }
 }
 
+/// Fused 2D antialias interpolation kernel.
+/// Applies separable H×W filter in a single pass: each thread computes one output pixel
+/// by iterating over the 2D filter window directly from the input tensor.
+/// Eliminates the intermediate buffer and second kernel launch of the separable approach.
+///
+/// Requirements:
+///   - AccumType must be a floating-point type (float or double). For int32_t (8-bit
+///     quantized weights), use the existing two-pass separable kernels instead, because
+///     fusing fixed-point h_weight * w_weight would require different quantization.
+///
+/// Filter separability: weight(y,x) = h_weight[y - ymin] * w_weight[x - xmin]
+template <typename T, typename AccumType>
+__global__ void _ComputeFusedInterpolation2D(
+    int64_t num_channels,
+    int64_t input_height, int64_t input_width,
+    int64_t output_height, int64_t output_width,
+    const fast_divmod div_output_hw,
+    const fast_divmod div_output_width,
+    const fast_divmod div_output_image,
+    int32_t h_window_size, int32_t w_window_size,
+    bool use_extrapolation, float extrapolation_value,
+    const int64_t* h_bound_data,
+    const int64_t* w_bound_data,
+    const int64_t* h_outof_bounds,
+    const int64_t* w_outof_bounds,
+    const AccumType* h_weight_coefficients,
+    const AccumType* w_weight_coefficients,
+    const T* Xdata, T* Ydata,
+    const int N) {
+  static_assert(!std::is_same<AccumType, int32_t>::value,
+                "Fused 2D kernel does not support int32_t accumulation (8-bit quantized weights)");
+
+  CALCULATE_ELEMENTWISE_INDEX_OR_EXIT(id, N);
+
+  // Decompose flat index → (batch, channel, y, x)
+  int batch_idx, image_index;
+  div_output_image.divmod(id, batch_idx, image_index);
+
+  int channel_idx, spatial_index;
+  div_output_hw.divmod(image_index, channel_idx, spatial_index);
+
+  int output_y, output_x;
+  div_output_width.divmod(spatial_index, output_y, output_x);
+
+  auto* Ydata_out = Ydata + id;
+
+  // Extrapolation: check if this output pixel maps outside the input
+  if (use_extrapolation) {
+    if (w_outof_bounds[output_x] != -1 || h_outof_bounds[output_y] != -1) {
+      *Ydata_out = static_cast<T>(extrapolation_value);
+      return;
+    }
+  }
+
+  // Look up clamped input bounds for this output pixel
+  const int64_t xmin = w_bound_data[static_cast<ptrdiff_t>(output_x) * 2];
+  const int64_t xmax = w_bound_data[static_cast<ptrdiff_t>(output_x) * 2 + 1];
+  const int64_t ymin = h_bound_data[static_cast<ptrdiff_t>(output_y) * 2];
+  const int64_t ymax = h_bound_data[static_cast<ptrdiff_t>(output_y) * 2 + 1];
+
+  const auto* w_weights = w_weight_coefficients + w_window_size * output_x;
+  const auto* h_weights = h_weight_coefficients + h_window_size * output_y;
+
+  const CUDA_LONG input_base = static_cast<CUDA_LONG>(
+      (batch_idx * num_channels + channel_idx) * input_height * input_width);
+
+  // Fused separable 2D filter: sum_{yi,xi} input[yi][xi] * h_w[yi-ymin] * w_w[xi-xmin]
+  AccumType result = static_cast<AccumType>(0);
+  for (int64_t yi = ymin; yi < ymax; ++yi) {
+    const AccumType h_w = h_weights[yi - ymin];
+    const auto* input_row = Xdata + input_base + yi * input_width;
+    for (int64_t xi = xmin; xi < xmax; ++xi) {
+      result += static_cast<AccumType>(input_row[xi]) * h_w * w_weights[xi - xmin];
+    }
+  }
+
+  if constexpr (std::is_same<T, int32_t>::value) {
+    *Ydata_out = static_cast<int32_t>(roundf(result));
+  } else {
+    *Ydata_out = static_cast<T>(result);
+  }
+}
+
 template <typename T, typename AccumType>
 __global__ void _ComputeInterpolationAtLevel3(
     int64_t input_depth,
@@ -902,13 +985,8 @@ void ResizeBiLinearUpsample(cudaStream_t stream,
   AccumType* y_weighted_buffer = GetTyped<AccumType>(weighted_buffer_ptr);
   AccumType* w_weighted_buffer = y_weighted_buffer + weighted_y_size;
 
-  const auto temp_buf_size = num_channels * input_height * output_width;
-  auto image_temp_buffer = AllocateTyped<T>(allocate_temp_space, narrow<size_t>(temp_buf_size));
-
   // clang-format off
   DISPATCH_ANTIALIAS_FILTER_SETUP(coordinate_transform_mode, [&]() {
-    //  Data is d, h, w in tuples
-
     _SetupBilinearUpsampleFilterAntiAlias<AccumType,
                                           BilinearFilter,
                                           coord_t><<<blocksPerDimsMappingGrid, 32, 0, stream>>>(
@@ -924,38 +1002,68 @@ void ResizeBiLinearUpsample(cudaStream_t stream,
         GetTyped<int64_t>(out_of_bounds_buffer_ptr),
         std::make_tuple(y_weighted_buffer, w_weighted_buffer));
   });
-
   // clang-format on
-  const fast_divmod div_step_image{narrow<int>(num_channels * input_height * output_width)};
-  // clang-format off
-  _ComputeInterpolationAtLevel1<T><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
-      num_channels, input_height, input_width, input_height, output_width,
-      div_output_width,
-      div_step_image,
-      w_window_size,
-      clip8_lookups,
-      w_bounds_buffer,
-      std::make_tuple(y_outof_bounds_buffer, w_outof_bounds_buffer),
-      w_weighted_buffer, input_data, GetTyped<T>(image_temp_buffer),
-      narrow<int>(temp_buf_size));
 
-  // clang-format on
-  const fast_divmod div_output_height{narrow<int>(output_height * output_width)};
-  // clang-format off
-  _ComputeInterpolationAtLevel2<T><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
-      num_channels, input_height, output_width, output_height, output_width,
-      div_output_height,
-      div_output_width,
-      div_output_image,
-      h_window_size,
-      use_extrapolation, extrapolation_value,
-      clip8_lookups,
-      y_bounds_buffer,
-      std::make_tuple(y_outof_bounds_buffer, w_outof_bounds_buffer),
-      y_weighted_buffer, GetTyped<T>(image_temp_buffer), output_data,
-      narrow<int>(N));
+  if constexpr (!std::is_same_v<AccumType, int32_t> && !std::is_same_v<T, int32_t>) {
+    // Fused 2D kernel: single pass reads input and writes output directly.
+    // Eliminates the intermediate buffer and second kernel launch.
+    // Not available for int32_t accumulation (8-bit quantized weights) because
+    // fusing h_weight * w_weight in fixed-point requires different quantization.
+    // Also excluded for int32_t output because the different operation order
+    // causes floating-point precision differences near 0.5 that affect rounding.
+    const fast_divmod div_output_hw{narrow<int>(output_height * output_width)};
+    // clang-format off
+    _ComputeFusedInterpolation2D<T, AccumType><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
+        num_channels,
+        input_height, input_width, output_height, output_width,
+        div_output_hw,
+        div_output_width,
+        div_output_image,
+        h_window_size, w_window_size,
+        use_extrapolation, extrapolation_value,
+        y_bounds_buffer, w_bounds_buffer,
+        y_outof_bounds_buffer, w_outof_bounds_buffer,
+        y_weighted_buffer, w_weighted_buffer,
+        input_data, output_data,
+        narrow<int>(N));
+    // clang-format on
+  } else {
+    // Two-pass separable approach for integer types.
+    // Level1: resize W dimension (input → temp buffer)
+    // Level2: resize H dimension (temp buffer → output)
+    const auto temp_buf_size = num_channels * input_height * output_width;
+    auto image_temp_buffer = AllocateTyped<T>(allocate_temp_space, narrow<size_t>(temp_buf_size));
 
-  // clang-format on
+    const fast_divmod div_step_image{narrow<int>(num_channels * input_height * output_width)};
+    // clang-format off
+    _ComputeInterpolationAtLevel1<T><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
+        num_channels, input_height, input_width, input_height, output_width,
+        div_output_width,
+        div_step_image,
+        w_window_size,
+        clip8_lookups,
+        w_bounds_buffer,
+        std::make_tuple(y_outof_bounds_buffer, w_outof_bounds_buffer),
+        w_weighted_buffer, input_data, GetTyped<T>(image_temp_buffer),
+        narrow<int>(temp_buf_size));
+    // clang-format on
+
+    const fast_divmod div_output_height{narrow<int>(output_height * output_width)};
+    // clang-format off
+    _ComputeInterpolationAtLevel2<T><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
+        num_channels, input_height, output_width, output_height, output_width,
+        div_output_height,
+        div_output_width,
+        div_output_image,
+        h_window_size,
+        use_extrapolation, extrapolation_value,
+        clip8_lookups,
+        y_bounds_buffer,
+        std::make_tuple(y_outof_bounds_buffer, w_outof_bounds_buffer),
+        y_weighted_buffer, GetTyped<T>(image_temp_buffer), output_data,
+        narrow<int>(N));
+    // clang-format on
+  }
 }
 
 template <typename T>
@@ -970,7 +1078,6 @@ void ResizeBicubicUpsample(cudaStream_t stream,
                            std::tuple<int64_t, int64_t, int64_t> inferred_input_dims,
                            std::tuple<int64_t, int64_t, int64_t> inferred_output_dims,
                            std::tuple<float, float, float> inferred_dim_rscales,
-                           // const TArray<int64_t>& input_strides,
                            const TArray<fast_divmod>& output_div_pitches,
                            gsl::span<const float> roi_vals,
                            const std::optional<float>& extrapolation,
@@ -991,10 +1098,7 @@ void ResizeBicubicUpsample(cudaStream_t stream,
   int64_t output_depth, output_height, output_width;
   std::tie(output_depth, output_height, output_width) = inferred_output_dims;
 
-  const auto temp_buf_size = SafeInt<int64_t>(batch_size) * num_channels * input_height * output_width;
-
-  int blocksPerGridL2 = narrow<int>(CeilDiv(N, GridDim::maxThreadsPerBlock));
-  int blocksPerGridL1 = narrow<int>(CeilDiv(temp_buf_size, GridDim::maxThreadsPerBlock));
+  int blocksPerGrid = narrow<int>(CeilDiv(N, GridDim::maxThreadsPerBlock));
   const fast_divmod div_output_image = (rank > 2) ? output_div_pitches[rank - 4]
                                                   : fast_divmod(gsl::narrow_cast<int>(N));
   const fast_divmod& div_output_width = output_div_pitches[rank - 2];
@@ -1026,14 +1130,11 @@ void ResizeBicubicUpsample(cudaStream_t stream,
   int64_t* y_outof_bounds_buffer = GetTyped<int64_t>(out_of_bounds_buffer_ptr);
   int64_t* w_outof_bounds_buffer = y_outof_bounds_buffer + output_height;
 
-  const int64_t weighted_buffer_size = SafeInt<int64_t>(weighted_y_size) +
-                                       weighted_w_size;
+  const int64_t weighted_buffer_size = SafeInt<int64_t>(weighted_y_size) + weighted_w_size;
   auto weighted_buffer_ptr = AllocateTyped<AccumType>(allocate_temp_space, weighted_buffer_size);
 
   AccumType* y_weighted_buffer = GetTyped<AccumType>(weighted_buffer_ptr);
   AccumType* w_weighted_buffer = y_weighted_buffer + weighted_y_size;
-
-  auto image_temp_buffer = AllocateTyped<T>(allocate_temp_space, narrow<size_t>(temp_buf_size));
 
   // clang-format off
   DISPATCH_ANTIALIAS_FILTER_SETUP(coordinate_transform_mode, [&]() {
@@ -1053,35 +1154,62 @@ void ResizeBicubicUpsample(cudaStream_t stream,
         std::make_tuple(y_weighted_buffer, w_weighted_buffer));
   });
   // clang-format on
-  const fast_divmod div_step_image(narrow<int>(num_channels * input_height * output_width));
-  // clang-format off
-  _ComputeInterpolationAtLevel1<T><<<blocksPerGridL1, GridDim::maxThreadsPerBlock, 0, stream>>>(
-      num_channels, input_height, input_width, input_height, output_width,
-      div_output_width,
-      div_step_image,
-      w_window_size,
-      clip8_lookups,
-      w_bounds_buffer,
-      std::make_tuple(y_outof_bounds_buffer, w_outof_bounds_buffer),
-      w_weighted_buffer, input_data, GetTyped<T>(image_temp_buffer),
-      narrow<int>(temp_buf_size));
-  // clang-format on
 
-  const fast_divmod div_output_height{narrow<int>(output_height * output_width)};
-  // clang-format off
-  _ComputeInterpolationAtLevel2<T><<<blocksPerGridL2, GridDim::maxThreadsPerBlock, 0, stream>>>(
-      num_channels, input_height, output_width, output_height, output_width,
-      div_output_height,
-      div_output_width,
-      div_output_image,
-      h_window_size,
-      use_extrapolation, extrapolation_value,
-      clip8_lookups,
-      y_bounds_buffer,
-      std::make_tuple(y_outof_bounds_buffer, w_outof_bounds_buffer),
-      y_weighted_buffer, GetTyped<T>(image_temp_buffer), output_data,
-      narrow<int>(N));
-  // clang-format on
+  if constexpr (!std::is_same_v<AccumType, int32_t> && !std::is_same_v<T, int32_t>) {
+    // Fused 2D kernel: single pass reads input and writes output directly.
+    const fast_divmod div_output_hw{narrow<int>(output_height * output_width)};
+    // clang-format off
+    _ComputeFusedInterpolation2D<T, AccumType><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
+        num_channels,
+        input_height, input_width, output_height, output_width,
+        div_output_hw,
+        div_output_width,
+        div_output_image,
+        h_window_size, w_window_size,
+        use_extrapolation, extrapolation_value,
+        y_bounds_buffer, w_bounds_buffer,
+        y_outof_bounds_buffer, w_outof_bounds_buffer,
+        y_weighted_buffer, w_weighted_buffer,
+        input_data, output_data,
+        narrow<int>(N));
+    // clang-format on
+  } else {
+    // Two-pass separable approach for integer types (8-bit with int32_t accumulation,
+    // or int32_t output where rounding is sensitive to floating-point operation order).
+    const auto temp_buf_size = SafeInt<int64_t>(batch_size) * num_channels * input_height * output_width;
+    auto image_temp_buffer = AllocateTyped<T>(allocate_temp_space, narrow<size_t>(temp_buf_size));
+
+    int blocksPerGridL1 = narrow<int>(CeilDiv(temp_buf_size, GridDim::maxThreadsPerBlock));
+    const fast_divmod div_step_image(narrow<int>(num_channels * input_height * output_width));
+    // clang-format off
+    _ComputeInterpolationAtLevel1<T><<<blocksPerGridL1, GridDim::maxThreadsPerBlock, 0, stream>>>(
+        num_channels, input_height, input_width, input_height, output_width,
+        div_output_width,
+        div_step_image,
+        w_window_size,
+        clip8_lookups,
+        w_bounds_buffer,
+        std::make_tuple(y_outof_bounds_buffer, w_outof_bounds_buffer),
+        w_weighted_buffer, input_data, GetTyped<T>(image_temp_buffer),
+        narrow<int>(temp_buf_size));
+    // clang-format on
+
+    const fast_divmod div_output_height{narrow<int>(output_height * output_width)};
+    // clang-format off
+    _ComputeInterpolationAtLevel2<T><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
+        num_channels, input_height, output_width, output_height, output_width,
+        div_output_height,
+        div_output_width,
+        div_output_image,
+        h_window_size,
+        use_extrapolation, extrapolation_value,
+        clip8_lookups,
+        y_bounds_buffer,
+        std::make_tuple(y_outof_bounds_buffer, w_outof_bounds_buffer),
+        y_weighted_buffer, GetTyped<T>(image_temp_buffer), output_data,
+        narrow<int>(N));
+    // clang-format on
+  }
 }
 
 template <class T>

--- a/onnxruntime/core/providers/cuda/tensor/resize_antialias_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/resize_antialias_impl.cu
@@ -339,6 +339,88 @@ __global__ void _ComputeFusedInterpolation2D(
   }
 }
 
+/// Fused 2D antialias interpolation kernel for NHWC layout.
+/// Each thread computes one output element (one channel of one spatial position).
+/// Data layout: [batch, height, width, channels]
+/// Flat index decomposition: id → (batch, y, x, channel)
+///
+/// The filter weights are shared across channels (same spatial interpolation),
+/// so the H/W weight lookup is identical to the NCHW kernel — only the
+/// input/output addressing changes.
+template <typename T, typename AccumType>
+__global__ void _ComputeFusedInterpolation2D_NHWC(
+    int64_t num_channels,
+    int64_t input_height, int64_t input_width,
+    int64_t output_height, int64_t output_width,
+    const fast_divmod div_output_wc,       // output_width * num_channels
+    const fast_divmod div_output_channel,  // num_channels
+    const fast_divmod div_output_image,    // output_height * output_width * num_channels
+    int32_t h_window_size, int32_t w_window_size,
+    bool use_extrapolation, float extrapolation_value,
+    const int64_t* h_bound_data,
+    const int64_t* w_bound_data,
+    const int64_t* h_outof_bounds,
+    const int64_t* w_outof_bounds,
+    const AccumType* h_weight_coefficients,
+    const AccumType* w_weight_coefficients,
+    const T* Xdata, T* Ydata,
+    const int N) {
+  static_assert(!std::is_same<AccumType, int32_t>::value,
+                "Fused 2D NHWC kernel does not support int32_t accumulation");
+
+  CALCULATE_ELEMENTWISE_INDEX_OR_EXIT(id, N);
+
+  // Decompose flat index → (batch, y, x, channel) for NHWC layout
+  int batch_idx, image_index;
+  div_output_image.divmod(id, batch_idx, image_index);
+
+  int output_y, wc_index;
+  div_output_wc.divmod(image_index, output_y, wc_index);
+
+  int output_x, channel_idx;
+  div_output_channel.divmod(wc_index, output_x, channel_idx);
+
+  auto* Ydata_out = Ydata + id;
+
+  // Extrapolation: check if this output pixel maps outside the input
+  if (use_extrapolation) {
+    if (w_outof_bounds[output_x] != -1 || h_outof_bounds[output_y] != -1) {
+      *Ydata_out = static_cast<T>(extrapolation_value);
+      return;
+    }
+  }
+
+  // Look up clamped input bounds for this output pixel
+  const int64_t xmin = w_bound_data[static_cast<ptrdiff_t>(output_x) * 2];
+  const int64_t xmax = w_bound_data[static_cast<ptrdiff_t>(output_x) * 2 + 1];
+  const int64_t ymin = h_bound_data[static_cast<ptrdiff_t>(output_y) * 2];
+  const int64_t ymax = h_bound_data[static_cast<ptrdiff_t>(output_y) * 2 + 1];
+
+  const auto* w_weights = w_weight_coefficients + w_window_size * output_x;
+  const auto* h_weights = h_weight_coefficients + h_window_size * output_y;
+
+  // NHWC input base: batch * H_in * W_in * C
+  const CUDA_LONG input_batch_base = static_cast<CUDA_LONG>(batch_idx) * input_height * input_width * num_channels;
+
+  // Fused separable 2D filter over the spatial window, reading one channel
+  // NHWC addressing: input[batch][yi][xi][channel] = input_batch_base + yi * W_in * C + xi * C + channel_idx
+  AccumType result = static_cast<AccumType>(0);
+  for (int64_t yi = ymin; yi < ymax; ++yi) {
+    const AccumType h_w = h_weights[yi - ymin];
+    const CUDA_LONG row_base = input_batch_base + static_cast<CUDA_LONG>(yi) * input_width * num_channels;
+    for (int64_t xi = xmin; xi < xmax; ++xi) {
+      const CUDA_LONG input_idx = row_base + static_cast<CUDA_LONG>(xi) * num_channels + channel_idx;
+      result += static_cast<AccumType>(Xdata[input_idx]) * h_w * w_weights[xi - xmin];
+    }
+  }
+
+  if constexpr (std::is_same<T, int32_t>::value) {
+    *Ydata_out = static_cast<int32_t>(roundf(result));
+  } else {
+    *Ydata_out = static_cast<T>(result);
+  }
+}
+
 template <typename T, typename AccumType>
 __global__ void _ComputeInterpolationAtLevel3(
     int64_t input_depth,
@@ -1212,6 +1294,108 @@ void ResizeBicubicUpsample(cudaStream_t stream,
   }
 }
 
+/// NHWC 2D antialias bilinear/bicubic launcher (fused kernel only).
+/// Handles both bilinear and bicubic — the filter type is encoded in the precomputed weights.
+/// For 8-bit types (int32_t accumulation), falls back to the NCHW separable path
+/// after transposing, which is not implemented here — the caller should reject those types.
+template <class T, typename FilterType>
+void ResizeNhwcBilinearBicubicUpsample(cudaStream_t stream,
+                                       ResizeCoordinateTransformationMode coordinate_transform_mode,
+                                       float cubic_coeff_a,
+                                       int64_t batch_size, int64_t num_channels,
+                                       int64_t input_height, int64_t input_width,
+                                       int64_t output_height, int64_t output_width,
+                                       float height_scale, float width_scale,
+                                       float support_value,
+                                       gsl::span<const float> roi_vals,
+                                       const std::optional<float>& extrapolation,
+                                       bool exclude_outside,
+                                       const TempSpaceAllocateFunc& allocate_temp_space,
+                                       const T* input_data,
+                                       T* output_data,
+                                       const size_t N) {
+  using AccumType = typename onnxruntime::AccumulateType<T>::type;
+
+  const bool use_extrapolation = extrapolation.has_value();
+  const float extrapolation_value = use_extrapolation ? *extrapolation : 0.f;
+
+  int blocksPerDimsMappingGrid =
+      narrow<int>(CeilDiv((output_height + output_width), 32));
+
+  int blocksPerGrid = narrow<int>(CeilDiv(N, GridDim::maxThreadsPerBlock));
+
+  // NHWC divmods: flat index = batch * (H_out * W_out * C) + y * (W_out * C) + x * C + c
+  const fast_divmod div_output_image{narrow<int>(output_height * output_width * num_channels)};
+  const fast_divmod div_output_wc{narrow<int>(output_width * num_channels)};
+  const fast_divmod div_output_channel{narrow<int>(num_channels)};
+
+  float h_scaled_support, w_scaled_support;
+  int32_t h_window_size, w_window_size;
+  const auto [weighted_y_size, weighted_w_size] =
+      ComputeBilinearScaleBufferSize(output_height, output_width,
+                                     height_scale, width_scale, support_value,
+                                     h_scaled_support, w_scaled_support, h_window_size, w_window_size);
+
+  SafeInt<int64_t> bounds_buffer_size = (SafeInt<int64_t>(output_height) + output_width) * 2;
+  SafeInt<int64_t> out_of_bounds_buffer_size = (SafeInt<int64_t>(output_height) + output_width);
+
+  auto bounds_buffer_ptr = AllocateTyped<int64_t>(allocate_temp_space, bounds_buffer_size);
+  auto out_of_bounds_buffer_ptr = AllocateTyped<int64_t>(allocate_temp_space, out_of_bounds_buffer_size);
+
+  int64_t* y_bounds_buffer = GetTyped<int64_t>(bounds_buffer_ptr);
+  int64_t* w_bounds_buffer = y_bounds_buffer + output_height * 2;
+
+  int64_t* y_outof_bounds_buffer = GetTyped<int64_t>(out_of_bounds_buffer_ptr);
+  int64_t* w_outof_bounds_buffer = y_outof_bounds_buffer + output_height;
+
+  const int64_t weighted_buffer_size = SafeInt<int64_t>(weighted_y_size) + weighted_w_size;
+  auto weighted_buffer_ptr = AllocateTyped<AccumType>(allocate_temp_space, narrow<size_t>(weighted_buffer_size));
+
+  AccumType* y_weighted_buffer = GetTyped<AccumType>(weighted_buffer_ptr);
+  AccumType* w_weighted_buffer = y_weighted_buffer + weighted_y_size;
+
+  // roi_vals layout for NHWC 4D: [roi_start_h, roi_start_w, ..., roi_end_h, roi_end_w]
+  // The caller already extracted H/W roi values at positions matching the spatial dims.
+  // For the setup kernel, we pass roi_h and roi_w starts/ends.
+  // roi_vals is always arranged as [start_dims..., end_dims...] with rank entries each.
+  // For NHWC, spatial dims are at index 1 (H) and 2 (W) in the 4-element roi.
+
+  // clang-format off
+  DISPATCH_ANTIALIAS_FILTER_SETUP(coordinate_transform_mode, [&]() {
+    _SetupBilinearUpsampleFilterAntiAlias<AccumType,
+                                          FilterType,
+                                          coord_t><<<blocksPerDimsMappingGrid, 32, 0, stream>>>(
+        std::make_tuple(input_height, input_width),
+        std::make_tuple(output_height, output_width),
+        std::make_tuple(height_scale, width_scale),
+        std::make_tuple(roi_vals[1], roi_vals[2]),                    // roi starts h, w (NHWC indices)
+        std::make_tuple(roi_vals[1 + 4], roi_vals[2 + 4]),            // roi ends h, w
+        std::make_tuple(h_scaled_support, w_scaled_support),
+        std::make_tuple(h_window_size, w_window_size),
+        cubic_coeff_a, exclude_outside,
+        GetTyped<int64_t>(bounds_buffer_ptr),
+        GetTyped<int64_t>(out_of_bounds_buffer_ptr),
+        std::make_tuple(y_weighted_buffer, w_weighted_buffer));
+  });
+  // clang-format on
+
+  // clang-format off
+  _ComputeFusedInterpolation2D_NHWC<T, AccumType><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
+      num_channels,
+      input_height, input_width, output_height, output_width,
+      div_output_wc,
+      div_output_channel,
+      div_output_image,
+      h_window_size, w_window_size,
+      use_extrapolation, extrapolation_value,
+      y_bounds_buffer, w_bounds_buffer,
+      y_outof_bounds_buffer, w_outof_bounds_buffer,
+      y_weighted_buffer, w_weighted_buffer,
+      input_data, output_data,
+      narrow<int>(N));
+  // clang-format on
+}
+
 template <class T>
 void ResizeAntiAliasImpl(
     cudaStream_t stream,
@@ -1229,6 +1413,7 @@ void ResizeAntiAliasImpl(
     gsl::span<const float> roi_vals,
     const std::optional<float>& extrapolation,
     bool exclude_outside,
+    bool is_nhwc,
     TempSpaceAllocateFunc allocate_temp_space,
     const uint8_t* clip8_lookups,
     const T* input_data,
@@ -1245,6 +1430,52 @@ void ResizeAntiAliasImpl(
   // Should not hit this as we have already validated input rank/scales and we provide verbose error messages
   // to the user.
   ORT_ENFORCE(is_2D || is_3D, "Only bilinear/trilinear and bicubic modes are supported in Resize anti-alias mode");
+
+  if (is_nhwc && is_2D) {
+    using AccumType = typename onnxruntime::AccumulateType<T>::type;
+    if constexpr (std::is_same_v<AccumType, int32_t>) {
+      // 8-bit types (uint8_t, int8_t) use int32_t accumulation which is not supported
+      // by the fused NHWC kernel. Reject at runtime.
+      ORT_NOT_IMPLEMENTED("NHWC antialias resize is not supported for 8-bit integer types on CUDA");
+    } else {
+      // NHWC path: use the fused NHWC kernel for both bilinear and bicubic
+      int64_t input_height, input_width;
+      std::tie(std::ignore, input_height, input_width) = inferred_input_dims;
+
+      int64_t output_height, output_width;
+      std::tie(std::ignore, output_height, output_width) = inferred_output_dims;
+
+      float height_scale, width_scale;
+      std::tie(std::ignore, height_scale, width_scale) = inferred_dim_rscales;
+
+      switch (upsample_mode) {
+        case UpsampleMode::LINEAR: {
+          constexpr float support_value = antialias_constants::kSupportSize;
+          ResizeNhwcBilinearBicubicUpsample<T, BilinearFilter>(
+              stream, coordinate_transform_mode, cubic_coeff_a,
+              batch_size, num_channels,
+              input_height, input_width, output_height, output_width,
+              height_scale, width_scale, support_value,
+              roi_vals, extrapolation, exclude_outside,
+              allocate_temp_space, input_data, output_data, N);
+        } break;
+        case CUBIC: {
+          constexpr float support_value = antialias_constants::kBiCubicSupportSize;
+          ResizeNhwcBilinearBicubicUpsample<T, BiCubicFilter>(
+              stream, coordinate_transform_mode, cubic_coeff_a,
+              batch_size, num_channels,
+              input_height, input_width, output_height, output_width,
+              height_scale, width_scale, support_value,
+              roi_vals, extrapolation, exclude_outside,
+              allocate_temp_space, input_data, output_data, N);
+        } break;
+        default:
+          ORT_NOT_IMPLEMENTED("Only bilinear and bicubic modes are supported for NHWC Resize anti-alias mode");
+          break;
+      }
+    }
+    return;
+  }
 
   switch (upsample_mode) {
     case UpsampleMode::LINEAR: {
@@ -1298,6 +1529,7 @@ void ResizeAntiAliasImpl(
       gsl::span<const float> roi_vals,                              \
       const std::optional<float>& extrapolation_value,              \
       bool exclude_outside,                                         \
+      bool is_nhwc,                                                 \
       TempSpaceAllocateFunc allocate_temp_space,                    \
       const uint8_t* clip8_lookups,                                 \
       const T* input_data,                                          \

--- a/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
@@ -15,6 +15,8 @@ using onnxruntime::ResizeCoordinateTransformationMode;
 using onnxruntime::ResizeNearestMode;
 using onnxruntime::UpsampleMode;
 
+constexpr int64_t kIntMax = static_cast<int64_t>(std::numeric_limits<int>::max());
+
 struct NearestPixel_SIMPLE {
   __device__ __forceinline__ int operator()(float x_original, bool is_down_sampling) const {
     if (is_down_sampling) {
@@ -724,15 +726,14 @@ Status ResizeNearestImpl(
     ResizeNearestMode calc_nearest_pixel,
     int64_t* /* prefix_dim_sum */,
     NearestMappingInfo* dims_mapping) {
-  constexpr int64_t kIntMax = static_cast<int64_t>(std::numeric_limits<int>::max());
   ORT_RETURN_IF_NOT(N <= static_cast<size_t>(kIntMax),
                     "ResizeNearestImpl: output element count exceeds int range.");
 
   for (int axis = 0; axis < rank; ++axis) {
     ORT_RETURN_IF_NOT(input_shape[axis] >= 0 && input_shape[axis] <= kIntMax,
-                      "ResizeNearestImpl: input dimension exceeds int range.");
+                      "ResizeNearestImpl: input dimension is not in the supported [0, INT_MAX] range.");
     ORT_RETURN_IF_NOT(output_shape[axis] >= 0 && output_shape[axis] <= kIntMax,
-                      "ResizeNearestImpl: output dimension exceeds int range.");
+                      "ResizeNearestImpl: output dimension is not in the supported [0, INT_MAX] range.");
   }
 
   unsigned int blocksPerGrid = static_cast<unsigned int>((N + GridDim::maxThreadsPerBlock - 1) / GridDim::maxThreadsPerBlock);
@@ -749,14 +750,14 @@ Status ResizeNearestImpl(
                       "ResizeNearestImpl: output height*width exceeds int range.");
 
     fast_divmod div_output_image = (rank > 2) ? output_div_pitches[rank - 3]
-                                              : fast_divmod(onnxruntime::narrow<int>(output_height * output_width));
+                                              : fast_divmod(static_cast<int>(output_hw));
     int blocksPerDimsMappingGrid = static_cast<int>(ceil((output_height + output_width) / 32.0));
 
     DISPATCH_RESIZE_COORDINATE_TRANSFORMATION_MODE(transform_coordinate, [&]() {
       DISPATCH_RESIZE_NEAREST_MODE(calc_nearest_pixel, [&]() {
         _ResizeNearestMappingKernel2D<T><<<blocksPerDimsMappingGrid, 32, 0, stream>>>(
-            onnxruntime::narrow<int>(input_shape[rank - 2]), onnxruntime::narrow<int>(input_shape[rank - 1]),
-            onnxruntime::narrow<int>(output_height), onnxruntime::narrow<int>(output_width),
+            static_cast<int>(input_shape[rank - 2]), static_cast<int>(input_shape[rank - 1]),
+            static_cast<int>(output_height), static_cast<int>(output_width),
             scales_vals[rank - 2], scales_vals[rank - 1],
             roi_vals[rank - 2], roi_vals[rank - 2 + rank],
             roi_vals[rank - 1], roi_vals[rank - 1 + rank],
@@ -767,7 +768,7 @@ Status ResizeNearestImpl(
     if (extrapolation_enabled) {
       _ResizeNearestKernel2D<T, true><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
           output_height, output_width,
-          input_shape[rank - 2] * input_shape[rank - 1], onnxruntime::narrow<int>(input_shape[rank - 1]),
+          input_shape[rank - 2] * input_shape[rank - 1], static_cast<int>(input_shape[rank - 1]),
           div_output_image, output_div_pitches[rank - 2],
           input_data, output_data, N,
           extrapolation_value,
@@ -775,7 +776,7 @@ Status ResizeNearestImpl(
     } else {
       _ResizeNearestKernel2D<T, false><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
           output_height, output_width,
-          input_shape[rank - 2] * input_shape[rank - 1], onnxruntime::narrow<int>(input_shape[rank - 1]),
+          input_shape[rank - 2] * input_shape[rank - 1], static_cast<int>(input_shape[rank - 1]),
           div_output_image, output_div_pitches[rank - 2],
           input_data, output_data, N,
           extrapolation_value,
@@ -801,15 +802,15 @@ Status ResizeNearestImpl(
                       "ResizeNearestImpl: output depth*height*width exceeds int range.");
 
     fast_divmod div_output_image = (rank > 3) ? output_div_pitches[rank - 4]
-                                              : fast_divmod(onnxruntime::narrow<int>(output_depth * output_height * output_width));
+                                              : fast_divmod(static_cast<int>(output_dhw));
     int blocksPerDimsMappingGrid = static_cast<int>(ceil((output_depth + output_height + output_width) / 32.0));
 
     DISPATCH_RESIZE_COORDINATE_TRANSFORMATION_MODE(transform_coordinate, [&]() {
       DISPATCH_RESIZE_NEAREST_MODE(calc_nearest_pixel, [&]() {
         _ResizeNearestMappingKernel3D<T><<<blocksPerDimsMappingGrid, 32, 0, stream>>>(
-            onnxruntime::narrow<int>(input_shape[rank - 3]), onnxruntime::narrow<int>(input_shape[rank - 2]),
-            onnxruntime::narrow<int>(input_shape[rank - 1]),
-            onnxruntime::narrow<int>(output_depth), onnxruntime::narrow<int>(output_height), onnxruntime::narrow<int>(output_width),
+            static_cast<int>(input_shape[rank - 3]), static_cast<int>(input_shape[rank - 2]),
+            static_cast<int>(input_shape[rank - 1]),
+            static_cast<int>(output_depth), static_cast<int>(output_height), static_cast<int>(output_width),
             scales_vals[rank - 3], scales_vals[rank - 2], scales_vals[rank - 1],
             roi_vals[rank - 3], roi_vals[rank - 3 + rank],
             roi_vals[rank - 2], roi_vals[rank - 2 + rank],
@@ -830,7 +831,7 @@ Status ResizeNearestImpl(
     if (extrapolation_enabled) {
       _ResizeNearestKernel3D<T, true><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
           output_depth, output_height, output_width,
-          input_stride_image, input_stride_depth, onnxruntime::narrow<int>(input_shape[rank - 1]),
+          input_stride_image, input_stride_depth, static_cast<int>(input_shape[rank - 1]),
           div_output_image, output_div_pitches[rank - 3], output_div_pitches[rank - 2],
           input_data, output_data, N,
           extrapolation_value,
@@ -838,7 +839,7 @@ Status ResizeNearestImpl(
     } else {
       _ResizeNearestKernel3D<T, false><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
           output_depth, output_height, output_width,
-          input_stride_image, input_stride_depth, onnxruntime::narrow<int>(input_shape[rank - 1]),
+          input_stride_image, input_stride_depth, static_cast<int>(input_shape[rank - 1]),
           div_output_image, output_div_pitches[rank - 3], output_div_pitches[rank - 2],
           input_data, output_data, N,
           extrapolation_value,
@@ -913,15 +914,15 @@ Status ResizeImpl(
   // to the user.
   ORT_RETURN_IF_NOT(is_2D || is_3D, "Only bilinear/trilinear and bicubic modes are supported in Resize");
 
-  ORT_RETURN_IF_NOT(N <= static_cast<size_t>(std::numeric_limits<int>::max()),
+  ORT_RETURN_IF_NOT(N <= static_cast<size_t>(kIntMax),
                     "ResizeImpl: output element count exceeds int range.");
 
   int blocksPerGrid = static_cast<int>((N + GridDim::maxThreadsPerBlock - 1) / GridDim::maxThreadsPerBlock);
   fast_divmod div_output_image;
   if (is_2D) {
-    div_output_image = (rank > 2) ? output_div_pitches[rank - 3] : fast_divmod(onnxruntime::narrow<int>(N));
+    div_output_image = (rank > 2) ? output_div_pitches[rank - 3] : fast_divmod(static_cast<int>(N));
   } else if (is_3D) {
-    div_output_image = (rank > 3) ? output_div_pitches[rank - 4] : fast_divmod(onnxruntime::narrow<int>(N));
+    div_output_image = (rank > 3) ? output_div_pitches[rank - 4] : fast_divmod(static_cast<int>(N));
   }
 
   int64_t output_depth = is_3D ? output_shape[rank - 3] : 0;

--- a/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
@@ -735,7 +735,7 @@ Status ResizeNearestImpl(
                       "ResizeNearestImpl: output dimension exceeds int range.");
   }
 
-  unsigned int blocksPerGrid = static_cast<unsigned int>(ceil(static_cast<float>(N) / GridDim::maxThreadsPerBlock));
+  unsigned int blocksPerGrid = static_cast<unsigned int>((N + GridDim::maxThreadsPerBlock - 1) / GridDim::maxThreadsPerBlock);
 
   bool could2d = rank >= 2 &&
                  transform_coordinate != ResizeCoordinateTransformationMode::TF_CROP_AND_RESIZE &&
@@ -743,9 +743,9 @@ Status ResizeNearestImpl(
   if (could2d) {
     int64_t output_height = output_shape[rank - 2];
     int64_t output_width = output_shape[rank - 1];
-    const SafeInt<int64_t> output_hw = SafeInt<int64_t>(output_height) * output_width;
+    int64_t output_hw = 0;
 
-    ORT_RETURN_IF_NOT(output_hw <= kIntMax,
+    ORT_RETURN_IF_NOT(SafeMultiply(output_height, output_width, output_hw) && output_hw <= kIntMax,
                       "ResizeNearestImpl: output height*width exceeds int range.");
 
     fast_divmod div_output_image = (rank > 2) ? output_div_pitches[rank - 3]
@@ -793,12 +793,11 @@ Status ResizeNearestImpl(
     int64_t output_depth = output_shape[rank - 3];
     int64_t output_height = output_shape[rank - 2];
     int64_t output_width = output_shape[rank - 1];
-    const SafeInt<int64_t> output_dh = SafeInt<int64_t>(output_depth) * output_height;
-    const SafeInt<int64_t> output_dhw = output_dh * output_width;
-
-    ORT_RETURN_IF_NOT(output_dh <= kIntMax,
+    int64_t output_dh = 0;
+    int64_t output_dhw = 0;
+    ORT_RETURN_IF_NOT(SafeMultiply(output_depth, output_height, output_dh) && output_dh <= kIntMax,
                       "ResizeNearestImpl: output depth*height exceeds int range.");
-    ORT_RETURN_IF_NOT(output_dhw <= kIntMax,
+    ORT_RETURN_IF_NOT(SafeMultiply(output_dh, output_width, output_dhw) && output_dhw <= kIntMax,
                       "ResizeNearestImpl: output depth*height*width exceeds int range.");
 
     fast_divmod div_output_image = (rank > 3) ? output_div_pitches[rank - 4]
@@ -917,7 +916,7 @@ Status ResizeImpl(
   ORT_RETURN_IF_NOT(N <= static_cast<size_t>(std::numeric_limits<int>::max()),
                     "ResizeImpl: output element count exceeds int range.");
 
-  int blocksPerGrid = static_cast<int>(ceil(static_cast<float>(N) / GridDim::maxThreadsPerBlock));
+  int blocksPerGrid = static_cast<int>((N + GridDim::maxThreadsPerBlock - 1) / GridDim::maxThreadsPerBlock);
   fast_divmod div_output_image;
   if (is_2D) {
     div_output_image = (rank > 2) ? output_div_pitches[rank - 3] : fast_divmod(onnxruntime::narrow<int>(N));

--- a/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
@@ -743,15 +743,9 @@ Status ResizeNearestImpl(
   if (could2d) {
     int64_t output_height = output_shape[rank - 2];
     int64_t output_width = output_shape[rank - 1];
-    bool output_hw_fits_int = false;
-    try {
-      const SafeInt<int64_t> output_hw = SafeInt<int64_t>(output_height) * output_width;
-      output_hw_fits_int = output_hw <= kIntMax;
-    } catch (const SafeIntException&) {
-      output_hw_fits_int = false;
-    }
+    const SafeInt<int64_t> output_hw = SafeInt<int64_t>(output_height) * output_width;
 
-    ORT_RETURN_IF_NOT(output_hw_fits_int,
+    ORT_RETURN_IF_NOT(output_hw <= kIntMax,
                       "ResizeNearestImpl: output height*width exceeds int range.");
 
     fast_divmod div_output_image = (rank > 2) ? output_div_pitches[rank - 3]
@@ -799,21 +793,12 @@ Status ResizeNearestImpl(
     int64_t output_depth = output_shape[rank - 3];
     int64_t output_height = output_shape[rank - 2];
     int64_t output_width = output_shape[rank - 1];
-    bool output_dh_fits_int = false;
-    bool output_dhw_fits_int = false;
-    try {
-      const SafeInt<int64_t> output_dh = SafeInt<int64_t>(output_depth) * output_height;
-      output_dh_fits_int = output_dh <= kIntMax;
-      const SafeInt<int64_t> output_dhw = output_dh * output_width;
-      output_dhw_fits_int = output_dhw <= kIntMax;
-    } catch (const SafeIntException&) {
-      output_dh_fits_int = false;
-      output_dhw_fits_int = false;
-    }
+    const SafeInt<int64_t> output_dh = SafeInt<int64_t>(output_depth) * output_height;
+    const SafeInt<int64_t> output_dhw = output_dh * output_width;
 
-    ORT_RETURN_IF_NOT(output_dh_fits_int,
+    ORT_RETURN_IF_NOT(output_dh <= kIntMax,
                       "ResizeNearestImpl: output depth*height exceeds int range.");
-    ORT_RETURN_IF_NOT(output_dhw_fits_int,
+    ORT_RETURN_IF_NOT(output_dhw <= kIntMax,
                       "ResizeNearestImpl: output depth*height*width exceeds int range.");
 
     fast_divmod div_output_image = (rank > 3) ? output_div_pitches[rank - 4]
@@ -837,13 +822,8 @@ Status ResizeNearestImpl(
 
     SafeInt<int64_t> input_stride_depth_safe = 0;
     SafeInt<int64_t> input_stride_image_safe = 0;
-    try {
-      input_stride_depth_safe = SafeInt<int64_t>(input_shape[rank - 2]) * input_shape[rank - 1];
-      input_stride_image_safe = SafeInt<int64_t>(input_shape[rank - 3]) * input_stride_depth_safe;
-    } catch (const SafeIntException&) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                             "ResizeNearestImpl: input strides exceed int range.");
-    }
+    input_stride_depth_safe = SafeInt<int64_t>(input_shape[rank - 2]) * input_shape[rank - 1];
+    input_stride_image_safe = SafeInt<int64_t>(input_shape[rank - 3]) * input_stride_depth_safe;
 
     const int64_t input_stride_depth = static_cast<int64_t>(input_stride_depth_safe);
     const int64_t input_stride_image = static_cast<int64_t>(input_stride_image_safe);

--- a/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
@@ -3,6 +3,9 @@
 
 #include "core/providers/cuda/cu_inc/common.cuh"
 #include "core/providers/cuda/tensor/resize_impl.h"
+#include <limits>
+
+#include "core/common/safeint.h"
 
 namespace onnxruntime {
 namespace cuda {
@@ -702,7 +705,7 @@ size_t CalcResizeBufferSize(const onnxruntime::UpsampleMode upsample_mode,
 }
 
 template <typename T>
-void ResizeNearestImpl(
+Status ResizeNearestImpl(
     cudaStream_t stream,
     const int rank,
     TArray<int64_t>& input_shape,
@@ -721,6 +724,17 @@ void ResizeNearestImpl(
     ResizeNearestMode calc_nearest_pixel,
     int64_t* /* prefix_dim_sum */,
     NearestMappingInfo* dims_mapping) {
+  constexpr int64_t kIntMax = static_cast<int64_t>(std::numeric_limits<int>::max());
+  ORT_RETURN_IF_NOT(N <= static_cast<size_t>(kIntMax),
+                    "ResizeNearestImpl: output element count exceeds int range.");
+
+  for (int axis = 0; axis < rank; ++axis) {
+    ORT_RETURN_IF_NOT(input_shape[axis] >= 0 && input_shape[axis] <= kIntMax,
+                      "ResizeNearestImpl: input dimension exceeds int range.");
+    ORT_RETURN_IF_NOT(output_shape[axis] >= 0 && output_shape[axis] <= kIntMax,
+                      "ResizeNearestImpl: output dimension exceeds int range.");
+  }
+
   unsigned int blocksPerGrid = static_cast<unsigned int>(ceil(static_cast<float>(N) / GridDim::maxThreadsPerBlock));
 
   bool could2d = rank >= 2 &&
@@ -729,15 +743,26 @@ void ResizeNearestImpl(
   if (could2d) {
     int64_t output_height = output_shape[rank - 2];
     int64_t output_width = output_shape[rank - 1];
+    bool output_hw_fits_int = false;
+    try {
+      const SafeInt<int64_t> output_hw = SafeInt<int64_t>(output_height) * output_width;
+      output_hw_fits_int = output_hw <= kIntMax;
+    } catch (const SafeIntException&) {
+      output_hw_fits_int = false;
+    }
+
+    ORT_RETURN_IF_NOT(output_hw_fits_int,
+                      "ResizeNearestImpl: output height*width exceeds int range.");
+
     fast_divmod div_output_image = (rank > 2) ? output_div_pitches[rank - 3]
-                                              : fast_divmod(static_cast<int>(output_height * output_width));
+                                              : fast_divmod(onnxruntime::narrow<int>(output_height * output_width));
     int blocksPerDimsMappingGrid = static_cast<int>(ceil((output_height + output_width) / 32.0));
 
     DISPATCH_RESIZE_COORDINATE_TRANSFORMATION_MODE(transform_coordinate, [&]() {
       DISPATCH_RESIZE_NEAREST_MODE(calc_nearest_pixel, [&]() {
         _ResizeNearestMappingKernel2D<T><<<blocksPerDimsMappingGrid, 32, 0, stream>>>(
-            static_cast<int>(input_shape[rank - 2]), static_cast<int>(input_shape[rank - 1]),
-            static_cast<int>(output_height), static_cast<int>(output_width),
+            onnxruntime::narrow<int>(input_shape[rank - 2]), onnxruntime::narrow<int>(input_shape[rank - 1]),
+            onnxruntime::narrow<int>(output_height), onnxruntime::narrow<int>(output_width),
             scales_vals[rank - 2], scales_vals[rank - 1],
             roi_vals[rank - 2], roi_vals[rank - 2 + rank],
             roi_vals[rank - 1], roi_vals[rank - 1 + rank],
@@ -748,7 +773,7 @@ void ResizeNearestImpl(
     if (extrapolation_enabled) {
       _ResizeNearestKernel2D<T, true><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
           output_height, output_width,
-          input_shape[rank - 2] * input_shape[rank - 1], static_cast<int>(input_shape[rank - 1]),
+          input_shape[rank - 2] * input_shape[rank - 1], onnxruntime::narrow<int>(input_shape[rank - 1]),
           div_output_image, output_div_pitches[rank - 2],
           input_data, output_data, N,
           extrapolation_value,
@@ -756,13 +781,13 @@ void ResizeNearestImpl(
     } else {
       _ResizeNearestKernel2D<T, false><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
           output_height, output_width,
-          input_shape[rank - 2] * input_shape[rank - 1], static_cast<int>(input_shape[rank - 1]),
+          input_shape[rank - 2] * input_shape[rank - 1], onnxruntime::narrow<int>(input_shape[rank - 1]),
           div_output_image, output_div_pitches[rank - 2],
           input_data, output_data, N,
           extrapolation_value,
           dims_mapping);
     }
-    return;
+    return Status::OK();
   }
 
   // Check if we can use the optimized 3D path: rank >= 3, not TF_CROP_AND_RESIZE,
@@ -774,16 +799,33 @@ void ResizeNearestImpl(
     int64_t output_depth = output_shape[rank - 3];
     int64_t output_height = output_shape[rank - 2];
     int64_t output_width = output_shape[rank - 1];
+    bool output_dh_fits_int = false;
+    bool output_dhw_fits_int = false;
+    try {
+      const SafeInt<int64_t> output_dh = SafeInt<int64_t>(output_depth) * output_height;
+      output_dh_fits_int = output_dh <= kIntMax;
+      const SafeInt<int64_t> output_dhw = output_dh * output_width;
+      output_dhw_fits_int = output_dhw <= kIntMax;
+    } catch (const SafeIntException&) {
+      output_dh_fits_int = false;
+      output_dhw_fits_int = false;
+    }
+
+    ORT_RETURN_IF_NOT(output_dh_fits_int,
+                      "ResizeNearestImpl: output depth*height exceeds int range.");
+    ORT_RETURN_IF_NOT(output_dhw_fits_int,
+                      "ResizeNearestImpl: output depth*height*width exceeds int range.");
+
     fast_divmod div_output_image = (rank > 3) ? output_div_pitches[rank - 4]
-                                              : fast_divmod(static_cast<int>(output_depth * output_height * output_width));
+                                              : fast_divmod(onnxruntime::narrow<int>(output_depth * output_height * output_width));
     int blocksPerDimsMappingGrid = static_cast<int>(ceil((output_depth + output_height + output_width) / 32.0));
 
     DISPATCH_RESIZE_COORDINATE_TRANSFORMATION_MODE(transform_coordinate, [&]() {
       DISPATCH_RESIZE_NEAREST_MODE(calc_nearest_pixel, [&]() {
         _ResizeNearestMappingKernel3D<T><<<blocksPerDimsMappingGrid, 32, 0, stream>>>(
-            static_cast<int>(input_shape[rank - 3]), static_cast<int>(input_shape[rank - 2]),
-            static_cast<int>(input_shape[rank - 1]),
-            static_cast<int>(output_depth), static_cast<int>(output_height), static_cast<int>(output_width),
+            onnxruntime::narrow<int>(input_shape[rank - 3]), onnxruntime::narrow<int>(input_shape[rank - 2]),
+            onnxruntime::narrow<int>(input_shape[rank - 1]),
+            onnxruntime::narrow<int>(output_depth), onnxruntime::narrow<int>(output_height), onnxruntime::narrow<int>(output_width),
             scales_vals[rank - 3], scales_vals[rank - 2], scales_vals[rank - 1],
             roi_vals[rank - 3], roi_vals[rank - 3 + rank],
             roi_vals[rank - 2], roi_vals[rank - 2 + rank],
@@ -795,10 +837,13 @@ void ResizeNearestImpl(
 
     int64_t input_stride_depth = input_shape[rank - 2] * input_shape[rank - 1];
     int64_t input_stride_image = input_shape[rank - 3] * input_stride_depth;
+    ORT_RETURN_IF_NOT(input_stride_depth <= kIntMax && input_stride_image <= kIntMax,
+                      "ResizeNearestImpl: input strides exceed int range.");
+
     if (extrapolation_enabled) {
       _ResizeNearestKernel3D<T, true><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
           output_depth, output_height, output_width,
-          input_stride_image, input_stride_depth, static_cast<int>(input_shape[rank - 1]),
+          input_stride_image, input_stride_depth, onnxruntime::narrow<int>(input_shape[rank - 1]),
           div_output_image, output_div_pitches[rank - 3], output_div_pitches[rank - 2],
           input_data, output_data, N,
           extrapolation_value,
@@ -806,13 +851,13 @@ void ResizeNearestImpl(
     } else {
       _ResizeNearestKernel3D<T, false><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
           output_depth, output_height, output_width,
-          input_stride_image, input_stride_depth, static_cast<int>(input_shape[rank - 1]),
+          input_stride_image, input_stride_depth, onnxruntime::narrow<int>(input_shape[rank - 1]),
           div_output_image, output_div_pitches[rank - 3], output_div_pitches[rank - 2],
           input_data, output_data, N,
           extrapolation_value,
           dims_mapping);
     }
-    return;
+    return Status::OK();
   }
 
   int64_t total_dim_sum = std::accumulate(output_shape.Data(), output_shape.Data() + rank, (int64_t)0);
@@ -834,11 +879,11 @@ void ResizeNearestImpl(
       extrapolation_value,
       reinterpret_cast<const int64_t*>(dims_mapping),
       reinterpret_cast<const NearestMappingInfo*>(reinterpret_cast<int64_t*>(dims_mapping) + rank));
-  return;
+  return Status::OK();
 }
 
 template <typename T>
-void ResizeImpl(
+Status ResizeImpl(
     cudaStream_t stream,
     const UpsampleMode upsample_mode,
     const int rank,
@@ -859,14 +904,14 @@ void ResizeImpl(
     ResizeNearestMode nearest_mode,
     void* dims_mapping) {
   if (upsample_mode == UpsampleMode::NN) {
-    ResizeNearestImpl(
+    ORT_RETURN_IF_ERROR(ResizeNearestImpl(
         stream, rank, input_shape, output_shape, input_strides, output_div_pitches,
         scales_vals, roi_vals, input_data, output_data, N,
         extrapolation_enabled, extrapolation_value, cubic_coeff_a,
         coordinate_transform_mode, nearest_mode,
         reinterpret_cast<int64_t*>(dims_mapping),
-        reinterpret_cast<NearestMappingInfo*>(reinterpret_cast<int64_t*>(dims_mapping) + rank));
-    return;
+        reinterpret_cast<NearestMappingInfo*>(reinterpret_cast<int64_t*>(dims_mapping) + rank)));
+    return Status::OK();
   }
 
   // We support a special case of bilinear or bicubic if the input data is 4D with the outer 2 scales being 1.0
@@ -879,7 +924,7 @@ void ResizeImpl(
 
   // Should not hit this as we have already validated input rank/scales and we provide verbose error messages
   // to the user.
-  ORT_ENFORCE(is_2D || is_3D, "Only bilinear/trilinear and bicubic modes are supported in Resize");
+  ORT_RETURN_IF_NOT(is_2D || is_3D, "Only bilinear/trilinear and bicubic modes are supported in Resize");
 
   int blocksPerGrid = static_cast<int>(ceil(static_cast<float>(N) / GridDim::maxThreadsPerBlock));
   fast_divmod div_output_image;
@@ -914,7 +959,7 @@ void ResizeImpl(
             output_div_pitches[rank - 2], div_output_image,
             input_data, output_data, N, extrapolation_value,
             reinterpret_cast<LinearMappingInfo*>(dims_mapping));
-        return;
+        return Status::OK();
       } else if (is_3D) {
         DISPATCH_RESIZE_COORDINATE_TRANSFORMATION_MODE(coordinate_transform_mode, [&]() {
           _ResizeTrilinearCoordinateMapping<T><<<blocksPerDimsMappingGrid, 32, 0, stream>>>(
@@ -933,7 +978,7 @@ void ResizeImpl(
             output_div_pitches[rank - 3], output_div_pitches[rank - 2], div_output_image,
             input_data, output_data, N, extrapolation_value,
             reinterpret_cast<LinearMappingInfo*>(dims_mapping));
-        return;
+        return Status::OK();
       }
       ORT_THROW("Resize support 2-D and 3-D dimensions in LINEAR mode.");
       break;
@@ -956,16 +1001,18 @@ void ResizeImpl(
             output_div_pitches[rank - 2], div_output_image,
             input_data, output_data, N, extrapolation_value,
             reinterpret_cast<CubicMappingInfo*>(dims_mapping));
-        return;
+        return Status::OK();
       }
       ORT_THROW("Resize supports only 2-D in CUBIC mode.");
     case UpsampleMode::NN:
       ORT_THROW("Only bilinear/trilinear and bicubic modes are supported in Resize");
   }
+
+  return Status::OK();
 }
 
 #define SPECIALIZED_IMPL(T)                                         \
-  template void ResizeImpl<T>(                                      \
+  template Status ResizeImpl<T>(                                    \
       cudaStream_t stream,                                          \
       const UpsampleMode upsample_mode,                             \
       const int rank,                                               \

--- a/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
@@ -377,7 +377,7 @@ __global__ void _ResizeBilinearCoordinateMapping(
     input_y = max(0.0f, min(input_y, static_cast<float>(input_height - 1)));
     int y_int = static_cast<int>(input_y);
     dims_mapping[id].origin_ = y_int;
-    dims_mapping[id].weight_ = (y_int >= input_height - 1) ? 0.5f : input_y - y_int;
+    dims_mapping[id].weight_ = (y_int >= input_height - 1) ? 0.0f : input_y - y_int;
   } else {  // x = id - output_height
     float input_x = scale_width == 1 ? static_cast<float>(id - output_height)
                                      : transform_coordinate(static_cast<float>(id - output_height),
@@ -390,7 +390,7 @@ __global__ void _ResizeBilinearCoordinateMapping(
     input_x = max(0.0f, min(input_x, static_cast<float>(input_width - 1)));
     int x_int = static_cast<int>(input_x);
     dims_mapping[id].origin_ = x_int;
-    dims_mapping[id].weight_ = (x_int >= input_width - 1) ? 0.5f : input_x - x_int;
+    dims_mapping[id].weight_ = (x_int >= input_width - 1) ? 0.0f : input_x - x_int;
   }
 }
 
@@ -461,7 +461,7 @@ __global__ void _ResizeTrilinearCoordinateMapping(
     input_z = max(0.0f, min(input_z, static_cast<float>(input_depth - 1)));
     int z_int = static_cast<int>(input_z);
     dims_mapping[id].origin_ = z_int;
-    dims_mapping[id].weight_ = (z_int >= input_depth - 1) ? 0.5f : input_z - z_int;
+    dims_mapping[id].weight_ = (z_int >= input_depth - 1) ? 0.0f : input_z - z_int;
   } else if (id >= output_depth && id < (output_depth + output_height)) {  //  y = id - output_depth
     float input_y = scale_height == 1 ? static_cast<float>(id - output_depth)
                                       : transform_coordinate(static_cast<float>(id - output_depth),
@@ -475,7 +475,7 @@ __global__ void _ResizeTrilinearCoordinateMapping(
     input_y = max(0.0f, min(input_y, static_cast<float>(input_height - 1)));
     int y_int = static_cast<int>(input_y);
     dims_mapping[id].origin_ = y_int;
-    dims_mapping[id].weight_ = (y_int >= input_height - 1) ? 0.5f : input_y - y_int;
+    dims_mapping[id].weight_ = (y_int >= input_height - 1) ? 0.0f : input_y - y_int;
   } else {  // x = id - output_depth - output_height
     float input_x = scale_width == 1 ? static_cast<float>(id - output_depth - output_height)
                                      : transform_coordinate(static_cast<float>(id - output_depth - output_height),
@@ -487,7 +487,7 @@ __global__ void _ResizeTrilinearCoordinateMapping(
     input_x = max(0.0f, min(input_x, static_cast<float>(input_width - 1)));
     int x_int = static_cast<int>(input_x);
     dims_mapping[id].origin_ = x_int;
-    dims_mapping[id].weight_ = (x_int >= input_width - 1) ? 0.5f : input_x - x_int;
+    dims_mapping[id].weight_ = (x_int >= input_width - 1) ? 0.0f : input_x - x_int;
   }
 }
 

--- a/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
@@ -288,9 +288,9 @@ __global__ void _ResizeNearestKernel2D(
       return;
     }
   }
-  int input_index = input_stride_image * imageid +
-                    input_stride_row * dims_mapping[h].origin_ +
-                    dims_mapping[output_height + w].origin_;
+  int64_t input_index = input_stride_image * imageid +
+                        static_cast<int64_t>(input_stride_row) * dims_mapping[h].origin_ +
+                        dims_mapping[output_height + w].origin_;
   output_data[id] = input_data[input_index];
 }
 
@@ -315,10 +315,10 @@ __global__ void _ResizeNearestKernel3D(
       return;
     }
   }
-  int input_index = static_cast<int>(input_stride_image) * imageid +
-                    static_cast<int>(input_stride_depth) * dims_mapping[d].origin_ +
-                    input_stride_row * dims_mapping[output_depth + h].origin_ +
-                    dims_mapping[output_depth + output_height + w].origin_;
+  int64_t input_index = input_stride_image * imageid +
+                        input_stride_depth * dims_mapping[d].origin_ +
+                        static_cast<int64_t>(input_stride_row) * dims_mapping[output_depth + h].origin_ +
+                        dims_mapping[output_depth + output_height + w].origin_;
   output_data[id] = input_data[input_index];
 }
 
@@ -336,7 +336,7 @@ __global__ void _ResizeNearestKernel(
   CALCULATE_ELEMENTWISE_INDEX_OR_EXIT(id, N);
 
   int output_index = static_cast<int>(id);
-  int input_index = 0;
+  int64_t input_index = 0;
   int extrapolation_occurred = 0;
   for (int axis = 0; axis < rank; ++axis) {
     int dim = 0;
@@ -827,8 +827,6 @@ Status ResizeNearestImpl(
 
     const int64_t input_stride_depth = static_cast<int64_t>(input_stride_depth_safe);
     const int64_t input_stride_image = static_cast<int64_t>(input_stride_image_safe);
-    ORT_RETURN_IF_NOT(input_stride_depth <= kIntMax && input_stride_image <= kIntMax,
-                      "ResizeNearestImpl: input strides exceed int range.");
 
     if (extrapolation_enabled) {
       _ResizeNearestKernel3D<T, true><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
@@ -975,7 +973,6 @@ Status ResizeImpl(
       }
       return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                              "Resize supports 2-D and 3-D dimensions in LINEAR mode.");
-      break;
     case UpsampleMode::CUBIC:
       if (is_2D) {
         DISPATCH_RESIZE_COORDINATE_TRANSFORMATION_MODE(coordinate_transform_mode, [&]() {

--- a/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
@@ -916,6 +916,9 @@ Status ResizeImpl(
   // to the user.
   ORT_RETURN_IF_NOT(is_2D || is_3D, "Only bilinear/trilinear and bicubic modes are supported in Resize");
 
+  ORT_RETURN_IF_NOT(N <= static_cast<size_t>(std::numeric_limits<int>::max()),
+                    "ResizeImpl: output element count exceeds int range.");
+
   int blocksPerGrid = static_cast<int>(ceil(static_cast<float>(N) / GridDim::maxThreadsPerBlock));
   fast_divmod div_output_image;
   if (is_2D) {

--- a/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
@@ -10,6 +10,7 @@
 namespace onnxruntime {
 namespace cuda {
 
+using onnxruntime::kNearestModeEps;
 using onnxruntime::ResizeCoordinateTransformationMode;
 using onnxruntime::ResizeNearestMode;
 using onnxruntime::UpsampleMode;
@@ -25,7 +26,8 @@ struct NearestPixel_SIMPLE {
 
 struct NearestPixel_ROUND_PREFER_FLOOR {
   __device__ __forceinline__ int operator()(float x_original, bool) const {
-    if (x_original == static_cast<int>(x_original) + 0.5f) {
+    float fraction = x_original - floorf(x_original);
+    if (fabsf(fraction - 0.5f) <= kNearestModeEps) {
       return static_cast<int>(_Floor(x_original));
     }
     return static_cast<int>(roundf(x_original));
@@ -34,10 +36,8 @@ struct NearestPixel_ROUND_PREFER_FLOOR {
 
 struct NearestPixel_ROUND_PREFER_CEIL {
   __device__ __forceinline__ int operator()(float x_original, bool) const {
-    // for half way cases prefer ceil
-    // roundf rounds away from zero which is correct for positive .5 values
-    // but for negative .5 values (e.g., -0.5) it rounds to -1 instead of 0 (ceil)
-    if (x_original == static_cast<int>(x_original) - 0.5f) {
+    float fraction = x_original - floorf(x_original);
+    if (fabsf(fraction - 0.5f) <= kNearestModeEps) {
       return static_cast<int>(_Ceil(x_original));
     }
     return static_cast<int>(roundf(x_original));

--- a/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
@@ -835,8 +835,18 @@ Status ResizeNearestImpl(
       });
     });
 
-    int64_t input_stride_depth = input_shape[rank - 2] * input_shape[rank - 1];
-    int64_t input_stride_image = input_shape[rank - 3] * input_stride_depth;
+    SafeInt<int64_t> input_stride_depth_safe = 0;
+    SafeInt<int64_t> input_stride_image_safe = 0;
+    try {
+      input_stride_depth_safe = SafeInt<int64_t>(input_shape[rank - 2]) * input_shape[rank - 1];
+      input_stride_image_safe = SafeInt<int64_t>(input_shape[rank - 3]) * input_stride_depth_safe;
+    } catch (const SafeIntException&) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "ResizeNearestImpl: input strides exceed int range.");
+    }
+
+    const int64_t input_stride_depth = static_cast<int64_t>(input_stride_depth_safe);
+    const int64_t input_stride_image = static_cast<int64_t>(input_stride_image_safe);
     ORT_RETURN_IF_NOT(input_stride_depth <= kIntMax && input_stride_image <= kIntMax,
                       "ResizeNearestImpl: input strides exceed int range.");
 
@@ -929,9 +939,9 @@ Status ResizeImpl(
   int blocksPerGrid = static_cast<int>(ceil(static_cast<float>(N) / GridDim::maxThreadsPerBlock));
   fast_divmod div_output_image;
   if (is_2D) {
-    div_output_image = (rank > 2) ? output_div_pitches[rank - 3] : fast_divmod(gsl::narrow_cast<int>(N));
+    div_output_image = (rank > 2) ? output_div_pitches[rank - 3] : fast_divmod(onnxruntime::narrow<int>(N));
   } else if (is_3D) {
-    div_output_image = (rank > 3) ? output_div_pitches[rank - 4] : fast_divmod(gsl::narrow_cast<int>(N));
+    div_output_image = (rank > 3) ? output_div_pitches[rank - 4] : fast_divmod(onnxruntime::narrow<int>(N));
   }
 
   int64_t output_depth = is_3D ? output_shape[rank - 3] : 0;
@@ -980,7 +990,8 @@ Status ResizeImpl(
             reinterpret_cast<LinearMappingInfo*>(dims_mapping));
         return Status::OK();
       }
-      ORT_THROW("Resize support 2-D and 3-D dimensions in LINEAR mode.");
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Resize supports 2-D and 3-D dimensions in LINEAR mode.");
       break;
     case UpsampleMode::CUBIC:
       if (is_2D) {
@@ -1003,9 +1014,11 @@ Status ResizeImpl(
             reinterpret_cast<CubicMappingInfo*>(dims_mapping));
         return Status::OK();
       }
-      ORT_THROW("Resize supports only 2-D in CUBIC mode.");
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Resize supports only 2-D in CUBIC mode.");
     case UpsampleMode::NN:
-      ORT_THROW("Only bilinear/trilinear and bicubic modes are supported in Resize");
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Only bilinear/trilinear and bicubic modes are supported in Resize");
   }
 
   return Status::OK();

--- a/onnxruntime/core/providers/cuda/tensor/resize_impl.h
+++ b/onnxruntime/core/providers/cuda/tensor/resize_impl.h
@@ -120,6 +120,7 @@ void ResizeAntiAliasImpl(
     gsl::span<const float> roi_vals,  // CPU
     const std::optional<float>& extrapolation_value,
     bool exclude_outside,
+    bool is_nhwc,
     TempSpaceAllocateFunc allocate_temp_space,
     const uint8_t* clip8_lookups,
     const T* input_data,

--- a/onnxruntime/core/providers/cuda/tensor/resize_impl.h
+++ b/onnxruntime/core/providers/cuda/tensor/resize_impl.h
@@ -80,7 +80,7 @@ size_t CalcResizeBufferSize(const onnxruntime::UpsampleMode upsample_mode,
                             const gsl::span<const int64_t>& output_dims);
 
 template <typename T>
-void ResizeImpl(
+Status ResizeImpl(
     cudaStream_t stream,
     const onnxruntime::UpsampleMode upsample_mode,
     const int rank,

--- a/onnxruntime/core/providers/cuda/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cuda/tensor/upsample.cc
@@ -190,7 +190,7 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
                 height_scale = scales[1];
                 width_scale = scales[2];
               } else {
-                return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Resize",
+                return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Resize",
                                        ": 4-D 'Linear' antialias mode requires batch and channel "
                                        "scales to be 1.0 (NCHW or NHWC layout).");
               }
@@ -309,7 +309,7 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
               height_scale = scales[1];
               width_scale = scales[2];
             } else {
-              return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Resize",
+              return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Resize",
                                      ": 4-D 'Cubic' antialias mode requires batch and channel "
                                      "scales to be 1.0 (NCHW or NHWC layout).");
             }

--- a/onnxruntime/core/providers/cuda/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cuda/tensor/upsample.cc
@@ -3,8 +3,10 @@
 
 #include "upsample.h"
 
+#include <limits>
 #include <utility>
 
+#include "core/common/safeint.h"
 #include "upsample_impl.h"
 #include "core/providers/cuda/tensor/resize_impl.h"
 #include "core/providers/cpu/tensor/utils.h"
@@ -63,7 +65,8 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
   auto X_dims = X->Shape().GetDims();
   int32_t rank = static_cast<int32_t>(X_dims.size());
 
-  ORT_ENFORCE(static_cast<int32_t>(output_dims.size()) == rank, "Rank of input and output tensor should be same.");
+  ORT_RETURN_IF_NOT(static_cast<int32_t>(output_dims.size()) == rank,
+                    "Rank of input and output tensor should be same.");
   if (rank == 0)
     return Status(ONNXRUNTIME, INVALID_ARGUMENT,
                   is_resize_ ? "Resize: input tensor cannot be scalar." : "Upsample: input tensor cannot be scalar.");
@@ -83,6 +86,24 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
   }
 
   typedef typename ToCudaType<T>::MappedType CudaT;
+  constexpr int64_t kIntMax = static_cast<int64_t>(std::numeric_limits<int>::max());
+
+  auto is_valid_non_negative_int = [kIntMax](int64_t v) {
+    return v >= 0 && v <= kIntMax;
+  };
+
+  auto checked_mul_fits_int = [kIntMax](int64_t a, int64_t b) {
+    if (a < 0 || b < 0) {
+      return false;
+    }
+
+    try {
+      const SafeInt<int64_t> product = SafeInt<int64_t>(a) * b;
+      return product <= kIntMax;
+    } catch (const SafeIntException&) {
+      return false;
+    }
+  };
 
   // kernel
   TensorPitches input_pitches(X_dims);
@@ -92,7 +113,9 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
   TArray<fast_divmod> output_div_pitches(rank);
 
   for (int32_t i = 0; i < rank; ++i) {
-    output_div_pitches[i] = fast_divmod(gsl::narrow_cast<int>(output_pitches[i]));
+    ORT_RETURN_IF_NOT(output_pitches[i] <= static_cast<size_t>(kIntMax),
+                      "Resize: output pitch exceeds supported int range for CUDA kernel indexing.");
+    output_div_pitches[i] = fast_divmod(onnxruntime::narrow<int>(output_pitches[i]));
   }
   size_t output_count = Y->Shape().Size();
 
@@ -272,6 +295,35 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
           return Status(ONNXRUNTIME, INVALID_ARGUMENT, "Resize: unexpected mode");
       }
     } else {
+      for (int32_t i = 0; i < rank; ++i) {
+        ORT_RETURN_IF_NOT(is_valid_non_negative_int(X_dims[i]) && is_valid_non_negative_int(output_dims[i]),
+                          "Resize: dimension exceeds supported int range for CUDA nearest indexing.");
+      }
+
+      if (mode_ == UpsampleMode::NN && rank >= 2) {
+        ORT_RETURN_IF_NOT(checked_mul_fits_int(output_dims[rank - 2], output_dims[rank - 1]),
+                          "Resize: output height*width exceeds supported int range for CUDA nearest indexing.");
+      }
+
+      if (mode_ == UpsampleMode::NN && rank >= 3) {
+        const int64_t output_depth = output_dims[rank - 3];
+        const int64_t output_height = output_dims[rank - 2];
+        const int64_t output_width = output_dims[rank - 1];
+        bool dhw_fits_int = false;
+        if (output_depth >= 0 && output_height >= 0 && output_width >= 0) {
+          try {
+            const SafeInt<int64_t> output_dh = SafeInt<int64_t>(output_depth) * output_height;
+            const SafeInt<int64_t> output_dhw = output_dh * output_width;
+            dhw_fits_int = output_dhw <= kIntMax;
+          } catch (const SafeIntException&) {
+            dhw_fits_int = false;
+          }
+        }
+
+        ORT_RETURN_IF_NOT(dhw_fits_int,
+                          "Resize: output depth*height*width exceeds supported int range for CUDA nearest indexing.");
+      }
+
       TArray<int64_t> input_shape(X_dims);
       TArray<int64_t> output_shape(output_dims);
       TArray<float, 10> roi_vals(roi);
@@ -280,20 +332,22 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
       size_t temp_buffer_size = CalcResizeBufferSize(mode_, output_dims);
       auto dims_mapping_buffer = GetScratchBuffer<unsigned char>(temp_buffer_size, GetComputeStream(context));
       void* dims_mapping = reinterpret_cast<void*>(dims_mapping_buffer.get());
-      ResizeImpl(Stream(context), mode_, rank, input_shape, output_shape,
-                 input_strides, output_div_pitches, scales_vals, roi_vals,
-                 reinterpret_cast<const CudaT*>(X->Data<T>()),
-                 reinterpret_cast<CudaT*>(Y->MutableData<T>()),
-                 output_count, use_extrapolation_, ToCudaType<T>::FromFloat(extrapolation_value_),
-                 cubic_coeff_a_, exclude_outside_,
-                 coordinate_transform_mode_, nearest_mode_,
-                 dims_mapping);
+      ORT_RETURN_IF_ERROR(ResizeImpl(Stream(context), mode_, rank, input_shape, output_shape,
+                                     input_strides, output_div_pitches, scales_vals, roi_vals,
+                                     reinterpret_cast<const CudaT*>(X->Data<T>()),
+                                     reinterpret_cast<CudaT*>(Y->MutableData<T>()),
+                                     output_count, use_extrapolation_, ToCudaType<T>::FromFloat(extrapolation_value_),
+                                     cubic_coeff_a_, exclude_outside_,
+                                     coordinate_transform_mode_, nearest_mode_,
+                                     dims_mapping));
     }
   } else {
     TArray<fast_divmod> scales_div(rank);
 
     for (int32_t i = 0; i < rank; ++i) {
-      scales_div[i] = fast_divmod(gsl::narrow_cast<int>(ceil(scales[i])));
+      ORT_RETURN_IF_NOT(ceil(scales[i]) <= static_cast<double>(std::numeric_limits<int>::max()),
+                        "Upsample: scale factor exceeds supported int range for CUDA indexing.");
+      scales_div[i] = fast_divmod(onnxruntime::narrow<int>(ceil(scales[i])));
     }
 
     UpsampleImpl(Stream(context),
@@ -314,7 +368,7 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
 template <typename T>
 Status Upsample<T>::ComputeInternal(OpKernelContext* context) const {
   const Tensor* X = context->Input<Tensor>(0);
-  ORT_ENFORCE(X != nullptr);
+  ORT_RETURN_IF_NOT(X != nullptr, "Input tensor is null.");
   auto input_dims = X->Shape().GetDims();
 
   TensorShapeVector output_dims(input_dims.size());
@@ -322,7 +376,7 @@ Status Upsample<T>::ComputeInternal(OpKernelContext* context) const {
   if (!roi_cached_) {
     bool use_default_roi = true;
     if (need_roi_input_) {
-      ORT_ENFORCE(roi_input_idx_ > 0, "Invalid roi input index.");
+      ORT_RETURN_IF_NOT(roi_input_idx_ > 0, "Invalid roi input index.");
       const auto* roi = context->Input<Tensor>(roi_input_idx_);
       if (roi != nullptr) {
         ParseRoiData(roi, roi_array);
@@ -368,15 +422,15 @@ Status Upsample<T>::ComputeInternal(OpKernelContext* context) const {
   // Scales and sizes are input to the node
   if (scales != nullptr && scales->Shape().Size() != 0) {
     // use scales input data
-    ORT_ENFORCE(sizes == nullptr, "Only one of scales or sizes must be provided as input.");
+    ORT_RETURN_IF_NOT(sizes == nullptr, "Only one of scales or sizes must be provided as input.");
     ORT_RETURN_IF_ERROR(ParseScalesData(scales, scales_array, input_dims.size()));
 
     // Compute output shape from scales and input dims
     ComputeOutputShape(scales_array, input_dims, output_dims);
   } else {
     // When sizes input is available directly populate it into the output_dims array.
-    ORT_ENFORCE(sizes != nullptr && sizes->Shape().Size() != 0,
-                "Either scales or sizes MUST be provided as input.");
+    ORT_RETURN_IF_NOT(sizes != nullptr && sizes->Shape().Size() != 0,
+                      "Either scales or sizes MUST be provided as input.");
     ORT_RETURN_IF_ERROR(ParseSizesData(sizes, output_dims, input_dims));
     ORT_RETURN_IF_ERROR(ParseScalesDataAndAdjustOutputSize(output_dims, input_dims, scales_array));
   }

--- a/onnxruntime/core/providers/cuda/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cuda/tensor/upsample.cc
@@ -152,6 +152,8 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
             float height_scale;
             float width_scale;
 
+            bool is_nhwc = false;
+
             if (is_2D) {
               input_height = X_dims[0];
               input_width = X_dims[1];
@@ -163,6 +165,7 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
               width_scale = scales[1];
             } else {
               if (scales[0] == 1.0f && scales[1] == 1.0f) {
+                // NCHW: batch and channel scales are 1
                 batch_size = X_dims[Channels<LAYOUT_NCHW>::N];
                 num_channels = X_dims[Channels<LAYOUT_NCHW>::C];
                 input_height = X_dims[Channels<LAYOUT_NCHW>::H];
@@ -173,8 +176,23 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
 
                 height_scale = scales[2];
                 width_scale = scales[3];
+              } else if (scales[0] == 1.0f && scales[3] == 1.0f) {
+                // NHWC: batch and channel scales are 1
+                is_nhwc = true;
+                batch_size = X_dims[Channels<LAYOUT_NHWC>::N];
+                num_channels = X_dims[Channels<LAYOUT_NHWC>::C];
+                input_height = X_dims[Channels<LAYOUT_NHWC>::H];
+                input_width = X_dims[Channels<LAYOUT_NHWC>::W];
+
+                output_height = output_dims[Channels<LAYOUT_NHWC>::H];
+                output_width = output_dims[Channels<LAYOUT_NHWC>::W];
+
+                height_scale = scales[1];
+                width_scale = scales[2];
               } else {
-                return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED, "Resize", ": NHWC is not supported yet");
+                return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Resize",
+                                       ": 4-D 'Linear' antialias mode requires batch and channel "
+                                       "scales to be 1.0 (NCHW or NHWC layout).");
               }
             }
 
@@ -192,6 +210,7 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
                                 roi,
                                 extrapolation_value,
                                 exclude_outside_,
+                                is_nhwc,
                                 allocate_temp_space,
                                 shared_lookup_table_ondevice,
                                 reinterpret_cast<const CudaT*>(X->Data<T>()),
@@ -235,6 +254,7 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
                                 roi,
                                 extrapolation_value,
                                 exclude_outside_,
+                                /*is_nhwc=*/false,
                                 allocate_temp_space,
                                 shared_lookup_table_ondevice,
                                 reinterpret_cast<const CudaT*>(X->Data<T>()),
@@ -255,21 +275,45 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
           }
 
           const bool is_2D = X_dims.size() == 2;
-          const bool is_nchw = is_2D ? true : (scales[0] == 1.0f && scales[1] == 1.0f);
 
-          ORT_RETURN_IF_NOT(is_nchw,
-                            "Resize 'Cubic' mode only supports NCWH layout "
-                            " with 2-D or 4-D with leading dims equal to 1");
+          int64_t batch_size = is_2D ? 1 : 0;
+          int64_t num_channels = is_2D ? 1 : 0;
+          int64_t input_height = is_2D ? X_dims[0] : 0;
+          int64_t input_width = is_2D ? X_dims[1] : 0;
+          int64_t output_height = is_2D ? output_dims[0] : 0;
+          int64_t output_width = is_2D ? output_dims[1] : 0;
+          float height_scale = is_2D ? scales[0] : 0.f;
+          float width_scale = is_2D ? scales[1] : 0.f;
+          bool is_nhwc = false;
 
-          const int64_t batch_size = is_2D ? 1 : X_dims[Channels<LAYOUT_NCHW>::N];
-          const int64_t num_channels = is_2D ? 1 : X_dims[Channels<LAYOUT_NCHW>::C];
-          const int64_t input_height = is_2D ? X_dims[0] : X_dims[Channels<LAYOUT_NCHW>::H];
-          const int64_t input_width = is_2D ? X_dims[1] : X_dims[Channels<LAYOUT_NCHW>::W];
-
-          const int64_t output_height = is_2D ? output_dims[0] : output_dims[Channels<LAYOUT_NCHW>::H];
-          const int64_t output_width = is_2D ? output_dims[1] : output_dims[Channels<LAYOUT_NCHW>::W];
-          const float height_scale = is_2D ? scales[0] : scales[2];
-          const float width_scale = is_2D ? scales[1] : scales[3];
+          if (!is_2D) {
+            if (scales[0] == 1.0f && scales[1] == 1.0f) {
+              // NCHW
+              batch_size = X_dims[Channels<LAYOUT_NCHW>::N];
+              num_channels = X_dims[Channels<LAYOUT_NCHW>::C];
+              input_height = X_dims[Channels<LAYOUT_NCHW>::H];
+              input_width = X_dims[Channels<LAYOUT_NCHW>::W];
+              output_height = output_dims[Channels<LAYOUT_NCHW>::H];
+              output_width = output_dims[Channels<LAYOUT_NCHW>::W];
+              height_scale = scales[2];
+              width_scale = scales[3];
+            } else if (scales[0] == 1.0f && scales[3] == 1.0f) {
+              // NHWC
+              is_nhwc = true;
+              batch_size = X_dims[Channels<LAYOUT_NHWC>::N];
+              num_channels = X_dims[Channels<LAYOUT_NHWC>::C];
+              input_height = X_dims[Channels<LAYOUT_NHWC>::H];
+              input_width = X_dims[Channels<LAYOUT_NHWC>::W];
+              output_height = output_dims[Channels<LAYOUT_NHWC>::H];
+              output_width = output_dims[Channels<LAYOUT_NHWC>::W];
+              height_scale = scales[1];
+              width_scale = scales[2];
+            } else {
+              return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Resize",
+                                     ": 4-D 'Cubic' antialias mode requires batch and channel "
+                                     "scales to be 1.0 (NCHW or NHWC layout).");
+            }
+          }
 
           ResizeAntiAliasImpl(Stream(context), rank, mode_, coordinate_transform_mode_, cubic_coeff_a_,
                               X_dims, output_dims,
@@ -281,6 +325,7 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
                               roi,
                               extrapolation_value,
                               exclude_outside_,
+                              is_nhwc,
                               allocate_temp_space,
                               shared_lookup_table_ondevice,
                               reinterpret_cast<const CudaT*>(X->Data<T>()),

--- a/onnxruntime/core/providers/cuda/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cuda/tensor/upsample.cc
@@ -92,15 +92,6 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
     return v >= 0 && v <= kIntMax;
   };
 
-  auto checked_mul_fits_int = [kIntMax](int64_t a, int64_t b) {
-    if (a < 0 || b < 0) {
-      return false;
-    }
-
-    int64_t product = 0;
-    return SafeMultiply(a, b, product) && product <= kIntMax;
-  };
-
   // kernel
   TensorPitches input_pitches(X_dims);
   TArray<int64_t> input_strides(input_pitches);
@@ -342,7 +333,8 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
       }
 
       if (mode_ == UpsampleMode::NN && rank >= 2) {
-        ORT_RETURN_IF_NOT(checked_mul_fits_int(output_dims[rank - 2], output_dims[rank - 1]),
+        int64_t output_hw = 0;
+        ORT_RETURN_IF_NOT(SafeMultiply(output_dims[rank - 2], output_dims[rank - 1], output_hw) && output_hw <= kIntMax,
                           "Resize: output height*width exceeds supported int range for CUDA nearest indexing.");
       }
 

--- a/onnxruntime/core/providers/cuda/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cuda/tensor/upsample.cc
@@ -97,8 +97,8 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
       return false;
     }
 
-    const SafeInt<int64_t> product = SafeInt<int64_t>(a) * b;
-    return product <= kIntMax;
+    int64_t product = 0;
+    return SafeMultiply(a, b, product) && product <= kIntMax;
   };
 
   // kernel
@@ -352,9 +352,11 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
         const int64_t output_width = output_dims[rank - 1];
         bool dhw_fits_int = false;
         if (output_depth >= 0 && output_height >= 0 && output_width >= 0) {
-          const SafeInt<int64_t> output_dh = SafeInt<int64_t>(output_depth) * output_height;
-          const SafeInt<int64_t> output_dhw = output_dh * output_width;
-          dhw_fits_int = output_dhw <= kIntMax;
+          int64_t output_dh = 0;
+          int64_t output_dhw = 0;
+          dhw_fits_int = SafeMultiply(output_depth, output_height, output_dh) &&
+                         SafeMultiply(output_dh, output_width, output_dhw) &&
+                         output_dhw <= kIntMax;
         }
 
         ORT_RETURN_IF_NOT(dhw_fits_int,

--- a/onnxruntime/core/providers/cuda/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cuda/tensor/upsample.cc
@@ -109,7 +109,7 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
   TArray<fast_divmod> output_div_pitches(rank);
 
   for (int32_t i = 0; i < rank; ++i) {
-    ORT_RETURN_IF_NOT(output_pitches[i] <= static_cast<size_t>(kIntMax),
+    ORT_RETURN_IF_NOT(output_pitches[i] >= 0 && output_pitches[i] <= kIntMax,
                       "Resize: output pitch exceeds supported int range for CUDA kernel indexing.");
     output_div_pitches[i] = fast_divmod(onnxruntime::narrow<int>(output_pitches[i]));
   }

--- a/onnxruntime/core/providers/cuda/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cuda/tensor/upsample.cc
@@ -97,12 +97,8 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
       return false;
     }
 
-    try {
-      const SafeInt<int64_t> product = SafeInt<int64_t>(a) * b;
-      return product <= kIntMax;
-    } catch (const SafeIntException&) {
-      return false;
-    }
+    const SafeInt<int64_t> product = SafeInt<int64_t>(a) * b;
+    return product <= kIntMax;
   };
 
   // kernel
@@ -311,13 +307,9 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
         const int64_t output_width = output_dims[rank - 1];
         bool dhw_fits_int = false;
         if (output_depth >= 0 && output_height >= 0 && output_width >= 0) {
-          try {
-            const SafeInt<int64_t> output_dh = SafeInt<int64_t>(output_depth) * output_height;
-            const SafeInt<int64_t> output_dhw = output_dh * output_width;
-            dhw_fits_int = output_dhw <= kIntMax;
-          } catch (const SafeIntException&) {
-            dhw_fits_int = false;
-          }
+          const SafeInt<int64_t> output_dh = SafeInt<int64_t>(output_depth) * output_height;
+          const SafeInt<int64_t> output_dhw = output_dh * output_width;
+          dhw_fits_int = output_dhw <= kIntMax;
         }
 
         ORT_RETURN_IF_NOT(dhw_fits_int,

--- a/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
@@ -3183,7 +3183,7 @@ TEST(ResizeOpTest, Axes_OutOfRange_18) {
   test.AddOutput<float>("Y", {1, 1, 4, 4, 4}, Y);
 
   test.Run(OpTester::ExpectResult::kExpectFailure,
-           "all values in axes should be in the range [-rank, rank - 1]",
+           "axis 5 is not in valid range [-5,4]",
            {kTensorrtExecutionProvider, kQnnExecutionProvider});
 }
 

--- a/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
@@ -2575,9 +2575,8 @@ TEST(ResizeOpTest, Antialias_NhwcBilinear) {
                           35.074074f, 75.07407f, 115.07407f,
                           36.590908f, 76.59091f, 116.59091f};
 
-  // Nchw is not supported by CUDA Resize implementation
-  InlinedVector<std::string_view> excluded_eps = {kCudaExecutionProvider};
-  TestAntialiasing({{"mode", "linear"}, {"exclude_outside", "1"}}, {1, 5, 8, 3}, X, {1, 4, 5, 3}, Y, excluded_eps);
+  // NHWC bilinear antialias is now supported on CUDA
+  TestAntialiasing({{"mode", "linear"}, {"exclude_outside", "1"}}, {1, 5, 8, 3}, X, {1, 4, 5, 3}, Y);
 }
 
 TEST(ResizeOpTest, Antialias_NhwcBilinear_dtype) {
@@ -2728,8 +2727,8 @@ TEST(ResizeOpTest, Antialias_NHWCBicubic_ExcludeOutside) {
       46.606194f, 19.878183f, 43.87818f, 21.358122f, 45.35812f,
       22.907503f, 46.907505f, 24.387442f, 48.387444f};
 
-  InlinedVector<std::string_view> excluded_eps = {kCudaExecutionProvider};
-  TestAntialiasing({{"mode", "cubic"}, {"exclude_outside", "0"}}, {1, 4, 6, 2}, X, {1, 8, 4, 2}, Y, excluded_eps);
+  // NHWC bicubic antialias is now supported on CUDA
+  TestAntialiasing({{"mode", "cubic"}, {"exclude_outside", "0"}}, {1, 4, 6, 2}, X, {1, 8, 4, 2}, Y);
 }
 
 TEST(ResizeOpTest, NoAntialias_AlignCorners_Cubic_Floor_NCHW) {

--- a/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
@@ -3085,14 +3085,17 @@ TEST(ResizeOpTest, Axes_and_Scales_CountMismatch_18) {
   std::vector<float> roi{};
   std::vector<float> scales{0.75f, 0.75f};
   std::vector<int64_t> axes{2, 3, 4};
+  std::vector<float> Y(16 * 4, 0.0f);
 
   OpTester test("Resize", 18);
+  test.AddShapeToTensorData(false);
   test.AddAttribute("mode", "linear");
   test.AddAttribute<std::vector<int64_t>>("axes", axes);
 
   test.AddInput<float>("X", {1, 1, 4, 4, 4}, X);
   test.AddInput<float>("roi", {0}, roi);
   test.AddInput<float>("scales", {int64_t(scales.size())}, scales);
+  test.AddOutput<float>("Y", {1, 1, 4, 4, 4}, Y);
 
   test.Run(OpTester::ExpectResult::kExpectFailure,
            "Number of elements in scales should be equal to number of axes.",
@@ -3105,14 +3108,17 @@ TEST(ResizeOpTest, Axes_OutOfRange_18) {
   std::vector<float> roi{};
   std::vector<float> scales{0.75f, 0.75f, 0.75f};
   std::vector<int64_t> axes{2, 3, 5};
+  std::vector<float> Y(16 * 4, 0.0f);
 
   OpTester test("Resize", 18);
+  test.AddShapeToTensorData(false);
   test.AddAttribute("mode", "linear");
   test.AddAttribute<std::vector<int64_t>>("axes", axes);
 
   test.AddInput<float>("X", {1, 1, 4, 4, 4}, X);
   test.AddInput<float>("roi", {0}, roi);
   test.AddInput<float>("scales", {int64_t(scales.size())}, scales);
+  test.AddOutput<float>("Y", {1, 1, 4, 4, 4}, Y);
 
   test.Run(OpTester::ExpectResult::kExpectFailure,
            "all values in axes should be in the range [-rank, rank - 1]",
@@ -3121,6 +3127,7 @@ TEST(ResizeOpTest, Axes_OutOfRange_18) {
 
 TEST(ResizeOpTest, Sizes_RankMismatch_13) {
   OpTester test("Resize", 13);
+  test.AddShapeToTensorData(false);
 
   std::vector<float> roi{};
   std::vector<float> scales{};
@@ -3134,11 +3141,13 @@ TEST(ResizeOpTest, Sizes_RankMismatch_13) {
       5.0f, 6.0f, 7.0f, 8.0f,
       9.0f, 10.0f, 11.0f, 12.0f,
       13.0f, 14.0f, 15.0f, 16.0f};
+  std::vector<float> Y = X;
 
   test.AddInput<float>("X", {N, C, H, W}, X);
   test.AddInput<float>("roi", {0}, roi);
   test.AddInput<float>("", {0}, scales);
   test.AddInput<int64_t>("sizes", {int64_t(sizes.size())}, sizes);
+  test.AddOutput<float>("Y", {N, C, H, W}, Y);
 
   test.Run(OpTester::ExpectResult::kExpectFailure,
            "Resize: input tensor's rank does not match the output tensor's rank.",

--- a/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
@@ -1541,7 +1541,9 @@ TEST(ResizeOpTest, ResizeOpNearestUpSample_RoundPreferCeil_HalfPixel_GH28291_Reg
       X[1], X[5], X[8], X[11], X[15], X[18]};
 
   test.AddOutput<float>("Y", {N, C, H, 6}, Y);
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", ExcludeTrtOnA100());
+  // OpenVINO EP does not implement the epsilon-based rounding fix for half_pixel ties.
+  std::unordered_set<std::string> excluded_eps = {kOpenVINOExecutionProvider};
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", ExcludeTrtOnA100(excluded_eps));
 }
 
 TEST(ResizeOpTest, ResizeOpNearest_OneToOneMappingBetweenInputAndOutputDataDims) {
@@ -3161,7 +3163,7 @@ TEST(ResizeOpTest, Axes_and_Scales_CountMismatch_18) {
 
   test.Run(OpTester::ExpectResult::kExpectFailure,
            "Number of elements in scales should be equal to number of axes.",
-           {kTensorrtExecutionProvider, kQnnExecutionProvider});
+           {kTensorrtExecutionProvider, kQnnExecutionProvider, kDmlExecutionProvider});
 }
 
 TEST(ResizeOpTest, Axes_OutOfRange_18) {
@@ -3184,7 +3186,7 @@ TEST(ResizeOpTest, Axes_OutOfRange_18) {
 
   test.Run(OpTester::ExpectResult::kExpectFailure,
            "axis 5 is not in valid range [-5,4]",
-           {kTensorrtExecutionProvider, kQnnExecutionProvider});
+           {kTensorrtExecutionProvider, kQnnExecutionProvider, kDmlExecutionProvider});
 }
 
 TEST(ResizeOpTest, Sizes_RankMismatch_13) {
@@ -3213,7 +3215,7 @@ TEST(ResizeOpTest, Sizes_RankMismatch_13) {
 
   test.Run(OpTester::ExpectResult::kExpectFailure,
            "Resize: input tensor's rank does not match the output tensor's rank.",
-           {kTensorrtExecutionProvider});
+           {kTensorrtExecutionProvider, kDmlExecutionProvider});
 }
 
 }  // namespace test

--- a/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
@@ -2728,7 +2728,6 @@ TEST(ResizeOpTest, Antialias_NHWCBicubic_ExcludeOutside) {
       46.606194f, 19.878183f, 43.87818f, 21.358122f, 45.35812f,
       22.907503f, 46.907505f, 24.387442f, 48.387444f};
 
-  // NHWC bicubic antialias is now supported on CUDA
   TestAntialiasing({{"mode", "cubic"}, {"exclude_outside", "0"}}, {1, 4, 6, 2}, X, {1, 8, 4, 2}, Y);
 }
 

--- a/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
@@ -1504,6 +1504,40 @@ TEST(ResizeOpTest, ResizeOpNearestUpSample_RoundPreferCeil_HalfPixel_2x2to7x8) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", ExcludeTrtOnA100());
 }
 
+// Regression coverage for GitHub issue #28291.
+// Keep this as a dedicated alias test so issue-driven coverage is explicit.
+TEST(ResizeOpTest, ResizeOpNearestUpSample_RoundPreferCeil_HalfPixel_GH28291_Regression) {
+  OpTester test("Resize", 13);
+
+  std::vector<float> roi{};
+  std::vector<float> scales{1.0f, 1.0f, 1.0f, 64.0f / 26.0f};
+
+  test.AddAttribute("mode", "nearest");
+  test.AddAttribute("coordinate_transformation_mode", "half_pixel");
+  test.AddAttribute("nearest_mode", "round_prefer_ceil");
+
+  constexpr int64_t N = 1, C = 1, H = 1, W = 26;
+  std::vector<float> X(26);
+  for (int i = 0; i < 26; i++) X[i] = static_cast<float>(i);
+
+  test.AddInput<float>("X", {N, C, H, W}, X);
+  test.AddInput<float>("roi", {0}, roi);
+  test.AddInput<float>("scales", {4}, scales);
+
+  std::vector<float> Y = {
+      0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 2.0f, 2.0f, 3.0f,
+      3.0f, 3.0f, 4.0f, 4.0f, 5.0f, 5.0f, 5.0f, 6.0f,
+      6.0f, 7.0f, 7.0f, 7.0f, 8.0f, 8.0f, 9.0f, 9.0f,
+      9.0f, 10.0f, 10.0f, 11.0f, 11.0f, 11.0f, 12.0f, 12.0f,
+      13.0f, 13.0f, 14.0f, 14.0f, 14.0f, 15.0f, 15.0f, 16.0f,
+      16.0f, 16.0f, 17.0f, 17.0f, 18.0f, 18.0f, 18.0f, 19.0f,
+      19.0f, 20.0f, 20.0f, 20.0f, 21.0f, 21.0f, 22.0f, 22.0f,
+      22.0f, 23.0f, 23.0f, 24.0f, 24.0f, 24.0f, 25.0f, 25.0f};
+
+  test.AddOutput<float>("Y", {N, C, H, 64}, Y);
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", ExcludeTrtOnA100());
+}
+
 TEST(ResizeOpTest, ResizeOpNearest_OneToOneMappingBetweenInputAndOutputDataDims) {
   // TODO: Unskip when fixed #41968513
   if (DefaultDmlExecutionProvider().get() != nullptr) {
@@ -3043,6 +3077,72 @@ TEST(ResizeOpTest, Axes_and_Size_18) {
 
   test.AddOutput<float>("Y", output_shape, Y);
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kQnnExecutionProvider});
+}
+
+TEST(ResizeOpTest, Axes_and_Scales_CountMismatch_18) {
+  std::vector<float> X(16 * 4);
+  std::iota(X.begin(), X.end(), 0.f);
+  std::vector<float> roi{};
+  std::vector<float> scales{0.75f, 0.75f};
+  std::vector<int64_t> axes{2, 3, 4};
+
+  OpTester test("Resize", 18);
+  test.AddAttribute("mode", "linear");
+  test.AddAttribute<std::vector<int64_t>>("axes", axes);
+
+  test.AddInput<float>("X", {1, 1, 4, 4, 4}, X);
+  test.AddInput<float>("roi", {0}, roi);
+  test.AddInput<float>("scales", {int64_t(scales.size())}, scales);
+
+  test.Run(OpTester::ExpectResult::kExpectFailure,
+           "Number of elements in scales should be equal to number of axes.",
+           {kTensorrtExecutionProvider, kQnnExecutionProvider});
+}
+
+TEST(ResizeOpTest, Axes_OutOfRange_18) {
+  std::vector<float> X(16 * 4);
+  std::iota(X.begin(), X.end(), 0.f);
+  std::vector<float> roi{};
+  std::vector<float> scales{0.75f, 0.75f, 0.75f};
+  std::vector<int64_t> axes{2, 3, 5};
+
+  OpTester test("Resize", 18);
+  test.AddAttribute("mode", "linear");
+  test.AddAttribute<std::vector<int64_t>>("axes", axes);
+
+  test.AddInput<float>("X", {1, 1, 4, 4, 4}, X);
+  test.AddInput<float>("roi", {0}, roi);
+  test.AddInput<float>("scales", {int64_t(scales.size())}, scales);
+
+  test.Run(OpTester::ExpectResult::kExpectFailure,
+           "all values in axes should be in the range [-rank, rank - 1]",
+           {kTensorrtExecutionProvider, kQnnExecutionProvider});
+}
+
+TEST(ResizeOpTest, Sizes_RankMismatch_13) {
+  OpTester test("Resize", 13);
+
+  std::vector<float> roi{};
+  std::vector<float> scales{};
+  std::vector<int64_t> sizes{1, 1, 8, 8, 8};
+
+  test.AddAttribute("mode", "nearest");
+
+  constexpr int64_t N = 1, C = 1, H = 4, W = 4;
+  std::vector<float> X = {
+      1.0f, 2.0f, 3.0f, 4.0f,
+      5.0f, 6.0f, 7.0f, 8.0f,
+      9.0f, 10.0f, 11.0f, 12.0f,
+      13.0f, 14.0f, 15.0f, 16.0f};
+
+  test.AddInput<float>("X", {N, C, H, W}, X);
+  test.AddInput<float>("roi", {0}, roi);
+  test.AddInput<float>("", {0}, scales);
+  test.AddInput<int64_t>("sizes", {int64_t(sizes.size())}, sizes);
+
+  test.Run(OpTester::ExpectResult::kExpectFailure,
+           "Resize: input tensor's rank does not match the output tensor's rank.",
+           {kTensorrtExecutionProvider});
 }
 
 }  // namespace test

--- a/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
@@ -1505,36 +1505,42 @@ TEST(ResizeOpTest, ResizeOpNearestUpSample_RoundPreferCeil_HalfPixel_2x2to7x8) {
 }
 
 // Regression coverage for GitHub issue #28291.
-// Keep this as a dedicated alias test so issue-driven coverage is explicit.
+// https://github.com/microsoft/onnxruntime/issues/28291
+//
+// Resize with mode=nearest, coordinate_transformation_mode=half_pixel, nearest_mode=round_prefer_ceil.
+// Input width=20, output width=6 (scale = 6/20 = 0.3).
+// For output element 4: x_original = (4 + 0.5) / 0.3 - 0.5 = 14.5
+// With round_prefer_ceil, the tie at 14.5 must round to 15.
+// Before the fix, float imprecision caused (4.5f / 0.3f - 0.5f) to yield ~14.4999 which
+// std::round mapped to 14 instead of 15.
 TEST(ResizeOpTest, ResizeOpNearestUpSample_RoundPreferCeil_HalfPixel_GH28291_Regression) {
   OpTester test("Resize", 13);
 
   std::vector<float> roi{};
-  std::vector<float> scales{1.0f, 1.0f, 1.0f, 64.0f / 26.0f};
+  std::vector<int64_t> sizes{1, 1, 1, 6};
 
   test.AddAttribute("mode", "nearest");
   test.AddAttribute("coordinate_transformation_mode", "half_pixel");
   test.AddAttribute("nearest_mode", "round_prefer_ceil");
 
-  constexpr int64_t N = 1, C = 1, H = 1, W = 26;
-  std::vector<float> X(26);
-  for (int i = 0; i < 26; i++) X[i] = static_cast<float>(i);
+  constexpr int64_t N = 1, C = 1, H = 1, W = 20;
+  // X[i] = i / 19.0 so values are in [0, 1]
+  std::vector<float> X(20);
+  for (int i = 0; i < 20; i++) X[i] = static_cast<float>(i) / 19.0f;
 
   test.AddInput<float>("X", {N, C, H, W}, X);
   test.AddInput<float>("roi", {0}, roi);
-  test.AddInput<float>("scales", {4}, scales);
+  test.AddInput<float>("", {0}, std::vector<float>{});
+  test.AddInput<int64_t>("sizes", {4}, sizes);
 
+  // Expected source indices computed as:
+  //   x_original(i) = (i + 0.5) / (6/20) - 0.5
+  //   index = round_prefer_ceil(x_original)
+  // indices: [1, 5, 8, 11, 15, 18]
   std::vector<float> Y = {
-      0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 2.0f, 2.0f, 3.0f,
-      3.0f, 3.0f, 4.0f, 4.0f, 5.0f, 5.0f, 5.0f, 6.0f,
-      6.0f, 7.0f, 7.0f, 7.0f, 8.0f, 8.0f, 9.0f, 9.0f,
-      9.0f, 10.0f, 10.0f, 11.0f, 11.0f, 11.0f, 12.0f, 12.0f,
-      13.0f, 13.0f, 14.0f, 14.0f, 14.0f, 15.0f, 15.0f, 16.0f,
-      16.0f, 16.0f, 17.0f, 17.0f, 18.0f, 18.0f, 18.0f, 19.0f,
-      19.0f, 20.0f, 20.0f, 20.0f, 21.0f, 21.0f, 22.0f, 22.0f,
-      22.0f, 23.0f, 23.0f, 24.0f, 24.0f, 24.0f, 25.0f, 25.0f};
+      X[1], X[5], X[8], X[11], X[15], X[18]};
 
-  test.AddOutput<float>("Y", {N, C, H, 64}, Y);
+  test.AddOutput<float>("Y", {N, C, H, 6}, Y);
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", ExcludeTrtOnA100());
 }
 
@@ -3077,6 +3083,63 @@ TEST(ResizeOpTest, Axes_and_Size_18) {
 
   test.AddOutput<float>("Y", output_shape, Y);
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kQnnExecutionProvider});
+}
+
+// Coverage for GitHub issue #28292.
+// https://github.com/microsoft/onnxruntime/issues/28292
+//
+// The issue reports that ORT's cubic Resize with pytorch_half_pixel differs from
+// PyTorch's bicubic interpolation (max abs diff ~0.06). This is NOT a bug; it is a
+// spec difference:
+//
+// 1. ONNX spec default for cubic_coeff_a is -0.75 (PyTorch uses -0.5 internally).
+//    When the user explicitly sets -0.5, both use the same coefficient, so this is
+//    not the source of the discrepancy.
+//
+// 2. The difference comes from boundary handling during cubic interpolation. Cubic
+//    mode samples a 4-pixel neighborhood [floor(x)-1, floor(x)+2]. At boundaries,
+//    the ONNX spec clamps indices to [0, len-1]. PyTorch has its own boundary
+//    padding logic that can produce different weights for border pixels, especially
+//    when downscaling (8->4) where x_original for output 0 is 0.5, requiring sampling
+//    of the out-of-bounds index -1 (clamped to 0 in ORT).
+//
+// This test documents ORT's correct-per-ONNX-spec behavior for this configuration.
+TEST(ResizeOpTest, ResizeOpCubicDownSample_PytorchHalfPixel_GH28292_SpecDifference) {
+  OpTester test("Resize", 18);
+
+  test.AddAttribute("mode", "cubic");
+  test.AddAttribute("coordinate_transformation_mode", "pytorch_half_pixel");
+  test.AddAttribute<float>("cubic_coeff_a", -0.5f);
+  test.AddAttribute<int64_t>("antialias", 0LL);
+
+  constexpr int64_t N = 1, C = 1, H = 8, W = 8;
+  // Deterministic input: use a simple sequential pattern
+  std::vector<float> X(64);
+  for (int i = 0; i < 64; i++) X[i] = static_cast<float>(i) / 63.0f;
+
+  std::vector<float> scales{1.0f, 1.0f, 0.5f, 0.5f};
+
+  test.AddInput<float>("X", {N, C, H, W}, X);
+  test.AddInput<float>("roi", {0}, std::vector<float>{});
+  test.AddInput<float>("scales", {4}, scales);
+
+  // Expected values computed by ORT CPU (correct per ONNX spec).
+  // These will differ from PyTorch's output due to boundary handling differences.
+  // Output shape: [1, 1, 4, 4]
+  std::vector<float> Y(16);
+  // Row 0: pixels at y_orig=0.5, x_orig={0.5, 2.5, 4.5, 6.5}
+  // Row 1: y_orig=2.5, Row 2: y_orig=4.5, Row 3: y_orig=6.5
+  // Computed from ONNX spec cubic interpolation with boundary clamping:
+  Y = {0.06250000f, 0.09523810f, 0.12698413f, 0.15972222f,
+       0.32440478f, 0.35714287f, 0.38888890f, 0.42162699f,
+       0.57837301f, 0.61111116f, 0.64285719f, 0.67559528f,
+       0.84027779f, 0.87301588f, 0.90476191f, 0.93750000f};
+
+  test.AddOutput<float>("Y", {N, C, 4, 4}, Y);
+  // Use relaxed tolerance since we are documenting the boundary behavior
+  test.SetOutputRelErr("Y", 1e-4f);
+  test.SetOutputAbsErr("Y", 1e-4f);
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", ExcludeTrtOnA100());
 }
 
 TEST(ResizeOpTest, Axes_and_Scales_CountMismatch_18) {

--- a/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
@@ -2577,7 +2577,6 @@ TEST(ResizeOpTest, Antialias_NhwcBilinear) {
                           35.074074f, 75.07407f, 115.07407f,
                           36.590908f, 76.59091f, 116.59091f};
 
-  // NHWC bilinear antialias is now supported on CUDA
   TestAntialiasing({{"mode", "linear"}, {"exclude_outside", "1"}}, {1, 5, 8, 3}, X, {1, 4, 5, 3}, Y);
 }
 


### PR DESCRIPTION
This pull request improves the robustness and correctness of the upsampling code in ONNX Runtime, especially for anti-aliased linear and trilinear upsampling on the CPU. The changes focus on safer handling of large tensor dimensions, improved memory safety, and code clarity for interpolation and weight calculation. The most important changes are grouped below.

**Dimension and Overflow Handling:**

* Added overflow checks for multiplication of large tensor dimensions to prevent integer overflows during output size calculations, using a new `checked_mul_int64` lambda. [[1]](diffhunk://#diff-13eb8371a91e6fab62e63ecc46583049f97e8acc244af6ce8cc1c981d1d72dd3R1106-R1118) [[2]](diffhunk://#diff-13eb8371a91e6fab62e63ecc46583049f97e8acc244af6ce8cc1c981d1d72dd3R1292-R1309)
* Ensured all tensor dimensions are validated to fit within the `int32_t` range before narrowing, improving safety for large tensors. [[1]](diffhunk://#diff-13eb8371a91e6fab62e63ecc46583049f97e8acc244af6ce8cc1c981d1d72dd3R1133-R1143) [[2]](diffhunk://#diff-13eb8371a91e6fab62e63ecc46583049f97e8acc244af6ce8cc1c981d1d72dd3L1131-R1234)

**Anti-Alias Upsampling Refactor:**

* Refactored the anti-alias upsampling filter setup to use a new `InterpolationBound` struct for per-pixel coordinate ranges, replacing the previous flat vector approach. This improves code clarity and reduces indexing errors. [[1]](diffhunk://#diff-051136817a71a65f4763b9f5c6e02c15f9a6aa39189d952717f4f36c6490ee38R25-R35) [[2]](diffhunk://#diff-051136817a71a65f4763b9f5c6e02c15f9a6aa39189d952717f4f36c6490ee38L126-R159) [[3]](diffhunk://#diff-051136817a71a65f4763b9f5c6e02c15f9a6aa39189d952717f4f36c6490ee38L155-L208)
* Updated all interpolation and extrapolation routines to use the new `bounds` structure, improving readability and maintainability. [[1]](diffhunk://#diff-051136817a71a65f4763b9f5c6e02c15f9a6aa39189d952717f4f36c6490ee38L272-R290) [[2]](diffhunk://#diff-051136817a71a65f4763b9f5c6e02c15f9a6aa39189d952717f4f36c6490ee38L341-R353) [[3]](diffhunk://#diff-051136817a71a65f4763b9f5c6e02c15f9a6aa39189d952717f4f36c6490ee38L391-R400)
* Imlpements CUDA NHWC cubic antialias support

**Memory and Type Safety:**

* Improved buffer management and type safety in filter weight calculation, including more robust normalization and quantization for int8/uint8 types.
* Fixed a minor logic bug in extrapolation handling by ensuring the loop is only entered if there are out-of-bound indices.

**General Code Improvements:**

* Added missing `<limits>` include and replaced some magic numbers with named variables for clarity. [[1]](diffhunk://#diff-13eb8371a91e6fab62e63ecc46583049f97e8acc244af6ce8cc1c981d1d72dd3R6) [[2]](diffhunk://#diff-13eb8371a91e6fab62e63ecc46583049f97e8acc244af6ce8cc1c981d1d72dd3L1198-R1257) [[3]](diffhunk://#diff-13eb8371a91e6fab62e63ecc46583049f97e8acc244af6ce8cc1c981d1d72dd3L1221-R1272)

These changes together make the upsampling code more robust, especially for large or edge-case tensors, and improve maintainability for future development.