### PR TITLE
[CUDA] PagedAttention: use exact max_query_len on FA path

### DIFF
--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention.cc
@@ -232,42 +232,44 @@ Status PagedAttention<T>::ComputeInternal(OpKernelContext* context) const {
   IAllocatorUniquePtr<void> gathered_value_buffer;
   IAllocatorUniquePtr<void> fmha_buffer;
 
-#if USE_MEMORY_EFFICIENT_ATTENTION
-  if (use_memory_efficient_attention) {
-    // MEA needs two host-side quantities:
-    //   - total_kv_tokens (= cumulative_seqlens_kv[batch_size]) to size tight gather buffers.
-    //   - max_query_len (= max per-batch new-query length) to size the rotary and MEA grids
-    //     correctly. The heuristic `token_count - batch_size + 1` underestimates when any
-    //     batch has 0 new tokens (valid input), silently dropping query-tokens from those
-    //     larger-than-average batches.
-    // Both come from cumulative_seqlens_q / cumulative_seqlens_kv, which are tiny (batch+1
-    // ints each), so one D->H copy of the full arrays is cheaper than issuing an extra
-    // reduction kernel and avoids a second sync.
+  // Compute max_query_len on the host for both FA and MEA. The previous
+  // `token_count - batch_size + 1` heuristic underestimates (or goes
+  // non-positive) when batches have zero new tokens. MEA additionally needs
+  // total_kv_tokens to size gather buffers.
+  if (use_flash_attention || use_memory_efficient_attention) {
     const int kCumulativeCount = parameters.batch_size + 1;
     auto cum_q_pinned = this->AllocateBufferOnCPUPinned<int>(kCumulativeCount);
-    auto cum_kv_pinned = this->AllocateBufferOnCPUPinned<int>(kCumulativeCount);
+    IAllocatorUniquePtr<int> cum_kv_pinned;
     CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(cum_q_pinned.get(),
                                          reinterpret_cast<const int*>(cumulative_seqlens_q->Data<int>()),
                                          sizeof(int) * kCumulativeCount, cudaMemcpyDeviceToHost, cuda_stream));
-    CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(cum_kv_pinned.get(), cumulative_seqlens_kv_ptr,
-                                         sizeof(int) * kCumulativeCount, cudaMemcpyDeviceToHost, cuda_stream));
+    if (use_memory_efficient_attention) {
+      cum_kv_pinned = this->AllocateBufferOnCPUPinned<int>(kCumulativeCount);
+      CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(cum_kv_pinned.get(), cumulative_seqlens_kv_ptr,
+                                           sizeof(int) * kCumulativeCount, cudaMemcpyDeviceToHost, cuda_stream));
+    }
     CUDA_RETURN_IF_ERROR(cudaStreamSynchronize(cuda_stream));
-    total_kv_tokens = cum_kv_pinned.get()[parameters.batch_size];
     for (int i = 0; i < parameters.batch_size; ++i) {
       const int q_len_i = cum_q_pinned.get()[i + 1] - cum_q_pinned.get()[i];
       if (q_len_i > max_query_len) {
         max_query_len = q_len_i;
       }
     }
-    if (total_kv_tokens == 0) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
-                             "PagedAttention MEA fallback: total_kv_tokens is zero for non-empty input.");
+    if (use_memory_efficient_attention) {
+      total_kv_tokens = cum_kv_pinned.get()[parameters.batch_size];
+      if (total_kv_tokens == 0) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                               "PagedAttention MEA fallback: total_kv_tokens is zero for non-empty input.");
+      }
+      if (total_kv_tokens < 0) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                               "PagedAttention MEA fallback: total_kv_tokens is negative (", total_kv_tokens, ").");
+      }
     }
-    if (total_kv_tokens < 0) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
-                             "PagedAttention MEA fallback: total_kv_tokens is negative (", total_kv_tokens, ").");
-    }
+  }
 
