### PR TITLE
Skip test_reduce_max/min_empty_set_cuda in backend test filters

### DIFF
--- a/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
+++ b/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
@@ -290,6 +290,8 @@
         "^test_reduce_log_sum_empty_set_expanded_cuda",
         "^test_reduce_log_sum_exp_empty_set_cuda",
         "^test_reduce_log_sum_exp_empty_set_expanded_cuda",
+        "^test_reduce_max_empty_set_cuda",
+        "^test_reduce_min_empty_set_cuda",
         "^test_reduce_prod_empty_set_cuda",
         "^test_reduce_sum_empty_set_cuda",
         "^test_reduce_sum_square_empty_set_cuda",


### PR DESCRIPTION
Adds skip entries for `test_reduce_max_empty_set_cuda` and `test_reduce_min_empty_set_cuda` in the ONNX backend test filters, alongside the other reduce empty-set test skips.

Note: `ReduceMax` and `ReduceMin` are primitive ops (not ONNX function ops), so no `_expanded` test variants are generated by ONNX — only the two non-expanded entries are needed.