### PR TITLE
fix: preserve Q/DQ around Resize when mode is linear or cubic

### DIFF
--- a/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selectors.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selectors.cc
@@ -181,6 +181,17 @@ bool DropQDQNodeGroupSelector::Check(const GraphViewer& graph_viewer, const Node
     return false;
   }
 
+  // Resize with mode != "nearest" (linear/cubic) is not order-preserving on integers,
+  // so dropping the surrounding Q/DQ pair would change numerical results. Only the
+  // default nearest-neighbor mode is safe to fold. See issue #21319.
+  if (node.OpType() == "Resize") {
+    const auto* mode_attr = graph_utils::GetNodeAttribute(node, "mode");
+    const std::string mode = (mode_attr != nullptr) ? mode_attr->s() : "nearest";
+    if (mode != "nearest") {
+      return false;
+    }
+  }
+
   const Node& dq_node = *dq_nodes.front();
   const Node& q_node = *q_nodes.front();
 

--- a/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selectors.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selectors.cc
@@ -186,8 +186,7 @@ bool DropQDQNodeGroupSelector::Check(const GraphViewer& graph_viewer, const Node
   // default nearest-neighbor mode is safe to fold. See issue #21319.
   if (node.OpType() == "Resize") {
     const auto* mode_attr = graph_utils::GetNodeAttribute(node, "mode");
-    const std::string mode = (mode_attr != nullptr) ? mode_attr->s() : "nearest";
-    if (mode != "nearest") {
+    if (mode_attr != nullptr && mode_attr->s() != "nearest") {
       return false;
     }
   }

--- a/onnxruntime/test/optimizer/qdq_transformer_test.cc
+++ b/onnxruntime/test/optimizer/qdq_transformer_test.cc
@@ -2034,6 +2034,44 @@ TEST(QDQTransformerTests, Resize_No_Fusion) {
   test_case({1, 8, 64, 64}, {4}, {1, 4, 128, 128}, 1, true /*use_contrib_qdq*/);
 }
 
+TEST(QDQTransformerTests, Resize_NonNearest_No_Fusion) {
+  // Resize with mode="linear" or mode="cubic" is not order-preserving on integers.
+  // The surrounding Q/DQ pair must NOT be dropped. See issue #21319.
+  auto test_case = [&](const std::vector<int64_t>& input1_shape,
+                       const std::vector<int64_t>& sizes_shape,
+                       const std::string& mode,
+                       bool use_contrib_qdq = false) {
+    auto check_graph = [&](InferenceSessionWrapper& session) {
+      auto op_to_count = CountOpsInGraph(session.GetGraph());
+      const QDQOpKeys qdq_keys = GetQDQOpKeys(use_contrib_qdq);
+      EXPECT_EQ(op_to_count["Resize"], 1);
+      EXPECT_EQ(op_to_count[qdq_keys.quantize_linear], 1);
+      EXPECT_EQ(op_to_count[qdq_keys.dequantize_linear], 1);
+    };
+
+    TransformerTester(BuildQDQResizeTestCase(input1_shape,
+                                             sizes_shape,
+                                             mode,                  // mode (linear or cubic)
+                                             "half_pixel",          // coordinate_transformation_mode
+                                             "round_prefer_floor",  // nearest_mode (unused for linear/cubic)
+                                             false,                 // add_dq_output_float
+                                             use_contrib_qdq),
+                      check_graph,
+                      TransformerLevel::Level1,
+                      TransformerLevel::Level2);
+  };
+
+  RandomValueGenerator rand_gen{optional<RandomValueGenerator::RandomSeedType>{2345}};
+  // mode="linear"
+  test_case({2, 13, 12, 37}, rand_gen.Uniform<int64_t>(std::vector<int64_t>{4}, 1, 16), "linear");
+  test_case({2, 13, 12, 37}, rand_gen.Uniform<int64_t>(std::vector<int64_t>{4}, 1, 16), "linear",
+            true /*use_contrib_qdq*/);
+  // mode="cubic"
+  test_case({2, 13, 12, 37}, rand_gen.Uniform<int64_t>(std::vector<int64_t>{4}, 1, 16), "cubic");
+  test_case({2, 13, 12, 37}, rand_gen.Uniform<int64_t>(std::vector<int64_t>{4}, 1, 16), "cubic",
+            true /*use_contrib_qdq*/);
+}
+
 TEST(QDQTransformerTests, ResizeReshapeSqueezeUnsqueeze) {
   auto test_case = [&](const std::vector<int64_t>& input_shape,
                        const std::vector<int64_t>& sizes_shape,

--- a/onnxruntime/test/optimizer/qdq_transformer_test.cc
+++ b/onnxruntime/test/optimizer/qdq_transformer_test.cc
@@ -2061,15 +2061,58 @@ TEST(QDQTransformerTests, Resize_NonNearest_No_Fusion) {
                       TransformerLevel::Level2);
   };
 
-  RandomValueGenerator rand_gen{optional<RandomValueGenerator::RandomSeedType>{2345}};
+  // Use fixed output sizes where batch and channel are unchanged (linear/cubic require scale=1 on batch/channel).
   // mode="linear"
-  test_case({2, 13, 12, 37}, rand_gen.Uniform<int64_t>(std::vector<int64_t>{4}, 1, 16), "linear");
-  test_case({2, 13, 12, 37}, rand_gen.Uniform<int64_t>(std::vector<int64_t>{4}, 1, 16), "linear",
-            true /*use_contrib_qdq*/);
+  test_case({1, 8, 64, 64}, {1, 8, 128, 128}, "linear");
+  test_case({1, 8, 64, 64}, {1, 8, 128, 128}, "linear", true /*use_contrib_qdq*/);
   // mode="cubic"
-  test_case({2, 13, 12, 37}, rand_gen.Uniform<int64_t>(std::vector<int64_t>{4}, 1, 16), "cubic");
-  test_case({2, 13, 12, 37}, rand_gen.Uniform<int64_t>(std::vector<int64_t>{4}, 1, 16), "cubic",
-            true /*use_contrib_qdq*/);
+  test_case({1, 8, 64, 64}, {1, 8, 128, 128}, "cubic");
+  test_case({1, 8, 64, 64}, {1, 8, 128, 128}, "cubic", true /*use_contrib_qdq*/);
+}
+
+TEST(QDQTransformerTests, Resize_DefaultMode_Fusion) {
+  // A Resize node with no "mode" attribute defaults to "nearest" per the ONNX spec.
+  // The selector must treat a missing mode attribute the same as mode="nearest" and
+  // allow Q/DQ to be dropped. See issue #21319.
+  auto test_case = [&](const std::vector<int64_t>& input1_shape,
+                       const std::vector<int64_t>& sizes_data,
+                       bool use_contrib_qdq = false) {
+    auto build_test_case = [&](ModelTestBuilder& builder) {
+      auto* input1_arg = builder.MakeInput<uint8_t>(input1_shape,
+                                                    std::numeric_limits<uint8_t>::min(),
+                                                    std::numeric_limits<uint8_t>::max());
+      auto* roi = builder.MakeInitializer<float>({0}, {});
+      auto* scales = builder.MakeInitializer<float>({0}, {});
+      auto* sizes = builder.Make1DInitializer<int64_t>(sizes_data);
+      auto* output_arg = builder.MakeOutput();
+
+      // add DQ
+      auto* dq_output = builder.MakeIntermediate();
+      builder.AddDequantizeLinearNode<uint8_t>(input1_arg, .003f, 1, dq_output, use_contrib_qdq);
+
+      // add Resize with no mode attribute (ONNX default = "nearest")
+      auto* resize_output = builder.MakeIntermediate();
+      builder.AddNode("Resize", {dq_output, roi, scales, sizes}, {resize_output});
+
+      // add Q
+      builder.AddQuantizeLinearNode<uint8_t>(resize_output, .003f, 1, output_arg, use_contrib_qdq);
+    };
+
+    auto check_graph = [&](InferenceSessionWrapper& session) {
+      auto op_to_count = CountOpsInGraph(session.GetGraph());
+      const QDQOpKeys qdq_keys = GetQDQOpKeys(use_contrib_qdq);
+      EXPECT_EQ(op_to_count["Resize"], 1);
+      EXPECT_EQ(op_to_count[qdq_keys.quantize_linear], 0);
+      EXPECT_EQ(op_to_count[qdq_keys.dequantize_linear], 0);
+    };
+
+    TransformerTester(build_test_case, check_graph,
+                      TransformerLevel::Level1,
+                      TransformerLevel::Level2);
+  };
+
+  test_case({1, 8, 64, 64}, {1, 8, 128, 128});
+  test_case({1, 8, 64, 64}, {1, 8, 128, 128}, true /*use_contrib_qdq*/);
 }
 
 TEST(QDQTransformerTests, ResizeReshapeSqueezeUnsqueeze) {


### PR DESCRIPTION
### Description

`DropQDQNodeGroupSelector::Check` unconditionally removes the surrounding
Q/DQ pair from a `Resize` node. This is only safe when `mode="nearest"`.
For `mode="linear"` and `mode="cubic"`, interpolation is not order-preserving
on integer scales, so folding Q/DQ into the integer Resize produces
numerically incorrect results.

This change adds a Resize-specific guard inside
`DropQDQNodeGroupSelector::Check` that reads the `mode` attribute (defaulting
to `"nearest"` per the ONNX spec when absent) and refuses the drop when the
mode is anything other than `"nearest"`. `DepthToSpace`, which shares the
same selector registration, is unaffected.

A regression test in `qdq_transformer_test.cc` exercises `mode="linear"` and
`mode="cubic"`, with and without contrib QDQ ops, and asserts that the Q/DQ
pair is preserved (Q and DQ counts remain at 1).

### Motivation and Context

Fixes #21319.

The reproducer in the issue runs a uint8-quantized model with a
`mode="linear"` Resize and expects `[[[[0, 0, 1, 1]]]]` but gets
`[[[[0, 0, 0, 1]]]]` because the optimizer folded the Q/DQ pair away and
ran linear interpolation in int8. After this change, the Q/DQ pair stays
in place and the resulting graph matches the `onnx.reference` output.