### PR TITLE
Add RVV (RISC-V Vector Extension) optimized convolution and pooling kernels for the NCHWc blocked format in MLAS

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -937,7 +937,6 @@ endif()
               ${MLAS_SRC_DIR}/riscv64/sconv_depthwise_kernel_rvv.cpp
               ${MLAS_SRC_DIR}/riscv64/sconv_nchwc_kernel_rvv.cpp
             )
-            # RVV depthwise replaces the MLAS_FLOAT32X4 version
             list(REMOVE_ITEM mlas_platform_srcs
               "${MLAS_SRC_DIR}/sconv_nchw_depthwise_multiplier_1.cpp")
             set_source_files_properties(

--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -908,6 +908,11 @@ endif()
     if(RISCV64 AND MLAS_SOURCE_IS_NOT_SET)
         file(GLOB_RECURSE mlas_platform_srcs CONFIGURE_DEPENDS
           "${MLAS_SRC_DIR}/scalar/*.cpp")
+        # Remove scalar depthwise kernel; replaced by the vectorized version
+        list(REMOVE_ITEM mlas_platform_srcs
+          "${MLAS_SRC_DIR}/scalar/SconvDepthwiseKernelScalar.cpp")
+        list(APPEND mlas_platform_srcs
+          ${MLAS_SRC_DIR}/sconv_nchw_depthwise_multiplier_1.cpp)
 
         if(onnxruntime_USE_RVV)
           set(OLD_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
@@ -929,11 +934,18 @@ endif()
               ${MLAS_SRC_DIR}/riscv64/sgemm_pack_b_rvv.cpp
               ${MLAS_SRC_DIR}/riscv64/sgemm_kernel_rvv.cpp
               ${MLAS_SRC_DIR}/riscv64/softmax_kernel_rvv.cpp
+              ${MLAS_SRC_DIR}/riscv64/sconv_depthwise_kernel_rvv.cpp
+              ${MLAS_SRC_DIR}/riscv64/sconv_nchwc_kernel_rvv.cpp
             )
+            # RVV depthwise replaces the MLAS_FLOAT32X4 version
+            list(REMOVE_ITEM mlas_platform_srcs
+              "${MLAS_SRC_DIR}/sconv_nchw_depthwise_multiplier_1.cpp")
             set_source_files_properties(
               ${MLAS_SRC_DIR}/riscv64/sgemm_pack_b_rvv.cpp
               ${MLAS_SRC_DIR}/riscv64/sgemm_kernel_rvv.cpp
               ${MLAS_SRC_DIR}/riscv64/softmax_kernel_rvv.cpp
+              ${MLAS_SRC_DIR}/riscv64/sconv_depthwise_kernel_rvv.cpp
+              ${MLAS_SRC_DIR}/riscv64/sconv_nchwc_kernel_rvv.cpp
               PROPERTIES COMPILE_FLAGS "-march=rv64gcv -mabi=lp64d")
             list(APPEND mlas_private_compile_definitions MLAS_USE_RVV=1)
           else()

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -881,7 +881,7 @@ enum MLAS_CONV_ALGORITHM {
     MlasConvAlgorithmExpandThenGemm,
     MlasConvAlgorithmExpandThenGemmSegmented,
     MlasConvAlgorithmDepthwiseMultiplierGreaterThan1,
-#if defined(MLAS_TARGET_WASM_SCALAR) || defined(MLAS_TARGET_ARM64)
+#if defined(MLAS_TARGET_WASM_SCALAR) || defined(MLAS_TARGET_ARM64) || defined(MLAS_TARGET_RISCV64)
     MlasConvAlgorithmDepthwise,
 #endif
 };

--- a/onnxruntime/core/mlas/lib/convolve.cpp
+++ b/onnxruntime/core/mlas/lib/convolve.cpp
@@ -855,7 +855,7 @@ Return Value:
     }
 }
 
-#if defined(MLAS_TARGET_WASM_SCALAR) || defined(MLAS_TARGET_ARM64)
+#if defined(MLAS_TARGET_WASM_SCALAR) || defined(MLAS_TARGET_ARM64) || defined(MLAS_TARGET_RISCV64)
 
 void
 MlasDepthwiseThreaded(
@@ -1119,7 +1119,7 @@ Return Value:
         return;
     }
 
-#if defined(MLAS_TARGET_WASM_SCALAR) || defined(MLAS_TARGET_ARM64)
+#if defined(MLAS_TARGET_WASM_SCALAR) || defined(MLAS_TARGET_ARM64) || defined(MLAS_TARGET_RISCV64)
 
     if (Algorithm == MlasConvAlgorithmDepthwise) {
         // Fill the Working Buffer with Zero for use by the depthwise kernel.
@@ -1178,7 +1178,7 @@ Return Value:
     }
 
 
-#if defined(MLAS_TARGET_WASM_SCALAR) || defined(MLAS_TARGET_ARM64)
+#if defined(MLAS_TARGET_WASM_SCALAR) || defined(MLAS_TARGET_ARM64) || defined(MLAS_TARGET_RISCV64)
 
     if (Algorithm == MlasConvAlgorithmDepthwise && ((BatchCount > 1) || (GroupCount > 1))) {
         const size_t BatchGroupCount = BatchCount * GroupCount;
@@ -1277,7 +1277,7 @@ Return Value:
                     break;
                 }
 
-#if defined(MLAS_TARGET_WASM_SCALAR) || defined(MLAS_TARGET_ARM64)
+#if defined(MLAS_TARGET_WASM_SCALAR) || defined(MLAS_TARGET_ARM64) || defined(MLAS_TARGET_RISCV64)
 
                 case MlasConvAlgorithmDepthwise:
                 {
@@ -1549,15 +1549,14 @@ Return Value:
     }
 #endif
 
-#if defined(MLAS_TARGET_WASM_SCALAR) || defined(MLAS_TARGET_ARM64)
+#if defined(MLAS_TARGET_WASM_SCALAR) || defined(MLAS_TARGET_ARM64) || defined(MLAS_TARGET_RISCV64)
 
-        // Scalar (WASM_SCALAR) / vectorized (ARM64) direct conv for depthwise convolution.
+        // Scalar (WASM_SCALAR) / vectorized (ARM64/RISCV64) direct conv for depthwise convolution.
         // Currently only support 3x3 kernel with padding <=1 and dilations = 1
-        // and on ARM64, it is further restricted to strides = 1.
+        // and on ARM64/RISCV64, it is further restricted to strides = 1.
         // TODO: support more general depthwise convolution.
 
