### PR TITLE
docs(quantization): clarify CPU parameter recommendations

### DIFF
--- a/onnxruntime/python/tools/quantization/README.md
+++ b/onnxruntime/python/tools/quantization/README.md
@@ -79,6 +79,60 @@ python -m onnxruntime.quantization.static_quantize_runner -i resnet18-v1-7\model
 python -m onnxruntime.quantization.static_quantize_runner -i resnet18-v1-7\model.onnx -o resnet18-v1-7\model_quant.onnx --activation_type qint16 --weight_type qint8 --per_channel
 ```
 
+### Choosing parameters for CPU inference
+
+The right combination of quantization parameters depends on the target CPU architecture.
+Choosing the wrong combination is a common cause of quantized models running *slower* than FP32.
+
+**Format**
+
+- Use `quant_format=QuantFormat.QDQ` (the default since ORT 1.11). ORT's CPU kernels are optimized
+  for the QDQ representation. `QOperator` format is mainly useful for specific hardware back-ends.
+
+**Activation type and weight type by platform**
+
+- x86/x64 without VNNI (most pre-Skylake-SP desktop/laptop CPUs):
+    - `activation_type=QuantType.QUInt8`, `weight_type=QuantType.QInt8`
+    - Set `reduce_range=True` to quantize weights to 7-bit and avoid integer saturation on CPUs
+      that lack the VNNI dot-product instruction.
+
+- x86/x64 with VNNI (Intel Skylake-SP, Cascade Lake, Ice Lake, Sapphire Rapids; AMD Zen4+):
+    - `activation_type=QuantType.QUInt8`, `weight_type=QuantType.QInt8`
+    - `reduce_range=False` — VNNI accumulates 8-bit products natively so range reduction is not needed.
+
+- ARM (Cortex-A, Apple Silicon, Graviton):
+    - `activation_type=QuantType.QInt8`, `weight_type=QuantType.QInt8`
+    - `reduce_range=False` — ARM NEON/SVE handles signed 8-bit arithmetic without saturation issues.
+
+**per_channel**
+
+- `per_channel=False` (default) gives better CPU throughput. `per_channel=True` can improve accuracy
+  for models whose weight distributions differ substantially across output channels.
+
+**Example: x64 non-VNNI**
+
+```python
+from onnxruntime.quantization import quantize_static, CalibrationDataReader, QuantFormat, QuantType
+
+quantize_static(
+    model_input="model.onnx",
+    model_output="model_quant.onnx",
+    calibration_data_reader=reader,
+    quant_format=QuantFormat.QDQ,
+    activation_type=QuantType.QUInt8,
+    weight_type=QuantType.QInt8,
+    reduce_range=True,   # recommended on non-VNNI x64
+    per_channel=False,
+)
+```
+
+Note: this guidance applies to models produced by `quantize_static`. The separate
+`convert_onnx_models_to_ort` tool's `--target_platform` flag only affects ORT format conversion
+and does not change the quantization parameters above.
+
+For the full quantization guide see
+https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html
+
 ### Tensor Quant Overrides Json Format
 With `--tensor_quant_overrides`, the tool can consume the json file with quantization override information.
 ```ps1

--- a/onnxruntime/python/tools/quantization/README.md
+++ b/onnxruntime/python/tools/quantization/README.md
@@ -93,16 +93,19 @@ Choosing the wrong combination is a common cause of quantized models running *sl
 
 - x86/x64 without VNNI (most pre-Skylake-SP desktop/laptop CPUs):
     - `activation_type=QuantType.QUInt8`, `weight_type=QuantType.QInt8`
-    - Set `reduce_range=True` to quantize weights to 7-bit and avoid integer saturation on CPUs
-      that lack the VNNI dot-product instruction.
+    - Set `reduce_range=True` to quantize weights to 7-bit to reduce the risk of integer saturation
+      on CPUs that typically lack the VNNI dot-product instruction.
 
