### PR TITLE
Use abseil for readable POSIX stack traces in debug builds

### DIFF
--- a/onnxruntime/core/platform/posix/stacktrace.cc
+++ b/onnxruntime/core/platform/posix/stacktrace.cc
@@ -11,6 +11,9 @@
 #include <spawn.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <cerrno>
+#include <cinttypes>
+#include <climits>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -21,7 +24,12 @@
 #include "absl/debugging/stacktrace.h"
 #include "absl/debugging/symbolize.h"
 
+#ifdef __APPLE__
+#include <crt_externs.h>
+#define environ (*_NSGetEnviron())
+#else
 extern char** environ;
+#endif
 
 namespace {
 
@@ -30,12 +38,34 @@ inline int GetAddr2LineEnv() {
   if (val == nullptr) {
     return 0;
   }
-  return atoi(val);
+  char* end = nullptr;
+  long parsed = strtol(val, &end, 10);
+  if (end == val || parsed < 0 || parsed > INT_MAX) {
+    return 0;
+  }
+  return static_cast<int>(parsed);
 }
 
 int GetAddr2LineCount() {
   static const int count = GetAddr2LineEnv();
   return count;
+}
+
+bool CreateCloseOnExecPipe(int pipe_fds[2]) {
+  if (pipe(pipe_fds) != 0) {
+    return false;
+  }
+
+  for (int i = 0; i < 2; ++i) {
+    const int flags = fcntl(pipe_fds[i], F_GETFD);
+    if (flags == -1 || fcntl(pipe_fds[i], F_SETFD, flags | FD_CLOEXEC) == -1) {
+      close(pipe_fds[0]);
+      close(pipe_fds[1]);
+      return false;
+    }
+  }
+
+  return true;
 }
 
 // Resolve file offsets to file:line using addr2line, grouped by binary.
@@ -70,7 +100,7 @@ std::unordered_map<void*, std::string> ResolveWithAddr2Line(
     offset_strs.reserve(frames.size());
     for (const auto& frame : frames) {
       char buf[32];
-      snprintf(buf, sizeof(buf), "0x%lx", static_cast<unsigned long>(frame.offset));
+      snprintf(buf, sizeof(buf), "0x%" PRIxPTR, frame.offset);
       offset_strs.emplace_back(buf);
     }
 
@@ -87,14 +117,28 @@ std::unordered_map<void*, std::string> ResolveWithAddr2Line(
 
     // Create a pipe for reading addr2line's stdout.
     int pipe_fds[2];
-    if (pipe(pipe_fds) != 0) continue;
+    if (!CreateCloseOnExecPipe(pipe_fds)) continue;
 
     posix_spawn_file_actions_t actions;
-    posix_spawn_file_actions_init(&actions);
-    posix_spawn_file_actions_adddup2(&actions, pipe_fds[1], STDOUT_FILENO);
-    posix_spawn_file_actions_addclose(&actions, pipe_fds[0]);
+    int rc = posix_spawn_file_actions_init(&actions);
+    if (rc != 0) {
+      close(pipe_fds[0]);
+      close(pipe_fds[1]);
+      continue;
+    }
+
+    bool actions_ok = true;
+    actions_ok &= posix_spawn_file_actions_adddup2(&actions, pipe_fds[1], STDOUT_FILENO) == 0;
+    actions_ok &= posix_spawn_file_actions_addclose(&actions, pipe_fds[0]) == 0;
     // Redirect stderr to /dev/null to suppress error messages.
-    posix_spawn_file_actions_addopen(&actions, STDERR_FILENO, "/dev/null", O_WRONLY, 0);
+    actions_ok &= posix_spawn_file_actions_addopen(&actions, STDERR_FILENO, "/dev/null", O_WRONLY, 0) == 0;
+
+    if (!actions_ok) {
+      posix_spawn_file_actions_destroy(&actions);
+      close(pipe_fds[0]);
+      close(pipe_fds[1]);
+      continue;
+    }
 
     pid_t pid;
     int spawn_ret = posix_spawnp(&pid, "addr2line", &actions, nullptr, argv.data(), environ);
@@ -110,10 +154,13 @@ std::unordered_map<void*, std::string> ResolveWithAddr2Line(
     FILE* fp = fdopen(pipe_fds[0], "r");
     if (!fp) {
       close(pipe_fds[0]);
-      waitpid(pid, nullptr, 0);
+      while (waitpid(pid, nullptr, 0) == -1 && errno == EINTR) {
+      }
       continue;
     }
 
+    // We intentionally do not use -f/-i so output remains 1 line per address.
+    // Adding those flags would break the 1:1 parsing below.
     char line_buf[1024];
     size_t frame_idx = 0;
     while (fgets(line_buf, sizeof(line_buf), fp) && frame_idx < frames.size()) {
@@ -122,14 +169,15 @@ std::unordered_map<void*, std::string> ResolveWithAddr2Line(
       if (len > 0 && line_buf[len - 1] == '\n') line_buf[len - 1] = '\0';
 
       std::string resolved(line_buf);
-      // addr2line returns "?? ??:0" or similar for unknown frames — skip those
-      if (resolved.find("??") == std::string::npos) {
+      // addr2line returns "??:0" or "??:?" for unknown frames, so skip those.
+      if (resolved != "??:0" && resolved != "??:?" && resolved.substr(0, 2) != "??") {
         result[frames[frame_idx].addr] = resolved;
       }
       ++frame_idx;
     }
     fclose(fp);
-    waitpid(pid, nullptr, 0);
+    while (waitpid(pid, nullptr, 0) == -1 && errno == EINTR) {
+    }
   }
 
   return result;
@@ -156,6 +204,7 @@ std::vector<std::string> GetStackTrace() {
   std::unordered_map<void*, std::string> resolved;
   int count = GetAddr2LineCount();
   if (count > 0) {
+    // Only resolve the top N frames to limit addr2line overhead on large binaries.
     resolved = ResolveWithAddr2Line(addresses, std::min(depth, count));
   }
 

--- a/onnxruntime/core/platform/posix/stacktrace.cc
+++ b/onnxruntime/core/platform/posix/stacktrace.cc
@@ -1,19 +1,20 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "core/common/common.h"
 #include <vector>
 
+#include "core/common/common.h"
+
 #if !defined(NDEBUG) && !defined(__ANDROID__) && !defined(__wasm__) && !defined(_OPSCHEMA_LIB_) && !defined(_AIX)
-#include <cstdlib>
-#include <cstdio>
-#include <cstring>
 #include <dlfcn.h>
 #include <fcntl.h>
-#include <sstream>
 #include <spawn.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <sstream>
 #include <unordered_map>
 #include "absl/debugging/stacktrace.h"
 #include "absl/debugging/symbolize.h"

--- a/onnxruntime/core/platform/posix/stacktrace.cc
+++ b/onnxruntime/core/platform/posix/stacktrace.cc
@@ -3,44 +3,114 @@
 
 #include "core/common/common.h"
 
-#if !defined(__ANDROID__) && !defined(__wasm__) && !defined(_OPSCHEMA_LIB_) && !defined(_AIX)
-#include <execinfo.h>
-#endif
 #include <vector>
+
+#if !defined(NDEBUG) && !defined(__ANDROID__) && !defined(__wasm__) && !defined(_OPSCHEMA_LIB_) && !defined(_AIX)
+#include <cstdio>
+#include <cstring>
+#include <dlfcn.h>
+#include <sstream>
+#include <unordered_map>
+#include "absl/debugging/stacktrace.h"
+#include "absl/debugging/symbolize.h"
+
+namespace {
+
+// Resolve file offsets to file:line using addr2line, grouped by binary.
+// Returns a map from original address to "file:line" string.
+std::unordered_map<void*, std::string> ResolveWithAddr2Line(
+    void** addresses, int depth) {
+  std::unordered_map<void*, std::string> result;
+
+  // Group addresses by their containing binary/shared-object.
+  // Key: binary path, Value: vector of (address, file_offset)
+  struct FrameInfo {
+    void* addr;
+    uintptr_t offset;
+  };
+  std::unordered_map<std::string, std::vector<FrameInfo>> groups;
+
+  for (int i = 0; i < depth; ++i) {
+    Dl_info info;
+    if (dladdr(addresses[i], &info) && info.dli_fname) {
+      uintptr_t offset = reinterpret_cast<uintptr_t>(addresses[i]) -
+                         reinterpret_cast<uintptr_t>(info.dli_fbase);
+      groups[info.dli_fname].push_back({addresses[i], offset});
+    }
+  }
+
+  // Call addr2line once per binary with all offsets in batch.
+  for (const auto& [binary, frames] : groups) {
+    // Use addr2line without -f/-C/-p to get just "file:line" per address.
+    std::string cmd = "addr2line -e " + binary;
+    for (const auto& frame : frames) {
+      char buf[32];
+      snprintf(buf, sizeof(buf), " 0x%lx", static_cast<unsigned long>(frame.offset));
+      cmd += buf;
+    }
+    cmd += " 2>/dev/null";
+
+    FILE* pipe = popen(cmd.c_str(), "r");
+    if (!pipe) continue;
+
+    // Read one line per address from addr2line output.
+    char line_buf[1024];
+    size_t frame_idx = 0;
+    while (fgets(line_buf, sizeof(line_buf), pipe) && frame_idx < frames.size()) {
+      // Remove trailing newline
+      size_t len = strlen(line_buf);
+      if (len > 0 && line_buf[len - 1] == '\n') line_buf[len - 1] = '\0';
+
+      std::string resolved(line_buf);
+      // addr2line returns "?? ??:0" or similar for unknown frames — skip those
+      if (resolved.find("??") == std::string::npos) {
+        result[frames[frame_idx].addr] = resolved;
+      }
+      ++frame_idx;
+    }
+    pclose(pipe);
+  }
+
+  return result;
+}
+
+}  // namespace
+#endif
 
 namespace onnxruntime {
 
 std::vector<std::string> GetStackTrace() {
   std::vector<std::string> stack;
 
-#if !defined(NDEBUG) && !defined(__ANDROID__) && !defined(__wasm__) && !defined(_OPSCHEMA_LIB_)
-  constexpr int kCallstackLimit = 64;  // Maximum depth of callstack
+#if !defined(NDEBUG) && !defined(__ANDROID__) && !defined(__wasm__) && !defined(_OPSCHEMA_LIB_) && !defined(_AIX)
+  constexpr int kCallstackLimit = 64;
+  void* addresses[kCallstackLimit];
 
-  void* array[kCallstackLimit];
-  char** strings = nullptr;
+  // skip_count=2 hides GetStackTrace and its caller (ORT_ENFORCE macro internals)
+  int depth = absl::GetStackTrace(addresses, kCallstackLimit, /*skip_count=*/2);
+  stack.reserve(depth);
 
-  int size = backtrace(array, kCallstackLimit);
-  stack.reserve(size);
-  strings = backtrace_symbols(array, size);
+  // Attempt to resolve file:line via addr2line (best-effort, debug builds only).
+  auto resolved = ResolveWithAddr2Line(addresses, depth);
 
-  // NOTE: To get meaningful info from the output, addr2line (or atos on osx) would need to be used.
-  // See https://gist.github.com/jvranish/4441299 for an example.
-  //
-  // To manually translate the output, use the value in the '()' after the executable name with addr2line
-  // e.g.
-  //   Stacktrace:
-  //    /home/me/src/github/onnxruntime/build/Linux/Debug/onnxruntime_test_all(+0x3f46cc) [0x559543faf6cc]
-  //
-  // >addr2line -f -C -e /home/me/src/github/onnxruntime/build/Linux/Debug/onnxruntime_test_all  +0x3f46cc
+  for (int i = 0; i < depth; ++i) {
+    std::ostringstream oss;
+    char symbol[1024];
+    if (absl::Symbolize(addresses[i], symbol, sizeof(symbol))) {
+      oss << symbol;
+    } else {
+      oss << "[unknown]";
+    }
 
-  // hide GetStackTrace so the output starts with the 'real' location
-  constexpr int start_frame = 1;
-  for (int i = start_frame; i < size; i++) {
-    stack.push_back(strings[i]);
+    // Append file:line if resolved, otherwise the raw address as fallback.
+    auto it = resolved.find(addresses[i]);
+    if (it != resolved.end()) {
+      oss << " at " << it->second;
+    } else {
+      oss << " [" << addresses[i] << "]";
+    }
+    stack.push_back(oss.str());
   }
-
-  free(strings);
-
 #endif
 
   return stack;

--- a/onnxruntime/core/platform/posix/stacktrace.cc
+++ b/onnxruntime/core/platform/posix/stacktrace.cc
@@ -15,6 +15,8 @@
 #include <cstdlib>
 #include <cstring>
 #include <sstream>
+#include <string>
+#include <algorithm>
 #include <unordered_map>
 #include "absl/debugging/stacktrace.h"
 #include "absl/debugging/symbolize.h"

--- a/onnxruntime/core/platform/posix/stacktrace.cc
+++ b/onnxruntime/core/platform/posix/stacktrace.cc
@@ -17,6 +17,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <algorithm>
@@ -33,6 +34,122 @@ extern char** environ;
 
 namespace {
 
+// RAII wrapper for a file descriptor: closes it on scope exit unless released.
+class ScopedFd {
+ public:
+  ScopedFd() = default;
+  explicit ScopedFd(int fd) : fd_(fd) {}
+  ScopedFd(const ScopedFd&) = delete;
+  ScopedFd& operator=(const ScopedFd&) = delete;
+  ScopedFd(ScopedFd&& other) noexcept : fd_(other.fd_) { other.fd_ = -1; }
+  ScopedFd& operator=(ScopedFd&& other) noexcept {
+    if (this != &other) {
+      Reset();
+      fd_ = other.fd_;
+      other.fd_ = -1;
+    }
+    return *this;
+  }
+  ~ScopedFd() { Reset(); }
+
+  int get() const { return fd_; }
+  void Reset() {
+    if (fd_ != -1) {
+      close(fd_);
+      fd_ = -1;
+    }
+  }
+  // Relinquish ownership; the caller becomes responsible for closing.
+  int Release() {
+    int fd = fd_;
+    fd_ = -1;
+    return fd;
+  }
+
+ private:
+  int fd_ = -1;
+};
+
+// RAII wrapper for posix_spawn_file_actions_t.
+class ScopedSpawnFileActions {
+ public:
+  ScopedSpawnFileActions() = default;
+  ScopedSpawnFileActions(const ScopedSpawnFileActions&) = delete;
+  ScopedSpawnFileActions& operator=(const ScopedSpawnFileActions&) = delete;
+  ~ScopedSpawnFileActions() {
+    if (initialized_) {
+      posix_spawn_file_actions_destroy(&actions_);
+    }
+  }
+
+  int Init() {
+    const int rc = posix_spawn_file_actions_init(&actions_);
+    initialized_ = (rc == 0);
+    return rc;
+  }
+  posix_spawn_file_actions_t* get() { return &actions_; }
+
+ private:
+  posix_spawn_file_actions_t actions_{};
+  bool initialized_ = false;
+};
+
+// RAII wrapper for a FILE* obtained from fdopen.
+class ScopedFile {
+ public:
+  explicit ScopedFile(FILE* fp) : fp_(fp) {}
+  ScopedFile(const ScopedFile&) = delete;
+  ScopedFile& operator=(const ScopedFile&) = delete;
+  ~ScopedFile() {
+    if (fp_ != nullptr) {
+      fclose(fp_);
+    }
+  }
+  FILE* get() const { return fp_; }
+
+ private:
+  FILE* fp_;
+};
+
+// RAII wrapper that reaps a child process on scope exit and exposes its status.
+class ScopedChild {
+ public:
+  explicit ScopedChild(pid_t pid) : pid_(pid) {}
+  ScopedChild(const ScopedChild&) = delete;
+  ScopedChild& operator=(const ScopedChild&) = delete;
+  ~ScopedChild() { Wait(); }
+
+  // Wait for the child and cache its exit status. Safe to call more than once.
+  void Wait() {
+    if (pid_ == -1) {
+      return;
+    }
+    int status = 0;
+    while (waitpid(pid_, &status, 0) == -1 && errno == EINTR) {
+    }
+    status_ = status;
+    pid_ = -1;
+  }
+
+  // Returns true only if the child exited normally with code 0.
+  bool ExitedCleanly() {
+    Wait();
+    return status_.has_value() && WIFEXITED(*status_) && WEXITSTATUS(*status_) == 0;
+  }
+
+ private:
+  pid_t pid_;
+  std::optional<int> status_;
+};
+
+// ORT_ADDR2LINE controls optional source file:line resolution for stack frames.
+// It is read as a non-negative integer N:
+//   - unset or 0 : disabled (default). Only symbol names from absl::Symbolize
+//                  are shown and no subprocess is spawned.
+//   - N > 0      : resolve file:line for the top N frames by invoking the
+//                  external `addr2line` tool (part of binutils). This is opt-in
+//                  because spawning addr2line and parsing DWARF can be very slow
+//                  on large debug binaries, and addr2line may not be installed.
 inline int GetAddr2LineEnv() {
   const char* val = std::getenv("ORT_ADDR2LINE");
   if (val == nullptr) {
@@ -85,7 +202,12 @@ std::unordered_map<void*, std::string> ResolveWithAddr2Line(
   for (int i = 0; i < depth; ++i) {
     Dl_info info;
     if (dladdr(addresses[i], &info) && info.dli_fname) {
-      uintptr_t offset = reinterpret_cast<uintptr_t>(addresses[i]) -
+      // Each captured address is a return address pointing just past the call
+      // instruction. Subtract 1 so addr2line resolves the call site itself
+      // rather than the following statement (which may be a different source
+      // line or even the next function). The map is still keyed by the original
+      // address so it matches the absl::Symbolize lookup in GetStackTrace.
+      uintptr_t offset = reinterpret_cast<uintptr_t>(addresses[i]) - 1 -
                          reinterpret_cast<uintptr_t>(info.dli_fbase);
       groups[info.dli_fname].push_back({addresses[i], offset});
     }
@@ -104,7 +226,7 @@ std::unordered_map<void*, std::string> ResolveWithAddr2Line(
       offset_strs.emplace_back(buf);
     }
 
-    // Build raw argv array for execvp. All pointers reference stable strings above.
+    // Build raw argv array for addr2line. All pointers reference stable strings above.
     std::vector<char*> argv;
     argv.reserve(3 + frames.size() + 1);
     argv.push_back(const_cast<char*>("addr2line"));
@@ -115,55 +237,51 @@ std::unordered_map<void*, std::string> ResolveWithAddr2Line(
     }
     argv.push_back(nullptr);
 
-    // Create a pipe for reading addr2line's stdout.
+    // Create a pipe for reading addr2line's stdout. RAII wrappers below own the
+    // descriptors, spawn file actions, FILE*, and child process so each early
+    // 'continue' releases everything without manual cleanup calls.
     int pipe_fds[2];
     if (!CreateCloseOnExecPipe(pipe_fds)) continue;
+    ScopedFd read_fd(pipe_fds[0]);
+    ScopedFd write_fd(pipe_fds[1]);
 
-    posix_spawn_file_actions_t actions;
-    int rc = posix_spawn_file_actions_init(&actions);
-    if (rc != 0) {
-      close(pipe_fds[0]);
-      close(pipe_fds[1]);
+    ScopedSpawnFileActions actions;
+    if (actions.Init() != 0) continue;
+
+    if (posix_spawn_file_actions_adddup2(actions.get(), write_fd.get(), STDOUT_FILENO) != 0 ||
+        posix_spawn_file_actions_addclose(actions.get(), read_fd.get()) != 0 ||
+        // Redirect stderr to /dev/null to suppress error messages.
+        posix_spawn_file_actions_addopen(actions.get(), STDERR_FILENO, "/dev/null", O_WRONLY, 0) != 0) {
       continue;
     }
 
-    bool actions_ok = true;
-    actions_ok &= posix_spawn_file_actions_adddup2(&actions, pipe_fds[1], STDOUT_FILENO) == 0;
-    actions_ok &= posix_spawn_file_actions_addclose(&actions, pipe_fds[0]) == 0;
-    // Redirect stderr to /dev/null to suppress error messages.
-    actions_ok &= posix_spawn_file_actions_addopen(&actions, STDERR_FILENO, "/dev/null", O_WRONLY, 0) == 0;
+    pid_t pid = -1;
+    const int spawn_ret = posix_spawnp(&pid, "addr2line", actions.get(), nullptr, argv.data(), environ);
 
-    if (!actions_ok) {
-      posix_spawn_file_actions_destroy(&actions);
-      close(pipe_fds[0]);
-      close(pipe_fds[1]);
-      continue;
-    }
+    // Close the write end in the parent so we observe EOF once addr2line exits.
+    write_fd.Reset();
 
-    pid_t pid;
-    int spawn_ret = posix_spawnp(&pid, "addr2line", &actions, nullptr, argv.data(), environ);
-    posix_spawn_file_actions_destroy(&actions);
-    close(pipe_fds[1]);
+    // posix_spawnp fails only when the child cannot be created. A missing
+    // addr2line still spawns but the child exits 127; that is handled by the
+    // ExitedCleanly() check below, which discards any output on failure.
+    if (spawn_ret != 0) continue;
+    ScopedChild child(pid);
 
-    if (spawn_ret != 0) {
-      close(pipe_fds[0]);
-      continue;
-    }
+    FILE* raw_fp = fdopen(read_fd.get(), "r");
+    if (raw_fp == nullptr) continue;
+    read_fd.Release();  // fp now owns the descriptor.
+    ScopedFile fp(raw_fp);
 
-    // Read one line per address from addr2line output.
-    FILE* fp = fdopen(pipe_fds[0], "r");
-    if (!fp) {
-      close(pipe_fds[0]);
-      while (waitpid(pid, nullptr, 0) == -1 && errno == EINTR) {
-      }
-      continue;
-    }
+    // Read into a local map and only commit it if addr2line exited cleanly, so a
+    // failed run (e.g., addr2line missing, or an unreadable binary) contributes
+    // no partial or garbage results.
+    std::unordered_map<void*, std::string> binary_result;
 
     // We intentionally do not use -f/-i so output remains 1 line per address.
     // Adding those flags would break the 1:1 parsing below.
     char line_buf[1024];
     size_t frame_idx = 0;
-    while (fgets(line_buf, sizeof(line_buf), fp) && frame_idx < frames.size()) {
+    while (fgets(line_buf, sizeof(line_buf), fp.get()) && frame_idx < frames.size()) {
       // Remove trailing newline
       size_t len = strlen(line_buf);
       if (len > 0 && line_buf[len - 1] == '\n') line_buf[len - 1] = '\0';
@@ -171,12 +289,16 @@ std::unordered_map<void*, std::string> ResolveWithAddr2Line(
       std::string resolved(line_buf);
       // addr2line returns "??:0" or "??:?" for unknown frames, so skip those.
       if (resolved != "??:0" && resolved != "??:?" && resolved.substr(0, 2) != "??") {
-        result[frames[frame_idx].addr] = resolved;
+        binary_result[frames[frame_idx].addr] = std::move(resolved);
       }
       ++frame_idx;
     }
-    fclose(fp);
-    while (waitpid(pid, nullptr, 0) == -1 && errno == EINTR) {
+
+    // Reap the child and only trust the output if it exited with status 0.
+    if (child.ExitedCleanly()) {
+      for (auto& kv : binary_result) {
+        result.insert(std::move(kv));
+      }
     }
   }
 

--- a/onnxruntime/core/platform/posix/stacktrace.cc
+++ b/onnxruntime/core/platform/posix/stacktrace.cc
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 #include "core/common/common.h"
-
 #include <vector>
 
 #if !defined(NDEBUG) && !defined(__ANDROID__) && !defined(__wasm__) && !defined(_OPSCHEMA_LIB_) && !defined(_AIX)
+#include <cstdlib>
 #include <cstdio>
 #include <cstring>
 #include <dlfcn.h>
@@ -15,6 +15,20 @@
 #include "absl/debugging/symbolize.h"
 
 namespace {
+
+inline int GetAddr2LineEnv() {
+  const char* val = std::getenv("ORT_ADDR2LINE");
+  if (val == nullptr) {
+    return 0;
+  }
+  return atoi(val);
+}
+
+// Check once whether ORT_ENABLE_ADDR2LINE is set.
+int GetAddr2LineCount() {
+  static const int count = GetAddr2LineEnv();
+  return count;
+}
 
 // Resolve file offsets to file:line using addr2line, grouped by binary.
 // Returns a map from original address to "file:line" string.
@@ -90,8 +104,14 @@ std::vector<std::string> GetStackTrace() {
   int depth = absl::GetStackTrace(addresses, kCallstackLimit, /*skip_count=*/2);
   stack.reserve(depth);
 
-  // Attempt to resolve file:line via addr2line (best-effort, debug builds only).
-  auto resolved = ResolveWithAddr2Line(addresses, depth);
+  // Resolve file:line via addr2line only when explicitly opted in via
+  // ORT_ENABLE_ADDR2LINE=1, since it spawns external processes and can be
+  // very slow on large debug binaries.
+  std::unordered_map<void*, std::string> resolved;
+  int count = GetAddr2LineCount();
+  if (count > 0) {
+    resolved = ResolveWithAddr2Line(addresses, std::min(depth, count));
+  }
 
   for (int i = 0; i < depth; ++i) {
     std::ostringstream oss;
@@ -102,7 +122,6 @@ std::vector<std::string> GetStackTrace() {
       oss << "[unknown]";
     }
 
-    // Append file:line if resolved, otherwise the raw address as fallback.
     auto it = resolved.find(addresses[i]);
     if (it != resolved.end()) {
       oss << " at " << it->second;

--- a/onnxruntime/core/platform/posix/stacktrace.cc
+++ b/onnxruntime/core/platform/posix/stacktrace.cc
@@ -24,6 +24,7 @@
 #include <unordered_map>
 #include "absl/debugging/stacktrace.h"
 #include "absl/debugging/symbolize.h"
+#include "core/platform/scoped_resource.h"
 
 #ifdef __APPLE__
 #include <crt_externs.h>
@@ -34,41 +35,23 @@ extern char** environ;
 
 namespace {
 
-// RAII wrapper for a file descriptor: closes it on scope exit unless released.
-class ScopedFd {
- public:
-  ScopedFd() = default;
-  explicit ScopedFd(int fd) : fd_(fd) {}
-  ScopedFd(const ScopedFd&) = delete;
-  ScopedFd& operator=(const ScopedFd&) = delete;
-  ScopedFd(ScopedFd&& other) noexcept : fd_(other.fd_) { other.fd_ = -1; }
-  ScopedFd& operator=(ScopedFd&& other) noexcept {
-    if (this != &other) {
-      Reset();
-      fd_ = other.fd_;
-      other.fd_ = -1;
-    }
-    return *this;
-  }
-  ~ScopedFd() { Reset(); }
-
-  int get() const { return fd_; }
-  void Reset() {
-    if (fd_ != -1) {
-      close(fd_);
-      fd_ = -1;
-    }
-  }
-  // Relinquish ownership; the caller becomes responsible for closing.
-  int Release() {
-    int fd = fd_;
-    fd_ = -1;
-    return fd;
-  }
-
- private:
-  int fd_ = -1;
+// Traits for a POSIX file descriptor, used with onnxruntime::ScopedResource to
+// close it on scope exit unless released.
+struct FdTraits {
+  using Handle = int;
+  static Handle GetInvalidHandleValue() noexcept { return -1; }
+  static void CleanUp(Handle fd) noexcept { close(fd); }
 };
+using ScopedFd = onnxruntime::ScopedResource<FdTraits>;
+
+// Traits for a FILE* obtained from fdopen, used with onnxruntime::ScopedResource
+// to fclose it on scope exit.
+struct FileTraits {
+  using Handle = FILE*;
+  static Handle GetInvalidHandleValue() noexcept { return nullptr; }
+  static void CleanUp(Handle fp) noexcept { fclose(fp); }
+};
+using ScopedFile = onnxruntime::ScopedResource<FileTraits>;
 
 // RAII wrapper for posix_spawn_file_actions_t.
 class ScopedSpawnFileActions {
@@ -92,23 +75,6 @@ class ScopedSpawnFileActions {
  private:
   posix_spawn_file_actions_t actions_{};
   bool initialized_ = false;
-};
-
-// RAII wrapper for a FILE* obtained from fdopen.
-class ScopedFile {
- public:
-  explicit ScopedFile(FILE* fp) : fp_(fp) {}
-  ScopedFile(const ScopedFile&) = delete;
-  ScopedFile& operator=(const ScopedFile&) = delete;
-  ~ScopedFile() {
-    if (fp_ != nullptr) {
-      fclose(fp_);
-    }
-  }
-  FILE* get() const { return fp_; }
-
- private:
-  FILE* fp_;
 };
 
 // RAII wrapper that reaps a child process on scope exit and exposes its status.
@@ -257,8 +223,8 @@ std::unordered_map<void*, std::string> ResolveWithAddr2Line(
     ScopedSpawnFileActions actions;
     if (actions.Init() != 0) continue;
 
-    if (posix_spawn_file_actions_adddup2(actions.get(), write_fd.get(), STDOUT_FILENO) != 0 ||
-        posix_spawn_file_actions_addclose(actions.get(), read_fd.get()) != 0 ||
+    if (posix_spawn_file_actions_adddup2(actions.get(), write_fd.Get(), STDOUT_FILENO) != 0 ||
+        posix_spawn_file_actions_addclose(actions.get(), read_fd.Get()) != 0 ||
         // Redirect stderr to /dev/null to suppress error messages.
         posix_spawn_file_actions_addopen(actions.get(), STDERR_FILENO, "/dev/null", O_WRONLY, 0) != 0) {
       continue;
@@ -277,7 +243,7 @@ std::unordered_map<void*, std::string> ResolveWithAddr2Line(
     if (spawn_ret != 0) continue;
     ScopedChild child(pid);
 
-    FILE* raw_fp = fdopen(read_fd.get(), "r");
+    FILE* raw_fp = fdopen(read_fd.Get(), "r");
     if (raw_fp == nullptr) continue;
     read_fd.Release();  // fp now owns the descriptor.
     ScopedFile fp(raw_fp);
@@ -291,7 +257,7 @@ std::unordered_map<void*, std::string> ResolveWithAddr2Line(
     // Adding those flags would break the 1:1 parsing below.
     char line_buf[1024];
     size_t frame_idx = 0;
-    while (fgets(line_buf, sizeof(line_buf), fp.get()) && frame_idx < frames.size()) {
+    while (fgets(line_buf, sizeof(line_buf), fp.Get()) && frame_idx < frames.size()) {
       // Remove trailing newline
       size_t len = strlen(line_buf);
       if (len > 0 && line_buf[len - 1] == '\n') line_buf[len - 1] = '\0';
@@ -316,7 +282,7 @@ std::unordered_map<void*, std::string> ResolveWithAddr2Line(
 }
 
 }  // namespace
-#endif
+#endif  // !defined(NDEBUG) && !defined(__ANDROID__) && !defined(__wasm__) && !defined(_OPSCHEMA_LIB_) && !defined(_AIX)
 
 namespace onnxruntime {
 
@@ -357,7 +323,7 @@ std::vector<std::string> GetStackTrace() {
     }
     stack.push_back(oss.str());
   }
-#endif
+#endif  // !defined(NDEBUG) && !defined(__ANDROID__) && !defined(__wasm__) && !defined(_OPSCHEMA_LIB_) && !defined(_AIX)
 
   return stack;
 }

--- a/onnxruntime/core/platform/posix/stacktrace.cc
+++ b/onnxruntime/core/platform/posix/stacktrace.cc
@@ -157,7 +157,10 @@ inline int GetAddr2LineEnv() {
   }
   char* end = nullptr;
   long parsed = strtol(val, &end, 10);
-  if (end == val || parsed < 0 || parsed > INT_MAX) {
+  // Reject empty input and any value with trailing non-numeric characters
+  // (e.g. "10foo"), so a malformed setting disables resolution rather than
+  // silently using a partially parsed number.
+  if (end == val || *end != '\0' || parsed < 0 || parsed > INT_MAX) {
     return 0;
   }
   return static_cast<int>(parsed);
@@ -202,13 +205,19 @@ std::unordered_map<void*, std::string> ResolveWithAddr2Line(
   for (int i = 0; i < depth; ++i) {
     Dl_info info;
     if (dladdr(addresses[i], &info) && info.dli_fname) {
+      const uintptr_t addr = reinterpret_cast<uintptr_t>(addresses[i]);
+      const uintptr_t base = reinterpret_cast<uintptr_t>(info.dli_fbase);
+      // Skip frames whose address is at or below the module base. Subtracting
+      // below would underflow uintptr_t and feed a garbage offset to addr2line.
+      if (addr <= base) {
+        continue;
+      }
       // Each captured address is a return address pointing just past the call
       // instruction. Subtract 1 so addr2line resolves the call site itself
       // rather than the following statement (which may be a different source
       // line or even the next function). The map is still keyed by the original
       // address so it matches the absl::Symbolize lookup in GetStackTrace.
-      uintptr_t offset = reinterpret_cast<uintptr_t>(addresses[i]) - 1 -
-                         reinterpret_cast<uintptr_t>(info.dli_fbase);
+      uintptr_t offset = addr - 1 - base;
       groups[info.dli_fname].push_back({addresses[i], offset});
     }
   }
@@ -261,9 +270,10 @@ std::unordered_map<void*, std::string> ResolveWithAddr2Line(
     // Close the write end in the parent so we observe EOF once addr2line exits.
     write_fd.Reset();
 
-    // posix_spawnp fails only when the child cannot be created. A missing
-    // addr2line still spawns but the child exits 127; that is handled by the
-    // ExitedCleanly() check below, which discards any output on failure.
+    // If addr2line cannot be executed (e.g. not installed), glibc posix_spawnp
+    // reports the failure here with a non-zero return (ENOENT) and no child is
+    // created. Some implementations instead spawn a child that exits 127; that
+    // case is caught by the ExitedCleanly() check below, which discards output.
     if (spawn_ret != 0) continue;
     ScopedChild child(pid);
 

--- a/onnxruntime/core/platform/posix/stacktrace.cc
+++ b/onnxruntime/core/platform/posix/stacktrace.cc
@@ -33,7 +33,6 @@ inline int GetAddr2LineEnv() {
   return atoi(val);
 }
 
-// Check once whether ORT_ADDR2LINE is set.
 int GetAddr2LineCount() {
   static const int count = GetAddr2LineEnv();
   return count;
@@ -152,9 +151,8 @@ std::vector<std::string> GetStackTrace() {
   int depth = absl::GetStackTrace(addresses, kCallstackLimit, /*skip_count=*/2);
   stack.reserve(depth);
 
-  // Resolve file:line via addr2line only when explicitly opted in via
-  // ORT_ADDR2LINE=1, since it spawns external processes and can be
-  // very slow on large debug binaries.
+  // Resolve file:line via addr2line only when explicitly opted in via ORT_ADDR2LINE=*,
+  // since it spawns external processes and can be very slow on large debug binaries.
   std::unordered_map<void*, std::string> resolved;
   int count = GetAddr2LineCount();
   if (count > 0) {

--- a/onnxruntime/core/platform/posix/stacktrace.cc
+++ b/onnxruntime/core/platform/posix/stacktrace.cc
@@ -9,10 +9,16 @@
 #include <cstdio>
 #include <cstring>
 #include <dlfcn.h>
+#include <fcntl.h>
 #include <sstream>
+#include <spawn.h>
+#include <sys/wait.h>
+#include <unistd.h>
 #include <unordered_map>
 #include "absl/debugging/stacktrace.h"
 #include "absl/debugging/symbolize.h"
+
+extern char** environ;
 
 namespace {
 
@@ -24,7 +30,7 @@ inline int GetAddr2LineEnv() {
   return atoi(val);
 }
 
-// Check once whether ORT_ENABLE_ADDR2LINE is set.
+// Check once whether ORT_ADDR2LINE is set.
 int GetAddr2LineCount() {
   static const int count = GetAddr2LineEnv();
   return count;
@@ -54,23 +60,61 @@ std::unordered_map<void*, std::string> ResolveWithAddr2Line(
   }
 
   // Call addr2line once per binary with all offsets in batch.
+  // Use posix_spawnp + pipe instead of popen to avoid shell injection risks
+  // from untrusted binary paths (e.g., paths with spaces or special chars).
   for (const auto& [binary, frames] : groups) {
-    // Use addr2line without -f/-C/-p to get just "file:line" per address.
-    std::string cmd = "addr2line -e " + binary;
+    // Build argv: {"addr2line", "-e", binary, "0xoffset1", "0xoffset2", ..., nullptr}
+    std::vector<std::string> offset_strs;
+    offset_strs.reserve(frames.size());
     for (const auto& frame : frames) {
       char buf[32];
-      snprintf(buf, sizeof(buf), " 0x%lx", static_cast<unsigned long>(frame.offset));
-      cmd += buf;
+      snprintf(buf, sizeof(buf), "0x%lx", static_cast<unsigned long>(frame.offset));
+      offset_strs.emplace_back(buf);
     }
-    cmd += " 2>/dev/null";
 
-    FILE* pipe = popen(cmd.c_str(), "r");
-    if (!pipe) continue;
+    // Build raw argv array for execvp. All pointers reference stable strings above.
+    std::vector<char*> argv;
+    argv.reserve(3 + frames.size() + 1);
+    argv.push_back(const_cast<char*>("addr2line"));
+    argv.push_back(const_cast<char*>("-e"));
+    argv.push_back(const_cast<char*>(binary.c_str()));
+    for (auto& s : offset_strs) {
+      argv.push_back(const_cast<char*>(s.c_str()));
+    }
+    argv.push_back(nullptr);
+
+    // Create a pipe for reading addr2line's stdout.
+    int pipe_fds[2];
+    if (pipe(pipe_fds) != 0) continue;
+
+    posix_spawn_file_actions_t actions;
+    posix_spawn_file_actions_init(&actions);
+    posix_spawn_file_actions_adddup2(&actions, pipe_fds[1], STDOUT_FILENO);
+    posix_spawn_file_actions_addclose(&actions, pipe_fds[0]);
+    // Redirect stderr to /dev/null to suppress error messages.
+    posix_spawn_file_actions_addopen(&actions, STDERR_FILENO, "/dev/null", O_WRONLY, 0);
+
+    pid_t pid;
+    int spawn_ret = posix_spawnp(&pid, "addr2line", &actions, nullptr, argv.data(), environ);
+    posix_spawn_file_actions_destroy(&actions);
+    close(pipe_fds[1]);
+
+    if (spawn_ret != 0) {
+      close(pipe_fds[0]);
+      continue;
+    }
 
     // Read one line per address from addr2line output.
+    FILE* fp = fdopen(pipe_fds[0], "r");
+    if (!fp) {
+      close(pipe_fds[0]);
+      waitpid(pid, nullptr, 0);
+      continue;
+    }
+
     char line_buf[1024];
     size_t frame_idx = 0;
-    while (fgets(line_buf, sizeof(line_buf), pipe) && frame_idx < frames.size()) {
+    while (fgets(line_buf, sizeof(line_buf), fp) && frame_idx < frames.size()) {
       // Remove trailing newline
       size_t len = strlen(line_buf);
       if (len > 0 && line_buf[len - 1] == '\n') line_buf[len - 1] = '\0';
@@ -82,7 +126,8 @@ std::unordered_map<void*, std::string> ResolveWithAddr2Line(
       }
       ++frame_idx;
     }
-    pclose(pipe);
+    fclose(fp);
+    waitpid(pid, nullptr, 0);
   }
 
   return result;
@@ -105,7 +150,7 @@ std::vector<std::string> GetStackTrace() {
   stack.reserve(depth);
 
   // Resolve file:line via addr2line only when explicitly opted in via
-  // ORT_ENABLE_ADDR2LINE=1, since it spawns external processes and can be
+  // ORT_ADDR2LINE=1, since it spawns external processes and can be
   // very slow on large debug binaries.
   std::unordered_map<void*, std::string> resolved;
   int count = GetAddr2LineCount();

--- a/onnxruntime/core/session/environment.cc
+++ b/onnxruntime/core/session/environment.cc
@@ -60,6 +60,10 @@
 #include "orttraining/core/optimizer/graph_transformer_registry.h"
 #endif
 
+#if !defined(_WIN32) && !defined(__ANDROID__) && !defined(__wasm__) && !defined(_AIX)
+#include "absl/debugging/symbolize.h"
+#endif
+
 #if defined(USE_CUDA) || defined(USE_CUDA_PROVIDER_INTERFACE)
 #include "core/providers/cuda/cuda_provider_factory.h"
 #include "core/providers/cuda/cuda_execution_provider_info.h"
@@ -69,6 +73,7 @@ using namespace ::onnxruntime::common;
 using namespace ONNX_NAMESPACE;
 
 std::once_flag schemaRegistrationOnceFlag;
+std::once_flag symbolizerInitOnceFlag;
 #if defined(USE_CUDA) || defined(USE_CUDA_PROVIDER_INTERFACE)
 ProviderInfo_CUDA& GetProviderInfo_CUDA();
 #endif  // defined(USE_CUDA) || defined(USE_CUDA_PROVIDER_INTERFACE)
@@ -267,6 +272,14 @@ Status Environment::Initialize(std::unique_ptr<logging::LoggingManager> logging_
   if (create_global_thread_pools) {
     ORT_RETURN_IF_ERROR(SetGlobalThreadingOptions(*tp_options));
   }
+
+  // Initialize abseil symbolizer for readable stack traces in debug builds.
+  // Windows uses C++23 <stacktrace> instead, so skip abseil symbolizer there.
+#if !defined(_WIN32) && !defined(__ANDROID__) && !defined(__wasm__) && !defined(_AIX)
+  std::call_once(symbolizerInitOnceFlag, []() {
+    absl::InitializeSymbolizer(nullptr);
+  });
+#endif
 
   ORT_TRY {
 #if !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/core/session/environment.cc
+++ b/onnxruntime/core/session/environment.cc
@@ -60,7 +60,7 @@
 #include "orttraining/core/optimizer/graph_transformer_registry.h"
 #endif
 
-#if !defined(NDEBUG) && !defined(_WIN32) && !defined(__ANDROID__) && !defined(__wasm__) && !defined(_AIX)
+#if !defined(NDEBUG) && defined(__linux__) && !defined(__ANDROID__)
 #include "absl/debugging/symbolize.h"
 #endif
 
@@ -274,8 +274,11 @@ Status Environment::Initialize(std::unique_ptr<logging::LoggingManager> logging_
   }
 
   // Initialize abseil symbolizer for readable stack traces in debug builds.
-  // Windows uses C++23 <stacktrace> instead, so skip abseil symbolizer there.
-#if !defined(NDEBUG) && !defined(_WIN32) && !defined(__ANDROID__) && !defined(__wasm__) && !defined(_AIX)
+  // Restricted to Linux: InitializeSymbolizer(nullptr) relies on /proc/self/exe
+  // to locate the executable, which is Linux-specific. Other platforms either
+  // use a different mechanism (Windows: C++23 <stacktrace>) or would need a real
+  // argv[0] path plumbed through, which is out of scope for this debug helper.
+#if !defined(NDEBUG) && defined(__linux__) && !defined(__ANDROID__)
   std::call_once(symbolizerInitOnceFlag, []() {
     absl::InitializeSymbolizer(nullptr);
   });

--- a/onnxruntime/core/session/environment.cc
+++ b/onnxruntime/core/session/environment.cc
@@ -60,7 +60,7 @@
 #include "orttraining/core/optimizer/graph_transformer_registry.h"
 #endif
 
-#if !defined(_WIN32) && !defined(__ANDROID__) && !defined(__wasm__) && !defined(_AIX)
+#if !defined(NDEBUG) && !defined(_WIN32) && !defined(__ANDROID__) && !defined(__wasm__) && !defined(_AIX)
 #include "absl/debugging/symbolize.h"
 #endif
 
@@ -275,7 +275,7 @@ Status Environment::Initialize(std::unique_ptr<logging::LoggingManager> logging_
 
   // Initialize abseil symbolizer for readable stack traces in debug builds.
   // Windows uses C++23 <stacktrace> instead, so skip abseil symbolizer there.
-#if !defined(_WIN32) && !defined(__ANDROID__) && !defined(__wasm__) && !defined(_AIX)
+#if !defined(NDEBUG) && !defined(_WIN32) && !defined(__ANDROID__) && !defined(__wasm__) && !defined(_AIX)
   std::call_once(symbolizerInitOnceFlag, []() {
     absl::InitializeSymbolizer(nullptr);
   });


### PR DESCRIPTION
## Description

Replace glibc `backtrace()`/`backtrace_symbols()` with abseil's `absl::GetStackTrace()`/`absl::Symbolize()` for POSIX/Linux debug builds, and add automatic `addr2line` resolution for file paths and line numbers. The previous implementation produced raw addresses requiring manual `addr2line` translation. The new implementation produces demangled function names with source locations directly in exception messages, with zero new dependencies.

## Summary of Changes

### Stack Trace Implementation

| File | Change |
|------|--------|
| `onnxruntime/core/platform/posix/stacktrace.cc` | Replace glibc `backtrace()`/`backtrace_symbols()` with `absl::GetStackTrace()`/`absl::Symbolize()`. Use `dladdr()` + `addr2line` to resolve source file and line number for each frame. |
| `onnxruntime/core/session/environment.cc` | Add one-time `absl::InitializeSymbolizer(nullptr)` call via `std::call_once` in `Environment::Initialize()`. On Linux, `nullptr` works because abseil reads `/proc/self/exe`. |

### Before vs After

**Before** (raw addresses requiring manual `addr2line`):
```
Stacktrace:
 /home/me/build/Debug/onnxruntime_test_all(+0x3f46cc) [0x559543faf6cc]
 /home/me/build/Debug/onnxruntime_test_all(+0x2bef04d) [0x559543faf6cc]
 ...
```

**After** (demangled function names + file:line):
```
Stacktrace:
onnxruntime::OpKernelContext::Output() at .../core/framework/op_kernel.cc:45
onnxruntime::Add<>::Compute() at .../core/providers/cpu/math/element_wise_ops.cc:596
...
```

Environment variable `ORT_ADDR2LINE` controls number of frames need to call addr2line to get file and location. The default value is 0, which avoids timeout in CI pipeline. In local debugging, you can set a proper value to assist debugging in Linux or WSL.

## Motivation and Context

Follow-up on #26257, which was closed because abseil's backtrace/symbolize is already available as a dependency. This PR implements that suggestion with additional file:line resolution:

- **No new dependency**: `absl::stacktrace` and `absl::symbolize` are already in `ABSEIL_LIBS` and linked to `onnxruntime_common`. `dladdr()` and `addr2line` are standard POSIX/Linux utilities.
- **No CMake changes needed**: Everything is already wired up
- **Debug-only**: Guarded by `#ifndef NDEBUG` — no performance impact in release builds
- **Best-effort file:line**: Uses `dladdr()` to compute file offsets, then calls `addr2line` in batch (once per binary). Falls back gracefully to function-name-only output if `addr2line` is unavailable.
- **Windows unchanged**: Windows already has superior stack traces via C++23 `<stacktrace>`
- **Platform exclusions preserved**: Android, WebAssembly, AIX, and `_OPSCHEMA_LIB_` builds continue to return empty stack traces

It might also resolve build issues of stacktrace on BSD, Alpine Linux and other musl libc-based distributions (See https://github.com/microsoft/onnxruntime/pull/28249, https://github.com/microsoft/onnxruntime/pull/24755, https://github.com/microsoft/onnxruntime/pull/28161, https://github.com/microsoft/onnxruntime/pull/27437)

Note that C++23 has stack trace support, but compiler support for C++23 is not mature, so abseil seems to be the best choice for now.

### How it works

1. `absl::GetStackTrace()` captures raw frame addresses
2. `absl::Symbolize()` resolves each address to a demangled function name
3. `dladdr()` determines which binary each address belongs to and computes the file offset
4. `addr2line` is called in batch (one invocation per binary) to resolve file:line
5. Results are combined into a single readable string per frame

## Testing

- Built and verified on Linux with CUDA EP in Debug mode
- Ran `onnxruntime_test_all --gtest_filter="*BadModelInvalidDimParamUsage*"` — confirmed stack trace shows demangled function names with file paths and line numbers through the full call chain
- Verified graceful fallback when addr2line cannot resolve a frame (shows function name + address only)
- No CMake changes, so no risk of build system regressions on other platforms