-        // On ARM64, only support stride = 1 for depthwise conv.
-    #if defined(MLAS_TARGET_ARM64)
+    #if defined(MLAS_TARGET_ARM64) || defined(MLAS_TARGET_RISCV64)
         bool depthwise_conv_stride_support_check = Parameters->StrideShape[0] == 1 && Parameters->StrideShape[1] == 1;
     #else
         bool depthwise_conv_stride_support_check = true;

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -1203,6 +1203,13 @@ extern "C" {
     MLAS_REDUCE_MAXIMUM_FLOAT_KERNEL MlasReduceMaximumF32KernelRvv;
     MLAS_COMPUTE_SOFTMAX_OUTPUT_FLOAT_KERNEL MlasComputeSoftmaxOutputF32KernelRvv;
     MLAS_COMPUTE_LOGSOFTMAX_OUTPUT_FLOAT_KERNEL MlasComputeLogSoftmaxOutputF32KernelRvv;
+    MLAS_CONV_FLOAT_KERNEL MlasConvNchwFloatKernelRvv;
+    MLAS_CONV_FLOAT_KERNEL MlasConvNchwcFloatKernelRvv;
+    MLAS_CONV_DEPTHWISE_FLOAT_KERNEL MlasConvDepthwiseFloatKernelRvv;
+    MLAS_CONV_POINTWISE_FLOAT_KERNEL MlasConvPointwiseFloatKernelRvv;
+    MLAS_POOL_FLOAT_KERNEL MlasPoolMaximumFloatKernelRvv;
+    MLAS_POOL_FLOAT_KERNEL MlasPoolAverageExcludePadFloatKernelRvv;
+    MLAS_POOL_FLOAT_KERNEL MlasPoolAverageIncludePadFloatKernelRvv;
 #endif
 #if defined(MLAS_TARGET_AMD64)
     MLAS_REDUCE_MAXIMUM_FLOAT_KERNEL MlasReduceMaximumF32KernelAvx;
@@ -1553,6 +1560,15 @@ struct MLAS_PLATFORM {
     MLAS_COMPUTE_SOFTMAX_OUTPUT_FLOAT_KERNEL* ComputeSoftmaxOutputF32Kernel;
 #endif
 
+#if defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV)
+    MLAS_CONV_FLOAT_KERNEL* ConvNchwFloatKernel;
+    MLAS_CONV_FLOAT_KERNEL* ConvNchwcFloatKernel;
+    MLAS_CONV_DEPTHWISE_FLOAT_KERNEL* ConvDepthwiseFloatKernel;
+    MLAS_CONV_POINTWISE_FLOAT_KERNEL* ConvPointwiseFloatKernel;
+    MLAS_POOL_FLOAT_KERNEL* PoolFloatKernel[MlasPoolingKindCount];
+    uint32_t NchwcBlockSize;
+#endif
+
 MLAS_COMPUTE_ERF_FP16_KERNEL* ErfFP16KernelRoutine = nullptr;
 MLAS_COMPUTE_GELU_FP16_KERNEL* GeluFP16KernelRoutine = nullptr;
 MLAS_COMPUTE_TANH_FP16_KERNEL* TanhFP16KernelRoutine = nullptr;
@@ -1760,7 +1776,7 @@ MlasFp32FromBits(
 #pragma warning(pop)
 #endif
 
-#if defined(MLAS_TARGET_WASM_SCALAR) || defined(MLAS_TARGET_ARM64)
+#if defined(MLAS_TARGET_WASM_SCALAR) || defined(MLAS_TARGET_ARM64) || defined(MLAS_TARGET_RISCV64)
 void
 MLASCALL
 MlasConvDepthwiseFloat_CHW(

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -27,7 +27,7 @@ Abstract:
 #include "kleidiai/mlasi_kleidiai.h"
 #endif
 
-#if defined(MLAS_USE_RVV)
+#if defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV)
 #include <riscv_vector.h>
 #endif
 

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -55,53 +55,7 @@ Abstract:
 #include <sys/auxv.h>
 #endif
 
-#if defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV) && defined(__linux__)
-#include <sys/auxv.h>
-#include <asm/hwcap.h>
-#ifndef COMPAT_HWCAP_ISA_V
-#define COMPAT_HWCAP_ISA_V (1UL << ('V' - 'A'))
-#endif
-#endif
 
-#if defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV)
-namespace {
-
-bool
-MlasStringEqualsIgnoreCase(
-    const char* value,
-    const char* expected
-    )
-{
-    while (*value != '\0' && *expected != '\0') {
-        const auto lhs = static_cast<unsigned char>(*value);
-        const auto rhs = static_cast<unsigned char>(*expected);
-        if (std::tolower(lhs) != std::tolower(rhs)) {
-            return false;
-        }
-        ++value;
-        ++expected;
-    }
-
-    return *value == '\0' && *expected == '\0';
-}
-
-bool
-MlasShouldForceScalarRiscv(
-    const char* value
-    )
-{
-    if (value == nullptr || value[0] == '\0') {
-        return false;
-    }
-
-    return MlasStringEqualsIgnoreCase(value, "1") ||
-           MlasStringEqualsIgnoreCase(value, "true") ||
-           MlasStringEqualsIgnoreCase(value, "on") ||
-           MlasStringEqualsIgnoreCase(value, "yes");
-}
-
-}  // namespace
-#endif
 
 #if defined(MLAS_TARGET_ARM64)
 #if defined(_WIN32)
@@ -329,40 +283,31 @@ Return Value:
     this->ComputeLogSoftmaxOutputF32Kernel = MlasComputeLogSoftmaxOutputF32Kernel;
 
 #if defined(MLAS_USE_RVV)
-    this->NchwcBlockSize = 1;
-    this->ConvNchwFloatKernel = nullptr;
-    this->ConvNchwcFloatKernel = nullptr;
-    this->ConvDepthwiseFloatKernel = nullptr;
-    this->ConvPointwiseFloatKernel = nullptr;
-    this->PoolFloatKernel[MlasMaximumPooling] = nullptr;
-    this->PoolFloatKernel[MlasAveragePoolingExcludePad] = nullptr;
-    this->PoolFloatKernel[MlasAveragePoolingIncludePad] = nullptr;
+    this->GemmFloatKernel = MlasGemmFloatKernelRvv;
+    this->ReduceMaximumF32Kernel = MlasReduceMaximumF32KernelRvv;
+    this->ComputeSumExpF32Kernel = MlasComputeSumExpF32KernelRvv;
+    this->ComputeSoftmaxOutputF32Kernel = MlasComputeSoftmaxOutputF32KernelRvv;
+    this->ComputeLogSoftmaxOutputF32Kernel = MlasComputeLogSoftmaxOutputF32KernelRvv;
 
-    bool has_rvv = true;
-#if defined(__linux__)
-    has_rvv = (getauxval(AT_HWCAP) & COMPAT_HWCAP_ISA_V) != 0;
-#endif
-    if (MlasShouldForceScalarRiscv(std::getenv("ORT_MLAS_RISCV_FORCE_SCALAR"))) {
-        has_rvv = false;
-    }
-    if (has_rvv) {
-        this->GemmFloatKernel = MlasGemmFloatKernelRvv;
-        this->ReduceMaximumF32Kernel = MlasReduceMaximumF32KernelRvv;
-        this->ComputeSumExpF32Kernel = MlasComputeSumExpF32KernelRvv;
-        this->ComputeSoftmaxOutputF32Kernel = MlasComputeSoftmaxOutputF32KernelRvv;
-        this->ComputeLogSoftmaxOutputF32Kernel = MlasComputeLogSoftmaxOutputF32KernelRvv;
-
-        // NCHWc kernels require VLEN>=128 so that vfloat32m4_t holds 16 floats.
-        if (__riscv_vlenb() >= 16) {
-            this->NchwcBlockSize = 16;
-            this->ConvNchwFloatKernel = MlasConvNchwFloatKernelRvv;
-            this->ConvNchwcFloatKernel = MlasConvNchwcFloatKernelRvv;
-            this->ConvDepthwiseFloatKernel = MlasConvDepthwiseFloatKernelRvv;
-            this->ConvPointwiseFloatKernel = MlasConvPointwiseFloatKernelRvv;
-            this->PoolFloatKernel[MlasMaximumPooling] = MlasPoolMaximumFloatKernelRvv;
-            this->PoolFloatKernel[MlasAveragePoolingExcludePad] = MlasPoolAverageExcludePadFloatKernelRvv;
-            this->PoolFloatKernel[MlasAveragePoolingIncludePad] = MlasPoolAverageIncludePadFloatKernelRvv;
-        }
+    // NCHWc kernels require VLEN>=128 so that vfloat32m4_t holds 16 floats.
+    if (__riscv_vlenb() >= 16) {
+        this->NchwcBlockSize = 16;
+        this->ConvNchwFloatKernel = MlasConvNchwFloatKernelRvv;
+        this->ConvNchwcFloatKernel = MlasConvNchwcFloatKernelRvv;
+        this->ConvDepthwiseFloatKernel = MlasConvDepthwiseFloatKernelRvv;
+        this->ConvPointwiseFloatKernel = MlasConvPointwiseFloatKernelRvv;
+        this->PoolFloatKernel[MlasMaximumPooling] = MlasPoolMaximumFloatKernelRvv;
+        this->PoolFloatKernel[MlasAveragePoolingExcludePad] = MlasPoolAverageExcludePadFloatKernelRvv;
+        this->PoolFloatKernel[MlasAveragePoolingIncludePad] = MlasPoolAverageIncludePadFloatKernelRvv;
+    } else {
+        this->NchwcBlockSize = 1;
+        this->ConvNchwFloatKernel = nullptr;
+        this->ConvNchwcFloatKernel = nullptr;
+        this->ConvDepthwiseFloatKernel = nullptr;
+        this->ConvPointwiseFloatKernel = nullptr;
+        this->PoolFloatKernel[MlasMaximumPooling] = nullptr;
+        this->PoolFloatKernel[MlasAveragePoolingExcludePad] = nullptr;
+        this->PoolFloatKernel[MlasAveragePoolingIncludePad] = nullptr;
     }
 #endif
 #endif

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -338,6 +338,15 @@ Return Value:
         this->ComputeSumExpF32Kernel = MlasComputeSumExpF32KernelRvv;
         this->ComputeSoftmaxOutputF32Kernel = MlasComputeSoftmaxOutputF32KernelRvv;
         this->ComputeLogSoftmaxOutputF32Kernel = MlasComputeLogSoftmaxOutputF32KernelRvv;
+
+        this->NchwcBlockSize = 16;
+        this->ConvNchwFloatKernel = MlasConvNchwFloatKernelRvv;
+        this->ConvNchwcFloatKernel = MlasConvNchwcFloatKernelRvv;
+        this->ConvDepthwiseFloatKernel = MlasConvDepthwiseFloatKernelRvv;
+        this->ConvPointwiseFloatKernel = MlasConvPointwiseFloatKernelRvv;
+        this->PoolFloatKernel[MlasMaximumPooling] = MlasPoolMaximumFloatKernelRvv;
+        this->PoolFloatKernel[MlasAveragePoolingExcludePad] = MlasPoolAverageExcludePadFloatKernelRvv;
+        this->PoolFloatKernel[MlasAveragePoolingIncludePad] = MlasPoolAverageIncludePadFloatKernelRvv;
     }
 #endif
 #endif

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -27,6 +27,10 @@ Abstract:
 #include "kleidiai/mlasi_kleidiai.h"
 #endif
 
+#if defined(MLAS_USE_RVV)
+#include <riscv_vector.h>
+#endif
+
 #include <cctype>
 #include <cstdlib>
 #include <mutex>
@@ -325,6 +329,15 @@ Return Value:
     this->ComputeLogSoftmaxOutputF32Kernel = MlasComputeLogSoftmaxOutputF32Kernel;
 
 #if defined(MLAS_USE_RVV)
+    this->NchwcBlockSize = 1;
+    this->ConvNchwFloatKernel = nullptr;
+    this->ConvNchwcFloatKernel = nullptr;
+    this->ConvDepthwiseFloatKernel = nullptr;
+    this->ConvPointwiseFloatKernel = nullptr;
+    this->PoolFloatKernel[MlasMaximumPooling] = nullptr;
+    this->PoolFloatKernel[MlasAveragePoolingExcludePad] = nullptr;
+    this->PoolFloatKernel[MlasAveragePoolingIncludePad] = nullptr;
+
     bool has_rvv = true;
 #if defined(__linux__)
     has_rvv = (getauxval(AT_HWCAP) & COMPAT_HWCAP_ISA_V) != 0;
@@ -339,14 +352,17 @@ Return Value:
         this->ComputeSoftmaxOutputF32Kernel = MlasComputeSoftmaxOutputF32KernelRvv;
         this->ComputeLogSoftmaxOutputF32Kernel = MlasComputeLogSoftmaxOutputF32KernelRvv;
 
-        this->NchwcBlockSize = 16;
-        this->ConvNchwFloatKernel = MlasConvNchwFloatKernelRvv;
-        this->ConvNchwcFloatKernel = MlasConvNchwcFloatKernelRvv;
-        this->ConvDepthwiseFloatKernel = MlasConvDepthwiseFloatKernelRvv;
-        this->ConvPointwiseFloatKernel = MlasConvPointwiseFloatKernelRvv;
-        this->PoolFloatKernel[MlasMaximumPooling] = MlasPoolMaximumFloatKernelRvv;
-        this->PoolFloatKernel[MlasAveragePoolingExcludePad] = MlasPoolAverageExcludePadFloatKernelRvv;
-        this->PoolFloatKernel[MlasAveragePoolingIncludePad] = MlasPoolAverageIncludePadFloatKernelRvv;
+        // NCHWc kernels require VLEN>=128 so that vfloat32m4_t holds 16 floats.
+        if (__riscv_vlenb() >= 16) {
+            this->NchwcBlockSize = 16;
+            this->ConvNchwFloatKernel = MlasConvNchwFloatKernelRvv;
+            this->ConvNchwcFloatKernel = MlasConvNchwcFloatKernelRvv;
+            this->ConvDepthwiseFloatKernel = MlasConvDepthwiseFloatKernelRvv;
+            this->ConvPointwiseFloatKernel = MlasConvPointwiseFloatKernelRvv;
+            this->PoolFloatKernel[MlasMaximumPooling] = MlasPoolMaximumFloatKernelRvv;
+            this->PoolFloatKernel[MlasAveragePoolingExcludePad] = MlasPoolAverageExcludePadFloatKernelRvv;
+            this->PoolFloatKernel[MlasAveragePoolingIncludePad] = MlasPoolAverageIncludePadFloatKernelRvv;
+        }
     }
 #endif
 #endif

--- a/onnxruntime/core/mlas/lib/riscv64/sconv_depthwise_kernel_rvv.cpp
+++ b/onnxruntime/core/mlas/lib/riscv64/sconv_depthwise_kernel_rvv.cpp
@@ -135,7 +135,13 @@ MlasConv2dSingleChannel_CHW_Kernel3x3_Pad01_Dilation1(
 
     const size_t pad_top = Parameters->Padding[0];
     const size_t pad_left = Parameters->Padding[1];
+    const size_t pad_bottom = Parameters->Padding[2];
     const size_t pad_right = Parameters->Padding[3];
+
+    assert(pad_top <= 1);
+    assert(pad_bottom <= 1);
+    assert(pad_left <= 1);
+    assert(pad_right <= 1);
 
     const float beta = Parameters->Beta;
     const bool accumulate_output = beta != 0.0f;

--- a/onnxruntime/core/mlas/lib/riscv64/sconv_depthwise_kernel_rvv.cpp
+++ b/onnxruntime/core/mlas/lib/riscv64/sconv_depthwise_kernel_rvv.cpp
@@ -1,0 +1,275 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    sconv_depthwise_kernel_rvv.cpp
+
+Abstract:
+
+    This module implements an RVV kernel for the single precision depthwise
+    convolution operation (3x3 kernel, stride 1, dilation 1, padding <= 1)
+    on riscv64.
+
+--*/
+
+#include "mlasi.h"
+
+#if defined(MLAS_USE_RVV)
+
+#include <riscv_vector.h>
+#include <cassert>
+
+namespace {
+
+MLAS_FORCEINLINE
+void
+DepthwiseAccumulateRowRvv(
+    vfloat32m4_t& acc,
+    const float* row,
+    size_t base,
+    float w0,
+    float w1,
+    float w2,
+    size_t vl
+    )
+{
+    if (row == nullptr) {
+        return;
+    }
+
+    const float* r = row + base;
+    vfloat32m4_t c0 = __riscv_vle32_v_f32m4(r, vl);
+    vfloat32m4_t c1 = __riscv_vle32_v_f32m4(r + 1, vl);
+    vfloat32m4_t c2 = __riscv_vle32_v_f32m4(r + 2, vl);
+
+    acc = __riscv_vfmacc_vf_f32m4(acc, w0, c0, vl);
+    acc = __riscv_vfmacc_vf_f32m4(acc, w1, c1, vl);
+    acc = __riscv_vfmacc_vf_f32m4(acc, w2, c2, vl);
+}
+
+MLAS_FORCEINLINE
+float
+DepthwiseSampleValue(
+    const float* row,
+    ptrdiff_t col,
+    size_t width
+    )
+{
+    if (row == nullptr || col < 0 || col >= static_cast<ptrdiff_t>(width)) {
+        return 0.0f;
+    }
+    return row[col];
+}
+
+MLAS_FORCEINLINE
+float
+DepthwiseComputeEdge(
+    const float* row0,
+    const float* row1,
+    const float* row2,
+    ptrdiff_t iw,
+    size_t width,
+    float w00, float w01, float w02,
+    float w10, float w11, float w12,
+    float w20, float w21, float w22
+    )
+{
+    float acc = 0.0f;
+    const ptrdiff_t c0 = iw;
+    const ptrdiff_t c1 = iw + 1;
+    const ptrdiff_t c2 = iw + 2;
+
+    acc += DepthwiseSampleValue(row0, c0, width) * w00;
+    acc += DepthwiseSampleValue(row0, c1, width) * w01;
+    acc += DepthwiseSampleValue(row0, c2, width) * w02;
+    acc += DepthwiseSampleValue(row1, c0, width) * w10;
+    acc += DepthwiseSampleValue(row1, c1, width) * w11;
+    acc += DepthwiseSampleValue(row1, c2, width) * w12;
+    acc += DepthwiseSampleValue(row2, c0, width) * w20;
+    acc += DepthwiseSampleValue(row2, c1, width) * w21;
+    acc += DepthwiseSampleValue(row2, c2, width) * w22;
+
+    return acc;
+}
+
+MLAS_FORCEINLINE
+float
+DepthwiseAccumulateRowScalar(
+    float acc,
+    const float* row,
+    size_t base,
+    float w0,
+    float w1,
+    float w2
+    )
+{
+    if (row == nullptr) {
+        return acc;
+    }
+
+    acc += row[base] * w0;
+    acc += row[base + 1] * w1;
+    acc += row[base + 2] * w2;
+    return acc;
+}
+
+}  // namespace
+
+static
+void
+MlasConv2dSingleChannel_CHW_Kernel3x3_Pad01_Dilation1(
+    const MLAS_CONV_PARAMETERS* Parameters,
+    const float* Input,
+    const float* Filter,
+    float* Output
+    )
+{
+    const size_t H = Parameters->InputShape[0];
+    const size_t W = Parameters->InputShape[1];
+    const size_t out_rows = Parameters->OutputShape[0];
+    const size_t out_cols = Parameters->OutputShape[1];
+
+    const size_t pad_top = Parameters->Padding[0];
+    const size_t pad_left = Parameters->Padding[1];
+    const size_t pad_right = Parameters->Padding[3];
+
+    const float beta = Parameters->Beta;
+    const bool accumulate_output = beta != 0.0f;
+
+    const float w00 = Filter[0];
+    const float w01 = Filter[1];
+    const float w02 = Filter[2];
+    const float w10 = Filter[3];
+    const float w11 = Filter[4];
+    const float w12 = Filter[5];
+    const float w20 = Filter[6];
+    const float w21 = Filter[7];
+    const float w22 = Filter[8];
+
+    for (size_t oh = 0; oh < out_rows; ++oh) {
+        const ptrdiff_t ih = static_cast<ptrdiff_t>(oh) - static_cast<ptrdiff_t>(pad_top);
+
+        const ptrdiff_t row0_index = ih;
+        const ptrdiff_t row1_index = ih + 1;
+        const ptrdiff_t row2_index = ih + 2;
+
+        const float* row0 = nullptr;
+        const float* row1 = nullptr;
+        const float* row2 = nullptr;
+
+        if (row0_index >= 0 && row0_index < static_cast<ptrdiff_t>(H)) {
+            row0 = Input + static_cast<size_t>(row0_index) * W;
+        }
+        if (row1_index >= 0 && row1_index < static_cast<ptrdiff_t>(H)) {
+            row1 = Input + static_cast<size_t>(row1_index) * W;
+        }
+        if (row2_index >= 0 && row2_index < static_cast<ptrdiff_t>(H)) {
+            row2 = Input + static_cast<size_t>(row2_index) * W;
+        }
+
+        float* out_row = Output + oh * out_cols;
+        size_t ow = 0;
+
+        if (pad_left && ow < out_cols) {
+            const ptrdiff_t iw = static_cast<ptrdiff_t>(ow) - static_cast<ptrdiff_t>(pad_left);
+            float acc = DepthwiseComputeEdge(
+                row0, row1, row2, iw, W,
+                w00, w01, w02, w10, w11, w12, w20, w21, w22
+            );
+            if (accumulate_output) {
+                acc += beta * out_row[ow];
+            }
+            out_row[ow++] = acc;
+        }
+
+        size_t interior_cols = 0;
+        if (out_cols > pad_left + pad_right) {
+            interior_cols = out_cols - pad_left - pad_right;
+        }
+
+        size_t processed = 0;
+        while (processed < interior_cols) {
+            const ptrdiff_t iw = static_cast<ptrdiff_t>(ow) - static_cast<ptrdiff_t>(pad_left);
+            const size_t base = static_cast<size_t>(iw);
+
+            size_t remaining = interior_cols - processed;
+            if ((base + remaining + 2) > W) {
+                remaining = (W > base + 2) ? W - base - 2 : 0;
+            }
+
+            if (remaining == 0) {
+                break;
+            }
+
+            size_t vl = __riscv_vsetvl_e32m4(remaining);
+
+            vfloat32m4_t acc = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+
+            DepthwiseAccumulateRowRvv(acc, row0, base, w00, w01, w02, vl);
+            DepthwiseAccumulateRowRvv(acc, row1, base, w10, w11, w12, vl);
+            DepthwiseAccumulateRowRvv(acc, row2, base, w20, w21, w22, vl);
+
+            if (accumulate_output) {
+                vfloat32m4_t prev = __riscv_vle32_v_f32m4(out_row + ow, vl);
+                acc = __riscv_vfmacc_vf_f32m4(acc, beta, prev, vl);
+            }
+
+            __riscv_vse32_v_f32m4(out_row + ow, acc, vl);
+            ow += vl;
+            processed += vl;
+        }
+
+        for (; processed < interior_cols; ++processed) {
+            const ptrdiff_t iw = static_cast<ptrdiff_t>(ow) - static_cast<ptrdiff_t>(pad_left);
+            const size_t base = static_cast<size_t>(iw);
+
+            float acc = 0.0f;
+            acc = DepthwiseAccumulateRowScalar(acc, row0, base, w00, w01, w02);
+            acc = DepthwiseAccumulateRowScalar(acc, row1, base, w10, w11, w12);
+            acc = DepthwiseAccumulateRowScalar(acc, row2, base, w20, w21, w22);
+
+            if (accumulate_output) {
+                acc += beta * out_row[ow];
+            }
+            out_row[ow++] = acc;
+        }
+
+        if (pad_right && ow < out_cols) {
+            const ptrdiff_t iw = static_cast<ptrdiff_t>(ow) - static_cast<ptrdiff_t>(pad_left);
+            float acc = DepthwiseComputeEdge(
+                row0, row1, row2, iw, W,
+                w00, w01, w02, w10, w11, w12, w20, w21, w22
+            );
+            if (accumulate_output) {
+                acc += beta * out_row[ow];
+            }
+            out_row[ow++] = acc;
+        }
+    }
+}
+
+void MlasConvDepthwiseFloat_CHW(
+    const MLAS_CONV_PARAMETERS* Parameters,
+    const float* Input,
+    const float* Filter,
+    float* Output,
+    const float* Zeros
+    )
+{
+    MLAS_UNREFERENCED_PARAMETER(Zeros);
+
+    assert(Parameters->Dimensions == 2);
+    assert(Parameters->FilterCount == 1);
+    assert(Parameters->InputChannels == 1);
+    assert(Parameters->KernelShape[0] == 3 && Parameters->KernelShape[1] == 3);
+    assert(Parameters->StrideShape[0] == 1 && Parameters->StrideShape[1] == 1);
+    assert(Parameters->DilationShape[0] == 1 && Parameters->DilationShape[1] == 1);
+
+    MlasConv2dSingleChannel_CHW_Kernel3x3_Pad01_Dilation1(Parameters, Input, Filter, Output);
+}
+
+#endif  // MLAS_USE_RVV

--- a/onnxruntime/core/mlas/lib/riscv64/sconv_nchwc_kernel_rvv.cpp
+++ b/onnxruntime/core/mlas/lib/riscv64/sconv_nchwc_kernel_rvv.cpp
@@ -1,0 +1,581 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    sconv_nchwc_kernel_rvv.cpp
+
+Abstract:
+
+    This module implements RVV kernels for the single precision NCHWc
+    convolution operations on riscv64: direct NCHW, direct NCHWc,
+    depthwise, and pointwise convolution.
+
+    BlockSize is fixed at 16, matching the ARM64 NEON NCHWc layout.
+    With VLEN>=128 and LMUL=4, a single vfloat32m4_t holds 16 floats.
+
+--*/
+
+#include "mlasi.h"
+
+#if defined(MLAS_USE_RVV)
+
+#include <riscv_vector.h>
+#include <limits>
+
+#define MLAS_CONV_KERNEL_FLAG_ACCUMULATE_OUTPUT     0x00000001
+#define MLAS_CONV_KERNEL_FLAG_BIAS_ADDITION         0x00000002
+#define MLAS_CONV_KERNEL_FLAG_RELU_ACTIVATION       0x00000004
+#define MLAS_CONV_KERNEL_FLAG_OTHER_ACTIVATION      0x00000008
+
+namespace {
+
+constexpr size_t BlockSize = 16;
+
+MLAS_FORCEINLINE
+void
+ApplyPostProcessing(
+    vfloat32m4_t& acc,
+    const float* Output,
+    const float* Bias,
+    unsigned KernelFlags,
+    size_t vl
+    )
+{
+    if (KernelFlags & MLAS_CONV_KERNEL_FLAG_ACCUMULATE_OUTPUT) {
+        vfloat32m4_t old_output = __riscv_vle32_v_f32m4(Output, vl);
+        acc = __riscv_vfadd_vv_f32m4(acc, old_output, vl);
+    }
+
+    if (KernelFlags & MLAS_CONV_KERNEL_FLAG_BIAS_ADDITION) {
+        vfloat32m4_t bias_vec = __riscv_vle32_v_f32m4(Bias, vl);
+        acc = __riscv_vfadd_vv_f32m4(acc, bias_vec, vl);
+    }
+
+    if (KernelFlags & MLAS_CONV_KERNEL_FLAG_RELU_ACTIVATION) {
+        vfloat32m4_t zero = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+        acc = __riscv_vfmax_vv_f32m4(acc, zero, vl);
+    }
+}
+
+}  // namespace
+
+//
+// Direct NCHW convolution kernel.
+//
+// Input is in NCHW format (single channel per kernel position).
+// Filter is laid out as [KH][KW][BlockSize] — one scalar input is
+// broadcast and multiplied with BlockSize filter values.
+// Output is in NCHWc (BlockSize channels interleaved).
+//
+
+void
+MLASCALL
+MlasConvNchwFloatKernelRvv(
+    const float* Input,
+    const float* Filter,
+    float* Output,
+    size_t StrideWidth,
+    size_t DilationWidth,
+    size_t FilterCount,
+    size_t InputStride,
+    size_t FilterStride,
+    size_t OutputStride,
+    size_t KernelHeight,
+    size_t KernelWidth,
+    const float* InputBase,
+    size_t InputWidth,
+    size_t DilatedInputWidth,
+    size_t OutputCountLeftPad,
+    size_t OutputCount,
+    size_t OutputCountRightPad,
+    const float* Bias,
+    unsigned KernelFlags
+    )
+{
+    MLAS_UNREFERENCED_PARAMETER(InputStride);
+
+    const size_t vl = __riscv_vsetvl_e32m4(BlockSize);
+    const size_t StrideWidthElements = StrideWidth / sizeof(float);
+    const size_t DilationWidthElements = DilationWidth / sizeof(float);
+    const size_t FilterStrideElements = FilterStride / sizeof(float);
+    const size_t OutputStrideElements = OutputStride / sizeof(float);
+    const size_t InputWidthElements = InputWidth / sizeof(float);
+    const size_t DilatedInputWidthElements = DilatedInputWidth / sizeof(float);
+
+    const size_t TotalOutputCount = OutputCountLeftPad + OutputCount + OutputCountRightPad;
+
+    for (size_t output_idx = 0; output_idx < TotalOutputCount; output_idx++) {
+
+        for (size_t filterSetBlock = 0; filterSetBlock < FilterCount; filterSetBlock++) {
+            const float* filter = Filter + filterSetBlock * FilterStrideElements;
+            float* output = Output + filterSetBlock * OutputStrideElements;
+
+            vfloat32m4_t acc = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+
+            for (size_t kh = 0; kh < KernelHeight; kh++) {
+                for (size_t kw = 0; kw < KernelWidth; kw++) {
+                    const float* input_pos = Input + output_idx * StrideWidthElements +
+                                             kh * DilatedInputWidthElements + kw * DilationWidthElements;
+
+                    const float* input_row_start = InputBase + kh * DilatedInputWidthElements;
+                    const float* input_row_end = input_row_start + InputWidthElements;
+
+                    float input_value = 0.0f;
+                    if (input_pos >= input_row_start && input_pos < input_row_end) {
+                        input_value = *input_pos;
+                    }
+
+                    size_t kernel_base_pos = kh * KernelWidth + kw;
+                    vfloat32m4_t filt = __riscv_vle32_v_f32m4(&filter[kernel_base_pos * BlockSize], vl);
+                    acc = __riscv_vfmacc_vf_f32m4(acc, input_value, filt, vl);
+                }
+            }
+
+            ApplyPostProcessing(acc, &output[output_idx * BlockSize],
+                                Bias ? &Bias[filterSetBlock * BlockSize] : nullptr,
+                                KernelFlags, vl);
+
+            __riscv_vse32_v_f32m4(&output[output_idx * BlockSize], acc, vl);
+        }
+    }
+}
+
+//
+// Direct NCHWc convolution kernel.
+//
+// Input is in NCHWc format (BlockSize channels interleaved per spatial position).
+// Filter layout: [KH][KW][BlockSize_in][BlockSize_out].
+// For each kernel position and input channel, one input scalar is broadcast
+// and multiplied with BlockSize output filter values.
+//
+
+void
+MLASCALL
+MlasConvNchwcFloatKernelRvv(
+    const float* Input,
+    const float* Filter,
+    float* Output,
+    size_t StrideWidth,
+    size_t DilationWidth,
+    size_t FilterCount,
+    size_t InputStride,
+    size_t FilterStride,
+    size_t OutputStride,
+    size_t KernelHeight,
+    size_t KernelWidth,
+    const float* InputBase,
+    size_t InputWidth,
+    size_t DilatedInputWidth,
+    size_t OutputCountLeftPad,
+    size_t OutputCount,
+    size_t OutputCountRightPad,
+    const float* Bias,
+    unsigned KernelFlags
+    )
+{
+    MLAS_UNREFERENCED_PARAMETER(InputStride);
+
+    const size_t vl = __riscv_vsetvl_e32m4(BlockSize);
+    const size_t StrideWidthElements = StrideWidth / sizeof(float);
+    const size_t DilationWidthElements = DilationWidth / sizeof(float);
+    const size_t FilterStrideElements = FilterStride / sizeof(float);
+    const size_t OutputStrideElements = OutputStride / sizeof(float);
+    const size_t InputWidthElements = InputWidth / sizeof(float);
+    const size_t DilatedInputWidthElements = DilatedInputWidth / sizeof(float);
+
+    const size_t TotalOutputCount = OutputCountLeftPad + OutputCount + OutputCountRightPad;
+
+    for (size_t output_idx = 0; output_idx < TotalOutputCount; output_idx++) {
+
+        for (size_t filterSetBlock = 0; filterSetBlock < FilterCount; filterSetBlock++) {
+            const float* filter = Filter + filterSetBlock * FilterStrideElements;
+            float* output = Output + filterSetBlock * OutputStrideElements;
+
+            vfloat32m4_t acc = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+
+            for (size_t kh = 0; kh < KernelHeight; kh++) {
+                for (size_t kw = 0; kw < KernelWidth; kw++) {
+                    const float* input_base = Input + output_idx * StrideWidthElements +
+                                              kh * DilatedInputWidthElements + kw * DilationWidthElements;
+
+                    const float* input_row_start = InputBase + kh * DilatedInputWidthElements;
+                    const float* input_row_end = input_row_start + InputWidthElements;
+
+                    size_t kernel_pos = kh * KernelWidth + kw;
+
+                    for (size_t ic = 0; ic < BlockSize; ic++) {
+                        const float* input_element = input_base + ic;
+
+                        float input_value = 0.0f;
+                        if (input_element >= input_row_start && input_element < input_row_end) {
+                            input_value = *input_element;
+                        }
+
+                        size_t filter_offset = kernel_pos * BlockSize * BlockSize + ic * BlockSize;
+                        vfloat32m4_t filt = __riscv_vle32_v_f32m4(&filter[filter_offset], vl);
+                        acc = __riscv_vfmacc_vf_f32m4(acc, input_value, filt, vl);
+                    }
+                }
+            }
+
+            ApplyPostProcessing(acc, &output[output_idx * BlockSize],
+                                Bias ? &Bias[filterSetBlock * BlockSize] : nullptr,
+                                KernelFlags, vl);
+
+            __riscv_vse32_v_f32m4(&output[output_idx * BlockSize], acc, vl);
+        }
+    }
+}
+
+//
+// Depthwise NCHWc convolution kernel.
+//
+// Each channel is convolved with its own filter (element-wise).
+// Input is NCHWc, filter is [KH][KW][BlockSize].
+//
+
+void
+MLASCALL
+MlasConvDepthwiseFloatKernelRvv(
+    const float* Input,
+    const float* Filter,
+    float* Output,
+    size_t StrideWidth,
+    size_t DilationWidth,
+    size_t InputStride,
+    size_t KernelHeight,
+    size_t KernelWidth,
+    const float* InputBase,
+    size_t InputWidth,
+    size_t DilatedInputWidth,
+    size_t OutputCountLeftPad,
+    size_t OutputCount,
+    size_t OutputCountRightPad,
+    const float* Bias,
+    unsigned KernelFlags
+    )
+{
+    MLAS_UNREFERENCED_PARAMETER(InputStride);
+
+    const size_t vl = __riscv_vsetvl_e32m4(BlockSize);
+    const size_t StrideWidthElements = StrideWidth / sizeof(float);
+    const size_t DilationWidthElements = DilationWidth / sizeof(float);
+    const size_t InputWidthElements = InputWidth / sizeof(float);
+    const size_t DilatedInputWidthElements = DilatedInputWidth / sizeof(float);
+
+    const size_t TotalOutputCount = OutputCountLeftPad + OutputCount + OutputCountRightPad;
+    const size_t KernelSize = KernelHeight * KernelWidth;
+
+    for (size_t output_idx = 0; output_idx < TotalOutputCount; output_idx++) {
+
+        vfloat32m4_t acc = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+
+        for (size_t kpos = 0; kpos < KernelSize; kpos++) {
+            size_t kh = kpos / KernelWidth;
+            size_t kw = kpos % KernelWidth;
+
+            const float* input_base = Input + output_idx * StrideWidthElements +
+                                      kh * DilatedInputWidthElements + kw * DilationWidthElements;
+
+            const float* input_row_start = InputBase + kh * DilatedInputWidthElements;
+            const float* input_row_end = input_row_start + InputWidthElements;
+
+            vfloat32m4_t input_vec;
+            if (input_base >= input_row_start && (input_base + BlockSize - 1) < input_row_end) {
+                input_vec = __riscv_vle32_v_f32m4(input_base, vl);
+            } else {
+                input_vec = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+            }
+
+            vfloat32m4_t filt = __riscv_vle32_v_f32m4(&Filter[kpos * BlockSize], vl);
+            acc = __riscv_vfmacc_vv_f32m4(acc, input_vec, filt, vl);
+        }
+
+        ApplyPostProcessing(acc, &Output[output_idx * BlockSize], Bias, KernelFlags, vl);
+
+        __riscv_vse32_v_f32m4(&Output[output_idx * BlockSize], acc, vl);
+    }
+}
+
+//
+// Pointwise (1x1) NCHWc convolution kernel.
+//
+// No padding, kernel size = 1.
+// Processes OutputCount output positions, accumulating over InputChannels
+// (counted in blocks of BlockSize).
+//
+
+void
+MLASCALL
+MlasConvPointwiseFloatKernelRvv(
+    const float* Input,
+    const float* Filter,
+    float* Output,
+    size_t StrideWidth,
+    size_t InputChannels,
+    size_t FilterCount,
+    size_t InputStride,
+    size_t FilterStride,
+    size_t OutputStride,
+    size_t OutputCount,
+    const float* Bias,
+    unsigned KernelFlags
+    )
+{
+    const size_t vl = __riscv_vsetvl_e32m4(BlockSize);
+    const size_t StrideWidthElements = StrideWidth / sizeof(float);
+    const size_t InputStrideElements = InputStride / sizeof(float);
+    const size_t FilterStrideElements = FilterStride / sizeof(float);
+    const size_t OutputStrideElements = OutputStride / sizeof(float);
+
+    for (size_t f = 0; f < FilterCount; f++) {
+        const float* filter = Filter + f * FilterStrideElements;
+        float* output = Output + f * OutputStrideElements;
+
+        for (size_t out = 0; out < OutputCount; out++) {
+
+            vfloat32m4_t acc = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+
+            const float* input = Input + out * StrideWidthElements;
+
+            for (size_t ic = 0; ic < InputChannels; ic++) {
+                for (size_t j = 0; j < BlockSize; j++) {
+                    float input_value = input[ic * InputStrideElements + j];
+                    vfloat32m4_t filt = __riscv_vle32_v_f32m4(
+                        &filter[ic * BlockSize * BlockSize + j * BlockSize], vl);
+                    acc = __riscv_vfmacc_vf_f32m4(acc, input_value, filt, vl);
+                }
+            }
+
+            ApplyPostProcessing(acc, &output[out * BlockSize],
+                                Bias ? &Bias[f * BlockSize] : nullptr,
+                                KernelFlags, vl);
+
+            __riscv_vse32_v_f32m4(&output[out * BlockSize], acc, vl);
+        }
+    }
+}
+
+//
+// Max pooling kernel for NCHWc format.
+//
+
+void
+MLASCALL
+MlasPoolMaximumFloatKernelRvv(
+    const float* Input,
+    float* Output,
+    size_t StrideWidth,
+    size_t DilationWidth,
+    size_t InputStride,
+    size_t ActualKernelSize,
+    size_t KernelHeight,
+    size_t KernelWidth,
+    const float* InputBase,
+    size_t InputWidth,
+    size_t DilatedInputWidth,
+    size_t OutputCountLeftPad,
+    size_t OutputCount,
+    size_t OutputCountRightPad
+    )
+{
+    MLAS_UNREFERENCED_PARAMETER(ActualKernelSize);
+    MLAS_UNREFERENCED_PARAMETER(InputStride);
+
+    const size_t vl = __riscv_vsetvl_e32m4(BlockSize);
+    const size_t StrideWidthElements = StrideWidth / sizeof(float);
+    const size_t DilationWidthElements = DilationWidth / sizeof(float);
+    const size_t InputWidthElements = InputWidth / sizeof(float);
+    const size_t DilatedInputWidthElements = DilatedInputWidth / sizeof(float);
+    const size_t TotalOutputCount = OutputCountLeftPad + OutputCount + OutputCountRightPad;
+
+    const float PadValue = std::numeric_limits<float>::lowest();
+
+    for (size_t output_idx = 0; output_idx < TotalOutputCount; output_idx++) {
+
+        vfloat32m4_t max_vec = __riscv_vfmv_v_f_f32m4(PadValue, vl);
+
+        for (size_t kh = 0; kh < KernelHeight; kh++) {
+            const float* row_start = InputBase + kh * DilatedInputWidthElements;
+            const float* row_end = row_start + InputWidthElements;
+
+            for (size_t kw = 0; kw < KernelWidth; kw++) {
+                const float* input_ptr = Input + output_idx * StrideWidthElements +
+                                         kh * DilatedInputWidthElements + kw * DilationWidthElements;
+
+                if (input_ptr >= row_start && (input_ptr + BlockSize) <= row_end) {
+                    vfloat32m4_t inp = __riscv_vle32_v_f32m4(input_ptr, vl);
+                    max_vec = __riscv_vfmax_vv_f32m4(max_vec, inp, vl);
+                } else {
+                    float values[BlockSize];
+                    for (size_t i = 0; i < BlockSize; i++) {
+                        const float* ep = input_ptr + i;
+                        values[i] = (ep >= row_start && ep < row_end) ? *ep : PadValue;
+                    }
+                    vfloat32m4_t inp = __riscv_vle32_v_f32m4(values, vl);
+                    max_vec = __riscv_vfmax_vv_f32m4(max_vec, inp, vl);
+                }
+            }
+        }
+
+        __riscv_vse32_v_f32m4(&Output[output_idx * BlockSize], max_vec, vl);
+    }
+}
+
+//
+// Average pooling kernel (shared implementation).
+//
+
+namespace {
+
+MLAS_FORCEINLINE
+void
+MlasPoolAverageFloatKernelRvvImpl(
+    const float* Input,
+    float* Output,
+    size_t StrideWidth,
+    size_t DilationWidth,
+    size_t ActualKernelSize,
+    size_t KernelHeight,
+    size_t KernelWidth,
+    const float* InputBase,
+    size_t InputWidth,
+    size_t DilatedInputWidth,
+    size_t OutputCountLeftPad,
+    size_t OutputCount,
+    size_t OutputCountRightPad,
+    bool ExcludePad
+    )
+{
+    const size_t vl = __riscv_vsetvl_e32m4(BlockSize);
+    const size_t StrideWidthElements = StrideWidth / sizeof(float);
+    const size_t DilationWidthElements = DilationWidth / sizeof(float);
+    const size_t InputWidthElements = InputWidth / sizeof(float);
+    const size_t DilatedInputWidthElements = DilatedInputWidth / sizeof(float);
+    const size_t TotalOutputCount = OutputCountLeftPad + OutputCount + OutputCountRightPad;
+
+    for (size_t output_idx = 0; output_idx < TotalOutputCount; output_idx++) {
+
+        vfloat32m4_t sum_vec = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+        uint32_t valid_count[BlockSize];
+
+        if (ExcludePad) {
+            for (size_t i = 0; i < BlockSize; i++) {
+                valid_count[i] = 0;
+            }
+        }
+
+        for (size_t kh = 0; kh < KernelHeight; kh++) {
+            const float* row_start = InputBase + kh * DilatedInputWidthElements;
+            const float* row_end = row_start + InputWidthElements;
+
+            for (size_t kw = 0; kw < KernelWidth; kw++) {
+                const float* input_ptr = Input + output_idx * StrideWidthElements +
+                                         kh * DilatedInputWidthElements + kw * DilationWidthElements;
+
+                if (input_ptr >= row_start && (input_ptr + BlockSize) <= row_end) {
+                    vfloat32m4_t inp = __riscv_vle32_v_f32m4(input_ptr, vl);
+                    sum_vec = __riscv_vfadd_vv_f32m4(sum_vec, inp, vl);
+
+                    if (ExcludePad) {
+                        for (size_t i = 0; i < BlockSize; i++) {
+                            valid_count[i]++;
+                        }
+                    }
+                } else {
+                    float values[BlockSize];
+                    for (size_t i = 0; i < BlockSize; i++) {
+                        const float* ep = input_ptr + i;
+                        if (ep >= row_start && ep < row_end) {
+                            values[i] = *ep;
+                            if (ExcludePad) {
+                                valid_count[i]++;
+                            }
+                        } else {
+                            values[i] = 0.0f;
+                        }
+                    }
+                    vfloat32m4_t inp = __riscv_vle32_v_f32m4(values, vl);
+                    sum_vec = __riscv_vfadd_vv_f32m4(sum_vec, inp, vl);
+                }
+            }
+        }
+
+        if (ExcludePad) {
+            float results[BlockSize];
+            __riscv_vse32_v_f32m4(results, sum_vec, vl);
+            for (size_t i = 0; i < BlockSize; i++) {
+                results[i] /= static_cast<float>(valid_count[i]);
+            }
+            vfloat32m4_t result_vec = __riscv_vle32_v_f32m4(results, vl);
+            __riscv_vse32_v_f32m4(&Output[output_idx * BlockSize], result_vec, vl);
+        } else {
+            vfloat32m4_t divisor = __riscv_vfmv_v_f_f32m4(
+                static_cast<float>(ActualKernelSize), vl);
+            vfloat32m4_t result_vec = __riscv_vfdiv_vv_f32m4(sum_vec, divisor, vl);
+            __riscv_vse32_v_f32m4(&Output[output_idx * BlockSize], result_vec, vl);
+        }
+    }
+}
+
+}  // namespace
+
+void
+MLASCALL
+MlasPoolAverageExcludePadFloatKernelRvv(
+    const float* Input,
+    float* Output,
+    size_t StrideWidth,
+    size_t DilationWidth,
+    size_t InputStride,
+    size_t ActualKernelSize,
+    size_t KernelHeight,
+    size_t KernelWidth,
+    const float* InputBase,
+    size_t InputWidth,
+    size_t DilatedInputWidth,
+    size_t OutputCountLeftPad,
+    size_t OutputCount,
+    size_t OutputCountRightPad
+    )
+{
+    MLAS_UNREFERENCED_PARAMETER(InputStride);
+
+    MlasPoolAverageFloatKernelRvvImpl(
+        Input, Output, StrideWidth, DilationWidth, ActualKernelSize,
+        KernelHeight, KernelWidth, InputBase, InputWidth, DilatedInputWidth,
+        OutputCountLeftPad, OutputCount, OutputCountRightPad, true);
+}
+
+void
+MLASCALL
+MlasPoolAverageIncludePadFloatKernelRvv(
+    const float* Input,
+    float* Output,
+    size_t StrideWidth,
+    size_t DilationWidth,
+    size_t InputStride,
+    size_t ActualKernelSize,
+    size_t KernelHeight,
+    size_t KernelWidth,
+    const float* InputBase,
+    size_t InputWidth,
+    size_t DilatedInputWidth,
+    size_t OutputCountLeftPad,
+    size_t OutputCount,
+    size_t OutputCountRightPad
+    )
+{
+    MLAS_UNREFERENCED_PARAMETER(InputStride);
+
+    MlasPoolAverageFloatKernelRvvImpl(
+        Input, Output, StrideWidth, DilationWidth, ActualKernelSize,
+        KernelHeight, KernelWidth, InputBase, InputWidth, DilatedInputWidth,
+        OutputCountLeftPad, OutputCount, OutputCountRightPad, false);
+}
+
+#endif  // MLAS_USE_RVV

--- a/onnxruntime/core/mlas/lib/riscv64/sconv_nchwc_kernel_rvv.cpp
+++ b/onnxruntime/core/mlas/lib/riscv64/sconv_nchwc_kernel_rvv.cpp
@@ -24,6 +24,7 @@ Abstract:
 #if defined(MLAS_USE_RVV)
 
 #include <riscv_vector.h>
+#include <cassert>
 #include <limits>
 
 #define MLAS_CONV_KERNEL_FLAG_ACCUMULATE_OUTPUT     0x00000001
@@ -51,6 +52,7 @@ ApplyPostProcessing(
     }
 
     if (KernelFlags & MLAS_CONV_KERNEL_FLAG_BIAS_ADDITION) {
+        assert(Bias != nullptr);
         vfloat32m4_t bias_vec = __riscv_vle32_v_f32m4(Bias, vl);
         acc = __riscv_vfadd_vv_f32m4(acc, bias_vec, vl);
     }
@@ -207,17 +209,27 @@ MlasConvNchwcFloatKernelRvv(
 
                     size_t kernel_pos = kh * KernelWidth + kw;
 
-                    for (size_t ic = 0; ic < BlockSize; ic++) {
-                        const float* input_element = input_base + ic;
+                    bool in_bounds = (input_base >= input_row_start) &&
+                                     ((input_base + BlockSize) <= input_row_end);
 
-                        float input_value = 0.0f;
-                        if (input_element >= input_row_start && input_element < input_row_end) {
-                            input_value = *input_element;
+                    if (in_bounds) {
+                        for (size_t ic = 0; ic < BlockSize; ic++) {
+                            float input_value = input_base[ic];
+                            size_t filter_offset = kernel_pos * BlockSize * BlockSize + ic * BlockSize;
+                            vfloat32m4_t filt = __riscv_vle32_v_f32m4(&filter[filter_offset], vl);
+                            acc = __riscv_vfmacc_vf_f32m4(acc, input_value, filt, vl);
                         }
-
-                        size_t filter_offset = kernel_pos * BlockSize * BlockSize + ic * BlockSize;
-                        vfloat32m4_t filt = __riscv_vle32_v_f32m4(&filter[filter_offset], vl);
-                        acc = __riscv_vfmacc_vf_f32m4(acc, input_value, filt, vl);
+                    } else {
+                        for (size_t ic = 0; ic < BlockSize; ic++) {
+                            const float* input_element = input_base + ic;
+                            float input_value = 0.0f;
+                            if (input_element >= input_row_start && input_element < input_row_end) {
+                                input_value = *input_element;
+                            }
+                            size_t filter_offset = kernel_pos * BlockSize * BlockSize + ic * BlockSize;
+                            vfloat32m4_t filt = __riscv_vle32_v_f32m4(&filter[filter_offset], vl);
+                            acc = __riscv_vfmacc_vf_f32m4(acc, input_value, filt, vl);
+                        }
                     }
                 }
             }
@@ -509,7 +521,9 @@ MlasPoolAverageFloatKernelRvvImpl(
             float results[BlockSize];
             __riscv_vse32_v_f32m4(results, sum_vec, vl);
             for (size_t i = 0; i < BlockSize; i++) {
-                results[i] /= static_cast<float>(valid_count[i]);
+                results[i] = (valid_count[i] > 0)
+                    ? results[i] / static_cast<float>(valid_count[i])
+                    : 0.0f;
             }
             vfloat32m4_t result_vec = __riscv_vle32_v_f32m4(results, vl);
             __riscv_vse32_v_f32m4(&Output[output_idx * BlockSize], result_vec, vl);

--- a/onnxruntime/core/mlas/lib/snchwc.cpp
+++ b/onnxruntime/core/mlas/lib/snchwc.cpp
@@ -104,7 +104,7 @@ Return Value:
 
 --*/
 {
-#if defined(MLAS_TARGET_AMD64) || defined(MLAS_TARGET_LARCH64) || (defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC))
+#if defined(MLAS_TARGET_AMD64) || defined(MLAS_TARGET_LARCH64) || (defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC)) || (defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV))
     return GetMlasPlatform().NchwcBlockSize;
 #else
     return 1;
@@ -683,7 +683,7 @@ struct MLAS_NCHWC_CONV_NCHWC_ALGORITHM : MLAS_NCHWC_GROUPED_CONV_ALGORITHM
 
         const size_t BlockedOutputWidth = BlockSize * OutputWidth;
 
-#if defined(MLAS_TARGET_AMD64) || defined(MLAS_TARGET_LARCH64) || (defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC))
+#if defined(MLAS_TARGET_AMD64) || defined(MLAS_TARGET_LARCH64) || (defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC)) || (defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV))
         MLAS_CONV_FLOAT_KERNEL* Kernel = GetMlasPlatform().ConvNchwcFloatKernel;
 #else
         MLAS_CONV_FLOAT_KERNEL* Kernel = MlasConvNchwcFloatKernel;
@@ -793,7 +793,7 @@ struct MLAS_NCHWC_CONV_NCHW_ALGORITHM : MLAS_NCHWC_GROUPED_CONV_ALGORITHM
 
         const size_t BlockedOutputWidth = BlockSize * OutputWidth;
 
-#if defined(MLAS_TARGET_AMD64) || defined(MLAS_TARGET_LARCH64) || (defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC))
+#if defined(MLAS_TARGET_AMD64) || defined(MLAS_TARGET_LARCH64) || (defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC)) || (defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV))
         MLAS_CONV_FLOAT_KERNEL* Kernel = GetMlasPlatform().ConvNchwFloatKernel;
 #if defined(MLAS_USE_ARM_NEON_NCHWC) && defined(__linux__)
         MLAS_CONV_FLOAT_KERNEL* const KernelFloat = GetMlasPlatform().ConvNchwFloatKernel;
@@ -914,7 +914,7 @@ struct MLAS_NCHWC_CONV_POINTWISE_ALGORITHM : MLAS_NCHWC_GROUPED_CONV_ALGORITHM
         const size_t FilterStrideBytes = BlockSize * InputChannels * sizeof(float);
         const size_t OutputStrideBytes = BlockSize * OutputSize * sizeof(float);
 
-#if defined(MLAS_TARGET_AMD64) || defined(MLAS_TARGET_LARCH64) || (defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC))
+#if defined(MLAS_TARGET_AMD64) || defined(MLAS_TARGET_LARCH64) || (defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC)) || (defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV))
         MLAS_CONV_POINTWISE_FLOAT_KERNEL* Kernel = GetMlasPlatform().ConvPointwiseFloatKernel;
 #if defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC) && !defined(_WIN32)
         // AArch64 assembly kernel pointwise convolution computes multiple
@@ -1069,7 +1069,7 @@ struct MLAS_NCHWC_CONV_DEPTHWISE_ALGORITHM : MLAS_NCHWC_CONV_ALGORITHM
 
         const size_t BlockedOutputWidth = BlockSize * OutputWidth;
 
-#if defined(MLAS_TARGET_AMD64) || defined(MLAS_TARGET_LARCH64) || (defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC))
+#if defined(MLAS_TARGET_AMD64) || defined(MLAS_TARGET_LARCH64) || (defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC)) || (defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV))
         MLAS_CONV_DEPTHWISE_FLOAT_KERNEL* Kernel = GetMlasPlatform().ConvDepthwiseFloatKernel;
 #if defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC) && !defined(_WIN32)
         MLAS_CONV_DEPTHWISE_FLOAT_KERNEL* const KernelFast = MlasConvDepthwiseFloatKernelNeonAsm;
@@ -1160,7 +1160,7 @@ struct MLAS_NCHWC_CONV_DEPTHWISE_ALGORITHM : MLAS_NCHWC_CONV_ALGORITHM
 
 struct MLAS_NCHWC_POOL_ALGORITHM : MLAS_NCHWC_NN_ALGORITHM
 {
-#if !defined(MLAS_TARGET_AMD64) && !defined(MLAS_TARGET_LARCH64) && !(defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC))
+#if !defined(MLAS_TARGET_AMD64) && !defined(MLAS_TARGET_LARCH64) && !(defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC)) && !(defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV))
     static MLAS_POOL_FLOAT_KERNEL* const PoolKernels[];
 #endif
 
@@ -1198,7 +1198,7 @@ struct MLAS_NCHWC_POOL_ALGORITHM : MLAS_NCHWC_NN_ALGORITHM
         const size_t DilatedInputWidthBytes = BlockSize * DilationHeight * InputWidth * sizeof(float);
         const size_t InputStrideBytes = DilatedInputWidthBytes - KernelWidth * DilationWidthBytes;
 
-#if defined(MLAS_TARGET_AMD64) || defined(MLAS_TARGET_LARCH64) || (defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC))
+#if defined(MLAS_TARGET_AMD64) || defined(MLAS_TARGET_LARCH64) || (defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC)) || (defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV))
         MLAS_POOL_FLOAT_KERNEL* Kernel = GetMlasPlatform().PoolFloatKernel[WorkBlock->PoolingKind];
 #else
         MLAS_POOL_FLOAT_KERNEL* Kernel = PoolKernels[WorkBlock->PoolingKind];
@@ -1264,7 +1264,7 @@ struct MLAS_NCHWC_POOL_ALGORITHM : MLAS_NCHWC_NN_ALGORITHM
     }
 };
 
-#if !defined(MLAS_TARGET_AMD64) && !defined(MLAS_TARGET_LARCH64) && !(defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC))
+#if !defined(MLAS_TARGET_AMD64) && !defined(MLAS_TARGET_LARCH64) && !(defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC)) && !(defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV))
 
 MLAS_POOL_FLOAT_KERNEL* const MLAS_NCHWC_POOL_ALGORITHM::PoolKernels[] =
 {
@@ -1694,7 +1694,7 @@ Return Value:
     }
 }
 
-#if !defined(MLAS_TARGET_AMD64) && !defined(MLAS_TARGET_LARCH64) && !(defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC))
+#if !defined(MLAS_TARGET_AMD64) && !defined(MLAS_TARGET_LARCH64) && !(defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC)) && !(defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV))
 
 //
 // Convolution and pooling kernel stubs for architectures that do not yet have


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

New kernel files:
  - riscv64/sconv_depthwise_kernel_rvv.cpp — RVV-optimized 3x3 stride-1 depthwise convolution (NCHW format), replacing the MLAS_FLOAT32X4 generic vectorized version
  - riscv64/sconv_nchwc_kernel_rvv.cpp — 7 NCHWc kernels using vfloat32m4_t (LMUL=4, BlockSize=16):
    - Direct NCHW conv (MlasConvNchwFloatKernelRvv)
    - Direct NCHWc conv (MlasConvNchwcFloatKernelRvv)
    - Depthwise NCHWc conv (MlasConvDepthwiseFloatKernelRvv)
    - Pointwise NCHWc conv (MlasConvPointwiseFloatKernelRvv)
    - Max/AvgExcludePad/AvgIncludePad pooling


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Following #28261, Optimize more MLAS kernels using RISC-V Vector (RVV) extensions.

Please Note:

- On the K3 (SpacemiT X60), VLEN=256. With LMUL=4 and e32, the hardware can hold (256/32) * 4 = 32 floats per vector register group — but we only request 16. So we're using half the available vector width.

-   The reason is that BlockSize=16 is baked into the NCHWc data layout across the whole framework (matching ARM64 NEON). Changing it to 32 would require a different NCHWc format and is not a localized change.

### Benchmark ((SpacemiT K3, VLEN=256, 8-core))
All tests pass with zero numerical error.

Kernel | Speedup (RVV vs scalar)
-- | --
Direct NCHW Conv | 1.27–1.29x
Direct NCHWc Conv | 1.93–1.95x
Depthwise NCHWc Conv | 10.8–12.5x
Pointwise NCHWc Conv | 29.4–30.4x
Max Pooling | 12.5–20.0x
Avg Pooling (exclude pad) | 4.0–4.3x
Avg Pooling (include pad) | 5.5–5.8x

