### PR TITLE
Skip test_reduce_max/min_empty_set_cuda in backend test filters

### DIFF
--- a/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
+++ b/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
@@ -290,6 +290,8 @@
         "^test_reduce_log_sum_empty_set_expanded_cuda",
         "^test_reduce_log_sum_exp_empty_set_cuda",
         "^test_reduce_log_sum_exp_empty_set_expanded_cuda",
+        "^test_reduce_max_empty_set_cuda",
+        "^test_reduce_min_empty_set_cuda",
         "^test_reduce_prod_empty_set_cuda",
         "^test_reduce_sum_empty_set_cuda",
         "^test_reduce_sum_square_empty_set_cuda",


### PR DESCRIPTION
### Description
Skip `test_reduce_max_empty_set_cuda` and `test_reduce_min_empty_set_cuda` in the ONNX backend test filters for the CUDA EP.

### Motivation and Context
These two tests fail in the Windows GPU CUDA CI Pipeline with:

```
onnxruntime.capi.onnxruntime_pybind11_state.RuntimeException: [ONNXRuntimeError] : 6 : RUNTIME_EXCEPTION :
Non-zero status code returned while running ReduceMax/ReduceMin node.
```

The CUDA `ReduceMax` / `ReduceMin` kernels do not currently handle empty-set inputs. Skipping these tests matches the pre-existing skips for other `reduce_*_empty_set_cuda` tests in the same file (e.g. `test_reduce_log_sum_empty_set_cuda`, `test_reduce_sum_empty_set_cuda`, `test_reduce_prod_empty_set_cuda`) until the CUDA kernels add empty-set support.