+#if USE_MEMORY_EFFICIENT_ATTENTION
+  if (use_memory_efficient_attention) {
     const size_t gather_elems = static_cast<size_t>(total_kv_tokens) *
                                 parameters.num_heads * parameters.head_size;
     gathered_key_buffer = GetScratchBuffer<void>(sizeof(T) * gather_elems, GetComputeStream(context));
@@ -318,6 +320,7 @@ Status PagedAttention<T>::ComputeInternal(OpKernelContext* context) const {
     data.cos_cache = reinterpret_cast<const CudaT*>(cos_cache->Data<T>());
     data.sin_cache = reinterpret_cast<const CudaT*>(sin_cache->Data<T>());
   }
+  data.max_query_len = max_query_len;  // consumed by both FA and MEA
   if (use_memory_efficient_attention) {
     data.gathered_key = reinterpret_cast<CudaT*>(gathered_key_buffer.get());
     data.gathered_value = reinterpret_cast<CudaT*>(gathered_value_buffer.get());
@@ -325,7 +328,6 @@ Status PagedAttention<T>::ComputeInternal(OpKernelContext* context) const {
       data.fmha_buffer = reinterpret_cast<CudaT*>(fmha_buffer.get());
     }
     data.total_kv_tokens = total_kv_tokens;
-    data.max_query_len = max_query_len;
   }
 
   cublasHandle_t cublas = GetCublasHandle(context);

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.cu
@@ -357,8 +357,9 @@ Status FlashAttention(
   const int local_window_size = parameters.local_window_size;
   const int max_num_blocks_per_seq = parameters.max_num_blocks_per_seq;
   const int block_size = parameters.block_size;
-  // The following are passed to flash api but not used by the kernel, so they can be determined heuristically
-  const int max_query_len = token_count - batch_size + 1;
+  // Host-computed actual max from paged_attention.cc. Used as both
+  // `params.seqlen_q` for mha_varlen_fwd and grid.x for the rotary kernel.
+  const int max_query_len = data.max_query_len;
   const int max_seq_len = parameters.max_num_blocks_per_seq * parameters.block_size;
 
   T* query = const_cast<T*>(data.query);
@@ -419,9 +420,9 @@ Status FlashAttention(
   void* softmax_lse = reinterpret_cast<void*>(data.softmax_lse);
   ORT_RETURN_IF_ERROR(onnxruntime::flash::mha_varlen_fwd(
       device_prop, stream, q, key_cache, value_cache, output, cumulative_seqlens_q, cumulative_seqlens_kv,
-      /*seqused_k*/ nullptr, block_table, softmax_lse, batch_size, num_heads, kv_num_heads, head_size, max_query_len,
-      max_seq_len, token_count, scale, softcap, /*is_causal*/ true, is_bf16, local_window_size - 1, max_num_blocks_per_seq,
-      block_size));
+      /*seqused_k*/ nullptr, block_table, softmax_lse, batch_size, num_heads, kv_num_heads, head_size,
+      max_query_len, max_seq_len, token_count, scale, softcap, /*is_causal*/ true, is_bf16, local_window_size - 1,
+      max_num_blocks_per_seq, block_size));
 
   DUMP_TENSOR_INIT();
   DUMP_TENSOR("flash attention output", data.output, token_count, num_heads, head_size);

--- a/onnxruntime/test/python/transformers/test_paged_attention_cuda.py
+++ b/onnxruntime/test/python/transformers/test_paged_attention_cuda.py
@@ -496,6 +496,7 @@ def parity_check_paged_attention(
     rtol=1e-3,
     atol=1e-3,
     sdpa_kernel=0,
+    new_seqlens_override=None,
 ):
     # Generate padded inputs
     q = torch.randn(
@@ -534,13 +535,18 @@ def parity_check_paged_attention(
         dtype=torch.int32,
         device="cuda",
     )
-    new_seqlens = torch.randint(
-        1,
-        config.sequence_length + 1,
-        (config.batch_size,),
-        dtype=torch.int32,
-        device="cuda",
-    )
+    if new_seqlens_override is not None:
+        new_seqlens = new_seqlens_override.to(dtype=torch.int32, device="cuda")
+        assert new_seqlens.shape == (config.batch_size,)
+        assert int(new_seqlens.max().item()) <= config.sequence_length
+    else:
+        new_seqlens = torch.randint(
+            1,
+            config.sequence_length + 1,
+            (config.batch_size,),
+            dtype=torch.int32,
+            device="cuda",
+        )
     cum_seqlens = torch.cat(
         (torch.tensor([0], dtype=torch.int32, device="cuda"), torch.cumsum(new_seqlens, dim=0))
     ).type(torch.int32)
@@ -776,6 +782,105 @@ class TestPagedAttentionMEA(unittest.TestCase):
             atol=5e-3,
             sdpa_kernel=SDPA_KERNEL_EFFICIENT_ATTENTION,
         )
+
+
+class TestPagedAttentionRotaryZeroTokenRegression(unittest.TestCase):
+    """Regression tests for the FA `max_query_len` heuristic when one or more
+    batches have zero new tokens.
+
+    The old FA path used `token_count - batch_size + 1` as both the rotary
+    grid size and the `mha_varlen_fwd` max query length. This assumes every
+    batch has at least one new token. With zero-token batches, the value can be
+    smaller than the real per-batch maximum, or even non-positive. Then rotary
+    can skip Q/K tokens, FA can under-launch at the kBlockM boundary, or FA can
+    fail with an invalid launch grid. The MEA path was fixed in PR #28200; this
+    class covers the FA regressions fixed by the current PR.
+    """
+
+    def _config(self, batch_size=4, sequence_length=10, total_sequence_length=64, rotary=True):
+        return Config(
+            batch_size=batch_size,
+            sequence_length=sequence_length,
+            total_sequence_length=total_sequence_length,
+            num_heads=8,
+            kv_num_heads=2,
+            head_size=64,
+            paged_kv_block_size=256,
+            local=False,
+            rotary=rotary,
+            rotary_interleaved=False,
+            packed=False,
+            softcap=0.0,
+        )
+
+    @unittest.skipIf(not has_flash_attention(), reason="Flash Attention is not available")
+    def test_fa_rotary_zero_token_first_batch(self):
+        # lens = [10, 0, 0, 0]. heuristic = 10 - 4 + 1 = 7. true max = 10.
+        # Tokens at positions s=7,8,9 in batch 0 do not get rotary applied.
+        new_seqlens = torch.tensor([10, 0, 0, 0], dtype=torch.int32, device="cuda")
+        parity_check_paged_attention(self._config(), rtol=5e-3, atol=5e-3, new_seqlens_override=new_seqlens)
+
+    @unittest.skipIf(not has_flash_attention(), reason="Flash Attention is not available")
+    def test_fa_rotary_zero_token_mixed(self):
+        # lens = [0, 7, 0, 3]. heuristic = 10 - 4 + 1 = 7. true max = 7.
+        # In this case the heuristic happens to equal the true max, but the
+        # input still has a zero-token batch and exercises the grid-launch path.
+        new_seqlens = torch.tensor([0, 7, 0, 3], dtype=torch.int32, device="cuda")
+        parity_check_paged_attention(self._config(), rtol=5e-3, atol=5e-3, new_seqlens_override=new_seqlens)
+
+    @unittest.skipIf(
+        not has_memory_efficient_attention(),
+        reason="MemoryEfficientAttention (fp16) requires sm>=53",
+    )
+    def test_mea_rotary_zero_token_no_regression(self):
+        # PR #28200 fixed the MEA path on this input. This test guards against
+        # a regression of that fix.
+        new_seqlens = torch.tensor([10, 0, 0, 0], dtype=torch.int32, device="cuda")
+        parity_check_paged_attention(
+            self._config(),
+            rtol=5e-3,
+            atol=5e-3,
+            sdpa_kernel=SDPA_KERNEL_EFFICIENT_ATTENTION,
+            new_seqlens_override=new_seqlens,
+        )
+
+    @unittest.skipIf(not has_flash_attention(), reason="Flash Attention is not available")
+    def test_fa_rotary_zero_token_large_batch(self):
+        # 16 batches, only batch 0 has new tokens. token_count = 10, so the
+        # heuristic max_query_len_hint = 10 - 16 + 1 = -5 (negative). The
+        # value reaches mha_varlen_fwd as params.seqlen_q. Without the exact
+        # max_query_len fix added in this PR, FA launches with an invalid grid
+        # and fails with CUDA error 9 (invalid configuration argument).
+        config = self._config(batch_size=16)
+        new_seqlens = torch.tensor([10] + [0] * 15, dtype=torch.int32, device="cuda")
+        parity_check_paged_attention(config, rtol=5e-3, atol=5e-3, new_seqlens_override=new_seqlens)
+
+    @unittest.skipIf(not has_flash_attention(), reason="Flash Attention is not available")
+    def test_fa_no_rotary_zero_token_sanity(self):
+        # With rotary off, the rotary kernel is not launched, so this input
+        # only checks that ordinary zero-token batches still work on the FA
+        # path. The max query length stays below the kBlockM=64 boundary here.
+        new_seqlens = torch.tensor([10, 0, 0, 0], dtype=torch.int32, device="cuda")
+        parity_check_paged_attention(self._config(rotary=False), rtol=5e-3, atol=5e-3, new_seqlens_override=new_seqlens)
+
+    @unittest.skipIf(not has_flash_attention(), reason="Flash Attention is not available")
+    def test_fa_kblockm_boundary_zero_token(self):
+        # batch_size=2, lens=[65, 0]. The true max new-query length is 65,
+        # which crosses the FA kBlockM=64 boundary. With the older
+        # `token_count - batch_size + 1` heuristic, mha_varlen_fwd would see
+        # seqlen_q=64 and launch grid.x=1, dropping the 65th query token.
+        # This test exercises FA grid sizing with rotary on.
+        config = self._config(batch_size=2, sequence_length=65, total_sequence_length=128)
+        new_seqlens = torch.tensor([65, 0], dtype=torch.int32, device="cuda")
+        parity_check_paged_attention(config, rtol=5e-3, atol=5e-3, new_seqlens_override=new_seqlens)
+
+    @unittest.skipIf(not has_flash_attention(), reason="Flash Attention is not available")
+    def test_fa_kblockm_boundary_zero_token_no_rotary(self):
+        # Same kBlockM=64 boundary case as above with rotary off. This isolates
+        # the FA grid silent-drop from the rotary grid silent-drop.
+        config = self._config(batch_size=2, sequence_length=65, total_sequence_length=128, rotary=False)
+        new_seqlens = torch.tensor([65, 0], dtype=torch.int32, device="cuda")
+        parity_check_paged_attention(config, rtol=5e-3, atol=5e-3, new_seqlens_override=new_seqlens)
 
 
 if __name__ == "__main__":

--- a/onnxruntime/test/python/transformers/test_paged_attention_cuda.py
+++ b/onnxruntime/test/python/transformers/test_paged_attention_cuda.py
@@ -538,6 +538,7 @@ def parity_check_paged_attention(
     if new_seqlens_override is not None:
         new_seqlens = new_seqlens_override.to(dtype=torch.int32, device="cuda")
         assert new_seqlens.shape == (config.batch_size,)
+        assert int(new_seqlens.min().item()) >= 0
         assert int(new_seqlens.max().item()) <= config.sequence_length
     else:
         new_seqlens = torch.randint(


### PR DESCRIPTION
### Description
Fix the FA dispatch path of `PagedAttention` to use the host-computed actual maximum new-query length per batch instead of the older `token_count - batch_size + 1` heuristic. The same value is used for both `mha_varlen_fwd` (`params.seqlen_q`) and the rotary kernel grid.

With the exact host-computed maximum:
- The rotary kernel grid is large enough to cover the true per-batch maximum, so no Q/K token is dropped from rotary.
- `mha_varlen_fwd` always sees a positive, accurate `seqlen_q`, so its `grid.x = ceil(params.seqlen_q / kBlockM)` covers all query tokens (no silent drop at kBlockM=64 boundaries) and is never invalid (no CUDA error 9).

The MEA path already used `data.max_query_len` (host-computed in `paged_attention.cc`) from #28200. This PR moves that host computation out of the MEA-only block so FA also sees the exact value, and the FA dispatch reads the same `data.max_query_len`.

### Motivation and Context
This is a follow-up to #28200. The MEA dispatch path was fixed there; the FA dispatch path uses the same heuristic and has the same root cause.

In `paged_attention_impl.cu`, the FA path computed:
```cpp
    const int max_query_len = token_count - batch_size + 1;
```
This value was passed to `mha_varlen_fwd` as `params.seqlen_q` and also used as `grid.x` for `LaunchRotaryEmbeddingKernel`. The formula assumes each batch has at least one new token, which is not enforced by the op input.

Three failure modes from the same heuristic underestimation:

1. **Rotary silent drop** — `lens=[10, 0, 0, 0]`. heuristic = 10 - 4 + 1 = 7, real max = 10. Tokens at positions s=7,8,9 in batch 0 are not rotated.
2. **FA grid silent drop at kBlockM=64 boundary** — `lens=[65, 0]`. heuristic = 64, real max = 65. `mha_varlen_fwd` launches with `grid.x = 1` but the 65th query token needs `grid.x = 2`.
3. **Non-positive heuristic** — `lens=[10, 0, ..., 0]` with batch_size = 16. heuristic = 10 - 16 + 1 = -5. The value reaches `mha_varlen_fwd` as `params.seqlen_q`, and the FA launch fails with CUDA error 9 (invalid configuration argument).

### Tests
New test class `TestPagedAttentionRotaryZeroTokenRegression`:
- `test_fa_rotary_zero_token_first_batch` — `lens=[10,0,0,0]`. Rotary silent drop reproducer.
- `test_fa_rotary_zero_token_mixed` — `lens=[0,7,0,3]`.
- `test_fa_rotary_zero_token_large_batch` — `lens=[10, 0×15]` (batch_size=16). Negative-heuristic CUDA error 9 reproducer.
- `test_fa_kblockm_boundary_zero_token` — `lens=[65, 0]` with rotary on. FA grid kBlockM-boundary silent drop reproducer.
- `test_fa_kblockm_boundary_zero_token_no_rotary` — same with rotary off.
- `test_mea_rotary_zero_token_no_regression` — guards against regression of the #28200 MEA fix.
- `test_fa_no_rotary_zero_token_sanity` — sanity for FA without rotary.

`parity_check_paged_attention` got a new optional parameter `new_seqlens_override` so tests can pass a deterministic per-batch distribution instead of `randint(1, ...)`.

Existing `TestPagedAttention` (24) + `TestPagedAttentionMEA` (24) suite passes (48/48). New regression class passes (7/7).

### Performance
Measured on RTX PRO 4500 (sm_120, CUDA 12.8). 100 warmup + 500 iterations per case. GPU clock lock is not available on this cloud GPU, so absolute numbers carry some measurement noise, but the trend is consistent.

| case | base us | this PR us | delta |
|---|---:|---:|---:|
| prefill B=1 rot=on (lens=[1024]) | 102.1 | 110.2 | +7.9% |
| prefill B=4 rot=on (lens=[1024]×4) | 567.9 | 360.6 | -36.5% |
| prefill B=16 rot=on (lens=[1024]×16) | 5988 | 1488 | **-75.1%** |
| prefill B=64 rot=on (lens=[1024]×64) | 82541 | 6317 | **-92.3%** |
| prefill B=64 rot=off (lens=[1024]×64) | 9496 | 4870 | **-48.7%** |
| decode B=1 rot=on (lens=[1]) | 26.4 | 34.8 | +31.4% |
| decode B=4 rot=on (lens=[1]×4) | 29.1 | 38.4 | +32.0% |
| decode B=16 rot=on (lens=[1]×16) | 46.1 | 55.6 | +20.5% |
| decode B=64 rot=on (lens=[1]×64) | 112.1 | 120.2 | +7.2% |
| mixed B=64 rot=on (lens=[1024,1×63]) | 1384 | 1390 | +0.4% |
| zero-mix B=4 rot=on (lens=[10,0,0,0]) | 27.7 | 34.6 | +25.0% |
| zero-mix B=16 rot=on (lens=[10, 0×15]) | CUDA error 9 | 37.6 | now passes |
| zero-mix B=64 rot=on (lens=[10, 0×63]) | CUDA error 9 | 49.9 | now passes |

The base heuristic over-launched the rotary kernel on prefill: for `lens=[1024]×64` it computes 65473, vs the true max of 1024. The rotary kernel was launching ~64x more blocks than needed; each over-launched block did the early-return work but the launch overhead was visible in wall-clock. The same heuristic was also passed to FA as `params.seqlen_q`, so FA also launched many unnecessary m-blocks in prefill-like cases.

Using the exact maximum gives:

- **Large prefill workloads**: significant speedup (-36% to -92%).
- **Decode small batches**: small absolute regression (~+5–10us per call) from the host D2H copy + `cudaStreamSynchronize` newly added on the FA path. In percent this is +20–30% on cases that take ~25us; on decode B=64 rot=on it is +7%.
- **Inputs that previously crashed** with CUDA error 9 now run.

The decode regression is the cost of the new D2H sync. It was already paid on the MEA path. The regression is small in absolute terms and the heuristic was silently wrong on these sparse-batch patterns, so this is a correctness fix.

### Test plan
- [x] new regression tests pass (7/7) on RTX PRO 4500 (sm_120, CUDA 12.8)
- [x] existing test_paged_attention_cuda suite passes (48/48)
- [x] CI green

cc: @tianleiwu