-- x86/x64 with VNNI (Intel Skylake-SP, Cascade Lake, Ice Lake, Sapphire Rapids; AMD Zen4+):
+- x86/x64 with VNNI (e.g., Intel Skylake-SP/Cascade Lake/Ice Lake/Sapphire Rapids or AMD Zen4 and
+  later, though exact support varies by SKU):
     - `activation_type=QuantType.QUInt8`, `weight_type=QuantType.QInt8`
-    - `reduce_range=False` — VNNI accumulates 8-bit products natively so range reduction is not needed.
+    - `reduce_range=False` — VNNI-capable cores typically accumulate 8-bit products without
+      saturation, so range reduction is often unnecessary.
 
 - ARM (Cortex-A, Apple Silicon, Graviton):
     - `activation_type=QuantType.QInt8`, `weight_type=QuantType.QInt8`
-    - `reduce_range=False` — ARM NEON/SVE handles signed 8-bit arithmetic without saturation issues.
+    - `reduce_range=False` — ARM NEON/SVE generally handles signed 8-bit arithmetic without
+      saturation issues.
 
 **per_channel**
 
@@ -113,6 +116,8 @@ Choosing the wrong combination is a common cause of quantized models running *sl
 
 ```python
 from onnxruntime.quantization import quantize_static, CalibrationDataReader, QuantFormat, QuantType
+
+# reader: CalibrationDataReader = MyCalibrationDataReader(...)  # user-supplied
 
 quantize_static(
     model_input="model.onnx",

--- a/onnxruntime/python/tools/quantization/quantize.py
+++ b/onnxruntime/python/tools/quantization/quantize.py
@@ -509,36 +509,41 @@ def quantize_static(
 ):
     """
     Given an onnx model and calibration data reader, create a quantized onnx model and save it into a file.
-    QuantFormat.QDQ has been the recommended format since 1.11. Recommended values for `activation_type`
-    and `weight_type` depend on the target hardware: see "Choosing parameters for CPU inference" below for
-    CPU guidance, or use symmetric `QuantType.QInt8` for both activations and weights when targeting GPU/TRT.
+    ``QuantFormat.QDQ`` has been the recommended format since 1.11. Recommended values for
+    ``activation_type`` and ``weight_type`` depend on the target hardware: see "Choosing parameters
+    for CPU inference" below for CPU guidance, or use symmetric ``QuantType.QInt8`` for both
+    activations and weights when targeting GPU/TRT.
 
     Choosing parameters for CPU inference:
 
-    - Format: QuantFormat.QDQ is strongly preferred over QOperator for CPU inference since ORT 1.11, as CPU
-      kernels are optimized for the QDQ representation.
+    - Format: ``QuantFormat.QDQ`` is strongly preferred over ``QOperator`` for CPU inference since
+      ORT 1.11, as CPU kernels are optimized for the QDQ representation.
 
     - x86/x64 CPU without VNNI (e.g., most pre-Skylake-SP desktop/laptop CPUs):
-      Use activation_type=QuantType.QUInt8 and weight_type=QuantType.QInt8, and set reduce_range=True.
-      The reduce_range flag quantizes weights to 7-bit to avoid integer overflow on CPUs that lack the
-      VNNI dot-product instruction, and is particularly helpful for per-channel weight quantization.
+      Use ``activation_type=QuantType.QUInt8`` and ``weight_type=QuantType.QInt8``, and set
+      ``reduce_range=True``. The ``reduce_range`` flag quantizes weights to 7-bit to reduce the risk
+      of integer saturation on CPUs that typically lack the VNNI dot-product instruction; this is
+      particularly helpful for per-channel weight quantization.
 
-    - x86/x64 CPU with VNNI (e.g., Intel Skylake-SP, Cascade Lake, Ice Lake, Sapphire Rapids; AMD Zen4+):
-      Use activation_type=QuantType.QUInt8 and weight_type=QuantType.QInt8 with reduce_range=False.
-      VNNI natively accumulates 8-bit products without overflow, so the range reduction is unnecessary.
+    - x86/x64 CPU with VNNI (e.g., Intel Skylake-SP/Cascade Lake/Ice Lake/Sapphire Rapids or AMD
+      Zen4 and later, though exact support varies by SKU):
+      Use ``activation_type=QuantType.QUInt8`` and ``weight_type=QuantType.QInt8`` with
+      ``reduce_range=False``. VNNI-capable cores typically accumulate 8-bit products without
+      saturation, so the range reduction is often unnecessary.
 
     - ARM CPU (e.g., Cortex-A, Apple Silicon, Graviton):
-      ARM cores handle symmetric QInt8 activations well. Use activation_type=QuantType.QInt8 and
-      weight_type=QuantType.QInt8 with reduce_range=False. Asymmetric (QUInt8) activations also work
-      but symmetric is often preferred by ARM-optimized kernels.
+      ARM cores generally handle symmetric ``QInt8`` activations well. Use
+      ``activation_type=QuantType.QInt8`` and ``weight_type=QuantType.QInt8`` with
+      ``reduce_range=False``. Asymmetric (``QUInt8``) activations also work but symmetric is often
+      preferred by ARM-optimized kernels.
 
-    - per_channel: Setting per_channel=False (the default) gives the best throughput on CPU. Setting
-      per_channel=True can improve accuracy for models with weight distributions that vary across
-      output channels (e.g., ResNet-style convolutions) at a small performance cost.
+    - per_channel: Setting ``per_channel=False`` (the default) gives the best throughput on CPU.
+      Setting ``per_channel=True`` can improve accuracy for models with weight distributions that
+      vary across output channels (e.g., ResNet-style convolutions) at a small performance cost.
 
-    Note: this guidance applies to models produced by `quantize_static`. The separate
-    `convert_onnx_models_to_ort` tool's `--target_platform` flag is unrelated and only affects ORT
-    format conversion; it does not change the quantization parameters above.
+    Note: this guidance applies to models produced by ``quantize_static``. The separate
+    ``convert_onnx_models_to_ort`` tool's ``--target_platform`` flag is unrelated and only affects
+    ORT format conversion; it does not change the quantization parameters above.
 
     For the full quantization guide including execution-provider-specific considerations, see
     https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html

--- a/onnxruntime/python/tools/quantization/quantize.py
+++ b/onnxruntime/python/tools/quantization/quantize.py
@@ -114,6 +114,11 @@ class StaticQuantConfig(QuantConfig):
         """
         This is the derived class for static Quantize Configuration
 
+        This config is consumed by ``quantize_static``. For CPU inference, the key parameters are
+        ``quant_format``, ``activation_type``, ``weight_type``, ``reduce_range``, and ``per_channel``.
+        See ``quantize_static`` for a summary of recommended values per target CPU, and refer to
+        https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html for the full guide.
+
         Args:
             calibration_data_reader:
                 a calibration data reader. It enumerates calibration data and generates inputs for the original model.
@@ -503,11 +508,40 @@ def quantize_static(
     calibration_cache_path: str | Path | None = None,
 ):
     """
-    Given an onnx model and calibration data reader, create a quantized onnx model and save it into a file
-    It is recommended to use QuantFormat.QDQ format from 1.11 with activation_type = QuantType.QInt8 and weight_type
-    = QuantType.QInt8. If model is targeted to GPU/TRT, symmetric activation and weight are required. If model is
-    targeted to CPU, asymmetric activation and symmetric weight are recommended for balance of performance and
-    accuracy.
+    Given an onnx model and calibration data reader, create a quantized onnx model and save it into a file.
+    QuantFormat.QDQ has been the recommended format since 1.11. Recommended values for `activation_type`
+    and `weight_type` depend on the target hardware: see "Choosing parameters for CPU inference" below for
+    CPU guidance, or use symmetric `QuantType.QInt8` for both activations and weights when targeting GPU/TRT.
+
+    Choosing parameters for CPU inference:
+
+    - Format: QuantFormat.QDQ is strongly preferred over QOperator for CPU inference since ORT 1.11, as CPU
+      kernels are optimized for the QDQ representation.
+
+    - x86/x64 CPU without VNNI (e.g., most pre-Skylake-SP desktop/laptop CPUs):
+      Use activation_type=QuantType.QUInt8 and weight_type=QuantType.QInt8, and set reduce_range=True.
+      The reduce_range flag quantizes weights to 7-bit to avoid integer overflow on CPUs that lack the
+      VNNI dot-product instruction, and is particularly helpful for per-channel weight quantization.
+
+    - x86/x64 CPU with VNNI (e.g., Intel Skylake-SP, Cascade Lake, Ice Lake, Sapphire Rapids; AMD Zen4+):
+      Use activation_type=QuantType.QUInt8 and weight_type=QuantType.QInt8 with reduce_range=False.
+      VNNI natively accumulates 8-bit products without overflow, so the range reduction is unnecessary.
+
+    - ARM CPU (e.g., Cortex-A, Apple Silicon, Graviton):
+      ARM cores handle symmetric QInt8 activations well. Use activation_type=QuantType.QInt8 and
+      weight_type=QuantType.QInt8 with reduce_range=False. Asymmetric (QUInt8) activations also work
+      but symmetric is often preferred by ARM-optimized kernels.
+
+    - per_channel: Setting per_channel=False (the default) gives the best throughput on CPU. Setting
+      per_channel=True can improve accuracy for models with weight distributions that vary across
+      output channels (e.g., ResNet-style convolutions) at a small performance cost.
+
+    Note: this guidance applies to models produced by `quantize_static`. The separate
+    `convert_onnx_models_to_ort` tool's `--target_platform` flag is unrelated and only affects ORT
+    format conversion; it does not change the quantization parameters above.
+
+    For the full quantization guide including execution-provider-specific considerations, see
+    https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html
 
     Args:
 


### PR DESCRIPTION
## Summary
- Document recommended `quantize_static` parameters for CPU inference per target hardware (x64 non-VNNI, x64 VNNI, ARM).
- Resolve the contradictory guidance previously present at the top of the `quantize_static` docstring.
- Add a matching "Choosing parameters for CPU inference" section to the quantization tool's README.

## Motivation
Fixes #26564.

Users following the existing docstring with default arguments can end up with QDQ-quantized models that are slower than the FP32 baseline on x86/x64 CPUs, because the docs didn't surface the importance of `reduce_range=True` on non-VNNI hardware or the recommended `activation_type` / `weight_type` combination per platform. The previous opening of the `quantize_static` docstring also contradicted itself: it recommended `QuantType.QInt8` for both activations and weights in one sentence and asymmetric activations for CPU in the next.

## Changes
- `onnxruntime/python/tools/quantization/quantize.py`
  - Rewrite the `quantize_static` opening paragraph to point at the new platform-keyed section instead of giving a single, contradictory recommendation.
  - Add a "Choosing parameters for CPU inference" section to the `quantize_static` docstring covering QDQ vs QOperator, x64 non-VNNI, x64 VNNI, ARM, and `per_channel`.
  - Add a short opening note to `StaticQuantConfig.__init__` cross-referencing the same guidance.
  - Clarify that this guidance is independent of `convert_onnx_models_to_ort --target_platform`.
- `onnxruntime/python/tools/quantization/README.md`
  - Add a "Choosing parameters for CPU inference" section after "Quantization Arguments", with a short `python` example and the same platform-keyed bullets.

No code, signatures, defaults, or behavior change. Documentation only.

## Test plan
- `python -c "import ast; ast.parse(open('onnxruntime/python/tools/quantization/quantize.py').read())"` parses cleanly.
- `lintrunner -a` reports no issues on the changed files.
- Existing tests in `onnxruntime/test/python/quantization/` are unaffected by docs-only changes.

## Issue resolution
Closes #26564.